### PR TITLE
Change: redesign and guard live output

### DIFF
--- a/assets/crosswatch.css
+++ b/assets/crosswatch.css
@@ -843,6 +843,61 @@ to{left:6px}
 #details .det-tools .ghost{border-radius:12px;background:rgba(255,255,255,.035)}
 #details .det-tools .ghost:hover{background:rgba(255,255,255,.07)}
 #details .det-tabs{padding:3px;background:rgba(255,255,255,.03)}
+#ops-card #details{--det-console-bg:#0d1119;--det-console-surface:#111722;--det-console-soft:rgba(255,255,255,.045);--det-console-border:rgba(255,255,255,.09);--det-console-border-strong:rgba(255,255,255,.15);--det-console-text:#e8edf7;--det-console-muted:#7f899b;--det-console-live:#39c98a;--det-console-stale:#e8a34d;margin-top:16px;padding:0!important;overflow:hidden;background:var(--det-console-bg)!important;border-color:var(--det-console-border)!important;box-shadow:0 18px 36px rgba(0,0,0,.24),inset 0 1px 0 rgba(255,255,255,.025)!important}
+#details .det-left{background:transparent}
+#details .det-head{display:flex;align-items:center;gap:12px;min-height:66px;margin:0!important;padding:11px 13px!important;border-bottom:1px solid var(--det-console-border)!important;flex-wrap:nowrap}
+#details .det-console-mark{display:inline-flex;align-items:center;justify-content:center;flex:0 0 34px;width:34px;height:34px;color:var(--det-console-muted)}
+#details .det-console-mark>.material-symbols-rounded{font-size:22px;font-variation-settings:"FILL" 0,"wght" 420,"GRAD" 0,"opsz" 24}
+#details .det-title{position:absolute!important;width:1px!important;height:1px!important;margin:-1px!important;padding:0!important;overflow:hidden!important;clip:rect(0,0,0,0)!important;white-space:nowrap!important;border:0!important}
+#details .det-tabs{display:inline-flex;align-items:center;gap:2px;padding:3px!important;border:1px solid var(--det-console-border)!important;border-radius:12px!important;background:var(--det-console-soft)!important}
+#details .det-tab{position:relative;min-height:32px;padding:0 12px!important;border-radius:9px!important;color:var(--det-console-muted)!important;opacity:1!important;font-size:12px;font-weight:800;transition:background .15s ease,color .15s ease,box-shadow .15s ease}
+#details .det-tab.active{background:var(--det-console-soft)!important;color:var(--det-console-text)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.04)}
+#details .det-tab.active::before{content:"";position:absolute;left:10px;right:10px;bottom:-4px;height:2px;border-radius:999px;background:var(--accent,#7c5cff);opacity:.78}
+#details .det-tab.connected::after{width:7px;height:7px;margin-left:7px;background:var(--det-console-live);box-shadow:0 0 8px color-mix(in srgb,var(--det-console-live) 50%,transparent)}
+#details .det-tab.stale::after{background:var(--det-console-stale)}
+#details .det-tools{margin-left:auto;display:flex;align-items:center;gap:7px}
+#details .det-tools .ghost{display:inline-flex;align-items:center;justify-content:center;gap:7px;height:36px;min-height:36px;padding:0 11px!important;border:1px solid var(--det-console-border)!important;border-radius:10px!important;background:var(--det-console-soft)!important;color:var(--det-console-muted)!important;opacity:1!important;transition:background .15s ease,border-color .15s ease,color .15s ease}
+#details .det-tools .ghost:hover,#details .det-tools .ghost:focus-visible{background:color-mix(in srgb,var(--det-console-soft) 65%,var(--det-console-text) 6%)!important;border-color:var(--det-console-border-strong)!important;color:var(--det-console-text)!important;box-shadow:none;outline:none}
+#details .det-tools .det-tool-icon{width:36px;padding:0!important}
+#details .det-tools .material-symbols-rounded{font-size:18px;line-height:1;font-variation-settings:"FILL" 0,"wght" 420,"GRAD" 0,"opsz" 20}
+#details .det-tools .det-follow.is-on .det-follow-icon,#details .det-tools .is-copied{color:var(--det-console-live)!important}
+#details .det-follow-caret{font-size:15px!important;opacity:.7}
+#details .det-panels{padding:12px;background:var(--det-console-bg)}
+#details .det-panel{min-width:0}
+#details :is(#det-log,#det-watch-log,#det-debug-log){box-sizing:border-box;width:100%;height:clamp(280px,38vh,500px)!important;min-height:280px!important;max-height:500px!important;margin:0;padding:0 10px!important;border:1px solid var(--det-console-border)!important;border-radius:12px!important;background:var(--det-console-surface)!important;color:var(--det-console-text)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.018)!important;font:500 12px/1.45 ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace!important;overflow:auto;overflow-x:hidden}
+#details .det-structured-line{--det-provider-rgb:126,139,159;--det-provider-color:#aab4c4;display:grid!important;grid-template-columns:minmax(48px,max-content) 52px minmax(0,1fr) auto;align-items:start;gap:10px;margin:0!important;padding:7px 8px!important;border-bottom:1px solid var(--det-console-border)!important;color:var(--det-console-text);background:transparent;animation:none!important}
+#details .det-structured-line[data-provider="PLEX"]{--det-provider-rgb:229,160,13;--det-provider-color:#e5b64c}
+#details .det-structured-line[data-provider="SIMKL"]{--det-provider-rgb:212,218,226;--det-provider-color:#d4dae2}
+#details .det-structured-line[data-provider="TRAKT"]{--det-provider-rgb:237,28,93;--det-provider-color:#f06b97}
+#details .det-structured-line[data-provider="MDBLIST"]{--det-provider-rgb:75,159,222;--det-provider-color:#78b9e8}
+#details .det-structured-line[data-provider="PUBLICMETADB"]{--det-provider-rgb:158,168,181;--det-provider-color:#aeb7c4}
+#details .det-structured-line[data-provider="JELLYFIN"]{--det-provider-rgb:170,92,255;--det-provider-color:#bf89ff}
+#details .det-structured-line[data-provider="EMBY"]{--det-provider-rgb:82,190,82;--det-provider-color:#79d579}
+#details .det-structured-line[data-provider="WATCH"],#details .det-structured-line[data-provider="SCROBBLE"]{--det-provider-rgb:55,201,145;--det-provider-color:#67d9ad}
+#details .det-structured-line[data-provider="SYNC"],#details .det-structured-line[data-provider="CROSSWATCH"]{--det-provider-rgb:126,112,232;--det-provider-color:#a89cf1}
+#details .det-structured-line:last-child{border-bottom:0!important}
+#details .det-structured-line .wlog-tag{display:inline-flex;align-items:center;justify-content:center;min-width:0;height:20px;padding:0 7px;border-radius:6px;border:1px solid rgba(var(--det-provider-rgb),.24);background:rgba(var(--det-provider-rgb),.12);color:var(--det-provider-color);font-size:9px;font-weight:900;letter-spacing:.035em;line-height:1;opacity:1;white-space:nowrap}
+#details .wlog-level{display:inline-flex;align-items:center;height:20px;font-size:10px;font-weight:850;letter-spacing:.025em;color:var(--det-console-muted);white-space:nowrap}
+#details .wlog-level.level-info,#details .wlog-level.level-success{color:#45c994}
+#details .wlog-level.level-debug,#details .wlog-level.level-trace{color:#72aaf4}
+#details .wlog-level.level-warn{color:#e7a84e}
+#details .wlog-level.level-error{color:#ec7180}
+#details .det-structured-line .wlog-msg{min-width:0;color:var(--det-console-text)!important;white-space:pre-wrap;overflow-wrap:anywhere;word-break:break-word;line-height:1.45}
+#details .wlog-time{padding-top:2px;color:var(--det-console-muted);font-size:10px;font-variant-numeric:tabular-nums;white-space:nowrap}
+#details :is(.cf-event:not(.det-structured-line)){margin:0!important;padding:8px 9px!important;border-bottom:1px solid var(--det-console-border)!important;border-radius:0!important}
+#details .det-console-footer{display:flex;align-items:center;gap:14px;min-height:48px;padding:0 15px;border-top:1px solid var(--det-console-border);background:var(--det-console-bg);color:var(--det-console-muted);font-size:11px;font-weight:650}
+#details .det-live-state{display:inline-flex;align-items:center;gap:7px;color:var(--det-console-muted)}
+#details .det-live-dot{width:7px;height:7px;border-radius:50%;background:var(--det-console-muted)}
+#details .det-live-state.is-live{color:var(--det-console-live)}
+#details .det-live-state.is-live .det-live-dot{background:var(--det-console-live);box-shadow:0 0 8px color-mix(in srgb,var(--det-console-live) 45%,transparent)}
+#details .det-live-state.is-stale{color:var(--det-console-stale)}
+#details .det-live-state.is-stale .det-live-dot{background:var(--det-console-stale)}
+#details .det-footer-spacer{flex:1 1 auto}
+#details .det-line-count{font-variant-numeric:tabular-nums}
+#details .det-list-icon{font-size:17px;opacity:.72}
+html[data-cw-theme=flat-dark] #ops-card #details{--det-console-bg:#171a22;--det-console-surface:#151922;--det-console-soft:#20242d;--det-console-border:rgba(255,255,255,.13);--det-console-border-strong:rgba(255,255,255,.2);--det-console-text:#e7ecf5;--det-console-muted:#9099a8}
+html[data-cw-theme=flat-light] #ops-card #details{--det-console-bg:#fff;--det-console-surface:#f8fafc;--det-console-soft:#eef2f7;--det-console-border:rgba(16,24,40,.14);--det-console-border-strong:rgba(16,24,40,.24);--det-console-text:#253044;--det-console-muted:#667085;--det-console-live:#16825b;--det-console-stale:#a15c08}
+@media(max-width:760px){#details .det-head{flex-wrap:wrap}#details .det-tools{margin-left:0}#details .det-tabs{order:2}#details .det-tools{order:3;margin-left:auto}#details .det-structured-line{grid-template-columns:minmax(44px,max-content) 48px minmax(0,1fr)}#details .wlog-time{grid-column:3;justify-self:end}#details .det-console-footer{gap:9px}.det-follow-state{display:none}}
 .ux-provider-row{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
 .ux-provider-row>*{flex:0 1 auto}
 #ux-lanes{margin-top:14px}

--- a/assets/helpers/details-log.js
+++ b/assets/helpers/details-log.js
@@ -14,7 +14,7 @@ if (typeof window.esWatch === "undefined") window.esWatch = null;
 if (typeof window._watchRetryTO === "undefined") window._watchRetryTO = null;
 if (typeof window._watchStaleIV === "undefined") window._watchStaleIV = null;
 if (typeof window._watchVisibilityHandler === "undefined") window._watchVisibilityHandler = null;
-if (typeof window._watchFlushIV === "undefined") window._watchFlushIV = null;
+if (typeof window._watchFlushRAF === "undefined") window._watchFlushRAF = null;
 if (typeof window.watchStickBottom === "undefined") window.watchStickBottom = true;
 if (typeof window.watchBuf === "undefined") window.watchBuf = [];
 if (typeof window.esDebug === "undefined") window.esDebug = null;
@@ -22,15 +22,25 @@ if (typeof window._debugRetryTO === "undefined") window._debugRetryTO = null;
 if (typeof window._debugStaleIV === "undefined") window._debugStaleIV = null;
 if (typeof window._debugVisibilityHandler === "undefined") window._debugVisibilityHandler = null;
 if (typeof window.debugStickBottom === "undefined") window.debugStickBottom = true;
+if (typeof window.debugBuf === "undefined") window.debugBuf = [];
+if (typeof window._debugFlushRAF === "undefined") window._debugFlushRAF = null;
 if (typeof window._detailsTabsWired === "undefined") window._detailsTabsWired = false;
 if (typeof window._detailsTab === "undefined") window._detailsTab = "sync";
-if (typeof window.DETAILS_MAX_LINES === "undefined") window.DETAILS_MAX_LINES = 2500;
+if (typeof window.DETAILS_MAX_LINES === "undefined") window.DETAILS_MAX_LINES = 600;
+if (typeof window.DETAILS_STREAM_TAIL === "undefined") window.DETAILS_STREAM_TAIL = 400;
+if (typeof window.DETAILS_QUEUE_MAX === "undefined") window.DETAILS_QUEUE_MAX = 1200;
+if (typeof window.DETAILS_BATCH_ROWS === "undefined") window.DETAILS_BATCH_ROWS = 80;
+if (typeof window.DETAILS_FRAME_BUDGET_MS === "undefined") window.DETAILS_FRAME_BUDGET_MS = 8;
 if (typeof window._detOpenSeq === "undefined") window._detOpenSeq = 0;
 if (typeof window._detBuf === "undefined") window._detBuf = "";
+if (typeof window.syncBuf === "undefined") window.syncBuf = [];
+if (typeof window._syncFlushRAF === "undefined") window._syncFlushRAF = null;
 if (typeof window._detSeenLines === "undefined") window._detSeenLines = [];
 if (typeof window._detReplayActive === "undefined") window._detReplayActive = false;
 if (typeof window._detReplayCursor === "undefined") window._detReplayCursor = 0;
 if (typeof window._detDidConnectOnce === "undefined") window._detDidConnectOnce = false;
+if (typeof window._detailsDropped === "undefined") window._detailsDropped = { sync: 0, watcher: 0, debug: 0 };
+if (typeof window._detailsStatusRAF === "undefined") window._detailsStatusRAF = null;
 
 function _activeDetailsLogEl() {
   if (window._detailsTab === "watcher") return document.getElementById("det-watch-log");
@@ -39,14 +49,50 @@ function _activeDetailsLogEl() {
 }
 
 function _pruneDetailsLog(el) {
-  const max = Number(window.DETAILS_MAX_LINES || 0) || 2500;
+  const max = Number(window.DETAILS_MAX_LINES || 0) || 600;
   while (el && el.childNodes && el.childNodes.length > max) el.removeChild(el.firstChild);
 }
 
 function _pruneSeenDetailLines() {
-  const max = Number(window.DETAILS_MAX_LINES || 0) || 2500;
+  const max = Number(window.DETAILS_MAX_LINES || 0) || 600;
   const lines = Array.isArray(window._detSeenLines) ? window._detSeenLines : [];
   if (lines.length > max) window._detSeenLines = lines.slice(lines.length - max);
+}
+
+function _detailsLimit(name, fallback) {
+  const value = Number(window[name] || 0);
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+function _resetDetailsDropped(tab) {
+  if (!window._detailsDropped || typeof window._detailsDropped !== "object") {
+    window._detailsDropped = { sync: 0, watcher: 0, debug: 0 };
+  }
+  window._detailsDropped[tab] = 0;
+}
+
+function _enqueueDetailsItem(queue, item, tab) {
+  queue.push(item);
+  const max = _detailsLimit("DETAILS_QUEUE_MAX", 1200);
+  if (queue.length <= max) return;
+  const dropped = queue.length - max;
+  queue.splice(0, dropped);
+  window._detailsDropped[tab] = Number(window._detailsDropped[tab] || 0) + dropped;
+  _scheduleDetailsConsoleStatus();
+}
+
+function _runDetailsBatch(queue, renderItem, afterBatch, scheduleNext) {
+  const maxRows = _detailsLimit("DETAILS_BATCH_ROWS", 80);
+  const budget = _detailsLimit("DETAILS_FRAME_BUDGET_MS", 8);
+  const started = performance.now();
+  let rendered = 0;
+  while (rendered < queue.length && rendered < maxRows && performance.now() - started < budget) {
+    renderItem(queue[rendered]);
+    rendered += 1;
+  }
+  if (rendered) queue.splice(0, rendered);
+  if (rendered) afterBatch?.(rendered);
+  if (queue.length) scheduleNext();
 }
 
 function _rememberDetailLine(line) {
@@ -135,9 +181,185 @@ function _decodeLogLine(line) {
   return host.value;
 }
 
+function _plainLogText(value) {
+  const host = document.createElement("div");
+  host.innerHTML = String(value ?? "").replace(/<br\s*\/?>/gi, "\n");
+  return String(host.textContent || host.innerText || "").replace(/\u00a0/g, " ").trim();
+}
+
+function _logTimeNow() {
+  return new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false });
+}
+
+function _parseLogParts(raw, fallbackProvider = "") {
+  let text = _plainLogText(raw);
+  const fallback = String(fallbackProvider || "").trim().toUpperCase();
+  let provider = "";
+  let level = "";
+  let time = "";
+  const known = new Set(_watchLogKnownTags());
+  const levelName = (value) => {
+    const key = String(value || "").trim().toUpperCase();
+    if (key === "WARNING") return "WARN";
+    if (key === "ERR" || key === "CRITICAL" || key === "FATAL") return "ERROR";
+    if (key === "I") return "INFO";
+    return ["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "SUCCESS"].includes(key) ? key : "";
+  };
+
+  for (let i = 0; i < 5; i++) {
+    const match = text.match(/^\s*\[([^\]]+)]\s*/);
+    if (!match) break;
+    const token = String(match[1] || "").trim();
+    const tokenLevel = levelName(token);
+    const tokenTime = token.match(/\b(\d{2}:\d{2}:\d{2})(?:[.,]\d+)?\b/);
+    if (tokenTime) time ||= tokenTime[1];
+    else if (tokenLevel) level ||= tokenLevel;
+    else if (known.has(token.toUpperCase()) || /^[A-Z][A-Z0-9_-]{1,20}$/.test(token)) provider ||= token.toUpperCase();
+    else break;
+    text = text.slice(match[0].length);
+  }
+
+  const timeMatch = text.match(/(?:^|\s)(\d{2}:\d{2}:\d{2})(?:[.,]\d+)?(?=\s|$)/);
+  if (timeMatch) {
+    time ||= timeMatch[1];
+    text = `${text.slice(0, timeMatch.index)} ${text.slice((timeMatch.index || 0) + timeMatch[0].length)}`.trim();
+  }
+
+  if (provider) {
+    const providerPrefix = new RegExp(`^\\s*(?:\\[${provider.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\]\\s*)+`, "i");
+    text = text.replace(providerPrefix, "");
+  } else {
+    const providerMatch = text.match(/^\s*([A-Z][A-Z0-9_-]{1,20})\s+(?=(?:TRACE|DEBUG|INFO|WARN(?:ING)?|ERROR|CRITICAL|SUCCESS)\b)/i);
+    if (providerMatch) {
+      provider = providerMatch[1].toUpperCase();
+      text = text.slice(providerMatch[0].length);
+    }
+  }
+
+  const levelMatch = text.match(/^\s*(TRACE|DEBUG|INFO|WARN(?:ING)?|ERROR|ERR|CRITICAL|FATAL|SUCCESS)\b[:\s-]*/i);
+  if (levelMatch) {
+    level ||= levelName(levelMatch[1]);
+    text = text.slice(levelMatch[0].length);
+  }
+
+  return {
+    provider: provider || fallback || "SYSTEM",
+    level: level || "INFO",
+    message: text.trim() || _plainLogText(raw) || "-",
+    time: time || _logTimeNow(),
+  };
+}
+
+function _structuredLogRow(raw, fallbackProvider = "") {
+  const parts = _parseLogParts(raw, fallbackProvider);
+  const row = document.createElement("div");
+  row.className = "wlog-line det-structured-line";
+  row.dataset.provider = parts.provider;
+  row.dataset.level = parts.level.toLowerCase();
+
+  const badge = document.createElement("span");
+  badge.className = "wlog-tag";
+  badge.textContent = parts.provider;
+
+  const level = document.createElement("span");
+  level.className = `wlog-level level-${parts.level.toLowerCase()}`;
+  level.textContent = parts.level;
+
+  const msg = document.createElement("span");
+  msg.className = "wlog-msg";
+  msg.textContent = parts.message;
+
+  const time = document.createElement("time");
+  time.className = "wlog-time";
+  time.textContent = parts.time;
+
+  row.append(badge, level, msg, time);
+  return row;
+}
+
+function _upgradeSyncLogRows(el) {
+  if (!el) return;
+  el.querySelectorAll(":scope > .cf-line:not([data-structured])").forEach((line) => {
+    const row = _structuredLogRow(line.textContent || "", "SYNC");
+    row.classList.add("cf-line", "cf-fade-in");
+    row.dataset.structured = "1";
+    line.replaceWith(row);
+  });
+}
+
+function _detailsStickBottom() {
+  if (window._detailsTab === "watcher") return !!window.watchStickBottom;
+  if (window._detailsTab === "debug") return !!window.debugStickBottom;
+  return !!window.detStickBottom;
+}
+
+function _updateDetailsConsoleStatus() {
+  const el = _activeDetailsLogEl();
+  const tab = document.getElementById(`det-tab-${window._detailsTab || "sync"}`);
+  const live = document.getElementById("det-live-state");
+  const liveLabel = live?.querySelector(".det-live-label");
+  const followState = document.getElementById("det-follow-state");
+  const count = document.getElementById("det-line-count");
+  const follow = document.getElementById("det-follow");
+  const following = _detailsStickBottom();
+  const stale = !!tab?.classList.contains("stale");
+  const connected = !!tab?.classList.contains("connected");
+  const rows = el?.childElementCount || 0;
+  const dropped = Number(window._detailsDropped?.[window._detailsTab || "sync"] || 0);
+
+  live?.classList.toggle("is-live", connected && !stale);
+  live?.classList.toggle("is-stale", stale);
+  if (liveLabel) liveLabel.textContent = stale ? "Reconnecting" : (connected ? "Live" : "Idle");
+  if (followState) followState.textContent = `Auto-scroll ${following ? "on" : "off"}`;
+  if (count) count.textContent = `${rows} ${rows === 1 ? "line" : "lines"}${dropped ? ` · ${dropped} omitted` : ""}`;
+  follow?.classList.toggle("is-on", following);
+  follow?.setAttribute("aria-pressed", String(following));
+}
+
+function _scheduleDetailsConsoleStatus() {
+  if (window._detailsStatusRAF) return;
+  window._detailsStatusRAF = requestAnimationFrame(() => {
+    window._detailsStatusRAF = null;
+    _updateDetailsConsoleStatus();
+  });
+}
+
+function _wireDetailsConsoleStatus() {
+  for (const id of ["det-log", "det-watch-log", "det-debug-log"]) {
+    const el = document.getElementById(id);
+    if (!el || el.__cwStatusObserver) continue;
+    el.__cwStatusObserver = new MutationObserver(_scheduleDetailsConsoleStatus);
+    el.__cwStatusObserver.observe(el, { childList: true });
+  }
+  _updateDetailsConsoleStatus();
+}
+
+function _copyableDetailsRow(row) {
+  if (!row) return "";
+  if (row.classList?.contains("det-structured-line")) {
+    const time = row.querySelector(".wlog-time")?.textContent?.trim() || "";
+    const provider = row.querySelector(".wlog-tag")?.textContent?.trim() || "SYSTEM";
+    const level = row.querySelector(".wlog-level")?.textContent?.trim() || "INFO";
+    const message = row.querySelector(".wlog-msg")?.textContent?.replace(/\s+/g, " ").trim() || "";
+    return [time, `[${provider}]`, level, message].filter(Boolean).join(" ");
+  }
+  return String(row.innerText || row.textContent || "")
+    .replace(/\s*\n\s*/g, " ")
+    .replace(/[\t ]+/g, " ")
+    .trim();
+}
+
+function _copyableDetailsLog(el) {
+  if (!el) return "";
+  const lines = Array.from(el.children, _copyableDetailsRow).filter(Boolean);
+  const dropped = Number(window._detailsDropped?.[window._detailsTab || "sync"] || 0);
+  if (dropped) lines.push(`--- ${dropped} incoming log ${dropped === 1 ? "entry was" : "entries were"} omitted from this view ---`);
+  return lines.join("\n");
+}
+
 async function _copyDetailsLog(btn) {
   const el = _activeDetailsLogEl();
-  const text = (el?.innerText || el?.textContent || "").trim();
+  const text = _copyableDetailsLog(el);
   if (!text) return;
 
   try {
@@ -155,11 +377,14 @@ async function _copyDetailsLog(btn) {
   }
 
   if (!btn) return;
-  const prev = btn.textContent;
-  btn.textContent = "Copied";
+  const icon = btn.querySelector(".material-symbols-rounded");
+  const prev = icon?.textContent || "content_copy";
+  if (icon) icon.textContent = "check";
+  btn.classList.add("is-copied");
   clearTimeout(btn._copyFlashTO);
   btn._copyFlashTO = setTimeout(() => {
-    btn.textContent = prev;
+    if (icon) icon.textContent = prev;
+    btn.classList.remove("is-copied");
   }, 1200);
 }
 
@@ -188,8 +413,20 @@ function setDetailsTab(tab) {
   tabDebug.classList.toggle("active", isDebug);
   tabDebug.setAttribute("aria-selected", String(isDebug));
 
-  if (isWatch) { try { openWatcherLog(); } catch {} }
-  if (isDebug) { try { openDebugLog(); } catch {} }
+  if (t === "sync") {
+    try { closeWatcherLog(); } catch {}
+    try { closeDebugLog(); } catch {}
+    if (_detailsVisible()) { try { openDetailsLog(); } catch {} }
+  } else if (isWatch) {
+    try { closeSyncLog(); } catch {}
+    try { closeDebugLog(); } catch {}
+    try { openWatcherLog(); } catch {}
+  } else if (isDebug) {
+    try { closeSyncLog(); } catch {}
+    try { closeWatcherLog(); } catch {}
+    try { openDebugLog(); } catch {}
+  }
+  _updateDetailsConsoleStatus();
 }
 
 function initDetailsTabs() {
@@ -199,6 +436,7 @@ function initDetailsTabs() {
   const tabDebug = document.getElementById("det-tab-debug");
   if (!tabSync || !tabWatch || !tabDebug) return;
   window._detailsTabsWired = true;
+  _wireDetailsConsoleStatus();
 
   tabSync.addEventListener("click", () => setDetailsTab("sync"));
   tabWatch.addEventListener("click", () => setDetailsTab("watcher"));
@@ -217,6 +455,10 @@ function initDetailsTabs() {
       const el = _activeDetailsLogEl();
       if (el) el.innerHTML = "";
       if (window._detailsTab === "watcher") window.watchBuf.length = 0;
+      if (window._detailsTab === "debug") window.debugBuf.length = 0;
+      if (window._detailsTab === "sync") window.syncBuf.length = 0;
+      _resetDetailsDropped(window._detailsTab || "sync");
+      _updateDetailsConsoleStatus();
     });
   }
 
@@ -236,27 +478,51 @@ function initDetailsTabs() {
         const el = document.getElementById("det-log");
         if (window.detStickBottom && el) el.scrollTop = el.scrollHeight;
       }
+      _updateDetailsConsoleStatus();
     });
   }
+}
+
+function closeSyncLog() {
+  window._detOpenSeq += 1;
+  try { window.esDet?.close?.(); } catch {}
+  try { window.esDetSummary?.close?.(); } catch {}
+  window.esDet = null;
+  window.esDetSummary = null;
+  window.syncBuf.length = 0;
+  if (window._syncFlushRAF) { cancelAnimationFrame(window._syncFlushRAF); window._syncFlushRAF = null; }
+  if (window._detStaleIV) { clearInterval(window._detStaleIV); window._detStaleIV = null; }
+  if (window._detRetryTO) { clearTimeout(window._detRetryTO); window._detRetryTO = null; }
+  if (window._detVisibilityHandler) {
+    document.removeEventListener("visibilitychange", window._detVisibilityHandler);
+    window._detVisibilityHandler = null;
+  }
+  const tabSync = document.getElementById("det-tab-sync");
+  tabSync?.classList.remove("connected", "stale");
+  _scheduleDetailsConsoleStatus();
 }
 
 function closeWatcherLog() {
   try { window.esWatch?.close?.(); } catch {}
   window.esWatch = null;
+  window.watchBuf.length = 0;
   if (window._watchRetryTO) { clearTimeout(window._watchRetryTO); window._watchRetryTO = null; }
   if (window._watchStaleIV) { clearInterval(window._watchStaleIV); window._watchStaleIV = null; }
-  if (window._watchFlushIV) { clearInterval(window._watchFlushIV); window._watchFlushIV = null; }
+  if (window._watchFlushRAF) { cancelAnimationFrame(window._watchFlushRAF); window._watchFlushRAF = null; }
   if (window._watchVisibilityHandler) {
     document.removeEventListener("visibilitychange", window._watchVisibilityHandler);
     window._watchVisibilityHandler = null;
   }
   const tabWatch = document.getElementById("det-tab-watcher");
   tabWatch?.classList.remove("connected", "stale");
+  _updateDetailsConsoleStatus();
 }
 
 function closeDebugLog() {
   try { window.esDebug?.close?.(); } catch {}
   window.esDebug = null;
+  window.debugBuf.length = 0;
+  if (window._debugFlushRAF) { cancelAnimationFrame(window._debugFlushRAF); window._debugFlushRAF = null; }
   if (window._debugRetryTO) { clearTimeout(window._debugRetryTO); window._debugRetryTO = null; }
   if (window._debugStaleIV) { clearInterval(window._debugStaleIV); window._debugStaleIV = null; }
   if (window._debugVisibilityHandler) {
@@ -265,13 +531,14 @@ function closeDebugLog() {
   }
   const tabDebug = document.getElementById("det-tab-debug");
   tabDebug?.classList.remove("connected", "stale");
+  _updateDetailsConsoleStatus();
 }
 
 function openDebugLog() {
   const el = document.getElementById("det-debug-log");
   const details = document.getElementById("details");
   const tabDebug = document.getElementById("det-tab-debug");
-  if (!el || !details || details.classList.contains("hidden")) return;
+  if (!el || !details || details.classList.contains("hidden") || window._detailsTab !== "debug") return;
   if (window.esDebug || window._debugOpening) return;
   window._debugOpening = true;
 
@@ -280,34 +547,38 @@ function openDebugLog() {
       el.addEventListener("scroll", () => {
         const pad = 12;
         window.debugStickBottom = el.scrollTop >= el.scrollHeight - el.clientHeight - pad;
+        _updateDetailsConsoleStatus();
       }, { passive: true });
       el.__cwScrollWired = true;
     }
 
     el.innerHTML = "";
     window.debugStickBottom = true;
-
-    const MAX_LINES = Number(window.DETAILS_MAX_LINES || 0) || 2500;
+    window.debugBuf.length = 0;
+    _resetDetailsDropped("debug");
     let lastMsgAt = Date.now();
 
-    const append = (html) => {
-      if (!html) return;
-      const row = document.createElement("div");
-      row.className = "wlog-line det-debug-line";
-
-      const msg = document.createElement("span");
-      msg.className = "wlog-msg";
-      msg.innerHTML = html;
-
-      row.appendChild(msg);
-      el.appendChild(row);
-      while (el.childNodes.length > MAX_LINES) el.removeChild(el.firstChild);
-      if (window.debugStickBottom) el.scrollTop = el.scrollHeight;
-      lastMsgAt = Date.now();
+    const scheduleFlush = () => {
+      if (window._debugFlushRAF || window._detailsTab !== "debug") return;
+      window._debugFlushRAF = requestAnimationFrame(() => {
+        window._debugFlushRAF = null;
+        const frag = document.createDocumentFragment();
+        _runDetailsBatch(window.debugBuf, (html) => {
+          const row = _structuredLogRow(html);
+          row.classList.add("det-debug-line");
+          frag.appendChild(row);
+        }, () => {
+          el.appendChild(frag);
+          _pruneDetailsLog(el);
+          if (window.debugStickBottom) el.scrollTop = el.scrollHeight;
+          _scheduleDetailsConsoleStatus();
+        }, scheduleFlush);
+      });
     };
 
     const url = new URL("/api/logs/stream", document.baseURI);
     url.searchParams.set("tag", "DEBUG");
+    url.searchParams.set("tail", String(_detailsLimit("DETAILS_STREAM_TAIL", 400)));
     url.searchParams.set("_ts", String(Date.now()));
 
     const es = new EventSource(url.toString());
@@ -315,21 +586,26 @@ function openDebugLog() {
     es.onopen = () => {
       tabDebug?.classList.add("connected");
       tabDebug?.classList.remove("stale");
+      _updateDetailsConsoleStatus();
     };
     es.onmessage = (ev) => {
       tabDebug?.classList.add("connected");
       tabDebug?.classList.remove("stale");
-      append(ev?.data);
+      if (!ev?.data) return;
+      lastMsgAt = Date.now();
+      _enqueueDetailsItem(window.debugBuf, ev.data, "debug");
+      scheduleFlush();
     };
     es.onerror = () => {
       tabDebug?.classList.remove("connected");
       tabDebug?.classList.add("stale");
+      _updateDetailsConsoleStatus();
       try { window.esDebug?.close?.(); } catch {}
       window.esDebug = null;
 
       if (window._debugRetryTO) clearTimeout(window._debugRetryTO);
       window._debugRetryTO = setTimeout(() => {
-        if (window._detailsTab === "debug") { try { openDebugLog(); } catch {} }
+        if (_detailsVisible() && window._detailsTab === "debug") { try { openDebugLog(); } catch {} }
       }, 1200);
     };
 
@@ -337,6 +613,7 @@ function openDebugLog() {
     window._debugStaleIV = setInterval(() => {
       const stale = (Date.now() - lastMsgAt) > 20000;
       tabDebug?.classList.toggle("stale", stale);
+      _updateDetailsConsoleStatus();
     }, 1000);
 
     if (window._debugVisibilityHandler) {
@@ -344,7 +621,7 @@ function openDebugLog() {
     }
     window._debugVisibilityHandler = () => {
       if (document.visibilityState !== "visible") return;
-      if (window._detailsTab === "debug") { try { openDebugLog(); } catch {} }
+      if (_detailsVisible() && window._detailsTab === "debug") { try { openDebugLog(); } catch {} }
     };
     document.addEventListener("visibilitychange", window._debugVisibilityHandler);
   } finally {
@@ -356,7 +633,7 @@ async function openWatcherLog() {
   const el = document.getElementById("det-watch-log");
   const details = document.getElementById("details");
   const tabWatch = document.getElementById("det-tab-watcher");
-  if (!el || !details || details.classList.contains("hidden")) return;
+  if (!el || !details || details.classList.contains("hidden") || window._detailsTab !== "watcher") return;
   if (window.esWatch || window._watchOpening) return;
   window._watchOpening = true;
 
@@ -369,6 +646,7 @@ async function openWatcherLog() {
       } catch {}
     }
 
+    if (!_detailsVisible() || window._detailsTab !== "watcher") return;
     const uniq = _watchLogTagsFromConfig(cfg);
 
     const url = new URL("/api/logs/watcher", document.baseURI);
@@ -379,6 +657,7 @@ async function openWatcherLog() {
       el.addEventListener("scroll", () => {
         const pad = 12;
         window.watchStickBottom = el.scrollTop >= el.scrollHeight - el.clientHeight - pad;
+        _updateDetailsConsoleStatus();
       }, { passive: true });
       el.__cwScrollWired = true;
     }
@@ -386,50 +665,38 @@ async function openWatcherLog() {
     window.watchBuf.length = 0;
     el.innerHTML = "";
     window.watchStickBottom = true;
-
-    const MAX_LINES = Number(window.DETAILS_MAX_LINES || 0) || 2500;
+    _resetDetailsDropped("watcher");
     let lastMsgAt = Date.now();
 
     const enqueue = (tag, html) => {
       if (!html) return;
-      window.watchBuf.push({ tag, html });
+      _enqueueDetailsItem(window.watchBuf, { tag, html }, "watcher");
       lastMsgAt = Date.now();
+      scheduleFlush();
     };
 
-    const flush = () => {
-      if (!window.watchBuf.length) return;
-      const frag = document.createDocumentFragment();
-      const items = window.watchBuf.splice(0, window.watchBuf.length);
-      for (const it of items) {
-        const row = document.createElement("div");
-        row.className = "wlog-line";
-
-        const badge = document.createElement("span");
-        badge.className = "wlog-tag";
-        badge.textContent = it.tag;
-
-        const msg = document.createElement("span");
-        msg.className = "wlog-msg";
-        msg.innerHTML = it.html;
-
-        row.appendChild(badge);
-        row.appendChild(msg);
-        frag.appendChild(row);
-      }
-      el.appendChild(frag);
-
-      while (el.childNodes.length > MAX_LINES) el.removeChild(el.firstChild);
-      if (window.watchStickBottom) el.scrollTop = el.scrollHeight;
+    const scheduleFlush = () => {
+      if (window._watchFlushRAF || window._detailsTab !== "watcher") return;
+      window._watchFlushRAF = requestAnimationFrame(() => {
+        window._watchFlushRAF = null;
+        const frag = document.createDocumentFragment();
+        _runDetailsBatch(window.watchBuf, (it) => {
+          frag.appendChild(_structuredLogRow(it.html, it.tag));
+        }, () => {
+          el.appendChild(frag);
+          _pruneDetailsLog(el);
+          if (window.watchStickBottom) el.scrollTop = el.scrollHeight;
+          _scheduleDetailsConsoleStatus();
+        }, scheduleFlush);
+      });
     };
-
-    if (window._watchFlushIV) clearInterval(window._watchFlushIV);
-    window._watchFlushIV = setInterval(flush, 120);
 
     url.searchParams.set("_ts", String(Date.now()));
     const es = new EventSource(url.toString());
     window.esWatch = es;
     tabWatch?.classList.add("connected");
     tabWatch?.classList.remove("stale");
+    _updateDetailsConsoleStatus();
 
     for (const t of (uniq.length ? uniq : _watchLogKnownTags())) {
       es.addEventListener(t, (ev) => enqueue(t, ev?.data));
@@ -439,12 +706,14 @@ async function openWatcherLog() {
 
     es.onerror = () => {
       tabWatch?.classList.remove("connected");
+      tabWatch?.classList.add("stale");
+      _updateDetailsConsoleStatus();
       try { window.esWatch?.close?.(); } catch {}
       window.esWatch = null;
 
       if (window._watchRetryTO) clearTimeout(window._watchRetryTO);
       window._watchRetryTO = setTimeout(() => {
-        if (window._detailsTab === "watcher") { try { openWatcherLog(); } catch {} }
+        if (_detailsVisible() && window._detailsTab === "watcher") { try { openWatcherLog(); } catch {} }
       }, 1200);
     };
 
@@ -452,6 +721,7 @@ async function openWatcherLog() {
     window._watchStaleIV = setInterval(() => {
       const stale = (Date.now() - lastMsgAt) > 20000;
       tabWatch?.classList.toggle("stale", stale);
+      _updateDetailsConsoleStatus();
     }, 1000);
 
     if (window._watchVisibilityHandler) {
@@ -459,7 +729,7 @@ async function openWatcherLog() {
     }
     window._watchVisibilityHandler = () => {
       if (document.visibilityState !== "visible") return;
-      if (window._detailsTab === "watcher") { try { openWatcherLog(); } catch {} }
+      if (_detailsVisible() && window._detailsTab === "watcher") { try { openWatcherLog(); } catch {} }
     };
     document.addEventListener("visibilitychange", window._watchVisibilityHandler);
   } finally {
@@ -471,7 +741,7 @@ async function openDetailsLog() {
   const el = document.getElementById("det-log");
   const slider = document.getElementById("det-scrub");
   if (!el) return;
-  if (!_detailsVisible()) return;
+  if (!_detailsVisible() || window._detailsTab !== "sync" || window.esDet) return;
   const authSetupPending = () => window.cwIsAuthSetupPending?.() === true;
   const tabSync = document.getElementById("det-tab-sync");
   const openSeq = ++window._detOpenSeq;
@@ -483,6 +753,7 @@ async function openDetailsLog() {
     window._cfgCache = cfg;
     window.appDebug = _isAppDebugMode(cfg);
   } catch (_) {}
+  if (openSeq !== window._detOpenSeq || !_detailsVisible() || window._detailsTab !== "sync") return;
 
   const CF = window.ClientFormatter;
   const useFormatter = !window.appDebug && CF && CF.processChunk && CF.renderInto;
@@ -493,6 +764,8 @@ async function openDetailsLog() {
   if (!useFormatter) el.classList?.add("cf-log-plain");
   window.detStickBottom = true;
   window._detBuf = "";
+  window.syncBuf.length = 0;
+  _resetDetailsDropped("sync");
   window._detSeenLines = [];
   window._detReplayActive = false;
   window._detReplayCursor = 0;
@@ -518,7 +791,10 @@ async function openDetailsLog() {
     window.detStickBottom = el.scrollTop >= el.scrollHeight - el.clientHeight - pad;
   };
 
-  el.addEventListener("scroll", () => { updateSlider(); updateStick(); }, { passive: true });
+  if (!el.__cwSyncScrollWired) {
+    el.addEventListener("scroll", () => { updateSlider(); updateStick(); _scheduleDetailsConsoleStatus(); }, { passive: true });
+    el.__cwSyncScrollWired = true;
+  }
 
   if (slider) {
     slider.addEventListener("input", () => {
@@ -532,14 +808,8 @@ async function openDetailsLog() {
     const lines = String(s).replace(/\r\n/g, "\n").split("\n");
     for (const line of lines) {
       if (!line) continue;
-      const row = document.createElement("div");
-      row.className = "wlog-line det-plain-line";
-
-      const msg = document.createElement("span");
-      msg.className = "wlog-msg";
-      msg.textContent = _decodeLogLine(line);
-
-      row.appendChild(msg);
+      const row = _structuredLogRow(_decodeLogLine(line), "SYNC");
+      row.classList.add("det-plain-line");
       el.appendChild(row);
     }
   };
@@ -548,18 +818,42 @@ async function openDetailsLog() {
   let retryMs = 1000;
   const STALE_MS = 20000;
 
+  const scheduleFlush = () => {
+    if (window._syncFlushRAF || window._detailsTab !== "sync") return;
+    window._syncFlushRAF = requestAnimationFrame(() => {
+      window._syncFlushRAF = null;
+      _runDetailsBatch(window.syncBuf, (line) => {
+        if (!useFormatter) {
+          appendRaw(line);
+          return;
+        }
+        const { tokens, buf } = CF.processChunk(window._detBuf, line);
+        window._detBuf = buf;
+        for (const tok of tokens) CF.renderInto(el, tok, false);
+      }, () => {
+        if (useFormatter) _upgradeSyncLogRows(el);
+        _pruneDetailsLog(el);
+        if (window.detStickBottom) el.scrollTop = el.scrollHeight;
+        updateSlider();
+        _scheduleDetailsConsoleStatus();
+      }, scheduleFlush);
+    });
+  };
+
   const connect = () => {
-    if (authSetupPending()) return;
+    if (authSetupPending() || !_detailsVisible() || window._detailsTab !== "sync") return;
     try { window.esDet?.close(); } catch (_) {}
     if (window._detDidConnectOnce) _beginDetailReplayFilter();
     const url = new URL("/api/logs/stream", document.baseURI);
     url.searchParams.set("tag", "SYNC");
+    url.searchParams.set("tail", String(_detailsLimit("DETAILS_STREAM_TAIL", 400)));
     url.searchParams.set("_ts", String(Date.now()));
     window.esDet = new EventSource(url.toString());
     window.esDet.onopen = () => {
       window._detDidConnectOnce = true;
       tabSync?.classList.add("connected");
       tabSync?.classList.remove("stale");
+      _updateDetailsConsoleStatus();
     };
 
     window.esDet.onmessage = (ev) => {
@@ -570,12 +864,15 @@ async function openDetailsLog() {
 
       if (ev.data === "::CLEAR::") {
         el.textContent = "";
+        window.syncBuf.length = 0;
         window._detBuf = "";
         window._detSeenLines = [];
         window._detReplayActive = false;
         window._detReplayCursor = 0;
         try { CF?.reset?.(); } catch {}
+        _resetDetailsDropped("sync");
         updateSlider();
+        _scheduleDetailsConsoleStatus();
         return;
       }
 
@@ -584,23 +881,16 @@ async function openDetailsLog() {
         return;
       }
 
-      if (!useFormatter) {
-        appendRaw(ev.data);
-      } else {
-        const { tokens, buf } = CF.processChunk(window._detBuf, ev.data);
-        window._detBuf = buf;
-        for (const tok of tokens) CF.renderInto(el, tok, false);
-      }
+      _enqueueDetailsItem(window.syncBuf, ev.data, "sync");
       _rememberDetailLine(ev.data);
-      _pruneDetailsLog(el);
-      if (window.detStickBottom) el.scrollTop = el.scrollHeight;
-      updateSlider();
+      scheduleFlush();
       retryMs = 1000;
     };
 
     window.esDet.onerror = () => {
         tabSync?.classList.remove("connected");
         tabSync?.classList.add("stale");
+      _updateDetailsConsoleStatus();
       try { window.esDet?.close(); } catch (_) {}
       window.esDet = null;
 
@@ -608,15 +898,16 @@ async function openDetailsLog() {
         const { tokens } = CF.processChunk("", window._detBuf);
         window._detBuf = "";
         for (const tok of tokens) CF.renderInto(el, tok, false);
+        _upgradeSyncLogRows(el);
         if (window.detStickBottom) el.scrollTop = el.scrollHeight;
         updateSlider();
       }
 
       if (!window._detRetryTO) {
-        if (authSetupPending()) return;
+        if (authSetupPending() || window._detailsTab !== "sync" || !_detailsVisible()) return;
         window._detRetryTO = setTimeout(() => {
           window._detRetryTO = null;
-          connect();
+          if (window._detailsTab === "sync" && _detailsVisible()) connect();
         }, retryMs);
         retryMs = Math.min(retryMs * 2, 15000);
       }
@@ -627,6 +918,7 @@ async function openDetailsLog() {
 
   window._detStaleIV = setInterval(() => {
     tabSync?.classList.toggle("stale", (Date.now() - lastMsgAt) > STALE_MS);
+    _updateDetailsConsoleStatus();
     if (!window.esDet) return;
     if (document.visibilityState !== "visible") return;
     if (Date.now() - lastMsgAt > STALE_MS) {
@@ -638,7 +930,7 @@ async function openDetailsLog() {
 
   window._detVisibilityHandler = () => {
     if (document.visibilityState !== "visible") return;
-    if (!window.esDet || (Date.now() - lastMsgAt > STALE_MS)) connect();
+    if (window._detailsTab === "sync" && (!window.esDet || (Date.now() - lastMsgAt > STALE_MS))) connect();
   };
   document.addEventListener("visibilitychange", window._detVisibilityHandler);
 
@@ -652,23 +944,10 @@ async function openDetailsLog() {
 }
 
 function closeDetailsLog() {
-  window._detOpenSeq += 1;
-  try { window.esDet?.close(); } catch (_) {}
-  try { window.esDetSummary?.close(); } catch (_) {}
-  window.esDet = null;
-  window.esDetSummary = null;
   window._detBuf = "";
   window._detReplayActive = false;
   window._detReplayCursor = 0;
-  if (window._detStaleIV) { clearInterval(window._detStaleIV); window._detStaleIV = null; }
-  if (window._detRetryTO) { clearTimeout(window._detRetryTO); window._detRetryTO = null; }
-  if (window._detVisibilityHandler) { document.removeEventListener("visibilitychange", window._detVisibilityHandler); window._detVisibilityHandler = null; }
-  const tabSync = document.getElementById("det-tab-sync");
-  tabSync?.classList.remove("connected", "stale");
-  const tabWatch = document.getElementById("det-tab-watcher");
-  tabWatch?.classList.remove("connected", "stale");
-  const tabDebug = document.getElementById("det-tab-debug");
-  tabDebug?.classList.remove("connected", "stale");
+  try { closeSyncLog(); } catch {}
   try { closeWatcherLog(); } catch {}
   try { closeDebugLog(); } catch {}
 }
@@ -679,13 +958,8 @@ function toggleDetails() {
   if (!d.classList.contains("hidden")) {
     try { initDetailsTabs(); } catch {}
     try { setDetailsTab(window._detailsTab || "sync"); } catch {}
-    openDetailsLog();
-    if (window._detailsTab === "watcher") { try { openWatcherLog(); } catch {} }
-    if (window._detailsTab === "debug") { try { openDebugLog(); } catch {} }
   } else {
     closeDetailsLog();
-    closeWatcherLog();
-    closeDebugLog();
   }
 }
 
@@ -693,24 +967,26 @@ function resetDetailsSyncLog() {
   const el = document.getElementById("det-log");
   if (el) el.textContent = "";
   window._detBuf = "";
+  window.syncBuf.length = 0;
+  if (window._syncFlushRAF) { cancelAnimationFrame(window._syncFlushRAF); window._syncFlushRAF = null; }
   window._detSeenLines = [];
   window._detReplayActive = false;
   window._detReplayCursor = 0;
   window._detDidConnectOnce = false;
   window.detStickBottom = true;
+  _resetDetailsDropped("sync");
   try { window.ClientFormatter?.reset?.(); } catch {}
 }
 
 window.addEventListener("beforeunload", () => {
   try { closeDetailsLog(); } catch {}
-  try { closeWatcherLog(); } catch {}
-  try { closeDebugLog(); } catch {}
 });
 
 
   const DetailsLog = {
     setDetailsTab,
     initDetailsTabs,
+    closeSyncLog,
     closeWatcherLog,
     openWatcherLog,
     closeDebugLog,

--- a/assets/helpers/details-log.js
+++ b/assets/helpers/details-log.js
@@ -175,16 +175,28 @@ function _isAppDebugMode(cfg) {
   return !!(cfg?.runtime?.debug || cfg?.runtime?.debug_mods);
 }
 
+function _decodeLogText(value) {
+  const named = { amp: "&", lt: "<", gt: ">", quot: '"', apos: "'", nbsp: " " };
+  return String(value ?? "")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]*>/g, "")
+    .replace(/&(#(?:x[0-9a-f]+|\d+)|amp|lt|gt|quot|apos|nbsp);/gi, (match, token) => {
+      const key = String(token || "").toLowerCase();
+      if (Object.prototype.hasOwnProperty.call(named, key)) return named[key];
+      const numeric = key.startsWith("#x")
+        ? Number.parseInt(key.slice(2), 16)
+        : Number.parseInt(key.slice(1), 10);
+      if (!Number.isInteger(numeric) || numeric < 0 || numeric > 0x10ffff || (numeric >= 0xd800 && numeric <= 0xdfff)) return match;
+      return String.fromCodePoint(numeric);
+    });
+}
+
 function _decodeLogLine(line) {
-  const host = document.createElement("textarea");
-  host.innerHTML = String(line ?? "").replace(/<br\s*\/?>/gi, "\n");
-  return host.value;
+  return _decodeLogText(line);
 }
 
 function _plainLogText(value) {
-  const host = document.createElement("div");
-  host.innerHTML = String(value ?? "").replace(/<br\s*\/?>/gi, "\n");
-  return String(host.textContent || host.innerText || "").replace(/\u00a0/g, " ").trim();
+  return _decodeLogText(value).replace(/\u00a0/g, " ").trim();
 }
 
 function _logTimeNow() {

--- a/assets/helpers/details-log.js
+++ b/assets/helpers/details-log.js
@@ -175,28 +175,12 @@ function _isAppDebugMode(cfg) {
   return !!(cfg?.runtime?.debug || cfg?.runtime?.debug_mods);
 }
 
-function _decodeLogText(value) {
-  const named = { amp: "&", lt: "<", gt: ">", quot: '"', apos: "'", nbsp: " " };
-  return String(value ?? "")
-    .replace(/<br\s*\/?>/gi, "\n")
-    .replace(/<[^>]*>/g, "")
-    .replace(/&(#(?:x[0-9a-f]+|\d+)|amp|lt|gt|quot|apos|nbsp);/gi, (match, token) => {
-      const key = String(token || "").toLowerCase();
-      if (Object.prototype.hasOwnProperty.call(named, key)) return named[key];
-      const numeric = key.startsWith("#x")
-        ? Number.parseInt(key.slice(2), 16)
-        : Number.parseInt(key.slice(1), 10);
-      if (!Number.isInteger(numeric) || numeric < 0 || numeric > 0x10ffff || (numeric >= 0xd800 && numeric <= 0xdfff)) return match;
-      return String.fromCodePoint(numeric);
-    });
-}
-
 function _decodeLogLine(line) {
-  return _decodeLogText(line);
+  return String(line ?? "");
 }
 
 function _plainLogText(value) {
-  return _decodeLogText(value).replace(/\u00a0/g, " ").trim();
+  return String(value ?? "").replace(/\u00a0/g, " ").trim();
 }
 
 function _logTimeNow() {
@@ -591,6 +575,7 @@ function openDebugLog() {
     const url = new URL("/api/logs/stream", document.baseURI);
     url.searchParams.set("tag", "DEBUG");
     url.searchParams.set("tail", String(_detailsLimit("DETAILS_STREAM_TAIL", 400)));
+    url.searchParams.set("plain", "1");
     url.searchParams.set("_ts", String(Date.now()));
 
     const es = new EventSource(url.toString());
@@ -663,6 +648,7 @@ async function openWatcherLog() {
 
     const url = new URL("/api/logs/watcher", document.baseURI);
     url.searchParams.set("tail", "200");
+    url.searchParams.set("plain", "1");
     if (uniq.length) url.searchParams.set("tags", uniq.join(","));
 
     if (!el.__cwScrollWired) {
@@ -859,6 +845,7 @@ async function openDetailsLog() {
     const url = new URL("/api/logs/stream", document.baseURI);
     url.searchParams.set("tag", "SYNC");
     url.searchParams.set("tail", String(_detailsLimit("DETAILS_STREAM_TAIL", 400)));
+    url.searchParams.set("plain", "1");
     url.searchParams.set("_ts", String(Date.now()));
     window.esDet = new EventSource(url.toString());
     window.esDet.onopen = () => {

--- a/assets/js/theme-flat-runtime.js
+++ b/assets/js/theme-flat-runtime.js
@@ -425,6 +425,7 @@ html[data-cw-theme="flat-light"] :is(#det-log,#det-watch-log,#det-debug-log,.log
 html[data-cw-theme="flat-light"] :is(#det-log,#det-watch-log,#det-debug-log,.log) :is(.cf-line,.wlog-line,.wlog-msg){color:#253044!important;-webkit-text-fill-color:#253044!important;}
 html[data-cw-theme="flat-light"] :is(#det-log,#det-watch-log,#det-debug-log,.log) :is(.cf-line,.wlog-line){border-bottom-color:rgba(16,24,40,.08)!important;}
 html[data-cw-theme="flat-light"] :is(#det-log,#det-watch-log,#det-debug-log,.log) .wlog-tag{background:#eef2f7!important;border-color:rgba(16,24,40,.14)!important;color:#344054!important;-webkit-text-fill-color:#344054!important;}
+html[data-cw-theme="flat-light"] #details .det-structured-line .wlog-tag{background:rgba(var(--det-provider-rgb),.10)!important;border-color:rgba(var(--det-provider-rgb),.24)!important;color:var(--det-provider-color)!important;-webkit-text-fill-color:var(--det-provider-color)!important;}
 html[data-cw-theme="flat-light"] :is(#det-log,#det-watch-log,#det-debug-log,.log) .c30,html[data-cw-theme="flat-light"] :is(#det-log,#det-watch-log,#det-debug-log,.log) .c90{color:#667085!important;-webkit-text-fill-color:#667085!important;}
 html[data-cw-theme="flat-light"] :is(#det-log,#det-watch-log,#det-debug-log,.log) :is(.c37,.c97){color:#172033!important;-webkit-text-fill-color:#172033!important;}
 html[data-cw-theme="flat-light"] :is(#det-log,#det-watch-log,#det-debug-log,.log) :is(.c31,.c91){color:#b42318!important;-webkit-text-fill-color:#b42318!important;}

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncIterator
 
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
+from html.parser import HTMLParser
 from pathlib import Path
 from urllib.parse import parse_qsl, urlencode, quote
 
@@ -507,6 +508,30 @@ def _log_lines(tag: str | None, tail: int | None = None) -> List[str]:
         return list(buf)
     return buf[-int(tail):]
 
+class _LogTextExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+
+    def handle_data(self, data: str) -> None:
+        self.parts.append(data)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() == "br":
+            self.parts.append("\n")
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.handle_starttag(tag, attrs)
+
+def _log_stream_text(line: str, plain: bool) -> str:
+    text = str(line or "")
+    if plain:
+        parser = _LogTextExtractor()
+        parser.feed(text)
+        parser.close()
+        text = "".join(parser.parts)
+    return text.replace("\r", " ").replace("\n", " ")
+
 def ansi_to_html(line: str) -> str:
     out, pos = [], 0
     state = {"b": False, "u": False, "fg": None, "bg": None}
@@ -794,6 +819,7 @@ async def api_logs_stream_initial(
     request: Request,
     tag: str = Query("SYNC"),
     tail: int | None = Query(None, ge=1, le=MAX_LOG_LINES),
+    plain: bool = Query(False),
 ):
     tag = _norm_log_tag(tag)
 
@@ -801,7 +827,7 @@ async def api_logs_stream_initial(
         buf = _get_log_buf(tag)
         initial = buf[-int(tail):] if tail else buf
         for line in initial:
-            yield f"data: {line}\n\n"
+            yield f"data: {_log_stream_text(line, plain)}\n\n"
         base = int(LOG_BASE_SEQ.get(tag, int(LOG_NEXT_SEQ.get(tag, 1))))
         last_seq = base + len(buf) - 1
         last = time.time()
@@ -818,7 +844,7 @@ async def api_logs_stream_initial(
                 start_idx = 0
             for i in range(start_idx, len(new_buf)):
                 line = new_buf[i]
-                yield f"data: {line}\n\n"
+                yield f"data: {_log_stream_text(line, plain)}\n\n"
                 last = time.time()
                 last_seq = base + i
             if time.time() - last > 15:
@@ -843,6 +869,7 @@ async def api_logs_watcher(
     request: Request,
     tail: int = Query(200, ge=1, le=3000),
     tags: str = Query("", description="Optional CSV override"),
+    plain: bool = Query(False),
 ):
     cfg = load_config() or {}
     if tags and tags.strip():
@@ -881,7 +908,7 @@ async def api_logs_watcher(
             buf = _get_log_buf(t)
             start = max(0, len(buf) - int(tail))
             for line in buf[start:]:
-                safe = (line or "").replace("\n", " ")
+                safe = _log_stream_text(line, plain)
                 yield f"event: {t}\ndata: {safe}\n\n"
             base = int(LOG_BASE_SEQ.get(t, int(LOG_NEXT_SEQ.get(t, 1))))
             last_seq[t] = base + len(buf) - 1
@@ -903,7 +930,7 @@ async def api_logs_watcher(
                     start_idx = 0
                 for i in range(start_idx, len(buf)):
                     line = buf[i]
-                    safe = (line or "").replace("\n", " ")
+                    safe = _log_stream_text(line, plain)
                     yield f"event: {t}\ndata: {safe}\n\n"
                     last = time.time()
                     seen = base + i

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -790,12 +790,17 @@ def logs_dump(channel: str = "TRAKT", n: int = 50):
     return {"channel": channel, "lines": _log_lines(channel, tail=n)}
 
 @app.get("/api/logs/stream", tags=["logging"])
-async def api_logs_stream_initial(request: Request, tag: str = Query("SYNC")):
+async def api_logs_stream_initial(
+    request: Request,
+    tag: str = Query("SYNC"),
+    tail: int | None = Query(None, ge=1, le=MAX_LOG_LINES),
+):
     tag = _norm_log_tag(tag)
 
     async def agen():
         buf = _get_log_buf(tag)
-        for line in buf:
+        initial = buf[-int(tail):] if tail else buf
+        for line in initial:
             yield f"data: {line}\n\n"
         base = int(LOG_BASE_SEQ.get(tag, int(LOG_NEXT_SEQ.get(tag, 1))))
         last_seq = base + len(buf) - 1

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -530,7 +530,10 @@ html[data-cw-theme=flat-light] #page-settings .cw-maint-action.restart .cw-maint
       <div class="details-grid">
         <div class="det-left">
           <div class="det-head">
-            <div class="det-title">Output</div>
+            <div class="det-console-mark" title="Output" aria-label="Output">
+              <span class="material-symbols-rounded" aria-hidden="true">terminal</span>
+              <span class="det-title">Output</span>
+            </div>
             <div class="det-tabs" role="tablist" aria-label="Output tabs">
               <button id="det-tab-sync" class="det-tab active" type="button"
                 role="tab" aria-selected="true" aria-controls="det-panel-sync" data-tab="sync">Sync</button>
@@ -540,9 +543,9 @@ html[data-cw-theme=flat-light] #page-settings .cw-maint-action.restart .cw-maint
                 role="tab" aria-selected="false" aria-controls="det-panel-debug" data-tab="debug">Debug</button>
             </div>
             <div class="det-tools">
-              <button id="det-copy" class="ghost" type="button" title="Copy current output">Copy</button>
-              <button id="det-clear" class="ghost" type="button" title="Clear current output">Clear</button>
-              <button id="det-follow" class="ghost" type="button" title="Toggle auto-follow">Follow</button>
+              <button id="det-copy" class="ghost det-tool-icon" type="button" title="Copy current output" aria-label="Copy current output"><span class="material-symbols-rounded" aria-hidden="true">content_copy</span></button>
+              <button id="det-clear" class="ghost det-tool-icon" type="button" title="Clear current output" aria-label="Clear current output"><span class="material-symbols-rounded" aria-hidden="true">delete</span></button>
+              <button id="det-follow" class="ghost det-follow" type="button" title="Toggle auto-follow" aria-pressed="true"><span class="material-symbols-rounded det-follow-icon" aria-hidden="true">podcasts</span><span>Follow</span><span class="material-symbols-rounded det-follow-caret" aria-hidden="true">expand_more</span></button>
             </div>
           </div>
           <div class="det-panels">
@@ -555,6 +558,13 @@ html[data-cw-theme=flat-light] #page-settings .cw-maint-action.restart .cw-maint
             <div id="det-panel-debug" class="det-panel hidden" role="tabpanel" aria-labelledby="det-tab-debug">
               <div id="det-debug-log" class="log wlog"></div>
             </div>
+          </div>
+          <div class="det-console-footer" aria-live="polite">
+            <span id="det-live-state" class="det-live-state"><span class="det-live-dot" aria-hidden="true"></span><span class="det-live-label">Live</span></span>
+            <span id="det-follow-state" class="det-follow-state">Auto-scroll on</span>
+            <span class="det-footer-spacer"></span>
+            <span id="det-line-count" class="det-line-count">0 lines</span>
+            <span class="material-symbols-rounded det-list-icon" aria-hidden="true">format_list_bulleted</span>
           </div>
 
         </div>


### PR DESCRIPTION
# Pull request

## Change

Redesigned the Sync, Watcher and Debug output as a structured terminal-style console.
Added provider, log-level and timestamp columns, live connection status, auto-scroll feedback and line counts. 
Copy now produces one readable log record per line.

Bounded the browser queues, rendered history and initial stream replay. Inactive output streams are closed and overloaded queues report omitted entries.

Added matching styling for Original, flat-dark and flat-light.

## Why

The previous output was difficult to scan and copied its visual columns as separate lines.
Large or rapidly updating streams could also create excessive DOM work and make the interface unresponsive.

## Testing

- Checked JavaScript syntax for the output and theme scripts.
- `crosswatch.py` and `ui_frontend.py`.
- `tests/test_sync_provider_logging.py -q`.

## Issue

NA