### PR TITLE
Add: persistent metadata caching

### DIFF
--- a/api/metaAPI.py
+++ b/api/metaAPI.py
@@ -25,6 +25,13 @@ from fastapi.responses import (
 from pydantic import BaseModel
 
 from cw_platform.config_base import load_config
+from cw_platform.metadata_cache import (
+    merge_metadata_cache_payload,
+    metadata_cache_path,
+    prune_metadata_cache,
+    read_metadata_cache,
+    write_metadata_cache,
+)
 
 try:
     from _logging import log as cw_log
@@ -115,9 +122,9 @@ def _shorten(txt: str, limit: int = 280) -> str:
 def _cfg_meta_ttl_secs() -> int:
     try:
         md = (load_config() or {}).get("metadata") or {}
-        return max(1, int(md.get("ttl_hours", 72))) * 3600
+        return max(1, int(md.get("ttl_hours", 720))) * 3600
     except Exception:
-        return 72 * 3600
+        return 720 * 3600
 
 
 def _meta_cache_enabled() -> bool:
@@ -163,12 +170,7 @@ def _cache_matches(cache_root: Path, stem: str) -> list[Path]:
 
 
 def _meta_cache_path(entity: str, tmdb_id: str | int, locale: str | None) -> Path:
-    t = "movie" if str(entity).lower() == "movie" else "show"
-    safe_id = _safe_cache_part(tmdb_id)
-    loc = _safe_cache_part(locale or "en-US", default="en-US")
-    sub = _meta_cache_dir() / t
-    sub.mkdir(parents=True, exist_ok=True)
-    return sub / f"{safe_id}.{loc}.json"
+    return metadata_cache_path(_meta_cache_dir(), entity, tmdb_id, locale)
 
 
 def _cfg_ui_locale() -> str | None:
@@ -444,66 +446,22 @@ def _need_satisfied(meta: dict[str, Any], need: dict[str, Any] | None) -> bool:
 
 
 def _read_meta_cache(p: Path) -> dict[str, Any] | None:
-    try:
-        if not p.exists():
-            return None
-        data = json.loads(p.read_text("utf-8"))
-        if not isinstance(data, dict):
-            return None
-        raw_ts = data.get("fetched_at")
-        try:
-            fetched_ts = float(raw_ts) if raw_ts is not None else 0.0
-        except (TypeError, ValueError):
-            fetched_ts = 0.0
-        if (time.time() - fetched_ts) > _cfg_meta_ttl_secs():
-            return None
-        return data
-    except Exception:
-        return None
+    return read_metadata_cache(p, ttl_seconds=_cfg_meta_ttl_secs())
 
 
 def _write_meta_cache(p: Path, payload: dict[str, Any]) -> None:
-    try:
-        tmp = p.with_suffix(p.suffix + ".tmp")
-        data = dict(payload)
-        data["fetched_at"] = time.time()
-        tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
-        tmp.replace(p)
-    except Exception:
-        pass
+    write_metadata_cache(p, payload)
 
 
 def _merge_meta_cache_payload(base: dict[str, Any] | None, extra: dict[str, Any]) -> dict[str, Any]:
-    prev = base if isinstance(base, dict) else {}
-    out = {**prev, **extra}
-    out["ids"] = {**(prev.get("ids") or {}), **(extra.get("ids") or {})}
-    out["detail"] = {**(prev.get("detail") or {}), **(extra.get("detail") or {})}
-    out["images"] = {**(prev.get("images") or {}), **(extra.get("images") or {})}
-    return out
+    return merge_metadata_cache_payload(base, extra)
 
 
 def _prune_meta_cache_if_needed() -> None:
     try:
         md = (load_config() or {}).get("metadata") or {}
         cap_mb = int(md.get("meta_cache_max_mb", 0))
-        if cap_mb <= 0:
-            return
-        root = _meta_cache_dir()
-        files = list(root.rglob("*.json"))
-        total = sum(f.stat().st_size for f in files)
-        cap = cap_mb * 1024 * 1024
-        if total <= cap:
-            return
-        files.sort(key=lambda f: f.stat().st_mtime)
-        target = int(cap * 0.9)
-        for f in files:
-            try:
-                total -= f.stat().st_size
-                f.unlink(missing_ok=True)
-            except Exception:
-                pass
-            if total <= target:
-                break
+        prune_metadata_cache(_meta_cache_dir(), max_mb=cap_mb)
     except Exception:
         pass
 

--- a/assets/helpers/settings-save.js
+++ b/assets/helpers/settings-save.js
@@ -545,7 +545,7 @@ async function saveSettings() {
     }
 
     const prevMetaLocale = _cwNorm(serverCfg?.metadata?.locale);
-    const prevMetaTTL = Number.isFinite(serverCfg?.metadata?.ttl_hours) ? Number(serverCfg.metadata.ttl_hours) : 72;
+    const prevMetaTTL = Number.isFinite(serverCfg?.metadata?.ttl_hours) ? Number(serverCfg.metadata.ttl_hours) : 720;
     const uiMetaLocale = _getVal("metadata_locale");
     const uiMetaTTL = _getVal("metadata_ttl_hours");
     if (uiMetaLocale !== prevMetaLocale) {

--- a/assets/helpers/settings-ui.js
+++ b/assets/helpers/settings-ui.js
@@ -1328,7 +1328,7 @@ async function loadConfig() {
     _setSelectValue("debug", mode);
   })();
   _setVal("metadata_locale", cfg.metadata?.locale || "");
-  _setVal("metadata_ttl_hours", String(Number.isFinite(cfg.metadata?.ttl_hours) ? cfg.metadata.ttl_hours : 72));
+  _setVal("metadata_ttl_hours", String(Number.isFinite(cfg.metadata?.ttl_hours) ? cfg.metadata.ttl_hours : 720));
 
   
   (function () {

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -554,7 +554,7 @@ DEFAULT_CFG: dict[str, Any] = {
     # --- Metadata (TMDb resolver) -------------------------------------------
     "metadata": {
         "locale": "en-US",                              # example: "en-US" / "nl-NL"
-        "ttl_hours": 72,                                # Coarse cache TTL
+        "ttl_hours": 720,                               # Metadata cache TTL (30 days)
     },
 
     # --- Anime ID Mapping ----------------------------------------------------

--- a/cw_platform/metadata_cache.py
+++ b/cw_platform/metadata_cache.py
@@ -1,0 +1,108 @@
+# /cw_platform/metadata_cache.py
+# CrossWatch - Shared persistent metadata cache
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+import re
+import time
+from pathlib import Path
+from threading import RLock
+from typing import Any, Mapping
+
+_SAFE_PART_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+_WRITE_LOCK = RLock()
+
+
+def _safe_part(value: Any, *, default: str) -> str:
+    text = _SAFE_PART_RE.sub("_", str(value or "").strip()).strip("._-")
+    return text or default
+
+
+def metadata_cache_path(
+    cache_root: Path | str,
+    entity: str,
+    tmdb_id: str | int,
+    locale: str | None,
+) -> Path:
+    root = Path(cache_root).resolve()
+    media = "movie" if str(entity or "").strip().lower() == "movie" else "show"
+    media_root = (root / media).resolve()
+    media_root.relative_to(root)
+    media_root.mkdir(parents=True, exist_ok=True)
+    name = f"{_safe_part(tmdb_id, default='x')}.{_safe_part(locale or 'en-US', default='en-US')}.json"
+    path = (media_root / name).resolve()
+    path.relative_to(media_root)
+    return path
+
+
+def read_metadata_cache(path: Path | str, *, ttl_seconds: int | None) -> dict[str, Any] | None:
+    try:
+        data = json.loads(Path(path).read_text("utf-8"))
+        if not isinstance(data, dict):
+            return None
+        if ttl_seconds is not None:
+            fetched_at = float(data.get("fetched_at") or 0.0)
+            if fetched_at <= 0 or (time.time() - fetched_at) > max(1, int(ttl_seconds)):
+                return None
+        return data
+    except Exception:
+        return None
+
+
+def merge_metadata_cache_payload(
+    base: Mapping[str, Any] | None,
+    extra: Mapping[str, Any],
+) -> dict[str, Any]:
+    previous = dict(base or {})
+    incoming = dict(extra or {})
+    out = {**previous, **incoming}
+    for field in ("ids", "detail", "images"):
+        old_raw = previous.get(field)
+        new_raw = incoming.get(field)
+        old_value: dict[str, Any] = dict(old_raw) if isinstance(old_raw, Mapping) else {}
+        new_value: dict[str, Any] = dict(new_raw) if isinstance(new_raw, Mapping) else {}
+        out[field] = {**old_value, **new_value}
+    return out
+
+
+def write_metadata_cache(path: Path | str, payload: Mapping[str, Any]) -> bool:
+    target = Path(path)
+    try:
+        data = dict(payload)
+        data["fetched_at"] = time.time()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        with _WRITE_LOCK:
+            tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+            tmp.replace(target)
+        return True
+    except Exception:
+        return False
+
+
+def prune_metadata_cache(cache_root: Path | str, *, max_mb: int) -> int:
+    if int(max_mb or 0) <= 0:
+        return 0
+    try:
+        root = Path(cache_root).resolve()
+        files = [path for path in root.rglob("*.json") if path.is_file() and not path.is_symlink()]
+        total = sum(path.stat().st_size for path in files)
+        cap = int(max_mb) * 1024 * 1024
+        if total <= cap:
+            return 0
+        files.sort(key=lambda path: path.stat().st_mtime)
+        target = int(cap * 0.9)
+        removed = 0
+        for path in files:
+            try:
+                total -= path.stat().st_size
+                path.unlink(missing_ok=True)
+                removed += 1
+            except Exception:
+                continue
+            if total <= target:
+                break
+        return removed
+    except Exception:
+        return 0

--- a/providers/metadata/_meta_TMDB.py
+++ b/providers/metadata/_meta_TMDB.py
@@ -64,11 +64,11 @@ class TmdbProvider:
     def _ttl_seconds(self) -> int:
         cfg = self.load_cfg() or {}
         md = cfg.get("metadata") or {}
-        hours = md.get("ttl_hours", 72)
+        hours = md.get("ttl_hours", 720)
         try:
             hours = int(hours)
         except Exception:
-            hours = 72
+            hours = 720
         return max(1, hours) * 3600
 
     def _backoff_params(self) -> tuple[int, float, float]:
@@ -628,8 +628,8 @@ def html() -> str:
 
           <div>
             <label for="metadata_ttl_hours">TTL hours (metadata.ttl_hours)</label>
-            <input id="metadata_ttl_hours" name="metadata_ttl_hours" type="number" min="1" step="1" placeholder="72" oninput="this.dataset.dirty='1'">
-            <div class="sub">Resolver cache freshness (coarse). Default 72h.</div>
+            <input id="metadata_ttl_hours" name="metadata_ttl_hours" type="number" min="1" step="1" placeholder="720" oninput="this.dataset.dirty='1'">
+            <div class="sub">Resolver cache freshness (coarse). Default 720h (30 days).</div>
           </div>
 
         </div>

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+
+from api import metaAPI
+from cw_platform.config_base import DEFAULT_CFG
+from cw_platform.metadata_cache import (
+    merge_metadata_cache_payload,
+    metadata_cache_path,
+    read_metadata_cache,
+    write_metadata_cache,
+)
+
+
+def test_metadata_default_ttl_is_30_days() -> None:
+    assert DEFAULT_CFG["metadata"]["ttl_hours"] == 720
+
+
+def test_shared_metadata_cache_round_trip_and_expiry(tmp_path, monkeypatch) -> None:
+    path = metadata_cache_path(tmp_path, "movie", "123", "nl-NL")
+    assert path == tmp_path / "movie" / "123.nl-NL.json"
+    assert write_metadata_cache(path, {"title": "Example", "year": 2026}) is True
+    assert read_metadata_cache(path, ttl_seconds=720 * 3600)["title"] == "Example"
+
+    payload = json.loads(path.read_text("utf-8"))
+    payload["fetched_at"] = 1
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    assert read_metadata_cache(path, ttl_seconds=720 * 3600) is None
+    assert read_metadata_cache(path, ttl_seconds=None)["title"] == "Example"
+
+    monkeypatch.setattr(metaAPI, "_meta_cache_dir", lambda: tmp_path)
+    monkeypatch.setattr(metaAPI, "_cfg_meta_ttl_secs", lambda: 720 * 3600)
+    assert metaAPI._meta_cache_path("movie", "123", "nl-NL") == path
+
+
+def test_shared_metadata_cache_merge_preserves_existing_artwork() -> None:
+    merged = merge_metadata_cache_payload(
+        {
+            "title": "Old title",
+            "ids": {"tmdb": "1", "imdb": "tt1"},
+            "images": {"poster": [{"url": "poster.jpg"}]},
+        },
+        {"title": "New title", "year": 2026, "ids": {"tmdb": "1"}},
+    )
+
+    assert merged["title"] == "New title"
+    assert merged["year"] == 2026
+    assert merged["ids"] == {"tmdb": "1", "imdb": "tt1"}
+    assert merged["images"] == {"poster": [{"url": "poster.jpg"}]}
+
+
+def test_meta_api_reuses_shared_disk_cache_after_memory_cache_reset(tmp_path, monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    class Metadata:
+        def resolve(self, *, entity, ids, locale=None, need=None):
+            calls.append((entity, ids["tmdb"]))
+            return {"type": entity, "title": "Cached title", "year": 2026, "ids": dict(ids)}
+
+    monkeypatch.setattr(metaAPI, "_env", lambda: (Metadata(), tmp_path.parent, lambda: {}))
+    monkeypatch.setattr(metaAPI, "_meta_cache_dir", lambda: tmp_path)
+    monkeypatch.setattr(metaAPI, "_meta_cache_enabled", lambda: True)
+    monkeypatch.setattr(metaAPI, "_cfg_meta_ttl_secs", lambda: 720 * 3600)
+    metaAPI._resolve_tmdb_cached.cache_clear()
+
+    first = metaAPI.get_meta("unused", "movie", "321", tmp_path, need={"title": True, "year": True}, locale="en-US")
+    metaAPI._resolve_tmdb_cached.cache_clear()
+    second = metaAPI.get_meta("unused", "movie", "321", tmp_path, need={"title": True, "year": True}, locale="en-US")
+
+    assert first["title"] == "Cached title"
+    assert second["title"] == "Cached title"
+    assert calls == [("movie", "321")]


### PR DESCRIPTION
# Pull request

## Change

- Added reusable persistent metadata-cache storage.
- Updated the central metadata API to use the shared cache implementation.
- Changed the default metadata TTL from 72 hours to 720 hours (30 days).
- Preserved existing metadata, identifiers and artwork when cache entries are refreshed.
- Retained cache-size limits and maintenance cleanup support.

## Why

PublicMetaDB enrichment and other metadata consumers need a shared disk cache to avoid repeated TMDb requests.
A 30-day TTL provides a better balance between metadata freshness and API usage.
Currently only the updated PublicMetaDB will be using persistent metadata caching as it was needed the most.

## Testing

- Tested cache reads, writes and expiry.
- Tested metadata merging and artwork preservation.
- Tested reuse after the in-memory cache is cleared.
- Verified the default TTL is 30 days.

## Issue

Part of #71