### PR TITLE
Add: support Plex shared-user tokens for friend/shared Plex users

### DIFF
--- a/assets/auth/auth.plex.js
+++ b/assets/auth/auth.plex.js
@@ -238,7 +238,7 @@ function ensurePlexInstanceUI() {
     }
     const name = String(user?.username || "This friend").trim() || "This friend";
     el.classList.remove("hidden");
-    el.textContent = `${name} is a Plex friend/shared account, not a Plex Home user. Syncing this account's watchlist, ratings, or history is highly unlikely to work with your Plex token. Create a separate Plex profile and authenticate with that friend's Plex account instead.`;
+    el.textContent = `${name} is a Plex friend/shared account, not a Plex Home user. CrossWatch can only use Plex's server-scoped shared token for History and Progress. Ratings and Watchlist still need that friend's own Plex profile/authentication, and Plex may remove this token path later.`;
   }
 
   function setPlexSuccess(on, text) {

--- a/cw_platform/anime_mapping/auto_update.py
+++ b/cw_platform/anime_mapping/auto_update.py
@@ -109,7 +109,6 @@ class AnimeMappingAutoUpdater:
                     self._set_status(enabled=True, last_check_at=last_checked, next_check_at=due_at)
 
                     if due_at and now < due_at:
-                        log("auto_update_waiting", level="debug", module="ANIME_MAPPING", extra={"release_tag": tag, "next_check_at": due_at})
                         self._sleep(min(MAX_SLEEP_SECONDS, max(1, due_at - now)))
                         continue
 

--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -35,7 +35,7 @@ def _error(event: str, **fields: Any) -> None:
 def _log(msg: str) -> None:
     _dbg(msg)
 
-__VERSION__ = "1.0"
+__VERSION__ = "1.1"
 os.environ.setdefault("CW_PLEX_VERSION", __VERSION__)
 os.environ.setdefault("CW_PLEX_UA", f"CrossWatch/{__VERSION__} (Plex)")
 __all__ = ["get_manifest", "PLEXModule", "PLEXClient", "PLEXError", "PLEXAuthError", "PLEXNotFound", "OPS"]
@@ -60,7 +60,7 @@ from .plex._common import (
     stable_client_id,
     set_client_id,
 )
-from .plex._utils import resolve_user_scope
+from .plex._utils import fetch_shared_server_token, resolve_user_scope
 from ._mod_common import (
     build_session,
     request_with_retries,
@@ -403,7 +403,9 @@ class PLEXClient:
 
         self._home_users_cache: list[dict[str, Any]] | None = None
         self._home_users_cache_ts: float = 0.0
-        self._token_stack: list[tuple[str | None, str | None, str | None, int | None, int | None]] = []
+        self._cloud_token_suppressed = False
+        self._user_scope_kind: str | None = None
+        self._token_stack: list[tuple[str | None, str | None, str | None, int | None, int | None, bool, str | None]] = []
 
     def connect(self) -> PLEXClient:
         try:
@@ -694,8 +696,12 @@ class PLEXClient:
             prev_token = None
 
         prev_cloud = self.cloud_token
+        prev_cloud_suppressed = self._cloud_token_suppressed
+        prev_scope_kind = self._user_scope_kind
         self.cloud_token = user_token
-        self._token_stack.append((prev_token, prev_cloud, self.user_username, self.user_account_id, self.user_home_id))
+        self._cloud_token_suppressed = False
+        self._user_scope_kind = "home"
+        self._token_stack.append((prev_token, prev_cloud, self.user_username, self.user_account_id, self.user_home_id, prev_cloud_suppressed, prev_scope_kind))
         self.session.headers["X-Plex-Token"] = pms_user_token
 
         try:
@@ -740,10 +746,101 @@ class PLEXClient:
         )
         return True
 
+    def enter_shared_user_scope(
+        self,
+        *,
+        target_username: str | None = None,
+        target_account_id: int | None = None,
+    ) -> bool:
+        srv = self.server
+        token = self.cloud_token or self.cfg.token
+        if not srv or not token:
+            return False
+
+        machine_id = (self.cfg.machine_id or "").strip() or None
+        if not machine_id:
+            try:
+                machine_id = str(getattr(srv, "machineIdentifier", None) or "").strip() or None
+            except Exception:
+                machine_id = None
+        if not machine_id:
+            machine_id = self._infer_machine_id(srv)
+        if not machine_id:
+            _warn("shared_scope_failed", reason="missing_machine_identifier")
+            return False
+
+        client_id = _plex_tv_client_id(self.cfg)
+        try:
+            pms_user_token = fetch_shared_server_token(
+                token,
+                machine_id=machine_id,
+                client_id=client_id,
+                user_id=target_account_id,
+                username=target_username,
+                timeout=float(self.cfg.timeout),
+            )
+        except Exception as e:
+            _warn("shared_scope_token_failed", error=str(e))
+            return False
+
+        if not pms_user_token:
+            return False
+
+        prev_token_raw = self.session.headers.get("X-Plex-Token")
+        if isinstance(prev_token_raw, bytes):
+            prev_token = prev_token_raw.decode("utf-8", "ignore")
+        elif isinstance(prev_token_raw, str):
+            prev_token = prev_token_raw
+        else:
+            prev_token = None
+
+        prev_cloud = self.cloud_token
+        prev_cloud_suppressed = self._cloud_token_suppressed
+        prev_scope_kind = self._user_scope_kind
+        self._token_stack.append((prev_token, prev_cloud, self.user_username, self.user_account_id, self.user_home_id, prev_cloud_suppressed, prev_scope_kind))
+        self.cloud_token = None
+        self._cloud_token_suppressed = True
+        self._user_scope_kind = "shared"
+        self.session.headers["X-Plex-Token"] = pms_user_token
+
+        try:
+            srv._token = pms_user_token  # type: ignore[attr-defined]
+        except Exception:
+            pass
+        try:
+            sess = getattr(srv, "_session", None) or self.session
+            sess.headers["X-Plex-Token"] = pms_user_token
+        except Exception:
+            pass
+
+        try:
+            baseurl = str(getattr(srv, "baseurl", None) or self._pms_baseurl or self.cfg.baseurl or "")
+            if baseurl:
+                configure_plex_context(baseurl=baseurl, token=pms_user_token)
+        except Exception:
+            pass
+
+        try:
+            rr = request_with_retries(self.session, "GET", srv.url("/library/sections"), timeout=float(self.cfg.timeout), max_retries=1)
+            if rr.status_code in (401, 403):
+                _warn("shared_scope_failed", reason="token_rejected")
+                self.exit_home_user_scope()
+                return False
+        except Exception as e:
+            _warn("shared_scope_verify_failed", error=str(e))
+            self.exit_home_user_scope()
+            return False
+
+        self.user_username = (target_username or "").strip() or None
+        self.user_home_id = None
+        self.user_account_id = target_account_id
+        _info("shared_scope_entered", user=str(self.user_username or ""), account_id=self.user_account_id)
+        return True
+
     def exit_home_user_scope(self) -> None:
         if not self._token_stack:
             return
-        prev_token, prev_cloud, prev_uname, prev_aid, prev_hid = self._token_stack.pop()
+        prev_token, prev_cloud, prev_uname, prev_aid, prev_hid, prev_cloud_suppressed, prev_scope_kind = self._token_stack.pop()
         srv = self.server
         if prev_token:
             try:
@@ -770,6 +867,8 @@ class PLEXClient:
         self.user_account_id = prev_aid
         self.user_home_id = prev_hid
         self.cloud_token = prev_cloud
+        self._cloud_token_suppressed = prev_cloud_suppressed
+        self._user_scope_kind = prev_scope_kind
 
     def account(self) -> MyPlexAccount:
         if not self._account:

--- a/providers/sync/plex/_common.py
+++ b/providers/sync/plex/_common.py
@@ -436,6 +436,11 @@ def active_pms_token(source: Any) -> str | None:
 def active_cloud_token(source: Any) -> str | None:
     for obj in (source, getattr(source, "client", None)):
         try:
+            if bool(getattr(obj, "_cloud_token_suppressed", False)):
+                return None
+        except Exception:
+            pass
+        try:
             tok = getattr(obj, "cloud_token", None)
             if tok and str(tok).strip():
                 return str(tok).strip()
@@ -1980,26 +1985,39 @@ def home_scope_enter(adapter: Any) -> tuple[bool, bool, int | None, str | None]:
     if not need:
         return False, False, sel_aid, sel_uname
 
+    can_home = False
     try:
-        if not bool(getattr(cli, "can_home_switch")()):
-            return True, False, sel_aid, sel_uname
+        can_home = bool(getattr(cli, "can_home_switch")())
     except Exception:
-        return True, False, sel_aid, sel_uname
+        can_home = False
 
-    pin = (getattr(getattr(cli, "cfg", None), "home_pin", None) or "").strip() or None
-    try:
-        ok = bool(
-            getattr(cli, "enter_home_user_scope")(
-                target_username=(str(desired_uname).strip() if desired_uname else None),
-                target_account_id=(int(desired_aid) if desired_aid is not None else None),
-                pin=pin,
+    ok = False
+    if can_home:
+        pin = (getattr(getattr(cli, "cfg", None), "home_pin", None) or "").strip() or None
+        try:
+            ok = bool(
+                getattr(cli, "enter_home_user_scope")(
+                    target_username=(str(desired_uname).strip() if desired_uname else None),
+                    target_account_id=(int(desired_aid) if desired_aid is not None else None),
+                    pin=pin,
+                )
             )
-        )
-    except Exception:
-        ok = False
+        except Exception:
+            ok = False
 
     if not ok:
-        _warn("home_scope_not_applied", selected=(desired_aid or desired_uname))
+        try:
+            ok = bool(
+                getattr(cli, "enter_shared_user_scope")(
+                    target_username=(str(desired_uname).strip() if desired_uname else None),
+                    target_account_id=(int(desired_aid) if desired_aid is not None else None),
+                )
+            )
+        except Exception:
+            ok = False
+
+    if not ok:
+        _warn("user_scope_not_applied", selected=(desired_aid or desired_uname))
     return True, ok, sel_aid, sel_uname
 
 

--- a/providers/sync/plex/_ratings.py
+++ b/providers/sync/plex/_ratings.py
@@ -54,15 +54,37 @@ def _preferred_pms_token(adapter: Any) -> tuple[str, str]:
     srv = getattr(cli, "server", None)
 
     for source, value in (
+        ("active_pms_token", active_pms_token(adapter)),
+        ("server._token", getattr(srv, "_token", None)),
         ("client._pms_token", getattr(cli, "_pms_token", None)),
         ("cfg.pms_token", getattr(getattr(cli, "cfg", None), "pms_token", None)),
-        ("server._token", getattr(srv, "_token", None)),
-        ("active_pms_token", active_pms_token(adapter)),
     ):
         tok = str(value or "").strip()
         if tok:
             return tok, source
     return "", "none"
+
+
+def _selected_account_id_for_query(adapter: Any) -> int:
+    def _int_or_zero(v: Any) -> int:
+        try:
+            return int(v or 0)
+        except Exception:
+            return 0
+
+    cfg_acct_id = _int_or_zero(plex_cfg_get(adapter, "account_id", 0))
+    if not cfg_acct_id:
+        cfg_acct_id = _int_or_zero(getattr(getattr(adapter, "cfg", None), "account_id", None))
+    cli_acct_id = _int_or_zero(getattr(getattr(adapter, "client", None), "user_account_id", None))
+    return cfg_acct_id or cli_acct_id
+
+
+def _shared_user_scope_active(adapter: Any) -> bool:
+    try:
+        cli = getattr(adapter, "client", None)
+        return str(getattr(cli, "_user_scope_kind", "") or "").strip().lower() == "shared" or bool(getattr(cli, "_cloud_token_suppressed", False))
+    except Exception:
+        return False
 
 def _container_from_plex_response(resp: Any) -> Mapping[str, Any] | None:
     try:
@@ -293,6 +315,13 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
     try:
         if need_scope and not did_switch:
             raise_home_scope_not_applied("ratings", sel_aid, sel_uname)
+        if _shared_user_scope_active(adapter):
+            _warn(
+                "index_skipped",
+                reason="shared_user_ratings_unsupported",
+                selected=(sel_aid or sel_uname),
+            )
+            return {}
 
         srv = getattr(getattr(adapter, "client", None), "server", None)
         if not srv:
@@ -326,6 +355,7 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
         page_size = int(plex_cfg_get(adapter, "ratings_page_size", 120) or 120)
         page_size = max(10, min(page_size, 200))
         workers = plex_worker_count(adapter, "rating_workers", "CW_PLEX_RATING_WORKERS", 12)
+        account_id = _selected_account_id_for_query(adapter)
 
         allow = plex_feature_library_ids(adapter, "ratings")
     
@@ -419,6 +449,8 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
                     "X-Plex-Container-Size": page_size,
                     "userRating>>": 0,
                 }
+                if account_id:
+                    params["accountID"] = int(account_id)
                 r = ses.get(path, params=params, headers=hdrs, timeout=tmo)
                 if not r.ok:
                     raise RuntimeError(f"PLEX ratings fast query failed (status={r.status_code})")
@@ -530,7 +562,7 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
                                         prog.done(ok=True, total=max(total, scanned) if total else None)
                                     except Exception:
                                         pass
-                                _info("index_done", count=len(out), added=added, scanned=scanned, fb_try=fb_try, fb_ok=fb_ok, workers=workers, truncated=True, limit=limit)
+                                _info("index_done", count=len(out), added=added, scanned=scanned, fb_try=fb_try, fb_ok=fb_ok, workers=workers, truncated=True, limit=limit, account_id=account_id, token_source=tok_source)
                                 return True
                         _tick()
                 finally:
@@ -551,7 +583,7 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
                                     prog.done(ok=True, total=max(total, scanned) if total else None)
                                 except Exception:
                                     pass
-                            _info("index_done", count=len(out), added=added, scanned=scanned, fb_try=fb_try, fb_ok=fb_ok, workers=workers, truncated=True, limit=limit)
+                            _info("index_done", count=len(out), added=added, scanned=scanned, fb_try=fb_try, fb_ok=fb_ok, workers=workers, truncated=True, limit=limit, account_id=account_id, token_source=tok_source)
                             return True
                     _tick()
             return False
@@ -586,7 +618,7 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
             except Exception:
                 pass
     
-        _info("index_done", count=len(out), added=added, scanned=scanned, fb_try=fb_try, fb_ok=fb_ok, workers=workers)
+        _info("index_done", count=len(out), added=added, scanned=scanned, fb_try=fb_try, fb_ok=fb_ok, workers=workers, account_id=account_id, token_source=tok_source)
         return out
     finally:
         home_scope_exit(adapter, did_switch)
@@ -613,6 +645,13 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         if need_scope and not did_switch:
             unresolved = unresolved_home_scope_not_applied(items, sel_aid, sel_uname)
             _info("write_skipped", op="add", reason="home_scope_not_applied", selected=(sel_aid or sel_uname), unresolved=len(unresolved))
+            return 0, unresolved
+        if _shared_user_scope_active(adapter):
+            unresolved: list[dict[str, Any]] = []
+            for it in items or []:
+                _UNRES.freeze(it, action="add", reasons=["shared_user_ratings_unsupported"])
+                unresolved.append({"item": id_minimal(it), "hint": "shared_user_ratings_unsupported"})
+            _warn("write_skipped", op="add", reason="shared_user_ratings_unsupported", selected=(sel_aid or sel_uname), unresolved=len(unresolved))
             return 0, unresolved
     
         ok = 0
@@ -669,6 +708,13 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
         if need_scope and not did_switch:
             unresolved = unresolved_home_scope_not_applied(items, sel_aid, sel_uname)
             _info("write_skipped", op="remove", reason="home_scope_not_applied", selected=(sel_aid or sel_uname), unresolved=len(unresolved))
+            return 0, unresolved
+        if _shared_user_scope_active(adapter):
+            unresolved: list[dict[str, Any]] = []
+            for it in items or []:
+                _UNRES.freeze(it, action="remove", reasons=["shared_user_ratings_unsupported"])
+                unresolved.append({"item": id_minimal(it), "hint": "shared_user_ratings_unsupported"})
+            _warn("write_skipped", op="remove", reason="shared_user_ratings_unsupported", selected=(sel_aid or sel_uname), unresolved=len(unresolved))
             return 0, unresolved
     
         ok = 0

--- a/providers/sync/plex/_utils.py
+++ b/providers/sync/plex/_utils.py
@@ -8,7 +8,7 @@ import re
 import time
 import ipaddress
 import xml.etree.ElementTree as ET
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 from typing import Any, Mapping
 
 import requests
@@ -557,6 +557,87 @@ def fetch_cloud_account_users(token: str, timeout: float = 8.0) -> list[dict[str
         except Exception:  # noqa: BLE001
             continue
     return []
+
+
+def fetch_shared_server_token(
+    token: str,
+    *,
+    machine_id: str,
+    client_id: str | None = None,
+    user_id: Any = None,
+    username: str | None = None,
+    timeout: float = 8.0,
+) -> str | None:
+    """Return Plex's provisional shared-server token for a friend user.
+
+    This mirrors PlexAPI's MyPlexUser.get_token(machineIdentifier) behavior.
+    Keep it isolated: Plex has said shared-server tokens may be removed later.
+    """
+
+    t = (token or "").strip()
+    mid = (machine_id or "").strip()
+    if not t or not mid:
+        return None
+
+    uid: int | None = None
+    try:
+        if user_id is not None and str(user_id).strip().isdigit():
+            uid = int(str(user_id).strip())
+    except Exception:  # noqa: BLE001
+        uid = None
+    uname = (username or "").strip().lower()
+    if uid is None and not uname:
+        return None
+
+    headers = _plex_headers(t)
+    if client_id and str(client_id).strip():
+        headers["X-Plex-Client-Identifier"] = str(client_id).strip()
+
+    url = f"https://plex.tv/api/servers/{quote(mid, safe='')}/shared_servers"
+    try:
+        response = requests.get(url, headers=headers, timeout=float(timeout))
+        if not response.ok or not (response.text or "").lstrip().startswith("<"):
+            return None
+        root = ET.fromstring(response.text or "")
+    except Exception:  # noqa: BLE001
+        return None
+
+    for el in root.iter():
+        attrs = getattr(el, "attrib", {}) or {}
+        access_token = (attrs.get("accessToken") or attrs.get("access_token") or "").strip()
+        if not access_token:
+            continue
+
+        raw_ids = (
+            attrs.get("userID"),
+            attrs.get("userId"),
+            attrs.get("user_id"),
+            attrs.get("accountID"),
+            attrs.get("accountId"),
+            attrs.get("account_id"),
+        )
+        id_match = False
+        if uid is not None:
+            for raw in raw_ids:
+                try:
+                    if raw is not None and int(str(raw).strip()) == uid:
+                        id_match = True
+                        break
+                except Exception:  # noqa: BLE001
+                    continue
+
+        raw_names = (
+            attrs.get("username"),
+            attrs.get("title"),
+            attrs.get("name"),
+            attrs.get("email"),
+        )
+        name_match = bool(uname) and any(str(n or "").strip().lower() == uname for n in raw_names)
+
+        if id_match or name_match:
+            return access_token
+
+    return None
 
 
 def _pms_id_from_attr_map(attrs: Mapping[str, Any]) -> int | None:


### PR DESCRIPTION
# Pull request

## Change

Adds Plex shared-server token support for friend/shared Plex users.

Shared Plex users can now enter a temporary server-scoped Plex context for supported server-side state. CrossWatch suppresses Plex cloud-token fallback during shared-user scope so cloud features do not accidentally use the server owner account.

Ratings are explicitly skipped for shared Plex users because Plex returns the server owner’s ratings even when the shared token and selected friend account ID are used. Watchlist remains unsupported for shared users because it is Plex cloud/account state.

## Why

This was needed so Plex friend/shared users can be configured in CrossWatch without requiring Plex Home access.

Runtime validation showed:
- Shared tokens work for server-side history/progress.
- Watchlist is account/cloud state and must not use the owner token.
- Ratings are unsafe through shared tokens because Plex returns owner ratings.

## Testing

- Manual runtime validation with Plex shared users:
  - history synced with the selected shared user
  - progress synced with the selected shared user
  - watchlist unsupported - stayed empty/skipped for shared users
  - ratings unsupported  - stayed empty/skipped for shared users

## Issue

Fixes #237