### PR TITLE
Fix: Trakt to SIMKL native anime episode history maps

### DIFF
--- a/api/maintenanceAPI.py
+++ b/api/maintenanceAPI.py
@@ -262,7 +262,7 @@ def maintenance_action_status(action: str) -> dict[str, Any]:
         retry_files = sum(1 for item in files if any(token in str(item.get("name") or "").lower() for token in retry_names))
         response.update(
             title="Retry provider items",
-            note="Clears retry guards, tombstones, phantom records and provider health state. Playback and activity files stay untouched.",
+            note="Clears provider runtime caches: retry guards, tombstones, phantom records, provider health, plus history, watermark and mapping index caches. Playback and activity files stay untouched.",
             metrics=[
                 _metric("Runtime files", len(files)),
                 _metric("Retry / guard files", retry_files),

--- a/cw_platform/event_archive/recorder.py
+++ b/cw_platform/event_archive/recorder.py
@@ -365,6 +365,28 @@ class RunRecorder:
             self._flush()
             return
 
+        if event == "archive:item_resolutions":
+            dst = _norm_prov(f.get("provider")) or self._dst
+            src = self._src if self._src and self._src != dst else self._a
+            op = str(f.get("op") or "add")
+            for row in (f.get("items") or []):
+                if not isinstance(row, Mapping):
+                    continue
+                k = str(row.get("key") or "")
+                if not k:
+                    continue
+                raw_it = row.get("item")
+                it: Mapping[str, Any] = raw_it if isinstance(raw_it, Mapping) else {}
+                self._add(
+                    event_type="unresolved_cleared", operation=op, severity="info",
+                    source_provider=src or None, destination_provider=dst or None,
+                    source_instance=self._si or None, destination_instance=self._di or None,
+                    reason_code="unresolved_cleared", reason="unresolved_cleared",
+                    item_key=k, **_item_fields(it),
+                )
+            self._flush()
+            return
+
         if event == "debug" and str(f.get("msg") or "") == "blocked.counts":
             bb = int(f.get("blocked_blackbox") or 0)
             dst_p = _norm_prov(f.get("dst")) or None

--- a/cw_platform/id_map.py
+++ b/cw_platform/id_map.py
@@ -330,6 +330,15 @@ def minimal(item: Mapping[str, Any]) -> dict[str, Any]:
         if opt in item and item.get(opt) not in (None, ""):
             out[opt] = item.get(opt)
 
+    abs_raw = item.get("_trakt_number_abs")
+    if isinstance(abs_raw, (int, str)) and str(abs_raw).strip():
+        try:
+            abs_no = int(abs_raw)
+            if abs_no > 0:
+                out["_trakt_number_abs"] = abs_no
+        except Exception:
+            pass
+
     # Preserve internal flags needed by orchestrator blocklist logic.
     try:
         if bool(item.get("_cw_marked")):

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -57,6 +57,25 @@ def _emit_item_failures(emit, provider, feature, pair, keys, key2item, bb_res) -
         pass
 
 
+def _emit_item_resolutions(emit, provider, feature, pair, keys, key2item) -> None:
+    try:
+        all_keys = [k for k in (keys or []) if k]
+        if not all_keys:
+            return
+        items = [{"key": k, "item": key2item.get(k)} for k in all_keys]
+        emit(
+            "archive:item_resolutions",
+            provider=provider,
+            feature=feature,
+            pair=pair,
+            op="add",
+            items=items,
+            total=len(all_keys),
+        )
+    except Exception:
+        pass
+
+
 def compute_effective_add(
     *,
     attempted_keys,
@@ -1478,6 +1497,9 @@ def run_one_way_feature(
                 if success_keys and not ambiguous_partial:
                     record_success(dst, feature, success_keys, pair=pair_key, cfg=cfg)
                     clear_unresolved(dst, feature, success_keys)
+                    resolved_keys = [k for k in success_keys if k in unresolved_before]
+                    if resolved_keys:
+                        _emit_item_resolutions(emit, dst, feature, pair_key, resolved_keys, key2item)
                     clear_items_for_feature(
                         ctx.state_store,
                         dbg,

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -9,7 +9,7 @@ import os
 import re
 import datetime as _dt
 
-from ._pairs_oneway import _emit_item_failures, compute_effective_add, select_baseline_keys
+from ._pairs_oneway import _emit_item_failures, _emit_item_resolutions, compute_effective_add, select_baseline_keys
 
 try:
     from ._pairs_oneway import (
@@ -1721,6 +1721,9 @@ def _two_way_sync(
                 if success_A:
                     record_success(a, feature, success_A, pair=pair_key, cfg=cfg)
                     clear_unresolved(a, feature, success_A)
+                    resolved_A = [k for k in success_A if k in unresolved_before_A]
+                    if resolved_A:
+                        _emit_item_resolutions(emit, a, feature, pair_key, resolved_A, k2i_A)
                     clear_items_for_feature(
                         ctx.state_store,
                         dbg,
@@ -1851,6 +1854,9 @@ def _two_way_sync(
                 if success_B:
                     record_success(b, feature, success_B, pair=pair_key, cfg=cfg)
                     clear_unresolved(b, feature, success_B)
+                    resolved_B = [k for k in success_B if k in unresolved_before_B]
+                    if resolved_B:
+                        _emit_item_resolutions(emit, b, feature, pair_key, resolved_B, k2i_B)
                     clear_items_for_feature(
                         ctx.state_store,
                         dbg,

--- a/providers/sync/_mod_SIMKL.py
+++ b/providers/sync/_mod_SIMKL.py
@@ -75,7 +75,7 @@ def _confirmed_keys(key_of, items: Iterable[Mapping[str, Any]], unresolved: Any)
         seen.add(k)
     return out
 
-__VERSION__ = "1.4"
+__VERSION__ = "1.5"
 __all__ = ["get_manifest", "SIMKLModule", "OPS"]
 
 

--- a/providers/sync/_mod_TRAKT.py
+++ b/providers/sync/_mod_TRAKT.py
@@ -89,7 +89,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.2"
+__VERSION__ = "1.3"
 __all__ = ["get_manifest", "TRAKTModule", "OPS"]
 
 os.environ.setdefault("CW_TRAKT_UA", f"CrossWatch TRAKT/{__VERSION__}")

--- a/providers/sync/simkl/_history.py
+++ b/providers/sync/simkl/_history.py
@@ -39,6 +39,7 @@ URL_ADD = f"{BASE}/sync/history"
 URL_REMOVE = f"{BASE}/sync/history/remove"
 URL_REDIRECT = f"{BASE}/redirect"
 URL_ANIME_EPISODES = f"{BASE}/anime/episodes"
+_CACHE_SCHEMA = 2
 
 
 def _unresolved_path() -> str:
@@ -333,6 +334,8 @@ def _cache_load() -> dict[str, dict[str, Any]]:
     data = _load_json(_cache_path())
     if not isinstance(data, dict):
         return {}
+    if int(data.get("schema") or 0) != _CACHE_SCHEMA:
+        return {}
     items = data.get("items")
     if not isinstance(items, dict):
         return {}
@@ -346,8 +349,15 @@ def _cache_load() -> dict[str, dict[str, Any]]:
     return out
 
 
+def _cache_doc_is_stale() -> bool:
+    data = _load_json(_cache_path())
+    if not isinstance(data, dict) or not data:
+        return False
+    return int(data.get("schema") or 0) != _CACHE_SCHEMA
+
+
 def _cache_save(items: Mapping[str, Any]) -> None:
-    _save_json(_cache_path(), {"generated_at": _as_iso(_now_epoch()), "items": dict(items)})
+    _save_json(_cache_path(), {"schema": _CACHE_SCHEMA, "generated_at": _as_iso(_now_epoch()), "items": dict(items)})
 
 
 def _evict_removes_from_cache(items_list: list[Mapping[str, Any]]) -> None:
@@ -639,6 +649,49 @@ def _source_title_episode_aliases(show_ids: Mapping[str, Any]) -> dict[str, dict
     return out
 
 
+def _source_abs_episode_aliases(show_ids: Mapping[str, Any]) -> dict[int, dict[str, Any]]:
+    try:
+        path = Path(_trakt_history_index_path())
+        data = json.loads(path.read_text("utf-8")) if path.exists() else {}
+    except Exception:
+        data = {}
+    items = data.get("items") if isinstance(data, Mapping) else None
+    if not isinstance(items, Mapping):
+        return {}
+
+    grouped: dict[int, dict[tuple[int, int], dict[str, Any]]] = {}
+    for item in items.values():
+        if not isinstance(item, Mapping):
+            continue
+        if str(item.get("type") or "").lower() != "episode":
+            continue
+        abs_num = _int_or_none(item.get("_trakt_number_abs"))
+        if abs_num is None or abs_num <= 0:
+            continue
+        raw_show_ids = item.get("show_ids")
+        item_show_ids: Mapping[str, Any] = raw_show_ids if isinstance(raw_show_ids, Mapping) else {}
+        if not _show_ids_overlap(show_ids, item_show_ids):
+            continue
+        source = _source_season_episode(item)
+        if source is None:
+            continue
+        s_num, e_num = source
+        grouped.setdefault(abs_num, {})[(s_num, e_num)] = {
+            "season": s_num,
+            "episode": e_num,
+            "show_ids": dict(item_show_ids),
+            "title": item.get("title"),
+            "series_title": item.get("series_title"),
+            "series_year": item.get("series_year") or item.get("year"),
+        }
+
+    out: dict[int, dict[str, Any]] = {}
+    for abs_num, choices in grouped.items():
+        if len(choices) == 1:
+            out[abs_num] = next(iter(choices.values()))
+    return out
+
+
 def _apply_since_limit(
     out: dict[str, dict[str, Any]],
     *,
@@ -694,6 +747,7 @@ def _parse_rows(
     anime_aliases = _load_anime_episode_alias_cache()
     anime_episode_cache = _load_anime_episode_map_cache()
     source_title_alias_cache: dict[str, dict[str, dict[str, Any]]] = {}
+    source_abs_alias_cache: dict[str, dict[int, dict[str, Any]]] = {}
 
     for row in movie_rows:
         if not isinstance(row, Mapping):
@@ -806,6 +860,12 @@ def _parse_rows(
                         alias = alias_raw
                     if alias is None:
                         show_key = json.dumps({str(k): str(v) for k, v in show_ids.items() if v not in (None, "")}, sort_keys=True)
+                        if show_key not in source_abs_alias_cache:
+                            source_abs_alias_cache[show_key] = _source_abs_episode_aliases(show_ids)
+                        abs_alias = source_abs_alias_cache.get(show_key, {}).get(e_num_internal)
+                        if isinstance(abs_alias, Mapping):
+                            alias = abs_alias
+                    if alias is None:
                         title_value = episode.get("title")
                         if not _title_match_key(title_value) and session is not None and headers is not None and timeout is not None:
                             title_value = _anime_episode_title_for_number(
@@ -956,7 +1016,8 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
     normalize_flat_watermarks()
 
     cached = _cache_load()
-    wm = get_watermark("history") or ""
+    cache_stale = _cache_doc_is_stale()
+    wm = "" if cache_stale else (get_watermark("history") or "")
     removed_wm = get_watermark("history_removed") or ""
 
     acts, _ = fetch_activities(session, _headers(adapter, force_refresh=True), timeout=timeout)
@@ -1616,6 +1677,13 @@ def _anime_retry_episode_number(
             mapped = _row_anime_episode_number(direct[0])
             if mapped:
                 return mapped
+        abs_num = _int_or_none(item.get("_trakt_number_abs"))
+        if abs_num is not None and abs_num > 0:
+            abs_hits = [row for row in rows if _row_anime_episode_number(row) == abs_num]
+            if len(abs_hits) == 1:
+                mapped = _row_anime_episode_number(abs_hits[0])
+                if mapped:
+                    return mapped
         title_key = _title_match_key(item.get("title"))
         if title_key:
             title_hits = [row for row in rows if _title_match_key(row.get("title")) == title_key]
@@ -2384,6 +2452,53 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
     _info("write_done", op="add", ok=False, applied=0, unresolved=len(unresolved))
     return 0, unresolved
 
+def _native_anime_remove_body(
+    items_list: list[Mapping[str, Any]],
+    *,
+    session: Any,
+    headers: Mapping[str, str],
+    timeout: float,
+    resolve_cache: dict[str, str],
+    misses: set[str],
+) -> tuple[dict[str, Any], list[str], set[int], list[Mapping[str, Any]]]:
+    episode_cache = _load_anime_episode_map_cache()
+    groups: dict[str, tuple[dict[str, str], list[Mapping[str, Any]]]] = {}
+    detected: set[int] = set()
+    for item in items_list:
+        if str(item.get("type") or "").lower() != "episode":
+            continue
+        native_ids = _native_anime_ids_for_mismatched_show(session, headers, timeout, item, resolve_cache, misses)
+        ids = {k: str(v) for k, v in native_ids.items() if k in {"simkl", "tvdb"} and v}
+        if not ids.get("simkl"):
+            continue
+        detected.add(id(item))
+        gkey = json.dumps(ids, sort_keys=True)
+        _ids, grouped = groups.setdefault(gkey, (dict(ids), []))
+        grouped.append(item)
+
+    anime_out: list[dict[str, Any]] = []
+    thaw: list[str] = []
+    mapped_ids: set[int] = set()
+    for _gkey, (ids, grouped) in groups.items():
+        mapped = _anime_retry_episode_numbers_for_group(
+            grouped, ids, session=session, headers=headers, timeout=timeout, episode_cache=episode_cache
+        )
+        episodes: list[dict[str, Any]] = []
+        for item in grouped:
+            number = mapped.get(_thaw_key(item))
+            if number is None:
+                continue
+            episodes.append({"number": number})
+            thaw.append(_thaw_key(item))
+            mapped_ids.add(id(item))
+        if episodes:
+            anime_out.append({"ids": dict(ids), "episodes": episodes})
+
+    unmapped = [item for item in items_list if id(item) in detected and id(item) not in mapped_ids]
+    body = {"anime": anime_out} if anime_out else {}
+    return body, thaw, detected, unmapped
+
+
 def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
     session = adapter.client.session
     headers = _headers(adapter)
@@ -2394,13 +2509,50 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
         _info("write_skipped", op="remove", reason="empty_payload", unresolved=len(unresolved))
         return 0, unresolved
     chunk_size = max(1, int(getattr(adapter.cfg, "history_chunk_size", 100) or 100))
+    native_resolve_cache = _load_anime_resolve_cache()
+    native_resolve_misses: set[str] = set()
     ok = 0
     for part in _chunk_items(items_list, chunk_size):
+        native_body, native_thaw, native_detected, native_unmapped = _native_anime_remove_body(
+            list(part),
+            session=session,
+            headers=headers,
+            timeout=timeout,
+            resolve_cache=native_resolve_cache,
+            misses=native_resolve_misses,
+        )
+        for item in native_unmapped:
+            unresolved.append({"item": id_minimal(item), "hint": "simkl_anime_remove_unmapped:episodes", "reason": "simkl_anime_remove_unmapped:episodes"})
+        if native_body:
+            try:
+                resp = session.post(
+                    URL_REMOVE,
+                    headers=headers,
+                    params=simkl_api_params_from_headers(headers),
+                    json=native_body,
+                    timeout=timeout,
+                )
+                if 200 <= resp.status_code < 300:
+                    _unfreeze(native_thaw)
+                    ok += len(native_thaw)
+                    _evict_removes_from_cache([it for it in part if id(it) in native_detected and id(it) not in {id(u) for u in native_unmapped}])
+                else:
+                    _warn("write_failed", op="remove", target="anime", status=resp.status_code, body=(resp.text or '')[:200])
+                    for item in part:
+                        if id(item) in native_detected and id(item) not in {id(u) for u in native_unmapped}:
+                            unresolved.append({"item": id_minimal(item), "hint": _write_failure_hint(resp, reason="anime_remove_failed")})
+            except Exception as exc:
+                _warn("write_failed", op="remove", target="anime", error=str(exc))
+                for item in part:
+                    if id(item) in native_detected and id(item) not in {id(u) for u in native_unmapped}:
+                        unresolved.append({"item": id_minimal(item), "hint": _write_failure_hint(exc=exc, reason="anime_remove_failed")})
         movies: list[dict[str, Any]] = []
         shows_whole: list[dict[str, Any]] = []
         shows_scoped: dict[str, dict[str, Any]] = {}
         thaw_keys: list[str] = []
         for item in part:
+            if id(item) in native_detected:
+                continue
             typ = str(item.get("type") or "").lower()
             bucket = str(item.get("simkl_bucket") or "").strip().lower()
             if typ == "movie" and bucket == "anime":

--- a/providers/sync/trakt/_history.py
+++ b/providers/sync/trakt/_history.py
@@ -35,6 +35,7 @@ URL_ADD = f"{BASE}/sync/history"
 URL_REMOVE = f"{BASE}/sync/history/remove"
 URL_COLL_ADD = f"{BASE}/sync/collection"
 RESOLVE_ENABLE = False
+_CACHE_SCHEMA = 2
 
 def _int_or_none(x: Any) -> int | None:
     if x is None:
@@ -183,6 +184,17 @@ def _chunked_items(seq: list[Mapping[str, Any]], n: int) -> Iterable[list[Mappin
         yield seq[i : i + size]
 
 
+_NATIVE_ANIME_PROVIDERS = {"SIMKL", "ANILIST"}
+
+
+def _episodes_extended() -> str | None:
+    for env_key in ("CW_PAIR_SRC", "CW_PAIR_DST"):
+        prov = str(os.getenv(env_key) or "").strip().upper()
+        if prov in _NATIVE_ANIME_PROVIDERS:
+            return "full"
+    return None
+
+
 def _history_number_fallback_enabled(adapter: Any) -> bool:
     return True if not RESOLVE_ENABLE else bool(_cfg_get(adapter, "history_number_fallback", False))
 
@@ -213,7 +225,10 @@ def _load_cache_doc() -> dict[str, Any]:
         p = _cache_path()
         if not p.exists():
             return {}
-        return json.loads(p.read_text("utf-8") or "{}")
+        doc = json.loads(p.read_text("utf-8") or "{}")
+        if not isinstance(doc, dict) or int(doc.get("schema") or 0) != _CACHE_SCHEMA:
+            return {}
+        return doc
     except Exception:
         return {}
 
@@ -225,6 +240,7 @@ def _save_cache_doc(items: Mapping[str, Any], watched_at: str | None, validated_
         cache_path = _cache_path()
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         doc = {
+            "schema": _CACHE_SCHEMA,
             "generated_at": _now_iso(),
             "items": dict(items),
             "wm": {"watched_at": watched_at or ""},
@@ -389,12 +405,14 @@ def _preflight_total(
         return None
 
 
-def _history_params(*, page: int, limit: int, start_at: str | None = None, end_at: str | None = None) -> dict[str, Any]:
+def _history_params(*, page: int, limit: int, start_at: str | None = None, end_at: str | None = None, extended: str | None = None) -> dict[str, Any]:
     params: dict[str, Any] = {"page": int(page), "limit": int(limit)}
     if start_at:
         params["start_at"] = str(start_at)
     if end_at:
         params["end_at"] = str(end_at)
+    if extended:
+        params["extended"] = str(extended)
     return params
 
 def _fetch_history(
@@ -408,6 +426,7 @@ def _fetch_history(
     max_retries: int,
     start_at: str | None = None,
     end_at: str | None = None,
+    extended: str | None = None,
     bump: Callable[[int], None] | None = None,
 ) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
@@ -419,7 +438,7 @@ def _fetch_history(
             "GET",
             url,
             headers=headers,
-            params=_history_params(page=page, limit=per_page, start_at=start_at, end_at=end_at),
+            params=_history_params(page=page, limit=per_page, start_at=start_at, end_at=end_at, extended=extended),
             timeout=timeout,
             max_retries=max_retries,
         )
@@ -467,6 +486,9 @@ def _fetch_history(
                 m["watched_at"] = w
                 if hid is not None:
                     m["_trakt_history_id"] = str(hid)
+                abs_no = _int_or_none(ep.get("number_abs"))
+                if abs_no is not None and abs_no > 0:
+                    m["_trakt_number_abs"] = abs_no
                 out.append(m)
                 added += 1
         if bump and added:
@@ -497,6 +519,8 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 100000) -
     cfg_max_pages = int(_cfg_num(adapter, "history_max_pages", max_pages, int))
     if cfg_max_pages <= 0:
         cfg_max_pages = max_pages
+
+    epi_extended = _episodes_extended()
 
     doc = _load_cache_doc()
     cached_items: dict[str, dict[str, Any]] = dict(doc.get("items") or {})
@@ -594,6 +618,7 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 100000) -
                     timeout=timeout,
                     max_retries=retries,
                     start_at=start_at,
+                    extended=epi_extended,
                 )
 
                 added = 0
@@ -723,6 +748,7 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 100000) -
         max_pages=cfg_max_pages,
         timeout=timeout,
         max_retries=retries,
+        extended=epi_extended,
         bump=bump,
     )
     idx: dict[str, dict[str, Any]] = {}


### PR DESCRIPTION
# Pull request

## Change

Improved Trakt to SIMKL history matching for anime that use different episode numbering.

CrossWatch now keeps Trakt’s absolute episode number and uses it to find the matching native SIMKL episode when season numbers, episode numbers or titles differ.

This applies to:
* Adding anime history to SIMKL
* Reading SIMKL history back into Trakt numbering
* Removing anime history from SIMKL
* One-way and two-way history syncs

Trakt only requests the additional episode information when a sync involves SIMKL or AniList, so normal Trakt syncs continue using the smaller response.

History caches are rebuilt automatically after upgrading. Previously unresolved items that sync successfully on retry are also cleared from Events.

The Maintenance cache cleanup description was corrected.

## Why

Trakt commonly stores anime using aired season and episode numbers, while SIMKL may use one continuous episode number.

For example, an episode stored as season 2 episode 13 on Trakt may be episode 52 on SIMKL. When the titles also differ, CrossWatch previously had no reliable way to connect them.

Using the absolute episode number provides a consistent match and prevents valid anime history from remaining unresolved or being added to the blackbox.

Watchlist and ratings are unaffected because SIMKL handles those at movie or show level rather than individual episode level.

## Testing

Added coverage for:

* Preserving Trakt absolute episode numbers during sync planning
* Matching episodes when Trakt and SIMKL titles differ
* Keeping the existing title-based matching fallback
* Rejecting missing or ambiguous absolute-number matches
* Leaving normal television shows unchanged
* Converting SIMKL history back to the original Trakt season and episode
* Removing the correct native SIMKL episode
* Clearing resolved Events entries after a successful retry
* Requesting extended Trakt episode data only for supported anime sync pairs

Existing history, specials, two-way sync, planning, logging and Maintenance tests also pass.

## Issue

Relates to #394
