### PR TITLE
Change: improve Jellyfin and Emby sync result handling

### DIFF
--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -232,8 +232,9 @@ DEFAULT_CFG: dict[str, Any] = {
     },
 
     "simkl": {
-        "access_token": "",                             # OAuth2 access token
-        "client_id": "",                                # From your Simkl app
+        "access_token": "",                             # OAuth2 / PIN access token
+        "auth_method": "",                              # "pin" | "oauth" (metadata; runtime uses access_token + client_id)
+        "client_id": "",                                # From your Simkl app (OAuth); baked app id when connected via PIN
         "client_secret": "",                            # From your Simkl app
         "date_from": "",                                # YYYY-MM-DD (optional start date for full sync)
         "watchlist_batch_size": 500,                    # Batch size for watchlist add/remove writes
@@ -656,7 +657,6 @@ DEFAULT_CFG: dict[str, Any] = {
         "recent_activity_limit": 3,                     # Recent Scrobble rows on Main tab
         "recent_syncs_display": "count:3",              # "count:3|4|5" | "hours:24|48|72"
         "recent_syncs_limit": 3,                        # Recent Sync rows on Main tab
-        "show_AI": True,                                # Show ASK AI from GitBook
         "show_quick_add_desktop": True,                 # Show the Main-tab quick add drawer on desktop
         "show_quick_add_mobile": True,                  # Show the Main-tab quick add floating button on mobile
         "protocol": "http",                             # "http" | "https" (HTTPS uses a self-signed cert by default)
@@ -702,7 +702,7 @@ def redact_config(cfg: dict[str, Any]) -> dict[str, Any]:
     # Provider-specific secret fields
     provider_secret_keys: dict[str, set[str]] = {
         "plex": {"account_token", "pms_token", "home_pin", "webhook_secret"},
-        "simkl": {"access_token", "client_secret"},
+        "simkl": {"access_token", "client_secret", "_pending_pin"},
         "anilist": {"access_token", "client_secret"},
         "mdblist": {"api_key", "access_token", "refresh_token", "_pending_device"},
         "publicmetadb": {"api_key"},
@@ -1397,7 +1397,6 @@ def _normalize_ui(cfg: dict[str, Any]) -> None:
     ui["show_recent_history_widget"] = bool(ui.get("show_recent_history_widget", True))
     ui["show_latest_ratings_widget"] = bool(ui.get("show_latest_ratings_widget", True))
     ui["show_recent_scrobble_widget"] = bool(ui.get("show_recent_scrobble_widget", True))
-    ui["show_AI"] = bool(ui.get("show_AI", True))
     ui["show_quick_add_desktop"] = bool(ui.get("show_quick_add_desktop", True))
     ui["show_quick_add_mobile"] = bool(ui.get("show_quick_add_mobile", True))
 

--- a/providers/sync/_mod_EMBY.py
+++ b/providers/sync/_mod_EMBY.py
@@ -29,7 +29,35 @@ from ._mod_common import (
     parse_rate_limit,  # parity
     label_emby,
     make_snapshot_progress,
+    unresolved_keys as _unresolved_keys,
+    build_op_result,
 )
+
+_HISTORY_META_FIELDS = ("confirmed_keys", "unresolved_keys", "results", "reason_counts")
+
+
+def _finalize_result(adapter: Any, key_of, feature: str, items, cnt: int, unresolved: Any) -> dict[str, Any]:
+    meta = getattr(adapter, "_history_write_meta", None) if feature == "history" else None
+    if isinstance(meta, Mapping):
+        rc = meta.get("reason_counts")
+        return build_op_result(
+            ok=True,
+            count=int(cnt),
+            confirmed_keys=meta.get("confirmed_keys") or [],
+            unresolved_keys=meta.get("unresolved_keys") or _unresolved_keys(unresolved, key_of),
+            unresolved=unresolved,
+            results=meta.get("results") or [],
+            reason_counts=(dict(rc) if isinstance(rc, Mapping) else None),
+        )
+    results = list(getattr(adapter, "_progress_write_results", [])) if feature == "progress" else []
+    return build_op_result(
+        ok=True,
+        count=int(cnt),
+        confirmed_keys=_confirmed_keys(key_of, items, unresolved),
+        unresolved_keys=_unresolved_keys(unresolved, key_of),
+        unresolved=unresolved,
+        results=results,
+    )
 
 
 def _confirmed_keys(key_of, items: Iterable[Mapping[str, Any]], unresolved: Any) -> list[str]:
@@ -77,7 +105,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.2"
+__VERSION__ = "2.0"
 os.environ.setdefault("CW_EMBY_VERSION", __VERSION__)
 os.environ.setdefault("CW_EMBY_UA", f"CrossWatch/{__VERSION__} (Emby)")
 __all__ = ["get_manifest", "EMBYModule", "OPS"]
@@ -590,9 +618,12 @@ class EMBYModule:
                 "unresolved": [],
                 "error": f"unknown_feature:{feature}",
             }
+        try:
+            setattr(self, "_history_write_meta", None)
+        except Exception:
+            pass
         cnt, unresolved = mod.add(self, lst)
-        confirmed_keys = _confirmed_keys(self.key_of, lst, unresolved)
-        return {"ok": True, "count": int(cnt), "unresolved": unresolved, "confirmed_keys": confirmed_keys, "results": list(getattr(self, "_progress_write_results", [])) if f == "progress" else []}
+        return _finalize_result(self, self.key_of, f, lst, cnt, unresolved)
     def remove(
         self,
         feature: str,
@@ -617,9 +648,12 @@ class EMBYModule:
                 "unresolved": [],
                 "error": f"unknown_feature:{feature}",
             }
+        try:
+            setattr(self, "_history_write_meta", None)
+        except Exception:
+            pass
         cnt, unresolved = mod.remove(self, lst)
-        confirmed_keys = _confirmed_keys(self.key_of, lst, unresolved)
-        return {"ok": True, "count": int(cnt), "unresolved": unresolved, "confirmed_keys": confirmed_keys, "results": list(getattr(self, "_progress_write_results", [])) if f == "progress" else []}
+        return _finalize_result(self, self.key_of, f, lst, cnt, unresolved)
 class _EmbyOPS:
     def name(self) -> str:
         return "EMBY"

--- a/providers/sync/_mod_JELLYFIN.py
+++ b/providers/sync/_mod_JELLYFIN.py
@@ -27,7 +27,33 @@ from ._mod_common import (
     parse_rate_limit,  # parity
     label_jellyfin,
     make_snapshot_progress,
+    unresolved_keys as _unresolved_keys,
+    build_op_result,
 )
+
+
+def _finalize_result(adapter: Any, key_of, feature: str, items, cnt: int, unresolved: Any) -> dict[str, Any]:
+    meta = getattr(adapter, "_history_write_meta", None) if feature == "history" else None
+    if isinstance(meta, Mapping):
+        rc = meta.get("reason_counts")
+        return build_op_result(
+            ok=True,
+            count=int(cnt),
+            confirmed_keys=meta.get("confirmed_keys") or [],
+            unresolved_keys=meta.get("unresolved_keys") or _unresolved_keys(unresolved, key_of),
+            unresolved=unresolved,
+            results=meta.get("results") or [],
+            reason_counts=(dict(rc) if isinstance(rc, Mapping) else None),
+        )
+    results = list(getattr(adapter, "_progress_write_results", [])) if feature == "progress" else []
+    return build_op_result(
+        ok=True,
+        count=int(cnt),
+        confirmed_keys=_confirmed_keys(key_of, items, unresolved),
+        unresolved_keys=_unresolved_keys(unresolved, key_of),
+        unresolved=unresolved,
+        results=results,
+    )
 
 
 def _confirmed_keys(key_of, items: Iterable[Mapping[str, Any]], unresolved: Any) -> list[str]:
@@ -75,7 +101,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.2"
+__VERSION__ = "2.0"
 _MIN_PROGRESS_WRITE_VERSION = (10, 9)
 _JF_VERSION_CACHE: dict[str, tuple[float, str | None]] = {}
 
@@ -480,6 +506,12 @@ class JELLYFINModule:
         auth_ok = bool(user_ok and user_code == 200)
         product = "Jellyfin Server"
         version = None
+        progress_supported = False
+        if auth_ok:
+            try:
+                progress_supported, version = self.client.progress_write_supported()
+            except Exception:
+                progress_supported, version = False, None
 
         base_ready = bool(server_ok and auth_ok)
         features = {
@@ -487,7 +519,7 @@ class JELLYFINModule:
             "history": base_ready if enabled.get("history") else False,
             "ratings": base_ready if enabled.get("ratings") else False,
             "playlists": base_ready if enabled.get("playlists") else False,
-            "progress": base_ready if enabled.get("progress") else False,
+            "progress": bool(base_ready and progress_supported) if enabled.get("progress") else False,
         }
 
         checks: list[bool] = [features[k] for k, on in enabled.items() if on]
@@ -513,6 +545,8 @@ class JELLYFINModule:
                 reasons.append(f"user:http:{user_code}")
             else:
                 reasons.append("user:unreachable")
+        if enabled.get("progress") and auth_ok and not progress_supported:
+            reasons.append(f"progress:unsupported_server_version:{version or 'unknown'}")
 
         details: dict[str, Any] = {
             "server_ok": server_ok,
@@ -588,7 +622,7 @@ class JELLYFINModule:
             supported, version = self.client.progress_write_supported()
             if not supported:
                 _info(f, "write_skipped", op="add", reason="unsupported_server_version", server_version=version)
-                return {"ok": False, "count": 0, "unresolved": [], "error": "unsupported_server_version", "server_version": version}
+                return {"ok": False, "count": 0, "unresolved": [], "confirmed_keys": [], "unresolved_keys": [], "results": [], "error": "unsupported_server_version", "server_version": version}
         if not self._is_enabled(f):
             _info(f, "write_skipped", op="add", reason="feature_disabled")
             return {"ok": True, "count": 0, "unresolved": []}
@@ -605,9 +639,12 @@ class JELLYFINModule:
                 "unresolved": [],
                 "error": f"unknown_feature:{feature}",
             }
+        try:
+            setattr(self, "_history_write_meta", None)
+        except Exception:
+            pass
         cnt, unres = mod.add(self, lst)
-        confirmed_keys = _confirmed_keys(self.key_of, lst, unres)
-        return {"ok": True, "count": int(cnt), "unresolved": unres, "confirmed_keys": confirmed_keys, "results": list(getattr(self, "_progress_write_results", [])) if f == "progress" else []}
+        return _finalize_result(self, self.key_of, f, lst, cnt, unres)
     def remove(
         self,
         feature: str,
@@ -616,6 +653,11 @@ class JELLYFINModule:
         dry_run: bool = False,
     ) -> Mapping[str, Any]:
         f = (feature or "watchlist").lower()
+        if f == "progress":
+            supported, version = self.client.progress_write_supported()
+            if not supported:
+                _info(f, "write_skipped", op="remove", reason="unsupported_server_version", server_version=version)
+                return {"ok": False, "count": 0, "unresolved": [], "confirmed_keys": [], "unresolved_keys": [], "results": [], "error": "unsupported_server_version", "server_version": version}
         if not self._is_enabled(f):
             _info(f, "write_skipped", op="remove", reason="feature_disabled")
             return {"ok": True, "count": 0, "unresolved": []}
@@ -632,9 +674,12 @@ class JELLYFINModule:
                 "unresolved": [],
                 "error": f"unknown_feature:{feature}",
             }
+        try:
+            setattr(self, "_history_write_meta", None)
+        except Exception:
+            pass
         cnt, unres = mod.remove(self, lst)
-        confirmed_keys = _confirmed_keys(self.key_of, lst, unres)
-        return {"ok": True, "count": int(cnt), "unresolved": unres, "confirmed_keys": confirmed_keys, "results": list(getattr(self, "_progress_write_results", [])) if f == "progress" else []}
+        return _finalize_result(self, self.key_of, f, lst, cnt, unres)
 class _JellyfinOPS:
     def name(self) -> str:
         return "JELLYFIN"

--- a/providers/sync/_mod_common.py
+++ b/providers/sync/_mod_common.py
@@ -30,7 +30,75 @@ __all__ = [
     "label_jellyfin",
     "label_emby",
     "SimpleRateLimiter",
+    "unresolved_key",
+    "unresolved_keys",
+    "dedup_keys",
+    "build_op_result",
 ]
+
+
+def unresolved_key(entry: Any, key_of: Callable[[Any], Any] | None = None) -> str:
+    if isinstance(entry, str):
+        return entry
+    if isinstance(entry, Mapping):
+        for field in ("key", "_cw_key"):
+            v = entry.get(field)
+            if isinstance(v, str) and v:
+                return v
+        inner = entry.get("item")
+        obj = inner if isinstance(inner, Mapping) else entry
+        if key_of is not None:
+            try:
+                return str(key_of(obj) or "")
+            except Exception:
+                return ""
+    return ""
+
+
+def unresolved_keys(unresolved: Any, key_of: Callable[[Any], Any] | None = None) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for u in unresolved or []:
+        k = unresolved_key(u, key_of)
+        if k and k not in seen:
+            seen.add(k)
+            out.append(k)
+    return out
+
+
+def dedup_keys(keys: Any) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for x in keys or []:
+        s = str(x or "").strip()
+        if s and s not in seen:
+            seen.add(s)
+            out.append(s)
+    return out
+
+
+def build_op_result(
+    *,
+    ok: bool = True,
+    count: int = 0,
+    confirmed_keys: Any = None,
+    unresolved_keys: Any = None,
+    unresolved: Any = None,
+    results: Any = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    res: dict[str, Any] = {
+        "ok": bool(ok),
+        "count": int(count or 0),
+        "confirmed_keys": dedup_keys(confirmed_keys),
+        "unresolved_keys": dedup_keys(unresolved_keys),
+        "unresolved": list(unresolved or []),
+        "results": list(results or []),
+    }
+    for key, value in (extra or {}).items():
+        if value is not None:
+            res[key] = value
+    return res
 
 EmitFn = Callable[[str, Mapping[str, Any]], None]
 FeatureLabelFn = Callable[[str, str, Mapping[str, Any]], str]

--- a/providers/sync/emby/_history.py
+++ b/providers/sync/emby/_history.py
@@ -550,31 +550,53 @@ def _unmark_played(http: Any, uid: str, item_id: str) -> bool:
         return False
 
 
+def _dst_user_states(http: Any, uid: str, iids: Iterable[Any], *, chunk_size: int = 200) -> dict[str, tuple[bool, int]]:
+    out: dict[str, tuple[bool, int]] = {}
+    ids: list[str] = []
+    seen: set[str] = set()
+    for x in iids or []:
+        s = str(x or "").strip()
+        if s and s not in seen:
+            seen.add(s)
+            ids.append(s)
+    if not ids:
+        return out
+    for batch in chunked(ids, max(1, int(chunk_size))):
+        try:
+            r = http.get(
+                f"/Users/{uid}/Items",
+                params={
+                    "Ids": ",".join(batch),
+                    "Fields": "UserData,UserDataPlayCount,UserDataLastPlayedDate",
+                    "EnableUserData": True,
+                },
+            )
+        except Exception as e:
+            _dbg("http_failed", op="dst_user_states", error=str(e))
+            r = None
+        if r is None or getattr(r, "status_code", 0) != 200:
+            _dbg("http_failed", op="dst_user_states", user_id=uid, status=getattr(r, "status_code", None))
+            continue
+        try:
+            arr = (r.json() or {}).get("Items") or []
+        except Exception:
+            arr = []
+        for row in arr:
+            if not isinstance(row, Mapping):
+                continue
+            iid = str(row.get("Id") or "").strip()
+            if not iid:
+                continue
+            ud = row.get("UserData") or {}
+            play_count = int(ud.get("PlayCount") or 0)
+            played = bool(ud.get("Played") is True or play_count > 0)
+            ts = _played_ts_from_row(row) or (_parse_iso_to_epoch(ud.get("LastPlayedDate")) or 0)
+            out[iid] = (played, int(ts or 0))
+    return out
+
+
 def _dst_user_state(http: Any, uid: str, iid: str) -> tuple[bool, int]:
-    try:
-        r = http.get(
-            f"/Users/{uid}/Items/{iid}",
-            params={
-                "Fields": "UserData,UserDataPlayCount,UserDataLastPlayedDate",
-                "EnableUserData": True,
-            },
-        )
-        if getattr(r, "status_code", 0) != 200:
-            _dbg("http_failed", op="dst_user_state", user_id=uid, item_id=iid, status=getattr(r, 'status_code', None))
-            return False, 0
-        data = r.json() or {}
-        ud = data.get("UserData") or {}
-        play_count = int(ud.get("PlayCount") or 0)
-        played_flag = bool(ud.get("Played") is True)
-        raw_ts = ud.get("LastPlayedDate")
-        ts = _parse_iso_to_epoch(raw_ts) or 0
-        played = bool(played_flag or play_count > 0)
-        if os.environ.get("CW_EMBY_DEBUG"):
-            _dbg("dst_user_state", item_id=iid, played=played, ts=ts)
-        return played, ts
-    except Exception as e:
-        _dbg("http_failed", op="dst_user_state", item_id=iid, error=str(e))
-        return False, 0
+    return _dst_user_states(http, uid, [str(iid)]).get(str(iid), (False, 0))
 
 
 # history index
@@ -1079,7 +1101,7 @@ def _prepare_mids(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[
             k = None
 
         if not k:
-            unresolved.append({"item": id_minimal(base), "hint": "missing_ids_for_key"})
+            unresolved.append({"item": id_minimal(base), "key": canonical_key(base) or "", "hint": "missing_ids_for_key", "reason": "missing_ids_for_key"})
             _freeze(base, reason="missing_ids_for_key")
             continue
 
@@ -1096,12 +1118,39 @@ def _prepare_mids(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[
         if iid:
             mids.append((k, iid))
         else:
-            unresolved.append({"item": id_minimal(m), "hint": "resolve_failed"})
+            unresolved.append({"item": id_minimal(m), "key": k, "hint": "resolve_failed", "reason": "resolve_failed"})
             _freeze(m, reason="resolve_failed")
 
     return wants, mids, unresolved
 
 # apply history
+_ST_WRITTEN = "written"
+_ST_ALREADY = "already_correct"
+_ST_NEWER = "destination_newer"
+_ST_WRITE_FAILED = "write_failed"
+_ST_MISSING_DATE = "missing_watched_at"
+_ST_RESOLVE_FAILED = "resolve_failed"
+_ST_READBACK = "readback_mismatch"
+
+
+def _set_write_meta(adapter: Any, meta: Mapping[str, Any]) -> None:
+    try:
+        setattr(adapter, "_history_write_meta", dict(meta))
+    except Exception:
+        pass
+
+
+def _result_row(key: str, status: str, *, action: str, reason: str, iid: str | None = None, req_ts: int = 0, dst_ts: int = 0) -> dict[str, Any]:
+    row: dict[str, Any] = {"key": key, "status": status, "action": action, "reason": reason}
+    if iid:
+        row["provider_item_id"] = str(iid)
+    if req_ts:
+        row["requested_at"] = _epoch_to_iso_z(req_ts)
+    if dst_ts:
+        row["destination_at"] = _epoch_to_iso_z(dst_ts)
+    return row
+
+
 def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
     http = adapter.client
     uid = adapter.cfg.user_id
@@ -1112,6 +1161,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
     do_force = bool(getattr(cfg, "history_force_overwrite", False))
     do_back = bool(getattr(cfg, "history_backdate", False))
     tol = int(getattr(cfg, "history_backdate_tolerance_s", 300))
+    verify = do_force or do_back
 
     try:
         from ._common import provider_index
@@ -1120,20 +1170,35 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
     except Exception:
         pass
 
-    wants, mids, unresolved = _prepare_mids(adapter, items)
+    wants, mids, pre_unresolved = _prepare_mids(adapter, items)
 
     shadow = _shadow_load()
     bb = _bb_load()
     ok = 0
     stats: dict[str, int] = {
-        "wrote": 0,
-        "forced": 0,
-        "backdated": 0,
-        "skip_newer": 0,
-        "skip_played_untimed": 0,
-        "skip_missing_date": 0,
-        "fail_mark": 0,
+        "wrote": 0, "forced": 0, "backdated": 0, "skip_newer": 0,
+        "skip_played_untimed": 0, "skip_missing_date": 0, "fail_mark": 0,
     }
+
+    results: list[dict[str, Any]] = []
+    confirmed_keys: list[str] = []
+    unresolved: list[dict[str, Any]] = list(pre_unresolved)
+    reason_counts: dict[str, int] = {}
+
+    def _fail(k: str, it: Mapping[str, Any], *, hint: str, iid: str | None = None) -> None:
+        unresolved.append({"item": id_minimal(it), "key": k, "hint": hint, "reason": "write_failed"})
+        _freeze(it, reason="write_failed")
+        results.append(_result_row(k, _ST_WRITE_FAILED, action="write", reason=hint, iid=iid))
+        reason_counts["write_failed"] = reason_counts.get("write_failed", 0) + 1
+
+    def _confirm(k: str, status: str, *, action: str, reason: str, iid: str, req_ts: int, dst_ts: int = 0) -> None:
+        confirmed_keys.append(k)
+        results.append(_result_row(k, status, action=action, reason=reason, iid=iid, req_ts=req_ts, dst_ts=dst_ts))
+
+    for u in pre_unresolved:
+        reason = str(u.get("reason") or "unresolved")
+        reason_counts[reason] = reason_counts.get(reason, 0) + 1
+        results.append(_result_row(str(u.get("key") or ""), _ST_RESOLVE_FAILED, action="resolve", reason=reason))
 
     total = len(mids)
     if total:
@@ -1141,16 +1206,21 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
 
     processed = 0
     for chunk in chunked(mids, qlim):
+        states = {} if do_force else _dst_user_states(http, uid, [iid for _, iid in chunk])
+        pending_verify: list[tuple[str, str, int]] = []
         for k, iid in chunk:
             it = wants[k]
             src_ts = _parse_iso_to_epoch(it.get("watched_at")) or 0
             if not src_ts:
-                unresolved.append({"item": id_minimal(it), "hint": "missing_watched_at"})
+                unresolved.append({"item": id_minimal(it), "key": k, "hint": "missing_watched_at", "reason": "missing_watched_at"})
                 _freeze(it, reason="missing_watched_at")
+                results.append(_result_row(k, _ST_MISSING_DATE, action="skip", reason="missing_watched_at", iid=iid))
+                reason_counts["missing_watched_at"] = reason_counts.get("missing_watched_at", 0) + 1
                 stats["skip_missing_date"] += 1
                 continue
 
             src_iso = _epoch_to_iso_z(src_ts)
+            played, dst_ts = states.get(iid, (False, 0))
 
             if do_force:
                 _unmark_played(http, uid, iid)
@@ -1160,21 +1230,21 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                     bb[k] = {"reason": "presence:shadow", "since": _now_iso_z()}
                     stats["wrote"] += 1
                     stats["forced"] += 1
+                    _confirm(k, _ST_WRITTEN, action="write", reason="forced", iid=iid, req_ts=src_ts)
+                    pending_verify.append((k, iid, src_ts))
                 else:
-                    unresolved.append({"item": id_minimal(it), "hint": "mark_played_failed"})
-                    _freeze(it, reason="write_failed")
+                    _fail(k, it, hint="mark_played_failed", iid=iid)
                     stats["fail_mark"] += 1
                 processed += 1
-                if (processed % 25) == 0:
-                    _dbg("write_progress", op="add", done=processed, total=total, ok=ok, unresolved=len(unresolved))
                 sleep_ms(delay)
                 continue
 
-            played, dst_ts = _dst_user_state(http, uid, iid)
             if played and dst_ts and dst_ts >= (src_ts - tol):
                 shadow[k] = int(shadow.get(k, 0)) + 1
                 bb[k] = {"reason": "presence:existing_newer", "since": _now_iso_z()}
                 stats["skip_newer"] += 1
+                status = _ST_ALREADY if abs(dst_ts - src_ts) <= tol else _ST_NEWER
+                _confirm(k, status, action="skip", reason="existing_newer", iid=iid, req_ts=src_ts, dst_ts=dst_ts)
                 continue
 
             if played and not dst_ts:
@@ -1184,6 +1254,8 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                     bb[k] = {"reason": "presence:shadow", "since": _now_iso_z()}
                     stats["wrote"] += 1
                     stats["backdated"] += 1
+                    _confirm(k, _ST_WRITTEN, action="write", reason="dated_untimed", iid=iid, req_ts=src_ts)
+                    pending_verify.append((k, iid, src_ts))
                     sleep_ms(delay)
                     continue
                 if do_back:
@@ -1194,11 +1266,14 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                         bb[k] = {"reason": "presence:shadow", "since": _now_iso_z()}
                         stats["wrote"] += 1
                         stats["backdated"] += 1
+                        _confirm(k, _ST_WRITTEN, action="write", reason="backdated", iid=iid, req_ts=src_ts)
+                        pending_verify.append((k, iid, src_ts))
                         sleep_ms(delay)
                         continue
                 shadow[k] = int(shadow.get(k, 0)) + 1
                 bb[k] = {"reason": "presence:existing_untimed", "since": _now_iso_z()}
                 stats["skip_played_untimed"] += 1
+                _confirm(k, _ST_ALREADY, action="skip", reason="existing_untimed", iid=iid, req_ts=src_ts)
                 continue
 
             if do_back and (not dst_ts or dst_ts >= (src_ts + tol)):
@@ -1209,13 +1284,12 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                     bb[k] = {"reason": "presence:shadow", "since": _now_iso_z()}
                     stats["wrote"] += 1
                     stats["backdated"] += 1
+                    _confirm(k, _ST_WRITTEN, action="write", reason="backdated", iid=iid, req_ts=src_ts)
+                    pending_verify.append((k, iid, src_ts))
                 else:
-                    unresolved.append({"item": id_minimal(it), "hint": "mark_played_failed"})
-                    _freeze(it, reason="write_failed")
+                    _fail(k, it, hint="mark_played_failed", iid=iid)
                     stats["fail_mark"] += 1
                 processed += 1
-                if (processed % 25) == 0:
-                    _dbg("write_progress", op="add", done=processed, total=total, ok=ok, unresolved=len(unresolved))
                 sleep_ms(delay)
                 continue
 
@@ -1224,9 +1298,10 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 shadow[k] = int(shadow.get(k, 0)) + 1
                 bb[k] = {"reason": "presence:shadow", "since": _now_iso_z()}
                 stats["wrote"] += 1
+                _confirm(k, _ST_WRITTEN, action="write", reason="wrote", iid=iid, req_ts=src_ts)
+                pending_verify.append((k, iid, src_ts))
             else:
-                unresolved.append({"item": id_minimal(it), "hint": "mark_played_failed"})
-                _freeze(it, reason="write_failed")
+                _fail(k, it, hint="mark_played_failed", iid=iid)
                 stats["fail_mark"] += 1
 
             processed += 1
@@ -1234,10 +1309,33 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 _dbg("write_progress", op="add", done=processed, total=total, ok=ok, unresolved=len(unresolved))
             sleep_ms(delay)
 
+        if verify and pending_verify:
+            final = _dst_user_states(http, uid, [iid for _, iid, _ in pending_verify])
+            for k, iid, req_ts in pending_verify:
+                played, _dst = final.get(iid, (False, 0))
+                if played:
+                    continue
+                confirmed_keys[:] = [c for c in confirmed_keys if c != k]
+                results[:] = [r for r in results if not (r.get("key") == k and r.get("provider_item_id") == str(iid))]
+                it = wants.get(k) or {}
+                unresolved.append({"item": id_minimal(it), "key": k, "hint": "readback_not_played", "reason": "readback_mismatch"})
+                _freeze(it, reason="readback_mismatch")
+                results.append(_result_row(k, _ST_READBACK, action="verify", reason="not_played", iid=iid, req_ts=req_ts))
+                reason_counts["readback_mismatch"] = reason_counts.get("readback_mismatch", 0) + 1
+                if ok > 0:
+                    ok -= 1
+
     _shadow_save(shadow)
     _bb_save(bb)
-    if ok:
-        _thaw_if_present([k for k, _ in mids])
+    if confirmed_keys:
+        _thaw_if_present(confirmed_keys)
+
+    _set_write_meta(adapter, {
+        "confirmed_keys": confirmed_keys,
+        "unresolved_keys": [str(u.get("key") or "") for u in unresolved if u.get("key")],
+        "results": results,
+        "reason_counts": reason_counts,
+    })
 
     _info("write_done", op="add", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved), wrote=stats['wrote'], forced=stats['forced'], backdated=stats['backdated'], skip_newer=stats['skip_newer'], skip_played_untimed=stats['skip_played_untimed'], skip_missing_date=stats['skip_missing_date'], fail_mark=stats['fail_mark'])
     return ok, unresolved
@@ -1248,9 +1346,18 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
     uid = adapter.cfg.user_id
     qlim = int(_history_limit(adapter) or 25)
     delay = _history_delay_ms(adapter)
-    wants, mids, unresolved = _prepare_mids(adapter, items)
+    wants, mids, pre_unresolved = _prepare_mids(adapter, items)
     shadow = _shadow_load()
     ok = 0
+
+    results: list[dict[str, Any]] = []
+    confirmed_keys: list[str] = []
+    unresolved: list[dict[str, Any]] = list(pre_unresolved)
+    reason_counts: dict[str, int] = {}
+    for u in pre_unresolved:
+        reason = str(u.get("reason") or "unresolved")
+        reason_counts[reason] = reason_counts.get(reason, 0) + 1
+        results.append(_result_row(str(u.get("key") or ""), _ST_RESOLVE_FAILED, action="resolve", reason=reason))
 
     for chunk in chunked(mids, qlim):
         for k, iid in chunk:
@@ -1260,15 +1367,29 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
             if nxt == 0:
                 if _unmark_played(http, uid, iid):
                     ok += 1
+                    confirmed_keys.append(k)
+                    results.append(_result_row(k, _ST_WRITTEN, action="write", reason="unmarked", iid=iid))
                 else:
-                    unresolved.append({"item": id_minimal(wants[k]), "hint": "unmark_played_failed"})
+                    unresolved.append({"item": id_minimal(wants[k]), "key": k, "hint": "unmark_played_failed", "reason": "write_failed"})
                     _freeze(wants[k], reason="write_failed")
+                    results.append(_result_row(k, _ST_WRITE_FAILED, action="write", reason="unmark_played_failed", iid=iid))
+                    reason_counts["write_failed"] = reason_counts.get("write_failed", 0) + 1
+            else:
+                confirmed_keys.append(k)
+                results.append(_result_row(k, _ST_ALREADY, action="skip", reason="ref_retained", iid=iid))
             sleep_ms(delay)
 
     shadow = {k: v for k, v in shadow.items() if v > 0}
     _shadow_save(shadow)
-    if ok:
-        _thaw_if_present([k for k, _ in mids])
+    if confirmed_keys:
+        _thaw_if_present(confirmed_keys)
+
+    _set_write_meta(adapter, {
+        "confirmed_keys": confirmed_keys,
+        "unresolved_keys": [str(u.get("key") or "") for u in unresolved if u.get("key")],
+        "results": results,
+        "reason_counts": reason_counts,
+    })
 
     _info("write_done", op="remove", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
     return ok, unresolved

--- a/providers/sync/emby/_watchlist.py
+++ b/providers/sync/emby/_watchlist.py
@@ -698,9 +698,11 @@ def _add_collections(
         mids = mids[1:]
 
     ok = 0
+    added_ids: list[str] = []
     for chunk in chunked(mids, qlim):
         if collection_add_items(http, cid, chunk):
             ok += len(chunk)
+            added_ids.extend(chunk)
         else:
             for _ in chunk:
                 unresolved.append(
@@ -708,9 +710,9 @@ def _add_collections(
                 )
         sleep_ms(delay)
 
-    if ok:
+    if added_ids:
         _thaw_if_present(
-            [canonical_key({"ids": {"emby": x}}) for x in (mids or [])],
+            [canonical_key({"ids": {"emby": x}}) for x in added_ids],
         )
     return ok, unresolved
 

--- a/providers/sync/jellyfin/_auth_http.py
+++ b/providers/sync/jellyfin/_auth_http.py
@@ -1,0 +1,265 @@
+# providers/sync/jellyfin/_auth_http.py
+# CrossWatch - Canonical Jellyfin authentication/connection primitives
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import os
+import re
+import secrets
+from typing import Any
+from urllib.parse import urljoin
+
+import requests
+from requests import exceptions as rx
+
+UA = os.environ.get("CW_JELLYFIN_UA") or os.environ.get("CW_UA") or "CrossWatch"
+CLIENT_VERSION = os.environ.get("CW_JELLYFIN_VERSION") or os.environ.get("CW_VERSION") or "1.0"
+CLIENT_NAME = "CrossWatch"
+DEVICE_NAME = "CrossWatch"
+
+MINIMUM_SERVER_VERSION = (10, 9)
+MINIMUM_SERVER_VERSION_TEXT = "10.9"
+QUICK_CONNECT_MIN_VERSION = (10, 8)
+
+HTTP_TIMEOUT_POST = 15
+HTTP_TIMEOUT_GET = 10
+
+_VERSION_RE = re.compile(r"^\s*(\d+)\.(\d+)")
+_SECRET_RE = re.compile(r'((?:Token|secret|Secret)\s*[=:]\s*)"?[^"&,\s]+', re.IGNORECASE)
+
+
+class JellyfinAuthError(RuntimeError):
+    def __init__(self, message: str, *, reason: str = "error") -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+def redact(text: Any) -> str:
+    return _SECRET_RE.sub(r"\1***", str(text or ""))
+
+
+def clean_base(url: str) -> str:
+    u = (url or "").strip()
+    if not u:
+        return ""
+    if not (u.startswith("http://") or u.startswith("https://")):
+        u = "http://" + u
+    return u if u.endswith("/") else u + "/"
+
+
+def new_device_id() -> str:
+    return secrets.token_hex(16)
+
+
+def mb_authorization(token: str | None, device_id: str) -> str:
+    base = (
+        f'MediaBrowser Client="{CLIENT_NAME}", Device="{DEVICE_NAME}", '
+        f'DeviceId="{device_id}", Version="{CLIENT_VERSION}"'
+    )
+    return f'{base}, Token="{token}"' if token else base
+
+
+def auth_headers(token: str | None, device_id: str) -> dict[str, str]:
+    value = mb_authorization(token, device_id)
+    headers: dict[str, str] = {
+        "Accept": "application/json",
+        "User-Agent": UA,
+        "Authorization": value,
+        "X-Emby-Authorization": value,
+    }
+    if token:
+        headers["X-MediaBrowser-Token"] = token
+        headers["X-Emby-Token"] = token
+    return headers
+
+
+def server_version_tuple(value: Any) -> tuple[int, int] | None:
+    match = _VERSION_RE.match(str(value or ""))
+    if not match:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def validate_server_version(value: Any) -> str:
+    version = str(value or "").strip()
+    parsed = server_version_tuple(version)
+    if parsed is None:
+        raise JellyfinAuthError(
+            f"Unable to determine Jellyfin server version; CrossWatch requires Jellyfin {MINIMUM_SERVER_VERSION_TEXT} or newer.",
+            reason="version_unknown",
+        )
+    if parsed < MINIMUM_SERVER_VERSION:
+        raise JellyfinAuthError(
+            f"Jellyfin version too old: detected {version}; CrossWatch requires Jellyfin {MINIMUM_SERVER_VERSION_TEXT} or newer.",
+            reason="version_too_old",
+        )
+    return version
+
+
+class JellyfinAuthSession:
+    """Short-lived authenticated-connection helper used to establish a token.
+
+    Both password and Quick Connect authentication build on this; once a token
+    exists the rest of CrossWatch consumes it through the runtime JFClient.
+    """
+
+    def __init__(
+        self,
+        server: str,
+        *,
+        device_id: str | None = None,
+        verify_ssl: bool = True,
+        token: str | None = None,
+    ) -> None:
+        self.base = clean_base(server)
+        if not self.base:
+            raise JellyfinAuthError("Malformed request: missing server", reason="missing_server")
+        self.device_id = (device_id or "").strip() or new_device_id()
+        self.verify_ssl = bool(verify_ssl)
+        self.token = (token or "").strip() or None
+        self._session = requests.Session()
+        self._session.verify = self.verify_ssl
+
+    def __enter__(self) -> "JellyfinAuthSession":
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
+        try:
+            self._session.close()
+        except Exception:
+            pass
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: Any = None,
+        content_type: str | None = None,
+        token: str | None = None,
+        expect_json: bool = True,
+    ) -> requests.Response:
+        url = urljoin(self.base, path.lstrip("/"))
+        headers = auth_headers(token if token is not None else self.token, self.device_id)
+        if content_type:
+            headers["Content-Type"] = content_type
+        timeout = HTTP_TIMEOUT_POST if method.upper() == "POST" else HTTP_TIMEOUT_GET
+        try:
+            return self._session.request(
+                method, url, params=params, json=json, headers=headers, timeout=timeout
+            )
+        except (rx.ConnectTimeout, rx.ReadTimeout):
+            raise JellyfinAuthError("Server not reachable: timeout", reason="unreachable")
+        except rx.SSLError:
+            raise JellyfinAuthError("Server not reachable: ssl", reason="unreachable")
+        except rx.ConnectionError:
+            raise JellyfinAuthError("Server not reachable: connection", reason="unreachable")
+        except rx.InvalidURL:
+            raise JellyfinAuthError("Malformed request: server url", reason="missing_server")
+        except rx.RequestException as exc:
+            raise JellyfinAuthError(
+                f"Server not reachable: {exc.__class__.__name__}", reason="unreachable"
+            )
+
+    @staticmethod
+    def _json(resp: requests.Response) -> dict[str, Any]:
+        try:
+            data = resp.json()
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    @staticmethod
+    def _raise_http(resp: requests.Response, default: str, *, reason: str = "error") -> None:
+        message = default
+        try:
+            body = resp.json() or {}
+            message = body.get("ErrorMessage") or body.get("Message") or default
+        except Exception:
+            text = (getattr(resp, "text", "") or "").strip()
+            if text:
+                message = f"{default}: {redact(text)[:200]}"
+        raise JellyfinAuthError(message, reason=reason)
+
+    def system_info(self, *, require_token: bool = True) -> dict[str, Any]:
+        resp = self._request("GET", "System/Info" if require_token else "System/Info/Public")
+        if not resp.ok:
+            self._raise_http(
+                resp,
+                f"Unable to determine Jellyfin server version; CrossWatch requires Jellyfin {MINIMUM_SERVER_VERSION_TEXT} or newer.",
+                reason="version_unknown",
+            )
+        return self._json(resp)
+
+    def server_version(self, *, require_token: bool = True) -> str:
+        info = self.system_info(require_token=require_token)
+        return validate_server_version(info.get("Version") or info.get("ServerVersion"))
+
+    def resolve_user(self, token: str) -> tuple[str, str]:
+        resp = self._request("GET", "Users/Me", token=token)
+        if not resp.ok:
+            return "", ""
+        info = self._json(resp)
+        return str(info.get("Id") or "").strip(), str(info.get("Name") or "").strip()
+
+    def authenticate_by_name(self, username: str, password: str) -> dict[str, Any]:
+        resp = self._request(
+            "POST",
+            "Users/AuthenticateByName",
+            json={"Username": username, "Pw": password},
+            content_type="application/json",
+            token="",
+        )
+        if resp.status_code in (401, 403):
+            raise JellyfinAuthError("Invalid credentials", reason="unauthorized")
+        if resp.status_code >= 500:
+            raise JellyfinAuthError(f"Server error ({resp.status_code})", reason="unreachable")
+        if not resp.ok:
+            self._raise_http(resp, "Login failed", reason="login_failed")
+        return self._json(resp)
+
+    def quick_connect_enabled(self) -> bool:
+        resp = self._request("GET", "QuickConnect/Enabled", token="")
+        if not resp.ok:
+            return False
+        try:
+            return bool(resp.json())
+        except Exception:
+            return False
+
+    def quick_connect_initiate(self) -> dict[str, Any]:
+        resp = self._request("POST", "QuickConnect/Initiate", token="")
+        if resp.status_code in (401, 403):
+            raise JellyfinAuthError("Quick Connect is disabled on this server", reason="disabled")
+        if not resp.ok:
+            self._raise_http(resp, "Quick Connect initiation failed", reason="initiate_failed")
+        data = self._json(resp)
+        if not (data.get("Secret") and data.get("Code")):
+            raise JellyfinAuthError("Quick Connect initiation failed", reason="initiate_failed")
+        return data
+
+    def quick_connect_state(self, secret: str) -> dict[str, Any]:
+        resp = self._request("GET", "QuickConnect/Connect", params={"secret": secret}, token="")
+        if resp.status_code == 404:
+            raise JellyfinAuthError("Quick Connect request expired", reason="expired")
+        if not resp.ok:
+            self._raise_http(resp, "Quick Connect check failed", reason="connect_failed")
+        return self._json(resp)
+
+    def authenticate_with_quick_connect(self, secret: str) -> dict[str, Any]:
+        resp = self._request(
+            "POST",
+            "Users/AuthenticateWithQuickConnect",
+            json={"Secret": secret},
+            content_type="application/json",
+            token="",
+        )
+        if resp.status_code in (401, 403):
+            raise JellyfinAuthError("Quick Connect request not authorized", reason="not_authorized")
+        if not resp.ok:
+            self._raise_http(resp, "Quick Connect authentication failed", reason="connect_failed")
+        return self._json(resp)

--- a/providers/sync/jellyfin/_history.py
+++ b/providers/sync/jellyfin/_history.py
@@ -23,7 +23,7 @@ from ._common import (
     _pair_scope,
     _is_capture_mode,
 )
-from ._routes import items as items_route, played as played_route, user_params
+from ._routes import items as items_route, played as played_route, user_data as user_data_route, user_params
 from cw_platform.id_map import canonical_key, minimal as id_minimal
 
 def _unresolved_path() -> str:
@@ -33,6 +33,9 @@ def _shadow_path() -> str:
     return str(state_file("jellyfin_history.shadow.json"))
 
 def _blackbox_path() -> str:
+    return str(state_file("jellyfin_history.jellyfin.blackbox.json"))
+
+def _legacy_blackbox_path() -> str:
     return str(state_file("jellyfin_history.jellyfin-plex.blackbox.json"))
 
 _dbg, _info, _warn = make_logger("history")
@@ -127,9 +130,46 @@ def _shadow_save(d: Mapping[str, Mapping[str, Any]]) -> None:
 
 
 # blackbox
+def _bb_write(path: str, d: Mapping[str, Any]) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(dict(d or {}), f, ensure_ascii=False, indent=2, sort_keys=True)
+    os.replace(tmp, path)
+
+
+def _migrate_blackbox() -> None:
+    legacy = _legacy_blackbox_path()
+    if not os.path.exists(legacy):
+        return
+    new = _blackbox_path()
+    try:
+        try:
+            with open(legacy, "r", encoding="utf-8") as f:
+                old_data = json.load(f) or {}
+        except Exception:
+            old_data = {}
+        new_data: dict[str, Any] = {}
+        if os.path.exists(new):
+            try:
+                with open(new, "r", encoding="utf-8") as f:
+                    new_data = json.load(f) or {}
+            except Exception:
+                new_data = {}
+        merged = {**(old_data if isinstance(old_data, dict) else {}), **(new_data if isinstance(new_data, dict) else {})}
+        _bb_write(new, merged)
+        try:
+            os.remove(legacy)
+        except Exception:
+            pass
+    except Exception:
+        pass
+
+
 def _bb_load() -> dict[str, Any]:
     if _is_capture_mode() or _pair_scope() is None:
         return {}
+    _migrate_blackbox()
     try:
         with open(_blackbox_path(), "r", encoding="utf-8") as f:
             return json.load(f) or {}
@@ -141,12 +181,7 @@ def _bb_save(d: Mapping[str, Any]) -> None:
     if _is_capture_mode() or _pair_scope() is None:
         return
     try:
-        path = _blackbox_path()
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        tmp = path + ".tmp"
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(d, f, ensure_ascii=False, indent=2, sort_keys=True)
-        os.replace(tmp, path)
+        _bb_write(_blackbox_path(), d)
     except Exception:
         pass
 
@@ -325,6 +360,44 @@ def _unmark_played(http: Any, uid: str, item_id: str) -> bool:
         return getattr(r, "status_code", 0) in (200, 204)
     except Exception:
         return False
+
+
+def _normalize_watched(http: Any, uid: str, item_id: str, *, date_played_iso: str | None) -> bool:
+    payload: dict[str, Any] = {"Played": True, "PlaybackPositionTicks": 0}
+    if date_played_iso:
+        payload["LastPlayedDate"] = date_played_iso
+    try:
+        r = http.post(user_data_route(str(item_id)), params=user_params(uid), json=payload)
+        return getattr(r, "status_code", 0) in (200, 204)
+    except Exception:
+        return False
+
+
+_ST_WRITTEN = "written"
+_ST_ALREADY = "already_correct"
+_ST_NEWER = "destination_newer"
+_ST_WRITE_FAILED = "write_failed"
+_ST_MISSING_DATE = "missing_watched_at"
+_ST_RESOLVE_FAILED = "resolve_failed"
+_ST_READBACK = "readback_mismatch"
+
+
+def _set_write_meta(adapter: Any, meta: Mapping[str, Any]) -> None:
+    try:
+        setattr(adapter, "_history_write_meta", dict(meta))
+    except Exception:
+        pass
+
+
+def _result_row(key: str, status: str, *, action: str, reason: str, iid: str | None = None, req_ts: int = 0, dst_ts: int = 0) -> dict[str, Any]:
+    row: dict[str, Any] = {"key": key, "status": status, "action": action, "reason": reason}
+    if iid:
+        row["provider_item_id"] = str(iid)
+    if req_ts:
+        row["requested_at"] = _epoch_to_iso_z(req_ts)
+    if dst_ts:
+        row["destination_at"] = _epoch_to_iso_z(dst_ts)
+    return row
 
 
 def _dst_user_state(http: Any, uid: str, iid: str) -> tuple[bool, int]:
@@ -737,11 +810,15 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
     qlim = int(_history_limit(adapter) or 25)
     delay = _history_delay_ms(adapter)
 
+    tol = int(getattr(adapter.cfg, "history_backdate_tolerance_s", 300) or 300)
     pre_unresolved: list[dict[str, Any]] = []
     wants: dict[str, dict[str, Any]] = {}
 
     for it in (items or []):
-        key, m, err = _prepare_want(it or {})
+        base = dict(it or {})
+        raw_key = str(base.get("_cw_key") or base.get("key") or "").strip() or None
+        raw_iid = str(base.get("jellyfin_item_id") or base.get("_jellyfin_item_id") or "").strip() or None
+        key, m, err = _prepare_want(base, raw_key=raw_key, raw_iid=raw_iid)
         if err:
             pre_unresolved.append(err)
             continue
@@ -749,30 +826,43 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         wants[key] = m
 
     mids: list[tuple[str, str]] = []
-    unresolved: list[dict[str, Any]] = []
-    if pre_unresolved:
-        unresolved.extend(pre_unresolved)
+    unresolved: list[dict[str, Any]] = list(pre_unresolved)
+    results: list[dict[str, Any]] = []
+    confirmed_keys: list[str] = []
+    reason_counts: dict[str, int] = {}
+
+    for u in pre_unresolved:
+        reason = str(u.get("reason") or u.get("hint") or "unresolved")
+        reason_counts[reason] = reason_counts.get(reason, 0) + 1
+        results.append(_result_row(str(u.get("key") or ""), _ST_RESOLVE_FAILED, action="resolve", reason=reason))
 
     for k, m in wants.items():
-        iid = _try_resolve_iid(adapter, m)
+        iid = m.get("jellyfin_item_id") or _try_resolve_iid(adapter, m)
         if iid:
-            mids.append((k, iid))
+            mids.append((k, str(iid)))
         else:
-            unresolved.append({"item": id_minimal(m), "hint": "resolve_failed"})
+            unresolved.append({"item": id_minimal(m), "key": k, "hint": "resolve_failed", "reason": "resolve_failed"})
             _freeze(m, reason="resolve_failed")
+            results.append(_result_row(k, _ST_RESOLVE_FAILED, action="resolve", reason="resolve_failed"))
+            reason_counts["resolve_failed"] = reason_counts.get("resolve_failed", 0) + 1
 
     shadow = _shadow_load()
     bb = _bb_load()
     ok = 0
     stats = {
-        "wrote": 0,
-        "forced": 0,
-        "backdated": 0,
-        "skip_newer": 0,
-        "skip_played_untimed": 0,
-        "skip_missing_date": 0,
-        "fail_mark": 0,
+        "wrote": 0, "forced": 0, "backdated": 0, "skip_newer": 0,
+        "skip_played_untimed": 0, "skip_missing_date": 0, "fail_mark": 0,
     }
+
+    def _confirm(k: str, status: str, *, action: str, reason: str, iid: str, req_ts: int, dst_ts: int = 0) -> None:
+        confirmed_keys.append(k)
+        results.append(_result_row(k, status, action=action, reason=reason, iid=iid, req_ts=req_ts, dst_ts=dst_ts))
+
+    def _fail(k: str, *, hint: str, iid: str | None = None) -> None:
+        unresolved.append({"item": id_minimal(wants[k]), "key": k, "hint": hint, "reason": "write_failed"})
+        _freeze(wants[k], reason="write_failed")
+        results.append(_result_row(k, _ST_WRITE_FAILED, action="write", reason=hint, iid=iid))
+        reason_counts["write_failed"] = reason_counts.get("write_failed", 0) + 1
 
     total = len(mids)
     if total:
@@ -781,11 +871,14 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
     processed = 0
     for chunk in chunked(mids, qlim):
         states = _dst_user_states(http, uid, [iid for _, iid in chunk])
+        pending_verify: list[tuple[str, str, int]] = []
         for k, iid in chunk:
             src_ts = _parse_iso_to_epoch(wants[k].get("watched_at")) or 0
             if not src_ts:
-                unresolved.append({"item": id_minimal(wants[k]), "hint": "missing_watched_at"})
+                unresolved.append({"item": id_minimal(wants[k]), "key": k, "hint": "missing_watched_at", "reason": "missing_watched_at"})
                 _freeze(wants[k], reason="missing_watched_at")
+                results.append(_result_row(k, _ST_MISSING_DATE, action="skip", reason="missing_watched_at", iid=iid))
+                reason_counts["missing_watched_at"] = reason_counts.get("missing_watched_at", 0) + 1
                 stats["skip_missing_date"] += 1
                 processed += 1
                 continue
@@ -793,21 +886,20 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             src_iso = _epoch_to_iso_z(src_ts)
             played, dst_ts = states.get(iid, (False, 0))
 
-            if played and dst_ts and src_ts and dst_ts >= src_ts:
+            if played and dst_ts and dst_ts >= (src_ts - tol):
                 bb[k] = {"reason": "presence:existing_newer", "since": _now_iso_z(), "iid": iid}
                 stats["skip_newer"] += 1
+                status = _ST_ALREADY if abs(dst_ts - src_ts) <= tol else _ST_NEWER
+                _confirm(k, status, action="skip", reason="existing_newer", iid=iid, req_ts=src_ts, dst_ts=dst_ts)
                 processed += 1
-                if (processed % 25) == 0:
-                    _dbg("write_progress", op="add", done=processed, total=total, ok=ok, unresolved=len(unresolved))
                 sleep_ms(delay)
                 continue
 
             if played and not dst_ts:
                 bb[k] = {"reason": "presence:existing_untimed", "since": _now_iso_z(), "iid": iid}
                 stats["skip_played_untimed"] += 1
+                _confirm(k, _ST_ALREADY, action="skip", reason="existing_untimed", iid=iid, req_ts=src_ts)
                 processed += 1
-                if (processed % 25) == 0:
-                    _dbg("write_progress", op="add", done=processed, total=total, ok=ok, unresolved=len(unresolved))
                 sleep_ms(delay)
                 continue
 
@@ -823,9 +915,12 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 }
                 bb[k] = {"reason": "presence:shadow", "since": _now_iso_z(), "iid": iid}
                 stats["wrote"] += 1
+                normalized = _normalize_watched(http, uid, iid, date_played_iso=src_iso)
+                _confirm(k, _ST_WRITTEN, action="write", reason="wrote", iid=iid, req_ts=src_ts)
+                if not normalized:
+                    pending_verify.append((k, iid, src_ts))
             else:
-                unresolved.append({"item": wants[k], "hint": "mark_played_failed"})
-                _freeze(wants[k], reason="write_failed")
+                _fail(k, hint="mark_played_failed", iid=iid)
                 stats["fail_mark"] += 1
 
             processed += 1
@@ -833,10 +928,33 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 _dbg("write_progress", op="add", done=processed, total=total, ok=ok, unresolved=len(unresolved))
             sleep_ms(delay)
 
+        if pending_verify:
+            final = _dst_user_states(http, uid, [iid for _, iid, _ in pending_verify])
+            for k, iid, req_ts in pending_verify:
+                played, _dst = final.get(iid, (False, 0))
+                if played:
+                    continue
+                confirmed_keys[:] = [c for c in confirmed_keys if c != k]
+                results[:] = [r for r in results if not (r.get("key") == k and r.get("provider_item_id") == str(iid))]
+                unresolved.append({"item": id_minimal(wants[k]), "key": k, "hint": "readback_not_played", "reason": "readback_mismatch"})
+                _freeze(wants[k], reason="readback_mismatch")
+                results.append(_result_row(k, _ST_READBACK, action="verify", reason="not_played", iid=iid, req_ts=req_ts))
+                reason_counts["readback_mismatch"] = reason_counts.get("readback_mismatch", 0) + 1
+                shadow.pop(k, None)
+                if ok > 0:
+                    ok -= 1
+
     _shadow_save(shadow)
     _bb_save(bb)
-    if ok:
-        _thaw_if_present([k for k, _ in mids])
+    if confirmed_keys:
+        _thaw_if_present(confirmed_keys)
+
+    _set_write_meta(adapter, {
+        "confirmed_keys": confirmed_keys,
+        "unresolved_keys": [str(u.get("key") or "") for u in unresolved if u.get("key")],
+        "results": results,
+        "reason_counts": reason_counts,
+    })
     _info("write_done", op="add", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved), **stats)
     return ok, unresolved
 
@@ -865,9 +983,14 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
         wants[key] = m
 
     mids: list[tuple[str, str]] = []
-    unresolved: list[dict[str, Any]] = []
-    if pre_unresolved:
-        unresolved.extend(pre_unresolved)
+    unresolved: list[dict[str, Any]] = list(pre_unresolved)
+    results: list[dict[str, Any]] = []
+    confirmed_keys: list[str] = []
+    reason_counts: dict[str, int] = {}
+    for u in pre_unresolved:
+        reason = str(u.get("reason") or u.get("hint") or "unresolved")
+        reason_counts[reason] = reason_counts.get(reason, 0) + 1
+        results.append(_result_row(str(u.get("key") or ""), _ST_RESOLVE_FAILED, action="resolve", reason=reason))
 
     for k, m in wants.items():
         ent = shadow.get(k) or {}
@@ -879,8 +1002,10 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
         if iid:
             mids.append((k, str(iid)))
         else:
-            unresolved.append({"item": id_minimal(m), "hint": "resolve_failed"})
+            unresolved.append({"item": id_minimal(m), "key": k, "hint": "resolve_failed", "reason": "resolve_failed"})
             _freeze(m, reason="resolve_failed")
+            results.append(_result_row(k, _ST_RESOLVE_FAILED, action="resolve", reason="resolve_failed"))
+            reason_counts["resolve_failed"] = reason_counts.get("resolve_failed", 0) + 1
     ok = 0
     for chunk in chunked(mids, qlim):
         for k, iid in chunk:
@@ -895,14 +1020,17 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
                     "iid": str(ent.get("iid") or iid),
                     "updated": _now_iso_z(),
                 }
+                confirmed_keys.append(k)
+                results.append(_result_row(k, _ST_ALREADY, action="skip", reason="ref_retained", iid=iid))
                 sleep_ms(delay)
                 continue
 
             # Force mode (tools/clear) always attempts to unmark.
             if _unmark_played(http, uid, iid):
                 ok += 1
+                confirmed_keys.append(k)
+                results.append(_result_row(k, _ST_WRITTEN, action="write", reason="unmarked", iid=iid))
                 if tracked:
-                    
                     if force_clear or cur_cnt <= 1:
                         shadow.pop(k, {})
                     else:
@@ -913,8 +1041,10 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
                             "updated": _now_iso_z(),
                         }
             else:
-                unresolved.append({"item": id_minimal(wants[k]), "hint": "unmark_played_failed"})
+                unresolved.append({"item": id_minimal(wants[k]), "key": k, "hint": "unmark_played_failed", "reason": "write_failed"})
                 _freeze(wants[k], reason="write_failed")
+                results.append(_result_row(k, _ST_WRITE_FAILED, action="write", reason="unmark_played_failed", iid=iid))
+                reason_counts["write_failed"] = reason_counts.get("write_failed", 0) + 1
 
                 if tracked:
                     shadow[k] = {
@@ -927,7 +1057,14 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
 
     shadow = {k: v for k, v in shadow.items() if int((v or {}).get("count") or 0) > 0}
     _shadow_save(shadow)
-    if ok:
-        _thaw_if_present([k for k, _ in mids])
+    if confirmed_keys:
+        _thaw_if_present(confirmed_keys)
+
+    _set_write_meta(adapter, {
+        "confirmed_keys": confirmed_keys,
+        "unresolved_keys": [str(u.get("key") or "") for u in unresolved if u.get("key")],
+        "results": results,
+        "reason_counts": reason_counts,
+    })
     _info("write_done", op="remove", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
     return ok, unresolved

--- a/providers/sync/jellyfin/_utils.py
+++ b/providers/sync/jellyfin/_utils.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
-import os
 from typing import Any
 from urllib.parse import urljoin
 
@@ -11,40 +10,9 @@ import requests
 
 from cw_platform.config_base import load_config, save_config
 from cw_platform.provider_instances import ensure_instance_block, normalize_instance_id
+from cw_platform.value_coercion import coerce_bool
 
-UA = os.environ.get("CW_JELLYFIN_UA") or os.environ.get("CW_UA") or "CrossWatch"
-
-
-def _clean(url: str) -> str:
-    u = (url or "").strip()
-    if not u:
-        return ""
-    if not (u.startswith("http://") or u.startswith("https://")):
-        u = "http://" + u
-    if not u.endswith("/"):
-        u += "/"
-    return u
-
-
-def _mb_auth(token: str | None, device_id: str) -> str:
-    version = os.environ.get("CW_JELLYFIN_VERSION") or os.environ.get("CW_VERSION") or "unknown"
-    base = f'MediaBrowser Client="CrossWatch", Device="Web", DeviceId="{device_id}", Version="{version}"'
-    return f'{base}, Token="{token}"' if token else base
-
-
-def _headers(token: str | None, device_id: str) -> dict[str, str]:
-    auth = _mb_auth(token, device_id)
-    h: dict[str, str] = {
-        "Accept": "application/json",
-        "User-Agent": UA,
-        "Authorization": auth,
-        "X-Emby-Authorization": auth,
-    }
-    if token:
-        h["X-MediaBrowser-Token"] = token
-    return h
-
-
+from ._auth_http import auth_headers as _headers, clean_base as _clean
 
 
 def _jellyfin(cfg: dict[str, Any], instance_id: Any) -> dict[str, Any]:
@@ -69,19 +37,20 @@ def ensure_whitelist_defaults(cfg: dict[str, Any] | None = None, instance_id: An
         save_config(cfg2)
 
 
-def _cfg_triplet(cfg: dict[str, Any] | None = None, instance_id: Any = None) -> tuple[str, str | None, str]:
+def _cfg_triplet(cfg: dict[str, Any] | None = None, instance_id: Any = None) -> tuple[str, str | None, str, bool]:
     cfg2 = cfg or load_config()
     jf = _jellyfin(cfg2, instance_id)
     server = _clean(jf.get("server", ""))
     token = (jf.get("access_token") or "").strip() or None
     devid = (jf.get("device_id") or "crosswatch").strip() or "crosswatch"
-    return server, token, devid
+    verify = coerce_bool(jf.get("verify_ssl", False))
+    return server, token, devid, verify
 
 
 def inspect_and_persist(cfg: dict[str, Any] | None = None, instance_id: Any = None) -> dict[str, Any]:
     cfg2 = cfg or load_config()
     jf = _jellyfin(cfg2, instance_id)
-    server, token, devid = _cfg_triplet(cfg2, instance_id)
+    server, token, devid, verify = _cfg_triplet(cfg2, instance_id)
 
     out: dict[str, Any] = {
         "server_url": server or jf.get("server", "") or "",
@@ -92,7 +61,7 @@ def inspect_and_persist(cfg: dict[str, Any] | None = None, instance_id: Any = No
     changed = False
     if server and token:
         try:
-            r = requests.get(urljoin(server, "Users/Me"), headers=_headers(token, devid), timeout=8)
+            r = requests.get(urljoin(server, "Users/Me"), headers=_headers(token, devid), timeout=8, verify=verify)
             if r.ok:
                 me = r.json() or {}
                 name = (me.get("Name") or out["username"] or "").strip()
@@ -124,7 +93,7 @@ def inspect_and_persist(cfg: dict[str, Any] | None = None, instance_id: Any = No
 
 def fetch_libraries_from_cfg(cfg: dict[str, Any] | None = None, instance_id: Any = None) -> list[dict[str, Any]]:
     cfg2 = cfg or load_config()
-    server, token, devid = _cfg_triplet(cfg2, instance_id)
+    server, token, devid, verify = _cfg_triplet(cfg2, instance_id)
     if not (server and token):
         return []
 
@@ -133,7 +102,7 @@ def fetch_libraries_from_cfg(cfg: dict[str, Any] | None = None, instance_id: Any
     url = urljoin(server, f"Users/{uid}/Views") if uid else urljoin(server, "Library/MediaFolders")
 
     try:
-        r = requests.get(url, headers=_headers(token, devid), timeout=10)
+        r = requests.get(url, headers=_headers(token, devid), timeout=10, verify=verify)
         if not r.ok:
             return []
 

--- a/providers/sync/jellyfin/_watchlist.py
+++ b/providers/sync/jellyfin/_watchlist.py
@@ -456,16 +456,18 @@ def _add_playlist(
             _freeze(it, reason="resolve_failed")
 
     ok = 0
+    added_ids: list[str] = []
     for chunk in chunked(mids, qlim):
         if playlist_add_items(http, pid, uid, chunk):
             ok += len(chunk)
+            added_ids.extend(chunk)
         else:
             for _ in chunk:
                 unresolved.append({"item": {}, "hint": "playlist_add_failed"})
         sleep_ms(delay)
 
-    if ok:
-        _thaw_if_present([canonical_key({"ids": {"jellyfin": x}}) for x in mids])
+    if added_ids:
+        _thaw_if_present([canonical_key({"ids": {"jellyfin": x}}) for x in added_ids])
     return ok, unresolved
 
 
@@ -552,16 +554,18 @@ def _add_collection(
             _freeze(it, reason="resolve_failed")
 
     ok = 0
+    added_ids: list[str] = []
     for chunk in chunked(mids, qlim):
         if collection_add_items(http, cid, chunk):
             ok += len(chunk)
+            added_ids.extend(chunk)
         else:
             for _ in chunk:
                 unresolved.append({"item": {}, "hint": "collection_add_failed"})
         sleep_ms(delay)
 
-    if ok:
-        _thaw_if_present([canonical_key({"ids": {"jellyfin": x}}) for x in mids])
+    if added_ids:
+        _thaw_if_present([canonical_key({"ids": {"jellyfin": x}}) for x in added_ids])
     return ok, unresolved
 
 


### PR DESCRIPTION
# Pull request

## Change

Updated the Jellyfin and Emby sync adapters to improve history, progress, and watchlist processing.

Added consistent operation results for confirmed and unresolved items, including detailed failure reasons. Improved history writes by handling items individually where needed and returning more accurate results for partially completed operations.

Centralized Jellyfin authentication and HTTP connection handling. Jellyfin health checks now report when progress synchronization is unavailable because of an unsupported server version.

Improved item resolution, duplicate handling, retry behavior, and watchlist updates so only successfully processed items are confirmed.

## Why

The previous adapter behavior could report items as successfully processed even when the provider did not accept every change. Error and unresolved item handling also differed between Jellyfin and Emby.

These changes make synchronization results more accurate, improve compatibility with different Jellyfin server versions, and provide clearer information when an item cannot be processed.

## Testing

Tested using manual and scripted testing.
Testing covered Jellyfin and Emby history synchronization, progress updates, watchlist changes, partial failures, unresolved items, authentication, health checks, and unsupported Jellyfin server versions.

## Issue

N/A
