### PR TITLE
Change: TMDb auth validation and settings feedback

### DIFF
--- a/api/authenticationAPI.py
+++ b/api/authenticationAPI.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Optional
 import copy
 
 import importlib
+import re
 import secrets
 import threading
 import time
@@ -1116,10 +1117,87 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         return {"users": users, "count": len(users), "instance": inst}
 
     # TMDB
+    TMDB_API_BASE = "https://api.themoviedb.org/3"
+
+    def _tmdb_v3_api_key_error(api_key: str) -> str:
+        key = str(api_key or "").strip()
+        if not key:
+            return "Missing api_key"
+        if key.lower().startswith("bearer "):
+            return "Paste the TMDb v3 API Key only, without a Bearer prefix."
+        if key.startswith("eyJ") or key.count(".") >= 2:
+            return "Use the TMDb API Key (v3 auth), not the API Read Access Token."
+        if not re.fullmatch(r"[0-9a-fA-F]{32}", key):
+            return "Invalid TMDb API key format. Use the 32-character API Key (v3 auth)."
+        return ""
+
+    def _tmdb_request_error(e: Exception) -> str:
+        if isinstance(e, requests.exceptions.Timeout):
+            return "TMDb request timed out"
+        if isinstance(e, requests.exceptions.HTTPError):
+            resp = getattr(e, "response", None)
+            status = int(getattr(resp, "status_code", 0) or 0)
+            msg = ""
+            try:
+                data = resp.json() if resp is not None else {}
+                if isinstance(data, dict):
+                    msg = str(data.get("status_message") or data.get("message") or "").strip()
+            except Exception:
+                msg = ""
+            low = msg.lower()
+            if status in (401, 403) or "invalid api key" in low:
+                return "Invalid TMDb API key. Use the v3 API Key, not the v4 Read Access Token."
+            if status == 429:
+                return "TMDb rate limit reached. Try again later."
+            if status >= 500:
+                return "TMDb server error. Try again later."
+            if msg:
+                return f"TMDb rejected the request: {msg}"
+            return f"TMDb rejected the request (HTTP {status})"
+        if isinstance(e, requests.exceptions.RequestException):
+            return "Could not reach TMDb. Check network/DNS from the CrossWatch container."
+        return "TMDb check failed"
+
+    def _tmdb_validate_metadata_key(api_key: str) -> tuple[bool, str]:
+        key = str(api_key or "").strip()
+        key_error = _tmdb_v3_api_key_error(key)
+        if key_error:
+            return False, key_error
+        try:
+            r = requests.get(f"{TMDB_API_BASE}/configuration", params={"api_key": key}, timeout=12)
+            r.raise_for_status()
+            data = r.json() or {}
+            if not isinstance(data, dict) or not isinstance(data.get("images"), dict):
+                return False, "TMDb returned an unexpected response"
+            return True, ""
+        except Exception as e:
+            return False, _tmdb_request_error(e)
+
+    @app.post("/api/tmdb/verify", tags=["auth"])
+    def api_tmdb_verify(payload: dict[str, Any] | None = Body(None)) -> dict[str, Any]:
+        try:
+            cfg = load_config()
+            current = str(((cfg.get("tmdb") or {}).get("api_key") or "")).strip()
+            key = str((payload or {}).get("api_key") or "").strip()
+            if _looks_masked_secret(key):
+                key = current
+            if not key:
+                key = current
+            ok, error = _tmdb_validate_metadata_key(key)
+            return {"ok": ok, "valid": ok, "error": error}
+        except Exception as e:
+            _safe_log(log_fn, "TMDB", f"[TMDB] ERROR verify: {e}")
+            return {"ok": False, "valid": False, "error": "TMDb check failed"}
+
     @app.post("/api/tmdb/save", tags=["auth"])
     def api_tmdb_save(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
         try:
             key = str((payload or {}).get("api_key") or "").strip()
+            if key:
+                ok, error = _tmdb_validate_metadata_key(key)
+                if not ok:
+                    _safe_log(log_fn, "TMDB", f"[TMDB] api_key validation failed: {error}")
+                    return {"ok": False, "error": error}
             cfg = load_config(); cfg.setdefault("tmdb", {})["api_key"] = key
             save_config(cfg)
             _safe_log(log_fn, "TMDB", "[TMDB] api_key saved")
@@ -1141,9 +1219,6 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
             _safe_log(log_fn, "TMDB", f"[TMDB] ERROR disconnect: {e}")
             return {"ok": False, "error": "internal"}
 
-    # TMDB Sync (v3 session)
-    TMDB_API_BASE = "https://api.themoviedb.org/3"
-
     def _tmdb_v3_request_token(api_key: str) -> dict[str, Any]:
         r = requests.get(f"{TMDB_API_BASE}/authentication/token/new", params={"api_key": api_key}, timeout=15)
         r.raise_for_status()
@@ -1164,15 +1239,24 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         r.raise_for_status()
         return r.json() or {}
 
+    def _tmdb_sync_error(e: Exception) -> str:
+        return _tmdb_request_error(e).replace("TMDb check failed", "TMDb connect failed")
+
+    def _tmdb_sync_key_error(api_key: str) -> str:
+        return _tmdb_v3_api_key_error(api_key)
+
     @app.post("/api/tmdb_sync/connect/start", tags=["auth"])
     def api_tmdb_sync_connect_start(payload: dict[str, Any] = Body(...), instance: str | None = Query(None)) -> dict[str, Any]:
         inst = normalize_instance_id(instance)
-        key = str((payload or {}).get("api_key") or "").strip()
-        if not key:
-            return {"ok": False, "error": "Missing api_key"}
         try:
             cfg = load_config()
             tm = ensure_instance_block(cfg, "tmdb_sync", inst)
+            key = str((payload or {}).get("api_key") or "").strip()
+            if _looks_masked_secret(key):
+                key = str((tm or {}).get("api_key") or "").strip()
+            key_error = _tmdb_sync_key_error(key)
+            if key_error:
+                return {"ok": False, "error": key_error}
             tm["api_key"] = key
 
             j = _tmdb_v3_request_token(key)
@@ -1195,8 +1279,9 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
                 "instance": inst,
             }
         except Exception as e:
-            _safe_log(log_fn, "TMDB_SYNC", f"[TMDB_SYNC] ERROR connect/start: {e}")
-            return {"ok": False, "error": "internal"}
+            err = _tmdb_sync_error(e)
+            _safe_log(log_fn, "TMDB_SYNC", f"[TMDB_SYNC] ERROR connect/start: {err}")
+            return {"ok": False, "error": err}
 
     @app.post("/api/tmdb_sync/connect/finish", tags=["auth"])
     def api_tmdb_sync_connect_finish(payload: dict[str, Any] = Body(...), instance: str | None = Query(None)) -> dict[str, Any]:
@@ -1205,6 +1290,8 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
             cfg = load_config()
             tm = ensure_instance_block(cfg, "tmdb_sync", inst)
             key = str((payload or {}).get("api_key") or tm.get("api_key") or "").strip()
+            if _looks_masked_secret(key):
+                key = str((tm or {}).get("api_key") or "").strip()
             token = str((payload or {}).get("request_token") or tm.get("_pending_request_token") or "").strip()
             if not key:
                 return {"ok": False, "error": "Missing api_key"}
@@ -1241,10 +1328,14 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
     def api_tmdb_sync_save(payload: dict[str, Any] = Body(...), instance: str | None = Query(None)) -> dict[str, Any]:
         inst = normalize_instance_id(instance)
         try:
-            key = str((payload or {}).get("api_key") or "").strip()
-            sess = str((payload or {}).get("session_id") or "").strip()
             cfg = load_config()
             tm = ensure_instance_block(cfg, "tmdb_sync", inst)
+            key = str((payload or {}).get("api_key") or "").strip()
+            sess = str((payload or {}).get("session_id") or "").strip()
+            if _looks_masked_secret(key):
+                key = str((tm or {}).get("api_key") or "").strip()
+            if _looks_masked_secret(sess):
+                sess = str((tm or {}).get("session_id") or "").strip()
             tm["api_key"] = key
             tm["session_id"] = sess
             tm.pop("_pending_request_token", None)

--- a/assets/auth/auth.tmdb.js
+++ b/assets/auth/auth.tmdb.js
@@ -12,6 +12,7 @@
   const Shared = window.CW.AuthShared;
   const el = Shared.el;
   const txt = Shared.txt;
+  const readSecretField = Shared.readSecretField;
   const note = Shared.notify;
   const profile = Shared.createProfileAdapter({
     provider: "tmdb_sync",
@@ -84,6 +85,12 @@
 
     const keyEl = el("tmdb_sync_api_key");
     const sessEl = el("tmdb_sync_session_id");
+
+    if (sessEl) {
+      sessEl.readOnly = true;
+      sessEl.setAttribute("aria-readonly", "true");
+      sessEl.setAttribute("tabindex", "-1");
+    }
     maskInput(keyEl, hasKey);
     maskInput(sessEl, hasSess);
 
@@ -165,11 +172,14 @@
   async function onConnect() {
     const keyEl = el("tmdb_sync_api_key");
     const sessEl = el("tmdb_sync_session_id");
-    const apiKey = txt(keyEl?.value);
-    const hasSess = !!txt(sessEl?.value) || sessEl?.dataset.masked === "1";
+    const keyState = readSecretField(keyEl);
+    const sessState = readSecretField(sessEl);
+    const apiKey = keyState.value;
+    const hasKey = keyState.hasValue;
+    const hasSess = sessState.hasValue;
     if (hasSess) { await refresh(false); return; }
 
-    if (!apiKey || apiKey.includes("***")) {
+    if (!hasKey) {
       setConn(false, "Enter your API key first.");
       el("tmdb_sync_hint")?.classList.remove("hidden");
       return;
@@ -179,15 +189,15 @@
       const r = await fetchJSON(tmdbApi(API.start), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ api_key: apiKey }),
+        body: JSON.stringify({ api_key: keyState.masked ? "********" : apiKey }),
       });
       if (!r.ok || (r.data && r.data.ok === false)) throw new Error(r.data?.error || "connect_failed");
       const j = r.data || {};
       if (j.auth_url) window.open(j.auth_url, "_blank", "noopener,noreferrer");
       setConn(false, "Approve in TMDb...");
       startPoll(120000);
-    } catch {
-      setConn(false, "TMDb connect failed");
+    } catch (err) {
+      setConn(false, (err && err.message) ? err.message : "TMDb connect failed");
     }
   }
 
@@ -226,20 +236,24 @@
     const sessEl = el("tmdb_sync_session_id");
 
     if (keyEl && !keyEl.__wired) {
+      Shared.wireSecretInput(keyEl, {
+        onInput(input) {
+          const has = readSecretField(input).hasValue;
+          el("tmdb_sync_hint")?.classList.toggle("hidden", has);
+        },
+      });
       keyEl.addEventListener("input", () => {
-        keyEl.dataset.touched = "1";
-        const has = (keyEl.value || "").trim().length > 0;
+        const has = readSecretField(keyEl).hasValue;
         el("tmdb_sync_hint")?.classList.toggle("hidden", has);
       });
       keyEl.addEventListener("change", () => {
-        const has = (keyEl.value || "").trim().length > 0;
+        const has = readSecretField(keyEl).hasValue;
         el("tmdb_sync_hint")?.classList.toggle("hidden", has);
       });
       keyEl.__wired = true;
     }
 
     if (sessEl && !sessEl.__wired) {
-      sessEl.addEventListener("input", () => { sessEl.dataset.touched = "1"; });
       sessEl.__wired = true;
     }
 
@@ -289,8 +303,8 @@
     const keyEl = el("tmdb_sync_api_key");
     const sessEl = el("tmdb_sync_session_id");
 
-    const key = txt(keyEl?.value || "");
-    const sess = txt(sessEl?.value || "");
+    const keyState = readSecretField(keyEl);
+    const sessState = readSecretField(sessEl);
 
     const inst = getTMDbSyncInstance();
     cfg.tmdb_sync = cfg.tmdb_sync || {};
@@ -299,8 +313,8 @@
       ? cfg.tmdb_sync
       : ((cfg.tmdb_sync.instances = cfg.tmdb_sync.instances || {}), (cfg.tmdb_sync.instances[inst] = cfg.tmdb_sync.instances[inst] || {}), cfg.tmdb_sync.instances[inst]);
 
-    if (key && !key.includes("***") && keyEl?.dataset.masked !== "1") dst.api_key = key;
-    if (sess && !sess.includes("***") && sessEl?.dataset.masked !== "1") dst.session_id = sess;
+    if (keyState.value) dst.api_key = keyState.value;
+    if (sessState.value) dst.session_id = sessState.value;
   });
 
   function boot() {

--- a/assets/helpers/settings-save.js
+++ b/assets/helpers/settings-save.js
@@ -7,7 +7,7 @@ const _cwJSONHeaders = { "Content-Type": "application/json" };
 const _cwSecretIds = [
   "plex_home_pin", "simkl_client_id", "simkl_client_secret",
   "trakt_client_id", "trakt_client_secret", "anilist_client_id", "anilist_client_secret",
-  "tmdb_api_key", "mdblist_key", "publicmetadb_key", "tautulli_key"
+  "tmdb_api_key", "tmdb_sync_api_key", "tmdb_sync_session_id", "mdblist_key", "publicmetadb_key", "tautulli_key"
 ];
 
 function _cwEl(id) { return document.getElementById(id); }
@@ -328,6 +328,30 @@ async function _cwValidateProviderSecret(provider, inst, change) {
   }
 }
 
+async function _cwValidateTmdbSecret(change) {
+  if (!change?.changed || !change?.set) return;
+  const resp = await _cwRequest("/api/tmdb/save", {
+    method: "POST",
+    headers: _cwJSONHeaders,
+    body: JSON.stringify({ api_key: change.set })
+  }, 15000);
+  const body = await _cwReadBody(resp);
+  if (!resp?.ok || body?.ok === false) {
+    _cwAbortSave(body?.error || body?.detail || `TMDb key check failed (${resp?.status || 0})`);
+  }
+  try {
+    const input = _cwEl("tmdb_api_key");
+    if (input) input.dataset.verified = "1";
+    const msg = _cwEl("tmdb_check_msg");
+    if (msg) {
+      msg.textContent = "Connected";
+      msg.classList.remove("hidden", "warn");
+      msg.classList.add("ok");
+    }
+    window.cwMetaSettingsHubUpdate?.();
+  } catch {}
+}
+
 async function _cwValidateTautulliSecret(inst, payload) {
   const server = _cwNorm(payload?.server_url);
   const apiKey = _cwNorm(payload?.api_key);
@@ -642,11 +666,14 @@ async function saveSettings() {
         trakt: _cwInstBlock(serverCfg?.trakt, _cwSelectedInst("trakt", "cw.ui.trakt.auth.instance.v1")),
         anilist: _cwInstBlock(serverCfg?.anilist, _cwSelectedInst("anilist")),
         mdblist: _cwInstBlock(serverCfg?.mdblist, _cwSelectedInst("mdblist")),
-        publicmetadb: _cwInstBlock(serverCfg?.publicmetadb, _cwSelectedInst("publicmetadb"))
+        publicmetadb: _cwInstBlock(serverCfg?.publicmetadb, _cwSelectedInst("publicmetadb")),
+        tmdb_sync: _cwInstBlock(serverCfg?.tmdb_sync, _cwSelectedInst("tmdb_sync", "cw.ui.tmdb_sync.auth.instance.v1"))
       };
       const publicmetadbInst = _cwSelectedInst("publicmetadb");
       const publicmetadbKey = _cwReadSecret("publicmetadb_key", _cwNorm(secrets.publicmetadb?.api_key));
+      const tmdbKey = _cwReadSecret("tmdb_api_key", _cwNorm(serverCfg?.tmdb?.api_key));
       await _cwValidateProviderSecret("publicmetadb", publicmetadbInst, publicmetadbKey);
+      await _cwValidateTmdbSecret(tmdbKey);
       [
         ["mdblist", _cwSelectedInst("mdblist"), [["api_key", _cwReadSecret("mdblist_key", _cwNorm(secrets.mdblist?.api_key))]]],
         ["publicmetadb", publicmetadbInst, [["api_key", publicmetadbKey]]],
@@ -654,7 +681,8 @@ async function saveSettings() {
         ["simkl", _cwSelectedInst("simkl"), [["client_id", _cwReadSecret("simkl_client_id", _cwNorm(secrets.simkl?.client_id))], ["client_secret", _cwReadSecret("simkl_client_secret", _cwNorm(secrets.simkl?.client_secret))]]],
         ["trakt", _cwSelectedInst("trakt", "cw.ui.trakt.auth.instance.v1"), [["client_id", _cwReadSecret("trakt_client_id", _cwNorm(secrets.trakt?.client_id))], ["client_secret", _cwReadSecret("trakt_client_secret", _cwNorm(secrets.trakt?.client_secret))]]],
         ["anilist", _cwSelectedInst("anilist"), [["client_id", _cwReadSecret("anilist_client_id", _cwNorm(secrets.anilist?.client_id))], ["client_secret", _cwReadSecret("anilist_client_secret", _cwNorm(secrets.anilist?.client_secret))]]],
-        ["tmdb", "default", [["api_key", _cwReadSecret("tmdb_api_key", _cwNorm(serverCfg?.tmdb?.api_key))]]]
+        ["tmdb_sync", _cwSelectedInst("tmdb_sync", "cw.ui.tmdb_sync.auth.instance.v1"), [["api_key", _cwReadSecret("tmdb_sync_api_key", _cwNorm(secrets.tmdb_sync?.api_key))], ["session_id", _cwReadSecret("tmdb_sync_session_id", _cwNorm(secrets.tmdb_sync?.session_id))]]],
+        ["tmdb", "default", [["api_key", tmdbKey]]]
       ].forEach(([rootKey, inst, fields]) => {
         const changes = fields.filter(([, ch]) => ch?.changed);
         if (!changes.length) return;

--- a/assets/helpers/settings-ui.js
+++ b/assets/helpers/settings-ui.js
@@ -1033,7 +1033,32 @@ function cwBuildTmdbPanel() {
   apiField.innerHTML = `<div class="muted" style="margin-bottom:6px;">API key</div>`;
   apiField.appendChild(keyInput);
 
+  const checkRow = document.createElement("div");
+  checkRow.className = "inline";
+  checkRow.style.display = "flex";
+  checkRow.style.marginTop = "10px";
+  checkRow.style.gap = "10px";
+  checkRow.style.alignItems = "center";
+  checkRow.style.justifyContent = "space-between";
+  checkRow.innerHTML = `
+    <button type="button" class="btn secondary" id="tmdb_check">Check</button>
+    <div id="tmdb_check_msg" class="msg ok hidden" aria-live="polite" style="margin-left:auto;width:auto;max-width:min(520px,60%);flex:0 1 auto;white-space:normal"></div>
+  `;
+  checkRow.querySelector("#tmdb_check")?.addEventListener("click", () => {
+    try { cwVerifyTmdbKey(); } catch {}
+  });
+  keyInput.addEventListener("input", () => {
+    keyInput.dataset.verified = "";
+    const msg = document.getElementById("tmdb_check_msg");
+    if (msg) {
+      msg.textContent = "";
+      msg.classList.add("hidden");
+    }
+    try { cwMetaSettingsHubUpdate(); } catch {}
+  });
+
   apiFields.appendChild(apiField);
+  apiFields.appendChild(checkRow);
   apiCard.appendChild(hint);
   apiCard.appendChild(apiFields);
 
@@ -1153,14 +1178,17 @@ function cwMetaSettingsHubUpdate() {
   }
 
   const hasKeyNow = uiHasKey || (!uiTouched && cfgHasKey);
-  if (chip) chip.textContent = `API key: ${hasKeyNow ? "set" : "missing"}`;
+  const verifyState = keyEl?.dataset?.verified || "";
+  const verified = hasKeyNow && verifyState === "1";
+  const failed = hasKeyNow && verifyState === "0";
+  if (chip) chip.textContent = `API key: ${verified ? "verified" : failed ? "check failed" : hasKeyNow ? "set" : "missing"}`;
 
   const dot = document.getElementById("meta-tmdb-dot");
   if (dot) {
-    dot.classList.toggle("on", hasKeyNow);
-    dot.title = hasKeyNow ? "Configured" : "Not configured";
+    dot.classList.toggle("on", hasKeyNow && !failed);
+    dot.title = verified ? "Verified" : failed ? "TMDb key check failed" : hasKeyNow ? "Configured; click Check to validate" : "Not configured";
     dot.setAttribute("aria-label", dot.title);
-    dot.closest?.('.cw-meta-provider-panel[data-provider="tmdb"]')?.classList?.toggle("is-configured", hasKeyNow);
+    dot.closest?.('.cw-meta-provider-panel[data-provider="tmdb"]')?.classList?.toggle("is-configured", hasKeyNow && !failed);
   }
 
   try { window.syncMetadataProviderDot?.(); } catch {}
@@ -1662,6 +1690,58 @@ async function updateTmdbHint() {
     hint.classList.toggle("hidden", has);
   } catch {
     hint.classList.remove("hidden");
+  }
+}
+
+function cwReadTmdbKeyForVerify() {
+  const input = document.getElementById("tmdb_api_key");
+  const value = String(input?.value || "").trim();
+  const masked = !!value && (input?.dataset?.masked === "1" || value === "********" || /^[*•]+$/.test(value));
+  if (masked) return { has: true, value: "********" };
+  return { has: !!value, value };
+}
+
+function cwSetTmdbCheckMessage(ok, text) {
+  const msg = document.getElementById("tmdb_check_msg");
+  if (!msg) return;
+  msg.textContent = String(text || "");
+  msg.classList.toggle("hidden", !msg.textContent);
+  msg.classList.toggle("warn", !!msg.textContent && !ok);
+  msg.classList.toggle("ok", !!msg.textContent && !!ok);
+}
+
+async function cwVerifyTmdbKey() {
+  const input = document.getElementById("tmdb_api_key");
+  const btn = document.getElementById("tmdb_check");
+  const state = cwReadTmdbKeyForVerify();
+  if (!state.has) {
+    if (input) input.dataset.verified = "0";
+    cwSetTmdbCheckMessage(false, "Missing API key");
+    try { cwMetaSettingsHubUpdate(); } catch {}
+    return false;
+  }
+  try {
+    if (btn) btn.disabled = true;
+    cwSetTmdbCheckMessage(true, "Checking...");
+    const r = await fetch("/api/tmdb/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      cache: "no-store",
+      body: JSON.stringify({ api_key: state.value }),
+    });
+    const data = await r.json().catch(() => ({}));
+    const ok = !!(r.ok && data && data.valid !== false && data.ok !== false);
+    if (input) input.dataset.verified = ok ? "1" : "0";
+    cwSetTmdbCheckMessage(ok, ok ? "Connected" : (data?.error || "TMDb key check failed."));
+    try { cwMetaSettingsHubUpdate(); } catch {}
+    return ok;
+  } catch {
+    if (input) input.dataset.verified = "0";
+    cwSetTmdbCheckMessage(false, "TMDb key check failed.");
+    try { cwMetaSettingsHubUpdate(); } catch {}
+    return false;
+  } finally {
+    if (btn) btn.disabled = false;
   }
 }
 

--- a/providers/auth/_auth_TMDB.py
+++ b/providers/auth/_auth_TMDB.py
@@ -43,14 +43,15 @@ class TMDbAuth(AuthProvider):
                     "label": "API Key (v3)",
                     "type": "password",
                     "required": True,
-                    "placeholder": "********",
+                    "placeholder": "Enter TMDb API key",
                 },
                 {
                     "key": "tmdb_sync.session_id",
                     "label": "Session ID (v3)",
                     "type": "password",
-                    "required": True,
-                    "placeholder": "session_id",
+                    "required": False,
+                    "readonly": True,
+                    "placeholder": "Created after approval",
                 },
             ],
             actions={"start": False, "finish": False, "refresh": True, "disconnect": True},
@@ -178,7 +179,7 @@ def _tmdb_sync_html() -> str:
                 <div class="grid2">
                   <div>
                     <label for="tmdb_sync_api_key">API Key (v3)</label>
-                    <input id="tmdb_sync_api_key" name="tmdb_sync_api_key" type="password" autocomplete="off" placeholder="********" />
+                    <input id="tmdb_sync_api_key" name="tmdb_sync_api_key" type="password" autocomplete="new-password" placeholder="Enter TMDb API key" spellcheck="false" autocapitalize="off" />
                     <div id="tmdb_sync_hint" class="msg warn" style="margin-top:8px">
                       You need an TMDb API key. Create one at
                       <a href="https://www.themoviedb.org/settings/api" target="_blank" rel="noopener">TMDb Preferences</a>
@@ -188,8 +189,8 @@ def _tmdb_sync_html() -> str:
             
                   <div>
                     <label for="tmdb_sync_session_id">Session ID (v3)</label>
-                    <input id="tmdb_sync_session_id" name="tmdb_sync_session_id" type="password" autocomplete="off" placeholder="Auto-filled after approval" />
-                    <div class="muted">Required for account watchlists/ratings.</div>
+                    <input id="tmdb_sync_session_id" name="tmdb_sync_session_id" type="password" autocomplete="off" placeholder="Created after approval" readonly aria-readonly="true" tabindex="-1" />
+                    <div class="muted">Created automatically after TMDb approval.</div>
                   </div>
                 </div>
             


### PR DESCRIPTION
# Pull request

## Change

- Improved TMDb Sync auth handling:
  - save **tmdb_sync** API/session secrets through settings save
  - handle masked saved keys correctly
  - reject v4 read tokens and invalid v3 key formats before calling TMDb
  - show useful TMDb/network errors instead of generic `internal`
  - make Session ID read-only because it is created after TMDb approval
  -
- Added TMDb metadata API key validation:
  - added `/api/tmdb/verify`
  - validate metadata API keys before saving
  - added a Check button in metadata settings
  - show a right-aligned **Connected** status pill next to Check
  - update metadata chip/dot state for verified or failed checks

## Why

TMDb Sync could appear to have an API key while the backend still saw an empty or masked value, and failures were shown as unclear messages. TMDb metadata also only checked whether a key was present, not whether it actually worked.
These changes make both TMDb flows better for users.

## Testing

- test_config_api.py
- manual validation

## Issue

NA