### PR TITLE
Fix: playback time-left and Plex resume removal(#366)

### DIFF
--- a/assets/js/playingcard.js
+++ b/assets/js/playingcard.js
@@ -92,6 +92,24 @@
     return h > 0 ? `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}` : `${m}:${String(s).padStart(2, "0")}`;
   };
 
+  const firstPositive = (...vals) => {
+    for (const v of vals) {
+      const n = Array.isArray(v) ? Number(v[0]) : Number(v);
+      if (Number.isFinite(n) && n > 0) return n;
+    }
+    return 0;
+  };
+
+  const runtimeMinsFor = (p, meta) => {
+    if (!meta) return 0;
+    const det = meta.detail || {};
+    const mt = String(p?.media_type || p?.type || "").toLowerCase();
+    if (mt === "episode") {
+      return firstPositive(det.episode_run_time, meta.episode_run_time, det.runtime, meta.runtime, meta.runtime_minutes, det.runtime_minutes);
+    }
+    return firstPositive(meta.runtime_minutes, det.runtime_minutes, meta.runtime, det.runtime);
+  };
+
   const metaKey = (p) => `${String(p?.media_type || p?.type || "").toLowerCase()}:${String(tmdbIdOf(p) || "")}`;
   const sourceLabel = (src) => {
     const s = String(src || "").toLowerCase();
@@ -418,7 +436,7 @@
   #playing-detail .pc-poster{display:block;width:100%;height:100%;border:0;border-radius:inherit;box-shadow:none;box-sizing:border-box}
   #playing-detail .pc-body{min-width:0;padding:14px 0;justify-content:flex-start}
   #playing-detail .pc-title{font-size:18px;line-height:1.15}
-  #playing-detail .pc-overview{margin-top:10px;max-height:7.25em;line-height:1.45;-webkit-line-clamp:5}
+  #playing-detail .pc-overview{margin-top:10px;max-height:4.35em;line-height:1.45;-webkit-line-clamp:3}
   #playing-detail .pc-close{position:static;width:24px;height:24px;min-width:24px}
   #playing-detail .pc-stats{min-width:0;display:grid;grid-template-rows:auto auto;align-content:center;gap:9px;padding:14px 6px 14px 14px;border-left:1px solid rgba(255,255,255,.08)}
   #playing-detail .pc-progress-wrap{margin:0;align-self:start}
@@ -436,6 +454,15 @@
   @media (max-width:680px){#playing-detail{bottom:max(10px,env(safe-area-inset-bottom));width:calc(100vw - 20px);border-radius:18px}#playing-detail .pc-inner{grid-template-columns:64px minmax(0,1fr);gap:12px;padding:12px}#playing-detail .pc-poster-link{width:64px;height:96px;grid-row:auto;border-radius:10px}#playing-detail .pc-body{padding:2px 0}#playing-detail .pc-title{font-size:15px;line-height:1.15}#playing-detail .pc-title-actions{gap:6px}#playing-detail .pc-nav{padding:2px 4px}#playing-detail .pc-nav-count{min-width:32px;font-size:10px}#playing-detail .pc-nav-btn{width:24px;height:24px}#playing-detail .pc-meta{gap:4px;margin-top:4px}#playing-detail .pc-chip{min-height:21px;font-size:9px;padding:0 7px}#playing-detail .pc-overview{margin-top:6px;max-height:4.35em;font-size:11px;-webkit-line-clamp:3}#playing-detail .pc-overview-more{font-size:9px}#playing-detail .pc-stats{grid-column:1 / -1;grid-template-rows:auto auto;padding:10px 0 0;border-left:0;border-top:1px solid rgba(255,255,255,.08)}#playing-detail .pc-info-block{min-height:58px}}
   @media (max-width:460px){#playing-detail .pc-stats-bottom{grid-template-columns:1fr}#playing-detail .pc-overview{-webkit-line-clamp:1;max-height:1.5em}}
   @media (hover:none){#playing-detail.show:hover{transform:translate(-50%,0);box-shadow:0 20px 48px rgba(0,0,0,.6)}}
+  /* the card must never grow taller than the 190px poster. */
+  @media (min-width:821px){
+    #playing-detail .pc-inner{min-height:190px;max-height:190px;height:190px;overflow:hidden}
+    #playing-detail .pc-body{min-height:0;max-height:190px;overflow:hidden}
+    #playing-detail .pc-stats{min-height:0;max-height:190px;overflow:hidden}
+    #playing-detail .pc-title{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;text-overflow:ellipsis;min-width:0}
+    #playing-detail .pc-meta{overflow:hidden}
+    #playing-detail .pc-overview-more{display:none!important}
+  }
   `;
 
   const style = document.createElement("style");
@@ -566,6 +593,7 @@
     cacheAt: 0,
     cachePayload: null,
     serverTs: 0,
+    durationByKey: new Map(),
   };
 
   const stopStatusPoll = () => {
@@ -745,15 +773,11 @@
     renderBaseMeta(p, releaseLabel);
     const runtimeMin = meta.runtime_minutes ?? det.runtime_minutes ?? meta.runtime ?? det.runtime;
     if (runtimeMin) addChip(runtimeLabel(runtimeMin));
-    if (!p?.duration_ms && runtimeMin) {
-      const pct = Math.max(0, Math.min(100, Number(p?.progress) || 0));
-      if (pct > 0) {
-        const totalMs = Number(runtimeMin) * 60 * 1000;
-        if (totalMs > 0) {
-          const remainingMs = Math.max(0, totalMs - totalMs * (pct / 100));
-          const remainingStr = formatTime(remainingMs);
-          if (remainingStr && !progTimeEl.textContent) progTimeEl.textContent = `${remainingStr} left`;
-        }
+    const metaRuntimeMin = runtimeMinsFor(p, meta);
+    if (metaRuntimeMin > 0) {
+      const durKey = keyOf(p);
+      if (!(Number(CARD.durationByKey.get(durKey)) > 0)) {
+        CARD.durationByKey.set(durKey, metaRuntimeMin * 60 * 1000);
       }
     }
     if (!p?.overview) {
@@ -770,6 +794,7 @@
     const tmdbUrl = buildTmdbUrl(Object.assign({}, p, { tmdb: tmdbIdOf(p) || (meta.ids && (meta.ids.tmdb || meta.ids.id)) }));
     setPosterLink(tmdbUrl, p?.title);
     detail.style.setProperty("--pc-backdrop", backdrop ? `url("${backdrop}")` : "none");
+    renderProgress(p);
   };
 
   const startStatusPoll = () => {
@@ -822,16 +847,23 @@
   nextBtn?.addEventListener("click", () => applySelectionOffset(1), true);
 
   const renderProgress = (p) => {
-    const pct = visualProgress(p);
+    const key = keyOf(p);
+    let totalMs = Number(p?.duration_ms) || 0;
+    if (totalMs > 0) {
+      CARD.durationByKey.set(key, totalMs);
+    } else {
+      totalMs = Number(CARD.durationByKey.get(key)) || 0;
+    }
+    const itemForPct = (totalMs > 0 && !(Number(p?.duration_ms) > 0)) ? { ...p, duration_ms: totalMs } : p;
+    const pct = visualProgress(itemForPct);
     progEl.style.width = `${pct}%`;
     progPctEl.textContent = `${Math.round(pct)}% watched`;
-    let timeLabel = "";
-    const totalMs = Number(p?.duration_ms) || 0;
     if (totalMs > 0) {
       const remainingStr = formatTime(Math.max(0, totalMs - totalMs * (pct / 100)));
-      if (remainingStr) timeLabel = `${remainingStr} left`;
+      progTimeEl.textContent = remainingStr ? `${remainingStr} left` : "";
+    } else {
+      progTimeEl.textContent = "";
     }
-    progTimeEl.textContent = timeLabel;
   };
 
   async function renderSelectedStream() {

--- a/providers/scrobble/currently_watching.py
+++ b/providers/scrobble/currently_watching.py
@@ -256,6 +256,8 @@ def _update_stream(source: str, payload: dict[str, Any], clear_on_stop: bool) ->
         st = str(payload.get("state") or "").lower()
 
         existing_started = 0
+        existing_duration_ms: Optional[int] = None
+        existing_cover: Optional[str] = None
         for alias_key in alias_keys:
             existing = streams.get(alias_key)
             if not isinstance(existing, dict):
@@ -264,6 +266,14 @@ def _update_stream(source: str, payload: dict[str, Any], clear_on_stop: bool) ->
                 existing_started = max(existing_started, int(existing.get("started") or 0))
             except Exception:
                 pass
+            if existing_duration_ms is None:
+                ed = _coerce_int(existing.get("duration_ms"))
+                if ed and ed > 0:
+                    existing_duration_ms = ed
+            if not existing_cover:
+                ec = str(existing.get("cover") or "").strip()
+                if ec:
+                    existing_cover = ec
             if alias_key != key:
                 streams.pop(alias_key, None)
 
@@ -274,6 +284,12 @@ def _update_stream(source: str, payload: dict[str, Any], clear_on_stop: bool) ->
             if not existing_started:
                 existing_started = now
             payload["started"] = existing_started
+            # Preserve stable auxiliary fields when the incoming payload lacks them.
+            incoming_duration = _coerce_int(payload.get("duration_ms"))
+            if (incoming_duration is None or incoming_duration <= 0) and existing_duration_ms:
+                payload["duration_ms"] = existing_duration_ms
+            if not str(payload.get("cover") or "").strip() and existing_cover:
+                payload["cover"] = existing_cover
             streams[key] = payload
 
         if not streams:

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -1237,7 +1237,7 @@ class WatchService:
             )
             self._log(f"ids resolved: {_media_name(ev)} -> {_ids_desc(ev.ids)}", "DEBUG")
             try:
-                _cw_update("plex", ev, provider_instance=str(self._instance_id or "default"))
+                _cw_update("plex", ev, duration_ms=d, provider_instance=str(self._instance_id or "default"))
             except Exception:
                 pass
             if sk and ev.action == "start":

--- a/providers/sync/plex/_progress.py
+++ b/providers/sync/plex/_progress.py
@@ -783,10 +783,37 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
 
             try:
                 obj = srv.fetchItem(int(rk))  # type: ignore[attr-defined]
-                duration = _to_int(getattr(obj, "duration", None)) or _to_int(it0.get("duration_ms")) or 0
-                _timeline_progress(adapter, srv, rk, 0, duration)
-                ok += 1
-                results.append({"status": "applied", "provider": "plex", "provider_instance": os.getenv("CW_PAIR_DST_INSTANCE") or "default", "remote_item_id": str(rk), "library_id": _library_id(obj) or it0.get("library_id"), "source_progress": 0, "target_progress": _to_int(getattr(obj, "viewOffset", None)), "reason": "clear_progress"})
+                library_id = _library_id(obj) or it0.get("library_id")
+
+                mark_unplayed = getattr(obj, "markUnplayed", None) or getattr(obj, "markUnwatched", None)
+                if callable(mark_unplayed):
+                    mark_unplayed()
+                else:
+                    srv.query("/:/unscrobble", params={"key": str(rk), "identifier": "com.plexapp.plugins.library"})  # type: ignore[attr-defined]
+
+                try:
+                    verify_obj = srv.fetchItem(int(rk))  # type: ignore[attr-defined]
+                    remaining = _to_int(getattr(verify_obj, "viewOffset", None))
+                except Exception:
+                    remaining = _to_int(getattr(obj, "viewOffset", None))
+
+                context = {
+                    "provider": "plex",
+                    "provider_instance": os.getenv("CW_PAIR_DST_INSTANCE") or "default",
+                    "remote_item_id": str(rk),
+                    "library_id": library_id,
+                    "source_progress": 0,
+                }
+
+                if remaining is not None and remaining > 0:
+                    entry = {"status": "failed", "reason": "clear_progress_unconfirmed", "target_progress": int(remaining), "item": it0, **context}
+                    unresolved.append(entry)
+                    results.append(entry)
+                    if _mods_debug():
+                        _warn("clear_unconfirmed", op="remove", rating_key=str(rk), remaining_view_offset=int(remaining), canonical_key=str(canonical_key(id_minimal(it0)) or ""))
+                else:
+                    ok += 1
+                    results.append({"status": "applied", **context, "target_progress": 0, "reason": "clear_progress"})
             except Exception as e:
                 if _mods_debug():
                     _warn("write_failed", op="remove", rating_key=str(rk), canonical_key=str(canonical_key(id_minimal(it0)) or ""), error=str(e))

--- a/services/playback_progress/adapters/media_servers.py
+++ b/services/playback_progress/adapters/media_servers.py
@@ -23,11 +23,9 @@ except Exception:
 
 try:
     from providers.sync._mod_PLEX import OPS as PLEX_OPS, PLEXModule
-    from providers.sync.plex._progress import _resolve_rating_key as _plex_resolve_rating_key
 except Exception:
     PLEX_OPS = None  # type: ignore[assignment]
     PLEXModule = None  # type: ignore[assignment]
-    _plex_resolve_rating_key = None  # type: ignore[assignment]
 
 
 def _int(value: Any) -> int | None:
@@ -329,6 +327,15 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
             decision = decisions[0] if decisions and isinstance(decisions[0], Mapping) else {}
             status = str(decision.get("status") or ("applied" if ok else "failed"))
             decision_reason = str(decision.get("reason") or "")
+            if ok:
+                message = f"Playback record removed from {self.provider_label}."
+                error_code = ""
+            elif decision_reason == "clear_progress_unconfirmed":
+                message = f"{self.provider_label} accepted the request, but the resume point is still present."
+                error_code = "progress_remove_unconfirmed"
+            else:
+                message = f"{self.provider_label} remove progress failed."
+                error_code = "progress_remove_failed"
             return PlaybackActionResult(
                 ok=ok,
                 provider=self.provider,
@@ -336,8 +343,8 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
                 operation="remove_progress",
                 remote_id=str(record.get("remote_id") or ""),
                 canonical_key=str(record.get("canonical_key") or ""),
-                message=f"Playback record removed from {self.provider_label}." if ok else f"{self.provider_label} remove progress failed.",
-                error_code="" if ok else "progress_remove_failed",
+                message=message,
+                error_code=error_code,
                 playback_cleanup_result=clean_mapping(result),
                 status=status,
                 reason=decision_reason,
@@ -345,31 +352,6 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
             )
         except Exception:
             return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message=f"{self.provider_label} remove progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
-
-    def _remove_plex_progress(self, config_view: Mapping[str, Any], record: Mapping[str, Any], *, instance_id: str) -> PlaybackActionResult:
-        if PLEXModule is None:
-            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Plex playback support is unavailable.", error_code="provider_unavailable")
-        try:
-            module = PLEXModule(config_view)
-            item = _history_item(record, self.provider)
-            remote_id = str(record.get("remote_id") or "").strip()
-            rating_key = remote_id if remote_id.isdigit() else ""
-            if not rating_key and _plex_resolve_rating_key is not None:
-                rating_key = str(_plex_resolve_rating_key(module, item) or "")
-            if not rating_key:
-                return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Plex item could not be resolved.", error_code="not_found", remote_id=remote_id, canonical_key=str(record.get("canonical_key") or ""))
-            server = getattr(getattr(module, "client", None), "server", None)
-            if not server:
-                return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Plex Media Server is not available.", error_code="server_unavailable", retryable=True, remote_id=remote_id, canonical_key=str(record.get("canonical_key") or ""))
-            obj = server.fetchItem(int(rating_key))
-            mark_unplayed = getattr(obj, "markUnplayed", None) or getattr(obj, "markUnwatched", None)
-            if callable(mark_unplayed):
-                mark_unplayed()
-            else:
-                server.query(f"/:/unscrobble?key={rating_key}&identifier=com.plexapp.plugins.library")
-            return PlaybackActionResult(True, self.provider, instance_id, "remove_progress", remote_id=remote_id or rating_key, canonical_key=str(record.get("canonical_key") or ""), message="Playback record removed from Plex.")
-        except Exception:
-            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Plex remove progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
 
     def mark_watched(
         self,


### PR DESCRIPTION
# Pull request

## Change

**Now Playing card**

* Plex scrobble now sends the resolved `duration_ms` for movies and episodes.
* currently_watching.py keeps the previous duration_ms and cover when an active update does not include them. Other fields still update normally. Stopped behavior is unchanged.
* playingcard.js now keeps a duration cache per stream and falls back to metadata runtime when needed. This fixes the flickering time left label and lets episode time left show when a duration can be found.
* Desktop layout now stays within the poster height. The overview is limited to 3 lines, the title to 2 lines, and the More expander is disabled so the card cannot grow past the poster.

**Plex Playback Progress remove**

* plex/_progress.py::remove() now clears resume progress through Plex methods first, with /:/unscrobble as fallback.
* After clearing, it fetches the item again and checks viewOffset.
* If the resume point is still there, it returns reason: "clear_progress_unconfirmed" instead of reporting success.
* Removed the unused _remove_plex_progress method and its import.

## Why

Movie time left flickered because duration was missing or overwritten by later updates.

Episode time left did not show because duration was often missing.

Long overviews could make the card taller than the poster.

Removing a Plex resume item looked successful, but the item stayed in the list because the old timeline write did not reliably clear Plex resume state.

## Testing

* Simulated `currently_watching._update_stream`:
  * `duration_ms` and `cover` are preserved when omitted.
  * An incoming duration replaces the previous one.
  * Stale fields still update.
  * `stopped` clears the stream.
* Simulated `plex/_progress.remove()`:
  * Confirmed clear returns `applied`.
  * Persisting offset returns `clear_progress_unconfirmed`.
  * The fallback path through `/:/unscrobble` was covered.

## Issue

Relates to #366