### PR TITLE
Add: MDBList Device Code authentication support

### DIFF
--- a/api/authenticationAPI.py
+++ b/api/authenticationAPI.py
@@ -38,6 +38,12 @@ import providers.sync.plex._utils as plex_utils
 
 __all__ = ["register_auth"]
 
+
+def _provider_auth():
+    from providers.auth import runtime as provider_auth
+
+    return provider_auth
+
 # Helpers
 def _status_from_msg(msg: str) -> int:
     m = (msg or "").lower()
@@ -66,6 +72,36 @@ def _looks_masked_secret(value: Any) -> bool:
     if text in {"••••••••", "********", "**********"}:
         return True
     return len(text) >= 3 and all(ch in {"•", "*"} for ch in text)
+
+
+def _validate_mdblist_api_key(api_key: str, *, timeout: float = 12.0) -> tuple[bool, str]:
+    key = str(api_key or "").strip()
+    if not key:
+        return False, "api_key_required"
+    try:
+        r = requests.get(
+            "https://api.mdblist.com/user",
+            params={"apikey": key},
+            headers={"Accept": "application/json", "User-Agent": "CrossWatch/MDBListAuth"},
+            timeout=timeout,
+        )
+    except requests.Timeout:
+        return False, "validation_timeout"
+    except requests.RequestException:
+        return False, "validation_failed"
+    if r.status_code in (401, 403):
+        return False, "invalid_api_key"
+    if r.status_code >= 400:
+        return False, f"validation_http_{int(r.status_code)}"
+    try:
+        data = r.json() or {}
+    except ValueError:
+        return False, "validation_bad_response"
+    if not isinstance(data, dict) or not (data.get("user_id") or data.get("username")):
+        return False, "invalid_api_key"
+    return True, ""
+
+
 def _defaults_for_provider(provider_key: str) -> dict[str, Any]:
     blk = DEFAULT_CFG.get(provider_key)
     return copy.deepcopy(blk) if isinstance(blk, dict) else {}
@@ -1224,42 +1260,98 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
 
     @app.post("/api/mdblist/save", tags=["auth"])
     def api_mdblist_save(payload: dict[str, Any] = Body(...), instance: str | None = Query(None)) -> dict[str, Any]:
+        inst = normalize_instance_id(instance)
         try:
+            provider_auth = _provider_auth()
+            method = provider_auth.normalize_auth_method("mdblist", (payload or {}).get("auth_method") or "api_key")
             key = str((payload or {}).get("api_key") or "").strip()
+            client_id = str((payload or {}).get("client_id") or "").strip()
             cfg = load_config()
-            m = ensure_instance_block(cfg, "mdblist", instance)
-            if key:
-                if _looks_masked_secret(key):
-                    key = ""
-                else:
+            m = ensure_instance_block(cfg, "mdblist", inst)
+            if method == "api_key":
+                if not _looks_masked_secret(key):
+                    ok, reason = _validate_mdblist_api_key(key)
+                    if not ok:
+                        _safe_log(log_fn, "MDBLIST", f"[MDBLIST] api_key validation failed reason={reason} instance={inst}")
+                        return {"ok": False, "error": reason, "instance": inst}
                     m["api_key"] = key
+                provider_auth.set_active_method("mdblist", m, "api_key")
+            else:
+                if client_id:
+                    m["client_id"] = client_id
+                provider_auth.set_active_method("mdblist", m, "device_code")
             save_config(cfg)
-            _safe_log(log_fn, "MDBLIST", f"[MDBLIST] api_key saved instance={normalize_instance_id(instance)}")
+            _safe_log(log_fn, "MDBLIST", f"[MDBLIST] auth saved method={method} instance={inst}")
             if isinstance(probe_cache, dict):
                 probe_cache["mdblist"] = (0.0, False)
-            return {"ok": True, "instance": normalize_instance_id(instance)}
+            return {"ok": True, "instance": inst, "auth_method": method}
         except Exception as e:
             _safe_log(log_fn, "MDBLIST", f"[MDBLIST] ERROR save: {e}")
             return {"ok": False, "error": "internal"}
 
+    @app.post("/api/mdblist/device/start", tags=["auth"])
+    def api_mdblist_device_start(payload: dict[str, Any] = Body(default_factory=dict), instance: str | None = Query(None)) -> dict[str, Any]:
+        inst = normalize_instance_id(instance)
+        try:
+            cfg = load_config()
+            client_id = str((payload or {}).get("client_id") or "").strip()
+            res = _provider_auth().start_device_code("mdblist", cfg, instance_id=inst, client_id=client_id)
+            if isinstance(probe_cache, dict):
+                probe_cache["mdblist"] = (0.0, False)
+            _safe_log(log_fn, "MDBLIST", f"[MDBLIST] device start instance={inst} ok={bool(res.get('ok'))}")
+            return res
+        except Exception as e:
+            _safe_log(log_fn, "MDBLIST", f"[MDBLIST] ERROR device start: {e}")
+            return {"ok": False, "error": "internal", "instance": inst}
+
+    @app.post("/api/mdblist/device/poll", tags=["auth"])
+    def api_mdblist_device_poll(payload: dict[str, Any] = Body(default_factory=dict), instance: str | None = Query(None)) -> dict[str, Any]:
+        inst = normalize_instance_id(instance)
+        try:
+            cfg = load_config()
+            res = _provider_auth().poll_device_code("mdblist", cfg, instance_id=inst, device_code=str((payload or {}).get("device_code") or "").strip() or None)
+            if res.get("ok") and isinstance(probe_cache, dict):
+                probe_cache["mdblist"] = (0.0, False)
+            return res
+        except Exception as e:
+            _safe_log(log_fn, "MDBLIST", f"[MDBLIST] ERROR device poll: {e}")
+            return {"ok": False, "status": "internal", "instance": inst}
+
+    @app.post("/api/mdblist/refresh", tags=["auth"])
+    def api_mdblist_refresh(instance: str | None = Query(None)) -> dict[str, Any]:
+        inst = normalize_instance_id(instance)
+        try:
+            cfg = load_config()
+            res = _provider_auth().refresh_token("mdblist", cfg, instance_id=inst)
+            if res.get("ok") and isinstance(probe_cache, dict):
+                probe_cache["mdblist"] = (0.0, False)
+            return res
+        except Exception as e:
+            _safe_log(log_fn, "MDBLIST", f"[MDBLIST] ERROR refresh: {e}")
+            return {"ok": False, "status": "internal", "instance": inst}
+
     @app.get("/api/mdblist/status", tags=["auth"])
     def api_mdblist_status(instance: str | None = Query(None)) -> dict[str, Any]:
         cfg = load_config()
-        m = ensure_instance_block(cfg, "mdblist", instance)
-        has = bool(str(m.get("api_key") or "").strip())
-        return {"connected": has, "instance": normalize_instance_id(instance)}
+        inst = normalize_instance_id(instance)
+        m = ensure_instance_block(cfg, "mdblist", inst)
+        out = _provider_auth().status_for_block("mdblist", m)
+        out["instance"] = inst
+        return out
 
     @app.post("/api/mdblist/disconnect", tags=["auth"])
     def api_mdblist_disconnect(instance: str | None = Query(None)) -> dict[str, Any]:
+        inst = normalize_instance_id(instance)
         try:
             cfg = load_config()
-            m = ensure_instance_block(cfg, "mdblist", instance)
+            m = ensure_instance_block(cfg, "mdblist", inst)
             m["api_key"] = ""
+            _provider_auth().clear_oauth("mdblist", m)
             save_config(cfg)
-            _safe_log(log_fn, "MDBLIST", f"[MDBLIST] disconnected instance={normalize_instance_id(instance)}")
+            _safe_log(log_fn, "MDBLIST", f"[MDBLIST] disconnected instance={inst}")
             if isinstance(probe_cache, dict):
                 probe_cache["mdblist"] = (0.0, False)
-            return {"ok": True, "instance": normalize_instance_id(instance)}
+            return {"ok": True, "instance": inst}
         except Exception as e:
             _safe_log(log_fn, "MDBLIST", f"[MDBLIST] ERROR disconnect: {e}")
             return {"ok": False, "error": "internal"}

--- a/api/probesAPI.py
+++ b/api/probesAPI.py
@@ -13,12 +13,19 @@ import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Callable, Mapping
 
+import requests
 from fastapi import FastAPI, Query
 from fastapi.responses import JSONResponse
 
 from cw_platform.config_base import load_config as _load_config
 
 from cw_platform.provider_instances import get_provider_block, list_instance_ids, normalize_instance_id, provider_key
+
+
+def _provider_auth():
+    from providers.auth import runtime as provider_auth
+
+    return provider_auth
 
 try:
     from providers.auth._auth_TRAKT import PROVIDER as TRAKT_AUTH_PROVIDER
@@ -198,8 +205,13 @@ def _probe_key(provider_id: str, cfg: Mapping[str, Any]) -> str:
 
     if p == "mdblist":
         m = cfg.get("mdblist") or {}
-        key = str((m.get("api_key") or m.get("key") or "")).strip()
-        return f"mdblist|key:{_secret_cache_tag(key)}" if key else "mdblist|unconfigured"
+        method = _provider_auth().active_method("mdblist", m)
+        if method == "api_key":
+            key = str((m.get("api_key") or m.get("key") or "")).strip()
+            return f"mdblist|api:{_secret_cache_tag(key)}" if key else "mdblist|unconfigured"
+        tok = str(m.get("access_token") or "").strip()
+        exp = str(m.get("expires_at") or "0")
+        return f"mdblist|device:{_secret_cache_tag(tok)}|exp:{exp}" if tok else "mdblist|unconfigured"
 
     if p == "tautulli":
         t = cfg.get("tautulli") or {}
@@ -335,9 +347,10 @@ def _http_post_json(
     data = json.dumps(dict(payload)).encode("utf-8")
     return _http_post_with_headers(url, headers=h, data=data, timeout=timeout)
 
-def _json_loads(b: bytes) -> dict[str, Any]:
+def _json_loads(b: bytes | str) -> Any:
     try:
-        return json.loads(b.decode("utf-8", errors="ignore"))
+        text = b.decode("utf-8", errors="ignore") if isinstance(b, bytes) else b
+        return json.loads(text)
     except Exception:
         return {}
 
@@ -791,17 +804,33 @@ def _probe_mdblist_detail(cfg: dict[str, Any], max_age_sec: int = PROBE_TTL) -> 
         return cached[1], cached[2]
 
     m: Mapping[str, Any] = (cfg.get("mdblist") or {}) if isinstance(cfg.get("mdblist"), Mapping) else {}
-    api_key = str((m.get("api_key") or m.get("key") or "")).strip()
-    if not api_key:
+    if not _provider_auth().is_configured("mdblist", m):
         with _CACHE_LOCK:
-            PROBE_DETAIL_CACHE[key] = (now, False, "MDBList: missing api_key")
-        return False, "MDBList: missing api_key"
+            PROBE_DETAIL_CACHE[key] = (now, False, "MDBList: missing authentication")
+        return False, "MDBList: missing authentication"
 
-    from urllib.parse import quote
-
-    url = f"https://api.mdblist.com/user?apikey={quote(api_key)}"
     timeout = max(int(HTTP_TIMEOUT), 6)
-    code, body, _ = _http_get_with_headers(url, headers=UA, timeout=timeout)
+    try:
+        sess = requests.Session()
+        hint = cfg.get("_cw_probe") if isinstance(cfg.get("_cw_probe"), Mapping) else {}
+        inst = normalize_instance_id((hint or {}).get("instance"))
+        r = _provider_auth().request_with_auth(
+            "mdblist",
+            sess,
+            "GET",
+            "https://api.mdblist.com/user",
+            cfg=cfg,
+            instance_id=inst,
+            headers=UA,
+            timeout=timeout,
+            max_retries=1,
+        )
+        code = int(r.status_code)
+        body = r.text or ""
+    except Exception as e:
+        code = 0
+        body = ""
+        _set_http_error(str(e))
 
     if code != 200:
         rsn = _reason_http(code, "MDBList")
@@ -1012,16 +1041,29 @@ def mdblist_user_info(cfg: dict[str, Any], max_age_sec: int = USERINFO_TTL) -> d
         return cached[1]
 
     md = (cfg.get("mdblist") or cfg.get("MDBLIST") or {}) or {}
-    api_key = str((md.get("api_key") or md.get("key") or "")).strip()
-    if not api_key:
+    if not _provider_auth().is_configured("mdblist", md):
         with _CACHE_LOCK:
             _USERINFO_CACHE[key] = (now, {})
         return {}
 
-    from urllib.parse import quote
-
-    url = f"https://api.mdblist.com/user?apikey={quote(api_key)}"
-    code, body = _http_get(url, headers=UA, timeout=6)
+    try:
+        sess = requests.Session()
+        hint = cfg.get("_cw_probe") if isinstance(cfg.get("_cw_probe"), Mapping) else {}
+        inst = normalize_instance_id((hint or {}).get("instance"))
+        r = _provider_auth().request_with_auth(
+            "mdblist",
+            sess,
+            "GET",
+            "https://api.mdblist.com/user",
+            cfg=cfg,
+            instance_id=inst,
+            headers=UA,
+            timeout=6,
+            max_retries=1,
+        )
+        code, body = int(r.status_code), r.text or ""
+    except Exception:
+        code, body = 0, ""
 
     out: dict[str, Any] = {}
     if code == 200:
@@ -1259,7 +1301,7 @@ def _prov_configured(cfg: dict[str, Any], name: str, instance_id: Any = "default
         return bool(str(blk.get("server") or "").strip() and str(blk.get("access_token") or blk.get("token") or blk.get("api_key") or "").strip())
 
     if ck == "mdblist":
-        return bool(str(blk.get("api_key") or blk.get("key") or "").strip())
+        return _provider_auth().is_configured("mdblist", blk)
 
     if ck == "publicmetadb":
         return bool(str(blk.get("api_key") or blk.get("key") or "").strip())

--- a/assets/auth/auth.mdblist.js
+++ b/assets/auth/auth.mdblist.js
@@ -6,12 +6,14 @@
   const el = (id) => document.getElementById(id);
   const txt = (v) => (typeof v === "string" ? v : "").trim();
   const note = (m) => (typeof window.notify === "function" ? window.notify(m) : void 0);
+  const MASK = "********";
+  const MDBLIST_INSTANCE_KEY = "cw.ui.mdblist.auth.instance.v1";
+  let pollTimer = null;
+  let methodOverride = "";
 
   function isMaskedSecret(v) {
     const value = txt(v);
-    if (!value) return false;
-    if (value === "••••••••" || value === "********" || value === "**********") return true;
-    return /^[•*]{3,}$/.test(value);
+    return !!value && (value === MASK || /^([*]|[•]){3,}$/.test(value));
   }
 
   function readSecretField(i) {
@@ -21,8 +23,6 @@
     if (masked) return { hasValue: true, masked: true, value: "" };
     return { hasValue: true, masked: false, value: raw };
   }
-
-  const MDBLIST_INSTANCE_KEY = "cw.ui.mdblist.auth.instance.v1";
 
   function getMDBListInstance() {
     var s = el("mdblist_instance");
@@ -51,6 +51,19 @@
     return { ok: r.ok, data: j };
   }
 
+  function friendlyError(code) {
+    const key = String(code || "").trim();
+    const map = {
+      api_key_required: "Enter your MDBList API key",
+      invalid_api_key: "Invalid MDBList API key",
+      validation_timeout: "MDBList validation timed out",
+      validation_failed: "Could not validate MDBList API key",
+      validation_bad_response: "MDBList returned an invalid validation response",
+      save_failed: "Saving MDBList key failed",
+    };
+    return map[key] || key.replace(/_/g, " ") || "Saving MDBList key failed";
+  }
+
   async function getCfg() {
     const r = await fetchJSON("/api/config?ts=" + Date.now(), { cache: "no-store" });
     return r.ok ? (r.data || {}) : {};
@@ -64,6 +77,88 @@
     if (!base.instances || typeof base.instances !== "object") base.instances = {};
     if (!base.instances[inst] || typeof base.instances[inst] !== "object") base.instances[inst] = {};
     return base.instances[inst];
+  }
+
+  function activeMethodFromBlock(blk) {
+    if (blk?._pending_device && (txt(blk._pending_device.user_code) || txt(blk._pending_device.device_code))) return "device_code";
+    if (txt(blk?.api_key) && !txt(blk?.access_token) && !txt(blk?.refresh_token)) return "api_key";
+    if (txt(blk?.access_token) || txt(blk?.refresh_token)) return "device_code";
+    const raw = txt(String(blk?.auth_method || "")).toLowerCase().replace("-", "_");
+    if (raw === "api" || raw === "apikey" || raw === "api_key") return "api_key";
+    if (raw === "device" || raw === "device_code" || raw === "oauth") return "device_code";
+    return "device_code";
+  }
+
+  function activeMethodFromStatus(data) {
+    if (data && data.pending) return "device_code";
+    if (data && data.api_key_configured && !data.device_configured) return "api_key";
+    if (data && data.device_configured) return "device_code";
+    return data && data.auth_method === "api_key" ? "api_key" : "device_code";
+  }
+
+  function setConn(ok, msg) {
+    const m = el("mdblist_msg");
+    if (!m) return;
+    m.textContent = ok ? (msg || "Connected.") : (msg || "Not connected");
+    m.classList.remove("hidden", "ok", "warn");
+    m.classList.add(ok ? "ok" : "warn");
+  }
+
+  function maskInput(i, has) {
+    if (!i) return;
+    if (has) { i.value = MASK; i.dataset.masked = "1"; }
+    else { i.value = ""; i.dataset.masked = "0"; }
+    i.dataset.loaded = "1";
+    i.dataset.touched = "";
+    i.dataset.clear = "";
+    i.dataset.hasKey = has ? "1" : "";
+  }
+
+  function setReadonlySecret(id, has) {
+    const i = el(id);
+    if (!i) return;
+    i.value = has ? MASK : "";
+    i.dataset.masked = has ? "1" : "0";
+  }
+
+  async function copyField(id, btn) {
+    const i = el(id);
+    const value = txt(i?.value);
+    if (!value || isMaskedSecret(value)) return note("Nothing to copy");
+    try {
+      await navigator.clipboard.writeText(value);
+      if (btn) {
+        const old = btn.textContent;
+        btn.textContent = "Copied";
+        setTimeout(() => { btn.textContent = old || "Copy"; }, 900);
+      }
+    } catch (_) {
+      note("Copy failed");
+    }
+  }
+
+  function setMethodUI(method) {
+    const m = method === "api_key" ? "api_key" : "device_code";
+    const sel = el("mdblist_auth_method");
+    if (sel) {
+      sel.value = m;
+      try {
+        window.CW?.IconSelect?.enhance(sel, sel.__cwIconSelectCfg || { className: "cw-plain-select" });
+      } catch (_) {}
+    }
+    const cidWrap = el("mdblist_client_id_wrap") || el("mdblist_client_id")?.closest("div");
+    const dev = el("mdblist_device_panel");
+    const api = el("mdblist_api_panel");
+    if (cidWrap) cidWrap.style.display = m === "device_code" ? "" : "none";
+    if (dev) dev.style.display = m === "device_code" ? "" : "none";
+    if (api) api.style.display = m === "api_key" ? "" : "none";
+  }
+
+  function setApiHintVisible(visible) {
+    const h = el("mdblist_hint");
+    if (!h) return;
+    h.classList.toggle("hidden", !visible);
+    h.style.display = visible ? "" : "none";
   }
 
   async function refreshMDBListInstanceOptions(preserve) {
@@ -102,7 +197,6 @@
     wrap.style.alignItems = 'center';
     wrap.style.marginLeft = 'auto';
     wrap.style.flexWrap = 'nowrap';
-    wrap.title = 'Select which MDBList profile this config applies to.';
 
     var lab = document.createElement('span');
     lab.className = 'muted';
@@ -110,14 +204,13 @@
 
     var sel = document.createElement('select');
     sel.id = 'mdblist_instance';
-sel.name = 'mdblist_instance';
+    sel.name = 'mdblist_instance';
     sel.className = 'input';
     sel.style.minWidth = '160px';
-
-    // Match Trakt: keep it compact and let content drive the width.
     sel.style.width = 'auto';
     sel.style.maxWidth = '220px';
     sel.style.flex = '0 0 auto';
+
     var btnNew = document.createElement('button');
     btnNew.type = 'button';
     btnNew.className = 'btn secondary';
@@ -137,149 +230,197 @@ sel.name = 'mdblist_instance';
     head.appendChild(wrap);
 
     refreshMDBListInstanceOptions(true);
-
-    if (sel && !sel._wired) {
-      sel._wired = true;
-      sel.addEventListener("change", function () {
-        setMDBListInstance(sel.value);
-        void hydrate();
-      });
-    }
-
-    var btnNew = el("mdblist_instance_new");
-    if (btnNew && !btnNew._wired) {
-      btnNew._wired = true;
-      btnNew.addEventListener("click", async function () {
-        try {
-          var r = await fetch("/api/provider-instances/mdblist/next?ts=" + Date.now(), {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: "{}",
-            cache: "no-store"
-          });
-          var j = await r.json().catch(function(){ return {}; });
-          var id = txt((j && j.id) || "");
-          if (!r.ok || (j && j.ok === false) || !id) throw new Error(String((j && j.error) || "create_failed"));
-          setMDBListInstance(id);
-          await refreshMDBListInstanceOptions(true);
-          void hydrate();
-        } catch (e) {
-          note("Could not create profile: " + (e && e.message ? e.message : e));
-        }
-      });
-    }
-
-    var btnDel = el("mdblist_instance_del");
-    if (btnDel && !btnDel._wired) {
-      btnDel._wired = true;
-      btnDel.addEventListener("click", async function () {
-        var id = getMDBListInstance();
-        if (id === "default") return note("Default profile cannot be deleted.");
-        if (!confirm('Delete MDBList profile "' + id + '"?')) return;
-        try {
-          var r = await fetch("/api/provider-instances/mdblist/" + encodeURIComponent(id), { method: "DELETE", cache: "no-store" });
-          var j = await r.json().catch(function(){ return {}; });
-          if (!r.ok || (j && j.ok === false)) throw new Error(String((j && j.error) || "delete_failed"));
-          setMDBListInstance("default");
-          await refreshMDBListInstanceOptions(false);
-          void hydrate();
-        } catch (e) {
-          note("Could not delete profile: " + (e && e.message ? e.message : e));
-        }
-      });
-    }
   }
 
-  async function saveKeyNarrow(key) {
+  async function saveAuth(payload) {
     const r = await fetchJSON(mdblApi("/api/mdblist/save"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ api_key: key })
+      body: JSON.stringify(payload || {})
     });
-    if (!r.ok || (r.data && r.data.ok === false)) throw new Error("save_failed");
+    if (!r.ok || (r.data && r.data.ok === false)) throw new Error(friendlyError((r.data && r.data.error) || "save_failed"));
+    return r.data || {};
   }
 
-  function setConn(ok, msg) {
-    const m = el("mdblist_msg");
-    if (!m) return;
-    const text = ok ? (msg || "Connected.") : (msg || "Not connected");
-    m.textContent = text;
-    m.classList.remove("hidden", "ok", "warn");
-    m.classList.add(ok ? "ok" : "warn");
-  }
-
-  async function refresh() {
+  async function refresh(showToast) {
     try {
       const r = await fetchJSON(mdblApi("/api/mdblist/status"), { cache: "no-store" });
-      const ok = !!(r.ok && r.data && r.data.connected);
-      setConn(ok);
-      note(ok ? "MDBList verified ✓" : "MDBList not connected");
+      const data = r.data || {};
+      const ok = !!(r.ok && data.connected);
+      const statusMethod = activeMethodFromStatus(data);
+      const method = methodOverride || statusMethod;
+      setMethodUI(method);
+      setReadonlySecret("mdblist_access_token", !!data.device_configured);
+      if (data.pending) {
+        const code = el("mdblist_device_code");
+        if (code && data.pending.user_code) code.value = txt(data.pending.user_code);
+        if (data.pending.user_code && !pollTimer) startPoll(Math.max(2, Number(data.pending.interval || 5)));
+      }
+      let msg = ok ? (statusMethod === "api_key" ? "Connected with API key." : "Connected with Device Code.") : "Not connected";
+      if (data.pending && !data.device_configured) msg = "Waiting for Device Code approval";
+      if (ok && data.expires_at && statusMethod === "device_code") msg = "Connected with Device Code.";
+      setConn(data.pending && !data.device_configured ? false : ok, msg);
+      if (showToast) note(ok ? "MDBList verified" : "MDBList not connected");
     } catch {
       setConn(false, "MDBList verify failed");
-      note("MDBList verify failed");
+      if (showToast) note("MDBList verify failed");
     }
-  }
-
-  function maskInput(i, has) {
-    if (!i) return;
-    if (has) { i.value = "••••••••"; i.dataset.masked = "1"; }
-    else { i.value = ""; i.dataset.masked = "0"; }
-    i.dataset.loaded = "1";
-    i.dataset.touched = "";
-    i.dataset.clear = "";
-    i.dataset.hasKey = has ? "1" : "";
   }
 
   async function hydrate() {
     ensureMDBListInstanceUI();
     const cfg = window._cfgCache || await getCfg();
     const blk = getMDBListCfgBlock(cfg);
-    const has = !!txt(blk?.api_key);
-    const i = el("mdblist_key");
-    maskInput(i, has);
-    el("mdblist_hint")?.classList.toggle("hidden", has);
-    await refresh();
+    const method = methodOverride || activeMethodFromBlock(blk);
+    setMethodUI(method);
+    const cid = el("mdblist_client_id");
+    if (cid) cid.value = txt(blk?.client_id || "");
+    setReadonlySecret("mdblist_access_token", !!txt(blk?.access_token));
+    const hasApiKey = !!txt(blk?.api_key);
+    maskInput(el("mdblist_key"), hasApiKey);
+    setApiHintVisible(!hasApiKey);
+
+    const pend = blk?._pending_device || {};
+    if (pend.user_code) {
+      const code = el("mdblist_device_code");
+      if (code) code.value = txt(pend.user_code);
+      startPoll(Math.max(2, Number(pend.interval || 5)));
+    }
+    await refresh(false);
   }
 
-  async function onSave() {
+  async function onMethodChange() {
+    const method = el("mdblist_auth_method")?.value === "api_key" ? "api_key" : "device_code";
+    methodOverride = method === "device_code" ? "device_code" : "";
+    setMethodUI(method);
+    try {
+      await saveAuth({ auth_method: method, client_id: txt(el("mdblist_client_id")?.value) });
+      await refresh(false);
+    } catch {
+      note("MDBList method switch failed");
+    }
+  }
+
+  async function onSaveApiKey() {
     const i = el("mdblist_key");
     const keyState = readSecretField(i);
     if (!keyState.value) {
-      if (keyState.masked || (i && i.dataset.hasKey === "1")) { await refresh(); note("Key unchanged"); return; }
+      if (keyState.masked || (i && i.dataset.hasKey === "1")) { await refresh(true); note("Key unchanged"); return; }
       note("Enter your MDBList API key"); return;
     }
     try {
-      await saveKeyNarrow(keyState.value);
-      if (i) maskInput(i, true);
-      el("mdblist_hint")?.classList.add("hidden");
-      note("MDBList key saved");
-      await refresh();
-    } catch {
-      note("Saving MDBList key failed");
+      methodOverride = "";
+      await saveAuth({ auth_method: "api_key", api_key: keyState.value });
+      maskInput(i, true);
+      setApiHintVisible(false);
+      note("MDBList API key saved");
+      await refresh(true);
+    } catch (e) {
+      const msg = e && e.message ? e.message : "Saving MDBList key failed";
+      setConn(false, msg);
+      note(msg);
+    }
+  }
+
+  function stopPoll() {
+    if (pollTimer) clearTimeout(pollTimer);
+    pollTimer = null;
+  }
+
+  function startPoll(intervalSec) {
+    stopPoll();
+    const run = async () => {
+      try {
+        const r = await fetchJSON(mdblApi("/api/mdblist/device/poll"), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{}",
+          cache: "no-store"
+        });
+        const data = r.data || {};
+        if (r.ok && data.ok) {
+          stopPoll();
+          methodOverride = "";
+          note("MDBList connected");
+          await hydrate();
+          return;
+        }
+        const status = String(data.status || data.error || "");
+        if (status && !["authorization_pending", "slow_down"].includes(status)) {
+          setConn(false, status.replace(/_/g, " "));
+          stopPoll();
+          return;
+        }
+      } catch (_) {}
+      pollTimer = setTimeout(run, Math.max(2, Number(intervalSec || 5)) * 1000);
+    };
+    pollTimer = setTimeout(run, Math.max(2, Number(intervalSec || 5)) * 1000);
+  }
+
+  async function onDeviceStart() {
+    const clientId = txt(el("mdblist_client_id")?.value);
+    if (!clientId) { note("Enter your MDBList Client ID"); return; }
+    let win = null;
+    try { win = window.open("about:blank", "_blank"); } catch (_) {}
+    try {
+      methodOverride = "device_code";
+      const r = await fetchJSON(mdblApi("/api/mdblist/device/start"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ client_id: clientId }),
+        cache: "no-store"
+      });
+      const data = r.data || {};
+      if (!r.ok || !data.ok) throw new Error(String(data.error || "device_start_failed"));
+      const code = el("mdblist_device_code");
+      if (code) code.value = txt(data.user_code);
+      setConn(false, "Waiting for approval");
+      startPoll(Math.max(2, Number(data.interval || 5)));
+      if (win && !win.closed) {
+        try { win.location.href = txt(data.verification_uri || "https://mdblist.com/oauth/device/"); win.focus(); } catch (_) {}
+      } else {
+        note("Popup blocked - allow popups and try again");
+      }
+    } catch (e) {
+      try { if (win && !win.closed) win.close(); } catch (_) {}
+      note("MDBList Device Code start failed: " + (e && e.message ? e.message : e));
     }
   }
 
   async function onDisc() {
+    stopPoll();
     try {
+      methodOverride = "";
       const r = await fetchJSON(mdblApi("/api/mdblist/disconnect"), { method: "POST" });
       if (!r.ok || (r.data && r.data.ok === false)) throw new Error("disconnect_failed");
-      const i = el("mdblist_key");
-      maskInput(i, false);
-      el("mdblist_hint")?.classList.remove("hidden");
+      maskInput(el("mdblist_key"), false);
+      const code = el("mdblist_device_code"); if (code) code.value = "";
+      setReadonlySecret("mdblist_access_token", false);
       setConn(false);
       note("MDBList disconnected");
+      await hydrate();
     } catch {
       note("MDBList disconnect failed");
     }
   }
 
   function wire() {
+    const method = el("mdblist_auth_method");
+    if (method && !method.__wired) { method.addEventListener("change", onMethodChange); method.__wired = true; }
     const s = el("mdblist_save");
-    if (s && !s.__wired) { s.addEventListener("click", onSave); s.__wired = true; }
-    const v = el("mdblist_verify");
-    if (v && !v.__wired) { v.addEventListener("click", refresh); v.__wired = true; }
+    if (s && !s.__wired) { s.addEventListener("click", onSaveApiKey); s.__wired = true; }
+    const start = el("mdblist_device_start");
+    if (start && !start.__wired) { start.addEventListener("click", onDeviceStart); start.__wired = true; }
+    const copyTok = el("mdblist_copy_token");
+    if (copyTok && !copyTok.__wired) { copyTok.addEventListener("click", () => copyField("mdblist_access_token", copyTok)); copyTok.__wired = true; }
+    const copyCode = el("mdblist_copy_code");
+    if (copyCode && !copyCode.__wired) { copyCode.addEventListener("click", () => copyField("mdblist_device_code", copyCode)); copyCode.__wired = true; }
     const d = el("mdblist_disconnect");
     if (d && !d.__wired) { d.addEventListener("click", onDisc); d.__wired = true; }
+    const dd = el("mdblist_disconnect_device");
+    if (dd && !dd.__wired) { dd.addEventListener("click", onDisc); dd.__wired = true; }
+    const da = el("mdblist_disconnect_api");
+    if (da && !da.__wired) { da.addEventListener("click", onDisc); da.__wired = true; }
     const k = el("mdblist_key");
     if (k && !k.__wiredSecret) {
       const clearMask = () => {
@@ -299,12 +440,62 @@ sel.name = 'mdblist_instance';
       });
       k.__wiredSecret = true;
     }
+    const sel = el("mdblist_instance");
+    if (sel && !sel.__wiredMdbl) {
+      sel.addEventListener("change", function () {
+        setMDBListInstance(sel.value);
+        methodOverride = "";
+        stopPoll();
+        void hydrate();
+      });
+      sel.__wiredMdbl = true;
+    }
+    const btnNew = el("mdblist_instance_new");
+    if (btnNew && !btnNew.__wiredMdbl) {
+      btnNew.addEventListener("click", async function () {
+        try {
+          var r = await fetch("/api/provider-instances/mdblist/next?ts=" + Date.now(), {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: "{}",
+            cache: "no-store"
+          });
+          var j = await r.json().catch(function(){ return {}; });
+          var id = txt((j && j.id) || "");
+          if (!r.ok || (j && j.ok === false) || !id) throw new Error(String((j && j.error) || "create_failed"));
+          setMDBListInstance(id);
+          await refreshMDBListInstanceOptions(true);
+          void hydrate();
+        } catch (e) {
+          note("Could not create profile: " + (e && e.message ? e.message : e));
+        }
+      });
+      btnNew.__wiredMdbl = true;
+    }
+    const btnDel = el("mdblist_instance_del");
+    if (btnDel && !btnDel.__wiredMdbl) {
+      btnDel.addEventListener("click", async function () {
+        var id = getMDBListInstance();
+        if (id === "default") return note("Default profile cannot be deleted.");
+        if (!confirm('Delete MDBList profile "' + id + '"?')) return;
+        try {
+          var r = await fetch("/api/provider-instances/mdblist/" + encodeURIComponent(id), { method: "DELETE", cache: "no-store" });
+          var j = await r.json().catch(function(){ return {}; });
+          if (!r.ok || (j && j.ok === false)) throw new Error(String((j && j.error) || "delete_failed"));
+          setMDBListInstance("default");
+          await refreshMDBListInstanceOptions(false);
+          void hydrate();
+        } catch (e) {
+          note("Could not delete profile: " + (e && e.message ? e.message : e));
+        }
+      });
+      btnDel.__wiredMdbl = true;
+    }
   }
 
   function watch() {
     const host = document.getElementById("auth-providers");
-    if (!host) return;
-    if (watch._obs) return;
+    if (!host || watch._obs) return;
     watch._obs = new MutationObserver(() => { ensureMDBListInstanceUI(); wire(); });
     watch._obs.observe(host, { childList: true, subtree: true });
   }
@@ -324,21 +515,20 @@ sel.name = 'mdblist_instance';
     const cfg = ev?.detail?.cfg;
     if (!cfg) return;
 
-    const keyState = readSecretField(el("mdblist_key"));
-    if (!keyState.value) return;
-
     const inst = getMDBListInstance();
     cfg.mdblist = cfg.mdblist || {};
-    if (inst === "default") {
-      cfg.mdblist.api_key = keyState.value;
-      return;
-    }
-    cfg.mdblist.instances = cfg.mdblist.instances || {};
-    cfg.mdblist.instances[inst] = cfg.mdblist.instances[inst] || {};
-    cfg.mdblist.instances[inst].api_key = keyState.value;
+    const target = inst === "default"
+      ? cfg.mdblist
+      : ((cfg.mdblist.instances = cfg.mdblist.instances || {}), (cfg.mdblist.instances[inst] = cfg.mdblist.instances[inst] || {}));
+
+    const method = el("mdblist_auth_method")?.value === "api_key" ? "api_key" : "device_code";
+    target.auth_method = method;
+    const clientId = txt(el("mdblist_client_id")?.value);
+    if (clientId) target.client_id = clientId;
+    const keyState = readSecretField(el("mdblist_key"));
+    if (method === "api_key" && keyState.value) target.api_key = keyState.value;
   });
 
   window.initMDBListAuthUI = boot;
-
   boot();
 })();

--- a/assets/crosswatch.js
+++ b/assets/crosswatch.js
@@ -367,6 +367,7 @@ function _cwHasConfiguredValue(v) {
       "anilist.client_secret",
       "anilist.access_token",
       "mdblist.api_key",
+      "mdblist.access_token",
       "tautulli.server_url",
       "tautulli.api_key",
       "tautulli.history.user_id",

--- a/assets/helpers/core.js
+++ b/assets/helpers/core.js
@@ -77,7 +77,7 @@
     { key: "ANILIST", paths: [["anilist"], ["auth", "anilist"]], keys: ["access_token", "token"] },
     { key: "JELLYFIN", paths: [["jellyfin"], ["auth", "jellyfin"]], keys: ["access_token"] },
     { key: "EMBY", paths: [["emby"], ["auth", "emby"]], keys: ["access_token", "api_key", "token"] },
-    { key: "MDBLIST", paths: [["mdblist"], ["auth", "mdblist"]], keys: ["api_key"] },
+    { key: "MDBLIST", paths: [["mdblist"], ["auth", "mdblist"]], keys: ["api_key", "access_token"] },
     { key: "PUBLICMETADB", paths: [["publicmetadb"], ["auth", "publicmetadb"]], keys: ["api_key"] },
   ];
 

--- a/assets/helpers/settings-save.js
+++ b/assets/helpers/settings-save.js
@@ -384,6 +384,16 @@ async function saveSettings() {
   const fromFab = !!document.activeElement?.closest?.("#save-fab");
   const readToggle = (id) => _cwTruthy(_cwEl(id)?.value || "");
   let schedChanged = false;
+  const schedulingPaneActive = () => {
+    try {
+      const active = document.querySelector("#page-settings .cw-settings-pane.active, #page-settings .cw-settings-panel.active");
+      const key = _cwNorm(active?.dataset?.pane || active?.dataset?.tab || window.__cwSettingsPane).toLowerCase();
+      if (key === "scheduling") return true;
+      return !!document.activeElement?.closest?.("#sec-scheduling");
+    } catch {
+      return false;
+    }
+  };
   const schedulingSaveError = (message) => {
     const msg = _cwNorm(message) || "Fix the scheduling errors before saving.";
     try {
@@ -674,8 +684,13 @@ async function saveSettings() {
       if (_cwFn("getSchedulingPatch", window)) {
         const validation = _cwFn("getSchedulingValidation", window)?.() || {};
         const issues = Array.isArray(validation.issues) ? validation.issues.filter(Boolean) : [];
-        if (issues.length) schedulingSaveError(issues[0]);
-        sched = window.getSchedulingPatch({ strict: true }) || sched;
+        if (issues.length) {
+          if (schedulingPaneActive()) schedulingSaveError(issues[0]);
+          console.warn("saveSettings: scheduling has validation issues; preserving existing scheduling config", issues[0]);
+          sched = serverCfg?.scheduling || sched;
+        } else {
+          sched = window.getSchedulingPatch({ strict: true }) || sched;
+        }
       }
       if (!same(sched, serverCfg?.scheduling || {})) {
         cfg.scheduling = sched;

--- a/assets/js/modals/insight-settings/index.js
+++ b/assets/js/modals/insight-settings/index.js
@@ -115,7 +115,7 @@ const getAllowedProviders = (cfg = window._cfgCache || {}) => {
     { key: "ANILIST", paths: [["anilist"], ["auth", "anilist"]], keys: ["access_token", "token"] },
     { key: "JELLYFIN", paths: [["jellyfin"], ["auth", "jellyfin"]], keys: ["access_token"] },
     { key: "EMBY", paths: [["emby"], ["auth", "emby"]], keys: ["access_token", "api_key", "token"] },
-    { key: "MDBLIST", paths: [["mdblist"], ["auth", "mdblist"]], keys: ["api_key"] },
+    { key: "MDBLIST", paths: [["mdblist"], ["auth", "mdblist"]], keys: ["api_key", "access_token"] },
     { key: "PUBLICMETADB", paths: [["publicmetadb"], ["auth", "publicmetadb"]], keys: ["api_key"] },
   ];
   for (const def of checks) if (def.paths.some((path) => hasAnyConfigValue(pathGet(cfg, path), def.keys))) set.add(def.key);

--- a/assets/js/scrobbler.js
+++ b/assets/js/scrobbler.js
@@ -1020,7 +1020,7 @@ function findSharedSinkProfileProviderConflicts(routes) {
     const ov = overlayCfgFor(s, r?.sink_instance);
     if (s === "trakt") return !!String(ov.access_token || "").trim();
     if (s === "simkl") return !!String(ov.access_token || "").trim();
-    if (s === "mdblist") return !!String(ov.api_key || "").trim();
+    if (s === "mdblist") return !!String(ov.api_key || ov.access_token || "").trim();
     return false;
   }
 
@@ -1894,7 +1894,7 @@ function chip(text, onRemove, onClick) {
 
   const traktTokenOk = !!String(traktCfg?.access_token || read("trakt.access_token", "") || "").trim();
   const simklTokenOk = !!String(simklCfg?.access_token || read("simkl.access_token", "") || "").trim();
-  const mdblTokenOk = !!String(mdblCfg?.api_key || read("mdblist.api_key", "") || "").trim();
+  const mdblTokenOk = !!String(mdblCfg?.api_key || mdblCfg?.access_token || read("mdblist.api_key", "") || read("mdblist.access_token", "") || "").trim();
 
   let sinkOk = true;
   let sinkErr = "";

--- a/assets/js/settings-insight.js
+++ b/assets/js/settings-insight.js
@@ -84,7 +84,7 @@
     if (p === 'emby' || p === 'jellyfin') return has(b.access_token) || has(b.api_key) || has(b.token);
     if (p === 'trakt' || p === 'simkl') return has(b.access_token) || has(b.refresh_token);
     if (p === 'anilist') return has(b.access_token) || has(b.token);
-    if (p === 'mdblist') return has(b.api_key);
+    if (p === 'mdblist') return has(b.api_key) || has(b.access_token);
     if (p === 'tautulli') return has((b || cfg?.tautulli || cfg?.auth?.tautulli || {}).server_url || (b || cfg?.tautulli || cfg?.auth?.tautulli || {}).server);
     if (p === 'tmdb') return has(b.api_key) && has(b.session_id || b.session);
     return has(b.access_token) || has(b.api_key) || has(b.token);

--- a/assets/js/watchlist.js
+++ b/assets/js/watchlist.js
@@ -1325,7 +1325,7 @@ const normReleased = v => (v === "yes" ? "released" : v === "no" ? "unreleased" 
         if (cfg?.tmdb_sync?.api_key && cfg?.tmdb_sync?.session_id) active.add("TMDB");
         if (cfg?.jellyfin?.access_token) active.add("JELLYFIN");
         if (cfg?.emby?.access_token || cfg?.emby?.api_key || cfg?.emby?.token) active.add("EMBY");
-        if (cfg?.mdblist?.api_key) active.add("MDBLIST");
+        if (cfg?.mdblist?.api_key || cfg?.mdblist?.access_token) active.add("MDBLIST");
         if (cfg?.publicmetadb?.api_key) active.add("PUBLICMETADB");
       }
     } catch {}

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -253,6 +253,13 @@ DEFAULT_CFG: dict[str, Any] = {
     },
 
     "mdblist": {
+        "auth_method": "",                              # "", "device_code" (default when new), or "api_key" (legacy/manual)
+        "client_id": "",                                # MDBList Device Code app client_id
+        "access_token": "",                             # OAuth access token (Device Code)
+        "refresh_token": "",                            # OAuth refresh token (Device Code)
+        "token_type": "Bearer",                         # OAuth token type
+        "scope": "write",                               # MDBList OAuth scope
+        "expires_at": 0,                                # Epoch when access_token expires
         "api_key": "",                                  # Your MDBList API key
         "timeout": 10,                                  # HTTP timeout (seconds)
         "max_retries": 3,                               # Retry budget
@@ -665,7 +672,7 @@ def redact_config(cfg: dict[str, Any]) -> dict[str, Any]:
         "plex": {"account_token", "pms_token", "home_pin", "webhook_secret"},
         "simkl": {"access_token", "refresh_token", "client_secret"},
         "anilist": {"access_token", "client_secret"},
-        "mdblist": {"api_key"},
+        "mdblist": {"api_key", "access_token", "refresh_token", "_pending_device"},
         "publicmetadb": {"api_key"},
         "tautulli": {"api_key"},
         "trakt": {"access_token", "refresh_token", "client_secret"},
@@ -1036,6 +1043,72 @@ def _normalize_mdblist(cfg: dict[str, Any]) -> None:
     else:
         m = {}
         cfg["mdblist"] = m
+
+    def _norm_method(block: dict[str, Any]) -> str:
+        has_api = bool(str(block.get("api_key") or block.get("key") or "").strip())
+        has_oauth = bool(str(block.get("access_token") or "").strip() or str(block.get("refresh_token") or "").strip())
+        if has_api and not has_oauth:
+            return "api_key"
+        if has_oauth:
+            return "device_code"
+        raw = str(block.get("auth_method") or "").strip().lower().replace("-", "_")
+        if raw in ("api", "apikey", "api_key", "key"):
+            return "api_key"
+        if raw in ("device", "device_code", "oauth", "oauth_device", "bearer"):
+            return "device_code"
+        return "device_code"
+
+    def _normalize_auth_block(block: dict[str, Any]) -> None:
+        method = _norm_method(block)
+        has_api_before = bool(str(block.get("api_key") or block.get("key") or "").strip())
+        has_oauth_before = bool(str(block.get("access_token") or "").strip() or str(block.get("refresh_token") or "").strip())
+        # Do not let a passive UI/config save destroy an existing API key just
+        # because the default method is Device Code. The API key becomes
+        # inactive once Device Code has real token state, and is cleared after
+        # MDBList returns tokens. A pending device flow is not active auth yet.
+        if method == "device_code" and has_api_before and not has_oauth_before:
+            method = "api_key"
+        block["auth_method"] = method
+        block["client_id"] = str(block.get("client_id") or "").strip()
+        block["access_token"] = str(block.get("access_token") or "").strip()
+        block["refresh_token"] = str(block.get("refresh_token") or "").strip()
+        block["token_type"] = str(block.get("token_type") or "Bearer").strip() or "Bearer"
+        block["scope"] = str(block.get("scope") or "write").strip() or "write"
+        try:
+            block["expires_at"] = int(block.get("expires_at") or 0)
+        except Exception:
+            block["expires_at"] = 0
+        block["api_key"] = str(block.get("api_key") or block.get("key") or "").strip()
+        if method == "api_key":
+            block["access_token"] = ""
+            block["refresh_token"] = ""
+            block["expires_at"] = 0
+        else:
+            block["api_key"] = ""
+        pend = block.get("_pending_device")
+        if isinstance(pend, dict):
+            pend["device_code"] = str(pend.get("device_code") or "").strip()
+            pend["user_code"] = str(pend.get("user_code") or "").strip()
+            pend["verification_uri"] = str(pend.get("verification_uri") or pend.get("verification_url") or "https://mdblist.com/oauth/device/").strip()
+            try:
+                pend["interval"] = int(pend.get("interval") or 5)
+            except Exception:
+                pend["interval"] = 5
+            try:
+                pend["expires_at"] = int(pend.get("expires_at") or 0)
+            except Exception:
+                pend["expires_at"] = 0
+            try:
+                pend["created_at"] = int(pend.get("created_at") or 0)
+            except Exception:
+                pend["created_at"] = 0
+
+    _normalize_auth_block(m)
+    insts = m.get("instances")
+    if isinstance(insts, dict):
+        for inst in insts.values():
+            if isinstance(inst, dict):
+                _normalize_auth_block(inst)
 
     rl0 = m.get("rate_limit")
     if isinstance(rl0, dict):

--- a/providers/auth/_auth_MDBLIST.py
+++ b/providers/auth/_auth_MDBLIST.py
@@ -10,12 +10,14 @@ import requests
 
 from ._auth_base import AuthManifest, AuthProvider, AuthStatus
 from cw_platform.config_base import load_config, save_config
-from cw_platform.provider_instances import get_provider_block, ensure_instance_block, normalize_instance_id
+from cw_platform.provider_instances import ensure_instance_block, get_provider_block, normalize_instance_id
+from providers.sync.mdblist import _auth as mdblist_auth
 
 try:
     from _logging import log as _real_log
 except ImportError:
     _real_log = None
+
 
 def log(msg: str, level: str = "INFO", module: str = "AUTH", **_: Any) -> None:
     try:
@@ -26,10 +28,12 @@ def log(msg: str, level: str = "INFO", module: str = "AUTH", **_: Any) -> None:
     except Exception:
         pass
 
+
 API_BASE = "https://api.mdblist.com"
 UA = "CrossWatch/1.0"
 HTTP_TIMEOUT = 10
-__VERSION__ = "2.0.0"
+__VERSION__ = "2.1.0"
+
 
 def _load_config() -> dict[str, Any]:
     try:
@@ -37,17 +41,26 @@ def _load_config() -> dict[str, Any]:
     except Exception:
         return {}
 
+
 def _block(cfg: Mapping[str, Any], instance_id: Any = None) -> dict[str, Any]:
     return get_provider_block(cfg or {}, "mdblist", instance_id)
 
+
 def _get(cfg: Mapping[str, Any], path: str, *, instance_id: Any = None, timeout: int = HTTP_TIMEOUT) -> tuple[int, dict[str, Any]]:
-    b = _block(cfg, instance_id)
-    key = str(b.get("api_key") or "").strip()
-    if not key:
+    if not mdblist_auth.is_configured(_block(cfg, instance_id)):
         return 0, {}
-    url = f"{API_BASE}{path}?apikey={key}"
     try:
-        r = requests.get(url, headers={"Accept": "application/json", "User-Agent": UA}, timeout=timeout)
+        session = requests.Session()
+        r = mdblist_auth.request_with_auth(
+            session,
+            "GET",
+            f"{API_BASE}{path}",
+            cfg=cfg,
+            instance_id=instance_id,
+            timeout=timeout,
+            max_retries=1,
+            headers={"Accept": "application/json", "User-Agent": UA},
+        )
     except Exception:
         return 0, {}
     try:
@@ -56,6 +69,7 @@ def _get(cfg: Mapping[str, Any], path: str, *, instance_id: Any = None, timeout:
         j = {}
     return r.status_code, j
 
+
 class MDBListAuth(AuthProvider):
     name = "MDBLIST"
 
@@ -63,18 +77,25 @@ class MDBListAuth(AuthProvider):
         return AuthManifest(
             name="MDBLIST",
             label="MDBList",
-            flow="api_keys",
+            flow="device_code",
             fields=[
+                {
+                    "key": "mdblist.client_id",
+                    "label": "Client ID",
+                    "type": "text",
+                    "required": False,
+                    "placeholder": "MDBList Device Code client_id",
+                },
                 {
                     "key": "mdblist.api_key",
                     "label": "API Key",
                     "type": "password",
-                    "required": True,
-                    "placeholder": "••••••••",
-                }
+                    "required": False,
+                    "placeholder": "********",
+                },
             ],
-            actions={"start": False, "finish": True, "refresh": False, "disconnect": True},
-            notes="Generate your API key in mdblist.com > Preferences.",
+            actions={"start": True, "finish": True, "refresh": True, "disconnect": True},
+            notes="Device Code is preferred. API key remains available as a legacy option.",
         )
 
     def capabilities(self) -> dict[str, Any]:
@@ -82,34 +103,52 @@ class MDBListAuth(AuthProvider):
 
     def get_status(self, cfg: Mapping[str, Any], *, instance_id: Any = None) -> AuthStatus:
         inst = normalize_instance_id(instance_id)
-        b = _block(cfg, inst)
-        has = bool(str(b.get("api_key") or "").strip())
+        status = mdblist_auth.status_for_block(_block(cfg, inst))
         label = "MDBList" if inst == "default" else f"MDBList ({inst})"
-        return AuthStatus(connected=has, label=label, user=None)
+        return AuthStatus(
+            connected=bool(status.get("connected")),
+            label=label,
+            user=str(status.get("username") or "") or None,
+            expires_at=int(status.get("expires_at") or 0) or None,
+        )
 
     def start(self, cfg: MutableMapping[str, Any] | None = None, *, redirect_uri: str | None = None, instance_id: Any = None) -> dict[str, Any]:
-        return {}
+        cfgd = dict(cfg or _load_config() or {})
+        return mdblist_auth.start_device_code(cfgd, instance_id=instance_id)
 
     def finish(self, cfg: MutableMapping[str, Any] | None = None, *, instance_id: Any = None, **payload: Any) -> AuthStatus:
         cfgd = dict(cfg or _load_config() or {})
         b = ensure_instance_block(cfgd, "mdblist", instance_id)
-        key = str(payload.get("api_key") or payload.get("mdblist.api_key") or "").strip()
-        b["api_key"] = key
+        method = mdblist_auth.normalize_auth_method(payload.get("auth_method") or b.get("auth_method"), b)
+        if method == "api_key":
+            b["api_key"] = str(payload.get("api_key") or payload.get("mdblist.api_key") or "").strip()
+            mdblist_auth.set_active_method(b, "api_key")
+        else:
+            if payload.get("client_id"):
+                b["client_id"] = str(payload.get("client_id") or "").strip()
+            mdblist_auth.set_active_method(b, "device_code")
         save_config(cfgd)
-        log(f"MDBList API key saved (instance={normalize_instance_id(instance_id)}).", module="AUTH")
+        log(f"MDBList auth saved (method={method}, instance={normalize_instance_id(instance_id)}).", module="AUTH")
         return self.get_status(cfgd, instance_id=instance_id)
 
     def refresh(self, cfg: MutableMapping[str, Any], *, instance_id: Any = None) -> AuthStatus:
+        try:
+            mdblist_auth.refresh_token(dict(cfg or _load_config() or {}), instance_id=instance_id)
+        except Exception:
+            pass
         return self.get_status(cfg, instance_id=instance_id)
 
     def disconnect(self, cfg: MutableMapping[str, Any] | None = None, *, instance_id: Any = None) -> AuthStatus:
         cfgd = dict(cfg or _load_config() or {})
         b = ensure_instance_block(cfgd, "mdblist", instance_id)
         b["api_key"] = ""
+        mdblist_auth.clear_oauth(b)
         save_config(cfgd)
         log(f"MDBList disconnected (instance={normalize_instance_id(instance_id)}).", module="AUTH")
         return self.get_status(cfgd, instance_id=instance_id)
 
+
+PROVIDER = MDBListAuth()
 
 
 def html() -> str:
@@ -123,22 +162,24 @@ def html() -> str:
     #sec-mdblist .inline .msg.hidden{display:none}
     #sec-mdblist .btn.danger{ background:#a8182e; border-color:rgba(255,107,107,.4) }
     #sec-mdblist .btn.danger:hover{ filter:brightness(1.08) }
-    
-    /* MDBList Connect  */
-    #sec-mdblist #mdblist_save{
+    #sec-mdblist .mdblist-action-row{display:flex;gap:12px;align-items:stretch}
+    #sec-mdblist .mdblist-action-row input{flex:1 1 auto;min-width:0}
+    #sec-mdblist .mdblist-action-row .btn{flex:0 0 auto;white-space:nowrap;min-height:44px}
+    #sec-mdblist #mdblist_save,#sec-mdblist #mdblist_device_start{
       background: linear-gradient(135deg,#00e084,#2ea859);
       border-color: rgba(0,224,132,.45);
       box-shadow: 0 0 14px rgba(0,224,132,.35);
       color: #fff;
+      min-width: 146px;
     }
-    #sec-mdblist #mdblist_save:hover{
+    #sec-mdblist #mdblist_save:hover,#sec-mdblist #mdblist_device_start:hover{
       filter: brightness(1.06);
       box-shadow: 0 0 18px rgba(0,224,132,.5);
     }
   </style>
 
   <div class="head" onclick="toggleSection && toggleSection('sec-mdblist')">
-    <span class="chev">▶</span><strong>MDBList</strong>
+    <span class="chev">&#9654;</span><strong>MDBList</strong>
   </div>
 
   <div class="body">
@@ -147,7 +188,7 @@ def html() -> str:
         <div class="cw-panel-head">
           <div>
             <div class="cw-panel-title">MDBList</div>
-            <div class="muted">Connect and verify your MDBList API key.</div>
+            <div class="muted">Connect with Device Code or use a legacy API key.</div>
           </div>
         </div>
 
@@ -158,27 +199,64 @@ def html() -> str:
         <div class="cw-subpanels">
           <div class="cw-subpanel active" data-sub="auth">
             <div class="grid2">
-                  <div>
-                    <label for="mdblist_key">API Key</label>
-                    <div style="display:flex;gap:8px">
-                      <input id="mdblist_key" name="mdblist_key" type="password" placeholder="••••••••" />
-                      <button id="mdblist_save" class="btn">Connect</button>
-                    </div>
-                    <div id="mdblist_hint" class="msg warn" style="margin-top:8px">
-                      You need an MDBList API key. Create one at
-                      <a href="https://mdblist.com/preferences/#api" target="_blank" rel="noopener">MDBList Preferences</a>.
-                    </div>
-                  </div>
-            
-                  <div>
-                    <div class="field-label">Status</div>
-                    <div class="inline">
-                      <button id="mdblist_verify" class="btn">Verify</button>
-                      <button id="mdblist_disconnect" class="btn danger">Disconnect</button>
-                      <div id="mdblist_msg" class="msg ok hidden" aria-live="polite"></div>
-                    </div>
+              <div>
+                <label for="mdblist_auth_method">Authentication Method</label>
+                <select id="mdblist_auth_method" name="mdblist_auth_method">
+                  <option value="device_code">Device Code</option>
+                  <option value="api_key">API Key</option>
+                </select>
+              </div>
+              <div id="mdblist_client_id_wrap">
+                <label for="mdblist_client_id">Device Code Client ID</label>
+                <input id="mdblist_client_id" name="mdblist_client_id" placeholder="MDBList app client_id" autocomplete="off" />
+              </div>
+            </div>
+
+            <div id="mdblist_device_panel" style="margin-top:10px">
+              <div class="sep"></div>
+              <div class="grid2">
+                <div>
+                  <div class="field-label">Current token</div>
+                  <div class="mdblist-action-row">
+                    <input id="mdblist_access_token" readonly placeholder="empty = not set" />
+                    <button id="mdblist_copy_token" class="btn copy">Copy</button>
                   </div>
                 </div>
+                <div>
+                  <div class="field-label">Link code (PIN)</div>
+                  <div class="mdblist-action-row">
+                    <input id="mdblist_device_code" readonly placeholder="" />
+                    <button id="mdblist_copy_code" class="btn copy">Copy</button>
+                  </div>
+                </div>
+              </div>
+              <div class="inline" style="margin-top:10px">
+                <button id="mdblist_device_start" class="btn">Connect MDBList</button>
+                <button id="mdblist_disconnect_device" class="btn danger">Delete</button>
+                <div class="sub">A browser window opens so you can enter your code.</div>
+              </div>
+            </div>
+
+            <div id="mdblist_api_panel" style="margin-top:10px">
+              <div class="grid2">
+                <div>
+                  <label for="mdblist_key">API Key</label>
+                  <div class="mdblist-action-row">
+                    <input id="mdblist_key" name="mdblist_key" type="password" placeholder="********" />
+                    <button id="mdblist_save" class="btn">Connect MDBList</button>
+                    <button id="mdblist_disconnect_api" class="btn danger">Delete</button>
+                  </div>
+                  <div id="mdblist_hint" class="msg warn" style="margin-top:8px">
+                    You need an MDBList API key. Create one at
+                    <a href="https://mdblist.com/preferences/#api" target="_blank" rel="noopener">MDBList Preferences</a>.
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="inline" style="margin-top:10px;justify-content:flex-end">
+              <div id="mdblist_msg" class="msg ok hidden" aria-live="polite"></div>
+            </div>
           </div>
         </div>
       </div>

--- a/providers/auth/runtime.py
+++ b/providers/auth/runtime.py
@@ -1,0 +1,70 @@
+# providers/auth/runtime.py
+# Generic runtime authentication dispatch for provider API calls
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
+from typing import Any
+
+import requests
+
+
+def _key(provider: Any) -> str:
+    return str(provider or "").strip().lower().replace("-", "_")
+
+
+def _backend(provider: Any):
+    name = _key(provider)
+    if name in {"mdb", "mdb_list", "mdblist"}:
+        from providers.sync.mdblist import _auth as mdblist_auth
+
+        return mdblist_auth
+    raise NotImplementedError(f"No runtime auth backend for provider: {provider}")
+
+
+def normalize_auth_method(provider: str, value: Any, block: Mapping[str, Any] | None = None) -> str:
+    return _backend(provider).normalize_auth_method(value, block)
+
+
+def active_method(provider: str, block: Mapping[str, Any] | None) -> str:
+    return _backend(provider).active_method(block)
+
+
+def is_configured(provider: str, block: Mapping[str, Any] | None) -> bool:
+    return bool(_backend(provider).is_configured(block))
+
+
+def status_for_block(provider: str, block: Mapping[str, Any] | None) -> dict[str, Any]:
+    return dict(_backend(provider).status_for_block(block))
+
+
+def set_active_method(provider: str, block: MutableMapping[str, Any], method: str) -> str:
+    return str(_backend(provider).set_active_method(block, method))
+
+
+def clear_oauth(provider: str, block: MutableMapping[str, Any]) -> None:
+    _backend(provider).clear_oauth(block)
+
+
+def start_device_code(provider: str, cfg: dict[str, Any] | None, **kwargs: Any) -> dict[str, Any]:
+    return dict(_backend(provider).start_device_code(cfg, **kwargs))
+
+
+def poll_device_code(provider: str, cfg: dict[str, Any] | None, **kwargs: Any) -> dict[str, Any]:
+    return dict(_backend(provider).poll_device_code(cfg, **kwargs))
+
+
+def refresh_token(provider: str, cfg: dict[str, Any] | None = None, **kwargs: Any) -> dict[str, Any]:
+    return dict(_backend(provider).refresh_token(cfg, **kwargs))
+
+
+def request_with_auth(
+    provider: str,
+    session: requests.Session,
+    method: str,
+    url: str,
+    *,
+    cfg: Mapping[str, Any] | None,
+    **kwargs: Any,
+) -> requests.Response:
+    return _backend(provider).request_with_auth(session, method, url, cfg=cfg, **kwargs)

--- a/providers/scrobble/mdblist/sink.py
+++ b/providers/scrobble/mdblist/sink.py
@@ -56,6 +56,12 @@ def _cfg() -> dict[str, Any]:
         return {}
 
 
+def _provider_auth():
+    from providers.auth import runtime as provider_auth
+
+    return provider_auth
+
+
 def _is_debug() -> bool:
     try:
         return bool((_cfg().get("runtime") or {}).get("debug"))
@@ -539,12 +545,19 @@ class MDBListSink(ScrobbleSink):
 
     def _post(self, path: str, body: dict[str, Any], api_key: str, cfg: dict[str, Any]) -> requests.Response:
         headers = {"Accept": "application/json", "Content-Type": "application/json", "User-Agent": APP_AGENT}
-        return requests.post(
+        session = requests.Session()
+        return _provider_auth().request_with_auth(
+            "mdblist",
+            session,
+            "POST",
             f"{MDBLIST_API}{path}",
+            cfg=cfg,
+            instance_id=self._instance_id,
             headers=headers,
             params={"apikey": api_key},
             json=body,
             timeout=_timeout(cfg),
+            max_retries=1,
         )
 
     def _send_http(self, path: str, body: dict[str, Any], api_key: str, cfg: dict[str, Any]) -> dict[str, Any]:
@@ -607,9 +620,9 @@ class MDBListSink(ScrobbleSink):
         m = cfg.get("mdblist") or {}
         api_key = str(m.get("api_key") or "").strip()
 
-        if not api_key:
+        if not _provider_auth().is_configured("mdblist", m):
             if not self._warn_no_key:
-                _log("Missing mdblist.api_key in config.json — skipping scrobble", "ERROR")
+                _log("Missing MDBList authentication in config.json - skipping scrobble", "ERROR")
                 self._warn_no_key = True
             return
 

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -55,6 +55,12 @@ def _cfg(ttl: float = _CFG_TTL_SEC) -> dict[str, Any]:
     return cfg2
 
 
+def _provider_auth():
+    from providers.auth import runtime as provider_auth
+
+    return provider_auth
+
+
 def _is_debug_cfg(cfg: dict[str, Any]) -> bool:
     try:
         v = ((cfg.get("runtime") or {}).get("debug"))
@@ -1586,8 +1592,9 @@ def _simkl_send_rating(media_type: str, ids: dict[str, Any], rating: int, cfg: d
 def _mdblist_send_rating(media_type: str, ids: dict[str, Any], rating: int, cfg: dict[str, Any], logger: Callable[..., None] | None) -> dict[str, Any]:
     md_cfg = (cfg.get("mdblist") or {}) if isinstance(cfg, dict) else {}
     apikey = str(md_cfg.get("api_key") or "").strip()
-    if not apikey:
-        return {"ok": False, "error": "missing_api_key"}
+    provider_auth = _provider_auth()
+    if not provider_auth.is_configured("mdblist", md_cfg):
+        return {"ok": False, "error": "missing_auth"}
     if media_type not in ("movie", "show"):
         return {"ok": True, "ignored": True}
     bucket = "movies" if media_type == "movie" else "shows"
@@ -1616,7 +1623,19 @@ def _mdblist_send_rating(media_type: str, ids: dict[str, Any], rating: int, cfg:
     r: requests.Response | None = None
     for attempt in range(max_retries):
         try:
-            r = requests.post(url, params={"apikey": apikey}, json=body, timeout=tmo)
+            sess = requests.Session()
+            r = provider_auth.request_with_auth(
+                "mdblist",
+                sess,
+                "POST",
+                url,
+                cfg=cfg,
+                instance_id=(cfg.get("scrobble") or {}).get("watch", {}).get("route_sink_instance") if isinstance((cfg.get("scrobble") or {}).get("watch"), Mapping) else None,
+                params={"apikey": apikey},
+                json=body,
+                timeout=tmo,
+                max_retries=1,
+            )
         except Exception as e:
             if attempt >= max_retries - 1:
                 _emit(logger, f"mdblist rating request failed: {type(e).__name__}: {e}", "ERROR")

--- a/providers/sync/_mod_MDBLIST.py
+++ b/providers/sync/_mod_MDBLIST.py
@@ -12,6 +12,7 @@ from cw_platform.id_map import canonical_key, minimal as id_minimal
 
 from ._log import log as cw_log
 from .mdblist._common import read_json as mdblist_read_json, state_file as mdblist_state_file, write_json as mdblist_write_json
+from .mdblist import _auth as mdblist_auth
 
 from ._mod_common import (
     HitSession,
@@ -201,6 +202,7 @@ def get_manifest() -> Mapping[str, Any]:
 @dataclass
 class MDBLISTConfig:
     api_key: str
+    auth_method: str = "device_code"
     timeout: float = 15.0
     max_retries: int = 3
     rate_get_per_sec: float = 10.0
@@ -215,12 +217,23 @@ class MDBLISTAuthError(MDBLISTError):
     pass
 
 
+def _pick_instance_id() -> str:
+    src_p = str(os.getenv("CW_PAIR_SRC") or "").upper().strip()
+    dst_p = str(os.getenv("CW_PAIR_DST") or "").upper().strip()
+    if src_p == "MDBLIST":
+        return str(os.getenv("CW_PAIR_SRC_INSTANCE") or "default").strip() or "default"
+    if dst_p == "MDBLIST":
+        return str(os.getenv("CW_PAIR_DST_INSTANCE") or "default").strip() or "default"
+    return str(os.getenv("CW_PROVIDER_INSTANCE") or os.getenv("CW_INSTANCE_ID") or "default").strip() or "default"
+
+
 class MDBLISTClient:
     BASE = "https://api.mdblist.com"
 
-    def __init__(self, cfg: MDBLISTConfig, raw_cfg: Mapping[str, Any]):
+    def __init__(self, cfg: MDBLISTConfig, raw_cfg: Mapping[str, Any], *, instance_id: Any = None):
         self.cfg = cfg
         self.raw_cfg = raw_cfg
+        self.instance_id = mdblist_auth.normalize_instance_id_value(instance_id)
         self.session: HitSession = build_session("MDBLIST", ctx, feature_label=_label_mdblist)
 
         try:
@@ -238,8 +251,8 @@ class MDBLISTClient:
             pass
 
     def connect(self) -> MDBLISTClient:
-        if not self.cfg.api_key:
-            raise MDBLISTAuthError("Missing MDBList api_key")
+        if not mdblist_auth.is_configured(mdblist_auth.provider_block(self.raw_cfg, self.instance_id)):
+            raise MDBLISTAuthError("Missing MDBList authentication")
         try:
             self.session.trust_env = False
         except Exception:
@@ -252,22 +265,30 @@ class MDBLISTClient:
         return self
 
     def get(self, url: str, **kw: Any):
-        return request_with_retries(
+        timeout = float(kw.pop("timeout", self.cfg.timeout))
+        max_retries = int(kw.pop("max_retries", self.cfg.max_retries))
+        return mdblist_auth.request_with_auth(
             self.session,
             "GET",
             url,
-            timeout=self.cfg.timeout,
-            max_retries=self.cfg.max_retries,
+            cfg=self.raw_cfg,
+            instance_id=self.instance_id,
+            timeout=timeout,
+            max_retries=max_retries,
             **kw,
         )
 
     def post(self, url: str, **kw: Any):
-        return request_with_retries(
+        timeout = float(kw.pop("timeout", self.cfg.timeout))
+        max_retries = int(kw.pop("max_retries", self.cfg.max_retries))
+        return mdblist_auth.request_with_auth(
             self.session,
             "POST",
             url,
-            timeout=self.cfg.timeout,
-            max_retries=self.cfg.max_retries,
+            cfg=self.raw_cfg,
+            instance_id=self.instance_id,
+            timeout=timeout,
+            max_retries=max_retries,
             **kw,
         )
 
@@ -306,6 +327,7 @@ class MDBLISTClient:
 class MDBLISTModule:
     def __init__(self, cfg: Mapping[str, Any]):
         m = dict(cfg.get("mdblist") or {})
+        self.instance_id = _pick_instance_id()
         rl = m.get("rate_limit")
         if not isinstance(rl, dict):
             rl = {}
@@ -320,18 +342,19 @@ class MDBLISTModule:
 
         self.cfg = MDBLISTConfig(
             api_key=str(m.get("api_key") or "").strip(),
+            auth_method=mdblist_auth.active_method(m),
             timeout=float(m.get("timeout", cfg.get("timeout", 15.0))),
             max_retries=int(m.get("max_retries", cfg.get("max_retries", 3))),
             rate_get_per_sec=get_rps,
             rate_post_per_sec=post_rps,
         )
-        if not self.cfg.api_key:
-            raise MDBLISTAuthError("Missing MDBList api_key")
+        if not mdblist_auth.is_configured(m):
+            raise MDBLISTAuthError("Missing MDBList authentication")
 
         if m.get("debug") in (True, "1", 1):
             os.environ.setdefault("CW_MDBLIST_DEBUG", "1")
 
-        self.client = MDBLISTClient(self.cfg, cfg).connect()
+        self.client = MDBLISTClient(self.cfg, cfg, instance_id=self.instance_id).connect()
         self.raw_cfg = cfg
         self.config = cfg
 
@@ -391,9 +414,7 @@ class MDBLISTModule:
         user_err: str | None = None
         user_reason: str | None = None
         try:
-            r = request_with_retries(
-                sess,
-                "GET",
+            r = self.client.get(
                 f"{base}/user",
                 params={"apikey": self.cfg.api_key},
                 timeout=tmo,
@@ -720,12 +741,11 @@ class _MDBLISTOPS:
         try:
             c = cfg or {}
             m = c.get("mdblist") or {}
-            apikey = str(m.get("api_key") or m.get("apikey") or "").strip()
-            if not apikey:
+            if not mdblist_auth.is_configured(m):
                 return {}
 
             now = time.time()
-            memo_key = apikey[-6:] if len(apikey) >= 6 else apikey
+            memo_key = str(m.get("auth_method") or "") + ":" + str(m.get("api_key") or m.get("access_token") or "")[-6:]
             ent = self._acts_memo.get(memo_key)
             if ent and (now - float(ent[0])) < 10.0:
                 return dict(ent[1])
@@ -763,11 +783,13 @@ class _MDBLISTOPS:
             except Exception:
                 pass
 
-            r = request_with_retries(
+            r = mdblist_auth.request_with_auth(
                 sess,
                 "GET",
                 f"{MDBLISTClient.BASE}/sync/last_activities",
-                params={"apikey": apikey},
+                cfg=c,
+                instance_id=_pick_instance_id(),
+                params={"apikey": str(m.get("api_key") or "").strip()},
                 timeout=8.0,
                 max_retries=1,
             )
@@ -815,8 +837,7 @@ class _MDBLISTOPS:
     def is_configured(self, cfg: Mapping[str, Any]) -> bool:
         c = cfg or {}
         m = c.get("mdblist") or {}
-        key = m.get("api_key") or m.get("apikey") or ""
-        return bool(str(key).strip())
+        return mdblist_auth.is_configured(m)
 
     def _adapter(self, cfg: Mapping[str, Any]) -> MDBLISTModule:
         return MDBLISTModule(cfg)

--- a/providers/sync/mdblist/_auth.py
+++ b/providers/sync/mdblist/_auth.py
@@ -1,0 +1,441 @@
+# /providers/sync/mdblist/_auth.py
+# Shared MDBList authentication helpers
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping, MutableMapping
+from typing import Any
+
+import requests
+
+from cw_platform.config_base import load_config, save_config
+from cw_platform.provider_instances import ensure_instance_block, get_provider_block, normalize_instance_id
+
+API_BASE = "https://api.mdblist.com"
+OAUTH_TOKEN_URL = f"{API_BASE}/oauth/token/"
+OAUTH_DEVICE_URL = f"{API_BASE}/oauth/device-authorization/"
+VERIFY_URL = "https://mdblist.com/oauth/device/"
+SCOPE = "write"
+REFRESH_SKEW_SEC = 300
+UA = "CrossWatch/MDBListAuth"
+
+
+class MDBListAuthError(RuntimeError):
+    pass
+
+
+def now() -> int:
+    return int(time.time())
+
+
+def normalize_auth_method(value: Any, block: Mapping[str, Any] | None = None) -> str:
+    b = block or {}
+    has_api_key = bool(str(b.get("api_key") or b.get("key") or "").strip())
+    has_oauth = bool(str(b.get("access_token") or "").strip() or str(b.get("refresh_token") or "").strip())
+    if has_api_key and not has_oauth:
+        return "api_key"
+    if has_oauth:
+        return "device_code"
+
+    raw = str(value or "").strip().lower().replace("-", "_")
+    if raw in {"api", "apikey", "api_key", "key"}:
+        return "api_key"
+    if raw in {"device", "device_code", "oauth", "oauth_device", "bearer"}:
+        return "device_code"
+    return "device_code"
+
+
+def normalize_instance_id_value(instance_id: Any = None) -> str:
+    return normalize_instance_id(instance_id)
+
+
+def provider_block(cfg: Mapping[str, Any] | None, instance_id: Any = None) -> dict[str, Any]:
+    out = get_provider_block(cfg or {}, "mdblist", instance_id)
+    if out:
+        return out
+
+    base = (cfg or {}).get("mdblist") if isinstance(cfg, Mapping) else None
+    return dict(base or {}) if isinstance(base, Mapping) else {}
+
+
+def writable_block(cfg: dict[str, Any], instance_id: Any = None) -> dict[str, Any]:
+    return ensure_instance_block(cfg, "mdblist", instance_id)
+
+
+def active_method(block: Mapping[str, Any] | None) -> str:
+    b = block or {}
+    return normalize_auth_method(b.get("auth_method"), b)
+
+
+def set_active_method(block: MutableMapping[str, Any], method: str) -> str:
+    m = normalize_auth_method(method, block)
+    block["auth_method"] = m
+    if m == "api_key":
+        clear_oauth(block)
+    elif str(block.get("access_token") or "").strip() or str(block.get("refresh_token") or "").strip():
+        block["api_key"] = ""
+    return m
+
+
+def clear_oauth(block: MutableMapping[str, Any]) -> None:
+    for key in (
+        "access_token",
+        "refresh_token",
+        "token_type",
+        "scope",
+        "expires_at",
+        "username",
+        "user_id",
+        "_pending_device",
+    ):
+        if key in block:
+            if key == "expires_at":
+                block[key] = 0
+            elif key == "_pending_device":
+                block.pop(key, None)
+            else:
+                block[key] = ""
+
+
+def clear_api_key(block: MutableMapping[str, Any]) -> None:
+    block["api_key"] = ""
+
+
+def is_configured(block: Mapping[str, Any] | None) -> bool:
+    b = block or {}
+    if active_method(b) == "api_key":
+        return bool(str(b.get("api_key") or b.get("key") or "").strip())
+    return bool(str(b.get("access_token") or "").strip() and str(b.get("client_id") or "").strip())
+
+
+def status_for_block(block: Mapping[str, Any] | None) -> dict[str, Any]:
+    b = block or {}
+    method = active_method(b)
+    out: dict[str, Any] = {
+        "auth_method": method,
+        "connected": is_configured(b),
+        "api_key_configured": bool(str(b.get("api_key") or b.get("key") or "").strip()),
+        "device_configured": bool(str(b.get("access_token") or "").strip()),
+        "client_id_configured": bool(str(b.get("client_id") or "").strip()),
+        "expires_at": int(b.get("expires_at") or 0) if method == "device_code" else 0,
+        "username": str(b.get("username") or ""),
+    }
+    pend = b.get("_pending_device")
+    if isinstance(pend, Mapping):
+        out["pending"] = {
+            "user_code": str(pend.get("user_code") or ""),
+            "verification_uri": str(pend.get("verification_uri") or pend.get("verification_url") or VERIFY_URL),
+            "expires_at": int(pend.get("expires_at") or 0),
+            "interval": int(pend.get("interval") or 5),
+        }
+    return out
+
+
+def about_to_expire(block: Mapping[str, Any], skew_sec: int = REFRESH_SKEW_SEC) -> bool:
+    exp = int(block.get("expires_at") or 0)
+    return bool(exp and exp - now() <= max(0, int(skew_sec)))
+
+
+def _load_full_cfg() -> dict[str, Any]:
+    try:
+        cfg = load_config() or {}
+        return cfg if isinstance(cfg, dict) else dict(cfg)
+    except Exception:
+        return {}
+
+
+def _save_full_cfg(cfg: dict[str, Any]) -> None:
+    save_config(cfg)
+
+
+def _copy_token_fields(dst: MutableMapping[str, Any], src: Mapping[str, Any]) -> None:
+    for key in ("access_token", "refresh_token", "token_type", "scope", "expires_at", "username", "user_id"):
+        if key in src:
+            dst[key] = src.get(key)
+
+
+def start_device_code(
+    cfg: dict[str, Any] | None,
+    *,
+    instance_id: Any = None,
+    client_id: str | None = None,
+    scope: str = SCOPE,
+    timeout: float = 20.0,
+) -> dict[str, Any]:
+    cfgd = cfg if isinstance(cfg, dict) else _load_full_cfg()
+    inst = normalize_instance_id(instance_id)
+    block = writable_block(cfgd, inst)
+    cid = str(client_id or block.get("client_id") or "").strip()
+    if not cid:
+        return {"ok": False, "error": "missing_client_id", "instance": inst}
+
+    block["client_id"] = cid
+    set_active_method(block, "device_code")
+
+    try:
+        r = requests.post(
+            OAUTH_DEVICE_URL,
+            data={"client_id": cid, "scope": scope or SCOPE},
+            headers={"Accept": "application/json", "User-Agent": UA},
+            timeout=timeout,
+        )
+    except requests.RequestException as e:
+        return {"ok": False, "error": "network_error", "detail": str(e), "instance": inst}
+
+    if r.status_code >= 400:
+        return {"ok": False, "error": "http_error", "status": int(r.status_code), "body": (r.text or "")[:400], "instance": inst}
+
+    try:
+        data: dict[str, Any] = r.json() or {}
+    except ValueError:
+        return {"ok": False, "error": "invalid_json", "body": (r.text or "")[:400], "instance": inst}
+
+    device_code = str(data.get("device_code") or "").strip()
+    user_code = str(data.get("user_code") or "").strip()
+    verification_uri = str(data.get("verification_uri") or data.get("verification_url") or VERIFY_URL).strip() or VERIFY_URL
+    interval = int(data.get("interval") or 5)
+    expires_at = now() + int(data.get("expires_in") or 300)
+    if not device_code or not user_code:
+        return {"ok": False, "error": "invalid_response", "body": (r.text or "")[:400], "instance": inst}
+
+    block["_pending_device"] = {
+        "device_code": device_code,
+        "user_code": user_code,
+        "verification_uri": verification_uri,
+        "interval": interval,
+        "expires_at": expires_at,
+        "created_at": now(),
+    }
+    _save_full_cfg(cfgd)
+    return {
+        "ok": True,
+        "instance": inst,
+        "device_code": device_code,
+        "user_code": user_code,
+        "verification_uri": verification_uri,
+        "interval": interval,
+        "expires_at": expires_at,
+    }
+
+
+def poll_device_code(
+    cfg: dict[str, Any] | None,
+    *,
+    instance_id: Any = None,
+    device_code: str | None = None,
+    timeout: float = 20.0,
+) -> dict[str, Any]:
+    cfgd = cfg if isinstance(cfg, dict) else _load_full_cfg()
+    inst = normalize_instance_id(instance_id)
+    block = writable_block(cfgd, inst)
+    cid = str(block.get("client_id") or "").strip()
+    pend = block.get("_pending_device") if isinstance(block.get("_pending_device"), Mapping) else {}
+    dc = str(device_code or (pend or {}).get("device_code") or "").strip()
+    if not cid:
+        return {"ok": False, "status": "missing_client_id", "instance": inst}
+    if not dc:
+        return {"ok": False, "status": "no_device_code", "instance": inst}
+    if int((pend or {}).get("expires_at") or 0) and now() >= int((pend or {}).get("expires_at") or 0):
+        return {"ok": False, "status": "expired_token", "instance": inst}
+
+    try:
+        r = requests.post(
+            OAUTH_TOKEN_URL,
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": dc,
+                "client_id": cid,
+            },
+            headers={"Accept": "application/json", "User-Agent": UA},
+            timeout=timeout,
+        )
+    except requests.RequestException as e:
+        return {"ok": False, "status": "network_error", "error": str(e), "instance": inst}
+
+    if r.status_code in (400, 401, 403):
+        try:
+            err = str((r.json() or {}).get("error") or "authorization_pending")
+        except Exception:
+            err = "authorization_pending"
+        return {"ok": False, "status": err, "instance": inst}
+    if r.status_code >= 400:
+        return {"ok": False, "status": f"http:{r.status_code}", "body": (r.text or "")[:400], "instance": inst}
+
+    try:
+        tok: dict[str, Any] = r.json() or {}
+    except ValueError:
+        return {"ok": False, "status": "bad_json", "instance": inst}
+
+    access_token = str(tok.get("access_token") or "").strip()
+    if not access_token:
+        return {"ok": False, "status": "no_access_token", "instance": inst}
+
+    block.update(
+        {
+            "auth_method": "device_code",
+            "api_key": "",
+            "access_token": access_token,
+            "refresh_token": str(tok.get("refresh_token") or block.get("refresh_token") or "").strip(),
+            "token_type": str(tok.get("token_type") or "Bearer").strip() or "Bearer",
+            "scope": str(tok.get("scope") or SCOPE).strip() or SCOPE,
+            "expires_at": now() + int(tok.get("expires_in") or 0),
+        }
+    )
+    block.pop("_pending_device", None)
+    _save_full_cfg(cfgd)
+    return {"ok": True, "status": "ok", "instance": inst, "expires_at": int(block.get("expires_at") or 0)}
+
+
+def refresh_token(
+    cfg: dict[str, Any] | None = None,
+    *,
+    instance_id: Any = None,
+    update_cfg: dict[str, Any] | None = None,
+    timeout: float = 20.0,
+) -> dict[str, Any]:
+    full = _load_full_cfg()
+    inst = normalize_instance_id(instance_id)
+    block = writable_block(full, inst)
+    cid = str(block.get("client_id") or "").strip()
+    rt = str(block.get("refresh_token") or "").strip()
+    if not cid and isinstance(cfg, Mapping):
+        cid = str(provider_block(cfg, inst).get("client_id") or "").strip()
+    if not rt and isinstance(cfg, Mapping):
+        rt = str(provider_block(cfg, inst).get("refresh_token") or "").strip()
+    if not cid or not rt:
+        return {"ok": False, "status": "missing_refresh", "instance": inst}
+
+    try:
+        r = requests.post(
+            OAUTH_TOKEN_URL,
+            data={"grant_type": "refresh_token", "refresh_token": rt, "client_id": cid},
+            headers={"Accept": "application/json", "User-Agent": UA},
+            timeout=timeout,
+        )
+    except requests.RequestException as e:
+        return {"ok": False, "status": "network_error", "error": str(e), "instance": inst}
+
+    if r.status_code >= 400:
+        err = ""
+        try:
+            body = r.json() or {}
+            err = str(body.get("error") or body.get("error_description") or "")
+        except Exception:
+            err = (r.text or "")[:400]
+        return {"ok": False, "status": f"refresh_failed:{r.status_code}", "error": err, "instance": inst}
+
+    try:
+        tok: dict[str, Any] = r.json() or {}
+    except ValueError:
+        return {"ok": False, "status": "bad_json", "instance": inst}
+
+    access_token = str(tok.get("access_token") or "").strip()
+    if not access_token:
+        return {"ok": False, "status": "no_access_token", "instance": inst}
+
+    block.update(
+        {
+            "auth_method": "device_code",
+            "api_key": "",
+            "client_id": cid,
+            "access_token": access_token,
+            "refresh_token": str(tok.get("refresh_token") or rt).strip(),
+            "token_type": str(tok.get("token_type") or block.get("token_type") or "Bearer").strip() or "Bearer",
+            "scope": str(tok.get("scope") or block.get("scope") or SCOPE).strip() or SCOPE,
+            "expires_at": now() + int(tok.get("expires_in") or 0),
+        }
+    )
+    _save_full_cfg(full)
+
+    for target in (cfg, update_cfg):
+        if isinstance(target, dict):
+            try:
+                _copy_token_fields(writable_block(target, inst), block)
+            except Exception:
+                try:
+                    md = target.get("mdblist")
+                    if isinstance(md, dict):
+                        _copy_token_fields(md, block)
+                except Exception:
+                    pass
+
+    return {"ok": True, "status": "ok", "instance": inst, "expires_at": int(block.get("expires_at") or 0)}
+
+
+def prepare_auth(
+    cfg: Mapping[str, Any] | None,
+    *,
+    instance_id: Any = None,
+    refresh: bool = True,
+) -> tuple[dict[str, str], dict[str, Any]]:
+    inst = normalize_instance_id(instance_id)
+    block = provider_block(cfg, inst)
+    method = active_method(block)
+    if method == "api_key":
+        api_key = str(block.get("api_key") or block.get("key") or "").strip()
+        if not api_key:
+            raise MDBListAuthError("missing_api_key")
+        return {}, {"apikey": api_key}
+
+    if refresh and (not str(block.get("access_token") or "").strip() or about_to_expire(block)):
+        res = refresh_token(dict(cfg or {}), instance_id=inst)
+        if not res.get("ok"):
+            raise MDBListAuthError(str(res.get("status") or "refresh_failed"))
+        block = provider_block(_load_full_cfg(), inst)
+
+    token = str(block.get("access_token") or "").strip()
+    if not token:
+        raise MDBListAuthError("missing_access_token")
+    return {"Authorization": f"Bearer {token}"}, {}
+
+
+def merge_auth_kwargs(
+    cfg: Mapping[str, Any] | None,
+    *,
+    instance_id: Any = None,
+    kwargs: dict[str, Any] | None = None,
+    refresh: bool = True,
+) -> dict[str, Any]:
+    out = dict(kwargs or {})
+    params = dict(out.get("params") or {})
+    params.pop("apikey", None)
+    headers = dict(out.get("headers") or {})
+    auth_headers, auth_params = prepare_auth(cfg, instance_id=instance_id, refresh=refresh)
+    params.update(auth_params)
+    headers.update(auth_headers)
+    if params:
+        out["params"] = params
+    elif "params" in out:
+        out.pop("params", None)
+    if headers:
+        out["headers"] = headers
+    return out
+
+
+def request_with_auth(
+    session: requests.Session,
+    method: str,
+    url: str,
+    *,
+    cfg: Mapping[str, Any] | None,
+    instance_id: Any = None,
+    timeout: float = 10.0,
+    max_retries: int = 3,
+    request_func: Any = None,
+    **kwargs: Any,
+) -> requests.Response:
+    from providers.sync._mod_common import request_with_retries
+
+    call = request_func or request_with_retries
+    req_kwargs = merge_auth_kwargs(cfg, instance_id=instance_id, kwargs=kwargs)
+    resp = call(session, method, url, timeout=timeout, max_retries=max_retries, **req_kwargs)
+    if getattr(resp, "status_code", None) != 401 or active_method(provider_block(cfg, instance_id)) != "device_code":
+        return resp
+
+    res = refresh_token(dict(cfg or {}), instance_id=instance_id)
+    if not res.get("ok"):
+        return resp
+    fresh_cfg = _load_full_cfg()
+    req_kwargs = merge_auth_kwargs(fresh_cfg, instance_id=instance_id, kwargs=kwargs, refresh=False)
+    return call(session, method, url, timeout=timeout, max_retries=max_retries, **req_kwargs)

--- a/providers/sync/mdblist/_common.py
+++ b/providers/sync/mdblist/_common.py
@@ -10,7 +10,11 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping, TypeGuard
 
+import requests
+
 from .._log import log as cw_log
+from ._auth import is_configured as auth_configured
+from ._auth import request_with_auth as mdblist_request_with_auth
 
 STATE_DIR = Path("/config/.cw_state")
 WATERMARK_PATH = STATE_DIR / "mdblist.watermarks.json"
@@ -78,6 +82,35 @@ def cfg_section(adapter: Any) -> Mapping[str, Any]:
     except Exception:
         pass
     return {}
+
+
+def instance_id(adapter: Any) -> str | None:
+    inst = getattr(adapter, "instance_id", None)
+    if inst:
+        return str(inst)
+    return None
+
+
+def has_auth(data: Mapping[str, Any]) -> bool:
+    return auth_configured(data)
+
+
+def mdblist_request(adapter: Any, method: str, url: str, **kwargs: Any):
+    cfg = getattr(adapter, "config", None) or getattr(adapter, "raw_cfg", None) or {}
+    client = getattr(adapter, "client", None)
+    session = getattr(client, "session", None) or requests.Session()
+    timeout = kwargs.pop("timeout", getattr(getattr(adapter, "cfg", None), "timeout", 10.0))
+    retries = kwargs.pop("max_retries", getattr(getattr(adapter, "cfg", None), "max_retries", 3))
+    return mdblist_request_with_auth(
+        session,
+        method,
+        url,
+        cfg=cfg,
+        instance_id=instance_id(adapter),
+        timeout=timeout,
+        max_retries=retries,
+        **kwargs,
+    )
 
 
 def cfg_int(data: Mapping[str, Any], key: str, default: int) -> int:

--- a/providers/sync/mdblist/_history.py
+++ b/providers/sync/mdblist/_history.py
@@ -26,8 +26,10 @@ from ._common import (
     cfg_int,
     cfg_section,
     get_watermark,
+    has_auth,
     iso_ok,
     iso_z,
+    mdblist_request,
     max_iso,
     now_iso,
     read_json,
@@ -211,8 +213,8 @@ def _fetch_last_activities(adapter: Any, *, timeout: float, retries: int) -> dic
 
     sess = adapter.client.session
     try:
-        r = request_with_retries(
-            sess,
+        r = mdblist_request(
+            adapter,
             "GET",
             URL_LAST_ACTIVITIES,
             params={"apikey": apikey},
@@ -668,12 +670,12 @@ def build_index(
     }
 
     apikey = str(cfg.get("api_key") or "").strip()
-    if not apikey:
+    if not has_auth(cfg):
         if cached:
-            _dbg("index_cache_hit", source="cache", reason="missing_api_key", count=len(cached))
+            _dbg("index_cache_hit", source="cache", reason="missing_auth", count=len(cached))
             _info("index_done", count=len(cached), source="cache")
         else:
-            _dbg("index_reconcile", reason="missing_api_key", strategy="empty")
+            _dbg("index_reconcile", reason="missing_auth", strategy="empty")
             _info("index_done", count=0, source="empty")
         return cached
 
@@ -784,8 +786,8 @@ def build_index(
         if since_req:
             params["since"] = since_req
         try:
-            r = request_with_retries(
-                sess,
+            r = mdblist_request(
+                adapter,
                 "GET",
                 URL_LIST,
                 params=params,
@@ -1103,9 +1105,9 @@ def _write(
     cfg = _cfg(adapter)
     apikey = str(cfg.get("api_key") or "").strip()
     items_list = list(items or [])
-    if not apikey:
-        unresolved = [{"item": id_minimal(it), "hint": "missing_api_key"} for it in items_list]
-        _info("write_skipped", op="remove" if unwatch else "add", reason="missing_api_key", unresolved=len(unresolved))
+    if not has_auth(cfg):
+        unresolved = [{"item": id_minimal(it), "hint": "missing_auth"} for it in items_list]
+        _info("write_skipped", op="remove" if unwatch else "add", reason="missing_auth", unresolved=len(unresolved))
         return 0, unresolved
 
     sess = adapter.client.session
@@ -1185,8 +1187,8 @@ def _write(
             backoff = delay_ms
 
             while True:
-                r = request_with_retries(
-                    sess,
+                r = mdblist_request(
+                    adapter,
                     "POST",
                     url,
                     params={"apikey": apikey},
@@ -1248,8 +1250,8 @@ def _write(
                     )
 
                     for single in part:
-                        r2 = request_with_retries(
-                            sess,
+                        r2 = mdblist_request(
+                            adapter,
                             "POST",
                             url,
                             params={"apikey": apikey},

--- a/providers/sync/mdblist/_ratings.py
+++ b/providers/sync/mdblist/_ratings.py
@@ -26,8 +26,10 @@ from ._common import (
     cfg_section,
     coalesce_since,
     get_watermark,
+    has_auth,
     iso_ok,
     iso_z,
+    mdblist_request,
     max_iso,
     now_iso,
     read_json,
@@ -168,8 +170,8 @@ def _fetch_last_activities(adapter: Any, *, apikey: str, timeout: float, retries
             pass
         return None
     try:
-        r = request_with_retries(
-            adapter.client.session,
+        r = mdblist_request(
+            adapter,
             "GET",
             URL_LAST_ACTIVITIES,
             params={"apikey": apikey},
@@ -616,12 +618,12 @@ def build_index(
     apikey = str(cfg.get("api_key") or "").strip()
     cached = _load_cache()
 
-    if not apikey:
+    if not has_auth(cfg):
         source = "cache" if cached else "empty"
         if cached:
-            _dbg("index_cache_hit", source=source, reason="missing_api_key", count=len(cached))
+            _dbg("index_cache_hit", source=source, reason="missing_auth", count=len(cached))
         else:
-            _dbg("index_reconcile", reason="missing_api_key", strategy="empty")
+            _dbg("index_reconcile", reason="missing_auth", strategy="empty")
         _info("index_done", count=len(cached), source=source)
         return dict(cached) if cached else {}
 
@@ -716,8 +718,8 @@ def build_index(
 
     _dbg("index_reconcile", reason="delta_fetch", strategy="delta", since=since_req, per_page=per_page, max_pages=max_pages, timeout=timeout, retries=retries)
     while True:
-        r = request_with_retries(
-            sess,
+        r = mdblist_request(
+            adapter,
             "GET",
             URL_LIST,
             params={"apikey": apikey, "offset": offset, "limit": per_page, "since": since_req},
@@ -1085,9 +1087,9 @@ def _write(
     cfg = _cfg(adapter)
     apikey = str(cfg.get("api_key") or "").strip()
     items_list = list(items or [])
-    if not apikey:
-        unresolved = [{"item": id_minimal(it), "hint": "missing_api_key"} for it in items_list]
-        _info("write_skipped", op="remove" if unrate else "add", reason="missing_api_key", unresolved=len(unresolved))
+    if not has_auth(cfg):
+        unresolved = [{"item": id_minimal(it), "hint": "missing_auth"} for it in items_list]
+        _info("write_skipped", op="remove" if unrate else "add", reason="missing_auth", unresolved=len(unresolved))
         return 0, unresolved
 
     sess = adapter.client.session
@@ -1135,8 +1137,8 @@ def _write(
             backoff = delay_ms
 
             while True:
-                r = request_with_retries(
-                    sess,
+                r = mdblist_request(
+                    adapter,
                     "POST",
                     url,
                     params={"apikey": apikey},

--- a/providers/sync/mdblist/_watchlist.py
+++ b/providers/sync/mdblist/_watchlist.py
@@ -22,8 +22,10 @@ from ._common import (
     cfg_int,
     cfg_section,
     get_watermark,
+    has_auth,
     iso_ok,
     iso_z,
+    mdblist_request,
     now_iso,
     read_json,
     save_watermark,
@@ -154,8 +156,8 @@ def _fetch_last_activities(adapter: Any, *, apikey: str, timeout: float, retries
             pass
         return None
     try:
-        r = request_with_retries(
-            adapter.client.session,
+        r = mdblist_request(
+            adapter,
             "GET",
             URL_LAST_ACTIVITIES,
             params={"apikey": apikey},
@@ -377,8 +379,8 @@ def _parse_rows_and_total(data: Any) -> tuple[list[Mapping[str, Any]], int | Non
 
 def _peek_live(adapter: Any, apikey: str, timeout: float, retries: int) -> tuple[str | None, int | None]:
     try:
-        r = request_with_retries(
-            adapter.client.session,
+        r = mdblist_request(
+            adapter,
             "GET",
             URL_LIST,
             params={"apikey": apikey, "limit": 1, "offset": 0, "unified": "true"},
@@ -407,12 +409,12 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
     apikey = _as_str(cfg.get("api_key")) or ""
     shadow = _shadow_load()
     cached: dict[str, dict[str, Any]] = dict(shadow.get("items") or {})
-    if not apikey:
+    if not has_auth(cfg):
         if cached:
-            _dbg("index_cache_hit", source="shadow", reason="missing_api_key", count=len(cached))
+            _dbg("index_cache_hit", source="shadow", reason="missing_auth", count=len(cached))
             _info("index_done", count=len(cached), source="shadow")
         else:
-            _dbg("index_reconcile", reason="missing_api_key", strategy="empty")
+            _dbg("index_reconcile", reason="missing_auth", strategy="empty")
             _info("index_done", count=0, source="empty")
         return cached
 
@@ -472,7 +474,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
 
     while True:
         params = {"apikey": apikey, "limit": limit, "offset": offset, "unified": "true"}
-        r = request_with_retries(sess, "GET", URL_LIST, params=params, timeout=timeout, max_retries=retries)
+        r = mdblist_request(adapter, "GET", URL_LIST, params=params, timeout=timeout, max_retries=retries)
         if r.status_code != 200:
             _warn("http_failed", op="index", method="GET", url=URL_LIST, status=r.status_code, offset=offset)
             break
@@ -617,9 +619,9 @@ def _write(adapter: Any, action: str, items: Iterable[Mapping[str, Any]]) -> tup
     cfg = _cfg(adapter)
     apikey = _as_str(cfg.get("api_key")) or ""
     items_list = list(items or [])
-    if not apikey:
-        unresolved = [{"item": id_minimal(it), "hint": "missing_api_key"} for it in items_list]
-        _info("write_skipped", op=action, reason="missing_api_key", unresolved=len(unresolved))
+    if not has_auth(cfg):
+        unresolved = [{"item": id_minimal(it), "hint": "missing_auth"} for it in items_list]
+        _info("write_skipped", op=action, reason="missing_auth", unresolved=len(unresolved))
         return 0, unresolved
 
     batch = _cfg_int(cfg, "watchlist_batch_size", 100)
@@ -640,8 +642,8 @@ def _write(adapter: Any, action: str, items: Iterable[Mapping[str, Any]]) -> tup
                 unresolved.append({"item": minimal, "hint": "missing_write_ids"})
             continue
 
-        r = request_with_retries(
-            sess,
+        r = mdblist_request(
+            adapter,
             "POST",
             URL_MODIFY.format(action=action),
             params={"apikey": apikey},

--- a/services/watchlist.py
+++ b/services/watchlist.py
@@ -7,9 +7,9 @@ import json
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
+from urllib.parse import urlencode
 
 import requests
-from urllib.parse import urlencode
 
 from cw_platform.config_base import CONFIG
 from cw_platform.modules_registry import MODULES as MR_MODULES, load_sync_ops
@@ -1319,12 +1319,19 @@ def _delete_on_plex_batch(
 _MDBLIST_REMOVE = "https://api.mdblist.com/watchlist/items/remove"
 
 
+def _provider_auth():
+    from providers.auth import runtime as provider_auth
+
+    return provider_auth
+
+
 def _delete_on_mdblist_batch(
     items: list[dict[str, Any]],
     cfg: dict[str, Any],
 ) -> None:
-    api_key = (cfg.get("api_key") or cfg.get("apikey") or "").strip()
-    if not api_key:
+    md_cfg = (cfg.get("mdblist") or cfg) if isinstance(cfg, dict) else {}
+    provider_auth = _provider_auth()
+    if not provider_auth.is_configured("mdblist", md_cfg):
         raise RuntimeError("MDBLIST not configured")
     payload: dict[str, list[dict[str, Any]]] = {"movies": [], "shows": []}
     for it in items or []:
@@ -1353,8 +1360,19 @@ def _delete_on_mdblist_batch(
     payload = {k: v for k, v in payload.items() if v}
     if not payload:
         raise RuntimeError("MDBLIST delete: no resolvable IDs")
-    url = f"{_MDBLIST_REMOVE}?{urlencode({'apikey': api_key})}"
-    r = requests.post(url, json=payload, timeout=45)
+    session = requests.Session()
+    cfg_full = cfg if isinstance(cfg.get("mdblist"), dict) else {"mdblist": md_cfg}
+    r = provider_auth.request_with_auth(
+        "mdblist",
+        session,
+        "POST",
+        _MDBLIST_REMOVE,
+        cfg=cfg_full,
+        params={"apikey": str(md_cfg.get("api_key") or md_cfg.get("apikey") or "").strip()},
+        json=payload,
+        timeout=45,
+        max_retries=1,
+    )
     if not r.ok:
         raise RuntimeError(
             f"MDBLIST delete failed: {getattr(r, 'text', 'no response')}"
@@ -1464,7 +1482,7 @@ def delete_watchlist_batch(
             _delete_on_emby_batch(items, cfg_view.get("emby", {}) or {})
             return
         if p == "MDBLIST":
-            _delete_on_mdblist_batch(items, cfg_view.get("mdblist", {}) or {})
+            _delete_on_mdblist_batch(items, cfg_view)
             return
         if p == "PUBLICMETADB":
             _delete_on_publicmetadb_batch(items, cfg_view)


### PR DESCRIPTION
# Pull request

## Change

- Added MDBList Device Code authentication alongside legacy API key authentication.
- Made Device Code the preferred MDBList auth flow while keeping API key support for existing setups.
- Added MDBList auth method switching with only one active method at a time.
- Added API key validation before saving MDBList keys.
- Updated MDBList probes, sync, watchlist actions, and scrobbling to use the selected auth method.
- Added automatic MDBList token refresh support for Device Code authentication.
- Improved the MDBList auth UI to match the Trakt-style connect/delete flow.
- Prevented unrelated scheduler validation issues from blocking provider settings saves.

## Why

MDBList expanded its authentication options and recommended Device Code or PKCE-style authentication. CrossWatch needed to support the new MDBList auth flow without breaking existing API key users.

## Testing

- Verified MDBList API key mode saves only after successful validation.
- Verified existing API key setups remain on API key mode.
- Verified switching to Device Code keeps the Device Code UI active while connecting.
- Verified MDBList status/probe paths work with the selected auth method.
- Ran Python compile checks on changed backend files.
- Ran JS syntax checks for MDBList auth and settings save scripts.
- Ran targeted pytest suite: `31 passed`.

## Issue

Fixes