### PR TITLE
Fix: empty space below Statistics card

### DIFF
--- a/assets/crosswatch.css
+++ b/assets/crosswatch.css
@@ -68,7 +68,8 @@ code{padding:2px 6px;border:1px solid var(--border);border-radius:8px;background
 @media(max-width:900px){.details-grid{grid-template-columns:1fr}
 }
 #layout{display:grid;gap:16px;align-items:stretch}
-#layout:not(.single):not(.full){grid-template-columns:minmax(620px,1fr) minmax(360px,420px)}
+#layout:not(.single):not(.full){grid-template-columns:minmax(620px,1fr) minmax(360px,420px);align-items:start;align-content:start}
+#layout:not(.single):not(.full)>#ops-card,#layout:not(.single):not(.full)>#stats-card{align-self:start;height:auto;min-height:0}
 #layout.full,#layout.single,.cw-settings-hub--single{grid-template-columns:1fr}
 .section>.head{position:relative;display:flex;align-items:center;gap:10px;padding:12px 44px 12px 14px;cursor:pointer}
 .section>.head .chev,.tab-caret{display:inline-block;flex:0 0 auto;font-size:0;line-height:0;color:currentColor}
@@ -543,7 +544,7 @@ main.full #stats-card,main.single #stats-card{grid-column:1;grid-row:auto;align-
 #stats-card .tile.g3 .k{color:#dfe3ee}
 #stats-card{grid-row:1;grid-column:2;align-self:start;height:auto;position:relative;overflow:hidden;isolation:isolate;transition:filter .2s ease}
 main#layout.details-open #stats-card{align-self:start;height:auto}
-main#layout.details-open #insights-footer{position:static!important;left:auto!important;right:auto!important;bottom:auto!important;margin-top:10px}
+main#layout.details-open #insights-footer{margin-top:10px}
 #stats-card.expanded{filter:brightness(1.02)}
 .sparkline .dot{r:2.5;opacity:.9}
 .sparkline .dot:hover{transform:scale(1.6)}
@@ -561,7 +562,7 @@ main#layout.details-open #insights-footer{position:static!important;left:auto!im
 @media(max-width:1100px){#ops-card,#placeholder-card,#stats-card{grid-column:1}
 }
 html.cw-compact #stats-card{grid-column:1!important;grid-row:auto!important;align-self:start!important;height:auto!important;padding-bottom:16px!important}
-html.cw-compact #insights-footer{position:static!important;left:auto!important;right:auto!important;bottom:auto!important;margin-top:10px!important}
+html.cw-compact #insights-footer{margin-top:10px!important}
 html.cw-compact #stats-card .stat-tiles{display:grid!important}
 html.cw-compact #stats-card .stat-block{display:block!important}
 html.cw-compact #stats-card #sync-history{max-height:260px;overflow:auto}

--- a/assets/helpers/details-log.js
+++ b/assets/helpers/details-log.js
@@ -1057,17 +1057,9 @@ function toggleDetails() {
   if (!d) return;
   const isOpen = d.classList.contains("hidden");
   const layout = document.getElementById("layout");
-  const statsCard = document.getElementById("stats-card");
-  const insightsFooter = document.getElementById("insights-footer");
-
-  if (!isOpen && statsCard && insightsFooter) {
-    const footerHeight = insightsFooter.getBoundingClientRect().height || insightsFooter.offsetHeight || 120;
-    statsCard.style.paddingBottom = `${footerHeight + 14}px`;
-  }
 
   d.classList.toggle("hidden", !isOpen);
   layout?.classList.toggle("details-open", isOpen);
-  if (isOpen) statsCard?.style.removeProperty("padding-bottom");
   if (isOpen) {
     try { initDetailsTabs(); } catch {}
     try { setDetailsTab(window._detailsTab || "sync"); } catch {}

--- a/assets/js/insights.js
+++ b/assets/js/insights.js
@@ -362,35 +362,18 @@ html[data-cw-theme="flat-light"] #insights-switch .ins-gear:hover{
   const refitProviderNumbers = () => { $$("#stat-providers .tile .n").forEach(fitProviderNumber); $$("#stat-providers .tile .mse").forEach(fitProviderMSE); };
   w.addEventListener("resize", refitProviderNumbers, { passive: true });
 
-  const footWrap = (() => {
-    let timer = 0;
-    const ensure = () => {
-      ensureStyles();
-      let foot = $("#insights-footer");
-      if (!foot) {
-        foot = d.createElement("div");
-        foot.id = "insights-footer";
-        foot.className = "ins-footer";
-        foot.innerHTML = '<div class="ins-foot-wrap"></div>';
-        ($("#stats-card") || d.body).appendChild(foot);
-      }
-      return $(".ins-foot-wrap", foot) || foot;
-    };
-    ensure.reserve = () => {
-      const card = $("#stats-card"), foot = $("#insights-footer");
-      if (!card || !foot) return;
-      clearTimeout(timer);
-      timer = setTimeout(() => {
-        if ($("main#layout")?.classList.contains("details-open")) {
-          card.style.removeProperty("padding-bottom");
-          return;
-        }
-        card.style.paddingBottom = `${(foot.getBoundingClientRect().height || foot.offsetHeight || 120) + 14}px`;
-      }, 0);
-    };
-    w.addEventListener("resize", ensure.reserve, { passive: true });
-    return ensure;
-  })();
+  const footWrap = () => {
+    ensureStyles();
+    let foot = $("#insights-footer");
+    if (!foot) {
+      foot = d.createElement("div");
+      foot.id = "insights-footer";
+      foot.className = "ins-footer";
+      foot.innerHTML = '<div class="ins-foot-wrap"></div>';
+      ($("#stats-card") || d.body).appendChild(foot);
+    }
+    return $(".ins-foot-wrap", foot) || foot;
+  };
 
   function placeSwitchBeforeTiles() {
     const wrap = footWrap(), sw = $("#insights-switch"), grid = $("#stat-providers");
@@ -444,7 +427,6 @@ html[data-cw-theme="flat-light"] #insights-switch .ins-gear:hover{
     }
     placeSwitchBeforeTiles();
     markActiveSwitcher();
-    footWrap.reserve();
   }
 
   const providerSelected = prov => {
@@ -478,7 +460,7 @@ html[data-cw-theme="flat-light"] #insights-switch .ins-gear:hover{
 
     if (!keys.length) {
       host.hidden = true;
-      return footWrap.reserve();
+      return;
     }
 
     host.hidden = false;
@@ -533,7 +515,6 @@ html[data-cw-theme="flat-light"] #insights-switch .ins-gear:hover{
 
     [...host.querySelectorAll(".tile")].forEach(tile => !seen.has(tile.id) && tile.remove());
     placeSwitchBeforeTiles();
-    footWrap.reserve();
   }
 
   function renderCrossWatchSnapshotHint(cwSnapshots) {
@@ -608,8 +589,6 @@ html[data-cw-theme="flat-light"] #insights-switch .ins-gear:hover{
     const configured = await getConfiguredProviders(forceConfigured);
     renderProviderStats(blk.providers, blk.active, configured, blk.raw?.providers_mse || null, data?.instances_by_provider || {});
     renderCrossWatchSnapshotHint(data?.crosswatch_snapshots || null);
-    footWrap.reserve();
-    if (!statsOnly) setTimeout(footWrap.reserve, 0);
   }
 
   async function refreshInsights(force = false) {


### PR DESCRIPTION
# Pull request

## Summary

Remove the empty space below the Statistics card on the Main page.

## Changes

- Align the dashboard columns to their content height
- Remove JavaScript padding calculations for the Insights footer
- Let the Statistics card and footer use the normal document layout

## Why

The Statistics card reserved extra space for the Insights footer, which could leave a large empty area below the card.

## Testing

Manual

## Issue

NA