### PR TITLE
Fix: SIMKL completed shows history sync

### DIFF
--- a/providers/sync/simkl/_history.py
+++ b/providers/sync/simkl/_history.py
@@ -564,6 +564,7 @@ def _fetch_all_items(
     params: dict[str, str] = {
         "extended": "full_anime_seasons",
         "episode_watched_at": "yes",
+        "include_all_episodes": "yes",
     }
     if since_iso:
         params["date_from"] = since_iso


### PR DESCRIPTION
# Pull request

## Change

Updated the SIMKL history sync request to include `include_all_episodes=yes` when fetching `/sync/all-items`.


## Why

SIMKL does not include episode rows for completed shows by default. CrossWatch was already requesting `episode_watched_at=yes`, but that only adds timestamps to episodes that are present in the response.

As a result, marking individual episodes as watched synced correctly, but marking a whole show as completed in SIMKL did not sync to CW Tracker history.

## Testing

- Verified that marking a show as completed in SIMKL now syncs its episodes into CW Tracker history.

## Issue

#266