### PR TITLE
Fix: correct Emby and Jellyfin progress sync

### DIFF
--- a/providers/sync/_mod_EMBY.py
+++ b/providers/sync/_mod_EMBY.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Iterable, Mapping
 import requests
 
 from cw_platform.provider_instances import normalize_instance_id
+from cw_platform.value_coercion import coerce_bool
 
 from ._log import log as cw_log
 
@@ -76,7 +77,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.1"
+__VERSION__ = "1.2"
 os.environ.setdefault("CW_EMBY_VERSION", __VERSION__)
 os.environ.setdefault("CW_EMBY_UA", f"CrossWatch/{__VERSION__} (Emby)")
 __all__ = ["get_manifest", "EMBYModule", "OPS"]
@@ -217,6 +218,8 @@ class EMBYConfig:
     history_libraries: list[str] | None = None
     progress_libraries: list[str] | None = None
     ratings_libraries: list[str] | None = None
+    progress_replay_enabled: bool = False
+    progress_timestamp_tolerance_seconds: int = 30
 
 
 class EMBYClient:
@@ -355,10 +358,10 @@ class EMBYModule:
             access_token=str(em.get("access_token") or "").strip(),
             user_id=str(em.get("user_id") or "").strip(),
             device_id=str(em.get("device_id") or "crosswatch"),
-            verify_ssl=bool(em.get("verify_ssl", True)),
+            verify_ssl=coerce_bool(em.get("verify_ssl", True), True),
             timeout=float((cfg or {}).get("timeout", em.get("timeout", 15.0))),
             max_retries=int((cfg or {}).get("max_retries", em.get("max_retries", 3))),
-            strict_id_matching=bool(em.get("strict_id_matching", False)),
+            strict_id_matching=coerce_bool(em.get("strict_id_matching", False)),
             watchlist_mode=wl_mode,
             watchlist_playlist_name=wl_pname,
             watchlist_query_limit=wl_qlim,
@@ -370,6 +373,8 @@ class EMBYModule:
             history_libraries=_list_str(hi.get("libraries")),
             progress_libraries=_list_str(pr.get("libraries")),
             ratings_libraries=_list_str(ra.get("libraries")),
+            progress_replay_enabled=coerce_bool(pr.get("replay_enabled", em.get("progress_replay_enabled", False))),
+            progress_timestamp_tolerance_seconds=_i(pr.get("timestamp_tolerance_seconds", em.get("progress_clock_drift_seconds", 30)), 30),
             history_force_overwrite=force_overwrite,
             history_backdate=backdate,
             history_backdate_tolerance_s=bd_tolerance,
@@ -587,7 +592,7 @@ class EMBYModule:
             }
         cnt, unresolved = mod.add(self, lst)
         confirmed_keys = _confirmed_keys(self.key_of, lst, unresolved)
-        return {"ok": True, "count": int(cnt), "unresolved": unresolved, "confirmed_keys": confirmed_keys}
+        return {"ok": True, "count": int(cnt), "unresolved": unresolved, "confirmed_keys": confirmed_keys, "results": list(getattr(self, "_progress_write_results", [])) if f == "progress" else []}
     def remove(
         self,
         feature: str,
@@ -614,7 +619,7 @@ class EMBYModule:
             }
         cnt, unresolved = mod.remove(self, lst)
         confirmed_keys = _confirmed_keys(self.key_of, lst, unresolved)
-        return {"ok": True, "count": int(cnt), "unresolved": unresolved, "confirmed_keys": confirmed_keys}
+        return {"ok": True, "count": int(cnt), "unresolved": unresolved, "confirmed_keys": confirmed_keys, "results": list(getattr(self, "_progress_write_results", [])) if f == "progress" else []}
 class _EmbyOPS:
     def name(self) -> str:
         return "EMBY"

--- a/providers/sync/_mod_JELLYFIN.py
+++ b/providers/sync/_mod_JELLYFIN.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Iterable, Mapping
 import requests
 
 from cw_platform.provider_instances import normalize_instance_id
+from cw_platform.value_coercion import coerce_bool
 
 from ._log import log as cw_log
 
@@ -74,7 +75,24 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.1"
+__VERSION__ = "1.2"
+_MIN_PROGRESS_WRITE_VERSION = (10, 9)
+_JF_VERSION_CACHE: dict[str, tuple[float, str | None]] = {}
+
+
+def _version_tuple(value: Any) -> tuple[int, ...] | None:
+    try:
+        parts = str(value or "").strip().split(".")
+        if len(parts) < 2 or not all(part.isdigit() for part in parts):
+            return None
+        return tuple(int(part) for part in parts)
+    except Exception:
+        return None
+
+
+def _progress_version_supported(value: Any) -> bool:
+    parsed = _version_tuple(value)
+    return bool(parsed and parsed[:2] >= _MIN_PROGRESS_WRITE_VERSION)
 os.environ.setdefault("CW_JELLYFIN_VERSION", __VERSION__)
 os.environ.setdefault("CW_JELLYFIN_UA", f"CrossWatch/{__VERSION__} (Jellyfin)")
 __all__ = ["get_manifest", "JELLYFINModule", "OPS"]
@@ -209,6 +227,8 @@ class JFConfig:
     history_libraries: list[str] | None = None
     progress_libraries: list[str] | None = None
     ratings_libraries: list[str] | None = None
+    progress_replay_enabled: bool = False
+    progress_timestamp_tolerance_seconds: int = 30
 
 
 class JFClient:
@@ -279,6 +299,27 @@ class JFClient:
     def system_info(self) -> requests.Response:
         return self.get(self.BASE_PATH_INFO)
 
+    def server_version(self, *, ttl_seconds: int = 300) -> str | None:
+        now = time.time()
+        cached = _JF_VERSION_CACHE.get(self.base)
+        if cached and now - cached[0] < max(1, int(ttl_seconds)):
+            return cached[1]
+        version: str | None = None
+        try:
+            response = self.system_info()
+            if getattr(response, "status_code", 0) == 200:
+                body = response.json() or {}
+                raw = body.get("Version") or body.get("ServerVersion")
+                version = str(raw).strip() if raw is not None and str(raw).strip() else None
+        except Exception:
+            version = None
+        _JF_VERSION_CACHE[self.base] = (now, version)
+        return version
+
+    def progress_write_supported(self) -> tuple[bool, str | None]:
+        version = self.server_version()
+        return _progress_version_supported(version), version
+
     def user_probe(self) -> requests.Response:
         path = self.BASE_PATH_USER.format(user_id=self.cfg.user_id)
         return self.get(path)
@@ -320,15 +361,21 @@ class JELLYFINModule:
             rows = [str(x).strip() for x in v if str(x).strip()]
             return rows or None
 
+        def _int_value(value: Any, default: int) -> int:
+            try:
+                return int(value)
+            except Exception:
+                return int(default)
+
         self.cfg = JFConfig(
             server=str(jf.get("server") or "").strip(),
             access_token=str(jf.get("access_token") or "").strip(),
             user_id=str(jf.get("user_id") or "").strip(),
             device_id=str(jf.get("device_id") or "crosswatch"),
-            verify_ssl=bool(jf.get("verify_ssl", True)),
+            verify_ssl=coerce_bool(jf.get("verify_ssl", True), True),
             timeout=float((cfg or {}).get("timeout", jf.get("timeout", 15.0))),
             max_retries=int((cfg or {}).get("max_retries", jf.get("max_retries", 3))),
-            strict_id_matching=bool(jf.get("strict_id_matching", False)),
+            strict_id_matching=coerce_bool(jf.get("strict_id_matching", False)),
             watchlist_mode=wl_mode,
             watchlist_playlist_name=wl_pname,
             watchlist_query_limit=wl_qlim,
@@ -340,6 +387,8 @@ class JELLYFINModule:
             history_libraries=_list_str(hi.get("libraries")),
             progress_libraries=_list_str(pr.get("libraries")),
             ratings_libraries=_list_str(ra.get("libraries")),
+            progress_replay_enabled=coerce_bool(pr.get("replay_enabled", jf.get("progress_replay_enabled", False))),
+            progress_timestamp_tolerance_seconds=_int_value(pr.get("timestamp_tolerance_seconds", jf.get("progress_clock_drift_seconds", 30)), 30),
         )
         self.client = JFClient(self.cfg)
 
@@ -535,6 +584,11 @@ class JELLYFINModule:
         dry_run: bool = False,
     ) -> Mapping[str, Any]:
         f = (feature or "watchlist").lower()
+        if f == "progress":
+            supported, version = self.client.progress_write_supported()
+            if not supported:
+                _info(f, "write_skipped", op="add", reason="unsupported_server_version", server_version=version)
+                return {"ok": False, "count": 0, "unresolved": [], "error": "unsupported_server_version", "server_version": version}
         if not self._is_enabled(f):
             _info(f, "write_skipped", op="add", reason="feature_disabled")
             return {"ok": True, "count": 0, "unresolved": []}
@@ -553,7 +607,7 @@ class JELLYFINModule:
             }
         cnt, unres = mod.add(self, lst)
         confirmed_keys = _confirmed_keys(self.key_of, lst, unres)
-        return {"ok": True, "count": int(cnt), "unresolved": unres, "confirmed_keys": confirmed_keys}
+        return {"ok": True, "count": int(cnt), "unresolved": unres, "confirmed_keys": confirmed_keys, "results": list(getattr(self, "_progress_write_results", [])) if f == "progress" else []}
     def remove(
         self,
         feature: str,
@@ -580,7 +634,7 @@ class JELLYFINModule:
             }
         cnt, unres = mod.remove(self, lst)
         confirmed_keys = _confirmed_keys(self.key_of, lst, unres)
-        return {"ok": True, "count": int(cnt), "unresolved": unres, "confirmed_keys": confirmed_keys}
+        return {"ok": True, "count": int(cnt), "unresolved": unres, "confirmed_keys": confirmed_keys, "results": list(getattr(self, "_progress_write_results", [])) if f == "progress" else []}
 class _JellyfinOPS:
     def name(self) -> str:
         return "JELLYFIN"
@@ -614,6 +668,13 @@ class _JellyfinOPS:
         user_id = (jf.get("user_id") or au.get("user_id") or "").strip()
 
         return bool(server and token and user_id)
+
+    def progress_write_capability(self, cfg: Mapping[str, Any]) -> tuple[bool, str, str | None]:
+        try:
+            supported, version = self._adapter(cfg).client.progress_write_supported()
+        except Exception:
+            supported, version = False, None
+        return supported, "" if supported else "unsupported_server_version", version
 
     def _adapter(self, cfg: Mapping[str, Any]) -> JELLYFINModule:
         return JELLYFINModule(cfg)

--- a/providers/sync/_progress_policy.py
+++ b/providers/sync/_progress_policy.py
@@ -1,0 +1,180 @@
+# /ptoviders/sync/_progress_policy.py
+# CrossWatch - Progress Policy Utilities
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+
+DEFAULT_TIMESTAMP_TOLERANCE_SECONDS = 30
+DEFAULT_PROGRESS_TOLERANCE_PERCENT = 0.1
+DEFAULT_PROGRESS_TOLERANCE_MS = 1_000
+
+
+def as_epoch(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, datetime):
+        current = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        return current.timestamp()
+    try:
+        text = str(value).strip()
+        if not text:
+            return None
+        if text.replace(".", "", 1).isdigit():
+            number = float(text)
+            return number / 1000.0 if number >= 10_000_000_000 else number
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return None
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        number = int(float(value))
+        return number if number > 0 else None
+    except Exception:
+        return None
+
+
+def progress_ratio(progress_ms: Any, duration_ms: Any) -> float | None:
+    progress = _positive_int(progress_ms)
+    duration = _positive_int(duration_ms)
+    if progress is None or duration is None:
+        return None
+    return progress / duration
+
+
+def _remote_id(record: Mapping[str, Any]) -> str:
+    raw_ids = record.get("ids")
+    ids: Mapping[str, Any] = raw_ids if isinstance(raw_ids, Mapping) else {}
+    return str(
+        record.get("remote_id")
+        or record.get("emby_item_id")
+        or record.get("jellyfin_item_id")
+        or record.get("ratingKey")
+        or record.get("_item_id")
+        or ids.get("emby")
+        or ids.get("jellyfin")
+        or ids.get("plex")
+        or ""
+    )
+
+
+def select_progress_record(
+    current: Mapping[str, Any] | None,
+    candidate: Mapping[str, Any],
+) -> tuple[dict[str, Any], str]:
+    """Select a canonical duplicate without depending on input order."""
+    if not isinstance(current, Mapping):
+        return dict(candidate), "new"
+
+    current_ts = as_epoch(current.get("progress_at") or current.get("updated_at"))
+    candidate_ts = as_epoch(candidate.get("progress_at") or candidate.get("updated_at"))
+    if current_ts is not None or candidate_ts is not None:
+        if current_ts is None:
+            return dict(candidate), "newer_timestamp"
+        if candidate_ts is None:
+            return dict(current), "keep_newer_timestamp"
+        if candidate_ts != current_ts:
+            return (
+                (dict(candidate), "newer_timestamp")
+                if candidate_ts > current_ts
+                else (dict(current), "keep_newer_timestamp")
+            )
+
+    current_ratio = progress_ratio(current.get("progress_ms"), current.get("duration_ms"))
+    candidate_ratio = progress_ratio(candidate.get("progress_ms"), candidate.get("duration_ms"))
+    if current_ratio is not None and candidate_ratio is not None and candidate_ratio != current_ratio:
+        return (
+            (dict(candidate), "higher_progress_percent")
+            if candidate_ratio > current_ratio
+            else (dict(current), "keep_higher_progress_percent")
+        )
+
+    current_ms = _positive_int(current.get("progress_ms")) or 0
+    candidate_ms = _positive_int(candidate.get("progress_ms")) or 0
+    if candidate_ms != current_ms:
+        return (
+            (dict(candidate), "higher_progress_offset")
+            if candidate_ms > current_ms
+            else (dict(current), "keep_higher_progress_offset")
+        )
+
+    current_key = (
+        _remote_id(current),
+        str(current.get("library_id") or ""),
+        str(current.get("title") or ""),
+    )
+    candidate_key = (
+        _remote_id(candidate),
+        str(candidate.get("library_id") or ""),
+        str(candidate.get("title") or ""),
+    )
+    if candidate_key < current_key:
+        return dict(candidate), "deterministic_fallback"
+    return dict(current), "keep_deterministic_fallback"
+
+
+def progress_materially_equal(
+    source_ms: Any,
+    source_duration_ms: Any,
+    target_ms: Any,
+    target_duration_ms: Any,
+    *,
+    percent_tolerance: float = DEFAULT_PROGRESS_TOLERANCE_PERCENT,
+    ms_tolerance: int = DEFAULT_PROGRESS_TOLERANCE_MS,
+) -> bool:
+    source_ratio = progress_ratio(source_ms, source_duration_ms)
+    target_ratio = progress_ratio(target_ms, target_duration_ms)
+    if source_ratio is not None and target_ratio is not None:
+        return abs(source_ratio - target_ratio) * 100.0 <= max(0.0, float(percent_tolerance))
+    source = _positive_int(source_ms)
+    target = _positive_int(target_ms)
+    return source is not None and target is not None and abs(source - target) <= max(0, int(ms_tolerance))
+
+
+@dataclass(frozen=True)
+class ProgressDecision:
+    apply: bool
+    reason: str
+    unwatch_first: bool = False
+
+
+def decide_progress_write(
+    *,
+    active_session: bool,
+    source_timestamp: Any,
+    target_timestamp: Any,
+    source_progress_ms: Any,
+    source_duration_ms: Any,
+    target_progress_ms: Any,
+    target_duration_ms: Any,
+    target_watched: bool,
+    same_origin: bool,
+    replay_enabled: bool,
+    timestamp_tolerance_seconds: int = DEFAULT_TIMESTAMP_TOLERANCE_SECONDS,
+) -> ProgressDecision:
+    if active_session:
+        return ProgressDecision(False, "active_session")
+    if same_origin:
+        return ProgressDecision(False, "same_origin")
+    source_ts = as_epoch(source_timestamp)
+    if source_ts is None:
+        return ProgressDecision(False, "missing_source_timestamp")
+    target_ts = as_epoch(target_timestamp)
+    tolerance = max(0, int(timestamp_tolerance_seconds))
+    if target_ts is not None and target_ts > source_ts + tolerance:
+        return ProgressDecision(False, "target_newer")
+    if target_watched and not replay_enabled:
+        return ProgressDecision(False, "already_watched")
+    if progress_materially_equal(
+        source_progress_ms,
+        source_duration_ms,
+        target_progress_ms,
+        target_duration_ms,
+    ):
+        return ProgressDecision(False, "progress_unchanged")
+    return ProgressDecision(True, "apply", unwatch_first=bool(target_watched and replay_enabled))

--- a/providers/sync/emby/_common.py
+++ b/providers/sync/emby/_common.py
@@ -179,7 +179,7 @@ def _emby_scope_from_list(libs: list[str]) -> dict[str, Any]:
         return {}
     if len(libs) == 1:
         return {"ParentId": libs[0], "Recursive": True}
-    return {"AncestorIds": libs, "Recursive": True}
+    return {"ParentIds": sorted(set(libs)), "Recursive": True}
 
 
 def emby_library_scope(cfg: CfgLike, feature: str) -> dict[str, Any]:
@@ -229,8 +229,25 @@ def emby_selected_library_ids(cfg: CfgLike, feature: str = "history") -> set[str
     parent = scope.get("ParentId")
     if parent:
         return {str(parent)}
-    ancestors = scope.get("AncestorIds") or []
-    return {str(value) for value in ancestors if value}
+    parents = scope.get("ParentIds") or []
+    return {str(value) for value in parents if value}
+
+
+def emby_scoped_params(params: Mapping[str, Any], cfg: CfgLike, feature: str) -> list[dict[str, Any]]:
+    base = {key: value for key, value in dict(params or {}).items() if key not in {"AncestorIds", "ParentIds", "ParentId"}}
+    libraries = sorted(emby_selected_library_ids(cfg, feature))
+    if not libraries:
+        return [base]
+    return [{**base, "ParentId": library_id, "Recursive": True} for library_id in libraries]
+
+
+def emby_get_scoped_items(http: Any, uid: str, params: Mapping[str, Any], cfg: CfgLike, feature: str) -> list[Mapping[str, Any]]:
+    rows: list[Mapping[str, Any]] = []
+    for query in emby_scoped_params(params, cfg, feature):
+        response = http.get(f"/Users/{uid}/Items", params=query)
+        if getattr(response, "status_code", 0) == 200:
+            rows.extend(row for row in ((response.json() or {}).get("Items") or []) if isinstance(row, Mapping))
+    return sorted(rows, key=lambda row: (str(row.get("Id") or ""), str(row.get("LibraryId") or row.get("CollectionFolderId") or "")))
 
 
 def emby_item_library_ids(item: Mapping[str, Any]) -> set[str]:
@@ -363,6 +380,9 @@ def normalize(obj: Mapping[str, Any]) -> dict[str, Any]:
     if isinstance(obj, Mapping) and "ids" in obj and "type" in obj:
         base = dict(obj)
         res = id_minimal(base)
+        raw = base.get("emby_item_id") or base.get("_emby_item_id") or (base.get("ids") or {}).get("emby")
+        if raw:
+            res["emby_item_id"] = str(raw)
         if "library_id" in base:
             res["library_id"] = base["library_id"]
         return res
@@ -375,6 +395,8 @@ def normalize(obj: Mapping[str, Any]) -> dict[str, Any]:
     if em_id:
         ids["emby"] = str(em_id)
     row: dict[str, Any] = {"type": t, "title": title, "year": year, "ids": ids}
+    if em_id:
+        row["emby_item_id"] = str(em_id)
     lib_id = obj.get("LibraryId")
     if not lib_id:
         anc = obj.get("AncestorIds")
@@ -419,6 +441,8 @@ def normalize(obj: Mapping[str, Any]) -> dict[str, Any]:
         except Exception:
             pass
     res = id_minimal(row)
+    if em_id:
+        res["emby_item_id"] = str(em_id)
     if "library_id" in row and row.get("library_id"):
         res["library_id"] = row["library_id"]
     return res
@@ -527,6 +551,12 @@ def build_provider_index(adapter: Any, *, feature: str | None = None) -> dict[st
     http, uid = adapter.client, adapter.cfg.user_id
     out: dict[str, list[dict[str, Any]]] = {}
     start, limit, total = 0, 500, None
+    parents: list[str | None] = []
+    parents.extend(sorted(emby_selected_library_ids(adapter.cfg, feature or "history")))
+    if not parents:
+        parents = [None]
+    parent_index = 0
+    seen_pages: set[tuple[str, ...]] = set()
     while True:
         params = {
             "IncludeItemTypes": "Movie,Series",
@@ -536,10 +566,16 @@ def build_provider_index(adapter: Any, *, feature: str | None = None) -> dict[st
             "Limit": limit,
             "EnableTotalRecordCount": True,
         }
-        params.update(emby_library_scope(adapter.cfg, feature) if feature else emby_scope_any(adapter.cfg))
+        parent_id = parents[parent_index]
+        if parent_id:
+            params["ParentId"] = parent_id
         r = http.get(f"/Users/{uid}/Items", params=params)
         body = r.json() or {}
         items = body.get("Items") or []
+        signature = tuple(str(row.get("Id") or "") for row in items if isinstance(row, Mapping))
+        if items and signature in seen_pages:
+            break
+        seen_pages.add(signature)
         if total is None:
             total = int(body.get("TotalRecordCount") or 0)
             cw_log("EMBY", "common", "debug", "index_fetch_counts", source="provider_index", total=total)
@@ -571,8 +607,12 @@ def build_provider_index(adapter: Any, *, feature: str | None = None) -> dict[st
                 if m:
                     out.setdefault(f"anilist.{int(m.group(1))}", []).append(row)
         start += len(items)
-        if not items or (total is not None and start >= total):
-            break
+        if not items or len(items) < limit or (total is not None and total > 0 and start >= total):
+            parent_index += 1
+            if parent_index >= len(parents):
+                break
+            start, total = 0, None
+            seen_pages.clear()
     for k, rows in out.items():
         rows.sort(key=lambda r: str(r.get("Id") or ""))
     cw_log("EMBY", "common", "debug", "index_done", source="provider_index", count=len(out))
@@ -604,7 +644,7 @@ def find_series_in_index(adapter: Any, pairs: Iterable[str]) -> dict[str, Any] |
         if pid:
             allowed_libs = [str(pid)]
         else:
-            anc = scope_hist.get("AncestorIds")
+            anc = scope_hist.get("ParentIds")
             if isinstance(anc, (list, tuple)):
                 allowed_libs = [str(x) for x in anc if x]
     def _row_lib_candidates(row: Mapping[str, Any]) -> list[str]:
@@ -1227,13 +1267,17 @@ def _direct_query_by_pairs(
         "Limit": 50,
         "UserId": uid,
     }
-    q.update(scope or {})
+    scope_values = dict(scope or {})
+    parent_ids = [str(value) for value in scope_values.pop("ParentIds", []) if value]
+    q.update(scope_values)
     try:
-        r = http.get(f"/Users/{uid}/Items", params=q)
-        if getattr(r, "status_code", 0) != 200:
-            return []
-        body = r.json() or {}
-        return body.get("Items") or []
+        rows: list[Mapping[str, Any]] = []
+        queries = [{**q, "ParentId": value, "Recursive": True} for value in sorted(parent_ids)] or [q]
+        for query in queries:
+            r = http.get(f"/Users/{uid}/Items", params=query)
+            if getattr(r, "status_code", 0) == 200:
+                rows.extend((r.json() or {}).get("Items") or [])
+        return rows
     except Exception:
         return []
 
@@ -1339,7 +1383,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
         if pid:
             allowed_libs = [str(pid)]
         else:
-            anc = scope_hist.get("AncestorIds")
+            anc = scope_hist.get("ParentIds")
             if isinstance(anc, (list, tuple)):
                 allowed_libs = [str(x) for x in anc if x]
     hint_lib = str(
@@ -1744,6 +1788,9 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "his
     selected_libs = emby_selected_library_ids(adapter.cfg, feature)
 
     ids = dict(it.get("ids") or {})
+    native_id = str(ids.get("emby") or "").strip()
+    if one and native_id and str(one) == native_id:
+        return [str(one)]
     show_ids = it.get("show_ids") if isinstance(it.get("show_ids"), Mapping) else None
 
     t = _lookup_type(it)
@@ -1807,10 +1854,8 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "his
                     "Fields": "ProviderIds,ProductionYear,Type",
                     "Limit": 50,
                 }
-                q.update(emby_library_scope(adapter.cfg, feature))
-                r = http.get("/Items", params=q)
                 t_l = title.lower()
-                for row in emby_filter_library_candidates(_items(r), selected_libs, trust_query_scope=True):
+                for row in emby_filter_library_candidates(emby_get_scoped_items(http, uid, q, adapter.cfg, feature), selected_libs, trust_query_scope=True):
                     if (row.get("Type") or "") != "Movie":
                         continue
                     nm = (row.get("Name") or "").strip().lower()
@@ -1853,10 +1898,8 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "his
                     "Fields": "ProviderIds,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesName",
                     "Limit": 200,
                 }
-                q.update(emby_library_scope(adapter.cfg, feature))
-                r = http.get("/Items", params=q)
                 st_l = series_title.lower()
-                for row in emby_filter_library_candidates(_items(r), selected_libs, trust_query_scope=True):
+                for row in emby_filter_library_candidates(emby_get_scoped_items(http, uid, q, adapter.cfg, feature), selected_libs, trust_query_scope=True):
                     if (row.get("Type") or "") != "Episode":
                         continue
                     sn = (row.get("SeriesName") or "").strip().lower()

--- a/providers/sync/emby/_history.py
+++ b/providers/sync/emby/_history.py
@@ -627,7 +627,7 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
             elif lib_ids:
                 scope_libs = [str(lib_ids)]
             if not scope_libs:
-                anc = scope_cfg.get("AncestorIds")
+                anc = scope_cfg.get("ParentIds")
                 if isinstance(anc, (list, tuple)):
                     scope_libs = [str(x) for x in anc if x]
 
@@ -654,8 +654,7 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
     def _scan(
         include_types: str,
         *,
-        allow_scope: bool,
-        drop_parentid: bool,
+        parent_id: str | None,
         filter_row: Any | None = None,
     ) -> tuple[int, int, int]:
         start = 0
@@ -663,6 +662,7 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
         added_presence = 0
         skipped_untimed = 0
         page = 0
+        seen_pages: set[tuple[str, ...]] = set()
 
         while True:
             t0 = time.monotonic()
@@ -684,21 +684,8 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
                 "UserId": uid,
             }
 
-            scope: Mapping[str, Any] | None = (
-                scope_cfg if (allow_scope and isinstance(scope_cfg, Mapping)) else {}
-            )
-
-            if allow_scope and isinstance(scope, Mapping):
-                for k, v in scope.items():
-                    if k == "IncludeItemTypes":
-                        continue
-                    if drop_parentid and k == "ParentId":
-                        continue
-                    params[k] = v
-                if "IncludeItemTypes" in scope:
-                    want = {x.strip() for x in include_types.split(",") if x.strip()}
-                    got = {x.strip() for x in str(scope["IncludeItemTypes"]).split(",") if x.strip()}
-                    params["IncludeItemTypes"] = ",".join(sorted(want | got))
+            if parent_id:
+                params["ParentId"] = parent_id
 
             r = http.get(f"/Users/{uid}/Items", params=params)
             if getattr(r, "status_code", 0) != 200:
@@ -711,6 +698,12 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
             except Exception as e:
                 _warn("parse_failed", op="index", error=str(e))
                 rows = []
+
+            signature = tuple(str(row.get("Id") or "") for row in rows if isinstance(row, Mapping))
+            if rows and signature in seen_pages:
+                _warn("pagination_repeated_page", scan=include_types, source_library_id=parent_id, start_index=start)
+                break
+            seen_pages.add(signature)
 
             page += 1
             took_ms = int((time.monotonic() - t0) * 1000)
@@ -894,8 +887,8 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
                     continue
 
                 lib_id: str | None = None
-                if scope_libs:
-                    lib_id = scope_libs[0]
+                if parent_id:
+                    lib_id = parent_id
                 else:
                     candidates: list[str] = []
                     mlid = m.get("library_id") if isinstance(m, dict) else None
@@ -939,8 +932,13 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
             _dbg("skipped_untimed_items", count=skipped_untimed)
         return added_events, added_presence, skipped_untimed
 
-    _scan("Movie,Video", allow_scope=True, drop_parentid=True, filter_row=_is_movieish)
-    _scan("Episode", allow_scope=True, drop_parentid=False, filter_row=None)
+    query_parents: list[str | None] = []
+    query_parents.extend(sorted(scope_libs))
+    if not query_parents:
+        query_parents = [None]
+    for query_parent in query_parents:
+        _scan("Movie,Video", parent_id=query_parent, filter_row=_is_movieish)
+        _scan("Episode", parent_id=query_parent, filter_row=None)
 
     events.sort(key=lambda x: x[0], reverse=True)
     if isinstance(limit, int) and limit > 0:

--- a/providers/sync/emby/_progress.py
+++ b/providers/sync/emby/_progress.py
@@ -3,10 +3,12 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping
 
 from cw_platform.id_map import canonical_key
+from providers.sync._progress_policy import decide_progress_write, select_progress_record
 
 from ._common import (
     _ids_from_provider_ids,
@@ -54,6 +56,50 @@ def _ms_to_ticks(v_ms: Any) -> int | None:
 def _pick_user_data(row: Mapping[str, Any]) -> Mapping[str, Any]:
     ud = row.get("UserData")
     return ud if isinstance(ud, Mapping) else {}
+
+
+def _same_origin(provider: str = "EMBY") -> bool:
+    source = str(os.getenv("CW_PAIR_SRC") or "").upper().strip()
+    target = str(os.getenv("CW_PAIR_DST") or provider).upper().strip()
+    source_instance = str(os.getenv("CW_PAIR_SRC_INSTANCE") or "default").lower().strip()
+    target_instance = str(os.getenv("CW_PAIR_DST_INSTANCE") or "default").lower().strip()
+    return source == target == provider and source_instance == target_instance
+
+
+def _active_item_ids(http: Any, uid: str) -> set[str]:
+    try:
+        response = http.get("/Sessions")
+        if getattr(response, "status_code", 0) != 200:
+            return set()
+        rows = response.json() or []
+        return {
+            str((row.get("NowPlayingItem") or {}).get("Id"))
+            for row in rows
+            if isinstance(row, Mapping)
+            and str(row.get("UserId") or "") == str(uid)
+            and isinstance(row.get("NowPlayingItem"), Mapping)
+            and (row.get("NowPlayingItem") or {}).get("Id")
+        }
+    except Exception:
+        return set()
+
+
+def _target_state(http: Any, uid: str, item_id: str) -> dict[str, Any]:
+    response = http.get(
+        f"/Users/{uid}/Items/{item_id}",
+        params={"Fields": "UserData,RunTimeTicks,LibraryId,CollectionFolderId"},
+    )
+    if getattr(response, "status_code", 0) != 200:
+        raise RuntimeError(f"target_state_http_{getattr(response, 'status_code', 0)}")
+    row = response.json() or {}
+    user_data = _pick_user_data(row)
+    return {
+        "watched": bool(user_data.get("Played") or user_data.get("IsPlayed")),
+        "progress_ms": _ticks_to_ms(user_data.get("PlaybackPositionTicks")),
+        "duration_ms": _ticks_to_ms(row.get("RunTimeTicks")),
+        "timestamp": user_data.get("LastPlayedDate") or user_data.get("LastPlayed") or row.get("DateLastSaved"),
+        "library_id": row.get("LibraryId") or row.get("CollectionFolderId"),
+    }
 
 
 def _series_ids_by_item_id(
@@ -117,6 +163,7 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
     page_size = 500
     for parent_id in parents:
         start = 0
+        seen_pages: set[tuple[str, ...]] = set()
         while True:
             params = dict(base_params)
             params.update({"StartIndex": start, "Limit": page_size, "EnableTotalRecordCount": True})
@@ -134,7 +181,11 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
             except Exception as e:
                 _warn("library_scope_query_failed", source_library_id=parent_id, allowed_library_ids=sorted(allowed), error=str(e))
                 break
-            new_count = 0
+            signature = tuple(str(raw.get("Id") or "") for raw in page if isinstance(raw, Mapping))
+            if page and signature in seen_pages:
+                _warn("pagination_repeated_page", source_library_id=parent_id, start_index=start)
+                break
+            seen_pages.add(signature)
             for raw in page:
                 if not isinstance(raw, Mapping):
                     continue
@@ -145,10 +196,9 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
                 if item_id:
                     seen_item_ids.add(item_id)
                 rows.append((raw, parent_id))
-                new_count += 1
             start += len(page)
             total = int(body.get("TotalRecordCount") or 0)
-            if not page or (total and start >= total) or len(page) < page_size or new_count == 0:
+            if not page or (total and start >= total) or len(page) < page_size:
                 break
 
     series_ids_by_item_id = _series_ids_by_item_id(http, str(uid), rows)
@@ -157,6 +207,10 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
     dup_keys = 0
     for raw, source_library_id in rows:
         total_rows += 1
+        raw_type = str(raw.get("Type") or "").strip()
+        if raw_type not in {"Movie", "Episode"}:
+            _warn("unsupported_progress_row_type", provider_item_id=str(raw.get("Id") or ""), media_type=raw_type)
+            continue
         if allowed:
             memberships = emby_item_library_ids(raw)
             if memberships and not (memberships & allowed):
@@ -169,6 +223,9 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
         series_id = str(raw.get("SeriesId") or "").strip()
         if series_id and series_ids_by_item_id.get(series_id):
             item["show_ids"] = dict(series_ids_by_item_id[series_id])
+        if raw_type == "Episode" and not item.get("show_ids") and not item.get("season") and not item.get("episode"):
+            _warn("incomplete_episode_progress_row", provider_item_id=str(raw.get("Id") or ""))
+            continue
         if source_library_id:
             item["library_id"] = source_library_id
 
@@ -189,23 +246,11 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
         if not ck:
             continue
 
-        action = "new"
         prev = out.get(ck)
-        if not isinstance(prev, Mapping):
-            out[ck] = item
-        else:
-            try:
-                p0 = int(prev.get("progress_ms") or 0)
-                p1 = int(item.get("progress_ms") or 0)
-            except Exception:
-                p0, p1 = 0, 0
-            if p0 and p1 and p1 < p0:
-                out[ck] = item
-                dup_keys += 1
-                action = "replace_lower"
-            elif p0 and p1:
-                dup_keys += 1
-                action = "dup_keep"
+        selected, action = select_progress_record(prev, item)
+        out[ck] = selected
+        if isinstance(prev, Mapping):
+            dup_keys += 1
 
         _dbg(
             "item",
@@ -215,11 +260,11 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
             series_title=str(item.get("series_title") or ""),
             season=item.get("season"),
             episode=item.get("episode"),
-            chosen_lastPlayedAt=str(item.get("progress_at") or ""),
-            chosen_viewOffset=int(item.get("progress_ms") or 0),
-            duration_ms=item.get("duration_ms"),
-            ids=dict(item.get("ids") or {}),
-            emby_item_id=str(item.get("emby_item_id") or item.get("jellyfin_item_id") or ""),
+            chosen_lastPlayedAt=str(selected.get("progress_at") or ""),
+            chosen_viewOffset=int(selected.get("progress_ms") or 0),
+            duration_ms=selected.get("duration_ms"),
+            ids=dict(selected.get("ids") or {}),
+            emby_item_id=str((selected.get("ids") or {}).get("emby") or ""),
             action=action,
         )
 
@@ -233,8 +278,12 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
     if not http or not uid:
         return 0, [{"item": dict(x), "hint": "not_configured"} for x in (items or [])]
 
-    ok = 0
+    applied = 0
     unresolved: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    active_items = _active_item_ids(http, str(uid))
+    replay_enabled = bool(getattr(adapter.cfg, "progress_replay_enabled", False))
+    tolerance = int(getattr(adapter.cfg, "progress_timestamp_tolerance_seconds", 30) or 30)
 
     for it in items or []:
         it0 = dict(it or {})
@@ -243,14 +292,19 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         iids = resolve_item_ids(adapter, it0, feature="progress")
         if not iids:
             _dbg("resolve_miss", canonical_key=str(ck), type=str(it0.get("type") or ""), ids=ids)
-            unresolved.append({"item": it0, "hint": str(getattr(adapter, "_emby_last_resolve_hint", "") or "not_found")})
+            reason = str(getattr(adapter, "_emby_last_resolve_hint", "") or "not_found")
+            entry = {"status": "unresolved", "reason": reason, "item": it0}
+            unresolved.append(entry)
+            results.append(entry)
             continue
         _dbg("resolve_hit", canonical_key=str(ck), type=str(it0.get("type") or ""), ids=ids, resolved=len(iids))
 
         ms = it0.get("progress_ms") or it0.get("progress") or it0.get("viewOffset")
         ticks = _ms_to_ticks(ms)
         if ticks is None:
-            unresolved.append({"item": it0, "hint": "missing_progress"})
+            entry = {"status": "unresolved", "reason": "missing_progress", "item": it0}
+            unresolved.append(entry)
+            results.append(entry)
             continue
 
         payload: dict[str, Any] = {"PlaybackPositionTicks": int(ticks)}
@@ -258,25 +312,58 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         if isinstance(pa, str) and pa.strip():
             payload["LastPlayedDate"] = pa.strip()
 
-        any_ok = False
         for iid in iids:
             try:
+                target = _target_state(http, str(uid), str(iid))
+                decision = decide_progress_write(
+                    active_session=str(iid) in active_items,
+                    source_timestamp=pa,
+                    target_timestamp=target.get("timestamp"),
+                    source_progress_ms=ms,
+                    source_duration_ms=it0.get("duration_ms"),
+                    target_progress_ms=target.get("progress_ms"),
+                    target_duration_ms=target.get("duration_ms"),
+                    target_watched=bool(target.get("watched")),
+                    same_origin=_same_origin(),
+                    replay_enabled=replay_enabled,
+                    timestamp_tolerance_seconds=tolerance,
+                )
+                context = {
+                    "provider": "emby", "provider_instance": os.getenv("CW_PAIR_DST_INSTANCE") or "default",
+                    "remote_item_id": str(iid), "library_id": target.get("library_id") or it0.get("library_id"),
+                    "source_timestamp": pa, "target_timestamp": target.get("timestamp"),
+                    "source_progress": ms, "target_progress": target.get("progress_ms"), "reason": decision.reason,
+                }
+                if not decision.apply:
+                    results.append({"status": "skipped", **context})
+                    _dbg("write_skipped", **{key: value for key, value in context.items() if key != "provider"})
+                    continue
+                if decision.unwatch_first:
+                    unwatch = http.delete(f"/Users/{uid}/PlayedItems/{iid}")
+                    if getattr(unwatch, "status_code", 0) not in (200, 204):
+                        entry = {"status": "failed", **context, "reason": "replay_unwatch_failed", "hint": f"http_{getattr(unwatch, 'status_code', 0)}", "item": it0}
+                        unresolved.append(entry)
+                        results.append(entry)
+                        continue
                 r = http.post(f"/Users/{uid}/Items/{iid}/UserData", json=payload)
                 sc = int(getattr(r, "status_code", 0) or 0)
                 _dbg("write_prepare", op="add", canonical_key=str(ck), item_id=str(iid), progress_ms=_ticks_to_ms(payload.get("PlaybackPositionTicks")), status=sc)
                 if sc in (200, 204):
-                    ok += 1
-                    any_ok = True
+                    applied += 1
+                    results.append({"status": "applied", **context})
                 else:
-                    unresolved.append({"item": it0, "hint": f"http_{sc}", "item_id": str(iid)})
+                    entry = {"status": "failed", **context, "hint": f"http_{sc}", "item": it0}
+                    unresolved.append(entry)
+                    results.append(entry)
             except Exception as e:
                 _warn("write_failed", op="add", canonical_key=str(ck), item_id=str(iid), error=str(e))
-                unresolved.append({"item": it0, "hint": f"exception:{e}", "item_id": str(iid)})
-        if not any_ok:
-            unresolved.append({"item": it0, "hint": "all_writes_failed"})
+                entry = {"status": "failed", "reason": "target_state_or_write_failed", "item": it0, "remote_item_id": str(iid), "hint": f"exception:{e}"}
+                unresolved.append(entry)
+                results.append(entry)
 
-    _info("write_done", op="add", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
-    return ok, unresolved
+    setattr(adapter, "_progress_write_results", results)
+    _info("write_done", op="add", ok=len(unresolved) == 0, applied=applied, skipped=sum(1 for row in results if row.get("status") == "skipped"), unresolved=sum(1 for row in results if row.get("status") == "unresolved"), failed=sum(1 for row in results if row.get("status") == "failed"))
+    return applied, unresolved
 
 
 def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
@@ -287,6 +374,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
 
     ok = 0
     unresolved: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
 
     for it in items or []:
         it0 = dict(it or {})
@@ -294,7 +382,9 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
         iid = resolve_item_id(adapter, it0, feature="progress")
         if not iid:
             _dbg("resolve_miss", canonical_key=str(ck))
-            unresolved.append({"item": it0, "hint": "not_found"})
+            entry = {"status": "unresolved", "reason": "not_found", "item": it0}
+            unresolved.append(entry)
+            results.append(entry)
             continue
         _dbg("resolve_hit", canonical_key=str(ck), resolved=1, resolved_id=str(iid))
 
@@ -305,11 +395,17 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
             _dbg("write_prepare", op="remove", canonical_key=str(ck), item_id=str(iid), status=sc)
             if sc in (200, 204):
                 ok += 1
+                results.append({"status": "applied", "provider": "emby", "remote_item_id": str(iid), "library_id": it0.get("library_id"), "source_progress": 0, "reason": "clear_progress"})
             else:
-                unresolved.append({"item": it0, "hint": f"http_{sc}"})
+                entry = {"status": "failed", "reason": "clear_progress_failed", "item": it0, "remote_item_id": str(iid), "hint": f"http_{sc}"}
+                unresolved.append(entry)
+                results.append(entry)
         except Exception as e:
             _warn("write_failed", op="remove", canonical_key=str(ck), item_id=str(iid), error=str(e))
-            unresolved.append({"item": it0, "hint": f"exception:{e}"})
+            entry = {"status": "failed", "reason": "clear_progress_failed", "item": it0, "remote_item_id": str(iid), "hint": f"exception:{e}"}
+            unresolved.append(entry)
+            results.append(entry)
 
+    setattr(adapter, "_progress_write_results", results)
     _info("write_done", op="remove", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
     return ok, unresolved

--- a/providers/sync/emby/_watchlist.py
+++ b/providers/sync/emby/_watchlist.py
@@ -229,6 +229,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
 
     out: dict[str, dict[str, Any]] = {}
     done = 0
+    seen_pages: set[tuple[str, ...]] = set()
 
     while True:
         r = http.get(
@@ -261,6 +262,10 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
             rows = []
             if total is None:
                 total = 0
+        signature = tuple(str(row.get("Id") or "") for row in rows if isinstance(row, Mapping))
+        if rows and signature in seen_pages:
+            break
+        seen_pages.add(signature)
 
         for row in rows:
             try:

--- a/providers/sync/jellyfin/_common.py
+++ b/providers/sync/jellyfin/_common.py
@@ -16,6 +16,8 @@ from .._log import log as cw_log
 from cw_platform.anime_mapping.service import mapped_or_default_media_type
 from cw_platform.id_map import minimal as id_minimal, canonical_key
 
+from ._routes import favorite as favorite_route, user_data as user_data_route, user_params
+
 _DEF_TYPES = {"movie", "show", "episode"}
 _IMDB_PAT = re.compile(r"(?:tt)?(\d{5,9})$")
 _NUM_PAT = re.compile(r"(\d{1,10})$")
@@ -191,7 +193,7 @@ def jf_library_scope(cfg: CfgLike, feature: str) -> dict[str, Any]:
         return {}
     if len(libs) == 1:
         return {"ParentId": libs[0], "Recursive": True}
-    return {"AncestorIds": libs, "Recursive": True}
+    return {"ParentIds": sorted(set(libs)), "Recursive": True}
 
 
 def with_jf_scope(params: Mapping[str, Any], cfg: CfgLike, feature: str) -> dict[str, Any]:
@@ -209,8 +211,25 @@ def jf_selected_library_ids(cfg: CfgLike, feature: str = "history") -> set[str]:
     parent = scope.get("ParentId")
     if parent:
         return {str(parent)}
-    ancestors = scope.get("AncestorIds") or []
-    return {str(value) for value in ancestors if value}
+    parents = scope.get("ParentIds") or []
+    return {str(value) for value in parents if value}
+
+
+def jf_scoped_params(params: Mapping[str, Any], cfg: CfgLike, feature: str) -> list[dict[str, Any]]:
+    base = {key: value for key, value in dict(params or {}).items() if key not in {"AncestorIds", "ParentIds", "ParentId"}}
+    libraries = sorted(jf_selected_library_ids(cfg, feature))
+    if not libraries:
+        return [base]
+    return [{**base, "ParentId": library_id, "Recursive": True} for library_id in libraries]
+
+
+def jf_get_scoped_items(http: Any, uid: str, params: Mapping[str, Any], cfg: CfgLike, feature: str) -> list[Mapping[str, Any]]:
+    rows: list[Mapping[str, Any]] = []
+    for query in jf_scoped_params(params, cfg, feature):
+        response = http.get("/Items", params={**query, "userId": uid})
+        if getattr(response, "status_code", 0) == 200:
+            rows.extend(row for row in ((response.json() or {}).get("Items") or []) if isinstance(row, Mapping))
+    return sorted(rows, key=lambda row: (str(row.get("Id") or ""), str(row.get("LibraryId") or row.get("CollectionFolderId") or "")))
 
 
 def jf_item_library_ids(item: Mapping[str, Any]) -> set[str]:
@@ -282,7 +301,7 @@ def jf_scope_any(cfg: CfgLike) -> dict[str, Any]:
         return {}
     if len(libs) == 1:
         return {"ParentId": libs[0], "Recursive": True}
-    return {"AncestorIds": libs, "Recursive": True}
+    return {"ParentIds": sorted(set(libs)), "Recursive": True}
 
 
 # library roots / mapping
@@ -644,6 +663,12 @@ def build_provider_index(adapter: Any, *, feature: str | None = None) -> dict[st
     start = 0
     limit = 500
     total: int | None = None
+    parents: list[str | None] = []
+    parents.extend(sorted(jf_selected_library_ids(adapter.cfg, feature or "history")))
+    if not parents:
+        parents = [None]
+    parent_index = 0
+    seen_pages: set[tuple[str, ...]] = set()
 
     while True:
         params: dict[str, Any] = {
@@ -654,10 +679,16 @@ def build_provider_index(adapter: Any, *, feature: str | None = None) -> dict[st
             "Limit": limit,
             "EnableTotalRecordCount": True,
         }
-        params.update(jf_library_scope(adapter.cfg, feature) if feature else jf_scope_any(adapter.cfg))
-        r = http.get(f"/Users/{uid}/Items", params=params)
+        parent_id = parents[parent_index]
+        if parent_id:
+            params["ParentId"] = parent_id
+        r = http.get("/Items", params={**params, "userId": uid})
         body = r.json() or {}
         items = body.get("Items") or []
+        signature = tuple(str(row.get("Id") or "") for row in items if isinstance(row, Mapping))
+        if items and signature in seen_pages:
+            break
+        seen_pages.add(signature)
         if total is None:
             total = int(body.get("TotalRecordCount") or 0)
             _dbg('index_fetch_counts', source='provider_index', total=total)
@@ -682,8 +713,12 @@ def build_provider_index(adapter: Any, *, feature: str | None = None) -> dict[st
                 if m_tvdb:
                     out.setdefault(f"tvdb.{int(m_tvdb.group(1))}", []).append(row)
         start += len(items)
-        if not items or (total is not None and start >= total):
-            break
+        if not items or len(items) < limit or (total is not None and total > 0 and start >= total):
+            parent_index += 1
+            if parent_index >= len(parents):
+                break
+            start, total = 0, None
+            seen_pages.clear()
 
     for k, rows in out.items():
         rows.sort(key=lambda r: str(r.get("Id") or ""))
@@ -735,7 +770,7 @@ def find_playlist_id_by_name(http: Any, user_id: str, name: str) -> str | None:
         "recursive": True,
         "SearchTerm": name,
     }
-    r = http.get(f"/Users/{user_id}/Items", params=q)
+    r = http.get("/Items", params=q)
     if getattr(r, "status_code", 0) != 200:
         return None
     items = (r.json() or {}).get("Items") or []
@@ -745,7 +780,7 @@ def find_playlist_id_by_name(http: Any, user_id: str, name: str) -> str | None:
             return it.get("Id")
     if not items:
         q = {"userId": user_id, "includeItemTypes": "Playlist", "recursive": True}
-        r = http.get(f"/Users/{user_id}/Items", params=q)
+        r = http.get("/Items", params=q)
         if getattr(r, "status_code", 0) != 200:
             return None
         for it in (r.json() or {}).get("Items") or []:
@@ -817,8 +852,9 @@ def playlist_remove_entries(http: Any, playlist_id: str, entry_ids: Iterable[str
 def find_collection_id_by_name(http: Any, user_id: str, name: str) -> str | None:
     try:
         r = http.get(
-            f"/Users/{user_id}/Items",
+            "/Items",
             params={
+                "userId": user_id,
                 "IncludeItemTypes": "BoxSet",
                 "Recursive": True,
                 "SearchTerm": name,
@@ -835,8 +871,8 @@ def find_collection_id_by_name(http: Any, user_id: str, name: str) -> str | None
             ):
                 return str(row.get("Id"))
         r2 = http.get(
-            f"/Users/{user_id}/Items",
-            params={"IncludeItemTypes": "BoxSet", "Recursive": True},
+            "/Items",
+            params={"userId": user_id, "IncludeItemTypes": "BoxSet", "Recursive": True},
         )
         if getattr(r2, "status_code", 0) != 200:
             return None
@@ -865,8 +901,9 @@ def create_collection(http: Any, name: str) -> str | None:
 def get_collection_items(http: Any, user_id: str, collection_id: str) -> dict[str, Any]:
     try:
         r = http.get(
-            f"/Users/{user_id}/Items",
+            "/Items",
             params={
+                "userId": user_id,
                 "ParentId": collection_id,
                 "Recursive": True,
                 "IncludeItemTypes": "Movie,Series",
@@ -896,8 +933,9 @@ def collection_fetch_all(
     total: int | None = None
     while True:
         r = http.get(
-            f"/Users/{user_id}/Items",
+            "/Items",
             params={
+                "userId": user_id,
                 "IncludeItemTypes": "Movie,Series",
                 "ParentId": collection_id,
                 "Recursive": False,
@@ -943,8 +981,9 @@ def collection_remove_items(http: Any, collection_id: str, item_ids: Iterable[st
 
 # misc writes
 def mark_favorite(http: Any, user_id: str, item_id: str, flag: bool) -> bool:
-    path = f"/Users/{user_id}/FavoriteItems/{item_id}"
-    r = http.post(path) if flag else http.delete(path)
+    path = favorite_route(item_id)
+    params = user_params(user_id)
+    r = http.post(path, params=params) if flag else http.delete(path, params=params)
     ok = getattr(r, "status_code", 0) in (200, 204)
     if not ok:
         body_snip = "no-body"
@@ -966,8 +1005,8 @@ def mark_favorite(http: Any, user_id: str, item_id: str, flag: bool) -> bool:
 def update_userdata(http: Any, user_id: str, item_id: str, payload: Mapping[str, Any]) -> bool:
     try:
         r = http.post(
-            f"/Items/{item_id}/UserData",
-            params={"userId": user_id},
+            user_data_route(item_id),
+            params=user_params(user_id),
             json=dict(payload),
         )
         return getattr(r, "status_code", 0) in (200, 204)
@@ -1022,15 +1061,18 @@ def _direct_query_by_pairs(
         "Recursive": True,
         "Fields": "ProviderIds,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesId,ParentId,CollectionFolderId,AncestorIds,LibraryId,Name",
         "Limit": 50,
-        "UserId": uid,
     }
-    q.update(scope or {})
+    scope_values = dict(scope or {})
+    parent_ids = [str(value) for value in scope_values.pop("ParentIds", []) if value]
+    q.update(scope_values)
     try:
-        r = http.get(f"/Users/{uid}/Items", params=q)
-        if getattr(r, "status_code", 0) != 200:
-            return []
-        body = r.json() or {}
-        return body.get("Items") or []
+        rows: list[Mapping[str, Any]] = []
+        queries = [{**q, "ParentId": value, "Recursive": True} for value in sorted(parent_ids)] or [q]
+        for query in queries:
+            r = http.get("/Items", params={**query, "userId": uid})
+            if getattr(r, "status_code", 0) == 200:
+                rows.extend((r.json() or {}).get("Items") or [])
+        return rows
     except Exception:
         return []
 
@@ -1072,8 +1114,8 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
         if selected_libs:
             try:
                 response = http.get(
-                    f"/Users/{uid}/Items/{jf}",
-                    params={"Fields": "LibraryId,CollectionFolderId,AncestorIds,ParentId,Type"},
+                    f"/Items/{jf}",
+                    params={"userId": uid, "Fields": "LibraryId,CollectionFolderId,AncestorIds,ParentId,Type"},
                 )
                 row = response.json() or {} if getattr(response, "status_code", 0) == 200 else {}
             except Exception:
@@ -1129,11 +1171,9 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
                     "Fields": "ProviderIds,ProductionYear,Type",
                     "Limit": 50,
                 }
-                q.update(jf_library_scope(adapter.cfg, feature))
-                r = http.get("/Items", params=q)
                 t_l = title.lower()
                 cand: list[Mapping[str, Any]] = []
-                raw_rows = (r.json() or {}).get("Items") or []
+                raw_rows = jf_get_scoped_items(http, uid, q, adapter.cfg, feature)
                 scoped_rows = jf_filter_library_candidates(raw_rows, selected_libs, trust_query_scope=True)
                 if raw_rows and not scoped_rows and selected_libs:
                     outside_scope_seen = True
@@ -1180,11 +1220,9 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
                     "Fields": "ProviderIds,ProductionYear,Type",
                     "Limit": 50,
                 }
-                q.update(jf_library_scope(adapter.cfg, feature))
-                r = http.get("/Items", params=q)
                 title_lc = title.lower()
                 cand = []
-                raw_rows = (r.json() or {}).get("Items") or []
+                raw_rows = jf_get_scoped_items(http, uid, q, adapter.cfg, feature)
                 scoped_rows = jf_filter_library_candidates(raw_rows, selected_libs, trust_query_scope=True)
                 if raw_rows and not scoped_rows and selected_libs:
                     outside_scope_seen = True
@@ -1305,11 +1343,9 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
                 "Fields": "ProviderIds,ProductionYear,Type",
                 "Limit": 50,
             }
-            q.update(jf_library_scope(adapter.cfg, feature))
-            r = http.get("/Items", params=q)
             t_l = series_title.lower()
             cands = []
-            raw_rows = (r.json() or {}).get("Items") or []
+            raw_rows = jf_get_scoped_items(http, uid, q, adapter.cfg, feature)
             scoped_rows = jf_filter_library_candidates(raw_rows, selected_libs, trust_query_scope=True)
             if raw_rows and not scoped_rows and selected_libs:
                 outside_scope_seen = True
@@ -1358,10 +1394,8 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
                 "Fields": "ProviderIds,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesId",
                 "Limit": 50,
             }
-            q.update(jf_library_scope(adapter.cfg, feature))
-            r = http.get("/Items", params=q)
             t_l = title.lower()
-            raw_rows = (r.json() or {}).get("Items") or []
+            raw_rows = jf_get_scoped_items(http, uid, q, adapter.cfg, feature)
             scoped_rows = jf_filter_library_candidates(raw_rows, selected_libs, trust_query_scope=True)
             if raw_rows and not scoped_rows and selected_libs:
                 outside_scope_seen = True
@@ -1402,6 +1436,9 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "his
     selected_libs = jf_selected_library_ids(adapter.cfg, feature)
 
     ids = dict(it.get("ids") or {})
+    native_id = str(ids.get("jellyfin") or "").strip()
+    if one and native_id and str(one) == native_id:
+        return [str(one)]
     show_ids = it.get("show_ids") if isinstance(it.get("show_ids"), Mapping) else None
 
     t = _lookup_type(it)
@@ -1459,10 +1496,8 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "his
                     "Fields": "ProviderIds,ProductionYear,Type",
                     "Limit": 50,
                 }
-                q.update(jf_library_scope(adapter.cfg, feature))
-                r = http.get("/Items", params=q)
                 t_l = title.lower()
-                for row in jf_filter_library_candidates((r.json() or {}).get("Items") or [], selected_libs, trust_query_scope=True):
+                for row in jf_filter_library_candidates(jf_get_scoped_items(http, uid, q, adapter.cfg, feature), selected_libs, trust_query_scope=True):
                     if (row.get("Type") or "") != "Movie":
                         continue
                     nm = (row.get("Name") or "").strip().lower()
@@ -1506,10 +1541,8 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "his
                     "Fields": "ProviderIds,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesName",
                     "Limit": 200,
                 }
-                q.update(jf_library_scope(adapter.cfg, feature))
-                r = http.get("/Items", params=q)
                 st_l = series_title.lower()
-                for row in jf_filter_library_candidates((r.json() or {}).get("Items") or [], selected_libs, trust_query_scope=True):
+                for row in jf_filter_library_candidates(jf_get_scoped_items(http, uid, q, adapter.cfg, feature), selected_libs, trust_query_scope=True):
                     if (row.get("Type") or "") != "Episode":
                         continue
                     sn = (row.get("SeriesName") or "").strip().lower()

--- a/providers/sync/jellyfin/_history.py
+++ b/providers/sync/jellyfin/_history.py
@@ -23,6 +23,7 @@ from ._common import (
     _pair_scope,
     _is_capture_mode,
 )
+from ._routes import items as items_route, played as played_route, user_params
 from cw_platform.id_map import canonical_key, minimal as id_minimal
 
 def _unresolved_path() -> str:
@@ -251,11 +252,11 @@ def _prefetch_series_meta(http: Any, uid: str, series_ids: Iterable[str]) -> Non
             continue
         try:
             r = http.get(
-                f"/Users/{uid}/Items",
-                params={
+                items_route(),
+                params=user_params(uid, {
                     'Ids': ids,
                     'Fields': 'ProviderIds,ProductionYear,Type,Name',
-                },
+                }),
             )
             if getattr(r, 'status_code', 0) != 200:
                 continue
@@ -312,7 +313,7 @@ def _series_ids_for(http: Any, uid: str, series_id: str | None) -> dict[str, str
 def _mark_played(http: Any, uid: str, item_id: str, *, date_played_iso: str | None) -> bool:
     try:
         params = {"datePlayed": date_played_iso} if date_played_iso else None
-        r = http.post(f"/Users/{uid}/PlayedItems/{item_id}", params=params)
+        r = http.post(played_route(item_id), params=user_params(uid, params))
         return getattr(r, "status_code", 0) in (200, 204)
     except Exception:
         return False
@@ -320,7 +321,7 @@ def _mark_played(http: Any, uid: str, item_id: str, *, date_played_iso: str | No
 
 def _unmark_played(http: Any, uid: str, item_id: str) -> bool:
     try:
-        r = http.delete(f"/Users/{uid}/PlayedItems/{item_id}")
+        r = http.delete(played_route(item_id), params=user_params(uid))
         return getattr(r, "status_code", 0) in (200, 204)
     except Exception:
         return False
@@ -350,9 +351,9 @@ def _dst_user_states(http: Any, uid: str, iids: Iterable[str]) -> dict[str, tupl
             continue
         try:
             r = http.get(
-                f"/Users/{uid}/Items",
+                items_route(),
                 params={
-                    'UserId': uid,
+                    'userId': uid,
                     'Ids': qids,
                     'Fields': 'UserData',
                     'Recursive': 'false',
@@ -408,7 +409,7 @@ def build_index(
         if pid:
             scope_libs = [str(pid)]
         else:
-            anc = scope_params.get("AncestorIds") or scope_params.get("ancestorIds")
+            anc = scope_params.get("ParentIds") or scope_params.get("parentIds")
             if isinstance(anc, (list, tuple)):
                 scope_libs = [str(x) for x in anc if x]
 
@@ -417,13 +418,18 @@ def build_index(
         _dbg("index_fetch_counts", source="library_roots", roots=list(sorted(roots.keys())))
 
     start = 0
+    query_parents: list[str | None] = []
+    query_parents.extend(sorted(scope_libs))
+    if not query_parents:
+        query_parents = [None]
+    scope_index = 0
+    seen_pages: set[tuple[str, ...]] = set()
     events: list[tuple[int, dict[str, Any], dict[str, Any]]] = []
     page = 0
 
     while True:
         t0 = time.monotonic()
         params: dict[str, Any] = {
-            "UserId": uid,
             "SortBy": "DatePlayed",
             "SortOrder": "Descending",
             "IncludeItemTypes": "Movie,Episode",
@@ -439,17 +445,30 @@ def build_index(
             "Limit": page_size,
         }
 
-        if scope_params:
-            params.update(scope_params)
+        current_parent = query_parents[scope_index]
+        if current_parent:
+            params["ParentId"] = current_parent
 
-        r = http.get(f"/Users/{uid}/Items", params=params)
+        r = http.get(items_route(), params=user_params(uid, params))
         body = r.json() or {}
         rows = body.get("Items") or []
+        raw_count = len(rows)
+        signature = tuple(str(row.get("Id") or "") for row in rows if isinstance(row, Mapping))
+        if rows and signature in seen_pages:
+            _warn("pagination_repeated_page", source_library_id=current_parent, start_index=start)
+            rows = []
+            raw_count = 0
+        seen_pages.add(signature)
         page += 1
         took_ms = int((time.monotonic() - t0) * 1000)
         _dbg("index_fetch_counts", source="page", page=page, start=start, got=len(rows), limit=page_size, latency_ms=took_ms)
         if not rows:
-            break
+            scope_index += 1
+            if scope_index >= len(query_parents):
+                break
+            start = 0
+            seen_pages.clear()
+            continue
 
         series_ids: set[str] = set()
         for r0 in rows:
@@ -535,11 +554,16 @@ def build_index(
                 out_ev["library_id"] = lib_id
             events.append((ts, {"key": ev_key}, out_ev))
 
-        start += len(body.get("Items") or [])
+        start += raw_count
         if isinstance(limit, int) and limit > 0 and len(events) >= int(limit):
             break
-        if not rows:
-            break
+        total = int(body.get("TotalRecordCount") or 0)
+        if not rows or raw_count < page_size or (total and start >= total):
+            scope_index += 1
+            if scope_index >= len(query_parents):
+                break
+            start = 0
+            seen_pages.clear()
 
     events.sort(key=lambda x: x[0], reverse=True)
     if isinstance(limit, int) and limit > 0:

--- a/providers/sync/jellyfin/_progress.py
+++ b/providers/sync/jellyfin/_progress.py
@@ -3,10 +3,12 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping
 
 from cw_platform.id_map import canonical_key
+from providers.sync._progress_policy import decide_progress_write, select_progress_record
 
 from ._common import (
     _ids_from_provider_ids,
@@ -18,6 +20,7 @@ from ._common import (
     resolve_item_id,
     resolve_item_ids,
 )
+from ._routes import items as items_route, played as played_route, user_data as user_data_route, user_params
 
 _dbg, _info, _warn = make_logger("progress")
 
@@ -56,6 +59,50 @@ def _pick_user_data(row: Mapping[str, Any]) -> Mapping[str, Any]:
     return ud if isinstance(ud, Mapping) else {}
 
 
+def _same_origin(provider: str = "JELLYFIN") -> bool:
+    source = str(os.getenv("CW_PAIR_SRC") or "").upper().strip()
+    target = str(os.getenv("CW_PAIR_DST") or provider).upper().strip()
+    source_instance = str(os.getenv("CW_PAIR_SRC_INSTANCE") or "default").lower().strip()
+    target_instance = str(os.getenv("CW_PAIR_DST_INSTANCE") or "default").lower().strip()
+    return source == target == provider and source_instance == target_instance
+
+
+def _active_item_ids(http: Any, uid: str) -> set[str]:
+    try:
+        response = http.get("/Sessions")
+        if getattr(response, "status_code", 0) != 200:
+            return set()
+        rows = response.json() or []
+        return {
+            str((row.get("NowPlayingItem") or {}).get("Id"))
+            for row in rows
+            if isinstance(row, Mapping)
+            and str(row.get("UserId") or "") == str(uid)
+            and isinstance(row.get("NowPlayingItem"), Mapping)
+            and (row.get("NowPlayingItem") or {}).get("Id")
+        }
+    except Exception:
+        return set()
+
+
+def _target_state(http: Any, uid: str, item_id: str) -> dict[str, Any]:
+    response = http.get(
+        items_route(item_id),
+        params=user_params(uid, {"Fields": "UserData,RunTimeTicks,LibraryId,CollectionFolderId"}),
+    )
+    if getattr(response, "status_code", 0) != 200:
+        raise RuntimeError(f"target_state_http_{getattr(response, 'status_code', 0)}")
+    row = response.json() or {}
+    user_data = _pick_user_data(row)
+    return {
+        "watched": bool(user_data.get("Played") or user_data.get("IsPlayed")),
+        "progress_ms": _ticks_to_ms(user_data.get("PlaybackPositionTicks")),
+        "duration_ms": _ticks_to_ms(row.get("RunTimeTicks")),
+        "timestamp": user_data.get("LastPlayedDate") or user_data.get("LastPlayed") or row.get("DateLastSaved"),
+        "library_id": row.get("LibraryId") or row.get("CollectionFolderId"),
+    }
+
+
 def _series_ids_by_item_id(
     http: Any,
     uid: str,
@@ -72,11 +119,11 @@ def _series_ids_by_item_id(
     for batch in chunked(series_ids, 100):
         try:
             response = http.get(
-                f"/Users/{uid}/Items",
-                params={
+                items_route(),
+                params=user_params(uid, {
                     "Ids": ",".join(batch),
                     "Fields": "ProviderIds,ProductionYear,Type,Name",
-                },
+                }),
             )
             if getattr(response, "status_code", 0) != 200:
                 continue
@@ -117,13 +164,14 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
     page_size = 500
     for parent_id in parents:
         start = 0
+        seen_pages: set[tuple[str, ...]] = set()
         while True:
             params = dict(base_params)
             params.update({"StartIndex": start, "Limit": page_size, "EnableTotalRecordCount": True})
             if parent_id:
                 params["ParentId"] = parent_id
             try:
-                r = http.get(f"/Users/{uid}/Items", params=params)
+                r = http.get(items_route(), params=user_params(uid, params))
                 if getattr(r, "status_code", 0) != 200:
                     _warn("library_scope_query_failed", source_library_id=parent_id, allowed_library_ids=sorted(allowed), status=getattr(r, "status_code", None))
                     break
@@ -134,7 +182,11 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
             except Exception as e:
                 _warn("library_scope_query_failed", source_library_id=parent_id, allowed_library_ids=sorted(allowed), error=str(e))
                 break
-            new_count = 0
+            signature = tuple(str(raw.get("Id") or "") for raw in page if isinstance(raw, Mapping))
+            if page and signature in seen_pages:
+                _warn("pagination_repeated_page", source_library_id=parent_id, start_index=start)
+                break
+            seen_pages.add(signature)
             for raw in page:
                 if not isinstance(raw, Mapping):
                     continue
@@ -145,10 +197,9 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
                 if item_id:
                     seen_item_ids.add(item_id)
                 rows.append((raw, parent_id))
-                new_count += 1
             start += len(page)
             total = int(body.get("TotalRecordCount") or 0)
-            if not page or (total and start >= total) or len(page) < page_size or new_count == 0:
+            if not page or (total and start >= total) or len(page) < page_size:
                 break
 
     series_ids_by_item_id = _series_ids_by_item_id(http, str(uid), rows)
@@ -157,6 +208,10 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
     dup_keys = 0
     for raw, source_library_id in rows:
         total_rows += 1
+        raw_type = str(raw.get("Type") or "").strip()
+        if raw_type not in {"Movie", "Episode"}:
+            _warn("unsupported_progress_row_type", provider_item_id=str(raw.get("Id") or ""), media_type=raw_type)
+            continue
         if allowed:
             memberships = jf_item_library_ids(raw)
             if memberships and not (memberships & allowed):
@@ -169,6 +224,9 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
         series_id = str(raw.get("SeriesId") or "").strip()
         if series_id and series_ids_by_item_id.get(series_id):
             item["show_ids"] = dict(series_ids_by_item_id[series_id])
+        if raw_type == "Episode" and not item.get("show_ids") and not item.get("season") and not item.get("episode"):
+            _warn("incomplete_episode_progress_row", provider_item_id=str(raw.get("Id") or ""))
+            continue
         if source_library_id:
             item["library_id"] = source_library_id
 
@@ -189,24 +247,11 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
         if not ck:
             continue
 
-        action = "new"
         prev = out.get(ck)
-        if not isinstance(prev, Mapping):
-            out[ck] = item
-        else:
-            # If duplicates exist for the same canonical key, keep the minimum
-            try:
-                p0 = int(prev.get("progress_ms") or 0)
-                p1 = int(item.get("progress_ms") or 0)
-            except Exception:
-                p0, p1 = 0, 0
-            if p0 and p1 and p1 < p0:
-                out[ck] = item
-                dup_keys += 1
-                action = "replace_lower"
-            elif p0 and p1:
-                dup_keys += 1
-                action = "dup_keep"
+        selected, action = select_progress_record(prev, item)
+        out[ck] = selected
+        if isinstance(prev, Mapping):
+            dup_keys += 1
 
         _dbg(
             "item",
@@ -216,11 +261,11 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
             series_title=str(item.get("series_title") or ""),
             season=item.get("season"),
             episode=item.get("episode"),
-            chosen_lastPlayedAt=str(item.get("progress_at") or ""),
-            chosen_viewOffset=int(item.get("progress_ms") or 0),
-            duration_ms=item.get("duration_ms"),
-            ids=dict(item.get("ids") or {}),
-            jellyfin_item_id=str(item.get("jellyfin_item_id") or ""),
+            chosen_lastPlayedAt=str(selected.get("progress_at") or ""),
+            chosen_viewOffset=int(selected.get("progress_ms") or 0),
+            duration_ms=selected.get("duration_ms"),
+            ids=dict(selected.get("ids") or {}),
+            jellyfin_item_id=str(selected.get("jellyfin_item_id") or ""),
             action=action,
         )
 
@@ -234,8 +279,12 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
     if not http or not uid:
         return 0, [{"item": dict(x), "hint": "not_configured"} for x in (items or [])]
 
-    ok = 0
+    applied = 0
     unresolved: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    active_items = _active_item_ids(http, str(uid))
+    replay_enabled = bool(getattr(adapter.cfg, "progress_replay_enabled", False))
+    tolerance = int(getattr(adapter.cfg, "progress_timestamp_tolerance_seconds", 30) or 30)
 
     for it in items or []:
         it0 = dict(it or {})
@@ -244,14 +293,19 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         iids = resolve_item_ids(adapter, it0, feature="progress")
         if not iids:
             _dbg("resolve_miss", canonical_key=str(ck), type=str(it0.get("type") or ""), ids=ids)
-            unresolved.append({"item": it0, "hint": str(getattr(adapter, "_jellyfin_last_resolve_hint", "") or "not_found")})
+            reason = str(getattr(adapter, "_jellyfin_last_resolve_hint", "") or "not_found")
+            entry = {"status": "unresolved", "reason": reason, "item": it0}
+            unresolved.append(entry)
+            results.append(entry)
             continue
         _dbg("resolve_hit", canonical_key=str(ck), type=str(it0.get("type") or ""), ids=ids, resolved=len(iids))
 
         ms = it0.get("progress_ms") or it0.get("progress") or it0.get("viewOffset")
         ticks = _ms_to_ticks(ms)
         if ticks is None:
-            unresolved.append({"item": it0, "hint": "missing_progress"})
+            entry = {"status": "unresolved", "reason": "missing_progress", "item": it0}
+            unresolved.append(entry)
+            results.append(entry)
             continue
 
         payload: dict[str, Any] = {"PlaybackPositionTicks": int(ticks)}
@@ -259,25 +313,58 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         if isinstance(pa, str) and pa.strip():
             payload["LastPlayedDate"] = pa.strip()
 
-        any_ok = False
         for iid in iids:
             try:
-                r = http.post(f"/Users/{uid}/Items/{iid}/UserData", json=payload)
+                target = _target_state(http, str(uid), str(iid))
+                decision = decide_progress_write(
+                    active_session=str(iid) in active_items,
+                    source_timestamp=pa,
+                    target_timestamp=target.get("timestamp"),
+                    source_progress_ms=ms,
+                    source_duration_ms=it0.get("duration_ms"),
+                    target_progress_ms=target.get("progress_ms"),
+                    target_duration_ms=target.get("duration_ms"),
+                    target_watched=bool(target.get("watched")),
+                    same_origin=_same_origin(),
+                    replay_enabled=replay_enabled,
+                    timestamp_tolerance_seconds=tolerance,
+                )
+                context = {
+                    "provider": "jellyfin", "provider_instance": os.getenv("CW_PAIR_DST_INSTANCE") or "default",
+                    "remote_item_id": str(iid), "library_id": target.get("library_id") or it0.get("library_id"),
+                    "source_timestamp": pa, "target_timestamp": target.get("timestamp"),
+                    "source_progress": ms, "target_progress": target.get("progress_ms"), "reason": decision.reason,
+                }
+                if not decision.apply:
+                    results.append({"status": "skipped", **context})
+                    _dbg("write_skipped", **{key: value for key, value in context.items() if key != "provider"})
+                    continue
+                if decision.unwatch_first:
+                    unwatch = http.delete(played_route(str(iid)), params=user_params(uid))
+                    if getattr(unwatch, "status_code", 0) not in (200, 204):
+                        entry = {"status": "failed", **context, "reason": "replay_unwatch_failed", "hint": f"http_{getattr(unwatch, 'status_code', 0)}", "item": it0}
+                        unresolved.append(entry)
+                        results.append(entry)
+                        continue
+                r = http.post(user_data_route(str(iid)), params=user_params(uid), json=payload)
                 sc = int(getattr(r, "status_code", 0) or 0)
                 _dbg("write_prepare", op="add", canonical_key=str(ck), item_id=str(iid), progress_ms=_ticks_to_ms(payload.get("PlaybackPositionTicks")), status=sc)
                 if sc in (200, 204):
-                    ok += 1
-                    any_ok = True
+                    applied += 1
+                    results.append({"status": "applied", **context})
                 else:
-                    unresolved.append({"item": it0, "hint": f"http_{sc}", "item_id": str(iid)})
+                    entry = {"status": "failed", **context, "hint": f"http_{sc}", "item": it0}
+                    unresolved.append(entry)
+                    results.append(entry)
             except Exception as e:
                 _warn("write_failed", op="add", canonical_key=str(ck), item_id=str(iid), error=str(e))
-                unresolved.append({"item": it0, "hint": f"exception:{e}", "item_id": str(iid)})
-        if not any_ok:
-            unresolved.append({"item": it0, "hint": "all_writes_failed"})
+                entry = {"status": "failed", "reason": "target_state_or_write_failed", "item": it0, "remote_item_id": str(iid), "hint": f"exception:{e}"}
+                unresolved.append(entry)
+                results.append(entry)
 
-    _info("write_done", op="add", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
-    return ok, unresolved
+    setattr(adapter, "_progress_write_results", results)
+    _info("write_done", op="add", ok=len(unresolved) == 0, applied=applied, skipped=sum(1 for row in results if row.get("status") == "skipped"), unresolved=sum(1 for row in results if row.get("status") == "unresolved"), failed=sum(1 for row in results if row.get("status") == "failed"))
+    return applied, unresolved
 
 
 def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
@@ -288,6 +375,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
 
     ok = 0
     unresolved: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
 
     for it in items or []:
         it0 = dict(it or {})
@@ -295,22 +383,30 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
         iid = resolve_item_id(adapter, it0, feature="progress")
         if not iid:
             _dbg("resolve_miss", canonical_key=str(ck))
-            unresolved.append({"item": it0, "hint": "not_found"})
+            entry = {"status": "unresolved", "reason": "not_found", "item": it0}
+            unresolved.append(entry)
+            results.append(entry)
             continue
         _dbg("resolve_hit", canonical_key=str(ck), resolved=1, resolved_id=str(iid))
 
         payload: dict[str, Any] = {"PlaybackPositionTicks": 0}
         try:
-            r = http.post(f"/Users/{uid}/Items/{iid}/UserData", json=payload)
+            r = http.post(user_data_route(str(iid)), params=user_params(uid), json=payload)
             sc = int(getattr(r, "status_code", 0) or 0)
             _dbg("write_prepare", op="remove", canonical_key=str(ck), item_id=str(iid), status=sc)
             if sc in (200, 204):
                 ok += 1
+                results.append({"status": "applied", "provider": "jellyfin", "remote_item_id": str(iid), "library_id": it0.get("library_id"), "source_progress": 0, "reason": "clear_progress"})
             else:
-                unresolved.append({"item": it0, "hint": f"http_{sc}"})
+                entry = {"status": "failed", "reason": "clear_progress_failed", "item": it0, "remote_item_id": str(iid), "hint": f"http_{sc}"}
+                unresolved.append(entry)
+                results.append(entry)
         except Exception as e:
             _warn("write_failed", op="remove", canonical_key=str(ck), item_id=str(iid), error=str(e))
-            unresolved.append({"item": it0, "hint": f"exception:{e}"})
+            entry = {"status": "failed", "reason": "clear_progress_failed", "item": it0, "remote_item_id": str(iid), "hint": f"exception:{e}"}
+            unresolved.append(entry)
+            results.append(entry)
 
+    setattr(adapter, "_progress_write_results", results)
     _info("write_done", op="remove", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
     return ok, unresolved

--- a/providers/sync/jellyfin/_ratings.py
+++ b/providers/sync/jellyfin/_ratings.py
@@ -20,6 +20,7 @@ from ._common import (
     _pair_scope,
     _is_capture_mode,
 )
+from ._routes import items as items_route, user_data as user_data_route, user_params
 
 def _unresolved_path() -> str:
     return str(state_file("jellyfin_ratings.unresolved.json"))
@@ -181,18 +182,13 @@ def _rate(http: Any, uid: str, item_id: str, rating: float | None) -> bool:
             r_val = max(0.0, min(10.0, r_val))
             payload["Rating"] = round(r_val, 1)
 
-        r1 = http.post(f"/UserItems/{item_id}/UserData", params={"userId": uid}, json=payload)
+        r1 = http.post(user_data_route(item_id), params=user_params(uid), json=payload)
         ok = getattr(r1, "status_code", 0) in (200, 204)
         if ok:
             return True
 
-        r2 = http.post(f"/Users/{uid}/Items/{item_id}/UserData", json=payload)
-        ok2 = getattr(r2, "status_code", 0) in (200, 204)
-
-        if not ok2:
-            body = _body_snip(r1) if getattr(r1,'status_code',0) not in (200,204) else _body_snip(r2)
-            _warn("write_failed", op="rate", user_id=uid, item_id=item_id, status1=getattr(r1,'status_code',None), status2=getattr(r2,'status_code',None), body=body)
-        return ok2
+        _warn("write_failed", op="rate", user_id=uid, item_id=item_id, status=getattr(r1, 'status_code', None), body=_body_snip(r1))
+        return False
     except Exception as e:
         _warn("write_failed", op="rate", item_id=item_id, error=repr(e))
         return False
@@ -215,11 +211,17 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
         if pid:
             scope_libs = [str(pid)]
         else:
-            anc = scope_params.get("AncestorIds")
+            anc = scope_params.get("ParentIds")
             if isinstance(anc, (list, tuple)):
                 scope_libs = [str(x) for x in anc if x]
 
     roots = jf_get_library_roots(adapter)
+    query_parents: list[str | None] = []
+    query_parents.extend(sorted(scope_libs))
+    if not query_parents:
+        query_parents = [None]
+    scope_index = 0
+    seen_pages: set[tuple[str, ...]] = set()
 
     out: dict[str, dict[str, Any]] = {}
     total_seen = 0
@@ -245,14 +247,24 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
             "sortBy": "SortName",
             "sortOrder": "Ascending",
         }
-        if scope_params:
-            params.update(scope_params)
+        current_parent = query_parents[scope_index]
+        if current_parent:
+            params["ParentId"] = current_parent
 
-        r = http.get(f"/Users/{uid}/Items", params=params)
+        r = http.get(items_route(), params=user_params(uid, params))
         body = r.json() or {}
         rows = body.get("Items") or []
+        signature = tuple(str(row.get("Id") or "") for row in rows if isinstance(row, Mapping))
+        if rows and signature in seen_pages:
+            rows = []
+        seen_pages.add(signature)
         if not rows:
-            break
+            scope_index += 1
+            if scope_index >= len(query_parents):
+                break
+            start = 0
+            seen_pages.clear()
+            continue
 
         for row in rows:
             total_seen += 1
@@ -328,8 +340,13 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
                 prog.tick(total_seen, total=max(total_seen, start))
             except Exception:
                 pass
-        if len(rows) < page:
-            break
+        total = int(body.get("TotalRecordCount") or 0)
+        if len(rows) < page or (total and start >= total):
+            scope_index += 1
+            if scope_index >= len(query_parents):
+                break
+            start = 0
+            seen_pages.clear()
 
     if prog:
         try:

--- a/providers/sync/jellyfin/_routes.py
+++ b/providers/sync/jellyfin/_routes.py
@@ -1,0 +1,26 @@
+# /providers/sync/jellyfin/_routes.py
+# CrossWatch - Jellyfin Sync Provider - Route Utilities
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def user_params(user_id: str, params: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    return {**dict(params or {}), "userId": str(user_id)}
+
+
+def items(item_id: str | None = None) -> str:
+    return f"/Items/{item_id}" if item_id else "/Items"
+
+
+def favorite(item_id: str) -> str:
+    return f"/UserFavoriteItems/{item_id}"
+
+
+def played(item_id: str) -> str:
+    return f"/UserPlayedItems/{item_id}"
+
+
+def user_data(item_id: str) -> str:
+    return f"/UserItems/{item_id}/UserData"

--- a/providers/sync/jellyfin/_watchlist.py
+++ b/providers/sync/jellyfin/_watchlist.py
@@ -32,6 +32,7 @@ from ._common import (
     _pair_scope,
     _is_capture_mode,
 )
+from ._routes import favorite as favorite_route, items as items_route, user_params
 
 def _unresolved_path() -> str:
     return str(state_file("jellyfin_watchlist.unresolved.json"))
@@ -222,11 +223,12 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
 
     out: dict[str, dict[str, Any]] = {}
     done = 0
+    seen_pages: set[tuple[str, ...]] = set()
 
     while True:
         r = http.get(
-            f"/Users/{uid}/Items",
-            params={
+            items_route(),
+            params=user_params(uid, {
                 "IncludeItemTypes": "Movie,Series",
                 "Recursive": True,
                 "EnableUserData": True,
@@ -237,7 +239,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
                 "EnableTotalRecordCount": True,
                 "StartIndex": start,
                 "Limit": page_size,
-            },
+            }),
         )
 
         try:
@@ -254,6 +256,10 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
             rows = []
             if total is None:
                 total = 0
+        signature = tuple(str(row.get("Id") or "") for row in rows if isinstance(row, Mapping))
+        if rows and signature in seen_pages:
+            break
+        seen_pages.add(signature)
 
         for row in rows:
             try:
@@ -279,9 +285,9 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
 def _favorite(http: Any, uid: str, item_id: str, flag: bool) -> bool:
     try:
         r = (
-            http.post(f"/Users/{uid}/FavoriteItems/{item_id}")
+            http.post(favorite_route(item_id), params=user_params(uid))
             if flag
-            else http.delete(f"/Users/{uid}/FavoriteItems/{item_id}")
+            else http.delete(favorite_route(item_id), params=user_params(uid))
         )
         return getattr(r, "status_code", 0) in (200, 204)
     except Exception:
@@ -299,8 +305,8 @@ def _verify_favorite(
     for attempt in range(max(1, retries)):
         try:
             r = http.get(
-                f"/Users/{uid}/Items/{iid}",
-                params={"Fields": "UserData", "EnableUserData": True},
+                items_route(iid),
+                params=user_params(uid, {"Fields": "UserData", "EnableUserData": True}),
             )
             if getattr(r, "status_code", 0) == 200:
                 ud = (r.json() or {}).get("UserData") or {}
@@ -310,8 +316,8 @@ def _verify_favorite(
                     return True
             else:
                 r2 = http.get(
-                    f"/Users/{uid}/Items",
-                    params={"Ids": iid, "Fields": "UserData", "EnableUserData": True},
+                    items_route(),
+                    params=user_params(uid, {"Ids": iid, "Fields": "UserData", "EnableUserData": True}),
                 )
                 if getattr(r2, "status_code", 0) == 200:
                     arr = (r2.json() or {}).get("Items") or []

--- a/services/playback_progress/adapters/media_servers.py
+++ b/services/playback_progress/adapters/media_servers.py
@@ -193,6 +193,15 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
             if not configured:
                 reason = f"{self.provider_label} is not connected for this instance."
         can_use = bool(configured and self.ops is not None)
+        can_write = can_use
+        if can_use and self.provider == "jellyfin" and hasattr(self.ops, "progress_write_capability"):
+            try:
+                can_write, write_reason, _version = self.ops.progress_write_capability(config_view)
+                if not can_write:
+                    reason = write_reason or "unsupported_server_version"
+            except Exception:
+                can_write = False
+                reason = "unsupported_server_version"
         return PlaybackCapabilities(
             provider=self.provider,
             provider_label=self.provider_label,
@@ -200,12 +209,12 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
             instance_label=instance_label,
             configured=configured,
             read=can_use,
-            remove_progress=can_use,
+            remove_progress=can_write,
             mark_watched=can_use,
-            update_progress=can_use,
-            bulk_remove_progress=can_use,
+            update_progress=can_write,
+            bulk_remove_progress=can_write,
             bulk_mark_watched=can_use,
-            bulk_update_progress=can_use,
+            bulk_update_progress=can_write,
             supports_movies=True,
             supports_episodes=True,
             supports_anime=False,
@@ -245,18 +254,13 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
             remote_id = key if key and not key.startswith("unknown:") else ""
         media_type = str(row.get("type") or "movie").strip().lower()
         if media_type not in {"movie", "episode", "anime_episode"}:
-            media_type = "episode" if media_type in {"show", "season"} else "movie"
+            return None
         title = _first_str(row.get("series_title") if media_type in {"episode", "anime_episode"} else None, row.get("title"))
         episode_title = _first_str(row.get("title")) if media_type in {"episode", "anime_episode"} else ""
         series_title = _first_str(row.get("series_title")) if media_type in {"episode", "anime_episode"} else ""
         show_ids = clean_mapping(row.get("show_ids") if isinstance(row.get("show_ids"), Mapping) else {})
         if media_type in {"episode", "anime_episode"}:
             show_ids = _resolve_with_metadata(metadata_provider, entity="tv", title=series_title or title, year=None, ids=show_ids)
-            if not _has_metadata_ids(ids) and _has_metadata_ids(show_ids):
-                ids = dict(ids)
-                for key_name in ("tmdb", "imdb", "tvdb"):
-                    if show_ids.get(key_name):
-                        ids.setdefault(key_name, show_ids.get(key_name))
         else:
             ids = _resolve_with_metadata(metadata_provider, entity="movie", title=title, year=row.get("year"), ids=ids)
         progress_ms = _int(row.get("progress_ms") or row.get("viewOffset") or row.get("view_offset"))
@@ -317,12 +321,14 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
     def remove_progress(self, config_view: Mapping[str, Any], record: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackActionResult:
         if self.ops is None:
             return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message=f"{self.provider_label} playback support is unavailable.", error_code="provider_unavailable")
-        if self.provider == "plex":
-            return self._remove_plex_progress(config_view, record, instance_id=instance_id)
         item = _history_item(record, self.provider)
         try:
             result = self.ops.remove(config_view, [item], feature="progress")
             ok = _successful_write(result)
+            decisions = result.get("results") if isinstance(result.get("results"), list) else []
+            decision = decisions[0] if decisions and isinstance(decisions[0], Mapping) else {}
+            status = str(decision.get("status") or ("applied" if ok else "failed"))
+            decision_reason = str(decision.get("reason") or "")
             return PlaybackActionResult(
                 ok=ok,
                 provider=self.provider,
@@ -333,6 +339,9 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
                 message=f"Playback record removed from {self.provider_label}." if ok else f"{self.provider_label} remove progress failed.",
                 error_code="" if ok else "progress_remove_failed",
                 playback_cleanup_result=clean_mapping(result),
+                status=status,
+                reason=decision_reason,
+                decision_context=clean_mapping(decision),
             )
         except Exception:
             return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message=f"{self.provider_label} remove progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
@@ -412,6 +421,10 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
         try:
             result = self.ops.add(config_view, [item], feature="progress")
             ok = _successful_write(result)
+            decisions = result.get("results") if isinstance(result.get("results"), list) else []
+            decision = decisions[0] if decisions and isinstance(decisions[0], Mapping) else {}
+            status = str(decision.get("status") or ("applied" if ok else "failed"))
+            decision_reason = str(decision.get("reason") or "")
             return PlaybackActionResult(
                 ok=ok,
                 provider=self.provider,
@@ -419,9 +432,12 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
                 operation="update_progress",
                 remote_id=str(record.get("remote_id") or ""),
                 canonical_key=str(record.get("canonical_key") or ""),
-                message=f"Progress updated on {self.provider_label} to {progress_percent:g}%." if ok else f"{self.provider_label} update progress failed.",
+                message=(f"Progress update skipped on {self.provider_label}: {decision_reason}." if status == "skipped" else (f"Progress updated on {self.provider_label} to {progress_percent:g}%." if ok else f"{self.provider_label} update progress failed.")),
                 error_code="" if ok else "progress_update_failed",
                 playback_cleanup_result=clean_mapping(result),
+                status=status,
+                reason=decision_reason,
+                decision_context=clean_mapping(decision),
             )
         except Exception:
             return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message=f"{self.provider_label} update progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))

--- a/services/playback_progress/models.py
+++ b/services/playback_progress/models.py
@@ -126,9 +126,15 @@ class PlaybackActionResult:
     remote_status: int | None = None
     history_result: dict[str, Any] | None = None
     playback_cleanup_result: dict[str, Any] | None = None
+    status: str = ""
+    reason: str = ""
+    decision_context: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return clean_mapping(asdict(self))
+        data = asdict(self)
+        if not data.get("status"):
+            data["status"] = "applied" if self.ok else "failed"
+        return clean_mapping(data)
 
 
 @dc_dataclass

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -1038,8 +1038,6 @@ class PlaybackProgressService:
         instance_id: str,
         instance_label: str,
     ) -> PlaybackActionResult:
-        if provider == "plex":
-            return PlaybackActionResult(True, provider, instance_id, "remove_progress", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), message="Cleanup skipped because Plex clears resume progress through mark-unwatched.")
         caps = adapter.capabilities(config_view, instance_id=instance_id, instance_label=instance_label)
         if not caps.remove_progress:
             return PlaybackActionResult(True, provider, instance_id, "remove_progress", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), message="Cleanup skipped because remove progress is unsupported.")


### PR DESCRIPTION
# Pull request

## Change

- Added shared playback-progress conflict and duplicate-selection policies.
- Prefer the newest progress timestamp, then normalized progress percentage, when duplicate media items exist.
- Query selected Emby and Jellyfin libraries individually
- Improved pagination handling 
- Added active-session, newer-target, watched-state, same-origin, and unchanged-progress protection.
- Added replay progress support for watched targets.
- Updated Jellyfin calls to current user-scoped API routes.
- Added Jellyfin progress-write capability detection for server version 10.9 or newer.
- Improved episode/show ID separation and structured operation reporting.

## Why

Duplicate media versions, library-scoped queries, stale timestamps, and active playback sessions could produce incorrect progress selection or overwrite newer target state. The changes make Emby and Jellyfin progress synchronization consistent with current Jellyfin API behavior.

## Testing

- various test scripts


## Issue

Relates to #355