### PR TITLE
Fix: latest Ratings sorted by sync time

### DIFF
--- a/services/dashboard_widgets.py
+++ b/services/dashboard_widgets.py
@@ -680,6 +680,24 @@ def _merge_media_row(prev: Mapping[str, Any], row: Mapping[str, Any], *, sort_ke
     return chosen
 
 
+_RATING_TRACKER_FLAG = "_tracker_rating"
+
+
+def _merge_rating_row(prev: Mapping[str, Any], row: Mapping[str, Any]) -> dict[str, Any]:
+    prev_row = dict(prev)
+    next_row = dict(row)
+    prev_tracker = bool(prev_row.get(_RATING_TRACKER_FLAG))
+    next_tracker = bool(next_row.get(_RATING_TRACKER_FLAG))
+    if prev_tracker == next_tracker:
+        return _merge_media_row(prev_row, next_row, sort_key="sort_epoch")
+    chosen, other = (prev_row, next_row) if prev_tracker else (next_row, prev_row)
+    _merge_sources(chosen, other)
+    _copy_richer_media_fields(chosen, other)
+    if not chosen.get("type") and other.get("type"):
+        chosen["type"] = other["type"]
+    return chosen
+
+
 def _tracker_feature_items(kind: str) -> dict[str, Any]:
     try:
         from services.editor import load_state
@@ -709,7 +727,7 @@ def latest_ratings_widget(
                 break
         prev = rows.get(match_key)
         if prev:
-            rows[match_key] = _merge_media_row(prev, row, sort_key="sort_epoch")
+            rows[match_key] = _merge_rating_row(prev, row)
         else:
             rows[match_key] = row
         for alias in _rating_aliases(rows[match_key]):
@@ -719,6 +737,7 @@ def latest_ratings_widget(
         item = _unwrap_rating_item(raw_item)
         row = _rating_row(str(raw_key), item, _sources_from_item(item))
         if row:
+            row[_RATING_TRACKER_FLAG] = True
             put(row)
 
     providers = state.get("providers") if isinstance(state.get("providers"), Mapping) else {}
@@ -743,6 +762,8 @@ def latest_ratings_widget(
     )
     cap = max(1, min(int(limit or 12), 24))
     selected = _resolve_missing_art_rows(items[:cap], size="w342")
+    for row in selected:
+        row.pop(_RATING_TRACKER_FLAG, None)
     return {"ok": True, "items": selected, "total": len(items)}
 
 

--- a/tests/test_dashboard_widgets.py
+++ b/tests/test_dashboard_widgets.py
@@ -420,6 +420,66 @@ def test_latest_ratings_widget_merges_provider_local_movie_ids_and_inherits_art(
     assert {source["provider"] for source in payload["items"][0]["sources"]} == {"SIMKL", "TRAKT"}
 
 
+def test_latest_ratings_widget_keeps_tracker_rated_at_over_destination_sync_time() -> None:
+    tracker_items = {
+        "movie|imdb:tt0113277": {
+            "type": "movie",
+            "title": "Heat",
+            "year": 1995,
+            "rating": 8,
+            "rated_at": "2020-01-01T00:00:00Z",
+            "sources_by_provider": {"TRAKT": ["main"]},
+        },
+        "movie|imdb:tt0468569": {
+            "type": "movie",
+            "title": "The Dark Knight",
+            "year": 2008,
+            "rating": 9,
+            "rated_at": "2026-01-05T00:00:00Z",
+            "sources_by_provider": {"TRAKT": ["main"]},
+        },
+    }
+    state = {
+        "providers": {
+            "TMDB": {
+                "ratings": {
+                    "baseline": {
+                        "items": {
+                            "tmdb:rating:949": {
+                                "type": "movie",
+                                "title": "Heat",
+                                "year": 1995,
+                                "ids": {"tmdb": 949},
+                                "rating": 8,
+                                "rated_at": "2026-02-01T00:00:00Z",
+                            },
+                            "tmdb:rating:680": {
+                                "type": "movie",
+                                "title": "Pulp Fiction",
+                                "year": 1994,
+                                "ids": {"tmdb": 680},
+                                "rating": 7,
+                                "rated_at": "2026-01-10T00:00:00Z",
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    payload = dashboard_widgets.latest_ratings_widget(state, limit=5, tracker_items=tracker_items)
+
+    titles = [item["title"] for item in payload["items"]]
+    assert titles == ["Pulp Fiction", "The Dark Knight", "Heat"]
+
+    heat = payload["items"][2]
+    assert heat["rated_at"] == "2020-01-01T00:00:00Z"
+    assert heat["tmdb"] == 949
+    assert {source["provider"] for source in heat["sources"]} == {"TRAKT", "TMDB"}
+    assert all(not key.startswith("_") for key in heat)
+
+
 def test_latest_ratings_widget_resolves_missing_art_from_metadata(monkeypatch) -> None:
     fake = FakeMetadataManager()
     monkeypatch.setattr(dashboard_widgets, "_METADATA_MANAGER", fake)


### PR DESCRIPTION
# Pull request

## Change

- Keep the CrossWatch tracker rating as the authoritative row when the same rating also exists in provider state.
- Provider rows can still add source and metadata information, but they no longer replace the tracker rating or its timestamp.
- Added regression tests for newer destination timestamps and reversed merge order.

## Why

A provider could report its sync time as `rated_at`, causing an older rating to appear as newly rated in the Latest Ratings widget.

## Testing

Tested tracker and provider ratings with different timestamps and verified that the tracker timestamp is retained regardless of merge order.

`test_dashboard_widgets.py`


## Issue

Relates to #378
