### PR TITLE
Change: harden media-server configuration and Jellyfin authentication

### DIFF
--- a/api/authenticationAPI.py
+++ b/api/authenticationAPI.py
@@ -55,6 +55,14 @@ def _status_from_msg(msg: str) -> int:
     if any(x in m for x in ("dns", "ssl", "connection", "refused", "unreachable", "getaddrinfo", "name or service")): return 502
     return 502
 
+def _public_jellyfin_runtime_error(exc: RuntimeError) -> str:
+    error_text = str(exc).lower()
+    if "version too old" in error_text:
+        return "Jellyfin version too old; CrossWatch requires Jellyfin 10.9 or newer."
+    if "unable to determine jellyfin server version" in error_text:
+        return "Unable to determine Jellyfin server version; CrossWatch requires Jellyfin 10.9 or newer."
+    return "Login failed"
+
 def _import_provider(modname: str, symbol: str = "PROVIDER"):
     try:
         mod = importlib.import_module(modname)
@@ -773,9 +781,11 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
             msg = res.get("error") or "Login failed"
             return JSONResponse({"ok": False, "error": msg}, _status_from_msg(msg))
         except RuntimeError as exc:
-            msg = str(exc) or "Login failed"
+            msg = _public_jellyfin_runtime_error(exc)
+            _safe_log(log_fn, "JELLYFIN", f"[JELLYFIN:{inst}] Login failed error_type={type(exc).__name__}")
             return JSONResponse({"ok": False, "error": msg}, _status_from_msg(msg))
-        except Exception:
+        except Exception as exc:
+            _safe_log(log_fn, "JELLYFIN", f"[JELLYFIN:{inst}] Login failed error_type={type(exc).__name__}")
             return JSONResponse({"ok": False, "error": "Login failed"}, 500)
 
     @app.post("/api/jellyfin/token/delete", tags=["auth"])

--- a/api/authenticationAPI.py
+++ b/api/authenticationAPI.py
@@ -20,6 +20,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
 
 from cw_platform.config_base import DEFAULT_CFG, load_config, save_config
 from cw_platform.provider_instances import ensure_instance_block, ensure_provider_block, normalize_instance_id
+from cw_platform.value_coercion import coerce_bool
 from providers.sync.emby._utils import (
     ensure_whitelist_defaults as emby_ensure_whitelist_defaults,
     fetch_libraries_from_cfg as emby_fetch_libraries_from_cfg,
@@ -48,6 +49,7 @@ def _provider_auth():
 # Helpers
 def _status_from_msg(msg: str) -> int:
     m = (msg or "").lower()
+    if "version too old" in m or "requires jellyfin" in m: return 400
     if any(x in m for x in ("401", "403", "invalid credential", "unauthor")): return 401
     if "timeout" in m: return 504
     if any(x in m for x in ("dns", "ssl", "connection", "refused", "unreachable", "getaddrinfo", "name or service")): return 502
@@ -151,7 +153,7 @@ def _validate_tautulli_credentials(server_url: str, api_key: str, *, timeout: fl
             params={"apikey": key, "cmd": "get_server_info"},
             headers={"Accept": "application/json", "User-Agent": "CrossWatch/TautulliAuth"},
             timeout=timeout,
-            verify=bool(verify_ssl),
+            verify=coerce_bool(verify_ssl, True),
         )
     except requests.Timeout:
         return False, "validation_timeout"
@@ -740,7 +742,7 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         if "password" in payload:
             jf["password"] = str(payload.get("password") or "")
         if "verify_ssl" in payload:
-            jf["verify_ssl"] = bool(payload.get("verify_ssl"))
+            jf["verify_ssl"] = coerce_bool(payload.get("verify_ssl"))
 
         server = str(jf.get("server") or "").strip()
         username = str(jf.get("username") or "").strip()
@@ -762,12 +764,16 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
                         "user_id": res.get("user_id") or jf2.get("user_id") or "",
                         "username": jf2.get("user") or jf2.get("username") or None,
                         "server": jf2.get("server") or None,
+                        "server_version": res.get("server_version") or jf2.get("server_version") or None,
                         "instance": inst,
                     },
                     200,
                 )
 
             msg = res.get("error") or "Login failed"
+            return JSONResponse({"ok": False, "error": msg}, _status_from_msg(msg))
+        except RuntimeError as exc:
+            msg = str(exc) or "Login failed"
             return JSONResponse({"ok": False, "error": msg}, _status_from_msg(msg))
         except Exception:
             return JSONResponse({"ok": False, "error": "Login failed"}, 500)
@@ -789,6 +795,7 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         return {
             "connected": bool(jf.get("access_token") and jf.get("server")),
             "user": jf.get("user") or jf.get("username") or None,
+            "server_version": jf.get("server_version") or None,
             "instance": inst,
         }
 
@@ -823,7 +830,7 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
             raise HTTPException(status_code=401, detail="Not connected to Jellyfin (missing server/token).")
 
         timeout = float(jf.get("timeout", 15) or 15)
-        verify = bool(jf.get("verify_ssl", False))
+        verify = coerce_bool(jf.get("verify_ssl", False))
         devid = str(jf.get("device_id") or "crosswatch").strip() or "crosswatch"
 
         base = f'MediaBrowser Client="CrossWatch", Device="Web", DeviceId="{devid}", Version="1.0"'
@@ -913,7 +920,7 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
             em["password"] = str(payload.get("password") or "")
 
         if "verify_ssl" in payload:
-            em["verify_ssl"] = bool(payload.get("verify_ssl"))
+            em["verify_ssl"] = coerce_bool(payload.get("verify_ssl"))
         if "timeout" in payload:
             em["timeout"] = _to_int(payload.get("timeout"), 15)
 
@@ -993,7 +1000,7 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
                         f"{server}/Users/Me",
                         headers={"X-Emby-Token": token, "Accept": "application/json"},
                         timeout=float(em.get("timeout", 15) or 15),
-                        verify=bool(em.get("verify_ssl", False)),
+                        verify=coerce_bool(em.get("verify_ssl", False)),
                     )
                     if r.ok:
                         me = r.json() or {}
@@ -1034,7 +1041,7 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
             raise HTTPException(status_code=401, detail="Not connected to Emby (missing server/token).")
 
         timeout = float(em.get("timeout", 15) or 15)
-        verify = bool(em.get("verify_ssl", False))
+        verify = coerce_bool(em.get("verify_ssl", False))
         device_id = str(em.get("device_id") or "crosswatch").strip() or "crosswatch"
         stored_user_id = str(em.get("user_id") or "").strip()
         auth = f'MediaBrowser Client="CrossWatch", Device="Web", DeviceId="{device_id}", Version="1.0", Token="{token}"'
@@ -1614,7 +1621,7 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
             raise HTTPException(status_code=400, detail="server_url required")
         if not final_key:
             raise HTTPException(status_code=400, detail="api_key required")
-        ok, reason = _validate_tautulli_credentials(final_server, final_key, verify_ssl=bool(t.get("verify_ssl", True)))
+        ok, reason = _validate_tautulli_credentials(final_server, final_key, verify_ssl=coerce_bool(t.get("verify_ssl", True), True))
         if not ok:
             _safe_log(log_fn, "TAUTULLI", f"[TAUTULLI] validation failed reason={reason} instance={inst}")
             return {"ok": False, "error": reason, "instance": inst}
@@ -1643,7 +1650,7 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
             server,
             key,
             timeout=float(t.get("timeout", 10) or 10),
-            verify_ssl=bool(t.get("verify_ssl", True)),
+            verify_ssl=coerce_bool(t.get("verify_ssl", True), True),
         )
         return {"connected": bool(ok), "instance": inst, **({} if ok else {"reason": reason})}
 

--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -15,6 +15,7 @@ import asyncio
 from fastapi import APIRouter, Body, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel
+from cw_platform.value_coercion import coerce_bool
 
 __all__ = ["router", "_is_sync_running", "_load_state", "_find_state_path"]
 
@@ -55,8 +56,8 @@ _ALLOWED_RATING_MODES: tuple[str, ...] = ("only_new", "from_date", "all")
 def _normalize_progress_block(v: dict | bool | None) -> dict:
     if isinstance(v, bool):
         return {
-            "enable": bool(v),
-            "add": bool(v),
+            "enable": coerce_bool(v),
+            "add": coerce_bool(v),
             "remove": False,
             "min_seconds": 60,
             "delta_seconds": 30,
@@ -65,9 +66,9 @@ def _normalize_progress_block(v: dict | bool | None) -> dict:
         }
 
     d = dict(v or {})
-    d["enable"] = bool(d.get("enable", d.get("enabled", False)))
-    d["add"] = bool(d.get("add", True))
-    d["remove"] = bool(d.get("remove", False))
+    d["enable"] = coerce_bool(d.get("enable", d.get("enabled", False)))
+    d["add"] = coerce_bool(d.get("add", True), True)
+    d["remove"] = coerce_bool(d.get("remove", False))
 
     def _i(x: Any, default: int) -> int:
         try:
@@ -92,7 +93,10 @@ def _normalize_progress_block(v: dict | bool | None) -> dict:
     d["min_seconds"] = max(0, min_s)
     d["delta_seconds"] = max(0, delta_s)
     d["max_percent"] = float(min(100.0, max(0.0, max_p)))
-    d["propagate_timestamp_updates"] = bool(
+    d["replay_enabled"] = coerce_bool(d.get("replay_enabled", False))
+    tolerance = _i(d.get("timestamp_tolerance_seconds"), 30)
+    d["timestamp_tolerance_seconds"] = max(0, min(300, tolerance))
+    d["propagate_timestamp_updates"] = coerce_bool(
         d.get("propagate_timestamp_updates", d.get("propagateTimestampUpdates", False))
     )
 
@@ -105,14 +109,14 @@ def _normalize_progress_block(v: dict | bool | None) -> dict:
 def _normalize_ratings_block(v: dict | bool | None) -> dict:
     if isinstance(v, bool):
         return {
-            "enable": bool(v), "add": bool(v), "remove": False,
+            "enable": coerce_bool(v), "add": coerce_bool(v), "remove": False,
             "types": ["movies", "shows"], "mode": "only_new", "from_date": "",
         }
 
     d = dict(v or {})
-    d["enable"] = bool(d.get("enable", d.get("enabled", False)))
-    d["add"] = bool(d.get("add", True))
-    d["remove"] = bool(d.get("remove", False))
+    d["enable"] = coerce_bool(d.get("enable", d.get("enabled", False)))
+    d["add"] = coerce_bool(d.get("add", True), True)
+    d["remove"] = coerce_bool(d.get("remove", False))
 
     t = d.get("types", [])
     if isinstance(t, str):
@@ -152,15 +156,15 @@ def _normalize_features(f: dict | None) -> dict:
             if isinstance(v, (bool, dict)):
                 f[k] = _normalize_progress_block(v)
         elif isinstance(v, bool):
-            f[k] = {"enable": bool(v), "add": bool(v), "remove": False}
+            f[k] = {"enable": coerce_bool(v), "add": coerce_bool(v), "remove": False}
         elif isinstance(v, dict):
-            v.setdefault("enable", True)
-            v.setdefault("add", True)
-            v.setdefault("remove", False)
+            v["enable"] = coerce_bool(v.get("enable", True), True)
+            v["add"] = coerce_bool(v.get("add", True), True)
+            v["remove"] = coerce_bool(v.get("remove", False))
         if isinstance(f.get(k), dict) and ("use_anime_mapping" in f[k] or "anime_only_sync" in f[k]):
-            use_map = bool(f[k].get("use_anime_mapping", False))
+            use_map = coerce_bool(f[k].get("use_anime_mapping", False))
             f[k]["use_anime_mapping"] = use_map
-            f[k]["anime_only_sync"] = bool(f[k].get("anime_only_sync", False)) if use_map else False
+            f[k]["anime_only_sync"] = coerce_bool(f[k].get("anime_only_sync", False)) if use_map else False
     return f
 
 _PROGRESS_ALLOWED = {"PLEX", "EMBY", "JELLYFIN", "PUBLICMETADB", "CROSSWATCH"}
@@ -191,22 +195,22 @@ def _normalize_pair_providers(p: Any) -> dict[str, Any]:
         if not key:
             continue
         if isinstance(v, bool):
-            out[key] = {"strict_id_matching": bool(v)}
+            out[key] = {"strict_id_matching": coerce_bool(v)}
             continue
         if not isinstance(v, dict):
             continue
         blk: dict[str, Any] = {}
         if "strict_id_matching" in v:
-            blk["strict_id_matching"] = bool(v.get("strict_id_matching"))
+            blk["strict_id_matching"] = coerce_bool(v.get("strict_id_matching"))
         if key == "trakt":
             if "history_ignore_dropped_shows" in v:
-                blk["history_ignore_dropped_shows"] = bool(v.get("history_ignore_dropped_shows"))
+                blk["history_ignore_dropped_shows"] = coerce_bool(v.get("history_ignore_dropped_shows"))
         if key == "mdblist":
             if "history_ignore_dropped_shows" in v:
-                blk["history_ignore_dropped_shows"] = bool(v.get("history_ignore_dropped_shows"))
+                blk["history_ignore_dropped_shows"] = coerce_bool(v.get("history_ignore_dropped_shows"))
         if key == "simkl":
             if "history_ignore_dropped_shows" in v:
-                blk["history_ignore_dropped_shows"] = bool(v.get("history_ignore_dropped_shows"))
+                blk["history_ignore_dropped_shows"] = coerce_bool(v.get("history_ignore_dropped_shows"))
         for kk, vv in v.items():
             if kk in {"strict_id_matching", "history_ignore_dropped_shows"}:
                 continue
@@ -534,7 +538,7 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
 
         if req_pair_id:
             pair = next((p for p in (cfg.get("pairs") or []) if str(p.get("id") or "") == req_pair_id), None)
-            if not pair or pair.get("enabled", True) is False:
+            if not pair or not coerce_bool(pair.get("enabled", True), True):
                 _sync_progress_ui(f"[!] Pair not found or disabled: {req_pair_id}")
                 _sync_progress_ui("[SYNC] exit code: 1")
                 return
@@ -560,12 +564,12 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
                 for _, fcfg in (fmap.items() or []):
                     if isinstance(fcfg, bool) and fcfg:
                         return True
-                    if isinstance(fcfg, dict) and fcfg.get("enable"):
+                    if isinstance(fcfg, dict) and coerce_bool(fcfg.get("enable", True), True):
                         return True
                 return False
 
             for pair in (cfg.get("pairs") or []):
-                if not pair.get("enabled", True):
+                if not coerce_bool(pair.get("enabled", True), True):
                     continue
                 if "features" in pair and not _pair_has_enabled_features(pair):
                     src = pair.get("source") or "?"
@@ -576,7 +580,7 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
                     )
 
             mgr = OrchestratorClass(config=cfg)
-            dry = bool(((cfg.get("sync") or {}).get("dry_run") or False)) or bool((overrides or {}).get("dry_run"))
+            dry = coerce_bool((cfg.get("sync") or {}).get("dry_run", False)) or coerce_bool((overrides or {}).get("dry_run"))
             result = mgr.run_pairs(
                 dry_run=dry,
                 progress=_sync_progress_ui,
@@ -1740,7 +1744,7 @@ def api_pairs_add(payload: PairIn = Body(...)) -> dict[str, Any]:
         item.setdefault("mode", "one-way")
         item["source_instance"] = _norm_instance_id(item.get("source_instance"))
         item["target_instance"] = _norm_instance_id(item.get("target_instance"))
-        item["enabled"] = bool(item.get("enabled", False))
+        item["enabled"] = coerce_bool(item.get("enabled", False))
         item["features"] = _normalize_features(item.get("features") or {"watchlist": True})
         _enforce_pair_feature_constraints(item)
         prov = _normalize_pair_providers(item.get("providers"))
@@ -2064,7 +2068,7 @@ def api_run_sync(payload: dict | None = Body(None)) -> dict[str, Any]:
             pair = next((p for p in pairs if str(p.get("id") or "") == pair_id), None)
             if not pair:
                 return {"ok": False, "error": f"Pair not found: {pair_id}"}
-            if pair.get("enabled", True) is False:
+            if not coerce_bool(pair.get("enabled", True), True):
                 return {"ok": False, "error": f"Pair disabled: {pair_id}"}
             pairs = [pair]
         if not any(p.get("enabled", True) for p in pairs):
@@ -2171,7 +2175,7 @@ async def api_run_summary_stream(request: Request) -> StreamingResponse:
         if not isinstance(enabled, dict):
             return ()
         try:
-            return tuple(sorted((str(k), bool(v)) for k, v in enabled.items()))
+            return tuple(sorted((str(k), coerce_bool(v)) for k, v in enabled.items()))
         except Exception:
             return ()
     async def agen():

--- a/assets/auth/auth.jellyfin.js
+++ b/assets/auth/auth.jellyfin.js
@@ -272,13 +272,14 @@
     const server = (Q("#jfy_server")?.value || "").trim();
     const username = (Q("#jfy_user")?.value || "").trim();
     const password = Q("#jfy_pass")?.value || "";
+    const verify_ssl = !!(Q("#jfy_verify_ssl")?.checked || Q("#jfy_verify_ssl_dup")?.checked);
     const btn = Q("button.btn.jellyfin"), msg = Q("#jfy_msg");
     if (btn) { btn.disabled = true; btn.classList.add("busy"); }
     setMsgBanner(msg, null, '');
     try {
       const r = await fetch(jfyApi("/api/jellyfin/login"), {
         method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ server, username, password }), cache: "no-store"
+        body: JSON.stringify({ server, username, password, verify_ssl }), cache: "no-store"
       });
       const j = await r.json().catch(() => ({}));
       if (!r.ok || j?.ok === false) { setMsgBanner(msg, 'warn', 'Login failed'); return; }

--- a/assets/js/modals/pair-config/help.js
+++ b/assets/js/modals/pair-config/help.js
@@ -39,6 +39,8 @@ export const HELP_TEXT = {
   "cx-pr-min": "Progress: Minimum seconds\nIgnore tiny offsets (scrubbing).",
   "cx-pr-delta": "Progress: Change threshold\nOnly write when the difference is large enough.",
   "cx-pr-maxp": "Progress: Ignore near complete (%)\nWhen near completion, history sync should handle watched state.",
+  "cx-pr-replay": "Replay watched items\nUnwatch the target, then apply resume progress.",
+  "cx-pr-tolerance": "Timestamp tolerance\nProtect targets newer by more than this many seconds.",
 
   "cx-jf-wl-mode": "Jellyfin: Watchlist mode\nJellyfin has no native Watchlist. CrossWatch maps it to:\n• Favorites: sets the Favorite flag\n• Playlist: writes to a named playlist (episodes only; no shows)\n• Collections: writes to a named collection\nChanging mode does not move existing items.\nTip: Favorites or Collections are the most compatible.",
   "cx-em-wl-mode": "Emby: Watchlist mode\nEmby has no native Watchlist. CrossWatch maps it to:\n• Favorites: sets the Favorite flag\n• Playlist: writes to a named playlist (episodes only; no shows)\n• Collections: writes to a named collection\nChanging mode does not move existing items.\nTip: Favorites or Collections are the most compatible.",

--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -204,7 +204,7 @@ function defaultState(){
       ratings:{enable:false,add:false,remove:false,types:["movies","shows","seasons","episodes"],mode:"all",from_date:""},
       history:{enable:false,add:false,remove:false},
       playlists:{enable:false,add:true,remove:false},
-      progress:{enable:false,add:true,remove:false,min_seconds:60,delta_seconds:30,max_percent:95,propagate_timestamp_updates:false}
+      progress:{enable:false,add:true,remove:false,min_seconds:60,delta_seconds:30,max_percent:95,replay_enabled:false,timestamp_tolerance_seconds:30,propagate_timestamp_updates:false}
     },
     pairProviders:{},
     jellyfin:{watchlist:{mode:"favorites",playlist_name:"Watchlist"}},
@@ -369,12 +369,12 @@ const commonFeatures=(state)=>{
 const defaultFor=(k)=>
   k==="watchlist"?{enable:false,add:false,remove:false}:
   k==="playlists"?{enable:false,add:true,remove:false}:
-  k==="progress"?{enable:false,add:true,remove:false,min_seconds:60,delta_seconds:30,max_percent:95,propagate_timestamp_updates:false}:
+  k==="progress"?{enable:false,add:true,remove:false,min_seconds:60,delta_seconds:30,max_percent:95,replay_enabled:false,timestamp_tolerance_seconds:30,propagate_timestamp_updates:false}:
   {enable:false,add:false,remove:false};
 function getOpts(state,key){
   if(!state.visited.has(key)){
     if(key==="ratings") state.options.ratings=Object.assign({enable:false,add:false,remove:false,types:["movies","shows","seasons","episodes"],mode:"all",from_date:""},state.options.ratings||{});
-    else if(key==="progress") state.options.progress=Object.assign({enable:false,add:true,remove:false,min_seconds:60,delta_seconds:30,max_percent:95,propagate_timestamp_updates:false},state.options.progress||{});
+    else if(key==="progress") state.options.progress=Object.assign({enable:false,add:true,remove:false,min_seconds:60,delta_seconds:30,max_percent:95,replay_enabled:false,timestamp_tolerance_seconds:30,propagate_timestamp_updates:false},state.options.progress||{});
     else state.options[key]=state.options[key]??defaultFor(key);
     state.visited.add(key);
   }
@@ -656,7 +656,7 @@ function applySubDisable(feature){
     ],
     history: ["#cx-hs-add", "#cx-hs-remove", "#cx-tr-hs-numfb", "#cx-tr-hs-col", "#cx-tr-hs-col-movies", "#cx-tr-hs-col-shows", "#cx-tr-hs-ignore-dropped", "#cx-md-hs-ignore-dropped", "#cx-sm-hs-ignore-dropped", "#cx-tr-hs-unres"],
     playlists:["#cx-pl-add","#cx-pl-remove"],
-    progress:["#cx-pr-add","#cx-pr-remove","#cx-pr-min","#cx-pr-delta","#cx-pr-maxp"]
+    progress:["#cx-pr-add","#cx-pr-remove","#cx-pr-min","#cx-pr-delta","#cx-pr-maxp","#cx-pr-replay","#cx-pr-tolerance"]
   };
   const on=ID(feature==="ratings"?"cx-rt-enable":feature==="watchlist"?"cx-wl-enable":feature==="history"?"cx-hs-enable":feature==="progress"?"cx-pr-enable":"cx-pl-enable")?.checked;
   (map[feature]||[]).forEach(sel=>{const n=Q(sel);if(n){n.disabled=!on;n.closest?.(".opt-row")?.classList.toggle("muted",!on)}});
@@ -1519,6 +1519,8 @@ left.innerHTML = `
     const minS = Number.isFinite(pr.min_seconds) ? pr.min_seconds : 60;
     const deltaS = Number.isFinite(pr.delta_seconds) ? pr.delta_seconds : 30;
     const maxP = Number.isFinite(pr.max_percent) ? pr.max_percent : 80;
+    const replayEnabled = pr.replay_enabled === true || ["1", "true", "yes", "on"].includes(String(pr.replay_enabled ?? "").trim().toLowerCase());
+    const timestampTolerance = Number.isFinite(Number(pr.timestamp_tolerance_seconds)) ? Math.max(0, Math.min(300, Math.round(Number(pr.timestamp_tolerance_seconds)))) : 30;
 
     left.innerHTML = `<div class="panel-title">Progress | Basics</div>
       <div class="grid2">
@@ -1530,7 +1532,7 @@ left.innerHTML = `
           <label class="switch"><input id="cx-pr-remove" type="checkbox" ${pr.remove ? "checked" : ""}><span class="slider"></span></label></div>
       </div>`;
 
-    right.innerHTML = `<div class="panel-title">Advanced</div>
+    right.innerHTML = `<div class="panel-title">Advanced Playback Progress</div>
       <div class="grid2 compact">
         <div class="opt-row"><label for="cx-pr-min" data-tip-id="cx-pr-min">Minimum seconds</label>
           <input id="cx-pr-min" class="input small" type="number" min="0" max="36000" value="${minS}"></div>
@@ -1538,7 +1540,12 @@ left.innerHTML = `
           <input id="cx-pr-delta" class="input small" type="number" min="0" max="36000" value="${deltaS}"></div>
         <div class="opt-row"><label for="cx-pr-maxp" data-tip-id="cx-pr-maxp">Ignore near complete (%)</label>
           <input id="cx-pr-maxp" class="input small" type="number" min="0" max="100" step="1" value="${maxP}"></div>
+        <div class="opt-row"><label for="cx-pr-replay" data-tip-id="cx-pr-replay">Replay watched items</label>
+          <label class="switch"><input id="cx-pr-replay" type="checkbox" ${replayEnabled ? "checked" : ""}><span class="slider"></span></label></div>
+        <div class="opt-row"><label for="cx-pr-tolerance" data-tip-id="cx-pr-tolerance">Timestamp tolerance (s)</label>
+          <input id="cx-pr-tolerance" class="input small" type="number" min="0" max="300" step="1" value="${timestampTolerance}"></div>
       </div>
+      <div class="muted" style="margin-top:10px;color:#f0b35a">Warning: replay progress marks watched targets unwatched before writing the resume position.</div>
       <div class="muted" style="margin-top:10px">Tip: Progress does not infer clears from absence. It only syncs resume positions.</div>`;
 
     applySubDisable("progress");
@@ -1827,13 +1834,16 @@ function bindChangeHandlers(state,root){
       const minS=parseInt(ID("cx-pr-min")?.value||"60",10);
       const delS=parseInt(ID("cx-pr-delta")?.value||"30",10);
       const maxP=parseFloat(ID("cx-pr-maxp")?.value||"95");
+      const tolerance=parseInt(ID("cx-pr-tolerance")?.value||"30",10);
       state.options.progress=Object.assign({},prev,{
         enable:!!ID("cx-pr-enable")?.checked,
         add:!!ID("cx-pr-add")?.checked,
         remove:!!ID("cx-pr-remove")?.checked,
         min_seconds: Number.isFinite(minS)?Math.max(0,minS):60,
         delta_seconds: Number.isFinite(delS)?Math.max(0,delS):30,
-        max_percent: Number.isFinite(maxP)?Math.min(100,Math.max(0,maxP)):80
+        max_percent: Number.isFinite(maxP)?Math.min(100,Math.max(0,maxP)):80,
+        replay_enabled:!!ID("cx-pr-replay")?.checked,
+        timestamp_tolerance_seconds:Number.isFinite(tolerance)?Math.max(0,Math.min(300,tolerance)):30
       });
       state.visited.add("progress");
     }

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -217,8 +217,6 @@ DEFAULT_CFG: dict[str, Any] = {
         # Ratings / History
         "rating_workers": 12,                           # Parallel workers for Plex ratings indexing. 12–16 is ideal on a local NAS.
         "history_workers": 12,                          # Parallel workers for Plex history indexing. 12–16 is ideal on a local NAS.
-        "progress_clock_drift_seconds": 30,             # Timestamp tolerance before a newer target blocks a progress write.
-        "progress_replay_enabled": False,               # Allow progress writes to already watched Plex items.
 
         # Watchlist via Discover (with PMS fallback toggle)
         "watchlist_allow_pms_fallback": False,          # Allow PMS watchlist fallback when needed. Keep False for strict Discover-only behavior.
@@ -400,6 +398,7 @@ DEFAULT_CFG: dict[str, Any] = {
         "device_id": "crosswatch",                      # Client device id
         "username": "",                                 # Optional (login username)
         "user": "",                                     # Optional (display name; hydrated after auth)
+        "server_version": "",                           # Detected during authentication; Jellyfin 10.9+ required
         "verify_ssl": False,                            # Verify TLS certificates
         "timeout": 15.0,                                # HTTP timeout (seconds)
         "max_retries": 3,                               # Retry budget for API calls
@@ -432,7 +431,7 @@ DEFAULT_CFG: dict[str, Any] = {
         },
 
         "progress": {
-            "libraries": []                             # whitelist for resumable items; empty = all
+            "libraries": [],                            # whitelist for resumable items; empty = all
         },
 
         # Ratings settings
@@ -481,7 +480,7 @@ DEFAULT_CFG: dict[str, Any] = {
         },
 
         "progress": {
-            "libraries": []                             # whitelist for resumable items; empty = all
+            "libraries": [],                            # whitelist for resumable items; empty = all
         },
 
         # Ratings settings

--- a/cw_platform/orchestrator/_pairs.py
+++ b/cw_platform/orchestrator/_pairs.py
@@ -18,12 +18,13 @@ from ._pairs_metrics import ApiMetrics, persist_api_totals
 from ..provider_instances import build_pair_config_view, build_provider_config_view, normalize_instance_id
 from ._pairs_oneway import run_one_way_feature
 from ._pairs_twoway import run_two_way_feature
+from ..value_coercion import coerce_bool
 
 def _deep_merge_provider_overrides(dst: dict[str, Any], src: Mapping[str, Any]) -> None:
     for k, v in (src or {}).items():
         kk = str(k)
         if kk == "strict_id_matching":
-            dst["strict_id_matching"] = bool(v)
+            dst["strict_id_matching"] = coerce_bool(v)
             continue
         cur = dst.get(kk)
         if isinstance(cur, dict) and isinstance(v, Mapping):
@@ -32,31 +33,35 @@ def _deep_merge_provider_overrides(dst: dict[str, Any], src: Mapping[str, Any]) 
             dst[kk] = v
 
 
-def _config_with_pair_progress_libraries(
+def _config_with_pair_progress_options(
     cfg: dict[str, Any],
     fcfg: Mapping[str, Any],
     providers: tuple[str, str],
 ) -> dict[str, Any]:
     lib_cfg = fcfg.get("libraries")
-    if not isinstance(lib_cfg, Mapping):
-        return cfg
-
     overrides: dict[str, list[str]] = {}
+    provider_keys: list[str] = []
     for provider in providers:
         name = str(provider or "").upper().strip()
         if name not in {"PLEX", "EMBY", "JELLYFIN"}:
             continue
-        raw = lib_cfg.get(name) or lib_cfg.get(name.lower())
-        if isinstance(raw, (list, tuple)):
-            values = [str(value).strip() for value in raw if str(value).strip()]
-            if values:
-                overrides[name.lower()] = values
+        provider_key = name.lower()
+        if provider_key not in provider_keys:
+            provider_keys.append(provider_key)
+        if isinstance(lib_cfg, Mapping):
+            raw = lib_cfg.get(name) or lib_cfg.get(provider_key)
+            if isinstance(raw, (list, tuple)):
+                values = [str(value).strip() for value in raw if str(value).strip()]
+                if values:
+                    overrides[provider_key] = values
 
-    if not overrides:
+    has_replay = "replay_enabled" in fcfg
+    has_tolerance = "timestamp_tolerance_seconds" in fcfg
+    if not provider_keys or (not overrides and not has_replay and not has_tolerance):
         return cfg
 
     out = copy.deepcopy(cfg)
-    for provider_key, values in overrides.items():
+    for provider_key in provider_keys:
         provider_cfg = out.setdefault(provider_key, {})
         if not isinstance(provider_cfg, dict):
             provider_cfg = {}
@@ -65,7 +70,16 @@ def _config_with_pair_progress_libraries(
         if not isinstance(progress_cfg, dict):
             progress_cfg = {}
             provider_cfg["progress"] = progress_cfg
-        progress_cfg["libraries"] = values
+        if provider_key in overrides:
+            progress_cfg["libraries"] = overrides[provider_key]
+        if has_replay:
+            progress_cfg["replay_enabled"] = coerce_bool(fcfg.get("replay_enabled", False))
+        if has_tolerance:
+            try:
+                tolerance = int(fcfg.get("timestamp_tolerance_seconds", 30))
+            except (TypeError, ValueError):
+                tolerance = 30
+            progress_cfg["timestamp_tolerance_seconds"] = max(0, min(300, tolerance))
     return out
 
 
@@ -192,10 +206,10 @@ def _feature_list_for_pair(pair: Mapping[str, Any]) -> list[str]:
         out: list[str] = []
         for fname, fcfg in fmap.items():
             if isinstance(fcfg, dict):
-                if bool(fcfg.get("enable", True)):
+                if coerce_bool(fcfg.get("enable", True), True):
                     out.append(str(fname))
-            elif isinstance(fcfg, bool):
-                if fcfg:
+            elif isinstance(fcfg, (bool, str, int, float)):
+                if coerce_bool(fcfg):
                     out.append(str(fname))
             else:
                 out.append(str(fname))
@@ -290,7 +304,7 @@ def run_pairs(ctx) -> dict[str, Any]:
 
     emit(
         "run:start",
-        dry_run=bool(ctx.dry_run or sync_cfg.get("dry_run", False)),
+        dry_run=coerce_bool(ctx.dry_run) or coerce_bool(sync_cfg.get("dry_run", False)),
         mode="v3",
     )
 
@@ -305,7 +319,7 @@ def run_pairs(ctx) -> dict[str, Any]:
     errors_total = 0
     attempted_add_duplicate_keys_total = 0
 
-    pairs = [p for p in (cfg.get("pairs") or []) if p.get("enabled", True)]
+    pairs = [p for p in (cfg.get("pairs") or []) if coerce_bool(p.get("enabled", True), True)]
     provs = ctx.providers or {}
 
     features_ran: set[str] = set()
@@ -329,7 +343,7 @@ def run_pairs(ctx) -> dict[str, Any]:
                 if isinstance(pv, Mapping):
                     _deep_merge_provider_overrides(blk, pv)
                 elif pv is not None and k in {"plex", "jellyfin", "emby"}:
-                    blk["strict_id_matching"] = bool(pv)
+                    blk["strict_id_matching"] = coerce_bool(pv)
 
         feat_map = dict(pair.get("features") or {})
         mode = str(pair.get("mode") or "one-way").lower().strip()
@@ -379,13 +393,13 @@ def run_pairs(ctx) -> dict[str, Any]:
 
         for feature in features:
             fcfg = feat_map.get(feature) or {}
-            if isinstance(fcfg, dict) and not bool(fcfg.get("enable", True)):
+            if isinstance(fcfg, dict) and not coerce_bool(fcfg.get("enable", True), True):
                 continue
 
             with _pair_env(pair, i=i, src=src, dst=dst, mode=mode, feature=feature):
                 prev_cfg = ctx.config
                 ctx.config = (
-                    _config_with_pair_progress_libraries(pair_cfg_view, fcfg, (src, dst))
+                    _config_with_pair_progress_options(pair_cfg_view, fcfg, (src, dst))
                     if feature == "progress"
                     else pair_cfg_view
                 )

--- a/cw_platform/value_coercion.py
+++ b/cw_platform/value_coercion.py
@@ -1,0 +1,24 @@
+# /cw_platform/value_coercion.py
+# CrossWatch - Value Coercion Utilities
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def coerce_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value != 0
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _TRUE_VALUES:
+            return True
+        if normalized in _FALSE_VALUES:
+            return False
+    return bool(default)

--- a/providers/auth/_auth_JELLYFIN.py
+++ b/providers/auth/_auth_JELLYFIN.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import secrets
+import re
 from collections.abc import Mapping, MutableMapping
 from typing import Any, cast
 from urllib.parse import urljoin
@@ -30,6 +31,8 @@ UA = "CrossWatch/1.0"
 __VERSION__ = "2.0.0"
 HTTP_TIMEOUT_POST = 15
 HTTP_TIMEOUT_GET = 10
+MINIMUM_SERVER_VERSION = (10, 9)
+MINIMUM_SERVER_VERSION_TEXT = "10.9"
 
 
 def _clean_base(url: str) -> str:
@@ -62,6 +65,27 @@ def _headers(token: str | None, device_id: str) -> dict[str, str]:
     return h
 
 
+def _server_version_tuple(value: Any) -> tuple[int, int] | None:
+    match = re.match(r"^\s*(\d+)\.(\d+)", str(value or ""))
+    if not match:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _validate_server_version(value: Any) -> str:
+    version = str(value or "").strip()
+    parsed = _server_version_tuple(version)
+    if parsed is None:
+        raise RuntimeError(
+            f"Unable to determine Jellyfin server version; CrossWatch requires Jellyfin {MINIMUM_SERVER_VERSION_TEXT} or newer."
+        )
+    if parsed < MINIMUM_SERVER_VERSION:
+        raise RuntimeError(
+            f"Jellyfin version too old: detected {version}; CrossWatch requires Jellyfin {MINIMUM_SERVER_VERSION_TEXT} or newer."
+        )
+    return version
+
+
 def _raise_with_details(resp: Any, default: str) -> None:
     msg = default
     try:
@@ -83,10 +107,10 @@ class JellyfinAuth(AuthProvider):
 
     def manifest(self) -> AuthManifest:
         return AuthManifest(
-            name="JELLYFIN",
-            label="Jellyfin",
-            flow="token",
-            fields=[
+            "JELLYFIN",
+            "Jellyfin",
+            "token",
+            [
                 {
                     "key": "jellyfin.server",
                     "label": "Server URL",
@@ -106,8 +130,9 @@ class JellyfinAuth(AuthProvider):
                     "required": False,
                 },
             ],
-            actions={"start": True, "finish": False, "refresh": False, "disconnect": True},
-            notes="Sign in with your Jellyfin account to obtain a user access token.",
+            {"start": True, "finish": False, "refresh": False, "disconnect": True},
+            None,
+            "Sign in with your Jellyfin account to obtain a user access token.",
         )
 
     def capabilities(self) -> dict[str, Any]:
@@ -191,6 +216,30 @@ class JellyfinAuth(AuthProvider):
         display = (user_obj.get("Name") or user).strip()
 
         try:
+            server_info = requests.get(
+                urljoin(base, "System/Info"),
+                headers=_headers(token, dev_id),
+                timeout=HTTP_TIMEOUT_GET,
+            )
+        except rx.RequestException as exc:
+            raise RuntimeError(
+                f"Unable to determine Jellyfin server version; CrossWatch requires Jellyfin {MINIMUM_SERVER_VERSION_TEXT} or newer."
+            ) from exc
+        if not server_info.ok:
+            raise RuntimeError(
+                f"Unable to determine Jellyfin server version; CrossWatch requires Jellyfin {MINIMUM_SERVER_VERSION_TEXT} or newer."
+            )
+        try:
+            server_info_data = server_info.json() or {}
+        except Exception as exc:
+            raise RuntimeError(
+                f"Unable to determine Jellyfin server version; CrossWatch requires Jellyfin {MINIMUM_SERVER_VERSION_TEXT} or newer."
+            ) from exc
+        server_version = _validate_server_version(
+            server_info_data.get("Version") or server_info_data.get("ServerVersion")
+        )
+
+        try:
             me = requests.get(
                 urljoin(base, "Users/Me"),
                 headers=_headers(token, dev_id),
@@ -205,10 +254,16 @@ class JellyfinAuth(AuthProvider):
         jf["access_token"] = token
         jf["user_id"] = user_id or jf.get("user_id") or ""
         jf["user"] = display or user
+        jf["server_version"] = server_version
         jf.pop("password", None)
 
         log("Jellyfin: access token stored", level="SUCCESS", module="AUTH")
-        return {"ok": True, "mode": "user_token", "user_id": jf.get("user_id") or ""}
+        return {
+            "ok": True,
+            "mode": "user_token",
+            "user_id": jf.get("user_id") or "",
+            "server_version": server_version,
+        }
 
     def finish(self, cfg: MutableMapping[str, Any], *, instance_id: Any = None, **payload: Any) -> AuthStatus:
         return self.get_status(cfg, instance_id)


### PR DESCRIPTION
# Pull request

## Change

- Added safe boolean for string-based configuration values.
- Added Jellyfin 10.9+ validation during authentication and stored the detected server version.
- Added pair-scoped replay progress and timestamp settings.
- Improved authentication, pair configuration, and progress-setting validation.

## Why

String values were previously treated as enabled.

Jellyfin progress writes require version 10.9 or newer, so unsupported servers will be rejected during configuration.
Im going to remove support for <10.9 jellyfin servers and use the newer API endpoints. 

Progress conflict behavior also needed configurable, pair-scoped controls instead of provider-wide settings.

## Testing

- Jellyfin authentication, progress configuration, and config API tests
- Validated the modified files

## Issue

Relates to #355