### PR TITLE
Change: harden metadata cache path handling

### DIFF
--- a/api/metaAPI.py
+++ b/api/metaAPI.py
@@ -445,16 +445,27 @@ def _need_satisfied(meta: dict[str, Any], need: dict[str, Any] | None) -> bool:
     return True
 
 
-def _read_meta_cache(p: Path) -> dict[str, Any] | None:
+def _read_meta_cache(
+    entity: str,
+    tmdb_id: str | int,
+    locale: str | None,
+) -> dict[str, Any] | None:
     return read_metadata_cache(
-        p,
-        cache_root=_meta_cache_dir(),
+        _meta_cache_dir(),
+        entity,
+        tmdb_id,
+        locale,
         ttl_seconds=_cfg_meta_ttl_secs(),
     )
 
 
-def _write_meta_cache(p: Path, payload: dict[str, Any]) -> None:
-    write_metadata_cache(p, payload, cache_root=_meta_cache_dir())
+def _write_meta_cache(
+    entity: str,
+    tmdb_id: str | int,
+    locale: str | None,
+    payload: dict[str, Any],
+) -> None:
+    write_metadata_cache(_meta_cache_dir(), entity, tmdb_id, locale, payload)
 
 
 def _merge_meta_cache_payload(base: dict[str, Any] | None, extra: dict[str, Any]) -> dict[str, Any]:
@@ -514,8 +525,7 @@ def get_meta(
     need_key = tuple(sorted(k for k, v in eff_need.items() if v))
     eff_locale = locale or _cfg_ui_locale()
     if _meta_cache_enabled():
-        p = _meta_cache_path(entity, tmdb_id, eff_locale or "en-US")
-        cached = _read_meta_cache(p)
+        cached = _read_meta_cache(entity, tmdb_id, eff_locale or "en-US")
         if cached and _need_satisfied(cached, eff_need):
             _meta_debug(
                 "meta_cache_hit",
@@ -541,7 +551,9 @@ def get_meta(
             payload = _merge_meta_cache_payload(cached, dict(res))
             payload["locale"] = eff_locale or payload.get("locale") or None
             _write_meta_cache(
-                _meta_cache_path(entity, tmdb_id, eff_locale or "en-US"),
+                entity,
+                tmdb_id,
+                eff_locale or "en-US",
                 payload,
             )
             _prune_meta_cache_if_needed()

--- a/api/metaAPI.py
+++ b/api/metaAPI.py
@@ -446,11 +446,15 @@ def _need_satisfied(meta: dict[str, Any], need: dict[str, Any] | None) -> bool:
 
 
 def _read_meta_cache(p: Path) -> dict[str, Any] | None:
-    return read_metadata_cache(p, ttl_seconds=_cfg_meta_ttl_secs())
+    return read_metadata_cache(
+        p,
+        cache_root=_meta_cache_dir(),
+        ttl_seconds=_cfg_meta_ttl_secs(),
+    )
 
 
 def _write_meta_cache(p: Path, payload: dict[str, Any]) -> None:
-    write_metadata_cache(p, payload)
+    write_metadata_cache(p, payload, cache_root=_meta_cache_dir())
 
 
 def _merge_meta_cache_payload(base: dict[str, Any] | None, extra: dict[str, Any]) -> dict[str, Any]:

--- a/cw_platform/metadata_cache.py
+++ b/cw_platform/metadata_cache.py
@@ -10,13 +10,38 @@ from pathlib import Path
 from threading import RLock
 from typing import Any, Mapping
 
-_SAFE_PART_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+_LOCALE_RE = re.compile(r"[a-zA-Z0-9]{1,8}(?:-[a-zA-Z0-9]{1,8})*")
 _WRITE_LOCK = RLock()
 
 
-def _safe_part(value: Any, *, default: str) -> str:
-    text = _SAFE_PART_RE.sub("_", str(value or "").strip()).strip("._-")
-    return text or default
+def _cache_tmdb_id(value: Any) -> str:
+    text = str(value or "").strip()
+    if "/" in text or "\\" in text or not text.isascii() or not text.isdecimal():
+        raise ValueError("TMDb ID must be a positive integer")
+    normalized = str(int(text))
+    if normalized == "0":
+        raise ValueError("TMDb ID must be a positive integer")
+    return normalized
+
+
+def _cache_locale(value: Any) -> str:
+    text = str(value or "en-US").strip()
+    if (
+        "/" in text
+        or "\\" in text
+        or len(text) > 64
+        or _LOCALE_RE.fullmatch(text) is None
+    ):
+        raise ValueError("Locale must be a valid language tag")
+    return text
+
+
+def _path_under_root(path: Path | str, cache_root: Path | str) -> Path:
+    # Resolve symlinks before enforcing the trusted cache boundary.
+    root = Path(cache_root).resolve()
+    target = Path(path).resolve()
+    target.relative_to(root)
+    return target
 
 
 def metadata_cache_path(
@@ -25,20 +50,28 @@ def metadata_cache_path(
     tmdb_id: str | int,
     locale: str | None,
 ) -> Path:
+    cache_id = _cache_tmdb_id(tmdb_id)
+    cache_locale = _cache_locale(locale)
     root = Path(cache_root).resolve()
     media = "movie" if str(entity or "").strip().lower() == "movie" else "show"
     media_root = (root / media).resolve()
     media_root.relative_to(root)
     media_root.mkdir(parents=True, exist_ok=True)
-    name = f"{_safe_part(tmdb_id, default='x')}.{_safe_part(locale or 'en-US', default='en-US')}.json"
+    name = f"{cache_id}.{cache_locale}.json"
     path = (media_root / name).resolve()
     path.relative_to(media_root)
     return path
 
 
-def read_metadata_cache(path: Path | str, *, ttl_seconds: int | None) -> dict[str, Any] | None:
+def read_metadata_cache(
+    path: Path | str,
+    *,
+    cache_root: Path | str,
+    ttl_seconds: int | None,
+) -> dict[str, Any] | None:
     try:
-        data = json.loads(Path(path).read_text("utf-8"))
+        target = _path_under_root(path, cache_root)
+        data = json.loads(target.read_text("utf-8"))
         if not isinstance(data, dict):
             return None
         if ttl_seconds is not None:
@@ -66,9 +99,14 @@ def merge_metadata_cache_payload(
     return out
 
 
-def write_metadata_cache(path: Path | str, payload: Mapping[str, Any]) -> bool:
-    target = Path(path)
+def write_metadata_cache(
+    path: Path | str,
+    payload: Mapping[str, Any],
+    *,
+    cache_root: Path | str,
+) -> bool:
     try:
+        target = _path_under_root(path, cache_root)
         data = dict(payload)
         data["fetched_at"] = time.time()
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/cw_platform/metadata_cache.py
+++ b/cw_platform/metadata_cache.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import time
 from pathlib import Path
@@ -36,14 +37,6 @@ def _cache_locale(value: Any) -> str:
     return text
 
 
-def _path_under_root(path: Path | str, cache_root: Path | str) -> Path:
-    # Resolve symlinks before enforcing the trusted cache boundary.
-    root = Path(cache_root).resolve()
-    target = Path(path).resolve()
-    target.relative_to(root)
-    return target
-
-
 def metadata_cache_path(
     cache_root: Path | str,
     entity: str,
@@ -52,25 +45,31 @@ def metadata_cache_path(
 ) -> Path:
     cache_id = _cache_tmdb_id(tmdb_id)
     cache_locale = _cache_locale(locale)
-    root = Path(cache_root).resolve()
+    root = os.path.realpath(os.fspath(cache_root))
     media = "movie" if str(entity or "").strip().lower() == "movie" else "show"
-    media_root = (root / media).resolve()
-    media_root.relative_to(root)
-    media_root.mkdir(parents=True, exist_ok=True)
+    media_root = os.path.realpath(os.path.join(root, media))
+    root_prefix = root if root.endswith(os.sep) else root + os.sep
+    if not media_root.startswith(root_prefix):
+        raise ValueError("Metadata cache media path escaped its root")
+    Path(media_root).mkdir(parents=True, exist_ok=True)
     name = f"{cache_id}.{cache_locale}.json"
-    path = (media_root / name).resolve()
-    path.relative_to(media_root)
-    return path
+    path = os.path.realpath(os.path.join(media_root, name))
+    media_prefix = media_root if media_root.endswith(os.sep) else media_root + os.sep
+    if not path.startswith(media_prefix):
+        raise ValueError("Metadata cache path escaped its media root")
+    return Path(path)
 
 
 def read_metadata_cache(
-    path: Path | str,
-    *,
     cache_root: Path | str,
+    entity: str,
+    tmdb_id: str | int,
+    locale: str | None,
+    *,
     ttl_seconds: int | None,
 ) -> dict[str, Any] | None:
     try:
-        target = _path_under_root(path, cache_root)
+        target = metadata_cache_path(cache_root, entity, tmdb_id, locale)
         data = json.loads(target.read_text("utf-8"))
         if not isinstance(data, dict):
             return None
@@ -100,13 +99,14 @@ def merge_metadata_cache_payload(
 
 
 def write_metadata_cache(
-    path: Path | str,
-    payload: Mapping[str, Any],
-    *,
     cache_root: Path | str,
+    entity: str,
+    tmdb_id: str | int,
+    locale: str | None,
+    payload: Mapping[str, Any],
 ) -> bool:
     try:
-        target = _path_under_root(path, cache_root)
+        target = metadata_cache_path(cache_root, entity, tmdb_id, locale)
         data = dict(payload)
         data["fetched_at"] = time.time()
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -253,7 +253,7 @@ def _plex_tv_resource_for_connection(
         return None, None
 
     try:
-        u = urlparse(str(baseurl).strip())
+        u = urlparse(str(baseurl).strip(), scheme="")
         want_host = (u.hostname or "").strip().lower()
         want_port = int(u.port or 32400)
         want_scheme = (u.scheme or "").strip().lower()
@@ -288,7 +288,7 @@ def _plex_tv_resource_for_connection(
             if not uri:
                 continue
             try:
-                cu = urlparse(uri)
+                cu = urlparse(uri, scheme="")
                 host = (cu.hostname or "").strip().lower()
                 port = int(cu.port or 32400)
                 scheme = (cu.scheme or "").strip().lower()

--- a/providers/sync/publicmetadb/_common.py
+++ b/providers/sync/publicmetadb/_common.py
@@ -12,7 +12,6 @@ from cw_platform.anime_mapping.service import mapped_or_default_media_type
 from cw_platform.config_base import CONFIG_BASE
 from cw_platform.metadata_cache import (
     merge_metadata_cache_payload,
-    metadata_cache_path,
     prune_metadata_cache,
     read_metadata_cache,
     write_metadata_cache,
@@ -259,12 +258,12 @@ def enrich_index_metadata(
         entity, tmdb_id = identity
         if identity not in cache:
             resolved: Mapping[str, Any] | None = None
-            disk_path: Path | None = None
             if disk_root is not None:
-                disk_path = metadata_cache_path(disk_root, entity, tmdb_id, locale or "en-US")
                 persisted = read_metadata_cache(
-                    disk_path,
-                    cache_root=disk_root,
+                    disk_root,
+                    entity,
+                    tmdb_id,
+                    locale or "en-US",
                     ttl_seconds=_metadata_cache_ttl_seconds(adapter),
                 )
                 needs_title = not str(item.get("series_title" if str(item.get("type") or "").lower() == "episode" else "title") or "").strip()
@@ -293,18 +292,22 @@ def enrich_index_metadata(
                         need={"title": True, "year": True},
                     )
                     resolved = fetched if isinstance(fetched, Mapping) and fetched else None
-                    if resolved is not None and disk_path is not None and disk_root is not None:
+                    if resolved is not None and disk_root is not None:
                         previous = read_metadata_cache(
-                            disk_path,
-                            cache_root=disk_root,
+                            disk_root,
+                            entity,
+                            tmdb_id,
+                            locale or "en-US",
                             ttl_seconds=None,
                         )
                         payload = merge_metadata_cache_payload(previous, resolved)
                         payload["locale"] = locale or payload.get("locale") or None
                         if write_metadata_cache(
-                            disk_path,
+                            disk_root,
+                            entity,
+                            tmdb_id,
+                            locale or "en-US",
                             payload,
-                            cache_root=disk_root,
                         ):
                             cache_written = True
                 except Exception as exc:

--- a/providers/sync/publicmetadb/_common.py
+++ b/providers/sync/publicmetadb/_common.py
@@ -262,7 +262,11 @@ def enrich_index_metadata(
             disk_path: Path | None = None
             if disk_root is not None:
                 disk_path = metadata_cache_path(disk_root, entity, tmdb_id, locale or "en-US")
-                persisted = read_metadata_cache(disk_path, ttl_seconds=_metadata_cache_ttl_seconds(adapter))
+                persisted = read_metadata_cache(
+                    disk_path,
+                    cache_root=disk_root,
+                    ttl_seconds=_metadata_cache_ttl_seconds(adapter),
+                )
                 needs_title = not str(item.get("series_title" if str(item.get("type") or "").lower() == "episode" else "title") or "").strip()
                 needs_year = item.get("year") in (None, "")
                 persisted_value: dict[str, Any] | None = dict(persisted) if isinstance(persisted, Mapping) else None
@@ -289,11 +293,19 @@ def enrich_index_metadata(
                         need={"title": True, "year": True},
                     )
                     resolved = fetched if isinstance(fetched, Mapping) and fetched else None
-                    if resolved is not None and disk_path is not None:
-                        previous = read_metadata_cache(disk_path, ttl_seconds=None)
+                    if resolved is not None and disk_path is not None and disk_root is not None:
+                        previous = read_metadata_cache(
+                            disk_path,
+                            cache_root=disk_root,
+                            ttl_seconds=None,
+                        )
                         payload = merge_metadata_cache_payload(previous, resolved)
                         payload["locale"] = locale or payload.get("locale") or None
-                        if write_metadata_cache(disk_path, payload):
+                        if write_metadata_cache(
+                            disk_path,
+                            payload,
+                            cache_root=disk_root,
+                        ):
                             cache_written = True
                 except Exception as exc:
                     provider_error = exc


### PR DESCRIPTION
# Pull request

## Change

- Validate TMDb IDs and locale components before constructing cache paths.
- Reject unsafe path components instead of rewriting them.
- Resolve cache paths and enforce containment within the configured cache root.
- Pass the trusted cache root explicitly from the metadata API and PublicMetaDB enrichment.
- Update metadata cache tests for the hardened interface.

## Why

 Explicit validation and root containment provide defense in depth and make the security boundary clear to static analysis.

## Testing

- `tests/test_metadata_cache.py -q` 
- Verified the PublicMetaDB changes with Pylance/Pyright

## Issue

Fixes CodeQL path-injection alerts 221–226.