### PR TITLE
Fix: harden SIMKL sync and snapshot handling

### DIFF
--- a/cw_platform/orchestrator/_snapshots.py
+++ b/cw_platform/orchestrator/_snapshots.py
@@ -617,16 +617,14 @@ def build_snapshots_for_feature(
                     dbg("snapshot.memo", provider=name, feature=feature, count=_eventish_count(feature, cached_idx), raw_count=len(cached_idx))
                     continue
 
-        degraded = False
         try:
             idx_raw = ops.build_index(config, feature=feature)  # type: ignore[call-arg]
         except Exception as e:
             emit_info(
                 f"[!] snapshot.failed provider={name} feature={feature} error={e}"
             )
-            dbg("provider.degraded", provider=name, feature=feature)
-            degraded = True
-            idx_raw = None
+            dbg("snapshot.failed", provider=name, feature=feature)
+            raise
 
         canon: SnapIndex = {}
 
@@ -657,12 +655,12 @@ def build_snapshots_for_feature(
         snaps[name] = canon
 
         if snap_ttl_sec > 0:
-            if degraded or not canon:
+            if not canon:
                 dbg(
                     "snapshot.no_cache_empty",
                     provider=name,
                     feature=feature,
-                    degraded=bool(degraded),
+                    degraded=False,
                 )
             else:
                 snap_cache[memo_key] = (now, canon)

--- a/providers/sync/_mod_SIMKL.py
+++ b/providers/sync/_mod_SIMKL.py
@@ -75,7 +75,7 @@ def _confirmed_keys(key_of, items: Iterable[Mapping[str, Any]], unresolved: Any)
         seen.add(k)
     return out
 
-__VERSION__ = "1.1"
+__VERSION__ = "1.2"
 __all__ = ["get_manifest", "SIMKLModule", "OPS"]
 
 

--- a/providers/sync/simkl/_common.py
+++ b/providers/sync/simkl/_common.py
@@ -14,6 +14,12 @@ from cw_platform.id_map import canonical_key, minimal as id_minimal
 
 START_OF_TIME_ISO = "1900-01-01T00:00:00Z"
 DEFAULT_DATE_FROM = START_OF_TIME_ISO
+
+
+class SIMKLFetchError(RuntimeError):
+    """Raised when a SIMKL read cannot produce a good snapshot"""
+
+
 def simkl_user_agent() -> str:
     env_ua = str(os.getenv("CW_UA") or "").strip()
     if env_ua:
@@ -335,6 +341,35 @@ def save_anime_tvdb_map(mp: Mapping[str, str]) -> None:
         anime_tvdb_map_path(),
         {"updated_at": int(time.time()), "map": dict(mp)},
     )
+
+
+def cache_anime_mappings(rows: Iterable[Mapping[str, Any]]) -> None:
+    """Merge TVDB mappings learned from a normal anime snapshot into the local cache."""
+    rows_list = [row for row in rows if isinstance(row, Mapping)]
+    if not rows_list:
+        return
+
+    tvdb_map, _updated = load_anime_tvdb_map()
+    observed_tvdb = False
+
+    for row in rows_list:
+        show = row.get("show") if isinstance(row.get("show"), Mapping) else row
+        ids = dict(show.get("ids") or {}) if isinstance(show, Mapping) else {}
+        simkl_id = str(ids.get("simkl") or ids.get("simkl_id") or "").strip()
+        tvdb = str(ids.get("tvdb") or "").strip()
+        observed_tvdb = observed_tvdb or bool(tvdb)
+        for key in ("simkl", "tmdb", "imdb"):
+            value = str(ids.get(key) or "").strip()
+            if not value:
+                continue
+            token = f"{key}:{value}"
+            if tvdb and tvdb_map.get(token) != tvdb:
+                tvdb_map[token] = tvdb
+
+    if observed_tvdb:
+        global _ANIME_TVDB_MAP_MEMO
+        _ANIME_TVDB_MAP_MEMO = dict(tvdb_map)
+        save_anime_tvdb_map(tvdb_map)
 
 
 def ensure_anime_tvdb_map(
@@ -689,6 +724,7 @@ __all__ = [
     "anime_tvdb_map_path",
     "load_anime_tvdb_map",
     "save_anime_tvdb_map",
+    "cache_anime_mappings",
     "ensure_anime_tvdb_map",
     "maybe_map_tvdb_ids",
     "fetch_activities",

--- a/providers/sync/simkl/_history.py
+++ b/providers/sync/simkl/_history.py
@@ -12,7 +12,9 @@ from cw_platform.id_map import canonical_key as _canonical_key, minimal as id_mi
 
 from .._log import log as cw_log
 from ._common import (
+    SIMKLFetchError,
     adapter_headers,
+    cache_anime_mappings,
     fetch_activities,
     extract_latest_ts,
     get_watermark,
@@ -32,8 +34,6 @@ BASE = "https://api.simkl.com"
 URL_ALL_ITEMS = f"{BASE}/sync/all-items"
 URL_ADD = f"{BASE}/sync/history"
 URL_REMOVE = f"{BASE}/sync/history/remove"
-URL_TV_EPISODES = f"{BASE}/tv/episodes"
-URL_ANIME_EPISODES = f"{BASE}/anime/episodes"
 
 
 def _unresolved_path() -> str:
@@ -44,7 +44,6 @@ ID_KEYS = ("tmdb", "imdb", "tvdb", "trakt", "simkl", "mal", "anilist", "kitsu", 
 _MOVIE_ID_KEYS = ("tmdb", "imdb", "tvdb", "trakt", "simkl")  # anime IDs excluded to prevent SIMKL misrouting to anime bucket
 _EPISODE_LOOKUP_ID_KEYS = ("tvdb", "anidb")
 
-_EP_LOOKUP_MEMO: dict[str, dict[tuple[int, int], dict[str, Any]]] = {}
 def _maybe_map_tvdb(adapter: Any, ids: Mapping[str, Any]) -> dict[str, str]:
     def _fetch_rows() -> Iterable[Mapping[str, Any]]:
         headers = _headers(adapter, force_refresh=True)
@@ -227,163 +226,6 @@ def _thaw_key(item: Mapping[str, Any]) -> str:
     typ = str(item.get("type") or "").lower()
     return simkl_key_of(item) if typ == "episode" else simkl_key_of(id_minimal(item))
 
-
-def _episode_lookup(
-    session: Any,
-    headers: Mapping[str, str],
-    *,
-    timeout: float,
-    show_ids: Mapping[str, Any],
-    kind: str,
-) -> dict[tuple[int, int], dict[str, Any]]:
-    ids = dict(show_ids or {})
-    candidates = [
-        str(ids.get("simkl") or "").strip(),
-        str(ids.get("tvdb") or "").strip(),
-        str(ids.get("tmdb") or "").strip(),
-        str(ids.get("imdb") or "").strip(),
-    ]
-    candidates = [c for c in candidates if c]
-    if not candidates:
-        return {}
-
-    base_url = URL_ANIME_EPISODES if str(kind).lower() == "anime" else URL_TV_EPISODES
-
-    for cand in candidates:
-        memo_key = f"{str(kind).lower()}:{cand}"
-        if memo_key in _EP_LOOKUP_MEMO:
-            return _EP_LOOKUP_MEMO[memo_key]
-
-    def _as_title(v: Any) -> str | None:
-        if isinstance(v, str):
-            t = v.strip()
-            return t or None
-        if isinstance(v, Mapping):
-            for k in ("en", "title", "name", "original", "en_title"):
-                t = _as_title(v.get(k))
-                if t:
-                    return t
-            for vv in v.values():
-                t = _as_title(vv)
-                if t:
-                    return t
-        if isinstance(v, list):
-            for it in v:
-                t = _as_title(it)
-                if t:
-                    return t
-        return None
-
-    def _pick_title(row: Mapping[str, Any]) -> str | None:
-        for key in ("title", "name", "en_title", "episode_title", "episodeName", "episodeTitle", "episode_name"):
-            t = _as_title(row.get(key))
-            if t:
-                return t
-        ep = row.get("episode")
-        if isinstance(ep, Mapping):
-            for key in ("title", "name", "en_title", "episode_title"):
-                t = _as_title(ep.get(key))
-                if t:
-                    return t
-        for key in ("titles", "names"):
-            t = _as_title(row.get(key))
-            if t:
-                return t
-        return None
-
-    def _extract_ids(row: Mapping[str, Any]) -> dict[str, str]:
-        raw = row.get("ids")
-        d = dict(raw) if isinstance(raw, Mapping) else {}
-        if d.get("simkl_id") and not d.get("simkl"):
-            d["simkl"] = d["simkl_id"]
-        return {k: str(d[k]) for k in ID_KEYS if d.get(k)}
-
-    for cand in candidates:
-        out: dict[tuple[int, int], dict[str, Any]] = {}
-        url = f"{base_url}/{cand}"
-        params = simkl_api_params_from_headers(
-            headers,
-            extended="full_anime_seasons" if str(kind).lower() == "anime" else "full",
-        )
-        try:
-            resp = session.get(url, headers=dict(headers), params=params, timeout=timeout)
-            if not resp.ok:
-                _warn("http_failed", op="episode_lookup", kind=str(kind).lower(), candidate=cand, status=resp.status_code)
-                _EP_LOOKUP_MEMO[memo_key] = {}
-                continue
-            body = resp.json() if (resp.text or "").strip() else []
-        except Exception as exc:
-            _warn("http_failed", op="episode_lookup", kind=str(kind).lower(), candidate=cand, error=str(exc))
-            _EP_LOOKUP_MEMO[memo_key] = {}
-            continue
-
-        if not isinstance(body, list):
-            _dbg("parse_failed", op="episode_lookup", kind=str(kind).lower(), candidate=cand, reason="non_list_body")
-            _EP_LOOKUP_MEMO[memo_key] = {}
-            continue
-        if not body:
-            _dbg("resolve_miss", op="episode_lookup", kind=str(kind).lower(), candidate=cand, reason="empty_response")
-            _EP_LOOKUP_MEMO[memo_key] = {}
-            continue
-
-        for row in body:
-            if not isinstance(row, Mapping):
-                continue
-            s_num = _safe_int(row.get("season") or row.get("season_number"))
-            e_num = _safe_int(row.get("episode") or row.get("episode_number") or row.get("number"))
-            if not s_num or not e_num:
-                continue
-            ep_meta: dict[str, Any] = {
-                "title": _pick_title(row),
-                "ids": _extract_ids(row),
-            }
-            tvdb_map = row.get("tvdb")
-            if isinstance(tvdb_map, Mapping):
-                tvdb_season = _safe_int(tvdb_map.get("season") or tvdb_map.get("tvdb_season"))
-                tvdb_episode = _safe_int(tvdb_map.get("episode") or tvdb_map.get("tvdb_number"))
-                if tvdb_season and tvdb_episode:
-                    ep_meta["tvdb"] = {"season": tvdb_season, "episode": tvdb_episode}
-            out[(s_num, e_num)] = ep_meta
-
-        if out:
-            for k in candidates:
-                _EP_LOOKUP_MEMO[f"{str(kind).lower()}:{k}"] = out
-            _dbg("resolve_hit", op="episode_lookup", kind=str(kind).lower(), candidate=cand, episodes=len(out))
-            return out
-
-        _EP_LOOKUP_MEMO[memo_key] = {}
-
-    return {}
-
-
-def _map_tvdb_episode_to_simkl_anime(
-    adapter: Any,
-    *,
-    show_ids: Mapping[str, Any],
-    season: int,
-    episode: int,
-) -> tuple[int, int] | None:
-    if season <= 0 or episode <= 0:
-        return None
-    lookup = _episode_lookup(
-        adapter.client.session,
-        _headers(adapter),
-        timeout=adapter.cfg.timeout,
-        show_ids=show_ids,
-        kind="anime",
-    )
-    if not lookup:
-        return None
-    for (simkl_season, simkl_episode), meta in lookup.items():
-        tvdb_map = meta.get("tvdb") if isinstance(meta, Mapping) else None
-        if not isinstance(tvdb_map, Mapping):
-            continue
-        if (
-            _safe_int(tvdb_map.get("season")) == int(season)
-            and _safe_int(tvdb_map.get("episode")) == int(episode)
-        ):
-            return simkl_season, simkl_episode
-    return None
 
 def _show_ids_of_episode(item: Mapping[str, Any]) -> dict[str, Any]:
     show_ids = _raw_show_ids(item)
@@ -663,21 +505,54 @@ def _fetch_all_items(
     )
     if since_iso:
         params["date_from"] = since_iso
-    resp = session.get(URL_ALL_ITEMS, headers=headers, params=params, timeout=timeout)
+    try:
+        resp = session.get(URL_ALL_ITEMS, headers=headers, params=params, timeout=timeout)
+    except Exception as exc:
+        _warn("http_failed", op="index", method="GET", url=URL_ALL_ITEMS, error=str(exc))
+        raise SIMKLFetchError("history all-items request failed") from exc
     if not resp.ok:
         _warn("http_failed", op="index", method="GET", url=URL_ALL_ITEMS, status=resp.status_code)
-        return {"movies": [], "shows": [], "anime": []}
+        raise SIMKLFetchError(f"history all-items request failed with HTTP {resp.status_code}")
     try:
-        body = resp.json() or {}
-    except Exception:
-        body = {}
+        body = resp.json()
+    except Exception as exc:
+        _warn("http_failed", op="index", method="GET", url=URL_ALL_ITEMS, reason="invalid_json")
+        raise SIMKLFetchError("history all-items returned invalid JSON") from exc
     out: dict[str, list[dict[str, Any]]] = {"movies": [], "shows": [], "anime": []}
-    if not isinstance(body, Mapping):
+    # SIMKL preserves a legacy response contract: applications with an internal
+    # app ID <= 58447 receive JSON null for an empty result, while newer apps
+    # receive the documented {}. SIMKL cannot change the legacy shape without
+    # breaking backward compatibility, so CrossWatch accepts both.
+    if body is None:
+        _dbg("index_empty_response", shape="null", compatibility="legacy")
         return out
+    if not isinstance(body, Mapping):
+        response_headers = getattr(resp, "headers", {})
+        content_type = ""
+        if isinstance(response_headers, Mapping):
+            content_type = str(
+                response_headers.get("Content-Type")
+                or response_headers.get("content-type")
+                or ""
+            ).split(";", 1)[0].strip()
+        json_count = len(body) if isinstance(body, (list, tuple)) else None
+        _warn(
+            "http_failed",
+            op="index",
+            method="GET",
+            url=URL_ALL_ITEMS,
+            status=getattr(resp, "status_code", None),
+            reason="invalid_response_shape",
+            content_type=content_type or "unknown",
+            json_type=type(body).__name__,
+            json_count=json_count,
+        )
+        raise SIMKLFetchError("history all-items returned an invalid response shape")
     for kind in ("movies", "shows", "anime"):
         rows = body.get(kind)
         if isinstance(rows, list):
             out[kind] = [x for x in rows if isinstance(x, dict) and not _is_null_env(x)]
+    cache_anime_mappings(out["anime"])
     return out
 
 
@@ -1008,7 +883,16 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
     _dbg("index_reconcile", reason=reason, strategy=strategy, date_from=date_from or "-", watermark=wm or "-")
 
     headers = _headers(adapter, force_refresh=True)
-    rows_by_kind = _fetch_all_items(session, headers, since_iso=date_from, timeout=timeout)
+    try:
+        rows_by_kind = _fetch_all_items(session, headers, since_iso=date_from, timeout=timeout)
+    except SIMKLFetchError:
+        if not cached:
+            raise
+        _warn("index_reconcile", reason="all_items_fetch_failed", source="cache_fallback")
+        _info("index_done", count=len(cached), source="cache_fallback")
+        out = dict(cached)
+        _apply_since_limit(out, since=since, limit=limit)
+        return out
     movie_rows = list(rows_by_kind.get("movies") or [])
     show_rows = list(rows_by_kind.get("shows") or [])
     anime_rows = list(rows_by_kind.get("anime") or [])
@@ -1019,19 +903,15 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
     _dedupe_history_movies(fetched)
     _dbg("index_fetch_counts", movies=movies_cnt, episodes=eps_cnt, from_date=date_from or "")
 
-    # SIMKL history deltas are filtered by watched_at
+    # An empty delta is complete: retain the cache and let the activity
+    # watermark advance below. Do not turn it into another full-library call.
     if strategy == "delta" and not fetched and (movies_cnt == 0 and eps_cnt == 0):
-        _dbg("index_reconcile", reason="incremental_empty", strategy="full_replace", date_from="-", watermark=wm or "-")
-        rows_by_kind = _fetch_all_items(session, headers, since_iso=None, timeout=timeout)
-        movie_rows = list(rows_by_kind.get("movies") or [])
-        show_rows = list(rows_by_kind.get("shows") or [])
-        anime_rows = list(rows_by_kind.get("anime") or [])
-        fetched, thaw, latest_ts_movies, latest_ts_shows, latest_ts_anime, movies_cnt, eps_cnt = _parse_rows(
-            movie_rows, show_rows, anime_rows, limit=None
+        _dbg(
+            "index_reconcile",
+            reason="incremental_empty",
+            strategy="delta_keep_cache",
+            watermark=wm or "-",
         )
-        _dedupe_history_movies(fetched)
-        _dbg("index_fetch_counts", movies=movies_cnt, episodes=eps_cnt, from_date="")
-        strategy = "full_replace"
 
     # Build final index
     if strategy == "delta":
@@ -1092,7 +972,8 @@ def _show_add_entry(adapter: Any, item: Mapping[str, Any]) -> dict[str, Any] | N
     ids = _ids_of(item)
     if not ids:
         return None
-    ids = _maybe_map_tvdb(adapter, ids)
+    if _is_anime_like(item, ids):
+        ids = _maybe_map_tvdb(adapter, ids)
     entry: dict[str, Any] = {"ids": ids}
     if _is_anime_like(item, ids):
         entry["use_tvdb_anime_seasons"] = True
@@ -1107,7 +988,8 @@ def _show_scope_entry(
     force_anime: bool = False,
 ) -> dict[str, Any] | None:
     show_ids = {k: str(raw_show_ids[k]) for k in ID_KEYS if raw_show_ids.get(k)}
-    show_ids = _maybe_map_tvdb(adapter, show_ids)
+    if force_anime or _is_anime_like(item, show_ids):
+        show_ids = _maybe_map_tvdb(adapter, show_ids)
     if not show_ids:
         return None
 
@@ -1126,21 +1008,6 @@ def _show_scope_entry(
         show["year"] = int(series_year)
 
     return show
-
-
-def _season_add_entry(adapter: Any, item: Mapping[str, Any]) -> tuple[dict[str, Any], int, str] | None:
-    show_ids_raw = _raw_show_ids(item)
-    if not show_ids_raw:
-        return None
-    show = _show_scope_entry(adapter, item, show_ids_raw)
-    if not show:
-        return None
-
-    s_num = _safe_int(item.get("season") or item.get("season_number"))
-    watched_at = item.get("watched_at") or item.get("watchedAt")
-    if not s_num or not isinstance(watched_at, str) or not watched_at:
-        return None
-    return show, s_num, watched_at
 
 
 def _episode_add_entry(adapter: Any, item: Mapping[str, Any]) -> tuple[dict[str, Any], int, int, str, dict[str, str]] | None:
@@ -1163,23 +1030,7 @@ def _episode_add_entry(adapter: Any, item: Mapping[str, Any]) -> tuple[dict[str,
     if s_num == 0 and not episode_ids:
         return None
 
-    anime_force = False
-    mapped = None
-    if s_num > 0:
-        try:
-            mapped = _map_tvdb_episode_to_simkl_anime(
-                adapter,
-                show_ids=show_ids_raw,
-                season=s_num,
-                episode=e_num,
-            )
-        except Exception:
-            mapped = None
-    if mapped is not None:
-        anime_force = True
-        s_num, e_num = mapped
-        episode_ids = {}
-
+    anime_force = s_num > 0 and _is_anime_like(item, show_ids_raw)
     show = _show_scope_entry(adapter, item, show_ids_raw, force_anime=anime_force)
     if not show:
         return None

--- a/providers/sync/simkl/_ratings.py
+++ b/providers/sync/simkl/_ratings.py
@@ -11,7 +11,9 @@ from cw_platform.id_map import minimal as id_minimal
 
 from .._log import log as cw_log
 from ._common import (
+    SIMKLFetchError,
     adapter_headers,
+    cache_anime_mappings,
     extract_latest_ts,
     fetch_activities,
     get_watermark,
@@ -28,6 +30,7 @@ from ._common import (
 )
 
 BASE = "https://api.simkl.com"
+URL_INDEX = f"{BASE}/sync/ratings"
 URL_ADD = f"{BASE}/sync/ratings"
 URL_REMOVE = f"{BASE}/sync/ratings/remove"
 
@@ -340,25 +343,6 @@ def _rshadow_merge_into(out: dict[str, dict[str, Any]], thaw: set[str]) -> None:
         _rshadow_save(sh)
 
 
-def _shadow_has_anime_items() -> bool:
-    sh = _rshadow_load()
-    store = sh.get("items") or {}
-    if not isinstance(store, Mapping):
-        return False
-    for rec_any in store.values():
-        rec = rec_any if isinstance(rec_any, Mapping) else {}
-        item = rec.get("item") if isinstance(rec.get("item"), Mapping) else {}
-        if not isinstance(item, Mapping):
-            continue
-        if str(item.get("anime_type") or "").strip():
-            return True
-        ids_any = item.get("ids")
-        ids: Mapping[str, Any] = ids_any if isinstance(ids_any, Mapping) else {}
-        if any(ids.get(k) for k in ("anilist", "mal", "kitsu", "anidb")):
-            return True
-    return False
-
-
 def _dedupe_prefer_plex_id(out: dict[str, dict[str, Any]]) -> None:
     if not out:
         return
@@ -529,71 +513,42 @@ def _merge_row_identity(m: dict[str, Any], row: Mapping[str, Any]) -> None:
             m["year"] = year
 
 
-def _resolve_by_simkl_id(
+def _fetch_current(
     sess: Any,
     hdrs: Mapping[str, str],
     *,
-    kind: str,
-    simkl_id: int,
     timeout: float,
-) -> Mapping[str, Any]:
-    params = simkl_api_params_from_headers(hdrs, extended="full")
-
-    k = str(kind or "").lower()
-    if k == "movies":
-        url = f"{BASE}/movies/{simkl_id}"
-    elif k == "anime":
-        url = f"{BASE}/anime/{simkl_id}"
-    else:
-        url = f"{BASE}/tv/{simkl_id}"
-
-    try:
-        resp = sess.get(url, headers=dict(hdrs), params=params, timeout=timeout)
-        if resp.status_code != 200:
-            return {}
-        data = resp.json()
-        return data if isinstance(data, Mapping) else {}
-    except Exception:
-        return {}
-
-
-RATINGS_ALL = "1,2,3,4,5,6,7,8,9,10"
-
-
-def _fetch_rows_current(
-    sess: Any,
-    hdrs: Mapping[str, str],
-    *,
-    kind: str,
-    timeout: float,
-) -> tuple[list[Mapping[str, Any]], bool]:
-    if kind not in {"movies", "shows", "anime"}:
-        return [], False
-    url = f"{BASE}/sync/ratings/{kind}/{RATINGS_ALL}"
+) -> tuple[dict[str, list[Mapping[str, Any]]], bool]:
+    empty = {"movies": [], "shows": [], "anime": []}
     try:
         resp = sess.get(
-            url,
+            URL_INDEX,
             headers=dict(hdrs),
             params=simkl_api_params_from_headers(hdrs),
             timeout=timeout,
         )
         if resp.status_code != 200:
-            _warn("http_failed", op="index", kind=kind, status=resp.status_code, body=(resp.text or "")[:200])
-            return [], False
+            _warn("http_failed", op="index", status=resp.status_code, body=(resp.text or "")[:200])
+            return empty, False
         data = resp.json()
         if not isinstance(data, Mapping):
-            if isinstance(data, list):
-                _dbg("index_reconcile", op="index", kind=kind, reason="non_mapping_bare_list", count=len(data))
-                return [r for r in data if isinstance(r, Mapping)], True
-            _dbg("http_failed", op="index", kind=kind, reason="non_mapping_response_assumed_empty")
-            return [], True
-        rows_any = data.get(kind)
-        if not isinstance(rows_any, list):
-            return [], True
-        return [r for r in rows_any if isinstance(r, Mapping)], True
+            _warn("http_failed", op="index", reason="invalid_response_shape")
+            return empty, False
+        out: dict[str, list[Mapping[str, Any]]] = {}
+        for kind in ("movies", "shows", "anime"):
+            rows_any = data.get(kind)
+            if rows_any is None:
+                out[kind] = []
+                continue
+            if not isinstance(rows_any, list):
+                _warn("http_failed", op="index", kind=kind, reason="invalid_bucket_shape")
+                return empty, False
+            out[kind] = [row for row in rows_any if isinstance(row, Mapping)]
+        cache_anime_mappings(out["anime"])
+        return out, True
     except Exception as exc:
-        _warn("http_failed", op="index", kind=kind, error=str(exc))
-        return [], False
+        _warn("http_failed", op="index", error=str(exc))
+        return empty, False
 
 
 def _filter_rows_since(
@@ -656,19 +611,9 @@ def build_index(adapter: Any, *, since_iso: str | None = None) -> dict[str, dict
             return out
 
     hdrs = _headers(adapter, force_refresh=True)
-    rows_movies_raw, ok_movies = _fetch_rows_current(sess, hdrs, kind="movies", timeout=tmo)
-    rows_shows_raw, ok_shows = _fetch_rows_current(sess, hdrs, kind="shows", timeout=tmo)
-    rows_anime_raw, ok_anime = _fetch_rows_current(sess, hdrs, kind="anime", timeout=tmo)
-    if ok_movies and ok_shows and not ok_anime:
-        if _shadow_has_anime_items():
-            _warn("index_reconcile", reason="anime_bucket_unavailable_shadow_has_items", source="current")
-        else:
-            _dbg("index_reconcile", reason="anime_bucket_unavailable_assumed_empty", source="current")
-        rows_anime_raw = []
-        ok_anime = True
-    fetch_ok = ok_movies and ok_shows and ok_anime
-
-    if not fetch_ok and shadow_has_data:
+    def _incomplete_fetch() -> dict[str, dict[str, Any]]:
+        if not shadow_has_data:
+            raise SIMKLFetchError("ratings snapshot fetch was incomplete and no shadow is available")
         _warn("index_reconcile", reason="current_fetch_incomplete", source="shadow_fallback")
         _rshadow_merge_into(out, thaw)
         _dedupe_prefer_plex_id(out)
@@ -679,6 +624,13 @@ def build_index(adapter: Any, *, since_iso: str | None = None) -> dict[str, dict
                 pass
         _info("index_done", count=len(out), source="shadow_fallback")
         return out
+
+    rows_by_kind, fetch_ok = _fetch_current(sess, hdrs, timeout=tmo)
+    if not fetch_ok:
+        return _incomplete_fetch()
+    rows_movies_raw = rows_by_kind["movies"]
+    rows_shows_raw = rows_by_kind["shows"]
+    rows_anime_raw = rows_by_kind["anime"]
 
     rows_movies = _filter_rows_since(rows_movies_raw, since_iso=since_iso)
     rows_shows = _filter_rows_since(rows_shows_raw, since_iso=since_iso)
@@ -861,7 +813,10 @@ def _show_entry_add(adapter: Any, it: Mapping[str, Any]) -> dict[str, Any] | Non
     rating = _norm_rating(it.get("rating"))
     if not ids or rating is None:
         return None
-    ids = _maybe_map_tvdb(adapter, ids)
+    bucket = str(it.get("simkl_bucket") or "").strip().lower()
+    is_anime = bucket == "anime" or any(ids.get(key) for key in ("mal", "anidb", "anilist", "kitsu"))
+    if is_anime:
+        ids = _maybe_map_tvdb(adapter, ids)
     ent: dict[str, Any] = {"ids": ids, "rating": rating}
     ra = _pick_rated_at(it)
     if ra:
@@ -885,6 +840,57 @@ def _chunk_items(seq: list[Mapping[str, Any]], n: int) -> Iterable[list[Mapping[
         yield seq[i : i + size]
 
 
+def _id_tokens(value: Any) -> set[str]:
+    if not isinstance(value, Mapping):
+        return set()
+    request = value.get("request")
+    if isinstance(request, Mapping):
+        nested = _id_tokens(request)
+        if nested:
+            return nested
+    ids_any = value.get("ids")
+    ids = ids_any if isinstance(ids_any, Mapping) else value
+    return {
+        f"{key}:{str(ids.get(key)).strip().lower()}"
+        for key in ID_KEYS
+        if ids.get(key) not in (None, "")
+    }
+
+
+def _partition_write_result(
+    attempted: list[Mapping[str, Any]],
+    payload: Any,
+) -> tuple[list[Mapping[str, Any]], list[Mapping[str, Any]]]:
+    if not isinstance(payload, Mapping):
+        return [], list(attempted)
+    not_found = payload.get("not_found")
+    if not isinstance(not_found, Mapping):
+        return list(attempted), []
+
+    rejected_tokens: set[str] = set()
+    rejected_without_ids = False
+    for rows in not_found.values():
+        if not isinstance(rows, list):
+            continue
+        for row in rows:
+            tokens = _id_tokens(row)
+            if tokens:
+                rejected_tokens.update(tokens)
+            else:
+                rejected_without_ids = True
+    if rejected_without_ids:
+        return [], list(attempted)
+    if not rejected_tokens:
+        return list(attempted), []
+
+    confirmed: list[Mapping[str, Any]] = []
+    rejected: list[Mapping[str, Any]] = []
+    for item in attempted:
+        target = rejected if (_id_tokens(item) & rejected_tokens) else confirmed
+        target.append(item)
+    return confirmed, rejected
+
+
 def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
     sess = adapter.client.session
     hdrs = _headers(adapter)
@@ -899,7 +905,6 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
     for part in _chunk_items(items_list, chunk_size):
         movies: list[dict[str, Any]] = []
         shows: list[dict[str, Any]] = []
-        thaw_keys: list[str] = []
         rshadow_events: list[dict[str, Any]] = []
         attempted: list[Mapping[str, Any]] = []
 
@@ -923,7 +928,6 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 ent = _movie_entry_add(it)
                 if ent:
                     movies.append(ent)
-                    thaw_keys.append(key)
                     attempted.append(it)
                     ev = dict(mini)
                     ev["rating"] = ent["rating"]
@@ -937,7 +941,6 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 ent = _show_entry_add(adapter, it)
                 if ent:
                     shows.append(ent)
-                    thaw_keys.append(key)
                     attempted.append(it)
                     ev = dict(mini)
                     ev["rating"] = ent["rating"]
@@ -954,7 +957,6 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             ent = _show_entry_add(adapter, it)
             if ent:
                 shows.append(ent)
-                thaw_keys.append(key)
                 attempted.append(it)
                 ev = dict(mini)
                 ev["rating"] = ent["rating"]
@@ -981,23 +983,42 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 timeout=adapter.cfg.timeout,
             )
             if 200 <= resp.status_code < 300:
-                _unfreeze_if_present(thaw_keys)
-                ok += len(movies) + len(shows)
                 try:
-                    _rshadow_put_all(rshadow_events)
+                    payload = resp.json() if (resp.text or "").strip() else None
+                except Exception:
+                    payload = None
+                confirmed, rejected = _partition_write_result(attempted, payload)
+                confirmed_keys = {
+                    simkl_key_of(id_minimal(dict(item)))
+                    for item in confirmed
+                }
+                _unfreeze_if_present(confirmed_keys)
+                ok += len(confirmed)
+                try:
+                    _rshadow_put_all(
+                        event
+                        for event in rshadow_events
+                        if simkl_key_of(id_minimal(dict(event))) in confirmed_keys
+                    )
                 except Exception as exc:
                     _warn("cache_save_failed", cache="shadow", op="add", error=str(exc))
+                for item in rejected:
+                    ids = _ids_of(item)
+                    rating = _norm_rating(item.get("rating"))
+                    unresolved.append({"item": id_minimal(dict(item)), "hint": "simkl_not_found"})
+                    if ids and rating is not None:
+                        _freeze(item, action="add", reasons=["not_found"], ids_sent=ids, rating=rating)
             else:
                 _warn("write_failed", op="add", status=resp.status_code, body=(resp.text or '')[:180])
                 for it in attempted:
-                    ids = _maybe_map_tvdb(adapter, _ids_of(it))
+                    ids = _ids_of(it)
                     rating = _norm_rating(it.get("rating"))
                     if ids and rating is not None:
                         _freeze(it, action="add", reasons=["write_failed"], ids_sent=ids, rating=rating)
         except Exception as exc:
             _warn("write_failed", op="add", error=str(exc))
             for it in attempted:
-                ids = _maybe_map_tvdb(adapter, _ids_of(it))
+                ids = _ids_of(it)
                 rating = _norm_rating(it.get("rating"))
                 if ids and rating is not None:
                     _freeze(it, action="add", reasons=["write_failed"], ids_sent=ids, rating=rating)
@@ -1020,7 +1041,6 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
     for part in _chunk_items(items_list, chunk_size):
         movies: list[dict[str, Any]] = []
         shows: list[dict[str, Any]] = []
-        thaw_keys: list[str] = []
         attempted: list[Mapping[str, Any]] = []
 
         for it in part:
@@ -1034,7 +1054,6 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
                 continue
 
             ids = _ids_of(it) or _show_ids_of_episode(it)
-            ids = _maybe_map_tvdb(adapter, ids)
             if not ids:
                 unresolved.append({"item": mini, "hint": "missing_ids"})
                 continue
@@ -1055,7 +1074,6 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
             else:
                 shows.append({"ids": ids})
 
-            thaw_keys.append(key)
             attempted.append(it)
 
         if not (movies or shows):
@@ -1076,12 +1094,21 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
                 timeout=adapter.cfg.timeout,
             )
             if 200 <= resp.status_code < 300:
-                _unfreeze_if_present(thaw_keys)
+                try:
+                    payload = resp.json() if (resp.text or "").strip() else None
+                except Exception:
+                    payload = None
+                confirmed, rejected = _partition_write_result(attempted, payload)
+                confirmed_keys = {
+                    simkl_key_of(id_minimal(dict(item)))
+                    for item in confirmed
+                }
+                _unfreeze_if_present(confirmed_keys)
                 try:
                     sh = _rshadow_load()
                     store: dict[str, Any] = dict(sh.get("items") or {})
                     changed = False
-                    for k in thaw_keys:
+                    for k in confirmed_keys:
                         if k in store:
                             store.pop(k, None)
                             changed = True
@@ -1090,7 +1117,12 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
                         _rshadow_save(sh)
                 except Exception:
                     pass
-                ok += len(movies) + len(shows)
+                ok += len(confirmed)
+                for item in rejected:
+                    ids = _ids_of(item) or _show_ids_of_episode(item)
+                    unresolved.append({"item": id_minimal(dict(item)), "hint": "simkl_not_found"})
+                    if ids:
+                        _freeze(item, action="remove", reasons=["not_found"], ids_sent=ids, rating=None)
                 continue
             _warn("write_failed", op="remove", status=resp.status_code, body=(resp.text or '')[:180])
         except Exception as exc:
@@ -1098,7 +1130,6 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
 
         for it in attempted:
             ids = _ids_of(it) or _show_ids_of_episode(it)
-            ids = _maybe_map_tvdb(adapter, ids)
             if ids:
                 _freeze(it, action="remove", reasons=["write_failed"], ids_sent=ids, rating=None)
 

--- a/providers/sync/simkl/_watchlist.py
+++ b/providers/sync/simkl/_watchlist.py
@@ -13,6 +13,7 @@ from cw_platform.id_map import minimal as id_minimal
 
 from .._log import log as cw_log
 from ._common import (
+    SIMKLFetchError,
     adapter_headers,
     coalesce_date_from,
     fetch_activities,
@@ -28,9 +29,8 @@ from ._common import (
 )
 
 BASE = "https://api.simkl.com"
-URL_INDEX_ALL = f"{BASE}/sync/all-items/"
+URL_INDEX_ALL = f"{BASE}/sync/all-items"
 URL_INDEX_BUCKET = f"{BASE}/sync/all-items/{{bucket}}/plantowatch"
-URL_INDEX_IDS = f"{BASE}/sync/all-items/{{bucket}}/plantowatch"
 URL_ADD = f"{BASE}/sync/add-to-list"
 URL_REMOVE = f"{BASE}/sync/history/remove"
 
@@ -400,37 +400,6 @@ def _merge_upsert(dst: dict[str, dict[str, Any]], src: Mapping[str, Mapping[str,
         }
 
 
-def _keys_from_write_resp(body: Any) -> list[str]:
-    keys: list[str] = []
-    if not isinstance(body, dict):
-        return keys
-
-    def _collect(parent: Mapping[str, Any]) -> None:
-        for bucket, media_type in (("movies", "movie"), ("shows", "show")):
-            value = parent.get(bucket)
-            if isinstance(value, list):
-                for item in value:
-                    ids = _ids_filter(
-                        (item.get("ids") or item) if isinstance(item, Mapping) else {},
-                    )
-                    if ids:
-                        m = {"type": media_type, "ids": ids, "simkl_bucket": bucket}
-                        keys.append(simkl_key_of(m))
-
-    for top in ("added", "removed", "deleted"):
-        section = body.get(top)
-        if isinstance(section, Mapping):
-            _collect(section)
-    _collect(body)
-    seen: set[str] = set()
-    uniq: list[str] = []
-    for key in keys:
-        if key not in seen:
-            uniq.append(key)
-            seen.add(key)
-    return uniq
-
-
 _SIG_ID_ORDER = ("tmdb", "imdb", "tvdb", "trakt", "simkl", "mal", "anilist", "kitsu", "anidb")
 
 
@@ -519,8 +488,7 @@ def _pull_bucket(
     force_refresh: bool = False,
 ) -> dict[str, dict[str, Any]]:
     session = adapter.client.session
-    url_ids = URL_INDEX_IDS.format(bucket=bucket)
-    url_full = URL_INDEX_BUCKET.format(bucket=bucket)
+    url = URL_INDEX_BUCKET.format(bucket=bucket)
     base_params: dict[str, Any] = {"extended": "ids_only" if ids_only else "full"}
     if bucket == "anime":
         base_params["extended"] = "full_anime_seasons"
@@ -544,11 +512,25 @@ def _pull_bucket(
             )
             if resp.status_code != 200:
                 _warn("http_failed", op="index", bucket=bucket, method="GET", url=url, status=resp.status_code)
-                return {}
+                raise SIMKLFetchError(f"watchlist bucket {bucket} request failed with HTTP {resp.status_code}")
             try:
                 data = resp.json()
-            except Exception:
-                data = None
+            except Exception as exc:
+                _warn("http_failed", op="index", bucket=bucket, method="GET", url=url, reason="invalid_json")
+                raise SIMKLFetchError(f"watchlist bucket {bucket} returned invalid JSON") from exc
+            # SIMKL app IDs <= 58447 receive legacy JSON null for an empty
+            # result; newer apps receive {}. Both must remain compatible.
+            if data is None:
+                _dbg(
+                    "index_empty_response",
+                    bucket=bucket,
+                    shape="null",
+                    compatibility="legacy",
+                )
+                return {}
+            if not isinstance(data, (Mapping, list)):
+                _warn("http_failed", op="index", bucket=bucket, method="GET", url=url, reason="invalid_response_shape")
+                raise SIMKLFetchError(f"watchlist bucket {bucket} returned an invalid response shape")
             rows = _rows_from_data(data, bucket)
             if not rows:
                 return {}
@@ -567,21 +549,12 @@ def _pull_bucket(
                     continue
             return out_local
         except Exception as exc:
+            if isinstance(exc, SIMKLFetchError):
+                raise
             _warn("http_failed", op="index", bucket=bucket, method="GET", url=url, error=str(exc))
-            return {}
+            raise SIMKLFetchError(f"watchlist bucket {bucket} request failed") from exc
 
-    first_url = url_ids if ids_only else url_full
-    result = _do_fetch(first_url, dict(base_params), force_refresh)
-    if not result:
-        alt_params = dict(base_params)
-        alt_params.pop("date_from", None)
-        if ids_only:
-            alt_params["extended"] = "full"
-            alt_url = url_full
-        else:
-            alt_url = first_url
-        result = _do_fetch(alt_url, alt_params, True)
-    return result
+    return _do_fetch(url, dict(base_params), force_refresh)
 
 
 def _pull_all_watchlist(
@@ -606,14 +579,25 @@ def _pull_all_watchlist(
         )
         if resp.status_code != 200:
             _warn("http_failed", op="index", method="GET", url=URL_INDEX_ALL, status=resp.status_code)
-            return {}
+            raise SIMKLFetchError(f"watchlist aggregate request failed with HTTP {resp.status_code}")
         try:
             data = resp.json()
-        except Exception:
-            data = None
+        except Exception as exc:
+            _warn("http_failed", op="index", method="GET", url=URL_INDEX_ALL, reason="invalid_json")
+            raise SIMKLFetchError("watchlist aggregate returned invalid JSON") from exc
+        # SIMKL app IDs <= 58447 receive legacy JSON null for an empty result;
+        # newer apps receive {}. Both must remain compatible.
+        if data is None:
+            _dbg("index_empty_response", shape="null", compatibility="legacy")
+            data = {}
+        if not isinstance(data, Mapping):
+            _warn("http_failed", op="index", method="GET", url=URL_INDEX_ALL, reason="invalid_response_shape")
+            raise SIMKLFetchError("watchlist aggregate returned an invalid response shape")
     except Exception as exc:
+        if isinstance(exc, SIMKLFetchError):
+            raise
         _warn("http_failed", op="index", method="GET", url=URL_INDEX_ALL, error=str(exc))
-        return {}
+        raise SIMKLFetchError("watchlist aggregate request failed") from exc
 
     out: dict[str, dict[str, Any]] = {}
     count = 0
@@ -637,7 +621,7 @@ def _pull_all_watchlist(
 
 
 
-def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, Any]]:
+def _build_index_live(adapter: Any, limit: int | None = None) -> dict[str, dict[str, Any]]:
     prog_mk = getattr(adapter, "progress_factory", None)
     prog: Any = prog_mk("watchlist") if callable(prog_mk) else None
     done = 0
@@ -969,6 +953,30 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
 
     _info("index_done", count=len(items), source="mixed")
     return items
+
+
+def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, Any]]:
+    shadow = _shadow_load()
+    raw_items = shadow.get("items") or {}
+    cached = (
+        {
+            str(key): dict(value)
+            for key, value in raw_items.items()
+            if isinstance(key, str) and isinstance(value, Mapping)
+        }
+        if isinstance(raw_items, Mapping)
+        else {}
+    )
+    buckets_seen = shadow.get("buckets_seen") or {}
+
+    try:
+        return _build_index_live(adapter, limit=limit)
+    except SIMKLFetchError:
+        if not isinstance(buckets_seen, Mapping) or not _has_all_buckets(cached, buckets_seen):
+            raise
+        _warn("index_reconcile", reason="watchlist_fetch_failed", source="shadow_fallback")
+        _info("index_done", count=len(cached), source="shadow_fallback")
+        return cached
 
 
 def _split_buckets(

--- a/services/playback_progress/adapters/simkl.py
+++ b/services/playback_progress/adapters/simkl.py
@@ -134,6 +134,7 @@ def _history_item(record: Mapping[str, Any]) -> dict[str, Any]:
 
 def _progress_body_from_record(record: Mapping[str, Any], progress_percent: float) -> dict[str, Any]:
     item = _history_item(record)
+    metadata = _as_mapping(record.get("provider_metadata"))
     media_type = str(record.get("media_type") or item.get("type") or "").lower()
     ids = clean_mapping(item.get("ids") if isinstance(item.get("ids"), Mapping) else {})
     body: dict[str, Any] = {"progress": progress_percent}
@@ -150,8 +151,14 @@ def _progress_body_from_record(record: Mapping[str, Any], progress_percent: floa
     show_ids = clean_mapping(item.get("show_ids") if isinstance(item.get("show_ids"), Mapping) else {})
     parent = "anime" if media_type == "anime_episode" else "show"
     episode: dict[str, Any] = {}
-    if ids:
-        episode["ids"] = ids
+    episode_ids = _as_mapping(metadata.get("episode_ids"))
+    supported_episode_ids = {
+        key: value
+        for key, value in episode_ids.items()
+        if key in {"tvdb", "anidb"} and value not in (None, "")
+    }
+    if supported_episode_ids:
+        episode["ids"] = supported_episode_ids
     if item.get("season") is not None:
         episode["season"] = item.get("season")
     if item.get("episode") is not None:
@@ -391,7 +398,11 @@ class SimklPlaybackAdapter(PlaybackProgressAdapter):
             can_mark_watched=caps.mark_watched,
             can_update_progress=caps.update_progress,
             capability_messages=[] if caps.configured else [caps.reason],
-            provider_metadata={"history_item": history_item, "show_ids": container_ids},
+            provider_metadata={
+                "history_item": history_item,
+                "show_ids": container_ids,
+                "episode_ids": episode_ids,
+            },
         )
 
     def remove_progress(


### PR DESCRIPTION
# Pull request

## Change

- Propagate snapshot failures instead of converting them into empty inventories.
- Preserve cached SIMKL history, ratings, and watchlist data when reads fail.
- Support both legacy `null` and newer `{}` empty SIMKL responses - still old bug in SIMKL API - validated with SIMKL devs
- Keep empty history deltas cached, advance watermarks, and avoid full-library retries.
- Consolidate ratings reads and correctly handle partial `not_found` responses.
- Reduce redundant watchlist calls and remove obsolete lookup code.
- Correct anime history mapping and playback episode ID handling.
- Updated SIMKL adapter version to `1.2.`

## Why

Failed or unexpected SIMKL responses could previously be interpreted as an empty library, potentially causing destructive synchronization.

SIMKL returns `null` for empty results to legacy applications and `{}` to newer applications. According to the SIMKL developers, an empty `{}` response is only returned to applications with an ID higher than `58447`. Older applications continue to receive `null` for backward compatibility, and this behavior cannot be changed without potentially breaking them. Crosswatch needs to handle both.

These changes make synchronization more safe while reducing unnecessary SIMKL API traffic.

## Testing

- SIMKL, orchestrator, and history test suites
- Verified legacy HTTP 200 `null` responses with curl.
- Live-tested initial import, empty delta handling, one new history item, cache reuse, and final zero-change.

## Issue

Relates to #358