### PR TITLE
Change: PublicMetaDB now has progress sync support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 <p align="center" style="font-size:14px;">
 <b>⭐ Star this repository to get updates</b><br>
 </p>
-<img width="1566" height="631" alt="providers1 (1)" src="https://github.com/user-attachments/assets/fa833ac6-ff96-440d-bfc0-5f749120af8c" />
+<img width="1975" height="796" alt="ov" src="https://github.com/user-attachments/assets/bcf1d3c0-628c-49e2-8249-c3d853f8b115" />
+
 <p align="center">
   <a href="https://github.com/cenodude/CrossWatch/releases/latest">
     <img src="https://img.shields.io/github/v/release/cenodude/CrossWatch?display_name=release&amp;sort=semver&amp;logo=github&amp;label=Latest%20Release&amp;style=for-the-badge" alt="Latest Release">

--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -159,7 +159,7 @@ def _normalize_features(f: dict | None) -> dict:
             v.setdefault("remove", False)
     return f
 
-_PROGRESS_ALLOWED = {"PLEX", "EMBY", "JELLYFIN", "CROSSWATCH"}
+_PROGRESS_ALLOWED = {"PLEX", "EMBY", "JELLYFIN", "PUBLICMETADB", "CROSSWATCH"}
 _RATINGS_ALLOWED = {"PLEX", "SIMKL", "TRAKT", "TMDB", "MDBLIST", "PUBLICMETADB", "CROSSWATCH"}
 
 def _enforce_pair_feature_constraints(pair: dict[str, Any]) -> None:

--- a/assets/js/modals/pair-config/help.js
+++ b/assets/js/modals/pair-config/help.js
@@ -29,7 +29,7 @@ export const HELP_TEXT = {
   "cx-md-hs-ignore-dropped": "MDBList: Ignore dropped shows\nWhen enabled, shows marked as dropped on MDBList are skipped during history sync. This suppresses sync for those shows; it does not remove them elsewhere.",
   "cx-sm-hs-ignore-dropped": "Simkl: Ignore dropped shows\nWhen enabled, shows marked as dropped on Simkl are skipped during history sync. This suppresses sync for those shows; it does not remove them elsewhere.",
 
-  "cx-pr-enable": "Progress: Enable\nSync resume position (where you left off) between media servers.",
+  "cx-pr-enable": "Progress: Enable\nSync resume position (where you left off) between providers.",
   "cx-pr-add": "Progress: Add / Update\nWrite resume position to the target.",
   "cx-pr-remove": "Progress: Remove\nClear resume position on the target (rare; Plex may not support).",
   "cx-pr-min": "Progress: Minimum seconds\nIgnore tiny offsets (scrubbing).",

--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -28,6 +28,7 @@ const isSimkl=(v)=>same(v,"simkl");
 const isJelly=(v)=>same(v,"jellyfin");
 const isTrakt=(v)=>same(v,"trakt");
 const isMDBList=(v)=>same(v,"mdblist");
+const isPublicMetaDB=(v)=>same(v,"publicmetadb");
 const isPlex = (v) => same(v, "plex");
 const isCrossWatch = (v) => same(v, "crosswatch");
 function hasPlex(state){ return isPlex(state?.src) || isPlex(state?.dst) }
@@ -38,6 +39,7 @@ function hasSimkl(state){return isSimkl(state?.src)||isSimkl(state?.dst)}
 function hasJelly(state){return isJelly(state?.src)||isJelly(state?.dst)}
 function hasTrakt(state){return isTrakt(state?.src)||isTrakt(state?.dst)}
 function hasMDBList(state){return isMDBList(state?.src)||isMDBList(state?.dst)}
+function hasPublicMetaDB(state){return isPublicMetaDB(state?.src)||isPublicMetaDB(state?.dst)}
 
 const RATINGS_TYPE_RULES={SIMKL:{disable:["seasons","episodes"]},TMDB:{disable:["seasons"]}};
 function ratingsDisabledFor(state){
@@ -448,7 +450,7 @@ function initPairLibraryUI(state){
 function renderWarnings(state){
   const flowBox=ID("cx-flow-warn"),main=Q(".cx-main");
   const HIDE=new Set(["globals","providers"]);
-  const BOTTOM=new Set(["watchlist","ratings","history","playlists"]);
+  const BOTTOM=new Set(["watchlist","ratings","history","progress","playlists"]);
   if(flowBox) flowBox.innerHTML="";
   ID("cx-feat-warn")?.remove();
   if(HIDE.has(state.feature)) return;
@@ -909,6 +911,8 @@ function renderFeaturePanel(state){
     const wl = getOpts(state, "watchlist");
     const emw = state.emby?.watchlist || { mode: "favorites", playlist_name: "Watchlist" };
     const jfw = state.jellyfin?.watchlist || { mode: "favorites", playlist_name: "Watchlist" };
+    const pmw = state.pairProviders?.publicmetadb || {};
+    const pmwName = (pmw.watchlist_name || state.cfgRaw?.publicmetadb?.watchlist_name || "Watchlist");
     const trPair = (state.pairProviders?.trakt) || {};
 
     left.innerHTML = `
@@ -962,6 +966,16 @@ function renderFeaturePanel(state){
           <div class="opt-row" style="grid-column:1/-1">
             <label for="cx-em-wl-pl-name">Name</label>
             <input id="cx-em-wl-pl-name" class="input" type="text" value="${emw.playlist_name||"Watchlist"}" placeholder="Watchlist">
+          </div>
+        </div>
+      `:""}
+
+      ${hasPublicMetaDB(state)?`
+        <div class="panel-title small" style="margin-top:6px">PublicMetaDB specifics</div>
+        <div class="grid2 compact">
+          <div class="opt-row" style="grid-column:1/-1">
+            <label for="cx-pmdb-wl-name">List name</label>
+            <input id="cx-pmdb-wl-name" class="input" type="text" value="${pmwName}" placeholder="Watchlist">
           </div>
         </div>
       `:""}
@@ -1765,6 +1779,13 @@ function bindChangeHandlers(state,root){
       em.watchlist={mode,playlist_name:name,watchlist_query_limit:q,watchlist_write_delay_ms:d,watchlist_guid_priority:gp.length?gp:undefined};
     }
 
+    if(id==="cx-pmdb-wl-name"){
+      state.pairProviders=state.pairProviders||{};
+      const pm=Object.assign({},state.pairProviders.publicmetadb||{});
+      pm.watchlist_name=(ID("cx-pmdb-wl-name")?.value||"").trim()||"Watchlist";
+      state.pairProviders.publicmetadb=pm;
+    }
+
     if (/^(plx-|jf-|em-)/.test(id)) {
       refreshProviderCardSummaries(state);
     }
@@ -2031,9 +2052,15 @@ function buildPayload(state,wrap){
   const useJf=(String(src).toUpperCase()==="JELLYFIN"||String(dst).toUpperCase()==="JELLYFIN");
   const useEm=(String(src).toUpperCase()==="EMBY"||String(dst).toUpperCase()==="EMBY");
   const useTr=(String(src).toUpperCase()==="TRAKT"||String(dst).toUpperCase()==="TRAKT");
+  const usePmdb=(String(src).toUpperCase()==="PUBLICMETADB"||String(dst).toUpperCase()==="PUBLICMETADB");
   if(usePlex) prov.plex={strict_id_matching:getPairProviderStrictValue(state, "plex")};
   if(useJf) prov.jellyfin={strict_id_matching:getPairProviderStrictValue(state, "jellyfin")};
   if(useEm) prov.emby={strict_id_matching:getPairProviderStrictValue(state, "emby")};
+  if(usePmdb){
+    const pmSrc=pp.publicmetadb||{};
+    const name=(ID("cx-pmdb-wl-name")?.value||pmSrc.watchlist_name||state.cfgRaw?.publicmetadb?.watchlist_name||"Watchlist").trim()||"Watchlist";
+    prov.publicmetadb=Object.assign({},pmSrc,{watchlist_name:name});
+  }
   if(useTr){
     const trSrc=pp.trakt||{};
     const colOn=!!trSrc.history_collection;

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -293,10 +293,13 @@ DEFAULT_CFG: dict[str, Any] = {
         "timeout": 15.0,                                # HTTP timeout (seconds)
         "max_retries": 3,                               # Retry budget
         "watchlist_list_id": "",                        # Optional list id; empty = discover/create
+        "watchlist_name": "Watchlist",                  # Default PublicMetaDB list name; pair config can override
         "watchlist_auto_create": True,                  # Create a private CrossWatch watchlist if missing
         "watchlist_page_size": 100,                     # GET page size for list items
         "history_per_page": 100,                        # GET page size for watched history
         "history_max_pages": 1000,                      # Safety cap for watched history fetches
+        "progress_per_page": 100,                       # GET page size for resume/progress
+        "progress_max_pages": 1000,                     # Safety cap for resume/progress fetches
         "ratings_label": "Overall",                     # PublicMetaDB rating label used by CrossWatch
         "ratings_submit_per_hour": 200,                 # PublicMetaDB contribution limit for rating creates
         "ratings_update_per_hour": 100,                 # PublicMetaDB contribution limit for rating updates
@@ -1059,6 +1062,7 @@ def _normalize_publicmetadb(cfg: dict[str, Any]) -> None:
         p = {}
         cfg["publicmetadb"] = p
     p["base_url"] = str(p.get("base_url") or "https://publicmetadb.com").strip().rstrip("/")
+    p["watchlist_name"] = str(p.get("watchlist_name") or "Watchlist").strip() or "Watchlist"
     p["watchlist_auto_create"] = bool(p.get("watchlist_auto_create", True))
 
     def _int_range(name: str, default: int, lo: int, hi: int) -> None:
@@ -1071,6 +1075,8 @@ def _normalize_publicmetadb(cfg: dict[str, Any]) -> None:
     _int_range("watchlist_page_size", 100, 1, 500)
     _int_range("history_per_page", 100, 1, 500)
     _int_range("history_max_pages", 1000, 1, 100000)
+    _int_range("progress_per_page", 100, 1, 500)
+    _int_range("progress_max_pages", 1000, 1, 100000)
     _int_range("ratings_submit_per_hour", 200, 1, 200)
     _int_range("ratings_update_per_hour", 100, 1, 100)
     p["ratings_label"] = str(p.get("ratings_label") or "Overall").strip() or "Overall"

--- a/providers/auth/_auth_PUBLICMETADB.py
+++ b/providers/auth/_auth_PUBLICMETADB.py
@@ -1,5 +1,6 @@
 # providers/auth/_auth_PUBLICMETADB.py
 # CrossWatch - PublicMetaDB Auth Provider
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
 from collections.abc import Mapping, MutableMapping
@@ -124,7 +125,7 @@ def html() -> str:
   </style>
 
   <div class="head" onclick="toggleSection && toggleSection('sec-publicmetadb')">
-    <span class="chev">&gt;</span><strong>PublicMetaDB</strong>
+    <span class="chev">▶</span><strong>PublicMetaDB</strong>
   </div>
 
   <div class="body">

--- a/providers/sync/_mod_PUBLICMETADB.py
+++ b/providers/sync/_mod_PUBLICMETADB.py
@@ -1,5 +1,6 @@
 # providers/sync/_mod_PUBLICMETADB.py
 # CrossWatch PublicMetaDB sync module
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
 import os
@@ -13,6 +14,7 @@ from cw_platform.id_map import canonical_key, minimal as id_minimal
 from ._log import log as cw_log
 from ._mod_common import HitSession, SimpleRateLimiter, build_session, parse_rate_limit, request_with_retries, safe_json
 from .publicmetadb import _history as feat_history
+from .publicmetadb import _progress as feat_progress
 from .publicmetadb import _ratings as feat_ratings
 from .publicmetadb import _watchlist as feat_watchlist
 
@@ -28,6 +30,8 @@ __all__ = ["get_manifest", "PUBLICMETADBModule", "OPS"]
 def _label_publicmetadb(method: str, url: str, kw: Mapping[str, Any]) -> str:
     if "/api/external/lists" in str(url):
         return "watchlist"
+    if "/api/external/resume" in str(url):
+        return "progress"
     if "/api/external/watched" in str(url):
         return "history"
     if "/api/external/ratings" in str(url) or "/api/external/episode-ratings" in str(url):
@@ -53,7 +57,7 @@ def _confirmed_keys(items: Iterable[Mapping[str, Any]], unresolved: Any) -> list
 
 
 def _features_flags() -> dict[str, bool]:
-    return {"watchlist": True, "ratings": True, "history": True, "playlists": False}
+    return {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False}
 
 
 def get_manifest() -> Mapping[str, Any]:
@@ -90,6 +94,15 @@ def get_manifest() -> Mapping[str, Any]:
                 "requires_ids": ["tmdb"],
                 "scale": "1-10",
             },
+            "progress": {
+                "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+                "upsert": True,
+                "remove": True,
+                "observed_deletes": True,
+                "requires_ids": ["tmdb"],
+                "requires_duration": True,
+                "server_completion_percent": 80,
+            },
         },
     }
 
@@ -100,11 +113,14 @@ class PUBLICMETADBConfig:
     base_url: str = "https://publicmetadb.com"
     timeout: float = 15.0
     max_retries: int = 3
+    watchlist_name: str = "Watchlist"
     rate_get_per_sec: float = 20.0
     rate_post_per_sec: float = 3.0
     watchlist_page_size: int = 100
     history_per_page: int = 100
     history_max_pages: int = 1000
+    progress_per_page: int = 100
+    progress_max_pages: int = 1000
     ratings_label: str = "Overall"
     ratings_submit_per_hour: int = 200
     ratings_update_per_hour: int = 100
@@ -226,11 +242,14 @@ class PUBLICMETADBModule:
             base_url=str(p.get("base_url") or "https://publicmetadb.com").strip().rstrip("/"),
             timeout=float(p.get("timeout", cfg.get("timeout", 15.0))),
             max_retries=int(p.get("max_retries", cfg.get("max_retries", 3))),
+            watchlist_name=str(p.get("watchlist_name") or "Watchlist").strip() or "Watchlist",
             rate_get_per_sec=_float("get_per_sec", 20.0, 20.0),
             rate_post_per_sec=_float("post_per_sec", 3.0, 3.0),
             watchlist_page_size=int(p.get("watchlist_page_size", 100) or 100),
             history_per_page=int(p.get("history_per_page", 100) or 100),
             history_max_pages=int(p.get("history_max_pages", 1000) or 1000),
+            progress_per_page=int(p.get("progress_per_page", 100) or 100),
+            progress_max_pages=int(p.get("progress_max_pages", 1000) or 1000),
             ratings_label=str(p.get("ratings_label") or "Overall").strip() or "Overall",
             ratings_submit_per_hour=_int_range("ratings_submit_per_hour", 200, 1, 200),
             ratings_update_per_hour=_int_range("ratings_update_per_hour", 100, 1, 100),
@@ -288,13 +307,13 @@ class PUBLICMETADBModule:
             "ok": ok,
             "status": status,
             "latency_ms": latency_ms,
-            "features": {"watchlist": ok, "ratings": ok, "history": ok, "playlists": False},
+            "features": {"watchlist": ok, "ratings": ok, "history": ok, "progress": ok, "playlists": False},
             "details": {"reason": reason} if reason else None,
             "api": {"lists": {"status": code, "rate": rate}},
         }
 
     def feature_names(self) -> tuple[str, ...]:
-        return ("watchlist", "ratings", "history")
+        return ("watchlist", "ratings", "history", "progress")
 
     def build_index(self, feature: str, **kwargs: Any) -> dict[str, dict[str, Any]]:
         if feature == "watchlist":
@@ -303,16 +322,20 @@ class PUBLICMETADBModule:
             return feat_history.build_index(self)
         if feature == "ratings":
             return feat_ratings.build_index(self)
+        if feature == "progress":
+            return feat_progress.build_index(self)
         return {}
 
     def add(self, feature: str, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
         lst = list(items or [])
-        if feature not in ("watchlist", "ratings", "history"):
+        if feature not in ("watchlist", "ratings", "history", "progress"):
             return {"ok": True, "count": 0, "unresolved": []}
         if dry_run:
             return {"ok": True, "count": len(lst), "dry_run": True}
         if feature == "history":
             cnt, unresolved = feat_history.add(self, lst)
+        elif feature == "progress":
+            cnt, unresolved = feat_progress.add(self, lst)
         elif feature == "ratings":
             cnt, unresolved = feat_ratings.add(self, lst)
         else:
@@ -321,12 +344,14 @@ class PUBLICMETADBModule:
 
     def remove(self, feature: str, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
         lst = list(items or [])
-        if feature not in ("watchlist", "ratings", "history"):
+        if feature not in ("watchlist", "ratings", "history", "progress"):
             return {"ok": True, "count": 0, "unresolved": []}
         if dry_run:
             return {"ok": True, "count": len(lst), "dry_run": True}
         if feature == "history":
             cnt, unresolved = feat_history.remove(self, lst)
+        elif feature == "progress":
+            cnt, unresolved = feat_progress.remove(self, lst)
         elif feature == "ratings":
             cnt, unresolved = feat_ratings.remove(self, lst)
         else:

--- a/providers/sync/publicmetadb/_common.py
+++ b/providers/sync/publicmetadb/_common.py
@@ -1,4 +1,6 @@
 # providers/sync/publicmetadb/_common.py
+# PUBLICMETADB Module for common functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
 import json

--- a/providers/sync/publicmetadb/_progress.py
+++ b/providers/sync/publicmetadb/_progress.py
@@ -1,9 +1,8 @@
-# /providers/sync/publicmetadb/_history.py
-# PUBLICMETADB Module for history functions
+# /providers/sync/publicmetadb/_progress.py
+# PUBLICMETADB Module for progress functions
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping
 
 from cw_platform.id_map import canonical_key, minimal as id_minimal
@@ -13,19 +12,19 @@ from ._common import as_int, read_json, state_file, tmdb_id_for_item, write_json
 
 
 def _dbg(event: str, **fields: Any) -> None:
-    cw_log("PUBLICMETADB", "history", "debug", event, **fields)
+    cw_log("PUBLICMETADB", "progress", "debug", event, **fields)
 
 
 def _info(event: str, **fields: Any) -> None:
-    cw_log("PUBLICMETADB", "history", "info", event, **fields)
+    cw_log("PUBLICMETADB", "progress", "info", event, **fields)
 
 
 def _warn(event: str, **fields: Any) -> None:
-    cw_log("PUBLICMETADB", "history", "warn", event, **fields)
+    cw_log("PUBLICMETADB", "progress", "warn", event, **fields)
 
 
 def _shadow_path():
-    return state_file("publicmetadb_history.shadow.json")
+    return state_file("publicmetadb_progress.shadow.json")
 
 
 def _shadow_load() -> dict[str, Any]:
@@ -37,53 +36,6 @@ def _shadow_load() -> dict[str, Any]:
 
 def _shadow_save(items: Mapping[str, Any]) -> None:
     write_json(_shadow_path(), {"items": dict(items)})
-
-
-def _iso_epoch(value: Any) -> int | None:
-    if value is None:
-        return None
-    s = str(value).strip()
-    if not s:
-        return None
-    try:
-        if s.isdigit():
-            n = int(s)
-            return n // 1000 if len(s) >= 13 else n
-        iso = s.replace("Z", "+00:00")
-        tail = iso[10:] if len(iso) > 10 else ""
-        if "T" in iso and "+" not in tail and "-" not in tail:
-            iso = iso + "+00:00"
-        return int(datetime.fromisoformat(iso).timestamp())
-    except Exception:
-        return None
-
-
-def _iso_z(value: Any) -> str | None:
-    epoch = _iso_epoch(value)
-    if epoch is None:
-        return None
-    return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def _event_key(item: Mapping[str, Any]) -> str:
-    mini = id_minimal(item)
-    base = canonical_key(mini)
-    watched_at = _iso_z(mini.get("watched_at") or item.get("watched_at") or item.get("last_watched_at"))
-    if watched_at:
-        return f"{base}@{_iso_epoch(watched_at)}"
-    hist_id = str(item.get("history_id") or item.get("_publicmetadb_history_id") or "").strip()
-    return f"{base}@id:{hist_id}" if hist_id else base
-
-
-def _show_tmdb_for_item(item: Mapping[str, Any]) -> int | None:
-    show_ids_obj = item.get("show_ids")
-    show_ids: Mapping[str, Any] = show_ids_obj if isinstance(show_ids_obj, Mapping) else {}
-    return as_int(show_ids.get("tmdb")) or tmdb_id_for_item(item)
-
-
-def _history_id(item: Mapping[str, Any]) -> str | None:
-    hid = str(item.get("_publicmetadb_history_id") or item.get("history_id") or "").strip()
-    return hid or None
 
 
 def _rows(data: Any) -> list[Any]:
@@ -98,14 +50,55 @@ def _rows(data: Any) -> list[Any]:
     return []
 
 
+def _show_tmdb_for_item(item: Mapping[str, Any]) -> int | None:
+    show_ids_obj = item.get("show_ids")
+    show_ids: Mapping[str, Any] = show_ids_obj if isinstance(show_ids_obj, Mapping) else {}
+    return as_int(show_ids.get("tmdb")) or tmdb_id_for_item(item)
+
+
+def _progress_ms(item: Mapping[str, Any]) -> int | None:
+    for key in ("progress_ms", "progressMs", "position_ms", "positionMs", "viewOffset"):
+        n = as_int(item.get(key))
+        if n is not None:
+            return n
+    return None
+
+
+def _duration_ms(item: Mapping[str, Any]) -> int | None:
+    for key in ("duration_ms", "durationMs", "runtime_ms", "runtimeMs", "duration", "runtime"):
+        n = as_int(item.get(key))
+        if n is not None and n > 0:
+            return n
+    return None
+
+
+def _resume_id(item: Mapping[str, Any]) -> str | None:
+    rid = str(item.get("_publicmetadb_resume_id") or item.get("resume_id") or item.get("id") or "").strip()
+    return rid or None
+
+
+def _item_key(item: Mapping[str, Any]) -> str:
+    return canonical_key(id_minimal(item))
+
+
 def _to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
     tmdb = tmdb_id_for_item(row)
     if tmdb is None:
         return None
-    media = str(row.get("media_type") or row.get("type") or "").strip().lower()
-    watched_at = _iso_z(row.get("watched_at") or row.get("watchedAt") or row.get("last_watched_at"))
-    hist_id = str(row.get("id") or row.get("history_id") or "").strip()
 
+    pos_ms = _progress_ms(row)
+    dur_ms = _duration_ms(row)
+    if pos_ms is None and dur_ms:
+        try:
+            pct = float(str(row.get("progress")).strip())
+            if pct > 0:
+                pos_ms = int((pct / 100.0) * float(dur_ms))
+        except Exception:
+            pos_ms = None
+    if pos_ms is None or pos_ms <= 0:
+        return None
+
+    media = str(row.get("media_type") or row.get("type") or "").strip().lower()
     if media in ("tv", "show", "series", "episode"):
         season = as_int(row.get("season") or row.get("season_number"))
         episode = as_int(row.get("episode") or row.get("episode_number"))
@@ -116,12 +109,13 @@ def _to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
             "show_ids": {"tmdb": str(tmdb)},
             "season": season,
             "episode": episode,
+            "progress_ms": int(pos_ms),
         }
         title = str(row.get("series_title") or row.get("show_title") or row.get("name") or "").strip()
         if title:
             out["series_title"] = title
     else:
-        out = {"type": "movie", "ids": {"tmdb": str(tmdb)}}
+        out = {"type": "movie", "ids": {"tmdb": str(tmdb)}, "progress_ms": int(pos_ms)}
         title = str(row.get("title") or row.get("name") or "").strip()
         if title:
             out["title"] = title
@@ -129,27 +123,33 @@ def _to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
         if year is not None:
             out["year"] = year
 
-    if watched_at:
-        out["watched"] = True
-        out["watched_at"] = watched_at
-    if hist_id:
-        out["history_id"] = hist_id
-        out["_publicmetadb_history_id"] = hist_id
-    return id_minimal(out)
+    if dur_ms is not None:
+        out["duration_ms"] = int(dur_ms)
+
+    updated = row.get("updated") or row.get("updated_at") or row.get("progress_at") or row.get("last_played")
+    if updated:
+        out["progress_at"] = str(updated)
+
+    rid = _resume_id(row)
+    mini = id_minimal(out)
+    if rid:
+        mini["resume_id"] = rid
+        mini["_publicmetadb_resume_id"] = rid
+    return mini
 
 
 def _fetch_all_items(adapter: Any) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
     out: dict[str, dict[str, Any]] = {}
     remote_ids: dict[str, str] = {}
     page = 1
-    per_page = int(getattr(adapter.cfg, "history_per_page", 100) or 100)
+    per_page = int(getattr(adapter.cfg, "progress_per_page", 100) or 100)
     per_page = max(1, min(per_page, 500))
-    max_pages = int(getattr(adapter.cfg, "history_max_pages", 1000) or 1000)
+    max_pages = int(getattr(adapter.cfg, "progress_max_pages", 1000) or 1000)
     max_pages = max(1, max_pages)
 
     while page <= max_pages:
         data = adapter.client.get_json(
-            "/api/external/watched",
+            "/api/external/resume",
             params={"page": page, "perPage": per_page},
         )
         rows = _rows(data)
@@ -161,15 +161,16 @@ def _fetch_all_items(adapter: Any) -> tuple[dict[str, dict[str, Any]], dict[str,
             mini = _to_minimal(row)
             if not mini:
                 continue
-            key = _event_key(mini)
+            key = _item_key(mini)
             out[key] = mini
-            rid = _history_id(mini) or str(row.get("id") or "").strip()
+            rid = _resume_id(mini) or str(row.get("id") or "").strip()
             if rid:
                 remote_ids[key] = rid
         total_pages = int(data.get("totalPages") or data.get("total_pages") or page) if isinstance(data, Mapping) else page
         if page >= total_pages:
             break
         page += 1
+
     if page > max_pages:
         _warn("index_limited", max_pages=max_pages, per_page=per_page)
     return out, remote_ids
@@ -184,9 +185,15 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
 
 def _payload_for_item(item: Mapping[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
     mini = id_minimal(item)
-    watched_at = _iso_z(mini.get("watched_at") or item.get("watched_at") or item.get("last_watched_at"))
-    if not watched_at:
-        return None, "missing_watched_at"
+    pos_ms = _progress_ms(mini) or _progress_ms(item) or as_int(item.get("progress"))
+    dur_ms = _duration_ms(mini) or _duration_ms(item)
+    if pos_ms is None:
+        return None, "missing_progress"
+    if pos_ms <= 0:
+        return None, "zero_progress"
+    if dur_ms is None:
+        return None, "missing_duration"
+
     typ = str(mini.get("type") or item.get("type") or "").strip().lower()
     if typ == "episode":
         tmdb = _show_tmdb_for_item(mini) or _show_tmdb_for_item(item)
@@ -199,13 +206,22 @@ def _payload_for_item(item: Mapping[str, Any]) -> tuple[dict[str, Any] | None, s
             "media_type": "tv",
             "season": int(season),
             "episode": int(episode),
-            "watched_at": watched_at,
+            "position_ms": int(pos_ms),
+            "runtime_ms": int(dur_ms),
         }, None
+
+    if typ not in ("movie", "movies"):
+        return None, "unsupported_progress_type"
 
     tmdb = tmdb_id_for_item(mini) or tmdb_id_for_item(item)
     if tmdb is None:
         return None, "missing_tmdb_id"
-    return {"tmdb_id": int(tmdb), "media_type": "movie", "watched_at": watched_at}, None
+    return {
+        "tmdb_id": int(tmdb),
+        "media_type": "movie",
+        "position_ms": int(pos_ms),
+        "runtime_ms": int(dur_ms),
+    }, None
 
 
 def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
@@ -217,24 +233,28 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
 
     for it in items_list:
         mini = id_minimal(it)
-        key = _event_key(mini)
-        if key in remote_ids:
-            continue
         payload, hint = _payload_for_item(it)
         if payload is None:
-            unresolved.append({"item": mini, "hint": hint or "unsupported_history_item"})
+            unresolved.append({"item": mini, "hint": hint or "unsupported_progress_item"})
             continue
-        r = adapter.client.post("/api/external/watched", json=payload)
+
+        r = adapter.client.post("/api/external/resume", json=payload)
         if 200 <= r.status_code < 300:
             data = adapter.client.safe_json(r)
             item = data.get("item") if isinstance(data, Mapping) else None
-            rid = str(item.get("id") or "").strip() if isinstance(item, Mapping) else ""
-            if rid:
-                remote_ids[key] = rid
+            action = str(data.get("action") or "").strip().lower() if isinstance(data, Mapping) else ""
+            key = _item_key(mini)
+            if isinstance(item, Mapping):
+                rid = str(item.get("id") or "").strip()
+                if rid:
+                    remote_ids[key] = rid
+            elif action in ("completed", "ignored"):
+                remote_ids.pop(key, None)
             ok += 1
         else:
             _warn("write_failed", op="add", status=r.status_code, body=(r.text or "")[:200])
             unresolved.append({"item": mini, "hint": f"http:{r.status_code}"})
+
     _shadow_save(remote_ids)
     _info("write_done", op="add", applied=ok, unresolved=len(unresolved))
     return ok, unresolved
@@ -251,18 +271,19 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
     ok = 0
     for it in items_list:
         mini = id_minimal(it)
-        key = _event_key(mini)
-        history_id = _history_id(it) or _history_id(mini) or str(remote_ids.get(key) or "").strip()
-        if not history_id:
-            unresolved.append({"item": mini, "hint": "missing_remote_history_id"})
+        key = _item_key(mini)
+        resume_id = _resume_id(it) or _resume_id(mini) or str(remote_ids.get(key) or "").strip()
+        if not resume_id:
+            unresolved.append({"item": mini, "hint": "missing_remote_resume_id"})
             continue
-        r = adapter.client.delete(f"/api/external/watched/{history_id}")
+        r = adapter.client.delete(f"/api/external/resume/{resume_id}")
         if 200 <= r.status_code < 300:
             remote_ids.pop(key, None)
             ok += 1
         else:
             _warn("write_failed", op="remove", status=r.status_code, body=(r.text or "")[:200])
             unresolved.append({"item": mini, "hint": f"http:{r.status_code}"})
+
     _shadow_save(remote_ids)
     _info("write_done", op="remove", applied=ok, unresolved=len(unresolved))
     return ok, unresolved

--- a/providers/sync/publicmetadb/_ratings.py
+++ b/providers/sync/publicmetadb/_ratings.py
@@ -1,3 +1,6 @@
+# /providers/sync/publicmetadb/_ratings.py
+# PUBLICMETADB Module for ratings functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
 import time

--- a/providers/sync/publicmetadb/_watchlist.py
+++ b/providers/sync/publicmetadb/_watchlist.py
@@ -1,4 +1,6 @@
 # providers/sync/publicmetadb/_watchlist.py
+# PUBLICMETADB Module for watchlist functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
 from typing import Any, Iterable, Mapping
@@ -64,13 +66,19 @@ def _find_watchlist(adapter: Any) -> str | None:
     configured = str(cfg.get("watchlist_list_id") or "").strip()
     if configured:
         return configured
+    configured_name = str(
+        cfg.get("watchlist_name")
+        or getattr(getattr(adapter, "cfg", None), "watchlist_name", "")
+        or "Watchlist"
+    ).strip() or "Watchlist"
+    configured_name_l = configured_name.lower()
 
     data = adapter.client.get_json("/api/external/lists", params={"page": 1, "perPage": 500})
     rows = data.get("items") if isinstance(data, Mapping) else None
     if not isinstance(rows, list):
         return None
 
-    preferred: str | None = None
+    typed_watchlist: str | None = None
     fallback: str | None = None
     for row in rows:
         if not isinstance(row, Mapping):
@@ -80,12 +88,13 @@ def _find_watchlist(adapter: Any) -> str | None:
             continue
         typ = str(row.get("type") or "").strip().lower()
         name = str(row.get("name") or "").strip().lower()
+        if name == configured_name_l:
+            return rid
         if typ == "watchlist":
-            preferred = rid
-            break
+            typed_watchlist = typed_watchlist or rid
         if name in ("crosswatch", "crosswatch watchlist", "watchlist"):
             fallback = fallback or rid
-    return preferred or fallback
+    return typed_watchlist or fallback
 
 
 def _ensure_watchlist(adapter: Any) -> str | None:
@@ -95,9 +104,14 @@ def _ensure_watchlist(adapter: Any) -> str | None:
     cfg = cfg_section(adapter)
     if cfg.get("watchlist_auto_create") is False:
         return None
+    name = str(
+        cfg.get("watchlist_name")
+        or getattr(getattr(adapter, "cfg", None), "watchlist_name", "")
+        or "Watchlist"
+    ).strip() or "Watchlist"
     data = adapter.client.post_json(
         "/api/external/lists",
-        json={"name": "CrossWatch Watchlist", "description": "Managed by CrossWatch", "is_public": False, "type": "watchlist"},
+        json={"name": name, "description": "Managed by CrossWatch", "is_public": False, "type": "watchlist"},
     )
     item = data.get("item") if isinstance(data, Mapping) else None
     if isinstance(item, Mapping):


### PR DESCRIPTION
# Pull request

## Change

Added PublicMetaDB progress sync support, pair-specific PublicMetaDB watchlist names and related pair-config UI updates.

## Why

PublicMetaDB now exposes resume/continue-watching endpoints, so CrossWatch can sync progress with it like other supported providers. Pair-specific watchlist names let different connections target different PublicMetaDB lists.

## Testing

Manually tested PublicMetaDB pair configuration by enabling progress sync, saving and reopening the pair, and confirming the setting persisted. Also checked the Watchlist tab UI for the new PublicMetaDB list-name field .

## Issue

Fixes #71
