### PR TITLE
Fix: include token in MediaBrowser authorization

### DIFF
--- a/providers/scrobble/jellyfin/watch.py
+++ b/providers/scrobble/jellyfin/watch.py
@@ -156,11 +156,12 @@ def _jf_bt(cfg: dict[str, Any]) -> tuple[str, str]:
 def _hdr(tok: str, cfg: dict[str, Any]) -> dict[str, str]:
     e = cfg.get("jellyfin") or {}
     did = str(e.get("device_id") or "crosswatch")
+    auth = f'MediaBrowser Client="CrossWatch", Device="CrossWatch", DeviceId="{did}", Version="1.0.0", Token="{tok}"'
     return {
         "Accept": "application/json",
         "X-Emby-Token": tok,
         "X-MediaBrowser-Token": tok,
-        "Authorization": f'Emby Client="CrossWatch", Device="CrossWatch", DeviceId="{did}", Version="1.0.0"',
+        "Authorization": auth,
     }
 
 

--- a/providers/webhooks/jellyfintrakt.py
+++ b/providers/webhooks/jellyfintrakt.py
@@ -83,11 +83,12 @@ def _jf_conn(cfg: dict[str, Any]) -> tuple[str, str, str, float, bool, str]:
 
 
 def _jf_headers(tok: str, did: str) -> dict[str, str]:
+    auth = f'MediaBrowser Client="CrossWatch", Device="CrossWatch", DeviceId="{did}", Version="1.0.0", Token="{tok}"'
     return {
         'Accept': 'application/json',
         'X-Emby-Token': tok,
         'X-MediaBrowser-Token': tok,
-        'Authorization': f'Emby Client="CrossWatch", Device="CrossWatch", DeviceId="{did}", Version="1.0.0"',
+        'Authorization': auth,
     }
 
 


### PR DESCRIPTION
## Change

- Include the API token in the Authorization header.
- Apply the change to watcher polling and webhook API lookups.

## Why

Some Jellyfin-compatible servers prioritize the Authorization header over the
token headers and could therefore requests to be rejected with 401 Unauthorized.

## Testing

- `tests/test_scrobble_mediabrowser_auth_headers.py`
- Manually tested if Jellyfin watcher still works.

## Issue

Relates to #345