### PR TITLE
Fix: dashboard details layout and Editor styling

### DIFF
--- a/assets/helpers/details-log.js
+++ b/assets/helpers/details-log.js
@@ -953,8 +953,21 @@ function closeDetailsLog() {
 
 function toggleDetails() {
   const d = document.getElementById("details");
-  d.classList.toggle("hidden");
-  if (!d.classList.contains("hidden")) {
+  if (!d) return;
+  const isOpen = d.classList.contains("hidden");
+  const layout = document.getElementById("layout");
+  const statsCard = document.getElementById("stats-card");
+  const insightsFooter = document.getElementById("insights-footer");
+
+  if (!isOpen && statsCard && insightsFooter) {
+    const footerHeight = insightsFooter.getBoundingClientRect().height || insightsFooter.offsetHeight || 120;
+    statsCard.style.paddingBottom = `${footerHeight + 14}px`;
+  }
+
+  d.classList.toggle("hidden", !isOpen);
+  layout?.classList.toggle("details-open", isOpen);
+  if (isOpen) statsCard?.style.removeProperty("padding-bottom");
+  if (isOpen) {
     try { initDetailsTabs(); } catch {}
     try { setDetailsTab(window._detailsTab || "sync"); } catch {}
   } else {

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -59,7 +59,6 @@
     html[data-cw-theme] #page-editor .cw-search-bar,
     html[data-cw-theme] #page-editor .cw-search-results,
     html[data-cw-theme] #page-editor .cw-search-item,
-    html[data-cw-theme] #page-editor .cw-import-panel,
     html[data-cw-theme] #page-editor .cw-policy-action{
       background:#20242d!important;
       background-image:none!important;
@@ -238,7 +237,6 @@
     html[data-cw-theme="flat-light"] #page-editor .cw-search-bar,
     html[data-cw-theme="flat-light"] #page-editor .cw-search-results,
     html[data-cw-theme="flat-light"] #page-editor .cw-search-item,
-    html[data-cw-theme="flat-light"] #page-editor .cw-import-panel,
     html[data-cw-theme="flat-light"] #page-editor .cw-policy-action{
       background:#f5f7fb!important;
       border-color:rgba(16,24,40,.16)!important;

--- a/assets/js/insights.js
+++ b/assets/js/insights.js
@@ -380,7 +380,13 @@ html[data-cw-theme="flat-light"] #insights-switch .ins-gear:hover{
       const card = $("#stats-card"), foot = $("#insights-footer");
       if (!card || !foot) return;
       clearTimeout(timer);
-      timer = setTimeout(() => card.style.paddingBottom = `${(foot.getBoundingClientRect().height || foot.offsetHeight || 120) + 14}px`, 0);
+      timer = setTimeout(() => {
+        if ($("main#layout")?.classList.contains("details-open")) {
+          card.style.removeProperty("padding-bottom");
+          return;
+        }
+        card.style.paddingBottom = `${(foot.getBoundingClientRect().height || foot.offsetHeight || 120) + 14}px`;
+      }, 0);
     };
     w.addEventListener("resize", ensure.reserve, { passive: true });
     return ensure;


### PR DESCRIPTION
# Pull request

## Change

- Added spacing between Recent sync entries.
- Prevented Insights content from overlapping or flickering when toggling View details.
- Matched Import provider state styling with surrounding Editor rows.

## Why

Dashboard content could briefly overlap or disappear when closing View details. The Editor import row also had inconsistent theme styling.

## Testing

- Manual validated

## Issue

NA