### PR TITLE
Add: playlist support to sync providers

### DIFF
--- a/providers/sync/_mod_EMBY.py
+++ b/providers/sync/_mod_EMBY.py
@@ -22,6 +22,12 @@ from .emby import _watchlist as feat_watchlist
 from .emby import _history as feat_history
 from .emby import _ratings as feat_ratings
 from .emby import _progress as feat_progress
+try:
+    from .emby import _playlists as feat_playlists
+except Exception as e:
+    feat_playlists = None
+    if os.environ.get("CW_DEBUG") or os.environ.get("CW_EMBY_DEBUG"):
+        cw_log("EMBY", "playlists", "warn", "feature_import_failed", error=str(e))
 
 from ._mod_common import (
     build_session,
@@ -172,6 +178,20 @@ _FEATURES: dict[str, Any] = {
     "progress": feat_progress,
 }
 
+_PLAYLIST_CAPABILITIES: dict[str, Any] = {
+    "read": True,
+    "create": True,
+    "add": True,
+    "remove": True,
+    "reorder": True,
+    "smart": False,
+    "smart_writable": False,
+    "media_types": ["movie", "show", "episode"],
+    "endpoint_types": ["playlist", "collection"],
+    "ordered_endpoint_types": ["playlist"],
+    "unordered_endpoint_types": ["collection"],
+}
+
 _HEALTH_SHADOW_NAME = "emby.health.shadow.json"
 
 
@@ -204,7 +224,7 @@ def get_manifest() -> Mapping[str, Any]:
             "watchlist": True,
             "history": True,
             "ratings": False,
-            "playlists": False,
+            "playlists": feat_playlists is not None,
             "progress": True,
         },
         "requires": ["requests"],
@@ -218,6 +238,7 @@ def get_manifest() -> Mapping[str, Any]:
                 "unrate": True,
                 "from_date": False,
             },
+            "playlists": _PLAYLIST_CAPABILITIES,
         },
     }
 
@@ -325,6 +346,7 @@ class EMBYClient:
 
 class EMBYModule:
     def __init__(self, cfg: Mapping[str, Any]):
+        self.instance_id = "default"
         inst = _pick_instance_id("EMBY")
         em = _merge_instance_block((cfg or {}).get("emby") or {}, inst)
         auth = _merge_instance_block(dict((cfg or {}).get("auth") or {}).get("emby") or {}, inst)
@@ -437,9 +459,11 @@ class EMBYModule:
 
     @staticmethod
     def supported_features() -> dict[str, bool]:
-        toggles = {"watchlist": True, "history": True, "ratings": False, "playlists": False, "progress": True}
+        toggles = {"watchlist": True, "history": True, "ratings": False, "playlists": feat_playlists is not None, "progress": True}
         present = _present_flags()
-        return {k: bool(toggles.get(k, False) and present.get(k, False)) for k in toggles.keys()}
+        out = {k: bool(toggles.get(k, False) and present.get(k, False)) for k in toggles.keys()}
+        out["playlists"] = bool(feat_playlists is not None)
+        return out
 
     def _is_enabled(self, feature: str) -> bool:
         return bool(self.supported_features().get(feature, False))
@@ -675,6 +699,7 @@ class _EmbyOPS:
                 "unrate": True,
                 "from_date": False,
             },
+            "playlists": _PLAYLIST_CAPABILITIES,
         }
 
     def is_configured(self, cfg: Mapping[str, Any]) -> bool:
@@ -719,5 +744,86 @@ class _EmbyOPS:
 
     def health(self, cfg: Mapping[str, Any]) -> Mapping[str, Any]:
         return self._adapter(cfg).health()
+
+    def _pl(self) -> Any:
+        if feat_playlists is None:
+            raise RuntimeError("Emby playlists feature is unavailable")
+        return feat_playlists
+
+    def _playlist_adapter(self, cfg: Mapping[str, Any], instance: str | None):
+        ad = self._adapter(cfg)
+        try:
+            ad.instance_id = normalize_instance_id(instance)
+        except Exception:
+            ad.instance_id = "default"
+        return ad
+
+    def list_playlist_resources(self, cfg: Mapping[str, Any], *, instance: str | None = None):
+        if feat_playlists is None:
+            return []
+        return list(self._pl().list_resources(self._playlist_adapter(cfg, instance)))
+
+    def get_playlist_snapshot(self, cfg: Mapping[str, Any], playlist_id: str, *, instance: str | None = None):
+        return self._pl().get_snapshot(self._playlist_adapter(cfg, instance), playlist_id)
+
+    def create_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        name: str,
+        *,
+        media_type: str | None = None,
+        items: Iterable[Mapping[str, Any]] | None = None,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ):
+        return self._pl().create(
+            self._playlist_adapter(cfg, instance),
+            name,
+            media_type=media_type,
+            items=list(items or []),
+            dry_run=dry_run,
+        )
+
+    def add_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Iterable[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        lst = list(items or [])
+        if dry_run:
+            return {"ok": True, "count": len(lst), "dry_run": True, "unresolved": [], "confirmed_keys": []}
+        return self._pl().add(self._playlist_adapter(cfg, instance), playlist_id, lst)
+
+    def remove_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Iterable[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        lst = list(items or [])
+        if dry_run:
+            return {"ok": True, "count": len(lst), "dry_run": True, "unresolved": [], "confirmed_keys": []}
+        return self._pl().remove(self._playlist_adapter(cfg, instance), playlist_id, lst)
+
+    def reorder_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        ordered_keys: Iterable[str],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        keys = list(ordered_keys or [])
+        if dry_run:
+            return {"ok": True, "count": 0, "dry_run": True}
+        return self._pl().reorder(self._playlist_adapter(cfg, instance), playlist_id, keys)
 
 OPS = _EmbyOPS()

--- a/providers/sync/_mod_JELLYFIN.py
+++ b/providers/sync/_mod_JELLYFIN.py
@@ -21,6 +21,12 @@ from .jellyfin import _watchlist as feat_watchlist
 from .jellyfin import _history as feat_history
 from .jellyfin import _ratings as feat_ratings
 from .jellyfin import _progress as feat_progress
+try:
+    from .jellyfin import _playlists as feat_playlists
+except Exception as e:
+    feat_playlists = None
+    if os.environ.get("CW_DEBUG") or os.environ.get("CW_JELLYFIN_DEBUG"):
+        cw_log("JELLYFIN", "playlists", "warn", "feature_import_failed", error=str(e))
 from ._mod_common import (
     build_session,
     request_with_retries,
@@ -165,6 +171,19 @@ _FEATURES: dict[str, Any] = {
     "progress": feat_progress,
 }
 
+_PLAYLIST_CAPABILITIES: dict[str, Any] = {
+    "read": True,
+    "create": True,
+    "add": True,
+    "remove": True,
+    "reorder": False,
+    "smart": False,
+    "smart_writable": False,
+    "media_types": ["movie", "show"],
+    "endpoint_types": ["playlist", "collection"],
+    "unordered_endpoint_types": ["collection"],
+}
+
 _HEALTH_SHADOW_NAME = "jellyfin.health.shadow.json"
 
 
@@ -214,7 +233,7 @@ def get_manifest() -> Mapping[str, Any]:
             "watchlist": True,
             "history": True,
             "ratings": False,
-            "playlists": False,
+            "playlists": feat_playlists is not None,
             "progress": True,
         },
         "requires": ["requests"],
@@ -228,6 +247,7 @@ def get_manifest() -> Mapping[str, Any]:
                 "unrate": True,
                 "from_date": False,
             },
+            "playlists": _PLAYLIST_CAPABILITIES,
         },
     }
 
@@ -353,6 +373,7 @@ class JFClient:
 
 class JELLYFINModule:
     def __init__(self, cfg: Mapping[str, Any]):
+        self.instance_id = "default"
         inst = _pick_instance_id("JELLYFIN")
         jf = _merge_instance_block((cfg or {}).get("jellyfin") or {}, inst)
         auth = _merge_instance_block(dict((cfg or {}).get("auth") or {}).get("jellyfin") or {}, inst)
@@ -446,9 +467,11 @@ class JELLYFINModule:
 
     @staticmethod
     def supported_features() -> dict[str, bool]:
-        toggles = {"watchlist": True, "history": True, "ratings": False, "playlists": False, "progress": True}
+        toggles = {"watchlist": True, "history": True, "ratings": False, "playlists": feat_playlists is not None, "progress": True}
         present = _present_flags()
-        return {k: bool(toggles.get(k, False) and present.get(k, False)) for k in toggles.keys()}
+        out = {k: bool(toggles.get(k, False) and present.get(k, False)) for k in toggles.keys()}
+        out["playlists"] = bool(feat_playlists is not None)
+        return out
 
     def _is_enabled(self, feature: str) -> bool:
         return bool(self.supported_features().get(feature, False))
@@ -701,6 +724,7 @@ class _JellyfinOPS:
                 "unrate": True,
                 "from_date": False,
             },
+            "playlists": _PLAYLIST_CAPABILITIES,
         }
 
     def is_configured(self, cfg: Mapping[str, Any]) -> bool:
@@ -754,5 +778,86 @@ class _JellyfinOPS:
 
     def health(self, cfg: Mapping[str, Any]) -> Mapping[str, Any]:
         return self._adapter(cfg).health()
+
+    def _pl(self) -> Any:
+        if feat_playlists is None:
+            raise RuntimeError("Jellyfin playlists feature is unavailable")
+        return feat_playlists
+
+    def _playlist_adapter(self, cfg: Mapping[str, Any], instance: str | None):
+        ad = self._adapter(cfg)
+        try:
+            ad.instance_id = normalize_instance_id(instance)
+        except Exception:
+            ad.instance_id = "default"
+        return ad
+
+    def list_playlist_resources(self, cfg: Mapping[str, Any], *, instance: str | None = None):
+        if feat_playlists is None:
+            return []
+        return list(self._pl().list_resources(self._playlist_adapter(cfg, instance)))
+
+    def get_playlist_snapshot(self, cfg: Mapping[str, Any], playlist_id: str, *, instance: str | None = None):
+        return self._pl().get_snapshot(self._playlist_adapter(cfg, instance), playlist_id)
+
+    def create_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        name: str,
+        *,
+        media_type: str | None = None,
+        items: Iterable[Mapping[str, Any]] | None = None,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ):
+        return self._pl().create(
+            self._playlist_adapter(cfg, instance),
+            name,
+            media_type=media_type,
+            items=list(items or []),
+            dry_run=dry_run,
+        )
+
+    def add_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Iterable[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        lst = list(items or [])
+        if dry_run:
+            return {"ok": True, "count": len(lst), "dry_run": True, "unresolved": [], "confirmed_keys": []}
+        return self._pl().add(self._playlist_adapter(cfg, instance), playlist_id, lst)
+
+    def remove_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Iterable[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        lst = list(items or [])
+        if dry_run:
+            return {"ok": True, "count": len(lst), "dry_run": True, "unresolved": [], "confirmed_keys": []}
+        return self._pl().remove(self._playlist_adapter(cfg, instance), playlist_id, lst)
+
+    def reorder_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        ordered_keys: Iterable[str],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        keys = list(ordered_keys or [])
+        if dry_run:
+            return {"ok": True, "count": 0, "dry_run": True}
+        return self._pl().reorder(self._playlist_adapter(cfg, instance), playlist_id, keys)
 
 OPS = _JellyfinOPS()

--- a/providers/sync/_mod_MDBLIST.py
+++ b/providers/sync/_mod_MDBLIST.py
@@ -101,7 +101,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.1"
+__VERSION__ = "1.2"
 __all__ = ["get_manifest", "MDBLISTModule", "OPS"]
 
 def _health(status: str, ok: bool, latency_ms: int) -> None:
@@ -149,6 +149,24 @@ except Exception as e:
     _warn("feature_import_failed", import_feature="history", error=f"{type(e).__name__}: {e}")
     feat_history = None
 
+try:
+    from .mdblist import _playlists as feat_playlists
+except Exception as e:
+    _warn("feature_import_failed", import_feature="playlists", error=f"{type(e).__name__}: {e}")
+    feat_playlists = None
+
+
+_PLAYLIST_CAPABILITIES: dict[str, Any] = {
+    "read": True,
+    "create": True,
+    "add": True,
+    "remove": True,
+    "reorder": False,
+    "smart": True,
+    "smart_writable": False,
+    "media_types": ["movies", "shows"],
+}
+
 
 _FEATURES: dict[str, Any] = {}
 if feat_watchlist:
@@ -164,7 +182,7 @@ def _features_flags() -> dict[str, bool]:
         "watchlist": "watchlist" in _FEATURES,
         "ratings": "ratings" in _FEATURES,
         "history": "history" in _FEATURES,
-        "playlists": False,
+        "playlists": feat_playlists is not None,
     }
 
 
@@ -195,6 +213,7 @@ def get_manifest() -> Mapping[str, Any]:
                 "unrate": True,
                 "from_date": True,
             },
+            "playlists": _PLAYLIST_CAPABILITIES,
         },
     }
 
@@ -375,7 +394,7 @@ class MDBLISTModule:
 
     @staticmethod
     def supported_features() -> dict[str, bool]:
-        toggles = {"watchlist": True, "ratings": True, "history": True, "playlists": False}
+        toggles = {"watchlist": True, "ratings": True, "history": True, "playlists": True}
         present = _features_flags()
         return {k: bool(toggles.get(k, False) and present.get(k, False)) for k in toggles.keys()}
 
@@ -445,7 +464,7 @@ class MDBLISTModule:
             "watchlist": bool(enabled.get("watchlist") and user_ok),
             "ratings": bool(enabled.get("ratings") and user_ok),
             "history": bool(enabled.get("history") and user_ok),
-            "playlists": False,
+            "playlists": bool(enabled.get("playlists") and user_ok),
         }
 
         if not need_any:
@@ -732,6 +751,7 @@ class _MDBLISTOPS:
                 "unrate": True,
                 "from_date": True,
             },
+            "playlists": _PLAYLIST_CAPABILITIES,
         }
 
 
@@ -885,5 +905,83 @@ class _MDBLISTOPS:
         category: str | None = None,
     ) -> Mapping[str, Any]:
         return self._adapter(cfg).fetch_journal(since=since, limit=limit, category=category)
+
+    def _pl(self) -> Any:
+        if feat_playlists is None:
+            raise MDBLISTError("MDBList playlists feature is unavailable")
+        return feat_playlists
+
+    def _playlist_adapter(self, cfg: Mapping[str, Any], instance: str | None):
+        ad = self._adapter(cfg)
+        try:
+            ad.instance_id = mdblist_auth.normalize_instance_id_value(instance)
+        except Exception:
+            ad.instance_id = "default"
+        return ad
+
+    def list_playlist_resources(self, cfg: Mapping[str, Any], *, instance: str | None = None):
+        if feat_playlists is None:
+            return []
+        return list(self._pl().list_resources(self._playlist_adapter(cfg, instance)))
+
+    def get_playlist_snapshot(self, cfg: Mapping[str, Any], playlist_id: str, *, instance: str | None = None):
+        return self._pl().get_snapshot(self._playlist_adapter(cfg, instance), playlist_id)
+
+    def create_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        name: str,
+        *,
+        media_type: str | None = None,
+        items: Iterable[Mapping[str, Any]] | None = None,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ):
+        return self._pl().create(
+            self._playlist_adapter(cfg, instance),
+            name,
+            media_type=media_type,
+            items=list(items or []),
+            dry_run=dry_run,
+        )
+
+    def add_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Iterable[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        lst = list(items or [])
+        if dry_run:
+            return {"ok": True, "count": len(lst), "dry_run": True, "unresolved": [], "confirmed_keys": []}
+        return self._pl().add(self._playlist_adapter(cfg, instance), playlist_id, lst)
+
+    def remove_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Iterable[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        lst = list(items or [])
+        if dry_run:
+            return {"ok": True, "count": len(lst), "dry_run": True, "unresolved": [], "confirmed_keys": []}
+        return self._pl().remove(self._playlist_adapter(cfg, instance), playlist_id, lst)
+
+    def reorder_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        ordered_keys: Iterable[str],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        return {"ok": True, "count": 0, "reordered": 0, "unsupported": True}
 
 OPS = _MDBLISTOPS()

--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -40,7 +40,7 @@ def _error(event: str, **fields: Any) -> None:
 def _log(msg: str) -> None:
     _dbg(msg)
 
-__VERSION__ = "2.0"
+__VERSION__ = "2.1"
 os.environ.setdefault("CW_PLEX_VERSION", __VERSION__)
 os.environ.setdefault("CW_PLEX_UA", f"CrossWatch/{__VERSION__} (Plex)")
 __all__ = ["get_manifest", "PLEXModule", "PLEXClient", "PLEXError", "PLEXAuthError", "PLEXNotFound", "OPS"]
@@ -108,7 +108,26 @@ except Exception as e:
     if os.environ.get("CW_DEBUG") or os.environ.get("CW_PLEX_DEBUG"):
         _warn("feature_import_failed", feature="progress", error=str(e))
 
-feat_playlists = None
+try:
+    from .plex import _playlists as feat_playlists
+except Exception as e:
+    feat_playlists = None
+    if os.environ.get("CW_DEBUG") or os.environ.get("CW_PLEX_DEBUG"):
+        _warn("feature_import_failed", feature="playlists", error=str(e))
+
+_PLAYLIST_CAPABILITIES: dict[str, Any] = {
+    "read": True,
+    "create": True,
+    "add": True,
+    "remove": True,
+    "reorder": True,
+    "smart": True,
+    "smart_writable": False,
+    "media_types": ["movie", "show", "episode"],
+    "endpoint_types": ["playlist", "collection"],
+    "ordered_endpoint_types": ["playlist"],
+    "unordered_endpoint_types": ["watchlist", "collection"],
+}
 
 
 class PLEXError(RuntimeError):
@@ -469,7 +488,7 @@ def get_manifest() -> Mapping[str, Any]:
         "version": __VERSION__,
         "type": "sync",
         "bidirectional": True,
-        "features": {"watchlist": True, "history": True, "ratings": True, "playlists": False, "progress": True},
+        "features": {"watchlist": True, "history": True, "ratings": True, "playlists": True, "progress": True},
         "requires": ["plexapi"],
         "capabilities": {
             "bidirectional": True,
@@ -483,6 +502,7 @@ def get_manifest() -> Mapping[str, Any]:
                 "unrate": True,
                 "from_date": False,
             },
+            "playlists": _PLAYLIST_CAPABILITIES,
         },
     }
 @dataclass
@@ -1069,7 +1089,6 @@ _FEATURES: dict[str, Any] = {
     "watchlist": feat_watchlist,
     "history": feat_history,
     "ratings": feat_ratings,
-    "playlists": feat_playlists,
     "progress": feat_progress,
 }
 
@@ -1080,7 +1099,7 @@ def _features_flags() -> dict[str, bool]:
         "history": "history" in _FEATURES and _FEATURES["history"] is not None,
         "ratings": "ratings" in _FEATURES and _FEATURES["ratings"] is not None,
         "progress": "progress" in _FEATURES and _FEATURES["progress"] is not None,
-        "playlists": "playlists" in _FEATURES and _FEATURES["playlists"] is not None,
+        "playlists": feat_playlists is not None,
     }
 
 
@@ -1120,6 +1139,7 @@ class PLEXModule:
                 pass
 
         self.client = PLEXClient(self.cfg).connect()
+        self.instance_id = "default"
         self.progress_factory = (
             lambda feature, total=None, throttle_ms=300: make_snapshot_progress(
                 ctx,
@@ -1132,7 +1152,7 @@ class PLEXModule:
 
     @staticmethod
     def supported_features() -> dict[str, bool]:
-        toggles = {"watchlist": True, "ratings": True, "history": True, "playlists": False, "progress": True}
+        toggles = {"watchlist": True, "ratings": True, "history": True, "playlists": True, "progress": True}
         present = _features_flags()
         return {k: bool(toggles.get(k, False) and present.get(k, False)) for k in toggles.keys()}
 
@@ -1412,6 +1432,7 @@ class _PlexOPS:
                 "unrate": True,
                 "from_date": False,
             },
+            "playlists": _PLAYLIST_CAPABILITIES,
         }
 
     def index_semantics(self, cfg: Mapping[str, Any], *, feature: str) -> str | None:
@@ -1490,6 +1511,89 @@ class _PlexOPS:
 
     def health(self, cfg: Mapping[str, Any]) -> Mapping[str, Any]:
         return self._adapter(cfg).health()
+
+    def _pl(self) -> Any:
+        if feat_playlists is None:
+            raise PLEXError("Plex playlists feature is unavailable")
+        return feat_playlists
+
+    def _playlist_adapter(self, cfg: Mapping[str, Any], instance: str | None):
+        from cw_platform.provider_instances import normalize_instance_id
+
+        ad = self._adapter(cfg)
+        try:
+            ad.instance_id = normalize_instance_id(instance)
+        except Exception:
+            ad.instance_id = "default"
+        return ad
+
+    def list_playlist_resources(self, cfg: Mapping[str, Any], *, instance: str | None = None):
+        if feat_playlists is None:
+            return []
+        return list(self._pl().list_resources(self._playlist_adapter(cfg, instance)))
+
+    def get_playlist_snapshot(self, cfg: Mapping[str, Any], playlist_id: str, *, instance: str | None = None):
+        return self._pl().get_snapshot(self._playlist_adapter(cfg, instance), playlist_id)
+
+    def create_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        name: str,
+        *,
+        media_type: str | None = None,
+        items: Iterable[Mapping[str, Any]] | None = None,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ):
+        return self._pl().create(
+            self._playlist_adapter(cfg, instance),
+            name,
+            media_type=media_type,
+            items=list(items or []),
+            dry_run=dry_run,
+        )
+
+    def add_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Iterable[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        lst = list(items or [])
+        if dry_run:
+            return {"ok": True, "count": len(lst), "dry_run": True, "unresolved": [], "confirmed_keys": []}
+        return self._pl().add(self._playlist_adapter(cfg, instance), playlist_id, lst)
+
+    def remove_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Iterable[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        lst = list(items or [])
+        if dry_run:
+            return {"ok": True, "count": len(lst), "dry_run": True, "unresolved": [], "confirmed_keys": []}
+        return self._pl().remove(self._playlist_adapter(cfg, instance), playlist_id, lst)
+
+    def reorder_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        ordered_keys: Iterable[str],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        keys = list(ordered_keys or [])
+        if dry_run:
+            return {"ok": True, "count": 0, "dry_run": True}
+        return self._pl().reorder(self._playlist_adapter(cfg, instance), playlist_id, keys)
 
 
 OPS = _PlexOPS()

--- a/providers/sync/_mod_PUBLICMETADB.py
+++ b/providers/sync/_mod_PUBLICMETADB.py
@@ -14,6 +14,7 @@ from cw_platform.id_map import canonical_key, minimal as id_minimal
 from ._log import log as cw_log
 from ._mod_common import HitSession, SimpleRateLimiter, build_session, parse_rate_limit, request_with_retries, safe_json
 from .publicmetadb import _history as feat_history
+from .publicmetadb import _playlists as feat_playlists
 from .publicmetadb import _progress as feat_progress
 from .publicmetadb import _ratings as feat_ratings
 from .publicmetadb import _watchlist as feat_watchlist
@@ -57,8 +58,24 @@ def _confirmed_keys(items: Iterable[Mapping[str, Any]], unresolved: Any) -> list
     return out
 
 
+_PLAYLIST_CAPABILITIES: dict[str, Any] = {
+    "read": True,
+    "create": True,
+    "add": True,
+    "remove": True,
+    "reorder": False,
+    "smart": False,
+    "smart_writable": False,
+    "media_types": ["movie", "show"],
+    "requires_ids": ["tmdb"],
+    "endpoint_types": ["playlist"],
+    "ordered_endpoint_types": [],
+    "unordered_endpoint_types": ["playlist"],
+}
+
+
 def _features_flags() -> dict[str, bool]:
-    return {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False}
+    return {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": True}
 
 
 def get_manifest() -> Mapping[str, Any]:
@@ -104,6 +121,7 @@ def get_manifest() -> Mapping[str, Any]:
                 "requires_duration": True,
                 "server_completion_percent": 80,
             },
+            "playlists": _PLAYLIST_CAPABILITIES,
         },
     }
 
@@ -262,6 +280,7 @@ class PUBLICMETADBModule:
         self.client = PUBLICMETADBClient(self.cfg, cfg).connect()
         self.raw_cfg = cfg
         self.config = cfg
+        self.instance_id = "default"
 
     @staticmethod
     def supported_features() -> dict[str, bool]:
@@ -308,7 +327,7 @@ class PUBLICMETADBModule:
             "ok": ok,
             "status": status,
             "latency_ms": latency_ms,
-            "features": {"watchlist": ok, "ratings": ok, "history": ok, "progress": ok, "playlists": False},
+            "features": {"watchlist": ok, "ratings": ok, "history": ok, "progress": ok, "playlists": ok},
             "details": {"reason": reason} if reason else None,
             "api": {"lists": {"status": code, "rate": rate}},
         }
@@ -402,6 +421,84 @@ class _PUBLICMETADBOPS:
 
     def health(self, cfg: Mapping[str, Any]) -> Mapping[str, Any]:
         return self._adapter(cfg).health()
+
+    def _pl(self) -> Any:
+        return feat_playlists
+
+    def _playlist_adapter(self, cfg: Mapping[str, Any], instance: str | None):
+        from cw_platform.provider_instances import normalize_instance_id
+
+        ad = self._adapter(cfg)
+        try:
+            ad.instance_id = normalize_instance_id(instance)
+        except Exception:
+            ad.instance_id = "default"
+        return ad
+
+    def list_playlist_resources(self, cfg: Mapping[str, Any], *, instance: str | None = None):
+        return list(self._pl().list_resources(self._playlist_adapter(cfg, instance)))
+
+    def get_playlist_snapshot(self, cfg: Mapping[str, Any], playlist_id: str, *, instance: str | None = None):
+        return self._pl().get_snapshot(self._playlist_adapter(cfg, instance), playlist_id)
+
+    def create_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        name: str,
+        *,
+        media_type: str | None = None,
+        items: Iterable[Mapping[str, Any]] | None = None,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ):
+        return self._pl().create(
+            self._playlist_adapter(cfg, instance),
+            name,
+            media_type=media_type,
+            items=list(items or []),
+            dry_run=dry_run,
+        )
+
+    def add_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Iterable[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        lst = list(items or [])
+        if dry_run:
+            return {"ok": True, "count": len(lst), "dry_run": True, "unresolved": [], "confirmed_keys": []}
+        return self._pl().add(self._playlist_adapter(cfg, instance), playlist_id, lst)
+
+    def remove_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Iterable[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        lst = list(items or [])
+        if dry_run:
+            return {"ok": True, "count": len(lst), "dry_run": True, "unresolved": [], "confirmed_keys": []}
+        return self._pl().remove(self._playlist_adapter(cfg, instance), playlist_id, lst)
+
+    def reorder_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        ordered_keys: Iterable[str],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        if dry_run:
+            return {"ok": True, "count": 0, "dry_run": True}
+        return self._pl().reorder(self._playlist_adapter(cfg, instance), playlist_id, list(ordered_keys or []))
 
 
 OPS = _PUBLICMETADBOPS()

--- a/providers/sync/_mod_TRAKT.py
+++ b/providers/sync/_mod_TRAKT.py
@@ -71,8 +71,10 @@ try:
     from .trakt import _ratings as feat_ratings
 except Exception:
     feat_ratings = None
-
-feat_playlists = None
+try:
+    from .trakt import _playlists as feat_playlists
+except Exception:
+    feat_playlists = None
 
 from ._mod_common import (
     build_session,
@@ -89,7 +91,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.3"
+__VERSION__ = "1.4"
 __all__ = ["get_manifest", "TRAKTModule", "OPS"]
 
 os.environ.setdefault("CW_TRAKT_UA", f"CrossWatch TRAKT/{__VERSION__}")
@@ -104,6 +106,16 @@ class TRAKTAuthError(TRAKTError):
 
 
 _PROVIDER = "TRAKT"
+
+_PLAYLIST_CAPABILITIES: dict[str, Any] = {
+    "read": True,
+    "create": True,
+    "add": True,
+    "remove": True,
+    "reorder": True,
+    "smart": False,
+    "media_types": ["movies", "shows", "seasons", "episodes"],
+}
 
 
 def _dbg(feature: str, event: str, **fields: Any) -> None:
@@ -127,8 +139,6 @@ if feat_history:
     _FEATURES["history"] = feat_history
 if feat_ratings:
     _FEATURES["ratings"] = feat_ratings
-if feat_playlists:
-    _FEATURES["playlists"] = feat_playlists
 
 
 def _features_flags() -> dict[str, bool]:
@@ -136,7 +146,7 @@ def _features_flags() -> dict[str, bool]:
         "watchlist": "watchlist" in _FEATURES,
         "ratings": "ratings" in _FEATURES,
         "history": "history" in _FEATURES,
-        "playlists": "playlists" in _FEATURES,
+        "playlists": feat_playlists is not None,
     }
 
 
@@ -159,6 +169,7 @@ def get_manifest() -> Mapping[str, Any]:
                 "unrate": True,
                 "from_date": True,
             },
+            "playlists": _PLAYLIST_CAPABILITIES,
         },
     }
 
@@ -379,6 +390,7 @@ class TRAKTModule:
             self.client = self.client.connect()
         self.raw_cfg = cfg
         self.config = cfg
+        self.instance_id = "default"
         self.progress_factory = (
             lambda feature, total=None, throttle_ms=300: make_snapshot_progress(
                 ctx,
@@ -395,7 +407,7 @@ class TRAKTModule:
             "watchlist": True,
             "ratings": True,
             "history": True,
-            "playlists": False,
+            "playlists": True,
         }
         present = _features_flags()
         return {k: bool(toggles.get(k, False) and present.get(k, False)) for k in toggles.keys()}
@@ -494,7 +506,7 @@ class TRAKTModule:
             "watchlist": (core_ok and wl_ok) if (need_wl and "watchlist" in _FEATURES) else False,
             "ratings": (core_ok if (enabled.get("ratings") and "ratings" in _FEATURES) else False),
             "history": (core_ok if (enabled.get("history") and "history" in _FEATURES) else False),
-            "playlists": (core_ok if (enabled.get("playlists") and "playlists" in _FEATURES) else False),
+            "playlists": (core_ok if enabled.get("playlists") else False),
         }
 
         checks: list[bool] = []
@@ -673,6 +685,7 @@ class _TraktOPS:
                 "unrate": True,
                 "from_date": True,
             },
+            "playlists": _PLAYLIST_CAPABILITIES,
         }
 
     def is_configured(self, cfg: Mapping[str, Any]) -> bool:
@@ -727,5 +740,81 @@ class _TraktOPS:
 
     def dropped_show_tokens(self, cfg: Mapping[str, Any]) -> set[str]:
         return self._adapter(cfg).dropped_show_tokens()
+
+    def _pl(self) -> Any:
+        if feat_playlists is None:
+            raise TRAKTError("Trakt playlists feature is unavailable")
+        return feat_playlists
+
+    def _playlist_adapter(self, cfg: Mapping[str, Any], instance: str | None):
+        from cw_platform.provider_instances import normalize_instance_id
+
+        ad = self._adapter(cfg)
+        try:
+            ad.instance_id = normalize_instance_id(instance)
+        except Exception:
+            ad.instance_id = "default"
+        return ad
+
+    def list_playlist_resources(self, cfg: Mapping[str, Any], *, instance: str | None = None):
+        if feat_playlists is None:
+            return []
+        return list(self._pl().list_resources(self._playlist_adapter(cfg, instance)))
+
+    def get_playlist_snapshot(self, cfg: Mapping[str, Any], playlist_id: str, *, instance: str | None = None):
+        return self._pl().get_snapshot(self._playlist_adapter(cfg, instance), playlist_id)
+
+    def create_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        name: str,
+        *,
+        media_type: str | None = None,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ):
+        return self._pl().create(self._playlist_adapter(cfg, instance), name, media_type=media_type, dry_run=dry_run)
+
+    def add_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Iterable[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        lst = list(items or [])
+        if dry_run:
+            return {"ok": True, "count": len(lst), "dry_run": True, "unresolved": [], "confirmed_keys": []}
+        return self._pl().add(self._playlist_adapter(cfg, instance), playlist_id, lst)
+
+    def remove_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Iterable[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        lst = list(items or [])
+        if dry_run:
+            return {"ok": True, "count": len(lst), "dry_run": True, "unresolved": [], "confirmed_keys": []}
+        return self._pl().remove(self._playlist_adapter(cfg, instance), playlist_id, lst)
+
+    def reorder_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        ordered_keys: Iterable[str],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        keys = list(ordered_keys or [])
+        if dry_run:
+            return {"ok": True, "count": 0, "dry_run": True}
+        return self._pl().reorder(self._playlist_adapter(cfg, instance), playlist_id, keys)
 
 OPS = _TraktOPS()

--- a/providers/sync/emby/_common.py
+++ b/providers/sync/emby/_common.py
@@ -983,6 +983,14 @@ def playlist_remove_entries(http: Any, playlist_id: str, entry_ids: Iterable[str
     return getattr(r, "status_code", 0) in (200, 204)
 
 
+def playlist_move_item(http: Any, playlist_id: str, item_id: str, new_index: int) -> bool:
+    iid = str(item_id or "").strip()
+    if not iid:
+        return True
+    r = http.post(f"/Playlists/{playlist_id}/Items/{iid}/Move/{max(0, int(new_index))}")
+    return getattr(r, "status_code", 0) in (200, 204)
+
+
 # collections (BoxSets)
 def find_seed_item_id(http: Any, user_id: str) -> str | None:
     for t in ("Movie", "Series"):

--- a/providers/sync/emby/_playlists.py
+++ b/providers/sync/emby/_playlists.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from cw_platform.playlists import PLAYLIST_KIND_REGULAR, PlaylistItem, PlaylistResource, PlaylistSnapshot
+
+from ._common import (
+    _fetch_all_collection_items,
+    _fetch_all_playlist_items,
+    chunked,
+    collection_add_items,
+    collection_remove_items,
+    create_collection,
+    create_playlist,
+    key_of as emby_key_of,
+    make_logger,
+    normalize as emby_normalize,
+    playlist_add_items,
+    playlist_move_item,
+    playlist_remove_entries,
+    resolve_item_id,
+    sleep_ms,
+)
+
+_PROVIDER = "EMBY"
+_PLAYLIST_MEDIA_TYPES = ("movie", "episode")
+_COLLECTION_MEDIA_TYPES = ("movie", "show")
+_RESOURCE_PREFIXES = {"playlist": "playlist:", "collection": "collection:"}
+_dbg, _info, _warn, _error = make_logger("playlists")
+
+
+class EmbyPlaylistError(RuntimeError):
+    pass
+
+
+class EmbyPlaylistNotFound(EmbyPlaylistError):
+    pass
+
+
+def _instance_id(adapter: Any) -> str:
+    inst = getattr(adapter, "instance_id", None)
+    return str(inst).strip() if inst else "default"
+
+
+def _prefixed(endpoint_type: str, raw_id: Any) -> str:
+    return f"{_RESOURCE_PREFIXES[endpoint_type]}{str(raw_id or '').strip()}"
+
+
+def _raw_id(resource_id: Any) -> tuple[str | None, str]:
+    s = str(resource_id or "").strip()
+    for endpoint_type, prefix in _RESOURCE_PREFIXES.items():
+        if s.lower().startswith(prefix):
+            return endpoint_type, s[len(prefix):].strip()
+    return None, s
+
+
+def _endpoint_type(row: Mapping[str, Any]) -> str | None:
+    typ = str(row.get("Type") or "").strip().lower()
+    if typ == "playlist":
+        return "playlist"
+    if typ == "boxset":
+        return "collection"
+    return None
+
+
+def _media_types(endpoint_type: str) -> tuple[str, ...]:
+    return _COLLECTION_MEDIA_TYPES if endpoint_type == "collection" else _PLAYLIST_MEDIA_TYPES
+
+
+def _resource_from_row(adapter: Any, row: Mapping[str, Any], endpoint_type: str | None = None) -> PlaylistResource | None:
+    raw = str(row.get("Id") or "").strip()
+    if not raw:
+        return None
+    et = endpoint_type or _endpoint_type(row)
+    if et not in _RESOURCE_PREFIXES:
+        return None
+    name = str(row.get("Name") or "").strip() or raw
+    return PlaylistResource(
+        provider=_PROVIDER,
+        id=_prefixed(et, raw),
+        name=name,
+        instance=_instance_id(adapter),
+        kind=PLAYLIST_KIND_REGULAR,
+        can_read=True,
+        can_add=True,
+        can_remove=True,
+        can_reorder=et == "playlist",
+        media_types=_media_types(et),
+        extra={
+            "endpoint_type": et,
+            "raw_id": raw,
+            "item_count": row.get("ChildCount") if row.get("ChildCount") is not None else row.get("RecursiveItemCount"),
+        },
+    )
+
+
+def _fetch_resources(adapter: Any, endpoint_type: str) -> list[PlaylistResource]:
+    http = adapter.client
+    uid = adapter.cfg.user_id
+    include = "Playlist" if endpoint_type == "playlist" else "BoxSet"
+    out: list[PlaylistResource] = []
+    start = 0
+    limit = 500
+    total: int | None = None
+    while True:
+        r = http.get(
+            f"/Users/{uid}/Items",
+            params={
+                "UserId": uid,
+                "IncludeItemTypes": include,
+                "Recursive": True,
+                "Fields": "ChildCount,RecursiveItemCount,DateCreated,DateLastMediaAdded",
+                "StartIndex": start,
+                "Limit": limit,
+                "EnableTotalRecordCount": True,
+            },
+        )
+        if getattr(r, "status_code", 0) != 200:
+            _warn("list_failed", endpoint_type=endpoint_type, status=getattr(r, "status_code", None))
+            return out
+        body = r.json() or {}
+        rows = body.get("Items") or []
+        if total is None:
+            try:
+                total = int(body.get("TotalRecordCount") or 0)
+            except Exception:
+                total = 0
+        for row in rows:
+            if not isinstance(row, Mapping):
+                continue
+            res = _resource_from_row(adapter, row, endpoint_type)
+            if res:
+                out.append(res)
+        start += len(rows)
+        if not rows or len(rows) < limit or (total is not None and total > 0 and start >= total):
+            break
+    return out
+
+
+def list_resources(adapter: Any) -> list[PlaylistResource]:
+    out = _fetch_resources(adapter, "playlist")
+    out.extend(_fetch_resources(adapter, "collection"))
+    out.sort(key=lambda r: (str(r.extra.get("endpoint_type") or ""), r.name.lower(), r.id))
+    _info("list_resources_done", count=len(out))
+    return out
+
+
+def _find_resource(adapter: Any, resource_id: Any) -> PlaylistResource | None:
+    et, rid = _raw_id(resource_id)
+    for res in list_resources(adapter):
+        raw = str(res.extra.get("raw_id") or "").strip()
+        if res.id == str(resource_id or "").strip() or raw == rid:
+            if not et or str(res.extra.get("endpoint_type") or "") == et:
+                return res
+    return None
+
+
+def _resolved_resource(adapter: Any, resource_id: Any) -> tuple[str, str, PlaylistResource]:
+    et, rid = _raw_id(resource_id)
+    res = _find_resource(adapter, resource_id)
+    if res:
+        raw = str(res.extra.get("raw_id") or "").strip()
+        kind = str(res.extra.get("endpoint_type") or et or "playlist")
+        return kind, raw or rid, res
+    if not rid:
+        raise EmbyPlaylistNotFound("missing emby playlist id")
+    if not et:
+        et = "playlist"
+    return et, rid, PlaylistResource(
+        provider=_PROVIDER,
+        id=_prefixed(et, rid),
+        name=rid,
+        instance=_instance_id(adapter),
+        can_read=True,
+        can_add=True,
+        can_remove=True,
+        can_reorder=et == "playlist",
+        media_types=_media_types(et),
+        extra={"endpoint_type": et, "raw_id": rid},
+    )
+
+
+def _accepts(endpoint_type: str, row: Mapping[str, Any]) -> bool:
+    typ = str(row.get("Type") or row.get("type") or "").strip().lower()
+    if endpoint_type == "collection":
+        return typ in ("movie", "show", "series")
+    return typ in ("movie", "episode")
+
+
+def get_snapshot(adapter: Any, playlist_id: Any) -> PlaylistSnapshot:
+    endpoint_type, raw_id, resource = _resolved_resource(adapter, playlist_id)
+    page_size = max(200, int(getattr(adapter.cfg, "watchlist_query_limit", 1000) or 1000))
+    if endpoint_type == "collection":
+        rows, _total = _fetch_all_collection_items(adapter.client, adapter.cfg.user_id, raw_id, page_size=page_size)
+    else:
+        rows, _total = _fetch_all_playlist_items(adapter.client, raw_id, page_size=page_size)
+    items: list[PlaylistItem] = []
+    for pos, row in enumerate(rows):
+        if not isinstance(row, Mapping) or not _accepts(endpoint_type, row):
+            continue
+        media = emby_normalize(row)
+        items.append(
+            PlaylistItem.from_media(
+                media,
+                playlist_item_id=row.get("PlaylistItemId") or row.get("playlistItemId") or row.get("Id"),
+                position=pos if endpoint_type == "playlist" else None,
+                provider_media_id=row.get("Id"),
+            )
+        )
+    _info("snapshot_done", list_id=resource.id, endpoint_type=endpoint_type, count=len(items))
+    return PlaylistSnapshot(resource=resource, items=items, checkpoint=None)
+
+
+def create(
+    adapter: Any,
+    name: str,
+    *,
+    media_type: str | None = None,
+    items: Sequence[Mapping[str, Any]] | None = None,
+    dry_run: bool = False,
+) -> PlaylistResource:
+    nm = str(name or "").strip()
+    if not nm:
+        raise ValueError("playlist name required")
+    endpoint_type = "collection" if str(media_type or "").strip().lower() in ("collection", "boxset") else "playlist"
+    if dry_run:
+        return PlaylistResource(
+            provider=_PROVIDER,
+            id="",
+            name=nm,
+            instance=_instance_id(adapter),
+            can_add=True,
+            can_remove=True,
+            can_reorder=endpoint_type == "playlist",
+            media_types=_media_types(endpoint_type),
+            extra={"endpoint_type": endpoint_type},
+        )
+    if endpoint_type == "collection":
+        rid = create_collection(adapter.client, nm)
+    else:
+        rid = create_playlist(adapter.client, adapter.cfg.user_id, nm, is_public=False)
+    if not rid:
+        raise EmbyPlaylistError(f"emby create {endpoint_type} failed")
+    res = _resource_from_row(adapter, {"Id": rid, "Name": nm, "Type": "BoxSet" if endpoint_type == "collection" else "Playlist"}, endpoint_type)
+    if res is None:
+        raise EmbyPlaylistError(f"emby create {endpoint_type} returned no id")
+    _info("create_done", list_id=res.id, endpoint_type=endpoint_type, name=res.name)
+    return res
+
+
+def _accepted_items(adapter: Any, endpoint_type: str, items: Sequence[Mapping[str, Any]]) -> tuple[list[tuple[str, str]], list[dict[str, Any]]]:
+    accepted: list[tuple[str, str]] = []
+    unresolved: list[dict[str, Any]] = []
+    seen_keys: set[str] = set()
+    for raw in items or []:
+        media = id_minimal(raw)
+        typ = str(media.get("type") or "").strip().lower()
+        if typ == "series":
+            media["type"] = "show"
+            typ = "show"
+        key = canonical_key(media)
+        if not key or key in seen_keys:
+            continue
+        seen_keys.add(key)
+        if typ not in _media_types(endpoint_type):
+            unresolved.append({"item": media, "hint": "unsupported_type"})
+            continue
+        iid = resolve_item_id(adapter, media, feature="playlists")
+        if not iid:
+            unresolved.append({"item": media, "hint": "not_in_library"})
+            continue
+        accepted.append((key, str(iid)))
+    return accepted, unresolved
+
+
+def add(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    endpoint_type, raw_id, resource = _resolved_resource(adapter, playlist_id)
+    accepted, unresolved = _accepted_items(adapter, endpoint_type, list(items or []))
+    if not accepted:
+        return {"ok": True, "count": 0, "unresolved": unresolved, "confirmed_keys": []}
+    qlim = max(1, int(getattr(adapter.cfg, "watchlist_query_limit", 25) or 25))
+    delay = int(getattr(adapter.cfg, "watchlist_write_delay_ms", 0) or 0)
+    added = 0
+    confirmed: list[str] = []
+    for chunk in chunked(accepted, qlim):
+        ids = [iid for _key, iid in chunk]
+        ok = collection_add_items(adapter.client, raw_id, ids) if endpoint_type == "collection" else playlist_add_items(adapter.client, raw_id, adapter.cfg.user_id, ids)
+        if ok:
+            added += len(ids)
+            confirmed.extend(key for key, _iid in chunk)
+        else:
+            for key, _iid in chunk:
+                unresolved.append({"item": {"key": key}, "hint": f"{endpoint_type}_add_failed"})
+        sleep_ms(delay)
+    _info("write_done", op="add", list_id=resource.id, endpoint_type=endpoint_type, applied=added, unresolved=len(unresolved))
+    return {"ok": True, "count": added, "unresolved": unresolved, "confirmed_keys": confirmed}
+
+
+def _current_members(adapter: Any, endpoint_type: str, raw_id: str) -> tuple[list[str], dict[str, list[str]], dict[str, set[str]]]:
+    page_size = max(200, int(getattr(adapter.cfg, "watchlist_query_limit", 1000) or 1000))
+    if endpoint_type == "collection":
+        rows, _total = _fetch_all_collection_items(adapter.client, adapter.cfg.user_id, raw_id, page_size=page_size)
+    else:
+        rows, _total = _fetch_all_playlist_items(adapter.client, raw_id, page_size=page_size)
+    ordered_keys: list[str] = []
+    by_key: dict[str, list[str]] = {}
+    keys_by_id: dict[str, set[str]] = {}
+    for row in rows:
+        if not isinstance(row, Mapping) or not _accepts(endpoint_type, row):
+            continue
+        key = emby_key_of(row)
+        remote_id = row.get("Id")
+        member_id = remote_id if endpoint_type == "collection" else (row.get("PlaylistItemId") or row.get("playlistItemId"))
+        if not key or not member_id:
+            continue
+        sid = str(member_id)
+        ordered_keys.append(key)
+        by_key.setdefault(key, []).append(sid)
+        keys_by_id.setdefault(sid, set()).add(key)
+    return ordered_keys, by_key, keys_by_id
+
+
+def remove(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    endpoint_type, raw_id, resource = _resolved_resource(adapter, playlist_id)
+    _ordered, by_key, keys_by_id = _current_members(adapter, endpoint_type, raw_id)
+    wanted: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    for raw in items or []:
+        key = canonical_key(id_minimal(raw))
+        ids = by_key.get(key) or []
+        if not ids:
+            unresolved.append({"item": id_minimal(raw), "hint": f"not_in_{endpoint_type}"})
+            continue
+        wanted.extend(ids)
+    seen: set[str] = set()
+    wanted = [x for x in wanted if not (x in seen or seen.add(x))]
+    if not wanted:
+        return {"ok": True, "count": 0, "unresolved": unresolved, "confirmed_keys": []}
+    qlim = max(1, int(getattr(adapter.cfg, "watchlist_query_limit", 25) or 25))
+    delay = int(getattr(adapter.cfg, "watchlist_write_delay_ms", 0) or 0)
+    removed = 0
+    confirmed_set: set[str] = set()
+    for chunk in chunked(wanted, qlim):
+        ok = collection_remove_items(adapter.client, raw_id, chunk) if endpoint_type == "collection" else playlist_remove_entries(adapter.client, raw_id, chunk)
+        if ok:
+            removed += len(chunk)
+            for sid in chunk:
+                confirmed_set.update(keys_by_id.get(sid, set()))
+        else:
+            for sid in chunk:
+                unresolved.append({"item": {"key": ",".join(sorted(keys_by_id.get(sid, set())))}, "hint": f"{endpoint_type}_remove_failed"})
+        sleep_ms(delay)
+    _info("write_done", op="remove", list_id=resource.id, endpoint_type=endpoint_type, applied=removed, unresolved=len(unresolved))
+    return {"ok": True, "count": removed, "unresolved": unresolved, "confirmed_keys": sorted(confirmed_set)}
+
+
+def reorder(adapter: Any, playlist_id: Any, ordered_keys: Sequence[str]) -> dict[str, Any]:
+    endpoint_type, raw_id, resource = _resolved_resource(adapter, playlist_id)
+    if endpoint_type != "playlist":
+        return {"ok": True, "count": 0, "reordered": 0, "unsupported": True}
+    current, by_key, _keys_by_id = _current_members(adapter, endpoint_type, raw_id)
+    item_id_by_key: dict[str, str] = {}
+    for key, ids in by_key.items():
+        if ids and key not in item_id_by_key:
+            item_id_by_key[key] = ids[0]
+    target = [str(k) for k in (ordered_keys or []) if str(k) in item_id_by_key]
+    work = [k for k in current if k in item_id_by_key]
+    moves = 0
+    for idx, key in enumerate(target):
+        if idx < len(work) and work[idx] == key:
+            continue
+        item_id = item_id_by_key.get(key)
+        if not item_id:
+            continue
+        if not playlist_move_item(adapter.client, raw_id, item_id, idx):
+            _warn("reorder_failed", list_id=resource.id, item_id=item_id, index=idx)
+            return {"ok": False, "count": moves, "reordered": moves, "error": "move_failed"}
+        try:
+            work.remove(key)
+        except ValueError:
+            pass
+        work.insert(idx, key)
+        moves += 1
+    _info("reorder_done", list_id=resource.id, moves=moves)
+    return {"ok": True, "count": moves, "reordered": moves}

--- a/providers/sync/jellyfin/_playlists.py
+++ b/providers/sync/jellyfin/_playlists.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Sequence
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from cw_platform.playlists import PLAYLIST_KIND_REGULAR, PlaylistItem, PlaylistResource, PlaylistSnapshot
+
+from ._common import (
+    chunked,
+    collection_add_items,
+    collection_fetch_all,
+    collection_remove_items,
+    create_collection,
+    create_playlist,
+    key_of as jelly_key_of,
+    make_logger,
+    normalize as jelly_normalize,
+    playlist_add_items,
+    playlist_fetch_all,
+    playlist_remove_entries,
+    resolve_item_id,
+    sleep_ms,
+)
+
+_PROVIDER = "JELLYFIN"
+_MEDIA_TYPES = ("movie", "show")
+_RESOURCE_PREFIXES = {"playlist": "playlist:", "collection": "collection:"}
+_dbg, _info, _warn = make_logger("playlists")
+
+
+class JellyfinPlaylistError(RuntimeError):
+    pass
+
+
+class JellyfinPlaylistNotFound(JellyfinPlaylistError):
+    pass
+
+
+def _instance_id(adapter: Any) -> str:
+    inst = getattr(adapter, "instance_id", None)
+    return str(inst).strip() if inst else "default"
+
+
+def _prefixed(endpoint_type: str, raw_id: Any) -> str:
+    return f"{_RESOURCE_PREFIXES[endpoint_type]}{str(raw_id or '').strip()}"
+
+
+def _raw_id(resource_id: Any) -> tuple[str | None, str]:
+    s = str(resource_id or "").strip()
+    for endpoint_type, prefix in _RESOURCE_PREFIXES.items():
+        if s.lower().startswith(prefix):
+            return endpoint_type, s[len(prefix):].strip()
+    return None, s
+
+
+def _endpoint_type(row: Mapping[str, Any]) -> str | None:
+    typ = str(row.get("Type") or "").strip().lower()
+    if typ == "playlist":
+        return "playlist"
+    if typ == "boxset":
+        return "collection"
+    return None
+
+
+def _resource_from_row(adapter: Any, row: Mapping[str, Any], endpoint_type: str | None = None) -> PlaylistResource | None:
+    raw = str(row.get("Id") or "").strip()
+    if not raw:
+        return None
+    et = endpoint_type or _endpoint_type(row)
+    if et not in _RESOURCE_PREFIXES:
+        return None
+    name = str(row.get("Name") or "").strip() or raw
+    return PlaylistResource(
+        provider=_PROVIDER,
+        id=_prefixed(et, raw),
+        name=name,
+        instance=_instance_id(adapter),
+        kind=PLAYLIST_KIND_REGULAR,
+        can_read=True,
+        can_add=True,
+        can_remove=True,
+        can_reorder=False,
+        media_types=_MEDIA_TYPES,
+        extra={
+            "endpoint_type": et,
+            "raw_id": raw,
+            "item_count": row.get("ChildCount") if row.get("ChildCount") is not None else row.get("RecursiveItemCount"),
+        },
+    )
+
+
+def _fetch_resources(adapter: Any, endpoint_type: str) -> list[PlaylistResource]:
+    http = adapter.client
+    uid = adapter.cfg.user_id
+    include = "Playlist" if endpoint_type == "playlist" else "BoxSet"
+    out: list[PlaylistResource] = []
+    start = 0
+    limit = 500
+    total: int | None = None
+    while True:
+        r = http.get(
+            "/Items",
+            params={
+                "userId": uid,
+                "IncludeItemTypes": include,
+                "Recursive": True,
+                "Fields": "ChildCount,RecursiveItemCount,DateCreated,DateLastMediaAdded",
+                "StartIndex": start,
+                "Limit": limit,
+                "EnableTotalRecordCount": True,
+            },
+        )
+        if getattr(r, "status_code", 0) != 200:
+            _warn("list_failed", endpoint_type=endpoint_type, status=getattr(r, "status_code", None))
+            return out
+        body = r.json() or {}
+        rows = body.get("Items") or []
+        if total is None:
+            try:
+                total = int(body.get("TotalRecordCount") or 0)
+            except Exception:
+                total = 0
+        for row in rows:
+            if not isinstance(row, Mapping):
+                continue
+            res = _resource_from_row(adapter, row, endpoint_type)
+            if res:
+                out.append(res)
+        start += len(rows)
+        if not rows or len(rows) < limit or (total is not None and total > 0 and start >= total):
+            break
+    return out
+
+
+def list_resources(adapter: Any) -> list[PlaylistResource]:
+    out = _fetch_resources(adapter, "playlist")
+    out.extend(_fetch_resources(adapter, "collection"))
+    out.sort(key=lambda r: (str(r.extra.get("endpoint_type") or ""), r.name.lower(), r.id))
+    _info("list_resources_done", count=len(out))
+    return out
+
+
+def _find_resource(adapter: Any, resource_id: Any) -> PlaylistResource | None:
+    et, rid = _raw_id(resource_id)
+    for res in list_resources(adapter):
+        raw = str(res.extra.get("raw_id") or "").strip()
+        if res.id == str(resource_id or "").strip() or raw == rid:
+            if not et or str(res.extra.get("endpoint_type") or "") == et:
+                return res
+    return None
+
+
+def _resolved_resource(adapter: Any, resource_id: Any) -> tuple[str, str, PlaylistResource]:
+    et, rid = _raw_id(resource_id)
+    res = _find_resource(adapter, resource_id)
+    if res:
+        raw = str(res.extra.get("raw_id") or "").strip()
+        kind = str(res.extra.get("endpoint_type") or et or "playlist")
+        return kind, raw or rid, res
+    if not rid:
+        raise JellyfinPlaylistNotFound("missing jellyfin playlist id")
+    if not et:
+        et = "playlist"
+    return et, rid, PlaylistResource(
+        provider=_PROVIDER,
+        id=_prefixed(et, rid),
+        name=rid,
+        instance=_instance_id(adapter),
+        can_read=True,
+        can_add=True,
+        can_remove=True,
+        can_reorder=False,
+        media_types=_MEDIA_TYPES,
+        extra={"endpoint_type": et, "raw_id": rid},
+    )
+
+
+def _is_movie_or_show(row: Mapping[str, Any]) -> bool:
+    typ = str(row.get("Type") or row.get("type") or "").strip().lower()
+    return typ in ("movie", "show", "series")
+
+
+def get_snapshot(adapter: Any, playlist_id: Any) -> PlaylistSnapshot:
+    endpoint_type, raw_id, resource = _resolved_resource(adapter, playlist_id)
+    page_size = max(200, int(getattr(adapter.cfg, "watchlist_query_limit", 1000) or 1000))
+    if endpoint_type == "collection":
+        rows, _total = collection_fetch_all(adapter.client, adapter.cfg.user_id, raw_id, page_size=page_size)
+    else:
+        rows, _total = playlist_fetch_all(adapter.client, raw_id, page_size=page_size)
+    items: list[PlaylistItem] = []
+    for pos, row in enumerate(rows):
+        if not isinstance(row, Mapping) or not _is_movie_or_show(row):
+            continue
+        media = jelly_normalize(row)
+        items.append(
+            PlaylistItem.from_media(
+                media,
+                playlist_item_id=row.get("PlaylistItemId") or row.get("playlistItemId") or row.get("Id"),
+                position=pos if endpoint_type == "playlist" else None,
+                provider_media_id=row.get("Id"),
+            )
+        )
+    _info("snapshot_done", list_id=resource.id, endpoint_type=endpoint_type, count=len(items))
+    return PlaylistSnapshot(resource=resource, items=items, checkpoint=None)
+
+
+def create(
+    adapter: Any,
+    name: str,
+    *,
+    media_type: str | None = None,
+    items: Sequence[Mapping[str, Any]] | None = None,
+    dry_run: bool = False,
+) -> PlaylistResource:
+    nm = str(name or "").strip()
+    if not nm:
+        raise ValueError("playlist name required")
+    endpoint_type = "collection" if str(media_type or "").strip().lower() in ("collection", "boxset") else "playlist"
+    if dry_run:
+        return PlaylistResource(
+            provider=_PROVIDER,
+            id="",
+            name=nm,
+            instance=_instance_id(adapter),
+            can_add=True,
+            can_remove=True,
+            can_reorder=False,
+            media_types=_MEDIA_TYPES,
+            extra={"endpoint_type": endpoint_type},
+        )
+    if endpoint_type == "collection":
+        rid = create_collection(adapter.client, nm)
+    else:
+        rid = create_playlist(adapter.client, adapter.cfg.user_id, nm, is_public=False)
+    if not rid:
+        raise JellyfinPlaylistError(f"jellyfin create {endpoint_type} failed")
+    res = _resource_from_row(adapter, {"Id": rid, "Name": nm, "Type": "BoxSet" if endpoint_type == "collection" else "Playlist"}, endpoint_type)
+    if res is None:
+        raise JellyfinPlaylistError(f"jellyfin create {endpoint_type} returned no id")
+    _info("create_done", list_id=res.id, endpoint_type=endpoint_type, name=res.name)
+    return res
+
+
+def _accepted_items(adapter: Any, items: Sequence[Mapping[str, Any]]) -> tuple[list[tuple[str, str]], list[dict[str, Any]]]:
+    accepted: list[tuple[str, str]] = []
+    unresolved: list[dict[str, Any]] = []
+    seen_keys: set[str] = set()
+    for raw in items or []:
+        media = id_minimal(raw)
+        typ = str(media.get("type") or "").strip().lower()
+        if typ == "series":
+            media["type"] = "show"
+            typ = "show"
+        key = canonical_key(media)
+        if not key or key in seen_keys:
+            continue
+        seen_keys.add(key)
+        if typ not in _MEDIA_TYPES:
+            unresolved.append({"item": media, "hint": "unsupported_type"})
+            continue
+        iid = resolve_item_id(adapter, media, feature="playlists")
+        if not iid:
+            unresolved.append({"item": media, "hint": "not_in_library"})
+            continue
+        accepted.append((key, str(iid)))
+    return accepted, unresolved
+
+
+def add(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    endpoint_type, raw_id, resource = _resolved_resource(adapter, playlist_id)
+    accepted, unresolved = _accepted_items(adapter, list(items or []))
+    if not accepted:
+        return {"ok": True, "count": 0, "unresolved": unresolved, "confirmed_keys": []}
+    qlim = max(1, int(getattr(adapter.cfg, "watchlist_query_limit", 25) or 25))
+    delay = int(getattr(adapter.cfg, "watchlist_write_delay_ms", 0) or 0)
+    added = 0
+    confirmed: list[str] = []
+    for chunk in chunked(accepted, qlim):
+        ids = [iid for _key, iid in chunk]
+        ok = collection_add_items(adapter.client, raw_id, ids) if endpoint_type == "collection" else playlist_add_items(adapter.client, raw_id, adapter.cfg.user_id, ids)
+        if ok:
+            added += len(ids)
+            confirmed.extend(key for key, _iid in chunk)
+        else:
+            for key, _iid in chunk:
+                unresolved.append({"item": {"key": key}, "hint": f"{endpoint_type}_add_failed"})
+        sleep_ms(delay)
+    _info("write_done", op="add", list_id=resource.id, endpoint_type=endpoint_type, applied=added, unresolved=len(unresolved))
+    return {"ok": True, "count": added, "unresolved": unresolved, "confirmed_keys": confirmed}
+
+
+def _current_members(adapter: Any, endpoint_type: str, raw_id: str) -> tuple[dict[str, list[str]], dict[str, set[str]]]:
+    page_size = max(200, int(getattr(adapter.cfg, "watchlist_query_limit", 1000) or 1000))
+    if endpoint_type == "collection":
+        rows, _total = collection_fetch_all(adapter.client, adapter.cfg.user_id, raw_id, page_size=page_size)
+    else:
+        rows, _total = playlist_fetch_all(adapter.client, raw_id, page_size=page_size)
+    by_key: dict[str, list[str]] = {}
+    keys_by_id: dict[str, set[str]] = {}
+    for row in rows:
+        if not isinstance(row, Mapping) or not _is_movie_or_show(row):
+            continue
+        key = jelly_key_of(row)
+        remote_id = row.get("Id")
+        member_id = remote_id if endpoint_type == "collection" else (row.get("PlaylistItemId") or row.get("playlistItemId"))
+        if not key or not member_id:
+            continue
+        sid = str(member_id)
+        by_key.setdefault(key, []).append(sid)
+        keys_by_id.setdefault(sid, set()).add(key)
+    return by_key, keys_by_id
+
+
+def remove(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    endpoint_type, raw_id, resource = _resolved_resource(adapter, playlist_id)
+    by_key, keys_by_id = _current_members(adapter, endpoint_type, raw_id)
+    wanted: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    for raw in items or []:
+        key = canonical_key(id_minimal(raw))
+        ids = by_key.get(key) or []
+        if not ids:
+            unresolved.append({"item": id_minimal(raw), "hint": f"not_in_{endpoint_type}"})
+            continue
+        wanted.extend(ids)
+    seen: set[str] = set()
+    wanted = [x for x in wanted if not (x in seen or seen.add(x))]
+    if not wanted:
+        return {"ok": True, "count": 0, "unresolved": unresolved, "confirmed_keys": []}
+    qlim = max(1, int(getattr(adapter.cfg, "watchlist_query_limit", 25) or 25))
+    delay = int(getattr(adapter.cfg, "watchlist_write_delay_ms", 0) or 0)
+    removed = 0
+    confirmed_set: set[str] = set()
+    for chunk in chunked(wanted, qlim):
+        ok = collection_remove_items(adapter.client, raw_id, chunk) if endpoint_type == "collection" else playlist_remove_entries(adapter.client, raw_id, chunk)
+        if ok:
+            removed += len(chunk)
+            for sid in chunk:
+                confirmed_set.update(keys_by_id.get(sid, set()))
+        else:
+            for sid in chunk:
+                unresolved.append({"item": {"key": ",".join(sorted(keys_by_id.get(sid, set())))}, "hint": f"{endpoint_type}_remove_failed"})
+        sleep_ms(delay)
+    _info("write_done", op="remove", list_id=resource.id, endpoint_type=endpoint_type, applied=removed, unresolved=len(unresolved))
+    return {"ok": True, "count": removed, "unresolved": unresolved, "confirmed_keys": sorted(confirmed_set)}
+
+
+def reorder(adapter: Any, playlist_id: Any, ordered_keys: Sequence[str]) -> dict[str, Any]:
+    return {"ok": True, "count": 0, "reordered": 0, "unsupported": True}

--- a/providers/sync/mdblist/_playlists.py
+++ b/providers/sync/mdblist/_playlists.py
@@ -1,0 +1,528 @@
+# /providers/sync/mdblist/_playlists.py
+# MDBList Module for playlist sync functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Sequence
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from cw_platform.playlists import (
+    PLAYLIST_KIND_REGULAR,
+    PLAYLIST_KIND_SMART,
+    PlaylistItem,
+    PlaylistResource,
+    PlaylistSnapshot,
+)
+
+from .._log import log as cw_log
+from . import _watchlist as feat_watchlist
+from ._common import cfg_section, has_auth, mdblist_request
+from ._watchlist import _as_int, _as_str, _parse_rows_and_total
+
+BASE = "https://api.mdblist.com"
+URL_USER_LISTS = f"{BASE}/lists/user"
+URL_LIST_ITEMS = f"{BASE}/lists/{{id}}/items"
+URL_LIST_ADD = f"{BASE}/lists/{{id}}/items/add"
+URL_LIST_REMOVE = f"{BASE}/lists/{{id}}/items/remove"
+URL_CREATE_LIST = f"{BASE}/lists/user/add"
+URL_UPDATE_LIST = f"{BASE}/lists/{{id}}/update"
+URL_USER = f"{BASE}/user"
+
+_PROVIDER = "MDBLIST"
+_FEATURE = "playlists"
+WATCHLIST_ID = "__watchlist__"
+_STATIC_MEDIA_TYPES = ("movie", "show", "season", "episode")
+_WRITE_GROUPS = {"movie": "movies", "show": "shows", "season": "seasons", "episode": "episodes"}
+
+
+def _info(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "info", event, **fields)
+
+
+def _warn(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "warn", event, **fields)
+
+
+class MDBListPlaylistError(RuntimeError):
+    pass
+
+
+class MDBListDynamicListError(MDBListPlaylistError):
+    pass
+
+
+class MDBListNotOwnedError(MDBListPlaylistError):
+    pass
+
+
+class MDBListNotFoundError(MDBListPlaylistError):
+    pass
+
+
+class MDBListCapacityError(MDBListPlaylistError):
+    pass
+
+
+def _instance_id(adapter: Any) -> str:
+    inst = getattr(adapter, "instance_id", None)
+    return str(inst).strip() if inst else "default"
+
+
+def _is_watchlist_id(resource_or_id: Any) -> bool:
+    raw = resource_or_id.id if isinstance(resource_or_id, PlaylistResource) else resource_or_id
+    lid = str(raw or "").strip().lower()
+    return lid in {WATCHLIST_ID, "watchlist", "mdblist:watchlist"}
+
+
+def _watchlist_resource(adapter: Any) -> PlaylistResource:
+    return PlaylistResource(
+        provider=_PROVIDER,
+        id=WATCHLIST_ID,
+        name="Watchlist",
+        instance=_instance_id(adapter),
+        kind=PLAYLIST_KIND_REGULAR,
+        can_read=True,
+        can_add=True,
+        can_remove=True,
+        can_reorder=False,
+        media_types=("movie", "show"),
+        extra={"builtin": "watchlist"},
+    )
+
+
+def _apikey(adapter: Any) -> str:
+    return _as_str(cfg_section(adapter).get("api_key")) or ""
+
+
+def _norm_media_type(v: Any) -> str:
+    t = str(v or "").strip().lower()
+    if t in ("episode", "episodes"):
+        return "episode"
+    if t in ("season", "seasons"):
+        return "season"
+    if t in ("show", "shows", "tv", "series"):
+        return "show"
+    return "movie"
+
+
+def _normalize_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    ids_src = row.get("ids")
+    ids_block: Mapping[str, Any] = ids_src if isinstance(ids_src, Mapping) else {}
+    ids: dict[str, Any] = {}
+    imdb = _as_str(ids_block.get("imdb") or row.get("imdb_id") or row.get("imdb"))
+    if imdb:
+        ids["imdb"] = imdb
+    tmdb = _as_int(ids_block.get("tmdb") or row.get("tmdb_id") or row.get("tmdb"))
+    if tmdb is not None:
+        ids["tmdb"] = str(tmdb)
+    tvdb = _as_int(ids_block.get("tvdb") or row.get("tvdb_id") or row.get("tvdb"))
+    if tvdb is not None:
+        ids["tvdb"] = str(tvdb)
+    trakt = _as_int(ids_block.get("trakt") or row.get("trakt_id") or row.get("trakt"))
+    if trakt is not None:
+        ids["trakt"] = str(trakt)
+    mal = _as_int(ids_block.get("mal") or row.get("mal_id") or row.get("mal"))
+    if mal is not None:
+        ids["mal"] = str(mal)
+    mdb = _as_str(ids_block.get("mdblist") or row.get("mdblist_id") or row.get("mdblist"))
+    if mdb:
+        ids["mdblist"] = mdb
+
+    typ = _norm_media_type(row.get("mediatype") or row.get("type"))
+    out: dict[str, Any] = {"type": typ, "ids": ids}
+    title = _as_str(row.get("title") or row.get("name"))
+    if title:
+        out["title"] = title
+    year = _as_int(row.get("release_year") or row.get("year") or row.get("first_air_year"))
+    if year is not None:
+        out["year"] = year
+    return out
+
+
+def _resource_from_list(adapter: Any, row: Mapping[str, Any]) -> PlaylistResource | None:
+    lid = row.get("id")
+    if lid is None:
+        return None
+    dynamic = bool(row.get("dynamic"))
+    raw_mediatype = _as_str(row.get("mediatype") or row.get("type"))
+    mediatype = _norm_media_type(raw_mediatype) if raw_mediatype else ""
+    media_types = (mediatype,) if dynamic and mediatype else _STATIC_MEDIA_TYPES
+    return PlaylistResource(
+        provider=_PROVIDER,
+        id=str(lid),
+        name=str(row.get("name") or "").strip() or str(lid),
+        instance=_instance_id(adapter),
+        kind=PLAYLIST_KIND_SMART if dynamic else PLAYLIST_KIND_REGULAR,
+        can_read=True,
+        can_add=not dynamic,
+        can_remove=not dynamic,
+        can_reorder=False,
+        media_types=media_types,
+        extra={
+            "dynamic": dynamic,
+            "static": not dynamic,
+            "mediatype": mediatype,
+            "item_count": _as_int(row.get("items")),
+            "private": bool(row.get("private")),
+            "slug": _as_str(row.get("slug")),
+            "description": _as_str(row.get("description")),
+            "owner": _as_str(row.get("user_name")),
+            "updated_at": _as_str(row.get("updated") or row.get("last_updated")),
+        },
+    )
+
+
+def list_resources(adapter: Any) -> list[PlaylistResource]:
+    if not has_auth(cfg_section(adapter)):
+        return []
+    r = mdblist_request(adapter, "GET", URL_USER_LISTS, params={"apikey": _apikey(adapter)})
+    if not (200 <= r.status_code < 300):
+        _warn("http_failed", op="list_resources", status=r.status_code)
+        return []
+    data = r.json() if (r.text or "").strip() else []
+    rows = data if isinstance(data, list) else (data.get("lists") if isinstance(data, Mapping) else [])
+    out: list[PlaylistResource] = [_watchlist_resource(adapter)]
+    for row in rows or []:
+        if not isinstance(row, Mapping):
+            continue
+        res = _resource_from_list(adapter, row)
+        if res:
+            out.append(res)
+    _info("list_resources_done", count=len(out))
+    return out
+
+
+def _find_owned_resource(adapter: Any, playlist_id: Any) -> PlaylistResource | None:
+    lid = str(playlist_id or "").strip()
+    for res in list_resources(adapter):
+        if res.id == lid:
+            return res
+    return None
+
+
+def get_snapshot(adapter: Any, playlist_id: Any) -> PlaylistSnapshot:
+    if _is_watchlist_id(playlist_id):
+        resource = _watchlist_resource(adapter)
+        idx = feat_watchlist.build_index(adapter) or {}
+        items = [PlaylistItem.from_media(m, position=i) for i, m in enumerate(idx.values()) if isinstance(m, Mapping)]
+        _info("snapshot_done", list_id=WATCHLIST_ID, count=len(items))
+        return PlaylistSnapshot(resource=resource, items=items, checkpoint=None)
+
+    lid = str(playlist_id or "").strip()
+    resource = _find_owned_resource(adapter, lid)
+    if resource is None:
+        resource = PlaylistResource(
+            provider=_PROVIDER,
+            id=lid,
+            name=lid,
+            instance=_instance_id(adapter),
+            can_read=True,
+            can_add=False,
+            can_remove=False,
+            can_reorder=False,
+        )
+
+    items: list[PlaylistItem] = []
+    offset = 0
+    limit = 1000
+    apikey = _apikey(adapter)
+    pos = 0
+    while offset <= 1_000_000:
+        r = mdblist_request(
+            adapter,
+            "GET",
+            URL_LIST_ITEMS.format(id=lid),
+            params={"apikey": apikey, "limit": limit, "offset": offset, "unified": "true"},
+        )
+        if not (200 <= r.status_code < 300):
+            _warn("http_failed", op="get_snapshot", status=r.status_code, list_id=lid)
+            break
+        data = r.json() if (r.text or "").strip() else {}
+        rows, _total = _parse_rows_and_total(data)
+        if not rows:
+            break
+        for row in rows:
+            media = _normalize_row(row)
+            rank = _as_int(row.get("rank"))
+            items.append(
+                PlaylistItem.from_media(
+                    media,
+                    playlist_item_id=row.get("id"),
+                    position=rank if rank is not None else pos,
+                    provider_media_id=row.get("id") or (media.get("ids") or {}).get("mdblist"),
+                )
+            )
+            pos += 1
+        has_more = None
+        try:
+            hdr = r.headers.get("X-Has-More")
+            if hdr is not None:
+                has_more = str(hdr).strip().lower() in ("1", "true", "yes")
+        except Exception:
+            has_more = None
+        if has_more is None:
+            pag = data.get("pagination") if isinstance(data, Mapping) else None
+            has_more = bool(pag.get("has_more")) if isinstance(pag, Mapping) else (len(rows) >= limit)
+        if not has_more:
+            break
+        offset += len(rows)
+
+    items.sort(key=lambda it: (it.position is None, it.position if it.position is not None else 0))
+    _info("snapshot_done", list_id=lid, count=len(items))
+    return PlaylistSnapshot(resource=resource, items=items, checkpoint=None)
+
+
+def create(
+    adapter: Any,
+    name: str,
+    *,
+    media_type: str | None = None,
+    items: Sequence[Mapping[str, Any]] | None = None,
+    dry_run: bool = False,
+) -> PlaylistResource:
+    nm = str(name or "").strip()
+    if not nm:
+        raise ValueError("playlist name required")
+    if dry_run:
+        return PlaylistResource(
+            provider=_PROVIDER,
+            id="",
+            name=nm,
+            instance=_instance_id(adapter),
+            can_add=True,
+            can_remove=True,
+            can_reorder=False,
+            media_types=_STATIC_MEDIA_TYPES,
+        )
+
+    body: dict[str, Any] = {"name": nm}
+    r = mdblist_request(
+        adapter,
+        "POST",
+        URL_CREATE_LIST,
+        params={"apikey": _apikey(adapter)},
+        json=body,
+    )
+    if r.status_code in (401, 403):
+        raise MDBListPlaylistError("mdblist create list unauthorized")
+    if not (200 <= r.status_code < 300):
+        _warn("create_failed", status=r.status_code, body=((r.text or "")[:180]))
+        raise MDBListPlaylistError(f"mdblist create list failed: http {r.status_code}")
+    data = r.json() if (r.text or "").strip() else {}
+    row: dict[str, Any] = {}
+    if isinstance(data, Mapping):
+        list_node = data.get("list")
+        ids_node = data.get("ids")
+        if isinstance(list_node, Mapping):
+            row = dict(list_node)
+        elif isinstance(ids_node, list) and ids_node:
+            row = {"id": ids_node[0], "name": nm}
+        else:
+            row = dict(data)
+    res = _resource_from_list(adapter, row) if row.get("id") is not None else None
+    if res is None:
+        raise MDBListPlaylistError("mdblist create list returned no id")
+    _info("create_done", list_id=res.id, name=res.name)
+    return res
+
+
+def update_metadata(adapter: Any, playlist_id: Any, *, name: str | None = None, private: bool | None = None) -> dict[str, Any]:
+    resource = _find_owned_resource(adapter, playlist_id)
+    if resource is None:
+        raise MDBListNotOwnedError("mdblist list is not owned by the authenticated user")
+    if resource.is_smart:
+        raise MDBListDynamicListError("cannot update a dynamic mdblist list")
+    body: dict[str, Any] = {}
+    if name is not None:
+        body["name"] = str(name)
+    if private is not None:
+        body["private"] = bool(private)
+    if not body:
+        return {"ok": True, "updated": False}
+    r = mdblist_request(
+        adapter,
+        "POST",
+        URL_UPDATE_LIST.format(id=resource.id),
+        params={"apikey": _apikey(adapter)},
+        json=body,
+    )
+    if not (200 <= r.status_code < 300):
+        _warn("update_failed", status=r.status_code, list_id=resource.id)
+        raise MDBListPlaylistError(f"mdblist update list failed: http {r.status_code}")
+    return {"ok": True, "updated": True}
+
+
+def _guard_writable(resource: PlaylistResource | None) -> PlaylistResource:
+    if resource is None:
+        raise MDBListNotOwnedError("mdblist list is not owned by the authenticated user")
+    if resource.is_smart:
+        raise MDBListDynamicListError("cannot write to a dynamic mdblist list")
+    if not (resource.can_add or resource.can_remove):
+        raise MDBListPlaylistError("mdblist list is read only")
+    return resource
+
+
+def _accept_items(items: Sequence[Mapping[str, Any]]) -> tuple[list[dict[str, Any]], list[str], list[dict[str, Any]]]:
+    accepted: list[dict[str, Any]] = []
+    keys: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    for raw in items or []:
+        m = id_minimal(raw)
+        kind = _norm_media_type(m.get("type"))
+        ids_raw = m.get("ids")
+        ids_src: Mapping[str, Any] = ids_raw if isinstance(ids_raw, Mapping) else {}
+        ids: dict[str, Any] = {}
+        if kind in ("season", "episode"):
+            tmdb = _as_int(ids_src.get("tmdb"))
+            if tmdb is not None:
+                ids["tmdb"] = tmdb
+        else:
+            imdb = _as_str(ids_src.get("imdb"))
+            if imdb:
+                ids["imdb"] = imdb
+            for key in ("tmdb", "tvdb", "trakt"):
+                v = _as_int(ids_src.get(key))
+                if v is not None:
+                    ids[key] = v
+            mdb = _as_str(ids_src.get("mdblist"))
+            if mdb:
+                ids["mdblist"] = mdb
+        if not ids:
+            unresolved.append({"item": m, "hint": "missing_supported_ids"})
+            continue
+        accepted.append({"type": kind, "ids": ids})
+        keys.append(canonical_key(m))
+    return accepted, keys, unresolved
+
+
+def _payload(accepted: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    buckets: dict[str, list[dict[str, Any]]] = {v: [] for v in _WRITE_GROUPS.values()}
+    for x in accepted:
+        ids = {k: v for k, v in dict(x.get("ids") or {}).items() if v not in (None, "")}
+        if not ids:
+            continue
+        bucket = _WRITE_GROUPS.get(str(x.get("type") or "movie"))
+        if bucket:
+            buckets[bucket].append(ids)
+    return {k: v for k, v in buckets.items() if v}
+
+
+def _count_bucket(value: Any) -> int:
+    if isinstance(value, list):
+        return len(value)
+    try:
+        return int(value or 0)
+    except Exception:
+        return 0
+
+
+def _confirmed_keys(items: Sequence[Mapping[str, Any]], unresolved: Sequence[Mapping[str, Any]]) -> list[str]:
+    unresolved_keys: set[str] = set()
+    for u in unresolved or []:
+        obj = u.get("item") if isinstance(u, Mapping) else None
+        if isinstance(obj, Mapping):
+            try:
+                unresolved_keys.add(canonical_key(id_minimal(obj)))
+            except Exception:
+                pass
+    out: list[str] = []
+    seen: set[str] = set()
+    for it in items or []:
+        try:
+            k = canonical_key(id_minimal(it))
+        except Exception:
+            k = ""
+        if not k or k in seen or k in unresolved_keys:
+            continue
+        seen.add(k)
+        out.append(k)
+    return out
+
+
+def _write(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]], *, op: str) -> dict[str, Any]:
+    if _is_watchlist_id(playlist_id):
+        lst = list(items or [])
+        count, unresolved = (feat_watchlist.add(adapter, lst) if op == "add" else feat_watchlist.remove(adapter, lst))
+        return {"ok": True, "count": int(count or 0), "unresolved": unresolved, "confirmed_keys": _confirmed_keys(lst, unresolved)}
+
+    resource = _guard_writable(_find_owned_resource(adapter, playlist_id))
+    accepted, keys, unresolved = _accept_items(items)
+    if not accepted:
+        _info("write_skipped", op=op, reason="empty_payload", unresolved=len(unresolved))
+        return {"ok": True, "count": 0, "unresolved": unresolved, "confirmed_keys": []}
+
+    payload = _payload(accepted)
+    if not payload:
+        for m in accepted:
+            unresolved.append({"item": id_minimal(m), "hint": "missing_write_ids"})
+        return {"ok": True, "count": 0, "unresolved": unresolved, "confirmed_keys": []}
+
+    url = URL_LIST_ADD if op == "add" else URL_LIST_REMOVE
+    r = mdblist_request(
+        adapter,
+        "POST",
+        url.format(id=resource.id),
+        params={"apikey": _apikey(adapter)},
+        json=payload,
+    )
+    if r.status_code == 429:
+        _warn("capacity", op=op, status=429)
+        for k in keys:
+            unresolved.append({"item": {"key": k}, "hint": "rate_limited"})
+        return {"ok": False, "count": 0, "unresolved": unresolved, "confirmed_keys": [], "capacity": "rate_limit"}
+    if r.status_code in (401, 403):
+        raise MDBListPlaylistError("mdblist write unauthorized or forbidden")
+    if not (200 <= r.status_code < 300):
+        _warn("write_failed", op=op, status=r.status_code, body=((r.text or "")[:180]))
+        for k in keys:
+            unresolved.append({"item": {"key": k}, "hint": f"http:{r.status_code}"})
+        return {"ok": False, "count": 0, "unresolved": unresolved, "confirmed_keys": []}
+
+    body = r.json() if (r.text or "").strip() else {}
+    body = body if isinstance(body, Mapping) else {}
+    bucket_key = "added" if op == "add" else "deleted"
+    bucket = body.get(bucket_key) or body.get("removed") or {}
+    applied = 0
+    if isinstance(bucket, Mapping):
+        applied = sum(_count_bucket(bucket.get(k)) for k in _WRITE_GROUPS.values())
+    if applied == 0 and not body.get("not_found") and not body.get("existing"):
+        applied = len(accepted)
+
+    nf = body.get("not_found") if isinstance(body.get("not_found"), Mapping) else {}
+    nf_keys: set[str] = set()
+    for grp, typ in (("movies", "movie"), ("shows", "show"), ("seasons", "season"), ("episodes", "episode")):
+        for obj in (nf.get(grp) or []) if isinstance(nf, Mapping) else []:
+            if isinstance(obj, Mapping):
+                ids = {k: v for k, v in obj.items() if k in ("imdb", "tmdb", "tvdb")}
+                if ids:
+                    nf_keys.add(canonical_key({"type": typ, "ids": ids}))
+                    unresolved.append({"item": id_minimal({"type": typ, "ids": ids}), "hint": "not_found"})
+
+    confirmed = [k for k in keys if k not in nf_keys]
+    _info("write_done", op=op, list_id=resource.id, applied=applied, unresolved=len(unresolved))
+    return {"ok": True, "count": applied, "unresolved": unresolved, "confirmed_keys": confirmed}
+
+
+def add(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    return _write(adapter, playlist_id, list(items or []), op="add")
+
+
+def remove(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    return _write(adapter, playlist_id, list(items or []), op="remove")
+
+
+def reorder(adapter: Any, playlist_id: Any, ordered_keys: Sequence[str]) -> dict[str, Any]:
+    return {"ok": True, "count": 0, "reordered": 0, "unsupported": True}
+
+
+def account(adapter: Any) -> dict[str, Any]:
+    if not has_auth(cfg_section(adapter)):
+        return {}
+    try:
+        r = mdblist_request(adapter, "GET", URL_USER, params={"apikey": _apikey(adapter)})
+        if 200 <= r.status_code < 300 and (r.text or "").strip():
+            data = r.json()
+            return dict(data) if isinstance(data, Mapping) else {}
+    except Exception:
+        return {}
+    return {}

--- a/providers/sync/plex/_playlists.py
+++ b/providers/sync/plex/_playlists.py
@@ -1,0 +1,616 @@
+# /providers/sync/plex/_playlists.py
+# Plex Module for playlist sync functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Sequence
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from cw_platform.playlists import (
+    PLAYLIST_KIND_REGULAR,
+    PLAYLIST_KIND_SMART,
+    PlaylistItem,
+    PlaylistResource,
+    PlaylistSnapshot,
+)
+
+from ._common import (
+    item_guid_candidates,
+    key_of as plex_key_of,
+    normalize as plex_normalize,
+    resolve_obj_by_guids,
+)
+from . import _watchlist as feat_watchlist
+from .._log import log as cw_log
+
+_PROVIDER = "PLEX"
+_FEATURE = "playlists"
+_VIDEO_TYPES = {"movie", "episode"}
+_COLLECTION_TYPES = {"movie", "show"}
+WATCHLIST_ID = "__watchlist__"
+COLLECTION_PREFIX = "collection:"
+
+
+def _info(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "info", event, **fields)
+
+
+def _warn(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "warn", event, **fields)
+
+
+class PlaylistError(RuntimeError):
+    pass
+
+
+class SmartPlaylistError(PlaylistError):
+    pass
+
+
+class PlaylistNotFound(PlaylistError):
+    pass
+
+
+def _instance_id(adapter: Any) -> str:
+    inst = getattr(adapter, "instance_id", None)
+    return str(inst).strip() if inst else "default"
+
+
+def _is_watchlist_id(resource_or_id: Any) -> bool:
+    raw = resource_or_id.id if isinstance(resource_or_id, PlaylistResource) else resource_or_id
+    lid = str(raw or "").strip().lower()
+    return lid in {WATCHLIST_ID, "watchlist", "plex:watchlist"}
+
+
+def _is_collection_id(resource_or_id: Any) -> bool:
+    raw = resource_or_id.id if isinstance(resource_or_id, PlaylistResource) else resource_or_id
+    return str(raw or "").strip().lower().startswith(COLLECTION_PREFIX)
+
+
+def _watchlist_resource(adapter: Any) -> PlaylistResource:
+    return PlaylistResource(
+        provider=_PROVIDER,
+        id=WATCHLIST_ID,
+        name="Watchlist",
+        instance=_instance_id(adapter),
+        kind=PLAYLIST_KIND_REGULAR,
+        can_read=True,
+        can_add=True,
+        can_remove=True,
+        can_reorder=False,
+        media_types=("movie", "show"),
+        extra={"builtin": "watchlist"},
+    )
+
+
+def _server(adapter: Any) -> Any:
+    srv = getattr(getattr(adapter, "client", None), "server", None)
+    if srv is None:
+        raise PlaylistError("plex server not connected")
+    return srv
+
+
+def _is_smart(pl: Any) -> bool:
+    try:
+        return bool(getattr(pl, "smart", False))
+    except Exception:
+        return False
+
+
+def _section_key(section: Any) -> str:
+    for attr in ("key", "librarySectionID", "sectionID"):
+        v = getattr(section, attr, None)
+        if v is not None and str(v).strip():
+            return str(v).strip()
+    return str(getattr(section, "title", "") or "").strip()
+
+
+def _section_type(section: Any) -> str:
+    return str(getattr(section, "type", "") or getattr(section, "TYPE", "") or "").strip().lower()
+
+
+def _collection_subtype(section: Any, coll: Any) -> str:
+    sub = str(getattr(coll, "subtype", "") or "").strip().lower()
+    return sub if sub in _COLLECTION_TYPES else _section_type(section)
+
+
+def _collection_id(section: Any, coll: Any) -> str:
+    sid = _section_key(section)
+    rk = getattr(coll, "ratingKey", None) or getattr(coll, "key", None) or getattr(coll, "title", "")
+    return f"{COLLECTION_PREFIX}{sid}:{str(rk or '').strip()}"
+
+
+def _parse_collection_id(value: Any) -> tuple[str, str] | None:
+    raw = str(value or "").strip()
+    if not raw.lower().startswith(COLLECTION_PREFIX):
+        return None
+    rest = raw[len(COLLECTION_PREFIX):]
+    if ":" not in rest:
+        return None
+    sid, rid = rest.split(":", 1)
+    sid = sid.strip()
+    rid = rid.strip()
+    if not sid or not rid:
+        return None
+    return sid, rid
+
+
+def _playlist_type(pl: Any) -> str:
+    return str(getattr(pl, "playlistType", "") or "").lower()
+
+
+def _resource_from_playlist(adapter: Any, pl: Any) -> PlaylistResource:
+    smart = _is_smart(pl)
+    rk = getattr(pl, "ratingKey", None)
+    pid = str(rk if rk is not None else (getattr(pl, "key", None) or getattr(pl, "title", "")))
+    return PlaylistResource(
+        provider=_PROVIDER,
+        id=pid,
+        name=str(getattr(pl, "title", "") or pid),
+        instance=_instance_id(adapter),
+        kind=PLAYLIST_KIND_SMART if smart else PLAYLIST_KIND_REGULAR,
+        can_read=True,
+        can_add=not smart,
+        can_remove=not smart,
+        can_reorder=not smart,
+        media_types=("movie", "episode"),
+        extra={"endpoint_type": "playlist", "raw_id": pid},
+    )
+
+
+def _resource_from_collection(adapter: Any, section: Any, coll: Any) -> PlaylistResource | None:
+    subtype = _collection_subtype(section, coll)
+    if subtype not in _COLLECTION_TYPES:
+        return None
+    smart = _is_smart(coll)
+    cid = _collection_id(section, coll)
+    raw = str(getattr(coll, "ratingKey", None) or "").strip()
+    return PlaylistResource(
+        provider=_PROVIDER,
+        id=cid,
+        name=str(getattr(coll, "title", "") or raw or cid),
+        instance=_instance_id(adapter),
+        kind=PLAYLIST_KIND_SMART if smart else PLAYLIST_KIND_REGULAR,
+        can_read=True,
+        can_add=not smart,
+        can_remove=not smart,
+        can_reorder=False,
+        media_types=(subtype,),
+        extra={
+            "endpoint_type": "collection",
+            "raw_id": raw,
+            "section_id": _section_key(section),
+            "section_title": str(getattr(section, "title", "") or ""),
+            "subtype": subtype,
+            "smart": smart,
+            "item_count": getattr(coll, "childCount", None),
+        },
+    )
+
+
+def _iter_video_playlists(srv: Any) -> list[Any]:
+    try:
+        playlists = list(srv.playlists() or [])
+    except Exception as e:
+        _warn("list_failed", error=str(e))
+        return []
+    return [pl for pl in playlists if _playlist_type(pl) in ("", "video")]
+
+
+def _iter_collection_sections(srv: Any) -> list[Any]:
+    try:
+        sections = list(srv.library.sections() or [])
+    except Exception as e:
+        _warn("collection_sections_failed", error=str(e))
+        return []
+    return [sec for sec in sections if _section_type(sec) in _COLLECTION_TYPES]
+
+
+def _iter_collections(srv: Any) -> list[tuple[Any, Any]]:
+    out: list[tuple[Any, Any]] = []
+    for sec in _iter_collection_sections(srv):
+        try:
+            cols = list(sec.collections() or [])
+        except Exception as e:
+            _warn("collection_list_failed", section=_section_key(sec), error=str(e))
+            continue
+        for coll in cols:
+            if _collection_subtype(sec, coll) in _COLLECTION_TYPES:
+                out.append((sec, coll))
+    return out
+
+
+def list_resources(adapter: Any) -> list[PlaylistResource]:
+    srv = _server(adapter)
+    out = [_watchlist_resource(adapter)]
+    out.extend(_resource_from_playlist(adapter, pl) for pl in _iter_video_playlists(srv))
+    for section, coll in _iter_collections(srv):
+        res = _resource_from_collection(adapter, section, coll)
+        if res:
+            out.append(res)
+    _info("list_resources_done", count=len(out))
+    return out
+
+
+def _find_playlist(srv: Any, playlist_id: Any) -> Any:
+    want = str(playlist_id or "").strip()
+    if not want:
+        raise PlaylistNotFound("missing playlist id")
+    for pl in _iter_video_playlists(srv):
+        rk = str(getattr(pl, "ratingKey", "") or "")
+        if rk and rk == want:
+            return pl
+    for pl in _iter_video_playlists(srv):
+        if str(getattr(pl, "title", "") or "") == want:
+            return pl
+    raise PlaylistNotFound(f"plex playlist not found: {want}")
+
+
+def _find_collection(srv: Any, collection_id: Any) -> tuple[Any, Any]:
+    parsed = _parse_collection_id(collection_id)
+    if not parsed:
+        raise PlaylistNotFound("missing plex collection id")
+    want_section, want_key = parsed
+    for section, coll in _iter_collections(srv):
+        if _section_key(section) != want_section:
+            continue
+        rk = str(getattr(coll, "ratingKey", "") or "")
+        key = str(getattr(coll, "key", "") or "")
+        title = str(getattr(coll, "title", "") or "")
+        if want_key in {rk, key, title}:
+            return section, coll
+    raise PlaylistNotFound(f"plex collection not found: {collection_id}")
+
+
+def _obj_key(obj: Any) -> str:
+    try:
+        return plex_key_of(obj)
+    except Exception:
+        return ""
+
+
+def get_snapshot(adapter: Any, playlist_id: Any) -> PlaylistSnapshot:
+    if _is_watchlist_id(playlist_id):
+        resource = _watchlist_resource(adapter)
+        idx = feat_watchlist.build_index(adapter) or {}
+        items = [PlaylistItem.from_media(m, position=i) for i, m in enumerate(idx.values()) if isinstance(m, Mapping)]
+        _info("snapshot_done", list_id=WATCHLIST_ID, count=len(items))
+        return PlaylistSnapshot(resource=resource, items=items, checkpoint=None)
+
+    srv = _server(adapter)
+    if _is_collection_id(playlist_id):
+        section, coll = _find_collection(srv, playlist_id)
+        resource = _resource_from_collection(adapter, section, coll)
+        if resource is None:
+            raise PlaylistNotFound(f"plex collection not supported: {playlist_id}")
+        try:
+            raw = list(coll.items() or [])
+        except Exception as e:
+            _warn("collection_snapshot_failed", list_id=resource.id, error=str(e))
+            raw = []
+        subtype = _collection_subtype(section, coll)
+        items = []
+        for obj in raw:
+            if str(getattr(obj, "type", "") or "").lower() != subtype:
+                continue
+            items.append(
+                PlaylistItem.from_media(
+                    plex_normalize(obj),
+                    playlist_item_id=getattr(obj, "ratingKey", None),
+                    position=None,
+                    provider_media_id=getattr(obj, "ratingKey", None),
+                )
+            )
+        _info("snapshot_done", list_id=resource.id, count=len(items))
+        return PlaylistSnapshot(resource=resource, items=items, checkpoint=None)
+
+    pl = _find_playlist(srv, playlist_id)
+    resource = _resource_from_playlist(adapter, pl)
+
+    items: list[PlaylistItem] = []
+    try:
+        raw = list(pl.items() or [])
+    except Exception as e:
+        _warn("snapshot_failed", list_id=resource.id, error=str(e))
+        raw = []
+
+    for pos, obj in enumerate(raw):
+        typ = str(getattr(obj, "type", "") or "").lower()
+        if typ not in _VIDEO_TYPES:
+            continue
+        media = plex_normalize(obj)
+        items.append(
+            PlaylistItem.from_media(
+                media,
+                playlist_item_id=getattr(obj, "playlistItemID", None),
+                position=pos,
+                provider_media_id=getattr(obj, "ratingKey", None),
+            )
+        )
+    _info("snapshot_done", list_id=resource.id, count=len(items))
+    return PlaylistSnapshot(resource=resource, items=items, checkpoint=None)
+
+
+def _resolve_object(srv: Any, item: Mapping[str, Any], *, accept: set[str] | None = None, allow: set[str] | None = None) -> Any | None:
+    guids = item_guid_candidates(item.get("ids") or {}, item.get("show_ids") or {}, item)
+    if not guids:
+        return None
+    return resolve_obj_by_guids(srv, guids, set(allow or set()), set(accept or _VIDEO_TYPES))
+
+
+def _resolve_items(srv: Any, items: Sequence[Mapping[str, Any]], *, accept: set[str] | None = None, allow: set[str] | None = None, missing_hint: str = "not_found") -> tuple[list[Any], list[str], list[dict[str, Any]]]:
+    resolved: list[Any] = []
+    confirmed: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in items or []:
+        m = id_minimal(raw)
+        if isinstance(raw, Mapping) and raw.get("show_ids"):
+            m["show_ids"] = raw.get("show_ids")
+        key = canonical_key(m)
+        if key in seen:
+            continue
+        seen.add(key)
+        obj = _resolve_object(srv, m, accept=accept, allow=allow)
+        if obj is None:
+            unresolved.append({"item": m, "hint": missing_hint})
+            continue
+        resolved.append(obj)
+        confirmed.append(key)
+    return resolved, confirmed, unresolved
+
+
+def create(
+    adapter: Any,
+    name: str,
+    *,
+    media_type: str | None = None,
+    items: Sequence[Mapping[str, Any]] | None = None,
+    dry_run: bool = False,
+) -> PlaylistResource:
+    nm = str(name or "").strip()
+    if not nm:
+        raise ValueError("playlist name required")
+    if dry_run:
+        return PlaylistResource(
+            provider=_PROVIDER,
+            id="",
+            name=nm,
+            instance=_instance_id(adapter),
+            can_add=True,
+            can_remove=True,
+            can_reorder=True,
+            media_types=("movie", "episode"),
+        )
+    srv = _server(adapter)
+    resolved, _confirmed, _unresolved = _resolve_items(srv, list(items or []))
+    if not resolved:
+        raise PlaylistError("plex requires at least one resolvable item to create a playlist")
+    try:
+        pl = srv.createPlaylist(nm, items=resolved)
+    except Exception as e:
+        _warn("create_failed", name=nm, error=str(e))
+        raise PlaylistError(f"plex create playlist failed: {e}") from e
+    _info("create_done", name=nm)
+    return _resource_from_playlist(adapter, pl)
+
+
+def _confirmed_keys(items: Sequence[Mapping[str, Any]], unresolved: Sequence[Mapping[str, Any]]) -> list[str]:
+    unresolved_keys: set[str] = set()
+    for u in unresolved or []:
+        obj = u.get("item") if isinstance(u, Mapping) else None
+        if isinstance(obj, Mapping):
+            try:
+                unresolved_keys.add(canonical_key(id_minimal(obj)))
+            except Exception:
+                pass
+    out: list[str] = []
+    seen: set[str] = set()
+    for it in items or []:
+        try:
+            k = canonical_key(id_minimal(it))
+        except Exception:
+            k = ""
+        if not k or k in seen or k in unresolved_keys:
+            continue
+        seen.add(k)
+        out.append(k)
+    return out
+
+
+def _guard_writable(pl: Any) -> None:
+    if _is_smart(pl):
+        raise SmartPlaylistError("cannot write to a plex smart playlist")
+    if _playlist_type(pl) not in ("", "video"):
+        raise PlaylistError("plex playlist is not a video playlist")
+
+
+def add(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    if _is_watchlist_id(playlist_id):
+        lst = list(items or [])
+        count, unresolved = feat_watchlist.add(adapter, lst)
+        return {"ok": True, "count": int(count or 0), "unresolved": unresolved, "confirmed_keys": _confirmed_keys(lst, unresolved)}
+
+    srv = _server(adapter)
+    if _is_collection_id(playlist_id):
+        section, coll = _find_collection(srv, playlist_id)
+        resource = _resource_from_collection(adapter, section, coll)
+        if resource is None:
+            raise PlaylistNotFound(f"plex collection not supported: {playlist_id}")
+        if resource.is_smart:
+            raise SmartPlaylistError("cannot write to a plex smart collection")
+        subtype = str(resource.extra.get("subtype") or "").strip().lower()
+        section_id = str(resource.extra.get("section_id") or "").strip()
+        allow = {section_id} if section_id else None
+        resolved, confirmed, unresolved = _resolve_items(
+            srv,
+            list(items or []),
+            accept={subtype},
+            allow=allow,
+            missing_hint="not_in_library",
+        )
+        added = 0
+        if resolved:
+            try:
+                coll.addItems(resolved)
+                added = len(resolved)
+            except Exception as e:
+                _warn("collection_add_failed", list_id=resource.id, error=str(e))
+                for obj in resolved:
+                    unresolved.append({"item": plex_normalize(obj), "hint": "add_failed"})
+                confirmed = []
+                added = 0
+        _info("write_done", op="add", list_id=resource.id, applied=added, unresolved=len(unresolved))
+        return {"ok": True, "count": added, "unresolved": unresolved, "confirmed_keys": confirmed}
+
+    pl = _find_playlist(srv, playlist_id)
+    _guard_writable(pl)
+
+    resolved, confirmed, unresolved = _resolve_items(srv, list(items or []))
+    added = 0
+    if resolved:
+        try:
+            pl.addItems(resolved)
+            added = len(resolved)
+        except Exception as e:
+            _warn("add_failed", list_id=str(playlist_id), error=str(e))
+            for obj in resolved:
+                unresolved.append({"item": plex_normalize(obj), "hint": "add_failed"})
+            confirmed = []
+            added = 0
+    _info("write_done", op="add", list_id=str(playlist_id), applied=added, unresolved=len(unresolved))
+    return {"ok": True, "count": added, "unresolved": unresolved, "confirmed_keys": confirmed}
+
+
+def remove(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    if _is_watchlist_id(playlist_id):
+        lst = list(items or [])
+        count, unresolved = feat_watchlist.remove(adapter, lst)
+        return {"ok": True, "count": int(count or 0), "unresolved": unresolved, "confirmed_keys": _confirmed_keys(lst, unresolved)}
+
+    srv = _server(adapter)
+    if _is_collection_id(playlist_id):
+        section, coll = _find_collection(srv, playlist_id)
+        resource = _resource_from_collection(adapter, section, coll)
+        if resource is None:
+            raise PlaylistNotFound(f"plex collection not supported: {playlist_id}")
+        if resource.is_smart:
+            raise SmartPlaylistError("cannot write to a plex smart collection")
+        wanted: set[str] = set()
+        for raw in items or []:
+            try:
+                wanted.add(canonical_key(id_minimal(raw)))
+            except Exception:
+                continue
+        try:
+            current = list(coll.items() or [])
+        except Exception as e:
+            _warn("collection_remove_failed", list_id=resource.id, error=str(e))
+            current = []
+        present: dict[str, Any] = {}
+        for obj in current:
+            k = _obj_key(obj)
+            if k and k not in present:
+                present[k] = obj
+        removed = 0
+        confirmed: list[str] = []
+        unresolved: list[dict[str, Any]] = []
+        for key in wanted:
+            obj = present.get(key)
+            if obj is None:
+                unresolved.append({"item": {"key": key}, "hint": "not_in_collection"})
+                continue
+            try:
+                coll.removeItems(obj)
+                removed += 1
+                confirmed.append(key)
+            except Exception as e:
+                _warn("collection_remove_item_failed", list_id=resource.id, error=str(e))
+                unresolved.append({"item": {"key": key}, "hint": "remove_failed"})
+        _info("write_done", op="remove", list_id=resource.id, applied=removed, unresolved=len(unresolved))
+        return {"ok": True, "count": removed, "unresolved": unresolved, "confirmed_keys": confirmed}
+
+    pl = _find_playlist(srv, playlist_id)
+    _guard_writable(pl)
+
+    wanted: set[str] = set()
+    for raw in items or []:
+        try:
+            wanted.add(canonical_key(id_minimal(raw)))
+        except Exception:
+            continue
+
+    removed = 0
+    confirmed: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    try:
+        current = list(pl.items() or [])
+    except Exception as e:
+        _warn("remove_failed", list_id=str(playlist_id), error=str(e))
+        current = []
+
+    present: dict[str, Any] = {}
+    for obj in current:
+        k = _obj_key(obj)
+        if k and k not in present:
+            present[k] = obj
+
+    for key in wanted:
+        obj = present.get(key)
+        if obj is None:
+            unresolved.append({"item": {"key": key}, "hint": "not_in_playlist"})
+            continue
+        try:
+            pl.removeItems(obj)
+            removed += 1
+            confirmed.append(key)
+        except Exception as e:
+            _warn("remove_item_failed", list_id=str(playlist_id), error=str(e))
+            unresolved.append({"item": {"key": key}, "hint": "remove_failed"})
+
+    _info("write_done", op="remove", list_id=str(playlist_id), applied=removed, unresolved=len(unresolved))
+    return {"ok": True, "count": removed, "unresolved": unresolved, "confirmed_keys": confirmed}
+
+
+def reorder(adapter: Any, playlist_id: Any, ordered_keys: Sequence[str]) -> dict[str, Any]:
+    if _is_watchlist_id(playlist_id):
+        return {"ok": True, "count": 0, "reordered": 0, "unsupported": True}
+    if _is_collection_id(playlist_id):
+        return {"ok": True, "count": 0, "reordered": 0, "unsupported": True}
+
+    srv = _server(adapter)
+    pl = _find_playlist(srv, playlist_id)
+    _guard_writable(pl)
+
+    try:
+        current = list(pl.items() or [])
+    except Exception as e:
+        _warn("reorder_failed", list_id=str(playlist_id), error=str(e))
+        return {"ok": False, "count": 0, "reordered": 0, "error": str(e)}
+
+    cur_keys = [_obj_key(o) for o in current]
+    obj_by_key: dict[str, Any] = {}
+    for k, o in zip(cur_keys, current):
+        if k and k not in obj_by_key:
+            obj_by_key[k] = o
+
+    target = [k for k in (ordered_keys or []) if k in obj_by_key]
+    work = [k for k in cur_keys if k]
+    moves = 0
+    for i, k in enumerate(target):
+        if i < len(work) and work[i] == k:
+            continue
+        after = obj_by_key[target[i - 1]] if i > 0 else None
+        try:
+            pl.moveItem(obj_by_key[k], after=after)
+        except TypeError:
+            pl.moveItem(obj_by_key[k], after)
+        moves += 1
+        try:
+            work.remove(k)
+        except ValueError:
+            pass
+        work.insert(i, k)
+
+    _info("reorder_done", list_id=str(playlist_id), moves=moves)
+    return {"ok": True, "count": moves, "reordered": moves}

--- a/providers/sync/publicmetadb/_playlists.py
+++ b/providers/sync/publicmetadb/_playlists.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from cw_platform.playlists import PLAYLIST_KIND_REGULAR, PlaylistItem, PlaylistResource, PlaylistSnapshot
+
+from .._log import log as cw_log
+from ._common import as_int, tmdb_id_for_item
+
+_PROVIDER = "PUBLICMETADB"
+_FEATURE = "playlists"
+_MEDIA_TYPES = ("movie", "show")
+
+
+class PublicMetaDBPlaylistError(RuntimeError):
+    pass
+
+
+class PublicMetaDBPlaylistNotFound(PublicMetaDBPlaylistError):
+    pass
+
+
+def _info(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "info", event, **fields)
+
+
+def _warn(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "warn", event, **fields)
+
+
+def _instance_id(adapter: Any) -> str:
+    inst = getattr(adapter, "instance_id", None)
+    return str(inst).strip() if inst else "default"
+
+
+def _rows(data: Any) -> list[Any]:
+    if isinstance(data, list):
+        return data
+    if not isinstance(data, Mapping):
+        return []
+    for key in ("items", "results", "data", "lists"):
+        val = data.get(key)
+        if isinstance(val, list):
+            return val
+    return []
+
+
+def _total_pages(data: Any, page: int) -> int:
+    if not isinstance(data, Mapping):
+        return page
+    for key in ("totalPages", "total_pages", "pages", "pageCount"):
+        value = as_int(data.get(key))
+        if value is not None:
+            return max(page, value)
+    pagination = data.get("pagination")
+    if isinstance(pagination, Mapping):
+        for key in ("totalPages", "total_pages", "pages", "pageCount"):
+            value = as_int(pagination.get(key))
+            if value is not None:
+                return max(page, value)
+    return page
+
+
+def _norm_type(value: Any) -> str:
+    s = str(value or "").strip().lower()
+    if s in ("show", "shows", "series", "tv"):
+        return "show"
+    return "movie"
+
+
+def _supported_type(value: Any) -> str | None:
+    s = str(value or "").strip().lower()
+    if s in ("show", "shows", "series", "tv"):
+        return "show"
+    if s in ("movie", "movies", "film"):
+        return "movie"
+    return None
+
+
+def _resource_from_row(adapter: Any, row: Mapping[str, Any]) -> PlaylistResource | None:
+    raw_id = str(row.get("id") or row.get("list_id") or "").strip()
+    if not raw_id:
+        return None
+    name = str(row.get("name") or row.get("title") or "").strip() or raw_id
+    count = as_int(row.get("item_count") or row.get("items_count") or row.get("items") or row.get("count"))
+    public_raw = row.get("is_public")
+    if public_raw is None:
+        public_raw = row.get("public")
+    return PlaylistResource(
+        provider=_PROVIDER,
+        id=raw_id,
+        name=name,
+        instance=_instance_id(adapter),
+        kind=PLAYLIST_KIND_REGULAR,
+        can_read=True,
+        can_add=True,
+        can_remove=True,
+        can_reorder=False,
+        media_types=_MEDIA_TYPES,
+        extra={
+            "endpoint_type": "playlist",
+            "raw_id": raw_id,
+            "item_count": count,
+            "private": not bool(public_raw),
+            "type": str(row.get("type") or "").strip().lower(),
+            "description": str(row.get("description") or "").strip(),
+        },
+    )
+
+
+def list_resources(adapter: Any) -> list[PlaylistResource]:
+    out: list[PlaylistResource] = []
+    page = 1
+    per_page = 500
+    while page <= 1000:
+        data = adapter.client.get_json("/api/external/lists", params={"page": page, "perPage": per_page})
+        rows = _rows(data)
+        if not rows:
+            break
+        for row in rows:
+            if not isinstance(row, Mapping):
+                continue
+            res = _resource_from_row(adapter, row)
+            if res:
+                out.append(res)
+        if page >= _total_pages(data, page):
+            break
+        page += 1
+    _info("list_resources_done", count=len(out))
+    return out
+
+
+def _find_resource(adapter: Any, playlist_id: Any) -> PlaylistResource | None:
+    lid = str(playlist_id or "").strip()
+    if not lid:
+        return None
+    for res in list_resources(adapter):
+        if res.id == lid:
+            return res
+    return None
+
+
+def _minimal_from_row(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    tmdb = tmdb_id_for_item(row)
+    if tmdb is None:
+        return None
+    typ = _norm_type(row.get("media_type") or row.get("type"))
+    out: dict[str, Any] = {"type": typ, "ids": {"tmdb": str(tmdb)}}
+    title = str(row.get("title") or row.get("name") or "").strip()
+    if title:
+        out["title"] = title
+    year = as_int(row.get("year") or row.get("release_year") or row.get("first_air_year"))
+    if year is not None:
+        out["year"] = year
+    return id_minimal(out)
+
+
+def _playlist_item_id(row: Mapping[str, Any]) -> str:
+    return str(row.get("id") or row.get("item_id") or row.get("list_item_id") or "").strip()
+
+
+def _fetch_items(adapter: Any, list_id: str) -> tuple[list[PlaylistItem], dict[str, str]]:
+    out: list[PlaylistItem] = []
+    remote_ids: dict[str, str] = {}
+    page = 1
+    per_page = int(getattr(adapter.cfg, "watchlist_page_size", 100) or 100)
+    per_page = max(1, min(per_page, 500))
+    while page <= 1000:
+        data = adapter.client.get_json(
+            f"/api/external/lists/{list_id}/items",
+            params={"page": page, "perPage": per_page},
+        )
+        rows = _rows(data)
+        if not rows:
+            break
+        for row in rows:
+            if not isinstance(row, Mapping):
+                continue
+            media = _minimal_from_row(row)
+            if not media:
+                continue
+            item_id = _playlist_item_id(row)
+            key = canonical_key(media)
+            if item_id:
+                remote_ids[key] = item_id
+            out.append(
+                PlaylistItem.from_media(
+                    media,
+                    playlist_item_id=item_id or None,
+                    position=None,
+                    provider_media_id=item_id or str(tmdb_id_for_item(media) or ""),
+                )
+            )
+        if page >= _total_pages(data, page):
+            break
+        page += 1
+    return out, remote_ids
+
+
+def get_snapshot(adapter: Any, playlist_id: Any) -> PlaylistSnapshot:
+    lid = str(playlist_id or "").strip()
+    if not lid:
+        raise PublicMetaDBPlaylistNotFound("missing publicmetadb list id")
+    resource = _find_resource(adapter, lid)
+    if resource is None:
+        resource = PlaylistResource(
+            provider=_PROVIDER,
+            id=lid,
+            name=lid,
+            instance=_instance_id(adapter),
+            kind=PLAYLIST_KIND_REGULAR,
+            can_read=True,
+            can_add=True,
+            can_remove=True,
+            can_reorder=False,
+            media_types=_MEDIA_TYPES,
+            extra={"endpoint_type": "playlist", "raw_id": lid},
+        )
+    items, _remote_ids = _fetch_items(adapter, lid)
+    _info("snapshot_done", list_id=lid, count=len(items))
+    return PlaylistSnapshot(resource=resource, items=items, checkpoint=None)
+
+
+def create(
+    adapter: Any,
+    name: str,
+    *,
+    media_type: str | None = None,
+    items: Sequence[Mapping[str, Any]] | None = None,
+    dry_run: bool = False,
+) -> PlaylistResource:
+    nm = str(name or "").strip()
+    if not nm:
+        raise ValueError("playlist name required")
+    if dry_run:
+        return PlaylistResource(
+            provider=_PROVIDER,
+            id="",
+            name=nm,
+            instance=_instance_id(adapter),
+            kind=PLAYLIST_KIND_REGULAR,
+            can_add=True,
+            can_remove=True,
+            can_reorder=False,
+            media_types=_MEDIA_TYPES,
+            extra={"endpoint_type": "playlist"},
+        )
+    data = adapter.client.post_json(
+        "/api/external/lists",
+        json={"name": nm, "description": "", "is_public": False, "type": "list"},
+    )
+    item = data.get("item") if isinstance(data, Mapping) else None
+    row = dict(item) if isinstance(item, Mapping) else dict(data) if isinstance(data, Mapping) else {}
+    row.setdefault("name", nm)
+    res = _resource_from_row(adapter, row)
+    if res is None:
+        raise PublicMetaDBPlaylistError("publicmetadb create list returned no id")
+    _info("create_done", list_id=res.id, name=res.name)
+    if items:
+        add(adapter, res.id, items)
+    return res
+
+
+def _accepted_items(items: Sequence[Mapping[str, Any]]) -> tuple[list[dict[str, Any]], list[str], list[dict[str, Any]]]:
+    accepted: list[dict[str, Any]] = []
+    keys: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in items or []:
+        media = id_minimal(raw)
+        typ = _supported_type(media.get("type"))
+        if typ is None:
+            unresolved.append({"item": media, "hint": "unsupported_media_type"})
+            continue
+        tmdb = tmdb_id_for_item(media)
+        if tmdb is None:
+            unresolved.append({"item": media, "hint": "missing_tmdb_id"})
+            continue
+        key = canonical_key(media)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        accepted.append({"tmdb_id": int(tmdb), "media_type": "tv" if typ == "show" else "movie"})
+        keys.append(key)
+    return accepted, keys, unresolved
+
+
+def add(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    lid = str(playlist_id or "").strip()
+    if not lid:
+        raise PublicMetaDBPlaylistNotFound("missing publicmetadb list id")
+    accepted, keys, unresolved = _accepted_items(list(items or []))
+    ok = 0
+    confirmed: list[str] = []
+    for idx, payload in enumerate(accepted):
+        r = adapter.client.post(f"/api/external/lists/{lid}/items", json=payload)
+        if 200 <= r.status_code < 300:
+            ok += 1
+            if idx < len(keys):
+                confirmed.append(keys[idx])
+        else:
+            key = keys[idx] if idx < len(keys) else ""
+            unresolved.append({"item": {"key": key}, "hint": f"http:{r.status_code}", "index": idx})
+    _info("write_done", op="add", list_id=lid, applied=ok, unresolved=len(unresolved))
+    return {"ok": True, "count": ok, "unresolved": unresolved, "confirmed_keys": confirmed}
+
+
+def remove(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    lid = str(playlist_id or "").strip()
+    if not lid:
+        raise PublicMetaDBPlaylistNotFound("missing publicmetadb list id")
+    _current, remote_ids = _fetch_items(adapter, lid)
+    unresolved: list[dict[str, Any]] = []
+    ok = 0
+    confirmed: list[str] = []
+    for raw in items or []:
+        media = id_minimal(raw)
+        typ = _supported_type(media.get("type"))
+        if typ is None:
+            unresolved.append({"item": media, "hint": "unsupported_media_type"})
+            continue
+        tmdb = tmdb_id_for_item(media)
+        if tmdb is None:
+            unresolved.append({"item": media, "hint": "missing_tmdb_id"})
+            continue
+        key = canonical_key(media)
+        item_id = remote_ids.get(key)
+        if not item_id:
+            unresolved.append({"item": media, "hint": "missing_remote_item_id"})
+            continue
+        r = adapter.client.delete(f"/api/external/lists/{lid}/items/{item_id}")
+        if 200 <= r.status_code < 300:
+            ok += 1
+            confirmed.append(key)
+        else:
+            unresolved.append({"item": media, "hint": f"http:{r.status_code}"})
+    _info("write_done", op="remove", list_id=lid, applied=ok, unresolved=len(unresolved))
+    return {"ok": True, "count": ok, "unresolved": unresolved, "confirmed_keys": confirmed}
+
+
+def reorder(adapter: Any, playlist_id: Any, ordered_keys: Sequence[str]) -> dict[str, Any]:
+    return {"ok": True, "count": 0, "reordered": 0, "unsupported": True}

--- a/providers/sync/simkl/_playlists.py
+++ b/providers/sync/simkl/_playlists.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Sequence
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from cw_platform.playlists import PLAYLIST_KIND_REGULAR, PlaylistItem, PlaylistResource, PlaylistSnapshot
+
+from .._log import log as cw_log
+from ._common import (
+    SIMKLFetchError,
+    adapter_headers,
+    extract_latest_ts,
+    fetch_activities,
+    simkl_api_params_from_headers,
+    key_of as simkl_key_of,
+)
+from . import _watchlist as feat_watchlist
+
+_PROVIDER = "SIMKL"
+_FEATURE = "playlists"
+BASE = "https://api.simkl.com"
+URL_STATUS = f"{BASE}/sync/all-items/{{bucket}}/{{status}}"
+URL_ADD = f"{BASE}/sync/add-to-list"
+URL_REMOVE = f"{BASE}/sync/history/remove"
+SIMKL_STATUS_WARNING = "SIMKL Custom Lists are not supported. These endpoints use SIMKL's built in status buckets, which are not true playlists. Changes may move or remove items from your SIMKL library. Use with caution."
+SIMKL_REMOVE_WARNING = "Removing from a SIMKL status bucket removes the item from the full SIMKL library and clears its SIMKL rating."
+
+_STATUS_ROWS: tuple[tuple[str, str, tuple[str, ...], tuple[str, ...]], ...] = (
+    ("plantowatch", "Plan to Watch", ("movie", "show", "anime"), ("movies", "shows", "anime")),
+    ("watching", "Watching", ("show", "anime"), ("shows", "anime")),
+    ("hold", "On Hold", ("show", "anime"), ("shows", "anime")),
+    ("dropped", "Dropped", ("movie", "show", "anime"), ("movies", "shows", "anime")),
+    ("completed", "Completed", ("movie", "show", "anime"), ("movies", "shows", "anime")),
+)
+_STATUS_META = {status: {"label": label, "media_types": media, "buckets": buckets} for status, label, media, buckets in _STATUS_ROWS}
+_MOVIE_BLOCKED_STATUSES = {"watching", "hold"}
+
+
+class SIMKLPlaylistError(RuntimeError):
+    pass
+
+
+class SIMKLPlaylistNotFound(SIMKLPlaylistError):
+    pass
+
+
+def _info(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "info", event, **fields)
+
+
+def _warn(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "warn", event, **fields)
+
+
+def _instance_id(adapter: Any) -> str:
+    inst = getattr(adapter, "instance_id", None)
+    return str(inst).strip() if inst else "default"
+
+
+def _status(value: Any) -> str:
+    raw = value.id if isinstance(value, PlaylistResource) else value
+    status = str(raw or "").strip().lower()
+    if status not in _STATUS_META:
+        raise SIMKLPlaylistNotFound("unknown simkl status bucket")
+    return status
+
+
+def _resource(adapter: Any, status: str) -> PlaylistResource:
+    meta = _STATUS_META[_status(status)]
+    return PlaylistResource(
+        provider=_PROVIDER,
+        id=status,
+        name=str(meta["label"]),
+        instance=_instance_id(adapter),
+        kind=PLAYLIST_KIND_REGULAR,
+        can_read=True,
+        can_add=True,
+        can_remove=True,
+        can_reorder=False,
+        media_types=tuple(meta["media_types"]),
+        extra={
+            "endpoint_type": "status_bucket",
+            "status": status,
+            "fixed": True,
+            "can_create": False,
+            "can_rename": False,
+            "can_delete": False,
+            "custom_lists_supported": False,
+            "destructive_remove": True,
+            "remove_warning": SIMKL_REMOVE_WARNING,
+            "warnings": [SIMKL_STATUS_WARNING],
+        },
+    )
+
+
+def list_resources(adapter: Any) -> list[PlaylistResource]:
+    out = [_resource(adapter, status) for status, _label, _media, _buckets in _STATUS_ROWS]
+    _info("list_resources_done", count=len(out))
+    return out
+
+
+def _response_json(resp: Any) -> Any:
+    try:
+        return resp.json() if getattr(resp, "text", "") else {}
+    except Exception:
+        return {}
+
+
+def _read_bucket(adapter: Any, bucket: str, status: str) -> list[PlaylistItem]:
+    headers = adapter_headers(adapter)
+    params = simkl_api_params_from_headers(headers, extended="full")
+    if bucket == "anime":
+        params["extended"] = "full_anime_seasons"
+    if bucket in ("shows", "anime"):
+        params["episode_watched_at"] = "yes"
+    url = URL_STATUS.format(bucket=bucket, status=status)
+    resp = adapter.client.session.get(url, headers=headers, params=params, timeout=getattr(adapter.cfg, "timeout", 15.0))
+    if not (200 <= int(getattr(resp, "status_code", 0) or 0) < 300):
+        raise SIMKLFetchError(f"simkl playlist read failed: {getattr(resp, 'status_code', 0)}")
+    rows = feat_watchlist._rows_from_data(_response_json(resp), bucket)
+    items: list[PlaylistItem] = []
+    for row in rows:
+        media = feat_watchlist._normalize_row(bucket, row)
+        if not media:
+            continue
+        media["simkl_bucket"] = bucket
+        media["simkl_status"] = status
+        item = PlaylistItem.from_media(
+            media,
+            position=None,
+            provider_media_id=str((media.get("ids") or {}).get("simkl") or ""),
+            playlist_item_id=str((media.get("ids") or {}).get("simkl") or ""),
+        )
+        item.item["simkl_bucket"] = bucket
+        item.item["simkl_status"] = status
+        if item.key:
+            items.append(item)
+    return items
+
+
+def _checkpoint(adapter: Any, status: str) -> str | None:
+    try:
+        headers = adapter_headers(adapter)
+        acts, _rate = fetch_activities(adapter.client.session, headers, timeout=getattr(adapter.cfg, "timeout", 15.0))
+        if not isinstance(acts, Mapping):
+            return None
+        paths = []
+        for bucket in _STATUS_META[status]["buckets"]:
+            paths.append((str(bucket), status))
+        return extract_latest_ts(acts, paths)
+    except Exception:
+        return None
+
+
+def get_snapshot(adapter: Any, playlist_id: Any) -> PlaylistSnapshot:
+    status = _status(playlist_id)
+    items: list[PlaylistItem] = []
+    seen: set[str] = set()
+    for bucket in _STATUS_META[status]["buckets"]:
+        for item in _read_bucket(adapter, bucket, status):
+            if item.key in seen:
+                continue
+            seen.add(item.key)
+            items.append(item)
+    _info("snapshot_done", status=status, count=len(items))
+    return PlaylistSnapshot(resource=_resource(adapter, status), items=items, checkpoint=_checkpoint(adapter, status))
+
+
+def create(
+    adapter: Any,
+    name: str,
+    *,
+    media_type: str | None = None,
+    items: Sequence[Mapping[str, Any]] | None = None,
+    dry_run: bool = False,
+) -> PlaylistResource:
+    raise SIMKLPlaylistError("SIMKL status bucket endpoints cannot be created")
+
+
+def _item_bucket(item: Mapping[str, Any]) -> str:
+    bucket = str(item.get("simkl_bucket") or "").strip().lower()
+    if bucket in ("movies", "shows", "anime"):
+        return bucket
+    typ = str(item.get("type") or "").strip().lower()
+    if typ == "movie":
+        return "movies"
+    if typ == "anime":
+        return "anime"
+    raw_ids = item.get("ids")
+    ids: Mapping[str, Any] = raw_ids if isinstance(raw_ids, Mapping) else {}
+    if any(ids.get(k) for k in ("mal", "anilist", "kitsu", "anidb")):
+        return "anime"
+    return "shows"
+
+
+def _ids(media: Mapping[str, Any]) -> dict[str, Any]:
+    raw = media.get("ids") if isinstance(media.get("ids"), Mapping) else {}
+    return feat_watchlist._ids_filter(raw or {})
+
+
+def _accepted_items(items: Sequence[Mapping[str, Any]], status: str) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any]], list[dict[str, Any]]]:
+    body: dict[str, list[dict[str, Any]]] = {"movies": [], "shows": []}
+    accepted: list[dict[str, Any]] = []
+    unresolved: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in items or []:
+        bucket = _item_bucket(raw)
+        media = id_minimal(raw)
+        if bucket in ("movies", "shows", "anime"):
+            media["simkl_bucket"] = bucket
+        if raw.get("simkl_status"):
+            media["simkl_status"] = raw.get("simkl_status")
+        if bucket == "movies" and status in _MOVIE_BLOCKED_STATUSES:
+            unresolved.append({"item": media, "hint": "unsupported_media_type"})
+            continue
+        ids = _ids(media)
+        if not ids:
+            unresolved.append({"item": media, "hint": "missing_simkl_supported_id"})
+            continue
+        key = canonical_key(media)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        entry = {"ids": ids, "to": status}
+        body["movies" if bucket == "movies" else "shows"].append(entry)
+        accepted.append({"key": key, "item": media, "ids": ids, "bucket": bucket})
+    return {k: v for k, v in body.items() if v}, accepted, unresolved
+
+
+def _id_sig(ids: Mapping[str, Any]) -> str:
+    return feat_watchlist._id_sig(ids)
+
+
+def _walk_mappings(obj: Any) -> Iterable[Mapping[str, Any]]:
+    if isinstance(obj, Mapping):
+        yield obj
+        for value in obj.values():
+            yield from _walk_mappings(value)
+    elif isinstance(obj, list):
+        for value in obj:
+            yield from _walk_mappings(value)
+
+
+def _response_status_by_sig(body: Any) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for row in _walk_mappings(body):
+        ids = row.get("ids") if isinstance(row.get("ids"), Mapping) else None
+        if not ids:
+            continue
+        status = str(row.get("status") or row.get("to") or row.get("watchlist_status") or row.get("list") or row.get("result_status") or "").strip().lower()
+        if status:
+            out[_id_sig(ids)] = status
+    return out
+
+
+def _confirmed_from_response(body: Any, accepted: Sequence[Mapping[str, Any]], status: str) -> tuple[list[str], list[dict[str, Any]]]:
+    processed = feat_watchlist._sigs_from_write_resp(body)
+    status_by_sig = _response_status_by_sig(body)
+    processed_count = feat_watchlist._sum_processed_from_body(body)
+    confirmed: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    for row in accepted:
+        raw_ids = row.get("ids")
+        ids: Mapping[str, Any] = raw_ids if isinstance(raw_ids, Mapping) else {}
+        sig = _id_sig(ids)
+        actual = status_by_sig.get(sig, "")
+        if actual and actual != status:
+            unresolved.append({"item": row.get("item") or {}, "hint": f"status_rewritten:{actual}", "actual_status": actual})
+            continue
+        if processed and sig not in processed:
+            unresolved.append({"item": row.get("item") or {}, "hint": "not_confirmed"})
+            continue
+        if not processed and processed_count and len(accepted) != processed_count:
+            unresolved.append({"item": row.get("item") or {}, "hint": "not_confirmed"})
+            continue
+        confirmed.append(str(row.get("key") or ""))
+    return [k for k in confirmed if k], unresolved
+
+
+def _write_status_shadow(status: str, accepted: Sequence[Mapping[str, Any]], confirmed: Sequence[str]) -> None:
+    rows = [dict(x.get("item") or {}) for x in accepted if str(x.get("key") or "") in set(confirmed)]
+    if not rows:
+        return
+    if status == "plantowatch":
+        try:
+            feat_watchlist._shadow_add_items(rows)
+        except Exception:
+            pass
+    else:
+        try:
+            feat_watchlist._shadow_remove_keys(confirmed)
+        except Exception:
+            pass
+    try:
+        feat_watchlist._unfreeze_if_present(confirmed)
+    except Exception:
+        pass
+
+
+def add(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    status = _status(playlist_id)
+    body, accepted, unresolved = _accepted_items(list(items or []), status)
+    if not accepted:
+        return {"ok": True, "count": 0, "unresolved": unresolved, "confirmed_keys": []}
+    headers = adapter_headers(adapter)
+    resp = adapter.client.session.post(URL_ADD, headers=headers, params=simkl_api_params_from_headers(headers), json=body, timeout=getattr(adapter.cfg, "timeout", 15.0))
+    data = _response_json(resp)
+    if not (200 <= int(getattr(resp, "status_code", 0) or 0) < 300):
+        unresolved.extend({"item": row.get("item") or {}, "hint": f"http:{getattr(resp, 'status_code', 0)}"} for row in accepted)
+        return {"ok": False, "count": 0, "unresolved": unresolved, "confirmed_keys": []}
+    confirmed, rewritten = _confirmed_from_response(data, accepted, status)
+    unresolved.extend(rewritten)
+    _write_status_shadow(status, accepted, confirmed)
+    _info("write_done", op="add", status=status, applied=len(confirmed), unresolved=len(unresolved))
+    return {"ok": True, "count": len(confirmed), "unresolved": unresolved, "confirmed_keys": confirmed}
+
+
+def _remove_payload(items: Sequence[Mapping[str, Any]], status: str) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any]], list[dict[str, Any]]]:
+    body, accepted, unresolved = _accepted_items(items, status)
+    for rows in body.values():
+        for row in rows:
+            row.pop("to", None)
+    return body, accepted, unresolved
+
+
+def remove(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    status = _status(playlist_id)
+    body, accepted, unresolved = _remove_payload(list(items or []), status)
+    keys = [str(x.get("key") or "") for x in accepted if x.get("key")]
+    if not keys:
+        return {"ok": True, "count": 0, "unresolved": unresolved, "confirmed_keys": [], "warnings": [SIMKL_REMOVE_WARNING]}
+    headers = adapter_headers(adapter)
+    resp = adapter.client.session.post(URL_REMOVE, headers=headers, params=simkl_api_params_from_headers(headers), json=body, timeout=getattr(adapter.cfg, "timeout", 15.0))
+    data = _response_json(resp)
+    if not (200 <= int(getattr(resp, "status_code", 0) or 0) < 300):
+        unresolved.extend({"item": {"key": key}, "hint": f"http:{getattr(resp, 'status_code', 0)}"} for key in keys)
+        return {"ok": False, "count": 0, "unresolved": unresolved, "confirmed_keys": [], "warnings": [SIMKL_REMOVE_WARNING]}
+    processed = feat_watchlist._sigs_from_write_resp(data)
+    processed_count = feat_watchlist._sum_processed_from_body(data)
+    confirmed = keys if not processed and (processed_count == 0 or processed_count == len(keys)) else []
+    if processed and accepted:
+        by_sig = {_id_sig(x.get("ids") or {}): str(x.get("key") or "") for x in accepted if isinstance(x.get("ids"), Mapping)}
+        confirmed = [key for sig, key in by_sig.items() if sig in processed and key]
+    try:
+        feat_watchlist._shadow_remove_keys(confirmed)
+        feat_watchlist._unfreeze_if_present(confirmed)
+    except Exception:
+        pass
+    _info("write_done", op="remove", status=status, applied=len(confirmed), unresolved=len(unresolved))
+    return {"ok": True, "count": len(confirmed), "unresolved": unresolved, "confirmed_keys": confirmed, "warnings": [SIMKL_REMOVE_WARNING]}
+
+
+def reorder(adapter: Any, playlist_id: Any, ordered_keys: Sequence[str]) -> dict[str, Any]:
+    return {"ok": True, "count": 0, "reordered": 0, "unsupported": True}

--- a/providers/sync/trakt/_playlists.py
+++ b/providers/sync/trakt/_playlists.py
@@ -1,0 +1,477 @@
+# /providers/sync/trakt/_playlists.py
+# TRAKT Module for playlist sync functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import time
+from typing import Any, Iterable, Mapping, Sequence
+
+from cw_platform.playlists import (
+    PLAYLIST_KIND_REGULAR,
+    PlaylistItem,
+    PlaylistResource,
+    PlaylistSnapshot,
+)
+
+from ._common import (
+    build_watchlist_body,
+    headers_for_adapter,
+    key_of,
+    normalize_watchlist_row,
+    _chunk,
+    _record_limit_error,
+)
+from . import _watchlist as feat_watchlist
+from ._watchlist import _batch_payload, _record_not_found
+from .._mod_common import request_with_retries
+from .._log import log as cw_log
+
+BASE = "https://api.trakt.tv"
+_PROVIDER = "TRAKT"
+_FEATURE = "playlists"
+_SUPPORTED_TYPES = ("movie", "show", "season", "episode")
+WATCHLIST_ID = "__watchlist__"
+
+_SETTINGS_MEMO: tuple[float, dict[str, Any] | None] = (0.0, None)
+
+
+def _dbg(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "debug", event, **fields)
+
+
+def _info(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "info", event, **fields)
+
+
+def _warn(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "warn", event, **fields)
+
+
+class TraktCapacityError(RuntimeError):
+    def __init__(self, message: str, *, scope: str, upgrade_url: str | None = None) -> None:
+        super().__init__(message)
+        self.scope = scope
+        self.upgrade_url = upgrade_url
+
+
+def _instance_id(adapter: Any) -> str:
+    inst = getattr(adapter, "instance_id", None)
+    return str(inst).strip() if inst else "default"
+
+
+def _list_id(resource_or_id: Any) -> str:
+    if isinstance(resource_or_id, PlaylistResource):
+        return resource_or_id.id
+    return str(resource_or_id or "").strip()
+
+
+def _is_watchlist_id(resource_or_id: Any) -> bool:
+    lid = _list_id(resource_or_id).strip().lower()
+    return lid in {WATCHLIST_ID, "watchlist", "trakt:watchlist"}
+
+
+def _watchlist_resource(adapter: Any) -> PlaylistResource:
+    return PlaylistResource(
+        provider=_PROVIDER,
+        id=WATCHLIST_ID,
+        name="Watchlist",
+        instance=_instance_id(adapter),
+        kind=PLAYLIST_KIND_REGULAR,
+        can_read=True,
+        can_add=True,
+        can_remove=True,
+        can_reorder=False,
+        media_types=("movies", "shows", "seasons", "episodes"),
+        extra={"builtin": "watchlist"},
+    )
+
+
+def _settings_limits(adapter: Any) -> dict[str, Any]:
+    global _SETTINGS_MEMO
+    now = time.time()
+    ts, cached = _SETTINGS_MEMO
+    if cached is not None and (now - ts) < 300.0:
+        return cached
+    limits: dict[str, Any] = {}
+    try:
+        r = adapter.client.get(f"{BASE}/users/settings")
+        if 200 <= r.status_code < 300 and (r.text or "").strip():
+            data = r.json()
+            raw = data.get("limits") if isinstance(data, Mapping) else None
+            if isinstance(raw, Mapping):
+                limits = dict(raw)
+    except Exception:
+        limits = {}
+    _SETTINGS_MEMO = (now, limits)
+    return limits
+
+
+def _list_item_limit(adapter: Any) -> int | None:
+    return _list_limit_field(adapter, "item_count")
+
+
+def _list_count_limit(adapter: Any) -> int | None:
+    return _list_limit_field(adapter, "count")
+
+
+def _list_limit_field(adapter: Any, field: str) -> int | None:
+    limits = _settings_limits(adapter)
+    lst = limits.get("list") if isinstance(limits, Mapping) else None
+    if isinstance(lst, Mapping):
+        raw = lst.get(field)
+        if raw is None:
+            return None
+        try:
+            v = int(raw)
+            return v if v > 0 else None
+        except Exception:
+            return None
+    return None
+
+
+def _resource_from_list(adapter: Any, row: Mapping[str, Any]) -> PlaylistResource | None:
+    ids = dict(row.get("ids") or {})
+    lid = ids.get("trakt")
+    if lid is None:
+        lid = ids.get("slug")
+    lid = str(lid or "").strip()
+    if not lid:
+        return None
+    return PlaylistResource(
+        provider=_PROVIDER,
+        id=lid,
+        name=str(row.get("name") or "").strip() or lid,
+        instance=_instance_id(adapter),
+        kind=PLAYLIST_KIND_REGULAR,
+        can_read=True,
+        can_add=True,
+        can_remove=True,
+        can_reorder=True,
+        media_types=("movies", "shows", "seasons", "episodes"),
+    )
+
+
+def list_resources(adapter: Any) -> list[PlaylistResource]:
+    sess = adapter.client.session
+    headers = headers_for_adapter(adapter)
+    out: list[PlaylistResource] = [_watchlist_resource(adapter)]
+    r = request_with_retries(
+        sess,
+        "GET",
+        f"{BASE}/users/me/lists",
+        headers=headers,
+        timeout=adapter.cfg.timeout,
+        max_retries=adapter.cfg.max_retries,
+    )
+    if r.status_code != 200:
+        _warn("http_failed", op="list_resources", status=r.status_code)
+        return out
+    data = r.json() if (r.text or "").strip() else []
+    for row in data or []:
+        if not isinstance(row, Mapping):
+            continue
+        res = _resource_from_list(adapter, row)
+        if res:
+            out.append(res)
+    _info("list_resources_done", count=len(out))
+    return out
+
+
+def get_snapshot(adapter: Any, playlist_id: Any) -> PlaylistSnapshot:
+    if _is_watchlist_id(playlist_id):
+        resource = _watchlist_resource(adapter)
+        idx = feat_watchlist.build_index(adapter) or {}
+        items = [PlaylistItem.from_media(m, position=i) for i, m in enumerate(idx.values()) if isinstance(m, Mapping)]
+        _info("snapshot_done", list_id=WATCHLIST_ID, count=len(items))
+        return PlaylistSnapshot(resource=resource, items=items, checkpoint=None)
+
+    lid = _list_id(playlist_id)
+    sess = adapter.client.session
+    headers = headers_for_adapter(adapter)
+
+    resource: PlaylistResource | None = None
+    for res in list_resources(adapter):
+        if res.id == lid or res.name == lid:
+            resource = res
+            lid = res.id
+            break
+    if resource is None:
+        resource = PlaylistResource(
+            provider=_PROVIDER,
+            id=lid,
+            name=lid,
+            instance=_instance_id(adapter),
+            can_add=True,
+            can_remove=True,
+            can_reorder=True,
+            media_types=("movies", "shows", "seasons", "episodes"),
+        )
+
+    items: list[PlaylistItem] = []
+    page = 1
+    per_page = 100
+    while page <= 1000:
+        r = request_with_retries(
+            sess,
+            "GET",
+            f"{BASE}/users/me/lists/{lid}/items",
+            headers=headers,
+            params={"page": page, "limit": per_page, "extended": "full"},
+            timeout=adapter.cfg.timeout,
+            max_retries=adapter.cfg.max_retries,
+        )
+        if r.status_code != 200:
+            _warn("http_failed", op="get_snapshot", status=r.status_code, list_id=lid)
+            break
+        rows = r.json() if (r.text or "").strip() else []
+        if not rows:
+            break
+        for row in rows:
+            if not isinstance(row, Mapping):
+                continue
+            typ = str(row.get("type") or "").lower()
+            if typ not in _SUPPORTED_TYPES:
+                continue
+            media = normalize_watchlist_row(row)
+            items.append(
+                PlaylistItem.from_media(
+                    media,
+                    playlist_item_id=row.get("id"),
+                    position=row.get("rank"),
+                    provider_media_id=(dict(media.get("ids") or {}).get("trakt")),
+                )
+            )
+        try:
+            page_count = int(r.headers.get("X-Pagination-Page-Count") or 0)
+        except Exception:
+            page_count = 0
+        if page_count and page >= page_count:
+            break
+        if len(rows) < per_page:
+            break
+        page += 1
+
+    items.sort(key=lambda it: (it.position is None, it.position if it.position is not None else 0))
+    _info("snapshot_done", list_id=lid, count=len(items))
+    return PlaylistSnapshot(resource=resource, items=items, checkpoint=None)
+
+
+def create(adapter: Any, name: str, *, media_type: str | None = None, dry_run: bool = False) -> PlaylistResource:
+    nm = str(name or "").strip()
+    if not nm:
+        raise ValueError("playlist name required")
+    if dry_run:
+        return PlaylistResource(
+            provider=_PROVIDER,
+            id="",
+            name=nm,
+            instance=_instance_id(adapter),
+            can_add=True,
+            can_remove=True,
+            can_reorder=True,
+            media_types=("movies", "shows", "seasons", "episodes"),
+        )
+
+    limit = _list_count_limit(adapter)
+    if limit is not None:
+        existing = len(list_resources(adapter))
+        if existing >= limit:
+            _record_limit_error("playlists")
+            raise TraktCapacityError("trakt list count limit reached", scope="list_count")
+
+    sess = adapter.client.session
+    headers = headers_for_adapter(adapter)
+    r = request_with_retries(
+        sess,
+        "POST",
+        f"{BASE}/users/me/lists",
+        headers=headers,
+        json={"name": nm, "privacy": "private"},
+        timeout=adapter.cfg.timeout,
+        max_retries=adapter.cfg.max_retries,
+    )
+    if r.status_code == 420:
+        _record_limit_error("playlists")
+        raise TraktCapacityError(
+            "trakt list count limit reached",
+            scope="list_count",
+            upgrade_url=r.headers.get("X-Upgrade-URL"),
+        )
+    if r.status_code not in (200, 201):
+        _warn("write_failed", op="create", status=r.status_code, body=((r.text or "")[:180]))
+        raise RuntimeError(f"trakt create list failed: http {r.status_code}")
+    data = r.json() if (r.text or "").strip() else {}
+    res = _resource_from_list(adapter, data if isinstance(data, Mapping) else {})
+    if res is None:
+        raise RuntimeError("trakt create list returned no id")
+    _info("create_done", list_id=res.id, name=res.name)
+    return res
+
+
+def _confirmed_keys(items: Iterable[Mapping[str, Any]], unresolved: list[dict[str, Any]]) -> list[str]:
+    ukeys: set[str] = set()
+    for u in unresolved or []:
+        obj = u.get("item") if isinstance(u, Mapping) else u
+        if isinstance(obj, Mapping):
+            try:
+                ukeys.add(key_of(obj))
+            except Exception:
+                pass
+    out: list[str] = []
+    seen: set[str] = set()
+    for it in items or []:
+        try:
+            k = key_of(it)
+        except Exception:
+            k = ""
+        if not k or k in seen or k in ukeys:
+            continue
+        seen.add(k)
+        out.append(k)
+    return out
+
+
+def _write(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]], *, op: str) -> dict[str, Any]:
+    if _is_watchlist_id(playlist_id):
+        lst = list(items or [])
+        count, unresolved = (feat_watchlist.add(adapter, lst) if op == "add" else feat_watchlist.remove(adapter, lst))
+        confirmed = _confirmed_keys(lst, unresolved)
+        return {"ok": True, "count": int(count or 0), "unresolved": unresolved, "confirmed_keys": confirmed}
+
+    lid = _list_id(playlist_id)
+    sess = adapter.client.session
+    headers = headers_for_adapter(adapter)
+    batch = 100
+
+    accepted, unresolved = _batch_payload(items)
+    if not accepted:
+        _info("write_skipped", op=op, reason="empty_payload", unresolved=len(unresolved))
+        return {"ok": True, "count": 0, "unresolved": unresolved, "confirmed_keys": []}
+
+    if op == "add":
+        limit = _list_item_limit(adapter)
+        if limit is not None:
+            try:
+                current = len(get_snapshot(adapter, lid).items)
+            except Exception:
+                current = 0
+            capacity = max(0, limit - current)
+            if capacity <= 0:
+                for x in accepted:
+                    unresolved.append({"item": x, "hint": "trakt_limit"})
+                _record_limit_error("playlists")
+                _warn("capacity", op=op, reason="list_item_limit", limit=limit, have=current)
+                return {"ok": False, "count": 0, "unresolved": unresolved, "confirmed_keys": [], "capacity": "list_item_count"}
+            if capacity < len(accepted):
+                overflow = accepted[capacity:]
+                accepted = accepted[:capacity]
+                for x in overflow:
+                    unresolved.append({"item": x, "hint": "trakt_limit"})
+
+    url = f"{BASE}/users/me/lists/{lid}/items"
+    if op == "remove":
+        url = f"{BASE}/users/me/lists/{lid}/items/remove"
+
+    ok = 0
+    capacity_hit = False
+    for sl in _chunk(accepted, batch):
+        payload = build_watchlist_body(sl)
+        if not payload:
+            continue
+        r = request_with_retries(
+            sess,
+            "POST",
+            url,
+            headers=headers,
+            json=payload,
+            timeout=adapter.cfg.timeout,
+            max_retries=adapter.cfg.max_retries,
+        )
+        if r.status_code in (200, 201):
+            d = r.json() if (r.text or "").strip() else {}
+            bucket = d.get("added") if op == "add" else (d.get("deleted") or d.get("removed"))
+            bucket = bucket or {}
+            ok += sum(int(bucket.get(k) or 0) for k in ("movies", "shows", "seasons", "episodes"))
+            _record_not_found(d.get("not_found") or {}, action=op, unresolved=unresolved)
+        elif r.status_code == 420:
+            capacity_hit = True
+            _record_limit_error("playlists")
+            _warn("capacity", op=op, status=420, upgrade_url=r.headers.get("X-Upgrade-URL"))
+            for x in sl:
+                unresolved.append({"item": x, "hint": "trakt_limit"})
+            break
+        else:
+            _warn("write_failed", op=op, status=r.status_code, body=((r.text or "")[:180]))
+            for x in sl:
+                unresolved.append({"item": x, "hint": f"http:{r.status_code}"})
+
+    confirmed = _confirmed_keys(accepted, unresolved)
+    out: dict[str, Any] = {
+        "ok": len([u for u in unresolved if u.get("hint") == "trakt_limit"]) == 0 or ok > 0,
+        "count": ok,
+        "unresolved": unresolved,
+        "confirmed_keys": confirmed,
+    }
+    if capacity_hit:
+        out["capacity"] = "list_item_count"
+    _info("write_done", op=op, list_id=lid, applied=ok, unresolved=len(unresolved))
+    return out
+
+
+def add(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    return _write(adapter, playlist_id, list(items or []), op="add")
+
+
+def remove(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    return _write(adapter, playlist_id, list(items or []), op="remove")
+
+
+def reorder(adapter: Any, playlist_id: Any, ordered_keys: Sequence[str]) -> dict[str, Any]:
+    if _is_watchlist_id(playlist_id):
+        return {"ok": True, "count": 0, "reordered": 0, "unsupported": True}
+
+    lid = _list_id(playlist_id)
+    snap = get_snapshot(adapter, lid)
+    key_to_item_id: dict[str, Any] = {}
+    for it in snap.items:
+        if it.key and it.playlist_item_id and it.key not in key_to_item_id:
+            key_to_item_id[it.key] = it.playlist_item_id
+
+    rank: list[Any] = []
+    seen: set[str] = set()
+    for k in ordered_keys or []:
+        ks = str(k or "").strip()
+        if not ks or ks in seen:
+            continue
+        seen.add(ks)
+        item_id = key_to_item_id.get(ks)
+        if item_id is not None:
+            rank.append(item_id)
+    for it in snap.items:
+        if it.key in seen:
+            continue
+        if it.playlist_item_id is not None:
+            rank.append(it.playlist_item_id)
+            seen.add(it.key)
+
+    if not rank:
+        return {"ok": True, "count": 0, "reordered": 0}
+
+    sess = adapter.client.session
+    headers = headers_for_adapter(adapter)
+    r = request_with_retries(
+        sess,
+        "POST",
+        f"{BASE}/users/me/lists/{lid}/items/reorder",
+        headers=headers,
+        json={"rank": rank},
+        timeout=adapter.cfg.timeout,
+        max_retries=adapter.cfg.max_retries,
+    )
+    if r.status_code not in (200, 201):
+        _warn("write_failed", op="reorder", status=r.status_code, body=((r.text or "")[:180]))
+        return {"ok": False, "count": 0, "reordered": 0, "error": f"http:{r.status_code}"}
+    d = r.json() if (r.text or "").strip() else {}
+    updated = int(d.get("updated") or 0) if isinstance(d, Mapping) else len(rank)
+    _info("reorder_done", list_id=lid, updated=updated)
+    return {"ok": True, "count": updated, "reordered": updated}


### PR DESCRIPTION
# Pull request

## Change

- Add playlist modules for Plex, Trakt, MDBList, Jellyfin, Emby, PublicMetaDB and SIMKL.
- Expose the playlist capability from each provider module so callers can discover which ones can list, add, remove or reorder.
- Add a playlist item move helper to the shared Emby client.

## Why

Playlists were the one feature with no provider support at all. This adds the read and write layer per provider behind a shared contract, so the platform and UI work that follows can treat every provider the same way instead of special casing each API.

## Testing

- Imported every provider module and checked the reported playlist capabilities.
- Ran the provider playlist tests for all seven providers.

## Issue

Relates to #439
