### PR TITLE
Change: allow Webhooks and Watcher to run together

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
   style="max-width:170px; height:auto; margin:0 0 12px 16px;"
 />
 
-**CrossWatch/CW** is a synchronization engine that keeps your **Plex, Jellyfin, Emby, SIMKL, Trakt, AniList, TMDb, MDBList and Tautulli** in sync. It runs locally with a web UI where you link accounts, define sync pairs, run them manually or on a schedule, and review stats and history. CW also includes its own tracker to keep your data safe with snapshots. With Profiles, you can manage separate sync setups for yourself and for friends or family too, with their own servers and/or tracker API's.
+**CrossWatch/CW** is a synchronization engine that keeps your **Plex, Jellyfin, PublicMetaDB, Emby, SIMKL, Trakt, AniList, TMDb, MDBList and Tautulli** in sync. It runs locally with a web UI where you link accounts, define sync pairs, run them manually or on a schedule, and review stats and history. CW also includes its own tracker to keep your data safe with snapshots. With Profiles, you can manage separate sync setups for yourself and for friends or family too, with their own servers and/or tracker API's.
 
 ### CW in a nutshell:
 * **One brain for all your media syncs** A single place to configure everything.
@@ -53,7 +53,7 @@
 * **Multi media-server** and **multi tracker** support with profiles.
 * **Synchronization**
   * Watchlists, ratings and History
-  * Progress sync your progress status between Plex, Emby and Jellyfin.
+  * Progress sync your progress status between Plex, Emby, Jellyfin and PublicMetaDB.
 * **Scrobble (tracks your activity)**
   * **Watcher** (Plex/Emby/Jellyfin to Trakt/SIMKL/MDBList)
     * Does not require any Plex Pass, Emby Premiere,etc.  

--- a/api/configAPI.py
+++ b/api/configAPI.py
@@ -13,6 +13,7 @@ from packaging.version import InvalidVersion, Version
 
 from fastapi import APIRouter, Body
 from fastapi.responses import JSONResponse
+from providers.scrobble.sources import source_enabled
 
 def _env() -> dict[str, Any]:
     try:
@@ -57,7 +58,51 @@ def _nostore(res: JSONResponse) -> JSONResponse:
 
 router = APIRouter(prefix="/api", tags=["config"])
 
+_LAST_SCROBBLE_SOURCE_LOG: tuple[bool, bool, bool] | None = None
+
+
+def _log_scrobble_source_state(env: dict[str, Any], cfg: dict[str, Any]) -> None:
+    global _LAST_SCROBBLE_SOURCE_LOG
+    try:
+        sc = cfg.get("scrobble") if isinstance(cfg.get("scrobble"), dict) else {}
+        enabled = bool((sc or {}).get("enabled"))
+        webhook = source_enabled(cfg, "webhook")
+        watcher = source_enabled(cfg, "watcher")
+        state = (enabled, webhook, watcher)
+        if state == _LAST_SCROBBLE_SOURCE_LOG:
+            return
+        _LAST_SCROBBLE_SOURCE_LOG = state
+
+        cw = env.get("CW")
+        logger_cls = getattr(cw, "_UIHostLogger", None) if cw is not None else None
+        base_log = getattr(cw, "LOG", None) if cw is not None else None
+        logger = logger_cls("SCROBBLE", "SCROBBLE") if callable(logger_cls) else None
+
+        def emit(message: str, level: str = "INFO") -> None:
+            if callable(base_log):
+                base_log(message, level=level, module="SCROBBLE")
+                return
+            if callable(logger):
+                logger(message, level=level)
+
+        if webhook and watcher:
+            emit(
+                "WARNING: both Webhook and Watcher are enabled; duplicate events are possible if the same server sends both",
+                level="WARN",
+            )
+        elif webhook:
+            emit("webhook endpoints enabled; waiting for Plex/Jellyfin/Emby events")
+        elif watcher:
+            emit("watcher source enabled")
+        else:
+            emit("scrobble sources disabled")
+    except Exception:
+        pass
+
+
 def _after_config_save(env: dict[str, Any], cfg: dict[str, Any]) -> None:
+    _log_scrobble_source_state(env, cfg)
+
     try:
         pc = env["probes_cache"]; ps = env["probes_status_cache"]
         if isinstance(pc, dict):
@@ -367,7 +412,7 @@ def api_config_save(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
 
     features = cfg.setdefault("features", {})
     watch_feat = features.setdefault("watch", {})
-    watch_feat["enabled"] = bool(sc_enabled and mode == "watch" and sc.get("watch", {}).get("autostart", False))
+    watch_feat["enabled"] = bool(source_enabled(cfg, "watcher") and sc.get("watch", {}).get("autostart", False))
 
     try:
         env["prune"](cfg)
@@ -443,7 +488,7 @@ def api_config_migrate() -> dict[str, Any]:
 
     features = cfg.setdefault("features", {})
     watch_feat = features.setdefault("watch", {})
-    watch_feat["enabled"] = bool(sc_enabled and mode == "watch" and sc.get("watch", {}).get("autostart", False))
+    watch_feat["enabled"] = bool(source_enabled(cfg, "watcher") and sc.get("watch", {}).get("autostart", False))
 
     try:
         env["prune"](cfg)

--- a/api/scrobbleAPI.py
+++ b/api/scrobbleAPI.py
@@ -20,6 +20,7 @@ from cw_platform.config_base import load_config, save_config
 from cw_platform.provider_instances import build_provider_config_view, normalize_instance_id
 from providers.scrobble.routes import build_route_cfg_by_id, normalize_route_options, normalize_routes
 from providers.scrobble.scrobble import mask_account as _mask_account
+from providers.scrobble.sources import scrobble_sources
 
 try:
     from providers.scrobble.currently_watching import state_file as _cw_state_file
@@ -246,9 +247,12 @@ def api_scrobble_event_routes() -> dict[str, Any]:
     sc = (cfg.get("scrobble") or {}) if isinstance(cfg.get("scrobble"), dict) else {}
     enabled = bool(sc.get("enabled"))
     mode = str(sc.get("mode") or "").strip().lower()
+    sources = scrobble_sources(sc)
+    watcher_enabled = bool(sources.get("watcher"))
+    webhook_enabled = bool(sources.get("webhook"))
 
     watcher_routes: list[dict[str, Any]] = []
-    if enabled and mode == "watch":
+    if watcher_enabled:
         for raw in normalize_routes(cfg):
             if not isinstance(raw, dict) or not bool(raw.get("enabled")):
                 continue
@@ -268,7 +272,7 @@ def api_scrobble_event_routes() -> dict[str, Any]:
             watcher_routes.append(route)
 
     webhook_routes: list[dict[str, Any]] = []
-    if enabled and mode == "webhook":
+    if webhook_enabled:
         for provider in ("plex", "jellyfin", "emby"):
             webhook_routes.append({
                 "id": provider,
@@ -282,8 +286,9 @@ def api_scrobble_event_routes() -> dict[str, Any]:
         "ok": True,
         "enabled": enabled,
         "mode": mode,
-        "watcher_enabled": enabled and mode == "watch",
-        "webhook_enabled": enabled and mode == "webhook",
+        "sources": sources,
+        "watcher_enabled": watcher_enabled,
+        "webhook_enabled": webhook_enabled,
         "watcher_routes": watcher_routes,
         "webhook_routes": webhook_routes,
     }

--- a/assets/js/scrobbler.js
+++ b/assets/js/scrobbler.js
@@ -197,7 +197,7 @@ function clearStickyNote(id) {
     trakt: { stop_pause_threshold: 80, force_stop_at: 80, regress_tolerance_percent: 5, progress_step: 25 },
   };
 
-  const STATE = { mount: null, webhookIds: null, routeWebhookHooks: [], webhookHost: null, watcherHost: null, cfg: {}, users: [], ui: { scrobbleEnabled: null, scrobbleMode: null, watchAutostart: null }, _noSinkAutostartFixApplied: false };
+  const STATE = { mount: null, webhookIds: null, routeWebhookHooks: [], webhookHost: null, watcherHost: null, cfg: {}, users: [], ui: { scrobbleEnabled: null, scrobbleSources: null, watchAutostart: null }, _noSinkAutostartFixApplied: false };
 
   const deepSet = (o, p, v) =>
     p.split(".").reduce(
@@ -262,6 +262,47 @@ function clearStickyNote(id) {
     deepSet(STATE.cfg, path, v);
     try { w._cfgCache ||= {}; deepSet(w._cfgCache, path, v); } catch {}
     try { syncHiddenServerInputs(); } catch {}
+  }
+
+  function scrobbleSourceState(cfg = STATE.cfg) {
+    const sc = cfg?.scrobble && typeof cfg.scrobble === "object" ? cfg.scrobble : {};
+    const enabled = !!sc.enabled;
+    if (!enabled) return { webhook: false, watcher: false };
+    const src = sc.sources && typeof sc.sources === "object" ? sc.sources : null;
+    if (src) {
+      return {
+        webhook: !!src.webhook,
+        watcher: !!(src.watcher ?? src.watch),
+      };
+    }
+    const mode = String(sc.mode || "").trim().toLowerCase();
+    return {
+      webhook: mode === "webhook",
+      watcher: mode === "watch",
+    };
+  }
+
+  function scrobbleLegacyMode(sources) {
+    return sources?.watcher && !sources?.webhook ? "watch" : "webhook";
+  }
+
+  function writeScrobbleSources(webhook, watcher) {
+    const sources = { webhook: !!webhook, watcher: !!watcher };
+    write("scrobble.sources", sources);
+    write("scrobble.enabled", sources.webhook || sources.watcher);
+    write("scrobble.mode", scrobbleLegacyMode(sources));
+    STATE.ui.scrobbleEnabled = sources.webhook || sources.watcher;
+    STATE.ui.scrobbleSources = { ...sources };
+    return sources;
+  }
+
+  function refreshHybridWarning() {
+    const sources = scrobbleSourceState();
+    if (sources.webhook && sources.watcher) {
+      setStickyNote("sc-webhook-warning", "Watcher and webhooks are both enabled. Use watcher for local servers and webhook URLs for remote servers. If the same server sends events through both, duplicate scrobbles may occur.", "warn");
+    } else {
+      setStickyNote("sc-webhook-warning", "These legacy webhooks scrobble only to Trakt. For Trakt/SIMKL/MDBList routes and better controls, use Watcher.", "warn");
+    }
   }
 
   const asArray = (v) => (Array.isArray(v) ? v.slice() : v == null || v === "" ? [] : [String(v)]);
@@ -1634,10 +1675,9 @@ function chip(text, onRemove, onClick) {
   }
 
   function applyModeDisable() {
-  const enabled = !!read("scrobble.enabled", false);
-  const mode = String(read("scrobble.mode", "webhook")).toLowerCase();
-  const useWebhook = enabled && mode === "webhook";
-  const useWatch = enabled && mode === "watch";
+  const sources = scrobbleSourceState();
+  const useWebhook = !!sources.webhook;
+  const useWatch = !!sources.watcher;
 
   const webRoot = STATE.webhookHost;
   const watchRoot = STATE.watcherHost;
@@ -2213,20 +2253,26 @@ function chip(text, onRemove, onClick) {
         try { delete STATE._routesCache; } catch {}
 
         const uiEnabled = STATE.ui?.scrobbleEnabled;
-        const uiModeRaw = String(STATE.ui?.scrobbleMode || "").toLowerCase().trim();
+        const uiSources = STATE.ui?.scrobbleSources;
         const uiAutostart = STATE.ui?.watchAutostart;
 
         const backendEnabled = !!fresh?.scrobble?.enabled;
-        const backendMode = String(fresh?.scrobble?.mode || "webhook").toLowerCase().trim();
+        const backendSources = scrobbleSourceState(fresh);
         const backendAutostart = !!fresh?.scrobble?.watch?.autostart;
 
         if (typeof uiEnabled === "boolean") {
           if (backendEnabled === uiEnabled) STATE.ui.scrobbleEnabled = null;
           else deepSet(STATE.cfg, "scrobble.enabled", uiEnabled);
         }
-        if (uiModeRaw) {
-          if (backendMode === uiModeRaw) STATE.ui.scrobbleMode = null;
-          else deepSet(STATE.cfg, "scrobble.mode", uiModeRaw);
+        if (uiSources && typeof uiSources === "object") {
+          const nextSources = { webhook: !!uiSources.webhook, watcher: !!uiSources.watcher };
+          if (backendSources.webhook === nextSources.webhook && backendSources.watcher === nextSources.watcher) {
+            STATE.ui.scrobbleSources = null;
+          } else {
+            deepSet(STATE.cfg, "scrobble.sources", nextSources);
+            deepSet(STATE.cfg, "scrobble.enabled", nextSources.webhook || nextSources.watcher);
+            deepSet(STATE.cfg, "scrobble.mode", scrobbleLegacyMode(nextSources));
+          }
         }
         if (typeof uiAutostart === "boolean") {
           if (backendAutostart === uiAutostart) STATE.ui.watchAutostart = null;
@@ -2249,10 +2295,9 @@ function chip(text, onRemove, onClick) {
       renderRoutesUi().catch(() => {});
     }
   } catch {}
-  const enabled = !!read("scrobble.enabled", false);
-  const mode = String(read("scrobble.mode", "webhook")).toLowerCase();
-  const useWebhook = enabled && mode === "webhook";
-  const useWatch = enabled && mode === "watch";
+  const sources = scrobbleSourceState();
+  const useWebhook = !!sources.webhook;
+  const useWatch = !!sources.watcher;
   const prov = provider();
 
   const whEl = $("#sc-enable-webhook", STATE.mount);
@@ -2261,6 +2306,7 @@ function chip(text, onRemove, onClick) {
   if (whEl) whEl.checked = useWebhook;
   ["#sc-enable-webhook-jf", "#sc-enable-webhook-emby", "#sc-enable-webhook-adv"].forEach((id) => { const n = $(id, STATE.mount); if (n) n.checked = useWebhook; });
   if (waEl) waEl.checked = useWatch;
+  refreshHybridWarning();
 
   const wlWeb = asArray(read("scrobble.webhook.filters_plex.username_whitelist", []));
   const hostWB = $("#sc-whitelist-webhook", STATE.mount);
@@ -2594,7 +2640,7 @@ async function hydrateJellyfin() {
 
   function wire() {
     ensureHiddenServerInputs();
-    setNote("sc-webhook-warning", "These legacy webhooks scrobble only to Trakt and will be removed in a future release; they're no longer maintained or supported, please switch to Watcher ASAP.", "warn");
+    refreshHybridWarning();
     // Copy the displayed webhook URL
     function getCodeText(id) {
       const n = $(id, STATE.mount);
@@ -2757,8 +2803,8 @@ async function hydrateJellyfin() {
           if (mute) return;
           mute = true;
           master.checked = !!c.checked;
-          master.dispatchEvent(new Event("change", { bubbles: true }));
           mute = false;
+          master.dispatchEvent(new Event("change", { bubbles: true }));
         });
       });
       on(master, "change", sync);
@@ -2792,38 +2838,35 @@ async function hydrateJellyfin() {
       });
     }
 
-    const syncExclusive = async (src) => {
+    const syncSources = async (src) => {
       const webOn = !!wh?.checked;
       const watOn = !!wa?.checked;
-      if (src === "webhook" && webOn && wa) wa.checked = false;
-      if (src === "watch" && watOn && wh) wh.checked = false;
+      const sources = writeScrobbleSources(webOn, watOn);
 
-      write("scrobble.enabled", (!!wh?.checked) || (!!wa?.checked));
-      write("scrobble.mode", (!!wa?.checked) ? "watch" : "webhook");
-
-      if (src === "watch" && !wa.checked) {
+      if (src === "watch" && !watOn) {
         write("scrobble.watch.autostart", false);
         const auto = $("#sc-autostart", STATE.mount);
         if (auto) auto.checked = false;
       }
       applyModeDisable();
+      refreshHybridWarning();
 
-      const enabled = (!!wh?.checked) || (!!wa?.checked);
-      const mode = (!!wa?.checked) ? "watch" : "webhook";
+      const enabled = sources.webhook || sources.watcher;
+      const mode = scrobbleLegacyMode(sources);
       const pairs = [
         ["scrobble.enabled", enabled],
+        ["scrobble.sources.webhook", sources.webhook],
+        ["scrobble.sources.watcher", sources.watcher],
         ["scrobble.mode", mode],
       ];
-      if (src === "watch" && !wa.checked) pairs.push(["scrobble.watch.autostart", false]);
-      const noteId = mode === "watch" ? "sc-pms-note" : "sc-endpoint-note";
-      STATE.ui.scrobbleEnabled = enabled;
-      STATE.ui.scrobbleMode = mode;
-      if (src === "watch" && !wa.checked) STATE.ui.watchAutostart = false;
+      if (src === "watch" && !watOn) pairs.push(["scrobble.watch.autostart", false]);
+      const noteId = src === "watch" ? "sc-pms-note" : "sc-endpoint-note";
+      if (src === "watch" && !watOn) STATE.ui.watchAutostart = false;
       await persistConfigPaths(pairs, noteId);
     };
 
-    if (wh) on(wh, "change", () => syncExclusive("webhook"));
-    if (wa) on(wa, "change", () => syncExclusive("watch"));
+    if (wh) on(wh, "change", () => syncSources("webhook"));
+    if (wa) on(wa, "change", () => syncSources("watch"));
 
     on($("#sc-autostart", STATE.mount), "change", (e) => {
       const v = !!e.target.checked;
@@ -2875,8 +2918,9 @@ async function hydrateJellyfin() {
   commitAdvancedInputsWebhook();
   commitAdvancedInputsTrakt();
 
-  const enabled = !!read("scrobble.enabled", false);
-  const mode = String(read("scrobble.mode", "webhook")).toLowerCase();
+  const sources = scrobbleSourceState();
+  const enabled = !!(sources.webhook || sources.watcher);
+  const mode = scrobbleLegacyMode(sources);
   const prov = provider();
 
   const wlWebHost = $("#sc-whitelist-webhook", STATE.mount);
@@ -2930,6 +2974,10 @@ if (dups.length) {
   return {
     enabled,
     mode: mode === "watch" ? "watch" : "webhook",
+    sources: {
+      webhook: !!sources.webhook,
+      watcher: !!sources.watcher,
+    },
     delete_plex: !!read("scrobble.delete_plex", false),
     delete_plex_types: read("scrobble.delete_plex_types", ["movie"]),
 
@@ -3053,5 +3101,3 @@ async function init(opts = {}) {
     init({ mountId: "scrobble-mount" });
   });
 })(window, document);
-
-

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -641,7 +641,22 @@ async def _lifespan(app: Any) -> AsyncIterator[None]:
         cfg = load_config() or {}
         sc = (cfg.get("scrobble") or {}) or {}
         watch = (sc.get("watch") or {}) if isinstance(sc.get("watch"), dict) else {}
-        want_autostart = bool(sc.get("enabled")) and str(sc.get("mode") or "").lower() == "watch" and bool(watch.get("autostart"))
+        from providers.scrobble.sources import source_enabled
+        want_webhooks = source_enabled(cfg, "webhook")
+        want_autostart = source_enabled(cfg, "watcher") and bool(watch.get("autostart"))
+
+        if want_webhooks:
+            LOG(
+                "webhook endpoints enabled; waiting for Plex/Jellyfin/Emby events",
+                level="INFO",
+                module="WEBHOOK",
+            )
+        if want_webhooks and source_enabled(cfg, "watcher"):
+            LOG(
+                "WARNING: both Webhook and Watcher are enabled; avoid sending the same server through both",
+                level="WARN",
+                module="SCROBBLE",
+            )
 
         if want_autostart:
             try:

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -549,13 +549,13 @@ DEFAULT_CFG: dict[str, Any] = {
     # --- Scrobble ------------------------------------------------------------
     "scrobble": {
         "enabled": False,                               # Master toggle
-        "mode": "watch",                                # "watch" | "webhook"
+        "mode": "watch",                                # Legacy fallback: "watch" | "webhook"; new saves use scrobble.sources for independent toggles
         "delete_plex": False,                           # Old name but still valid. Auto-remove movies from all your Watchlists, for all media servers
         "delete_plex_types": ["movie"],                 # Old name but still valid. Movie/show/episode
 
         # Watcher settings
         "watch": {
-            "autostart": False,                         # Start watcher on boot if enabled+mode=watch
+            "autostart": False,                         # Start watcher on boot if the watcher source is enabled
             "routes": [],                               # Route-based config
             "plex_simkl_ratings": False,                # Watch mode: forward Plex ratings to SIMKL
             "plex_trakt_ratings": False,                # Watch mode: forward Plex ratings to Trakt

--- a/providers/scrobble/emby/watch.py
+++ b/providers/scrobble/emby/watch.py
@@ -16,6 +16,7 @@ except Exception:
 from cw_platform.config_base import load_config
 from providers.scrobble.scrobble import Dispatcher, ScrobbleSink, ScrobbleEvent, MediaType, mask_account as _mask_account
 from providers.scrobble.currently_watching import update_from_event as _cw_update, update_from_payload as _cw_update_payload
+from providers.scrobble.sources import source_enabled
 
 TRAKT_API = "https://api.trakt.tv"
 _HTTP = requests.Session()
@@ -1168,8 +1169,7 @@ class EmbyWatchService:
     def start(self) -> None:
         self._stop.clear()
         cfg = self._active_cfg() or {}
-        sc = (cfg.get("scrobble") or {})
-        if not bool(sc.get("enabled")) or str(sc.get("mode") or "").lower() != "watch":
+        if not source_enabled(cfg, "watcher"):
             self._log("Watcher disabled by config; not starting", "INFO")
             return
         if self._disabled:

--- a/providers/scrobble/jellyfin/watch.py
+++ b/providers/scrobble/jellyfin/watch.py
@@ -16,6 +16,7 @@ except Exception:
 from cw_platform.config_base import load_config
 from providers.scrobble.scrobble import Dispatcher, ScrobbleSink, ScrobbleEvent, MediaType, mask_account as _mask_account
 from providers.scrobble.currently_watching import update_from_event as _cw_update, update_from_payload as _cw_update_payload
+from providers.scrobble.sources import source_enabled
 
 TRAKT_API = "https://api.trakt.tv"
 _HTTP = requests.Session()
@@ -1166,8 +1167,7 @@ class JellyfinWatchService:
     def start(self) -> None:
         self._stop.clear()
         cfg = self._active_cfg() or {}
-        sc = (cfg.get("scrobble") or {})
-        if not bool(sc.get("enabled")) or str(sc.get("mode") or "").lower() != "watch":
+        if not source_enabled(cfg, "watcher"):
             self._log("Watcher disabled by config; not starting", "INFO")
             return
         if self._disabled:

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -29,6 +29,7 @@ from providers.scrobble.scrobble import (
     mask_account as _mask_account,
 )
 from providers.scrobble.currently_watching import update_from_event as _cw_update, update_from_payload as _cw_update_payload
+from providers.scrobble.sources import source_enabled
 
 
 _CFG_CACHE: dict[str, Any] = {"ts": 0.0, "cfg": {}}
@@ -1018,8 +1019,7 @@ class WatchService:
         if t in ("timeline", "progress"):
             try:
                 cfg = self._active_cfg()
-                sc = (cfg.get("scrobble") or {})
-                if not bool(sc.get("enabled")) or str(sc.get("mode") or "").lower() != "watch":
+                if not source_enabled(cfg, "watcher"):
                     return
                 self._ingest_progress_from_alert(alert, cfg)
             except Exception:
@@ -1033,8 +1033,7 @@ class WatchService:
             except Exception:
                 server_uuid = None
             cfg = self._active_cfg()
-            sc = (cfg.get("scrobble") or {})
-            if not bool(sc.get("enabled")) or str(sc.get("mode") or "").lower() != "watch":
+            if not source_enabled(cfg, "watcher"):
                 return
 
             try:
@@ -1246,8 +1245,7 @@ class WatchService:
     def start(self) -> None:
         self._stop.clear()
         cfg = self._cfg_provider() or {}
-        sc = (cfg.get("scrobble") or {})
-        if not bool(sc.get("enabled")) or str(sc.get("mode") or "").lower() != "watch":
+        if not source_enabled(cfg, "watcher"):
             self._log("Watcher disabled by config; not starting", "INFO")
             return
         lvl = "DEBUG" if self._quiet_startup else "INFO"
@@ -1322,7 +1320,7 @@ def autostart_from_config() -> WatchService | None:
     global _AUTO_WATCH
     cfg = _cfg() or {}
     sc = (cfg.get("scrobble") or {})
-    if not (sc.get("enabled") and str(sc.get("mode") or "").lower() == "watch"):
+    if not source_enabled(cfg, "watcher"):
         return None
     if not ((sc.get("watch") or {}).get("autostart")):
         return None
@@ -1630,7 +1628,7 @@ def process_rating_webhook(
 ) -> dict[str, Any]:
     cfg = cfg_override or _cfg() or {}
     sc = (cfg.get("scrobble") or {})
-    if not bool(sc.get("enabled")) or str(sc.get("mode") or "").lower() != "watch":
+    if not source_enabled(cfg, "watcher"):
         return {"ok": True, "ignored": True}
 
     watch_cfg = (sc.get("watch") or {})

--- a/providers/scrobble/sources.py
+++ b/providers/scrobble/sources.py
@@ -1,0 +1,60 @@
+# CrossWatch - Scrobble source toggles
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+SourceMap = dict[str, bool]
+
+
+def _scrobble_block(cfg_or_scrobble: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    if not isinstance(cfg_or_scrobble, Mapping):
+        return {}
+    sc = cfg_or_scrobble.get("scrobble")
+    if isinstance(sc, Mapping):
+        return sc
+    return cfg_or_scrobble
+
+
+def normalize_source_name(source: Any) -> str:
+    raw = str(source or "").strip().lower()
+    if raw in {"watch", "watcher"}:
+        return "watcher"
+    if raw in {"webhook", "webhooks"}:
+        return "webhook"
+    return raw
+
+
+def scrobble_sources(cfg_or_scrobble: Mapping[str, Any] | None) -> SourceMap:
+    sc = _scrobble_block(cfg_or_scrobble)
+    if not bool(sc.get("enabled")):
+        return {"webhook": False, "watcher": False}
+
+    sources = sc.get("sources")
+    if isinstance(sources, Mapping):
+        watcher_value = sources.get("watcher", sources.get("watch", False))
+        return {
+            "webhook": bool(sources.get("webhook", False)),
+            "watcher": bool(watcher_value),
+        }
+
+    mode = str(sc.get("mode") or "").strip().lower()
+    return {
+        "webhook": mode == "webhook",
+        "watcher": mode == "watch",
+    }
+
+
+def source_enabled(cfg_or_scrobble: Mapping[str, Any] | None, source: Any) -> bool:
+    name = normalize_source_name(source)
+    return bool(scrobble_sources(cfg_or_scrobble).get(name, False))
+
+
+def legacy_mode_for_sources(sources: Mapping[str, Any] | None, fallback: str = "webhook") -> str:
+    if not isinstance(sources, Mapping):
+        return "watch" if str(fallback or "").strip().lower() == "watch" else "webhook"
+    webhook = bool(sources.get("webhook", False))
+    watcher = bool(sources.get("watcher", sources.get("watch", False)))
+    return "watch" if watcher and not webhook else "webhook"

--- a/providers/scrobble/watch_manager.py
+++ b/providers/scrobble/watch_manager.py
@@ -17,6 +17,7 @@ except Exception:
 from cw_platform.config_base import load_config
 from providers.scrobble.routes import build_route_cfg, build_route_cfg_by_id, find_route, normalize_routes
 from providers.scrobble.scrobble import Dispatcher, ScrobbleEvent
+from providers.scrobble.sources import source_enabled
 
 
 def _log(msg: str, level: str = "INFO") -> None:
@@ -234,8 +235,7 @@ class WatchManager:
             self.stop_all()
 
             cfg = load_config() or {}
-            sc = (cfg.get("scrobble") or {}) or {}
-            if not bool(sc.get("enabled")) or str(sc.get("mode") or "").lower() != "watch":
+            if not source_enabled(cfg, "watcher"):
                 self._app.state.watch_groups = {}
                 return self.status()
 

--- a/providers/webhooks/embytrakt.py
+++ b/providers/webhooks/embytrakt.py
@@ -19,6 +19,7 @@ except Exception:
 from providers.scrobble.currently_watching import update_from_payload as _cw_update
 from providers.scrobble._auto_remove_watchlist import remove_across_providers_by_ids as _rm_across
 from providers.scrobble.scrobble import mask_account as _mask_account
+from providers.scrobble.sources import source_enabled
 try:
     from api.watchlistAPI import remove_across_providers_by_ids as _rm_across_api
 except Exception:
@@ -846,7 +847,7 @@ def process_webhook(
     try:
         cfg = _ensure_scrobble(_load_config())
         sc = cfg.get("scrobble") or {}
-        if not bool(sc.get("enabled")) or str(sc.get("mode") or "").lower() != "webhook":
+        if not source_enabled(cfg, "webhook"):
             _emit(logger, "scrobble webhook disabled", "DEBUG")
             return {"ok": True, "ignored": True}
         if not payload:

--- a/providers/webhooks/jellyfintrakt.py
+++ b/providers/webhooks/jellyfintrakt.py
@@ -17,6 +17,7 @@ except Exception:
 from providers.scrobble.currently_watching import update_from_payload as _cw_update
 from providers.scrobble._auto_remove_watchlist import remove_across_providers_by_ids as _rm_across
 from providers.scrobble.scrobble import mask_account as _mask_account
+from providers.scrobble.sources import source_enabled
 try:
     from api.watchlistAPI import remove_across_providers_by_ids as _rm_across_api
 except Exception:
@@ -1034,7 +1035,7 @@ def process_webhook(
         cfg = _ensure_scrobble(_load_config())
 
         sc = cfg.get("scrobble") or {}
-        if not bool(sc.get("enabled")) or str(sc.get("mode") or "").lower() != "webhook":
+        if not source_enabled(cfg, "webhook"):
             _emit(logger, "scrobble webhook disabled", "DEBUG")
             return {"ok": True, "ignored": True}
 

--- a/providers/webhooks/plextrakt.py
+++ b/providers/webhooks/plextrakt.py
@@ -23,6 +23,7 @@ except Exception:
 from providers.scrobble.currently_watching import update_from_payload as _cw_update
 from providers.scrobble._auto_remove_watchlist import remove_across_providers_by_ids as _rm_across
 from providers.scrobble.scrobble import mask_account as _mask_account
+from providers.scrobble.sources import source_enabled
 
 try:
     from api.watchlistAPI import remove_across_providers_by_ids as _rm_across_api
@@ -1082,7 +1083,7 @@ def process_webhook(
     cfg = _ensure_scrobble(_load_config())
 
     sc = cfg.get("scrobble") or {}
-    if not bool(sc.get("enabled")) or str(sc.get("mode") or "").lower() != "webhook":
+    if not source_enabled(cfg, "webhook"):
         _emit(logger, "scrobble webhook disabled by config", "DEBUG")
         return {"ok": True, "ignored": True}
 


### PR DESCRIPTION
# Pull request

## Change

Added independent scrobble source handling so Webhooks and Watcher can both be enabled at the same time.

This keeps the existing `scrobble.mode` behavior as a legacy fallback, while new configs can use `scrobble.sources.webhook` and `scrobble.sources.watcher`.

Also added UI and console warnings when both sources are enabled, plus webhook-enabled logging so passive webhook endpoints are visible in the console.

## Why

This allows users to use Watcher for local media servers while still accepting webhook events from remote or shared servers.
It avoids introducing a separate Hybrid mode and keeps the setup simple: enabling both Webhook and Watcher now naturally creates the hybrid behavior.

## Testing

- Ran `node --check assets/js/scrobbler.js`.
- Verified source gating logic for Watcher and Webhook paths.
- Verified the UI no longer forces Webhook and Watcher toggles to be mutually exclusive.

## Issue

Fixes #248