### PR TITLE
Change: centralize wiki help links in registry

### DIFF
--- a/assets/helpers/help-links.js
+++ b/assets/helpers/help-links.js
@@ -1,0 +1,36 @@
+/* assets/helpers/help-links.js */
+/* Central wiki help link registry */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function(){
+  const BASE = "https://wiki.crosswatch.app/";
+
+  const PATHS = Object.freeze({
+    plex: "crosswatch/settings/connections/media-servers/plex",
+    emby: "crosswatch/settings/connections/media-servers/emby",
+    jellyfin: "crosswatch/settings/connections/media-servers/jellyfin",
+    trakt: "crosswatch/settings/connections/trackers/trakt",
+    simkl: "crosswatch/settings/connections/trackers/simkl",
+    tmdb: "crosswatch/settings/connections/trackers/tmdb",
+    mdblist: "crosswatch/settings/connections/trackers/mdblist",
+    publicmetadb: "crosswatch/settings/connections/trackers/publicmetadb",
+    anilist: "crosswatch/settings/connections/trackers/anilist",
+    tautulli: "crosswatch/settings/connections/others/tautulli",
+    "tmdb-metadata": "crosswatch/settings/connections/metadata/tmdb-metadata",
+    "anime-mapping": "crosswatch/settings/connections/metadata/anime-id-mapping",
+    "connection-profiles": "crosswatch/settings/connections/profiles",
+  });
+
+  function normalizeKey(v){ return String(v || "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, ""); }
+
+  function path(key){ return PATHS[normalizeKey(key)] || ""; }
+
+  function url(key){
+    const rel = path(key);
+    return rel ? BASE + rel : BASE;
+  }
+
+  const HelpLinks = Object.freeze({ base: BASE, paths: PATHS, path, url });
+
+  window.CW = window.CW || {};
+  window.CW.HelpLinks = HelpLinks;
+})();

--- a/assets/js/modals/setup-wizard/index.js
+++ b/assets/js/modals/setup-wizard/index.js
@@ -206,7 +206,7 @@ export default {
           <div class="card" role="listitem">
             <div class="ico" aria-hidden="true"><span class="material-symbols-rounded">key</span></div>
             <div>
-              <div><b>Authentication providers</b></div>
+              <div><b>Connections</b></div>
               <div class="muted">Next: link one or more providers in Settings.</div>
             </div>
           </div>

--- a/providers/auth/_auth_TRAKT.py
+++ b/providers/auth/_auth_TRAKT.py
@@ -256,8 +256,7 @@ class _TraktProvider:
             </div>
 
             <div id="trakt_hint" class="msg warn hidden" style="margin-top:8px">
-              You need a Trakt API application. Create one at
-              <a href="https://trakt.tv/oauth/applications" target="_blank" rel="noopener">Trakt Applications</a>.
+              You need a Trakt API application. Create one at <a href="https://trakt.tv/oauth/applications" target="_blank" rel="noopener">Trakt Applications</a>
               Set the Redirect URL to <code id="trakt_redirect_uri_preview">urn:ietf:wg:oauth:2.0:oob</code>.
               <button id="btn-copy-trakt-redirect" class="btn" type="button" style="margin-left:8px">Copy Redirect URL</button>
             </div>

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -75,7 +75,7 @@ def register_ui_root(app: FastAPI) -> None:
 
 
 _HELPER_SCRIPTS = (
-    "provider-meta.js", "icon-select.js", "scrobbler-ui.js", "scrobbler-user-picker.js", "page-loader.js", "dom.js", "events.js", "api.js", "core.js", "details-log.js",
+    "help-links.js", "provider-meta.js", "icon-select.js", "scrobbler-ui.js", "scrobbler-user-picker.js", "page-loader.js", "dom.js", "events.js", "api.js", "core.js", "details-log.js",
     "watchlist-preview.js", "providers-ui.js", "settings-ui.js", "settings-save.js", "maintenance.js", "backups.js",
     "restart_apply.js",
 )
@@ -420,13 +420,13 @@ html[data-cw-theme=flat-light] #page-settings .cw-maint-action.restart .cw-maint
         <span class="tab-caret" aria-hidden="true"></span>
       </button>
       <div class="cw-menu hidden" id="cw-settings-menu" role="menu" aria-labelledby="tab-settings">
-        <button class="cw-menu-item active" data-settings-pane="overview" type="button" role="menuitem" aria-current="page" onclick="window.cwSettingsMenuSelect('overview')"><span class="material-symbols-rounded cw-menu-icon" aria-hidden="true">settings</span><span>Settings overview</span></button>
+        <button class="cw-menu-item active" data-settings-pane="overview" type="button" role="menuitem" aria-current="page" onclick="window.cwSettingsMenuSelect('overview')"><span class="material-symbols-rounded cw-menu-icon" aria-hidden="true">grid_view</span><span>Settings overview</span></button>
         <div class="cw-menu-sep" role="separator" aria-hidden="true"></div>
-        <button class="cw-menu-item" data-settings-pane="providers" type="button" role="menuitem" onclick="window.cwSettingsMenuSelect('providers')"><span class="material-symbols-rounded cw-menu-icon" aria-hidden="true">link</span><span>Connections</span></button>
+        <button class="cw-menu-item" data-settings-pane="providers" type="button" role="menuitem" onclick="window.cwSettingsMenuSelect('providers')"><span class="material-symbols-rounded cw-menu-icon" aria-hidden="true">device_hub</span><span>Connections</span></button>
         <button class="cw-menu-item" data-settings-pane="sync" type="button" role="menuitem" onclick="window.cwSettingsMenuSelect('pairs')"><span class="material-symbols-rounded cw-menu-icon" aria-hidden="true">sync_alt</span><span>Sync pairs</span></button>
-        <button class="cw-menu-item" data-settings-pane="scrobbler" type="button" role="menuitem" onclick="window.cwSettingsMenuSelect('scrobbler')"><span class="material-symbols-rounded cw-menu-icon" aria-hidden="true">music_note</span><span>Scrobbler</span></button>
-        <button class="cw-menu-item" data-settings-pane="scheduling" type="button" role="menuitem" onclick="window.cwSettingsMenuSelect('scheduling')"><span class="material-symbols-rounded cw-menu-icon" aria-hidden="true">calendar_month</span><span>Scheduling</span></button>
-        <button class="cw-menu-item" data-settings-pane="app" type="button" role="menuitem" onclick="window.cwSettingsMenuSelect('app')"><span class="material-symbols-rounded cw-menu-icon" aria-hidden="true">shield</span><span>UI and Security</span></button>
+        <button class="cw-menu-item" data-settings-pane="scrobbler" type="button" role="menuitem" onclick="window.cwSettingsMenuSelect('scrobbler')"><span class="material-symbols-rounded cw-menu-icon" aria-hidden="true">sensors</span><span>Scrobbler</span></button>
+        <button class="cw-menu-item" data-settings-pane="scheduling" type="button" role="menuitem" onclick="window.cwSettingsMenuSelect('scheduling')"><span class="material-symbols-rounded cw-menu-icon" aria-hidden="true">schedule</span><span>Scheduling</span></button>
+        <button class="cw-menu-item" data-settings-pane="app" type="button" role="menuitem" onclick="window.cwSettingsMenuSelect('app')"><span class="material-symbols-rounded cw-menu-icon" aria-hidden="true">security</span><span>UI and Security</span></button>
         <button class="cw-menu-item" data-settings-pane="maintenance" type="button" role="menuitem" onclick="window.cwSettingsMenuSelect('maintenance')"><span class="material-symbols-rounded cw-menu-icon" aria-hidden="true">build</span><span>Maintenance</span></button>
         <div class="cw-menu-sep" role="separator" aria-hidden="true"></div>
         <button class="cw-menu-item danger" type="button" role="menuitem" onclick="window.cwSettingsMenuLogout()"><span class="material-symbols-rounded cw-menu-icon" aria-hidden="true">logout</span><span>Log out</span></button>


### PR DESCRIPTION
# Pull request

## Change

Added a central registry for CrossWatch Wiki links used by connection providers and metadata settings.

Also updated:

* The setup wizard label from “Authentication providers” to “Connections”
* The Trakt application help text formatting
* Settings menu icons for Overview, Connections, Scrobbler, Scheduling, and UI and Security
* Frontend asset loading to include the new help-link registry before the other UI helpers

## Why

Wiki paths were not centrally managed, making documentation links harder to maintain and update consistently.
A shared registry provides one location for provider-specific help URLs and keeps the connection UI aligned with the current Wiki structure.

## Testing

Verified that:
* The help-link registry loads with the frontend helper scripts
* Provider keys resolve to the correct Wiki paths
* Unknown keys fall back to the Wiki homepage
* The setup wizard displays the updated Connections label
* The Trakt application link remains functional
* The updated Settings menu icons render correctly

## Issue

NA
