### PR TITLE
Fix: season-zero history sync and two-way matching

### DIFF
--- a/cw_platform/id_map.py
+++ b/cw_platform/id_map.py
@@ -243,8 +243,8 @@ def _show_id_from(item: Mapping[str, Any]) -> str | None:
 
 
 def _se_fragment(item: Mapping[str, Any]) -> str | None:
-    s = item.get("season") or item.get("season_number")
-    e = item.get("episode") or item.get("episode_number")
+    s = item.get("season") if item.get("season") is not None else item.get("season_number")
+    e = item.get("episode") if item.get("episode") is not None else item.get("episode_number")
     try:
         s = int(s) if s is not None else None
         e = int(e) if e is not None else None

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -577,11 +577,13 @@ def run_one_way_feature(
 
         if typ == "episode":
             try:
-                s = int(it.get("season") or 0)
-                e = int(it.get("episode") or 0)
+                season_raw = it.get("season") if it.get("season") is not None else it.get("season_number")
+                episode_raw = it.get("episode") if it.get("episode") is not None else it.get("episode_number")
+                s = int(season_raw) if season_raw is not None else -1
+                e = int(episode_raw) if episode_raw is not None else 0
             except Exception:
-                s, e = 0, 0
-            has_frag = bool(s > 0 and e > 0)
+                s, e = -1, 0
+            has_frag = bool(s >= 0 and e > 0)
             if has_frag:
                 frag = f"#s{s:02d}e{e:02d}"
     
@@ -599,10 +601,11 @@ def run_one_way_feature(
 
         elif typ == "season":
             try:
-                s = int(it.get("season") or 0)
+                season_raw = it.get("season") if it.get("season") is not None else it.get("season_number")
+                s = int(season_raw) if season_raw is not None else -1
             except Exception:
-                s = 0
-            if s > 0:
+                s = -1
+            if s >= 0:
                 frag = f"#season:{s}"
                 for src_ids in (show_ids, ids):
                     for k, v in src_ids.items():

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -600,11 +600,13 @@ def _two_way_sync(
 
         if typ == "episode":
             try:
-                s = int(it.get("season") or 0)
-                e = int(it.get("episode") or 0)
+                season_raw = it.get("season") if it.get("season") is not None else it.get("season_number")
+                episode_raw = it.get("episode") if it.get("episode") is not None else it.get("episode_number")
+                s = int(season_raw) if season_raw is not None else -1
+                e = int(episode_raw) if episode_raw is not None else 0
             except Exception:
-                s, e = 0, 0
-            if s > 0 and e > 0:
+                s, e = -1, 0
+            if s >= 0 and e > 0:
                 frag = f"#s{s:02d}e{e:02d}"
                 for k, v in ids.items():
                     if v is None or str(v) == "":
@@ -613,10 +615,11 @@ def _two_way_sync(
 
         elif typ == "season":
             try:
-                s = int(it.get("season") or 0)
+                season_raw = it.get("season") if it.get("season") is not None else it.get("season_number")
+                s = int(season_raw) if season_raw is not None else -1
             except Exception:
-                s = 0
-            if s > 0:
+                s = -1
+            if s >= 0:
                 frag = f"#season:{s}"
                 for k, v in ids.items():
                     if v is None or str(v) == "":

--- a/providers/sync/_mod_MDBLIST.py
+++ b/providers/sync/_mod_MDBLIST.py
@@ -101,7 +101,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.0"
+__VERSION__ = "1.1"
 __all__ = ["get_manifest", "MDBLISTModule", "OPS"]
 
 def _health(status: str, ok: bool, latency_ms: int) -> None:

--- a/providers/sync/_mod_PUBLICMETADB.py
+++ b/providers/sync/_mod_PUBLICMETADB.py
@@ -23,7 +23,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "0.1"
+__VERSION__ = "0.2"
 __all__ = ["get_manifest", "PUBLICMETADBModule", "OPS"]
 
 

--- a/providers/sync/_mod_TRAKT.py
+++ b/providers/sync/_mod_TRAKT.py
@@ -89,7 +89,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.0"
+__VERSION__ = "1.1"
 __all__ = ["get_manifest", "TRAKTModule", "OPS"]
 
 os.environ.setdefault("CW_TRAKT_UA", f"CrossWatch TRAKT/{__VERSION__}")

--- a/providers/sync/mdblist/_history.py
+++ b/providers/sync/mdblist/_history.py
@@ -1005,7 +1005,18 @@ def _bucketize(items: Iterable[Mapping[str, Any]], *, unwatch: bool) -> tuple[di
         if not isinstance(show_obj.get("seasons"), list):
             show_obj["seasons"] = []
         seasons_list: list[dict[str, Any]] = show_obj["seasons"]
-        season_obj: dict[str, Any] | None = next((x for x in seasons_list if int(x.get("number") or -1) == s), None)
+        season_obj: dict[str, Any] | None = None
+        for candidate in seasons_list:
+            candidate_raw = candidate.get("number")
+            if candidate_raw is None:
+                continue
+            try:
+                candidate_number = int(candidate_raw)
+            except (TypeError, ValueError):
+                continue
+            if candidate_number == s:
+                season_obj = candidate
+                break
         if not season_obj:
             season_obj = {"number": s}
             seasons_list.append(season_obj)

--- a/providers/sync/publicmetadb/_history.py
+++ b/providers/sync/publicmetadb/_history.py
@@ -107,8 +107,10 @@ def _to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
     hist_id = str(row.get("id") or row.get("history_id") or "").strip()
 
     if media in ("tv", "show", "series", "episode"):
-        season = as_int(row.get("season") or row.get("season_number"))
-        episode = as_int(row.get("episode") or row.get("episode_number"))
+        season_raw = row.get("season") if row.get("season") is not None else row.get("season_number")
+        episode_raw = row.get("episode") if row.get("episode") is not None else row.get("episode_number")
+        season = as_int(season_raw)
+        episode = as_int(episode_raw)
         if season is None or episode is None:
             return None
         out: dict[str, Any] = {
@@ -190,8 +192,10 @@ def _payload_for_item(item: Mapping[str, Any]) -> tuple[dict[str, Any] | None, s
     typ = str(mini.get("type") or item.get("type") or "").strip().lower()
     if typ == "episode":
         tmdb = _show_tmdb_for_item(mini) or _show_tmdb_for_item(item)
-        season = as_int(mini.get("season") or item.get("season"))
-        episode = as_int(mini.get("episode") or item.get("episode"))
+        season_raw = mini.get("season") if mini.get("season") is not None else item.get("season")
+        episode_raw = mini.get("episode") if mini.get("episode") is not None else item.get("episode")
+        season = as_int(season_raw)
+        episode = as_int(episode_raw)
         if tmdb is None or season is None or episode is None:
             return None, "missing_show_tmdb_or_episode_numbers"
         return {

--- a/providers/sync/simkl/_common.py
+++ b/providers/sync/simkl/_common.py
@@ -548,6 +548,8 @@ def normalize(obj: Mapping[str, Any]) -> dict[str, Any]:
 
     if obj_type == "episode":
         ids = _fix_imdb((payload.get("ids") if isinstance(payload, Mapping) else None) or obj.get("ids") or {})
+        show_ids_raw = obj.get("show_ids")
+        show_ids = _fix_imdb(show_ids_raw) if isinstance(show_ids_raw, Mapping) else {}
 
         def _to_int(v: Any) -> int | None:
             try:
@@ -555,13 +557,16 @@ def normalize(obj: Mapping[str, Any]) -> dict[str, Any]:
             except Exception:
                 return None
 
+        raw_season = obj.get("season") if obj.get("season") is not None else obj.get("season_number")
+        raw_episode = obj.get("episode") if obj.get("episode") is not None else obj.get("episode_number")
         base = {
             "type": "episode",
             "title": (payload.get("title") if isinstance(payload, Mapping) else None) or obj.get("title"),
             "year": (payload.get("year") if isinstance(payload, Mapping) else None) or obj.get("year"),
             "ids": {k: v for k, v in ids.items() if v},
-            "season": _to_int(obj.get("season") or obj.get("season_number")),
-            "episode": _to_int(obj.get("episode") or obj.get("episode_number")),
+            "season": _to_int(raw_season),
+            "episode": _to_int(raw_episode),
+            "show_ids": {k: v for k, v in show_ids.items() if v},
         }
         return id_minimal(base)
 
@@ -607,15 +612,18 @@ def key_of(item: Mapping[str, Any]) -> str:
     typ = str(item.get("type") or "").lower()
     if typ == "episode":
 
-        def _to_int(v: Any) -> int:
+        def _to_int(v: Any) -> int | None:
             try:
-                n = int(v)
-                return n if n > 0 else 0
+                return int(v)
             except Exception:
-                return 0
+                return None
 
-        s_num = _to_int(item.get("season") or item.get("season_number"))
-        e_num = _to_int(item.get("episode") or item.get("episode_number") or item.get("number"))
+        raw_season = item.get("season") if item.get("season") is not None else item.get("season_number")
+        raw_episode = item.get("episode") if item.get("episode") is not None else item.get("episode_number")
+        if raw_episode is None:
+            raw_episode = item.get("number")
+        s_num = _to_int(raw_season)
+        e_num = _to_int(raw_episode)
 
         show_ids_raw = item.get("show_ids")
         show_ids = dict(show_ids_raw) if isinstance(show_ids_raw, Mapping) else {}
@@ -624,21 +632,23 @@ def key_of(item: Mapping[str, Any]) -> str:
             ids = dict(ids_raw) if isinstance(ids_raw, Mapping) else {}
             show_ids = {k: ids[k] for k in ("tmdb", "imdb", "tvdb", "simkl") if ids.get(k)}
 
-        if show_ids and s_num and e_num:
+        if show_ids and s_num is not None and s_num >= 0 and e_num is not None and e_num > 0:
             show_key = canonical_key(id_minimal({"type": "show", "ids": _fix_imdb(show_ids)})) or ""
             if show_key:
                 return f"{show_key}#s{s_num:02d}e{e_num:02d}"
 
     if typ == "season":
 
-        def _to_int(v: Any) -> int:
+        def _to_int(v: Any) -> int | None:
             try:
-                n = int(v)
-                return n if n > 0 else 0
+                return int(v)
             except Exception:
-                return 0
+                return None
 
-        s_num = _to_int(item.get("season") or item.get("season_number") or item.get("number"))
+        raw_season = item.get("season") if item.get("season") is not None else item.get("season_number")
+        if raw_season is None:
+            raw_season = item.get("number")
+        s_num = _to_int(raw_season)
 
         show_ids_raw = item.get("show_ids")
         show_ids = dict(show_ids_raw) if isinstance(show_ids_raw, Mapping) else {}
@@ -647,7 +657,7 @@ def key_of(item: Mapping[str, Any]) -> str:
             ids = dict(ids_raw) if isinstance(ids_raw, Mapping) else {}
             show_ids = {k: ids[k] for k in ("tmdb", "imdb", "tvdb", "simkl") if ids.get(k)}
 
-        if show_ids and s_num:
+        if show_ids and s_num is not None and s_num >= 0:
             show_key = canonical_key(id_minimal({"type": "show", "ids": _fix_imdb(show_ids)})) or ""
             if show_key:
                 return f"{show_key}#season:{s_num}"

--- a/providers/sync/simkl/_history.py
+++ b/providers/sync/simkl/_history.py
@@ -832,10 +832,16 @@ def _parse_rows(
                 continue
         for season in row.get("seasons") or []:
             season = season if isinstance(season, Mapping) else {}
-            s_num_internal = int((season.get("number") or season.get("season") or 0))
+            raw_season = season.get("number") if season.get("number") is not None else season.get("season")
+            s_num_internal = _int_or_none(raw_season)
+            if s_num_internal is None or s_num_internal < 0:
+                continue
             for episode in (season.get("episodes") or []):
                 episode = episode if isinstance(episode, Mapping) else {}
-                e_num_internal = int((episode.get("number") or episode.get("episode") or 0))
+                raw_episode = episode.get("number") if episode.get("number") is not None else episode.get("episode")
+                e_num_internal = _int_or_none(raw_episode)
+                if e_num_internal is None or e_num_internal <= 0:
+                    continue
                 s_num = s_num_internal
                 e_num = e_num_internal
                 if row_kind == "anime":
@@ -851,13 +857,14 @@ def _parse_rows(
                 if not ts and row_kind == "shows":
                     watched_at = (row.get("last_watched_at") or "").strip()
                     ts = _as_epoch(watched_at)
-                if not ts or not s_num or not e_num:
+                if not ts or s_num < 0 or e_num <= 0:
                     continue
+                episode_ids = _episode_lookup_ids(episode) if s_num == 0 else {}
                 ep = {
                     "type": "episode",
                     "season": s_num,
                     "episode": e_num,
-                    "ids": dict(show_ids),
+                    "ids": dict(episode_ids or show_ids),
                     "title": f"S{s_num:02d}E{e_num:02d}",
                     "year": None,
                     "series_title": series_name,
@@ -1511,9 +1518,18 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
                 continue
             if typ == "episode":
                 show_ids = _show_ids_of_episode(item)
-                s_num = int(item.get("season") or item.get("season_number") or 0)
-                e_num = int(item.get("episode") or item.get("episode_number") or 0)
-                if not show_ids or not s_num or not e_num:
+                raw_season = item.get("season") if item.get("season") is not None else item.get("season_number")
+                raw_episode = item.get("episode") if item.get("episode") is not None else item.get("episode_number")
+                s_num = _safe_int(raw_season)
+                e_num = _safe_int(raw_episode)
+                episode_ids = _episode_lookup_ids(item)
+                if not s_num:
+                    if _int_or_none(raw_season) == 0 and episode_ids:
+                        s_num = 0
+                    else:
+                        unresolved.append({"item": id_minimal(item), "hint": "missing_show_ids_or_s/e"})
+                        continue
+                if not show_ids or e_num <= 0:
                     unresolved.append({"item": id_minimal(item), "hint": "missing_show_ids_or_s/e"})
                     continue
                 show_entry = _show_scope_entry(adapter, item, show_ids)
@@ -1522,7 +1538,10 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
                     continue
                 group = _merge_show_group(shows_scoped, show_entry)
                 season = _merge_show_season(group, s_num)
-                season.setdefault("episodes", []).append({"number": e_num})
+                episode_payload: dict[str, Any] = {"number": e_num}
+                if s_num == 0:
+                    episode_payload["ids"] = dict(episode_ids)
+                season.setdefault("episodes", []).append(episode_payload)
                 thaw_keys.append(_thaw_key(item))
                 continue
             ids = _ids_of(item)

--- a/tests/test_history_specials.py
+++ b/tests/test_history_specials.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from cw_platform.id_map import canonical_key, minimal
+from cw_platform.orchestrator import _applier, _unresolved
+from providers.sync.mdblist._history import _bucketize
+from providers.sync.publicmetadb._history import _payload_for_item, _to_minimal
+from providers.sync._mod_SIMKL import _confirmed_keys
+from providers.sync.simkl import _history as simkl_history
+from providers.sync.simkl._common import key_of as simkl_key_of
+from providers.sync.trakt._history import _batch_add, _batch_remove
+
+
+WATCHED_AT = "2026-01-02T03:04:05Z"
+SHOW_IDS = {"tmdb": "63372", "tvdb": "295685", "trakt": "100"}
+ISSUE_311_ITEM = {
+    "type": "episode",
+    "title": "The Making of The Walking Dead",
+    "season": 0,
+    "episode": 48,
+    "watched_at": "2023-10-12T12:28:00.000Z",
+    "ids": {"tmdb": "63372", "tvdb": "2960601", "trakt": "5942444"},
+    "show_ids": {
+        "tmdb": "1402",
+        "imdb": "tt1520211",
+        "tvdb": "153021",
+        "trakt": "1393",
+        "slug": "the-walking-dead",
+    },
+}
+
+
+def _special(number: int) -> dict[str, object]:
+    return {
+        "type": "episode",
+        "ids": dict(SHOW_IDS),
+        "show_ids": dict(SHOW_IDS),
+        "season": 0,
+        "episode": number,
+        "watched_at": WATCHED_AT,
+    }
+
+
+def test_special_episode_canonical_key_keeps_season_zero() -> None:
+    item = {"type": "episode", "show_ids": {"tmdb": "63372"}, "season": 0, "episode": 1}
+
+    assert canonical_key(item) == "tmdb:63372#s00e01"
+
+
+def test_publicmetadb_special_episode_round_trip_shape() -> None:
+    row = {
+        "id": "history-1",
+        "tmdb_id": 63372,
+        "media_type": "tv",
+        "season": 0,
+        "episode": 1,
+        "watched_at": WATCHED_AT,
+    }
+
+    parsed = _to_minimal(row)
+    payload, hint = _payload_for_item(_special(1))
+
+    assert parsed is not None
+    assert parsed["season"] == 0
+    assert parsed["episode"] == 1
+    assert parsed["show_ids"] == {"tmdb": "63372"}
+    assert payload == {
+        "tmdb_id": 63372,
+        "media_type": "tv",
+        "season": 0,
+        "episode": 1,
+        "watched_at": WATCHED_AT,
+    }
+    assert hint is None
+
+
+def test_mdblist_groups_multiple_specials_under_one_season() -> None:
+    body, accepted = _bucketize([_special(1), _special(2)], unwatch=False)
+
+    shows = body["shows_nested"]
+    assert len(shows) == 1
+    assert shows[0]["seasons"] == [
+        {
+            "number": 0,
+            "episodes": [
+                {"number": 1, "watched_at": WATCHED_AT},
+                {"number": 2, "watched_at": WATCHED_AT},
+            ],
+        }
+    ]
+    assert len(accepted) == 2
+
+
+def test_trakt_special_episode_add_and_remove_shapes() -> None:
+    adapter = SimpleNamespace(config={})
+
+    add_body, add_unresolved, *_ = _batch_add(adapter, [_special(1), _special(2)])
+    remove_body, remove_unresolved, *_ = _batch_remove(adapter, [_special(1), _special(2)])
+
+    add_season = add_body["shows"][0]["seasons"][0]
+    remove_season = remove_body["shows"][0]["seasons"][0]
+    assert add_season["number"] == 0
+    assert [episode["number"] for episode in add_season["episodes"]] == [1, 2]
+    assert remove_season == {"number": 0, "episodes": [{"number": 1}, {"number": 2}]}
+    assert add_unresolved == []
+    assert remove_unresolved == []
+
+
+def test_simkl_special_episode_is_available_as_history_source() -> None:
+    row = {
+        "show": {
+            "title": "Example Show",
+            "year": 2020,
+            "ids": dict(SHOW_IDS),
+        },
+        "seasons": [
+            {
+                "number": 0,
+                "episodes": [
+                    {
+                        "number": 1,
+                        "watched_at": WATCHED_AT,
+                        "ids": {"tvdb": "900001"},
+                    },
+                    {"number": 2, "watched_at": WATCHED_AT},
+                ],
+            }
+        ],
+    }
+
+    items, _thaw, _movies_ts, shows_ts, _anime_ts, movies_count, episode_count = simkl_history._parse_rows(
+        [], [row], [], limit=None
+    )
+
+    assert len(items) == 2
+    by_episode = {item["episode"]: item for item in items.values()}
+    assert by_episode[1]["season"] == 0
+    assert by_episode[1]["ids"] == {"tvdb": "900001"}
+    assert by_episode[2]["season"] == 0
+    assert by_episode[2]["ids"] == SHOW_IDS
+    assert by_episode[2]["show_ids"] == SHOW_IDS
+    assert shows_ts is not None
+    assert movies_count == 0
+    assert episode_count == 2
+
+
+def test_simkl_special_episode_remove_uses_episode_lookup_ids(monkeypatch) -> None:
+    requests: list[dict[str, object]] = []
+
+    class Session:
+        def post(self, _url, **kwargs):
+            requests.append(kwargs["json"])
+            return SimpleNamespace(status_code=200, text="", json=lambda: {})
+
+    monkeypatch.setattr(simkl_history, "_unfreeze", lambda _keys: None)
+    monkeypatch.setattr(simkl_history, "_evict_removes_from_cache", lambda _items: None)
+    adapter = SimpleNamespace(
+        client=SimpleNamespace(session=Session()),
+        cfg=SimpleNamespace(timeout=5, history_chunk_size=100, api_key="key", access_token="token"),
+    )
+    item = _special(1)
+    item["ids"] = {"tvdb": "900001"}
+
+    applied, unresolved = simkl_history.remove(adapter, [item])
+
+    assert applied == 1
+    assert unresolved == []
+    episode = requests[0]["shows"][0]["seasons"][0]["episodes"][0]
+    assert episode == {"number": 1, "ids": {"tvdb": "900001"}}
+
+
+def test_issue_311_simkl_add_sends_episode_lookup_id(monkeypatch) -> None:
+    requests: list[dict[str, object]] = []
+
+    class Session:
+        def post(self, _url, **kwargs):
+            requests.append(kwargs["json"])
+            payload = {
+                "added": {"movies": 0, "shows": 0, "episodes": 1},
+                "not_found": {"movies": [], "shows": [], "episodes": []},
+            }
+            return SimpleNamespace(status_code=201, text="json", json=lambda: payload)
+
+    monkeypatch.setattr(simkl_history, "_unfreeze", lambda _keys: None)
+    monkeypatch.setattr(simkl_history, "_inject_adds_into_cache", lambda _items: None)
+    adapter = SimpleNamespace(
+        client=SimpleNamespace(session=Session()),
+        cfg=SimpleNamespace(timeout=5, api_key="key", access_token="token"),
+    )
+
+    applied, unresolved = simkl_history.add(adapter, [dict(ISSUE_311_ITEM)])
+
+    assert applied == 1
+    assert unresolved == []
+    show = requests[0]["shows"][0]
+    assert show["ids"]["tmdb"] == "1402"
+    assert show["seasons"] == [
+        {
+            "number": 0,
+            "episodes": [
+                {
+                    "number": 48,
+                    "watched_at": "2023-10-12T12:28:00.000Z",
+                    "ids": {"tvdb": "2960601"},
+                }
+            ],
+        }
+    ]
+
+
+def test_issue_311_rejected_special_is_blocked_after_first_attempt(monkeypatch, tmp_path) -> None:
+    class Session:
+        def post(self, _url, **kwargs):
+            payload = {
+                "added": {"movies": 0, "shows": 0, "episodes": 0},
+                "not_found": {"movies": [], "shows": [], "episodes": kwargs["json"]["shows"]},
+            }
+            return SimpleNamespace(status_code=201, text="json", json=lambda: payload)
+
+    monkeypatch.setattr(simkl_history, "_unfreeze", lambda _keys: None)
+    monkeypatch.setattr(_unresolved, "STATE_DIR", tmp_path)
+    monkeypatch.setenv("CW_PAIR_KEY", "TRAKT-SIMKL-history-issue311")
+    adapter = SimpleNamespace(
+        client=SimpleNamespace(session=Session()),
+        cfg=SimpleNamespace(timeout=5, api_key="key", access_token="token"),
+    )
+    source_item = dict(ISSUE_311_ITEM)
+
+    applied, unresolved = simkl_history.add(adapter, [source_item])
+    confirmed = _confirmed_keys(simkl_key_of, [source_item], unresolved)
+    normalized = _applier._normalize(
+        {"ok": True, "count": applied, "unresolved": unresolved, "confirmed_keys": confirmed},
+        [minimal(source_item)],
+        "add",
+        dst="SIMKL",
+        feature="history",
+        emit=lambda *_args, **_kwargs: None,
+    )
+    blocked = _unresolved.load_unresolved_keys("SIMKL", "history", cross_features=True)
+
+    expected_key = canonical_key(minimal(source_item))
+    assert applied == 0
+    assert normalized["unresolved"] == 1
+    assert confirmed == []
+    assert blocked == {expected_key}

--- a/tests/test_twoway_history_specials.py
+++ b/tests/test_twoway_history_specials.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from cw_platform.id_map import canonical_key
+from cw_platform.orchestrator import _pairs_twoway as twoway
+
+
+WATCHED_AT = "2023-10-12T12:28:00.000Z"
+WATCHED_EPOCH = 1697113680
+TRAKT_SPECIAL = {
+    "type": "episode",
+    "title": "The Making of The Walking Dead",
+    "season": 0,
+    "episode": 48,
+    "watched_at": WATCHED_AT,
+    "ids": {"tmdb": "63372", "tvdb": "2960601", "trakt": "5942444"},
+    "show_ids": {"tmdb": "1402", "imdb": "tt1520211", "tvdb": "153021", "trakt": "1393"},
+}
+SIMKL_SPECIAL = {
+    **TRAKT_SPECIAL,
+    "ids": {"tvdb": "2960601"},
+    "show_ids": {"tvdb": "153021"},
+}
+
+
+class _StateStore:
+    def __init__(self) -> None:
+        self.state: dict[str, Any] = {}
+
+    def load_state(self) -> dict[str, Any]:
+        return self.state
+
+    def save_state(self, value: dict[str, Any]) -> None:
+        self.state = value
+
+    def load_tomb(self) -> dict[str, Any]:
+        return {}
+
+    def save_tomb(self, _value: dict[str, Any]) -> None:
+        return None
+
+
+class _Ops:
+    def __init__(self) -> None:
+        self.added: list[dict[str, Any]] = []
+
+    def add(self, _cfg, items, *, feature, dry_run=False):
+        self.added.extend(dict(item) for item in items)
+        return {
+            "ok": True,
+            "count": len(items),
+            "confirmed_keys": [canonical_key(item) for item in items],
+            "unresolved": [],
+        }
+
+    def remove(self, *_args, **_kwargs):
+        return {"ok": True, "count": 0}
+
+    def update(self, *_args, **_kwargs):
+        return {"ok": True, "count": 0}
+
+    def capabilities(self):
+        return {"history": {"observed_deletes": False}}
+
+
+def _run_two_way(monkeypatch, snapshots: dict[str, dict[str, dict[str, Any]]]):
+    trakt = _Ops()
+    simkl = _Ops()
+    monkeypatch.setattr(twoway, "build_snapshots_for_feature", lambda **_kwargs: snapshots)
+    ctx = SimpleNamespace(
+        config={"sync": {"include_observed_deletes": False, "blackbox": {"enabled": False}}, "runtime": {}},
+        providers={"TRAKT": trakt, "SIMKL": simkl},
+        emit=lambda *_args, **_kwargs: None,
+        emit_info=lambda *_args, **_kwargs: None,
+        dbg=lambda *_args, **_kwargs: None,
+        dry_run=False,
+        snap_cache={},
+        snap_ttl_sec=0,
+        state_store=_StateStore(),
+        stats_manual_blocked=0,
+        apply_chunk_pause_ms=0,
+    )
+    result = twoway._two_way_sync(ctx, "TRAKT", "SIMKL", feature="history", fcfg={}, health_map={})
+    return result, trakt, simkl
+
+
+def test_trakt_simkl_two_way_routes_and_converges_special(monkeypatch) -> None:
+    monkeypatch.setattr(twoway, "_supports_feature", lambda _ops, _feature: True)
+    monkeypatch.setattr(twoway, "_health_feature_ok", lambda _health, _feature: True)
+    monkeypatch.setattr(twoway, "_health_status", lambda _health: "up")
+    monkeypatch.setattr(twoway, "_resolve_flags", lambda _fcfg, _sync: {"allow_adds": True, "allow_removals": False})
+    monkeypatch.setattr(twoway, "_anime_pair_feature_options", lambda *_args, **_kwargs: {"use_anime_mapping": False})
+    monkeypatch.setattr(twoway, "_anime_config_with_pair_feature_options", lambda cfg, _opts: cfg)
+    monkeypatch.setattr(twoway, "_index_semantics", lambda *_args, **_kwargs: "full")
+    monkeypatch.setattr(twoway, "prev_checkpoint", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(twoway, "module_checkpoint", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(twoway, "keys_for_feature", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(twoway, "_manual_policy", lambda *_args, **_kwargs: ([], set()))
+    monkeypatch.setattr(twoway, "_provider_ignore_dropped_enabled", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(twoway, "apply_blocklist", lambda _state, items, **_kwargs: list(items))
+    monkeypatch.setattr(twoway, "_maybe_block_massdelete", lambda items, **_kwargs: list(items))
+    monkeypatch.setattr(twoway, "effective_chunk_size", lambda *_args, **_kwargs: 100)
+    monkeypatch.setattr(twoway, "load_blackbox_keys", lambda *_args, **_kwargs: set())
+    monkeypatch.setattr(twoway, "record_attempts", lambda *_args, **_kwargs: {"ok": True, "count": 0})
+    monkeypatch.setattr(twoway, "record_success", lambda *_args, **_kwargs: {"ok": True, "count": 0})
+
+    trakt_key = f"tmdb:1402#s00e48@{WATCHED_EPOCH}"
+    missing_result, trakt, simkl = _run_two_way(monkeypatch, {"TRAKT": {trakt_key: TRAKT_SPECIAL}, "SIMKL": {}})
+
+    assert missing_result["adds_to_A"] == 0
+    assert missing_result["adds_to_B"] == 1
+    assert trakt.added == []
+    assert len(simkl.added) == 1
+    assert simkl.added[0]["season"] == 0
+    assert simkl.added[0]["episode"] == 48
+
+    simkl_key = f"tvdb:153021#s00e48@{WATCHED_EPOCH}"
+    converged_result, trakt, simkl = _run_two_way(
+        monkeypatch,
+        {"TRAKT": {trakt_key: TRAKT_SPECIAL}, "SIMKL": {simkl_key: SIMKL_SPECIAL}}
+    )
+
+    assert converged_result["adds_to_A"] == 0
+    assert converged_result["adds_to_B"] == 0
+    assert trakt.added == []
+    assert simkl.added == []


### PR DESCRIPTION
# Pull request

## Change

- Preserve season-zero episode identity in shared canonical keys.
- Match season-zero episodes across one-way and two-way provider pairs.
- Send supported episode-level IDs when writing Trakt specials to SIMKL.
- Read and remove SIMKL season-zero history correctly.
- Preserve PublicMetaDB season-zero episodes during history reads.
- Group multiple MDBList specials under one season-zero payload.
- Add focused provider and Trakt-SIMKL two-way regression coverage.

## Why

Season zero was treated as missing in several identity, planning and provider paths.
This caused specials to be skipped, duplicated, mismatched between providers, or repeatedly written to SIMKL. Two-way pairs could also fail to converge when Trakt and SIMKL exposed different ID sets for the same special.

## Testing

- history, planner and two-way tests passed.
- Verified the exact issue #311 sample payload.
- Verified successful Trakt-to-SIMKL routing.
- Verified permanent SIMKL rejection is blocked after one attempt.
- Verified two-way convergence when providers expose different IDs.
- Verified normal-season behavior across all affected providers.

## Issue

Fixes #311