### PR TITLE
Add:  server and pair progress library whitelisting

### DIFF
--- a/assets/auth/auth.emby.js
+++ b/assets/auth/auth.emby.js
@@ -12,7 +12,9 @@
 
   let H = new Set(); // history lib ids
   let R = new Set(); // ratings lib ids
+  let P = new Set(); // progress lib ids
   let S = new Set(); // scrobble lib ids
+  let lastLibraries = [];
   let hydrated = false;
   let connected = false;
 
@@ -127,9 +129,11 @@
   function syncHidden() {
     const selH = Q("#emby_lib_history");
     const selR = Q("#emby_lib_ratings");
+    const selP = Q("#emby_lib_progress");
     const selS = Q("#emby_lib_scrobble");
     if (selH) selH.innerHTML = [...H].map(id => `<option selected value="${id}">${id}</option>`).join("");
     if (selR) selR.innerHTML = [...R].map(id => `<option selected value="${id}">${id}</option>`).join("");
+    if (selP) selP.innerHTML = [...P].map(id => `<option selected value="${id}">${id}</option>`).join("");
     if (selS) selS.innerHTML = [...S].map(id => `<option selected value="${id}">${id}</option>`).join("");
   }
 
@@ -137,14 +141,17 @@
     const rows = Qa("#emby_lib_matrix .lm-row:not(.hide)");
     const allHist = rows.length && rows.every(r => r.querySelector(".lm-dot.hist")?.classList.contains("on"));
     const allRate = rows.length && rows.every(r => r.querySelector(".lm-dot.rate")?.classList.contains("on"));
+    const allProg = rows.length && rows.every(r => r.querySelector(".lm-dot.prog")?.classList.contains("on"));
     const allScr = rows.length && rows.every(r => r.querySelector(".lm-dot.scr")?.classList.contains("on"));
-    const h = Q("#emby_hist_all"), r = Q("#emby_rate_all"), s = Q("#emby_scr_all");
+    const h = Q("#emby_hist_all"), r = Q("#emby_rate_all"), p = Q("#emby_prog_all"), s = Q("#emby_scr_all");
     if (h) { h.classList.toggle("on", !!allHist); h.setAttribute("aria-pressed", allHist ? "true" : "false"); }
     if (r) { r.classList.toggle("on", !!allRate); r.setAttribute("aria-pressed", allRate ? "true" : "false"); }
+    if (p) { p.classList.toggle("on", !!allProg); p.setAttribute("aria-pressed", allProg ? "true" : "false"); }
     if (s) { s.classList.toggle("on", !!allScr); s.setAttribute("aria-pressed", allScr ? "true" : "false"); }
   }
 
   function renderLibraries(libs) {
+    lastLibraries = Array.isArray(libs) ? libs : [];
     const box = Q("#emby_lib_matrix"); if (!box) return;
     box.innerHTML = "";
     const f = document.createDocumentFragment();
@@ -156,6 +163,7 @@
         <div class="lm-name">${ESC(it.title)}</div>
         <button class="lm-dot hist${H.has(id) ? " on" : ""}" data-kind="history" aria-pressed="${H.has(id)}" title="Toggle History"></button>
         <button class="lm-dot rate${R.has(id) ? " on" : ""}" data-kind="ratings" aria-pressed="${R.has(id)}" title="Toggle Ratings"></button>
+        <button class="lm-dot prog${P.has(id) ? " on" : ""}" data-kind="progress" aria-pressed="${P.has(id)}" title="Toggle Progress"></button>
         <button class="lm-dot scr${S.has(id) ? " on" : ""}" data-kind="scrobble" aria-pressed="${S.has(id)}" title="Toggle Scrobble"></button>`;
       f.appendChild(row);
     });
@@ -165,7 +173,11 @@
     syncSelectAll();
   }
 
-  async function embyLoadLibraries() {
+  async function embyLoadLibraries(force = false) {
+    if (!force && lastLibraries.length) {
+      renderLibraries(lastLibraries);
+      return;
+    }
     try {
       const r = await fetch(embyApi(LIB_URL), { cache: "no-store" });
       const d = r.ok ? await r.json().catch(() => ({})) : {};
@@ -185,9 +197,12 @@
   async function hydrateFromConfig(force = false) {
     if (hydrated && !force) return;
     try {
-      const r = await fetch("/api/config", { cache: "no-store" });
-      if (!r.ok) return;
-      const cfg = await r.json();
+      let cfg = !force && window.__cfg && Object.keys(window.__cfg).length ? window.__cfg : null;
+      if (!cfg) {
+        const r = await fetch("/api/config", { cache: "no-store" });
+        if (!r.ok) return;
+        cfg = await r.json();
+      }
       window.__cfg = cfg;
       const em = getEmbyCfgBlock(cfg);
 
@@ -201,10 +216,12 @@
 
       H = new Set((em.history?.libraries || []).map(String));
       R = new Set((em.ratings?.libraries || []).map(String));
+      P = new Set((em.progress?.libraries || []).map(String));
       S = new Set((em.scrobble?.libraries || []).map(String));
 
       hydrated = true;
-      await embyLoadLibraries();
+      if (lastLibraries.length) renderLibraries(lastLibraries);
+      else await embyLoadLibraries();
     } catch { /* ignore */ }
   }
 
@@ -322,10 +339,12 @@
 
     em.history = em.history || {};
     em.ratings = em.ratings || {};
+    em.progress = em.progress || {};
     em.scrobble = em.scrobble || {};
 
     em.history.libraries = [...H];
     em.ratings.libraries = [...R];
+    em.progress.libraries = [...P];
     em.scrobble.libraries = [...S];
 
     return cfg;
@@ -345,6 +364,7 @@
       if (id) {
         if (kind === "history") { on ? H.add(id) : H.delete(id); }
         if (kind === "ratings") { on ? R.add(id) : R.delete(id); }
+        if (kind === "progress") { on ? P.add(id) : P.delete(id); }
         if (kind === "scrobble") { on ? S.add(id) : S.delete(id); }
       }
       syncHidden();
@@ -387,6 +407,19 @@
       Qa("#emby_lib_matrix .lm-dot.scr").forEach((x) => {
         x.classList.toggle("on", on); x.setAttribute("aria-pressed", on ? "true" : "false");
         if (on) { const r = x.closest(".lm-row"); if (r) S.add(String(r.dataset.id || "")); }
+      });
+      syncHidden(); syncSelectAll(); return;
+    }
+
+    if (ev?.target?.id === "emby_prog_all") {
+      const b = Q("#emby_prog_all");
+      if (!b) return;
+      const on = !b.classList.contains("on");
+      b.classList.toggle("on", on); b.setAttribute("aria-pressed", on ? "true" : "false");
+      P = new Set();
+      Qa("#emby_lib_matrix .lm-dot.prog").forEach((x) => {
+        x.classList.toggle("on", on); x.setAttribute("aria-pressed", on ? "true" : "false");
+        if (on) { const r = x.closest(".lm-row"); if (r) P.add(String(r.dataset.id || "")); }
       });
       syncHidden(); syncSelectAll(); return;
     }
@@ -448,7 +481,7 @@
     if (t && t.id === "btn-emby-login") embyLogin();
     if (t && t.id === "btn-emby-delete") embyDeleteToken();
     if (t && t.id === "btn-emby-auto") embyAuto();
-    if (t && t.id === "btn-emby-load-libraries") embyLoadLibraries();
+    if (t && t.id === "btn-emby-load-libraries") embyLoadLibraries(true);
   }, true);
 
   document.addEventListener("change", (ev) => {

--- a/assets/auth/auth.jellyfin.js
+++ b/assets/auth/auth.jellyfin.js
@@ -11,7 +11,9 @@
 
   let H = new Set();
   let R = new Set();
+  let P = new Set();
   let S = new Set();
+  let lastLibraries = [];
   let hydrated = false;
   let connected = false;
 
@@ -124,9 +126,11 @@
   function syncHidden() {
     const selH = Q("#jfy_lib_history");
     const selR = Q("#jfy_lib_ratings");
+    const selP = Q("#jfy_lib_progress");
     const selS = Q("#jfy_lib_scrobble");
     if (selH) selH.innerHTML = [...H].map(id => `<option selected value="${id}">${id}</option>`).join("");
     if (selR) selR.innerHTML = [...R].map(id => `<option selected value="${id}">${id}</option>`).join("");
+    if (selP) selP.innerHTML = [...P].map(id => `<option selected value="${id}">${id}</option>`).join("");
     if (selS) selS.innerHTML = [...S].map(id => `<option selected value="${id}">${id}</option>`).join("");
   }
 
@@ -134,14 +138,17 @@
     const rows = Qa("#jfy_lib_matrix .lm-row:not(.hide)");
     const allHist = rows.length && rows.every(r => r.querySelector(".lm-dot.hist")?.classList.contains("on"));
     const allRate = rows.length && rows.every(r => r.querySelector(".lm-dot.rate")?.classList.contains("on"));
+    const allProg = rows.length && rows.every(r => r.querySelector(".lm-dot.prog")?.classList.contains("on"));
     const allScr = rows.length && rows.every(r => r.querySelector(".lm-dot.scr")?.classList.contains("on"));
-    const h = Q("#jfy_hist_all"), r = Q("#jfy_rate_all"), s = Q("#jfy_scr_all");
+    const h = Q("#jfy_hist_all"), r = Q("#jfy_rate_all"), p = Q("#jfy_prog_all"), s = Q("#jfy_scr_all");
     if (h) { h.classList.toggle("on", !!allHist); h.setAttribute("aria-pressed", allHist ? "true" : "false"); }
     if (r) { r.classList.toggle("on", !!allRate); r.setAttribute("aria-pressed", allRate ? "true" : "false"); }
+    if (p) { p.classList.toggle("on", !!allProg); p.setAttribute("aria-pressed", allProg ? "true" : "false"); }
     if (s) { s.classList.toggle("on", !!allScr); s.setAttribute("aria-pressed", allScr ? "true" : "false"); }
   }
 
   function renderLibraries(libs) {
+    lastLibraries = Array.isArray(libs) ? libs : [];
     const box = Q("#jfy_lib_matrix"); if (!box) return;
     box.innerHTML = "";
     const f = document.createDocumentFragment();
@@ -153,6 +160,7 @@
         <div class="lm-name">${ESC(it.title)}</div>
         <button type="button" class="lm-dot hist${H.has(id) ? " on" : ""}" data-kind="history" aria-pressed="${H.has(id)}" title="Toggle History"></button>
         <button type="button" class="lm-dot rate${R.has(id) ? " on" : ""}" data-kind="ratings" aria-pressed="${R.has(id)}" title="Toggle Ratings"></button>
+        <button type="button" class="lm-dot prog${P.has(id) ? " on" : ""}" data-kind="progress" aria-pressed="${P.has(id)}" title="Toggle Progress"></button>
         <button type="button" class="lm-dot scr${S.has(id) ? " on" : ""}" data-kind="scrobble" aria-pressed="${S.has(id)}" title="Toggle Scrobble"></button>`;
       f.appendChild(row);
     });
@@ -170,7 +178,11 @@
     renderLibraries(libs);
   }
 
-  async function jfyLoadLibraries() {
+  async function jfyLoadLibraries(force = false) {
+    if (!force && lastLibraries.length) {
+      renderLibraries(lastLibraries);
+      return;
+    }
     try {
       const r = await fetch(jfyApi(LIB_URL), { cache: "no-store" });
       const d = r.ok ? await r.json().catch(() => ({})) : {};
@@ -189,9 +201,12 @@
   async function hydrateFromConfig(force = false) {
     if (hydrated && !force) return;
     try {
-      const r = await fetch("/api/config", { cache: "no-store" });
-      if (!r.ok) return;
-      const cfg = await r.json();
+      let cfg = !force && window.__cfg && Object.keys(window.__cfg).length ? window.__cfg : null;
+      if (!cfg) {
+        const r = await fetch("/api/config", { cache: "no-store" });
+        if (!r.ok) return;
+        cfg = await r.json();
+      }
       window.__cfg = cfg;
       const jf = getJfyCfgBlock(cfg);
 
@@ -205,10 +220,12 @@
 
       H = new Set((jf.history?.libraries || []).map(String));
       R = new Set((jf.ratings?.libraries || []).map(String));
+      P = new Set((jf.progress?.libraries || []).map(String));
       S = new Set((jf.scrobble?.libraries || []).map(String));
 
       hydrated = true;
-      await jfyLoadLibraries();
+      if (lastLibraries.length) renderLibraries(lastLibraries);
+      else await jfyLoadLibraries();
     } catch { }
   }
 
@@ -314,6 +331,7 @@
       jf.verify_ssl = !!((vs && vs.checked) || (vs2 && vs2.checked));
       jf.history = Object.assign({}, jf.history || {}, { libraries: Array.from(H) });
       jf.ratings = Object.assign({}, jf.ratings || {}, { libraries: Array.from(R) });
+      jf.progress = Object.assign({}, jf.progress || {}, { libraries: Array.from(P) });
       jf.scrobble = Object.assign({}, jf.scrobble || {}, { libraries: Array.from(S) });
     }
     return cfg;
@@ -365,6 +383,20 @@
       return;
     }
 
+    if (btn.id === "jfy_prog_all") {
+      ev.preventDefault(); ev.stopPropagation();
+      const on = !btn.classList.contains("on"); btn.classList.toggle("on", on); btn.setAttribute("aria-pressed", on ? "true" : "false");
+      P = new Set();
+      Qa("#jfy_lib_matrix .lm-dot.prog").forEach((b) => {
+        b.classList.toggle("on", on); b.setAttribute("aria-pressed", on ? "true" : "false");
+        if (on) { const r = b.closest(".lm-row"); if (r) P.add(String(r.dataset.id || "")); }
+      });
+      syncHidden();
+      repaint();
+      syncSelectAll();
+      return;
+    }
+
     if (btn.closest("#jfy_lib_matrix")) {
       ev.preventDefault(); ev.stopPropagation();
       const row = btn.closest(".lm-row"); if (!row) return;
@@ -373,6 +405,7 @@
       btn.classList.toggle("on", on); btn.setAttribute("aria-pressed", on ? "true" : "false");
       if (kind === "history") { (on ? H.add(id) : H.delete(id)); }
       else if (kind === "ratings") { (on ? R.add(id) : R.delete(id)); }
+      else if (kind === "progress") { (on ? P.add(id) : P.delete(id)); }
       else if (kind === "scrobble") { (on ? S.add(id) : S.delete(id)); }
       syncHidden();
       repaint();
@@ -415,7 +448,7 @@
     if (t && t.id === "btn-jfy-login") jfyLogin();
     if (t && t.id === "btn-jfy-delete") jfyDeleteToken();
     if (t && t.id === "btn-jfy-auto") jfyAuto();
-    if (t && t.id === "btn-jfy-load-libraries") jfyLoadLibraries();
+    if (t && t.id === "btn-jfy-load-libraries") jfyLoadLibraries(true);
   }, true);
 
   document.addEventListener("change", (ev) => {

--- a/assets/auth/auth.plex.js
+++ b/assets/auth/auth.plex.js
@@ -457,13 +457,26 @@ async function plexDeleteToken() {
 }
 
 
-  function getPlexState() { return (w.__plexState ||= { hist: new Set(), rate: new Set(), scr: new Set(), libs: [], hydrated: false, connected: false }); }
+  function getPlexState() {
+    const st = (w.__plexState ||= { hist: new Set(), rate: new Set(), prog: new Set(), scr: new Set(), libs: [], hydrated: false, connected: false });
+    st.prog ||= new Set();
+    return st;
+  }
 
   // Config
   async function hydratePlexFromConfigRaw() {
     try {
       const r = await fetch("/api/config", { cache: "no-store" }); if (!r.ok) return;
       const cfg = await r.json(); const p = getPlexCfgBlock(cfg);
+      w.__cfg = cfg;
+      const st = getPlexState();
+      st.hist = new Set((p.history?.libraries || []).map(x => String(x)));
+      st.rate = new Set((p.ratings?.libraries || []).map(x => String(x)));
+      st.prog = new Set((p.progress?.libraries || []).map(x => String(x)));
+      st.scr  = new Set((p.scrobble?.libraries || []).map(x => String(x)));
+      st.hydrated = true;
+      w.__plexHydrated = true;
+      if (st.libs.length) mountPlexLibraryMatrix();
       await waitFor("#plex_server_url"); await waitFor("#plex_username");
       const set = (id, val) => { const el = $(id); if (el != null && val != null) el.value = String(val); };
       const tok = String(p.account_token || '').trim();
@@ -479,18 +492,12 @@ async function plexDeleteToken() {
       await refreshPlexSelectedUserScopeNotice();
       try { const cb = $("plex_verify_ssl"); if (cb) cb.checked = !!p.verify_ssl; } catch {}
 
-      const st = getPlexState();
-      st.hist = new Set((p.history?.libraries || []).map(x => String(x)));
-      st.rate = new Set((p.ratings?.libraries || []).map(x => String(x)));
-      st.scr  = new Set((p.scrobble?.libraries || []).map(x => String(x)));
-      st.hydrated = true;
-      w.__plexHydrated = true;
-
-      ["plex_lib_history", "plex_lib_ratings", "plex_lib_scrobble"].forEach(id => {
+      ["plex_lib_history", "plex_lib_ratings", "plex_lib_progress", "plex_lib_scrobble"].forEach(id => {
         const el = $(id); if (!el) return;
         Array.from(el.options || []).forEach(o => {
           if (id === "plex_lib_history") o.selected = st.hist.has(o.value);
           if (id === "plex_lib_ratings") o.selected = st.rate.has(o.value);
+          if (id === "plex_lib_progress") o.selected = st.prog.has(o.value);
           if (id === "plex_lib_scrobble") o.selected = st.scr.has(o.value);
         });
       });
@@ -1026,6 +1033,7 @@ const tags = [
       };
       fill("plex_lib_history");
       fill("plex_lib_ratings");
+      fill("plex_lib_progress");
       fill("plex_lib_scrobble");
     } catch (e) {
       console.warn("[plex] library select fill failed", e);
@@ -1059,8 +1067,10 @@ const tags = [
       if (host) host.innerHTML = '<div class="sub">Loading libraries…</div>';
     } catch {}
     try { getPlexState().libs = []; } catch {}
-    try { await hydratePlexFromConfigRaw(); } catch {}
+    const hydrate = hydratePlexFromConfigRaw().catch(() => {});
     try { await plexLoadLibraries(); } catch {}
+    try { mountPlexLibraryMatrix(); } catch {}
+    await hydrate;
     try { mountPlexLibraryMatrix(); } catch {}
   }
 
@@ -1069,6 +1079,7 @@ const tags = [
     const host    = $("plex_lib_matrix");
     const histSel = $("plex_lib_history");
     const rateSel = $("plex_lib_ratings");
+    const progSel = $("plex_lib_progress");
     const scrSel  = $("plex_lib_scrobble");
     const filter  = $("plex_lib_filter");
     if (!host) return;
@@ -1091,6 +1102,7 @@ const tags = [
          <div class="lm-name" title="#${lib.id}">${lib.title} <span class="lm-id">#${lib.id}</span></div>
          <button type="button" class="lm-dot hist ${st.hist.has(lib.id) ? "on" : ""}" aria-label="History" aria-pressed="${st.hist.has(lib.id)}"></button>
          <button type="button" class="lm-dot rate ${st.rate.has(lib.id) ? "on" : ""}" aria-label="Ratings" aria-pressed="${st.rate.has(lib.id)}"></button>
+         <button type="button" class="lm-dot prog ${st.prog.has(lib.id) ? "on" : ""}" aria-label="Progress" aria-pressed="${st.prog.has(lib.id)}"></button>
          <button type="button" class="lm-dot scr ${st.scr.has(lib.id) ? "on" : ""}" aria-label="Scrobble" aria-pressed="${st.scr.has(lib.id)}"></button>
        </div>`;
 
@@ -1117,12 +1129,14 @@ const tags = [
       applyFilter();
       setSelFromSet(histSel, st.hist);
       setSelFromSet(rateSel, st.rate);
+      setSelFromSet(progSel, st.prog);
       setSelFromSet(scrSel,  st.scr);
     }
 
     function toggleOne(id, which) {
       if (which === "hist") { st.hist.has(id) ? st.hist.delete(id) : st.hist.add(id); render(); return; }
       if (which === "rate") { st.rate.has(id) ? st.rate.delete(id) : st.rate.add(id); render(); return; }
+      if (which === "prog") { st.prog.has(id) ? st.prog.delete(id) : st.prog.add(id); render(); return; }
       if (which === "scr")  { st.scr.has(id) ? st.scr.delete(id) : st.scr.add(id);  render(); return; }
     }
 
@@ -1130,7 +1144,7 @@ const tags = [
       host.addEventListener("click", (ev) => {
         const btn = ev.target.closest(".lm-dot"); if (!btn) return;
         const row = ev.target.closest(".lm-row"); const id = row?.dataset?.id; if (!id) return;
-        const which = btn.classList.contains("hist") ? "hist" : (btn.classList.contains("scr") ? "scr" : "rate");
+        const which = btn.classList.contains("hist") ? "hist" : (btn.classList.contains("scr") ? "scr" : (btn.classList.contains("prog") ? "prog" : "rate"));
         toggleOne(id, which);
       });
 
@@ -1155,6 +1169,13 @@ const tags = [
         render();
       });
 
+      $("plex_prog_all")?.addEventListener("click", () => {
+        const visible = Array.from(host.querySelectorAll(".lm-row:not(.hide)")).map(r => r.dataset.id);
+        const allOn = visible.every(id => st.prog.has(id));
+        if (allOn) visible.forEach(id => st.prog.delete(id)); else visible.forEach(id => st.prog.add(id));
+        render();
+      });
+
       filter?.addEventListener("input", applyFilter);
 
       histSel?.addEventListener("change", () => {
@@ -1165,6 +1186,11 @@ const tags = [
       rateSel?.addEventListener("change", () => {
         if (syncing) return;
         st.rate = new Set(Array.from(rateSel.selectedOptions || []).map(o => String(o.value)));
+        render();
+      });
+      progSel?.addEventListener("change", () => {
+        if (syncing) return;
+        st.prog = new Set(Array.from(progSel.selectedOptions || []).map(o => String(o.value)));
         render();
       });
       scrSel?.addEventListener("change", () => {
@@ -1214,15 +1240,17 @@ const tags = [
     const st = getPlexState();
     const uiReady = !!st.hydrated ||
       !!document.querySelector("#plex_lib_matrix .lm-row") ||
-      !!document.querySelector("#plex_lib_history option, #plex_lib_ratings option, #plex_lib_scrobble option");
+      !!document.querySelector("#plex_lib_history option, #plex_lib_ratings option, #plex_lib_progress option, #plex_lib_scrobble option");
     if (uiReady) {
       const toInts = (set) => Array.from(set || []).map(x => parseInt(String(x), 10)).filter(Number.isFinite);
       const hist = toInts(st.hist);
       const rate = toInts(st.rate);
+      const prog = toInts(st.prog);
       const scr  = toInts(st.scr);
       plex.scrobble = Object.assign({}, plex.scrobble || {}, { libraries: scr });
       plex.history  = Object.assign({}, plex.history  || {}, { libraries: hist });
       plex.ratings  = Object.assign({}, plex.ratings  || {}, { libraries: rate });
+      plex.progress = Object.assign({}, plex.progress || {}, { libraries: prog });
     }
     return cfg;
   }

--- a/assets/crosswatch.css
+++ b/assets/crosswatch.css
@@ -536,6 +536,8 @@ main.full #stats-card,main.single #stats-card{grid-column:1;grid-row:auto;align-
 #stats-card .tile.g3{background:linear-gradient(180deg,rgba(255,255,255,.02),transparent),rgba(11,11,22,.32)!important;border-color:rgba(255,255,255,.12)!important;backdrop-filter:blur(2px) saturate(110%)}
 #stats-card .tile.g3 .k{color:#dfe3ee}
 #stats-card{grid-row:1;grid-column:2;align-self:stretch;height:100%;position:relative;overflow:hidden;isolation:isolate;transition:filter .2s ease}
+main#layout.details-open #stats-card{align-self:start;height:auto}
+main#layout.details-open #insights-footer{position:static!important;left:auto!important;right:auto!important;bottom:auto!important;margin-top:10px}
 #stats-card.expanded{filter:brightness(1.02)}
 .sparkline .dot{r:2.5;opacity:.9}
 .sparkline .dot:hover{transform:scale(1.6)}
@@ -705,7 +707,8 @@ to{left:6px}
 .n.bump{animation:valuePop .35s ease-out}
 .ghost{background:0 0;border:none;color:inherit;opacity:.6;cursor:pointer}
 .history-list{display:grid;gap:8px}
-#sync-history.history-list{gap:12px}
+#sync-history.history-list{gap:0}
+#sync-history>.list{display:grid;gap:6px}
 .history-item{display:flex;align-items:center;justify-content:space-between;padding:10px 12px;border-radius:12px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.06)}
 .watchtime{display:flex;align-items:baseline;gap:10px}
 .watchtime .big{font-size:28px;font-weight:800;letter-spacing:.2px;background:linear-gradient(90deg,var(--grad1,#7c5cff),var(--grad2,#2de2ff));background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent}

--- a/assets/helpers/settings-save.js
+++ b/assets/helpers/settings-save.js
@@ -124,12 +124,13 @@ function _cwReadLibrarySource(prefix, numeric = false) {
   const readRows = (rootSelector, rowCls, dotCls) => {
     const rows = document.querySelectorAll(`${rootSelector} .${rowCls}`);
     if (!rows.length) return null;
-    const out = { H: [], R: [], S: [] };
+    const out = { H: [], R: [], P: [], S: [] };
     rows.forEach((row) => {
       const id = cast(row.dataset.id);
       if (id == null) return;
       if (row.querySelector(`.${dotCls}hist.on`)) out.H.push(id);
       if (row.querySelector(`.${dotCls}rate.on`)) out.R.push(id);
+      if (row.querySelector(`.${dotCls}prog.on`)) out.P.push(id);
       if (row.querySelector(`.${dotCls}scr.on`)) out.S.push(id);
     });
     return out;
@@ -142,13 +143,13 @@ function _cwReadLibrarySource(prefix, numeric = false) {
   };
   return readRows(`#${prefix}_lib_matrix`, "lm-row", "lm-dot.")
     || readRows(`#${prefix}_lib_whitelist`, "whrow", "whtog.")
-    || { H: readSelect("history"), R: readSelect("ratings"), S: readSelect("scrobble") };
+    || { H: readSelect("history"), R: readSelect("ratings"), P: readSelect("progress"), S: readSelect("scrobble") };
 }
 
 function _cwApplyLibraryConfig(target, prev, src, numeric = false) {
   if (!target || !src) return false;
   let dirty = false;
-  for (const [shortKey, longKey] of [["H", "history"], ["R", "ratings"], ["S", "scrobble"]]) {
+  for (const [shortKey, longKey] of [["H", "history"], ["R", "ratings"], ["P", "progress"], ["S", "scrobble"]]) {
     const nextVals = src[shortKey] || [], prevVals = prev?.[longKey]?.libraries || [];
     if (_cwSameList(nextVals, prevVals, numeric)) continue;
     target[longKey] = { ...(target[longKey] || {}), libraries: nextVals };
@@ -162,7 +163,7 @@ function _cwHydrated(prefix, sectionId, ...flags) {
     || _cwEl(sectionId)?.dataset?.hydrated === "1"
     || document.querySelectorAll(`#${prefix}_lib_matrix .lm-row`).length > 0
     || document.querySelectorAll(`#${prefix}_lib_whitelist .whrow`).length > 0
-    || !!document.querySelector(`#${prefix}_lib_history option, #${prefix}_lib_ratings option, #${prefix}_lib_scrobble option`);
+    || !!document.querySelector(`#${prefix}_lib_history option, #${prefix}_lib_ratings option, #${prefix}_lib_progress option, #${prefix}_lib_scrobble option`);
 }
 
 function _cwToNumList(xs) {
@@ -776,10 +777,11 @@ async function saveSettings() {
       if (uiAid !== null && uiAid !== prevAid) { next.account_id = uiAid; mark(); }
       if (!!_cwEl("plex_verify_ssl")?.checked !== !!prev?.verify_ssl) { next.verify_ssl = !!_cwEl("plex_verify_ssl")?.checked; mark(); }
       if (_cwHydrated("plex", "sec-plex", window.__plexHydrated === true)) {
-        const st = window.__plexState || { hist: new Set(), rate: new Set(), scr: new Set() };
+        const st = window.__plexState || { hist: new Set(), rate: new Set(), prog: new Set(), scr: new Set() };
         const src = {
           H: _cwSelectNums("plex_lib_history") ?? _cwToNumList(st.hist),
           R: _cwSelectNums("plex_lib_ratings") ?? _cwToNumList(st.rate),
+          P: _cwSelectNums("plex_lib_progress") ?? _cwToNumList(st.prog),
           S: _cwSelectNums("plex_lib_scrobble") ?? _cwToNumList(st.scr)
         };
         if (_cwApplyLibraryConfig(next, prev, src, true)) mark();

--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -665,9 +665,11 @@ function applySubDisable(feature){
 function countProviderLibraries(state, providerName){
   const historyLibs = state.options?.history?.libraries?.[providerName];
   const ratingsLibs = state.options?.ratings?.libraries?.[providerName];
+  const progressLibs = state.options?.progress?.libraries?.[providerName];
   const historyCount = Array.isArray(historyLibs) ? historyLibs.length : 0;
   const ratingsCount = Array.isArray(ratingsLibs) ? ratingsLibs.length : 0;
-  return historyCount + ratingsCount;
+  const progressCount = Array.isArray(progressLibs) ? progressLibs.length : 0;
+  return historyCount + ratingsCount + progressCount;
 }
 
 function getProviderOverrideCount(state, providerKey){
@@ -792,6 +794,10 @@ function renderFeaturePanel(state){
               <div class="field-label">Ratings</div>
               <div class="chip-row" id="plx-rate-libs"></div>
             </div>
+            <div class="opt-row">
+              <div class="field-label">Progress</div>
+              <div class="chip-row" id="plx-prog-libs"></div>
+            </div>
             <button type="button" class="cx-btn small" id="plx-libs-load">Load libraries</button>
           </div>
         </div>
@@ -829,6 +835,10 @@ function renderFeaturePanel(state){
               <div class="field-label">Ratings</div>
               <div class="chip-row" id="jf-rate-libs"></div>
             </div>
+            <div class="opt-row">
+              <div class="field-label">Progress</div>
+              <div class="chip-row" id="jf-prog-libs"></div>
+            </div>
             <button type="button" class="cx-btn small" id="jf-libs-load">Load libraries</button>
           </div>
         </div>
@@ -865,6 +875,10 @@ function renderFeaturePanel(state){
             <div class="opt-row">
               <div class="field-label">Ratings</div>
               <div class="chip-row" id="em-rate-libs"></div>
+            </div>
+            <div class="opt-row">
+              <div class="field-label">Progress</div>
+              <div class="chip-row" id="em-prog-libs"></div>
             </div>
             <button type="button" class="cx-btn small" id="em-libs-load">Load libraries</button>
           </div>

--- a/assets/js/modals/pair-config/libraries.js
+++ b/assets/js/modals/pair-config/libraries.js
@@ -87,10 +87,13 @@ export function createLibraryController({
     let hostId = "";
     if (kind === "PLEX" && feature === "history") hostId = "plx-hist-libs";
     else if (kind === "PLEX" && feature === "ratings") hostId = "plx-rate-libs";
+    else if (kind === "PLEX" && feature === "progress") hostId = "plx-prog-libs";
     else if (kind === "JELLYFIN" && feature === "history") hostId = "jf-hist-libs";
     else if (kind === "JELLYFIN" && feature === "ratings") hostId = "jf-rate-libs";
+    else if (kind === "JELLYFIN" && feature === "progress") hostId = "jf-prog-libs";
     else if (kind === "EMBY" && feature === "history") hostId = "em-hist-libs";
     else if (kind === "EMBY" && feature === "ratings") hostId = "em-rate-libs";
+    else if (kind === "EMBY" && feature === "progress") hostId = "em-prog-libs";
     const host = ID(hostId);
     if (!host) return;
     const info = getFeatureLibraries(state, feature, kind);
@@ -138,6 +141,9 @@ export function createLibraryController({
         }),
         fetchPairLibraries(kind, "ratings").then((libs) => {
           renderPairLibChips(state, kind, "ratings", libs);
+        }),
+        fetchPairLibraries(kind, "progress").then((libs) => {
+          renderPairLibChips(state, kind, "progress", libs);
         }),
       ]).finally(() => {
         if (btn) {

--- a/assets/themes/flat.css
+++ b/assets/themes/flat.css
@@ -96,8 +96,8 @@ html[data-cw-theme="flat-light"] #page-watchlist .wl-card .wl-provider-icon,html
 html[data-cw-theme="flat-light"] #page-watchlist .wl-detail .score text{fill:#111827!important;}
 html[data-cw-theme="flat-light"] #page-watchlist .wl-detail .score circle:first-of-type{stroke:rgba(15,23,42,.16)!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .cw-subpanel[data-sub="whitelist"] > div{max-width:none!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .cw-subpanel[data-sub="whitelist"]{--lm-hist-col:88px!important;--lm-rate-col:88px!important;--lm-scr-col:112px!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-head{display:grid!important;grid-template-columns:minmax(300px,1fr) var(--lm-hist-col,88px) var(--lm-rate-col,88px) var(--lm-scr-col,112px)!important;gap:10px!important;align-items:center!important;margin:18px 0 10px!important;padding:0 18px 0 12px!important;box-sizing:border-box!important;}
+:is(#sec-plex,#sec-emby,#sec-jellyfin) .cw-subpanel[data-sub="whitelist"]{--lm-hist-col:88px!important;--lm-rate-col:88px!important;--lm-prog-col:92px!important;--lm-scr-col:112px!important;}
+:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-head{display:grid!important;grid-template-columns:minmax(260px,1fr) var(--lm-hist-col,88px) var(--lm-rate-col,88px) var(--lm-prog-col,92px) var(--lm-scr-col,112px)!important;gap:10px!important;align-items:center!important;margin:18px 0 10px!important;padding:0 18px 0 12px!important;box-sizing:border-box!important;}
 :is(#sec-emby,#sec-jellyfin) .lm-head .lm-col:nth-of-type(2){display:none!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-head .title,:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-head .lm-filter{grid-column:1!important;grid-row:1!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-head .title{color:#c3c9d5!important;font-size:12px!important;font-weight:850!important;letter-spacing:.12em!important;text-transform:uppercase!important;}
@@ -109,17 +109,19 @@ html[data-cw-theme="flat-light"] #page-watchlist .wl-detail .score circle:first-
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-rows::-webkit-scrollbar-track{background:#20242d!important;border-radius:12px!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-rows::-webkit-scrollbar-thumb{border-radius:12px!important;border:2px solid #20242d!important;background:#4b5564!important;box-shadow:none!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-rows::-webkit-scrollbar-thumb:hover{background:#5d6878!important;box-shadow:none!important;filter:none!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-row{display:grid!important;grid-template-columns:minmax(0,1fr) var(--lm-hist-col,88px) var(--lm-rate-col,88px) var(--lm-scr-col,112px)!important;gap:10px!important;align-items:center!important;min-height:42px!important;padding:8px 12px!important;border-radius:12px!important;border:1px solid rgba(255,255,255,.04)!important;background:#1b1f28!important;color:#eef1f6!important;}
+:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-row{display:grid!important;grid-template-columns:minmax(0,1fr) var(--lm-hist-col,88px) var(--lm-rate-col,88px) var(--lm-prog-col,92px) var(--lm-scr-col,112px)!important;gap:10px!important;align-items:center!important;min-height:42px!important;padding:8px 12px!important;border-radius:12px!important;border:1px solid rgba(255,255,255,.04)!important;background:#1b1f28!important;color:#eef1f6!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-name{color:#eef1f6!important;min-width:0!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-id{color:#a9b0bd!important;opacity:.78!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot{appearance:none!important;-webkit-appearance:none!important;width:18px!important;height:18px!important;min-width:18px!important;min-height:18px!important;max-width:18px!important;max-height:18px!important;padding:0!important;margin:0!important;display:inline-block!important;border:2px solid currentColor!important;border-radius:999px!important;border-width:2px!important;background:transparent!important;box-shadow:none!important;outline:0!important;cursor:pointer!important;justify-self:center!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot:focus-visible{box-shadow:0 0 0 4px rgba(125,134,201,.22)!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.hist{color:#9b8ee8!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.rate{color:#62bfe3!important;}
+:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.prog{color:#e0a85a!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.scr{color:#57b58a!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.on{box-shadow:0 0 0 4px rgba(255,255,255,.04)!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.hist.on{background:#9b8ee8!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.rate.on{background:#62bfe3!important;}
+:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.prog.on{background:#e0a85a!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.scr.on{background:#57b58a!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-hidden{display:none!important;}
 html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-head .title{color:#475467!important;}
@@ -134,16 +136,18 @@ html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-name
 html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-id{color:#667085!important;}
 html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.hist{color:#7567c8!important;}
 html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.rate{color:#247fa4!important;}
+html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.prog{color:#9a5d12!important;}
 html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.scr{color:#177245!important;}
 html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.hist.on{background:#7567c8!important;}
 html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.rate.on{background:#247fa4!important;}
+html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.prog.on{background:#9a5d12!important;}
 html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.scr.on{background:#177245!important;}
-@media (max-width:760px){:is(#sec-plex,#sec-emby,#sec-jellyfin) .cw-subpanel[data-sub="whitelist"]{--lm-hist-col:52px!important;--lm-rate-col:52px!important;--lm-scr-col:68px!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-head,:is(#sec-emby,#sec-jellyfin) .lm-head{grid-template-columns:minmax(180px,1fr) var(--lm-hist-col,52px) var(--lm-rate-col,52px) var(--lm-scr-col,68px)!important;gap:8px!important;padding-right:10px!important;}
+@media (max-width:760px){:is(#sec-plex,#sec-emby,#sec-jellyfin) .cw-subpanel[data-sub="whitelist"]{--lm-hist-col:52px!important;--lm-rate-col:52px!important;--lm-prog-col:58px!important;--lm-scr-col:68px!important;}
+:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-head,:is(#sec-emby,#sec-jellyfin) .lm-head{grid-template-columns:minmax(150px,1fr) var(--lm-hist-col,52px) var(--lm-rate-col,52px) var(--lm-prog-col,58px) var(--lm-scr-col,68px)!important;gap:8px!important;padding-right:10px!important;}
 :is(#sec-emby,#sec-jellyfin) .lm-head .lm-col:nth-of-type(2){display:none!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-head .lm-filter{width:100%!important;min-width:0!important;}
 :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-col .sub{font-size:11px!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-row{grid-template-columns:minmax(0,1fr) var(--lm-hist-col,52px) var(--lm-rate-col,52px) var(--lm-scr-col,68px)!important;}
+:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-row{grid-template-columns:minmax(0,1fr) var(--lm-hist-col,52px) var(--lm-rate-col,52px) var(--lm-prog-col,58px) var(--lm-scr-col,68px)!important;}
 }
 html[data-cw-theme] #sched-inline-log{gap:12px!important;}
 html[data-cw-theme] #sched-inline-log .sched{min-height:40px!important;padding:7px 15px!important;border-radius:18px!important;background:#242936!important;border-color:rgba(255,255,255,.12)!important;color:#f3f6ff!important;box-shadow:none!important;backdrop-filter:none!important;-webkit-backdrop-filter:none!important;isolation:isolate!important;}
@@ -225,6 +229,7 @@ html[data-cw-theme] .cx-modal-shell.pair-config-modal #cx-modal .flow-mode-inlin
 html[data-cw-theme] .cx-modal-shell.pair-config-modal #cx-modal #cx-mode-one:checked + label,html[data-cw-theme] .cx-modal-shell.pair-config-modal #cx-modal #cx-mode-two:checked + label{background:#4656a6!important;color:#f8fafc!important;box-shadow:none!important;}
 html[data-cw-theme] .cx-modal-shell.pair-config-modal #cx-modal .opt-row .switch .slider{background:var(--pc-panel-2)!important;border-color:var(--pc-border)!important;box-shadow:none!important;}
 html[data-cw-theme] .cx-modal-shell.pair-config-modal #cx-modal .opt-row .switch input:checked + .slider{background:#57b58a!important;border-color:rgba(87,181,138,.42)!important;box-shadow:none!important;}
+html[data-cw-theme="flat-dark"] .cx-modal-shell.pair-config-modal #cx-modal .chip-row .chip.on{background:#343b5d!important;border-color:rgba(125,134,201,.72)!important;color:#f7f8ff!important;box-shadow:inset 0 0 0 1px rgba(125,134,201,.24)!important;}
 html[data-cw-theme] .cx-modal-shell.pair-config-modal #cx-modal #gl-drop-adv{padding:14px 16px!important;}
 html[data-cw-theme] .cx-modal-shell.pair-config-modal #cx-modal #gl-drop-adv .grid2.compact{display:grid!important;grid-template-columns:repeat(2,minmax(0,1fr))!important;gap:12px!important;}
 html[data-cw-theme] .cx-modal-shell.pair-config-modal #cx-modal #gl-drop-adv .grid2.compact .opt-row{display:grid!important;grid-template-columns:auto minmax(0,1fr) auto!important;align-items:center!important;gap:10px!important;min-height:58px!important;padding:12px 14px!important;background:var(--pc-panel-2)!important;border-color:var(--pc-border)!important;}

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -207,6 +207,9 @@ DEFAULT_CFG: dict[str, Any] = {
             "libraries": [],                            # Whitelist of library GUIDs; empty = all
             "include_marked_watched": True,             # Include items manually marked as watched in Plex
         },
+        "progress": {
+            "libraries": [],                            # Whitelist for resumable items; empty = all
+        },
         "ratings": {
             "libraries": [],                            # Whitelist of library GUIDs; empty = all
         },
@@ -214,6 +217,8 @@ DEFAULT_CFG: dict[str, Any] = {
         # Ratings / History
         "rating_workers": 12,                           # Parallel workers for Plex ratings indexing. 12–16 is ideal on a local NAS.
         "history_workers": 12,                          # Parallel workers for Plex history indexing. 12–16 is ideal on a local NAS.
+        "progress_clock_drift_seconds": 30,             # Timestamp tolerance before a newer target blocks a progress write.
+        "progress_replay_enabled": False,               # Allow progress writes to already watched Plex items.
 
         # Watchlist via Discover (with PMS fallback toggle)
         "watchlist_allow_pms_fallback": False,          # Allow PMS watchlist fallback when needed. Keep False for strict Discover-only behavior.
@@ -426,6 +431,10 @@ DEFAULT_CFG: dict[str, Any] = {
             "libraries": []                             # whitelist of library GUIDs (from /api/jellyfin/libraries.key); empty = all
         },
 
+        "progress": {
+            "libraries": []                             # whitelist for resumable items; empty = all
+        },
+
         # Ratings settings
         "ratings": {
             "ratings_query_limit": 2000,                # ratings query limit, default 2000
@@ -469,6 +478,10 @@ DEFAULT_CFG: dict[str, Any] = {
                 "agent:themoviedb:en", "agent:themoviedb", "agent:imdb"
             ],
             "libraries": []                             # whitelist of library GUIDs (from /api/emby/libraries.key); empty = all
+        },
+
+        "progress": {
+            "libraries": []                             # whitelist for resumable items; empty = all
         },
 
         # Ratings settings

--- a/cw_platform/orchestrator/_pairs.py
+++ b/cw_platform/orchestrator/_pairs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 from contextlib import contextmanager
+import copy
 import os
 
 from ._pairs_utils import (
@@ -29,6 +30,43 @@ def _deep_merge_provider_overrides(dst: dict[str, Any], src: Mapping[str, Any]) 
             _deep_merge_provider_overrides(cur, v)
         else:
             dst[kk] = v
+
+
+def _config_with_pair_progress_libraries(
+    cfg: dict[str, Any],
+    fcfg: Mapping[str, Any],
+    providers: tuple[str, str],
+) -> dict[str, Any]:
+    lib_cfg = fcfg.get("libraries")
+    if not isinstance(lib_cfg, Mapping):
+        return cfg
+
+    overrides: dict[str, list[str]] = {}
+    for provider in providers:
+        name = str(provider or "").upper().strip()
+        if name not in {"PLEX", "EMBY", "JELLYFIN"}:
+            continue
+        raw = lib_cfg.get(name) or lib_cfg.get(name.lower())
+        if isinstance(raw, (list, tuple)):
+            values = [str(value).strip() for value in raw if str(value).strip()]
+            if values:
+                overrides[name.lower()] = values
+
+    if not overrides:
+        return cfg
+
+    out = copy.deepcopy(cfg)
+    for provider_key, values in overrides.items():
+        provider_cfg = out.setdefault(provider_key, {})
+        if not isinstance(provider_cfg, dict):
+            provider_cfg = {}
+            out[provider_key] = provider_cfg
+        progress_cfg = provider_cfg.setdefault("progress", {})
+        if not isinstance(progress_cfg, dict):
+            progress_cfg = {}
+            provider_cfg["progress"] = progress_cfg
+        progress_cfg["libraries"] = values
+    return out
 
 
 
@@ -346,7 +384,11 @@ def run_pairs(ctx) -> dict[str, Any]:
 
             with _pair_env(pair, i=i, src=src, dst=dst, mode=mode, feature=feature):
                 prev_cfg = ctx.config
-                ctx.config = pair_cfg_view
+                ctx.config = (
+                    _config_with_pair_progress_libraries(pair_cfg_view, fcfg, (src, dst))
+                    if feature == "progress"
+                    else pair_cfg_view
+                )
                 try:
                     if not injected:
                         inject_ctx_into_provider(sops, ctx)

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -354,7 +354,7 @@ def _effective_library_whitelist(
     feature: str,
     fcfg: Mapping[str, Any],
 ) -> list[str]:
-    if feature not in ("history", "ratings"):
+    if feature not in ("history", "ratings", "progress"):
         return []
 
     libs: list[str] = []

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -192,7 +192,7 @@ def _effective_library_whitelist(
     feature: str,
     fcfg: Mapping[str, Any],
 ) -> list[str]:
-    if feature not in ("history", "ratings"):
+    if feature not in ("history", "ratings", "progress"):
         return []
 
     libs: list[str] = []

--- a/providers/auth/_auth_EMBY.py
+++ b/providers/auth/_auth_EMBY.py
@@ -340,12 +340,14 @@ def html() -> str:
                 <div class="lm-col"><span class="sub">Select all:</span></div>
                 <div class="lm-col"><button id="emby_hist_all" type="button" class="lm-dot hist" title="Toggle all History" aria-pressed="false"></button><span class="sub">History</span></div>
                 <div class="lm-col"><button id="emby_rate_all" type="button" class="lm-dot rate" title="Toggle all Ratings" aria-pressed="false"></button><span class="sub">Ratings</span></div>
+                <div class="lm-col"><button id="emby_prog_all" type="button" class="lm-dot prog" title="Toggle all Progress" aria-pressed="false"></button><span class="sub">Progress</span></div>
                 <div class="lm-col"><button id="emby_scr_all" type="button" class="lm-dot scr" title="Toggle all Scrobble" aria-pressed="false"></button><span class="sub">Scrobble</span></div>
               </div>
               <div id="emby_lib_matrix" class="lm-rows"></div>
               <div class="sub" style="margin-top:6px">Empty = all libraries.</div>
               <select id="emby_lib_history" class="lm-hidden" multiple></select>
               <select id="emby_lib_ratings" class="lm-hidden" multiple></select>
+              <select id="emby_lib_progress" class="lm-hidden" multiple></select>
               <select id="emby_lib_scrobble" class="lm-hidden" multiple></select>
             </div>
           </div>

--- a/providers/auth/_auth_JELLYFIN.py
+++ b/providers/auth/_auth_JELLYFIN.py
@@ -347,12 +347,14 @@ def html() -> str:
                 <div class="lm-col"><span class="sub">Select all:</span></div>
                 <div class="lm-col"><button id="jfy_hist_all" type="button" class="lm-dot hist" title="Toggle all History" aria-pressed="false"></button><span class="sub">History</span></div>
                 <div class="lm-col"><button id="jfy_rate_all" type="button" class="lm-dot rate" title="Toggle all Ratings" aria-pressed="false"></button><span class="sub">Ratings</span></div>
+                <div class="lm-col"><button id="jfy_prog_all" type="button" class="lm-dot prog" title="Toggle all Progress" aria-pressed="false"></button><span class="sub">Progress</span></div>
                 <div class="lm-col"><button id="jfy_scr_all" type="button" class="lm-dot scr" title="Toggle all Scrobble" aria-pressed="false"></button><span class="sub">Scrobble</span></div>
               </div>
               <div id="jfy_lib_matrix" class="lm-rows"></div>
               <div class="sub" style="margin-top:6px">Empty = all libraries.</div>
               <select id="jfy_lib_history" name="jfy_lib_history" class="lm-hidden" multiple></select>
               <select id="jfy_lib_ratings" name="jfy_lib_ratings" class="lm-hidden" multiple></select>
+              <select id="jfy_lib_progress" name="jfy_lib_progress" class="lm-hidden" multiple></select>
               <select id="jfy_lib_scrobble" name="jfy_lib_scrobble" class="lm-hidden" multiple></select>
             </div>
           </div>

--- a/providers/auth/_auth_PLEX.py
+++ b/providers/auth/_auth_PLEX.py
@@ -406,12 +406,14 @@ def html() -> str:
                 <input id="plex_lib_filter" class="lm-filter" placeholder="Filter...">
                 <div class="lm-col"><button id="plex_hist_all" type="button" class="lm-dot hist" title="Toggle all History"></button><span class="sub">History</span></div>
                 <div class="lm-col"><button id="plex_rate_all" type="button" class="lm-dot rate" title="Toggle all Ratings"></button><span class="sub">Ratings</span></div>
+                <div class="lm-col"><button id="plex_prog_all" type="button" class="lm-dot prog" title="Toggle all Progress"></button><span class="sub">Progress</span></div>
                 <div class="lm-col"><button id="plex_scr_all" type="button" class="lm-dot scr" title="Toggle all Scrobble"></button><span class="sub">Scrobble</span></div>
               </div>
               <div id="plex_lib_matrix" class="lm-rows"></div>
               <div class="sub" style="margin-top:6px">Empty = all libraries.</div>
               <select id="plex_lib_history" class="lm-hidden" multiple></select>
               <select id="plex_lib_ratings" class="lm-hidden" multiple></select>
+              <select id="plex_lib_progress" class="lm-hidden" multiple></select>
               <select id="plex_lib_scrobble" class="lm-hidden" multiple></select>
             </div>
           </div>

--- a/providers/sync/emby/_utils.py
+++ b/providers/sync/emby/_utils.py
@@ -59,6 +59,10 @@ def ensure_whitelist_defaults(cfg: dict[str, Any] | None = None, instance_id: An
         em.setdefault("history", {}).setdefault("libraries", [])
         changed = True
 
+    if "progress" not in em or "libraries" not in (em.get("progress") or {}):
+        em.setdefault("progress", {}).setdefault("libraries", [])
+        changed = True
+
     if "ratings" not in em or "libraries" not in (em.get("ratings") or {}):
         em.setdefault("ratings", {}).setdefault("libraries", [])
         changed = True

--- a/providers/sync/jellyfin/_utils.py
+++ b/providers/sync/jellyfin/_utils.py
@@ -57,7 +57,7 @@ def ensure_whitelist_defaults(cfg: dict[str, Any] | None = None, instance_id: An
     jf = _jellyfin(cfg2, instance_id)
     changed = False
 
-    for sec in ("history", "ratings", "scrobble"):
+    for sec in ("history", "progress", "ratings", "scrobble"):
         if sec not in jf or not isinstance(jf.get(sec), dict):
             jf[sec] = {}
             changed = True

--- a/providers/sync/plex/_utils.py
+++ b/providers/sync/plex/_utils.py
@@ -1062,7 +1062,7 @@ def ensure_whitelist_defaults(cfg: dict[str, Any] | None = None, instance_id: An
     if not isinstance(plex["scrobble"].get("libraries"), list):
         plex["scrobble"]["libraries"] = []
         changed = True
-    for sec in ("history", "ratings", "scrobble"):
+    for sec in ("history", "progress", "ratings", "scrobble"):
         libs = plex[sec]["libraries"]
         norm = sorted({str(x).strip() for x in libs if str(x).strip()})
         if libs != norm:


### PR DESCRIPTION
# Pull request

## Change

Added configurable Progress library whitelisting for Plex, Emby, and Jellyfin.
Reuse code from history, etc.

- Add a Progress column to server-level library settings.
- Load and save `progress.libraries`.
- Add Progress library chips to pair configuration.
- Save pair selections under `features.progress.libraries`.
- Apply pair Progress scope to one-way and two-way synchronization.
- Pass pair scope into provider target resolution.
- Fall back to server-level scope when the pair selection is empty.
- Prevent excluded duplicate candidates from escaping pair scope.
- Repaint saved selections before slower provider requests finish.
- Reuse loaded Emby and Jellyfin library rows.

## Why

Progress synchronization supported library scoping, but it could not be configured from either the server-level or pair-specific UI.

## Testing

- `tests/test_progress_library_scope.py tests/test_analyzer.py`.
- Added server-level, pair-level, fallback, resolver propagation, one-way, and two-way scope tests.

## Issue

Related to #338