### PR TITLE
Change: better Plex profile safety and user-scope feedback

### DIFF
--- a/api/authenticationAPI.py
+++ b/api/authenticationAPI.py
@@ -517,7 +517,14 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         token = (plex.get("account_token") or "").strip()
         base = (plex.get("server_url") or "").strip()
         if not token:
-            return {"users": [], "count": 0, "instance": inst}
+            return {
+                "users": [],
+                "count": 0,
+                "instance": inst,
+                "ok": False,
+                "reason": "token_required",
+                "message": "Connect this Plex profile first.",
+            }
 
         norm = lambda s: (s or "").strip().lower()
         is_local_id = (

--- a/assets/auth/auth.plex.js
+++ b/assets/auth/auth.plex.js
@@ -208,6 +208,39 @@ function ensurePlexInstanceUI() {
     setPlexPanelNotice(kind, text);
   }
 
+  function ensurePlexUserScopeNotice() {
+    const userPick = $("plex_user_pick_btn")?.closest(".userpick") || $("plex_username")?.parentElement;
+    if (!userPick) return null;
+    let el = $("plex_user_scope_notice");
+    if (el) return el;
+    el = d.createElement("div");
+    el.id = "plex_user_scope_notice";
+    el.className = "sub hidden";
+    el.style.marginTop = "8px";
+    el.style.padding = "8px 10px";
+    el.style.borderRadius = "8px";
+    el.style.border = "1px solid rgba(247,185,85,.35)";
+    el.style.background = "rgba(247,185,85,.08)";
+    el.style.color = "#f7b955";
+    el.style.lineHeight = "1.35";
+    userPick.insertAdjacentElement("afterend", el);
+    return el;
+  }
+
+  function setPlexUserScopeNotice(user) {
+    const el = ensurePlexUserScopeNotice();
+    if (!el) return;
+    const type = String(user?.type || "").trim().toLowerCase();
+    if (type !== "friend") {
+      el.classList.add("hidden");
+      el.textContent = "";
+      return;
+    }
+    const name = String(user?.username || "This friend").trim() || "This friend";
+    el.classList.remove("hidden");
+    el.textContent = `${name} is a Plex friend/shared account, not a Plex Home user. Syncing this account's watchlist, ratings, or history is highly unlikely to work with your Plex token. Create a separate Plex profile and authenticate with that friend's Plex account instead.`;
+  }
+
   function setPlexSuccess(on, text) {
     try { getPlexState().connected = !!on; } catch {}
     if (on) setPlexBanner("ok", text || "Connected");
@@ -288,7 +321,7 @@ function ensurePlexInstanceUI() {
       const msg = $("plex_msg");
       if (msg && !pin) setPlexBanner("warn", "PIN request failed");
       try { setPlexBannerDetail(null, ""); } catch {}
-      if (pin) { try { await Shared.copyText(pin, null, { failureMessage: false }); } catch {} }
+      if (pin && d.hasFocus()) { try { await Shared.copyText(pin, null, { failureMessage: false }); } catch {} }
       if (win && !win.closed) {
         try { win.focus(); } catch {}
       } else {
@@ -328,7 +361,11 @@ function ensurePlexInstanceUI() {
       const tok = (p.account_token || "").trim();
 
       if (tok) {
-        if (tok !== lastTok) { lastTok = tok; inspectTried = false; }
+        if (tok !== lastTok) {
+          lastTok = tok;
+          inspectTried = false;
+          try { __plexUsersByInst.delete(getPlexInstance()); __plexUsersMetaByInst.delete(getPlexInstance()); } catch {}
+        }
         try {
 
           const urlEl  = $("plex_server_url");
@@ -402,6 +439,7 @@ async function plexDeleteToken() {
     if (r.ok && (j.ok !== false)) {
       ["plex_pin", "plex_username", "plex_account_id"].forEach((id) => { const el = $(id); if (el) el.value = ""; });
       try { const st = getPlexState(); st.libs = []; st.connected = false; } catch {}
+      try { __plexUsersByInst.delete(getPlexInstance()); __plexUsersMetaByInst.delete(getPlexInstance()); } catch {}
       try { setPlexBanner("warn", "Disconnected"); } catch {}
       try { setPlexBannerDetail("warn", "Token deleted and saved."); } catch {}
       try { notify("Plex disconnected (saved)."); } catch {}
@@ -438,6 +476,7 @@ async function plexDeleteToken() {
       set("plex_account_id", aid || "");
       // If account_id is missing, resolve it once from /api/plex/pickusers.
       await resolvePlexAccountIdFromUsers();
+      await refreshPlexSelectedUserScopeNotice();
       try { const cb = $("plex_verify_ssl"); if (cb) cb.checked = !!p.verify_ssl; } catch {}
 
       const st = getPlexState();
@@ -741,7 +780,7 @@ const tags = [
       if (!needsResolve) return;
 
       if (opts.bustCache) {
-        try { __plexUsersByInst.delete(getPlexInstance()); } catch {}
+        try { __plexUsersByInst.delete(getPlexInstance()); __plexUsersMetaByInst.delete(getPlexInstance()); } catch {}
       }
 
       const users = await fetchPlexUsers();
@@ -772,18 +811,50 @@ const tags = [
 
   // User picker
   const __plexUsersByInst = new Map();
+  const __plexUsersMetaByInst = new Map();
 
   async function fetchPlexUsers() {
     const inst = getPlexInstance();
     if (__plexUsersByInst.has(inst)) return __plexUsersByInst.get(inst) || [];
     let out = [];
+    let meta = {};
     try {
       const r = await fetch(plexApi("/api/plex/pickusers"), { cache: "no-store" });
       const j = await r.json();
       out = Array.isArray(j?.users) ? j.users : [];
-    } catch { out = []; }
+      meta = j && typeof j === "object" ? j : {};
+    } catch { out = []; meta = {}; }
     __plexUsersByInst.set(inst, out);
+    __plexUsersMetaByInst.set(inst, meta);
     return out;
+  }
+
+  async function refreshPlexSelectedUserScopeNotice() {
+    try {
+      const userEl = $("plex_username");
+      const idEl = $("plex_account_id");
+      const wantUser = String(userEl?.value || "").trim().toLowerCase();
+      const wantId = String(idEl?.value || "").trim();
+      if (!wantUser && !wantId) {
+        setPlexUserScopeNotice(null);
+        return;
+      }
+
+      const users = await fetchPlexUsers();
+      const sameId = (u) => {
+        if (!wantId) return false;
+        return [u?.id, u?.account_id, u?.cloud_account_id, u?.pms_account_id]
+          .some((v) => v != null && String(v).trim() === wantId);
+      };
+      const sameUser = (u) => {
+        if (!wantUser) return false;
+        return String(u?.username || u?.title || "").trim().toLowerCase() === wantUser;
+      };
+      const match = users.find(sameId) || users.find(sameUser) || null;
+      setPlexUserScopeNotice(match);
+    } catch {
+      setPlexUserScopeNotice(null);
+    }
   }
 
   function renderPlexUserList() {
@@ -793,7 +864,9 @@ const tags = [
     const rankSrc  = { cloud:0, pms:1 };
     const by = new Map();
 
-    const src = __plexUsersByInst.get(getPlexInstance()) || [];
+    const inst = getPlexInstance();
+    const src = __plexUsersByInst.get(inst) || [];
+    const meta = __plexUsersMetaByInst.get(inst) || {};
 
     for (const u of src) {
       const uname = (u.username || u.title || `user#${u.id}`).trim();
@@ -831,13 +904,13 @@ const tags = [
 
     const esc = s => String(s||"").replace(/[&<>"']/g,c=>({ "&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
     listEl.innerHTML = users.length ? users.map(u => `
-      <button type="button" class="userrow" data-uid="${esc(u.id)}" data-username="${esc(u.username)}">
+      <button type="button" class="userrow" data-uid="${esc(u.id)}" data-username="${esc(u.username)}" data-usertype="${esc(u.type)}" data-userlabel="${esc(u.label)}" data-usersource="${esc(u.source)}">
         <div class="row1">
           <strong>${esc(u.username)}</strong>
           <span class="tag ${esc(u.type)}">${esc(u.label || u.type)}</span>
         </div>
       </button>
-    `).join("") : '<div class="sub">No users found.</div>';
+    `).join("") : `<div class="sub">${esc(meta.reason === "token_required" ? (meta.message || "Connect this Plex profile first.") : "No users found.")}</div>`;
   }
 
   function placePlexUserPop() {
@@ -884,12 +957,22 @@ const tags = [
         const row = e.target.closest(".userrow"); if (!row) return;
         const uname = row.dataset.username || "";
         const uid   = row.dataset.uid || "";
+        const type  = row.dataset.usertype || "";
+        const label = row.dataset.userlabel || "";
+        const source = row.dataset.usersource || "";
         const uEl = $("plex_username"); if (uEl) uEl.value = uname;
         const aEl = $("plex_account_id"); if (aEl) aEl.value = uid;
+        setPlexUserScopeNotice({ username: uname, type, label, source });
         closePlexUserPicker();
         try{ document.dispatchEvent(new CustomEvent("settings-collect",{detail:{section:"plex-users"}})); }catch{}
       });
     }
+    ["plex_username", "plex_account_id"].forEach((id) => {
+      const input = $(id);
+      if (!input || input.__plexUserScopeNoticeWired) return;
+      input.__plexUserScopeNoticeWired = true;
+      input.addEventListener("input", () => setPlexUserScopeNotice(null));
+    });
     if (!document.__plexUserAway){
       document.__plexUserAway = true;
       document.addEventListener("click",(e)=>{

--- a/assets/crosswatch.css
+++ b/assets/crosswatch.css
@@ -896,7 +896,9 @@ to{left:6px}
 #placeholder-card.cw-main-card{padding:14px 18px 16px}
 #placeholder-card .cw-main-card-head{margin-bottom:10px;padding-bottom:8px;border-color:rgba(255,255,255,.1)}
 #placeholder-card .wall-msg{display:inline-flex;align-items:center;gap:8px;margin:0 0 10px;padding:8px 10px;border-radius:12px;border:1px solid var(--cw-flat-border,rgba(255,255,255,.12));background:var(--cw-flat-panel-2,rgba(255,255,255,.035));color:var(--cw-flat-muted,rgba(185,193,230,.78))}
+#placeholder-card .wall-msg.is-empty{display:flex;width:100%;min-height:70px;margin:0;justify-content:center;border-style:dashed}
 #placeholder-card .wall-wrap{margin:0;padding:0 42px;min-height:0;border:0;border-radius:0;background:0 0;box-shadow:none;overflow:visible}
+#placeholder-card .wall-wrap.is-empty{display:none}
 #placeholder-card #poster-row.row-scroll{--poster-gap:10px;display:grid;grid-auto-flow:column;grid-auto-columns:118px;align-items:start;gap:var(--poster-gap);width:100%;max-width:100%;padding:2px 4px 6px;overflow-x:auto;overflow-y:hidden;scroll-snap-type:x proximity;scrollbar-width:none}
 #placeholder-card #poster-row.row-scroll::-webkit-scrollbar{display:none}
 #placeholder-card .poster{width:118px;min-width:118px;border-radius:14px;border-color:rgba(255,255,255,.14);box-shadow:none}

--- a/assets/helpers/watchlist-preview.js
+++ b/assets/helpers/watchlist-preview.js
@@ -562,15 +562,24 @@
   };
   const hidePreviewCard = (card, row, msg) => {
     card?.classList.add("hidden");
-    if (row) { row.innerHTML = ""; row.classList.add("hidden"); }
-    if (msg) msg.textContent = "";
+    if (row) {
+      row.innerHTML = "";
+      row.classList.add("hidden");
+      row.closest(".wall-wrap")?.classList.remove("is-empty");
+    }
+    if (msg) {
+      msg.textContent = "";
+      msg.classList.remove("is-empty");
+    }
     window.wallLoaded = false;
   };
   const setWallEmpty = (row, msg, text) => {
     window.__wallRenderSignature = "";
     row.replaceChildren();
     row.classList.add("hidden");
+    row.closest(".wall-wrap")?.classList.add("is-empty");
     msg.textContent = text;
+    msg.classList.add("is-empty");
     msg.classList.remove("hidden");
   };
 
@@ -725,7 +734,9 @@
     window._lastSyncEpoch = lastSyncEpoch || null;
     window.__cwWallPreviewItems = itemMap;
     row.replaceChildren(frag);
+    row.closest(".wall-wrap")?.classList.remove("is-empty");
     row.classList.remove("hidden");
+    msg.classList.remove("is-empty");
     msg.classList.add("hidden");
     window.__wallRenderSignature = wallSignature(wallItems, lastSyncEpoch);
     initWallInteractions();
@@ -751,7 +762,9 @@
     const hasRenderedWall = row.childElementCount > 0 && !row.classList.contains("hidden");
     if (!hasRenderedWall) {
       msg.textContent = "Loading...";
+      msg.classList.remove("is-empty");
       msg.classList.remove("hidden");
+      row.closest(".wall-wrap")?.classList.remove("is-empty");
       row.classList.add("hidden");
       const cached = readWallCache();
       if (cached) {

--- a/providers/sync/plex/_common.py
+++ b/providers/sync/plex/_common.py
@@ -2015,6 +2015,31 @@ def home_scope_exit(adapter: Any, did_switch: bool) -> None:
         pass
 
 
+def home_scope_selected_label(sel_aid: Any, sel_uname: Any) -> str:
+    v = sel_aid if sel_aid is not None else sel_uname
+    return str(v or "").strip() or "selected user"
+
+
+def raise_home_scope_not_applied(feature: str, sel_aid: Any, sel_uname: Any) -> None:
+    selected = home_scope_selected_label(sel_aid, sel_uname)
+    _warn("home_scope_blocked", target_feature=str(feature or ""), selected=selected)
+    raise RuntimeError(f"Plex selected user scope could not be applied for {feature}: {selected}")
+
+
+def unresolved_home_scope_not_applied(items: Iterable[Mapping[str, Any]] | None, sel_aid: Any, sel_uname: Any) -> list[dict[str, Any]]:
+    from cw_platform.id_map import minimal as id_minimal
+
+    selected = home_scope_selected_label(sel_aid, sel_uname)
+    out: list[dict[str, Any]] = []
+    for item in items or []:
+        try:
+            minimal = id_minimal(item)
+        except Exception:
+            minimal = dict(item or {})
+        out.append({"item": minimal, "hint": "home_scope_not_applied", "selected": selected})
+    return out
+
+
 def as_epoch(v: Any) -> int | None:
     if v is None:
         return None

--- a/providers/sync/plex/_progress.py
+++ b/providers/sync/plex/_progress.py
@@ -17,10 +17,12 @@ from ._common import (
     home_scope_exit,
     item_guid_candidates,
     plex_cfg_get,
+    raise_home_scope_not_applied,
     server_find_rating_key_by_guid,
     make_logger,
     minimal_from_history_row,
     normalize,
+    unresolved_home_scope_not_applied,
 )
 
 
@@ -133,8 +135,11 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
     if not srv:
         return {}
 
-    _need_scope, did_switch, _aid, _uname = home_scope_enter(adapter)
+    need_scope, did_switch, sel_aid, sel_uname = home_scope_enter(adapter)
     try:
+        if need_scope and not did_switch:
+            raise_home_scope_not_applied("progress", sel_aid, sel_uname)
+
         rks = _fetch_resume_rating_keys(srv, limit=150)
         out: dict[str, dict[str, Any]] = {}
         dbg = _mods_debug()
@@ -381,8 +386,13 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
     if not srv:
         return 0, [{"item": dict(x), "hint": "not_configured"} for x in (items or [])]
 
-    _need_scope, did_switch, _aid, _uname = home_scope_enter(adapter)
+    need_scope, did_switch, sel_aid, sel_uname = home_scope_enter(adapter)
     try:
+        if need_scope and not did_switch:
+            unresolved = unresolved_home_scope_not_applied(items, sel_aid, sel_uname)
+            _info("write_skipped", op="add", reason="home_scope_not_applied", selected=(sel_aid or sel_uname), unresolved=len(unresolved))
+            return 0, unresolved
+
         ok = 0
         unresolved: list[dict[str, Any]] = []
 
@@ -423,8 +433,13 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
     if not srv:
         return 0, [{"item": dict(x), "hint": "not_configured"} for x in (items or [])]
 
-    _need_scope, did_switch, _aid, _uname = home_scope_enter(adapter)
+    need_scope, did_switch, sel_aid, sel_uname = home_scope_enter(adapter)
     try:
+        if need_scope and not did_switch:
+            unresolved = unresolved_home_scope_not_applied(items, sel_aid, sel_uname)
+            _info("write_skipped", op="remove", reason="home_scope_not_applied", selected=(sel_aid or sel_uname), unresolved=len(unresolved))
+            return 0, unresolved
+
         ok = 0
         unresolved: list[dict[str, Any]] = []
 

--- a/providers/sync/plex/_ratings.py
+++ b/providers/sync/plex/_ratings.py
@@ -27,10 +27,12 @@ from ._common import (
     plex_cfg_get,
     plex_feature_library_ids,
     plex_headers,
+    raise_home_scope_not_applied,
     server_find_rating_key_by_guid,
     plex_worker_count,
     season_rating_key_from_show,
     section_allowed,
+    unresolved_home_scope_not_applied,
     unresolved_store,
     emit,
     make_logger,
@@ -289,6 +291,9 @@ def _rate(srv: Any, rating_key: Any, rating_1to10: int) -> bool:
 def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, Any]]:
     need_scope, did_switch, sel_aid, sel_uname = home_scope_enter(adapter)
     try:
+        if need_scope and not did_switch:
+            raise_home_scope_not_applied("ratings", sel_aid, sel_uname)
+
         srv = getattr(getattr(adapter, "client", None), "server", None)
         if not srv:
             raise RuntimeError("PLEX server not bound")
@@ -594,7 +599,7 @@ def _get_existing_rating(srv: Any, rating_key: Any) -> int | None:
     return _norm_rating(getattr(it, "userRating", None))
 
 def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
-    _, did_switch, _, _ = home_scope_enter(adapter)
+    need_scope, did_switch, sel_aid, sel_uname = home_scope_enter(adapter)
     try:
         srv = getattr(getattr(adapter, "client", None), "server", None)
         if not srv:
@@ -603,6 +608,11 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 _UNRES.freeze(it, action="add", reasons=["no_plex_server"])
                 unresolved.append({"item": id_minimal(it), "hint": "no_plex_server"})
             _info("write_skipped", op="add", reason="no_server")
+            return 0, unresolved
+
+        if need_scope and not did_switch:
+            unresolved = unresolved_home_scope_not_applied(items, sel_aid, sel_uname)
+            _info("write_skipped", op="add", reason="home_scope_not_applied", selected=(sel_aid or sel_uname), unresolved=len(unresolved))
             return 0, unresolved
     
         ok = 0
@@ -645,7 +655,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
     finally:
         home_scope_exit(adapter, did_switch)
 def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
-    _, did_switch, _, _ = home_scope_enter(adapter)
+    need_scope, did_switch, sel_aid, sel_uname = home_scope_enter(adapter)
     try:
         srv = getattr(getattr(adapter, "client", None), "server", None)
         if not srv:
@@ -654,6 +664,11 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
                 _UNRES.freeze(it, action="remove", reasons=["no_plex_server"])
                 unresolved.append({"item": id_minimal(it), "hint": "no_plex_server"})
             _info("write_skipped", op="remove", reason="no_server")
+            return 0, unresolved
+
+        if need_scope and not did_switch:
+            unresolved = unresolved_home_scope_not_applied(items, sel_aid, sel_uname)
+            _info("write_skipped", op="remove", reason="home_scope_not_applied", selected=(sel_aid or sel_uname), unresolved=len(unresolved))
             return 0, unresolved
     
         ok = 0

--- a/providers/sync/plex/_watchlist.py
+++ b/providers/sync/plex/_watchlist.py
@@ -17,11 +17,13 @@ from ._common import (
     hydrate_external_ids,
     home_scope_enter,
     home_scope_exit,
+    raise_home_scope_not_applied,
     ids_from_discover_row,
     meta_guids,
     normalize_discover_row,
     plex_headers,
     sort_guid_candidates,
+    unresolved_home_scope_not_applied,
     unresolved_store,
     make_logger,
 )
@@ -466,8 +468,11 @@ def _pms_find_in_index(libtype: str, guid_candidates: list[str]) -> Any | None:
 
 # Index build
 def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
-    _, did_switch, _, _ = home_scope_enter(adapter)
+    need_scope, did_switch, sel_aid, sel_uname = home_scope_enter(adapter)
     try:
+        if need_scope and not did_switch:
+            raise_home_scope_not_applied("watchlist", sel_aid, sel_uname)
+
         token = active_cloud_token(adapter)
         if not token:
             raise RuntimeError("Plex token is required for watchlist index")
@@ -558,8 +563,13 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
 
 # Add
 def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
-    _, did_switch, _, _ = home_scope_enter(adapter)
+    need_scope, did_switch, sel_aid, sel_uname = home_scope_enter(adapter)
     try:
+        if need_scope and not did_switch:
+            unresolved = unresolved_home_scope_not_applied(items, sel_aid, sel_uname)
+            _info("write_skipped", op="add", reason="home_scope_not_applied", selected=(sel_aid or sel_uname), unresolved=len(unresolved))
+            return 0, unresolved
+
         token = active_cloud_token(adapter)
         if not token:
             raise RuntimeError("Plex token is required for watchlist writes")
@@ -702,8 +712,13 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
 
 # Remove
 def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
-    _, did_switch, _, _ = home_scope_enter(adapter)
+    need_scope, did_switch, sel_aid, sel_uname = home_scope_enter(adapter)
     try:
+        if need_scope and not did_switch:
+            unresolved = unresolved_home_scope_not_applied(items, sel_aid, sel_uname)
+            _info("write_skipped", op="remove", reason="home_scope_not_applied", selected=(sel_aid or sel_uname), unresolved=len(unresolved))
+            return 0, unresolved
+
         token = active_cloud_token(adapter)
         if not token:
             raise RuntimeError("Plex token is required for watchlist writes")


### PR DESCRIPTION
# Pull request

## Change

- Added clearer Plex profile picker feedback when a profile is not connected yet.
- Added warnings when selecting Plex friend/shared accounts, including saved selections on profile load.
- Prevented Plex watchlist, ratings, and progress sync from falling back to the token owner when selected user scoping fails.
- Polished the empty watchlist preview state so the empty message is centered and the poster rail is hidden until items render.

## Why

Plex friend/shared accounts can appear in the picker, but they usually cannot be synced with the server owner’s token. Previously, failed user scoping could silently continue with the token owner’s Plex data, which could sync the wrong watchlist, ratings, or progress.

The UI now explains the limitation, and the sync path fails closed instead of using the wrong account data.

## Testing

- ` providers\sync\plex\_common.py providers\sync\plex\_watchlist.py providers\sync\plex\_progress.py providers\sync\plex\_ratings.py api\authenticationAPI.py`

## Issue

Fixes #292