### PR TITLE
Fix: TMDb metadata gating for dashboard widgets

### DIFF
--- a/assets/helpers/settings-ui.js
+++ b/assets/helpers/settings-ui.js
@@ -1042,13 +1042,17 @@ function cwBuildTmdbPanel() {
   checkRow.style.marginTop = "10px";
   checkRow.style.gap = "10px";
   checkRow.style.alignItems = "center";
-  checkRow.style.justifyContent = "space-between";
+  checkRow.style.justifyContent = "flex-start";
   checkRow.innerHTML = `
     <button type="button" class="btn secondary" id="tmdb_check">Check</button>
+    <button type="button" class="btn danger" id="tmdb_delete">Delete</button>
     <div id="tmdb_check_msg" class="msg ok hidden" aria-live="polite" style="margin-left:auto;width:auto;max-width:min(520px,60%);flex:0 1 auto;white-space:normal"></div>
   `;
   checkRow.querySelector("#tmdb_check")?.addEventListener("click", () => {
     try { cwVerifyTmdbKey(); } catch {}
+  });
+  checkRow.querySelector("#tmdb_delete")?.addEventListener("click", () => {
+    try { cwDeleteTmdbKey(); } catch {}
   });
   keyInput.addEventListener("input", () => {
     keyInput.dataset.verified = "";
@@ -1769,6 +1773,49 @@ async function cwVerifyTmdbKey() {
   }
 }
 
+async function cwDeleteTmdbKey() {
+  const input = document.getElementById("tmdb_api_key");
+  const btn = document.getElementById("tmdb_delete");
+  const checkBtn = document.getElementById("tmdb_check");
+  try {
+    if (btn) btn.disabled = true;
+    if (checkBtn) checkBtn.disabled = true;
+    cwSetTmdbCheckMessage(true, "Deleting...");
+    const r = await fetch("/api/tmdb/disconnect", {
+      method: "POST",
+      cache: "no-store",
+      credentials: "same-origin",
+    });
+    const data = await r.json().catch(() => ({}));
+    if (!r.ok || data?.ok === false) throw new Error(data?.error || "disconnect_failed");
+    if (input) {
+      input.value = "";
+      input.dataset.masked = "0";
+      input.dataset.loaded = "1";
+      input.dataset.touched = "";
+      input.dataset.clear = "";
+      input.dataset.verified = "0";
+    }
+    try {
+      const cfg = window._cfgCache;
+      if (cfg?.tmdb && typeof cfg.tmdb === "object") cfg.tmdb.api_key = "";
+    } catch {}
+    try { window.CW?.Cache?.invalidate?.("config"); } catch {}
+    try { window.invalidateConfigCache?.(); } catch {}
+    try { window.manualRefreshStatus?.(); } catch {}
+    try { updateTmdbHint(); } catch {}
+    try { cwMetaSettingsHubUpdate(); } catch {}
+    cwSetTmdbCheckMessage(true, "Deleted");
+    return true;
+  } catch {
+    cwSetTmdbCheckMessage(false, "TMDb key delete failed.");
+    return false;
+  } finally {
+    if (btn) btn.disabled = false;
+    if (checkBtn) checkBtn.disabled = false;
+  }
+}
+
 function setTraktSuccess(show) {
   const el = document.getElementById("trakt_msg");
   if (el) el.classList.toggle("hidden", !show);
@@ -1797,6 +1844,7 @@ function setTraktSuccess(show) {
     cwAnimeMappingSaveSettings,
     cwAnimeMappingRun,
     cwBuildTmdbPanel,
+    cwDeleteTmdbKey,
     cwMetaSettingsSelect,
     cwMetaSettingsHubUpdate,
     cwMetaSettingsHubInit,

--- a/assets/helpers/watchlist-preview.js
+++ b/assets/helpers/watchlist-preview.js
@@ -880,7 +880,7 @@
         }
         return "";
       };
-      return fromBlock(cfg?.tmdb) || fromBlock(cfg?.tmdb_sync);
+      return fromBlock(cfg?.tmdb);
     };
 
     try {

--- a/assets/js/dashboard-widgets.js
+++ b/assets/js/dashboard-widgets.js
@@ -43,11 +43,11 @@
     return res.json();
   }
 
-  async function getConfig() {
+  async function getConfig(force = false) {
     if (cfgPromise) return cfgPromise;
     cfgPromise = (async () => {
       try {
-        if (window.CW?.API?.Config?.load) return window.CW.API.Config.load(false);
+        if (window.CW?.API?.Config?.load) return window.CW.API.Config.load(!!force);
         return await fetchJSON("/api/config");
       } finally {
         window.setTimeout(() => { cfgPromise = null; }, 1500);
@@ -70,14 +70,24 @@
     };
   }
 
-  async function readSettings() {
-    try {
-      const cfg = await getConfig();
-      return widgetSettings(cfg?.ui || cfg?.user_interface || {});
-    } catch (e) {
-      if (authPendingError(e)) return { history: true, ratings: true, scrobble: true };
-      return { history: true, ratings: true, scrobble: true };
-    }
+  function hasTmdbKeyInConfig(cfg) {
+    const pickFromBlock = (block) => {
+      if (!block || typeof block !== "object") return "";
+      const direct = String(block.api_key || "").trim();
+      if (direct) return direct;
+      const insts = block.instances;
+      if (!insts || typeof insts !== "object") return "";
+      for (const value of Object.values(insts)) {
+        const key = value && typeof value === "object" ? String(value.api_key || "").trim() : "";
+        if (key) return key;
+      }
+      return "";
+    };
+    return !!pickFromBlock(cfg?.tmdb);
+  }
+
+  function hideDashboardWidgets() {
+    $("#dashboard-widgets-card")?.classList.add("hidden");
   }
 
   function providerMeta() {
@@ -332,7 +342,7 @@
 
   async function refreshDashboardWidgets({ forceConfig = false } = {}) {
     if (!isOnMain()) {
-      $("#dashboard-widgets-card")?.classList.add("hidden");
+      hideDashboardWidgets();
       return;
     }
     if (authSetupPending()) {
@@ -341,13 +351,28 @@
     }
     if (forceConfig) cfgPromise = null;
     const seq = ++loadSeq;
-    const settings = await readSettings();
+    let cfg;
+    try {
+      cfg = await getConfig(forceConfig);
+    } catch (e) {
+      if (authPendingError(e)) {
+        scheduleAuthReadyRefresh();
+        return;
+      }
+      hideDashboardWidgets();
+      return;
+    }
+    const settings = widgetSettings(cfg?.ui || cfg?.user_interface || {});
     if (seq !== loadSeq || !isOnMain()) return;
     visibleCounts.history = PAGE_STEP;
     visibleCounts.ratings = RATING_PAGE_STEP;
     visibleCounts.scrobble = PAGE_STEP;
     applyVisibility(settings);
     if (!settings.history && !settings.ratings && !settings.scrobble) return;
+    if (!hasTmdbKeyInConfig(cfg)) {
+      hideDashboardWidgets();
+      return;
+    }
 
     const historyHost = $("#recent-history-list");
     const ratingsHost = $("#latest-ratings-grid");
@@ -411,7 +436,7 @@
     document.addEventListener("tab-changed", (event) => {
       const id = event?.detail?.id || event?.detail?.tab;
       if (String(id || "").toLowerCase() === "main") setTimeout(() => refreshDashboardWidgets(), 50);
-      else $("#dashboard-widgets-card")?.classList.add("hidden");
+      else hideDashboardWidgets();
     });
     window.addEventListener("settings-changed", () => setTimeout(() => refreshDashboardWidgets({ forceConfig: true }), 300));
     window.addEventListener("activity-log-cleared", () => setTimeout(() => refreshDashboardWidgets(), 100));


### PR DESCRIPTION
# Pull request

## Change

Added a Delete button for the TMDb metadata API key and improve TMDb checks for the dashboard widgets and watchlist widget.

Dashboard widgets and the watchlist widget now require the TMDb metadata key from `cfg.tmdb.api_key` only. 
The incorrect `tmdb_sync` fallback was removed.

## Why

TMDb Sync is a separate provider account and should not enable metadata-driven widgets or previews. Users with only TMDb Sync configured could incorrectly pass the metadata gate, while metadata key changes could leave widgets hidden due to stale config.

## Testing

- `tests/test_dashboard_widgets.py`

## Issue

NA