### PR TITLE
Fix: harden Anime Mapping paths and error responses

### DIFF
--- a/api/animeMappingAPI.py
+++ b/api/animeMappingAPI.py
@@ -19,6 +19,10 @@ from cw_platform.config_base import load_config, save_config
 router = APIRouter(prefix="/api/anime-mapping", tags=["anime-mapping"])
 
 
+def _client_error_message(action: str) -> str:
+    return f"Anime Mapping {action} failed. Check the server logs for details."
+
+
 def _release_tag(payload: dict[str, Any] | None = None) -> str:
     cfg = load_config() or {}
     data: dict[str, Any] = payload if isinstance(payload, dict) else {}
@@ -125,7 +129,7 @@ def api_anime_mapping_settings(payload: dict[str, Any] | None = Body(default=Non
                     },
                 )
             except Exception as boot_e:
-                bootstrap_error = str(boot_e)
+                bootstrap_error = _client_error_message("bootstrap")
                 st["error"] = boot_e.__class__.__name__
                 st["message"] = bootstrap_error
                 log(
@@ -135,7 +139,7 @@ def api_anime_mapping_settings(payload: dict[str, Any] | None = Body(default=Non
                     extra={
                         "release_tag": str(block.get("release_tag") or "v3"),
                         "error_type": boot_e.__class__.__name__,
-                        "error": bootstrap_error,
+                        "error": str(boot_e),
                     },
                 )
         try:
@@ -147,7 +151,7 @@ def api_anime_mapping_settings(payload: dict[str, Any] | None = Body(default=Non
                 module="ANIME_MAPPING",
                 extra={"error_type": sched_e.__class__.__name__, "error": str(sched_e)},
             )
-            st["auto_update_error"] = str(sched_e)
+            st["auto_update_error"] = _client_error_message("auto-update refresh")
         st["auto_update_status"] = auto_update_status()
         return JSONResponse(
             {
@@ -165,7 +169,7 @@ def api_anime_mapping_settings(payload: dict[str, Any] | None = Body(default=Non
             module="ANIME_MAPPING",
             extra={"error_type": e.__class__.__name__, "error": str(e)},
         )
-        return JSONResponse({"ok": False, "error": e.__class__.__name__, "message": str(e)}, status_code=500)
+        return JSONResponse({"ok": False, "error": e.__class__.__name__, "message": _client_error_message("settings update")}, status_code=500)
 
 
 @router.post("/update")
@@ -183,7 +187,7 @@ def api_anime_mapping_update(payload: dict[str, Any] | None = Body(default=None)
             module="ANIME_MAPPING",
             extra={"error_type": e.__class__.__name__, "error": str(e)},
         )
-        return JSONResponse({"ok": False, "error": e.__class__.__name__, "message": str(e)}, status_code=500)
+        return JSONResponse({"ok": False, "error": e.__class__.__name__, "message": _client_error_message("manual update")}, status_code=500)
 
 
 @router.post("/rebuild-index")
@@ -211,4 +215,4 @@ def api_anime_mapping_rebuild_index(payload: dict[str, Any] | None = Body(defaul
             module="ANIME_MAPPING",
             extra={"error_type": e.__class__.__name__, "error": str(e)},
         )
-        return JSONResponse({"ok": False, "error": e.__class__.__name__, "message": str(e)}, status_code=500)
+        return JSONResponse({"ok": False, "error": e.__class__.__name__, "message": _client_error_message("index rebuild")}, status_code=500)

--- a/cw_platform/anime_mapping/storage.py
+++ b/cw_platform/anime_mapping/storage.py
@@ -19,6 +19,7 @@ from .descriptors import Descriptor, parse_descriptor
 
 SCHEMA_VERSION = 1
 _RELEASE_TAG_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+_PROVIDER = "anibridge"
 
 
 def normalize_release_tag(value: Any = "v3") -> str:
@@ -26,23 +27,48 @@ def normalize_release_tag(value: Any = "v3") -> str:
     return tag if _RELEASE_TAG_RE.fullmatch(tag) else "v3"
 
 
+def _base_root() -> Path:
+    return (CONFIG_BASE() / ".cw_cache" / "anime_mapping" / _PROVIDER).resolve()
+
+
+def _safe_child(base: Path, *parts: str) -> Path:
+    root = base.resolve()
+    candidate = root.joinpath(*parts).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("Invalid anime mapping path") from exc
+    return candidate
+
+
+def _safe_existing_path(path: Path, *, base: Path | None = None) -> Path:
+    root = (base or _base_root()).resolve()
+    candidate = Path(path).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("Invalid anime mapping path") from exc
+    return candidate
+
+
 def cache_root(release_tag: str = "v3") -> Path:
     tag = normalize_release_tag(release_tag)
-    return CONFIG_BASE() / ".cw_cache" / "anime_mapping" / "anibridge" / tag
+    return _safe_child(_base_root(), tag)
 
 
 def paths(release_tag: str = "v3") -> dict[str, Path]:
     root = cache_root(release_tag)
     return {
         "root": root,
-        "stats": root / "stats.json",
-        "mappings": root / "mappings.min.json",
-        "db": root / "anime_mapping.sqlite",
-        "state": root / "state.json",
+        "stats": _safe_child(root, "stats.json"),
+        "mappings": _safe_child(root, "mappings.min.json"),
+        "db": _safe_child(root, "anime_mapping.sqlite"),
+        "state": _safe_child(root, "state.json"),
     }
 
 
 def read_json(path: Path) -> dict[str, Any]:
+    path = _safe_existing_path(path)
     try:
         data = json.loads(path.read_text("utf-8"))
         return data if isinstance(data, dict) else {}
@@ -51,6 +77,7 @@ def read_json(path: Path) -> dict[str, Any]:
 
 
 def write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path = _safe_existing_path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
     try:
@@ -78,6 +105,7 @@ def write_state(release_tag: str, patch: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _connect(db_path: Path) -> sqlite3.Connection:
+    db_path = _safe_existing_path(db_path)
     con = sqlite3.connect(str(db_path))
     con.row_factory = sqlite3.Row
     return con
@@ -147,20 +175,21 @@ def rebuild_sqlite_from_mappings(
     db_path: Path | None = None,
 ) -> dict[str, Any]:
     pp = paths(release_tag)
-    mappings_path = mappings_path or pp["mappings"]
-    db_path = db_path or pp["db"]
+    root = pp["root"]
+    mappings_path = _safe_existing_path(mappings_path or pp["mappings"], base=root)
+    db_path = _safe_existing_path(db_path or pp["db"], base=root)
     if not mappings_path.exists():
-        raise FileNotFoundError(str(mappings_path))
+        raise FileNotFoundError("AniBridge mappings file is missing")
 
     data = json.loads(mappings_path.read_text("utf-8"))
     if not isinstance(data, dict):
         raise ValueError("AniBridge mappings payload must be a JSON object")
 
-    root = db_path.parent
-    root.mkdir(parents=True, exist_ok=True)
-    fd, tmp_name = tempfile.mkstemp(prefix=f".{db_path.name}.", suffix=".tmp", dir=str(root))
+    db_dir = db_path.parent
+    db_dir.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{db_path.name}.", suffix=".tmp", dir=str(db_dir))
     os.close(fd)
-    tmp = Path(tmp_name)
+    tmp = _safe_existing_path(Path(tmp_name), base=db_dir)
     rows: list[tuple[str, str, str, str, str, str, str, str, str, str, int]] = []
     edge_count = 0
     source_count = 0
@@ -228,7 +257,7 @@ def rebuild_sqlite_from_mappings(
 
 
 def query_edges(release_tag: str, provider: str, ident: str) -> list[dict[str, Any]]:
-    db = paths(release_tag)["db"]
+    db = _safe_existing_path(paths(release_tag)["db"])
     if not db.exists():
         return []
     p = str(provider or "").strip().lower()

--- a/cw_platform/anime_mapping/updater.py
+++ b/cw_platform/anime_mapping/updater.py
@@ -16,7 +16,15 @@ import requests
 
 from _logging import log
 
-from .storage import normalize_release_tag, paths, read_state, rebuild_sqlite_from_mappings, write_json_atomic, write_state
+from .storage import (
+    normalize_release_tag,
+    paths,
+    read_state,
+    rebuild_sqlite_from_mappings,
+    write_json_atomic,
+    write_state,
+    _safe_existing_path,
+)
 
 BASE_URL = "https://github.com/anibridge/anibridge-mappings/releases/download"
 UA = "CrossWatch AnimeMapping/1.0"
@@ -43,8 +51,10 @@ def _download_json(url: str, *, timeout: float = 30.0) -> tuple[dict[str, Any], 
 
 
 def _download_file_atomic(url: str, dest: Path, *, timeout: float = 120.0) -> dict[str, Any]:
+    dest = _safe_existing_path(dest)
     dest.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(prefix=f".{dest.name}.", suffix=".tmp", dir=str(dest.parent))
+    tmp_path = _safe_existing_path(Path(tmp_name), base=dest.parent)
     size = 0
     headers: dict[str, str] = {}
     try:
@@ -59,16 +69,16 @@ def _download_file_atomic(url: str, dest: Path, *, timeout: float = 120.0) -> di
                     size += len(chunk)
 
         # Validate before swapping.
-        with open(tmp_name, "r", encoding="utf-8") as f:
+        with open(tmp_path, "r", encoding="utf-8") as f:
             data = json.load(f)
         if not isinstance(data, dict):
             raise ValueError("AniBridge mappings payload must be a JSON object")
-        os.replace(tmp_name, dest)
+        os.replace(tmp_path, dest)
         return {"size": size, "headers": headers}
     finally:
         try:
-            if os.path.exists(tmp_name):
-                os.unlink(tmp_name)
+            if tmp_path.exists():
+                tmp_path.unlink()
         except Exception:
             pass
 
@@ -77,11 +87,14 @@ def status(*, cfg: Mapping[str, Any] | None = None) -> dict[str, Any]:
     am = _cfg_block(cfg)
     tag = normalize_release_tag(am.get("release_tag"))
     pp = paths(tag)
+    stats_path = _safe_existing_path(pp["stats"])
+    mappings_path = _safe_existing_path(pp["mappings"])
+    db_path = _safe_existing_path(pp["db"])
     st = read_state(tag)
     stats = {}
-    if pp["stats"].exists():
+    if stats_path.exists():
         try:
-            stats = json.loads(pp["stats"].read_text("utf-8"))
+            stats = json.loads(stats_path.read_text("utf-8"))
         except Exception:
             stats = {}
     meta = stats.get("meta") if isinstance(stats, dict) else {}
@@ -101,9 +114,9 @@ def status(*, cfg: Mapping[str, Any] | None = None) -> dict[str, Any]:
         except Exception:
             age_hours = None
 
-    mapping_size = pp["mappings"].stat().st_size if pp["mappings"].exists() else 0
-    db_size = pp["db"].stat().st_size if pp["db"].exists() else 0
-    installed = bool(pp["mappings"].exists() and pp["db"].exists())
+    mapping_size = mappings_path.stat().st_size if mappings_path.exists() else 0
+    db_size = db_path.stat().st_size if db_path.exists() else 0
+    installed = bool(mappings_path.exists() and db_path.exists())
     return {
         "ok": True,
         "enabled": bool(am.get("enabled", False)),
@@ -111,7 +124,7 @@ def status(*, cfg: Mapping[str, Any] | None = None) -> dict[str, Any]:
         "provider": str(am.get("provider") or "anibridge"),
         "release_tag": tag,
         "installed": installed,
-        "index_ready": bool(pp["db"].exists() and st.get("index_ready", False)),
+        "index_ready": bool(db_path.exists() and st.get("index_ready", False)),
         "status": "installed" if installed else "missing",
         "dataset_generated_on": generated_on,
         "age_hours": age_hours,
@@ -137,7 +150,11 @@ def update(*, release_tag: str = "v3", force: bool = False) -> dict[str, Any]:
 def _update_locked(*, release_tag: str = "v3", force: bool = False) -> dict[str, Any]:
     tag = normalize_release_tag(release_tag)
     pp = paths(tag)
-    pp["root"].mkdir(parents=True, exist_ok=True)
+    root = _safe_existing_path(pp["root"])
+    mappings_path = _safe_existing_path(pp["mappings"])
+    db_path = _safe_existing_path(pp["db"])
+    stats_path = _safe_existing_path(pp["stats"])
+    root.mkdir(parents=True, exist_ok=True)
     now = int(time.time())
 
     stats_url = _asset_url(tag, "stats.json")
@@ -147,9 +164,9 @@ def _update_locked(*, release_tag: str = "v3", force: bool = False) -> dict[str,
     generated_on = str((meta or {}).get("generated_on") or "")
     previous = read_state(tag)
     previous_generated = str(previous.get("dataset_generated_on") or "")
-    changed = force or not pp["mappings"].exists() or not pp["db"].exists() or (generated_on and generated_on != previous_generated)
+    changed = force or not mappings_path.exists() or not db_path.exists() or (generated_on and generated_on != previous_generated)
 
-    write_json_atomic(pp["stats"], stats_data)
+    write_json_atomic(stats_path, stats_data)
     write_state(
         tag,
         {
@@ -175,7 +192,7 @@ def _update_locked(*, release_tag: str = "v3", force: bool = False) -> dict[str,
         return {"ok": True, "updated": False, **status(cfg={"anime_mapping": {"release_tag": tag, "enabled": True}})}
 
     log("download_started", level="debug", module="ANIME_MAPPING", extra={"release_tag": tag})
-    dl = _download_file_atomic(mappings_url, pp["mappings"])
+    dl = _download_file_atomic(mappings_url, mappings_path)
     log(
         "download_finished",
         level="debug",


### PR DESCRIPTION
# Pull request

## Change

Hardened Anime Mapping filesystem handling and API error responses.

- Added safe path validation for Anime Mapping cache, mapping, stats, state, SQLite, and temporary download files.
- Prevented user/config-derived values from escaping the Anime Mapping cache directory.
- Replaced raw exception messages in Anime Mapping API responses with generic client-facing errors.
- Kept detailed exception information in server logs for troubleshooting.

## Why

CodeQL reported path-expression and exception-disclosure findings in the Anime Mapping implementation.

This prevents exposing internal exception details to clients and ensures Anime Mapping file operations stay inside the expected cache location.

## Issue

NA