### PR TITLE
Fix: retry unresolved writes until blackbox promotion

### DIFF
--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -578,8 +578,11 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
                     t["blocked"] += int(o.get("adds_blocked", 0) or 0) + int(o.get("removes_blocked", 0) or 0)
                 elif msg == "blocked.manual":
                     t["blocked"] += int(o.get("blocked_items", o.get("blocked_keys", 0)) or 0)
-                elif msg == "blocked.unresolved":
-                    t["blocked"] += int(o.get("blocked", 0) or 0)
+                elif msg == "blocked.counts":
+                    t["blocked"] += int(o.get("blocked_blackbox", 0) or 0) + int(o.get("blocked_manual", 0) or 0)
+
+            elif ev == "blocked.counts":
+                t["blocked"] += int(o.get("blocked_blackbox", 0) or 0) + int(o.get("blocked_manual", 0) or 0)
 
             elif ev == "run:done":
                 t["blocked"] = max(t["blocked"], int(o.get("blocked", 0) or 0))

--- a/assets/js/modals/pair-config/help.js
+++ b/assets/js/modals/pair-config/help.js
@@ -11,6 +11,8 @@ export const HELP_TEXT = {
   "gl-observed": "Include observed deletes\nIf off, observed deletes are ignored and delta-delete providers are disabled (safer).",
   "gl-bb-enable": "Blackbox: Enabled\nAutomatic flapper protection and failure quarantine.",
   "gl-bb-pair": "Blackbox: Pair scoped\nKeep blackbox decisions per pair instead of global.",
+  "gl-bb-section": "Blackbox\nUnresolved is only a reporting state: items that fail to write are recorded, shown in diagnostics, and retried on every sync. Blackbox is the quarantine state and the only thing that stops an item from being planned again.",
+  "gl-bb-promote": "Promote after (failed writes)\nNumber of consecutive failed write attempts before an item is moved to the blackbox. Until then the item keeps being retried; unresolved alone never blocks it.",
   "gl-section-main": "Globals\nThese are the overall safety and behavior settings for this connection. The defaults are good enough for most users, so only change them when you have a specific reason.",
   "gl-section-advanced": "Advanced\nThese are extra retention and blackbox safety controls. The defaults are good enough for most users, so you usually do not need to change anything here.",
 

--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -212,7 +212,7 @@ function defaultState(){
     globals:{
       dry_run:false,verify_after_write:false,drop_guard:false,allow_mass_delete:true,one_way_remove_mode:"source_deletes",
       tombstone_ttl_days:30,include_observed_deletes:true,
-      blackbox:{enabled:true,promote_after:1,unresolved_days:0,cooldown_days:30,pair_scoped:true,block_adds:true,block_removes:true}
+      blackbox:{enabled:true,promote_after:3,cooldown_days:30,pair_scoped:true,block_adds:true,block_removes:true}
     },
     cfgRaw:null,
     visited:new Set()
@@ -332,7 +332,7 @@ async function loadConfigBits(state){
     tombstone_ttl_days:Number.isFinite(s.tombstone_ttl_days)?s.tombstone_ttl_days:30,
     include_observed_deletes:!!s.include_observed_deletes,
     blackbox:Object.assign(
-      {enabled:true,promote_after:1,unresolved_days:0,cooldown_days:30,pair_scoped:true,block_adds:true,block_removes:true},
+      {enabled:true,promote_after:3,cooldown_days:30,pair_scoped:true,block_adds:true,block_removes:true},
       s.blackbox||{}
     ),
     runtime:Object.assign(
@@ -940,14 +940,14 @@ function renderFeaturePanel(state){
     right.innerHTML=`<div class="panel-title">Advanced <button type="button" class="cx-help material-symbols-rounded" data-tip-id="gl-section-advanced">help</button></div>
       <div class="opt-row"><label for="gl-ttl">Tombstone TTL (days)</label><input id="gl-ttl" class="input" type="number" min="0" step="1" value="${g.tombstone_ttl_days??30}"></div><div class="muted">Keep delete markers to avoid re-adding.</div>
       <div class="opt-row"><label for="gl-observed">Include observed deletes</label><label class="switch"><input id="gl-observed" type="checkbox" ${g.include_observed_deletes?"checked":""}><span class="slider"></span></label></div>
-      <div class="panel-title small" style="margin-top:10px">Blackbox</div>
+      <div class="panel-title small" style="margin-top:10px">Blackbox <button type="button" class="cx-help material-symbols-rounded" data-tip-id="gl-bb-section">help</button></div>
       <div class="grid2 compact">
         <div class="opt-row"><label for="gl-bb-enable">Enabled</label><label class="switch"><input id="gl-bb-enable" type="checkbox" ${bb.enabled?"checked":""}><span class="slider"></span></label></div>
         <div class="opt-row"><label for="gl-bb-pair">Pair scoped</label><label class="switch"><input id="gl-bb-pair" type="checkbox" ${bb.pair_scoped?"checked":""}><span class="slider"></span></label></div>
-        <div class="opt-row"><label for="gl-bb-promote">Promote after (days)</label><input id="gl-bb-promote" class="input small" type="number" min="0" max="365" step="1" value="${bb.promote_after??1}"></div>
-        <div class="opt-row"><label for="gl-bb-unresolved">Unresolved days</label><input id="gl-bb-unresolved" class="input small" type="number" min="0" max="365" step="1" value="${bb.unresolved_days??0}"></div>
+        <div class="opt-row"><label for="gl-bb-promote">Promote after (failed writes) <button type="button" class="cx-help material-symbols-rounded" data-tip-id="gl-bb-promote">help</button></label><input id="gl-bb-promote" class="input small" type="number" min="0" max="365" step="1" value="${bb.promote_after??3}"></div>
         <div class="opt-row"><label for="gl-bb-cooldown">Cooldown days</label><input id="gl-bb-cooldown" class="input small" type="number" min="0" max="365" step="1" value="${bb.cooldown_days??30}"></div>
-      </div>`;
+      </div>
+      <div class="muted">Unresolved is a reporting state: failed writes are logged and retried every sync. Blackbox is the quarantine state: after this many failed writes an item is blackboxed and only then stops being planned.</div>`;
     return;
   }
 
@@ -1853,7 +1853,6 @@ function bindChangeHandlers(state,root){
         enabled:!!Q("#gl-bb-enable")?.checked,
         pair_scoped:!!Q("#gl-bb-pair")?.checked,
         promote_after:Math.min(365,Math.max(0,parseInt(Q("#gl-bb-promote")?.value||"0",10)||0)),
-        unresolved_days:Math.min(365,Math.max(0,parseInt(Q("#gl-bb-unresolved")?.value||"0",10)||0)),
         cooldown_days:Math.min(365,Math.max(0,parseInt(Q("#gl-bb-cooldown")?.value||"0",10)||0))
       };
       bb.block_adds = bb.enabled;
@@ -1948,7 +1947,6 @@ async function saveConfigBits(state){
         enabled:!!ID("gl-bb-enable")?.checked,
         pair_scoped:!!ID("gl-bb-pair")?.checked,
         promote_after:Math.min(365,Math.max(0,parseInt(ID("gl-bb-promote")?.value||"0",10)||0)),
-        unresolved_days:Math.min(365,Math.max(0,parseInt(ID("gl-bb-unresolved")?.value||"0",10)||0)),
         cooldown_days:Math.min(365,Math.max(0,parseInt(ID("gl-bb-cooldown")?.value||"0",10)||0))
       };
       bb.block_adds = bb.enabled; bb.block_removes = bb.enabled;

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -531,8 +531,7 @@ DEFAULT_CFG: dict[str, Any] = {
         # Blackbox (including flapper protection)
         "blackbox": {
             "enabled": True,                            # Turn off to fully disable blackbox logic
-            "promote_after": 1,                         # Promote an item to blackbox after N consecutive unresolved/fail events
-            "unresolved_days": 0,                       # Minimum unresolved age (days) before it counts (0 = immediate)
+            "promote_after": 3,                         # Promote an item to blackbox after N consecutive failed writes
             "pair_scoped": True,                        # Track per source-target pair to avoid blocking the same title elsewhere
             "cooldown_days": 30,                        # Auto-prune/decay blackbox entries after this cooldown period
             "block_adds": True,                         # When blackboxed, block planned ADDs for that item

--- a/cw_platform/orchestrator/_blackbox.py
+++ b/cw_platform/orchestrator/_blackbox.py
@@ -58,7 +58,6 @@ def _flap_path(dst: str, feature: str, pair: str | None = None) -> Path:
 _DEFAULT_BB: dict[str, Any] = {
     "enabled": True,
     "promote_after": 3,
-    "unresolved_days": 0,
     "pair_scoped": True,
     "cooldown_days": 30,
     "block_adds": True,
@@ -124,43 +123,6 @@ def _promote(dst: str, feature: str, key: str, *, reason: str, ts: int, pair: st
         data[key] = {"reason": str(reason or "flapper"), "since": int(ts)}
         _write_json(path, data)
 
-def maybe_promote_to_blackbox(
-    dst: str,
-    feature: str,
-    key: str,
-    *,
-    cfg: Mapping[str, Any],
-    ts: int | None = None,
-    pair: str | None = None,
-    unresolved_map: Mapping[str, Mapping[str, Any]] | None = None,
-) -> dict[str, Any]:
-    ts = int(ts or time.time())
-    bb = _load_bb_cfg(cfg)
-    promote_after = int(bb.get("promote_after", 3) or 3)
-    unresolved_days = int(bb.get("unresolved_days", 0) or 0)
-    pair_scoped = bool(bb.get("pair_scoped", True))
-    if not pair_scoped:
-        pair = None
-
-    counters = load_flap_counters(dst, feature)
-    row = counters.get(key) or {}
-    cons = int(row.get("consecutive") or 0)
-
-    if cons >= promote_after:
-        _promote(dst, feature, key, reason=f"flapper:consecutive>={promote_after}", ts=ts, pair=pair)
-        return {"promoted": True, "reason": "consecutive", "since": ts}
-
-    if unresolved_days > 0 and unresolved_map:
-        meta = unresolved_map.get(key) or {}
-        uts = int(meta.get("ts") or 0)
-        if uts > 0:
-            age_days = (ts - uts) / 86400.0
-            if age_days >= unresolved_days:
-                _promote(dst, feature, key, reason=f"unresolved_age>={unresolved_days}d", ts=ts, pair=pair)
-                return {"promoted": True, "reason": "unresolved_age", "since": ts}
-
-    return {"promoted": False, "reason": None, "since": None}
-
 def _normalize_keys(keys: Iterable[str] | None) -> tuple[list[str], list[str]]:
     ordered: list[str] = []
     unique: list[str] = []
@@ -186,7 +148,6 @@ def record_attempts(
     op: str = "add",
     pair: str | None = None,
     cfg: Mapping[str, Any] | None = None,
-    unresolved_map: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     bb = _load_bb_cfg(cfg)
     ts = int(time.time())
@@ -195,7 +156,6 @@ def record_attempts(
     flap_data = _read_json(flap_path)
 
     promote_after = int(bb.get("promote_after", 3) or 3)
-    unresolved_days = int(bb.get("unresolved_days", 0) or 0)
     pair_scoped = bool(bb.get("pair_scoped", True))
     scoped_pair = pair if pair_scoped else None
     bb_path = _bb_path(dst, feature, scoped_pair)
@@ -219,14 +179,6 @@ def record_attempts(
         if cons >= promote_after:
             should_promote = True
             promote_reason = f"flapper:consecutive>={promote_after}"
-        elif unresolved_days > 0 and unresolved_map:
-            meta = unresolved_map.get(key) or {}
-            uts = int(meta.get("ts") or 0)
-            if uts > 0:
-                age_days = (ts - uts) / 86400.0
-                if age_days >= unresolved_days:
-                    should_promote = True
-                    promote_reason = f"unresolved_age>={unresolved_days}d"
 
         if should_promote and key not in bb_data:
             bb_data[key] = {"reason": promote_reason or str(reason or "flapper"), "since": int(ts)}

--- a/cw_platform/orchestrator/_pairs_blocklist.py
+++ b/cw_platform/orchestrator/_pairs_blocklist.py
@@ -64,12 +64,12 @@ def blocked_keys_for_destination(
     pair_key: str | None = None,
     cross_feature_unresolved: bool = True,
 ) -> set[str]:
-    g_tomb, p_tomb, unr, bb = _breakdown(
+    g_tomb, p_tomb, _unr, bb = _breakdown(
         state_store, dst, feature,
         pair_key=pair_key,
         cross_feature_unresolved=cross_feature_unresolved,
     )
-    return g_tomb | p_tomb | unr | bb
+    return g_tomb | p_tomb | bb
 
 def _ts_epoch(v: Any) -> int | None:
     if v is None:
@@ -206,10 +206,16 @@ def apply_blocklist(
         blackbox = set()
 
     pair_tomb_eff: set[str] = set() if ignore_pair_tomb else set(pair_tomb)
-    bl = global_tomb | pair_tomb_eff | unresolved | blackbox
+    bl = global_tomb | pair_tomb_eff | blackbox
 
-    if emit is not None:
+    items_in = list(items or [])
+    input_count = len(items_in)
+
+    def _emit_counts(result_list: list[dict[str, Any]]) -> None:
+        if emit is None:
+            return
         try:
+            kept_bb = filter_with(state_store, items_in, extra_block=blackbox) if blackbox else items_in
             emit(
                 "debug",
                 msg="blocked.counts",
@@ -219,29 +225,31 @@ def apply_blocklist(
                 blocked_global_tomb=0,
                 blocked_pair_tomb=len(pair_tomb_eff),
                 blocked_unresolved=len(unresolved),
-                blocked_blackbox=len(blackbox),
-                blocked_total=len(bl),
+                blocked_blackbox=input_count - len(kept_bb),
+                blocked_total=input_count - len(result_list),
             )
         except Exception:
             pass
 
-    items_list = list(items or [])
-    if not items_list or not bl:
-        return items_list
+    if not items_in or not bl:
+        _emit_counts(items_in)
+        return items_in
 
     feature_norm = str(feature or "").lower()
     if feature_norm not in {"history", "ratings"}:
-        return filter_with(state_store, items_list, extra_block=bl)
+        result = filter_with(state_store, items_in, extra_block=bl)
+        _emit_counts(result)
+        return result
 
-    hard = (global_tomb | unresolved | blackbox)
-    if hard:
-        items_list = filter_with(state_store, items_list, extra_block=hard)
+    hard = (global_tomb | blackbox)
+    filtered = filter_with(state_store, items_in, extra_block=hard) if hard else items_in
 
     if ignore_pair_tomb or not pair_tomb_eff:
-        return items_list
+        _emit_counts(filtered)
+        return filtered
 
     out: list[dict[str, Any]] = []
-    for it in items_list:
+    for it in filtered:
         try:
             blocked = (
                 _history_is_blocked_by_tomb(it, pmap)
@@ -257,4 +265,5 @@ def apply_blocklist(
             except Exception:
                 pass
         out.append(it)
+    _emit_counts(out)
     return out

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -26,7 +26,7 @@ from ._snapshots import (
 )
 from ._applier import apply_add, apply_remove, apply_update
 from ._chunking import effective_chunk_size
-from ._unresolved import load_unresolved_keys, record_unresolved
+from ._unresolved import load_unresolved_keys, record_unresolved, clear_unresolved
 from ._planner import diff, diff_ratings, diff_progress, _pick_rating
 from ._phantoms import PhantomGuard
 from ._tombstones import clear_items_for_feature
@@ -1138,25 +1138,13 @@ def run_one_way_feature(
     except Exception:
         unresolved_known = set()
 
-    if unresolved_known and adds:
-        _before = len(adds)
+    if unresolved_known:
         try:
-            adds = [it for it in adds if _ck(it) not in unresolved_known]
+            retried = sum(1 for it in adds if _ck(it) in unresolved_known) + sum(1 for it in updates if _ck(it) in unresolved_known)
         except Exception:
-            pass
-        _blocked = _before - len(adds)
-        if _blocked:
-            emit("debug", msg="blocked.unresolved", feature=feature, dst=dst, blocked=_blocked)
-
-    if unresolved_known and updates:
-        _before = len(updates)
-        try:
-            updates = [it for it in updates if _ck(it) not in unresolved_known]
-        except Exception:
-            pass
-        _blocked = _before - len(updates)
-        if _blocked:
-            emit("debug", msg="blocked.unresolved", feature=feature, dst=dst, blocked=_blocked)
+            retried = 0
+        if retried:
+            emit("debug", msg="unresolved.retry", feature=feature, dst=dst, retried=retried)
 
     emit("one:plan", src=src, dst=dst, feature=feature,
         adds=len(adds), removes=len(removes), updates=len(updates),
@@ -1396,6 +1384,7 @@ def run_one_way_feature(
             
                 if success_keys and not ambiguous_partial:
                     record_success(dst, feature, success_keys, pair=pair_key, cfg=cfg)
+                    clear_unresolved(dst, feature, success_keys)
                     clear_items_for_feature(
                         ctx.state_store,
                         dbg,

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -80,7 +80,7 @@ from ._snapshots import (
 from ._applier import apply_add, apply_remove, apply_update
 from ._chunking import effective_chunk_size
 from ._tombstones import clear_items_for_feature, keys_for_feature
-from ._unresolved import load_unresolved_keys, record_unresolved
+from ._unresolved import load_unresolved_keys, record_unresolved, clear_unresolved
 from ._phantoms import PhantomGuard  # type: ignore[attr-defined]
 
 from ._pairs_blocklist import apply_blocklist
@@ -1342,19 +1342,12 @@ def _two_way_sync(
     try:
         unresolved_A = set(load_unresolved_keys(a, feature, cross_features=_cross_feature_unresolved(feature)) or [])
         unresolved_B = set(load_unresolved_keys(b, feature, cross_features=_cross_feature_unresolved(feature)) or [])
-
-        preA, preB = len(add_to_A), len(add_to_B)
-        add_to_A = [it for it in add_to_A if _ck(it) not in unresolved_A]
-        add_to_B = [it for it in add_to_B if _ck(it) not in unresolved_B]
-
-        blkA = preA - len(add_to_A)
-        blkB = preB - len(add_to_B)
-        if blkA:
-            emit("debug", msg="blocked.counts", feature=feature, dst=a,
-                 pair=f"{a}-{b}", blocked_unresolved=blkA, blocked_total=blkA)
-        if blkB:
-            emit("debug", msg="blocked.counts", feature=feature, dst=b,
-                 pair=f"{a}-{b}", blocked_unresolved=blkB, blocked_total=blkB)
+        retryA = sum(1 for it in add_to_A if _ck(it) in unresolved_A)
+        retryB = sum(1 for it in add_to_B if _ck(it) in unresolved_B)
+        if retryA:
+            emit("debug", msg="unresolved.retry", feature=feature, dst=a, pair=f"{a}-{b}", retried=retryA)
+        if retryB:
+            emit("debug", msg="unresolved.retry", feature=feature, dst=b, pair=f"{a}-{b}", retried=retryB)
     except Exception:
         pass
 
@@ -1720,6 +1713,7 @@ def _two_way_sync(
             
                 if success_A:
                     record_success(a, feature, success_A, pair=pair_key, cfg=cfg)
+                    clear_unresolved(a, feature, success_A)
                     clear_items_for_feature(
                         ctx.state_store,
                         dbg,
@@ -1836,6 +1830,7 @@ def _two_way_sync(
             
                 if success_B:
                     record_success(b, feature, success_B, pair=pair_key, cfg=cfg)
+                    clear_unresolved(b, feature, success_B)
                     clear_items_for_feature(
                         ctx.state_store,
                         dbg,

--- a/cw_platform/orchestrator/_unresolved.py
+++ b/cw_platform/orchestrator/_unresolved.py
@@ -14,6 +14,7 @@ __all__ = [
     "load_unresolved_keys",
     "load_unresolved_map",
     "record_unresolved",
+    "clear_unresolved",
 ]
 
 STATE_DIR = Path("/config/.cw_state")
@@ -278,3 +279,48 @@ def record_unresolved(
 
     ok, error = _atomic_write(path, data)
     return {"ok": ok, "count": added if ok else 0, "path": str(path), **({"error": error} if error else {})}
+
+
+def clear_unresolved(
+    dst: str,
+    feature: str,
+    keys: Iterable[str],
+) -> dict[str, Any]:
+    key_set = {str(k) for k in (keys or []) if k}
+    if not dst or not key_set:
+        return {"ok": True, "count": 0}
+
+    removed = 0
+
+    pend = _pending_path(dst, feature)
+    pdata = _read_json(pend)
+    if pdata:
+        pchanged = False
+        klist = pdata.get("keys")
+        if isinstance(klist, list):
+            kept = [k for k in klist if str(k) not in key_set]
+            if len(kept) != len(klist):
+                removed += len(klist) - len(kept)
+                pdata["keys"] = kept
+                pchanged = True
+        for bucket in ("items", "hints"):
+            sub = pdata.get(bucket)
+            if isinstance(sub, dict):
+                for k in [k for k in sub.keys() if str(k) in key_set]:
+                    sub.pop(k, None)
+                    pchanged = True
+        if pchanged:
+            _atomic_write(pend, pdata)
+
+    blk = _blocking_path(dst, feature)
+    bdata = _read_json(blk)
+    if bdata:
+        bchanged = False
+        for k in [k for k in bdata.keys() if str(k) in key_set]:
+            bdata.pop(k, None)
+            removed += 1
+            bchanged = True
+        if bchanged:
+            _atomic_write(blk, bdata)
+
+    return {"ok": True, "count": removed}


### PR DESCRIPTION
# Pull request

## Change

- Reworked unresolved handling.
- Unresolved items are no longer blocked before diff planning.
- apply_blocklist no longer adds unresolved keys to the filtering set. 
- Unresolved counts remain in blocked.counts for reporting only. 
- Removed the separate unresolved hard filter from one way and two way pair flows.
- Failed writes are now recorded, reported and retried on every sync. 
- Successful writes now clear prior unresolved state through clear_unresolved in _unresolved.py. 
- Fixed the run summary Total blocked counter. 
- syncAPI now tallies blackbox and manual blocks from blocked.counts. 

UI changes:
- Promote after (days) was renamed to Promote after (failed writes).
- Help tooltips now explain that unresolved is a reporting and retry state, while blackbox is a quarantine state.
- The promote_after default is now aligned with the backend default of 3. This gives items a real retry window.
- Removed the unresolved_days setting end to end. This includes the UI field, config template and defaults.
- unresolved_days was a no op. 
- Deleted maybe_promote_to_blackbox. 

## Why

- A failed write was stored as unresolved.
- On the next sync, apply_blocklist filtered the item before planning. Because of that, the item was never retried.
- This meant promote_after could never advance. 
- That behavior was incorrect. Unresolved should only report retryable failures. Blackbox should be the only quarantine state.
- The old promote_after default of 1 also made this worse. It blackboxed an item after the first failure, with no retry window.
- The unresolved_days setting added more confusion. It was shown in the UI, but did nothing.

## Testing

- Added tests/test_unresolved_blackbox_retry.py.

The test covers the full sequence:
- Unresolved is recorded after a failed write.
- The item is not filtered during syncs 1 to 3.
- The item is blackboxed once failed attempts reach promote_after.
- The item is filtered by blackbox after promotion.
- Unresolved state and flap state are cleared after a successful write before promotion.
- The test also checks blocked_blackbox and blocked_total counts used by the run summary.

## Issue

NA
