### PR TITLE
Fix: harden Plex  progress sync

### DIFF
--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from typing import Any, Iterable, Mapping
 from urllib.parse import urlparse
 
+from cw_platform.value_coercion import coerce_bool
+
 from ._log import log as cw_log
 
 def _health(status: str, ok: bool, latency_ms: int) -> None:
@@ -35,7 +37,7 @@ def _error(event: str, **fields: Any) -> None:
 def _log(msg: str) -> None:
     _dbg(msg)
 
-__VERSION__ = "1.2"
+__VERSION__ = "1.3"
 os.environ.setdefault("CW_PLEX_VERSION", __VERSION__)
 os.environ.setdefault("CW_PLEX_UA", f"CrossWatch/{__VERSION__} (Plex)")
 __all__ = ["get_manifest", "PLEXModule", "PLEXClient", "PLEXError", "PLEXAuthError", "PLEXNotFound", "OPS"]
@@ -947,9 +949,9 @@ class PLEXModule:
             password=plex_cfg.get("password"),
             timeout=float(plex_cfg.get("timeout", cfg.get("timeout", 10.0))),
             max_retries=int(plex_cfg.get("max_retries", cfg.get("max_retries", 3))),
-            watchlist_allow_pms_fallback=bool(plex_cfg.get("watchlist_allow_pms_fallback", True)),
+            watchlist_allow_pms_fallback=coerce_bool(plex_cfg.get("watchlist_allow_pms_fallback", True), True),
             watchlist_page_size=int(plex_cfg.get("watchlist_page_size", 100)),
-            strict_id_matching=bool(plex_cfg.get("strict_id_matching", False)),
+            strict_id_matching=coerce_bool(plex_cfg.get("strict_id_matching", False)),
         )
 
         configure_plex_context(baseurl=self.cfg.baseurl or "", token=(self.cfg.pms_token or self.cfg.token or ""))
@@ -1207,7 +1209,7 @@ class PLEXModule:
                         if uk:
                             unresolved_keys.add(str(uk))
             confirmed_keys = [k for k in attempted_keys if k not in unresolved_keys and not str(k).startswith("unknown:")]
-            return {"ok": True, "count": int(cnt), "unresolved": unresolved, "confirmed_keys": confirmed_keys}
+            return {"ok": True, "count": int(cnt), "unresolved": unresolved, "confirmed_keys": confirmed_keys, "results": list(getattr(self, "_progress_write_results", [])) if feature == "progress" else []}
         except Exception as e:
             return {"ok": False, "error": str(e)}
 
@@ -1259,7 +1261,7 @@ class PLEXModule:
                         if uk:
                             unresolved_keys.add(str(uk))
             confirmed_keys = [k for k in attempted_keys if k not in unresolved_keys and not str(k).startswith("unknown:")]
-            return {"ok": True, "count": int(cnt), "unresolved": unresolved, "confirmed_keys": confirmed_keys}
+            return {"ok": True, "count": int(cnt), "unresolved": unresolved, "confirmed_keys": confirmed_keys, "results": list(getattr(self, "_progress_write_results", [])) if feature == "progress" else []}
         except Exception as e:
             return {"ok": False, "error": str(e)}
 

--- a/providers/sync/plex/_history.py
+++ b/providers/sync/plex/_history.py
@@ -475,6 +475,7 @@ def _iter_marked_watched_from_library(
             continue
 
         start = 0
+        seen_pages: set[tuple[str, ...]] = set()
         while True:
             params = {
                 "type": plex_type,
@@ -494,6 +495,10 @@ def _iter_marked_watched_from_library(
             rows, total = _rows_from(r)
             if not rows:
                 break
+            signature = tuple(str(row.get("ratingKey") or row.get("key") or "") for row in rows)
+            if signature in seen_pages:
+                break
+            seen_pages.add(signature)
 
             stop = False
             for row in rows:

--- a/providers/sync/plex/_progress.py
+++ b/providers/sync/plex/_progress.py
@@ -8,6 +8,8 @@ from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping
 
 from cw_platform.id_map import canonical_key, ids_from_guid, ids_from, minimal as id_minimal
+from cw_platform.value_coercion import coerce_bool
+from providers.sync._progress_policy import decide_progress_write
 
 from ._common import (
     active_pms_token,
@@ -17,6 +19,7 @@ from ._common import (
     home_scope_exit,
     item_guid_candidates,
     plex_cfg_get,
+    plex_feature_cfg,
     plex_feature_library_ids,
     raise_home_scope_not_applied,
     server_find_rating_key_by_guid,
@@ -94,14 +97,70 @@ def _same_plex_endpoint() -> bool:
     return src == dst == "PLEX" and src_instance == dst_instance
 
 
-def _currently_playing(srv: Any, rating_key: str) -> bool:
+def _currently_playing(
+    srv: Any,
+    rating_key: str,
+    *,
+    account_id: int | None = None,
+    username: str | None = None,
+) -> bool:
     try:
         for session in srv.sessions() or []:  # type: ignore[attr-defined]
-            if str(getattr(session, "ratingKey", "") or "") == str(rating_key):
-                return True
+            if str(getattr(session, "ratingKey", "") or "") != str(rating_key):
+                continue
+            if account_id is not None:
+                session_account_id = getattr(session, "accountID", None) or getattr(session, "userID", None)
+                if session_account_id is not None and str(session_account_id) != str(account_id):
+                    continue
+            if username:
+                names = getattr(session, "usernames", None) or []
+                if isinstance(names, str):
+                    names = [names]
+                user = getattr(session, "user", None)
+                user_name = getattr(user, "title", None) or getattr(user, "username", None)
+                normalized_names = {str(value).strip().lower() for value in [*names, user_name] if value}
+                if normalized_names and username.strip().lower() not in normalized_names:
+                    continue
+            return True
     except Exception:
         pass
     return False
+
+
+def _timeline_progress(adapter: Any, srv: Any, rating_key: str, progress_ms: int, duration_ms: int) -> None:
+    client_id = str(
+        getattr(getattr(adapter, "cfg", None), "client_id", None)
+        or os.getenv("PLEX_CLIENT_IDENTIFIER")
+        or os.getenv("CW_PLEX_CID")
+        or "crosswatch"
+    )
+    session = getattr(srv, "_session", None)
+    post = getattr(session, "post", None)
+    if not callable(post):
+        raise RuntimeError("plex_timeline_post_unavailable")
+    srv.query(
+        "/:/timeline",
+        method=post,
+        params={
+            "ratingKey": str(rating_key),
+            "key": f"/library/metadata/{rating_key}",
+            "identifier": "com.plexapp.plugins.library",
+            "state": "stopped",
+            "time": max(0, int(progress_ms)),
+            "duration": max(0, int(duration_ms)),
+            "X-Plex-Client-Identifier": client_id,
+        },
+    )
+
+
+def _progress_write_options(adapter: Any) -> tuple[bool, int]:
+    progress_cfg = plex_feature_cfg(adapter, "progress")
+    replay_enabled = coerce_bool(progress_cfg.get("replay_enabled", False))
+    try:
+        tolerance = max(0, int(progress_cfg.get("timestamp_tolerance_seconds", 30)))
+    except (TypeError, ValueError):
+        tolerance = 30
+    return replay_enabled, tolerance
 
 
 def _truthy_attr(obj: Any, name: str) -> bool:
@@ -131,11 +190,19 @@ def _fetch_resume_items(srv: Any, *, page_size: int = 100) -> dict[str, str | No
 
     def _q(path: str) -> None:
         start = 0
+        seen_pages: set[tuple[str, ...]] = set()
         while True:
             key = f"{path}?X-Plex-Container-Start={start}&X-Plex-Container-Size={int(page_size)}&includeUserState=1"
             root = srv.query(key)  # type: ignore[attr-defined]
             rows = list(root) if root is not None else []
-            new_count = 0
+            signature = tuple(
+                str((getattr(el, "attrib", {}) or {}).get("ratingKey") or (getattr(el, "attrib", {}) or {}).get("key") or "")
+                for el in rows
+            )
+            if rows and signature in seen_pages:
+                _warn("pagination_repeated_page", source=path, start_index=start)
+                break
+            seen_pages.add(signature)
             for el in rows:
                 a = getattr(el, "attrib", {}) or {}
                 rk = a.get("ratingKey") or a.get("key")
@@ -149,9 +216,8 @@ def _fetch_resume_items(srv: Any, *, page_size: int = 100) -> dict[str, str | No
                         items[key_id] = lid
                     continue
                 items[key_id] = lid
-                new_count += 1
             start += len(rows)
-            if not rows or len(rows) < page_size or new_count == 0:
+            if not rows or len(rows) < page_size:
                 break
 
     for p in ("/hubs/continueWatching/items", "/library/onDeck", "/library/recentlyViewed"):
@@ -555,62 +621,86 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             _info("write_skipped", op="add", reason="home_scope_not_applied", selected=(sel_aid or sel_uname), unresolved=len(unresolved))
             return 0, unresolved
 
-        ok = 0
+        applied = 0
         unresolved: list[dict[str, Any]] = []
+        results: list[dict[str, Any]] = []
 
         for it in items or []:
             it0 = dict(it or {})
-            if _same_plex_endpoint():
-                ok += 1
-                _dbg("write_skipped", reason="same_provider_origin", canonical_key=str(canonical_key(id_minimal(it0)) or ""))
-                continue
             ms = it0.get("progress_ms") or it0.get("viewOffset") or it0.get("progress")
             ms_i = _to_int(ms)
             if ms_i is None or ms_i <= 0:
-                unresolved.append({"item": it0, "hint": "missing_progress"})
+                entry = {"status": "unresolved", "reason": "missing_progress", "item": it0}
+                unresolved.append(entry)
+                results.append(entry)
                 if _mods_debug():
                     _dbg("add.unresolved", hint="missing_progress", canonical_key=str(canonical_key(id_minimal(it0)) or ""), ids=dict(ids_from(it0)))
                 continue
 
             rk = _resolve_rating_key(adapter, it0)
             if not rk:
-                unresolved.append({"item": it0, "hint": str(getattr(adapter, "_plex_progress_last_resolve_hint", "") or "not_found")})
+                reason = str(getattr(adapter, "_plex_progress_last_resolve_hint", "") or "not_found")
+                entry = {"status": "unresolved", "reason": reason, "item": it0}
+                unresolved.append(entry)
+                results.append(entry)
                 if _mods_debug():
                     _dbg("resolve_miss", hint="not_found", canonical_key=str(canonical_key(id_minimal(it0)) or ""), ids=dict(ids_from(it0)))
                 continue
 
             try:
                 obj = srv.fetchItem(int(rk))  # type: ignore[attr-defined]
-                if _currently_playing(srv, rk):
-                    ok += 1
-                    _dbg("write_skipped", reason="currently_playing", provider_item_id=str(rk))
-                    continue
-                replay_enabled = bool(plex_cfg_get(adapter, "progress_replay_enabled", False))
+                replay_enabled, drift = _progress_write_options(adapter)
                 watched = bool(
                     _truthy_attr(obj, "isWatched")
                     or _truthy_attr(obj, "isPlayed")
                     or int(getattr(obj, "viewCount", 0) or 0) > 0
                 )
-                if watched and not replay_enabled:
-                    ok += 1
-                    _dbg("write_skipped", reason="target_watched", provider_item_id=str(rk))
+                source_timestamp = it0.get("progress_at") or it0.get("lastViewedAt")
+                target_timestamp = getattr(obj, "lastViewedAt", None) or getattr(obj, "viewedAt", None) or getattr(obj, "updatedAt", None)
+                target_progress = _to_int(getattr(obj, "viewOffset", None))
+                duration = _to_int(getattr(obj, "duration", None)) or _to_int(it0.get("duration_ms")) or 0
+                decision = decide_progress_write(
+                    active_session=_currently_playing(srv, rk, account_id=sel_aid, username=sel_uname),
+                    source_timestamp=source_timestamp,
+                    target_timestamp=target_timestamp,
+                    source_progress_ms=ms_i,
+                    source_duration_ms=it0.get("duration_ms") or duration,
+                    target_progress_ms=target_progress,
+                    target_duration_ms=duration,
+                    target_watched=watched,
+                    same_origin=_same_plex_endpoint(),
+                    replay_enabled=replay_enabled,
+                    timestamp_tolerance_seconds=drift,
+                )
+                context = {
+                    "provider": "plex", "provider_instance": os.getenv("CW_PAIR_DST_INSTANCE") or "default",
+                    "remote_item_id": str(rk), "library_id": _library_id(obj) or it0.get("library_id"),
+                    "source_timestamp": source_timestamp, "target_timestamp": target_timestamp,
+                    "source_progress": ms_i, "target_progress": target_progress, "reason": decision.reason,
+                }
+                if not decision.apply:
+                    results.append({"status": "skipped", **context})
+                    _dbg("write_skipped", **{key: value for key, value in context.items() if key != "provider"})
                     continue
-                drift = max(0, int(plex_cfg_get(adapter, "progress_clock_drift_seconds", 30) or 30))
-                source_ts = _epoch(it0.get("progress_at") or it0.get("lastViewedAt"))
-                target_ts = _epoch(getattr(obj, "lastViewedAt", None) or getattr(obj, "viewedAt", None))
-                if source_ts is not None and target_ts is not None and target_ts > source_ts + drift:
-                    ok += 1
-                    _dbg("write_skipped", reason="target_progress_newer", provider_item_id=str(rk), clock_drift_seconds=drift)
-                    continue
-                obj.updateProgress(int(ms_i), state="stopped")
-                ok += 1
+                if decision.unwatch_first:
+                    mark_unplayed = getattr(obj, "markUnplayed", None) or getattr(obj, "markUnwatched", None)
+                    if callable(mark_unplayed):
+                        mark_unplayed()
+                    else:
+                        srv.query(f"/:/unscrobble?key={rk}&identifier=com.plexapp.plugins.library")  # type: ignore[attr-defined]
+                _timeline_progress(adapter, srv, rk, int(ms_i), duration)
+                applied += 1
+                results.append({"status": "applied", **context})
             except Exception as e:
                 if _mods_debug():
                     _warn("write_failed", op="add", rating_key=str(rk), canonical_key=str(canonical_key(id_minimal(it0)) or ""), error=str(e))
-                unresolved.append({"item": it0, "hint": f"exception:{e}"})
+                entry = {"status": "failed", "reason": "target_state_or_write_failed", "remote_item_id": str(rk), "item": it0, "hint": f"exception:{e}"}
+                unresolved.append(entry)
+                results.append(entry)
 
-        _info("write_done", op="add", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
-        return ok, unresolved
+        setattr(adapter, "_progress_write_results", results)
+        _info("write_done", op="add", ok=len(unresolved) == 0, applied=applied, skipped=sum(1 for row in results if row.get("status") == "skipped"), unresolved=sum(1 for row in results if row.get("status") == "unresolved"), failed=sum(1 for row in results if row.get("status") == "failed"))
+        return applied, unresolved
     finally:
         home_scope_exit(adapter, did_switch)
 
@@ -629,30 +719,34 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
 
         ok = 0
         unresolved: list[dict[str, Any]] = []
+        results: list[dict[str, Any]] = []
 
         for it in items or []:
             it0 = dict(it or {})
             rk = _resolve_rating_key(adapter, it0)
             if not rk:
-                unresolved.append({"item": it0, "hint": "not_found"})
+                entry = {"status": "unresolved", "reason": "not_found", "item": it0}
+                unresolved.append(entry)
+                results.append(entry)
                 if _mods_debug():
                     _dbg("resolve_miss", hint="not_found", canonical_key=str(canonical_key(id_minimal(it0)) or ""), ids=dict(ids_from(it0)))
                 continue
 
             try:
                 obj = srv.fetchItem(int(rk))  # type: ignore[attr-defined]
-                mark_unplayed = getattr(obj, "markUnplayed", None) or getattr(obj, "markUnwatched", None)
-                if callable(mark_unplayed):
-                    mark_unplayed()
-                else:
-                    srv.query(f"/:/unscrobble?key={rk}&identifier=com.plexapp.plugins.library")  # type: ignore[attr-defined]
+                duration = _to_int(getattr(obj, "duration", None)) or _to_int(it0.get("duration_ms")) or 0
+                _timeline_progress(adapter, srv, rk, 0, duration)
                 ok += 1
+                results.append({"status": "applied", "provider": "plex", "provider_instance": os.getenv("CW_PAIR_DST_INSTANCE") or "default", "remote_item_id": str(rk), "library_id": _library_id(obj) or it0.get("library_id"), "source_progress": 0, "target_progress": _to_int(getattr(obj, "viewOffset", None)), "reason": "clear_progress"})
             except Exception as e:
                 if _mods_debug():
                     _warn("write_failed", op="remove", rating_key=str(rk), canonical_key=str(canonical_key(id_minimal(it0)) or ""), error=str(e))
-                unresolved.append({"item": it0, "hint": f"exception:{e}"})
+                entry = {"status": "failed", "reason": "clear_progress_failed", "item": it0, "remote_item_id": str(rk), "hint": f"exception:{e}"}
+                unresolved.append(entry)
+                results.append(entry)
 
-        _info("write_done", op="remove", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved), mode="unscrobble")
+        setattr(adapter, "_progress_write_results", results)
+        _info("write_done", op="remove", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved), mode="clear_resume")
         return ok, unresolved
     finally:
         home_scope_exit(adapter, did_switch)

--- a/providers/sync/plex/_ratings.py
+++ b/providers/sync/plex/_ratings.py
@@ -439,6 +439,8 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
         def _iter_rating_rows(path: str, tnum: int) -> Iterable[Mapping[str, Any]]:
             nonlocal total
             start = 0
+            expected_total: int | None = None
+            seen_pages: set[tuple[str, ...]] = set()
             while True:
                 params = {
                     "type": int(tnum),
@@ -461,6 +463,12 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
                     raise RuntimeError(f"PLEX ratings fast query parse failed (ct={(r.headers or {}).get('Content-Type')}; head={head!r})")
 
                 mc = cont.get("MediaContainer") or {}
+                try:
+                    raw_total = mc.get("totalSize")
+                    if raw_total is not None:
+                        expected_total = int(str(raw_total))
+                except Exception:
+                    pass
                 if start == 0:
                     try:
                         total += int(mc.get("totalSize") or 0)
@@ -471,12 +479,16 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
                 rows = mc.get("Metadata") or []
                 if not rows:
                     break
+                signature = tuple(str(row.get("ratingKey") or row.get("key") or "") for row in rows if isinstance(row, Mapping))
+                if signature in seen_pages:
+                    break
+                seen_pages.add(signature)
                 for row in rows:
                     if isinstance(row, Mapping):
                         yield cast(Mapping[str, Any], row)
-                if len(rows) < page_size:
-                    break
                 start += len(rows)
+                if len(rows) < page_size or (expected_total is not None and start >= expected_total):
+                    break
 
         def _consume_rows(rows: list[Mapping[str, Any]], tnum: int) -> bool:
             nonlocal scanned, added, fb_try, fb_ok

--- a/providers/sync/plex/_utils.py
+++ b/providers/sync/plex/_utils.py
@@ -16,19 +16,11 @@ from requests.exceptions import ConnectionError, SSLError
 
 from cw_platform.config_base import load_config, save_config
 from cw_platform.provider_instances import normalize_instance_id
+from cw_platform.value_coercion import coerce_bool
 
 from ._common import make_logger, plex_headers
 def _boolish(value: Any, default: bool) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return bool(value)
-    s = str(value).strip().lower()
-    if s in ("0", "false", "no", "off", "n"):
-        return False
-    if s in ("1", "true", "yes", "on", "y"):
-        return True
-    return default
+    return coerce_bool(value, default)
 
 
 _dbg, _info, _warn, _error, _log = make_logger("utils")

--- a/providers/sync/plex/_watchlist.py
+++ b/providers/sync/plex/_watchlist.py
@@ -495,6 +495,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
         raw = 0
         coll = 0
         typ: dict[str, int] = {}
+        seen_pages: set[tuple[str, ...]] = set()
     
         while True:
             params = dict(base_params)
@@ -529,6 +530,10 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
     
             if not rows:
                 break
+            signature = tuple(str(row.get("ratingKey") or row.get("key") or row.get("guid") or "") for row in rows)
+            if signature in seen_pages:
+                break
+            seen_pages.add(signature)
     
             stop = False
             for row in rows:
@@ -551,9 +556,9 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
     
             if stop:
                 break
-            if total is None and start > 0 and len(rows) < page_size:
-                break
             start += len(rows)
+            if len(rows) < page_size or (total is not None and start >= total):
+                break
     
         _UNRES.unfreeze(out.keys())
         _info("index_done", count=len(out), raw=raw, collections=coll, types=typ)


### PR DESCRIPTION
# Pull request

## Change

- Added progress conflict protection for Plex.
- Protected active sessions, newer target progress, watched items and unchanged progress.
- Added replay-progress handling for watched items.
- Changed progress removal to clear the resume position without marking an item unwatched.
- Preserved Plex Home user and account scoping.
- Improved pagination across progress, history, ratings, and watchlist reads.
- Added structured applied, skipped, unresolved, and failed results.

## Why

Plex progress synchronization could overwrite newer or active playback state, count skipped operations as applied and mark watched items unwatched when only their resume position needed clearing. Pagination could also stop incorrectly or repeat pages indefinitely.

## Testing

- Compiled all changed Plex modules successfully.
- Manual validated / real checks

## Issue

Relates to #355