### PR TITLE
Fix: resolve Trakt watchlist limit from user settings

### DIFF
--- a/providers/sync/trakt/_common.py
+++ b/providers/sync/trakt/_common.py
@@ -26,6 +26,7 @@ def _user_agent() -> str:
 
 STATE_DIR = Path("/config/.cw_state")
 _ACT_MEMO: tuple[float, dict[str, Any] | None] = (0.0, None)
+_SETTINGS_MEMO: tuple[float, dict[str, Any] | None] = (0.0, None)
 
 
 def _pair_scope() -> str | None:
@@ -219,6 +220,77 @@ def fetch_last_activities(
         return None
     except Exception:
         return None
+
+
+def fetch_user_settings(
+    session: Any,
+    headers: Mapping[str, str],
+    *,
+    timeout: float = 15.0,
+    max_retries: int = 3,
+) -> dict[str, Any] | None:
+    global _SETTINGS_MEMO
+    now = time.time()
+    ts, cached = _SETTINGS_MEMO
+    if cached is not None and (now - ts) < 300.0:
+        return cached
+    url = "https://api.trakt.tv/users/settings"
+    try:
+        r = request_with_retries(
+            session,
+            "GET",
+            url,
+            headers=dict(headers),
+            timeout=timeout,
+            max_retries=max_retries,
+        )
+        if 200 <= r.status_code < 300:
+            data = r.json() if (r.text or "").strip() else {}
+            _SETTINGS_MEMO = (now, data)
+            return data
+        return None
+    except Exception:
+        return None
+
+
+def resolve_watchlist_limit(adapter: Any, cfg: Mapping[str, Any]) -> int | None:
+    raw = cfg.get("watchlist_limit")
+    if raw is not None and str(raw).strip():
+        try:
+            v = int(raw)
+            if v > 0:
+                return v
+        except Exception:
+            pass
+
+    settings = fetch_user_settings(
+        adapter.client.session,
+        headers_for_adapter(adapter),
+        timeout=float(getattr(adapter.cfg, "timeout", 15.0) or 15.0),
+        max_retries=int(getattr(adapter.cfg, "max_retries", 3) or 3),
+    )
+    if not isinstance(settings, Mapping):
+        return None
+
+    limits = settings.get("limits")
+    wl = limits.get("watchlist") if isinstance(limits, Mapping) else None
+    item_count = wl.get("item_count") if isinstance(wl, Mapping) else None
+    if isinstance(item_count, (int, str)):
+        try:
+            iv = int(item_count)
+            if iv > 0:
+                return iv
+        except Exception:
+            pass
+
+    user = settings.get("user")
+    if isinstance(user, Mapping):
+        vip = bool(user.get("vip") or user.get("vip_og") or user.get("vip_ep"))
+    else:
+        vip = False
+    if not vip:
+        return 250
+    return None
 
 
 def extract_latest_ts(activities: Mapping[str, Any], paths: Iterable[Iterable[str]]) -> str | None:

--- a/providers/sync/trakt/_common.py
+++ b/providers/sync/trakt/_common.py
@@ -222,46 +222,37 @@ def fetch_last_activities(
         return None
 
 
-def fetch_user_settings(
-    session: Any,
-    headers: Mapping[str, str],
-    *,
-    timeout: float = 15.0,
-    max_retries: int = 3,
-) -> dict[str, Any] | None:
+def _pos_int(v: Any) -> int | None:
+    if not isinstance(v, (int, str)):
+        return None
+    try:
+        n = int(v)
+    except Exception:
+        return None
+    return n if n > 0 else None
+
+
+def fetch_user_settings(session: Any, headers: Mapping[str, str], *, timeout: float = 15.0, max_retries: int = 3) -> dict[str, Any] | None:
     global _SETTINGS_MEMO
     now = time.time()
     ts, cached = _SETTINGS_MEMO
     if cached is not None and (now - ts) < 300.0:
         return cached
-    url = "https://api.trakt.tv/users/settings"
     try:
-        r = request_with_retries(
-            session,
-            "GET",
-            url,
-            headers=dict(headers),
-            timeout=timeout,
-            max_retries=max_retries,
-        )
+        r = request_with_retries(session, "GET", "https://api.trakt.tv/users/settings", headers=dict(headers), timeout=timeout, max_retries=max_retries)
         if 200 <= r.status_code < 300:
             data = r.json() if (r.text or "").strip() else {}
             _SETTINGS_MEMO = (now, data)
             return data
-        return None
     except Exception:
-        return None
+        pass
+    return None
 
 
 def resolve_watchlist_limit(adapter: Any, cfg: Mapping[str, Any]) -> int | None:
-    raw = cfg.get("watchlist_limit")
-    if raw is not None and str(raw).strip():
-        try:
-            v = int(raw)
-            if v > 0:
-                return v
-        except Exception:
-            pass
+    override = _pos_int(cfg.get("watchlist_limit"))
+    if override is not None:
+        return override
 
     settings = fetch_user_settings(
         adapter.client.session,
@@ -274,21 +265,13 @@ def resolve_watchlist_limit(adapter: Any, cfg: Mapping[str, Any]) -> int | None:
 
     limits = settings.get("limits")
     wl = limits.get("watchlist") if isinstance(limits, Mapping) else None
-    item_count = wl.get("item_count") if isinstance(wl, Mapping) else None
-    if isinstance(item_count, (int, str)):
-        try:
-            iv = int(item_count)
-            if iv > 0:
-                return iv
-        except Exception:
-            pass
+    item_count = _pos_int(wl.get("item_count")) if isinstance(wl, Mapping) else None
+    if item_count is not None:
+        return item_count
 
     user = settings.get("user")
-    if isinstance(user, Mapping):
-        vip = bool(user.get("vip") or user.get("vip_og") or user.get("vip_ep"))
-    else:
-        vip = False
-    if not vip:
+    user = user if isinstance(user, Mapping) else {}
+    if not (user.get("vip") or user.get("vip_og") or user.get("vip_ep")):
         return 250
     return None
 

--- a/providers/sync/trakt/_watchlist.py
+++ b/providers/sync/trakt/_watchlist.py
@@ -22,6 +22,7 @@ from ._common import (
     _last_limit_path,
     _record_limit_error,
     headers_for_adapter,
+    resolve_watchlist_limit,
 )
 from .._mod_common import request_with_retries
 from cw_platform.id_map import minimal as id_minimal
@@ -331,8 +332,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
     batch = _cfg_int(cfg, "watchlist_batch_size", 100)
     log_rates = _cfg_bool(cfg, "watchlist_log_rate_limits", True)
 
-    vip = bool(cfg.get("vip"))
-    wl_limit = None if vip else int(cfg.get("watchlist_limit") or 100)
+    wl_limit = resolve_watchlist_limit(adapter, cfg)
     current_count = _current_watchlist_size()
     capacity = None if wl_limit is None else max(0, wl_limit - current_count)
 


### PR DESCRIPTION
# Pull request

## Change

Updated Trakt watchlist syncing to use the account’s actual watchlist limit.

The limit is now determined from:

* A manual configuration override
* The limit reported by Trakt account settings
* A fallback of 250 items for free accounts when no normal payload is provided by api

VIP accounts without a reported limit are no longer given an unnecessary local cap. 
The existing partial-sync and Trakt limit handling remain unchanged.

## Why

Previously used a fallback limit of 100 items, while free Trakt accounts support up to 250 watchlist items.
This caused valid items above 100 to be incorrectly marked as blocked by the Trakt limit.

## Testing

* Added tests for API-provided limits, manual overrides and the free-account fallback
* Trakt watchlist limit tests pass - test_trakt_watchlist_limit.py (local only)

## Issue

Relates to #433

Note: Add to collection renamed to Add to library will be in a seperate PR for the new experimental playlist feature.
Note: WIKI is updated https://wiki.crosswatch.app/related-information/trakt-vs-simkl-free-plans