### PR TITLE
Fix: use forwarded scheme for webhook URLs

### DIFF
--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -283,7 +283,11 @@ def _safe_webhook_settings(settings: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _base_url(request: Request) -> str:
-    return str(request.base_url).rstrip("/")
+    base = str(request.base_url).rstrip("/")
+    proto = str(request.headers.get("x-forwarded-proto") or "").split(",", 1)[0].strip().lower()
+    if proto == "https" and base.startswith("http://"):
+        base = "https://" + base[7:]
+    return base
 
 
 def _profile_endpoint_url(request: Request, provider: str, token: str) -> str:


### PR DESCRIPTION
# Pull request

## Change

* Honored the `X-Forwarded-Proto` header when building webhook endpoint URLs.

## Why

Webhook endpoint URLs were derived from the internal request scheme. 
Behind a reverse proxy that terminates TLS and forwards plain HTTP.

## Testing

* Webhook profile endpoint URL behind an `https` reverse proxy now shows `https://host:port/...` 
* Plexwatcher and route-ratings webhook URLs pick up the same corrected scheme
* Direct HTTP access (no proxy / no forwarded header) still returns `http://`

## Issue

NA
