### PR TITLE
Fix: enforce library whitelist and auto-reload routes at save

### DIFF
--- a/api/configAPI.py
+++ b/api/configAPI.py
@@ -17,6 +17,7 @@ from providers.scrobble.sources import source_enabled
 from _logging import log as BASE_LOG
 
 BACKUP_LOG = BASE_LOG.child("BACKUP")
+WATCH_LOG = BASE_LOG.child("WATCH")
 
 def _env() -> dict[str, Any]:
     try:
@@ -132,6 +133,81 @@ def _after_config_save(env: dict[str, Any], cfg: dict[str, Any]) -> None:
                 getattr(sched, "stop", lambda: None)()
     except Exception:
         pass
+
+def _stable_json(v: Any) -> str:
+    try:
+        return json.dumps(v, sort_keys=True, separators=(",", ":"), default=str)
+    except Exception:
+        return str(v)
+
+
+def _watch_runtime_fingerprint(cfg: dict[str, Any]) -> str:
+    sc = cfg.get("scrobble")
+    sc = sc if isinstance(sc, dict) else {}
+    watch = sc.get("watch")
+    watch = watch if isinstance(watch, dict) else {}
+    sources = sc.get("sources")
+    sources = sources if isinstance(sources, dict) else {}
+    routes = watch.get("routes")
+    filters = watch.get("filters")
+    relevant = {
+        "scrobble_enabled": bool(sc.get("enabled")),
+        "mode": str(sc.get("mode") or ""),
+        "source_watcher": bool(sources.get("watcher", sources.get("watch", False))),
+        "watch_autostart": bool(watch.get("autostart")),
+        "routes": routes if isinstance(routes, list) else None,
+        "provider": watch.get("provider"),
+        "sink": watch.get("sink"),
+        "filters": filters if isinstance(filters, dict) else {},
+    }
+    return _stable_json(relevant)
+
+
+def _watch_runtime_changed(before: dict[str, Any], after: dict[str, Any]) -> bool:
+    return _watch_runtime_fingerprint(before) != _watch_runtime_fingerprint(after)
+
+
+def _watcher_running(app: Any) -> bool:
+    try:
+        from providers.scrobble import watch_manager as wm
+        st = wm.status(app) or {}
+    except Exception:
+        return False
+    try:
+        for g in (st.get("groups") or []):
+            if isinstance(g, dict) and g.get("running"):
+                return True
+        for r in (st.get("routes") or []):
+            if isinstance(r, dict) and r.get("running"):
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def _apply_watch_runtime(app: Any, cfg: dict[str, Any], watcher_was_running: bool) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    try:
+        from providers.scrobble import watch_manager as wm
+    except Exception as e:
+        WATCH_LOG.error(f"watcher runtime refresh unavailable: {type(e).__name__}: {e}")
+        return {"watcher_reload_error": f"watch_manager unavailable: {e}"}
+    try:
+        if not source_enabled(cfg, "watcher"):
+            wm.stop_all(app, wait=False)
+            out["watcher_stopped"] = True
+            WATCH_LOG.info("Watcher source disabled; stopped watcher runtime")
+        else:
+            autostart = bool(((cfg.get("scrobble") or {}).get("watch") or {}).get("autostart"))
+            if watcher_was_running or autostart:
+                wm.start_from_config(app)
+                out["watcher_reloaded"] = True
+                WATCH_LOG.info("Watcher routing changed; refreshed watcher runtime")
+    except Exception as e:
+        out["watcher_reload_error"] = str(e)
+        WATCH_LOG.error(f"watcher runtime refresh failed: {type(e).__name__}: {e}")
+    return out
+
 
 def _norm_ver(v: str | None) -> str:
     raw = (v or "").strip()
@@ -324,7 +400,7 @@ def api_config() -> JSONResponse:
     return _nostore(JSONResponse(cfg))
 
 @router.post("/config")
-def api_config_save(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
+def api_config_save(request: Request, payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
     env = _env()
     incoming = dict(payload or {})
     current  = dict(env["load"]() or {})
@@ -457,11 +533,22 @@ def api_config_save(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
     except Exception:
         pass
 
+    # Detect watcher-routing changes
+    watch_runtime_changed = _watch_runtime_changed(current, cfg)
+    watcher_was_running = _watcher_running(request.app) if watch_runtime_changed else False
+
     env["save"](cfg)
 
     _after_config_save(env, cfg)
 
-    return {"ok": True}
+    result: dict[str, Any] = {"ok": True}
+    if watch_runtime_changed:
+        try:
+            result.update(_apply_watch_runtime(request.app, cfg, watcher_was_running))
+        except Exception as e:
+            result["watcher_reload_error"] = str(e)
+            WATCH_LOG.error(f"watcher runtime refresh failed: {type(e).__name__}: {e}")
+    return result
 
 @router.post("/config/migrate")
 def api_config_migrate() -> dict[str, Any]:

--- a/providers/scrobble/emby/watch.py
+++ b/providers/scrobble/emby/watch.py
@@ -726,18 +726,23 @@ class EmbyWatchService:
 
     def _passes_filters(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> bool:
         sk = str(ev.session_key or "")
-        if sk and sk in self._allowed_sessions:
-            return True
-
         libs = self._scrobble_whitelist(cfg)
+
         if libs:
+            # A whitelist must be validated per event
             view_id = self._session_view_id(ev.raw or {}, cfg)
             if not view_id or view_id not in libs:
+                if sk:
+                    self._allowed_sessions.discard(sk)
                 if _is_debug():
                     item = ((ev.raw or {}).get("NowPlayingItem") or {}) if isinstance(ev.raw, Mapping) else {}
                     name = (item.get("Name") or item.get("SeriesName") or "?") if isinstance(item, Mapping) else "?"
                     self._dbg(f"event filtered by scrobble whitelist: view={view_id or 'none'} allowed={sorted(libs)} item={name}")
                 return False
+            return True
+
+        if sk and sk in self._allowed_sessions:
+            return True
 
         if sk:
             self._allowed_sessions.add(sk)
@@ -1100,6 +1105,10 @@ class EmbyWatchService:
                 except Exception:
                     pass
                 try:
+                    self._allowed_sessions.discard(sid)
+                except Exception:
+                    pass
+                try:
                     self._cw_last_heartbeat.pop(sid, None)
                 except Exception:
                     pass
@@ -1149,6 +1158,10 @@ class EmbyWatchService:
                 del self._last[sid]
                 try:
                     self._filtered_sessions.discard(sid)
+                except Exception:
+                    pass
+                try:
+                    self._allowed_sessions.discard(sid)
                 except Exception:
                     pass
                 try:

--- a/providers/scrobble/jellyfin/watch.py
+++ b/providers/scrobble/jellyfin/watch.py
@@ -724,18 +724,23 @@ class JellyfinWatchService:
 
     def _passes_filters(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> bool:
         sk = str(ev.session_key or "")
-        if sk and sk in self._allowed_sessions:
-            return True
-
         libs = self._scrobble_whitelist(cfg)
+
         if libs:
+            # A whitelist must be validated per event
             view_id = self._session_view_id(ev.raw or {}, cfg)
             if not view_id or view_id not in libs:
+                if sk:
+                    self._allowed_sessions.discard(sk)
                 if _is_debug():
                     item = ((ev.raw or {}).get("NowPlayingItem") or {}) if isinstance(ev.raw, Mapping) else {}
                     name = (item.get("Name") or item.get("SeriesName") or "?") if isinstance(item, Mapping) else "?"
                     self._dbg(f"event filtered by scrobble whitelist: view={view_id or 'none'} allowed={sorted(libs)} item={name}")
                 return False
+            return True
+
+        if sk and sk in self._allowed_sessions:
+            return True
 
         if sk:
             self._allowed_sessions.add(sk)
@@ -1099,6 +1104,10 @@ class JellyfinWatchService:
                 except Exception:
                     pass
                 try:
+                    self._allowed_sessions.discard(sid)
+                except Exception:
+                    pass
+                try:
                     self._cw_last_heartbeat.pop(sid, None)
                 except Exception:
                     pass
@@ -1148,6 +1157,10 @@ class JellyfinWatchService:
                 del self._last[sid]
                 try:
                     self._filtered_sessions.discard(sid)
+                except Exception:
+                    pass
+                try:
+                    self._allowed_sessions.discard(sid)
                 except Exception:
                     pass
                 try:

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -742,10 +742,20 @@ class WatchService:
         cache_key: str | None = None
         if sk:
             cache_key = f"{sk}|{_norm_user(ev.account or '')}|{str(ev.server_uuid or '').strip().lower()}"
-            if cache_key in self._allowed_sessions:
-                return True
 
         cfg = self._active_cfg()
+
+        # # A whitelist must be validated per event
+        libs = _as_set_str((((cfg.get("plex") or {}).get("scrobble") or {}).get("libraries")))
+        if libs:
+            sid = self._plex_section_id(ev)
+            if not sid or sid not in libs:
+                if cache_key:
+                    self._allowed_sessions.discard(cache_key)
+                return False
+
+        if cache_key and cache_key in self._allowed_sessions:
+            return True
 
         def _allow() -> bool:
             if cache_key:
@@ -756,13 +766,6 @@ class WatchService:
         if bool(filt.get("ignore_live_tv_dvr")) and _is_live_tv_dvr_event(ev):
             return False
 
-        libs = _as_set_str((((cfg.get("plex") or {}).get("scrobble") or {}).get("libraries")))
-        if libs:
-            sid = self._plex_section_id(ev)
-            if not sid:
-                return False
-            if sid not in libs:
-                return False
         return _allow()
 
     def _find_rating_key(self, raw: dict[str, Any]) -> int | None:


### PR DESCRIPTION
# Pull request

## Change

- Scrobble watchers (Emby, Jellyfin, Plex) now validate the scrobble library whitelist on every event instead of trusting a cached session. A session that once played an allowed library can no longer scrobble a later item from a blocked library. The fast allow-cache is used only when no whitelist is set; blocked and cleaned-up sessions are dropped from it.
- Saving `/api/config` now refreshes the watcher runtime automatically when watcher routing changes

## Why

- Items from unselected libraries (e.g. a Kids movie) were still scrobbled, because the session cache was checked before the library whitelist. This was more Emby specific but same guard has now been implemented for emby, jellyfin and plex watcher.
- After editing watcher routes in the UI, the running service kept the old route graph until a manual Watcher Reload or restart.

## Testing

- Manually tested with Emby, Jellyfin and Plex: unselected libraries are now blocked
- Added unit tests: watcher whitelist filtering for Emby and Jellyfin (including the same-session allowed-then-blocked case), and config-save runtime reload (route add/change, source disabled stops, autostart start-vs-refresh

## Issue

Relates to #338
