### PR TITLE
Change: scrobble logs with distinct module names

### DIFF
--- a/providers/scrobble/emby/watch.py
+++ b/providers/scrobble/emby/watch.py
@@ -583,12 +583,12 @@ class EmbyWatchService:
             return
         if BASE_LOG is not None:
             try:
-                BASE_LOG(msg, level=lvl, module="EMBY ")
+                BASE_LOG(msg, level=lvl, module="EMBY-WATCH")
                 return
             except Exception:
                 pass
         ts = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
-        print(f"[{ts}] [EMBY ] {lvl} {msg}")
+        print(f"[{ts}] [EMBY-WATCH] {lvl} {msg}")
 
     def _dbg(self, msg: str) -> None:
         self._log(msg, "DEBUG")

--- a/providers/scrobble/jellyfin/watch.py
+++ b/providers/scrobble/jellyfin/watch.py
@@ -581,12 +581,12 @@ class JellyfinWatchService:
             return
         if BASE_LOG is not None:
             try:
-                BASE_LOG(msg, level=lvl, module="JFIN ")
+                BASE_LOG(msg, level=lvl, module="JELLYFIN-WATCH")
                 return
             except Exception:
                 pass
         ts = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
-        print(f"[{ts}] [JFIN ] {lvl} {msg}")
+        print(f"[{ts}] [JELLYFIN-WATCH] {lvl} {msg}")
 
     def _dbg(self, msg: str) -> None:
         self._log(msg, "DEBUG")

--- a/providers/scrobble/mdblist/sink.py
+++ b/providers/scrobble/mdblist/sink.py
@@ -75,11 +75,11 @@ def _log(msg: str, lvl: str = "INFO") -> None:
         return
     if BASE_LOG is not None:
         try:
-            BASE_LOG(str(msg), level=level, module="MDBLIST")
+            BASE_LOG(str(msg), level=level, module="MDBLIST-SCROBBLE")
             return
         except Exception:
             pass
-    print(f"[MDBLIST:{level}] {msg}")
+    print(f"[MDBLIST-SCROBBLE:{level}] {msg}")
 
 
 def _merged_provider_block(cfg: Mapping[str, Any], key: str, instance_id: Any = None) -> dict[str, Any]:

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -390,12 +390,12 @@ class WatchService:
             return
         if BASE_LOG is not None:
             try:
-                BASE_LOG(msg, level=lvl, module="PLEX ")
+                BASE_LOG(msg, level=lvl, module="PLEX-WATCH")
                 return
             except Exception:
                 pass
         ts = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
-        print(f"[{ts}] [PLEX ] {lvl} {msg}")
+        print(f"[{ts}] [PLEX-WATCH] {lvl} {msg}")
 
     def _dbg(self, msg: str) -> None:
         self._log(msg, "DEBUG")

--- a/providers/scrobble/simkl/sink.py
+++ b/providers/scrobble/simkl/sink.py
@@ -78,11 +78,11 @@ def _log(msg: str, lvl: str = "INFO") -> None:
         return
     if BASE_LOG is not None:
         try:
-            BASE_LOG(str(msg), level=level, module="SIMKL")
+            BASE_LOG(str(msg), level=level, module="SIMKL-SCROBBLE")
             return
         except Exception:
             pass
-    print(f"[SIMKL:{level}] {msg}")
+    print(f"[SIMKL-SCROBBLE:{level}] {msg}")
 
 
 def _merged_provider_block(cfg: Mapping[str, Any], key: str, instance_id: Any = None) -> dict[str, Any]:

--- a/providers/scrobble/trakt/sink.py
+++ b/providers/scrobble/trakt/sink.py
@@ -69,11 +69,11 @@ def _log(msg: str, level: str = "INFO") -> None:
         return
     if BASE_LOG is not None:
         try:
-            BASE_LOG(str(msg), level=lvl, module="TRAKT")
+            BASE_LOG(str(msg), level=lvl, module="TRAKT-SCROBBLE")
             return
         except Exception:
             pass
-    print(f"[TRAKT:{lvl}] {msg}")
+    print(f"[TRAKT-SCROBBLE:{lvl}] {msg}")
 
 
 def _dbg(msg: str) -> None:


### PR DESCRIPTION
# Pull request

## Change

- Tags scrobble and watch log lines with a distinct module name per provider.
- Emby, jellyfin, mdblist, plex, simkl and trakt now log under a WATCH or SCROBBLE label.

## Why

Scrobble log lines used the plain provider name. They mixed with sync log lines and were hard to tell apart.

## Testing

Ran the scrobbler. Log lines show the new labels, for example PLEX-WATCH and MDBLIST-SCROBBLE.

## Issue

NA
