### PR TITLE
Fix:  SSE reconnect and wall cache

### DIFF
--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -2285,6 +2285,10 @@ def api_run_summary_file() -> Response:
         headers={"Content-Disposition": 'attachment; filename="last_sync.json"'},
     )
 
+_SSE_HEARTBEAT_SEC = 15.0
+_SSE_HEARTBEAT_COMMENT = ": keep-alive\n\n"
+
+
 @router.get("/run/summary/stream")
 async def api_run_summary_stream(request: Request) -> StreamingResponse:
     import html, re
@@ -2336,11 +2340,13 @@ async def api_run_summary_stream(request: Request) -> StreamingResponse:
         last_key = None
         last_idx = 0
         last_hydrate_sig = None
+        last_emit = time.monotonic()
         LOG_BUFFERS = _rt()[0]
 
         while True:
             if await request.is_disconnected():
                 break
+            emitted = False
             buf_len = 0
             try:
                 buf = LOG_BUFFERS.get("SYNC") or []
@@ -2359,6 +2365,7 @@ async def api_run_summary_stream(request: Request) -> StreamingResponse:
                             evt = (str(obj.get("event") or "log").strip() or "log")
                             yield f"event: {evt}\n"
                             yield f"data: {json.dumps(obj, separators=(',',':'))}\n\n"
+                            emitted = True
                     last_idx = len(buf)
             except Exception:
                 pass
@@ -2396,6 +2403,14 @@ async def api_run_summary_stream(request: Request) -> StreamingResponse:
             if key != last_key:
                 last_key = key
                 yield f"data: {json.dumps(snap, separators=(',',':'))}\n\n"
+                emitted = True
+
+            now = time.monotonic()
+            if emitted:
+                last_emit = now
+            elif (now - last_emit) >= _SSE_HEARTBEAT_SEC:
+                yield _SSE_HEARTBEAT_COMMENT
+                last_emit = now
 
             await asyncio.sleep(0.25)
 
@@ -2407,6 +2422,5 @@ async def api_run_summary_stream(request: Request) -> StreamingResponse:
             "Pragma": "no-cache",
             "Expires": "0",
             "X-Accel-Buffering": "no",
-            "Connection": "keep-alive",
         },
     )

--- a/assets/helpers/watchlist-preview.js
+++ b/assets/helpers/watchlist-preview.js
@@ -15,9 +15,23 @@
   window._lastSyncEpoch = window._lastSyncEpoch || null;
   window.__wallRenderSignature = window.__wallRenderSignature || "";
   const WALL_PREVIEW_CACHE_KEY = "cw.wall.preview.v2";
-  const WALL_PREVIEW_LEGACY_CACHE_KEY = `cw.wall.preview.${window.APP_VERSION || "v1"}`;
+  const WALL_PREVIEW_MIGRATION_KEY = "cw.wallPreviewMigrated.v1";
   const WALL_PREVIEW_REFRESH_TTL_MS = 60 * 1000;
   const DEFAULT_INSTANCE = "default";
+
+  const migrateWallPreviewCache = () => {
+    try {
+      if (localStorage.getItem(WALL_PREVIEW_MIGRATION_KEY)) return;
+      const stale = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i) || "";
+        if (key.startsWith("cw.wall.preview.")) stale.push(key);
+      }
+      for (const key of stale) localStorage.removeItem(key);
+      localStorage.setItem(WALL_PREVIEW_MIGRATION_KEY, "1");
+    } catch {}
+  };
+  migrateWallPreviewCache();
 
   const json = async (url, opt) => {
     if (authSetupPending()) throw new Error("auth setup pending");
@@ -71,16 +85,8 @@
 
   const readWallCache = () => {
     try {
-      let raw = localStorage.getItem(WALL_PREVIEW_CACHE_KEY)
-        || localStorage.getItem(WALL_PREVIEW_LEGACY_CACHE_KEY);
-      if (!raw) {
-        for (let i = 0; i < localStorage.length; i++) {
-          const key = localStorage.key(i) || "";
-          if (!key.startsWith("cw.wall.preview.") || key === WALL_PREVIEW_CACHE_KEY) continue;
-          raw = localStorage.getItem(key);
-          if (raw) break;
-        }
-      }
+      const raw = localStorage.getItem(WALL_PREVIEW_CACHE_KEY);
+      if (!raw) return null;
       const data = JSON.parse(raw);
       return Array.isArray(data?.items) ? data : null;
     } catch {
@@ -92,6 +98,10 @@
     try {
       localStorage.setItem(WALL_PREVIEW_CACHE_KEY, JSON.stringify({ items, last_sync_epoch: lastSyncEpoch || 0, total }));
     } catch {}
+  };
+
+  const clearWallCache = () => {
+    try { localStorage.removeItem(WALL_PREVIEW_CACHE_KEY); } catch {}
   };
 
   const hasRenderedWall = (row = document.getElementById("poster-row")) => !!(row?.childElementCount && !row.classList.contains("hidden"));
@@ -845,17 +855,13 @@
 
     const myReq = ++wallReqSeq;
     const refreshVersion = window.__cwWallPreviewDirtyVersion;
-    let renderedWall = hasRenderedWall(row);
+    const renderedWall = hasRenderedWall(row);
     if (!renderedWall) {
       msg.textContent = "Loading...";
       msg.classList.remove("is-empty");
       msg.classList.remove("hidden");
       row.closest(".wall-wrap")?.classList.remove("is-empty");
       row.classList.add("hidden");
-      const cached = readWallCache();
-      if (cached) {
-        renderedWall = renderWall(row, msg, cached.items, cached.last_sync_epoch || 0, { total: cached.total ?? null });
-      }
     }
 
     const limit = Number.isFinite(window.MAX_WALL_POSTERS) ? Math.max(1, Number(window.MAX_WALL_POSTERS)) : 20;
@@ -867,6 +873,7 @@
       if (myReq !== wallReqSeq) return false;
       if (!isOnMain()) { hidePreviewCard(card, row, msg, { preserve: true }); return false; }
       if (!gate.allowed) {
+        clearWallCache();
         hidePreviewCard(card, row, msg);
         return false;
       }
@@ -877,13 +884,14 @@
       const data = wallResult.data;
       if (myReq !== wallReqSeq) return false;
       if (!isOnMain()) { hidePreviewCard(card, row, msg, { preserve: true }); return false; }
-      if (data?.missing_tmdb_key) { hidePreviewCard(card, row, msg); return false; }
+      if (data?.missing_tmdb_key) { clearWallCache(); hidePreviewCard(card, row, msg); return false; }
       if (!data?.ok) { msg.textContent = data?.error || "No state data found."; return false; }
 
       let items = Array.isArray(data.items) ? data.items.slice() : [];
       if (!items.length) items = (data.items || []).filter((it) => String(it?.status || "").toLowerCase() === "both");
       window._lastSyncEpoch = data.last_sync_epoch || null;
       if (!items.length) {
+        clearWallCache();
         setWallEmpty(row, msg, "No items to show yet.");
         markPreviewClean(refreshVersion);
         return true;
@@ -893,6 +901,10 @@
       markPreviewClean(refreshVersion);
       return true;
     } catch {
+      const cached = readWallCache();
+      if (cached?.items?.length) {
+        return renderWall(row, msg, cached.items, cached.last_sync_epoch || 0, { total: cached.total ?? null });
+      }
       if (!renderedWall) {
         row.classList.add("hidden");
         msg.classList.remove("hidden");

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -549,15 +549,21 @@
       on(esSummary, ["run:error", "run:aborted"], () => {
         try { sync.error(); setRunButtonState(false); } catch {}
       });
-      esSummary.onerror = () => {
-        safe(esSummary?.close?.bind(esSummary));
-        esSummary = null;
-        window.esSum = null;
-        if (authSetupPending()) return;
-        setTimeout(openSummaryStream, 2000);
-      };
+      esSummary.onopen = () => safe(summaryStream.onOpen.bind(summaryStream));
+      esSummary.onerror = () => summaryStream.onError();
     } catch {}
   };
+
+  const summaryStream = window.CW.createSummaryStreamController({
+    isHidden: () => document.hidden,
+    openStream: () => window.openSummaryStream(),
+    closeStream: () => {
+      safe(esSummary?.close?.bind(esSummary));
+      esSummary = null;
+      window.esSum = null;
+    },
+    pullSummary: () => { pullSummary().then(renderAll); },
+  });
 
   window.openLogStream = function openLogStream() {
     try {
@@ -574,11 +580,13 @@
   };
 
   window.addEventListener("visibilitychange", () => {
-    if (document.visibilityState === "visible") {
-      if (authSetupPending()) return;
-      openSummaryStream();
-      openLogStream();
+    if (document.hidden) {
+      summaryStream.onVisibility();
+      return;
     }
+    if (authSetupPending()) return;
+    summaryStream.onVisibility();
+    openLogStream();
   });
 
   window.addEventListener("auth-changed", () => {

--- a/assets/js/run-summary-stream.js
+++ b/assets/js/run-summary-stream.js
@@ -1,0 +1,80 @@
+/* assets/js/run-summary-stream.js */
+/* CrossWatch - Run-summary SSE stream lifecycle controller */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+  } else {
+    (root.CW = root.CW || {}).createSummaryStreamController = api.createSummaryStreamController;
+  }
+})(typeof self !== "undefined" ? self : this, function () {
+  function createSummaryStreamController(deps) {
+    const isHidden = deps.isHidden;
+    const openStream = deps.openStream;
+    const closeStream = deps.closeStream;
+    const pullSummary = deps.pullSummary;
+    const setTimer = deps.setTimer || ((fn, ms) => setTimeout(fn, ms));
+    const clearTimer = deps.clearTimer || ((t) => clearTimeout(t));
+    const baseDelay = deps.baseDelay ?? 2000;
+    const maxDelay = deps.maxDelay ?? 30000;
+
+    let reconnectTimer = null;
+    let attempt = 0;
+
+    function clearReconnect() {
+      if (reconnectTimer !== null) {
+        clearTimer(reconnectTimer);
+        reconnectTimer = null;
+      }
+    }
+
+    function scheduleReconnect() {
+      if (isHidden()) return;
+      if (reconnectTimer !== null) return;
+      const delay = Math.min(baseDelay * 2 ** attempt, maxDelay);
+      attempt += 1;
+      reconnectTimer = setTimer(() => {
+        reconnectTimer = null;
+        if (isHidden()) return;
+        openStream();
+      }, delay);
+    }
+
+    return {
+      onOpen() {
+        attempt = 0;
+        clearReconnect();
+      },
+      onError() {
+        closeStream();
+        if (isHidden()) return;
+        scheduleReconnect();
+      },
+      onVisibility() {
+        if (isHidden()) {
+          closeStream();
+          clearReconnect();
+          return Promise.resolve();
+        }
+        clearReconnect();
+        attempt = 0;
+        let pulled;
+        try { pulled = pullSummary(); } catch (e) { pulled = Promise.reject(e); }
+        return Promise.resolve(pulled)
+          .catch(() => {})
+          .then(() => {
+            if (isHidden()) return;
+            openStream();
+          });
+      },
+      clearReconnect,
+      _state() {
+        return { hasTimer: reconnectTimer !== null, attempt };
+      },
+    };
+  }
+
+  return { createSummaryStreamController };
+});


### PR DESCRIPTION
# Pull request

## Summary

Improve the run summary stream lifecycle and prevent unnecessary reconnect activity.

## Changes

- Add a reusable controller for the summary event stream
- Close the stream while the browser tab is hidden
- Refresh the summary and reconnect when the tab becomes visible
- Add capped exponential backoff after connection errors
- Update the sync API and watchlist preview integration

## Why

The run summary stream could reconnect repeatedly or remain active while the page was not visible. 
This caused unnecessary requests and unreliable summary updates.

## Testing

Manual by dev browser tools and test scripts:
test_syncAPI.py
test_watchlist-preview.js
