### PR TITLE
Add: AniList ratings sync with Anime Mapping support

### DIFF
--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -164,7 +164,7 @@ def _normalize_features(f: dict | None) -> dict:
     return f
 
 _PROGRESS_ALLOWED = {"PLEX", "EMBY", "JELLYFIN", "PUBLICMETADB", "CROSSWATCH"}
-_RATINGS_ALLOWED = {"PLEX", "SIMKL", "TRAKT", "TMDB", "MDBLIST", "PUBLICMETADB", "CROSSWATCH"}
+_RATINGS_ALLOWED = {"PLEX", "SIMKL", "TRAKT", "TMDB", "MDBLIST", "PUBLICMETADB", "CROSSWATCH", "ANILIST"}
 
 def _enforce_pair_feature_constraints(pair: dict[str, Any]) -> None:
     try:

--- a/assets/helpers/settings-ui.js
+++ b/assets/helpers/settings-ui.js
@@ -861,7 +861,7 @@ function cwBuildAnimeMappingPanel() {
     <div class="cw-panel-head anime-mapping-head">
       <div class="cw-panel-head-main">
         <div class="cw-panel-title">Anime ID Mapping</div>
-        <div class="muted">Local anime ID index for AniList watchlist pairs.</div>
+        <div class="muted">Local anime ID index for AniList watchlist and ratings pairs.</div>
       </div>
       <label class="cx-toggle anime-mapping-toggle">
         <input type="checkbox" id="anime_mapping_enabled">

--- a/assets/js/modals/pair-config/help.js
+++ b/assets/js/modals/pair-config/help.js
@@ -22,6 +22,8 @@ export const HELP_TEXT = {
   "cx-rt-enable": "Ratings: Enable\nCompare and write ratings to the target.",
   "cx-rt-add": "Ratings: Add / Update\nWrites ratings/updates to the target.",
   "cx-rt-remove": "Ratings: Remove\nClears ratings on the target (destructive and only for very specific needs).",
+  "cx-rt-anime-map": "Use Anime ID Mapping\nUse the local AniBridge ID database for this AniList ratings pair. When enabled from here, global Anime ID Mapping is enabled too.",
+  "cx-rt-anime-only": "Anime-only sync\nOnly sync ratings for items that Anime ID Mapping can confirm as anime. Non-anime and unmapped items are skipped before AniList title search.",
 
   "cx-hs-enable": "History: Enable\nCompare and write watch history to the target.",
   "cx-hs-add": "History: Add\nAdds plays/watched items to the target history.",

--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -69,7 +69,7 @@ function normalizeAnimeFeatureOptions(state, feature){
   return opts;
 }
 
-const RATINGS_TYPE_RULES={SIMKL:{disable:["seasons","episodes"]},TMDB:{disable:["seasons"]}};
+const RATINGS_TYPE_RULES={SIMKL:{disable:["seasons","episodes"]},TMDB:{disable:["seasons"]},ANILIST:{disable:["seasons","episodes"]}};
 function ratingsDisabledFor(state){
   const names=[state?.src,state?.dst].map(x=>String(x||"").trim().toUpperCase());
   const out=new Set();
@@ -312,6 +312,7 @@ async function loadProviders(state){
     {name:"CROSSWATCH",label:"CW Tracker",features:{watchlist:true,ratings:true,history:true,progress:true,playlists:false},capabilities:{bidirectional:true},version:"1.0.0"},
     {name:"SIMKL",label:"Simkl",features:{watchlist:true,ratings:true,history:true,progress:false,playlists:false},capabilities:{bidirectional:true},version:"1.0.0"},
     {name:"TRAKT",label:"Trakt",features:{watchlist:true,ratings:true,history:true,progress:false,playlists:true},capabilities:{bidirectional:true},version:"1.0.0"},
+    {name:"ANILIST",label:"AniList",features:{watchlist:true,ratings:true,history:false,progress:false,playlists:false},capabilities:{bidirectional:true},version:"0.1"},
     {name:"JELLYFIN",label:"Jellyfin",features:{watchlist:true,ratings:false,history:true,progress:true,playlists:true},capabilities:{bidirectional:true},version:"1.2.1"},
     {name:"EMBY",label:"Emby",features:{watchlist:true,ratings:false,history:true,progress:true,playlists:true},capabilities:{bidirectional:true},version:"1.0.0"} 
   ]
@@ -650,7 +651,7 @@ function applySubDisable(feature){
       "#tr-wl-etag","#tr-wl-ttl","#tr-wl-batch","#tr-wl-log","#tr-wl-freeze"
     ],
     ratings: [
-      "#cx-rt-add","#cx-rt-remove","#cx-rt-type-all","#cx-rt-type-movies","#cx-rt-type-shows","#cx-rt-type-seasons","#cx-rt-type-episodes","#cx-rt-mode","#cx-rt-from-date",
+      "#cx-rt-add","#cx-rt-remove","#cx-rt-anime-map","#cx-rt-anime-only","#cx-rt-type-all","#cx-rt-type-movies","#cx-rt-type-shows","#cx-rt-type-seasons","#cx-rt-type-episodes","#cx-rt-mode","#cx-rt-from-date",
       "#tr-rt-perpage","#tr-rt-maxpages","#tr-rt-chunk"
     ],
     history: ["#cx-hs-add", "#cx-hs-remove", "#cx-tr-hs-numfb", "#cx-tr-hs-col", "#cx-tr-hs-col-movies", "#cx-tr-hs-col-shows", "#cx-tr-hs-ignore-dropped", "#cx-md-hs-ignore-dropped", "#cx-sm-hs-ignore-dropped", "#cx-tr-hs-unres"],
@@ -1158,12 +1159,29 @@ function renderFeaturePanel(state){
   }
 
   if(state.feature==="ratings"){
-    const rt=getOpts(state,"ratings"),hasType=t=>Array.isArray(rt.types)&&rt.types.includes(t);
+    getOpts(state,"ratings");
+    const rt=normalizeAnimeFeatureOptions(state,"ratings"),hasType=t=>Array.isArray(rt.types)&&rt.types.includes(t);
+    const showAnime = hasAniList(state);
+    const canAnimeOnly = anilistCanReceive(state);
+    const animeOnlyDisabled = !rt.use_anime_mapping || !canAnimeOnly;
 
     left.innerHTML=`<div class="panel-title">Ratings | Basics</div>
       <div class="opt-row"><label for="cx-rt-enable">Enable</label><label class="switch"><input id="cx-rt-enable" type="checkbox" ${rt.enable?"checked":""}><span class="slider"></span></label></div>
       <div class="grid2"><div class="opt-row"><label for="cx-rt-add">Add / Update</label><label class="switch"><input id="cx-rt-add" type="checkbox" ${rt.add?"checked":""}><span class="slider"></span></label></div>
       <div class="opt-row"><label for="cx-rt-remove">Remove (clear)</label><label class="switch"><input id="cx-rt-remove" type="checkbox" ${rt.remove?"checked":""}><span class="slider"></span></label></div></div>
+      ${showAnime?`
+        <div class="panel-title small" style="margin-top:6px">AniList options</div>
+        <div class="grid2 compact">
+          <div class="opt-row">
+            <label for="cx-rt-anime-map">Use Anime ID Mapping</label>
+            <label class="switch"><input id="cx-rt-anime-map" type="checkbox" ${rt.use_anime_mapping?"checked":""}><span class="slider"></span></label>
+          </div>
+          <div class="opt-row ${animeOnlyDisabled?"muted":""}">
+            <label for="cx-rt-anime-only">Anime-only sync</label>
+            <label class="switch"><input id="cx-rt-anime-only" type="checkbox" ${rt.anime_only_sync?"checked":""} ${animeOnlyDisabled?"disabled":""}><span class="slider"></span></label>
+          </div>
+        </div>
+      `:""}
       <div class="panel-title small">Scope</div>
       <div class="grid2 compact">
         <div class="opt-row"><label for="cx-rt-type-all">All</label><label class="switch"><input id="cx-rt-type-all" type="checkbox" ${(hasType("movies")&&hasType("shows")&&hasType("seasons")&&hasType("episodes"))?"checked":""}><span class="slider"></span></label></div>
@@ -1674,6 +1692,24 @@ function bindChangeHandlers(state,root){
 
     if (id === "cx-rt-enable") {
       applySubDisable("ratings");
+      const mapOn = !!ID("cx-rt-anime-map")?.checked;
+      const only = ID("cx-rt-anime-only");
+      if (only) {
+        only.disabled = !mapOn || !anilistCanReceive(state) || !ID("cx-rt-enable")?.checked;
+        if (only.disabled) only.checked = false;
+        only.closest?.(".opt-row")?.classList.toggle("muted", only.disabled);
+      }
+    }
+
+    if (id === "cx-rt-anime-map") {
+      const mapOn = !!ID("cx-rt-anime-map")?.checked;
+      const only = ID("cx-rt-anime-only");
+      if (only) {
+        only.disabled = !mapOn || !anilistCanReceive(state) || !ID("cx-rt-enable")?.checked;
+        if (!mapOn || !anilistCanReceive(state) || !ID("cx-rt-enable")?.checked) only.checked = false;
+        else if (mapOn) only.checked = true;
+        only.closest?.(".opt-row")?.classList.toggle("muted", only.disabled);
+      }
     }
 
     if (id === "cx-hs-enable") {
@@ -1741,6 +1777,8 @@ function bindChangeHandlers(state,root){
         enable:!!ID("cx-rt-enable")?.checked,
         add:!!ID("cx-rt-add")?.checked,
         remove:!!ID("cx-rt-remove")?.checked,
+        use_anime_mapping:!!ID("cx-rt-anime-map")?.checked,
+        anime_only_sync:!!ID("cx-rt-anime-map")?.checked && !!ID("cx-rt-anime-only")?.checked && anilistCanReceive(state),
         types,
         mode:ID("cx-rt-mode")?.value||"all",
         from_date:(ID("cx-rt-from-date")?.value||"").trim()
@@ -1865,7 +1903,10 @@ async function saveConfigBits(state){
   try{
     const cur=await fetch("/api/config",{cache:"no-store"}).then(r=>r.ok?r.json():{});
     const cfg=typeof structuredClone==="function"?structuredClone(cur||{}):jclone(cur||{});
-    const shouldEnableAnimeMapping = hasAniList(state) && !!normalizeAnimeFeatureOptions(state, "watchlist").use_anime_mapping;
+    const shouldEnableAnimeMapping = hasAniList(state) && (
+      !!normalizeAnimeFeatureOptions(state, "watchlist").use_anime_mapping ||
+      !!normalizeAnimeFeatureOptions(state, "ratings").use_anime_mapping
+    );
 
     if(ID("gl-dry")){
       const dropOn=!!ID("gl-drop")?.checked;
@@ -2124,17 +2165,21 @@ function buildPayload(state,wrap){
   const watchlist=get("watchlist");
   const animePair=isAniList(src)||isAniList(dst);
   const animeCanReceive=isAniList(dst)||(animePair&&modeTwo);
-  if(animePair){
-    if(!hasOwn(watchlist,"use_anime_mapping")) watchlist.use_anime_mapping=globalAnimeMappingEnabled(state);
-    watchlist.use_anime_mapping=!!watchlist.use_anime_mapping;
-    if(!watchlist.use_anime_mapping||!animeCanReceive) watchlist.anime_only_sync=false;
-    else if(!hasOwn(watchlist,"anime_only_sync")) watchlist.anime_only_sync=true;
-    else watchlist.anime_only_sync=!!watchlist.anime_only_sync;
-  }else{
-    watchlist.use_anime_mapping=false;
-    watchlist.anime_only_sync=false;
-  }
   const ratings=get("ratings");
+  const normalizeAnimePairBlock=(block)=>{
+    if(animePair){
+      if(!hasOwn(block,"use_anime_mapping")) block.use_anime_mapping=globalAnimeMappingEnabled(state);
+      block.use_anime_mapping=!!block.use_anime_mapping;
+      if(!block.use_anime_mapping||!animeCanReceive) block.anime_only_sync=false;
+      else if(!hasOwn(block,"anime_only_sync")) block.anime_only_sync=true;
+      else block.anime_only_sync=!!block.anime_only_sync;
+    }else{
+      block.use_anime_mapping=false;
+      block.anime_only_sync=false;
+    }
+  };
+  normalizeAnimePairBlock(watchlist);
+  normalizeAnimePairBlock(ratings);
   const progress=get("progress");
   const dis=ratingsDisabledFor({src,dst});
   if(ratings&&Array.isArray(ratings.types)&&dis.size)ratings.types=ratings.types.filter(t=>!dis.has(String(t)));

--- a/cw_platform/anime_mapping/service.py
+++ b/cw_platform/anime_mapping/service.py
@@ -12,7 +12,7 @@ from .descriptors import descriptor_candidates_for_id, parse_descriptor
 from .storage import paths, query_edges, read_state
 
 ANIME_NATIVE_PROVIDERS = {"anilist"}
-DEFAULT_FEATURES = {"watchlist"}
+DEFAULT_FEATURES = {"watchlist", "ratings"}
 OUTPUT_KEYS = ("anilist", "mal", "anidb", "tmdb", "tvdb", "imdb")
 PAIR_FEATURE_OPTIONS_KEY = "_cw_pair_feature_options"
 _MEDIA_KIND_KEYS: dict[str, str] = {
@@ -78,13 +78,14 @@ def anime_mapping_pair_feature_options(
     anime_only_default: bool = False,
 ) -> dict[str, Any]:
     feature_name = str(feature or "").strip().lower()
-    base_enabled = mapping_enabled_for_feature(cfg, feature_name) and mapping_enabled_for_pair(cfg, *providers)
+    pair_enabled = mapping_enabled_for_pair(cfg, *providers)
+    base_enabled = mapping_enabled_for_feature(cfg, feature_name) and pair_enabled
     opts = _pair_feature_options(feature_cfg)
 
     if "use_anime_mapping" not in dict(feature_cfg or {}):
         opts["use_anime_mapping"] = bool(base_enabled)
     else:
-        opts["use_anime_mapping"] = bool(base_enabled and opts.get("use_anime_mapping"))
+        opts["use_anime_mapping"] = bool(pair_enabled and opts.get("use_anime_mapping"))
 
     if not opts["use_anime_mapping"]:
         opts["anime_only_sync"] = False

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -561,7 +561,7 @@ DEFAULT_CFG: dict[str, Any] = {
         "refresh_hours": 24,                            # Minimum age before an automatic refresh is considered
         "stale_after_days": 14,                         # UI/status warning threshold
         "use_for_pairs": ["anilist"],                   # Providers that activate anime mapping when present in a pair
-        "features": ["watchlist"],                      # Sync features where anime ID enrichment is applied
+        "features": ["watchlist", "ratings"],           # Sync features where anime ID enrichment is applied
     },
 
     # --- Scrobble ------------------------------------------------------------
@@ -1360,7 +1360,7 @@ def _normalize_anime_mapping(cfg: dict[str, Any]) -> None:
         return out or list(default)
 
     am["use_for_pairs"] = _string_list(am.get("use_for_pairs"), ["anilist"])
-    am["features"] = _string_list(am.get("features"), ["watchlist"])
+    am["features"] = _string_list(am.get("features"), ["watchlist", "ratings"])
 
 
 def _normalize_ui(cfg: dict[str, Any]) -> None:

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -1061,15 +1061,12 @@ def run_one_way_feature(
 
     if allow_removes:
         if feature == "ratings":
-            if remove_mode == "mirror":
-                removes = list(mirror_removes or [])
-                if removes:
-                    removes = [it for it in removes if not _present(src_idx, src_alias, it)]
-                    if prev_dst:
-                        prev_dst_alias = _alias_index(prev_dst)
-                        removes = [it for it in removes if _present(prev_dst, prev_dst_alias, it)]
-            else:
-                removes = _observed_source_removes()
+            removes = list(mirror_removes or [])
+            if removes:
+                removes = [it for it in removes if not _present(src_idx, src_alias, it)]
+                if prev_dst:
+                    prev_dst_alias = _alias_index(prev_dst)
+                    removes = [it for it in removes if _present(prev_dst, prev_dst_alias, it)]
         elif remove_mode == "mirror":
             removes = list(mirror_removes or [])
             if removes:

--- a/providers/auth/_auth_ANILIST.py
+++ b/providers/auth/_auth_ANILIST.py
@@ -100,7 +100,12 @@ class AniListAuth(AuthProvider):
         )
 
     def capabilities(self) -> dict[str, Any]:
-        return {"features": {"watchlist": {"read": True, "write": True}}}
+        return {
+            "features": {
+                "watchlist": {"read": True, "write": True},
+                "ratings": {"read": True, "write": True},
+            }
+        }
 
     def get_status(self, cfg: Mapping[str, Any], *, instance_id: Any = None) -> AuthStatus:
         s = _read(cfg, instance_id)

--- a/providers/sync/_mod_ANILIST.py
+++ b/providers/sync/_mod_ANILIST.py
@@ -86,6 +86,20 @@ except Exception as e:
         error=str(e),
     )
 
+try:
+    from .anilist import _ratings as feat_ratings
+except Exception as e:
+    feat_ratings = None
+    cw_log(
+        "ANILIST",
+        "module",
+        "warn",
+        "feature_import_failed",
+        import_feature="ratings",
+        error_type=e.__class__.__name__,
+        error=str(e),
+    )
+
 
 GQL_URL = "https://graphql.anilist.co"
 UA = os.environ.get("CW_ANILIST_UA") or os.environ.get("CW_UA") or f"CrossWatch/{__VERSION__} (AniList)"
@@ -117,10 +131,22 @@ def label_anilist(method: str, url: str, kw: Mapping[str, Any]) -> str:
         payload = kw.get("json")
         if isinstance(payload, Mapping):
             q = str(payload.get("query") or "")
+            variables_raw = payload.get("variables")
+            variables = variables_raw if isinstance(variables_raw, Mapping) else {}
             if "Viewer" in q:
                 return "viewer"
+            if "MediaListCollection" in q and "score(" in q:
+                return "ratings:index"
             if "MediaListCollection" in q:
                 return "watchlist:index"
+            if "SaveMediaListEntry" in q and "scoreRaw" in q:
+                try:
+                    score_raw = variables.get("scoreRaw")
+                    if score_raw is not None and int(score_raw) == 0:
+                        return "ratings:remove"
+                except Exception:
+                    pass
+                return "ratings:add"
             if "SaveMediaListEntry" in q:
                 return "watchlist:add"
             if "DeleteMediaListEntry" in q:
@@ -128,6 +154,8 @@ def label_anilist(method: str, url: str, kw: Mapping[str, Any]) -> str:
             if "MediaList(" in q or " MediaList(" in q:
                 return "watchlist:lookup"
             if "Media(idMal" in q:
+                if "score(" in q:
+                    return "ratings:resolve"
                 return "watchlist:resolve"
     except Exception:
         pass
@@ -223,7 +251,7 @@ class ANILISTClient:
 
 
 def supported_features() -> dict[str, bool]:
-    return {"watchlist": bool(feat_watchlist), "ratings": False, "history": False, "playlists": False}
+    return {"watchlist": bool(feat_watchlist), "ratings": bool(feat_ratings), "history": False, "playlists": False}
 
 
 def get_manifest() -> Mapping[str, Any]:
@@ -240,6 +268,12 @@ def get_manifest() -> Mapping[str, Any]:
             "provides_ids": True,
             "index_semantics": "present",
             "observed_deletes": False,
+            "ratings": {
+                "types": {"movies": True, "shows": True, "seasons": False, "episodes": False},
+                "upsert": True,
+                "unrate": True,
+                "from_date": False,
+            },
         },
     }
 
@@ -345,7 +379,7 @@ class ANILISTModule:
         feats = supported_features()
         features = {
             "watchlist": bool(feats.get("watchlist") and ok),
-            "ratings": False,
+            "ratings": bool(feats.get("ratings") and ok),
             "history": False,
             "playlists": False,
         }
@@ -379,10 +413,11 @@ class ANILISTModule:
         return tuple(k for k, v in feats.items() if v)
 
     def build_index(self, feature: str, **kwargs: Any) -> dict[str, dict[str, Any]]:
-        if feature != "watchlist" or not feat_watchlist:
+        mod = {"watchlist": feat_watchlist, "ratings": feat_ratings}.get(str(feature or "").strip().lower())
+        if not mod:
             _info("index_skipped", feature=feature, reason="disabled_or_missing")
             return {}
-        return feat_watchlist.build_index(self)
+        return mod.build_index(self)
 
     def add(
         self,
@@ -396,11 +431,13 @@ class ANILISTModule:
             return {"ok": True, "count": 0}
         if dry_run:
             return {"ok": True, "count": len(lst), "dry_run": True}
-        if feature != "watchlist" or not feat_watchlist:
+        feature_name = str(feature or "").strip().lower()
+        mod = {"watchlist": feat_watchlist, "ratings": feat_ratings}.get(feature_name)
+        if not mod:
             _info("write_skipped", op="add", feature=feature, reason="disabled_or_missing")
             return {"ok": True, "count": 0, "unresolved": []}
-        if hasattr(feat_watchlist, "add_detailed"):
-            res = feat_watchlist.add_detailed(self, lst)  # type: ignore[attr-defined]
+        if hasattr(mod, "add_detailed"):
+            res = mod.add_detailed(self, lst)  # type: ignore[attr-defined]
             confirmed_keys = (res or {}).get("confirmed_keys") or []
             skipped_keys = (res or {}).get("skipped_keys") or []
             unresolved = (res or {}).get("unresolved") or []
@@ -413,9 +450,10 @@ class ANILISTModule:
                 "skipped_keys": list(skipped_keys) if isinstance(skipped_keys, list) else [],
                 "unresolved": list(unresolved) if isinstance(unresolved, list) else [],
             }
-        count, unresolved = feat_watchlist.add(self, lst)
+        count, unresolved = mod.add(self, lst)
         confirmed_keys = _confirmed_keys(self.key_of, lst, unresolved)
         return {"ok": True, "count": int(count), "unresolved": unresolved, "confirmed_keys": confirmed_keys}
+
     def remove(
         self,
         feature: str,
@@ -428,12 +466,15 @@ class ANILISTModule:
             return {"ok": True, "count": 0}
         if dry_run:
             return {"ok": True, "count": len(lst), "dry_run": True}
-        if feature != "watchlist" or not feat_watchlist:
+        feature_name = str(feature or "").strip().lower()
+        mod = {"watchlist": feat_watchlist, "ratings": feat_ratings}.get(feature_name)
+        if not mod:
             _info("write_skipped", op="remove", feature=feature, reason="disabled_or_missing")
             return {"ok": True, "count": 0, "unresolved": []}
-        count, unresolved = feat_watchlist.remove(self, lst)
+        count, unresolved = mod.remove(self, lst)
         confirmed_keys = _confirmed_keys(self.key_of, lst, unresolved)
         return {"ok": True, "count": int(count), "unresolved": unresolved, "confirmed_keys": confirmed_keys}
+
 class _ANILISTOPS:
     def name(self) -> str:
         return "ANILIST"
@@ -450,6 +491,12 @@ class _ANILISTOPS:
             "provides_ids": True,
             "index_semantics": "present",
             "observed_deletes": False,
+            "ratings": {
+                "types": {"movies": True, "shows": True, "seasons": False, "episodes": False},
+                "upsert": True,
+                "unrate": True,
+                "from_date": False,
+            },
         }
 
     def is_configured(self, cfg: Mapping[str, Any]) -> bool:

--- a/providers/sync/anilist/_ratings.py
+++ b/providers/sync/anilist/_ratings.py
@@ -1,0 +1,562 @@
+# /providers/sync/anilist/_ratings.py
+# AniList ratings sync functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from cw_platform.anime_mapping import AnimeMappingService
+from cw_platform.anime_mapping.service import (
+    PAIR_FEATURE_OPTIONS_KEY,
+    mapped_or_default_media_type,
+    mapping_enabled_for_feature,
+    runtime_pair_feature_options,
+)
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+
+from .._log import log as cw_log
+
+
+def _dbg(msg: str, **fields: Any) -> None:
+    cw_log("ANILIST", "ratings", "debug", msg, **fields)
+
+
+def _info(msg: str, **fields: Any) -> None:
+    cw_log("ANILIST", "ratings", "info", msg, **fields)
+
+
+def _warn(msg: str, **fields: Any) -> None:
+    cw_log("ANILIST", "ratings", "warn", msg, **fields)
+
+
+def _error(msg: str, **fields: Any) -> None:
+    cw_log("ANILIST", "ratings", "error", msg, **fields)
+
+
+GQL_LIST_RATINGS = """
+query ($userId: Int!, $type: MediaType!) {
+  MediaListCollection(userId: $userId, type: $type) {
+    lists {
+      entries {
+        id
+        mediaId
+        status
+        score(format: POINT_10)
+        updatedAt
+        createdAt
+        media {
+          id
+          idMal
+          title { romaji english native }
+          format
+          seasonYear
+          startDate { year }
+        }
+      }
+    }
+  }
+}
+""".strip()
+
+GQL_MEDIA_BY_MAL = """
+query ($idMal: Int!, $type: MediaType!) {
+  Media(idMal: $idMal, type: $type) { id idMal }
+}
+""".strip()
+
+GQL_SEARCH = """
+query ($search: String!, $page: Int = 1) {
+  Page(page: $page, perPage: 10) {
+    media(search: $search, type: ANIME) {
+      id
+      idMal
+      format
+      seasonYear
+      startDate { year }
+      title { romaji english native }
+    }
+  }
+}
+""".strip()
+
+GQL_SAVE_RATING = """
+mutation ($mediaId: Int!, $scoreRaw: Int!) {
+  SaveMediaListEntry(mediaId: $mediaId, scoreRaw: $scoreRaw) {
+    id
+    mediaId
+    score(format: POINT_10)
+  }
+}
+""".strip()
+
+
+def _to_int(v: Any) -> int | None:
+    try:
+        if v is None or isinstance(v, bool):
+            return None
+        if isinstance(v, int):
+            return int(v)
+        s = str(v).strip()
+        if not s:
+            return None
+        return int(float(s))
+    except Exception:
+        return None
+
+
+def _to_float(v: Any) -> float | None:
+    try:
+        if v is None or isinstance(v, bool):
+            return None
+        s = str(v).strip()
+        if not s:
+            return None
+        return float(s)
+    except Exception:
+        return None
+
+
+def _rating_1_10(v: Any) -> int | None:
+    f = _to_float(v)
+    if f is None or f <= 0:
+        return None
+    if 10 < f <= 100:
+        f = f / 10.0
+    n = int(f + 0.5)
+    return n if 1 <= n <= 10 else None
+
+
+def _score_raw(v: Any) -> int | None:
+    rating = _rating_1_10(v)
+    if rating is None:
+        return None
+    return max(0, min(100, int(rating) * 10))
+
+
+def _pick_title(t: Mapping[str, Any] | None) -> str:
+    if not isinstance(t, Mapping):
+        return ""
+    return str(t.get("english") or t.get("romaji") or t.get("native") or "").strip()
+
+
+def _media_type(media: Mapping[str, Any]) -> str:
+    fmt = str(media.get("format") or "").strip().upper()
+    return "movie" if fmt == "MOVIE" else "show"
+
+
+def _iso_from_epoch(v: Any) -> str | None:
+    n = _to_int(v)
+    if not n:
+        return None
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(int(n)))
+
+
+def _unresolved_item(item: Mapping[str, Any], reason: str) -> dict[str, Any]:
+    out = dict(id_minimal(item))
+    out["reason"] = reason
+    return out
+
+
+def _mapping_enabled(adapter: Any) -> bool:
+    try:
+        cfg = getattr(adapter, "raw_cfg", None)
+        if not isinstance(cfg, Mapping):
+            return False
+        if PAIR_FEATURE_OPTIONS_KEY in cfg:
+            opts = runtime_pair_feature_options(cfg, "ratings")
+            return bool(opts.get("use_anime_mapping", False))
+        return mapping_enabled_for_feature(cfg, "ratings")
+    except Exception:
+        return False
+
+
+def _mapping_ready(adapter: Any) -> bool:
+    if not _mapping_enabled(adapter):
+        return False
+    try:
+        svc = AnimeMappingService(getattr(adapter, "raw_cfg", None))
+        ready = bool(svc.ready())
+        if not ready and not getattr(adapter, "_cw_anime_ratings_mapping_unavailable_logged", False):
+            setattr(adapter, "_cw_anime_ratings_mapping_unavailable_logged", True)
+            _warn("anime_mapping_unavailable", fallback="title_resolve")
+        return ready
+    except Exception as e:
+        if not getattr(adapter, "_cw_anime_ratings_mapping_unavailable_logged", False):
+            setattr(adapter, "_cw_anime_ratings_mapping_unavailable_logged", True)
+            _warn("anime_mapping_unavailable", fallback="title_resolve", error_type=e.__class__.__name__)
+        return False
+
+
+def _anime_only_sync(adapter: Any) -> bool:
+    try:
+        cfg = getattr(adapter, "raw_cfg", None)
+        if not isinstance(cfg, Mapping) or PAIR_FEATURE_OPTIONS_KEY not in cfg:
+            return False
+        opts = runtime_pair_feature_options(cfg, "ratings")
+        return bool(opts.get("anime_only_sync", False) and _mapping_ready(adapter))
+    except Exception:
+        return False
+
+
+def _has_mapping_detail(item: Mapping[str, Any]) -> bool:
+    detail = item.get("detail") if isinstance(item.get("detail"), Mapping) else {}
+    amap = detail.get("anime_mapping") if isinstance(detail, Mapping) else {}
+    return isinstance(amap, Mapping) and any(bool(v) for v in amap.values())
+
+
+def _anime_enrich(adapter: Any, item: Mapping[str, Any]) -> dict[str, Any]:
+    out = dict(item or {})
+    try:
+        if not _mapping_ready(adapter):
+            return out
+        media_type = mapped_or_default_media_type(out)
+        svc = AnimeMappingService(getattr(adapter, "raw_cfg", None))
+        enriched = svc.enrich_ids(out.get("ids") if isinstance(out.get("ids"), Mapping) else {}, media_type=media_type)
+        if not isinstance(enriched, Mapping):
+            return out
+        if enriched.get("ids"):
+            ids0 = out.get("ids") if isinstance(out.get("ids"), Mapping) else {}
+            out["ids"] = enriched["ids"]
+            if dict(out.get("ids") or {}) != dict(ids0 or {}):
+                out["_cw_anime_mapping"] = True
+                _dbg("mapping_enriched", ids_before=len(ids0 or {}), ids_after=len(out.get("ids") or {}), title=str(out.get("title") or ""))
+        detail_raw = out.get("detail")
+        detail: dict[str, Any] = dict(detail_raw) if isinstance(detail_raw, Mapping) else {}
+        enriched_detail = enriched.get("detail")
+        if isinstance(enriched_detail, Mapping):
+            for k, v in enriched_detail.items():
+                detail[str(k)] = v
+        if detail:
+            out["detail"] = detail
+    except Exception as e:
+        _dbg("mapping_enrich_failed", error_type=e.__class__.__name__)
+    return out
+
+
+def _tick(prog: Any, value: int, total: int | None = None, *, force: bool = False) -> None:
+    if prog is None:
+        return
+    try:
+        if total is not None:
+            prog.tick(value, total=total, force=force)
+        else:
+            prog.tick(value)
+    except Exception:
+        pass
+
+
+def _done(prog: Any, *, ok: bool, total: int) -> None:
+    if prog is None:
+        return
+    done = getattr(prog, "done", None)
+    if not callable(done):
+        return
+    try:
+        done(ok=ok, total=total)
+    except Exception:
+        pass
+
+
+def _item_from_entry(adapter: Any, entry: Mapping[str, Any]) -> dict[str, Any] | None:
+    media = entry.get("media")
+    if not isinstance(media, Mapping):
+        return None
+    mid = _to_int(media.get("id") or entry.get("mediaId"))
+    if not mid:
+        return None
+    score = _rating_1_10(entry.get("score"))
+    if score is None:
+        return None
+    title = _pick_title(media.get("title") if isinstance(media.get("title"), Mapping) else None)
+    if not title:
+        return None
+    year = _to_int(media.get("seasonYear"))
+    if year is None:
+        sd = media.get("startDate")
+        if isinstance(sd, Mapping):
+            year = _to_int(sd.get("year"))
+    ids: dict[str, Any] = {"anilist": int(mid)}
+    mal = _to_int(media.get("idMal"))
+    if mal:
+        ids["mal"] = int(mal)
+    item: dict[str, Any] = {
+        "type": _media_type(media),
+        "title": title,
+        "year": int(year or 0),
+        "ids": ids,
+        "rating": int(score),
+        "anilist": {
+            "list_entry_id": int(_to_int(entry.get("id")) or 0),
+            "status": str(entry.get("status") or ""),
+        },
+    }
+    rated_at = _iso_from_epoch(entry.get("updatedAt") or entry.get("createdAt"))
+    if rated_at:
+        item["rated_at"] = rated_at
+    return _anime_enrich(adapter, item)
+
+
+def _resolve_media_id(adapter: Any, item: Mapping[str, Any]) -> tuple[int | None, dict[str, Any]]:
+    ids_raw = item.get("ids")
+    ids = ids_raw if isinstance(ids_raw, Mapping) else {}
+    mid = _to_int(ids.get("anilist"))
+    if mid:
+        return int(mid), {"anilist_id": int(mid), "method": "direct_id"}
+
+    mal = _to_int(ids.get("mal"))
+    if mal:
+        try:
+            data = adapter.client.gql(
+                GQL_MEDIA_BY_MAL,
+                {"idMal": int(mal), "type": "ANIME"},
+                feature="ratings:resolve",
+                tolerate_errors=True,
+            )
+            media = (data or {}).get("Media")
+            aid = _to_int(media.get("id")) if isinstance(media, Mapping) else None
+            if aid:
+                return int(aid), {"anilist_id": int(aid), "mal": int(mal), "method": "mal_lookup"}
+        except Exception as e:
+            _dbg("resolve_miss", method="mal_lookup", error_type=e.__class__.__name__, mal=int(mal))
+
+    if _anime_only_sync(adapter):
+        return None, {"anime_only_unmapped": True}
+
+    title = str(item.get("title") or "").strip()
+    if not title:
+        return None, {"missing_title": True}
+
+    year = _to_int(item.get("year"))
+    want_kind = str(item.get("type") or "").strip().lower()
+    try:
+        data = adapter.client.gql(
+            GQL_SEARCH,
+            {"search": title, "page": 1},
+            feature="ratings:search",
+            tolerate_errors=True,
+        )
+    except Exception as e:
+        _dbg("resolve_miss", method="search", error_type=e.__class__.__name__, title=title)
+        return None, {"search_failed": True}
+
+    page = (data or {}).get("Page")
+    rows = page.get("media") if isinstance(page, Mapping) else None
+    if not isinstance(rows, list):
+        return None, {"no_results": True}
+
+    best_id: int | None = None
+    best_score = -999
+    for cand in rows:
+        if not isinstance(cand, Mapping):
+            continue
+        cid = _to_int(cand.get("id"))
+        if not cid:
+            continue
+        ctitle = _pick_title(cand.get("title") if isinstance(cand.get("title"), Mapping) else None)
+        if not ctitle:
+            continue
+        score = 0
+        if ctitle.casefold() == title.casefold():
+            score += 60
+        elif title.casefold() in ctitle.casefold() or ctitle.casefold() in title.casefold():
+            score += 25
+        c_year = _to_int(cand.get("seasonYear"))
+        if c_year is None:
+            sd = cand.get("startDate")
+            if isinstance(sd, Mapping):
+                c_year = _to_int(sd.get("year"))
+        if year and c_year:
+            score += 15 if int(year) == int(c_year) else -15
+        fmt = str(cand.get("format") or "").strip().upper()
+        if want_kind == "movie":
+            score += 8 if fmt == "MOVIE" else -10
+        elif want_kind in ("show", "series", "tv", "anime"):
+            score += 5 if fmt != "MOVIE" else -4
+        if score > best_score:
+            best_score = score
+            best_id = int(cid)
+
+    if best_id and best_score >= 35:
+        _dbg("resolve_hit", anilist_id=int(best_id), score=int(best_score), title=title, year=year)
+        return int(best_id), {"anilist_id": int(best_id), "method": "search"}
+
+    _dbg("resolve_miss", reason="low_score" if best_id else "no_results", best_score=int(best_score), title=title, year=year)
+    return None, {"no_match": True}
+
+
+def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
+    prog_mk = getattr(adapter, "progress_factory", None)
+    prog = prog_mk("ratings") if callable(prog_mk) else None
+    viewer = adapter.client.viewer()
+    user_id = viewer.get("id") if isinstance(viewer, dict) else None
+    if not user_id:
+        return {}
+
+    t0 = time.time()
+    data = adapter.client.gql(
+        GQL_LIST_RATINGS,
+        {"userId": int(user_id), "type": "ANIME"},
+        feature="ratings:index",
+    )
+    _dbg("index_fetch_counts", source="live", dur_ms=int((time.time() - t0) * 1000))
+
+    mlc = (data or {}).get("MediaListCollection")
+    lists = mlc.get("lists") if isinstance(mlc, Mapping) else None
+    if not isinstance(lists, list):
+        return {}
+
+    out: dict[str, dict[str, Any]] = {}
+    done = 0
+    for lst in lists:
+        if not isinstance(lst, Mapping):
+            continue
+        entries = lst.get("entries")
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, Mapping):
+                continue
+            item = _item_from_entry(adapter, entry)
+            if not item:
+                continue
+            mini = id_minimal(item)
+            key = canonical_key(mini)
+            if not key:
+                continue
+            out[key] = mini
+            done += 1
+            _tick(prog, done)
+
+    _done(prog, ok=True, total=len(out))
+    _info("index_done", count=len(out), source="live")
+    return out
+
+
+def add_detailed(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    lst = list(items or [])
+    if not lst:
+        return {"ok": True, "count": 0, "confirmed": 0, "confirmed_keys": [], "skipped_keys": [], "unresolved": []}
+
+    prog_mk = getattr(adapter, "progress_factory", None)
+    prog = prog_mk("ratings", total=len(lst)) if callable(prog_mk) else None
+
+    ok = 0
+    unresolved: list[dict[str, Any]] = []
+    confirmed_keys: list[str] = []
+    skipped_keys: list[str] = []
+    seen_ok: set[str] = set()
+    seen_skip: set[str] = set()
+    skipped = 0
+    try:
+        opts = runtime_pair_feature_options(getattr(adapter, "raw_cfg", {}) if isinstance(getattr(adapter, "raw_cfg", {}), Mapping) else {}, "ratings")
+        _dbg(
+            "runtime_options",
+            use_anime_mapping=bool(opts.get("use_anime_mapping", False)),
+            anime_only_sync=bool(opts.get("anime_only_sync", False)),
+        )
+    except Exception:
+        pass
+
+    for i, it in enumerate(lst, start=1):
+        enriched = _anime_enrich(adapter, it)
+        mapped_item = bool(enriched.get("_cw_anime_mapping") or _has_mapping_detail(enriched))
+        mini = id_minimal(enriched)
+        if mapped_item:
+            mini["_cw_anime_mapping"] = True
+        src_key = adapter.key_of(mini) or ""
+        score_raw = _score_raw(mini.get("rating"))
+        if score_raw is None:
+            unresolved.append(_unresolved_item(mini, "missing_or_invalid_rating"))
+            _tick(prog, i, total=len(lst))
+            continue
+
+        mid, meta = _resolve_media_id(adapter, mini)
+        if not mid:
+            reason = "anime_only_unmapped" if meta.get("anime_only_unmapped") else "not_anime_or_no_match"
+            _dbg("write_item_skipped", op="add", title=str(mini.get("title") or ""), year=_to_int(mini.get("year")), reason=reason)
+            if meta.get("anime_only_unmapped"):
+                if src_key and src_key not in seen_skip:
+                    skipped_keys.append(src_key)
+                    seen_skip.add(src_key)
+                skipped += 1
+            else:
+                unresolved.append(_unresolved_item(mini, reason))
+            _tick(prog, i, total=len(lst))
+            continue
+
+        try:
+            adapter.client.gql(
+                GQL_SAVE_RATING,
+                {"mediaId": int(mid), "scoreRaw": int(score_raw)},
+                feature="ratings:add",
+            )
+            ok += 1
+            if src_key and src_key not in seen_ok:
+                confirmed_keys.append(src_key)
+                seen_ok.add(src_key)
+            _dbg("write_item_done", op="add", anilist_id=int(mid), rating=int(score_raw / 10), source=str(meta.get("method") or ""))
+        except Exception as e:
+            _warn("write_failed", op="add", error_type=e.__class__.__name__, anilist_id=int(mid))
+            unresolved.append(_unresolved_item(mini, f"write_failed:{e.__class__.__name__}"))
+        _tick(prog, i, total=len(lst))
+
+    _done(prog, ok=len(unresolved) == 0, total=len(lst))
+    _info("write_done", op="add", ok=len(unresolved) == 0, applied=ok, skipped=skipped, unresolved=len(unresolved))
+    return {
+        "ok": True,
+        "count": int(ok),
+        "confirmed": int(ok),
+        "confirmed_keys": confirmed_keys,
+        "skipped": int(skipped),
+        "skipped_keys": skipped_keys,
+        "unresolved": unresolved,
+    }
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    res = add_detailed(adapter, items)
+    count = int((res or {}).get("confirmed", (res or {}).get("count", 0)) or 0)
+    unresolved = (res or {}).get("unresolved") or []
+    return count, list(unresolved) if isinstance(unresolved, list) else []
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    lst = list(items or [])
+    if not lst:
+        return 0, []
+
+    prog_mk = getattr(adapter, "progress_factory", None)
+    prog = prog_mk("ratings", total=len(lst)) if callable(prog_mk) else None
+
+    ok = 0
+    unresolved: list[dict[str, Any]] = []
+    for i, it in enumerate(lst, start=1):
+        enriched = _anime_enrich(adapter, it)
+        mini = id_minimal(enriched)
+        mid, meta = _resolve_media_id(adapter, mini)
+        if not mid:
+            if meta.get("anime_only_unmapped"):
+                _dbg("write_item_skipped", op="remove", title=str(mini.get("title") or ""), reason="anime_only_unmapped")
+            else:
+                unresolved.append(_unresolved_item(mini, "not_anime_or_no_match"))
+            _tick(prog, i, total=len(lst))
+            continue
+        try:
+            adapter.client.gql(
+                GQL_SAVE_RATING,
+                {"mediaId": int(mid), "scoreRaw": 0},
+                feature="ratings:remove",
+            )
+            ok += 1
+            _dbg("write_item_done", op="remove", anilist_id=int(mid))
+        except Exception as e:
+            _warn("write_failed", op="remove", error_type=e.__class__.__name__, anilist_id=int(mid))
+            unresolved.append(_unresolved_item(mini, f"write_failed:{e.__class__.__name__}"))
+        _tick(prog, i, total=len(lst))
+
+    _done(prog, ok=len(unresolved) == 0, total=len(lst))
+    _info("write_done", op="remove", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
+    return ok, unresolved


### PR DESCRIPTION
# Pull request

## Change

Adds AniList ratings support, including reading AniList scores, writing ratings, and clearing ratings without deleting AniList list entries.

Extends Anime ID Mapping and Anime-only sync to AniList ratings pairs, adds the pair configuration controls/help text, and allows AniList ratings through sync pair normalization.

Also fixes one-way ratings removal so clearing a rating on the source can clear the destination rating when Ratings remove/clear is enabled.

## Why

AniList only accepts anime entries, while providers like Plex commonly expose TMDb/TVDb/IMDb IDs. Ratings need the same Anime Mapping path as watchlists so anime ratings can sync reliably and non-anime ratings can be skipped cleanly.

Rating removals also needed explicit handling because Plex rating removals are not always represented as normal observed delete events.

## Testing

- Manually tested Plex to AniList ratings sync with Anime ID Mapping enabled.
- Verified anime items resolve through Anime ID Mapping and non-anime items are skipped when Anime-only sync is enabled.
- Verified changing an existing Plex rating updates the AniList rating.
- Verified clearing/removing a Plex rating clears the AniList rating in one-way sync.
- Verified pair configuration UI for AniList watchlist/ratings mapping options.

## Issue

Fixes #268