### PR TITLE
Fix:  Emby and Jellyfin episode resolution

### DIFF
--- a/providers/sync/_mod_EMBY.py
+++ b/providers/sync/_mod_EMBY.py
@@ -76,7 +76,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.0"
+__VERSION__ = "1.1"
 os.environ.setdefault("CW_EMBY_VERSION", __VERSION__)
 os.environ.setdefault("CW_EMBY_UA", f"CrossWatch/{__VERSION__} (Emby)")
 __all__ = ["get_manifest", "EMBYModule", "OPS"]
@@ -215,6 +215,7 @@ class EMBYConfig:
     history_backdate: bool = False
     history_backdate_tolerance_s: int = 300
     history_libraries: list[str] | None = None
+    progress_libraries: list[str] | None = None
     ratings_libraries: list[str] | None = None
 
 
@@ -318,6 +319,7 @@ class EMBYModule:
         hi_qlim = int(hi.get("history_query_limit", 25) or 25)
         hi_wdel = int(hi.get("history_write_delay_ms", 0) or 0)
         hi_gprio = hi.get("history_guid_priority") or wl_gprio
+        pr = dict(em.get("progress") or {})
         ra = dict(em.get("ratings") or {})
 
         def _list_str(v: Any) -> list[str] | None:
@@ -366,6 +368,7 @@ class EMBYModule:
             history_write_delay_ms=hi_wdel,
             history_guid_priority=list(hi_gprio),
             history_libraries=_list_str(hi.get("libraries")),
+            progress_libraries=_list_str(pr.get("libraries")),
             ratings_libraries=_list_str(ra.get("libraries")),
             history_force_overwrite=force_overwrite,
             history_backdate=backdate,

--- a/providers/sync/_mod_JELLYFIN.py
+++ b/providers/sync/_mod_JELLYFIN.py
@@ -74,7 +74,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.0"
+__VERSION__ = "1.1"
 os.environ.setdefault("CW_JELLYFIN_VERSION", __VERSION__)
 os.environ.setdefault("CW_JELLYFIN_UA", f"CrossWatch/{__VERSION__} (Jellyfin)")
 __all__ = ["get_manifest", "JELLYFINModule", "OPS"]
@@ -207,6 +207,7 @@ class JFConfig:
     history_write_delay_ms: int = 0
     history_guid_priority: list[str] | None = None
     history_libraries: list[str] | None = None
+    progress_libraries: list[str] | None = None
     ratings_libraries: list[str] | None = None
 
 
@@ -310,6 +311,7 @@ class JELLYFINModule:
         hi_qlim = int(hi.get("history_query_limit", 25) or 25)
         hi_wdel = int(hi.get("history_write_delay_ms", 0) or 0)
         hi_gprio = hi.get("history_guid_priority") or wl_gprio
+        pr = dict(jf.get("progress") or {})
         ra = dict(jf.get("ratings") or {})
 
         def _list_str(v: Any) -> list[str] | None:
@@ -336,6 +338,7 @@ class JELLYFINModule:
             history_write_delay_ms=hi_wdel,
             history_guid_priority=list(hi_gprio),
             history_libraries=_list_str(hi.get("libraries")),
+            progress_libraries=_list_str(pr.get("libraries")),
             ratings_libraries=_list_str(ra.get("libraries")),
         )
         self.client = JFClient(self.cfg)

--- a/providers/sync/emby/_common.py
+++ b/providers/sync/emby/_common.py
@@ -68,7 +68,7 @@ _BAD_NUM = re.compile(r"^\d{13,}$")
 CfgLike = Mapping[str, Any] | object
 
 # Adapter-scoped provider-index cache
-_PROVIDER_INDEX_CACHE: dict[int, tuple[float, dict[str, list[dict[str, Any]]]]] = {}
+_PROVIDER_INDEX_CACHE: dict[tuple[int, tuple[str, ...]], tuple[float, dict[str, list[dict[str, Any]]]]] = {}
 
 
 def _debug_level() -> str:
@@ -222,6 +222,44 @@ def emby_scope_history(cfg: CfgLike) -> dict[str, Any]:
         if libs_list:
             return _emby_scope_from_list(libs_list)
     return {}
+
+
+def emby_selected_library_ids(cfg: CfgLike, feature: str = "history") -> set[str]:
+    scope = emby_scope_history(cfg) if feature == "history" else emby_library_scope(cfg, feature)
+    parent = scope.get("ParentId")
+    if parent:
+        return {str(parent)}
+    ancestors = scope.get("AncestorIds") or []
+    return {str(value) for value in ancestors if value}
+
+
+def emby_item_library_ids(item: Mapping[str, Any]) -> set[str]:
+    out: set[str] = set()
+    for key in ("LibraryId", "CollectionFolderId"):
+        value = item.get(key)
+        if value:
+            out.add(str(value))
+    ancestors = item.get("AncestorIds") or []
+    if isinstance(ancestors, (list, tuple, set)):
+        out.update(str(value) for value in ancestors if value)
+    return out
+
+
+def emby_filter_library_candidates(
+    rows: Iterable[Mapping[str, Any]],
+    allowed: set[str],
+    *,
+    trust_query_scope: bool = False,
+) -> list[Mapping[str, Any]]:
+    candidates = list(rows)
+    if not allowed:
+        return candidates
+    matched = [row for row in candidates if emby_item_library_ids(row) & allowed]
+    if matched:
+        return matched
+    if trust_query_scope and not any(emby_item_library_ids(row) for row in candidates):
+        return candidates
+    return []
 
 
 def emby_scope_ratings(cfg: CfgLike) -> dict[str, Any]:
@@ -485,7 +523,7 @@ def all_ext_pairs(it_ids: Mapping[str, Any], priority: Iterable[str]) -> list[st
 
 
 # provider index
-def build_provider_index(adapter: Any) -> dict[str, list[dict[str, Any]]]:
+def build_provider_index(adapter: Any, *, feature: str | None = None) -> dict[str, list[dict[str, Any]]]:
     http, uid = adapter.client, adapter.cfg.user_id
     out: dict[str, list[dict[str, Any]]] = {}
     start, limit, total = 0, 500, None
@@ -498,7 +536,7 @@ def build_provider_index(adapter: Any) -> dict[str, list[dict[str, Any]]]:
             "Limit": limit,
             "EnableTotalRecordCount": True,
         }
-        params.update(emby_scope_any(adapter.cfg))
+        params.update(emby_library_scope(adapter.cfg, feature) if feature else emby_scope_any(adapter.cfg))
         r = http.get(f"/Users/{uid}/Items", params=params)
         body = r.json() or {}
         items = body.get("Items") or []
@@ -541,14 +579,14 @@ def build_provider_index(adapter: Any) -> dict[str, list[dict[str, Any]]]:
     return out
 
 
-def provider_index(adapter: Any, *, ttl_sec: int = 300, force_refresh: bool = False) -> dict[str, list[dict[str, Any]]]:
-    key = id(adapter)
+def provider_index(adapter: Any, *, ttl_sec: int = 300, force_refresh: bool = False, feature: str = "history") -> dict[str, list[dict[str, Any]]]:
+    key = (id(adapter), tuple(sorted(emby_selected_library_ids(adapter.cfg, feature))))
     now = time.time()
     if not force_refresh:
         hit = _PROVIDER_INDEX_CACHE.get(key)
         if hit and (now - hit[0]) < max(1, int(ttl_sec)):
             return hit[1]
-    idx = build_provider_index(adapter)
+    idx = build_provider_index(adapter) if feature == "history" else build_provider_index(adapter, feature=feature)
     _PROVIDER_INDEX_CACHE[key] = (now, idx)
     return idx
 
@@ -1185,7 +1223,7 @@ def _direct_query_by_pairs(
         "AnyProviderIdEquals": ",".join(pairs),
         "IncludeItemTypes": include_types,
         "Recursive": True,
-        "Fields": "ProviderIds,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesId,ParentId,Name",
+        "Fields": "ProviderIds,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesId,ParentId,CollectionFolderId,AncestorIds,LibraryId,Name",
         "Limit": 50,
         "UserId": uid,
     }
@@ -1200,8 +1238,24 @@ def _direct_query_by_pairs(
         return []
 
 
-def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
+def _episode_number_matches(row: Mapping[str, Any], season: Any, episode: Any) -> bool:
+    row_season = row.get("ParentIndexNumber")
+    row_episode = row.get("IndexNumber")
+    if row_season is None or row_episode is None or season is None or episode is None:
+        return False
+    try:
+        return (
+            int(row_season) == int(season)
+            and int(row_episode) == int(episode)
+        )
+    except (TypeError, ValueError):
+        return False
+
+
+def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "history") -> str | None:
     http, uid = adapter.client, adapter.cfg.user_id
+    selected_libs = emby_selected_library_ids(adapter.cfg, feature)
+    setattr(adapter, "_emby_last_resolve_hint", None)
     ids = dict(it.get("ids") or {})
     try:
         memo: dict[str, str | None] = getattr(adapter, "_emby_resolve_cache")
@@ -1223,6 +1277,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
                 "e": it.get("episode"),
                 "st": it.get("series_title"),
                 "sid": it.get("show_ids"),
+                "libs": sorted(selected_libs),
             },
             sort_keys=True,
         )
@@ -1237,9 +1292,25 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
         return memo[mk]
     em = ids.get("emby")
     if em and not looks_like_bad_id(em):
-        cw_log("EMBY", "common", "debug", "resolve_hit", kind="direct", method="provider_id", item_id=str(em))
-        memo[mk] = str(em)
-        return str(em)
+        if selected_libs:
+            try:
+                response = http.get(
+                    f"/Users/{uid}/Items/{em}",
+                    params={"Fields": "LibraryId,CollectionFolderId,AncestorIds,ParentId,Type"},
+                )
+                row = response.json() or {} if getattr(response, "status_code", 0) == 200 else {}
+            except Exception:
+                row = {}
+            if not emby_filter_library_candidates([row] if row else [], selected_libs):
+                setattr(adapter, "_emby_last_resolve_hint", "outside_library_scope")
+                cw_log("EMBY", "common", "debug", "target_candidate_outside_library_scope", item_id=str(em), allowed_library_ids=sorted(selected_libs), resolution_method="provider_id")
+            else:
+                memo[mk] = str(em)
+                return str(em)
+        else:
+            cw_log("EMBY", "common", "debug", "resolve_hit", kind="direct", method="provider_id", item_id=str(em))
+            memo[mk] = str(em)
+            return str(em)
     t = _lookup_type(it)
     title = (it.get("title") or "").strip()
     year = it.get("year")
@@ -1251,6 +1322,11 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
     series_ids = dict(it.get("show_ids") or {})
     prio = _merged_guid_priority(adapter)
     ep_pairs = all_ext_pairs(ids, prio)
+    exact_episode_pairs = [
+        pref
+        for pref in ep_pairs
+        if pref.partition(".")[0] in ("tmdb", "imdb", "tvdb")
+    ]
     series_pairs = all_ext_pairs(series_ids, prio) if series_ids else []
     scope_hist: dict[str, Any] = {}
     try:
@@ -1272,6 +1348,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
         or it.get("source_library_id")
         or ""
     ).strip()
+    outside_scope_seen = False
     def _row_lib_candidates(row: Mapping[str, Any]) -> list[str]:
         c: list[str] = []
         try:
@@ -1286,24 +1363,25 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
             pass
         return c
     def _prefer_library(rows: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+        nonlocal outside_scope_seen
         if not rows:
             return list(rows)
-        if hint_lib:
+        if hint_lib and (not allowed_libs or hint_lib in allowed_libs):
             m = [r for r in rows if hint_lib in _row_lib_candidates(r)]
             if m:
                 return m
         if allowed_libs:
-            aset = set(allowed_libs)
-            m = [r for r in rows if any(x in aset for x in _row_lib_candidates(r))]
-            if m:
-                return m
+            filtered = emby_filter_library_candidates(rows, set(allowed_libs), trust_query_scope=True)
+            if not filtered:
+                outside_scope_seen = True
+            return filtered
         return list(rows)
     if hint_lib and hint_lib in allowed_libs:
         scope = _emby_scope_from_list([hint_lib])
     elif allowed_libs:
         scope = _emby_scope_from_list(allowed_libs)
     else:
-        scope = emby_scope_any(adapter.cfg)
+        scope = emby_library_scope(adapter.cfg, feature)
     if t == "movie":
         rows = _direct_query_by_pairs(http, uid, ep_pairs, "Movie", scope)
         if rows:
@@ -1323,26 +1401,79 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
                 memo[mk] = iid
                 return iid
     elif t == "episode":
-        rows = _direct_query_by_pairs(http, uid, ep_pairs, "Episode,Series", scope)
-        ep_row = next(
-            (
-                r
-                for r in rows
-                if (r.get("Type") or "") == "Episode"
-                and int(r.get("ParentIndexNumber") or -1) == int(season or -999)
-                and int(r.get("IndexNumber") or -1) == int(episode or -999)
-            ),
-            None,
-        )
-        if ep_row and ep_row.get("Id"):
-            iid = str(ep_row["Id"])
-            memo[mk] = iid
-            cw_log("EMBY", "common", "debug", "resolve_hit", kind="episode", method="direct_query", item_id=iid)
-            return iid
-        ser_row = next((r for r in rows if (r.get("Type") or "") == "Series"), None)
-        if not ser_row and series_pairs:
-            rows2 = _direct_query_by_pairs(http, uid, series_pairs, "Series", scope)
-            ser_row = next((r for r in rows2 if (r.get("Type") or "") == "Series"), None)
+        for pref in exact_episode_pairs:
+            rows = _direct_query_by_pairs(http, uid, [pref], "Episode,Series", scope)
+            episode_rows: list[Mapping[str, Any]] = []
+            seen_episode_ids: set[str] = set()
+            for row in _prefer_library(rows):
+                iid = str(row.get("Id") or "").strip()
+                if (row.get("Type") or "") != "Episode" or not iid or looks_like_bad_id(iid):
+                    continue
+                if iid not in seen_episode_ids:
+                    seen_episode_ids.add(iid)
+                    episode_rows.append(row)
+            provider_type, _, provider_value = pref.partition(".")
+            if len(episode_rows) == 1:
+                iid = str(episode_rows[0]["Id"])
+                memo[mk] = iid
+                cw_log(
+                    "EMBY",
+                    "common",
+                    "debug",
+                    "resolve_hit",
+                    kind="episode",
+                    method="exact_episode_provider_id",
+                    provider_type=provider_type,
+                    provider_value=provider_value,
+                    item_id=iid,
+                )
+                return iid
+            if len(episode_rows) > 1:
+                numbered = [
+                    row
+                    for row in episode_rows
+                    if _episode_number_matches(row, season, episode)
+                ]
+                if len(numbered) == 1:
+                    iid = str(numbered[0]["Id"])
+                    memo[mk] = iid
+                    cw_log(
+                        "EMBY",
+                        "common",
+                        "debug",
+                        "resolve_hit",
+                        kind="episode",
+                        method="episode_provider_id_number_disambiguation",
+                        provider_type=provider_type,
+                        provider_value=provider_value,
+                        season=season,
+                        episode=episode,
+                        item_id=iid,
+                    )
+                    return iid
+                cw_log(
+                    "EMBY",
+                    "common",
+                    "debug",
+                    "resolve_miss",
+                    kind="episode",
+                    method="ambiguous_episode_provider_id",
+                    provider_type=provider_type,
+                    provider_value=provider_value,
+                    candidate_count=len(episode_rows),
+                    numbered_candidate_count=len(numbered),
+                    season=season,
+                    episode=episode,
+                )
+        ser_row: Mapping[str, Any] | None = None
+        matched_series_pair: str | None = None
+        for pref in series_pairs:
+            rows = _direct_query_by_pairs(http, uid, [pref], "Series", scope)
+            series_rows = [r for r in _prefer_library(rows) if (r.get("Type") or "") == "Series"]
+            if series_rows:
+                ser_row = series_rows[0]
+                matched_series_pair = pref
+                break
         if ser_row and season is not None and episode is not None:
             sid = ser_row.get("Id")
             if sid:
@@ -1361,13 +1492,15 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
                                 "debug",
                                 "resolve_hit",
                                 kind="episode",
-                                method="series_episodes",
+                                method="show_provider_id_episode_number",
+                                provider_type=(matched_series_pair or "").partition(".")[0],
+                                provider_value=(matched_series_pair or "").partition(".")[2],
                                 season=int(season),
                                 episode=int(episode),
                                 item_id=iid,
                             )
                             return iid
-    idx = provider_index(adapter)
+    idx = provider_index(adapter, feature=feature)
     if t == "movie":
         for pref in ep_pairs:
             cands = idx.get(pref) or []
@@ -1406,15 +1539,19 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
                 return iid
     if t == "episode":
         series_row: dict[str, Any] | None = None
+        matched_series_pair: str | None = None
         if series_pairs:
-            series_row = find_series_in_index(adapter, series_pairs)
-            if series_row:
-                cw_log("EMBY", "common", "debug", "resolve_hit", kind="series", method="show_ids_index")
-        if not series_row and ep_pairs:
-            maybe = find_series_in_index(adapter, ep_pairs)
-            if maybe:
-                series_row = maybe
-                cw_log("EMBY", "common", "debug", "resolve_hit", kind="series", method="episode_ids_index")
+            idx_rows = provider_index(adapter, feature=feature)
+            for pref in series_pairs:
+                candidates = [
+                    row
+                    for row in _prefer_library(idx_rows.get(pref) or [])
+                    if (row.get("Type") or "") == "Series"
+                ]
+                if candidates:
+                    series_row = dict(candidates[0])
+                    matched_series_pair = pref
+                    break
         if series_row and season is not None and episode is not None:
             sid = series_row.get("Id")
             if sid:
@@ -1436,7 +1573,9 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
                                 "debug",
                                 "resolve_hit",
                                 kind="episode",
-                                method="provider_index_episode",
+                                method="show_provider_id_episode_number",
+                                provider_type=(matched_series_pair or "").partition(".")[0],
+                                provider_value=(matched_series_pair or "").partition(".")[2],
                                 season=int(season),
                                 episode=int(episode),
                                 item_id=str(iid),
@@ -1464,7 +1603,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
             r = http.get("/Items", params=q)
             t_l = title.lower()
             cand: list[Mapping[str, Any]] = []
-            for row in _items(r):
+            for row in _prefer_library(_items(r)):
                 if (row.get("Type") or "") != "Movie":
                     continue
                 nm = (row.get("Name") or "").strip().lower()
@@ -1504,7 +1643,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
             r = http.get("/Items", params=q)
             title_lc = title.lower()
             cand2: list[Mapping[str, Any]] = []
-            for row in _items(r):
+            for row in _prefer_library(_items(r)):
                 if (row.get("Type") or "") != "Series":
                     continue
                 nm = (row.get("Name") or "").strip().lower()
@@ -1548,7 +1687,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
             q.update(scope or {})
             r = http.get("/Items", params=q)
             t_l = title.lower()
-            for row in _items(r):
+            for row in _prefer_library(_items(r)):
                 if (row.get("Type") or "") != "Episode":
                     continue
                 nm = (row.get("Name") or "").strip().lower()
@@ -1585,9 +1724,11 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
         episode=episode,
         series_title=series_title,
     )
+    if outside_scope_seen or getattr(adapter, "_emby_last_resolve_hint", None) == "outside_library_scope":
+        setattr(adapter, "_emby_last_resolve_hint", "outside_library_scope")
     return None
 
-def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
+def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "history") -> list[str]:
     http = getattr(adapter, "client", None)
     uid = getattr(getattr(adapter, "cfg", None), "user_id", None)
     if not http or not uid:
@@ -1599,7 +1740,8 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
         if s and not looks_like_bad_id(s):
             return [s]
 
-    one = resolve_item_id(adapter, it)
+    one = resolve_item_id(adapter, it, feature=feature)
+    selected_libs = emby_selected_library_ids(adapter.cfg, feature)
 
     ids = dict(it.get("ids") or {})
     show_ids = it.get("show_ids") if isinstance(it.get("show_ids"), Mapping) else None
@@ -1620,7 +1762,7 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
             if p not in pairs:
                 pairs.append(p)
 
-    idx = build_provider_index(adapter)
+    idx = build_provider_index(adapter) if feature == "history" else build_provider_index(adapter, feature=feature)
 
     def _valid(iid: Any) -> str | None:
         s = str(iid or "").strip()
@@ -1638,7 +1780,7 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
 
     if t == "movie":
         for pref in pairs:
-            rows = idx.get(pref) or []
+            rows = emby_filter_library_candidates(idx.get(pref) or [], selected_libs)
             cands = [row for row in rows if (row.get("Type") or "") == "Movie"]
             if isinstance(year, int):
                 yr = int(year)
@@ -1665,10 +1807,10 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
                     "Fields": "ProviderIds,ProductionYear,Type",
                     "Limit": 50,
                 }
-                q.update(emby_scope_any(adapter.cfg))
+                q.update(emby_library_scope(adapter.cfg, feature))
                 r = http.get("/Items", params=q)
                 t_l = title.lower()
-                for row in _items(r):
+                for row in emby_filter_library_candidates(_items(r), selected_libs, trust_query_scope=True):
                     if (row.get("Type") or "") != "Movie":
                         continue
                     nm = (row.get("Name") or "").strip().lower()
@@ -1685,7 +1827,7 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
 
     if t == "episode":
         for pref in pairs:
-            rows = idx.get(pref) or []
+            rows = emby_filter_library_candidates(idx.get(pref) or [], selected_libs)
             cands = [row for row in rows if (row.get("Type") or "") == "Episode"]
             for row in cands:
                 try:
@@ -1711,10 +1853,10 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
                     "Fields": "ProviderIds,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesName",
                     "Limit": 200,
                 }
-                q.update(emby_scope_any(adapter.cfg))
+                q.update(emby_library_scope(adapter.cfg, feature))
                 r = http.get("/Items", params=q)
                 st_l = series_title.lower()
-                for row in _items(r):
+                for row in emby_filter_library_candidates(_items(r), selected_libs, trust_query_scope=True):
                     if (row.get("Type") or "") != "Episode":
                         continue
                     sn = (row.get("SeriesName") or "").strip().lower()

--- a/providers/sync/emby/_progress.py
+++ b/providers/sync/emby/_progress.py
@@ -9,8 +9,10 @@ from typing import Any, Iterable, Mapping
 from cw_platform.id_map import canonical_key
 
 from ._common import (
+    emby_item_library_ids,
     make_logger,
     normalize as emby_normalize,
+    emby_selected_library_ids,
     resolve_item_id,
     resolve_item_ids,
 )
@@ -58,39 +60,74 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
     if not http or not uid:
         return {}
 
-    params: dict[str, Any] = {
+    base_params: dict[str, Any] = {
         "Recursive": True,
         "IncludeItemTypes": "Movie,Episode",
-        "Fields": "UserData,ProviderIds,RunTimeTicks,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesId,ParentId,Name",
+        "Fields": "UserData,ProviderIds,RunTimeTicks,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesId,ParentId,CollectionFolderId,AncestorIds,LibraryId,Name",
         "EnableUserData": True,
         "IsResumable": True,
-        "Limit": 10_000,
     }
-
-    try:
-        r = http.get(f"/Users/{uid}/Items", params=params)
-        if getattr(r, "status_code", 0) != 200:
-            _warn("http_failed", op="build_index", status=getattr(r, "status_code", None))
-            return {}
-        body = r.json() or {}
-        rows = body.get("Items") or []
-        if not isinstance(rows, list):
-            return {}
-    except Exception as e:
-        _warn("http_failed", op="build_index", error=str(e))
-        return {}
+    allowed = emby_selected_library_ids(adapter.cfg, "progress")
+    if not allowed:
+        _dbg("library_scope_not_configured")
+    parents: list[str | None] = list(sorted(allowed))
+    if not parents:
+        parents.append(None)
+    rows: list[tuple[Mapping[str, Any], str | None]] = []
+    seen_item_ids: set[str] = set()
+    page_size = 500
+    for parent_id in parents:
+        start = 0
+        while True:
+            params = dict(base_params)
+            params.update({"StartIndex": start, "Limit": page_size, "EnableTotalRecordCount": True})
+            if parent_id:
+                params["ParentId"] = parent_id
+            try:
+                r = http.get(f"/Users/{uid}/Items", params=params)
+                if getattr(r, "status_code", 0) != 200:
+                    _warn("library_scope_query_failed", source_library_id=parent_id, allowed_library_ids=sorted(allowed), status=getattr(r, "status_code", None))
+                    break
+                body = r.json() or {}
+                page = body.get("Items") or []
+                if not isinstance(page, list):
+                    break
+            except Exception as e:
+                _warn("library_scope_query_failed", source_library_id=parent_id, allowed_library_ids=sorted(allowed), error=str(e))
+                break
+            new_count = 0
+            for raw in page:
+                if not isinstance(raw, Mapping):
+                    continue
+                item_id = str(raw.get("Id") or "").strip()
+                if item_id and item_id in seen_item_ids:
+                    _dbg("duplicate_progress_item", provider_item_id=item_id, source_library_id=parent_id, item_title=str(raw.get("Name") or ""), media_type=str(raw.get("Type") or ""))
+                    continue
+                if item_id:
+                    seen_item_ids.add(item_id)
+                rows.append((raw, parent_id))
+                new_count += 1
+            start += len(page)
+            total = int(body.get("TotalRecordCount") or 0)
+            if not page or (total and start >= total) or len(page) < page_size or new_count == 0:
+                break
 
     out: dict[str, dict[str, Any]] = {}
     total_rows = 0
     dup_keys = 0
-    for raw in rows:
-        if not isinstance(raw, Mapping):
-            continue
+    for raw, source_library_id in rows:
         total_rows += 1
+        if allowed:
+            memberships = emby_item_library_ids(raw)
+            if memberships and not (memberships & allowed):
+                _dbg("outside_library_scope", provider_item_id=str(raw.get("Id") or ""), source_library_id=source_library_id, allowed_library_ids=sorted(allowed), item_title=str(raw.get("Name") or ""), media_type=str(raw.get("Type") or ""), provider_ids=dict(raw.get("ProviderIds") or {}))
+                continue
         try:
             item = emby_normalize(raw)
         except Exception:
             continue
+        if source_library_id:
+            item["library_id"] = source_library_id
 
         ud = _pick_user_data(raw)
         pos_ms = _ticks_to_ms(ud.get("PlaybackPositionTicks"))
@@ -143,7 +180,7 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
             action=action,
         )
 
-    _info("index_done", count=len(out), rows=total_rows, dup_keys=dup_keys)
+    _info("index_done", count=len(out), rows=total_rows, dup_keys=dup_keys, allowed_library_ids=sorted(allowed), scope_enabled=bool(allowed))
     return out
 
 
@@ -160,10 +197,10 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         it0 = dict(it or {})
         ck = canonical_key(it0) or ""
         ids = dict(it0.get("ids") or {})
-        iids = resolve_item_ids(adapter, it0)
+        iids = resolve_item_ids(adapter, it0, feature="progress")
         if not iids:
             _dbg("resolve_miss", canonical_key=str(ck), type=str(it0.get("type") or ""), ids=ids)
-            unresolved.append({"item": it0, "hint": "not_found"})
+            unresolved.append({"item": it0, "hint": str(getattr(adapter, "_emby_last_resolve_hint", "") or "not_found")})
             continue
         _dbg("resolve_hit", canonical_key=str(ck), type=str(it0.get("type") or ""), ids=ids, resolved=len(iids))
 
@@ -211,7 +248,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
     for it in items or []:
         it0 = dict(it or {})
         ck = canonical_key(it0) or ""
-        iid = resolve_item_id(adapter, it0)
+        iid = resolve_item_id(adapter, it0, feature="progress")
         if not iid:
             _dbg("resolve_miss", canonical_key=str(ck))
             unresolved.append({"item": it0, "hint": "not_found"})

--- a/providers/sync/jellyfin/_common.py
+++ b/providers/sync/jellyfin/_common.py
@@ -2,7 +2,7 @@
 # JELLYFIN Module for common functions
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
-from typing import Any, Mapping, Iterable
+from typing import Any, Mapping, Iterable, Sequence
 
 import json
 import os
@@ -202,6 +202,44 @@ def with_jf_scope(params: Mapping[str, Any], cfg: CfgLike, feature: str) -> dict
 
 def jf_scope_history(cfg: CfgLike) -> dict[str, Any]:
     return jf_library_scope(cfg, "history")
+
+
+def jf_selected_library_ids(cfg: CfgLike, feature: str = "history") -> set[str]:
+    scope = jf_scope_history(cfg) if feature == "history" else jf_library_scope(cfg, feature)
+    parent = scope.get("ParentId")
+    if parent:
+        return {str(parent)}
+    ancestors = scope.get("AncestorIds") or []
+    return {str(value) for value in ancestors if value}
+
+
+def jf_item_library_ids(item: Mapping[str, Any]) -> set[str]:
+    out: set[str] = set()
+    for key in ("LibraryId", "CollectionFolderId"):
+        value = item.get(key)
+        if value:
+            out.add(str(value))
+    ancestors = item.get("AncestorIds") or []
+    if isinstance(ancestors, (list, tuple, set)):
+        out.update(str(value) for value in ancestors if value)
+    return out
+
+
+def jf_filter_library_candidates(
+    rows: Iterable[Mapping[str, Any]],
+    allowed: set[str],
+    *,
+    trust_query_scope: bool = False,
+) -> list[Mapping[str, Any]]:
+    candidates = list(rows)
+    if not allowed:
+        return candidates
+    matched = [row for row in candidates if jf_item_library_ids(row) & allowed]
+    if matched:
+        return matched
+    if trust_query_scope and not any(jf_item_library_ids(row) for row in candidates):
+        return candidates
+    return []
 
 
 def jf_scope_ratings(cfg: CfgLike) -> dict[str, Any]:
@@ -594,9 +632,10 @@ def all_ext_pairs(it_ids: Mapping[str, Any], priority: Iterable[str]) -> list[st
 
 
 # provider index
-def build_provider_index(adapter: Any) -> dict[str, list[dict[str, Any]]]:
+def build_provider_index(adapter: Any, *, feature: str | None = None) -> dict[str, list[dict[str, Any]]]:
     cache = getattr(adapter, "_provider_index_cache", None)
-    if isinstance(cache, dict) and cache:
+    scope_key = tuple(sorted(jf_selected_library_ids(adapter.cfg, feature or "history")))
+    if isinstance(cache, dict) and cache and getattr(adapter, "_provider_index_scope", None) == scope_key:
         return cache
 
     http = adapter.client
@@ -615,7 +654,7 @@ def build_provider_index(adapter: Any) -> dict[str, list[dict[str, Any]]]:
             "Limit": limit,
             "EnableTotalRecordCount": True,
         }
-        params.update(jf_scope_any(adapter.cfg))
+        params.update(jf_library_scope(adapter.cfg, feature) if feature else jf_scope_any(adapter.cfg))
         r = http.get(f"/Users/{uid}/Items", params=params)
         body = r.json() or {}
         items = body.get("Items") or []
@@ -650,6 +689,7 @@ def build_provider_index(adapter: Any) -> dict[str, list[dict[str, Any]]]:
         rows.sort(key=lambda r: str(r.get("Id") or ""))
     _dbg('index_done', source='provider_index', count=len(out))
     setattr(adapter, "_provider_index_cache", out)
+    setattr(adapter, "_provider_index_scope", scope_key)
     return out
 
 
@@ -937,12 +977,12 @@ def update_userdata(http: Any, user_id: str, item_id: str, payload: Mapping[str,
 
 # resolver (movie/show/episode)
 def _pick_from_candidates(
-    cands: list[dict[str, Any]],
+    cands: Sequence[Mapping[str, Any]],
     *,
     want_type: str | None,
     want_year: int | None,
 ) -> str | None:
-    def score_val(row: dict[str, Any]) -> tuple[int, int, str]:
+    def score_val(row: Mapping[str, Any]) -> tuple[int, int, str]:
         t = (row.get("Type") or "").strip()
         y = row.get("ProductionYear")
         s = 0
@@ -967,9 +1007,54 @@ def _pick_from_candidates(
     return str(iid) if iid and not looks_like_bad_id(iid) else None
 
 
-def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
+def _direct_query_by_pairs(
+    http: Any,
+    uid: str,
+    pairs: list[str],
+    include_types: str,
+    scope: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    if not pairs:
+        return []
+    q: dict[str, Any] = {
+        "AnyProviderIdEquals": ",".join(pairs),
+        "IncludeItemTypes": include_types,
+        "Recursive": True,
+        "Fields": "ProviderIds,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesId,ParentId,CollectionFolderId,AncestorIds,LibraryId,Name",
+        "Limit": 50,
+        "UserId": uid,
+    }
+    q.update(scope or {})
+    try:
+        r = http.get(f"/Users/{uid}/Items", params=q)
+        if getattr(r, "status_code", 0) != 200:
+            return []
+        body = r.json() or {}
+        return body.get("Items") or []
+    except Exception:
+        return []
+
+
+def _episode_number_matches(row: Mapping[str, Any], season: Any, episode: Any) -> bool:
+    row_season = row.get("ParentIndexNumber")
+    row_episode = row.get("IndexNumber")
+    if row_season is None or row_episode is None or season is None or episode is None:
+        return False
+    try:
+        return (
+            int(row_season) == int(season)
+            and int(row_episode) == int(episode)
+        )
+    except (TypeError, ValueError):
+        return False
+
+
+def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "history") -> str | None:
     http = adapter.client
     uid = adapter.cfg.user_id
+    selected_libs = jf_selected_library_ids(adapter.cfg, feature)
+    setattr(adapter, "_jellyfin_last_resolve_hint", None)
+    outside_scope_seen = False
 
     # Prefer native Jellyfin item id when present.
     raw_iid = it.get("jellyfin_item_id") or it.get("_jellyfin_item_id")
@@ -984,8 +1069,24 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
 
     jf = ids.get("jellyfin")
     if jf and not looks_like_bad_id(jf):
-        _dbg('resolve_hit', kind='direct', method='provider_id', item_id=str(jf))
-        return str(jf)
+        if selected_libs:
+            try:
+                response = http.get(
+                    f"/Users/{uid}/Items/{jf}",
+                    params={"Fields": "LibraryId,CollectionFolderId,AncestorIds,ParentId,Type"},
+                )
+                row = response.json() or {} if getattr(response, "status_code", 0) == 200 else {}
+            except Exception:
+                row = {}
+            if not jf_filter_library_candidates([row] if row else [], selected_libs):
+                outside_scope_seen = True
+                setattr(adapter, "_jellyfin_last_resolve_hint", "outside_library_scope")
+                _dbg('target_candidate_outside_library_scope', item_id=str(jf), allowed_library_ids=sorted(selected_libs), resolution_method='provider_id')
+            else:
+                return str(jf)
+        else:
+            _dbg('resolve_hit', kind='direct', method='provider_id', item_id=str(jf))
+            return str(jf)
 
     t = _lookup_type(it)
     title = (it.get("title") or "").strip()
@@ -997,20 +1098,23 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
     strict = bool(getattr(getattr(adapter, "cfg", None), "strict_id_matching", False))
 
     prio = guid_priority_from_cfg(getattr(getattr(adapter, "cfg", None), "watchlist_guid_priority", None))
-    pairs = all_ext_pairs(ids, prio)
+    episode_pairs = all_ext_pairs(ids, prio)
+    series_pairs = all_ext_pairs(show_ids, prio) if show_ids else []
+    pairs = list(episode_pairs)
 
-    if show_ids:
-        spairs = all_ext_pairs(show_ids, prio)
-        for p in spairs:
+    if series_pairs:
+        for p in series_pairs:
             if p not in pairs:
                 pairs.append(p)
 
-    idx = build_provider_index(adapter)
-
     # Movies
     if t == "movie":
+        idx = build_provider_index(adapter) if feature == "history" else build_provider_index(adapter, feature=feature)
         for pref in pairs:
-            cands = idx.get(pref) or []
+            raw_cands = idx.get(pref) or []
+            cands = jf_filter_library_candidates(raw_cands, selected_libs)
+            if raw_cands and not cands and selected_libs:
+                outside_scope_seen = True
             iid = _pick_from_candidates(cands, want_type="movie", want_year=year)
             if iid:
                 _dbg('resolve_hit', kind='movie', method='provider_index', pref=pref, item_id=iid)
@@ -1025,11 +1129,15 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
                     "Fields": "ProviderIds,ProductionYear,Type",
                     "Limit": 50,
                 }
-                q.update(jf_scope_any(adapter.cfg))
+                q.update(jf_library_scope(adapter.cfg, feature))
                 r = http.get("/Items", params=q)
                 t_l = title.lower()
                 cand: list[Mapping[str, Any]] = []
-                for row in (r.json() or {}).get("Items") or []:
+                raw_rows = (r.json() or {}).get("Items") or []
+                scoped_rows = jf_filter_library_candidates(raw_rows, selected_libs, trust_query_scope=True)
+                if raw_rows and not scoped_rows and selected_libs:
+                    outside_scope_seen = True
+                for row in scoped_rows:
                     if (row.get("Type") or "") != "Movie":
                         continue
                     nm = (row.get("Name") or "").strip().lower()
@@ -1045,12 +1153,18 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
             except Exception:
                 pass
         _dbg('resolve_miss', kind='movie', title=title, year=year)
+        if outside_scope_seen:
+            setattr(adapter, "_jellyfin_last_resolve_hint", "outside_library_scope")
         return None
 
     # Shows
     if t in ("show", "series"):
+        idx = build_provider_index(adapter) if feature == "history" else build_provider_index(adapter, feature=feature)
         for pref in pairs:
-            rows = idx.get(pref) or []
+            raw_rows = idx.get(pref) or []
+            rows = jf_filter_library_candidates(raw_rows, selected_libs)
+            if raw_rows and not rows and selected_libs:
+                outside_scope_seen = True
             cands = [row for row in rows if (row.get("Type") or "").strip() == "Series"]
             iid = _pick_from_candidates(cands, want_type="show", want_year=year)
             if iid:
@@ -1066,11 +1180,15 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
                     "Fields": "ProviderIds,ProductionYear,Type",
                     "Limit": 50,
                 }
-                q.update(jf_scope_any(adapter.cfg))
+                q.update(jf_library_scope(adapter.cfg, feature))
                 r = http.get("/Items", params=q)
                 title_lc = title.lower()
                 cand = []
-                for row in (r.json() or {}).get("Items") or []:
+                raw_rows = (r.json() or {}).get("Items") or []
+                scoped_rows = jf_filter_library_candidates(raw_rows, selected_libs, trust_query_scope=True)
+                if raw_rows and not scoped_rows and selected_libs:
+                    outside_scope_seen = True
+                for row in scoped_rows:
                     if (row.get("Type") or "") != "Series":
                         continue
                     nm = (row.get("Name") or "").strip().lower()
@@ -1088,14 +1206,95 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
             except Exception:
                 pass
         _dbg('resolve_miss', kind='series', title=title, year=year)
+        if outside_scope_seen:
+            setattr(adapter, "_jellyfin_last_resolve_hint", "outside_library_scope")
         return None
 
     # Episodes
+    scope = jf_library_scope(adapter.cfg, feature)
+    for pref in episode_pairs:
+        rows = _direct_query_by_pairs(http, uid, [pref], "Episode,Series", scope)
+        episode_rows: list[Mapping[str, Any]] = []
+        seen_episode_ids: set[str] = set()
+        filtered_rows = jf_filter_library_candidates(rows, selected_libs, trust_query_scope=True)
+        if rows and not filtered_rows and selected_libs:
+            outside_scope_seen = True
+        for row in filtered_rows:
+            iid = str(row.get("Id") or "").strip()
+            if (row.get("Type") or "") != "Episode" or not iid or looks_like_bad_id(iid):
+                continue
+            if iid not in seen_episode_ids:
+                seen_episode_ids.add(iid)
+                episode_rows.append(row)
+        provider_type, _, provider_value = pref.partition(".")
+        if len(episode_rows) == 1:
+            iid = str(episode_rows[0]["Id"])
+            _dbg(
+                'resolve_hit',
+                kind='episode',
+                method='exact_episode_provider_id',
+                provider_type=provider_type,
+                provider_value=provider_value,
+                item_id=iid,
+            )
+            return iid
+        if len(episode_rows) > 1:
+            numbered = [
+                row
+                for row in episode_rows
+                if _episode_number_matches(row, season, episode)
+            ]
+            if len(numbered) == 1:
+                iid = str(numbered[0]["Id"])
+                _dbg(
+                    'resolve_hit',
+                    kind='episode',
+                    method='episode_provider_id_number_disambiguation',
+                    provider_type=provider_type,
+                    provider_value=provider_value,
+                    season=season,
+                    episode=episode,
+                    item_id=iid,
+                )
+                return iid
+            _dbg(
+                'resolve_miss',
+                kind='episode',
+                method='ambiguous_episode_provider_id',
+                provider_type=provider_type,
+                provider_value=provider_value,
+                candidate_count=len(episode_rows),
+                numbered_candidate_count=len(numbered),
+                season=season,
+                episode=episode,
+            )
+
     series_row: dict[str, Any] | None = None
-    if pairs:
-        series_row = find_series_in_index(adapter, pairs)
-        if series_row:
-            _dbg('resolve_hit', kind='series', method='provider_index_candidate')
+    matched_series_pair: str | None = None
+    for pref in series_pairs:
+        rows = _direct_query_by_pairs(http, uid, [pref], "Series", scope)
+        scoped_rows = jf_filter_library_candidates(rows, selected_libs, trust_query_scope=True)
+        if rows and not scoped_rows and selected_libs:
+            outside_scope_seen = True
+        series_rows = [row for row in scoped_rows if (row.get("Type") or "") == "Series"]
+        if series_rows:
+            series_row = dict(series_rows[0])
+            matched_series_pair = pref
+            break
+    if not series_row and series_pairs:
+        idx = build_provider_index(adapter) if feature == "history" else build_provider_index(adapter, feature=feature)
+        for pref in series_pairs:
+            raw_rows = idx.get(pref) or []
+            rows = jf_filter_library_candidates(raw_rows, selected_libs)
+            if raw_rows and not rows and selected_libs:
+                outside_scope_seen = True
+            series_row = next(
+                (dict(row) for row in rows if (row.get("Type") or "").strip() == "Series"),
+                None,
+            )
+            if series_row:
+                matched_series_pair = pref
+                break
     if not series_row and series_title and not strict:
         try:
             q = {
@@ -1106,11 +1305,15 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
                 "Fields": "ProviderIds,ProductionYear,Type",
                 "Limit": 50,
             }
-            q.update(jf_scope_any(adapter.cfg))
+            q.update(jf_library_scope(adapter.cfg, feature))
             r = http.get("/Items", params=q)
             t_l = series_title.lower()
             cands = []
-            for row in (r.json() or {}).get("Items") or []:
+            raw_rows = (r.json() or {}).get("Items") or []
+            scoped_rows = jf_filter_library_candidates(raw_rows, selected_libs, trust_query_scope=True)
+            if raw_rows and not scoped_rows and selected_libs:
+                outside_scope_seen = True
+            for row in scoped_rows:
                 if (row.get("Type") or "") != "Series":
                     continue
                 nm = (row.get("Name") or "").strip().lower()
@@ -1133,7 +1336,16 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
                 if isinstance(s, int) and isinstance(e, int) and s == int(season) and e == int(episode):
                     iid = row.get("Id")
                     if iid and not looks_like_bad_id(iid):
-                        _dbg('resolve_hit', kind='episode', method='series_episodes', season=int(season), episode=int(episode), item_id=str(iid))
+                        _dbg(
+                            'resolve_hit',
+                            kind='episode',
+                            method='show_provider_id_episode_number',
+                            provider_type=(matched_series_pair or '').partition('.')[0],
+                            provider_value=(matched_series_pair or '').partition('.')[2],
+                            season=int(season),
+                            episode=int(episode),
+                            item_id=str(iid),
+                        )
                         return str(iid)
 
     if title and not strict:
@@ -1146,10 +1358,14 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
                 "Fields": "ProviderIds,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesId",
                 "Limit": 50,
             }
-            q.update(jf_scope_any(adapter.cfg))
+            q.update(jf_library_scope(adapter.cfg, feature))
             r = http.get("/Items", params=q)
             t_l = title.lower()
-            for row in (r.json() or {}).get("Items") or []:
+            raw_rows = (r.json() or {}).get("Items") or []
+            scoped_rows = jf_filter_library_candidates(raw_rows, selected_libs, trust_query_scope=True)
+            if raw_rows and not scoped_rows and selected_libs:
+                outside_scope_seen = True
+            for row in scoped_rows:
                 if (row.get("Type") or "") != "Episode":
                     continue
                 nm = (row.get("Name") or "").strip().lower()
@@ -1164,10 +1380,12 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any]) -> str | None:
             pass
 
     _dbg('resolve_miss', kind='episode', title=title, series_title=series_title, season=season, episode=episode)
+    if outside_scope_seen:
+        setattr(adapter, "_jellyfin_last_resolve_hint", "outside_library_scope")
     return None
 
 
-def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
+def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "history") -> list[str]:
     http = getattr(adapter, "client", None)
     uid = getattr(getattr(adapter, "cfg", None), "user_id", None)
     if not http or not uid:
@@ -1180,7 +1398,8 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
         if s and not looks_like_bad_id(s):
             return [s]
 
-    one = resolve_item_id(adapter, it)
+    one = resolve_item_id(adapter, it, feature=feature)
+    selected_libs = jf_selected_library_ids(adapter.cfg, feature)
 
     ids = dict(it.get("ids") or {})
     show_ids = it.get("show_ids") if isinstance(it.get("show_ids"), Mapping) else None
@@ -1202,7 +1421,7 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
             if p not in pairs:
                 pairs.append(p)
 
-    idx = build_provider_index(adapter)
+    idx = build_provider_index(adapter) if feature == "history" else build_provider_index(adapter, feature=feature)
 
     def _valid(iid: Any) -> str | None:
         s = str(iid or "").strip()
@@ -1213,7 +1432,7 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
     # Movies
     if t == "movie":
         for pref in pairs:
-            rows = idx.get(pref) or []
+            rows = jf_filter_library_candidates(idx.get(pref) or [], selected_libs)
             cands = [row for row in rows if (row.get("Type") or "") == "Movie"]
             if isinstance(year, int):
                 yr = int(year)
@@ -1240,10 +1459,10 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
                     "Fields": "ProviderIds,ProductionYear,Type",
                     "Limit": 50,
                 }
-                q.update(jf_scope_any(adapter.cfg))
+                q.update(jf_library_scope(adapter.cfg, feature))
                 r = http.get("/Items", params=q)
                 t_l = title.lower()
-                for row in (r.json() or {}).get("Items") or []:
+                for row in jf_filter_library_candidates((r.json() or {}).get("Items") or [], selected_libs, trust_query_scope=True):
                     if (row.get("Type") or "") != "Movie":
                         continue
                     nm = (row.get("Name") or "").strip().lower()
@@ -1261,7 +1480,7 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
     # Episodes
     if t == "episode":
         for pref in pairs:
-            rows = idx.get(pref) or []
+            rows = jf_filter_library_candidates(idx.get(pref) or [], selected_libs)
             cands = [row for row in rows if (row.get("Type") or "") == "Episode"]
             for row in cands:
                 try:
@@ -1287,10 +1506,10 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any]) -> list[str]:
                     "Fields": "ProviderIds,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesName",
                     "Limit": 200,
                 }
-                q.update(jf_scope_any(adapter.cfg))
+                q.update(jf_library_scope(adapter.cfg, feature))
                 r = http.get("/Items", params=q)
                 st_l = series_title.lower()
-                for row in (r.json() or {}).get("Items") or []:
+                for row in jf_filter_library_candidates((r.json() or {}).get("Items") or [], selected_libs, trust_query_scope=True):
                     if (row.get("Type") or "") != "Episode":
                         continue
                     sn = (row.get("SeriesName") or "").strip().lower()

--- a/providers/sync/jellyfin/_progress.py
+++ b/providers/sync/jellyfin/_progress.py
@@ -9,6 +9,8 @@ from typing import Any, Iterable, Mapping
 from cw_platform.id_map import canonical_key
 
 from ._common import (
+    jf_item_library_ids,
+    jf_selected_library_ids,
     make_logger,
     normalize as jelly_normalize,
     resolve_item_id,
@@ -58,39 +60,74 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
     if not http or not uid:
         return {}
 
-    params: dict[str, Any] = {
+    base_params: dict[str, Any] = {
         "Recursive": True,
         "IncludeItemTypes": "Movie,Episode",
-        "Fields": "UserData,ProviderIds,RunTimeTicks,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesId,ParentId,Name",
+        "Fields": "UserData,ProviderIds,RunTimeTicks,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesId,ParentId,CollectionFolderId,AncestorIds,LibraryId,Name",
         "EnableUserData": True,
         "IsResumable": True,
-        "Limit": 10_000,
     }
-
-    try:
-        r = http.get(f"/Users/{uid}/Items", params=params)
-        if getattr(r, "status_code", 0) != 200:
-            _warn("http_failed", op="build_index", status=getattr(r, "status_code", None))
-            return {}
-        body = r.json() or {}
-        rows = body.get("Items") or []
-        if not isinstance(rows, list):
-            return {}
-    except Exception as e:
-        _warn("http_failed", op="build_index", error=str(e))
-        return {}
+    allowed = jf_selected_library_ids(adapter.cfg, "progress")
+    if not allowed:
+        _dbg("library_scope_not_configured")
+    parents: list[str | None] = list(sorted(allowed))
+    if not parents:
+        parents.append(None)
+    rows: list[tuple[Mapping[str, Any], str | None]] = []
+    seen_item_ids: set[str] = set()
+    page_size = 500
+    for parent_id in parents:
+        start = 0
+        while True:
+            params = dict(base_params)
+            params.update({"StartIndex": start, "Limit": page_size, "EnableTotalRecordCount": True})
+            if parent_id:
+                params["ParentId"] = parent_id
+            try:
+                r = http.get(f"/Users/{uid}/Items", params=params)
+                if getattr(r, "status_code", 0) != 200:
+                    _warn("library_scope_query_failed", source_library_id=parent_id, allowed_library_ids=sorted(allowed), status=getattr(r, "status_code", None))
+                    break
+                body = r.json() or {}
+                page = body.get("Items") or []
+                if not isinstance(page, list):
+                    break
+            except Exception as e:
+                _warn("library_scope_query_failed", source_library_id=parent_id, allowed_library_ids=sorted(allowed), error=str(e))
+                break
+            new_count = 0
+            for raw in page:
+                if not isinstance(raw, Mapping):
+                    continue
+                item_id = str(raw.get("Id") or "").strip()
+                if item_id and item_id in seen_item_ids:
+                    _dbg("duplicate_progress_item", provider_item_id=item_id, source_library_id=parent_id, item_title=str(raw.get("Name") or ""), media_type=str(raw.get("Type") or ""))
+                    continue
+                if item_id:
+                    seen_item_ids.add(item_id)
+                rows.append((raw, parent_id))
+                new_count += 1
+            start += len(page)
+            total = int(body.get("TotalRecordCount") or 0)
+            if not page or (total and start >= total) or len(page) < page_size or new_count == 0:
+                break
 
     out: dict[str, dict[str, Any]] = {}
     total_rows = 0
     dup_keys = 0
-    for raw in rows:
-        if not isinstance(raw, Mapping):
-            continue
+    for raw, source_library_id in rows:
         total_rows += 1
+        if allowed:
+            memberships = jf_item_library_ids(raw)
+            if memberships and not (memberships & allowed):
+                _dbg("outside_library_scope", provider_item_id=str(raw.get("Id") or ""), source_library_id=source_library_id, allowed_library_ids=sorted(allowed), item_title=str(raw.get("Name") or ""), media_type=str(raw.get("Type") or ""), provider_ids=dict(raw.get("ProviderIds") or {}))
+                continue
         try:
             item = jelly_normalize(raw)
         except Exception:
             continue
+        if source_library_id:
+            item["library_id"] = source_library_id
 
         ud = _pick_user_data(raw)
         pos_ms = _ticks_to_ms(ud.get("PlaybackPositionTicks"))
@@ -144,7 +181,7 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
             action=action,
         )
 
-    _info("index_done", count=len(out), rows=total_rows, dup_keys=dup_keys)
+    _info("index_done", count=len(out), rows=total_rows, dup_keys=dup_keys, allowed_library_ids=sorted(allowed), scope_enabled=bool(allowed))
     return out
 
 
@@ -161,10 +198,10 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         it0 = dict(it or {})
         ck = canonical_key(it0) or ""
         ids = dict(it0.get("ids") or {})
-        iids = resolve_item_ids(adapter, it0)
+        iids = resolve_item_ids(adapter, it0, feature="progress")
         if not iids:
             _dbg("resolve_miss", canonical_key=str(ck), type=str(it0.get("type") or ""), ids=ids)
-            unresolved.append({"item": it0, "hint": "not_found"})
+            unresolved.append({"item": it0, "hint": str(getattr(adapter, "_jellyfin_last_resolve_hint", "") or "not_found")})
             continue
         _dbg("resolve_hit", canonical_key=str(ck), type=str(it0.get("type") or ""), ids=ids, resolved=len(iids))
 
@@ -212,7 +249,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
     for it in items or []:
         it0 = dict(it or {})
         ck = canonical_key(it0) or ""
-        iid = resolve_item_id(adapter, it0)
+        iid = resolve_item_id(adapter, it0, feature="progress")
         if not iid:
             _dbg("resolve_miss", canonical_key=str(ck))
             unresolved.append({"item": it0, "hint": "not_found"})


### PR DESCRIPTION
# Pull request

## Change

Updated the Emby and Jellyfin adapters to:

- Treat unique exact episode provider IDs as primary identity.
- Accept exact episode matches despite numbering differences.
- Filter non-Episode provider-ID results.
- Use numbering only to disambiguate duplicate Episode matches.
- Preserve parent-show and title fallback resolution.
- Scope resumable queries and target resolution to Progress libraries.
- Paginate and deduplicate progress results.
- Include library scope in resolver caching.
- Add episode-resolution and library-scope diagnostics.

## Why

Valid episodes could become unresolved when providers used different season or episode numbering despite sharing an exact TVDB or IMDb episode ID.

Progress indexing could also include items from excluded libraries.

## Testing

- ` tests/test_media_browser_episode_resolution.py tests/test_progress_library_scope.py`.
- Added Emby and Jellyfin resolution and library-scope tests.

## Issue

NA