### PR TITLE
Fix: live playback refresh and maintenance error exposure

### DIFF
--- a/assets/js/schedulerbanner.js
+++ b/assets/js/schedulerbanner.js
@@ -24,7 +24,7 @@
     chipIcon={pairs:"sync_alt",sched:"calendar_month",watch:"visibility",hook:"webhook",providers:"shield",update:"notifications"},
     chipNav={pairs:{target:"pairs",label:"Open sync pair settings"},sched:{target:"scheduling",label:"Open scheduler settings"},watch:{target:"watcher",label:"Open watcher settings"},hook:{target:"webhook",label:"Open webhook settings"},providers:{target:"refresh-providers",label:"Re-check provider connections"},update:{target:"refresh-update",label:"Re-check for updates"}},
     S={cfg:null,pairs:{total:0,active:0},sched:{enabled:false,running:false,next:0,advanced:false,captures:0},evt:{enabled:false,count:0},watch:{...blank(),alive:false},hook:blank(),system:{providers:{total:0,connected:0,missing:[],known:false},update:{known:false,available:false,current:"",latest:"",url:""}},timers:{sched:null,scrob:null,wait:null,rotate:null},debounce:null,last:{watcher:"",webhook:""}};
-  const SHARED_WATCH_KEY="__CW_CURRENT_WATCHING_SHARED__",SHARED_WATCH_TTL_MS=10000,WATCHER_UNAVAILABLE_GRACE_MS=35000;
+  const SHARED_WATCH_KEY="__CW_CURRENT_WATCHING_SHARED__",SHARED_WATCH_TTL_MS=3000,WATCHER_UNAVAILABLE_GRACE_MS=35000;
   let scrobPollSeq=0;
 
   if (!$("#sched-banner-css")) {
@@ -471,11 +471,12 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
       if (nextWatch.enabled) watcherReportedAlive=!!(await API().Watch.status(force))?.alive;
       if (watcherReportedAlive) nextWatch.lastHealthyAt=now;
       const shared=!force?window[SHARED_WATCH_KEY]:null;
-      const cw=shared&&typeof shared==="object"&&(now-(Number(shared.at)||0))<SHARED_WATCH_TTL_MS
+      const sharedFresh=shared&&typeof shared==="object"&&(now-(Number(shared.at)||0))<SHARED_WATCH_TTL_MS;
+      const cw=sharedFresh
         ? (shared.payload||null)
         : await API().Watch.currentlyWatching(force).catch(()=>null);
       if (cw&&typeof cw==="object") {
-        window[SHARED_WATCH_KEY]={at:now,payload:cw};
+        if (!sharedFresh) window[SHARED_WATCH_KEY]={at:now,payload:cw};
         const all=Array.isArray(cw.streams)?cw.streams.filter(x=>x&&typeof x==="object"):[];
         const watchItems=all.filter(it=>!isWebhookStream(it));
         const hookItems=all.filter(isWebhookStream);

--- a/services/activity.py
+++ b/services/activity.py
@@ -10,6 +10,9 @@ import time
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
+from _logging import log as BASE_LOG
+
+LOG = BASE_LOG.child("ACTIVITY")
 LOG_VERSION = 1
 DEFAULT_LIMIT = 1000
 LOG_FILE_NAME = "activity_history.json"
@@ -431,7 +434,8 @@ def clear_events(*, kind: str | None = None) -> dict[str, Any]:
                 "remaining": len(kept),
             }
         except Exception as e:
-            return {"ok": False, "error": "clear_activity_failed", "path": str(path), "existed": bool(existed), "detail": str(e)}
+            LOG.error(f"failed to clear activity log: {type(e).__name__}: {e}")
+            return {"ok": False, "error": "clear_activity_failed"}
 
 
 def clear_scrobble_events() -> dict[str, Any]:


### PR DESCRIPTION
# Pull request

## Change

- Refresh live playback state sooner so webhook play events update the playing card and banner.
- Prevent stale shared playback data from having its cache lifetime extended.
- Keep activity cleanup exception details in server logs and return generic API errors.

## Why

Webhook playback could remain hidden until the dashboard was refreshed. 
Activity cleanup failures could also expose internal exception details through API responses.

## Testing

- `test_activity_security.py -q` 

## Issue

Resolves CodeQL code-scanning alerts #217 and #218.