### PR TITLE
Change: scrobbler modal save feedback

### DIFF
--- a/assets/crosswatch.css
+++ b/assets/crosswatch.css
@@ -1461,6 +1461,9 @@ html[data-cw-theme=flat-light] .cw-history-copy span{color:#667085}
 #page-settings #auth-providers .cw-connection-modal-panel .cw-connection-footer-save.is-failed .cw-save-result-icon{animation:cwSaveShake .5s ease}
 @keyframes cwSavePop{0%{transform:scale(.2) rotate(-14deg);opacity:0}55%{transform:scale(1.28) rotate(5deg);opacity:1}100%{transform:scale(1) rotate(0)}}
 @keyframes cwSaveShake{0%{transform:scale(.4);opacity:0}40%{transform:scale(1.15);opacity:1}55%{transform:translateX(-3px)}70%{transform:translateX(3px)}85%{transform:translateX(-2px)}100%{transform:translateX(0) scale(1)}}
+.cw-connection-footer-save .cw-save-result-icon{font-size:22px;line-height:1;font-weight:700}
+.cw-connection-footer-save.is-saved .cw-save-result-icon{animation:cwSavePop .45s cubic-bezier(.16,.84,.22,1)}
+.cw-connection-footer-save.is-failed .cw-save-result-icon{animation:cwSaveShake .5s ease}
 #page-settings #auth-providers .cw-connection-success-burst{position:absolute;inset:0;z-index:2;overflow:hidden;pointer-events:none;opacity:0}
 #page-settings #auth-providers .cw-connection-success-burst.is-active{opacity:1}
 #page-settings #auth-providers .cw-connection-success-burst span{position:absolute;left:var(--x,78%);top:var(--y,62%);width:var(--w,7px);height:var(--h,12px);border-radius:2px;background:var(--c,#00e084);box-shadow:0 0 12px color-mix(in srgb,var(--c,#00e084) 70%,transparent);opacity:0;transform:translate(-50%,-50%) rotate(var(--r,0deg)) scale(.45);animation:cwConnectionConfetti 1.45s cubic-bezier(.16,.84,.22,1) var(--d,0ms) forwards}

--- a/assets/js/modals/scrobbler-route/index.js
+++ b/assets/js/modals/scrobbler-route/index.js
@@ -561,10 +561,35 @@ async function save(regenerate = false) {
     props.mode = "edit";
     busy(false);
     render();
+    flashSave(true);
   } catch (err) {
     busy(false);
     render(err.payload?.errors || [{ message: err.message }]);
+    flashSave(false);
   }
+}
+
+let flashTimer = 0;
+function flashSave(ok) {
+  const btn = root?.querySelector(".cw-connection-footer-save");
+  if (!btn) return;
+  const label = btn.textContent || "Save changes";
+  const grad = ok ? "#00e084,#2ea859" : "#ff5a6a,#d1342f";
+  const bd = ok ? "rgba(0,224,132,.6)" : "rgba(255,112,124,.6)";
+  btn.classList.remove("is-saved", "is-failed");
+  btn.classList.add(ok ? "is-saved" : "is-failed");
+  btn.innerHTML = `<span class="material-symbols-rounded cw-save-result-icon">${ok ? "check" : "close"}</span>`;
+  btn.style.cssText = `background:linear-gradient(135deg,${grad})!important;border-color:${bd}!important;color:#fff!important;-webkit-text-fill-color:#fff!important;pointer-events:none!important`;
+  const ic = btn.querySelector(".cw-save-result-icon");
+  if (ic) ic.style.cssText = "color:#fff!important;-webkit-text-fill-color:#fff!important";
+  if (flashTimer) clearTimeout(flashTimer);
+  flashTimer = setTimeout(() => {
+    const b = root?.querySelector(".cw-connection-footer-save");
+    if (!b) return;
+    b.classList.remove("is-saved", "is-failed");
+    b.style.cssText = "";
+    b.textContent = label;
+  }, 1500);
 }
 
 function resetDeleteConfirm(btn) {

--- a/assets/js/modals/scrobbler-webhook/index.js
+++ b/assets/js/modals/scrobbler-webhook/index.js
@@ -577,12 +577,38 @@ async function save() {
     props.webhook = saved || { provider: body.provider, provider_instance: body.provider_instance, sink, sink_instance: (body.sink_instances || {})[sink] || "default", enabled: true, endpoint_url: "", effective_settings: {}, explicit_settings: {} };
     originalSink = String(props.webhook.sink || "").toLowerCase();
     activeTab = "source";
+    if (root) root.dataset.scrmTab = "source";
     setBusy(false);
     render();
+    flashSave(true);
   } catch (err) {
     setBusy(false);
     render(err.payload?.errors || [{ message: err.message }]);
+    flashSave(false);
   }
+}
+
+let flashTimer = 0;
+function flashSave(ok) {
+  const btn = root?.querySelector(".cw-connection-footer-save");
+  if (!btn) return;
+  const label = btn.textContent || "Save changes";
+  const grad = ok ? "#00e084,#2ea859" : "#ff5a6a,#d1342f";
+  const bd = ok ? "rgba(0,224,132,.6)" : "rgba(255,112,124,.6)";
+  btn.classList.remove("is-saved", "is-failed");
+  btn.classList.add(ok ? "is-saved" : "is-failed");
+  btn.innerHTML = `<span class="material-symbols-rounded cw-save-result-icon">${ok ? "check" : "close"}</span>`;
+  btn.style.cssText = `background:linear-gradient(135deg,${grad})!important;border-color:${bd}!important;color:#fff!important;-webkit-text-fill-color:#fff!important;pointer-events:none!important`;
+  const ic = btn.querySelector(".cw-save-result-icon");
+  if (ic) ic.style.cssText = "color:#fff!important;-webkit-text-fill-color:#fff!important";
+  if (flashTimer) clearTimeout(flashTimer);
+  flashTimer = setTimeout(() => {
+    const b = root?.querySelector(".cw-connection-footer-save");
+    if (!b) return;
+    b.classList.remove("is-saved", "is-failed");
+    b.style.cssText = "";
+    b.textContent = label;
+  }, 1500);
 }
 
 function clearDanger() {
@@ -639,11 +665,26 @@ async function regenerate(btn) {
   try {
     const current = selectedWebhook();
     const data = await api("/api/scrobbler/webhooks/profile/regenerate", { provider: current.provider, provider_instance: current.provider_instance });
+    props.overview = data;
     props.onSaved?.(data);
-    window.cxCloseModal?.();
+    const sink = String(current.sink || "").toLowerCase();
+    const saved = (data.webhooks || []).find((w) =>
+      String(w.provider || "").toLowerCase() === String(current.provider || "").toLowerCase() &&
+      normInst(w.provider_instance) === normInst(current.provider_instance) &&
+      String(w.sink || "").toLowerCase() === sink
+    );
+    props.mode = "edit";
+    props.webhook = saved || { ...current, endpoint_url: "" };
+    originalSink = String(props.webhook.sink || "").toLowerCase();
+    activeTab = "source";
+    if (root) root.dataset.scrmTab = "source";
+    setBusy(false);
+    render();
+    flashSave(true);
   } catch (err) {
     setBusy(false);
     render(err.payload?.errors || [{ message: err.message }]);
+    flashSave(false);
   }
 }
 


### PR DESCRIPTION
# Pull request

## Change

* Added an animated save confirmation to Watcher/Webhook modals, matching the connection modal
* Webhook: after saving, return to the Source tab so the endpoint URL is visible
* Webhook: Regenerate now reloads the new URL in place instead of closing the modal

## Why

Consistancy between connections modal and the WatcherWebhook modal.

## Testing

* Saving a watcher route and a webhook profile (success and failure)
* Webhook save lands on Source with the endpoint URL shown
* Webhook regenerate produces a new URL and keeps the modal open

## Issue

NA
