### PR TITLE
Change: improved Plex progress synchronization

### DIFF
--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -35,7 +35,7 @@ def _error(event: str, **fields: Any) -> None:
 def _log(msg: str) -> None:
     _dbg(msg)
 
-__VERSION__ = "1.1"
+__VERSION__ = "1.2"
 os.environ.setdefault("CW_PLEX_VERSION", __VERSION__)
 os.environ.setdefault("CW_PLEX_UA", f"CrossWatch/{__VERSION__} (Plex)")
 __all__ = ["get_manifest", "PLEXModule", "PLEXClient", "PLEXError", "PLEXAuthError", "PLEXNotFound", "OPS"]

--- a/providers/sync/plex/_progress.py
+++ b/providers/sync/plex/_progress.py
@@ -17,6 +17,7 @@ from ._common import (
     home_scope_exit,
     item_guid_candidates,
     plex_cfg_get,
+    plex_feature_library_ids,
     raise_home_scope_not_applied,
     server_find_rating_key_by_guid,
     make_logger,
@@ -67,17 +68,91 @@ def _iso(v: Any) -> str | None:
         return None
 
 
+def _epoch(v: Any) -> float | None:
+    if v is None:
+        return None
+    if isinstance(v, datetime):
+        dt = v if v.tzinfo else v.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    try:
+        text = str(v).strip()
+        if not text:
+            return None
+        if text.replace(".", "", 1).isdigit():
+            value = float(text)
+            return value / 1000.0 if value > 10_000_000_000 else value
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return None
+
+
+def _same_plex_endpoint() -> bool:
+    src = str(os.getenv("CW_PAIR_SRC") or "").upper().strip()
+    dst = str(os.getenv("CW_PAIR_DST") or "").upper().strip()
+    src_instance = str(os.getenv("CW_PAIR_SRC_INSTANCE") or "default").strip().lower() or "default"
+    dst_instance = str(os.getenv("CW_PAIR_DST_INSTANCE") or "default").strip().lower() or "default"
+    return src == dst == "PLEX" and src_instance == dst_instance
+
+
+def _currently_playing(srv: Any, rating_key: str) -> bool:
+    try:
+        for session in srv.sessions() or []:  # type: ignore[attr-defined]
+            if str(getattr(session, "ratingKey", "") or "") == str(rating_key):
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def _truthy_attr(obj: Any, name: str) -> bool:
+    try:
+        value = getattr(obj, name, False)
+        return bool(value() if callable(value) else value)
+    except Exception:
+        return False
+
+
 def _fetch_resume_rating_keys(srv: Any, *, limit: int = 100) -> set[str]:
-    rks: set[str] = set()
+    return set(_fetch_resume_items(srv, page_size=limit))
+
+
+def _library_id(value: Any) -> str | None:
+    source = getattr(value, "attrib", None) if not isinstance(value, Mapping) else value
+    source = source if isinstance(source, Mapping) else {}
+    for key in ("librarySectionID", "sectionID", "librarySectionId", "sectionId", "library_id"):
+        raw = source.get(key)
+        if raw is not None and str(raw).strip():
+            return str(raw).strip()
+    return None
+
+
+def _fetch_resume_items(srv: Any, *, page_size: int = 100) -> dict[str, str | None]:
+    items: dict[str, str | None] = {}
 
     def _q(path: str) -> None:
-        key = f"{path}?X-Plex-Container-Start=0&X-Plex-Container-Size={int(limit)}&includeUserState=1"
-        root = srv.query(key)  # type: ignore[attr-defined]
-        for el in list(root) if root is not None else []:
-            a = getattr(el, "attrib", {}) or {}
-            rk = a.get("ratingKey") or a.get("key")
-            if rk:
-                rks.add(str(rk))
+        start = 0
+        while True:
+            key = f"{path}?X-Plex-Container-Start={start}&X-Plex-Container-Size={int(page_size)}&includeUserState=1"
+            root = srv.query(key)  # type: ignore[attr-defined]
+            rows = list(root) if root is not None else []
+            new_count = 0
+            for el in rows:
+                a = getattr(el, "attrib", {}) or {}
+                rk = a.get("ratingKey") or a.get("key")
+                if not rk:
+                    continue
+                key_id = str(rk)
+                lid = _library_id(a)
+                if key_id in items:
+                    _dbg("duplicate_progress_item", provider_item_id=key_id, source_library_id=lid)
+                    if not items[key_id] and lid:
+                        items[key_id] = lid
+                    continue
+                items[key_id] = lid
+                new_count += 1
+            start += len(rows)
+            if not rows or len(rows) < page_size or new_count == 0:
+                break
 
     for p in ("/hubs/continueWatching/items", "/library/onDeck", "/library/recentlyViewed"):
         try:
@@ -86,8 +161,8 @@ def _fetch_resume_rating_keys(srv: Any, *, limit: int = 100) -> set[str]:
             continue
 
     if _mods_debug():
-        _dbg("index_fetch_counts", source="resume", count=len(rks), limit=int(limit))
-    return rks
+        _dbg("index_fetch_counts", source="resume", count=len(items), page_size=int(page_size))
+    return items
 
 
 def _fetch_metadata_row(srv: Any, rk: str) -> tuple[dict[str, Any] | None, dict[str, str]]:
@@ -140,14 +215,24 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
         if need_scope and not did_switch:
             raise_home_scope_not_applied("progress", sel_aid, sel_uname)
 
-        rks = _fetch_resume_rating_keys(srv, limit=150)
+        resume_items = _fetch_resume_items(srv, page_size=150)
+        allowed = plex_feature_library_ids(adapter, "progress")
+        if not allowed:
+            _dbg("library_scope_not_configured")
         out: dict[str, dict[str, Any]] = {}
         dbg = _mods_debug()
         token = active_pms_token(adapter)
 
-        for rk in sorted(rks):
+        for rk in sorted(resume_items):
             a, ext_ids = _fetch_metadata_row(srv, rk)
             if not a:
+                continue
+            library_id = resume_items.get(rk) or _library_id(a)
+            if allowed and not library_id:
+                _dbg("missing_library_id", provider_item_id=str(rk), allowed_library_ids=sorted(allowed), item_title=str(a.get("title") or ""), media_type=str(a.get("type") or ""), provider_ids=dict(ext_ids))
+                continue
+            if allowed and library_id not in allowed:
+                _dbg("outside_library_scope", provider_item_id=str(rk), source_library_id=library_id, allowed_library_ids=sorted(allowed), item_title=str(a.get("title") or ""), media_type=str(a.get("type") or ""), provider_ids=dict(ext_ids))
                 continue
 
             pos_ms = _to_int(a.get("viewOffset"))
@@ -200,6 +285,8 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
                         base[key_name] = enriched.get(key_name)
 
             norm = id_minimal(base)
+            if library_id:
+                norm["library_id"] = library_id
             if ts:
                 norm["progress_at"] = ts
             norm["progress_ms"] = int(pos_ms)
@@ -221,18 +308,44 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
                     canonical_key=str(ck),
                 )
 
-        _info("index_done", count=len(out))
+        _info("index_done", count=len(out), allowed_library_ids=sorted(allowed), scope_enabled=bool(allowed))
         return out
     finally:
         home_scope_exit(adapter, did_switch)
 
 
 def _resolve_rating_key(adapter: Any, it: Mapping[str, Any]) -> str | None:
+    setattr(adapter, "_plex_progress_last_resolve_hint", None)
+    allowed = plex_feature_library_ids(adapter, "progress")
+    outside_scope_seen = False
+
+    def _allowed_obj(obj: Any, method: str) -> bool:
+        nonlocal outside_scope_seen
+        if not allowed:
+            return True
+        lid = _library_id({
+            "librarySectionID": getattr(obj, "librarySectionID", None),
+            "sectionID": getattr(obj, "sectionID", None),
+            "librarySectionId": getattr(obj, "librarySectionId", None),
+            "sectionId": getattr(obj, "sectionId", None),
+        })
+        if lid in allowed:
+            return True
+        outside_scope_seen = True
+        _dbg("target_candidate_outside_library_scope", provider_item_id=str(getattr(obj, "ratingKey", "") or ""), source_library_id=lid, allowed_library_ids=sorted(allowed), resolution_method=method, item_title=str(getattr(obj, "title", "") or ""), media_type=str(getattr(obj, "type", "") or ""), canonical_key=str(canonical_key(id_minimal(it)) or ""), provider_ids=dict(it.get("ids") or {}), show_ids=dict(it.get("show_ids") or {}), season=it.get("season"), episode=it.get("episode"))
+        return False
+
     # Normalize IDs
     ids = ids_from(it)
     base_rk = (ids.get("plex") or "").strip()
     if base_rk.isdigit():
-        return base_rk
+        srv0 = getattr(getattr(adapter, "client", None), "server", None)
+        try:
+            direct_obj = srv0.fetchItem(int(base_rk)) if srv0 else None  # type: ignore[attr-defined]
+        except Exception:
+            direct_obj = None
+        if direct_obj is not None and _allowed_obj(direct_obj, "direct_plex_rating_key"):
+            return base_rk
 
     srv = getattr(getattr(adapter, "client", None), "server", None)
     if not srv:
@@ -274,22 +387,62 @@ def _resolve_rating_key(adapter: Any, it: Mapping[str, Any]) -> str | None:
             obj = srv.fetchItem(int(rk))  # type: ignore[attr-defined]
             otype = str(getattr(obj, "type", "") or "").lower()
             if not is_episode and otype == "movie":
-                return str(rk)
+                if _allowed_obj(obj, "exact_external_guid"):
+                    return str(rk)
             if is_episode:
                 if otype == "episode":
-                    return str(rk)
+                    if _allowed_obj(obj, "exact_external_guid"):
+                        return str(rk)
                 if otype in ("show", "season"):
                     season = it.get("season")
                     episode = it.get("episode")
                     rk_ep = episode_rating_key_from_show(obj, season, episode)
                     if rk_ep:
-                        return rk_ep
+                        try:
+                            ep_obj = srv.fetchItem(int(rk_ep))  # type: ignore[attr-defined]
+                        except Exception:
+                            ep_obj = None
+                        if ep_obj is not None and _allowed_obj(ep_obj, "show_guid_episode_number"):
+                            return rk_ep
         except Exception:
-            # If fetchItem fails, still try to use rk for movies.
-            return str(rk) if (not is_episode) else None
+            pass
+
+    # A global GUID lookup can return a duplicate from an excluded section.
+    if allowed and guid_candidates:
+        try:
+            library = getattr(srv, "library", None)
+            for section_id in sorted(allowed):
+                section = library.sectionByID(int(section_id)) if library else None
+                if section is None:
+                    continue
+                for guid in guid_candidates:
+                    try:
+                        matches = list(section.search(guid=guid) or [])
+                    except Exception:
+                        matches = []
+                    for obj in matches:
+                        otype = str(getattr(obj, "type", "") or "").lower()
+                        if not _allowed_obj(obj, "exact_external_guid_scoped_search"):
+                            continue
+                        if not is_episode and otype == "movie":
+                            candidate = getattr(obj, "ratingKey", None)
+                            if candidate:
+                                return str(candidate)
+                        if is_episode and otype == "episode":
+                            candidate = getattr(obj, "ratingKey", None)
+                            if candidate:
+                                return str(candidate)
+                        if is_episode and otype in ("show", "season"):
+                            candidate = episode_rating_key_from_show(obj, it.get("season"), it.get("episode"))
+                            if candidate:
+                                return str(candidate)
+        except Exception:
+            pass
 
     strict = bool(plex_cfg_get(adapter, "strict_id_matching", False))
     if strict:
+        if outside_scope_seen:
+            setattr(adapter, "_plex_progress_last_resolve_hint", "outside_library_scope")
         return None
 
     # Title fallback
@@ -318,6 +471,8 @@ def _resolve_rating_key(adapter: Any, it: Mapping[str, Any]) -> str | None:
     if not hits:
         if dbg:
             _dbg("resolve_miss", source="title", query_title=str(query_title))
+        if outside_scope_seen:
+            setattr(adapter, "_plex_progress_last_resolve_hint", "outside_library_scope")
         return None
 
     if dbg:
@@ -364,7 +519,12 @@ def _resolve_rating_key(adapter: Any, it: Mapping[str, Any]) -> str | None:
             pass
         return sc
 
-    best = max(hits, key=_score)
+    scoped_hits = [obj for obj in hits if _allowed_obj(obj, "title_fallback")]
+    if not scoped_hits:
+        if outside_scope_seen:
+            setattr(adapter, "_plex_progress_last_resolve_hint", "outside_library_scope")
+        return None
+    best = max(scoped_hits, key=_score)
     try:
         otype = str(getattr(best, "type", "") or "").lower()
         if not is_episode:
@@ -378,6 +538,8 @@ def _resolve_rating_key(adapter: Any, it: Mapping[str, Any]) -> str | None:
             return rk_ep
     except Exception:
         return None
+    if outside_scope_seen:
+        setattr(adapter, "_plex_progress_last_resolve_hint", "outside_library_scope")
     return None
 
 
@@ -398,6 +560,10 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
 
         for it in items or []:
             it0 = dict(it or {})
+            if _same_plex_endpoint():
+                ok += 1
+                _dbg("write_skipped", reason="same_provider_origin", canonical_key=str(canonical_key(id_minimal(it0)) or ""))
+                continue
             ms = it0.get("progress_ms") or it0.get("viewOffset") or it0.get("progress")
             ms_i = _to_int(ms)
             if ms_i is None or ms_i <= 0:
@@ -408,13 +574,34 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
 
             rk = _resolve_rating_key(adapter, it0)
             if not rk:
-                unresolved.append({"item": it0, "hint": "not_found"})
+                unresolved.append({"item": it0, "hint": str(getattr(adapter, "_plex_progress_last_resolve_hint", "") or "not_found")})
                 if _mods_debug():
                     _dbg("resolve_miss", hint="not_found", canonical_key=str(canonical_key(id_minimal(it0)) or ""), ids=dict(ids_from(it0)))
                 continue
 
             try:
                 obj = srv.fetchItem(int(rk))  # type: ignore[attr-defined]
+                if _currently_playing(srv, rk):
+                    ok += 1
+                    _dbg("write_skipped", reason="currently_playing", provider_item_id=str(rk))
+                    continue
+                replay_enabled = bool(plex_cfg_get(adapter, "progress_replay_enabled", False))
+                watched = bool(
+                    _truthy_attr(obj, "isWatched")
+                    or _truthy_attr(obj, "isPlayed")
+                    or int(getattr(obj, "viewCount", 0) or 0) > 0
+                )
+                if watched and not replay_enabled:
+                    ok += 1
+                    _dbg("write_skipped", reason="target_watched", provider_item_id=str(rk))
+                    continue
+                drift = max(0, int(plex_cfg_get(adapter, "progress_clock_drift_seconds", 30) or 30))
+                source_ts = _epoch(it0.get("progress_at") or it0.get("lastViewedAt"))
+                target_ts = _epoch(getattr(obj, "lastViewedAt", None) or getattr(obj, "viewedAt", None))
+                if source_ts is not None and target_ts is not None and target_ts > source_ts + drift:
+                    ok += 1
+                    _dbg("write_skipped", reason="target_progress_newer", provider_item_id=str(rk), clock_drift_seconds=drift)
+                    continue
                 obj.updateProgress(int(ms_i), state="stopped")
                 ok += 1
             except Exception as e:


### PR DESCRIPTION
# Pull request

## Change

Improved Plex progress synchronization.

- Filter resumable items to configured Progress libraries.
- Recover missing hub library IDs from metadata.
- Reject items whose library cannot be determined while scoped.
- Select allowed duplicates during target resolution.
- Preserve exact Episode GUID resolution across numbering differences.
- Skip currently playing targets.
- Do not overwrite newer target progress.
- Skip watched targets unless replay progress is enabled.
- Prevent same-provider writeback.
- Add configurable clock-drift tolerance.
- Replace fixed progress limits with segmented requests.

## Why

Plex global progress endpoints can return items from excluded libraries. 

## Testing

- Ran `tests/test_progress_library_scope.py tests/test_auth_plex_api.py`.
- Added library recovery, duplicate resolution, playback protection, replay, same-provider, and clock-drift tests.

## Issue

NA