### PR TITLE
Improve: live playback and profile grouping

### DIFF
--- a/api/metaAPI.py
+++ b/api/metaAPI.py
@@ -416,6 +416,18 @@ def _need_satisfied(meta: dict[str, Any], need: dict[str, Any] | None) -> bool:
             )
         if k == "videos":
             return "videos" in meta
+        if k == "vote_count":
+            return "vote_count" in meta or "vote_count" in det
+        if k == "series_info":
+            return all(
+                field in det
+                for field in (
+                    "status",
+                    "number_of_seasons",
+                    "number_of_episodes",
+                    "next_episode_to_air",
+                )
+            )
         return bool(meta.get(k))
 
     for k, v in (need or {}).items():
@@ -1193,6 +1205,7 @@ def api_metadata_bulk(
             "genres",
             "videos",
             "score",
+            "vote_count",
             "certification",
             "release",
             "detail",

--- a/api/scrobbleAPI.py
+++ b/api/scrobbleAPI.py
@@ -371,6 +371,21 @@ def _scheduler_event_webhook_payload(provider: str, payload: dict[str, Any], res
         except Exception:
             return None
 
+    def _first(*values: Any) -> Any:
+        for value in values:
+            if value not in (None, ""):
+                return value
+        return None
+
+    def _number(*values: Any) -> int | None:
+        value = _first(*values)
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
     provider_lc = str(provider or "").strip().lower()
     action_raw = str((result or {}).get("action") or "").strip().lower()
     event_name = action_raw.rsplit("/", 1)[-1] if action_raw.startswith("/scrobble/") else action_raw
@@ -400,6 +415,7 @@ def _scheduler_event_webhook_payload(provider: str, payload: dict[str, Any], res
     media_type = str(
         _dig(payload, "Metadata", "type")
         or _dig(payload, "Item", "Type")
+        or _dig(payload, "NowPlayingItem", "Type")
         or payload.get("itemType")
         or ""
     ).strip().lower()
@@ -413,14 +429,38 @@ def _scheduler_event_webhook_payload(provider: str, payload: dict[str, Any], res
         or ""
     ).strip()
 
-    title = str(
-        _dig(payload, "Metadata", "title")
-        or _dig(payload, "Metadata", "grandparentTitle")
-        or _dig(payload, "Item", "Name")
-        or _dig(payload, "Item", "SeriesName")
-        or payload.get("Name")
+    series_title = str(
+        _first(
+            _dig(payload, "Metadata", "grandparentTitle"),
+            _dig(payload, "Item", "SeriesName"),
+            _dig(payload, "NowPlayingItem", "SeriesName"),
+            payload.get("SeriesName"),
+        )
         or ""
     ).strip()
+    item_title = str(
+        _first(
+            _dig(payload, "Metadata", "title"),
+            _dig(payload, "Item", "Name"),
+            _dig(payload, "NowPlayingItem", "Name"),
+            payload.get("Name"),
+        )
+        or ""
+    ).strip()
+    title = series_title if media_type == "episode" and series_title else item_title
+
+    season = _number(
+        _dig(payload, "Metadata", "parentIndex"),
+        _dig(payload, "Item", "ParentIndexNumber"),
+        _dig(payload, "NowPlayingItem", "ParentIndexNumber"),
+        payload.get("SeasonNumber"),
+    )
+    episode = _number(
+        _dig(payload, "Metadata", "index"),
+        _dig(payload, "Item", "IndexNumber"),
+        _dig(payload, "NowPlayingItem", "IndexNumber"),
+        payload.get("EpisodeNumber"),
+    )
 
     ids = {}
     for key in ("imdb", "tmdb", "tvdb", "trakt"):
@@ -441,6 +481,8 @@ def _scheduler_event_webhook_payload(provider: str, payload: dict[str, Any], res
         "finished": finished,
         "session_key": str(payload.get("sessionKey") or payload.get("SessionId") or "").strip(),
         "title": title,
+        "season": season if media_type == "episode" else None,
+        "episode": episode if media_type == "episode" else None,
         "ids": ids,
         "ts": int(time.time()),
     }
@@ -470,6 +512,14 @@ def _emit_activity_webhook_event(provider: str, payload: dict[str, Any], result:
 
     try:
         event = _scheduler_event_webhook_payload(provider, payload or {}, result)
+        trakt_payload = result.get("trakt")
+        trakt_action = str(trakt_payload.get("action") or "").strip().lower() if isinstance(trakt_payload, dict) else ""
+        confirmed_scrobble = trakt_action in {"scrobble", "stop"}
+        confirmed_conflict = str(result.get("note") or "").strip().lower() == "409_checkin"
+        if trakt_action and not confirmed_scrobble:
+            return
+        if not trakt_action and not confirmed_conflict and not bool(event.get("finished")):
+            return
         media_type = str(event.get("media_type") or "").strip().lower()
         if media_type not in {"movie", "episode"}:
             return
@@ -485,6 +535,8 @@ def _emit_activity_webhook_event(provider: str, payload: dict[str, Any], result:
                 "target_instance": "default",
                 "media_type": media_type,
                 "title": event.get("title"),
+                "season": event.get("season"),
+                "episode": event.get("episode"),
                 "progress": event.get("progress"),
                 "account": event.get("account"),
                 "watched_at": event.get("ts"),
@@ -1487,7 +1539,7 @@ async def webhook_trakt(request: Request) -> JSONResponse:
     elif res.get("debounced"):
         log("plex-webhook: debounced pause", "DEBUG")
     elif res.get("suppressed"):
-        log("plex-webhook: suppressed late start", "DEBUG")
+        log("plex-webhook: event suppressed by scrobble rules", "DEBUG")
     elif res.get("dedup"):
         log("plex-webhook: duplicate event suppressed", "DEBUG")
 

--- a/assets/crosswatch.css
+++ b/assets/crosswatch.css
@@ -757,7 +757,6 @@ to{left:6px}
 .snap-close:hover{background:rgba(255,255,255,.2)}
 #details .det-left{grid-column:1/-1;display:flex;flex-direction:column;min-height:0}
 #details .det-head{display:flex;align-items:center;gap:8px 10px;margin-bottom:8px;flex-wrap:wrap}
-#details .det-title{font-weight:800;letter-spacing:.01em}
 #details .det-tools{margin-left:auto;display:flex;gap:6px}
 #details .det-tools .ghost{width:auto;min-width:unset;padding:6px 10px;border-radius:10px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.03);cursor:pointer;opacity:.92}
 #details .det-tools .ghost:hover{background:rgba(255,255,255,.06)}
@@ -839,16 +838,12 @@ to{left:6px}
 #ops-card #details{margin-top:16px;border-radius:22px;border-color:rgba(255,255,255,.08);background:radial-gradient(920px 260px at 0 0,rgba(124,92,255,.1),transparent 52%),linear-gradient(180deg,rgba(255,255,255,.026),rgba(255,255,255,.012));box-shadow:0 18px 34px rgba(0,0,0,.18),inset 0 1px 0 rgba(255,255,255,.02)}
 #ops-card .meta-card{border-radius:18px;border-color:rgba(255,255,255,.08);background:linear-gradient(180deg,rgba(255,255,255,.032),rgba(255,255,255,.012));box-shadow:0 12px 26px rgba(0,0,0,.18),inset 0 1px 0 rgba(255,255,255,.02)}
 #details .det-head{margin-bottom:12px;padding-bottom:10px;border-bottom:1px solid rgba(255,255,255,.07)}
-#details .det-title{flex:0 0 100%}
 #details .det-tools .ghost{border-radius:12px;background:rgba(255,255,255,.035)}
 #details .det-tools .ghost:hover{background:rgba(255,255,255,.07)}
 #details .det-tabs{padding:3px;background:rgba(255,255,255,.03)}
 #ops-card #details{--det-console-bg:#0d1119;--det-console-surface:#111722;--det-console-soft:rgba(255,255,255,.045);--det-console-border:rgba(255,255,255,.09);--det-console-border-strong:rgba(255,255,255,.15);--det-console-text:#e8edf7;--det-console-muted:#7f899b;--det-console-live:#39c98a;--det-console-stale:#e8a34d;margin-top:16px;padding:0!important;overflow:hidden;background:var(--det-console-bg)!important;border-color:var(--det-console-border)!important;box-shadow:0 18px 36px rgba(0,0,0,.24),inset 0 1px 0 rgba(255,255,255,.025)!important}
 #details .det-left{background:transparent}
 #details .det-head{display:flex;align-items:center;gap:12px;min-height:66px;margin:0!important;padding:11px 13px!important;border-bottom:1px solid var(--det-console-border)!important;flex-wrap:nowrap}
-#details .det-console-mark{display:inline-flex;align-items:center;justify-content:center;flex:0 0 34px;width:34px;height:34px;color:var(--det-console-muted)}
-#details .det-console-mark>.material-symbols-rounded{font-size:22px;font-variation-settings:"FILL" 0,"wght" 420,"GRAD" 0,"opsz" 24}
-#details .det-title{position:absolute!important;width:1px!important;height:1px!important;margin:-1px!important;padding:0!important;overflow:hidden!important;clip:rect(0,0,0,0)!important;white-space:nowrap!important;border:0!important}
 #details .det-tabs{display:inline-flex;align-items:center;gap:2px;padding:3px!important;border:1px solid var(--det-console-border)!important;border-radius:12px!important;background:var(--det-console-soft)!important}
 #details .det-tab{position:relative;min-height:32px;padding:0 12px!important;border-radius:9px!important;color:var(--det-console-muted)!important;opacity:1!important;font-size:12px;font-weight:800;transition:background .15s ease,color .15s ease,box-shadow .15s ease}
 #details .det-tab.active{background:var(--det-console-soft)!important;color:var(--det-console-text)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.04)}

--- a/assets/js/activity.js
+++ b/assets/js/activity.js
@@ -58,8 +58,8 @@
     }
     const s = Number(item?.season || 0);
     const e = Number(item?.episode || 0);
-    const code = s && e ? ` S${String(s).padStart(2, "0")}E${String(e).padStart(2, "0")}` : "";
-    return `${title}${code}`;
+    const code = s && e ? `S${String(s).padStart(2, "0")}E${String(e).padStart(2, "0")}` : "";
+    return code ? `${title} - ${code}` : title;
   }
 
   function providerMeta() {

--- a/assets/js/playingcard.js
+++ b/assets/js/playingcard.js
@@ -1,5 +1,4 @@
 /* assets/js/playingcard.js */
-/* refactored */
 /* CrossWatch - Now Playing Card UI */
 /* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
 (() => {
@@ -23,12 +22,18 @@
     return !!cfg && ui.show_playingcard !== false && hasTmdbKey(cfg);
   };
 
-  const isSmallScreen = () => {
-    try { return !!window.matchMedia?.("(max-width: 680px)")?.matches; } catch { return false; }
-  };
-
-
   const isActiveState = (s) => ["playing", "paused", "buffering"].includes(String(s || "").toLowerCase());
+  const visualProgress = (item, nowMs = Date.now()) => {
+    const base = Math.max(0, Math.min(100, Number(item?.progress) || 0));
+    if (String(item?.state || item?.status || "").toLowerCase() !== "playing") return base;
+    const durationMs = Number(item?.duration_ms) || 0;
+    const updatedSec = Number(item?.updated) || 0;
+    if (!(durationMs > 0) || !(updatedSec > 0)) return base;
+    const serverTs = Number(item?._server_ts) || 0;
+    const receivedAt = Number(item?._received_at_ms) || 0;
+    const nowSec = serverTs && receivedAt ? serverTs + Math.max(0, nowMs - receivedAt) / 1000 : nowMs / 1000;
+    return Math.max(base, Math.min(100, base + (Math.max(0, nowSec - updatedSec) * 100000 / durationMs)));
+  };
   const keyOf = (p) => {
     const k = String(p?._key || "").trim();
     if (k) return k;
@@ -47,25 +52,11 @@
       : p?.tmdb || p?.tmdb_id || ids.tmdb || ids.tmdb_show || ids.id;
   };
 
-  const imdbIdOf = (p, meta) => {
-    const ids = Object.assign({}, p?.ids || {}, meta?.ids || {});
-    return String(p?.media_type || p?.type || "").toLowerCase() === "episode"
-      ? ids.imdb_show || ids.imdb || ids.imdb_id
-      : ids.imdb || ids.imdb_show || ids.imdb_id;
-  };
-
   const buildTmdbUrl = (p) => {
     const id = tmdbIdOf(p);
     if (!id) return "";
     const type = String(p?.media_type || p?.type || "").toLowerCase() === "movie" ? "movie" : "tv";
     return `https://www.themoviedb.org/${type}/${encodeURIComponent(String(id))}`;
-  };
-
-  const buildImdbUrl = (p, meta) => {
-    const id = imdbIdOf(p, meta);
-    if (!id) return "";
-    const clean = String(id).startsWith("tt") ? String(id) : `tt${id}`;
-    return `https://www.imdb.com/title/${clean}`;
   };
 
   const buildArtUrl = (p) => {
@@ -142,7 +133,7 @@
   const statusText = (state, since = "") => {
     const st = String(state || "").toLowerCase();
     let label = st === "paused" ? "Paused" : st === "buffering" ? "Buffering..." : st === "stopped" ? "Stopped" : "Now Playing";
-    if (since) label += ` | ${since}`;
+    if (since) label += `\n${since}`;
     return label;
   };
 
@@ -179,6 +170,8 @@
     if (!tmdb) return null;
     const mt = String(p?.media_type || p?.type || "").toLowerCase();
     const type = mt === "movie" ? "movie" : "show";
+    const need = { overview: 1, runtime_minutes: 1, ids: 1, videos: 1, genres: 1, certification: 1, score: 1, vote_count: 1, release: 1, backdrop: 1 };
+    if (type === "show") need.series_info = 1;
 
     const req = (async () => {
       try {
@@ -187,7 +180,7 @@
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           items: [{ type, tmdb }],
-          need: { overview: 1, runtime_minutes: 1, ids: 1, videos: 1, genres: 1, certification: 1, score: 1, release: 1, backdrop: 1 },
+          need,
           concurrency: 1
         })
       });
@@ -247,11 +240,13 @@
         const streams = activeStreamsFromPayload(j);
         const ts = Number(j?.ts) || 0;
         countByKey.clear();
+        const receivedAt = Date.now();
         streams.forEach((item) => {
           const k = keyOf(item);
           if (k) countByKey.set(k, streams.length);
           item._streams_count = streams.length;
           if (ts) item._server_ts = ts;
+          item._received_at_ms = receivedAt;
         });
         CARD.serverTs = ts || CARD.serverTs || 0;
         const payload = { streams, primary: streams[0] || null, ts };
@@ -276,6 +271,8 @@
   #playing-detail::before{content:"";position:absolute;inset:0;border-radius:inherit;background-image:linear-gradient(90deg,rgba(25,29,38,.92) 0%,rgba(25,29,38,.76) 42%,rgba(25,29,38,.88) 100%),var(--pc-backdrop,none);background-size:100% 100%,cover;background-position:center center,center center;background-repeat:no-repeat,no-repeat;pointer-events:none;z-index:0}
   #playing-detail .pc-body{position:relative;display:flex;flex-direction:column;justify-content:flex-start;padding-bottom:0}
   #playing-detail .pc-inner{position:relative;z-index:1;display:grid;grid-template-columns:104px 1fr 170px;gap:14px;align-items:stretch;padding:14px}
+  #playing-detail .pc-poster-link{display:block;width:104px;border-radius:14px;overflow:hidden;background:#05070d;text-decoration:none}
+  #playing-detail .pc-poster-link[href]{cursor:pointer}
   #playing-detail .pc-poster{width:104px;border:1px solid rgba(255,255,255,.06);border-radius:14px;object-fit:cover;box-shadow:0 14px 30px rgba(0,0,0,.44),inset 0 1px 0 rgba(255,255,255,.04);background:#05070d}
   #playing-detail .pc-title-row{display:flex;align-items:flex-start;gap:8px}
   #playing-detail .pc-title{font-weight:700;font-size:17px;letter-spacing:.005em;line-height:1.2}
@@ -287,38 +284,49 @@
   #playing-detail .pc-nav-btn:hover{background:rgba(255,255,255,.09);transform:translateY(-1px)}
   #playing-detail .pc-nav-btn:disabled{opacity:.35;cursor:default;transform:none}
   #playing-detail .pc-nav-count{min-width:40px;text-align:center;font-size:11px;font-weight:800;letter-spacing:.08em;color:rgba(236,241,251,.88)}
-  #playing-detail .pc-close{display:inline-flex;align-items:center;justify-content:flex-end;gap:4px;flex:0 0 auto;width:auto;min-width:0;max-width:max-content;margin:0;padding:4px 10px 4px 8px;border:1px solid rgba(255,255,255,.08);border-radius:999px;background:linear-gradient(180deg,rgba(255,255,255,.045),rgba(255,255,255,.018));color:rgba(232,238,252,.78);cursor:pointer;font-size:12px;line-height:1;text-transform:uppercase;letter-spacing:.08em;white-space:nowrap;transition:background .18s ease,border-color .18s ease,color .18s ease,transform .18s ease}
+  #playing-detail .pc-close{display:inline-flex;align-items:center;justify-content:center;flex:0 0 auto;width:32px;height:32px;min-width:32px;margin:0;padding:0;border:1px solid rgba(255,255,255,.08);border-radius:50%;background:linear-gradient(180deg,rgba(255,255,255,.045),rgba(255,255,255,.018));color:rgba(232,238,252,.78);cursor:pointer;line-height:1;transition:background .18s ease,border-color .18s ease,color .18s ease,transform .18s ease}
   #playing-detail .pc-close .material-symbols-rounded{font-size:18px;line-height:1;font-variation-settings:"FILL" 0,"wght" 400,"GRAD" 0,"opsz" 20}
-  #playing-detail .pc-close-text{display:inline-flex;align-items:center;justify-content:flex-end;min-width:0;flex:0 0 auto}
   #playing-detail .pc-close:hover{color:#fff;border-color:rgba(255,255,255,.13);background:linear-gradient(180deg,rgba(255,255,255,.075),rgba(255,255,255,.03));transform:translateY(-1px)}
   #playing-detail .pc-meta{display:flex;flex-wrap:wrap;gap:5px;margin-top:6px}
   #playing-detail .pc-chip{display:inline-flex;align-items:center;justify-content:center;min-height:24px;padding:0 9px;border:1px solid rgba(255,255,255,.07);border-radius:999px;background:linear-gradient(180deg,rgba(255,255,255,.055),rgba(255,255,255,.022));box-shadow:inset 0 1px 0 rgba(255,255,255,.03);font-size:10px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:rgba(236,241,251,.86);line-height:1}
   .pc-chip-streams{background:linear-gradient(180deg,rgba(255,255,255,.08),rgba(255,255,255,.032))}
   #playing-detail .pc-overview{margin-top:8px;font-size:12px;line-height:1.45;color:rgba(211,219,234,.7);max-height:3.2em;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical}
+  #playing-detail .pc-overview-wrap{position:static;min-width:0;min-height:0}
+  #playing-detail .pc-overview-more{position:absolute;right:2px;bottom:2px;z-index:2;padding:0;border:0;background:transparent;color:rgba(236,241,251,.72);font:inherit;font-size:10px;font-weight:700;line-height:1;cursor:pointer}
+  #playing-detail .pc-overview-more:hover{color:#fff}
+  #playing-detail .pc-overview-more[hidden]{display:none}
+  #playing-detail .pc-overview-wrap.is-expanded .pc-overview{display:block;overflow-x:hidden;overflow-y:auto;text-overflow:clip;-webkit-line-clamp:unset;scrollbar-width:thin;scrollbar-color:rgba(126,226,184,.55) rgba(255,255,255,.06)}
   #playing-detail .pc-progress-wrap{margin-top:auto;position:relative;width:100%;max-width:100%;box-sizing:border-box}
   #playing-detail .pc-progress-bg{position:relative;width:100%;height:22px;border:1px solid rgba(255,255,255,.06);border-radius:999px;background:linear-gradient(180deg,rgba(12,16,27,.96),rgba(8,11,19,.98));overflow:hidden;box-shadow:inset 0 1px 0 rgba(255,255,255,.025)}
-  #playing-detail .pc-progress{width:0;height:100%;background:linear-gradient(90deg,rgba(106,97,255,.84),rgba(75,157,255,.88));transition:width .4s cubic-bezier(.22,.7,.25,1)}
+  #playing-detail .pc-progress{width:0;height:100%;background:linear-gradient(90deg,#5fb6ff,#7ee2b8);transition:width .4s cubic-bezier(.22,.7,.25,1)}
   #playing-detail .pc-progress::after{content:"";position:absolute;inset:0;border-radius:999px;box-shadow:0 0 18px rgba(84,124,255,.22);pointer-events:none}
   #playing-detail .pc-progress-labels{position:absolute;inset:0;display:flex;align-items:center;justify-content:space-between;padding:0 10px;pointer-events:none;font-size:11px;font-weight:700;color:rgba(236,241,251,.92);text-shadow:0 1px 2px rgba(0,0,0,.8);box-sizing:border-box}
-  #playing-detail .pc-right{display:flex;flex-direction:column;align-items:stretch;justify-content:flex-start;gap:8px}
-  #playing-detail .pc-right-top{display:flex;align-items:center;justify-content:flex-end;gap:10px}
-  #playing-detail .pc-score-circle{--pc-score-deg:0deg;--pc-score-color:#16a34a;--pc-score-track:#111827;position:relative;align-self:flex-end;display:flex;align-items:center;justify-content:center;width:58px;height:58px;border-radius:50%;background:conic-gradient(var(--pc-score-color) var(--pc-score-deg),var(--pc-score-track) var(--pc-score-deg));color:#fff;font-weight:700;box-shadow:0 14px 28px rgba(0,0,0,.34)}
-  #playing-detail .pc-score-circle::before{content:"";position:absolute;inset:4px;border-radius:50%;background:linear-gradient(180deg,rgba(8,11,20,.98),rgba(4,7,14,.98))}
-  #playing-detail .pc-score-circle.is-empty{background:conic-gradient(#374151 0deg,#111827 0deg)}
-  #playing-detail #pc-score{position:relative;font-size:18px}
-  #playing-detail .pc-score-label{align-self:flex-end;font-size:11px;color:rgba(200,209,226,.56);text-align:right}
-  #playing-detail .pc-link{display:inline-flex;align-items:center;justify-content:center;min-height:28px;padding:0 10px;border:1px solid rgba(255,255,255,.07);border-radius:999px;background:linear-gradient(180deg,rgba(255,255,255,.045),rgba(255,255,255,.018));color:#dbe8ff;font-size:11px;font-weight:700;text-decoration:none;text-align:center;transition:background .18s ease,border-color .18s ease,color .18s ease,transform .18s ease}
-  #playing-detail .pc-link + .pc-link{margin-top:0}
-  #playing-detail .pc-link:hover{border-color:rgba(122,138,255,.24);background:linear-gradient(180deg,rgba(96,104,242,.18),rgba(255,255,255,.03));color:#f3f7ff;transform:translateY(-1px)}
-  #playing-detail .pc-status{position:static;display:inline-flex;align-items:center;justify-content:center;align-self:stretch;min-height:28px;margin-top:auto;padding:0 10px;border:1px solid rgba(255,255,255,.07);border-radius:999px;background:linear-gradient(180deg,rgba(255,255,255,.045),rgba(255,255,255,.018));font-size:10px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:rgba(236,241,251,.88);opacity:.96;white-space:nowrap;text-align:center}
+  #playing-detail .pc-info-block{display:grid;align-content:center;gap:4px;min-width:0;min-height:62px;padding:8px 10px;border:1px solid rgba(255,255,255,.14);border-radius:10px;background:rgba(20,26,36,.5);box-sizing:border-box}
+  #playing-detail .pc-info-label{display:flex;align-items:center;gap:5px;min-width:0;font-size:8px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:rgba(200,209,226,.62);white-space:nowrap}
+  #playing-detail .pc-info-value{display:flex;align-items:center;gap:6px;min-width:0;font-size:17px;font-weight:800;line-height:1}
+  #playing-detail .pc-info-note{font-size:8px;line-height:1.1;color:rgba(200,209,226,.5);white-space:nowrap}
+  #playing-detail .pc-info-icon{font-size:21px;line-height:1;font-variation-settings:"FILL" 1,"wght" 550,"GRAD" 0,"opsz" 22}
+  #playing-detail .pc-information-block{align-content:start;gap:6px;min-height:80px}
+  #playing-detail .pc-information-block.is-series{min-height:100px}
+  #playing-detail .pc-information-rows{display:grid;gap:5px;min-width:0}
+  #playing-detail .pc-information-row{display:grid;grid-template-columns:15px minmax(0,1fr);align-items:start;gap:6px;min-width:0;color:rgba(222,229,241,.78)}
+  #playing-detail .pc-information-row-icon{font-size:15px;line-height:1.1;color:#22c55e;font-variation-settings:"FILL" 1,"wght" 500,"GRAD" 0,"opsz" 18}
+  #playing-detail .pc-information-copy{min-width:0;font-size:9px;line-height:1.2}
+  #playing-detail .pc-information-main{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  #playing-detail .pc-information-sub{display:block;margin-top:2px;color:rgba(200,209,226,.48);font-size:8px;white-space:nowrap}
+  #playing-detail .pc-rating-block{--pc-rating-color:#8b93a7}
+  #playing-detail .pc-rating-block .pc-info-value{color:var(--pc-rating-color)}
+  #playing-detail .pc-rating-block.rating-low{--pc-rating-color:#ef4444}
+  #playing-detail .pc-rating-block.rating-mid{--pc-rating-color:#f59e0b}
+  #playing-detail .pc-rating-block.rating-high{--pc-rating-color:#22c55e}
+  #playing-detail .pc-status{position:static;font-size:10px;font-weight:700;line-height:1.45;letter-spacing:.08em;text-transform:uppercase;color:rgba(236,241,251,.88);opacity:.96;white-space:pre-line;text-align:left}
   #playing-detail,
   #playing-detail .pc-nav,
   #playing-detail .pc-nav-btn,
   #playing-detail .pc-close,
   #playing-detail .pc-chip,
   #playing-detail .pc-progress-bg,
-  #playing-detail .pc-score-circle::before,
-  #playing-detail .pc-link,
+  #playing-detail .pc-info-block,
   #playing-detail .pc-status{
     background:#20242d!important;
     border-color:rgba(255,255,255,.14)!important;
@@ -345,8 +353,7 @@
   }
   #playing-detail.show:hover,
   #playing-detail .pc-nav-btn:hover,
-  #playing-detail .pc-close:hover,
-  #playing-detail .pc-link:hover{
+  #playing-detail .pc-close:hover{
     background:#2b313d!important;
     border-color:rgba(255,255,255,.19)!important;
     box-shadow:none!important;
@@ -354,27 +361,24 @@
     transform:translate(-50%,0)!important;
   }
   #playing-detail .pc-nav-btn:hover,
-  #playing-detail .pc-close:hover,
-  #playing-detail .pc-link:hover{
+  #playing-detail .pc-close:hover{
     transform:none!important;
   }
-  #playing-detail .pc-poster,
-  #playing-detail .pc-score-circle{
+  #playing-detail .pc-poster{
     box-shadow:none!important;
     filter:none!important;
     text-shadow:none!important;
   }
   #playing-detail .pc-progress{
-    background:#7d86c9!important;
+    background:linear-gradient(90deg,#5fb6ff,#7ee2b8)!important;
     box-shadow:none!important;
   }
-  #playing-detail .pc-score-circle{
-    --pc-score-track:rgba(148,163,184,.24);
-    background:conic-gradient(var(--pc-score-color) var(--pc-score-deg),var(--pc-score-track) var(--pc-score-deg))!important;
-  }
-  #playing-detail .pc-score-circle.is-empty{
-    --pc-score-track:rgba(148,163,184,.22);
-    background:conic-gradient(#64748b 0deg,var(--pc-score-track) 0deg)!important;
+  #playing-detail .pc-info-block{
+    background:linear-gradient(145deg,rgba(21,28,39,.62),rgba(14,20,30,.42))!important;
+    border-color:rgba(255,255,255,.16)!important;
+    box-shadow:inset 0 1px 0 rgba(255,255,255,.055),0 10px 28px rgba(0,0,0,.12)!important;
+    -webkit-backdrop-filter:blur(12px) saturate(115%);
+    backdrop-filter:blur(12px) saturate(115%);
   }
   html[data-cw-theme="flat-light"] #playing-detail,
   html[data-cw-theme="flat-light"] #playing-detail .pc-nav,
@@ -382,8 +386,7 @@
   html[data-cw-theme="flat-light"] #playing-detail .pc-close,
   html[data-cw-theme="flat-light"] #playing-detail .pc-chip,
   html[data-cw-theme="flat-light"] #playing-detail .pc-progress-bg,
-  html[data-cw-theme="flat-light"] #playing-detail .pc-score-circle::before,
-  html[data-cw-theme="flat-light"] #playing-detail .pc-link,
+  html[data-cw-theme="flat-light"] #playing-detail .pc-info-block,
   html[data-cw-theme="flat-light"] #playing-detail .pc-status{
     background:#ffffff!important;
     border-color:rgba(21,31,48,.14)!important;
@@ -391,28 +394,47 @@
   }
   html[data-cw-theme="flat-light"] #playing-detail.show:hover,
   html[data-cw-theme="flat-light"] #playing-detail .pc-nav-btn:hover,
-  html[data-cw-theme="flat-light"] #playing-detail .pc-close:hover,
-  html[data-cw-theme="flat-light"] #playing-detail .pc-link:hover{
+  html[data-cw-theme="flat-light"] #playing-detail .pc-close:hover{
     background:#eef2f7!important;
     border-color:rgba(21,31,48,.20)!important;
   }
   html[data-cw-theme="flat-light"] #playing-detail .pc-progress{
-    background:#5865a8!important;
+    background:linear-gradient(90deg,#5fb6ff,#7ee2b8)!important;
   }
-  html[data-cw-theme="flat-light"] #playing-detail .pc-score-circle{
-    --pc-score-track:rgba(15,23,42,.16);
-    background:conic-gradient(var(--pc-score-color) var(--pc-score-deg),var(--pc-score-track) var(--pc-score-deg))!important;
-    color:#172033!important;
+  html[data-cw-theme="flat-light"] #playing-detail .pc-info-block{
+    background:linear-gradient(145deg,rgba(255,255,255,.72),rgba(244,247,251,.58))!important;
+    border-color:rgba(21,31,48,.14)!important;
+    box-shadow:inset 0 1px 0 rgba(255,255,255,.72),0 10px 26px rgba(31,41,55,.08)!important;
   }
-  html[data-cw-theme="flat-light"] #playing-detail .pc-score-circle.is-empty{
-    background:conic-gradient(#94a3b8 0deg,var(--pc-score-track) 0deg)!important;
-  }
+  html[data-cw-theme="flat-light"] #playing-detail .pc-overview-more{color:rgba(23,32,51,.68)}
+  html[data-cw-theme="flat-light"] #playing-detail .pc-overview-more:hover{color:#172033}
   html[data-cw-theme="flat-light"] #playing-detail::before{
     background-image:linear-gradient(90deg,rgba(255,255,255,.94) 0%,rgba(255,255,255,.80) 42%,rgba(255,255,255,.92) 100%),var(--pc-backdrop,none)!important;
   }
-  @media (max-width:1024px){#playing-detail{width:calc(100vw - 40px)}}
-  @media (max-width:768px){#playing-detail .pc-inner{grid-template-columns:80px 1fr;grid-template-rows:auto auto}#playing-detail .pc-right{grid-column:span 2;flex-direction:row;justify-content:space-between}}
-  @media (max-width:680px){#playing-detail{bottom:max(10px,env(safe-area-inset-bottom));width:calc(100vw - 20px);border-radius:18px}#playing-detail .pc-inner{grid-template-columns:64px 1fr;gap:12px;padding:12px}#playing-detail .pc-poster{width:64px;height:96px;border-radius:10px}#playing-detail .pc-title{font-size:15px;line-height:1.15}#playing-detail .pc-title-actions{gap:6px}#playing-detail .pc-nav{padding:2px 4px}#playing-detail .pc-nav-count{min-width:32px;font-size:10px}#playing-detail .pc-nav-btn{width:24px;height:24px}#playing-detail .pc-close{min-width:0;margin:0;padding:2px 8px 2px 6px}#playing-detail .pc-close-text{display:none}#playing-detail .pc-meta{gap:4px;margin-top:4px}#playing-detail .pc-chip{font-size:10px;padding:3px 7px}#playing-detail .pc-overview{display:none}#playing-detail .pc-progress-bg{height:18px}#playing-detail .pc-progress-labels{font-size:11px;padding:0 8px}#playing-detail .pc-right{grid-column:1 / -1;flex-direction:row;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:8px}#playing-detail .pc-right-top{order:0;display:flex;align-items:center;gap:8px}#playing-detail .pc-score-circle{width:46px;height:46px}#playing-detail .pc-score-label{display:none}#playing-detail .pc-link{font-size:11px;padding:4px 8px;border-radius:999px;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.10);text-decoration:none}#playing-detail .pc-status{margin-top:0;flex:1 1 auto;text-align:right;white-space:normal;max-width:60%}}
+  /* Split Info Layout: preserve the current styling while reducing card height. */
+  #playing-detail{width:min(780px,calc(100vw - 60px))}
+  #playing-detail .pc-inner{grid-template-columns:126px minmax(235px,1fr) minmax(320px,350px);gap:14px;align-items:stretch;padding:0 14px 0 0;min-height:190px;box-sizing:border-box}
+  #playing-detail .pc-poster-link{width:126px;height:190px;align-self:stretch;border-right:1px solid rgba(255,255,255,.06);border-radius:19px 0 0 19px;box-sizing:border-box}
+  #playing-detail .pc-poster{display:block;width:100%;height:100%;border:0;border-radius:inherit;box-shadow:none;box-sizing:border-box}
+  #playing-detail .pc-body{min-width:0;padding:14px 0;justify-content:flex-start}
+  #playing-detail .pc-title{font-size:18px;line-height:1.15}
+  #playing-detail .pc-overview{margin-top:10px;max-height:7.25em;line-height:1.45;-webkit-line-clamp:5}
+  #playing-detail .pc-close{position:static;width:24px;height:24px;min-width:24px}
+  #playing-detail .pc-stats{min-width:0;display:grid;grid-template-rows:auto auto;align-content:center;gap:9px;padding:14px 6px 14px 14px;border-left:1px solid rgba(255,255,255,.08)}
+  #playing-detail .pc-progress-wrap{margin:0;align-self:start}
+  #playing-detail .pc-progress-labels{position:static;display:flex;align-items:center;justify-content:space-between;min-height:24px;margin-bottom:5px;padding:0;pointer-events:auto;font-size:11px;text-shadow:none}
+  #playing-detail .pc-progress-end{display:flex;align-items:center;justify-content:flex-end;gap:8px;min-width:0}
+  #playing-detail .pc-progress-bg{height:8px}
+  #playing-detail .pc-stats-bottom{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));align-items:start;gap:8px;min-width:0}
+  #playing-detail .pc-info-block{min-height:62px}
+  #playing-detail .pc-rating-stack{display:flex;flex-direction:column;gap:7px;min-width:0}
+  #playing-detail .pc-status-head{display:flex;align-items:center;justify-content:center;gap:7px;min-width:0;padding:2px 2px 0}
+  #playing-detail .pc-status-icon{flex:0 0 auto;margin-top:-1px;color:#22c55e;font-size:21px;line-height:1;font-variation-settings:"FILL" 1,"wght" 650,"GRAD" 0,"opsz" 22;filter:drop-shadow(0 0 6px rgba(34,197,94,.28))}
+  #playing-detail .pc-status{min-width:0;border:0!important;background:transparent!important;text-align:center}
+  @media (max-width:1024px){#playing-detail{width:min(780px,calc(100vw - 40px))}#playing-detail .pc-inner{grid-template-columns:112px minmax(220px,1fr) minmax(230px,250px)}#playing-detail .pc-poster-link{width:112px;height:190px}}
+  @media (max-width:820px){#playing-detail .pc-inner{grid-template-columns:82px minmax(0,1fr) minmax(210px,240px);min-height:0;padding:12px}#playing-detail .pc-poster-link{width:82px;height:123px;grid-row:1 / span 2;align-self:center;border:1px solid rgba(255,255,255,.06);border-radius:11px}#playing-detail .pc-body{padding:4px 0}}
+  @media (max-width:680px){#playing-detail{bottom:max(10px,env(safe-area-inset-bottom));width:calc(100vw - 20px);border-radius:18px}#playing-detail .pc-inner{grid-template-columns:64px minmax(0,1fr);gap:12px;padding:12px}#playing-detail .pc-poster-link{width:64px;height:96px;grid-row:auto;border-radius:10px}#playing-detail .pc-body{padding:2px 0}#playing-detail .pc-title{font-size:15px;line-height:1.15}#playing-detail .pc-title-actions{gap:6px}#playing-detail .pc-nav{padding:2px 4px}#playing-detail .pc-nav-count{min-width:32px;font-size:10px}#playing-detail .pc-nav-btn{width:24px;height:24px}#playing-detail .pc-meta{gap:4px;margin-top:4px}#playing-detail .pc-chip{min-height:21px;font-size:9px;padding:0 7px}#playing-detail .pc-overview{margin-top:6px;max-height:4.35em;font-size:11px;-webkit-line-clamp:3}#playing-detail .pc-overview-more{font-size:9px}#playing-detail .pc-stats{grid-column:1 / -1;grid-template-rows:auto auto;padding:10px 0 0;border-left:0;border-top:1px solid rgba(255,255,255,.08)}#playing-detail .pc-info-block{min-height:58px}}
+  @media (max-width:460px){#playing-detail .pc-stats-bottom{grid-template-columns:1fr}#playing-detail .pc-overview{-webkit-line-clamp:1;max-height:1.5em}}
   @media (hover:none){#playing-detail.show:hover{transform:translate(-50%,0);box-shadow:0 20px 48px rgba(0,0,0,.6)}}
   `;
 
@@ -425,7 +447,9 @@
   detail.setAttribute("aria-live", "polite");
   detail.innerHTML = `
     <div class="pc-inner">
-      <img id="pc-poster" class="pc-poster" src="/assets/img/placeholder_poster.svg" alt="">
+      <a id="pc-poster-link" class="pc-poster-link" target="_blank" rel="noopener noreferrer">
+        <img id="pc-poster" class="pc-poster" src="/assets/img/placeholder_poster.svg" alt="">
+      </a>
       <div class="pc-body">
         <div class="pc-title-row">
           <div id="pc-title" class="pc-title">Now Playing</div>
@@ -438,23 +462,36 @@
           </div>
         </div>
         <div id="pc-meta" class="pc-meta"></div>
-        <div id="pc-overview" class="pc-overview"></div>
-        <div class="pc-progress-wrap">
-          <div class="pc-progress-bg"><div id="pc-progress" class="pc-progress"></div></div>
-          <div class="pc-progress-labels"><span id="pc-progress-pct"></span><span id="pc-progress-time"></span></div>
+        <div id="pc-overview-wrap" class="pc-overview-wrap">
+          <div id="pc-overview" class="pc-overview"></div>
+          <button id="pc-overview-more" class="pc-overview-more" type="button" aria-expanded="false" hidden>More</button>
         </div>
       </div>
-      <div class="pc-right">
-        <div class="pc-right-top">
-          <button id="pc-close" class="pc-close" title="Hide">
-            <span class="material-symbols-rounded" aria-hidden="true">close</span><span class="pc-close-text">Hide</span>
-          </button>
-          <div id="pc-score-circle" class="pc-score-circle is-empty"><span id="pc-score">--</span></div>
+      <div class="pc-stats">
+        <div class="pc-progress-wrap">
+          <div class="pc-progress-labels">
+            <span id="pc-progress-pct"></span>
+            <span class="pc-progress-end">
+              <span id="pc-progress-time"></span>
+              <button id="pc-close" class="pc-close" type="button" title="Hide" aria-label="Hide Playing card"><span class="material-symbols-rounded" aria-hidden="true">close</span></button>
+            </span>
+          </div>
+          <div class="pc-progress-bg"><div id="pc-progress" class="pc-progress"></div></div>
         </div>
-        <div class="pc-score-label">User Score</div>
-        <a id="pc-tmdb" class="pc-link" href="#" target="_blank" rel="noopener noreferrer"></a>
-        <a id="pc-imdb" class="pc-link" href="#" target="_blank" rel="noopener noreferrer"></a>
-        <div id="pc-status" class="pc-status">Now Playing</div>
+        <div class="pc-stats-bottom">
+          <div id="pc-information-block" class="pc-info-block pc-information-block">
+            <div class="pc-info-label">Information</div>
+            <div id="pc-information-rows" class="pc-information-rows"></div>
+          </div>
+          <div class="pc-rating-stack">
+            <div id="pc-rating-block" class="pc-info-block pc-rating-block">
+              <div class="pc-info-label">TMDB Rating</div>
+              <div class="pc-info-value"><span class="material-symbols-rounded pc-info-icon" aria-hidden="true">star</span><span id="pc-rating">--</span></div>
+              <div id="pc-rating-votes" class="pc-info-note">Rating unavailable</div>
+            </div>
+            <div class="pc-status-head"><span id="pc-status-icon" class="material-symbols-rounded pc-status-icon" aria-hidden="true">play_arrow</span><div id="pc-status" class="pc-status">Now Playing</div></div>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -462,17 +499,22 @@
   document.body.appendChild(detail);
 
   const posterEl = detail.querySelector("#pc-poster");
+  const posterLinkEl = detail.querySelector("#pc-poster-link");
   const titleEl = detail.querySelector("#pc-title");
   const metaEl = detail.querySelector("#pc-meta");
   const overviewEl = detail.querySelector("#pc-overview");
+  const overviewWrapEl = detail.querySelector("#pc-overview-wrap");
+  const overviewMoreBtn = detail.querySelector("#pc-overview-more");
   const progEl = detail.querySelector("#pc-progress");
   const progPctEl = detail.querySelector("#pc-progress-pct");
   const progTimeEl = detail.querySelector("#pc-progress-time");
-  const scoreCircleEl = detail.querySelector("#pc-score-circle");
-  const scoreEl = detail.querySelector("#pc-score");
-  const tmdbEl = detail.querySelector("#pc-tmdb");
-  const imdbEl = detail.querySelector("#pc-imdb");
+  const informationBlockEl = detail.querySelector("#pc-information-block");
+  const informationRowsEl = detail.querySelector("#pc-information-rows");
+  const ratingBlockEl = detail.querySelector("#pc-rating-block");
+  const ratingEl = detail.querySelector("#pc-rating");
+  const ratingVotesEl = detail.querySelector("#pc-rating-votes");
   const statusEl = detail.querySelector("#pc-status");
+  const statusIconEl = detail.querySelector("#pc-status-icon");
   const closeBtn = detail.querySelector("#pc-close");
   const navWrap = detail.querySelector("#pc-nav");
   const prevBtn = detail.querySelector("#pc-prev");
@@ -484,11 +526,42 @@
     posterEl.src = "/assets/img/placeholder_poster.svg";
   };
 
+  let overviewMeasureFrame = 0;
+  const updateOverviewMore = () => {
+    if (overviewMeasureFrame) cancelAnimationFrame(overviewMeasureFrame);
+    overviewMeasureFrame = requestAnimationFrame(() => {
+      overviewMeasureFrame = 0;
+      if (overviewWrapEl.classList.contains("is-expanded")) return;
+      const hasOverflow = !!overviewEl.textContent.trim() && overviewEl.scrollHeight > overviewEl.clientHeight + 1;
+      overviewWrapEl.classList.toggle("has-overflow", hasOverflow);
+      overviewMoreBtn.hidden = !hasOverflow;
+    });
+  };
+
+  const setOverview = (value) => {
+    overviewWrapEl.classList.remove("is-expanded");
+    overviewEl.scrollTop = 0;
+    overviewEl.textContent = String(value || "");
+    overviewMoreBtn.textContent = "More";
+    overviewMoreBtn.setAttribute("aria-expanded", "false");
+    overviewMoreBtn.hidden = true;
+    updateOverviewMore();
+  };
+
+  overviewMoreBtn.addEventListener("click", () => {
+    const expanded = overviewWrapEl.classList.toggle("is-expanded");
+    overviewEl.scrollTop = 0;
+    overviewMoreBtn.textContent = expanded ? "Less" : "More";
+    overviewMoreBtn.setAttribute("aria-expanded", expanded ? "true" : "false");
+    if (!expanded) updateOverviewMore();
+  });
+
   const CARD = {
     selectedKey: "",
     streams: [],
     dismissed: false,
     poll: null,
+    tick: null,
     cacheBusy: null,
     cacheAt: 0,
     cachePayload: null,
@@ -496,9 +569,10 @@
   };
 
   const stopStatusPoll = () => {
-    if (!CARD.poll) return;
-    try { clearInterval(CARD.poll); } catch {}
+    try { if (CARD.poll) clearInterval(CARD.poll); } catch {}
+    try { if (CARD.tick) clearInterval(CARD.tick); } catch {}
     CARD.poll = null;
+    CARD.tick = null;
   };
   const hide = (resetSelection = false) => {
     detail.classList.remove("show");
@@ -536,33 +610,124 @@
     if (releaseLabel && releaseLabel !== yearLabel) addChip(releaseLabel);
   };
 
-  const setScoreState = (score100) => {
-    if (score100 != null) {
-      const value = Math.max(0, Math.min(100, Math.round(score100)));
-      const deg = value * 3.6;
-      const color = value <= 49 ? "#ef4444" : value <= 74 ? "#f59e0b" : "#22c55e";
-      scoreEl.textContent = `${value}%`;
-      scoreCircleEl.classList.remove("is-empty");
-      scoreCircleEl.style.setProperty("--pc-score-deg", `${deg}deg`);
-      scoreCircleEl.style.setProperty("--pc-score-color", color);
-      return;
-    }
-    scoreEl.textContent = "--";
-    scoreCircleEl.classList.add("is-empty");
-    scoreCircleEl.style.setProperty("--pc-score-deg", "0deg");
-    scoreCircleEl.style.setProperty("--pc-score-color", "#374151");
+  const formatDateLabel = (raw) => {
+    const value = String(raw || "").trim().split("T")[0];
+    const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!match) return value;
+    const date = new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])));
+    return date.toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric", timeZone: "UTC" });
   };
 
-  const setLinkState = (el, href, shortLabel, longLabel) => {
-    if (!href) {
-      el.style.display = "none";
-      el.textContent = "";
-      el.removeAttribute("href");
+  const informationRow = (icon, main, sub = "") => {
+    const row = document.createElement("div");
+    row.className = "pc-information-row";
+    const iconEl = document.createElement("span");
+    iconEl.className = "material-symbols-rounded pc-information-row-icon";
+    iconEl.setAttribute("aria-hidden", "true");
+    iconEl.textContent = icon;
+    const copy = document.createElement("span");
+    copy.className = "pc-information-copy";
+    const mainEl = document.createElement("span");
+    mainEl.className = "pc-information-main";
+    mainEl.textContent = main;
+    mainEl.title = main;
+    copy.appendChild(mainEl);
+    if (sub) {
+      const subEl = document.createElement("span");
+      subEl.className = "pc-information-sub";
+      subEl.textContent = sub;
+      copy.appendChild(subEl);
+    }
+    row.append(iconEl, copy);
+    return row;
+  };
+
+  const genreLabel = (meta, det) => {
+    const raw = meta?.genres || det?.genres || [];
+    return (Array.isArray(raw) ? raw : [])
+      .map((genre) => typeof genre === "string" ? genre : genre?.name)
+      .map((genre) => String(genre || "").trim())
+      .filter(Boolean)
+      .join(", ") || "Genres unavailable";
+  };
+
+  const nextEpisodeLabels = (nextEpisode) => {
+    if (!nextEpisode || typeof nextEpisode !== "object") return ["No upcoming episode", ""];
+    const season = Number(nextEpisode.season_number);
+    const episode = Number(nextEpisode.episode_number);
+    const code = Number.isInteger(season) && Number.isInteger(episode)
+      ? `S${String(season).padStart(2, "0")}E${String(episode).padStart(2, "0")}`
+      : "Next episode";
+    const airDate = String(nextEpisode.air_date || "").trim();
+    let timing = "";
+    const match = airDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (match) {
+      const target = Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+      const now = new Date();
+      const today = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+      const days = Math.round((target - today) / 86400000);
+      timing = days === 0 ? "Airs today" : days === 1 ? "Airs tomorrow" : days > 1 ? `Airs in ${days} days` : "Previously aired";
+    }
+    return [[code, timing].filter(Boolean).join(" · "), formatDateLabel(airDate)];
+  };
+
+  const renderInformation = (p, meta, det, runtimeMin, releaseRaw) => {
+    const isMovie = String(p?.media_type || p?.type || "").toLowerCase() === "movie";
+    informationBlockEl.classList.toggle("is-series", !isMovie);
+    informationRowsEl.replaceChildren();
+    informationRowsEl.appendChild(informationRow("sell", genreLabel(meta, det)));
+    if (isMovie) {
+      informationRowsEl.appendChild(informationRow("calendar_month", formatDateLabel(releaseRaw) || "Release date unavailable"));
+      informationRowsEl.appendChild(informationRow("schedule", runtimeLabel(runtimeMin) || "Runtime unavailable"));
       return;
     }
-    el.href = href;
-    el.textContent = isSmallScreen() ? shortLabel : longLabel;
-    el.style.display = "";
+
+    informationRowsEl.appendChild(informationRow("tv", String(det?.status || "Status unavailable")));
+    const seasons = Number(det?.number_of_seasons);
+    const episodes = Number(det?.number_of_episodes);
+    const totals = [
+      Number.isFinite(seasons) && seasons > 0 ? `${seasons} Season${seasons === 1 ? "" : "s"}` : "",
+      Number.isFinite(episodes) && episodes > 0 ? `${episodes} Episode${episodes === 1 ? "" : "s"}` : "",
+    ].filter(Boolean).join(" · ") || "Series totals unavailable";
+    informationRowsEl.appendChild(informationRow("layers", totals));
+    const [nextMain, nextSub] = nextEpisodeLabels(det?.next_episode_to_air);
+    informationRowsEl.appendChild(informationRow("arrow_forward", nextMain, nextSub));
+  };
+
+  const setInformationLoading = (p) => {
+    const isMovie = String(p?.media_type || p?.type || "").toLowerCase() === "movie";
+    informationBlockEl.classList.toggle("is-series", !isMovie);
+    informationRowsEl.replaceChildren(informationRow("hourglass_empty", "Loading information..."));
+  };
+
+  const setRatingState = (rawRating, rawVoteCount) => {
+    const rating = Number(rawRating);
+    const available = Number.isFinite(rating) && rating >= 1 && rating <= 10;
+    ratingBlockEl.classList.toggle("rating-low", available && rating < 5);
+    ratingBlockEl.classList.toggle("rating-mid", available && rating >= 5 && rating < 7);
+    ratingBlockEl.classList.toggle("rating-high", available && rating >= 7);
+    ratingEl.textContent = available ? rating.toFixed(1) : "--";
+
+    const votes = Number(rawVoteCount);
+    ratingVotesEl.textContent = !available
+      ? "Rating unavailable"
+      : Number.isFinite(votes) && votes > 0
+        ? `${votes.toLocaleString(undefined, { notation: "compact", maximumFractionDigits: 1 })} votes`
+        : "0 votes";
+  };
+
+  const setPosterLink = (href, title = "") => {
+    if (!href) {
+      posterLinkEl.removeAttribute("href");
+      posterLinkEl.removeAttribute("aria-label");
+      posterLinkEl.removeAttribute("title");
+      posterLinkEl.setAttribute("aria-disabled", "true");
+      return;
+    }
+    posterLinkEl.href = href;
+    posterLinkEl.setAttribute("aria-label", `Open ${title || "title"} on TMDb`);
+    posterLinkEl.title = `Open ${title || "title"} on TMDb`;
+    posterLinkEl.removeAttribute("aria-disabled");
   };
 
   const applyMeta = (p, meta) => {
@@ -593,23 +758,34 @@
     }
     if (!p?.overview) {
       const ov = meta.overview || det.overview || det.tagline;
-      if (ov) overviewEl.textContent = ov;
+      if (ov) setOverview(ov);
     }
     const rawScore = Number(meta.score ?? meta.vote_average);
-    setScoreState(Number.isFinite(rawScore) ? rawScore : null);
+    const rawRating = Number(meta.vote_average ?? det.vote_average);
+    const rating = Number.isFinite(rawRating)
+      ? rawRating
+      : Number.isFinite(rawScore) ? rawScore / 10 : null;
+    setRatingState(rating, meta.vote_count ?? det.vote_count);
+    renderInformation(p, meta, det, runtimeMin, releaseLabel || releaseRaw);
     const tmdbUrl = buildTmdbUrl(Object.assign({}, p, { tmdb: tmdbIdOf(p) || (meta.ids && (meta.ids.tmdb || meta.ids.id)) }));
-    setLinkState(tmdbEl, tmdbUrl, "TMDb", "View on TMDb");
-    const imdbUrl = buildImdbUrl(p, meta);
-    setLinkState(imdbEl, imdbUrl, "IMDb", "View on IMDb");
+    setPosterLink(tmdbUrl, p?.title);
     detail.style.setProperty("--pc-backdrop", backdrop ? `url("${backdrop}")` : "none");
   };
 
   const startStatusPoll = () => {
-    if (CARD.poll) return;
-    CARD.poll = setInterval(() => {
-      if (!detail.classList.contains("show") || document.hidden) return;
-      refreshCard(CARD.selectedKey, false).catch(() => {});
-    }, 15000);
+    if (!CARD.poll) {
+      CARD.poll = setInterval(() => {
+        if (!detail.classList.contains("show") || document.hidden) return;
+        refreshCard(CARD.selectedKey, false).catch(() => {});
+      }, 15000);
+    }
+    if (!CARD.tick) {
+      CARD.tick = setInterval(() => {
+        if (!detail.classList.contains("show") || document.hidden) return;
+        const item = selectedStream();
+        if (item) renderProgress(item);
+      }, 1000);
+    }
   };
   closeBtn.addEventListener("click", () => {
     CARD.dismissed = true;
@@ -645,6 +821,19 @@
   prevBtn?.addEventListener("click", () => applySelectionOffset(-1), true);
   nextBtn?.addEventListener("click", () => applySelectionOffset(1), true);
 
+  const renderProgress = (p) => {
+    const pct = visualProgress(p);
+    progEl.style.width = `${pct}%`;
+    progPctEl.textContent = `${Math.round(pct)}% watched`;
+    let timeLabel = "";
+    const totalMs = Number(p?.duration_ms) || 0;
+    if (totalMs > 0) {
+      const remainingStr = formatTime(Math.max(0, totalMs - totalMs * (pct / 100)));
+      if (remainingStr) timeLabel = `${remainingStr} left`;
+    }
+    progTimeEl.textContent = timeLabel;
+  };
+
   async function renderSelectedStream() {
     const p = selectedStream();
     if (!p) {
@@ -662,44 +851,39 @@
     const updatedSec = Number(p.updated) || 0;
     if (updatedSec) {
       const ageMs = Date.now() - updatedSec * 1000;
-      const maxAgeMs = st === "paused" ? 4 * 60 * 60 * 1000 : 10 * 60 * 1000;
+      const totalMs = Number(p.duration_ms) || 0;
+      const baseProgress = Math.max(0, Math.min(100, Number(p.progress) || 0));
+      const expectedRemainingMs = totalMs > 0 ? totalMs * (100 - baseProgress) / 100 : 0;
+      const maxAgeMs = st === "paused"
+        ? 4 * 60 * 60 * 1000
+        : st === "playing" && expectedRemainingMs > 0
+          ? Math.max(10 * 60 * 1000, expectedRemainingMs + 10 * 60 * 1000)
+          : 10 * 60 * 1000;
       if (ageMs > maxAgeMs) {
         hide(true);
         return;
       }
     }
 
-    const pct = Math.round(Math.max(0, Math.min(100, Number(p.progress) || 0)));
     const startedSec = Number(p.started) || 0;
     const serverTs = Number(p._server_ts) || CARD.serverTs || 0;
     if (serverTs) CARD.serverTs = serverTs;
     const nowSec = serverTs || Math.floor(Date.now() / 1000);
-    const since = startedSec ? sinceLabel(nowSec, startedSec) : "";
+    const since = updatedSec ? sinceLabel(nowSec, updatedSec) : startedSec ? sinceLabel(nowSec, startedSec) : "";
 
     statusEl.textContent = statusText(st, since);
+    statusIconEl.textContent = st === "paused" ? "pause" : "play_arrow";
     statusEl.title = `source=${p.source || ""}, instance=${p.provider_instance || ""}, state=${state || ""}, started=${startedSec || ""}, updated=${updatedSec || ""}`;
 
     titleEl.textContent = p.year ? `${p.title} ${p.year}` : (p.title || "Now Playing");
-    overviewEl.textContent = p.overview || "";
+    setOverview(p.overview || "");
     renderBaseMeta(p);
     posterEl.src = buildArtUrl(p);
     posterEl.alt = p.title || "Poster";
-    progEl.style.width = `${pct}%`;
-
-    let timeLabel = "";
-    if (p.duration_ms && pct > 0) {
-      const totalMs = Number(p.duration_ms) || 0;
-      if (totalMs > 0) {
-        const remainingMs = Math.max(0, totalMs - totalMs * (pct / 100));
-        const remainingStr = formatTime(remainingMs);
-        if (remainingStr) timeLabel = `${remainingStr} left`;
-      }
-    }
-    progPctEl.textContent = `${pct}% watched`;
-    progTimeEl.textContent = timeLabel;
-    setScoreState(null);
-    setLinkState(tmdbEl, "", "TMDb", "View on TMDb");
-    setLinkState(imdbEl, "", "IMDb", "View on IMDb");
+    setPosterLink(buildTmdbUrl(p), p.title);
+    renderProgress(p);
+    setInformationLoading(p);
+    setRatingState(null, null);
     detail.style.setProperty("--pc-backdrop", "none");
     updateNav();
     detail.classList.add("show");

--- a/assets/js/schedulerbanner.js
+++ b/assets/js/schedulerbanner.js
@@ -1,5 +1,4 @@
 /* assets/js/schedulerbanner.js */
-/* refactored */
 /* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
 (()=>{
   if (window.__SCHED_BANNER_INIT__) return;
@@ -20,10 +19,10 @@
       .filter(r=>r&&typeof r==="object"&&r.active!==false&&String(r?.provider||"").trim()&&String(r?.feature||"").trim()&&String(r?.at||"").trim()).length,
     activeEventRules=c=>(((c?.scheduling||c||{})?.advanced?.event_rules)||((c?.scheduling||c||{})?.advanced?.eventRules)||[])
       .filter(r=>r&&typeof r==="object"&&r.active!==false&&String(r?.action?.kind||"sync_pair")==="sync_pair"&&String(r?.action?.pair_id||r?.action?.pairId||r?.pair_id||"").trim()&&String(r?.filters?.route_id||r?.filters?.routeId||"").trim()).length,
-    chipText={pairs:"Sync pairs",sched:"Scheduler",watch:"Watcher",hook:"Webhook",providers:"Provider connections",update:"Updates"},
-    chipIcon={pairs:"sync_alt",sched:"calendar_month",watch:"visibility",hook:"webhook",providers:"shield",update:"notifications"},
-    chipNav={pairs:{target:"pairs",label:"Open sync pair settings"},sched:{target:"scheduling",label:"Open scheduler settings"},watch:{target:"watcher",label:"Open watcher settings"},hook:{target:"webhook",label:"Open webhook settings"},providers:{target:"refresh-providers",label:"Re-check provider connections"},update:{target:"refresh-update",label:"Re-check for updates"}},
-    S={cfg:null,pairs:{total:0,active:0},sched:{enabled:false,running:false,next:0,advanced:false,captures:0},evt:{enabled:false,count:0},watch:{...blank(),alive:false},hook:blank(),system:{providers:{total:0,connected:0,missing:[],known:false},update:{known:false,available:false,current:"",latest:"",url:""}},timers:{sched:null,scrob:null,wait:null,rotate:null},debounce:null,last:{watcher:"",webhook:""}};
+    chipText={pairs:"Sync pairs",sched:"Scheduler",watch:"Watcher",hook:"Webhook",health:"CrossWatch health",update:"Updates"},
+    chipIcon={pairs:"sync_alt",sched:"calendar_month",watch:"visibility",hook:"webhook",health:"arrow_upward",update:"notifications"},
+    chipNav={pairs:{target:"pairs",label:"Open sync pair settings"},sched:{target:"scheduling",label:"Open scheduler settings"},watch:{target:"watcher",label:"Open watcher settings"},hook:{target:"webhook",label:"Open webhook settings"},health:{target:"maintenance",label:"Open Maintenance tools"},update:{target:"refresh-update",label:"Re-check for updates"}},
+    S={cfg:null,pairs:{total:0,active:0},sched:{enabled:false,running:false,next:0,advanced:false,captures:0},evt:{enabled:false,count:0},watch:{...blank(),alive:false},hook:blank(),system:{health:{known:false,ok:false,status:"checking"},update:{known:false,available:false,current:"",latest:"",url:""}},timers:{sched:null,scrob:null,health:null,wait:null,rotate:null},debounce:null,last:{watcher:"",webhook:""}};
   const SHARED_WATCH_KEY="__CW_CURRENT_WATCHING_SHARED__",SHARED_WATCH_TTL_MS=3000,WATCHER_UNAVAILABLE_GRACE_MS=35000;
   let scrobPollSeq=0;
 
@@ -90,10 +89,22 @@
 #ops-card #sched-inline-log .hub-status-group:first-child .sched:first-child[data-tip]:hover::after,#ops-card #sched-inline-log .hub-status-group:first-child .sched:first-child[data-tip]:focus-visible::after{transform:translateX(0) translateY(0)!important;}
 #ops-card #sched-inline-log .hub-group-system .sched:last-child[data-tip]::after{left:auto!important;right:0!important;transform:translateX(0) translateY(4px)!important;}
 #ops-card #sched-inline-log .hub-group-system .sched:last-child[data-tip]:hover::after,#ops-card #sched-inline-log .hub-group-system .sched:last-child[data-tip]:focus-visible::after{transform:translateX(0) translateY(0)!important;}
+#ops-card #sched-inline-log .sched[data-tip]::after{display:none!important;}
+#ops-card #sched-inline-log .cw-hub-tip{position:absolute;z-index:40;left:50%;bottom:calc(100% + 11px);display:grid;gap:2px;min-width:210px;max-width:min(310px,80vw);padding:10px 12px;border-radius:10px;background:var(--hub-card-bg);border:1px solid color-mix(in srgb,var(--service-state) 34%,var(--hub-card-border));box-shadow:0 14px 32px rgba(0,0,0,.34);color:var(--hub-text);font-size:11px;line-height:1.5;letter-spacing:.01em;text-align:left;white-space:nowrap;opacity:0;pointer-events:none;transform:translateX(-50%) translateY(4px);transition:opacity .16s ease,transform .16s ease;}
+#ops-card #sched-inline-log .sched[data-tip]:hover>.cw-hub-tip,#ops-card #sched-inline-log .sched[data-tip]:focus-visible>.cw-hub-tip{opacity:1;transform:translateX(-50%) translateY(0);}
+#ops-card #sched-inline-log .cw-hub-tip-line{display:block;font-weight:750;overflow:hidden;text-overflow:ellipsis;}
+#ops-card #sched-inline-log .cw-hub-tip-action{display:block;margin-top:5px;padding-top:6px;border-top:1px solid color-mix(in srgb,var(--hub-muted) 24%,transparent);color:color-mix(in srgb,var(--service-state) 72%,var(--hub-text));font-weight:500;}
+#ops-card #sched-inline-log .hub-status-group:first-child .sched:first-child .cw-hub-tip{left:0;transform:translateX(0) translateY(4px);}
+#ops-card #sched-inline-log .hub-status-group:first-child .sched:first-child[data-tip]:hover>.cw-hub-tip,#ops-card #sched-inline-log .hub-status-group:first-child .sched:first-child[data-tip]:focus-visible>.cw-hub-tip{transform:translateX(0) translateY(0);}
+#ops-card #sched-inline-log .hub-group-system .sched:last-child .cw-hub-tip{left:auto;right:0;transform:translateX(0) translateY(4px);}
+#ops-card #sched-inline-log .hub-group-system .sched:last-child[data-tip]:hover>.cw-hub-tip,#ops-card #sched-inline-log .hub-group-system .sched:last-child[data-tip]:focus-visible>.cw-hub-tip{transform:translateX(0) translateY(0);}
 html[data-cw-theme="flat-dark"] #ops-card .action-row{--hub-service-good:#57b58a;--hub-service-bad:#d86672;--hub-service-disabled:#7c8491;--hub-action-bg:#20242d;--hub-action-hover:#272c36;--hub-card-bg:#20242d;--hub-card-border:rgba(255,255,255,.13);--hub-text:#eef1f6;--hub-muted:#a9b0bd;}
 html[data-cw-theme="flat-light"] #ops-card .action-row{--hub-service-good:#276348;--hub-service-bad:#a93f4d;--hub-service-disabled:#98a2b3;--hub-action-bg:#fff;--hub-action-hover:#eef2f7;--hub-card-bg:#fff;--hub-card-border:rgba(16,24,40,.16);--hub-text:#172033;--hub-muted:#667085;}
 html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-service-bad:#e06470;--hub-service-disabled:#77808f;--hub-action-bg:rgba(255,255,255,.035);--hub-action-hover:rgba(255,255,255,.065);--hub-card-bg:linear-gradient(180deg,rgba(20,24,34,.96),rgba(12,15,23,.98));--hub-card-border:rgba(255,255,255,.09);--hub-text:#eef3ff;--hub-muted:rgba(188,198,217,.68);}
+#ops-card #sched-inline-log #chip-update.update-available::after{content:"";position:absolute;z-index:0;inset:0;border-radius:inherit;background:color-mix(in srgb,var(--hub-service-good) 22%,transparent);opacity:0;pointer-events:none;animation:cwHubUpdateBlink 2.8s ease-in-out infinite;}
+@keyframes cwHubUpdateBlink{0%,100%{opacity:0}50%{opacity:1}}
 @keyframes cwHubSyncSpin{to{transform:rotate(360deg)}}
+@media(prefers-reduced-motion:reduce){#ops-card #sched-inline-log #chip-update.update-available::after{animation:none;opacity:.7;}}
 @media(max-width:760px){#ops-card .action-buttons{width:100%!important;}#ops-card .action-buttons>.cw-split-run,#ops-card .action-buttons>.cw-hub-action{flex:1 1 150px!important;}#sched-inline-log{flex-wrap:wrap!important;}#ops-card #sched-inline-log .hub-group-system{margin-left:0;}}
 @media(max-width:480px){#ops-card .action-buttons>.cw-split-run,#ops-card .action-buttons>.cw-hub-action{flex:1 1 100%!important;}#ops-card #sched-inline-log .sched[data-tip]::after{left:0!important;transform:translateX(0) translateY(4px)!important;}#ops-card #sched-inline-log .sched[data-tip]:hover::after,#ops-card #sched-inline-log .sched[data-tip]:focus-visible::after{transform:translateX(0) translateY(0)!important;}}
 `;
@@ -109,7 +120,7 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
   })();
 
   function activateStatusTarget(target){
-    if (target==="refresh-providers") return document.getElementById("btn-status-refresh")?.click();
+    if (target==="maintenance") return window.openMaintenanceModal?.();
     if (target==="refresh-update") return CW().checkForUpdate?.();
     window.showTab?.("settings");
     setTimeout(()=>{
@@ -136,13 +147,13 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
     if (!wrap) {
       wrap=document.createElement("div");
       wrap.id="sched-inline-log";
-      const statusTile=k=>{const nav=chipNav[k];return `<div class="sched idle${["sched","watch","hook"].includes(k)?" has-copy":""}" id="chip-${k}" role="${nav?"button":"status"}" tabindex="0"${nav?` data-nav="${nav.target}" data-nav-label="${nav.label}"`:""}><span class="ic service-icon material-symbols-rounded" aria-hidden="true">${chipIcon[k]}</span><span class="copy"><span class="label">${chipText[k]}</span><span class="value" id="${k}-value">-</span><span class="meta" id="${k}-meta"></span><span class="badges" id="${k}-badges"></span></span>${["watch","hook"].includes(k)?`<span class="watch-progress" aria-hidden="true"><span class="watch-progress-value" id="${k}-progress-value"></span></span>`:""}</div>`};
+      const statusTile=k=>{const nav=chipNav[k];return `<div class="sched idle${["sched","watch","hook"].includes(k)?" has-copy":""}" id="chip-${k}" role="${nav?"button":"status"}" tabindex="0"${nav?` data-nav="${nav.target}" data-nav-label="${nav.label}"`:""}><span class="ic service-icon material-symbols-rounded" aria-hidden="true">${chipIcon[k]}</span><span class="copy"><span class="label">${chipText[k]}</span><span class="value" id="${k}-value">-</span><span class="meta" id="${k}-meta"></span><span class="badges" id="${k}-badges"></span></span>${["watch","hook"].includes(k)?`<span class="watch-progress" aria-hidden="true"><span class="watch-progress-value" id="${k}-progress-value"></span></span>`:""}<span class="cw-hub-tip" aria-hidden="true"></span></div>`};
       wrap.innerHTML=`
         <div class="hub-status-group hub-group-monitoring">
           <div class="hub-group-items">${["sched","watch","hook"].map(statusTile).join("")}</div>
         </div>
         <div class="hub-status-group hub-group-system">
-          <div class="hub-group-items">${["pairs","providers","update"].map(statusTile).join("")}</div>
+          <div class="hub-group-items">${["pairs","health","update"].map(statusTile).join("")}</div>
         </div>`;
       host.appendChild(wrap);
     }
@@ -185,17 +196,31 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
     if (!raw || raw.toLowerCase()==="default") return "Default";
     return raw;
   };
+  const streamTitle=(item)=>{
+    const title=String(item?.title||"").trim()||"Untitled";
+    const season=item?.season==null||item.season===""?null:Number(item.season);
+    const episode=item?.episode==null||item.episode===""?null:Number(item.episode);
+    if (!Number.isInteger(season)||season<0||!Number.isInteger(episode)||episode<0) return title;
+    return `${title} - S${String(season).padStart(2,"0")}E${String(episode).padStart(2,"0")}`;
+  };
+  const visualProgress=(item,nowMs=Date.now())=>{
+    const base=Math.max(0,Math.min(100,Number(item?.progress)||0));
+    if (String(item?.state||"").toLowerCase()!=="playing") return base;
+    const durationMs=Number(item?.duration_ms)||0,updatedSec=Number(item?.updated)||0;
+    if (!(durationMs>0)||!(updatedSec>0)) return base;
+    const serverTs=Number(item?._server_ts)||0,receivedAt=Number(item?._received_at_ms)||0;
+    const nowSec=serverTs&&receivedAt?serverTs+Math.max(0,nowMs-receivedAt)/1000:nowMs/1000;
+    return Math.max(base,Math.min(100,base+(Math.max(0,nowSec-updatedSec)*100000/durationMs)));
+  };
   const streamSummary=(item)=>{
     if (!item || typeof item!=="object") return "";
     const src=sourceLabel(item.source);
     const inst=instanceLabel(item.provider_instance);
-    const title=String(item.title||"").trim() || "Untitled";
-    const pct=Number(item.progress);
-    const bits=[src];
-    if (inst) bits.push(inst);
-    bits.push(title);
-    if (Number.isFinite(pct)) bits.push(`${Math.round(pct)}%`);
-    return bits.join(" • ");
+    const title=streamTitle(item);
+    const pct=visualProgress(item);
+    const sourceLine=[src,inst].filter(Boolean).join(" \u2022 ");
+    const mediaLine=[title,Number.isFinite(pct)?`${Math.round(pct)}%`:""].filter(Boolean).join(" \u2022 ");
+    return [sourceLine,mediaLine].filter(Boolean).join("\n");
   };
   const currentItem=(bucket)=>{
     const items=Array.isArray(bucket?.items)?bucket.items:[];
@@ -208,6 +233,23 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
     return source.includes("webhook")||["plextrakt","embytrakt","jellyfintrakt"].includes(source);
   };
   const tooltipFor=(label,items)=>[label,...(Array.isArray(items)?items.map(streamSummary).filter(Boolean):[])].join("\n");
+
+  const renderTip=(el,tip,action)=>{
+    if (!el?.tip) return;
+    el.tip.replaceChildren();
+    String(tip||"").split("\n").map(line=>line.trim()).filter(Boolean).forEach(line=>{
+      const row=document.createElement("span");
+      row.className="cw-hub-tip-line";
+      row.textContent=line;
+      el.tip.appendChild(row);
+    });
+    if (action) {
+      const row=document.createElement("span");
+      row.className="cw-hub-tip-action";
+      row.textContent=action;
+      el.tip.appendChild(row);
+    }
+  };
 
   function emit(source,detail){
     const payload={source,...detail}, key=JSON.stringify(payload);
@@ -231,6 +273,7 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
         el.badges.innerHTML="";
         el.badges.style.display="none";
       }
+      el.tip?.replaceChildren();
       return el.chip.removeAttribute("data-tip"), el.chip.removeAttribute("title");
     }
     const healthy=!!ok&&!idle;
@@ -255,16 +298,18 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
       el.badges.style.display=badgeHtml?"inline-flex":"none";
     }
     tip=String(tip||"").trim().replace(/\s*\u2022\s*/,"\n");
-    tip=[tip,el.chip.dataset.navLabel||""].filter(Boolean).join("\n");
+    const action=el.chip.dataset.navLabel||"";
+    const aria=[tip,action].filter(Boolean).join("\n");
+    renderTip(el,tip,action);
     el.chip.removeAttribute("title");
-    tip?(el.chip.dataset.tip=tip,el.chip.setAttribute("aria-label",tip)):(el.chip.removeAttribute("data-tip"),el.chip.removeAttribute("aria-label"));
+    aria?(el.chip.dataset.tip=aria,el.chip.setAttribute("aria-label",aria)):(el.chip.removeAttribute("data-tip"),el.chip.removeAttribute("aria-label"));
   }
 
   function render(){
     const host=ensureBanner();
     if (!host) return;
-    const E=k=>({chip:$(`#chip-${k}`,host),value:$(`#${k}-value`,host),meta:$(`#${k}-meta`,host),badges:$(`#${k}-badges`,host),progress:["watch","hook"].includes(k)?$(".watch-progress",$(`#chip-${k}`,host)):null,progressValue:["watch","hook"].includes(k)?$(`#${k}-progress-value`,host):null}),
-      pairs=E("pairs"), sched=E("sched"), watch=E("watch"), hook=E("hook"), providers=E("providers"), update=E("update"),
+    const E=k=>{const chip=$(`#chip-${k}`,host);return {chip,icon:$(".service-icon",chip),value:$(`#${k}-value`,host),meta:$(`#${k}-meta`,host),badges:$(`#${k}-badges`,host),tip:$(".cw-hub-tip",chip),progress:["watch","hook"].includes(k)?$(".watch-progress",chip):null,progressValue:["watch","hook"].includes(k)?$(`#${k}-progress-value`,host):null};},
+      pairs=E("pairs"), sched=E("sched"), watch=E("watch"), hook=E("hook"), health=E("health"), update=E("update"),
       watchItem=currentItem(S.watch),
       hookItem=currentItem(S.hook),
       watchLive=!!(watchItem&&S.watch.alive),
@@ -297,9 +342,9 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
       show:false
     }:{
       value:S.watch.alive?"":"unavailable",
-      meta:watchLive?(watchItem.title||"Watching"):"",
+      meta:watchLive?streamTitle(watchItem):"",
       badges:S.watch.streams>1?[S.watch.streams]:[],
-      progress:watchLive?watchItem.progress:null,
+      progress:watchLive?visualProgress(watchItem):null,
       live:watchLive, ok:S.watch.alive, idle:!S.watch.alive,
       tip:watchLive?tooltipFor(`Watcher • ${S.watch.streams} active stream${S.watch.streams===1?"":"s"}`,S.watch.items):`Watcher ${S.watch.alive?"running":"idle"}${S.watch.state?` • state ${S.watch.state}`:""}`
     });
@@ -309,28 +354,26 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
       show:false
     }:{
       value:"",
-      meta:hookLive?(hookItem.title||"Watching"):"",
+      meta:hookLive?streamTitle(hookItem):"",
       badges:S.hook.streams>1?[S.hook.streams]:[],
-      progress:hookLive?hookItem.progress:null,
+      progress:hookLive?visualProgress(hookItem):null,
       live:hookLive, ok:true, idle:false,
       tip:hookLive?tooltipFor(`Webhook • ${S.hook.streams} active stream${S.hook.streams===1?"":"s"}`,S.hook.items):"Webhook listening"
     });
     emit("webhook",hookLive?{title:hookItem.title,progress:Number(hookItem.progress)||0,state:hookItem.state||"playing",_streams_count:S.hook.streams}:{state:"stopped"});
     $(".hub-group-monitoring",host)?.classList.toggle("is-hidden",[sched,watch,hook].every(item=>item.chip?.classList.contains("is-hidden")));
 
-    const providerState=S.system.providers||{}, providerTotal=Number(providerState.total)||0, providerConnected=Number(providerState.connected)||0;
-    paint(providers,!providerState.known?{
+    const healthState=S.system.health||{};
+    if (health.icon) health.icon.textContent=healthState.known&&!healthState.ok?"arrow_downward":"arrow_upward";
+    paint(health,!healthState.known?{
       value:"checking", ok:false, disabled:true,
-      tip:"Provider connections\nStatus: checking"
-    }:providerTotal===0?{
-      value:"none", ok:false, disabled:true,
-      tip:"Provider connections\nStatus: no configured providers"
-    }:providerConnected===providerTotal?{
-      value:"healthy", ok:true,
-      tip:`Provider connections\nStatus: healthy\nConnected: ${providerConnected} of ${providerTotal}`
+      tip:"CrossWatch health\nStatus: checking"
+    }:healthState.ok?{
+      value:"up", ok:true,
+      tip:"CrossWatch health\nStatus: up"
     }:{
-      value:"attention", ok:false, idle:true,
-      tip:["Provider connections","Status: attention required",`Connected: ${providerConnected} of ${providerTotal}`,providerState.missing?.length?`Unavailable: ${providerState.missing.join(", ")}`:""].filter(Boolean).join("\n")
+      value:"down", ok:false,
+      tip:["CrossWatch health","Status: down",healthState.status&&healthState.status!=="down"?`Response: ${healthState.status}`:""].filter(Boolean).join("\n")
     });
 
     const updateState=S.system.update||{};
@@ -338,7 +381,7 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
       value:"checking", ok:false, disabled:true,
       tip:"Updates\nStatus: checking"
     }:updateState.available?{
-      value:"available", ok:false, idle:true,
+      value:"available", ok:false, disabled:true,
       tip:["Update available",updateState.latest?`Latest: ${updateState.latest}`:"",updateState.current?`Installed: ${updateState.current}`:""].filter(Boolean).join("\n")
     }:updateState.ahead?{
       value:"ahead", ok:true,
@@ -350,33 +393,13 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
       value:"current", ok:true,
       tip:["Updates","Status: up to date",updateState.current?`Installed: ${updateState.current}`:""].filter(Boolean).join("\n")
     });
+    update.chip?.classList.toggle("update-available",!!updateState.available);
 
     host.style.display="flex";
   }
 
   async function readConfig(force=false){
     try { return await API()?.Config.load(force)||{}; } catch { return Cache()?.getCfg()||{}; }
-  }
-
-  const providerName=key=>{
-    try { return CW()?.ProviderMeta?.label?.(String(key||"").toLowerCase())||String(key||""); }
-    catch { return String(key||""); }
-  };
-
-  function applyProviderHealth(detail=window.__CW_PROVIDER_STATUS__){
-    if (!detail||typeof detail!=="object") return;
-    const status=detail.providers&&typeof detail.providers==="object"?detail.providers:{};
-    const statusKeys=new Set(Object.keys(status).map(key=>String(key||"").toUpperCase()));
-    const providerList=Array.isArray(window.cx?.providers)?window.cx.providers:[];
-    const hasConfiguredFlag=providerList.some(item=>typeof item?.configured==="boolean");
-    const fromList=hasConfiguredFlag?providerList
-      .filter(item=>item?.configured!==false&&item?.enabled!==false)
-      .map(item=>String(item?.key||item?.name||item?.label||"").trim().toUpperCase())
-      .filter(key=>key&&statusKeys.has(key)):[];
-    const configured=[...new Set(fromList.length?fromList:(Array.isArray(detail.configuredProviders)?detail.configuredProviders:[]).map(key=>String(key||"").trim().toUpperCase()).filter(Boolean))];
-    const infoFor=key=>status[key]??status[key.toLowerCase()]??status[key.toUpperCase()]??{};
-    const missing=configured.filter(key=>!infoFor(key)?.connected).map(providerName);
-    S.system.providers={total:configured.length,connected:configured.length-missing.length,missing,known:true};
   }
 
   function applyUpdateStatus(detail=window.__CW_UPDATE_STATUS__){
@@ -417,6 +440,22 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
       total:list.length,
       active:list.filter(pair=>pair&&pair.enabled!==false).length
     };
+  }
+
+  async function pollHealth(){
+    clear("health");
+    if (document.hidden) return scheduleHealth();
+    try {
+      const response=await fetch("/api/health",{cache:"no-store",headers:{Accept:"application/json"}});
+      const data=await response.json().catch(()=>({}));
+      const status=String(data?.status||"").trim().toLowerCase();
+      const ok=response.ok&&data?.ok===true&&status==="ok";
+      S.system.health={known:true,ok,status:status||response.statusText||"unknown"};
+    } catch {
+      S.system.health={known:true,ok:false,status:"unreachable"};
+    }
+    render();
+    scheduleHealth();
   }
 
   async function pollSched(force=false){
@@ -478,6 +517,8 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
       if (cw&&typeof cw==="object") {
         if (!sharedFresh) window[SHARED_WATCH_KEY]={at:now,payload:cw};
         const all=Array.isArray(cw.streams)?cw.streams.filter(x=>x&&typeof x==="object"):[];
+        const serverTs=Number(cw.ts)||0,receivedAt=Date.now();
+        all.forEach(item=>{if(serverTs)item._server_ts=serverTs;item._received_at_ms=receivedAt;});
         const watchItems=all.filter(it=>!isWebhookStream(it));
         const hookItems=all.filter(isWebhookStream);
         Object.assign(nextWatch,{items:watchItems,streams:watchItems.length,title:String(watchItems[0]?.title||""),state:watchItems[0]?.state||null,index:Math.min(Number(nextWatch.index)||0,Math.max(0,watchItems.length-1))});
@@ -493,9 +534,10 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
     scheduleScrob();
   }
 
-  const scheduleSched=()=>S.sched.enabled&&(S.timers.sched=setTimeout(()=>pollSched(false),30000)),
+  const scheduleHealth=()=>S.timers.health=setTimeout(()=>pollHealth(),30000),
+    scheduleSched=()=>S.sched.enabled&&(S.timers.sched=setTimeout(()=>pollSched(false),30000)),
     scheduleScrob=()=>S.cfg?.scrobble?.enabled&&(S.timers.scrob=setTimeout(()=>pollScrob(false),scrobSources().webhook?5000:15000)),
-    stop=()=>["sched","scrob","rotate"].forEach(clear);
+    stop=()=>["sched","scrob","health","rotate"].forEach(clear);
 
   function scheduleRotate(){
     clear("rotate");
@@ -511,8 +553,7 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
 
   async function refresh(forceCfg=false){
     stop();
-    [S.cfg]=await Promise.all([readConfig(forceCfg),pollPairs(forceCfg)]);
-    applyProviderHealth();
+    [S.cfg]=await Promise.all([readConfig(forceCfg),pollPairs(forceCfg),pollHealth()]);
     applyUpdateStatus();
     if (!schedulingOn(S.cfg?.scheduling) && !S.cfg?.scrobble?.enabled) {
       S.sched={enabled:false,running:false,next:0,advanced:false,captures:0};
@@ -544,7 +585,6 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
     document.addEventListener("config-saved",()=>queueRefresh(true));
     window.addEventListener("cx:pairs:changed",refreshPairs);
     document.addEventListener("cx-state-change",refreshPairs);
-    document.addEventListener("cw-status-updated",event=>{applyProviderHealth(event?.detail);render();});
     document.addEventListener("cw-update-status",event=>{applyUpdateStatus(event?.detail);render();});
     window.addEventListener("auth-changed",()=>queueRefresh(true));
     document.addEventListener("scheduling-status-refresh",()=>pollSched(true));
@@ -552,6 +592,11 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
     document.addEventListener("tab-changed",e=>["main","settings"].includes(e?.detail?.id)&&queueRefresh(false));
     window.addEventListener("focus",()=>queueRefresh(false));
     window.refreshSchedulingBanner=queueRefresh;
+    S.timers.visual=setInterval(()=>{
+      if (document.hidden) return;
+      const items=[currentItem(S.watch),currentItem(S.hook)].filter(Boolean);
+      if (items.some(item=>String(item?.state||"").toLowerCase()==="playing"&&Number(item?.duration_ms)>0)) render();
+    },1000);
   }
 
   document.addEventListener("DOMContentLoaded",()=>{

--- a/providers/metadata/_meta_TMDB.py
+++ b/providers/metadata/_meta_TMDB.py
@@ -462,6 +462,15 @@ class TmdbProvider:
             self._log_exc("TMDb detail fetch failed", e)
             return {}
 
+        vote_count_raw = det.get("vote_count")
+        vote_count = (
+            int(vote_count_raw)
+            if isinstance(vote_count_raw, (int, float))
+            and not isinstance(vote_count_raw, bool)
+            and vote_count_raw >= 0
+            else None
+        )
+
         if kind == "movie":
             title_out = det.get("title") or det.get("original_title")
             year = self._safe_int_year(det.get("release_date"))
@@ -495,7 +504,10 @@ class TmdbProvider:
             detail = {
                 "first_air_date": det.get("first_air_date"),
                 "episode_run_time": run_list,
+                "status": det.get("status"),
                 "number_of_seasons": det.get("number_of_seasons"),
+                "number_of_episodes": det.get("number_of_episodes"),
+                "next_episode_to_air": det.get("next_episode_to_air"),
             }
 
         images: dict[str, list[dict[str, Any]]] = {}
@@ -546,6 +558,7 @@ class TmdbProvider:
             "title": title_out,
             "year": year,
             "runtime_minutes": runtime_minutes,
+            "vote_count": vote_count,
             "images": images or {},
             "detail": detail,
         }

--- a/providers/webhooks/plextrakt.py
+++ b/providers/webhooks/plextrakt.py
@@ -576,7 +576,7 @@ def _progress(md: Mapping[str, Any]) -> float | None:
     return round(max(0.0, min(100.0, progress)), 2)
 
 
-def _probe_active_progress(cfg: dict[str, Any], rating_key: Any) -> int | None:
+def _probe_active_progress(cfg: dict[str, Any], rating_key: Any) -> tuple[int, int] | None:
     try:
         base, token = _plex_base_token(cfg)
         rk = str(rating_key or "")
@@ -587,12 +587,13 @@ def _probe_active_progress(cfg: dict[str, Any], rating_key: Any) -> int | None:
             return None
         root = ET.fromstring(r.text or "")
 
-        def _pct(v: Any) -> int | None:
+        def _playback(v: Any) -> tuple[int, int] | None:
             d = int(v.get("duration") or "0") or 0
             vo = int(v.get("viewOffset") or "0") or 0
             if d <= 0:
                 return None
-            return int(round(100.0 * max(0, min(vo, d)) / float(d)))
+            progress = int(round(100.0 * max(0, min(vo, d)) / float(d)))
+            return progress, d
 
         hit = None
         for v in root.iter("Video"):
@@ -602,7 +603,7 @@ def _probe_active_progress(cfg: dict[str, Any], rating_key: Any) -> int | None:
                 hit = v
         if hit is None:
             return None
-        return _pct(hit)
+        return _playback(hit)
     except Exception:
         return None
     return None
@@ -1267,14 +1268,16 @@ def process_webhook(
         return {"ok": True, "debounced": True}
 
     progress_source = "Metadata" if prog_raw is not None else ""
+    probed_duration_ms: int | None = None
     if (
         prog_raw is None
         and probe_progress
         and rk
         and event in ("media.play", "media.resume", "media.pause")
     ):
-        p_probe = _probe_active_progress(cfg, rk)
-        if isinstance(p_probe, int):
+        playback_probe = _probe_active_progress(cfg, rk)
+        if playback_probe is not None:
+            p_probe, probed_duration_ms = playback_probe
             prog_raw = float(p_probe)
             progress_source = "Plex active session"
 
@@ -1341,6 +1344,68 @@ def process_webhook(
             _emit(logger, "PMS says played → force STOP at ≥95%", "DEBUG")
             prog = max(prog, last_prog, 95.0)
 
+    def _update_playback_state() -> None:
+        # Only media.stop is authoritative for removing the live card/banner.
+        if event == "media.scrobble":
+            return
+        try:
+            stop_flag = event == "media.stop"
+            if (media_type or "").lower() == "episode":
+                title = (md.get("grandparentTitle") or md.get("title") or "").strip()
+            else:
+                title = (md.get("title") or md.get("grandparentTitle") or "").strip()
+            year = md.get("year")
+
+            season_val = None
+            episode_val = None
+            if (media_type or "").lower() == "episode":
+                try:
+                    season_val = int(md.get("parentIndex") or 0) or None
+                except Exception:
+                    season_val = None
+                try:
+                    episode_val = int(md.get("index") or 0) or None
+                except Exception:
+                    episode_val = None
+
+            duration_ms = probed_duration_ms
+            try:
+                dur_val = md.get("duration")
+                if dur_val is not None:
+                    metadata_duration_ms = int(dur_val)
+                    if metadata_duration_ms > 0:
+                        duration_ms = metadata_duration_ms
+            except Exception:
+                pass
+
+            if event in ("media.play", "media.resume"):
+                state_val = "playing"
+            elif event == "media.pause":
+                state_val = "paused"
+            elif stop_flag:
+                state_val = "stopped"
+            else:
+                state_val = "playing"
+
+            cw_ids = _cw_ids_for_payload(media_type, md, ids_all2, cfg, logger=logger)
+            _cw_update(
+                source="plextrakt",
+                media_type=(media_type or ""),
+                title=title,
+                year=year,
+                season=season_val,
+                episode=episode_val,
+                progress=prog,
+                stop=stop_flag,
+                duration_ms=duration_ms,
+                cover=None,
+                state=state_val,
+                clear_on_stop=True,
+                ids=cw_ids,
+            )
+        except Exception:
+            pass
+
     fast_cancel_stop = False
     if event == "media.stop" and prog < force_stop_at:
         age = now - float(st.get("first_seen", now))
@@ -1360,6 +1425,7 @@ def process_webhook(
                 "prog": prog,
                 "finished": False,
             }
+            _update_playback_state()
             return {"ok": True, "suppressed": True}
 
         if fast_cancel and prog < last_p:
@@ -1411,6 +1477,7 @@ def process_webhook(
             "prog": prog,
             "finished": (prog >= force_stop_at),
         }
+        _update_playback_state()
         return {"ok": True, "suppressed": True}
 
     if event in ("media.stop", "media.scrobble") and prog >= force_stop_at:
@@ -1424,63 +1491,13 @@ def process_webhook(
                 "finished": True,
                 **({"wl_removed": st.get("wl_removed")} if st.get("wl_removed") else {}),
             }
+            _update_playback_state()
             return {"ok": True, "suppressed": True}
 
     if event in ("media.stop", "media.scrobble") and prog >= force_stop_at:
         _LAST_FINISH_BY_ACC[_account_key(payload)] = {"rk": str(rk or ""), "ts": now}
 
-    try:
-        stop_flag = event in ("media.stop", "media.scrobble")
-        title = (md.get("title") or md.get("grandparentTitle") or "").strip()
-        year = md.get("year")
-
-        season_val = None
-        episode_val = None
-        if (media_type or "").lower() == "episode":
-            try:
-                season_val = int(md.get("parentIndex") or 0) or None
-            except Exception:
-                season_val = None
-            try:
-                episode_val = int(md.get("index") or 0) or None
-            except Exception:
-                episode_val = None
-
-        duration_ms = None
-        try:
-            dur_val = md.get("duration")
-            if dur_val is not None:
-                duration_ms = int(dur_val)
-        except Exception:
-            duration_ms = None
-
-        if event in ("media.play", "media.resume"):
-            state_val = "playing"
-        elif event == "media.pause":
-            state_val = "paused"
-        elif event in ("media.stop", "media.scrobble"):
-            state_val = "stopped"
-        else:
-            state_val = "playing"
-
-        cw_ids = _cw_ids_for_payload(media_type, md, ids_all2, cfg, logger=logger)
-        _cw_update(
-            source="plextrakt",
-            media_type=(media_type or ""),
-            title=title,
-            year=year,
-            season=season_val,
-            episode=episode_val,
-            progress=prog,
-            stop=stop_flag,
-            duration_ms=duration_ms,
-            cover=None,
-            state=state_val,
-            clear_on_stop=True,
-            ids=cw_ids,
-        )
-    except Exception:
-        pass
+    _update_playback_state()
 
     body = _build_primary_body(media_type, md, ids_all2, prog, cfg, logger=logger)
     if not body:

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -29,6 +29,7 @@ LOG = BASE_LOG.child("PLAYBACK")
 CACHE_TTL_SECONDS = 60.0
 MAX_WORKERS = 6
 DEFAULT_PROVIDER_TIMEOUT_SECONDS = 12.0
+GROUP_PROGRESS_TOLERANCE = 2.0
 PHASE1_PROVIDERS = ("trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin")
 SORT_VALUES = {"last_updated", "progress_high", "progress_low", "remaining_time", "rating_high", "title", "provider"}
 LIVE_MEDIA_PROVIDERS = {"plex", "emby", "jellyfin"}
@@ -66,13 +67,6 @@ def _group_number(value: Any) -> str:
         return str(int(value))
     except Exception:
         return str(value).strip().lower()
-
-
-def _group_progress(value: Any) -> str:
-    try:
-        return str(round(float(value)))
-    except Exception:
-        return ""
 
 
 def _live_source_provider(value: Any) -> str:
@@ -277,9 +271,9 @@ def _overlay_live_streams(items: list[dict[str, Any]], streams: list[dict[str, A
 def _record_group_keys(item: Mapping[str, Any]) -> list[str]:
     keys: list[str] = []
     key = str(item.get("canonical_key") or "").strip().lower()
-    progress = _group_progress(item.get("progress_percent"))
+    profile = _group_text(normalize_instance_id(item.get("instance_id")))
     if key and not key.startswith("unknown:"):
-        keys.append(f"key:{key}:progress:{progress}")
+        keys.append(f"key:{key}:profile:{profile}")
     media_type = _group_text(item.get("media_type"))
     title = _group_text(item.get("title"))
     series = _group_text(item.get("series_title"))
@@ -287,17 +281,12 @@ def _record_group_keys(item: Mapping[str, Any]) -> list[str]:
     episode = _group_number(item.get("episode"))
     year = _group_number(item.get("year"))
     if media_type == "movie":
-        fallback = f"fallback:movie:{title}:{year}:{progress}"
+        fallback = f"fallback:movie:{title}:{year}:profile:{profile}"
     else:
-        fallback = f"fallback:episode:{series or title}:{season}:{episode}:{progress}"
+        fallback = f"fallback:episode:{series or title}:{season}:{episode}:profile:{profile}"
     if fallback not in keys:
         keys.append(fallback)
     return keys
-
-
-def _record_group_key(item: Mapping[str, Any]) -> str:
-    keys = _record_group_keys(item)
-    return keys[0] if keys else "fallback:unknown"
 
 
 def _record_time_value(item: Mapping[str, Any]) -> float:
@@ -330,6 +319,30 @@ def _float_or_none(value: Any) -> float | None:
         return number if math.isfinite(number) else None
     except Exception:
         return None
+
+
+def _split_progress_groups(records: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    numeric: list[tuple[float, dict[str, Any]]] = []
+    missing: list[dict[str, Any]] = []
+    for record in records:
+        progress = _float_or_none(record.get("progress_percent"))
+        if progress is None:
+            missing.append(record)
+        else:
+            numeric.append((progress, record))
+
+    numeric.sort(key=lambda entry: (entry[0], _record_order_key(entry[1])))
+    groups: list[list[dict[str, Any]]] = []
+    group_start: float | None = None
+    for progress, record in numeric:
+        if group_start is None or progress - group_start > GROUP_PROGRESS_TOLERANCE:
+            groups.append([record])
+            group_start = progress
+        else:
+            groups[-1].append(record)
+    if missing:
+        groups.append(sorted(missing, key=_record_order_key))
+    return groups
 
 
 def _remaining_seconds(duration_seconds: Any, progress_percent: Any) -> int | None:
@@ -461,10 +474,32 @@ def _combine_records(records: list[dict[str, Any]]) -> dict[str, Any]:
     primary["can_remove_progress"] = any(bool(record.get("can_remove_progress")) for record in ordered)
     primary["can_mark_watched"] = any(bool(record.get("can_mark_watched")) for record in ordered)
     primary["can_update_progress"] = any(bool(record.get("can_update_progress")) for record in ordered)
+    combined_id = "|".join(
+        sorted(
+            f"{str(record.get('provider') or '').strip().lower()}:{normalize_instance_id(record.get('instance_id'))}:{str(record.get('remote_id') or record.get('canonical_key') or '').strip()}"
+            for record in ordered
+        )
+    )
     primary["provider"] = "combined" if len(ordered) > 1 else primary.get("provider")
     primary["instance_id"] = "all" if len(ordered) > 1 else primary.get("instance_id")
-    primary["remote_id"] = _record_group_key(primary) if len(ordered) > 1 else primary.get("remote_id")
+    primary["remote_id"] = combined_id if len(ordered) > 1 else primary.get("remote_id")
     return primary
+
+
+def _group_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    identity_groups: dict[str, list[dict[str, Any]]] = {}
+    aliases: dict[str, str] = {}
+    for item in records:
+        keys = _record_group_keys(item)
+        group_key = next((aliases[key] for key in keys if key in aliases), keys[0] if keys else "fallback:unknown")
+        identity_groups.setdefault(group_key, []).append(item)
+        for key in keys:
+            aliases[key] = group_key
+    return [
+        _combine_records(progress_group)
+        for identity_group in identity_groups.values()
+        for progress_group in _split_progress_groups(identity_group)
+    ]
 
 
 def _validated_progress_percent(value: Any) -> tuple[float | None, str]:
@@ -790,15 +825,7 @@ class PlaybackProgressService:
         _overlay_live_streams(items)
         filtered = self._apply_filters(items, media_type=media_type, progress_min=progress_min, progress_max=progress_max, age=age, rating_min=rating_min, search=search)
         if not provider_filter:
-            groups: dict[str, list[dict[str, Any]]] = {}
-            aliases: dict[str, str] = {}
-            for item in filtered:
-                keys = _record_group_keys(item)
-                group_key = next((aliases[key] for key in keys if key in aliases), keys[0] if keys else "fallback:unknown")
-                groups.setdefault(group_key, []).append(item)
-                for key in keys:
-                    aliases[key] = group_key
-            filtered = [_combine_records(group) for group in groups.values()]
+            filtered = _group_records(filtered)
         sorted_items = self._sort(filtered, sort)
         page = max(1, int(page or 1))
         page_size = max(1, min(250, int(page_size or 50)))

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -530,10 +530,6 @@ html[data-cw-theme=flat-light] #page-settings .cw-maint-action.restart .cw-maint
       <div class="details-grid">
         <div class="det-left">
           <div class="det-head">
-            <div class="det-console-mark" title="Output" aria-label="Output">
-              <span class="material-symbols-rounded" aria-hidden="true">terminal</span>
-              <span class="det-title">Output</span>
-            </div>
             <div class="det-tabs" role="tablist" aria-label="Output tabs">
               <button id="det-tab-sync" class="det-tab active" type="button"
                 role="tab" aria-selected="true" aria-controls="det-panel-sync" data-tab="sync">Sync</button>


### PR DESCRIPTION
# Pull request

## Change

- Group Playback Progress records only when their media, profile and playback positions match.
- Allow a two-percentage-point margin when combining progress from the same profile.
- Preserve Plex webhook progress and duration using active-session data when webhook metadata is incomplete.
- Add visual progress for active Watcher and webhook playback.
- Redesign the Now Playing card with responsive Information and TMDB Rating blocks.
- Replace the provider-connections indicator with application health polling from `/api/health`.
- Open Maintenance from the health indicator and highlight available updates.
- Remove the redundant terminal icon from Live Output.

## Why

Playback records from different user profiles could be combined even though they represented different viewers. Webhook progress could also appear frozen when providers did not continuously report playback updates.

The Now Playing card  lacked useful movie and series metadata. But, in short, I didn’t like it. Whats more to say.


## Testing

- `.tests/test_playback_progress.py tests/test_plex_webhook_progress.py tests/test_tmdb_rating.py -q`
- including some manual and live tests.


## Issue

Fixes