### PR TITLE
Add: TMDb enrichment for PublicMetaDB

### DIFF
--- a/api/editorAPI.py
+++ b/api/editorAPI.py
@@ -15,7 +15,7 @@ from fastapi.responses import StreamingResponse
 
 from cw_platform.config_base import load_config
 from cw_platform.id_map import canonical_key, merge_ids, minimal
-from cw_platform.modules_registry import load_sync_ops
+from cw_platform.modules_registry import load_sync_ops, state_read_features
 from cw_platform.orchestrator._snapshots import module_checkpoint
 from cw_platform.orchestrator._state_store import StateStore
 from cw_platform.provider_instances import build_provider_config_view, list_instance_ids, normalize_instance_id
@@ -1188,10 +1188,7 @@ def api_editor_state_import_providers() -> dict[str, Any]:
             label = str(getattr(ops, "label", lambda: name)())
         except Exception:
             label = name
-        try:
-            feats = dict(getattr(ops, "features", lambda: {})())
-        except Exception:
-            feats = {}
+        feats = state_read_features(ops)
         try:
             inst_ids = list_instance_ids(cfg, name)
         except Exception:
@@ -1272,10 +1269,7 @@ def api_editor_state_import(payload: dict[str, Any] = Body(...)) -> dict[str, An
         except Exception:
             raise HTTPException(status_code=400, detail=f"Provider not configured: {provider} ({provider_instance})")
 
-    try:
-        feats_supported = dict(getattr(ops, "features", lambda: {})())
-    except Exception:
-        feats_supported = {}
+    feats_supported = state_read_features(ops)
 
     store = _state_store()
     state = store.load_state() if not dry_run else {"providers": {}, "wall": [], "last_sync_epoch": None}
@@ -1314,7 +1308,11 @@ def api_editor_state_import(payload: dict[str, Any] = Body(...)) -> dict[str, An
 
     for feature in features:
         if not bool(feats_supported.get(feature)):
-            imported["features"][feature] = {"ok": False, "skipped": True, "reason": "feature disabled"}
+            imported["features"][feature] = {
+                "ok": False,
+                "skipped": True,
+                "reason": "complete provider state unavailable",
+            }
             continue
 
         t0 = _t.time()

--- a/cw_platform/modules_registry.py
+++ b/cw_platform/modules_registry.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+from collections.abc import Mapping
 from importlib import import_module
 from typing import Any
 
@@ -47,3 +48,22 @@ def load_sync_ops(name: str) -> Any | None:
         return None
     mod = import_module(path)
     return getattr(mod, "OPS", None)
+
+
+def state_read_features(ops: Any) -> dict[str, bool]:
+    """Return features that can provide a complete provider-state inventory.
+    Providers may still support writes for a feature that cannot be enumerated
+    completely. Captures and provider-state imports must only use the latter.
+    """
+    fn = getattr(ops, "state_read_features", None)
+    if not callable(fn):
+        fn = getattr(ops, "features", None)
+    if not callable(fn):
+        return {}
+    try:
+        raw = fn() or {}
+    except Exception:
+        return {}
+    if not isinstance(raw, Mapping):
+        return {}
+    return {str(key): bool(value) for key, value in raw.items()}

--- a/providers/sync/_mod_PUBLICMETADB.py
+++ b/providers/sync/_mod_PUBLICMETADB.py
@@ -17,13 +17,14 @@ from .publicmetadb import _history as feat_history
 from .publicmetadb import _progress as feat_progress
 from .publicmetadb import _ratings as feat_ratings
 from .publicmetadb import _watchlist as feat_watchlist
+from .publicmetadb._common import enrich_index_metadata
 
 try:  # type: ignore[name-defined]
     ctx  # type: ignore[misc]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "0.2"
+__VERSION__ = "0.3"
 __all__ = ["get_manifest", "PUBLICMETADBModule", "OPS"]
 
 
@@ -317,14 +318,16 @@ class PUBLICMETADBModule:
 
     def build_index(self, feature: str, **kwargs: Any) -> dict[str, dict[str, Any]]:
         if feature == "watchlist":
-            return feat_watchlist.build_index(self)
-        if feature == "history":
-            return feat_history.build_index(self)
-        if feature == "ratings":
-            return feat_ratings.build_index(self)
-        if feature == "progress":
-            return feat_progress.build_index(self)
-        return {}
+            items = feat_watchlist.build_index(self)
+        elif feature == "history":
+            items = feat_history.build_index(self)
+        elif feature == "ratings":
+            items = feat_ratings.build_index(self)
+        elif feature == "progress":
+            items = feat_progress.build_index(self)
+        else:
+            return {}
+        return enrich_index_metadata(self, items, feature=feature)
 
     def add(self, feature: str, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
         lst = list(items or [])
@@ -368,6 +371,15 @@ class _PUBLICMETADBOPS:
 
     def features(self) -> Mapping[str, bool]:
         return PUBLICMETADBModule.supported_features()
+
+    def state_read_features(self) -> Mapping[str, bool]:
+        """Features for complete captures and provider-state imports."""
+        features = dict(PUBLICMETADBModule.supported_features())
+        # PublicMetaDB accepts rating writes but cannot enumerate a user's
+        # complete ratings inventory. The local shadow is intentionally not
+        # treated as authoritative provider state.
+        features["ratings"] = False
+        return features
 
     def capabilities(self) -> Mapping[str, Any]:
         return get_manifest()["capabilities"]

--- a/providers/sync/publicmetadb/_common.py
+++ b/providers/sync/publicmetadb/_common.py
@@ -3,11 +3,9 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 from pathlib import Path
-from threading import RLock
 from typing import Any, Mapping
 
 from cw_platform.anime_mapping.service import mapped_or_default_media_type
@@ -24,8 +22,6 @@ from .._log import log as cw_log
 
 STATE_DIR = Path("/config/.cw_state")
 STATE_DIR.mkdir(parents=True, exist_ok=True)
-_TMDB_METADATA_PROVIDERS: dict[tuple[str, str, str], Any] = {}
-_TMDB_METADATA_PROVIDERS_LOCK = RLock()
 
 
 def _pair_scope() -> str | None:
@@ -201,21 +197,11 @@ def _tmdb_metadata_provider(adapter: Any) -> Any:
     runtime_obj = cfg.get("runtime") if isinstance(cfg, Mapping) else None
     runtime: Mapping[str, Any] = runtime_obj if isinstance(runtime_obj, Mapping) else {}
     provider_cfg = {"tmdb": dict(tmdb), "metadata": dict(metadata), "runtime": dict(runtime)}
-    api_key_hash = hashlib.sha256(_tmdb_metadata_api_key(adapter).encode("utf-8")).hexdigest()
-    provider_key = (
-        api_key_hash,
-        _tmdb_metadata_locale(adapter) or "",
-        str(metadata.get("ttl_hours") or "720"),
-    )
 
     def _load_cfg() -> dict[str, Any]:
         return provider_cfg
 
-    with _TMDB_METADATA_PROVIDERS_LOCK:
-        provider = _TMDB_METADATA_PROVIDERS.get(provider_key)
-        if provider is None:
-            provider = TmdbProvider(_load_cfg, lambda _data: None)
-            _TMDB_METADATA_PROVIDERS[provider_key] = provider
+    provider = TmdbProvider(_load_cfg, lambda _data: None)
     setattr(adapter, "_publicmetadb_tmdb_metadata_provider", provider)
     return provider
 

--- a/providers/sync/publicmetadb/_common.py
+++ b/providers/sync/publicmetadb/_common.py
@@ -3,17 +3,29 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from pathlib import Path
+from threading import RLock
 from typing import Any, Mapping
 
 from cw_platform.anime_mapping.service import mapped_or_default_media_type
+from cw_platform.config_base import CONFIG_BASE
+from cw_platform.metadata_cache import (
+    merge_metadata_cache_payload,
+    metadata_cache_path,
+    prune_metadata_cache,
+    read_metadata_cache,
+    write_metadata_cache,
+)
 
 from .._log import log as cw_log
 
 STATE_DIR = Path("/config/.cw_state")
 STATE_DIR.mkdir(parents=True, exist_ok=True)
+_TMDB_METADATA_PROVIDERS: dict[tuple[str, str, str], Any] = {}
+_TMDB_METADATA_PROVIDERS_LOCK = RLock()
 
 
 def _pair_scope() -> str | None:
@@ -96,3 +108,253 @@ def tmdb_id_for_item(item: Mapping[str, Any]) -> int | None:
     ids_obj = item.get("ids")
     ids: Mapping[str, Any] = ids_obj if isinstance(ids_obj, Mapping) else {}
     return as_int(ids.get("tmdb") or item.get("tmdb") or item.get("tmdb_id"))
+
+
+def _tmdb_metadata_api_key(adapter: Any) -> str:
+    cfg = getattr(adapter, "config", {}) or {}
+    if not isinstance(cfg, Mapping):
+        return ""
+    tmdb_obj = cfg.get("tmdb")
+    tmdb: Mapping[str, Any] = tmdb_obj if isinstance(tmdb_obj, Mapping) else {}
+    metadata_obj = cfg.get("metadata")
+    metadata: Mapping[str, Any] = metadata_obj if isinstance(metadata_obj, Mapping) else {}
+    return str(tmdb.get("api_key") or metadata.get("tmdb_api_key") or "").strip()
+
+
+def _tmdb_metadata_locale(adapter: Any) -> str | None:
+    cfg = getattr(adapter, "config", {}) or {}
+    if not isinstance(cfg, Mapping):
+        return None
+    metadata_obj = cfg.get("metadata")
+    metadata: Mapping[str, Any] = metadata_obj if isinstance(metadata_obj, Mapping) else {}
+    ui_obj = cfg.get("ui")
+    ui: Mapping[str, Any] = ui_obj if isinstance(ui_obj, Mapping) else {}
+    locale = str(metadata.get("locale") or ui.get("locale") or "").strip()
+    return locale or None
+
+
+def _metadata_cache_enabled(adapter: Any) -> bool:
+    cfg = getattr(adapter, "config", {}) or {}
+    metadata_obj = cfg.get("metadata") if isinstance(cfg, Mapping) else None
+    metadata: Mapping[str, Any] = metadata_obj if isinstance(metadata_obj, Mapping) else {}
+    return bool(metadata.get("meta_cache_enable", True))
+
+
+def _metadata_cache_ttl_seconds(adapter: Any) -> int:
+    cfg = getattr(adapter, "config", {}) or {}
+    metadata_obj = cfg.get("metadata") if isinstance(cfg, Mapping) else None
+    metadata: Mapping[str, Any] = metadata_obj if isinstance(metadata_obj, Mapping) else {}
+    try:
+        hours = int(metadata.get("ttl_hours", 720))
+    except Exception:
+        hours = 720
+    return max(1, hours) * 3600
+
+
+def _metadata_cache_max_mb(adapter: Any) -> int:
+    cfg = getattr(adapter, "config", {}) or {}
+    metadata_obj = cfg.get("metadata") if isinstance(cfg, Mapping) else None
+    metadata: Mapping[str, Any] = metadata_obj if isinstance(metadata_obj, Mapping) else {}
+    try:
+        return max(0, int(metadata.get("meta_cache_max_mb", 0)))
+    except Exception:
+        return 0
+
+
+def _metadata_cache_root() -> Path:
+    root = CONFIG_BASE() / "cache" / "meta"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _metadata_identity(item: Mapping[str, Any]) -> tuple[str, int] | None:
+    typ = str(item.get("type") or "").strip().lower()
+    if typ == "episode":
+        show_ids_obj = item.get("show_ids")
+        show_ids: Mapping[str, Any] = show_ids_obj if isinstance(show_ids_obj, Mapping) else {}
+        tmdb = as_int(show_ids.get("tmdb")) or tmdb_id_for_item(item)
+        return ("show", tmdb) if tmdb is not None else None
+    tmdb = tmdb_id_for_item(item)
+    if tmdb is None:
+        return None
+    return ("show" if typ in ("show", "series", "tv") else "movie", tmdb)
+
+
+def _needs_metadata(item: Mapping[str, Any]) -> bool:
+    typ = str(item.get("type") or "").strip().lower()
+    title_key = "series_title" if typ == "episode" else "title"
+    return not str(item.get(title_key) or "").strip() or item.get("year") in (None, "")
+
+
+def _tmdb_metadata_provider(adapter: Any) -> Any:
+    provider = getattr(adapter, "_publicmetadb_tmdb_metadata_provider", None)
+    if provider is not None:
+        return provider
+
+    from providers.metadata._meta_TMDB import TmdbProvider
+
+    cfg = getattr(adapter, "config", {}) or {}
+    tmdb_obj = cfg.get("tmdb") if isinstance(cfg, Mapping) else None
+    tmdb: Mapping[str, Any] = tmdb_obj if isinstance(tmdb_obj, Mapping) else {}
+    metadata_obj = cfg.get("metadata") if isinstance(cfg, Mapping) else None
+    metadata: Mapping[str, Any] = metadata_obj if isinstance(metadata_obj, Mapping) else {}
+    runtime_obj = cfg.get("runtime") if isinstance(cfg, Mapping) else None
+    runtime: Mapping[str, Any] = runtime_obj if isinstance(runtime_obj, Mapping) else {}
+    provider_cfg = {"tmdb": dict(tmdb), "metadata": dict(metadata), "runtime": dict(runtime)}
+    api_key_hash = hashlib.sha256(_tmdb_metadata_api_key(adapter).encode("utf-8")).hexdigest()
+    provider_key = (
+        api_key_hash,
+        _tmdb_metadata_locale(adapter) or "",
+        str(metadata.get("ttl_hours") or "720"),
+    )
+
+    def _load_cfg() -> dict[str, Any]:
+        return provider_cfg
+
+    with _TMDB_METADATA_PROVIDERS_LOCK:
+        provider = _TMDB_METADATA_PROVIDERS.get(provider_key)
+        if provider is None:
+            provider = TmdbProvider(_load_cfg, lambda _data: None)
+            _TMDB_METADATA_PROVIDERS[provider_key] = provider
+    setattr(adapter, "_publicmetadb_tmdb_metadata_provider", provider)
+    return provider
+
+
+def enrich_index_metadata(
+    adapter: Any,
+    items: Mapping[str, Mapping[str, Any]],
+    *,
+    feature: str,
+) -> dict[str, dict[str, Any]]:
+    """Fill sparse PublicMetaDB index rows from the TMDb metadata provider."""
+    out = {str(key): dict(item) for key, item in (items or {}).items() if isinstance(item, Mapping)}
+    candidates = [(key, item) for key, item in out.items() if _needs_metadata(item)]
+    if not candidates:
+        return out
+
+    if not _tmdb_metadata_api_key(adapter):
+        logged_obj = getattr(adapter, "_publicmetadb_metadata_unavailable_logged", set())
+        logged = logged_obj if isinstance(logged_obj, set) else set()
+        if feature not in logged:
+            cw_log(
+                "PUBLICMETADB",
+                feature,
+                "warn",
+                "metadata_enrichment_unavailable",
+                reason="missing_tmdb_metadata_api_key",
+                missing=len(candidates),
+            )
+            logged.add(feature)
+            setattr(adapter, "_publicmetadb_metadata_unavailable_logged", logged)
+        return out
+
+    cache_obj = getattr(adapter, "_publicmetadb_metadata_cache", None)
+    cache: dict[tuple[str, int], Mapping[str, Any] | None]
+    if isinstance(cache_obj, dict):
+        cache = cache_obj
+    else:
+        cache = {}
+        setattr(adapter, "_publicmetadb_metadata_cache", cache)
+
+    enriched = 0
+    unresolved = 0
+    disk_hits = 0
+    cache_written = False
+    provider: Any | None = None
+    provider_error: Exception | None = None
+    locale = _tmdb_metadata_locale(adapter)
+    disk_enabled = _metadata_cache_enabled(adapter)
+    disk_root = _metadata_cache_root() if disk_enabled else None
+    for key, item in candidates:
+        identity = _metadata_identity(item)
+        if identity is None:
+            unresolved += 1
+            continue
+        entity, tmdb_id = identity
+        if identity not in cache:
+            resolved: Mapping[str, Any] | None = None
+            disk_path: Path | None = None
+            if disk_root is not None:
+                disk_path = metadata_cache_path(disk_root, entity, tmdb_id, locale or "en-US")
+                persisted = read_metadata_cache(disk_path, ttl_seconds=_metadata_cache_ttl_seconds(adapter))
+                needs_title = not str(item.get("series_title" if str(item.get("type") or "").lower() == "episode" else "title") or "").strip()
+                needs_year = item.get("year") in (None, "")
+                persisted_value: dict[str, Any] | None = dict(persisted) if isinstance(persisted, Mapping) else None
+                if persisted_value is not None:
+                    persisted_satisfies = not needs_title or bool(str(persisted_value.get("title") or "").strip())
+                    if persisted_satisfies and needs_year:
+                        persisted_satisfies = "year" in persisted_value
+                else:
+                    persisted_satisfies = False
+                if persisted_satisfies and persisted_value is not None:
+                    resolved = persisted_value
+                    disk_hits += 1
+
+            if resolved is None and provider_error is None:
+                try:
+                    active_provider = provider
+                    if active_provider is None:
+                        active_provider = _tmdb_metadata_provider(adapter)
+                        provider = active_provider
+                    fetched = active_provider.fetch(
+                        entity=entity,
+                        ids={"tmdb": str(tmdb_id)},
+                        locale=locale,
+                        need={"title": True, "year": True},
+                    )
+                    resolved = fetched if isinstance(fetched, Mapping) and fetched else None
+                    if resolved is not None and disk_path is not None:
+                        previous = read_metadata_cache(disk_path, ttl_seconds=None)
+                        payload = merge_metadata_cache_payload(previous, resolved)
+                        payload["locale"] = locale or payload.get("locale") or None
+                        if write_metadata_cache(disk_path, payload):
+                            cache_written = True
+                except Exception as exc:
+                    provider_error = exc
+
+            cache[identity] = resolved
+
+        metadata = cache.get(identity)
+        if not isinstance(metadata, Mapping):
+            unresolved += 1
+            continue
+
+        merged = dict(item)
+        title = str(metadata.get("title") or "").strip()
+        title_key = "series_title" if str(item.get("type") or "").strip().lower() == "episode" else "title"
+        changed = False
+        if not str(merged.get(title_key) or "").strip() and title:
+            merged[title_key] = title
+            changed = True
+        if merged.get("year") in (None, "") and metadata.get("year") not in (None, ""):
+            merged["year"] = metadata.get("year")
+            changed = True
+        if changed:
+            out[key] = merged
+            enriched += 1
+
+    if provider_error is not None:
+        cw_log(
+            "PUBLICMETADB",
+            feature,
+            "warn",
+            "metadata_enrichment_unavailable",
+            reason="tmdb_metadata_provider_unavailable",
+            error_type=provider_error.__class__.__name__,
+            unresolved=unresolved,
+        )
+    if cache_written and disk_root is not None:
+        prune_metadata_cache(disk_root, max_mb=_metadata_cache_max_mb(adapter))
+
+    cw_log(
+        "PUBLICMETADB",
+        feature,
+        "debug",
+        "metadata_enrichment_done",
+        candidates=len(candidates),
+        enriched=enriched,
+        unresolved=unresolved,
+        cached=len(cache),
+        disk_hits=disk_hits,
+    )
+    return out

--- a/services/snapshots.py
+++ b/services/snapshots.py
@@ -15,7 +15,7 @@ import re
 import uuid
 
 from cw_platform.config_base import CONFIG, load_config
-from cw_platform.modules_registry import MODULES as MR_MODULES, load_sync_ops
+from cw_platform.modules_registry import MODULES as MR_MODULES, load_sync_ops, state_read_features
 from cw_platform.provider_instances import build_provider_config_view, list_instance_ids, normalize_instance_id
 
 Feature = Literal["watchlist", "ratings", "history", "progress"]
@@ -218,13 +218,8 @@ def _capture_mode_env(
                 os.environ[key] = value
 
 
-def _feature_enabled(ops: Any, feature: Feature) -> bool:
-    try:
-        feats = ops.features() or {}
-        v = feats.get(feature)
-        return bool(v)
-    except Exception:
-        return False
+def _state_read_feature_enabled(ops: Any, feature: Feature) -> bool:
+    return bool(state_read_features(ops).get(feature))
 
 
 def _configured(ops: Any, cfg: Mapping[str, Any]) -> bool:
@@ -271,12 +266,8 @@ def snapshot_manifest(cfg: Mapping[str, Any] | None = None) -> list[dict[str, An
         ops = load_sync_ops(pid)
         if not ops:
             continue
-        feats = {}
-        try:
-            raw = ops.features() or {}
-            feats = {k: bool(raw.get(k)) for k in SNAPSHOT_FEATURES}
-        except Exception:
-            feats = {"watchlist": False, "ratings": False, "history": False, "progress": False}
+        raw = state_read_features(ops)
+        feats = {k: bool(raw.get(k)) for k in SNAPSHOT_FEATURES}
 
         insts = list_instance_ids(cfg, pid)
         inst_meta: list[dict[str, Any]] = []
@@ -532,7 +523,7 @@ def create_snapshot(
 
         for f in SNAPSHOT_FEATURES:
             feat = _norm_feature(f)
-            if not _feature_enabled(ops, feat):
+            if not _state_read_feature_enabled(ops, feat):
                 continue
             try:
                 child = _create_single_snapshot(ops=ops, cfg=cfg, pid=pid, instance=inst, feat=feat, label=label, ts=ts)
@@ -566,7 +557,7 @@ def create_snapshot(
         return {"ok": True, "path": rel, "provider": pid, "instance": inst, "feature": "all", "label": payload["label"], "created_at": payload["created_at"], "stats": stats, "children": children}
 
     feat = _norm_feature(str(feat_any))
-    if not _feature_enabled(ops, feat):
+    if not _state_read_feature_enabled(ops, feat):
         raise ValueError(f"Feature not enabled for provider: {pid} / {feat}")
 
     return _create_single_snapshot(ops=ops, cfg=cfg, pid=pid, instance=inst, feat=feat, label=label, ts=ts)
@@ -752,7 +743,7 @@ def _restore_single_snapshot(
 
     if not _configured(ops, cfg_view):
         raise ValueError(f"Provider not configured: {pid}#{inst}")
-    if not _feature_enabled(ops, feat):
+    if not _state_read_feature_enabled(ops, feat):
         raise ValueError(f"Feature not enabled for provider: {pid} / {feat}")
 
     snap_items = snap.get("items") or {}
@@ -991,7 +982,7 @@ def clear_provider_features(
 
     for f in features:
         feat = _norm_feature(f)
-        if not _feature_enabled(ops, feat):
+        if not _state_read_feature_enabled(ops, feat):
             done["results"][feat] = {"ok": True, "skipped": True, "reason": "feature_disabled"}
             continue
         if pid == "PLEX" and feat == "progress":


### PR DESCRIPTION
# Pull request

## Change

- Added TMDb title and release-year enrichment for PublicMetaDB History, Ratings, Watchlist and Playback Progress.
- Reused metadata from the shared persistent cache where available.
- Added logging when enrichment cannot run because TMDb metadata is not configured.
- Added a provider-state capability for features that can expose a complete remote inventory.
- Kept outgoing PublicMetaDB Ratings synchronization enabled while excluding Ratings from Captures and Editor provider-state imports.
- Updated the PublicMetaDB adapter version to 0.3.

## Why

PublicMetaDB only return items containing TMDb identifiers, leaving titles and release years missing throughout CrossWatch.

PublicMetaDB also accepts rating writes but cannot enumerate a user’s complete ratings inventory. Its local ratings shadow must therefore not be treated as complete provider state for Captures or imports.

## Testing

- Tested enrichment across History, Ratings, Watchlist and Playback Progress.
- Tested cache reuse, expiry and locale separation.
- Tested logging when TMDb metadata is unavailable.
- Tested that outgoing Ratings remain enabled while Ratings Captures and provider-state imports are disabled.
- Tested full Captures, restore and comparison behavior.

## Issue

Part of #71