### PR TITLE
Refactor: media-server whitelisting and modal

### DIFF
--- a/api/authenticationAPI.py
+++ b/api/authenticationAPI.py
@@ -46,6 +46,16 @@ __all__ = ["register_auth"]
 _LOG = logging.getLogger("crosswatch.api.authentication")
 
 
+def _apply_media_overrides(cfg: Any, provider: str, inst: str, server: str | None, verify_ssl: bool | None) -> dict[str, Any]:
+    block = ensure_instance_block(cfg, provider, inst)
+    s = str(server or "").strip()
+    if s:
+        block["server_url" if provider == "plex" else "server"] = s
+    if verify_ssl is not None:
+        block["verify_ssl"] = coerce_bool(verify_ssl)
+    return block
+
+
 def _provider_auth():
     from providers.auth import runtime as provider_auth
 
@@ -521,18 +531,19 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         _probe_bust("plex")
         return {"ok": True, "instance": inst}
     @app.get("/api/plex/libraries", tags=["media providers"])
-    def plex_libraries(instance: str | None = Query(None)) -> dict[str, Any]:
+    def plex_libraries(instance: str | None = Query(None), server: str | None = Query(None), verify_ssl: bool | None = Query(None)) -> dict[str, Any]:
         inst = normalize_instance_id(instance)
         cfg = load_config()
+        _apply_media_overrides(cfg, "plex", inst, server, verify_ssl)
         ensure_whitelist_defaults(cfg, instance_id=inst)
         return {"libraries": fetch_libraries_from_cfg(cfg, instance_id=inst), "instance": inst}
 
     
     @app.get("/api/plex/pms/probe", tags=["media providers"])
-    def plex_pms_probe(timeout: float = 5.0, instance: str | None = Query(None)) -> dict[str, Any]:
+    def plex_pms_probe(timeout: float = 5.0, instance: str | None = Query(None), server: str | None = Query(None), verify_ssl: bool | None = Query(None)) -> dict[str, Any]:
         inst = normalize_instance_id(instance)
         cfg = load_config()
-        plex = ensure_instance_block(cfg, "plex", inst)
+        plex = _apply_media_overrides(cfg, "plex", inst, server, verify_ssl)
         token = (plex.get("account_token") or "").strip()
         base = (plex.get("server_url") or "").strip().rstrip("/")
 
@@ -584,10 +595,11 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
 
 
     @app.get("/api/plex/pickusers", tags=["media providers"])
-    def plex_pickusers(instance: str | None = Query(None)) -> dict[str, Any]:
+    def plex_pickusers(instance: str | None = Query(None), server: str | None = Query(None), verify_ssl: bool | None = Query(None)) -> dict[str, Any]:
         inst = normalize_instance_id(instance)
         cfg = load_config()
-        plex = ensure_instance_block(cfg, "plex", inst)
+        override = bool(str(server or "").strip())
+        plex = _apply_media_overrides(cfg, "plex", inst, server, verify_ssl)
         token = (plex.get("account_token") or "").strip()
         base = (plex.get("server_url") or "").strip()
         if not token:
@@ -623,10 +635,11 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
                     if url2 and not (plex.get("server_url") or "").strip():
                         plex["server_url"] = url2
                         base = url2
-                    try:
-                        save_config(cfg)
-                    except Exception:
-                        pass
+                    if not override:
+                        try:
+                            save_config(cfg)
+                        except Exception:
+                            pass
                 except Exception:
                     pass
             sess_tok = pms_token or token
@@ -791,8 +804,8 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
 
 
     @app.get("/api/plex/users", tags=["media providers"])
-    def plex_users(instance: str | None = Query(None)) -> dict[str, Any]:
-        return plex_pickusers(instance=instance)
+    def plex_users(instance: str | None = Query(None), server: str | None = Query(None), verify_ssl: bool | None = Query(None)) -> dict[str, Any]:
+        return plex_pickusers(instance=instance, server=server, verify_ssl=verify_ssl)
 
     # JELLYFIN
     @app.post("/api/jellyfin/login", tags=["auth"])
@@ -951,9 +964,10 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         return jf_inspect_and_persist(cfg, instance_id=inst)
 
     @app.get("/api/jellyfin/libraries", tags=["media providers"])
-    def jf_libraries(instance: str | None = Query(None)):
+    def jf_libraries(instance: str | None = Query(None), server: str | None = Query(None), verify_ssl: bool | None = Query(None)):
         cfg = load_config()
         inst = normalize_instance_id(instance)
+        _apply_media_overrides(cfg, "jellyfin", inst, server, verify_ssl)
         jf_ensure_whitelist_defaults(cfg, instance_id=inst)
         return {
             "libraries": jf_fetch_libraries_from_cfg(cfg, instance_id=inst),
@@ -961,10 +975,10 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         }
 
     @app.get("/api/jellyfin/users", tags=["media providers"], response_model=None)
-    def jf_users(instance: str | None = Query(None)) -> dict[str, Any]:
+    def jf_users(instance: str | None = Query(None), server: str | None = Query(None), verify_ssl: bool | None = Query(None)) -> dict[str, Any]:
         inst = normalize_instance_id(instance)
         cfg = load_config()
-        jf = ensure_instance_block(cfg, "jellyfin", inst)
+        jf = _apply_media_overrides(cfg, "jellyfin", inst, server, verify_ssl)
 
         server = _clean_media_base(jf.get("server"))
         access_token = str((jf.get("access_token") or "")).strip()
@@ -1161,9 +1175,10 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         return out
 
     @app.get("/api/emby/libraries", tags=["media providers"])
-    def emby_libraries(instance: str | None = Query(None)) -> dict[str, Any]:
+    def emby_libraries(instance: str | None = Query(None), server: str | None = Query(None), verify_ssl: bool | None = Query(None)) -> dict[str, Any]:
         inst = normalize_instance_id(instance)
         cfg = load_config()
+        _apply_media_overrides(cfg, "emby", inst, server, verify_ssl)
         try:
             emby_ensure_whitelist_defaults(cfg, instance_id=inst)
         except TypeError:
@@ -1175,10 +1190,10 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         return {"libraries": libs, "instance": inst}
 
     @app.get("/api/emby/users", tags=["media providers"], response_model=None)
-    def emby_users(instance: str | None = Query(None)) -> dict[str, Any]:
+    def emby_users(instance: str | None = Query(None), server: str | None = Query(None), verify_ssl: bool | None = Query(None)) -> dict[str, Any]:
         inst = normalize_instance_id(instance)
         cfg = load_config()
-        em = ensure_instance_block(cfg, "emby", inst)
+        em = _apply_media_overrides(cfg, "emby", inst, server, verify_ssl)
 
         server = _clean_media_base(em.get("server"))
         access_token = str((em.get("access_token") or "")).strip()

--- a/assets/auth/auth.emby.js
+++ b/assets/auth/auth.emby.js
@@ -21,7 +21,6 @@
   const EMBY_SUBTAB_KEY = "cw.ui.emby.auth.subtab.v1";
   let embyAutoTabInst = "";
   let embyNewProfileInst = "";
-  let embyQuickSave = null;
 
   const embyProfile = Shared.createProfileAdapter({
     provider: "emby",
@@ -87,7 +86,7 @@
     }
 
     if (sub === "whitelist") {
-      try { embyLoadLibraries(); } catch {}
+      try { embyLoadLibraries(true); } catch {}
     }
     try { Shared.setMediaAuthStep(root, sub); } catch {}
   }
@@ -157,14 +156,6 @@
     embyAuthSubSelect(active?.dataset?.sub || "auth", { persist: false });
   }
 
-  async function persistEmbyRuntimeSettings() {
-    if (!getEmbySetupState().configured) return null;
-    embyQuickSave ||= Shared.saveMergedConfig((cfg) => {
-      mergeEmbyIntoCfg(cfg);
-    }).finally(() => { embyQuickSave = null; });
-    return embyQuickSave;
-  }
-
   // helpers
   const put = (sel, val) => { const el = Q(sel); if (el != null) el.value = (val ?? "") + ""; };
   const visible = (el) => !!el && getComputedStyle(el).display !== "none" && !el.hidden;
@@ -193,39 +184,33 @@
     if (selS) selS.innerHTML = [...S].map(id => `<option selected value="${id}">${id}</option>`).join("");
   }
 
-  function syncSelectAll() {
-    const rows = Qa("#emby_lib_matrix .lm-row:not(.hide)");
-    const allHist = rows.length && rows.every(r => r.querySelector(".lm-dot.hist")?.classList.contains("on"));
-    const allRate = rows.length && rows.every(r => r.querySelector(".lm-dot.rate")?.classList.contains("on"));
-    const allProg = rows.length && rows.every(r => r.querySelector(".lm-dot.prog")?.classList.contains("on"));
-    const allScr = rows.length && rows.every(r => r.querySelector(".lm-dot.scr")?.classList.contains("on"));
-    const h = Q("#emby_hist_all"), r = Q("#emby_rate_all"), p = Q("#emby_prog_all"), s = Q("#emby_scr_all");
-    if (h) { h.classList.toggle("on", !!allHist); h.setAttribute("aria-pressed", allHist ? "true" : "false"); }
-    if (r) { r.classList.toggle("on", !!allRate); r.setAttribute("aria-pressed", allRate ? "true" : "false"); }
-    if (p) { p.classList.toggle("on", !!allProg); p.setAttribute("aria-pressed", allProg ? "true" : "false"); }
-    if (s) { s.classList.toggle("on", !!allScr); s.setAttribute("aria-pressed", allScr ? "true" : "false"); }
-  }
+  let wlHandle = null;
+  const setFor = (fk) => ({ hist: H, rate: R, prog: P, scr: S }[fk]);
 
   function renderLibraries(libs) {
-    lastLibraries = Array.isArray(libs) ? libs : [];
-    const box = Q("#emby_lib_matrix"); if (!box) return;
-    box.innerHTML = "";
-    const f = document.createDocumentFragment();
-    (Array.isArray(libs) ? libs : []).forEach((it) => {
-      const id = String(it.key);
-      const row = document.createElement("div");
-      row.className = "lm-row"; row.dataset.id = id;
-      row.innerHTML = `
-        <div class="lm-name">${ESC(it.title)}</div>
-        <button class="lm-dot hist${H.has(id) ? " on" : ""}" data-kind="history" aria-pressed="${H.has(id)}" title="Toggle History"></button>
-        <button class="lm-dot rate${R.has(id) ? " on" : ""}" data-kind="ratings" aria-pressed="${R.has(id)}" title="Toggle Ratings"></button>
-        <button class="lm-dot prog${P.has(id) ? " on" : ""}" data-kind="progress" aria-pressed="${P.has(id)}" title="Toggle Progress"></button>
-        <button class="lm-dot scr${S.has(id) ? " on" : ""}" data-kind="scrobble" aria-pressed="${S.has(id)}" title="Toggle Scrobble"></button>`;
-      f.appendChild(row);
-    });
-    box.appendChild(f);
+    if (Array.isArray(libs)) lastLibraries = libs;
     syncHidden();
-    syncSelectAll();
+    const host = Q("#emby_lib_matrix");
+    if (!host || !window.cwWhitelistTable) return;
+    if (wlHandle) { wlHandle.render(); return; }
+    wlHandle = window.cwWhitelistTable.mount({
+      host,
+      features: [ { key: "hist", label: "History" }, { key: "rate", label: "Ratings" }, { key: "prog", label: "Progress" }, { key: "scr", label: "Scrobble" } ],
+      getLibs: () => lastLibraries,
+      isOn: (fk, id) => setFor(fk).has(String(id)),
+      setOn: (fk, id, on) => { const s = setFor(fk); if (on) s.add(String(id)); else s.delete(String(id)); },
+      commit: syncHidden,
+      load: async () => { await embyLoadLibraries(true); },
+    });
+  }
+
+  function embyLiveQS() {
+    let qs = "";
+    const server = (Q("#emby_server_url")?.value || Q("#emby_server")?.value || "").trim();
+    if (server) qs += `&server=${encodeURIComponent(server)}`;
+    const cb = Q("#emby_verify_ssl") || Q("#emby_verify_ssl_dup");
+    if (cb) qs += `&verify_ssl=${(Q("#emby_verify_ssl")?.checked || Q("#emby_verify_ssl_dup")?.checked) ? 1 : 0}`;
+    return qs;
   }
 
   async function embyLoadLibraries(force = false) {
@@ -234,8 +219,7 @@
       return;
     }
     try {
-      await persistEmbyRuntimeSettings();
-      const r = await fetch(embyApi(LIB_URL), { cache: "no-store" });
+      const r = await fetch(embyApi(LIB_URL) + embyLiveQS(), { cache: "no-store" });
       const d = r.ok ? await r.json().catch(() => ({})) : {};
       const libs = Array.isArray(d?.libraries) ? d.libraries : (Array.isArray(d) ? d : []);
       renderLibraries(libs);
@@ -412,81 +396,6 @@
     return cfg;
   }
 
-  // library toggles
-  document.addEventListener("click", (ev) => {
-    const btn = ev?.target?.closest ? ev.target.closest("#emby_lib_matrix .lm-dot") : null;
-    if (btn) {
-      const row = btn.closest(".lm-row");
-      const id = row ? String(row.dataset.id || "") : "";
-      const kind = String(btn.dataset.kind || "");
-      const on = !btn.classList.contains("on");
-      btn.classList.toggle("on", on);
-      btn.setAttribute("aria-pressed", on ? "true" : "false");
-
-      if (id) {
-        if (kind === "history") { on ? H.add(id) : H.delete(id); }
-        if (kind === "ratings") { on ? R.add(id) : R.delete(id); }
-        if (kind === "progress") { on ? P.add(id) : P.delete(id); }
-        if (kind === "scrobble") { on ? S.add(id) : S.delete(id); }
-      }
-      syncHidden();
-      syncSelectAll();
-      return;
-    }
-
-    if (ev?.target?.id === "emby_hist_all") {
-      const b = Q("#emby_hist_all");
-      if (!b) return;
-      const on = !b.classList.contains("on");
-      b.classList.toggle("on", on); b.setAttribute("aria-pressed", on ? "true" : "false");
-      H = new Set();
-      Qa("#emby_lib_matrix .lm-dot.hist").forEach((x) => {
-        x.classList.toggle("on", on); x.setAttribute("aria-pressed", on ? "true" : "false");
-        if (on) { const r = x.closest(".lm-row"); if (r) H.add(String(r.dataset.id || "")); }
-      });
-      syncHidden(); syncSelectAll(); return;
-    }
-
-    if (ev?.target?.id === "emby_rate_all") {
-      const b = Q("#emby_rate_all");
-      if (!b) return;
-      const on = !b.classList.contains("on");
-      b.classList.toggle("on", on); b.setAttribute("aria-pressed", on ? "true" : "false");
-      R = new Set();
-      Qa("#emby_lib_matrix .lm-dot.rate").forEach((x) => {
-        x.classList.toggle("on", on); x.setAttribute("aria-pressed", on ? "true" : "false");
-        if (on) { const r = x.closest(".lm-row"); if (r) R.add(String(r.dataset.id || "")); }
-      });
-      syncHidden(); syncSelectAll(); return;
-    }
-
-    if (ev?.target?.id === "emby_scr_all") {
-      const b = Q("#emby_scr_all");
-      if (!b) return;
-      const on = !b.classList.contains("on");
-      b.classList.toggle("on", on); b.setAttribute("aria-pressed", on ? "true" : "false");
-      S = new Set();
-      Qa("#emby_lib_matrix .lm-dot.scr").forEach((x) => {
-        x.classList.toggle("on", on); x.setAttribute("aria-pressed", on ? "true" : "false");
-        if (on) { const r = x.closest(".lm-row"); if (r) S.add(String(r.dataset.id || "")); }
-      });
-      syncHidden(); syncSelectAll(); return;
-    }
-
-    if (ev?.target?.id === "emby_prog_all") {
-      const b = Q("#emby_prog_all");
-      if (!b) return;
-      const on = !b.classList.contains("on");
-      b.classList.toggle("on", on); b.setAttribute("aria-pressed", on ? "true" : "false");
-      P = new Set();
-      Qa("#emby_lib_matrix .lm-dot.prog").forEach((x) => {
-        x.classList.toggle("on", on); x.setAttribute("aria-pressed", on ? "true" : "false");
-        if (on) { const r = x.closest(".lm-row"); if (r) P.add(String(r.dataset.id || "")); }
-      });
-      syncHidden(); syncSelectAll(); return;
-    }
-  }, true);
-
   function findEmbyPickUserButton() {
     const root = Q('#sec-emby .cw-meta-provider-panel[data-provider="emby"]') || Q("#sec-emby");
     if (!root) return null;
@@ -510,7 +419,6 @@
 
   async function embyPickUser(ev) {
     try { ev?.preventDefault?.(); } catch {}
-    try { await persistEmbyRuntimeSettings(); } catch {}
     if (!window.cwMediaUserPicker || typeof window.cwMediaUserPicker.open !== "function") {
       window.notify?.("User picker not available", "warn");
       return;
@@ -519,6 +427,8 @@
     window.cwMediaUserPicker.open({
       provider: "emby",
       instance: inst,
+      server: (Q("#emby_server_url")?.value || Q("#emby_server")?.value || "").trim(),
+      verifySsl: !!(Q("#emby_verify_ssl")?.checked || Q("#emby_verify_ssl_dup")?.checked),
       anchorEl: findEmbyPickUserButton() || Q("#emby_pick_user") || null,
       title: "Pick Emby user",
       onPick: (u) => {
@@ -571,6 +481,7 @@
   window.cwAuth = window.cwAuth || {};
   window.cwAuth.emby = window.cwAuth.emby || {};
   window.cwAuth.emby.init = ensureHydrate;
+  window.cwAuth.emby.rehydrate = () => { try { hydrateFromConfig(true); } catch {} };
 
   window.embyAuto = embyAuto;
   window.embyLoadLibraries = embyLoadLibraries;
@@ -578,7 +489,6 @@
   window.embyLogin = embyLogin;
   window.embyDeleteToken = embyDeleteToken;
   window.embyPickUser = embyPickUser;
-  window.persistEmbyRuntimeSettings = persistEmbyRuntimeSettings;
 
   // integration
   window.registerSettingsCollector?.(mergeEmbyIntoCfg);

--- a/assets/auth/auth.jellyfin.js
+++ b/assets/auth/auth.jellyfin.js
@@ -20,7 +20,6 @@
   const JFY_SUBTAB_KEY = "cw.ui.jellyfin.auth.subtab.v1";
   let jfyAutoTabInst = "";
   let jfyNewProfileInst = "";
-  let jfyQuickSave = null;
 
   const _notify = Shared.notify;
   const jfyProfile = Shared.createProfileAdapter({
@@ -86,7 +85,7 @@
     }
 
     if (sub === "whitelist") {
-      try { jfyLoadLibraries(); } catch {}
+      try { jfyLoadLibraries(true); } catch {}
     }
     if (sub !== "auth") { try { jfyQcStop({ cancel: true }); } catch {} }
     try { Shared.setMediaAuthStep(root, sub); } catch {}
@@ -157,14 +156,6 @@
     jfyAuthSubSelect(active?.dataset?.sub || "auth", { persist: false });
   }
 
-  async function persistJfyRuntimeSettings() {
-    if (!getJfySetupState().configured) return null;
-    jfyQuickSave ||= Shared.saveMergedConfig((cfg) => {
-      mergeJellyfinIntoCfg(cfg);
-    }).finally(() => { jfyQuickSave = null; });
-    return jfyQuickSave;
-  }
-
 
   const put = (sel, val) => { const el = Q(sel); if (el != null) el.value = (val ?? "") + ""; };
   const visible = (el) => !!el && getComputedStyle(el).display !== "none" && !el.hidden;
@@ -205,47 +196,33 @@
     if (selS) selS.innerHTML = [...S].map(id => `<option selected value="${id}">${id}</option>`).join("");
   }
 
-  function syncSelectAll() {
-    const rows = Qa("#jfy_lib_matrix .lm-row:not(.hide)");
-    const allHist = rows.length && rows.every(r => r.querySelector(".lm-dot.hist")?.classList.contains("on"));
-    const allRate = rows.length && rows.every(r => r.querySelector(".lm-dot.rate")?.classList.contains("on"));
-    const allProg = rows.length && rows.every(r => r.querySelector(".lm-dot.prog")?.classList.contains("on"));
-    const allScr = rows.length && rows.every(r => r.querySelector(".lm-dot.scr")?.classList.contains("on"));
-    const h = Q("#jfy_hist_all"), r = Q("#jfy_rate_all"), p = Q("#jfy_prog_all"), s = Q("#jfy_scr_all");
-    if (h) { h.classList.toggle("on", !!allHist); h.setAttribute("aria-pressed", allHist ? "true" : "false"); }
-    if (r) { r.classList.toggle("on", !!allRate); r.setAttribute("aria-pressed", allRate ? "true" : "false"); }
-    if (p) { p.classList.toggle("on", !!allProg); p.setAttribute("aria-pressed", allProg ? "true" : "false"); }
-    if (s) { s.classList.toggle("on", !!allScr); s.setAttribute("aria-pressed", allScr ? "true" : "false"); }
-  }
+  let wlHandle = null;
+  const setFor = (fk) => ({ hist: H, rate: R, prog: P, scr: S }[fk]);
 
   function renderLibraries(libs) {
-    lastLibraries = Array.isArray(libs) ? libs : [];
-    const box = Q("#jfy_lib_matrix"); if (!box) return;
-    box.innerHTML = "";
-    const f = document.createDocumentFragment();
-    (Array.isArray(libs) ? libs : []).forEach((it) => {
-      const id = String(it.key);
-      const row = document.createElement("div");
-      row.className = "lm-row"; row.dataset.id = id;
-      row.innerHTML = `
-        <div class="lm-name">${ESC(it.title)}</div>
-        <button type="button" class="lm-dot hist${H.has(id) ? " on" : ""}" data-kind="history" aria-pressed="${H.has(id)}" title="Toggle History"></button>
-        <button type="button" class="lm-dot rate${R.has(id) ? " on" : ""}" data-kind="ratings" aria-pressed="${R.has(id)}" title="Toggle Ratings"></button>
-        <button type="button" class="lm-dot prog${P.has(id) ? " on" : ""}" data-kind="progress" aria-pressed="${P.has(id)}" title="Toggle Progress"></button>
-        <button type="button" class="lm-dot scr${S.has(id) ? " on" : ""}" data-kind="scrobble" aria-pressed="${S.has(id)}" title="Toggle Scrobble"></button>`;
-      f.appendChild(row);
-    });
-    box.appendChild(f);
+    if (Array.isArray(libs)) lastLibraries = libs;
     syncHidden();
-    syncSelectAll();
+    const host = Q("#jfy_lib_matrix");
+    if (!host || !window.cwWhitelistTable) return;
+    if (wlHandle) { wlHandle.render(); return; }
+    wlHandle = window.cwWhitelistTable.mount({
+      host,
+      features: [ { key: "hist", label: "History" }, { key: "rate", label: "Ratings" }, { key: "prog", label: "Progress" }, { key: "scr", label: "Scrobble" } ],
+      getLibs: () => lastLibraries,
+      isOn: (fk, id) => setFor(fk).has(String(id)),
+      setOn: (fk, id, on) => { const s = setFor(fk); if (on) s.add(String(id)); else s.delete(String(id)); },
+      commit: syncHidden,
+      load: async () => { await jfyLoadLibraries(true); },
+    });
   }
 
-  function repaint() {
-    const libs = Qa("#jfy_lib_matrix .lm-row").map(r => ({
-      key: r.dataset.id,
-      title: r.querySelector(".lm-name")?.textContent || ""
-    }));
-    renderLibraries(libs);
+  function jfyLiveQS() {
+    let qs = "";
+    const server = (Q("#jfy_server_url")?.value || Q("#jfy_server")?.value || "").trim();
+    if (server) qs += `&server=${encodeURIComponent(server)}`;
+    const cb = Q("#jfy_verify_ssl") || Q("#jfy_verify_ssl_dup");
+    if (cb) qs += `&verify_ssl=${(Q("#jfy_verify_ssl")?.checked || Q("#jfy_verify_ssl_dup")?.checked) ? 1 : 0}`;
+    return qs;
   }
 
   async function jfyLoadLibraries(force = false) {
@@ -254,8 +231,7 @@
       return;
     }
     try {
-      await persistJfyRuntimeSettings();
-      const r = await fetch(jfyApi(LIB_URL), { cache: "no-store" });
+      const r = await fetch(jfyApi(LIB_URL) + jfyLiveQS(), { cache: "no-store" });
       const d = r.ok ? await r.json().catch(() => ({})) : {};
       const libs = Array.isArray(d?.libraries) ? d.libraries : (Array.isArray(d) ? d : []);
       renderLibraries(libs);
@@ -418,86 +394,8 @@
     return cfg;
   }
 
-  document.addEventListener("click", (ev) => {
-    const t = ev.target; if (!(t instanceof Element)) return;
-    const btn = t.closest(".lm-dot") || t.closest(".lm-col")?.querySelector(".lm-dot"); if (!btn) return;
-
-    if (btn.id === "jfy_hist_all") {
-      ev.preventDefault(); ev.stopPropagation();
-      const on = !btn.classList.contains("on"); btn.classList.toggle("on", on); btn.setAttribute("aria-pressed", on ? "true" : "false");
-      H = new Set();
-      Qa("#jfy_lib_matrix .lm-dot.hist").forEach((b) => {
-        b.classList.toggle("on", on); b.setAttribute("aria-pressed", on ? "true" : "false");
-        if (on) { const r = b.closest(".lm-row"); if (r) H.add(String(r.dataset.id || "")); }
-      });
-      syncHidden();
-      repaint();
-      syncSelectAll();
-      return;
-    }
-
-    if (btn.id === "jfy_rate_all") {
-      ev.preventDefault(); ev.stopPropagation();
-      const on = !btn.classList.contains("on"); btn.classList.toggle("on", on); btn.setAttribute("aria-pressed", on ? "true" : "false");
-      R = new Set();
-      Qa("#jfy_lib_matrix .lm-dot.rate").forEach((b) => {
-        b.classList.toggle("on", on); b.setAttribute("aria-pressed", on ? "true" : "false");
-        if (on) { const r = b.closest(".lm-row"); if (r) R.add(String(r.dataset.id || "")); }
-      });
-      syncHidden();
-      repaint();
-      syncSelectAll();
-      return;
-    }
-
-    if (btn.id === "jfy_scr_all") {
-      ev.preventDefault(); ev.stopPropagation();
-      const on = !btn.classList.contains("on"); btn.classList.toggle("on", on); btn.setAttribute("aria-pressed", on ? "true" : "false");
-      S = new Set();
-      Qa("#jfy_lib_matrix .lm-dot.scr").forEach((b) => {
-        b.classList.toggle("on", on); b.setAttribute("aria-pressed", on ? "true" : "false");
-        if (on) { const r = b.closest(".lm-row"); if (r) S.add(String(r.dataset.id || "")); }
-      });
-      syncHidden();
-      repaint();
-      syncSelectAll();
-      return;
-    }
-
-    if (btn.id === "jfy_prog_all") {
-      ev.preventDefault(); ev.stopPropagation();
-      const on = !btn.classList.contains("on"); btn.classList.toggle("on", on); btn.setAttribute("aria-pressed", on ? "true" : "false");
-      P = new Set();
-      Qa("#jfy_lib_matrix .lm-dot.prog").forEach((b) => {
-        b.classList.toggle("on", on); b.setAttribute("aria-pressed", on ? "true" : "false");
-        if (on) { const r = b.closest(".lm-row"); if (r) P.add(String(r.dataset.id || "")); }
-      });
-      syncHidden();
-      repaint();
-      syncSelectAll();
-      return;
-    }
-
-    if (btn.closest("#jfy_lib_matrix")) {
-      ev.preventDefault(); ev.stopPropagation();
-      const row = btn.closest(".lm-row"); if (!row) return;
-      const id = String(row.dataset.id || ""), kind = btn.dataset.kind;
-      const on = !btn.classList.contains("on");
-      btn.classList.toggle("on", on); btn.setAttribute("aria-pressed", on ? "true" : "false");
-      if (kind === "history") { (on ? H.add(id) : H.delete(id)); }
-      else if (kind === "ratings") { (on ? R.add(id) : R.delete(id)); }
-      else if (kind === "progress") { (on ? P.add(id) : P.delete(id)); }
-      else if (kind === "scrobble") { (on ? S.add(id) : S.delete(id)); }
-      syncHidden();
-      repaint();
-      syncSelectAll();
-      return;
-    }
-  }, true);
-
   async function jfyPickUser(ev) {
     try { ev?.preventDefault?.(); } catch {}
-    try { await persistJfyRuntimeSettings(); } catch {}
     if (!window.cwMediaUserPicker || typeof window.cwMediaUserPicker.open !== "function") {
       window.notify?.("User picker not available", "warn");
       return;
@@ -506,6 +404,8 @@
     window.cwMediaUserPicker.open({
       provider: "jellyfin",
       instance: inst,
+      server: (Q("#jfy_server_url")?.value || Q("#jfy_server")?.value || "").trim(),
+      verifySsl: !!(Q("#jfy_verify_ssl")?.checked || Q("#jfy_verify_ssl_dup")?.checked),
       anchorEl: Q("#jfy_pick_user") || null,
       title: "Pick Jellyfin user",
       onPick: (u) => {
@@ -792,13 +692,13 @@
   window.cwAuth = window.cwAuth || {};
   window.cwAuth.jellyfin = window.cwAuth.jellyfin || {};
   window.cwAuth.jellyfin.init = ensureHydrate;
+  window.cwAuth.jellyfin.rehydrate = () => { try { hydrateFromConfig(true); } catch {} };
 
   window.jfyAuto = jfyAuto;
   window.jfyLoadLibraries = jfyLoadLibraries;
   window.mergeJellyfinIntoCfg = mergeJellyfinIntoCfg;
   window.jfyLogin = jfyLogin;
   window.jfyDeleteToken = jfyDeleteToken;
-  window.persistJfyRuntimeSettings = persistJfyRuntimeSettings;
 
   window.registerSettingsCollector?.(mergeJellyfinIntoCfg);
   document.addEventListener("settings-collect", (e) => { try { mergeJellyfinIntoCfg(e?.detail?.cfg || (window.__cfg ||= {})); } catch {} }, true);

--- a/assets/auth/auth.plex.js
+++ b/assets/auth/auth.plex.js
@@ -22,7 +22,6 @@
   const PLEX_SUBTAB_KEY = "cw.ui.plex.auth.subtab.v1";
   let __plexAutoTabInst = "";
   let __plexNewProfileInst = "";
-  let __plexQuickSave = null;
 
 const plexProfile = Shared.createProfileAdapter({
   provider: "plex",
@@ -91,7 +90,9 @@ function ensurePlexInstanceUI() {
     }
 
     if (sub === "whitelist") {
+      const fresh = !w.__plexWlHandle;
       try { mountPlexLibraryMatrix(); } catch {}
+      if (!fresh) { try { w.__plexWlHandle?.load(true); } catch {} }
     }
 
     if (sub === "settings") {
@@ -166,22 +167,6 @@ function ensurePlexInstanceUI() {
     }
     const active = root.querySelector(".cw-subtile.active[data-sub]");
     plexAuthSubSelect(active?.dataset?.sub || "auth", { persist: false });
-  }
-
-  async function persistPlexRuntimeSettings() {
-    const state = getPlexSetupState();
-    if (!state.configured) return null;
-    const currUrl = $("plex_server_url")?.value?.trim() || "";
-    __plexQuickSave ||= Shared.saveMergedConfig((cfg) => {
-      mergePlexIntoCfg(cfg);
-    }).then((cfg) => {
-      if (currUrl && currUrl !== (w.__lastPlexUrl || "")) {
-        try { __plexUsersByInst.delete(getPlexInstance()); } catch {}
-        w.__lastPlexUrl = currUrl;
-      }
-      return cfg;
-    }).finally(() => { __plexQuickSave = null; });
-    return __plexQuickSave;
   }
 
   let __plexHydrateWatch = null;
@@ -428,15 +413,14 @@ function ensurePlexInstanceUI() {
   }
 
   async function plexProbePmsReachability() {
-    try { await persistPlexRuntimeSettings(); } catch {}
     const cfg = await fetch("/api/config" + bust(), { cache: "no-store" }).then(r => r.json()).catch(() => ({}));
     const tok = String(getPlexCfgBlock(cfg || {}).account_token || "").trim();
-    if (!tok) { setPlexBannerDetail(null, ""); return; }
+    if (!tok) { try { window.CW.AuthShared.clearConnectionWarnings(); } catch {} return; }
     try {
-      const r = await fetch(plexApi("/api/plex/pms/probe"), { cache: "no-store" });
+      const r = await fetch(plexApi("/api/plex/pms/probe") + plexLiveQS(), { cache: "no-store" });
       const j = await r.json().catch(() => ({}));
       if (r.ok && j?.reachable) {
-        setPlexBannerDetail(null, "");
+        try { window.CW.AuthShared.clearConnectionWarnings(); } catch {}
         return;
       }
       const base = String(j?.server_url || "").trim();
@@ -444,9 +428,9 @@ function ensurePlexInstanceUI() {
       let msg = "Connected, but PMS is not reachable - validate settings.";
       if (!base) msg = "Connected, but no PMS URL is set - validate settings.";
       else if (sc === 401 || sc === 403) msg = "Connected, but PMS rejected the token - validate settings.";
-      setPlexBannerDetail("warn", msg);
+      try { window.CW.AuthShared.showConnectionWarning(msg); } catch {}
     } catch {
-      setPlexBannerDetail("warn", "Connected, but PMS is not reachable - validate settings.");
+      try { window.CW.AuthShared.showConnectionWarning("Connected, but PMS is not reachable - validate settings."); } catch {}
     }
   }
 
@@ -900,17 +884,26 @@ const tags = [
 
   const __plexUsersByInst = new Map();
 
+  function plexLiveQS() {
+    let qs = "";
+    const url = $("plex_server_url")?.value?.trim() || "";
+    if (url) qs += `&server=${encodeURIComponent(url)}`;
+    const cb = $("plex_verify_ssl");
+    if (cb) qs += `&verify_ssl=${cb.checked ? 1 : 0}`;
+    return qs;
+  }
+
   async function fetchPlexUsers() {
     const inst = getPlexInstance();
     const currUrl = $("plex_server_url")?.value?.trim() || "";
     if (currUrl && currUrl !== (w.__lastPlexUrl || "")) {
-      await persistPlexRuntimeSettings();
+      try { __plexUsersByInst.delete(inst); } catch {}
+      w.__lastPlexUrl = currUrl;
     }
     if (__plexUsersByInst.has(inst)) return __plexUsersByInst.get(inst) || [];
     let out = [];
     try {
-      await persistPlexRuntimeSettings();
-      const r = await fetch(plexApi("/api/plex/pickusers"), { cache: "no-store" });
+      const r = await fetch(plexApi("/api/plex/pickusers") + plexLiveQS(), { cache: "no-store" });
       const j = await r.json();
       out = Array.isArray(j?.users) ? j.users : [];
     } catch { out = []; }
@@ -949,10 +942,11 @@ const tags = [
   async function openPlexUserPicker() {
     const btn = $("plex_user_pick_btn");
     if (!window.cwMediaUserPicker || typeof window.cwMediaUserPicker.open !== "function") return;
-    try { await persistPlexRuntimeSettings(); } catch {}
     window.cwMediaUserPicker.open({
       provider: "plex",
       instance: getPlexInstance(),
+      server: $("plex_server_url")?.value?.trim() || "",
+      verifySsl: !!$("plex_verify_ssl")?.checked,
       anchorEl: btn,
       title: "Pick Plex user",
       onPick: (u) => {
@@ -987,8 +981,7 @@ const tags = [
   async function plexLoadLibraries() {
     let libs = [];
     try {
-      await persistPlexRuntimeSettings();
-      const r = await fetch(plexApi("/api/plex/libraries"), { cache: "no-store" });
+      const r = await fetch(plexApi("/api/plex/libraries") + plexLiveQS(), { cache: "no-store" });
       if (r.ok) {
         const j = await r.json();
         libs = Array.isArray(j?.libraries) ? j.libraries : [];
@@ -1055,122 +1048,33 @@ const tags = [
 
   // Matrix UI
   function mountPlexLibraryMatrix() {
-    const host    = $("plex_lib_matrix");
-    const histSel = $("plex_lib_history");
-    const rateSel = $("plex_lib_ratings");
-    const progSel = $("plex_lib_progress");
-    const scrSel  = $("plex_lib_scrobble");
-    if (!host) return;
-    const firstMount = !host.__wired;
-    if (firstMount) host.__wired = true;
-
+    const host = $("plex_lib_matrix");
+    if (!host || !w.cwWhitelistTable) return;
     const st = getPlexState();
-    let syncing = false;
-
-    const setSelFromSet = (sel, set) => {
-      if (!sel) return;
-      syncing = true;
-      const want = new Set([...set].map(String));
-      Array.from(sel.options).forEach(o => { o.selected = want.has(String(o.value)); });
-      syncing = false;
+    const setKey = { hist: "hist", rate: "rate", prog: "prog", scr: "scr" };
+    const selId  = { hist: "plex_lib_history", rate: "plex_lib_ratings", prog: "plex_lib_progress", scr: "plex_lib_scrobble" };
+    const syncSelects = () => {
+      Object.keys(selId).forEach((k) => {
+        const sel = $(selId[k]); if (!sel) return;
+        const set = st[setKey[k]];
+        Array.from(sel.options).forEach((o) => { o.selected = set.has(String(o.value)); });
+      });
     };
-
-    const rowHTML = (lib) =>
-      `<div class="lm-row" data-id="${lib.id}" data-name="${lib.title.toLowerCase()}">
-         <div class="lm-name" title="#${lib.id}">${lib.title} <span class="lm-id">#${lib.id}</span></div>
-         <button type="button" class="lm-dot hist ${st.hist.has(lib.id) ? "on" : ""}" aria-label="History" aria-pressed="${st.hist.has(lib.id)}"></button>
-         <button type="button" class="lm-dot rate ${st.rate.has(lib.id) ? "on" : ""}" aria-label="Ratings" aria-pressed="${st.rate.has(lib.id)}"></button>
-         <button type="button" class="lm-dot prog ${st.prog.has(lib.id) ? "on" : ""}" aria-label="Progress" aria-pressed="${st.prog.has(lib.id)}"></button>
-         <button type="button" class="lm-dot scr ${st.scr.has(lib.id) ? "on" : ""}" aria-label="Scrobble" aria-pressed="${st.scr.has(lib.id)}"></button>
-       </div>`;
-
-    function render() {
-      const libs = getPlexState().libs;
-      const hasServer =
-        (document.getElementById("plex_server_url")?.value?.trim() || "") &&
-        getPlexState().connected;
-      if (!libs.length && hasServer) {
-        notify("No libraries could be loaded from Plex. Check the Server URL and make sure this is a Plex server your account can access.");
-      }
-
-      host.innerHTML = libs.length
-        ? libs.map(rowHTML).join("")
-        : `<div class="sub">No libraries loaded.</div>`;
-      setSelFromSet(histSel, st.hist);
-      setSelFromSet(rateSel, st.rate);
-      setSelFromSet(progSel, st.prog);
-      setSelFromSet(scrSel,  st.scr);
-    }
-
-    function toggleOne(id, which) {
-      if (which === "hist") { st.hist.has(id) ? st.hist.delete(id) : st.hist.add(id); render(); return; }
-      if (which === "rate") { st.rate.has(id) ? st.rate.delete(id) : st.rate.add(id); render(); return; }
-      if (which === "prog") { st.prog.has(id) ? st.prog.delete(id) : st.prog.add(id); render(); return; }
-      if (which === "scr")  { st.scr.has(id) ? st.scr.delete(id) : st.scr.add(id);  render(); return; }
-    }
-
-    if (firstMount) {
-      host.addEventListener("click", (ev) => {
-        const btn = ev.target.closest(".lm-dot"); if (!btn) return;
-        const row = ev.target.closest(".lm-row"); const id = row?.dataset?.id; if (!id) return;
-        const which = btn.classList.contains("hist") ? "hist" : (btn.classList.contains("scr") ? "scr" : (btn.classList.contains("prog") ? "prog" : "rate"));
-        toggleOne(id, which);
-      });
-
-      $("plex_hist_all")?.addEventListener("click", () => {
-        const visible = Array.from(host.querySelectorAll(".lm-row:not(.hide)")).map(r => r.dataset.id);
-        const allOn = visible.every(id => st.hist.has(id));
-        if (allOn) visible.forEach(id => st.hist.delete(id)); else visible.forEach(id => st.hist.add(id));
-        render();
-      });
-
-      $("plex_rate_all")?.addEventListener("click", () => {
-        const visible = Array.from(host.querySelectorAll(".lm-row:not(.hide)")).map(r => r.dataset.id);
-        const allOn = visible.every(id => st.rate.has(id));
-        if (allOn) visible.forEach(id => st.rate.delete(id)); else visible.forEach(id => st.rate.add(id));
-        render();
-      });
-
-      $("plex_scr_all")?.addEventListener("click", () => {
-        const visible = Array.from(host.querySelectorAll(".lm-row:not(.hide)")).map(r => r.dataset.id);
-        const allOn = visible.every(id => st.scr.has(id));
-        if (allOn) visible.forEach(id => st.scr.delete(id)); else visible.forEach(id => st.scr.add(id));
-        render();
-      });
-
-      $("plex_prog_all")?.addEventListener("click", () => {
-        const visible = Array.from(host.querySelectorAll(".lm-row:not(.hide)")).map(r => r.dataset.id);
-        const allOn = visible.every(id => st.prog.has(id));
-        if (allOn) visible.forEach(id => st.prog.delete(id)); else visible.forEach(id => st.prog.add(id));
-        render();
-      });
-
-      histSel?.addEventListener("change", () => {
-        if (syncing) return;
-        st.hist = new Set(Array.from(histSel.selectedOptions || []).map(o => String(o.value)));
-        render();
-      });
-      rateSel?.addEventListener("change", () => {
-        if (syncing) return;
-        st.rate = new Set(Array.from(rateSel.selectedOptions || []).map(o => String(o.value)));
-        render();
-      });
-      progSel?.addEventListener("change", () => {
-        if (syncing) return;
-        st.prog = new Set(Array.from(progSel.selectedOptions || []).map(o => String(o.value)));
-        render();
-      });
-      scrSel?.addEventListener("change", () => {
-        if (syncing) return;
-        st.scr = new Set(Array.from(scrSel.selectedOptions || []).map(o => String(o.value)));
-        render();
-      });
-    }
-
-    (async () => {
-      if (!getPlexState().libs.length) await plexLoadLibraries();
-      render();
-    })();
+    w.__plexWlHandle = w.cwWhitelistTable.mount({
+      host,
+      features: [
+        { key: "hist", label: "History" },
+        { key: "rate", label: "Ratings" },
+        { key: "prog", label: "Progress" },
+        { key: "scr",  label: "Scrobble" },
+      ],
+      getLibs: () => getPlexState().libs || [],
+      isOn: (fk, id) => st[setKey[fk]].has(String(id)),
+      setOn: (fk, id, on) => { const s = st[setKey[fk]]; if (on) s.add(String(id)); else s.delete(String(id)); },
+      commit: syncSelects,
+      load: async () => { await plexLoadLibraries(); syncSelects(); },
+    });
+    return w.__plexWlHandle;
   }
 
   function mergePlexIntoCfg(cfg) {
@@ -1206,7 +1110,7 @@ const tags = [
 
     const st = getPlexState();
     const uiReady = !!st.hydrated ||
-      !!document.querySelector("#plex_lib_matrix .lm-row") ||
+      !!document.querySelector("#plex_lib_matrix .cw-wl-row") ||
       !!document.querySelector("#plex_lib_history option, #plex_lib_ratings option, #plex_lib_progress option, #plex_lib_scrobble option");
     if (uiReady) {
       const toInts = (set) => Array.from(set || []).map(x => parseInt(String(x), 10)).filter(Number.isFinite);
@@ -1323,6 +1227,7 @@ const tags = [
   w.cwAuth = w.cwAuth || {};
   w.cwAuth.plex = w.cwAuth.plex || {};
   w.cwAuth.plex.init = initPlexAuthUI;
+  w.cwAuth.plex.rehydrate = () => { try { hydratePlexFromConfigRaw(); } catch {} };
 
   d.addEventListener("tab-changed", async (ev) => {
     const onSettings = ev?.detail?.id ? /settings/i.test(ev.detail.id) : !!q("#sec-plex");
@@ -1350,7 +1255,6 @@ const tags = [
     openPlexUserPicker, closePlexUserPicker, mountPlexUserPicker,
     refreshPlexLibraries,
     plexProbePmsReachability,
-    persistPlexRuntimeSettings,
   });
 
 })(window, document);

--- a/assets/css/whitelist.css
+++ b/assets/css/whitelist.css
@@ -1,0 +1,115 @@
+/* /assets/css/whitelist.css */
+:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-hidden,
+#page-settings #auth-providers .lm-hidden{display:none!important}
+
+#page-settings #auth-providers .cw-wl{
+  --wl-col:88px;
+  --wl-hist:#22d3ee;
+  --wl-rate:#3b82f6;
+  --wl-prog:#f59e0b;
+  --wl-scr:#22c55e;
+  --wl-bg:#0e121a;
+  --wl-row:#161b25;
+  --wl-row-h:#1d2431;
+  --wl-bd:rgba(255,255,255,.08);
+  --wl-fg:#e7ecf5;
+  --wl-mut:#9aa4b2;
+  --wl-chip:rgba(255,255,255,.05);
+  display:flex;flex-direction:column;gap:12px;color:var(--wl-fg);max-width:100%;
+}
+
+html[data-cw-theme="flat-dark"] #page-settings #auth-providers .cw-wl{
+  --wl-bg:#10151d;--wl-row:#161c26;--wl-row-h:#1f2734;--wl-bd:rgba(255,255,255,.07);--wl-chip:rgba(255,255,255,.05);
+}
+html[data-cw-theme="flat-light"] #page-settings #auth-providers .cw-wl{
+  --wl-bg:#eef2f8;--wl-row:#ffffff;--wl-row-h:#f1f5fb;--wl-bd:rgba(15,23,42,.12);--wl-fg:#0f172a;--wl-mut:#5b6472;--wl-chip:rgba(15,23,42,.05);
+}
+
+#page-settings #auth-providers .cw-wl-scroll{
+  max-height:min(52vh,460px);overflow-y:auto;border-radius:14px;
+  scrollbar-width:thin;scrollbar-color:rgba(124,92,255,.7) transparent;
+}
+#page-settings #auth-providers .cw-wl-scroll::-webkit-scrollbar{width:9px}
+#page-settings #auth-providers .cw-wl-scroll::-webkit-scrollbar-thumb{background:linear-gradient(180deg,rgba(124,92,255,.85),rgba(86,60,180,.85));border-radius:999px;border:2px solid transparent;background-clip:padding-box}
+
+#page-settings #auth-providers .cw-wl-colrow{
+  position:sticky;top:0;z-index:2;background:var(--wl-bg);
+  display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:center;gap:12px;
+  padding:4px 12px 8px;color:var(--wl-mut);text-transform:uppercase;font-size:.68rem;letter-spacing:.08em;font-weight:800;
+}
+#page-settings #auth-providers .cw-wl-cols{display:grid;grid-template-columns:repeat(4,var(--wl-col))}
+#page-settings #auth-providers .cw-wl-colhead{
+  display:inline-flex;flex-direction:column;align-items:center;gap:4px;background:none;border:0;cursor:pointer;
+  color:var(--wl-mut);font:inherit;text-transform:uppercase;letter-spacing:.06em;font-weight:800;font-size:.66rem;padding:4px 0;
+}
+#page-settings #auth-providers .cw-wl-colhead:hover{color:var(--wl-fg)}
+#page-settings #auth-providers .cw-wl-colhead .cw-wl-cico{font-size:19px;color:var(--_c)!important;-webkit-text-fill-color:var(--_c)!important;filter:drop-shadow(0 0 6px color-mix(in srgb,var(--_c) 45%,transparent))}
+#page-settings #auth-providers .cw-wl-colhead.cw-wl-hist{--_c:var(--wl-hist)}
+#page-settings #auth-providers .cw-wl-colhead.cw-wl-rate{--_c:var(--wl-rate)}
+#page-settings #auth-providers .cw-wl-colhead.cw-wl-prog{--_c:var(--wl-prog)}
+#page-settings #auth-providers .cw-wl-colhead.cw-wl-scr{--_c:var(--wl-scr)}
+
+#page-settings #auth-providers .cw-wl-rows{display:flex;flex-direction:column;gap:8px;padding:2px}
+
+#page-settings #auth-providers .cw-wl-row{
+  display:grid;grid-template-columns:auto auto minmax(0,1fr) auto;align-items:center;gap:12px;
+  padding:9px 12px;border-radius:14px;background:var(--wl-row);box-shadow:inset 0 0 0 1px var(--wl-bd);
+  transition:background .14s,box-shadow .14s;
+}
+#page-settings #auth-providers .cw-wl-row:hover{background:var(--wl-row-h);box-shadow:inset 0 0 0 1px rgba(124,92,255,.4)}
+#page-settings #auth-providers .cw-wl-handle{
+  width:14px;height:18px;flex:0 0 auto;opacity:.4;cursor:default;
+  background-image:radial-gradient(currentColor 1.4px,transparent 1.5px);background-size:6px 6px;background-position:0 0;color:var(--wl-mut);
+}
+#page-settings #auth-providers .cw-wl-ic{
+  width:38px;height:38px;flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;
+  border-radius:10px;background:var(--wl-chip);border:1px solid var(--wl-bd);color:var(--wl-fg)
+}
+#page-settings #auth-providers .cw-wl-ic .material-symbols-rounded{font-size:22px}
+#page-settings #auth-providers .cw-wl-name{min-width:0;font-weight:800;font-size:.95rem;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+#page-settings #auth-providers .cw-wl-checks{display:grid;grid-template-columns:repeat(4,var(--wl-col));align-items:center}
+
+#page-settings #auth-providers .cw-wl-check{position:relative;display:inline-flex;align-items:center;justify-content:center;min-height:28px;cursor:pointer}
+#page-settings #auth-providers .cw-wl-check input{position:absolute;inset:0;opacity:0;margin:0;cursor:pointer}
+#page-settings #auth-providers .cw-wl-check .cw-wl-box{
+  width:18px;height:18px;border-radius:6px;border:2px solid var(--_c);background:transparent;
+  display:inline-flex;align-items:center;justify-content:center;transition:background .12s,border-color .12s,transform .1s
+}
+#page-settings #auth-providers .cw-wl-check.cw-wl-hist{--_c:var(--wl-hist)}
+#page-settings #auth-providers .cw-wl-check.cw-wl-rate{--_c:var(--wl-rate)}
+#page-settings #auth-providers .cw-wl-check.cw-wl-prog{--_c:var(--wl-prog)}
+#page-settings #auth-providers .cw-wl-check.cw-wl-scr{--_c:var(--wl-scr)}
+#page-settings #auth-providers .cw-wl-check .cw-wl-box::after{
+  content:"";width:5px;height:9px;margin-top:-1px;border:solid #0a1018;border-width:0 2.2px 2.2px 0;
+  transform:rotate(45deg) scale(0);transition:transform .12s
+}
+#page-settings #auth-providers .cw-wl-check input:checked + .cw-wl-box{background:var(--_c);border-color:var(--_c)}
+#page-settings #auth-providers .cw-wl-check input:checked + .cw-wl-box::after{transform:rotate(45deg) scale(1)}
+#page-settings #auth-providers .cw-wl-check:hover .cw-wl-box{transform:scale(1.08)}
+#page-settings #auth-providers .cw-wl-check input:focus-visible + .cw-wl-box{box-shadow:0 0 0 3px color-mix(in srgb,var(--_c) 38%,transparent)}
+
+#page-settings #auth-providers .cw-wl-empty{padding:22px 14px;text-align:center;color:var(--wl-mut);background:var(--wl-row);border:1px dashed var(--wl-bd);border-radius:14px}
+
+#page-settings #auth-providers .cw-wl-foot{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
+#page-settings #auth-providers .cw-wl-note{color:var(--wl-mut);font-size:.82rem}
+#page-settings #auth-providers .cw-wl-foot-r{display:flex;align-items:center;gap:12px}
+#page-settings #auth-providers .cw-wl-stamp{color:var(--wl-mut);font-size:.78rem}
+#page-settings #auth-providers .cw-wl-load{
+  display:inline-flex;align-items:center;gap:7px;min-height:38px;padding:0 16px;border-radius:11px;
+  border:1px solid var(--wl-bd);background:var(--wl-chip);color:var(--wl-fg);font-weight:800;font-size:.86rem;cursor:pointer;
+  transition:background .15s,border-color .15s
+}
+#page-settings #auth-providers .cw-wl-load:hover{background:var(--wl-row-h);border-color:rgba(124,92,255,.5)}
+#page-settings #auth-providers .cw-wl-load .material-symbols-rounded{font-size:19px}
+#page-settings #auth-providers .cw-wl-load.busy{opacity:.6;pointer-events:none}
+#page-settings #auth-providers .cw-wl-load.busy .material-symbols-rounded{animation:cwWlSpin 1s linear infinite}
+@keyframes cwWlSpin{to{transform:rotate(360deg)}}
+#page-settings #auth-providers .cw-wl-load.is-done{background:linear-gradient(135deg,#00e084,#2ea859)!important;border-color:rgba(0,224,132,.6)!important;color:#fff!important;-webkit-text-fill-color:#fff!important;pointer-events:none}
+#page-settings #auth-providers .cw-wl-load.is-fail{background:linear-gradient(135deg,#ff5a6a,#d1342f)!important;border-color:rgba(255,112,124,.6)!important;color:#fff!important;-webkit-text-fill-color:#fff!important;pointer-events:none}
+#page-settings #auth-providers .cw-wl-load:is(.is-done,.is-fail) .material-symbols-rounded{color:#fff!important;-webkit-text-fill-color:#fff!important;animation:cwWlPop .45s cubic-bezier(.16,.84,.22,1)}
+@keyframes cwWlPop{0%{transform:scale(.2) rotate(-12deg);opacity:.2}55%{transform:scale(1.3) rotate(4deg);opacity:1}100%{transform:scale(1) rotate(0)}}
+
+@media (max-width:720px){
+  #page-settings #auth-providers .cw-wl{--wl-col:60px}
+  #page-settings #auth-providers .cw-wl-check .cw-wl-box{width:17px;height:17px}
+}

--- a/assets/helpers/media_user_picker.js
+++ b/assets/helpers/media_user_picker.js
@@ -139,17 +139,25 @@
     return isAdmin ? "Admin" : "";
   }
 
+  function overrideQS() {
+    let qs = "";
+    if (STATE.server) qs += `&server=${encodeURIComponent(STATE.server)}`;
+    if (STATE.verifySsl != null) qs += `&verify_ssl=${STATE.verifySsl ? 1 : 0}`;
+    return qs;
+  }
+
   async function fetchUsers(provider, instance) {
     const p = String(provider || "").toLowerCase();
     const inst = canonicalInstanceId(instance);
     if (!p) return [];
 
+    const extra = overrideQS();
     const urls = p === "plex"
       ? [
-          `/api/plex/pickusers?instance=${encodeURIComponent(inst)}`,
-          `/api/plex/users?instance=${encodeURIComponent(inst)}`,
+          `/api/plex/pickusers?instance=${encodeURIComponent(inst)}${extra}`,
+          `/api/plex/users?instance=${encodeURIComponent(inst)}${extra}`,
         ]
-      : [`/api/${encodeURIComponent(p)}/users?instance=${encodeURIComponent(inst)}`];
+      : [`/api/${encodeURIComponent(p)}/users?instance=${encodeURIComponent(inst)}${extra}`];
 
     let lastError = null;
     for (const url of urls) {
@@ -212,6 +220,8 @@
     all: [],
     overlay: true,
     seq: 0,
+    server: "",
+    verifySsl: null,
   };
 
   function place() {
@@ -283,6 +293,8 @@
     STATE.title = String(opts?.title || "Pick user");
     STATE.onPick = typeof opts?.onPick === "function" ? opts.onPick : null;
     STATE.overlay = opts?.overlay !== false;
+    STATE.server = String(opts?.server || "").trim();
+    STATE.verifySsl = (opts && "verifySsl" in opts) ? opts.verifySsl : null;
     const seq = ++STATE.seq;
 
     const overlay = d.getElementById(OVERLAY_ID);

--- a/assets/helpers/providers-ui.js
+++ b/assets/helpers/providers-ui.js
@@ -1354,6 +1354,7 @@
     try { await window.cwEnsureAuthSection?.(info.sectionId); } catch {}
     const providerId = connectionInfoForKey(info.key)?.provider || String(info.key || "").toLowerCase();
     try { window.cwAuth?.[providerId]?.init?.(); } catch {}
+    try { window.cwAuth?.[providerId]?.rehydrate?.(); } catch {}
     enhanceConnectionModal(section, overlay, info.key);
     wireCopyButtons();
   }

--- a/assets/helpers/whitelist_table.js
+++ b/assets/helpers/whitelist_table.js
@@ -1,0 +1,154 @@
+// assets/helpers/whitelist_table.js
+// Shared whitelist table for media-server connection modals (Plex / Emby / Jellyfin).
+(function (w, d) {
+  if (w.cwWhitelistTable) return;
+
+  const esc = (s) => String(s == null ? "" : s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+
+  function relTime(ts) {
+    if (!ts) return "never";
+    const s = Math.max(0, Math.floor((Date.now() - ts) / 1000));
+    if (s < 5) return "just now";
+    if (s < 60) return `${s}s ago`;
+    const m = Math.floor(s / 60);
+    if (m < 60) return `${m} min ago`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h ago`;
+    return `${Math.floor(h / 24)}d ago`;
+  }
+
+  const LIB_ICON = `<span class="material-symbols-rounded" aria-hidden="true">movie</span>`;
+  const FEATURE_ICON = { hist: "history", rate: "star", prog: "progress_activity", scr: "graphic_eq" };
+
+  function mount(opts) {
+    const host = opts && opts.host;
+    if (!host) return null;
+
+    const features = opts.features || [];
+    const getLibs = opts.getLibs || (() => []);
+    const isOn = opts.isOn || (() => false);
+    const setOn = opts.setOn || (() => {});
+    const commit = opts.commit || (() => {});
+    const load = opts.load || (async () => {});
+
+    const libId = (l) => String(l.id != null ? l.id : l.key);
+    const libTitle = (l) => String(l.title || l.name || libId(l));
+
+    if (host.__cwWlTimer) { clearInterval(host.__cwWlTimer); host.__cwWlTimer = 0; }
+
+    function toggleColumn(fkey) {
+      const libs = getLibs();
+      if (!libs.length) return;
+      const allOn = libs.every((l) => isOn(fkey, libId(l)));
+      libs.forEach((l) => setOn(fkey, libId(l), !allOn));
+      commit();
+      render();
+    }
+
+    function colHeadHTML() {
+      return features.map((f) => `<button type="button" class="cw-wl-colhead cw-wl-${f.key}" data-col="${f.key}"><span class="material-symbols-rounded cw-wl-cico" aria-hidden="true">${f.icon || FEATURE_ICON[f.key] || "check_circle"}</span><span>${esc(f.label)}</span></button>`).join("");
+    }
+
+    function rowsHTML(libs) {
+      if (!libs.length) return `<div class="cw-wl-empty">No libraries loaded. Click “Load libraries”.</div>`;
+      return libs.map((l) => {
+        const id = libId(l);
+        const checks = features.map((f) => {
+          const on = isOn(f.key, id);
+          return `<label class="cw-wl-check cw-wl-${f.key}"><input type="checkbox" data-feat="${f.key}" ${on ? "checked" : ""} aria-label="${esc(f.label)} — ${esc(libTitle(l))}"><span class="cw-wl-box"></span></label>`;
+        }).join("");
+        return `<div class="cw-wl-row" data-id="${esc(id)}" title="${esc(libTitle(l))} · #${esc(id)}">
+          <span class="cw-wl-handle" aria-hidden="true"></span>
+          <span class="cw-wl-ic">${LIB_ICON}</span>
+          <span class="cw-wl-name">${esc(libTitle(l))}</span>
+          <span class="cw-wl-checks">${checks}</span>
+        </div>`;
+      }).join("");
+    }
+
+    function stampText() {
+      const ts = host.__cwWlLoadedAt || 0;
+      return ts ? `Last loaded: ${relTime(ts)}` : "Not loaded yet";
+    }
+
+    function render() {
+      const libs = getLibs();
+      host.innerHTML = `
+        <div class="cw-wl">
+          <div class="cw-wl-scroll">
+            <div class="cw-wl-colrow">
+              <div class="cw-wl-collib">Library</div>
+              <div class="cw-wl-cols">${colHeadHTML()}</div>
+            </div>
+            <div class="cw-wl-rows">${rowsHTML(libs)}</div>
+          </div>
+          <div class="cw-wl-foot">
+            <div class="cw-wl-note">Empty = all libraries.</div>
+            <div class="cw-wl-foot-r">
+              <span class="cw-wl-stamp">${stampText()}</span>
+              <button type="button" class="cw-wl-load" data-act="load"><span class="material-symbols-rounded" aria-hidden="true">sync</span>Load libraries</button>
+            </div>
+          </div>
+        </div>`;
+      const stampEl = host.querySelector(".cw-wl-stamp");
+      host.__cwWlTimer = setInterval(() => {
+        const el = host.querySelector(".cw-wl-stamp");
+        if (!el) { clearInterval(host.__cwWlTimer); host.__cwWlTimer = 0; return; }
+        el.textContent = stampText();
+      }, 30000);
+      void stampEl;
+    }
+
+    async function doLoad(force, flash) {
+      const btn = host.querySelector(".cw-wl-load");
+      if (btn) { btn.disabled = true; btn.classList.add("busy"); }
+      let ok = true;
+      try {
+        await load(force);
+        host.__cwWlLoadedAt = Date.now();
+      } catch (_) { ok = false; }
+      render();
+      if (flash) {
+        const nb = host.querySelector(".cw-wl-load");
+        const ic = nb && nb.querySelector(".material-symbols-rounded");
+        if (nb) {
+          nb.classList.add(ok ? "is-done" : "is-fail");
+          if (ic) ic.textContent = ok ? "check" : "error";
+          setTimeout(() => {
+            nb.classList.remove("is-done", "is-fail");
+            const ic2 = nb.querySelector(".material-symbols-rounded");
+            if (ic2) ic2.textContent = "sync";
+          }, 1500);
+        }
+      }
+    }
+
+    if (!host.__cwWlBound) {
+      host.__cwWlBound = true;
+      host.addEventListener("click", (ev) => {
+        const act = ev.target.closest?.("[data-act]");
+        if (act && act.dataset.act === "load") return void doLoad(true, true);
+        const col = ev.target.closest?.(".cw-wl-colhead[data-col]");
+        if (col) return toggleColumn(col.dataset.col);
+      });
+      host.addEventListener("change", (ev) => {
+        const cb = ev.target.closest?.('input[type="checkbox"][data-feat]');
+        if (!cb) return;
+        const row = ev.target.closest?.(".cw-wl-row");
+        const id = row && row.dataset.id;
+        if (!id) return;
+        setOn(cb.dataset.feat, id, cb.checked);
+        commit();
+      });
+    }
+
+    render();
+    (async () => {
+      if (!getLibs().length) await doLoad(false);
+    })();
+
+    return { render, load: doLoad };
+  }
+
+  w.cwWhitelistTable = { mount };
+})(window, document);

--- a/assets/themes/flat.css
+++ b/assets/themes/flat.css
@@ -99,57 +99,6 @@ html[data-cw-theme="flat-light"] #page-watchlist .wl-card .wl-provider-icons{bor
 html[data-cw-theme="flat-light"] #page-watchlist .wl-card .wl-provider-icon,html[data-cw-theme="flat-light"] #page-watchlist .wl-card .wl-type-corner{border-color:rgba(15,23,42,.14)!important;background:rgba(255,255,255,.52)!important;color:#111827!important;}
 html[data-cw-theme="flat-light"] #page-watchlist .wl-detail .score text{fill:#111827!important;}
 html[data-cw-theme="flat-light"] #page-watchlist .wl-detail .score circle:first-of-type{stroke:rgba(15,23,42,.16)!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .cw-subpanel[data-sub="whitelist"] > div{max-width:none!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .cw-subpanel[data-sub="whitelist"]{--lm-hist-col:88px!important;--lm-rate-col:88px!important;--lm-prog-col:92px!important;--lm-scr-col:112px!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-head{display:grid!important;grid-template-columns:minmax(260px,1fr) var(--lm-hist-col,88px) var(--lm-rate-col,88px) var(--lm-prog-col,92px) var(--lm-scr-col,112px)!important;gap:10px!important;align-items:center!important;margin:18px 0 10px!important;padding:0 18px 0 12px!important;box-sizing:border-box!important;}
-:is(#sec-emby,#sec-jellyfin) .lm-head .lm-col:nth-of-type(2){display:none!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-head .title{grid-column:1!important;grid-row:1!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-head .title{color:#c3c9d5!important;font-size:12px!important;font-weight:850!important;letter-spacing:.12em!important;text-transform:uppercase!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-col{position:static!important;display:inline-flex!important;align-items:center!important;justify-content:center!important;gap:8px!important;min-width:0!important;white-space:nowrap!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-col .sub{position:static!important;left:auto!important;color:#a9b0bd!important;font-size:13px!important;opacity:1!important;white-space:nowrap!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-rows{display:grid!important;gap:8px!important;max-height:300px!important;min-height:220px!important;overflow:auto!important;border:1px solid rgba(255,255,255,.14)!important;border-radius:16px!important;padding:10px!important;background:#171a22!important;box-shadow:none!important;scrollbar-width:thin!important;scrollbar-color:#4b5564 #20242d!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-rows::-webkit-scrollbar{width:10px!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-rows::-webkit-scrollbar-track{background:#20242d!important;border-radius:12px!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-rows::-webkit-scrollbar-thumb{border-radius:12px!important;border:2px solid #20242d!important;background:#4b5564!important;box-shadow:none!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-rows::-webkit-scrollbar-thumb:hover{background:#5d6878!important;box-shadow:none!important;filter:none!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-row{display:grid!important;grid-template-columns:minmax(0,1fr) var(--lm-hist-col,88px) var(--lm-rate-col,88px) var(--lm-prog-col,92px) var(--lm-scr-col,112px)!important;gap:10px!important;align-items:center!important;min-height:42px!important;padding:8px 12px!important;border-radius:12px!important;border:1px solid rgba(255,255,255,.04)!important;background:#1b1f28!important;color:#eef1f6!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-name{color:#eef1f6!important;min-width:0!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-id{color:#a9b0bd!important;opacity:.78!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot{appearance:none!important;-webkit-appearance:none!important;width:18px!important;height:18px!important;min-width:18px!important;min-height:18px!important;max-width:18px!important;max-height:18px!important;padding:0!important;margin:0!important;display:inline-block!important;border:2px solid currentColor!important;border-radius:999px!important;border-width:2px!important;background:transparent!important;box-shadow:none!important;outline:0!important;cursor:pointer!important;justify-self:center!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot:focus-visible{box-shadow:0 0 0 4px rgba(125,134,201,.22)!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.hist{color:#9b8ee8!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.rate{color:#62bfe3!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.prog{color:#e0a85a!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.scr{color:#57b58a!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.on{box-shadow:0 0 0 4px rgba(255,255,255,.04)!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.hist.on{background:#9b8ee8!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.rate.on{background:#62bfe3!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.prog.on{background:#e0a85a!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.scr.on{background:#57b58a!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-hidden{display:none!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-head .title{color:#475467!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-col .sub{color:#475467!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-rows{background:#ffffff!important;border-color:rgba(16,24,40,.18)!important;scrollbar-color:#c4ccd8 #eef2f7!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-rows::-webkit-scrollbar-track{background:#eef2f7!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-rows::-webkit-scrollbar-thumb{border-color:#eef2f7!important;background:#c4ccd8!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-rows::-webkit-scrollbar-thumb:hover{background:#aeb8c6!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-row{background:#f5f7fb!important;border-color:rgba(16,24,40,.10)!important;color:#111827!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-name{color:#111827!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-id{color:#667085!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.hist{color:#7567c8!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.rate{color:#247fa4!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.prog{color:#9a5d12!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.scr{color:#177245!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.hist.on{background:#7567c8!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.rate.on{background:#247fa4!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.prog.on{background:#9a5d12!important;}
-html[data-cw-theme="flat-light"] :is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-dot.scr.on{background:#177245!important;}
-@media (max-width:760px){:is(#sec-plex,#sec-emby,#sec-jellyfin) .cw-subpanel[data-sub="whitelist"]{--lm-hist-col:52px!important;--lm-rate-col:52px!important;--lm-prog-col:58px!important;--lm-scr-col:68px!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-head,:is(#sec-emby,#sec-jellyfin) .lm-head{grid-template-columns:minmax(150px,1fr) var(--lm-hist-col,52px) var(--lm-rate-col,52px) var(--lm-prog-col,58px) var(--lm-scr-col,68px)!important;gap:8px!important;padding-right:10px!important;}
-:is(#sec-emby,#sec-jellyfin) .lm-head .lm-col:nth-of-type(2){display:none!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-col .sub{font-size:11px!important;}
-:is(#sec-plex,#sec-emby,#sec-jellyfin) .lm-row{grid-template-columns:minmax(0,1fr) var(--lm-hist-col,52px) var(--lm-rate-col,52px) var(--lm-prog-col,58px) var(--lm-scr-col,68px)!important;}
-}
 html[data-cw-theme] #sched-inline-log{gap:12px!important;}
 html[data-cw-theme] #sched-inline-log .sched{min-height:40px!important;padding:7px 15px!important;border-radius:18px!important;background:#242936!important;border-color:rgba(255,255,255,.12)!important;color:#f3f6ff!important;box-shadow:none!important;backdrop-filter:none!important;-webkit-backdrop-filter:none!important;isolation:isolate!important;}
 html[data-cw-theme] #sched-inline-log .sched::before{content:""!important;position:absolute!important;inset:0 auto 0 0!important;width:4px!important;border-radius:18px 0 0 18px!important;background:rgba(148,163,184,.58)!important;opacity:1!important;pointer-events:none!important;}

--- a/providers/auth/_auth_EMBY.py
+++ b/providers/auth/_auth_EMBY.py
@@ -329,19 +329,7 @@ def html() -> str:
 
           <div class="cw-subpanel" data-sub="whitelist">
             <div style="max-width:980px">
-              <div class="lm-head">
-                <div class="title">Whitelist Libraries</div>
-                <div class="lm-col"><span class="sub">Select all:</span></div>
-                <div class="lm-col"><button id="emby_hist_all" type="button" class="lm-dot hist" title="Toggle all History" aria-pressed="false"></button><span class="sub">History</span></div>
-                <div class="lm-col"><button id="emby_rate_all" type="button" class="lm-dot rate" title="Toggle all Ratings" aria-pressed="false"></button><span class="sub">Ratings</span></div>
-                <div class="lm-col"><button id="emby_prog_all" type="button" class="lm-dot prog" title="Toggle all Progress" aria-pressed="false"></button><span class="sub">Progress</span></div>
-                <div class="lm-col"><button id="emby_scr_all" type="button" class="lm-dot scr" title="Toggle all Scrobble" aria-pressed="false"></button><span class="sub">Scrobble</span></div>
-              </div>
-              <div id="emby_lib_matrix" class="lm-rows"></div>
-              <div class="inline" style="gap:12px;margin-top:12px;margin-bottom:0">
-                <button id="btn-emby-load-libraries" class="btn" type="button" title="Load Emby libraries">Load libraries</button>
-              </div>
-              <div class="sub" style="margin-top:6px">Empty = all libraries.</div>
+              <div id="emby_lib_matrix"></div>
               <select id="emby_lib_history" class="lm-hidden" multiple></select>
               <select id="emby_lib_ratings" class="lm-hidden" multiple></select>
               <select id="emby_lib_progress" class="lm-hidden" multiple></select>

--- a/providers/auth/_auth_JELLYFIN.py
+++ b/providers/auth/_auth_JELLYFIN.py
@@ -492,19 +492,7 @@ def html() -> str:
 
           <div class="cw-subpanel" data-sub="whitelist">
             <div style="max-width:980px">
-              <div class="lm-head">
-                <div class="title">Whitelist Libraries</div>
-                <div class="lm-col"><span class="sub">Select all:</span></div>
-                <div class="lm-col"><button id="jfy_hist_all" type="button" class="lm-dot hist" title="Toggle all History" aria-pressed="false"></button><span class="sub">History</span></div>
-                <div class="lm-col"><button id="jfy_rate_all" type="button" class="lm-dot rate" title="Toggle all Ratings" aria-pressed="false"></button><span class="sub">Ratings</span></div>
-                <div class="lm-col"><button id="jfy_prog_all" type="button" class="lm-dot prog" title="Toggle all Progress" aria-pressed="false"></button><span class="sub">Progress</span></div>
-                <div class="lm-col"><button id="jfy_scr_all" type="button" class="lm-dot scr" title="Toggle all Scrobble" aria-pressed="false"></button><span class="sub">Scrobble</span></div>
-              </div>
-              <div id="jfy_lib_matrix" class="lm-rows"></div>
-              <div class="inline" style="gap:12px;margin-top:12px;margin-bottom:0">
-                <button id="btn-jfy-load-libraries" class="btn" type="button" title="Load Jellyfin libraries">Load libraries</button>
-              </div>
-              <div class="sub" style="margin-top:6px">Empty = all libraries.</div>
+              <div id="jfy_lib_matrix"></div>
               <select id="jfy_lib_history" name="jfy_lib_history" class="lm-hidden" multiple></select>
               <select id="jfy_lib_ratings" name="jfy_lib_ratings" class="lm-hidden" multiple></select>
               <select id="jfy_lib_progress" name="jfy_lib_progress" class="lm-hidden" multiple></select>

--- a/providers/auth/_auth_PLEX.py
+++ b/providers/auth/_auth_PLEX.py
@@ -376,18 +376,7 @@ def html() -> str:
 
           <div class="cw-subpanel" data-sub="whitelist">
             <div style="max-width:980px">
-              <div class="lm-head">
-                <div class="title">Whitelist Libraries</div>
-                <div class="lm-col"><button id="plex_hist_all" type="button" class="lm-dot hist" title="Toggle all History"></button><span class="sub">History</span></div>
-                <div class="lm-col"><button id="plex_rate_all" type="button" class="lm-dot rate" title="Toggle all Ratings"></button><span class="sub">Ratings</span></div>
-                <div class="lm-col"><button id="plex_prog_all" type="button" class="lm-dot prog" title="Toggle all Progress"></button><span class="sub">Progress</span></div>
-                <div class="lm-col"><button id="plex_scr_all" type="button" class="lm-dot scr" title="Toggle all Scrobble"></button><span class="sub">Scrobble</span></div>
-              </div>
-              <div id="plex_lib_matrix" class="lm-rows"></div>
-              <div class="plex-btnrow" style="margin-top:12px;margin-bottom:0">
-                <button id="btn-plex-load-libraries" class="btn" type="button" title="Load Plex libraries">Load libraries</button>
-              </div>
-              <div class="sub" style="margin-top:6px">Empty = all libraries.</div>
+              <div id="plex_lib_matrix"></div>
               <select id="plex_lib_history" class="lm-hidden" multiple></select>
               <select id="plex_lib_ratings" class="lm-hidden" multiple></select>
               <select id="plex_lib_progress" class="lm-hidden" multiple></select>

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -101,6 +101,7 @@ def _asset_block() -> str:
     return "\n".join((
         helper_tags,
         '<script src="/assets/helpers/media_user_picker.js?v=__CW_VERSION__" defer></script>',
+        '<script src="/assets/helpers/whitelist_table.js?v=__CW_VERSION__" defer></script>',
         '<script src="/assets/crosswatch.js?v=__CW_VERSION__"></script>',
         app_tags,
         '<script src="/assets/auth/auth.shared.js?v=__CW_VERSION__"></script>',
@@ -152,6 +153,7 @@ def _get_index_html_static() -> str:
     watchlist: "Watchlist",
     playback_progress: "Playback Progress",
     snapshots: "Captures",
+    playlists: "Playlists",
     editor: "Editor",
     settings: "Settings",
   };
@@ -209,6 +211,7 @@ def _get_index_html_static() -> str:
 
 <link rel="stylesheet" href="/assets/themes/tokens.css?v=__CW_VERSION__">
 <link rel="stylesheet" href="/assets/crosswatch.css?v=__CW_VERSION__">
+<link rel="stylesheet" href="/assets/css/whitelist.css?v=__CW_VERSION__">
 <link rel="stylesheet" href="/assets/ui-shell.css?v=__CW_VERSION__">
 <style id="cw-dark-shell-overrides">
 :root{--cw-ov-shell:linear-gradient(180deg,rgba(8,10,14,.96),rgba(3,5,8,.98));--cw-ov-shell-soft:linear-gradient(180deg,rgba(11,14,20,.94),rgba(5,7,10,.97));--cw-ov-shell-strong:linear-gradient(180deg,rgba(13,16,23,.96),rgba(6,8,11,.98));--cw-ov-border:rgba(255,255,255,.075);--cw-ov-border-strong:rgba(255,255,255,.12);--cw-ov-shadow:0 20px 48px rgba(0,0,0,.36),inset 0 1px 0 rgba(255,255,255,.03);--cw-ov-fg:rgba(242,245,255,.96);--cw-ov-soft:rgba(194,202,222,.72)}
@@ -402,6 +405,7 @@ html[data-cw-theme=flat-light] #page-settings .cw-maint-action.restart .cw-maint
     <button id="tab-watchlist" class="tab" type="button" onclick="showTab('watchlist')">Watchlist</button>
     <button id="tab-playback_progress" class="tab" type="button" onclick="showTab('playback_progress')">Playback</button>
     <button id="tab-snapshots" class="tab" type="button" onclick="showTab('snapshots')">Captures</button>
+    <button id="tab-playlists" class="tab" type="button" onclick="showTab('playlists')">Playlists</button>
     <button id="tab-editor" class="tab" type="button" onclick="showTab('editor')">Editor</button>
     <div class="cw-tabmenu" id="tab-settings-menu">
       <button id="tab-settings" class="tab" type="button"
@@ -642,6 +646,8 @@ html[data-cw-theme=flat-light] #page-settings .cw-maint-action.restart .cw-maint
   </section>
 
   <section id="page-snapshots" class="card hidden"></section>
+
+  <section id="page-playlists" class="card hidden tab-page"></section>
 
   <section id="page-editor" class="card hidden"></section>
 


### PR DESCRIPTION
# Pull request

## Change

* Redesigned Plex/Emby/Jellyfin library whitelisting into one shared, theme-aware table 
* Added a shared whitelist component and a dedicated whitelist stylesheet
* Removed the legacy per-provider matrix markup, JS, and CSS
* Stopped the user picker and library loading from writing config on interaction
* Fixed the connection modal showing a stale server URL after cancelling and reopening
* Fixed the whitelist not refreshing for the current server when the tab is opened

## Why

The whitelisting UI was dated and unresponsive, with the same logic duplicated across three providers and its styling scattered in the theme file. Worse, simply interacting with a media-server connection. 

## Testing

* Load libraries, toggle checkboxes per feature, save and reopen to confirm the selection persists
* Editing the server URL, cancelling, then reopening 
* User picker and library loading against an edited (unsaved) server URL

## Issue

NA