### PR TITLE
Fix: remove freeze logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
   * Analyzer: Finds items that are **stuck** or inconsistent between providers.
   * Playback Progress Manager: View and edit unfinished playback sessions across providers.
   * Editor: Inspect and adjust your items and add or block items.
+  * Events Viewer: Search and inspect sync runs.
   * Captures: Rollback tool for provider watchlist, ratings, and history.
   * Backup & Restore: Create, validate, import and restore configuration.
 

--- a/_logging.py
+++ b/_logging.py
@@ -1,5 +1,5 @@
 # _logging.py
-# CrossWatch - logging: A simple logging utility with color and JSON support.
+# CrossWatch - logging utility
 # Copyright (c) 2025-2026 CrossWatch / Cenodude
 from __future__ import annotations
 

--- a/providers/sync/_mod_SIMKL.py
+++ b/providers/sync/_mod_SIMKL.py
@@ -75,7 +75,7 @@ def _confirmed_keys(key_of, items: Iterable[Mapping[str, Any]], unresolved: Any)
         seen.add(k)
     return out
 
-__VERSION__ = "1.2"
+__VERSION__ = "1.3"
 __all__ = ["get_manifest", "SIMKLModule", "OPS"]
 
 

--- a/providers/sync/_mod_TRAKT.py
+++ b/providers/sync/_mod_TRAKT.py
@@ -89,7 +89,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.1"
+__VERSION__ = "1.2"
 __all__ = ["get_manifest", "TRAKTModule", "OPS"]
 
 os.environ.setdefault("CW_TRAKT_UA", f"CrossWatch TRAKT/{__VERSION__}")

--- a/providers/sync/plex/_history.py
+++ b/providers/sync/plex/_history.py
@@ -301,6 +301,7 @@ class HistoryCatalog:
             "rk": rk,
             "type": "episode" if kind in ("episode", "anime") else ("show" if kind in ("show", "season") else "movie"),
             "title": entry.get("title"),
+            "series_title": entry.get("series_title") or entry.get("show_title"),
             "year": entry.get("year"),
             "library_id": entry.get("library_id"),
             "ids": dict(entry.get("ids") or {}),
@@ -458,6 +459,8 @@ def _catalog_entry_to_minimal(e: Mapping[str, Any]) -> dict[str, Any]:
     if e.get("library_id") is not None:
         row["library_id"] = e.get("library_id")
     if kind == "episode":
+        if e.get("series_title"):
+            row["series_title"] = e.get("series_title")
         if e.get("show_ids"):
             row["show_ids"] = dict(e.get("show_ids") or {})
         if e.get("season") is not None:
@@ -897,6 +900,7 @@ def _live_watched_entry(meta: Mapping[str, Any], ts: int) -> dict[str, Any] | No
         "rk": str(rk),
         "type": meta.get("type") or "movie",
         "title": meta.get("title"),
+        "series_title": meta.get("series_title") or meta.get("show_title"),
         "year": meta.get("year"),
         "library_id": meta.get("library_id"),
         "ids": ids,
@@ -917,6 +921,109 @@ def _iter_live_watched(adapter: Any, allow: set[str], *, full: bool = True) -> l
         if entry:
             out.append(entry)
     return out
+
+
+def _populate_catalog_episode_leaves(adapter: Any, allow: set[str], cat: HistoryCatalog) -> int:
+    srv = getattr(getattr(adapter, "client", None), "server", None)
+    if not srv:
+        return 0
+    base = _as_base_url(srv)
+    ses = getattr(srv, "_session", None)
+    token = getattr(srv, "token", None) or getattr(srv, "_token", None) or ""
+    if not (base and ses and token):
+        return 0
+
+    headers = dict(getattr(ses, "headers", {}) or {})
+    headers.update(plex_headers(token))
+    headers["Accept"] = "application/json"
+
+    try:
+        page_size = int(_history_cfg_get(adapter, "episode_catalog_page_size", 1000) or 1000)
+    except Exception:
+        page_size = 1000
+    page_size = max(100, min(page_size, 2000))
+
+    try:
+        sections = list(adapter.libraries(types=("show",)) or [])
+    except Exception:
+        sections = []
+
+    added = 0
+    scanned = 0
+    t0 = time.time()
+    for sec_obj in sections:
+        section_id = _marked_section_id(sec_obj) or ""
+        if not section_id or (allow and section_id not in allow):
+            continue
+        start = 0
+        seen_pages: set[tuple[str, ...]] = set()
+        while True:
+            params = {
+                "type": 4,
+                "sort": "episode.addedAt",
+                "includeGuids": 1,
+                "X-Plex-Container-Start": start,
+                "X-Plex-Container-Size": page_size,
+            }
+            try:
+                r = ses.get(f"{base}/library/sections/{section_id}/all", params=params, headers=headers, timeout=20)
+            except Exception:
+                break
+            if not getattr(r, "ok", False):
+                break
+            try:
+                ctype = (r.headers.get("content-type") or "").lower()
+                data = (r.json() or {}) if "application/json" in ctype else _xml_to_container(r.text or "")
+                mc = data.get("MediaContainer") or {}
+                rows0 = mc.get("Metadata") or []
+                rows = [x for x in rows0 if isinstance(x, Mapping)]
+                total = mc.get("totalSize")
+                total_i = int(total) if total is not None else None
+            except Exception:
+                rows = []
+                total_i = None
+            if not rows:
+                break
+            signature = tuple(str(row.get("ratingKey") or row.get("key") or "") for row in rows)
+            if signature in seen_pages:
+                break
+            seen_pages.add(signature)
+            scanned += len(rows)
+            for row in rows:
+                meta = normalize_discover_row(row, token=token) or {}
+                ids = dict(meta.get("ids") or {})
+                rk = str(ids.get("plex") or row.get("ratingKey") or "").strip()
+                if not rk:
+                    continue
+                existing = cat.by_rk.get(rk) or {}
+                entry = {
+                    "rk": rk,
+                    "type": "episode",
+                    "title": meta.get("title") or row.get("grandparentTitle") or row.get("title"),
+                    "series_title": meta.get("series_title") or meta.get("show_title") or row.get("grandparentTitle"),
+                    "library_id": meta.get("library_id"),
+                    "ids": ids,
+                    "show_ids": dict(meta.get("show_ids") or {}),
+                    "show_rk": (meta.get("show_ids") or {}).get("plex") if isinstance(meta.get("show_ids"), Mapping) else None,
+                    "season": meta.get("season"),
+                    "episode": meta.get("episode"),
+                    "watched": bool(existing.get("watched")),
+                    "view_count": existing.get("view_count"),
+                    "last_viewed_at": existing.get("last_viewed_at"),
+                }
+                cat.add(entry)
+                added += 1
+            start += len(rows)
+            if total_i is not None and start >= total_i:
+                break
+            if len(rows) < page_size:
+                break
+
+    _emit({
+        "event": "plex.catalog", "action": "episode_leaves", "feature": "history", "level": "debug",
+        "scanned": scanned, "added": added, "duration_ms": int((time.time() - t0) * 1000),
+    })
+    return added
 
 
 def _build_history_catalog(adapter: Any, allow: set[str], *, force: bool = False, live: bool = True) -> HistoryCatalog:
@@ -1549,6 +1656,15 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         unresolved: list[dict[str, Any]] = []
         shadow_batch: list[Mapping[str, Any]] = []
         to_scrobble: list[tuple[Mapping[str, Any], str, str, int]] = []
+        episode_catalog_filled = False
+
+        def _ensure_episode_catalog() -> None:
+            nonlocal episode_catalog_filled
+            if episode_catalog_filled:
+                return
+            episode_catalog_filled = True
+            if _populate_catalog_episode_leaves(adapter, allow, cat):
+                _store_history_catalog(adapter, allow, cat)
 
         for item in items or []:
             key = canonical_key(item) or ""
@@ -1575,14 +1691,11 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 ok += 1
                 continue
 
+            if not rk and klass == CLASS_SHOW_MATCHED_EPISODE_MISSING:
+                _ensure_episode_catalog()
+                rk, klass = cat.resolve(item, strict=write_strict)
+
             if not rk and klass == CLASS_RESOLVE_AMBIGUOUS:
-                # The catalog is built from the full PMS GUID index + a
-                # live-watched scan, so a definitive miss (not_in_plex_catalog /
-                # show_matched_episode_missing) is authoritative -- the per-item
-                # Plex fallback would fire a live search only to re-confirm it,
-                # which is what made large unresolved backlogs take minutes.
-                # Only an ambiguous catalog match can benefit from a targeted
-                # lookup, so restrict the (expensive) fallback to that case.
                 rk = _resolve_rating_key(adapter, item, strict=write_strict)
 
             if not rk:

--- a/providers/sync/simkl/_ratings.py
+++ b/providers/sync/simkl/_ratings.py
@@ -35,10 +35,6 @@ URL_ADD = f"{BASE}/sync/ratings"
 URL_REMOVE = f"{BASE}/sync/ratings/remove"
 
 
-def _unresolved_path() -> str:
-    return str(state_file("simkl_ratings.unresolved.json"))
-
-
 def _shadow_path() -> str:
     return str(state_file("simkl.ratings.shadow.json"))
 
@@ -147,64 +143,6 @@ def _load_json(path: str) -> dict[str, Any]:
 
 def _save_json(path: str, data: Mapping[str, Any]) -> None:
     save_json_state(path, data)
-
-
-def _load_unresolved() -> dict[str, Any]:
-    data = _load_json(_unresolved_path())
-    if not isinstance(data, dict):
-        return {}
-    cleaned = False
-    for k in list(data.keys()):
-        if _is_unknown_key(k):
-            data.pop(k, None)
-            cleaned = True
-    if cleaned:
-        _save_json(_unresolved_path(), data)
-    return data
-
-
-def _save_unresolved(data: Mapping[str, Any]) -> None:
-    _save_json(_unresolved_path(), data)
-
-
-def _is_frozen(item: Mapping[str, Any]) -> bool:
-    key = simkl_key_of(id_minimal(dict(item)))
-    return key in _load_unresolved()
-
-
-def _freeze(
-    item: Mapping[str, Any],
-    *,
-    action: str,
-    reasons: list[str],
-    ids_sent: Mapping[str, Any],
-    rating: int | None,
-) -> None:
-    key = simkl_key_of(id_minimal(dict(item)))
-    if _is_unknown_key(key):
-        return
-    data = _load_unresolved()
-    row = data.get(key) or {"feature": "ratings", "action": action, "first_seen": _now(), "attempts": 0}
-    row.update({"item": id_minimal(dict(item)), "last_attempt": _now()})
-    existing_reasons: list[str] = list(row.get("reasons", [])) if isinstance(row.get("reasons"), list) else []
-    row["reasons"] = sorted(set(existing_reasons) | set(reasons or []))
-    row["ids_sent"] = dict(ids_sent or {})
-    if rating is not None:
-        row["rating"] = int(rating)
-    row["attempts"] = int(row.get("attempts", 0)) + 1
-    data[key] = row
-    _save_unresolved(data)
-
-
-def _unfreeze_if_present(keys: Iterable[str]) -> None:
-    data = _load_unresolved()
-    changed = False
-    for k in set(keys or []):
-        if k in data:
-            del data[k]
-            changed = True
-    if changed:
-        _save_unresolved(data)
 
 
 def _rshadow_load() -> dict[str, Any]:
@@ -602,7 +540,6 @@ def build_index(adapter: Any, *, since_iso: str | None = None) -> dict[str, dict
                     prog.done(ok=True, total=len(out))
                 except Exception:
                     pass
-            _unfreeze_if_present(thaw)
             try:
                 _rshadow_put_all(out.values())
             except Exception as exc:
@@ -776,7 +713,6 @@ def build_index(adapter: Any, *, since_iso: str | None = None) -> dict[str, dict
     if latest_any is not None:
         update_watermark_if_new("ratings", _as_iso(latest_any))
 
-    _unfreeze_if_present(thaw)
     try:
         _rshadow_replace_all(out.values())
     except Exception as exc:
@@ -921,9 +857,6 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 unresolved.append({"item": mini, "hint": "missing_or_invalid_type"})
                 continue
 
-            if _is_frozen(it):
-                continue
-
             if typ == "movie" and group == "movies":
                 ent = _movie_entry_add(it)
                 if ent:
@@ -992,7 +925,6 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                     simkl_key_of(id_minimal(dict(item)))
                     for item in confirmed
                 }
-                _unfreeze_if_present(confirmed_keys)
                 ok += len(confirmed)
                 try:
                     _rshadow_put_all(
@@ -1003,25 +935,15 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 except Exception as exc:
                     _warn("cache_save_failed", cache="shadow", op="add", error=str(exc))
                 for item in rejected:
-                    ids = _ids_of(item)
-                    rating = _norm_rating(item.get("rating"))
                     unresolved.append({"item": id_minimal(dict(item)), "hint": "simkl_not_found"})
-                    if ids and rating is not None:
-                        _freeze(item, action="add", reasons=["not_found"], ids_sent=ids, rating=rating)
             else:
                 _warn("write_failed", op="add", status=resp.status_code, body=(resp.text or '')[:180])
                 for it in attempted:
-                    ids = _ids_of(it)
-                    rating = _norm_rating(it.get("rating"))
-                    if ids and rating is not None:
-                        _freeze(it, action="add", reasons=["write_failed"], ids_sent=ids, rating=rating)
+                    unresolved.append({"item": id_minimal(dict(it)), "hint": "write_failed"})
         except Exception as exc:
             _warn("write_failed", op="add", error=str(exc))
             for it in attempted:
-                ids = _ids_of(it)
-                rating = _norm_rating(it.get("rating"))
-                if ids and rating is not None:
-                    _freeze(it, action="add", reasons=["write_failed"], ids_sent=ids, rating=rating)
+                unresolved.append({"item": id_minimal(dict(it)), "hint": "write_failed"})
 
     _info("write_done", op="add", ok=bool(items_list) and len(unresolved) == 0 and ok == len(items_list), applied=ok, unresolved=len(unresolved))
     return ok, unresolved
@@ -1048,9 +970,6 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
             key = simkl_key_of(mini)
             if _is_unknown_key(key):
                 unresolved.append({"item": mini, "hint": "missing_identity"})
-                continue
-
-            if _is_frozen(it):
                 continue
 
             ids = _ids_of(it) or _show_ids_of_episode(it)
@@ -1103,7 +1022,6 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
                     simkl_key_of(id_minimal(dict(item)))
                     for item in confirmed
                 }
-                _unfreeze_if_present(confirmed_keys)
                 try:
                     sh = _rshadow_load()
                     store: dict[str, Any] = dict(sh.get("items") or {})
@@ -1119,19 +1037,14 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
                     pass
                 ok += len(confirmed)
                 for item in rejected:
-                    ids = _ids_of(item) or _show_ids_of_episode(item)
                     unresolved.append({"item": id_minimal(dict(item)), "hint": "simkl_not_found"})
-                    if ids:
-                        _freeze(item, action="remove", reasons=["not_found"], ids_sent=ids, rating=None)
                 continue
             _warn("write_failed", op="remove", status=resp.status_code, body=(resp.text or '')[:180])
         except Exception as exc:
             _warn("write_failed", op="remove", error=str(exc))
 
         for it in attempted:
-            ids = _ids_of(it) or _show_ids_of_episode(it)
-            if ids:
-                _freeze(it, action="remove", reasons=["write_failed"], ids_sent=ids, rating=None)
+            unresolved.append({"item": id_minimal(dict(it)), "hint": "write_failed"})
 
     _info("write_done", op="remove", ok=bool(items_list) and len(unresolved) == 0 and ok == len(items_list), applied=ok, unresolved=len(unresolved))
     return ok, unresolved

--- a/providers/sync/trakt/_history.py
+++ b/providers/sync/trakt/_history.py
@@ -45,10 +45,6 @@ def _int_or_none(x: Any) -> int | None:
         return None
 
 
-def _unresolved_path() -> Path:
-    return state_file("trakt_history.unresolved.json")
-
-
 def _cache_path() -> Path:
     return state_file("trakt_history.index.json")
 
@@ -187,14 +183,6 @@ def _chunked_items(seq: list[Mapping[str, Any]], n: int) -> Iterable[list[Mappin
         yield seq[i : i + size]
 
 
-def _freeze_enabled(adapter: Any) -> bool:
-    v = _cfg_get(adapter, "history_unresolved", False)
-    try:
-        return bool(v)
-    except Exception:
-        return False
-
-
 def _history_number_fallback_enabled(adapter: Any) -> bool:
     return True if not RESOLVE_ENABLE else bool(_cfg_get(adapter, "history_number_fallback", False))
 
@@ -216,28 +204,6 @@ def _history_collection_types(adapter: Any) -> set[str]:
         out = {"movies"}
     return out
 
-
-
-def _load_unresolved() -> dict[str, Any]:
-    if _is_capture_mode() or _pair_scope() is None:
-        return {}
-    p = _unresolved_path()
-    try:
-        return json.loads(p.read_text("utf-8"))
-    except Exception:
-        return {}
-
-
-def _save_unresolved(data: Mapping[str, Any]) -> None:
-    if _is_capture_mode() or _pair_scope() is None:
-        return
-    try:
-        _unresolved_path().parent.mkdir(parents=True, exist_ok=True)
-        tmp = _unresolved_path().with_suffix(".tmp")
-        tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True), "utf-8")
-        os.replace(tmp, _unresolved_path())
-    except Exception as e:
-        _warn("cache_save_failed", cache="unresolved", op="save", error=str(e))
 
 
 def _load_cache_doc() -> dict[str, Any]:
@@ -374,40 +340,6 @@ def _cache_remove_source_items(adapter: Any, items: Iterable[Mapping[str, Any]])
     except Exception as e:
         _warn("cache_save_failed", cache="index", op="remove", error=str(e))
 
-
-
-def _freeze_item_if_enabled(adapter: Any, item: Mapping[str, Any], *, action: str, reasons: list[str]) -> None:
-    if not _freeze_enabled(adapter):
-        return
-    m = id_minimal(item)
-    k = key_of(m)
-    data = _load_unresolved()
-    entry = data.get(k) or {"feature": "history", "action": action, "first_seen": _now_iso(), "attempts": 0}
-    entry.update({"item": m, "last_attempt": _now_iso()})
-    rset = set(entry.get("reasons", [])) | set(reasons or [])
-    entry["reasons"] = sorted(rset)
-    entry["attempts"] = int(entry.get("attempts", 0)) + 1
-    data[k] = entry
-    _save_unresolved(data)
-
-
-def _unfreeze_keys_if_present(adapter: Any, keys: Iterable[str]) -> None:
-    if not _freeze_enabled(adapter):
-        return
-    data = _load_unresolved()
-    changed = False
-    for k in list(keys or []):
-        if k in data:
-            del data[k]
-            changed = True
-    if changed:
-        _save_unresolved(data)
-
-
-def _is_frozen(adapter: Any, item: Mapping[str, Any]) -> bool:
-    if not _freeze_enabled(adapter):
-        return False
-    return key_of(id_minimal(item)) in _load_unresolved()
 
 
 def _hdr_int(headers: Mapping[str, Any], name: str) -> int | None:
@@ -664,7 +596,6 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 100000) -
                     start_at=start_at,
                 )
 
-                base_keys_to_unfreeze: set[str] = set()
                 added = 0
 
                 for m in movies + episodes:
@@ -697,10 +628,8 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 100000) -
                         continue
 
                     idx[ek] = m
-                    base_keys_to_unfreeze.add(base_key)
                     added += 1
 
-                _unfreeze_keys_if_present(adapter, base_keys_to_unfreeze)
                 _dbg("index_fetch_counts", source="cache_delta", added=added, count=len(idx))
 
                 count_ok = True
@@ -797,7 +726,6 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 100000) -
         bump=bump,
     )
     idx: dict[str, dict[str, Any]] = {}
-    base_keys_to_unfreeze: set[str] = set()
     for m in movies + episodes:
         w = _iso8601(m.get("watched_at"))
         ts = _as_epoch(w) if w else None
@@ -847,12 +775,9 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 100000) -
 
             _warn("index_reconcile", reason="key_collision", key=ek, key2=ek2, imdb=imdb_id or None, trakt=trakt_id or None, tmdb=tmdb_id or None, history_id=hid or None)
             idx[ek2] = m
-            base_keys_to_unfreeze.add(alt_base)
         else:
             idx[ek] = m
-            base_keys_to_unfreeze.add(base_key)
 
-    _unfreeze_keys_if_present(adapter, base_keys_to_unfreeze)
     if prog:
         try:
             if announced_total is not None:
@@ -1139,10 +1064,6 @@ def _batch_add(
         accepted_keys.append(key_of(m))
 
     for it in items or []:
-        if _is_frozen(adapter, it):
-            _dbg("skip_frozen", title=id_minimal(it).get("title"))
-            continue
-
         kind = (pick_trakt_kind(it) or "movies").lower()
         ids = ids_for_trakt(it)
         show_ids = _extract_show_ids_for_episode(it)
@@ -1159,14 +1080,12 @@ def _batch_add(
         if when_error:
             m = _history_item_minimal(kind, it, ids)
             unresolved.append({"item": m, "hint": when_error})
-            _freeze_item_if_enabled(adapter, m, action="add", reasons=[when_error.replace(" ", "-")])
             continue
 
         if kind == "movies":
             if not ids:
                 m = _history_item_minimal(kind, it, ids)
                 unresolved.append({"item": m, "hint": "missing ids"})
-                _freeze_item_if_enabled(adapter, m, action="add", reasons=["missing-ids"])
                 continue
             obj: dict[str, Any] = {"ids": ids}
             if when:
@@ -1183,7 +1102,6 @@ def _batch_add(
             if not ids:
                 m = _history_item_minimal(kind, it, ids)
                 unresolved.append({"item": m, "hint": "missing ids"})
-                _freeze_item_if_enabled(adapter, m, action="add", reasons=["missing-ids"])
                 continue
             skey = _show_key(ids)
             entry = shows_map.setdefault(skey, {"ids": ids, "seasons": {}})
@@ -1207,7 +1125,6 @@ def _batch_add(
                 if season_i is None:
                     m = _history_item_minimal(kind, it, ids)
                     unresolved.append({"item": m, "hint": "invalid season number"})
-                    _freeze_item_if_enabled(adapter, m, action="add", reasons=["season-number-invalid"])
                     continue
                 season_entry = entry["seasons"].setdefault(season_i, {"number": season_i})
                 if when:
@@ -1216,7 +1133,6 @@ def _batch_add(
                 continue
             m = _history_item_minimal(kind, it, ids)
             unresolved.append({"item": m, "hint": "season scope or ids missing"})
-            _freeze_item_if_enabled(adapter, m, action="add", reasons=["season-scope-missing"])
             continue
         if kind == "episodes":
             show_scope_ok = bool(show_ids and season_no is not None and episode_no is not None)
@@ -1229,7 +1145,6 @@ def _batch_add(
             if not show_scope_ok and (season_no is None or episode_no is None) and not (ids and ("trakt" in ids)):
                 m = _history_item_minimal(kind, it, ids)
                 unresolved.append({"item": m, "hint": "missing season/episode"})
-                _freeze_item_if_enabled(adapter, m, action="add", reasons=["missing-season-episode"])
                 continue
 
             if use_ids:
@@ -1267,7 +1182,6 @@ def _batch_add(
 
             m = _history_item_minimal(kind, it, ids)
             unresolved.append({"item": m, "hint": "episode scope or ids missing"})
-            _freeze_item_if_enabled(adapter, m, action="add", reasons=["episode-scope-missing"])
 
     body: dict[str, Any] = {}
     if movies:
@@ -1313,10 +1227,6 @@ def _batch_remove(
         accepted_keys.append(key_of(m))
 
     for it in items or []:
-        if _is_frozen(adapter, it):
-            _dbg("skip_frozen", title=id_minimal(it).get("title"))
-            continue
-
         raw_history_id = _parse_raw_history_id(it)
         if raw_history_id is not None:
             m = id_minimal(it)
@@ -1341,7 +1251,6 @@ def _batch_remove(
             if not ids:
                 m = _history_item_minimal(kind, it, ids)
                 unresolved.append({"item": m, "hint": "missing ids"})
-                _freeze_item_if_enabled(adapter, m, action="remove", reasons=["missing-ids"])
                 continue
             movies.append({"ids": ids})
             _accept(_history_item_minimal(kind, it, ids))
@@ -1351,7 +1260,6 @@ def _batch_remove(
             if not ids:
                 m = _history_item_minimal(kind, it, ids)
                 unresolved.append({"item": m, "hint": "missing ids"})
-                _freeze_item_if_enabled(adapter, m, action="remove", reasons=["missing-ids"])
                 continue
             skey = _show_key(ids)
             shows_map.setdefault(skey, {"ids": ids, "seasons": {}})
@@ -1370,14 +1278,12 @@ def _batch_remove(
                 if season_i is None:
                     m = _history_item_minimal(kind, it, ids)
                     unresolved.append({"item": m, "hint": "invalid season number"})
-                    _freeze_item_if_enabled(adapter, m, action="remove", reasons=["season-number-invalid"])
                     continue
                 entry["seasons"].setdefault(season_i, {"number": season_i})
                 _accept(_history_item_minimal(kind, it, ids))
                 continue
             m = _history_item_minimal(kind, it, ids)
             unresolved.append({"item": m, "hint": "season scope or ids missing"})
-            _freeze_item_if_enabled(adapter, m, action="remove", reasons=["season-scope-missing"])
             continue
 
         if kind == "episodes":
@@ -1389,7 +1295,6 @@ def _batch_remove(
                 if season_i is None or ep_i is None:
                     m = _history_item_minimal(kind, it, ids)
                     unresolved.append({"item": m, "hint": "invalid season/episode number"})
-                    _freeze_item_if_enabled(adapter, m, action="remove", reasons=["season-episode-number-invalid"])
                     continue
                 season_entry = entry["seasons"].setdefault(season_i, {"number": season_i, "episodes": []})
                 season_entry.setdefault("episodes", []).append({"number": ep_i})
@@ -1401,7 +1306,6 @@ def _batch_remove(
                 continue
             m = _history_item_minimal(kind, it, ids)
             unresolved.append({"item": m, "hint": "episode scope or ids missing"})
-            _freeze_item_if_enabled(adapter, m, action="remove", reasons=["episode-scope-missing"])
 
     body: dict[str, Any] = {}
     if movies:
@@ -1658,13 +1562,8 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 pass
 
             unresolved.append(u)
-            try:
-                _freeze_item_if_enabled(adapter, u["item"], action="add", reasons=["not-found"])
-            except Exception:
-                pass
 
         if ok_total > 0:
-            _unfreeze_keys_if_present(adapter, accepted_keys)
             unresolved_keys_for_cache: set[str] = set()
             try:
                 for u in unresolved or []:
@@ -1724,7 +1623,6 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             skipped_keys = list(dict.fromkeys(list(skipped_keys or []) + list(accepted_keys or [])))
         except Exception:
             pass
-        _unfreeze_keys_if_present(adapter, accepted_keys)
         _bust_index_cache("write:add:duplicate")
     elif r.status_code == 420:
         _warn("rate_limit", op="add", status=420)
@@ -1736,7 +1634,6 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
     else:
         _warn("write_failed", op="add", status=r.status_code, body=((r.text or "")[:200]))
         for m in accepted_minimals:
-            _freeze_item_if_enabled(adapter, m, action="add", reasons=[f"http:{r.status_code}"])
             unresolved.append({"item": m, "hint": f"http:{r.status_code}"})
     _info("write_done", op="add", ok=len(unresolved) == 0, applied=ok_added, unresolved=len(unresolved), skipped=len(skipped_keys))
     return ok_added, unresolved, skipped_keys
@@ -1794,17 +1691,15 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
             nf_unresolved = _unresolved_from_not_found(nf, raw_id_map)
             for u in nf_unresolved:
                 unresolved.append(u)
-                _freeze_item_if_enabled(adapter, u["item"], action="remove", reasons=["not-found"])
 
             if part_ok > 0:
                 ok += part_ok
-                _unfreeze_keys_if_present(adapter, accepted_keys)
                 _cache_remove_source_items(adapter, accepted_minimals)
             elif not nf_unresolved:
                 _dbg("write_prepare", op="remove", reason="noop_response", chunk_items=len(part))
         else:
             _warn("write_failed", op="remove", status=r.status_code, body=((r.text or "")[:200]))
             for m in accepted_minimals:
-                _freeze_item_if_enabled(adapter, m, action="remove", reasons=[f"http:{r.status_code}"])
+                unresolved.append({"item": m, "hint": f"http:{r.status_code}"})
     _info("write_done", op="remove", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
     return ok, unresolved

--- a/providers/sync/trakt/_watchlist.py
+++ b/providers/sync/trakt/_watchlist.py
@@ -35,8 +35,6 @@ def _shadow_path() -> Path:
     return state_file("trakt_watchlist.shadow.json")
 
 
-def _unresolved_path() -> Path:
-    return state_file("trakt_watchlist.unresolved.json")
 
 
 
@@ -145,71 +143,6 @@ def _shadow_save(etag: str | None, items: Mapping[str, Any]) -> None:
         pass
 
 
-# Unresolved state
-def _load_unresolved() -> dict[str, Any]:
-    if _is_capture_mode() or _pair_scope() is None:
-        return {}
-    p = _unresolved_path()
-    try:
-        return json.loads(p.read_text("utf-8"))
-    except Exception:
-        return {}
-
-
-def _save_unresolved(data: Mapping[str, Any]) -> None:
-    if _is_capture_mode() or _pair_scope() is None:
-        return
-    try:
-        _unresolved_path().parent.mkdir(parents=True, exist_ok=True)
-        tmp = _unresolved_path().with_suffix(".tmp")
-        tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True), "utf-8")
-        os.replace(tmp, _unresolved_path())
-    except Exception as e:
-        _warn("cache_save_failed", cache="unresolved", op="save", error=str(e))
-
-
-def _freeze_item(
-    item: Mapping[str, Any],
-    *,
-    action: str,
-    reasons: list[str],
-    details: Mapping[str, Any] | None = None,
-) -> None:
-    m = id_minimal(item)
-    key = key_of(m)
-    data = _load_unresolved()
-    entry = data.get(key) or {
-        "feature": "watchlist",
-        "action": action,
-        "first_seen": _now_iso(),
-        "attempts": 0,
-    }
-    entry.update({"item": m, "last_attempt": _now_iso()})
-    rset = set(entry.get("reasons", [])) | set(reasons or [])
-    entry["reasons"] = sorted(rset)
-    if details:
-        cur_details = dict(entry.get("details") or {})
-        cur_details.update(details)
-        entry["details"] = cur_details
-    entry["attempts"] = int(entry.get("attempts", 0)) + 1
-    data[key] = entry
-    _save_unresolved(data)
-
-
-def _unfreeze_keys_if_present(keys: Iterable[str]) -> None:
-    data = _load_unresolved()
-    changed = False
-    for k in list(keys or []):
-        if k in data:
-            del data[k]
-            changed = True
-    if changed:
-        _save_unresolved(data)
-
-
-def _is_frozen(item: Mapping[str, Any]) -> bool:
-    return key_of(id_minimal(item)) in _load_unresolved()
-
 # Rate limit logging
 def _log_rate_headers(resp: Any) -> None:
     try:
@@ -270,7 +203,6 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
         total = len(idx)
         _tick(prog, 0, total=total, force=True)
         _tick(prog, total, total=total)
-        _unfreeze_keys_if_present(idx.keys())
         _info("index_done", count=len(idx), source="shadow")
         return idx
 
@@ -280,7 +212,6 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
         total = len(idx)
         _tick(prog, 0, total=total, force=True)
         _tick(prog, total, total=total)
-        _unfreeze_keys_if_present(idx.keys())
         _info("index_done", count=len(idx), source="shadow_fallback")
         return idx
 
@@ -289,7 +220,6 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
     idx: dict[str, dict[str, Any]] = {key_of(m): m for m in items}
     if use_etag:
         _shadow_save(etag, idx)
-    _unfreeze_keys_if_present(idx.keys())
 
     total = len(idx)
     _tick(prog, 0, total=total, force=True)
@@ -307,10 +237,6 @@ def _batch_payload(
     rejected: list[dict[str, Any]] = []
     for it in items or []:
         m = id_minimal(it)
-        if _is_frozen(m):
-            _dbg("write_item_skipped", reason="frozen", item=m)
-            continue
-
         kind = pick_trakt_kind(m)
         ids = ids_for_trakt(m)
         show_ids = dict(m.get("show_ids") or {})
@@ -335,21 +261,14 @@ def _batch_payload(
     return accepted, rejected
 
 
-def _freeze_not_found(
+def _record_not_found(
     not_found: Mapping[str, Any],
     *,
     action: str,
     unresolved: list[dict[str, Any]],
-    add_details: bool,
 ) -> None:
     def freeze_minimal(m: dict[str, Any], details: Mapping[str, Any] | None = None) -> None:
         unresolved.append({"item": m, "hint": "not_found"})
-        _freeze_item(
-            m,
-            action=action,
-            reasons=[f"{action}:not-found"],
-            details=details if add_details else None,
-        )
 
     for t in ("movies", "seasons", "episodes"):
         for obj in (not_found.get(t) or []):
@@ -411,7 +330,6 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
     cfg = _cfg(adapter)
     batch = _cfg_int(cfg, "watchlist_batch_size", 100)
     log_rates = _cfg_bool(cfg, "watchlist_log_rate_limits", True)
-    freeze_details = _cfg_bool(cfg, "watchlist_freeze_details", True)
 
     vip = bool(cfg.get("vip"))
     wl_limit = None if vip else int(cfg.get("watchlist_limit") or 100)
@@ -466,7 +384,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             ok += sum(int(added.get(k) or 0) for k in ("movies", "shows", "seasons", "episodes"))
             ok += sum(int(existing.get(k) or 0) for k in ("movies", "shows", "seasons", "episodes"))
             nf = d.get("not_found") or {}
-            _freeze_not_found(nf, action="add", unresolved=unresolved, add_details=freeze_details)
+            _record_not_found(nf, action="add", unresolved=unresolved)
         elif r.status_code == 420:
             upgrade_url = r.headers.get("X-Upgrade-URL")
             _warn("rate_limit", op="add", status=420, upgrade_url=upgrade_url)
@@ -483,12 +401,6 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             _warn("write_failed", op="add", status=r.status_code, body=((r.text or "")[:180]))
             for x in sl:
                 unresolved.append({"item": x, "hint": f"http:{r.status_code}"})
-                _freeze_item(
-                    x,
-                    action="add",
-                    reasons=[f"http:{r.status_code}"],
-                    details={"status": r.status_code} if freeze_details else None,
-                )
     _info("write_done", op="add", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
     return ok, unresolved
 
@@ -496,7 +408,6 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
     cfg = _cfg(adapter)
     batch = _cfg_int(cfg, "watchlist_batch_size", 100)
     log_rates = _cfg_bool(cfg, "watchlist_log_rate_limits", True)
-    freeze_details = _cfg_bool(cfg, "watchlist_freeze_details", True)
 
     sess = adapter.client.session
     headers = headers_for_adapter(adapter)
@@ -528,17 +439,11 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
             deleted = d.get("deleted") or d.get("removed") or {}
             ok += sum(int(deleted.get(k) or 0) for k in ("movies", "shows", "seasons", "episodes"))
             nf = d.get("not_found") or {}
-            _freeze_not_found(nf, action="remove", unresolved=unresolved, add_details=freeze_details)
+            _record_not_found(nf, action="remove", unresolved=unresolved)
         else:
             _warn("write_failed", op="remove", status=r.status_code, body=((r.text or "")[:180]))
             for x in sl:
                 unresolved.append({"item": x, "hint": f"http:{r.status_code}"})
-                _freeze_item(
-                    x,
-                    action="remove",
-                    reasons=[f"http:{r.status_code}"],
-                    details={"status": r.status_code} if freeze_details else None,
-                )
 
     _info("write_done", op="remove", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
     return ok, unresolved


### PR DESCRIPTION
# Pull request

## Change

- Removes freeze logic from the SIMKL and TRAKT adapters.
- Drops the per-provider freeze skip lists from SIMKL ratings, TRAKT history and TRAKT watchlist. 
- Failed items report as unresolved insteadof silent skips.
- Extends PLEX history resolution.

Updated the SIMKL and TRAKT adapter versions.

## Why

Freeze skipped items silently. Attempted minus unresolved was counted as confirmed, so counts were wrong.
This matches the freeze removal already done for the PLEX adapter.

## Testing

Ran SIMKL ratings, TRAKT history and TRAKT watchlist syncs. 
Failed items now show up as unresolved. No silent skips.
Counts in the run summary match the plan.

## Issue

NA
