### PR TITLE
Add: AniBridge dataset attribution to About and settings

### DIFF
--- a/assets/crosswatch.css
+++ b/assets/crosswatch.css
@@ -1133,6 +1133,9 @@ html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;b
 #page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-status{min-width:0;padding:12px;border:1px solid rgba(255,255,255,.08);border-radius:12px;background:rgba(0,0,0,.14)}
 #page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-status span{display:block;margin-bottom:5px;font-size:11px;font-weight:900;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
 #page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-status strong{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:13px;color:var(--fg)}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-source{margin-top:-2px;color:var(--muted);font-size:12px;line-height:1.45;opacity:.78}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-source a{color:var(--fg);font-weight:750;text-decoration:none;border-bottom:1px dashed currentColor}
+#page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-source a:hover{border-bottom-style:solid}
 #page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-toggle{justify-self:end}
 #page-settings #sec-meta .cw-meta-provider-panel[data-provider=anime-mapping] .anime-mapping-actions{margin-top:0}
 #page-settings #sec-meta #anime_mapping_error:empty{display:none}

--- a/assets/helpers/settings-ui.js
+++ b/assets/helpers/settings-ui.js
@@ -904,6 +904,9 @@ function cwBuildAnimeMappingPanel() {
           <strong id="anime_mapping_counts">-</strong>
         </div>
       </div>
+      <div class="anime-mapping-source">
+        Dataset source: <a href="https://github.com/anibridge/anibridge-mappings" target="_blank" rel="noopener noreferrer">anibridge/anibridge-mappings</a>. CrossWatch downloads the AniBridge mappings dataset to translate media identifiers between AniList and TMDB, TVDB, IMDb, MyAnimeList, and AniDB.
+      </div>
       <div class="auth-card-notes" id="anime_mapping_error"></div>
       <div class="cw-settings-inline-action anime-mapping-actions">
         <button class="btn primary" type="button" id="btn-anime-mapping-update">Update now</button>

--- a/assets/js/modals/about.js
+++ b/assets/js/modals/about.js
@@ -151,7 +151,7 @@ function view(info, mods, logo) {
       #about-host .badge{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border-radius:999px;background:rgba(0,0,0,.24);border:1px solid rgba(255,255,255,.08)}
       #about-host .badge .dot{width:8px;height:8px;border-radius:999px;background:rgba(150,70,255,.90);box-shadow:0 0 0 4px rgba(150,70,255,.18)}
       #about-host .headline{font-weight:950;font-size:20px;line-height:1.15;margin:10px 0 8px}
-      #about-host .lede{opacity:.84;max-width:72ch;line-height:1.5}
+      #about-host .lede{opacity:.84;width:100%;line-height:1.5}
       #about-host .eyebrow{margin:0 0 6px;color:rgba(228,234,255,.54);font-size:11px;font-weight:900;letter-spacing:.14em;text-transform:uppercase}
       #about-host .update{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:12px;border-color:rgba(150,70,255,.22);
         background:linear-gradient(135deg,rgba(150,70,255,.14),rgba(60,140,255,.08))
@@ -235,7 +235,7 @@ function view(info, mods, logo) {
         <section class="card">
           <div class="eyebrow">Disclaimer</div>
           <div class="discBody">
-            <div>Independent community project. Not affiliated with, endorsed by, or sponsored by Plex, Emby, Jellyfin, Trakt, SIMKL, TMDb, Tautulli, AniList, or MDBList.</div>
+            <div>Independent community project. Not affiliated with, endorsed by, or sponsored by Plex, Emby, Jellyfin, Trakt, SIMKL, TMDb, Tautulli, AniList, PublicMetaDB, or MDBList. CrossWatch uses the AniBridge mappings dataset to translate media identifiers between AniList and providers such as TMDB, TVDB, IMDb, MyAnimeList and AniDB.</div>
             <ul>
               <li>Names, logos, and brands belong to their owners and are used for identification only.</li>
               <li>Third-party APIs have their own rules. Use them without getting yourself banned.</li>


### PR DESCRIPTION
# Pull request

## Change

Updated the About modal and Anime ID Mapping settings to include AniBridge dataset attribution.

- Let the About intro text use the full available card width.
- Added PublicMetaDB to the About disclaimer affiliation list.
- Added AniBridge mappings dataset wording to the About disclaimer.
- Added a dataset source link in the Anime ID Mapping settings card.

## Why

CrossWatch downloads and uses the AniBridge mappings dataset for Anime ID Mapping, so the UI clearly attribute the dataset source and explain what it is used for.

## Testing

Manually reviewed the affected UI text and checked the git diff.

## Issue

NA