### PR TITLE
Fix: SIMKL anime movie history classification

### DIFF
--- a/api/versionAPI.py
+++ b/api/versionAPI.py
@@ -19,7 +19,7 @@ __all__ = ["router"]
 
 router = APIRouter(prefix="/api", tags=["version"])
 
-CURRENT_VERSION = os.getenv("APP_VERSION", "v0.9.23")
+CURRENT_VERSION = os.getenv("APP_VERSION", "v0.9.24")
 REPO = os.getenv("GITHUB_REPO", "cenodude/CrossWatch")
 
 

--- a/cw_platform/orchestrator/_planner.py
+++ b/cw_platform/orchestrator/_planner.py
@@ -21,14 +21,13 @@ def _strong_keys(item: Mapping[str, Any]) -> set[str]:
         s = str(v).strip().lower()
         return f"{k}:{s}" if s else None
 
-    ids = ids_from(item)
-    for k in _STRONG_ID_KEYS:
-        t = _tok(k, ids.get(k))
-        if t:
-            out.add(t)
-
     typ = str(item.get("type") or "").strip().lower()
+    ids = ids_from(item)
     if typ not in ("season", "episode"):
+        for k in _STRONG_ID_KEYS:
+            t = _tok(k, ids.get(k))
+            if t:
+                out.add(t)
         return out
 
     s = item.get("season") if item.get("season") is not None else item.get("season_number")
@@ -37,6 +36,10 @@ def _strong_keys(item: Mapping[str, Any]) -> set[str]:
         sn = int(s) if s is not None else None
         en = int(e) if e is not None else None
     except Exception:
+        for k in _STRONG_ID_KEYS:
+            t = _tok(k, ids.get(k))
+            if t:
+                out.add(t)
         return out
 
     frag: str | None = None
@@ -46,15 +49,21 @@ def _strong_keys(item: Mapping[str, Any]) -> set[str]:
         frag = f"#s{str(sn).zfill(2)}e{str(en).zfill(2)}"
 
     if not frag:
+        for k in _STRONG_ID_KEYS:
+            t = _tok(k, ids.get(k))
+            if t:
+                out.add(t)
         return out
 
+    source_ids: Mapping[str, Any] = ids
     show_ids_raw = item.get("show_ids")
     if isinstance(show_ids_raw, Mapping) and show_ids_raw:
-        sids = coalesce_ids(show_ids_raw)
-        for k in _STRONG_ID_KEYS:
-            t = _tok(k, sids.get(k))
-            if t:
-                out.add(f"{t}{frag}")
+        source_ids = coalesce_ids(show_ids_raw) or ids
+
+    for k in _STRONG_ID_KEYS:
+        t = _tok(k, source_ids.get(k))
+        if t:
+            out.add(f"{t}{frag}")
 
     return out
 

--- a/providers/sync/_mod_SIMKL.py
+++ b/providers/sync/_mod_SIMKL.py
@@ -23,7 +23,16 @@ from ._mod_common import (
     SimpleRateLimiter,
     request_with_retries,
 )
-from .simkl._common import _pair_scope as simkl_pair_scope, _is_capture_mode as simkl_capture_mode, build_headers, memoize_activities, normalize as simkl_normalize, key_of as simkl_key_of, state_file
+from .simkl._common import (
+    _pair_scope as simkl_pair_scope,
+    _is_capture_mode as simkl_capture_mode,
+    build_headers,
+    memoize_activities,
+    normalize as simkl_normalize,
+    key_of as simkl_key_of,
+    simkl_api_params,
+    state_file,
+)
 
 
 def _confirmed_keys(key_of, items: Iterable[Mapping[str, Any]], unresolved: Any) -> list[str]:
@@ -66,7 +75,7 @@ def _confirmed_keys(key_of, items: Iterable[Mapping[str, Any]], unresolved: Any)
         seen.add(k)
     return out
 
-__VERSION__ = "1.0"
+__VERSION__ = "1.1"
 __all__ = ["get_manifest", "SIMKLModule", "OPS"]
 
 
@@ -255,12 +264,18 @@ class SIMKLClient:
         )
 
     def _request(self, method: str, url: str, **kw: Any) -> requests.Response:
+        params = dict(kw.pop("params", {}) or {})
+        merged_params = simkl_api_params(self.cfg.api_key)
+        merged_params.update(params)
+        kw["params"] = merged_params
+        timeout = kw.pop("timeout", self.cfg.timeout)
+        max_retries = kw.pop("max_retries", self.cfg.max_retries)
         return request_with_retries(
             self.session,
             method,
             url,
-            timeout=self.cfg.timeout,
-            max_retries=self.cfg.max_retries,
+            timeout=timeout,
+            max_retries=max_retries,
             **kw,
         )
 
@@ -269,7 +284,7 @@ class SIMKLClient:
 
     def activities(self) -> dict[str, Any]:
         try:
-            r = self._request("POST", f"{self.BASE}/sync/activities")
+            r = self._request("GET", f"{self.BASE}/sync/activities")
             if r.ok:
                 return r.json() if r.text else {}
             return {"status": r.status_code}
@@ -358,13 +373,7 @@ class SIMKLModule:
 
         if need_core:
             try:
-                r = request_with_retries(
-                    sess,
-                    "POST",
-                    f"{base}/sync/activities",
-                    timeout=tmo,
-                    max_retries=self.cfg.max_retries,
-                )
+                r = self.client._request("GET", f"{base}/sync/activities", timeout=tmo)
                 core_code = r.status_code
                 if r.status_code in (401, 403):
                     core_reason = "unauthorized"

--- a/providers/sync/simkl/_common.py
+++ b/providers/sync/simkl/_common.py
@@ -25,6 +25,32 @@ def simkl_user_agent() -> str:
             return f"CrossWatch/{version.strip()} (SIMKL)"
     return "CrossWatch (SIMKL)"
 
+
+def simkl_app_version() -> str:
+    env_version = str(os.getenv("APP_VERSION") or "").strip()
+    if env_version:
+        return env_version
+    for mod_name in ("sync._mod_SIMKL", "providers.sync._mod_SIMKL"):
+        mod = sys.modules.get(mod_name)
+        version = getattr(mod, "__VERSION__", None) if mod is not None else None
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    return "1.0"
+
+
+def simkl_api_params(api_key: Any, **extra: Any) -> dict[str, Any]:
+    params: dict[str, Any] = {
+        "client_id": str(api_key or "").strip(),
+        "app-name": "crosswatch",
+        "app-version": simkl_app_version(),
+    }
+    params.update({k: v for k, v in extra.items() if v is not None})
+    return params
+
+
+def simkl_api_params_from_headers(headers: Mapping[str, Any], **extra: Any) -> dict[str, Any]:
+    return simkl_api_params((headers or {}).get("simkl-api-key"), **extra)
+
 STATE_DIR = Path("/config/.cw_state")
 
 
@@ -427,7 +453,12 @@ def fetch_activities(
     url = "https://api.simkl.com/sync/activities"
     rate: dict[str, Any] = {}
     try:
-        resp = session.post(url, headers=dict(headers), timeout=timeout)
+        resp = session.get(
+            url,
+            headers=dict(headers),
+            params=simkl_api_params_from_headers(headers),
+            timeout=timeout,
+        )
         rate = parse_rate_limit(resp.headers)
         if 200 <= resp.status_code < 300:
             data = resp.json() if (resp.text or "").strip() else {}
@@ -642,6 +673,9 @@ __all__ = [
     "load_json_state",
     "save_json_state",
     "slug_to_title",
+    "simkl_app_version",
+    "simkl_api_params",
+    "simkl_api_params_from_headers",
     "anime_tvdb_map_path",
     "load_anime_tvdb_map",
     "save_anime_tvdb_map",

--- a/providers/sync/simkl/_history.py
+++ b/providers/sync/simkl/_history.py
@@ -19,6 +19,7 @@ from ._common import (
     load_json_state,
     maybe_map_tvdb_ids,
     normalize_flat_watermarks,
+    simkl_api_params_from_headers,
     key_of as simkl_key_of,
     normalize as simkl_normalize,
     save_json_state,
@@ -45,11 +46,12 @@ _MOVIE_ID_KEYS = ("tmdb", "imdb", "tvdb", "trakt", "simkl")  # anime IDs exclude
 _EP_LOOKUP_MEMO: dict[str, dict[tuple[int, int], dict[str, Any]]] = {}
 def _maybe_map_tvdb(adapter: Any, ids: Mapping[str, Any]) -> dict[str, str]:
     def _fetch_rows() -> Iterable[Mapping[str, Any]]:
+        headers = _headers(adapter, force_refresh=True)
         try:
             resp = adapter.client.session.get(
                 f"{BASE}/sync/all-items/anime",
-                headers=_headers(adapter, force_refresh=True),
-                params={"extended": "full_anime_seasons"},
+                headers=headers,
+                params=simkl_api_params_from_headers(headers, extended="full_anime_seasons"),
                 timeout=adapter.cfg.timeout,
             )
             data = resp.json() if resp.ok else {}
@@ -283,16 +285,13 @@ def _episode_lookup(
             d["simkl"] = d["simkl_id"]
         return {k: str(d[k]) for k in ID_KEYS if d.get(k)}
 
-    client_id = str(headers.get("simkl-api-key") or "").strip()
-
     for cand in candidates:
         out: dict[tuple[int, int], dict[str, Any]] = {}
         url = f"{base_url}/{cand}"
-        params: dict[str, str] = {
-            "extended": "full_anime_seasons" if str(kind).lower() == "anime" else "full",
-        }
-        if client_id:
-            params["client_id"] = client_id
+        params = simkl_api_params_from_headers(
+            headers,
+            extended="full_anime_seasons" if str(kind).lower() == "anime" else "full",
+        )
         try:
             resp = session.get(url, headers=dict(headers), params=params, timeout=timeout)
             if not resp.ok:
@@ -539,11 +538,15 @@ def _inject_adds_into_cache(items_list: list[Mapping[str, Any]]) -> None:
             entry["season"] = item.get("season")
             entry["episode"] = item.get("episode")
             entry["series_title"] = item.get("series_title")
-            entry["simkl_bucket"] = "shows"
+            entry["simkl_bucket"] = str(item.get("simkl_bucket") or "shows").strip().lower() or "shows"
         else:
             entry["title"] = item.get("title")
             entry["year"] = item.get("year")
-            entry["simkl_bucket"] = "movies"
+            bucket = str(item.get("simkl_bucket") or "").strip().lower()
+            entry["simkl_bucket"] = bucket if bucket in {"movies", "shows", "anime"} else ("movies" if item_type == "movie" else "shows")
+            anime_type = str(item.get("anime_type") or "").strip().lower()
+            if anime_type:
+                entry["anime_type"] = anime_type
         to_inject[event_key] = entry
 
     if not to_inject:
@@ -554,6 +557,84 @@ def _inject_adds_into_cache(items_list: list[Mapping[str, Any]]) -> None:
     _dbg("cache_injected", count=len(to_inject))
 
 
+def _response_bucket(simkl_type: Any) -> str | None:
+    typ = str(simkl_type or "").strip().lower()
+    if typ in {"movie", "movies"}:
+        return "movies"
+    if typ in {"show", "shows", "tv", "tv_show", "tv_shows"}:
+        return "shows"
+    if typ == "anime":
+        return "anime"
+    return None
+
+
+def _response_classification(row: Any) -> dict[str, str]:
+    if not isinstance(row, Mapping):
+        return {}
+    response = row.get("response")
+    src: Mapping[str, Any] = response if isinstance(response, Mapping) else row
+    out: dict[str, str] = {}
+    bucket = _response_bucket(src.get("simkl_type") or src.get("type") or row.get("simkl_type"))
+    if bucket:
+        out["simkl_bucket"] = bucket
+    anime_type = src.get("anime_type") or src.get("animeType") or row.get("anime_type") or row.get("animeType")
+    if isinstance(anime_type, str) and anime_type.strip():
+        out["anime_type"] = anime_type.strip().lower()
+    status = src.get("status") or row.get("status")
+    if isinstance(status, str) and status.strip():
+        out["simkl_status"] = status.strip().lower()
+    return out
+
+
+def _response_ids(row: Any) -> dict[str, str]:
+    if not isinstance(row, Mapping):
+        return {}
+    response = row.get("response")
+    src: Mapping[str, Any] = response if isinstance(response, Mapping) else row
+    ids = src.get("ids") if isinstance(src.get("ids"), Mapping) else row.get("ids")
+    if not isinstance(ids, Mapping):
+        return {}
+    return {str(k).lower(): str(v) for k, v in ids.items() if v not in (None, "")}
+
+
+def _classification_key(item: Mapping[str, Any]) -> str:
+    return json.dumps(dict(_scope_ids_for_freeze(item) or _ids_of(item) or {}), sort_keys=True)
+
+
+def _apply_response_classification(items_list: list[Mapping[str, Any]], payload: Mapping[str, Any]) -> None:
+    added = payload.get("added")
+    statuses = added.get("statuses") if isinstance(added, Mapping) else None
+    if not isinstance(statuses, list):
+        return
+
+    by_key: dict[str, list[Mapping[str, Any]]] = {}
+    by_id: dict[tuple[str, str], list[Mapping[str, Any]]] = {}
+    for item in items_list:
+        if not isinstance(item, Mapping):
+            continue
+        by_key.setdefault(_classification_key(item), []).append(item)
+        for field, value in (_scope_ids_for_freeze(item) or _ids_of(item) or {}).items():
+            if value not in (None, ""):
+                by_id.setdefault((str(field).lower(), str(value)), []).append(item)
+
+    fallback = [item for item in items_list if isinstance(item, Mapping)]
+    for idx, row in enumerate(statuses):
+        cls = _response_classification(row)
+        if not cls:
+            continue
+        matches: list[Mapping[str, Any]] = []
+        ids = _response_ids(row)
+        for field, value in ids.items():
+            matches.extend(by_id.get((field, value), []))
+        if not matches and ids:
+            matches = by_key.get(json.dumps(ids, sort_keys=True), [])
+        if not matches and idx < len(fallback):
+            matches = [fallback[idx]]
+        for item in matches:
+            if isinstance(item, dict):
+                item.update(cls)
+
+
 def _fetch_all_items(
     session: Any,
     headers: Mapping[str, str],
@@ -561,11 +642,12 @@ def _fetch_all_items(
     since_iso: str | None,
     timeout: float,
 ) -> dict[str, list[dict[str, Any]]]:
-    params: dict[str, str] = {
-        "extended": "full_anime_seasons",
-        "episode_watched_at": "yes",
-        "include_all_episodes": "yes",
-    }
+    params = simkl_api_params_from_headers(
+        headers,
+        extended="full_anime_seasons",
+        episode_watched_at="yes",
+        include_all_episodes="yes",
+    )
     if since_iso:
         params["date_from"] = since_iso
     resp = session.get(URL_ALL_ITEMS, headers=headers, params=params, timeout=timeout)
@@ -584,6 +666,16 @@ def _fetch_all_items(
         if isinstance(rows, list):
             out[kind] = [x for x in rows if isinstance(x, dict) and not _is_null_env(x)]
     return out
+
+
+def _anime_type_from_row(row: Mapping[str, Any], show: Any, base: Mapping[str, Any]) -> str | None:
+    for node in (show, row.get("anime"), row.get("show"), row, base):
+        if not isinstance(node, Mapping):
+            continue
+        at = node.get("anime_type") or node.get("animeType")
+        if isinstance(at, str) and at.strip():
+            return at.strip().lower()
+    return None
 
 
 def _apply_since_limit(
@@ -687,8 +779,7 @@ def _parse_rows(
             sid = str(show_ids.get("simkl") or "").strip()
             series_name = f"SIMKL:{sid}" if sid else "Unknown Series"
         if row_kind == "anime":
-            at = (show.get("anime_type") or show.get("animeType")) if isinstance(show, Mapping) else None
-            anime_type = at.strip().lower() if isinstance(at, str) and at.strip() else None
+            anime_type = _anime_type_from_row(row, show, base)
             if anime_type == "movie":
                 watched_at = (row.get("last_watched_at") or row.get("watched_at") or "").strip()
                 if not watched_at:
@@ -1204,9 +1295,16 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         return 0, unresolved
 
     try:
-        resp = session.post(URL_ADD, headers=headers, json=body, timeout=timeout)
+        resp = session.post(
+            URL_ADD,
+            headers=headers,
+            params=simkl_api_params_from_headers(headers),
+            json=body,
+            timeout=timeout,
+        )
         if 200 <= resp.status_code < 300:
             _unfreeze(thaw_keys)
+            payload: dict[str, Any] = {}
             eps_count = sum(
                 len(season.get("episodes", []))
                 for group in shows_scoped.values()
@@ -1224,6 +1322,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             try:
                 payload = resp.json() if (resp.text or '').strip() else {}
                 if isinstance(payload, dict):
+                    _apply_response_classification(items_list, payload)
                     a = payload.get("added")
                     if isinstance(a, dict):
                         added_new["movies"] = int(a.get("movies") or 0)
@@ -1407,7 +1506,13 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
         if not body:
             continue
         try:
-            resp = session.post(URL_REMOVE, headers=headers, json=body, timeout=timeout)
+            resp = session.post(
+                URL_REMOVE,
+                headers=headers,
+                params=simkl_api_params_from_headers(headers),
+                json=body,
+                timeout=timeout,
+            )
             if 200 <= resp.status_code < 300:
                 _unfreeze(thaw_keys)
                 ok += len(thaw_keys)

--- a/providers/sync/simkl/_ratings.py
+++ b/providers/sync/simkl/_ratings.py
@@ -18,6 +18,7 @@ from ._common import (
     load_json_state,
     maybe_map_tvdb_ids,
     normalize_flat_watermarks,
+    simkl_api_params_from_headers,
     key_of as simkl_key_of,
     normalize as simkl_normalize,
     save_json_state,
@@ -44,11 +45,12 @@ ID_KEYS = ("tmdb", "imdb", "tvdb", "simkl", "trakt", "mal", "anilist", "kitsu", 
 
 def _maybe_map_tvdb(adapter: Any, ids: Mapping[str, Any]) -> dict[str, str]:
     def _fetch_rows() -> Iterable[Mapping[str, Any]]:
+        headers = _headers(adapter, force_refresh=True)
         try:
             resp = adapter.client.session.get(
                 f"{BASE}/sync/all-items/anime",
-                headers=_headers(adapter, force_refresh=True),
-                params={"extended": "full_anime_seasons"},
+                headers=headers,
+                params=simkl_api_params_from_headers(headers, extended="full_anime_seasons"),
                 timeout=adapter.cfg.timeout,
             )
             data = resp.json() if resp.ok else {}
@@ -535,10 +537,7 @@ def _resolve_by_simkl_id(
     simkl_id: int,
     timeout: float,
 ) -> Mapping[str, Any]:
-    client_id = str(hdrs.get("simkl-api-key") or "").strip()
-    params: dict[str, str] = {"extended": "full"}
-    if client_id:
-        params["client_id"] = client_id
+    params = simkl_api_params_from_headers(hdrs, extended="full")
 
     k = str(kind or "").lower()
     if k == "movies":
@@ -572,7 +571,12 @@ def _fetch_rows_current(
         return [], False
     url = f"{BASE}/sync/ratings/{kind}/{RATINGS_ALL}"
     try:
-        resp = sess.post(url, headers=dict(hdrs), timeout=timeout)
+        resp = sess.get(
+            url,
+            headers=dict(hdrs),
+            params=simkl_api_params_from_headers(hdrs),
+            timeout=timeout,
+        )
         if resp.status_code != 200:
             _warn("http_failed", op="index", kind=kind, status=resp.status_code, body=(resp.text or "")[:200])
             return [], False
@@ -969,7 +973,13 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             body["shows"] = shows
 
         try:
-            resp = sess.post(URL_ADD, headers=hdrs, json=body, timeout=adapter.cfg.timeout)
+            resp = sess.post(
+                URL_ADD,
+                headers=hdrs,
+                params=simkl_api_params_from_headers(hdrs),
+                json=body,
+                timeout=adapter.cfg.timeout,
+            )
             if 200 <= resp.status_code < 300:
                 _unfreeze_if_present(thaw_keys)
                 ok += len(movies) + len(shows)
@@ -1058,7 +1068,13 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
             body["shows"] = shows
 
         try:
-            resp = sess.post(URL_REMOVE, headers=hdrs, json=body, timeout=adapter.cfg.timeout)
+            resp = sess.post(
+                URL_REMOVE,
+                headers=hdrs,
+                params=simkl_api_params_from_headers(hdrs),
+                json=body,
+                timeout=adapter.cfg.timeout,
+            )
             if 200 <= resp.status_code < 300:
                 _unfreeze_if_present(thaw_keys)
                 try:

--- a/providers/sync/simkl/_watchlist.py
+++ b/providers/sync/simkl/_watchlist.py
@@ -19,6 +19,7 @@ from ._common import (
     get_watermark,
     load_json_state,
     normalize_flat_watermarks,
+    simkl_api_params_from_headers,
     key_of as simkl_key_of,
     save_json_state,
     save_watermark,
@@ -533,11 +534,12 @@ def _pull_bucket(
         params: dict[str, Any],
         force: bool,
     ) -> dict[str, dict[str, Any]]:
+        headers = _headers(adapter, force_refresh=force)
         try:
             resp = session.get(
                 url,
-                headers=_headers(adapter, force_refresh=force),
-                params=params,
+                headers=headers,
+                params=simkl_api_params_from_headers(headers, **params),
                 timeout=adapter.cfg.timeout,
             )
             if resp.status_code != 200:
@@ -590,6 +592,7 @@ def _pull_all_watchlist(
     force_refresh: bool = False,
 ) -> dict[str, dict[str, Any]]:
     session = adapter.client.session
+    headers = _headers(adapter, force_refresh=force_refresh)
     params: dict[str, Any] = {}
     if date_from:
         params["date_from"] = date_from
@@ -597,8 +600,8 @@ def _pull_all_watchlist(
     try:
         resp = session.get(
             URL_INDEX_ALL,
-            headers=_headers(adapter, force_refresh=force_refresh),
-            params=params or None,
+            headers=headers,
+            params=simkl_api_params_from_headers(headers, **params),
             timeout=adapter.cfg.timeout,
         )
         if resp.status_code != 200:
@@ -1033,6 +1036,7 @@ def add(
             resp = session.post(
                 URL_ADD,
                 headers=headers,
+                params=simkl_api_params_from_headers(headers),
                 json=body,
                 timeout=adapter.cfg.timeout,
             )
@@ -1133,6 +1137,7 @@ def remove(
             resp = session.post(
                 URL_REMOVE,
                 headers=headers,
+                params=simkl_api_params_from_headers(headers),
                 json=payload,
                 timeout=adapter.cfg.timeout,
             )


### PR DESCRIPTION
# Pull request

## Change

Updated the SIMKL sync adapter to follow the current SIMKL API more closely.
- Preserve SIMKL response classification (`simkl_type`, `anime_type`, status) after history writes.
- Keep SIMKL anime movies as movie records instead of synthetic episode records.
- Tighten orchestrator episode/season strong-key matching so episode keys use show IDs plus season/episode context.

## Why

SIMKL can expose anime movies in a show-like progress model, such as a movie trilogy with episode-style progress rows.
Without preserving SIMKL’s media classification, CrossWatch could treat a TMDB movie ID as a TV-show parent ID and create bad records like:

`tmdb:1311031#s01e01`

That caused anime movies to appear as unrelated TV episodes and made the analyzer/editor hard to use because the row was already stored with the wrong media type.

## Testing

Manual testing:
- Marked the affected SIMKL anime movie/progress item and imported SIMKL history into CrossWatch.
- Confirmed CrossWatch now stores TMDB `1311031` as `MOVIE` with key `tmdb:1311031`.
- Confirmed the previous bad shape `tmdb:1311031#s01e01` no longer appears for this item.

## Issue

Fixes #266
SIMKL anime movie history records being imported as synthetic TV episodes.