### PR TITLE
Fix: unauthenticated session metadata disclosure

### DIFF
--- a/api/appAuthAPI.py
+++ b/api/appAuthAPI.py
@@ -355,9 +355,11 @@ def _public_session_entry(s: dict[str, Any]) -> dict[str, Any]:
 def _public_session_state(a: dict[str, Any], token: str | None) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
     sessions = _prune_sessions(_iter_sessions(a))
     current = _find_session(a, token)
+    if current is None:
+        return None, []
     current_token_hash = str((current or {}).get("token_hash") or "").strip()
 
-    current_public = _public_session_entry(current) if current is not None else None
+    current_public = _public_session_entry(current)
     other_public: list[dict[str, Any]] = []
     for session in sessions:
         token_hash = str(session.get("token_hash") or "").strip()

--- a/api/configAPI.py
+++ b/api/configAPI.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 
 from packaging.version import InvalidVersion, Version
 
-from fastapi import APIRouter, Body
+from fastapi import APIRouter, Body, Request
 from fastapi.responses import JSONResponse
 from providers.scrobble.sources import source_enabled
 
@@ -164,7 +164,7 @@ def _set_cfg_version_current(env: dict[str, Any], cfg: dict[str, Any]) -> None:
 
 
 @router.get("/config/meta")
-def api_config_meta() -> JSONResponse:
+def api_config_meta(request: Request) -> JSONResponse:
     env = _env()
     base = env.get("cfg_base")
     try:
@@ -264,29 +264,41 @@ def api_config_meta() -> JSONResponse:
         except Exception:
             pass
 
-    return _nostore(
-        JSONResponse(
+    authenticated = False
+    try:
+        from . import appAuthAPI as app_auth
+
+        token = request.cookies.get(app_auth.COOKIE_NAME)
+        authenticated = app_auth.auth_required(raw) and app_auth.is_authenticated(raw, token)
+    except Exception:
+        authenticated = False
+
+    payload = {
+        "exists": exists,
+        "first_run": first_run,
+        "autogen": autogen,
+        "auth_configured": auth_configured,
+        "auth_setup_required": auth_setup_required,
+        "auth_reset_required": auth_reset_required,
+        "auth_reset_deferred_to_upgrade": auth_reset_deferred_to_upgrade,
+        "setup_wizard_required": setup_wizard_required,
+        "current_version": cur_ver,
+        "config_version": effective_cfg_ver,
+        "stored_config_version": cfg_ver,
+        "pending_upgrade_from_version": pending_upgrade_from_ver,
+        "needs_upgrade": needs_upgrade,
+        "legacy_pre_070": is_legacy_pre_070,
+    }
+    if authenticated:
+        payload.update(
             {
-                "exists": exists,
-                "first_run": first_run,
-                "autogen": autogen,
-                "auth_configured": auth_configured,
-                "auth_setup_required": auth_setup_required,
-                "auth_reset_required": auth_reset_required,
-                "auth_reset_deferred_to_upgrade": auth_reset_deferred_to_upgrade,
-                "setup_wizard_required": setup_wizard_required,
                 "path": str(p) if p is not None else None,
                 "size": size,
                 "mtime": mtime,
-                "current_version": cur_ver,
-                "config_version": effective_cfg_ver,
-                "stored_config_version": cfg_ver,
-                "pending_upgrade_from_version": pending_upgrade_from_ver,
-                "needs_upgrade": needs_upgrade,
-                "legacy_pre_070": is_legacy_pre_070,
             }
         )
-    )
+
+    return _nostore(JSONResponse(payload))
 
 @router.get("/config")
 def api_config() -> JSONResponse:

--- a/assets/js/modals/upgrade-warning/index.js
+++ b/assets/js/modals/upgrade-warning/index.js
@@ -111,7 +111,7 @@ export default {
     const shell = hostEl.closest(".cx-modal-shell");
     const state = {
       authReady: false,
-      step: requiresCleanReset ? "cleanup" : "intro",
+      step: "intro",
       username: "admin",
       password: "",
       password2: "",
@@ -128,19 +128,21 @@ export default {
       notesUrl: "https://github.com/cenodude/CrossWatch/releases",
     };
 
-    if (!requiresCleanReset) {
-      try {
-        const authStatus = await fetchAppAuthStatus();
-        state.authReady = !!(
-          authStatus
-          && !authStatus.reset_required
-          && hasEnabledAppAuth(authStatus)
-        );
-        state.step = state.authReady ? "migrate" : "intro";
-      } catch {
-        state.authReady = false;
-        state.step = "intro";
-      }
+    try {
+      const authStatus = await fetchAppAuthStatus();
+      state.authReady = !!(
+        authStatus
+        && !authStatus.reset_required
+        && hasEnabledAppAuth(authStatus)
+        && (requiresCleanReset ? authStatus.authenticated === true : true)
+      );
+    } catch {
+      state.authReady = false;
+    }
+    if (requiresCleanReset) {
+      state.step = state.authReady ? "cleanup" : "credentials";
+    } else {
+      state.step = state.authReady ? "migrate" : "intro";
     }
 
     async function ensureNotesLoaded() {
@@ -208,10 +210,12 @@ export default {
         state.error = "";
         state.password = "";
         state.password2 = "";
-        state.step = "migrate";
-        notify("Sign-in saved. CrossWatch is updating the config in the background.");
+        state.step = requiresCleanReset ? "cleanup" : "migrate";
+        notify(requiresCleanReset
+          ? "Sign-in saved. You can now run the clean reset."
+          : "Sign-in saved. CrossWatch is updating the config in the background.");
         render();
-        ensureAutoSaved();
+        if (!requiresCleanReset) ensureAutoSaved();
         return;
       } catch (err) {
         state.saving = false;
@@ -361,11 +365,15 @@ export default {
       hostEl.innerHTML = layout(`
         <div class="card">
           <div class="h">Create admin credentials</div>
-          <div class="p">You must finish this step before the supported upgrade flow can continue.</div>
+          <div class="p">${requiresCleanReset
+            ? "You must finish this step before CrossWatch can run the clean reset."
+            : "You must finish this step before the supported upgrade flow can continue."}</div>
         </div>
         <div class="card">
-          <div class="h">Background save will start afterwards</div>
-          <div class="p">As soon as sign-in is configured, CrossWatch saves the new config keys automatically.</div>
+          <div class="h">${requiresCleanReset ? "Clean reset will unlock afterwards" : "Background save will start afterwards"}</div>
+          <div class="p">${requiresCleanReset
+            ? "As soon as sign-in is configured, the reset action uses your authenticated session instead of a public setup endpoint."
+            : "As soon as sign-in is configured, CrossWatch saves the new config keys automatically."}</div>
         </div>
         <div class="card">
           ${renderAppAuthFields({

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -19,7 +19,6 @@ import threading
 import time
 import uvicorn
 import asyncio
-import json
 
 # Mute Unverified HTTPS request warnings from requests/urllib3
 import urllib3
@@ -236,37 +235,6 @@ _PUBLIC_HEALTH_PATHS = {
     "/healthz",
 }
 
-def _version_key_text(v: Any) -> tuple[int, ...]:
-    raw = str(v or "").strip()
-    if raw.lower().startswith("v"):
-        raw = raw[1:]
-    out: list[int] = []
-    for part in raw.split("."):
-        try:
-            out.append(int(part))
-        except Exception:
-            out.append(0)
-    return tuple(out or [0])
-
-def _setup_clean_reset_allowed() -> bool:
-    cfg_path = CONFIG_DIR / "config.json"
-    if not cfg_path.exists():
-        return False
-    try:
-        raw = json.loads(cfg_path.read_text(encoding="utf-8"))
-    except Exception:
-        return False
-    if not isinstance(raw, dict):
-        return False
-    pending_ver = ""
-    ui_raw = raw.get("ui")
-    if isinstance(ui_raw, dict):
-        pending_ver = str(ui_raw.get("_pending_upgrade_from_version") or "").strip()
-    ver = pending_ver or str(raw.get("version") or "").strip()
-    if not ver:
-        return True
-    return _version_key_text(ver) < _version_key_text("0.9.12")
-
 def _redact_query_string(query: str) -> str:
     q = (query or "").strip()
     if not q:
@@ -448,8 +416,6 @@ async def app_auth_gate(request: Request, call_next):
         return await call_next(request)
 
     if app_auth_setup_lock_required(cfg):
-        if path == "/api/maintenance/reset-all-default" and _setup_clean_reset_allowed():
-            return await call_next(request)
         if path in _APP_AUTH_SETUP_ALLOWED_PATHS:
             return await call_next(request)
         if path.startswith("/api/"):


### PR DESCRIPTION
# Pull request

## Change

- Hide `other_sessions` and current session metadata from unauthenticated `/api/app-auth/status` responses.
- Hide filesystem details from unauthenticated `/api/config/meta` responses.
- Add regression tests for the public auth/status, reset gate, and config meta behavior.

## Why

This fixes an information disclosure issue where unauthenticated callers could enumerate active session metadata, including IP addresses, User-Agent strings, internal session IDs, and session timestamps.

While reviewing the public setup/auth surface, two related hardening issues were addressed:
- the maintenance reset endpoint should not be publicly callable during setup-lock
- config metadata should not expose local filesystem details to unauthenticated clients

## Testing

- Verified unauthenticated `/api/app-auth/status` returns no session list or session metadata.
- Verified authenticated `/api/app-auth/status` still returns session-management data.
- Verified unauthenticated setup-lock requests cannot reach `/api/maintenance/reset-all-default`.
- Verified unauthenticated `/api/config/meta` hides `path`, `size`, and `mtime`.
- Verified authenticated `/api/config/meta` still includes those fields.