### PR TITLE
Change: rework orchestrator apply and pairing logic

### DIFF
--- a/.env.bash
+++ b/.env.bash
@@ -1,1 +1,0 @@
-export PATH="$(pwd)/.venv/Scripts:$PATH"

--- a/.gitignore
+++ b/.gitignore
@@ -11,38 +11,73 @@ dist/
 build/
 *.log
 
-# Virtualenv
+# Virtual environments
 .venv/
 env/
 venv/
 ENV/
 pip-wheel-metadata/
+
+# Databases
+*.sqlite
 *.sqlite3
+*.sqlite-wal
+*.sqlite-shm
+*.sqlite3-wal
+*.sqlite3-shm
 
-# VS Code
-.vscode/*
+# IDE and local tools
+.vscode/
+.idea/
+*.swp
+*.swo
+.agents/
+.codex/
 
-# Docker and Container data
+# Docker and container data
 docker-compose.override.yml
 
-# volumes/configs
+# Environment files
+.env
+.env.*
+!.env.example
+!.env.sample
+
+# CrossWatch configuration and secrets
 /config/
-state.json
-config.json
+/config.json
+/state.json
+/profiles.json
+/last_sync.json
+/statistics.json
+/watchlist_hide.json
+/.cw_master_key
+
+# CrossWatch runtime data
+/.cw_state/
+/.cw_cache/
+/.cw_databases/
+/.cw_provider/
+/backups/
+/snapshots/
+/sync_reports/
+/tls/
+/logs/
 
 # OS generated files
 .DS_Store
 Thumbs.db
+**/@eaDir/
 
-# Test config / local test artifacts
-**/pytest.ini
-pytest.ini
+# Test and coverage artifacts
 .pytest_cache/
 .coverage
 .coverage.*
 htmlcov/
 coverage.xml
 pytestdebug.log
+.pytest_tmp*/
+pytest-cache-files-*/
 
 # Tooling caches
 .mypy_cache/
@@ -51,7 +86,13 @@ pytestdebug.log
 .nox/
 *.sarif
 .hypothesis/
+
+# Node and Playwright
 node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-store/
 playwright-report/
 test-results/
 .playwright/
@@ -59,9 +100,6 @@ playwright/.auth/
 .env.playwright
 .env.playwright.local
 
-# CrossWatch runtime state
-.cw_state/
-
-# Local test/temp workspaces
-.pytest_tmp*/
-pytest-cache-files-*/
+# Temporary files
+*.tmp
+*.bak

--- a/cw_platform/event_archive/context.py
+++ b/cw_platform/event_archive/context.py
@@ -164,7 +164,13 @@ def build_context(
     return out
 
 
-def build_group_context(group_id: Any = None, *, conn: sqlite3.Connection | None = None) -> dict[str, Any]:
+def build_group_context(
+    group_id: Any = None,
+    *,
+    run_items_limit: int | None = 100,
+    run_items_offset: int = 0,
+    conn: sqlite3.Connection | None = None,
+) -> dict[str, Any]:
     from . import groups as _groups
     c = conn or get_conn()
     out: dict[str, Any] = {"ok": True, "group": None, "events": [], "context": {}, "related_groups": []}
@@ -187,8 +193,14 @@ def build_group_context(group_id: Any = None, *, conn: sqlite3.Connection | None
         out["related_groups"] = [r for r in rel if str(r.get("id")) != str(g.get("id"))]
     elif str(g.get("operation") or "") == "run":
         run_id = next((e.get("run_id") for e in out["events"] if e.get("run_id")), None)
-        out["run_items"] = _safe(lambda: _groups.run_problem_items(
-            run_id, g.get("first_event_at"), g.get("last_event_at"), conn=c).get("items")) or []
+        res = _safe(lambda: _groups.run_problem_items(
+            run_id, g.get("first_event_at"), g.get("last_event_at"),
+            limit=run_items_limit, offset=run_items_offset, conn=c,
+        )) or {}
+        out["run_items"] = res.get("items") or []
+        out["run_items_total"] = int(res.get("total") or 0)
+        out["run_items_limit"] = int(res.get("limit") or run_items_limit or out["run_items_total"] or 0)
+        out["run_items_offset"] = int(res.get("offset") or run_items_offset or 0)
     return out
 
 
@@ -613,7 +625,7 @@ def best_title(item_key: Any, *, title: Any = None, media_type: Any = None,
         or (season is not None and episode is not None)
     weak = (not cur) or bool(tag and cur.upper() == tag)
     new_title = cur or None
-    if weak:
+    if weak or is_episode:
         series = info.get("series_title")
         ititle = info.get("title")
         pick = (series or ititle) if is_episode else (ititle or series)

--- a/cw_platform/event_archive/db.py
+++ b/cw_platform/event_archive/db.py
@@ -72,7 +72,15 @@ def get_conn() -> sqlite3.Connection | None:
     with _LOCK:
         want = str(events_db_path())
         if _CONN is not None and _CONN_PATH == want:
-            return _CONN
+            if want == ":memory:" or Path(want).exists():
+                return _CONN
+            try:
+                _CONN.close()
+            except Exception:
+                pass
+            _CONN = None
+            _CONN_PATH = None
+            _LOG.warning("event archive database file missing; recreating %s", want)
         if _CONN is not None:
             try:
                 _CONN.close()

--- a/cw_platform/event_archive/groups.py
+++ b/cw_platform/event_archive/groups.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 import sqlite3
 import time
 from typing import Any
@@ -160,8 +161,19 @@ def _summarize(status: str, events: list[dict[str, Any]], feature: str, dst: str
 
     # one sync run with its pair/feature jobs and health checks
     if types & {"sync_run_started", "sync_run_finished"}:
-        pairs = sum(1 for e in events if e.get("event_type") == "plan_created")
-        tail = f", {pairs} pairs" if pairs else ""
+        plan_events = [e for e in events if e.get("event_type") == "plan_created"]
+        pair_keys = {str(e.get("pair_key") or "").strip().upper() for e in plan_events}
+        pair_keys.discard("")
+        pairs = len(pair_keys) or len(plan_events)
+        feats: list[str] = []
+        for e in plan_events:
+            fe = str(e.get("feature") or "").strip().lower()
+            if fe and fe not in feats:
+                feats.append(fe)
+        feat_disp = ", ".join(f.title() for f in feats)
+        tail = f", {pairs} {'pair' if pairs == 1 else 'pairs'}" if pairs else ""
+        if tail and feat_disp:
+            tail += f" ({feat_disp})"
         if "sync_run_finished" in types:
             fin = next((e for e in reversed(events) if e.get("event_type") == "sync_run_finished"), last)
             d = _detail(fin)
@@ -427,6 +439,15 @@ def _vis_clause(visibility: str | None) -> str | None:
     return "g.acknowledged_at IS NULL"
 
 
+def _event_vis_clause(visibility: str | None) -> str | None:
+    v = str(visibility or "open").strip().lower()
+    if v == "all":
+        return None
+    if v == "acknowledged":
+        return "(e.acknowledged_at IS NOT NULL OR EXISTS (SELECT 1 FROM event_groups eg WHERE eg.id=e.group_id AND eg.acknowledged_at IS NOT NULL))"
+    return "e.acknowledged_at IS NULL AND NOT EXISTS (SELECT 1 FROM event_groups eg WHERE eg.id=e.group_id AND eg.acknowledged_at IS NOT NULL)"
+
+
 _CATEGORY_STATUS = {
     "successful": ("resolved", "completed"),
     "problems": ("failed", "blackboxed", "unresolved"),
@@ -450,6 +471,8 @@ def list_groups(
     item_key: str | None = None,
     run_id: str | None = None,
     reason_code: str | None = None,
+    operation: str | None = None,
+    top_level_only: bool = False,
     since: int | None = None,
     until: int | None = None,
     order: str | None = "newest",
@@ -483,6 +506,17 @@ def list_groups(
     eq("destination_provider", destination_provider, up=True)
     eq("source_provider", source_provider, up=True)
     eq("reason_code", reason_code)
+    eq("operation", operation)
+
+    if top_level_only:
+        clauses.append(
+            "(g.operation='run' OR g.item_key IS NULL OR g.item_key='' OR NOT EXISTS ("
+            "SELECT 1 FROM events pe JOIN event_groups rg "
+            "ON rg.operation='run' AND pe.created_at>=rg.first_event_at AND pe.created_at<=rg.last_event_at "
+            "WHERE pe.group_id=g.id AND pe.event_type IN "
+            "('write_failed','unresolved_recorded','blackbox_promoted','blackbox_blocked')"
+            "))"
+        )
 
     if provider:
         p = provider.upper()
@@ -491,17 +525,25 @@ def list_groups(
 
     if q:
         like = f"%{q}%"
+        evc = _event_vis_clause(visibility)
+        event_where = "e.title LIKE ? OR e.item_key LIKE ? OR e.reason LIKE ? OR e.reason_code LIKE ?"
+        if evc:
+            event_where = f"({event_where}) AND {evc}"
         clauses.append(
             "(g.summary LIKE ? OR g.title LIKE ? OR g.item_key LIKE ? OR g.reason LIKE ? OR g.reason_code LIKE ? "
-            "OR g.id IN (SELECT group_id FROM events WHERE title LIKE ? OR item_key LIKE ? OR reason LIKE ? OR reason_code LIKE ?))"
+            f"OR g.id IN (SELECT e.group_id FROM events e WHERE e.group_id IS NOT NULL AND {event_where}))"
         )
         params.extend([like] * 9)
 
     if event_type:
-        clauses.append("g.id IN (SELECT group_id FROM events WHERE event_type=?)")
+        evc = _event_vis_clause(visibility)
+        suffix = f" AND {evc}" if evc else ""
+        clauses.append(f"g.id IN (SELECT e.group_id FROM events e WHERE e.group_id IS NOT NULL AND e.event_type=?{suffix})")
         params.append(event_type)
     if run_id:
-        clauses.append("g.id IN (SELECT group_id FROM events WHERE run_id=?)")
+        evc = _event_vis_clause(visibility)
+        suffix = f" AND {evc}" if evc else ""
+        clauses.append(f"g.id IN (SELECT e.group_id FROM events e WHERE e.group_id IS NOT NULL AND e.run_id=?{suffix})")
         params.append(run_id)
 
     if since not in (None, ""):
@@ -524,7 +566,7 @@ def list_groups(
     # hide health-only groups 
     explicit = str(visibility or "").strip().lower() == "all" or any(v not in (None, "") for v in (
         q, status, category, event_type, provider, origin_provider,
-        destination_provider, source_provider, feature, pair_key, item_key, run_id, reason_code,
+        destination_provider, source_provider, feature, pair_key, item_key, run_id, reason_code, operation,
     ))
     if not explicit:
         clauses.append(
@@ -582,13 +624,15 @@ def group_events(group_id: Any, *, order: str | None = "asc", limit: int = 500, 
     return {"items": [dict(r) for r in rows], "total": total, "limit": lim, "offset": off}
 
 
-def run_problem_items(run_id: Any, since: Any = None, until: Any = None, *, conn: sqlite3.Connection | None = None) -> dict[str, Any]:
-    """Item threads that had a failure/unresolved/blackbox event during this run.
-
-    Matches on run_id when present, but also on the run's time window: imported
-    events carry a report-derived run_id that differs from the live run's id, so
-    the window is the reliable link between a run and its problem items.
-    """
+def run_problem_items(
+    run_id: Any,
+    since: Any = None,
+    until: Any = None,
+    *,
+    limit: int | None = None,
+    offset: int = 0,
+    conn: sqlite3.Connection | None = None,
+) -> dict[str, Any]:
     c = conn or get_conn()
     rid = str(run_id or "").strip()
     match: list[str] = []
@@ -600,31 +644,268 @@ def run_problem_items(run_id: Any, since: Any = None, until: Any = None, *, conn
         match.append("(created_at >= ? AND created_at <= ?)")
         params.extend([int(since), int(until)])
     if c is None or not match:
-        return {"items": []}
+        return {"items": [], "total": 0, "limit": limit, "offset": max(0, int(offset or 0))}
+    off = max(0, int(offset or 0))
+    lim = None if limit is None else max(1, min(int(limit or 100), 500))
+    base_sql = (
+        f"FROM event_groups g "
+        "WHERE g.item_key IS NOT NULL AND g.item_key <> '' AND g.id IN ("
+        "  SELECT DISTINCT group_id FROM events WHERE group_id IS NOT NULL "
+        "  AND event_type IN ('write_failed','unresolved_recorded','blackbox_promoted','blackbox_blocked') "
+        f"  AND ({' OR '.join(match)})"
+        ")"
+    )
     try:
+        total = int(c.execute(f"SELECT COUNT(*) {base_sql}", params).fetchone()[0])
+        sql = (
+            f"SELECT {','.join('g.' + col for col in _GROUP_COLUMNS)} {base_sql} "
+            "ORDER BY g.last_event_at DESC, g.id DESC"
+        )
+        row_params = list(params)
+        if lim is not None:
+            sql += " LIMIT ? OFFSET ?"
+            row_params.extend([lim, off])
         rows = c.execute(
-            f"SELECT {','.join('g.' + col for col in _GROUP_COLUMNS)} FROM event_groups g "
-            "WHERE g.item_key IS NOT NULL AND g.item_key <> '' AND g.id IN ("
-            "  SELECT DISTINCT group_id FROM events WHERE group_id IS NOT NULL "
-            "  AND event_type IN ('write_failed','unresolved_recorded','blackbox_promoted','blackbox_blocked') "
-            f"  AND ({' OR '.join(match)})"
-            ") ORDER BY g.last_event_at DESC, g.id DESC",
-            params,
+            sql,
+            row_params,
         ).fetchall()
     except Exception as exc:
         _LOG.warning("run problem items failed: %s", exc)
-        return {"items": []}
-    return {"items": [dict(r) for r in rows]}
+        return {"items": [], "total": 0, "limit": lim if lim is not None else limit, "offset": off}
+    return {"items": [dict(r) for r in rows], "total": total, "limit": lim if lim is not None else total, "offset": off}
+
+
+def _run_children_bulk(
+    runs: list[dict[str, Any]],
+    item_ids: set[Any],
+    *,
+    conn: sqlite3.Connection,
+) -> dict[Any, list[Any]]:
+    out: dict[Any, list[Any]] = {r.get("id"): [] for r in runs}
+    windows: list[tuple[Any, int, int]] = []
+    for run in runs:
+        first_event_at = run.get("first_event_at")
+        last_event_at = run.get("last_event_at")
+        if first_event_at is None or last_event_at is None:
+            continue
+        try:
+            windows.append((run.get("id"), int(first_event_at), int(last_event_at)))
+        except (TypeError, ValueError):
+            continue
+    ids = [int(x) for x in item_ids if x not in (None, "")]
+    if not windows or not ids:
+        return out
+
+    lo = min(x[1] for x in windows)
+    hi = max(x[2] for x in windows)
+    seen: dict[Any, set[Any]] = {run_id: set() for run_id, _, _ in windows}
+    try:
+        rows = conn.execute(
+            "SELECT DISTINCT group_id, created_at FROM events "
+            f"WHERE group_id IN ({','.join('?' for _ in ids)}) "
+            "AND event_type IN ('write_failed','unresolved_recorded','blackbox_promoted','blackbox_blocked') "
+            "AND created_at>=? AND created_at<=? ORDER BY created_at DESC, group_id DESC",
+            [*ids, lo, hi],
+        ).fetchall()
+    except Exception as exc:
+        _LOG.warning("bulk run children failed: %s", exc)
+        return out
+
+    for row in rows:
+        group_id = row["group_id"]
+        created_at = int(row["created_at"] or 0)
+        for run_id, since, until in windows:
+            if since <= created_at <= until and group_id not in seen[run_id]:
+                seen[run_id].add(group_id)
+                out[run_id].append(group_id)
+    return out
+
+
+def _run_child_groups_bulk(
+    runs: list[dict[str, Any]],
+    *,
+    visibility: str | None,
+    conn: sqlite3.Connection,
+) -> dict[Any, list[dict[str, Any]]]:
+    """Load all visible problem children for the current run-parent page."""
+    out: dict[Any, list[dict[str, Any]]] = {r.get("id"): [] for r in runs}
+    windows: list[tuple[Any, int, int]] = []
+    for run in runs:
+        first_event_at = run.get("first_event_at")
+        last_event_at = run.get("last_event_at")
+        if first_event_at is None or last_event_at is None:
+            continue
+        try:
+            windows.append((run.get("id"), int(first_event_at), int(last_event_at)))
+        except (TypeError, ValueError):
+            continue
+    if not windows:
+        return out
+    lo = min(x[1] for x in windows)
+    hi = max(x[2] for x in windows)
+    vis = _vis_clause(visibility)
+    vis_sql = f" AND {vis}" if vis else ""
+    try:
+        rows = conn.execute(
+            f"SELECT DISTINCT {','.join('g.' + col for col in _GROUP_COLUMNS)}, e.created_at AS problem_at "
+            "FROM events e JOIN event_groups g ON g.id=e.group_id "
+            "WHERE g.item_key IS NOT NULL AND g.item_key<>'' "
+            "AND e.event_type IN ('write_failed','unresolved_recorded','blackbox_promoted','blackbox_blocked') "
+            f"AND e.created_at>=? AND e.created_at<=?{vis_sql} "
+            "ORDER BY g.last_event_at DESC, g.id DESC",
+            (lo, hi),
+        ).fetchall()
+    except Exception as exc:
+        _LOG.warning("bulk run child groups failed: %s", exc)
+        return out
+    seen: dict[Any, set[Any]] = {run_id: set() for run_id, _, _ in windows}
+    for row in rows:
+        group_id = row["id"]
+        problem_at = int(row["problem_at"] or 0)
+        group = {col: row[col] for col in _GROUP_COLUMNS}
+        for run_id, since, until in windows:
+            if since <= problem_at <= until and group_id not in seen[run_id]:
+                seen[run_id].add(group_id)
+                out[run_id].append(group)
+    return out
+
+
+def _run_child_counts_bulk(
+    runs: list[dict[str, Any]],
+    *,
+    visibility: str | None,
+    conn: sqlite3.Connection,
+) -> dict[Any, int]:
+    out: dict[Any, int] = {r.get("id"): 0 for r in runs}
+    windows: list[tuple[Any, int, int]] = []
+    for run in runs:
+        first_event_at = run.get("first_event_at")
+        last_event_at = run.get("last_event_at")
+        if first_event_at is None or last_event_at is None:
+            continue
+        try:
+            windows.append((run.get("id"), int(first_event_at), int(last_event_at)))
+        except (TypeError, ValueError):
+            continue
+    if not windows:
+        return out
+    lo = min(x[1] for x in windows)
+    hi = max(x[2] for x in windows)
+    vis = _vis_clause(visibility)
+    vis_sql = f" AND {vis}" if vis else ""
+    try:
+        rows = conn.execute(
+            "SELECT DISTINCT g.id AS group_id, e.created_at AS problem_at "
+            "FROM events e JOIN event_groups g ON g.id=e.group_id "
+            "WHERE g.item_key IS NOT NULL AND g.item_key<>'' "
+            "AND e.event_type IN ('write_failed','unresolved_recorded','blackbox_promoted','blackbox_blocked') "
+            f"AND e.created_at>=? AND e.created_at<=?{vis_sql} "
+            "ORDER BY e.created_at DESC, g.id DESC",
+            (lo, hi),
+        ).fetchall()
+    except Exception as exc:
+        _LOG.warning("bulk run child counts failed: %s", exc)
+        return out
+    seen: dict[Any, set[Any]] = {run_id: set() for run_id, _, _ in windows}
+    for row in rows:
+        group_id = row["group_id"]
+        problem_at = int(row["problem_at"] or 0)
+        for run_id, since, until in windows:
+            if since <= problem_at <= until and group_id not in seen[run_id]:
+                seen[run_id].add(group_id)
+    for run_id, ids in seen.items():
+        out[run_id] = len(ids)
+    return out
+
+
+def _run_problem_status_counts_bulk(
+    runs: list[dict[str, Any]],
+    *,
+    conn: sqlite3.Connection,
+) -> dict[Any, dict[str, int]]:
+    """Count unique problem groups by status for every visible run."""
+    windows: list[tuple[Any, int, int]] = []
+    for run in runs:
+        first_event_at = run.get("first_event_at")
+        last_event_at = run.get("last_event_at")
+        if first_event_at is None or last_event_at is None:
+            continue
+        try:
+            windows.append((run.get("id"), int(first_event_at), int(last_event_at)))
+        except (TypeError, ValueError):
+            continue
+    out: dict[Any, dict[str, int]] = {run_id: {} for run_id, _, _ in windows}
+    if not windows:
+        return out
+    lo = min(x[1] for x in windows)
+    hi = max(x[2] for x in windows)
+    matched: dict[Any, dict[str, set[Any]]] = {run_id: {} for run_id, _, _ in windows}
+    try:
+        rows = conn.execute(
+            "SELECT DISTINCT e.group_id, e.created_at FROM events e "
+            "WHERE e.group_id IS NOT NULL "
+            "AND e.event_type IN ('blackbox_promoted','blackbox_blocked') "
+            "AND e.created_at>=? AND e.created_at<=?",
+            (lo, hi),
+        ).fetchall()
+    except Exception as exc:
+        _LOG.warning("bulk run status counts failed: %s", exc)
+        return out
+    for row in rows:
+        group_id = row["group_id"]
+        created_at = int(row["created_at"] or 0)
+        for run_id, since, until in windows:
+            if since <= created_at <= until:
+                matched[run_id].setdefault("blackboxed", set()).add(group_id)
+    for run_id, statuses in matched.items():
+        out[run_id] = {status: len(group_ids) for status, group_ids in statuses.items()}
+    return out
 
 
 def list_tree(*, order: str | None = "newest", limit: int = 50, offset: int = 0,
-              conn: sqlite3.Connection | None = None, **filters: Any) -> dict[str, Any]:
+              include_children: bool = True, conn: sqlite3.Connection | None = None, **filters: Any) -> dict[str, Any]:
     """Grouped list as a tree: run threads are parents, the item threads that had
     a problem during each run are nested as `children`; items owned by a run are
     lifted out of the top level. Standalone item threads stay at the top level."""
     c = conn or get_conn()
     if c is None:
         return {"items": [], "total": 0, "limit": limit, "offset": offset}
+    visibility = filters.get("visibility", "open")
+    active_filters = any(
+        value not in (None, "")
+        for key, value in filters.items()
+        if key != "visibility"
+    )
+    if not active_filters:
+        parent_page = list_groups(
+            order=order,
+            limit=limit,
+            offset=offset,
+            conn=c,
+            visibility=visibility,
+            top_level_only=True,
+        )
+        top = parent_page.get("items") or []
+        runs = [g for g in top if str(g.get("operation") or "") == "run"]
+        children_by_run = _run_child_groups_bulk(runs, visibility=visibility, conn=c) if include_children else {}
+        child_counts_by_run = _run_child_counts_bulk(runs, visibility=visibility, conn=c) if not include_children else {}
+        status_counts_by_run = _run_problem_status_counts_bulk(runs, conn=c)
+        for run in runs:
+            children = children_by_run.get(run.get("id"), [])
+            run["children"] = children[:500] if include_children else []
+            run["children_total"] = len(children) if include_children else int(child_counts_by_run.get(run.get("id")) or 0)
+            blackboxed = int((status_counts_by_run.get(run.get("id")) or {}).get("blackboxed") or 0)
+            summary = str(run.get("summary") or "")
+            if blackboxed and "blackboxed" not in summary.lower():
+                pair_suffix = re.search(r", \d+ pairs?(?: \([^)]*\))?$", summary)
+                insert_at = pair_suffix.start() if pair_suffix else len(summary)
+                run["summary"] = f"{summary[:insert_at]}, {blackboxed} blackboxed{summary[insert_at:]}"
+        return {
+            "items": top,
+            "total": int(parent_page.get("total") or 0),
+            "limit": int(parent_page.get("limit") or limit),
+            "offset": int(parent_page.get("offset") or offset),
+        }
     flat = list_groups(order=order, limit=2000, offset=0, conn=c, **filters).get("items") or []
     runs: list[dict[str, Any]] = []
     items: list[dict[str, Any]] = []
@@ -638,10 +919,18 @@ def list_tree(*, order: str | None = "newest", limit: int = 50, offset: int = 0,
             others.append(g)
     items_by_id = {g["id"]: g for g in items}
     owned: set[Any] = set()
+    children_by_run = _run_children_bulk(runs, set(items_by_id), conn=c)
+    status_counts_by_run = _run_problem_status_counts_bulk(runs, conn=c)
     for r in runs:
-        res = run_problem_items(None, r.get("first_event_at"), r.get("last_event_at"), conn=c).get("items") or []
-        kids = [items_by_id[x["id"]] for x in res if x["id"] in items_by_id]
+        kids = [items_by_id[x] for x in children_by_run.get(r.get("id"), []) if x in items_by_id]
+        kids.sort(key=lambda g: (int(g.get("last_event_at") or 0), int(g.get("id") or 0)), reverse=True)
         r["children"] = kids
+        blackboxed = int((status_counts_by_run.get(r.get("id")) or {}).get("blackboxed") or 0)
+        summary = str(r.get("summary") or "")
+        if blackboxed and "blackboxed" not in summary.lower():
+            pair_suffix = re.search(r", \d+ pairs?$", summary)
+            insert_at = pair_suffix.start() if pair_suffix else len(summary)
+            r["summary"] = f"{summary[:insert_at]}, {blackboxed} blackboxed{summary[insert_at:]}"
         owned.update(k["id"] for k in kids)
     top = runs + [g for g in items if g["id"] not in owned] + others
     rev = str(order or "newest").strip().lower() not in ("oldest", "asc")

--- a/cw_platform/event_archive/maintenance.py
+++ b/cw_platform/event_archive/maintenance.py
@@ -31,10 +31,11 @@ def _db_size(p: Path) -> int:
 def health(*, conn: sqlite3.Connection | None = None) -> dict[str, Any]:
     path = events_db_path()
     p = Path(str(path))
+    exists = p.exists()
     c = conn or get_conn()
     if c is None:
-        return {"ok": False, "available": False, "healthy": False, "path": str(path), "exists": p.exists()}
-    out: dict[str, Any] = {"ok": True, "available": True, "path": str(path), "exists": p.exists()}
+        return {"ok": False, "available": False, "healthy": False, "path": str(path), "exists": exists}
+    out: dict[str, Any] = {"ok": True, "available": True, "path": str(path), "exists": exists}
     try:
         integrity = str(c.execute("PRAGMA integrity_check").fetchone()[0])
         quick = str(c.execute("PRAGMA quick_check").fetchone()[0])
@@ -43,7 +44,7 @@ def health(*, conn: sqlite3.Connection | None = None) -> dict[str, Any]:
         jm = str(c.execute("PRAGMA journal_mode").fetchone()[0])
         st = status(conn=c)
         out.update({
-            "healthy": integrity == "ok" and quick == "ok" and not fk and ver == SCHEMA_VERSION,
+            "healthy": exists and integrity == "ok" and quick == "ok" and not fk and ver == SCHEMA_VERSION,
             "integrity": integrity,
             "quick_check": quick,
             "foreign_key_errors": len(fk),
@@ -59,6 +60,8 @@ def health(*, conn: sqlite3.Connection | None = None) -> dict[str, Any]:
             "size_bytes": _db_size(p),
             "wal_size_bytes": _file_size(Path(str(p) + "-wal")),
         })
+        if not exists:
+            out["error"] = "database_file_missing"
     except Exception:
         _LOG.exception("events health check failed")
         out.update({"healthy": False, "error": "internal_error"})

--- a/cw_platform/event_archive/query.py
+++ b/cw_platform/event_archive/query.py
@@ -50,8 +50,8 @@ def _vis_clause(visibility: str | None) -> str | None:
     if v == "all":
         return None
     if v == "acknowledged":
-        return "acknowledged_at IS NOT NULL"
-    return "acknowledged_at IS NULL"
+        return "(acknowledged_at IS NOT NULL OR EXISTS (SELECT 1 FROM event_groups g WHERE g.id=events.group_id AND g.acknowledged_at IS NOT NULL))"
+    return "acknowledged_at IS NULL AND NOT EXISTS (SELECT 1 FROM event_groups g WHERE g.id=events.group_id AND g.acknowledged_at IS NOT NULL)"
 
 
 def _order_dir(order: str | None) -> str:

--- a/cw_platform/event_archive/recorder.py
+++ b/cw_platform/event_archive/recorder.py
@@ -424,7 +424,12 @@ def _item_fields(it: Mapping[str, Any]) -> dict[str, Any]:
         episode = int(episode) if episode not in (None, "") else None
     except Exception:
         episode = None
-    title = it.get("title") or it.get("series_title") or it.get("show_title") or it.get("name")
+    is_ep = str(it.get("type") or "").lower() == "episode" or (season is not None and episode is not None)
+    if is_ep:
+        title = (it.get("series_title") or it.get("show_title") or it.get("show")
+                 or it.get("grandparent_title") or it.get("title") or it.get("name"))
+    else:
+        title = it.get("title") or it.get("series_title") or it.get("show_title") or it.get("name")
     return {
         "title": str(title) if title else None,
         "year": year,

--- a/cw_platform/event_archive/schema.py
+++ b/cw_platform/event_archive/schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import sqlite3
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 _CREATE_SYNC_RUNS = """
 CREATE TABLE IF NOT EXISTS sync_runs (
@@ -122,6 +122,8 @@ _INDEXES = (
     "CREATE INDEX IF NOT EXISTS idx_events_pair_feature ON events(pair_key, feature)",
     "CREATE INDEX IF NOT EXISTS idx_events_item_key ON events(item_key)",
     "CREATE INDEX IF NOT EXISTS idx_events_reason_code ON events(reason_code)",
+    "CREATE INDEX IF NOT EXISTS idx_events_run_type_group ON events(run_id, event_type, group_id)",
+    "CREATE INDEX IF NOT EXISTS idx_events_group_created_id ON events(group_id, created_at, id)",
 )
 
 _GROUP_INDEXES = (
@@ -133,6 +135,7 @@ _GROUP_INDEXES = (
     "CREATE INDEX IF NOT EXISTS idx_groups_origin_provider ON event_groups(origin_provider)",
     "CREATE INDEX IF NOT EXISTS idx_groups_status ON event_groups(status)",
     "CREATE INDEX IF NOT EXISTS idx_groups_acknowledged ON event_groups(acknowledged_at)",
+    "CREATE INDEX IF NOT EXISTS idx_groups_ack_last_id ON event_groups(acknowledged_at, last_event_at, id)",
 )
 
 

--- a/cw_platform/orchestrator/_applier.py
+++ b/cw_platform/orchestrator/_applier.py
@@ -7,6 +7,17 @@ from typing import Any, Callable, cast
 from . import _unresolved as _unresolved_mod
 record_unresolved = cast(Callable[..., dict[str, Any]], getattr(_unresolved_mod, "record_unresolved"))
 
+_UNRESOLVED_EXAMPLE_CAP = 25
+
+_PASSTHROUGH_KEY_LISTS = (
+    "presence_confirmed_keys",
+    "accepted_keys",
+    "live_confirmed_keys",
+    "accepted_not_seen_live_keys",
+    "date_confirmed_keys",
+    "date_mismatch_keys",
+)
+
 def _retry(fn: Callable[[], Any], *, attempts: int = 3, base_sleep: float = 0.5) -> Any:
     last = None
     for i in range(attempts):
@@ -138,11 +149,16 @@ def _normalize(
             return x, (str(hint).strip() or None) if hint is not None else None
 
         unresolved_details: list[dict[str, Any]] = []
+        reason_counts: dict[str, int] = {}
         for raw in unresolved_list:
             if not isinstance(raw, Mapping):
                 continue
             item_u, hint_u = _unwrap(raw)
             if not isinstance(item_u, Mapping):
+                continue
+            reason_key = str(hint_u) if hint_u else "unknown"
+            reason_counts[reason_key] = reason_counts.get(reason_key, 0) + 1
+            if len(unresolved_details) >= _UNRESOLVED_EXAMPLE_CAP:
                 continue
             detail: dict[str, Any] = {}
             for field in ("type", "title", "name", "year", "season", "episode", "series_title", "show_title"):
@@ -153,7 +169,18 @@ def _normalize(
                 detail["reason"] = str(hint_u)
             unresolved_details.append(detail)
 
-        emit("apply:unresolved", provider=dst, feature=feature, count=len(unresolved_list), items=unresolved_details)
+        _total = len(unresolved_list)
+        emit(
+            "apply:unresolved",
+            provider=dst,
+            feature=feature,
+            count=_total,
+            items=unresolved_details,
+            total=_total,
+            shown=len(unresolved_details),
+            omitted=max(0, _total - len(unresolved_details)),
+            reason_counts=reason_counts,
+        )
 
         def _has_ids(x: Mapping[str, Any] | None) -> bool:
             _id_keys = ("tmdb", "imdb", "tvdb", "trakt", "slug")
@@ -242,6 +269,13 @@ def _normalize(
         "unresolved": int(unresolved),
         "errors": int(errors),
     }
+    for f in _PASSTHROUGH_KEY_LISTS:
+        v = res.get(f)
+        if isinstance(v, list):
+            out[f] = [str(x) for x in v if x]
+    rc = res.get("reason_counts")
+    if isinstance(rc, Mapping):
+        out["reason_counts"] = dict(rc)
     out["count"] = out["confirmed"]
     return out
 
@@ -278,6 +312,7 @@ def _apply_chunked(
         "skipped_reported": 0,
         "skip_basis": "provider_keys",
         "unresolved": 0,
+        "unresolved_keys": [],
         "errors": 0,
     }
     for i in range(0, total, csize):
@@ -297,6 +332,17 @@ def _apply_chunked(
             agg["confirmed_keys"].extend(res["confirmed_keys"])
         if res.get("skipped_keys"):
             agg["skipped_keys"].extend(res["skipped_keys"])
+        if res.get("unresolved_keys"):
+            agg["unresolved_keys"].extend(res["unresolved_keys"])
+        for f in _PASSTHROUGH_KEY_LISTS:
+            v = res.get(f)
+            if isinstance(v, list):
+                agg.setdefault(f, []).extend(v)
+        rc = res.get("reason_counts")
+        if isinstance(rc, Mapping):
+            agg_rc = agg.setdefault("reason_counts", {})
+            for rk, rv in rc.items():
+                agg_rc[rk] = int(agg_rc.get(rk, 0)) + int(rv or 0)
         basis = str(res.get("skip_basis") or "provider_keys")
         if agg.get("skip_basis") != basis:
             agg["skip_basis"] = "mixed"

--- a/cw_platform/orchestrator/_blackbox.py
+++ b/cw_platform/orchestrator/_blackbox.py
@@ -150,14 +150,24 @@ def record_attempts(
     cfg: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     bb = _load_bb_cfg(cfg)
-    ts = int(time.time())
     ordered_keys, unique_keys = _normalize_keys(keys)
+    pair_scoped = bool(bb.get("pair_scoped", True))
+    scoped_pair = pair if pair_scoped else None
+    if not bool(bb.get("enabled", True)):
+        return {
+            "ok": True,
+            "count": len(ordered_keys),
+            "promoted": 0,
+            "promoted_keys": [],
+            "pair": scoped_pair or "global",
+            "disabled": True,
+        }
+
+    ts = int(time.time())
     flap_path = _flap_path(dst, feature)
     flap_data = _read_json(flap_path)
 
     promote_after = int(bb.get("promote_after", 3) or 3)
-    pair_scoped = bool(bb.get("pair_scoped", True))
-    scoped_pair = pair if pair_scoped else None
     bb_path = _bb_path(dst, feature, scoped_pair)
     bb_data = _read_json(bb_path)
 

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -13,10 +13,90 @@ import datetime as _dt
 def _emit_item_failures(emit, provider, feature, pair, keys, key2item, bb_res) -> None:
     try:
         prom = set((bb_res or {}).get("promoted_keys") or [])
-        items = [{"key": k, "item": key2item.get(k), "promoted": k in prom, "reason": "apply:add:failed"} for k in keys]
-        emit("archive:item_failures", provider=provider, feature=feature, pair=pair, op="add", items=items)
+        all_keys = [k for k in (keys or [])]
+        total = len(all_keys)
+        unresolved_reasons = load_unresolved_map(provider, feature, cross_features=False)
+
+        def _reason_for_key(k: str) -> str:
+            from_state = unresolved_reasons.get(k) if isinstance(unresolved_reasons, dict) else None
+            if isinstance(from_state, Mapping):
+                reason = str(from_state.get("reason") or "").strip()
+                if reason:
+                    return reason
+            item = key2item.get(k)
+            if isinstance(item, Mapping):
+                for field in ("_cw_unresolved_hint", "hint", "reason", "error"):
+                    reason = str(item.get(field) or "").strip()
+                    if reason:
+                        return reason
+            return "apply:add:failed"
+
+        reason_counts: dict[str, int] = {}
+        for k in all_keys:
+            reason = _reason_for_key(k)
+            reason_counts[reason] = reason_counts.get(reason, 0) + 1
+        items = [
+            {"key": k, "item": key2item.get(k), "promoted": k in prom, "reason": _reason_for_key(k)}
+            for k in all_keys
+        ]
+        if prom:
+            reason_counts["promoted"] = len(prom & set(all_keys))
+        emit(
+            "archive:item_failures",
+            provider=provider,
+            feature=feature,
+            pair=pair,
+            op="add",
+            items=items,
+            total=total,
+            shown=len(items),
+            omitted=0,
+            reason_counts=reason_counts,
+        )
     except Exception:
         pass
+
+
+def compute_effective_add(
+    *,
+    attempted_keys,
+    prov_confirmed,
+    confirmed_keys,
+    still_unresolved,
+    skipped_keys,
+    have_exact_keys,
+    verify_after_write,
+    provider_skipped,
+) -> dict[str, Any]:
+    conf = list(confirmed_keys or [])
+    pc = int(prov_confirmed or 0)
+    if have_exact_keys:
+        pc = min(pc or len(conf), len(conf))
+    ambiguous_partial = (not have_exact_keys) and bool(provider_skipped) and bool(pc) and (pc < len(conf))
+    strict_pessimist = (not have_exact_keys) and (not verify_after_write) and bool(still_unresolved)
+    if strict_pessimist or ambiguous_partial:
+        eff = 0
+    else:
+        eff = len(conf) if (verify_after_write or have_exact_keys) else min(pc, len(conf))
+    success_keys = conf if (verify_after_write or have_exact_keys) else conf[:eff]
+    skset = set(skipped_keys or set())
+    sset = set(success_keys)
+    failed_keys = [k for k in (attempted_keys or []) if k not in sset and k not in skset]
+    return {
+        "effective": int(eff),
+        "prov_confirmed": int(pc),
+        "ambiguous_partial": bool(ambiguous_partial),
+        "success_keys": success_keys,
+        "failed_keys": failed_keys,
+    }
+
+
+def select_baseline_keys(success_keys, result) -> list:
+    presence_raw = (result or {}).get("presence_confirmed_keys")
+    if isinstance(presence_raw, list):
+        pcset = {str(x) for x in presence_raw if x}
+        return [k for k in (success_keys or []) if k in pcset]
+    return list(success_keys or [])
 
 
 from ..provider_instances import normalize_instance_id
@@ -29,14 +109,17 @@ from ..anime_mapping.service import (
 )
 from ._snapshots import (
     build_snapshots_for_feature,
+    bust_snapshot_cache,
     coerce_suspect_snapshot,
     module_checkpoint,
+    needs_post_apply_refresh,
     provider_index_semantics,
     prev_checkpoint,
+    refresh_destination_after_apply,
 )
 from ._applier import apply_add, apply_remove, apply_update
 from ._chunking import effective_chunk_size
-from ._unresolved import load_unresolved_keys, record_unresolved, clear_unresolved
+from ._unresolved import load_unresolved_keys, load_unresolved_map, record_unresolved, clear_unresolved
 from ._planner import diff, diff_ratings, diff_progress, _pick_rating
 from ._phantoms import PhantomGuard
 from ._tombstones import clear_items_for_feature
@@ -561,10 +644,7 @@ def run_one_way_feature(
 
     def _bust_snapshot(pname: str) -> None:
         try:
-            sc = getattr(ctx, "snap_cache", None)
-            if isinstance(sc, dict):
-                sc.pop((pname, feature), None)
-                sc.pop(pname, None)
+            bust_snapshot_cache(getattr(ctx, "snap_cache", None), pname, feature)
         except Exception:
             pass
 
@@ -1065,7 +1145,7 @@ def run_one_way_feature(
         return observed_removes
 
     if allow_removes:
-        if feature == "ratings":
+        if feature == "ratings" and remove_mode == "mirror":
             removes = list(mirror_removes or [])
             if removes:
                 removes = [it for it in removes if not _present(src_idx, src_alias, it)]
@@ -1214,6 +1294,7 @@ def run_one_way_feature(
     unresolved_new_total = 0
     dry_run_flag = bool(ctx.dry_run or sync_cfg.get("dry_run", False))
     verify_after_write = bool(sync_cfg.get("verify_after_write", False))
+    post_apply_add_res: dict[str, Any] | None = None
 
     if updates:
         if dst_down:
@@ -1335,10 +1416,8 @@ def run_one_way_feature(
             
             prov_confirmed = int((add_res or {}).get("confirmed", (add_res or {}).get("count", 0)) or 0)
             added_provider_reported = prov_confirmed
-            if have_exact_keys:
-                prov_confirmed = min(prov_confirmed or len(confirmed_keys), len(confirmed_keys))
-            
-            if not dry_run_flag and not new_unresolved and prov_confirmed == 0 and adds:
+
+            if not dry_run_flag and not new_unresolved and prov_confirmed == 0 and adds and not have_exact_keys:
                 try:
                     record_unresolved(dst, feature, adds, hint="apply:add:no_confirmations_fallback")
                     new_unresolved = set(attempted_keys)
@@ -1351,14 +1430,22 @@ def run_one_way_feature(
 
             unresolved_new_total += len(still_unresolved)
 
-            ambiguous_partial = (not have_exact_keys) and bool(res_add.get("skipped")) and prov_confirmed and (prov_confirmed < len(confirmed_keys))
+            _decision = compute_effective_add(
+                attempted_keys=attempted_keys,
+                prov_confirmed=prov_confirmed,
+                confirmed_keys=confirmed_keys,
+                still_unresolved=still_unresolved,
+                skipped_keys=skipped_keys_set,
+                have_exact_keys=have_exact_keys,
+                verify_after_write=verify_after_write,
+                provider_skipped=bool(res_add.get("skipped")),
+            )
+            prov_confirmed = _decision["prov_confirmed"]
+            added_effective = _decision["effective"]
+            ambiguous_partial = _decision["ambiguous_partial"]
+            success_keys = _decision["success_keys"]
+            failed_keys = _decision["failed_keys"]
 
-            strict_pessimist = (not have_exact_keys) and (not verify_after_write) and bool(still_unresolved)
-            if strict_pessimist or ambiguous_partial:
-                added_effective = 0
-            else:
-                added_effective = len(confirmed_keys) if (verify_after_write or have_exact_keys) else min(prov_confirmed, len(confirmed_keys))
-            
             if added_effective != prov_confirmed and not have_exact_keys:
                 dbg("apply:add:corrected", dst=dst, feature=feature,
                     provider_count=prov_confirmed, effective=added_effective,
@@ -1374,9 +1461,6 @@ def run_one_way_feature(
                     skipped_inferred=int(res_add.get("skipped_inferred", 0) or 0),
                     skip_basis=str(res_add.get("skip_basis") or "provider_keys"),
                 )
-            
-            success_keys = confirmed_keys if (verify_after_write or have_exact_keys) else confirmed_keys[:added_effective]
-            failed_keys = [k for k in attempted_keys if k not in set(success_keys) and k not in skipped_keys_set]
             try:
                 if failed_keys and not ambiguous_partial:
                     _bb = record_attempts(dst, feature, failed_keys, reason="apply:add:failed", op="add",
@@ -1405,12 +1489,14 @@ def run_one_way_feature(
                     guard.record_success(success_keys)
             except Exception:
                 pass
-            if success_keys and not dry_run_flag:
-                for k in success_keys:
+            baseline_keys = select_baseline_keys(success_keys, add_res)
+            if baseline_keys and not dry_run_flag:
+                for k in baseline_keys:
                     v = key2item.get(k)
                     if v:
                         dst_full[k] = v
                 _bust_snapshot(dst)
+            post_apply_add_res = add_res
 
     removed_count = 0
     rem_keys_attempted: list[str] = []
@@ -1482,6 +1568,31 @@ def run_one_way_feature(
                     if k in dst_full:
                         dst_full.pop(k, None)
                 _bust_snapshot(dst)
+
+    if (not dry_run_flag) and (not dst_down) and needs_post_apply_refresh(post_apply_add_res):
+        _r = post_apply_add_res or {}
+        emit("post_apply_refresh:start", provider=dst, instance=dst_inst, feature=feature,
+             reason="accepted_not_live_confirmed",
+             accepted_keys=len(_r.get("accepted_keys") or []),
+             accepted_not_seen_live_keys=len(_r.get("accepted_not_seen_live_keys") or []),
+             presence_confirmed_keys=len(_r.get("presence_confirmed_keys") or []))
+        try:
+            refreshed = refresh_destination_after_apply(
+                ops=dst_ops, config=provider_cfg, feature=feature, provider=dst, snap_cache=ctx.snap_cache,
+            )
+        except Exception:
+            refreshed = None
+        base_update = 0
+        if refreshed:
+            for rk, rv in refreshed.items():
+                if rk not in dst_full:
+                    base_update += 1
+                dst_full[rk] = rv
+        tk = str(os.environ.get("CW_PLEX_TRACE_KEY", "") or "").strip().lower()
+        contains_trace = bool(tk) and any(str(k).split("@", 1)[0].lower() == tk for k in (refreshed or {}))
+        emit("post_apply_refresh:done", provider=dst, instance=dst_inst, feature=feature,
+             refreshed_count=len(refreshed or {}), first_keys=list(refreshed or {})[:10],
+             contains_trace_key=contains_trace, baseline_update_count=base_update)
 
     try:
         st = ctx.state_store.load_state() or {}

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -9,7 +9,7 @@ import os
 import re
 import datetime as _dt
 
-from ._pairs_oneway import _emit_item_failures
+from ._pairs_oneway import _emit_item_failures, compute_effective_add, select_baseline_keys
 
 try:
     from ._pairs_oneway import (
@@ -74,10 +74,13 @@ from ..anime_mapping.service import (
 )
 from ._snapshots import (
     build_snapshots_for_feature,
+    bust_snapshot_cache,
     coerce_suspect_snapshot,
     module_checkpoint,
+    needs_post_apply_refresh,
     provider_index_semantics,
     prev_checkpoint,
+    refresh_destination_after_apply,
 )
 from ._applier import apply_add, apply_remove, apply_update
 from ._chunking import effective_chunk_size
@@ -376,10 +379,7 @@ def _two_way_sync(
 
     def _bust_snapshot(pname: str) -> None:
         try:
-            sc = getattr(ctx, "snap_cache", None)
-            if isinstance(sc, dict):
-                sc.pop((pname, feature), None)
-                sc.pop(pname, None)
+            bust_snapshot_cache(getattr(ctx, "snap_cache", None), pname, feature)
         except Exception:
             pass
 
@@ -1535,6 +1535,8 @@ def _two_way_sync(
     eff_upd_B = 0
     eff_add_A = 0
     eff_add_B = 0
+    post_apply_A_res: dict[str, Any] | None = None
+    post_apply_B_res: dict[str, Any] | None = None
     unresolved_new_A_total = 0
     unresolved_new_B_total = 0
 
@@ -1674,29 +1676,34 @@ def _two_way_sync(
                 confirmed_A = [k for k in attempted_A if k not in still_unresolved_A]
 
         
-            prov_count_A = _confirmed(resA_add)
-            if have_exact_keys_A:
-                prov_count_A = min(prov_count_A or len(confirmed_A), len(confirmed_A))
-            
-            ambiguous_partial_A = False
             if verify_after_write and _apply_verify_after_write_supported(aops):
                 try:
                     unresolved_again = set(load_unresolved_keys(a, feature, cross_features=_cross_feature_unresolved(feature)) or [])
                     confirmed_A = [k for k in confirmed_A if k not in unresolved_again]
                 except Exception:
                     pass
-                eff_add_A = len(confirmed_A)
-            else:
-                ambiguous_partial_A = (not have_exact_keys_A) and bool((resA_add or {}).get("skipped")) and prov_count_A and (prov_count_A < len(confirmed_A))
-                eff_add_A = 0 if still_unresolved_A or ambiguous_partial_A else min(prov_count_A, len(confirmed_A))
-            
+
+            _decision_A = compute_effective_add(
+                attempted_keys=attempted_A,
+                prov_confirmed=_confirmed(resA_add),
+                confirmed_keys=confirmed_A,
+                still_unresolved=still_unresolved_A,
+                skipped_keys=skipped_keys_A,
+                have_exact_keys=have_exact_keys_A,
+                verify_after_write=verify_after_write,
+                provider_skipped=bool((resA_add or {}).get("skipped")),
+            )
+            prov_count_A = _decision_A["prov_confirmed"]
+            eff_add_A = _decision_A["effective"]
+            ambiguous_partial_A = _decision_A["ambiguous_partial"]
+            success_A = _decision_A["success_keys"]
+            failed_A = _decision_A["failed_keys"]
+
             if eff_add_A != prov_count_A and not have_exact_keys_A:
                 dbg("two:apply:add:corrected", dst=a, feature=feature,
                     provider_count=prov_count_A, effective=eff_add_A, newly_unresolved=len(new_unresolved_A))
-            
-            success_A = confirmed_A if (verify_after_write or have_exact_keys_A) else confirmed_A[:eff_add_A]
+
             try:
-                failed_A = [k for k in attempted_A if k not in set(success_A) and k not in skipped_keys_A]
                 if failed_A and not ambiguous_partial_A:
                     _bb_A = record_attempts(a, feature, failed_A,
                         reason="two:apply:add:failed", op="add",
@@ -1726,12 +1733,14 @@ def _two_way_sync(
             except Exception:
                 pass
             
-            if success_A and not dry_run_flag:
-                for k in success_A:
+            baseline_keys_A = select_baseline_keys(success_A, resA_add)
+            if baseline_keys_A and not dry_run_flag:
+                for k in baseline_keys_A:
                     v = k2i_A.get(k)
                     if v:
                         A_eff[k] = v
                 _bust_snapshot(a)
+            post_apply_A_res = resA_add
             emit("two:apply:add:A:done", dst=a, feature=feature,
                  count=_confirmed(resA_add),
                  attempted=int(resA_add.get("attempted", 0)),
@@ -1797,29 +1806,34 @@ def _two_way_sync(
                 confirmed_B = [k for k in attempted_B if k not in still_unresolved_B]
 
         
-            prov_count_B = _confirmed(resB_add)
-            if have_exact_keys_B:
-                prov_count_B = min(prov_count_B or len(confirmed_B), len(confirmed_B))
-            
-            ambiguous_partial_B = False
             if verify_after_write and _apply_verify_after_write_supported(bops):
                 try:
                     unresolved_again = set(load_unresolved_keys(b, feature, cross_features=_cross_feature_unresolved(feature)) or [])
                     confirmed_B = [k for k in confirmed_B if k not in unresolved_again]
                 except Exception:
                     pass
-                eff_add_B = len(confirmed_B)
-            else:
-                ambiguous_partial_B = (not have_exact_keys_B) and bool((resB_add or {}).get("skipped")) and prov_count_B and (prov_count_B < len(confirmed_B))
-                eff_add_B = 0 if still_unresolved_B or ambiguous_partial_B else min(prov_count_B, len(confirmed_B))
-            
+
+            _decision_B = compute_effective_add(
+                attempted_keys=attempted_B,
+                prov_confirmed=_confirmed(resB_add),
+                confirmed_keys=confirmed_B,
+                still_unresolved=still_unresolved_B,
+                skipped_keys=skipped_keys_B,
+                have_exact_keys=have_exact_keys_B,
+                verify_after_write=verify_after_write,
+                provider_skipped=bool((resB_add or {}).get("skipped")),
+            )
+            prov_count_B = _decision_B["prov_confirmed"]
+            eff_add_B = _decision_B["effective"]
+            ambiguous_partial_B = _decision_B["ambiguous_partial"]
+            success_B = _decision_B["success_keys"]
+            failed_B = _decision_B["failed_keys"]
+
             if eff_add_B != prov_count_B and not have_exact_keys_B:
                 dbg("two:apply:add:corrected", dst=b, feature=feature,
                     provider_count=prov_count_B, effective=eff_add_B, newly_unresolved=len(new_unresolved_B))
-            
-            success_B = confirmed_B if (verify_after_write or have_exact_keys_B) else confirmed_B[:eff_add_B]
+
             try:
-                failed_B = [k for k in attempted_B if k not in set(success_B) and k not in skipped_keys_B]
                 if failed_B and not ambiguous_partial_B:
                     _bb_B = record_attempts(b, feature, failed_B,
                         reason="two:apply:add:failed", op="add",
@@ -1849,12 +1863,14 @@ def _two_way_sync(
             except Exception:
                 pass
             
-            if success_B and not dry_run_flag:
-                for k in success_B:
+            baseline_keys_B = select_baseline_keys(success_B, resB_add)
+            if baseline_keys_B and not dry_run_flag:
+                for k in baseline_keys_B:
                     v = k2i_B.get(k)
                     if v:
                         B_eff[k] = v
                 _bust_snapshot(b)
+            post_apply_B_res = resB_add
             emit("two:apply:add:B:done", dst=b, feature=feature,
                  count=_confirmed(resB_add),
                  attempted=int(resB_add.get("attempted", 0)),
@@ -1863,6 +1879,36 @@ def _two_way_sync(
                  unresolved=int(resB_add.get("unresolved", 0)),
                  errors=int(resB_add.get("errors", 0)),
                  result=resB_add)
+
+    def _post_apply_refresh(prov: str, inst: str, res: dict[str, Any] | None, ops: Any, eff: dict[str, Any], down: bool) -> None:
+        if dry_run_flag or down or not needs_post_apply_refresh(res):
+            return
+        r = res or {}
+        emit("post_apply_refresh:start", provider=prov, instance=inst, feature=feature,
+             reason="accepted_not_live_confirmed",
+             accepted_keys=len(r.get("accepted_keys") or []),
+             accepted_not_seen_live_keys=len(r.get("accepted_not_seen_live_keys") or []),
+             presence_confirmed_keys=len(r.get("presence_confirmed_keys") or []))
+        try:
+            refreshed = refresh_destination_after_apply(
+                ops=ops, config=provider_cfg, feature=feature, provider=prov, snap_cache=ctx.snap_cache,
+            )
+        except Exception:
+            refreshed = None
+        base_update = 0
+        if refreshed:
+            for rk, rv in refreshed.items():
+                if rk not in eff:
+                    base_update += 1
+                eff[rk] = rv
+        tk = str(os.environ.get("CW_PLEX_TRACE_KEY", "") or "").strip().lower()
+        contains_trace = bool(tk) and any(str(k).split("@", 1)[0].lower() == tk for k in (refreshed or {}))
+        emit("post_apply_refresh:done", provider=prov, instance=inst, feature=feature,
+             refreshed_count=len(refreshed or {}), first_keys=list(refreshed or {})[:10],
+             contains_trace_key=contains_trace, baseline_update_count=base_update)
+
+    _post_apply_refresh(a, src_inst, post_apply_A_res, aops, A_eff, a_down)
+    _post_apply_refresh(b, dst_inst, post_apply_B_res, bops, B_eff, b_down)
 
     try:
         st = ctx.state_store.load_state() or {}

--- a/cw_platform/orchestrator/_snapshots.py
+++ b/cw_platform/orchestrator/_snapshots.py
@@ -23,6 +23,82 @@ SnapIndex = dict[str, dict[str, Any]]
 SnapCache = dict[tuple[str, str, str], tuple[float, SnapIndex]]
 
 
+def bust_snapshot_cache(snap_cache: Any, provider: str, feature: str) -> None:
+    if not isinstance(snap_cache, dict):
+        return
+    prov = str(provider or "")
+    feat = str(feature or "")
+    for key in [
+        k for k in list(snap_cache.keys())
+        if isinstance(k, tuple) and len(k) == 3 and str(k[1]) == prov and str(k[2]) == feat
+    ]:
+        snap_cache.pop(key, None)
+
+
+def canonicalize_index(idx_raw: Any, *, feature: str) -> "SnapIndex":
+    canon: SnapIndex = {}
+    if isinstance(idx_raw, list):
+        for raw in idx_raw:
+            if not isinstance(raw, Mapping):
+                continue
+            item = dict(raw)
+            key = canonical_key(item)
+            if key:
+                canon[key] = item
+    elif isinstance(idx_raw, Mapping):
+        for k, raw in idx_raw.items():
+            if not isinstance(raw, Mapping):
+                continue
+            item = dict(raw)
+            computed = canonical_key(item) or ""
+            provider_key = k.split("@", 1)[0] if isinstance(k, str) and k else ""
+            key = _pick_key(provider_key, computed)
+            if key:
+                canon[key] = item
+    return _coalesce_by_shared_ids(canon, feature=feature)
+
+
+def needs_post_apply_refresh(result: Mapping[str, Any] | None) -> bool:
+    r = result or {}
+    not_seen = r.get("accepted_not_seen_live_keys") or []
+    if not_seen:
+        return True
+    accepted = r.get("accepted_keys") or []
+    presence = r.get("presence_confirmed_keys")
+    return bool(accepted) and not presence
+
+
+def refresh_destination_after_apply(
+    *,
+    ops: InventoryOps,
+    config: Mapping[str, Any],
+    feature: str,
+    provider: str,
+    snap_cache: Any,
+) -> "SnapIndex | None":
+    bust_snapshot_cache(snap_cache, provider, feature)
+    idx_raw: Any = None
+    refresher = getattr(ops, "snapshot_refresh", None)
+    if callable(refresher):
+        try:
+            idx_raw = refresher(config, feature=feature)
+        except Exception:
+            idx_raw = None
+    if idx_raw is None:
+        try:
+            idx_raw = ops.build_index(config, feature=feature)  # type: ignore[call-arg]
+        except Exception:
+            return None
+    canon = canonicalize_index(idx_raw, feature=feature)
+    try:
+        scope = pair_scope() or "unscoped"
+        if canon:
+            snap_cache[(scope, provider, feature)] = (time.time(), canon)
+    except Exception:
+        pass
+    return canon
+
+
 def provider_index_semantics(
     ops: InventoryOps,
     config: Mapping[str, Any],
@@ -626,32 +702,7 @@ def build_snapshots_for_feature(
             dbg("snapshot.failed", provider=name, feature=feature)
             raise
 
-        canon: SnapIndex = {}
-
-        if isinstance(idx_raw, list):
-            for raw in idx_raw:
-                if not isinstance(raw, Mapping):
-                    continue
-                item = dict(raw)
-                key = canonical_key(item)
-                if key:
-                    canon[key] = item
-
-        elif isinstance(idx_raw, Mapping):
-            for k, raw in idx_raw.items():
-                if not isinstance(raw, Mapping):
-                    continue
-                item = dict(raw)
-                computed = canonical_key(item) or ""
-                provider_key = k.split("@", 1)[0] if isinstance(k, str) and k else ""
-                key = _pick_key(provider_key, computed)
-                if key:
-                    canon[key] = item
-
-        else:
-            canon = {}
-
-        canon = _coalesce_by_shared_ids(canon, feature=feature)
+        canon = canonicalize_index(idx_raw, feature=feature)
         snaps[name] = canon
 
         if snap_ttl_sec > 0:

--- a/cw_platform/orchestrator/_unresolved.py
+++ b/cw_platform/orchestrator/_unresolved.py
@@ -13,12 +13,17 @@ import time
 __all__ = [
     "load_unresolved_keys",
     "load_unresolved_map",
+    "load_unresolved_items",
     "record_unresolved",
     "clear_unresolved",
 ]
 
 STATE_DIR = Path("/config/.cw_state")
 _LOG = logging.getLogger("crosswatch.orchestrator.unresolved")
+_GENERIC_FAILURE_HINTS = {
+    "apply:add:failed",
+    "two:apply:add:failed",
+}
 
 from ._scope import scoped_file, scope_safe
 
@@ -144,11 +149,20 @@ def load_unresolved_map(
     scope = scope_safe()
 
     if feature and not cross_features:
-        p = _blocking_path(dst_lower, feature)
-        data = _read_json(p)
-        if data:
-            for k, v in data.items():
-                out[str(k)] = v if isinstance(v, dict) else {}
+        blocking = _read_json(_blocking_path(dst_lower, feature))
+        for k, v in blocking.items():
+            out[str(k)] = v if isinstance(v, dict) else {}
+
+        pending = _read_json(_pending_path(dst_lower, feature))
+        raw_hints = pending.get("hints") if isinstance(pending, dict) else None
+        hints = raw_hints if isinstance(raw_hints, dict) else {}
+        raw_keys = pending.get("keys") if isinstance(pending, dict) else None
+        keys = raw_keys if isinstance(raw_keys, list) else []
+        for k in keys:
+            if not k:
+                continue
+            v = hints.get(k) or {}
+            out[str(k)] = v if isinstance(v, dict) else {}
         return out
 
     if not STATE_DIR.exists():
@@ -192,6 +206,52 @@ def load_unresolved_map(
                 for k, v in (data or {}).items():
                     out[str(k)] = v if isinstance(v, dict) else {}
     return out
+
+
+def load_unresolved_items(dst: str | None = None) -> list[dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    if not STATE_DIR.exists():
+        return []
+    dst_lower = str(dst or "").strip().lower()
+    for p in sorted(STATE_DIR.iterdir()):
+        if not p.is_file():
+            continue
+        name = p.name
+        if ".unresolved" not in name or not name.endswith(".json"):
+            continue
+        if dst_lower and not name.startswith(f"{dst_lower}_"):
+            continue
+
+        data = _read_json(p)
+        if not isinstance(data, dict):
+            continue
+        raw_items = data.get("items")
+        items: dict[str, Any] = raw_items if isinstance(raw_items, dict) else {}
+        raw_hints = data.get("hints")
+        hints: dict[str, Any] = raw_hints if isinstance(raw_hints, dict) else {}
+        keys = data.get("keys")
+        key_iter = keys if isinstance(keys, list) else list(items.keys())
+
+        feature = ""
+        try:
+            base = name.split(".unresolved", 1)[0]
+            if "_" in base:
+                feature = base.split("_", 1)[1]
+        except Exception:
+            feature = ""
+
+        for raw_ck in key_iter:
+            ck = str(raw_ck or "").strip()
+            if not ck or ck in out:
+                continue
+            hint = hints.get(ck) if isinstance(hints, dict) else None
+            reason = str(hint.get("reason") or "").strip() if isinstance(hint, Mapping) else ""
+            rec: dict[str, Any] = {"key": ck, "reason": reason, "feature": feature}
+            item = items.get(ck) if isinstance(items, dict) else None
+            if isinstance(item, Mapping):
+                rec["item"] = dict(item)
+            out[ck] = rec
+    return list(out.values())
 
 
 # Write helpers
@@ -275,7 +335,18 @@ def record_unresolved(
         effective_hint = item_hint or hint
         if effective_hint:
             hints = data.setdefault("hints", {})
-            hints[ck] = {"reason": str(effective_hint), "ts": now}
+            existing_hint = hints.get(ck) if isinstance(hints, dict) else None
+            existing_reason = ""
+            if isinstance(existing_hint, Mapping):
+                existing_reason = str(existing_hint.get("reason") or "").strip()
+            new_reason = str(effective_hint).strip()
+            if (
+                existing_reason
+                and existing_reason not in _GENERIC_FAILURE_HINTS
+                and new_reason in _GENERIC_FAILURE_HINTS
+            ):
+                continue
+            hints[ck] = {"reason": new_reason, "ts": now}
 
     ok, error = _atomic_write(path, data)
     return {"ok": ok, "count": added if ok else 0, "path": str(path), **({"error": error} if error else {})}


### PR DESCRIPTION
# Pull request

## Change

Reworks the orchestrator apply and pairing logic:

- Fixes one-way ratings removes to honor source_deletes. 
- Removes come from items un-rated on the source, not a mirror of the destination.
- Reports frozen and skipped items as unresolved.
- Emits ui:spotlight items for add, update and remove.
- Hardens snapshot, blackbox and unresolved handling.

## Why

One-way ratings deleted destination items that were not on the source. This lost ratings added on the other side.
Frozen items were skipped silently. Counts read as confirmed when they were not.

## Testing

Ran two-way ratings. Adds went both ways. No unwanted removes.

Ran history sync. Counts matched the plan.

Ran multiple test scripts

## Issue

NA
