### PR TITLE
Adds minute offset to hourly scheduling

### DIFF
--- a/assets/helpers/core.js
+++ b/assets/helpers/core.js
@@ -2035,6 +2035,7 @@ async function loadConfig() {
   _setVal("schEnabled", String(!!s.enabled));
   _setVal("schMode",    typeof s.mode === "string" && s.mode ? s.mode : "hourly");
   _setVal("schN",       Number.isFinite(s.every_n_hours) ? String(s.every_n_hours) : "2");
+  _setVal("schMinuteOffset", Number.isFinite(s.minute_offset) ? String(s.minute_offset) : "0");
   _setVal("schTime",    typeof s.daily_time === "string" && s.daily_time ? s.daily_time : "03:30");
   if (document.getElementById("schTz")) _setVal("schTz", s.timezone || "");
 
@@ -2607,6 +2608,7 @@ async function saveSettings() {
           enabled: readToggle("schEnabled"),
           mode: _getVal("schMode"),
           every_n_hours: parseInt((_getVal("schN") || "2"), 10),
+          minute_offset: parseInt((_getVal("schMinuteOffset") || "0"), 10),
           daily_time: _getVal("schTime") || "03:30",
           advanced: { enabled: false, jobs: [] }
         };

--- a/assets/js/scheduler.js
+++ b/assets/js/scheduler.js
@@ -180,6 +180,7 @@
       setBooleanSelect($("#schEnabled"), !!saved.enabled);
       $("#schMode") && ($("#schMode").value = saved.mode || "hourly");
       $("#schN")    && ($("#schN").value = String(saved.every_n_hours || 2));
+      $("#schMinuteOffset") && ($("#schMinuteOffset").value = String(saved.minute_offset || 0));
       $("#schTime") && ($("#schTime").value = saved.daily_time || "03:30");
 
       const adv = saved?.advanced || {};
@@ -218,9 +219,10 @@
     const enabled = ($("#schEnabled")?.value || "").trim() === "true";
     const mode = $("#schMode")?.value || "hourly";
     const every_n_hours = parseInt($("#schN")?.value || "2", 10);
+    const minute_offset = parseInt($("#schMinuteOffset")?.value || "0", 10);
     const daily_time = $("#schTime")?.value || "03:30";
     const advanced = serializeAdvanced();
-    return { enabled, mode, every_n_hours, daily_time, advanced };
+    return { enabled, mode, every_n_hours, minute_offset, daily_time, advanced };
   };
 
   // boot

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -341,6 +341,7 @@ DEFAULT_CFG: dict[str, Any] = {
         "enabled": False,                               # Master toggle for periodic runs
         "mode": "hourly",                               # "hourly" or "daily"
         "every_n_hours": 2,                             # When mode=hourly, run every N hours (1–12)
+        "minute_offset": 0,                             # Minute offset for every_n_hours mode (0-59)
         "daily_time": "03:30",                          # When mode=daily, run at this time (HH:MM, 24h)
     },
 

--- a/services/scheduling.py
+++ b/services/scheduling.py
@@ -18,6 +18,7 @@ DEFAULT_SCHEDULING: dict[str, Any] = {
     "enabled": False,
     "mode": "disabled",          # disabled | hourly | every_n_hours | daily_time
     "every_n_hours": 2,
+    "minute_offset": 0,          # Minute offset for every_n_hours mode (0-59)
     "daily_time": "03:30",       # HH:MM (24h)
     "timezone": "Europe/Amsterdam",
     "jitter_seconds": 0,
@@ -85,7 +86,11 @@ def compute_next_run(now: datetime, sch: dict[str, Any]) -> datetime:
             n = max(1, int(sch.get("every_n_hours") or 2))
         except Exception:
             n = 2
-        anchor = (now if isinstance(now, datetime) else _now_local_naive()).replace(second=0, microsecond=0)
+        try:
+            minute_offset = max(0, min(59, int(sch.get("minute_offset") or 0)))
+        except Exception:
+            minute_offset = 0
+        anchor = (now if isinstance(now, datetime) else _now_local_naive()).replace(minute=minute_offset, second=0, microsecond=0)
         return _apply_jitter(anchor + timedelta(hours=n), sch)
 
     if mode == "daily_time":

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -290,6 +290,7 @@ def _get_index_html_static() -> str:
               <div><label>Enable</label><select id="schEnabled"><option value="false">Disabled</option><option value="true">Enabled</option></select></div>
               <div><label>Frequency</label><select id="schMode"><option value="hourly">Every hour</option><option value="every_n_hours">Every N hours</option><option value="daily_time">Daily at…</option></select></div>
               <div><label>Every N hours</label><input id="schN" type="number" min="1" max="24" value="2"></div>
+              <div><label>Minute offset (0-59)</label><input id="schMinuteOffset" type="number" min="0" max="59" value="0"></div>
               <div><label>Time</label><input id="schTime" type="time" value="03:30"></div>
             </div>
           </div>


### PR DESCRIPTION
I noticed that when setting the schedule to `Every N hours` it would keep the minute of when you saved the config instead. 

I.E. If I did every 4 hours at 10:06 it would set the scheduled next run to be at 14:06. I would have expected it to be just 14:00.

I didn't know if keeping the minutes was intentional so I also added a config where you can set which minute to run on. 
So now if I set it to run every 4 hours and  set `minute_offset` to 0, at 10:06 the next run will be at 14:00.

Please let me know of any further changes you would like me to make.