### PR TITLE
Fix: block webhook dispatch to unconfigured dest

### DIFF
--- a/providers/webhooks/dispatch.py
+++ b/providers/webhooks/dispatch.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from cw_platform.provider_instances import normalize_instance_id
 from providers.scrobble.scrobble import ScrobbleAction, ScrobbleEvent
-from providers.webhooks.config import webhook_settings, webhook_sinks
+from providers.webhooks.config import sink_configured, webhook_settings, webhook_sink_instance, webhook_sinks
 
 
 class DispatchResponse:
@@ -53,13 +53,6 @@ def _int(v: Any) -> int | None:
         return int(v) if v not in (None, "") else None
     except Exception:
         return None
-
-
-def _sink_instance(settings: Mapping[str, Any], sink: str) -> str:
-    wh = settings if isinstance(settings, Mapping) else {}
-    sink_instances = wh.get("sink_instances")
-    instances = sink_instances if isinstance(sink_instances, Mapping) else {}
-    return normalize_instance_id(str(instances.get(sink) or "default"))
 
 
 def _make_sink(name: str, instance_id: str, cfg_provider: Callable[[], dict[str, Any]]) -> Any:
@@ -187,8 +180,14 @@ def dispatch_scrobble(
         raw=raw,
     )
     targets: list[dict[str, Any]] = []
+    dispatched: list[str] = []
     for sink in sinks:
-        inst = _sink_instance(wh, sink)
+        inst = webhook_sink_instance(wh, sink)
+        if not sink_configured(cfg, sink, inst):
+            targets.append({"target": sink, "target_instance": inst, "ok": False, "skipped": True, "error": "not_configured"})
+            _emit(logger, f"webhook sink {sink}:{inst} skipped: not configured in Connections", "WARNING")
+            continue
+        dispatched.append(sink)
         route_cfg = _route_cfg(cfg, provider_lc, provider_inst, sink, inst)
 
         def _provider(route_cfg: dict[str, Any] = route_cfg) -> dict[str, Any]:
@@ -202,7 +201,7 @@ def dispatch_scrobble(
             target["error"] = str(e)
             _emit(logger, f"webhook sink {sink}:{inst} failed: {e}", "ERROR")
         targets.append(target)
-    ok = any(bool(t.get("ok")) for t in targets)
+    ok = not targets or any(bool(t.get("ok")) for t in targets)
     payload = {
         "action": path,
         "status": 200 if ok else 502,
@@ -210,5 +209,5 @@ def dispatch_scrobble(
         "activity_recorded": True,
         "targets": targets,
     }
-    _emit(logger, f"webhook dispatch {path} -> {','.join(sinks)} status={payload['status']}", "DEBUG")
+    _emit(logger, f"webhook dispatch {path} -> {','.join(dispatched) or 'none'} status={payload['status']}", "DEBUG")
     return DispatchResponse(payload["status"], payload)

--- a/providers/webhooks/emby.py
+++ b/providers/webhooks/emby.py
@@ -20,7 +20,7 @@ from providers.scrobble.currently_watching import update_from_payload as _cw_upd
 from providers.scrobble._auto_remove_watchlist import remove_across_providers_by_ids as _rm_across
 from providers.scrobble.scrobble import mask_account as _mask_account
 from providers.scrobble.sources import source_enabled
-from providers.webhooks.config import webhook_sinks
+from providers.webhooks.config import configured_webhook_sinks
 from providers.webhooks.dispatch import dispatch_scrobble as _dispatch_scrobble
 try:
     from api.watchlistAPI import remove_across_providers_by_ids as _rm_across_api
@@ -58,7 +58,7 @@ _ITEM_VIEW_CACHE: dict[str, str | None] = {}
 
 
 def _sinks_from_webhook_cfg(cfg: dict[str, Any], provider_instance: Any = None) -> set[str]:
-    return set(webhook_sinks(cfg, "emby", provider_instance))
+    return set(configured_webhook_sinks(cfg, "emby", provider_instance))
 
 
 def _as_set_str(v: Any) -> set[str]:

--- a/providers/webhooks/jellyfin.py
+++ b/providers/webhooks/jellyfin.py
@@ -18,7 +18,7 @@ from providers.scrobble.currently_watching import update_from_payload as _cw_upd
 from providers.scrobble._auto_remove_watchlist import remove_across_providers_by_ids as _rm_across
 from providers.scrobble.scrobble import mask_account as _mask_account
 from providers.scrobble.sources import source_enabled
-from providers.webhooks.config import webhook_sinks
+from providers.webhooks.config import configured_webhook_sinks
 from providers.webhooks.dispatch import dispatch_scrobble as _dispatch_scrobble
 try:
     from api.watchlistAPI import remove_across_providers_by_ids as _rm_across_api
@@ -59,7 +59,7 @@ _JF_ITEM_VIEW_CACHE: dict[str, str | None] = {}
 
 
 def _sinks_from_webhook_cfg(cfg: dict[str, Any], provider_instance: Any = None) -> set[str]:
-    return set(webhook_sinks(cfg, "jellyfin", provider_instance))
+    return set(configured_webhook_sinks(cfg, "jellyfin", provider_instance))
 
 
 def _as_set_str(v: Any) -> set[str]:

--- a/providers/webhooks/plex.py
+++ b/providers/webhooks/plex.py
@@ -24,7 +24,7 @@ from providers.scrobble.currently_watching import update_from_payload as _cw_upd
 from providers.scrobble._auto_remove_watchlist import remove_across_providers_by_ids as _rm_across
 from providers.scrobble.scrobble import mask_account as _mask_account
 from providers.scrobble.sources import source_enabled
-from providers.webhooks.config import webhook_sinks
+from providers.webhooks.config import configured_webhook_sinks
 from providers.webhooks.dispatch import dispatch_scrobble as _dispatch_scrobble
 
 try:
@@ -67,7 +67,7 @@ _DEF_TRAKT: dict[str, Any] = {
 
 
 def _sinks_from_webhook_cfg(cfg: dict[str, Any], provider_instance: Any = None) -> set[str]:
-    return set(webhook_sinks(cfg, "plex", provider_instance))
+    return set(configured_webhook_sinks(cfg, "plex", provider_instance))
 
 
 def _archive(event_type: str, media_type: str, md: dict[str, Any], ids: dict[str, Any], account: Any, prog: Any, **kw: Any) -> None:


### PR DESCRIPTION
# Pull request

## Change

Only dispatch media-server webhook events to destinations that are actually configured.

The shared webhook dispatcher now:
* Skips destinations whose selected profile is not connected
* Records skipped destinations as `not_configured`
* Continues dispatching to other valid destinations
* Returns a successful response when no destination requires processing
* Logs the destinations that were actually dispatched

Plex, Emby, and Jellyfin webhook handling now use the configured destination list better..

## Why

A webhook route could include Trakt, SIMKL, or MDBList even when the selected destination profile was not configured. CrossWatch would then attempt to dispatch the event and could return a failure for an otherwise valid webhook request.

## Testing

Verified webhook dispatch with:
* All selected destinations configured
* A mix of configured and unconfigured destinations
* No configured destinations
* Separate destination profiles
* Plex, Emby, and Jellyfin webhook sources

## Issue

NA
