### PR TITLE
Change: centralize provider auth profiles and credential validation

### DIFF
--- a/api/authenticationAPI.py
+++ b/api/authenticationAPI.py
@@ -102,6 +102,77 @@ def _validate_mdblist_api_key(api_key: str, *, timeout: float = 12.0) -> tuple[b
     return True, ""
 
 
+def _validate_publicmetadb_api_key(api_key: str, *, base_url: str = "https://publicmetadb.com", timeout: float = 12.0) -> tuple[bool, str]:
+    key = str(api_key or "").strip()
+    if not key:
+        return False, "api_key_required"
+    base = str(base_url or "https://publicmetadb.com").strip().rstrip("/") or "https://publicmetadb.com"
+    try:
+        r = requests.get(
+            f"{base}/api/external/lists",
+            params={"page": 1, "perPage": 1},
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {key}",
+                "User-Agent": "CrossWatch/PublicMetaDBAuth",
+            },
+            timeout=timeout,
+        )
+    except requests.Timeout:
+        return False, "validation_timeout"
+    except requests.RequestException:
+        return False, "validation_failed"
+    if r.status_code in (401, 403):
+        return False, "invalid_api_key"
+    if r.status_code >= 400:
+        return False, f"validation_http_{int(r.status_code)}"
+    try:
+        data = r.json() or {}
+    except ValueError:
+        return False, "validation_bad_response"
+    if not isinstance(data, dict) or not isinstance(data.get("items"), list):
+        return False, "validation_bad_response"
+    return True, ""
+
+
+def _validate_tautulli_credentials(server_url: str, api_key: str, *, timeout: float = 12.0, verify_ssl: bool = True) -> tuple[bool, str]:
+    server = str(server_url or "").strip().rstrip("/")
+    key = str(api_key or "").strip()
+    if not server:
+        return False, "server_url_required"
+    if not key:
+        return False, "api_key_required"
+    if not server.startswith(("http://", "https://")):
+        server = "http://" + server
+    try:
+        r = requests.get(
+            f"{server}/api/v2",
+            params={"apikey": key, "cmd": "get_server_info"},
+            headers={"Accept": "application/json", "User-Agent": "CrossWatch/TautulliAuth"},
+            timeout=timeout,
+            verify=bool(verify_ssl),
+        )
+    except requests.Timeout:
+        return False, "validation_timeout"
+    except requests.RequestException:
+        return False, "validation_failed"
+    if r.status_code in (401, 403):
+        return False, "invalid_api_key"
+    if r.status_code >= 400:
+        return False, f"validation_http_{int(r.status_code)}"
+    try:
+        data = r.json() or {}
+    except ValueError:
+        return False, "validation_bad_response"
+    resp = data.get("response") if isinstance(data, dict) else None
+    if isinstance(resp, dict) and str(resp.get("result") or "").lower() == "success":
+        return True, ""
+    msg = str((resp or {}).get("message") or "").strip().lower() if isinstance(resp, dict) else ""
+    if "apikey" in msg or "api key" in msg:
+        return False, "invalid_api_key"
+    return False, "validation_bad_response"
+
+
 def _defaults_for_provider(provider_key: str) -> dict[str, Any]:
     blk = DEFAULT_CFG.get(provider_key)
     return copy.deepcopy(blk) if isinstance(blk, dict) else {}
@@ -1363,6 +1434,11 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
                 if _looks_masked_secret(key):
                     key = ""
                 else:
+                    base_url = str(p.get("base_url") or "https://publicmetadb.com").strip().rstrip("/")
+                    ok, reason = _validate_publicmetadb_api_key(key, base_url=base_url)
+                    if not ok:
+                        _safe_log(log_fn, "PUBLICMETADB", f"[PUBLICMETADB] api_key validation failed reason={reason} instance={normalize_instance_id(instance)}")
+                        return {"ok": False, "error": reason, "instance": normalize_instance_id(instance)}
                     p["api_key"] = key
             p.setdefault("base_url", "https://publicmetadb.com")
             save_config(cfg)
@@ -1378,8 +1454,14 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
     def api_publicmetadb_status(instance: str | None = Query(None)) -> dict[str, Any]:
         cfg = load_config()
         p = ensure_instance_block(cfg, "publicmetadb", instance)
-        has = bool(str(p.get("api_key") or "").strip())
-        return {"connected": has, "instance": normalize_instance_id(instance)}
+        key = str(p.get("api_key") or "").strip()
+        if not key:
+            return {"connected": False, "instance": normalize_instance_id(instance), "reason": "api_key_required"}
+        ok, reason = _validate_publicmetadb_api_key(
+            key,
+            base_url=str(p.get("base_url") or "https://publicmetadb.com").strip().rstrip("/"),
+        )
+        return {"connected": bool(ok), "instance": normalize_instance_id(instance), **({} if ok else {"reason": reason})}
 
     @app.post("/api/publicmetadb/disconnect", tags=["auth"])
     def api_publicmetadb_disconnect(instance: str | None = Query(None)) -> dict[str, Any]:
@@ -1434,6 +1516,10 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
             raise HTTPException(status_code=400, detail="server_url required")
         if not final_key:
             raise HTTPException(status_code=400, detail="api_key required")
+        ok, reason = _validate_tautulli_credentials(final_server, final_key, verify_ssl=bool(t.get("verify_ssl", True)))
+        if not ok:
+            _safe_log(log_fn, "TAUTULLI", f"[TAUTULLI] validation failed reason={reason} instance={inst}")
+            return {"ok": False, "error": reason, "instance": inst}
 
         save_config(cfg)
         _safe_log(log_fn, "TAUTULLI", f"[TAUTULLI] saved instance={inst}")
@@ -1455,38 +1541,13 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         if not verify:
             return {"connected": True, "instance": inst}
 
-        if server and not server.startswith(("http://", "https://")):
-            server = "http://" + server
-
-        try:
-            r = requests.get(
-                f"{server}/api/v2",
-                params={"apikey": key, "cmd": "get_server_info"},
-                headers={"Accept": "application/json"},
-                timeout=float(t.get("timeout", 10) or 10),
-                verify=bool(t.get("verify_ssl", True)),
-            )
-            j = {}
-            try:
-                j = r.json() if r.ok else {}
-            except Exception:
-                j = {}
-            resp = j.get("response") if isinstance(j, dict) else None
-            ok = bool(
-                r.ok
-                and isinstance(resp, dict)
-                and str(resp.get("result") or "").lower() == "success"
-            )
-            if ok:
-                return {"connected": True, "instance": inst}
-            reason = "verify_failed"
-            if isinstance(resp, dict):
-                reason = str(resp.get("message") or reason)
-            elif not r.ok:
-                reason = f"HTTP {r.status_code}"
-            return {"connected": False, "instance": inst, "reason": reason}
-        except Exception:
-            return {"connected": False, "instance": inst, "reason": "verify_failed"}
+        ok, reason = _validate_tautulli_credentials(
+            server,
+            key,
+            timeout=float(t.get("timeout", 10) or 10),
+            verify_ssl=bool(t.get("verify_ssl", True)),
+        )
+        return {"connected": bool(ok), "instance": inst, **({} if ok else {"reason": reason})}
 
     @app.post("/api/tautulli/disconnect", tags=["auth"])
     def api_tautulli_disconnect(instance: str | None = Query(None)) -> dict[str, Any]:
@@ -1839,10 +1900,8 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
                 return PlainTextResponse("SIMKL token exchange failed.", 400)
 
             simkl_cfg["access_token"] = str(tokens.get("access_token") or "").strip()
-            if tokens.get("refresh_token"):
-                simkl_cfg["refresh_token"] = str(tokens.get("refresh_token") or "").strip()
-            if tokens.get("expires_in"):
-                simkl_cfg["token_expires_at"] = int(time.time()) + int(tokens["expires_in"])
+            simkl_cfg.pop("refresh_token", None)
+            simkl_cfg.pop("token_expires_at", None)
             save_config(cfg)
 
             SIMKL_STATE.pop(state, None)
@@ -2015,12 +2074,5 @@ def simkl_exchange_code(cfg: dict[str, Any], instance_id: Any, client_id: str, c
     access = str(s.get("access_token") or "").strip()
     if not access:
         return None
-    refresh = str(s.get("refresh_token") or "").strip()
-    exp_at = int(s.get("token_expires_at", 0) or 0)
-    expires_in = max(0, exp_at - int(time.time())) if exp_at else 0
     out: dict[str, Any] = {"access_token": access}
-    if refresh:
-        out["refresh_token"] = refresh
-    if expires_in:
-        out["expires_in"] = expires_in
     return out

--- a/api/versionAPI.py
+++ b/api/versionAPI.py
@@ -19,7 +19,7 @@ __all__ = ["router"]
 
 router = APIRouter(prefix="/api", tags=["version"])
 
-CURRENT_VERSION = os.getenv("APP_VERSION", "v0.9.21")
+CURRENT_VERSION = os.getenv("APP_VERSION", "v0.9.22")
 REPO = os.getenv("GITHUB_REPO", "cenodude/CrossWatch")
 
 

--- a/assets/auth/auth.anilist.js
+++ b/assets/auth/auth.anilist.js
@@ -2,59 +2,37 @@
 (function (w, d) {
   "use strict";
 
-  const $ = (id) => d.getElementById(id);
+  const Shared = w.CW.AuthShared;
+  const $ = Shared.el;
   const Q = (sel, root = d) => root.querySelector(sel);
-  const notify = w.notify || ((m) => console.log("[notify]", m));
+  const notify = Shared.notify;
   const bust = () => `?ts=${Date.now()}`;
+  const profile = Shared.createProfileAdapter({
+    provider: "anilist",
+    configKey: "anilist",
+    label: "AniList",
+    sectionId: "sec-anilist",
+    selectId: "anilist_instance",
+    storageKey: "cw.ui.anilist.auth.instance.v1",
+    title: "Select which AniList account this config applies to.",
+  });
 
   function isMaskedSecret(v) {
-    const value = String(v || "").trim();
-    if (!value) return false;
-    if (value === "••••••••" || value === "********" || value === "**********") return true;
-    return /^[•*]{3,}$/.test(value);
+    return Shared.isMaskedSecret(v);
   }
 
   function markSecretField(el, value) {
-    if (!el) return;
-    const text = String(value || "").trim();
-    el.value = text;
-    el.dataset.masked = isMaskedSecret(text) ? "1" : "0";
-    el.dataset.loaded = "1";
-    if (!el.dataset.touched) el.dataset.touched = "";
+    return Shared.markSecretField(el, value);
   }
 
   function wireSecretField(el, onChange) {
-    if (!el || el.__cwSecretWired) return;
-    const clearMask = () => {
-      if (el.dataset.masked === "1") {
-        el.value = "";
-        el.dataset.masked = "0";
-      }
-    };
-    el.addEventListener("beforeinput", clearMask);
-    el.addEventListener("paste", () => {
-      clearMask();
-      el.dataset.touched = "1";
-      if (typeof onChange === "function") onChange();
-    });
-    el.addEventListener("input", () => {
-      if (isMaskedSecret(el.value)) el.dataset.masked = "1";
-      else if (el.dataset.masked === "1") el.dataset.masked = "0";
-      el.dataset.touched = "1";
-      if (typeof onChange === "function") onChange();
-    });
-    el.__cwSecretWired = true;
+    return Shared.wireSecretInput(el, { onInput: onChange });
   }
 
   function readSecretField(el) {
-    const raw = String(el?.value || "").trim();
-    const masked = !!(el && (el.dataset.masked === "1" || isMaskedSecret(raw)));
-    if (!raw && !masked) return { hasValue: false, masked: false, value: "" };
-    if (masked) return { hasValue: true, masked: true, value: "" };
-    return { hasValue: true, masked: false, value: raw };
+    return Shared.readSecretField(el);
   }
 
-  const INST_KEY = "cw.ui.anilist.auth.instance.v1";
   const SECTION = "#sec-anilist";
 
   function normalizeId(v) {
@@ -64,26 +42,17 @@
   }
 
   function getAniListInstance() {
-    const el = Q(SECTION + " #anilist_instance") || $("#anilist_instance");
-    let v = el ? String(el.value || "").trim() : "";
-    if (!v) {
-      try { v = localStorage.getItem(INST_KEY) || ""; } catch {}
-    }
-    return normalizeId(v);
+    return profile ? profile.getInstance() : "default";
   }
 
   function setAniListInstance(v) {
     const id = normalizeId(v);
-    try { localStorage.setItem(INST_KEY, id); } catch {}
-    const el = Q(SECTION + " #anilist_instance") || $("#anilist_instance");
-    if (el) el.value = id;
+    if (profile) profile.setInstance(id);
     return id;
   }
 
   function anilistApi(path) {
-    const p = String(path || "");
-    const sep = p.includes("?") ? "&" : "?";
-    return p + sep + "instance=" + encodeURIComponent(getAniListInstance()) + "&ts=" + Date.now();
+    return profile ? profile.api(path) : String(path || "");
   }
 
   function computeRedirect() {
@@ -91,12 +60,7 @@
   }
 
   function setAniListSuccess(on, txt) {
-    const msg = $("anilist_msg");
-    if (!msg) return;
-    msg.classList.toggle("hidden", !on && !txt);
-    msg.classList.toggle("ok", !!on);
-    msg.classList.toggle("warn", !!txt && !on);
-    msg.textContent = txt || (on ? "Connected." : "");
+    return Shared.setStatusPill("anilist_msg", on ? "ok" : (txt ? "warn" : null), txt || (on ? "Connected" : ""));
   }
 
   function renderAniListHint() {
@@ -107,142 +71,25 @@
       'You need an AniList API key. Create one at ' +
       '<a href="https://anilist.co/settings/developer" target="_blank" rel="noreferrer">AniList Developer</a>. ' +
       'Set the Redirect URL to <code id="redirect_uri_preview_anilist"></code>.' +
-      ' <button class="btn" style="margin-left:8px" onclick="copyAniListRedirect()">Copy Redirect URL</button>';
+      ' <button id="btn-copy-anilist-redirect" class="btn" type="button" style="margin-left:8px">Copy Redirect URL</button>';
 
     hint.__cwRendered = true;
   }
 
   async function refreshAniListInstanceOptions(preserve = true) {
-  const sel = Q(SECTION + " #anilist_instance") || $("#anilist_instance");
-  if (!sel) return;
-
-  let want = preserve ? getAniListInstance() : "default";
-  sel.innerHTML = "";
-
-  const addOpt = (id, label) => {
-    const o = d.createElement("option");
-    o.value = String(id);
-    o.textContent = String(label || id);
-    sel.appendChild(o);
-  };
-
-  // Always render Default, even if the API call fails.
-  addOpt("default", "Default");
-
-  try {
-    const r = await fetch("/api/provider-instances/anilist" + bust(), { cache: "no-store" });
-    const data = await r.json().catch(() => null);
-    const opts = Array.isArray(data) ? data : (Array.isArray(data?.instances) ? data.instances : []);
-
-    opts.forEach((o) => {
-      if (!o || !o.id || o.id === "default") return;
-      addOpt(o.id, o.label || o.name || o.id);
-    });
-  } catch {}
-
-  if (!Array.from(sel.options).some((o) => o.value === want)) want = "default";
-  sel.value = want;
-  setAniListInstance(want);
-}
+    if (profile) await profile.refreshOptions(preserve);
+  }
 
 
   function ensureAniListInstanceUI() {
-    const panel = Q('#sec-anilist .cw-meta-provider-panel[data-provider="anilist"]') || Q('#sec-anilist .cw-meta-provider-panel') || Q(SECTION);
-    const head = panel ? Q(".cw-panel-head", panel) : null;
-    if (!head || head.__cwAniListInstanceUI) return;
-    head.__cwAniListInstanceUI = true;
-
-    const wrap = d.createElement("div");
-    wrap.className = "inline";
-    wrap.style.display = "flex";
-    wrap.style.gap = "8px";
-    wrap.style.alignItems = "center";
-    wrap.style.marginLeft = 'auto';
-    wrap.style.flexWrap = 'nowrap';
-    wrap.title = "Select which AniList account this config applies to.";
-
-    const lab = d.createElement("span");
-    lab.className = "muted";
-    lab.textContent = "Profile";
-
-    const sel = d.createElement("select");
-    sel.id = "anilist_instance";
-sel.name = "anilist_instance";
-    sel.className = "input";
-    sel.style.minWidth = "160px";
-
-    // Match Trakt: keep it compact and let content drive the width.
-    sel.style.width = 'auto';
-    sel.style.maxWidth = '220px';
-    sel.style.flex = '0 0 auto';
-    const btnNew = d.createElement("button");
-    btnNew.type = "button";
-    btnNew.className = "btn secondary";
-    btnNew.id = "anilist_instance_new";
-    btnNew.textContent = "New";
-
-    const btnDel = d.createElement("button");
-    btnDel.type = "button";
-    btnDel.className = "btn secondary";
-    btnDel.id = "anilist_instance_del";
-    btnDel.textContent = "Delete";
-
-    wrap.appendChild(lab);
-    wrap.appendChild(sel);
-    wrap.appendChild(btnNew);
-    wrap.appendChild(btnDel);
-    head.appendChild(wrap);
-
-    refreshAniListInstanceOptions(true);
-
-    sel.addEventListener("change", async () => {
-      setAniListInstance(sel.value);
+    profile?.ensureUI(async () => {
       await hydrateFromConfig(true);
       updateAniListButtonState();
-    });
-
-    btnNew.addEventListener("click", async () => {
-      try {
-        const r = await fetch(`/api/provider-instances/anilist/next?ts=${Date.now()}`, { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}", cache: "no-store" });
-        const j = await r.json().catch(() => ({}));
-        const id = String(j?.id || "").trim();
-        if (!r.ok || j?.ok === false || !id) throw new Error(String(j?.error || "create_failed"));
-        setAniListInstance(id);
-        await refreshAniListInstanceOptions(true);
-        await hydrateFromConfig(true);
-        updateAniListButtonState();
-      } catch (e) {
-        notify("Could not create profile: " + (e?.message || e));
-      }
-    });
-
-    btnDel.addEventListener("click", async () => {
-      const inst = getAniListInstance();
-      if (inst === "default") return notify("Default profile cannot be deleted.");
-      if (!confirm(`Delete AniList profile '${inst}'?`)) return;
-      try {
-        const r = await fetch(`/api/provider-instances/anilist/${encodeURIComponent(inst)}`, { method: "DELETE", cache: "no-store" });
-        const j = await r.json().catch(() => ({}));
-        if (!r.ok || j?.ok === false) throw new Error(String(j?.error || "delete_failed"));
-        setAniListInstance("default");
-        await refreshAniListInstanceOptions(false);
-        await hydrateFromConfig(true);
-        updateAniListButtonState();
-      } catch (e) {
-        notify("Could not delete profile: " + (e?.message || e));
-      }
     });
   }
 
   function getAniListCfgBlock(cfg) {
-    cfg = cfg || {};
-    const base = (cfg.anilist && typeof cfg.anilist === "object") ? cfg.anilist : (cfg.anilist = {});
-    const inst = getAniListInstance();
-    if (inst === "default") return base;
-
-    if (!base.instances || typeof base.instances !== "object") base.instances = {};
-    if (!base.instances[inst] || typeof base.instances[inst] !== "object") base.instances[inst] = {};
-    return base.instances[inst];
+    return profile ? profile.cfgBlock(cfg, true) : {};
   }
 
   async function hydrateFromConfig(force = false) {
@@ -257,11 +104,9 @@ sel.name = "anilist_instance";
 
       const cidEl = $("anilist_client_id");
       const secEl = $("anilist_client_secret");
-      const tokEl = $("anilist_access_token");
 
       if (cidEl && (force || !cidEl.value || cidEl.dataset.masked === "1")) markSecretField(cidEl, cid);
       if (secEl && (force || !secEl.value || secEl.dataset.masked === "1")) markSecretField(secEl, sec);
-      if (tokEl && (force || !tokEl.value)) tokEl.value = tok;
 
       if (tok) setAniListSuccess(true);
       else setAniListSuccess(false, "");
@@ -310,33 +155,19 @@ sel.name = "anilist_instance";
       sec.__cwBound = true;
     }
 
+    const copyBtn = $("btn-copy-anilist-redirect");
+    if (copyBtn && !copyBtn.__wired) { copyBtn.addEventListener("click", copyAniListRedirect); copyBtn.__wired = true; }
+    const connectBtn = $("btn-connect-anilist");
+    if (connectBtn && !connectBtn.__wired) { connectBtn.addEventListener("click", startAniList); connectBtn.__wired = true; }
+    const deleteBtn = $("btn-delete-anilist");
+    if (deleteBtn && !deleteBtn.__wired) { deleteBtn.addEventListener("click", anilistDeleteToken); deleteBtn.__wired = true; }
+
     updateAniListButtonState();
   }
 
   async function copyAniListRedirect() {
     const uri = computeRedirect();
-    try {
-      await navigator.clipboard.writeText(uri);
-      notify("Redirect URL copied ✓");
-      return;
-    } catch {}
-
-    try {
-      const ta = d.createElement("textarea");
-      ta.value = uri;
-      ta.setAttribute("readonly", "");
-      ta.style.position = "fixed";
-      ta.style.top = "0";
-      ta.style.left = "0";
-      ta.style.opacity = "0";
-      d.body.appendChild(ta);
-      ta.focus();
-      ta.select();
-      ta.setSelectionRange(0, ta.value.length);
-      const ok = d.execCommand("copy");
-      d.body.removeChild(ta);
-      if (ok) notify("Redirect URL copied ✓");
-    } catch {}
+    return Shared.copyText(uri, $("btn-copy-anilist-redirect"), { successMessage: "Redirect URL copied" });
   }
 
   async function anilistDeleteToken() {
@@ -362,27 +193,22 @@ sel.name = "anilist_instance";
       const j = await r.json().catch(() => ({}));
 
       if (r.ok && j.ok !== false) {
-        try {
-          const el = $("anilist_access_token");
-          if (el) el.value = "";
-        } catch {}
-
         if (msg) {
           msg.classList.add("warn");
-          msg.textContent = "Disconnected.";
+          msg.textContent = "Disconnected";
         }
-        notify("AniList token removed.");
+        notify("AniList disconnected");
         try { w.dispatchEvent(new CustomEvent("auth-changed")); } catch {}
       } else {
         if (msg) {
           msg.classList.add("warn");
-          msg.textContent = "Could not remove token.";
+          msg.textContent = "Could not disconnect";
         }
       }
     } catch {
       if (msg) {
         msg.classList.add("warn");
-        msg.textContent = "Could not remove token.";
+        msg.textContent = "Could not disconnect";
       }
     } finally {
       if (btn) {
@@ -456,11 +282,6 @@ sel.name = "anilist_instance";
       const blk = getAniListCfgBlock(cfg || {});
       const tok = String(blk?.access_token || "").trim();
       if (tok) {
-        try {
-          const el = $("anilist_access_token");
-          if (el) el.value = tok;
-        } catch {}
-
         setAniListSuccess(true);
 
         pollHandle = null;
@@ -476,10 +297,11 @@ sel.name = "anilist_instance";
 
   let __anilistInitDone = false;
   function initAniListAuthLoader() {
+    try { initAniListAuthUI(); } catch (_) {}
+
     if (__anilistInitDone) return;
     __anilistInitDone = true;
 
-    try { initAniListAuthUI(); } catch (_) {}
     try { hydrateFromConfig(true); } catch (_) {}
   }
 

--- a/assets/auth/auth.emby.js
+++ b/assets/auth/auth.emby.js
@@ -3,6 +3,7 @@
   "use strict";
 
   // --- utils
+  const Shared = window.CW && window.CW.AuthShared;
   const Q = (s, r = document) => r.querySelector(s);
   const Qa = (s, r = document) => Array.from(r.querySelectorAll(s) || []);
   const ESC = (s) => String(s || "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
@@ -13,149 +14,44 @@
   let R = new Set(); // ratings lib ids
   let S = new Set(); // scrobble lib ids
   let hydrated = false;
+  let connected = false;
 
   const EMBY_SUBTAB_KEY = "cw.ui.emby.auth.subtab.v1";
 
-  const EMBY_INSTANCE_KEY = "cw.ui.emby.auth.instance.v1";
+  const embyProfile = Shared.createProfileAdapter({
+    provider: "emby",
+    configKey: "emby",
+    label: "Emby",
+    sectionId: "sec-emby",
+    selectId: "emby_instance",
+    storageKey: "cw.ui.emby.auth.instance.v1",
+    title: "Select which Emby server/account this config applies to.",
+  });
 
   function getEmbyInstance() {
-    const el = Q("#emby_instance");
-    let v = el ? String(el.value || "").trim() : "";
-    if (!v) { try { v = localStorage.getItem(EMBY_INSTANCE_KEY) || ""; } catch {} }
-    v = (v || "").trim() || "default";
-    return v.toLowerCase() === "default" ? "default" : v;
+    return embyProfile ? embyProfile.getInstance() : "default";
   }
 
   function setEmbyInstance(v) {
-    const id = (String(v || "").trim() || "default");
-    try { localStorage.setItem(EMBY_INSTANCE_KEY, id); } catch {}
-    const el = Q("#emby_instance");
-    if (el) el.value = id;
+    if (embyProfile) embyProfile.setInstance(v);
   }
 
   function embyApi(path) {
-    const p = String(path || "");
-    const sep = p.includes("?") ? "&" : "?";
-    return p + sep + "instance=" + encodeURIComponent(getEmbyInstance()) + "&ts=" + Date.now();
+    return embyProfile ? embyProfile.api(path) : String(path || "");
   }
 
   function getEmbyCfgBlock(cfg) {
-    cfg = cfg || {};
-    const base = (cfg.emby && typeof cfg.emby === "object") ? cfg.emby : (cfg.emby = {});
-    const inst = getEmbyInstance();
-    if (inst === "default") return base;
-    if (!base.instances || typeof base.instances !== "object") base.instances = {};
-    if (!base.instances[inst] || typeof base.instances[inst] !== "object") base.instances[inst] = {};
-    return base.instances[inst];
+    return embyProfile ? embyProfile.cfgBlock(cfg, true) : {};
   }
 
   async function refreshEmbyInstanceOptions(preserve = true) {
-    const sel = Q("#emby_instance");
-    if (!sel) return;
-    let want = preserve ? getEmbyInstance() : "default";
-    try {
-      const r = await fetch("/api/provider-instances/emby?ts=" + Date.now(), { cache: "no-store" });
-      const arr = await r.json().catch(() => []);
-      const opts = Array.isArray(arr) ? arr : [];
-
-      sel.innerHTML = "";
-      const addOpt = (id, label) => {
-        const o = document.createElement("option");
-        o.value = String(id);
-        o.textContent = String(label || id);
-        sel.appendChild(o);
-      };
-
-      addOpt("default", "Default");
-      opts.forEach((o) => { if (o && o.id && o.id !== "default") addOpt(o.id, o.label || o.id); });
-
-      if (!Array.from(sel.options).some(o => o.value === want)) want = "default";
-      sel.value = want;
-      setEmbyInstance(want);
-    } catch {}
+    if (embyProfile) await embyProfile.refreshOptions(preserve);
   }
 
   function ensureEmbyInstanceUI() {
-    const panel = Q('#sec-emby .cw-meta-provider-panel[data-provider="emby"]');
-    const head = panel ? Q(".cw-panel-head", panel) : null;
-    if (!head || head.__embyInstanceUI) return;
-    head.__embyInstanceUI = true;
-
-    const wrap = document.createElement("div");
-    wrap.className = "inline";
-    wrap.style.display = "flex";
-    wrap.style.gap = "8px";
-    wrap.style.alignItems = "center";
-    wrap.title = "Select which Emby server/account this config applies to.";
-
-    const lab = document.createElement("span");
-    lab.className = "muted";
-    lab.textContent = "Profile";
-
-    const sel = document.createElement("select");
-    sel.id = "emby_instance";
-sel.name = "emby_instance";
-    sel.className = "input";
-    sel.style.minWidth = "160px";
-
-    const btnNew = document.createElement("button");
-    btnNew.type = "button";
-    btnNew.className = "btn secondary";
-    btnNew.id = "emby_instance_new";
-    btnNew.textContent = "New";
-
-    const btnDel = document.createElement("button");
-    btnDel.type = "button";
-    btnDel.className = "btn secondary";
-    btnDel.id = "emby_instance_del";
-    btnDel.textContent = "Delete";
-
-    wrap.appendChild(lab);
-    wrap.appendChild(sel);
-    wrap.appendChild(btnNew);
-    wrap.appendChild(btnDel);
-    head.appendChild(wrap);
-
-    refreshEmbyInstanceOptions(true);
-
-    sel.addEventListener("change", async () => {
-      setEmbyInstance(sel.value);
+    embyProfile?.ensureUI(async () => {
       try { hydrated = false; } catch {}
       try { await hydrateFromConfig(true); } catch {}
-    });
-
-    btnNew.addEventListener("click", async () => {
-      try {
-        const r = await fetch(`/api/provider-instances/emby/next?ts=${Date.now()}`, { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}", cache: "no-store" });
-        const j = await r.json().catch(() => ({}));
-        const id = String(j?.id || "").trim();
-        if (!r.ok || j?.ok === false || !id) throw new Error(String(j?.error || "create_failed"));
-        setEmbyInstance(id);
-        await refreshEmbyInstanceOptions(true);
-        sel.value = id;
-        hydrated = false;
-        try { await hydrateFromConfig(true); } catch {}
-      } catch (e) {
-        (window.notify || console.log)("Could not create profile: " + (e?.message || e));
-      }
-    });
-
-    btnDel.addEventListener("click", async () => {
-      const id = getEmbyInstance();
-      if (id === "default") return (window.notify || console.log)("Default profile cannot be deleted.");
-      if (!confirm(`Delete Emby profile "${id}"?`)) return;
-      try {
-        const r = await fetch(`/api/provider-instances/emby/${encodeURIComponent(id)}`, { method: "DELETE", cache: "no-store" });
-        const j = await r.json().catch(() => ({}));
-        if (!r.ok || j?.ok === false) throw new Error(String(j?.error || "delete_failed"));
-        setEmbyInstance("default");
-        await refreshEmbyInstanceOptions(false);
-        sel.value = "default";
-        hydrated = false;
-        try { await hydrateFromConfig(true); } catch {}
-      } catch (e) {
-        (window.notify || console.log)("Could not delete profile: " + (e?.message || e));
-      }
     });
   }
 
@@ -206,15 +102,17 @@ sel.name = "emby_instance";
 
   // helpers
   const put = (sel, val) => { const el = Q(sel); if (el != null) el.value = (val ?? "") + ""; };
-  const maskToken = (has) => { const el = Q("#emby_tok"); if (el) { el.value = has ? "••••••••" : ""; el.dataset.masked = has ? "1" : "0"; } };
   const visible = (el) => !!el && getComputedStyle(el).display !== "none" && !el.hidden;
 
   function setMsgBanner(msg, kind, text) {
-    if (!msg) return;
-    msg.classList.remove('hidden', 'ok', 'warn');
-    if (!kind) { msg.classList.add('hidden'); msg.textContent = ''; return; }
-    msg.classList.add(kind);
-    msg.textContent = text || '';
+    return Shared.setStatusPill(msg, kind, text);
+  }
+
+  function setConnected(has) {
+    connected = !!has;
+    const msg = Q("#emby_msg");
+    if (connected) setMsgBanner(msg, "ok", "Connected");
+    else setMsgBanner(msg, null, "");
   }
 
   // libraries UI
@@ -280,8 +178,7 @@ sel.name = "emby_instance";
   function embySectionLooksEmpty() {
     const s1 = Q("#emby_server") || Q("#emby_server_url");
     const u1 = Q("#emby_user") || Q("#emby_username");
-    const tok = Q("#emby_tok");
-    const vals = [s1, u1, tok].map(el => el ? String(el.value || "").trim() : "");
+    const vals = [s1, u1].map(el => el ? String(el.value || "").trim() : "");
     return vals.every(v => !v);
   }
 
@@ -300,7 +197,7 @@ sel.name = "emby_instance";
       const v1 = Q("#emby_verify_ssl"), v2 = Q("#emby_verify_ssl_dup");
       if (v1) v1.checked = !!em.verify_ssl;
       if (v2) v2.checked = !!em.verify_ssl;
-      maskToken(!!(em.access_token || "").trim());
+      setConnected(!!(em.access_token || "").trim());
 
       H = new Set((em.history?.libraries || []).map(String));
       R = new Set((em.ratings?.libraries || []).map(String));
@@ -375,8 +272,8 @@ sel.name = "emby_instance";
       const j = await r.json().catch(() => ({}));
       if (!r.ok || j?.ok === false) throw new Error(String(j?.error || j?.detail || `HTTP ${r.status}`));
 
-      setMsgBanner(msg, "ok", "Signed in.");
-      maskToken(true);
+      setConnected(true);
+      setMsgBanner(msg, "ok", "Connected");
       hydrated = false;
       try { await hydrateFromConfig(true); } catch {}
     } catch (e) {
@@ -398,8 +295,8 @@ sel.name = "emby_instance";
       });
       const j = await r.json().catch(() => ({}));
       if (!r.ok || j?.ok === false) throw new Error(String(j?.error || `HTTP ${r.status}`));
-      setMsgBanner(msg, "ok", "Deleted.");
-      maskToken(false);
+      setConnected(false);
+      setMsgBanner(msg, "ok", "Disconnected");
       hydrated = false;
       try { await hydrateFromConfig(true); } catch {}
     } catch (e) {
@@ -497,38 +394,11 @@ sel.name = "emby_instance";
 
   document.addEventListener("input", (ev) => { if (ev.target?.id === "emby_lib_filter") applyFilter(); }, true);
 
-  function _normPickText(t) {
-    return String(t || "").replace(/\s+/g, " ").trim().toLowerCase();
-  }
-
   function findEmbyPickUserButton() {
     const root = Q('#sec-emby .cw-meta-provider-panel[data-provider="emby"]') || Q("#sec-emby");
     if (!root) return null;
     const settings = root.querySelector('.cw-subpanel[data-sub="settings"]') || root;
-
-    let btn = settings.querySelector("#emby_pick_user");
-    if (btn) return btn;
-
-    btn = settings.querySelector('[data-cw-emby="pick-user"]');
-    if (btn) return btn;
-
-    const uid = settings.querySelector("#emby_user_id");
-    if (!uid) return null;
-
-    // Look for a nearby button with matching text.
-    const candidates = [];
-    const p1 = uid.parentElement;
-    const p2 = p1 ? p1.parentElement : null;
-    [p1, p2].filter(Boolean).forEach((p) => p.querySelectorAll("button").forEach((b) => candidates.push(b)));
-
-    const hit = candidates.find((b) => {
-      const txt = _normPickText(b.textContent);
-      if (!txt || !(txt.includes("pick") && txt.includes("user"))) return false;
-      const box = b.closest("div") || b.parentElement;
-      return !!(box && box.contains(uid));
-    });
-
-    return hit || null;
+    return settings.querySelector("#emby_pick_user") || settings.querySelector('[data-cw-emby="pick-user"]');
   }
 
   function wireEmbyPickUserButton() {
@@ -537,36 +407,12 @@ sel.name = "emby_instance";
     const settings = root.querySelector('.cw-subpanel[data-sub="settings"]') || root;
     if (!settings) return;
 
-    let btn = findEmbyPickUserButton();
-    const uid = settings.querySelector("#emby_user_id");
-
-    // If template doesn't have a button yet, inject one next to the user id input.
-    if (!btn && uid) {
-      btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = "btn";
-      btn.id = "emby_pick_user";
-      btn.textContent = "Pick user";
-      btn.dataset.cwEmby = "pick-user";
-
-      const row = uid.closest(".inp-row") || uid.parentElement;
-      if (row) {
-        row.classList.add("inp-row");
-        uid.classList.add("grow");
-        row.appendChild(btn);
-      } else {
-        uid.insertAdjacentElement("afterend", btn);
-      }
-    }
-
+    const btn = findEmbyPickUserButton();
     if (!btn || btn.__cwEmbyPickWired) return;
     btn.__cwEmbyPickWired = true;
     if (!btn.id) btn.id = "emby_pick_user";
     try { btn.dataset.cwEmby = btn.dataset.cwEmby || "pick-user"; } catch {}
     btn.addEventListener("click", embyPickUser, true);
-    if (!btn.getAttribute("onclick")) {
-      btn.setAttribute("onclick", "try{window.embyPickUser&&window.embyPickUser(event);}catch(_){;}");
-    }
   }
 
   async function embyPickUser(ev) {
@@ -596,24 +442,21 @@ sel.name = "emby_instance";
   }
 
   document.addEventListener("click", (ev) => {
-    let btn = ev?.target?.closest ? ev.target.closest('#emby_pick_user,[data-cw-emby="pick-user"]') : null;
-
-    // Fallback for older markup: no id/dataset, but button is next to the user id input.
-    if (!btn) {
-      const b = ev?.target?.closest ? ev.target.closest("button") : null;
-      if (b) {
-        const root = Q('#sec-emby .cw-meta-provider-panel[data-provider="emby"]') || Q("#sec-emby");
-        const settings = root ? (root.querySelector('.cw-subpanel[data-sub="settings"]') || root) : null;
-        const uid = settings ? settings.querySelector("#emby_user_id") : null;
-        const txt = _normPickText(b.textContent);
-        if (uid && settings && settings.classList.contains("active") && settings.contains(b) && txt.includes("pick") && txt.includes("user")) {
-          const box = b.closest("div") || b.parentElement;
-          if (box && box.contains(uid)) btn = b;
-        }
-      }
-    }
-
+    const btn = ev?.target?.closest ? ev.target.closest('#emby_pick_user,[data-cw-emby="pick-user"]') : null;
     if (btn) embyPickUser(ev);
+    const t = ev?.target;
+    if (t && t.id === "btn-emby-login") embyLogin();
+    if (t && t.id === "btn-emby-delete") embyDeleteToken();
+    if (t && t.id === "btn-emby-auto") embyAuto();
+    if (t && t.id === "btn-emby-load-libraries") embyLoadLibraries();
+  }, true);
+
+  document.addEventListener("change", (ev) => {
+    const t = ev?.target;
+    if (t && t.id === "emby_verify_ssl_dup") {
+      const primary = Q("#emby_verify_ssl");
+      if (primary) primary.checked = !!t.checked;
+    }
   }, true);
 
   // expose

--- a/assets/auth/auth.jellyfin.js
+++ b/assets/auth/auth.jellyfin.js
@@ -2,6 +2,7 @@
 (function () {
   "use strict";
 
+  const Shared = window.CW && window.CW.AuthShared;
   const Q = (s, r = document) => r.querySelector(s);
   const Qa = (s, r = document) => Array.from(r.querySelectorAll(s) || []);
   const ESC = (s) => String(s || "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
@@ -12,147 +13,47 @@
   let R = new Set();
   let S = new Set();
   let hydrated = false;
+  let connected = false;
 
   const JFY_SUBTAB_KEY = "cw.ui.jellyfin.auth.subtab.v1";
 
-  const JFY_INSTANCE_KEY = "cw.ui.jellyfin.auth.instance.v1";
-  const _notify = (m) => { try { if (typeof window.notify === "function") window.notify(m); } catch {} };
+  const _notify = Shared.notify;
+  const jfyProfile = Shared.createProfileAdapter({
+    provider: "jellyfin",
+    configKey: "jellyfin",
+    label: "Jellyfin",
+    sectionId: "sec-jellyfin",
+    selectId: "jellyfin_instance",
+    storageKey: "cw.ui.jellyfin.auth.instance.v1",
+    title: "Select which Jellyfin server/account this config applies to.",
+  });
 
   function getJfyInstance() {
-    const el = Q("#jellyfin_instance");
-    let v = el ? String(el.value || "").trim() : "";
-    if (!v) { try { v = localStorage.getItem(JFY_INSTANCE_KEY) || ""; } catch {} }
-    v = (v || "").trim() || "default";
-    return v.toLowerCase() === "default" ? "default" : v;
+    return jfyProfile ? jfyProfile.getInstance() : "default";
   }
 
   function setJfyInstance(v) {
-    const id = (String(v || "").trim() || "default");
-    try { localStorage.setItem(JFY_INSTANCE_KEY, id); } catch {}
-    const el = Q("#jellyfin_instance");
-    if (el) el.value = id;
+    if (jfyProfile) jfyProfile.setInstance(v);
   }
 
   function jfyApi(path) {
-    const p = String(path || "");
-    const sep = p.includes("?") ? "&" : "?";
-    return p + sep + "instance=" + encodeURIComponent(getJfyInstance()) + "&ts=" + Date.now();
+    return jfyProfile ? jfyProfile.api(path) : String(path || "");
   }
 
   function getJfyCfgBlock(cfg) {
-    cfg = cfg || {};
-    const base = (cfg.jellyfin && typeof cfg.jellyfin === "object") ? cfg.jellyfin : (cfg.jellyfin = {});
-    const inst = getJfyInstance();
-    if (inst === "default") return base;
-    if (!base.instances || typeof base.instances !== "object") base.instances = {};
-    if (!base.instances[inst] || typeof base.instances[inst] !== "object") base.instances[inst] = {};
-    return base.instances[inst];
+    return jfyProfile ? jfyProfile.cfgBlock(cfg, true) : {};
   }
 
   async function refreshJfyInstanceOptions(preserve = true) {
-    const sel = Q("#jellyfin_instance");
-    if (!sel) return;
-    let want = preserve ? getJfyInstance() : "default";
-    try {
-      const r = await fetch("/api/provider-instances/jellyfin?ts=" + Date.now(), { cache: "no-store" });
-      const arr = await r.json().catch(() => []);
-      const opts = Array.isArray(arr) ? arr : [];
-
-      sel.innerHTML = "";
-      const addOpt = (id, label) => {
-        const o = document.createElement("option");
-        o.value = String(id);
-        o.textContent = String(label || id);
-        sel.appendChild(o);
-      };
-
-      addOpt("default", "Default");
-      opts.forEach((o) => { if (o && o.id && o.id !== "default") addOpt(o.id, o.label || o.id); });
-
-      if (!Array.from(sel.options).some(o => o.value === want)) want = "default";
-      sel.value = want;
-      setJfyInstance(want);
-    } catch {}
+    if (jfyProfile) await jfyProfile.refreshOptions(preserve);
   }
 
   function ensureJfyInstanceUI() {
-    const panel = Q('#sec-jellyfin .cw-meta-provider-panel[data-provider="jellyfin"]');
-    const head = panel ? Q(".cw-panel-head", panel) : null;
-    if (!head || head.__jfyInstanceUI) return;
-    head.__jfyInstanceUI = true;
-
-    const wrap = document.createElement("div");
-    wrap.className = "inline";
-    wrap.style.display = "flex";
-    wrap.style.gap = "8px";
-    wrap.style.alignItems = "center";
-
-    const lab = document.createElement("span");
-    lab.className = "muted";
-    lab.textContent = "Profile";
-
-    const sel = document.createElement("select");
-    sel.id = "jellyfin_instance";
-sel.name = "jellyfin_instance";
-    sel.className = "input";
-    sel.style.minWidth = "160px";
-
-    const btnNew = document.createElement("button");
-    btnNew.type = "button";
-    btnNew.className = "btn secondary";
-    btnNew.textContent = "New";
-
-    const btnDel = document.createElement("button");
-    btnDel.type = "button";
-    btnDel.className = "btn secondary";
-    btnDel.textContent = "Delete";
-
-    wrap.appendChild(lab);
-    wrap.appendChild(sel);
-    wrap.appendChild(btnNew);
-    wrap.appendChild(btnDel);
-
-    head.appendChild(wrap);
-
-    sel.addEventListener("change", () => {
-      setJfyInstance(sel.value);
+    jfyProfile?.ensureUI(() => {
       hydrated = false;
       hydrateFromConfig(true);
       jfyLoadLibraries?.();
     });
-
-    btnNew.addEventListener("click", async () => {
-      try {
-        const r = await fetch(`/api/provider-instances/jellyfin/next?ts=${Date.now()}`, { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}", cache: "no-store" });
-        const j = await r.json().catch(() => ({}));
-        const id = String((j && j.id) || "").trim();
-        if (!r.ok || (j && j.ok === false) || !id) { _notify("Could not create profile"); return; }
-        setJfyInstance(id);
-        await refreshJfyInstanceOptions(true);
-        sel.value = id;
-        hydrated = false;
-        hydrateFromConfig(true);
-      } catch { _notify("Could not create profile"); }
-    });
-
-    btnDel.addEventListener("click", async () => {
-      const id = getJfyInstance();
-      if (id === "default") { _notify("Default profile cannot be deleted"); return; }
-      if (!confirm(`Delete Jellyfin profile '${id}'?`)) return;
-      try {
-        const r = await fetch(`/api/provider-instances/jellyfin/${encodeURIComponent(id)}`, { method: "DELETE", cache: "no-store" });
-        const j = await r.json().catch(() => ({}));
-        if (!(j && j.ok)) { _notify("Could not delete profile"); return; }
-        await refreshJfyInstanceOptions(false);
-        setJfyInstance("default");
-        sel.value = "default";
-        hydrated = false;
-        hydrateFromConfig(true);
-      } catch { _notify("Could not delete profile"); }
-    });
-
-    refreshJfyInstanceOptions(true);
-    setTimeout(() => { try { sel.value = getJfyInstance(); } catch {} }, 0);
   }
 
 
@@ -199,15 +100,17 @@ sel.name = "jellyfin_instance";
 
 
   const put = (sel, val) => { const el = Q(sel); if (el != null) el.value = (val ?? "") + ""; };
-  const maskToken = (has) => { const el = Q("#jfy_tok"); if (el) { el.value = has ? "••••••••" : ""; el.dataset.masked = has ? "1" : "0"; } };
   const visible = (el) => !!el && getComputedStyle(el).display !== "none" && !el.hidden;
 
   function setMsgBanner(msg, kind, text) {
-    if (!msg) return;
-    msg.classList.remove('hidden', 'ok', 'warn');
-    if (!kind) { msg.classList.add('hidden'); msg.textContent = ''; return; }
-    msg.classList.add(kind);
-    msg.textContent = text || '';
+    return Shared.setStatusPill(msg, kind, text);
+  }
+
+  function setConnected(has) {
+    connected = !!has;
+    const msg = Q("#jfy_msg");
+    if (connected) setMsgBanner(msg, "ok", "Connected");
+    else setMsgBanner(msg, null, "");
   }
 
   function applyFilter() {
@@ -279,8 +182,7 @@ sel.name = "jellyfin_instance";
   function jfySectionLooksEmpty() {
     const s1 = Q("#jfy_server") || Q("#jfy_server_url");
     const u1 = Q("#jfy_user") || Q("#jfy_username");
-    const tok = Q("#jfy_tok");
-    const vals = [s1, u1, tok].map(el => el ? String(el.value || "").trim() : "");
+    const vals = [s1, u1].map(el => el ? String(el.value || "").trim() : "");
     return vals.every(v => !v);
   }
 
@@ -299,7 +201,7 @@ sel.name = "jellyfin_instance";
       const v1 = Q("#jfy_verify_ssl"), v2 = Q("#jfy_verify_ssl_dup");
       if (v1) v1.checked = !!jf.verify_ssl;
       if (v2) v2.checked = !!jf.verify_ssl;
-      maskToken(!!(jf.access_token || "").trim());
+      setConnected(!!(jf.access_token || "").trim());
 
       H = new Set((jf.history?.libraries || []).map(String));
       R = new Set((jf.ratings?.libraries || []).map(String));
@@ -365,8 +267,8 @@ sel.name = "jellyfin_instance";
       if (!r.ok || j?.ok === false) { setMsgBanner(msg, 'warn', 'Login failed'); return; }
       put("#jfy_server_url", server); put("#jfy_username", username);
       if (j?.user_id) put("#jfy_user_id", j.user_id);
-      maskToken(true); if (Q("#jfy_pass")) Q("#jfy_pass").value = "";
-      setMsgBanner(msg, 'ok', 'Connected.');
+      setConnected(true); if (Q("#jfy_pass")) Q("#jfy_pass").value = "";
+      setMsgBanner(msg, 'ok', 'Connected');
       await jfyLoadLibraries();
     } finally { if (btn) { btn.disabled = false; btn.classList.remove("busy"); } }
   }
@@ -385,9 +287,9 @@ sel.name = "jellyfin_instance";
       });
       const j = await r.json().catch(() => ({}));
       if (r.ok && (j.ok !== false)) {
-        const tok = document.querySelector('#jfy_tok'); if (tok) { tok.value = ''; tok.dataset.masked = '0'; }
         const pass = document.querySelector('#jfy_pass'); if (pass) pass.value = '';
-        if (msg) { msg.className = 'msg'; msg.textContent = 'Access token removed.'; }
+        setConnected(false);
+        if (msg) { msg.className = 'msg'; msg.textContent = 'Disconnected'; }
       } else {
         if (msg) { msg.className = 'msg warn'; msg.textContent = 'Could not remove token.'; }
       }
@@ -510,6 +412,18 @@ sel.name = "jellyfin_instance";
   document.addEventListener("click", (ev) => {
     const t = ev?.target;
     if (t && t.id === "jfy_pick_user") jfyPickUser(ev);
+    if (t && t.id === "btn-jfy-login") jfyLogin();
+    if (t && t.id === "btn-jfy-delete") jfyDeleteToken();
+    if (t && t.id === "btn-jfy-auto") jfyAuto();
+    if (t && t.id === "btn-jfy-load-libraries") jfyLoadLibraries();
+  }, true);
+
+  document.addEventListener("change", (ev) => {
+    const t = ev?.target;
+    if (t && t.id === "jfy_verify_ssl_dup") {
+      const primary = Q("#jfy_verify_ssl");
+      if (primary) primary.checked = !!t.checked;
+    }
   }, true);
 
   window.jfyAuto = jfyAuto;
@@ -521,4 +435,3 @@ sel.name = "jellyfin_instance";
   window.registerSettingsCollector?.(mergeJellyfinIntoCfg);
   document.addEventListener("settings-collect", (e) => { try { mergeJellyfinIntoCfg(e?.detail?.cfg || (window.__cfg ||= {})); } catch {} }, true);
 })();
-

--- a/assets/auth/auth.mdblist.js
+++ b/assets/auth/auth.mdblist.js
@@ -3,11 +3,19 @@
   if (window._mdblPatched) return;
   window._mdblPatched = true;
 
-  const el = (id) => document.getElementById(id);
-  const txt = (v) => (typeof v === "string" ? v : "").trim();
-  const note = (m) => (typeof window.notify === "function" ? window.notify(m) : void 0);
+  const Shared = window.CW.AuthShared;
+  const el = Shared.el;
+  const txt = Shared.txt;
+  const note = Shared.notify;
   const MASK = "********";
-  const MDBLIST_INSTANCE_KEY = "cw.ui.mdblist.auth.instance.v1";
+  const profile = Shared.createProfileAdapter({
+    provider: "mdblist",
+    configKey: "mdblist",
+    label: "MDBList",
+    sectionId: "sec-mdblist",
+    selectId: "mdblist_instance",
+    storageKey: "cw.ui.mdblist.auth.instance.v1",
+  });
   let pollTimer = null;
   let methodOverride = "";
 
@@ -25,30 +33,19 @@
   }
 
   function getMDBListInstance() {
-    var s = el("mdblist_instance");
-    var v = s ? txt(s.value) : "";
-    if (!v) { try { v = localStorage.getItem(MDBLIST_INSTANCE_KEY) || ""; } catch (_) {} }
-    v = txt(v) || "default";
-    return v.toLowerCase() === "default" ? "default" : v;
+    return profile ? profile.getInstance() : "default";
   }
 
   function setMDBListInstance(v) {
-    var id = txt(String(v || "")) || "default";
-    try { localStorage.setItem(MDBLIST_INSTANCE_KEY, id); } catch (_) {}
-    var s = el("mdblist_instance");
-    if (s) s.value = id;
+    if (profile) profile.setInstance(v);
   }
 
   function mdblApi(path) {
-    var p = String(path || "");
-    var sep = p.indexOf("?") >= 0 ? "&" : "?";
-    return p + sep + "instance=" + encodeURIComponent(getMDBListInstance()) + "&ts=" + Date.now();
+    return profile ? profile.api(path) : String(path || "");
   }
 
   async function fetchJSON(url, opts) {
-    const r = await fetch(url, opts || {});
-    let j = null; try { j = await r.json(); } catch {}
-    return { ok: r.ok, data: j };
+    return Shared.fetchJSON(url, opts);
   }
 
   function friendlyError(code) {
@@ -65,18 +62,11 @@
   }
 
   async function getCfg() {
-    const r = await fetchJSON("/api/config?ts=" + Date.now(), { cache: "no-store" });
-    return r.ok ? (r.data || {}) : {};
+    return Shared.getConfig();
   }
 
   function getMDBListCfgBlock(cfg) {
-    cfg = cfg || {};
-    var base = (cfg.mdblist && typeof cfg.mdblist === "object") ? cfg.mdblist : (cfg.mdblist = {});
-    var inst = getMDBListInstance();
-    if (inst === "default") return base;
-    if (!base.instances || typeof base.instances !== "object") base.instances = {};
-    if (!base.instances[inst] || typeof base.instances[inst] !== "object") base.instances[inst] = {};
-    return base.instances[inst];
+    return profile ? profile.cfgBlock(cfg, true) : {};
   }
 
   function activeMethodFromBlock(blk) {
@@ -97,44 +87,15 @@
   }
 
   function setConn(ok, msg) {
-    const m = el("mdblist_msg");
-    if (!m) return;
-    m.textContent = ok ? (msg || "Connected.") : (msg || "Not connected");
-    m.classList.remove("hidden", "ok", "warn");
-    m.classList.add(ok ? "ok" : "warn");
+    return Shared.setStatus("mdblist_msg", ok, msg);
   }
 
   function maskInput(i, has) {
-    if (!i) return;
-    if (has) { i.value = MASK; i.dataset.masked = "1"; }
-    else { i.value = ""; i.dataset.masked = "0"; }
-    i.dataset.loaded = "1";
-    i.dataset.touched = "";
-    i.dataset.clear = "";
-    i.dataset.hasKey = has ? "1" : "";
-  }
-
-  function setReadonlySecret(id, has) {
-    const i = el(id);
-    if (!i) return;
-    i.value = has ? MASK : "";
-    i.dataset.masked = has ? "1" : "0";
+    return Shared.maskSecret(i, has, { mask: MASK });
   }
 
   async function copyField(id, btn) {
-    const i = el(id);
-    const value = txt(i?.value);
-    if (!value || isMaskedSecret(value)) return note("Nothing to copy");
-    try {
-      await navigator.clipboard.writeText(value);
-      if (btn) {
-        const old = btn.textContent;
-        btn.textContent = "Copied";
-        setTimeout(() => { btn.textContent = old || "Copy"; }, 900);
-      }
-    } catch (_) {
-      note("Copy failed");
-    }
+    return Shared.copyField(id, btn, { emptyMessage: "Nothing to copy" });
   }
 
   function setMethodUI(method) {
@@ -160,74 +121,15 @@
   }
 
   async function refreshMDBListInstanceOptions(preserve) {
-    var sel = el("mdblist_instance");
-    if (!sel) return;
-    var want = preserve === false ? "default" : getMDBListInstance();
-    try {
-      var r = await fetch("/api/provider-instances/mdblist?ts=" + Date.now(), { cache: "no-store" });
-      var arr = await r.json().catch(function(){ return []; });
-      var opts = Array.isArray(arr) ? arr : [];
-      sel.innerHTML = "";
-      function addOpt(id, label) {
-        var o = document.createElement("option");
-        o.value = String(id);
-        o.textContent = String(label || id);
-        sel.appendChild(o);
-      }
-      addOpt("default", "Default");
-      opts.forEach(function(o){ if (o && o.id && o.id !== "default") addOpt(o.id, o.label || o.id); });
-      if (!Array.from(sel.options).some(function(o){ return o.value === want; })) want = "default";
-      sel.value = want;
-      setMDBListInstance(want);
-    } catch (_) {}
+    if (profile) await profile.refreshOptions(preserve);
   }
 
   function ensureMDBListInstanceUI() {
-    var panel = document.querySelector('#sec-mdblist .cw-meta-provider-panel[data-provider="mdblist"]') || document.querySelector('#sec-mdblist .cw-meta-provider-panel') || document.querySelector('#sec-mdblist');
-    var head = panel ? panel.querySelector('.cw-panel-head') : null;
-    if (!head || head.__mdblistInstanceUI) return;
-    head.__mdblistInstanceUI = true;
-
-    var wrap = document.createElement('div');
-    wrap.className = 'inline';
-    wrap.style.display = 'flex';
-    wrap.style.gap = '8px';
-    wrap.style.alignItems = 'center';
-    wrap.style.marginLeft = 'auto';
-    wrap.style.flexWrap = 'nowrap';
-
-    var lab = document.createElement('span');
-    lab.className = 'muted';
-    lab.textContent = 'Profile';
-
-    var sel = document.createElement('select');
-    sel.id = 'mdblist_instance';
-    sel.name = 'mdblist_instance';
-    sel.className = 'input';
-    sel.style.minWidth = '160px';
-    sel.style.width = 'auto';
-    sel.style.maxWidth = '220px';
-    sel.style.flex = '0 0 auto';
-
-    var btnNew = document.createElement('button');
-    btnNew.type = 'button';
-    btnNew.className = 'btn secondary';
-    btnNew.id = 'mdblist_instance_new';
-    btnNew.textContent = 'New';
-
-    var btnDel = document.createElement('button');
-    btnDel.type = 'button';
-    btnDel.className = 'btn secondary';
-    btnDel.id = 'mdblist_instance_del';
-    btnDel.textContent = 'Delete';
-
-    wrap.appendChild(lab);
-    wrap.appendChild(sel);
-    wrap.appendChild(btnNew);
-    wrap.appendChild(btnDel);
-    head.appendChild(wrap);
-
-    refreshMDBListInstanceOptions(true);
+    profile?.ensureUI(() => {
+      methodOverride = "";
+      stopPoll();
+      void hydrate();
+    });
   }
 
   async function saveAuth(payload) {
@@ -248,15 +150,14 @@
       const statusMethod = activeMethodFromStatus(data);
       const method = methodOverride || statusMethod;
       setMethodUI(method);
-      setReadonlySecret("mdblist_access_token", !!data.device_configured);
       if (data.pending) {
         const code = el("mdblist_device_code");
         if (code && data.pending.user_code) code.value = txt(data.pending.user_code);
         if (data.pending.user_code && !pollTimer) startPoll(Math.max(2, Number(data.pending.interval || 5)));
       }
-      let msg = ok ? (statusMethod === "api_key" ? "Connected with API key." : "Connected with Device Code.") : "Not connected";
+      let msg = ok ? (statusMethod === "api_key" ? "Connected with API key" : "Connected with Device Code") : "Not connected";
       if (data.pending && !data.device_configured) msg = "Waiting for Device Code approval";
-      if (ok && data.expires_at && statusMethod === "device_code") msg = "Connected with Device Code.";
+      if (ok && data.expires_at && statusMethod === "device_code") msg = "Connected with Device Code";
       setConn(data.pending && !data.device_configured ? false : ok, msg);
       if (showToast) note(ok ? "MDBList verified" : "MDBList not connected");
     } catch {
@@ -271,7 +172,6 @@
     const blk = getMDBListCfgBlock(cfg);
     const method = methodOverride || activeMethodFromBlock(blk);
     setMethodUI(method);
-    setReadonlySecret("mdblist_access_token", !!txt(blk?.access_token));
     const hasApiKey = !!txt(blk?.api_key);
     maskInput(el("mdblist_key"), hasApiKey);
     setApiHintVisible(!hasApiKey);
@@ -389,7 +289,6 @@
       if (!r.ok || (r.data && r.data.ok === false)) throw new Error("disconnect_failed");
       maskInput(el("mdblist_key"), false);
       const code = el("mdblist_device_code"); if (code) code.value = "";
-      setReadonlySecret("mdblist_access_token", false);
       setConn(false);
       note("MDBList disconnected");
       await hydrate();
@@ -405,8 +304,6 @@
     if (s && !s.__wired) { s.addEventListener("click", onSaveApiKey); s.__wired = true; }
     const start = el("mdblist_device_start");
     if (start && !start.__wired) { start.addEventListener("click", onDeviceStart); start.__wired = true; }
-    const copyTok = el("mdblist_copy_token");
-    if (copyTok && !copyTok.__wired) { copyTok.addEventListener("click", () => copyField("mdblist_access_token", copyTok)); copyTok.__wired = true; }
     const copyCode = el("mdblist_copy_code");
     if (copyCode && !copyCode.__wired) { copyCode.addEventListener("click", () => copyField("mdblist_device_code", copyCode)); copyCode.__wired = true; }
     const d = el("mdblist_disconnect");
@@ -417,73 +314,8 @@
     if (da && !da.__wired) { da.addEventListener("click", onDisc); da.__wired = true; }
     const k = el("mdblist_key");
     if (k && !k.__wiredSecret) {
-      const clearMask = () => {
-        if (k.dataset.masked === "1") {
-          k.value = "";
-          k.dataset.masked = "0";
-          k.dataset.touched = "1";
-          k.dataset.hasKey = "";
-        }
-      };
-      k.addEventListener("focus", clearMask);
-      k.addEventListener("beforeinput", clearMask);
-      k.addEventListener("input", () => {
-        k.dataset.masked = isMaskedSecret(k.value) ? "1" : "0";
-        k.dataset.touched = "1";
-        if (k.dataset.masked !== "1") k.dataset.hasKey = "";
-      });
+      Shared.wireSecretInput(k);
       k.__wiredSecret = true;
-    }
-    const sel = el("mdblist_instance");
-    if (sel && !sel.__wiredMdbl) {
-      sel.addEventListener("change", function () {
-        setMDBListInstance(sel.value);
-        methodOverride = "";
-        stopPoll();
-        void hydrate();
-      });
-      sel.__wiredMdbl = true;
-    }
-    const btnNew = el("mdblist_instance_new");
-    if (btnNew && !btnNew.__wiredMdbl) {
-      btnNew.addEventListener("click", async function () {
-        try {
-          var r = await fetch("/api/provider-instances/mdblist/next?ts=" + Date.now(), {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: "{}",
-            cache: "no-store"
-          });
-          var j = await r.json().catch(function(){ return {}; });
-          var id = txt((j && j.id) || "");
-          if (!r.ok || (j && j.ok === false) || !id) throw new Error(String((j && j.error) || "create_failed"));
-          setMDBListInstance(id);
-          await refreshMDBListInstanceOptions(true);
-          void hydrate();
-        } catch (e) {
-          note("Could not create profile: " + (e && e.message ? e.message : e));
-        }
-      });
-      btnNew.__wiredMdbl = true;
-    }
-    const btnDel = el("mdblist_instance_del");
-    if (btnDel && !btnDel.__wiredMdbl) {
-      btnDel.addEventListener("click", async function () {
-        var id = getMDBListInstance();
-        if (id === "default") return note("Default profile cannot be deleted.");
-        if (!confirm('Delete MDBList profile "' + id + '"?')) return;
-        try {
-          var r = await fetch("/api/provider-instances/mdblist/" + encodeURIComponent(id), { method: "DELETE", cache: "no-store" });
-          var j = await r.json().catch(function(){ return {}; });
-          if (!r.ok || (j && j.ok === false)) throw new Error(String((j && j.error) || "delete_failed"));
-          setMDBListInstance("default");
-          await refreshMDBListInstanceOptions(false);
-          void hydrate();
-        } catch (e) {
-          note("Could not delete profile: " + (e && e.message ? e.message : e));
-        }
-      });
-      btnDel.__wiredMdbl = true;
     }
   }
 

--- a/assets/auth/auth.plex.js
+++ b/assets/auth/auth.plex.js
@@ -1,9 +1,10 @@
 // auth.plex.js - Plex auth
 (function (w, d) {
 
+  const Shared = w.CW && w.CW.AuthShared;
   const $ = (s) => d.getElementById(s);
   const q = (sel, root = d) => root.querySelector(sel);
-  const notify = w.notify || ((m) => console.log("[notify]", m));
+  const notify = Shared.notify;
   const bust = () => `?ts=${Date.now()}`;
   const exists = (sel) => !!q(sel);
   function waitFor(sel, timeout = 12000) {
@@ -20,159 +21,46 @@
 
   const PLEX_SUBTAB_KEY = "cw.ui.plex.auth.subtab.v1";
 
-const PLEX_INSTANCE_KEY = "cw.ui.plex.auth.instance.v1";
+const plexProfile = Shared.createProfileAdapter({
+  provider: "plex",
+  configKey: "plex",
+  label: "Plex",
+  sectionId: "sec-plex",
+  selectId: "plex_instance",
+  storageKey: "cw.ui.plex.auth.instance.v1",
+  title: "Select which Plex account this config applies to.",
+});
 
 function getPlexInstance() {
-  const el = $("plex_instance");
-  let v = el ? String(el.value || "").trim() : "";
-  if (!v) { try { v = localStorage.getItem(PLEX_INSTANCE_KEY) || ""; } catch {} }
-  v = (v || "").trim() || "default";
-  return v.toLowerCase() === "default" ? "default" : v;
+  return plexProfile ? plexProfile.getInstance() : "default";
 }
 
 function setPlexInstance(v) {
-  const id = (String(v || "").trim() || "default");
-  try { localStorage.setItem(PLEX_INSTANCE_KEY, id); } catch {}
-  const el = $("plex_instance");
-  if (el) el.value = id;
+  if (plexProfile) plexProfile.setInstance(v);
 }
 
 function plexApi(path) {
-  const p = String(path || "");
-  const sep = p.includes("?") ? "&" : "?";
-  return p + sep + "instance=" + encodeURIComponent(getPlexInstance()) + "&ts=" + Date.now();
+  return plexProfile ? plexProfile.api(path) : String(path || "");
 }
 
 function getPlexCfgBlock(cfg) {
-  cfg = cfg || {};
-  const base = (cfg.plex && typeof cfg.plex === "object") ? cfg.plex : (cfg.plex = {});
-  const inst = getPlexInstance();
-  if (inst === "default") return base;
-  return (base.instances && typeof base.instances === "object" && base.instances[inst] && typeof base.instances[inst] === "object")
-    ? base.instances[inst]
-    : {};
+  return plexProfile ? plexProfile.cfgBlock(cfg, false) : {};
 }
 
 function ensurePlexCfgBlock(cfg) {
-  cfg = cfg || {};
-  const base = (cfg.plex && typeof cfg.plex === "object") ? cfg.plex : (cfg.plex = {});
-  const inst = getPlexInstance();
-  if (inst === "default") return base;
-  if (!base.instances || typeof base.instances !== "object") base.instances = {};
-  if (!base.instances[inst] || typeof base.instances[inst] !== "object") base.instances[inst] = {};
-  return base.instances[inst];
+  return plexProfile ? plexProfile.cfgBlock(cfg, true) : {};
 }
 
 async function refreshPlexInstanceOptions(preserve = true) {
-  const sel = $("plex_instance");
-  if (!sel) return;
-  let want = preserve ? getPlexInstance() : "default";
-  try {
-    const r = await fetch("/api/provider-instances/plex?ts=" + Date.now(), { cache: "no-store" });
-    const arr = await r.json().catch(() => []);
-    const opts = Array.isArray(arr) ? arr : [];
-
-    sel.innerHTML = "";
-    const addOpt = (id, label) => {
-      const o = d.createElement("option");
-      o.value = String(id);
-      o.textContent = String(label || id);
-      sel.appendChild(o);
-    };
-
-    addOpt("default", "Default");
-    opts.forEach((o) => { if (o && o.id && o.id !== "default") addOpt(o.id, o.label || o.id); });
-
-    if (!Array.from(sel.options).some(o => o.value === want)) want = "default";
-    sel.value = want;
-    setPlexInstance(want);
-  } catch {}
+  if (plexProfile) await plexProfile.refreshOptions(preserve);
 }
 
 function ensurePlexInstanceUI() {
-  const panel = q('#sec-plex .cw-meta-provider-panel[data-provider="plex"]');
-  const head = panel ? q(".cw-panel-head", panel) : null;
-  if (!head || head.__plexInstanceUI) return;
-  head.__plexInstanceUI = true;
-
-  const wrap = d.createElement("div");
-  wrap.className = "inline";
-  wrap.style.display = "flex";
-  wrap.style.gap = "8px";
-  wrap.style.alignItems = "center";
-  wrap.title = "Select which Plex account this config applies to.";
-
-  const lab = d.createElement("span");
-  lab.className = "muted";
-  lab.textContent = "Profile";
-
-  const sel = d.createElement("select");
-  sel.id = "plex_instance";
-sel.name = "plex_instance";
-  sel.className = "input";
-  sel.style.minWidth = "160px";
-
-  const btnNew = d.createElement("button");
-  btnNew.type = "button";
-  btnNew.className = "btn secondary";
-  btnNew.id = "plex_instance_new";
-  btnNew.textContent = "New";
-
-  const btnDel = d.createElement("button");
-  btnDel.type = "button";
-  btnDel.className = "btn secondary";
-  btnDel.id = "plex_instance_del";
-  btnDel.textContent = "Delete";
-
-  wrap.appendChild(lab);
-  wrap.appendChild(sel);
-  wrap.appendChild(btnNew);
-  wrap.appendChild(btnDel);
-  head.appendChild(wrap);
-
-  refreshPlexInstanceOptions(true);
-
-  sel.addEventListener("change", async () => {
-    setPlexInstance(sel.value);
+  plexProfile?.ensureUI(async () => {
     try { await hydratePlexFromConfigRaw(); } catch {}
     try { refreshPlexLibraries(); } catch {}
     try { mountPlexUserPicker(); } catch {}
     try { schedulePlexPmsProbe(200); } catch {}
-  });
-
-  btnNew.addEventListener("click", async () => {
-    try {
-      const r = await fetch(`/api/provider-instances/plex/next?ts=${Date.now()}`, { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}", cache: "no-store" });
-      const j = await r.json().catch(() => ({}));
-      const id = String(j?.id || "").trim();
-      if (!r.ok || j?.ok === false || !id) throw new Error(String(j?.error || "create_failed"));
-      setPlexInstance(id);
-      await refreshPlexInstanceOptions(true);
-      sel.value = id;
-      try { await hydratePlexFromConfigRaw(); } catch {}
-      try { refreshPlexLibraries(); } catch {}
-      try { mountPlexUserPicker(); } catch {}
-      try { schedulePlexPmsProbe(200); } catch {}
-    } catch (e) {
-      notify("Could not create profile: " + (e?.message || e));
-    }
-  });
-
-  btnDel.addEventListener("click", async () => {
-    const id = getPlexInstance();
-    if (id === "default") return notify("Default profile cannot be deleted.");
-    if (!confirm(`Delete Plex profile "${id}"?`)) return;
-    try {
-      const r = await fetch(`/api/provider-instances/plex/${encodeURIComponent(id)}`, { method: "DELETE", cache: "no-store" });
-      const j = await r.json().catch(() => ({}));
-      if (!r.ok || j?.ok === false) throw new Error(String(j?.error || "delete_failed"));
-      setPlexInstance("default");
-      await refreshPlexInstanceOptions(false);
-      sel.value = "default";
-      try { await hydratePlexFromConfigRaw(); } catch {}
-    } catch (e) {
-      notify("Could not delete profile: " + (e?.message || e));
-    }
   });
 }
 
@@ -230,7 +118,9 @@ sel.name = "plex_instance";
     __plexHydrateTimer = setTimeout(async () => {
       try { ensurePlexInstanceUI(); } catch {}
       try { mountPlexAuthTabs(); } catch {}
-      if (!$("plex_token") || !$("plex_server_url") || !$("plex_username")) return;
+      try { wirePlexCopyButton(); } catch {}
+      try { wirePlexActionButtons(); } catch {}
+      if (!$("plex_server_url") || !$("plex_username")) return;
       if (__plexHydrateBusy) return;
       __plexHydrateBusy = true;
       try { await hydratePlexFromConfigRaw(); } catch {}
@@ -258,12 +148,7 @@ sel.name = "plex_instance";
 
   // status banner
   function setPlexBanner(kind, text) {
-    const el = $("plex_msg");
-    if (!el) return;
-    el.classList.remove("hidden", "ok", "warn");
-    if (!kind) { el.classList.add("hidden"); el.textContent = ""; return; }
-    el.classList.add(kind);
-    el.textContent = text || "";
+    return Shared.setStatusPill("plex_msg", kind, text);
   }
 
   function ensurePlexPanelNotice() {
@@ -324,6 +209,7 @@ sel.name = "plex_instance";
   }
 
   function setPlexSuccess(on, text) {
+    try { getPlexState().connected = !!on; } catch {}
     if (on) setPlexBanner("ok", text || "Connected");
     else { setPlexBanner(null, ""); setPlexBannerDetail(null, ""); }
   }
@@ -334,6 +220,25 @@ sel.name = "plex_instance";
     schedulePlexPmsProbe(200);
   }
 
+  async function copyPlexPin(btn) {
+    return Shared.copyField("plex_pin", btn);
+  }
+
+  function wirePlexCopyButton() {
+    Shared.wireCopyButton("btn-copy-plex-pin", "plex_pin");
+  }
+
+  function wirePlexActionButtons() {
+    const connect = $("btn-connect-plex");
+    if (connect && !connect.__wired) { connect.addEventListener("click", requestPlexPin); connect.__wired = true; }
+    const del = $("btn-delete-plex");
+    if (del && !del.__wired) { del.addEventListener("click", plexDeleteToken); del.__wired = true; }
+    const auto = $("btn-plex-auto");
+    if (auto && !auto.__wired) { auto.addEventListener("click", plexAuto); auto.__wired = true; }
+    const libs = $("btn-plex-load-libraries");
+    if (libs && !libs.__wired) { libs.addEventListener("click", refreshPlexLibraries); libs.__wired = true; }
+  }
+
   let __plexProbeT = null;
   function schedulePlexPmsProbe(delayMs = 400) {
     try { if (__plexProbeT) clearTimeout(__plexProbeT); } catch {}
@@ -341,7 +246,8 @@ sel.name = "plex_instance";
   }
 
   async function plexProbePmsReachability() {
-    const tok = String($("plex_token")?.value || "").trim();
+    const cfg = await fetch("/api/config" + bust(), { cache: "no-store" }).then(r => r.json()).catch(() => ({}));
+    const tok = String(getPlexCfgBlock(cfg || {}).account_token || "").trim();
     if (!tok) { setPlexBannerDetail(null, ""); return; }
     try {
       const r = await fetch(plexApi("/api/plex/pms/probe"), { cache: "no-store" });
@@ -379,9 +285,10 @@ sel.name = "plex_instance";
     const pin = data.code || data.pin || data.id || "";
     try {
       d.querySelectorAll('#plex_pin, input[name="plex_pin"]').forEach(el => { el.value = pin; });
-      const msg = $("plex_msg"); if (msg) { msg.textContent = pin ? ("PIN: " + pin) : "PIN request ok"; msg.classList.remove("hidden"); }
+      const msg = $("plex_msg");
+      if (msg && !pin) setPlexBanner("warn", "PIN request failed");
       try { setPlexBannerDetail(null, ""); } catch {}
-      if (pin) { try { await navigator.clipboard.writeText(pin); } catch {} }
+      if (pin) { try { await Shared.copyText(pin, null, { failureMessage: false }); } catch {} }
       if (win && !win.closed) {
         try { win.focus(); } catch {}
       } else {
@@ -423,8 +330,6 @@ sel.name = "plex_instance";
       if (tok) {
         if (tok !== lastTok) { lastTok = tok; inspectTried = false; }
         try {
-          const tokenEl = $("plex_token");
-          if (tokenEl) tokenEl.value = tok;
 
           const urlEl  = $("plex_server_url");
           const userEl = $("plex_username");
@@ -495,8 +400,8 @@ async function plexDeleteToken() {
     });
     const j = await r.json().catch(() => ({}));
     if (r.ok && (j.ok !== false)) {
-      ["plex_token", "plex_pin", "plex_username", "plex_account_id"].forEach((id) => { const el = $(id); if (el) el.value = ""; });
-      try { getPlexState().libs = []; } catch {}
+      ["plex_pin", "plex_username", "plex_account_id"].forEach((id) => { const el = $(id); if (el) el.value = ""; });
+      try { const st = getPlexState(); st.libs = []; st.connected = false; } catch {}
       try { setPlexBanner("warn", "Disconnected"); } catch {}
       try { setPlexBannerDetail("warn", "Token deleted and saved."); } catch {}
       try { notify("Plex disconnected (saved)."); } catch {}
@@ -514,7 +419,7 @@ async function plexDeleteToken() {
 }
 
 
-  function getPlexState() { return (w.__plexState ||= { hist: new Set(), rate: new Set(), scr: new Set(), libs: [], hydrated: false }); }
+  function getPlexState() { return (w.__plexState ||= { hist: new Set(), rate: new Set(), scr: new Set(), libs: [], hydrated: false, connected: false }); }
 
   // Config
   async function hydratePlexFromConfigRaw() {
@@ -523,7 +428,6 @@ async function plexDeleteToken() {
       const cfg = await r.json(); const p = getPlexCfgBlock(cfg);
       await waitFor("#plex_server_url"); await waitFor("#plex_username");
       const set = (id, val) => { const el = $(id); if (el != null && val != null) el.value = String(val); };
-      set("plex_token", p.account_token || "");
       const tok = String(p.account_token || '').trim();
       if (tok) setPlexConnected();
       else setPlexSuccess(false);
@@ -712,7 +616,8 @@ const tags = [
       return;
     }
 
-    const tok = String($("plex_token")?.value || "").trim();
+    const cfg = await fetch("/api/config" + bust(), { cache: "no-store" }).then(r => r.json()).catch(() => ({}));
+    const tok = String(getPlexCfgBlock(cfg || {}).account_token || "").trim();
     if (!tok) return;
 
     const inst = getPlexInstance();
@@ -1055,7 +960,7 @@ const tags = [
     try {
       const hasServer =
         (document.getElementById("plex_server_url")?.value?.trim() || "") &&
-        (document.getElementById("plex_token")?.value?.trim() || "");
+        getPlexState().connected;
       if (!libs.length && hasServer) {
         notify("No libraries could be loaded from Plex. Check the Server URL and make sure this is a Plex server your account can access.");
       }
@@ -1118,7 +1023,7 @@ const tags = [
       const libs = getPlexState().libs;
       const hasServer =
         (document.getElementById("plex_server_url")?.value?.trim() || "") &&
-        (document.getElementById("plex_token")?.value?.trim() || "");
+        getPlexState().connected;
       if (!libs.length && hasServer) {
         notify("No libraries could be loaded from Plex. Check the Server URL and make sure this is a Plex server your account can access.");
       }
@@ -1292,10 +1197,14 @@ const tags = [
 
   let __plexInitDone = false;
   function initPlexAuthUI() {
+    try { ensurePlexInstanceUI(); } catch {}
+    try { mountPlexAuthTabs(); } catch {}
+    try { wirePlexCopyButton(); } catch {}
+    try { wirePlexActionButtons(); } catch {}
+
     if (__plexInitDone) return;
     __plexInitDone = true;
     try { watchForPlexDom(); } catch {}
-    try { mountPlexAuthTabs(); } catch {}
     try { hookPlexSave(); } catch {}
     setTimeout(() => { try { hydratePlexFromConfigRaw(); } catch {} }, 100);
     setTimeout(() => { try { schedulePlexPmsProbe(300); } catch {} }, 450);
@@ -1341,6 +1250,8 @@ const tags = [
     if (onSettings) {
       try { watchForPlexDom(); } catch {}
       try { mountPlexAuthTabs(); } catch {}
+      try { wirePlexCopyButton(); } catch {}
+      try { wirePlexActionButtons(); } catch {}
       await waitFor("#plex_server_url");
       try { hydratePlexFromConfigRaw(); } catch {}
       try { await plexLoadLibraries(); } catch {}

--- a/assets/auth/auth.publicmetadb.js
+++ b/assets/auth/auth.publicmetadb.js
@@ -3,175 +3,50 @@
   if (window._publicMetaDBPatched) return;
   window._publicMetaDBPatched = true;
 
-  const el = (id) => document.getElementById(id);
-  const txt = (v) => (typeof v === "string" ? v : "").trim();
-  const note = (m) => (typeof window.notify === "function" ? window.notify(m) : void 0);
-
-  function isMaskedSecret(v) {
-    const value = txt(v);
-    if (!value) return false;
-    if (value === "********" || value === "**********") return true;
-    return /^[*]{3,}$/.test(value);
-  }
-
-  function readSecretField(i) {
-    const raw = txt(i && i.value);
-    const masked = !!(i && (i.dataset.masked === "1" || isMaskedSecret(raw)));
-    if (!raw && !masked) return { hasValue: false, masked: false, value: "" };
-    if (masked) return { hasValue: true, masked: true, value: "" };
-    return { hasValue: true, masked: false, value: raw };
-  }
-
-  const INSTANCE_KEY = "cw.ui.publicmetadb.auth.instance.v1";
+  const Shared = window.CW.AuthShared;
+  const el = Shared.el;
+  const txt = Shared.txt;
+  const note = Shared.notify;
+  const readSecretField = Shared.readSecretField;
+  const profile = Shared.createProfileAdapter({
+    provider: "publicmetadb",
+    configKey: "publicmetadb",
+    label: "PublicMetaDB",
+    sectionId: "sec-publicmetadb",
+    selectId: "publicmetadb_instance",
+    storageKey: "cw.ui.publicmetadb.auth.instance.v1",
+  });
 
   function getInstance() {
-    var s = el("publicmetadb_instance");
-    var v = s ? txt(s.value) : "";
-    if (!v) { try { v = localStorage.getItem(INSTANCE_KEY) || ""; } catch (_) {} }
-    v = txt(v) || "default";
-    return v.toLowerCase() === "default" ? "default" : v;
+    return profile ? profile.getInstance() : "default";
   }
 
   function setInstance(v) {
-    var id = txt(String(v || "")) || "default";
-    try { localStorage.setItem(INSTANCE_KEY, id); } catch (_) {}
-    var s = el("publicmetadb_instance");
-    if (s) s.value = id;
+    if (profile) profile.setInstance(v);
   }
 
   function api(path) {
-    var p = String(path || "");
-    var sep = p.indexOf("?") >= 0 ? "&" : "?";
-    return p + sep + "instance=" + encodeURIComponent(getInstance()) + "&ts=" + Date.now();
+    return profile ? profile.api(path) : String(path || "");
   }
 
   async function fetchJSON(url, opts) {
-    const r = await fetch(url, opts || {});
-    let j = null; try { j = await r.json(); } catch {}
-    return { ok: r.ok, data: j };
+    return Shared.fetchJSON(url, opts);
   }
 
   async function getCfg() {
-    const r = await fetchJSON("/api/config?ts=" + Date.now(), { cache: "no-store" });
-    return r.ok ? (r.data || {}) : {};
+    return Shared.getConfig();
   }
 
   function cfgBlock(cfg) {
-    cfg = cfg || {};
-    var base = (cfg.publicmetadb && typeof cfg.publicmetadb === "object") ? cfg.publicmetadb : (cfg.publicmetadb = {});
-    var inst = getInstance();
-    if (inst === "default") return base;
-    if (!base.instances || typeof base.instances !== "object") base.instances = {};
-    if (!base.instances[inst] || typeof base.instances[inst] !== "object") base.instances[inst] = {};
-    return base.instances[inst];
+    return profile ? profile.cfgBlock(cfg, true) : {};
   }
 
   async function refreshInstanceOptions(preserve) {
-    var sel = el("publicmetadb_instance");
-    if (!sel) return;
-    var want = preserve === false ? "default" : getInstance();
-    try {
-      var r = await fetch("/api/provider-instances/publicmetadb?ts=" + Date.now(), { cache: "no-store" });
-      var arr = await r.json().catch(function(){ return []; });
-      var opts = Array.isArray(arr) ? arr : [];
-      sel.innerHTML = "";
-      function addOpt(id, label) {
-        var o = document.createElement("option");
-        o.value = String(id);
-        o.textContent = String(label || id);
-        sel.appendChild(o);
-      }
-      addOpt("default", "Default");
-      opts.forEach(function(o){ if (o && o.id && o.id !== "default") addOpt(o.id, o.label || o.id); });
-      if (!Array.from(sel.options).some(function(o){ return o.value === want; })) want = "default";
-      sel.value = want;
-      setInstance(want);
-    } catch (_) {}
+    if (profile) await profile.refreshOptions(preserve);
   }
 
   function ensureInstanceUI() {
-    var panel = document.querySelector('#sec-publicmetadb .cw-meta-provider-panel[data-provider="publicmetadb"]') || document.querySelector('#sec-publicmetadb');
-    var head = panel ? panel.querySelector('.cw-panel-head') : null;
-    if (!head || head.__publicmetadbInstanceUI) return;
-    head.__publicmetadbInstanceUI = true;
-
-    var wrap = document.createElement('div');
-    wrap.className = 'inline';
-    wrap.style.display = 'flex';
-    wrap.style.gap = '8px';
-    wrap.style.alignItems = 'center';
-    wrap.style.marginLeft = 'auto';
-    wrap.style.flexWrap = 'nowrap';
-
-    var lab = document.createElement('span');
-    lab.className = 'muted';
-    lab.textContent = 'Profile';
-
-    var sel = document.createElement('select');
-    sel.id = 'publicmetadb_instance';
-    sel.name = 'publicmetadb_instance';
-    sel.className = 'input';
-    sel.style.minWidth = '160px';
-    sel.style.width = 'auto';
-    sel.style.maxWidth = '220px';
-    sel.style.flex = '0 0 auto';
-
-    var btnNew = document.createElement('button');
-    btnNew.type = 'button';
-    btnNew.className = 'btn secondary';
-    btnNew.id = 'publicmetadb_instance_new';
-    btnNew.textContent = 'New';
-
-    var btnDel = document.createElement('button');
-    btnDel.type = 'button';
-    btnDel.className = 'btn secondary';
-    btnDel.id = 'publicmetadb_instance_del';
-    btnDel.textContent = 'Delete';
-
-    wrap.appendChild(lab);
-    wrap.appendChild(sel);
-    wrap.appendChild(btnNew);
-    wrap.appendChild(btnDel);
-    head.appendChild(wrap);
-
-    refreshInstanceOptions(true);
-    sel.addEventListener("change", function () {
-      setInstance(sel.value);
-      void hydrate();
-    });
-    btnNew.addEventListener("click", async function () {
-      try {
-        var r = await fetch("/api/provider-instances/publicmetadb/next?ts=" + Date.now(), {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: "{}",
-          cache: "no-store"
-        });
-        var j = await r.json().catch(function(){ return {}; });
-        var id = txt((j && j.id) || "");
-        if (!r.ok || (j && j.ok === false) || !id) throw new Error(String((j && j.error) || "create_failed"));
-        setInstance(id);
-        await refreshInstanceOptions(true);
-        void hydrate();
-      } catch (e) {
-        note("Could not create profile: " + (e && e.message ? e.message : e));
-      }
-    });
-    btnDel.addEventListener("click", async function () {
-      var id = getInstance();
-      if (id === "default") return note("Default profile cannot be deleted.");
-      if (!confirm('Delete PublicMetaDB profile "' + id + '"?')) return;
-      try {
-        var r = await fetch("/api/provider-instances/publicmetadb/" + encodeURIComponent(id), { method: "DELETE", cache: "no-store" });
-        var j = await r.json().catch(function(){ return {}; });
-        if (!r.ok || (j && j.ok === false)) throw new Error(String((j && j.error) || "delete_failed"));
-        setInstance("default");
-        await refreshInstanceOptions(false);
-        void hydrate();
-      } catch (e) {
-        note("Could not delete profile: " + (e && e.message ? e.message : e));
-      }
-    });
+    profile?.ensureUI(() => { void hydrate(); });
   }
 
   async function saveKey(key) {
@@ -180,23 +55,35 @@
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ api_key: key })
     });
-    if (!r.ok || (r.data && r.data.ok === false)) throw new Error("save_failed");
+    if (!r.ok || (r.data && r.data.ok === false)) throw new Error(friendlyError((r.data && r.data.error) || "save_failed"));
+  }
+
+  function friendlyError(code) {
+    switch (String(code || "")) {
+      case "api_key_required": return "Enter your PublicMetaDB API key";
+      case "invalid_api_key": return "Invalid PublicMetaDB API key";
+      case "validation_timeout": return "PublicMetaDB validation timed out";
+      case "validation_failed": return "Could not validate PublicMetaDB API key";
+      case "validation_bad_response": return "PublicMetaDB validation returned an unexpected response";
+      default:
+        if (String(code || "").startsWith("validation_http_")) {
+          return "PublicMetaDB validation failed";
+        }
+        return "Saving PublicMetaDB key failed";
+    }
   }
 
   function setConn(ok, msg) {
-    const m = el("publicmetadb_msg");
-    if (!m) return;
-    m.textContent = ok ? (msg || "Connected.") : (msg || "Not connected");
-    m.classList.remove("hidden", "ok", "warn");
-    m.classList.add(ok ? "ok" : "warn");
+    return Shared.setStatus("publicmetadb_msg", ok, msg);
   }
 
   async function refresh() {
     try {
       const r = await fetchJSON(api("/api/publicmetadb/status"), { cache: "no-store" });
       const ok = !!(r.ok && r.data && r.data.connected);
-      setConn(ok);
-      note(ok ? "PublicMetaDB verified" : "PublicMetaDB not connected");
+      const reason = String((r.data && r.data.reason) || "");
+      setConn(ok, ok || reason === "api_key_required" ? "" : friendlyError(reason));
+      note(ok ? "PublicMetaDB connected" : "PublicMetaDB not connected");
     } catch {
       setConn(false, "PublicMetaDB verify failed");
       note("PublicMetaDB verify failed");
@@ -204,13 +91,7 @@
   }
 
   function maskInput(i, has) {
-    if (!i) return;
-    if (has) { i.value = "********"; i.dataset.masked = "1"; }
-    else { i.value = ""; i.dataset.masked = "0"; }
-    i.dataset.loaded = "1";
-    i.dataset.touched = "";
-    i.dataset.clear = "";
-    i.dataset.hasKey = has ? "1" : "";
+    return Shared.maskSecret(i, has);
   }
 
   async function hydrate() {
@@ -236,8 +117,10 @@
       el("publicmetadb_hint")?.classList.add("hidden");
       note("PublicMetaDB key saved");
       await refresh();
-    } catch {
-      note("Saving PublicMetaDB key failed");
+    } catch (e) {
+      const msg = e && e.message ? e.message : "Saving PublicMetaDB key failed";
+      setConn(false, msg);
+      note(msg);
     }
   }
 
@@ -257,27 +140,11 @@
   function wire() {
     const s = el("publicmetadb_save");
     if (s && !s.__wired) { s.addEventListener("click", onSave); s.__wired = true; }
-    const v = el("publicmetadb_verify");
-    if (v && !v.__wired) { v.addEventListener("click", refresh); v.__wired = true; }
     const d = el("publicmetadb_disconnect");
     if (d && !d.__wired) { d.addEventListener("click", onDisc); d.__wired = true; }
     const k = el("publicmetadb_key");
     if (k && !k.__wiredSecret) {
-      const clearMask = () => {
-        if (k.dataset.masked === "1") {
-          k.value = "";
-          k.dataset.masked = "0";
-          k.dataset.touched = "1";
-          k.dataset.hasKey = "";
-        }
-      };
-      k.addEventListener("focus", clearMask);
-      k.addEventListener("beforeinput", clearMask);
-      k.addEventListener("input", () => {
-        k.dataset.masked = isMaskedSecret(k.value) ? "1" : "0";
-        k.dataset.touched = "1";
-        if (k.dataset.masked !== "1") k.dataset.hasKey = "";
-      });
+      Shared.wireSecretInput(k);
       k.__wiredSecret = true;
     }
   }

--- a/assets/auth/auth.shared.js
+++ b/assets/auth/auth.shared.js
@@ -1,0 +1,379 @@
+// assets/auth/auth.shared.js
+// Shared frontend helpers for auth provider panels.
+(function (w, d) {
+  if (w.CW?.AuthShared) return;
+
+  const el = (id) => d.getElementById(id);
+  const txt = (v) => (typeof v === "string" ? v : (v == null ? "" : String(v))).trim();
+  const notify = (m) => { try { if (typeof w.notify === "function") w.notify(m); } catch (_) {} };
+
+  function isMaskedSecret(v) {
+    const value = txt(v);
+    return !!value && (
+      value === "********" ||
+      value === "**********" ||
+      /^[*]{3,}$/.test(value) ||
+      (value.length >= 3 && !/[A-Za-z0-9]/.test(value))
+    );
+  }
+
+  function readSecretField(input) {
+    const raw = txt(input && input.value);
+    const masked = !!(input && (input.dataset.masked === "1" || isMaskedSecret(raw)));
+    if (!raw && !masked) return { hasValue: false, masked: false, value: "" };
+    if (masked) return { hasValue: true, masked: true, value: "" };
+    return { hasValue: true, masked: false, value: raw };
+  }
+
+  function maskSecret(input, hasValue, opts) {
+    if (!input) return;
+    const mask = txt(opts?.mask) || "********";
+    input.value = hasValue ? mask : "";
+    input.dataset.masked = hasValue ? "1" : "0";
+    input.dataset.loaded = "1";
+    input.dataset.touched = "";
+    input.dataset.clear = "";
+    input.dataset.hasKey = hasValue ? "1" : "";
+  }
+
+  function markSecretField(input, value) {
+    if (!input) return;
+    const text = txt(value);
+    input.value = text;
+    input.dataset.masked = isMaskedSecret(text) ? "1" : "0";
+    input.dataset.loaded = "1";
+    if (!input.dataset.touched) input.dataset.touched = "";
+  }
+
+  function wireSecretInput(input, opts) {
+    if (!input || input.__cwAuthSharedSecret) return;
+    const clearOnFocus = opts?.clearOnFocus !== false;
+    const clearMask = () => {
+      if (input.dataset.masked === "1") {
+        input.value = "";
+        input.dataset.masked = "0";
+        input.dataset.touched = "1";
+        input.dataset.hasKey = "";
+      }
+    };
+    if (clearOnFocus) input.addEventListener("focus", clearMask);
+    input.addEventListener("beforeinput", clearMask);
+    input.addEventListener("input", () => {
+      input.dataset.masked = isMaskedSecret(input.value) ? "1" : "0";
+      input.dataset.touched = "1";
+      if (input.dataset.masked !== "1") input.dataset.hasKey = "";
+      try { opts?.onInput?.(input); } catch (_) {}
+    });
+    input.__cwAuthSharedSecret = true;
+  }
+
+  async function fetchJSON(url, opts) {
+    const r = await fetch(url, opts || {});
+    let data = null;
+    try { data = await r.json(); } catch (_) {}
+    return { ok: r.ok, data, status: r.status };
+  }
+
+  async function getConfig() {
+    if (w._cfgCache) return w._cfgCache;
+    const r = await fetchJSON("/api/config?ts=" + Date.now(), { cache: "no-store" });
+    return r.ok ? (r.data || {}) : {};
+  }
+
+  function setStatusPill(target, state, msg) {
+    const node = typeof target === "string" ? el(target) : target;
+    if (!node) return;
+    node.classList.remove("hidden", "ok", "warn");
+
+    const value = typeof state === "boolean" ? (state ? "ok" : "warn") : txt(state).toLowerCase();
+    if (!value || value === "hidden" || value === "none" || value === "clear") {
+      node.classList.add("hidden");
+      node.textContent = "";
+      return;
+    }
+
+    const ok = value === "ok" || value === "connected" || value === "success";
+    node.classList.add(ok ? "ok" : "warn");
+    node.textContent = msg || (ok ? "Connected" : "Not connected");
+  }
+
+  function setStatus(msgId, ok, msg) {
+    setStatusPill(msgId, ok ? "ok" : "warn", msg);
+  }
+
+  function flashCopyButton(btn, text) {
+    if (!btn) return;
+    const old = btn.textContent;
+    btn.textContent = text || "Copied";
+    btn.classList.add("copied");
+    clearTimeout(btn.__cwAuthCopyTimer);
+    btn.__cwAuthCopyTimer = setTimeout(() => {
+      btn.textContent = old || "Copy";
+      btn.classList.remove("copied");
+    }, 900);
+  }
+
+  async function copyText(value, btn, opts) {
+    const text = txt(value);
+    if (!text) {
+      if (opts?.emptyMessage) notify(opts.emptyMessage);
+      return false;
+    }
+    try {
+      if (navigator.clipboard && w.isSecureContext) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const ta = d.createElement("textarea");
+        ta.value = text;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "fixed";
+        ta.style.top = "-9999px";
+        d.body.appendChild(ta);
+        ta.select();
+        d.execCommand("copy");
+        ta.remove();
+      }
+      flashCopyButton(btn, opts?.copiedText);
+      if (opts?.successMessage) notify(opts.successMessage);
+      return true;
+    } catch (e) {
+      if (opts?.failureMessage !== false) notify(opts?.failureMessage || "Copy failed");
+      try { console.warn("Copy failed", e); } catch (_) {}
+      return false;
+    }
+  }
+
+  async function copyField(field, btn, opts) {
+    const node = typeof field === "string" ? el(field) : field;
+    const value = txt(node && ("value" in node ? node.value : node.textContent));
+    if (!opts?.allowMasked && isMaskedSecret(value)) {
+      if (opts?.emptyMessage) notify(opts.emptyMessage);
+      return false;
+    }
+    return copyText(value, btn, opts);
+  }
+
+  function wireCopyButton(btn, field, opts) {
+    const button = typeof btn === "string" ? el(btn) : btn;
+    if (!button || button.__cwAuthCopyWired) return;
+    button.__cwAuthCopyWired = true;
+    button.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      void copyField(field, button, opts);
+    });
+  }
+
+  function createProfileAdapter(opts) {
+    const provider = txt(opts.provider);
+    const configKey = txt(opts.configKey || provider);
+    const label = txt(opts.label || provider);
+    const selectId = txt(opts.selectId || `${provider}_instance`);
+    const storageKey = txt(opts.storageKey || `cw.ui.${provider}.auth.instance.v1`);
+    const sectionId = txt(opts.sectionId || `sec-${provider}`);
+    const panelSelector = opts.panelSelector || `#${sectionId} .cw-meta-provider-panel`;
+    const apiProvider = txt(opts.instanceProvider || provider);
+    const title = txt(opts.title || `Select which ${label} profile this config applies to.`);
+    let uiObserver = null;
+
+    function addDefaultOption(sel) {
+      if (!sel || sel.options.length) return;
+      const option = d.createElement("option");
+      option.value = "default";
+      option.textContent = "Default";
+      sel.appendChild(option);
+      sel.value = "default";
+    }
+
+    function getInstance() {
+      const sel = el(selectId);
+      let value = sel ? txt(sel.value) : "";
+      if (!value || (value === "default" && sel && sel.options && sel.options.length <= 1)) {
+        try { value = localStorage.getItem(storageKey) || value || ""; } catch (_) {}
+      }
+      value = txt(value) || "default";
+      return value.toLowerCase() === "default" ? "default" : value;
+    }
+
+    function setInstance(value) {
+      const id = txt(value) || "default";
+      try { localStorage.setItem(storageKey, id); } catch (_) {}
+      const sel = el(selectId);
+      if (sel) sel.value = id;
+    }
+
+    function api(path) {
+      const p = String(path || "");
+      const sep = p.indexOf("?") >= 0 ? "&" : "?";
+      return p + sep + "instance=" + encodeURIComponent(getInstance()) + "&ts=" + Date.now();
+    }
+
+    function cfgBlock(cfg, create) {
+      cfg = cfg || {};
+      let base = (cfg[configKey] && typeof cfg[configKey] === "object") ? cfg[configKey] : null;
+      if (!base && create) base = cfg[configKey] = {};
+      if (!base) return {};
+      const inst = getInstance();
+      if (inst === "default") return base;
+      if (!base.instances || typeof base.instances !== "object") {
+        if (!create) return {};
+        base.instances = {};
+      }
+      if (!base.instances[inst] || typeof base.instances[inst] !== "object") {
+        if (!create) return {};
+        base.instances[inst] = {};
+      }
+      return base.instances[inst];
+    }
+
+    async function refreshOptions(preserve) {
+      const sel = el(selectId);
+      if (!sel) return;
+      addDefaultOption(sel);
+      let want = preserve === false ? "default" : getInstance();
+      try {
+        const r = await fetch(`/api/provider-instances/${encodeURIComponent(apiProvider)}?ts=${Date.now()}`, { cache: "no-store" });
+        const arr = await r.json().catch(() => []);
+        const opts = Array.isArray(arr) ? arr : [];
+        sel.innerHTML = "";
+        const addOpt = (id, text) => {
+          const option = d.createElement("option");
+          option.value = String(id);
+          option.textContent = String(text || id);
+          sel.appendChild(option);
+        };
+        addOpt("default", "Default");
+        opts.forEach((item) => { if (item && item.id && item.id !== "default") addOpt(item.id, item.label || item.id); });
+        if (!Array.from(sel.options).some((option) => option.value === want)) want = "default";
+        sel.value = want;
+        setInstance(want);
+      } catch (_) {}
+    }
+
+    function ensureUI(onChange) {
+      const panel = d.querySelector(panelSelector) || d.querySelector(`#${sectionId}`);
+      const head = panel ? panel.querySelector(".cw-panel-head") : null;
+      if (!head) {
+        if (!uiObserver) {
+          try {
+            uiObserver = new MutationObserver(() => {
+              const retryPanel = d.querySelector(panelSelector) || d.querySelector(`#${sectionId}`);
+              const retryHead = retryPanel ? retryPanel.querySelector(".cw-panel-head") : null;
+              if (!retryHead) return;
+              try { uiObserver.disconnect(); } catch (_) {}
+              uiObserver = null;
+              ensureUI(onChange);
+            });
+            uiObserver.observe(d.documentElement || d.body, { childList: true, subtree: true });
+          } catch (_) {}
+        }
+        return;
+      }
+      if (uiObserver) {
+        try { uiObserver.disconnect(); } catch (_) {}
+        uiObserver = null;
+      }
+      if (head.__cwProfileAdapter) return;
+      head.__cwProfileAdapter = true;
+
+      const wrap = d.createElement("div");
+      wrap.className = "inline";
+      wrap.style.display = "flex";
+      wrap.style.gap = "8px";
+      wrap.style.alignItems = "center";
+      wrap.style.marginLeft = "auto";
+      wrap.style.flexWrap = "nowrap";
+      wrap.title = title;
+
+      const lab = d.createElement("span");
+      lab.className = "muted";
+      lab.textContent = "Profile";
+
+      const sel = d.createElement("select");
+      sel.id = selectId;
+      sel.name = selectId;
+      sel.className = "input";
+      sel.style.minWidth = "160px";
+      sel.style.width = "auto";
+      sel.style.maxWidth = "220px";
+      sel.style.flex = "0 0 auto";
+      addDefaultOption(sel);
+      setInstance(getInstance());
+
+      const btnNew = d.createElement("button");
+      btnNew.type = "button";
+      btnNew.className = "btn secondary";
+      btnNew.id = `${selectId}_new`;
+      btnNew.textContent = "New";
+
+      const btnDel = d.createElement("button");
+      btnDel.type = "button";
+      btnDel.className = "btn secondary";
+      btnDel.id = `${selectId}_del`;
+      btnDel.textContent = "Delete";
+
+      wrap.append(lab, sel, btnNew, btnDel);
+      head.appendChild(wrap);
+      refreshOptions(true);
+
+      sel.addEventListener("change", () => {
+        setInstance(sel.value);
+        try { Promise.resolve(onChange?.()).catch(() => {}); } catch (_) {}
+      });
+      btnNew.addEventListener("click", async () => {
+        try {
+          const r = await fetch(`/api/provider-instances/${encodeURIComponent(apiProvider)}/next?ts=${Date.now()}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: "{}",
+            cache: "no-store",
+          });
+          const j = await r.json().catch(() => ({}));
+          const id = txt(j && j.id);
+          if (!r.ok || (j && j.ok === false) || !id) throw new Error(String((j && j.error) || "create_failed"));
+          setInstance(id);
+          await refreshOptions(true);
+          try { Promise.resolve(onChange?.()).catch(() => {}); } catch (_) {}
+        } catch (e) {
+          notify("Could not create profile: " + (e && e.message ? e.message : e));
+        }
+      });
+      btnDel.addEventListener("click", async () => {
+        const id = getInstance();
+        if (id === "default") return notify("Default profile cannot be deleted.");
+        if (!confirm(`Delete ${label} profile "${id}"?`)) return;
+        try {
+          const r = await fetch(`/api/provider-instances/${encodeURIComponent(apiProvider)}/${encodeURIComponent(id)}`, { method: "DELETE", cache: "no-store" });
+          const j = await r.json().catch(() => ({}));
+          if (!r.ok || (j && j.ok === false)) throw new Error(String((j && j.error) || "delete_failed"));
+          setInstance("default");
+          await refreshOptions(false);
+          try { Promise.resolve(onChange?.()).catch(() => {}); } catch (_) {}
+        } catch (e) {
+          notify("Could not delete profile: " + (e && e.message ? e.message : e));
+        }
+      });
+    }
+
+    return { getInstance, setInstance, api, cfgBlock, refreshOptions, ensureUI };
+  }
+
+  w.CW = w.CW || {};
+  w.CW.AuthShared = {
+    el,
+    txt,
+    notify,
+    isMaskedSecret,
+    readSecretField,
+    maskSecret,
+    markSecretField,
+    wireSecretInput,
+    fetchJSON,
+    getConfig,
+    setStatusPill,
+    setStatus,
+    copyText,
+    copyField,
+    wireCopyButton,
+    createProfileAdapter,
+  };
+})(window, document);

--- a/assets/auth/auth.simkl.js
+++ b/assets/auth/auth.simkl.js
@@ -1,138 +1,39 @@
 // auth.simkl.js
 (function (w, d) {
+  const Shared = w.CW && w.CW.AuthShared;
   const $ = (s) => d.getElementById(s);
   const q = (sel, root = d) => root.querySelector(sel);
-  const notify = w.notify || ((m) => console.log("[notify]", m));
+  const notify = Shared.notify;
   const bust = () => `?ts=${Date.now()}`;
 
   // Profiles
-  const SIMKL_INSTANCE_KEY = "cw.ui.simkl.auth.instance.v1";
-  const _str = (v) => (typeof v === "string" ? v.trim() : (v == null ? "" : String(v).trim()));
+  const profile = Shared.createProfileAdapter({
+    provider: "simkl",
+    configKey: "simkl",
+    label: "SIMKL",
+    sectionId: "sec-simkl",
+    selectId: "simkl_instance",
+    storageKey: "cw.ui.simkl.auth.instance.v1",
+    panelSelector: '#sec-simkl .cw-meta-provider-panel[data-provider="simkl"], .cw-meta-provider-panel[data-provider="simkl"]',
+    title: "Select which SIMKL account this config applies to.",
+  });
+  const _str = Shared.txt;
   const _setVal = (id, v) => { const e = $(id); if (e && String(e.value || "") !== String(v || "")) e.value = String(v || ""); };
 
   function getSimklInstance() {
-    try { return (_str(localStorage.getItem(SIMKL_INSTANCE_KEY)) || "default"); } catch (_) { return "default"; }
+    return profile ? profile.getInstance() : "default";
   }
   function setSimklInstance(id) {
-    try { localStorage.setItem(SIMKL_INSTANCE_KEY, _str(id) || "default"); } catch (_) {}
+    if (profile) profile.setInstance(id);
   }
   function simklApi(url) {
-    try {
-      const u = new URL(url, d.baseURI);
-      u.searchParams.set("instance", getSimklInstance());
-      u.searchParams.set("ts", Date.now());
-      return u.toString();
-    } catch (_) {
-      const sep = String(url).includes("?") ? "&" : "?";
-      return String(url) + sep + "instance=" + encodeURIComponent(getSimklInstance()) + "&ts=" + Date.now();
-    }
+    return profile ? profile.api(url) : String(url || "");
   }
   async function refreshSimklInstanceOptions(preserve) {
-    const sel = $("simkl_instance");
-    if (!sel) return;
-    let want = preserve === false ? "default" : getSimklInstance();
-    try {
-      const r = await fetch("/api/provider-instances/simkl?ts=" + Date.now(), { cache: "no-store" });
-      const arr = await r.json().catch(() => []);
-      const opts = Array.isArray(arr) ? arr : [];
-      sel.innerHTML = "";
-      const addOpt = (id, label) => {
-        const o = d.createElement("option");
-        o.value = String(id);
-        o.textContent = String(label || id);
-        sel.appendChild(o);
-      };
-      addOpt("default", "Default");
-      opts.forEach((o) => { if (o && o.id && o.id !== "default") addOpt(o.id, o.label || o.id); });
-      if (!Array.from(sel.options).some((o) => o.value === want)) want = "default";
-      sel.value = want;
-      setSimklInstance(want);
-    } catch (_) {}
+    if (profile) await profile.refreshOptions(preserve);
   }
   function ensureSimklInstanceUI() {
-    const panel = d.querySelector('#sec-simkl .cw-meta-provider-panel[data-provider="simkl"]') || d.querySelector('.cw-meta-provider-panel[data-provider="simkl"]') || d.querySelector('#sec-simkl .cw-meta-provider-panel') || d.querySelector('#sec-simkl') || d.querySelector('[data-provider="simkl"]');
-    if (!panel) return;
-    if (panel.querySelector('#simkl_instance')) return;
-    const head = panel.querySelector('.cw-panel-head') || panel.querySelector('.panel-head') || panel.querySelector('header') || panel;
-    if (head.__simklInstanceUI) return;
-    head.__simklInstanceUI = true;
-
-    const wrap = d.createElement('div');
-    wrap.className = 'inline';
-    wrap.style.display = 'flex';
-    wrap.style.gap = '8px';
-    wrap.style.alignItems = 'center';
-    try { head.style.flexWrap = 'wrap'; } catch (_) {}
-    wrap.style.marginLeft = 'auto';
-    wrap.style.flexWrap = 'nowrap';
-    wrap.title = 'Select which SIMKL account this config applies to.';
-
-    const label = d.createElement('span');
-    label.className = 'muted';
-    label.textContent = 'Profile';
-
-    const sel = d.createElement('select');
-    sel.id = 'simkl_instance';
-sel.name = 'simkl_instance';
-    sel.className = 'input';
-    sel.style.minWidth = '160px';
-    // Match Trakt: keep it compact and let content drive the width.
-    sel.style.width = 'auto';
-    sel.style.maxWidth = '220px';
-    sel.style.flex = '0 0 auto';
-    sel.style.display = 'inline-block';
-
-    const btnNew = d.createElement('button');
-    btnNew.type = 'button';
-    btnNew.className = 'btn secondary';
-    btnNew.textContent = 'New';
-
-    const btnDel = d.createElement('button');
-    btnDel.type = 'button';
-    btnDel.className = 'btn secondary';
-    btnDel.textContent = 'Delete';
-
-    wrap.appendChild(label);
-    wrap.appendChild(sel);
-    wrap.appendChild(btnNew);
-    wrap.appendChild(btnDel);
-    if (head === panel) panel.insertBefore(wrap, panel.firstChild);
-    else head.appendChild(wrap);
-
-    sel.addEventListener("change", async () => {
-      setSimklInstance(sel.value);
-      await hydrateSimklFromConfig();
-    });
-
-    btnNew.addEventListener("click", async () => {
-      try {
-        const r = await fetch("/api/provider-instances/simkl/next?ts=" + Date.now(), { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}", cache: "no-store" });
-        const j = await r.json().catch(() => ({}));
-        const inst = _str(j && j.id);
-        if (!r.ok || (j && j.ok === false) || !inst) throw new Error(String((j && j.error) || "create_failed"));
-        setSimklInstance(inst);
-        await refreshSimklInstanceOptions(true);
-        await hydrateSimklFromConfig();
-      } catch (e) {
-        notify("Could not create profile: " + (e && e.message ? e.message : e));
-      }
-    });
-
-    btnDel.addEventListener("click", async () => {
-      const id = getSimklInstance();
-      if (id === "default") return notify("Default profile cannot be deleted.");
-      if (!confirm('Delete SIMKL profile "' + id + '"?')) return;
-      try {
-        const r = await fetch("/api/provider-instances/simkl/" + encodeURIComponent(id), { method: "DELETE", cache: "no-store" });
-        const j = await r.json().catch(() => ({}));
-        if (!r.ok || (j && j.ok === false)) throw new Error(String((j && j.error) || "delete_failed"));
-        setSimklInstance("default");
-        await refreshSimklInstanceOptions(false);
-        await hydrateSimklFromConfig();
-      } catch (e) {
-        notify("Could not delete profile: " + (e && e.message ? e.message : e));
-      }
-    });
+    profile?.ensureUI(() => { void hydrateSimklFromConfig(); });
   }
 
   let _simklPersistT = null;
@@ -140,19 +41,11 @@ sel.name = 'simkl_instance';
     try {
       const cid = _str($("simkl_client_id")?.value);
       const sec = _str($("simkl_client_secret")?.value);
-      const cfg = await fetch("/api/config", { cache: "no-store" }).then((r) => (r.ok ? r.json() : null)).catch(() => null);
+      const cfg = await Shared.getConfig();
       if (!cfg) return;
-      const base = (cfg.simkl && typeof cfg.simkl === "object") ? cfg.simkl : (cfg.simkl = {});
-      const inst = getSimklInstance();
-      if (inst === "default") {
-        base.client_id = cid;
-        base.client_secret = sec;
-      } else {
-        if (!base.instances || typeof base.instances !== "object") base.instances = {};
-        if (!base.instances[inst] || typeof base.instances[inst] !== "object") base.instances[inst] = {};
-        base.instances[inst].client_id = cid;
-        base.instances[inst].client_secret = sec;
-      }
+      const block = profile ? profile.cfgBlock(cfg, true) : (cfg.simkl = cfg.simkl || {});
+      block.client_id = cid;
+      block.client_secret = sec;
       await fetch("/api/config", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(cfg) }).catch(() => {});
     } catch (_) {}
   }
@@ -167,12 +60,11 @@ sel.name = 'simkl_instance';
       if (!cfg) return;
       const inst = getSimklInstance();
       const base = (cfg.simkl && typeof cfg.simkl === "object") ? cfg.simkl : {};
-      const blk = (inst === "default") ? base : (base.instances && base.instances[inst]) || {};
+      const blk = profile ? profile.cfgBlock(cfg, false) : ((inst === "default") ? base : (base.instances && base.instances[inst]) || {});
       const isDefault = (inst === "default");
       _setVal("simkl_client_id", _str(blk.client_id || (isDefault ? base.client_id : "")));
       _setVal("simkl_client_secret", _str(blk.client_secret || (isDefault ? base.client_secret : "")));
       const tok = _str(blk.access_token || (isDefault ? (cfg?.auth?.simkl?.access_token || "") : ""));
-      _setVal("simkl_access_token", tok);
       try { setSimklSuccess(!!tok); } catch {}
       try { updateSimklButtonState(); } catch {}
     } catch (e) {
@@ -186,16 +78,11 @@ sel.name = 'simkl_instance';
       : (location.origin + "/callback"));
 
   function setSimklBanner(kind, text) {
-    const el = $("simkl_msg");
-    if (!el) return;
-    el.classList.remove("hidden", "ok", "warn");
-    if (!kind) { el.classList.add("hidden"); el.textContent = ""; return; }
-    el.classList.add(kind);
-    el.textContent = text || "";
+    return Shared.setStatusPill("simkl_msg", kind, text);
   }
 
   function setSimklSuccess(on, text) {
-    if (on) setSimklBanner("ok", text || "Connected.");
+    if (on) setSimklBanner("ok", text || "Connected");
     else setSimklBanner(null, "");
   }
 
@@ -220,12 +107,7 @@ sel.name = 'simkl_instance';
   const updateSimklHint = updateSimklButtonState;
 
   async function copyRedirect() {
-    try {
-      await navigator.clipboard.writeText(computeRedirect());
-      notify("Redirect URI copied ✓");
-    } catch {
-      notify("Copy failed");
-    }
+    return Shared.copyText(computeRedirect(), $("btn-copy-simkl-redirect"), { successMessage: "Redirect URI copied" });
   }
 
   async function simklDeleteToken() {
@@ -242,9 +124,8 @@ sel.name = 'simkl_instance';
       });
       const j = await r.json().catch(() => ({}));
       if (r.ok && (j.ok !== false)) {
-        try { const el = $("simkl_access_token"); if (el) el.value = ""; } catch {}
         try { setSimklSuccess(false); } catch {}
-        notify("SIMKL access token removed.");
+        notify("SIMKL disconnected.");
       } else {
         if (msg) { msg.classList.add("warn"); msg.textContent = "Could not remove token."; }
       }
@@ -329,7 +210,6 @@ sel.name = 'simkl_instance';
       const blk = (inst === "default") ? base : (base.instances && base.instances[inst]) || {};
       const tok = _str(blk.access_token || (inst === "default" ? (cfg?.auth?.simkl?.access_token || "") : ""));
       if (tok) {
-        try { const el = $("simkl_access_token"); if (el) el.value = tok; } catch {}
         try { setSimklSuccess(true); } catch {}
         cleanup();
         return;
@@ -355,19 +235,26 @@ sel.name = 'simkl_instance';
 
   let __simklInitDone = false;
   function initSimklAuthUI() {
-    if (__simklInitDone) return;
-    __simklInitDone = true;
     try { ensureSimklInstanceUI(); } catch (_) {}
     try { refreshSimklInstanceOptions(true); } catch (_) {}
     try { hydrateSimklFromConfig(); } catch (_) {}
 
-    $("simkl_client_id")?.addEventListener("input", updateSimklButtonState);
-    $("simkl_client_secret")?.addEventListener("input", updateSimklButtonState);
+    const cid = $("simkl_client_id");
+    if (cid && !cid.__simklBound) { cid.addEventListener("input", updateSimklButtonState); cid.__simklBound = true; }
+    const sec = $("simkl_client_secret");
+    if (sec && !sec.__simklBound) { sec.addEventListener("input", updateSimklButtonState); sec.__simklBound = true; }
+    const copy = $("btn-copy-simkl-redirect");
+    if (copy && !copy.__simklBound) { copy.addEventListener("click", copyRedirect); copy.__simklBound = true; }
+    const connect = $("btn-connect-simkl");
+    if (connect && !connect.__simklBound) { connect.addEventListener("click", startSimkl); connect.__simklBound = true; }
+    const del = $("btn-delete-simkl");
+    if (del && !del.__simklBound) { del.addEventListener("click", simklDeleteToken); del.__simklBound = true; }
 
     const rid = $("redirect_uri_preview");
     if (rid) rid.textContent = computeRedirect();
 
     updateSimklButtonState();
+    __simklInitDone = true;
   }
 
   if (d.readyState === "loading") d.addEventListener("DOMContentLoaded", initSimklAuthUI, { once: true });

--- a/assets/auth/auth.tautulli.js
+++ b/assets/auth/auth.tautulli.js
@@ -3,395 +3,89 @@
   if (window._tautPatched) return;
   window._tautPatched = true;
 
-  const el = (id) => document.getElementById(id);
-  const txt = (v) => (typeof v === "string" ? v : "").trim();
-  const note = (m) => (typeof window.notify === "function" ? window.notify(m) : void 0);
-
-  const TAUTULLI_INSTANCE_KEY = "cw.ui.tautulli.auth.instance.v1";
+  const Shared = window.CW.AuthShared;
+  const el = Shared.el;
+  const txt = Shared.txt;
+  const note = Shared.notify;
+  const profile = Shared.createProfileAdapter({
+    provider: "tautulli",
+    configKey: "tautulli",
+    label: "Tautulli",
+    sectionId: "sec-tautulli",
+    selectId: "tautulli_instance",
+    storageKey: "cw.ui.tautulli.auth.instance.v1",
+    title: "Select which Tautulli server this config applies to.",
+  });
 
   function getTautulliInstance() {
-    var s = el("tautulli_instance");
-    var v = s ? txt(s.value) : "";
-    if (!v) { try { v = localStorage.getItem(TAUTULLI_INSTANCE_KEY) || ""; } catch (_) {} }
-    v = txt(v) || "default";
-    return v.toLowerCase() === "default" ? "default" : v;
+    return profile ? profile.getInstance() : "default";
   }
 
   function setTautulliInstance(v) {
-    var id = txt(String(v || "")) || "default";
-    try { localStorage.setItem(TAUTULLI_INSTANCE_KEY, id); } catch (_) {}
-    var s = el("tautulli_instance");
-    if (s) s.value = id;
+    if (profile) profile.setInstance(v);
   }
 
   function tautApi(path) {
-    var p = String(path || "");
-    var sep = p.indexOf("?") >= 0 ? "&" : "?";
-    return p + sep + "instance=" + encodeURIComponent(getTautulliInstance()) + "&ts=" + Date.now();
+    return profile ? profile.api(path) : String(path || "");
   }
 
   async function fetchJSON(url, opts) {
-    const r = await fetch(url, opts || {});
-    let j = null;
-    try { j = await r.json(); } catch {}
-    return { ok: r.ok, data: j, status: r.status };
+    return Shared.fetchJSON(url, opts);
   }
 
   async function getCfg() {
-    const r = await fetchJSON("/api/config?ts=" + Date.now(), { cache: "no-store" });
-    return r.ok ? (r.data || {}) : {};
+    return Shared.getConfig();
+  }
+
+  function friendlyError(code) {
+    const key = String(code || "").trim();
+    switch (key) {
+      case "server_url_required": return "Enter Tautulli server URL";
+      case "api_key_required": return "Enter your Tautulli API key";
+      case "invalid_api_key": return "Invalid Tautulli API key";
+      case "validation_timeout": return "Tautulli validation timed out";
+      case "validation_failed": return "Could not connect to Tautulli";
+      case "validation_bad_response": return "Tautulli validation returned an unexpected response";
+      default:
+        if (key.startsWith("validation_http_")) return "Tautulli validation failed";
+        return key || "Not connected";
+    }
   }
 
   function getTautulliCfgBlock(cfg) {
-    cfg = cfg || {};
-    var base = (cfg.tautulli && typeof cfg.tautulli === "object") ? cfg.tautulli : (cfg.tautulli = {});
-    var inst = getTautulliInstance();
-    if (inst === "default") return base;
-    if (!base.instances || typeof base.instances !== "object") base.instances = {};
-    if (!base.instances[inst] || typeof base.instances[inst] !== "object") base.instances[inst] = {};
-    return base.instances[inst];
+    return profile ? profile.cfgBlock(cfg, true) : {};
   }
 
   async function refreshTautulliInstanceOptions(preserve) {
-    var sel = el("tautulli_instance");
-    if (!sel) return;
-    var want = preserve === false ? "default" : getTautulliInstance();
-    try {
-      var r = await fetch("/api/provider-instances/tautulli?ts=" + Date.now(), { cache: "no-store" });
-      var arr = await r.json().catch(function(){ return []; });
-      var opts = Array.isArray(arr) ? arr : [];
-      sel.innerHTML = "";
-      function addOpt(id, label) {
-        var o = document.createElement("option");
-        o.value = String(id);
-        o.textContent = String(label || id);
-        sel.appendChild(o);
-      }
-      addOpt("default", "Default");
-      opts.forEach(function(o){ if (o && o.id && o.id !== "default") addOpt(o.id, o.label || o.id); });
-      if (!Array.from(sel.options).some(function(o){ return o.value === want; })) want = "default";
-      sel.value = want;
-      setTautulliInstance(want);
-    } catch (_) {}
+    if (profile) await profile.refreshOptions(preserve);
   }
 
   function ensureTautulliInstanceUI() {
-    var panel = document.querySelector('#sec-tautulli .cw-meta-provider-panel[data-provider="tautulli"]') || document.querySelector('#sec-tautulli .cw-meta-provider-panel') || document.querySelector('#sec-tautulli');
-    var head = panel ? panel.querySelector('.cw-panel-head') : null;
-    if (!head || head.__tautulliInstanceUI) return;
-    head.__tautulliInstanceUI = true;
-
-    var wrap = document.createElement('div');
-    wrap.className = 'inline';
-    wrap.style.display = 'flex';
-    wrap.style.gap = '8px';
-    wrap.style.alignItems = 'center';
-    wrap.style.marginLeft = 'auto';
-    wrap.style.flexWrap = 'nowrap';
-    wrap.title = 'Select which Tautulli server this config applies to.';
-
-    var lab = document.createElement('span');
-    lab.className = 'muted';
-    lab.textContent = 'Profile';
-
-    var sel = document.createElement('select');
-    sel.id = 'tautulli_instance';
-sel.name = 'tautulli_instance';
-    sel.className = 'input';
-    sel.style.minWidth = '160px';
-
-    // Match Trakt: keep it compact and let content drive the width.
-    sel.style.width = 'auto';
-    sel.style.maxWidth = '220px';
-    sel.style.flex = '0 0 auto';
-    var btnNewEl = document.createElement('button');
-    btnNewEl.type = 'button';
-    btnNewEl.className = 'btn secondary';
-    btnNewEl.id = 'tautulli_instance_new';
-    btnNewEl.textContent = 'New';
-
-    var btnDelEl = document.createElement('button');
-    btnDelEl.type = 'button';
-    btnDelEl.className = 'btn secondary';
-    btnDelEl.id = 'tautulli_instance_del';
-    btnDelEl.textContent = 'Delete';
-
-    wrap.appendChild(lab);
-    wrap.appendChild(sel);
-    wrap.appendChild(btnNewEl);
-    wrap.appendChild(btnDelEl);
-    head.appendChild(wrap);
-
-    refreshTautulliInstanceOptions(true);
-
-    if (sel && !sel._wired) {
-      sel._wired = true;
-      sel.addEventListener('change', function () {
-        setTautulliInstance(sel.value);
-        void hydrate();
-      });
-    }
-
-    var btnNew = el("tautulli_instance_new");
-    if (btnNew && !btnNew._wired) {
-      btnNew._wired = true;
-      btnNew.addEventListener("click", async function () {
-        try {
-          var r = await fetch("/api/provider-instances/tautulli/next?ts=" + Date.now(), {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: "{}",
-            cache: "no-store",
-          });
-          var j = await r.json().catch(function(){ return {}; });
-          var id = txt((j && j.id) || "");
-          if (!r.ok || (j && j.ok === false) || !id) throw new Error(String((j && j.error) || "create_failed"));
-          setTautulliInstance(id);
-          await refreshTautulliInstanceOptions(true);
-          void hydrate();
-        } catch (e) {
-          note("Could not create profile: " + (e && e.message ? e.message : e));
-        }
-      });
-    }
-
-    var btnDel = el("tautulli_instance_del");
-    if (btnDel && !btnDel._wired) {
-      btnDel._wired = true;
-      btnDel.addEventListener("click", async function () {
-        var id = getTautulliInstance();
-        if (id === "default") return note("Default profile cannot be deleted.");
-        if (!confirm('Delete Tautulli profile "' + id + '"?')) return;
-        try {
-          var r = await fetch("/api/provider-instances/tautulli/" + encodeURIComponent(id), {
-            method: "DELETE",
-            cache: "no-store",
-          });
-          var j = await r.json().catch(function(){ return {}; });
-          if (!r.ok || (j && j.ok === false)) throw new Error(String((j && j.error) || "delete_failed"));
-          setTautulliInstance("default");
-          await refreshTautulliInstanceOptions(false);
-          void hydrate();
-        } catch (e) {
-          note("Could not delete profile: " + (e && e.message ? e.message : e));
-        }
-      });
-    }
+    profile?.ensureUI(() => { void hydrate(); });
   }
 
   function setConn(ok, msg) {
-    const m = el("tautulli_msg");
-    if (!m) return;
-    const text = ok ? (msg || "Connected.") : (msg || "Not connected");
-    m.textContent = text;
-    m.classList.remove("hidden", "ok", "warn");
-    m.classList.add(ok ? "ok" : "warn");
-  }
-
-  function showActionsRow() {
-    const row = el("tautulli_actions_row");
-    if (!row) return;
-    row.hidden = false;
-    row.removeAttribute("hidden");
-    row.classList.remove("hidden");
-    row.style.display = "flex";
-  }
-
-
-  function pickFieldBox(input) {
-    if (!input) return null;
-    let cur = input;
-    for (let i = 0; i < 6; i++) {
-      const p = cur && cur.parentElement;
-      if (!p) break;
-      const fields = p.querySelectorAll("input,select,textarea");
-      if (fields.length === 1 && p.contains(input)) return p;
-      cur = p;
-    }
-    return input.parentElement;
-  }
-
-  function ensureFieldsLayout() {
-    const root = document.getElementById("sec-tautulli") || document.querySelector("#sec-tautulli");
-    if (!root) return;
-    if (root.__cwTautulliFieldsV2 && document.getElementById("tautulli_actions_row")) return;
-
-    const serverEl = el("tautulli_server");
-    const keyEl = el("tautulli_key");
-    const userEl = el("tautulli_user_id");
-    const hintEl = el("tautulli_hint");
-    if (!serverEl || !keyEl || !userEl) return;
-    if (!root.contains(serverEl) || !root.contains(keyEl) || !root.contains(userEl)) return;
-
-    const outerGrid = root.querySelector('.body .grid2');
-    if (outerGrid) {
-      outerGrid.style.gridTemplateColumns = "1fr";
-      const rightCol = outerGrid.querySelector('div:nth-child(2)');
-      if (rightCol) rightCol.style.display = "none";
-    }
-
-    const leftCol = root.querySelector('.body .grid2 > div:first-child') || root.querySelector('.body');
-    if (!leftCol) return;
-
-    const actions = document.getElementById("tautulli_actions_row");
-    const saveBtn = el("tautulli_save");
-    const verifyBtn = el("tautulli_verify");
-    const discBtn = el("tautulli_disconnect");
-    const msgEl = el("tautulli_msg");
-    const saved = {
-      server: serverEl,
-      key: keyEl,
-      user: userEl,
-      hint: hintEl,
-      actions,
-      saveBtn,
-      verifyBtn,
-      discBtn,
-      msgEl,
-    };
-
-    const canBuildActions = !!saved.actions || !!(saved.saveBtn && saved.verifyBtn && saved.discBtn && saved.msgEl);
-    if (!canBuildActions) return;
-
-    function mkField(labelText, inputEl) {
-      const w = document.createElement("div");
-      const lab = document.createElement("label");
-      if (inputEl) {
-        if (!inputEl.id) {
-          inputEl.id = "tautulli_field_" + String(labelText || "field")
-            .toLowerCase()
-            .replace(/[^a-z0-9]+/g, "_")
-            .replace(/^_+|_+$/g, "");
-        }
-        lab.htmlFor = inputEl.id;
-      }
-      lab.textContent = labelText;
-      w.appendChild(lab);
-      w.appendChild(inputEl);
-      return w;
-    }
-
-    try {
-      // Rebuild the left column
-      leftCol.innerHTML = "";
-
-      const row1 = document.createElement("div");
-      row1.id = "tautulli_row1";
-      row1.style.display = "grid";
-      row1.style.gridTemplateColumns = "1fr 1fr";
-      row1.style.gap = "12px";
-
-      saved.server.style.width = "100%";
-      saved.key.style.width = "100%";
-
-      row1.appendChild(mkField("Server URL", saved.server));
-      row1.appendChild(mkField("API Key", saved.key));
-      leftCol.appendChild(row1);
-
-      const userWrap = mkField("User ID (optional)", saved.user);
-      saved.user.style.maxWidth = "240px";
-      saved.user.style.width = "240px";
-      userWrap.style.maxWidth = "240px";
-      userWrap.style.marginTop = "10px";
-      leftCol.appendChild(userWrap);
-
-      if (saved.hint) {
-        saved.hint.style.marginTop = "10px";
-        leftCol.appendChild(saved.hint);
-      }
-
-      if (saved.actions) {
-        saved.actions.style.marginTop = "12px";
-        leftCol.appendChild(saved.actions);
-      } else if (saved.saveBtn && saved.verifyBtn && saved.discBtn && saved.msgEl) {
-        const row = document.createElement("div");
-        row.id = "tautulli_actions_row";
-        row.className = "inline";
-        row.style.display = "flex";
-        row.style.gap = "10px";
-        row.style.alignItems = "center";
-        row.style.marginTop = "12px";
-        saved.msgEl.style.marginLeft = "auto";
-        row.appendChild(saved.saveBtn);
-        row.appendChild(saved.verifyBtn);
-        row.appendChild(saved.discBtn);
-        row.appendChild(saved.msgEl);
-        leftCol.appendChild(row);
-
-        const oldInline = saved.verifyBtn.closest(".inline") || saved.verifyBtn.parentElement;
-        const oldCol = oldInline ? oldInline.parentElement : null;
-        if (oldCol && oldCol !== row && root.contains(oldCol)) oldCol.style.display = "none";
-      }
-
-      showActionsRow();
-      if (leftCol.querySelector("#tautulli_actions_row")) root.__cwTautulliFieldsV2 = true;
-    } catch (_) {}
-  }
-
-  function compactLayout() {
-    const root = document.getElementById("sec-tautulli") || document.querySelector("#sec-tautulli");
-    if (!root) return;
-    if (root.__cwTautulliCompact && document.getElementById("tautulli_actions_row")) return;
-
-    const save = el("tautulli_save");
-    const verify = el("tautulli_verify");
-    const disc = el("tautulli_disconnect");
-    const msg = el("tautulli_msg");
-    if (!save || !verify || !disc || !msg) return;
-    if (!root.contains(save) || !root.contains(verify) || !root.contains(disc) || !root.contains(msg)) return;
-
-    // Capture the original status
-    const oldInline = verify.closest(".inline") || verify.parentElement;
-    const oldCol = oldInline ? oldInline.parentElement : null;
-
-    const user = el("tautulli_user_id");
-    let anchor = user ? (user.parentElement || user.closest("div")) : null;
-    if (!anchor || !root.contains(anchor)) anchor = save.closest("div") || save.parentElement;
-
-    const row = document.createElement("div");
-    row.id = "tautulli_actions_row";
-    row.className = "inline";
-    row.style.display = "flex";
-    row.style.gap = "10px";
-    row.style.alignItems = "center";
-    row.style.marginTop = "12px";
-    msg.style.marginLeft = "auto";
-    row.appendChild(save);
-    row.appendChild(verify);
-    row.appendChild(disc);
-    row.appendChild(msg);
-    anchor.insertAdjacentElement("afterend", row);
-
-    if (oldCol && oldCol !== row && root.contains(oldCol)) oldCol.style.display = "none";
-
-    showActionsRow();
-    if (document.getElementById("tautulli_actions_row")) root.__cwTautulliCompact = true;
+    return Shared.setStatus("tautulli_msg", ok, msg);
   }
 
   function maskKey(i, has) {
-    if (!i) return;
-    if (has) { i.value = "••••••••"; i.dataset.masked = "1"; }
-    else { i.value = ""; i.dataset.masked = "0"; }
-    i.dataset.hasKey = has ? "1" : "";
+    return Shared.maskSecret(i, has);
   }
 
   async function refresh() {
     try {
       const r = await fetchJSON(tautApi("/api/tautulli/status?verify=1"), { cache: "no-store" });
       const ok = !!(r.ok && r.data && r.data.connected);
-      setConn(ok, ok ? "Connected" : (r.data && r.data.reason ? String(r.data.reason) : "Not connected"));
-      note(ok ? "Tautulli verified ✓" : "Tautulli not connected");
+      setConn(ok, ok ? "Connected" : friendlyError(r.data && r.data.reason));
+      note(ok ? "Tautulli connected" : "Tautulli not connected");
     } catch {
-      setConn(false, "Verify failed");
-      note("Tautulli verify failed");
+      setConn(false, "Could not connect to Tautulli");
+      note("Tautulli validation failed");
     }
   }
 
   async function hydrate() {
     ensureTautulliInstanceUI();
-    compactLayout();
-    ensureFieldsLayout();
-    showActionsRow();
     const cfg = window._cfgCache || await getCfg();
     const t = getTautulliCfgBlock(cfg);
     const h = t && typeof t.history === "object" ? t.history : {};
@@ -428,14 +122,16 @@ sel.name = 'tautulli_instance';
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ server_url: server, api_key: key, user_id }),
       });
-      if (!r.ok || (r.data && r.data.ok === false)) throw new Error(r.data?.error || "save_failed");
+      if (!r.ok || (r.data && r.data.ok === false)) throw new Error(friendlyError(r.data?.error || "save_failed"));
 
       if (key) maskKey(keyInput, true);
       el("tautulli_hint")?.classList.add("hidden");
       note("Tautulli saved");
       await refresh();
     } catch (e) {
-      note("Saving Tautulli failed" + (e && e.message ? ": " + e.message : ""));
+      const msg = e && e.message ? e.message : "Saving Tautulli failed";
+      setConn(false, msg);
+      note(msg);
     }
   }
 
@@ -454,32 +150,15 @@ sel.name = 'tautulli_instance';
   }
 
   function wire() {
-    compactLayout();
-    ensureFieldsLayout();
-    showActionsRow();
     const s = el("tautulli_save");
     if (s && !s.__wired) { s.addEventListener("click", onSave); s.__wired = true; }
-
-    const v = el("tautulli_verify");
-    if (v && !v.__wired) { v.addEventListener("click", refresh); v.__wired = true; }
 
     const d = el("tautulli_disconnect");
     if (d && !d.__wired) { d.addEventListener("click", onDisc); d.__wired = true; }
 
     const k = el("tautulli_key");
     if (k && !k.__wiredSecret) {
-      k.addEventListener("focus", () => {
-        if (k.dataset.masked === "1") {
-          k.value = "";
-          k.dataset.masked = "0";
-          k.dataset.touched = "1";
-        }
-      });
-      k.addEventListener("input", () => {
-        k.dataset.masked = "0";
-        k.dataset.touched = "1";
-        k.dataset.hasKey = "";
-      });
+      Shared.wireSecretInput(k);
       k.__wiredSecret = true;
     }
 
@@ -488,9 +167,6 @@ sel.name = 'tautulli_instance';
       u.addEventListener("input", () => { u.dataset.touched = "1"; });
       u.__wiredUser = true;
     }
-
-    // Keep layout consistent
-    compactLayout();
   }
 
   function watch() {
@@ -524,7 +200,7 @@ sel.name = 'tautulli_instance';
     const user_id = txt(userIdEl?.value || "");
     const uidTouched = !!userIdEl?.dataset.touched;
 
-    if (keyEl && (keyEl.dataset.masked === "1" || key === "••••••••" || key === "********" || key === "**********")) {
+    if (keyEl && (keyEl.dataset.masked === "1" || key === "********" || key === "********" || key === "**********")) {
       key = "";
     }
 

--- a/assets/auth/auth.tmdb.js
+++ b/assets/auth/auth.tmdb.js
@@ -9,40 +9,34 @@
     disconnect: "/api/tmdb_sync/disconnect",
   };
 
-  const el = (id) => document.getElementById(id);
-  const txt = (v) => (typeof v === "string" ? v : "").trim();
-  const note = (m) => (typeof window.notify === "function" ? window.notify(m) : void 0);
-
-  const TMDB_SYNC_INSTANCE_KEY = "cw.ui.tmdb_sync.auth.instance.v1";
+  const Shared = window.CW.AuthShared;
+  const el = Shared.el;
+  const txt = Shared.txt;
+  const note = Shared.notify;
+  const profile = Shared.createProfileAdapter({
+    provider: "tmdb_sync",
+    configKey: "tmdb_sync",
+    label: "TMDb Sync",
+    sectionId: "sec-tmdb-sync",
+    selectId: "tmdb_sync_instance",
+    storageKey: "cw.ui.tmdb_sync.auth.instance.v1",
+    title: "Select which TMDb Sync account this config applies to.",
+  });
 
   function getTMDbSyncInstance() {
-    var s = el("tmdb_sync_instance");
-    var v = s ? txt(s.value) : "";
-    if (!v) {
-      try { v = localStorage.getItem(TMDB_SYNC_INSTANCE_KEY) || ""; } catch (_) {}
-    }
-    v = txt(v) || "default";
-    return v.toLowerCase() === "default" ? "default" : v;
+    return profile ? profile.getInstance() : "default";
   }
 
   function setTMDbSyncInstance(v) {
-    var id = txt(String(v || "")) || "default";
-    try { localStorage.setItem(TMDB_SYNC_INSTANCE_KEY, id); } catch (_) {}
-    var s = el("tmdb_sync_instance");
-    if (s) s.value = id;
+    if (profile) profile.setInstance(v);
   }
 
   function tmdbApi(path) {
-    var p = String(path || "");
-    var sep = p.indexOf("?") >= 0 ? "&" : "?";
-    return p + sep + "instance=" + encodeURIComponent(getTMDbSyncInstance()) + "&ts=" + Date.now();
+    return profile ? profile.api(path) : String(path || "");
   }
 
   async function fetchJSON(url, opts) {
-    const r = await fetch(url, opts || {});
-    let j = null;
-    try { j = await r.json(); } catch {}
-    return { ok: r.ok, data: j };
+    return Shared.fetchJSON(url, opts);
   }
 
   async function getCfg(forceFresh) {
@@ -57,158 +51,24 @@
   }
 
   function getTMDbSyncCfgBlock(cfg) {
-    cfg = cfg || {};
-    var base = (cfg.tmdb_sync && typeof cfg.tmdb_sync === "object") ? cfg.tmdb_sync : (cfg.tmdb_sync = {});
-    var inst = getTMDbSyncInstance();
-    if (inst === "default") return base;
-    if (!base.instances || typeof base.instances !== "object") base.instances = {};
-    if (!base.instances[inst] || typeof base.instances[inst] !== "object") base.instances[inst] = {};
-    return base.instances[inst];
+    return profile ? profile.cfgBlock(cfg, true) : {};
   }
 
   async function refreshTMDbSyncInstanceOptions(preserve) {
-    var sel = el("tmdb_sync_instance");
-    if (!sel) return;
-    var want = preserve === false ? "default" : getTMDbSyncInstance();
-    try {
-      var r = await fetch("/api/provider-instances/tmdb_sync?ts=" + Date.now(), { cache: "no-store" });
-      var arr = await r.json().catch(function(){ return []; });
-      var opts = Array.isArray(arr) ? arr : [];
-      sel.innerHTML = "";
-      function addOpt(id, label) {
-        var o = document.createElement("option");
-        o.value = String(id);
-        o.textContent = String(label || id);
-        sel.appendChild(o);
-      }
-      addOpt("default", "Default");
-      opts.forEach(function(o){ if (o && o.id && o.id !== "default") addOpt(o.id, o.label || o.id); });
-      if (!Array.from(sel.options).some(function(o){ return o.value === want; })) want = "default";
-      sel.value = want;
-      setTMDbSyncInstance(want);
-    } catch (_) {}
+    if (profile) await profile.refreshOptions(preserve);
   }
 
   function ensureTMDbSyncInstanceUI() {
-    var panel = document.querySelector('#sec-tmdb-sync .cw-meta-provider-panel[data-provider="tmdb_sync"]') || document.querySelector('#sec-tmdb-sync .cw-meta-provider-panel') || document.querySelector('#sec-tmdb-sync');
-    var head = panel ? panel.querySelector('.cw-panel-head') : null;
-    if (!head || head.__tmdbSyncInstanceUI) return;
-    head.__tmdbSyncInstanceUI = true;
-
-    var wrap = document.createElement('div');
-    wrap.className = 'inline';
-    wrap.style.display = 'flex';
-    wrap.style.gap = '8px';
-    wrap.style.alignItems = 'center';
-    wrap.style.marginLeft = 'auto';
-    wrap.style.flexWrap = 'nowrap';
-    wrap.title = 'Select which TMDb Sync account this config applies to.';
-
-    var lab = document.createElement('span');
-    lab.className = 'muted';
-    lab.textContent = 'Profile';
-
-    var selEl = document.createElement('select');
-    selEl.id = 'tmdb_sync_instance';
-selEl.name = 'tmdb_sync_instance';
-    selEl.className = 'input';
-    selEl.style.minWidth = '160px';
-
-    // Match Trakt: keep it compact and let content drive the width.
-    selEl.style.width = 'auto';
-    selEl.style.maxWidth = '220px';
-    selEl.style.flex = '0 0 auto';
-    var btnNewEl = document.createElement('button');
-    btnNewEl.type = 'button';
-    btnNewEl.className = 'btn secondary';
-    btnNewEl.id = 'tmdb_sync_instance_new';
-    btnNewEl.textContent = 'New';
-
-    var btnDelEl = document.createElement('button');
-    btnDelEl.type = 'button';
-    btnDelEl.className = 'btn secondary';
-    btnDelEl.id = 'tmdb_sync_instance_del';
-    btnDelEl.textContent = 'Delete';
-
-    wrap.appendChild(lab);
-    wrap.appendChild(selEl);
-    wrap.appendChild(btnNewEl);
-    wrap.appendChild(btnDelEl);
-    head.appendChild(wrap);
-
-    refreshTMDbSyncInstanceOptions(true);
-
-    var sel = el("tmdb_sync_instance");
-    if (sel && !sel._wired) {
-      sel._wired = true;
-      sel.addEventListener("change", function () {
-        setTMDbSyncInstance(sel.value);
-        void hydrate(true, true);
-      });
-    }
-
-    var btnNew = el("tmdb_sync_instance_new");
-    if (btnNew && !btnNew._wired) {
-      btnNew._wired = true;
-      btnNew.addEventListener("click", async function () {
-        try {
-          var r = await fetch("/api/provider-instances/tmdb_sync/next?ts=" + Date.now(), {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: "{}",
-            cache: "no-store"
-          });
-          var j = await r.json().catch(function(){ return {}; });
-          var id = txt((j && j.id) || "");
-          if (!r.ok || (j && j.ok === false) || !id) throw new Error(String((j && j.error) || "create_failed"));
-          setTMDbSyncInstance(id);
-          await refreshTMDbSyncInstanceOptions(true);
-          await hydrate(true, true);
-          note("TMDb Sync profile created");
-        } catch {
-          note("TMDb Sync profile create failed");
-        }
-      });
-    }
-
-    var btnDel = el("tmdb_sync_instance_del");
-    if (btnDel && !btnDel._wired) {
-      btnDel._wired = true;
-      btnDel.addEventListener("click", async function () {
-        var inst = getTMDbSyncInstance();
-        if (inst === "default") { note("Cannot delete Default"); return; }
-        if (!confirm("Delete TMDb Sync profile '" + inst + "'?")) return;
-        try {
-          var r = await fetch("/api/provider-instances/tmdb_sync/" + encodeURIComponent(inst), { method: "DELETE", cache: "no-store" });
-          var j = await r.json().catch(function(){ return {}; });
-          if (!r.ok || (j && j.ok === false)) throw new Error(String((j && j.error) || "delete_failed"));
-          setTMDbSyncInstance("default");
-          await refreshTMDbSyncInstanceOptions(false);
-          await hydrate(true, true);
-          note("TMDb Sync profile deleted");
-        } catch {
-          note("TMDb Sync profile delete failed");
-        }
-      });
-    }
+    profile?.ensureUI(() => { void hydrate(true, true); });
   }
 
   function setConn(ok, msg) {
-    const m = el("tmdb_sync_msg");
-    if (!m) return;
-    const text = ok ? (msg || "Connected.") : (msg || "Not connected");
-    m.textContent = text;
-    m.classList.remove("hidden", "ok", "warn");
-    m.classList.add(ok ? "ok" : "warn");
+    return Shared.setStatus("tmdb_sync_msg", ok, msg);
   }
 
   function maskInput(i, has) {
-    if (!i) return;
-    if (i.dataset.touched === "1") return;
-    if (has) { i.value = "••••••••"; i.dataset.masked = "1"; }
-    else { i.value = ""; i.dataset.masked = "0"; }
-    i.dataset.loaded = "1";
-    i.dataset.hasValue = has ? "1" : "";
+    if (!i || i.dataset.touched === "1") return;
+    return Shared.maskSecret(i, has);
   }
 
   async function hydrate(forceFresh, verifyAfter) {
@@ -251,11 +111,11 @@ selEl.name = 'tmdb_sync_instance';
         await hydrate(true, false);
         const u = j.account?.username ? ` (${j.account.username})` : "";
         setConn(true, `Connected${u}`);
-        if (!silent) note("TMDb verified ✓");
+        if (!silent) note("TMDb verified ");
         return;
       }
       if (j.pending) {
-        setConn(false, "Pending approval…");
+        setConn(false, "Pending approval...");
         if (!silent) note("TMDb pending approval");
         return;
       }
@@ -276,13 +136,13 @@ selEl.name = 'tmdb_sync_instance';
       await hydrate(true, false);
       const u = j.account?.username ? ` (${j.account.username})` : "";
       setConn(true, `Connected${u}`);
-      note("TMDb connected ✓");
+      note("TMDb connected ");
       return;
     }
 
     if (Date.now() >= pollUntil) {
       stopPoll();
-      setConn(false, j.pending ? "Still pending. Approve on TMDb, then click Verify." : (j.error || "Not connected"));
+      setConn(false, j.pending ? "Still pending. Approve on TMDb, then click Connect." : (j.error || "Not connected"));
       return;
     }
 
@@ -292,7 +152,7 @@ selEl.name = 'tmdb_sync_instance';
       return;
     }
 
-    setConn(false, "Waiting…");
+    setConn(false, "Waiting...");
     pollTimer = setTimeout(tickPoll, 2000);
   }
 
@@ -309,7 +169,7 @@ selEl.name = 'tmdb_sync_instance';
     const hasSess = !!txt(sessEl?.value) || sessEl?.dataset.masked === "1";
     if (hasSess) { await refresh(false); return; }
 
-    if (!apiKey || apiKey.includes("•••")) {
+    if (!apiKey || apiKey.includes("***")) {
       setConn(false, "Enter your API key first.");
       el("tmdb_sync_hint")?.classList.remove("hidden");
       return;
@@ -324,14 +184,14 @@ selEl.name = 'tmdb_sync_instance';
       if (!r.ok || (r.data && r.data.ok === false)) throw new Error(r.data?.error || "connect_failed");
       const j = r.data || {};
       if (j.auth_url) window.open(j.auth_url, "_blank", "noopener,noreferrer");
-      setConn(false, "Approve in TMDb…");
+      setConn(false, "Approve in TMDb...");
       startPoll(120000);
     } catch {
       setConn(false, "TMDb connect failed");
     }
   }
 
-  async function onVerify() {
+  async function checkPendingApproval() {
     stopPoll();
     await refresh(false);
     const m = el("tmdb_sync_msg");
@@ -386,14 +246,11 @@ selEl.name = 'tmdb_sync_instance';
     const c = el("tmdb_sync_connect");
     if (c && !c.__wired) { c.addEventListener("click", onConnect); c.__wired = true; }
 
-    const v = el("tmdb_sync_verify");
-    if (v && !v.__wired) { v.addEventListener("click", onVerify); v.__wired = true; }
-
     const d = el("tmdb_sync_disconnect");
     if (d && !d.__wired) { d.addEventListener("click", onDisconnect); d.__wired = true; }
 
     if (!wire._focusWired) {
-      window.addEventListener("focus", () => { onVerify(); }, { passive: true });
+      window.addEventListener("focus", () => { checkPendingApproval(); }, { passive: true });
       wire._focusWired = true;
     }
 
@@ -442,8 +299,8 @@ selEl.name = 'tmdb_sync_instance';
       ? cfg.tmdb_sync
       : ((cfg.tmdb_sync.instances = cfg.tmdb_sync.instances || {}), (cfg.tmdb_sync.instances[inst] = cfg.tmdb_sync.instances[inst] || {}), cfg.tmdb_sync.instances[inst]);
 
-    if (key && !key.includes("•••") && keyEl?.dataset.masked !== "1") dst.api_key = key;
-    if (sess && !sess.includes("•••") && sessEl?.dataset.masked !== "1") dst.session_id = sess;
+    if (key && !key.includes("***") && keyEl?.dataset.masked !== "1") dst.api_key = key;
+    if (sess && !sess.includes("***") && sessEl?.dataset.masked !== "1") dst.session_id = sess;
   });
 
   function boot() {

--- a/assets/auth/auth.trakt.js
+++ b/assets/auth/auth.trakt.js
@@ -4,209 +4,61 @@
   window._traktPatched = true;
 
   // Utils
-  function _notify(msg) { try { if (typeof window.notify === "function") window.notify(msg); } catch (_) {} }
-  function _el(id) { return document.getElementById(id); }
+  const Shared = window.CW.AuthShared;
+  const traktProfile = Shared.createProfileAdapter({
+    provider: "trakt",
+    configKey: "trakt",
+    label: "Trakt",
+    sectionId: "sec-trakt",
+    selectId: "trakt_instance",
+    storageKey: "cw.ui.trakt.auth.instance.v1",
+    panelSelector: '#sec-trakt .cw-meta-provider-panel[data-provider="trakt"], .cw-meta-provider-panel[data-provider="trakt"]',
+    title: "Select which Trakt account this config applies to.",
+  });
+  function _notify(msg) { Shared.notify(msg); }
+  function _el(id) { return Shared.el(id); }
   function _setVal(id, v) { var el = _el(id); if (el) el.value = v == null ? "" : String(v); }
-  function _str(x) { return (typeof x === "string" ? x : "").trim(); }
+  function _str(x) { return Shared.txt(x); }
   function _isMaskedSecret(v) {
-    var value = _str(v);
-    if (!value) return false;
-    if (value === '••••••••' || value === '********' || value === '**********') return true;
-    return /^[•*]{3,}$/.test(value);
+    return Shared.isMaskedSecret(v);
   }
   function _markSecretField(el, value) {
-    if (!el) return;
-    var text = _str(value);
-    el.value = text;
-    el.dataset.masked = _isMaskedSecret(text) ? '1' : '0';
-    el.dataset.loaded = '1';
-    if (!el.dataset.touched) el.dataset.touched = '';
+    return Shared.markSecretField(el, value);
   }
   function _wireSecretField(el, onChange) {
-    if (!el || el.__cwSecretWired) return;
-    var clearMask = function () {
-      if (el.dataset.masked === '1') {
-        el.value = '';
-        el.dataset.masked = '0';
-      }
-    };
-    el.addEventListener('beforeinput', function () {
-      clearMask();
-    });
-    el.addEventListener('paste', function () {
-      clearMask();
-      el.dataset.touched = '1';
-      if (typeof onChange === 'function') onChange();
-    });
-    el.addEventListener('input', function () {
-      if (_isMaskedSecret(el.value)) el.dataset.masked = '1';
-      else if (el.dataset.masked === '1') el.dataset.masked = '0';
-      el.dataset.touched = '1';
-      if (typeof onChange === 'function') onChange();
-    });
-    el.__cwSecretWired = true;
+    return Shared.wireSecretInput(el, { onInput: onChange });
   }
   function _readSecretField(el) {
-    var raw = _str(el ? el.value : '');
-    var masked = !!(el && (el.dataset.masked === '1' || _isMaskedSecret(raw)));
-    if (!raw && !masked) return { hasValue: false, masked: false, value: '' };
-    if (masked) return { hasValue: true, masked: true, value: '' };
-    return { hasValue: true, masked: false, value: raw };
+    return Shared.readSecretField(el);
   }
 
-  const TRAKT_INSTANCE_KEY = "cw.ui.trakt.auth.instance.v1";
+  var traktConnected = false;
 
   function getTraktInstance() {
-    var el = _el("trakt_instance");
-    var v = el ? _str(el.value) : "";
-    if (!v) { try { v = localStorage.getItem(TRAKT_INSTANCE_KEY) || ""; } catch (_) {} }
-    v = _str(v) || "default";
-    return v.toLowerCase() === "default" ? "default" : v;
+    return traktProfile ? traktProfile.getInstance() : "default";
   }
 
   function setTraktInstance(v) {
-    var id = _str(String(v || "")) || "default";
-    try { localStorage.setItem(TRAKT_INSTANCE_KEY, id); } catch (_) {}
-    var el = _el("trakt_instance");
-    if (el) el.value = id;
+    if (traktProfile) traktProfile.setInstance(v);
   }
 
   function traktApi(path) {
-    var p = String(path || "");
-    var sep = p.indexOf("?") >= 0 ? "&" : "?";
-    return p + sep + "instance=" + encodeURIComponent(getTraktInstance()) + "&ts=" + Date.now();
+    return traktProfile ? traktProfile.api(path) : String(path || "");
   }
 
   function getTraktCfgBlock(cfg) {
-    cfg = cfg || {};
-    var base = (cfg.trakt && typeof cfg.trakt === "object") ? cfg.trakt : (cfg.trakt = {});
-    var inst = getTraktInstance();
-    if (inst === "default") return base;
-    if (!base.instances || typeof base.instances !== "object") base.instances = {};
-    if (!base.instances[inst] || typeof base.instances[inst] !== "object") base.instances[inst] = {};
-    return base.instances[inst];
+    return traktProfile ? traktProfile.cfgBlock(cfg, true) : {};
   }
 
   async function refreshTraktInstanceOptions(preserve) {
-    var sel = _el("trakt_instance");
-    if (!sel) return;
-    var want = preserve === false ? "default" : getTraktInstance();
-    try {
-      var r = await fetch("/api/provider-instances/trakt?ts=" + Date.now(), { cache: "no-store" });
-      var arr = await r.json().catch(function(){ return []; });
-      var opts = Array.isArray(arr) ? arr : [];
-      sel.innerHTML = "";
-      function addOpt(id, label) {
-        var o = document.createElement("option");
-        o.value = String(id);
-        o.textContent = String(label || id);
-        sel.appendChild(o);
-      }
-      addOpt("default", "Default");
-      opts.forEach(function(o){ if (o && o.id && o.id !== "default") addOpt(o.id, o.label || o.id); });
-      if (!Array.from(sel.options).some(function(o){ return o.value === want; })) want = "default";
-      sel.value = want;
-      setTraktInstance(want);
-    } catch (_) {}
+    if (traktProfile) await traktProfile.refreshOptions(preserve);
   }
 
   function ensureTraktInstanceUI() {
-    var panel = document.querySelector('#sec-trakt .cw-meta-provider-panel[data-provider="trakt"]') || document.querySelector('.cw-meta-provider-panel[data-provider="trakt"]') || document.querySelector('#sec-trakt .cw-meta-provider-panel') || document.querySelector('#sec-trakt') || document.querySelector('[data-provider="trakt"]');
-    if (!panel) return;
-    if (panel.querySelector('#trakt_instance')) return;
-    var head = panel.querySelector('.cw-panel-head') || panel.querySelector('.panel-head') || panel.querySelector('header') || panel;
-    if (head.__traktInstanceUI) return;
-    head.__traktInstanceUI = true;
-
-    var wrap = document.createElement('div');
-    wrap.className = 'inline';
-    wrap.style.display = 'flex';
-    wrap.style.gap = '8px';
-    wrap.style.alignItems = 'center';
-    try { head.style.flexWrap = 'wrap'; } catch (_) {}
-    wrap.title = 'Select which Trakt account this config applies to.';
-
-    var lab = document.createElement('span');
-    lab.className = 'muted';
-    lab.textContent = 'Profile';
-
-    var sel = document.createElement('select');
-    sel.id = 'trakt_instance';
-sel.name = 'trakt_instance';
-    sel.className = 'input';
-    sel.style.minWidth = '140px';
-    sel.style.width = 'auto';
-    sel.style.maxWidth = '220px';
-    sel.style.flex = '0 0 auto';
-
-    var btnNewEl = document.createElement('button');
-    btnNewEl.type = 'button';
-    btnNewEl.className = 'btn secondary';
-    btnNewEl.id = 'trakt_instance_new';
-    btnNewEl.textContent = 'New';
-
-    var btnDelEl = document.createElement('button');
-    btnDelEl.type = 'button';
-    btnDelEl.className = 'btn secondary';
-    btnDelEl.id = 'trakt_instance_del';
-    btnDelEl.textContent = 'Delete';
-
-    wrap.appendChild(lab);
-    wrap.appendChild(sel);
-    wrap.appendChild(btnNewEl);
-    wrap.appendChild(btnDelEl);
-    if (head === panel) panel.insertBefore(wrap, panel.firstChild);
-    else head.appendChild(wrap);
-
-    refreshTraktInstanceOptions(true);
-
-    var sel = _el('trakt_instance');
-    if (sel && !sel._wired) {
-      sel._wired = true;
-      sel.addEventListener('change', function(){
-        setTraktInstance(sel.value);
-        void hydrateAuthFromConfig();
-        try { startTraktTokenPoll(); } catch (_) {}
-      });
-    }
-
-    var btnNew = _el('trakt_instance_new');
-    if (btnNew && !btnNew._wired) {
-      btnNew._wired = true;
-      btnNew.addEventListener('click', async function(){
-        try {
-          var r = await fetch('/api/provider-instances/trakt/next?ts=' + Date.now(), { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}', cache: 'no-store' });
-          var j = await r.json().catch(function(){ return {}; });
-          var id = _str((j && j.id) || '');
-          if (!r.ok || (j && j.ok === false) || !id) throw new Error(String((j && j.error) || 'create_failed'));
-          setTraktInstance(id);
-          await refreshTraktInstanceOptions(true);
-          void hydrateAuthFromConfig();
-        } catch (e) {
-          _notify('Could not create profile: ' + (e && e.message ? e.message : e));
-        }
-      });
-    }
-
-    var btnDel = _el('trakt_instance_del');
-    if (btnDel && !btnDel._wired) {
-      btnDel._wired = true;
-      btnDel.addEventListener('click', async function(){
-        var id = getTraktInstance();
-        if (id === 'default') return _notify('Default profile cannot be deleted.');
-        if (!confirm('Delete Trakt profile "' + id + '"?')) return;
-        try {
-          var r = await fetch('/api/provider-instances/trakt/' + encodeURIComponent(id), { method: 'DELETE', cache: 'no-store' });
-          var j = await r.json().catch(function(){ return {}; });
-          if (!r.ok || (j && j.ok === false)) throw new Error(String((j && j.error) || 'delete_failed'));
-          setTraktInstance('default');
-          await refreshTraktInstanceOptions(false);
-          void hydrateAuthFromConfig();
-        } catch (e) {
-          _notify('Could not delete profile: ' + (e && e.message ? e.message : e));
-        }
-      });
-    }
+    traktProfile?.ensureUI(() => {
+      void hydrateAuthFromConfig();
+      try { startTraktTokenPoll(); } catch (_) {}
+    });
   }
 
   async function persistTraktClientFields() {
@@ -229,16 +81,15 @@ sel.name = 'trakt_instance';
       var msg = _el('trakt_msg');
       if (!msg) return;
       var pinEl = _el('trakt_pin'); var pin = _str(pinEl ? pinEl.value : '');
-      var tokEl = _el('trakt_token'); var tok = _str(tokEl ? tokEl.value : '');
-      msg.classList.remove('hidden', 'ok', 'warn');
-      if (tok) { msg.classList.add('ok'); msg.textContent = 'Connected.'; return; }
-      if (pin) { msg.classList.add('warn'); msg.textContent = 'Code: ' + pin; return; }
-      msg.classList.add('hidden'); msg.textContent = '';
+      if (traktConnected) return Shared.setStatusPill(msg, "ok", "Connected");
+      if (pin) return Shared.setStatusPill(msg, "warn", "Code: " + pin);
+      return Shared.setStatusPill(msg, null);
     } catch (_) {}
   }
   // status banner
   function setTraktSuccess(show) {
     try {
+      traktConnected = !!show;
       if (show) updateTraktBanner();
       else { var el = _el('trakt_msg'); if (el) { el.classList.add('hidden'); el.textContent = ''; el.classList.remove('ok','warn'); } }
     } catch (_) {}
@@ -256,21 +107,6 @@ sel.name = 'trakt_instance';
   }
 
   // Hydrate
-  async function hydratePlexFromConfigRaw() {
-    var cfg = await fetchConfig(); if (!cfg) return;
-    var tok = _str(cfg.plex && cfg.plex.account_token);
-    if (tok) _setVal("plex_token", tok);
-  }
-
-  async function hydrateSimklFromConfigRaw() {
-    var cfg = await fetchConfig(); if (!cfg) return;
-    var s = cfg.simkl || {};
-    var a = (cfg.auth && cfg.auth.simkl) || {};
-    _setVal("simkl_client_id",     _str(s.client_id));
-    _setVal("simkl_client_secret", _str(s.client_secret));
-    _setVal("simkl_access_token",  _str(s.access_token || a.access_token));
-  }
-
   async function hydrateAuthFromConfig() {
     try {
       var cfg = await fetchConfig(); if (!cfg) return;
@@ -279,7 +115,7 @@ sel.name = 'trakt_instance';
             var isDefault = (getTraktInstance() === "default");
       _markSecretField(_el("trakt_client_id"),     _str(t.client_id || (isDefault ? (cfg.trakt && cfg.trakt.client_id) : "")));
       _markSecretField(_el("trakt_client_secret"), _str(t.client_secret || (isDefault ? (cfg.trakt && cfg.trakt.client_secret) : "")));
-      _setVal("trakt_token",         _str(t.access_token || (getTraktInstance() === 'default' ? a.access_token : '')));
+      traktConnected = !!_str(t.access_token || (getTraktInstance() === 'default' ? a.access_token : ''));
       _setVal("trakt_pin",           _str((t._pending_device && t._pending_device.user_code) || ''));
       updateTraktHint();
       updateTraktBanner();
@@ -289,8 +125,6 @@ sel.name = 'trakt_instance';
   }
 
   async function hydrateAllSecretsRaw() {
-    try { await hydratePlexFromConfigRaw(); } catch (_) {}
-    try { await hydrateSimklFromConfigRaw(); } catch (_) {}
     try { await hydrateAuthFromConfig(); } catch (_) {}
   }
 
@@ -309,37 +143,8 @@ sel.name = 'trakt_instance';
 
   // Copy helpers
   async function _copyText(text, btn) {
-    if (!text) return false;
-    try {
-      if (navigator.clipboard && window.isSecureContext) {
-        await navigator.clipboard.writeText(text);
-      } else {
-        var ta = document.createElement("textarea");
-        ta.value = text;
-        ta.setAttribute("readonly", "");
-        ta.style.position = "fixed";
-        ta.style.top = "-9999px";
-        document.body.appendChild(ta);
-        ta.select();
-        document.execCommand("copy");
-        document.body.removeChild(ta);
-      }
-      if (btn) {
-        btn.classList.add("copied");
-        setTimeout(function(){ btn.classList.remove("copied"); }, 1200);
-      }
-      return true;
-    } catch (e) {
-      console.warn("Copy failed", e);
-      return false;
-    }
+    return Shared.copyText(text, btn, { failureMessage: false });
   }
-
-  window.copyInputValue = async function (inputId, btn) {
-    var el = document.getElementById(inputId);
-    if (!el) return;
-    await _copyText(el.value || "", btn);
-  };
 
   window.copyTraktRedirect = async function () {
     var code = document.getElementById("trakt_redirect_uri_preview");
@@ -347,30 +152,9 @@ sel.name = 'trakt_instance';
     await _copyText(text);
   };
 
-  window.copyRedirect = async function () {
-    var code = document.getElementById("redirect_uri_preview");
-    var text = ((code && code.textContent) || (code && code.value) || "").trim();
-    await _copyText(text);
-  };
-
   var __traktInitDone = false;
   function initTraktAuthUI() {
-    if (__traktInitDone) return;
-    __traktInitDone = true;
-
-    [
-      ["btn-copy-trakt-pin",   "trakt_pin"],
-      ["btn-copy-trakt-token", "trakt_token"],
-      ["btn-copy-plex-pin",    "plex_pin"],
-      ["btn-copy-plex-token",  "plex_token"]
-    ].forEach(function (pair) {
-      var btnId = pair[0], inputId = pair[1];
-      var b = document.getElementById(btnId);
-      if (b && !b._copyHooked) {
-        b.addEventListener("click", function () { window.copyInputValue(inputId, this); });
-        b._copyHooked = true;
-      }
-    });
+    Shared.wireCopyButton("btn-copy-trakt-pin", "trakt_pin");
 
     try {
       ensureTraktInstanceUI();
@@ -381,6 +165,13 @@ sel.name = 'trakt_instance';
       if (idEl)  idEl.addEventListener('change', function(){ void persistTraktClientFields(); });
       if (secEl) secEl.addEventListener('change', function(){ void persistTraktClientFields(); });
 
+      var copyRedirect = _el("btn-copy-trakt-redirect");
+      if (copyRedirect && !copyRedirect.__wired) { copyRedirect.addEventListener("click", () => window.copyTraktRedirect()); copyRedirect.__wired = true; }
+      var connectBtn = _el("btn-connect-trakt");
+      if (connectBtn && !connectBtn.__wired) { connectBtn.addEventListener("click", requestTraktPin); connectBtn.__wired = true; }
+      var deleteBtn = _el("btn-delete-trakt");
+      if (deleteBtn && !deleteBtn.__wired) { deleteBtn.addEventListener("click", traktDeleteToken); deleteBtn.__wired = true; }
+
       updateTraktHint();
       updateTraktBanner();
       hydrateAllSecretsRaw();
@@ -388,6 +179,9 @@ sel.name = 'trakt_instance';
     } catch (e) {
       console.warn("[trakt] init failed", e);
     }
+
+    if (__traktInitDone) return;
+    __traktInitDone = true;
 
     try {
       if (!window.__traktBannerTick) {
@@ -437,9 +231,8 @@ sel.name = 'trakt_instance';
     try { if (window._traktVisPollCfg) document.removeEventListener("visibilitychange", window._traktVisPollCfg); } catch (_){}
     window._traktVisPollCfg = null;
 
-    var tokenNow = _str(_el("trakt_token")?.value);
     var pinNow = _str(_el("trakt_pin")?.value);
-    if (tokenNow || !pinNow) {
+    if (traktConnected || !pinNow) {
       window._traktPollCfg = null;
       return;
     }
@@ -483,7 +276,6 @@ sel.name = 'trakt_instance';
         tok = _str(t && t.access_token) || (getTraktInstance() === 'default' ? tok : '');
       } catch (_) {}
       if (tok) {
-        _setVal("trakt_token", tok);
         setTraktSuccess(true);
         cleanup();
         return;
@@ -565,7 +357,7 @@ sel.name = 'trakt_instance';
       }
 
       if (code) {
-        try { await navigator.clipboard.writeText(code); } catch (_) {}
+        try { await Shared.copyText(code, null, { failureMessage: false }); } catch (_) {}
         try { startTraktDevicePoll(); } catch (_) {}
         try { startTraktTokenPoll(); } catch (_) {}
       }
@@ -580,7 +372,7 @@ sel.name = 'trakt_instance';
     }
   }
 
-  // Delete Trakt access token via backend endpoint
+  // Disconnect Trakt via backend endpoint
   async function traktDeleteToken() {
     var btn = document.querySelector('#sec-trakt .btn.danger');
     var msg = document.getElementById('trakt_msg');
@@ -595,8 +387,8 @@ sel.name = 'trakt_instance';
       });
       var j = await r.json().catch(()=>({}));
       if (r.ok && (j.ok !== false)) {
-        _setVal('trakt_token',''); _setVal('trakt_pin',''); setTraktSuccess(false);
-        if (msg) msg.textContent = 'Access token removed.';
+        _setVal('trakt_pin',''); setTraktSuccess(false);
+        if (msg) msg.textContent = 'Disconnected';
       } else {
         if (msg) { msg.classList.add('warn'); msg.textContent = 'Could not remove token.'; }
       }
@@ -632,11 +424,9 @@ sel.name = 'trakt_instance';
     window.updateTraktHint              = updateTraktHint;
     window.flushTraktCreds              = flushTraktCreds;
     window.hydrateAuthFromConfig        = hydrateAuthFromConfig;
-    window.hydratePlexFromConfigRaw     = hydratePlexFromConfigRaw;
-    window.hydrateSimklFromConfigRaw    = hydrateSimklFromConfigRaw;
     window.hydrateSecretsRaw            = hydrateAllSecretsRaw;
     window.requestTraktPin              = requestTraktPin;
-    window.startTraktTokenPoll          = startTraktTokenPoll;       // legacy/fallback
+    window.startTraktTokenPoll          = startTraktTokenPoll;
     window.startTraktDevicePoll         = startTraktDevicePoll;
     window.traktDeleteToken             = traktDeleteToken;
   } catch (_) {}

--- a/assets/auth/auth_loader.js
+++ b/assets/auth/auth_loader.js
@@ -29,6 +29,7 @@
   };
 
   const loaded = new Map();
+  let sharedPromise = null;
 
   function _prefetch(host) {
     try {
@@ -38,6 +39,23 @@
 
   function _ver() {
     return String(w.__CW_VERSION__ || "").trim();
+  }
+
+  function loadShared() {
+    if (w.CW?.AuthShared) return Promise.resolve(true);
+    if (sharedPromise) return sharedPromise;
+    const url = new URL("/assets/auth/auth.shared.js", d.baseURI);
+    const v = _ver();
+    if (v) url.searchParams.set("v", v);
+    sharedPromise = new Promise((resolve, reject) => {
+      const s = d.createElement("script");
+      s.src = url.toString();
+      s.async = true;
+      s.onload = () => resolve(true);
+      s.onerror = () => reject(new Error("Failed to load shared auth helpers"));
+      d.head.appendChild(s);
+    });
+    return sharedPromise;
   }
 
   function load(provider) {
@@ -51,7 +69,7 @@
     const v = _ver();
     if (v) url.searchParams.set("v", v);
 
-    const p = new Promise((resolve, reject) => {
+    const p = loadShared().then(() => new Promise((resolve, reject) => {
       const s = d.createElement("script");
       s.src = url.toString();
       // Dynamic scripts: let them execute as soon as they load.
@@ -59,7 +77,7 @@
       s.onload = () => resolve(true);
       s.onerror = () => reject(new Error(`Failed to load auth script: ${key}`));
       d.head.appendChild(s);
-    });
+    }));
 
     loaded.set(key, p);
     return p;
@@ -131,7 +149,7 @@
   if (d.readyState === "loading") d.addEventListener("DOMContentLoaded", attach, { once: true });
   else attach();
 
-  w.cwAuthLoader = { load, ensureSection };
+  w.cwAuthLoader = { load, ensureSection, loadShared };
   w.cwLoadAuth = load;
   w.cwEnsureAuthSection = ensureSection;
 })(window, document);

--- a/assets/helpers/providers-ui.js
+++ b/assets/helpers/providers-ui.js
@@ -20,15 +20,29 @@
   function bindCopyButton(btnId, inputId) {
     const btn = document.getElementById(btnId);
     if (!btn || btn.__cwBound) return;
-    btn.addEventListener("click", (e) => window.copyInputValue?.(inputId, e.currentTarget));
+    if (btn.getAttribute("onclick")) {
+      btn.__cwBound = true;
+      return;
+    }
+    btn.addEventListener("click", (e) => window.CW.AuthShared.copyField(inputId, e.currentTarget));
     btn.__cwBound = true;
   }
 
   function wireCopyButtons() {
     bindCopyButton("btn-copy-plex-pin", "plex_pin");
-    bindCopyButton("btn-copy-plex-token", "plex_token");
     bindCopyButton("btn-copy-trakt-pin", "trakt_pin");
-    bindCopyButton("btn-copy-trakt-token", "trakt_token");
+  }
+
+  function initMountedAuthSections(root, tries = 0) {
+    if (!root) return;
+    if (typeof window.cwEnsureAuthSection !== "function") {
+      if (tries < 20) setTimeout(() => initMountedAuthSections(root, tries + 1), 50);
+      return;
+    }
+    const sections = Array.from(root.querySelectorAll(".section.open[id]"));
+    sections.forEach((sec) => {
+      try { window.cwEnsureAuthSection(sec.id).catch(() => {}); } catch {}
+    });
   }
 
   function collapseAuthSections(root) {
@@ -43,7 +57,7 @@
       if (!want.some((w) => text.startsWith(w))) return;
       sec.classList.remove("open");
       const chev = sec.querySelector(":scope > .head .chev");
-      if (chev) chev.textContent = "▶";
+      if (chev) chev.textContent = "";
     });
     root.querySelectorAll("details").forEach((det) => {
       const text = (det.querySelector(":scope > summary")?.textContent || "").trim().toLowerCase();
@@ -111,6 +125,7 @@
         window.initAniListAuthUI?.();
 
         collapseAuthSections(slot);
+        initMountedAuthSections(slot);
         wireCopyButtons();
 
         ["trakt_client_id", "trakt_client_secret"].forEach((id) => {

--- a/assets/helpers/settings-save.js
+++ b/assets/helpers/settings-save.js
@@ -5,9 +5,9 @@
 
 const _cwJSONHeaders = { "Content-Type": "application/json" };
 const _cwSecretIds = [
-  "plex_token", "plex_home_pin", "simkl_client_id", "simkl_client_secret",
+  "plex_home_pin", "simkl_client_id", "simkl_client_secret",
   "trakt_client_id", "trakt_client_secret", "anilist_client_id", "anilist_client_secret",
-  "tmdb_api_key", "mdblist_key", "publicmetadb_key"
+  "tmdb_api_key", "mdblist_key", "publicmetadb_key", "tautulli_key"
 ];
 
 function _cwEl(id) { return document.getElementById(id); }
@@ -290,6 +290,60 @@ function _cwReadSecret(id, previousValue) {
   return raw !== previousValue ? { changed: true, set: raw } : { changed: false };
 }
 
+function _cwProviderAuthError(provider, code) {
+  const key = _cwNorm(code);
+  if (provider === "tautulli") {
+    if (key === "server_url_required") return "Enter Tautulli server URL";
+    if (key === "api_key_required") return "Enter your Tautulli API key";
+    if (key === "invalid_api_key") return "Invalid Tautulli API key";
+    if (key === "validation_timeout") return "Tautulli validation timed out";
+    if (key === "validation_failed") return "Could not connect to Tautulli";
+    if (key === "validation_bad_response") return "Tautulli validation returned an unexpected response";
+    if (key.startsWith("validation_http_")) return "Tautulli validation failed";
+    return "Saving Tautulli failed";
+  }
+  if (provider === "publicmetadb") {
+    if (key === "api_key_required") return "Enter your PublicMetaDB API key";
+    if (key === "invalid_api_key") return "Invalid PublicMetaDB API key";
+    if (key === "validation_timeout") return "PublicMetaDB validation timed out";
+    if (key === "validation_failed") return "Could not validate PublicMetaDB API key";
+    if (key === "validation_bad_response") return "PublicMetaDB validation returned an unexpected response";
+    if (key.startsWith("validation_http_")) return "PublicMetaDB validation failed";
+    return "Saving PublicMetaDB key failed";
+  }
+  return "Provider authentication failed";
+}
+
+async function _cwValidateProviderSecret(provider, inst, change) {
+  if (provider !== "publicmetadb" || !change?.changed || !change?.set) return;
+  const url = `/api/publicmetadb/save?instance=${encodeURIComponent(_cwNormInst(inst))}`;
+  const resp = await _cwRequest(url, {
+    method: "POST",
+    headers: _cwJSONHeaders,
+    body: JSON.stringify({ api_key: change.set })
+  }, 15000);
+  const body = await _cwReadBody(resp);
+  if (!resp?.ok || body?.ok === false) {
+    _cwAbortSave(_cwProviderAuthError(provider, body?.error || `http_${resp?.status || 0}`));
+  }
+}
+
+async function _cwValidateTautulliSecret(inst, payload) {
+  const server = _cwNorm(payload?.server_url);
+  const apiKey = _cwNorm(payload?.api_key);
+  if (!server && !apiKey) return;
+  const url = `/api/tautulli/save?instance=${encodeURIComponent(_cwNormInst(inst))}`;
+  const resp = await _cwRequest(url, {
+    method: "POST",
+    headers: _cwJSONHeaders,
+    body: JSON.stringify(payload || {})
+  }, 15000);
+  const body = await _cwReadBody(resp);
+  if (!resp?.ok || body?.ok === false) {
+    _cwAbortSave(_cwProviderAuthError("tautulli", body?.error || body?.detail || `http_${resp?.status || 0}`));
+  }
+}
+
 async function _cwSaveAppAuth(serverCfg) {
   const MIN_PASSWORD_LENGTH = 8;
   const wantEnabled = true;
@@ -502,6 +556,10 @@ async function saveSettings() {
       show_AI: typeof serverCfg?.ui?.show_AI === "boolean" ? !!serverCfg.ui.show_AI : true,
       show_quick_add_desktop: typeof serverCfg?.ui?.show_quick_add_desktop === "boolean" ? !!serverCfg.ui.show_quick_add_desktop : true,
       show_quick_add_mobile: typeof serverCfg?.ui?.show_quick_add_mobile === "boolean" ? !!serverCfg.ui.show_quick_add_mobile : true,
+      theme: (() => {
+        const theme = _cwNorm(serverCfg?.ui?.theme).toLowerCase();
+        return theme === "flat-light" || theme === "original" ? theme : "flat-dark";
+      })(),
       protocol: _cwNorm(serverCfg?.ui?.protocol).toLowerCase() === "https" ? "https" : "http"
     };
 
@@ -525,6 +583,17 @@ async function saveSettings() {
       uiCfg[limitKey] = displayLimit(next);
       mark();
     });
+
+    const themeEl = _cwEl("ui_theme");
+    if (themeEl) {
+      const rawTheme = _cwNorm(themeEl.value).toLowerCase();
+      const nextTheme = rawTheme === "flat-light" || rawTheme === "original" ? rawTheme : "flat-dark";
+      if (nextTheme !== prevUi.theme) {
+        ensureObj(cfg, "ui").theme = nextTheme;
+        try { window.CWTheme?.apply?.(nextTheme, { persist: true }); } catch {}
+        mark();
+      }
+    }
 
     const protoEl = _cwEl("ui_protocol");
     if (protoEl) {
@@ -575,10 +644,13 @@ async function saveSettings() {
         mdblist: _cwInstBlock(serverCfg?.mdblist, _cwSelectedInst("mdblist")),
         publicmetadb: _cwInstBlock(serverCfg?.publicmetadb, _cwSelectedInst("publicmetadb"))
       };
+      const publicmetadbInst = _cwSelectedInst("publicmetadb");
+      const publicmetadbKey = _cwReadSecret("publicmetadb_key", _cwNorm(secrets.publicmetadb?.api_key));
+      await _cwValidateProviderSecret("publicmetadb", publicmetadbInst, publicmetadbKey);
       [
         ["mdblist", _cwSelectedInst("mdblist"), [["api_key", _cwReadSecret("mdblist_key", _cwNorm(secrets.mdblist?.api_key))]]],
-        ["publicmetadb", _cwSelectedInst("publicmetadb"), [["api_key", _cwReadSecret("publicmetadb_key", _cwNorm(secrets.publicmetadb?.api_key))]]],
-        ["plex", _cwSelectedInst("plex"), [["account_token", _cwReadSecret("plex_token", _cwNorm(secrets.plex?.account_token))], ["home_pin", _cwReadSecret("plex_home_pin", _cwNorm(secrets.plex?.home_pin)), ""]]],
+        ["publicmetadb", publicmetadbInst, [["api_key", publicmetadbKey]]],
+        ["plex", _cwSelectedInst("plex"), [["home_pin", _cwReadSecret("plex_home_pin", _cwNorm(secrets.plex?.home_pin)), ""]]],
         ["simkl", _cwSelectedInst("simkl"), [["client_id", _cwReadSecret("simkl_client_id", _cwNorm(secrets.simkl?.client_id))], ["client_secret", _cwReadSecret("simkl_client_secret", _cwNorm(secrets.simkl?.client_secret))]]],
         ["trakt", _cwSelectedInst("trakt", "cw.ui.trakt.auth.instance.v1"), [["client_id", _cwReadSecret("trakt_client_id", _cwNorm(secrets.trakt?.client_id))], ["client_secret", _cwReadSecret("trakt_client_secret", _cwNorm(secrets.trakt?.client_secret))]]],
         ["anilist", _cwSelectedInst("anilist"), [["client_id", _cwReadSecret("anilist_client_id", _cwNorm(secrets.anilist?.client_id))], ["client_secret", _cwReadSecret("anilist_client_secret", _cwNorm(secrets.anilist?.client_secret))]]],
@@ -591,8 +663,36 @@ async function saveSettings() {
         changes.forEach(([prop, ch, clearValue]) => _cwApplySecret(target, prop, ch, clearValue));
         mark();
       });
+
+      const tautulliInst = _cwSelectedInst("tautulli");
+      const tautulliPrev = _cwInstBlock(serverCfg?.tautulli, tautulliInst);
+      const tautulliServer = _cwNorm(_cwEl("tautulli_server")?.value || "");
+      const tautulliKey = _cwReadSecret("tautulli_key", _cwNorm(tautulliPrev?.api_key));
+      const tautulliUserEl = _cwEl("tautulli_user_id");
+      const tautulliUser = _cwNorm(tautulliUserEl?.value || "");
+      const tautulliUserTouched = !!tautulliUserEl?.dataset?.touched;
+      const tautulliPayload = {};
+      const tautulliServerChanged = !!tautulliServer && tautulliServer !== _cwNorm(tautulliPrev?.server_url);
+      if (tautulliServer) tautulliPayload.server_url = tautulliServer;
+      if (tautulliKey.changed && tautulliKey.set) tautulliPayload.api_key = tautulliKey.set;
+      if (tautulliUser || tautulliUserTouched) tautulliPayload.user_id = tautulliUser;
+      if (tautulliServerChanged || (tautulliKey.changed && tautulliKey.set)) {
+        await _cwValidateTautulliSecret(tautulliInst, tautulliPayload);
+      }
+      if (tautulliServerChanged || tautulliKey.changed || tautulliUser || tautulliUserTouched) {
+        cfg.tautulli = cfg.tautulli && typeof cfg.tautulli === "object" ? cfg.tautulli : {};
+        const ttarget = _cwEnsureInstBlock(cfg.tautulli, tautulliInst);
+        if (tautulliServer) ttarget.server_url = tautulliServer;
+        if (tautulliKey.changed) _cwApplySecret(ttarget, "api_key", tautulliKey);
+        if (tautulliUser || tautulliUserTouched) {
+          ttarget.history = ttarget.history && typeof ttarget.history === "object" ? ttarget.history : {};
+          ttarget.history.user_id = tautulliUser;
+        }
+        mark();
+      }
     } catch (e) {
       console.warn("saveSettings: secret merge failed", e);
+      if (e?.__cwAbortSave) throw e;
     }
 
     try {

--- a/assets/helpers/settings-ui.js
+++ b/assets/helpers/settings-ui.js
@@ -93,28 +93,12 @@ async function loadCrossWatchSnapshots(cfg) {
 
 const UI_SETTINGS_TAB_KEY = "cw.ui.settings.tab.v1";
 
-function _uiDaysLeftFromEpochSeconds(epochSeconds) {
-  if (!epochSeconds || !Number.isFinite(epochSeconds)) return null;
-  const ms = epochSeconds * 1000;
-  const diffMs = ms - Date.now();
-  if (diffMs <= 0) return 0;
-  return Math.ceil(diffMs / (24 * 60 * 60 * 1000));
-}
-
 function cwUiSettingsSelect(tab, opts = {}) {
   const t = String(tab || "ui").toLowerCase();
   const persist = opts.persist !== false;
 
-  const hub = document.getElementById("ui_settings_hub");
   const panels = document.getElementById("ui_settings_panels");
-  if (!hub || !panels) return;
-
-  const tiles = hub.querySelectorAll(".cw-hub-tile");
-  tiles.forEach((btn) => {
-    const k = String(btn.dataset.tab || "").toLowerCase();
-    btn.classList.toggle("active", k === t);
-    btn.setAttribute("aria-selected", k === t ? "true" : "false");
-  });
+  if (!panels) return;
 
   const ps = panels.querySelectorAll(".cw-settings-panel");
   ps.forEach((p) => {
@@ -130,92 +114,8 @@ function cwUiSettingsSelect(tab, opts = {}) {
 }
 
 function cwUiSettingsHubUpdate() {
-  const set = (id, text) => {
-    const el = document.getElementById(id);
-    if (el) el.textContent = text;
-  };
-
-  const wl = document.getElementById("ui_show_watchlist_preview");
-  if (wl) set("hub_ui_watchlist", `Watchlist: ${wl.value === "false" ? "Hide" : "Show"}`);
-
-  const pc = document.getElementById("ui_show_playingcard");
-  if (pc) set("hub_ui_playing", `Playing: ${pc.value === "false" ? "Hide" : "Show"}`);
-
-  const displaySummary = (value) => {
-    const text = String(value || "count:3");
-    if (text.startsWith("hours:")) return `${text.slice(6)}h`;
-    if (text.startsWith("count:")) return text.slice(6);
-    return "3";
-  };
-
-  const recentActivity = document.getElementById("ui_show_recent_activity");
-  const recentActivityDisplay = document.getElementById("ui_recent_activity_display");
-  if (recentActivity) {
-    const suffix = recentActivityDisplay ? `, ${displaySummary(recentActivityDisplay.value)}` : "";
-    set("hub_ui_activity", `Activity: ${recentActivity.value === "false" ? "Hide" : "Show"}${suffix}`);
-  }
-
-  const ai = document.getElementById("ui_show_AI");
-  if (ai) set("hub_ui_askai", `ASK AI: ${ai.value === "false" ? "Hide" : "Show"}`);
-
-  const quickDesk = document.getElementById("ui_show_quick_add_desktop");
-  const quickMobile = document.getElementById("ui_show_quick_add_mobile");
-  if (quickDesk || quickMobile) {
-    const deskShown = quickDesk ? quickDesk.value !== "false" : false;
-    const mobileShown = quickMobile ? quickMobile.value !== "false" : false;
-    let quickAddLabel = "Hide";
-    if (deskShown && mobileShown) quickAddLabel = "Show";
-    else if (deskShown) quickAddLabel = "Desktop";
-    else if (mobileShown) quickAddLabel = "Mobile";
-    set("hub_ui_quickadd", `Quick Add: ${quickAddLabel}`);
-  }
-
-  const proto = document.getElementById("ui_protocol");
-  if (proto) set("hub_ui_proto", `Proto: ${String(proto.value || "http").toUpperCase()}`);
-
-  const aaEnabled = true;
   const aaRememberEnabled = (document.getElementById("app_auth_remember_enabled")?.value || "").toString() === "true";
-  const st = window._appAuthStatus || null;
-
-  if (st && st.configured && st.authenticated) {
-    set("hub_sec_auth", "Auth: On");
-    if (!aaRememberEnabled) {
-      set("hub_sec_session", "Session: browser");
-    } else {
-      const days = _uiDaysLeftFromEpochSeconds(st.session_expires_at);
-      set("hub_sec_session", days == null ? "Session: active" : `Session: ${days}d`);
-    }
-  } else if (st && st.enabled && !st.configured) {
-    set("hub_sec_auth", "Auth: On");
-    set("hub_sec_session", "Set password");
-  } else {
-    set("hub_sec_auth", "Auth: On");
-    set("hub_sec_session", "Locked");
-  }
-
-  // Trusted reverse proxies indicator
-  try {
-    const raw = (document.getElementById("trusted_proxies")?.value || "").toString().trim();
-    let on = false;
-    if (raw) {
-      on = raw.split(/[;\n,]+/).map(s => s.trim()).filter(Boolean).length > 0;
-    } else {
-      const tp = window._cfgCache?.security?.trusted_proxies;
-      on = Array.isArray(tp) && tp.length > 0;
-    }
-    set("hub_sec_proxy", `Proxy: ${on ? "On" : "Off"}`);
-  } catch {
-    set("hub_sec_proxy", "Proxy: —");
-  }
-
   const cwEnabled = (document.getElementById("cw_enabled")?.value || "").toString() !== "false";
-  set("hub_cw_enabled", `Tracker: ${cwEnabled ? "On" : "Off"}`);
-
-  const retRaw = (document.getElementById("cw_retention_days")?.value || "").toString().trim();
-  const ret = retRaw === "" ? null : parseInt(retRaw, 10);
-  if (ret == null || Number.isNaN(ret)) set("hub_cw_retention", "Retention: —");
-  else if (ret === 0) set("hub_cw_retention", "Retention: ∞");
-  else set("hub_cw_retention", `Retention: ${ret}d`);
 
   const authFields = document.getElementById("app_auth_fields");
   if (authFields) authFields.classList.remove("cw-disabled");
@@ -295,6 +195,7 @@ function cwUiSettingsHubInit() {
     "ui_show_AI",
     "ui_show_quick_add_desktop",
     "ui_show_quick_add_mobile",
+    "ui_theme",
     "ui_protocol",
     "app_auth_username",
     "app_auth_password",
@@ -1170,6 +1071,18 @@ async function loadConfig() {
     _setSelectValue("ui_recent_syncs_display", normalizeDisplay(ui.recent_syncs_display, Number(ui.recent_syncs_limit)));
 
     {
+      const theme = String(ui.theme || "flat-dark").trim().toLowerCase();
+      let storedTheme = "";
+      try {
+        const raw = localStorage.getItem("cw.ui.theme");
+        if (raw === "flat-light" || raw === "flat-dark" || raw === "original") storedTheme = raw;
+      } catch {}
+      const normalizedTheme = storedTheme || ((theme === "flat-light" || theme === "original") ? theme : "flat-dark");
+      _setSelectValue("ui_theme", normalizedTheme);
+      try { window.CWTheme?.apply?.(normalizedTheme, { persist: true }); } catch {}
+    }
+
+    {
       const on = (typeof ui.show_AI === "boolean")
         ? !!ui.show_AI
         : true;
@@ -1267,18 +1180,15 @@ async function loadConfig() {
   };
 
   
-  setRaw("plex_token",    val(cfg.plex?.account_token));
   setRaw("plex_home_pin", val(cfg.plex?.home_pin));
 
   
   setRaw("simkl_client_id",     val(cfg.simkl?.client_id));
   setRaw("simkl_client_secret", val(cfg.simkl?.client_secret));
-  setRaw("simkl_access_token",  val(cfg.simkl?.access_token) || val(cfg.auth?.simkl?.access_token));
 
   
   setRaw("anilist_client_id",     val(cfg.anilist?.client_id));
   setRaw("anilist_client_secret", val(cfg.anilist?.client_secret));
-  setRaw("anilist_access_token",  val(cfg.anilist?.access_token) || val(cfg.auth?.anilist?.access_token));
 
   
   setRaw("tmdb_api_key",        val(cfg.tmdb?.api_key));
@@ -1290,7 +1200,6 @@ async function loadConfig() {
   
   setRaw("trakt_client_id",     val(cfg.trakt?.client_id));
   setRaw("trakt_client_secret", val(cfg.trakt?.client_secret));
-  setRaw("trakt_token",         val(cfg.trakt?.access_token) || val(cfg.auth?.trakt?.access_token));
 })(cfg);
 
   try { cwMetaSettingsHubUpdate(); } catch {}

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -229,8 +229,6 @@ DEFAULT_CFG: dict[str, Any] = {
 
     "simkl": {
         "access_token": "",                             # OAuth2 access token
-        "refresh_token": "",                            # OAuth2 refresh token
-        "token_expires_at": 0,                          # Epoch when access_token expires
         "client_id": "",                                # From your Simkl app
         "client_secret": "",                            # From your Simkl app
         "date_from": "",                                # YYYY-MM-DD (optional start date for full sync)
@@ -617,6 +615,7 @@ DEFAULT_CFG: dict[str, Any] = {
 
     # --- User Interface ------------------------------------------------------
     "ui": {
+        "theme": "flat-dark",                           # "flat-dark" | "flat-light" | "original"
         "show_watchlist_preview": True,                 # Show Watchlist Preview card on Main tab
         "show_playingcard": True,                       # Show Now Playing card on Main tab
         "show_recent_activity": True,                   # Show Recent Activity card on Main tab
@@ -670,7 +669,7 @@ def redact_config(cfg: dict[str, Any]) -> dict[str, Any]:
     # Provider-specific secret fields
     provider_secret_keys: dict[str, set[str]] = {
         "plex": {"account_token", "pms_token", "home_pin", "webhook_secret"},
-        "simkl": {"access_token", "refresh_token", "client_secret"},
+        "simkl": {"access_token", "client_secret"},
         "anilist": {"access_token", "client_secret"},
         "mdblist": {"api_key", "access_token", "refresh_token", "_pending_device"},
         "publicmetadb": {"api_key"},
@@ -1312,6 +1311,11 @@ def _normalize_scheduling(cfg: dict[str, Any]) -> None:
 
 def _normalize_ui(cfg: dict[str, Any]) -> None:
     ui = _ensure_dict(cfg, "ui")
+
+    theme = str(ui.get("theme", "flat-dark") or "flat-dark").strip().lower()
+    if theme not in {"flat-dark", "flat-light", "original"}:
+        theme = "flat-dark"
+    ui["theme"] = theme
 
     ui["show_watchlist_preview"] = bool(ui.get("show_watchlist_preview", True))
     ui["show_playingcard"] = bool(ui.get("show_playingcard", True))

--- a/providers/auth/_auth_ANILIST.py
+++ b/providers/auth/_auth_ANILIST.py
@@ -119,8 +119,8 @@ class AniListAuth(AuthProvider):
         log("ANILIST: start OAuth", extra={"redirect_uri": redirect_uri})
         return {"url": url}
 
-    def finish(self, cfg: MutableMapping[str, Any], **payload: Any) -> AuthStatus:
-        inst = payload.get("instance_id")
+    def finish(self, cfg: MutableMapping[str, Any], *, instance_id: Any = None, **payload: Any) -> AuthStatus:
+        inst = instance_id if instance_id is not None else payload.get("instance_id")
         _, _, s = _blocks(cfg, inst)
         code = str(payload.get("code") or "").strip()
         redirect_uri = str(payload.get("redirect_uri") or "").strip()
@@ -163,17 +163,18 @@ def html() -> str:
     #sec-anilist .btn.danger{background:#a8182e;border-color:rgba(255,107,107,.4)}
     #sec-anilist .btn.danger:hover{filter:brightness(1.08)}
     #sec-anilist #btn-connect-anilist{
-      background: linear-gradient(135deg,#6d5dfc,#a855f7);
-      border-color: rgba(168,85,247,.45);
-      box-shadow: 0 0 12px rgba(168,85,247,.35);
+      background: linear-gradient(135deg,#00e084,#2ea859);
+      border-color: rgba(0,224,132,.45);
+      box-shadow: 0 0 14px rgba(0,224,132,.35);
+      color: #fff;
     }
-    #sec-anilist #btn-connect-anilist:hover{filter:brightness(1.06);box-shadow: 0 0 18px rgba(168,85,247,.5)}
+    #sec-anilist #btn-connect-anilist:hover{filter:brightness(1.06);box-shadow: 0 0 18px rgba(0,224,132,.5)}
   
     #sec-anilist .grid2{display:grid;grid-template-columns:1fr 1fr;gap:12px}
   </style>
 
-  <div class="head" onclick="toggleSection && toggleSection('sec-anilist')">
-    <span class="chev">▶</span><strong>AniList</strong>
+  <div class="head" data-toggle-section="sec-anilist">
+    <span class="chev"></span><strong>AniList</strong>
   </div>
 
   <div class="body">
@@ -195,11 +196,11 @@ def html() -> str:
             <div class="grid2">
                   <div>
                     <label for="anilist_client_id">Client ID</label>
-                    <input id="anilist_client_id" name="anilist_client_id" placeholder="Your AniList client_id" autocomplete="off" oninput="updateAniListButtonState()" />
+                    <input id="anilist_client_id" name="anilist_client_id" placeholder="Your AniList client_id" autocomplete="off" />
                   </div>
                   <div>
                     <label for="anilist_client_secret">Client Secret</label>
-                    <input id="anilist_client_secret" name="anilist_client_secret" placeholder="Your AniList client_secret" type="password" autocomplete="off" oninput="updateAniListButtonState()" />
+                    <input id="anilist_client_secret" name="anilist_client_secret" placeholder="Your AniList client_secret" type="password" autocomplete="off" />
                   </div>
                 </div>
             
@@ -207,19 +208,14 @@ def html() -> str:
                 You need an AniList API key. Create one at
                 <a href="https://anilist.co/settings/developer" target="_blank" rel="noopener">AniList Developer</a>.
                 Set the Redirect URL to <code id="redirect_uri_preview_anilist"></code>.
-                <button class="btn" style="margin-left:8px" onclick="copyAniListRedirect()">Copy Redirect URL</button>
+                <button id="btn-copy-anilist-redirect" class="btn" type="button" style="margin-left:8px">Copy Redirect URL</button>
                 </div>
             
             
                 <div class="inline" style="margin-top:10px">
-                  <button class="btn" id="btn-connect-anilist" onclick="startAniList()">Connect AniList</button>
-                  <button class="btn danger" onclick="anilistDeleteToken()">Disconnect</button>
+                  <button class="btn" id="btn-connect-anilist" type="button">Connect AniList</button>
+                  <button class="btn danger" id="btn-delete-anilist" type="button">Disconnect</button>
                   <span class="msg ok hidden" id="anilist_msg" role="status" aria-live="polite"></span>
-                </div>
-            
-                <div style="margin-top:10px">
-                  <label for="anilist_access_token">Access Token</label>
-                  <input id="anilist_access_token" name="anilist_access_token" placeholder="(auto-filled after auth)" autocomplete="off" />
                 </div>
           </div>
         </div>

--- a/providers/auth/_auth_EMBY.py
+++ b/providers/auth/_auth_EMBY.py
@@ -128,7 +128,7 @@ class EmbyAuth(AuthProvider):
         user = (em.get("user") or em.get("username") or "").strip() or None
         return AuthStatus(connected=bool(server and token), label="Emby", user=user)
 
-    def start(self, cfg: MutableMapping[str, Any], redirect_uri: str, instance_id: Any = None) -> dict[str, Any]:
+    def start(self, cfg: MutableMapping[str, Any], redirect_uri: str | None = None, *, instance_id: Any = None) -> dict[str, Any]:
         import requests
         from requests import exceptions as rx
 
@@ -204,11 +204,11 @@ class EmbyAuth(AuthProvider):
         log("Emby: access token stored", level="SUCCESS", module="AUTH")
         return {"ok": True, "mode": "user_token", "user_id": em.get("user_id") or ""}
 
-    def finish(self, cfg: MutableMapping[str, Any], **payload: Any) -> AuthStatus:
-        return self.get_status(cfg)
+    def finish(self, cfg: MutableMapping[str, Any], *, instance_id: Any = None, **payload: Any) -> AuthStatus:
+        return self.get_status(cfg, instance_id)
 
-    def refresh(self, cfg: MutableMapping[str, Any]) -> AuthStatus:
-        return self.get_status(cfg)
+    def refresh(self, cfg: MutableMapping[str, Any], *, instance_id: Any = None) -> AuthStatus:
+        return self.get_status(cfg, instance_id)
 
     def disconnect(self, cfg: MutableMapping[str, Any], instance_id: Any = None) -> AuthStatus:
         inst = normalize_instance_id(instance_id)
@@ -237,34 +237,6 @@ def html() -> str:
     #sec-emby .btn.danger{ background:#a8182e; border-color:rgba(255,107,107,.4) }
     #sec-emby .btn.danger:hover{ filter:brightness(1.08) }
 
-    /* matrix */
-    #sec-emby .lm-head{
-      --lm-hist-col:76px;--lm-rate-col:76px;--lm-scr-col:104px;
-      display:grid;grid-template-columns:minmax(0,1fr) var(--lm-hist-col) var(--lm-rate-col) var(--lm-scr-col);
-      gap:6px;align-items:center;margin-bottom:8px;padding:0 24px 0 8px;box-sizing:border-box
-    }
-    #sec-emby .lm-head .title{font-weight:700}
-    #sec-emby .lm-head .title,#sec-emby .lm-head .lm-filter{grid-column:1;grid-row:1}
-    #sec-emby .lm-head .lm-filter{justify-self:end;width:min(280px,55%)}
-    #sec-emby .lm-rows{
-      display:grid;gap:6px;max-height:280px;min-height:200px;
-      overflow:auto;border:1px solid var(--border);border-radius:10px;padding:8px;background:#090b10
-    }
-    #sec-emby .lm-row{display:grid;grid-template-columns:minmax(0,1fr) 76px 76px 104px;gap:6px;align-items:center;background:#0b0d12;border-radius:8px;padding:6px 8px}
-    #sec-emby .lm-row.hide{display:none}
-    #sec-emby .lm-name{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-    #sec-emby .lm-dot{width:16px;height:16px;border-radius:50%;border:2px solid currentColor;background:transparent;cursor:pointer;display:inline-block;vertical-align:middle;justify-self:center}
-    #sec-emby .lm-dot.hist{color:#b066ff;box-shadow:0 0 6px rgba(176,102,255,.55)}
-    #sec-emby .lm-dot.hist.on{background:#b066ff;box-shadow:0 0 10px rgba(176,102,255,.95)}
-    #sec-emby .lm-dot.rate{color:#00d1ff;box-shadow:0 0 6px rgba(0,209,255,.55)}
-    #sec-emby .lm-dot.rate.on{background:#00d1ff;box-shadow:0 0 10px rgba(0,209,255,.95)}
-    #sec-emby .lm-dot.scr{color:#35ff8f;box-shadow:0 0 6px rgba(53,255,143,.55)}
-    #sec-emby .lm-dot.scr.on{background:#35ff8f;box-shadow:0 0 10px rgba(53,255,143,.95)}
-    #sec-emby .lm-col{position:relative;display:flex;align-items:center;justify-content:center;gap:6px;min-width:0}
-    #sec-emby .lm-col .sub{position:absolute;left:calc(50% + 14px);white-space:nowrap}
-    #sec-emby .lm-filter{min-width:160px}
-    #sec-emby select.lm-hidden{display:none}
-
     #sec-emby .inline .msg{margin-left:auto}
     #sec-emby .inline .msg.hidden{display:none}
 
@@ -281,8 +253,8 @@ def html() -> str:
     }
   </style>
 
-  <div class="head" onclick="toggleSection && toggleSection('sec-emby')">
-    <span class="chev">▶</span><strong>Emby</strong>
+  <div class="head" data-toggle-section="sec-emby">
+    <span class="chev"></span><strong>Emby</strong>
   </div>
 
   <div class="body">
@@ -304,31 +276,27 @@ def html() -> str:
         <div class="cw-subpanels">
           <div class="cw-subpanel active" data-sub="auth">
             <div class="grid2">
-              <div>
+              <div style="grid-column:1 / -1">
                 <label for="emby_server">Server URL</label>
                 <div class="inp-row">
                   <input id="emby_server" name="emby_server" class="grow" placeholder="http://host:8096/">
                   <label class="verify"><input id="emby_verify_ssl" type="checkbox"> Verify SSL</label>
                 </div>
               </div>
+            </div>
+            <div class="grid2" style="margin-top:8px">
               <div>
                 <label for="emby_user">Username</label>
                 <input id="emby_user" name="emby_user" placeholder="username">
               </div>
-            </div>
-            <div class="grid2" style="margin-top:8px">
               <div>
                 <label for="emby_pass">Password</label>
                 <input id="emby_pass" name="emby_pass" type="password" placeholder="********">
               </div>
-              <div>
-                <label for="emby_tok">Access Token</label>
-                <input id="emby_tok" name="emby_tok" readonly placeholder="empty = not set">
-              </div>
             </div>
             <div class="inline" style="margin-top:10px">
-              <button class="btn emby" onclick="try{ embyLogin && embyLogin(); }catch(_){;}">Sign in</button>
-              <button class="btn danger" onclick="try{ embyDeleteToken && embyDeleteToken(); }catch(_){;}">Delete</button>
+              <button id="btn-emby-login" class="btn emby" type="button">Sign in</button>
+              <button id="btn-emby-delete" class="btn danger" type="button">Delete</button>
               <div id="emby_msg" class="msg ok hidden" role="status" aria-live="polite"></div>
             </div>
           </div>
@@ -338,7 +306,7 @@ def html() -> str:
               <label for="emby_server_url">Server URL</label>
               <div class="inp-row">
                 <input id="emby_server_url" name="emby_server_url" class="grow" placeholder="http://host:8096/">
-                <label class="verify"><input id="emby_verify_ssl_dup" type="checkbox" onclick="(function(){var a=document.getElementById('emby_verify_ssl'); if(a) a.checked = document.getElementById('emby_verify_ssl_dup').checked;})();"> Verify SSL</label>
+                <label class="verify"><input id="emby_verify_ssl_dup" type="checkbox"> Verify SSL</label>
               </div>
               <div class="sub">Leave blank to discover.</div>
 
@@ -350,10 +318,10 @@ def html() -> str:
                 <input id="emby_user_id" name="emby_user_id" class="grow" placeholder="e.g. 6f7a0b3b-... (GUID)">
                 <button id="emby_pick_user" class="btn" type="button" data-cw-emby="pick-user">Pick user</button>
               </div>
-              <div class="sub">Uses your current token. Admin tokens show all users; otherwise you'll only see yourself.</div>
+              <div class="sub">Uses your signed-in account. Admin accounts show all users; otherwise you'll only see yourself.</div>
 
               <div class="inline" style="gap:12px;margin-top:12px">
-                <button class="btn" onclick="(window.embyAuto||function(){})();">Auto-Fetch</button>
+                <button id="btn-emby-auto" class="btn" type="button">Auto-Fetch</button>
                 <span class="sub" style="margin-left:auto">Edit values before Save if needed.</span>
               </div>
             </div>
@@ -362,13 +330,13 @@ def html() -> str:
           <div class="cw-subpanel" data-sub="whitelist">
             <div style="max-width:980px">
               <div class="inline" style="gap:12px;margin-top:0;margin-bottom:12px">
-                <button class="btn" title="Load Emby libraries" onclick="(window.embyLoadLibraries||function(){})();">Load libraries</button>
-                <span class="sub" style="margin-left:auto">Refresh after changing Server URL / token.</span>
+                <button id="btn-emby-load-libraries" class="btn" type="button" title="Load Emby libraries">Load libraries</button>
+                <span class="sub" style="margin-left:auto">Refresh after changing Server URL.</span>
               </div>
 
               <div class="lm-head">
                 <div class="title">Whitelist Libraries</div>
-                <input id="emby_lib_filter" class="lm-filter" placeholder="Filter…">
+                <input id="emby_lib_filter" class="lm-filter" placeholder="Filter...">
                 <div class="lm-col"><span class="sub">Select all:</span></div>
                 <div class="lm-col"><button id="emby_hist_all" type="button" class="lm-dot hist" title="Toggle all History" aria-pressed="false"></button><span class="sub">History</span></div>
                 <div class="lm-col"><button id="emby_rate_all" type="button" class="lm-dot rate" title="Toggle all Ratings" aria-pressed="false"></button><span class="sub">Ratings</span></div>

--- a/providers/auth/_auth_JELLYFIN.py
+++ b/providers/auth/_auth_JELLYFIN.py
@@ -133,7 +133,7 @@ class JellyfinAuth(AuthProvider):
         user = (jf.get("user") or jf.get("username") or "").strip() or None
         return AuthStatus(connected=bool(server and token), label="Jellyfin", user=user)
 
-    def start(self, cfg: MutableMapping[str, Any], redirect_uri: str, instance_id: Any = None) -> dict[str, Any]:
+    def start(self, cfg: MutableMapping[str, Any], redirect_uri: str | None = None, *, instance_id: Any = None) -> dict[str, Any]:
         import requests
         from requests import exceptions as rx
 
@@ -210,11 +210,11 @@ class JellyfinAuth(AuthProvider):
         log("Jellyfin: access token stored", level="SUCCESS", module="AUTH")
         return {"ok": True, "mode": "user_token", "user_id": jf.get("user_id") or ""}
 
-    def finish(self, cfg: MutableMapping[str, Any], **payload: Any) -> AuthStatus:
-        return self.get_status(cfg)
+    def finish(self, cfg: MutableMapping[str, Any], *, instance_id: Any = None, **payload: Any) -> AuthStatus:
+        return self.get_status(cfg, instance_id)
 
-    def refresh(self, cfg: MutableMapping[str, Any]) -> AuthStatus:
-        return self.get_status(cfg)
+    def refresh(self, cfg: MutableMapping[str, Any], *, instance_id: Any = None) -> AuthStatus:
+        return self.get_status(cfg, instance_id)
 
     def disconnect(self, cfg: MutableMapping[str, Any], instance_id: Any = None) -> AuthStatus:
         inst = normalize_instance_id(instance_id)
@@ -244,34 +244,6 @@ def html() -> str:
     #sec-jellyfin .btn.danger{ background:#a8182e; border-color:rgba(255,107,107,.4) }
     #sec-jellyfin .btn.danger:hover{ filter:brightness(1.08) }
 
-    /* matrix */
-    #sec-jellyfin .lm-head{
-      --lm-hist-col:76px;--lm-rate-col:76px;--lm-scr-col:104px;
-      display:grid;grid-template-columns:minmax(0,1fr) var(--lm-hist-col) var(--lm-rate-col) var(--lm-scr-col);
-      gap:6px;align-items:center;margin-bottom:8px;padding:0 24px 0 8px;box-sizing:border-box
-    }
-    #sec-jellyfin .lm-head .title{font-weight:700}
-    #sec-jellyfin .lm-head .title,#sec-jellyfin .lm-head .lm-filter{grid-column:1;grid-row:1}
-    #sec-jellyfin .lm-head .lm-filter{justify-self:end;width:min(280px,55%)}
-    #sec-jellyfin .lm-rows{
-      display:grid;gap:6px;max-height:280px;min-height:200px;
-      overflow:auto;border:1px solid var(--border);border-radius:10px;padding:8px;background:#090b10
-    }
-    #sec-jellyfin .lm-row{display:grid;grid-template-columns:minmax(0,1fr) 76px 76px 104px;gap:6px;align-items:center;background:#0b0d12;border-radius:8px;padding:6px 8px}
-    #sec-jellyfin .lm-row.hide{display:none}
-    #sec-jellyfin .lm-name{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-    #sec-jellyfin .lm-dot{width:16px;height:16px;border-radius:50%;border:2px solid currentColor;background:transparent;cursor:pointer;display:inline-block;vertical-align:middle;justify-self:center}
-    #sec-jellyfin .lm-dot.hist{color:#b066ff;box-shadow:0 0 6px rgba(176,102,255,.55)}
-    #sec-jellyfin .lm-dot.hist.on{background:#b066ff;box-shadow:0 0 10px rgba(176,102,255,.95)}
-    #sec-jellyfin .lm-dot.rate{color:#00d1ff;box-shadow:0 0 6px rgba(0,209,255,.55)}
-    #sec-jellyfin .lm-dot.rate.on{background:#00d1ff;box-shadow:0 0 10px rgba(0,209,255,.95)}
-    #sec-jellyfin .lm-dot.scr{color:#35ff8f;box-shadow:0 0 6px rgba(53,255,143,.55)}
-    #sec-jellyfin .lm-dot.scr.on{background:#35ff8f;box-shadow:0 0 10px rgba(53,255,143,.95)}
-    #sec-jellyfin .lm-col{position:relative;display:flex;align-items:center;justify-content:center;gap:6px;min-width:0}
-    #sec-jellyfin .lm-col .sub{position:absolute;left:calc(50% + 14px);white-space:nowrap}
-    #sec-jellyfin .lm-filter{min-width:160px}
-    #sec-jellyfin select.lm-hidden{display:none}
-
     #sec-jellyfin .inline .msg{margin-left:auto}
     #sec-jellyfin .inline .msg.hidden{display:none}
 
@@ -288,8 +260,8 @@ def html() -> str:
     }
   </style>
 
-  <div class="head" onclick="toggleSection && toggleSection('sec-jellyfin')">
-    <span class="chev">▶</span><strong>Jellyfin</strong>
+  <div class="head" data-toggle-section="sec-jellyfin">
+    <span class="chev"></span><strong>Jellyfin</strong>
   </div>
 
   <div class="body">
@@ -311,31 +283,27 @@ def html() -> str:
         <div class="cw-subpanels">
           <div class="cw-subpanel active" data-sub="auth">
             <div class="grid2">
-              <div>
+              <div style="grid-column:1 / -1">
                 <label for="jfy_server">Server URL</label>
                 <div class="inp-row">
                   <input id="jfy_server" name="jfy_server" class="grow" placeholder="http://host:8096/">
                   <label class="verify"><input id="jfy_verify_ssl" type="checkbox"> Verify SSL</label>
                 </div>
               </div>
+            </div>
+            <div class="grid2" style="margin-top:8px">
               <div>
                 <label for="jfy_user">Username</label>
                 <input id="jfy_user" name="jfy_user" placeholder="username">
               </div>
-            </div>
-            <div class="grid2" style="margin-top:8px">
               <div>
                 <label for="jfy_pass">Password</label>
                 <input id="jfy_pass" name="jfy_pass" type="password" placeholder="********">
               </div>
-              <div>
-                <label for="jfy_tok">Access Token</label>
-                <input id="jfy_tok" name="jfy_tok" readonly placeholder="empty = not set">
-              </div>
             </div>
             <div class="inline" style="margin-top:10px">
-              <button class="btn jellyfin" onclick="try{ jfyLogin && jfyLogin(); }catch(_){;}">Sign in</button>
-              <button class="btn danger" onclick="try{ jfyDeleteToken && jfyDeleteToken(); }catch(_){;}">Delete</button>
+              <button id="btn-jfy-login" class="btn jellyfin" type="button">Sign in</button>
+              <button id="btn-jfy-delete" class="btn danger" type="button">Delete</button>
               <div id="jfy_msg" class="msg ok hidden" role="status" aria-live="polite"></div>
             </div>
           </div>
@@ -345,7 +313,7 @@ def html() -> str:
               <label for="jfy_server_url">Server URL</label>
               <div class="inp-row">
                 <input id="jfy_server_url" name="jfy_server_url" class="grow" placeholder="http://host:8096/">
-                <label class="verify"><input id="jfy_verify_ssl_dup" type="checkbox" onclick="(function(){var a=document.getElementById('jfy_verify_ssl'); if(a) a.checked = document.getElementById('jfy_verify_ssl_dup').checked;})();"> Verify SSL</label>
+                <label class="verify"><input id="jfy_verify_ssl_dup" type="checkbox"> Verify SSL</label>
               </div>
               <div class="sub">Leave blank to discover.</div>
 
@@ -357,10 +325,10 @@ def html() -> str:
                 <input id="jfy_user_id" name="jfy_user_id" class="grow" placeholder="e.g. 6f7a0b3b-... (GUID)">
                 <button id="jfy_pick_user" class="btn" type="button">Pick user</button>
               </div>
-              <div class="sub">Uses your current token. Admin tokens show all users; otherwise you'll only see yourself.</div>
+              <div class="sub">Uses your signed-in account. Admin accounts show all users; otherwise you'll only see yourself.</div>
 
               <div class="inline" style="gap:12px;margin-top:12px">
-                <button class="btn" onclick="(window.jfyAuto||function(){})();">Auto-Fetch</button>
+                <button id="btn-jfy-auto" class="btn" type="button">Auto-Fetch</button>
                 <span class="sub" style="margin-left:auto">Edit values before Save if needed.</span>
               </div>
             </div>
@@ -369,13 +337,13 @@ def html() -> str:
           <div class="cw-subpanel" data-sub="whitelist">
             <div style="max-width:980px">
               <div class="inline" style="gap:12px;margin-top:0;margin-bottom:12px">
-                <button class="btn" title="Load Jellyfin libraries" onclick="(window.jfyLoadLibraries||function(){})();">Load libraries</button>
-                <span class="sub" style="margin-left:auto">Refresh after changing Server URL / token.</span>
+                <button id="btn-jfy-load-libraries" class="btn" type="button" title="Load Jellyfin libraries">Load libraries</button>
+                <span class="sub" style="margin-left:auto">Refresh after changing Server URL.</span>
               </div>
 
               <div class="lm-head">
                 <div class="title">Whitelist Libraries</div>
-                <input id="jfy_lib_filter" name="jfy_lib_filter" class="lm-filter" placeholder="Filter…">
+                <input id="jfy_lib_filter" name="jfy_lib_filter" class="lm-filter" placeholder="Filter...">
                 <div class="lm-col"><span class="sub">Select all:</span></div>
                 <div class="lm-col"><button id="jfy_hist_all" type="button" class="lm-dot hist" title="Toggle all History" aria-pressed="false"></button><span class="sub">History</span></div>
                 <div class="lm-col"><button id="jfy_rate_all" type="button" class="lm-dot rate" title="Toggle all Ratings" aria-pressed="false"></button><span class="sub">Ratings</span></div>

--- a/providers/auth/_auth_MDBLIST.py
+++ b/providers/auth/_auth_MDBLIST.py
@@ -170,7 +170,7 @@ def html() -> str:
     }
   </style>
 
-  <div class="head" onclick="toggleSection && toggleSection('sec-mdblist')">
+  <div class="head" data-toggle-section="sec-mdblist">
     <span class="chev">&#9654;</span><strong>MDBList</strong>
   </div>
 
@@ -202,20 +202,11 @@ def html() -> str:
 
             <div id="mdblist_device_panel" style="margin-top:10px">
               <div class="sep"></div>
-              <div class="grid2">
-                <div>
-                  <div class="field-label">Current token</div>
-                  <div class="mdblist-action-row">
-                    <input id="mdblist_access_token" readonly placeholder="empty = not set" />
-                    <button id="mdblist_copy_token" class="btn copy">Copy</button>
-                  </div>
-                </div>
-                <div>
-                  <div class="field-label">Link code (PIN)</div>
-                  <div class="mdblist-action-row">
-                    <input id="mdblist_device_code" readonly placeholder="" />
-                    <button id="mdblist_copy_code" class="btn copy">Copy</button>
-                  </div>
+              <div>
+                <div class="field-label">Link code (PIN)</div>
+                <div class="mdblist-action-row">
+                  <input id="mdblist_device_code" readonly placeholder="" />
+                  <button id="mdblist_copy_code" class="btn copy">Copy</button>
                 </div>
               </div>
               <div class="inline" style="margin-top:10px">

--- a/providers/auth/_auth_PLEX.py
+++ b/providers/auth/_auth_PLEX.py
@@ -63,9 +63,17 @@ class PlexAuth(AuthProvider):
             "entity_types": ["movie", "show"],
         }
 
-    def get_status(self, cfg: Mapping[str, Any]) -> AuthStatus:
-        token = str(((cfg.get("plex") or {}) if isinstance(cfg, Mapping) else {}).get("account_token") or "").strip()
-        return AuthStatus(connected=bool(token), label="Plex")
+    def get_status(self, cfg: Mapping[str, Any], *, instance_id: Any = None) -> AuthStatus:
+        inst = normalize_instance_id(instance_id)
+        base = (cfg.get("plex") or {}) if isinstance(cfg, Mapping) else {}
+        block: Mapping[str, Any] = base if isinstance(base, Mapping) else {}
+        if inst != "default":
+            insts = block.get("instances")
+            inst_block = insts.get(inst) if isinstance(insts, Mapping) else None
+            block = inst_block if isinstance(inst_block, Mapping) else {}
+        token = str(block.get("account_token") or "").strip()
+        label = "Plex" if inst == "default" else f"Plex ({inst})"
+        return AuthStatus(connected=bool(token), label=label)
 
     def start(self, cfg: MutableMapping[str, Any], redirect_uri: str, instance_id: Any = None) -> dict[str, Any]:
         inst = normalize_instance_id(instance_id)
@@ -133,8 +141,8 @@ class PlexAuth(AuthProvider):
             log(f"Plex[{inst}]: token stored", level="SUCCESS", module="AUTH")
         return AuthStatus(connected=bool(str(plex.get("account_token") or "").strip()), label="Plex")
 
-    def refresh(self, cfg: MutableMapping[str, Any]) -> AuthStatus:
-        return self.get_status(cfg)
+    def refresh(self, cfg: MutableMapping[str, Any], *, instance_id: Any = None) -> AuthStatus:
+        return self.get_status(cfg, instance_id=instance_id)
 
     def disconnect(self, cfg: MutableMapping[str, Any], instance_id: Any = None) -> AuthStatus:
         inst = normalize_instance_id(instance_id)
@@ -214,7 +222,7 @@ def html() -> str:
     #sec-plex details.settings summary .title{font-weight:700;letter-spacing:.2px;position:relative;top:3.5px}
     #sec-plex details.settings summary .hint{opacity:.7;font-size:.92em;margin-left:auto;text-align:right;padding-right:26px}
     #sec-plex details.settings summary::after{
-      content:'▸';color:#b066ff;text-shadow:0 0 8px rgba(176,102,255,.65);
+      content:'>';color:#b066ff;text-shadow:0 0 8px rgba(176,102,255,.65);
       position:absolute;right:10px;top:50%;transform:translateY(-50%);transition:transform .18s ease,color .18s ease,text-shadow .18s ease
     }
     #sec-plex details.settings[open] > summary::after{transform:translateY(-50%) rotate(90deg);color:#00d1ff;text-shadow:0 0 10px rgba(0,209,255,.85)}
@@ -223,40 +231,6 @@ def html() -> str:
       box-shadow:inset 0 0 0 1px rgba(255,255,255,.05),0 0 18px rgba(176,102,255,.25),0 0 18px rgba(0,209,255,.25);
       transform:translateY(-1px)
     }
-
-    /* matrix */
-    #sec-plex .lm-head{
-      --lm-hist-col:76px;--lm-rate-col:76px;--lm-scr-col:104px;
-      display:grid;grid-template-columns:minmax(0,1fr) var(--lm-hist-col) var(--lm-rate-col) var(--lm-scr-col);
-      gap:6px;align-items:center;margin-bottom:8px;padding:0 24px 0 8px;box-sizing:border-box
-    }
-    #sec-plex .lm-head .title{font-weight:700}
-    #sec-plex .lm-head .title,#sec-plex .lm-head .lm-filter{grid-column:1;grid-row:1}
-    #sec-plex .lm-head .lm-filter{justify-self:end;width:min(280px,55%)}
-    #sec-plex .lm-rows{display:grid;gap:6px;max-height:260px;overflow:auto;border:1px solid var(--border);border-radius:10px;padding:6px;background:#090b10}
-    #sec-plex .lm-row{display:grid;grid-template-columns:minmax(0,1fr) 76px 76px 104px;gap:6px;align-items:center;background:#0b0d12;border-radius:8px;padding:6px 8px}
-    #sec-plex .lm-row.hide{display:none}
-    #sec-plex .lm-name{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-    #sec-plex .lm-id{opacity:.5;margin-left:6px}
-    #sec-plex .lm-dot{width:16px;height:16px;border-radius:50%;border:2px solid currentColor;background:transparent;cursor:pointer;display:inline-block;vertical-align:middle;justify-self:center}
-    #sec-plex .lm-dot.hist{color:#b066ff;box-shadow:0 0 6px rgba(176,102,255,.55)}
-    #sec-plex .lm-dot.hist.on{background:#b066ff;box-shadow:0 0 10px rgba(176,102,255,.95)}
-    #sec-plex .lm-dot.rate{color:#00d1ff;box-shadow:0 0 6px rgba(0,209,255,.55)}
-    #sec-plex .lm-dot.rate.on{background:#00d1ff;box-shadow:0 0 10px rgba(0,209,255,.95)}
-    #sec-plex .lm-dot.scr{color:#35ff8f;box-shadow:0 0 6px rgba(53,255,143,.55)}
-    #sec-plex .lm-dot.scr.on{background:#35ff8f;box-shadow:0 0 10px rgba(53,255,143,.95)}
-    #sec-plex .lm-col{position:relative;display:flex;align-items:center;justify-content:center;gap:6px;min-width:0}
-    #sec-plex .lm-col .sub{position:absolute;left:calc(50% + 14px);white-space:nowrap}
-    #sec-plex .lm-filter{min-width:160px}
-    #sec-plex select.lm-hidden{display:none}
-
-    /* neon scrollbar (matrix) */
-    #sec-plex .lm-rows{scrollbar-width:thin;scrollbar-color:#b066ff #0b0d12}
-    #sec-plex .lm-rows::-webkit-scrollbar{width:10px}
-    #sec-plex .lm-rows::-webkit-scrollbar-track{background:#0b0d12;border-radius:10px}
-    #sec-plex .lm-rows::-webkit-scrollbar-thumb{border-radius:10px;border:2px solid #0b0d12;background:linear-gradient(180deg,#b066ff 0%,#00d1ff 100%);box-shadow:0 0 8px rgba(176,102,255,.55),0 0 8px rgba(0,209,255,.55)}
-    #sec-plex .lm-rows::-webkit-scrollbar-thumb:hover{filter:brightness(1.08);box-shadow:0 0 10px rgba(176,102,255,.85),0 0 10px rgba(0,209,255,.85)}
-    #sec-plex .lm-rows::-webkit-scrollbar-thumb:active{filter:brightness(1.15)}
 
     /* user picker */
     #sec-plex .userpick{position:relative;display:inline-block}
@@ -333,8 +307,8 @@ def html() -> str:
 
   </style>
 
-  <div class="head" onclick="toggleSection('sec-plex')">
-    <span class="chev">▶</span><strong>Plex</strong>
+  <div class="head" data-toggle-section="sec-plex">
+    <span class="chev"></span><strong>Plex</strong>
   </div>
 
   <div class="body">
@@ -355,26 +329,17 @@ def html() -> str:
 
         <div class="cw-subpanels">
           <div class="cw-subpanel active" data-sub="auth">
-            <div class="grid2">
-              <div>
-                <label for="plex_token">Current token</label>
-                <div class="inline">
-                  <input id="plex_token" name="plex_token" placeholder="empty = not set">
-                  <button class="btn copy" onclick="copyInputValue('plex_token', this)">Copy</button>
-                </div>
-              </div>
-              <div>
-                <label for="plex_pin">Link code (PIN)</label>
-                <div class="inline">
-                  <input id="plex_pin" name="plex_pin" placeholder="" readonly>
-                  <button class="btn copy" onclick="copyInputValue('plex_pin', this)">Copy</button>
-                </div>
+            <div>
+              <label for="plex_pin">Link code (PIN)</label>
+              <div class="inline">
+                <input id="plex_pin" name="plex_pin" placeholder="" readonly>
+                <button id="btn-copy-plex-pin" type="button" class="btn copy">Copy</button>
               </div>
             </div>
 
             <div class="inline pinrow">
-              <button class="btn" onclick="requestPlexPin()">Connect PLEX</button>
-              <button class="btn danger" onclick="try{ plexDeleteToken && plexDeleteToken(); }catch(_){;}">Delete</button>
+              <button id="btn-connect-plex" class="btn" type="button">Connect PLEX</button>
+              <button id="btn-delete-plex" class="btn danger" type="button">Delete</button>
               <div class="hint">Opens plex.tv/link to complete sign-in.</div>
               <div class="plexmsg">
                 <div id="plex_msg" class="msg ok hidden">PIN</div>
@@ -407,7 +372,7 @@ def html() -> str:
                 <button class="btn" id="plex_user_pick_btn" title="Choose from server users">Pick</button>
                 <div id="plex_user_pop" class="userpop hidden">
                   <div class="pophead">
-                    <input id="plex_user_filter" placeholder="Filter users…">
+                    <input id="plex_user_filter" placeholder="Filter users...">
                     <button type="button" class="btn" id="plex_user_close">Close</button>
                   </div>
                   <div id="plex_user_list" class="userlist"></div>
@@ -423,7 +388,7 @@ def html() -> str:
               <div class="sub">Only needed if the selected Plex Home user is PIN-protected.</div>
 
               <div class="plex-btnrow">
-                <button class="btn" title="Fetch Server URL, Username, Account ID" onclick="plexAuto()">Auto-Fetch</button>
+                <button id="btn-plex-auto" class="btn" type="button" title="Fetch Server URL, Username, Account ID">Auto-Fetch</button>
                 <span class="sub" style="align-self:center">Edit values before Save if needed.</span>
               </div>
             </div>
@@ -432,13 +397,13 @@ def html() -> str:
           <div class="cw-subpanel" data-sub="whitelist">
             <div style="max-width:980px">
               <div class="plex-btnrow" style="margin-top:0;margin-bottom:12px">
-                <button class="btn" title="Load Plex libraries" onclick="refreshPlexLibraries()">Load libraries</button>
+                <button id="btn-plex-load-libraries" class="btn" type="button" title="Load Plex libraries">Load libraries</button>
                 <span class="sub" style="align-self:center">Refresh after changing Server URL / token.</span>
               </div>
 
               <div class="lm-head">
                 <div class="title">Whitelist Libraries</div>
-                <input id="plex_lib_filter" class="lm-filter" placeholder="Filter…">
+                <input id="plex_lib_filter" class="lm-filter" placeholder="Filter...">
                 <div class="lm-col"><button id="plex_hist_all" type="button" class="lm-dot hist" title="Toggle all History"></button><span class="sub">History</span></div>
                 <div class="lm-col"><button id="plex_rate_all" type="button" class="lm-dot rate" title="Toggle all Ratings"></button><span class="sub">Ratings</span></div>
                 <div class="lm-col"><button id="plex_scr_all" type="button" class="lm-dot scr" title="Toggle all Scrobble"></button><span class="sub">Scrobble</span></div>
@@ -455,178 +420,4 @@ def html() -> str:
     </div>
   </div>
 
-  <script>
-  (function(){
-    const $ = (id)=>document.getElementById(id);
-    const esc = (s)=>String(s||"").replace(/[&<>"']/g,c=>({ "&":"&amp;","<":"&lt;","&gt;":"&gt;","\"":"&quot;","'":"&#39;" }[c]));
-    let __users = null;
-    let __pickerTries = 0;
-
-    const PLEX_INSTANCE_KEY = "cw.ui.plex.auth.instance.v1";
-
-    function getInst(){
-      let v = (document.getElementById("plex_instance")?.value || "").trim();
-      if (!v) { try { v = localStorage.getItem(PLEX_INSTANCE_KEY) || ""; } catch {} }
-      v = (v || "").trim() || "default";
-      return v.toLowerCase() === "default" ? "default" : v;
-    }
-
-    function getPlexBlk(cfg, opts){
-      cfg = cfg || {};
-      opts = opts || {};
-      const createBase = opts.createBase === true;
-      const base = (cfg.plex && typeof cfg.plex === "object") ? cfg.plex : (createBase ? (cfg.plex = {}) : null);
-      if (!base) return null;
-      const inst = getInst();
-      if (inst === "default") return base;
-      return (base.instances && typeof base.instances === "object" && base.instances[inst] && typeof base.instances[inst] === "object")
-        ? base.instances[inst]
-        : null;
-    }
-
-    (async ()=>{
-      try{
-        const r = await fetch("/api/config",{cache:"no-store"});
-        const cfg = await r.json();
-        const blk = getPlexBlk(cfg);
-        const on = !!(blk?.verify_ssl);
-        const cb = $("plex_verify_ssl"); if (cb) cb.checked = on;
-      }catch{}
-    })();
-
-    document.addEventListener("settings-collect",(ev)=>{
-      try{
-        const cfg = ev?.detail?.cfg || (window.__cfg ||= {});
-        const blk = getPlexBlk(cfg, { createBase: true });
-        if (!blk) return;
-        blk.verify_ssl = !!$("plex_verify_ssl")?.checked;
-      }catch{}
-    }, true);
-
-    async function fetchUsers(){
-      if (Array.isArray(__users) && __users.length) return __users;
-      try{
-        const inst = (document.getElementById("plex_instance")?.value || "default").trim() || "default";
-        const r = await fetch("/api/plex/users?instance="+encodeURIComponent(inst)+"&ts="+Date.now(), { cache:"no-store" });
-        const j = await r.json();
-        __users = Array.isArray(j?.users) ? j.users : [];
-      }catch{ __users = []; }
-      return __users;
-    }
-
-    function renderUsers(){
-      const box = $("plex_user_list"); if (!box) return;
-      const q = ($("plex_user_filter")?.value || "").trim().toLowerCase();
-      const list = (__users||[]).filter(u=>{
-        const hay = [u.title,u.username,u.email,u.type].filter(Boolean).join(" ").toLowerCase();
-        return !q || hay.includes(q);
-      });
-      box.innerHTML = list.length ? list.map(u => `
-        <button type="button" class="userrow" data-uid="${esc(u.id)}" data-username="${esc(u.username||"")}">
-          <div class="row1">
-            <strong>${esc(u.title||u.username||("User #"+u.id))}</strong>
-            <span class="sub">@${esc(u.username||"")}</span>
-            <span class="tag ${u.type==='owner'?'owner':'friend'}">${esc(u.type||"")}</span>
-          </div>
-          ${u.email ? `<div class="sub">${esc(u.email)}</div>` : ""}
-        </button>
-      `).join("") : '<div class="sub">No users found.</div>';
-    }
-
-    function openPicker(){
-      const pop = $("plex_user_pop"); if (!pop) return;
-      pop.classList.remove("hidden");
-      fetchUsers().then(renderUsers);
-      $("plex_user_filter")?.focus();
-    }
-    function closePicker(){ $("plex_user_pop")?.classList.add("hidden"); }
-
-    function attachOnce(){
-      // Prefer the shared JS implementation from assets/auth/auth.plex.js.
-      // It supports instances and uses the richer /api/plex/pickusers endpoint.
-      if (typeof window.mountPlexUserPicker === "function") {
-        try { window.mountPlexUserPicker(); } catch {}
-        return;
-      }
-      // auth_loader might load after this inline script; give it a moment.
-      if (__pickerTries++ < 40) return setTimeout(attachOnce, 100);
-
-      const pick = $("plex_user_pick_btn");
-      if (pick && !pick.__wired){ pick.__wired = true; pick.addEventListener("click", openPicker); }
-      const close = $("plex_user_close");
-      if (close && !close.__wired){ close.__wired = true; close.addEventListener("click", closePicker); }
-      const filter = $("plex_user_filter");
-      if (filter && !filter.__wired){ filter.__wired = true; filter.addEventListener("input", renderUsers); }
-      const list = $("plex_user_list");
-      if (list && !list.__wired){
-        list.__wired = true;
-        list.addEventListener("click", (e)=>{
-          const row = e.target.closest(".userrow"); if (!row) return;
-          const uname = row.dataset.username || "";
-          const uid   = row.dataset.uid || "";
-          const uEl = $("plex_username"); if (uEl) uEl.value = uname;
-          const aEl = $("plex_account_id"); if (aEl) aEl.value = uid;
-          closePicker();
-          try{ document.dispatchEvent(new CustomEvent("settings-collect",{detail:{section:"plex-users"}})); }catch{}
-        });
-      }
-      if (!document.__plexUserAway){
-        document.__plexUserAway = true;
-        document.addEventListener("click",(e)=>{
-          const pop = $("plex_user_pop");
-          if (!pop || pop.classList.contains("hidden")) return;
-          if (pop.contains(e.target) || e.target.id==="plex_user_pick_btn") return;
-          pop.classList.add("hidden");
-        });
-      }
-    }
-
-    attachOnce();
-    document.addEventListener("tab-changed", ()=>attachOnce());
-
-    async function refreshPlexLibraries(){
-      try{
-        const host = document.getElementById("plex_lib_matrix");
-        if (host) host.innerHTML = '<div class="sub">Loading libraries…</div>';
-      }catch{}
-
-      let usedHelpers = false;
-      try{
-        if (typeof window.hydratePlexFromConfigRaw === "function") { await window.hydratePlexFromConfigRaw(); usedHelpers = true; }
-      }catch{}
-      try{
-        if (typeof window.plexLoadLibraries === "function") { await window.plexLoadLibraries(); usedHelpers = true; }
-      }catch{}
-      try{
-        if (typeof window.mountPlexLibraryMatrix === "function") { window.mountPlexLibraryMatrix(); usedHelpers = true; }
-      }catch{}
-
-      if (usedHelpers) return;
-
-      try{
-        const r = await fetch("/api/plex/libraries?ts="+Date.now(), { cache:"no-store" });
-        const j = await r.json();
-        const libs = Array.isArray(j?.libraries) ? j.libraries : [];
-        const fill = (id)=>{
-          const el = document.getElementById(id); if (!el) return;
-          const keep = new Set(Array.from(el.selectedOptions||[]).map(o=>o.value));
-          el.innerHTML = "";
-          libs.forEach(it=>{
-            const o = document.createElement("option");
-            o.value = String(it.key);
-            o.textContent = `${it.title} (${it.type||"lib"}) — #${it.key}`;
-            if (keep.has(o.value)) o.selected = true;
-            el.appendChild(o);
-          });
-        };
-        fill("plex_lib_history"); fill("plex_lib_ratings");
-        const host = document.getElementById("plex_lib_matrix");
-        if (host) host.innerHTML = '<div class="sub">Libraries loaded.</div>';
-      }catch{}
-    }
-
-    window.refreshPlexLibraries = refreshPlexLibraries;
-
-  })();
-  </script>
 </div>'''

--- a/providers/auth/_auth_PUBLICMETADB.py
+++ b/providers/auth/_auth_PUBLICMETADB.py
@@ -45,6 +45,35 @@ def _block(cfg: Mapping[str, Any], instance_id: Any = None) -> dict[str, Any]:
     return get_provider_block(cfg or {}, "publicmetadb", instance_id)
 
 
+def validate_api_key(api_key: str, *, base_url: str = API_BASE, timeout: float = HTTP_TIMEOUT) -> tuple[bool, str]:
+    key = str(api_key or "").strip()
+    if not key:
+        return False, "api_key_required"
+    base = str(base_url or API_BASE).strip().rstrip("/") or API_BASE
+    try:
+        r = requests.get(
+            f"{base}/api/external/lists",
+            params={"page": 1, "perPage": 1},
+            headers={"Accept": "application/json", "Authorization": f"Bearer {key}", "User-Agent": UA},
+            timeout=timeout,
+        )
+    except requests.Timeout:
+        return False, "validation_timeout"
+    except requests.RequestException:
+        return False, "validation_failed"
+    if r.status_code in (401, 403):
+        return False, "invalid_api_key"
+    if r.status_code >= 400:
+        return False, f"validation_http_{int(r.status_code)}"
+    try:
+        data = r.json() or {}
+    except ValueError:
+        return False, "validation_bad_response"
+    if not isinstance(data, dict) or not isinstance(data.get("items"), list):
+        return False, "validation_bad_response"
+    return True, ""
+
+
 def _status_from_key(cfg: Mapping[str, Any], instance_id: Any = None) -> AuthStatus:
     inst = normalize_instance_id(instance_id)
     b = _block(cfg, inst)
@@ -88,6 +117,9 @@ class PublicMetaDBAuth(AuthProvider):
         b = ensure_instance_block(cfgd, "publicmetadb", instance_id)
         key = str(payload.get("api_key") or payload.get("publicmetadb.api_key") or "").strip()
         if key:
+            ok, reason = validate_api_key(key, base_url=str(b.get("base_url") or API_BASE).strip().rstrip("/"))
+            if not ok:
+                raise ValueError(reason)
             b["api_key"] = key
         save_config(cfgd)
         log(f"PublicMetaDB API key saved (instance={normalize_instance_id(instance_id)}).", module="AUTH")
@@ -124,8 +156,8 @@ def html() -> str:
     }
   </style>
 
-  <div class="head" onclick="toggleSection && toggleSection('sec-publicmetadb')">
-    <span class="chev">▶</span><strong>PublicMetaDB</strong>
+  <div class="head" data-toggle-section="sec-publicmetadb">
+    <span class="chev"></span><strong>PublicMetaDB</strong>
   </div>
 
   <div class="body">
@@ -160,7 +192,6 @@ def html() -> str:
               <div>
                 <div class="field-label">Status</div>
                 <div class="inline">
-                  <button id="publicmetadb_verify" class="btn">Verify</button>
                   <button id="publicmetadb_disconnect" class="btn danger">Disconnect</button>
                   <div id="publicmetadb_msg" class="msg ok hidden" aria-live="polite"></div>
                 </div>

--- a/providers/auth/_auth_SIMKL.py
+++ b/providers/auth/_auth_SIMKL.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
-import time
 from collections.abc import Mapping, MutableMapping
 from typing import Any
 from urllib.parse import urlencode
@@ -55,7 +54,7 @@ class SimklAuth(AuthProvider):
                     "required": True,
                 },
             ],
-            actions={"start": True, "finish": False, "refresh": True, "disconnect": True},
+            actions={"start": True, "finish": False, "refresh": False, "disconnect": True},
             notes="Authorize with SIMKL; you'll be redirected back to the app.",
         )
 
@@ -87,16 +86,10 @@ class SimklAuth(AuthProvider):
                     blk = sub
 
         ok = bool((blk.get("access_token") or "").strip())
-        try:
-            exp = int(blk.get("token_expires_at") or 0) or None
-        except Exception:
-            exp = None
-
         return AuthStatus(
             connected=ok,
             label="SIMKL",
             user=blk.get("account") or None,
-            expires_at=exp,
             scopes=blk.get("scopes") or None,
         )
 
@@ -104,7 +97,7 @@ class SimklAuth(AuthProvider):
         inst = normalize_instance_id(instance_id)
         if isinstance(cfg, dict):
             base = ensure_provider_block(cfg, "simkl")
-            view_like = inst != "default" and "instances" not in base and any(k in base for k in ("access_token", "refresh_token", "token_expires_at"))
+            view_like = inst != "default" and "instances" not in base and bool(str(base.get("access_token") or "").strip())
             if view_like:
                 blk = base
             else:
@@ -129,20 +122,6 @@ class SimklAuth(AuthProvider):
     def _apply_token_response(self, target: MutableMapping[str, Any], j: dict[str, Any]) -> None:
         if j.get("access_token"):
             target["access_token"] = j["access_token"]
-        if "refresh_token" in j and j.get("refresh_token") is not None:
-            target["refresh_token"] = j["refresh_token"]
-
-        exp_in = j.get("expires_in")
-        if isinstance(exp_in, (int, float)) and exp_in > 0:
-            target["token_expires_at"] = int(time.time()) + int(exp_in)
-        else:
-            for k in ("token_expires_at", "expires_at"):
-                if k in j:
-                    try:
-                        target["token_expires_at"] = int(j[k])
-                        break
-                    except Exception:
-                        pass
 
         if j.get("scope"):
             target["scopes"] = j["scope"]
@@ -153,7 +132,7 @@ class SimklAuth(AuthProvider):
             "response_type": "code",
             "client_id": client_id,
             "redirect_uri": redirect_uri,
-            "scope": "public write offline_access",
+            "scope": "public write",
         }
         url = f"{SIMKL_AUTH}?{urlencode(params)}"
         inst = normalize_instance_id(instance_id)
@@ -194,44 +173,14 @@ class SimklAuth(AuthProvider):
 
     def refresh(self, cfg: MutableMapping[str, Any], instance_id: str | None = None) -> AuthStatus:
         inst = normalize_instance_id(instance_id)
-        client_id, client_secret, target = self._resolve_creds(cfg, inst)
-
-        if not (target.get("refresh_token") or "").strip():
-            log("SIMKL: no refresh token", level="WARNING", module="AUTH", extra={"instance": inst})
-            return self.get_status(cfg, inst)
-
-        data = {
-            "grant_type": "refresh_token",
-            "client_id": client_id,
-            "client_secret": client_secret,
-            "refresh_token": target.get("refresh_token", ""),
-        }
-        headers = {
-            "User-Agent": UA,
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-            "simkl-api-key": client_id,
-        }
-        log("SIMKL: refresh token", level="INFO", module="AUTH", extra={"instance": inst})
-        r = requests.post(SIMKL_TOKEN, json=data, headers=headers, timeout=12)
-        r.raise_for_status()
-        j = r.json() or {}
-
-        self._apply_token_response(target, j)
-        try:
-            if isinstance(cfg, dict):
-                save_config(dict(cfg))
-        except Exception:
-            pass
-
-        log("SIMKL: refresh ok", level="SUCCESS", module="AUTH", extra={"instance": inst})
+        log("SIMKL: refresh skipped; access tokens are long-lived", level="INFO", module="AUTH", extra={"instance": inst})
         return self.get_status(cfg, inst)
 
     def disconnect(self, cfg: MutableMapping[str, Any], instance_id: str | None = None) -> AuthStatus:
         inst = normalize_instance_id(instance_id)
         if isinstance(cfg, dict):
             base = ensure_provider_block(cfg, "simkl")
-            view_like = inst != "default" and "instances" not in base and any(k in base for k in ("access_token", "refresh_token", "token_expires_at"))
+            view_like = inst != "default" and "instances" not in base and bool(str(base.get("access_token") or "").strip())
             target = base if view_like else ensure_instance_block(cfg, "simkl", inst)
         else:
             target = cfg.setdefault("simkl", {})  # type: ignore[assignment]
@@ -281,8 +230,8 @@ def html() -> str:
     #sec-simkl .grid2{display:grid;grid-template-columns:1fr 1fr;gap:12px}
   </style>
 
-  <div class="head" onclick="toggleSection && toggleSection('sec-simkl')">
-    <span class="chev">▶</span><strong>SIMKL</strong>
+  <div class="head" data-toggle-section="sec-simkl">
+    <span class="chev"></span><strong>SIMKL</strong>
   </div>
 
   <div class="body">
@@ -304,11 +253,11 @@ def html() -> str:
             <div class="grid2">
                   <div>
                     <label for="simkl_client_id">Client ID</label>
-                    <input id="simkl_client_id" name="simkl_client_id" placeholder="Your SIMKL client id" oninput="updateSimklButtonState()">
+                    <input id="simkl_client_id" name="simkl_client_id" placeholder="Your SIMKL client id">
                   </div>
                   <div>
                     <label for="simkl_client_secret">Client Secret</label>
-                    <input id="simkl_client_secret" name="simkl_client_secret" placeholder="Your SIMKL client secret" oninput="updateSimklButtonState()" type="password">
+                    <input id="simkl_client_secret" name="simkl_client_secret" placeholder="Your SIMKL client secret" type="password">
                   </div>
                 </div>
             
@@ -316,22 +265,15 @@ def html() -> str:
                   You need a SIMKL API key. Create one at
                   <a href="https://simkl.com/settings/developer/" target="_blank" rel="noopener">SIMKL Developer</a>.
                   Set the Redirect URL to <code id="redirect_uri_preview"></code>.
-                  <button class="btn" style="margin-left:8px" onclick="copyRedirect()">Copy Redirect URL</button>
+                  <button id="btn-copy-simkl-redirect" class="btn" type="button" style="margin-left:8px">Copy Redirect URL</button>
                 </div>
             
                 <div class="inline" style="margin-top:8px">
-                  <button id="btn-connect-simkl" class="btn" onclick="startSimkl()">Connect SIMKL</button>
-                  <button class="btn danger" onclick="try{ simklDeleteToken && simklDeleteToken(); }catch(_){;}">Delete</button>
+                  <button id="btn-connect-simkl" class="btn" type="button">Connect SIMKL</button>
+                  <button id="btn-delete-simkl" class="btn danger" type="button">Delete</button>
                   <span id="simkl-countdown" style="min-width:60px;"></span>
                   <div id="simkl-status" class="text-sm" style="color:var(--muted)">Opens SIMKL authorize; callback returns here</div>
-                  <div id="simkl_msg" class="msg ok hidden">Successfully retrieved token</div>
-                </div>
-            
-                <div class="grid2" style="margin-top:8px">
-                  <div>
-                    <label for="simkl_access_token">Access token</label>
-                    <input id="simkl_access_token" name="simkl_access_token" readonly placeholder="empty = not set">
-                  </div>
+                  <div id="simkl_msg" class="msg ok hidden">Connected</div>
                 </div>
             
                 <div class="sep"></div>

--- a/providers/auth/_auth_TAUTULLI.py
+++ b/providers/auth/_auth_TAUTULLI.py
@@ -6,11 +6,14 @@ from __future__ import annotations
 from collections.abc import Mapping, MutableMapping
 from typing import Any
 
+import requests
+
 from ._auth_base import AuthManifest, AuthProvider, AuthStatus
 from cw_platform.config_base import load_config, save_config
 from cw_platform.provider_instances import get_provider_block, ensure_instance_block, normalize_instance_id
 
 __VERSION__ = "2.0.0"
+UA = "CrossWatch/1.0"
 
 
 
@@ -23,6 +26,44 @@ def _load_config() -> dict[str, Any]:
 
 def _block(cfg: Mapping[str, Any], instance_id: Any = None) -> dict[str, Any]:
     return get_provider_block(cfg or {}, "tautulli", instance_id)
+
+
+def validate_credentials(server_url: str, api_key: str, *, timeout: float = 12.0, verify_ssl: bool = True) -> tuple[bool, str]:
+    server = str(server_url or "").strip().rstrip("/")
+    key = str(api_key or "").strip()
+    if not server:
+        return False, "server_url_required"
+    if not key:
+        return False, "api_key_required"
+    if not server.startswith(("http://", "https://")):
+        server = "http://" + server
+    try:
+        r = requests.get(
+            f"{server}/api/v2",
+            params={"apikey": key, "cmd": "get_server_info"},
+            headers={"Accept": "application/json", "User-Agent": UA},
+            timeout=timeout,
+            verify=bool(verify_ssl),
+        )
+    except requests.Timeout:
+        return False, "validation_timeout"
+    except requests.RequestException:
+        return False, "validation_failed"
+    if r.status_code in (401, 403):
+        return False, "invalid_api_key"
+    if r.status_code >= 400:
+        return False, f"validation_http_{int(r.status_code)}"
+    try:
+        data = r.json() or {}
+    except ValueError:
+        return False, "validation_bad_response"
+    resp = data.get("response") if isinstance(data, dict) else None
+    if isinstance(resp, dict) and str(resp.get("result") or "").lower() == "success":
+        return True, ""
+    msg = str((resp or {}).get("message") or "").strip().lower() if isinstance(resp, dict) else ""
+    if "apikey" in msg or "api key" in msg:
+        return False, "invalid_api_key"
+    return False, "validation_bad_response"
 
 
 
@@ -47,7 +88,7 @@ class TautulliAuth(AuthProvider):
                     "label": "API Key",
                     "type": "password",
                     "required": True,
-                    "placeholder": "••••••••",
+                    "placeholder": "********",
                 },
                 {
                     "key": "tautulli.verify_ssl",
@@ -85,8 +126,17 @@ class TautulliAuth(AuthProvider):
         cfgd = dict(cfg or _load_config() or {})
         inst = normalize_instance_id(instance_id)
         t = ensure_instance_block(cfgd, "tautulli", inst)
-        t["server_url"] = str(payload.get("server_url") or payload.get("tautulli.server_url") or "").strip()
-        t["api_key"] = str(payload.get("api_key") or payload.get("tautulli.api_key") or "").strip()
+        server_url = str(payload.get("server_url") or payload.get("tautulli.server_url") or "").strip()
+        api_key = str(payload.get("api_key") or payload.get("tautulli.api_key") or "").strip()
+        ok, reason = validate_credentials(
+            server_url,
+            api_key,
+            verify_ssl=bool(payload.get("verify_ssl", payload.get("tautulli.verify_ssl", True))),
+        )
+        if not ok:
+            raise ValueError(reason)
+        t["server_url"] = server_url
+        t["api_key"] = api_key
         if "verify_ssl" in payload or "tautulli.verify_ssl" in payload:
             t["verify_ssl"] = bool(payload.get("verify_ssl", payload.get("tautulli.verify_ssl", True)))
 
@@ -118,18 +168,34 @@ def html() -> str:
     #sec-tautulli .msg{margin-left:auto;padding:8px 12px;border-radius:12px;border:1px solid rgba(0,255,170,.18);background:rgba(0,255,170,.08);color:#b9ffd7;font-weight:600}
     #sec-tautulli .msg.warn{border-color:rgba(255,210,0,.18);background:rgba(255,210,0,.08);color:#ffe9a6}
     #sec-tautulli .msg.hidden{display:none}
+    #sec-tautulli #tautulli_hint{margin-left:0}
+    #sec-tautulli #tautulli_user_id{max-width:240px;width:240px}
     #sec-tautulli .btn.danger{ background:#a8182e; border-color:rgba(255,107,107,.4) }
     #sec-tautulli #tautulli_save{
-      background: linear-gradient(135deg,#ff8a00,#ff5a1f);
-      border-color: rgba(255,138,0,.55);
-      box-shadow: 0 0 14px rgba(255,138,0,.35);
+      background: linear-gradient(135deg,#00e084,#2ea859);
+      border-color: rgba(0,224,132,.45);
+      box-shadow: 0 0 14px rgba(0,224,132,.35);
       color: #fff;
     }
-    #sec-tautulli #tautulli_save:hover{filter:brightness(1.06);box-shadow:0 0 18px rgba(255,138,0,.5)}
+    #sec-tautulli #tautulli_save:hover{filter:brightness(1.06);box-shadow:0 0 18px rgba(0,224,132,.5)}
+    #sec-tautulli .cw-help{
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:18px;
+      height:18px;
+      margin-left:6px;
+      border-radius:999px;
+      border:1px solid rgba(255,255,255,.22);
+      color:rgba(255,255,255,.78);
+      font-size:12px;
+      line-height:1;
+      cursor:help;
+    }
   </style>
 
-  <div class="head" onclick="toggleSection && toggleSection('sec-tautulli')">
-    <span class="chev">▶</span><strong>Tautulli</strong>
+  <div class="head" data-toggle-section="sec-tautulli">
+    <span class="chev"></span><strong>Tautulli</strong>
   </div>
 
   <div class="body">
@@ -149,31 +215,30 @@ def html() -> str:
         <div class="cw-subpanels">
           <div class="cw-subpanel active" data-sub="auth">
             <div class="grid2">
-                  <div>
-                    <label for="tautulli_server">Server URL</label>
-                    <input id="tautulli_server" name="tautulli_server" type="text" placeholder="http://localhost:8181" />
-                    <label for="tautulli_key" style="margin-top:10px">API Key</label>
-                    <div style="display:flex;gap:8px">
-                      <input id="tautulli_key" name="tautulli_key" type="password" placeholder="••••••••" />
-                      <button id="tautulli_save" class="btn">Connect</button>
-                    </div>
-                    <label for="tautulli_user_id" style="margin-top:10px">User ID (optional)</label>
-                    <input id="tautulli_user_id" name="tautulli_user_id" type="text" placeholder="1" />
-            
-                    <div id="tautulli_hint" class="msg warn" style="margin-top:8px">
-                      API key: Tautulli → Settings → Web Interface → API.
-                    </div>
-                  </div>
-            
-                  <div>
-                    <div class="field-label">Status</div>
-                    <div class="inline">
-                      <button id="tautulli_verify" class="btn">Verify</button>
-                      <button id="tautulli_disconnect" class="btn danger">Disconnect</button>
-                      <div id="tautulli_msg" class="msg ok hidden" aria-live="polite"></div>
-                    </div>
-                  </div>
-                </div>
+              <div>
+                <label for="tautulli_server">Server URL</label>
+                <input id="tautulli_server" name="tautulli_server" type="text" placeholder="http://localhost:8181" />
+              </div>
+              <div>
+                <label for="tautulli_key">API Key</label>
+                <input id="tautulli_key" name="tautulli_key" type="password" placeholder="********" />
+              </div>
+            </div>
+
+            <div style="margin-top:10px;max-width:240px">
+              <label for="tautulli_user_id">User ID (optional)<span class="cw-help" title="If this is empty, CrossWatch imports history for all Tautulli users. Normally you only want one user ID.">?</span></label>
+              <input id="tautulli_user_id" name="tautulli_user_id" type="text" placeholder="1" />
+            </div>
+
+            <div id="tautulli_hint" class="msg warn" style="margin-top:10px">
+              API key: Tautulli > Settings > Web Interface > API.
+            </div>
+
+            <div id="tautulli_actions_row" class="inline" style="margin-top:12px">
+              <button id="tautulli_save" class="btn">Connect</button>
+              <button id="tautulli_disconnect" class="btn danger">Disconnect</button>
+              <div id="tautulli_msg" class="msg ok hidden" aria-live="polite"></div>
+            </div>
           </div>
         </div>
       </div>

--- a/providers/auth/_auth_TMDB.py
+++ b/providers/auth/_auth_TMDB.py
@@ -43,7 +43,7 @@ class TMDbAuth(AuthProvider):
                     "label": "API Key (v3)",
                     "type": "password",
                     "required": True,
-                    "placeholder": "••••••••",
+                    "placeholder": "********",
                 },
                 {
                     "key": "tmdb_sync.session_id",
@@ -60,7 +60,7 @@ class TMDbAuth(AuthProvider):
     def capabilities(self) -> dict[str, Any]:
         return {"watchlist": True, "ratings": True}
 
-    def get_status(self, cfg: Mapping[str, Any], instance_id: str | None = None) -> AuthStatus:
+    def get_status(self, cfg: Mapping[str, Any], *, instance_id: str | None = None) -> AuthStatus:
         inst = normalize_instance_id(instance_id)
         tm: Mapping[str, Any] = {}
         base = cfg.get("tmdb_sync") if isinstance(cfg, Mapping) else None
@@ -76,10 +76,10 @@ class TMDbAuth(AuthProvider):
         has_sess = bool(str(tm.get("session_id") or "").strip())
         return AuthStatus(connected=bool(has_key and has_sess), label="TMDb", user=None)
 
-    def start(self, cfg: MutableMapping[str, Any], redirect_uri: str) -> dict[str, Any]:
+    def start(self, cfg: MutableMapping[str, Any], redirect_uri: str | None = None, *, instance_id: str | None = None) -> dict[str, Any]:
         return {}
 
-    def finish(self, cfg: MutableMapping[str, Any], instance_id: str | None = None, **payload: Any) -> AuthStatus:
+    def finish(self, cfg: MutableMapping[str, Any], *, instance_id: str | None = None, **payload: Any) -> AuthStatus:
         key = (payload.get("api_key") or payload.get("tmdb_sync.api_key") or "").strip()
         sess = (payload.get("session_id") or payload.get("tmdb_sync.session_id") or "").strip()
 
@@ -97,12 +97,12 @@ class TMDbAuth(AuthProvider):
                 tm["session_id"] = sess
 
         log(f"TMDb sync credentials saved ({inst}).", module="AUTH")
-        return self.get_status(cfg, inst)
+        return self.get_status(cfg, instance_id=inst)
 
-    def refresh(self, cfg: MutableMapping[str, Any], instance_id: str | None = None) -> AuthStatus:
-        return self.get_status(cfg, instance_id)
+    def refresh(self, cfg: MutableMapping[str, Any], *, instance_id: str | None = None) -> AuthStatus:
+        return self.get_status(cfg, instance_id=instance_id)
 
-    def disconnect(self, cfg: MutableMapping[str, Any], instance_id: str | None = None) -> AuthStatus:
+    def disconnect(self, cfg: MutableMapping[str, Any], *, instance_id: str | None = None) -> AuthStatus:
         inst = normalize_instance_id(instance_id)
         if isinstance(cfg, dict):
             ensure_provider_block(cfg, "tmdb_sync")
@@ -121,7 +121,7 @@ class TMDbAuth(AuthProvider):
                 tm.pop("username", None)
 
         log(f"TMDb disconnected ({inst}).", module="AUTH")
-        return self.get_status(cfg, inst)
+        return self.get_status(cfg, instance_id=inst)
 
     def html(self) -> str:
         return _tmdb_sync_html()
@@ -153,8 +153,8 @@ def _tmdb_sync_html() -> str:
     }
   </style>
 
-  <div class="head" onclick="toggleSection && toggleSection('sec-tmdb-sync')">
-    <span class="chev">▶</span><strong>TMDb (Sync)</strong>
+  <div class="head" data-toggle-section="sec-tmdb-sync">
+    <span class="chev"></span><strong>TMDb (Sync)</strong>
   </div>
 
   <div class="body">
@@ -178,10 +178,7 @@ def _tmdb_sync_html() -> str:
                 <div class="grid2">
                   <div>
                     <label for="tmdb_sync_api_key">API Key (v3)</label>
-                    <div style="display:flex;gap:8px">
-                      <input id="tmdb_sync_api_key" name="tmdb_sync_api_key" type="password" autocomplete="off" placeholder="••••••••" />
-                      <button id="tmdb_sync_connect" class="btn">Connect</button>
-                    </div>
+                    <input id="tmdb_sync_api_key" name="tmdb_sync_api_key" type="password" autocomplete="off" placeholder="********" />
                     <div id="tmdb_sync_hint" class="msg warn" style="margin-top:8px">
                       You need an TMDb API key. Create one at
                       <a href="https://www.themoviedb.org/settings/api" target="_blank" rel="noopener">TMDb Preferences</a>
@@ -199,7 +196,7 @@ def _tmdb_sync_html() -> str:
                 <div style="margin-top:10px">
                   <div class="field-label">Status</div>
                   <div class="inline">
-                    <button id="tmdb_sync_verify" class="btn">Verify</button>
+                    <button id="tmdb_sync_connect" class="btn">Connect</button>
                     <button id="tmdb_sync_disconnect" class="btn danger">Disconnect</button>
                     <div id="tmdb_sync_msg" class="msg ok hidden" aria-live="polite" style="margin-left:auto"></div>
                   </div>

--- a/providers/auth/_auth_TRAKT.py
+++ b/providers/auth/_auth_TRAKT.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import requests
 
+from ._auth_base import AuthManifest, AuthStatus
 from cw_platform.config_base import load_config, save_config
 from cw_platform.provider_instances import ensure_instance_block, ensure_provider_block, normalize_instance_id
 
@@ -111,19 +112,41 @@ class _TraktProvider:
     name = "TRAKT"
     label = "Trakt"
 
-    def manifest(self) -> dict[str, Any]:
-        return {
-            "name": self.name,
-            "label": self.label,
-            "flow": "device_pin",
-            "fields": [
+    def manifest(self) -> AuthManifest:
+        return AuthManifest(
+            name=self.name,
+            label=self.label,
+            flow="device_pin",
+            fields=[
                 {"key": "trakt.client_id", "label": "Client ID", "type": "text", "required": True},
                 {"key": "trakt.client_secret", "label": "Client Secret", "type": "password", "required": True},
             ],
-            "actions": {"start": True, "finish": True, "refresh": True, "disconnect": True},
-            "verify_url": VERIFY_URL,
-            "notes": "Open Trakt, enter the code, then return here. Client ID/Secret are required.",
+            actions={"start": True, "finish": True, "refresh": True, "disconnect": True},
+            verify_url=VERIFY_URL,
+            notes="Open Trakt, enter the code, then return here. Client ID/Secret are required.",
+        )
+
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "watchlist": True,
+            "ratings": True,
+            "history": True,
+            "device_code": True,
+            "refresh": True,
         }
+
+    def get_status(self, cfg: dict[str, Any] | None = None, *, instance_id: Any = None) -> AuthStatus:
+        cfg = cfg or _load_config()
+        inst, _, tr = _blocks(cfg, instance_id)
+        token = str(tr.get("access_token") or "").strip()
+        label = "Trakt" if inst == "default" else f"Trakt ({inst})"
+        return AuthStatus(
+            connected=bool(token),
+            label=label,
+            user=str(tr.get("username") or "") or None,
+            expires_at=int(tr.get("expires_at") or 0) or None,
+            scopes=[str(tr.get("scope") or "public")],
+        )
 
     def html(self, cfg: dict[str, Any] | None = None) -> str:
         # HTML is static; multi-profile UI is injected by auth.trakt.js
@@ -147,8 +170,8 @@ class _TraktProvider:
     }
   </style>
 
-  <div class="head" onclick="toggleSection && toggleSection('sec-trakt')">
-    <span class="chev">▶</span><strong>Trakt</strong>
+  <div class="head" data-toggle-section="sec-trakt">
+    <span class="chev"></span><strong>Trakt</strong>
   </div>
 
   <div class="body">
@@ -170,15 +193,11 @@ class _TraktProvider:
             <div class="grid2">
               <div>
                 <label for="trakt_client_id">Client ID</label>
-                <input id="trakt_client_id" name="trakt_client_id" placeholder="Enter your Trakt Client ID"
-                  oninput="updateTraktHint()"
-                  onchange="try{saveSetting('trakt.client_id', this.value); updateTraktHint();}catch(_){}">
+                <input id="trakt_client_id" name="trakt_client_id" placeholder="Enter your Trakt Client ID">
               </div>
               <div>
                 <label for="trakt_client_secret">Client Secret</label>
-                <input id="trakt_client_secret" name="trakt_client_secret" type="password" placeholder="Enter your Trakt Client Secret"
-                  oninput="updateTraktHint()"
-                  onchange="try{saveSetting('trakt.client_secret', this.value); updateTraktHint();}catch(_){}">
+                <input id="trakt_client_secret" name="trakt_client_secret" type="password" placeholder="Enter your Trakt Client Secret">
               </div>
             </div>
 
@@ -186,31 +205,22 @@ class _TraktProvider:
               You need a Trakt API application. Create one at
               <a href="https://trakt.tv/oauth/applications" target="_blank" rel="noopener">Trakt Applications</a>.
               Set the Redirect URL to <code id="trakt_redirect_uri_preview">urn:ietf:wg:oauth:2.0:oob</code>.
-              <button class="btn" style="margin-left:8px" onclick="copyTraktRedirect()">Copy Redirect URL</button>
+              <button id="btn-copy-trakt-redirect" class="btn" type="button" style="margin-left:8px">Copy Redirect URL</button>
             </div>
 
             <div class="sep"></div>
 
-            <div class="grid2">
-              <div>
-                <div class="field-label">Current token</div>
-                <div style="display:flex;gap:8px">
-                  <input id="trakt_token" placeholder="empty = not set" readonly>
-                  <button id="btn-copy-trakt-token" class="btn copy" onclick="copyInputValue('trakt_token', this)">Copy</button>
-                </div>
-              </div>
-              <div>
-                <div class="field-label">Link code (PIN)</div>
-                <div style="display:flex;gap:8px">
-                  <input id="trakt_pin" placeholder="" readonly>
-                  <button id="btn-copy-trakt-pin" class="btn copy" onclick="copyInputValue('trakt_pin', this)">Copy</button>
-                </div>
+            <div>
+              <div class="field-label">Link code (PIN)</div>
+              <div style="display:flex;gap:8px">
+                <input id="trakt_pin" placeholder="" readonly>
+                <button id="btn-copy-trakt-pin" class="btn copy" type="button">Copy</button>
               </div>
             </div>
 
             <div class="inline" style="margin-top:10px">
-              <button id="btn-connect-trakt" class="btn" onclick="requestTraktPin()">Connect TRAKT</button>
-              <button class="btn danger" onclick="try{ traktDeleteToken && traktDeleteToken(); }catch(_){;}">Delete</button>
+              <button id="btn-connect-trakt" class="btn" type="button">Connect TRAKT</button>
+              <button id="btn-delete-trakt" class="btn danger" type="button">Delete</button>
               <div class="sub">Open <a href="https://trakt.tv/activate" target="_blank" rel="noopener">trakt.tv/activate</a> and enter your code.</div>
               <div id="trakt_msg" class="msg ok hidden" role="status" aria-live="polite"></div>
             </div>
@@ -401,6 +411,15 @@ class _TraktProvider:
         _save_config(cfg)
         log("TRAKT: refresh ok", level="SUCCESS", module="AUTH")
         return {"ok": True, "status": "ok"}
+
+    def disconnect(self, cfg: dict[str, Any] | None = None, *, instance_id: Any = None) -> AuthStatus:
+        cfg = cfg or _load_config()
+        inst, _, tr = _blocks(cfg, instance_id)
+        for key in ("access_token", "refresh_token", "scope", "token_type", "expires_at", "_pending_device"):
+            tr.pop(key, None)
+        _save_config(cfg)
+        log(f"TRAKT[{inst}]: disconnected", level="INFO", module="AUTH")
+        return self.get_status(cfg, instance_id=inst)
 
 
 PROVIDER = _TraktProvider()

--- a/providers/auth/_auth_base.py
+++ b/providers/auth/_auth_base.py
@@ -3,9 +3,10 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import Mapping, MutableMapping
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 @dataclass
 class AuthManifest:
@@ -26,13 +27,86 @@ class AuthStatus:
     scopes: list[str] | None = None
     extra: dict[str, Any] = field(default_factory=dict)
 
+
+@dataclass
+class AuthResult:
+    ok: bool
+    status: str = ""
+    error: str | None = None
+    message: str | None = None
+    data: dict[str, Any] = field(default_factory=dict)
+    status_code: int | None = None
+
+
+def manifest_to_dict(manifest: Any) -> dict[str, Any]:
+    if dataclasses.is_dataclass(manifest) and not isinstance(manifest, type):
+        return dict(dataclasses.asdict(cast(Any, manifest)))
+    if isinstance(manifest, Mapping):
+        return dict(manifest)
+    data = getattr(manifest, "__dict__", None)
+    return dict(data) if isinstance(data, dict) else {"name": str(manifest)}
+
+
+def auth_status_to_dict(status: Any, *, instance_id: Any = None) -> dict[str, Any]:
+    out: dict[str, Any]
+    if dataclasses.is_dataclass(status) and not isinstance(status, type):
+        out = dict(dataclasses.asdict(cast(Any, status)))
+    elif isinstance(status, Mapping):
+        out = dict(status)
+    else:
+        data = getattr(status, "__dict__", None)
+        out = dict(data) if isinstance(data, dict) else {"connected": bool(status)}
+    out["connected"] = bool(out.get("connected"))
+    out.setdefault("label", "")
+    if instance_id is not None:
+        out.setdefault("instance", str(instance_id or "default"))
+    return out
+
+
+def auth_result_to_dict(result: Any, *, instance_id: Any = None) -> dict[str, Any]:
+    out: dict[str, Any]
+    if dataclasses.is_dataclass(result) and not isinstance(result, type):
+        out = dict(dataclasses.asdict(cast(Any, result)))
+    elif isinstance(result, Mapping):
+        out = dict(result)
+    else:
+        data = getattr(result, "__dict__", None)
+        out = dict(data) if isinstance(data, dict) else {"ok": bool(result)}
+    out["ok"] = bool(out.get("ok"))
+    if instance_id is not None:
+        out.setdefault("instance", str(instance_id or "default"))
+    return out
+
+
 class AuthProvider(Protocol):
     name: str
 
-    def manifest(self) -> AuthManifest: ...
+    def manifest(self) -> AuthManifest | Mapping[str, Any]: ...
     def capabilities(self) -> dict[str, Any]: ...
-    def get_status(self, cfg: Mapping[str, Any]) -> AuthStatus: ...
-    def start(self, cfg: MutableMapping[str, Any], redirect_uri: str) -> dict[str, Any]: ...
-    def finish(self, cfg: MutableMapping[str, Any], **payload: Any) -> AuthStatus: ...
-    def refresh(self, cfg: MutableMapping[str, Any]) -> AuthStatus: ...
-    def disconnect(self, cfg: MutableMapping[str, Any]) -> AuthStatus: ...
+    def get_status(self, cfg: Mapping[str, Any], *, instance_id: Any = None) -> AuthStatus | Mapping[str, Any]: ...
+    def start(
+        self,
+        cfg: MutableMapping[str, Any],
+        redirect_uri: str | None = None,
+        *,
+        instance_id: Any = None,
+    ) -> dict[str, Any] | AuthResult: ...
+    def finish(
+        self,
+        cfg: MutableMapping[str, Any],
+        *,
+        instance_id: Any = None,
+        **payload: Any,
+    ) -> AuthStatus | Mapping[str, Any]: ...
+    def refresh(
+        self,
+        cfg: MutableMapping[str, Any],
+        *,
+        instance_id: Any = None,
+    ) -> AuthStatus | Mapping[str, Any]: ...
+    def disconnect(
+        self,
+        cfg: MutableMapping[str, Any],
+        *,
+        instance_id: Any = None,
+    ) -> AuthStatus | Mapping[str, Any]: ...

--- a/providers/auth/registry.py
+++ b/providers/auth/registry.py
@@ -3,13 +3,14 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
-import dataclasses
 import importlib
 import inspect
 import pkgutil
 from pathlib import Path
 from types import ModuleType
 from typing import Any
+
+from ._auth_base import manifest_to_dict
 
 
 PKG_NAME: str = __package__ or "providers.auth"
@@ -83,12 +84,7 @@ def _provider_from_module(mod: ModuleType) -> Any | None:
 
 
 def _manifest_to_dict(man: Any) -> dict[str, Any]:
-    if dataclasses.is_dataclass(man):
-        return dataclasses.asdict(man)  # type: ignore[arg-type]
-    if isinstance(man, dict):
-        return dict(man)
-    d = getattr(man, "__dict__", None)
-    return dict(d) if isinstance(d, dict) else {"name": str(man)}
+    return manifest_to_dict(man)
 
 
 def auth_providers_manifests() -> list[dict[str, Any]]:
@@ -176,7 +172,7 @@ def auth_providers_html() -> str:
         body = "".join(items) if items else '<div class="sub">No providers.</div>'
         return (
             f'<div class="section open" id="{gid}">'
-            f'  <div class="head" onclick="toggleSection(\'{gid}\')"><span class="chev">▶</span><strong>{title}</strong></div>'
+            f'  <div class="head" data-toggle-section="{gid}"><span class="chev"></span><strong>{title}</strong></div>'
             f'  <div class="body">{body}</div>'
             f'</div>'
         )

--- a/providers/sync/_mod_ANILIST.py
+++ b/providers/sync/_mod_ANILIST.py
@@ -54,7 +54,7 @@ def _confirmed_keys(key_of, items: Iterable[Mapping[str, Any]], unresolved: Any)
         seen.add(k)
     return out
 
-__VERSION__ = "1.0"
+__VERSION__ = "0.1"
 os.environ.setdefault("CW_ANILIST_VERSION", __VERSION__)
 os.environ.setdefault("CW_ANILIST_UA", f"CrossWatch/{__VERSION__} (AniList)")
 __all__ = ["get_manifest", "ANILISTModule", "OPS"]

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -135,11 +135,13 @@ def _asset_block() -> str:
         '<script src="/assets/helpers/media_user_picker.js?v=__CW_VERSION__" defer></script>',
         '<script src="/assets/crosswatch.js?v=__CW_VERSION__"></script>',
         app_tags,
+        '<script src="/assets/auth/auth.shared.js?v=__CW_VERSION__"></script>',
         '<script src="/assets/auth/auth_loader.js?v=__CW_VERSION__" defer></script>',
         '<script src="/assets/auth/auth.tmdb.js?v=__CW_VERSION__" defer></script>',
         '<script src="/assets/js/client-formatter.js?v=__CW_VERSION__" defer></script>',
         '<link rel="stylesheet" href="/assets/js/modals/core/styles.css?v=__CW_VERSION__">',
         '<script type="module" src="/assets/js/modals.js?v=__CW_VERSION__"></script>',
+        '<script src="/assets/js/theme-flat-runtime.js?v=__CW_VERSION__" defer></script>',
     ))
 
 
@@ -232,6 +234,24 @@ def _get_index_html_static() -> str:
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<script>
+(() => {
+  try {
+    const raw = localStorage.getItem("cw.ui.theme") || "flat-dark";
+    const theme = raw === "flat-light" ? "flat-light" : raw === "original" ? "original" : "flat-dark";
+    if (theme === "original") {
+      delete document.documentElement.dataset.cwTheme;
+    } else {
+      document.documentElement.dataset.cwTheme = theme;
+    }
+    document.documentElement.classList.toggle("cw-theme-light", theme === "flat-light");
+    document.documentElement.classList.toggle("cw-theme-dark", theme === "flat-dark");
+    document.documentElement.classList.toggle("cw-theme-original", theme === "original");
+  } catch {
+    document.documentElement.dataset.cwTheme = "flat-dark";
+  }
+})();
+</script>
 
 <link rel="stylesheet" href="/assets/crosswatch.css?v=__CW_VERSION__">
 <link rel="stylesheet" href="/assets/ui-shell.css?v=__CW_VERSION__">
@@ -252,14 +272,6 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
 #page-settings .cw-settings-nav-card{background:radial-gradient(120% 150% at 0% 0%,rgba(68,76,120,.07),transparent 34%),var(--cw-ov-shell-soft)!important;opacity:.94}
 #page-settings .cw-settings-nav-btn{background:linear-gradient(180deg,rgba(255,255,255,.024),rgba(255,255,255,.012))!important;border-color:rgba(255,255,255,.07)!important}
 #page-settings .cw-settings-nav-btn.active{background:radial-gradient(860px 240px at 4% 0%,rgba(124,92,255,.18),transparent 52%),linear-gradient(180deg,rgba(20,24,34,.98),rgba(7,9,13,.99))!important;border-color:rgba(156,140,255,.22)!important;box-shadow:0 0 0 1px rgba(124,92,255,.12),0 12px 22px rgba(0,0,0,.22)!important}
-#page-settings #ui_settings_hub .cw-hub-tile{--hub-accent:124,92,255}
-#page-settings #ui_settings_hub .cw-hub-tile[data-tab="ui"]{--hub-accent:124,92,255}
-#page-settings #ui_settings_hub .cw-hub-tile[data-tab="security"]{--hub-accent:132,116,255}
-#page-settings #ui_settings_hub .cw-hub-tile[data-tab="tracker"]{--hub-accent:45,161,255}
-#page-settings #ui_settings_hub .cw-hub-tile.active,#page-settings #ui_settings_hub .cw-hub-tile[aria-selected="true"]{border-color:rgba(var(--hub-accent),.62)!important;box-shadow:0 0 0 2px rgba(var(--hub-accent),.20),0 18px 38px rgba(0,0,0,.32),inset 0 1px 0 rgba(255,255,255,.08)!important;transform:translateY(-1px)}
-#page-settings #ui_settings_hub .cw-hub-tile.active::after,#page-settings #ui_settings_hub .cw-hub-tile[aria-selected="true"]::after{content:"Open";position:absolute;right:16px;top:14px;z-index:2;display:inline-flex;align-items:center;justify-content:center;min-height:24px;padding:0 10px;border-radius:999px;border:1px solid rgba(var(--hub-accent),.36);background:rgba(var(--hub-accent),.15);color:#f5f7ff;font-size:10px;font-weight:900;letter-spacing:.12em;text-transform:uppercase;box-shadow:0 0 18px rgba(var(--hub-accent),.12)}
-#page-settings #ui_settings_hub .cw-hub-tile.active .cw-hub-icon,#page-settings #ui_settings_hub .cw-hub-tile[aria-selected="true"] .cw-hub-icon{border-color:rgba(var(--hub-accent),.36);background:linear-gradient(180deg,rgba(var(--hub-accent),.22),rgba(255,255,255,.035));box-shadow:0 0 0 1px rgba(var(--hub-accent),.12),0 10px 22px rgba(0,0,0,.22),inset 0 1px 0 rgba(255,255,255,.08)}
-#page-settings #ui_settings_hub .cw-hub-tile.active .cw-hub-title,#page-settings #ui_settings_hub .cw-hub-tile[aria-selected="true"] .cw-hub-title{color:#fff}
 #page-settings .cw-settings-setup-step.is-done{background:radial-gradient(900px 220px at 0% 0%,rgba(44,144,110,.18),transparent 58%),var(--cw-ov-shell)!important;border-color:rgba(76,176,136,.26)!important}
 #page-settings .cw-settings-setup-step.is-active{background:radial-gradient(900px 220px at 0% 0%,rgba(124,92,255,.18),transparent 58%),var(--cw-ov-shell)!important;border-color:rgba(150,132,255,.24)!important}
 #page-settings input,#page-settings select,#page-settings textarea{background:rgba(4,6,10,.94)!important;border:1px solid rgba(255,255,255,.08)!important;color:var(--cw-ov-fg)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.02)!important}
@@ -317,9 +329,6 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
 #page-settings .cw-hub-tile{position:relative;overflow:hidden;min-height:148px;padding:18px;border-radius:24px;display:grid;align-content:start}
 #page-settings .cw-hub-tile::before{content:"";position:absolute;inset:0;pointer-events:none;background:linear-gradient(135deg,rgba(255,255,255,.05),transparent 42%)}
 #page-settings .cw-hub-tile>*{position:relative;z-index:1}
-#page-settings .cw-hub-tile[data-tab="ui"]{background:radial-gradient(125% 145% at 0% 0%,rgba(92,96,182,.16),transparent 40%),linear-gradient(180deg,rgba(11,14,21,.96),rgba(6,8,12,.985))!important}
-#page-settings .cw-hub-tile[data-tab="security"]{background:radial-gradient(125% 145% at 0% 0%,rgba(124,92,255,.18),transparent 40%),linear-gradient(180deg,rgba(11,14,21,.96),rgba(6,8,12,.985))!important}
-#page-settings .cw-hub-tile[data-tab="tracker"]{background:radial-gradient(125% 145% at 0% 0%,rgba(45,161,255,.16),transparent 40%),linear-gradient(180deg,rgba(11,14,21,.96),rgba(6,8,12,.985))!important}
 #page-settings .cw-hub-top{display:flex;align-items:flex-start;gap:14px}
 #page-settings .cw-hub-icon{width:44px;height:44px;flex:0 0 44px;display:grid;place-items:center;border-radius:14px;border:1px solid rgba(255,255,255,.10);background:linear-gradient(180deg,rgba(255,255,255,.07),rgba(255,255,255,.03));box-shadow:inset 0 1px 0 rgba(255,255,255,.05)}
 #page-settings .cw-hub-icon .material-symbols-rounded{font-size:21px;line-height:1;color:#f1f5ff}
@@ -386,7 +395,7 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
               aria-haspopup="menu" aria-expanded="false"
               onclick="window.cwToggleSettingsMenu(event)">
         <span>Settings</span>
-        <span class="tab-caret" aria-hidden="true">▾</span>
+        <span class="tab-caret" aria-hidden="true"></span>
       </button>
       <div class="cw-menu hidden" id="cw-settings-menu" role="menu" aria-labelledby="tab-settings">
         <button class="cw-menu-item" type="button" role="menuitem" onclick="window.cwSettingsMenuSelect('overview')">Settings overview</button>
@@ -406,7 +415,7 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
               aria-haspopup="menu" aria-expanded="false"
               onclick="window.cwToggleAboutMenu(event)">
         <span>About</span>
-        <span class="tab-caret" aria-hidden="true">▾</span>
+        <span class="tab-caret" aria-hidden="true"></span>
       </button>
       <div class="cw-menu hidden" id="cw-about-menu" role="menu" aria-labelledby="tab-about">
         <button class="cw-menu-item" type="button" role="menuitem" onclick="window.cwAboutMenuSelect('about')">About</button>
@@ -451,7 +460,7 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
       <div class="action-buttons">
         <div class="cw-split-run" id="cw-sync-split">
         <button id="run" class="btn acc cw-split-main" onclick="runSync()"><span class="label">Synchronize</span><span class="spinner" aria-hidden="true"></span></button>
-        <button id="run-menu" class="btn acc cw-split-edge" type="button" title="Sync options" aria-haspopup="menu" aria-expanded="false" onclick="window.cwToggleSyncMenu(event)">▾</button>
+        <button id="run-menu" class="btn acc cw-split-edge" type="button" title="Sync options" aria-label="Sync options" aria-haspopup="menu" aria-expanded="false" onclick="window.cwToggleSyncMenu(event)"><span class="material-symbols-rounded" aria-hidden="true">expand_more</span></button>
         <div class="cw-menu cw-sync-menu hidden" id="cw-sync-menu" role="menu" aria-labelledby="run-menu"></div>
       </div>
         <button class="btn" onclick="toggleDetails()">View details</button>
@@ -490,10 +499,10 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
         <div class="det-right">
           <div class="meta-card">
             <div class="meta-grid">
-              <div class="meta-label">Module</div><div class="meta-value"><span id="det-cmd" class="pillvalue truncate">–</span></div>
-              <div class="meta-label">Version</div><div class="meta-value"><span id="det-ver" class="pillvalue">–</span></div>
-              <div class="meta-label">Started</div><div class="meta-value"><span id="det-start" class="pillvalue mono">–</span></div>
-              <div class="meta-label">Finished</div><div class="meta-value"><span id="det-finish" class="pillvalue mono">–</span></div>
+              <div class="meta-label">Module</div><div class="meta-value"><span id="det-cmd" class="pillvalue truncate">-</span></div>
+              <div class="meta-label">Version</div><div class="meta-value"><span id="det-ver" class="pillvalue">-</span></div>
+              <div class="meta-label">Started</div><div class="meta-value"><span id="det-start" class="pillvalue mono">-</span></div>
+              <div class="meta-label">Finished</div><div class="meta-value"><span id="det-finish" class="pillvalue mono">-</span></div>
             </div>
             <div class="meta-actions"><button class="btn" onclick="copySummary(this)">Copy summary</button></div>
           </div>
@@ -528,7 +537,7 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
     </div>
 
     <div class="stat-block">
-      <div class="stat-block-header"><span class="pill plain">Recent syncs</span><button class="ghost refresh-insights" onclick="refreshInsights()" title="Refresh">⟲</button></div>
+      <div class="stat-block-header"><span class="pill plain">Recent syncs</span><button class="ghost refresh-insights" onclick="refreshInsights()" title="Refresh">R</button></div>
       <div id="sync-history" class="history-list"></div>
     </div>
   </section>
@@ -540,12 +549,12 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
         <div class="cw-main-card-kicker">Watchlist Preview</div>
       </div>
     </div>
-    <div id="wall-msg" class="wall-msg">Loading…</div>
+    <div id="wall-msg" class="wall-msg">Loading...</div>
     <div class="wall-wrap">
       <div id="edgeL" class="edge left"></div><div id="edgeR" class="edge right"></div>
       <div id="poster-row" class="row-scroll" aria-label="Watchlist preview"></div>
-      <button class="nav prev" type="button" onclick="scrollWall(-1)" aria-label="Scroll left">‹</button>
-      <button class="nav next" type="button" onclick="scrollWall(1)" aria-label="Scroll right">›</button>
+      <button class="nav prev" type="button" onclick="scrollWall(-1)" aria-label="Scroll left"><</button>
+      <button class="nav next" type="button" onclick="scrollWall(1)" aria-label="Scroll right">></button>
     </div>
   </section>
 
@@ -716,15 +725,15 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
           </div>
           <div class="cw-settings-pane-stack cw-settings-providers-stack">
             <div class="section cw-settings-section cw-settings-provider-section" id="sec-auth">
-              <div class="head" onclick="toggleSection('sec-auth')">
-                <span class="chev">▶</span><strong>Authentication</strong>
+              <div class="head" data-toggle-section="sec-auth">
+                <span class="chev"></span><strong>Authentication</strong>
                 <span id="auth-providers-icons" class="cw-provider-head-icons">__CW_AUTH_HEADER_ICONS__</span>
               </div>
               <div class="body"><div id="auth-providers"></div></div>
             </div>
 
             <div class="section cw-settings-section cw-settings-provider-section" id="sec-sync">
-              <div class="head" onclick="toggleSection('sec-sync')"><span class="chev">▶</span><strong>Synchronization</strong></div>
+              <div class="head" data-toggle-section="sec-sync"><span class="chev"></span><strong>Synchronization</strong></div>
               <div class="body">
                 <div class="sub">Providers</div><div id="providers_list" class="grid2"></div>
                 <div class="sep"></div><div class="sub">Pairs</div><div id="pairs_list"></div>
@@ -735,7 +744,7 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
               </div>
             </div>
 
-            <div class="section cw-settings-section cw-settings-provider-section" id="sec-meta"><div class="head" onclick="toggleSection('sec-meta')"><span class="chev">▶</span><strong>Metadata</strong></div><div class="body">
+            <div class="section cw-settings-section cw-settings-provider-section" id="sec-meta"><div class="head" data-toggle-section="sec-meta"><span class="chev"></span><strong>Metadata</strong></div><div class="body">
 <div id="metadata-providers">
   <div class="cw-settings-hub" id="meta_provider_tiles">
     <button type="button" class="cw-hub-tile tmdb" data-provider="tmdb" aria-selected="false">
@@ -743,7 +752,7 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
         <div class="cw-hub-title">TMDb</div>
         <span class="auth-dot" id="meta-tmdb-dot" aria-hidden="true"></span>
       </div>
-      <span class="hidden" id="hub_tmdb_key" aria-hidden="true">API key: —</span>
+      <span class="hidden" id="hub_tmdb_key" aria-hidden="true">API key: -</span>
     </button>
   </div>
 
@@ -769,13 +778,13 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
             </div>
           </div>
           <div class="section open cw-settings-section" id="sec-scheduling" data-accordion="off">
-            <div class="head"><span class="chev">▶</span><strong>Scheduling</strong></div>
+            <div class="head"><span class="chev"></span><strong>Scheduling</strong></div>
             <div class="body">
               <div id="sched-provider-panel" class="cw-panel hidden"></div>
               <div id="sched-provider-raw" class="hidden">
                 <div class="grid2">
                   <div><label for="schEnabled">Enable</label><select id="schEnabled" name="schEnabled"><option value="false">Disabled</option><option value="true">Enabled</option></select></div>
-                  <div><label for="schMode">Frequency</label><select id="schMode" name="schMode"><option value="hourly">Every hour</option><option value="every_n_hours">Every N hours</option><option value="daily_time">Daily at…</option><option value="custom_interval">Custom</option></select></div>
+                  <div><label for="schMode">Frequency</label><select id="schMode" name="schMode"><option value="hourly">Every hour</option><option value="every_n_hours">Every N hours</option><option value="daily_time">Daily at...</option><option value="custom_interval">Custom</option></select></div>
                   <div><label for="schN">Every N hours</label><input id="schN" name="schN" type="number" min="2" value="12"></div>
                   <div><label for="schTime">Time</label><input id="schTime" name="schTime" type="time" value="03:30"></div>
                   <div><label for="schCustomValue">Custom interval</label><input id="schCustomValue" name="schCustomValue" type="number" min="15" step="15" value="60"></div>
@@ -802,14 +811,14 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
           <div id="sec-scrobbler" class="cw-settings-pane-stack cw-settings-scrobbler-stack" data-accordion="off">
             <div id="scrobble-mount" class="cw-settings-pane-stack cw-settings-scrobbler-stack-inner">
               <div class="section cw-settings-section cw-settings-provider-section" id="sc-sec-webhook">
-                <div class="head" onclick="toggleSection('sc-sec-webhook')">
-                  <span class="chev">▶</span><strong>Webhook</strong>
+                <div class="head" data-toggle-section="sc-sec-webhook">
+                  <span class="chev"></span><strong>Webhook</strong>
                 </div>
                 <div class="body"><div id="scrob-webhook"></div></div>
               </div>
               <div class="section open cw-settings-section cw-settings-provider-section" id="sc-sec-watch">
-                <div class="head" onclick="toggleSection('sc-sec-watch')">
-                  <span class="chev">▶</span><strong>Watcher</strong>
+                <div class="head" data-toggle-section="sc-sec-watch">
+                  <span class="chev"></span><strong>Watcher</strong>
                 </div>
                 <div class="body"><div id="scrob-watcher"></div></div>
               </div>
@@ -832,59 +841,10 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
           </div>
           <div class="section open cw-settings-section" id="sec-ui" data-accordion="off">
             <div class="head" style="display:flex;align-items:center">
-              <span class="chev">▶</span>
+              <span class="chev"></span>
               <strong>Settings (UI / Security / CW Tracker)</strong>
             </div>
             <div class="body">
-
-              <div class="cw-settings-hub" id="ui_settings_hub">
-                <button type="button" class="cw-hub-tile active" data-tab="ui" onclick="cwUiSettingsSelect?.('ui')">
-                  <div class="cw-hub-top">
-                    <div class="cw-hub-icon" aria-hidden="true"><span class="material-symbols-rounded">palette</span></div>
-                    <div class="cw-hub-copy">
-                      <div class="cw-hub-title">User Interface</div>
-                      <div class="cw-hub-desc">Dashboard visuals</div>
-                    </div>
-                  </div>
-                  <div class="chips">
-                    <span class="chip" id="hub_ui_watchlist">Watchlist: -</span>
-                    <span class="chip" id="hub_ui_playing">Playing: -</span>
-                    <span class="chip" id="hub_ui_activity">Activity: -</span>
-                    <span class="chip" id="hub_ui_askai">ASK AI: -</span>
-                    <span class="chip" id="hub_ui_quickadd">Quick Add: -</span>
-                    <span class="chip" id="hub_ui_proto">Proto: -</span>
-                  </div>
-                </button>
-
-                <button type="button" class="cw-hub-tile" data-tab="security" onclick="cwUiSettingsSelect?.('security')">
-                  <div class="cw-hub-top">
-                    <div class="cw-hub-icon" aria-hidden="true"><span class="material-symbols-rounded">shield_lock</span></div>
-                    <div class="cw-hub-copy">
-                      <div class="cw-hub-title">Security</div>
-                      <div class="cw-hub-desc">Protect CrossWatch</div>
-                    </div>
-                  </div>
-                  <div class="chips">
-                    <span class="chip" id="hub_sec_auth">Auth: -</span>
-                    <span class="chip" id="hub_sec_session">Session: -</span>
-                    <span class="chip" id="hub_sec_proxy">Proxy: -</span>
-                  </div>
-                </button>
-
-                <button type="button" class="cw-hub-tile" data-tab="tracker" onclick="cwUiSettingsSelect?.('tracker')">
-                  <div class="cw-hub-top">
-                    <div class="cw-hub-icon" aria-hidden="true"><span class="material-symbols-rounded">inventory_2</span></div>
-                    <div class="cw-hub-copy">
-                      <div class="cw-hub-title">CW Tracker</div>
-                      <div class="cw-hub-desc">Local snapshots</div>
-                    </div>
-                  </div>
-                  <div class="chips">
-                    <span class="chip" id="hub_cw_enabled">Tracker: -</span>
-                    <span class="chip" id="hub_cw_retention">Retention: -</span>
-                  </div>
-                </button>
-              </div>
 
               <div class="cw-settings-panels" id="ui_settings_panels">
 
@@ -999,6 +959,21 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
                             <option value="false">Hide</option>
                           </select>
                         </div>
+                      </div>
+                    </div>
+
+                    <div class="cw-settings-block">
+                      <div class="cw-settings-block-title">Theme</div>
+                      <div>
+                        <div class="cw-field-label-row">
+                          <label for="ui_theme">Theme</label>
+                          <button type="button" class="cw-field-help material-symbols-rounded" title="Theme: Choose Flat dark, Flat light, or Original to use the classic CrossWatch styling." aria-label="Theme setting help">help</button>
+                        </div>
+                        <select id="ui_theme" name="ui_theme" style="min-width:220px;max-width:360px">
+                          <option value="flat-dark">Flat dark</option>
+                          <option value="flat-light">Flat light</option>
+                          <option value="original">Original</option>
+                        </select>
                       </div>
                     </div>
 
@@ -1265,7 +1240,7 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
             </div>
           </div>
           <div class="section open cw-settings-section" id="sec-troubleshoot" data-accordion="off">
-            <div class="head"><span class="chev">▶</span><strong>Maintenance</strong></div>
+            <div class="head"><span class="chev"></span><strong>Maintenance</strong></div>
             <div class="body">
               <div>
                 <label for="debug">Debug</label>
@@ -1280,7 +1255,7 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
                 <button class="btn danger" onclick="openMaintenanceModal()">Maintenance Tools</button>
                 <button class="btn danger" onclick="restartCrossWatch()">Restart CrossWatch</button>
               </div>
-              <div id="tb_msg" class="msg ok hidden">Done ✓</div>
+              <div id="tb_msg" class="msg ok hidden">Done </div>
             </div>
           </div>
         </section>
@@ -1306,9 +1281,9 @@ __CW_ASSET_BLOCK__
 <script>document.addEventListener('DOMContentLoaded',()=>{try{if(typeof openSummaryStream==='function')openSummaryStream()}catch(e){}});</script>
 
 <div id="save-frost" class="hidden" aria-hidden="true"></div>
-<div id="save-fab" class="hidden" role="toolbar" aria-label="Sticky save"><button id="save-fab-btn" class="btn" onclick="saveSettings(this)"><span class="btn-ic">✔</span> <span class="btn-label">Save</span></button></div>
+<div id="save-fab" class="hidden" role="toolbar" aria-label="Sticky save"><button id="save-fab-btn" class="btn" onclick="saveSettings(this)"><span class="btn-label">SAVE</span></button></div>
 
-<script>(()=>{const list=p=>[...p.querySelectorAll(':scope>.section')].filter(s=>s.dataset.accordion!=='off'),set=(s,on)=>{s.classList.toggle('open',!!on);s.querySelector('.head')?.setAttribute('aria-expanded',String(!!on));const c=s.querySelector('.chev');if(c)c.textContent=on?'▼':'▶'},siblings=s=>s?.parentElement?list(s.parentElement):[];window.toggleSection=id=>{const s=document.getElementById(id);if(!s||s.dataset.accordion==='off')return;const on=!s.classList.contains('open');siblings(s).forEach(x=>set(x,x===s&&on))};window.openSection=id=>{const s=document.getElementById(id);if(!s||s.dataset.accordion==='off')return;siblings(s).forEach(x=>set(x,x===s))};document.addEventListener('DOMContentLoaded',()=>[...new Set([...document.querySelectorAll('.section')].map(s=>s.parentElement).filter(Boolean))].forEach(p=>{const open=list(p).find(s=>s.classList.contains('open'));list(p).forEach(s=>set(s,s===open))}),{once:true})})();</script>
+<script>(()=>{const list=p=>[...p.querySelectorAll(':scope>.section')].filter(s=>s.dataset.accordion!=='off'),set=(s,on)=>{s.classList.toggle('open',!!on);s.querySelector('.head')?.setAttribute('aria-expanded',String(!!on));const c=s.querySelector('.chev');if(c)c.textContent=''},siblings=s=>s?.parentElement?list(s.parentElement):[];window.toggleSection=id=>{const s=document.getElementById(id);if(!s||s.dataset.accordion==='off')return;const on=!s.classList.contains('open');siblings(s).forEach(x=>set(x,x===s&&on))};window.openSection=id=>{const s=document.getElementById(id);if(!s||s.dataset.accordion==='off')return;siblings(s).forEach(x=>set(x,x===s))};document.addEventListener('click',e=>{const h=e.target?.closest?.('[data-toggle-section]');if(!h)return;e.preventDefault();window.toggleSection?.(h.dataset.toggleSection)},true);document.addEventListener('DOMContentLoaded',()=>[...new Set([...document.querySelectorAll('.section')].map(s=>s.parentElement).filter(Boolean))].forEach(p=>{const open=list(p).find(s=>s.classList.contains('open'));list(p).forEach(s=>set(s,s===open))}),{once:true})})();</script>
 
 
 <script>(()=>{const panes='#page-settings .cw-settings-pane',nav='#cw-settings-nav .cw-settings-nav-btn',norm=v=>String(v||'overview').trim().toLowerCase(),apply=p=>{const name=norm(p);let found=false;document.querySelectorAll(panes).forEach(n=>{const on=norm(n.dataset.pane)===name;n.classList.toggle('active',on);found=found||on});if(!found&&name!=='overview')return apply('overview');document.querySelectorAll(nav).forEach(b=>{const on=norm(b.dataset.pane)===name;b.classList.toggle('active',on);b.setAttribute('aria-current',on?'page':'false')});window.__cwSettingsPane=name;document.dispatchEvent(new CustomEvent('cw-settings-pane-changed',{detail:{pane:name}}))};window.cwSettingsSelect=p=>{apply(p);const main=document.getElementById('cw-settings-left');if(main&&window.innerWidth<1200)main.scrollIntoView({behavior:'smooth',block:'start'})};document.addEventListener('DOMContentLoaded',()=>apply(window.__cwSettingsPane||'overview'),{once:true});document.addEventListener('tab-changed',e=>((e?.detail?.id||e?.detail?.tab)==='settings')&&setTimeout(()=>apply(window.__cwSettingsPane||'overview'),0))})();</script>
@@ -1466,13 +1441,13 @@ __CW_ASSET_BLOCK__
   document.addEventListener("DOMContentLoaded", () => render({}), { once: true });
 })();
 </script>
-<script>(()=>{window.cwScrobblerJump=sectionId=>(window.cwSettingsSelect?.('scrobbler'),setTimeout(()=>{window.openSection?.(sectionId);document.getElementById(sectionId)?.scrollIntoView({behavior:'smooth',block:'start'})},0));window.cwUiSettingsJump=tab=>(window.cwSettingsSelect?.('app'),setTimeout(()=>{window.cwUiSettingsSelect?.(tab);document.querySelector(`#ui_settings_hub .cw-hub-tile[data-tab="${String(tab||'').trim().toLowerCase()}"]`)?.scrollIntoView({behavior:'smooth',block:'nearest',inline:'center'})},0))})();</script>
+<script>(()=>{window.cwScrobblerJump=sectionId=>(window.cwSettingsSelect?.('scrobbler'),setTimeout(()=>{window.openSection?.(sectionId);document.getElementById(sectionId)?.scrollIntoView({behavior:'smooth',block:'start'})},0));window.cwUiSettingsJump=tab=>(window.cwSettingsSelect?.('app'),setTimeout(()=>{const t=String(tab||'').trim().toLowerCase();window.cwUiSettingsSelect?.(t);document.querySelector(`#ui_settings_panels .cw-settings-panel[data-tab="${t}"]`)?.scrollIntoView({behavior:'smooth',block:'start'})},0))})();</script>
 
 <script>(()=>{const origFetch=window.fetch;if(typeof origFetch!=='function'||origFetch.__cwAuthPendingWrapped)return;const pending=()=>window.cwIsAuthSetupPending?.()===true,allowPath=p=>p.startsWith('/api/app-auth/')||p==='/api/config/meta'||p.startsWith('/api/config/meta?')||p.startsWith('/assets/')||p==='/favicon.svg';const emptyJson=(body='{}')=>new Response(body,{status:200,headers:{'Content-Type':'application/json','Cache-Control':'no-store'}});window.fetch=Object.assign(async function(resource,init){try{if(!pending())return await origFetch(resource,init);const url=typeof resource==='string'?resource:String(resource?.url||'');const u=new URL(url,location.origin);if(u.origin!==location.origin||!u.pathname.startsWith('/api/')||allowPath(u.pathname)||allowPath(u.pathname+u.search))return await origFetch(resource,init);const method=String(init?.method||resource?.method||'GET').toUpperCase();if(method!=='GET'&&method!=='HEAD')return await origFetch(resource,init);if(u.pathname.startsWith('/api/config'))return emptyJson('{}');if(u.pathname.startsWith('/api/status'))return emptyJson('{"providers":{}}');if(u.pathname.startsWith('/api/pairs'))return emptyJson('[]');if(u.pathname.startsWith('/api/scheduling'))return emptyJson('{}');if(u.pathname.startsWith('/api/insights'))return emptyJson('{}');if(u.pathname.startsWith('/api/watch/'))return emptyJson('{}');if(u.pathname.startsWith('/api/webhooks/'))return emptyJson('{}');return emptyJson('{}')}catch{return await origFetch(resource,init)}},{__cwAuthPendingWrapped:true})})();</script>
 
 <script>(()=>{const $=id=>document.getElementById(id),fab=$('save-fab'),frost=$('save-frost'),page=$('page-settings'),tab=$('tab-settings'),visible=()=>{if(!page)return false;const cs=getComputedStyle(page);return!page.classList.contains('hidden')&&cs.display!=='none'&&cs.visibility!=='hidden'},update=()=>{const on=visible();fab?.classList.toggle('hidden',!on);frost?.classList.toggle('hidden',!on)},watch=(el,attrs)=>el&&new MutationObserver(update).observe(el,{attributes:true,attributeFilter:attrs});document.addEventListener('DOMContentLoaded',()=>{watch(page,['class','style']);watch(tab,['class']);update()},{once:true});document.addEventListener('tab-changed',update);window.addEventListener('hashchange',update);document.querySelector('.tabs')?.addEventListener('click',update,true)})();</script>
 
-<script>(()=>{const install=()=>{const orig=window.saveSettings;if(typeof orig!=='function'||orig._wrapped)return;window.saveSettings=Object.assign(async function(btnOrEvent){const btn=btnOrEvent instanceof HTMLElement?btnOrEvent:document.getElementById('save-fab-btn');if(btn&&!btn.dataset.defaultHtml)btn.dataset.defaultHtml=btn.innerHTML;if(btn)btn.disabled=true;try{const ret=orig.apply(this,arguments);await(ret&&typeof ret.then==='function'?ret:Promise.resolve());window.invalidateConfigCache?.();window.manualRefreshStatus?.();if(btn){btn.innerHTML='Settings saved ✓';setTimeout(()=>{btn.innerHTML=btn.dataset.defaultHtml||'<span class="btn-ic">✔</span> <span class="btn-label">Save</span>';btn.disabled=false},1600)}return ret}catch(e){if(btn){btn.innerHTML='Save failed';setTimeout(()=>{btn.innerHTML=btn.dataset.defaultHtml||'<span class="btn-ic">✔</span> <span class="btn-label">Save</span>';btn.disabled=false},2000)}throw e}},{_wrapped:true})};document.readyState==='complete'?install():window.addEventListener('load',install,{once:true})})();</script>
+<script>(()=>{const install=()=>{const orig=window.saveSettings;if(typeof orig!=='function'||orig._wrapped)return;window.saveSettings=Object.assign(async function(btnOrEvent){const btn=btnOrEvent instanceof HTMLElement?btnOrEvent:document.getElementById('save-fab-btn');if(btn&&!btn.dataset.defaultHtml)btn.dataset.defaultHtml=btn.innerHTML;if(btn)btn.disabled=true;try{const ret=orig.apply(this,arguments);await(ret&&typeof ret.then==='function'?ret:Promise.resolve());window.invalidateConfigCache?.();window.manualRefreshStatus?.();if(btn){btn.innerHTML='Settings saved';setTimeout(()=>{btn.innerHTML=btn.dataset.defaultHtml||'<span class="btn-label">SAVE</span>';btn.disabled=false},1600)}return ret}catch(e){if(btn){btn.innerHTML='Save failed';setTimeout(()=>{btn.innerHTML=btn.dataset.defaultHtml||'<span class="btn-label">SAVE</span>';btn.disabled=false},2000)}throw e}},{_wrapped:true})};document.readyState==='complete'?install():window.addEventListener('load',install,{once:true})})();</script>
 </body></html>
 
 """


### PR DESCRIPTION
# Pull request

## Change

Centralizes provider authentication UI/profile handling with a shared frontend helper and updates auth providers to use the same profile selector, secret masking, copy helpers, and status-pill behavior.

Also adds/updates backend auth validation for PublicMetaDB and Tautulli, aligns provider auth contracts around instance-aware methods, removes exposed token fields from auth panels, and updated CW version to v0.9.22.

## Why

Provider auth/profile handling had a lot of duplicated frontend code and inconsistent behavior between providers. Some profile controls could appear late after page mount because provider scripts were lazy-loaded and initialized at different moments.

This makes auth UI initialization more predictable, improves multi-profile support, avoids exposing token fields in the UI, and validates credentials before saving where possible.

## Testing

- Ran JS syntax checks
- Manually reviewed the changed auth/provider diffs.

## Issue

NA