### PR TITLE
Add:  multi-provider playback progress management

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -27,6 +27,7 @@ from .wallAPI import register_wall
 from .versionAPI import router as version_router
 from .editorAPI import router as editor_router
 from .providerInstancesAPI import router as provider_instances_router
+from .playbackProgressAPI import router as playback_progress_router
 from .syncAPI import (
     router as sync_router,
     _is_sync_running,
@@ -57,6 +58,7 @@ __all__ = [
     "export_router",
     "editor_router",
     "provider_instances_router",
+    "playback_progress_router",
     "register_probes",
     "register_insights",
     "register_wall",
@@ -94,6 +96,7 @@ def register(
     app.include_router(export_router)
     app.include_router(editor_router)
     app.include_router(provider_instances_router)
+    app.include_router(playback_progress_router)
 
     register_probes(app, load_config)
     register_insights(app)

--- a/api/playbackProgressAPI.py
+++ b/api/playbackProgressAPI.py
@@ -1,0 +1,89 @@
+# /api/playbackProgressAPI.py
+# CrossWatch - Local Playback Progress API
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Body, Query
+from fastapi.responses import JSONResponse
+
+from services.playback_progress import get_service
+from services.playback_progress.models import utc_now_iso
+
+router = APIRouter(prefix="/api/playback_progress", tags=["playback_progress"])
+
+
+@router.get("/providers")
+def api_playback_progress_providers() -> dict[str, Any]:
+    service = get_service()
+    return {
+        "providers": [cap.to_dict() for cap in service.capabilities()],
+        "refreshed_at": utc_now_iso(),
+    }
+
+
+@router.get("/settings")
+def api_playback_progress_settings() -> dict[str, Any]:
+    return get_service().settings()
+
+
+@router.post("/settings")
+def api_playback_progress_save_settings(payload: dict[str, Any] = Body(...)) -> JSONResponse:
+    result = get_service().save_settings(payload)
+    return JSONResponse(result, status_code=200 if result.get("ok") else 400)
+
+
+@router.get("/items")
+def api_playback_progress_items(
+    provider: str | None = Query(None),
+    instance_id: str | None = Query(None),
+    media_type: str | None = Query(None),
+    progress_min: float | None = Query(None, ge=0, le=100),
+    progress_max: float | None = Query(None, ge=0, le=100),
+    age: str | None = Query(None),
+    rating_min: float | None = Query(None, ge=0, le=10),
+    search: str | None = Query(None),
+    sort: str = Query("last_updated"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=250),
+    force_refresh: bool = Query(False),
+) -> dict[str, Any]:
+    service = get_service()
+    return service.items(
+        provider=provider,
+        instance_id=instance_id,
+        media_type=media_type,
+        progress_min=progress_min,
+        progress_max=progress_max,
+        age=age,
+        rating_min=rating_min,
+        search=search,
+        sort=sort,
+        page=page,
+        page_size=page_size,
+        force_refresh=force_refresh,
+    )
+
+
+@router.post("/actions/remove")
+def api_playback_progress_remove(payload: dict[str, Any] = Body(...)) -> JSONResponse:
+    result = get_service().remove(payload)
+    return JSONResponse(result, status_code=200 if result.get("ok") else 400)
+
+
+@router.post("/actions/mark_watched")
+def api_playback_progress_mark_watched(payload: dict[str, Any] = Body(...)) -> JSONResponse:
+    result = get_service().mark_watched(payload)
+    return JSONResponse(result, status_code=200 if result.get("ok") else 400)
+
+
+@router.post("/actions/update_progress")
+def api_playback_progress_update_progress(payload: dict[str, Any] = Body(...)) -> JSONResponse:
+    result = get_service().update_progress(payload)
+    return JSONResponse(result, status_code=200 if result.get("ok") else 400)
+
+
+@router.post("/actions/bulk")
+def api_playback_progress_bulk(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
+    return get_service().bulk(payload)

--- a/assets/crosswatch.css
+++ b/assets/crosswatch.css
@@ -874,6 +874,8 @@ to{left:6px}
 #ux-lanes .chip.more:hover,#ux-spotlight .chip.more:hover,.ux-spots-modal .chip.more:hover{background:rgba(255,255,255,.06)}
 .ux-spots-modal{position:fixed;inset:0;z-index:9999}
 .ux-spots-modal.hidden{display:none}
+.cw-page-loading,.cw-page-load-error{margin:18px;padding:18px;border:1px solid rgba(255,255,255,.10);border-radius:18px;background:linear-gradient(180deg,rgba(255,255,255,.045),rgba(255,255,255,.018));color:rgba(236,242,250,.82);font-weight:750}
+.cw-page-load-error{color:#ffd9df;border-color:rgba(255,110,135,.22);background:linear-gradient(180deg,rgba(124,30,50,.20),rgba(88,18,34,.12))}
 .ux-spots-backdrop{position:absolute;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(2px)}
 .ux-title{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .ux-date{margin-left:auto;font-size:10px;opacity:.7;white-space:nowrap}

--- a/assets/crosswatch.js
+++ b/assets/crosswatch.js
@@ -13,13 +13,13 @@
   // Tabs
   function showTab(id) {
     try {
-      D.querySelectorAll("#page-main, #page-watchlist, #page-settings, .tab-page")
+      D.querySelectorAll("#page-main, #page-watchlist, #page-playback_progress, #page-settings, .tab-page")
         .forEach(el => el.classList.add("hidden"));
 
       const tgt = D.getElementById("page-" + id) || D.getElementById(id);
       if (tgt) tgt.classList.remove("hidden");
 
-      ["main", "watchlist", "settings"].forEach(n => {
+      ["main", "watchlist", "playback_progress", "snapshots", "editor", "settings"].forEach(n => {
         const th = D.getElementById("tab-" + n);
         if (th) th.classList.toggle("active", n === id);
       });
@@ -29,6 +29,26 @@
 
       if (id === "watchlist") {
         try { window.Watchlist?.mount?.(D.getElementById("page-watchlist")); } catch {}
+      }
+      if (id === "playback_progress") {
+        (async () => {
+          try {
+            if (!window.PlaybackProgress?.mount && window.CW?.PageLoader?.ensure) {
+              await window.CW.PageLoader.ensure({
+                key: "playback_progress",
+                src: "/assets/js/playback_progress.js",
+                namespace: "PlaybackProgress",
+              });
+            }
+            window.PlaybackProgress?.mount?.(D.getElementById("page-playback_progress"));
+          } catch (e) {
+            console.warn("[crosswatch] Playback Progress failed to load", e);
+            const root = D.getElementById("playback-progress-root");
+            if (root && (!root.children.length || root.querySelector(".cw-page-loading"))) {
+              root.innerHTML = '<div class="cw-page-load-error">Playback Progress failed to load. Refresh the page and try again.</div>';
+            }
+          }
+        })();
       }
     } catch (e) {
       console.warn("[crosswatch] showTab failed", e);

--- a/assets/helpers/core.js
+++ b/assets/helpers/core.js
@@ -837,7 +837,7 @@
   }
 
   function setTabHeaderState(tab) {
-    ["main", "watchlist", "snapshots", "editor", "settings"].forEach((name) => {
+    ["main", "watchlist", "playback_progress", "snapshots", "editor", "settings"].forEach((name) => {
       byId(`tab-${name}`)?.classList.toggle("active", name === tab);
     });
   }
@@ -848,6 +848,7 @@
     if (tab !== "main") byId("placeholder-card")?.classList.add("hidden");
 
     byId("page-watchlist")?.classList.toggle("hidden", tab !== "watchlist");
+    byId("page-playback_progress")?.classList.toggle("hidden", tab !== "playback_progress");
     byId("page-snapshots")?.classList.toggle("hidden", tab !== "snapshots");
     byId("page-editor")?.classList.toggle("hidden", tab !== "editor");
     byId("page-settings")?.classList.toggle("hidden", tab !== "settings");
@@ -914,6 +915,21 @@
         console.warn("Watchlist load/refresh failed:", e);
       }
       state.currentTab = "watchlist";
+      return;
+    }
+
+    if (tab === "playback_progress") {
+      try {
+        await ensurePageModule("playback_progress", "/assets/js/playback_progress.js", "PlaybackProgress");
+        window.PlaybackProgress?.mount?.(byId("page-playback_progress"));
+      } catch (e) {
+        console.warn("Playback Progress load/refresh failed:", e);
+        const root = byId("playback-progress-root");
+        if (root && (!root.children.length || root.querySelector(".cw-page-loading"))) {
+          root.innerHTML = '<div class="cw-page-load-error">Playback Progress failed to load. Refresh the page and try again.</div>';
+        }
+      }
+      state.currentTab = "playback_progress";
       return;
     }
 

--- a/assets/js/playback_progress.js
+++ b/assets/js/playback_progress.js
@@ -1,0 +1,586 @@
+/* Playback Progress page */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const ROOT_ID = "playback-progress-root";
+  const STYLE_ID = "playback-progress-style";
+  const esc = (s) => String(s ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+  const api = async (url, opts = {}) => {
+    const r = await fetch(url, { credentials: "same-origin", cache: "no-store", ...opts });
+    const txt = await r.text();
+    let data = {};
+    try { data = txt ? JSON.parse(txt) : {}; } catch {}
+    if (!r.ok) data.ok = false;
+    return data;
+  };
+  const icon = (name) => `<span class="material-symbols-rounded" aria-hidden="true">${name}</span>`;
+  const providerIcon = (provider) => {
+    const p = String(provider || "").toUpperCase();
+    return `<img src="/assets/img/${esc(p)}-log.svg" alt="" onerror="this.remove()">`;
+  };
+  const state = {
+    mounted: false,
+    page: 1,
+    pageSize: 30,
+    total: 0,
+    items: [],
+    providers: [],
+    errors: [],
+    selected: new Map(),
+    filters: { provider: "", media_type: "", progress: "", age: "", rating: "", search: "", sort: "last_updated" },
+    busy: false,
+    settings: null
+  };
+
+  function ensureStyle() {
+    if (document.getElementById(STYLE_ID)) return;
+    const css = `
+#page-playback_progress{max-width:none;width:100%;grid-column:1/-1;padding:0;background:transparent!important;border:0!important;box-shadow:none!important}
+#${ROOT_ID}{--pp-shell-bg:linear-gradient(180deg,rgba(8,10,15,.985),rgba(2,3,7,.975));--pp-panel-bg:linear-gradient(180deg,rgba(12,14,20,.95),rgba(4,5,10,.945));--pp-panel-bg-strong:linear-gradient(180deg,rgba(9,11,17,.985),rgba(2,3,7,.975));--pp-input-bg:rgba(7,11,19,.78);--pp-border:rgba(255,255,255,.09);--pp-border-soft:rgba(255,255,255,.055);--pp-soft:rgba(201,210,228,.72);--pp-fg:rgba(244,247,255,.96);--pp-shadow:0 20px 54px rgba(0,0,0,.42),inset 0 1px 0 rgba(255,255,255,.04);--pp-danger-bg:linear-gradient(180deg,rgba(118,28,46,.30),rgba(82,14,28,.24));--pp-danger-border:rgba(255,138,160,.15);--pp-danger-fg:#ffe7ee;display:grid;gap:14px;color:var(--pp-fg)}
+.pp-head,.pp-status,.pp-toolbar,.pp-card,.pp-errors,.pp-bulk,.pp-pager{border:1px solid var(--pp-border);background:var(--pp-panel-bg);box-shadow:var(--pp-shadow);border-radius:18px;color:var(--pp-fg)}
+.pp-head{padding:18px 20px;display:flex;align-items:flex-start;justify-content:space-between;gap:16px;background:radial-gradient(115% 120% at 0% 0%,rgba(78,68,170,.10),transparent 46%),radial-gradient(88% 100% at 100% 100%,rgba(34,46,108,.06),transparent 54%),var(--pp-shell-bg);border-radius:20px}.pp-title{font-size:24px;font-weight:850;line-height:1.1}.pp-intro{margin-top:6px;color:var(--pp-soft);max-width:78ch;font-size:13px;line-height:1.45}.pp-head-actions{display:flex;gap:8px;align-items:center}.pp-btn{display:inline-flex;align-items:center;justify-content:center;gap:7px;min-height:36px;padding:0 12px;border-radius:12px;border:1px solid var(--pp-border);background:var(--pp-panel-bg);color:var(--pp-fg);font-weight:750;cursor:pointer;box-shadow:none}.pp-btn:hover{border-color:var(--pp-border);background:var(--pp-panel-bg-strong)}.pp-btn[disabled]{opacity:.45;cursor:not-allowed}.pp-btn.danger{color:var(--pp-danger-fg);border-color:var(--pp-danger-border);background:var(--pp-danger-bg)}.pp-icon-btn{width:38px;padding:0}.pp-status{padding:12px;display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px}.pp-provider{display:flex;align-items:center;gap:10px;min-width:0;padding:10px;border-radius:12px;background:var(--pp-panel-bg-strong);border:1px solid var(--pp-border-soft)}.pp-provider img{width:34px;max-height:18px;object-fit:contain}.pp-provider-main{min-width:0}.pp-provider-name{font-weight:800;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.pp-provider-sub{margin-top:2px;color:var(--pp-soft);font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.pp-dot{width:9px;height:9px;border-radius:50%;background:#8b93a7;margin-left:auto;flex:0 0 auto}.pp-dot.ok{background:#42d392}.pp-dot.warn{background:#f3ba5f}.pp-toolbar{padding:12px;display:grid;grid-template-columns:minmax(220px,1.4fr) repeat(6,minmax(120px,1fr));gap:10px}.pp-field{min-width:0;height:38px;border-radius:12px;border:1px solid var(--pp-border);background:var(--pp-input-bg);color:var(--pp-fg);padding:0 11px}.pp-field option{background:#0d111a;color:#f7f9ff}.pp-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}.pp-card{position:relative;overflow:hidden;display:grid;grid-template-columns:112px minmax(0,1fr);min-height:190px;background:var(--pp-panel-bg-strong)}.pp-art{position:relative;background:#10131b}.pp-art img{width:100%;height:100%;object-fit:cover;display:block}.pp-check{position:absolute;left:8px;top:8px;z-index:2;width:24px;height:24px;accent-color:#79a7ff}.pp-body{padding:14px;display:grid;gap:10px;align-content:space-between;min-width:0}.pp-top{display:grid;gap:6px;min-width:0}.pp-badges{display:flex;gap:7px;align-items:center;flex-wrap:wrap}.pp-badge{display:inline-flex;align-items:center;gap:6px;min-height:24px;padding:0 8px;border-radius:999px;border:1px solid var(--pp-border-soft);background:var(--pp-panel-bg);font-size:11px;font-weight:800;color:var(--pp-soft)}.pp-badge img{max-width:46px;max-height:14px}.pp-card-title{font-size:17px;font-weight:850;line-height:1.15;min-width:0;color:var(--pp-fg)}.pp-card-sub{color:var(--pp-soft);font-size:13px;line-height:1.35;min-width:0}.pp-meta{display:flex;gap:8px;flex-wrap:wrap;color:var(--pp-soft);font-size:12px}.pp-progress{display:grid;gap:5px}.pp-progress-row{display:flex;justify-content:space-between;gap:10px;color:var(--pp-soft);font-size:12px}.pp-bar{height:8px;border-radius:999px;background:rgba(255,255,255,.08);overflow:hidden}.pp-bar span{display:block;height:100%;border-radius:inherit;background:linear-gradient(90deg,#5fb6ff,#7ee2b8);width:0}.pp-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap}.pp-errors{padding:12px;color:var(--pp-danger-fg);font-size:13px;background:var(--pp-panel-bg)}.pp-pager{display:flex;align-items:center;justify-content:center;gap:10px;padding:10px;color:var(--pp-soft)}.pp-empty{grid-column:1/-1;padding:28px;text-align:center;color:var(--pp-soft);border:1px dashed var(--pp-border);border-radius:18px}.pp-bulk{position:sticky;bottom:12px;z-index:20;padding:10px 12px;display:flex;align-items:center;justify-content:space-between;gap:12px}.pp-bulk.hidden{display:none!important}.pp-bulk-left,.pp-bulk-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap}.pp-toast{position:fixed;left:50%;bottom:20px;z-index:9999;transform:translateX(-50%);padding:10px 14px;border-radius:14px;border:1px solid var(--pp-border);background:var(--pp-panel-bg-strong);color:var(--pp-fg);box-shadow:var(--pp-shadow)}.pp-toast.hidden{display:none}
+html[data-cw-theme=flat-dark] #${ROOT_ID}{--pp-shell-bg:#171a22;--pp-panel-bg:#171a22;--pp-panel-bg-strong:#20242d;--pp-input-bg:#12151c;--pp-border:rgba(255,255,255,.13);--pp-border-soft:rgba(255,255,255,.10);--pp-soft:#a9b0bd;--pp-fg:#eef1f6;--pp-shadow:none;--pp-danger-bg:#43272e;--pp-danger-border:rgba(216,102,114,.42);--pp-danger-fg:#ffe3e7}
+html[data-cw-theme=flat-light] #${ROOT_ID}{--pp-shell-bg:#ffffff;--pp-panel-bg:#ffffff;--pp-panel-bg-strong:#f5f7fb;--pp-input-bg:#ffffff;--pp-border:rgba(16,24,40,.16);--pp-border-soft:rgba(16,24,40,.11);--pp-soft:#475467;--pp-fg:#111827;--pp-shadow:none;--pp-danger-bg:#f7dbe1;--pp-danger-border:rgba(169,63,77,.34);--pp-danger-fg:#7f1d2d}
+html[data-cw-theme=flat-dark] .pp-head,html[data-cw-theme=flat-light] .pp-head{background:var(--pp-panel-bg)!important;background-image:none!important}
+html[data-cw-theme=flat-light] .pp-field option{background:#ffffff;color:#111827}.cw-compact #page-playback_progress{display:block!important}.cw-compact #${ROOT_ID}{padding:10px}.cw-compact .pp-toolbar{grid-template-columns:1fr 1fr}.cw-compact .pp-head{display:grid}.cw-compact .pp-grid{grid-template-columns:1fr}.cw-compact .pp-card{grid-template-columns:92px minmax(0,1fr)}.cw-compact .pp-card-title{font-size:15px}
+@media(max-width:980px){.pp-toolbar{grid-template-columns:1fr 1fr}.pp-grid{grid-template-columns:1fr}}@media(max-width:640px){.pp-toolbar{grid-template-columns:1fr}.pp-card{grid-template-columns:88px minmax(0,1fr)}.pp-head-actions{justify-content:flex-start}.pp-bulk{display:grid}.pp-bulk-left,.pp-bulk-actions{justify-content:center}}
+.pp-toolbar{display:flex;align-items:center;gap:10px}.pp-toolbar #pp-search{flex:0 1 320px;min-width:180px}.pp-toolbar .pp-field:not(#pp-search),.pp-toolbar .cw-icon-select{flex:1 1 180px;min-width:170px}.pp-toolbar .cw-icon-select-btn{min-height:38px;border-radius:12px}.pp-toolbar .cw-icon-select-menu{min-width:185px}.pp-grid{align-items:start}.pp-card{grid-template-columns:96px minmax(0,1fr);height:144px;min-height:0;cursor:pointer;border-radius:16px;transition:border-color .16s ease,background .16s ease,transform .16s ease;isolation:isolate}.pp-card:hover{border-color:rgba(126,226,184,.28);transform:translateY(-1px)}.pp-card.selected{border-color:rgba(126,226,184,.68);box-shadow:0 0 0 1px rgba(126,226,184,.28),var(--pp-shadow)}.pp-card.selected:after{content:"";position:absolute;left:10px;top:10px;width:24px;height:24px;border-radius:7px;background:#7ee2b8;box-shadow:0 6px 16px rgba(0,0,0,.28)}.pp-card.selected:before{content:"check";position:absolute;left:10px;top:10px;z-index:2;width:24px;height:24px;display:grid;place-items:center;font-family:"Material Symbols Rounded";font-size:18px;color:#061015}.pp-check{display:none!important}.pp-art{z-index:1}.pp-art:after{content:"";position:absolute;inset:0;pointer-events:none;background:linear-gradient(90deg,rgba(3,5,10,.03),rgba(3,5,10,.16))}.pp-body{position:relative;overflow:hidden;padding:9px 14px;gap:6px}.pp-body:before{content:"";position:absolute;inset:0;z-index:0;pointer-events:none;background:linear-gradient(90deg,rgba(32,36,45,.96),rgba(32,36,45,.86) 54%,rgba(32,36,45,.92)),var(--pp-backdrop,none);background-size:cover;background-position:center;opacity:.48}.pp-body>*{position:relative;z-index:1}.pp-top{gap:4px}.pp-card-head{display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:start;gap:12px;min-width:0}.pp-title-wrap{min-width:0}.pp-card-side{display:grid;gap:6px;justify-items:end;align-content:start}.pp-provider-stack{display:flex;align-items:center;justify-content:flex-end;gap:6px;flex-wrap:wrap;min-width:0}.pp-provider-pill{display:inline-flex;align-items:center;gap:6px;min-height:23px;padding:0 8px;border-radius:999px;border:1px solid var(--pp-border-soft);background:var(--pp-panel-bg);color:var(--pp-soft);font-size:11px;font-weight:850;white-space:nowrap;overflow:visible}.pp-provider-pill img{width:16px;height:16px;max-width:none;max-height:none;object-fit:contain;flex:0 0 16px}.pp-badges,.pp-kind{display:none}.pp-card-title{font-size:18px}.pp-card-sub{font-size:13px}.pp-progress{gap:5px}.pp-progress-row{align-items:center;font-size:13px;flex-wrap:wrap}.pp-progress-row strong{font-size:14px;color:var(--pp-fg)}.pp-timing{display:inline-flex;align-items:center;justify-content:flex-end;gap:12px;margin-left:auto;color:var(--pp-soft);white-space:nowrap}.pp-paused{color:var(--pp-soft);white-space:nowrap}.pp-meta{display:none}.pp-actions{justify-content:flex-end;gap:6px;align-self:end}.pp-actions .pp-btn{min-height:32px;border-radius:12px}.pp-action-btn{min-height:28px!important;padding:0 9px;border-radius:999px!important;background:rgba(255,255,255,.035)!important;border-color:rgba(255,255,255,.08)!important;color:rgba(230,236,248,.74)!important;font-size:12px;font-weight:780;gap:5px;box-shadow:none;opacity:.82}.pp-action-btn .material-symbols-rounded{font-size:19px}.pp-action-btn:hover{opacity:1;color:var(--pp-fg)!important;background:rgba(255,255,255,.07)!important;border-color:rgba(255,255,255,.15)!important}.pp-action-watch .material-symbols-rounded{color:#9de4d0}.pp-action-edit .material-symbols-rounded{color:#9cc7ff}.pp-action-remove{color:rgba(255,214,222,.70)!important;background:rgba(149,48,67,.08)!important;border-color:rgba(255,138,160,.12)!important}.pp-action-remove .material-symbols-rounded{color:#ff9aaa}.pp-action-remove:hover{color:#ffe8ee!important;background:rgba(149,48,67,.16)!important;border-color:rgba(255,138,160,.24)!important}.pp-modal{position:fixed;inset:0;z-index:9998;display:grid;place-items:center;background:rgba(0,0,0,.48);backdrop-filter:blur(4px)}.pp-modal.hidden{display:none!important}.pp-dialog{width:min(420px,calc(100vw - 28px));padding:16px;border-radius:16px;border:1px solid var(--pp-border);background:var(--pp-panel-bg-strong);box-shadow:var(--pp-shadow);display:grid;gap:14px}.pp-dialog-title{font-size:18px;font-weight:850}.pp-dialog-sub{color:var(--pp-soft);font-size:12px}.pp-progress-edit{display:grid;grid-template-columns:1fr 84px;gap:10px;align-items:center}.pp-progress-edit input[type=range]{width:100%;accent-color:#7ee2b8}.pp-progress-edit input[type=number]{height:38px;border-radius:10px;border:1px solid var(--pp-border);background:var(--pp-input-bg);color:var(--pp-fg);padding:0 10px;font-weight:800}.pp-dialog-error{min-height:18px;color:var(--pp-danger-fg);font-size:12px}.pp-dialog-actions{display:flex;justify-content:flex-end;gap:8px}.cw-compact .pp-card{grid-template-columns:90px minmax(0,1fr);height:136px;min-height:0}html[data-cw-theme=flat-dark] .pp-body:before{background:linear-gradient(90deg,rgba(32,36,45,.97),rgba(32,36,45,.88) 54%,rgba(32,36,45,.94)),var(--pp-backdrop,none);opacity:.46}html[data-cw-theme=flat-light] .pp-body:before{background:linear-gradient(90deg,rgba(245,247,251,.96),rgba(245,247,251,.84) 54%,rgba(245,247,251,.92)),var(--pp-backdrop,none);opacity:.42}html[data-cw-theme=flat-light] .pp-art:after{background:linear-gradient(90deg,rgba(255,255,255,.02),rgba(255,255,255,.14))}html[data-cw-theme=flat-light] .pp-action-btn{background:rgba(17,24,39,.035)!important;border-color:rgba(17,24,39,.12)!important;color:rgba(17,24,39,.68)!important}html[data-cw-theme=flat-light] .pp-action-btn:hover{background:rgba(17,24,39,.075)!important;border-color:rgba(17,24,39,.18)!important;color:#111827!important}html[data-cw-theme=flat-light] .pp-action-remove{background:rgba(169,63,77,.08)!important;border-color:rgba(169,63,77,.16)!important;color:#8f2738!important}html[data-cw-theme=flat-dark] .pp-art:after{background:linear-gradient(90deg,rgba(7,10,16,.02),rgba(7,10,16,.16))}.pp-status.hidden{display:none!important}.pp-status-message{grid-column:1/-1;padding:12px 14px;color:var(--pp-soft);font-weight:750;text-align:center}@media(max-width:980px){.pp-toolbar{flex-wrap:wrap}.pp-toolbar #pp-search{flex:1 1 100%;min-width:0}.pp-toolbar .pp-field:not(#pp-search),.pp-toolbar .cw-icon-select{flex:1 1 170px}.pp-card{grid-template-columns:90px minmax(0,1fr);height:136px}}@media(max-width:640px){.pp-toolbar{display:grid;grid-template-columns:1fr}.pp-toolbar #pp-search,.pp-toolbar .pp-field:not(#pp-search),.pp-toolbar .cw-icon-select{min-width:0;flex:auto}.pp-card{grid-template-columns:82px minmax(0,1fr);height:132px}.pp-card-head{grid-template-columns:1fr}.pp-card-side{justify-items:start}.pp-provider-stack{justify-content:flex-start}.pp-card-title{font-size:16px}.pp-timing{margin-left:0;flex-wrap:wrap;justify-content:flex-start;gap:8px}.pp-action-btn{padding:0 8px;font-size:0}.pp-action-btn .material-symbols-rounded{font-size:20px}}
+.pp-settings-dialog{width:min(1040px,calc(100vw - 28px))}.pp-settings-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));align-items:start;gap:12px;max-height:min(560px,64vh);overflow:auto;padding-right:2px}.pp-settings-list>.pp-dialog-sub{grid-column:1/-1}.pp-settings-table{display:grid;gap:8px;min-width:0}.pp-settings-row{display:grid;grid-template-columns:auto minmax(0,1fr) auto;align-items:center;gap:10px;min-height:74px;padding:10px;border-radius:12px;border:1px solid var(--pp-border-soft);background:rgba(255,255,255,.035)}.pp-settings-row input[type=checkbox]{width:18px;height:18px;accent-color:#7ee2b8}.pp-settings-main{min-width:0}.pp-settings-name{display:flex;align-items:center;gap:8px;font-weight:850;min-width:0}.pp-settings-name img{width:16px;height:16px;max-width:none;max-height:none;object-fit:contain;flex:0 0 16px}.pp-settings-sub{margin-top:2px;color:var(--pp-soft);font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.pp-settings-pill{font-size:11px;color:var(--pp-soft);font-weight:800}.pp-settings-timeout{display:flex;align-items:center;justify-content:flex-start;gap:12px;flex-wrap:wrap}.pp-settings-timeout-label{display:inline-flex;align-items:center;gap:6px;min-width:0}.pp-help-icon{display:inline-grid;place-items:center;width:18px;height:18px;border-radius:999px;border:1px solid var(--pp-border-soft);background:rgba(255,255,255,.045);color:var(--pp-soft);cursor:help}.pp-help-icon .material-symbols-rounded{font-size:15px;line-height:1}.pp-settings-timeout input{width:96px;height:38px;border-radius:10px;border:1px solid var(--pp-border);background:var(--pp-input-bg);color:var(--pp-fg);padding:0 10px;font-weight:800}@media(max-width:760px){.pp-settings-list{grid-template-columns:1fr;max-height:min(560px,58vh)}.pp-settings-row{grid-template-columns:auto 1fr}.pp-settings-pill{display:none}}
+    `;
+    document.head.appendChild(Object.assign(document.createElement("style"), { id: STYLE_ID, textContent: css }));
+  }
+
+  function root() {
+    return document.getElementById(ROOT_ID);
+  }
+
+  function shell() {
+    return `
+      <div class="pp-head">
+        <div><div class="pp-title">Playback Progress</div><div class="pp-intro">Manage unfinished playback records across supported providers.</div></div>
+        <div class="pp-head-actions"><button class="pp-btn pp-icon-btn" id="pp-settings" title="Playback Progress settings" aria-label="Playback Progress settings">${icon("settings")}</button><button class="pp-btn pp-icon-btn" id="pp-refresh" title="Refresh provider data" aria-label="Refresh provider data">${icon("refresh")}</button></div>
+      </div>
+      <div class="pp-status" id="pp-status"></div>
+      <div class="pp-toolbar">
+        <input class="pp-field" id="pp-search" type="search" placeholder="Search">
+        <select class="pp-field" id="pp-provider"></select>
+        <select class="pp-field" id="pp-type"><option value="">All Types</option><option value="movie">Movies</option><option value="episode">TV Episodes</option><option value="anime_episode">Anime Episodes</option></select>
+        <select class="pp-field" id="pp-progress"><option value="">All Progress</option><option value="0:24.99">Under 25 percent</option><option value="25:50">25 to 50 percent</option><option value="50:75">50 to 75 percent</option><option value="75:100">Over 75 percent</option><option value="90:100">Nearly Finished</option></select>
+        <select class="pp-field" id="pp-age"><option value="">All Time</option><option value="today">Today</option><option value="7d">Last 7 Days</option><option value="30d">Last 30 Days</option><option value="older_30d">Older Than 30 Days</option></select>
+        <select class="pp-field hidden" id="pp-rating"><option value="">All Ratings</option><option value="6">6 and Higher</option><option value="7">7 and Higher</option><option value="8">8 and Higher</option><option value="9">9 and Higher</option></select>
+        <select class="pp-field" id="pp-sort"><option value="last_updated">Last Updated</option><option value="progress_high">Progress High</option><option value="progress_low">Progress Low</option><option value="remaining_time">Remaining Time</option><option value="rating_high">Rating High</option><option value="title">Title</option><option value="provider">Provider</option></select>
+      </div>
+      <div class="pp-errors hidden" id="pp-errors"></div>
+      <div class="pp-grid" id="pp-grid"></div>
+      <div class="pp-pager" id="pp-pager"><button class="pp-btn" id="pp-prev">${icon("chevron_left")}</button><span id="pp-page-text"></span><button class="pp-btn" id="pp-next">${icon("chevron_right")}</button></div>
+      <div class="pp-bulk hidden" id="pp-bulk"><div class="pp-bulk-left"><strong id="pp-selected-count">0 selected</strong><button class="pp-btn" id="pp-select-visible">Select Visible</button><button class="pp-btn" id="pp-select-all">Select All Filtered Results</button><button class="pp-btn" id="pp-clear-selection">Clear Selection</button></div><div class="pp-bulk-actions"><button class="pp-btn" id="pp-bulk-edit">${icon("edit")} Edit Progress</button><button class="pp-btn" id="pp-bulk-watch">${icon("check_circle")} Mark as Watched</button><button class="pp-btn danger" id="pp-bulk-remove">${icon("delete")} Remove Progress</button></div></div>
+      <div class="pp-modal hidden" id="pp-progress-dialog" role="dialog" aria-modal="true" aria-labelledby="pp-progress-dialog-title">
+        <div class="pp-dialog">
+          <div><div class="pp-dialog-title" id="pp-progress-dialog-title">Edit Progress</div><div class="pp-dialog-sub" id="pp-progress-dialog-sub"></div></div>
+          <div class="pp-progress-edit"><input id="pp-progress-range" type="range" min="2" max="79" step="1"><input id="pp-progress-value" type="number" min="2" max="79" step="1"></div>
+          <div class="pp-dialog-error" id="pp-progress-error"></div>
+          <div class="pp-dialog-actions"><button class="pp-btn" id="pp-progress-cancel">Cancel</button><button class="pp-btn" id="pp-progress-apply">Apply</button></div>
+        </div>
+      </div>
+      <div class="pp-modal hidden" id="pp-settings-dialog" role="dialog" aria-modal="true" aria-labelledby="pp-settings-title">
+        <div class="pp-dialog pp-settings-dialog">
+          <div><div class="pp-dialog-title" id="pp-settings-title">Playback Progress Settings</div><div class="pp-dialog-sub">Choose which provider profiles appear on this screen.</div></div>
+          <div class="pp-settings-timeout"><span class="pp-dialog-sub pp-settings-timeout-label">Slow provider timeout <span class="pp-help-icon" tabindex="0" title="How many seconds Playback Progress waits for each provider profile before skipping it for this refresh. Slower providers are shown as timed out instead of blocking the whole page.">${icon("help")}</span></span><input id="pp-settings-timeout" type="number" min="3" max="60" step="1"></div>
+          <div class="pp-settings-list" id="pp-settings-list"></div>
+          <div class="pp-dialog-error" id="pp-settings-error"></div>
+          <div class="pp-dialog-actions"><button class="pp-btn" id="pp-settings-cancel">Cancel</button><button class="pp-btn" id="pp-settings-save">Save</button></div>
+        </div>
+      </div>
+      <div class="pp-toast hidden" id="pp-toast"></div>
+    `;
+  }
+
+  const providerKey = (item) => `${item.provider}:${item.instance_id}`;
+  const recordsOf = (item) => Array.isArray(item?.records) && item.records.length ? item.records : [item];
+  const recordKey = (item) => item?.is_combined ? `combined:${item.remote_id || item.canonical_key || recordsOf(item).map((r) => `${providerKey(r)}:${r.remote_id}`).join("|")}` : `${providerKey(item)}:${item.remote_id}`;
+  const fmtPct = (n) => Number.isFinite(Number(n)) ? `${Math.round(Number(n))}%` : "Unknown";
+  const fmtRemaining = (n) => {
+    const s = Number(n);
+    if (!Number.isFinite(s) || s <= 0) return "";
+    const mins = Math.round(s / 60);
+    return mins >= 60 ? `${Math.floor(mins / 60)}h ${mins % 60}m left` : `${mins}m left`;
+  };
+  const fmtDate = (v) => {
+    const d = Date.parse(v || "");
+    return Number.isFinite(d) ? new Date(d).toLocaleString() : "";
+  };
+  const fmtPaused = (v) => {
+    const d = Date.parse(v || "");
+    if (!Number.isFinite(d)) return "";
+    const diff = Date.now() - d;
+    if (diff >= 0) {
+      const mins = Math.floor(diff / 60000);
+      if (mins < 1) return "Paused just now";
+      if (mins < 60) return `Paused ${mins} min ago`;
+      const hours = Math.floor(mins / 60);
+      if (hours < 24) return `Paused ${hours}h ago`;
+      const days = Math.floor(hours / 24);
+      if (days < 31) return `Paused ${days} day${days === 1 ? "" : "s"} ago`;
+      const months = Math.floor(days / 30);
+      if (months < 12) return `Paused ${months} month${months === 1 ? "" : "s"} ago`;
+      const years = Math.floor(days / 365);
+      return `Paused ${years} year${years === 1 ? "" : "s"} ago`;
+    }
+    return `Paused ${new Date(d).toLocaleDateString()}`;
+  };
+  const titleOf = (it) => it.media_type === "movie" ? (it.title || "Untitled") : (it.series_title || it.title || "Untitled");
+  const subOf = (it) => {
+    if (it.media_type === "movie") return ["Movie", it.year].filter(Boolean).join(" - ");
+    const ep = it.season != null && it.episode != null ? `S${String(it.season).padStart(2, "0")}E${String(it.episode).padStart(2, "0")}` : "";
+    const type = it.media_type === "anime_episode" ? "Anime-Episode" : "TV-Episode";
+    const label = [ep, it.episode_title].filter(Boolean).join(" - ");
+    return label ? `${label} (${type})` : type;
+  };
+  const tmdbArtUrl = (it, size = "w342", kind = "poster") => {
+    const media = String(it?.media_type || it?.type || "").toLowerCase();
+    const meta = it?.provider_metadata && typeof it.provider_metadata === "object" ? it.provider_metadata : {};
+    const showIds = meta.show_ids && typeof meta.show_ids === "object" ? meta.show_ids : {};
+    const ids = it?.ids && typeof it.ids === "object" ? it.ids : {};
+    const source = media === "movie" ? ids : (showIds.tmdb ? showIds : ids);
+    const tmdb = source?.tmdb || it?.tmdb;
+    if (!tmdb) return "";
+    const typ = media === "movie" ? "movie" : "tv";
+    return `/art/tmdb/${typ}/${encodeURIComponent(String(tmdb))}?kind=${encodeURIComponent(kind)}&size=${encodeURIComponent(size)}&locale=${encodeURIComponent(window.__CW_LOCALE || navigator.language || "en-US")}`;
+  };
+  const providerPills = (it) => {
+    const providers = Array.isArray(it.providers) && it.providers.length
+      ? it.providers
+      : [{ provider: it.provider, provider_label: it.provider_label, instance_id: it.instance_id, instance_label: it.instance_label }];
+    return providers.map((p) => `<span class="pp-provider-pill">${providerIcon(p.provider)}${esc(profileLabel(p))}</span>`).join("");
+  };
+  const profileLabel = (p) => {
+    const provider = String(p.provider || "");
+    const providerLabel = String(p.provider_label || provider);
+    let label = String(p.instance_label || p.instance_id || "").trim();
+    for (const prefix of [providerLabel, provider]) {
+      if (prefix && label.toLowerCase().startsWith(prefix.toLowerCase())) {
+        label = label.slice(prefix.length).trim();
+      }
+    }
+    return label || (String(p.instance_id || "").trim() || "Default");
+  };
+  const actionRecords = (item, action) => recordsOf(item).filter((it) => {
+    if (action === "mark_watched") return it.can_mark_watched;
+    if (action === "update_progress") return it.can_update_progress;
+    return it.can_remove_progress;
+  });
+  const actionPayloads = (items, action) => items.flatMap((it) => actionRecords(it, action).map((record) => ({
+    provider: record.provider,
+    instance_id: record.instance_id,
+    remote_id: record.remote_id,
+    canonical_key: record.canonical_key,
+    record
+  })));
+  const avgProgress = (items) => {
+    const values = items.flatMap((it) => recordsOf(it)).map((it) => Number(it.progress_percent)).filter(Number.isFinite);
+    if (!values.length) return 25;
+    return Math.max(2, Math.min(79, Math.round(values.reduce((a, b) => a + b, 0) / values.length)));
+  };
+  const actionTitle = (action) => action === "mark_watched" ? "Mark as Watched" : action === "update_progress" ? "Edit Progress" : "Remove Progress";
+
+  function toast(msg) {
+    const el = document.getElementById("pp-toast");
+    if (!el) return;
+    el.textContent = msg;
+    el.classList.remove("hidden");
+    clearTimeout(toast._t);
+    toast._t = setTimeout(() => el.classList.add("hidden"), 2400);
+  }
+
+  function askProgress(defaultValue, count) {
+    return new Promise((resolve) => {
+      const dlg = document.getElementById("pp-progress-dialog");
+      const range = document.getElementById("pp-progress-range");
+      const value = document.getElementById("pp-progress-value");
+      const sub = document.getElementById("pp-progress-dialog-sub");
+      const err = document.getElementById("pp-progress-error");
+      const apply = document.getElementById("pp-progress-apply");
+      const cancel = document.getElementById("pp-progress-cancel");
+      if (!dlg || !range || !value || !sub || !err || !apply || !cancel) return resolve(null);
+      const initial = Math.max(2, Math.min(79, Math.round(Number(defaultValue) || 25)));
+      range.value = String(initial);
+      value.value = String(initial);
+      sub.textContent = `${count || 1} provider record${count === 1 ? "" : "s"}`;
+      err.textContent = "";
+      dlg.classList.remove("hidden");
+      value.focus();
+      value.select?.();
+      const syncFromRange = () => { value.value = range.value; err.textContent = ""; };
+      const syncFromValue = () => { range.value = String(Math.max(2, Math.min(79, Math.round(Number(value.value) || initial)))); err.textContent = ""; };
+      const done = (result) => {
+        dlg.classList.add("hidden");
+        range.removeEventListener("input", syncFromRange);
+        value.removeEventListener("input", syncFromValue);
+        apply.removeEventListener("click", onApply);
+        cancel.removeEventListener("click", onCancel);
+        dlg.removeEventListener("click", onBackdrop);
+        dlg.removeEventListener("keydown", onKey);
+        resolve(result);
+      };
+      const onApply = () => {
+        const n = Number(value.value);
+        if (!Number.isFinite(n) || n < 2 || n >= 80) {
+          err.textContent = "Use 2-79%. Use Watched for completed items.";
+          return;
+        }
+        done(Math.round(n * 100) / 100);
+      };
+      const onCancel = () => done(null);
+      const onBackdrop = (e) => { if (e.target === dlg) done(null); };
+      const onKey = (e) => {
+        if (e.key === "Escape") done(null);
+        if (e.key === "Enter") onApply();
+      };
+      range.addEventListener("input", syncFromRange);
+      value.addEventListener("input", syncFromValue);
+      apply.addEventListener("click", onApply);
+      cancel.addEventListener("click", onCancel);
+      dlg.addEventListener("click", onBackdrop);
+      dlg.addEventListener("keydown", onKey);
+    });
+  }
+
+  async function openSettings() {
+    const dlg = document.getElementById("pp-settings-dialog");
+    const list = document.getElementById("pp-settings-list");
+    const timeout = document.getElementById("pp-settings-timeout");
+    const err = document.getElementById("pp-settings-error");
+    if (!dlg || !list || !timeout || !err) return;
+    err.textContent = "";
+    list.innerHTML = `<div class="pp-dialog-sub">Loading provider profiles...</div>`;
+    dlg.classList.remove("hidden");
+    const data = await api("/api/playback_progress/settings");
+    state.settings = data;
+    timeout.value = String(Math.round(Number(data.provider_timeout_seconds || 12)));
+    const profiles = Array.isArray(data.profiles) ? data.profiles : [];
+    if (!profiles.length) {
+      list.innerHTML = `<div class="pp-dialog-sub">No compatible provider profiles were found.</div>`;
+      return;
+    }
+    const rows = profiles.map((p) => {
+      const key = `${p.provider}:${p.instance_id}`;
+      const disabled = p.configured && p.read ? "" : " disabled";
+      const status = p.configured && p.read ? "available" : (p.reason || "not configured");
+      return `<label class="pp-settings-row">
+        <input type="checkbox" data-key="${esc(key)}" data-provider="${esc(p.provider)}" data-instance="${esc(p.instance_id)}"${p.included ? " checked" : ""}${disabled}>
+        <span class="pp-settings-main"><span class="pp-settings-name">${providerIcon(p.provider)}${esc(p.instance_label || p.provider_label || key)}</span><span class="pp-settings-sub">${esc(status)}</span></span>
+        <span class="pp-settings-pill">${esc(p.provider_label || p.provider)}</span>
+      </label>`;
+    });
+    const tables = [];
+    for (let i = 0; i < rows.length; i += 5) {
+      tables.push(`<div class="pp-settings-table">${rows.slice(i, i + 5).join("")}</div>`);
+    }
+    list.innerHTML = tables.join("");
+  }
+
+  function closeSettings() {
+    document.getElementById("pp-settings-dialog")?.classList.add("hidden");
+  }
+
+  async function saveSettings() {
+    const dlg = document.getElementById("pp-settings-dialog");
+    const list = document.getElementById("pp-settings-list");
+    const timeout = document.getElementById("pp-settings-timeout");
+    const err = document.getElementById("pp-settings-error");
+    if (!dlg || !list || !timeout || !err) return;
+    const n = Number(timeout.value);
+    if (!Number.isFinite(n) || n < 3 || n > 60) {
+      err.textContent = "Use a timeout between 3 and 60 seconds.";
+      return;
+    }
+    const profiles = [...list.querySelectorAll("input[type=checkbox][data-provider]")].map((el) => ({
+      provider: el.dataset.provider,
+      instance_id: el.dataset.instance,
+      included: el.checked
+    }));
+    const res = await api("/api/playback_progress/settings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profiles, provider_timeout_seconds: n })
+    });
+    if (!res.ok) {
+      err.textContent = res.message || res.error || "Settings could not be saved.";
+      return;
+    }
+    closeSettings();
+    toast("Playback Progress settings saved");
+    state.selected.clear();
+    await load(true);
+  }
+
+  function providerOptions() {
+    const readable = state.providers.filter((p) => p.read && p.configured && p.included !== false);
+    const opts = ['<option value="">All Providers</option>'];
+    readable.forEach((p) => opts.push(`<option value="${esc(p.provider)}:${esc(p.instance_id)}">${esc(p.instance_label || p.provider_label)}</option>`));
+    document.getElementById("pp-provider").innerHTML = opts.join("");
+    const cur = state.filters.provider;
+    if ([...document.getElementById("pp-provider").options].some((o) => o.value === cur)) document.getElementById("pp-provider").value = cur;
+  }
+
+  function renderStatus() {
+    const wrap = document.getElementById("pp-status");
+    const configured = state.providers.filter((p) => p.configured && p.read);
+    const readable = configured.filter((p) => p.included !== false);
+    if (readable.length) {
+      wrap.classList.add("hidden");
+      wrap.innerHTML = "";
+      return;
+    }
+    wrap.innerHTML = `<div class="pp-status-message">${configured.length ? "Enable at least one provider profile in Playback Progress settings." : "Connect at least one compatible provider to view playback progress."}</div>`;
+    wrap.classList.remove("hidden");
+  }
+
+  function renderErrors() {
+    const el = document.getElementById("pp-errors");
+    if (!state.errors.length) return el.classList.add("hidden");
+    el.innerHTML = state.errors.map((e) => `${esc(e.provider || "Provider")} ${esc(e.instance_id || "")}: ${esc(e.message || e.error_code || "failed")}`).join("<br>");
+    el.classList.remove("hidden");
+  }
+
+  function card(it) {
+    const key = recordKey(it);
+    const selected = state.selected.has(key) ? " selected" : "";
+    const pct = Math.max(0, Math.min(100, Number(it.progress_percent || 0)));
+    const remaining = fmtRemaining(it.remaining_seconds);
+    const posterImg = it.poster_url || tmdbArtUrl(it, "w342") || "/assets/img/placeholder_poster.svg";
+    const backdropImg = it.backdrop_url || tmdbArtUrl(it, "w780", "backdrop");
+    const backdropStyle = backdropImg ? ` style="--pp-backdrop:url('${esc(backdropImg)}')"` : "";
+    const paused = fmtPaused(it.updated_at || it.progress_at);
+    const timing = [remaining ? `<span>${esc(remaining)}</span>` : "", paused ? `<span class="pp-paused">${esc(paused)}</span>` : ""].filter(Boolean).join("");
+    const actionWatch = it.can_mark_watched ? `<button class="pp-btn pp-action-btn pp-action-watch" data-action="watch" data-key="${esc(key)}" title="Mark as watched" aria-label="Mark as watched">${icon("check_circle")}<span>Watched</span></button>` : "";
+    const actionEdit = it.can_update_progress ? `<button class="pp-btn pp-action-btn pp-action-edit" data-action="edit" data-key="${esc(key)}" title="Edit progress" aria-label="Edit progress">${icon("edit")}<span>Edit</span></button>` : "";
+    const actionRemove = it.can_remove_progress ? `<button class="pp-btn pp-action-btn pp-action-remove" data-action="remove" data-key="${esc(key)}" title="Remove progress" aria-label="Remove progress">${icon("delete")}<span>Remove</span></button>` : "";
+    return `<article class="pp-card${selected}" data-key="${esc(key)}" role="checkbox" aria-checked="${state.selected.has(key) ? "true" : "false"}" tabindex="0"${backdropStyle}>
+      <div class="pp-art"><img src="${esc(posterImg)}" alt="" loading="lazy" decoding="async" onerror="this.onerror=null;this.src='/assets/img/placeholder_poster.svg'"></div>
+      <div class="pp-body">
+        <div class="pp-top">
+          <div class="pp-card-head">
+            <div class="pp-title-wrap"><div class="pp-card-title">${esc(titleOf(it))}</div><div class="pp-card-sub">${esc(subOf(it))}</div></div>
+            <div class="pp-card-side"><div class="pp-provider-stack">${providerPills(it)}</div></div>
+          </div>
+        </div>
+        <div class="pp-progress"><div class="pp-progress-row"><strong>${esc(fmtPct(it.progress_percent))} watched</strong><span class="pp-timing">${timing}</span></div><div class="pp-bar"><span style="width:${pct}%"></span></div></div>
+        <div class="pp-actions">${actionEdit}${actionWatch}${actionRemove}</div>
+      </div>
+    </article>`;
+  }
+
+  function updateBulk() {
+    const bulk = document.getElementById("pp-bulk");
+    const count = state.selected.size;
+    document.getElementById("pp-selected-count").textContent = `${count} selected`;
+    bulk.classList.toggle("hidden", count === 0);
+  }
+
+  function renderItems() {
+    const grid = document.getElementById("pp-grid");
+    const ratingFilter = document.getElementById("pp-rating");
+    ratingFilter.classList.toggle("hidden", !state.items.some((it) => it.rating != null));
+    grid.innerHTML = state.items.length ? state.items.map(card).join("") : `<div class="pp-empty">No playback records found.</div>`;
+    const maxPage = Math.max(1, Math.ceil((state.total || 0) / state.pageSize));
+    document.getElementById("pp-page-text").textContent = `${state.page} / ${maxPage} - ${state.total} total`;
+    document.getElementById("pp-prev").disabled = state.page <= 1;
+    document.getElementById("pp-next").disabled = state.page >= maxPage;
+    updateBulk();
+  }
+
+  function query(force = false, all = false) {
+    const params = new URLSearchParams();
+    const [provider, instance] = String(state.filters.provider || "").split(":");
+    if (provider) params.set("provider", provider);
+    if (instance) params.set("instance_id", instance);
+    if (state.filters.media_type) params.set("media_type", state.filters.media_type);
+    if (state.filters.age) params.set("age", state.filters.age);
+    if (state.filters.rating) params.set("rating_min", state.filters.rating);
+    if (state.filters.search) params.set("search", state.filters.search);
+    if (state.filters.sort) params.set("sort", state.filters.sort);
+    if (state.filters.progress) {
+      const [min, max] = state.filters.progress.split(":");
+      if (min) params.set("progress_min", min);
+      if (max) params.set("progress_max", max);
+    }
+    params.set("page", all ? "1" : String(state.page));
+    params.set("page_size", all ? "250" : String(state.pageSize));
+    if (force) params.set("force_refresh", "true");
+    return params;
+  }
+
+  async function load(force = false) {
+    if (state.busy) return;
+    state.busy = true;
+    document.getElementById("pp-refresh")?.setAttribute("disabled", "disabled");
+    try {
+      const data = await api(`/api/playback_progress/items?${query(force).toString()}`);
+      state.items = Array.isArray(data.items) ? data.items : [];
+      state.providers = Array.isArray(data.providers) ? data.providers : [];
+      state.errors = Array.isArray(data.errors) ? data.errors : [];
+      state.total = Number(data.total || 0);
+      state.page = Number(data.page || 1);
+      providerOptions();
+      renderStatus();
+      renderErrors();
+      renderItems();
+    } catch (e) {
+      state.items = [];
+      state.errors = [{ provider: "Playback Progress", message: String(e?.message || e || "Request failed") }];
+      state.total = 0;
+      renderErrors();
+      renderItems();
+    } finally {
+      state.busy = false;
+      document.getElementById("pp-refresh")?.removeAttribute("disabled");
+    }
+  }
+
+  async function act(action, item) {
+    const bulkAction = action === "watch" ? "mark_watched" : action === "edit" ? "update_progress" : "remove_progress";
+    const payloads = actionPayloads([item], bulkAction);
+    let progressPercent = null;
+    if (bulkAction === "update_progress") {
+      if (!payloads.length) return toast("Edit Progress is unsupported for this record.");
+      progressPercent = await askProgress(avgProgress([item]), payloads.length);
+      if (progressPercent == null) return;
+    }
+    if (payloads.length > 1 || item.is_combined) {
+      if (!payloads.length) return toast("Action is unsupported for this record.");
+      const res = await api("/api/playback_progress/actions/bulk", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ action: bulkAction, progress_percent: progressPercent, items: payloads }) });
+      toast(`Successful ${res.successful || 0}, failed ${res.failed || 0}, unsupported ${res.unsupported || 0}`);
+      if ((res.successful || 0) > 0) {
+        state.selected.delete(recordKey(item));
+        await load(true);
+      }
+      return;
+    }
+    const url = action === "watch" ? "/api/playback_progress/actions/mark_watched" : action === "edit" ? "/api/playback_progress/actions/update_progress" : "/api/playback_progress/actions/remove";
+    const record = recordsOf(item)[0] || item;
+    const body = { provider: record.provider, instance_id: record.instance_id, remote_id: record.remote_id, canonical_key: record.canonical_key, progress_percent: progressPercent, record };
+    const res = await api(url, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+    toast(res.message || (res.ok ? "Done" : "Action failed"));
+    if (res.ok) {
+      state.selected.delete(recordKey(item));
+      await load(true);
+    }
+  }
+
+  async function bulk(action) {
+    const selected = [...state.selected.values()];
+    if (!selected.length) return;
+    const allRecords = selected.flatMap((it) => recordsOf(it));
+    const payloads = actionPayloads(selected, action);
+    const unsupported = allRecords.length - payloads.length;
+    if (!payloads.length) return toast(`${actionTitle(action)} is unsupported for the selected records.`);
+    let progressPercent = null;
+    if (action === "update_progress") {
+      progressPercent = await askProgress(avgProgress(selected), payloads.length);
+      if (progressPercent == null) return;
+    } else if (!confirm(`${actionTitle(action)} for ${payloads.length} eligible provider record(s)? ${unsupported ? `${unsupported} unsupported provider record(s) will be skipped.` : ""}`)) return;
+    const res = await api("/api/playback_progress/actions/bulk", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ action, progress_percent: progressPercent, items: payloads }) });
+    toast(`Successful ${res.successful || 0}, failed ${res.failed || 0}, unsupported ${res.unsupported || 0}`);
+    state.selected.clear();
+    await load(true);
+  }
+
+  function bind() {
+    const r = root();
+    const update = (key, val) => { state.filters[key] = val; state.page = 1; load(false); };
+    r.addEventListener("change", (e) => {
+      const t = e.target;
+      if (!t) return;
+      if (t.id === "pp-provider") update("provider", t.value);
+      if (t.id === "pp-type") update("media_type", t.value);
+      if (t.id === "pp-progress") update("progress", t.value);
+      if (t.id === "pp-age") update("age", t.value);
+      if (t.id === "pp-rating") update("rating", t.value);
+      if (t.id === "pp-sort") update("sort", t.value);
+    }, true);
+    r.addEventListener("input", (e) => {
+      if (e.target?.id !== "pp-search") return;
+      clearTimeout(bind._search);
+      bind._search = setTimeout(() => update("search", e.target.value), 180);
+    }, true);
+    r.addEventListener("click", async (e) => {
+      const btn = e.target?.closest?.("button");
+      if (btn) {
+        if (btn.id === "pp-settings") return openSettings();
+        if (btn.id === "pp-settings-cancel") return closeSettings();
+        if (btn.id === "pp-settings-save") return saveSettings();
+        if (btn.id === "pp-refresh") return load(true);
+        if (btn.id === "pp-prev" && state.page > 1) { state.page--; return load(false); }
+        if (btn.id === "pp-next") { state.page++; return load(false); }
+        if (btn.id === "pp-select-visible") { state.items.forEach((it) => state.selected.set(recordKey(it), it)); renderItems(); return; }
+        if (btn.id === "pp-clear-selection") { state.selected.clear(); renderItems(); return; }
+        if (btn.id === "pp-select-all") {
+          const data = await api(`/api/playback_progress/items?${query(false, true).toString()}`);
+          (data.items || []).forEach((it) => state.selected.set(recordKey(it), it));
+          renderItems();
+          return;
+        }
+        if (btn.id === "pp-bulk-watch") return bulk("mark_watched");
+        if (btn.id === "pp-bulk-edit") return bulk("update_progress");
+        if (btn.id === "pp-bulk-remove") return bulk("remove_progress");
+        if (btn.dataset?.action && btn.dataset?.key) {
+          const item = state.items.find((it) => recordKey(it) === btn.dataset.key);
+          if (item) return act(btn.dataset.action, item);
+        }
+        return;
+      }
+      const settingsDialog = e.target?.closest?.("#pp-settings-dialog");
+      if (settingsDialog && e.target === settingsDialog) {
+        closeSettings();
+        return;
+      }
+      const card = e.target?.closest?.(".pp-card[data-key]");
+      if (card) {
+        const item = state.items.find((it) => recordKey(it) === card.dataset.key);
+        if (!item) return;
+        if (state.selected.has(card.dataset.key)) state.selected.delete(card.dataset.key);
+        else state.selected.set(card.dataset.key, item);
+        renderItems();
+      }
+    }, true);
+    r.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && !document.getElementById("pp-settings-dialog")?.classList.contains("hidden")) {
+        closeSettings();
+        return;
+      }
+      if (e.key !== " " && e.key !== "Enter") return;
+      const card = e.target?.closest?.(".pp-card[data-key]");
+      if (!card) return;
+      e.preventDefault();
+      const item = state.items.find((it) => recordKey(it) === card.dataset.key);
+      if (!item) return;
+      if (state.selected.has(card.dataset.key)) state.selected.delete(card.dataset.key);
+      else state.selected.set(card.dataset.key, item);
+      renderItems();
+    }, true);
+  }
+
+  function mount() {
+    ensureStyle();
+    const el = root();
+    if (!el) return;
+    if (!state.mounted) {
+      el.innerHTML = shell();
+      bind();
+      state.mounted = true;
+    }
+    load(false);
+  }
+
+  window.PlaybackProgress = { mount, refresh: () => load(true) };
+  document.addEventListener("tab-changed", (e) => {
+    if ((e.detail?.id || e.detail?.tab) === "playback_progress") mount();
+  });
+  const mountIfActive = () => {
+    const page = document.getElementById("page-playback_progress");
+    const tab = document.getElementById("tab-playback_progress");
+    if (page && (!page.classList.contains("hidden") || tab?.classList.contains("active"))) mount();
+  };
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", mountIfActive, { once: true });
+  else mountIfActive();
+})();

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -314,6 +314,11 @@ DEFAULT_CFG: dict[str, Any] = {
             "get_per_sec": 20,
         },
     },
+
+    "playback_progress": {
+        "disabled_profiles": [],                        # Provider profiles excluded from Continue Watching, e.g. ["trakt:default"]
+        "provider_timeout_seconds": 12.0,               # Max time this screen waits for provider profiles during one refresh
+    },
     
      "tautulli": {
          "server_url": "",                              # http(s)://host:8181

--- a/providers/auth/_auth_TRAKT.py
+++ b/providers/auth/_auth_TRAKT.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import re
+import threading
 import time
 from typing import Any
 
@@ -59,6 +60,9 @@ _H: dict[str, str] = {
     "trakt-api-version": "2",
 }
 
+_REFRESH_LOCKS: dict[str, threading.Lock] = {}
+_REFRESH_LOCKS_GUARD = threading.Lock()
+
 
 def _now() -> int:
     return int(time.time())
@@ -72,6 +76,16 @@ def _load_config() -> dict[str, Any]:
         return dict(cfg)
     except Exception:
         return {}
+
+
+def _refresh_lock(instance_id: Any) -> threading.Lock:
+    inst = normalize_instance_id(instance_id)
+    with _REFRESH_LOCKS_GUARD:
+        lock = _REFRESH_LOCKS.get(inst)
+        if lock is None:
+            lock = threading.Lock()
+            _REFRESH_LOCKS[inst] = lock
+        return lock
 
 
 def _save_config(cfg: dict[str, Any]) -> None:
@@ -347,70 +361,79 @@ class _TraktProvider:
         return {"ok": True, "status": "ok"}
 
     def refresh(self, cfg: dict[str, Any] | None = None, *, instance_id: Any = None) -> dict[str, Any]:
-        cfg = cfg or _load_config()
-        inst, _, tr = _blocks(cfg, instance_id)
-        c = _client(cfg, inst)
+        inst_key = normalize_instance_id(instance_id)
+        with _refresh_lock(inst_key):
+            cfg = cfg or _load_config()
+            inst, _, tr = _blocks(cfg, inst_key)
+            c = _client(cfg, inst)
 
-        rt = str(tr.get("refresh_token") or "").strip()
-        cid = str(c.get("client_id") or "").strip()
-        secr = str(c.get("client_secret") or "").strip()
-
-        if not (cid and secr and rt):
-            log("TRAKT: missing client_id/client_secret/refresh_token for refresh", "ERROR")
-            return {"ok": False, "status": "missing_refresh"}
-
-        log("TRAKT: refresh token", level="INFO", module="AUTH")
-
-        payload: dict[str, Any] = {
-            "refresh_token": rt,
-            "client_id": cid,
-            "client_secret": secr,
-            "grant_type": "refresh_token",
-        }
-
-        try:
-            r = requests.post(OAUTH_TOKEN, json=payload, headers=_headers(), timeout=30)
-        except Exception as e:
-            log(f"TRAKT: token refresh network error: {e}", "ERROR")
-            return {"ok": False, "status": "network_error", "error": str(e)}
-
-        if r.status_code >= 400:
-            body: dict[str, Any] = {}
             try:
-                body = r.json() or {}
+                exp = int(tr.get("expires_at") or 0)
             except Exception:
-                body = {}
-            err = str(body.get("error") or "") or str(body.get("error_description") or "") or (r.text or "")[:400]
-            log(f"TRAKT: token refresh failed {r.status_code}: {err}", "ERROR")
-            return {"ok": False, "status": f"refresh_failed:{r.status_code}", "error": err}
+                exp = 0
+            if str(tr.get("access_token") or "").strip() and exp and exp > (_now() + 120):
+                return {"ok": True, "status": "fresh", "expires_at": exp}
 
-        try:
-            tok: dict[str, Any] = r.json() or {}
-        except Exception as e:
-            log(f"TRAKT: token refresh invalid JSON: {e}", "ERROR")
-            return {"ok": False, "status": "bad_json"}
+            rt = str(tr.get("refresh_token") or "").strip()
+            cid = str(c.get("client_id") or "").strip()
+            secr = str(c.get("client_secret") or "").strip()
 
-        acc = str(tok.get("access_token") or "").strip()
-        if not acc:
-            log("TRAKT: token refresh succeeded but no access_token in response", "ERROR")
-            return {"ok": False, "status": "no_access_token"}
+            if not (cid and secr and rt):
+                log("TRAKT: missing client_id/client_secret/refresh_token for refresh", "ERROR")
+                return {"ok": False, "status": "missing_refresh"}
 
-        new_rt = str(tok.get("refresh_token") or rt or "").strip()
-        exp_in = int(tok.get("expires_in") or 0)
-        expires_at = _now() + exp_in if exp_in > 0 else 0
+            log("TRAKT: refresh token", level="INFO", module="AUTH")
 
-        tr.update(
-            {
-                "access_token": acc,
-                "refresh_token": new_rt,
-                "scope": tok.get("scope") or tr.get("scope") or "public",
-                "token_type": tok.get("token_type") or tr.get("token_type") or "bearer",
-                "expires_at": expires_at,
+            payload: dict[str, Any] = {
+                "refresh_token": rt,
+                "client_id": cid,
+                "client_secret": secr,
+                "grant_type": "refresh_token",
             }
-        )
-        _save_config(cfg)
-        log("TRAKT: refresh ok", level="SUCCESS", module="AUTH")
-        return {"ok": True, "status": "ok"}
+
+            try:
+                r = requests.post(OAUTH_TOKEN, json=payload, headers=_headers(), timeout=30)
+            except Exception as e:
+                log(f"TRAKT: token refresh network error: {e}", "ERROR")
+                return {"ok": False, "status": "network_error", "error": str(e)}
+
+            if r.status_code >= 400:
+                body: dict[str, Any] = {}
+                try:
+                    body = r.json() or {}
+                except Exception:
+                    body = {}
+                err = str(body.get("error") or "") or str(body.get("error_description") or "") or (r.text or "")[:400]
+                log(f"TRAKT: token refresh failed {r.status_code}: {err}", "ERROR")
+                return {"ok": False, "status": f"refresh_failed:{r.status_code}", "error": err}
+
+            try:
+                tok: dict[str, Any] = r.json() or {}
+            except Exception as e:
+                log(f"TRAKT: token refresh invalid JSON: {e}", "ERROR")
+                return {"ok": False, "status": "bad_json"}
+
+            acc = str(tok.get("access_token") or "").strip()
+            if not acc:
+                log("TRAKT: token refresh succeeded but no access_token in response", "ERROR")
+                return {"ok": False, "status": "no_access_token"}
+
+            new_rt = str(tok.get("refresh_token") or rt or "").strip()
+            exp_in = int(tok.get("expires_in") or 0)
+            expires_at = _now() + exp_in if exp_in > 0 else 0
+
+            tr.update(
+                {
+                    "access_token": acc,
+                    "refresh_token": new_rt,
+                    "scope": tok.get("scope") or tr.get("scope") or "public",
+                    "token_type": tok.get("token_type") or tr.get("token_type") or "bearer",
+                    "expires_at": expires_at,
+                }
+            )
+            _save_config(cfg)
+            log("TRAKT: refresh ok", level="SUCCESS", module="AUTH")
+            return {"ok": True, "status": "ok"}
 
     def disconnect(self, cfg: dict[str, Any] | None = None, *, instance_id: Any = None) -> AuthStatus:
         cfg = cfg or _load_config()

--- a/providers/sync/plex/_progress.py
+++ b/providers/sync/plex/_progress.py
@@ -10,6 +10,7 @@ from typing import Any, Iterable, Mapping
 from cw_platform.id_map import canonical_key, ids_from_guid, ids_from, minimal as id_minimal
 
 from ._common import (
+    active_pms_token,
     episode_rating_key_from_show,
     has_external_ids,
     home_scope_enter,
@@ -18,6 +19,7 @@ from ._common import (
     plex_cfg_get,
     server_find_rating_key_by_guid,
     make_logger,
+    minimal_from_history_row,
     normalize,
 )
 
@@ -86,7 +88,7 @@ def _fetch_resume_rating_keys(srv: Any, *, limit: int = 100) -> set[str]:
     return rks
 
 
-def _fetch_metadata_row(srv: Any, rk: str) -> tuple[Mapping[str, Any] | None, dict[str, str]]:
+def _fetch_metadata_row(srv: Any, rk: str) -> tuple[dict[str, Any] | None, dict[str, str]]:
     try:
         key = f"/library/metadata/{str(rk).strip()}?includeUserState=1&includeGuids=1"
         root = srv.query(key)  # type: ignore[attr-defined]
@@ -96,18 +98,23 @@ def _fetch_metadata_row(srv: Any, rk: str) -> tuple[Mapping[str, Any] | None, di
 
         el = rows[0]
         a = getattr(el, "attrib", {}) or {}
+        row = dict(a)
 
         ids: dict[str, str] = {}
+        guid_rows: list[dict[str, str]] = []
 
         try:
             for g in el.findall("./Guid"):  # type: ignore[attr-defined]
                 gid = (getattr(g, "attrib", {}) or {}).get("id")
                 if gid:
+                    guid_rows.append({"id": str(gid)})
                     for k, v in ids_from_guid(str(gid)).items():
                         if k != "guid" and v:
                             ids[k] = v
         except Exception:
             pass
+        if guid_rows:
+            row["Guid"] = guid_rows
 
         # Some agents encode tmdb/imdb in the main guid string.
         g0 = a.get("guid")
@@ -116,7 +123,7 @@ def _fetch_metadata_row(srv: Any, rk: str) -> tuple[Mapping[str, Any] | None, di
                 if k != "guid" and v:
                     ids[k] = v
 
-        return a, ids
+        return row, ids
     except Exception:
         return None, {}
 
@@ -131,6 +138,7 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
         rks = _fetch_resume_rating_keys(srv, limit=150)
         out: dict[str, dict[str, Any]] = {}
         dbg = _mods_debug()
+        token = active_pms_token(adapter)
 
         for rk in sorted(rks):
             a, ext_ids = _fetch_metadata_row(srv, rk)
@@ -152,9 +160,11 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
                 "ids": {},
             }
 
+            base["ids"]["plex"] = str(rk)
+
             # Keep external IDs when available
             if has_external_ids(ext_ids):
-                base["ids"] = dict(ext_ids)
+                base["ids"].update(dict(ext_ids))
                 base["ids"]["plex"] = str(rk)
 
             if typ == "episode":
@@ -169,6 +179,20 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
                             show_ids[k] = v
                 if show_ids:
                     base["show_ids"] = show_ids
+
+            enriched = minimal_from_history_row(a, token=token, allow_discover=True)
+            if isinstance(enriched, Mapping):
+                enriched_ids = enriched.get("ids") if isinstance(enriched.get("ids"), Mapping) else {}
+                if enriched_ids:
+                    base["ids"].update({str(k): v for k, v in enriched_ids.items() if v})
+                    base["ids"]["plex"] = str(rk)
+                enriched_show_ids = enriched.get("show_ids") if isinstance(enriched.get("show_ids"), Mapping) else {}
+                if typ == "episode" and enriched_show_ids:
+                    base.setdefault("show_ids", {})
+                    base["show_ids"].update({str(k): v for k, v in enriched_show_ids.items() if v})
+                for key_name in ("title", "series_title", "year", "season", "episode"):
+                    if enriched.get(key_name) is not None and base.get(key_name) in (None, ""):
+                        base[key_name] = enriched.get(key_name)
 
             norm = id_minimal(base)
             if ts:
@@ -395,6 +419,38 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
 
 
 def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
-    unresolved = [{"item": dict(x), "hint": "not_supported"} for x in (items or [])]
-    _info("write_skipped", op="remove", reason="not_supported", unresolved=len(unresolved))
-    return 0, unresolved
+    srv = getattr(getattr(adapter, "client", None), "server", None)
+    if not srv:
+        return 0, [{"item": dict(x), "hint": "not_configured"} for x in (items or [])]
+
+    _need_scope, did_switch, _aid, _uname = home_scope_enter(adapter)
+    try:
+        ok = 0
+        unresolved: list[dict[str, Any]] = []
+
+        for it in items or []:
+            it0 = dict(it or {})
+            rk = _resolve_rating_key(adapter, it0)
+            if not rk:
+                unresolved.append({"item": it0, "hint": "not_found"})
+                if _mods_debug():
+                    _dbg("resolve_miss", hint="not_found", canonical_key=str(canonical_key(id_minimal(it0)) or ""), ids=dict(ids_from(it0)))
+                continue
+
+            try:
+                obj = srv.fetchItem(int(rk))  # type: ignore[attr-defined]
+                mark_unplayed = getattr(obj, "markUnplayed", None) or getattr(obj, "markUnwatched", None)
+                if callable(mark_unplayed):
+                    mark_unplayed()
+                else:
+                    srv.query(f"/:/unscrobble?key={rk}&identifier=com.plexapp.plugins.library")  # type: ignore[attr-defined]
+                ok += 1
+            except Exception as e:
+                if _mods_debug():
+                    _warn("write_failed", op="remove", rating_key=str(rk), canonical_key=str(canonical_key(id_minimal(it0)) or ""), error=str(e))
+                unresolved.append({"item": it0, "hint": f"exception:{e}"})
+
+        _info("write_done", op="remove", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved), mode="unscrobble")
+        return ok, unresolved
+    finally:
+        home_scope_exit(adapter, did_switch)

--- a/services/playback_progress/__init__.py
+++ b/services/playback_progress/__init__.py
@@ -1,0 +1,5 @@
+"""Provider-neutral Playback Progress manager."""
+
+from .service import PlaybackProgressService, get_service
+
+__all__ = ["PlaybackProgressService", "get_service"]

--- a/services/playback_progress/adapters/base.py
+++ b/services/playback_progress/adapters/base.py
@@ -1,0 +1,99 @@
+# /services/playback_progress/adapters/base.py
+# CrossWatch - Playback Progress Adapters
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult
+
+
+class PlaybackProgressAdapter:
+    provider = ""
+    provider_label = ""
+
+    def capabilities(
+        self,
+        config_view: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+    ) -> PlaybackCapabilities:
+        raise NotImplementedError
+
+    def list_progress(
+        self,
+        config_view: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+        force_refresh: bool = False,
+    ) -> PlaybackListResult:
+        raise NotImplementedError
+
+    def remove_progress(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+    ) -> PlaybackActionResult:
+        raise NotImplementedError
+
+    def mark_watched(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+        watched_at: str | None = None,
+    ) -> PlaybackActionResult:
+        raise NotImplementedError
+
+    def update_progress(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        progress_percent: float,
+        *,
+        instance_id: str,
+        instance_label: str,
+    ) -> PlaybackActionResult:
+        raise NotImplementedError
+
+
+def public_failure(
+    *,
+    provider: str,
+    instance_id: str,
+    operation: str,
+    message: str,
+    error_code: str = "provider_error",
+    remote_status: int | None = None,
+    retryable: bool = False,
+    remote_id: str = "",
+    canonical_key: str = "",
+) -> PlaybackActionResult:
+    return PlaybackActionResult(
+        ok=False,
+        provider=provider,
+        instance_id=instance_id,
+        operation=operation,
+        remote_id=remote_id,
+        canonical_key=canonical_key,
+        error_code=error_code,
+        message=message,
+        remote_status=remote_status,
+        retryable=retryable,
+    )
+
+
+def configured_label(block: Mapping[str, Any] | None, fallback: str) -> str:
+    if isinstance(block, Mapping):
+        for key in ("label", "name", "account_label"):
+            value = str(block.get(key) or "").strip()
+            if value:
+                return value
+    return fallback

--- a/services/playback_progress/adapters/mdblist.py
+++ b/services/playback_progress/adapters/mdblist.py
@@ -1,0 +1,468 @@
+# /services/playback_progress/adapters/mdblist.py
+# CrossWatch - MDBList Playback Progress Adapter
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from typing import Any, Mapping, cast
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from providers.sync._mod_MDBLIST import MDBLISTModule, OPS as MDBLIST_OPS
+from providers.sync.mdblist._common import iso_ok, iso_z, max_iso
+
+from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
+from .base import PlaybackProgressAdapter, public_failure
+
+
+MDBLIST_PLAYBACK_REASON = ""
+
+
+def _int(value: Any) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(value)
+    except Exception:
+        return None
+
+
+def _float(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _first_str(*values: Any) -> str:
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return ""
+
+
+def _duration_seconds_from_sources(*sources: Mapping[str, Any]) -> int | None:
+    for source in sources:
+        for key in ("runtime_ms", "duration_ms"):
+            value = _float(source.get(key))
+            if value and value > 0:
+                return int(round(value / 1000.0))
+        for key in ("runtime_seconds", "duration_seconds"):
+            value = _float(source.get(key))
+            if value and value > 0:
+                return int(round(value))
+        for key in ("runtime", "runtime_minutes", "duration_minutes"):
+            value = _float(source.get(key))
+            if value and value > 0:
+                return int(round(value * 60.0))
+        duration = _float(source.get("duration"))
+        if duration and duration > 0:
+            return int(round(duration * 60.0 if duration <= 600 else duration))
+    return None
+
+
+def _remaining_seconds(duration_seconds: int | None, progress_percent: float | None) -> int | None:
+    if duration_seconds is None or progress_percent is None or duration_seconds <= 0:
+        return None
+    remaining = int(round(duration_seconds * max(0.0, 100.0 - min(progress_percent, 100.0)) / 100.0))
+    return remaining if remaining > 0 else None
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _ids(obj: Any) -> dict[str, Any]:
+    if not isinstance(obj, Mapping):
+        return {}
+    raw_ids = obj.get("ids")
+    raw = raw_ids if isinstance(raw_ids, Mapping) else obj
+    if not isinstance(raw, Mapping):
+        return {}
+    out: dict[str, Any] = {}
+    for key in ("imdb", "tmdb", "tvdb", "trakt", "mdblist"):
+        value = raw.get(key) or raw.get(f"{key}_id")
+        if value is None or value == "":
+            continue
+        if key in {"tmdb", "tvdb", "trakt"}:
+            try:
+                out[key] = int(value)
+            except Exception:
+                continue
+        elif key == "imdb":
+            text = str(value).strip()
+            if text and not text.startswith("tt") and text.isdigit():
+                text = f"tt{text}"
+            if text:
+                out[key] = text
+        else:
+            out[key] = str(value).strip()
+    return out
+
+
+def _module(config_view: Mapping[str, Any], instance_id: str) -> MDBLISTModule:
+    mod = MDBLISTModule(config_view)
+    # MDBLISTModule normally chooses its instance from sync-pair env vars. Playback Progress
+    # carries the selected instance explicitly, so keep the request auth on that instance.
+    mod.instance_id = instance_id
+    try:
+        mod.client.instance_id = instance_id
+    except Exception:
+        pass
+    return mod
+
+
+def _history_item(record: Mapping[str, Any]) -> dict[str, Any]:
+    meta = _as_mapping(record.get("provider_metadata"))
+    history_value = meta.get("history_item")
+    hist = history_value if isinstance(history_value, Mapping) else None
+    if hist:
+        return clean_mapping(hist)
+    media_type = str(record.get("media_type") or "").lower()
+    ids = clean_mapping(record.get("ids") if isinstance(record.get("ids"), Mapping) else {})
+    item: dict[str, Any] = {
+        "type": "episode" if media_type == "episode" else "movie",
+        "ids": ids,
+        "title": record.get("episode_title") or record.get("title") or record.get("series_title"),
+        "year": record.get("year"),
+    }
+    if media_type == "episode":
+        item["show_ids"] = clean_mapping(_as_mapping(meta.get("show_ids"))) or ids
+        item["series_title"] = record.get("series_title")
+        item["season"] = record.get("season")
+        item["episode"] = record.get("episode")
+    return clean_mapping(item)
+
+
+def _progress_body_from_record(record: Mapping[str, Any], progress_percent: float) -> dict[str, Any]:
+    item = _history_item(record)
+    media_type = str(record.get("media_type") or item.get("type") or "").lower()
+    ids = clean_mapping(item.get("ids") if isinstance(item.get("ids"), Mapping) else {})
+    body: dict[str, Any] = {"progress": progress_percent}
+    if media_type == "movie":
+        movie: dict[str, Any] = {}
+        if ids:
+            movie["ids"] = ids
+        if item.get("title"):
+            movie["title"] = item.get("title")
+        if item.get("year") is not None:
+            movie["year"] = item.get("year")
+        body["movie"] = movie
+        return clean_mapping(body)
+    show_ids = clean_mapping(item.get("show_ids") if isinstance(item.get("show_ids"), Mapping) else {})
+    show: dict[str, Any] = {}
+    if show_ids:
+        show["ids"] = show_ids
+    if item.get("series_title"):
+        show["title"] = item.get("series_title")
+    episode: dict[str, Any] = {}
+    if item.get("season") is not None:
+        episode["season"] = item.get("season")
+    if item.get("episode") is not None:
+        episode["number"] = item.get("episode")
+    if ids:
+        episode["ids"] = ids
+    body["show"] = show
+    body["episode"] = episode
+    return clean_mapping(body)
+
+
+class MDBListPlaybackAdapter(PlaybackProgressAdapter):
+    provider = "mdblist"
+    provider_label = "MDBList"
+
+    def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
+        configured = False
+        try:
+            configured = bool(MDBLIST_OPS.is_configured(config_view))
+        except Exception:
+            configured = False
+        reason = "" if configured else "MDBList is not connected for this instance."
+        return PlaybackCapabilities(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            configured=configured,
+            read=configured,
+            remove_progress=configured,
+            mark_watched=configured,
+            update_progress=configured,
+            bulk_remove_progress=configured,
+            bulk_mark_watched=configured,
+            bulk_update_progress=configured,
+            supports_movies=configured,
+            supports_episodes=configured,
+            supports_anime=False,
+            reason=reason,
+        )
+
+    def activity_marker(self, config_view: Mapping[str, Any], *, instance_id: str = "default") -> str:
+        try:
+            mod = _module(config_view, instance_id)
+            data = mod.client.last_activities()
+            if not isinstance(data, Mapping):
+                return ""
+            latest: str | None = None
+            for key in ("paused_at", "episode_paused_at"):
+                value = data.get(key)
+                if iso_ok(value):
+                    latest = max_iso(latest, iso_z(str(value)))
+            return latest or ""
+        except Exception:
+            return ""
+
+    def list_progress(
+        self,
+        config_view: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+        force_refresh: bool = False,
+    ) -> PlaybackListResult:
+        try:
+            mod = _module(config_view, instance_id)
+            response = mod.client.get(f"{mod.client.BASE}/sync/playback", params={"apikey": mod.cfg.api_key})
+            if not (200 <= response.status_code < 300):
+                return PlaybackListResult(
+                    ok=False,
+                    provider=self.provider,
+                    instance_id=instance_id,
+                    error_code=f"http:{response.status_code}",
+                    message="MDBList playback request failed.",
+                    remote_status=response.status_code,
+                    retryable=response.status_code in {408, 429, 500, 502, 503, 504},
+                )
+            data = response.json() if (response.text or "").strip() else []
+            rows: list[Mapping[str, Any]] = []
+            if isinstance(data, list):
+                rows = [row for row in data if isinstance(row, Mapping)]
+            elif isinstance(data, Mapping):
+                for key in ("playback", "items", "sessions", "movies", "episodes"):
+                    value = data.get(key)
+                    if isinstance(value, list):
+                        rows.extend(row for row in value if isinstance(row, Mapping))
+            caps = self.capabilities(config_view, instance_id=instance_id, instance_label=instance_label)
+            items = [self._normalize(row, instance_id, instance_label, caps) for row in rows]
+            return PlaybackListResult(
+                ok=True,
+                provider=self.provider,
+                instance_id=instance_id,
+                items=[item for item in items if item],
+                refreshed_at=utc_now_iso(),
+            )
+        except Exception:
+            return PlaybackListResult(
+                ok=False,
+                provider=self.provider,
+                instance_id=instance_id,
+                error_code="provider_error",
+                message="MDBList playback request failed.",
+                retryable=True,
+            )
+
+    def _normalize(
+        self,
+        row: Mapping[str, Any],
+        instance_id: str,
+        instance_label: str,
+        caps: PlaybackCapabilities,
+    ) -> PlaybackRecord | None:
+        remote_id = _first_str(row.get("id"), row.get("playback_id"), row.get("session_id"))
+        if not remote_id:
+            return None
+        row_type = str(row.get("type") or "").strip().lower()
+        movie = _as_mapping(row.get("movie"))
+        show = _as_mapping(row.get("show"))
+        episode_obj = _as_mapping(row.get("episode"))
+        season_obj = _as_mapping(row.get("season"))
+        show_season_obj = _as_mapping(show.get("season"))
+        show_episode_obj = _as_mapping(show_season_obj.get("episode"))
+
+        if movie or row_type == "movie":
+            payload = movie or row
+            ids = _ids(payload)
+            title = _first_str(payload.get("title"), payload.get("name"), row.get("title"))
+            year = _int(payload.get("year") or row.get("year"))
+            item = id_minimal({"type": "movie", "ids": ids, "title": title, "year": year})
+            history_item = dict(item)
+            media_type = "movie"
+            canonical = canonical_key(item) or ""
+            series_title = ""
+            episode_title = ""
+            season_no = None
+            episode_no = None
+        else:
+            show_ids = _ids(show or row)
+            ep_ids = _ids(episode_obj)
+            series_title = _first_str(show.get("title"), show.get("name"), row.get("series_title"), row.get("show_title"), row.get("title"))
+            episode_title = _first_str(episode_obj.get("title"), episode_obj.get("name"), row.get("episode_title"))
+            season_no = _int(
+                episode_obj.get("season")
+                or season_obj.get("number")
+                or show_season_obj.get("number")
+                or row.get("season")
+                or row.get("season_number")
+            )
+            episode_no = _int(
+                episode_obj.get("number")
+                or episode_obj.get("episode")
+                or show_episode_obj.get("number")
+                or show_episode_obj.get("episode")
+                or row.get("episode")
+                or row.get("episode_number")
+            )
+            ids = ep_ids or show_ids
+            item = id_minimal(
+                {
+                    "type": "episode",
+                    "ids": ids,
+                    "show_ids": show_ids or ids,
+                    "series_title": series_title,
+                    "title": episode_title or series_title,
+                    "season": season_no,
+                    "episode": episode_no,
+                }
+            )
+            history_item = dict(item)
+            media_type = "episode"
+            canonical = canonical_key(item) or ""
+            title = series_title or episode_title
+            year = _int(show.get("year") or row.get("year"))
+
+        updated = _first_str(row.get("paused_at"), row.get("updated_at"), row.get("progress_at")) or None
+        progress = _float(row.get("progress") or row.get("progress_percent") or row.get("percent"))
+        duration = _duration_seconds_from_sources(row, movie, show, episode_obj)
+        remaining = _remaining_seconds(duration, progress)
+        return PlaybackRecord(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            remote_id=remote_id,
+            canonical_key=canonical,
+            media_type=media_type,
+            title=title,
+            episode_title=episode_title,
+            series_title=series_title,
+            season=season_no,
+            episode=episode_no,
+            year=year,
+            ids=ids,
+            progress_percent=progress,
+            remaining_seconds=remaining,
+            duration_seconds=duration,
+            progress_at=updated,
+            updated_at=updated,
+            source_app=_first_str(row.get("app"), row.get("source_app"), row.get("application")),
+            source_device=_first_str(row.get("device"), row.get("source_device")),
+            rating=_float(row.get("rating")),
+            poster_url=_first_str(row.get("poster"), row.get("poster_url")),
+            backdrop_url=_first_str(row.get("backdrop"), row.get("backdrop_url"), row.get("fanart")),
+            can_remove_progress=caps.remove_progress,
+            can_mark_watched=caps.mark_watched,
+            can_update_progress=caps.update_progress,
+            capability_messages=[] if caps.configured else [caps.reason],
+            provider_metadata={
+                "history_item": history_item,
+                "show_ids": clean_mapping(history_item.get("show_ids") if isinstance(history_item.get("show_ids"), Mapping) else {}),
+            },
+        )
+
+    def remove_progress(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+    ) -> PlaybackActionResult:
+        remote_id = str(record.get("remote_id") or "").strip()
+        if not remote_id:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Missing MDBList playback record id.", error_code="missing_remote_id")
+        try:
+            mod = _module(config_view, instance_id)
+            response = mod.client.post(
+                f"{mod.client.BASE}/scrobble/clear",
+                params={"apikey": mod.cfg.api_key},
+                json={"id": int(remote_id) if remote_id.isdigit() else remote_id},
+            )
+            if response.status_code in {200, 201, 202, 204, 404}:
+                return PlaybackActionResult(
+                    ok=True,
+                    provider=self.provider,
+                    instance_id=instance_id,
+                    operation="remove_progress",
+                    remote_id=remote_id,
+                    canonical_key=str(record.get("canonical_key") or ""),
+                    message="Playback record removed." if response.status_code != 404 else "Playback record was already absent.",
+                    remote_status=response.status_code,
+                )
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="MDBList remove progress failed.", error_code=f"http:{response.status_code}", remote_status=response.status_code, retryable=response.status_code in {408, 429, 500, 502, 503, 504}, remote_id=remote_id, canonical_key=str(record.get("canonical_key") or ""))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="MDBList remove progress failed.", retryable=True, remote_id=remote_id, canonical_key=str(record.get("canonical_key") or ""))
+
+    def mark_watched(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+        watched_at: str | None = None,
+    ) -> PlaybackActionResult:
+        item = _history_item(record)
+        if watched_at:
+            item["watched_at"] = watched_at
+        elif not item.get("watched_at"):
+            item["watched_at"] = utc_now_iso()
+        try:
+            result = MDBLIST_OPS.add(config_view, [item], feature="history")
+            ok = bool(result.get("ok"))
+            return PlaybackActionResult(
+                ok=ok,
+                provider=self.provider,
+                instance_id=instance_id,
+                operation="mark_watched",
+                remote_id=str(record.get("remote_id") or ""),
+                canonical_key=str(record.get("canonical_key") or ""),
+                message="Marked watched on MDBList." if ok else "MDBList mark watched failed.",
+                error_code="" if ok else "history_failed",
+                history_result=clean_mapping(result),
+            )
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="mark_watched", message="MDBList mark watched failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+
+    def update_progress(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        progress_percent: float,
+        *,
+        instance_id: str,
+        instance_label: str,
+    ) -> PlaybackActionResult:
+        try:
+            mod = _module(config_view, instance_id)
+            response = mod.client.post(
+                f"{mod.client.BASE}/scrobble/pause",
+                params={"apikey": mod.cfg.api_key},
+                json=_progress_body_from_record(record, progress_percent),
+            )
+            if response.status_code in {200, 201, 202}:
+                return PlaybackActionResult(
+                    ok=True,
+                    provider=self.provider,
+                    instance_id=instance_id,
+                    operation="update_progress",
+                    remote_id=str(record.get("remote_id") or ""),
+                    canonical_key=str(record.get("canonical_key") or ""),
+                    message=f"Progress updated on MDBList to {progress_percent:g}%.",
+                    remote_status=response.status_code,
+                )
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message="MDBList update progress failed.", error_code=f"http:{response.status_code}", remote_status=response.status_code, retryable=response.status_code in {408, 429, 500, 502, 503, 504}, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message="MDBList update progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))

--- a/services/playback_progress/adapters/media_servers.py
+++ b/services/playback_progress/adapters/media_servers.py
@@ -1,0 +1,442 @@
+# /services/playback_progress/adapters/media_servers.py
+# CrossWatch - Media Server Playback Progress Adapters
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from typing import Any, Mapping, cast
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from providers.metadata._meta_TMDB import TmdbProvider
+
+from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
+from .base import PlaybackProgressAdapter, public_failure
+
+try:
+    from providers.sync._mod_EMBY import OPS as EMBY_OPS
+except Exception:
+    EMBY_OPS = None  # type: ignore[assignment]
+
+try:
+    from providers.sync._mod_JELLYFIN import OPS as JELLYFIN_OPS
+except Exception:
+    JELLYFIN_OPS = None  # type: ignore[assignment]
+
+try:
+    from providers.sync._mod_PLEX import OPS as PLEX_OPS, PLEXModule
+    from providers.sync.plex._progress import _resolve_rating_key as _plex_resolve_rating_key
+except Exception:
+    PLEX_OPS = None  # type: ignore[assignment]
+    PLEXModule = None  # type: ignore[assignment]
+    _plex_resolve_rating_key = None  # type: ignore[assignment]
+
+
+def _int(value: Any) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(float(str(value).strip()))
+    except Exception:
+        return None
+
+
+def _float(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _first_str(*values: Any) -> str:
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return ""
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _ms_to_seconds(value: Any) -> int | None:
+    n = _int(value)
+    return int(round(n / 1000.0)) if n and n > 0 else None
+
+
+def _progress_percent(progress_ms: int | None, duration_ms: int | None) -> float | None:
+    if progress_ms is None or duration_ms is None or duration_ms <= 0:
+        return None
+    return round((float(progress_ms) / float(duration_ms)) * 100.0, 3)
+
+
+def _progress_ms_for_percent(record: Mapping[str, Any], progress_percent: float) -> tuple[int | None, str]:
+    duration_seconds = _int(record.get("duration_seconds"))
+    if duration_seconds is None:
+        progress_item = _as_mapping(_as_mapping(record.get("provider_metadata")).get("progress_item"))
+        duration_seconds = _ms_to_seconds(progress_item.get("duration_ms") or progress_item.get("duration"))
+    if duration_seconds is None or duration_seconds <= 0:
+        return None, "missing_duration"
+    duration_ms = duration_seconds * 1000
+    progress_ms = int(round((float(progress_percent) / 100.0) * float(duration_ms)))
+    progress_ms = max(1, min(duration_ms - 1, progress_ms))
+    return progress_ms, ""
+
+
+def _history_item(record: Mapping[str, Any], provider: str) -> dict[str, Any]:
+    meta = _as_mapping(record.get("provider_metadata"))
+    history_value = meta.get("history_item")
+    if isinstance(history_value, Mapping):
+        out = clean_mapping(history_value)
+        remote_id = _first_str(record.get("remote_id"))
+        if remote_id:
+            ids = out.get("ids")
+            if not isinstance(ids, dict):
+                ids = {}
+                out["ids"] = ids
+            ids[provider] = remote_id
+        return clean_mapping(out)
+    media_type = str(record.get("media_type") or "").lower()
+    ids = clean_mapping(record.get("ids") if isinstance(record.get("ids"), Mapping) else {})
+    remote_id = _first_str(record.get("remote_id"))
+    if remote_id and provider in {"plex", "emby", "jellyfin"}:
+        ids.setdefault(provider, remote_id)
+    item: dict[str, Any] = {
+        "type": "episode" if media_type in {"episode", "anime_episode"} else "movie",
+        "title": record.get("episode_title") or record.get("title") or record.get("series_title"),
+        "series_title": record.get("series_title"),
+        "year": record.get("year"),
+        "season": record.get("season"),
+        "episode": record.get("episode"),
+        "ids": ids,
+    }
+    show_ids = _as_mapping(meta.get("show_ids"))
+    if show_ids:
+        item["show_ids"] = clean_mapping(show_ids)
+    return clean_mapping(item)
+
+
+def _successful_write(result: Mapping[str, Any]) -> bool:
+    if not bool(result.get("ok")):
+        return False
+    count = _int(result.get("count"))
+    unresolved = result.get("unresolved")
+    if count and count > 0:
+        return True
+    return count == 0 and isinstance(unresolved, list) and len(unresolved) == 0
+
+
+def _has_metadata_ids(ids: Mapping[str, Any]) -> bool:
+    return any(_first_str(ids.get(key)) for key in ("tmdb", "imdb", "tvdb"))
+
+
+def _metadata_provider(config_view: Mapping[str, Any]) -> TmdbProvider | None:
+    tmdb = _as_mapping(config_view.get("tmdb"))
+    metadata = _as_mapping(config_view.get("metadata"))
+    if not _first_str(tmdb.get("api_key"), metadata.get("tmdb_api_key")):
+        return None
+    cfg = dict(config_view)
+    return TmdbProvider(lambda: cfg, lambda _cfg: None)
+
+
+def _resolve_with_metadata(
+    provider: TmdbProvider | None,
+    *,
+    entity: str,
+    title: str,
+    year: Any,
+    ids: Mapping[str, Any],
+) -> dict[str, Any]:
+    if _has_metadata_ids(ids):
+        return dict(ids)
+    if provider is None or not title:
+        return dict(ids)
+    lookup_ids = {str(k): str(v) for k, v in ids.items() if v}
+    lookup_ids["title"] = title
+    if year:
+        lookup_ids["year"] = str(year)
+    try:
+        resolved = provider.fetch(
+            entity=entity,
+            ids=lookup_ids,
+            need={"ids": True, "poster": False, "backdrop": False},
+        )
+    except Exception:
+        return dict(ids)
+    resolved_ids = resolved.get("ids") if isinstance(resolved, Mapping) else None
+    if not isinstance(resolved_ids, Mapping):
+        return dict(ids)
+    out = dict(ids)
+    out.update({str(k): v for k, v in resolved_ids.items() if v})
+    return out
+
+
+class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
+    provider = ""
+    provider_label = ""
+    ops: Any = None
+    module_cls: Any = None
+
+    def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
+        configured = False
+        reason = ""
+        if self.ops is None:
+            reason = f"{self.provider_label} playback support is unavailable in this installation."
+        else:
+            try:
+                configured = bool(self.ops.is_configured(config_view))
+            except Exception:
+                configured = False
+            if not configured:
+                reason = f"{self.provider_label} is not connected for this instance."
+        can_use = bool(configured and self.ops is not None)
+        return PlaybackCapabilities(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            configured=configured,
+            read=can_use,
+            remove_progress=can_use,
+            mark_watched=can_use,
+            update_progress=can_use,
+            bulk_remove_progress=can_use,
+            bulk_mark_watched=can_use,
+            bulk_update_progress=can_use,
+            supports_movies=True,
+            supports_episodes=True,
+            supports_anime=False,
+            reason=reason,
+        )
+
+    def list_progress(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str, force_refresh: bool = False) -> PlaybackListResult:
+        if self.ops is None:
+            return PlaybackListResult(ok=False, provider=self.provider, instance_id=instance_id, error_code="provider_unavailable", message=f"{self.provider_label} playback support is unavailable.", retryable=False)
+        try:
+            caps = self.capabilities(config_view, instance_id=instance_id, instance_label=instance_label)
+            rows = self.ops.build_index(config_view, feature="progress")
+            metadata_provider = _metadata_provider(config_view)
+            items = [
+                record
+                for key, row in (rows or {}).items()
+                if isinstance(row, Mapping)
+                for record in [self._normalize(str(key), row, metadata_provider, instance_id, instance_label, caps)]
+                if record is not None
+            ]
+            return PlaybackListResult(ok=True, provider=self.provider, instance_id=instance_id, items=items, refreshed_at=utc_now_iso())
+        except Exception:
+            return PlaybackListResult(ok=False, provider=self.provider, instance_id=instance_id, error_code="provider_error", message=f"{self.provider_label} playback request failed.", retryable=True)
+
+    def _normalize(
+        self,
+        key: str,
+        row: Mapping[str, Any],
+        metadata_provider: TmdbProvider | None,
+        instance_id: str,
+        instance_label: str,
+        caps: PlaybackCapabilities,
+    ) -> PlaybackRecord | None:
+        ids = clean_mapping(row.get("ids") if isinstance(row.get("ids"), Mapping) else {})
+        remote_id = _first_str(row.get(f"{self.provider}_item_id"), row.get("_item_id"), row.get("ratingKey"), ids.get(self.provider), row.get("id"))
+        if not remote_id:
+            remote_id = key if key and not key.startswith("unknown:") else ""
+        media_type = str(row.get("type") or "movie").strip().lower()
+        if media_type not in {"movie", "episode", "anime_episode"}:
+            media_type = "episode" if media_type in {"show", "season"} else "movie"
+        title = _first_str(row.get("series_title") if media_type in {"episode", "anime_episode"} else None, row.get("title"))
+        episode_title = _first_str(row.get("title")) if media_type in {"episode", "anime_episode"} else ""
+        series_title = _first_str(row.get("series_title")) if media_type in {"episode", "anime_episode"} else ""
+        show_ids = clean_mapping(row.get("show_ids") if isinstance(row.get("show_ids"), Mapping) else {})
+        if media_type in {"episode", "anime_episode"}:
+            show_ids = _resolve_with_metadata(metadata_provider, entity="tv", title=series_title or title, year=row.get("year"), ids=show_ids)
+            if not _has_metadata_ids(ids) and _has_metadata_ids(show_ids):
+                ids = dict(ids)
+                for key_name in ("tmdb", "imdb", "tvdb"):
+                    if show_ids.get(key_name):
+                        ids.setdefault(key_name, show_ids.get(key_name))
+        else:
+            ids = _resolve_with_metadata(metadata_provider, entity="movie", title=title, year=row.get("year"), ids=ids)
+        progress_ms = _int(row.get("progress_ms") or row.get("viewOffset") or row.get("view_offset"))
+        duration_ms = _int(row.get("duration_ms") or row.get("duration"))
+        progress = _progress_percent(progress_ms, duration_ms)
+        duration_seconds = _ms_to_seconds(duration_ms)
+        remaining_seconds = _ms_to_seconds((duration_ms - progress_ms) if duration_ms and progress_ms is not None else None)
+        item = id_minimal(
+            {
+                "type": "episode" if media_type in {"episode", "anime_episode"} else "movie",
+                "title": episode_title or title,
+                "series_title": series_title,
+                "year": row.get("year"),
+                "season": row.get("season"),
+                "episode": row.get("episode"),
+                "ids": ids,
+                "show_ids": show_ids,
+            }
+        )
+        canonical = canonical_key(item) or key or ""
+        return PlaybackRecord(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            remote_id=remote_id,
+            canonical_key=canonical,
+            media_type=media_type,
+            title=title,
+            episode_title=episode_title,
+            series_title=series_title,
+            season=_int(row.get("season")),
+            episode=_int(row.get("episode")),
+            year=_int(row.get("year")),
+            ids=ids,
+            progress_percent=progress,
+            remaining_seconds=remaining_seconds,
+            duration_seconds=duration_seconds,
+            progress_at=_first_str(row.get("progress_at"), row.get("updated_at")) or None,
+            updated_at=_first_str(row.get("progress_at"), row.get("updated_at")) or None,
+            poster_url=_first_str(row.get("poster"), row.get("poster_url")),
+            backdrop_url=_first_str(row.get("backdrop"), row.get("backdrop_url"), row.get("fanart")),
+            can_remove_progress=caps.remove_progress,
+            can_mark_watched=caps.mark_watched,
+            can_update_progress=bool(caps.update_progress and duration_seconds),
+            capability_messages=[] if caps.configured else [caps.reason],
+            provider_metadata={
+                "history_item": clean_mapping(item),
+                "show_ids": clean_mapping(show_ids),
+                "progress_item": clean_mapping(row),
+            },
+        )
+
+    def remove_progress(self, config_view: Mapping[str, Any], record: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackActionResult:
+        if self.ops is None:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message=f"{self.provider_label} playback support is unavailable.", error_code="provider_unavailable")
+        if self.provider == "plex":
+            return self._remove_plex_progress(config_view, record, instance_id=instance_id)
+        item = _history_item(record, self.provider)
+        try:
+            result = self.ops.remove(config_view, [item], feature="progress")
+            ok = _successful_write(result)
+            return PlaybackActionResult(
+                ok=ok,
+                provider=self.provider,
+                instance_id=instance_id,
+                operation="remove_progress",
+                remote_id=str(record.get("remote_id") or ""),
+                canonical_key=str(record.get("canonical_key") or ""),
+                message=f"Playback record removed from {self.provider_label}." if ok else f"{self.provider_label} remove progress failed.",
+                error_code="" if ok else "progress_remove_failed",
+                playback_cleanup_result=clean_mapping(result),
+            )
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message=f"{self.provider_label} remove progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+
+    def _remove_plex_progress(self, config_view: Mapping[str, Any], record: Mapping[str, Any], *, instance_id: str) -> PlaybackActionResult:
+        if PLEXModule is None:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Plex playback support is unavailable.", error_code="provider_unavailable")
+        try:
+            module = PLEXModule(config_view)
+            item = _history_item(record, self.provider)
+            remote_id = str(record.get("remote_id") or "").strip()
+            rating_key = remote_id if remote_id.isdigit() else ""
+            if not rating_key and _plex_resolve_rating_key is not None:
+                rating_key = str(_plex_resolve_rating_key(module, item) or "")
+            if not rating_key:
+                return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Plex item could not be resolved.", error_code="not_found", remote_id=remote_id, canonical_key=str(record.get("canonical_key") or ""))
+            server = getattr(getattr(module, "client", None), "server", None)
+            if not server:
+                return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Plex Media Server is not available.", error_code="server_unavailable", retryable=True, remote_id=remote_id, canonical_key=str(record.get("canonical_key") or ""))
+            obj = server.fetchItem(int(rating_key))
+            mark_unplayed = getattr(obj, "markUnplayed", None) or getattr(obj, "markUnwatched", None)
+            if callable(mark_unplayed):
+                mark_unplayed()
+            else:
+                server.query(f"/:/unscrobble?key={rating_key}&identifier=com.plexapp.plugins.library")
+            return PlaybackActionResult(True, self.provider, instance_id, "remove_progress", remote_id=remote_id or rating_key, canonical_key=str(record.get("canonical_key") or ""), message="Playback record removed from Plex.")
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Plex remove progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+
+    def mark_watched(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+        watched_at: str | None = None,
+    ) -> PlaybackActionResult:
+        if self.ops is None:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="mark_watched", message=f"{self.provider_label} playback support is unavailable.", error_code="provider_unavailable")
+        item = _history_item(record, self.provider)
+        item["watched_at"] = watched_at or utc_now_iso()
+        try:
+            result = self.ops.add(config_view, [item], feature="history")
+            ok = _successful_write(result)
+            return PlaybackActionResult(
+                ok=ok,
+                provider=self.provider,
+                instance_id=instance_id,
+                operation="mark_watched",
+                remote_id=str(record.get("remote_id") or ""),
+                canonical_key=str(record.get("canonical_key") or ""),
+                message=f"Marked watched on {self.provider_label}." if ok else f"{self.provider_label} mark watched failed.",
+                error_code="" if ok else "history_failed",
+                history_result=clean_mapping(result),
+            )
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="mark_watched", message=f"{self.provider_label} mark watched failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+
+    def update_progress(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        progress_percent: float,
+        *,
+        instance_id: str,
+        instance_label: str,
+    ) -> PlaybackActionResult:
+        if self.ops is None:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message=f"{self.provider_label} playback support is unavailable.", error_code="provider_unavailable")
+        progress_ms, reason = _progress_ms_for_percent(record, progress_percent)
+        if progress_ms is None:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message=f"{self.provider_label} update progress failed: {reason}.", error_code=reason or "invalid_record", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+        item = _history_item(record, self.provider)
+        item["progress_ms"] = progress_ms
+        item["progress_at"] = utc_now_iso()
+        try:
+            result = self.ops.add(config_view, [item], feature="progress")
+            ok = _successful_write(result)
+            return PlaybackActionResult(
+                ok=ok,
+                provider=self.provider,
+                instance_id=instance_id,
+                operation="update_progress",
+                remote_id=str(record.get("remote_id") or ""),
+                canonical_key=str(record.get("canonical_key") or ""),
+                message=f"Progress updated on {self.provider_label} to {progress_percent:g}%." if ok else f"{self.provider_label} update progress failed.",
+                error_code="" if ok else "progress_update_failed",
+                playback_cleanup_result=clean_mapping(result),
+            )
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message=f"{self.provider_label} update progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+
+
+class PlexPlaybackAdapter(_MediaServerPlaybackAdapter):
+    provider = "plex"
+    provider_label = "Plex"
+    ops = PLEX_OPS
+    module_cls = PLEXModule
+
+
+class EmbyPlaybackAdapter(_MediaServerPlaybackAdapter):
+    provider = "emby"
+    provider_label = "Emby"
+    ops = EMBY_OPS
+
+
+class JellyfinPlaybackAdapter(_MediaServerPlaybackAdapter):
+    provider = "jellyfin"
+    provider_label = "Jellyfin"
+    ops = JELLYFIN_OPS

--- a/services/playback_progress/adapters/publicmetadb.py
+++ b/services/playback_progress/adapters/publicmetadb.py
@@ -1,0 +1,393 @@
+# /services/playback_progress/adapters/publicmetadb.py
+# CrossWatch - PublicMetaDB Playback Progress Adapter
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from typing import Any, Mapping, cast
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from providers.sync._mod_PUBLICMETADB import OPS as PUBLICMETADB_OPS, PUBLICMETADBModule
+
+from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
+from .base import PlaybackProgressAdapter, public_failure
+
+
+def _int(value: Any) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(value)
+    except Exception:
+        return None
+
+
+def _float(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _first_str(*values: Any) -> str:
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return ""
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _rows(data: Any) -> list[Mapping[str, Any]]:
+    if isinstance(data, list):
+        return [row for row in data if isinstance(row, Mapping)]
+    if not isinstance(data, Mapping):
+        return []
+    for key in ("items", "results", "data"):
+        value = data.get(key)
+        if isinstance(value, list):
+            return [row for row in value if isinstance(row, Mapping)]
+    return []
+
+
+def _ms_to_seconds(value: Any) -> int | None:
+    ms = _int(value)
+    if ms is None or ms <= 0:
+        return None
+    return max(1, round(ms / 1000))
+
+
+def _seconds_to_ms(value: Any) -> int | None:
+    seconds = _int(value)
+    if seconds is None or seconds <= 0:
+        return None
+    return int(seconds) * 1000
+
+
+def _history_item(record: Mapping[str, Any]) -> dict[str, Any]:
+    meta = _as_mapping(record.get("provider_metadata"))
+    history_value = meta.get("history_item")
+    hist = history_value if isinstance(history_value, Mapping) else None
+    if hist:
+        return clean_mapping(hist)
+
+    media_type = str(record.get("media_type") or "").lower()
+    ids = clean_mapping(record.get("ids") if isinstance(record.get("ids"), Mapping) else {})
+    item: dict[str, Any] = {
+        "type": "episode" if media_type in {"episode", "anime_episode"} else "movie",
+        "ids": ids,
+        "title": record.get("episode_title") or record.get("title") or record.get("series_title"),
+        "year": record.get("year"),
+    }
+    if item["type"] == "episode":
+        item["show_ids"] = clean_mapping(_as_mapping(meta.get("show_ids"))) or ids
+        item["series_title"] = record.get("series_title")
+        item["season"] = record.get("season")
+        item["episode"] = record.get("episode")
+    return clean_mapping(item)
+
+
+def _progress_payload_from_record(record: Mapping[str, Any], progress_percent: float) -> tuple[dict[str, Any] | None, str]:
+    meta = _as_mapping(record.get("provider_metadata"))
+    resume = _as_mapping(meta.get("resume_item"))
+    runtime_ms = _int(resume.get("runtime_ms") or resume.get("runtimeMs") or resume.get("duration_ms") or resume.get("durationMs")) or _seconds_to_ms(record.get("duration_seconds"))
+    if runtime_ms is None:
+        return None, "missing_duration"
+    position_ms = max(1, min(runtime_ms - 1, round((float(progress_percent) / 100.0) * float(runtime_ms))))
+    media_type = str(record.get("media_type") or "").lower()
+    ids = _as_mapping(record.get("ids"))
+    show_ids = _as_mapping(meta.get("show_ids")) or ids
+    tmdb = _int(show_ids.get("tmdb") if media_type in {"episode", "anime_episode"} else ids.get("tmdb"))
+    if tmdb is None:
+        tmdb = _int(resume.get("tmdb_id") or resume.get("tmdb"))
+    if tmdb is None:
+        return None, "missing_tmdb_id"
+    if media_type in {"episode", "anime_episode"}:
+        season = _int(record.get("season") or resume.get("season") or resume.get("season_number"))
+        episode = _int(record.get("episode") or resume.get("episode") or resume.get("episode_number"))
+        if season is None or episode is None:
+            return None, "missing_episode_numbers"
+        return {
+            "tmdb_id": int(tmdb),
+            "media_type": "tv",
+            "season": int(season),
+            "episode": int(episode),
+            "position_ms": int(position_ms),
+            "runtime_ms": int(runtime_ms),
+        }, ""
+    return {
+        "tmdb_id": int(tmdb),
+        "media_type": "movie",
+        "position_ms": int(position_ms),
+        "runtime_ms": int(runtime_ms),
+    }, ""
+
+
+class PublicMetaDBPlaybackAdapter(PlaybackProgressAdapter):
+    provider = "publicmetadb"
+    provider_label = "PublicMetaDB"
+
+    def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
+        configured = False
+        try:
+            configured = bool(PUBLICMETADB_OPS.is_configured(config_view))
+        except Exception:
+            configured = False
+        reason = "" if configured else "PublicMetaDB is not connected for this instance."
+        return PlaybackCapabilities(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            configured=configured,
+            read=configured,
+            remove_progress=configured,
+            mark_watched=configured,
+            update_progress=configured,
+            bulk_remove_progress=configured,
+            bulk_mark_watched=configured,
+            bulk_update_progress=configured,
+            supports_movies=configured,
+            supports_episodes=configured,
+            supports_anime=False,
+            reason=reason,
+        )
+
+    def list_progress(
+        self,
+        config_view: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+        force_refresh: bool = False,
+    ) -> PlaybackListResult:
+        try:
+            module = PUBLICMETADBModule(config_view)
+            page = 1
+            per_page = max(1, min(int(getattr(module.cfg, "progress_per_page", 100) or 100), 500))
+            max_pages = max(1, int(getattr(module.cfg, "progress_max_pages", 1000) or 1000))
+            rows: list[Mapping[str, Any]] = []
+            while page <= max_pages:
+                response = module.client.get("/api/external/resume", params={"page": page, "perPage": per_page})
+                if not (200 <= response.status_code < 300):
+                    return PlaybackListResult(
+                        ok=False,
+                        provider=self.provider,
+                        instance_id=instance_id,
+                        error_code=f"http:{response.status_code}",
+                        message="PublicMetaDB resume request failed.",
+                        remote_status=response.status_code,
+                        retryable=response.status_code in {408, 429, 500, 502, 503, 504},
+                    )
+                data = module.client.safe_json(response)
+                page_rows = _rows(data)
+                if not page_rows:
+                    break
+                rows.extend(page_rows)
+                total_pages = _int(data.get("totalPages") or data.get("total_pages")) if isinstance(data, Mapping) else None
+                if total_pages is None or page >= total_pages:
+                    break
+                page += 1
+
+            caps = self.capabilities(config_view, instance_id=instance_id, instance_label=instance_label)
+            items = [self._normalize(row, instance_id, instance_label, caps) for row in rows]
+            return PlaybackListResult(
+                ok=True,
+                provider=self.provider,
+                instance_id=instance_id,
+                items=[item for item in items if item],
+                refreshed_at=utc_now_iso(),
+            )
+        except Exception:
+            return PlaybackListResult(
+                ok=False,
+                provider=self.provider,
+                instance_id=instance_id,
+                error_code="provider_error",
+                message="PublicMetaDB resume request failed.",
+                retryable=True,
+            )
+
+    def _normalize(
+        self,
+        row: Mapping[str, Any],
+        instance_id: str,
+        instance_label: str,
+        caps: PlaybackCapabilities,
+    ) -> PlaybackRecord | None:
+        remote_id = _first_str(row.get("id"), row.get("resume_id"), row.get("_publicmetadb_resume_id"))
+        if not remote_id:
+            return None
+
+        media = str(row.get("media_type") or row.get("type") or "").strip().lower()
+        is_episode = media in {"tv", "show", "series", "episode"}
+        tmdb = _int(row.get("tmdb_id") or row.get("tmdb"))
+        ids = {"tmdb": tmdb} if tmdb is not None else {}
+        progress_ms = _int(row.get("position_ms") or row.get("positionMs") or row.get("progress_ms") or row.get("progressMs"))
+        runtime_ms = _int(row.get("runtime_ms") or row.get("runtimeMs") or row.get("duration_ms") or row.get("durationMs"))
+        progress = _float(row.get("progress") or row.get("progress_percent"))
+        if progress is None and progress_ms is not None and runtime_ms:
+            progress = round((float(progress_ms) / float(runtime_ms)) * 100.0, 3)
+        updated = _first_str(row.get("updated"), row.get("updated_at"), row.get("progress_at"), row.get("last_played")) or None
+
+        if is_episode:
+            series_title = _first_str(row.get("series_title"), row.get("show_title"), row.get("title"), row.get("name"))
+            episode_title = _first_str(row.get("episode_title"), row.get("episode_name"))
+            season_no = _int(row.get("season") or row.get("season_number"))
+            episode_no = _int(row.get("episode") or row.get("episode_number"))
+            item = id_minimal(
+                {
+                    "type": "episode",
+                    "ids": ids,
+                    "show_ids": ids,
+                    "series_title": series_title,
+                    "title": episode_title or series_title,
+                    "season": season_no,
+                    "episode": episode_no,
+                }
+            )
+            history_item = dict(item)
+            media_type = "episode"
+            title = series_title or episode_title
+            year = _int(row.get("year"))
+        else:
+            title = _first_str(row.get("title"), row.get("name"))
+            year = _int(row.get("year"))
+            item = id_minimal({"type": "movie", "ids": ids, "title": title, "year": year})
+            history_item = dict(item)
+            media_type = "movie"
+            series_title = ""
+            episode_title = ""
+            season_no = None
+            episode_no = None
+
+        canonical = canonical_key(item) or ""
+        duration_seconds = _ms_to_seconds(runtime_ms)
+        return PlaybackRecord(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            remote_id=remote_id,
+            canonical_key=canonical,
+            media_type=media_type,
+            title=title,
+            episode_title=episode_title,
+            series_title=series_title,
+            season=season_no,
+            episode=episode_no,
+            year=year,
+            ids=ids,
+            progress_percent=progress,
+            remaining_seconds=max(0, _ms_to_seconds(runtime_ms - progress_ms) or 0) if runtime_ms and progress_ms is not None else None,
+            duration_seconds=duration_seconds,
+            progress_at=updated,
+            updated_at=updated,
+            source_app=_first_str(row.get("app"), row.get("source_app"), row.get("application")),
+            source_device=_first_str(row.get("device"), row.get("source_device")),
+            rating=_float(row.get("rating")),
+            poster_url=_first_str(row.get("poster"), row.get("poster_url")),
+            backdrop_url=_first_str(row.get("backdrop"), row.get("backdrop_url"), row.get("fanart")),
+            can_remove_progress=caps.remove_progress,
+            can_mark_watched=caps.mark_watched,
+            can_update_progress=bool(caps.update_progress and duration_seconds),
+            capability_messages=[] if caps.configured else [caps.reason],
+            provider_metadata={
+                "history_item": history_item,
+                "show_ids": clean_mapping(history_item.get("show_ids") if isinstance(history_item.get("show_ids"), Mapping) else {}),
+                "resume_item": clean_mapping(row),
+            },
+        )
+
+    def remove_progress(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+    ) -> PlaybackActionResult:
+        remote_id = str(record.get("remote_id") or "").strip()
+        if not remote_id:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Missing PublicMetaDB resume record id.", error_code="missing_remote_id")
+        try:
+            module = PUBLICMETADBModule(config_view)
+            response = module.client.delete(f"/api/external/resume/{remote_id}")
+            if response.status_code in {200, 202, 204, 404}:
+                return PlaybackActionResult(
+                    ok=True,
+                    provider=self.provider,
+                    instance_id=instance_id,
+                    operation="remove_progress",
+                    remote_id=remote_id,
+                    canonical_key=str(record.get("canonical_key") or ""),
+                    message="Playback record removed." if response.status_code != 404 else "Playback record was already absent.",
+                    remote_status=response.status_code,
+                )
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="PublicMetaDB remove progress failed.", error_code=f"http:{response.status_code}", remote_status=response.status_code, retryable=response.status_code in {408, 429, 500, 502, 503, 504}, remote_id=remote_id, canonical_key=str(record.get("canonical_key") or ""))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="PublicMetaDB remove progress failed.", retryable=True, remote_id=remote_id, canonical_key=str(record.get("canonical_key") or ""))
+
+    def mark_watched(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+        watched_at: str | None = None,
+    ) -> PlaybackActionResult:
+        item = _history_item(record)
+        item["watched_at"] = watched_at or utc_now_iso()
+        try:
+            result = PUBLICMETADB_OPS.add(config_view, [item], feature="history")
+            ok = bool(result.get("ok"))
+            return PlaybackActionResult(
+                ok=ok,
+                provider=self.provider,
+                instance_id=instance_id,
+                operation="mark_watched",
+                remote_id=str(record.get("remote_id") or ""),
+                canonical_key=str(record.get("canonical_key") or ""),
+                message="Marked watched on PublicMetaDB." if ok else "PublicMetaDB mark watched failed.",
+                error_code="" if ok else "history_failed",
+                history_result=clean_mapping(result),
+            )
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="mark_watched", message="PublicMetaDB mark watched failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+
+    def update_progress(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        progress_percent: float,
+        *,
+        instance_id: str,
+        instance_label: str,
+    ) -> PlaybackActionResult:
+        payload, reason = _progress_payload_from_record(record, progress_percent)
+        if payload is None:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message=f"PublicMetaDB update progress failed: {reason}.", error_code=reason or "invalid_record", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+        try:
+            module = PUBLICMETADBModule(config_view)
+            response = module.client.post("/api/external/resume", json=payload)
+            if response.status_code in {200, 201, 202}:
+                return PlaybackActionResult(
+                    ok=True,
+                    provider=self.provider,
+                    instance_id=instance_id,
+                    operation="update_progress",
+                    remote_id=str(record.get("remote_id") or ""),
+                    canonical_key=str(record.get("canonical_key") or ""),
+                    message=f"Progress updated on PublicMetaDB to {progress_percent:g}%.",
+                    remote_status=response.status_code,
+                )
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message="PublicMetaDB update progress failed.", error_code=f"http:{response.status_code}", remote_status=response.status_code, retryable=response.status_code in {408, 429, 500, 502, 503, 504}, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message="PublicMetaDB update progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))

--- a/services/playback_progress/adapters/simkl.py
+++ b/services/playback_progress/adapters/simkl.py
@@ -1,0 +1,451 @@
+# /services/playback_progress/adapters/simkl.py
+# CrossWatch - Simkl Playback Progress Adapter
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping, cast
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from providers.sync._mod_SIMKL import OPS as SIMKL_OPS, SIMKLModule, __VERSION__ as SIMKL_MODULE_VERSION
+from providers.sync.simkl._common import build_headers, extract_latest_ts, fetch_activities
+
+from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
+from .base import PlaybackProgressAdapter, public_failure
+
+
+def _int(value: Any) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(value)
+    except Exception:
+        return None
+
+
+def _float(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _first_str(*values: Any) -> str:
+    for value in values:
+        if value is None:
+            continue
+        s = str(value).strip()
+        if s:
+            return s
+    return ""
+
+
+def _duration_seconds_from_sources(*sources: Mapping[str, Any]) -> int | None:
+    for source in sources:
+        for key in ("runtime_ms", "duration_ms"):
+            value = _float(source.get(key))
+            if value and value > 0:
+                return int(round(value / 1000.0))
+        for key in ("runtime_seconds", "duration_seconds"):
+            value = _float(source.get(key))
+            if value and value > 0:
+                return int(round(value))
+        for key in ("runtime", "runtime_minutes", "duration_minutes"):
+            value = _float(source.get(key))
+            if value and value > 0:
+                return int(round(value * 60.0))
+        duration = _float(source.get("duration"))
+        if duration and duration > 0:
+            return int(round(duration * 60.0 if duration <= 600 else duration))
+    return None
+
+
+def _remaining_seconds(duration_seconds: int | None, progress_percent: float | None) -> int | None:
+    if duration_seconds is None or progress_percent is None or duration_seconds <= 0:
+        return None
+    remaining = int(round(duration_seconds * max(0.0, 100.0 - min(progress_percent, 100.0)) / 100.0))
+    return remaining if remaining > 0 else None
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _api_params(api_key: str, **extra: Any) -> dict[str, Any]:
+    version = str(os.getenv("APP_VERSION") or SIMKL_MODULE_VERSION or "1.0").strip()
+    params: dict[str, Any] = {
+        "client_id": api_key,
+        "app-name": "crosswatch",
+        "app-version": version,
+    }
+    params.update({k: v for k, v in extra.items() if v is not None})
+    return params
+
+
+def _pick_container(row: Mapping[str, Any]) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
+    row_type = str(row.get("type") or "").lower()
+    episode = _as_mapping(row.get("episode"))
+    for key, media_type in (("movie", "movie"), ("show", "episode"), ("anime", "anime_episode")):
+        container_value = row.get(key)
+        if isinstance(container_value, Mapping):
+            return media_type, cast(Mapping[str, Any], container_value), episode
+    if row_type in {"movie", "movies"}:
+        return "movie", row, {}
+    if row_type in {"anime", "anime_episode"}:
+        anime = _as_mapping(row.get("anime"))
+        return "anime_episode", anime or row, episode
+    show = _as_mapping(row.get("show"))
+    return "episode", show or row, episode
+
+
+def _image_url(value: Any) -> str:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if isinstance(value, Mapping):
+        for key in ("poster", "medium", "large", "small", "url"):
+            s = _first_str(value.get(key))
+            if s:
+                return s
+    return ""
+
+
+def _history_item(record: Mapping[str, Any]) -> dict[str, Any]:
+    meta = _as_mapping(record.get("provider_metadata"))
+    history_value = meta.get("history_item")
+    hist = history_value if isinstance(history_value, Mapping) else None
+    if hist:
+        return clean_mapping(hist)
+    media_type = str(record.get("media_type") or "").lower()
+    return clean_mapping(
+        {
+            "type": "episode" if media_type in {"episode", "anime_episode"} else "movie",
+            "title": record.get("episode_title") or record.get("title") or record.get("series_title"),
+            "series_title": record.get("series_title"),
+            "year": record.get("year"),
+            "season": record.get("season"),
+            "episode": record.get("episode"),
+            "ids": record.get("ids") if isinstance(record.get("ids"), Mapping) else {},
+            "show_ids": _as_mapping(meta.get("show_ids")),
+        }
+    )
+
+
+def _progress_body_from_record(record: Mapping[str, Any], progress_percent: float) -> dict[str, Any]:
+    item = _history_item(record)
+    media_type = str(record.get("media_type") or item.get("type") or "").lower()
+    ids = clean_mapping(item.get("ids") if isinstance(item.get("ids"), Mapping) else {})
+    body: dict[str, Any] = {"progress": progress_percent}
+    if media_type == "movie":
+        movie: dict[str, Any] = {}
+        if ids:
+            movie["ids"] = ids
+        if item.get("title"):
+            movie["title"] = item.get("title")
+        if item.get("year") is not None:
+            movie["year"] = item.get("year")
+        body["movie"] = movie
+        return clean_mapping(body)
+    show_ids = clean_mapping(item.get("show_ids") if isinstance(item.get("show_ids"), Mapping) else {})
+    parent = "anime" if media_type == "anime_episode" else "show"
+    episode: dict[str, Any] = {}
+    if ids:
+        episode["ids"] = ids
+    if item.get("season") is not None:
+        episode["season"] = item.get("season")
+    if item.get("episode") is not None:
+        episode["number"] = item.get("episode")
+    if show_ids:
+        body[parent] = {"ids": show_ids}
+    body["episode"] = episode
+    return clean_mapping(body)
+
+
+class SimklPlaybackAdapter(PlaybackProgressAdapter):
+    provider = "simkl"
+    provider_label = "SIMKL"
+
+    def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
+        configured = False
+        try:
+            block = _as_mapping(config_view.get("simkl"))
+            configured = bool(
+                SIMKL_OPS.is_configured(config_view)
+                and str(block.get("api_key") or block.get("client_id") or "").strip()
+            )
+        except Exception:
+            configured = False
+        reason = "" if configured else "SIMKL is not connected for this instance or is missing its API key."
+        return PlaybackCapabilities(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            configured=configured,
+            read=configured,
+            remove_progress=configured,
+            mark_watched=configured,
+            update_progress=configured,
+            bulk_remove_progress=configured,
+            bulk_mark_watched=configured,
+            bulk_update_progress=configured,
+            supports_movies=configured,
+            supports_episodes=configured,
+            supports_anime=configured,
+            reason=reason,
+        )
+
+    def activity_marker(self, config_view: Mapping[str, Any]) -> str:
+        try:
+            module = SIMKLModule(config_view)
+            headers = build_headers({"simkl": {"api_key": module.cfg.api_key, "access_token": module.cfg.access_token}})
+            acts, _rate = fetch_activities(module.client.session, headers, timeout=float(module.cfg.timeout or 8.0))
+            if not isinstance(acts, Mapping):
+                return ""
+            latest = extract_latest_ts(
+                acts,
+                (
+                    ("playback",),
+                    ("playback", "updated_at"),
+                    ("movies", "playback"),
+                    ("shows", "playback"),
+                    ("anime", "playback"),
+                    ("all",),
+                ),
+            )
+            return str(latest or "")
+        except Exception:
+            return ""
+
+    def list_progress(
+        self,
+        config_view: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+        force_refresh: bool = False,
+    ) -> PlaybackListResult:
+        try:
+            module = SIMKLModule(config_view)
+            headers = build_headers(
+                {"simkl": {"api_key": module.cfg.api_key, "access_token": module.cfg.access_token}},
+                force_refresh=force_refresh,
+            )
+            caps = self.capabilities(config_view, instance_id=instance_id, instance_label=instance_label)
+            response = module.client._request(
+                "GET",
+                f"{module.client.BASE}/sync/playback",
+                headers=headers,
+                params=_api_params(module.cfg.api_key, limit=100, hide_watched="true"),
+            )
+            if not (200 <= response.status_code < 300):
+                detail = str(response.text or "").strip()
+                status = int(response.status_code)
+                message = "SIMKL playback request failed."
+                if detail:
+                    message = f"{message} {detail}"
+                return PlaybackListResult(
+                    ok=False,
+                    provider=self.provider,
+                    instance_id=instance_id,
+                    error_code=f"http:{status}",
+                    message=message,
+                    remote_status=status,
+                    retryable=status in {408, 429, 500, 502, 503, 504},
+                )
+            data = response.json() if (response.text or "").strip() else []
+            rows: list[Mapping[str, Any]] = []
+            if isinstance(data, list):
+                rows.extend([r for r in data if isinstance(r, Mapping)])
+            elif isinstance(data, Mapping):
+                for key in ("items", "playback", "movies", "episodes", "shows", "anime"):
+                    bucket = data.get(key)
+                    if isinstance(bucket, list):
+                        rows.extend([r for r in bucket if isinstance(r, Mapping)])
+            items = [self._normalize(row, instance_id, instance_label, caps) for row in rows]
+            return PlaybackListResult(ok=True, provider=self.provider, instance_id=instance_id, items=[x for x in items if x], refreshed_at=utc_now_iso())
+        except Exception:
+            return PlaybackListResult(ok=False, provider=self.provider, instance_id=instance_id, error_code="provider_error", message="SIMKL playback request failed.", retryable=True)
+
+    def _normalize(
+        self,
+        row: Mapping[str, Any],
+        instance_id: str,
+        instance_label: str,
+        caps: PlaybackCapabilities,
+    ) -> PlaybackRecord | None:
+        remote = _first_str(row.get("id"), row.get("playback_id"), row.get("session_id"))
+        if not remote:
+            return None
+        media_type, container, episode = _pick_container(row)
+        container_ids = clean_mapping(container.get("ids") if isinstance(container.get("ids"), Mapping) else row.get("ids") if isinstance(row.get("ids"), Mapping) else {})
+        episode_ids = clean_mapping(episode.get("ids") if isinstance(episode.get("ids"), Mapping) else {})
+        if media_type == "movie":
+            title = _first_str(container.get("title"), row.get("title"))
+            item = id_minimal({"type": "movie", "title": title, "year": container.get("year") or row.get("year"), "ids": container_ids})
+            history_item = dict(item)
+            key = canonical_key(item) or ""
+            series_title = ""
+            episode_title = ""
+            season = None
+            episode_no = None
+        else:
+            series_title = _first_str(container.get("title"), row.get("series_title"), row.get("show_title"))
+            episode_title = _first_str(episode.get("title"), row.get("episode_title"))
+            season = _int(episode.get("season") or row.get("season") or row.get("season_number"))
+            episode_no = _int(episode.get("episode") or episode.get("number") or row.get("episode") or row.get("episode_number"))
+            item = id_minimal(
+                {
+                    "type": "episode",
+                    "title": episode_title or series_title,
+                    "series_title": series_title,
+                    "year": container.get("year") or row.get("year"),
+                    "season": season,
+                    "episode": episode_no,
+                    "ids": episode_ids or container_ids,
+                    "show_ids": container_ids,
+                }
+            )
+            history_item = dict(item)
+            key = canonical_key(item) or ""
+            title = series_title or episode_title
+        poster = _image_url(row.get("poster") or container.get("poster") or container.get("poster_url") or container.get("image"))
+        backdrop = _image_url(row.get("backdrop") or row.get("fanart") or container.get("fanart") or container.get("backdrop"))
+        progress = _float(row.get("percent") or row.get("progress") or row.get("progress_percent"))
+        updated = _first_str(row.get("watched_at"), row.get("updated_at"), row.get("date"), row.get("last_watched_at")) or None
+        remaining = _int(row.get("remaining") or row.get("remaining_seconds"))
+        duration = _int(row.get("runtime_seconds") or row.get("duration_seconds")) or _duration_seconds_from_sources(row, container, episode)
+        if remaining is None and _int(row.get("remaining_mins")) is not None:
+            remaining = int(_int(row.get("remaining_mins")) or 0) * 60
+        if remaining is None:
+            remaining = _remaining_seconds(duration, progress)
+        return PlaybackRecord(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            remote_id=remote,
+            canonical_key=key,
+            media_type=media_type,
+            title=title,
+            episode_title=episode_title,
+            series_title=series_title,
+            season=season,
+            episode=episode_no,
+            year=_int(container.get("year") or row.get("year")),
+            ids=episode_ids or container_ids,
+            progress_percent=progress,
+            remaining_seconds=remaining,
+            duration_seconds=duration,
+            progress_at=updated,
+            updated_at=updated,
+            source_app=_first_str(row.get("app"), row.get("source_app"), row.get("application")),
+            source_device=_first_str(row.get("device"), row.get("source_device")),
+            rating=_float(row.get("rating")),
+            poster_url=poster,
+            backdrop_url=backdrop,
+            can_remove_progress=caps.remove_progress,
+            can_mark_watched=caps.mark_watched,
+            can_update_progress=caps.update_progress,
+            capability_messages=[] if caps.configured else [caps.reason],
+            provider_metadata={"history_item": history_item, "show_ids": container_ids},
+        )
+
+    def remove_progress(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+    ) -> PlaybackActionResult:
+        remote_id = str(record.get("remote_id") or "").strip()
+        if not remote_id:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Missing SIMKL playback record id.", error_code="missing_remote_id")
+        try:
+            module = SIMKLModule(config_view)
+            headers = build_headers({"simkl": {"api_key": module.cfg.api_key, "access_token": module.cfg.access_token}}, force_refresh=True)
+            response = module.client._request(
+                "DELETE",
+                f"{module.client.BASE}/sync/playback/{remote_id}",
+                headers=headers,
+                params=_api_params(module.cfg.api_key),
+            )
+            if response.status_code in {200, 202, 204, 404}:
+                return PlaybackActionResult(
+                    ok=True,
+                    provider=self.provider,
+                    instance_id=instance_id,
+                    operation="remove_progress",
+                    remote_id=remote_id,
+                    canonical_key=str(record.get("canonical_key") or ""),
+                    message="Playback record removed." if response.status_code != 404 else "Playback record was already absent.",
+                    remote_status=response.status_code,
+                )
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="SIMKL remove progress failed.", error_code=f"http:{response.status_code}", remote_status=response.status_code, retryable=response.status_code in {408, 429, 500, 502, 503, 504}, remote_id=remote_id, canonical_key=str(record.get("canonical_key") or ""))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="SIMKL remove progress failed.", retryable=True, remote_id=remote_id, canonical_key=str(record.get("canonical_key") or ""))
+
+    def mark_watched(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+        watched_at: str | None = None,
+    ) -> PlaybackActionResult:
+        item = _history_item(record)
+        if watched_at:
+            item["watched_at"] = watched_at
+        try:
+            result = SIMKL_OPS.add(config_view, [item], feature="history")
+            ok = bool(result.get("ok"))
+            return PlaybackActionResult(
+                ok=ok,
+                provider=self.provider,
+                instance_id=instance_id,
+                operation="mark_watched",
+                remote_id=str(record.get("remote_id") or ""),
+                canonical_key=str(record.get("canonical_key") or ""),
+                message="Marked watched on SIMKL." if ok else "SIMKL mark watched failed.",
+                error_code="" if ok else "history_failed",
+                history_result=clean_mapping(result),
+            )
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="mark_watched", message="SIMKL mark watched failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+
+    def update_progress(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        progress_percent: float,
+        *,
+        instance_id: str,
+        instance_label: str,
+    ) -> PlaybackActionResult:
+        try:
+            module = SIMKLModule(config_view)
+            headers = build_headers({"simkl": {"api_key": module.cfg.api_key, "access_token": module.cfg.access_token}}, force_refresh=True)
+            response = module.client._request(
+                "POST",
+                f"{module.client.BASE}/scrobble/pause",
+                headers=headers,
+                params=_api_params(module.cfg.api_key),
+                json=_progress_body_from_record(record, progress_percent),
+            )
+            if response.status_code in {200, 201, 202}:
+                return PlaybackActionResult(
+                    ok=True,
+                    provider=self.provider,
+                    instance_id=instance_id,
+                    operation="update_progress",
+                    remote_id=str(record.get("remote_id") or ""),
+                    canonical_key=str(record.get("canonical_key") or ""),
+                    message=f"Progress updated on SIMKL to {progress_percent:g}%.",
+                    remote_status=response.status_code,
+                )
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message="SIMKL update progress failed.", error_code=f"http:{response.status_code}", remote_status=response.status_code, retryable=response.status_code in {408, 429, 500, 502, 503, 504}, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message="SIMKL update progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))

--- a/services/playback_progress/adapters/trakt.py
+++ b/services/playback_progress/adapters/trakt.py
@@ -1,0 +1,383 @@
+# /services/playback_progress/adapters/trakt.py
+# CrossWatch - Trakt Playback Progress Adapter
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from providers.sync._mod_TRAKT import OPS as TRAKT_OPS, TRAKTModule
+
+from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
+from .base import PlaybackProgressAdapter, public_failure
+
+
+def _num(value: Any) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(value)
+    except Exception:
+        return None
+
+
+def _float(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _duration_seconds_from_sources(*sources: Mapping[str, Any]) -> int | None:
+    for source in sources:
+        for key in ("runtime_ms", "duration_ms"):
+            value = _float(source.get(key))
+            if value and value > 0:
+                return int(round(value / 1000.0))
+        for key in ("runtime_seconds", "duration_seconds"):
+            value = _float(source.get(key))
+            if value and value > 0:
+                return int(round(value))
+        for key in ("runtime", "runtime_minutes", "duration_minutes"):
+            value = _float(source.get(key))
+            if value and value > 0:
+                return int(round(value * 60.0))
+        duration = _float(source.get("duration"))
+        if duration and duration > 0:
+            return int(round(duration * 60.0 if duration <= 600 else duration))
+    return None
+
+
+def _remaining_seconds(duration_seconds: int | None, progress_percent: float | None) -> int | None:
+    if duration_seconds is None or progress_percent is None or duration_seconds <= 0:
+        return None
+    remaining = int(round(duration_seconds * max(0.0, 100.0 - min(progress_percent, 100.0)) / 100.0))
+    return remaining if remaining > 0 else None
+
+
+def _media_from_row(row: Mapping[str, Any]) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
+    row_type = str(row.get("type") or "").lower()
+    movie_value = row.get("movie")
+    episode_value = row.get("episode")
+    show_value = row.get("show")
+    movie: Mapping[str, Any] | None = movie_value if isinstance(movie_value, Mapping) else None
+    episode: Mapping[str, Any] | None = episode_value if isinstance(episode_value, Mapping) else None
+    show_payload: Mapping[str, Any] = show_value if isinstance(show_value, Mapping) else {}
+    if movie is not None:
+        return "movie", movie, {}
+    if episode is not None:
+        return "episode", episode, show_payload
+    if row_type == "movie":
+        return "movie", row, {}
+    return "episode", episode or row, show_payload
+
+
+def _history_item_from_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    meta = record.get("provider_metadata") if isinstance(record.get("provider_metadata"), Mapping) else {}
+    hist = meta.get("history_item") if isinstance(meta, Mapping) and isinstance(meta.get("history_item"), Mapping) else None
+    if hist:
+        out = dict(hist)
+    else:
+        media_type = str(record.get("media_type") or "").lower()
+        ids = clean_mapping(record.get("ids") if isinstance(record.get("ids"), Mapping) else {})
+        out = {
+            "type": "episode" if media_type in {"episode", "anime_episode"} else "movie",
+            "title": record.get("episode_title") or record.get("title") or record.get("series_title"),
+            "series_title": record.get("series_title") or "",
+            "year": record.get("year"),
+            "season": record.get("season"),
+            "episode": record.get("episode"),
+            "ids": ids,
+        }
+        show_ids = meta.get("show_ids") if isinstance(meta, Mapping) and isinstance(meta.get("show_ids"), Mapping) else None
+        if show_ids:
+            out["show_ids"] = clean_mapping(show_ids)
+    return clean_mapping(out)
+
+
+def _progress_body_from_record(record: Mapping[str, Any], progress_percent: float) -> dict[str, Any]:
+    item = _history_item_from_record(record)
+    media_type = str(record.get("media_type") or item.get("type") or "").lower()
+    ids = clean_mapping(item.get("ids") if isinstance(item.get("ids"), Mapping) else {})
+    body: dict[str, Any] = {"progress": progress_percent}
+    if media_type == "movie":
+        movie: dict[str, Any] = {}
+        if ids:
+            movie["ids"] = ids
+        if item.get("title"):
+            movie["title"] = item.get("title")
+        if item.get("year") is not None:
+            movie["year"] = item.get("year")
+        body["movie"] = movie
+        return clean_mapping(body)
+    show_ids = clean_mapping(item.get("show_ids") if isinstance(item.get("show_ids"), Mapping) else {})
+    episode: dict[str, Any] = {}
+    if ids:
+        episode["ids"] = ids
+    if item.get("season") is not None:
+        episode["season"] = item.get("season")
+    if item.get("episode") is not None:
+        episode["number"] = item.get("episode")
+    if item.get("title"):
+        episode["title"] = item.get("title")
+    if show_ids:
+        body["show"] = {"ids": show_ids}
+    body["episode"] = episode
+    return clean_mapping(body)
+
+
+class TraktPlaybackAdapter(PlaybackProgressAdapter):
+    provider = "trakt"
+    provider_label = "Trakt"
+
+    def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
+        configured = False
+        reason = ""
+        try:
+            trakt_block = config_view.get("trakt")
+            block: Mapping[str, Any] = trakt_block if isinstance(trakt_block, Mapping) else {}
+            configured = bool(TRAKT_OPS.is_configured(config_view) and str(block.get("client_id") or block.get("api_key") or "").strip())
+        except Exception:
+            configured = False
+        if not configured:
+            reason = "Trakt is not connected for this instance or is missing its client id."
+        return PlaybackCapabilities(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            configured=configured,
+            read=configured,
+            remove_progress=configured,
+            mark_watched=configured,
+            update_progress=configured,
+            bulk_remove_progress=configured,
+            bulk_mark_watched=configured,
+            bulk_update_progress=configured,
+            supports_movies=configured,
+            supports_episodes=configured,
+            supports_anime=False,
+            reason=reason,
+        )
+
+    def list_progress(
+        self,
+        config_view: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+        force_refresh: bool = False,
+    ) -> PlaybackListResult:
+        try:
+            module = TRAKTModule(config_view)
+            rows: list[Mapping[str, Any]] = []
+            seen_ids: set[str] = set()
+            first_error: tuple[int, str] | None = None
+            for kind in ("movies", "episodes"):
+                response = module.client.get(f"{module.client.BASE}/sync/playback/{kind}", params={"extended": "full,images"})
+                if not (200 <= response.status_code < 300):
+                    if first_error is None:
+                        first_error = (int(response.status_code), kind)
+                    continue
+                data = response.json() if (response.text or "").strip() else []
+                if not isinstance(data, list):
+                    continue
+                for row in data:
+                    if not isinstance(row, Mapping):
+                        continue
+                    row_id = str(row.get("id") or "").strip()
+                    if row_id and row_id in seen_ids:
+                        continue
+                    if row_id:
+                        seen_ids.add(row_id)
+                    rows.append(row)
+            if first_error and not rows:
+                status, kind = first_error
+                return PlaybackListResult(
+                    ok=False,
+                    provider=self.provider,
+                    instance_id=instance_id,
+                    error_code=f"http:{status}",
+                    message=f"Trakt playback {kind} request failed.",
+                    remote_status=status,
+                    retryable=status in {408, 429, 500, 502, 503, 504},
+                )
+            caps = self.capabilities(config_view, instance_id=instance_id, instance_label=instance_label)
+            items = [self._normalize(row, instance_id, instance_label, caps) for row in rows]
+            return PlaybackListResult(ok=True, provider=self.provider, instance_id=instance_id, items=[x for x in items if x], refreshed_at=utc_now_iso())
+        except Exception:
+            return PlaybackListResult(
+                ok=False,
+                provider=self.provider,
+                instance_id=instance_id,
+                error_code="provider_error",
+                message="Trakt playback request failed.",
+                retryable=True,
+            )
+
+    def _normalize(
+        self,
+        row: Mapping[str, Any],
+        instance_id: str,
+        instance_label: str,
+        caps: PlaybackCapabilities,
+    ) -> PlaybackRecord | None:
+        remote = str(row.get("id") or "").strip()
+        if not remote:
+            return None
+        media_type, payload, show = _media_from_row(row)
+        ids = clean_mapping(payload.get("ids") if isinstance(payload.get("ids"), Mapping) else {})
+        show_ids = clean_mapping(show.get("ids") if isinstance(show.get("ids"), Mapping) else {})
+        if media_type == "movie":
+            title = str(payload.get("title") or row.get("title") or "").strip()
+            item = id_minimal({"type": "movie", "title": title, "year": payload.get("year"), "ids": ids})
+            key = canonical_key(item) or ""
+            history_item = dict(item)
+            episode_title = ""
+            series_title = ""
+        else:
+            episode_title = str(payload.get("title") or "").strip()
+            series_title = str(show.get("title") or row.get("series_title") or "").strip()
+            title = series_title or episode_title
+            item = id_minimal(
+                {
+                    "type": "episode",
+                    "title": episode_title or series_title,
+                    "series_title": series_title,
+                    "year": show.get("year") or payload.get("year"),
+                    "season": payload.get("season"),
+                    "episode": payload.get("number") or payload.get("episode"),
+                    "ids": ids,
+                    "show_ids": show_ids,
+                }
+            )
+            key = canonical_key(item) or ""
+            history_item = dict(item)
+        images_payload = payload.get("images")
+        images: Mapping[str, Any] = images_payload if isinstance(images_payload, Mapping) else {}
+        poster = ""
+        backdrop = ""
+        try:
+            poster = str(((images.get("poster") or []) or [""])[0] or "")
+            backdrop = str(((images.get("fanart") or images.get("background") or []) or [""])[0] or "")
+        except Exception:
+            poster = ""
+            backdrop = ""
+        progress = _float(row.get("progress"))
+        duration = _duration_seconds_from_sources(payload, show, row)
+        updated = str(row.get("paused_at") or row.get("updated_at") or "").strip() or None
+        return PlaybackRecord(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            remote_id=remote,
+            canonical_key=key,
+            media_type=media_type,
+            title=title,
+            episode_title=episode_title,
+            series_title=series_title,
+            season=_num(payload.get("season")),
+            episode=_num(payload.get("number") or payload.get("episode")),
+            year=_num(payload.get("year") or show.get("year")),
+            ids=ids,
+            progress_percent=progress,
+            remaining_seconds=_remaining_seconds(duration, progress),
+            duration_seconds=duration,
+            progress_at=updated,
+            updated_at=updated,
+            poster_url=poster,
+            backdrop_url=backdrop,
+            can_remove_progress=caps.remove_progress,
+            can_mark_watched=caps.mark_watched,
+            can_update_progress=caps.update_progress,
+            capability_messages=[] if caps.configured else [caps.reason],
+            provider_metadata={"history_item": history_item, "show_ids": show_ids},
+        )
+
+    def remove_progress(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+    ) -> PlaybackActionResult:
+        remote_id = str(record.get("remote_id") or "").strip()
+        if not remote_id:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Missing Trakt playback record id.", error_code="missing_remote_id")
+        try:
+            module = TRAKTModule(config_view)
+            response = module.client.delete(f"{module.client.BASE}/sync/playback/{remote_id}")
+            if response.status_code in {200, 202, 204, 404}:
+                return PlaybackActionResult(
+                    ok=True,
+                    provider=self.provider,
+                    instance_id=instance_id,
+                    operation="remove_progress",
+                    remote_id=remote_id,
+                    canonical_key=str(record.get("canonical_key") or ""),
+                    message="Playback record removed." if response.status_code != 404 else "Playback record was already absent.",
+                    remote_status=response.status_code,
+                )
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Trakt remove progress failed.", error_code=f"http:{response.status_code}", remote_status=response.status_code, retryable=response.status_code in {408, 429, 500, 502, 503, 504}, remote_id=remote_id, canonical_key=str(record.get("canonical_key") or ""))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Trakt remove progress failed.", retryable=True, remote_id=remote_id, canonical_key=str(record.get("canonical_key") or ""))
+
+    def mark_watched(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+        watched_at: str | None = None,
+    ) -> PlaybackActionResult:
+        item = _history_item_from_record(record)
+        if watched_at:
+            item["watched_at"] = watched_at
+        try:
+            result = TRAKT_OPS.add(config_view, [item], feature="history")
+            ok = bool(result.get("ok"))
+            return PlaybackActionResult(
+                ok=ok,
+                provider=self.provider,
+                instance_id=instance_id,
+                operation="mark_watched",
+                remote_id=str(record.get("remote_id") or ""),
+                canonical_key=str(record.get("canonical_key") or ""),
+                message="Marked watched on Trakt." if ok else "Trakt mark watched failed.",
+                error_code="" if ok else "history_failed",
+                history_result=clean_mapping(result),
+            )
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="mark_watched", message="Trakt mark watched failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+
+    def update_progress(
+        self,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        progress_percent: float,
+        *,
+        instance_id: str,
+        instance_label: str,
+    ) -> PlaybackActionResult:
+        try:
+            module = TRAKTModule(config_view)
+            response = module.client.post(f"{module.client.BASE}/scrobble/pause", json=_progress_body_from_record(record, progress_percent))
+            if response.status_code in {200, 201, 202}:
+                return PlaybackActionResult(
+                    ok=True,
+                    provider=self.provider,
+                    instance_id=instance_id,
+                    operation="update_progress",
+                    remote_id=str(record.get("remote_id") or ""),
+                    canonical_key=str(record.get("canonical_key") or ""),
+                    message=f"Progress updated on Trakt to {progress_percent:g}%.",
+                    remote_status=response.status_code,
+                )
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message="Trakt update progress failed.", error_code=f"http:{response.status_code}", remote_status=response.status_code, retryable=response.status_code in {408, 429, 500, 502, 503, 504}, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message="Trakt update progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))

--- a/services/playback_progress/models.py
+++ b/services/playback_progress/models.py
@@ -1,0 +1,156 @@
+# /services/playback_progress/models.py
+# CrossWatch - Playback Progress Models
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass as dc_dataclass, field
+from typing import Any, Mapping
+
+
+def utc_now_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def clean_mapping(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    blocked = {"token", "access_token", "refresh_token", "authorization", "api_key", "apikey", "cookie", "secret"}
+    out: dict[str, Any] = {}
+    for key, val in value.items():
+        k = str(key)
+        if k.lower() in blocked or any(part in k.lower() for part in blocked):
+            continue
+        if isinstance(val, Mapping):
+            out[k] = clean_mapping(val)
+        elif isinstance(val, list):
+            out[k] = [
+                clean_mapping(item) if isinstance(item, Mapping) else item
+                for item in val[:50]
+            ]
+        elif isinstance(val, (str, int, float, bool)) or val is None:
+            out[k] = val
+    return out
+
+
+@dc_dataclass
+class PlaybackCapabilities:
+    provider: str
+    provider_label: str
+    instance_id: str
+    instance_label: str
+    included: bool = True
+    configured: bool = False
+    read: bool = False
+    remove_progress: bool = False
+    mark_watched: bool = False
+    update_progress: bool = False
+    bulk_remove_progress: bool = False
+    bulk_mark_watched: bool = False
+    bulk_update_progress: bool = False
+    supports_movies: bool = False
+    supports_episodes: bool = False
+    supports_anime: bool = False
+    reason: str = ""
+    last_refresh: str | None = None
+    last_error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["capabilities"] = {
+            "read": self.read,
+            "remove_progress": self.remove_progress,
+            "mark_watched": self.mark_watched,
+            "update_progress": self.update_progress,
+            "bulk_remove_progress": self.bulk_remove_progress,
+            "bulk_mark_watched": self.bulk_mark_watched,
+            "bulk_update_progress": self.bulk_update_progress,
+            "supports_movies": self.supports_movies,
+            "supports_episodes": self.supports_episodes,
+            "supports_anime": self.supports_anime,
+        }
+        return data
+
+
+@dc_dataclass
+class PlaybackRecord:
+    provider: str
+    provider_label: str
+    instance_id: str
+    instance_label: str
+    remote_id: str
+    canonical_key: str
+    media_type: str
+    title: str = ""
+    episode_title: str = ""
+    series_title: str = ""
+    season: int | None = None
+    episode: int | None = None
+    year: int | None = None
+    ids: dict[str, Any] = field(default_factory=dict)
+    progress_percent: float | None = None
+    remaining_seconds: int | None = None
+    duration_seconds: int | None = None
+    progress_at: str | None = None
+    updated_at: str | None = None
+    source_app: str = ""
+    source_device: str = ""
+    rating: float | None = None
+    poster_url: str = ""
+    backdrop_url: str = ""
+    can_remove_progress: bool = False
+    can_mark_watched: bool = False
+    can_update_progress: bool = False
+    capability_messages: list[str] = field(default_factory=list)
+    provider_metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["ids"] = clean_mapping(self.ids)
+        data["provider_metadata"] = clean_mapping(self.provider_metadata)
+        return data
+
+
+@dc_dataclass
+class PlaybackActionResult:
+    ok: bool
+    provider: str
+    instance_id: str
+    operation: str
+    remote_id: str = ""
+    canonical_key: str = ""
+    error_code: str = ""
+    message: str = ""
+    retryable: bool = False
+    remote_status: int | None = None
+    history_result: dict[str, Any] | None = None
+    playback_cleanup_result: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return clean_mapping(asdict(self))
+
+
+@dc_dataclass
+class PlaybackListResult:
+    ok: bool
+    provider: str
+    instance_id: str
+    items: list[PlaybackRecord] = field(default_factory=list)
+    error_code: str = ""
+    message: str = ""
+    retryable: bool = False
+    remote_status: int | None = None
+    refreshed_at: str | None = None
+
+    def to_error(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "provider": self.provider,
+            "instance_id": self.instance_id,
+            "operation": "list_progress",
+            "error_code": self.error_code,
+            "message": self.message,
+            "retryable": self.retryable,
+            "remote_status": self.remote_status,
+        }

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -1,0 +1,761 @@
+# /services/playback_progress/service.py
+# CrossWatch - Playback Progress Service
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+import math
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, wait
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, cast
+
+from _logging import log as BASE_LOG
+from cw_platform.config_base import load_config, save_config
+from cw_platform.provider_instances import build_provider_config_view, get_provider_block, list_instance_ids, normalize_instance_id
+
+from .adapters.base import PlaybackProgressAdapter, configured_label
+from .adapters.media_servers import EmbyPlaybackAdapter, JellyfinPlaybackAdapter, PlexPlaybackAdapter
+from .adapters.mdblist import MDBListPlaybackAdapter
+from .adapters.publicmetadb import PublicMetaDBPlaybackAdapter
+from .adapters.simkl import SimklPlaybackAdapter
+from .adapters.trakt import TraktPlaybackAdapter
+from .models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, clean_mapping, utc_now_iso
+
+
+LOG = BASE_LOG.child("PLAYBACK")
+CACHE_TTL_SECONDS = 60.0
+MAX_WORKERS = 6
+DEFAULT_PROVIDER_TIMEOUT_SECONDS = 12.0
+PHASE1_PROVIDERS = ("trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin")
+SORT_VALUES = {"last_updated", "progress_high", "progress_low", "remaining_time", "rating_high", "title", "provider"}
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        text = value.strip()
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        dt = datetime.fromisoformat(text)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    except Exception:
+        return None
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _group_text(value: Any) -> str:
+    return " ".join(str(value or "").strip().lower().split())
+
+
+def _group_number(value: Any) -> str:
+    if value is None or value == "":
+        return ""
+    try:
+        return str(int(value))
+    except Exception:
+        return str(value).strip().lower()
+
+
+def _group_progress(value: Any) -> str:
+    try:
+        return str(round(float(value)))
+    except Exception:
+        return ""
+
+
+def _record_group_keys(item: Mapping[str, Any]) -> list[str]:
+    keys: list[str] = []
+    key = str(item.get("canonical_key") or "").strip().lower()
+    if key and not key.startswith("unknown:"):
+        keys.append(f"key:{key}")
+    media_type = _group_text(item.get("media_type"))
+    title = _group_text(item.get("title"))
+    series = _group_text(item.get("series_title"))
+    season = _group_number(item.get("season"))
+    episode = _group_number(item.get("episode"))
+    year = _group_number(item.get("year"))
+    progress = _group_progress(item.get("progress_percent"))
+    if media_type == "movie":
+        fallback = f"fallback:movie:{title}:{year}:{progress}"
+    else:
+        fallback = f"fallback:episode:{series or title}:{season}:{episode}:{progress}"
+    if fallback not in keys:
+        keys.append(fallback)
+    return keys
+
+
+def _record_group_key(item: Mapping[str, Any]) -> str:
+    keys = _record_group_keys(item)
+    return keys[0] if keys else "fallback:unknown"
+
+
+def _record_time_value(item: Mapping[str, Any]) -> float:
+    dt = _parse_iso(item.get("updated_at") or item.get("progress_at"))
+    return dt.timestamp() if dt else 0.0
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        number = float(value)
+        return number if math.isfinite(number) else None
+    except Exception:
+        return None
+
+
+def _remaining_seconds(duration_seconds: Any, progress_percent: Any) -> int | None:
+    duration = _float_or_none(duration_seconds)
+    progress = _float_or_none(progress_percent)
+    if duration is None or progress is None or duration <= 0:
+        return None
+    remaining = int(round(duration * max(0.0, 100.0 - min(progress, 100.0)) / 100.0))
+    return remaining if remaining > 0 else None
+
+
+def _blank_scalar(value: Any) -> bool:
+    return value is None or value == ""
+
+
+def _with_remaining_fallback(item: dict[str, Any]) -> dict[str, Any]:
+    if not _blank_scalar(item.get("remaining_seconds")):
+        return item
+    remaining = _remaining_seconds(item.get("duration_seconds"), item.get("progress_percent"))
+    if remaining is not None:
+        item["remaining_seconds"] = remaining
+    return item
+
+
+def _combine_records(records: list[dict[str, Any]]) -> dict[str, Any]:
+    ordered = sorted(records, key=_record_time_value, reverse=True)
+    primary = dict(ordered[0])
+    if _blank_scalar(primary.get("remaining_seconds")):
+        primary["remaining_seconds"] = next((record.get("remaining_seconds") for record in ordered if not _blank_scalar(record.get("remaining_seconds"))), None)
+    if _blank_scalar(primary.get("duration_seconds")):
+        primary["duration_seconds"] = next((record.get("duration_seconds") for record in ordered if not _blank_scalar(record.get("duration_seconds"))), None)
+    providers: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for record in ordered:
+        provider = str(record.get("provider") or "").strip()
+        instance_id = normalize_instance_id(record.get("instance_id"))
+        key = (provider, instance_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        providers.append(
+            {
+                "provider": provider,
+                "provider_label": str(record.get("provider_label") or provider),
+                "instance_id": instance_id,
+                "instance_label": str(record.get("instance_label") or record.get("provider_label") or provider),
+                "can_remove_progress": bool(record.get("can_remove_progress")),
+                "can_mark_watched": bool(record.get("can_mark_watched")),
+                "can_update_progress": bool(record.get("can_update_progress")),
+                "remote_id": str(record.get("remote_id") or ""),
+            }
+        )
+    primary["records"] = ordered
+    primary["providers"] = providers
+    primary["provider_count"] = len(providers)
+    primary["is_combined"] = len(ordered) > 1
+    primary["can_remove_progress"] = any(bool(record.get("can_remove_progress")) for record in ordered)
+    primary["can_mark_watched"] = any(bool(record.get("can_mark_watched")) for record in ordered)
+    primary["can_update_progress"] = any(bool(record.get("can_update_progress")) for record in ordered)
+    primary["provider"] = "combined" if len(ordered) > 1 else primary.get("provider")
+    primary["instance_id"] = "all" if len(ordered) > 1 else primary.get("instance_id")
+    primary["remote_id"] = _record_group_key(primary) if len(ordered) > 1 else primary.get("remote_id")
+    return primary
+
+
+def _validated_progress_percent(value: Any) -> tuple[float | None, str]:
+    try:
+        progress = float(value)
+    except Exception:
+        return None, "Progress must be a number."
+    if not math.isfinite(progress):
+        return None, "Progress must be a finite number."
+    if progress < 2 or progress >= 80:
+        return None, "Progress must be between 2 and 79 percent. Use Mark as Watched for completed items."
+    return round(progress, 2), ""
+
+
+def _instance_label(cfg: Mapping[str, Any], provider: str, instance_id: str) -> str:
+    block = get_provider_block(cfg, provider, instance_id)
+    label = configured_label(block, "Default" if instance_id == "default" else instance_id)
+    provider_label = {
+        "trakt": "Trakt",
+        "simkl": "SIMKL",
+        "mdblist": "MDBList",
+        "publicmetadb": "PublicMetaDB",
+        "plex": "Plex",
+        "emby": "Emby",
+        "jellyfin": "Jellyfin",
+    }.get(provider, provider)
+    if label.lower() == "default":
+        return f"{provider_label} Default"
+    if label.lower().startswith(provider_label.lower()):
+        return label
+    return f"{provider_label} {label}"
+
+
+def _profile_key(provider: Any, instance_id: Any) -> str:
+    return f"{str(provider or '').strip().lower()}:{normalize_instance_id(instance_id)}"
+
+
+def _playback_settings(cfg: Mapping[str, Any]) -> Mapping[str, Any]:
+    value = cfg.get("playback_progress") if isinstance(cfg, Mapping) else None
+    return value if isinstance(value, Mapping) else {}
+
+
+def _disabled_profiles(cfg: Mapping[str, Any]) -> set[str]:
+    raw = _playback_settings(cfg).get("disabled_profiles")
+    if not isinstance(raw, list):
+        return set()
+    return {_profile_key(*(str(item).split(":", 1) if ":" in str(item) else (item, "default"))) for item in raw}
+
+
+def _profile_included(cfg: Mapping[str, Any], provider: Any, instance_id: Any) -> bool:
+    return _profile_key(provider, instance_id) not in _disabled_profiles(cfg)
+
+
+def _provider_timeout_seconds(cfg: Mapping[str, Any]) -> float:
+    try:
+        raw = float(_playback_settings(cfg).get("provider_timeout_seconds") or DEFAULT_PROVIDER_TIMEOUT_SECONDS)
+    except Exception:
+        raw = DEFAULT_PROVIDER_TIMEOUT_SECONDS
+    return max(3.0, min(raw, 60.0))
+
+
+class PlaybackProgressService:
+    def __init__(self) -> None:
+        self.adapters: dict[str, PlaybackProgressAdapter] = {
+            "trakt": TraktPlaybackAdapter(),
+            "simkl": SimklPlaybackAdapter(),
+            "mdblist": MDBListPlaybackAdapter(),
+            "publicmetadb": PublicMetaDBPlaybackAdapter(),
+            "plex": PlexPlaybackAdapter(),
+            "emby": EmbyPlaybackAdapter(),
+            "jellyfin": JellyfinPlaybackAdapter(),
+        }
+        self._cache: dict[tuple[str, str], dict[str, Any]] = {}
+        self._lock = threading.RLock()
+
+    def provider_instances(self, cfg: Mapping[str, Any] | None = None) -> list[dict[str, str]]:
+        config = cfg or load_config()
+        out: list[dict[str, str]] = []
+        for provider in PHASE1_PROVIDERS:
+            for instance_id in list_instance_ids(config, provider):
+                inst = normalize_instance_id(instance_id)
+                out.append(
+                    {
+                        "provider": provider,
+                        "instance_id": inst,
+                        "instance_label": _instance_label(config, provider, inst),
+                    }
+                )
+        return out
+
+    def capabilities(self, cfg: Mapping[str, Any] | None = None) -> list[PlaybackCapabilities]:
+        config = cfg or load_config()
+        out: list[PlaybackCapabilities] = []
+        for spec in self.provider_instances(config):
+            provider = spec["provider"]
+            adapter = self.adapters.get(provider)
+            if not adapter:
+                continue
+            config_view = build_provider_config_view(config, provider, spec["instance_id"])
+            try:
+                cap = adapter.capabilities(config_view, instance_id=spec["instance_id"], instance_label=spec["instance_label"])
+                cap.included = _profile_included(config, provider, spec["instance_id"])
+                if not cap.included:
+                    cap.reason = "Excluded from Playback Progress."
+                cached = self._cache.get((provider, spec["instance_id"]))
+                if cached:
+                    cap.last_refresh = cached.get("refreshed_at")
+                    err = cached.get("error")
+                    if isinstance(err, Mapping):
+                        cap.last_error = str(err.get("message") or err.get("error_code") or "")
+                out.append(cap)
+            except Exception:
+                out.append(
+                    PlaybackCapabilities(
+                        provider=provider,
+                        provider_label=getattr(adapter, "provider_label", provider),
+                        instance_id=spec["instance_id"],
+                        instance_label=spec["instance_label"],
+                        included=_profile_included(config, provider, spec["instance_id"]),
+                        configured=False,
+                        reason="Capability detection failed.",
+                        last_error="Capability detection failed.",
+                    )
+                )
+        return out
+
+    def _cache_key(self, provider: str, instance_id: str) -> tuple[str, str]:
+        return (str(provider).lower(), normalize_instance_id(instance_id))
+
+    def invalidate(self, provider: str, instance_id: str) -> None:
+        with self._lock:
+            self._cache.pop(self._cache_key(provider, instance_id), None)
+        LOG.debug(f"cache invalidated provider={provider} instance={normalize_instance_id(instance_id)}")
+
+    def _activity_marker(self, adapter: PlaybackProgressAdapter, config_view: Mapping[str, Any], *, instance_id: str) -> str:
+        marker_fn = getattr(adapter, "activity_marker", None)
+        if callable(marker_fn):
+            try:
+                return str(marker_fn(config_view, instance_id=instance_id) or "")
+            except TypeError:
+                try:
+                    return str(marker_fn(config_view) or "")
+                except Exception:
+                    return ""
+            except Exception:
+                return ""
+        return ""
+
+    def _list_one(
+        self,
+        cfg: Mapping[str, Any],
+        spec: Mapping[str, str],
+        force_refresh: bool,
+    ) -> PlaybackListResult:
+        provider = spec["provider"]
+        instance_id = spec["instance_id"]
+        adapter = self.adapters[provider]
+        config_view = build_provider_config_view(cfg, provider, instance_id)
+        cap = adapter.capabilities(config_view, instance_id=instance_id, instance_label=spec["instance_label"])
+        if not cap.read:
+            return PlaybackListResult(
+                ok=False,
+                provider=provider,
+                instance_id=instance_id,
+                error_code="unsupported" if cap.configured else "not_configured",
+                message=cap.reason or "Provider does not support playback listing.",
+            )
+
+        key = self._cache_key(provider, instance_id)
+        now = time.time()
+        with self._lock:
+            cached = self._cache.get(key)
+            if not force_refresh and cached and (now - float(cached.get("ts") or 0)) < CACHE_TTL_SECONDS:
+                result = cached.get("result")
+                if isinstance(result, PlaybackListResult):
+                    LOG.debug(f"cache hit provider={provider} instance={instance_id}")
+                    return result
+
+        marker = self._activity_marker(adapter, config_view, instance_id=instance_id)
+        with self._lock:
+            cached = self._cache.get(key)
+            if (
+                not force_refresh
+                and cached
+                and (not marker or marker == cached.get("activity_marker"))
+            ):
+                result = cached.get("result")
+                if isinstance(result, PlaybackListResult):
+                    LOG.debug(f"activity unchanged provider={provider} instance={instance_id}")
+                    return result
+
+        started = time.monotonic()
+        result = adapter.list_progress(
+            config_view,
+            instance_id=instance_id,
+            instance_label=spec["instance_label"],
+            force_refresh=force_refresh,
+        )
+        elapsed_ms = int((time.monotonic() - started) * 1000)
+        with self._lock:
+            if result.ok:
+                self._cache[key] = {"ts": now, "result": result, "activity_marker": marker, "refreshed_at": result.refreshed_at}
+                LOG.debug(f"provider listed provider={provider} instance={instance_id} items={len(result.items)} elapsed_ms={elapsed_ms}")
+            else:
+                self._cache[key] = {"ts": now, "result": result, "activity_marker": marker, "error": result.to_error()}
+                LOG.warn(f"provider list failed provider={provider} instance={instance_id} error={result.error_code or 'provider_error'} status={result.remote_status or ''} elapsed_ms={elapsed_ms}")
+        return result
+
+    def items(
+        self,
+        *,
+        provider: str | None = None,
+        instance_id: str | None = None,
+        media_type: str | None = None,
+        progress_min: float | None = None,
+        progress_max: float | None = None,
+        age: str | None = None,
+        rating_min: float | None = None,
+        search: str | None = None,
+        sort: str = "last_updated",
+        page: int = 1,
+        page_size: int = 50,
+        force_refresh: bool = False,
+    ) -> dict[str, Any]:
+        cfg = load_config()
+        provider_filter = str(provider or "").strip().lower()
+        instance_filter = normalize_instance_id(instance_id) if instance_id else ""
+        specs = [
+            spec
+            for spec in self.provider_instances(cfg)
+            if (not provider_filter or spec["provider"] == provider_filter)
+            and (not instance_filter or spec["instance_id"] == instance_filter)
+        ]
+        readable_specs: list[dict[str, str]] = []
+        capabilities = self.capabilities(cfg)
+        cap_by_key = {(cap.provider, cap.instance_id): cap for cap in capabilities}
+        for spec in specs:
+            cap = cap_by_key.get((spec["provider"], spec["instance_id"]))
+            if cap and cap.read and cap.included:
+                readable_specs.append(dict(spec))
+
+        LOG.info(
+            f"list requested providers={len(readable_specs)} force_refresh={bool(force_refresh)} "
+            f"provider_filter={provider_filter or 'all'} instance_filter={instance_filter or 'all'}"
+        )
+        results: list[PlaybackListResult] = []
+        if readable_specs:
+            pool = ThreadPoolExecutor(max_workers=min(MAX_WORKERS, len(readable_specs)))
+            future_specs = {pool.submit(self._list_one, cfg, spec, force_refresh): spec for spec in readable_specs}
+            try:
+                done, pending = wait(future_specs, timeout=_provider_timeout_seconds(cfg))
+                for future in done:
+                    try:
+                        results.append(future.result())
+                    except Exception:
+                        results.append(PlaybackListResult(ok=False, provider="unknown", instance_id="", error_code="provider_error", message="Provider request failed.", retryable=True))
+                for future in pending:
+                    spec = future_specs[future]
+                    future.cancel()
+                    LOG.warn(
+                        f"provider timeout provider={spec['provider']} instance={spec['instance_id']} "
+                        f"timeout_s={_provider_timeout_seconds(cfg):g}"
+                    )
+                    results.append(
+                        PlaybackListResult(
+                            ok=False,
+                            provider=spec["provider"],
+                            instance_id=spec["instance_id"],
+                            error_code="provider_timeout",
+                            message="Provider did not respond quickly enough. It was skipped for this refresh.",
+                            retryable=True,
+                        )
+                    )
+            finally:
+                pool.shutdown(wait=False, cancel_futures=True)
+
+        errors = [r.to_error() for r in results if not r.ok]
+        items = [_with_remaining_fallback(item.to_dict()) for result in results if result.ok for item in result.items]
+        filtered = self._apply_filters(items, media_type=media_type, progress_min=progress_min, progress_max=progress_max, age=age, rating_min=rating_min, search=search)
+        if not provider_filter:
+            groups: dict[str, list[dict[str, Any]]] = {}
+            aliases: dict[str, str] = {}
+            for item in filtered:
+                keys = _record_group_keys(item)
+                group_key = next((aliases[key] for key in keys if key in aliases), keys[0] if keys else "fallback:unknown")
+                groups.setdefault(group_key, []).append(item)
+                for key in keys:
+                    aliases[key] = group_key
+            filtered = [_combine_records(group) for group in groups.values()]
+        sorted_items = self._sort(filtered, sort)
+        page = max(1, int(page or 1))
+        page_size = max(1, min(250, int(page_size or 50)))
+        total = len(sorted_items)
+        start = (page - 1) * page_size
+        end = start + page_size
+        LOG.debug(f"list completed total={total} errors={len(errors)} page={page} page_size={page_size}")
+        return {
+            "items": sorted_items[start:end],
+            "page": page,
+            "page_size": page_size,
+            "total": total,
+            "providers": [cap.to_dict() for cap in capabilities],
+            "errors": errors,
+            "partial": bool(errors and items),
+            "refreshed_at": utc_now_iso(),
+        }
+
+    def settings(self, cfg: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        config = cfg or load_config()
+        disabled = _disabled_profiles(config)
+        profiles = []
+        for cap in self.capabilities(config):
+            key = _profile_key(cap.provider, cap.instance_id)
+            profiles.append(
+                {
+                    "key": key,
+                    "provider": cap.provider,
+                    "provider_label": cap.provider_label,
+                    "instance_id": cap.instance_id,
+                    "instance_label": cap.instance_label,
+                    "configured": cap.configured,
+                    "read": cap.read,
+                    "included": key not in disabled,
+                    "reason": cap.reason,
+                }
+            )
+        return {
+            "provider_timeout_seconds": _provider_timeout_seconds(config),
+            "disabled_profiles": sorted(disabled),
+            "profiles": profiles,
+            "refreshed_at": utc_now_iso(),
+        }
+
+    def save_settings(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        cfg = load_config()
+        known = {_profile_key(spec["provider"], spec["instance_id"]) for spec in self.provider_instances(cfg)}
+        disabled: set[str] = set()
+        profiles_value = payload.get("profiles")
+        if isinstance(profiles_value, list):
+            for item in profiles_value:
+                if not isinstance(item, Mapping):
+                    continue
+                key = _profile_key(item.get("provider") or str(item.get("key") or "").split(":", 1)[0], item.get("instance_id") or (str(item.get("key") or "").split(":", 1)[1] if ":" in str(item.get("key") or "") else "default"))
+                if key in known and not bool(item.get("included", True)):
+                    disabled.add(key)
+        else:
+            raw = payload.get("disabled_profiles")
+            if isinstance(raw, list):
+                disabled = {_profile_key(*(str(item).split(":", 1) if ":" in str(item) else (item, "default"))) for item in raw}
+                disabled &= known
+
+        block = cfg.setdefault("playback_progress", {})
+        if not isinstance(block, dict):
+            block = {}
+            cfg["playback_progress"] = block
+        block["disabled_profiles"] = sorted(disabled)
+        if "provider_timeout_seconds" in payload:
+            try:
+                block["provider_timeout_seconds"] = _provider_timeout_seconds({"playback_progress": {"provider_timeout_seconds": payload.get("provider_timeout_seconds")}})
+            except Exception:
+                block["provider_timeout_seconds"] = DEFAULT_PROVIDER_TIMEOUT_SECONDS
+        save_config(cfg)
+        with self._lock:
+            self._cache.clear()
+        LOG.info(
+            f"settings saved disabled_profiles={len(disabled)} "
+            f"timeout_s={_provider_timeout_seconds(cfg):g}"
+        )
+        return {"ok": True, "settings": self.settings(cfg)}
+
+    def _apply_filters(self, items: list[dict[str, Any]], **filters: Any) -> list[dict[str, Any]]:
+        media_type = str(filters.get("media_type") or "").strip().lower()
+        q = str(filters.get("search") or "").strip().lower()
+        age = str(filters.get("age") or "").strip().lower()
+        rating_min = filters.get("rating_min")
+        progress_min = filters.get("progress_min")
+        progress_max = filters.get("progress_max")
+        now = datetime.now(timezone.utc)
+        out: list[dict[str, Any]] = []
+        for item in items:
+            if media_type and media_type not in {"all", item.get("media_type")}:
+                continue
+            progress = item.get("progress_percent")
+            if progress_min is not None and (progress is None or float(progress) < float(progress_min)):
+                continue
+            if progress_max is not None and (progress is None or float(progress) > float(progress_max)):
+                continue
+            rating = item.get("rating")
+            if rating_min is not None and (rating is None or float(rating) < float(rating_min)):
+                continue
+            if age:
+                dt = _parse_iso(item.get("updated_at") or item.get("progress_at"))
+                if age == "today":
+                    if not dt or dt.date() != now.date():
+                        continue
+                elif age == "7d":
+                    if not dt or dt < now - timedelta(days=7):
+                        continue
+                elif age == "30d":
+                    if not dt or dt < now - timedelta(days=30):
+                        continue
+                elif age == "older_30d":
+                    if not dt or dt >= now - timedelta(days=30):
+                        continue
+            if q:
+                hay = " ".join(
+                    str(item.get(key) or "")
+                    for key in ("title", "series_title", "episode_title", "provider_label", "instance_label", "source_app", "source_device")
+                ).lower()
+                if item.get("season") is not None and item.get("episode") is not None:
+                    hay += f" s{int(item['season']):02d}e{int(item['episode']):02d}"
+                if q not in hay:
+                    continue
+            out.append(item)
+        return out
+
+    def _sort(self, items: list[dict[str, Any]], sort: str) -> list[dict[str, Any]]:
+        key = sort if sort in SORT_VALUES else "last_updated"
+        def ts(item: Mapping[str, Any]) -> float:
+            dt = _parse_iso(item.get("updated_at") or item.get("progress_at"))
+            return dt.timestamp() if dt else 0.0
+        def progress_low(item: Mapping[str, Any]) -> float:
+            progress = item.get("progress_percent")
+            return float(progress) if progress is not None else math.inf
+        def remaining_time(item: Mapping[str, Any]) -> int:
+            remaining = item.get("remaining_seconds")
+            return int(remaining) if remaining is not None else 10**12
+        if key == "progress_high":
+            return sorted(items, key=lambda x: float(x.get("progress_percent") or -1), reverse=True)
+        if key == "progress_low":
+            return sorted(items, key=progress_low)
+        if key == "remaining_time":
+            return sorted(items, key=remaining_time)
+        if key == "rating_high":
+            return sorted(items, key=lambda x: float(x.get("rating") or -1), reverse=True)
+        if key == "title":
+            return sorted(items, key=lambda x: str(x.get("series_title") or x.get("title") or "").lower())
+        if key == "provider":
+            return sorted(items, key=lambda x: (str(x.get("provider_label") or ""), str(x.get("instance_label") or ""), str(x.get("title") or "")))
+        return sorted(items, key=ts, reverse=True)
+
+    def _adapter_for_action(self, cfg: Mapping[str, Any], provider: str, instance_id: str) -> tuple[PlaybackProgressAdapter | None, dict[str, Any], str]:
+        provider_key = str(provider or "").strip().lower()
+        inst = normalize_instance_id(instance_id)
+        adapter = self.adapters.get(provider_key)
+        if not adapter:
+            return None, {}, inst
+        return adapter, build_provider_config_view(cfg, provider_key, inst), inst
+
+    def remove(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        cfg = load_config()
+        provider = str(payload.get("provider") or "").lower()
+        instance_id = normalize_instance_id(payload.get("instance_id"))
+        record_value = payload.get("record")
+        record = _as_mapping(record_value) if isinstance(record_value, Mapping) else payload
+        adapter, config_view, inst = self._adapter_for_action(cfg, provider, instance_id)
+        if adapter is None:
+            LOG.warn(f"remove requested unknown provider={provider} instance={inst}")
+            return PlaybackActionResult(False, provider, inst, "remove_progress", error_code="unknown_provider", message="Unknown provider.").to_dict()
+        label = _instance_label(cfg, provider, inst)
+        LOG.info(f"remove progress requested provider={provider} instance={inst} remote_id={record.get('remote_id') or ''}")
+        result = adapter.remove_progress(config_view, record, instance_id=inst, instance_label=label)
+        if result.ok:
+            self.invalidate(provider, inst)
+            LOG.success(f"remove progress completed provider={provider} instance={inst} remote_id={record.get('remote_id') or ''}")
+        else:
+            LOG.warn(f"remove progress failed provider={provider} instance={inst} error={result.error_code or 'provider_error'}")
+        return result.to_dict()
+
+    def mark_watched(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        cfg = load_config()
+        provider = str(payload.get("provider") or "").lower()
+        instance_id = normalize_instance_id(payload.get("instance_id"))
+        record_value = payload.get("record")
+        record = _as_mapping(record_value) if isinstance(record_value, Mapping) else payload
+        adapter, config_view, inst = self._adapter_for_action(cfg, provider, instance_id)
+        if adapter is None:
+            LOG.warn(f"mark watched requested unknown provider={provider} instance={inst}")
+            return PlaybackActionResult(False, provider, inst, "mark_watched", error_code="unknown_provider", message="Unknown provider.").to_dict()
+        label = _instance_label(cfg, provider, inst)
+        LOG.info(f"mark watched requested provider={provider} instance={inst} remote_id={record.get('remote_id') or ''}")
+        result = adapter.mark_watched(config_view, record, instance_id=inst, instance_label=label, watched_at=str(payload.get("watched_at") or "").strip() or None)
+        if result.ok:
+            self.invalidate(provider, inst)
+            cleanup = self._cleanup_after_mark(adapter, config_view, record, provider, inst, label)
+            result.playback_cleanup_result = cleanup.to_dict()
+            self.invalidate(provider, inst)
+            LOG.success(f"mark watched completed provider={provider} instance={inst} remote_id={record.get('remote_id') or ''}")
+        else:
+            LOG.warn(f"mark watched failed provider={provider} instance={inst} error={result.error_code or 'provider_error'}")
+        return result.to_dict()
+
+    def _cleanup_after_mark(
+        self,
+        adapter: PlaybackProgressAdapter,
+        config_view: Mapping[str, Any],
+        record: Mapping[str, Any],
+        provider: str,
+        instance_id: str,
+        instance_label: str,
+    ) -> PlaybackActionResult:
+        if provider == "plex":
+            return PlaybackActionResult(True, provider, instance_id, "remove_progress", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), message="Cleanup skipped because Plex clears resume progress through mark-unwatched.")
+        caps = adapter.capabilities(config_view, instance_id=instance_id, instance_label=instance_label)
+        if not caps.remove_progress:
+            return PlaybackActionResult(True, provider, instance_id, "remove_progress", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), message="Cleanup skipped because remove progress is unsupported.")
+        return adapter.remove_progress(config_view, record, instance_id=instance_id, instance_label=instance_label)
+
+    def bulk(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        action = str(payload.get("action") or "").strip().lower()
+        items_value = payload.get("items")
+        items: list[Any] = items_value if isinstance(items_value, list) else []
+        results: list[dict[str, Any]] = []
+        for item in items:
+            if not isinstance(item, Mapping):
+                results.append({"ok": False, "operation": action, "error_code": "invalid_item", "message": "Invalid selected item."})
+                continue
+            record_value = item.get("record")
+            record = _as_mapping(record_value) if isinstance(record_value, Mapping) else item
+            if action == "remove_progress":
+                if not record.get("can_remove_progress"):
+                    results.append({"ok": False, "provider": item.get("provider"), "instance_id": item.get("instance_id"), "operation": action, "remote_id": item.get("remote_id"), "canonical_key": item.get("canonical_key"), "error_code": "unsupported", "message": "Remove Progress is unsupported for this record."})
+                    continue
+                results.append(self.remove(item))
+            elif action == "mark_watched":
+                if not record.get("can_mark_watched"):
+                    results.append({"ok": False, "provider": item.get("provider"), "instance_id": item.get("instance_id"), "operation": action, "remote_id": item.get("remote_id"), "canonical_key": item.get("canonical_key"), "error_code": "unsupported", "message": "Mark as Watched is unsupported for this record."})
+                    continue
+                results.append(self.mark_watched(item))
+            elif action == "update_progress":
+                progress, reason = _validated_progress_percent(payload.get("progress_percent"))
+                if progress is None:
+                    results.append({"ok": False, "provider": item.get("provider"), "instance_id": item.get("instance_id"), "operation": action, "remote_id": item.get("remote_id"), "canonical_key": item.get("canonical_key"), "error_code": "invalid_progress", "message": reason})
+                    continue
+                if not record.get("can_update_progress"):
+                    results.append({"ok": False, "provider": item.get("provider"), "instance_id": item.get("instance_id"), "operation": action, "remote_id": item.get("remote_id"), "canonical_key": item.get("canonical_key"), "error_code": "unsupported", "message": "Edit Progress is unsupported for this record."})
+                    continue
+                update_item = dict(item)
+                update_item["progress_percent"] = progress
+                results.append(self.update_progress(update_item))
+            else:
+                results.append({"ok": False, "operation": action, "error_code": "unsupported_action", "message": "Unsupported bulk action."})
+        successful = sum(1 for r in results if r.get("ok"))
+        unsupported = sum(1 for r in results if r.get("error_code") == "unsupported")
+        failed = sum(1 for r in results if not r.get("ok") and r.get("error_code") != "unsupported")
+        LOG.info(f"bulk action completed action={action or 'unknown'} items={len(items)} successful={successful} failed={failed} unsupported={unsupported}")
+        return {
+            "results": [clean_mapping(r) for r in results],
+            "successful": successful,
+            "failed": failed,
+            "skipped": 0,
+            "unsupported": unsupported,
+        }
+
+    def update_progress(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        progress, reason = _validated_progress_percent(payload.get("progress_percent"))
+        provider = str(payload.get("provider") or "").lower()
+        instance_id = normalize_instance_id(payload.get("instance_id"))
+        if progress is None:
+            LOG.warn(f"update progress rejected provider={provider} instance={instance_id} reason={reason}")
+            return PlaybackActionResult(False, provider, instance_id, "update_progress", error_code="invalid_progress", message=reason).to_dict()
+        cfg = load_config()
+        record_value = payload.get("record")
+        record = _as_mapping(record_value) if isinstance(record_value, Mapping) else payload
+        adapter, config_view, inst = self._adapter_for_action(cfg, provider, instance_id)
+        if adapter is None:
+            LOG.warn(f"update progress requested unknown provider={provider} instance={inst}")
+            return PlaybackActionResult(False, provider, inst, "update_progress", error_code="unknown_provider", message="Unknown provider.").to_dict()
+        if not record.get("can_update_progress"):
+            LOG.warn(f"update progress unsupported provider={provider} instance={inst} remote_id={record.get('remote_id') or ''}")
+            return PlaybackActionResult(False, provider, inst, "update_progress", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), error_code="unsupported", message="Edit Progress is unsupported for this record.").to_dict()
+        label = _instance_label(cfg, provider, inst)
+        LOG.info(f"update progress requested provider={provider} instance={inst} remote_id={record.get('remote_id') or ''} progress={progress:g}")
+        result = adapter.update_progress(config_view, record, progress, instance_id=inst, instance_label=label)
+        if result.ok:
+            self.invalidate(provider, inst)
+            LOG.success(f"update progress completed provider={provider} instance={inst} remote_id={record.get('remote_id') or ''} progress={progress:g}")
+        else:
+            LOG.warn(f"update progress failed provider={provider} instance={inst} error={result.error_code or 'provider_error'}")
+        return result.to_dict()
+
+
+_SERVICE = PlaybackProgressService()
+
+
+def get_service() -> PlaybackProgressService:
+    return _SERVICE

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -111,7 +111,7 @@ _HELPER_SCRIPTS = (
 _APP_SCRIPTS = (
     "syncbar.js", "main.js", "connections.overlay.js", "connections.pairs.overlay.js", "scheduler.js",
     "schedulerbanner.js", "playingcard.js", "insights.js", "activity.js", "main-status.js", "settings-insight.js", "scrobbler.js",
-    "editor.js", "snapshots.js",
+    "editor.js", "snapshots.js", "playback_progress.js",
 )
 _AUTH_HEADER_ICONS = (
     {"prov": "PLEX", "label": "Plex"},
@@ -199,6 +199,7 @@ def _get_index_html_static() -> str:
   const TITLES = {
     main: "Main",
     watchlist: "Watchlist",
+    playback_progress: "Playback Progress",
     snapshots: "Captures",
     editor: "Editor",
     settings: "Settings",
@@ -420,6 +421,7 @@ html[data-cw-theme=flat-light] #page-settings .cw-maint-action.restart .cw-maint
   <nav class="tabs" aria-label="Primary navigation">
     <button id="tab-main" class="tab active" type="button" onclick="showTab('main')">Main</button>
     <button id="tab-watchlist" class="tab" type="button" onclick="showTab('watchlist')">Watchlist</button>
+    <button id="tab-playback_progress" class="tab" type="button" onclick="showTab('playback_progress')">Playback</button>
     <button id="tab-snapshots" class="tab" type="button" onclick="showTab('snapshots')">Captures</button>
     <button id="tab-editor" class="tab" type="button" onclick="showTab('editor')">Editor</button>
     <div class="cw-tabmenu" id="tab-settings-menu">
@@ -592,6 +594,12 @@ html[data-cw-theme=flat-light] #page-settings .cw-maint-action.restart .cw-maint
 
   <section id="page-watchlist" class="card hidden">
     <div class="title">Watchlist</div><div id="watchlist-root"></div>
+  </section>
+
+  <section id="page-playback_progress" class="card hidden tab-page">
+    <div id="playback-progress-root">
+      <div class="cw-page-loading">Loading Playback Progress...</div>
+    </div>
   </section>
 
   <section id="page-snapshots" class="card hidden"></section>


### PR DESCRIPTION
# Pull request

## Change

Adds a Playback Progress screen and API for viewing and managing unfinished playback across Trakt, SIMKL, MDBList, PublicMetaDB, Plex, Emby, and Jellyfin.

This includes shared playback progress models, provider adapters, combined cards across providers, bulk edit/mark-watched/remove actions, provider-profile inclusion settings, slow-provider timeout handling, compact card controls, and media-server metadata enrichment for artwork and grouping.

Also wires the feature into the app shell, frontend assets, config defaults, and supporting auth/progress paths.

## Why

Users need one place to manage continue-watching progress across trackers and media servers without duplicate cards for the same item.

Combining provider records keeps the page cleaner, while profile toggles and timeout handling prevent unwanted or slow providers from hurting the user experience.

## Testing

- manual tested
- test_playback_progress

## Issue

#287 