### PR TITLE
Fix: Playback Progress profile isolation

### DIFF
--- a/assets/js/playback_progress.js
+++ b/assets/js/playback_progress.js
@@ -367,7 +367,12 @@ html[data-cw-theme=flat-light] #${ROOT_ID} .pp-toolbar,html[data-cw-theme=flat-l
     const displayProgress = Number.isFinite(Number(it.live_progress_percent)) ? it.live_progress_percent : it.progress_percent;
     const pct = Math.max(0, Math.min(100, Number(displayProgress || 0)));
     const remaining = fmtRemaining(Number.isFinite(Number(it.live_remaining_seconds)) ? it.live_remaining_seconds : it.remaining_seconds);
-    const posterImg = it.poster_url || tmdbArtUrl(it, "w342") || "/assets/img/placeholder_poster.svg";
+    const directPoster = String(it.poster_url || "").trim();
+    const metadataPoster = tmdbArtUrl(it, "w342");
+    const posterImg = directPoster || metadataPoster || "/assets/img/placeholder_poster.svg";
+    const posterFallback = directPoster && metadataPoster && directPoster !== metadataPoster ? metadataPoster : "";
+    const posterFallbackAttr = posterFallback ? ` data-fallback-src="${esc(posterFallback)}"` : "";
+    const posterKey = `${posterImg}|${posterFallback}`;
     const backdropImg = it.backdrop_url || tmdbArtUrl(it, "w780", "backdrop");
     const backdropStyle = backdropImg ? ` style="--pp-backdrop:url('${esc(backdropImg)}')"` : "";
     const live = liveLabel(it);
@@ -379,7 +384,7 @@ html[data-cw-theme=flat-light] #${ROOT_ID} .pp-toolbar,html[data-cw-theme=flat-l
     const actionEdit = it.can_update_progress ? `<button class="pp-btn pp-action-btn pp-action-edit" data-action="edit" data-key="${esc(key)}" title="Edit progress" aria-label="Edit progress">${icon("edit")}<span>Edit</span></button>` : "";
     const actionRemove = it.can_remove_progress ? `<button class="pp-btn pp-action-btn pp-action-remove" data-action="remove" data-key="${esc(key)}" title="Remove progress" aria-label="Remove progress">${icon("delete")}<span>Remove</span></button>` : "";
     return `<article class="pp-card${selected}" data-key="${esc(key)}" role="checkbox" aria-checked="${state.selected.has(key) ? "true" : "false"}" tabindex="0"${backdropStyle}>
-      <div class="pp-art"><img src="${esc(posterImg)}" alt="" loading="lazy" decoding="async" onerror="this.onerror=null;this.src='/assets/img/placeholder_poster.svg'"></div>
+      <div class="pp-art"><img src="${esc(posterImg)}"${posterFallbackAttr} data-poster-key="${esc(posterKey)}" alt="" loading="lazy" decoding="async" onerror="const fallback=this.dataset.fallbackSrc;if(fallback){delete this.dataset.fallbackSrc;this.src=fallback}else{this.onerror=null;this.src='/assets/img/placeholder_poster.svg'}"></div>
       <div class="pp-body">
         <div class="pp-top">
           <div class="pp-card-head">
@@ -400,11 +405,29 @@ html[data-cw-theme=flat-light] #${ROOT_ID} .pp-toolbar,html[data-cw-theme=flat-l
     bulk.classList.toggle("hidden", count === 0);
   }
 
-  function renderItems() {
+  function renderItems(preserveArtwork = true) {
     const grid = document.getElementById("pp-grid");
     const ratingFilter = document.getElementById("pp-rating");
     ratingFilter.classList.toggle("hidden", !state.items.some((it) => Number(it.rating) > 0));
-    grid.innerHTML = state.items.length ? state.items.map(card).join("") : `<div class="pp-empty">No playback records found.</div>`;
+    const markup = state.items.length ? state.items.map(card).join("") : `<div class="pp-empty">No playback records found.</div>`;
+    if (preserveArtwork && state.items.length && grid.children.length) {
+      const existing = new Map(
+        [...grid.querySelectorAll(".pp-card[data-key]")].map((cardEl) => [cardEl.dataset.key, cardEl])
+      );
+      const template = document.createElement("template");
+      template.innerHTML = markup;
+      template.content.querySelectorAll(".pp-card[data-key]").forEach((nextCard) => {
+        const currentCard = existing.get(nextCard.dataset.key);
+        const currentImg = currentCard?.querySelector(".pp-art img[data-poster-key]");
+        const nextImg = nextCard.querySelector(".pp-art img[data-poster-key]");
+        if (currentImg && nextImg && currentImg.dataset.posterKey === nextImg.dataset.posterKey) {
+          nextImg.replaceWith(currentImg);
+        }
+      });
+      grid.replaceChildren(template.content);
+    } else {
+      grid.innerHTML = markup;
+    }
     const maxPage = Math.max(1, Math.ceil((state.total || 0) / state.pageSize));
     document.getElementById("pp-page-text").textContent = `${state.page} / ${maxPage} - ${state.total} total`;
     document.getElementById("pp-prev").disabled = state.page <= 1;
@@ -447,7 +470,7 @@ html[data-cw-theme=flat-light] #${ROOT_ID} .pp-toolbar,html[data-cw-theme=flat-l
       providerOptions();
       renderStatus();
       renderErrors();
-      renderItems();
+      renderItems(!force);
     } catch (e) {
       state.items = [];
       state.errors = [{ provider: "Playback Progress", message: String(e?.message || e || "Request failed") }];

--- a/services/playback_progress/adapters/trakt.py
+++ b/services/playback_progress/adapters/trakt.py
@@ -30,6 +30,17 @@ def _float(value: Any) -> float | None:
         return None
 
 
+def _trakt_image_url(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if text.startswith("//"):
+        return f"https:{text}"
+    if text.lower().startswith("media.trakt.tv/"):
+        return f"https://{text}"
+    return text
+
+
 def _duration_seconds_from_sources(*sources: Mapping[str, Any]) -> int | None:
     for source in sources:
         for key in ("runtime_ms", "duration_ms"):
@@ -264,8 +275,8 @@ class TraktPlaybackAdapter(PlaybackProgressAdapter):
         poster = ""
         backdrop = ""
         try:
-            poster = str(((images.get("poster") or []) or [""])[0] or "")
-            backdrop = str(((images.get("fanart") or images.get("background") or []) or [""])[0] or "")
+            poster = _trakt_image_url(((images.get("poster") or []) or [""])[0])
+            backdrop = _trakt_image_url(((images.get("fanart") or images.get("background") or []) or [""])[0])
         except Exception:
             poster = ""
             backdrop = ""

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -14,7 +14,7 @@ from typing import Any, Mapping, cast
 from _logging import log as BASE_LOG
 from cw_platform.config_base import load_config, save_config
 from cw_platform.id_map import canonical_key, minimal as id_minimal
-from cw_platform.provider_instances import build_provider_config_view, get_provider_block, list_instance_ids, normalize_instance_id
+from cw_platform.provider_instances import build_provider_config_view, get_instance_block, get_provider_block, list_instance_ids, normalize_instance_id
 
 from .adapters.base import PlaybackProgressAdapter, configured_label
 from .adapters.media_servers import EmbyPlaybackAdapter, JellyfinPlaybackAdapter, PlexPlaybackAdapter
@@ -232,7 +232,7 @@ def _apply_live_overlay(item: dict[str, Any], stream: Mapping[str, Any]) -> None
     progress = _live_progress_percent(stream)
     remaining = _live_remaining_seconds(stream, progress)
     provider = str(stream.get("_live_provider") or _live_source_provider(stream.get("source")) or "").strip().lower()
-    instance_id = str(stream.get("_live_instance_id") or "").strip()
+    instance_id = normalize_instance_id(stream.get("_live_instance_id") or stream.get("provider_instance"))
     item["live_state"] = str(stream.get("state") or "").strip().lower()
     item["live_source"] = str(stream.get("source") or "").strip()
     item["live_provider"] = provider
@@ -264,10 +264,10 @@ def _overlay_live_streams(items: list[dict[str, Any]], streams: list[dict[str, A
         for key in _live_match_keys(item):
             for stream in by_key.get(key, []):
                 live_provider = str(stream.get("_live_provider") or _live_source_provider(stream.get("source")) or "").strip().lower()
-                live_instance = str(stream.get("_live_instance_id") or "").strip()
+                live_instance = normalize_instance_id(stream.get("_live_instance_id") or stream.get("provider_instance"))
                 if live_provider and live_provider != provider:
                     continue
-                if live_instance and live_instance != instance_id:
+                if live_instance != instance_id:
                     continue
                 candidates.append(stream)
         if candidates:
@@ -277,15 +277,15 @@ def _overlay_live_streams(items: list[dict[str, Any]], streams: list[dict[str, A
 def _record_group_keys(item: Mapping[str, Any]) -> list[str]:
     keys: list[str] = []
     key = str(item.get("canonical_key") or "").strip().lower()
+    progress = _group_progress(item.get("progress_percent"))
     if key and not key.startswith("unknown:"):
-        keys.append(f"key:{key}")
+        keys.append(f"key:{key}:progress:{progress}")
     media_type = _group_text(item.get("media_type"))
     title = _group_text(item.get("title"))
     series = _group_text(item.get("series_title"))
     season = _group_number(item.get("season"))
     episode = _group_number(item.get("episode"))
     year = _group_number(item.get("year"))
-    progress = _group_progress(item.get("progress_percent"))
     if media_type == "movie":
         fallback = f"fallback:movie:{title}:{year}:{progress}"
     else:
@@ -309,6 +309,17 @@ def _record_time_value(item: Mapping[str, Any]) -> float:
         return float(live_updated)
     dt = _parse_iso(item.get("updated_at") or item.get("progress_at"))
     return dt.timestamp() if dt else 0.0
+
+
+def _record_order_key(item: Mapping[str, Any]) -> tuple[float, int, str, str, str]:
+    artwork = int(not _blank_scalar(item.get("poster_url"))) + int(not _blank_scalar(item.get("backdrop_url")))
+    return (
+        -_record_time_value(item),
+        -artwork,
+        str(item.get("provider") or "").strip().lower(),
+        normalize_instance_id(item.get("instance_id")),
+        str(item.get("remote_id") or "").strip(),
+    )
 
 
 def _float_or_none(value: Any) -> float | None:
@@ -355,7 +366,7 @@ def _with_remaining_fallback(item: dict[str, Any]) -> dict[str, Any]:
 
 
 def _combine_records(records: list[dict[str, Any]]) -> dict[str, Any]:
-    ordered = sorted(records, key=_record_time_value, reverse=True)
+    ordered = sorted(records, key=_record_order_key)
     primary = dict(ordered[0])
     live_records = [record for record in ordered if str(record.get("live_state") or "").strip().lower() in LIVE_ACTIVE_STATES]
     if live_records:
@@ -382,6 +393,41 @@ def _combine_records(records: list[dict[str, Any]]) -> dict[str, Any]:
         primary["remaining_seconds"] = next((record.get("remaining_seconds") for record in ordered if not _blank_scalar(record.get("remaining_seconds"))), None)
     if _blank_scalar(primary.get("duration_seconds")):
         primary["duration_seconds"] = next((record.get("duration_seconds") for record in ordered if not _blank_scalar(record.get("duration_seconds"))), None)
+    artwork_records = sorted(
+        records,
+        key=lambda record: (
+            str(record.get("provider") or "").strip().lower(),
+            normalize_instance_id(record.get("instance_id")),
+            str(record.get("remote_id") or "").strip(),
+        ),
+    )
+    for field in ("poster_url", "backdrop_url"):
+        primary[field] = next((record.get(field) for record in artwork_records if not _blank_scalar(record.get(field))), "")
+    merged_ids: dict[str, Any] = {}
+    for record in ordered:
+        ids = record.get("ids")
+        if not isinstance(ids, Mapping):
+            continue
+        for key, value in ids.items():
+            if not _blank_scalar(value):
+                merged_ids.setdefault(str(key), value)
+    if merged_ids:
+        primary["ids"] = merged_ids
+    primary_meta_value = primary.get("provider_metadata")
+    primary_meta: dict[str, Any] = (
+        {str(key): value for key, value in primary_meta_value.items()}
+        if isinstance(primary_meta_value, Mapping)
+        else {}
+    )
+    if not isinstance(primary_meta.get("show_ids"), Mapping) or not primary_meta.get("show_ids"):
+        for record in ordered:
+            meta = record.get("provider_metadata")
+            show_ids = meta.get("show_ids") if isinstance(meta, Mapping) else None
+            if isinstance(show_ids, Mapping) and show_ids:
+                primary_meta["show_ids"] = {str(key): value for key, value in show_ids.items()}
+                break
+    if primary_meta:
+        primary["provider_metadata"] = primary_meta
     ratings = [rating for rating in (_rating_value(record.get("rating")) for record in ordered) if rating is not None]
     if ratings:
         primary["rating"] = max(ratings)
@@ -456,6 +502,47 @@ def _profile_key(provider: Any, instance_id: Any) -> str:
     return f"{str(provider or '').strip().lower()}:{normalize_instance_id(instance_id)}"
 
 
+def _path_value(block: Mapping[str, Any], path: str) -> Any:
+    value: Any = block
+    for part in path.split("."):
+        if not isinstance(value, Mapping):
+            return None
+        value = value.get(part)
+    return value
+
+
+def _profile_has_explicit_identity(cfg: Mapping[str, Any], provider: str, instance_id: Any) -> bool:
+    inst = normalize_instance_id(instance_id)
+    if inst == "default":
+        return True
+    raw = get_instance_block(cfg, provider, inst, create=False)
+    if not raw:
+        return False
+    identity_paths = {
+        "trakt": ("access_token", "token", "oauth.access_token"),
+        "simkl": ("access_token", "token", "oauth.access_token"),
+        "mdblist": ("access_token", "api_key", "key"),
+        "publicmetadb": ("api_key",),
+        "plex": (
+            "account_token",
+            "token",
+            "pms_token",
+            "pms.token",
+            "pms.x_plex_token",
+            "username",
+            "account_id",
+            "baseurl",
+            "server_url",
+            "server",
+            "server_name",
+            "machine_id",
+        ),
+        "emby": ("access_token", "user_id"),
+        "jellyfin": ("access_token", "user_id"),
+    }.get(str(provider or "").strip().lower(), ())
+    return any(str(_path_value(raw, path) or "").strip() for path in identity_paths)
+
+
 def _playback_settings(cfg: Mapping[str, Any]) -> Mapping[str, Any]:
     value = cfg.get("playback_progress") if isinstance(cfg, Mapping) else None
     return value if isinstance(value, Mapping) else {}
@@ -500,6 +587,8 @@ class PlaybackProgressService:
         for provider in PHASE1_PROVIDERS:
             for instance_id in list_instance_ids(config, provider):
                 inst = normalize_instance_id(instance_id)
+                if not _profile_has_explicit_identity(config, provider, inst):
+                    continue
                 out.append(
                     {
                         "provider": provider,

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from services.playback_progress.service import (
+    _combine_records,
+    _overlay_live_streams,
+    _profile_has_explicit_identity,
+    _record_group_keys,
+    PlaybackProgressService,
+)
+from services.playback_progress.adapters.trakt import _trakt_image_url
+
+
+def _record(**overrides):
+    record = {
+        "provider": "plex",
+        "provider_label": "Plex",
+        "instance_id": "default",
+        "instance_label": "Plex Default",
+        "remote_id": "101",
+        "canonical_key": "tmdb:123",
+        "media_type": "movie",
+        "title": "Pressure",
+        "year": 2026,
+        "ids": {"tmdb": "123"},
+        "progress_percent": 2.0,
+        "updated_at": "2026-06-27T10:00:00Z",
+        "poster_url": "",
+        "backdrop_url": "",
+        "provider_metadata": {},
+    }
+    record.update(overrides)
+    return record
+
+
+def test_combined_record_keeps_available_artwork_regardless_of_input_order():
+    missing = _record(provider="simkl", remote_id="simkl-1", ids={})
+    artwork = _record(
+        provider="trakt",
+        remote_id="trakt-1",
+        poster_url="https://images.example/pressure.jpg",
+        backdrop_url="https://images.example/pressure-bg.jpg",
+    )
+
+    forward = _combine_records([missing, artwork])
+    reverse = _combine_records([artwork, missing])
+
+    assert forward["poster_url"] == artwork["poster_url"]
+    assert forward["backdrop_url"] == artwork["backdrop_url"]
+    assert forward["ids"] == {"tmdb": "123"}
+    assert reverse["poster_url"] == forward["poster_url"]
+    assert reverse["backdrop_url"] == forward["backdrop_url"]
+
+
+def test_combined_record_uses_stable_artwork_source_instead_of_newest_record():
+    newer = _record(
+        provider="simkl",
+        remote_id="simkl-1",
+        updated_at="2026-06-27T11:00:00Z",
+        poster_url="https://simkl.example/pressure.jpg",
+    )
+    older = _record(
+        provider="mdblist",
+        remote_id="mdblist-1",
+        updated_at="2026-06-27T09:00:00Z",
+        poster_url="https://mdblist.example/pressure.jpg",
+    )
+
+    forward = _combine_records([newer, older])
+    reverse = _combine_records([older, newer])
+
+    assert forward["poster_url"] == older["poster_url"]
+    assert reverse["poster_url"] == older["poster_url"]
+
+
+def test_same_title_with_different_profile_progress_does_not_group():
+    default = _record(instance_id="default", progress_percent=5.1)
+    profile = _record(instance_id="P01", progress_percent=22.4)
+
+    assert set(_record_group_keys(default)).isdisjoint(_record_group_keys(profile))
+
+
+def test_same_title_with_matching_progress_can_still_combine_across_profiles():
+    default = _record(instance_id="default", progress_percent=5.1)
+    profile = _record(instance_id="P01", progress_percent=5.4)
+
+    assert set(_record_group_keys(default)) & set(_record_group_keys(profile))
+
+
+def test_unscoped_live_stream_only_updates_default_profile():
+    items = [
+        _record(instance_id="default"),
+        _record(instance_id="P01", remote_id="102"),
+    ]
+    stream = {
+        "source": "plex",
+        "state": "playing",
+        "media_type": "movie",
+        "title": "Pressure",
+        "year": 2026,
+        "ids": {"tmdb": "123"},
+        "progress": 12,
+        "updated": 1_750_000_000,
+    }
+
+    _overlay_live_streams(items, [stream])
+
+    assert items[0]["live_state"] == "playing"
+    assert items[0]["live_instance_id"] == "default"
+    assert "live_state" not in items[1]
+
+
+def test_scoped_live_stream_only_updates_matching_profile():
+    items = [
+        _record(instance_id="default"),
+        _record(instance_id="P01", remote_id="102"),
+    ]
+    stream = {
+        "source": "plex",
+        "provider_instance": "P01",
+        "state": "paused",
+        "media_type": "movie",
+        "title": "Pressure",
+        "year": 2026,
+        "ids": {"tmdb": "123"},
+        "progress": 18,
+        "updated": 1_750_000_000,
+    }
+
+    _overlay_live_streams(items, [stream])
+
+    assert "live_state" not in items[0]
+    assert items[1]["live_state"] == "paused"
+    assert items[1]["live_instance_id"] == "P01"
+
+
+def test_empty_provider_profile_does_not_inherit_default_identity():
+    cfg = {
+        "plex": {
+            "account_token": "default-owner-token",
+            "instances": {"PLEX-P01": {}},
+        }
+    }
+
+    assert _profile_has_explicit_identity(cfg, "plex", "default") is True
+    assert _profile_has_explicit_identity(cfg, "plex", "PLEX-P01") is False
+    plex_specs = [spec for spec in PlaybackProgressService().provider_instances(cfg) if spec["provider"] == "plex"]
+    assert [spec["instance_id"] for spec in plex_specs] == ["default"]
+
+
+def test_plex_home_profile_with_explicit_user_scope_can_inherit_connection():
+    cfg = {
+        "plex": {
+            "account_token": "default-owner-token",
+            "server_url": "https://plex.example",
+            "instances": {
+                "PLEX-P01": {"username": "Home User", "account_id": 42},
+            },
+        }
+    }
+
+    assert _profile_has_explicit_identity(cfg, "plex", "PLEX-P01") is True
+    plex_specs = [spec for spec in PlaybackProgressService().provider_instances(cfg) if spec["provider"] == "plex"]
+    assert [spec["instance_id"] for spec in plex_specs] == ["default", "PLEX-P01"]
+
+
+def test_empty_oauth_profile_is_not_treated_as_default_account():
+    cfg = {
+        "trakt": {
+            "access_token": "default-token",
+            "client_id": "client-id",
+            "instances": {
+                "TRAKT-P01": {},
+                "TRAKT-P02": {"access_token": "second-account-token"},
+            },
+        }
+    }
+
+    assert _profile_has_explicit_identity(cfg, "trakt", "TRAKT-P01") is False
+    assert _profile_has_explicit_identity(cfg, "trakt", "TRAKT-P02") is True
+    trakt_specs = [spec for spec in PlaybackProgressService().provider_instances(cfg) if spec["provider"] == "trakt"]
+    assert [spec["instance_id"] for spec in trakt_specs] == ["default", "TRAKT-P02"]
+
+
+def test_trakt_image_urls_are_absolute():
+    path = "media.trakt.tv/images/movies/001/077/714/posters/thumb/9646f8cb88.jpg.webp"
+
+    assert _trakt_image_url(path) == f"https://{path}"
+    assert _trakt_image_url(f"//{path}") == f"https://{path}"
+    assert _trakt_image_url(f"https://{path}") == f"https://{path}"


### PR DESCRIPTION
# Pull request

## Change

- Ignore empty provider profiles instead of inheriting the Default account.
- Keep live playback state scoped to the correct profile.
- Separate records when profile progress differs.
- Stabilize artwork and metadata selection for combined records.
- Preserve loaded posters during live progress refreshes.

## Why

Empty profiles were treated as configured because they inherited Default credentials, causing duplicate and incorrectly labelled records. Combined-provider refreshes could also recreate or switch poster elements, while scheme-less Trakt image URLs incorrectly resolved against the CrossWatch host.

## Testing

- Manual checks validated
- test scripts validated

## Issue

Fixes #317