### PR TITLE
Add: Backup & Restore with scheduled backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 * **Synchronization**
   * Watchlists, ratings and History
   * Progress sync your progress status between Plex, Emby, Jellyfin and PublicMetaDB.
+  * Anime ID mapping (powered AniBridge) for better AniList matching across providers.
 * **Scrobble (tracks your activity)**
   * **Watcher** (Plex/Emby/Jellyfin to Trakt/SIMKL/MDBList)
     * Does not require any Plex Pass, Emby Premiere,etc.  

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -14,6 +14,7 @@ from .manualAPI import router as manual_router
 from .insightAPI import register_insights
 from .watchlistAPI import router as watchlist_router
 from .snapshotsAPI import router as snapshots_router
+from .backupsAPI import router as backups_router
 from .schedulingAPI import router as scheduling_router
 from .probesAPI import (
     register_probes,
@@ -47,6 +48,7 @@ __all__ = [
     "manual_router",
     "watchlist_router",
     "snapshots_router",
+    "backups_router",
     "scheduling_router",
     "scrobble_router",
     "sync_router",
@@ -81,6 +83,7 @@ def register(
     app.include_router(manual_router)
     app.include_router(watchlist_router)
     app.include_router(snapshots_router)
+    app.include_router(backups_router)
     app.include_router(maintenance_router)
     app.include_router(activity_router)
     app.include_router(scheduling_router)

--- a/api/backupsAPI.py
+++ b/api/backupsAPI.py
@@ -1,0 +1,317 @@
+# /api/backupsAPI.py
+# CrossWatch - Backup and restore API
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import os
+import tempfile
+import threading
+
+from fastapi import APIRouter, Body, File, Query, UploadFile
+from fastapi.responses import FileResponse, JSONResponse, Response
+
+from _logging import log as BASE_LOG
+from services.backups import (
+    MAX_ARCHIVE_BYTES,
+    create_backup,
+    delete_backup,
+    enforce_backup_retention,
+    list_backups,
+    restore_backup,
+    save_uploaded_backup,
+    validate_backup,
+    _resolve_backup_file,
+)
+
+router = APIRouter(prefix="/api/backups", tags=["backups"])
+LOG = BASE_LOG.child("BACKUP")
+
+_SAFE_ERROR_PREFIXES = (
+    "Backup path is required",
+    "Backup not found",
+    "Backup archive is too large",
+    "Backup archive contains too many files",
+    "Backup archive failed integrity check",
+    "Backup manifest",
+    "Invalid backup",
+    "Invalid path",
+    "Invalid restore target",
+    "Unsupported backup schema",
+    "Uploaded backup",
+)
+
+
+def _ok(payload: dict[str, Any], *, status_code: int = 200) -> JSONResponse:
+    payload.setdefault("ok", True)
+    return JSONResponse(payload, status_code=status_code, headers={"Cache-Control": "no-store"})
+
+
+def _public_error(msg: str, default: str = "backup_request_failed") -> str:
+    text = str(msg or "").strip()
+    if text and any(text.startswith(prefix) for prefix in _SAFE_ERROR_PREFIXES):
+        return text
+    return default
+
+
+def _err(msg: str, *, status_code: int = 400, extra: dict[str, Any] | None = None) -> JSONResponse:
+    payload: dict[str, Any] = {"ok": False, "error": _public_error(msg)}
+    if extra:
+        payload.update(extra)
+    return JSONResponse(payload, status_code=status_code, headers={"Cache-Control": "no-store"})
+
+
+def _debug_failure(action: str, err: Exception) -> None:
+    LOG.debug(
+        f"{action} failure detail",
+        extra={"error_type": type(err).__name__, "public_error": _public_error(str(err))},
+    )
+
+
+def _refresh_scheduler() -> None:
+    try:
+        import crosswatch as CW
+
+        scheduler = getattr(CW, "scheduler", None)
+        if scheduler is not None:
+            getattr(scheduler, "start", lambda: None)()
+            getattr(scheduler, "refresh", lambda: None)()
+    except Exception:
+        pass
+
+
+def _restart_soon() -> None:
+    def _kill() -> None:
+        os._exit(0)
+
+    threading.Timer(0.75, _kill).start()
+
+
+@router.get("/list")
+def api_backups_list() -> JSONResponse:
+    try:
+        LOG.debug("backup list requested")
+        return _ok({"backups": list_backups()})
+    except Exception as e:
+        LOG.warn(f"backup list request failed: {type(e).__name__}")
+        _debug_failure("backup list", e)
+        return _err(str(e))
+
+
+@router.post("/create")
+def api_backups_create(body: dict[str, Any] | None = Body(default=None)) -> JSONResponse:
+    body = body or {}
+    try:
+        LOG.debug(
+            "manual backup requested",
+            extra={
+                "scope": str(body.get("scope") or "app_state"),
+                "include_snapshots": bool(body.get("include_snapshots")) if "include_snapshots" in body else None,
+                "include_reports": bool(body.get("include_reports")) if "include_reports" in body else None,
+                "include_cache": bool(body.get("include_cache")),
+            },
+        )
+        res = create_backup(
+            scope=str(body.get("scope") or "app_state"),
+            label=str(body.get("label") or "manual"),
+            include_snapshots=bool(body.get("include_snapshots")) if "include_snapshots" in body else None,
+            include_reports=bool(body.get("include_reports")) if "include_reports" in body else None,
+            include_cache=bool(body.get("include_cache")),
+            trigger="manual",
+        )
+        return _ok({"backup": res})
+    except Exception as e:
+        LOG.warn(f"manual backup request failed: {type(e).__name__}")
+        _debug_failure("manual backup", e)
+        return _err(str(e))
+
+
+@router.get("/download", response_model=None)
+def api_backups_download(path: str = Query(..., description="Relative path under /config/backups")) -> Response:
+    try:
+        rel, file_path = _resolve_backup_file(path)
+        LOG.info(f"backup download requested path={rel}")
+        name = Path(rel).name
+        return FileResponse(
+            str(file_path),
+            media_type="application/zip",
+            filename=name,
+            headers={
+                "Cache-Control": "no-store",
+                "X-Content-Type-Options": "nosniff",
+            },
+        )
+    except Exception as e:
+        LOG.warn(f"backup download request failed: {type(e).__name__}")
+        _debug_failure("backup download", e)
+        return _err(str(e))
+
+
+@router.post("/validate")
+def api_backups_validate(body: dict[str, Any] = Body(...)) -> JSONResponse:
+    try:
+        path = str(body.get("path") or "").strip()
+        LOG.debug("backup validate requested")
+        return _ok({"validation": validate_backup(path)})
+    except Exception as e:
+        LOG.warn(f"backup validate request failed: {type(e).__name__}")
+        _debug_failure("backup validate", e)
+        return _err(str(e))
+
+
+@router.post("/restore")
+def api_backups_restore(body: dict[str, Any] = Body(...)) -> JSONResponse:
+    try:
+        path = str(body.get("path") or "").strip()
+        restart = bool(body.get("restart"))
+        LOG.info(f"backup restore requested restart={restart}")
+        res = restore_backup(path, create_pre_restore=True)
+        if res.get("ok") and restart:
+            res["restart_scheduled"] = True
+            LOG.info("backup restore requested restart scheduled")
+            _restart_soon()
+        return _ok({"result": res}, status_code=200 if res.get("ok") else 400)
+    except Exception as e:
+        LOG.warn(f"backup restore request failed: {type(e).__name__}")
+        _debug_failure("backup restore", e)
+        return _err(str(e))
+
+
+@router.post("/delete")
+def api_backups_delete(body: dict[str, Any] = Body(...)) -> JSONResponse:
+    try:
+        path = str(body.get("path") or "").strip()
+        LOG.debug("backup delete requested")
+        return _ok({"result": delete_backup(path)})
+    except Exception as e:
+        LOG.warn(f"backup delete request failed: {type(e).__name__}")
+        _debug_failure("backup delete", e)
+        return _err(str(e))
+
+
+@router.post("/upload")
+async def api_backups_upload(file: UploadFile = File(...)) -> JSONResponse:
+    suffix = Path(str(file.filename or "")).suffix.lower()
+    if suffix != ".zip":
+        LOG.warn("backup upload rejected invalid extension")
+        return _err("Invalid backup path")
+
+    tmp_name = ""
+    try:
+        LOG.info("backup upload requested")
+        fd, tmp_name = tempfile.mkstemp(prefix="crosswatch-backup-upload-", suffix=".zip")
+        total = 0
+        with os.fdopen(fd, "wb") as out:
+            while True:
+                chunk = await file.read(1024 * 1024)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > MAX_ARCHIVE_BYTES:
+                    raise ValueError("Uploaded backup is too large")
+                out.write(chunk)
+        res = save_uploaded_backup(Path(tmp_name))
+        tmp_name = ""
+        return _ok({"backup": res})
+    except Exception as e:
+        LOG.warn(f"backup upload request failed: {type(e).__name__}")
+        _debug_failure("backup upload", e)
+        return _err(str(e))
+    finally:
+        try:
+            await file.close()
+        except Exception:
+            pass
+        if tmp_name:
+            try:
+                Path(tmp_name).unlink(missing_ok=True)
+            except Exception:
+                pass
+
+
+@router.get("/schedule")
+def api_backups_schedule_get() -> JSONResponse:
+    try:
+        LOG.debug("backup schedule requested")
+        from cw_platform.config_base import load_config
+
+        cfg = load_config() or {}
+        raw_sch = cfg.get("scheduling")
+        sch: dict[str, Any] = raw_sch if isinstance(raw_sch, dict) else {}
+        raw_adv = sch.get("advanced")
+        adv: dict[str, Any] = raw_adv if isinstance(raw_adv, dict) else {}
+        raw_jobs = adv.get("backup_jobs") or adv.get("backupJobs")
+        jobs = raw_jobs if isinstance(raw_jobs, list) else []
+        job = jobs[0] if isinstance(jobs, list) and jobs and isinstance(jobs[0], dict) else {}
+        return _ok({"schedule": job, "advanced_enabled": bool(adv.get("enabled"))})
+    except Exception as e:
+        LOG.warn(f"backup schedule request failed: {type(e).__name__}")
+        _debug_failure("backup schedule", e)
+        return _err(str(e))
+
+
+@router.post("/schedule")
+def api_backups_schedule_post(body: dict[str, Any] = Body(...)) -> JSONResponse:
+    try:
+        from cw_platform.config_base import load_config, save_config
+
+        enabled = bool(body.get("enabled"))
+        LOG.info(f"saving backup schedule enabled={enabled}")
+        cfg = load_config() or {}
+        sch = cfg.setdefault("scheduling", {})
+        if not isinstance(sch, dict):
+            sch = {}
+            cfg["scheduling"] = sch
+        adv = sch.setdefault("advanced", {})
+        if not isinstance(adv, dict):
+            adv = {}
+            sch["advanced"] = adv
+        adv["enabled"] = bool(adv.get("enabled") or enabled)
+
+        job = {
+            "id": "app-backup-default",
+            "scope": str(body.get("scope") or "app_state"),
+            "at": str(body.get("at") or "03:00"),
+            "days": body.get("days") if isinstance(body.get("days"), list) else [],
+            "label_template": str(body.get("label_template") or "scheduled-{scope}-{date}"),
+            "retention_days": int(body.get("retention_days") or 30),
+            "max_backups": int(body.get("max_backups") or 10),
+            "auto_delete_old": bool(body.get("auto_delete_old", True)),
+            "include_snapshots": bool(body.get("include_snapshots")),
+            "include_reports": bool(body.get("include_reports")),
+            "include_cache": bool(body.get("include_cache")),
+            "active": enabled,
+        }
+
+        raw_jobs0 = adv.get("backup_jobs")
+        jobs0 = raw_jobs0 if isinstance(raw_jobs0, list) else []
+        jobs = [x for x in jobs0 if not (isinstance(x, dict) and str(x.get("id") or "") == "app-backup-default")]
+        jobs.insert(0, job)
+        adv["backup_jobs"] = jobs
+        save_config(cfg)
+        _refresh_scheduler()
+        LOG.success(f"backup schedule saved enabled={enabled}")
+        return _ok({"schedule": job, "advanced_enabled": bool(adv.get("enabled"))})
+    except Exception as e:
+        LOG.warn(f"backup schedule save failed: {type(e).__name__}")
+        _debug_failure("backup schedule save", e)
+        return _err(str(e))
+
+
+@router.post("/retention")
+def api_backups_retention(body: dict[str, Any] | None = Body(default=None)) -> JSONResponse:
+    body = body or {}
+    try:
+        LOG.info("backup retention requested")
+        res = enforce_backup_retention(
+            retention_days=int(body.get("retention_days") or 0),
+            max_backups=int(body.get("max_backups") or 0),
+            auto_delete_old=True,
+        )
+        return _ok({"result": res})
+    except Exception as e:
+        LOG.warn(f"backup retention request failed: {type(e).__name__}")
+        _debug_failure("backup retention", e)
+        return _err(str(e))

--- a/api/configAPI.py
+++ b/api/configAPI.py
@@ -14,6 +14,9 @@ from packaging.version import InvalidVersion, Version
 from fastapi import APIRouter, Body, Request
 from fastapi.responses import JSONResponse
 from providers.scrobble.sources import source_enabled
+from _logging import log as BASE_LOG
+
+BACKUP_LOG = BASE_LOG.child("BACKUP")
 
 def _env() -> dict[str, Any]:
     try:
@@ -464,12 +467,28 @@ def api_config_migrate() -> dict[str, Any]:
     forced_paths: list[str] = []
 
     try:
-        backup = getattr(base, "backup_config_file", None)
-        if callable(backup):
-            backup_result = backup()
-            if backup_result is not None:
-                backup_path = str(backup_result)
+        try:
+            if not hasattr(base, "config_path"):
+                raise RuntimeError("config backend has no file path")
+            from services.backups import create_backup
+
+            BACKUP_LOG.info("creating pre-upgrade backup")
+            backup_result = create_backup(scope="config_only", label="pre-upgrade", trigger="upgrade")
+            backup_path = str(backup_result.get("path") or "")
+            BACKUP_LOG.success(f"pre-upgrade backup created path={backup_path or 'backup created'}")
+        except Exception as e:
+            BACKUP_LOG.debug(f"pre-upgrade backup service unavailable: {type(e).__name__}")
+            backup = getattr(base, "backup_config_file", None)
+            if callable(backup):
+                BACKUP_LOG.debug("pre-upgrade backup falling back to legacy config backup")
+                legacy_backup = backup()
+                if legacy_backup is not None:
+                    backup_path = str(legacy_backup)
+                    BACKUP_LOG.success("legacy pre-upgrade config backup created")
+            if not backup_path:
+                BACKUP_LOG.warn("pre-upgrade backup was not created")
     except Exception:
+        BACKUP_LOG.error("pre-upgrade backup failed")
         return {"ok": False, "error": "config_backup_failed"}
 
     cfg: dict[str, Any] = dict(current or {})

--- a/api/versionAPI.py
+++ b/api/versionAPI.py
@@ -19,7 +19,7 @@ __all__ = ["router"]
 
 router = APIRouter(prefix="/api", tags=["version"])
 
-CURRENT_VERSION = os.getenv("APP_VERSION", "v0.9.22")
+CURRENT_VERSION = os.getenv("APP_VERSION", "v0.9.23")
 REPO = os.getenv("GITHUB_REPO", "cenodude/CrossWatch")
 
 

--- a/assets/helpers/backups.js
+++ b/assets/helpers/backups.js
@@ -1,0 +1,637 @@
+/* assets/helpers/backups.js */
+/* CrossWatch Backup & Restore UI */
+(function(){
+  const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+  const SPLIT_STORAGE_KEY = "cw.backups.controlsHeight.v4";
+  const SPLIT_DEFAULTS = { manual: 215, scheduled: 315 };
+  const SPLIT_MINS = { manual: 145, scheduled: 285 };
+  const SCOPES = [
+    ["config_only", "Config"],
+    ["app_state", "Normal"],
+    ["full", "Full"]
+  ];
+  const state = { backups: [], schedule: {}, selected: "", controlsHeight: {}, rowStatus: {}, message: "", mode: "manual", refreshing: false };
+
+  function $(id){ return document.getElementById(id); }
+
+  function api(url, init){
+    return fetch(url, Object.assign({ cache: "no-store" }, init || {})).then(async (r) => {
+      const j = await r.json().catch(() => ({}));
+      if (!r.ok || j?.ok === false) throw new Error(j?.error || "Request failed");
+      return j;
+    });
+  }
+
+  function postJSON(url, body){
+    return api(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body || {})
+    });
+  }
+
+  function el(tag, attrs, children){
+    const node = document.createElement(tag);
+    const a = attrs || {};
+    for (const [k, v] of Object.entries(a)) {
+      if (v === false || v === null || v === undefined) continue;
+      if (k === "class") node.className = String(v);
+      else if (k === "text") node.textContent = String(v);
+      else if (k === "title" || k === "aria-label" || k === "type" || k === "value" || k === "name" || k === "id" || k === "for" || k === "accept") node.setAttribute(k, String(v));
+      else if (k === "checked") node.checked = !!v;
+      else if (k === "disabled") node.disabled = !!v;
+      else if (k === "on") {
+        for (const [ev, fn] of Object.entries(v || {})) node.addEventListener(ev, fn);
+      }
+      else node.setAttribute(k, String(v));
+    }
+    for (const child of [].concat(children || [])) {
+      if (child === null || child === undefined) continue;
+      node.appendChild(typeof child === "string" ? document.createTextNode(child) : child);
+    }
+    return node;
+  }
+
+  function icon(name){ return el("span", { class: "material-symbols-rounded br-icon", text: name }); }
+
+  function fmtBytes(n){
+    const v = Number(n || 0);
+    if (v < 1024) return `${v} B`;
+    const units = ["KB", "MB", "GB", "TB"];
+    let x = v / 1024;
+    let i = 0;
+    while (x >= 1024 && i < units.length - 1) { x /= 1024; i++; }
+    return `${x.toFixed(x >= 10 ? 1 : 2)} ${units[i]}`;
+  }
+
+  function fmtDate(value, fallback){
+    const raw = value || (fallback ? Number(fallback) * 1000 : 0);
+    if (!raw) return "Never";
+    const d = new Date(raw);
+    if (Number.isNaN(d.getTime())) return "Unknown";
+    return d.toLocaleString();
+  }
+
+  function scopeLabel(scope){
+    const found = SCOPES.find((x) => x[0] === scope);
+    return found ? found[1] : (scope || "Unknown");
+  }
+
+  function toast(text, delay){
+    state.message = String(text || "");
+    clearTimeout(toast._lt);
+    const local = $("br-msg");
+    if (local) {
+      local.textContent = state.message;
+      local.classList.remove("hidden");
+    }
+    toast._lt = setTimeout(() => {
+      state.message = "";
+      const cur = $("br-msg");
+      if (cur) cur.classList.add("hidden");
+    }, delay || 4200);
+  }
+
+  function ensureStyles(){
+    if ($("cw-backups-style")) return;
+    const s = document.createElement("style");
+    s.id = "cw-backups-style";
+    s.textContent = `
+#cw-backups-modal.hidden{display:none!important}
+#cw-backups-modal{--br-overlay:rgba(0,0,0,.68);--br-shell:linear-gradient(180deg,rgba(11,13,20,.99),rgba(4,5,10,.995));--br-head:linear-gradient(180deg,rgba(255,255,255,.035),rgba(255,255,255,.01));--br-panel:linear-gradient(180deg,rgba(255,255,255,.035),rgba(255,255,255,.018));--br-panel-hover:rgba(255,255,255,.095);--br-row:rgba(255,255,255,.025);--br-row-active:rgba(96,108,255,.08);--br-field:rgba(2,4,9,.78);--br-fg:#f5f7ff;--br-title:#f8fbff;--br-muted:rgba(210,218,235,.68);--br-soft:rgba(210,218,235,.58);--br-border:rgba(255,255,255,.085);--br-border-strong:rgba(255,255,255,.16);--br-focus:rgba(126,137,255,.35);--br-focus-ring:rgba(126,137,255,.10);--br-accent:#7d86ff;--br-primary:linear-gradient(180deg,rgba(89,97,216,.78),rgba(61,70,166,.72));--br-primary-border:rgba(149,158,255,.30);--br-primary-shadow:0 12px 24px rgba(42,48,132,.22);--br-danger:#ffdede;--br-danger-border:rgba(255,100,100,.32);--br-ok-bg:rgba(73,226,163,.09);--br-ok-border:rgba(73,226,163,.18);--br-ok-fg:#dfffee;--br-split:rgba(255,255,255,.16);--br-split-handle:rgba(255,255,255,.09);position:fixed;inset:0;z-index:1300;display:flex;align-items:center;justify-content:center;background:var(--br-overlay);padding:16px;color:var(--br-fg)}
+html[data-cw-theme=flat-dark] #cw-backups-modal{--br-overlay:rgba(0,0,0,.58);--br-shell:#171a22;--br-head:#20242d;--br-panel:#20242d;--br-panel-hover:#2b3140;--br-row:#242936;--br-row-active:#2b3144;--br-field:#161a22;--br-fg:#eef1f6;--br-title:#f3f6ff;--br-muted:#a9b0bd;--br-soft:#8f98a8;--br-border:rgba(255,255,255,.13);--br-border-strong:rgba(255,255,255,.22);--br-focus:rgba(125,134,201,.58);--br-focus-ring:rgba(125,134,201,.18);--br-accent:#7d86c9;--br-primary:#253044;--br-primary-border:#253044;--br-primary-shadow:none;--br-danger:#ffe7eb;--br-danger-border:rgba(216,102,114,.42);--br-ok-bg:rgba(31,79,58,.72);--br-ok-border:rgba(87,181,138,.32);--br-ok-fg:#c9f7dd;--br-split:rgba(255,255,255,.18);--br-split-handle:#303642}
+html[data-cw-theme=flat-light] #cw-backups-modal{--br-overlay:rgba(15,23,42,.42);--br-shell:#ffffff;--br-head:#ffffff;--br-panel:#ffffff;--br-panel-hover:#eef2f7;--br-row:#f5f7fb;--br-row-active:#e9ecf7;--br-field:#ffffff;--br-fg:#111827;--br-title:#111827;--br-muted:#475467;--br-soft:#667085;--br-border:rgba(16,24,40,.16);--br-border-strong:rgba(16,24,40,.26);--br-focus:rgba(70,86,166,.38);--br-focus-ring:rgba(70,86,166,.14);--br-accent:#4656a6;--br-primary:#253044;--br-primary-border:#253044;--br-primary-shadow:none;--br-danger:#7f1d2d;--br-danger-border:rgba(169,63,77,.35);--br-ok-bg:#dff8eb;--br-ok-border:rgba(18,185,129,.32);--br-ok-fg:#12623f;--br-split:rgba(16,24,40,.18);--br-split-handle:#d9e0ea}
+#cw-backups-modal *{box-sizing:border-box}
+#cw-backups-modal .br-dialog{width:min(1140px,calc(100vw - 32px));height:min(780px,calc(100vh - 32px));display:flex;flex-direction:column;border:1px solid var(--br-border);border-radius:16px;background:var(--br-shell);box-shadow:0 26px 72px rgba(0,0,0,.34);overflow:hidden}
+#cw-backups-modal .br-head{display:flex;align-items:center;justify-content:space-between;gap:16px;flex:0 0 auto;padding:16px 18px 14px;border-bottom:1px solid var(--br-border);background:var(--br-head)}
+#cw-backups-modal .br-title{font-weight:900;font-size:21px;line-height:1.12;letter-spacing:0;color:var(--br-title)}
+#cw-backups-modal .br-sub{margin-top:5px;color:var(--br-muted);font-size:12px;line-height:1.45}
+#cw-backups-modal .br-close,#cw-backups-modal .br-iconbtn{appearance:none;display:inline-flex;align-items:center;justify-content:center;flex:0 0 auto;width:36px;height:36px;padding:0;border:1px solid var(--br-border);border-radius:10px;background:var(--br-row);color:var(--br-fg);cursor:pointer}
+#cw-backups-modal .br-close:hover,#cw-backups-modal .br-iconbtn:hover{background:var(--br-panel-hover);border-color:var(--br-border-strong)}
+#cw-backups-modal .br-icon{font-size:20px;line-height:1}
+#cw-backups-modal .br-iconbtn.spin .br-icon{animation:brspin .8s linear infinite}
+@keyframes brspin{to{transform:rotate(360deg)}}
+#cw-backups-modal .br-body{flex:1 1 auto;min-height:0;padding:14px;display:grid;grid-template-rows:minmax(145px,var(--br-controls-height,215px)) 10px minmax(0,1fr);grid-template-columns:minmax(0,1fr);gap:8px;overflow:hidden}
+#cw-backups-modal .br-panel{min-width:0;min-height:0;border:1px solid var(--br-border);border-radius:12px;background:var(--br-panel);box-shadow:inset 0 1px 0 rgba(255,255,255,.025)}
+#cw-backups-modal .br-controls{padding:12px;display:grid;grid-template-rows:auto minmax(0,1fr);gap:10px;overflow:hidden}
+#cw-backups-modal .br-mode-top{display:flex;align-items:center;justify-content:space-between;gap:10px;min-width:0}
+#cw-backups-modal .br-mode-top .br-msg{flex:1 1 auto;margin-top:0!important;min-width:180px;max-width:560px}
+#cw-backups-modal .br-mode-tabs{display:inline-flex;align-items:center;gap:6px;padding:4px;border:1px solid var(--br-border);border-radius:12px;background:var(--br-row)}
+#cw-backups-modal .br-mode-tab{appearance:none;min-height:34px;padding:0 12px;border:0;border-radius:9px;background:transparent;color:var(--br-muted);font:inherit;font-size:12px;font-weight:900;letter-spacing:.08em;text-transform:uppercase;cursor:pointer}
+#cw-backups-modal .br-mode-tab.active{background:var(--br-primary);color:#fff;box-shadow:var(--br-primary-shadow)}
+#cw-backups-modal .br-mode-window{min-width:0;min-height:0;overflow:hidden}
+#cw-backups-modal .br-mode-track{height:100%;display:grid;grid-template-columns:100% 100%;transition:transform .2s ease}
+#cw-backups-modal .br-mode-track.scheduled{transform:translateX(-100%)}
+#cw-backups-modal .br-mode-pane{min-width:0;min-height:0;display:grid;gap:10px;align-content:start;padding:2px}
+#cw-backups-modal .br-splitter{appearance:none;width:100%;height:10px;margin:0;border:0;border-radius:999px;background:transparent;cursor:row-resize;position:relative}
+#cw-backups-modal .br-splitter:before{content:"";position:absolute;left:10px;right:10px;top:4px;height:2px;border-radius:999px;background:var(--br-split)}
+#cw-backups-modal .br-splitter:after{content:"";position:absolute;left:50%;top:1px;width:56px;height:8px;transform:translateX(-50%);border-radius:999px;background:var(--br-split-handle);border:1px solid var(--br-border)}
+#cw-backups-modal .br-splitter:hover:before,#cw-backups-modal .br-splitter:focus-visible:before{background:var(--br-focus)}
+#cw-backups-modal .br-splitter:focus-visible{outline:2px solid var(--br-focus);outline-offset:2px}
+#cw-backups-modal.br-resizing,#cw-backups-modal.br-resizing *{cursor:row-resize!important;user-select:none!important}
+#cw-backups-modal .br-section{min-width:0;display:grid;gap:10px;align-content:start}
+#cw-backups-modal .br-section-head{display:grid;grid-template-columns:auto minmax(230px,1fr) auto;align-items:center;gap:10px}
+#cw-backups-modal .br-section-head h3{margin:0!important}
+#cw-backups-modal .br-section-head .br-check{min-height:34px}
+#cw-backups-modal .br-section-head .br-actions{margin:0;justify-content:flex-end}
+#cw-backups-modal .br-section-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}
+#cw-backups-modal .br-schedule-grid{display:grid;grid-template-columns:minmax(150px,1.15fr) minmax(105px,.75fr) repeat(2,minmax(92px,.65fr));gap:10px}
+#cw-backups-modal .br-manual-grid{display:grid;grid-template-columns:minmax(160px,.75fr) minmax(180px,1fr) auto;gap:10px;align-items:end}
+#cw-backups-modal .br-section-wide{grid-column:1/-1}
+#cw-backups-modal .br-list-panel{padding:14px;display:flex;flex-direction:column;overflow:hidden}
+#cw-backups-modal .br-panel h3{margin:0 0 10px;font-size:11px;text-transform:uppercase;letter-spacing:.13em;color:var(--br-muted)}
+#cw-backups-modal .br-field{display:grid;gap:6px;margin:0 0 10px}
+#cw-backups-modal .br-section .br-field{margin:0}
+#cw-backups-modal .br-field>label{display:block;margin:0;font-size:11px;color:var(--br-muted);font-weight:850;letter-spacing:.08em;text-transform:uppercase}
+#cw-backups-modal .br-field input:not([type=checkbox]),#cw-backups-modal .br-field select{width:100%;height:38px;min-height:38px;border-radius:10px;border:1px solid var(--br-border);background:var(--br-field);color:var(--br-fg);padding:0 11px;font:inherit;font-size:13px;outline:none;color-scheme:dark}
+html[data-cw-theme=flat-light] #cw-backups-modal .br-field input:not([type=checkbox]),html[data-cw-theme=flat-light] #cw-backups-modal .br-field select{color-scheme:light}
+#cw-backups-modal .br-field input:focus,#cw-backups-modal .br-field select:focus{border-color:var(--br-focus);box-shadow:0 0 0 3px var(--br-focus-ring)}
+#cw-backups-modal .br-check{display:grid!important;grid-template-columns:18px minmax(0,1fr);align-items:center;gap:9px;width:100%;min-height:30px;margin:0!important;padding:5px 7px;border-radius:9px;color:var(--br-fg)!important;font-size:12px;font-weight:750;letter-spacing:0;text-transform:none;background:var(--br-row);cursor:pointer}
+#cw-backups-modal .br-check:hover{background:var(--br-panel-hover)}
+#cw-backups-modal input[type=checkbox]{appearance:auto!important;-webkit-appearance:auto!important;width:15px!important;height:15px!important;min-width:15px!important;min-height:15px!important;max-width:15px!important;max-height:15px!important;margin:0!important;padding:0!important;accent-color:var(--br-accent);justify-self:center}
+#cw-backups-modal .br-check span{min-width:0;line-height:1.3;text-align:left}
+#cw-backups-modal .br-section-head .br-switch{justify-self:start}
+#cw-backups-modal .br-switch{position:relative;display:inline-flex!important;align-items:center;gap:10px;width:auto;min-height:34px;margin:0!important;padding:0;color:var(--br-fg)!important;background:transparent;font-size:13px;font-weight:750;cursor:pointer;user-select:none}
+#cw-backups-modal .br-switch input{position:absolute!important;opacity:0!important;pointer-events:none!important;width:1px!important;height:1px!important}
+#cw-backups-modal .br-switch-ui{position:relative;display:inline-block;width:48px;height:28px;border-radius:999px;background:linear-gradient(180deg,rgba(255,255,255,.10),rgba(255,255,255,.05));border:1px solid var(--br-border);box-shadow:inset 0 1px 0 rgba(255,255,255,.03),inset 0 0 0 1px rgba(0,0,0,.16);transition:background .18s ease,border-color .18s ease,box-shadow .18s ease}
+#cw-backups-modal .br-switch-ui:after{content:"";position:absolute;left:3px;top:3px;width:20px;height:20px;border-radius:50%;background:rgba(255,255,255,.94);box-shadow:0 10px 20px rgba(0,0,0,.34);transition:transform .18s ease,background .18s ease}
+#cw-backups-modal .br-switch input:checked+.br-switch-ui{background:linear-gradient(180deg,rgba(42,202,126,.34),rgba(28,136,87,.28));border-color:rgba(34,197,94,.42)}
+#cw-backups-modal .br-switch input:checked+.br-switch-ui:after{transform:translateX(20px);background:#fff}
+#cw-backups-modal .br-switch input:focus-visible+.br-switch-ui{box-shadow:0 0 0 2px var(--br-focus-ring),0 0 0 6px rgba(100,110,255,.12),inset 0 0 0 1px rgba(0,0,0,.16)}
+#cw-backups-modal .br-switch-text{min-width:0;white-space:nowrap;color:var(--br-muted);font-weight:800}
+#cw-backups-modal .br-switch-state{display:inline-flex;align-items:center;min-height:24px;padding:0 9px;border-radius:999px;background:var(--br-row);border:1px solid var(--br-border);font-size:11px;font-weight:900;letter-spacing:.08em;text-transform:uppercase;color:var(--br-muted)}
+#cw-backups-modal .br-switch-state:before{content:"Off"}
+#cw-backups-modal .br-switch input:checked~.br-switch-state{color:var(--br-ok-fg);border-color:var(--br-ok-border);background:var(--br-ok-bg)}
+#cw-backups-modal .br-switch input:checked~.br-switch-state:before{content:"On"}
+html[data-cw-theme=flat-dark] #cw-backups-modal .br-switch-ui{background:#2b313d;border-color:rgba(255,255,255,.14);box-shadow:none}
+html[data-cw-theme=flat-dark] #cw-backups-modal .br-switch-ui:after{background:#dce2ec;box-shadow:none}
+html[data-cw-theme=flat-dark] #cw-backups-modal .br-switch input:checked+.br-switch-ui{background:#2d493d;border-color:rgba(87,181,138,.46)}
+html[data-cw-theme=flat-light] #cw-backups-modal .br-switch-ui{background:#eef2f7;border-color:rgba(21,31,48,.14);box-shadow:none}
+html[data-cw-theme=flat-light] #cw-backups-modal .br-switch-ui:after{background:#fff;box-shadow:none}
+html[data-cw-theme=flat-light] #cw-backups-modal .br-switch input:checked+.br-switch-ui{background:#dff2e9;border-color:rgba(47,148,109,.36)}
+#cw-backups-modal .br-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-top:10px}
+#cw-backups-modal .br-btn{appearance:none;display:inline-flex;align-items:center;justify-content:center;gap:7px;min-height:36px;padding:0 12px;border-radius:10px;border:1px solid var(--br-border);background:var(--br-row);color:var(--br-fg);cursor:pointer;font:inherit;font-size:13px;font-weight:850;white-space:nowrap}
+#cw-backups-modal .br-btn:hover{background:var(--br-panel-hover);border-color:var(--br-border-strong)}
+#cw-backups-modal .br-btn.primary{background:var(--br-primary);border-color:var(--br-primary-border);box-shadow:var(--br-primary-shadow);color:#fff}
+#cw-backups-modal .br-btn.danger{border-color:var(--br-danger-border);color:var(--br-danger)}
+#cw-backups-modal .br-btn:disabled{opacity:.45;cursor:not-allowed}
+#cw-backups-modal .br-msg{margin-top:10px;padding:9px 10px;border-radius:10px;background:var(--br-ok-bg);border:1px solid var(--br-ok-border);font-size:12px;color:var(--br-ok-fg)}
+#cw-backups-modal .br-msg.hidden{display:none}
+body.br-backups-open #save-fab,body.br-backups-open #save-frost{display:none!important}
+#cw-backups-modal .br-status{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px;margin-bottom:12px;flex:0 0 auto}
+#cw-backups-modal .br-stat{min-width:0;border:1px solid var(--br-border);border-radius:10px;padding:10px 11px;background:var(--br-row)}
+#cw-backups-modal .br-stat b{display:block;font-size:14px;line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--br-title)}
+#cw-backups-modal .br-stat span{display:block;margin-top:5px;font-size:10px;text-transform:uppercase;letter-spacing:.08em;color:var(--br-soft)}
+#cw-backups-modal .br-list-head{display:flex;align-items:center;justify-content:space-between;gap:10px;margin:0 0 10px;flex:0 0 auto}
+#cw-backups-modal .br-list-head h3{margin:0}
+#cw-backups-modal .br-list{display:flex;flex-direction:column;gap:8px;min-height:0;overflow:auto;padding-right:2px}
+#cw-backups-modal .br-row{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:12px;align-items:center;padding:11px 12px;border:1px solid var(--br-border);border-radius:11px;background:var(--br-row)}
+#cw-backups-modal .br-row.active{border-color:var(--br-focus);background:var(--br-row-active)}
+#cw-backups-modal .br-main{min-width:0;display:grid;gap:7px}
+#cw-backups-modal .br-name{font-weight:850;font-size:14px;line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--br-title)}
+#cw-backups-modal .br-meta{display:flex;gap:6px;flex-wrap:wrap;color:var(--br-muted);font-size:12px}
+#cw-backups-modal .br-pill{display:inline-flex;align-items:center;min-height:22px;padding:0 8px;border-radius:999px;border:1px solid var(--br-border);background:var(--br-panel)}
+#cw-backups-modal .br-row-note{font-size:12px;line-height:1.35;color:var(--br-muted)}
+#cw-backups-modal .br-row-note.ok{color:var(--br-ok-fg)}
+#cw-backups-modal .br-row-note.warn{color:var(--br-danger)}
+#cw-backups-modal .br-row-actions{display:flex;align-items:center;gap:6px;justify-content:flex-end}
+#cw-backups-modal .br-days{display:grid;grid-template-columns:repeat(7,minmax(0,1fr));gap:6px}
+#cw-backups-modal .br-days-field{grid-template-columns:auto minmax(0,1fr);align-items:center;gap:10px}
+#cw-backups-modal .br-days-field>label{padding-top:0;min-width:42px}
+#cw-backups-modal .br-day{display:grid!important;grid-template-columns:16px minmax(0,1fr);align-items:center;gap:7px;min-height:31px;margin:0!important;padding:0 8px;border:1px solid var(--br-border);border-radius:9px;background:var(--br-row);font-size:12px;font-weight:800;color:var(--br-fg)!important}
+#cw-backups-modal .br-day span{text-align:left;white-space:nowrap}
+#cw-backups-modal .br-upload{display:none}
+@media (max-width:1100px){#cw-backups-modal .br-section-head{grid-template-columns:1fr auto}#cw-backups-modal .br-section-head .br-switch{grid-column:1/-1}#cw-backups-modal .br-schedule-grid{grid-template-columns:repeat(2,minmax(0,1fr))}#cw-backups-modal .br-days-field{grid-template-columns:1fr}#cw-backups-modal .br-days{grid-template-columns:repeat(4,minmax(0,1fr))}}
+@media (max-width:920px){#cw-backups-modal .br-dialog{height:calc(100vh - 24px);width:calc(100vw - 24px)}#cw-backups-modal .br-body{grid-template-rows:auto minmax(0,1fr);overflow:auto}#cw-backups-modal .br-splitter{display:none}#cw-backups-modal .br-controls{overflow:visible}#cw-backups-modal .br-list-panel{overflow:visible}#cw-backups-modal .br-status{grid-template-columns:1fr 1fr}#cw-backups-modal .br-list{overflow:visible}}
+@media (max-width:680px){#cw-backups-modal .br-mode-top{align-items:stretch;flex-direction:column}#cw-backups-modal .br-mode-tabs{width:100%;display:grid;grid-template-columns:1fr 1fr}#cw-backups-modal .br-manual-grid{grid-template-columns:1fr}}
+@media (max-width:560px){#cw-backups-modal{padding:8px}#cw-backups-modal .br-dialog{width:calc(100vw - 16px);height:calc(100vh - 16px);border-radius:12px}#cw-backups-modal .br-head{padding:13px 14px}#cw-backups-modal .br-body{padding:10px;gap:10px}#cw-backups-modal .br-section-grid,#cw-backups-modal .br-schedule-grid,#cw-backups-modal .br-section-head{grid-template-columns:1fr}#cw-backups-modal .br-section-head .br-actions{justify-content:flex-start}#cw-backups-modal .br-status{grid-template-columns:1fr}#cw-backups-modal .br-row{grid-template-columns:1fr}#cw-backups-modal .br-row-actions{justify-content:flex-start}#cw-backups-modal .br-days{grid-template-columns:1fr 1fr}}
+`;
+    document.head.appendChild(s);
+  }
+
+  function scopeSelect(id, value){
+    const sel = el("select", { id });
+    for (const [v, label] of SCOPES) sel.appendChild(el("option", { value: v, text: label }));
+    sel.value = value || "app_state";
+    return sel;
+  }
+
+  function check(id, label, checked){
+    const input = el("input", { id, type: "checkbox", checked: !!checked });
+    return el("label", { class: "br-check", for: id }, [input, el("span", { text: label })]);
+  }
+
+  function switcher(id, label, checked){
+    const input = el("input", { id, type: "checkbox", checked: !!checked });
+    return el("label", { class: "br-switch", for: id }, [
+      input,
+      el("span", { class: "br-switch-ui", "aria-hidden": "true" }),
+      el("span", { class: "br-switch-text", text: label }),
+      el("span", { class: "br-switch-state", "aria-hidden": "true" })
+    ]);
+  }
+
+  function buildShell(){
+    ensureStyles();
+    if ($("cw-backups-modal")) return;
+    const modal = el("div", { id: "cw-backups-modal", class: "hidden", "aria-hidden": "true" });
+    const dialog = el("div", { class: "br-dialog", role: "dialog", "aria-modal": "true", "aria-label": "Backup and Restore" });
+    const head = el("div", { class: "br-head" }, [
+      el("div", {}, [
+        el("div", { class: "br-title", text: "Backup & Restore" }),
+        el("div", { class: "br-sub", text: "Back up CrossWatch config, Normal state, or a Full archive." })
+      ]),
+      el("button", { class: "br-close", type: "button", title: "Close", "aria-label": "Close", on: { click: close } }, [icon("close")])
+    ]);
+    const body = el("div", { class: "br-body", id: "br-body" });
+    dialog.appendChild(head);
+    dialog.appendChild(body);
+    modal.appendChild(dialog);
+    modal.addEventListener("click", (e) => { if (e.target === modal) close(); });
+    ["input", "change"].forEach((name) => {
+      modal.addEventListener(name, (e) => e.stopPropagation());
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && !modal.classList.contains("hidden")) close();
+    });
+    document.body.appendChild(modal);
+    renderBody();
+  }
+
+  function renderBody(){
+    const body = $("br-body");
+    if (!body) return;
+    body.replaceChildren();
+    applySplitHeight(body);
+    body.appendChild(renderControls());
+    body.appendChild(renderSplitter(body));
+    body.appendChild(renderListPanel());
+  }
+
+  function splitMode(){
+    return state.mode === "scheduled" ? "scheduled" : "manual";
+  }
+
+  function splitStorageKey(mode){
+    return `${SPLIT_STORAGE_KEY}.${mode || splitMode()}`;
+  }
+
+  function splitDefault(mode){
+    return SPLIT_DEFAULTS[mode || splitMode()] || SPLIT_DEFAULTS.manual;
+  }
+
+  function splitMin(mode){
+    return SPLIT_MINS[mode || splitMode()] || SPLIT_MINS.manual;
+  }
+
+  function clampSplitHeight(body, value){
+    const mode = splitMode();
+    const min = splitMin(mode);
+    const max = Math.max(min, body.clientHeight - 220);
+    return Math.min(Math.max(Number(value) || splitDefault(mode), min), max);
+  }
+
+  function storedSplitHeight(){
+    const mode = splitMode();
+    if (state.controlsHeight[mode]) return state.controlsHeight[mode];
+    try {
+      const raw = Number(window.localStorage?.getItem(splitStorageKey(mode)) || 0);
+      return Number.isFinite(raw) && raw > 0 ? raw : splitDefault(mode);
+    } catch {
+      return splitDefault(mode);
+    }
+  }
+
+  function applySplitHeight(body, value){
+    const wanted = value || storedSplitHeight();
+    if (body.clientHeight <= 0) {
+      body.style.setProperty("--br-controls-height", `${Number(wanted) || splitDefault()}px`);
+      return;
+    }
+    const height = clampSplitHeight(body, wanted);
+    const mode = splitMode();
+    state.controlsHeight[mode] = height;
+    body.style.setProperty("--br-controls-height", `${height}px`);
+    try { window.localStorage?.setItem(splitStorageKey(mode), String(height)); } catch {}
+  }
+
+  function renderSplitter(body){
+    const splitter = el("button", {
+      class: "br-splitter",
+      type: "button",
+      title: "Resize panels",
+      "aria-label": "Resize backup panels",
+      "aria-orientation": "horizontal"
+    });
+    splitter.addEventListener("pointerdown", (e) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      const modal = $("cw-backups-modal");
+      const startY = e.clientY;
+      const startHeight = state.controlsHeight[splitMode()] || body.getBoundingClientRect().height * 0.42;
+      splitter.setPointerCapture(e.pointerId);
+      modal?.classList.add("br-resizing");
+      const move = (ev) => applySplitHeight(body, startHeight + ev.clientY - startY);
+      const stop = () => {
+        modal?.classList.remove("br-resizing");
+        splitter.removeEventListener("pointermove", move);
+        splitter.removeEventListener("pointerup", stop);
+        splitter.removeEventListener("pointercancel", stop);
+      };
+      splitter.addEventListener("pointermove", move);
+      splitter.addEventListener("pointerup", stop);
+      splitter.addEventListener("pointercancel", stop);
+    });
+    splitter.addEventListener("keydown", (e) => {
+      if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+      e.preventDefault();
+      applySplitHeight(body, (state.controlsHeight[splitMode()] || storedSplitHeight()) + (e.key === "ArrowDown" ? 20 : -20));
+    });
+    return splitter;
+  }
+
+  function renderControls(){
+    const schedule = state.schedule || {};
+    const panel = el("div", { class: "br-panel br-controls" });
+    const activeMode = state.mode === "scheduled" ? "scheduled" : "manual";
+    const setMode = (mode) => {
+      state.mode = mode === "scheduled" ? "scheduled" : "manual";
+      renderBody();
+    };
+    const tab = (mode, label) => el("button", {
+      class: `br-mode-tab ${activeMode === mode ? "active" : ""}`,
+      type: "button",
+      "aria-pressed": activeMode === mode ? "true" : "false",
+      on: { click: () => setMode(mode) }
+    }, [label]);
+    panel.appendChild(el("div", { class: "br-mode-top" }, [
+      el("div", { class: "br-mode-tabs", role: "group", "aria-label": "Backup mode" }, [
+        tab("manual", "Manual Backup"),
+        tab("scheduled", "Scheduled Backups")
+      ]),
+      el("div", { id: "br-msg", class: `br-msg ${state.message ? "" : "hidden"}`, text: state.message })
+    ]));
+
+    const create = el("div", { class: "br-mode-pane br-section" });
+    create.appendChild(el("div", { class: "br-manual-grid" }, [
+      el("div", { class: "br-field" }, [el("label", { for: "br-scope", text: "Scope" }), scopeSelect("br-scope", "app_state")]),
+      el("div", { class: "br-field" }, [el("label", { for: "br-label", text: "Label" }), el("input", { id: "br-label", type: "text", value: "manual" })]),
+      el("div", { class: "br-actions" }, [
+        el("button", { class: "br-btn primary", type: "button", on: { click: createNow } }, ["Create Backup"]),
+        el("button", { class: "br-btn", type: "button", on: { click: () => $("br-upload")?.click() } }, ["Import"]),
+        el("input", { id: "br-upload", class: "br-upload", type: "file", accept: ".zip", on: { change: uploadBackup } })
+      ])
+    ]));
+
+    const scheduled = el("div", { class: "br-mode-pane br-section br-scheduled" });
+    scheduled.appendChild(el("div", { class: "br-section-head" }, [
+      el("h3", { text: "Scheduled Backups" }),
+      switcher("br-sch-enabled", "Enable", !!schedule.active),
+      el("div", { class: "br-actions" }, [
+        el("button", { class: "br-btn primary", type: "button", on: { click: saveSchedule } }, ["Save Schedule"])
+      ])
+    ]));
+    scheduled.appendChild(el("div", { class: "br-schedule-grid" }, [
+      el("div", { class: "br-field" }, [el("label", { for: "br-sch-scope", text: "Scope" }), scopeSelect("br-sch-scope", schedule.scope || "app_state")]),
+      el("div", { class: "br-field" }, [el("label", { for: "br-sch-at", text: "Time" }), el("input", { id: "br-sch-at", type: "time", value: schedule.at || "03:00" })]),
+      el("div", { class: "br-field" }, [el("label", { for: "br-ret-days", text: "Retention days" }), el("input", { id: "br-ret-days", type: "number", value: String(schedule.retention_days ?? 30), min: "0" })]),
+      el("div", { class: "br-field" }, [el("label", { for: "br-max-backups", text: "Max backups" }), el("input", { id: "br-max-backups", type: "number", value: String(schedule.max_backups ?? 10), min: "0" })])
+    ]));
+    const days = Array.isArray(schedule.days) ? schedule.days.map(Number) : [];
+    const daysBox = el("div", { class: "br-days" });
+    DAY_NAMES.forEach((name, i) => {
+      const n = i + 1;
+      const cb = el("input", { type: "checkbox", value: String(n), checked: days.includes(n) });
+      daysBox.appendChild(el("label", { class: "br-day" }, [cb, el("span", { text: name })]));
+    });
+    scheduled.appendChild(el("div", { class: "br-field br-days-field" }, [el("label", { text: "Days" }), daysBox]));
+    panel.appendChild(el("div", { class: "br-mode-window" }, [
+      el("div", { class: `br-mode-track ${activeMode}` }, [create, scheduled])
+    ]));
+    return panel;
+  }
+
+  function renderStatus(panel){
+    const latest = state.backups[0] || {};
+    const total = state.backups.reduce((n, b) => n + Number(b.size || 0), 0);
+    const ext = latest.external_key_required ? "External key" : (latest.master_key_included ? "Key included" : "No key needed");
+    const next = (state.schedule || {}).active ? `${state.schedule.at || "03:00"}` : "Disabled";
+    panel.appendChild(el("div", { class: "br-status" }, [
+      el("div", { class: "br-stat" }, [el("b", { text: fmtDate(latest.created_at, latest.mtime) }), el("span", { text: "Last backup" })]),
+      el("div", { class: "br-stat" }, [el("b", { text: next }), el("span", { text: "Schedule" })]),
+      el("div", { class: "br-stat" }, [el("b", { text: fmtBytes(total) }), el("span", { text: "Stored" })]),
+      el("div", { class: "br-stat" }, [el("b", { text: ext }), el("span", { text: "Key status" })])
+    ]));
+  }
+
+  function renderListPanel(){
+    const panel = el("div", { class: "br-panel br-list-panel" });
+    panel.appendChild(el("div", { class: "br-list-head" }, [
+      el("h3", { text: "Backup List" }),
+      el("button", {
+        class: `br-iconbtn ${state.refreshing ? "spin" : ""}`,
+        type: "button",
+        title: "Refresh",
+        "aria-label": "Refresh",
+        disabled: state.refreshing,
+        on: { click: () => refresh({ busy: true }) }
+      }, [icon("refresh")])
+    ]));
+    renderStatus(panel);
+    const list = el("div", { class: "br-list", id: "br-list" });
+    if (!state.backups.length) {
+      list.appendChild(el("div", { class: "br-row" }, [el("div", { class: "br-main" }, [el("div", { class: "br-name", text: "No backups yet" }), el("div", { class: "br-meta" }, [el("span", { text: "Create one manually or enable the schedule." })])])]));
+    } else {
+      state.backups.forEach((b) => list.appendChild(renderBackupRow(b)));
+    }
+    panel.appendChild(list);
+    return panel;
+  }
+
+  function renderBackupRow(b){
+    const path = String(b.path || "");
+    const row = el("div", { class: `br-row ${state.selected === path ? "active" : ""}` });
+    const main = el("div", { class: "br-main" }, [
+      el("div", { class: "br-name", text: b.label || PathName(path) }),
+      el("div", { class: "br-meta" }, [
+        el("span", { class: "br-pill", text: scopeLabel(b.scope) }),
+        el("span", { class: "br-pill", text: fmtBytes(b.size) }),
+        el("span", { class: "br-pill", text: fmtDate(b.created_at, b.mtime) }),
+        el("span", { class: "br-pill", text: b.external_key_required ? "External key required" : (b.master_key_included ? "Key included" : "No key") })
+      ])
+    ]);
+    const note = state.rowStatus[path];
+    if (note?.text) {
+      main.appendChild(el("div", { class: `br-row-note ${note.kind || ""}`, text: note.text }));
+    }
+    const actions = el("div", { class: "br-row-actions" }, [
+      el("button", { class: "br-iconbtn", type: "button", title: "Download", "aria-label": "Download", on: { click: (e) => { e.stopPropagation(); downloadBackup(path); } } }, [icon("download")]),
+      el("button", { class: "br-iconbtn", type: "button", title: "Validate", "aria-label": "Validate", on: { click: (e) => { e.stopPropagation(); validateBackup(path); } } }, [icon("verified")]),
+      el("button", { class: "br-iconbtn", type: "button", title: "Restore", "aria-label": "Restore", on: { click: (e) => { e.stopPropagation(); restoreBackup(path); } } }, [icon("settings_backup_restore")]),
+      el("button", { class: "br-iconbtn", type: "button", title: "Delete", "aria-label": "Delete", on: { click: (e) => { e.stopPropagation(); deleteBackup(path); } } }, [icon("delete")])
+    ]);
+    row.appendChild(main);
+    row.appendChild(actions);
+    row.addEventListener("click", () => { state.selected = path; renderBody(); });
+    return row;
+  }
+
+  function PathName(path){
+    const parts = String(path || "").split("/");
+    return parts[parts.length - 1] || "Backup";
+  }
+
+  function currentCreateOptions(){
+    return {
+      scope: $("br-scope")?.value || "app_state",
+      label: $("br-label")?.value || "manual",
+      include_snapshots: false,
+      include_reports: false,
+      include_cache: false
+    };
+  }
+
+  async function createNow(){
+    try {
+      toast("Creating backup...");
+      await postJSON("/api/backups/create", currentCreateOptions());
+      toast("Backup created");
+      await refresh();
+    } catch (e) {
+      toast(`Backup failed: ${e.message || e}`, 3200);
+    }
+  }
+
+  async function uploadBackup(e){
+    const input = e.currentTarget;
+    const file = input?.files?.[0];
+    if (!file) return;
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      toast("Importing backup...");
+      await api("/api/backups/upload", { method: "POST", body: form });
+      toast("Backup imported");
+      input.value = "";
+      await refresh();
+    } catch (err) {
+      toast(`Import failed: ${err.message || err}`, 3200);
+    }
+  }
+
+  function downloadBackup(path){
+    if (!path) return;
+    window.location.href = `/api/backups/download?path=${encodeURIComponent(path)}`;
+  }
+
+  async function validateBackup(path){
+    try {
+      state.rowStatus[path] = { kind: "", text: "Validating backup..." };
+      renderBody();
+      const res = await postJSON("/api/backups/validate", { path });
+      const errors = res?.validation?.errors || [];
+      state.rowStatus[path] = errors.length
+        ? { kind: "warn", text: `Validation found ${errors.length} issue(s).` }
+        : { kind: "ok", text: "Successfully validated." };
+      renderBody();
+    } catch (e) {
+      state.rowStatus[path] = { kind: "warn", text: `Validation failed: ${e.message || e}` };
+      renderBody();
+    }
+  }
+
+  async function restoreBackup(path){
+    if (!path) return;
+    const ok = window.confirm("Restore this CrossWatch backup?\n\nA pre-restore backup will be created first and CrossWatch will restart after restore.");
+    if (!ok) return;
+    try {
+      toast("Restoring backup...");
+      await postJSON("/api/backups/restore", { path, restart: true });
+      toast("Restore applied. Restarting...");
+      setTimeout(() => { try { window.location.reload(); } catch {} }, 2400);
+    } catch (e) {
+      toast(`Restore failed: ${e.message || e}`, 4200);
+    }
+  }
+
+  async function deleteBackup(path){
+    if (!path) return;
+    if (!window.confirm("Delete this backup?")) return;
+    try {
+      await postJSON("/api/backups/delete", { path });
+      toast("Backup deleted");
+      await refresh();
+    } catch (e) {
+      toast(`Delete failed: ${e.message || e}`, 3200);
+    }
+  }
+
+  function readScheduleForm(){
+    const dayChecks = Array.from(document.querySelectorAll(".br-days input[type=checkbox]"));
+    const days = dayChecks.filter((x) => x.checked).map((x) => Number(x.value)).filter((n) => n >= 1 && n <= 7);
+    return {
+      enabled: !!$("br-sch-enabled")?.checked,
+      scope: $("br-sch-scope")?.value || "app_state",
+      at: $("br-sch-at")?.value || "03:00",
+      days,
+      retention_days: Number($("br-ret-days")?.value || 30),
+      max_backups: Number($("br-max-backups")?.value || 10),
+      auto_delete_old: true,
+      include_snapshots: false,
+      include_reports: false,
+      include_cache: false
+    };
+  }
+
+  async function saveSchedule(){
+    try {
+      const res = await postJSON("/api/backups/schedule", readScheduleForm());
+      state.schedule = res.schedule || {};
+      toast("Backup schedule saved");
+      renderBody();
+    } catch (e) {
+      toast(`Schedule failed: ${e.message || e}`, 3200);
+    }
+  }
+
+  async function refresh(opts){
+    const busy = !!(opts && opts.busy);
+    if (busy) {
+      state.refreshing = true;
+      renderBody();
+    }
+    try {
+      const [list, sched] = await Promise.all([
+        api("/api/backups/list"),
+        api("/api/backups/schedule")
+      ]);
+      state.backups = Array.isArray(list.backups) ? list.backups : [];
+      state.schedule = sched.schedule || {};
+    } finally {
+      if (busy) state.refreshing = false;
+      renderBody();
+    }
+  }
+
+  function open(){
+    buildShell();
+    const modal = $("cw-backups-modal");
+    if (!modal) return;
+    document.body.classList.add("br-backups-open", "cx-modal-open");
+    modal.classList.remove("hidden");
+    modal.setAttribute("aria-hidden", "false");
+    refresh().catch((e) => toast(`Refresh failed: ${e.message || e}`, 3200));
+  }
+
+  function close(){
+    const modal = $("cw-backups-modal");
+    if (!modal) return;
+    modal.classList.add("hidden");
+    modal.setAttribute("aria-hidden", "true");
+    document.body.classList.remove("br-backups-open", "cx-modal-open");
+  }
+
+  window.openBackupRestore = open;
+  (window.CW ||= {});
+  window.CW.Backups = { open, close, refresh };
+})();

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -41,6 +41,7 @@ from api.appAuthAPI import (
 )
 
 from _logging import log as LOG, BLUE, GREEN, DIM, RESET  # type: ignore
+BACKUP_LOG = LOG.child("BACKUP")
 
 def _c(text: str, color: str) -> str:
     return f"{color}{text}{RESET}" if LOG.use_color else text
@@ -913,10 +914,76 @@ async def api_logs_watcher(
 # Scheduler sync starter
 def _start_sync_from_scheduler(payload: dict[str, Any] | None = None) -> bool:
     p = dict(payload or {})
+    raw_backup = p.get("backup")
+    backup: dict[str, Any] = raw_backup if isinstance(raw_backup, dict) else {}
+    backup_job_id = str(p.get("backup_job_id") or "").strip()
+    scheduler_mode = str(p.get("scheduler_mode") or "").strip().lower()
+    if backup_job_id or scheduler_mode == "advanced_backup" or backup:
+        try:
+            from services.backups import create_backup, enforce_backup_retention, render_backup_label_template
+
+            scope = str(backup.get("scope") or "app_state").strip().lower()
+            label_template = str(backup.get("label_template") or backup.get("labelTemplate") or "").strip()
+            try:
+                retention_days = max(0, int(backup.get("retention_days") or 0))
+            except Exception:
+                retention_days = 0
+            try:
+                max_backups = max(0, int(backup.get("max_backups") or 0))
+            except Exception:
+                max_backups = 0
+            auto_delete_old = backup.get("auto_delete_old") is True
+            label = render_backup_label_template(label_template, scope=scope)
+            BACKUP_LOG.info(f"scheduled backup starting scope={scope} job={backup_job_id or 'default'}")
+            BACKUP_LOG.debug(
+                "scheduled backup options",
+                extra={
+                    "scope": scope,
+                    "job_id": backup_job_id or "default",
+                    "retention_days": retention_days,
+                    "max_backups": max_backups,
+                    "auto_delete_old": auto_delete_old,
+                    "include_snapshots": bool(backup.get("include_snapshots")),
+                    "include_reports": bool(backup.get("include_reports")),
+                    "include_cache": bool(backup.get("include_cache")),
+                },
+            )
+            res = create_backup(
+                scope=scope,
+                label=label,
+                include_snapshots=bool(backup.get("include_snapshots")),
+                include_reports=bool(backup.get("include_reports")),
+                include_cache=bool(backup.get("include_cache")),
+                trigger="scheduler",
+            ) or {}
+            _append_log(
+                "SYNC",
+                f"[i] Scheduler backup: saved {scope} -> {res.get('path') or 'backup created'}",
+            )
+            BACKUP_LOG.success(f"scheduled backup completed scope={scope} path={res.get('path') or 'backup created'}")
+            if auto_delete_old:
+                cleanup = enforce_backup_retention(
+                    retention_days=retention_days,
+                    max_backups=max_backups,
+                    auto_delete_old=True,
+                ) or {}
+                deleted = cleanup.get("deleted") or []
+                if deleted:
+                    _append_log("SYNC", f"[i] Scheduler backup retention: deleted {len(deleted)} old backup(s)")
+                BACKUP_LOG.debug(
+                    "scheduled backup retention completed",
+                    extra={"deleted": len(deleted), "errors": len(cleanup.get("errors") or [])},
+                )
+            return True
+        except Exception as e:
+            _append_log("SYNC", f"[!] Scheduler backup failed: {type(e).__name__}")
+            BACKUP_LOG.error(f"scheduled backup failed: {type(e).__name__}")
+            BACKUP_LOG.debug("scheduled backup failure detail", extra={"error_type": type(e).__name__})
+            return False
+
     raw_capture = p.get("capture")
     capture: dict[str, Any] = raw_capture if isinstance(raw_capture, dict) else {}
     capture_job_id = str(p.get("capture_job_id") or "").strip()
-    scheduler_mode = str(p.get("scheduler_mode") or "").strip().lower()
     if capture_job_id or scheduler_mode == "advanced_capture" or capture:
         try:
             from services.snapshots import create_snapshot, enforce_capture_retention, render_capture_label_template

--- a/services/backups.py
+++ b/services/backups.py
@@ -1,0 +1,670 @@
+# services/backups.py
+# CrossWatch - Application backup and restore helpers
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timedelta, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import uuid
+import zipfile
+
+from _logging import log as BASE_LOG
+from cw_platform.config_base import CONFIG, _current_version_norm
+
+BackupScope = Literal["config_only", "app_state", "full"]
+
+LOG = BASE_LOG.child("BACKUP")
+
+BACKUP_KIND = "crosswatch_backup"
+BACKUP_SCHEMA_VERSION = 1
+BACKUP_SCOPES = {"config_only", "app_state", "full"}
+MAX_ARCHIVE_BYTES = 2 * 1024 * 1024 * 1024
+MAX_ZIP_MEMBERS = 100_000
+MANIFEST_NAME = "manifest.json"
+
+_APP_STATE_FILES = (
+    "config.json",
+    ".cw_master_key",
+    "state.json",
+    "last_sync.json",
+    "statistics.json",
+    "watchlist_hide.json",
+)
+_APP_STATE_DIRS = (
+    ".cw_state",
+    "tls",
+)
+_FULL_DIRS = (
+    "snapshots",
+    ".cw_provider",
+    "sync_reports",
+    ".cw_cache",
+)
+_OPTIONAL_RESTORE_DIRS = (
+    "cache",
+)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _backups_dir() -> Path:
+    d = CONFIG / "backups"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _safe_backup_label(value: str) -> str:
+    raw = re.sub(r"[^a-zA-Z0-9._ -]+", "", str(value or "").strip())
+    raw = re.sub(r"\s+", "-", raw).strip("-._ ")
+    return raw[:48] or "manual"
+
+
+def render_backup_label_template(template: str, *, scope: str, ts: datetime | None = None) -> str:
+    stamp = ts if isinstance(ts, datetime) else _utc_now()
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
+    raw = str(template or "").strip() or "scheduled-{scope}-{date}"
+    values = {
+        "scope": str(scope or "app_state").strip().lower(),
+        "date": stamp.strftime("%Y-%m-%d"),
+        "time": stamp.strftime("%H-%M"),
+        "datetime": stamp.strftime("%Y-%m-%d_%H-%M"),
+        "stamp": stamp.strftime("%Y%m%dT%H%M%SZ"),
+    }
+    try:
+        rendered = raw.format_map(values)
+    except Exception:
+        rendered = raw
+    return _safe_backup_label(rendered)
+
+
+def _normalize_scope(scope: Any) -> BackupScope:
+    raw = str(scope or "app_state").strip().lower()
+    if raw not in BACKUP_SCOPES:
+        raw = "app_state"
+    return raw  # type: ignore[return-value]
+
+
+def _is_env_key_configured() -> bool:
+    return bool((os.getenv("CW_CONFIG_KEY") or "").strip() or (os.getenv("CROSSWATCH_CONFIG_KEY") or "").strip())
+
+
+def _config_has_encrypted_values() -> bool:
+    p = CONFIG / "config.json"
+    if not p.exists() or not p.is_file():
+        return False
+    try:
+        return "enc:v1:" in p.read_text(encoding="utf-8", errors="ignore")
+    except Exception:
+        return False
+
+
+def _rel_from_config(path: Path) -> str:
+    base = CONFIG.resolve()
+    target = path.resolve()
+    try:
+        rel = target.relative_to(base)
+    except ValueError as e:
+        raise ValueError("Path is outside the config directory") from e
+    return rel.as_posix()
+
+
+def _safe_rel_path(raw: Any) -> str:
+    text = str(raw or "").strip().replace("\\", "/")
+    if not text:
+        raise ValueError("Path is required")
+    posix = PurePosixPath(text)
+    parts = [part for part in posix.parts if part not in ("", ".")]
+    if posix.is_absolute() or not parts or any(part == ".." for part in parts):
+        raise ValueError("Invalid path")
+    if parts[0] == "backups":
+        raise ValueError("Invalid path")
+    return "/".join(parts)
+
+
+def _resolve_backup_file(path: str, *, must_exist: bool = True) -> tuple[str, Path]:
+    text = str(path or "").strip().replace("\\", "/")
+    if not text:
+        raise ValueError("Backup path is required")
+    posix = PurePosixPath(text)
+    parts = [part for part in posix.parts if part not in ("", ".")]
+    if posix.is_absolute() or not parts or any(part == ".." for part in parts):
+        raise ValueError("Invalid backup path")
+    if Path(parts[-1]).suffix.lower() != ".zip":
+        raise ValueError("Invalid backup path")
+
+    base = _backups_dir().resolve()
+    target = base.joinpath(*parts).resolve()
+    try:
+        target.relative_to(base)
+    except ValueError as e:
+        raise ValueError("Invalid backup path") from e
+    if must_exist and (not target.exists() or not target.is_file()):
+        raise ValueError("Backup not found")
+    return "/".join(parts), target
+
+
+def _resolve_restore_target(rel_path: str) -> Path:
+    rel = _safe_rel_path(rel_path)
+    allowed_files = set(_APP_STATE_FILES)
+    allowed_dirs = set(_APP_STATE_DIRS) | set(_FULL_DIRS) | set(_OPTIONAL_RESTORE_DIRS)
+    first = rel.split("/", 1)[0]
+    if rel not in allowed_files and first not in allowed_dirs:
+        raise ValueError("Invalid restore target")
+    base = CONFIG.resolve()
+    target = base.joinpath(*PurePosixPath(rel).parts).resolve()
+    try:
+        target.relative_to(base)
+    except ValueError as e:
+        raise ValueError("Invalid restore target") from e
+    return target
+
+
+def _iter_files_under(path: Path) -> Iterable[Path]:
+    if path.is_file():
+        if not path.is_symlink():
+            yield path
+        return
+    if not path.is_dir() or path.is_symlink():
+        return
+    for child in sorted(path.rglob("*")):
+        try:
+            if child.is_file() and not child.is_symlink():
+                yield child
+        except OSError:
+            continue
+
+
+def _candidate_roots(
+    scope: BackupScope,
+    *,
+    include_snapshots: bool | None = None,
+    include_reports: bool | None = None,
+    include_cache: bool = False,
+) -> list[Path]:
+    names: list[str] = []
+    if scope == "config_only":
+        names.extend(("config.json", ".cw_master_key"))
+    else:
+        names.extend(_APP_STATE_FILES)
+        names.extend(_APP_STATE_DIRS)
+        if scope == "full":
+            names.extend(_FULL_DIRS)
+        if include_snapshots is True and "snapshots" not in names:
+            names.append("snapshots")
+        if include_reports is True and "sync_reports" not in names:
+            names.append("sync_reports")
+        if include_cache:
+            names.append("cache")
+
+    out: list[Path] = []
+    seen: set[str] = set()
+    backup_root = _backups_dir().resolve()
+    for name in names:
+        rel = _safe_rel_path(name)
+        p = (CONFIG / rel).resolve()
+        try:
+            p.relative_to(CONFIG.resolve())
+        except ValueError:
+            continue
+        try:
+            p.relative_to(backup_root)
+            continue
+        except ValueError:
+            pass
+        key = str(p)
+        if key not in seen:
+            seen.add(key)
+            out.append(p)
+    return out
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _sha256_zip_member(zf: zipfile.ZipFile, name: str) -> str:
+    h = hashlib.sha256()
+    with zf.open(name, "r") as src:
+        for chunk in iter(lambda: src.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _backup_rel_for_new(ts: datetime, label: str) -> tuple[str, Path]:
+    day_dir = _backups_dir() / ts.strftime("%Y-%m-%d")
+    day_dir.mkdir(parents=True, exist_ok=True)
+    stamp = ts.strftime("%Y%m%dT%H%M%SZ")
+    base_name = f"crosswatch-backup-{stamp}-{_safe_backup_label(label)}.zip"
+    target = day_dir / base_name
+    i = 1
+    while target.exists():
+        target = day_dir / f"crosswatch-backup-{stamp}-{_safe_backup_label(label)}-{i}.zip"
+        i += 1
+    return _rel_from_backup_root(target), target
+
+
+def _rel_from_backup_root(path: Path) -> str:
+    base = _backups_dir().resolve()
+    target = path.resolve()
+    try:
+        return target.relative_to(base).as_posix()
+    except ValueError as e:
+        raise ValueError("Path is outside the backups directory") from e
+
+
+def _safe_log_text(value: Any) -> str:
+    text = str(value or "").strip().replace("\r", " ").replace("\n", " ")
+    try:
+        text = text.replace(str(CONFIG.resolve()), "<config>")
+        text = text.replace(str(_backups_dir().resolve()), "<backups>")
+    except Exception:
+        pass
+    return text[:300] or "no detail"
+
+
+def _safe_log_errors(errors: list[str]) -> list[str]:
+    return [_safe_log_text(err) for err in errors[:10]]
+
+
+def _error_text(err: Exception) -> str:
+    text = _safe_log_text(err)
+    return text if text != "no detail" else type(err).__name__
+
+
+def create_backup(
+    *,
+    scope: BackupScope | str = "app_state",
+    label: str = "manual",
+    include_snapshots: bool | None = None,
+    include_reports: bool | None = None,
+    include_cache: bool = False,
+    trigger: str = "manual",
+) -> dict[str, Any]:
+    sc = _normalize_scope(scope)
+    ts = _utc_now()
+    safe_label = _safe_backup_label(label or trigger or sc)
+    rel, target = _backup_rel_for_new(ts, safe_label)
+    tmp = target.with_suffix(target.suffix + f".tmp.{uuid.uuid4().hex[:8]}")
+
+    LOG.info(f"creating backup scope={sc} trigger={trigger or 'manual'} label={safe_label}")
+    LOG.debug(
+        "backup create options",
+        extra={
+            "scope": sc,
+            "trigger": str(trigger or "manual"),
+            "include_snapshots": include_snapshots,
+            "include_reports": include_reports,
+            "include_cache": bool(include_cache),
+        },
+    )
+
+    files: list[Path] = []
+    seen: set[str] = set()
+    for root in _candidate_roots(sc, include_snapshots=include_snapshots, include_reports=include_reports, include_cache=include_cache):
+        for file_path in _iter_files_under(root):
+            rel_file = _rel_from_config(file_path)
+            if rel_file in seen:
+                continue
+            seen.add(rel_file)
+            files.append(file_path)
+
+    LOG.debug("backup file selection completed", extra={"scope": sc, "file_count": len(files)})
+
+    manifest_files: list[dict[str, Any]] = []
+    total_size = 0
+    try:
+        with zipfile.ZipFile(tmp, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+            for file_path in files:
+                rel_file = _rel_from_config(file_path)
+                st = file_path.stat()
+                total_size += int(st.st_size)
+                digest = _sha256_file(file_path)
+                manifest_files.append(
+                    {
+                        "path": rel_file,
+                        "size": int(st.st_size),
+                        "sha256": digest,
+                    }
+                )
+                zf.write(file_path, rel_file)
+
+            key_included = any(row.get("path") == ".cw_master_key" for row in manifest_files)
+            encrypted = _config_has_encrypted_values()
+            manifest = {
+                "kind": BACKUP_KIND,
+                "schema_version": BACKUP_SCHEMA_VERSION,
+                "created_at": ts.isoformat(),
+                "app_version": _current_version_norm(),
+                "scope": sc,
+                "label": safe_label,
+                "trigger": str(trigger or "manual"),
+                "files": manifest_files,
+                "file_count": len(manifest_files),
+                "total_size": total_size,
+                "config_encrypted": encrypted,
+                "master_key_included": key_included,
+                "external_key_required": bool(encrypted and not key_included),
+                "env_key_configured": _is_env_key_configured(),
+            }
+            zf.writestr(MANIFEST_NAME, json.dumps(manifest, indent=2, sort_keys=False) + "\n")
+        os.replace(tmp, target)
+    except Exception as e:
+        try:
+            tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+        LOG.error(f"backup create failed scope={sc} trigger={trigger or 'manual'}: {type(e).__name__}")
+        LOG.debug(f"backup create failure detail: {_error_text(e)}", extra={"scope": sc, "target": rel})
+        raise
+
+    result = {
+        "ok": True,
+        "path": rel,
+        "created_at": ts.isoformat(),
+        "scope": sc,
+        "label": safe_label,
+        "size": int(target.stat().st_size),
+        "file_count": len(manifest_files),
+        "total_size": total_size,
+        "master_key_included": any(row.get("path") == ".cw_master_key" for row in manifest_files),
+        "external_key_required": bool(_config_has_encrypted_values() and not any(row.get("path") == ".cw_master_key" for row in manifest_files)),
+    }
+    LOG.success(
+        f"backup created scope={sc} trigger={trigger or 'manual'} path={rel} files={result['file_count']} size={result['size']}"
+    )
+    LOG.debug(
+        "backup manifest summary",
+        extra={
+            "path": rel,
+            "scope": sc,
+            "file_count": result["file_count"],
+            "total_size": total_size,
+            "master_key_included": result["master_key_included"],
+            "external_key_required": result["external_key_required"],
+        },
+    )
+    return result
+
+
+def _read_manifest_from_zip(zf: zipfile.ZipFile) -> dict[str, Any]:
+    try:
+        info = zf.getinfo(MANIFEST_NAME)
+    except KeyError as e:
+        raise ValueError("Backup manifest is missing") from e
+    if info.file_size > 5 * 1024 * 1024:
+        raise ValueError("Backup manifest is too large")
+    with zf.open(info, "r") as f:
+        data = json.loads(f.read().decode("utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Invalid backup manifest")
+    if str(data.get("kind") or "") != BACKUP_KIND:
+        raise ValueError("Invalid backup kind")
+    if int(data.get("schema_version") or 0) != BACKUP_SCHEMA_VERSION:
+        raise ValueError("Unsupported backup schema")
+    files = data.get("files")
+    if not isinstance(files, list):
+        raise ValueError("Invalid backup file list")
+    return data
+
+
+def validate_backup(path: str) -> dict[str, Any]:
+    rel, target = _resolve_backup_file(path)
+    LOG.debug(f"validating backup path={rel}")
+    if target.stat().st_size > MAX_ARCHIVE_BYTES:
+        LOG.warn(f"backup validation rejected oversized archive path={rel}")
+        raise ValueError("Backup archive is too large")
+
+    errors: list[str] = []
+    try:
+        with zipfile.ZipFile(target, "r") as zf:
+            infos = zf.infolist()
+            if len(infos) > MAX_ZIP_MEMBERS:
+                raise ValueError("Backup archive contains too many files")
+            bad = zf.testzip()
+            if bad:
+                raise ValueError("Backup archive failed integrity check")
+            manifest = _read_manifest_from_zip(zf)
+            info_by_name = {info.filename: info for info in infos}
+            for row in manifest.get("files") or []:
+                if not isinstance(row, Mapping):
+                    errors.append("Invalid manifest file entry")
+                    continue
+                member = _safe_rel_path(row.get("path"))
+                try:
+                    _resolve_restore_target(member)
+                except Exception:
+                    errors.append(f"Invalid restore target: {member}")
+                    continue
+                if member not in info_by_name:
+                    errors.append(f"Missing archive member: {member}")
+                    continue
+                info = info_by_name[member]
+                if info.is_dir():
+                    errors.append(f"Invalid directory member: {member}")
+                    continue
+                expected_size = int(row.get("size") or -1)
+                if expected_size >= 0 and expected_size != int(info.file_size):
+                    errors.append(f"Size mismatch: {member}")
+                    continue
+                expected_hash = str(row.get("sha256") or "").strip().lower()
+                if not re.fullmatch(r"[0-9a-f]{64}", expected_hash):
+                    errors.append(f"Invalid hash: {member}")
+                    continue
+                actual_hash = _sha256_zip_member(zf, member)
+                if actual_hash != expected_hash:
+                    errors.append(f"Hash mismatch: {member}")
+    except zipfile.BadZipFile as e:
+        LOG.warn(f"backup validation rejected invalid archive path={rel}")
+        raise ValueError("Invalid backup archive") from e
+
+    result = {
+        "ok": len(errors) == 0,
+        "path": rel,
+        "manifest": manifest,
+        "errors": errors,
+    }
+    if result["ok"]:
+        LOG.success(f"backup validated path={rel}")
+    else:
+        LOG.warn(f"backup validation failed path={rel} errors={len(errors)}")
+        LOG.debug("backup validation errors", extra={"path": rel, "errors": _safe_log_errors(errors), "error_count": len(errors)})
+    return result
+
+
+def list_backups() -> list[dict[str, Any]]:
+    base = _backups_dir()
+    out: list[dict[str, Any]] = []
+    for p in sorted(base.rglob("*.zip")):
+        try:
+            rel = _rel_from_backup_root(p)
+        except Exception:
+            continue
+        row: dict[str, Any] = {
+            "path": rel,
+            "size": int(p.stat().st_size),
+            "mtime": int(p.stat().st_mtime),
+            "valid": None,
+        }
+        try:
+            with zipfile.ZipFile(p, "r") as zf:
+                manifest = _read_manifest_from_zip(zf)
+            row.update(
+                {
+                    "valid": True,
+                    "created_at": manifest.get("created_at"),
+                    "app_version": manifest.get("app_version"),
+                    "scope": manifest.get("scope"),
+                    "label": manifest.get("label"),
+                    "file_count": manifest.get("file_count"),
+                    "total_size": manifest.get("total_size"),
+                    "master_key_included": manifest.get("master_key_included"),
+                    "external_key_required": manifest.get("external_key_required"),
+                }
+            )
+        except Exception:
+            row["valid"] = False
+        out.append(row)
+    out.sort(key=lambda x: int(x.get("mtime") or 0), reverse=True)
+    LOG.debug(f"listed backups count={len(out)}")
+    return out
+
+
+def delete_backup(path: str) -> dict[str, Any]:
+    rel, target = _resolve_backup_file(path)
+    LOG.info(f"deleting backup path={rel}")
+    target.unlink()
+    LOG.success(f"backup deleted path={rel}")
+    return {"ok": True, "deleted": rel}
+
+
+def enforce_backup_retention(*, retention_days: int = 0, max_backups: int = 0, auto_delete_old: bool = False) -> dict[str, Any]:
+    if not auto_delete_old:
+        LOG.debug("backup retention skipped auto_delete_old=false")
+        return {"ok": True, "applied": False, "deleted": [], "errors": []}
+
+    keep_days = max(0, int(retention_days or 0))
+    keep_count = max(0, int(max_backups or 0))
+    LOG.info(f"applying backup retention days={keep_days} max={keep_count}")
+    rows = list_backups()
+    cutoff = _utc_now() - timedelta(days=keep_days) if keep_days > 0 else None
+    to_delete: list[str] = []
+    kept: list[dict[str, Any]] = []
+
+    for row in rows:
+        path = str(row.get("path") or "")
+        created = datetime.fromtimestamp(int(row.get("mtime") or 0), tz=timezone.utc)
+        if cutoff is not None and created < cutoff:
+            to_delete.append(path)
+            continue
+        kept.append(row)
+
+    if keep_count > 0 and len(kept) > keep_count:
+        to_delete.extend(str(row.get("path") or "") for row in kept[keep_count:])
+
+    LOG.debug(
+        "backup retention candidates",
+        extra={"total_backups": len(rows), "candidate_count": len(to_delete), "retention_days": keep_days, "max_backups": keep_count},
+    )
+    deleted: list[str] = []
+    errors: list[str] = []
+    seen: set[str] = set()
+    for rel in to_delete:
+        if not rel or rel in seen:
+            continue
+        seen.add(rel)
+        try:
+            deleted.append(str(delete_backup(rel).get("deleted") or rel))
+        except Exception as e:
+            errors.append(str(e))
+    result = {"ok": not errors, "applied": True, "deleted": deleted, "errors": errors}
+    if errors:
+        LOG.warn(f"backup retention completed with errors deleted={len(deleted)} errors={len(errors)}")
+        LOG.debug("backup retention errors", extra={"errors": _safe_log_errors(errors), "error_count": len(errors)})
+    else:
+        LOG.success(f"backup retention completed deleted={len(deleted)}")
+    return result
+
+
+def restore_backup(path: str, *, create_pre_restore: bool = True) -> dict[str, Any]:
+    validation = validate_backup(path)
+    if not validation.get("ok"):
+        LOG.warn(f"backup restore blocked validation_failed path={validation.get('path') or 'unknown'}")
+        return {"ok": False, "error": "backup_validation_failed", "errors": validation.get("errors") or []}
+
+    rel, target = _resolve_backup_file(path)
+    LOG.info(f"restoring backup path={rel} pre_restore={bool(create_pre_restore)}")
+    raw_manifest = validation.get("manifest")
+    manifest: dict[str, Any] = raw_manifest if isinstance(raw_manifest, dict) else {}
+    if bool(manifest.get("external_key_required")) and not _is_env_key_configured():
+        LOG.warn(f"backup restore blocked external_config_key_required path={rel}")
+        return {
+            "ok": False,
+            "error": "external_config_key_required",
+            "path": rel,
+        }
+
+    pre_restore = None
+    if create_pre_restore:
+        pre_restore = create_backup(scope="app_state", label="pre-restore", trigger="pre_restore")
+        LOG.debug(
+            "pre-restore backup created",
+            extra={"source": rel, "pre_restore_path": str((pre_restore or {}).get("path") or "")},
+        )
+
+    restored: list[str] = []
+    errors: list[str] = []
+    try:
+        with zipfile.ZipFile(target, "r") as zf:
+            raw_files = manifest.get("files")
+            files = raw_files if isinstance(raw_files, list) else []
+            for row in files:
+                if not isinstance(row, Mapping):
+                    continue
+                member = _safe_rel_path(row.get("path"))
+                dst = _resolve_restore_target(member)
+                tmp = dst.with_suffix(dst.suffix + f".restore.{uuid.uuid4().hex[:8]}.tmp")
+                try:
+                    dst.parent.mkdir(parents=True, exist_ok=True)
+                    with zf.open(member, "r") as src, tmp.open("wb") as out:
+                        shutil.copyfileobj(src, out, length=1024 * 1024)
+                    os.replace(tmp, dst)
+                    restored.append(member)
+                except Exception as e:
+                    errors.append(f"{member}: {e}")
+                    try:
+                        tmp.unlink(missing_ok=True)
+                    except Exception:
+                        pass
+    except zipfile.BadZipFile:
+        LOG.warn(f"backup restore failed invalid archive path={rel}")
+        return {"ok": False, "error": "invalid_backup_archive", "restored": restored, "errors": errors}
+
+    result = {
+        "ok": len(errors) == 0,
+        "path": rel,
+        "pre_restore_backup": pre_restore,
+        "restored": restored,
+        "errors": errors,
+        "restart_required": True,
+    }
+    if result["ok"]:
+        LOG.success(f"backup restored path={rel} files={len(restored)}")
+    else:
+        LOG.warn(f"backup restore completed with errors path={rel} restored={len(restored)} errors={len(errors)}")
+        LOG.debug("backup restore errors", extra={"path": rel, "errors": _safe_log_errors(errors), "error_count": len(errors)})
+    return result
+
+
+def save_uploaded_backup(upload_path: Path) -> dict[str, Any]:
+    if upload_path.stat().st_size > MAX_ARCHIVE_BYTES:
+        LOG.warn("uploaded backup rejected oversized archive")
+        raise ValueError("Uploaded backup is too large")
+    LOG.info("importing uploaded backup")
+    ts = _utc_now()
+    imports_dir = _backups_dir() / "imported" / ts.strftime("%Y-%m-%d")
+    imports_dir.mkdir(parents=True, exist_ok=True)
+    target = imports_dir / f"crosswatch-import-{ts.strftime('%Y%m%dT%H%M%SZ')}-{uuid.uuid4().hex[:8]}.zip"
+    shutil.move(str(upload_path), target)
+    rel = _rel_from_backup_root(target)
+    validation = validate_backup(rel)
+    if not validation.get("ok"):
+        target.unlink(missing_ok=True)
+        LOG.warn(f"uploaded backup rejected validation_failed path={rel}")
+        raise ValueError("Uploaded backup failed validation")
+    LOG.success(f"uploaded backup imported path={rel}")
+    return {"ok": True, "path": rel, "validation": validation}

--- a/services/scheduling.py
+++ b/services/scheduling.py
@@ -33,6 +33,7 @@ DEFAULT_SCHEDULING: dict[str, Any] = {
         "enabled": False,
         "jobs": [],
         "capture_jobs": [],
+        "backup_jobs": [],
         "event_rules": [],
     },
 }
@@ -158,6 +159,8 @@ def merge_defaults(s: dict[str, Any]) -> dict[str, Any]:
                 out_adv["jobs"] = []
             if not isinstance(out_adv.get("capture_jobs"), list):
                 out_adv["capture_jobs"] = []
+            if not isinstance(out_adv.get("backup_jobs"), list):
+                out_adv["backup_jobs"] = []
             if not isinstance(out_adv.get("event_rules"), list):
                 out_adv["event_rules"] = []
             out["advanced"] = out_adv
@@ -287,6 +290,38 @@ def _normalize_capture_job(j: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _normalize_backup_job(j: dict[str, Any]) -> dict[str, Any]:
+    days = j.get("days")
+    if not isinstance(days, list):
+        days = []
+    days2: list[int] = []
+    for d in days:
+        try:
+            n = int(d)
+            if 1 <= n <= 7 and n not in days2:
+                days2.append(n)
+        except Exception:
+            continue
+    days2.sort()
+    scope = str(j.get("scope") or "app_state").strip().lower()
+    if scope not in {"config_only", "app_state", "full"}:
+        scope = "app_state"
+    return {
+        "id": str(j.get("id") or "").strip() or f"backup_job_{_now_ts()}",
+        "scope": scope,
+        "label_template": str(j.get("label_template") or j.get("labelTemplate") or "").strip(),
+        "retention_days": _as_int(j.get("retention_days", j.get("retentionDays", j.get("keep_days", 0))), 0, minimum=0),
+        "max_backups": _as_int(j.get("max_backups", j.get("maxBackups", j.get("keep_count", 0))), 0, minimum=0),
+        "auto_delete_old": _as_bool(j.get("auto_delete_old", j.get("autoDeleteOld")), False),
+        "include_snapshots": _as_bool(j.get("include_snapshots", j.get("includeSnapshots")), False),
+        "include_reports": _as_bool(j.get("include_reports", j.get("includeReports")), False),
+        "include_cache": _as_bool(j.get("include_cache", j.get("includeCache")), False),
+        "at": (str(j.get("at") or "").strip() or None),
+        "days": days2,
+        "active": _as_bool(j.get("active"), True),
+    }
+
+
 def _normalize_event_rule(rule: dict[str, Any]) -> dict[str, Any]:
     source = str(rule.get("source") or "").strip().lower()
     if source not in {"watcher", "webhook"}:
@@ -392,6 +427,26 @@ def _iter_adv_capture_jobs(sch: dict[str, Any]) -> list[dict[str, Any]]:
         if not job["active"]:
             continue
         if not job["provider"] or not job["feature"]:
+            continue
+        if not job["at"] or _parse_hhmm(job["at"]) is None:
+            continue
+        out.append(job)
+    return out
+
+
+def _iter_adv_backup_jobs(sch: dict[str, Any]) -> list[dict[str, Any]]:
+    adv = sch.get("advanced") or {}
+    if not isinstance(adv, dict) or not adv.get("enabled"):
+        return []
+    jobs = adv.get("backup_jobs") or adv.get("backupJobs") or []
+    if not isinstance(jobs, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for raw in jobs:
+        if not isinstance(raw, dict):
+            continue
+        job = _normalize_backup_job(raw)
+        if not job["active"]:
             continue
         if not job["at"] or _parse_hhmm(job["at"]) is None:
             continue
@@ -535,6 +590,8 @@ class SyncScheduler:
             "last_capture_job_id": "",
             "last_capture_provider": "",
             "last_capture_feature": "",
+            "last_backup_job_id": "",
+            "last_backup_scope": "",
             "last_rule_id": "",
             "last_event_source": "",
             "last_event_name": "",
@@ -593,6 +650,7 @@ class SyncScheduler:
     def _adv_signature(self, sch: dict[str, Any]) -> str:
         jobs = _iter_adv_jobs(sch)
         capture_jobs = _iter_adv_capture_jobs(sch)
+        backup_jobs = _iter_adv_backup_jobs(sch)
         pairs = [
             ("sync", str(j.get("id") or ""), str(j.get("pair_id") or ""), str(j.get("at") or ""), tuple(j.get("days") or []))
             for j in jobs
@@ -612,6 +670,22 @@ class SyncScheduler:
             )
             for j in capture_jobs
         ]
+        pairs += [
+            (
+                "backup",
+                str(j.get("id") or ""),
+                str(j.get("scope") or ""),
+                str(j.get("at") or ""),
+                tuple(j.get("days") or []),
+                int(j.get("retention_days") or 0),
+                int(j.get("max_backups") or 0),
+                bool(j.get("auto_delete_old")),
+                bool(j.get("include_snapshots")),
+                bool(j.get("include_reports")),
+                bool(j.get("include_cache")),
+            )
+            for j in backup_jobs
+        ]
         return repr(sorted(pairs))
 
     def _adv_seed_past_due_today(self, sch: dict[str, Any], tz: Any | None) -> None:
@@ -630,6 +704,12 @@ class SyncScheduler:
             self._adv_last_key[job["id"]] = f"{today}@{job.get('at')}"
 
         for job in _iter_adv_capture_jobs(sch):
+            dt = _job_due_today(base, job)
+            if dt is None or dt >= current:
+                continue
+            self._adv_last_key[job["id"]] = f"{today}@{job.get('at')}"
+
+        for job in _iter_adv_backup_jobs(sch):
             dt = _job_due_today(base, job)
             if dt is None or dt >= current:
                 continue
@@ -890,6 +970,8 @@ class SyncScheduler:
                 self._status["last_capture_job_id"] = ""
                 self._status["last_capture_provider"] = ""
                 self._status["last_capture_feature"] = ""
+                self._status["last_backup_job_id"] = ""
+                self._status["last_backup_scope"] = ""
                 self._status["last_rule_id"] = str(rule.get("id") or "")
                 self._status["last_event_source"] = str(event.get("source") or "")
                 self._status["last_event_name"] = str(event.get("event") or "")
@@ -935,7 +1017,8 @@ class SyncScheduler:
     def _adv_next(self, sch: dict[str, Any], now_local: datetime, tz: Any | None) -> datetime | None:
         jobs = _iter_adv_jobs(sch)
         capture_jobs = _iter_adv_capture_jobs(sch)
-        if not jobs and not capture_jobs:
+        backup_jobs = _iter_adv_backup_jobs(sch)
+        if not jobs and not capture_jobs and not backup_jobs:
             return None
 
         now = _as_now_in_tz(tz)
@@ -955,6 +1038,12 @@ class SyncScheduler:
             if best is None or cand < best:
                 best = cand
         for j in capture_jobs:
+            cand = _next_job_time(base, j)
+            if cand is None:
+                continue
+            if best is None or cand < best:
+                best = cand
+        for j in backup_jobs:
             cand = _next_job_time(base, j)
             if cand is None:
                 continue
@@ -1010,10 +1099,35 @@ class SyncScheduler:
         due.sort(key=lambda x: (x[0], str(x[1].get("id") or "")))
         return due
 
+    def _adv_due_backup_jobs(self, sch: dict[str, Any], tz: Any | None) -> list[tuple[datetime, dict[str, Any]]]:
+        jobs = _iter_adv_backup_jobs(sch)
+        if not jobs:
+            return []
+
+        now = _as_now_in_tz(tz)
+        base = now.replace(second=0, microsecond=0)
+        today = base.date().isoformat()
+
+        due: list[tuple[datetime, dict[str, Any]]] = []
+        for j in jobs:
+            dt = _job_due_today(base, j)
+            if dt is None:
+                continue
+            if dt > base:
+                continue
+            key = f"{today}@{j.get('at')}"
+            if self._adv_last_key.get(j["id"]) == key:
+                continue
+            due.append((dt, j))
+
+        due.sort(key=lambda x: (x[0], str(x[1].get("id") or "")))
+        return due
+
     def _adv_run_due(self, sch: dict[str, Any], tz: Any | None) -> bool:
         due = self._adv_due_jobs(sch, tz)
         due_capture = self._adv_due_capture_jobs(sch, tz)
-        if not due and not due_capture:
+        due_backup = self._adv_due_backup_jobs(sch, tz)
+        if not due and not due_capture and not due_backup:
             return False
 
         now = _as_now_in_tz(tz)
@@ -1067,6 +1181,8 @@ class SyncScheduler:
                 self._status["last_capture_job_id"] = ""
                 self._status["last_capture_provider"] = ""
                 self._status["last_capture_feature"] = ""
+                self._status["last_backup_job_id"] = ""
+                self._status["last_backup_scope"] = ""
                 self._status["last_rule_id"] = ""
                 self._status["last_event_source"] = ""
                 self._status["last_event_name"] = ""
@@ -1123,6 +1239,65 @@ class SyncScheduler:
                 self._status["last_capture_job_id"] = j["id"]
                 self._status["last_capture_provider"] = j["provider"] or ""
                 self._status["last_capture_feature"] = j["feature"] or ""
+                self._status["last_backup_job_id"] = ""
+                self._status["last_backup_scope"] = ""
+                self._status["last_rule_id"] = ""
+                self._status["last_event_source"] = ""
+                self._status["last_event_name"] = ""
+
+            self._adv_last_key[j["id"]] = f"{today}@{j.get('at')}"
+        for _, j in due_backup:
+            if self._stop.is_set():
+                break
+
+            waited = 0
+            while self.is_sync_running_fn() and not self._stop.is_set():
+                if waited == 0:
+                    self._log("advanced backup: sync is busy; waiting to run due backup job(s)", level="INFO")
+                waited += 1
+                self._sleep_or_poke(2.0)
+                if self._poke.is_set():
+                    self._poke.clear()
+                    return True
+
+            payload = {
+                "source": "scheduler",
+                "scheduler_mode": "advanced_backup",
+                "backup_job_id": j["id"],
+                "backup": {
+                    "scope": j["scope"],
+                    "label_template": j.get("label_template") or "",
+                    "retention_days": int(j.get("retention_days") or 0),
+                    "max_backups": int(j.get("max_backups") or 0),
+                    "auto_delete_old": bool(j.get("auto_delete_old")),
+                    "include_snapshots": bool(j.get("include_snapshots")),
+                    "include_reports": bool(j.get("include_reports")),
+                    "include_cache": bool(j.get("include_cache")),
+                },
+            }
+
+            self._log(
+                f"advanced backup: running job {j['id']} for {j['scope']}",
+                level="INFO",
+            )
+            ok = self._run_sync(payload)
+            if not ok:
+                ok_all = False
+                self._log(f"advanced backup: job {j['id']} failed", level="ERROR")
+            else:
+                self._log(f"advanced backup: job {j['id']} ok", level="INFO")
+
+            with self._lock:
+                self._status["last_run_ok"] = ok
+                self._status["last_run_at"] = _now_ts()
+                self._status["last_error"] = "" if ok else "advanced backup job failed"
+                self._status["last_job_id"] = ""
+                self._status["last_pair_id"] = ""
+                self._status["last_capture_job_id"] = ""
+                self._status["last_capture_provider"] = ""
+                self._status["last_capture_feature"] = ""
+                self._status["last_backup_job_id"] = j["id"]
+                self._status["last_backup_scope"] = j["scope"] or ""
                 self._status["last_rule_id"] = ""
                 self._status["last_event_source"] = ""
                 self._status["last_event_name"] = ""
@@ -1143,6 +1318,8 @@ class SyncScheduler:
             self._status["last_capture_job_id"] = ""
             self._status["last_capture_provider"] = ""
             self._status["last_capture_feature"] = ""
+            self._status["last_backup_job_id"] = ""
+            self._status["last_backup_scope"] = ""
             self._status["last_rule_id"] = ""
             self._status["last_event_source"] = ""
             self._status["last_event_name"] = ""

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+
+def _patch_config_dir(monkeypatch, tmp_path: Path) -> None:
+    import services.backups as backups
+
+    monkeypatch.setattr(backups, "CONFIG", tmp_path)
+
+
+def test_config_backup_includes_master_key_and_validates(tmp_path: Path, monkeypatch) -> None:
+    _patch_config_dir(monkeypatch, tmp_path)
+    import services.backups as backups
+
+    (tmp_path / "config.json").write_text('{"plex":{"account_token":"enc:v1:test"}}\n', encoding="utf-8")
+    (tmp_path / ".cw_master_key").write_text("test-key", encoding="utf-8")
+
+    res = backups.create_backup(scope="config_only", label="unit", trigger="test")
+    validation = backups.validate_backup(res["path"])
+
+    assert validation["ok"] is True
+    manifest = validation["manifest"]
+    assert manifest["master_key_included"] is True
+    assert manifest["external_key_required"] is False
+    assert {row["path"] for row in manifest["files"]} == {"config.json", ".cw_master_key"}
+
+
+def test_restore_config_backup_creates_pre_restore_backup(tmp_path: Path, monkeypatch) -> None:
+    _patch_config_dir(monkeypatch, tmp_path)
+    import services.backups as backups
+
+    (tmp_path / "config.json").write_text('{"version":"before"}\n', encoding="utf-8")
+    (tmp_path / ".cw_master_key").write_text("test-key", encoding="utf-8")
+    res = backups.create_backup(scope="config_only", label="restore-src", trigger="test")
+
+    (tmp_path / "config.json").write_text('{"version":"after"}\n', encoding="utf-8")
+    restored = backups.restore_backup(res["path"], create_pre_restore=True)
+
+    assert restored["ok"] is True
+    assert restored["pre_restore_backup"]["path"]
+    assert json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))["version"] == "before"
+
+
+def test_validate_rejects_archive_member_outside_restore_allowlist(tmp_path: Path, monkeypatch) -> None:
+    _patch_config_dir(monkeypatch, tmp_path)
+    import services.backups as backups
+
+    target = tmp_path / "backups" / "bad.zip"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = b"not allowed"
+    manifest = {
+        "kind": backups.BACKUP_KIND,
+        "schema_version": backups.BACKUP_SCHEMA_VERSION,
+        "created_at": datetime.utcnow().isoformat(),
+        "files": [
+            {
+                "path": "api/backdoor.py",
+                "size": len(payload),
+                "sha256": "0" * 64,
+            }
+        ],
+    }
+    with zipfile.ZipFile(target, "w") as zf:
+        zf.writestr("api/backdoor.py", payload)
+        zf.writestr("manifest.json", json.dumps(manifest))
+
+    validation = backups.validate_backup("bad.zip")
+
+    assert validation["ok"] is False
+    assert any("Invalid restore target" in err for err in validation["errors"])
+
+
+def test_scheduler_backup_job_payload(monkeypatch) -> None:
+    import services.scheduling as scheduling
+    from services.scheduling import SyncScheduler
+
+    now = datetime(2026, 3, 15, 8, 5, 0)
+    monkeypatch.setattr(scheduling, "_as_now_in_tz", lambda _tz=None: now)
+    monkeypatch.setattr(scheduling, "_now_ts", lambda: int(now.timestamp()))
+
+    seen: list[dict] = []
+    config = {
+        "scheduling": {
+            "enabled": False,
+            "mode": "disabled",
+            "advanced": {
+                "enabled": True,
+                "jobs": [],
+                "capture_jobs": [],
+                "backup_jobs": [
+                    {
+                        "id": "morning-backup",
+                        "scope": "app_state",
+                        "at": "08:00",
+                        "days": [7],
+                        "label_template": "nightly-{scope}-{date}",
+                        "retention_days": 30,
+                        "max_backups": 10,
+                        "auto_delete_old": True,
+                        "include_snapshots": True,
+                        "include_reports": False,
+                        "include_cache": False,
+                        "active": True,
+                    }
+                ],
+                "event_rules": [],
+            },
+        }
+    }
+
+    scheduler = SyncScheduler(
+        load_config=lambda: config,
+        save_config=lambda next_cfg: config.update(next_cfg),
+        run_sync_fn=lambda payload=None: seen.append(payload or {}) or True,
+        is_sync_running_fn=lambda: False,
+    )
+
+    ok = scheduler._adv_run_due(config["scheduling"], None)
+
+    assert ok is True
+    assert seen == [
+        {
+            "source": "scheduler",
+            "scheduler_mode": "advanced_backup",
+            "backup_job_id": "morning-backup",
+            "backup": {
+                "scope": "app_state",
+                "label_template": "nightly-{scope}-{date}",
+                "retention_days": 30,
+                "max_backups": 10,
+                "auto_delete_old": True,
+                "include_snapshots": True,
+                "include_reports": False,
+                "include_cache": False,
+            },
+        }
+    ]
+
+    status = scheduler.status()
+    assert status["last_backup_job_id"] == "morning-backup"
+    assert status["last_backup_scope"] == "app_state"

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -105,7 +105,7 @@ def _is_https_request(request: Request) -> bool:
 
 _HELPER_SCRIPTS = (
     "provider-meta.js", "icon-select.js", "scrobbler-ui.js", "scrobbler-user-picker.js", "page-loader.js", "dom.js", "events.js", "api.js", "core.js", "details-log.js",
-    "watchlist-preview.js", "providers-ui.js", "settings-ui.js", "settings-save.js", "maintenance.js",
+    "watchlist-preview.js", "providers-ui.js", "settings-ui.js", "settings-save.js", "maintenance.js", "backups.js",
     "restart_apply.js",
 )
 _APP_SCRIPTS = (
@@ -337,8 +337,40 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
 #page-settings .cw-hub-desc{margin-top:0;font-size:12px;line-height:1.3}
 #page-settings .cw-hub-tile .chips{margin-top:14px;align-self:start}
 #page-settings .cw-hub-tile .chip{padding:6px 10px;border-radius:999px;border-color:rgba(255,255,255,.09);background:rgba(0,0,0,.24);font-size:12px}
+#page-settings .cw-maint-section{overflow:hidden}
+#page-settings .cw-maint-section>.head{display:none!important}
+#page-settings .cw-maint-section>.body{padding:18px!important}
+#page-settings .cw-maint-layout{display:grid;gap:14px}
+#page-settings .cw-maint-debug-card{display:grid;gap:14px;padding:16px;border:1px solid rgba(255,255,255,.08);border-radius:22px;background:linear-gradient(180deg,rgba(255,255,255,.045),rgba(255,255,255,.018));box-shadow:inset 0 1px 0 rgba(255,255,255,.03)}
+#page-settings .cw-maint-card-head{display:flex;align-items:center;gap:12px;min-width:0}
+#page-settings .cw-maint-card-icon{width:42px;height:42px;flex:0 0 42px;display:grid;place-items:center;border-radius:14px;border:1px solid rgba(255,255,255,.10);background:linear-gradient(180deg,rgba(125,134,201,.18),rgba(125,134,201,.08));color:#edf2ff}
+#page-settings .cw-maint-card-icon.material-symbols-rounded{font-size:22px;font-variation-settings:"FILL" 0,"wght" 600,"GRAD" 0,"opsz" 24}
+#page-settings .cw-maint-card-copy{display:grid;gap:3px;min-width:0}
+#page-settings .cw-maint-card-copy strong{font-size:15px;line-height:1.15}
+#page-settings .cw-maint-card-copy small{font-size:12px;line-height:1.35;color:var(--cw-ov-soft)!important}
+#page-settings .cw-maint-debug-field{display:grid;gap:7px}
+#page-settings .cw-maint-debug-field label{font-size:11px;font-weight:900;letter-spacing:.11em;text-transform:uppercase}
+#page-settings .cw-maint-debug-field select{height:44px;min-height:44px;border-radius:14px!important}
+#page-settings .cw-maint-actions{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
+#page-settings .cw-maint-action.btn{min-height:104px;height:auto;padding:14px!important;border-radius:18px!important;display:flex!important;align-items:flex-start!important;justify-content:flex-start!important;gap:12px!important;text-align:left!important;background:linear-gradient(180deg,rgba(255,255,255,.042),rgba(255,255,255,.018))!important;border-color:rgba(255,255,255,.09)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.03)!important;color:var(--cw-ov-fg)!important}
+#page-settings .cw-maint-action.btn:hover{background:linear-gradient(180deg,rgba(255,255,255,.065),rgba(255,255,255,.026))!important;border-color:rgba(255,255,255,.16)!important;transform:translateY(-1px)}
+#page-settings .cw-maint-action-icon{width:38px;height:38px;flex:0 0 38px;display:grid;place-items:center;border-radius:13px;border:1px solid rgba(255,255,255,.10);background:rgba(125,134,201,.12);color:#eef3ff}
+#page-settings .cw-maint-action-icon.material-symbols-rounded{font-size:21px;font-variation-settings:"FILL" 0,"wght" 600,"GRAD" 0,"opsz" 24}
+#page-settings .cw-maint-action-copy{display:grid;gap:4px;min-width:0}
+#page-settings .cw-maint-action-copy strong{font-size:14px;line-height:1.15;color:var(--cw-ov-fg)!important}
+#page-settings .cw-maint-action-copy small{font-size:12px;line-height:1.35;color:var(--cw-ov-soft)!important;font-weight:700;white-space:normal}
+#page-settings .cw-maint-action.backup .cw-maint-action-icon{background:rgba(34,197,94,.11);border-color:rgba(34,197,94,.18);color:#d9fff0}
+#page-settings .cw-maint-action.tools .cw-maint-action-icon{background:rgba(125,134,201,.14);border-color:rgba(125,134,201,.22);color:#edf2ff}
+#page-settings .cw-maint-action.restart .cw-maint-action-icon{background:rgba(255,92,112,.10);border-color:rgba(255,120,138,.22);color:#ffdce2}
+#page-settings .cw-maint-action.restart{border-color:rgba(255,120,138,.18)!important}
+html[data-cw-theme=flat-dark] #page-settings .cw-maint-debug-card,html[data-cw-theme=flat-dark] #page-settings .cw-maint-action.btn{background:#20242d!important;background-image:none!important;border-color:rgba(255,255,255,.13)!important;box-shadow:none!important}
+html[data-cw-theme=flat-dark] #page-settings .cw-maint-card-icon,html[data-cw-theme=flat-dark] #page-settings .cw-maint-action-icon{background:#171a22!important;background-image:none!important;border-color:rgba(255,255,255,.14)!important;color:#dbe1eb!important}
+html[data-cw-theme=flat-light] #page-settings .cw-maint-debug-card,html[data-cw-theme=flat-light] #page-settings .cw-maint-action.btn{background:#fff!important;background-image:none!important;border-color:rgba(21,31,48,.14)!important;box-shadow:none!important;color:#172033!important}
+html[data-cw-theme=flat-light] #page-settings .cw-maint-card-icon,html[data-cw-theme=flat-light] #page-settings .cw-maint-action-icon{background:#eef2f7!important;background-image:none!important;border-color:rgba(21,31,48,.14)!important;color:#344054!important}
+html[data-cw-theme=flat-light] #page-settings .cw-maint-action.restart .cw-maint-action-icon{background:#f7dde2!important;border-color:rgba(201,79,97,.36)!important;color:#7f1d2d!important}
 @media (max-width:900px){#page-settings .cw-settings-2col,#page-settings .cw-settings-split{grid-template-columns:1fr}}
-@media (max-width:640px){#page-settings .cw-settings-statusrow{align-items:stretch}#page-settings .cw-settings-status{min-width:0}#page-settings .cw-settings-shell .btn.primary,#page-settings .cw-settings-shell #btn-auth-logout,#page-settings .cw-settings-shell #btn-auth-logout-others,#page-settings .cw-settings-inline-action .btn{width:100%}}
+@media (max-width:900px){#page-settings .cw-maint-actions{grid-template-columns:1fr}}
+@media (max-width:640px){#page-settings .cw-settings-statusrow{align-items:stretch}#page-settings .cw-settings-status{min-width:0}#page-settings .cw-settings-shell .btn.primary,#page-settings .cw-settings-shell #btn-auth-logout,#page-settings .cw-settings-shell #btn-auth-logout-others,#page-settings .cw-settings-inline-action .btn{width:100%}#page-settings .cw-maint-section>.body{padding:14px!important}#page-settings .cw-maint-card-head{align-items:flex-start}#page-settings .cw-maint-action.btn{min-height:auto}}
 </style>
 <script>
 (() => {
@@ -1229,23 +1261,55 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
               <p>Use these actions to reset CrossWatch states. They are safe but cannot be undone.</p>
             </div>
           </div>
-          <div class="section open cw-settings-section" id="sec-troubleshoot" data-accordion="off">
+          <div class="section open cw-settings-section cw-maint-section" id="sec-troubleshoot" data-accordion="off">
             <div class="head"><span class="chev"></span><strong>Maintenance</strong></div>
             <div class="body">
-              <div>
-                <label for="debug">Debug</label>
-                <select id="debug" name="debug">
-                  <option value="off">off</option>
-                  <option value="on">on</option>
-                  <option value="mods">on - including MOD debug - best option for debug</option>
-                  <option value="full">on - full (requires restart) - use with caution</option>
-                </select>
+              <div class="cw-maint-layout">
+                <div class="cw-maint-debug-card">
+                  <div class="cw-maint-card-head">
+                    <span class="material-symbols-rounded cw-maint-card-icon" aria-hidden="true">bug_report</span>
+                    <div class="cw-maint-card-copy">
+                      <strong>Debug logging</strong>
+                      <small>Control how much detail CrossWatch writes to the live logs and diagnostics.</small>
+                    </div>
+                  </div>
+                  <div class="cw-maint-debug-field">
+                    <label for="debug">Level</label>
+                    <select id="debug" name="debug">
+                      <option value="off">off</option>
+                      <option value="on">on</option>
+                      <option value="mods">on - including MOD debug - best option for debug</option>
+                      <option value="full">on - full (requires restart) - use with caution</option>
+                    </select>
+                  </div>
+                </div>
+
+                <div class="cw-maint-actions" aria-label="Maintenance actions">
+                  <button class="btn cw-maint-action backup" type="button" onclick="openBackupRestore()">
+                    <span class="material-symbols-rounded cw-maint-action-icon" aria-hidden="true">backup</span>
+                    <span class="cw-maint-action-copy">
+                      <strong>Backup & Restore</strong>
+                      <small>Create archives, validate backups, restore state, or manage schedules.</small>
+                    </span>
+                  </button>
+                  <button class="btn cw-maint-action tools" type="button" onclick="openMaintenanceModal()">
+                    <span class="material-symbols-rounded cw-maint-action-icon" aria-hidden="true">tune</span>
+                    <span class="cw-maint-action-copy">
+                      <strong>Maintenance Tools</strong>
+                      <small>Clean local state, reset counters, and run recovery actions.</small>
+                    </span>
+                  </button>
+                  <button class="btn cw-maint-action restart" type="button" onclick="restartCrossWatch()">
+                    <span class="material-symbols-rounded cw-maint-action-icon" aria-hidden="true">restart_alt</span>
+                    <span class="cw-maint-action-copy">
+                      <strong>Restart CrossWatch</strong>
+                      <small>Restart CW contrainer.</small>
+                    </span>
+                  </button>
+                </div>
+
+                <div id="tb_msg" class="msg ok hidden">Done </div>
               </div>
-              <div class="chiprow">
-                <button class="btn danger" onclick="openMaintenanceModal()">Maintenance Tools</button>
-                <button class="btn danger" onclick="restartCrossWatch()">Restart CrossWatch</button>
-              </div>
-              <div id="tb_msg" class="msg ok hidden">Done </div>
             </div>
           </div>
         </section>
@@ -1264,7 +1328,7 @@ header .tab.active,header .cw-ui-btn.active{background:linear-gradient(180deg,rg
 </div>
 
 
-<script>(()=>{const $=id=>document.getElementById(id),closeMenu=id=>{const m=$(id==="settings"?"cw-settings-menu":"cw-about-menu"),b=$(id==="settings"?"tab-settings":"tab-about");m?.classList.add("hidden");b?.setAttribute("aria-expanded","false")},closeAll=()=>{closeMenu("settings");closeMenu("about")},toggleMenu=(id,e)=>{e?.preventDefault?.();e?.stopPropagation?.();const menuId=id==="settings"?"cw-settings-menu":"cw-about-menu",btnId=id==="settings"?"tab-settings":"tab-about",m=$(menuId),b=$(btnId);if(!m||!b)return;const open=m.classList.contains("hidden");closeAll();m.classList.toggle("hidden",!open);b.setAttribute("aria-expanded",String(open))},setHelp=open=>{const o=$("cw-help-overlay");if(!o)return;if(open){const f=$("cw-help-frame");if(f&&!f.src)f.src="https://wiki.crosswatch.app";o.classList.remove("hidden");o.setAttribute("aria-hidden","false")}else{o.classList.add("hidden");o.setAttribute("aria-hidden","true")}},openSettings=pane=>{window.showTab?.("settings");setTimeout(()=>window.cwSettingsSelect?.(pane),0)},logout=()=>{closeMenu("settings");if(typeof window.cwAppLogout==="function")return window.cwAppLogout();window.location.href="/logout"};window.APP_VERSION="__CW_VERSION__";window["__CW_"+"VERSION__"]=window.APP_VERSION;window.cwOpenHelp=()=>setHelp(true);window.cwCloseHelp=()=>setHelp(false);window.openHelp=()=>window.location?.protocol==="https:"?window.cwOpenHelp?.():window.open("https://wiki.crosswatch.app","_blank","noopener,noreferrer");window.cwCloseAboutMenu=()=>closeMenu("about");window.cwCloseSettingsMenu=()=>closeMenu("settings");window.cwToggleAboutMenu=e=>toggleMenu("about",e);window.cwToggleSettingsMenu=e=>toggleMenu("settings",e);window.cwAboutMenuSelect=w=>(closeMenu("about"),w==="about"?window.openAbout?.():w==="help"?window.openHelp?.():undefined);window.cwSettingsMenuLogout=logout;window.cwSettingsMenuSelect=w=>{closeMenu("settings");if(w==="overview")return openSettings("overview");if(w==="providers")return openSettings("providers");if(w==="scheduling")return openSettings("scheduling");if(w==="pairs")return(window.showTab?.("settings"),window.cwProvidersJump?.("sec-sync"));if(w==="scrobbler")return openSettings("scrobbler");if(w==="app")return openSettings("app");if(w==="maintenance")return window.openMaintenanceModal?.()};document.addEventListener("click",e=>{const o=$("cw-help-overlay"),c=$("cw-help-card"),aboutHost=$("tab-about-menu"),settingsHost=$("tab-settings-menu");if(o&&!o.classList.contains("hidden")&&c&&!c.contains(e.target))window.cwCloseHelp?.();if(aboutHost&&!aboutHost.contains(e.target))closeMenu("about");if(settingsHost&&!settingsHost.contains(e.target))closeMenu("settings")},true);document.addEventListener("keydown",e=>{if(e.key!=="Escape")return;window.cwCloseHelp?.();closeAll()},true)})();</script>
+<script>(()=>{const $=id=>document.getElementById(id),closeMenu=id=>{const m=$(id==="settings"?"cw-settings-menu":"cw-about-menu"),b=$(id==="settings"?"tab-settings":"tab-about");m?.classList.add("hidden");b?.setAttribute("aria-expanded","false")},closeAll=()=>{closeMenu("settings");closeMenu("about")},toggleMenu=(id,e)=>{e?.preventDefault?.();e?.stopPropagation?.();const menuId=id==="settings"?"cw-settings-menu":"cw-about-menu",btnId=id==="settings"?"tab-settings":"tab-about",m=$(menuId),b=$(btnId);if(!m||!b)return;const open=m.classList.contains("hidden");closeAll();m.classList.toggle("hidden",!open);b.setAttribute("aria-expanded",String(open))},setHelp=open=>{const o=$("cw-help-overlay");if(!o)return;if(open){const f=$("cw-help-frame");if(f&&!f.src)f.src="https://wiki.crosswatch.app";o.classList.remove("hidden");o.setAttribute("aria-hidden","false")}else{o.classList.add("hidden");o.setAttribute("aria-hidden","true")}},openSettings=pane=>{window.showTab?.("settings");setTimeout(()=>window.cwSettingsSelect?.(pane),0)},logout=()=>{closeMenu("settings");if(typeof window.cwAppLogout==="function")return window.cwAppLogout();window.location.href="/logout"};window.APP_VERSION="__CW_VERSION__";window["__CW_"+"VERSION__"]=window.APP_VERSION;window.cwOpenHelp=()=>setHelp(true);window.cwCloseHelp=()=>setHelp(false);window.openHelp=()=>window.location?.protocol==="https:"?window.cwOpenHelp?.():window.open("https://wiki.crosswatch.app","_blank","noopener,noreferrer");window.cwCloseAboutMenu=()=>closeMenu("about");window.cwCloseSettingsMenu=()=>closeMenu("settings");window.cwToggleAboutMenu=e=>toggleMenu("about",e);window.cwToggleSettingsMenu=e=>toggleMenu("settings",e);window.cwAboutMenuSelect=w=>(closeMenu("about"),w==="about"?window.openAbout?.():w==="help"?window.openHelp?.():undefined);window.cwSettingsMenuLogout=logout;window.cwSettingsMenuSelect=w=>{closeMenu("settings");if(w==="overview")return openSettings("overview");if(w==="providers")return openSettings("providers");if(w==="scheduling")return openSettings("scheduling");if(w==="pairs")return(window.showTab?.("settings"),window.cwProvidersJump?.("sec-sync"));if(w==="scrobbler")return openSettings("scrobbler");if(w==="app")return openSettings("app");if(w==="maintenance")return openSettings("maintenance")};document.addEventListener("click",e=>{const o=$("cw-help-overlay"),c=$("cw-help-card"),aboutHost=$("tab-about-menu"),settingsHost=$("tab-settings-menu");if(o&&!o.classList.contains("hidden")&&c&&!c.contains(e.target))window.cwCloseHelp?.();if(aboutHost&&!aboutHost.contains(e.target))closeMenu("about");if(settingsHost&&!settingsHost.contains(e.target))closeMenu("settings")},true);document.addEventListener("keydown",e=>{if(e.key!=="Escape")return;window.cwCloseHelp?.();closeAll()},true)})();</script>
 
 __CW_ASSET_BLOCK__
 
@@ -1300,7 +1364,7 @@ __CW_ASSET_BLOCK__
     if (key === "scheduling" || key === "automation") return window.cwSettingsSelect?.("scheduling");
     if (key === "scrobbler") return window.cwSettingsSelect?.("scrobbler");
     if (key === "app") return window.cwSettingsSelect?.("app");
-    if (key === "maintenance") return window.openMaintenanceModal?.();
+    if (key === "maintenance") return window.cwSettingsSelect?.("maintenance");
   };
 
   window.cwSettingsOverviewGo = (key) => {


### PR DESCRIPTION
# Pull request

## Change

Adds Backup & Restore support for CrossWatch, including manual backups, backup validation, restore, import, delete, retention cleanup, and scheduled background backups.


## Why

CrossWatch already created a simple upgrade backup, but there was no proper user-facing backup/restore workflow or scheduled backup support. This gives users a safer way to protect config and local state before upgrades, changes, or recovery work.

## Testing

- `test_backups.py -q`
- Smoke-tested scheduled backup execution through `SyncScheduler.start()` with a due background backup job.

## Issue

Fixes