### PR TITLE
Change: improved dashboard and probes

### DIFF
--- a/api/maintenanceAPI.py
+++ b/api/maintenanceAPI.py
@@ -302,6 +302,18 @@ def clear_cache() -> dict[str, Any]:
         "after": after,
     }
 
+
+@router.post("/clear-provider-sync-cache")
+def clear_provider_sync_cache() -> dict[str, Any]:
+    """Reset pair baselines and provider runtime cache without touching user-facing local history."""
+    state = clear_state_minimal()
+    cache = clear_cache()
+    return {
+        "ok": bool(state.get("ok")) and bool(cache.get("ok")),
+        "state": state,
+        "cache": cache,
+    }
+
 @router.get("/provider-cache")
 def provider_cache_status() -> dict[str, Any]:
     info = _scan_provider_cache()
@@ -435,6 +447,25 @@ def clear_activity_log() -> dict[str, Any]:
         return res
     except Exception as e:
         return {"ok": False, "error": "clear_activity_log_failed", "detail": str(e)}
+
+
+@router.post("/clear-recent-scrobbles")
+def clear_recent_scrobbles() -> dict[str, Any]:
+    try:
+        from services.activity import clear_scrobble_events
+
+        res = clear_scrobble_events()
+        _, _, _, _, _, _append_log = _cw()
+        try:
+            _append_log(
+                "TRBL",
+                "\x1b[91m[TROUBLESHOOT]\x1b[0m Cleared local recent scrobbles.",
+            )
+        except Exception:
+            pass
+        return res
+    except Exception as e:
+        return {"ok": False, "error": "clear_recent_scrobbles_failed", "detail": str(e)}
 
 # --- statistics reset / recalculation ---
 @router.post("/reset-stats")

--- a/api/maintenanceAPI.py
+++ b/api/maintenanceAPI.py
@@ -445,8 +445,8 @@ def clear_activity_log() -> dict[str, Any]:
         except Exception:
             pass
         return res
-    except Exception as e:
-        return {"ok": False, "error": "clear_activity_log_failed", "detail": str(e)}
+    except Exception:
+        return {"ok": False, "error": "clear_activity_log_failed"}
 
 
 @router.post("/clear-recent-scrobbles")
@@ -464,8 +464,8 @@ def clear_recent_scrobbles() -> dict[str, Any]:
         except Exception:
             pass
         return res
-    except Exception as e:
-        return {"ok": False, "error": "clear_recent_scrobbles_failed", "detail": str(e)}
+    except Exception:
+        return {"ok": False, "error": "clear_recent_scrobbles_failed"}
 
 # --- statistics reset / recalculation ---
 @router.post("/reset-stats")

--- a/api/metaAPI.py
+++ b/api/metaAPI.py
@@ -887,7 +887,7 @@ def api_tmdb_art(
     tmdb_id: int = FPath(...),
     size: str = Query("w342"),
     kind: str = Query("poster"),
-    season: int | None = Query(None, ge=1),
+    season: int | None = Query(None, ge=0),
     episode: int | None = Query(None, ge=1),
     locale: str | None = Query(None),
 ):

--- a/assets/crosswatch.css
+++ b/assets/crosswatch.css
@@ -813,16 +813,23 @@ to{left:6px}
 #conn-badges.vip-badges .conn-item.conn-spacer{padding:0;border:0;background:0 0;box-shadow:none}
 #conn-badges .conn-pill{height:28px;padding:0 8px;border-radius:16px;gap:6px}
 #conn-badges .conn-text{font-size:11px;font-weight:800;letter-spacing:-.015em;line-height:1;min-width:0}
-#conn-badges .dot{width:8px;height:8px}
+#conn-badges .conn-provider-visual{position:relative;align-self:stretch;display:block;width:var(--vip-rail);min-width:var(--vip-rail);height:100%;overflow:hidden;isolation:isolate;flex:0 0 var(--vip-rail);border-radius:inherit;background:radial-gradient(88% 72% at 18% 14%,rgba(var(--conn-provider-rgb,255,255,255),.22),transparent 54%),radial-gradient(72% 58% at 82% 76%,rgba(var(--conn-provider-rgb,255,255,255),.10),transparent 68%),rgba(255,255,255,.025)}
+#conn-badges .conn-provider-visual::after{content:"";position:absolute;left:50%;top:54%;width:220%;height:220%;transform:translate(-50%,-50%);background-image:var(--conn-provider-logo);background-repeat:no-repeat;background-position:center;background-size:contain;mix-blend-mode:screen;opacity:.42;filter:saturate(1.35) brightness(1.12) contrast(1.04)}
+#conn-badges .conn-provider-visual .dot{position:absolute;left:50%;right:auto;top:50%;z-index:2;transform:translate(-50%,-50%)}
+#conn-badges .dot{width:10px;height:10px}
 #conn-badges .conn-brand{gap:0}
-#conn-badges .conn-pill:not(.has-vip){padding-inline:10px 8px}
-#conn-badges .conn-pill.has-vip{display:grid!important;grid-template-columns:var(--vip-rail) auto 8px;align-items:center;column-gap:6px;padding:0 8px 0 0}
-#conn-badges .conn-pill.has-vip .conn-brand{width:var(--vip-rail);min-width:var(--vip-rail);height:100%;justify-content:center;align-items:center;flex:0 0 var(--vip-rail)}
+#conn-badges .conn-brand:empty{display:none}
+#conn-badges .conn-pill:not(.has-vip){padding:0}
+#conn-badges .conn-pill:not(.has-vip) .conn-provider-visual{border-radius:inherit}
+#conn-badges .conn-pill::after{content:none!important;display:none!important}
+#conn-badges .conn-pill.has-vip{display:inline-flex!important;align-items:center;padding:0;overflow:visible}
+#conn-badges .conn-pill.ok.has-vip::before{content:none}
+#conn-badges .conn-pill.has-vip .conn-brand{position:absolute;left:50%;top:1px;width:var(--crown-size);min-width:var(--crown-size);height:var(--crown-size);justify-content:center;align-items:center;z-index:4;pointer-events:none;transform:translate(-50%,-62%)}
 #conn-badges .conn-pill.has-vip .conn-logo{display:none}
 #conn-badges .conn-pill.has-vip .conn-text{justify-self:center;text-align:center}
-#conn-badges .conn-pill.has-vip .dot{justify-self:end}
-#conn-badges .conn-pill.has-vip .conn-slot{width:100%;min-width:100%;height:100%;display:flex;align-items:center;justify-content:center;padding:0}
-#conn-badges .conn-pill.has-vip .conn-slot svg{width:var(--crown-size);height:var(--crown-size);transform:translateX(-5px)}
+#conn-badges .conn-pill.has-vip .conn-provider-visual{justify-self:center}
+#conn-badges .conn-pill.has-vip .conn-slot{width:var(--crown-size);min-width:var(--crown-size);height:var(--crown-size);display:flex;align-items:center;justify-content:center;padding:0;color:rgba(239,242,248,.72);filter:drop-shadow(0 1px 1px rgba(0,0,0,.9)) drop-shadow(0 3px 5px rgba(0,0,0,.48))}
+#conn-badges .conn-pill.has-vip .conn-slot svg{width:var(--crown-size);height:var(--crown-size);transform:rotate(-8deg)}
 #ops-card .action-row{margin-top:16px;padding:12px;border:1px solid rgba(255,255,255,.08);border-radius:18px;background:linear-gradient(180deg,rgba(255,255,255,.032),rgba(255,255,255,.014));box-shadow:inset 0 1px 0 rgba(255,255,255,.02)}
 #ops-card .action-buttons{gap:10px}
 #ops-card .action-buttons .btn:not(.acc){background:linear-gradient(180deg,rgba(255,255,255,.05),rgba(255,255,255,.02));border-color:rgba(255,255,255,.1);box-shadow:0 10px 22px rgba(0,0,0,.18),inset 0 1px 0 rgba(255,255,255,.02)}
@@ -933,8 +940,8 @@ html[data-cw-theme=flat-light] #placeholder-card .edge.left{background:linear-gr
 html[data-cw-theme=flat-light] #placeholder-card .edge.right{background:linear-gradient(270deg,#fff 0,rgba(255,255,255,.76) 46%,transparent 100%)}
 html[data-cw-theme=flat-light] #placeholder-card .nav{background:#f5f7fb;border-color:rgba(16,24,40,.18);color:#172033}
 html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;border-color:rgba(16,24,40,.26)}
-.cw-dashboard-widgets{display:grid;grid-template-columns:minmax(360px,1fr) minmax(360px,.84fr) minmax(360px,1fr);gap:16px;align-items:stretch}
-.cw-dash-widget{--dash-panel:linear-gradient(180deg,rgba(18,21,30,.94),rgba(9,11,18,.96));--dash-panel-soft:rgba(255,255,255,.045);--dash-panel-strong:rgba(5,8,14,.64);--dash-border:rgba(255,255,255,.095);--dash-border-strong:rgba(255,255,255,.16);--dash-text:#f4f7ff;--dash-muted:rgba(190,199,216,.72);position:relative;min-width:0;overflow:hidden;border:1px solid var(--dash-border);border-radius:20px;background:radial-gradient(110% 90% at 8% 0,rgba(84,95,173,.14),transparent 54%),radial-gradient(90% 80% at 100% 100%,rgba(34,140,112,.10),transparent 58%),var(--dash-panel);box-shadow:0 18px 42px rgba(0,0,0,.22),inset 0 1px 0 rgba(255,255,255,.04);padding:16px;color:var(--dash-text)}
+.cw-dashboard-widgets{display:grid;grid-template-columns:minmax(360px,1fr) minmax(360px,.84fr) minmax(360px,1fr);gap:16px;align-items:start}
+.cw-dash-widget{--dash-panel:linear-gradient(180deg,rgba(18,21,30,.94),rgba(9,11,18,.96));--dash-panel-soft:rgba(255,255,255,.045);--dash-panel-strong:rgba(5,8,14,.64);--dash-border:rgba(255,255,255,.095);--dash-border-strong:rgba(255,255,255,.16);--dash-text:#f4f7ff;--dash-muted:rgba(190,199,216,.72);position:relative;align-self:start;min-width:0;overflow:hidden;border:1px solid var(--dash-border);border-radius:20px;background:radial-gradient(110% 90% at 8% 0,rgba(84,95,173,.14),transparent 54%),radial-gradient(90% 80% at 100% 100%,rgba(34,140,112,.10),transparent 58%),var(--dash-panel);box-shadow:0 18px 42px rgba(0,0,0,.22),inset 0 1px 0 rgba(255,255,255,.04);padding:16px;color:var(--dash-text)}
 .cw-dash-widget--ratings{background:radial-gradient(90% 75% at 0 0,rgba(141,103,54,.14),transparent 54%),radial-gradient(88% 80% at 100% 100%,rgba(91,82,167,.12),transparent 58%),var(--dash-panel)}
 .cw-dash-widget--scrobble{background:radial-gradient(90% 70% at 0 0,rgba(87,181,138,.14),transparent 52%),radial-gradient(90% 80% at 100% 100%,rgba(125,134,201,.13),transparent 58%),var(--dash-panel)}
 .cw-dash-widget-head{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:14px}
@@ -942,7 +949,7 @@ html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;b
 .cw-dash-title-row .material-symbols-rounded{display:inline-flex;align-items:center;justify-content:center;width:34px;height:34px;border-radius:12px;border:1px solid var(--dash-border);background:var(--dash-panel-soft);color:var(--dash-text);font-size:21px}
 .cw-dash-title-row h3{margin:0;font-size:18px;font-weight:850;line-height:1.1;color:var(--dash-text);letter-spacing:0}
 .cw-dash-head-actions{display:flex;align-items:center;justify-content:flex-end;gap:8px;flex:0 0 auto}
-.cw-widget-count-chip{display:inline-flex;align-items:center;justify-content:center;min-height:28px;padding:0 10px;border-radius:999px;border:1px solid var(--dash-border,rgba(255,255,255,.095));background:var(--dash-panel-soft,rgba(255,255,255,.045));color:var(--dash-muted,rgba(190,199,216,.72));font-size:11px;font-weight:850;line-height:1;white-space:nowrap}
+.cw-widget-count-chip{display:inline-flex;align-items:center;justify-content:center;min-width:30px;height:30px;padding:0 8px;border-radius:10px;border:1px solid rgba(139,149,255,.18);background:linear-gradient(145deg,rgba(91,99,214,.18),rgba(34,40,82,.12));color:var(--dash-text,#f4f7ff);box-shadow:inset 0 1px 0 rgba(255,255,255,.04),0 8px 18px rgba(0,0,0,.14);font-size:12px;font-weight:900;font-variant-numeric:tabular-nums;line-height:1;white-space:nowrap}
 .cw-dash-ghost{display:inline-flex;align-items:center;justify-content:center;flex:0 0 auto;width:36px;height:36px;border-radius:12px;border:1px solid var(--dash-border);background:var(--dash-panel-soft);color:var(--dash-text);cursor:pointer;font-size:20px;line-height:1;transition:background .14s ease,border-color .14s ease,transform .14s ease}
 .cw-dash-ghost:hover{background:rgba(255,255,255,.075);border-color:var(--dash-border-strong);transform:translateY(-1px)}
 .cw-history-widget-list{display:grid;grid-auto-rows:max-content;align-content:start;align-items:start;gap:10px;max-height:650px;overflow:auto;padding-right:2px}
@@ -968,6 +975,7 @@ html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;b
 .cw-scrobble-source{display:inline-flex;align-items:center;justify-content:center;min-height:22px;padding:0 9px;border-radius:999px;border:1px solid rgba(var(--cw-source-rgb),.38);background:rgba(var(--cw-source-rgb),.13);box-shadow:inset 0 1px 0 rgba(255,255,255,.06),0 0 14px rgba(var(--cw-source-rgb),.10);color:rgb(var(--cw-source-rgb));font-size:10px;font-weight:900;letter-spacing:.03em;white-space:nowrap}
 .cw-dash-see-more{display:inline-flex;align-items:center;justify-content:center;width:100%;min-height:38px;border-radius:14px;border:1px solid var(--dash-border);background:var(--dash-panel-soft);color:var(--dash-text);cursor:pointer;transition:background .14s ease,border-color .14s ease,transform .14s ease}
 .cw-dash-see-more:hover{background:rgba(255,255,255,.075);border-color:var(--dash-border-strong);transform:translateY(-1px)}
+.cw-dash-see-more:disabled{opacity:.58;cursor:default;transform:none}
 .cw-dash-see-more .material-symbols-rounded{font-size:22px;line-height:1}
 .cw-ratings-widget-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
 .cw-ratings-widget-grid>.cw-dash-see-more{grid-column:1/-1}
@@ -1255,14 +1263,18 @@ html[data-cw-theme=flat-light] #page-settings #sec-meta #anime_mapping_error:not
 html[data-cw-theme=flat-light] #page-settings #sec-anilist .anilist-mapping-rec{background:#f6fbff!important;background-image:none!important;border-color:rgba(2,114,174,.22)!important;box-shadow:none!important;color:#172033!important}
 html[data-cw-theme=flat-light] #page-settings #sec-anilist .anilist-mapping-rec-kicker{color:#075985!important}
 html[data-cw-theme=flat-light] #page-settings #sec-anilist .anilist-mapping-rec-state{color:#7a4a00!important}
-#conn-badges.vip-badges{--crown-size:21px!important;--rail-pad:4px!important;--vip-rail:calc(var(--crown-size) + (2*var(--rail-pad)))!important;gap:6px!important}
-#conn-badges .conn-pill{height:30px!important;padding:0 8px!important;gap:6px!important;border-radius:14px!important}
+#conn-badges.vip-badges{--crown-size:23px!important;--rail-pad:4px!important;--vip-rail:42px!important;gap:10px!important}
+#conn-badges .conn-pill{height:42px!important;min-height:42px!important;padding:0!important;gap:0!important;border-radius:20px!important;overflow:visible!important}
 #conn-badges .conn-text{font-size:12px!important;line-height:1!important;flex:1 1 auto!important;text-align:center!important}
 #conn-badges .conn-pill.has-vip .conn-text{transform:translateX(-4px)!important}
-#conn-badges .dot{width:11px!important;height:11px!important;flex:0 0 auto!important;margin-left:auto!important}
-#conn-badges .conn-pill.has-vip .conn-brand{width:var(--vip-rail)!important;min-width:var(--vip-rail)!important;flex:0 0 var(--vip-rail)!important;justify-content:center!important}
-#conn-badges .conn-pill.has-vip .conn-slot{width:100%!important;min-width:100%!important;display:flex!important;align-items:center!important;justify-content:center!important;padding-left:0!important}
-#conn-badges .conn-pill.has-vip .conn-slot svg{width:var(--crown-size)!important;height:var(--crown-size)!important;transform:translateX(-7px)!important}
+#conn-badges .dot{width:12px!important;height:12px!important;flex:0 0 auto!important;margin:0!important}
+#conn-badges .conn-pill.has-vip .conn-brand{position:absolute!important;left:50%!important;top:1px!important;width:var(--crown-size)!important;min-width:var(--crown-size)!important;height:var(--crown-size)!important;justify-content:center!important;transform:translate(-50%,-62%)!important;z-index:4!important}
+#conn-badges .conn-pill.has-vip .conn-slot{width:var(--crown-size)!important;min-width:var(--crown-size)!important;height:var(--crown-size)!important;display:flex!important;align-items:center!important;justify-content:center!important;padding:0!important;color:rgba(239,242,248,.72)!important}
+#conn-badges .conn-pill.has-vip .conn-slot svg{width:var(--crown-size)!important;height:var(--crown-size)!important;transform:rotate(-8deg)!important}
+html.cw-theme-original #conn-badges .conn-pill{background:#11151d!important;border-color:rgba(255,255,255,.12)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.05),0 8px 18px rgba(0,0,0,.28)!important}
+html.cw-theme-original #conn-badges .conn-provider-visual{background:radial-gradient(88% 72% at 18% 14%,rgba(var(--conn-provider-rgb,255,255,255),.16),transparent 54%),radial-gradient(72% 58% at 82% 76%,rgba(var(--conn-provider-rgb,255,255,255),.08),transparent 68%),#0d1118}
+html.cw-theme-original #conn-badges .conn-provider-visual::after{mix-blend-mode:screen;opacity:.48;filter:saturate(1.24) brightness(1.06) contrast(1.08)}
+html.cw-theme-original #conn-badges .conn-pill.has-vip .conn-slot{color:rgba(235,239,247,.68)!important}
 html[data-cw-theme=flat-dark] #ops-card.card,html[data-cw-theme=flat-dark] #page-settings #auth-providers>.section,html[data-cw-theme=flat-dark] #page-settings #auth-providers>.section>.body>.section,html[data-cw-theme=flat-dark] #page-settings #sec-meta.cw-hub-tile.tmdb,html[data-cw-theme=flat-dark] #page-settings .cw-settings-pane-stack>.cw-settings-section,html[data-cw-theme=flat-dark] #page-settings .cw-settings-section,html[data-cw-theme=flat-dark] #stats-card.stat-block,html[data-cw-theme=flat-dark] #stats-card.stats-modern,html[data-cw-theme=flat-dark] .card,html[data-cw-theme=flat-dark] .cw-panel,html[data-cw-theme=flat-dark] .cw-settings-hero-panel,html[data-cw-theme=flat-dark] .cw-settings-metric,html[data-cw-theme=flat-dark] .cw-settings-mini-action,html[data-cw-theme=flat-dark] .cw-settings-nav-card,html[data-cw-theme=flat-dark] .cw-settings-overview-card,html[data-cw-theme=flat-dark] .cw-settings-pane-head,html[data-cw-theme=flat-dark] .cw-settings-panel,html[data-cw-theme=flat-dark] .cw-settings-progress-card,html[data-cw-theme=flat-dark] .cw-settings-setup-step,html[data-cw-theme=flat-dark] .details,html[data-cw-theme=flat-dark] .meta-card,html[data-cw-theme=flat-dark] .section,html[data-cw-theme=flat-dark] .tile{background:var(--panel)!important;border-color:var(--border)!important;box-shadow:none!important;text-shadow:none!important}
 html[data-cw-theme=flat-dark] #page-settings .cw-settings-pane-stack>.cw-settings-section,html[data-cw-theme=flat-dark] #page-settings .cw-settings-section,html[data-cw-theme=flat-dark] .card,html[data-cw-theme=flat-dark] .cw-panel,html[data-cw-theme=flat-dark] .cw-settings-hero-panel,html[data-cw-theme=flat-dark] .cw-settings-nav-card,html[data-cw-theme=flat-dark] .cw-settings-overview-card,html[data-cw-theme=flat-dark] .cw-settings-pane-head,html[data-cw-theme=flat-dark] .cw-settings-panel,html[data-cw-theme=flat-dark] .cw-settings-progress-card,html[data-cw-theme=flat-dark] .details,html[data-cw-theme=flat-dark] .meta-card{border-radius:12px!important}
 html[data-cw-theme=flat-dark] #page-settings #auth-providers>.section,html[data-cw-theme=flat-dark] #page-settings #auth-providers>.section>.body>.section,html[data-cw-theme=flat-dark] #page-settings #sec-meta.cw-hub-tile.tmdb,html[data-cw-theme=flat-dark] .cw-settings-metric,html[data-cw-theme=flat-dark] .cw-settings-mini-action,html[data-cw-theme=flat-dark] .cw-settings-setup-step,html[data-cw-theme=flat-dark] .tile{border-radius:10px!important}
@@ -1360,25 +1372,28 @@ html[data-cw-theme=flat-dark] body #page-settings .cw-settings-setup-step.is-act
 html[data-cw-theme=flat-dark] body #page-settings .cw-settings-setup-step.is-done .cw-settings-step-state{background:#263b31!important;border-color:rgba(87,181,138,.42)!important;color:#dcffe7!important}
 html[data-cw-theme=flat-dark] body #page-settings .cw-settings-setup-step.is-active .cw-settings-step-state{background:#252b3d!important;border-color:rgba(125,134,201,.45)!important;color:#f5f7ff!important}
 html[data-cw-theme=flat-dark] body #page-settings :is(.cw-settings-overview-card,.cw-settings-setup-step,.cw-settings-nav-card,.cw-settings-nav-btn,.cw-settings-pane-head,.cw-settings-mini-action,.cw-hub-tile,.si-card,.si-row)::after,html[data-cw-theme=flat-dark] body #page-settings :is(.cw-settings-overview-card,.cw-settings-setup-step,.cw-settings-nav-card,.cw-settings-nav-btn,.cw-settings-pane-head,.cw-settings-mini-action,.cw-hub-tile,.si-card,.si-row)::before{content:none!important;display:none!important}
-html[data-cw-theme] body #conn-badges.vip-badges{--crown-size:19px!important;--rail-pad:7px!important;--vip-rail:42px!important;gap:10px!important;align-items:center!important}
+html[data-cw-theme] body #conn-badges.vip-badges{--crown-size:23px!important;--rail-pad:7px!important;--vip-rail:42px!important;gap:10px!important;align-items:center!important}
 html[data-cw-theme] body #conn-badges.vip-badges .conn-item{display:flex!important;align-items:center!important}
-html[data-cw-theme] body #conn-badges .conn-pill{min-height:42px!important;height:42px!important;min-width:112px!important;padding:0 14px!important;gap:10px!important;border-radius:20px!important;border-color:rgba(255,255,255,.13)!important;background:#242936!important;color:#eef1f6!important;box-shadow:none!important;filter:none!important;overflow:hidden!important;transition:background .16s ease,border-color .16s ease,transform .16s ease!important}
+html[data-cw-theme] body #conn-badges .conn-pill{min-height:42px!important;height:42px!important;min-width:0!important;padding:0!important;gap:0!important;border-radius:20px!important;border-color:rgba(255,255,255,.13)!important;background:#242936!important;color:#eef1f6!important;box-shadow:none!important;filter:none!important;overflow:visible!important;transition:background .16s ease,border-color .16s ease,transform .16s ease!important}
 html[data-cw-theme] body #conn-badges .conn-pill::after{content:none!important;display:none!important}
 html[data-cw-theme] body #conn-badges .conn-pill>*{position:relative!important;z-index:1!important}
 html[data-cw-theme] body #conn-badges .conn-pill:hover{transform:translateY(-1px)!important;background:#2a303d!important;border-color:rgba(255,255,255,.2)!important;filter:none!important}
-html[data-cw-theme] body #conn-badges .conn-pill.has-vip{display:grid!important;grid-template-columns:var(--vip-rail) minmax(0,auto) 10px!important;column-gap:10px!important;padding:0 14px 0 0!important}
-html[data-cw-theme] body #conn-badges .conn-pill.ok.has-vip::before{content:""!important;display:block!important;position:absolute!important;inset:0 auto 0 0!important;width:var(--vip-rail)!important;border-radius:20px 0 0 20px!important;background:#303047!important;border-right:1px solid rgba(255,255,255,.1)!important;opacity:1!important;z-index:0!important}
-html[data-cw-theme] body #conn-badges .conn-pill.has-vip .conn-brand{width:var(--vip-rail)!important;min-width:var(--vip-rail)!important;height:100%!important;justify-content:center!important}
-html[data-cw-theme] body #conn-badges .conn-pill.has-vip .conn-slot{width:100%!important;min-width:100%!important;height:100%!important;display:flex!important;align-items:center!important;justify-content:center!important;transform-origin:50% 70%!important;animation:crown-bob 5s ease-in-out infinite!important}
+html[data-cw-theme] body #conn-badges .conn-pill.has-vip{display:inline-flex!important;padding:0!important}
+html[data-cw-theme] body #conn-badges .conn-pill.ok.has-vip::before{content:none!important;display:none!important}
+html[data-cw-theme] body #conn-badges .conn-pill.has-vip .conn-brand{position:absolute!important;left:50%!important;top:1px!important;width:var(--crown-size)!important;min-width:var(--crown-size)!important;height:var(--crown-size)!important;justify-content:center!important;transform:translate(-50%,-62%)!important;z-index:4!important}
+html[data-cw-theme] body #conn-badges .conn-pill.has-vip .conn-slot{width:var(--crown-size)!important;min-width:var(--crown-size)!important;height:var(--crown-size)!important;display:flex!important;align-items:center!important;justify-content:center!important;transform-origin:50% 70%!important;animation:crown-bob 5s ease-in-out infinite!important}
 html[data-cw-theme] body #conn-badges .conn-pill.has-vip:hover .conn-slot{animation:crown-bob 5s ease-in-out infinite,crown-tilt .8s cubic-bezier(.2,.8,.2,1) 1!important}
-html[data-cw-theme] body #conn-badges .conn-pill.has-vip .conn-slot svg{width:var(--crown-size)!important;height:var(--crown-size)!important;transform:none!important;opacity:.92!important}
-html[data-cw-theme] body #conn-badges .conn-pill.has-vip .conn-text{transform:none!important;justify-self:start!important;text-align:left!important}
-html[data-cw-theme] body #conn-badges .conn-text{font-size:13px!important;font-weight:850!important;letter-spacing:-.01em!important;line-height:1!important}
-html[data-cw-theme] body #conn-badges .dot{width:10px!important;height:10px!important;border-radius:999px!important}
+html[data-cw-theme] body #conn-badges .conn-pill.has-vip .conn-slot svg{width:var(--crown-size)!important;height:var(--crown-size)!important;transform:rotate(-8deg)!important;opacity:.96!important}
+html[data-cw-theme] body #conn-badges .conn-pill:not(.has-vip){padding:0!important}
+html[data-cw-theme] body #conn-badges .conn-pill.has-vip .conn-provider-visual{justify-self:start!important}
+html[data-cw-theme] body #conn-badges .dot{width:12px!important;height:12px!important;border-radius:999px!important}
 html[data-cw-theme] body #conn-badges .conn-pill .dot.ok{background:#66bd95!important;color:#66bd95!important}
 html[data-cw-theme] body #conn-badges .conn-pill .dot.no{background:#d86672!important;color:#d86672!important}
 html[data-cw-theme] body #btn-status-refresh{width:42px!important;height:42px!important;border-radius:16px!important;background:#242936!important;border-color:rgba(255,255,255,.13)!important}
 html[data-cw-theme] body #btn-status-refresh:hover{background:#2a303d!important;border-color:rgba(255,255,255,.2)!important}
 html[data-cw-theme=flat-light] body #btn-status-refresh,html[data-cw-theme=flat-light] body #conn-badges .conn-pill{background:#fff!important;border-color:rgba(16,24,40,.16)!important;color:#172033!important}
 html[data-cw-theme=flat-light] body #btn-status-refresh:hover,html[data-cw-theme=flat-light] body #conn-badges .conn-pill:hover{background:#f3f6fb!important;border-color:rgba(16,24,40,.24)!important}
-html[data-cw-theme=flat-light] body #conn-badges .conn-pill.ok.has-vip::before{background:#eef1fb!important;border-right-color:rgba(16,24,40,.1)!important}
+html[data-cw-theme=flat-light] body #conn-badges .conn-pill.ok.has-vip::before{background:#eef1fb!important}
+html[data-cw-theme=flat-light] body #conn-badges .conn-provider-visual{background:radial-gradient(88% 72% at 18% 14%,rgba(var(--conn-provider-rgb,16,24,40),.28),transparent 54%),radial-gradient(72% 58% at 82% 76%,rgba(var(--conn-provider-rgb,16,24,40),.16),transparent 68%),rgba(16,24,40,.045)}
+html[data-cw-theme=flat-light] body #conn-badges .conn-provider-visual::after{mix-blend-mode:multiply;opacity:.48;filter:saturate(1.38) brightness(.94) contrast(1.18)}
+html[data-cw-theme=flat-light] body #conn-badges .conn-pill.has-vip .conn-slot{color:rgba(52,64,84,.68)!important;filter:drop-shadow(0 1px 1px rgba(255,255,255,.9)) drop-shadow(0 2px 4px rgba(16,24,40,.22))}

--- a/assets/helpers/watchlist-preview.js
+++ b/assets/helpers/watchlist-preview.js
@@ -11,7 +11,8 @@
   window.__wallLoading = window.__wallLoading || false;
   window._lastSyncEpoch = window._lastSyncEpoch || null;
   window.__wallRenderSignature = window.__wallRenderSignature || "";
-  const WALL_PREVIEW_CACHE_KEY = `cw.wall.preview.${window.APP_VERSION || "v1"}`;
+  const WALL_PREVIEW_CACHE_KEY = "cw.wall.preview.v2";
+  const WALL_PREVIEW_LEGACY_CACHE_KEY = `cw.wall.preview.${window.APP_VERSION || "v1"}`;
   const DEFAULT_INSTANCE = "default";
 
   const json = async (url, opt) => {
@@ -66,7 +67,17 @@
 
   const readWallCache = () => {
     try {
-      const data = JSON.parse(localStorage.getItem(WALL_PREVIEW_CACHE_KEY) || "{}");
+      let raw = localStorage.getItem(WALL_PREVIEW_CACHE_KEY)
+        || localStorage.getItem(WALL_PREVIEW_LEGACY_CACHE_KEY);
+      if (!raw) {
+        for (let i = 0; i < localStorage.length; i++) {
+          const key = localStorage.key(i) || "";
+          if (!key.startsWith("cw.wall.preview.") || key === WALL_PREVIEW_CACHE_KEY) continue;
+          raw = localStorage.getItem(key);
+          if (raw) break;
+        }
+      }
+      const data = JSON.parse(raw);
       return Array.isArray(data?.items) ? data : null;
     } catch {
       return null;
@@ -127,7 +138,7 @@
   function artUrl(item, size = "w342") {
     const tmdb = item?.tmdb;
     if (!tmdb) return null;
-    return `/art/tmdb/${isTV(item.type || item.entity || item.media_type) ? "tv" : "movie"}/${tmdb}?size=${encodeURIComponent(size)}&cb=${window._lastSyncEpoch || 0}`;
+    return `/art/tmdb/${isTV(item.type || item.entity || item.media_type) ? "tv" : "movie"}/${tmdb}?size=${encodeURIComponent(size)}`;
   }
 
   const providerLogoPath = (name) => window.CW?.ProviderMeta?.logoPath?.(name) || "";
@@ -145,7 +156,9 @@
   function setWatchlistCount(total) {
     const chip = document.getElementById("watchlist-count-chip");
     if (!chip) return;
-    chip.textContent = countLabel(total, "item");
+    const count = Number(total || 0);
+    chip.textContent = String(Number.isFinite(count) ? count : 0);
+    chip.setAttribute("aria-label", countLabel(total, "item"));
     chip.classList.remove("hidden");
   }
 
@@ -749,7 +762,8 @@
       link.dataset.source = source;
 
       const img = document.createElement("img");
-      img.loading = "lazy";
+      img.loading = renderedCount < 4 ? "eager" : "lazy";
+      if (renderedCount < 4) img.fetchPriority = "high";
       img.alt = `${item.title || ""} (${item.year || ""})`;
       img.src = artUrl(item, "w342") || "/assets/img/placeholder_poster.svg";
       img.onerror = function () { this.onerror = null; this.src = "/assets/img/placeholder_poster.svg"; };
@@ -815,19 +829,8 @@
     if (!card || !msg || !row) return;
     if (!isOnMain()) { hidePreviewCard(card, row, msg); return; }
 
-    try {
-      const gate = await previewGate();
-      if (!isOnMain()) { hidePreviewCard(card, row, msg); return; }
-      if (!gate.allowed) {
-        card.classList.add("hidden");
-        hideWatchlistCount();
-        return;
-      }
-      card.classList.remove("hidden");
-    } catch {}
-
     const myReq = ++wallReqSeq;
-    const hasRenderedWall = row.childElementCount > 0 && !row.classList.contains("hidden");
+    let hasRenderedWall = row.childElementCount > 0 && !row.classList.contains("hidden");
     if (!hasRenderedWall) {
       msg.textContent = "Loading...";
       msg.classList.remove("is-empty");
@@ -836,33 +839,48 @@
       row.classList.add("hidden");
       const cached = readWallCache();
       if (cached) {
-        renderWall(row, msg, cached.items, cached.last_sync_epoch || 0, { total: cached.total ?? null });
+        hasRenderedWall = renderWall(row, msg, cached.items, cached.last_sync_epoch || 0, { total: cached.total ?? null });
       }
     }
 
+    const limit = Number.isFinite(window.MAX_WALL_POSTERS) ? Math.max(1, Number(window.MAX_WALL_POSTERS)) : 20;
+    const wallDataPromise = json(`/api/state/wall?both_only=0&active_only=1&limit=${encodeURIComponent(limit)}`)
+      .then((data) => ({ data }), (error) => ({ error }));
+
     try {
-      const limit = Number.isFinite(window.MAX_WALL_POSTERS) ? Math.max(1, Number(window.MAX_WALL_POSTERS)) : 20;
-      const data = await json(`/api/state/wall?both_only=0&active_only=1&limit=${encodeURIComponent(limit)}`);
-      if (myReq !== wallReqSeq) return;
-      if (!isOnMain()) { hidePreviewCard(card, row, msg); return; }
-      if (data?.missing_tmdb_key) { card.classList.add("hidden"); hideWatchlistCount(); return; }
-      if (!data?.ok) { msg.textContent = data?.error || "No state data found."; return; }
+      const gate = await previewGate();
+      if (myReq !== wallReqSeq) return false;
+      if (!isOnMain()) { hidePreviewCard(card, row, msg); return false; }
+      if (!gate.allowed) {
+        hidePreviewCard(card, row, msg);
+        return false;
+      }
+      card.classList.remove("hidden");
+
+      const wallResult = await wallDataPromise;
+      if (wallResult.error) throw wallResult.error;
+      const data = wallResult.data;
+      if (myReq !== wallReqSeq) return false;
+      if (!isOnMain()) { hidePreviewCard(card, row, msg); return false; }
+      if (data?.missing_tmdb_key) { hidePreviewCard(card, row, msg); return false; }
+      if (!data?.ok) { msg.textContent = data?.error || "No state data found."; return false; }
 
       let items = Array.isArray(data.items) ? data.items.slice() : [];
       if (!items.length) items = (data.items || []).filter((it) => String(it?.status || "").toLowerCase() === "both");
       window._lastSyncEpoch = data.last_sync_epoch || null;
       if (!items.length) {
         setWallEmpty(row, msg, "No items to show yet.");
-        return;
+        return true;
       }
       writeWallCache(items, data.last_sync_epoch || 0, data?.total ?? items.length);
-      renderWall(row, msg, items, data.last_sync_epoch || 0, { preserveIfSame: true, total: data?.total ?? items.length });
+      return renderWall(row, msg, items, data.last_sync_epoch || 0, { preserveIfSame: true, total: data?.total ?? items.length });
     } catch {
       if (!hasRenderedWall) {
         row.classList.add("hidden");
         msg.classList.remove("hidden");
       }
       msg.textContent = "Failed to load preview.";
+      return hasRenderedWall;
     }
   }
 
@@ -917,23 +935,11 @@
         hidePreviewCard(card, row, msg);
         return;
       }
-      const { allowed } = await previewGate();
+      window.wallLoaded = !!(await loadWall());
       if (!isOnMain()) {
         hidePreviewCard(card, row, msg);
         return;
       }
-      if (!allowed) {
-        if (card) card.classList.add("hidden");
-        hideWatchlistCount();
-        window.wallLoaded = false;
-        return;
-      }
-      await loadWall();
-      if (!isOnMain()) {
-        hidePreviewCard(card, row, msg);
-        return;
-      }
-      window.wallLoaded = true;
     } catch (e) {
       if (String(e?.message || e || "").includes("auth setup pending")) return;
       console.error("Failed to update watchlist preview:", e);
@@ -956,16 +962,12 @@
         msg.classList.remove("hidden");
       }
 
-      const { allowed } = await previewGate();
-      if (!isOnMain()) { hidePreviewCard(card, row, msg); return false; }
-      if (!allowed) { hidePreviewCard(card, row, msg); return false; }
-
       if (!window.wallLoaded && !window.__wallLoading) {
         window.__wallLoading = true;
-        try { await loadWall(); window.wallLoaded = true; }
+        try { window.wallLoaded = !!(await loadWall()); }
         finally { window.__wallLoading = false; }
       }
-      return true;
+      return !!window.wallLoaded;
     } finally {
       previewBusy = false;
     }

--- a/assets/js/dashboard-widgets.js
+++ b/assets/js/dashboard-widgets.js
@@ -173,7 +173,9 @@
   function setCountChip(id, total, noun) {
     const chip = $(`#${id}`);
     if (!chip) return;
-    chip.textContent = countLabel(total, noun);
+    const count = Number(total || 0);
+    chip.textContent = String(Number.isFinite(count) ? count : 0);
+    chip.setAttribute("aria-label", countLabel(total, noun));
     chip.classList.remove("hidden");
   }
 
@@ -336,7 +338,7 @@
       </div>`).join("");
   }
 
-  function renderPagedList(host, items, count, cardFn, emptyText, kind) {
+  function renderPagedList(host, items, count, cardFn, emptyText, kind, keepPager = false) {
     if (!host) return;
     if (!items.length) {
       setEmpty(host, emptyText);
@@ -344,8 +346,8 @@
     }
     const visible = Math.min(count, items.length);
     const hasMore = visible < items.length;
-    const button = hasMore
-      ? `<button type="button" class="cw-dash-see-more" data-cw-widget-more="${esc(kind)}" aria-label="Show more ${esc(kind)} items">
+    const button = hasMore || keepPager
+      ? `<button type="button" class="cw-dash-see-more" data-cw-widget-more="${esc(kind)}" aria-label="${hasMore ? `Show more ${esc(kind)} items` : `All ${esc(kind)} items shown`}"${hasMore ? "" : " disabled"}>
           <span class="material-symbols-rounded">expand_more</span>
         </button>`
       : "";
@@ -414,6 +416,7 @@
       const ratingItems = Array.isArray(data?.latest_ratings?.items) ? data.latest_ratings.items : [];
       setCountChip("recent-history-count-chip", data?.recent_history?.total ?? historyItems.length, "item");
       setCountChip("latest-ratings-count-chip", data?.latest_ratings?.total ?? ratingItems.length, "rating");
+      setCountChip("recent-scrobble-count-chip", data?.recent_scrobble?.total ?? scrobbleItems.length, "scrobble");
       latestItems.history = historyItems;
       latestItems.ratings = ratingItems;
       latestItems.scrobble = scrobbleItems;
@@ -424,7 +427,7 @@
         renderPagedList(ratingsHost, ratingItems, visibleCounts.ratings, ratingCard, "No ratings recorded yet.", "ratings");
       }
       if (settings.scrobble) {
-        renderPagedList(scrobbleHost, scrobbleItems, visibleCounts.scrobble, activityCard, "No recent scrobble recorded yet.", "scrobble");
+        renderPagedList(scrobbleHost, scrobbleItems, visibleCounts.scrobble, activityCard, "No recent scrobble recorded yet.", "scrobble", true);
       }
     } catch (e) {
       if (authPendingError(e)) {
@@ -453,7 +456,7 @@
       } else if (kind === "ratings") {
         renderPagedList($("#latest-ratings-grid"), latestItems.ratings, visibleCounts.ratings, ratingCard, "No ratings recorded yet.", "ratings");
       } else {
-        renderPagedList($("#recent-scrobble-list"), latestItems.scrobble, visibleCounts.scrobble, activityCard, "No recent scrobble recorded yet.", "scrobble");
+        renderPagedList($("#recent-scrobble-list"), latestItems.scrobble, visibleCounts.scrobble, activityCard, "No recent scrobble recorded yet.", "scrobble", true);
       }
     });
     document.addEventListener("tab-changed", (event) => {

--- a/assets/js/main-status.js
+++ b/assets/js/main-status.js
@@ -8,6 +8,8 @@
   const meta = window.CW?.ProviderMeta || {};
   const up = (v) => (typeof meta.keyOf === "function" ? meta.keyOf(v) : txt(v).toUpperCase());
   const providerLabel = (v) => (typeof meta.label === "function" ? meta.label(v) : (txt(v) || up(v)));
+  const providerLogo = (v) => (typeof meta.logoPath === "function" ? meta.logoPath(v) : `/assets/img/${up(v)}.svg`);
+  const providerTone = (v) => (typeof meta.tone === "function" ? meta.tone(v)?.rgb : "255,255,255") || "255,255,255";
   const mask = (v) => v === "*****" || /^[•]+$/.test(v);
   const pretty = (v) => (txt(v).toLowerCase() === "default" ? "Default" : txt(v));
   const AUTH_MAP = typeof meta.authProviders === "function"
@@ -136,17 +138,19 @@
     const inst = data && typeof data === "object" ? data.instances : null;
     const sum = data && typeof data === "object" ? data.instances_summary : null;
     if (!inst || typeof inst !== "object") return "";
+    const profileIds = Object.keys(inst).sort((a, b) => (a !== "default") - (b !== "default") || a.localeCompare(b));
+    if (!profileIds.length) return "";
     const ok = Number(sum?.ok);
     const probed = Number(sum?.probed);
     const total = Number(sum?.total);
-    if (!Number.isFinite(total) || total <= 1) return "";
-    const lines = [
-      Number.isFinite(probed) && probed > 0 && probed < total
-        ? `Profiles: ${ok}/${probed} checked, ${total} total`
+    const lines = [`Profiles: ${profileIds.map(pretty).join(", ")}`];
+    if (Number.isFinite(total) && total > 1) {
+      lines.push(Number.isFinite(probed) && probed > 0 && probed < total
+        ? `Checked profiles: ${ok}/${probed}, ${total} total`
         : Number.isFinite(ok)
-        ? `Profiles: ${ok}/${total} connected`
-        : `Profiles: ${total}`,
-    ];
+        ? `Connected profiles: ${ok}/${total}`
+        : `Profile count: ${total}`);
+    }
     const used = Array.isArray(sum?.used) ? sum.used : [];
     if (used.length) {
       const labels = used.slice(0, 4).map(pretty);
@@ -186,10 +190,19 @@
     const pill = wrap?.querySelector?.(".conn-pill");
     if (!pill) return;
     const provKey = up(key || name);
-    const text = pill.querySelector(".conn-text");
     const dot = pill.querySelector(".dot");
     const brand = pill.querySelector(".conn-brand");
     const hasSlot = !!pill.querySelector(".conn-slot");
+    let visual = pill.querySelector(".conn-provider-visual");
+    if (!visual) {
+      visual = document.createElement("span");
+      visual.className = "conn-provider-visual";
+      visual.setAttribute("aria-hidden", "true");
+      const legacy = pill.querySelector(".conn-provider-logo,.conn-text");
+      if (legacy) legacy.replaceWith(visual);
+      else pill.insertBefore(visual, dot || null);
+    }
+    if (dot && dot.parentElement !== visual) visual.appendChild(dot);
 
     wrap.dataset.prov = provKey;
     pill.dataset.prov = provKey;
@@ -199,7 +212,9 @@
     pill.ariaLabel = `${name} ${connected ? "connected" : "disconnected"}`;
     if (detail) pill.title = detail;
     else pill.removeAttribute("title");
-    if (text && text.textContent !== name) text.textContent = name;
+    const logoSrc = providerLogo(provKey);
+    visual.style.setProperty("--conn-provider-logo", `url("${logoSrc}")`);
+    visual.style.setProperty("--conn-provider-rgb", providerTone(provKey));
     if (dot) {
       dot.classList.toggle("ok", !!connected);
       dot.classList.toggle("no", !connected);
@@ -221,12 +236,11 @@
     pill.role = "status";
     pill.ariaLabel = `${name} ${connected ? "connected" : "disconnected"}`;
     if (detail) pill.title = detail;
-    pill.innerHTML = `<div class="conn-brand"><span class="conn-logo"></span>${
+    pill.innerHTML = `<div class="conn-brand">${
       vip ? `<span class="conn-slot">${CROWN}</span>` : ""
-    }</div><span class="conn-text"></span><span class="dot ${
+    }</div><span class="conn-provider-visual" aria-hidden="true"><span class="dot ${
       connected ? "ok" : "no"
-    }" aria-hidden="true"></span>`;
-    pill.querySelector(".conn-text").textContent = name;
+    }" aria-hidden="true"></span></span>`;
     wrap.appendChild(pill);
     updateConn(wrap, { name, connected, vip, detail, key });
     return wrap;
@@ -273,9 +287,13 @@
         const data = providers[key] || {};
         const name = providerLabel(key) || titleCase(key);
         const meta = providerMeta(key, data);
-        const detail =
-          [instancesDetail(data), meta.detail, usageDetail(data)].filter(Boolean).join("\n") ||
-          `${name} ${data?.connected ? "connected" : "not connected"}`;
+        const detail = [
+          `Provider: ${name}`,
+          `Status: ${data?.connected ? "Connected" : "Not connected"}`,
+          instancesDetail(data) || "Profiles: Not reported",
+          meta.detail,
+          usageDetail(data),
+        ].filter(Boolean).join("\n");
         const provKey = up(key);
         const existing = existingByKey.get(provKey);
         const item = existing || makeConn({ name, connected: !!data.connected, vip: meta.vip, detail, key });

--- a/assets/js/modals/maintenance/index.js
+++ b/assets/js/modals/maintenance/index.js
@@ -29,6 +29,7 @@ const SIMPLE_OPS = {
   cache: "/api/maintenance/clear-cache",
   metadata: "/api/maintenance/clear-metadata-cache",
   activity: "/api/maintenance/clear-activity-log",
+  scrobbles: "/api/maintenance/clear-recent-scrobbles",
   stats: "/api/maintenance/reset-stats",
   playing: "/api/maintenance/reset-currently-watching",
 };
@@ -37,33 +38,33 @@ const OPS = [
     key: "state",
     kind: "state",
     icon: "deployed_code_history",
-    title: "Clear state",
-    tag: "state.json",
-    desc: 'Removes orchestrator <code>state.json</code> so the next sync rebuilds baseline state from providers.',
+    title: "Rebuild sync state",
+    tag: "sync pairs",
+    desc: 'Starts every sync pair from fresh provider baselines on its next run.',
   },
   {
     key: "cache",
     kind: "cache",
     icon: "network_node",
-    title: "Clear provider cache",
-    tag: ".cw_state",
-    desc: 'Clears provider shadow / flap files under <code>/config/.cw_state</code> so unresolved items and health state are retried.',
+    title: "Retry provider items",
+    tag: "runtime",
+    desc: 'Clears temporary retry and health data so unresolved provider items are tried again.',
   },
   {
     key: "meta",
     kind: "metadata",
     icon: "gallery_thumbnail",
-    title: "Remove metadata cache",
-    tag: "/config/cache",
-    desc: 'Deletes cached posters and metadata under <code>/config/cache</code>. Artwork and meta will be refetched when needed.',
+    title: "Refresh artwork & metadata",
+    tag: "artwork",
+    desc: 'Removes cached artwork and metadata so fresh copies are fetched when needed.',
   },
   {
     key: "tracker",
     kind: "tracker",
     icon: "deployed_code",
-    title: "Clear CrossWatch tracker",
-    tag: "tracker",
-    desc: 'Cleans up local tracker files (<code>watchlist.json</code>, <code>history.json</code>, <code>ratings.json</code>) and optional snapshots.',
+    title: "Reset local tracker",
+    tag: "local library",
+    desc: 'Clears local Watchlist, History and Ratings tracker data. Provider accounts stay untouched.',
     extra: `
       <div class="action-options">
         <label><input type="checkbox" id="cxm-cw-state" checked><span>Tracker state files</span></label>
@@ -75,32 +76,41 @@ const OPS = [
     key: "activity",
     kind: "activity",
     icon: "fact_check",
-    title: "Clear activity log",
-    tag: "local only",
-    desc: "Clears CrossWatch's local Recent Activity list. Provider watch history is not changed.",
+    title: "Clear all activity",
+    tag: "local activity",
+    desc: "Clears the complete local activity list without changing provider watch history.",
+  },
+  {
+    key: "scrobbles",
+    kind: "scrobbles",
+    icon: "podcasts",
+    title: "Clear Recent Scrobbles",
+    tag: "scrobbles only",
+    desc: "Clears only the local Recent Scrobble list while keeping other Recent Activity entries.",
   },
   {
     key: "stats",
     kind: "stats",
     icon: "monitoring",
-    title: "Reset statistics",
-    tag: "stats + reports",
-    desc: "Drops statistics, reports and insights caches, then reloads stats from a clean state. Does not touch provider data.",
+    title: "Rebuild statistics",
+    tag: "stats & reports",
+    desc: "Rebuilds Statistics, Reports and Insights from clean local data.",
   },
   {
     key: "playing",
     kind: "playing",
     icon: "live_tv",
-    title: "Reset currently playing",
-    desc: 'Clears <code>currently_watching.json</code> so stuck "currently playing" entries disappear.',
+    title: "Clear currently playing",
+    tag: "playback",
+    desc: 'Removes stuck items from the local Currently Playing list.',
   },
   {
     key: "defaults",
     kind: "defaults",
     icon: "release_alert",
-    title: "Reset all to default",
-    tag: "DANGER",
-    desc: "Resets CrossWatch to a clean install state by deleting local state, caches, tracker files, reports and TLS material, and backing up <code>config.json</code>. Snapshots in <code>/config/snapshots</code> are kept.",
+    title: "Factory reset",
+    tag: "danger zone",
+    desc: "Returns CrossWatch to a clean install and backs up config.json. Snapshots are kept.",
   },
 ];
 const renderActionRow = ({ key, icon, title, tag, desc, extra = "" }) => `
@@ -131,13 +141,18 @@ function injectCSS() {
     position: relative;
     display: flex;
     flex-direction: column;
-    height: 100%;
+    height: auto;
+    max-height: min(80vh, calc(100vh - 40px));
     background:
       radial-gradient(96% 125% at 0% 0%, rgba(72,52,146,.18), transparent 36%),
       linear-gradient(180deg, rgba(5,7,14,.99), rgba(3,5,11,.99));
     border: 1px solid rgba(255,255,255,.06);
     border-radius: 22px;
     box-shadow: inset 0 1px 0 rgba(255,255,255,.025), 0 28px 60px rgba(0,0,0,.32);
+  }
+  .cx-modal-shell.cw-maint-shell {
+    height: auto !important;
+    max-height: min(80vh, calc(100vh - 40px)) !important;
   }
 
   .cw-maint .cx-head {
@@ -222,41 +237,84 @@ function injectCSS() {
   .cw-maint .cx-body {
     flex: 1;
     min-height: 0;
-    padding: 12px 14px 14px;
+    padding: 10px 12px 12px;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
+    overflow: auto;
   }
 
   .cw-maint .summary-card {
-    background: radial-gradient(120% 140% at 0% 0%,rgba(84,58,164,.10),transparent 38%),
-                linear-gradient(180deg,rgba(10,13,24,.97),rgba(6,9,18,.965));
-    border-radius: 18px;
+    background: linear-gradient(135deg,rgba(81,91,190,.12),rgba(21,27,52,.45));
+    border-radius: 16px;
     border: 1px solid rgba(255,255,255,.07);
-    padding: 10px 12px;
+    padding: 9px 11px;
     display: grid;
-    grid-template-columns: minmax(0,1.3fr) minmax(0,1fr);
-    grid-gap: 10px;
+    grid-template-columns: minmax(240px,1fr) auto auto;
+    align-items: center;
+    gap: 12px;
     font-size: 12px;
-    box-shadow: 0 18px 34px rgba(0,0,0,.24), inset 0 1px 0 rgba(255,255,255,.025);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.025);
   }
-  @media (max-width: 900px) {
+  @media (max-width: 980px) {
     .cw-maint .summary-card {
-      grid-template-columns: minmax(0,1fr);
+      grid-template-columns: minmax(0,1fr) auto;
     }
+    .cw-maint .storage-details { grid-column: 1 / -1; }
   }
-  .cw-maint .summary-label {
-    opacity: .78;
-    margin-bottom: 5px;
+  .cw-maint .summary-safe {
+    display: grid;
+    grid-template-columns: 32px minmax(0,1fr);
+    align-items: center;
+    gap: 9px;
+  }
+  .cw-maint .summary-safe-icon {
+    width: 32px;
+    height: 32px;
+    display: grid;
+    place-items: center;
+    border-radius: 11px;
+    border: 1px solid rgba(124,242,176,.16);
+    background: rgba(55,178,126,.09);
+    color: #bdf0d0;
+  }
+  .cw-maint .summary-safe-icon .material-symbols-rounded { font-size: 19px; }
+  .cw-maint .summary-safe strong { display:block;color:#f5f7ff;font-size:12px; }
+  .cw-maint .summary-safe span { display:block;margin-top:2px;color:rgba(205,214,231,.7);font-size:11px; }
+  .cw-maint .storage-details { position: relative; }
+  .cw-maint .storage-details summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 6px 9px;
+    border-radius: 999px;
+    border: 1px solid rgba(255,255,255,.08);
+    background: rgba(255,255,255,.03);
+    color: rgba(224,230,242,.8);
     font-size: 10px;
     font-weight: 800;
-    letter-spacing: .14em;
+    letter-spacing: .06em;
     text-transform: uppercase;
+    white-space: nowrap;
   }
+  .cw-maint .storage-details summary::-webkit-details-marker { display:none; }
+  .cw-maint .storage-details[open] .summary-paths {
+    display:block;
+    position:absolute;
+    z-index:8;
+    right:0;
+    top:calc(100% + 6px);
+    min-width:310px;
+    padding:9px 10px;
+    border-radius:13px;
+    border:1px solid rgba(255,255,255,.1);
+    background:#111521;
+    box-shadow:0 16px 34px rgba(0,0,0,.34);
+  }
+  .cw-maint .summary-paths { display:none;line-height:1.7;color:rgba(205,214,231,.76); }
   .cw-maint .summary-paths code {
-    font-size: 11px;
+    font-size: 10px;
     background: rgba(255,255,255,.035);
-    padding: 2px 6px;
+    padding: 1px 5px;
     border-radius: 999px;
   }
   .cw-maint .summary-badges {
@@ -278,45 +336,46 @@ function injectCSS() {
 
   .cw-maint .actions {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 8px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 7px;
     margin-top: 0;
   }
-  @media (max-width: 980px) {
+  @media (max-width: 1100px) {
     .cw-maint .actions {
-      grid-template-columns: 1fr;
+      grid-template-columns: repeat(2,minmax(0,1fr));
     }
   }
+  @media (max-width: 720px) { .cw-maint .actions { grid-template-columns:1fr; } }
 
   .cw-maint .action-row {
     background: radial-gradient(120% 145% at 0% 0%,rgba(76,54,150,.08),transparent 38%),linear-gradient(180deg,rgba(9,12,22,.97),rgba(5,8,17,.965));
-    border-radius: 18px;
+    border-radius: 15px;
     border: 1px solid rgba(255,255,255,.07);
-    padding: 12px 13px;
+    padding: 9px 10px;
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
-    gap: 12px;
-    box-shadow: 0 16px 30px rgba(0,0,0,.22), inset 0 1px 0 rgba(255,255,255,.02);
+    gap: 8px;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.02);
     transition: transform .14s ease,border-color .14s ease,box-shadow .16s ease,background .16s ease;
   }
   .cw-maint .action-row:hover {
     transform: translateY(-1px);
     border-color: rgba(130,116,220,.16);
-    box-shadow: 0 20px 34px rgba(0,0,0,.26), inset 0 1px 0 rgba(255,255,255,.03);
+    box-shadow: 0 12px 24px rgba(0,0,0,.18), inset 0 1px 0 rgba(255,255,255,.03);
   }
   .cw-maint .action-main {
     display: grid;
-    grid-template-columns: 26px minmax(0, 1fr);
+    grid-template-columns: 28px minmax(0, 1fr);
     align-items: start;
-    gap: 10px;
+    gap: 9px;
     flex: 1;
     min-width: 0;
   }
   .cw-maint .action-icon {
     width: 28px;
     height: 28px;
-    border-radius: 10px;
+    border-radius: 9px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -345,27 +404,27 @@ function injectCSS() {
     min-width: 0;
   }
   .cw-maint .action-title {
-    font-size: 13px;
-    font-weight: 750;
+    font-size: 12px;
+    font-weight: 800;
     line-height: 1.2;
   }
   .cw-maint .action-tag {
-    padding: 2px 8px;
+    padding: 2px 6px;
     border-radius: 999px;
     border: 1px solid rgba(255,255,255,.08);
-    font-size: 10px;
+    font-size: 9px;
     text-transform: uppercase;
     letter-spacing: .09em;
     opacity: .86;
     background: rgba(255,255,255,.028);
   }
   .cw-maint .action-desc {
-    font-size: 11px;
-    line-height: 1.35;
+    font-size: 10.5px;
+    line-height: 1.3;
     color: rgba(197,206,224,.76);
   }
   .cw-maint .action-desc code {
-    font-size: 11px;
+    font-size: 10px;
     background: rgba(255,255,255,.035);
     border-radius: 999px;
     padding: 1px 6px;
@@ -373,11 +432,11 @@ function injectCSS() {
 
   .cw-maint .action-options {
     width: 100%;
-    margin-top: 6px;
-    font-size: 12px;
+    margin-top: 4px;
+    font-size: 10px;
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 4px 16px;
+    gap: 3px 10px;
     align-items: start;
   }
   .cw-maint .action-options label {
@@ -407,8 +466,8 @@ function injectCSS() {
     align-self: start;
     border-radius: 999px;
     border: 1px solid rgba(255,255,255,.09);
-    padding: 7px 14px;
-    font-size: 11px;
+    padding: 6px 11px;
+    font-size: 10px;
     font-weight: 700;
     letter-spacing: .09em;
     text-transform: uppercase;
@@ -429,41 +488,62 @@ function injectCSS() {
   }
   .cw-maint .action-row[data-op="state"] .action-icon {
     border-color: rgba(255,134,145,.16);
+    background: rgba(126,121,255,.10);
   }
   .cw-maint .action-row[data-op="cache"] .action-icon {
     border-color: rgba(164,138,255,.18);
+    background: rgba(164,138,255,.10);
   }
   .cw-maint .action-row[data-op="meta"] .action-icon {
     border-color: rgba(255,201,110,.18);
+    background: rgba(255,201,110,.09);
   }
   .cw-maint .action-row[data-op="tracker"] .action-icon {
     border-color: rgba(115,197,255,.18);
+    background: rgba(115,197,255,.09);
   }
   .cw-maint .action-row[data-op="stats"] .action-icon {
     border-color: rgba(120,220,176,.18);
+    background: rgba(120,220,176,.09);
   }
   .cw-maint .action-row[data-op="playing"] .action-icon {
     border-color: rgba(190,196,255,.16);
+    background: rgba(190,196,255,.08);
   }
   .cw-maint .action-row[data-op="activity"] .action-icon {
     border-color: rgba(124,242,176,.16);
+    background: rgba(124,242,176,.08);
+  }
+  .cw-maint .action-row[data-op="scrobbles"] .action-icon {
+    border-color: rgba(104,191,255,.18);
+    background: rgba(104,191,255,.09);
   }
 
   .cw-maint .action-row[data-op="defaults"] .action-icon {
     border-color: rgba(255,106,106,.18);
+    background: rgba(255,106,106,.10);
+  }
+  .cw-maint .action-row[data-op="defaults"] {
+    border-color: rgba(255,106,106,.14);
+    background: linear-gradient(145deg,rgba(75,27,40,.18),rgba(17,12,20,.86));
   }
 
   .cw-maint .status {
     display: flex;
     align-items: center;
     gap: 10px;
-    min-height: 42px;
-    margin-top: 2px;
-    padding: 9px 12px;
-    border-radius: 16px;
+    min-height: 38px;
+    margin-top: 0;
+    padding: 7px 10px;
+    border-radius: 14px;
     border: 1px solid rgba(255,255,255,.07);
     background: radial-gradient(120% 140% at 0% 0%,rgba(74,54,150,.06),transparent 38%),linear-gradient(180deg,rgba(9,12,22,.97),rgba(6,8,16,.96));
     box-shadow: inset 0 1px 0 rgba(255,255,255,.02);
+    position: sticky;
+    bottom: 0;
+    z-index: 5;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
   }
   .cw-maint .status::before {
     content: "STATUS";
@@ -513,6 +593,28 @@ function injectCSS() {
     box-shadow: inset 0 1px 0 rgba(255,255,255,.02),0 12px 24px rgba(0,0,0,.22);
     margin-right: 8px; /* small gap before CLOSE */
   }
+  #cw-clear-provider-cache {
+    border-radius: 999px;
+    border: 1px solid rgba(139,149,255,.2);
+    padding: 7px 14px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: .09em;
+    text-transform: uppercase;
+    cursor: pointer;
+    background: linear-gradient(180deg,rgba(35,39,78,.94),rgba(20,24,50,.92));
+    color: #fff;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.03),0 12px 24px rgba(0,0,0,.2);
+  }
+  #cw-clear-provider-cache:hover {
+    border-color: rgba(154,162,255,.3);
+    background: linear-gradient(180deg,rgba(47,52,101,.96),rgba(25,30,61,.94));
+  }
+  #cw-clear-provider-cache[disabled] {
+    opacity: .6;
+    cursor: wait;
+    box-shadow: none;
+  }
   #cw-clean-all:hover {
     border-color: rgba(255,146,160,.22);
     background: linear-gradient(180deg,rgba(72,26,39,.96),rgba(44,15,25,.94));
@@ -529,13 +631,13 @@ function injectCSS() {
   html[data-cw-theme="flat-dark"] .cw-maint .summary-card,
   html[data-cw-theme="flat-dark"] .cw-maint .summary-pill,
   html[data-cw-theme="flat-dark"] .cw-maint .action-row,
-  html[data-cw-theme="flat-dark"] .cw-maint .action-icon,
   html[data-cw-theme="flat-dark"] .cw-maint .action-desc code,
   html[data-cw-theme="flat-dark"] .cw-maint .action-options label,
   html[data-cw-theme="flat-dark"] .cw-maint .action-options input,
   html[data-cw-theme="flat-dark"] .cw-maint .run-btn,
   html[data-cw-theme="flat-dark"] .cw-maint .status,
   html[data-cw-theme="flat-dark"] .cw-maint .status::before,
+  html[data-cw-theme="flat-dark"] #cw-clear-provider-cache,
   html[data-cw-theme="flat-dark"] #cw-clean-all {
     background: #20242d !important;
     border-color: rgba(255,255,255,.14) !important;
@@ -546,6 +648,7 @@ function injectCSS() {
   html[data-cw-theme="flat-dark"] .cw-maint .close-btn:hover,
   html[data-cw-theme="flat-dark"] .cw-maint .action-row:hover,
   html[data-cw-theme="flat-dark"] .cw-maint .run-btn:hover,
+  html[data-cw-theme="flat-dark"] #cw-clear-provider-cache:hover,
   html[data-cw-theme="flat-dark"] #cw-clean-all:hover {
     background: #2b313d !important;
     border-color: rgba(255,255,255,.19) !important;
@@ -565,6 +668,15 @@ function injectCSS() {
     background: #43272e !important;
     border-color: rgba(216,102,114,.42) !important;
   }
+  html[data-cw-theme="flat-dark"] .cw-maint #cw-clear-provider-cache,
+  html[data-cw-theme="flat-dark"] #cw-clear-provider-cache {
+    background: #292f4c !important;
+    border-color: rgba(128,139,226,.4) !important;
+  }
+  html[data-cw-theme="flat-dark"] .cw-maint .action-row[data-op="defaults"] {
+    background:#35252a !important;
+    border-color:rgba(216,102,114,.3) !important;
+  }
   html[data-cw-theme="flat-dark"] .cw-maint .cx-body {
     scrollbar-color: #3a414c #151821 !important;
   }
@@ -583,7 +695,6 @@ function injectCSS() {
   html[data-cw-theme="flat-light"] .cw-maint .summary-card,
   html[data-cw-theme="flat-light"] .cw-maint .summary-pill,
   html[data-cw-theme="flat-light"] .cw-maint .action-row,
-  html[data-cw-theme="flat-light"] .cw-maint .action-icon,
   html[data-cw-theme="flat-light"] .cw-maint .action-desc code,
   html[data-cw-theme="flat-light"] .cw-maint .action-options label,
   html[data-cw-theme="flat-light"] .cw-maint .action-options input,
@@ -606,6 +717,35 @@ function injectCSS() {
     border-color: rgba(201,79,97,.36) !important;
     color: #7f1d2d !important;
   }
+  html[data-cw-theme="flat-light"] .cw-maint #cw-clear-provider-cache,
+  html[data-cw-theme="flat-light"] #cw-clear-provider-cache {
+    background: #e8ebff !important;
+    border-color: rgba(80,91,184,.3) !important;
+    color: #313b82 !important;
+  }
+  html[data-cw-theme="flat-light"] .cw-maint .summary-safe strong { color:#172033; }
+  html[data-cw-theme="flat-light"] .cw-maint .summary-safe span { color:#667085; }
+  html[data-cw-theme="flat-light"] .cw-maint .summary-safe-icon {
+    background:#e9f8f0;
+    border-color:rgba(31,143,91,.2);
+    color:#207a50;
+  }
+  html[data-cw-theme="flat-light"] .cw-maint .action-icon .material-symbols-rounded { color:#344054; }
+  html[data-cw-theme="flat-light"] .cw-maint .action-row[data-op="defaults"] {
+    background:#fff4f5 !important;
+    border-color:rgba(201,79,97,.24) !important;
+  }
+  html[data-cw-theme="flat-light"] .cw-maint .storage-details summary {
+    background:#f5f7fb;
+    border-color:rgba(21,31,48,.14);
+    color:#475467;
+  }
+  html[data-cw-theme="flat-light"] .cw-maint .storage-details[open] .summary-paths {
+    background:#fff;
+    border-color:rgba(21,31,48,.14);
+    color:#475467;
+    box-shadow:0 16px 34px rgba(15,23,42,.14);
+  }
   html[data-cw-theme="flat-light"] .cw-maint .cx-body {
     scrollbar-color: #c4ccd8 #eef2f7 !important;
   }
@@ -626,13 +766,13 @@ export default {
 
     const shell = root.closest(".cx-modal-shell");
     if (shell) {
+      shell.classList.add("cw-maint-shell");
       shell.style.setProperty("--cxModalW", "1180px");
       shell.style.setProperty("--cxModalMaxW", "1180px");
       shell.style.setProperty("--cxModalMaxH", "80vh");
     }
     const cleanAllOps = [
-      () => post(SIMPLE_OPS.state),
-      () => post(SIMPLE_OPS.cache),
+      () => post("/api/maintenance/clear-provider-sync-cache"),
       () => post(SIMPLE_OPS.metadata),
       () => post(SIMPLE_OPS.activity),
       () => post("/api/maintenance/crosswatch-tracker/clear", { clear_state: true, clear_snapshots: true }),
@@ -653,6 +793,7 @@ export default {
             </div>
           </div>
           <div class="cx-head-right">
+            <button id="cw-clear-provider-cache" type="button">Clear Provider Sync Cache</button>
             <button id="cw-clean-all" class="cw-btn danger">Clean Everything</button>
             <button type="button" class="close-btn" id="cxm-close">Close</button>
           </div>
@@ -660,22 +801,24 @@ export default {
 
         <div class="cx-body">
           <div class="summary-card">
-            <div>
-              <div class="summary-label">Paths</div>
+            <div class="summary-safe">
+              <div class="summary-safe-icon"><span class="material-symbols-rounded" aria-hidden="true">verified_user</span></div>
+              <div>
+                <strong>Local cleanup only</strong>
+                <span>These tools do not delete data from provider accounts.</span>
+              </div>
+            </div>
+            <div class="summary-badges">
+              <span class="summary-pill" id="cxm-tracker-count">Tracker: -</span>
+              <span class="summary-pill" id="cxm-cache-count">Provider cache: -</span>
+            </div>
+            <details class="storage-details">
+              <summary>Storage details</summary>
               <div class="summary-paths">
-                Tracker root:
-                <code id="cxm-tracker-root">/config/.cw_provider</code><br>
-                Provider cache:
-                <code id="cxm-cache-root">/config/.cw_state</code>
+                Tracker: <code id="cxm-tracker-root">/config/.cw_provider</code><br>
+                Provider cache: <code id="cxm-cache-root">/config/.cw_state</code>
               </div>
-            </div>
-            <div>
-              <div class="summary-label">Counts</div>
-              <div class="summary-badges">
-                <span class="summary-pill" id="cxm-tracker-count">Tracker: -</span>
-                <span class="summary-pill" id="cxm-cache-count">Provider cache: -</span>
-              </div>
-            </div>
+            </details>
           </div>
 
           <div class="actions">
@@ -788,7 +931,7 @@ export default {
           return;
         }
 
-        if (kind === "activity") {
+        if (kind === "activity" || kind === "scrobbles") {
           try { window.dispatchEvent(new CustomEvent("activity-log-cleared")); } catch {}
         }
 
@@ -813,6 +956,30 @@ export default {
       const btn = row?.querySelector(".run-btn");
       if (btn) btn.addEventListener("click", () => runOp(kind, btn));
     });
+
+    const clearProviderCacheBtn = root.querySelector("#cw-clear-provider-cache");
+    if (clearProviderCacheBtn) {
+      clearProviderCacheBtn.addEventListener("click", async () => {
+        if (!confirm("Clear provider sync baselines and runtime cache so every sync pair starts fresh? Local tracker data, metadata and recent activity will be kept.")) {
+          return;
+        }
+        clearProviderCacheBtn.disabled = true;
+        const originalText = clearProviderCacheBtn.textContent;
+        clearProviderCacheBtn.textContent = "Clearing...";
+        setStatus("Clearing provider sync cache...", "busy");
+        try {
+          const res = await post("/api/maintenance/clear-provider-sync-cache");
+          if (res?.ok === false) throw new Error("Provider sync cache could not be fully cleared");
+          await refreshSummary();
+          setStatus("Provider sync cache cleared. Sync pairs will rebuild on their next run.", "ok");
+        } catch (e) {
+          setStatus(`Error: ${e.message || String(e)}`, "err");
+        } finally {
+          clearProviderCacheBtn.disabled = false;
+          clearProviderCacheBtn.textContent = originalText;
+        }
+      });
+    }
 
     // Clean Everything button
     const cleanAllBtn = root.querySelector("#cw-clean-all");

--- a/assets/js/theme-flat-runtime.js
+++ b/assets/js/theme-flat-runtime.js
@@ -488,43 +488,45 @@ html[data-cw-theme] :is(#about-host,#setup-host,#upg-host) :is(.badge .dot){back
 html[data-cw-theme] #upg-host .notes :is(h2,h3,h4,strong,code),html[data-cw-theme] #upg-host .notes pre.notes-code code{color:var(--cw-modal-text)!important;-webkit-text-fill-color:var(--cw-modal-text)!important;}
 html[data-cw-theme] #upg-host .notes :is(p,li,.notes-list,.notes-quote){color:var(--cw-modal-muted)!important;-webkit-text-fill-color:var(--cw-modal-muted)!important;}
 html[data-cw-theme] #upg-host .notes :is(code,pre.notes-code,blockquote.notes-quote){background:var(--cw-modal-bg)!important;border-color:var(--cw-modal-border)!important;box-shadow:none!important;}
-html[data-cw-theme] #page-watchlist .wl-side .ins-card:has(#wl-metrics){isolation:isolate;overflow:hidden;background:radial-gradient(115% 95% at 7% 5%,rgba(112,102,225,.18),transparent 47%),radial-gradient(80% 70% at 105% 22%,rgba(34,197,150,.12),transparent 52%),linear-gradient(180deg,#1f2532 0%,#171c26 100%)!important;border-color:rgba(145,157,214,.24)!important;box-shadow:0 18px 38px rgba(0,0,0,.20),inset 0 1px 0 rgba(255,255,255,.05)!important;}
-html[data-cw-theme] #page-watchlist .wl-side .ins-card:has(#wl-metrics)::before{content:""!important;display:block!important;position:absolute;inset:0;z-index:0;pointer-events:none;opacity:.86;background:linear-gradient(90deg,rgba(255,255,255,.055) 0 1px,transparent 1px 100%),linear-gradient(180deg,rgba(255,255,255,.04) 0 1px,transparent 1px 100%);background-size:42px 42px;mask-image:linear-gradient(120deg,transparent 0%,#000 18%,transparent 72%);}
-html[data-cw-theme] #page-watchlist .wl-side .ins-card:has(#wl-metrics)::after{content:"";position:absolute;right:-42px;bottom:-48px;width:166px;height:166px;z-index:0;pointer-events:none;background:url("/assets/img/CROSSWATCH.svg") center/contain no-repeat;opacity:.045;transform:rotate(-13deg);filter:grayscale(1) brightness(2.2);}
-html[data-cw-theme] #page-watchlist .wl-side .ins-card:has(#wl-metrics) > *{position:relative;z-index:1;}
-html[data-cw-theme] #page-watchlist .wl-side .ins-card:has(#wl-metrics) .ins-row{border-top-color:rgba(255,255,255,.08)!important;}
-html[data-cw-theme] #page-watchlist .wl-insight{gap:12px!important;}
-html[data-cw-theme] #page-watchlist .wl-insight-score{isolation:isolate;overflow:hidden;min-height:128px!important;background:radial-gradient(circle at 50% 48%,rgba(97,102,211,.32) 0 23%,transparent 24%),conic-gradient(from 210deg,rgba(83,224,169,.86),rgba(130,138,226,.88),rgba(83,224,169,.86)),linear-gradient(180deg,#252b38,#171c26)!important;border-color:rgba(151,160,229,.28)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.08),0 14px 30px rgba(0,0,0,.18)!important;}
-html[data-cw-theme] #page-watchlist .wl-insight-score::before{content:""!important;display:block!important;position:absolute;inset:10px;z-index:0;border-radius:inherit;background:linear-gradient(180deg,#202632,#171c26)!important;pointer-events:none;}
-html[data-cw-theme] #page-watchlist .wl-insight-score::after{content:"";position:absolute;right:-24px;bottom:-28px;width:116px;height:116px;z-index:0;pointer-events:none;background:url("/assets/img/CROSSWATCH.svg") center/contain no-repeat;opacity:.08;filter:grayscale(1) brightness(2);transform:rotate(-10deg);}
-html[data-cw-theme] #page-watchlist .wl-insight-score strong{font-size:36px!important;color:#f8fbff!important;text-shadow:0 10px 24px rgba(0,0,0,.22)!important;}
-html[data-cw-theme] #page-watchlist .wl-insight-score span{color:rgba(231,237,249,.78)!important;}
-html[data-cw-theme] #page-watchlist .wl-insight-stat{overflow:hidden;background:linear-gradient(180deg,rgba(45,52,67,.92),rgba(30,36,48,.94))!important;border-color:rgba(255,255,255,.12)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.05)!important;}
-html[data-cw-theme] #page-watchlist .wl-insight-stat::before{content:"";position:absolute;left:12px;right:12px;top:0;height:3px;border-radius:0 0 999px 999px;background:linear-gradient(90deg,rgba(91,227,170,.15),rgba(137,147,235,.88),rgba(91,227,170,.15));opacity:.74;}
-html[data-cw-theme] #page-watchlist .wl-insight-stat .k{color:rgba(220,228,243,.70)!important;}
-html[data-cw-theme] #page-watchlist .wl-insight-stat .v{color:#f8fbff!important;}
-html[data-cw-theme] #page-watchlist .wl-provider-card{--pulse-rgb:137,147,235;--pulse-logo:url("/assets/img/CROSSWATCH.svg");isolation:isolate;overflow:hidden;background:radial-gradient(105% 130% at 100% 0%,rgba(var(--pulse-rgb),.22),transparent 48%),linear-gradient(180deg,#252b38 0%,#1b212c 100%)!important;border-color:rgba(var(--pulse-rgb),.26)!important;box-shadow:0 12px 24px rgba(0,0,0,.15),inset 0 1px 0 rgba(255,255,255,.06)!important;}
-html[data-cw-theme] #page-watchlist .wl-provider-card::before{content:""!important;display:block!important;position:absolute;inset:-20px -34px -24px auto;width:136px;z-index:0;pointer-events:none;background:var(--pulse-logo) center/contain no-repeat!important;opacity:.105;transform:rotate(-9deg) scale(1.12);filter:grayscale(.1) brightness(1.6);}
-html[data-cw-theme] #page-watchlist .wl-provider-card::after{content:"";position:absolute;left:0;right:0;bottom:0;z-index:0;height:3px;pointer-events:none;background:linear-gradient(90deg,rgba(var(--pulse-rgb),0),rgba(var(--pulse-rgb),.92),rgba(var(--pulse-rgb),0));opacity:.85;}
-html[data-cw-theme] #page-watchlist .wl-provider-card > *{position:relative;z-index:1;}
-html[data-cw-theme] #page-watchlist .wl-provider-card.is-live{border-color:rgba(var(--pulse-rgb),.38)!important;}
-html[data-cw-theme] #page-watchlist .wl-provider-card.is-idle{opacity:.88!important;filter:saturate(.72);}
-html[data-cw-theme] #page-watchlist .wl-provider-card.is-idle::before{opacity:.055!important;filter:grayscale(1) brightness(1.8);}
-html[data-cw-theme] #page-watchlist .wl-provider-brand{background:rgba(var(--pulse-rgb),.12)!important;border-color:rgba(var(--pulse-rgb),.30)!important;}
-html[data-cw-theme] #page-watchlist .wl-provider-top strong{color:#f8fbff!important;}
-html[data-cw-theme] #page-watchlist .wl-provider-name{color:rgba(221,229,244,.72)!important;}
-html[data-cw-theme] #page-watchlist .wl-provider-sub{color:rgba(234,240,250,.78)!important;}
-html[data-cw-theme] #page-watchlist .wl-provider-card.provider-crosswatch{--pulse-rgb:139,111,255;--pulse-logo:url("/assets/img/CROSSWATCH.svg");}
-html[data-cw-theme] #page-watchlist .wl-provider-card.provider-plex{--pulse-rgb:235,176,43;--pulse-logo:url("/assets/img/PLEX.svg");}
-html[data-cw-theme] #page-watchlist .wl-provider-card.provider-simkl{--pulse-rgb:220,225,226;--pulse-logo:url("/assets/img/SIMKL.svg");}
-html[data-cw-theme] #page-watchlist .wl-provider-card.provider-trakt{--pulse-rgb:210,58,182;--pulse-logo:url("/assets/img/TRAKT.svg");}
-html[data-cw-theme] #page-watchlist .wl-provider-card.provider-mdblist{--pulse-rgb:72,144,220;--pulse-logo:url("/assets/img/MDBLIST.svg");}
-html[data-cw-theme] #page-watchlist .wl-provider-card.provider-publicmetadb{--pulse-rgb:208,214,216;--pulse-logo:url("/assets/img/PUBLICMETADB.svg");}
-html[data-cw-theme] #page-watchlist .wl-provider-card.provider-tmdb{--pulse-rgb:1,180,228;--pulse-logo:url("/assets/img/TMDB.svg");}
-html[data-cw-theme] #page-watchlist .wl-provider-card.provider-anilist{--pulse-rgb:2,169,255;--pulse-logo:url("/assets/img/ANILIST.svg");}
-html[data-cw-theme] #page-watchlist .wl-provider-card.provider-jellyfin{--pulse-rgb:164,99,255;--pulse-logo:url("/assets/img/JELLYFIN.svg");}
-html[data-cw-theme] #page-watchlist .wl-provider-card.provider-emby{--pulse-rgb:82,150,220;--pulse-logo:url("/assets/img/EMBY.svg");}
-html[data-cw-theme] #page-watchlist .wl-provider-card.provider-tautulli{--pulse-rgb:251,137,37;--pulse-logo:url("/assets/img/TAUTULLI.svg");}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-side .ins-card:has(#wl-metrics){isolation:isolate;overflow:hidden;background:radial-gradient(115% 95% at 7% 5%,rgba(112,102,225,.18),transparent 47%),radial-gradient(80% 70% at 105% 22%,rgba(34,197,150,.12),transparent 52%),linear-gradient(180deg,#1f2532 0%,#171c26 100%)!important;border-color:rgba(145,157,214,.24)!important;box-shadow:0 18px 38px rgba(0,0,0,.20),inset 0 1px 0 rgba(255,255,255,.05)!important;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-side .ins-card:has(#wl-metrics)::before{content:""!important;display:block!important;position:absolute;inset:0;z-index:0;pointer-events:none;opacity:.86;background:linear-gradient(90deg,rgba(255,255,255,.055) 0 1px,transparent 1px 100%),linear-gradient(180deg,rgba(255,255,255,.04) 0 1px,transparent 1px 100%);background-size:42px 42px;mask-image:linear-gradient(120deg,transparent 0%,#000 18%,transparent 72%);}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-side .ins-card:has(#wl-metrics)::after{content:"";position:absolute;right:-42px;bottom:-48px;width:166px;height:166px;z-index:0;pointer-events:none;background:url("/assets/img/CROSSWATCH.svg") center/contain no-repeat;opacity:.045;transform:rotate(-13deg);filter:grayscale(1) brightness(2.2);}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-side .ins-card:has(#wl-metrics) > *{position:relative;z-index:1;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-side .ins-card:has(#wl-metrics) .ins-row{border-top-color:rgba(255,255,255,.08)!important;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-insight{gap:12px!important;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-insight-score{isolation:isolate;overflow:hidden;min-height:128px!important;background:radial-gradient(circle at 50% 48%,rgba(97,102,211,.32) 0 23%,transparent 24%),conic-gradient(from 210deg,rgba(83,224,169,.86),rgba(130,138,226,.88),rgba(83,224,169,.86)),linear-gradient(180deg,#252b38,#171c26)!important;border-color:rgba(151,160,229,.28)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.08),0 14px 30px rgba(0,0,0,.18)!important;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-insight-score::before{content:""!important;display:block!important;position:absolute;inset:10px;z-index:0;border-radius:inherit;background:linear-gradient(180deg,#202632,#171c26)!important;pointer-events:none;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-insight-score::after{content:"";position:absolute;right:-24px;bottom:-28px;width:116px;height:116px;z-index:0;pointer-events:none;background:url("/assets/img/CROSSWATCH.svg") center/contain no-repeat;opacity:.08;filter:grayscale(1) brightness(2);transform:rotate(-10deg);}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-insight-score strong{font-size:36px!important;color:#f8fbff!important;text-shadow:0 10px 24px rgba(0,0,0,.22)!important;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-insight-score span{color:rgba(231,237,249,.78)!important;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-insight-stat{overflow:hidden;background:linear-gradient(180deg,rgba(45,52,67,.92),rgba(30,36,48,.94))!important;border-color:rgba(255,255,255,.12)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.05)!important;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-insight-stat::before{content:"";position:absolute;left:12px;right:12px;top:0;height:3px;border-radius:0 0 999px 999px;background:linear-gradient(90deg,rgba(91,227,170,.15),rgba(137,147,235,.88),rgba(91,227,170,.15));opacity:.74;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-insight-stat .k{color:rgba(220,228,243,.70)!important;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-insight-stat .v{color:#f8fbff!important;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card.is-idle{opacity:.88!important;filter:saturate(.72);}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card.is-idle::before{opacity:.055!important;filter:grayscale(1) brightness(1.8);}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-top strong{color:#f8fbff!important;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-name{color:rgba(221,229,244,.72)!important;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-sub{color:rgba(234,240,250,.78)!important;}
+/* coverage-pulse:start */
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card{--pulse-rgb:137,147,235;--pulse-logo:url("/assets/img/CROSSWATCH.svg");isolation:isolate;overflow:hidden;background:radial-gradient(105% 130% at 100% 0%,rgba(var(--pulse-rgb),.22),transparent 48%),linear-gradient(180deg,#252b38 0%,#1b212c 100%)!important;border-color:rgba(var(--pulse-rgb),.26)!important;box-shadow:0 12px 24px rgba(0,0,0,.15),inset 0 1px 0 rgba(255,255,255,.06)!important;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card::before{content:""!important;display:block!important;position:absolute;inset:-20px -34px -24px auto;width:136px;z-index:0;pointer-events:none;background:var(--pulse-logo) center/contain no-repeat!important;opacity:.105;transform:rotate(-9deg) scale(1.12);filter:grayscale(.1) brightness(1.6);}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card::after{content:"";position:absolute;left:0;right:0;bottom:0;z-index:0;height:3px;pointer-events:none;background:linear-gradient(90deg,rgba(var(--pulse-rgb),0),rgba(var(--pulse-rgb),.92),rgba(var(--pulse-rgb),0));opacity:.85;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card > *{position:relative;z-index:1;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card.is-live{border-color:rgba(var(--pulse-rgb),.38)!important;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-brand{background:rgba(var(--pulse-rgb),.12)!important;border-color:rgba(var(--pulse-rgb),.30)!important;}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card.provider-crosswatch{--pulse-rgb:139,111,255;--pulse-logo:url("/assets/img/CROSSWATCH.svg");}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card.provider-plex{--pulse-rgb:235,176,43;--pulse-logo:url("/assets/img/PLEX.svg");}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card.provider-simkl{--pulse-rgb:220,225,226;--pulse-logo:url("/assets/img/SIMKL.svg");}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card.provider-trakt{--pulse-rgb:210,58,182;--pulse-logo:url("/assets/img/TRAKT.svg");}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card.provider-mdblist{--pulse-rgb:72,144,220;--pulse-logo:url("/assets/img/MDBLIST.svg");}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card.provider-publicmetadb{--pulse-rgb:208,214,216;--pulse-logo:url("/assets/img/PUBLICMETADB.svg");}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card.provider-tmdb{--pulse-rgb:1,180,228;--pulse-logo:url("/assets/img/TMDB.svg");}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card.provider-anilist{--pulse-rgb:2,169,255;--pulse-logo:url("/assets/img/ANILIST.svg");}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card.provider-jellyfin{--pulse-rgb:164,99,255;--pulse-logo:url("/assets/img/JELLYFIN.svg");}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card.provider-emby{--pulse-rgb:82,150,220;--pulse-logo:url("/assets/img/EMBY.svg");}
+html:is([data-cw-theme],.cw-theme-original) #page-watchlist .wl-provider-card.provider-tautulli{--pulse-rgb:251,137,37;--pulse-logo:url("/assets/img/TAUTULLI.svg");}
+/* coverage-pulse:end */
 html[data-cw-theme="flat-light"] #page-watchlist .wl-side .ins-card:has(#wl-metrics){background:radial-gradient(115% 95% at 7% 4%,rgba(91,112,217,.18),transparent 46%),radial-gradient(84% 76% at 105% 20%,rgba(23,169,124,.14),transparent 52%),linear-gradient(180deg,#ffffff 0%,#eef4fb 100%)!important;border-color:rgba(84,99,170,.24)!important;box-shadow:0 18px 34px rgba(18,29,56,.10),inset 0 1px 0 rgba(255,255,255,.82)!important;}
 html[data-cw-theme="flat-light"] #page-watchlist .wl-side .ins-card:has(#wl-metrics)::before{background:linear-gradient(90deg,rgba(37,51,95,.06) 0 1px,transparent 1px 100%),linear-gradient(180deg,rgba(37,51,95,.045) 0 1px,transparent 1px 100%)!important;opacity:.72!important;}
 html[data-cw-theme="flat-light"] #page-watchlist .wl-side .ins-card:has(#wl-metrics)::after{opacity:.055!important;filter:grayscale(1) brightness(.75)!important;}
@@ -809,6 +811,15 @@ html[data-cw-theme="flat-light"] :is(#card-scrobbler,#sec-scrobbler) #sc-status-
 `; 
 
   const STORAGE_KEY = "cw.ui.theme";
+  const ORIGINAL_COVERAGE_STYLE_ID = "cw-original-coverage-pulse";
+  const COVERAGE_START = "/* coverage-pulse:start */";
+  const COVERAGE_END = "/* coverage-pulse:end */";
+  const ORIGINAL_PROVIDER_TONE_CSS = `
+html.cw-theme-original #page-watchlist .wl-provider-card{background:radial-gradient(105% 130% at 100% 0%,rgba(var(--pulse-rgb),.12),transparent 50%),linear-gradient(180deg,#12151d 0%,#07090e 100%)!important;box-shadow:0 10px 22px rgba(0,0,0,.24),inset 0 1px 0 rgba(255,255,255,.04)!important;}
+html.cw-theme-original #page-watchlist .wl-provider-card::before{opacity:.075;filter:grayscale(.15) brightness(1.3);}
+html.cw-theme-original #page-watchlist .wl-provider-card::after{opacity:.68;}
+html.cw-theme-original #page-watchlist .wl-provider-brand{background:rgba(var(--pulse-rgb),.09)!important;border-color:rgba(var(--pulse-rgb),.26)!important;}
+`;
 
   function normalizeTheme(value) {
     const raw = String(value || "").trim().toLowerCase();
@@ -837,6 +848,26 @@ html[data-cw-theme="flat-light"] :is(#card-scrobbler,#sec-scrobbler) #sc-status-
     } catch {}
   }
 
+  function removeOriginalCoverageStyle() {
+    try {
+      document.getElementById(ORIGINAL_COVERAGE_STYLE_ID)?.remove();
+    } catch {}
+  }
+
+  function installOriginalCoverageStyle() {
+    const start = CSS.indexOf(COVERAGE_START);
+    const end = CSS.indexOf(COVERAGE_END);
+    if (start < 0 || end <= start) return;
+    const coverageCss = `${CSS.slice(start + COVERAGE_START.length, end).trim()}\n${ORIGINAL_PROVIDER_TONE_CSS.trim()}`;
+    const existing = document.getElementById(ORIGINAL_COVERAGE_STYLE_ID);
+    if (existing?.textContent === coverageCss) return;
+    existing?.remove();
+    const style = document.createElement("style");
+    style.id = ORIGINAL_COVERAGE_STYLE_ID;
+    style.textContent = coverageCss;
+    document.head.appendChild(style);
+  }
+
   function isOriginalTheme() {
     const root = document.documentElement;
     return root.classList.contains("cw-theme-original")
@@ -857,7 +888,9 @@ html[data-cw-theme="flat-light"] :is(#card-scrobbler,#sec-scrobbler) #sc-status-
     setThemeColor(theme);
     if (theme === "original") {
       removeRuntimeStyle();
+      installOriginalCoverageStyle();
     } else {
+      removeOriginalCoverageStyle();
       install();
     }
     if (opts.persist) {
@@ -905,8 +938,10 @@ html[data-cw-theme="flat-light"] :is(#card-scrobbler,#sec-scrobbler) #sc-status-
   function install() {
     if (isOriginalTheme()) {
       removeRuntimeStyle();
+      installOriginalCoverageStyle();
       return;
     }
+    removeOriginalCoverageStyle();
     const existing = document.getElementById("cw-flat-runtime-theme");
     if (existing) existing.remove();
     const style = document.createElement("style");
@@ -967,7 +1002,9 @@ html[data-cw-theme="flat-light"] :is(#card-scrobbler,#sec-scrobbler) #sc-status-
       new MutationObserver((records) => {
         const addedStyle = records.some((record) =>
           Array.from(record.addedNodes).some((node) =>
-            node?.nodeName === "STYLE" && node.id !== "cw-flat-runtime-theme"
+            node?.nodeName === "STYLE"
+              && node.id !== "cw-flat-runtime-theme"
+              && node.id !== ORIGINAL_COVERAGE_STYLE_ID
           )
         );
         const addedPairModal = records.some((record) =>

--- a/services/activity.py
+++ b/services/activity.py
@@ -347,6 +347,7 @@ def list_events(
     offset: int = 0,
     media_type: str = "all",
     status: str = "all",
+    kind: str = "all",
     query: str = "",
     since: int | None = None,
     group_routes: bool = True,
@@ -356,6 +357,7 @@ def list_events(
 
     mt = str(media_type or "all").strip().lower()
     st = str(status or "all").strip().lower()
+    kd = str(kind or "all").strip().lower()
     q = str(query or "").strip().lower()
     since_ts = _as_int(since)
 
@@ -371,6 +373,8 @@ def list_events(
             got = str(item.get("status") or "").lower()
             if got != want:
                 return False
+        if kd != "all" and str(item.get("kind") or "").strip().lower() != kd:
+            return False
         if q:
             hay = " ".join(
                 str(item.get(k) or "")
@@ -400,15 +404,38 @@ def list_events(
     }
 
 
-def clear_events() -> dict[str, Any]:
+def clear_events(*, kind: str | None = None) -> dict[str, Any]:
     path = activity_path()
     existed = path.exists()
+    wanted = str(kind or "").strip().lower()
     with _LOCK:
         try:
-            path.unlink(missing_ok=True)
-            return {"ok": True, "path": str(path), "existed": bool(existed), "removed": 1 if existed else 0}
+            if not wanted:
+                path.unlink(missing_ok=True)
+                return {"ok": True, "path": str(path), "existed": bool(existed), "removed": 1 if existed else 0}
+
+            payload = _read_payload()
+            items = [x for x in list(payload.get("items") or []) if isinstance(x, dict)]
+            kept = [x for x in items if str(x.get("kind") or "").strip().lower() != wanted]
+            removed = len(items) - len(kept)
+            if kept:
+                _write_payload({"v": LOG_VERSION, "items": kept})
+            else:
+                path.unlink(missing_ok=True)
+            return {
+                "ok": True,
+                "path": str(path),
+                "existed": bool(existed),
+                "kind": wanted,
+                "removed": removed,
+                "remaining": len(kept),
+            }
         except Exception as e:
             return {"ok": False, "error": "clear_activity_failed", "path": str(path), "existed": bool(existed), "detail": str(e)}
+
+
+def clear_scrobble_events() -> dict[str, Any]:
+    return clear_events(kind="scrobble")
 
 
 def record_history_sync_items(

--- a/services/dashboard_widgets.py
+++ b/services/dashboard_widgets.py
@@ -343,8 +343,8 @@ def _history_key(raw_key: str, item: Mapping[str, Any]) -> str:
         [
             _media_type(item),
             base,
-            str(_season_number(item) or ""),
-            str(_episode_number(item) or ""),
+            "" if _season_number(item) is None else str(_season_number(item)),
+            "" if _episode_number(item) is None else str(_episode_number(item)),
             str(_history_sort_epoch(item) or _history_key_epoch(raw_key)),
         ]
     )
@@ -862,7 +862,7 @@ def recent_history_widget(
 
 def recent_scrobble_widget(*, limit: int = 8) -> dict[str, Any]:
     cap = max(1, min(int(limit or 8), 24))
-    payload = list_events(limit=max(cap, 12), offset=0, status="ok", group_routes=True)
+    payload = list_events(limit=max(cap, 12), offset=0, status="ok", kind="scrobble", group_routes=True)
     rows = [_activity_row(item) for item in payload.get("items") or [] if isinstance(item, Mapping)]
     selected = _resolve_missing_art_rows(rows[:cap], size="w300", episode_still=True)
     return {"ok": True, "items": selected, "total": len(rows)}

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -659,7 +659,10 @@ html[data-cw-theme=flat-light] #page-settings .cw-maint-action.restart .cw-maint
           <span class="material-symbols-rounded" aria-hidden="true">sensors</span>
           <h3>Recent Scrobble</h3>
         </div>
-        <button id="recent-scrobble-refresh" class="cw-dash-ghost material-symbols-rounded" type="button" title="Refresh recent scrobble" aria-label="Refresh recent scrobble">refresh</button>
+        <div class="cw-dash-head-actions">
+          <span id="recent-scrobble-count-chip" class="cw-widget-count-chip hidden" aria-live="polite"></span>
+          <button id="recent-scrobble-refresh" class="cw-dash-ghost material-symbols-rounded" type="button" title="Refresh recent scrobble" aria-label="Refresh recent scrobble">refresh</button>
+        </div>
       </div>
       <div id="recent-scrobble-list" class="cw-history-widget-list cw-widget-scrollbar" aria-live="polite"></div>
     </article>


### PR DESCRIPTION
# Pull request

## Change

- Added compact numeric counters to Watchlist, Recent History, Latest Ratings, and Recent Scrobble.
- Changed probes for all themes
- Made the dashboard widgets size independently so empty cards no longer stretch with populated widgets.
- Kept Recent Scrobble pagination consistent with the other widgets.
- Improved Watchlist widget loading by rendering cached data immediately.
- Fixed TMDb artwork loading for season-zero special episodes.
- Added targeted maintenance actions for resetting provider sync caches and clearing recent scrobbles.
- Redesigned Maintenance with compact cards, clearer descriptions, content-based modal sizing, and a visible status bar.

## Why

Dashboard widgets could create large empty panels when another widget contained more entries, and the Watchlist preview loaded noticeably later than the other widgets.

Maintenance also needed a more focused cleanup options and a clearer interface that scales to its content.
Also added another option clear provider cache.

## Testing

- Ran dashboard, special-episode, activity, and maintenance tests successfully.
- pytest test scripts 

## Issue

NA