### PR TITLE
Fix: upgrade warning needing two acknowledgements after refresh

### DIFF
--- a/api/configAPI.py
+++ b/api/configAPI.py
@@ -99,6 +99,25 @@ def _safe_ver(v: str | None) -> Version:
         return Version("0.0.0")
 
 
+def _set_cfg_version_current(env: dict[str, Any], cfg: dict[str, Any]) -> None:
+    try:
+        base = env.get("cfg_base")
+        cur_fn = getattr(base, "_current_version_norm", None) if base is not None else None
+        if callable(cur_fn):
+            cfg["version"] = str(cur_fn() or "").strip()
+            return
+    except Exception:
+        pass
+
+    try:
+        from api.versionAPI import CURRENT_VERSION as _V
+        raw = str(_V or "").strip()
+    except Exception:
+        raw = str(os.getenv("APP_VERSION") or "").strip()
+
+    cfg["version"] = _norm_ver(raw)
+
+
 @router.get("/config/meta")
 def api_config_meta() -> JSONResponse:
     env = _env()
@@ -364,6 +383,7 @@ def api_config_save(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
         if isinstance(ui, dict):
             ui.pop("_autogen", None)
             ui.pop("_pending_upgrade_from_version", None)
+            _set_cfg_version_current(env, cfg)
     except Exception:
         pass
 
@@ -441,6 +461,7 @@ def api_config_migrate() -> dict[str, Any]:
         if isinstance(ui, dict):
             ui.pop("_autogen", None)
             ui.pop("_pending_upgrade_from_version", None)
+            _set_cfg_version_current(env, cfg)
     except Exception:
         pass
 


### PR DESCRIPTION
# Pull request

## Change

Fixed the upgrade warning flow so acknowledging the modal no longer requires two passes before it stays dismissed across a hard refresh.

The fix updates the config migration/save path to stamp the config with the current app version at the same time the pending upgrade marker is cleared. This keeps the upgrade acknowledgement from being reintroduced during the same save.

This is a backend/config-state fix only. No modal behavior was changed.

## Why

The upgrade warning could appear twice because the first acknowledgement cleared `ui._pending_upgrade_from_version`, but the same save could immediately add it back.

That happened because `save_config()` saw an older stored config version and recreated the pending upgrade marker before the save completed. As a result, the first hard refresh could still report `needs_upgrade`, and the modal would appear again. After the second acknowledgement, the version state had caught up, so the modal finally disappeared.

This change makes the version and pending-upgrade state update together so the modal is dismissed correctly after a single acknowledgement.

## Testing

- Reviewed the upgrade warning flow from `/api/config/meta` through `/api/config/migrate`.
- Verified the config migration path now updates the config version before saving when clearing `_pending_upgrade_from_version`.
- Ran a Python compile sanity check on `api/configAPI.py`.

## Issue

N/A
