### PR TITLE
Add: playlists sync engine and API

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -14,6 +14,7 @@ from .animeMappingAPI import router as anime_mapping_router
 from .manualAPI import router as manual_router
 from .insightAPI import register_insights
 from .watchlistAPI import router as watchlist_router
+from .playlistsAPI import router as playlists_router
 from .snapshotsAPI import router as snapshots_router
 from .backupsAPI import router as backups_router
 from .schedulingAPI import router as scheduling_router
@@ -52,6 +53,7 @@ __all__ = [
     "anime_mapping_router",
     "manual_router",
     "watchlist_router",
+    "playlists_router",
     "snapshots_router",
     "backups_router",
     "scheduling_router",
@@ -90,6 +92,7 @@ def register(
     app.include_router(anime_mapping_router)
     app.include_router(manual_router)
     app.include_router(watchlist_router)
+    app.include_router(playlists_router)
     app.include_router(snapshots_router)
     app.include_router(backups_router)
     app.include_router(maintenance_router)

--- a/api/playlistsAPI.py
+++ b/api/playlistsAPI.py
@@ -1,0 +1,167 @@
+# /api/playlistsAPI.py
+# CrossWatch - Playlists API (endpoints, mapping profiles, preview, run)
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Body, Path as FPath, Query
+from fastapi.responses import JSONResponse
+
+from cw_platform.config_base import load_config
+from services import playlists as svc
+
+router = APIRouter(prefix="/api/playlists", tags=["playlists"])
+
+
+@router.get("/providers")
+def api_playlist_providers() -> JSONResponse:
+    cfg = load_config() or {}
+    return JSONResponse({"ok": True, "providers": svc.list_playlist_providers(cfg)})
+
+
+@router.get("/resources")
+def api_playlist_resources(
+    provider: str = Query(...),
+    instance: str | None = Query(None),
+) -> JSONResponse:
+    cfg = load_config() or {}
+    res = svc.list_resources(cfg, provider, instance)
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
+@router.get("/overview")
+def api_playlist_overview() -> JSONResponse:
+    cfg = load_config() or {}
+    return JSONResponse(svc.overview(cfg))
+
+
+# Endpoints
+
+@router.get("/endpoints")
+def api_playlist_endpoints() -> JSONResponse:
+    cfg = load_config() or {}
+    return JSONResponse({"ok": True, "endpoints": svc.list_endpoints(cfg)})
+
+
+@router.post("/endpoints")
+def api_playlist_endpoint_upsert(payload: dict[str, Any] = Body(...)) -> JSONResponse:
+    cfg = load_config() or {}
+    res = svc.upsert_endpoint(cfg, payload)
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
+@router.delete("/endpoints/{endpoint_id}")
+def api_playlist_endpoint_delete(endpoint_id: str = FPath(...)) -> JSONResponse:
+    cfg = load_config() or {}
+    res = svc.delete_endpoint(cfg, endpoint_id)
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
+@router.post("/endpoints/{endpoint_id}/sync")
+def api_playlist_endpoint_sync(endpoint_id: str = FPath(...)) -> JSONResponse:
+    cfg = load_config() or {}
+    res = svc.sync_endpoint(cfg, endpoint_id)
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
+@router.get("/activity")
+def api_playlist_activity() -> JSONResponse:
+    cfg = load_config() or {}
+    return JSONResponse({"ok": True, "activity": svc.activity(cfg)})
+
+
+@router.get("/rulesets")
+def api_playlist_rulesets() -> JSONResponse:
+    cfg = load_config() or {}
+    return JSONResponse({"ok": True, "rulesets": svc.list_rulesets(cfg)})
+
+
+@router.get("/rulesets/{ruleset_id}")
+def api_playlist_ruleset_get(ruleset_id: str = FPath(...)) -> JSONResponse:
+    cfg = load_config() or {}
+    rs = svc.get_ruleset(cfg, ruleset_id)
+    res = {"ok": bool(rs), "ruleset": rs, "error": None if rs else "ruleset not found"}
+    return JSONResponse(res, status_code=(200 if rs else 404))
+
+
+@router.post("/rulesets")
+def api_playlist_ruleset_upsert(payload: dict[str, Any] = Body(...)) -> JSONResponse:
+    cfg = load_config() or {}
+    res = svc.upsert_ruleset(cfg, payload.get("ruleset") or payload)
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
+@router.post("/rulesets/validate")
+def api_playlist_ruleset_validate(payload: dict[str, Any] = Body(...)) -> JSONResponse:
+    res = svc.validate_ruleset_payload(payload.get("ruleset") or payload)
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
+@router.post("/rulesets/{ruleset_id}/clone")
+def api_playlist_ruleset_clone(ruleset_id: str = FPath(...), payload: dict[str, Any] | None = Body(default=None)) -> JSONResponse:
+    cfg = load_config() or {}
+    res = svc.clone_ruleset(cfg, ruleset_id, payload or {})
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
+@router.delete("/rulesets/{ruleset_id}")
+def api_playlist_ruleset_delete(ruleset_id: str = FPath(...)) -> JSONResponse:
+    cfg = load_config() or {}
+    res = svc.delete_ruleset(cfg, ruleset_id)
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
+# Mapping profiles
+
+@router.get("/mappings")
+def api_playlist_mappings() -> JSONResponse:
+    cfg = load_config() or {}
+    return JSONResponse({"ok": True, "mappings": svc.list_mappings(cfg)})
+
+
+@router.post("/mappings")
+def api_playlist_mapping_upsert(payload: dict[str, Any] = Body(...)) -> JSONResponse:
+    cfg = load_config() or {}
+    res = svc.upsert_mapping(cfg, payload.get("mapping") or payload)
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
+@router.delete("/mappings/{mapping_id}")
+def api_playlist_mapping_delete(mapping_id: str = FPath(...)) -> JSONResponse:
+    cfg = load_config() or {}
+    res = svc.delete_mapping(cfg, mapping_id)
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
+@router.post("/mappings/{mapping_id}/preview")
+def api_playlist_mapping_preview(mapping_id: str = FPath(...)) -> JSONResponse:
+    cfg = load_config() or {}
+    res = svc.preview_mapping(cfg, mapping_id)
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
+@router.post("/mappings/{mapping_id}/run")
+def api_playlist_mapping_run(
+    mapping_id: str = FPath(...),
+    dry_run: bool = Query(False),
+) -> JSONResponse:
+    cfg = load_config() or {}
+    res = svc.run_mapping(cfg, mapping_id, dry_run=dry_run)
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
+@router.get("/mappings/{mapping_id}/result")
+def api_playlist_mapping_result(mapping_id: str = FPath(...)) -> JSONResponse:
+    cfg = load_config() or {}
+    res = svc.latest_result(cfg, mapping_id)
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
+# Pair-facing: compatible + available mappings for a given pair
+
+@router.get("/pairs/{pair_id}/mappings")
+def api_playlist_pair_mappings(pair_id: str = FPath(...)) -> JSONResponse:
+    cfg = load_config() or {}
+    res = svc.mappings_for_pair(cfg, pair_id)
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))

--- a/cw_platform/orchestrator/_pairs.py
+++ b/cw_platform/orchestrator/_pairs.py
@@ -18,6 +18,7 @@ from ._pairs_metrics import ApiMetrics, persist_api_totals
 from ..provider_instances import build_pair_config_view, build_provider_config_view, normalize_instance_id
 from ._pairs_oneway import run_one_way_feature
 from ._pairs_twoway import run_two_way_feature
+from ._pairs_playlists import run_playlist_mappings
 from ..value_coercion import coerce_bool
 
 def _deep_merge_provider_overrides(dst: dict[str, Any], src: Mapping[str, Any]) -> None:
@@ -436,7 +437,23 @@ def run_pairs(ctx) -> dict[str, Any]:
                     features_ran.add(feature)
 
                     try:
-                        if mode == "two-way":
+                        if feature == "playlists":
+                            res = run_playlist_mappings(
+                                ctx,
+                                src,
+                                dst,
+                                fcfg=fcfg,
+                                health_map=health_map,
+                                full_cfg=cfg,
+                                pair=pair,
+                            )
+                            added_total += int(res.get("added", 0))
+                            removed_total += int(res.get("removed", 0))
+                            updated_total += int(res.get("updated", 0))
+                            unresolved_total += int(res.get("unresolved", 0))
+                            skipped_total += int(res.get("skipped", 0))
+                            errors_total += int(res.get("errors", 0))
+                        elif mode == "two-way":
                             res = run_two_way_feature(ctx, src, dst, feature=feature, fcfg=fcfg, health_map=health_map)
                             updated_total += int(res.get("upd_to_A", 0)) + int(res.get("upd_to_B", 0))
                             added_total += int(res.get("adds_to_A", 0)) + int(res.get("adds_to_B", 0))

--- a/cw_platform/orchestrator/_pairs_playlists.py
+++ b/cw_platform/orchestrator/_pairs_playlists.py
@@ -1,0 +1,117 @@
+# cw_platform/orchestrator/_pairs_playlists.py
+# CrossWatch - Playlist mapping dispatch for the pair orchestrator
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ..playlists_runner import PlaylistRunError, resolve_pair_mappings, run_mapping
+
+
+def _emit(ctx, event: str, **fields: Any) -> None:
+    try:
+        ctx.emit(event, **fields)
+    except Exception:
+        pass
+
+
+def _record_playlist_stats(ctx, src: str, dst: str, totals: Mapping[str, Any]) -> None:
+    added = int(totals.get("added") or 0)
+    removed = int(totals.get("removed") or 0)
+    updated = int(totals.get("updated") or 0)
+    if not (added or removed or updated):
+        return
+    stats = getattr(ctx, "stats", None)
+    fn = getattr(stats, "record_feature_totals", None)
+    if not callable(fn):
+        fn = getattr(getattr(stats, "impl", None), "record_feature_totals", None)
+    if not callable(fn):
+        return
+    try:
+        fn(
+            "playlists",
+            added=added,
+            removed=removed,
+            updated=updated,
+            src=dst or src,
+            run_id=f"{src}->{dst}:playlists",
+        )
+    except Exception:
+        pass
+
+
+def run_playlist_mappings(
+    ctx,
+    src: str,
+    dst: str,
+    *,
+    fcfg: Mapping[str, Any],
+    health_map: Mapping[str, Any] | None = None,
+    full_cfg: Mapping[str, Any],
+    pair: Mapping[str, Any],
+) -> dict[str, Any]:
+    totals = {
+        "ok": True,
+        "added": 0,
+        "removed": 0,
+        "updated": 0,
+        "unresolved": 0,
+        "skipped": 0,
+        "errors": 0,
+        "mappings": 0,
+        "warnings": [],
+    }
+
+    resolved = resolve_pair_mappings(full_cfg, pair)
+    if not resolved:
+        _emit(ctx, "playlist:pair", src=src, dst=dst, mappings=0)
+        return totals
+
+    providers = ctx.providers or {}
+    dry_run = bool(getattr(ctx, "dry_run", False))
+
+    for mapping in resolved:
+        mapping_id = str(mapping.get("id") or "")
+        try:
+            res = run_mapping(
+                full_cfg,
+                mapping,
+                dry_run=dry_run,
+                providers=providers,
+                emit=ctx.emit,
+            )
+        except PlaylistRunError as e:
+            totals["errors"] += 1
+            _emit(ctx, "playlist:mapping:error", src=src, dst=dst, mapping=mapping_id, error=str(e))
+            continue
+        except Exception as e:
+            totals["errors"] += 1
+            _emit(ctx, "playlist:mapping:error", src=src, dst=dst, mapping=mapping_id, error=str(e))
+            continue
+
+        totals["mappings"] += 1
+        totals["added"] += int(res.get("added", 0) or 0)
+        totals["removed"] += int(res.get("removed", 0) or 0)
+        totals["updated"] += int(res.get("reordered", 0) or 0)
+        totals["unresolved"] += int(res.get("unresolved_count", len(res.get("unresolved") or [])) or 0)
+        if not res.get("ok", True):
+            totals["errors"] += 1
+        for w in res.get("warnings") or []:
+            if w not in totals["warnings"]:
+                totals["warnings"].append(str(w))
+
+    _emit(
+        ctx,
+        "playlist:pair",
+        src=src,
+        dst=dst,
+        mappings=totals["mappings"],
+        added=totals["added"],
+        removed=totals["removed"],
+        reordered=totals["updated"],
+        unresolved=totals["unresolved"],
+        errors=totals["errors"],
+    )
+    _record_playlist_stats(ctx, src, dst, totals)
+    return totals

--- a/cw_platform/playlists.py
+++ b/cw_platform/playlists.py
@@ -1,0 +1,406 @@
+# cw_platform/playlists.py
+# CrossWatch - Playlist domain model and provider contract
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, Sequence, runtime_checkable
+
+from .id_map import canonical_key, minimal
+
+PLAYLIST_KIND_REGULAR = "regular"
+PLAYLIST_KIND_SMART = "smart"
+RULESET_SCHEMA_VERSION = 1
+BUILTIN_TRAKT_FREE_ACCOUNT_RULESET_ID = "trakt_free_account"
+
+RULESET_ENUMS: dict[str, set[str]] = {
+    "direction": {"one_way", "bidirectional"},
+    "initial_sync": {"source_authoritative"},
+    "read_mode": {"direct", "aggregate"},
+    "write_mode": {"direct", "partition"},
+    "membership": {"add_only", "managed_only", "mirror"},
+    "order": {"ignore", "preserve"},
+    "deduplicate": {"canonical_id"},
+    "allocation": {"stable_first_fit"},
+    "rebalance": {"never"},
+    "overflow": {"block"},
+}
+
+RULESET_NUMERIC_FIELDS = {
+    "per_endpoint_capacity": (1, 100000),
+    "aggregate_capacity": (1, 1000000),
+    "maximum_targets": (1, 50),
+}
+
+RULESET_BOOL_FIELDS = {"built_in", "track_assignments"}
+RULESET_NAME_MAX = 10
+_SAFE_NAME_CHARS = " _.'-&()"
+
+BUILTIN_RULESETS: dict[str, dict[str, Any]] = {
+    BUILTIN_TRAKT_FREE_ACCOUNT_RULESET_ID: {
+        "id": BUILTIN_TRAKT_FREE_ACCOUNT_RULESET_ID,
+        "name": "TraktFree",
+        "schema_version": RULESET_SCHEMA_VERSION,
+        "built_in": True,
+        "direction": "bidirectional",
+        "initial_sync": "source_authoritative",
+        "read_mode": "aggregate",
+        "write_mode": "partition",
+        "membership": "managed_only",
+        "order": "ignore",
+        "deduplicate": "canonical_id",
+        "allocation": "stable_first_fit",
+        "rebalance": "never",
+        "overflow": "block",
+        "per_endpoint_capacity": 250,
+        "aggregate_capacity": 1000,
+        "maximum_targets": 5,
+        "track_assignments": True,
+    }
+}
+
+_PLAYLIST_METHODS = (
+    "list_playlist_resources",
+    "get_playlist_snapshot",
+    "create_playlist",
+    "add_playlist_items",
+    "remove_playlist_items",
+    "reorder_playlist_items",
+)
+
+
+def _clean_str(v: Any) -> str:
+    return str(v).strip() if v is not None else ""
+
+
+def _safe_name_error(name: Any, label: str, max_len: int) -> str:
+    s = _clean_str(name)
+    if not s:
+        return f"{label} required"
+    if len(s) > max_len:
+        return f"{label} must be {max_len} characters or fewer"
+    if not s[0].isalnum():
+        return f"{label} must start with a letter or number"
+    if any(not (ch.isalnum() or ch in _SAFE_NAME_CHARS) for ch in s):
+        return f"{label} contains unsupported characters"
+    return ""
+
+
+def _norm_kind(v: Any) -> str:
+    k = _clean_str(v).lower()
+    return PLAYLIST_KIND_SMART if k == PLAYLIST_KIND_SMART else PLAYLIST_KIND_REGULAR
+
+
+def _norm_media_types(v: Any) -> tuple[str, ...]:
+    if v is None:
+        return ()
+    if isinstance(v, str):
+        raw: Sequence[Any] = [x for x in v.replace(",", " ").split() if x]
+    elif isinstance(v, (list, tuple, set)):
+        raw = list(v)
+    else:
+        return ()
+    out: list[str] = []
+    for x in raw:
+        s = _clean_str(x).lower()
+        if s and s not in out:
+            out.append(s)
+    return tuple(out)
+
+
+def _ruleset_int(v: Any, *, default: int, bounds: tuple[int, int]) -> int:
+    try:
+        n = int(v)
+    except Exception:
+        n = int(default)
+    lo, hi = bounds
+    if n < lo:
+        return lo
+    if n > hi:
+        return hi
+    return n
+
+
+def normalize_ruleset(data: Mapping[str, Any], *, built_in: bool | None = None) -> dict[str, Any]:
+    src = dict(data or {})
+    rid = _clean_str(src.get("id"))
+    name = _clean_str(src.get("name"))
+    out: dict[str, Any] = {
+        "id": rid,
+        "name": name or rid,
+        "description": _clean_str(src.get("description")),
+        "schema_version": RULESET_SCHEMA_VERSION,
+        "built_in": bool(src.get("built_in", False) if built_in is None else built_in),
+    }
+    for key, allowed in RULESET_ENUMS.items():
+        val = _clean_str(src.get(key)).lower()
+        if val not in allowed:
+            val = BUILTIN_RULESETS[BUILTIN_TRAKT_FREE_ACCOUNT_RULESET_ID][key]
+        out[key] = val
+    for key, bounds in RULESET_NUMERIC_FIELDS.items():
+        default = BUILTIN_RULESETS[BUILTIN_TRAKT_FREE_ACCOUNT_RULESET_ID][key]
+        out[key] = _ruleset_int(src.get(key), default=default, bounds=bounds)
+    out["track_assignments"] = bool(src.get("track_assignments", True))
+    return out
+
+
+def validate_ruleset(data: Mapping[str, Any], *, require_id: bool = True) -> tuple[bool, str, dict[str, Any] | None]:
+    raw = dict(data or {})
+    if require_id and not _clean_str(raw.get("id")):
+        return False, "ruleset id required", None
+    name_err = _safe_name_error(raw.get("name"), "ruleset name", RULESET_NAME_MAX)
+    if name_err:
+        return False, name_err, None
+    if int(raw.get("schema_version") or RULESET_SCHEMA_VERSION) != RULESET_SCHEMA_VERSION:
+        return False, "unsupported ruleset schema version", None
+    for key, allowed in RULESET_ENUMS.items():
+        val = _clean_str(raw.get(key)).lower()
+        if val not in allowed:
+            return False, f"invalid {key}", None
+    for key, bounds in RULESET_NUMERIC_FIELDS.items():
+        raw_value = raw.get(key)
+        if raw_value is None:
+            return False, f"invalid {key}", None
+        try:
+            n = int(raw_value)
+        except Exception:
+            return False, f"invalid {key}", None
+        lo, hi = bounds
+        if n < lo or n > hi:
+            return False, f"{key} out of range", None
+    return True, "", normalize_ruleset(raw)
+
+
+def builtin_rulesets() -> list[dict[str, Any]]:
+    return [normalize_ruleset(v, built_in=True) for v in BUILTIN_RULESETS.values()]
+
+
+@dataclass
+class PlaylistResource:
+    provider: str
+    id: str
+    name: str = ""
+    instance: str = "default"
+    kind: str = PLAYLIST_KIND_REGULAR
+    can_read: bool = True
+    can_add: bool = False
+    can_remove: bool = False
+    can_reorder: bool = False
+    media_types: tuple[str, ...] = ()
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.provider = _clean_str(self.provider).upper()
+        self.id = _clean_str(self.id)
+        self.name = _clean_str(self.name)
+        self.instance = _clean_str(self.instance) or "default"
+        self.kind = _norm_kind(self.kind)
+        self.can_read = bool(self.can_read)
+        self.can_add = bool(self.can_add)
+        self.can_remove = bool(self.can_remove)
+        self.can_reorder = bool(self.can_reorder)
+        self.media_types = _norm_media_types(self.media_types)
+        self.extra = dict(self.extra) if isinstance(self.extra, Mapping) else {}
+
+    @property
+    def is_smart(self) -> bool:
+        return self.kind == PLAYLIST_KIND_SMART
+
+    @property
+    def writable(self) -> bool:
+        return not self.is_smart and (self.can_add or self.can_remove)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "instance": self.instance,
+            "id": self.id,
+            "name": self.name,
+            "kind": self.kind,
+            "smart": self.is_smart,
+            "can_read": self.can_read,
+            "can_add": self.can_add,
+            "can_remove": self.can_remove,
+            "can_reorder": self.can_reorder,
+            "writable": self.writable,
+            "media_types": list(self.media_types),
+            "extra": dict(self.extra),
+        }
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, Any]) -> "PlaylistResource":
+        return cls(
+            provider=d.get("provider") or "",
+            id=d.get("id") or "",
+            name=d.get("name") or "",
+            instance=d.get("instance") or "default",
+            kind=d.get("kind") or (PLAYLIST_KIND_SMART if d.get("smart") else PLAYLIST_KIND_REGULAR),
+            can_read=bool(d.get("can_read", True)),
+            can_add=bool(d.get("can_add", False)),
+            can_remove=bool(d.get("can_remove", False)),
+            can_reorder=bool(d.get("can_reorder", False)),
+            media_types=d.get("media_types") or (),
+            extra=d.get("extra") or {},
+        )
+
+
+@dataclass
+class PlaylistItem:
+    key: str
+    item: dict[str, Any] = field(default_factory=dict)
+    playlist_item_id: str | None = None
+    position: int | None = None
+    provider_media_id: str | None = None
+
+    def __post_init__(self) -> None:
+        self.key = _clean_str(self.key)
+        if self.playlist_item_id is not None:
+            self.playlist_item_id = _clean_str(self.playlist_item_id) or None
+        if self.provider_media_id is not None:
+            self.provider_media_id = _clean_str(self.provider_media_id) or None
+        if self.position is not None:
+            try:
+                self.position = int(self.position)
+            except Exception:
+                self.position = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "item": dict(self.item or {}),
+            "playlist_item_id": self.playlist_item_id,
+            "position": self.position,
+            "provider_media_id": self.provider_media_id,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, Any]) -> "PlaylistItem":
+        return cls(
+            key=d.get("key") or "",
+            item=dict(d.get("item") or {}),
+            playlist_item_id=d.get("playlist_item_id"),
+            position=d.get("position"),
+            provider_media_id=d.get("provider_media_id"),
+        )
+
+    @classmethod
+    def from_media(
+        cls,
+        media: Mapping[str, Any],
+        *,
+        playlist_item_id: Any = None,
+        position: Any = None,
+        provider_media_id: Any = None,
+    ) -> "PlaylistItem":
+        m = minimal(media)
+        key = canonical_key(media)
+        return cls(
+            key=key,
+            item=m,
+            playlist_item_id=playlist_item_id,
+            position=position,
+            provider_media_id=provider_media_id,
+        )
+
+
+@dataclass
+class PlaylistSnapshot:
+    resource: PlaylistResource
+    items: list[PlaylistItem] = field(default_factory=list)
+    checkpoint: str | None = None
+
+    def ordered_keys(self) -> list[str]:
+        return [it.key for it in self.items if it.key]
+
+    def by_key(self) -> dict[str, PlaylistItem]:
+        out: dict[str, PlaylistItem] = {}
+        for it in self.items:
+            if it.key and it.key not in out:
+                out[it.key] = it
+        return out
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "resource": self.resource.to_dict(),
+            "items": [it.to_dict() for it in self.items],
+            "checkpoint": self.checkpoint,
+            "count": len(self.items),
+        }
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, Any]) -> "PlaylistSnapshot":
+        return cls(
+            resource=PlaylistResource.from_dict(d.get("resource") or {}),
+            items=[PlaylistItem.from_dict(x) for x in (d.get("items") or []) if isinstance(x, Mapping)],
+            checkpoint=d.get("checkpoint"),
+        )
+
+
+@runtime_checkable
+class PlaylistOps(Protocol):
+    def list_playlist_resources(
+        self, cfg: Mapping[str, Any], *, instance: str | None = None
+    ) -> Sequence[PlaylistResource]: ...
+
+    def get_playlist_snapshot(
+        self, cfg: Mapping[str, Any], playlist_id: str, *, instance: str | None = None
+    ) -> PlaylistSnapshot: ...
+
+    def create_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        name: str,
+        *,
+        media_type: str | None = None,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> PlaylistResource: ...
+
+    def add_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Sequence[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]: ...
+
+    def remove_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Sequence[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]: ...
+
+    def reorder_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        ordered_keys: Sequence[str],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]: ...
+
+
+def supports_playlists(ops: Any) -> bool:
+    return bool(ops) and all(callable(getattr(ops, m, None)) for m in _PLAYLIST_METHODS)
+
+
+def playlist_capabilities(source: Any) -> dict[str, Any]:
+    root: Any = None
+    if isinstance(source, Mapping):
+        root = source.get("capabilities")
+    else:
+        get_caps = getattr(source, "capabilities", None)
+        if callable(get_caps):
+            try:
+                root = get_caps()
+            except Exception:
+                root = None
+    caps = root.get("playlists") if isinstance(root, Mapping) else None
+    return dict(caps) if isinstance(caps, Mapping) else {}

--- a/cw_platform/playlists_runner.py
+++ b/cw_platform/playlists_runner.py
@@ -1,0 +1,1237 @@
+# cw_platform/playlists_runner.py
+# CrossWatch - Playlist endpoints, mapping profiles and one-way sync runner
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from .config_base import CONFIG_BASE
+from .id_map import any_key_overlap, canonical_key, keys_for_item
+from .playlists import (
+    BUILTIN_RULESETS,
+    BUILTIN_TRAKT_FREE_ACCOUNT_RULESET_ID,
+    PlaylistItem,
+    PlaylistResource,
+    PlaylistSnapshot,
+    builtin_rulesets,
+    normalize_ruleset,
+    supports_playlists,
+    validate_ruleset,
+)
+from .provider_instances import build_provider_config_view, normalize_instance_id
+
+MEMBERSHIP_ADD_ONLY = "add_only"
+MEMBERSHIP_MANAGED_ONLY = "managed_only"
+MEMBERSHIP_MIRROR = "mirror"
+_MEMBERSHIP = {MEMBERSHIP_ADD_ONLY, MEMBERSHIP_MANAGED_ONLY, MEMBERSHIP_MIRROR}
+
+ORDER_IGNORE = "ignore"
+ORDER_PRESERVE = "preserve"
+_ORDER = {ORDER_IGNORE, ORDER_PRESERVE}
+
+ENDPOINT_PREFIX = "EP"
+MAPPING_PREFIX = "MAP"
+RULESET_PREFIX = "RULE"
+
+
+class PlaylistRunError(RuntimeError):
+    pass
+
+
+def _state_path() -> Path:
+    return Path(CONFIG_BASE()) / ".cw_state" / "playlists_state.json"
+
+
+def _load_all_state() -> dict[str, Any]:
+    p = _state_path()
+    try:
+        data = json.loads(p.read_text("utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _save_all_state(data: Mapping[str, Any]) -> None:
+    p = _state_path()
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = p.with_suffix(".tmp")
+        tmp.write_text(json.dumps(dict(data), ensure_ascii=False, indent=2, sort_keys=True), "utf-8")
+        tmp.replace(p)
+    except Exception:
+        pass
+
+
+def next_id(items: Sequence[Mapping[str, Any]], prefix: str) -> str:
+    nums: list[int] = []
+    for it in items or []:
+        raw = str((it or {}).get("id") or "")
+        if raw.upper().startswith(f"{prefix}-"):
+            tail = raw.split("-", 1)[1]
+            if tail.isdigit():
+                nums.append(int(tail))
+    n = (max(nums) + 1) if nums else 1
+    return f"{prefix}-{n:02d}"
+
+
+def pl_root(cfg: Mapping[str, Any], *, create: bool = False) -> dict[str, Any]:
+    root = cfg.get("playlists") if isinstance(cfg, Mapping) else None
+    if not isinstance(root, dict):
+        if not create or not isinstance(cfg, dict):
+            return {"endpoints": [], "mappings": [], "rulesets": []}
+        root = {"endpoints": [], "mappings": [], "rulesets": []}
+        cfg["playlists"] = root
+    if not isinstance(root.get("endpoints"), list):
+        root["endpoints"] = []
+    if not isinstance(root.get("mappings"), list):
+        root["mappings"] = []
+    if not isinstance(root.get("rulesets"), list):
+        root["rulesets"] = []
+    return root
+
+
+def list_builtin_rulesets() -> list[dict[str, Any]]:
+    return builtin_rulesets()
+
+
+def list_custom_rulesets(cfg: Mapping[str, Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for r in pl_root(cfg).get("rulesets", []):
+        if isinstance(r, Mapping):
+            ok, _why, clean = validate_ruleset(r)
+            if ok and clean:
+                clean["built_in"] = False
+                out.append(clean)
+    return out
+
+
+def list_rulesets(cfg: Mapping[str, Any]) -> list[dict[str, Any]]:
+    custom = {r["id"]: r for r in list_custom_rulesets(cfg)}
+    out = list_builtin_rulesets()
+    out.extend(custom[k] for k in sorted(custom))
+    return out
+
+
+def get_ruleset(cfg: Mapping[str, Any], ruleset_id: Any) -> dict[str, Any] | None:
+    rid = str(ruleset_id or "").strip()
+    if not rid:
+        return None
+    if rid in BUILTIN_RULESETS:
+        return normalize_ruleset(BUILTIN_RULESETS[rid], built_in=True)
+    for r in list_custom_rulesets(cfg):
+        if r.get("id") == rid:
+            return r
+    return None
+
+
+def list_endpoints(cfg: Mapping[str, Any]) -> list[dict[str, Any]]:
+    return [dict(e) for e in pl_root(cfg).get("endpoints", []) if isinstance(e, Mapping)]
+
+
+def get_endpoint(cfg: Mapping[str, Any], endpoint_id: Any) -> dict[str, Any] | None:
+    eid = str(endpoint_id or "").strip()
+    if not eid:
+        return None
+    for e in pl_root(cfg).get("endpoints", []):
+        if isinstance(e, Mapping) and str(e.get("id") or "") == eid:
+            return dict(e)
+    return None
+
+
+def list_mapping_profiles(cfg: Mapping[str, Any]) -> list[dict[str, Any]]:
+    return [dict(m) for m in pl_root(cfg).get("mappings", []) if isinstance(m, Mapping)]
+
+
+def get_mapping_profile(cfg: Mapping[str, Any], mapping_id: Any) -> dict[str, Any] | None:
+    mid = str(mapping_id or "").strip()
+    if not mid:
+        return None
+    for m in pl_root(cfg).get("mappings", []):
+        if isinstance(m, Mapping) and str(m.get("id") or "") == mid:
+            return dict(m)
+    return None
+
+
+def _endpoint_view(ep: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "provider": str(ep.get("provider") or "").strip().upper(),
+        "instance": normalize_instance_id(ep.get("instance")),
+        "playlist_id": str(ep.get("playlist_id") or "").strip(),
+        "playlist_name": ep.get("playlist_name") or ep.get("name"),
+        "endpoint_id": str(ep.get("id") or "").strip(),
+    }
+
+
+def _target_ids(profile: Mapping[str, Any]) -> list[str]:
+    raw = profile.get("target_endpoints")
+    out: list[str] = []
+    if isinstance(raw, list):
+        for x in raw:
+            s = str((x or {}).get("id") if isinstance(x, Mapping) else x).strip()
+            if s and s not in out:
+                out.append(s)
+    return out
+
+
+def _norm_membership_val(v: Any) -> str:
+    s = str(v or "").strip().lower()
+    return s if s in _MEMBERSHIP else MEMBERSHIP_MANAGED_ONLY
+
+
+def _norm_order_val(v: Any) -> str:
+    s = str(v or "").strip().lower()
+    return s if s in _ORDER else ORDER_IGNORE
+
+
+def resolve_mapping(cfg: Mapping[str, Any], profile: Mapping[str, Any]) -> dict[str, Any] | None:
+    se = get_endpoint(cfg, profile.get("source_endpoint"))
+    target_ids = _target_ids(profile)
+    target_eps = [get_endpoint(cfg, tid) for tid in target_ids]
+    targets = [e for e in target_eps if e]
+    if not se or not targets or len(targets) != len(target_ids):
+        return None
+    te = targets[0]
+    return {
+        "id": str(profile.get("id") or "").strip(),
+        "name": profile.get("name") or profile.get("id"),
+        "source_endpoint": str(profile.get("source_endpoint") or "").strip(),
+        "target_endpoints": [str(e.get("id") or "").strip() for e in targets],
+        "source": _endpoint_view(se),
+        "target": _endpoint_view(te),
+        "targets": [_endpoint_view(e) for e in targets],
+        "ruleset_id": str(profile.get("ruleset_id") or "").strip(),
+        "membership": _norm_membership_val(profile.get("membership")),
+        "order": _norm_order_val(profile.get("order")),
+        "enabled": bool(profile.get("enabled", True)),
+        "allow_mass_delete": bool(profile.get("allow_mass_delete")),
+    }
+
+
+def resolve_mapping_by_id(cfg: Mapping[str, Any], mapping_id: Any) -> dict[str, Any] | None:
+    profile = get_mapping_profile(cfg, mapping_id)
+    return resolve_mapping(cfg, profile) if profile else None
+
+
+def _pair_id(pair: Mapping[str, Any]) -> str:
+    return str(pair.get("id") or pair.get("pair_id") or "").strip() or "pair"
+
+
+def _pair_providers(pair: Mapping[str, Any]) -> tuple[str, str, str, str]:
+    src = str(pair.get("src") or pair.get("source") or "").strip().upper()
+    dst = str(pair.get("dst") or pair.get("target") or "").strip().upper()
+    src_inst = normalize_instance_id(pair.get("src_instance") or pair.get("source_instance"))
+    dst_inst = normalize_instance_id(pair.get("dst_instance") or pair.get("target_instance"))
+    return src, src_inst, dst, dst_inst
+
+
+def _pair_mode(pair: Mapping[str, Any]) -> str:
+    return "two-way" if "two" in str(pair.get("mode") or "one-way").strip().lower() else "one-way"
+
+
+def pair_mapping_ids(pair: Mapping[str, Any]) -> list[str]:
+    feats = pair.get("features") if isinstance(pair, Mapping) else None
+    pl = feats.get("playlists") if isinstance(feats, Mapping) else None
+    ids = pl.get("mappings") if isinstance(pl, Mapping) else None
+    out: list[str] = []
+    for x in ids or []:
+        s = str(x).strip() if not isinstance(x, Mapping) else str(x.get("id") or "").strip()
+        if s and s not in out:
+            out.append(s)
+    return out
+
+
+def _mapping_targets(mapping: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    raw = mapping.get("targets")
+    if not isinstance(raw, list):
+        return []
+    return [t for t in raw if isinstance(t, Mapping)]
+
+
+def mapping_compatible_with_pair(resolved: Mapping[str, Any], pair: Mapping[str, Any]) -> bool:
+    src, src_inst, dst, dst_inst = _pair_providers(pair)
+    s = (resolved["source"]["provider"], resolved["source"]["instance"])
+    targets = _mapping_targets(resolved)
+    target_pairs = {(str(t.get("provider") or ""), str(t.get("instance") or "")) for t in targets if isinstance(t, Mapping)}
+    if _pair_mode(pair) == "two-way":
+        return (s == (src, src_inst) and target_pairs == {(dst, dst_inst)}) or (s == (dst, dst_inst) and target_pairs == {(src, src_inst)})
+    return s == (src, src_inst) and target_pairs == {(dst, dst_inst)}
+
+
+def resolve_pair_mappings(cfg: Mapping[str, Any], pair: Mapping[str, Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for mid in pair_mapping_ids(pair):
+        resolved = resolve_mapping_by_id(cfg, mid)
+        if not resolved or not resolved.get("enabled", True):
+            continue
+        if not mapping_compatible_with_pair(resolved, pair):
+            continue
+        out.append(resolved)
+    return out
+
+
+def scope_key(mapping: Mapping[str, Any]) -> str:
+    s = mapping.get("source") or {}
+    targets = _mapping_targets(mapping)
+    target_parts: list[str] = []
+    for t in targets:
+        target_parts.append("/".join([
+            str(t.get("endpoint_id") or ""),
+            str(t.get("provider") or ""),
+            str(t.get("instance") or ""),
+            str(t.get("playlist_id") or ""),
+        ]))
+    parts = [
+        str(mapping.get("id") or ""),
+        str(mapping.get("ruleset_id") or ""),
+        str(s.get("provider") or ""),
+        str(s.get("instance") or ""),
+        str(s.get("playlist_id") or ""),
+        ",".join(target_parts),
+    ]
+    return "|".join(parts)
+
+
+def load_baseline(mapping: Mapping[str, Any]) -> set[str]:
+    entry = _load_all_state().get(scope_key(mapping)) or {}
+    managed = entry.get("managed") if isinstance(entry, Mapping) else None
+    return {str(k) for k in (managed or []) if str(k).strip()}
+
+
+def save_baseline(mapping: Mapping[str, Any], managed: set[str], *, meta: Mapping[str, Any] | None = None) -> None:
+    data = _load_all_state()
+    key = scope_key(mapping)
+    raw_entry = data.get(key)
+    entry = raw_entry if isinstance(raw_entry, dict) else {}
+    entry["managed"] = sorted(managed)
+    entry["updated_at"] = int(time.time())
+    entry["meta"] = dict(meta or {})
+    data[key] = entry
+    _save_all_state(data)
+
+
+def delete_baseline(mapping: Mapping[str, Any]) -> bool:
+    data = _load_all_state()
+    key = scope_key(mapping)
+    if key in data:
+        data.pop(key, None)
+        _save_all_state(data)
+        return True
+    return False
+
+
+def store_result(mapping: Mapping[str, Any], result: Mapping[str, Any]) -> None:
+    data = _load_all_state()
+    key = scope_key(mapping)
+    raw = data.get(key)
+    entry: dict[str, Any] = raw if isinstance(raw, dict) else {}
+    entry["last_result"] = dict(result)
+    data[key] = entry
+    _save_all_state(data)
+
+
+def load_result(mapping: Mapping[str, Any]) -> dict[str, Any] | None:
+    entry = _load_all_state().get(scope_key(mapping)) or {}
+    res = entry.get("last_result") if isinstance(entry, Mapping) else None
+    return dict(res) if isinstance(res, Mapping) else None
+
+
+def prune_baselines(valid_keys: set[str]) -> int:
+    data = _load_all_state()
+    removed = 0
+    for key in list(data.keys()):
+        if key not in valid_keys:
+            data.pop(key, None)
+            removed += 1
+    if removed:
+        _save_all_state(data)
+    return removed
+
+
+@dataclass
+class PlaylistPlan:
+    membership: str
+    order: str
+    source_count: int = 0
+    target_count: int = 0
+    resolved_count: int = 0
+    unresolved_count: int = 0
+    additions: list[str] = field(default_factory=list)
+    removals: list[str] = field(default_factory=list)
+    reorder_count: int = 0
+    manual_affected: bool = False
+    warnings: list[str] = field(default_factory=list)
+    add_items: list[dict[str, Any]] = field(default_factory=list)
+    remove_items: list[dict[str, Any]] = field(default_factory=list)
+    target_order: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "membership": self.membership,
+            "order": self.order,
+            "source_count": self.source_count,
+            "target_count": self.target_count,
+            "resolved_count": self.resolved_count,
+            "unresolved_count": self.unresolved_count,
+            "additions": list(self.additions),
+            "removals": list(self.removals),
+            "planned_additions": len(self.additions),
+            "planned_removals": len(self.removals),
+            "reorder_count": self.reorder_count,
+            "manual_affected": self.manual_affected,
+            "warnings": list(self.warnings),
+        }
+
+
+def _providers() -> dict[str, Any]:
+    from .orchestrator._providers import load_sync_providers
+
+    return load_sync_providers()
+
+
+def _find_resource(ops: Any, cfg: Mapping[str, Any], instance: str, playlist_id: str):
+    try:
+        for res in ops.list_playlist_resources(cfg, instance=instance) or []:
+            if res.id == playlist_id or res.name == playlist_id:
+                return res
+    except Exception:
+        return None
+    return None
+
+
+def _merge_warnings(target: dict[str, Any] | list[str], *sources: Any) -> None:
+    warnings = target if isinstance(target, list) else target.setdefault("warnings", [])
+    if not isinstance(warnings, list):
+        return
+    seen = {str(x) for x in warnings}
+    for source in sources:
+        raw = source
+        if isinstance(source, PlaylistResource):
+            extra = source.extra or {}
+            raw = list(extra.get("warnings") or [])
+            if extra.get("remove_warning"):
+                raw.append(extra.get("remove_warning"))
+        elif isinstance(source, Mapping):
+            raw = source.get("warnings") or []
+        if isinstance(raw, str):
+            values = [raw]
+        elif isinstance(raw, Iterable):
+            values = list(raw)
+        else:
+            values = []
+        for value in values:
+            text = str(value or "").strip()
+            if text and text not in seen:
+                warnings.append(text)
+                seen.add(text)
+
+
+def _state_entry(mapping: Mapping[str, Any]) -> dict[str, Any]:
+    raw = _load_all_state().get(scope_key(mapping))
+    return dict(raw) if isinstance(raw, Mapping) else {}
+
+
+def _save_state_entry(mapping: Mapping[str, Any], entry: Mapping[str, Any]) -> None:
+    data = _load_all_state()
+    data[scope_key(mapping)] = dict(entry)
+    _save_all_state(data)
+
+
+def _ops_cfg(providers: Mapping[str, Any], cfg: Mapping[str, Any], endpoint: Mapping[str, Any]) -> tuple[Any, dict[str, Any], str, str, str]:
+    provider = str(endpoint.get("provider") or "").strip().upper()
+    inst = normalize_instance_id(endpoint.get("instance"))
+    playlist_id = str(endpoint.get("playlist_id") or "").strip()
+    ops = providers.get(provider)
+    if not ops or not supports_playlists(ops):
+        raise PlaylistRunError(f"provider {provider or '?'} does not support playlists")
+    return ops, build_provider_config_view(cfg, provider, inst), inst, provider, playlist_id
+
+
+def _snapshot_endpoint(providers: Mapping[str, Any], cfg: Mapping[str, Any], endpoint: Mapping[str, Any]) -> tuple[PlaylistSnapshot, Any, Mapping[str, Any], str]:
+    ops, view, inst, provider, playlist_id = _ops_cfg(providers, cfg, endpoint)
+    if not playlist_id:
+        raise PlaylistRunError("playlist id missing")
+    snap = ops.get_playlist_snapshot(view, playlist_id, instance=inst)
+    if not isinstance(snap, PlaylistSnapshot):
+        raise PlaylistRunError(f"{provider} returned an invalid playlist snapshot")
+    return snap, ops, view, inst
+
+
+def _unique_snapshot_items(snapshot: PlaylistSnapshot) -> tuple[list[PlaylistItem], dict[str, PlaylistItem]]:
+    ordered: list[PlaylistItem] = []
+    by_key: dict[str, PlaylistItem] = {}
+    for it in snapshot.items:
+        if not it.key or it.key in by_key:
+            continue
+        by_key[it.key] = it
+        ordered.append(it)
+    return ordered, by_key
+
+
+def _playlist_item_keys(item: PlaylistItem) -> set[str]:
+    keys = {str(item.key or "").strip().lower()} if item.key else set()
+    try:
+        keys.update(keys_for_item(item.item or {}))
+    except Exception:
+        pass
+    return {k for k in keys if k}
+
+
+def _snapshot_key_union(items: Iterable[PlaylistItem]) -> set[str]:
+    out: set[str] = set()
+    for item in items:
+        out.update(_playlist_item_keys(item))
+    return out
+
+
+def _assignment_map(entry: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    raw = entry.get("assignments") if isinstance(entry, Mapping) else None
+    return {str(k): dict(v) for k, v in (raw or {}).items() if isinstance(v, Mapping)}
+
+
+def _aggregate_targets(
+    providers: Mapping[str, Any],
+    cfg: Mapping[str, Any],
+    targets: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    logical: dict[str, PlaylistItem] = {}
+    physical: dict[str, list[dict[str, Any]]] = {}
+    per_target: dict[str, dict[str, Any]] = {}
+    target_ctx: dict[str, dict[str, Any]] = {}
+    duplicates: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for pos, target in enumerate(targets):
+        endpoint_id = str(target.get("endpoint_id") or "").strip()
+        snap, ops, view, inst = _snapshot_endpoint(providers, cfg, target)
+        resource = snap.resource
+        _merge_warnings(warnings, resource)
+        if resource.is_smart:
+            raise PlaylistRunError(f"target {endpoint_id} is a smart playlist and cannot be written")
+        if not (resource.can_add or resource.can_remove):
+            raise PlaylistRunError(f"target {endpoint_id} is read only")
+        ordered, by_key = _unique_snapshot_items(snap)
+        per_target[endpoint_id] = {
+            "endpoint_id": endpoint_id,
+            "provider": target.get("provider"),
+            "instance": target.get("instance"),
+            "playlist_id": target.get("playlist_id"),
+            "playlist_name": target.get("playlist_name"),
+            "current_count": len(snap.items),
+            "logical_count": len(by_key),
+            "available_capacity": 0,
+            "planned_additions": 0,
+            "planned_removals": 0,
+        }
+        target_ctx[endpoint_id] = {"ops": ops, "cfg": view, "instance": inst, "playlist_id": target.get("playlist_id")}
+        for it in ordered:
+            loc = {"endpoint_id": endpoint_id, "order": pos, "item": it}
+            physical.setdefault(it.key, []).append(loc)
+            if it.key not in logical:
+                logical[it.key] = it
+            else:
+                duplicates.append({"key": it.key, "endpoints": [x["endpoint_id"] for x in physical[it.key]]})
+    return {"logical": logical, "physical": physical, "per_target": per_target, "target_ctx": target_ctx, "duplicates": duplicates, "warnings": warnings}
+
+
+def _source_resource_writable(providers: Mapping[str, Any], cfg: Mapping[str, Any], source: Mapping[str, Any]) -> bool:
+    ops, view, inst, _provider, playlist_id = _ops_cfg(providers, cfg, source)
+    res = _find_resource(ops, view, inst, playlist_id)
+    return bool(res and not res.is_smart and res.can_add and res.can_remove)
+
+
+def _ruleset_for_mapping(cfg: Mapping[str, Any], mapping: Mapping[str, Any]) -> dict[str, Any] | None:
+    rid = str(mapping.get("ruleset_id") or "").strip()
+    return get_ruleset(cfg, rid) if rid else None
+
+
+def _first_physical_endpoint(physical: Mapping[str, list[dict[str, Any]]], key: str) -> str | None:
+    locs = physical.get(key) or []
+    if not locs:
+        return None
+    return str(sorted(locs, key=lambda x: int(x.get("order") or 0))[0].get("endpoint_id") or "") or None
+
+
+def _plan_ruleset(
+    cfg: Mapping[str, Any],
+    mapping: Mapping[str, Any],
+    *,
+    providers: Mapping[str, Any] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    providers = providers or _providers()
+    ruleset = _ruleset_for_mapping(cfg, mapping)
+    if not ruleset:
+        raise PlaylistRunError("ruleset not found")
+    if ruleset["read_mode"] != "aggregate" or ruleset["write_mode"] != "partition":
+        raise PlaylistRunError("ruleset mode is not supported by this engine")
+    targets = _mapping_targets(mapping)
+    if len(targets) < 1:
+        raise PlaylistRunError("at least one target endpoint is required")
+    if len(targets) > int(ruleset["maximum_targets"]):
+        raise PlaylistRunError("too many target endpoints for ruleset")
+    endpoint_ids = [str(t.get("endpoint_id") or "").strip() for t in targets if isinstance(t, Mapping)]
+    if len(endpoint_ids) != len(set(endpoint_ids)):
+        raise PlaylistRunError("duplicate target endpoints are not allowed")
+    source = mapping.get("source") or {}
+    source_snap, source_ops, source_cfg, source_inst = _snapshot_endpoint(providers, cfg, source)
+    if ruleset["direction"] == "bidirectional" and not _source_resource_writable(providers, cfg, source):
+        raise PlaylistRunError("source endpoint must support add and remove for bidirectional rulesets")
+    source_items, source_by_key = _unique_snapshot_items(source_snap)
+    source_keys = [it.key for it in source_items]
+    source_set = set(source_by_key)
+    agg = _aggregate_targets(providers, cfg, targets)
+    warnings: list[str] = list(agg.get("warnings") or [])
+    if ruleset["direction"] == "bidirectional":
+        _merge_warnings(warnings, source_snap.resource)
+    target_by_key: dict[str, PlaylistItem] = dict(agg["logical"])
+    target_set = set(target_by_key)
+    physical = agg["physical"]
+    entry = _state_entry(mapping)
+    assignments = _assignment_map(entry)
+    initialized = bool(entry.get("last_success"))
+    prev_source = {str(k) for k in ((entry.get("last_success") or {}).get("source_keys") or [])}
+    prev_target = {str(k) for k in ((entry.get("last_success") or {}).get("target_keys") or [])}
+    managed = {k for k, v in assignments.items() if v.get("managed", True)}
+    if not initialized:
+        managed = set(source_set)
+    add_to_source: set[str] = set()
+    remove_from_source: set[str] = set()
+    add_to_target: set[str] = set()
+    remove_from_target: set[str] = set()
+    if initialized:
+        add_to_target |= source_set - prev_source
+        remove_from_target |= {k for k in (prev_source - source_set) if k in managed}
+        add_to_source |= target_set - prev_target
+        remove_from_source |= {k for k in (prev_target - target_set) if k in managed}
+    else:
+        add_to_target |= source_set - target_set
+    final_source = (source_set | add_to_source) - remove_from_source
+    final_managed = (managed | source_set | add_to_source | add_to_target) - remove_from_source - remove_from_target
+    per_target = {k: dict(v) for k, v in agg["per_target"].items()}
+    capacity = int(ruleset["per_endpoint_capacity"])
+    aggregate_capacity = int(ruleset["aggregate_capacity"])
+    for eid, row in per_target.items():
+        row["available_capacity"] = max(0, capacity - int(row.get("current_count") or 0))
+    target_additions: dict[str, list[str]] = {eid: [] for eid in endpoint_ids}
+    target_removals: dict[str, list[str]] = {eid: [] for eid in endpoint_ids}
+    assignment_target: dict[str, str] = {}
+    for key in sorted(final_managed):
+        current_eid = _first_physical_endpoint(physical, key)
+        previous_eid = str((assignments.get(key) or {}).get("endpoint_id") or "")
+        if current_eid:
+            assignment_target[key] = current_eid
+        elif previous_eid in per_target:
+            assignment_target[key] = previous_eid
+    for key in sorted(remove_from_target):
+        eid = _first_physical_endpoint(physical, key) or str((assignments.get(key) or {}).get("endpoint_id") or "")
+        if eid in target_removals:
+            target_removals[eid].append(key)
+    planned_counts = {eid: int(per_target[eid].get("current_count") or 0) - len(target_removals[eid]) for eid in endpoint_ids}
+    for key in source_keys:
+        if key not in final_managed or key in target_set:
+            continue
+        eid = assignment_target.get(key)
+        if eid in planned_counts and planned_counts[eid] < capacity:
+            pass
+        else:
+            eid = ""
+            for candidate in endpoint_ids:
+                if planned_counts[candidate] < capacity:
+                    eid = candidate
+                    break
+        if eid:
+            assignment_target[key] = eid
+            target_additions[eid].append(key)
+            planned_counts[eid] += 1
+    overflow_keys = [k for k in source_keys if k in final_managed and k not in target_set and k not in assignment_target]
+    total_capacity = min(aggregate_capacity, capacity * len(endpoint_ids))
+    final_target_logical_count = len((target_set | set(add_to_target) | add_to_source) - remove_from_target - remove_from_source)
+    overflow_count = len(overflow_keys)
+    if final_target_logical_count > total_capacity:
+        overflow_count = max(overflow_count, final_target_logical_count - total_capacity)
+    for eid in endpoint_ids:
+        per_target[eid]["planned_additions"] = len(target_additions[eid])
+        per_target[eid]["planned_removals"] = len(target_removals[eid])
+    unmanaged = target_set - final_managed
+    plan = {
+        "ruleset_id": ruleset["id"],
+        "ruleset": ruleset,
+        "blocked": overflow_count > 0,
+        "capacity_error": overflow_count > 0,
+        "logical_source_count": len(source_set),
+        "logical_aggregated_target_count": len(target_set),
+        "source_count": len(source_set),
+        "target_count": len(target_set),
+        "managed_target_count": len(target_set & final_managed),
+        "unmanaged_target_count": len(unmanaged),
+        "total_capacity": total_capacity,
+        "available_capacity": sum(int(per_target[eid]["available_capacity"]) for eid in endpoint_ids),
+        "overflow_count": overflow_count,
+        "planned_additions": sum(len(v) for v in target_additions.values()) + len(add_to_source),
+        "planned_removals": sum(len(v) for v in target_removals.values()) + len(remove_from_source),
+        "duplicates": agg["duplicates"],
+        "unresolved": [],
+        "unresolved_count": 0,
+        "per_target": [per_target[eid] for eid in endpoint_ids],
+        "warnings": warnings,
+        "initial": not initialized,
+        "membership": ruleset["membership"],
+        "order": ruleset["order"],
+    }
+    ctx = {
+        "source_ops": source_ops,
+        "source_cfg": source_cfg,
+        "source_inst": source_inst,
+        "source_playlist_id": source.get("playlist_id"),
+        "source_by_key": source_by_key,
+        "target_by_key": target_by_key,
+        "target_ctx": agg["target_ctx"],
+        "physical": physical,
+        "assignments": assignments,
+        "assignment_target": assignment_target,
+        "target_additions": target_additions,
+        "target_removals": target_removals,
+        "add_to_source": add_to_source,
+        "remove_from_source": remove_from_source,
+        "final_managed": final_managed,
+        "final_source": final_source,
+        "source_keys": source_keys,
+        "target_keys": sorted(target_set),
+        "ruleset": ruleset,
+        "state_entry": entry,
+        "endpoint_ids": endpoint_ids,
+    }
+    return plan, ctx
+
+
+def preview_ruleset_mapping(
+    cfg: Mapping[str, Any],
+    mapping: Mapping[str, Any],
+    *,
+    providers: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    plan, _ctx = _plan_ruleset(cfg, mapping, providers=providers)
+    return plan
+
+
+def build_plan(
+    cfg: Mapping[str, Any],
+    mapping: Mapping[str, Any],
+    *,
+    providers: Mapping[str, Any] | None = None,
+) -> tuple[PlaylistPlan, dict[str, Any]]:
+    providers = providers or _providers()
+    source = mapping.get("source") or {}
+    target = mapping.get("target") or {}
+    src = str(source.get("provider") or "").strip().upper()
+    dst = str(target.get("provider") or "").strip().upper()
+    src_inst = normalize_instance_id(source.get("instance"))
+    dst_inst = normalize_instance_id(target.get("instance"))
+    src_pl = str(source.get("playlist_id") or "").strip()
+    dst_pl = str(target.get("playlist_id") or "").strip()
+    membership = _norm_membership_val(mapping.get("membership"))
+    order = _norm_order_val(mapping.get("order"))
+
+    plan = PlaylistPlan(membership=membership, order=order)
+
+    src_ops = providers.get(src)
+    dst_ops = providers.get(dst)
+    if not src_ops or not supports_playlists(src_ops):
+        raise PlaylistRunError(f"source provider {src or '?'} does not support playlists")
+    if not dst_ops or not supports_playlists(dst_ops):
+        raise PlaylistRunError(f"target provider {dst or '?'} does not support playlists")
+    if not src_pl:
+        raise PlaylistRunError("mapping source playlist id missing")
+    if not dst_pl:
+        raise PlaylistRunError("mapping target playlist id missing")
+
+    src_cfg = build_provider_config_view(cfg, src, src_inst)
+    dst_cfg = build_provider_config_view(cfg, dst, dst_inst)
+
+    dst_resource = _find_resource(dst_ops, dst_cfg, dst_inst, dst_pl)
+    if dst_resource is None:
+        raise PlaylistRunError(f"target playlist not found: {dst_pl}")
+    if dst_resource.is_smart:
+        raise PlaylistRunError("target playlist is a smart playlist and cannot be written")
+    if not (dst_resource.can_add or dst_resource.can_remove):
+        raise PlaylistRunError("target playlist is read only")
+    _merge_warnings(plan.warnings, dst_resource)
+
+    src_snap: PlaylistSnapshot = src_ops.get_playlist_snapshot(src_cfg, src_pl, instance=src_inst)
+    dst_snap: PlaylistSnapshot = dst_ops.get_playlist_snapshot(dst_cfg, dst_pl, instance=dst_inst)
+
+    src_by_key = src_snap.by_key()
+    dst_by_key = dst_snap.by_key()
+    src_keys = list(src_snap.ordered_keys())
+    src_set = set(src_by_key.keys())
+    dst_set = set(dst_by_key.keys())
+    src_aliases = _snapshot_key_union(src_by_key.values())
+    dst_aliases = _snapshot_key_union(dst_by_key.values())
+    baseline = load_baseline(mapping)
+
+    plan.source_count = len(src_set)
+    plan.target_count = len(dst_set)
+
+    additions = [k for k in src_keys if not any_key_overlap(_playlist_item_keys(src_by_key[k]), dst_aliases)]
+
+    removals: list[str] = []
+    if membership == MEMBERSHIP_MANAGED_ONLY:
+        removals = sorted(k for k in (baseline & dst_set) if k in dst_by_key and not any_key_overlap(_playlist_item_keys(dst_by_key[k]), src_aliases))
+    elif membership == MEMBERSHIP_MIRROR:
+        removals = sorted(k for k in dst_set if k in dst_by_key and not any_key_overlap(_playlist_item_keys(dst_by_key[k]), src_aliases))
+
+    plan.additions = additions
+    plan.removals = removals
+    plan.resolved_count = len(additions)
+    plan.manual_affected = bool(set(removals) - baseline)
+
+    plan.add_items = [dict(src_by_key[k].item) for k in additions if k in src_by_key]
+    plan.remove_items = [dict(dst_by_key[k].item) for k in removals if k in dst_by_key]
+
+    if order == ORDER_PRESERVE:
+        projected = (dst_set | set(additions)) - set(removals)
+        target_order = [k for k in src_keys if k in projected]
+        plan.target_order = target_order
+        current_order = [k for k in dst_snap.ordered_keys() if k in projected]
+        if not dst_resource.can_reorder:
+            plan.warnings.append("target playlist does not support reordering")
+        elif target_order != current_order:
+            plan.reorder_count = len(target_order)
+
+    ctx = {
+        "src": src,
+        "src_inst": src_inst,
+        "dst": dst,
+        "dst_inst": dst_inst,
+        "src_pl": src_pl,
+        "dst_pl": dst_pl,
+        "src_ops": src_ops,
+        "dst_ops": dst_ops,
+        "src_cfg": src_cfg,
+        "dst_cfg": dst_cfg,
+        "dst_resource": dst_resource,
+        "baseline": baseline,
+        "dst_set": dst_set,
+        "src_set": src_set,
+        "src_keys": src_keys,
+    }
+    return plan, ctx
+
+
+def preview_mapping(
+    cfg: Mapping[str, Any],
+    mapping: Mapping[str, Any],
+    *,
+    providers: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    if mapping.get("ruleset_id"):
+        return preview_ruleset_mapping(cfg, mapping, providers=providers)
+    plan, _ctx = build_plan(cfg, mapping, providers=providers)
+    return plan.to_dict()
+
+
+def _item_dict_from_sources(key: str, *sources: Mapping[str, Any]) -> dict[str, Any]:
+    for src in sources:
+        val = src.get(key) if isinstance(src, Mapping) else None
+        if isinstance(val, PlaylistItem):
+            return dict(val.item or {})
+        if isinstance(val, Mapping):
+            item = val.get("item")
+            return dict(item if isinstance(item, Mapping) else val)
+    return {"key": key}
+
+
+def _apply_ruleset_mapping(
+    cfg: Mapping[str, Any],
+    mapping: Mapping[str, Any],
+    *,
+    dry_run: bool = False,
+    providers: Mapping[str, Any] | None = None,
+    emit: Callable[..., None] | None = None,
+) -> dict[str, Any]:
+    plan, ctx = _plan_ruleset(cfg, mapping, providers=providers)
+    mapping_id = str(mapping.get("id") or "")
+    result: dict[str, Any] = {
+        "ok": not bool(plan.get("blocked")),
+        "mapping_id": mapping_id,
+        "ruleset_id": plan.get("ruleset_id"),
+        "dry_run": bool(dry_run),
+        "capacity_error": bool(plan.get("capacity_error")),
+        "overflow_count": int(plan.get("overflow_count") or 0),
+        "planned_additions": int(plan.get("planned_additions") or 0),
+        "planned_removals": int(plan.get("planned_removals") or 0),
+        "added": 0,
+        "removed": 0,
+        "reordered": 0,
+        "unresolved": [],
+        "warnings": list(plan.get("warnings") or []),
+        "per_target": list(plan.get("per_target") or []),
+        "logical_source_count": int(plan.get("logical_source_count") or 0),
+        "logical_aggregated_target_count": int(plan.get("logical_aggregated_target_count") or 0),
+        "managed_target_count": int(plan.get("managed_target_count") or 0),
+        "unmanaged_target_count": int(plan.get("unmanaged_target_count") or 0),
+        "total_capacity": int(plan.get("total_capacity") or 0),
+        "available_capacity": int(plan.get("available_capacity") or 0),
+        "duplicates": list(plan.get("duplicates") or []),
+    }
+    if plan.get("blocked"):
+        result["error"] = "capacity exceeded"
+        result["unresolved_count"] = 0
+        result["finished_at"] = int(time.time())
+        store_result(mapping, result)
+        _emit(emit, "playlist:capacity", mapping=mapping_id, ruleset=plan.get("ruleset_id"), overflow=result["overflow_count"])
+        return result
+    if dry_run:
+        result["added"] = int(plan.get("planned_additions") or 0)
+        result["removed"] = int(plan.get("planned_removals") or 0)
+        _emit(emit, "playlist:dry_run", mapping=mapping_id, additions=result["added"], removals=result["removed"])
+        return result
+    source_by_key = ctx["source_by_key"]
+    target_by_key = ctx["target_by_key"]
+    assignments = ctx["assignments"]
+    applied_ok = True
+    for eid, keys in ctx["target_removals"].items():
+        if not keys:
+            continue
+        tctx = ctx["target_ctx"][eid]
+        items = [_item_dict_from_sources(k, target_by_key, assignments) for k in keys]
+        res = tctx["ops"].remove_playlist_items(tctx["cfg"], tctx["playlist_id"], items, instance=tctx["instance"]) or {}
+        result["removed"] += int(res.get("count") or 0)
+        result["unresolved"].extend(res.get("unresolved") or [])
+        _merge_warnings(result, res)
+        if res.get("capacity"):
+            result["capacity_error"] = True
+        if res.get("ok") is False:
+            applied_ok = False
+        _record_events(_event_rows(mapping_id=mapping_id, ctx={"src": ctx["ruleset"]["id"], "dst": eid, "dst_inst": ""}, operation="remove", items=items))
+    for keyset, op_name in ((ctx["remove_from_source"], "remove"), (ctx["add_to_source"], "add")):
+        if not keyset:
+            continue
+        items = [_item_dict_from_sources(k, source_by_key, target_by_key, assignments) for k in sorted(keyset)]
+        if op_name == "remove":
+            res = ctx["source_ops"].remove_playlist_items(ctx["source_cfg"], ctx["source_playlist_id"], items, instance=ctx["source_inst"]) or {}
+            result["removed"] += int(res.get("count") or 0)
+        else:
+            res = ctx["source_ops"].add_playlist_items(ctx["source_cfg"], ctx["source_playlist_id"], items, instance=ctx["source_inst"]) or {}
+            result["added"] += int(res.get("count") or 0)
+        result["unresolved"].extend(res.get("unresolved") or [])
+        _merge_warnings(result, res)
+        if res.get("capacity"):
+            result["capacity_error"] = True
+        if res.get("ok") is False:
+            applied_ok = False
+        _record_events(_event_rows(mapping_id=mapping_id, ctx={"src": ctx["ruleset"]["id"], "dst": "source", "dst_inst": ""}, operation=op_name, items=items))
+    for eid, keys in ctx["target_additions"].items():
+        if not keys:
+            continue
+        tctx = ctx["target_ctx"][eid]
+        items = [_item_dict_from_sources(k, source_by_key, target_by_key, assignments) for k in keys]
+        res = tctx["ops"].add_playlist_items(tctx["cfg"], tctx["playlist_id"], items, instance=tctx["instance"]) or {}
+        result["added"] += int(res.get("count") or 0)
+        result["unresolved"].extend(res.get("unresolved") or [])
+        _merge_warnings(result, res)
+        if res.get("capacity"):
+            result["capacity_error"] = True
+        if res.get("ok") is False:
+            applied_ok = False
+        _record_events(_event_rows(mapping_id=mapping_id, ctx={"src": ctx["ruleset"]["id"], "dst": eid, "dst_inst": ""}, operation="add", items=items))
+    result["unresolved_count"] = len(result["unresolved"])
+    if result["unresolved_count"] or result["capacity_error"] or not applied_ok:
+        result["ok"] = False
+        result["finished_at"] = int(time.time())
+        store_result(mapping, result)
+        return result
+    now = int(time.time())
+    final_target_keys: set[str] = set(ctx["target_keys"])
+    for keys in ctx["target_additions"].values():
+        final_target_keys.update(keys)
+    for keys in ctx["target_removals"].values():
+        final_target_keys.difference_update(keys)
+    next_assignments: dict[str, dict[str, Any]] = {}
+    for key in sorted(ctx["final_managed"]):
+        eid = str(ctx["assignment_target"].get(key) or _first_physical_endpoint(ctx["physical"], key) or "")
+        if not eid:
+            continue
+        item = _item_dict_from_sources(key, source_by_key, target_by_key, assignments)
+        next_assignments[key] = {
+            "endpoint_id": eid,
+            "managed": True,
+            "previous_logical_source": key in ctx["final_source"],
+            "previous_logical_target": key in final_target_keys,
+            "previous_physical_target": eid,
+            "item": item,
+            "last_success": now,
+        }
+    entry = dict(ctx["state_entry"])
+    entry["assignments"] = next_assignments
+    entry["managed"] = sorted(next_assignments)
+    entry["last_success"] = {
+        "finished_at": now,
+        "source_keys": sorted(ctx["final_source"]),
+        "target_keys": sorted(final_target_keys),
+        "ruleset_id": plan.get("ruleset_id"),
+    }
+    result["managed_count"] = len(next_assignments)
+    result["finished_at"] = now
+    entry["last_result"] = dict(result)
+    _save_state_entry(mapping, entry)
+    _emit(
+        emit,
+        "playlist:done",
+        mapping=mapping_id,
+        ruleset=plan.get("ruleset_id"),
+        targets=len(ctx["endpoint_ids"]),
+        added=result["added"],
+        removed=result["removed"],
+    )
+    return result
+
+
+def _emit(emit: Callable[..., None] | None, event: str, **fields: Any) -> None:
+    if emit is None:
+        return
+    try:
+        emit(event, **fields)
+    except Exception:
+        pass
+
+
+def _record_events(rows: Sequence[Mapping[str, Any]]) -> None:
+    if not rows:
+        return
+    try:
+        from .event_archive import record_events
+
+        record_events(rows)
+    except Exception:
+        pass
+
+
+def _event_rows(
+    *,
+    mapping_id: str,
+    ctx: Mapping[str, Any],
+    operation: str,
+    items: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    from .id_map import canonical_key
+
+    now = int(time.time())
+    rows: list[dict[str, Any]] = []
+    for it in items or []:
+        mt = str(it.get("type") or "").lower()
+        media_type = "episode" if mt == "episode" else ("movie" if mt in ("movie", "") else mt)
+        rows.append(
+            {
+                "domain": "sync",
+                "created_at": now,
+                "event_type": f"playlist_{operation}",
+                "severity": "info",
+                "feature": "playlists",
+                "operation": operation,
+                "pair_key": mapping_id,
+                "direction": "one_way",
+                "source_provider": ctx.get("src"),
+                "source_instance": ctx.get("src_inst"),
+                "destination_provider": ctx.get("dst"),
+                "destination_instance": ctx.get("dst_inst"),
+                "item_key": canonical_key(it),
+                "title": it.get("title"),
+                "year": it.get("year"),
+                "media_type": media_type,
+                "season": it.get("season"),
+                "episode": it.get("episode"),
+                "detail": {"target_playlist": ctx.get("dst_pl"), "mapping": mapping_id},
+            }
+        )
+    return rows
+
+
+def _spotlight_items(items: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    from .id_map import canonical_key
+
+    out: list[dict[str, Any]] = []
+    for it in list(items or [])[:25]:
+        out.append(
+            {
+                "key": canonical_key(it),
+                "title": it.get("title") or it.get("name") or "",
+                "type": it.get("type") or "",
+                "year": it.get("year"),
+                "season": it.get("season"),
+                "episode": it.get("episode"),
+            }
+        )
+    return out
+
+
+def run_mapping(
+    cfg: Mapping[str, Any],
+    mapping: Mapping[str, Any],
+    *,
+    dry_run: bool = False,
+    providers: Mapping[str, Any] | None = None,
+    emit: Callable[..., None] | None = None,
+) -> dict[str, Any]:
+    if mapping.get("ruleset_id"):
+        return _apply_ruleset_mapping(cfg, mapping, dry_run=dry_run, providers=providers, emit=emit)
+    plan, ctx = build_plan(cfg, mapping, providers=providers)
+
+    dst_ops = ctx["dst_ops"]
+    dst_cfg = ctx["dst_cfg"]
+    dst_inst = ctx["dst_inst"]
+    dst_pl = ctx["dst_pl"]
+    baseline: set[str] = set(ctx["baseline"])
+    mapping_id = str(mapping.get("id") or "")
+
+    result: dict[str, Any] = {
+        "ok": True,
+        "mapping_id": mapping_id,
+        "dry_run": bool(dry_run),
+        "membership": plan.membership,
+        "order": plan.order,
+        "planned_additions": len(plan.additions),
+        "planned_removals": len(plan.removals),
+        "added": 0,
+        "removed": 0,
+        "reordered": 0,
+        "unresolved": [],
+        "warnings": list(plan.warnings),
+        "manual_affected": plan.manual_affected,
+    }
+
+    remove_items = list(plan.remove_items)
+    runtime = cfg.get("runtime") or {}
+    min_prev = int(runtime.get("suspect_min_prev", 20) or 20)
+    if (
+        plan.membership in (MEMBERSHIP_MANAGED_ONLY, MEMBERSHIP_MIRROR)
+        and remove_items
+        and len(ctx["dst_set"]) >= min_prev
+    ):
+        allow_mass_delete = bool(mapping.get("allow_mass_delete"))
+        ratio = float(runtime.get("suspect_shrink_ratio", 0.10) or 0.10)
+        try:
+            from .orchestrator._pairs_massdelete import maybe_block_mass_delete
+
+            guarded = maybe_block_mass_delete(
+                remove_items,
+                len(ctx["dst_set"]),
+                allow_mass_delete=allow_mass_delete,
+                suspect_ratio=ratio,
+                emit=(lambda ev, **kw: _emit(emit, ev, **kw)),
+                dbg=(lambda *a, **k: None),
+                dst_name=str(ctx["dst"]),
+                feature="playlists",
+            )
+        except Exception:
+            guarded = remove_items
+        if len(guarded) != len(remove_items):
+            result["warnings"].append("mass_delete_blocked")
+        remove_items = guarded
+
+    applied_add_keys: set[str] = set()
+    applied_remove_keys: set[str] = set()
+
+    if dry_run:
+        result["added"] = len(plan.add_items)
+        result["removed"] = len(remove_items)
+        result["reordered"] = plan.reorder_count
+        _emit(emit, "playlist:dry_run", mapping=mapping_id, additions=result["added"], removals=result["removed"])
+        return result
+
+    from .id_map import canonical_key
+
+    if plan.add_items:
+        add_res = dst_ops.add_playlist_items(dst_cfg, dst_pl, plan.add_items, instance=dst_inst) or {}
+        result["added"] = int(add_res.get("count") or 0)
+        result["unresolved"].extend(add_res.get("unresolved") or [])
+        _merge_warnings(result, add_res)
+        confirmed = set(add_res.get("confirmed_keys") or [])
+        if not confirmed and result["added"]:
+            confirmed = {canonical_key(it) for it in plan.add_items}
+        applied_add_keys = confirmed
+        if add_res.get("capacity"):
+            result["warnings"].append(f"capacity:{add_res.get('capacity')}")
+        added_items = [it for it in plan.add_items if canonical_key(it) in confirmed]
+        _record_events(_event_rows(mapping_id=mapping_id, ctx=ctx, operation="add", items=added_items))
+        if result["added"]:
+            _emit(
+                emit,
+                "apply:add:done",
+                feature="playlists",
+                mapping=mapping_id,
+                count=result["added"],
+                result={"count": result["added"], "confirmed_keys": list(confirmed)},
+                spotlight=_spotlight_items(added_items),
+            )
+
+    if remove_items:
+        rm_res = dst_ops.remove_playlist_items(dst_cfg, dst_pl, remove_items, instance=dst_inst) or {}
+        result["removed"] = int(rm_res.get("count") or 0)
+        result["unresolved"].extend(rm_res.get("unresolved") or [])
+        _merge_warnings(result, rm_res)
+        confirmed_rm = set(rm_res.get("confirmed_keys") or [])
+        if not confirmed_rm and result["removed"]:
+            confirmed_rm = {canonical_key(it) for it in remove_items}
+        applied_remove_keys = confirmed_rm
+        removed_items = [it for it in remove_items if canonical_key(it) in confirmed_rm]
+        _record_events(_event_rows(mapping_id=mapping_id, ctx=ctx, operation="remove", items=removed_items))
+        if result["removed"]:
+            _emit(
+                emit,
+                "apply:remove:done",
+                feature="playlists",
+                mapping=mapping_id,
+                count=result["removed"],
+                result={"count": result["removed"], "confirmed_keys": list(confirmed_rm)},
+                spotlight=_spotlight_items(removed_items),
+            )
+
+    if plan.order == ORDER_PRESERVE and plan.reorder_count and plan.target_order:
+        try:
+            dst_snap2 = dst_ops.get_playlist_snapshot(dst_cfg, dst_pl, instance=dst_inst)
+            present = set(dst_snap2.by_key().keys())
+        except Exception:
+            present = set()
+        target_order = [k for k in plan.target_order if not present or k in present]
+        if ctx["dst_resource"].can_reorder and target_order:
+            ro = dst_ops.reorder_playlist_items(dst_cfg, dst_pl, target_order, instance=dst_inst) or {}
+            result["reordered"] = int(ro.get("reordered") or ro.get("count") or 0)
+            if result["reordered"]:
+                _emit(
+                    emit,
+                    "apply:update:done",
+                    feature="playlists",
+                    mapping=mapping_id,
+                    count=result["reordered"],
+                    result={"count": result["reordered"]},
+                )
+
+    new_managed = (baseline | applied_add_keys) - applied_remove_keys
+    if plan.membership == MEMBERSHIP_MIRROR:
+        new_managed = (ctx["src_set"] & ((ctx["dst_set"] | applied_add_keys) - applied_remove_keys))
+    save_baseline(
+        mapping,
+        new_managed,
+        meta={
+            "membership": plan.membership,
+            "order": plan.order,
+            "last_added": result["added"],
+            "last_removed": result["removed"],
+        },
+    )
+    result["managed_count"] = len(new_managed)
+    result["unresolved_count"] = len(result["unresolved"])
+    result["finished_at"] = int(time.time())
+    store_result(mapping, result)
+    _emit(
+        emit,
+        "playlist:done",
+        mapping=mapping_id,
+        added=result["added"],
+        removed=result["removed"],
+        reordered=result["reordered"],
+    )
+    return result

--- a/services/playlists.py
+++ b/services/playlists.py
@@ -1,0 +1,942 @@
+# services/playlists.py
+# CrossWatch - Playlist endpoints, mapping profiles and run service
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping
+
+from cw_platform.playlists import BUILTIN_RULESETS, playlist_capabilities, supports_playlists, validate_ruleset
+from cw_platform.provider_instances import (
+    build_provider_config_view,
+    list_instance_ids,
+    normalize_instance_id,
+)
+from cw_platform import playlists_runner as runner
+
+_MEMBERSHIP = {"add_only", "managed_only", "mirror"}
+_ORDER = {"ignore", "preserve"}
+_NAME_MAX = 10
+_PLAYLIST_NAME_MAX = 20
+_SAFE_NAME_CHARS = " _.'-&()"
+
+
+def _safe_name_error(name: Any, label: str, max_len: int) -> str:
+    s = str(name or "").strip()
+    if not s:
+        return f"{label} required"
+    if len(s) > max_len:
+        return f"{label} must be {max_len} characters or fewer"
+    if not s[0].isalnum():
+        return f"{label} must start with a letter or number"
+    if any(not (ch.isalnum() or ch in _SAFE_NAME_CHARS) for ch in s):
+        return f"{label} contains unsupported characters"
+    return ""
+
+
+def _name_error(name: Any, label: str) -> str:
+    return _safe_name_error(name, label, _NAME_MAX)
+
+
+def _playlist_name_error(name: Any) -> str:
+    return _safe_name_error(name, "new playlist name", _PLAYLIST_NAME_MAX)
+
+
+def _clean_target_ids(payload: Mapping[str, Any]) -> list[str]:
+    raw = payload.get("target_endpoints")
+    out: list[str] = []
+    if isinstance(raw, list):
+        for x in raw:
+            s = str((x or {}).get("id") if isinstance(x, Mapping) else x).strip()
+            if s and s not in out:
+                out.append(s)
+    return out
+
+
+
+def _providers() -> dict[str, Any]:
+    from cw_platform.orchestrator._providers import load_sync_providers
+
+    return load_sync_providers()
+
+
+def _label_for(ops: Any, provider: str) -> str:
+    getter = getattr(ops, "label", None)
+    if callable(getter):
+        try:
+            return str(getter())
+        except Exception:
+            pass
+    return provider.title()
+
+
+def _cfg_pairs(cfg: Mapping[str, Any]) -> list[dict[str, Any]]:
+    pairs = cfg.get("pairs")
+    return [p for p in pairs if isinstance(p, dict)] if isinstance(pairs, list) else []
+
+
+def _find_pair(cfg: Mapping[str, Any], pair_id: str) -> dict[str, Any] | None:
+    pid = str(pair_id or "").strip()
+    for p in _cfg_pairs(cfg):
+        if str(p.get("id") or "") == pid:
+            return p
+    return None
+
+
+# Providers / resources
+
+def list_playlist_providers(cfg: Mapping[str, Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    provs = _providers()
+    for name, ops in sorted(provs.items()):
+        if not supports_playlists(ops):
+            continue
+        caps = playlist_capabilities(ops)
+        label = _label_for(ops, name)
+        is_conf = getattr(ops, "is_configured", None)
+        for inst in list_instance_ids(cfg, name):
+            configured = True
+            if callable(is_conf):
+                try:
+                    configured = bool(is_conf(build_provider_config_view(cfg, name, inst)))
+                except Exception:
+                    configured = False
+            out.append(
+                {
+                    "provider": name,
+                    "instance": inst,
+                    "label": label,
+                    "configured": configured,
+                    "capabilities": caps,
+                }
+            )
+    return out
+
+
+def list_resources(cfg: Mapping[str, Any], provider: str, instance: str | None = None) -> dict[str, Any]:
+    name = str(provider or "").strip().upper()
+    inst = normalize_instance_id(instance)
+    ops = _providers().get(name)
+    if not ops or not supports_playlists(ops):
+        return {"ok": False, "error": "provider not playlist-capable", "resources": []}
+    try:
+        view = build_provider_config_view(cfg, name, inst)
+        resources = ops.list_playlist_resources(view, instance=inst) or []
+    except Exception as e:
+        return {"ok": False, "error": str(e), "resources": []}
+    return {"ok": True, "provider": name, "instance": inst, "resources": [r.to_dict() for r in resources]}
+
+
+# Endpoints
+
+def _clean_endpoint(payload: Mapping[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "id": str(payload.get("id") or "").strip(),
+        "name": str(payload.get("name") or "").strip(),
+        "provider": str(payload.get("provider") or "").strip().upper(),
+        "instance": normalize_instance_id(payload.get("instance")),
+        "playlist_id": str(payload.get("playlist_id") or "").strip(),
+        "playlist_name": str(payload.get("playlist_name") or "").strip(),
+    }
+    playlist_type = str(payload.get("playlist_type") or payload.get("endpoint_type") or "").strip().lower()
+    if playlist_type:
+        out["playlist_type"] = playlist_type
+    media_types = payload.get("media_types")
+    if isinstance(media_types, list):
+        out["media_types"] = [str(x).strip().lower() for x in media_types if str(x).strip()]
+    return out
+
+
+def list_endpoints(cfg: Mapping[str, Any]) -> list[dict[str, Any]]:
+    provs = _providers()
+    out: list[dict[str, Any]] = []
+    for ep in runner.list_endpoints(cfg):
+        ep = dict(ep)
+        ep["provider_label"] = _label_for(provs.get(str(ep.get("provider") or "").upper()), str(ep.get("provider") or ""))
+        out.append(ep)
+    return out
+
+
+def provider_count_summary(cfg: Mapping[str, Any]) -> dict[str, Any]:
+    counts: dict[str, int] = {}
+    inst_counts: dict[str, dict[str, int]] = {}
+
+    def add(provider: Any, instance: Any, count: Any) -> None:
+        key = str(provider or "").strip().lower()
+        if not key:
+            return
+        try:
+            n = max(0, int(count or 0))
+        except Exception:
+            return
+        inst = str(instance or "default").strip() or "default"
+        counts[key] = max(int(counts.get(key) or 0), n)
+        by_inst = inst_counts.setdefault(key, {})
+        by_inst[inst] = max(int(by_inst.get(inst) or 0), n)
+
+    for ep in list_endpoints(cfg):
+        if not isinstance(ep, Mapping):
+            continue
+        raw_count = ep.get("item_count")
+        if raw_count is None:
+            continue
+        add(ep.get("provider"), ep.get("instance"), raw_count)
+
+    try:
+        profiles = runner.list_mapping_profiles(cfg) or []
+    except Exception:
+        profiles = []
+
+    for profile in profiles:
+        if not isinstance(profile, Mapping):
+            continue
+        resolved = runner.resolve_mapping(cfg, profile)
+        if not resolved:
+            continue
+        try:
+            result = runner.load_result(resolved) or {}
+        except Exception:
+            result = {}
+        if not isinstance(result, Mapping) or not result.get("finished_at"):
+            continue
+        targets = resolved.get("targets") if isinstance(resolved, Mapping) else None
+        if not isinstance(targets, list) or not targets:
+            continue
+        per_target = result.get("per_target")
+        if isinstance(per_target, list) and per_target:
+            by_eid: dict[str, int] = {}
+            for row in per_target:
+                if not isinstance(row, Mapping):
+                    continue
+                eid = str(row.get("endpoint_id") or "").strip()
+                if not eid:
+                    continue
+                count = int(row.get("current_count") or 0)
+                count += int(row.get("planned_additions") or 0)
+                count -= int(row.get("planned_removals") or 0)
+                by_eid[eid] = max(0, count)
+            for target in targets:
+                if not isinstance(target, Mapping):
+                    continue
+                count = by_eid.get(str(target.get("endpoint_id") or "").strip())
+                if count is not None:
+                    add(target.get("provider"), target.get("instance"), count)
+            continue
+        count = int(result.get("managed_count") or result.get("target_count") or 0)
+        if count <= 0:
+            continue
+        target = targets[0]
+        if isinstance(target, Mapping):
+            add(target.get("provider"), target.get("instance"), count)
+
+    return {"providers": counts, "providers_instances": inst_counts}
+
+
+def _snapshot_count(cfg: Mapping[str, Any], provider: str, instance: str, playlist_id: str) -> int | None:
+    ops = _providers().get(str(provider or "").upper())
+    if not ops or not supports_playlists(ops) or not playlist_id:
+        return None
+    try:
+        view = build_provider_config_view(cfg, provider, instance)
+        snap = ops.get_playlist_snapshot(view, playlist_id, instance=instance)
+        return len(snap.items)
+    except Exception:
+        return None
+
+
+def _resource_meta(cfg: Mapping[str, Any], provider: str, instance: str, playlist_id: str) -> dict[str, Any]:
+    ops = _providers().get(str(provider or "").upper())
+    if not ops or not supports_playlists(ops) or not playlist_id:
+        return {}
+    try:
+        view = build_provider_config_view(cfg, provider, instance)
+        for res in ops.list_playlist_resources(view, instance=instance) or []:
+            raw_id = str((res.extra or {}).get("raw_id") or "").strip()
+            if res.id == playlist_id or raw_id == playlist_id:
+                extra = res.extra or {}
+                out: dict[str, Any] = {
+                    "playlist_type": str(extra.get("endpoint_type") or res.kind or "").strip().lower(),
+                    "media_types": list(res.media_types or []),
+                    "can_reorder": bool(res.can_reorder),
+                    "destructive_remove": bool(extra.get("destructive_remove")),
+                    "remove_warning": str(extra.get("remove_warning") or "").strip(),
+                    "warnings": [str(w) for w in (extra.get("warnings") or []) if str(w).strip()],
+                }
+                return {k: v for k, v in out.items() if v not in ("", [], None)}
+    except Exception:
+        return {}
+    return {}
+
+
+def _refresh_endpoint_meta(cfg: dict[str, Any], endpoint_id: str) -> dict[str, Any] | None:
+    root = runner.pl_root(cfg, create=True)
+    for ep in root["endpoints"]:
+        if isinstance(ep, dict) and str(ep.get("id") or "") == str(endpoint_id):
+            provider = str(ep.get("provider") or "").strip().upper()
+            instance = normalize_instance_id(ep.get("instance"))
+            playlist_id = str(ep.get("playlist_id") or "")
+            ep.update(_resource_meta(cfg, provider, instance, playlist_id))
+            cnt = _snapshot_count(cfg, provider, instance, playlist_id)
+            if cnt is not None:
+                ep["item_count"] = cnt
+            ep["last_synced"] = int(time.time())
+            return dict(ep)
+    return None
+
+
+def sync_endpoint(cfg: dict[str, Any], endpoint_id: str) -> dict[str, Any]:
+    ep = _refresh_endpoint_meta(cfg, endpoint_id)
+    if ep is None:
+        return {"ok": False, "error": "endpoint not found"}
+    _save(cfg)
+    return {"ok": True, "endpoint": ep}
+
+
+def activity(cfg: Mapping[str, Any], *, limit: int = 25) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for ep in list_endpoints(cfg):
+        ts = ep.get("last_synced")
+        if ts:
+            rows.append({
+                "ts": int(ts), "type": "Sync", "status": "completed",
+                "label": f"{ep.get('provider_label') or ep.get('provider')} · {ep.get('name')}",
+                "details": (f"{ep.get('item_count')} items" if ep.get("item_count") is not None else ""),
+            })
+    for m in list_mappings(cfg):
+        r = m.get("last_result") or {}
+        if isinstance(r, Mapping) and r.get("finished_at"):
+            finished_at = int(r.get("finished_at") or 0)
+            src = (m.get("source") or {}).get("label"); dst = (m.get("target") or {}).get("label")
+            rows.append({
+                "ts": finished_at, "type": "Run", "status": "completed" if r.get("ok", True) else "error",
+                "label": f"{m.get('id')} · {src} → {dst}",
+                "details": f"{(m.get('ruleset') or {}).get('name') or r.get('ruleset_id') or 'direct'}, {len(m.get('targets') or [])} target(s), +{int(r.get('added', 0))}/-{int(r.get('removed', 0))}" + (", capacity error" if r.get("capacity_error") else ""),
+            })
+    rows.sort(key=lambda x: x["ts"], reverse=True)
+    return rows[: max(1, int(limit))]
+
+
+def upsert_endpoint(cfg: dict[str, Any], payload: Mapping[str, Any]) -> dict[str, Any]:
+    clean = _clean_endpoint(payload)
+    name_err = _name_error(clean["name"], "endpoint name")
+    if name_err:
+        return {"ok": False, "error": name_err}
+    if not clean["provider"]:
+        return {"ok": False, "error": "provider required"}
+    ops = _providers().get(clean["provider"])
+    if not ops or not supports_playlists(ops):
+        return {"ok": False, "error": "provider not playlist-capable"}
+
+    create = bool(payload.get("create"))
+    create_name = str(payload.get("create_name") or clean["name"] or "").strip()
+    if create and not clean["playlist_id"]:
+        create_err = _playlist_name_error(create_name)
+        if create_err:
+            return {"ok": False, "error": create_err}
+        media_type = str(payload.get("media_type") or "movie").strip().lower()
+        try:
+            view = build_provider_config_view(cfg, clean["provider"], clean["instance"])
+            res = ops.create_playlist(view, create_name, media_type=media_type, instance=clean["instance"])
+            clean["playlist_id"] = res.id
+            clean["playlist_name"] = clean["playlist_name"] or res.name
+        except Exception as e:
+            return {"ok": False, "error": f"create failed: {e}"}
+
+    if not clean["playlist_id"]:
+        return {"ok": False, "error": "playlist required"}
+    root = runner.pl_root(cfg, create=True)
+    endpoints = root["endpoints"]
+    if clean["id"]:
+        for i, ep in enumerate(endpoints):
+            if isinstance(ep, Mapping) and str(ep.get("id") or "") == clean["id"]:
+                endpoints[i] = clean
+                out = _refresh_endpoint_meta(cfg, clean["id"]) or clean
+                _refresh_mapping_pairs_for_endpoint(cfg, clean["id"])
+                _save(cfg)
+                return {"ok": True, "endpoint": out, "created": False}
+    clean["id"] = runner.next_id(endpoints, runner.ENDPOINT_PREFIX)
+    endpoints.append(clean)
+    out = _refresh_endpoint_meta(cfg, clean["id"]) or clean
+    _save(cfg)
+    return {"ok": True, "endpoint": out, "created": True}
+
+
+def delete_endpoint(cfg: dict[str, Any], endpoint_id: str) -> dict[str, Any]:
+    eid = str(endpoint_id or "").strip()
+    used_by = [
+        str(m.get("id"))
+        for m in runner.list_mapping_profiles(cfg)
+        if str(m.get("source_endpoint") or "") == eid or eid in _clean_target_ids(m)
+    ]
+    if used_by:
+        return {"ok": False, "error": f"endpoint in use by {', '.join(used_by)}"}
+    root = runner.pl_root(cfg, create=True)
+    before = len(root["endpoints"])
+    root["endpoints"] = [e for e in root["endpoints"] if str((e or {}).get("id") or "") != eid]
+    if len(root["endpoints"]) == before:
+        return {"ok": False, "error": "endpoint not found"}
+    _save(cfg)
+    return {"ok": True}
+
+
+# Mapping profiles
+
+def _clean_mapping(payload: Mapping[str, Any]) -> dict[str, Any]:
+    membership = str(payload.get("membership") or "").strip().lower()
+    if membership not in _MEMBERSHIP:
+        membership = "managed_only"
+    order = str(payload.get("order") or "").strip().lower()
+    if order not in _ORDER:
+        order = "ignore"
+    target_ids = _clean_target_ids(payload)
+    out: dict[str, Any] = {
+        "id": str(payload.get("id") or "").strip(),
+        "name": str(payload.get("name") or "").strip(),
+        "source_endpoint": str(payload.get("source_endpoint") or "").strip(),
+        "target_endpoints": target_ids,
+        "ruleset_id": str(payload.get("ruleset_id") or "").strip(),
+        "membership": membership,
+        "order": order,
+        "enabled": bool(payload.get("enabled", True)),
+    }
+    if payload.get("allow_mass_delete"):
+        out["allow_mass_delete"] = True
+    return out
+
+
+def _endpoint_reorderable(cfg: Mapping[str, Any], endpoint_id: str) -> bool:
+    ep = runner.get_endpoint(cfg, endpoint_id)
+    if not ep:
+        return True
+    if "can_reorder" in ep:
+        return bool(ep.get("can_reorder"))
+    ops = _providers().get(str(ep.get("provider") or "").upper())
+    if not ops:
+        return True
+    return bool(playlist_capabilities(ops).get("reorder", True))
+
+
+def validate_mapping(cfg: Mapping[str, Any], payload: Mapping[str, Any]) -> tuple[bool, str]:
+    clean = _clean_mapping(payload)
+    name_err = _name_error(clean["name"], "mapping name")
+    if name_err:
+        return False, name_err
+    if not clean["source_endpoint"] or not clean["target_endpoints"]:
+        return False, "source and target endpoints required"
+    if clean["source_endpoint"] in clean["target_endpoints"]:
+        return False, "source and target must differ"
+    if not runner.get_endpoint(cfg, clean["source_endpoint"]):
+        return False, "source endpoint not found"
+    if len(clean["target_endpoints"]) != len(set(clean["target_endpoints"])):
+        return False, "duplicate target endpoints are not allowed"
+    for tid in clean["target_endpoints"]:
+        if not runner.get_endpoint(cfg, tid):
+            return False, "target endpoint not found"
+    target_pairs: set[tuple[str, str]] = set()
+    for tid in clean["target_endpoints"]:
+        ep = runner.get_endpoint(cfg, tid) or {}
+        target_pairs.add((str(ep.get("provider") or "").strip().upper(), normalize_instance_id(ep.get("instance"))))
+    if len(target_pairs) > 1:
+        return False, "target endpoints must share the same provider profile"
+    if clean["ruleset_id"]:
+        rs = runner.get_ruleset(cfg, clean["ruleset_id"])
+        if not rs:
+            return False, "ruleset not found"
+        if len(clean["target_endpoints"]) > int(rs.get("maximum_targets") or 1):
+            return False, "too many target endpoints for ruleset"
+    elif len(clean["target_endpoints"]) != 1:
+        return False, "direct mappings require exactly one target endpoint"
+    first_target = clean["target_endpoints"][0]
+    if clean["order"] == "preserve" and not _endpoint_reorderable(cfg, first_target):
+        return False, "target provider does not support ordering; use order 'ignore'"
+    return True, ""
+
+
+def assigned_pair_of(cfg: Mapping[str, Any], mapping_id: str) -> str | None:
+    mid = str(mapping_id or "").strip()
+    for p in _cfg_pairs(cfg):
+        if mid in runner.pair_mapping_ids(p):
+            return str(p.get("id") or "")
+    return None
+
+
+def _pair_playlist_block(pair: Mapping[str, Any]) -> dict[str, Any]:
+    feats = pair.get("features") if isinstance(pair, Mapping) else None
+    pl = feats.get("playlists") if isinstance(feats, Mapping) else None
+    return dict(pl) if isinstance(pl, Mapping) else {}
+
+
+def _managed_playlist_pair_for(pair: Mapping[str, Any], mapping_id: str) -> bool:
+    pl = _pair_playlist_block(pair)
+    return str(pl.get("managed_by") or "") == "playlists" and str(pl.get("mapping_id") or "") == str(mapping_id)
+
+
+def _mapping_direction_mode(cfg: Mapping[str, Any], clean: Mapping[str, Any]) -> str:
+    rs = runner.get_ruleset(cfg, clean.get("ruleset_id")) if clean.get("ruleset_id") else None
+    return "two-way" if rs and str(rs.get("direction") or "") == "bidirectional" else "one-way"
+
+
+def _new_pair_id(pairs: list[dict[str, Any]]) -> str:
+    existing = {str(p.get("id") or "") for p in pairs if isinstance(p, Mapping)}
+    for _ in range(20):
+        pid = f"pair_playlist_{uuid.uuid4().hex[:12]}"
+        if pid not in existing:
+            return pid
+    return f"pair_playlist_{int(time.time())}"
+
+
+def _pair_payload_for_mapping(cfg: Mapping[str, Any], clean: Mapping[str, Any]) -> tuple[bool, str, dict[str, Any] | None]:
+    src_ep = runner.get_endpoint(cfg, clean.get("source_endpoint")) or {}
+    target_eps = [runner.get_endpoint(cfg, tid) or {} for tid in _clean_target_ids(clean)]
+    target_pairs = {
+        (str(ep.get("provider") or "").strip().upper(), normalize_instance_id(ep.get("instance")))
+        for ep in target_eps
+        if ep
+    }
+    if not src_ep or not target_pairs:
+        return False, "source and target endpoints required", None
+    if len(target_pairs) != 1:
+        return False, "target endpoints must share the same provider profile", None
+    target_provider, target_instance = next(iter(target_pairs))
+    source_provider = str(src_ep.get("provider") or "").strip().upper()
+    source_instance = normalize_instance_id(src_ep.get("instance"))
+    mapping_id = str(clean.get("id") or "").strip()
+    if not mapping_id:
+        return False, "mapping id required", None
+    return True, "", {
+        "source": source_provider,
+        "target": target_provider,
+        "source_instance": source_instance,
+        "target_instance": target_instance,
+        "mode": _mapping_direction_mode(cfg, clean),
+        "enabled": bool(clean.get("enabled", True)),
+        "features": {
+            "playlists": {
+                "enable": True,
+                "mappings": [mapping_id],
+                "managed_by": "playlists",
+                "mapping_id": mapping_id,
+            }
+        },
+    }
+
+
+def _ensure_mapping_pair(cfg: dict[str, Any], clean: Mapping[str, Any]) -> tuple[bool, str, str]:
+    pairs = cfg.get("pairs")
+    if not isinstance(pairs, list):
+        pairs = []
+        cfg["pairs"] = pairs
+    ok, why, payload = _pair_payload_for_mapping(cfg, clean)
+    if not ok or payload is None:
+        return False, why, ""
+    mid = str(clean.get("id") or "").strip()
+    existing: dict[str, Any] | None = None
+    for pair in pairs:
+        if isinstance(pair, dict) and _managed_playlist_pair_for(pair, mid):
+            existing = pair
+            break
+    if existing is None:
+        for pair in pairs:
+            if not isinstance(pair, dict):
+                continue
+            if mid in runner.pair_mapping_ids(pair):
+                feats = pair.get("features")
+                pl = feats.get("playlists") if isinstance(feats, dict) else None
+                if isinstance(pl, dict):
+                    pl["mappings"] = [x for x in runner.pair_mapping_ids(pair) if x != mid]
+    if existing is None:
+        item = dict(payload)
+        item["id"] = _new_pair_id(pairs)
+        pairs.append(item)
+        return True, "", item["id"]
+    existing.update(payload)
+    existing.setdefault("id", _new_pair_id(pairs))
+    return True, "", str(existing.get("id") or "")
+
+
+def _remove_mapping_from_pairs(cfg: dict[str, Any], mapping_id: str) -> None:
+    pairs = cfg.get("pairs")
+    if not isinstance(pairs, list):
+        return
+    kept: list[dict[str, Any]] = []
+    for pair in pairs:
+        if not isinstance(pair, dict):
+            kept.append(pair)
+            continue
+        feats = pair.get("features")
+        pl = feats.get("playlists") if isinstance(feats, dict) else None
+        if not isinstance(pl, dict):
+            kept.append(pair)
+            continue
+        if _managed_playlist_pair_for(pair, mapping_id):
+            continue
+        ids = [x for x in runner.pair_mapping_ids(pair) if x != mapping_id]
+        if ids != runner.pair_mapping_ids(pair):
+            pl["mappings"] = ids
+            if not ids and str(pl.get("managed_by") or "") == "playlists":
+                continue
+        kept.append(pair)
+    cfg["pairs"] = kept
+
+
+def _refresh_mapping_pairs_for_endpoint(cfg: dict[str, Any], endpoint_id: str) -> None:
+    eid = str(endpoint_id or "").strip()
+    if not eid:
+        return
+    for mapping in runner.list_mapping_profiles(cfg):
+        if str(mapping.get("source_endpoint") or "") == eid or eid in _clean_target_ids(mapping):
+            _ensure_mapping_pair(cfg, _clean_mapping(mapping))
+
+
+def _refresh_mapping_pairs_for_ruleset(cfg: dict[str, Any], ruleset_id: str) -> None:
+    rid = str(ruleset_id or "").strip()
+    if not rid:
+        return
+    for mapping in runner.list_mapping_profiles(cfg):
+        if str(mapping.get("ruleset_id") or "") == rid:
+            _ensure_mapping_pair(cfg, _clean_mapping(mapping))
+
+
+def reconcile_mapping_pairs(cfg: dict[str, Any]) -> dict[str, Any]:
+    created: list[str] = []
+    errors: list[str] = []
+    for mapping in runner.list_mapping_profiles(cfg):
+        clean = _clean_mapping(mapping)
+        mid = clean.get("id") or ""
+        if not mid or assigned_pair_of(cfg, mid):
+            continue
+        ok, why, pair_id = _ensure_mapping_pair(cfg, clean)
+        if ok and pair_id:
+            created.append(pair_id)
+        elif why:
+            errors.append(f"{mid}: {why}")
+    if created:
+        _save(cfg)
+    return {"ok": not errors, "created": created, "errors": errors}
+
+
+def _enrich_mapping(cfg: Mapping[str, Any], profile: Mapping[str, Any]) -> dict[str, Any]:
+    provs = _providers()
+    clean = _clean_mapping(profile)
+    resolved = runner.resolve_mapping(cfg, profile)
+    valid = resolved is not None
+    src_ep = runner.get_endpoint(cfg, clean["source_endpoint"]) or {}
+    first_target = clean["target_endpoints"][0] if clean["target_endpoints"] else ""
+    dst_ep = runner.get_endpoint(cfg, first_target) or {}
+    target_eps = [runner.get_endpoint(cfg, tid) or {} for tid in clean["target_endpoints"]]
+    result = None
+    if resolved:
+        try:
+            result = runner.load_result(resolved)
+        except Exception:
+            result = None
+    clean.update(
+        {
+            "valid": valid,
+            "source": {
+                "endpoint_id": clean["source_endpoint"],
+                "name": src_ep.get("name"),
+                "provider": str(src_ep.get("provider") or "").upper(),
+                "instance": normalize_instance_id(src_ep.get("instance")),
+                "playlist_name": src_ep.get("playlist_name"),
+                "label": _label_for(provs.get(str(src_ep.get("provider") or "").upper()), str(src_ep.get("provider") or "")),
+            },
+            "target": {
+                "endpoint_id": first_target,
+                "name": dst_ep.get("name"),
+                "provider": str(dst_ep.get("provider") or "").upper(),
+                "instance": normalize_instance_id(dst_ep.get("instance")),
+                "playlist_name": dst_ep.get("playlist_name"),
+                "label": _label_for(provs.get(str(dst_ep.get("provider") or "").upper()), str(dst_ep.get("provider") or "")),
+            },
+            "targets": [
+                {
+                    "endpoint_id": str(ep.get("id") or ""),
+                    "name": ep.get("name"),
+                    "provider": str(ep.get("provider") or "").upper(),
+                    "instance": normalize_instance_id(ep.get("instance")),
+                    "playlist_name": ep.get("playlist_name"),
+                    "label": _label_for(provs.get(str(ep.get("provider") or "").upper()), str(ep.get("provider") or "")),
+                }
+                for ep in target_eps
+                if ep
+            ],
+            "ruleset": runner.get_ruleset(cfg, clean["ruleset_id"]) if clean["ruleset_id"] else None,
+            "assigned_pair": assigned_pair_of(cfg, clean["id"]),
+            "last_result": result,
+        }
+    )
+    pair_id = clean.get("assigned_pair") or assigned_pair_of(cfg, clean["id"])
+    if pair_id:
+        clean["assigned_pair"] = pair_id
+        pair = _find_pair(cfg, pair_id)
+        if pair:
+            clean["assigned_pair_label"] = (
+                f"{pair.get('source')}:{normalize_instance_id(pair.get('source_instance'))}"
+                f" -> {pair.get('target')}:{normalize_instance_id(pair.get('target_instance'))}"
+            )
+    return clean
+
+
+def list_mappings(cfg: Mapping[str, Any]) -> list[dict[str, Any]]:
+    if isinstance(cfg, dict):
+        reconcile_mapping_pairs(cfg)
+    return [_enrich_mapping(cfg, m) for m in runner.list_mapping_profiles(cfg)]
+
+
+def get_mapping(cfg: Mapping[str, Any], mapping_id: str) -> dict[str, Any] | None:
+    return runner.get_mapping_profile(cfg, mapping_id)
+
+
+def upsert_mapping(cfg: dict[str, Any], payload: Mapping[str, Any]) -> dict[str, Any]:
+    ok, why = validate_mapping(cfg, payload)
+    if not ok:
+        return {"ok": False, "error": why}
+    clean = _clean_mapping(payload)
+    root = runner.pl_root(cfg, create=True)
+    mappings = root["mappings"]
+    mid = clean["id"]
+    if mid:
+        for i, m in enumerate(mappings):
+            if isinstance(m, Mapping) and str(m.get("id") or "") == mid:
+                pair_ok, pair_error, pair_id = _ensure_mapping_pair(cfg, clean)
+                if not pair_ok:
+                    return {"ok": False, "error": pair_error}
+                mappings[i] = clean
+                _save(cfg)
+                out = _enrich_mapping(cfg, clean)
+                out["assigned_pair"] = pair_id or out.get("assigned_pair")
+                return {"ok": True, "mapping": out, "created": False, "pair_id": pair_id}
+    clean["id"] = runner.next_id(mappings, runner.MAPPING_PREFIX)
+    pair_ok, pair_error, pair_id = _ensure_mapping_pair(cfg, clean)
+    if not pair_ok:
+        return {"ok": False, "error": pair_error}
+    mappings.append(clean)
+    _save(cfg)
+    out = _enrich_mapping(cfg, clean)
+    out["assigned_pair"] = pair_id or out.get("assigned_pair")
+    return {"ok": True, "mapping": out, "created": True, "pair_id": pair_id}
+
+
+def delete_mapping(cfg: dict[str, Any], mapping_id: str) -> dict[str, Any]:
+    mid = str(mapping_id or "").strip()
+    root = runner.pl_root(cfg, create=True)
+    target = None
+    for m in root["mappings"]:
+        if isinstance(m, Mapping) and str(m.get("id") or "") == mid:
+            target = m
+            break
+    if target is None:
+        return {"ok": False, "error": "mapping not found"}
+    resolved = runner.resolve_mapping(cfg, target)
+    if resolved:
+        try:
+            runner.delete_baseline(resolved)
+        except Exception:
+            pass
+    _remove_mapping_from_pairs(cfg, mid)
+    root["mappings"] = [m for m in root["mappings"] if m is not target]
+    for p in _cfg_pairs(cfg):
+        feats = p.get("features") if isinstance(p, dict) else None
+        pl = feats.get("playlists") if isinstance(feats, dict) else None
+        if isinstance(pl, dict) and isinstance(pl.get("mappings"), list):
+            pl["mappings"] = [x for x in pl["mappings"] if str(x).strip() != mid]
+    _save(cfg)
+    return {"ok": True}
+
+
+def list_rulesets(cfg: Mapping[str, Any]) -> list[dict[str, Any]]:
+    return runner.list_rulesets(cfg)
+
+
+def get_ruleset(cfg: Mapping[str, Any], ruleset_id: str) -> dict[str, Any] | None:
+    return runner.get_ruleset(cfg, ruleset_id)
+
+
+def upsert_ruleset(cfg: dict[str, Any], payload: Mapping[str, Any]) -> dict[str, Any]:
+    raw = dict(payload or {})
+    rid = str(raw.get("id") or "").strip()
+    if rid in BUILTIN_RULESETS:
+        return {"ok": False, "error": "built in rulesets are immutable"}
+    raw["built_in"] = False
+    ok, why, clean = validate_ruleset(raw, require_id=bool(rid))
+    if not ok or not clean:
+        return {"ok": False, "error": why}
+    root = runner.pl_root(cfg, create=True)
+    rulesets = root["rulesets"]
+    if not clean["id"]:
+        clean["id"] = runner.next_id(rulesets, runner.RULESET_PREFIX)
+    for i, existing in enumerate(rulesets):
+        if isinstance(existing, Mapping) and str(existing.get("id") or "") == clean["id"]:
+            rulesets[i] = clean
+            _refresh_mapping_pairs_for_ruleset(cfg, clean["id"])
+            _save(cfg)
+            return {"ok": True, "ruleset": clean, "created": False}
+    rulesets.append(clean)
+    _refresh_mapping_pairs_for_ruleset(cfg, clean["id"])
+    _save(cfg)
+    return {"ok": True, "ruleset": clean, "created": True}
+
+
+def clone_ruleset(cfg: dict[str, Any], ruleset_id: str, payload: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    base = runner.get_ruleset(cfg, ruleset_id)
+    if not base:
+        return {"ok": False, "error": "ruleset not found"}
+    raw = dict(base)
+    raw["id"] = ""
+    raw["name"] = str((payload or {}).get("name") or f"{base.get('name')} Custom").strip()
+    raw["built_in"] = False
+    return upsert_ruleset(cfg, raw)
+
+
+def delete_ruleset(cfg: dict[str, Any], ruleset_id: str) -> dict[str, Any]:
+    rid = str(ruleset_id or "").strip()
+    if rid in BUILTIN_RULESETS:
+        return {"ok": False, "error": "built in rulesets cannot be deleted"}
+    used_by = [str(m.get("id")) for m in runner.list_mapping_profiles(cfg) if str(m.get("ruleset_id") or "") == rid]
+    if used_by:
+        return {"ok": False, "error": f"ruleset in use by {', '.join(used_by)}"}
+    root = runner.pl_root(cfg, create=True)
+    before = len(root["rulesets"])
+    root["rulesets"] = [r for r in root["rulesets"] if str((r or {}).get("id") or "") != rid]
+    if len(root["rulesets"]) == before:
+        return {"ok": False, "error": "ruleset not found"}
+    _save(cfg)
+    return {"ok": True}
+
+
+def validate_ruleset_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    ok, why, clean = validate_ruleset(dict(payload or {}), require_id=bool((payload or {}).get("id")))
+    return {"ok": ok, "error": why, "ruleset": clean}
+
+
+# Pair-facing
+
+def mappings_for_pair(cfg: Mapping[str, Any], pair_id: str) -> dict[str, Any]:
+    pair = _find_pair(cfg, pair_id)
+    if not pair:
+        return {"ok": False, "error": "pair not found", "mappings": []}
+    selected = set(runner.pair_mapping_ids(pair))
+    out: list[dict[str, Any]] = []
+    for profile in runner.list_mapping_profiles(cfg):
+        resolved = runner.resolve_mapping(cfg, profile)
+        if not resolved:
+            continue
+        if not runner.mapping_compatible_with_pair(resolved, pair):
+            continue
+        mid = str(profile.get("id") or "")
+        assigned = assigned_pair_of(cfg, mid)
+        if assigned and assigned != str(pair.get("id") or ""):
+            continue
+        enriched = _enrich_mapping(cfg, profile)
+        enriched["selected"] = mid in selected
+        out.append(enriched)
+    return {"ok": True, "pair_id": str(pair.get("id") or ""), "mappings": out}
+
+
+# Run / preview
+
+@contextmanager
+def _mapping_env(resolved: Mapping[str, Any]) -> Iterator[None]:
+    src = resolved["source"]
+    dst = resolved["target"]
+    keys = {
+        "CW_PAIR_KEY": f"playlist:{resolved.get('id')}",
+        "CW_PAIR_SRC": str(src.get("provider") or ""),
+        "CW_PAIR_SRC_INSTANCE": str(src.get("instance") or "default"),
+        "CW_PAIR_DST": str(dst.get("provider") or ""),
+        "CW_PAIR_DST_INSTANCE": str(dst.get("instance") or "default"),
+    }
+    prev = {k: os.environ.get(k) for k in keys}
+    os.environ.update({k: v for k, v in keys.items() if v})
+    try:
+        yield
+    finally:
+        for k, v in prev.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def preview_mapping(cfg: Mapping[str, Any], mapping_id: str) -> dict[str, Any]:
+    resolved = runner.resolve_mapping_by_id(cfg, mapping_id)
+    if not resolved:
+        return {"ok": False, "error": "mapping not found or endpoints missing"}
+    try:
+        with _mapping_env(resolved):
+            plan = runner.preview_mapping(cfg, resolved)
+    except runner.PlaylistRunError as e:
+        return {"ok": False, "error": str(e)}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+    return {"ok": True, "preview": plan}
+
+
+def run_mapping(cfg: Mapping[str, Any], mapping_id: str, *, dry_run: bool = False) -> dict[str, Any]:
+    resolved = runner.resolve_mapping_by_id(cfg, mapping_id)
+    if not resolved:
+        return {"ok": False, "error": "mapping not found or endpoints missing"}
+    try:
+        with _mapping_env(resolved):
+            result = runner.run_mapping(cfg, resolved, dry_run=dry_run)
+    except runner.PlaylistRunError as e:
+        return {"ok": False, "error": str(e)}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+    return {"ok": True, "result": result}
+
+
+def latest_result(cfg: Mapping[str, Any], mapping_id: str) -> dict[str, Any]:
+    resolved = runner.resolve_mapping_by_id(cfg, mapping_id)
+    if not resolved:
+        return {"ok": False, "error": "mapping not found"}
+    try:
+        result = runner.load_result(resolved)
+    except Exception:
+        result = None
+    return {"ok": True, "result": result}
+
+
+def overview(cfg: Mapping[str, Any]) -> dict[str, Any]:
+    mappings = list_mappings(cfg)
+    enabled = [m for m in mappings if m.get("enabled") and m.get("assigned_pair")]
+    last_sync = 0
+    unresolved = 0
+    warnings: list[str] = []
+    for m in mappings:
+        res = m.get("last_result") or {}
+        if isinstance(res, Mapping):
+            ts = int(res.get("finished_at") or 0)
+            last_sync = max(last_sync, ts)
+            unresolved += int(res.get("unresolved_count") or 0)
+            for w in res.get("warnings") or []:
+                warnings.append(str(w))
+    return {
+        "ok": True,
+        "total_mappings": len(mappings),
+        "enabled_mappings": len(enabled),
+        "endpoints": len(runner.list_endpoints(cfg)),
+        "last_sync_epoch": last_sync or None,
+        "unresolved": unresolved,
+        "warnings": sorted(set(warnings)),
+    }
+
+
+def cleanup_state(cfg: Mapping[str, Any]) -> dict[str, Any]:
+    valid: set[str] = set()
+    for profile in runner.list_mapping_profiles(cfg):
+        resolved = runner.resolve_mapping(cfg, profile)
+        if resolved:
+            valid.add(runner.scope_key(resolved))
+    removed = runner.prune_baselines(valid)
+    return {"ok": True, "pruned": removed}
+
+
+def _save(cfg: dict[str, Any]) -> None:
+    from cw_platform.config_base import save_config
+
+    save_config(cfg)


### PR DESCRIPTION
# Pull request

## Change

- Add the playlists domain model and the provider contract that describes what each provider can do with a list.
- Add the sync runner with membership modes add only, managed only and mirror, plus optional order preservation.
- Store a baseline per mapping so the runner can tell a removal apart from an item that was never there.
- Reuse the existing mass delete guard so a bad run cannot empty a target list.
- Add reusable endpoints and mapping profiles, a service layer for managing them, and the /api/playlists routes.
- Run playlist mappings from the orchestrator for both one way and two way pairs.

## Why

Playlists needed a sync path of its own. The flat inventory and diff model used by watchlist and history cannot express list membership or item order, and it has no notion of the same title living in several lists at once. Endpoints and mapping profiles are defined once and reused, so a list does not have to be redescribed for every pair that touches it.

Each mapping stays directional even on a two way pair, since merging two lists in both directions has no safe answer when both sides changed.

## Testing

- Ran the model, runner, ruleset, orchestration and service tests
- Confirmed the API routes register and the orchestrator dispatches playlists 

## Issue

Relates to #439
