### PR TITLE
Add: MDBList Device Code authentication

### DIFF
--- a/api/authenticationAPI.py
+++ b/api/authenticationAPI.py
@@ -1265,7 +1265,6 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
             provider_auth = _provider_auth()
             method = provider_auth.normalize_auth_method("mdblist", (payload or {}).get("auth_method") or "api_key")
             key = str((payload or {}).get("api_key") or "").strip()
-            client_id = str((payload or {}).get("client_id") or "").strip()
             cfg = load_config()
             m = ensure_instance_block(cfg, "mdblist", inst)
             if method == "api_key":
@@ -1277,8 +1276,7 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
                     m["api_key"] = key
                 provider_auth.set_active_method("mdblist", m, "api_key")
             else:
-                if client_id:
-                    m["client_id"] = client_id
+                m.pop("client_id", None)
                 provider_auth.set_active_method("mdblist", m, "device_code")
             save_config(cfg)
             _safe_log(log_fn, "MDBLIST", f"[MDBLIST] auth saved method={method} instance={inst}")
@@ -1294,8 +1292,7 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         inst = normalize_instance_id(instance)
         try:
             cfg = load_config()
-            client_id = str((payload or {}).get("client_id") or "").strip()
-            res = _provider_auth().start_device_code("mdblist", cfg, instance_id=inst, client_id=client_id)
+            res = _provider_auth().start_device_code("mdblist", cfg, instance_id=inst)
             if isinstance(probe_cache, dict):
                 probe_cache["mdblist"] = (0.0, False)
             _safe_log(log_fn, "MDBLIST", f"[MDBLIST] device start instance={inst} ok={bool(res.get('ok'))}")

--- a/assets/auth/auth.mdblist.js
+++ b/assets/auth/auth.mdblist.js
@@ -146,10 +146,8 @@
         window.CW?.IconSelect?.enhance(sel, sel.__cwIconSelectCfg || { className: "cw-plain-select" });
       } catch (_) {}
     }
-    const cidWrap = el("mdblist_client_id_wrap") || el("mdblist_client_id")?.closest("div");
     const dev = el("mdblist_device_panel");
     const api = el("mdblist_api_panel");
-    if (cidWrap) cidWrap.style.display = m === "device_code" ? "" : "none";
     if (dev) dev.style.display = m === "device_code" ? "" : "none";
     if (api) api.style.display = m === "api_key" ? "" : "none";
   }
@@ -273,8 +271,6 @@
     const blk = getMDBListCfgBlock(cfg);
     const method = methodOverride || activeMethodFromBlock(blk);
     setMethodUI(method);
-    const cid = el("mdblist_client_id");
-    if (cid) cid.value = txt(blk?.client_id || "");
     setReadonlySecret("mdblist_access_token", !!txt(blk?.access_token));
     const hasApiKey = !!txt(blk?.api_key);
     maskInput(el("mdblist_key"), hasApiKey);
@@ -294,7 +290,7 @@
     methodOverride = method === "device_code" ? "device_code" : "";
     setMethodUI(method);
     try {
-      await saveAuth({ auth_method: method, client_id: txt(el("mdblist_client_id")?.value) });
+      await saveAuth({ auth_method: method });
       await refresh(false);
     } catch {
       note("MDBList method switch failed");
@@ -358,8 +354,6 @@
   }
 
   async function onDeviceStart() {
-    const clientId = txt(el("mdblist_client_id")?.value);
-    if (!clientId) { note("Enter your MDBList Client ID"); return; }
     let win = null;
     try { win = window.open("about:blank", "_blank"); } catch (_) {}
     try {
@@ -367,7 +361,7 @@
       const r = await fetchJSON(mdblApi("/api/mdblist/device/start"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ client_id: clientId }),
+        body: "{}",
         cache: "no-store"
       });
       const data = r.data || {};
@@ -523,8 +517,6 @@
 
     const method = el("mdblist_auth_method")?.value === "api_key" ? "api_key" : "device_code";
     target.auth_method = method;
-    const clientId = txt(el("mdblist_client_id")?.value);
-    if (clientId) target.client_id = clientId;
     const keyState = readSecretField(el("mdblist_key"));
     if (method === "api_key" && keyState.value) target.api_key = keyState.value;
   });

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -254,7 +254,7 @@ DEFAULT_CFG: dict[str, Any] = {
 
     "mdblist": {
         "auth_method": "",                              # "", "device_code" (default when new), or "api_key" (legacy/manual)
-        "client_id": "",                                # MDBList Device Code app client_id
+        "client_id": "",                                # Deprecated; CrossWatch MDBList app client_id is supplied internally
         "access_token": "",                             # OAuth access token (Device Code)
         "refresh_token": "",                            # OAuth refresh token (Device Code)
         "token_type": "Bearer",                         # OAuth token type
@@ -1047,9 +1047,12 @@ def _normalize_mdblist(cfg: dict[str, Any]) -> None:
     def _norm_method(block: dict[str, Any]) -> str:
         has_api = bool(str(block.get("api_key") or block.get("key") or "").strip())
         has_oauth = bool(str(block.get("access_token") or "").strip() or str(block.get("refresh_token") or "").strip())
+        has_pending_device = isinstance(block.get("_pending_device"), dict)
         if has_api and not has_oauth:
+            if has_pending_device:
+                return "device_code"
             return "api_key"
-        if has_oauth:
+        if has_oauth or has_pending_device:
             return "device_code"
         raw = str(block.get("auth_method") or "").strip().lower().replace("-", "_")
         if raw in ("api", "apikey", "api_key", "key"):
@@ -1065,8 +1068,10 @@ def _normalize_mdblist(cfg: dict[str, Any]) -> None:
         # Do not let a passive UI/config save destroy an existing API key just
         # because the default method is Device Code. The API key becomes
         # inactive once Device Code has real token state, and is cleared after
-        # MDBList returns tokens. A pending device flow is not active auth yet.
-        if method == "device_code" and has_api_before and not has_oauth_before:
+        # MDBList returns tokens. A pending device flow is an explicit switch
+        # in progress, so keep it selected while the user approves the login.
+        has_pending_before = isinstance(block.get("_pending_device"), dict)
+        if method == "device_code" and has_api_before and not has_oauth_before and not has_pending_before:
             method = "api_key"
         block["auth_method"] = method
         block["client_id"] = str(block.get("client_id") or "").strip()

--- a/providers/auth/_auth_MDBLIST.py
+++ b/providers/auth/_auth_MDBLIST.py
@@ -80,13 +80,6 @@ class MDBListAuth(AuthProvider):
             flow="device_code",
             fields=[
                 {
-                    "key": "mdblist.client_id",
-                    "label": "Client ID",
-                    "type": "text",
-                    "required": False,
-                    "placeholder": "MDBList Device Code client_id",
-                },
-                {
                     "key": "mdblist.api_key",
                     "label": "API Key",
                     "type": "password",
@@ -124,8 +117,7 @@ class MDBListAuth(AuthProvider):
             b["api_key"] = str(payload.get("api_key") or payload.get("mdblist.api_key") or "").strip()
             mdblist_auth.set_active_method(b, "api_key")
         else:
-            if payload.get("client_id"):
-                b["client_id"] = str(payload.get("client_id") or "").strip()
+            b.pop("client_id", None)
             mdblist_auth.set_active_method(b, "device_code")
         save_config(cfgd)
         log(f"MDBList auth saved (method={method}, instance={normalize_instance_id(instance_id)}).", module="AUTH")
@@ -205,10 +197,6 @@ def html() -> str:
                   <option value="device_code">Device Code</option>
                   <option value="api_key">API Key</option>
                 </select>
-              </div>
-              <div id="mdblist_client_id_wrap">
-                <label for="mdblist_client_id">Device Code Client ID</label>
-                <input id="mdblist_client_id" name="mdblist_client_id" placeholder="MDBList app client_id" autocomplete="off" />
               </div>
             </div>
 

--- a/providers/sync/mdblist/_auth.py
+++ b/providers/sync/mdblist/_auth.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude
 from __future__ import annotations
 
+import os
 import time
 from collections.abc import Mapping, MutableMapping
 from typing import Any
@@ -16,6 +17,8 @@ API_BASE = "https://api.mdblist.com"
 OAUTH_TOKEN_URL = f"{API_BASE}/oauth/token/"
 OAUTH_DEVICE_URL = f"{API_BASE}/oauth/device-authorization/"
 VERIFY_URL = "https://mdblist.com/oauth/device/"
+DEFAULT_CLIENT_ID = "4A5MNaWPLOLSHws7JCQXOtATBOs2AmYJsqcwT7Uj"
+CLIENT_ID_ENV = "CROSSWATCH_MDBLIST_CLIENT_ID"
 SCOPE = "write"
 REFRESH_SKEW_SEC = 300
 UA = "CrossWatch/MDBListAuth"
@@ -29,13 +32,20 @@ def now() -> int:
     return int(time.time())
 
 
+def app_client_id() -> str:
+    return str(os.environ.get(CLIENT_ID_ENV) or DEFAULT_CLIENT_ID).strip()
+
+
 def normalize_auth_method(value: Any, block: Mapping[str, Any] | None = None) -> str:
     b = block or {}
     has_api_key = bool(str(b.get("api_key") or b.get("key") or "").strip())
     has_oauth = bool(str(b.get("access_token") or "").strip() or str(b.get("refresh_token") or "").strip())
+    has_pending_device = isinstance(b.get("_pending_device"), Mapping)
     if has_api_key and not has_oauth:
+        if has_pending_device:
+            return "device_code"
         return "api_key"
-    if has_oauth:
+    if has_oauth or has_pending_device:
         return "device_code"
 
     raw = str(value or "").strip().lower().replace("-", "_")
@@ -106,7 +116,7 @@ def is_configured(block: Mapping[str, Any] | None) -> bool:
     b = block or {}
     if active_method(b) == "api_key":
         return bool(str(b.get("api_key") or b.get("key") or "").strip())
-    return bool(str(b.get("access_token") or "").strip() and str(b.get("client_id") or "").strip())
+    return bool(str(b.get("access_token") or "").strip())
 
 
 def status_for_block(block: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -117,7 +127,7 @@ def status_for_block(block: Mapping[str, Any] | None) -> dict[str, Any]:
         "connected": is_configured(b),
         "api_key_configured": bool(str(b.get("api_key") or b.get("key") or "").strip()),
         "device_configured": bool(str(b.get("access_token") or "").strip()),
-        "client_id_configured": bool(str(b.get("client_id") or "").strip()),
+        "client_id_configured": bool(app_client_id()),
         "expires_at": int(b.get("expires_at") or 0) if method == "device_code" else 0,
         "username": str(b.get("username") or ""),
     }
@@ -166,11 +176,11 @@ def start_device_code(
     cfgd = cfg if isinstance(cfg, dict) else _load_full_cfg()
     inst = normalize_instance_id(instance_id)
     block = writable_block(cfgd, inst)
-    cid = str(client_id or block.get("client_id") or "").strip()
+    cid = app_client_id()
     if not cid:
         return {"ok": False, "error": "missing_client_id", "instance": inst}
 
-    block["client_id"] = cid
+    block.pop("client_id", None)
     set_active_method(block, "device_code")
 
     try:
@@ -207,6 +217,7 @@ def start_device_code(
         "expires_at": expires_at,
         "created_at": now(),
     }
+    block["auth_method"] = "device_code"
     _save_full_cfg(cfgd)
     return {
         "ok": True,
@@ -229,7 +240,7 @@ def poll_device_code(
     cfgd = cfg if isinstance(cfg, dict) else _load_full_cfg()
     inst = normalize_instance_id(instance_id)
     block = writable_block(cfgd, inst)
-    cid = str(block.get("client_id") or "").strip()
+    cid = app_client_id()
     pend = block.get("_pending_device") if isinstance(block.get("_pending_device"), Mapping) else {}
     dc = str(device_code or (pend or {}).get("device_code") or "").strip()
     if not cid:
@@ -297,10 +308,8 @@ def refresh_token(
     full = _load_full_cfg()
     inst = normalize_instance_id(instance_id)
     block = writable_block(full, inst)
-    cid = str(block.get("client_id") or "").strip()
+    cid = app_client_id()
     rt = str(block.get("refresh_token") or "").strip()
-    if not cid and isinstance(cfg, Mapping):
-        cid = str(provider_block(cfg, inst).get("client_id") or "").strip()
     if not rt and isinstance(cfg, Mapping):
         rt = str(provider_block(cfg, inst).get("refresh_token") or "").strip()
     if not cid or not rt:
@@ -338,7 +347,6 @@ def refresh_token(
         {
             "auth_method": "device_code",
             "api_key": "",
-            "client_id": cid,
             "access_token": access_token,
             "refresh_token": str(tok.get("refresh_token") or rt).strip(),
             "token_type": str(tok.get("token_type") or block.get("token_type") or "Bearer").strip() or "Bearer",


### PR DESCRIPTION
# Pull request

## Change

Adds MDBList Device Code authentication as the default MDBList auth method, while keeping legacy API key authentication available.

Also updates MDBList auth handling so:
- only one auth method is active at a time
- API keys are validated before saving
- Device Code token refresh is handled by the shared provider auth runtime
- probes and watcher calls use the active MDBList auth method
- the MDBList UI follows the Trakt-style connect/delete flow
- users no longer need to provide an MDBList client ID; CrossWatch uses its own app client ID internally

## Why

MDBList expanded its authentication options and recommends OAuth Device Code authentication over API keys.

This keeps existing API key setups compatible, but moves new/default authentication to the newer Device Code flow.

## Testing

- Ran Python compile checks for updated backend/auth files
- Ran `node --check` for MDBList auth JavaScript
- Ran focused pytest coverage:
  - `providers/tests/test_manifests.py`
  - `tests/test_scheduling_capture_jobs.py`
- Ran `git diff --check`

## Issue

Fixes