### PR TITLE
Fix:  history library scope when a plex id is present

### DIFF
--- a/providers/sync/plex/_history.py
+++ b/providers/sync/plex/_history.py
@@ -1797,10 +1797,12 @@ def _resolve_rating_key(adapter: Any, item: Mapping[str, Any], *, strict: bool |
     if not srv:
         return None
 
+    allow = plex_feature_library_ids(adapter, "history")
     rk = ids.get("plex") or None
     if rk:
         try:
-            if srv.fetchItem(int(rk)):
+            obj_rk = srv.fetchItem(int(rk))
+            if obj_rk and section_allowed(obj_rk, allow):
                 return str(rk)
         except Exception:
             pass
@@ -1811,7 +1813,6 @@ def _resolve_rating_key(adapter: Any, item: Mapping[str, Any], *, strict: bool |
     is_episode = kind == "episode"
 
     strict = bool(plex_cfg_get(adapter, "strict_id_matching", False)) if strict is None else bool(strict)
-    allow = plex_feature_library_ids(adapter, "history")
 
     season = item.get("season") or item.get("season_number")
     episode = item.get("episode") or item.get("episode_number")


### PR DESCRIPTION
# Pull request

## Change

- Checks the library scope in the history rating key resolver when the item already carries a plex id.
- The resolver now fetches the object and confirms it sits in an allowed library before it accepts the plex id. 
- The allow set is computed once up front.

## Why

- A direct plex id skipped the library whitelist. 
- History could resolve to an item outside the allowed libraries.

## Testing

Ran history sync with a library whitelist. Items with a plex id outside the scope no longer resolve. Items inside the scope still sync.

## Issue

Fixes #379
