### PR TITLE
Fix: mandatory auth setup bypass

### DIFF
--- a/api/appAuthAPI.py
+++ b/api/appAuthAPI.py
@@ -26,6 +26,7 @@ __all__ = [
     "AUTH_TTL_SEC",
     "MIN_PASSWORD_LENGTH",
     "auth_required",
+    "credentials_configured",
     "is_authenticated",
     "reset_pending",
     "setup_lock_required",
@@ -262,10 +263,8 @@ def _sync_legacy_session(a: dict[str, Any], sessions: list[dict[str, Any]]) -> N
     s["expires_at"] = int(last.get("expires_at") or 0)
 
 
-def auth_required(cfg: dict[str, Any]) -> bool:
+def credentials_configured(cfg: dict[str, Any]) -> bool:
     a = _cfg_auth(cfg)
-    if not bool(a.get("enabled")):
-        return False
     if not str(a.get("username") or "").strip():
         return False
     p = _cfg_pwd(a)
@@ -274,6 +273,11 @@ def auth_required(cfg: dict[str, Any]) -> bool:
     if not str(p.get("salt") or "").strip():
         return False
     return True
+
+
+def auth_required(cfg: dict[str, Any]) -> bool:
+    a = _cfg_auth(cfg)
+    return bool(a.get("enabled")) and credentials_configured(cfg)
 
 
 def reset_pending(cfg: dict[str, Any]) -> bool:
@@ -317,7 +321,7 @@ def _config_needs_upgrade(cfg: dict[str, Any]) -> bool:
 def setup_lock_required(cfg: dict[str, Any]) -> bool:
     if reset_pending(cfg):
         return True
-    return (not auth_required(cfg)) and _config_needs_upgrade(cfg)
+    return not auth_required(cfg)
 
 
 def _find_session(a: dict[str, Any], token: str | None) -> dict[str, Any] | None:
@@ -365,7 +369,7 @@ def _public_session_state(a: dict[str, Any], token: str | None) -> tuple[dict[st
 
 def is_authenticated(cfg: dict[str, Any], token: str | None) -> bool:
     if not auth_required(cfg):
-        return True
+        return False
     a = _cfg_auth(cfg)
     return _find_session(a, token) is not None
 
@@ -997,9 +1001,10 @@ def api_status(request: Request) -> JSONResponse:
         plex_st = authPlex.get_status(cfg)
     except Exception:
         plex_st = {"enabled": False, "linked": False}
-    configured = bool(str(a.get("username") or "").strip() and str(p.get("hash") or "").strip() and str(p.get("salt") or "").strip())
+    configured = credentials_configured(cfg)
     enabled = bool(a.get("enabled"))
     pending_setup = setup_lock_required(cfg)
+    active = auth_required(cfg)
     token = request.cookies.get(COOKIE_NAME)
     s = _find_session(a, token)
     current_session, other_sessions = _public_session_state(a, token)
@@ -1007,8 +1012,9 @@ def api_status(request: Request) -> JSONResponse:
         {
             "enabled": enabled,
             "configured": configured,
+            "setup_required": pending_setup,
             "username": str(a.get("username") or "") if (enabled and s is not None) else "",
-            "authenticated": (s is not None) if auth_required(cfg) else (not pending_setup),
+            "authenticated": (s is not None) if active else False,
             "session_expires_at": int((s or {}).get("expires_at") or 0),
             "current_session": current_session,
             "other_sessions": other_sessions,

--- a/api/authPlexAPI.py
+++ b/api/authPlexAPI.py
@@ -80,7 +80,9 @@ def _unauthorized() -> JSONResponse:
 
 def _require_authenticated(request: Request, cfg: dict[str, Any]) -> str | None:
     token = request.cookies.get(app_auth.COOKIE_NAME)
-    if app_auth.auth_required(cfg) and not app_auth.is_authenticated(cfg, token):
+    if not app_auth.auth_required(cfg):
+        return None
+    if not app_auth.is_authenticated(cfg, token):
         return None
     return token
 
@@ -89,7 +91,7 @@ def _require_authenticated(request: Request, cfg: dict[str, Any]) -> str | None:
 def api_plex_status(request: Request) -> JSONResponse:
     cfg = load_config()
     token = request.cookies.get(app_auth.COOKIE_NAME)
-    authed = (not app_auth.auth_required(cfg)) or app_auth.is_authenticated(cfg, token)
+    authed = app_auth.auth_required(cfg) and app_auth.is_authenticated(cfg, token)
     st = authPlex.get_status(cfg)
     payload = {
         "enabled": bool(st["enabled"]),
@@ -106,6 +108,12 @@ def api_plex_status(request: Request) -> JSONResponse:
 @router.post("/start")
 def api_plex_start(request: Request, payload: dict[str, Any] | None = Body(None)) -> JSONResponse:
     cfg = load_config()
+    if not app_auth.auth_required(cfg):
+        return JSONResponse(
+            {"ok": False, "error": "Authentication setup required"},
+            status_code=403,
+            headers={"Cache-Control": "no-store"},
+        )
     if not authPlex.login_available(cfg):
         return JSONResponse({"ok": False, "error": "Plex sign-in is not linked yet"}, status_code=400, headers={"Cache-Control": "no-store"})
 
@@ -131,6 +139,12 @@ def api_plex_start(request: Request, payload: dict[str, Any] | None = Body(None)
 @router.post("/check")
 def api_plex_check(request: Request, payload: dict[str, Any] = Body(...)) -> JSONResponse:
     cfg = load_config()
+    if not app_auth.auth_required(cfg):
+        return JSONResponse(
+            {"ok": False, "error": "Authentication setup required"},
+            status_code=403,
+            headers={"Cache-Control": "no-store"},
+        )
     if not authPlex.login_available(cfg):
         return JSONResponse({"ok": False, "error": "Plex sign-in is not linked yet"}, status_code=400, headers={"Cache-Control": "no-store"})
 

--- a/api/configAPI.py
+++ b/api/configAPI.py
@@ -250,8 +250,9 @@ def api_config_meta() -> JSONResponse:
         needs_upgrade = False
         is_legacy_pre_070 = False
 
+    auth_setup_required = bool(auth_reset_required or not auth_configured)
     auth_reset_deferred_to_upgrade = bool(needs_upgrade and auth_reset_required)
-    setup_wizard_required = bool(auth_reset_required and not needs_upgrade)
+    setup_wizard_required = bool(auth_setup_required and not needs_upgrade)
 
     mtime = None
     size = None
@@ -270,6 +271,7 @@ def api_config_meta() -> JSONResponse:
                 "first_run": first_run,
                 "autogen": autogen,
                 "auth_configured": auth_configured,
+                "auth_setup_required": auth_setup_required,
                 "auth_reset_required": auth_reset_required,
                 "auth_reset_deferred_to_upgrade": auth_reset_deferred_to_upgrade,
                 "setup_wizard_required": setup_wizard_required,

--- a/api/maintenanceAPI.py
+++ b/api/maintenanceAPI.py
@@ -304,7 +304,7 @@ def provider_cache_status() -> dict[str, Any]:
 
 
 @router.post("/reset-all-default")
-def reset_all_to_default() -> dict[str, Any]:
+def reset_all_to_default(payload: dict[str, Any] | None = Body(None)) -> dict[str, Any]:
     _, CONFIG_DIR, *_rest = _cw()
 
     ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
@@ -354,6 +354,14 @@ def reset_all_to_default() -> dict[str, Any]:
             else:
                 report["ok"] = False
                 report["errors"].append(f"remove_failed: {name}")
+
+    if report["ok"] and bool((payload or {}).get("restart")):
+        report["restart_scheduled"] = True
+
+        def _kill() -> None:
+            os._exit(0)
+
+        threading.Timer(0.75, _kill).start()
 
     return report
 

--- a/assets/crosswatch.js
+++ b/assets/crosswatch.js
@@ -432,8 +432,7 @@ async function _cwFetchBootstrapAuthState() {
     const status = statusResp.ok ? await statusResp.json() : null;
     const blocked = !!(
       status
-      && !status.authenticated
-      && (status.reset_required || !status.configured || meta?.auth_reset_required || meta?.first_run || meta?.autogen)
+      && (status.setup_required || status.reset_required || !status.configured || meta?.auth_setup_required || meta?.auth_reset_required || meta?.first_run || meta?.autogen)
     );
     window.__cwAuthSetupPending = blocked;
     window.__cwAuthBootstrapState = { meta, status, blocked };

--- a/assets/js/modals/upgrade-warning/index.js
+++ b/assets/js/modals/upgrade-warning/index.js
@@ -45,26 +45,24 @@ async function _runConfigMigration() {
 }
 
 async function _runFullReset() {
-  return postJson("/api/maintenance/reset-all-default", {});
+  return postJson("/api/maintenance/reset-all-default", {
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ restart: true }),
+  });
 }
 
-async function _restartAfterMigration() {
+async function _waitForScheduledRestart() {
   try {
     window.cxCloseModal?.();
   } catch {}
 
-  setTimeout(() => {
-    try {
-      if (window.cwRestartCrossWatchWithOverlay) {
-        window.cwRestartCrossWatchWithOverlay();
-        return;
-      }
-    } catch {}
+  try {
+    window.cwShowApplyOverlay?.("Restarting CrossWatch", "Restarting container / service...", 12);
+  } catch {}
 
-    fetch("/api/maintenance/restart", { method: "POST", cache: "no-store" }).finally(() => {
-      window.location.reload();
-    });
-  }, 150);
+  setTimeout(() => {
+    try { window.location.reload(); } catch {}
+  }, 12000);
 }
 
 async function runCleanupAndRestart(btn) {
@@ -85,7 +83,7 @@ async function runCleanupAndRestart(btn) {
     notify(res && res.backup
       ? `Cleanup completed. Config backup created: ${res.backup}`
       : "Cleanup completed. CrossWatch will restart now.");
-    await _restartAfterMigration();
+    await _waitForScheduledRestart();
   } catch (e) {
     console.warn("[upgrade-warning] cleanup failed", e);
     notify("Cleanup failed. Check logs.");

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -19,6 +19,7 @@ import threading
 import time
 import uvicorn
 import asyncio
+import json
 
 # Mute Unverified HTTPS request warnings from requests/urllib3
 import urllib3
@@ -235,6 +236,37 @@ _PUBLIC_HEALTH_PATHS = {
     "/healthz",
 }
 
+def _version_key_text(v: Any) -> tuple[int, ...]:
+    raw = str(v or "").strip()
+    if raw.lower().startswith("v"):
+        raw = raw[1:]
+    out: list[int] = []
+    for part in raw.split("."):
+        try:
+            out.append(int(part))
+        except Exception:
+            out.append(0)
+    return tuple(out or [0])
+
+def _setup_clean_reset_allowed() -> bool:
+    cfg_path = CONFIG_DIR / "config.json"
+    if not cfg_path.exists():
+        return False
+    try:
+        raw = json.loads(cfg_path.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    if not isinstance(raw, dict):
+        return False
+    pending_ver = ""
+    ui_raw = raw.get("ui")
+    if isinstance(ui_raw, dict):
+        pending_ver = str(ui_raw.get("_pending_upgrade_from_version") or "").strip()
+    ver = pending_ver or str(raw.get("version") or "").strip()
+    if not ver:
+        return True
+    return _version_key_text(ver) < _version_key_text("0.9.12")
+
 def _redact_query_string(query: str) -> str:
     q = (query or "").strip()
     if not q:
@@ -411,18 +443,13 @@ async def app_auth_gate(request: Request, call_next):
     if path in _PUBLIC_HEALTH_PATHS:
         return await call_next(request)
     
-    if path.startswith("/api/app-auth/") or path in {"/login", "/logout"}:
-        return await call_next(request)
-    
     # exclude webhooks from auth
     if path.startswith("/webhook/"):
         return await call_next(request)
 
-    # exclude callback paths
-    if path == "/callback" or path.startswith("/callback/"):
-        return await call_next(request)
-
     if app_auth_setup_lock_required(cfg):
+        if path == "/api/maintenance/reset-all-default" and _setup_clean_reset_allowed():
+            return await call_next(request)
         if path in _APP_AUTH_SETUP_ALLOWED_PATHS:
             return await call_next(request)
         if path.startswith("/api/"):
@@ -432,6 +459,13 @@ async def app_auth_gate(request: Request, call_next):
                 headers={"Cache-Control": "no-store"},
             )
         return RedirectResponse(url="/", status_code=302)
+
+    if path.startswith("/api/app-auth/") or path in {"/login", "/logout"}:
+        return await call_next(request)
+
+    # exclude callback paths
+    if path == "/callback" or path.startswith("/callback/"):
+        return await call_next(request)
 
     if not app_auth_required(cfg):
         return await call_next(request)


### PR DESCRIPTION
# Pull request

## Change

Hardened the app auth setup flow so missing local credentials always put CrossWatch into setup lock.

- Added explicit `setup_required` auth status.
- Treat missing auth credentials as setup-required, even on current configs.
- Block normal API/provider auth paths while app auth setup is pending.
- Prevent Plex SSO app-auth routes from bypassing missing local credentials.
- Keep OAuth callbacks available only after setup lock clears.
- Allow legacy unsupported config 

## Why

A fresh browser session could treat missing auth credentials as authenticated when the config was already on the current version. That allowed users to reach adapter/provider setup before creating the required CrossWatch username/password, causing inconsistent setup behavior and downstream provider failures.

## Testing

- `pytest tests/test_app_auth_api.py tests/test_auth_plex_api.py tests/test_config_api.py -q`

## Issue

Fixes mandatory auth setup bypass in new browser sessions.