### PR TITLE
Fix : media library whitelist alignment and Plex hydrate loop

### DIFF
--- a/assets/auth/auth.plex.js
+++ b/assets/auth/auth.plex.js
@@ -224,16 +224,26 @@ sel.name = "plex_instance";
 
   let __plexHydrateWatch = null;
   let __plexHydrateTimer = null;
+  let __plexHydrateBusy = false;
   function schedulePlexHydrate(delayMs = 0) {
     try { if (__plexHydrateTimer) clearTimeout(__plexHydrateTimer); } catch {}
     __plexHydrateTimer = setTimeout(async () => {
       try { ensurePlexInstanceUI(); } catch {}
       try { mountPlexAuthTabs(); } catch {}
       if (!$("plex_token") || !$("plex_server_url") || !$("plex_username")) return;
+      if (__plexHydrateBusy) return;
+      __plexHydrateBusy = true;
       try { await hydratePlexFromConfigRaw(); } catch {}
       try { mountPlexLibraryMatrix(); } catch {}
       try { mountPlexUserPicker(); } catch {}
       try { schedulePlexPmsProbe(250); } catch {}
+      __plexHydrateBusy = false;
+      try {
+        if (__plexHydrateWatch && getPlexState().hydrated) {
+          __plexHydrateWatch.disconnect();
+          __plexHydrateWatch = null;
+        }
+      } catch {}
     }, Math.max(0, delayMs | 0));
   }
 
@@ -522,8 +532,8 @@ async function plexDeleteToken() {
       set("plex_username", p.username || "");
       const aid = (p.account_id != null ? String(p.account_id).trim() : "");
       set("plex_account_id", aid || "");
-      // If account_id is missing (or still the legacy placeholder), resolve via /api/plex/pickusers.
-      await resolvePlexAccountIdFromUsers({ bustCache: true });
+      // If account_id is missing, resolve it once from /api/plex/pickusers.
+      await resolvePlexAccountIdFromUsers();
       try { const cb = $("plex_verify_ssl"); if (cb) cb.checked = !!p.verify_ssl; } catch {}
 
       const st = getPlexState();
@@ -531,6 +541,7 @@ async function plexDeleteToken() {
       st.rate = new Set((p.ratings?.libraries || []).map(x => String(x)));
       st.scr  = new Set((p.scrobble?.libraries || []).map(x => String(x)));
       st.hydrated = true;
+      w.__plexHydrated = true;
 
       ["plex_lib_history", "plex_lib_ratings", "plex_lib_scrobble"].forEach(id => {
         const el = $(id); if (!el) return;
@@ -802,7 +813,7 @@ const tags = [
         }
       } catch {}
 
-      // Resolve account_id via /api/plex/pickusers if missing/legacy.
+      // Resolve account_id via /api/plex/pickusers if missing.
       await resolvePlexAccountIdFromUsers({ bustCache: true });
 } catch (e) {
       console.warn("[plex] Auto-Fetch failed", e);
@@ -820,8 +831,9 @@ const tags = [
       const userEl = $("plex_username");
       const wantUser = String(opts.username ?? (userEl?.value || "")).trim().toLowerCase();
       const currId = String(idEl.value || "").trim();
-      const needsResolve = !currId;
-      if (!(needsResolve || wantUser)) return;
+      const currNum = parseInt(currId, 10);
+      const needsResolve = !(Number.isFinite(currNum) && currNum > 0);
+      if (!needsResolve) return;
 
       if (opts.bustCache) {
         try { __plexUsersByInst.delete(getPlexInstance()); } catch {}

--- a/providers/auth/_auth_EMBY.py
+++ b/providers/auth/_auth_EMBY.py
@@ -238,23 +238,30 @@ def html() -> str:
     #sec-emby .btn.danger:hover{ filter:brightness(1.08) }
 
     /* matrix */
-    #sec-emby .lm-head{display:grid;grid-template-columns:1fr auto auto auto auto auto;gap:10px;align-items:center;margin-bottom:8px}
+    #sec-emby .lm-head{
+      --lm-hist-col:76px;--lm-rate-col:76px;--lm-scr-col:104px;
+      display:grid;grid-template-columns:minmax(0,1fr) var(--lm-hist-col) var(--lm-rate-col) var(--lm-scr-col);
+      gap:6px;align-items:center;margin-bottom:8px;padding:0 24px 0 8px;box-sizing:border-box
+    }
     #sec-emby .lm-head .title{font-weight:700}
+    #sec-emby .lm-head .title,#sec-emby .lm-head .lm-filter{grid-column:1;grid-row:1}
+    #sec-emby .lm-head .lm-filter{justify-self:end;width:min(280px,55%)}
     #sec-emby .lm-rows{
       display:grid;gap:6px;max-height:280px;min-height:200px;
       overflow:auto;border:1px solid var(--border);border-radius:10px;padding:8px;background:#090b10
     }
-    #sec-emby .lm-row{display:grid;grid-template-columns:1fr 40px 40px 40px;gap:6px;align-items:center;background:#0b0d12;border-radius:8px;padding:6px 8px}
+    #sec-emby .lm-row{display:grid;grid-template-columns:minmax(0,1fr) 76px 76px 104px;gap:6px;align-items:center;background:#0b0d12;border-radius:8px;padding:6px 8px}
     #sec-emby .lm-row.hide{display:none}
     #sec-emby .lm-name{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-    #sec-emby .lm-dot{width:16px;height:16px;border-radius:50%;border:2px solid currentColor;background:transparent;cursor:pointer;display:inline-block;vertical-align:middle}
+    #sec-emby .lm-dot{width:16px;height:16px;border-radius:50%;border:2px solid currentColor;background:transparent;cursor:pointer;display:inline-block;vertical-align:middle;justify-self:center}
     #sec-emby .lm-dot.hist{color:#b066ff;box-shadow:0 0 6px rgba(176,102,255,.55)}
     #sec-emby .lm-dot.hist.on{background:#b066ff;box-shadow:0 0 10px rgba(176,102,255,.95)}
     #sec-emby .lm-dot.rate{color:#00d1ff;box-shadow:0 0 6px rgba(0,209,255,.55)}
     #sec-emby .lm-dot.rate.on{background:#00d1ff;box-shadow:0 0 10px rgba(0,209,255,.95)}
     #sec-emby .lm-dot.scr{color:#35ff8f;box-shadow:0 0 6px rgba(53,255,143,.55)}
     #sec-emby .lm-dot.scr.on{background:#35ff8f;box-shadow:0 0 10px rgba(53,255,143,.95)}
-    #sec-emby .lm-col{display:flex;align-items:center;gap:6px}
+    #sec-emby .lm-col{position:relative;display:flex;align-items:center;justify-content:center;gap:6px;min-width:0}
+    #sec-emby .lm-col .sub{position:absolute;left:calc(50% + 14px);white-space:nowrap}
     #sec-emby .lm-filter{min-width:160px}
     #sec-emby select.lm-hidden{display:none}
 

--- a/providers/auth/_auth_JELLYFIN.py
+++ b/providers/auth/_auth_JELLYFIN.py
@@ -245,23 +245,30 @@ def html() -> str:
     #sec-jellyfin .btn.danger:hover{ filter:brightness(1.08) }
 
     /* matrix */
-    #sec-jellyfin .lm-head{display:grid;grid-template-columns:1fr auto auto auto auto auto;gap:10px;align-items:center;margin-bottom:8px}
+    #sec-jellyfin .lm-head{
+      --lm-hist-col:76px;--lm-rate-col:76px;--lm-scr-col:104px;
+      display:grid;grid-template-columns:minmax(0,1fr) var(--lm-hist-col) var(--lm-rate-col) var(--lm-scr-col);
+      gap:6px;align-items:center;margin-bottom:8px;padding:0 24px 0 8px;box-sizing:border-box
+    }
     #sec-jellyfin .lm-head .title{font-weight:700}
+    #sec-jellyfin .lm-head .title,#sec-jellyfin .lm-head .lm-filter{grid-column:1;grid-row:1}
+    #sec-jellyfin .lm-head .lm-filter{justify-self:end;width:min(280px,55%)}
     #sec-jellyfin .lm-rows{
       display:grid;gap:6px;max-height:280px;min-height:200px;
       overflow:auto;border:1px solid var(--border);border-radius:10px;padding:8px;background:#090b10
     }
-    #sec-jellyfin .lm-row{display:grid;grid-template-columns:1fr 40px 40px 40px;gap:6px;align-items:center;background:#0b0d12;border-radius:8px;padding:6px 8px}
+    #sec-jellyfin .lm-row{display:grid;grid-template-columns:minmax(0,1fr) 76px 76px 104px;gap:6px;align-items:center;background:#0b0d12;border-radius:8px;padding:6px 8px}
     #sec-jellyfin .lm-row.hide{display:none}
     #sec-jellyfin .lm-name{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-    #sec-jellyfin .lm-dot{width:16px;height:16px;border-radius:50%;border:2px solid currentColor;background:transparent;cursor:pointer;display:inline-block;vertical-align:middle}
+    #sec-jellyfin .lm-dot{width:16px;height:16px;border-radius:50%;border:2px solid currentColor;background:transparent;cursor:pointer;display:inline-block;vertical-align:middle;justify-self:center}
     #sec-jellyfin .lm-dot.hist{color:#b066ff;box-shadow:0 0 6px rgba(176,102,255,.55)}
     #sec-jellyfin .lm-dot.hist.on{background:#b066ff;box-shadow:0 0 10px rgba(176,102,255,.95)}
     #sec-jellyfin .lm-dot.rate{color:#00d1ff;box-shadow:0 0 6px rgba(0,209,255,.55)}
     #sec-jellyfin .lm-dot.rate.on{background:#00d1ff;box-shadow:0 0 10px rgba(0,209,255,.95)}
     #sec-jellyfin .lm-dot.scr{color:#35ff8f;box-shadow:0 0 6px rgba(53,255,143,.55)}
     #sec-jellyfin .lm-dot.scr.on{background:#35ff8f;box-shadow:0 0 10px rgba(53,255,143,.95)}
-    #sec-jellyfin .lm-col{display:flex;align-items:center;gap:6px}
+    #sec-jellyfin .lm-col{position:relative;display:flex;align-items:center;justify-content:center;gap:6px;min-width:0}
+    #sec-jellyfin .lm-col .sub{position:absolute;left:calc(50% + 14px);white-space:nowrap}
     #sec-jellyfin .lm-filter{min-width:160px}
     #sec-jellyfin select.lm-hidden{display:none}
 

--- a/providers/auth/_auth_PLEX.py
+++ b/providers/auth/_auth_PLEX.py
@@ -225,21 +225,28 @@ def html() -> str:
     }
 
     /* matrix */
-    #sec-plex .lm-head{display:grid;grid-template-columns:1fr auto auto auto auto auto;gap:10px;align-items:center;margin-bottom:8px}
+    #sec-plex .lm-head{
+      --lm-hist-col:76px;--lm-rate-col:76px;--lm-scr-col:104px;
+      display:grid;grid-template-columns:minmax(0,1fr) var(--lm-hist-col) var(--lm-rate-col) var(--lm-scr-col);
+      gap:6px;align-items:center;margin-bottom:8px;padding:0 24px 0 8px;box-sizing:border-box
+    }
     #sec-plex .lm-head .title{font-weight:700}
+    #sec-plex .lm-head .title,#sec-plex .lm-head .lm-filter{grid-column:1;grid-row:1}
+    #sec-plex .lm-head .lm-filter{justify-self:end;width:min(280px,55%)}
     #sec-plex .lm-rows{display:grid;gap:6px;max-height:260px;overflow:auto;border:1px solid var(--border);border-radius:10px;padding:6px;background:#090b10}
-    #sec-plex .lm-row{display:grid;grid-template-columns:1fr 40px 40px 40px;gap:6px;align-items:center;background:#0b0d12;border-radius:8px;padding:6px 8px}
+    #sec-plex .lm-row{display:grid;grid-template-columns:minmax(0,1fr) 76px 76px 104px;gap:6px;align-items:center;background:#0b0d12;border-radius:8px;padding:6px 8px}
     #sec-plex .lm-row.hide{display:none}
     #sec-plex .lm-name{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
     #sec-plex .lm-id{opacity:.5;margin-left:6px}
-    #sec-plex .lm-dot{width:16px;height:16px;border-radius:50%;border:2px solid currentColor;background:transparent;cursor:pointer;display:inline-block;vertical-align:middle}
+    #sec-plex .lm-dot{width:16px;height:16px;border-radius:50%;border:2px solid currentColor;background:transparent;cursor:pointer;display:inline-block;vertical-align:middle;justify-self:center}
     #sec-plex .lm-dot.hist{color:#b066ff;box-shadow:0 0 6px rgba(176,102,255,.55)}
     #sec-plex .lm-dot.hist.on{background:#b066ff;box-shadow:0 0 10px rgba(176,102,255,.95)}
     #sec-plex .lm-dot.rate{color:#00d1ff;box-shadow:0 0 6px rgba(0,209,255,.55)}
     #sec-plex .lm-dot.rate.on{background:#00d1ff;box-shadow:0 0 10px rgba(0,209,255,.95)}
     #sec-plex .lm-dot.scr{color:#35ff8f;box-shadow:0 0 6px rgba(53,255,143,.55)}
     #sec-plex .lm-dot.scr.on{background:#35ff8f;box-shadow:0 0 10px rgba(53,255,143,.95)}
-    #sec-plex .lm-col{display:flex;align-items:center;gap:6px}
+    #sec-plex .lm-col{position:relative;display:flex;align-items:center;justify-content:center;gap:6px;min-width:0}
+    #sec-plex .lm-col .sub{position:absolute;left:calc(50% + 14px);white-space:nowrap}
     #sec-plex .lm-filter{min-width:160px}
     #sec-plex select.lm-hidden{display:none}
 


### PR DESCRIPTION
# Pull request

## Change

- Aligned Plex, Jellyfin, and Emby whitelist library columns so header toggles match row toggles.
- Updated Plex auth hydration to stop the broad observer after initial hydrate.
- Avoided repeated Plex user resolution when a valid account ID already exists.

## Why

The whitelist headers for History, Ratings, and Scrobble did not line up with the library row circles. Plex could also rehydrate too often when unrelated UI changed, which could spam config/user requests.

## Testing

- Ran `pytest tests\test_auth_plex_api.py`

## Issue

Fixes #255 