### PR TITLE
Add Anime-only sync controls for AniList pairs

### DIFF
--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -157,6 +157,10 @@ def _normalize_features(f: dict | None) -> dict:
             v.setdefault("enable", True)
             v.setdefault("add", True)
             v.setdefault("remove", False)
+        if isinstance(f.get(k), dict) and ("use_anime_mapping" in f[k] or "anime_only_sync" in f[k]):
+            use_map = bool(f[k].get("use_anime_mapping", False))
+            f[k]["use_anime_mapping"] = use_map
+            f[k]["anime_only_sync"] = bool(f[k].get("anime_only_sync", False)) if use_map else False
     return f
 
 _PROGRESS_ALLOWED = {"PLEX", "EMBY", "JELLYFIN", "PUBLICMETADB", "CROSSWATCH"}

--- a/assets/js/modals/pair-config/help.js
+++ b/assets/js/modals/pair-config/help.js
@@ -17,6 +17,8 @@ export const HELP_TEXT = {
   "cx-wl-enable": "Watchlist: Enable\nCompare watchlists and write missing items to the target.",
   "cx-wl-add": "Watchlist: Add\nAdds missing items to the target watchlist.",
   "cx-wl-remove": "Watchlist: Remove\nRemoves items from the target.",
+  "cx-wl-anime-map": "Use Anime ID Mapping\nUse the local AniBridge ID database for this AniList watchlist pair. When enabled from here, global Anime ID Mapping is enabled too.",
+  "cx-wl-anime-only": "Anime-only sync\nOnly sync items that Anime ID Mapping can confirm as anime. Non-anime and unmapped items are skipped before AniList title search.",
   "cx-rt-enable": "Ratings: Enable\nCompare and write ratings to the target.",
   "cx-rt-add": "Ratings: Add / Update\nWrites ratings/updates to the target.",
   "cx-rt-remove": "Ratings: Remove\nClears ratings on the target (destructive and only for very specific needs).",

--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -40,6 +40,34 @@ function hasJelly(state){return isJelly(state?.src)||isJelly(state?.dst)}
 function hasTrakt(state){return isTrakt(state?.src)||isTrakt(state?.dst)}
 function hasMDBList(state){return isMDBList(state?.src)||isMDBList(state?.dst)}
 function hasPublicMetaDB(state){return isPublicMetaDB(state?.src)||isPublicMetaDB(state?.dst)}
+const isAniList=(v)=>same(v,"anilist");
+function hasAniList(state){return isAniList(state?.src)||isAniList(state?.dst)}
+function hasOwn(obj,key){return !!obj&&Object.prototype.hasOwnProperty.call(obj,key)}
+function isTwoWayMode(state){return !!ID("cx-mode-two")?.checked||String(state?.mode||"").toLowerCase().startsWith("two")}
+function anilistCanReceive(state){return isAniList(state?.dst)||(hasAniList(state)&&isTwoWayMode(state))}
+function globalAnimeMappingEnabled(state){return !!state?.cfgRaw?.anime_mapping?.enabled}
+function normalizeAnimeFeatureOptions(state, feature){
+  const key=String(feature||"watchlist").trim().toLowerCase()||"watchlist";
+  const opts=Object.assign({}, state?.options?.[key]||{});
+  if(!hasAniList(state)){
+    opts.use_anime_mapping=false;
+    opts.anime_only_sync=false;
+    state.options[key]=opts;
+    return opts;
+  }
+  if(!hasOwn(opts,"use_anime_mapping")) opts.use_anime_mapping=globalAnimeMappingEnabled(state);
+  opts.use_anime_mapping=!!opts.use_anime_mapping;
+  const canOnly=anilistCanReceive(state);
+  if(!opts.use_anime_mapping || !canOnly){
+    opts.anime_only_sync=false;
+  }else if(!hasOwn(opts,"anime_only_sync")){
+    opts.anime_only_sync=true;
+  }else{
+    opts.anime_only_sync=!!opts.anime_only_sync;
+  }
+  state.options[key]=opts;
+  return opts;
+}
 
 const RATINGS_TYPE_RULES={SIMKL:{disable:["seasons","episodes"]},TMDB:{disable:["seasons"]}};
 function ratingsDisabledFor(state){
@@ -546,8 +574,8 @@ function renderProviderSelects(state){
   };
   bindCardTrigger(ID("cx-src-trigger"),srcSel);
   bindCardTrigger(ID("cx-dst-trigger"),dstSel);
-  srcSel.onchange=()=>{state.src=srcSel.value||null;upd();renderInstanceSelects(state);updateFlow(state,true);refreshTabs(state);renderWarnings(state)};
-  dstSel.onchange=()=>{state.dst=dstSel.value||null;upd();renderInstanceSelects(state);updateFlow(state,true);refreshTabs(state);renderWarnings(state)};
+  srcSel.onchange=()=>{state.src=srcSel.value||null;upd();renderInstanceSelects(state);updateFlow(state,true);refreshTabs(state);renderFeaturePanel(state);renderWarnings(state)};
+  dstSel.onchange=()=>{state.dst=dstSel.value||null;upd();renderInstanceSelects(state);updateFlow(state,true);refreshTabs(state);renderFeaturePanel(state);renderWarnings(state)};
   upd();renderInstanceSelects(state);ID("cx-mode-two").checked=state.mode==="two-way";ID("cx-mode-one").checked=!ID("cx-mode-two").checked;ID("cx-enabled").checked=!!state.enabled;
 }
 
@@ -614,6 +642,7 @@ function applySubDisable(feature){
   const map={
     watchlist: [
       "#cx-wl-add","#cx-wl-remove",
+      "#cx-wl-anime-map","#cx-wl-anime-only",
       "#plx-wl-pms","#plx-wl-limit","#plx-wl-delay","#plx-wl-title","#plx-wl-meta","#plx-wl-guid",
       "#cx-jf-wl-mode-fav","#cx-jf-wl-mode-pl","#cx-jf-wl-mode-col","#cx-jf-wl-pl-name",
       "#cx-em-wl-mode-fav","#cx-em-wl-mode-pl","#cx-em-wl-mode-col","#cx-em-wl-pl-name",
@@ -908,12 +937,16 @@ function renderFeaturePanel(state){
   }
 
   if (state.feature === "watchlist") {
-    const wl = getOpts(state, "watchlist");
+    getOpts(state, "watchlist");
+    const wl = normalizeAnimeFeatureOptions(state, "watchlist");
     const emw = state.emby?.watchlist || { mode: "favorites", playlist_name: "Watchlist" };
     const jfw = state.jellyfin?.watchlist || { mode: "favorites", playlist_name: "Watchlist" };
     const pmw = state.pairProviders?.publicmetadb || {};
     const pmwName = (pmw.watchlist_name || state.cfgRaw?.publicmetadb?.watchlist_name || "Watchlist");
     const trPair = (state.pairProviders?.trakt) || {};
+    const showAnime = hasAniList(state);
+    const canAnimeOnly = anilistCanReceive(state);
+    const animeOnlyDisabled = !wl.use_anime_mapping || !canAnimeOnly;
 
     left.innerHTML = `
       <div class="panel-title">Watchlist | Basics</div>
@@ -925,6 +958,20 @@ function renderFeaturePanel(state){
         <div class="opt-row"><label for="cx-wl-add">Add</label><label class="switch"><input id="cx-wl-add" type="checkbox" ${wl.add?"checked":""}><span class="slider"></span></label></div>
         <div class="opt-row"><label for="cx-wl-remove">Remove</label><label class="switch"><input id="cx-wl-remove" type="checkbox" ${wl.remove?"checked":""}><span class="slider"></span></label></div>
       </div>
+
+      ${showAnime?`
+        <div class="panel-title small" style="margin-top:6px">AniList options</div>
+        <div class="grid2 compact">
+          <div class="opt-row">
+            <label for="cx-wl-anime-map">Use Anime ID Mapping</label>
+            <label class="switch"><input id="cx-wl-anime-map" type="checkbox" ${wl.use_anime_mapping?"checked":""}><span class="slider"></span></label>
+          </div>
+          <div class="opt-row ${animeOnlyDisabled?"muted":""}">
+            <label for="cx-wl-anime-only">Anime-only sync</label>
+            <label class="switch"><input id="cx-wl-anime-only" type="checkbox" ${wl.anime_only_sync?"checked":""} ${animeOnlyDisabled?"disabled":""}><span class="slider"></span></label>
+          </div>
+        </div>
+      `:""}
 
       ${hasJelly(state)?`
         <div class="panel-title small" style="margin-top:6px">Jellyfin specifics</div>
@@ -1614,6 +1661,17 @@ function bindChangeHandlers(state,root){
       applySubDisable("watchlist");
     }
 
+    if (id === "cx-wl-anime-map") {
+      const mapOn = !!ID("cx-wl-anime-map")?.checked;
+      const only = ID("cx-wl-anime-only");
+      if (only) {
+        only.disabled = !mapOn || !anilistCanReceive(state);
+        if (!mapOn || !anilistCanReceive(state)) only.checked = false;
+        else if (mapOn) only.checked = true;
+        only.closest?.(".opt-row")?.classList.toggle("muted", only.disabled);
+      }
+    }
+
     if (id === "cx-rt-enable") {
       applySubDisable("ratings");
     }
@@ -1640,11 +1698,17 @@ function bindChangeHandlers(state,root){
 
     if(id.startsWith("cx-wl-")){
       const prev=state.options.watchlist||{};
+      const mapEl=ID("cx-wl-anime-map");
+      const onlyEl=ID("cx-wl-anime-only");
+      const useMap=mapEl ? !!mapEl.checked : !!prev.use_anime_mapping;
       state.options.watchlist=Object.assign({},prev,{
         enable:!!ID("cx-wl-enable")?.checked,
         add:!!ID("cx-wl-add")?.checked,
-        remove:!!ID("cx-wl-remove")?.checked
+        remove:!!ID("cx-wl-remove")?.checked,
+        use_anime_mapping:useMap,
+        anime_only_sync:useMap && onlyEl ? !!onlyEl.checked : false
       });
+      normalizeAnimeFeatureOptions(state, "watchlist");
       state.visited.add("watchlist");
     }
 
@@ -1801,6 +1865,7 @@ async function saveConfigBits(state){
   try{
     const cur=await fetch("/api/config",{cache:"no-store"}).then(r=>r.ok?r.json():{});
     const cfg=typeof structuredClone==="function"?structuredClone(cur||{}):jclone(cur||{});
+    const shouldEnableAnimeMapping = hasAniList(state) && !!normalizeAnimeFeatureOptions(state, "watchlist").use_anime_mapping;
 
     if(ID("gl-dry")){
       const dropOn=!!ID("gl-drop")?.checked;
@@ -2028,8 +2093,24 @@ async function saveConfigBits(state){
       cfg.mdblist = md;
     }
 
+    if(shouldEnableAnimeMapping){
+      const am=Object.assign({provider:"anibridge",release_tag:"v3"}, cfg.anime_mapping||{});
+      am.enabled=true;
+      cfg.anime_mapping=am;
+    }
+
     const res=await fetch("/api/config",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(cfg)});
     if(!res.ok)throw new Error("POST /api/config "+res.status);
+    if(shouldEnableAnimeMapping){
+      const am=cfg.anime_mapping||{};
+      try{
+        await fetch("/api/anime-mapping/settings",{
+          method:"POST",
+          headers:{"Content-Type":"application/json"},
+          body:JSON.stringify({enabled:true,provider:am.provider||"anibridge",release_tag:am.release_tag||"v3"})
+        });
+      }catch{}
+    }
   }catch(e){console.warn("[cx] saving config bits failed",e)}
 }
 
@@ -2041,6 +2122,18 @@ function buildPayload(state,wrap){
   const modeTwo=!!ID("cx-mode-two")?.checked;const enabled=!!ID("cx-enabled")?.checked;
   const get=k=>Object.assign(defaultFor(k), (state.options||{})[k]||{});
   const watchlist=get("watchlist");
+  const animePair=isAniList(src)||isAniList(dst);
+  const animeCanReceive=isAniList(dst)||(animePair&&modeTwo);
+  if(animePair){
+    if(!hasOwn(watchlist,"use_anime_mapping")) watchlist.use_anime_mapping=globalAnimeMappingEnabled(state);
+    watchlist.use_anime_mapping=!!watchlist.use_anime_mapping;
+    if(!watchlist.use_anime_mapping||!animeCanReceive) watchlist.anime_only_sync=false;
+    else if(!hasOwn(watchlist,"anime_only_sync")) watchlist.anime_only_sync=true;
+    else watchlist.anime_only_sync=!!watchlist.anime_only_sync;
+  }else{
+    watchlist.use_anime_mapping=false;
+    watchlist.anime_only_sync=false;
+  }
   const ratings=get("ratings");
   const progress=get("progress");
   const dis=ratingsDisabledFor({src,dst});
@@ -2153,7 +2246,7 @@ export default{
     restartFlowAnimation(ID("cx-mode-two")?.checked ? "two" : "one");
 
     ID("cx-enabled").addEventListener("change",()=>updateFlow(state,true));
-    QA('input[name="cx-mode"]').forEach(el=>el.addEventListener("change",()=>updateFlow(state,true)));
+    QA('input[name="cx-mode"]').forEach(el=>el.addEventListener("change",()=>{state.mode=ID("cx-mode-two")?.checked?"two-way":"one-way";updateFlow(state,true);renderFeaturePanel(state)}));
     bindChangeHandlers(state,wrap);
     queueMicrotask(() => applyHelpIcons(wrap, { QA }));
     ensureInlineFoot(hostEl);

--- a/cw_platform/anime_mapping/service.py
+++ b/cw_platform/anime_mapping/service.py
@@ -14,6 +14,7 @@ from .storage import paths, query_edges, read_state
 ANIME_NATIVE_PROVIDERS = {"anilist"}
 DEFAULT_FEATURES = {"watchlist"}
 OUTPUT_KEYS = ("anilist", "mal", "anidb", "tmdb", "tvdb", "imdb")
+PAIR_FEATURE_OPTIONS_KEY = "_cw_pair_feature_options"
 _MEDIA_KIND_KEYS: dict[str, str] = {
     "tmdb_movie": "movie",
     "tvdb_movie": "movie",
@@ -59,6 +60,57 @@ def mapping_enabled_for_feature(cfg: Mapping[str, Any], feature: Any) -> bool:
     else:
         enabled = set(DEFAULT_FEATURES)
     return str(feature or "").strip().lower() in enabled
+
+
+def _pair_feature_options(raw: Mapping[str, Any] | None) -> dict[str, Any]:
+    out = dict(raw or {}) if isinstance(raw, Mapping) else {}
+    use_map = bool(out.get("use_anime_mapping", False))
+    out["use_anime_mapping"] = use_map
+    out["anime_only_sync"] = bool(out.get("anime_only_sync", False)) if use_map else False
+    return out
+
+
+def anime_mapping_pair_feature_options(
+    cfg: Mapping[str, Any],
+    feature_cfg: Mapping[str, Any] | None,
+    feature: Any,
+    *providers: Any,
+    anime_only_default: bool = False,
+) -> dict[str, Any]:
+    feature_name = str(feature or "").strip().lower()
+    base_enabled = mapping_enabled_for_feature(cfg, feature_name) and mapping_enabled_for_pair(cfg, *providers)
+    opts = _pair_feature_options(feature_cfg)
+
+    if "use_anime_mapping" not in dict(feature_cfg or {}):
+        opts["use_anime_mapping"] = bool(base_enabled)
+    else:
+        opts["use_anime_mapping"] = bool(base_enabled and opts.get("use_anime_mapping"))
+
+    if not opts["use_anime_mapping"]:
+        opts["anime_only_sync"] = False
+    elif "anime_only_sync" not in dict(feature_cfg or {}):
+        opts["anime_only_sync"] = bool(anime_only_default)
+
+    opts["feature"] = feature_name
+    return opts
+
+
+def config_with_pair_feature_options(
+    cfg: Mapping[str, Any],
+    options: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    out = dict(cfg or {})
+    out[PAIR_FEATURE_OPTIONS_KEY] = _pair_feature_options(options)
+    return out
+
+
+def runtime_pair_feature_options(cfg: Mapping[str, Any], feature: Any = "watchlist") -> dict[str, Any]:
+    raw = cfg.get(PAIR_FEATURE_OPTIONS_KEY) if isinstance(cfg, Mapping) else {}
+    opts = _pair_feature_options(raw if isinstance(raw, Mapping) else {})
+    if opts.get("feature") and str(opts.get("feature") or "").strip().lower() != str(feature or "").strip().lower():
+        return {"use_anime_mapping": False, "anime_only_sync": False, "feature": str(feature or "").strip().lower()}
+    opts["feature"] = str(feature or "").strip().lower()
+    return opts
 
 
 def mapped_media_type(item: Mapping[str, Any]) -> str | None:

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -13,9 +13,9 @@ from ..provider_instances import normalize_instance_id
 
 from ..id_map import minimal as _minimal, canonical_key as _ck, merge_ids as _merge_ids
 from ..anime_mapping.service import (
+    anime_mapping_pair_feature_options as _anime_pair_feature_options,
+    config_with_pair_feature_options as _anime_config_with_pair_feature_options,
     enrich_index_for_pair as _anime_enrich_index_for_pair,
-    mapping_enabled_for_feature as _anime_mapping_enabled_for_feature,
-    mapping_enabled_for_pair as _anime_mapping_enabled_for_pair,
 )
 from ._snapshots import (
     build_snapshots_for_feature,
@@ -479,6 +479,8 @@ def run_one_way_feature(
     dst = str(dst).upper()
     src_ops = provs.get(src)
     dst_ops = provs.get(dst)
+    anime_pair_opts = _anime_pair_feature_options(cfg, fcfg, feature, src, dst, anime_only_default=(dst == "ANILIST"))
+    provider_cfg = _anime_config_with_pair_feature_options(cfg, anime_pair_opts) if "ANILIST" in {src, dst} else cfg
 
     emit("feature:start", src=src, dst=dst, feature=feature)
 
@@ -734,7 +736,7 @@ def run_one_way_feature(
 
     snaps = build_snapshots_for_feature(
         feature=feature,
-        config=cfg,
+        config=provider_cfg,
         providers=pair_providers,
         snap_cache=ctx.snap_cache,
         snap_ttl_sec=ctx.snap_ttl_sec,
@@ -782,7 +784,7 @@ def run_one_way_feature(
 
     if drop_guard:
         prev_cp_src = prev_checkpoint(prev_state, src, feature, src_inst)
-        now_cp_src = module_checkpoint(src_ops, cfg, feature)
+        now_cp_src = module_checkpoint(src_ops, provider_cfg, feature)
         eff_src, src_suspect, src_reason = coerce_suspect_snapshot(
             config=cfg,
             provider=src, ops=src_ops,
@@ -795,7 +797,7 @@ def run_one_way_feature(
             dbg("snapshot.guard", provider=src, feature=feature, reason=src_reason)
 
         prev_cp_dst = prev_checkpoint(prev_state, dst, feature, dst_inst)
-        now_cp_dst = module_checkpoint(dst_ops, cfg, feature)
+        now_cp_dst = module_checkpoint(dst_ops, provider_cfg, feature)
         eff_dst, dst_suspect, dst_reason = coerce_suspect_snapshot(
             config=cfg,
             provider=dst, ops=dst_ops,
@@ -810,8 +812,8 @@ def run_one_way_feature(
         eff_src, eff_dst = dict(src_cur), dict(dst_cur)
         src_suspect = False
         dst_suspect = False
-        now_cp_src = module_checkpoint(src_ops, cfg, feature)
-        now_cp_dst = module_checkpoint(dst_ops, cfg, feature)
+        now_cp_src = module_checkpoint(src_ops, provider_cfg, feature)
+        now_cp_dst = module_checkpoint(dst_ops, provider_cfg, feature)
 
     libs_src: list[str] = _effective_library_whitelist(cfg, src, feature, fcfg)
     libs_dst: list[str] = _effective_library_whitelist(cfg, dst, feature, fcfg)
@@ -853,11 +855,11 @@ def run_one_way_feature(
     dst_full = _enrich_index_payload(dst_full, prev_dst, feature)
     src_idx = _enrich_index_payload(src_idx, prev_src, feature)
 
-    if _anime_mapping_enabled_for_feature(cfg, feature) and _anime_mapping_enabled_for_pair(cfg, src, dst):
+    if bool(anime_pair_opts.get("use_anime_mapping", False)):
         src_before = len(src_idx)
         dst_before = len(dst_full)
-        src_idx = _anime_enrich_index_for_pair(src_idx, cfg, src, dst)
-        dst_full = _anime_enrich_index_for_pair(dst_full, cfg, src, dst)
+        src_idx = _anime_enrich_index_for_pair(src_idx, provider_cfg, src, dst)
+        dst_full = _anime_enrich_index_for_pair(dst_full, provider_cfg, src, dst)
         if len(src_idx) != src_before or len(dst_full) != dst_before:
             dbg("anime_mapping.rekeyed", feature=feature, src=src, dst=dst, src_items=len(src_idx), dst_items=len(dst_full))
 
@@ -1232,7 +1234,7 @@ def run_one_way_feature(
             unresolved_before = set(load_unresolved_keys(dst, feature, cross_features=_cross_feature_unresolved(feature)) or [])
             upd_res = apply_update(
                 dst_ops=dst_ops,
-                cfg=cfg,
+                cfg=provider_cfg,
                 dst_name=dst,
                 feature=feature,
                 items=updates,
@@ -1283,7 +1285,7 @@ def run_one_way_feature(
             _ = set(load_blackbox_keys(dst, feature) or [])
             add_res = apply_add(
                 dst_ops=dst_ops,
-                cfg=cfg,
+                cfg=provider_cfg,
                 dst_name=dst,
                 feature=feature,
                 items=adds,
@@ -1429,7 +1431,7 @@ def run_one_way_feature(
         else:
             rem_res = apply_remove(
                 dst_ops=dst_ops,
-                cfg=cfg,
+                cfg=provider_cfg,
                 dst_name=dst,
                 feature=feature,
                 items=removes,

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -66,9 +66,9 @@ except Exception:
 
 from ..id_map import minimal as _minimal, canonical_key as _ck, merge_ids as _merge_ids
 from ..anime_mapping.service import (
+    anime_mapping_pair_feature_options as _anime_pair_feature_options,
+    config_with_pair_feature_options as _anime_config_with_pair_feature_options,
     enrich_index_for_pair as _anime_enrich_index_for_pair,
-    mapping_enabled_for_feature as _anime_mapping_enabled_for_feature,
-    mapping_enabled_for_pair as _anime_mapping_enabled_for_pair,
 )
 from ._snapshots import (
     build_snapshots_for_feature,
@@ -303,6 +303,8 @@ def _two_way_sync(
 
     aops = provs.get(a)
     bops = provs.get(b)
+    anime_pair_opts = _anime_pair_feature_options(cfg, fcfg, feature, a, b, anime_only_default=(a == "ANILIST" or b == "ANILIST"))
+    provider_cfg = _anime_config_with_pair_feature_options(cfg, anime_pair_opts) if "ANILIST" in {a, b} else cfg
     if not aops or not bops:
         info(f"[!] Missing provider ops for {a}<->{b}")
         return {"ok": False, "adds_to_A": 0, "adds_to_B": 0, "rem_from_A": 0, "rem_from_B": 0}
@@ -392,7 +394,7 @@ def _two_way_sync(
     pair_providers = {a: aops, b: bops}
 
     snaps = build_snapshots_for_feature(
-        feature=feature, config=cfg, providers=pair_providers,
+        feature=feature, config=provider_cfg, providers=pair_providers,
         snap_cache=ctx.snap_cache, snap_ttl_sec=ctx.snap_ttl_sec,
         dbg=dbg, emit_info=info,
     )
@@ -440,12 +442,12 @@ def _two_way_sync(
 
     prev_cp_A = prev_checkpoint(prev_state, a, feature, src_inst)
     prev_cp_B = prev_checkpoint(prev_state, b, feature, dst_inst)
-    now_cp_A = module_checkpoint(aops, cfg, feature)
-    now_cp_B = module_checkpoint(bops, cfg, feature)
+    now_cp_A = module_checkpoint(aops, provider_cfg, feature)
+    now_cp_B = module_checkpoint(bops, provider_cfg, feature)
 
     if drop_guard:
         A_eff_guard, A_suspect, A_reason = coerce_suspect_snapshot(
-            config=cfg,
+            config=provider_cfg,
             provider=a, ops=aops, prev_idx=prevA, cur_idx=A_cur, feature=feature,
             suspect_min_prev=int((cfg.get("runtime") or {}).get("suspect_min_prev", 20)),
             suspect_shrink_ratio=float((cfg.get("runtime") or {}).get("suspect_shrink_ratio", 0.10)),
@@ -455,7 +457,7 @@ def _two_way_sync(
         if A_suspect:
             dbg("snapshot.guard", provider=a, feature=feature, reason=A_reason)
         B_eff_guard, B_suspect, B_reason = coerce_suspect_snapshot(
-            config=cfg,
+            config=provider_cfg,
             provider=b, ops=bops, prev_idx=prevB, cur_idx=B_cur, feature=feature,
             suspect_min_prev=int((cfg.get("runtime") or {}).get("suspect_min_prev", 20)),
             suspect_shrink_ratio=float((cfg.get("runtime") or {}).get("suspect_shrink_ratio", 0.10)),
@@ -514,11 +516,11 @@ def _two_way_sync(
     A_eff = _enrich_index_payload(A_eff, prevA, feature)
     B_eff = _enrich_index_payload(B_eff, prevB, feature)
 
-    if _anime_mapping_enabled_for_feature(cfg, feature) and _anime_mapping_enabled_for_pair(cfg, a, b):
+    if bool(anime_pair_opts.get("use_anime_mapping", False)):
         a_before = len(A_eff)
         b_before = len(B_eff)
-        A_eff = _anime_enrich_index_for_pair(A_eff, cfg, a, b)
-        B_eff = _anime_enrich_index_for_pair(B_eff, cfg, a, b)
+        A_eff = _anime_enrich_index_for_pair(A_eff, provider_cfg, a, b)
+        B_eff = _anime_enrich_index_for_pair(B_eff, provider_cfg, a, b)
         if len(A_eff) != a_before or len(B_eff) != b_before:
             dbg("anime_mapping.rekeyed", feature=feature, a=a, b=b, a_items=len(A_eff), b_items=len(B_eff))
 
@@ -1478,7 +1480,7 @@ def _two_way_sync(
         else:
             emit("two:apply:remove:A:start", dst=a, feature=feature, count=len(rem_from_A))
             resA_rem = apply_remove(
-                dst_ops=aops, cfg=cfg, dst_name=a, feature=feature, items=rem_from_A,
+                dst_ops=aops, cfg=provider_cfg, dst_name=a, feature=feature, items=rem_from_A,
                 dry_run=dry_run_flag, emit=emit, dbg=dbg,
                 chunk_size=effective_chunk_size(ctx, a), chunk_pause_ms=_pause_for(a),
             )
@@ -1510,7 +1512,7 @@ def _two_way_sync(
         else:
             emit("two:apply:remove:B:start", dst=b, feature=feature, count=len(rem_from_B))
             resB_rem = apply_remove(
-                dst_ops=bops, cfg=cfg, dst_name=b, feature=feature, items=rem_from_B,
+                dst_ops=bops, cfg=provider_cfg, dst_name=b, feature=feature, items=rem_from_B,
                 dry_run=dry_run_flag, emit=emit, dbg=dbg,
                 chunk_size=effective_chunk_size(ctx, b), chunk_pause_ms=_pause_for(b),
             )
@@ -1555,7 +1557,7 @@ def _two_way_sync(
             emit("two:apply:update:A:start", dst=a, feature=feature, count=len(upd_to_A))
             unresolved_before_A = set(load_unresolved_keys(a, feature, cross_features=_cross_feature_unresolved(feature)) or [])
             resA_upd = apply_update(
-                dst_ops=aops, cfg=cfg, dst_name=a, feature=feature, items=upd_to_A,
+                dst_ops=aops, cfg=provider_cfg, dst_name=a, feature=feature, items=upd_to_A,
                 dry_run=dry_run_flag, emit=emit, dbg=dbg,
                 chunk_size=effective_chunk_size(ctx, a), chunk_pause_ms=_pause_for(a),
             )
@@ -1595,7 +1597,7 @@ def _two_way_sync(
             emit("two:apply:update:B:start", dst=b, feature=feature, count=len(upd_to_B))
             unresolved_before_B = set(load_unresolved_keys(b, feature, cross_features=_cross_feature_unresolved(feature)) or [])
             resB_upd = apply_update(
-                dst_ops=bops, cfg=cfg, dst_name=b, feature=feature, items=upd_to_B,
+                dst_ops=bops, cfg=provider_cfg, dst_name=b, feature=feature, items=upd_to_B,
                 dry_run=dry_run_flag, emit=emit, dbg=dbg,
                 chunk_size=effective_chunk_size(ctx, b), chunk_pause_ms=_pause_for(b),
             )
@@ -1647,7 +1649,7 @@ def _two_way_sync(
                 k2i_A[k] = _minimal(it)
             
             resA_add = apply_add(
-                dst_ops=aops, cfg=cfg, dst_name=a, feature=feature, items=add_to_A,
+                dst_ops=aops, cfg=provider_cfg, dst_name=a, feature=feature, items=add_to_A,
                 dry_run=dry_run_flag, emit=emit, dbg=dbg,
                 chunk_size=effective_chunk_size(ctx, a), chunk_pause_ms=_pause_for(a),
             )
@@ -1763,7 +1765,7 @@ def _two_way_sync(
                 k2i_B[k] = _minimal(it)
             
             resB_add = apply_add(
-                dst_ops=bops, cfg=cfg, dst_name=b, feature=feature, items=add_to_B,
+                dst_ops=bops, cfg=provider_cfg, dst_name=b, feature=feature, items=add_to_B,
                 dry_run=dry_run_flag, emit=emit, dbg=dbg,
                 chunk_size=effective_chunk_size(ctx, b), chunk_pause_ms=_pause_for(b),
             )

--- a/providers/sync/anilist/_watchlist.py
+++ b/providers/sync/anilist/_watchlist.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from cw_platform.id_map import minimal as id_minimal
 from cw_platform.anime_mapping import AnimeMappingService
+from cw_platform.anime_mapping.service import PAIR_FEATURE_OPTIONS_KEY, runtime_pair_feature_options
 
 from ._common import read_json, state_file, write_json
 from .._log import log as cw_log
@@ -165,10 +166,42 @@ def _to_int(v: Any) -> int | None:
 def _anime_mapping_enabled(adapter: Any) -> bool:
     try:
         cfg = getattr(adapter, "raw_cfg", None)
+        has_runtime_opts = isinstance(cfg, Mapping) and PAIR_FEATURE_OPTIONS_KEY in cfg
+        opts = runtime_pair_feature_options(cfg if isinstance(cfg, Mapping) else {}, "watchlist")
+        if has_runtime_opts and opts.get("use_anime_mapping") is False:
+            return False
         block = cfg.get("anime_mapping") if isinstance(cfg, Mapping) else {}
         if not isinstance(block, Mapping):
             return False
         return bool(block.get("enabled", False))
+    except Exception:
+        return False
+
+
+def _anime_mapping_ready(adapter: Any) -> bool:
+    if not _anime_mapping_enabled(adapter):
+        return False
+    try:
+        svc = AnimeMappingService(getattr(adapter, "raw_cfg", None))
+        ready = bool(svc.ready())
+        if not ready and not getattr(adapter, "_cw_anime_mapping_unavailable_logged", False):
+            setattr(adapter, "_cw_anime_mapping_unavailable_logged", True)
+            _warn("anime_mapping_unavailable", fallback="title_resolve")
+        return ready
+    except Exception as e:
+        if not getattr(adapter, "_cw_anime_mapping_unavailable_logged", False):
+            setattr(adapter, "_cw_anime_mapping_unavailable_logged", True)
+            _warn("anime_mapping_unavailable", fallback="title_resolve", error_type=e.__class__.__name__)
+        return False
+
+
+def _anime_only_sync(adapter: Any) -> bool:
+    try:
+        cfg = getattr(adapter, "raw_cfg", None)
+        if not (isinstance(cfg, Mapping) and PAIR_FEATURE_OPTIONS_KEY in cfg):
+            return False
+        opts = runtime_pair_feature_options(cfg if isinstance(cfg, Mapping) else {}, "watchlist")
+        return bool(opts.get("anime_only_sync", False) and _anime_mapping_ready(adapter))
     except Exception:
         return False
 
@@ -181,12 +214,10 @@ def _has_anime_mapping_detail(item: Mapping[str, Any]) -> bool:
 
 def _anime_enrich(adapter: Any, item: Mapping[str, Any]) -> dict[str, Any]:
     out = dict(item or {})
-    if not _anime_mapping_enabled(adapter):
-        return out
     try:
-        svc = AnimeMappingService(getattr(adapter, "raw_cfg", None))
-        if not svc.ready():
+        if not _anime_mapping_ready(adapter):
             return out
+        svc = AnimeMappingService(getattr(adapter, "raw_cfg", None))
         enriched = svc.enrich_item(out)
         if isinstance(enriched, dict):
             ids0 = out.get("ids") if isinstance(out.get("ids"), Mapping) else {}
@@ -305,6 +336,15 @@ def _resolve_media_id(adapter: Any, item: Mapping[str, Any]) -> tuple[int | None
                     source="anime_mapping" if mapped else "item_ids",
                 )
                 return int(aid), meta
+
+    if _anime_only_sync(adapter):
+        _dbg(
+            "resolve_miss",
+            title=str(item.get("title") or ""),
+            year=_to_int(item.get("year")),
+            reason="anime_only_unmapped",
+        )
+        return None, {"anime_only_unmapped": True}
 
     title = str(item.get("title") or "").strip()
     if not title:
@@ -596,11 +636,12 @@ def add_detailed(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, 
             mid, meta = _resolve_media_id(adapter, m)
 
         if not mid:
+            skip_reason = "anime_only_unmapped" if meta.get("anime_only_unmapped") else "not_anime_or_no_match"
 
             if src_key:
                 ent2: dict[str, Any] = dict(shadow.get(src_key) or {})
                 ent2["ignored"] = True
-                ent2["ignore_reason"] = "not_anime_or_no_match"
+                ent2["ignore_reason"] = skip_reason
                 ent2["type"] = str(m.get("type") or ent2.get("type") or "")
                 src_ids = m.get("ids")
                 if isinstance(src_ids, Mapping) and src_ids:
@@ -614,7 +655,7 @@ def add_detailed(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, 
                 ent2["updated_at"] = int(time.time())
                 shadow[src_key] = ent2
                 shadow_changed = True
-            _dbg("write_item_skipped", op="add", title=str(m.get('title') or ''), year=_to_int(m.get('year')), reason="not_anime_or_no_match")
+            _dbg("write_item_skipped", op="add", title=str(m.get('title') or ''), year=_to_int(m.get('year')), reason=skip_reason)
             if src_key and src_key not in _seen_skip:
                 skipped_keys.append(src_key)
                 _seen_skip.add(src_key)


### PR DESCRIPTION
# Pull request

## Change

Added per-pair AniList watchlist controls for Anime ID Mapping and Anime-only sync.

- Added pair-level `Use Anime ID Mapping` and `Anime-only sync` toggles for AniList watchlist pairs.
- Added help icons/tooltips for both new options.
- Automatically enables global Anime ID Mapping when a pair enables Anime ID Mapping.
- Enforces that Anime-only sync can only be active when Anime ID Mapping is active.
- Passes pair-level Anime Mapping options through one-way and two-way orchestration.
- Updates AniList watchlist writes so Anime-only sync skips unmapped/non-anime items before AniList title search.

## Why

AniList only accepts anime. Without a filter, providers like Plex can send all watchlist items to AniList and most non-anime titles are rejected after title resolution.

Anime-only sync makes Plex/Emby/Jellyfin/etc. to AniList cleaner by adding confirmed anime and skipping non-anime items as skipped, not unresolved errors.

## Testing

- Ran JS syntax checks for the pair-config modal files.
- Ran focused Anime Mapping pair-option tests.


## Issue

NA