### PR TITLE
Add: Anime ID Mapping support for AniList syncs

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -9,6 +9,7 @@ from .tlsAPI import router as tls_router
 from .maintenanceAPI import router as maintenance_router
 from .activityAPI import router as activity_router
 from .metaAPI import router as meta_router
+from .animeMappingAPI import router as anime_mapping_router
 from .manualAPI import router as manual_router
 from .insightAPI import register_insights
 from .watchlistAPI import router as watchlist_router
@@ -42,6 +43,7 @@ __all__ = [
     "maintenance_router",
     "activity_router",
     "meta_router",
+    "anime_mapping_router",
     "manual_router",
     "watchlist_router",
     "snapshots_router",
@@ -75,6 +77,7 @@ def register(
     app.include_router(health_router)
     app.include_router(tls_router)
     app.include_router(meta_router)
+    app.include_router(anime_mapping_router)
     app.include_router(manual_router)
     app.include_router(watchlist_router)
     app.include_router(snapshots_router)

--- a/api/animeMappingAPI.py
+++ b/api/animeMappingAPI.py
@@ -1,0 +1,214 @@
+# /api/anime-mapping
+# CrossWatch - Anime Mapping API
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Body
+from fastapi.responses import JSONResponse
+
+from _logging import log
+
+from cw_platform.anime_mapping.auto_update import refresh_from_config as refresh_auto_update
+from cw_platform.anime_mapping.auto_update import status as auto_update_status
+from cw_platform.anime_mapping.storage import normalize_release_tag, rebuild_sqlite_from_mappings
+from cw_platform.anime_mapping.updater import status as mapping_status, update as mapping_update
+from cw_platform.config_base import load_config, save_config
+
+router = APIRouter(prefix="/api/anime-mapping", tags=["anime-mapping"])
+
+
+def _release_tag(payload: dict[str, Any] | None = None) -> str:
+    cfg = load_config() or {}
+    data: dict[str, Any] = payload if isinstance(payload, dict) else {}
+    raw_block = cfg.get("anime_mapping")
+    block: dict[str, Any] = raw_block if isinstance(raw_block, dict) else {}
+    return normalize_release_tag(data.get("release_tag") or block.get("release_tag"))
+
+
+def _int_at_least(value: Any, default: int, minimum: int) -> int:
+    try:
+        return max(minimum, int(value))
+    except Exception:
+        return default
+
+
+def _provider_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        raw = value.replace(",", " ").split()
+    elif isinstance(value, (list, tuple, set)):
+        raw = list(value)
+    else:
+        raw = []
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        name = str(item or "").strip().lower()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        out.append(name)
+    return out
+
+
+@router.get("/status")
+def api_anime_mapping_status() -> JSONResponse:
+    cfg = load_config() or {}
+    st = mapping_status(cfg=cfg)
+    st["auto_update_status"] = auto_update_status()
+    return JSONResponse(st)
+
+
+@router.post("/settings")
+def api_anime_mapping_settings(payload: dict[str, Any] | None = Body(default=None)) -> JSONResponse:
+    try:
+        data = payload or {}
+        cfg = load_config() or {}
+        block = cfg.get("anime_mapping") if isinstance(cfg.get("anime_mapping"), dict) else {}
+        block = dict(block or {})
+
+        if "enabled" in data:
+            block["enabled"] = bool(data.get("enabled"))
+        if "auto_update" in data:
+            block["auto_update"] = bool(data.get("auto_update"))
+        if "provider" in data:
+            provider = str(data.get("provider") or "anibridge").strip().lower() or "anibridge"
+            block["provider"] = provider
+        if "release_tag" in data:
+            block["release_tag"] = normalize_release_tag(data.get("release_tag"))
+        if "refresh_hours" in data:
+            block["refresh_hours"] = _int_at_least(data.get("refresh_hours"), 24, 1)
+        if "stale_after_days" in data:
+            block["stale_after_days"] = _int_at_least(data.get("stale_after_days"), 14, 1)
+        if "use_for_pairs" in data:
+            providers = _provider_list(data.get("use_for_pairs"))
+            block["use_for_pairs"] = providers or ["anilist"]
+
+        cfg["anime_mapping"] = block
+        save_config(cfg)
+        log(
+            "settings_saved",
+            level="debug",
+            module="ANIME_MAPPING",
+            extra={
+                "enabled": bool(block.get("enabled", False)),
+                "auto_update": bool(block.get("auto_update", True)),
+                "release_tag": str(block.get("release_tag") or "v3"),
+                "use_for_pairs": ",".join(_provider_list(block.get("use_for_pairs")) or ["anilist"]),
+            },
+        )
+        st = mapping_status(cfg=cfg)
+        bootstrap = None
+        bootstrap_error = ""
+        if bool(block.get("enabled", False)) and not bool(st.get("installed") and st.get("index_ready")):
+            try:
+                log(
+                    "bootstrap_started",
+                    level="debug",
+                    module="ANIME_MAPPING",
+                    extra={
+                        "release_tag": str(block.get("release_tag") or "v3"),
+                        "reason": "enabled_missing_index",
+                    },
+                )
+                bootstrap = mapping_update(release_tag=str(block.get("release_tag") or "v3"), force=False)
+                st = mapping_status(cfg=cfg)
+                log(
+                    "bootstrap_finished",
+                    level="debug",
+                    module="ANIME_MAPPING",
+                    extra={
+                        "release_tag": str(block.get("release_tag") or "v3"),
+                        "installed": bool(st.get("installed")),
+                        "index_ready": bool(st.get("index_ready")),
+                    },
+                )
+            except Exception as boot_e:
+                bootstrap_error = str(boot_e)
+                st["error"] = boot_e.__class__.__name__
+                st["message"] = bootstrap_error
+                log(
+                    "bootstrap_failed",
+                    level="error",
+                    module="ANIME_MAPPING",
+                    extra={
+                        "release_tag": str(block.get("release_tag") or "v3"),
+                        "error_type": boot_e.__class__.__name__,
+                        "error": bootstrap_error,
+                    },
+                )
+        try:
+            refresh_auto_update(load_config)
+        except Exception as sched_e:
+            log(
+                "auto_update_refresh_failed",
+                level="error",
+                module="ANIME_MAPPING",
+                extra={"error_type": sched_e.__class__.__name__, "error": str(sched_e)},
+            )
+            st["auto_update_error"] = str(sched_e)
+        st["auto_update_status"] = auto_update_status()
+        return JSONResponse(
+            {
+                "ok": True,
+                "anime_mapping": block,
+                "status": st,
+                "bootstrap": bootstrap,
+                "bootstrap_error": bootstrap_error,
+            }
+        )
+    except Exception as e:
+        log(
+            "settings_failed",
+            level="error",
+            module="ANIME_MAPPING",
+            extra={"error_type": e.__class__.__name__, "error": str(e)},
+        )
+        return JSONResponse({"ok": False, "error": e.__class__.__name__, "message": str(e)}, status_code=500)
+
+
+@router.post("/update")
+def api_anime_mapping_update(payload: dict[str, Any] | None = Body(default=None)) -> JSONResponse:
+    try:
+        tag = _release_tag(payload)
+        force = bool((payload or {}).get("force", False))
+        res = mapping_update(release_tag=tag, force=force)
+        res["auto_update_status"] = auto_update_status()
+        return JSONResponse(res)
+    except Exception as e:
+        log(
+            "manual_update_failed",
+            level="error",
+            module="ANIME_MAPPING",
+            extra={"error_type": e.__class__.__name__, "error": str(e)},
+        )
+        return JSONResponse({"ok": False, "error": e.__class__.__name__, "message": str(e)}, status_code=500)
+
+
+@router.post("/rebuild-index")
+def api_anime_mapping_rebuild_index(payload: dict[str, Any] | None = Body(default=None)) -> JSONResponse:
+    try:
+        tag = _release_tag(payload)
+        log("manual_rebuild_requested", level="debug", module="ANIME_MAPPING", extra={"release_tag": tag})
+        res = rebuild_sqlite_from_mappings(release_tag=tag)
+        cfg = load_config() or {}
+        log(
+            "manual_rebuild_finished",
+            level="debug",
+            module="ANIME_MAPPING",
+            extra={
+                "release_tag": tag,
+                "source_count": int(res.get("source_count") or 0),
+                "edge_count": int(res.get("edge_count") or 0),
+            },
+        )
+        return JSONResponse({"ok": True, "rebuild": res, "status": mapping_status(cfg=cfg), "auto_update_status": auto_update_status()})
+    except Exception as e:
+        log(
+            "manual_rebuild_failed",
+            level="error",
+            module="ANIME_MAPPING",
+            extra={"error_type": e.__class__.__name__, "error": str(e)},
+        )
+        return JSONResponse({"ok": False, "error": e.__class__.__name__, "message": str(e)}, status_code=500)

--- a/assets/auth/auth.anilist.js
+++ b/assets/auth/auth.anilist.js
@@ -34,6 +34,10 @@
   }
 
   const SECTION = "#sec-anilist";
+  const MAPPING_DISMISS_KEY = "cw.ui.anilist.animeMapping.dismissed.v1";
+  let mappingRecommendBusy = false;
+  let mappingRecommendStatus = null;
+  let anilistConnected = false;
 
   function normalizeId(v) {
     v = String(v || "").trim();
@@ -61,6 +65,176 @@
 
   function setAniListSuccess(on, txt) {
     return Shared.setStatusPill("anilist_msg", on ? "ok" : (txt ? "warn" : null), txt || (on ? "Connected" : ""));
+  }
+
+  function toast(message, ok = true) {
+    try {
+      if (typeof w.CW?.DOM?.showToast === "function") {
+        w.CW.DOM.showToast(message, !!ok);
+        return;
+      }
+    } catch {}
+    notify(message);
+  }
+
+  function mappingRecommendationDismissed() {
+    try { return localStorage.getItem(MAPPING_DISMISS_KEY) === "1"; } catch { return false; }
+  }
+
+  function setMappingRecommendationDismissed() {
+    try { localStorage.setItem(MAPPING_DISMISS_KEY, "1"); } catch {}
+  }
+
+  function hasAniListCredentials() {
+    try {
+      const cidState = readSecretField($("anilist_client_id"));
+      const secState = readSecretField($("anilist_client_secret"));
+      return !!(cidState.hasValue && secState.hasValue);
+    } catch {
+      return false;
+    }
+  }
+
+  function hasAniListConnection() {
+    return !!anilistConnected;
+  }
+
+  function ensureMappingRecommendation() {
+    const sub = Q(SECTION + ' .cw-subpanel[data-sub="auth"]');
+    if (!sub) return null;
+
+    let box = $("anilist_mapping_recommendation");
+    if (box) return box;
+
+    box = d.createElement("div");
+    box.id = "anilist_mapping_recommendation";
+    box.className = "anilist-mapping-rec hidden";
+    box.innerHTML =
+      '<div class="anilist-mapping-rec-copy">' +
+        '<div class="anilist-mapping-rec-kicker">Recommended for AniList</div>' +
+        '<strong>Use Anime ID Mapping</strong>' +
+        '<div class="muted">Improves matching by translating AniList IDs to IDs your media servers and trackers understand.</div>' +
+        '<div class="anilist-mapping-rec-state" id="anilist_mapping_recommendation_state"></div>' +
+      '</div>' +
+      '<div class="anilist-mapping-rec-actions">' +
+        '<button class="btn primary" type="button" id="btn-anilist-enable-mapping">Enable Anime ID Mapping</button>' +
+        '<button class="btn" type="button" id="btn-anilist-dismiss-mapping">Not now</button>' +
+      '</div>';
+
+    const controls = Q(SECTION + " .inline");
+    if (controls && controls.parentNode === sub) controls.insertAdjacentElement("afterend", box);
+    else sub.appendChild(box);
+
+    const enableBtn = $("btn-anilist-enable-mapping");
+    if (enableBtn && !enableBtn.__wired) {
+      enableBtn.addEventListener("click", enableAnimeMappingFromAniList);
+      enableBtn.__wired = true;
+    }
+
+    const dismissBtn = $("btn-anilist-dismiss-mapping");
+    if (dismissBtn && !dismissBtn.__wired) {
+      dismissBtn.addEventListener("click", () => {
+        setMappingRecommendationDismissed();
+        renderMappingRecommendation();
+      });
+      dismissBtn.__wired = true;
+    }
+
+    return box;
+  }
+
+  function renderMappingRecommendation(status = mappingRecommendStatus) {
+    const box = ensureMappingRecommendation();
+    if (!box) return;
+
+    const connected = hasAniListConnection();
+    const enabled = !!(status?.enabled || w._cfgCache?.anime_mapping?.enabled);
+    const show = connected && !enabled && !mappingRecommendationDismissed();
+    box.classList.toggle("hidden", !show);
+    box.classList.toggle("busy", !!mappingRecommendBusy);
+
+    const btn = $("btn-anilist-enable-mapping");
+    if (btn) {
+      btn.disabled = !!mappingRecommendBusy;
+      btn.textContent = mappingRecommendBusy ? "Enabling..." : "Enable Anime ID Mapping";
+    }
+
+    const state = $("anilist_mapping_recommendation_state");
+    if (state) {
+      const err = String(status?.error || "").trim();
+      state.textContent = mappingRecommendBusy ? "Downloading mapping database if needed..." : err;
+      state.classList.toggle("hidden", !(mappingRecommendBusy || err));
+    }
+  }
+
+  let mappingRefreshTimer = null;
+  function queueMappingRecommendationRefresh(delay = 120) {
+    clearTimeout(mappingRefreshTimer);
+    mappingRefreshTimer = setTimeout(() => {
+      refreshMappingRecommendation().catch(() => {});
+    }, delay);
+  }
+
+  async function refreshMappingRecommendation() {
+    ensureMappingRecommendation();
+    if (!hasAniListConnection()) {
+      renderMappingRecommendation();
+      return null;
+    }
+
+    try {
+      const r = await fetch("/api/anime-mapping/status", { cache: "no-store", credentials: "same-origin" });
+      if (!r.ok) throw new Error(`Status failed (${r.status})`);
+      mappingRecommendStatus = await r.json().catch(() => ({}));
+    } catch (e) {
+      mappingRecommendStatus = { ...(mappingRecommendStatus || {}), error: e?.message || "Could not check Anime ID Mapping status" };
+    }
+
+    renderMappingRecommendation(mappingRecommendStatus);
+    return mappingRecommendStatus;
+  }
+
+  async function enableAnimeMappingFromAniList() {
+    mappingRecommendBusy = true;
+    renderMappingRecommendation();
+
+    try {
+      const r = await fetch("/api/anime-mapping/settings", {
+        method: "POST",
+        cache: "no-store",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled: true,
+          auto_update: true,
+          provider: "anibridge",
+          use_for_pairs: ["anilist"],
+        }),
+      });
+      const data = await r.json().catch(() => ({}));
+      if (!r.ok || data.ok === false) throw new Error(data.message || data.error || `Enable failed (${r.status})`);
+
+      w._cfgCache ||= {};
+      w._cfgCache.anime_mapping = data.anime_mapping || {
+        ...(w._cfgCache.anime_mapping || {}),
+        enabled: true,
+        auto_update: true,
+        provider: "anibridge",
+        use_for_pairs: ["anilist"],
+      };
+      mappingRecommendStatus = data.status || { ...(mappingRecommendStatus || {}), enabled: true };
+
+      try { w.cwAnimeMappingRenderStatus?.(mappingRecommendStatus); } catch {}
+      try { await w.cwAnimeMappingRefreshStatus?.(); } catch {}
+      toast(data.bootstrap_error ? data.bootstrap_error : "Anime ID Mapping enabled", !data.bootstrap_error);
+    } catch (e) {
+      mappingRecommendStatus = { ...(mappingRecommendStatus || {}), error: e?.message || "Could not enable Anime ID Mapping" };
+      toast(mappingRecommendStatus.error, false);
+    } finally {
+      mappingRecommendBusy = false;
+      renderMappingRecommendation();
+      queueMappingRecommendationRefresh(0);
+    }
   }
 
   function renderAniListHint() {
@@ -108,10 +282,12 @@
       if (cidEl && (force || !cidEl.value || cidEl.dataset.masked === "1")) markSecretField(cidEl, cid);
       if (secEl && (force || !secEl.value || secEl.dataset.masked === "1")) markSecretField(secEl, sec);
 
+      anilistConnected = !!tok;
       if (tok) setAniListSuccess(true);
       else setAniListSuccess(false, "");
 
       updateAniListButtonState();
+      queueMappingRecommendationRefresh();
     } catch {}
   }
 
@@ -134,6 +310,7 @@
       }
       if (btn) btn.disabled = !ok;
       if (hint) hint.classList.toggle("hidden", ok);
+      renderMappingRecommendation();
     } catch (e) {
       console.warn("updateAniListButtonState failed", e);
     }
@@ -163,6 +340,7 @@
     if (deleteBtn && !deleteBtn.__wired) { deleteBtn.addEventListener("click", anilistDeleteToken); deleteBtn.__wired = true; }
 
     updateAniListButtonState();
+    queueMappingRecommendationRefresh();
   }
 
   async function copyAniListRedirect() {
@@ -216,6 +394,8 @@
         btn.classList.remove("busy");
       }
       try { setAniListSuccess(false, ""); } catch {}
+      anilistConnected = false;
+      queueMappingRecommendationRefresh();
     }
   }
 
@@ -282,9 +462,11 @@
       const blk = getAniListCfgBlock(cfg || {});
       const tok = String(blk?.access_token || "").trim();
       if (tok) {
+        anilistConnected = true;
         setAniListSuccess(true);
 
         pollHandle = null;
+        queueMappingRecommendationRefresh(0);
         try { w.dispatchEvent(new CustomEvent("auth-changed")); } catch {}
         return;
       }
@@ -319,5 +501,6 @@
     startAniList,
     copyAniListRedirect,
     anilistDeleteToken,
+    refreshAniListMappingRecommendation: refreshMappingRecommendation,
   });
 })(window, document);

--- a/assets/crosswatch.css
+++ b/assets/crosswatch.css
@@ -797,7 +797,7 @@ to{left:6px}
 .cw-main-card-kicker{font-size:11px;font-weight:800;letter-spacing:.14em;text-transform:uppercase;color:rgba(185,193,230,.74)}
 .cw-main-card-head-copy h2{margin:4px 0 0;font-size:24px;line-height:1.04;font-weight:850;letter-spacing:-.02em}
 .cw-main-card-head-copy p{margin:8px 0 0;color:rgba(185,193,230,.78);max-width:560px}
-.cw-main-card-head-side{margin-left:auto;display:flex;align-items:center;justify-content:flex-end;gap:8px;flex-wrap:wrap;min-width:0;max-width:min(100%,880px)}
+.cw-main-card-head-side{margin-left:auto;display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:start;justify-content:flex-end;gap:8px;min-width:0;max-width:min(100%,880px)}
 .cw-main-card-head-actions{display:flex;align-items:center;gap:8px;flex:0 0 auto;flex-wrap:wrap;justify-content:flex-end}
 #ops-card.card.cw-main-card{padding:18px 18px 22px}
 #placeholder-card.cw-main-card,#stats-card.card.cw-main-card{padding:18px}
@@ -1095,17 +1095,69 @@ html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;b
 #page-settings #auth-providers>.section>.body>.section>.body{padding:0 18px;max-height:0;overflow:hidden}
 #page-settings #auth-providers>.section>.body>.section.open>.body{padding:12px 18px 18px;max-height:2200px;overflow:visible}
 #page-settings #auth-providers>.section>.head,#page-settings .cw-settings-pane-stack>.cw-settings-section:not(.cw-settings-provider-section)>.head,#page-settings .cw-settings-provider-section>.head{gap:12px}
+#page-settings #sec-anilist .anilist-mapping-rec{display:flex;align-items:center;justify-content:space-between;gap:14px;margin-top:12px;padding:14px 16px;border:1px solid rgba(var(--anilist-rgb),.22);border-radius:14px;background:linear-gradient(135deg,rgba(var(--anilist-rgb),.12),rgba(34,197,94,.08));box-shadow:inset 0 1px 0 rgba(255,255,255,.035)}
+#page-settings #sec-anilist .anilist-mapping-rec.hidden{display:none!important}
+#page-settings #sec-anilist .anilist-mapping-rec-copy{min-width:0;display:grid;gap:4px}
+#page-settings #sec-anilist .anilist-mapping-rec-kicker{font-size:11px;font-weight:900;letter-spacing:.08em;text-transform:uppercase;color:rgba(176,212,255,.88)}
+#page-settings #sec-anilist .anilist-mapping-rec-copy strong{display:block;color:var(--fg);font-size:15px;line-height:1.2}
+#page-settings #sec-anilist .anilist-mapping-rec-state{font-size:12px;font-weight:750;color:#ffe2a7}
+#page-settings #sec-anilist .anilist-mapping-rec-state.hidden{display:none!important}
+#page-settings #sec-anilist .anilist-mapping-rec-actions{display:flex;align-items:center;gap:10px;flex-wrap:wrap;justify-content:flex-end}
+#page-settings #sec-anilist .anilist-mapping-rec.busy .btn{pointer-events:none;opacity:.72}
 @media(max-width:980px){#page-settings #auth-providers .section>.body .section>.head,#page-settings #auth-providers .section>.head,#page-settings #cw-settings-left.section>.head{padding-left:16px!important}
 #page-settings #auth-providers>.section>.body>.section.open>.body,#page-settings #auth-providers>.section>.body>.section>.head{padding-left:16px!important;padding-right:16px!important}
 }
-#page-settings #sec-meta #meta_provider_tiles{grid-template-columns:1fr;justify-content:stretch}
-#page-settings #sec-meta .cw-hub-tile.tmdb{width:100%;min-height:68px;border:1px solid rgba(255,255,255,.08);border-radius:18px;padding:16px 18px;display:flex;align-items:center;background:radial-gradient(680px 180px at 0 0,rgba(124,92,255,.08),transparent 52%),linear-gradient(180deg,rgba(255,255,255,.022),rgba(255,255,255,.008));box-shadow:0 12px 24px rgba(0,0,0,.16),inset 0 1px 0 rgba(255,255,255,.02);transform:none}
-#page-settings #sec-meta .cw-hub-tile.tmdb:hover{border-color:rgba(255,255,255,.12);background:radial-gradient(680px 180px at 0 0,rgba(124,92,255,.1),transparent 52%),linear-gradient(180deg,rgba(255,255,255,.028),rgba(255,255,255,.010));box-shadow:0 14px 28px rgba(0,0,0,.18),inset 0 1px 0 rgba(255,255,255,.03);transform:translateY(-1px)}
-#page-settings #sec-meta .cw-hub-tile.tmdb.active{border-color:rgba(124,92,255,.45);background:radial-gradient(720px 200px at 0 0,rgba(124,92,255,.14),transparent 54%),linear-gradient(180deg,rgba(255,255,255,.032),rgba(255,255,255,.012));box-shadow:0 0 0 1px rgba(124,92,255,.16),0 14px 30px rgba(0,0,0,.22),inset 0 1px 0 rgba(255,255,255,.03)}
-#page-settings #sec-meta .cw-hub-tile.tmdb::after,#page-settings #sec-meta .cw-hub-tile.tmdb::before{content:none;display:none}
-#page-settings #sec-meta .cw-hub-tile.tmdb .cw-meta-provider-row{width:100%;display:flex;align-items:center;justify-content:space-between;gap:12px}
-#page-settings #sec-meta .cw-hub-tile.tmdb .cw-hub-title{font-size:15px;font-weight:800;letter-spacing:-.01em}
-#page-settings #sec-meta .cw-hub-tile.tmdb #meta-tmdb-dot{margin-left:auto;flex:0 0 auto}
+@media(max-width:760px){#page-settings #sec-anilist .anilist-mapping-rec{align-items:stretch}#page-settings #sec-anilist .anilist-mapping-rec-actions{width:100%;justify-content:flex-start}#page-settings #sec-anilist .anilist-mapping-rec-actions .btn{flex:1 1 180px}}
+#page-settings #sec-meta .cw-meta-provider-stack{display:grid;gap:18px}
+#page-settings #sec-meta .cw-meta-provider-stack .cw-meta-provider-panel{margin:0;border:1px solid rgba(255,255,255,.08);border-radius:18px;background:radial-gradient(680px 180px at 0 0,rgba(124,92,255,.08),transparent 52%),linear-gradient(180deg,rgba(255,255,255,.022),rgba(255,255,255,.008));box-shadow:0 12px 24px rgba(0,0,0,.16),inset 0 1px 0 rgba(255,255,255,.02);overflow:hidden}
+#page-settings #sec-meta .cw-meta-provider-stack .cw-meta-provider-panel>.head{min-height:68px;padding:16px 18px!important;align-items:center;background:0 0;gap:12px}
+#page-settings #sec-meta .cw-meta-provider-stack .cw-meta-provider-panel>.head:hover{background:rgba(255,255,255,.025)}
+#page-settings #sec-meta .cw-meta-provider-head-copy{min-width:0;display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+#page-settings #sec-meta .cw-meta-provider-stack .cw-meta-provider-panel>.head strong{font-size:15px;line-height:1.2;letter-spacing:-.01em}
+#page-settings #sec-meta .cw-meta-provider-help{display:inline-flex;align-items:center;justify-content:center;color:rgba(185,193,230,.78);line-height:1;cursor:help}
+#page-settings #sec-meta .cw-meta-provider-help-icon{flex:0 0 auto;font-size:17px;line-height:1;color:rgba(185,193,230,.9)}
+#page-settings #sec-meta .cw-meta-provider-stack .cw-meta-provider-panel>.head .auth-dot{margin-left:auto;flex:0 0 auto}
+#page-settings #sec-meta .cw-meta-provider-stack .cw-meta-provider-panel>.body{padding:0 18px;max-height:0;overflow:hidden}
+#page-settings #sec-meta .cw-meta-provider-stack .cw-meta-provider-panel.open>.body{padding:12px 18px 18px;max-height:2200px;overflow:visible}
+#page-settings #sec-meta .cw-meta-provider-stack .cw-meta-provider-panel .cw-panel-head{margin-bottom:10px}
+#page-settings #sec-meta .cw-meta-provider-stack .cw-meta-provider-panel>.body>.cw-subtiles{margin-top:0}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping]>.body>.auth-card{margin:8px 0 0}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-head{align-items:center}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .cw-panel-head-main{min-width:0}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-card{display:grid;gap:14px}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-summary{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr) auto;gap:14px;align-items:center}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-summary>div{min-width:0}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-summary strong{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--fg)}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-inline-toggle{margin-top:6px;justify-content:flex-start}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-status-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-status{min-width:0;padding:12px;border:1px solid rgba(255,255,255,.08);border-radius:12px;background:rgba(0,0,0,.14)}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-status span{display:block;margin-bottom:5px;font-size:11px;font-weight:900;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-status strong{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:13px;color:var(--fg)}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-toggle{justify-self:end}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-actions{margin-top:0}
+#page-settings #sec-meta #anime_mapping_error:empty{display:none}
+#page-settings #sec-meta #anime_mapping_error:not(:empty){color:rgba(255,186,194,.96)}
+@media(max-width:900px){#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-summary{grid-template-columns:1fr}#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-toggle{justify-self:start}}
+@media(max-width:760px){#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-status-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
+@media(max-width:520px){#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-status-grid{grid-template-columns:1fr}#page-settings #sec-meta .cw-meta-provider-head-copy{gap:6px}}
+html[data-cw-theme=flat-dark] #page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .auth-card{background:#20242d!important;background-image:none!important;border-color:rgba(255,255,255,.13)!important;box-shadow:none!important;color:#eef1f6!important}
+html[data-cw-theme=flat-dark] #page-settings #sec-meta .cw-meta-provider-stack .cw-meta-provider-panel{background:#171a22!important;background-image:none!important;border-color:rgba(255,255,255,.13)!important;box-shadow:none!important;color:#eef1f6!important}
+html[data-cw-theme=flat-dark] #page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-status{background:#171a22!important;border-color:rgba(255,255,255,.14)!important;color:#dbe1eb!important}
+html[data-cw-theme=flat-dark] #page-settings #sec-meta .cw-meta-provider-help{color:#aeb6c6!important}
+html[data-cw-theme=flat-dark] #page-settings #sec-meta .cw-meta-provider-help-icon{color:#c6cde0!important}
+html[data-cw-theme=flat-dark] #page-settings #sec-meta #anime_mapping_error:not(:empty){color:#ffd9df!important}
+html[data-cw-theme=flat-dark] #page-settings #sec-anilist .anilist-mapping-rec{background:#20242d!important;background-image:none!important;border-color:rgba(2,169,255,.28)!important;box-shadow:none!important;color:#eef1f6!important}
+html[data-cw-theme=flat-dark] #page-settings #sec-anilist .anilist-mapping-rec-kicker{color:#9dccff!important}
+html[data-cw-theme=flat-dark] #page-settings #sec-anilist .anilist-mapping-rec-state{color:#ffe2a7!important}
+html[data-cw-theme=flat-light] #page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .auth-card{background:#fff!important;background-image:none!important;border-color:rgba(21,31,48,.14)!important;box-shadow:none!important;color:#172033!important}
+html[data-cw-theme=flat-light] #page-settings #sec-meta .cw-meta-provider-stack .cw-meta-provider-panel{background:#fff!important;background-image:none!important;border-color:rgba(21,31,48,.14)!important;box-shadow:none!important;color:#172033!important}
+html[data-cw-theme=flat-light] #page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-status{background:#f3f6fb!important;border-color:rgba(21,31,48,.14)!important;color:#344054!important}
+html[data-cw-theme=flat-light] #page-settings #sec-meta .cw-meta-provider-help{color:#667085!important}
+html[data-cw-theme=flat-light] #page-settings #sec-meta .cw-meta-provider-help-icon{color:#475467!important}
+html[data-cw-theme=flat-light] #page-settings #sec-meta #anime_mapping_error:not(:empty){color:#7f1d2d!important}
+html[data-cw-theme=flat-light] #page-settings #sec-anilist .anilist-mapping-rec{background:#f6fbff!important;background-image:none!important;border-color:rgba(2,114,174,.22)!important;box-shadow:none!important;color:#172033!important}
+html[data-cw-theme=flat-light] #page-settings #sec-anilist .anilist-mapping-rec-kicker{color:#075985!important}
+html[data-cw-theme=flat-light] #page-settings #sec-anilist .anilist-mapping-rec-state{color:#7a4a00!important}
 #conn-badges.vip-badges{--crown-size:21px!important;--rail-pad:4px!important;--vip-rail:calc(var(--crown-size) + (2*var(--rail-pad)))!important;gap:6px!important}
 #conn-badges .conn-pill{height:30px!important;padding:0 8px!important;gap:6px!important;border-radius:14px!important}
 #conn-badges .conn-text{font-size:12px!important;line-height:1!important;flex:1 1 auto!important;text-align:center!important}

--- a/assets/helpers/core.js
+++ b/assets/helpers/core.js
@@ -282,7 +282,7 @@
       if (def.paths.some((path) => hasAnyConfigValue(pathGet(cfg, path), def.keys))) set.add(def.key);
     }
 
-    if ([cfg?.tmdb_sync, cfg?.tmdb, cfg?.auth?.tmdb_sync].some(hasTmdbConfig)) set.add("TMDB");
+    if ([cfg?.tmdb_sync, cfg?.auth?.tmdb_sync].some(hasTmdbConfig)) set.add("TMDB");
     if ([cfg?.tautulli, cfg?.auth?.tautulli].some((block) => hasAnyConfigValue(block, ["api_key", "server_url", "server"]))) set.add("TAUTULLI");
 
     const crosswatch = cfg?.crosswatch || cfg?.CrossWatch || {};

--- a/assets/helpers/settings-ui.js
+++ b/assets/helpers/settings-ui.js
@@ -614,8 +614,10 @@ try {
 const META_SETTINGS_TAB_KEY = "cw.ui.metadata.tab.v1";
 const META_PROVIDER_STATE_KEY = "cw.ui.meta.provider.v1";
 const TMDB_META_SUBTAB_KEY = "cw.ui.meta.tmdb.sub.v1";
+const ANIME_MAPPING_PROVIDER = "anime-mapping";
 
 let activeMetaProvider = null;
+let animeMappingBusy = false;
 
 function cwMetaProviderUpdateChips() {
   try { cwMetaSettingsHubUpdate?.(); } catch {}
@@ -624,25 +626,15 @@ function cwMetaProviderUpdateChips() {
 function cwMetaProviderSelect(provider, opts = {}) {
   const want = provider ? String(provider).toLowerCase() : null;
 
-  const tilesHost = document.getElementById("meta_provider_tiles");
   const panelHost = document.getElementById("meta-provider-panel");
-  if (!tilesHost || !panelHost) return;
-
-  const tiles = tilesHost.querySelectorAll("[data-provider]");
-  tiles.forEach((btn) => {
-    const k = String(btn.dataset.provider || "").toLowerCase();
-    const on = !!(want && k === want);
-    btn.classList.toggle("active", on);
-    btn.setAttribute("aria-selected", on ? "true" : "false");
-  });
+  if (!panelHost) return;
 
   activeMetaProvider = want;
-  panelHost.classList.toggle("hidden", !want);
+  panelHost.classList.remove("hidden");
 
   const panels = panelHost.querySelectorAll(".cw-meta-provider-panel");
   panels.forEach((p) => {
-    const k = String(p.dataset.provider || "").toLowerCase();
-    p.classList.toggle("active", !!(want && k === want));
+    p.classList.add("active");
   });
 
   if (opts.persist !== false) {
@@ -677,22 +669,12 @@ function cwMetaProviderInit() {
 }
 
 function cwMetaProviderEnsure() {
-  const tilesHost = document.getElementById("meta_provider_tiles");
   const panelHost = document.getElementById("meta-provider-panel");
-  if (!tilesHost || !panelHost) return;
-
-  tilesHost.querySelectorAll("[data-provider]").forEach((btn) => {
-    if (btn.__cwMetaWired) return;
-    btn.addEventListener("click", () => {
-      const want = String(btn.dataset.provider || "").toLowerCase();
-      if (want && activeMetaProvider === want) cwMetaProviderSelect(null);
-      else cwMetaProviderSelect(btn.dataset.provider || null);
-    });
-    btn.__cwMetaWired = true;
-  });
+  if (!panelHost) return;
 
   if (!panelHost.dataset.__cwMetaBuilt) {
     try { cwBuildTmdbPanel(); } catch {}
+    try { cwBuildAnimeMappingPanel(); } catch {}
     panelHost.dataset.__cwMetaBuilt = "1";
   }
 
@@ -706,6 +688,255 @@ function cwMetaProviderEnsure() {
 
   try { cwMetaProviderInit(); } catch {}
   try { cwMetaProviderUpdateChips(); } catch {}
+  try { cwAnimeMappingRefreshStatus(); } catch {}
+}
+
+function _cwSetText(id, value) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = String(value ?? "");
+}
+
+function _cwSetChecked(id, value) {
+  const el = document.getElementById(id);
+  if (el) el.checked = !!value;
+}
+
+function _cwFormatUtc(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return "-";
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return raw;
+  return d.toISOString().replace("T", " ").slice(0, 16) + " UTC";
+}
+
+function _cwAnimeMappingUseForLabel() {
+  const cfg = window._cfgCache || {};
+  const block = cfg.anime_mapping || {};
+  const raw = Array.isArray(block.use_for_pairs) ? block.use_for_pairs : ["anilist"];
+  const vals = raw.map((x) => String(x || "").trim().toLowerCase()).filter(Boolean);
+  if (!vals.length || vals.includes("anilist")) return "AniList pairs";
+  return vals.map((x) => x.toUpperCase()).join(", ");
+}
+
+function _cwAnimeMappingSetBusy(on, label = "") {
+  animeMappingBusy = !!on;
+  ["anime_mapping_enabled", "anime_mapping_auto_update", "btn-anime-mapping-update", "btn-anime-mapping-rebuild"].forEach((id) => {
+    const el = document.getElementById(id);
+    if (el) el.disabled = !!on;
+  });
+  if (on) {
+    _cwSetText("anime_mapping_dataset", label || "Updating");
+  }
+}
+
+function cwAnimeMappingRenderStatus(st = {}) {
+  const cfg = window._cfgCache || {};
+  const block = cfg.anime_mapping || {};
+  const err = String(st.error || st.message || "").trim();
+  const installed = !!st.installed;
+  const ready = !!st.index_ready;
+  const enabled = st.enabled !== undefined ? !!st.enabled : !!block.enabled;
+  const autoUpdate = st.auto_update !== undefined ? !!st.auto_update : block.auto_update !== false;
+  const dataset = err ? "Error" : (animeMappingBusy ? "Updating" : (installed ? "Installed" : "Missing"));
+  const index = ready ? "Ready" : "Missing";
+
+  _cwSetChecked("anime_mapping_enabled", enabled);
+  _cwSetChecked("anime_mapping_auto_update", autoUpdate);
+  _cwSetText("anime_mapping_used_for", _cwAnimeMappingUseForLabel());
+  _cwSetText("anime_mapping_auto_update_state", autoUpdate ? "Daily" : "Manual");
+  _cwSetText("anime_mapping_dataset", dataset);
+  _cwSetText("anime_mapping_generated", _cwFormatUtc(st.dataset_generated_on));
+  _cwSetText("anime_mapping_index", index);
+  _cwSetText("anime_mapping_counts", installed ? `${Number(st.source_count || 0).toLocaleString()} sources | ${Number(st.edge_count || 0).toLocaleString()} edges` : "-");
+  _cwSetText("anime_mapping_error", err);
+
+  const dot = document.getElementById("anime-mapping-dot");
+  if (dot) {
+    dot.classList.toggle("on", !!(enabled && installed && ready && !err));
+    dot.classList.toggle("off", !!(!enabled || !installed || !ready || err));
+  }
+}
+
+async function cwAnimeMappingRefreshStatus() {
+  try {
+    const r = await fetch("/api/anime-mapping/status", { cache: "no-store", credentials: "same-origin" });
+    if (!r.ok) throw new Error(`GET /api/anime-mapping/status ${r.status}`);
+    const st = await r.json();
+    window.__animeMappingStatus = st || {};
+    cwAnimeMappingRenderStatus(st || {});
+    return st;
+  } catch (e) {
+    cwAnimeMappingRenderStatus({ error: e?.message || "Status failed" });
+    return null;
+  }
+}
+
+async function cwAnimeMappingSaveSettings() {
+  const enabled = !!document.getElementById("anime_mapping_enabled")?.checked;
+  const autoUpdate = !!document.getElementById("anime_mapping_auto_update")?.checked;
+  const st0 = window.__animeMappingStatus || {};
+  const needsBootstrap = enabled && !(st0.installed && st0.index_ready);
+  _cwAnimeMappingSetBusy(true, needsBootstrap ? "Downloading" : "Saving");
+  try {
+    const r = await fetch("/api/anime-mapping/settings", {
+      method: "POST",
+      cache: "no-store",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        enabled,
+        auto_update: autoUpdate,
+        provider: "anibridge",
+        use_for_pairs: ["anilist"],
+      }),
+    });
+    const data = await r.json().catch(() => ({}));
+    if (!r.ok || data.ok === false) throw new Error(data.message || data.error || `Settings failed (${r.status})`);
+    window._cfgCache ||= {};
+    window._cfgCache.anime_mapping = data.anime_mapping || {
+      ...(window._cfgCache.anime_mapping || {}),
+      enabled,
+      auto_update: autoUpdate,
+      provider: "anibridge",
+      use_for_pairs: ["anilist"],
+    };
+    if (data.status) window.__animeMappingStatus = data.status;
+    cwAnimeMappingRenderStatus(data.status || window.__animeMappingStatus || {});
+    if (data.bootstrap_error) throw new Error(data.bootstrap_error);
+    try { window.CW?.DOM?.showToast?.(needsBootstrap ? "Anime mapping enabled and downloaded" : "Anime ID Mapping saved", true); } catch {}
+  } catch (e) {
+    cwAnimeMappingRenderStatus({ ...(window.__animeMappingStatus || {}), error: e?.message || "Save failed" });
+    try { window.CW?.DOM?.showToast?.(e?.message || "Anime ID Mapping save failed", false); } catch {}
+  } finally {
+    _cwAnimeMappingSetBusy(false);
+    try { await cwAnimeMappingRefreshStatus(); } catch {}
+  }
+}
+
+async function cwAnimeMappingRun(action) {
+  const update = action === "update";
+  _cwAnimeMappingSetBusy(true, update ? "Updating" : "Rebuilding");
+  try {
+    const r = await fetch(update ? "/api/anime-mapping/update" : "/api/anime-mapping/rebuild-index", {
+      method: "POST",
+      cache: "no-store",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(update ? { force: false } : {}),
+    });
+    const data = await r.json().catch(() => ({}));
+    if (!r.ok || data.ok === false) throw new Error(data.message || data.error || `${update ? "Update" : "Rebuild"} failed (${r.status})`);
+    cwAnimeMappingRenderStatus(data.status || data || {});
+    try { window.CW?.DOM?.showToast?.(update ? "Anime mapping updated" : "Anime mapping index rebuilt", true); } catch {}
+  } catch (e) {
+    cwAnimeMappingRenderStatus({ ...(window.__animeMappingStatus || {}), error: e?.message || "Action failed" });
+    try { window.CW?.DOM?.showToast?.(e?.message || "Anime mapping action failed", false); } catch {}
+  } finally {
+    _cwAnimeMappingSetBusy(false);
+    try { await cwAnimeMappingRefreshStatus(); } catch {}
+  }
+}
+
+function cwBuildAnimeMappingPanel() {
+  const panelHost = document.getElementById("meta-provider-panel");
+  if (!panelHost) return;
+  if (panelHost.querySelector(`.cw-meta-provider-panel[data-provider="${ANIME_MAPPING_PROVIDER}"]`)) return;
+
+  const wrap = document.createElement("div");
+  wrap.className = "section cw-settings-section cw-settings-provider-section cw-meta-provider-panel active";
+  wrap.id = "sec-meta-anime-mapping";
+  wrap.dataset.provider = ANIME_MAPPING_PROVIDER;
+  wrap.innerHTML = `
+    <div class="head" data-toggle-section="sec-meta-anime-mapping">
+      <span class="chev"></span>
+      <div class="cw-meta-provider-head-copy">
+        <strong>Anime ID Mapping</strong>
+        <span class="cw-meta-provider-help" title="Only needed for anime-specific providers such as AniList." aria-label="Only needed for anime-specific providers such as AniList.">
+          <span class="material-symbols-rounded cw-meta-provider-help-icon" aria-hidden="true">info</span>
+        </span>
+      </div>
+      <span class="auth-dot" id="anime-mapping-dot" aria-hidden="true"></span>
+    </div>
+    <div class="body">
+    <div class="cw-panel-head anime-mapping-head">
+      <div class="cw-panel-head-main">
+        <div class="cw-panel-title">Anime ID Mapping</div>
+        <div class="muted">Local anime ID index for AniList watchlist pairs.</div>
+      </div>
+      <label class="cx-toggle anime-mapping-toggle">
+        <input type="checkbox" id="anime_mapping_enabled">
+        <span class="cx-toggle-ui" aria-hidden="true"></span>
+        <span class="cx-toggle-text">Enable</span>
+        <span class="cx-toggle-state" aria-hidden="true"></span>
+      </label>
+    </div>
+    <div class="auth-card anime-mapping-card">
+      <div class="anime-mapping-summary">
+        <div>
+          <div class="muted">Used for</div>
+          <strong id="anime_mapping_used_for">AniList pairs</strong>
+        </div>
+        <div>
+          <div class="muted">Auto-update</div>
+          <label class="cx-toggle anime-mapping-inline-toggle">
+            <input type="checkbox" id="anime_mapping_auto_update">
+            <span class="cx-toggle-ui" aria-hidden="true"></span>
+            <span class="cx-toggle-text" id="anime_mapping_auto_update_state">Daily</span>
+            <span class="cx-toggle-state" aria-hidden="true"></span>
+          </label>
+        </div>
+      </div>
+      <div class="anime-mapping-status-grid">
+        <div class="anime-mapping-status">
+          <span>Dataset</span>
+          <strong id="anime_mapping_dataset">-</strong>
+        </div>
+        <div class="anime-mapping-status">
+          <span>Index</span>
+          <strong id="anime_mapping_index">-</strong>
+        </div>
+        <div class="anime-mapping-status">
+          <span>Generated</span>
+          <strong class="mono" id="anime_mapping_generated">-</strong>
+        </div>
+        <div class="anime-mapping-status">
+          <span>Size</span>
+          <strong id="anime_mapping_counts">-</strong>
+        </div>
+      </div>
+      <div class="auth-card-notes" id="anime_mapping_error"></div>
+      <div class="cw-settings-inline-action anime-mapping-actions">
+        <button class="btn primary" type="button" id="btn-anime-mapping-update">Update now</button>
+        <button class="btn" type="button" id="btn-anime-mapping-rebuild">Rebuild index</button>
+      </div>
+    </div>
+    </div>
+  `;
+
+  panelHost.appendChild(wrap);
+
+  const enabled = document.getElementById("anime_mapping_enabled");
+  const autoUpdate = document.getElementById("anime_mapping_auto_update");
+  const btnUpdate = document.getElementById("btn-anime-mapping-update");
+  const btnRebuild = document.getElementById("btn-anime-mapping-rebuild");
+  if (enabled && !enabled.__cwAnimeWired) {
+    enabled.addEventListener("change", () => cwAnimeMappingSaveSettings());
+    enabled.__cwAnimeWired = true;
+  }
+  if (autoUpdate && !autoUpdate.__cwAnimeWired) {
+    autoUpdate.addEventListener("change", () => cwAnimeMappingSaveSettings());
+    autoUpdate.__cwAnimeWired = true;
+  }
+  if (btnUpdate && !btnUpdate.__cwAnimeWired) {
+    btnUpdate.addEventListener("click", () => cwAnimeMappingRun("update"));
+    btnUpdate.__cwAnimeWired = true;
+  }
+  if (btnRebuild && !btnRebuild.__cwAnimeWired) {
+    btnRebuild.addEventListener("click", () => cwAnimeMappingRun("rebuild"));
+    btnRebuild.__cwAnimeWired = true;
+  }
+
+  try { cwAnimeMappingRenderStatus(window.__animeMappingStatus || {}); } catch {}
 }
 
 function cwBuildTmdbPanel() {
@@ -715,8 +946,26 @@ function cwBuildTmdbPanel() {
   if (panelHost.querySelector('.cw-meta-provider-panel[data-provider="tmdb"]')) return;
 
   const wrap = document.createElement("div");
-  wrap.className = "cw-meta-provider-panel";
+  wrap.className = "section cw-settings-section cw-settings-provider-section cw-meta-provider-panel active";
+  wrap.id = "sec-meta-tmdb";
   wrap.dataset.provider = "tmdb";
+
+  const sectionHead = document.createElement("div");
+  sectionHead.className = "head";
+  sectionHead.dataset.toggleSection = "sec-meta-tmdb";
+  sectionHead.innerHTML = `
+    <span class="chev"></span>
+    <div class="cw-meta-provider-head-copy">
+      <strong>TMDb</strong>
+      <span class="cw-meta-provider-help" title="Highly recommended for matching, metadata and images." aria-label="Highly recommended for matching, metadata and images.">
+        <span class="material-symbols-rounded cw-meta-provider-help-icon" aria-hidden="true">info</span>
+      </span>
+    </div>
+    <span class="auth-dot" id="meta-tmdb-dot" aria-hidden="true"></span>
+  `;
+
+  const sectionBody = document.createElement("div");
+  sectionBody.className = "body";
 
   const head = document.createElement("div");
   head.className = "cw-panel-head";
@@ -833,9 +1082,11 @@ function cwBuildTmdbPanel() {
   subPanels.appendChild(pApi);
   subPanels.appendChild(pAdv);
 
-  wrap.appendChild(head);
-  wrap.appendChild(subTiles);
-  wrap.appendChild(subPanels);
+  sectionBody.appendChild(head);
+  sectionBody.appendChild(subTiles);
+  sectionBody.appendChild(subPanels);
+  wrap.appendChild(sectionHead);
+  wrap.appendChild(sectionBody);
 
   panelHost.appendChild(wrap);
 
@@ -874,11 +1125,11 @@ function cwMetaSettingsSelect(tab, opts = {}) {
     try { localStorage.setItem(META_SETTINGS_TAB_KEY, want); } catch {}
   }
   try { cwMetaSettingsHubUpdate(); } catch {}
+  try { cwAnimeMappingRefreshStatus(); } catch {}
 }
 
 function cwMetaSettingsHubUpdate() {
   const chip = document.getElementById("hub_tmdb_key");
-  if (!chip) return;
 
   const cfg = window._cfgCache || {};
   const cfgKey = String(cfg?.tmdb?.api_key || "").trim();
@@ -899,7 +1150,17 @@ function cwMetaSettingsHubUpdate() {
   }
 
   const hasKeyNow = uiHasKey || (!uiTouched && cfgHasKey);
-  chip.textContent = `API key: ${hasKeyNow ? "set" : "missing"}`;
+  if (chip) chip.textContent = `API key: ${hasKeyNow ? "set" : "missing"}`;
+
+  const dot = document.getElementById("meta-tmdb-dot");
+  if (dot) {
+    dot.classList.toggle("on", hasKeyNow);
+    dot.title = hasKeyNow ? "Configured" : "Not configured";
+    dot.setAttribute("aria-label", dot.title);
+    dot.closest?.('.cw-meta-provider-panel[data-provider="tmdb"]')?.classList?.toggle("is-configured", hasKeyNow);
+  }
+
+  try { window.syncMetadataProviderDot?.(); } catch {}
 }
 
 function cwMetaSettingsHubInit() {
@@ -1423,6 +1684,11 @@ function setTraktSuccess(show) {
     cwMetaProviderSubSelect,
     cwMetaProviderInit,
     cwMetaProviderEnsure,
+    cwBuildAnimeMappingPanel,
+    cwAnimeMappingRenderStatus,
+    cwAnimeMappingRefreshStatus,
+    cwAnimeMappingSaveSettings,
+    cwAnimeMappingRun,
     cwBuildTmdbPanel,
     cwMetaSettingsSelect,
     cwMetaSettingsHubUpdate,

--- a/assets/js/connections.overlay.js
+++ b/assets/js/connections.overlay.js
@@ -28,7 +28,7 @@
     const css = `
 #providers_list{display:block!important;width:100%!important;scrollbar-gutter:stable;overscroll-behavior:contain}
 #providers_list .providers-board{display:grid!important;width:100%!important;grid-template-columns:repeat(auto-fit,minmax(240px,1fr))!important;gap:14px!important;align-items:start!important;justify-content:start!important}
-#providers_list .prov-card{position:relative;min-height:124px;padding:14px 14px 16px;border-radius:22px;background:linear-gradient(180deg,rgba(8,10,18,.96),rgba(5,7,14,.94));isolation:isolate;overflow:hidden}
+#providers_list .prov-card{position:relative;height:124px;min-height:124px;padding:14px 14px 16px;border-radius:22px;background:linear-gradient(180deg,rgba(8,10,18,.96),rgba(5,7,14,.94));isolation:isolate;overflow:hidden}
 #providers_list .prov-card::before{content:"";position:absolute;inset:8px;pointer-events:none;border-radius:18px;border:1px solid rgba(255,255,255,.10);opacity:.7}
 #providers_list .prov-card::after{content:"";position:absolute;inset:-30% 20% auto -10%;height:70%;pointer-events:none;background:linear-gradient(135deg,rgba(255,255,255,.10),transparent 55%);opacity:.28;transform:rotate(-12deg)}
 #providers_list .prov-card > *{position:relative;z-index:1}
@@ -45,8 +45,9 @@
 #providers_list .prov-card.brand-publicmetadb .prov-watermark::after{width:176%;height:206%;transform:translate(-50%,-50%) scale(1.08);opacity:.22}
 #providers_list .prov-card.brand-tmdb-sync .prov-watermark::after{width:174%;height:124%;transform:translate(-50%,-50%) scale(1.14)}
 #providers_list .prov-card.brand-tautulli .prov-watermark::after{width:160%;height:188%;transform:translate(-50%,-50%) scale(1.2)}
-#providers_list .prov-main{display:flex;flex-direction:column;align-items:flex-start;justify-content:space-between;min-height:92px;gap:10px}
-#providers_list .prov-title{font-size:1rem;font-weight:900;line-height:1.08;letter-spacing:.04em;text-transform:uppercase;color:#f6f7fb;text-shadow:0 1px 0 rgba(0,0,0,.35)}
+#providers_list .prov-main{display:flex;flex-direction:column;align-items:flex-start;justify-content:space-between;height:100%;min-height:0;gap:10px}
+#providers_list .prov-title{max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:1rem;font-weight:900;line-height:1.08;letter-spacing:.04em;text-transform:uppercase;color:#f6f7fb;text-shadow:0 1px 0 rgba(0,0,0,.35)}
+#providers_list .prov-card.is-source .prov-title,#providers_list .prov-card.is-target .prov-title{max-width:calc(100% - 134px)}
 #providers_list .prov-features{display:inline-flex;align-items:center;gap:8px;padding:0;margin:0}
 #providers_list .prov-dot{width:11px;height:11px;border-radius:999px;display:inline-block;background:rgba(255,255,255,.18);box-shadow:inset 0 0 0 2px rgba(255,255,255,.14)}
 #providers_list .prov-dot.on{box-shadow:none}
@@ -55,14 +56,14 @@
 #providers_list .prov-dot.hi.on{background:#2de2ff;box-shadow:0 0 8px rgba(45,226,255,.95),0 0 18px rgba(45,226,255,.42)}
 #providers_list .prov-dot.pr.on{background:#a78bfa;box-shadow:0 0 8px rgba(167,139,250,.95),0 0 18px rgba(167,139,250,.42)}
 #providers_list .prov-dot.pl.on{background:#ff00e5;box-shadow:0 0 8px rgba(255,0,229,.95),0 0 18px rgba(255,0,229,.42)}
-#providers_list .prov-actions{display:flex;gap:6px;flex-wrap:wrap;align-items:center}
+#providers_list .prov-actions{display:flex;gap:6px;flex-wrap:wrap;align-items:center;width:100%;min-height:36px}
 #providers_list .prov-btn{appearance:none;-webkit-appearance:none;display:inline-flex;align-items:center;justify-content:center;min-width:118px;min-height:36px;padding:7px 12px;white-space:nowrap;border-radius:14px;border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(12,14,30,.96),rgba(7,8,20,.96));color:#f3f5fb;font-size:.86rem;font-weight:850;letter-spacing:.01em;cursor:pointer;box-shadow:0 8px 18px rgba(0,0,0,.28),inset 0 1px 0 rgba(255,255,255,.06);transition:transform .14s ease,box-shadow .18s ease,border-color .18s ease,background .18s ease}
 #providers_list .prov-btn:hover{transform:translateY(-1px);box-shadow:0 14px 28px rgba(0,0,0,.38),inset 0 1px 0 rgba(255,255,255,.10)}
 #providers_list .prov-btn:active{transform:translateY(0)}
 #providers_list .prov-btn.target{border-color:rgba(255,255,255,.22);background:linear-gradient(180deg,rgba(18,21,38,.98),rgba(8,10,22,.98))}
 #providers_list .prov-btn.selected{border-color:rgba(255,255,255,.24);background:linear-gradient(180deg,rgba(19,24,40,.98),rgba(10,13,26,.98))}
-#providers_list .prov-badge{display:inline-flex;align-items:center;gap:6px;min-height:32px;padding:5px 9px;max-width:100%;white-space:nowrap;border-radius:999px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.05);font-weight:800;font-size:.64rem;letter-spacing:.08em;text-transform:uppercase;color:#eef2ff}
-#providers_list .prov-badge::before{content:"";width:7px;height:7px;border-radius:999px;background:currentColor;opacity:.9}
+#providers_list .prov-badge{position:absolute;top:0;right:0;display:inline-flex;align-items:center;gap:6px;height:24px;min-height:24px;max-width:124px;padding:4px 8px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;border-radius:999px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.05);font-weight:800;font-size:.58rem;line-height:1;letter-spacing:.08em;text-transform:uppercase;color:#eef2ff}
+#providers_list .prov-badge::before{content:"";flex:0 0 7px;width:7px;height:7px;border-radius:999px;background:currentColor;opacity:.9}
 #providers_list .prov-card.is-source .prov-badge{color:#7c5cff;box-shadow:0 0 16px rgba(124,92,255,.22)}
 #providers_list .prov-card.is-target .prov-badge{color:#19c37d;box-shadow:0 0 16px rgba(25,195,125,.18)}
 #providers_list .prov-empty{padding:14px 0;color:var(--muted,#9aa4b2)}

--- a/assets/js/insights.js
+++ b/assets/js/insights.js
@@ -119,7 +119,7 @@
     d.head.appendChild(s);
     const s2 = d.createElement("style");
     s2.id = "insights-provider-styles-v8-mse";
-    s2.textContent = `#stats-card #stat-providers .tile .mse{display:inline-flex!important;flex-direction:column!important;align-items:center!important;justify-content:center!important;gap:1px!important}html.cw-compact #stats-card #stat-providers .tile .mse{flex-direction:column!important}#stats-card #stat-providers .tile .mse .mse-row{display:inline-flex;align-items:center;justify-content:center;gap:2px;width:max-content}#stats-card #stat-providers .tile .mse .mse-row-anime{margin-top:-1px}#stats-card #stat-providers .tile .mse .mse-chip{gap:1px;padding:2px 5px}#stats-card #stat-providers .tile .mse .mse-chip .k{display:inline-flex;align-items:center;justify-content:center;min-width:1ch}#stats-card #stat-providers .tile .mse .mse-chip-anime{padding-inline:4px}`;
+    s2.textContent = `#stats-card #stat-providers .tile .mse{display:inline-flex!important;flex-direction:row!important;align-items:center!important;justify-content:center!important;gap:2px!important}html.cw-compact #stats-card #stat-providers .tile .mse{flex-direction:row!important}#stats-card #stat-providers .tile .mse .mse-row{display:inline-flex;align-items:center;justify-content:center;gap:2px;width:max-content}#stats-card #stat-providers .tile .mse .mse-chip{gap:1px;padding:2px 5px}#stats-card #stat-providers .tile .mse .mse-chip .k{display:inline-flex;align-items:center;justify-content:center;min-width:1ch}#stats-card #stat-providers .tile .mse .mse-chip-anime{padding-inline:4px}`;
     d.head.appendChild(s2);
     const s3 = d.createElement("style");
     s3.id = "insights-provider-styles-v8-segmented";
@@ -504,14 +504,15 @@ html[data-cw-theme="flat-light"] #insights-switch .ins-gear:hover{
         tile.title = prov === "crosswatch" ? `${label} • ${total} • Click to switch snapshot` : `${label} • ${total}`;
       } else {
         const m = +per.movies || 0, s = +per.shows || 0, a = +per.anime || 0;
-        const mainParts = [["M", m], ["S", s]].filter(([, v]) => v).map(([k, v]) => `<span class="mse-chip"><span class="k">${k}</span><span class="v">${v}</span></span>`);
-        const animePart = a ? `<span class="mse-chip mse-chip-anime"><span class="k">A</span><span class="v">${a}</span></span>` : "";
-        if (!mainParts.length && !animePart) {
+        const parts = [["M", m, ""], ["S", s, ""], ["A", a, " mse-chip-anime"]]
+          .filter(([, v]) => v)
+          .map(([k, v, cls]) => `<span class="mse-chip${cls}"><span class="k">${k}</span><span class="v">${v}</span></span>`);
+        if (!parts.length) {
           info.textContent = "";
           info.style.display = "none";
           tile.title = `${label} • ${total}`;
         } else {
-          info.innerHTML = `<span class="mse-row mse-row-main">${mainParts.join("")}</span>${animePart ? `<span class="mse-row mse-row-anime">${animePart}</span>` : ""}`;
+          info.innerHTML = `<span class="mse-row">${parts.join("")}</span>`;
           info.style.display = "";
           fitProviderMSE(info);
           tile.title = `${label} • ${total} • Movies ${m} • Shows ${s} • Anime ${a}`;

--- a/assets/js/main-status.js
+++ b/assets/js/main-status.js
@@ -82,8 +82,8 @@
   function syncMetadataProviderDot() {
     const chip = $("hub_tmdb_key");
     const dot = $("meta-tmdb-dot");
-    const tile = dot?.closest?.(".cw-hub-tile.tmdb");
-    if (!chip || !dot || !tile) return false;
+    const panel = dot?.closest?.('.cw-meta-provider-panel[data-provider="tmdb"]') || dot?.closest?.(".cw-hub-tile.tmdb");
+    if (!dot) return false;
 
     const cfg = getCachedConfig();
     const cfgKey = txt(cfg?.tmdb?.api_key);
@@ -98,13 +98,13 @@
       if (touched) uiHas = v.length > 0 || mask(v);
     }
 
-    const raw = txt(chip.textContent).toLowerCase();
+    const raw = txt(chip?.textContent).toLowerCase();
     const chipHas = /\bset\b/.test(raw) && !/\bmissing\b|\bnot set\b|\bunset\b|\bempty\b|—/.test(raw);
     const on = uiHas || (!touched && (cfgHas || chipHas));
     dot.classList.toggle("on", on);
     dot.title = on ? "Configured" : "Not configured";
     dot.setAttribute("aria-label", dot.title);
-    tile.classList.toggle("is-configured", on);
+    panel?.classList?.toggle("is-configured", on);
     return true;
   }
 
@@ -308,7 +308,7 @@
   function init() {
     bindStatusButton();
     observe("auth-providers", "auth", 200, () => refreshAuthDots(true).catch(() => {}).finally(renderProviders), { childList: true, subtree: true });
-    observe("hub_tmdb_key", "meta", 0, syncMetadataProviderDot, { childList: true, characterData: true, subtree: true });
+    observe("meta-tmdb-dot", "meta", 0, syncMetadataProviderDot, { childList: true, characterData: true, subtree: true });
     renderCachedProviders();
     let tries = 0;
     (function retry() {

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -702,8 +702,23 @@ async def _lifespan(app: Any) -> AsyncIterator[None]:
         except Exception:
             pass
     try:
+        from cw_platform.anime_mapping.auto_update import refresh_from_config as _anime_mapping_refresh_auto_update
+
+        _anime_mapping_refresh_auto_update(load_config)
+    except Exception as e:
+        try:
+            _UIHostLogger("SYNC")(f"anime mapping auto-update startup error: {e}", level="ERROR")
+        except Exception:
+            pass
+    try:
         yield
     finally:
+        try:
+            from cw_platform.anime_mapping.auto_update import stop as _anime_mapping_stop_auto_update
+
+            _anime_mapping_stop_auto_update()
+        except Exception:
+            pass
         try:
             from providers.scrobble.watch_manager import stop_all as _wm_stop
             _wm_stop(app)

--- a/cw_platform/anime_mapping/__init__.py
+++ b/cw_platform/anime_mapping/__init__.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from .service import (
+    AnimeMappingService,
+    enrich_index_for_pair,
+    enrich_item,
+    mapping_enabled_for_feature,
+    mapping_enabled_for_pair,
+)
+
+__all__ = [
+    "AnimeMappingService",
+    "enrich_index_for_pair",
+    "enrich_item",
+    "mapping_enabled_for_feature",
+    "mapping_enabled_for_pair",
+]

--- a/cw_platform/anime_mapping/auto_update.py
+++ b/cw_platform/anime_mapping/auto_update.py
@@ -1,0 +1,200 @@
+# /cw_platform/anime_mapping/auto_update.py
+# CrossWatch - Automatic Anime Mapping Updater
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from _logging import log
+
+from .updater import status as mapping_status, update as mapping_update
+
+MIN_REFRESH_SECONDS = 3600
+MAX_SLEEP_SECONDS = 600
+
+
+class AnimeMappingAutoUpdater:
+    def __init__(self, load_config: Callable[[], dict[str, Any]]) -> None:
+        self.load_config = load_config
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+        self._poke = threading.Event()
+        self._lock = threading.Lock()
+        self._status: dict[str, Any] = {
+            "running": False,
+            "enabled": False,
+            "last_check_at": 0,
+            "last_update_at": 0,
+            "next_check_at": 0,
+            "last_error": "",
+        }
+
+    def start(self) -> None:
+        with self._lock:
+            if self._thread and self._thread.is_alive():
+                self._poke.set()
+                return
+            self._stop.clear()
+            self._poke.clear()
+            self._thread = threading.Thread(target=self._loop, name="AnimeMappingAutoUpdater", daemon=True)
+            self._thread.start()
+        log("auto_update_thread_started", level="debug", module="ANIME_MAPPING")
+
+    def stop(self) -> None:
+        thread = self._thread
+        if not thread or not thread.is_alive():
+            self._thread = None
+            with self._lock:
+                self._status["running"] = False
+                self._status["next_check_at"] = 0
+            return
+        self._stop.set()
+        self._poke.set()
+        thread.join(timeout=3.0)
+        if self._thread is thread:
+            self._thread = None
+        log("auto_update_thread_stopped", level="debug", module="ANIME_MAPPING")
+
+    def refresh(self) -> None:
+        self._poke.set()
+        self.start()
+
+    def status(self) -> dict[str, Any]:
+        with self._lock:
+            return dict(self._status)
+
+    def _cfg(self) -> tuple[dict[str, Any], dict[str, Any]]:
+        cfg = self.load_config() or {}
+        block = cfg.get("anime_mapping") if isinstance(cfg, Mapping) else {}
+        return cfg, dict(block or {}) if isinstance(block, Mapping) else {}
+
+    def _enabled(self, block: Mapping[str, Any]) -> bool:
+        return bool(block.get("enabled", False)) and bool(block.get("auto_update", True))
+
+    def _interval_seconds(self, block: Mapping[str, Any]) -> int:
+        try:
+            hours = int(block.get("refresh_hours", 24) or 24)
+        except Exception:
+            hours = 24
+        return max(MIN_REFRESH_SECONDS, hours * 3600)
+
+    def _set_status(self, **patch: Any) -> None:
+        with self._lock:
+            self._status.update(patch)
+
+    def _loop(self) -> None:
+        self._set_status(running=True)
+        try:
+            while not self._stop.is_set():
+                now = int(time.time())
+                try:
+                    cfg, block = self._cfg()
+                    enabled = self._enabled(block)
+                    tag = str(block.get("release_tag") or "v3").strip() or "v3"
+                    interval = self._interval_seconds(block)
+
+                    if not enabled:
+                        self._set_status(enabled=False, next_check_at=0, last_error="")
+                        self._sleep(60.0)
+                        continue
+
+                    st = mapping_status(cfg=cfg)
+                    last_checked = int(st.get("last_checked_at") or 0)
+                    installed = bool(st.get("installed") and st.get("index_ready"))
+                    due_at = 0 if not last_checked or not installed else last_checked + interval
+
+                    self._set_status(enabled=True, last_check_at=last_checked, next_check_at=due_at)
+
+                    if due_at and now < due_at:
+                        log("auto_update_waiting", level="debug", module="ANIME_MAPPING", extra={"release_tag": tag, "next_check_at": due_at})
+                        self._sleep(min(MAX_SLEEP_SECONDS, max(1, due_at - now)))
+                        continue
+
+                    log(
+                        "auto_update_started",
+                        level="debug",
+                        module="ANIME_MAPPING",
+                        extra={
+                            "release_tag": tag,
+                            "reason": "missing_index" if not installed else "interval_due",
+                        },
+                    )
+                    res = mapping_update(release_tag=tag, force=False)
+                    next_check = int(time.time()) + interval
+                    self._set_status(
+                        last_check_at=int(time.time()),
+                        last_update_at=int(time.time()) if bool(res.get("updated")) else int(st.get("last_updated_at") or 0),
+                        next_check_at=next_check,
+                        last_error="",
+                    )
+                    log(
+                        "auto_update_finished",
+                        level="debug",
+                        module="ANIME_MAPPING",
+                        extra={
+                            "release_tag": tag,
+                            "updated": bool(res.get("updated")),
+                            "next_check_at": next_check,
+                        },
+                    )
+                except Exception as exc:
+                    self._set_status(last_error=str(exc), next_check_at=int(time.time()) + MAX_SLEEP_SECONDS)
+                    log(
+                        "auto_update_failed",
+                        level="error",
+                        module="ANIME_MAPPING",
+                        extra={"error_type": exc.__class__.__name__, "error": str(exc)},
+                    )
+                    self._sleep(MAX_SLEEP_SECONDS)
+                    continue
+
+                self._sleep(min(MAX_SLEEP_SECONDS, self._interval_seconds(block)))
+        finally:
+            self._set_status(running=False)
+
+    def _sleep(self, seconds: float) -> None:
+        if seconds <= 0:
+            return
+        self._poke.wait(timeout=seconds)
+        self._poke.clear()
+
+
+_WORKER: AnimeMappingAutoUpdater | None = None
+_WORKER_LOCK = threading.Lock()
+
+
+def configure(load_config: Callable[[], dict[str, Any]]) -> AnimeMappingAutoUpdater:
+    global _WORKER
+    with _WORKER_LOCK:
+        if _WORKER is None:
+            _WORKER = AnimeMappingAutoUpdater(load_config)
+        else:
+            _WORKER.load_config = load_config
+        return _WORKER
+
+
+def refresh_from_config(load_config: Callable[[], dict[str, Any]]) -> None:
+    worker = configure(load_config)
+    cfg = load_config() or {}
+    block = cfg.get("anime_mapping") if isinstance(cfg, Mapping) else {}
+    enabled = bool((block or {}).get("enabled", False)) and bool((block or {}).get("auto_update", True)) if isinstance(block, Mapping) else False
+    if enabled:
+        worker.refresh()
+    else:
+        worker.stop()
+
+
+def stop() -> None:
+    with _WORKER_LOCK:
+        worker = _WORKER
+    if worker is not None:
+        worker.stop()
+
+
+def status() -> dict[str, Any]:
+    with _WORKER_LOCK:
+        worker = _WORKER
+    return worker.status() if worker is not None else {"running": False, "enabled": False, "next_check_at": 0}

--- a/cw_platform/anime_mapping/descriptors.py
+++ b/cw_platform/anime_mapping/descriptors.py
@@ -1,0 +1,70 @@
+# /cw_platform/anime_mapping/descriptors.py
+# CrossWatch - Anime Mapping Descriptor Utilities
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Descriptor:
+    raw: str
+    provider: str
+    id: str
+    scope: str = ""
+    media_kind: str = ""
+
+
+_PROVIDER_ALIASES: dict[str, tuple[str, str]] = {
+    "anilist": ("anilist", ""),
+    "mal": ("mal", ""),
+    "anidb": ("anidb", ""),
+    "tmdb_show": ("tmdb", "show"),
+    "tmdb_movie": ("tmdb", "movie"),
+    "tvdb_show": ("tvdb", "show"),
+    "tvdb_movie": ("tvdb", "movie"),
+    "imdb_show": ("imdb", "show"),
+    "imdb_movie": ("imdb", "movie"),
+}
+
+
+def parse_descriptor(value: Any) -> Descriptor | None:
+    raw = str(value or "").strip()
+    if not raw or ":" not in raw:
+        return None
+    parts = raw.split(":")
+    if len(parts) < 2:
+        return None
+    base = parts[0].strip().lower()
+    ident = parts[1].strip()
+    if not base or not ident:
+        return None
+    provider, media_kind = _PROVIDER_ALIASES.get(base, (base, ""))
+    if provider not in {"anilist", "mal", "anidb", "tmdb", "tvdb", "imdb"}:
+        return None
+    scope = ":".join(parts[2:]).strip() if len(parts) > 2 else ""
+    return Descriptor(raw=raw, provider=provider, id=ident, scope=scope, media_kind=media_kind)
+
+
+def descriptor_candidates_for_id(provider: str, ident: Any, *, media_type: str | None = None) -> list[str]:
+    p = str(provider or "").strip().lower()
+    v = str(ident or "").strip()
+    if not p or not v:
+        return []
+
+    typ = str(media_type or "").strip().lower()
+    is_movie = typ in {"movie", "movies", "film"}
+
+    if p in {"anilist", "mal", "anidb"}:
+        return [f"{p}:{v}"]
+    if p == "tmdb":
+        order = ["tmdb_movie", "tmdb_show"] if is_movie else ["tmdb_show", "tmdb_movie"]
+        return [f"{base}:{v}" for base in order]
+    if p == "tvdb":
+        order = ["tvdb_movie", "tvdb_show"] if is_movie else ["tvdb_show", "tvdb_movie"]
+        return [f"{base}:{v}" for base in order]
+    if p == "imdb":
+        order = ["imdb_movie", "imdb_show"] if is_movie else ["imdb_show", "imdb_movie"]
+        return [f"{base}:{v}" for base in order]
+    return []

--- a/cw_platform/anime_mapping/service.py
+++ b/cw_platform/anime_mapping/service.py
@@ -1,0 +1,272 @@
+# /cw_platform/anime_mapping/service.py
+# CrossWatch - Anime Mapping Service
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from cw_platform.id_map import canonical_key, ids_from, merge_ids, minimal
+
+from .descriptors import descriptor_candidates_for_id, parse_descriptor
+from .storage import paths, query_edges, read_state
+
+ANIME_NATIVE_PROVIDERS = {"anilist"}
+DEFAULT_FEATURES = {"watchlist"}
+OUTPUT_KEYS = ("anilist", "mal", "anidb", "tmdb", "tvdb", "imdb")
+_MEDIA_KIND_KEYS: dict[str, str] = {
+    "tmdb_movie": "movie",
+    "tvdb_movie": "movie",
+    "imdb_movie": "movie",
+    "tmdb_show": "show",
+    "tvdb_show": "show",
+    "imdb_show": "show",
+}
+
+
+def _norm_provider(value: Any) -> str:
+    out = str(value or "").strip().lower()
+    for sep in ("#", ".", ":"):
+        if sep in out:
+            out = out.split(sep, 1)[0].strip()
+    return out
+
+
+def mapping_enabled_for_pair(cfg: Mapping[str, Any], *providers: Any) -> bool:
+    block = cfg.get("anime_mapping") if isinstance(cfg, Mapping) else {}
+    block = block if isinstance(block, Mapping) else {}
+    if not bool(block.get("enabled", False)):
+        return False
+    use_for = block.get("use_for_pairs")
+    if isinstance(use_for, (list, tuple, set)):
+        allowed = {_norm_provider(x) for x in use_for if _norm_provider(x)}
+    else:
+        allowed = set(ANIME_NATIVE_PROVIDERS)
+    names = {_norm_provider(p) for p in providers if _norm_provider(p)}
+    return bool(names & allowed)
+
+
+def mapping_enabled_for_feature(cfg: Mapping[str, Any], feature: Any) -> bool:
+    block = cfg.get("anime_mapping") if isinstance(cfg, Mapping) else {}
+    block = block if isinstance(block, Mapping) else {}
+    if not bool(block.get("enabled", False)):
+        return False
+    raw = block.get("features")
+    if isinstance(raw, str):
+        enabled = {x.strip().lower() for x in raw.replace(",", " ").split() if x.strip()}
+    elif isinstance(raw, (list, tuple, set)):
+        enabled = {str(x or "").strip().lower() for x in raw if str(x or "").strip()}
+    else:
+        enabled = set(DEFAULT_FEATURES)
+    return str(feature or "").strip().lower() in enabled
+
+
+def mapped_media_type(item: Mapping[str, Any]) -> str | None:
+    detail = item.get("detail") if isinstance(item.get("detail"), Mapping) else {}
+    amap = detail.get("anime_mapping") if isinstance(detail, Mapping) else {}
+    if not isinstance(amap, Mapping):
+        return None
+
+    has_movie = False
+    has_show = False
+    for key, value in amap.items():
+        kind = _MEDIA_KIND_KEYS.get(str(key or "").strip().lower())
+        if not kind:
+            continue
+        present = False
+        if isinstance(value, list):
+            present = bool(value)
+        elif isinstance(value, Mapping):
+            present = bool(value)
+        elif value not in (None, "", False):
+            present = True
+        if not present:
+            continue
+        if kind == "movie":
+            has_movie = True
+        elif kind == "show":
+            has_show = True
+
+    if has_movie and not has_show:
+        return "movie"
+    if has_show:
+        return "show"
+    return None
+
+
+def mapped_or_default_media_type(item: Mapping[str, Any]) -> str:
+    current = str(item.get("type") or item.get("entity") or "").strip().lower()
+    if current in {"movie", "movies", "film"}:
+        return "movie"
+    if current in {"show", "shows", "series", "tv", "tv_shows", "tvshows"}:
+        return "show"
+    if current == "anime":
+        return mapped_media_type(item) or "show"
+    return current or "movie"
+
+
+class AnimeMappingService:
+    def __init__(self, cfg: Mapping[str, Any] | None = None):
+        self.cfg = cfg if isinstance(cfg, Mapping) else {}
+        block = self.cfg.get("anime_mapping") if isinstance(self.cfg, Mapping) else {}
+        block = block if isinstance(block, Mapping) else {}
+        self.release_tag = str(block.get("release_tag") or "v3").strip() or "v3"
+
+    def ready(self) -> bool:
+        pp = paths(self.release_tag)
+        return bool(pp["db"].exists() and read_state(self.release_tag).get("index_ready", False))
+
+    def enrich_ids(self, ids: Mapping[str, Any] | None, *, media_type: str | None = None) -> dict[str, Any]:
+        ids0 = {str(k).lower(): v for k, v in dict(ids or {}).items() if v not in (None, "")}
+        if not ids0 or not self.ready():
+            return {"ids": dict(ids0), "detail": {}, "changed": False}
+
+        seen_sources: set[tuple[str, str]] = set()
+        rows: list[dict[str, Any]] = []
+        source_descriptors: list[str] = []
+        queue: list[tuple[int, str]] = []
+
+        for key, value in ids0.items():
+            for raw_desc in descriptor_candidates_for_id(key, value, media_type=media_type):
+                queue.append((0, raw_desc))
+
+        max_depth = 2
+        max_queries = 40
+        while queue and len(seen_sources) < max_queries:
+            depth, raw_desc = queue.pop(0)
+            desc = parse_descriptor(raw_desc)
+            if desc is None:
+                continue
+            source_descriptors.append(raw_desc)
+            skey = (desc.provider, desc.id)
+            if skey in seen_sources:
+                continue
+            seen_sources.add(skey)
+            try:
+                next_rows = query_edges(self.release_tag, desc.provider, desc.id)
+            except Exception:
+                continue
+            rows.extend(next_rows)
+            if depth >= max_depth:
+                continue
+            for row in next_rows:
+                tp = str(row.get("target_provider") or "").strip().lower()
+                tid = str(row.get("target_id") or "").strip()
+                if tp not in OUTPUT_KEYS or not tid:
+                    continue
+                kind = str(row.get("target_kind") or "").strip().lower()
+                scope = str(row.get("target_scope") or "").strip()
+                prefix = f"{tp}_{kind}" if kind else tp
+                next_desc = f"{prefix}:{tid}:{scope}" if scope else f"{prefix}:{tid}"
+                queue.append((depth + 1, next_desc))
+
+        if not rows:
+            return {"ids": dict(ids0), "detail": {}, "changed": False}
+
+        out_ids: dict[str, Any] = dict(ids0)
+        details: dict[str, list[dict[str, Any]]] = {}
+
+        def add_detail(row: Mapping[str, Any]) -> None:
+            tp = str(row.get("target_provider") or "").strip()
+            tid = str(row.get("target_id") or "").strip()
+            if not tp or not tid:
+                return
+            kind = str(row.get("target_kind") or "").strip()
+            scope = str(row.get("target_scope") or "").strip()
+            key = f"{tp}_{kind}" if kind else tp
+            ent = {
+                "id": tid,
+                "scope": scope,
+                "source_range": str(row.get("source_range") or ""),
+                "target_range": str(row.get("target_range") or ""),
+            }
+            bucket = details.setdefault(key, [])
+            marker = (ent["id"], ent["scope"], ent["source_range"], ent["target_range"])
+            for old in bucket:
+                if (
+                    old.get("id"),
+                    old.get("scope"),
+                    old.get("source_range"),
+                    old.get("target_range"),
+                ) == marker:
+                    return
+            bucket.append(ent)
+
+        for row in rows:
+            add_detail(row)
+            tp = str(row.get("target_provider") or "").strip().lower()
+            tid = str(row.get("target_id") or "").strip()
+            if tp not in OUTPUT_KEYS or not tid:
+                continue
+            if out_ids.get(tp) in (None, ""):
+                out_ids[tp] = tid
+
+        merged = merge_ids(ids0, out_ids)
+        changed = merged != {k: str(v) for k, v in ids0.items() if v not in (None, "")}
+        detail = {
+            "anime_mapping": {
+                "provider": "anibridge",
+                "release_tag": self.release_tag,
+                "source_descriptors": sorted(set(source_descriptors)),
+                **details,
+            }
+        } if details else {}
+        return {"ids": merged or dict(ids0), "detail": detail, "changed": bool(changed)}
+
+    def enrich_item(self, item: Mapping[str, Any]) -> dict[str, Any]:
+        out = dict(item or {})
+        media_type = str(out.get("type") or out.get("entity") or "").strip().lower()
+        ids = ids_from(out)
+        res = self.enrich_ids(ids, media_type=media_type)
+        if not res.get("changed") and not res.get("detail"):
+            return out
+        if res.get("ids"):
+            out["ids"] = res["ids"]
+        detail = out.get("detail")
+        if not isinstance(detail, dict):
+            detail = {}
+        for k, v in (res.get("detail") or {}).items():
+            detail[k] = v
+        if detail:
+            out["detail"] = detail
+        mapped_type = mapped_or_default_media_type(out)
+        current_type = str(out.get("type") or "").strip().lower()
+        if current_type == "anime" and mapped_type in {"movie", "show"}:
+            out["_cw_original_type"] = out.get("type")
+            out["type"] = mapped_type
+        return out
+
+
+def enrich_item(item: Mapping[str, Any], cfg: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    return AnimeMappingService(cfg).enrich_item(item)
+
+
+def enrich_index_for_pair(
+    index: Mapping[str, Any],
+    cfg: Mapping[str, Any],
+    *providers: Any,
+) -> dict[str, Any]:
+    if not index or not mapping_enabled_for_pair(cfg, *providers):
+        return dict(index or {})
+    svc = AnimeMappingService(cfg)
+    if not svc.ready():
+        return dict(index or {})
+    out: dict[str, Any] = {}
+    for key, value in (index or {}).items():
+        if not isinstance(value, Mapping):
+            out[str(key)] = value
+            continue
+        try:
+            enriched = svc.enrich_item(value)
+            mini = minimal(enriched)
+            new_key = canonical_key(mini) or str(key)
+            existing = out.get(new_key)
+            if isinstance(existing, Mapping):
+                merged = dict(existing)
+                merged["ids"] = merge_ids(existing.get("ids") if isinstance(existing.get("ids"), Mapping) else {}, mini.get("ids") if isinstance(mini.get("ids"), Mapping) else {})
+                out[new_key] = merged
+            else:
+                out[new_key] = mini
+        except Exception:
+            out[str(key)] = value
+    return out

--- a/cw_platform/anime_mapping/storage.py
+++ b/cw_platform/anime_mapping/storage.py
@@ -1,0 +1,253 @@
+# /cw_platform/anime_mapping/storage.py
+# CrossWatch - Anime Mapping Storage Utilities
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import tempfile
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from cw_platform.config_base import CONFIG_BASE
+
+from .descriptors import Descriptor, parse_descriptor
+
+SCHEMA_VERSION = 1
+_RELEASE_TAG_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+
+
+def normalize_release_tag(value: Any = "v3") -> str:
+    tag = str(value or "v3").strip() or "v3"
+    return tag if _RELEASE_TAG_RE.fullmatch(tag) else "v3"
+
+
+def cache_root(release_tag: str = "v3") -> Path:
+    tag = normalize_release_tag(release_tag)
+    return CONFIG_BASE() / ".cw_cache" / "anime_mapping" / "anibridge" / tag
+
+
+def paths(release_tag: str = "v3") -> dict[str, Path]:
+    root = cache_root(release_tag)
+    return {
+        "root": root,
+        "stats": root / "stats.json",
+        "mappings": root / "mappings.min.json",
+        "db": root / "anime_mapping.sqlite",
+        "state": root / "state.json",
+    }
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text("utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(dict(payload or {}), f, ensure_ascii=False, indent=2, sort_keys=True)
+        os.replace(tmp_name, path)
+    finally:
+        try:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+        except Exception:
+            pass
+
+
+def read_state(release_tag: str = "v3") -> dict[str, Any]:
+    return read_json(paths(release_tag)["state"])
+
+
+def write_state(release_tag: str, patch: Mapping[str, Any]) -> dict[str, Any]:
+    p = paths(release_tag)["state"]
+    state = read_json(p)
+    state.update(dict(patch or {}))
+    write_json_atomic(p, state)
+    return state
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    con = sqlite3.connect(str(db_path))
+    con.row_factory = sqlite3.Row
+    return con
+
+
+def _init_schema(con: sqlite3.Connection) -> None:
+    con.executescript(
+        """
+        PRAGMA journal_mode=WAL;
+        CREATE TABLE IF NOT EXISTS mapping_edges (
+          source_provider TEXT NOT NULL,
+          source_id TEXT NOT NULL,
+          source_scope TEXT NOT NULL DEFAULT '',
+          source_kind TEXT NOT NULL DEFAULT '',
+          target_provider TEXT NOT NULL,
+          target_id TEXT NOT NULL,
+          target_scope TEXT NOT NULL DEFAULT '',
+          target_kind TEXT NOT NULL DEFAULT '',
+          source_range TEXT NOT NULL DEFAULT '',
+          target_range TEXT NOT NULL DEFAULT '',
+          reverse INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_mapping_source
+          ON mapping_edges(source_provider, source_id);
+        CREATE INDEX IF NOT EXISTS idx_mapping_source_scope
+          ON mapping_edges(source_provider, source_id, source_scope);
+        CREATE INDEX IF NOT EXISTS idx_mapping_target
+          ON mapping_edges(target_provider, target_id);
+        CREATE TABLE IF NOT EXISTS meta (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        );
+        """
+    )
+
+
+def _insert_edge(
+    rows: list[tuple[str, str, str, str, str, str, str, str, str, str, int]],
+    src: Descriptor,
+    dst: Descriptor,
+    source_range: Any = "",
+    target_range: Any = "",
+    *,
+    reverse: bool = False,
+) -> None:
+    rows.append(
+        (
+            src.provider,
+            src.id,
+            src.scope,
+            src.media_kind,
+            dst.provider,
+            dst.id,
+            dst.scope,
+            dst.media_kind,
+            str(source_range or ""),
+            str(target_range or ""),
+            1 if reverse else 0,
+        )
+    )
+
+
+def rebuild_sqlite_from_mappings(
+    *,
+    release_tag: str = "v3",
+    mappings_path: Path | None = None,
+    db_path: Path | None = None,
+) -> dict[str, Any]:
+    pp = paths(release_tag)
+    mappings_path = mappings_path or pp["mappings"]
+    db_path = db_path or pp["db"]
+    if not mappings_path.exists():
+        raise FileNotFoundError(str(mappings_path))
+
+    data = json.loads(mappings_path.read_text("utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("AniBridge mappings payload must be a JSON object")
+
+    root = db_path.parent
+    root.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{db_path.name}.", suffix=".tmp", dir=str(root))
+    os.close(fd)
+    tmp = Path(tmp_name)
+    rows: list[tuple[str, str, str, str, str, str, str, str, str, str, int]] = []
+    edge_count = 0
+    source_count = 0
+
+    try:
+        for raw_src, targets in data.items():
+            src = parse_descriptor(raw_src)
+            if src is None or not isinstance(targets, Mapping):
+                continue
+            source_count += 1
+            for raw_dst, ranges in targets.items():
+                dst = parse_descriptor(raw_dst)
+                if dst is None:
+                    continue
+                if isinstance(ranges, Mapping) and ranges:
+                    for source_range, target_range in ranges.items():
+                        _insert_edge(rows, src, dst, source_range, target_range)
+                        _insert_edge(rows, dst, src, target_range, source_range, reverse=True)
+                        edge_count += 2
+                else:
+                    _insert_edge(rows, src, dst)
+                    _insert_edge(rows, dst, src, reverse=True)
+                    edge_count += 2
+
+        con = _connect(tmp)
+        try:
+            _init_schema(con)
+            con.executemany(
+                """
+                INSERT INTO mapping_edges (
+                  source_provider, source_id, source_scope, source_kind,
+                  target_provider, target_id, target_scope, target_kind,
+                  source_range, target_range, reverse
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                rows,
+            )
+            con.execute("INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)", ("schema_version", str(SCHEMA_VERSION)))
+            con.execute("INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)", ("built_at", str(int(time.time()))))
+            con.execute("INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)", ("source_count", str(source_count)))
+            con.execute("INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)", ("edge_count", str(edge_count)))
+            con.commit()
+        finally:
+            con.close()
+
+        os.replace(tmp, db_path)
+    finally:
+        try:
+            if tmp.exists():
+                tmp.unlink()
+        except Exception:
+            pass
+
+    write_state(
+        release_tag,
+        {
+            "index_ready": True,
+            "index_built_at": int(time.time()),
+            "schema_version": SCHEMA_VERSION,
+            "source_count": source_count,
+            "edge_count": edge_count,
+        },
+    )
+    return {"ok": True, "source_count": source_count, "edge_count": edge_count, "db_path": str(db_path)}
+
+
+def query_edges(release_tag: str, provider: str, ident: str) -> list[dict[str, Any]]:
+    db = paths(release_tag)["db"]
+    if not db.exists():
+        return []
+    p = str(provider or "").strip().lower()
+    i = str(ident or "").strip()
+    if not p or not i:
+        return []
+    con = _connect(db)
+    try:
+        rows = con.execute(
+            """
+            SELECT source_provider, source_id, source_scope, source_kind,
+                   target_provider, target_id, target_scope, target_kind,
+                   source_range, target_range, reverse
+            FROM mapping_edges
+            WHERE source_provider = ? AND source_id = ?
+            LIMIT 500
+            """,
+            (p, i),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        con.close()

--- a/cw_platform/anime_mapping/updater.py
+++ b/cw_platform/anime_mapping/updater.py
@@ -1,0 +1,207 @@
+# /cw_platform/anime_mapping/updater.py
+# CrossWatch - Anime Mapping Updater
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from _logging import log
+
+from .storage import normalize_release_tag, paths, read_state, rebuild_sqlite_from_mappings, write_json_atomic, write_state
+
+BASE_URL = "https://github.com/anibridge/anibridge-mappings/releases/download"
+UA = "CrossWatch AnimeMapping/1.0"
+_UPDATE_LOCK = threading.Lock()
+
+
+def _cfg_block(cfg: Mapping[str, Any] | None) -> dict[str, Any]:
+    am = (cfg or {}).get("anime_mapping") if isinstance(cfg, Mapping) else {}
+    return am if isinstance(am, dict) else {}
+
+
+def _asset_url(release_tag: str, name: str) -> str:
+    tag = normalize_release_tag(release_tag)
+    return f"{BASE_URL}/{tag}/{name}"
+
+
+def _download_json(url: str, *, timeout: float = 30.0) -> tuple[dict[str, Any], dict[str, str]]:
+    r = requests.get(url, headers={"User-Agent": UA, "Accept": "application/json"}, timeout=timeout)
+    r.raise_for_status()
+    data = r.json()
+    if not isinstance(data, dict):
+        raise ValueError(f"{url} did not return a JSON object")
+    return data, {k.lower(): v for k, v in r.headers.items()}
+
+
+def _download_file_atomic(url: str, dest: Path, *, timeout: float = 120.0) -> dict[str, Any]:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{dest.name}.", suffix=".tmp", dir=str(dest.parent))
+    size = 0
+    headers: dict[str, str] = {}
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            with requests.get(url, headers={"User-Agent": UA}, timeout=timeout, stream=True) as r:
+                r.raise_for_status()
+                headers = {k.lower(): v for k, v in r.headers.items()}
+                for chunk in r.iter_content(1024 * 1024):
+                    if not chunk:
+                        continue
+                    fh.write(chunk)
+                    size += len(chunk)
+
+        # Validate before swapping.
+        with open(tmp_name, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            raise ValueError("AniBridge mappings payload must be a JSON object")
+        os.replace(tmp_name, dest)
+        return {"size": size, "headers": headers}
+    finally:
+        try:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+        except Exception:
+            pass
+
+
+def status(*, cfg: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    am = _cfg_block(cfg)
+    tag = normalize_release_tag(am.get("release_tag"))
+    pp = paths(tag)
+    st = read_state(tag)
+    stats = {}
+    if pp["stats"].exists():
+        try:
+            stats = json.loads(pp["stats"].read_text("utf-8"))
+        except Exception:
+            stats = {}
+    meta = stats.get("meta") if isinstance(stats, dict) else {}
+    generated_on = str(st.get("dataset_generated_on") or (meta or {}).get("generated_on") or "")
+    stale_after_days = int(am.get("stale_after_days", 14) or 14)
+    stale = False
+    age_hours: float | None = None
+    if generated_on:
+        try:
+            from datetime import datetime, timezone
+
+            dt = datetime.fromisoformat(generated_on.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            age_hours = max(0.0, (datetime.now(timezone.utc) - dt).total_seconds() / 3600.0)
+            stale = age_hours > (stale_after_days * 24)
+        except Exception:
+            age_hours = None
+
+    mapping_size = pp["mappings"].stat().st_size if pp["mappings"].exists() else 0
+    db_size = pp["db"].stat().st_size if pp["db"].exists() else 0
+    installed = bool(pp["mappings"].exists() and pp["db"].exists())
+    return {
+        "ok": True,
+        "enabled": bool(am.get("enabled", False)),
+        "auto_update": bool(am.get("auto_update", True)),
+        "provider": str(am.get("provider") or "anibridge"),
+        "release_tag": tag,
+        "installed": installed,
+        "index_ready": bool(pp["db"].exists() and st.get("index_ready", False)),
+        "status": "installed" if installed else "missing",
+        "dataset_generated_on": generated_on,
+        "age_hours": age_hours,
+        "stale": stale,
+        "stale_after_days": stale_after_days,
+        "last_checked_at": int(st.get("last_checked_at") or 0),
+        "last_updated_at": int(st.get("last_updated_at") or 0),
+        "index_built_at": int(st.get("index_built_at") or 0),
+        "source_count": int(st.get("source_count") or 0),
+        "edge_count": int(st.get("edge_count") or 0),
+        "mappings_size": int(mapping_size),
+        "db_size": int(db_size),
+        "root": str(pp["root"]),
+        "stats": stats if isinstance(stats, dict) else {},
+    }
+
+
+def update(*, release_tag: str = "v3", force: bool = False) -> dict[str, Any]:
+    with _UPDATE_LOCK:
+        return _update_locked(release_tag=release_tag, force=force)
+
+
+def _update_locked(*, release_tag: str = "v3", force: bool = False) -> dict[str, Any]:
+    tag = normalize_release_tag(release_tag)
+    pp = paths(tag)
+    pp["root"].mkdir(parents=True, exist_ok=True)
+    now = int(time.time())
+
+    stats_url = _asset_url(tag, "stats.json")
+    mappings_url = _asset_url(tag, "mappings.min.json")
+    stats_data, stats_headers = _download_json(stats_url)
+    meta = stats_data.get("meta") if isinstance(stats_data.get("meta"), dict) else {}
+    generated_on = str((meta or {}).get("generated_on") or "")
+    previous = read_state(tag)
+    previous_generated = str(previous.get("dataset_generated_on") or "")
+    changed = force or not pp["mappings"].exists() or not pp["db"].exists() or (generated_on and generated_on != previous_generated)
+
+    write_json_atomic(pp["stats"], stats_data)
+    write_state(
+        tag,
+        {
+            "last_checked_at": now,
+            "dataset_generated_on": generated_on,
+            "stats_etag": stats_headers.get("etag", ""),
+            "stats_last_modified": stats_headers.get("last-modified", ""),
+        },
+    )
+
+    if not changed:
+        log(
+            "update_skipped",
+            level="debug",
+            module="ANIME_MAPPING",
+            extra={
+                "release_tag": tag,
+                "reason": "dataset_current",
+                "generated_on": generated_on,
+                "previous_generated_on": previous_generated,
+            },
+        )
+        return {"ok": True, "updated": False, **status(cfg={"anime_mapping": {"release_tag": tag, "enabled": True}})}
+
+    log("download_started", level="debug", module="ANIME_MAPPING", extra={"release_tag": tag})
+    dl = _download_file_atomic(mappings_url, pp["mappings"])
+    log(
+        "download_finished",
+        level="debug",
+        module="ANIME_MAPPING",
+        extra={"release_tag": tag, "mappings_size": int(dl.get("size") or 0)},
+    )
+    log("index_rebuild_started", level="debug", module="ANIME_MAPPING", extra={"release_tag": tag})
+    rebuild = rebuild_sqlite_from_mappings(release_tag=tag)
+    log(
+        "index_rebuild_finished",
+        level="debug",
+        module="ANIME_MAPPING",
+        extra={
+            "release_tag": tag,
+            "source_count": int(rebuild.get("source_count") or 0),
+            "edge_count": int(rebuild.get("edge_count") or 0),
+        },
+    )
+    write_state(
+        tag,
+        {
+            "last_updated_at": int(time.time()),
+            "mappings_etag": (dl.get("headers") or {}).get("etag", ""),
+            "mappings_last_modified": (dl.get("headers") or {}).get("last-modified", ""),
+            "mappings_size": int(dl.get("size") or 0),
+            "error": "",
+        },
+    )
+    return {"ok": True, "updated": True, "download": dl, "rebuild": rebuild, **status(cfg={"anime_mapping": {"release_tag": tag, "enabled": True}})}

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import copy
 import json
 import os
+import re
 import secrets
 import base64
 import hashlib
@@ -549,6 +550,18 @@ DEFAULT_CFG: dict[str, Any] = {
     "metadata": {
         "locale": "en-US",                              # example: "en-US" / "nl-NL"
         "ttl_hours": 72,                                # Coarse cache TTL
+    },
+
+    # --- Anime ID Mapping ----------------------------------------------------
+    "anime_mapping": {
+        "enabled": False,                               # Enable local anime ID enrichment for anime-native providers
+        "auto_update": True,                            # Refresh the local AniBridge dataset in the background when enabled
+        "provider": "anibridge",                        # Local dataset provider
+        "release_tag": "v3",                            # AniBridge release tag
+        "refresh_hours": 24,                            # Minimum age before an automatic refresh is considered
+        "stale_after_days": 14,                         # UI/status warning threshold
+        "use_for_pairs": ["anilist"],                   # Providers that activate anime mapping when present in a pair
+        "features": ["watchlist"],                      # Sync features where anime ID enrichment is applied
     },
 
     # --- Scrobble ------------------------------------------------------------
@@ -1219,7 +1232,7 @@ def _normalize_scheduling(cfg: dict[str, Any]) -> None:
         s["every_n_hours"] = 1
     elif mode_raw == "daily_time":
         mode = "daily_time"
-    elif mode_raw == "custom_interval":
+    elif mode_raw in {"custom_interval", "custom"}:
         mode = "custom_interval"
     elif mode_raw == "every_n_hours":
         mode = "every_n_hours"
@@ -1307,6 +1320,47 @@ def _normalize_scheduling(cfg: dict[str, Any]) -> None:
         out.append(j)
 
     adv["jobs"] = out
+
+
+def _normalize_anime_mapping(cfg: dict[str, Any]) -> None:
+    am = _ensure_dict(cfg, "anime_mapping")
+    am["enabled"] = bool(am.get("enabled", False))
+    am["auto_update"] = bool(am.get("auto_update", True))
+
+    provider = str(am.get("provider") or "anibridge").strip().lower() or "anibridge"
+    am["provider"] = provider
+
+    tag = str(am.get("release_tag") or "v3").strip() or "v3"
+    if not re.fullmatch(r"[A-Za-z0-9._-]{1,64}", tag):
+        tag = "v3"
+    am["release_tag"] = tag
+
+    try:
+        refresh_hours = int(am.get("refresh_hours", 24) or 24)
+    except Exception:
+        refresh_hours = 24
+    am["refresh_hours"] = max(1, refresh_hours)
+
+    try:
+        stale_after_days = int(am.get("stale_after_days", 14) or 14)
+    except Exception:
+        stale_after_days = 14
+    am["stale_after_days"] = max(1, stale_after_days)
+
+    def _string_list(value: Any, default: list[str]) -> list[str]:
+        raw = value if isinstance(value, list) else default
+        out: list[str] = []
+        seen: set[str] = set()
+        for item in raw:
+            name = str(item or "").strip().lower()
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            out.append(name)
+        return out or list(default)
+
+    am["use_for_pairs"] = _string_list(am.get("use_for_pairs"), ["anilist"])
+    am["features"] = _string_list(am.get("features"), ["watchlist"])
 
 
 def _normalize_ui(cfg: dict[str, Any]) -> None:
@@ -1501,6 +1555,7 @@ def load_config() -> dict[str, Any]:
     _normalize_simkl(cfg)
     _normalize_mdblist(cfg)
     _normalize_publicmetadb(cfg)
+    _normalize_anime_mapping(cfg)
     _normalize_scheduling(cfg)
     _normalize_app_auth(cfg)
     pairs = cfg.get("pairs")
@@ -1550,6 +1605,7 @@ def save_config(cfg: dict[str, Any]) -> None:
     _normalize_simkl(data)
     _normalize_mdblist(data)
     _normalize_publicmetadb(data)
+    _normalize_anime_mapping(data)
     _normalize_scheduling(data)
     _normalize_app_auth(data)
     _normalize_ui(data)

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -12,6 +12,11 @@ import datetime as _dt
 from ..provider_instances import normalize_instance_id
 
 from ..id_map import minimal as _minimal, canonical_key as _ck, merge_ids as _merge_ids
+from ..anime_mapping.service import (
+    enrich_index_for_pair as _anime_enrich_index_for_pair,
+    mapping_enabled_for_feature as _anime_mapping_enabled_for_feature,
+    mapping_enabled_for_pair as _anime_mapping_enabled_for_pair,
+)
 from ._snapshots import (
     build_snapshots_for_feature,
     coerce_suspect_snapshot,
@@ -847,6 +852,14 @@ def run_one_way_feature(
     # Keep metadata when the provider index is presence-only.
     dst_full = _enrich_index_payload(dst_full, prev_dst, feature)
     src_idx = _enrich_index_payload(src_idx, prev_src, feature)
+
+    if _anime_mapping_enabled_for_feature(cfg, feature) and _anime_mapping_enabled_for_pair(cfg, src, dst):
+        src_before = len(src_idx)
+        dst_before = len(dst_full)
+        src_idx = _anime_enrich_index_for_pair(src_idx, cfg, src, dst)
+        dst_full = _anime_enrich_index_for_pair(dst_full, cfg, src, dst)
+        if len(src_idx) != src_before or len(dst_full) != dst_before:
+            dbg("anime_mapping.rekeyed", feature=feature, src=src, dst=dst, src_items=len(src_idx), dst_items=len(dst_full))
 
     # Repair sparse destination snapshots using the source index.
     if feature in ("history", "ratings", "progress"):

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -65,6 +65,11 @@ except Exception:
         return idx
 
 from ..id_map import minimal as _minimal, canonical_key as _ck, merge_ids as _merge_ids
+from ..anime_mapping.service import (
+    enrich_index_for_pair as _anime_enrich_index_for_pair,
+    mapping_enabled_for_feature as _anime_mapping_enabled_for_feature,
+    mapping_enabled_for_pair as _anime_mapping_enabled_for_pair,
+)
 from ._snapshots import (
     build_snapshots_for_feature,
     coerce_suspect_snapshot,
@@ -508,6 +513,14 @@ def _two_way_sync(
     # Keep rich metadata when the provider index is presence-only.
     A_eff = _enrich_index_payload(A_eff, prevA, feature)
     B_eff = _enrich_index_payload(B_eff, prevB, feature)
+
+    if _anime_mapping_enabled_for_feature(cfg, feature) and _anime_mapping_enabled_for_pair(cfg, a, b):
+        a_before = len(A_eff)
+        b_before = len(B_eff)
+        A_eff = _anime_enrich_index_for_pair(A_eff, cfg, a, b)
+        B_eff = _anime_enrich_index_for_pair(B_eff, cfg, a, b)
+        if len(A_eff) != a_before or len(B_eff) != b_before:
+            dbg("anime_mapping.rekeyed", feature=feature, a=a, b=b, a_items=len(A_eff), b_items=len(B_eff))
 
     now = int(_t.time())
     tomb_ttl_days = int((cfg.get("sync") or {}).get("tombstone_ttl_days", 30))

--- a/providers/sync/anilist/_watchlist.py
+++ b/providers/sync/anilist/_watchlist.py
@@ -13,6 +13,7 @@ from typing import Any
 from pathlib import Path
 
 from cw_platform.id_map import minimal as id_minimal
+from cw_platform.anime_mapping import AnimeMappingService
 
 from ._common import read_json, state_file, write_json
 from .._log import log as cw_log
@@ -161,6 +162,44 @@ def _to_int(v: Any) -> int | None:
         return None
 
 
+def _anime_mapping_enabled(adapter: Any) -> bool:
+    try:
+        cfg = getattr(adapter, "raw_cfg", None)
+        block = cfg.get("anime_mapping") if isinstance(cfg, Mapping) else {}
+        if not isinstance(block, Mapping):
+            return False
+        return bool(block.get("enabled", False))
+    except Exception:
+        return False
+
+
+def _has_anime_mapping_detail(item: Mapping[str, Any]) -> bool:
+    detail = item.get("detail") if isinstance(item.get("detail"), Mapping) else {}
+    amap = detail.get("anime_mapping") if isinstance(detail, Mapping) else {}
+    return isinstance(amap, Mapping) and any(bool(v) for v in amap.values())
+
+
+def _anime_enrich(adapter: Any, item: Mapping[str, Any]) -> dict[str, Any]:
+    out = dict(item or {})
+    if not _anime_mapping_enabled(adapter):
+        return out
+    try:
+        svc = AnimeMappingService(getattr(adapter, "raw_cfg", None))
+        if not svc.ready():
+            return out
+        enriched = svc.enrich_item(out)
+        if isinstance(enriched, dict):
+            ids0 = out.get("ids") if isinstance(out.get("ids"), Mapping) else {}
+            ids1 = enriched.get("ids") if isinstance(enriched.get("ids"), Mapping) else {}
+            if ids1 and dict(ids1) != dict(ids0 or {}):
+                _dbg("mapping_enriched", ids_before=len(ids0 or {}), ids_after=len(ids1), title=str(out.get("title") or ""))
+                enriched["_cw_anime_mapping"] = True
+            return enriched
+    except Exception as e:
+        _dbg("mapping_enrich_failed", error_type=e.__class__.__name__)
+    return out
+
+
 def _tick(prog: Any, value: int, total: int | None = None, *, force: bool = False) -> None:
     if prog is None:
         return
@@ -223,11 +262,21 @@ def _score_candidate(
 
 
 def _resolve_media_id(adapter: Any, item: Mapping[str, Any]) -> tuple[int | None, dict[str, Any]]:
+    item = _anime_enrich(adapter, item)
     ids = item.get("ids")
     ids = dict(ids) if isinstance(ids, Mapping) else {}
+    mapped = bool(item.get("_cw_anime_mapping") or _has_anime_mapping_detail(item))
 
     mid = _to_int(ids.get("anilist"))
     if mid:
+        _dbg(
+            "resolve_hit",
+            title=str(item.get("title") or ""),
+            year=_to_int(item.get("year")),
+            anilist_id=int(mid),
+            method="direct_id",
+            source="anime_mapping" if mapped else "item_ids",
+        )
         return mid, {"anilist_id": int(mid)}
 
     mal = _to_int(ids.get("mal"))
@@ -246,6 +295,15 @@ def _resolve_media_id(adapter: Any, item: Mapping[str, Any]) -> tuple[int | None
                 mm = _to_int(m.get("idMal"))
                 if mm:
                     meta["mal"] = int(mm)
+                _dbg(
+                    "resolve_hit",
+                    title=str(item.get("title") or ""),
+                    year=_to_int(item.get("year")),
+                    anilist_id=int(aid),
+                    mal=int(mal),
+                    method="mal_lookup",
+                    source="anime_mapping" if mapped else "item_ids",
+                )
                 return int(aid), meta
 
     title = str(item.get("title") or "").strip()
@@ -409,6 +467,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
                 "ids": ids,
                 "anilist": {"list_entry_id": int(entry_id or 0), "status": "PLANNING"},
             }
+            item = _anime_enrich(adapter, item)
 
             src_key = rev.get(int(mid))
             if src_key:
@@ -511,7 +570,11 @@ def add_detailed(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, 
     skipped = 0
 
     for i, it in enumerate(lst, start=1):
-        m = id_minimal(it)
+        enriched_item = _anime_enrich(adapter, it)
+        mapped_item = bool(enriched_item.get("_cw_anime_mapping") or _has_anime_mapping_detail(enriched_item))
+        m = id_minimal(enriched_item)
+        if mapped_item:
+            m["_cw_anime_mapping"] = True
         src_key = adapter.key_of(m) or ""
         ent = shadow.get(src_key) if src_key and isinstance(shadow, dict) else None
 
@@ -697,7 +760,11 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
     skipped = 0
 
     for i, it in enumerate(lst, start=1):
-        m = id_minimal(it)
+        enriched_item = _anime_enrich(adapter, it)
+        mapped_item = bool(enriched_item.get("_cw_anime_mapping") or _has_anime_mapping_detail(enriched_item))
+        m = id_minimal(enriched_item)
+        if mapped_item:
+            m["_cw_anime_mapping"] = True
         src_key = adapter.key_of(m) or ""
         ent = shadow.get(src_key) if src_key and isinstance(shadow.get(src_key), Mapping) else None
         if isinstance(ent, Mapping) and ent.get("ignored") is True:

--- a/providers/sync/crosswatch/_watchlist.py
+++ b/providers/sync/crosswatch/_watchlist.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
+from cw_platform.anime_mapping.service import mapped_or_default_media_type
 from cw_platform.config_base import load_config, save_config
 from cw_platform.id_map import canonical_key, merge_ids, minimal as id_minimal
 from cw_platform.metadata import MetadataManager
@@ -44,8 +45,10 @@ def _meta() -> MetadataManager | None:
         return None
 
 
-def _type_to_entity(typ: Any) -> str:
-    t = str(typ or "").lower().strip()
+def _type_to_entity(item: Mapping[str, Any] | Any) -> str:
+    if isinstance(item, Mapping):
+        return "movie" if mapped_or_default_media_type(item) == "movie" else "show"
+    t = str(item or "").lower().strip()
     return "movie" if t == "movie" else "show"
 
 
@@ -79,7 +82,7 @@ def _ensure_tmdb_for_item(item: dict[str, Any]) -> bool:
 
     try:
         res = mm.resolve(
-            entity=_type_to_entity(item.get("type")),
+            entity=_type_to_entity(item),
             ids={"imdb": imdb},
             need={"poster": False, "backdrop": False, "overview": False},
         )

--- a/providers/sync/emby/_common.py
+++ b/providers/sync/emby/_common.py
@@ -10,6 +10,7 @@ import os
 import re
 import shutil
 import time
+from cw_platform.anime_mapping.service import mapped_or_default_media_type
 from cw_platform.id_map import minimal as id_minimal, canonical_key
 from .._log import log as cw_log
 
@@ -263,6 +264,13 @@ def _norm_type(t: Any) -> str:
     if x in ("episode", "episodes"):
         return "episode"
     return "movie"
+
+
+def _lookup_type(it: Mapping[str, Any]) -> str:
+    raw = _norm_type(it.get("type"))
+    if raw == "episode":
+        return raw
+    return mapped_or_default_media_type(it)
 
 
 def looks_like_bad_id(iid: Any) -> bool:
@@ -1232,7 +1240,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
         cw_log("EMBY", "common", "debug", "resolve_hit", kind="direct", method="provider_id", item_id=str(em))
         memo[mk] = str(em)
         return str(em)
-    t = _norm_type(it.get("type"))
+    t = _lookup_type(it)
     title = (it.get("title") or "").strip()
     year = it.get("year")
     season = it.get("season")
@@ -1596,7 +1604,7 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
     ids = dict(it.get("ids") or {})
     show_ids = it.get("show_ids") if isinstance(it.get("show_ids"), Mapping) else None
 
-    t = _norm_type(it.get("type"))
+    t = _lookup_type(it)
     title = (it.get("title") or "").strip()
     year = it.get("year")
     season = it.get("season")

--- a/providers/sync/emby/_watchlist.py
+++ b/providers/sync/emby/_watchlist.py
@@ -6,6 +6,8 @@ import json
 import os
 from typing import Any, Iterable, Mapping
 
+from cw_platform.anime_mapping.service import mapped_or_default_media_type
+
 from ._common import (
     _is_capture_mode,
     make_logger,
@@ -343,8 +345,11 @@ def _filter_watchlist_items(
 ) -> list[Mapping[str, Any]]:
     out: list[Mapping[str, Any]] = []
     for it in items or []:
-        t = (it.get("type") or "").strip().lower()
-        if t in ("movie", "show", "series"):
+        raw_t = (it.get("type") or "").strip().lower()
+        if raw_t not in ("movie", "movies", "show", "shows", "series", "tv", "anime"):
+            continue
+        t = mapped_or_default_media_type(it)
+        if t in ("movie", "show"):
             out.append(it)
     return out
 
@@ -360,7 +365,13 @@ def _add_favorites(
     unresolved: list[dict[str, Any]] = []
 
     for it in items or []:
-        t = (it.get("type") or "").strip().lower()
+        raw_t = (it.get("type") or "").strip().lower()
+        if raw_t == "episode":
+            t = "episode"
+        elif raw_t in ("movie", "movies", "show", "shows", "series", "tv", "anime"):
+            t = mapped_or_default_media_type(it)
+        else:
+            continue
         if t not in ("movie", "show", "series", "episode"):
             continue
         k = canonical_key(id_minimal(it))

--- a/providers/sync/jellyfin/_common.py
+++ b/providers/sync/jellyfin/_common.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from .._log import log as cw_log
 
+from cw_platform.anime_mapping.service import mapped_or_default_media_type
 from cw_platform.id_map import minimal as id_minimal, canonical_key
 
 _DEF_TYPES = {"movie", "show", "episode"}
@@ -402,6 +403,13 @@ def _norm_type(t: Any) -> str:
     if x in ("episode", "episodes"):
         return "episode"
     return "movie"
+
+
+def _lookup_type(it: Mapping[str, Any]) -> str:
+    raw = _norm_type(it.get("type"))
+    if raw == "episode":
+        return raw
+    return mapped_or_default_media_type(it)
 
 
 def looks_like_bad_id(iid: Any) -> bool:
@@ -979,7 +987,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
         _dbg('resolve_hit', kind='direct', method='provider_id', item_id=str(jf))
         return str(jf)
 
-    t = _norm_type(it.get("type"))
+    t = _lookup_type(it)
     title = (it.get("title") or "").strip()
     year = it.get("year")
     season = it.get("season")
@@ -1177,7 +1185,7 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
     ids = dict(it.get("ids") or {})
     show_ids = it.get("show_ids") if isinstance(it.get("show_ids"), Mapping) else None
 
-    t = _norm_type(it.get("type"))
+    t = _lookup_type(it)
     title = (it.get("title") or "").strip()
     year = it.get("year")
     season = it.get("season")

--- a/providers/sync/jellyfin/_watchlist.py
+++ b/providers/sync/jellyfin/_watchlist.py
@@ -7,6 +7,7 @@ import json
 import os
 from typing import Any, Iterable, Mapping
 
+from cw_platform.anime_mapping.service import mapped_or_default_media_type
 from cw_platform.id_map import canonical_key, minimal as id_minimal
 from ._common import (
     state_file,
@@ -333,7 +334,10 @@ def _verify_favorite(
 def _filter_watchlist_items(items: Iterable[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
     out: list[Mapping[str, Any]] = []
     for it in items or []:
-        t = (it.get("type") or "").strip().lower()
+        raw_t = (it.get("type") or "").strip().lower()
+        if raw_t not in ("movie", "movies", "show", "shows", "series", "tv", "anime"):
+            continue
+        t = mapped_or_default_media_type(it)
         if t in ("movie", "show"):
             out.append(it)
     return out

--- a/providers/sync/mdblist/_watchlist.py
+++ b/providers/sync/mdblist/_watchlist.py
@@ -10,6 +10,7 @@ import time
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
+from cw_platform.anime_mapping.service import mapped_or_default_media_type
 from cw_platform.id_map import minimal as id_minimal
 
 from .._log import log as cw_log
@@ -259,7 +260,9 @@ def _ids_for_mdblist(item: Mapping[str, Any]) -> dict[str, Any]:
             "kitsu": item.get("kitsu") or item.get("kitsu_id"),
         }
 
-    typ = str(item.get("type") or item.get("mediatype") or "").strip().lower()
+    typ = mapped_or_default_media_type(item)
+    if not typ:
+        typ = str(item.get("type") or item.get("mediatype") or "").strip().lower()
     if typ.endswith("s") and typ in ("movies", "shows"):
         typ = typ[:-1]
     if typ not in ("movie", "show"):
@@ -542,7 +545,7 @@ def _batch_payload(items: Iterable[Mapping[str, Any]]) -> tuple[list[dict[str, A
         if not any(ids.get(k) not in (None, "") for k in ("imdb", "tmdb", "trakt", "tvdb", "kitsu", "mdblist")):
             rejected.append({"item": minimal_item, "hint": "missing_supported_ids"})
             continue
-        kind = "show" if str(item.get("type") or "").lower() in ("show", "shows", "tv", "series") else "movie"
+        kind = "show" if mapped_or_default_media_type(item) == "show" else "movie"
         accepted.append({"type": kind, "ids": ids})
     return accepted, rejected
 

--- a/providers/sync/plex/_watchlist.py
+++ b/providers/sync/plex/_watchlist.py
@@ -28,6 +28,7 @@ from ._common import (
 
 
 from cw_platform.id_map import canonical_key, minimal as id_minimal, ids_from_guid
+from cw_platform.anime_mapping.service import mapped_or_default_media_type
 from .. import _mod_common as mod_common
 
 _UNRES = unresolved_store("watchlist")
@@ -185,6 +186,25 @@ def _clean_query_tokens(*, title: str | None, year: int | None, slug: str | None
         add(slug.replace("-", " "))
     return out[:8]
 
+def _has_anime_mapping(item: Mapping[str, Any]) -> bool:
+    detail = item.get("detail") if isinstance(item.get("detail"), Mapping) else {}
+    amap = detail.get("anime_mapping") if isinstance(detail, Mapping) else {}
+    if not isinstance(amap, Mapping):
+        return False
+    return any(bool(v) for v in amap.values())
+
+def _uses_anime_mapping_resolver(item: Mapping[str, Any]) -> bool:
+    kind = str(item.get("type") or item.get("entity") or "").strip().lower()
+    return kind == "anime" or _has_anime_mapping(item)
+
+def _libtype_for_item(item: Mapping[str, Any]) -> str:
+    kind = mapped_or_default_media_type(item)
+    if kind == "show":
+        return "show"
+    if kind == "movie":
+        return "movie"
+    return "movie"
+
 def _id_pairs_from_guid(g: str) -> set[tuple[str, str]]:
     s: set[tuple[str, str]] = set()
     try:
@@ -194,6 +214,14 @@ def _id_pairs_from_guid(g: str) -> set[tuple[str, str]]:
     except Exception:
         pass
     return s
+
+def _id_pairs_from_ids(ids: Mapping[str, Any] | None) -> set[tuple[str, str]]:
+    if not isinstance(ids, Mapping):
+        return set()
+    return {(k, str(v)) for k, v in ids.items() if k in ("tmdb", "imdb", "tvdb") and v}
+
+def _fmt_id_pairs(pairs: set[tuple[str, str]]) -> str:
+    return ",".join(f"{k}:{v}" for k, v in sorted(pairs))
 
 # ID resolver via METADATA.matches
 def _metadata_match_by_ids(
@@ -228,19 +256,23 @@ def _metadata_match_by_ids(
             accept_json=True,
         )
         if not cont:
+            _dbg("metadata_match_empty", key=key, id=v, libtype=libtype)
             continue
+        rows = 0
         for row in _iter_search_rows(cont):
+            rows += 1
             rk = str(row.get("ratingKey") or "") if isinstance(row, Mapping) else ""
             if not rk:
                 continue
             row_ids = ids_from_discover_row(row) if isinstance(row, Mapping) else {}
             if row_ids.get(key) and str(row_ids.get(key)) == v:
-                _dbg("resolve_rating_key", rating_key=rk, source="metadata_matches", key=key)
+                _dbg("resolve_rating_key", rating_key=rk, source="metadata_matches", key=key, matched_id=f"{key}:{v}")
                 return rk
             ext = hydrate_external_ids(token, rk) if rk else {}
             if ext.get(key) and str(ext.get(key)) == v:
-                _dbg("resolve_rating_key", rating_key=rk, source="metadata_matches_hydrate", key=key)
+                _dbg("resolve_rating_key", rating_key=rk, source="metadata_matches_hydrate", key=key, matched_id=f"{key}:{v}")
                 return rk
+        _dbg("metadata_match_miss", key=key, id=v, libtype=libtype, rows=rows)
     return None
 
 # Fallback resolver via Discover search
@@ -259,6 +291,7 @@ def _discover_resolve_rating_key(
     query_limit: int,
     allow_title: bool,
     cfg: Mapping[str, Any],
+    skip_metadata_match: bool = False,
 ) -> str | None:
     ids: dict[str, Any] = {}
     if isinstance(item_ids, Mapping):
@@ -273,11 +306,13 @@ def _discover_resolve_rating_key(
         except Exception:
             pass
 
-    use_match = _cfg_bool(cfg, "watchlist_use_metadata_match", True)
+    use_match = _cfg_bool(cfg, "watchlist_use_metadata_match", True) and not skip_metadata_match
     if use_match and any(ids.get(k) for k in ("tmdb", "imdb", "tvdb")):
         rk0 = _metadata_match_by_ids(session, token, ids, libtype, year, timeout=timeout, retries=retries)
         if rk0:
             return rk0
+    elif skip_metadata_match and any(ids.get(k) for k in ("tmdb", "imdb", "tvdb")):
+        _dbg("metadata_match_skip", reason="anime_mapping", libtype=libtype, ids=_fmt_id_pairs(_id_pairs_from_ids(ids)))
 
     queries = _clean_query_tokens(
         title=(title if allow_title else None),
@@ -289,18 +324,21 @@ def _discover_resolve_rating_key(
 
     pri = _guid_priority(cfg)
     targets = [(_g, _id_pairs_from_guid(_g)) for _g in sort_guid_candidates(guid_candidates or [], priority=pri)]
+    target_pairs = _id_pairs_from_ids(ids)
+    for _, pairs in targets:
+        target_pairs |= pairs
 
-    def ids_match(rk: str, row: Mapping[str, Any]) -> bool:
+    def matched_ids(rk: str, row: Mapping[str, Any]) -> set[tuple[str, str]]:
         row_ids = ids_from_discover_row(row) if isinstance(row, Mapping) else {}
         row_pairs = {(k, str(v)) for k, v in row_ids.items() if k in ("tmdb", "imdb", "tvdb")}
         g = row.get("guid")
         if g:
             row_pairs |= _id_pairs_from_guid(str(g))
         if row_pairs:
-            return any(tgt & row_pairs for _, tgt in targets if tgt)
+            return target_pairs & row_pairs
         ext = hydrate_external_ids(token, rk) or {}
         hyd_pairs = {(k, str(v)) for k, v in ext.items() if k in ("tmdb", "imdb", "tvdb")}
-        return bool(hyd_pairs and any(tgt & hyd_pairs for _, tgt in targets if tgt))
+        return target_pairs & hyd_pairs
 
     params_common: dict[str, Any] = {
         "limit": 25,
@@ -331,8 +369,9 @@ def _discover_resolve_rating_key(
             rk = str(row.get("ratingKey") or "") if isinstance(row, Mapping) else ""
             if not rk:
                 continue
-            if ids_match(rk, row):
-                _dbg("resolve_rating_key", rating_key=rk, source="discover_search", query=q)
+            hit = matched_ids(rk, row)
+            if hit:
+                _dbg("resolve_rating_key", rating_key=rk, source="discover_search", query=q, matched_ids=_fmt_id_pairs(hit))
                 return rk
         if not any_row:
             _dbg("discover_search_empty", query=q)
@@ -560,8 +599,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 continue
     
             guids = sort_guid_candidates(candidate_guids_from_ids(it, include_raw_ids=True), priority=_guid_priority(cfg))
-            kind = (it.get("type") or "movie").lower()
-            libtype = "show" if kind in ("show", "series", "tv") else "movie"
+            libtype = _libtype_for_item(it)
             title = it.get("title")
             year = it.get("year")
             slug = (it.get("ids") or {}).get("slug") if isinstance(it.get("ids"), dict) else None
@@ -603,6 +641,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 query_limit=qlimit,
                 allow_title=allow_title,
                 cfg=cfg,
+                skip_metadata_match=_uses_anime_mapping_resolver(it),
             )
     
             if rk:
@@ -704,8 +743,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
                 continue
     
             guids = sort_guid_candidates(candidate_guids_from_ids(it, include_raw_ids=True), priority=_guid_priority(cfg))
-            kind = (it.get("type") or "movie").lower()
-            libtype = "show" if kind in ("show", "series", "tv") else "movie"
+            libtype = _libtype_for_item(it)
             title = it.get("title")
             year = it.get("year")
             slug = (it.get("ids") or {}).get("slug") if isinstance(it.get("ids"), dict) else None
@@ -747,6 +785,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
                 query_limit=qlimit,
                 allow_title=allow_title,
                 cfg=cfg,
+                skip_metadata_match=_uses_anime_mapping_resolver(it),
             )
     
             if rk:

--- a/providers/sync/publicmetadb/_common.py
+++ b/providers/sync/publicmetadb/_common.py
@@ -8,6 +8,8 @@ import os
 from pathlib import Path
 from typing import Any, Mapping
 
+from cw_platform.anime_mapping.service import mapped_or_default_media_type
+
 from .._log import log as cw_log
 
 STATE_DIR = Path("/config/.cw_state")
@@ -84,10 +86,10 @@ def as_int(value: Any) -> int | None:
 
 
 def media_type_for_item(item: Mapping[str, Any]) -> str:
-    typ = str(item.get("type") or item.get("media_type") or "").strip().lower()
-    if typ in ("tv", "show", "shows", "series"):
-        return "tv"
-    return "movie"
+    probe = item
+    if not item.get("type") and item.get("media_type"):
+        probe = {**dict(item), "type": item.get("media_type")}
+    return "tv" if mapped_or_default_media_type(probe) == "show" else "movie"
 
 
 def tmdb_id_for_item(item: Mapping[str, Any]) -> int | None:

--- a/providers/sync/simkl/_watchlist.py
+++ b/providers/sync/simkl/_watchlist.py
@@ -8,6 +8,7 @@ import os
 import time
 from typing import Any, Iterable, Mapping
 
+from cw_platform.anime_mapping.service import mapped_or_default_media_type
 from cw_platform.id_map import minimal as id_minimal
 
 from .._log import log as cw_log
@@ -195,8 +196,8 @@ def _kind_group(item: Mapping[str, Any]) -> str:
         return "movies"
     if bucket in ("shows", "anime"):
         return "shows"
-    media_type = str(item.get("type") or "movie").strip().lower()
-    return "movies" if media_type in ("movie", "movies") else "shows"
+    media_type = mapped_or_default_media_type(item)
+    return "movies" if media_type == "movie" else "shows"
 
 
 def _sum_processed_from_body(body: Any) -> int:

--- a/providers/sync/tmdb/_common.py
+++ b/providers/sync/tmdb/_common.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
 
+from cw_platform.anime_mapping.service import mapped_or_default_media_type
 from cw_platform.id_map import canonical_key, ids_from, minimal as id_minimal
 
 STATE_DIR = Path("/config/.cw_state")
@@ -177,19 +178,17 @@ def tmdb_id_from_item(item: Mapping[str, Any]) -> int | None:
 
 
 def pick_media_type(item: Mapping[str, Any]) -> str:
-    t = _norm_kind(item.get("type"))
-    if t == "tv":
-        return "tv"
-    if t == "season":
-        return "season"
-    if t == "episode":
-        return "episode"
-    return "movie"
+    raw = _norm_kind(item.get("type"))
+    if raw in ("season", "episode"):
+        return raw
+    return "tv" if mapped_or_default_media_type(item) == "show" else "movie"
 
 
 def pick_watchlist_media_type(item: Mapping[str, Any]) -> str:
-    t = _norm_kind(item.get("type"))
-    return "tv" if t in ("tv", "season", "episode") else "movie"
+    raw = _norm_kind(item.get("type"))
+    if raw in ("season", "episode"):
+        return "tv"
+    return "tv" if mapped_or_default_media_type(item) == "show" else "movie"
 
 
 def unresolved_item(item: Mapping[str, Any], reason: str) -> dict[str, Any]:

--- a/providers/sync/trakt/_common.py
+++ b/providers/sync/trakt/_common.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 from cw_platform.id_map import minimal as id_minimal, canonical_key
+from cw_platform.anime_mapping.service import mapped_or_default_media_type
 
 from .._mod_common import request_with_retries
 from .._log import log as cw_log
@@ -523,12 +524,13 @@ def ids_for_trakt(item: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def pick_trakt_kind(item: Mapping[str, Any]) -> str:
-    t = str(item.get("type") or "movie").lower()
+    t = str(item.get("type") or "movie").strip().lower()
     if t == "episode":
         return "episodes"
     if t == "season":
         return "seasons"
-    if t in ("show", "series", "tv"):
+    media_type = mapped_or_default_media_type(item)
+    if media_type == "show":
         return "shows"
     return "movies"
 

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -720,7 +720,7 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
             <div class="cw-settings-jumpbar" aria-label="Provider sections">
               <button type="button" class="cw-settings-jump" data-target="sec-auth" onclick="cwProvidersJump?.('sec-auth')">Authentication</button>
               <button type="button" class="cw-settings-jump" data-target="sec-sync" onclick="cwProvidersJump?.('sec-sync')">Synchronization</button>
-              <button type="button" class="cw-settings-jump" data-target="sec-meta" onclick="cwProvidersJump?.('sec-meta')">Metadata</button>
+              <button type="button" class="cw-settings-jump" data-target="sec-meta" onclick="cwProvidersJump?.('sec-meta')">Metadata / ID Mapping</button>
             </div>
           </div>
           <div class="cw-settings-pane-stack cw-settings-providers-stack">
@@ -744,19 +744,9 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
               </div>
             </div>
 
-            <div class="section cw-settings-section cw-settings-provider-section" id="sec-meta"><div class="head" data-toggle-section="sec-meta"><span class="chev"></span><strong>Metadata</strong></div><div class="body">
+            <div class="section cw-settings-section cw-settings-provider-section" id="sec-meta"><div class="head" data-toggle-section="sec-meta"><span class="chev"></span><strong>Metadata / ID Mapping</strong></div><div class="body">
 <div id="metadata-providers">
-  <div class="cw-settings-hub" id="meta_provider_tiles">
-    <button type="button" class="cw-hub-tile tmdb" data-provider="tmdb" aria-selected="false">
-      <div class="cw-meta-provider-row">
-        <div class="cw-hub-title">TMDb</div>
-        <span class="auth-dot" id="meta-tmdb-dot" aria-hidden="true"></span>
-      </div>
-      <span class="hidden" id="hub_tmdb_key" aria-hidden="true">API key: -</span>
-    </button>
-  </div>
-
-  <div id="meta-provider-panel" class="cw-panel hidden"></div>
+  <div id="meta-provider-panel" class="cw-meta-provider-stack"></div>
   <div id="meta-provider-raw" class="hidden"></div>
 </div>
 </div></div>


### PR DESCRIPTION
# Pull request

## Change

Added Anime ID Mapping support using a local AniBridge mapping database.

- Added Anime ID Mapping config, status, update, rebuild, and auth-protected API endpoints.
- Added local SQLite-backed AniBridge mapping storage and updater.
- Added automatic bootstrap when Anime ID Mapping is enabled and the database is missing.
- Added optional daily auto-update support.
- Enriched AniList watchlist items with mapped IDs such as TMDb, TVDb, IMDb, MAL, AniDB, and AniList.
- Updated sync matching so AniList pairs can match media-server/tracker IDs more reliably.
- Updated provider routing for mapped anime movies vs shows across Plex, Emby, Jellyfin, Trakt, SIMKL, MDBList, TMDb, PublicMetaDB, and CrossWatch.
- Added Settings UI controls and AniList recommendation prompt for enabling Anime ID Mapping.
- Added error/status handling for missing, updating, installed, and failed mapping database states.

## Why

AniList and MAL IDs are not understood by many media servers and trackers, which caused poor matching for anime watchlist syncs.

Anime ID Mapping bridges AniList anime entries to IDs that Plex, Emby, Jellyfin, Trakt, MDBList, SIMKL, TMDb, and other providers can understand. This makes AniList watchlist syncs much more reliable, especially for anime movies and shows that previously only had AniList/MAL identifiers.

## Testing

- Added Anime Mapping unit tests for:
  - ID enrichment
  - reverse lookup
  - missing database fallback
  - bootstrap failure handling
  - manual update/rebuild error handling
  - movie/show routing
  - pair/feature enablement
- Added API auth coverage to ensure Anime Mapping endpoints require authentication.
- Verified provider routing for Plex, Emby, Jellyfin, Trakt, SIMKL, MDBList, TMDb, PublicMetaDB, and CrossWatch.

## Issue
Fixes #268