### PR TITLE
Fix: docker runtime UID/GID remapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,12 @@ WORKDIR /app
 
 # --- runtime user ---
 ARG APP_USER=appuser
+ARG APP_GROUP
 ARG APP_UID=1000
 ARG APP_GID=1000
-RUN groupadd -g "${APP_GID}" "${APP_USER}" \
- && useradd -m -u "${APP_UID}" -g "${APP_GID}" -s /bin/bash "${APP_USER}"
+RUN APP_GROUP="${APP_GROUP:-${APP_USER}}" \
+ && groupadd -g "${APP_GID}" "${APP_GROUP}" \
+ && useradd -m -u "${APP_UID}" -g "${APP_GROUP}" -s /bin/bash "${APP_USER}"
 
 # --- deps
 COPY requirements.txt /app/requirements.txt

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,20 +5,132 @@ set -Eeuo pipefail
 
 WEB_HOST="${WEB_HOST:-0.0.0.0}"
 WEB_PORT="${WEB_PORT:-8787}"
-APP_USER="${APP_USER:-appuser}"
-APP_GROUP="${APP_GROUP:-appuser}"
-APP_UID="${APP_UID:-1000}"
-APP_GID="${APP_GID:-1000}"
+DEFAULT_APP_USER="appuser"
+DEFAULT_APP_GROUP="appuser"
+APP_USER_INPUT="${APP_USER:-}"
+APP_GROUP_INPUT="${APP_GROUP:-}"
+APP_UID_INPUT="${APP_UID:-}"
+APP_GID_INPUT="${APP_GID:-}"
+APP_USER="${APP_USER_INPUT:-${DEFAULT_APP_USER}}"
+APP_GROUP="${APP_GROUP_INPUT:-${DEFAULT_APP_GROUP}}"
+APP_UID="${APP_UID_INPUT:-1000}"
+APP_GID="${APP_GID_INPUT:-1000}"
 APP_DIR="${APP_DIR:-/app}"
 RUNTIME_DIR="${RUNTIME_DIR:-/config}"
 
 export PYTHONPATH="${APP_DIR}:${PYTHONPATH:-}"
 
+is_uint() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+die() {
+  echo "[ENTRYPOINT] ERROR: $*" >&2
+  exit 1
+}
+
+warn() {
+  echo "[ENTRYPOINT] WARNING: $*" >&2
+}
+
+name_for_gid() {
+  getent group "$1" | cut -d: -f1 || true
+}
+
+name_for_uid() {
+  getent passwd "$1" | cut -d: -f1 || true
+}
+
+gid_for_group() {
+  getent group "$1" | cut -d: -f3 || true
+}
+
+uid_for_user() {
+  getent passwd "$1" | cut -d: -f3 || true
+}
+
+normalize_app_identity() {
+  is_uint "${APP_UID}" || die "APP_UID must be numeric, got '${APP_UID}'"
+  is_uint "${APP_GID}" || die "APP_GID must be numeric, got '${APP_GID}'"
+
+  if [[ -n "${APP_USER_INPUT}" && "${APP_USER_INPUT}" =~ ^[0-9]+$ ]]; then
+    [[ -z "${APP_UID_INPUT}" || "${APP_UID_INPUT}" == "${APP_USER_INPUT}" ]] \
+      || warn "APP_USER is numeric but APP_UID is also set; using APP_UID=${APP_UID}"
+    [[ -n "${APP_UID_INPUT}" ]] || APP_UID="${APP_USER_INPUT}"
+    APP_USER="${DEFAULT_APP_USER}"
+  fi
+
+  if [[ -n "${APP_GROUP_INPUT}" && "${APP_GROUP_INPUT}" =~ ^[0-9]+$ ]]; then
+    [[ -z "${APP_GID_INPUT}" || "${APP_GID_INPUT}" == "${APP_GROUP_INPUT}" ]] \
+      || warn "APP_GROUP is numeric but APP_GID is also set; using APP_GID=${APP_GID}"
+    [[ -n "${APP_GID_INPUT}" ]] || APP_GID="${APP_GROUP_INPUT}"
+    APP_GROUP="${DEFAULT_APP_GROUP}"
+  fi
+}
+
+ensure_group() {
+  local current_gid existing_group
+
+  if getent group "${APP_GROUP}" >/dev/null 2>&1; then
+    current_gid="$(gid_for_group "${APP_GROUP}")"
+    if [[ "${current_gid}" != "${APP_GID}" ]]; then
+      existing_group="$(name_for_gid "${APP_GID}")"
+      [[ -z "${existing_group}" ]] \
+        || die "Group '${APP_GROUP}' has GID ${current_gid}, but requested GID ${APP_GID} already belongs to '${existing_group}'"
+      groupmod -g "${APP_GID}" "${APP_GROUP}"
+    fi
+    return 0
+  fi
+
+  existing_group="$(name_for_gid "${APP_GID}")"
+  if [[ -n "${existing_group}" ]]; then
+    if [[ "${existing_group}" == "${DEFAULT_APP_GROUP}" ]]; then
+      groupmod -n "${APP_GROUP}" "${existing_group}"
+    else
+      die "Cannot create group '${APP_GROUP}' with GID ${APP_GID}; GID already belongs to '${existing_group}'"
+    fi
+  else
+    groupadd -g "${APP_GID}" "${APP_GROUP}"
+  fi
+}
+
+ensure_user_account() {
+  local current_gid current_uid existing_user home_dir
+
+  if getent passwd "${APP_USER}" >/dev/null 2>&1; then
+    current_uid="$(uid_for_user "${APP_USER}")"
+    if [[ "${current_uid}" != "${APP_UID}" ]]; then
+      existing_user="$(name_for_uid "${APP_UID}")"
+      [[ -z "${existing_user}" ]] \
+        || die "User '${APP_USER}' has UID ${current_uid}, but requested UID ${APP_UID} already belongs to '${existing_user}'"
+      usermod -u "${APP_UID}" "${APP_USER}"
+    fi
+  else
+    existing_user="$(name_for_uid "${APP_UID}")"
+    if [[ -n "${existing_user}" ]]; then
+      if [[ "${existing_user}" == "${DEFAULT_APP_USER}" ]]; then
+        home_dir="/home/${APP_USER}"
+        usermod -l "${APP_USER}" -d "${home_dir}" -m "${existing_user}"
+      else
+        die "Cannot create user '${APP_USER}' with UID ${APP_UID}; UID already belongs to '${existing_user}'"
+      fi
+    else
+      useradd -m -u "${APP_UID}" -g "${APP_GROUP}" -s /bin/bash "${APP_USER}"
+    fi
+  fi
+
+  current_gid="$(id -g "${APP_USER}")"
+  if [[ "${current_gid}" != "${APP_GID}" ]]; then
+    usermod -g "${APP_GROUP}" "${APP_USER}"
+  fi
+}
+
 ensure_user() {
   # Create runtime user/group only when running as root
   if [[ "$(id -u)" -ne 0 ]]; then return 0; fi
-  getent group "${APP_GROUP}" >/dev/null 2>&1 || groupadd -g "${APP_GID}" "${APP_GROUP}"
-  id -u "${APP_USER}" >/dev/null 2>&1 || useradd -m -u "${APP_UID}" -g "${APP_GROUP}" -s /bin/bash "${APP_USER}"
+  normalize_app_identity
+  ensure_group
+  ensure_user_account
 }
 
 prep_runtime() {
@@ -38,12 +150,20 @@ run_as() {
   fi
 }
 
+run_identity() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    echo "${APP_USER}:${APP_GROUP} (${APP_UID}:${APP_GID})"
+  else
+    echo "$(id -un):$(id -gn) ($(id -u):$(id -g))"
+  fi
+}
+
 main() {
   ensure_user
   prep_runtime
   cd "${APP_DIR}"
 
-  echo "[ENTRYPOINT] CrossWatch on ${WEB_HOST}:${WEB_PORT} (reload=${RELOAD:-no}) as $(id -un)"
+  echo "[ENTRYPOINT] CrossWatch on ${WEB_HOST}:${WEB_PORT} (reload=${RELOAD:-no}) as $(run_identity)"
 
   if [[ "$#" -gt 0 ]]; then
     # Run a custom command


### PR DESCRIPTION
# Pull request

## Change

Updated the Docker runtime user handling so `APP_UID`, `APP_GID`, `APP_USER`, and `APP_GROUP` are reconciled with the prebuilt container user/group instead of blindly trying to create new accounts.

This allows:
- setting only `APP_UID` and `APP_GID`
- setting all four values for a named custom user/group
- using numeric `APP_USER`/`APP_GROUP` as shorthand for UID/GID
- running explicitly as `root:root`

Also added build-time `APP_GROUP` support while preserving the previous default behavior.

## Why

The image already contains `appuser:appuser` as `1000:1000`, so runtime changes could fail with collisions such as:

- `groupadd: GID '1000' already exists`
- `groupadd: '1002' is not a valid group name`

This made it unreliable to run CrossWatch as a non-default UID/GID.

## Testing

Tested with a local Docker build and runtime checks:

- default user/group: `appuser:appuser` `1000:1000`
- `APP_UID=1001 APP_GID=1002`
- `APP_UID=1001 APP_GID=1002 APP_USER=foo APP_GROUP=foo`
- `APP_USER=1001 APP_GROUP=1002`
- `APP_USER=foo APP_GROUP=foo`
- `APP_UID=0 APP_GID=0 APP_USER=root APP_GROUP=root`
- verified `/config` ownership is updated to the requested UID/GID
- verified normal app startup still works

## Issue

#273 