### PR TITLE
Add: test coverage for playlists

### DIFF
--- a/providers/tests/test_emby_playlists.py
+++ b/providers/tests/test_emby_playlists.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+from cw_platform.id_map import canonical_key
+from cw_platform.playlists import supports_playlists
+
+pl = importlib.import_module("providers.sync.emby._playlists")
+mod = importlib.import_module("providers.sync._mod_EMBY")
+
+
+class FakeResp:
+    def __init__(self, status: int, payload: Any = None):
+        self.status_code = status
+        self._payload = payload
+        self.text = "x" if payload is not None else ""
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeHttp:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def get(self, path: str, *, params: dict[str, Any] | None = None) -> FakeResp:
+        params = params or {}
+        self.calls.append({"method": "GET", "path": path, "params": dict(params)})
+        if path == "/Users/U1/Items" and params.get("ParentId") == "C1":
+            return FakeResp(200, {"Items": [row("I2", "Series", "Show", tvdb="42")], "TotalRecordCount": 1})
+        if path == "/Users/U1/Items" and params.get("IncludeItemTypes") == "Playlist":
+            return FakeResp(200, {"Items": [{"Id": "P1", "Name": "Weekend", "Type": "Playlist", "ChildCount": 2}], "TotalRecordCount": 1})
+        if path == "/Users/U1/Items" and params.get("IncludeItemTypes") == "BoxSet":
+            return FakeResp(200, {"Items": [{"Id": "C1", "Name": "Favorites", "Type": "BoxSet", "ChildCount": 1}], "TotalRecordCount": 1})
+        if path == "/Playlists/P1/Items":
+            return FakeResp(200, {"Items": [
+                row("I1", "Movie", "Dune", tmdb="438631", playlist_item_id="E1"),
+                row("I3", "Episode", "Pilot", tmdb="1001", playlist_item_id="E3"),
+            ], "TotalRecordCount": 2})
+        return FakeResp(404, {})
+
+    def post(self, path: str, *, params: dict[str, Any] | None = None, json: Any = None) -> FakeResp:
+        self.calls.append({"method": "POST", "path": path, "params": dict(params or {}), "json": json})
+        if path in ("/Playlists/P1/Items", "/Collections/C1/Items"):
+            return FakeResp(204, {})
+        if path.startswith("/Playlists/P1/Items/") and "/Move/" in path:
+            return FakeResp(204, {})
+        if path == "/Playlists":
+            return FakeResp(200, {"Id": "P2"})
+        if path == "/Collections":
+            return FakeResp(200, {"Id": "C2"})
+        return FakeResp(404, {})
+
+    def delete(self, path: str, *, params: dict[str, Any] | None = None) -> FakeResp:
+        self.calls.append({"method": "DELETE", "path": path, "params": dict(params or {})})
+        if path in ("/Playlists/P1/Items", "/Collections/C1/Items"):
+            return FakeResp(204, {})
+        return FakeResp(404, {})
+
+
+class FakeCfg:
+    user_id = "U1"
+    watchlist_query_limit = 25
+    watchlist_write_delay_ms = 0
+    strict_id_matching = False
+    watchlist_guid_priority = None
+
+
+class FakeAdapter:
+    def __init__(self) -> None:
+        self.client = FakeHttp()
+        self.cfg = FakeCfg()
+        self.instance_id = "default"
+
+
+def row(iid: str, typ: str, name: str, *, tmdb: str | None = None, tvdb: str | None = None, playlist_item_id: str | None = None) -> dict[str, Any]:
+    provider_ids: dict[str, str] = {}
+    if tmdb:
+        provider_ids["Tmdb"] = tmdb
+    if tvdb:
+        provider_ids["Tvdb"] = tvdb
+    out = {"Id": iid, "Type": typ, "Name": name, "ProviderIds": provider_ids, "ProductionYear": 2021}
+    if playlist_item_id:
+        out["PlaylistItemId"] = playlist_item_id
+    return out
+
+
+def movie(tmdb: str, title: str = "Dune") -> dict[str, Any]:
+    return {"type": "movie", "title": title, "year": 2021, "ids": {"tmdb": tmdb}}
+
+
+def show(tvdb: str, title: str = "Show") -> dict[str, Any]:
+    return {"type": "show", "title": title, "ids": {"tvdb": tvdb}}
+
+
+def test_emby_ops_are_playlist_capable():
+    assert supports_playlists(mod.OPS)
+    assert mod.OPS.features()["playlists"] is True
+    caps = mod.OPS.capabilities()["playlists"]
+    assert caps["endpoint_types"] == ["playlist", "collection"]
+    assert caps["ordered_endpoint_types"] == ["playlist"]
+
+
+def test_list_resources_exposes_ordered_playlists_and_unordered_collections():
+    ad = FakeAdapter()
+    resources = pl.list_resources(ad)
+    by_id = {r.id: r for r in resources}
+
+    assert set(by_id) == {"playlist:P1", "collection:C1"}
+    assert by_id["playlist:P1"].extra["endpoint_type"] == "playlist"
+    assert by_id["playlist:P1"].can_reorder is True
+    assert by_id["playlist:P1"].media_types == ("movie", "episode")
+    assert by_id["collection:C1"].extra["endpoint_type"] == "collection"
+    assert by_id["collection:C1"].can_reorder is False
+    assert by_id["collection:C1"].media_types == ("movie", "show")
+
+
+def test_snapshots_keep_playlist_order_without_show_episode_conversion():
+    ad = FakeAdapter()
+    playlist = pl.get_snapshot(ad, "playlist:P1")
+    collection = pl.get_snapshot(ad, "collection:C1")
+
+    assert playlist.ordered_keys() == ["tmdb:438631", "tmdb:1001"]
+    assert playlist.items[0].playlist_item_id == "E1"
+    assert playlist.items[0].position == 0
+    assert collection.ordered_keys() == ["tvdb:42"]
+    assert collection.items[0].position is None
+
+
+def test_add_reports_missing_library_and_does_not_expand_shows_for_playlists(monkeypatch):
+    ad = FakeAdapter()
+
+    def fake_resolve(adapter: Any, item: dict[str, Any], *, feature: str = "history") -> str | None:
+        return {"tmdb:438631": "I1"}.get(canonical_key(item))
+
+    monkeypatch.setattr(pl, "resolve_item_id", fake_resolve)
+    res = pl.add(ad, "playlist:P1", [movie("438631"), movie("999", "Ghost"), show("42")])
+
+    assert res["count"] == 1
+    assert res["confirmed_keys"] == ["tmdb:438631"]
+    assert [u["hint"] for u in res["unresolved"]] == ["not_in_library", "unsupported_type"]
+    call = next(c for c in ad.client.calls if c["method"] == "POST" and c["path"] == "/Playlists/P1/Items")
+    assert call["params"]["Ids"] == "I1"
+    assert call["params"]["UserId"] == "U1"
+
+
+def test_collection_add_and_remove_use_collection_id(monkeypatch):
+    ad = FakeAdapter()
+
+    def fake_resolve(adapter: Any, item: dict[str, Any], *, feature: str = "history") -> str | None:
+        return {"tvdb:42": "I2"}.get(canonical_key(item))
+
+    monkeypatch.setattr(pl, "resolve_item_id", fake_resolve)
+    item = show("42")
+    add_res = pl.add(ad, "collection:C1", [item])
+    rm_res = pl.remove(ad, "collection:C1", [item])
+
+    assert add_res["count"] == 1
+    assert rm_res["count"] == 1
+    add_call = next(c for c in ad.client.calls if c["method"] == "POST" and c["path"] == "/Collections/C1/Items")
+    remove_call = next(c for c in ad.client.calls if c["method"] == "DELETE" and c["path"] == "/Collections/C1/Items")
+    assert add_call["params"]["Ids"] == "I2"
+    assert remove_call["params"]["Ids"] == "I2"
+
+
+def test_playlist_remove_and_reorder_use_entry_ids():
+    ad = FakeAdapter()
+
+    rm_res = pl.remove(ad, "playlist:P1", [movie("438631")])
+    reorder_res = pl.reorder(ad, "playlist:P1", ["tmdb:1001", "tmdb:438631"])
+
+    assert rm_res["count"] == 1
+    remove_call = next(c for c in ad.client.calls if c["method"] == "DELETE" and c["path"] == "/Playlists/P1/Items")
+    assert remove_call["params"]["EntryIds"] == "E1"
+    assert reorder_res["reordered"] == 1
+    assert any(c["method"] == "POST" and c["path"] == "/Playlists/P1/Items/E3/Move/0" for c in ad.client.calls)
+
+
+def test_create_can_make_playlist_or_collection():
+    ad = FakeAdapter()
+    playlist = pl.create(ad, "NewList")
+    collection = pl.create(ad, "NewBox", media_type="collection")
+
+    assert playlist.id == "playlist:P2"
+    assert collection.id == "collection:C2"
+    assert any(c["path"] == "/Playlists" and c["params"]["Name"] == "NewList" for c in ad.client.calls)
+    assert any(c["path"] == "/Collections" and c["params"]["Name"] == "NewBox" for c in ad.client.calls)

--- a/providers/tests/test_jellyfin_playlists.py
+++ b/providers/tests/test_jellyfin_playlists.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+from cw_platform.id_map import canonical_key
+from cw_platform.playlists import supports_playlists
+
+pl = importlib.import_module("providers.sync.jellyfin._playlists")
+mod = importlib.import_module("providers.sync._mod_JELLYFIN")
+
+
+class FakeResp:
+    def __init__(self, status: int, payload: Any = None):
+        self.status_code = status
+        self._payload = payload
+        self.text = "x" if payload is not None else ""
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeHttp:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def get(self, path: str, *, params: dict[str, Any] | None = None) -> FakeResp:
+        params = params or {}
+        self.calls.append({"method": "GET", "path": path, "params": dict(params)})
+        if path == "/Items" and params.get("ParentId") == "C1":
+            return FakeResp(200, {"Items": [row("I2", "Series", "Show", tvdb="42")], "TotalRecordCount": 1})
+        if path == "/Items" and params.get("IncludeItemTypes") == "Playlist":
+            return FakeResp(200, {"Items": [{"Id": "P1", "Name": "Weekend", "Type": "Playlist", "ChildCount": 1}], "TotalRecordCount": 1})
+        if path == "/Items" and params.get("IncludeItemTypes") == "BoxSet":
+            return FakeResp(200, {"Items": [{"Id": "C1", "Name": "Favorites", "Type": "BoxSet", "ChildCount": 1}], "TotalRecordCount": 1})
+        if path == "/Playlists/P1/Items":
+            return FakeResp(200, {"Items": [row("I1", "Movie", "Dune", tmdb="438631", playlist_item_id="E1")], "TotalRecordCount": 1})
+        return FakeResp(404, {})
+
+    def post(self, path: str, *, params: dict[str, Any] | None = None, json: Any = None) -> FakeResp:
+        self.calls.append({"method": "POST", "path": path, "params": dict(params or {}), "json": json})
+        if path in ("/Playlists/P1/Items", "/Collections/C1/Items"):
+            return FakeResp(204, {})
+        if path == "/Playlists":
+            return FakeResp(200, {"Id": "P2"})
+        if path == "/Collections":
+            return FakeResp(200, {"Id": "C2"})
+        return FakeResp(404, {})
+
+    def delete(self, path: str, *, params: dict[str, Any] | None = None) -> FakeResp:
+        self.calls.append({"method": "DELETE", "path": path, "params": dict(params or {})})
+        if path in ("/Playlists/P1/Items", "/Collections/C1/Items"):
+            return FakeResp(204, {})
+        return FakeResp(404, {})
+
+
+class FakeCfg:
+    user_id = "U1"
+    watchlist_query_limit = 25
+    watchlist_write_delay_ms = 0
+    strict_id_matching = False
+    watchlist_guid_priority = None
+
+
+class FakeAdapter:
+    def __init__(self) -> None:
+        self.client = FakeHttp()
+        self.cfg = FakeCfg()
+        self.instance_id = "default"
+
+
+def row(iid: str, typ: str, name: str, *, tmdb: str | None = None, tvdb: str | None = None, playlist_item_id: str | None = None) -> dict[str, Any]:
+    provider_ids: dict[str, str] = {}
+    if tmdb:
+        provider_ids["Tmdb"] = tmdb
+    if tvdb:
+        provider_ids["Tvdb"] = tvdb
+    out = {"Id": iid, "Type": typ, "Name": name, "ProviderIds": provider_ids, "ProductionYear": 2021}
+    if playlist_item_id:
+        out["PlaylistItemId"] = playlist_item_id
+    return out
+
+
+def media(tmdb: str, title: str = "Dune") -> dict[str, Any]:
+    return {"type": "movie", "title": title, "year": 2021, "ids": {"tmdb": tmdb}}
+
+
+def test_jellyfin_ops_are_playlist_capable():
+    assert supports_playlists(mod.OPS)
+    assert mod.OPS.features()["playlists"] is True
+    assert mod.OPS.capabilities()["playlists"]["endpoint_types"] == ["playlist", "collection"]
+
+
+def test_list_resources_exposes_playlists_and_collections():
+    ad = FakeAdapter()
+    resources = pl.list_resources(ad)
+    by_id = {r.id: r for r in resources}
+
+    assert set(by_id) == {"playlist:P1", "collection:C1"}
+    assert by_id["playlist:P1"].extra["endpoint_type"] == "playlist"
+    assert by_id["collection:C1"].extra["endpoint_type"] == "collection"
+    assert by_id["collection:C1"].can_reorder is False
+    assert by_id["collection:C1"].media_types == ("movie", "show")
+
+
+def test_snapshots_use_explicit_container_ids():
+    ad = FakeAdapter()
+    playlist = pl.get_snapshot(ad, "playlist:P1")
+    collection = pl.get_snapshot(ad, "collection:C1")
+
+    assert playlist.ordered_keys() == ["tmdb:438631"]
+    assert playlist.items[0].playlist_item_id == "E1"
+    assert collection.ordered_keys() == ["tvdb:42"]
+    assert collection.items[0].position is None
+    assert any(c["path"] == "/Playlists/P1/Items" for c in ad.client.calls)
+    assert any(c["path"] == "/Items" and c["params"].get("ParentId") == "C1" for c in ad.client.calls)
+
+
+def test_add_reports_missing_library_and_writes_raw_playlist_id(monkeypatch):
+    ad = FakeAdapter()
+
+    def fake_resolve(adapter: Any, item: dict[str, Any], *, feature: str = "history") -> str | None:
+        return {"tmdb:438631": "I1"}.get(canonical_key(item))
+
+    monkeypatch.setattr(pl, "resolve_item_id", fake_resolve)
+    res = pl.add(ad, "playlist:P1", [media("438631"), media("999", "Ghost")])
+
+    assert res["count"] == 1
+    assert res["confirmed_keys"] == ["tmdb:438631"]
+    assert res["unresolved"][0]["hint"] == "not_in_library"
+    call = next(c for c in ad.client.calls if c["method"] == "POST" and c["path"] == "/Playlists/P1/Items")
+    assert call["params"]["ids"] == "I1"
+    assert call["params"]["userId"] == "U1"
+
+
+def test_collection_add_and_remove_use_collection_id(monkeypatch):
+    ad = FakeAdapter()
+
+    def fake_resolve(adapter: Any, item: dict[str, Any], *, feature: str = "history") -> str | None:
+        return {"tvdb:42": "I2"}.get(canonical_key(item))
+
+    monkeypatch.setattr(pl, "resolve_item_id", fake_resolve)
+    item = {"type": "show", "title": "Show", "ids": {"tvdb": "42"}}
+    add_res = pl.add(ad, "collection:C1", [item])
+    rm_res = pl.remove(ad, "collection:C1", [item])
+
+    assert add_res["count"] == 1
+    assert rm_res["count"] == 1
+    add_call = next(c for c in ad.client.calls if c["method"] == "POST" and c["path"] == "/Collections/C1/Items")
+    remove_call = next(c for c in ad.client.calls if c["method"] == "DELETE" and c["path"] == "/Collections/C1/Items")
+    assert add_call["params"]["Ids"] == "I2"
+    assert remove_call["params"]["Ids"] == "I2"
+
+
+def test_create_can_make_playlist_or_collection():
+    ad = FakeAdapter()
+    playlist = pl.create(ad, "NewList")
+    collection = pl.create(ad, "NewBox", media_type="collection")
+
+    assert playlist.id == "playlist:P2"
+    assert collection.id == "collection:C2"
+    assert any(c["path"] == "/Playlists" and c["json"]["Name"] == "NewList" for c in ad.client.calls)
+    assert any(c["path"] == "/Collections" and c["params"]["Name"] == "NewBox" for c in ad.client.calls)

--- a/providers/tests/test_mdblist_playlists.py
+++ b/providers/tests/test_mdblist_playlists.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+
+pl = importlib.import_module("providers.sync.mdblist._playlists")
+
+
+class FakeResp:
+    def __init__(self, status: int, payload: Any = None, headers: dict[str, str] | None = None):
+        self.status_code = status
+        self._payload = payload
+        self.headers = headers or {}
+        self.text = "x" if payload is not None else ""
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeCfg:
+    timeout = 15.0
+    max_retries = 1
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.headers: dict[str, str] = {}
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.session = FakeSession()
+
+
+class FakeAdapter:
+    def __init__(self) -> None:
+        self.cfg = FakeCfg()
+        self.client = FakeClient()
+        self.instance_id = "default"
+        self.config = {"mdblist": {"api_key": "k"}}
+        self.raw_cfg = self.config
+
+
+USER_LISTS = [
+    {"id": 101, "name": "Weekend", "slug": "weekend", "mediatype": "movie", "items": 2, "dynamic": False, "private": True, "user_name": "me"},
+    {"id": 202, "name": "Top Trending", "slug": "trending", "mediatype": "show", "items": 5, "dynamic": True, "private": False, "user_name": "me"},
+]
+
+LIST_ITEMS = {
+    "movies": [
+        {"id": 9001, "rank": 1, "title": "Dune", "imdb_id": "tt1160419", "tmdb_id": 438631, "mediatype": "movie", "release_year": 2021},
+    ],
+    "shows": [
+        {"id": 9002, "rank": 2, "title": "Severance", "imdb_id": "tt11280740", "tvdb_id": 371980, "mediatype": "show", "release_year": 2022},
+    ],
+}
+
+
+def _router(monkeypatch, handlers):
+    captured: list[dict[str, Any]] = []
+
+    def fake_req(adapter, method, url, **kw):
+        captured.append({"method": method, "url": url, "json": kw.get("json"), "params": kw.get("params")})
+        for (m, needle), resp in handlers.items():
+            if method == m and needle in url:
+                return resp() if callable(resp) else resp
+        return FakeResp(404, None)
+
+    monkeypatch.setattr(pl, "mdblist_request", fake_req)
+    monkeypatch.setattr(pl, "has_auth", lambda *_a, **_k: True)
+    return captured
+
+
+def test_dynamic_list_is_read_only_static_is_writable(monkeypatch):
+    _router(monkeypatch, {("GET", "/lists/user"): FakeResp(200, USER_LISTS)})
+    res = pl.list_resources(FakeAdapter())
+    by_id = {r.id: r for r in res}
+    watchlist = by_id[pl.WATCHLIST_ID]
+    assert watchlist.name == "Watchlist"
+    assert watchlist.can_add and watchlist.can_remove
+    assert watchlist.can_reorder is False
+    static = by_id["101"]
+    dynamic = by_id["202"]
+    assert static.can_add and static.can_remove and static.can_reorder is False
+    assert static.media_types == ("movie", "show", "season", "episode")
+    assert static.is_smart is False
+    assert dynamic.is_smart is True
+    assert dynamic.can_add is False and dynamic.can_remove is False
+    assert dynamic.media_types == ("show",)
+    assert static.extra["item_count"] == 2 and static.extra["private"] is True
+    assert dynamic.extra["dynamic"] is True
+
+
+def test_watchlist_snapshot_and_writes_delegate(monkeypatch):
+    monkeypatch.setattr(
+        pl.feat_watchlist,
+        "build_index",
+        lambda ad: {"tmdb:438631": {"type": "movie", "title": "Dune", "ids": {"tmdb": "438631"}}},
+    )
+    monkeypatch.setattr(pl.feat_watchlist, "add", lambda ad, items: (len(list(items)), []))
+    monkeypatch.setattr(pl.feat_watchlist, "remove", lambda ad, items: (len(list(items)), []))
+
+    ad = FakeAdapter()
+    snap = pl.get_snapshot(ad, pl.WATCHLIST_ID)
+    assert snap.resource.name == "Watchlist"
+    assert snap.ordered_keys() == ["tmdb:438631"]
+
+    item = {"type": "movie", "title": "Dune", "ids": {"tmdb": "438631"}}
+    add_res = pl.add(ad, pl.WATCHLIST_ID, [item])
+    rm_res = pl.remove(ad, pl.WATCHLIST_ID, [item])
+    assert add_res["count"] == 1 and add_res["confirmed_keys"] == ["tmdb:438631"]
+    assert rm_res["count"] == 1 and rm_res["confirmed_keys"] == ["tmdb:438631"]
+    assert pl.reorder(ad, pl.WATCHLIST_ID, ["tmdb:438631"])["unsupported"] is True
+
+
+def test_snapshot_normalizes_movies_and_shows_with_rank_and_ids(monkeypatch):
+    _router(
+        monkeypatch,
+        {
+            ("GET", "/lists/user"): FakeResp(200, USER_LISTS),
+            ("GET", "/lists/101/items"): FakeResp(200, LIST_ITEMS, headers={"X-Has-More": "false"}),
+        },
+    )
+    snap = pl.get_snapshot(FakeAdapter(), "101")
+    assert len(snap.items) == 2
+    first = snap.items[0]
+    assert first.item["ids"].get("imdb") == "tt1160419"
+    assert first.item["ids"].get("tmdb") == "438631"
+    assert first.item["ids"].get("mdblist") is None
+    assert first.playlist_item_id == "9001"
+    assert first.position == 1
+    show = snap.items[1]
+    assert show.item["type"] == "show"
+    assert show.item["ids"].get("imdb") == "tt11280740"
+    assert show.item["ids"].get("tvdb") == "371980"
+    assert show.item["ids"].get("tmdb") is None
+
+
+def test_snapshot_reads_nested_id_blocks(monkeypatch):
+    rows = {
+        "movies": [
+            {
+                "id": 9001,
+                "rank": 1,
+                "title": "Dune",
+                "ids": {"imdb": "tt1160419", "tmdb": 438631, "mdblist": "mdb-1"},
+                "mediatype": "movie",
+            },
+        ],
+    }
+    _router(
+        monkeypatch,
+        {
+            ("GET", "/lists/user"): FakeResp(200, USER_LISTS),
+            ("GET", "/lists/101/items"): FakeResp(200, rows, headers={"X-Has-More": "false"}),
+        },
+    )
+    snap = pl.get_snapshot(FakeAdapter(), "101")
+    assert snap.items[0].key == "tmdb:438631"
+    assert snap.items[0].item["ids"]["imdb"] == "tt1160419"
+    assert snap.items[0].item["ids"]["mdblist"] == "mdb-1"
+
+
+def test_add_and_remove_payload_shapes(monkeypatch):
+    captured = _router(
+        monkeypatch,
+        {
+            ("GET", "/lists/user"): FakeResp(200, USER_LISTS),
+            ("POST", "/lists/101/items/add"): FakeResp(200, {"added": {"movies": 1, "shows": 1}}),
+            ("POST", "/lists/101/items/remove"): FakeResp(200, {"deleted": {"movies": 1}}),
+        },
+    )
+    items = [
+        {"type": "movie", "title": "Dune", "ids": {"imdb": "tt1160419", "tmdb": "438631"}},
+        {"type": "show", "title": "Severance", "ids": {"imdb": "tt11280740"}},
+    ]
+    add_res = pl.add(FakeAdapter(), "101", items)
+    assert add_res["ok"] is True and add_res["count"] == 2
+    add_call = next(c for c in captured if c["url"].endswith("/items/add"))
+    assert add_call["json"] == {"movies": [{"imdb": "tt1160419", "tmdb": 438631}], "shows": [{"imdb": "tt11280740"}]}
+
+    rm_res = pl.remove(FakeAdapter(), "101", items[:1])
+    assert rm_res["count"] == 1
+
+
+def test_add_existing_items_are_not_reported_as_new_additions(monkeypatch):
+    _router(
+        monkeypatch,
+        {
+            ("GET", "/lists/user"): FakeResp(200, USER_LISTS),
+            ("POST", "/lists/101/items/add"): FakeResp(200, {"existing": {"movies": 1}}),
+        },
+    )
+    res = pl.add(FakeAdapter(), "101", [{"type": "movie", "title": "Dune", "ids": {"tmdb": "438631"}}])
+    assert res["ok"] is True
+    assert res["count"] == 0
+    assert res["confirmed_keys"] == ["tmdb:438631"]
+
+
+def test_create_static_list_uses_current_user_add_route(monkeypatch):
+    captured = _router(
+        monkeypatch,
+        {("POST", "/lists/user/add"): FakeResp(200, {"id": 303, "name": "Short"})},
+    )
+    res = pl.create(FakeAdapter(), "Short", media_type="show")
+    assert res.id == "303"
+    call = next(c for c in captured if c["url"].endswith("/lists/user/add"))
+    assert call["json"] == {"name": "Short"}
+
+
+def test_seasons_and_episodes_use_tmdb_buckets(monkeypatch):
+    captured = _router(
+        monkeypatch,
+        {
+            ("GET", "/lists/user"): FakeResp(200, USER_LISTS),
+            ("POST", "/lists/101/items/add"): FakeResp(200, {"added": {"seasons": 1, "episodes": 1}}),
+        },
+    )
+    items = [
+        {"type": "episode", "title": "Ep", "ids": {"tmdb": "2001", "imdb": "tt0000001"}},
+        {"type": "season", "title": "S1", "ids": {"tmdb": 1001, "tvdb": "111"}},
+    ]
+    res = pl.add(FakeAdapter(), "101", items)
+    assert res["count"] == 2
+    add_call = next(c for c in captured if c["url"].endswith("/items/add"))
+    assert add_call["json"] == {"seasons": [{"tmdb": 1001}], "episodes": [{"tmdb": 2001}]}
+
+
+def test_seasons_and_episodes_without_tmdb_rejected_before_request(monkeypatch):
+    captured = _router(monkeypatch, {("GET", "/lists/user"): FakeResp(200, USER_LISTS)})
+    items = [
+        {"type": "episode", "title": "Ep", "ids": {"imdb": "tt0000001"}},
+        {"type": "season", "title": "S1", "ids": {"tvdb": "111"}},
+    ]
+    res = pl.add(FakeAdapter(), "101", items)
+    assert res["count"] == 0
+    assert all(u["hint"] == "missing_supported_ids" for u in res["unresolved"])
+    assert not any("/items/add" in c["url"] for c in captured)
+
+
+def test_write_to_dynamic_list_rejected(monkeypatch):
+    _router(monkeypatch, {("GET", "/lists/user"): FakeResp(200, USER_LISTS)})
+    with pytest.raises(pl.MDBListDynamicListError):
+        pl.add(FakeAdapter(), "202", [{"type": "movie", "ids": {"imdb": "tt1"}}])
+
+
+def test_write_to_unowned_list_rejected(monkeypatch):
+    _router(monkeypatch, {("GET", "/lists/user"): FakeResp(200, USER_LISTS)})
+    with pytest.raises(pl.MDBListNotOwnedError):
+        pl.add(FakeAdapter(), "999", [{"type": "movie", "ids": {"imdb": "tt1"}}])
+
+
+def test_reorder_is_noop_unsupported(monkeypatch):
+    _router(monkeypatch, {("GET", "/lists/user"): FakeResp(200, USER_LISTS)})
+    res = pl.reorder(FakeAdapter(), "101", ["imdb:tt1"])
+    assert res["reordered"] == 0 and res["unsupported"] is True

--- a/providers/tests/test_plex_playlists.py
+++ b/providers/tests/test_plex_playlists.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+
+plpl = importlib.import_module("providers.sync.plex._playlists")
+
+
+class FObj:
+    def __init__(
+        self,
+        tmdb: int,
+        title: str,
+        year: int = 2020,
+        typ: str = "movie",
+        rk: int | None = None,
+        plid: int | None = None,
+        section_id: int | str | None = None,
+    ):
+        self.type = typ
+        self.title = title
+        self.year = year
+        self.guid = f"tmdb://{tmdb}"
+        self.guids: list[Any] = []
+        self.ratingKey = rk if rk is not None else int(tmdb)
+        self.playlistItemID = plid
+        if section_id is not None:
+            self.librarySectionID = str(section_id)
+
+
+class FakePlaylist:
+    def __init__(self, title: str, rk: int, items: list[Any], smart: bool = False, ptype: str = "video"):
+        self.title = title
+        self.ratingKey = rk
+        self.smart = smart
+        self.playlistType = ptype
+        self._items = list(items)
+        self.calls: list[Any] = []
+
+    def items(self) -> list[Any]:
+        return list(self._items)
+
+    def addItems(self, objs: Any) -> None:
+        lst = objs if isinstance(objs, list) else [objs]
+        self.calls.append(("add", lst))
+        self._items.extend(lst)
+
+    def removeItems(self, obj: Any) -> None:
+        self.calls.append(("remove", obj))
+        self._items.remove(obj)
+
+    def moveItem(self, obj: Any, after: Any = None) -> None:
+        self.calls.append(("move", obj, after))
+        self._items.remove(obj)
+        if after is None:
+            self._items.insert(0, obj)
+        else:
+            idx = self._items.index(after)
+            self._items.insert(idx + 1, obj)
+
+
+class FakeCollection:
+    def __init__(
+        self,
+        title: str,
+        rk: int,
+        items: list[Any],
+        smart: bool = False,
+        subtype: str = "movie",
+        section_id: int | str = 1,
+    ):
+        self.title = title
+        self.ratingKey = rk
+        self.key = str(rk)
+        self.smart = smart
+        self.subtype = subtype
+        self.childCount = len(items)
+        self.librarySectionID = str(section_id)
+        self.librarySectionKey = str(section_id)
+        self._items = list(items)
+        self.calls: list[Any] = []
+
+    def items(self) -> list[Any]:
+        return list(self._items)
+
+    def addItems(self, objs: Any) -> None:
+        lst = objs if isinstance(objs, list) else [objs]
+        self.calls.append(("add", lst))
+        self._items.extend(lst)
+        self.childCount = len(self._items)
+
+    def removeItems(self, obj: Any) -> None:
+        self.calls.append(("remove", obj))
+        self._items.remove(obj)
+        self.childCount = len(self._items)
+
+
+class FakeSection:
+    def __init__(self, title: str, key: int | str, typ: str, collections: list[FakeCollection]):
+        self.title = title
+        self.key = str(key)
+        self.type = typ
+        self._collections = collections
+
+    def collections(self) -> list[FakeCollection]:
+        return list(self._collections)
+
+
+class FakeLibrary:
+    def __init__(self, sections: list[FakeSection]):
+        self._sections = sections
+
+    def sections(self) -> list[FakeSection]:
+        return list(self._sections)
+
+
+class FakeServer:
+    def __init__(self, playlists: list[FakePlaylist], library: list[FObj], sections: list[FakeSection] | None = None):
+        self._playlists = playlists
+        self.items_library = library
+        self.library = FakeLibrary(sections or [])
+        self.created: list[FakePlaylist] = []
+
+    def playlists(self) -> list[FakePlaylist]:
+        return list(self._playlists)
+
+    def createPlaylist(self, name: str, items: Any = None) -> FakePlaylist:
+        pl = FakePlaylist(name, 999, items or [])
+        self.created.append(pl)
+        self._playlists.append(pl)
+        return pl
+
+
+class FakeClient:
+    def __init__(self, server: FakeServer):
+        self.server = server
+
+
+class FakeAdapter:
+    def __init__(self, server: FakeServer):
+        self.client = FakeClient(server)
+        self.instance_id = "default"
+
+
+def _fake_resolve(srv: FakeServer, guids: list[str], allow: set, accept: set) -> Any:
+    for g in guids:
+        for obj in srv.items_library:
+            if obj.guid == g and obj.type in accept:
+                section = str(getattr(obj, "librarySectionID", "") or "")
+                if allow and section and section not in allow:
+                    continue
+                return obj
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _patch_resolve(monkeypatch):
+    monkeypatch.setattr(plpl, "resolve_obj_by_guids", _fake_resolve)
+
+
+def _media(tmdb: int, title: str) -> dict[str, Any]:
+    return {"type": "movie", "title": title, "year": 2020, "ids": {"tmdb": str(tmdb)}}
+
+
+def test_capability_detection_regular_and_smart():
+    a = FObj(1, "A", plid=101)
+    regular = FakePlaylist("Weekend", 10, [a], smart=False)
+    smart = FakePlaylist("Recently Added", 20, [a], smart=True)
+    ad = FakeAdapter(FakeServer([regular, smart], [a]))
+
+    res = plpl.list_resources(ad)
+    by_id = {r.id: r for r in res}
+    assert by_id[plpl.WATCHLIST_ID].name == "Watchlist"
+    assert by_id[plpl.WATCHLIST_ID].can_add is True
+    assert by_id[plpl.WATCHLIST_ID].can_reorder is False
+    assert by_id["10"].is_smart is False
+    assert by_id["10"].can_add is True and by_id["10"].can_reorder is True
+    assert by_id["20"].is_smart is True
+    assert by_id["20"].can_add is False and by_id["20"].can_remove is False
+
+
+def test_collection_resources_manual_and_smart():
+    movie = FObj(1, "A", section_id=1)
+    show = FObj(2, "S", typ="show", section_id=2)
+    manual = FakeCollection("Movies", 30, [movie], smart=False, subtype="movie", section_id=1)
+    smart = FakeCollection("Shows", 40, [show], smart=True, subtype="show", section_id=2)
+    sections = [
+        FakeSection("Movies", 1, "movie", [manual]),
+        FakeSection("Shows", 2, "show", [smart]),
+    ]
+    ad = FakeAdapter(FakeServer([], [movie, show], sections))
+
+    res = plpl.list_resources(ad)
+    by_id = {r.id: r for r in res}
+    movie_id = f"{plpl.COLLECTION_PREFIX}1:30"
+    show_id = f"{plpl.COLLECTION_PREFIX}2:40"
+    assert by_id[movie_id].name == "Movies"
+    assert by_id[movie_id].extra["endpoint_type"] == "collection"
+    assert by_id[movie_id].media_types == ("movie",)
+    assert by_id[movie_id].can_add is True and by_id[movie_id].can_reorder is False
+    assert by_id[show_id].is_smart is True
+    assert by_id[show_id].media_types == ("show",)
+    assert by_id[show_id].can_add is False and by_id[show_id].can_remove is False
+
+
+def test_watchlist_snapshot_and_writes_delegate(monkeypatch):
+    monkeypatch.setattr(
+        plpl.feat_watchlist,
+        "build_index",
+        lambda ad: {"tmdb:1": {"type": "movie", "title": "A", "ids": {"tmdb": "1"}}},
+    )
+    monkeypatch.setattr(plpl.feat_watchlist, "add", lambda ad, items: (len(list(items)), []))
+    monkeypatch.setattr(plpl.feat_watchlist, "remove", lambda ad, items: (len(list(items)), []))
+
+    a = FObj(1, "A", plid=101)
+    ad = FakeAdapter(FakeServer([], [a]))
+    snap = plpl.get_snapshot(ad, plpl.WATCHLIST_ID)
+    assert snap.resource.name == "Watchlist"
+    assert snap.ordered_keys() == ["tmdb:1"]
+
+    item = _media(1, "A")
+    add_res = plpl.add(ad, plpl.WATCHLIST_ID, [item])
+    rm_res = plpl.remove(ad, plpl.WATCHLIST_ID, [item])
+    assert add_res["count"] == 1 and add_res["confirmed_keys"] == ["tmdb:1"]
+    assert rm_res["count"] == 1 and rm_res["confirmed_keys"] == ["tmdb:1"]
+    assert plpl.reorder(ad, plpl.WATCHLIST_ID, ["tmdb:1"])["unsupported"] is True
+
+
+def test_collection_snapshot_and_writes_use_scoped_ids():
+    a = FObj(1, "A", section_id=1)
+    b = FObj(2, "B", section_id=1)
+    other = FObj(2, "B Other", section_id=2)
+    coll = FakeCollection("Movies", 30, [a], subtype="movie", section_id=1)
+    sections = [FakeSection("Movies", 1, "movie", [coll])]
+    ad = FakeAdapter(FakeServer([], [a, other, b], sections))
+    collection_id = f"{plpl.COLLECTION_PREFIX}1:30"
+
+    snap = plpl.get_snapshot(ad, collection_id)
+    assert snap.resource.name == "Movies"
+    assert snap.resource.can_reorder is False
+    assert snap.ordered_keys() == ["tmdb:1"]
+    assert snap.items[0].position is None
+
+    add_res = plpl.add(ad, collection_id, [_media(2, "B")])
+    assert add_res["count"] == 1
+    assert add_res["confirmed_keys"] == ["tmdb:2"]
+    assert coll.calls[-1][0] == "add"
+    assert coll.calls[-1][1][0] is b
+
+    rm_res = plpl.remove(ad, collection_id, [_media(1, "A")])
+    assert rm_res["count"] == 1
+    assert rm_res["confirmed_keys"] == ["tmdb:1"]
+    assert coll.calls[-1][0] == "remove"
+
+
+def test_collection_missing_library_media_reports_not_in_library():
+    a = FObj(1, "A", section_id=1)
+    coll = FakeCollection("Movies", 30, [a], subtype="movie", section_id=1)
+    sections = [FakeSection("Movies", 1, "movie", [coll])]
+    ad = FakeAdapter(FakeServer([], [a], sections))
+
+    res = plpl.add(ad, f"{plpl.COLLECTION_PREFIX}1:30", [_media(999, "Ghost")])
+    assert res["count"] == 0
+    assert res["confirmed_keys"] == []
+    assert res["unresolved"] and res["unresolved"][0]["hint"] == "not_in_library"
+
+
+def test_smart_collection_writes_rejected_and_reorder_unsupported():
+    a = FObj(1, "A", section_id=1)
+    coll = FakeCollection("Smart Movies", 30, [a], smart=True, subtype="movie", section_id=1)
+    sections = [FakeSection("Movies", 1, "movie", [coll])]
+    ad = FakeAdapter(FakeServer([], [a], sections))
+    collection_id = f"{plpl.COLLECTION_PREFIX}1:30"
+
+    with pytest.raises(plpl.SmartPlaylistError):
+        plpl.add(ad, collection_id, [_media(1, "A")])
+    with pytest.raises(plpl.SmartPlaylistError):
+        plpl.remove(ad, collection_id, [_media(1, "A")])
+    assert plpl.reorder(ad, collection_id, ["tmdb:1"])["unsupported"] is True
+
+
+def test_missing_library_media_is_unresolved():
+    a = FObj(1, "A", plid=101)
+    regular = FakePlaylist("Weekend", 10, [a], smart=False)
+    ad = FakeAdapter(FakeServer([regular], [a]))
+
+    res = plpl.add(ad, "10", [_media(999, "Ghost")])
+    assert res["count"] == 0
+    assert res["confirmed_keys"] == []
+    assert res["unresolved"] and res["unresolved"][0]["hint"] == "not_found"
+
+
+def test_smart_playlist_writes_rejected():
+    a = FObj(1, "A", plid=101)
+    smart = FakePlaylist("Smart", 20, [a], smart=True)
+    ad = FakeAdapter(FakeServer([smart], [a]))
+
+    with pytest.raises(plpl.SmartPlaylistError):
+        plpl.add(ad, "20", [_media(1, "A")])
+    with pytest.raises(plpl.SmartPlaylistError):
+        plpl.remove(ad, "20", [_media(1, "A")])
+    with pytest.raises(plpl.SmartPlaylistError):
+        plpl.reorder(ad, "20", ["tmdb:1"])
+
+
+def test_add_remove_basic():
+    a = FObj(1, "A", plid=101)
+    b = FObj(2, "B", plid=102)
+    regular = FakePlaylist("Weekend", 10, [a], smart=False)
+    ad = FakeAdapter(FakeServer([regular], [a, b]))
+
+    add_res = plpl.add(ad, "10", [_media(2, "B")])
+    assert add_res["count"] == 1
+    assert add_res["confirmed_keys"] == ["tmdb:2"]
+
+    rm_res = plpl.remove(ad, "10", [_media(1, "A")])
+    assert rm_res["count"] == 1
+    assert rm_res["confirmed_keys"] == ["tmdb:1"]
+
+
+def test_snapshot_ordered():
+    a = FObj(1, "A", plid=101)
+    b = FObj(2, "B", plid=102)
+    regular = FakePlaylist("Weekend", 10, [a, b], smart=False)
+    ad = FakeAdapter(FakeServer([regular], [a, b]))
+    snap = plpl.get_snapshot(ad, "10")
+    assert snap.ordered_keys() == ["tmdb:1", "tmdb:2"]
+    assert snap.items[0].playlist_item_id == "101"
+
+
+def test_reorder_minimal_moves_and_idempotent():
+    a = FObj(1, "A", plid=101)
+    b = FObj(2, "B", plid=102)
+    c = FObj(3, "C", plid=103)
+    regular = FakePlaylist("Weekend", 10, [a, b, c], smart=False)
+    ad = FakeAdapter(FakeServer([regular], [a, b, c]))
+
+    res = plpl.reorder(ad, "10", ["tmdb:3", "tmdb:1", "tmdb:2"])
+    assert res["reordered"] >= 1
+    assert [o.ratingKey for o in regular.items()] == [3, 1, 2]
+
+    res2 = plpl.reorder(ad, "10", ["tmdb:3", "tmdb:1", "tmdb:2"])
+    assert res2["reordered"] == 0

--- a/providers/tests/test_publicmetadb_playlists.py
+++ b/providers/tests/test_publicmetadb_playlists.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+pl = importlib.import_module("providers.sync.publicmetadb._playlists")
+
+
+class FakeResp:
+    def __init__(self, status: int, payload: Any = None):
+        self.status_code = status
+        self._payload = payload
+        self.text = "x" if payload is not None else ""
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeCfg:
+    watchlist_page_size = 2
+
+
+class FakeClient:
+    def __init__(self, responses: dict[tuple[str, str, int | None], Any] | None = None):
+        self.responses = responses or {}
+        self.calls: list[dict[str, Any]] = []
+
+    def get_json(self, path: str, **kw: Any) -> dict[str, Any]:
+        page = None
+        params = kw.get("params")
+        if isinstance(params, dict):
+            page = int(params.get("page") or 1)
+        self.calls.append({"method": "GET", "path": path, "params": params})
+        return dict(self.responses.get(("GET", path, page), {"items": []}))
+
+    def post_json(self, path: str, **kw: Any) -> dict[str, Any]:
+        self.calls.append({"method": "POST_JSON", "path": path, "json": kw.get("json")})
+        return dict(self.responses.get(("POST_JSON", path, None), {}))
+
+    def post(self, path: str, **kw: Any) -> FakeResp:
+        self.calls.append({"method": "POST", "path": path, "json": kw.get("json")})
+        return FakeResp(200, self.responses.get(("POST", path, None), {"item": {"id": "x"}}))
+
+    def delete(self, path: str, **kw: Any) -> FakeResp:
+        self.calls.append({"method": "DELETE", "path": path, "json": kw.get("json")})
+        return FakeResp(200, self.responses.get(("DELETE", path, None), {}))
+
+
+class FakeAdapter:
+    def __init__(self, client: FakeClient):
+        self.cfg = FakeCfg()
+        self.client = client
+        self.instance_id = "default"
+        self.config = {"publicmetadb": {"api_key": "k"}}
+
+
+def _movie(tmdb: int, title: str = "Movie") -> dict[str, Any]:
+    return {"type": "movie", "title": title, "ids": {"tmdb": str(tmdb)}}
+
+
+def _show(tmdb: int, title: str = "Show") -> dict[str, Any]:
+    return {"type": "show", "title": title, "ids": {"tmdb": str(tmdb)}}
+
+
+def test_list_resources_uses_exact_ids_and_pagination():
+    client = FakeClient(
+        {
+            ("GET", "/api/external/lists", 1): {
+                "items": [
+                    {"id": "list-a", "name": "Weekend", "is_public": False, "items": 2},
+                    {"id": "watch-1", "name": "Watchlist", "type": "watchlist", "is_public": False},
+                ],
+                "totalPages": 2,
+            },
+            ("GET", "/api/external/lists", 2): {
+                "items": [{"id": "list-b", "name": "Shows", "is_public": True, "item_count": 1}],
+                "totalPages": 2,
+            },
+        }
+    )
+
+    resources = pl.list_resources(FakeAdapter(client))
+    by_id = {r.id: r for r in resources}
+    assert set(by_id) == {"list-a", "watch-1", "list-b"}
+    assert by_id["list-a"].name == "Weekend"
+    assert by_id["list-a"].can_reorder is False
+    assert by_id["list-a"].media_types == ("movie", "show")
+    assert by_id["list-a"].extra["raw_id"] == "list-a"
+    assert by_id["list-b"].extra["private"] is False
+
+
+def test_snapshot_reads_movies_and_shows_with_pagination():
+    client = FakeClient(
+        {
+            ("GET", "/api/external/lists", 1): {"items": [{"id": "list-a", "name": "Weekend"}]},
+            ("GET", "/api/external/lists/list-a/items", 1): {
+                "items": [
+                    {"id": "i1", "tmdb_id": 438631, "media_type": "movie", "title": "Dune", "year": 2021},
+                    {"id": "i2", "tmdb_id": 95396, "media_type": "tv", "title": "Severance", "year": 2022},
+                ],
+                "totalPages": 2,
+            },
+            ("GET", "/api/external/lists/list-a/items", 2): {
+                "items": [{"id": "i3", "tmdb_id": None, "media_type": "movie", "title": "Sparse"}],
+                "totalPages": 2,
+            },
+        }
+    )
+
+    snap = pl.get_snapshot(FakeAdapter(client), "list-a")
+    assert snap.resource.id == "list-a"
+    assert snap.ordered_keys() == ["tmdb:438631", "tmdb:95396"]
+    assert snap.items[0].playlist_item_id == "i1"
+    assert snap.items[0].position is None
+    assert snap.items[1].item["type"] == "show"
+
+
+def test_create_private_list_and_add_payloads_require_tmdb():
+    client = FakeClient(
+        {
+            ("POST_JSON", "/api/external/lists", None): {"item": {"id": "created-1", "name": "Private"}},
+        }
+    )
+    ad = FakeAdapter(client)
+
+    res = pl.create(ad, "Private")
+    assert res.id == "created-1"
+    create_call = next(c for c in client.calls if c["method"] == "POST_JSON")
+    assert create_call["json"] == {"name": "Private", "description": "", "is_public": False, "type": "list"}
+
+    add = pl.add(ad, "created-1", [_movie(438631, "Dune"), _show(95396, "Severance"), {"type": "movie", "ids": {}}])
+    assert add["count"] == 2
+    assert add["confirmed_keys"] == ["tmdb:438631", "tmdb:95396"]
+    assert add["unresolved"][0]["hint"] == "missing_tmdb_id"
+    post_calls = [c for c in client.calls if c["method"] == "POST" and c["path"].endswith("/items")]
+    assert post_calls[0]["json"] == {"tmdb_id": 438631, "media_type": "movie"}
+    assert post_calls[1]["json"] == {"tmdb_id": 95396, "media_type": "tv"}
+
+
+def test_remove_fetches_selected_list_item_ids():
+    client = FakeClient(
+        {
+            ("GET", "/api/external/lists/list-a/items", 1): {
+                "items": [{"id": "a-item", "tmdb_id": 1, "media_type": "movie"}],
+            },
+            ("GET", "/api/external/lists/list-b/items", 1): {
+                "items": [{"id": "b-item", "tmdb_id": 1, "media_type": "movie"}],
+            },
+        }
+    )
+    ad = FakeAdapter(client)
+
+    res_a = pl.remove(ad, "list-a", [_movie(1)])
+    res_b = pl.remove(ad, "list-b", [_movie(1)])
+    assert res_a["count"] == 1 and res_b["count"] == 1
+    deletes = [c["path"] for c in client.calls if c["method"] == "DELETE"]
+    assert "/api/external/lists/list-a/items/a-item" in deletes
+    assert "/api/external/lists/list-b/items/b-item" in deletes
+
+
+def test_reorder_is_unsupported():
+    assert pl.reorder(FakeAdapter(FakeClient()), "list-a", ["tmdb:1"])["unsupported"] is True

--- a/providers/tests/test_simkl_history_anime_mapping.py
+++ b/providers/tests/test_simkl_history_anime_mapping.py
@@ -1,0 +1,1084 @@
+﻿from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+
+class _Resp:
+    def __init__(self, status=200, payload=None, text=None, headers=None):
+        self.status_code = status
+        self._payload = payload if payload is not None else {}
+        self.text = text if text is not None else json.dumps(self._payload)
+        self.headers = headers if headers is not None else {}
+
+    def json(self):
+        return self._payload
+
+    @property
+    def ok(self):
+        return 200 <= self.status_code < 300
+
+
+def _ok_add(episodes=0, movies=0, shows=0, not_found=None):
+    return {
+        "added": {"movies": movies, "shows": shows, "episodes": episodes},
+        "not_found": not_found or {"movies": [], "shows": [], "episodes": []},
+    }
+
+
+class _Session:
+    def __init__(self, post_handler=None, redirect_map=None, episodes_map=None, all_items=None):
+        self.posts = []
+        self.gets = []
+        self._post_handler = post_handler or (lambda url, body: _Resp(200, _ok_add(episodes=1)))
+        self._redirect_map = {str(k): str(v) for k, v in (redirect_map or {}).items()}
+        self._episodes_map = {str(k): v for k, v in (episodes_map or {}).items()}
+        self._all_items = all_items
+
+    def post(self, url, headers=None, params=None, json=None, timeout=None):
+        self.posts.append({"url": url, "json": json})
+        return self._post_handler(url, json)
+
+    def get(self, url, headers=None, params=None, timeout=None, allow_redirects=None):
+        self.gets.append({"url": url, "params": params})
+        import sync.simkl._history as m
+        if url == m.URL_ALL_ITEMS:
+            if callable(self._all_items):
+                return _Resp(200, self._all_items(len([g for g in self.gets if g["url"] == url])))
+            return _Resp(200, self._all_items or {"movies": [], "shows": [], "anime": []})
+        if url == m.URL_REDIRECT:
+            tvdb = str((params or {}).get("tvdb") or "")
+            simkl = self._redirect_map.get(tvdb)
+            if simkl:
+                return _Resp(302, {}, headers={"Location": f"https://simkl.com/anime/{simkl}/x"})
+            return _Resp(404, {})
+        if "/anime/episodes/" in url:
+            simkl = url.rsplit("/", 1)[-1]
+            return _Resp(200, self._episodes_map.get(simkl, []))
+        return _Resp(404, {})
+
+
+def _patch_fs(monkeypatch, m):
+    store: dict[str, str] = {}
+    monkeypatch.setattr(m, "state_file", lambda name: name)
+    monkeypatch.setattr(m, "_load_json", lambda path: json.loads(store.get(path) or "{}"))
+    monkeypatch.setattr(m, "_save_json", lambda path, data: store.__setitem__(path, json.dumps(data)))
+    monkeypatch.setattr(m, "cache_anime_mappings", lambda *a, **k: None)
+    monkeypatch.setattr(m, "_headers", lambda *a, **k: {})
+    monkeypatch.setattr(m, "simkl_api_params_from_headers", lambda headers=None, **k: dict(k))
+    monkeypatch.setattr(m, "_unfreeze", lambda *a, **k: None)
+    monkeypatch.setattr(m, "_freeze", lambda *a, **k: None)
+    monkeypatch.setattr(m, "_inject_adds_into_cache", lambda *a, **k: None)
+    monkeypatch.setattr(m, "_load_anime_resolve_cache", lambda: m._AnimeResolveState({}, {}))
+    monkeypatch.setattr(m, "_save_anime_resolve_cache", lambda *a, **k: None)
+    monkeypatch.setattr(m, "_load_anime_episode_map_cache", lambda: {})
+    monkeypatch.setattr(m, "_save_anime_episode_map_cache", lambda *a, **k: None)
+    monkeypatch.setattr(m, "_load_anime_episode_alias_cache", lambda: {})
+    monkeypatch.setattr(m, "_save_anime_episode_alias_cache", lambda *a, **k: None)
+
+
+def _adapter(session):
+    return SimpleNamespace(client=SimpleNamespace(session=session), cfg=SimpleNamespace(timeout=5, history_chunk_size=100))
+
+
+def _episode(tvdb, tmdb, season, episode, series, *, number_abs=None):
+    item = {
+        "type": "episode",
+        "season": season,
+        "episode": episode,
+        "watched_at": "2024-01-01T00:00:00Z",
+        "show_ids": {"tvdb": tvdb, "tmdb": tmdb},
+        "series_title": series,
+    }
+    if number_abs is not None:
+        item["_trakt_number_abs"] = number_abs
+    return item
+
+
+def _dbz(season, episode, number_abs):
+    return _episode("81472", "12971", season, episode, "Dragon Ball Z", number_abs=number_abs)
+
+
+def _aot(season, episode):
+    return _episode("267440", "1429", season, episode, "Attack on Titan")
+
+
+def _s00(show_tvdb, show_tmdb, episode, series, *, ep_tvdb=None):
+    item = {
+        "type": "episode",
+        "season": 0,
+        "episode": episode,
+        "watched_at": "2024-01-01T00:00:00Z",
+        "show_ids": {"tvdb": show_tvdb, "tmdb": show_tmdb},
+        "series_title": series,
+    }
+    if ep_tvdb is not None:
+        item["ids"] = {"tvdb": ep_tvdb}
+    return item
+
+
+# DBZ redirects to a native SIMKL anime entry whose absolute episodes exist (E40 present).
+_DBZ_REDIRECT = {"81472": "41487"}
+_DBZ_EPISODES = {"41487": [{"episode": n, "title": f"dbz{n}", "tvdb": {"season": 1, "episode": n}} for n in range(1, 60)]}
+# Attack on Titan's parent TVDB redirects to a cour whose native map only covers S1 (no S4).
+_AOT_REDIRECT = {"267440": "39687"}
+_AOT_EPISODES = {"39687": [{"episode": n, "title": f"aot{n}", "tvdb": {"season": 1, "episode": n}} for n in range(1, 26)]}
+
+
+def _shows_of(session, url):
+    for p in session.posts:
+        if p["url"] == url and isinstance(p["json"], dict) and "shows" in p["json"]:
+            for show in p["json"]["shows"]:
+                yield show
+
+
+def _anime_of(session, url):
+    for p in session.posts:
+        if p["url"] == url and isinstance(p["json"], dict) and "anime" in p["json"]:
+            for grp in p["json"]["anime"]:
+                yield grp
+
+
+def test_dbz_resolves_to_anime_e40_absent_from_shows(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _Session(redirect_map=_DBZ_REDIRECT, episodes_map=_DBZ_EPISODES)
+    adapter = _adapter(session)
+
+    ok, unresolved = m.add(adapter, [_dbz(2, 1, 40)])
+
+    anime_numbers = [e["number"] for grp in _anime_of(session, m.URL_ADD) for e in grp["episodes"]]
+    assert anime_numbers == [40]
+    assert list(_shows_of(session, m.URL_ADD)) == []
+    assert ok == 1
+    assert unresolved == []
+
+
+def test_aot_s04e17_falls_to_shows_with_flag(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _Session(redirect_map=_AOT_REDIRECT, episodes_map=_AOT_EPISODES)
+    adapter = _adapter(session)
+
+    ok, unresolved = m.add(adapter, [_aot(4, 17)])
+
+    assert list(_anime_of(session, m.URL_ADD)) == []
+    shows = list(_shows_of(session, m.URL_ADD))
+    assert len(shows) == 1
+    assert shows[0]["use_tvdb_anime_seasons"] is True
+    assert shows[0]["ids"].get("tvdb") == "267440"
+    seasons = {s["number"]: s for s in shows[0]["seasons"]}
+    ep = seasons[4]["episodes"][0]
+    assert ep["number"] == 17
+    assert ep["watched_at"] == "2024-01-01T00:00:00Z"
+    assert unresolved == []
+
+
+def test_aot_range_not_marked_missing(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _Session(redirect_map=_AOT_REDIRECT, episodes_map=_AOT_EPISODES)
+    adapter = _adapter(session)
+
+    ok, unresolved = m.add(adapter, [_aot(4, 16), _aot(4, 17), _aot(4, 18)])
+
+    assert unresolved == []
+    assert list(_anime_of(session, m.URL_ADD)) == []
+    numbers = sorted(
+        e["number"]
+        for show in _shows_of(session, m.URL_ADD)
+        for s in show["seasons"]
+        for e in s["episodes"]
+    )
+    assert numbers == [16, 17, 18]
+
+
+def test_no_duplicate_between_anime_and_shows(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _Session(redirect_map={**_DBZ_REDIRECT, **_AOT_REDIRECT}, episodes_map={**_DBZ_EPISODES, **_AOT_EPISODES})
+    adapter = _adapter(session)
+
+    m.add(adapter, [_dbz(2, 1, 40), _aot(4, 17)])
+
+    anime_numbers = [e["number"] for grp in _anime_of(session, m.URL_ADD) for e in grp["episodes"]]
+    show_ids = [show["ids"].get("tvdb") for show in _shows_of(session, m.URL_ADD)]
+    assert anime_numbers == [40]
+    assert show_ids == ["267440"]
+    assert "81472" not in show_ids
+
+
+def _remove_session():
+    return _Session(
+        post_handler=lambda url, body: _Resp(200, {"deleted": {"episodes": 1}, "not_found": {"shows": [], "movies": []}}),
+        redirect_map={**_DBZ_REDIRECT, **_AOT_REDIRECT},
+        episodes_map={**_DBZ_EPISODES, **_AOT_EPISODES},
+    )
+
+
+def test_dbz_mapped_removal_uses_anime(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _remove_session()
+    adapter = _adapter(session)
+
+    ok, unresolved = m.remove(adapter, [_dbz(2, 1, 40)])
+
+    anime_numbers = [e["number"] for grp in _anime_of(session, m.URL_REMOVE) for e in grp["episodes"]]
+    assert anime_numbers == [40]
+    assert list(_shows_of(session, m.URL_REMOVE)) == []
+    assert unresolved == []
+
+
+def test_aot_unmapped_removal_never_falls_to_shows(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _remove_session()
+    adapter = _adapter(session)
+
+    ok, unresolved = m.remove(adapter, [_aot(4, 17)])
+
+    assert list(_anime_of(session, m.URL_REMOVE)) == []
+    assert list(_shows_of(session, m.URL_REMOVE)) == []
+    assert ok == 0
+    assert [u["hint"] for u in unresolved] == ["simkl_anime_remove_unmapped"]
+
+
+def test_native_identity_removal_groups_by_simkl_record(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _remove_session()
+    adapter = _adapter(session)
+
+    def _native(record, native_number, season, episode):
+        item = _aot(season, episode)
+        item["show_ids"] = {"tvdb": "267440", "tmdb": "1429", "simkl": record}
+        item["_simkl_episode_number"] = native_number
+        item["simkl_bucket"] = "anime"
+        return item
+
+    items = [
+        _native("39687", 1, 1, 1),
+        _native("39687", 2, 1, 2),
+        _native("1579947", 1, 4, 17),
+    ]
+    ok, unresolved = m.remove(adapter, items)
+
+    groups = {grp["ids"]["simkl"]: [e["number"] for e in grp["episodes"]] for grp in _anime_of(session, m.URL_REMOVE)}
+    assert groups == {"39687": [1, 2], "1579947": [1]}
+    assert list(_shows_of(session, m.URL_REMOVE)) == []
+    assert session.gets == [g for g in session.gets if g["url"] == m.URL_ALL_ITEMS]
+    assert ok == 3
+    assert unresolved == []
+
+
+def test_removal_no_adjacent_inference(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _remove_session()
+    adapter = _adapter(session)
+
+    # S02E01 maps to native E40 via number_abs; the adjacent S02E02 has no native
+    # mapping and must NOT be inferred into anime[] from its neighbour.
+    mapped = _dbz(2, 1, 40)
+    unmapped = _episode("81472", "12971", 2, 2, "Dragon Ball Z")
+    _ok, unresolved = m.remove(adapter, [mapped, unmapped])
+
+    anime_numbers = [e["number"] for grp in _anime_of(session, m.URL_REMOVE) for e in grp["episodes"]]
+    assert anime_numbers == [40]
+    assert list(_shows_of(session, m.URL_REMOVE)) == []
+    assert [u["hint"] for u in unresolved] == ["simkl_anime_remove_unmapped"]
+
+
+def test_mixed_response_confirms_all_but_not_found(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+
+    not_found_obj = {
+        "ids": {"tvdb": "121361", "tmdb": "1399"},
+        "seasons": [{"number": 1, "episodes": [{"number": 1}]}],
+    }
+    # One not_found item plus deliberately underreported added counts.
+    session = _Session(
+        post_handler=lambda url, body: _Resp(
+            200,
+            {"added": {"movies": 0, "shows": 0, "episodes": 0}, "not_found": {"movies": [], "shows": [], "episodes": [not_found_obj]}},
+        )
+    )
+    adapter = _adapter(session)
+
+    items = [
+        _episode("81189", "1396", 3, 8, "Breaking Bad"),
+        _episode("121361", "1399", 1, 1, "Game of Thrones"),
+        _episode("153021", "1408", 2, 5, "House"),
+    ]
+    ok, unresolved = m.add(adapter, items)
+
+    assert ok == 2
+    assert len(unresolved) == 1
+
+
+def test_anime_like_s00_unmapped_is_unresolved(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _Session(redirect_map=_AOT_REDIRECT, episodes_map=_AOT_EPISODES)
+    adapter = _adapter(session)
+
+    item = _s00("267440", "1429", 2, "Attack on Titan")
+    ok, unresolved = m.add(adapter, [item])
+
+    assert ok == 0
+    assert len(unresolved) == 1
+    assert list(_shows_of(session, m.URL_ADD)) == []
+    assert list(_anime_of(session, m.URL_ADD)) == []
+
+
+def test_non_anime_s00_uses_scoped_shows_payload(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _Session()
+    adapter = _adapter(session)
+
+    item = _s00("81189", "1396", 5, "Breaking Bad")
+    ok, unresolved = m.add(adapter, [item])
+
+    shows = list(_shows_of(session, m.URL_ADD))
+    assert len(shows) == 1
+    seasons = {s["number"]: s for s in shows[0]["seasons"]}
+    assert 0 in seasons
+    assert [e["number"] for e in seasons[0]["episodes"]] == [5]
+    assert list(_anime_of(session, m.URL_ADD)) == []
+    assert ok == 1
+    assert unresolved == []
+
+
+def _anime_bucket_s00():
+    return {
+        "type": "episode",
+        "season": 0,
+        "episode": 2,
+        "watched_at": "2024-01-01T00:00:00Z",
+        "show_ids": {"tvdb": "555555", "tmdb": "1"},
+        "series_title": "Some Anime",
+        "simkl_bucket": "anime",
+    }
+
+
+def test_anime_bucket_s00_without_redirect_is_unresolved(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _Session()
+    adapter = _adapter(session)
+
+    ok, unresolved = m.add(adapter, [_anime_bucket_s00()])
+
+    assert ok == 0
+    assert len(unresolved) == 1
+    assert list(_shows_of(session, m.URL_ADD)) == []
+    assert list(_anime_of(session, m.URL_ADD)) == []
+
+
+def test_anime_bucket_s00_removal_is_unresolved(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _Session()
+    adapter = _adapter(session)
+
+    ok, unresolved = m.remove(adapter, [_anime_bucket_s00()])
+
+    assert ok == 0
+    assert len(unresolved) == 1
+    assert list(_shows_of(session, m.URL_REMOVE)) == []
+    assert list(_anime_of(session, m.URL_REMOVE)) == []
+
+
+def test_normal_tv_confirms_all_when_no_not_found(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _Session(post_handler=lambda url, body: _Resp(200, _ok_add(episodes=1)))
+    adapter = _adapter(session)
+
+    items = [
+        _episode("81189", "1396", 3, 8, "Breaking Bad"),
+        _episode("121361", "1399", 1, 1, "Game of Thrones"),
+        _episode("153021", "1408", 2, 5, "House"),
+    ]
+    ok, unresolved = m.add(adapter, items)
+
+    assert unresolved == []
+    assert ok == 3
+
+
+def test_normal_tv_uses_shows_payload(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _Session()
+    adapter = _adapter(session)
+
+    m.add(adapter, [_episode("81189", "1396", 3, 8, "Breaking Bad")])
+
+    shows = list(_shows_of(session, m.URL_ADD))
+    assert shows and list(_anime_of(session, m.URL_ADD)) == []
+    seasons = {s["number"]: s for s in shows[0]["seasons"]}
+    assert [e["number"] for e in seasons[3]["episodes"]] == [8]
+
+
+def test_anime_retry_confirms_all_when_no_not_found(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _Session(
+        post_handler=lambda url, body: _Resp(200, _ok_add(episodes=0)),
+        redirect_map=_DBZ_REDIRECT,
+        episodes_map=_DBZ_EPISODES,
+    )
+    adapter = _adapter(session)
+
+    ok, unresolved = m.add(adapter, [_dbz(2, 1, 40)])
+
+    assert unresolved == []
+    assert ok == 1
+
+
+def test_dbz_absolute_fallback_group_mapping(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _Session(episodes_map=_DBZ_EPISODES)
+    adapter = _adapter(session)
+
+    item = _dbz(2, 1, 40)
+    mapped = m._anime_retry_episode_numbers_for_group(
+        [item],
+        {"simkl": "41487", "tvdb": "81472"},
+        session=session,
+        headers={},
+        timeout=5,
+        episode_cache={},
+    )
+    assert mapped == {m._thaw_key(item): 40}
+
+
+def test_read_back_native_e01_maps_to_tvdb_s04e17():
+    import sync.simkl._history as m
+
+    anime_rows = [
+        {
+            "show": {
+                "title": "Shingeki no Kyojin The Final Season Part 2",
+                "ids": {"simkl": 1579947, "tvdb": "267440", "tmdb": "1429"},
+                "anime_type": "tv",
+            },
+            "seasons": [
+                {
+                    "number": 1,
+                    "episodes": [
+                        {
+                            "number": 1,
+                            "watched_at": "2024-01-01T00:00:00Z",
+                            "tvdb": {"season": 4, "episode": 17},
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+    out, *_ = m._parse_rows([], [], anime_rows, limit=None)
+    eps = [v for v in out.values() if str(v.get("type")) == "episode"]
+    assert len(eps) == 1
+    assert eps[0]["season"] == 4
+    assert eps[0]["episode"] == 17
+
+
+def _set_source_aliases(monkeypatch, m, aliases):
+    monkeypatch.setattr(m, "_load_source_aliases", lambda: {k: dict(v) for k, v in aliases.items()})
+    monkeypatch.setattr(m, "_save_source_aliases", lambda *a, **k: None)
+
+
+def test_s00_special_read_back_maps_to_trakt_s00e02(monkeypatch):
+    import sync.simkl._history as m
+    from cw_platform.id_map import canonical_key
+
+    trakt_item = {
+        "type": "episode",
+        "ids": {"tvdb": "4635717"},
+        "show_ids": {"tmdb": "1429", "tvdb": "267440"},
+        "season": 0,
+        "episode": 2,
+        "title": "AOT Special 2",
+        "series_title": "Attack on Titan",
+    }
+    _set_source_aliases(
+        monkeypatch,
+        m,
+        {
+            "k1": {
+                "season": 0,
+                "episode": 2,
+                "ids": {"tvdb": "4635717"},
+                "show_ids": {"tmdb": "1429", "tvdb": "267440"},
+                "title": "AOT Special 2",
+                "series_title": "Attack on Titan",
+            }
+        },
+    )
+
+    anime_row = {
+        "show": {"title": "AoT OVA", "ids": {"simkl": 999999, "tvdb": "888888"}, "anime_type": "special"},
+        "seasons": [
+            {
+                "number": 1,
+                "episodes": [
+                    {
+                        "number": 2,
+                        "watched_at": "2024-05-05T00:00:00Z",
+                        "ids": {"tvdb_id": "4635717"},
+                        "tvdb": {"season": 5, "episode": 9},
+                    }
+                ],
+            }
+        ],
+    }
+
+    out, *_ = m._parse_rows([], [], [anime_row], limit=None)
+    eps = [v for v in out.values() if str(v.get("type")) == "episode"]
+    assert len(eps) == 1
+    ep = eps[0]
+    assert (ep["season"], ep["episode"]) == (0, 2)
+    assert {k: ep["show_ids"][k] for k in ("tmdb", "tvdb")} == {"tmdb": "1429", "tvdb": "267440"}
+    assert ep["show_ids"]["simkl"] == "999999"
+    assert ep["_simkl_episode_number"] == 2
+    assert ep["series_title"] == "Attack on Titan"
+    assert ep["watched_at"] == "2024-05-05T00:00:00Z"
+    assert canonical_key(ep) == canonical_key(trakt_item)
+
+
+def test_special_without_episode_id_not_mapped_to_s00(monkeypatch):
+    import sync.simkl._history as m
+
+    _set_source_aliases(
+        monkeypatch,
+        m,
+        {"k1": {"season": 0, "episode": 2, "ids": {"tvdb": "4635717"}, "show_ids": {"tmdb": "1429", "tvdb": "267440"}}},
+    )
+
+    anime_row = {
+        "show": {"title": "AoT OVA", "ids": {"simkl": 999999, "tvdb": "888888"}, "anime_type": "special"},
+        "seasons": [{"number": 1, "episodes": [{"number": 2, "watched_at": "2024-05-05T00:00:00Z"}]}],
+    }
+
+    out, *_ = m._parse_rows([], [], [anime_row], limit=None)
+    eps = [v for v in out.values() if str(v.get("type")) == "episode"]
+    assert len(eps) == 1
+    assert eps[0]["season"] != 0
+    assert (eps[0]["season"], eps[0]["episode"]) == (1, 2)
+
+
+def test_unrelated_anime_movie_stays_movie(monkeypatch):
+    import sync.simkl._history as m
+
+    _set_source_aliases(
+        monkeypatch,
+        m,
+        {"k1": {"season": 0, "episode": 3, "ids": {"tvdb": "111222"}, "show_ids": {"tmdb": "12971", "tvdb": "81472"}}},
+    )
+
+    anime_row = {
+        "show": {"title": "Some Anime Film", "ids": {"simkl": 777, "tvdb": "999000"}, "anime_type": "movie"},
+        "last_watched_at": "2024-06-06T00:00:00Z",
+        "seasons": [],
+    }
+
+    out, *_ = m._parse_rows([], [], [anime_row], limit=None)
+    items = list(out.values())
+    assert len(items) == 1
+    assert items[0]["type"] == "movie"
+
+
+def test_no_simkl_history_code_reads_trakt_index():
+    import inspect
+    import sync.simkl._history as m
+
+    src = inspect.getsource(m)
+    assert "trakt_history.index" not in src
+    assert not hasattr(m, "_trakt_history_index_path")
+
+
+def test_confirmed_item_populates_source_alias(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    saved: dict = {}
+    monkeypatch.setattr(m, "_load_source_aliases", lambda: {})
+    monkeypatch.setattr(m, "_save_source_aliases", lambda items: saved.update({"items": dict(items)}))
+
+    session = _Session(post_handler=lambda url, body: _Resp(200, _ok_add(episodes=1)))
+    adapter = _adapter(session)
+
+    item = _episode("81189", "1396", 3, 8, "Breaking Bad")
+    item["ids"] = {"tvdb": "700700"}
+    item["_trakt_number_abs"] = 33
+    ok, unresolved = m.add(adapter, [item])
+
+    assert ok == 1
+    assert saved.get("items")
+    rec = next(iter(saved["items"].values()))
+    assert (rec["season"], rec["episode"]) == (3, 8)
+    assert rec["ids"] == {"tvdb": "700700"}
+    assert rec["number_abs"] == 33
+    assert rec["show_ids"].get("tvdb") == "81189"
+
+
+def test_number_abs_preserves_dbz_read_back(monkeypatch):
+    import sync.simkl._history as m
+
+    _set_source_aliases(
+        monkeypatch,
+        m,
+        {"k1": {"season": 2, "episode": 1, "ids": {}, "show_ids": {"tvdb": "81472", "tmdb": "12971"}, "number_abs": 40, "series_title": "Dragon Ball Z"}},
+    )
+
+    anime_row = {
+        "show": {"title": "Dragon Ball Z", "ids": {"simkl": 41487, "tvdb": "81472", "tmdb": "12971"}, "anime_type": "tv"},
+        "seasons": [{"number": 1, "episodes": [{"number": 40, "watched_at": "2024-01-01T00:00:00Z"}]}],
+    }
+
+    out, *_ = m._parse_rows([], [], [anime_row], limit=None)
+    eps = [v for v in out.values() if str(v.get("type")) == "episode"]
+    assert len(eps) == 1
+    assert (eps[0]["season"], eps[0]["episode"]) == (2, 1)
+
+
+def test_single_episode_stays_granular(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _Session()
+    adapter = _adapter(session)
+
+    m.add(adapter, [_episode("81189", "1396", 1, 5, "Breaking Bad")])
+
+    shows = list(_shows_of(session, m.URL_ADD))
+    seasons = {s["number"]: s for s in shows[0]["seasons"]}
+    assert set(seasons.keys()) == {1}
+    assert [e["number"] for e in seasons[1]["episodes"]] == [5]
+    assert "watched_at" not in seasons[1]
+
+
+class _RedirectSession:
+    def __init__(self, location=None, raise_exc=False, status=302):
+        self.gets = 0
+        self._location = location
+        self._raise = raise_exc
+        self._status = status
+
+    def get(self, url, headers=None, params=None, timeout=None, allow_redirects=None):
+        self.gets += 1
+        if self._raise:
+            raise RuntimeError("boom")
+        headers_out = {"Location": self._location} if self._location else {}
+        return _Resp(self._status, {}, headers=headers_out)
+
+
+def _patch_params(monkeypatch, m):
+    monkeypatch.setattr(m, "simkl_api_params_from_headers", lambda headers=None, **k: dict(k))
+
+
+def test_resolve_positive_cache_no_http():
+    import sync.simkl._history as m
+
+    state = m._AnimeResolveState({"267440": "39687"}, {})
+    sess = _RedirectSession()
+    out = m._resolved_anime_ids_for_tvdb(sess, {}, 5, "267440", state)
+    assert out == {"simkl": "39687", "tvdb": "267440"}
+    assert sess.gets == 0
+    assert state.cached_positive == 1
+
+
+def test_resolve_negative_cache_no_http():
+    import sync.simkl._history as m
+
+    state = m._AnimeResolveState({}, {"999": m._now_epoch()})
+    sess = _RedirectSession()
+    out = m._resolved_anime_ids_for_tvdb(sess, {}, 5, "999", state)
+    assert out == {}
+    assert sess.gets == 0
+    assert state.cached_negative == 1
+
+
+def test_resolve_non_anime_persists_negative_and_is_not_failed(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_params(monkeypatch, m)
+    saved = []
+    monkeypatch.setattr(m, "_save_anime_resolve_cache", lambda st: saved.append(st))
+    state = m._AnimeResolveState({}, {})
+    sess = _RedirectSession(location="https://simkl.com/tv/12345/foo")
+
+    out = m._resolved_anime_ids_for_tvdb(sess, {}, 5, "888", state)
+    assert out == {}
+    assert "888" in state.misses
+    assert state.non_anime == 1
+    assert state.failed == 0
+    assert saved
+
+    out2 = m._resolved_anime_ids_for_tvdb(sess, {}, 5, "888", state)
+    assert out2 == {}
+    assert sess.gets == 1
+    assert state.cached_negative == 1
+
+
+def test_resolve_positive_removes_expired_negative(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_params(monkeypatch, m)
+    monkeypatch.setattr(m, "_save_anime_resolve_cache", lambda st: None)
+    old = m._now_epoch() - m._ANIME_RESOLVE_MISS_TTL - 10
+    state = m._AnimeResolveState({}, {"777": old})
+    sess = _RedirectSession(location="https://simkl.com/anime/41487/dbz")
+
+    out = m._resolved_anime_ids_for_tvdb(sess, {}, 5, "777", state)
+    assert out == {"simkl": "41487", "tvdb": "777"}
+    assert "777" not in state.misses
+    assert state.resolved["777"] == "41487"
+    assert sess.gets == 1
+
+
+def test_resolve_http_exception_is_failed(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_params(monkeypatch, m)
+    state = m._AnimeResolveState({}, {})
+    sess = _RedirectSession(raise_exc=True)
+
+    out = m._resolved_anime_ids_for_tvdb(sess, {}, 5, "500", state)
+    assert out == {}
+    assert state.failed == 1
+    assert state.non_anime == 0
+    assert "500" not in state.misses
+
+
+def test_resolve_error_status_not_negatively_cached(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_params(monkeypatch, m)
+    saved = []
+    monkeypatch.setattr(m, "_save_anime_resolve_cache", lambda st: saved.append(st))
+    for status in (401, 403, 429, 500, 503):
+        state = m._AnimeResolveState({}, {})
+        sess = _RedirectSession(location="https://simkl.com/tv/12345/foo", status=status)
+        out = m._resolved_anime_ids_for_tvdb(sess, {}, 5, "888", state)
+        assert out == {}
+        assert "888" not in state.misses
+        assert state.non_anime == 0
+        assert state.failed == 1
+    assert saved == []
+
+
+def test_resolve_redirect_without_location_not_negatively_cached(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_params(monkeypatch, m)
+    monkeypatch.setattr(m, "_save_anime_resolve_cache", lambda st: None)
+    state = m._AnimeResolveState({}, {})
+    sess = _RedirectSession(location=None, status=302)
+
+    out = m._resolved_anime_ids_for_tvdb(sess, {}, 5, "888", state)
+    assert out == {}
+    assert "888" not in state.misses
+    assert state.non_anime == 0
+    assert state.failed == 1
+
+
+def test_load_resolve_cache_backward_compat_flat(monkeypatch):
+    import sync.simkl._history as m
+
+    monkeypatch.setattr(m, "_load_json", lambda path: {"tvdb_to_simkl": {"111": "222"}})
+    state = m._load_anime_resolve_cache()
+    assert state.resolved == {"111": "222"}
+    assert state.misses == {}
+
+
+def test_load_resolve_cache_new_format(monkeypatch):
+    import sync.simkl._history as m
+
+    monkeypatch.setattr(m, "_load_json", lambda path: {"resolved": {"1": "2"}, "misses": {"3": 1700000000}})
+    state = m._load_anime_resolve_cache()
+    assert state.resolved == {"1": "2"}
+    assert state.misses == {"3": 1700000000}
+
+
+def test_show_exact_episode_id_alias_restores_season_episode(monkeypatch):
+    import sync.simkl._history as m
+    from cw_platform.id_map import canonical_key
+
+    trakt_item = {
+        "type": "episode",
+        "ids": {"tvdb": "5057304"},
+        "show_ids": {"tmdb": "42009", "tvdb": "253463"},
+        "season": 2,
+        "episode": 4,
+        "title": "White Christmas",
+        "series_title": "Black Mirror",
+        "series_year": 2011,
+    }
+    _set_source_aliases(
+        monkeypatch,
+        m,
+        {
+            "k1": {
+                "season": 2,
+                "episode": 4,
+                "ids": {"tvdb": "5057304"},
+                "show_ids": {"tmdb": "42009", "tvdb": "253463"},
+                "title": "White Christmas",
+                "series_title": "Black Mirror",
+                "series_year": 2011,
+            }
+        },
+    )
+
+    show_row = {
+        "show": {"title": "Black Mirror", "year": 2011, "ids": {"tmdb": "42009", "tvdb": "253463", "simkl": 12345}},
+        "seasons": [
+            {
+                "number": 0,
+                "episodes": [
+                    {"number": 1, "watched_at": "2024-05-05T00:00:00Z", "ids": {"tvdb": "5057304"}}
+                ],
+            }
+        ],
+    }
+
+    out, *_ = m._parse_rows([], [show_row], [], limit=None)
+    eps = [v for v in out.values() if str(v.get("type")) == "episode"]
+    assert len(eps) == 1
+    ep = eps[0]
+    assert (ep["season"], ep["episode"]) == (2, 4)
+    assert ep["ids"] == {"tvdb": "5057304"}
+    assert ep["show_ids"] == {"tmdb": "42009", "tvdb": "253463"}
+    assert ep["title"] == "White Christmas"
+    assert ep["series_title"] == "Black Mirror"
+    assert ep["series_year"] == 2011
+    assert ep["watched_at"] == "2024-05-05T00:00:00Z"
+    assert canonical_key(ep) == canonical_key(trakt_item)
+
+
+def test_show_unique_exact_id_maps_across_anthology_split(monkeypatch):
+    import sync.simkl._history as m
+
+    aliases = {}
+    for n in range(1, 10):
+        aliases[f"m{n}"] = {
+            "season": 1,
+            "episode": n,
+            "ids": {"tvdb": str(10649168 + n)},
+            "show_ids": {"tmdb": "225634"},
+            "title": f"Monsters S01E{n:02d}",
+            "series_title": "Monsters",
+        }
+    _set_source_aliases(monkeypatch, m, aliases)
+
+    show_row = {
+        "show": {"title": "Monster", "ids": {"tmdb": "113988", "simkl": 5150}},
+        "seasons": [
+            {
+                "number": 2,
+                "episodes": [
+                    {
+                        "number": n,
+                        "watched_at": "2024-05-05T00:00:00Z",
+                        "ids": {"tvdb": str(10649168 + n)},
+                    }
+                    for n in range(1, 10)
+                ],
+            }
+        ],
+    }
+
+    out, *_ = m._parse_rows([], [show_row], [], limit=None)
+    eps = [v for v in out.values() if str(v.get("type")) == "episode"]
+    assert len(eps) == 9
+    assert sorted((e["season"], e["episode"]) for e in eps) == [(1, n) for n in range(1, 10)]
+    assert all(e["show_ids"] == {"tmdb": "225634"} for e in eps)
+    assert all(e["series_title"] == "Monsters" for e in eps)
+
+
+def _wvl_aliases():
+    return {
+        "a5": {
+            "season": 3,
+            "episode": 5,
+            "ids": {"tvdb": "111005"},
+            "show_ids": {"tmdb": "5000", "tvdb": "6000"},
+            "title": "WVL S03E05",
+        },
+        "a7": {
+            "season": 3,
+            "episode": 5,
+            "ids": {"tvdb": "111007"},
+            "show_ids": {"tmdb": "5000", "tvdb": "6000"},
+            "title": "WVL S03E07",
+        },
+    }
+
+
+def test_show_alias_rejected_when_target_coordinate_already_watched(monkeypatch):
+    import sync.simkl._history as m
+
+    _set_source_aliases(monkeypatch, m, _wvl_aliases())
+
+    show_row = {
+        "show": {"title": "Winter vol Liefde", "ids": {"tmdb": "5000", "tvdb": "6000", "simkl": 4242}},
+        "seasons": [
+            {
+                "number": 3,
+                "episodes": [
+                    {"number": 5, "watched_at": "2024-05-05T00:00:00Z", "ids": {"tvdb": "111005"}},
+                    {"number": 7, "watched_at": "2024-05-06T00:00:00Z", "ids": {"tvdb": "111007"}},
+                ],
+            }
+        ],
+    }
+
+    out, *_ = m._parse_rows([], [show_row], [], limit=None)
+    eps = [v for v in out.values() if str(v.get("type")) == "episode"]
+    coords = sorted((e["season"], e["episode"]) for e in eps)
+    assert coords == [(3, 5), (3, 7)]
+
+
+def test_show_alias_accepted_when_target_not_otherwise_watched(monkeypatch):
+    import sync.simkl._history as m
+
+    _set_source_aliases(monkeypatch, m, {"a7": _wvl_aliases()["a7"]})
+
+    show_row = {
+        "show": {"title": "Winter vol Liefde", "ids": {"tmdb": "5000", "tvdb": "6000", "simkl": 4242}},
+        "seasons": [
+            {
+                "number": 3,
+                "episodes": [
+                    {"number": 7, "watched_at": "2024-05-06T00:00:00Z", "ids": {"tvdb": "111007"}},
+                ],
+            }
+        ],
+    }
+
+    out, *_ = m._parse_rows([], [show_row], [], limit=None)
+    eps = [v for v in out.values() if str(v.get("type")) == "episode"]
+    assert len(eps) == 1
+    assert (eps[0]["season"], eps[0]["episode"]) == (3, 5)
+
+
+def test_unwatched_rows_do_not_block_alias_coordinates(monkeypatch):
+    import sync.simkl._history as m
+
+    _set_source_aliases(monkeypatch, m, {"a7": _wvl_aliases()["a7"]})
+
+    show_row = {
+        "show": {"title": "Winter vol Liefde", "ids": {"tmdb": "5000", "tvdb": "6000", "simkl": 4242}},
+        "seasons": [
+            {
+                "number": 3,
+                "episodes": [
+                    {"number": 5},
+                    {"number": 7, "watched_at": "2024-05-06T00:00:00Z", "ids": {"tvdb": "111007"}},
+                ],
+            }
+        ],
+    }
+
+    out, *_ = m._parse_rows([], [show_row], [], limit=None)
+    eps = [v for v in out.values() if str(v.get("type")) == "episode"]
+    assert len(eps) == 1
+    assert (eps[0]["season"], eps[0]["episode"]) == (3, 5)
+
+
+def test_collision_gate_not_applied_to_anime(monkeypatch):
+    import sync.simkl._history as m
+
+    _set_source_aliases(
+        monkeypatch,
+        m,
+        {
+            "k1": {
+                "season": 1,
+                "episode": 2,
+                "ids": {"tvdb": "4635717"},
+                "show_ids": {"tmdb": "1429", "tvdb": "267440"},
+                "title": "AOT Special 2",
+            }
+        },
+    )
+
+    anime_row = {
+        "show": {"title": "AoT OVA", "ids": {"simkl": 999999, "tvdb": "888888"}},
+        "seasons": [
+            {
+                "number": 1,
+                "episodes": [
+                    {"number": 2, "watched_at": "2024-05-05T00:00:00Z"},
+                    {"number": 3, "watched_at": "2024-05-06T00:00:00Z", "ids": {"tvdb": "4635717"}},
+                ],
+            }
+        ],
+    }
+
+    out, *_ = m._parse_rows([], [], [anime_row], limit=None)
+    eps = [v for v in out.values() if str(v.get("type")) == "episode"]
+    mapped = [e for e in eps if e["show_ids"].get("tvdb") == "267440"]
+    assert len(mapped) == 1
+    assert (mapped[0]["season"], mapped[0]["episode"]) == (1, 2)
+
+
+def test_show_no_abs_or_title_mapping_applied(monkeypatch):
+    import sync.simkl._history as m
+
+    _set_source_aliases(
+        monkeypatch,
+        m,
+        {
+            "k1": {
+                "season": 2,
+                "episode": 4,
+                "ids": {"tvdb": "5057304"},
+                "show_ids": {"tmdb": "42009", "tvdb": "253463"},
+                "title": "White Christmas",
+                "number_abs": 7,
+            }
+        },
+    )
+
+    show_row = {
+        "show": {"title": "Black Mirror", "ids": {"tmdb": "42009", "tvdb": "253463", "simkl": 12345}},
+        "seasons": [
+            {
+                "number": 1,
+                "episodes": [
+                    {"number": 7, "watched_at": "2024-05-05T00:00:00Z", "title": "White Christmas"}
+                ],
+            }
+        ],
+    }
+
+    out, *_ = m._parse_rows([], [show_row], [], limit=None)
+    eps = [v for v in out.values() if str(v.get("type")) == "episode"]
+    assert len(eps) == 1
+    assert (eps[0]["season"], eps[0]["episode"]) == (1, 7)
+

--- a/providers/tests/test_simkl_history_cold_state.py
+++ b/providers/tests/test_simkl_history_cold_state.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from cw_platform.id_map import canonical_key
+
+
+WATCHED = "2024-05-05T00:00:00Z"
+
+
+def _alias_store(monkeypatch, m):
+    """In-memory state FS; _write_json no-ops without a pair scope."""
+    store: dict[str, str] = {}
+    monkeypatch.setattr(m, "_source_alias_path", lambda: "simkl_history.source_alias.json")
+    monkeypatch.setattr(m, "_load_json", lambda path: json.loads(store.get(path) or "{}"))
+    monkeypatch.setattr(m, "_save_json", lambda path, data: store.__setitem__(path, json.dumps(data)))
+    return store
+
+
+def _src_episode(*, show_ids, season, episode, ep_tvdb=None, title=None, series_title=None, number_abs=None):
+    item = {
+        "type": "episode",
+        "season": season,
+        "episode": episode,
+        "watched": True,
+        "watched_at": WATCHED,
+        "ids": {"tvdb": str(ep_tvdb)} if ep_tvdb else {},
+        "show_ids": dict(show_ids),
+        "title": title,
+        "series_title": series_title,
+    }
+    if number_abs is not None:
+        item["_trakt_number_abs"] = number_abs
+    return item
+
+
+def _monsters_source():
+    return [
+        _src_episode(
+            show_ids={"tmdb": "225634"},
+            season=1,
+            episode=n,
+            ep_tvdb=10649168 + n,
+            title=f"Monsters S01E{n:02d}",
+            series_title="Monsters",
+        )
+        for n in range(1, 10)
+    ]
+
+
+def _black_mirror_source():
+    return [
+        _src_episode(
+            show_ids={"tmdb": "42009", "tvdb": "253463"},
+            season=2,
+            episode=4,
+            ep_tvdb=5057304,
+            title="White Christmas",
+            series_title="Black Mirror",
+        )
+    ]
+
+
+def _dbz_source():
+    coords = {41: (2, 2), 43: (2, 4), 255: (8, 12), 257: (8, 14)}
+    return [
+        _src_episode(
+            show_ids={"tmdb": "12971", "tvdb": "81472"},
+            season=s,
+            episode=e,
+            title=f"DBZ abs {abs_num}",
+            series_title="Dragon Ball Z",
+            number_abs=abs_num,
+        )
+        for abs_num, (s, e) in coords.items()
+    ]
+
+
+def _aot_source():
+    return [
+        _src_episode(
+            show_ids={"tmdb": "1429", "tvdb": "267440"},
+            season=0,
+            episode=1,
+            ep_tvdb=4635717,
+            title="AOT Special 1",
+            series_title="Attack on Titan",
+        )
+    ]
+
+
+def _cold_source_snapshot():
+    items = _monsters_source() + _black_mirror_source() + _dbz_source() + _aot_source()
+    return {canonical_key(it): it for it in items}
+
+
+def _simkl_rows():
+    monsters_row = {
+        "show": {"title": "Monster", "ids": {"tmdb": "113988", "simkl": 5150}},
+        "seasons": [
+            {
+                "number": 2,
+                "episodes": [
+                    {"number": n, "watched_at": WATCHED, "ids": {"tvdb": str(10649168 + n)}}
+                    for n in range(1, 10)
+                ],
+            }
+        ],
+    }
+    black_mirror_row = {
+        "show": {"title": "Black Mirror", "year": 2011, "ids": {"tmdb": "42009", "tvdb": "253463", "simkl": 12345}},
+        "seasons": [
+            {"number": 0, "episodes": [{"number": 1, "watched_at": WATCHED, "ids": {"tvdb": "5057304"}}]}
+        ],
+    }
+    dbz_row = {
+        "show": {"title": "Dragon Ball Z", "ids": {"simkl": 41487, "tvdb": "81472", "tmdb": "12971"}},
+        "seasons": [
+            {
+                "number": 1,
+                "episodes": [
+                    {"number": 41, "watched_at": WATCHED},
+                    {"number": 43, "watched_at": WATCHED},
+                    {"number": 255, "watched_at": WATCHED},
+                    {"number": 257, "watched_at": WATCHED},
+                ],
+            }
+        ],
+    }
+    aot_row = {
+        "show": {"title": "AoT OVA", "ids": {"simkl": 999999, "tvdb": "888888"}},
+        "seasons": [
+            {"number": 1, "episodes": [{"number": 1, "watched_at": WATCHED, "ids": {"tvdb": "4635717"}}]}
+        ],
+    }
+    return [monsters_row, black_mirror_row], [dbz_row, aot_row]
+
+
+def _parse_cold(m):
+    show_rows, anime_rows = _simkl_rows()
+    out, *_ = m._parse_rows([], show_rows, anime_rows, limit=None)
+    return out
+
+
+def test_cold_state_alias_file_starts_empty(monkeypatch):
+    import sync.simkl._history as m
+
+    store = _alias_store(monkeypatch, m)
+    assert store == {}
+    assert m._load_source_aliases() == {}
+
+    produced = m.prepare_source_snapshot(list(_cold_source_snapshot().values()))
+
+    assert produced == 15
+    stored = json.loads(store["simkl_history.source_alias.json"])["items"]
+    assert len(stored) == 15
+
+
+def test_cold_state_prepare_reproduces_aliases_without_writes(monkeypatch):
+    import sync.simkl._history as m
+
+    _alias_store(monkeypatch, m)
+    posts: list = []
+    monkeypatch.setattr(
+        m,
+        "_post",
+        lambda *a, **k: posts.append(a) or SimpleNamespace(status_code=200, text="{}", json=lambda: {}),
+        raising=False,
+    )
+
+    m.prepare_source_snapshot(list(_cold_source_snapshot().values()))
+
+    assert posts == []
+    recs = m._load_source_aliases()
+    by_ep_tvdb = {r["ids"].get("tvdb"): r for r in recs.values() if r.get("ids")}
+    assert by_ep_tvdb["5057304"]["season"] == 2
+    assert by_ep_tvdb["5057304"]["episode"] == 4
+    assert by_ep_tvdb["10649169"]["show_ids"] == {"tmdb": "225634"}
+    abs_recs = sorted(r["number_abs"] for r in recs.values() if r.get("number_abs"))
+    assert abs_recs == [41, 43, 255, 257]
+
+
+def test_cold_state_monsters_anthology_normalizes_to_source(monkeypatch):
+    import sync.simkl._history as m
+
+    _alias_store(monkeypatch, m)
+    m.prepare_source_snapshot(list(_cold_source_snapshot().values()))
+
+    out = _parse_cold(m)
+    monsters = [v for v in out.values() if v.get("series_title") == "Monsters"]
+
+    assert len(monsters) == 9
+    assert sorted((e["season"], e["episode"]) for e in monsters) == [(1, n) for n in range(1, 10)]
+    assert all(e["show_ids"] == {"tmdb": "225634"} for e in monsters)
+
+
+def test_cold_state_black_mirror_normalizes_to_s02e04(monkeypatch):
+    import sync.simkl._history as m
+
+    _alias_store(monkeypatch, m)
+    m.prepare_source_snapshot(list(_cold_source_snapshot().values()))
+
+    out = _parse_cold(m)
+    bm = [v for v in out.values() if v.get("series_title") == "Black Mirror"]
+
+    assert len(bm) == 1
+    assert (bm[0]["season"], bm[0]["episode"]) == (2, 4)
+
+
+def test_cold_state_dbz_native_numbers_normalize_to_source(monkeypatch):
+    import sync.simkl._history as m
+
+    _alias_store(monkeypatch, m)
+    m.prepare_source_snapshot(list(_cold_source_snapshot().values()))
+
+    out = _parse_cold(m)
+    dbz = [v for v in out.values() if v.get("series_title") == "Dragon Ball Z"]
+
+    assert sorted((e["season"], e["episode"]) for e in dbz) == [(2, 2), (2, 4), (8, 12), (8, 14)]
+
+
+def test_cold_state_first_planner_run_produces_zero_adds(monkeypatch):
+    import sync.simkl._history as m
+
+    _alias_store(monkeypatch, m)
+    source = _cold_source_snapshot()
+    assert len(source) == 15
+
+    m.prepare_source_snapshot(list(source.values()))
+    dest = {canonical_key(v): v for v in _parse_cold(m).values()}
+
+    adds = [k for k in source if k not in dest]
+    assert adds == []
+
+
+def test_cold_state_without_prepare_would_add_everything(monkeypatch):
+    import sync.simkl._history as m
+
+    _alias_store(monkeypatch, m)
+    source = _cold_source_snapshot()
+    dest = {canonical_key(v): v for v in _parse_cold(m).values()}
+
+    adds = [k for k in source if k not in dest]
+    assert len(adds) == 15
+
+
+def test_cold_state_unmapped_anime_s00_remains_unresolved(monkeypatch):
+    import sync.simkl._history as m
+    from test_simkl_history_anime_mapping import _Resp, _Session, _adapter, _ok_add, _patch_fs
+
+    _patch_fs(monkeypatch, m)
+    _alias_store(monkeypatch, m)
+    m.prepare_source_snapshot(list(_cold_source_snapshot().values()))
+
+    specials = [
+        {
+            "type": "episode",
+            "season": 0,
+            "episode": n,
+            "watched_at": WATCHED,
+            "ids": {},
+            "show_ids": {"tvdb": "267440", "tmdb": "1429", "anidb": "9541"},
+            "series_title": "Attack on Titan",
+        }
+        for n in range(2, 7)
+    ]
+
+    session = _Session(
+        post_handler=lambda url, body: _Resp(200, _ok_add(episodes=0)),
+        redirect_map={"267440": "39687"},
+    )
+    ok, unresolved = m.add(_adapter(session), specials)
+
+    assert ok == 0
+    assert len(unresolved) == 5
+    assert all(u.get("hint") == "simkl_anime_season_zero_unmapped" for u in unresolved)
+
+
+def test_exact_ids_read_top_level_and_nested_shapes():
+    import sync.simkl._history as m
+
+    assert m._episode_exact_ids({"ids": {"tvdb": "5057304"}}) == {"tvdb": "5057304"}
+    assert m._episode_exact_ids({"ids": {"tvdb_id": 5057304}}) == {"tvdb": "5057304"}
+    assert m._episode_exact_ids({"tvdb_id": 5057304}) == {"tvdb": "5057304"}
+    assert m._episode_exact_ids({"tvdb": 5057304}) == {"tvdb": "5057304"}
+    assert m._episode_exact_ids({"anidb_id": 999}) == {"anidb": "999"}
+    assert m._episode_exact_ids({"tvdb": {"season": 5, "episode": 9}}) == {}
+    assert m._episode_exact_ids({"number": 1, "watched_at": WATCHED}) == {}
+
+
+def test_top_level_episode_tvdb_id_normalizes_show_row(monkeypatch):
+    import sync.simkl._history as m
+
+    _alias_store(monkeypatch, m)
+    m.prepare_source_snapshot(_black_mirror_source())
+
+    show_row = {
+        "show": {"title": "Black Mirror", "ids": {"tmdb": "42009", "tvdb": "253463", "simkl": 12345}},
+        "seasons": [
+            {"number": 0, "episodes": [{"number": 1, "watched_at": WATCHED, "tvdb_id": 5057304}]}
+        ],
+    }
+
+    out, *_ = m._parse_rows([], [show_row], [], limit=None)
+    eps = [v for v in out.values() if str(v.get("type")) == "episode"]
+
+    assert len(eps) == 1
+    assert (eps[0]["season"], eps[0]["episode"]) == (2, 4)
+
+
+def test_cross_show_alias_not_blocked_by_same_coordinate_in_other_show(monkeypatch):
+    import sync.simkl._history as m
+
+    _alias_store(monkeypatch, m)
+    m.prepare_source_snapshot(_monsters_source())
+
+    show_row = {
+        "show": {"title": "Monster", "ids": {"tmdb": "113988", "simkl": 5150}},
+        "seasons": [
+            {
+                "number": 1,
+                "episodes": [
+                    {"number": n, "watched_at": WATCHED, "ids": {"tvdb": str(90000 + n)}}
+                    for n in range(1, 10)
+                ],
+            },
+            {
+                "number": 2,
+                "episodes": [
+                    {"number": n, "watched_at": WATCHED, "ids": {"tvdb": str(10649168 + n)}}
+                    for n in range(1, 10)
+                ],
+            },
+        ],
+    }
+
+    out, *_ = m._parse_rows([], [show_row], [], limit=None)
+    mapped = [v for v in out.values() if v.get("show_ids") == {"tmdb": "225634"}]
+    native = [v for v in out.values() if v.get("show_ids") == {"tmdb": "113988", "simkl": "5150"}]
+
+    assert len(mapped) == 9
+    assert sorted((e["season"], e["episode"]) for e in mapped) == [(1, n) for n in range(1, 10)]
+    assert len(native) == 9
+    assert sorted((e["season"], e["episode"]) for e in native) == [(1, n) for n in range(1, 10)]
+    assert len({canonical_key(v) for v in out.values()}) == 18
+
+
+def test_cold_state_preserves_winter_vol_liefde_collision_protection(monkeypatch):
+    import sync.simkl._history as m
+
+    _alias_store(monkeypatch, m)
+    source = [
+        _src_episode(show_ids={"tmdb": "5000", "tvdb": "6000"}, season=3, episode=5, ep_tvdb=111005, title="WVL 5"),
+        _src_episode(show_ids={"tmdb": "5000", "tvdb": "6000"}, season=3, episode=5, ep_tvdb=111007, title="WVL 7"),
+    ]
+    m.prepare_source_snapshot(source)
+
+    show_row = {
+        "show": {"title": "Winter vol Liefde", "ids": {"tmdb": "5000", "tvdb": "6000", "simkl": 4242}},
+        "seasons": [
+            {
+                "number": 3,
+                "episodes": [
+                    {"number": 5, "watched_at": WATCHED, "ids": {"tvdb": "111005"}},
+                    {"number": 7, "watched_at": WATCHED, "ids": {"tvdb": "111007"}},
+                ],
+            }
+        ],
+    }
+
+    out, *_ = m._parse_rows([], [show_row], [], limit=None)
+    eps = [v for v in out.values() if str(v.get("type")) == "episode"]
+
+    assert sorted((e["season"], e["episode"]) for e in eps) == [(3, 5), (3, 7)]

--- a/providers/tests/test_simkl_history_delta_merge.py
+++ b/providers/tests/test_simkl_history_delta_merge.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+
+AOT_SHOW_IDS = {"tmdb": "1429", "tvdb": "267440", "simkl": 1429000}
+OLD_WATCHED = "2024-01-01T00:00:00Z"
+NEW_WATCHED = "2024-06-01T00:00:00Z"
+
+
+def _state_store(monkeypatch, m):
+    store: dict[str, str] = {}
+    monkeypatch.setattr(m, "state_file", lambda name: name)
+    monkeypatch.setattr(m, "_load_json", lambda path: json.loads(store.get(path) or "{}"))
+    monkeypatch.setattr(m, "_save_json", lambda path, data: store.__setitem__(path, json.dumps(data)))
+    return store
+
+
+def _aot_row(coords, watched_at=OLD_WATCHED):
+    seasons: dict[int, list[dict]] = {}
+    for s, e in coords:
+        seasons.setdefault(s, []).append({"number": e, "watched_at": watched_at})
+    return {
+        "show": {"title": "Attack on Titan", "year": 2013, "ids": dict(AOT_SHOW_IDS)},
+        "seasons": [{"number": s, "episodes": eps} for s, eps in sorted(seasons.items())],
+    }
+
+
+def _coords_of(index):
+    return sorted(
+        (v["season"], v["episode"])
+        for v in index.values()
+        if str(v.get("type")) == "episode" and v.get("series_title") == "Attack on Titan"
+    )
+
+
+def _patch_index_env(monkeypatch, m, *, watermark, removed_watermark, acts, rows):
+    monkeypatch.setattr(m, "normalize_flat_watermarks", lambda: None)
+    monkeypatch.setattr(
+        m,
+        "get_watermark",
+        lambda kind: removed_watermark if kind == "history_removed" else watermark,
+    )
+    monkeypatch.setattr(m, "update_watermark_if_new", lambda *a, **k: None)
+    monkeypatch.setattr(m, "fetch_activities", lambda *a, **k: (acts, None))
+    monkeypatch.setattr(m, "_headers", lambda *a, **k: {})
+    monkeypatch.setattr(m, "_unfreeze", lambda *a, **k: None)
+    monkeypatch.setattr(m, "_fetch_all_items", lambda *a, **k: dict(rows))
+    return SimpleNamespace(client=SimpleNamespace(session=object()), cfg=SimpleNamespace(timeout=5))
+
+
+def _acts(watched_iso, removed_iso=None):
+    out = {"tv_shows": {"all": watched_iso}}
+    if removed_iso:
+        out["tv_shows"]["removed_from_list"] = removed_iso
+    return out
+
+
+def _seed_cache(m, coords, watched_at=OLD_WATCHED):
+    seed, *_ = m._parse_rows([], [_aot_row(coords, watched_at)], [], limit=None)
+    m._cache_save(seed)
+    return seed
+
+
+def test_delta_merges_without_evicting_untouched_episodes(monkeypatch):
+    import sync.simkl._history as m
+
+    _state_store(monkeypatch, m)
+    seeded = [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 5), (4, 28)]
+    seed = _seed_cache(m, seeded)
+    assert len(seed) == len(seeded)
+
+    stale_key = next(k for k, v in seed.items() if (v["season"], v["episode"]) == (4, 28))
+    stale = m._cache_load()
+    stale[stale_key]["series_title"] = "STALE"
+    m._cache_save(stale)
+
+    delta_rows = {
+        "movies": [],
+        "shows": [_aot_row([(4, 28)], OLD_WATCHED), _aot_row([(4, 29)], NEW_WATCHED)],
+        "anime": [],
+    }
+    adapter = _patch_index_env(
+        monkeypatch,
+        m,
+        watermark=OLD_WATCHED,
+        removed_watermark="",
+        acts=_acts(NEW_WATCHED),
+        rows=delta_rows,
+    )
+
+    out = m.build_index(adapter)
+
+    assert _coords_of(out) == sorted(seeded + [(4, 29)])
+    assert set(seed) <= set(out)
+    assert out[stale_key]["series_title"] == "Attack on Titan"
+    assert len(out) == len(seed) + 1
+    assert m._cache_load().keys() == out.keys()
+
+
+def test_removal_refresh_replaces_cache_and_prunes(monkeypatch):
+    import sync.simkl._history as m
+
+    _state_store(monkeypatch, m)
+    seed = _seed_cache(m, [(1, 1), (1, 2), (2, 1), (4, 28)])
+
+    surviving = {"movies": [], "shows": [_aot_row([(1, 1), (1, 2)])], "anime": []}
+    adapter = _patch_index_env(
+        monkeypatch,
+        m,
+        watermark=OLD_WATCHED,
+        removed_watermark=OLD_WATCHED,
+        acts=_acts(NEW_WATCHED, removed_iso=NEW_WATCHED),
+        rows=surviving,
+    )
+
+    out = m.build_index(adapter)
+
+    assert _coords_of(out) == [(1, 1), (1, 2)]
+    assert len(out) == 2
+    assert set(out) < set(seed)
+    assert m._cache_load().keys() == out.keys()
+
+
+def test_injected_historical_episode_survives_later_delta(monkeypatch):
+    import sync.simkl._history as m
+
+    _state_store(monkeypatch, m)
+    _seed_cache(m, [(1, 1), (1, 2)])
+
+    historical = {
+        "type": "episode",
+        "season": 3,
+        "episode": 7,
+        "watched_at": "2019-03-03T00:00:00Z",
+        "ids": {},
+        "show_ids": {k: str(v) for k, v in AOT_SHOW_IDS.items()},
+        "series_title": "Attack on Titan",
+    }
+    m._inject_adds_into_cache([historical])
+    injected_key = next(k for k, v in m._cache_load().items() if (v.get("season"), v.get("episode")) == (3, 7))
+
+    delta_rows = {"movies": [], "shows": [_aot_row([(1, 3)], NEW_WATCHED)], "anime": []}
+    adapter = _patch_index_env(
+        monkeypatch,
+        m,
+        watermark=OLD_WATCHED,
+        removed_watermark="",
+        acts=_acts(NEW_WATCHED),
+        rows=delta_rows,
+    )
+
+    out = m.build_index(adapter)
+
+    assert injected_key in out
+    assert injected_key in m._cache_load()
+    assert _coords_of(out) == [(1, 1), (1, 2), (1, 3), (3, 7)]

--- a/providers/tests/test_simkl_history_remove_verify.py
+++ b/providers/tests/test_simkl_history_remove_verify.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from cw_platform.id_map import canonical_key, minimal
+
+from test_simkl_history_anime_mapping import _Resp, _Session, _adapter, _patch_fs
+
+
+WATCHED = "2024-01-01T00:00:00Z"
+RECORD_A = 39687
+RECORD_B = 1579947
+
+
+def _anime_row(record, tvdb_season, numbers, *, title="Attack on Titan"):
+    return {
+        "show": {"title": title, "ids": {"simkl": record, "tvdb": "267440", "tmdb": "1429"}, "anime_type": "tv"},
+        "seasons": [
+            {
+                "number": 1,
+                "episodes": [
+                    {"number": n, "watched_at": WATCHED, "tvdb": {"season": tvdb_season, "episode": n}}
+                    for n in numbers
+                ],
+            }
+        ],
+    }
+
+
+def _aot_rows(a_numbers, b_numbers):
+    rows = []
+    if a_numbers:
+        rows.append(_anime_row(RECORD_A, 1, a_numbers))
+    if b_numbers:
+        rows.append(_anime_row(RECORD_B, 4, b_numbers))
+    return rows
+
+
+def _payload(anime_rows=None, show_rows=None, movie_rows=None):
+    return {"movies": movie_rows or [], "shows": show_rows or [], "anime": anime_rows or []}
+
+
+def _parsed(m, anime_rows=None, show_rows=None, movie_rows=None):
+    out, *_ = m._parse_rows(movie_rows or [], show_rows or [], anime_rows or [], limit=None)
+    return out
+
+
+def _no_sleep(monkeypatch, m):
+    monkeypatch.setattr(m.time, "sleep", lambda *_a, **_k: None)
+
+
+def test_split_records_preserve_native_identity(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    parsed = _parsed(m, _aot_rows([1, 2], [17]))
+    eps = list(parsed.values())
+
+    assert len(eps) == 3
+    by_coord = {(e["season"], e["episode"]): e for e in eps}
+    assert set(by_coord) == {(1, 1), (1, 2), (4, 17)}
+    assert by_coord[(1, 1)]["show_ids"]["simkl"] == str(RECORD_A)
+    assert by_coord[(1, 1)]["_simkl_episode_number"] == 1
+    assert by_coord[(4, 17)]["show_ids"]["simkl"] == str(RECORD_B)
+    assert by_coord[(4, 17)]["_simkl_episode_number"] == 17
+    assert all(e["simkl_bucket"] == "anime" for e in eps)
+    assert all(e["show_ids"]["tvdb"] == "267440" for e in eps)
+
+    trakt_like = {"type": "episode", "show_ids": {"tvdb": "267440", "tmdb": "1429"}, "season": 4, "episode": 17}
+    assert canonical_key(by_coord[(4, 17)]) == canonical_key(trakt_like)
+
+
+def test_minimal_preserves_native_identity_without_changing_key():
+    import sync.simkl._history as m
+
+    item = {
+        "type": "episode",
+        "season": 4,
+        "episode": 17,
+        "show_ids": {"tvdb": "267440", "tmdb": "1429", "simkl": "1579947"},
+        "simkl_bucket": "anime",
+        "anime_type": "tv",
+        "_simkl_episode_number": 17,
+    }
+    out = minimal(item)
+
+    assert out["simkl_bucket"] == "anime"
+    assert out["anime_type"] == "tv"
+    assert out["_simkl_episode_number"] == 17
+    assert out["show_ids"]["simkl"] == "1579947"
+    assert canonical_key(out) == canonical_key(item)
+    assert m._thaw_key(out) == m._thaw_key(item)
+
+
+def test_verified_absence_confirms_removal(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    _no_sleep(monkeypatch, m)
+    items = list(_parsed(m, _aot_rows([1, 2], [17])).values())
+    session = _Session(
+        post_handler=lambda url, body: _Resp(200, {"deleted": {"episodes": 3}}),
+        all_items=_payload(),
+    )
+    adapter = _adapter(session)
+
+    ok, unresolved = m.remove(adapter, items)
+
+    assert ok == 3
+    assert unresolved == []
+    assert len(getattr(adapter, "_simkl_history_remove_confirmed_keys")) == 3
+    assert getattr(adapter, "_simkl_history_remove_skipped_keys") == []
+
+
+def test_http_ok_but_item_still_present_is_not_confirmed(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    _no_sleep(monkeypatch, m)
+    rows = _aot_rows([1], [])
+    items = list(_parsed(m, rows).values())
+    forgotten: list = []
+    monkeypatch.setattr(m, "_forget_source_aliases", lambda its: forgotten.extend(its))
+    session = _Session(
+        post_handler=lambda url, body: _Resp(200, {"deleted": {"episodes": 1}}),
+        all_items=_payload(anime_rows=rows),
+    )
+    adapter = _adapter(session)
+
+    ok, unresolved = m.remove(adapter, items)
+
+    assert ok == 0
+    assert [u["hint"] for u in unresolved] == ["simkl_remove_not_confirmed"]
+    assert getattr(adapter, "_simkl_history_remove_confirmed_keys") == []
+    assert forgotten == []
+
+
+def test_verification_failure_confirms_nothing(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    _no_sleep(monkeypatch, m)
+    items = list(_parsed(m, _aot_rows([1, 2], [])).values())
+    saved: list = []
+    monkeypatch.setattr(m, "_cache_save", lambda payload: saved.append(payload))
+    forgotten: list = []
+    monkeypatch.setattr(m, "_forget_source_aliases", lambda its: forgotten.extend(its))
+
+    class _Dead(_Session):
+        def get(self, url, headers=None, params=None, timeout=None, allow_redirects=None):
+            import sync.simkl._history as mod
+            if url == mod.URL_ALL_ITEMS:
+                return _Resp(503, {})
+            return super().get(url, headers=headers, params=params, timeout=timeout, allow_redirects=allow_redirects)
+
+    session = _Dead(post_handler=lambda url, body: _Resp(200, {"deleted": {"episodes": 2}}))
+    adapter = _adapter(session)
+
+    ok, unresolved = m.remove(adapter, items)
+
+    assert ok == 0
+    assert [u["hint"] for u in unresolved] == ["simkl_remove_verification_failed"] * 2
+    assert getattr(adapter, "_simkl_history_remove_confirmed_keys") == []
+    assert saved == []
+    assert forgotten == []
+
+
+def test_partial_removal_confirms_only_absent_items(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    _no_sleep(monkeypatch, m)
+    a_numbers = list(range(1, 51))
+    b_numbers = list(range(1, 38))
+    items = list(_parsed(m, _aot_rows(a_numbers, b_numbers)).values())
+    assert len(items) == 87
+
+    remaining_rows = _aot_rows(a_numbers[25:], b_numbers)
+    session = _Session(
+        post_handler=lambda url, body: _Resp(200, {"deleted": {"episodes": 87}}),
+        all_items=_payload(anime_rows=remaining_rows),
+    )
+    adapter = _adapter(session)
+
+    ok, unresolved = m.remove(adapter, items)
+
+    assert ok == 25
+    assert len(unresolved) == 62
+    assert {u["hint"] for u in unresolved} == {"simkl_remove_not_confirmed"}
+
+    confirmed = set(getattr(adapter, "_simkl_history_remove_confirmed_keys"))
+    expected = {m._thaw_key(it) for it in items[:25]}
+    assert confirmed == expected
+
+    cached = m._cache_load()
+    assert len(cached) == 62
+    assert not (confirmed & {k.split("@", 1)[0] for k in cached})
+
+
+def test_full_removal_confirms_every_item(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    _no_sleep(monkeypatch, m)
+    items = list(_parsed(m, _aot_rows(list(range(1, 51)), list(range(1, 38)))).values())
+    session = _Session(
+        post_handler=lambda url, body: _Resp(200, {"deleted": {"episodes": 87}}),
+        all_items=_payload(),
+    )
+    adapter = _adapter(session)
+
+    ok, unresolved = m.remove(adapter, items)
+
+    groups = {
+        grp["ids"]["simkl"]: len(grp["episodes"])
+        for p in session.posts
+        if p["url"] == m.URL_REMOVE
+        for grp in (p["json"].get("anime") or [])
+    }
+    assert groups == {str(RECORD_A): 50, str(RECORD_B): 37}
+    assert ok == 87
+    assert unresolved == []
+    assert m._cache_load() == {}
+
+
+def test_non_anime_removal_still_works(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    _no_sleep(monkeypatch, m)
+    show_rows = [
+        {
+            "show": {"title": "Breaking Bad", "ids": {"tvdb": "81189", "tmdb": "1396"}},
+            "seasons": [{"number": 3, "episodes": [{"number": 8, "watched_at": WATCHED}]}],
+        }
+    ]
+    movie_rows = [{"movie": {"title": "Heat", "year": 1995, "ids": {"tmdb": "949"}}, "last_watched_at": WATCHED}]
+    items = list(_parsed(m, show_rows=show_rows, movie_rows=movie_rows).values())
+    assert len(items) == 2
+
+    session = _Session(
+        post_handler=lambda url, body: _Resp(200, {"deleted": {"episodes": 1, "movies": 1}}),
+        all_items=_payload(),
+    )
+    adapter = _adapter(session)
+
+    ok, unresolved = m.remove(adapter, items)
+
+    body = next(p["json"] for p in session.posts if p["url"] == m.URL_REMOVE)
+    assert [mv["ids"]["tmdb"] for mv in body["movies"]] == ["949"]
+    assert body["shows"][0]["seasons"][0]["episodes"][0]["number"] == 8
+    assert "anime" not in body
+    assert ok == 2
+    assert unresolved == []
+
+
+def test_source_aliases_survive_a_shrinking_source_snapshot(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    full = [
+        {
+            "type": "episode",
+            "season": 1,
+            "episode": n,
+            "watched_at": WATCHED,
+            "ids": {"tvdb": str(700000 + n)},
+            "show_ids": {"tvdb": "267440", "tmdb": "1429"},
+            "title": f"AoT S01E{n:02d}",
+            "series_title": "Attack on Titan",
+        }
+        for n in range(1, 4)
+    ]
+    m.prepare_source_snapshot(full)
+    assert len(m._load_source_aliases()) == 3
+
+    m.prepare_source_snapshot(full[:1])
+
+    assert len(m._load_source_aliases()) == 3
+
+
+def test_confirmed_removal_forgets_only_its_own_aliases(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    items = [
+        {
+            "type": "episode",
+            "season": 1,
+            "episode": n,
+            "watched_at": WATCHED,
+            "ids": {"tvdb": str(700000 + n)},
+            "show_ids": {"tvdb": "267440", "tmdb": "1429"},
+            "title": f"AoT S01E{n:02d}",
+            "series_title": "Attack on Titan",
+        }
+        for n in range(1, 4)
+    ]
+    m.prepare_source_snapshot(items)
+    assert len(m._load_source_aliases()) == 3
+
+    m._forget_source_aliases(items[:2])
+
+    remaining = m._load_source_aliases()
+    assert list(remaining) == [m._thaw_key(items[2])]
+
+
+def test_module_remove_returns_exact_confirmed_keys(monkeypatch):
+    import sync.simkl._history as m
+    import sync._mod_SIMKL as mod
+
+    _patch_fs(monkeypatch, m)
+    _no_sleep(monkeypatch, m)
+    rows = _aot_rows([1, 2], [])
+    items = list(_parsed(m, rows).values())
+    session = _Session(
+        post_handler=lambda url, body: _Resp(200, {"deleted": {"episodes": 2}}),
+        all_items=_payload(anime_rows=_aot_rows([2], [])),
+    )
+
+    adapter = SimpleNamespace(
+        client=SimpleNamespace(session=session),
+        cfg=SimpleNamespace(timeout=5, history_chunk_size=100),
+        key_of=m._thaw_key,
+    )
+    res = mod.SIMKLModule.remove(adapter, "history", items)
+
+    assert res["count"] == 1
+    assert res["confirmed_keys"] == [m._thaw_key(items[0])]
+    assert len(res["confirmed_keys"]) == res["count"]
+    assert len(res["unresolved"]) == 1
+    assert m._thaw_key(items[1]) in res["skipped_keys"]

--- a/providers/tests/test_simkl_history_season_zero_strict.py
+++ b/providers/tests/test_simkl_history_season_zero_strict.py
@@ -1,0 +1,427 @@
+﻿from __future__ import annotations
+
+import json
+
+from test_simkl_history_anime_mapping import _Resp, _Session, _adapter, _ok_add, _anime_of, _shows_of
+
+
+AOT_REDIRECT = {"267440": "39687"}
+AOT_ROWS = {
+    "39687": [
+        {"episode": n, "title": f"aot{n}", "tvdb": {"season": 1, "episode": n}}
+        for n in range(1, 26)
+    ]
+}
+WATCHED = "2024-01-01T00:00:00Z"
+
+
+def _alias_store(monkeypatch, m, aliases=None):
+    store: dict[str, str] = {}
+    monkeypatch.setattr(m, "state_file", lambda name: name)
+    monkeypatch.setattr(m, "_load_json", lambda path: json.loads(store.get(path) or "{}"))
+    monkeypatch.setattr(m, "_save_json", lambda path, data: store.__setitem__(path, json.dumps(data)))
+    if aliases:
+        m._save_anime_episode_alias_cache(aliases)
+    return store
+
+
+def _patch_write_env(monkeypatch, m):
+    monkeypatch.setattr(m, "_headers", lambda *a, **k: {})
+    monkeypatch.setattr(m, "simkl_api_params_from_headers", lambda headers=None, **k: dict(k))
+    monkeypatch.setattr(m, "_unfreeze", lambda *a, **k: None)
+    monkeypatch.setattr(m, "_freeze", lambda *a, **k: None)
+    monkeypatch.setattr(m, "_load_anime_resolve_cache", lambda: m._AnimeResolveState({"267440": "39687"}, {}))
+    monkeypatch.setattr(m, "_save_anime_resolve_cache", lambda *a, **k: None)
+    injected: list = []
+    monkeypatch.setattr(m, "_inject_adds_into_cache", lambda items: injected.extend(items))
+    return injected
+
+
+def _aot_s00(episode, *, ep_tvdb=None, title=None, number_abs=None):
+    item = {
+        "type": "episode",
+        "season": 0,
+        "episode": episode,
+        "watched_at": WATCHED,
+        "show_ids": {"tvdb": "267440", "tmdb": "1429"},
+        "series_title": "Attack on Titan",
+        "title": title,
+    }
+    if ep_tvdb is not None:
+        item["ids"] = {"tvdb": str(ep_tvdb)}
+    if number_abs is not None:
+        item["_trakt_number_abs"] = number_abs
+    return item
+
+
+def _poisoned_alias():
+    return {
+        "39687:1": {
+            "season": 0,
+            "episode": 1,
+            "show_ids": {"tvdb": "267440", "tmdb": "1429"},
+            "title": "Ilse's Notebook",
+            "series_title": "Attack on Titan",
+        }
+    }
+
+
+def _alias_for(native, *, episode=1):
+    return {
+        f"39687:{native}": {
+            "season": 0,
+            "episode": episode,
+            "show_ids": {"tvdb": "267440", "tmdb": "1429"},
+            "title": "Ilse's Notebook",
+            "series_title": "Attack on Titan",
+        }
+    }
+
+
+def _resolve(m, monkeypatch, rows, item, *, aliases=None):
+    store = _alias_store(monkeypatch, m, aliases)
+    monkeypatch.setattr(m, "simkl_api_params_from_headers", lambda headers=None, **k: dict(k))
+    session = _Session(episodes_map={"39687": rows})
+    native = m._anime_retry_episode_number(
+        item,
+        {"simkl": "39687", "tvdb": "267440"},
+        session=session,
+        headers={},
+        timeout=5,
+        episode_cache={},
+        alias_cache=m._load_anime_episode_alias_cache(),
+    )
+    return native, m._load_anime_episode_alias_cache(), store
+
+
+def test_row_confirms_source_ignores_titles():
+    import sync.simkl._history as m
+
+    row = {"episode": 5, "title": "Ilse's Notebook", "ids": {}, "tvdb": {"season": None, "episode": None}}
+    item = _aot_s00(1, title="Ilse's Notebook")
+
+    assert m._anime_row_confirms_source(row, item, 0, 1) is False
+
+
+def test_title_only_alias_is_invalidated_then_resolved_by_unique_title(monkeypatch):
+    import sync.simkl._history as m
+
+    rows = [
+        {"episode": 5, "title": "Ilse's Notebook"},
+        {"episode": 9, "title": "aot9", "tvdb": {"season": 1, "episode": 9}},
+    ]
+    native, aliases, _ = _resolve(
+        m, monkeypatch, rows, _aot_s00(1, title="Ilse's Notebook"), aliases=_alias_for(5)
+    )
+
+    assert native == 5
+    assert aliases == {}
+
+
+def test_duplicate_titles_block_alias_and_unique_title_fallback(monkeypatch):
+    import sync.simkl._history as m
+
+    rows = [
+        {"episode": 5, "title": "Ilse's Notebook"},
+        {"episode": 6, "title": "ILSE'S  NOTEBOOK!"},
+    ]
+    native, aliases, _ = _resolve(
+        m, monkeypatch, rows, _aot_s00(1, title="Ilse's Notebook"), aliases=_alias_for(5)
+    )
+
+    assert native is None
+    assert aliases == {}
+
+
+def test_duplicate_titles_leave_season_zero_item_unresolved(monkeypatch):
+    import sync.simkl._history as m
+
+    _alias_store(monkeypatch, m, _alias_for(5))
+    injected = _patch_write_env(monkeypatch, m)
+    session = _Session(
+        post_handler=lambda url, body: _Resp(200, _ok_add(episodes=1)),
+        redirect_map=AOT_REDIRECT,
+        episodes_map={"39687": [
+            {"episode": 5, "title": "Ilse's Notebook"},
+            {"episode": 6, "title": "ILSE'S  NOTEBOOK!"},
+        ]},
+    )
+
+    ok, unresolved = m.add(_adapter(session), [_aot_s00(1, title="Ilse's Notebook")])
+
+    assert ok == 0
+    assert [u["hint"] for u in unresolved] == ["simkl_anime_season_zero_unmapped"]
+    assert list(_anime_of(session, m.URL_ADD)) == []
+    assert injected == []
+
+
+def test_alias_with_exact_tvdb_coordinates_is_kept(monkeypatch):
+    import sync.simkl._history as m
+
+    rows = [
+        {"episode": 26, "title": "unrelated", "tvdb": {"season": 0, "episode": 1}},
+        {"episode": 9, "title": "aot9", "tvdb": {"season": 1, "episode": 9}},
+    ]
+    native, aliases, _ = _resolve(m, monkeypatch, rows, _aot_s00(1), aliases=_alias_for(26))
+
+    assert native == 26
+    assert aliases.keys() == {"39687:26"}
+
+
+def test_alias_with_exact_episode_ids_is_kept(monkeypatch):
+    import sync.simkl._history as m
+
+    for field, value in (("tvdb", "4635717"), ("anidb", "9541")):
+        rows = [{"episode": 27, "title": "unrelated", "ids": {field: value}}]
+        item = _aot_s00(1)
+        item["ids"] = {field: value}
+        native, aliases, _ = _resolve(m, monkeypatch, rows, item, aliases=_alias_for(27))
+
+        assert native == 27
+        assert aliases.keys() == {"39687:27"}
+
+
+def _duplicate_native_rows():
+    return [
+        {"episode": 1, "title": "To You, 2000 Years in the Future", "tvdb": {"season": 1, "episode": 1}},
+        {"episode": 1, "title": "Since That Day", "tvdb": {"season": None, "episode": None}},
+    ]
+
+
+def test_unique_title_with_duplicate_native_number_is_rejected(monkeypatch):
+    import sync.simkl._history as m
+
+    rows = _duplicate_native_rows()
+    item = _aot_s00(1, title="Since That Day")
+
+    title_hits = [r for r in rows if m._title_match_key(r.get("title")) == m._title_match_key("Since That Day")]
+    assert len(title_hits) == 1
+
+    native, aliases, _ = _resolve(m, monkeypatch, rows, item)
+
+    assert native is None
+    assert aliases == {}
+
+
+def test_duplicate_native_number_leaves_item_unresolved(monkeypatch):
+    import sync.simkl._history as m
+
+    _alias_store(monkeypatch, m)
+    injected = _patch_write_env(monkeypatch, m)
+    session = _Session(
+        post_handler=lambda url, body: _Resp(200, _ok_add(episodes=1)),
+        redirect_map=AOT_REDIRECT,
+        episodes_map={"39687": _duplicate_native_rows()},
+    )
+    adapter = _adapter(session)
+
+    ok, unresolved = m.add(adapter, [_aot_s00(1, title="Since That Day")])
+
+    assert ok == 0
+    assert [u["hint"] for u in unresolved] == ["simkl_anime_season_zero_unmapped"]
+    assert list(_anime_of(session, m.URL_ADD)) == []
+    assert list(_shows_of(session, m.URL_ADD)) == []
+    assert session.posts == []
+    assert injected == []
+    assert getattr(adapter, "_simkl_history_add_confirmed_keys") == []
+    assert m._load_anime_episode_alias_cache() == {}
+
+
+def test_alias_to_duplicate_native_number_is_invalidated(monkeypatch):
+    import sync.simkl._history as m
+
+    native, aliases, _ = _resolve(
+        m,
+        monkeypatch,
+        _duplicate_native_rows(),
+        _aot_s00(1, title="Since That Day"),
+        aliases=_alias_for(1),
+    )
+
+    assert native is None
+    assert aliases == {}
+
+
+def test_exact_episode_id_with_duplicate_native_number_is_rejected(monkeypatch):
+    import sync.simkl._history as m
+
+    rows = [
+        {"episode": 1, "title": "To You, 2000 Years in the Future", "tvdb": {"season": 1, "episode": 1}},
+        {"episode": 1, "title": "Since That Day", "ids": {"tvdb": "4546796"}},
+    ]
+    item = _aot_s00(1, ep_tvdb=4546796)
+    native, _aliases, _ = _resolve(m, monkeypatch, rows, item)
+
+    assert native is None
+
+
+def test_unique_native_number_season_zero_row_is_accepted(monkeypatch):
+    import sync.simkl._history as m
+
+    rows = [
+        {"episode": 1, "title": "To You, 2000 Years in the Future", "tvdb": {"season": 1, "episode": 1}},
+        {"episode": 26, "title": "Since That Day", "tvdb": {"season": 0, "episode": 1}},
+    ]
+    native, _aliases, _ = _resolve(m, monkeypatch, rows, _aot_s00(1, title="Since That Day"))
+
+    assert native == 26
+
+
+def test_cache_schema_bumped_invalidates_legacy_documents(monkeypatch):
+    import sync.simkl._history as m
+
+    assert m._CACHE_SCHEMA == 4
+    store: dict[str, str] = {}
+    monkeypatch.setattr(m, "state_file", lambda name: name)
+    monkeypatch.setattr(m, "_load_json", lambda path: json.loads(store.get(path) or "{}"))
+    monkeypatch.setattr(m, "_save_json", lambda path, data: store.__setitem__(path, json.dumps(data)))
+    store[m._cache_path()] = json.dumps({"schema": 3, "items": {"poisoned@1": {"type": "episode", "season": 0, "episode": 1}}})
+
+    assert m._cache_doc_is_stale() is True
+    assert m._cache_load() == {}
+
+
+def test_conflicting_season_zero_alias_is_rejected_and_purged(monkeypatch):
+    import sync.simkl._history as m
+
+    _alias_store(monkeypatch, m, _poisoned_alias())
+    injected = _patch_write_env(monkeypatch, m)
+    session = _Session(
+        post_handler=lambda url, body: _Resp(200, _ok_add(episodes=1)),
+        redirect_map=AOT_REDIRECT,
+        episodes_map=AOT_ROWS,
+    )
+
+    ok, unresolved = m.add(_adapter(session), [_aot_s00(1, title="Ilse's Notebook")])
+
+    assert ok == 0
+    assert [u["hint"] for u in unresolved] == ["simkl_anime_season_zero_unmapped"]
+    assert list(_anime_of(session, m.URL_ADD)) == []
+    assert list(_shows_of(session, m.URL_ADD)) == []
+    assert injected == []
+    assert m._load_anime_episode_alias_cache() == {}
+
+
+def test_authoritative_season_zero_mapping_is_used(monkeypatch):
+    import sync.simkl._history as m
+
+    rows = {
+        "39687": AOT_ROWS["39687"] + [
+            {"episode": 26, "title": "Ilse's Notebook", "tvdb": {"season": 0, "episode": 1}}
+        ]
+    }
+    _alias_store(monkeypatch, m)
+    _patch_write_env(monkeypatch, m)
+    session = _Session(
+        post_handler=lambda url, body: _Resp(200, _ok_add(episodes=1)),
+        redirect_map=AOT_REDIRECT,
+        episodes_map=rows,
+    )
+
+    ok, unresolved = m.add(_adapter(session), [_aot_s00(1)])
+
+    numbers = [e["number"] for grp in _anime_of(session, m.URL_ADD) for e in grp["episodes"]]
+    assert numbers == [26]
+    assert ok == 1
+    assert unresolved == []
+
+
+def test_season_zero_episode_id_match_beats_absolute_number(monkeypatch):
+    import sync.simkl._history as m
+
+    rows = {
+        "39687": [
+            {"episode": 3, "title": "aot3", "tvdb": {"season": 1, "episode": 3}},
+            {"episode": 27, "title": "OVA", "ids": {"tvdb": "4635717"}},
+        ]
+    }
+    _alias_store(monkeypatch, m)
+    _patch_write_env(monkeypatch, m)
+    session = _Session(
+        post_handler=lambda url, body: _Resp(200, _ok_add(episodes=1)),
+        redirect_map=AOT_REDIRECT,
+        episodes_map=rows,
+    )
+
+    ok, unresolved = m.add(_adapter(session), [_aot_s00(1, ep_tvdb=4635717, number_abs=3)])
+
+    numbers = [e["number"] for grp in _anime_of(session, m.URL_ADD) for e in grp["episodes"]]
+    assert numbers == [27]
+    assert ok == 1
+    assert unresolved == []
+
+
+def test_ok_response_does_not_confirm_unvalidated_season_zero(monkeypatch):
+    import sync.simkl._history as m
+
+    _alias_store(monkeypatch, m, _poisoned_alias())
+    injected = _patch_write_env(monkeypatch, m)
+    session = _Session(
+        post_handler=lambda url, body: _Resp(200, _ok_add(episodes=1, not_found=None)),
+        redirect_map=AOT_REDIRECT,
+        episodes_map=AOT_ROWS,
+    )
+    adapter = _adapter(session)
+
+    ok, unresolved = m.add(adapter, [_aot_s00(1, title="Ilse's Notebook"), _aot_s00(2), _aot_s00(3)])
+
+    assert session.posts == []
+    assert ok == 0
+    assert len(unresolved) == 3
+    assert all(u["hint"] == "simkl_anime_season_zero_unmapped" for u in unresolved)
+    assert getattr(adapter, "_simkl_history_add_confirmed_keys") == []
+    assert injected == []
+
+
+def test_season_zero_group_anchor_inference_disabled(monkeypatch):
+    import sync.simkl._history as m
+
+    rows = {
+        "39687": AOT_ROWS["39687"] + [
+            {"episode": 26, "title": "Ilse's Notebook", "tvdb": {"season": 0, "episode": 1}}
+        ]
+    }
+    _alias_store(monkeypatch, m)
+    monkeypatch.setattr(m, "_headers", lambda *a, **k: {})
+    monkeypatch.setattr(m, "simkl_api_params_from_headers", lambda headers=None, **k: dict(k))
+    session = _Session(episodes_map=rows)
+
+    mapped = m._anime_retry_episode_numbers_for_group(
+        [_aot_s00(1), _aot_s00(2), _aot_s00(3)],
+        {"simkl": "39687", "tvdb": "267440"},
+        session=session,
+        headers={},
+        timeout=5,
+        episode_cache={},
+    )
+
+    assert list(mapped.values()) == [26]
+
+
+def test_normal_anime_season_one_still_writes(monkeypatch):
+    import sync.simkl._history as m
+
+    _alias_store(monkeypatch, m)
+    _patch_write_env(monkeypatch, m)
+    session = _Session(
+        post_handler=lambda url, body: _Resp(200, _ok_add(episodes=1)),
+        redirect_map=AOT_REDIRECT,
+        episodes_map=AOT_ROWS,
+    )
+
+    item = {
+        "type": "episode",
+        "season": 1,
+        "episode": 1,
+        "watched_at": WATCHED,
+        "show_ids": {"tvdb": "267440", "tmdb": "1429"},
+        "series_title": "Attack on Titan",
+    }
+    ok, unresolved = m.add(_adapter(session), [item])
+
+    numbers = [e["number"] for grp in _anime_of(session, m.URL_ADD) for e in grp["episodes"]]
+    assert numbers == [1]
+    assert ok == 1
+    assert unresolved == []
+
+

--- a/providers/tests/test_simkl_playlists.py
+++ b/providers/tests/test_simkl_playlists.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+pl = importlib.import_module("providers.sync.simkl._playlists")
+mod = importlib.import_module("providers.sync._mod_SIMKL")
+
+
+class FakeResp:
+    def __init__(self, status: int, payload: Any = None):
+        self.status_code = status
+        self._payload = payload
+        self.text = "x" if payload is not None else ""
+        self.headers = {}
+        self.ok = 200 <= status < 300
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, responses: dict[tuple[str, str], Any] | None = None):
+        self.responses = responses or {}
+        self.calls: list[dict[str, Any]] = []
+
+    def get(self, url: str, **kw: Any) -> FakeResp:
+        self.calls.append({"method": "GET", "url": url, "params": kw.get("params")})
+        return FakeResp(200, self.responses.get(("GET", url), {}))
+
+    def post(self, url: str, **kw: Any) -> FakeResp:
+        self.calls.append({"method": "POST", "url": url, "json": kw.get("json"), "params": kw.get("params")})
+        return FakeResp(200, self.responses.get(("POST", url), {}))
+
+
+class FakeCfg:
+    api_key = "client"
+    access_token = "token"
+    timeout = 5
+    watchlist_batch_size = 100
+
+
+class FakeClient:
+    def __init__(self, session: FakeSession):
+        self.session = session
+
+
+class FakeAdapter:
+    def __init__(self, session: FakeSession):
+        self.cfg = FakeCfg()
+        self.client = FakeClient(session)
+        self.instance_id = "default"
+
+
+def _movie(tmdb: int = 1) -> dict[str, Any]:
+    return {"type": "movie", "title": "Movie", "ids": {"tmdb": tmdb}}
+
+
+def _show(tvdb: int = 2) -> dict[str, Any]:
+    return {"type": "show", "title": "Show", "ids": {"tvdb": tvdb}}
+
+
+def test_enumerates_fixed_status_bucket_endpoints():
+    resources = pl.list_resources(FakeAdapter(FakeSession()))
+    by_id = {r.id: r for r in resources}
+    assert list(by_id) == ["plantowatch", "watching", "hold", "dropped", "completed"]
+    assert by_id["plantowatch"].name == "Plan to Watch"
+    assert by_id["watching"].media_types == ("show", "anime")
+    assert by_id["completed"].can_add is True
+    assert by_id["completed"].can_remove is True
+    assert by_id["completed"].can_reorder is False
+    assert by_id["completed"].extra["endpoint_type"] == "status_bucket"
+    assert by_id["completed"].extra["destructive_remove"] is True
+    assert by_id["completed"].extra["custom_lists_supported"] is False
+
+
+def test_status_snapshot_reads_all_allowed_categories():
+    session = FakeSession(
+        {
+            ("GET", "https://api.simkl.com/sync/all-items/movies/completed"): {
+                "movies": [{"movie": {"title": "Dune", "year": 2021, "ids": {"tmdb": 438631, "simkl": 1}}}]
+            },
+            ("GET", "https://api.simkl.com/sync/all-items/shows/completed"): {
+                "shows": [{"show": {"title": "Severance", "year": 2022, "ids": {"tvdb": 371980, "simkl": 2}}}]
+            },
+            ("GET", "https://api.simkl.com/sync/all-items/anime/completed"): {
+                "anime": [{"anime": {"title": "Frieren", "year": 2023, "ids": {"mal": 52991, "simkl": 3}}}]
+            },
+            ("GET", "https://api.simkl.com/sync/activities"): {
+                "movies": {"completed": "2026-01-01T00:00:00Z"},
+                "shows": {"completed": "2026-01-02T00:00:00Z"},
+                "anime": {"completed": "2026-01-03T00:00:00Z"},
+            },
+        }
+    )
+
+    snap = pl.get_snapshot(FakeAdapter(session), "completed")
+
+    assert snap.resource.id == "completed"
+    assert len(snap.items) == 3
+    assert {c["url"] for c in session.calls if c["method"] == "GET"} >= {
+        "https://api.simkl.com/sync/all-items/movies/completed",
+        "https://api.simkl.com/sync/all-items/shows/completed",
+        "https://api.simkl.com/sync/all-items/anime/completed",
+    }
+    assert {it.item["simkl_bucket"] for it in snap.items} == {"movies", "shows", "anime"}
+    assert snap.checkpoint == "2026-01-03T00:00:00Z"
+
+
+def test_movies_are_blocked_for_watching_and_hold():
+    session = FakeSession()
+    res = pl.add(FakeAdapter(session), "watching", [_movie()])
+
+    assert res["count"] == 0
+    assert res["unresolved"][0]["hint"] == "unsupported_media_type"
+    assert not [c for c in session.calls if c["method"] == "POST"]
+
+
+def test_add_moves_item_to_selected_bucket():
+    session = FakeSession(
+        {
+            ("POST", "https://api.simkl.com/sync/add-to-list"): {
+                "added": {"shows": [{"ids": {"tvdb": 2}, "status": "dropped"}]}
+            }
+        }
+    )
+
+    res = pl.add(FakeAdapter(session), "dropped", [_show()])
+
+    assert res["count"] == 1
+    assert res["confirmed_keys"] == ["tvdb:2"]
+    call = next(c for c in session.calls if c["method"] == "POST")
+    assert call["url"] == "https://api.simkl.com/sync/add-to-list"
+    assert call["json"] == {"shows": [{"ids": {"tvdb": "2"}, "to": "dropped"}]}
+
+
+def test_server_rewritten_status_is_not_confirmed():
+    session = FakeSession(
+        {
+            ("POST", "https://api.simkl.com/sync/add-to-list"): {
+                "added": {"movies": [{"ids": {"tmdb": 1}, "status": "completed"}]}
+            }
+        }
+    )
+
+    res = pl.add(FakeAdapter(session), "dropped", [_movie()])
+
+    assert res["count"] == 0
+    assert res["confirmed_keys"] == []
+    assert res["unresolved"][0]["hint"] == "status_rewritten:completed"
+    assert res["unresolved"][0]["actual_status"] == "completed"
+
+
+def test_remove_uses_destructive_history_remove_warning():
+    session = FakeSession(
+        {
+            ("POST", "https://api.simkl.com/sync/history/remove"): {
+                "removed": {"movies": [{"ids": {"tmdb": 1}}]}
+            }
+        }
+    )
+
+    res = pl.remove(FakeAdapter(session), "completed", [_movie()])
+
+    assert res["count"] == 1
+    assert pl.SIMKL_REMOVE_WARNING in res["warnings"]
+    call = next(c for c in session.calls if c["method"] == "POST")
+    assert call["url"] == "https://api.simkl.com/sync/history/remove"
+    assert call["json"] == {"movies": [{"ids": {"tmdb": "1"}}]}
+
+
+def test_existing_watchlist_path_still_delegates_to_plan_to_watch(monkeypatch):
+    called: dict[str, Any] = {}
+
+    class FakeWatchlist:
+        @staticmethod
+        def add(adapter: Any, items: Any) -> tuple[int, list[Any]]:
+            called["items"] = list(items)
+            return 1, []
+
+    monkeypatch.setitem(mod._FEATURES, "watchlist", FakeWatchlist)
+    monkeypatch.setattr(mod, "feat_watchlist", FakeWatchlist)
+    adapter = mod.SIMKLModule.__new__(mod.SIMKLModule)
+    adapter.key_of = staticmethod(lambda item: "tmdb:1")
+
+    res = mod.SIMKLModule.add(adapter, "watchlist", [_movie()])
+
+    assert res["count"] == 1
+    assert called["items"][0]["ids"]["tmdb"] == 1

--- a/providers/tests/test_trakt_playlists.py
+++ b/providers/tests/test_trakt_playlists.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+
+pl = importlib.import_module("providers.sync.trakt._playlists")
+
+
+class FakeResp:
+    def __init__(self, status: int, payload: Any = None, headers: dict[str, str] | None = None):
+        self.status_code = status
+        self._payload = payload
+        self.headers = headers or {}
+        self.text = "x" if payload is not None else ""
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeCfg:
+    client_id = "cid"
+    access_token = "tok"
+    timeout = 15.0
+    max_retries = 1
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.headers: dict[str, str] = {}
+
+
+class FakeClient:
+    def __init__(self, settings: Any) -> None:
+        self.session = FakeSession()
+        self._settings = settings
+
+    def get(self, url: str, **kw: Any) -> FakeResp:
+        return FakeResp(200, self._settings)
+
+
+class FakeAdapter:
+    def __init__(self, settings: Any = None) -> None:
+        self.cfg = FakeCfg()
+        self.client = FakeClient(settings or {"limits": {"list": {"count": 30, "item_count": 100}}})
+        self.instance_id = "default"
+
+
+LIST_ROW = {"name": "Weekend", "ids": {"trakt": 123, "slug": "weekend"}}
+ITEM_ROWS = [
+    {"id": 9001, "rank": 1, "type": "movie", "movie": {"title": "Dune", "year": 2021, "ids": {"trakt": 1, "tmdb": 438631, "slug": "dune-2021"}}},
+    {"id": 9002, "rank": 2, "type": "show", "show": {"title": "Severance", "year": 2022, "ids": {"trakt": 2, "tmdb": 95396, "slug": "severance"}}},
+    {"id": 9003, "rank": 3, "type": "person", "person": {"name": "Nobody", "ids": {"trakt": 3}}},
+]
+
+
+def _router(monkeypatch, handlers):
+    captured: list[dict[str, Any]] = []
+
+    def fake_rwr(sess, method, url, **kw):
+        captured.append({"method": method, "url": url, "json": kw.get("json"), "params": kw.get("params")})
+        for (m, needle), resp in handlers.items():
+            if method == m and needle in url:
+                return resp() if callable(resp) else resp
+        return FakeResp(404, None)
+
+    monkeypatch.setattr(pl, "request_with_retries", fake_rwr)
+    pl._SETTINGS_MEMO = (0.0, None)
+    return captured
+
+
+def test_list_resources_and_normalization(monkeypatch):
+    _router(monkeypatch, {("GET", "/users/me/lists"): FakeResp(200, [LIST_ROW])})
+    ad = FakeAdapter()
+    res = pl.list_resources(ad)
+    by_id = {r.id: r for r in res}
+    watchlist = by_id[pl.WATCHLIST_ID]
+    assert watchlist.name == "Watchlist"
+    assert watchlist.can_add and watchlist.can_remove
+    assert watchlist.can_reorder is False
+    r = by_id["123"]
+    assert r.provider == "TRAKT"
+    assert r.id == "123"
+    assert r.name == "Weekend"
+    assert r.can_add and r.can_remove and r.can_reorder
+    assert r.is_smart is False
+
+
+def test_watchlist_snapshot_and_writes_delegate(monkeypatch):
+    monkeypatch.setattr(
+        pl.feat_watchlist,
+        "build_index",
+        lambda ad: {"tmdb:438631": {"type": "movie", "title": "Dune", "ids": {"tmdb": "438631"}}},
+    )
+    monkeypatch.setattr(pl.feat_watchlist, "add", lambda ad, items: (len(list(items)), []))
+    monkeypatch.setattr(pl.feat_watchlist, "remove", lambda ad, items: (len(list(items)), []))
+
+    snap = pl.get_snapshot(FakeAdapter(), pl.WATCHLIST_ID)
+    assert snap.resource.name == "Watchlist"
+    assert snap.ordered_keys() == ["tmdb:438631"]
+
+    item = {"type": "movie", "title": "Dune", "ids": {"tmdb": "438631"}}
+    add_res = pl.add(FakeAdapter(), pl.WATCHLIST_ID, [item])
+    rm_res = pl.remove(FakeAdapter(), pl.WATCHLIST_ID, [item])
+    assert add_res["count"] == 1 and add_res["confirmed_keys"] == ["tmdb:438631"]
+    assert rm_res["count"] == 1 and rm_res["confirmed_keys"] == ["tmdb:438631"]
+    assert pl.reorder(FakeAdapter(), pl.WATCHLIST_ID, ["tmdb:438631"])["unsupported"] is True
+
+
+def test_snapshot_drops_unsupported_and_maps_keys(monkeypatch):
+    def items_resp():
+        return FakeResp(200, ITEM_ROWS, headers={"X-Pagination-Page-Count": "1"})
+
+    _router(
+        monkeypatch,
+        {
+            ("GET", "/users/me/lists/123/items"): items_resp,
+            ("GET", "/users/me/lists"): FakeResp(200, [LIST_ROW]),
+        },
+    )
+    snap = pl.get_snapshot(FakeAdapter(), "123")
+    keys = snap.ordered_keys()
+    assert keys == ["tmdb:438631", "tmdb:95396"]
+    first = snap.items[0]
+    assert first.playlist_item_id == "9001"
+    assert first.position == 1
+
+
+def test_add_and_remove_mixed_media(monkeypatch):
+    captured = _router(
+        monkeypatch,
+        {
+            ("GET", "/users/me/lists/123/items"): FakeResp(200, [], headers={"X-Pagination-Page-Count": "1"}),
+            ("GET", "/users/me/lists"): FakeResp(200, [LIST_ROW]),
+            ("POST", "/items/remove"): FakeResp(200, {"deleted": {"movies": 1}}),
+            ("POST", "/users/me/lists/123/items"): FakeResp(200, {"added": {"movies": 1, "shows": 1}, "not_found": {}}),
+        },
+    )
+    items = [
+        {"type": "movie", "title": "Dune", "year": 2021, "ids": {"tmdb": "438631"}},
+        {"type": "show", "title": "Severance", "year": 2022, "ids": {"tmdb": "95396"}},
+    ]
+    add_res = pl.add(FakeAdapter(), "123", items)
+    assert add_res["ok"] is True
+    assert add_res["count"] == 2
+    assert set(add_res["confirmed_keys"]) == {"tmdb:438631", "tmdb:95396"}
+
+    rm_res = pl.remove(FakeAdapter(), "123", items[:1])
+    assert rm_res["count"] == 1
+    assert any("/items/remove" in c["url"] for c in captured)
+
+
+def test_reorder_uses_list_item_ids(monkeypatch):
+    captured = _router(
+        monkeypatch,
+        {
+            ("GET", "/users/me/lists/123/items"): FakeResp(200, ITEM_ROWS, headers={"X-Pagination-Page-Count": "1"}),
+            ("GET", "/users/me/lists"): FakeResp(200, [LIST_ROW]),
+            ("POST", "/items/reorder"): FakeResp(200, {"updated": 2}),
+        },
+    )
+    res = pl.reorder(FakeAdapter(), "123", ["tmdb:95396", "tmdb:438631"])
+    assert res["ok"] is True
+    reorder_call = next(c for c in captured if "/items/reorder" in c["url"])
+    assert reorder_call["json"] == {"rank": ["9002", "9001"]}
+
+
+def test_add_http_420_is_capacity_failure(monkeypatch):
+    _router(
+        monkeypatch,
+        {
+            ("GET", "/users/me/lists/123/items"): FakeResp(200, [], headers={"X-Pagination-Page-Count": "1"}),
+            ("GET", "/users/me/lists"): FakeResp(200, [LIST_ROW]),
+            ("POST", "/users/me/lists/123/items"): FakeResp(420, {}, headers={"X-Upgrade-URL": "https://trakt.tv/vip"}),
+        },
+    )
+    res = pl.add(FakeAdapter(), "123", [{"type": "movie", "title": "Dune", "ids": {"tmdb": "438631"}}])
+    assert res.get("capacity") == "list_item_count"
+    assert any(u.get("hint") == "trakt_limit" for u in res["unresolved"])
+
+
+def test_create_respects_list_count_limit(monkeypatch):
+    _router(monkeypatch, {("GET", "/users/me/lists"): FakeResp(200, [LIST_ROW])})
+    ad = FakeAdapter(settings={"limits": {"list": {"count": 1, "item_count": 100}}})
+    with pytest.raises(pl.TraktCapacityError):
+        pl.create(ad, "New List")

--- a/providers/tests/test_trakt_watchlist_limit.py
+++ b/providers/tests/test_trakt_watchlist_limit.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+_common = importlib.import_module("providers.sync.trakt._common")
+
+
+class FakeResp:
+    def __init__(self, status: int, payload: Any = None):
+        self.status_code = status
+        self._payload = payload
+        self.text = "x" if payload is not None else ""
+        self.headers: dict[str, str] = {}
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeCfg:
+    client_id = "cid"
+    access_token = "tok"
+    timeout = 15.0
+    max_retries = 1
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.headers: dict[str, str] = {}
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.session = FakeSession()
+
+
+class FakeAdapter:
+    def __init__(self) -> None:
+        self.cfg = FakeCfg()
+        self.client = FakeClient()
+
+
+def _patch_settings(monkeypatch, payload, status=200):
+    _common._SETTINGS_MEMO = (0.0, None)
+
+    def fake_rwr(sess, method, url, **kw):
+        return FakeResp(status, payload)
+
+    monkeypatch.setattr(_common, "request_with_retries", fake_rwr)
+
+
+def test_api_supplied_limit(monkeypatch):
+    _patch_settings(monkeypatch, {"user": {"vip": False}, "limits": {"watchlist": {"item_count": 400}}})
+    assert _common.resolve_watchlist_limit(FakeAdapter(), {}) == 400
+
+
+def test_config_override(monkeypatch):
+    _patch_settings(monkeypatch, {"user": {"vip": False}, "limits": {"watchlist": {"item_count": 400}}})
+    assert _common.resolve_watchlist_limit(FakeAdapter(), {"watchlist_limit": 42}) == 42
+
+
+def test_free_account_fallback(monkeypatch):
+    _patch_settings(monkeypatch, {"user": {"vip": False}, "limits": {}})
+    assert _common.resolve_watchlist_limit(FakeAdapter(), {}) == 250

--- a/tests/test_analyzer_attention_model.py
+++ b/tests/test_analyzer_attention_model.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import services.analyzer as A
+
+
+def _mismatch(provider, feature, key, targets, alias_keys, *, blocked=False):
+    return {
+        "provider": provider,
+        "feature": feature,
+        "key": key,
+        "targets": list(targets),
+        "alias_keys": list(alias_keys),
+        "blocked": blocked,
+    }
+
+
+def _record(provider, feature, key, alias_keys, *, reason="simkl_not_found:episodes"):
+    return {
+        "provider": provider,
+        "feature": feature,
+        "key": key,
+        "alias_keys": list(alias_keys),
+        "ids": {},
+        "item": {},
+        "reason": reason,
+    }
+
+
+def test_live_mismatch_only_one_row():
+    model = A._attention_model([_mismatch("TRAKT", "history", "tmdb:1", ["SIMKL"], ["tmdb:1"])], [])
+    assert model["counts"] == {"current_mismatch": 1, "pending_retry": 0, "blocked": 0, "total": 1}
+    row = model["rows"][0]
+    assert row["current_mismatch"] and not row["unresolved"] and not row["blocked"]
+
+
+def test_unresolved_only_one_pending_row():
+    model = A._attention_model([], [_record("SIMKL", "history", "tmdb:1", ["tmdb:1"])])
+    assert model["counts"]["pending_retry"] == 1
+    assert model["counts"]["current_mismatch"] == 0
+    row = model["rows"][0]
+    assert row["unresolved"] and not row["current_mismatch"]
+
+
+def test_same_item_in_both_is_one_row_with_both_states():
+    mismatch = [_mismatch("TRAKT", "history", "tmdb:1", ["SIMKL"], ["tmdb:1", "imdb:tt1"])]
+    records = [_record("SIMKL", "history", "tmdb:1", ["tmdb:1"])]
+    model = A._attention_model(mismatch, records)
+    assert model["counts"]["total"] == 1
+    row = model["rows"][0]
+    assert row["current_mismatch"] and row["unresolved"]
+    assert model["counts"]["current_mismatch"] == 1
+    assert model["counts"]["pending_retry"] == 1
+
+
+def test_pending_count_matches_full_unresolved_subset():
+    mismatch = [
+        _mismatch("TRAKT", "history", "tmdb:1", ["SIMKL"], ["tmdb:1"]),
+        _mismatch("TRAKT", "history", "tmdb:2", ["SIMKL"], ["tmdb:2"]),
+    ]
+    records = [
+        _record("SIMKL", "history", "tmdb:2", ["tmdb:2"]),
+        _record("SIMKL", "history", "tmdb:3", ["tmdb:3"]),
+    ]
+    model = A._attention_model(mismatch, records)
+    pending_rows = [r for r in model["rows"] if r["unresolved"]]
+    assert model["counts"]["pending_retry"] == len(pending_rows)
+    assert model["counts"]["pending_retry"] == 2
+
+
+def test_pair_filtering_applies_to_both_sources(monkeypatch):
+    problems = [
+        {
+            "type": "missing_peer",
+            "provider": "TRAKT",
+            "feature": "history",
+            "key": "tmdb:1",
+            "targets": ["SIMKL"],
+            "ids": {"tmdb": "1"},
+            "item_type": "movie",
+        }
+    ]
+    monkeypatch.setattr(
+        A,
+        "_unresolved_records",
+        lambda allowed: [
+            _record("SIMKL", "history", "tmdb:9", ["tmdb:9"]),
+            _record("PLEX", "history", "tmdb:5", ["tmdb:5"]),
+        ],
+    )
+    ctx = SimpleNamespace(pairs={("TRAKT", "history"): ["SIMKL"]})
+    model = A._attention_from_analysis(problems, None, ctx)
+    providers = {r["provider"] for r in model["rows"]}
+    assert "PLEX" not in providers
+    assert model["counts"]["current_mismatch"] == 1
+    assert model["counts"]["pending_retry"] == 1
+
+
+def test_confirmed_retry_clears_unresolved():
+    before = A._attention_model([], [_record("SIMKL", "history", "tmdb:1", ["tmdb:1"])])
+    assert before["counts"]["pending_retry"] == 1
+    after = A._attention_model([], [])
+    assert after["counts"]["pending_retry"] == 0
+
+
+def test_read_back_removes_current_mismatch():
+    before = A._attention_model([_mismatch("TRAKT", "history", "tmdb:1", ["SIMKL"], ["tmdb:1"])], [])
+    assert before["counts"]["current_mismatch"] == 1
+    after = A._attention_model([], [])
+    assert after["counts"]["current_mismatch"] == 0
+
+
+def test_provider_neutral():
+    mismatch = [_mismatch("EMBY", "history", "imdb:tt7", ["JELLYFIN"], ["imdb:tt7"])]
+    records = [_record("JELLYFIN", "history", "imdb:tt7", ["imdb:tt7"])]
+    model = A._attention_model(mismatch, records)
+    assert model["counts"]["total"] == 1
+    row = model["rows"][0]
+    assert row["current_mismatch"] and row["unresolved"]
+    assert row["provider"] == "JELLYFIN"
+
+
+def test_blocked_item_distinct_from_failed_write():
+    mismatch = [_mismatch("TRAKT", "history", "tmdb:1", ["SIMKL"], ["tmdb:1"], blocked=True)]
+    records = [_record("SIMKL", "history", "tmdb:2", ["tmdb:2"], reason="simkl_write_failed:http_500")]
+    model = A._attention_model(mismatch, records)
+    blocked_rows = [r for r in model["rows"] if r["blocked"]]
+    pending_rows = [r for r in model["rows"] if r["unresolved"]]
+    assert len(blocked_rows) == 1 and not blocked_rows[0]["current_mismatch"]
+    assert len(pending_rows) == 1 and not pending_rows[0]["blocked"]
+    assert model["counts"]["blocked"] == 1
+    assert model["counts"]["pending_retry"] == 1

--- a/tests/test_editor_playlists.py
+++ b/tests/test_editor_playlists.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from api import editorAPI as api
+from cw_platform.playlists import PLAYLIST_KIND_SMART, PlaylistItem, PlaylistResource, PlaylistSnapshot
+
+
+class FakePlaylistOps:
+    def __init__(self, resource: PlaylistResource | None = None):
+        self.resource = resource or PlaylistResource(
+            provider="PLEX",
+            id="pl1",
+            name="Movies",
+            can_add=True,
+            can_remove=True,
+            can_reorder=True,
+            media_types=("movie", "show"),
+        )
+        self.items = [
+            {"type": "movie", "title": "One", "ids": {"tmdb": "1"}},
+            {"type": "movie", "title": "Two", "ids": {"tmdb": "2"}},
+        ]
+        self.calls: list[tuple[str, Any]] = []
+
+    def list_playlist_resources(self, cfg, *, instance=None):
+        return [self.resource]
+
+    def get_playlist_snapshot(self, cfg, playlist_id, *, instance=None):
+        return PlaylistSnapshot(
+            resource=self.resource,
+            items=[PlaylistItem.from_media(item, position=i) for i, item in enumerate(self.items)],
+        )
+
+    def create_playlist(self, cfg, name, *, media_type=None, instance=None, dry_run=False):
+        return self.resource
+
+    def add_playlist_items(self, cfg, playlist_id, items, *, instance=None, dry_run=False):
+        self.calls.append(("add", [dict(x) for x in items]))
+        self.items.extend(dict(x) for x in items)
+        return {"ok": True, "count": len(items), "unresolved": []}
+
+    def remove_playlist_items(self, cfg, playlist_id, items, *, instance=None, dry_run=False):
+        self.calls.append(("remove", [dict(x) for x in items]))
+        remove_ids = {str((x.get("ids") or {}).get("tmdb") or "") for x in items}
+        self.items = [x for x in self.items if str((x.get("ids") or {}).get("tmdb") or "") not in remove_ids]
+        return {"ok": True, "count": len(items), "unresolved": []}
+
+    def reorder_playlist_items(self, cfg, playlist_id, ordered_keys, *, instance=None, dry_run=False):
+        self.calls.append(("reorder", list(ordered_keys)))
+        return {"ok": True, "reordered": len(ordered_keys)}
+
+
+def _endpoint() -> dict[str, Any]:
+    return {
+        "id": "EP-01",
+        "name": "Films",
+        "provider": "PLEX",
+        "provider_label": "Plex",
+        "instance": "default",
+        "playlist_id": "pl1",
+        "playlist_name": "Movies",
+    }
+
+
+@pytest.fixture
+def editor_playlist(monkeypatch):
+    ops = FakePlaylistOps()
+    cfg = {"playlists": {"endpoints": [_endpoint()]}}
+    monkeypatch.setattr(api, "load_config", lambda: cfg)
+    monkeypatch.setattr(api.playlist_svc, "list_endpoints", lambda _cfg: [_endpoint()])
+    monkeypatch.setattr(api.playlists_runner, "get_endpoint", lambda _cfg, eid: _endpoint() if eid == "EP-01" else None)
+    monkeypatch.setattr(api, "load_sync_ops", lambda provider: ops if provider == "PLEX" else None)
+    monkeypatch.setattr(api, "build_provider_config_view", lambda cfg, provider, instance: {"provider": provider, "instance": instance})
+    return ops
+
+
+def test_editor_lists_playlist_endpoints(editor_playlist) -> None:
+    data = api.api_editor_playlist_endpoints()
+    assert data["ok"] is True
+    assert data["endpoints"][0]["id"] == "EP-01"
+
+
+def test_editor_loads_playlist_endpoint_snapshot(editor_playlist) -> None:
+    data = api.api_editor_get_state(kind="watchlist", source="playlist", endpoint="EP-01")
+    assert data["source"] == "playlist"
+    assert data["resource"]["can_add"] is True
+    assert data["resource"]["media_types"] == ["movie", "show"]
+    assert set(data["items"]) == {"tmdb:1", "tmdb:2"}
+    assert data["original_keys"] == ["tmdb:1", "tmdb:2"]
+
+
+def test_editor_saves_playlist_diff_through_provider_ops(editor_playlist) -> None:
+    result = api.api_editor_save_state(
+        {
+            "source": "playlist",
+            "endpoint": "EP-01",
+            "items": {
+                "tmdb:2": {"type": "movie", "title": "Two", "ids": {"tmdb": "2"}},
+                "tmdb:3": {"type": "movie", "title": "Three", "ids": {"tmdb": "3"}},
+            },
+        }
+    )
+    assert result["planned_additions"] == 1
+    assert result["planned_removals"] == 1
+    assert result["added"] == 1
+    assert result["removed"] == 1
+    assert any(call[0] == "add" and call[1][0]["ids"]["tmdb"] == "3" for call in editor_playlist.calls)
+    assert any(call[0] == "remove" for call in editor_playlist.calls)
+
+
+def test_editor_blocks_readonly_playlist_endpoint(monkeypatch, editor_playlist) -> None:
+    editor_playlist.resource = PlaylistResource(
+        provider="PLEX",
+        id="pl1",
+        name="Smart",
+        kind=PLAYLIST_KIND_SMART,
+        can_read=True,
+        can_add=False,
+        can_remove=False,
+        can_reorder=False,
+    )
+    with pytest.raises(HTTPException) as exc:
+        api.api_editor_save_state(
+            {
+                "source": "playlist",
+                "endpoint": "EP-01",
+                "items": {"tmdb:1": {"type": "movie", "title": "One", "ids": {"tmdb": "1"}}},
+            }
+        )
+    assert exc.value.status_code == 400
+
+
+def test_editor_ui_exposes_playlist_source() -> None:
+    from pathlib import Path
+
+    js = (Path(__file__).resolve().parents[1] / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    assert 'option[value="playlist"]' in js
+    assert "/api/editor/playlists/endpoints" in js
+    assert "payload.endpoint = state.snapshot" in js
+    assert "state.playlistOriginalKeys" in js
+    assert 'state.source !== "state" && state.source !== "playlist"' in js

--- a/tests/test_orchestrator_remove_accounting.py
+++ b/tests/test_orchestrator_remove_accounting.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from cw_platform.orchestrator._pairs_oneway import compute_effective_remove, is_remove_retry_reason
+
+
+def _keys(n, prefix="imdb:tt"):
+    return [f"{prefix}{i:04d}" for i in range(n)]
+
+
+def test_exact_keys_select_only_confirmed_removals():
+    attempted = _keys(87)
+    confirmed = attempted[:25]
+
+    out = compute_effective_remove(
+        attempted_keys=attempted,
+        provider_confirmed_count=87,
+        provider_confirmed_keys=confirmed,
+        provider_unresolved_count=62,
+    )
+
+    assert out["have_exact_keys"] is True
+    assert out["ambiguous"] is False
+    assert out["effective"] == 25
+    assert out["success_keys"] == confirmed
+    assert out["failed_keys"] == attempted[25:]
+    assert len(out["failed_keys"]) == 62
+
+
+def test_exact_keys_outside_attempted_set_are_ignored():
+    out = compute_effective_remove(
+        attempted_keys=["a", "b"],
+        provider_confirmed_count=3,
+        provider_confirmed_keys=["a", "zz"],
+        provider_unresolved_count=0,
+    )
+
+    assert out["success_keys"] == ["a"]
+    assert out["failed_keys"] == ["b"]
+    assert out["effective"] == 1
+
+
+def test_full_clean_count_without_exact_keys_is_accepted():
+    attempted = _keys(10)
+
+    out = compute_effective_remove(
+        attempted_keys=attempted,
+        provider_confirmed_count=10,
+        provider_confirmed_keys=[],
+        provider_unresolved_count=0,
+        provider_errors=0,
+    )
+
+    assert out["have_exact_keys"] is False
+    assert out["ambiguous"] is False
+    assert out["success_keys"] == attempted
+    assert out["failed_keys"] == []
+
+
+def test_ambiguous_partial_without_exact_keys_confirms_nothing():
+    attempted = _keys(10)
+
+    out = compute_effective_remove(
+        attempted_keys=attempted,
+        provider_confirmed_count=4,
+        provider_confirmed_keys=[],
+        provider_unresolved_count=0,
+    )
+
+    assert out["ambiguous"] is True
+    assert out["effective"] == 0
+    assert out["success_keys"] == []
+    assert out["failed_keys"] == attempted
+
+
+def test_full_count_with_unresolved_or_errors_is_not_accepted():
+    attempted = _keys(10)
+
+    with_unresolved = compute_effective_remove(
+        attempted_keys=attempted,
+        provider_confirmed_count=10,
+        provider_confirmed_keys=[],
+        provider_unresolved_count=2,
+    )
+    with_errors = compute_effective_remove(
+        attempted_keys=attempted,
+        provider_confirmed_count=10,
+        provider_confirmed_keys=[],
+        provider_unresolved_count=0,
+        provider_errors=1,
+    )
+
+    assert with_unresolved["success_keys"] == []
+    assert with_errors["success_keys"] == []
+    assert with_unresolved["failed_keys"] == attempted
+    assert with_errors["failed_keys"] == attempted
+
+
+def test_zero_confirmed_is_failure_not_ambiguous():
+    attempted = _keys(5)
+
+    out = compute_effective_remove(
+        attempted_keys=attempted,
+        provider_confirmed_count=0,
+        provider_confirmed_keys=[],
+        provider_unresolved_count=5,
+    )
+
+    assert out["ambiguous"] is False
+    assert out["success_keys"] == []
+    assert out["failed_keys"] == attempted
+
+
+def test_remove_retry_reasons_are_selected_and_add_reasons_are_not():
+    assert is_remove_retry_reason("apply:remove:unconfirmed") is True
+    assert is_remove_retry_reason("two:apply:remove:unconfirmed") is True
+    assert is_remove_retry_reason("provider_down:remove") is True
+
+    assert is_remove_retry_reason("apply:add:failed") is False
+    assert is_remove_retry_reason("two:apply:add:failed") is False
+    assert is_remove_retry_reason("provider_down") is False
+    assert is_remove_retry_reason("") is False
+    assert is_remove_retry_reason(None) is False

--- a/tests/test_playlists_model.py
+++ b/tests/test_playlists_model.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from cw_platform.playlists import (
+    PLAYLIST_KIND_REGULAR,
+    PLAYLIST_KIND_SMART,
+    PlaylistItem,
+    PlaylistResource,
+    PlaylistSnapshot,
+    normalize_ruleset,
+    playlist_capabilities,
+    supports_playlists,
+    validate_ruleset,
+)
+
+
+def test_resource_roundtrip_and_normalization():
+    res = PlaylistResource(
+        provider="trakt",
+        id=" 123 ",
+        name="Weekend",
+        kind="SMART",
+        can_add=True,
+        media_types="movies, shows",
+    )
+    assert res.provider == "TRAKT"
+    assert res.id == "123"
+    assert res.kind == PLAYLIST_KIND_SMART
+    assert res.is_smart is True
+    assert res.writable is False
+    assert res.media_types == ("movies", "shows")
+
+    d = res.to_dict()
+    again = PlaylistResource.from_dict(d)
+    assert again.to_dict() == d
+
+
+def test_regular_resource_writable():
+    res = PlaylistResource(provider="plex", id="9", kind="regular", can_add=True, can_remove=True)
+    assert res.kind == PLAYLIST_KIND_REGULAR
+    assert res.writable is True
+
+
+def test_item_from_media_uses_canonical_key():
+    it = PlaylistItem.from_media(
+        {"type": "movie", "title": "Dune", "year": 2021, "ids": {"tmdb": "438631"}},
+        playlist_item_id="pi1",
+        position=3,
+    )
+    assert it.key == "tmdb:438631"
+    assert it.playlist_item_id == "pi1"
+    assert it.position == 3
+    assert it.item.get("ids", {}).get("tmdb") == "438631"
+
+    again = PlaylistItem.from_dict(it.to_dict())
+    assert again.to_dict() == it.to_dict()
+
+
+def test_snapshot_helpers():
+    res = PlaylistResource(provider="plex", id="9")
+    a = PlaylistItem(key="tmdb:1", item={"type": "movie"})
+    b = PlaylistItem(key="tmdb:2", item={"type": "movie"})
+    snap = PlaylistSnapshot(resource=res, items=[a, b], checkpoint="cp")
+    assert snap.ordered_keys() == ["tmdb:1", "tmdb:2"]
+    assert set(snap.by_key().keys()) == {"tmdb:1", "tmdb:2"}
+    assert PlaylistSnapshot.from_dict(snap.to_dict()).ordered_keys() == ["tmdb:1", "tmdb:2"]
+
+
+def test_ruleset_description_is_preserved():
+    rs = normalize_ruleset({
+        "id": "RULE-01",
+        "name": "Split",
+        "description": "Human readable note",
+        "direction": "one_way",
+        "initial_sync": "source_authoritative",
+        "read_mode": "direct",
+        "write_mode": "partition",
+        "membership": "managed_only",
+        "order": "ignore",
+        "deduplicate": "canonical_id",
+        "allocation": "stable_first_fit",
+        "rebalance": "never",
+        "overflow": "block",
+        "per_endpoint_capacity": 100,
+        "aggregate_capacity": 1000,
+        "maximum_targets": 5,
+        "track_assignments": True,
+    })
+    assert rs["description"] == "Human readable note"
+
+
+def test_ruleset_name_is_required_and_short():
+    base = {
+        "id": "RULE-01",
+        "name": "Split",
+        "direction": "one_way",
+        "initial_sync": "source_authoritative",
+        "read_mode": "direct",
+        "write_mode": "partition",
+        "membership": "managed_only",
+        "order": "ignore",
+        "deduplicate": "canonical_id",
+        "allocation": "stable_first_fit",
+        "rebalance": "never",
+        "overflow": "block",
+        "per_endpoint_capacity": 100,
+        "aggregate_capacity": 1000,
+        "maximum_targets": 5,
+        "track_assignments": True,
+    }
+    ok, why, _ = validate_ruleset({**base, "name": ""})
+    assert not ok and "required" in why
+    ok2, why2, _ = validate_ruleset({**base, "name": "VeryLongName"})
+    assert not ok2 and "10 characters" in why2
+    ok3, why3, _ = validate_ruleset({**base, "name": "$Bad"})
+    assert not ok3 and "letter or number" in why3
+    ok4, why4, _ = validate_ruleset({**base, "name": "Bad/Name"})
+    assert not ok4 and "unsupported" in why4
+
+
+def test_supports_playlists_discovery():
+    class Bare:
+        pass
+
+    class Full:
+        def list_playlist_resources(self, *a, **k): ...
+        def get_playlist_snapshot(self, *a, **k): ...
+        def create_playlist(self, *a, **k): ...
+        def add_playlist_items(self, *a, **k): ...
+        def remove_playlist_items(self, *a, **k): ...
+        def reorder_playlist_items(self, *a, **k): ...
+
+    assert supports_playlists(Bare()) is False
+    assert supports_playlists(Full()) is True
+    assert supports_playlists(None) is False
+
+
+def test_trakt_manifest_declares_playlists():
+    mod = importlib.import_module("providers.sync._mod_TRAKT")
+    manifest = mod.get_manifest()
+    assert manifest["features"]["playlists"] is True
+    assert manifest["features"]["watchlist"] is True
+    caps = playlist_capabilities(manifest)
+    assert caps.get("read") is True
+    assert caps.get("smart") is False
+    assert "movies" in caps.get("media_types", [])
+    assert supports_playlists(mod.OPS) is True
+
+
+def test_plex_manifest_declares_playlists():
+    pytest.importorskip("plexapi")
+    mod = importlib.import_module("providers.sync._mod_PLEX")
+    manifest = mod.get_manifest()
+    assert manifest["features"]["playlists"] is True
+    assert manifest["features"]["watchlist"] is True
+    caps = playlist_capabilities(manifest)
+    assert caps.get("read") is True
+    assert caps.get("smart") is True
+    assert caps.get("smart_writable") is False
+    assert supports_playlists(mod.OPS) is True

--- a/tests/test_playlists_orchestration.py
+++ b/tests/test_playlists_orchestration.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from cw_platform import playlists_runner
+from cw_platform.orchestrator import _pairs as pairs
+from cw_platform.orchestrator import _pairs_playlists as glue
+
+
+class FakeOps:
+    def __init__(self, name: str):
+        self._name = name
+
+    def name(self) -> str:
+        return self._name
+
+    def label(self) -> str:
+        return self._name.title()
+
+    def features(self) -> dict[str, bool]:
+        return {"playlists": True}
+
+    def capabilities(self) -> dict[str, Any]:
+        return {}
+
+    def health(self, cfg, **kw) -> dict[str, Any]:
+        return {"ok": True, "status": "ok", "features": {"playlists": True}, "api": {}}
+
+    def build_index(self, cfg, *, feature):
+        return {}
+
+    def add(self, cfg, items, *, feature, dry_run=False):
+        return {"ok": True, "count": 0}
+
+    def remove(self, cfg, items, *, feature, dry_run=False):
+        return {"ok": True, "count": 0}
+
+    def list_playlist_resources(self, cfg, *, instance=None):
+        return []
+
+    def get_playlist_snapshot(self, cfg, playlist_id, *, instance=None):
+        return None
+
+    def create_playlist(self, *a, **k):
+        return None
+
+    def add_playlist_items(self, *a, **k):
+        return {"ok": True}
+
+    def remove_playlist_items(self, *a, **k):
+        return {"ok": True}
+
+    def reorder_playlist_items(self, *a, **k):
+        return {"ok": True}
+
+
+class FakeStats:
+    def record_summary(self, **kw):
+        pass
+
+    def http_overview(self, *a, **k):
+        return {}
+
+    def overview(self, *a, **k):
+        return {}
+
+
+class FakeStateStore:
+    def save_last(self, d):
+        pass
+
+    def load_state(self):
+        return {}
+
+    def save_state(self, d):
+        pass
+
+
+def _ctx(cfg):
+    return SimpleNamespace(
+        config=cfg,
+        providers={"FAKESRC": FakeOps("FAKESRC"), "FAKEDST": FakeOps("FAKEDST")},
+        emit=lambda *a, **k: None,
+        emit_info=lambda *a, **k: None,
+        dbg=lambda *a, **k: None,
+        dry_run=False,
+        tomb_prune=lambda *a, **k: None,
+        state_store=FakeStateStore(),
+        stats=FakeStats(),
+        emit_rate_warnings=lambda: None,
+    )
+
+
+def _pair_cfg(mode="one-way"):
+    return {
+        "trakt": {},
+        "plex": {},
+        "runtime": {},
+        "sync": {},
+        "playlists": {
+            "endpoints": [
+                {"id": "EP-01", "name": "s", "provider": "FAKESRC", "instance": "default", "playlist_id": "L1"},
+                {"id": "EP-02", "name": "t", "provider": "FAKEDST", "instance": "default", "playlist_id": "T1"},
+            ],
+            "mappings": [
+                {"id": "MAP-01", "source_endpoint": "EP-01", "target_endpoints": ["EP-02"],
+                 "membership": "managed_only", "order": "ignore", "enabled": True},
+            ],
+        },
+        "pairs": [
+            {
+                "id": "p1",
+                "source": "FAKESRC",
+                "target": "FAKEDST",
+                "source_instance": "default",
+                "target_instance": "default",
+                "enabled": True,
+                "mode": mode,
+                "features": {"playlists": {"enable": True, "mappings": ["MAP-01"]}},
+            }
+        ],
+    }
+
+
+def test_pairs_routes_playlists_to_dedicated_runner(config_base, monkeypatch):
+    calls = {"playlist": 0, "oneway": 0, "twoway": 0}
+
+    def fake_playlist(ctx, src, dst, *, fcfg, health_map, full_cfg, pair):
+        calls["playlist"] += 1
+        assert src == "FAKESRC" and dst == "FAKEDST"
+        assert (fcfg.get("mappings") or []) == ["MAP-01"]
+        return {"added": 3, "removed": 1, "updated": 2, "unresolved": 0, "skipped": 0, "errors": 0}
+
+    def fail_oneway(*a, **k):
+        calls["oneway"] += 1
+        raise AssertionError("playlists must not use run_one_way_feature")
+
+    def fail_twoway(*a, **k):
+        calls["twoway"] += 1
+        raise AssertionError("playlists must not use run_two_way_feature")
+
+    monkeypatch.setattr(pairs, "run_playlist_mappings", fake_playlist)
+    monkeypatch.setattr(pairs, "run_one_way_feature", fail_oneway)
+    monkeypatch.setattr(pairs, "run_two_way_feature", fail_twoway)
+
+    result = pairs.run_pairs(_ctx(_pair_cfg("one-way")))
+    assert calls["playlist"] == 1
+    assert calls["oneway"] == 0
+    assert result["added"] == 3
+    assert result["removed"] == 1
+    assert result["updated"] == 2
+
+
+def test_pairs_runs_playlists_directionally_on_two_way(config_base, monkeypatch):
+    calls = {"playlist": 0}
+
+    def fake_playlist(ctx, src, dst, *, fcfg, health_map, full_cfg, pair):
+        calls["playlist"] += 1
+        assert src == "FAKESRC" and dst == "FAKEDST"
+        return {"added": 1, "removed": 0, "updated": 0, "unresolved": 0, "skipped": 0, "errors": 0}
+
+    monkeypatch.setattr(pairs, "run_playlist_mappings", fake_playlist)
+    monkeypatch.setattr(pairs, "run_one_way_feature", lambda *a, **k: (_ for _ in ()).throw(AssertionError("no")))
+    monkeypatch.setattr(pairs, "run_two_way_feature", lambda *a, **k: (_ for _ in ()).throw(AssertionError("playlists must not use run_two_way_feature")))
+
+    result = pairs.run_pairs(_ctx(_pair_cfg("two-way")))
+    assert calls["playlist"] == 1
+    assert result["added"] == 1
+    assert result["errors"] == 0
+
+
+def test_playlist_pair_records_feature_totals(config_base, monkeypatch):
+    calls: list[dict[str, Any]] = []
+
+    class Stats:
+        def record_feature_totals(self, feature, **kwargs):
+            calls.append({"feature": feature, **kwargs})
+
+    cfg = _pair_cfg("one-way")
+    ctx = _ctx(cfg)
+    ctx.stats = Stats()
+    monkeypatch.setattr(glue, "resolve_pair_mappings", lambda _cfg, _pair: [{"id": "MAP-01"}])
+    monkeypatch.setattr(glue, "run_mapping", lambda *a, **k: {"ok": True, "added": 3, "removed": 0, "reordered": 0, "unresolved_count": 0})
+
+    result = glue.run_playlist_mappings(
+        ctx,
+        "FAKESRC",
+        "FAKEDST",
+        fcfg={"mappings": ["MAP-01"]},
+        health_map={},
+        full_cfg=cfg,
+        pair=cfg["pairs"][0],
+    )
+
+    assert result["added"] == 3
+    assert calls == [
+        {
+            "feature": "playlists",
+            "added": 3,
+            "removed": 0,
+            "updated": 0,
+            "src": "FAKEDST",
+            "run_id": "FAKESRC->FAKEDST:playlists",
+        }
+    ]
+
+
+def test_manual_and_scheduled_share_core_runner():
+    from services import playlists as svc
+
+    assert glue.run_mapping is playlists_runner.run_mapping
+    assert svc.runner.run_mapping is playlists_runner.run_mapping

--- a/tests/test_playlists_rulesets.py
+++ b/tests/test_playlists_rulesets.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from typing import Any
+
+from cw_platform.id_map import canonical_key
+from cw_platform.playlists import BUILTIN_TRAKT_FREE_ACCOUNT_RULESET_ID, BUILTIN_RULESETS
+from cw_platform.playlists import PlaylistItem, PlaylistResource, PlaylistSnapshot
+from cw_platform import playlists_runner as R
+from services import playlists as svc
+
+
+class FakeOps:
+    def __init__(self, name: str, playlists: dict[str, list[dict[str, Any]]]):
+        self.name = name
+        self.playlists = playlists
+        self.calls: list[tuple[str, str, list[str]]] = []
+
+    def list_playlist_resources(self, cfg, *, instance=None):
+        return [
+            PlaylistResource(provider=self.name, id=pid, name=pid, can_read=True, can_add=True, can_remove=True, can_reorder=False)
+            for pid in self.playlists
+        ]
+
+    def get_playlist_snapshot(self, cfg, playlist_id, *, instance=None):
+        items = [PlaylistItem.from_media(m, position=i) for i, m in enumerate(self.playlists[str(playlist_id)])]
+        res = PlaylistResource(provider=self.name, id=str(playlist_id), name=str(playlist_id), can_read=True, can_add=True, can_remove=True)
+        return PlaylistSnapshot(resource=res, items=items)
+
+    def create_playlist(self, *a, **k):
+        return PlaylistResource(provider=self.name, id="new", name="new")
+
+    def add_playlist_items(self, cfg, playlist_id, items, *, instance=None, dry_run=False):
+        keys = [canonical_key(x) for x in items]
+        self.calls.append(("add", str(playlist_id), keys))
+        have = {canonical_key(x) for x in self.playlists[str(playlist_id)]}
+        confirmed: list[str] = []
+        for it in items:
+            k = canonical_key(it)
+            if k not in have:
+                self.playlists[str(playlist_id)].append(dict(it))
+                have.add(k)
+            confirmed.append(k)
+        return {"ok": True, "count": len(confirmed), "unresolved": [], "confirmed_keys": confirmed}
+
+    def remove_playlist_items(self, cfg, playlist_id, items, *, instance=None, dry_run=False):
+        keys = [canonical_key(x) for x in items]
+        self.calls.append(("remove", str(playlist_id), keys))
+        want = set(keys)
+        before = len(self.playlists[str(playlist_id)])
+        self.playlists[str(playlist_id)] = [x for x in self.playlists[str(playlist_id)] if canonical_key(x) not in want]
+        return {"ok": True, "count": before - len(self.playlists[str(playlist_id)]), "unresolved": [], "confirmed_keys": keys}
+
+    def reorder_playlist_items(self, *a, **k):
+        return {"ok": True, "count": 0, "reordered": 0}
+
+
+def movie(n: int) -> dict[str, Any]:
+    return {"type": "movie", "title": f"M{n}", "ids": {"tmdb": str(n)}}
+
+
+def cfg(rule: dict[str, Any] | None = None) -> dict[str, Any]:
+    root = {
+        "plex": {},
+        "trakt": {},
+        "runtime": {},
+        "playlists": {
+            "endpoints": [
+                {"id": "EP-S", "name": "source", "provider": "PLEX", "instance": "default", "playlist_id": "S"},
+                {"id": "EP-1", "name": "target1", "provider": "TRAKT", "instance": "default", "playlist_id": "T1"},
+                {"id": "EP-2", "name": "target2", "provider": "TRAKT", "instance": "default", "playlist_id": "T2"},
+                {"id": "EP-3", "name": "target3", "provider": "TRAKT", "instance": "default", "playlist_id": "T3"},
+            ],
+            "mappings": [],
+            "rulesets": [],
+        },
+    }
+    if rule:
+        root["playlists"]["rulesets"].append(rule)
+    return root
+
+
+def mapping(rule_id: str = BUILTIN_TRAKT_FREE_ACCOUNT_RULESET_ID, targets: list[str] | None = None) -> dict[str, Any]:
+    ids = targets or ["EP-1", "EP-2"]
+    return {
+        "id": "MAP-01",
+        "source_endpoint": "EP-S",
+        "target_endpoints": ids,
+        "source": {"provider": "PLEX", "instance": "default", "playlist_id": "S", "endpoint_id": "EP-S"},
+        "target": {"provider": "TRAKT", "instance": "default", "playlist_id": "T1", "endpoint_id": "EP-1"},
+        "targets": [
+            {"provider": "TRAKT", "instance": "default", "playlist_id": "T1", "endpoint_id": "EP-1"},
+            {"provider": "TRAKT", "instance": "default", "playlist_id": "T2", "endpoint_id": "EP-2"},
+        ][: len(ids)],
+        "ruleset_id": rule_id,
+        "enabled": True,
+    }
+
+
+def providers(src: list[dict[str, Any]], t1=None, t2=None, t3=None):
+    plex = FakeOps("PLEX", {"S": list(src)})
+    trakt = FakeOps("TRAKT", {"T1": list(t1 or []), "T2": list(t2 or []), "T3": list(t3 or [])})
+    return {"PLEX": plex, "TRAKT": trakt}
+
+
+def custom_rule(capacity: int, aggregate: int | None = None) -> dict[str, Any]:
+    rule = dict(BUILTIN_RULESETS[BUILTIN_TRAKT_FREE_ACCOUNT_RULESET_ID])
+    rule.update({"id": "customrl", "name": "Custom", "built_in": False, "per_endpoint_capacity": capacity, "aggregate_capacity": aggregate or capacity * 5})
+    return rule
+
+
+def test_partition_500_source_items_into_two_250_targets(config_base):
+    provs = providers([movie(i) for i in range(500)])
+    plan = R.preview_mapping(cfg(), mapping(), providers=provs)
+    assert plan["blocked"] is False
+    assert [x["planned_additions"] for x in plan["per_target"]] == [250, 250]
+
+
+def test_aggregate_target_reads_as_one_logical_collection(config_base):
+    provs = providers([], [movie(i) for i in range(250)], [movie(i) for i in range(250, 500)])
+    plan = R.preview_mapping(cfg(), mapping(), providers=provs)
+    assert plan["logical_aggregated_target_count"] == 500
+    assert plan["planned_additions"] == 0
+
+
+def test_stable_assignment_does_not_rebalance_after_addition(config_base):
+    rule = custom_rule(300, 600)
+    conf = cfg(rule)
+    provs = providers([movie(i) for i in range(500)])
+    m = mapping("customrl")
+    R.run_mapping(conf, m, providers=provs)
+    before = R._state_entry(m)["assignments"]
+    provs["PLEX"].playlists["S"].append(movie(500))
+    R.run_mapping(conf, m, providers=provs)
+    after = R._state_entry(m)["assignments"]
+    assert {k: v["endpoint_id"] for k, v in before.items()} == {k: after[k]["endpoint_id"] for k in before}
+    assert after["tmdb:500"]["endpoint_id"] == "EP-2"
+
+
+def test_target_addition_propagates_back_to_source(config_base):
+    conf = cfg(custom_rule(10, 20))
+    provs = providers([movie(1)])
+    m = mapping("customrl")
+    R.run_mapping(conf, m, providers=provs)
+    provs["TRAKT"].playlists["T1"].append(movie(2))
+    res = R.run_mapping(conf, m, providers=provs)
+    assert res["ok"] is True
+    assert canonical_key(movie(2)) in {canonical_key(x) for x in provs["PLEX"].playlists["S"]}
+
+
+def test_target_removal_propagates_back_to_source(config_base):
+    conf = cfg(custom_rule(10, 20))
+    provs = providers([movie(1), movie(2)])
+    m = mapping("customrl")
+    R.run_mapping(conf, m, providers=provs)
+    provs["TRAKT"].playlists["T1"] = [x for x in provs["TRAKT"].playlists["T1"] if canonical_key(x) != "tmdb:1"]
+    R.run_mapping(conf, m, providers=provs)
+    assert "tmdb:1" not in {canonical_key(x) for x in provs["PLEX"].playlists["S"]}
+
+
+def test_501_items_blocks_before_writes(config_base):
+    provs = providers([movie(i) for i in range(501)])
+    res = R.run_mapping(cfg(), mapping(), providers=provs)
+    assert res["ok"] is False
+    assert res["capacity_error"] is True
+    assert provs["TRAKT"].calls == []
+
+
+def test_unmanaged_target_items_count_toward_capacity(config_base):
+    src = [movie(i) for i in range(250)]
+    unmanaged = [movie(1000 + i) for i in range(10)]
+    provs = providers(src, unmanaged, [])
+    plan = R.preview_mapping(cfg(), mapping(), providers=provs)
+    assert [x["planned_additions"] for x in plan["per_target"]] == [240, 10]
+
+
+def test_built_in_ruleset_rejects_modification(config_base):
+    conf = cfg()
+    raw = dict(BUILTIN_RULESETS[BUILTIN_TRAKT_FREE_ACCOUNT_RULESET_ID])
+    raw["per_endpoint_capacity"] = 500
+    res = svc.upsert_ruleset(conf, raw)
+    assert res["ok"] is False
+
+
+def test_cloned_custom_ruleset_uses_changed_capacity(config_base):
+    conf = cfg()
+    cloned = svc.clone_ruleset(conf, BUILTIN_TRAKT_FREE_ACCOUNT_RULESET_ID, {"name": "SmallTrakt"})
+    assert cloned["ok"] is True
+    rs = dict(cloned["ruleset"])
+    rs["per_endpoint_capacity"] = 2
+    rs["aggregate_capacity"] = 4
+    saved = svc.upsert_ruleset(conf, rs)
+    assert saved["ok"] is True
+    provs = providers([movie(i) for i in range(4)])
+    plan = R.preview_mapping(conf, mapping(rs["id"]), providers=provs)
+    assert [x["planned_additions"] for x in plan["per_target"]] == [2, 2]

--- a/tests/test_playlists_runner.py
+++ b/tests/test_playlists_runner.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cw_platform.id_map import canonical_key
+from cw_platform.playlists import PlaylistItem, PlaylistResource, PlaylistSnapshot
+from cw_platform import playlists_runner as R
+
+
+class FakeOps:
+    def __init__(self, name: str, playlists: dict[str, dict[str, Any]]):
+        self._name = name
+        self.pl = playlists
+        self.calls: list[Any] = []
+
+    def _resource(self, pid: str) -> PlaylistResource:
+        d = self.pl[pid]
+        smart = bool(d.get("smart"))
+        return PlaylistResource(
+            provider=self._name,
+            id=pid,
+            name=d.get("name") or pid,
+            kind="smart" if smart else "regular",
+            can_add=not smart,
+            can_remove=not smart,
+            can_reorder=bool(d.get("can_reorder", True)) and not smart,
+        )
+
+    def list_playlist_resources(self, cfg, *, instance=None):
+        return [self._resource(pid) for pid in self.pl]
+
+    def get_playlist_snapshot(self, cfg, playlist_id, *, instance=None):
+        d = self.pl[playlist_id]
+        items = [PlaylistItem.from_media(m, position=i) for i, m in enumerate(d["items"])]
+        return PlaylistSnapshot(resource=self._resource(playlist_id), items=items)
+
+    def create_playlist(self, *a, **k):
+        return PlaylistResource(provider=self._name, id="new", name="new")
+
+    def add_playlist_items(self, cfg, playlist_id, items, *, instance=None, dry_run=False):
+        self.calls.append(("add", playlist_id, [canonical_key(x) for x in items]))
+        d = self.pl[playlist_id]
+        existing = {canonical_key(m) for m in d["items"]}
+        added, conf = 0, []
+        for it in items:
+            k = canonical_key(it)
+            if k not in existing:
+                d["items"].append(dict(it))
+                existing.add(k)
+                added += 1
+                conf.append(k)
+        return {"ok": True, "count": added, "unresolved": [], "confirmed_keys": conf}
+
+    def remove_playlist_items(self, cfg, playlist_id, items, *, instance=None, dry_run=False):
+        self.calls.append(("remove", playlist_id, [canonical_key(x) for x in items]))
+        d = self.pl[playlist_id]
+        want = {canonical_key(x) for x in items}
+        before = len(d["items"])
+        conf = [canonical_key(m) for m in d["items"] if canonical_key(m) in want]
+        d["items"] = [m for m in d["items"] if canonical_key(m) not in want]
+        return {"ok": True, "count": before - len(d["items"]), "unresolved": [], "confirmed_keys": conf}
+
+    def reorder_playlist_items(self, cfg, playlist_id, ordered_keys, *, instance=None, dry_run=False):
+        self.calls.append(("reorder", playlist_id, list(ordered_keys)))
+        d = self.pl[playlist_id]
+        order = {k: i for i, k in enumerate(ordered_keys)}
+        d["items"].sort(key=lambda m: order.get(canonical_key(m), 10**9))
+        return {"ok": True, "reordered": len(ordered_keys), "count": len(ordered_keys)}
+
+
+def _movie(n: int) -> dict[str, Any]:
+    return {"type": "movie", "title": f"M{n}", "year": 2020, "ids": {"tmdb": str(n)}}
+
+
+def _movie_ids(n: int, ids: dict[str, Any]) -> dict[str, Any]:
+    return {"type": "movie", "title": f"M{n}", "year": 2020, "ids": ids}
+
+
+def _cfg():
+    return {"trakt": {}, "plex": {}, "runtime": {}}
+
+
+def _mapping(mid="MAP-01", src_pl="L1", dst_pl="T1", membership="managed_only", order="ignore"):
+    return {
+        "id": mid,
+        "source": {"provider": "TRAKT", "instance": "default", "playlist_id": src_pl},
+        "target": {"provider": "PLEX", "instance": "default", "playlist_id": dst_pl},
+        "targets": [{"provider": "PLEX", "instance": "default", "playlist_id": dst_pl}],
+        "membership": membership,
+        "order": order,
+        "enabled": True,
+    }
+
+
+def _providers(src_pl, dst_pl):
+    return {"TRAKT": FakeOps("TRAKT", src_pl), "PLEX": FakeOps("PLEX", dst_pl)}
+
+
+def test_managed_only_preserves_manual_items(config_base):
+    src = {"L1": {"name": "src", "items": [_movie(1), _movie(2)]}}
+    dst = {"T1": {"name": "dst", "items": [_movie(1), _movie(3)]}}
+    provs = _providers(src, dst)
+
+    r1 = R.run_mapping(_cfg(), _mapping(), providers=provs)
+    assert r1["added"] == 1
+    assert {canonical_key(m) for m in dst["T1"]["items"]} == {"tmdb:1", "tmdb:2", "tmdb:3"}
+
+    src["L1"]["items"] = [_movie(1)]
+    r2 = R.run_mapping(_cfg(), _mapping(), providers=provs)
+    assert r2["removed"] == 1
+    assert {canonical_key(m) for m in dst["T1"]["items"]} == {"tmdb:1", "tmdb:3"}
+
+
+def test_direct_mapping_matches_items_by_any_shared_external_id(config_base):
+    src = {"L1": {"name": "src", "items": [_movie_ids(1, {"tmdb": "1", "imdb": "tt0000001"})]}}
+    dst = {"T1": {"name": "dst", "items": [_movie_ids(1, {"imdb": "tt0000001"})]}}
+    provs = _providers(src, dst)
+
+    res = R.run_mapping(_cfg(), _mapping(), providers=provs)
+
+    assert res["added"] == 0
+    assert provs["PLEX"].calls == []
+
+
+def test_mirror_removes_extras(config_base):
+    src = {"L1": {"name": "src", "items": [_movie(1), _movie(2)]}}
+    dst = {"T1": {"name": "dst", "items": [_movie(1), _movie(3)]}}
+    provs = _providers(src, dst)
+    res = R.run_mapping(_cfg(), _mapping(membership="mirror"), providers=provs)
+    assert res["added"] == 1 and res["removed"] == 1
+    assert res["manual_affected"] is True
+    assert {canonical_key(m) for m in dst["T1"]["items"]} == {"tmdb:1", "tmdb:2"}
+
+
+def test_multiple_mappings_isolated(config_base):
+    src = {"L1": {"name": "s1", "items": [_movie(1)]}, "L2": {"name": "s2", "items": [_movie(9)]}}
+    dst = {"T1": {"name": "d1", "items": []}, "T2": {"name": "d2", "items": []}}
+    provs = _providers(src, dst)
+
+    R.run_mapping(_cfg(), _mapping("MAP-01", "L1", "T1"), providers=provs)
+    R.run_mapping(_cfg(), _mapping("MAP-02", "L2", "T2"), providers=provs)
+
+    assert R.load_baseline(_mapping("MAP-01", "L1", "T1")) == {"tmdb:1"}
+    assert R.load_baseline(_mapping("MAP-02", "L2", "T2")) == {"tmdb:9"}
+
+
+def test_dry_run_no_mutation(config_base):
+    src = {"L1": {"name": "src", "items": [_movie(1), _movie(2)]}}
+    dst = {"T1": {"name": "dst", "items": [_movie(1)]}}
+    provs = _providers(src, dst)
+    res = R.run_mapping(_cfg(), _mapping(), providers=provs, dry_run=True)
+    assert res["dry_run"] is True and res["planned_additions"] == 1
+    assert provs["PLEX"].calls == []
+    assert len(dst["T1"]["items"]) == 1
+
+
+def test_ordering_idempotent(config_base):
+    src = {"L1": {"name": "src", "items": [_movie(2), _movie(1)]}}
+    dst = {"T1": {"name": "dst", "items": [_movie(1), _movie(2)]}}
+    provs = _providers(src, dst)
+    m = _mapping(order="preserve")
+    r1 = R.run_mapping(_cfg(), m, providers=provs)
+    assert r1["reordered"] > 0
+    assert [canonical_key(x) for x in dst["T1"]["items"]] == ["tmdb:2", "tmdb:1"]
+    r2 = R.run_mapping(_cfg(), m, providers=provs)
+    assert r2["reordered"] == 0
+
+
+def test_smart_target_fails_before_writes(config_base):
+    src = {"L1": {"name": "src", "items": [_movie(1)]}}
+    dst = {"T1": {"name": "dst", "items": [], "smart": True}}
+    provs = _providers(src, dst)
+    with pytest.raises(R.PlaylistRunError):
+        R.run_mapping(_cfg(), _mapping(), providers=provs)
+    assert provs["PLEX"].calls == []
+
+
+def test_missing_target_playlist_fails(config_base):
+    src = {"L1": {"name": "src", "items": [_movie(1)]}}
+    dst = {"T1": {"name": "dst", "items": []}}
+    provs = _providers(src, dst)
+    with pytest.raises(R.PlaylistRunError):
+        R.run_mapping(_cfg(), _mapping(dst_pl="NOPE"), providers=provs)
+
+
+def test_scope_key_isolates_by_mapping_and_endpoints():
+    a = R.scope_key(_mapping("MAP-01", "L1", "T1"))
+    b = R.scope_key(_mapping("MAP-01", "L1", "T2"))
+    c = R.scope_key(_mapping("MAP-02", "L1", "T1"))
+    assert a != b and a != c

--- a/tests/test_playlists_service.py
+++ b/tests/test_playlists_service.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cw_platform.id_map import canonical_key
+from cw_platform.playlists import PlaylistItem, PlaylistResource, PlaylistSnapshot
+from cw_platform import playlists_runner as runner
+from services import playlists as svc
+
+
+class FakeOps:
+    def __init__(self, name: str, playlists: dict[str, dict[str, Any]], reorder: bool = True):
+        self._name = name
+        self.pl = playlists
+        self.reorder = reorder
+        self.calls: list[Any] = []
+
+    def name(self) -> str:
+        return self._name
+
+    def label(self) -> str:
+        return self._name.title()
+
+    def capabilities(self) -> dict[str, Any]:
+        return {"playlists": {"reorder": self.reorder}}
+
+    def is_configured(self, cfg) -> bool:
+        return True
+
+    def _res(self, pid: str) -> PlaylistResource:
+        return PlaylistResource(provider=self._name, id=pid, name=self.pl[pid].get("name") or pid,
+                                can_add=True, can_remove=True, can_reorder=self.reorder)
+
+    def list_playlist_resources(self, cfg, *, instance=None):
+        return [self._res(p) for p in self.pl]
+
+    def get_playlist_snapshot(self, cfg, playlist_id, *, instance=None):
+        d = self.pl[playlist_id]
+        items = [PlaylistItem.from_media(m, position=i) for i, m in enumerate(d["items"])]
+        return PlaylistSnapshot(resource=self._res(playlist_id), items=items)
+
+    def create_playlist(self, cfg, name, *, media_type=None, items=None, instance=None, dry_run=False):
+        return PlaylistResource(provider=self._name, id="new", name=name)
+
+    def add_playlist_items(self, cfg, playlist_id, items, *, instance=None, dry_run=False):
+        self.calls.append(("add", playlist_id))
+        d = self.pl[playlist_id]
+        existing = {canonical_key(m) for m in d["items"]}
+        conf = []
+        for it in items:
+            k = canonical_key(it)
+            if k not in existing:
+                d["items"].append(dict(it))
+                existing.add(k)
+                conf.append(k)
+        return {"ok": True, "count": len(conf), "unresolved": [], "confirmed_keys": conf}
+
+    def remove_playlist_items(self, cfg, playlist_id, items, *, instance=None, dry_run=False):
+        self.calls.append(("remove", playlist_id))
+        d = self.pl[playlist_id]
+        want = {canonical_key(x) for x in items}
+        conf = [canonical_key(m) for m in d["items"] if canonical_key(m) in want]
+        d["items"] = [m for m in d["items"] if canonical_key(m) not in want]
+        return {"ok": True, "count": len(conf), "unresolved": [], "confirmed_keys": conf}
+
+    def reorder_playlist_items(self, cfg, playlist_id, ordered_keys, *, instance=None, dry_run=False):
+        self.calls.append(("reorder", playlist_id))
+        return {"ok": True, "reordered": len(ordered_keys), "count": len(ordered_keys)}
+
+
+def _movie(n: int) -> dict[str, Any]:
+    return {"type": "movie", "title": f"M{n}", "ids": {"tmdb": str(n)}}
+
+
+@pytest.fixture
+def fake_providers(monkeypatch):
+    src = {"L1": {"name": "src1", "items": [_movie(1), _movie(2)]}, "L2": {"name": "src2", "items": [_movie(9)]}}
+    dst = {"T1": {"name": "dst1", "items": []}, "T2": {"name": "dst2", "items": []}}
+    provs = {"TRAKT": FakeOps("TRAKT", src), "PLEX": FakeOps("PLEX", dst)}
+    monkeypatch.setattr(svc, "_providers", lambda: provs)
+    monkeypatch.setattr(runner, "_providers", lambda: provs)
+    monkeypatch.setattr(svc, "_save", lambda cfg: None)
+    return provs
+
+
+def _cfg():
+    return {
+        "trakt": {"client_id": "x", "access_token": "y"},
+        "plex": {"account_token": "z"},
+        "runtime": {},
+        "playlists": {"endpoints": [], "mappings": []},
+        "pairs": [
+            {"id": "p1", "source": "TRAKT", "target": "PLEX", "source_instance": "default",
+             "target_instance": "default", "mode": "one-way", "enabled": True,
+             "features": {"playlists": {"enable": True, "mappings": []}}},
+        ],
+    }
+
+
+def _seed_endpoints(cfg):
+    e1 = svc.upsert_endpoint(cfg, {"name": "Trakt src", "provider": "TRAKT", "instance": "default", "playlist_id": "L1"})
+    e2 = svc.upsert_endpoint(cfg, {"name": "Plex dst", "provider": "PLEX", "instance": "default", "playlist_id": "T1"})
+    return e1["endpoint"]["id"], e2["endpoint"]["id"]
+
+
+def test_endpoints_and_mapping_ids(config_base, fake_providers):
+    cfg = _cfg()
+    e1, e2 = _seed_endpoints(cfg)
+    assert e1 == "EP-01" and e2 == "EP-02"
+    m = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": [e2]})
+    assert m["ok"] and m["created"] and m["mapping"]["id"] == "MAP-01"
+    assert m["pair_id"].startswith("pair_playlist_")
+    pair = next(p for p in cfg["pairs"] if p["id"] == m["pair_id"])
+    assert pair["source"] == "TRAKT"
+    assert pair["target"] == "PLEX"
+    assert pair["features"]["playlists"]["mappings"] == ["MAP-01"]
+    assert pair["features"]["playlists"]["managed_by"] == "playlists"
+    maps = svc.list_mappings(cfg)
+    assert len(maps) == 1
+    assert maps[0]["source"]["provider"] == "TRAKT" and maps[0]["target"]["provider"] == "PLEX"
+    assert maps[0]["assigned_pair"] == m["pair_id"]
+
+
+def test_endpoint_name_is_required_and_short(config_base, fake_providers):
+    cfg = _cfg()
+    missing = svc.upsert_endpoint(cfg, {"name": "", "provider": "TRAKT", "instance": "default", "playlist_id": "L1"})
+    assert missing["ok"] is False and "required" in missing["error"]
+    long = svc.upsert_endpoint(cfg, {"name": "VeryLongName", "provider": "TRAKT", "instance": "default", "playlist_id": "L1"})
+    assert long["ok"] is False and "10 characters" in long["error"]
+    bad = svc.upsert_endpoint(cfg, {"name": "Bad/Name", "provider": "TRAKT", "instance": "default", "playlist_id": "L1"})
+    assert bad["ok"] is False and "unsupported" in bad["error"]
+    bad_start = svc.upsert_endpoint(cfg, {"name": "$Bad", "provider": "TRAKT", "instance": "default", "playlist_id": "L1"})
+    assert bad_start["ok"] is False and "letter or number" in bad_start["error"]
+
+
+def test_created_playlist_name_is_limited_and_safe(config_base, fake_providers):
+    cfg = _cfg()
+    long = svc.upsert_endpoint(cfg, {"name": "NewList", "provider": "TRAKT", "instance": "default", "create": True, "create_name": "This Playlist Name Is Too Long"})
+    assert long["ok"] is False and "20 characters" in long["error"]
+    bad = svc.upsert_endpoint(cfg, {"name": "NewList", "provider": "TRAKT", "instance": "default", "create": True, "create_name": "Bad/List"})
+    assert bad["ok"] is False and "unsupported" in bad["error"]
+    ok = svc.upsert_endpoint(cfg, {"name": "NewList", "provider": "TRAKT", "instance": "default", "create": True, "create_name": "Weekend Movies"})
+    assert ok["ok"] is True
+
+
+def test_mapping_validation(config_base, fake_providers):
+    cfg = _cfg()
+    e1, e2 = _seed_endpoints(cfg)
+    ok, _ = svc.validate_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": [e2]})
+    assert ok
+    bad, why = svc.validate_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": [e1]})
+    assert not bad and "differ" in why
+    bad2, why2 = svc.validate_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": ["EP-99"]})
+    assert not bad2
+    bad3, why3 = svc.validate_mapping(cfg, {"name": "", "source_endpoint": e1, "target_endpoints": [e2]})
+    assert not bad3 and "required" in why3
+    bad4, why4 = svc.validate_mapping(cfg, {"name": "LongMapName", "source_endpoint": e1, "target_endpoints": [e2]})
+    assert not bad4 and "10 characters" in why4
+    bad5, why5 = svc.validate_mapping(cfg, {"name": "Bad/Map", "source_endpoint": e1, "target_endpoints": [e2]})
+    assert not bad5 and "unsupported" in why5
+
+
+def test_preserve_order_rejected_when_target_not_reorderable(config_base, monkeypatch):
+    src = {"L1": {"name": "s", "items": [_movie(1)]}}
+    dst = {"T1": {"name": "d", "items": []}}
+    provs = {"TRAKT": FakeOps("TRAKT", src), "PLEX": FakeOps("PLEX", dst, reorder=False)}
+    monkeypatch.setattr(svc, "_providers", lambda: provs)
+    monkeypatch.setattr(runner, "_providers", lambda: provs)
+    monkeypatch.setattr(svc, "_save", lambda c: None)
+    cfg = _cfg()
+    e1, e2 = _seed_endpoints(cfg)
+    res = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": [e2], "order": "preserve"})
+    assert res["ok"] is False and "ordering" in res["error"]
+    assert svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": [e2], "order": "ignore"})["ok"]
+
+
+def test_preserve_order_uses_endpoint_reorderability(config_base, fake_providers):
+    cfg = _cfg()
+    e1, e2 = _seed_endpoints(cfg)
+    for ep in cfg["playlists"]["endpoints"]:
+        if ep["id"] == e2:
+            ep["can_reorder"] = False
+
+    res = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": [e2], "order": "preserve"})
+    assert res["ok"] is False and "ordering" in res["error"]
+
+
+def test_preview_performs_no_writes(config_base, fake_providers):
+    cfg = _cfg()
+    e1, e2 = _seed_endpoints(cfg)
+    mid = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": [e2]})["mapping"]["id"]
+    prev = svc.preview_mapping(cfg, mid)
+    assert prev["ok"] and prev["preview"]["planned_additions"] == 2
+    assert fake_providers["PLEX"].calls == []
+
+
+def test_run_only_selected_mapping(config_base, fake_providers):
+    cfg = _cfg()
+    e1 = svc.upsert_endpoint(cfg, {"name": "s1", "provider": "TRAKT", "instance": "default", "playlist_id": "L1"})["endpoint"]["id"]
+    e2 = svc.upsert_endpoint(cfg, {"name": "d1", "provider": "PLEX", "instance": "default", "playlist_id": "T1"})["endpoint"]["id"]
+    e3 = svc.upsert_endpoint(cfg, {"name": "s2", "provider": "TRAKT", "instance": "default", "playlist_id": "L2"})["endpoint"]["id"]
+    e4 = svc.upsert_endpoint(cfg, {"name": "d2", "provider": "PLEX", "instance": "default", "playlist_id": "T2"})["endpoint"]["id"]
+    m1 = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": [e2]})["mapping"]["id"]
+    svc.upsert_mapping(cfg, {"name": "Map2", "source_endpoint": e3, "target_endpoints": [e4]})
+
+    out = svc.run_mapping(cfg, m1)
+    assert out["ok"] and out["result"]["added"] == 2
+    assert ("add", "T1") in fake_providers["PLEX"].calls
+    assert ("add", "T2") not in fake_providers["PLEX"].calls
+
+
+def test_provider_count_summary_merges_endpoint_and_mapping_counts(config_base, fake_providers):
+    cfg = _cfg()
+    e1, e2 = _seed_endpoints(cfg)
+    mid = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": [e2]})["mapping"]["id"]
+    before = svc.provider_count_summary(cfg)
+    assert before["providers"]["trakt"] == 2
+    assert before["providers"].get("plex", 0) == 0
+
+    out = svc.run_mapping(cfg, mid)
+    assert out["ok"] and out["result"]["added"] == 2
+    after = svc.provider_count_summary(cfg)
+    assert after["providers"]["trakt"] == 2
+    assert after["providers"]["plex"] == 2
+    assert after["providers_instances"]["plex"]["default"] == 2
+
+
+def test_mappings_for_pair_compat_and_one_pair(config_base, fake_providers):
+    cfg = _cfg()
+    e1, e2 = _seed_endpoints(cfg)
+    r1 = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": [e2]})
+    m1 = r1["mapping"]["id"]
+    m2 = svc.upsert_mapping(cfg, {"name": "Map2", "source_endpoint": e1, "target_endpoints": [e2]})["mapping"]["id"]
+
+    res = svc.mappings_for_pair(cfg, "p1")
+    assert {m["id"] for m in res["mappings"]} == set()
+    generated = svc.mappings_for_pair(cfg, r1["pair_id"])
+    assert {m["id"] for m in generated["mappings"]} == {m1}
+
+    cfg["pairs"].append({"id": "p2", "source": "TRAKT", "target": "PLEX", "source_instance": "default",
+                         "target_instance": "default", "mode": "one-way", "enabled": True,
+                         "features": {"playlists": {"enable": True, "mappings": [m2]}}})
+    res2 = svc.mappings_for_pair(cfg, "p1")
+    assert {m["id"] for m in res2["mappings"]} == set()
+
+
+def test_mapping_delete_removes_generated_pair(config_base, fake_providers):
+    cfg = _cfg()
+    e1, e2 = _seed_endpoints(cfg)
+    res = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": [e2]})
+    mid = res["mapping"]["id"]
+    pair_id = res["pair_id"]
+    assert any(p["id"] == pair_id for p in cfg["pairs"])
+
+    deleted = svc.delete_mapping(cfg, mid)
+    assert deleted["ok"]
+    assert not any(p.get("id") == pair_id for p in cfg["pairs"])
+
+
+def test_list_mappings_repairs_orphan_mapping_pair(config_base, fake_providers):
+    cfg = _cfg()
+    e1, e2 = _seed_endpoints(cfg)
+    cfg["playlists"]["mappings"].append({
+        "id": "MAP-99",
+        "name": "Legacy orphan",
+        "source_endpoint": e1,
+        "target_endpoints": [e2],
+        "ruleset_id": "",
+        "membership": "managed_only",
+        "order": "ignore",
+        "enabled": True,
+    })
+
+    maps = svc.list_mappings(cfg)
+    repaired = next(m for m in maps if m["id"] == "MAP-99")
+    assert repaired["assigned_pair"].startswith("pair_playlist_")
+    pair = next(p for p in cfg["pairs"] if p["id"] == repaired["assigned_pair"])
+    assert pair["features"]["playlists"]["mappings"] == ["MAP-99"]
+
+
+def test_endpoint_edit_refreshes_generated_pair(config_base, fake_providers):
+    cfg = _cfg()
+    e1, e2 = _seed_endpoints(cfg)
+    res = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": [e2]})
+    pair_id = res["pair_id"]
+
+    upd = svc.upsert_endpoint(cfg, {"id": e2, "name": "Plex dst", "provider": "PLEX", "instance": "second", "playlist_id": "T1"})
+    assert upd["ok"]
+    pair = next(p for p in cfg["pairs"] if p["id"] == pair_id)
+    assert pair["target_instance"] == "second"

--- a/tests/test_playlists_ui.py
+++ b/tests/test_playlists_ui.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def test_index_html_registers_playlists_page():
+    from ui_frontend import get_index_html
+
+    html = get_index_html()
+    assert 'id="tab-playlists"' in html
+    assert 'id="page-playlists"' in html
+
+
+def test_core_js_routes_playlists_tab():
+    core = (REPO / "assets" / "helpers" / "core.js").read_text(encoding="utf-8")
+    assert '"/assets/js/playlists.js"' in core
+    assert 'byId("page-playlists")' in core
+    assert '"playlists"' in core
+
+
+def test_playlists_assets_exist():
+    assert (REPO / "assets" / "js" / "playlists.js").is_file()
+
+
+def test_playlists_page_is_modal_first_overview():
+    js = (REPO / "assets" / "js" / "playlists.js").read_text(encoding="utf-8")
+    assert "Playlist endpoints" in js
+    assert "Mappings" in js
+    assert "Activity overview" in js
+    assert "+ New endpoint" in js
+    assert "+ New mapping" in js
+    assert "Manage rulesets" in js
+    assert 'id="pl-rulesets-summary"' not in js
+    assert 'id="pl-manage-rulesets"' not in js
+    assert 'id="pl-refresh"' not in js
+    assert 'data-action="rulesets-manage"' not in js
+    assert "function renderRulesetSummary" not in js
+    assert 'id="pl-map-manage-rulesets"' in js
+    assert "pl-ep-editor" not in js
+    assert "pl-map-editor" not in js
+    assert '<header class="pl-header">' not in js
+    assert "#page-playlists .pl-header{position:static;" in js
+    assert "padding:18px 20px" in js
+    assert "#page-playlists .pl-title{margin:0;font-size:28px;line-height:1.1;font-weight:850" in js
+    assert "#page-playlists .pl-sub{margin-top:6px;color:var(--pl-soft);font-size:16px" in js
+    assert "#page-playlists .pl-header .pl-btn{min-height:0;padding:10px 14px;border-radius:10px;font-size:14px;font-weight:850;gap:8px}" in js
+    assert '<button class="pl-btn" id="pl-new-endpoint"><span class="material-symbols-rounded" aria-hidden="true">add</span>New endpoint</button>' in js
+    assert '<button class="pl-btn" id="pl-new-mapping"' in js
+    assert "--pl-shell-bg" in js
+    assert "--pl-shell-bg:#171d26" in js
+    assert 'html[data-cw-theme="flat-dark"] #page-playlists' in js
+    assert 'html[data-cw-theme="flat-light"] #page-playlists' in js
+
+
+def test_playlists_modals_cover_create_edit_delete_flows():
+    js = (REPO / "assets" / "js" / "playlists.js").read_text(encoding="utf-8")
+    assert "function openEndpointModal" in js
+    assert "function openMappingModal" in js
+    assert "function openRulesetManager" in js
+    assert "function openRulesetForm" in js
+    assert "function openEndpointDelete" in js
+    assert "function openMappingDelete" in js
+    assert "function openRulesetDelete" in js
+    assert "Discard unsaved changes?" in js
+    assert "Source and destination endpoints must be different." in js
+    assert "Built in rulesets cannot be edited." in js
+    assert "Built in rulesets cannot be deleted." in js
+    assert "mappingDraft.ruleset_id" in js
+    assert 'runPair: (id) => request("/api/run"' in js
+    assert "m.assigned_pair" in js
+    assert "const NAME_MAX = 10" in js
+    assert "const PLAYLIST_NAME_MAX = 20" in js
+    assert "SAFE_NAME_CHARS" in js
+    assert "function bindNameValidation" in js
+    assert "function nameFieldError" in js
+    assert "function playlistNameError" in js
+    assert "must be ${max} characters or fewer" in js
+    assert "safeNameError(name, label, NAME_MAX)" in js
+    assert "safeNameError(name, \"New playlist name\", PLAYLIST_NAME_MAX)" in js
+    assert "can only use letters, numbers, spaces" in js
+    assert "maxlength=\"${PLAYLIST_NAME_MAX}\"" in js
+    assert 'id="pl-ep-type"' not in js
+    assert "media_type: mediaType" not in js
+    assert 'placeholder="Endpoint name"' in js
+    assert 'placeholder="Mapping name"' in js
+    assert 'placeholder="Weekend"' not in js
+    assert 'placeholder="Weekend movies"' not in js
+    assert "pl-ep-name-error" in js
+    assert "pl-ep-create-name-error" in js
+    assert "pl-map-name-error" in js
+    assert "pl-rs-name-error" in js
+
+
+def test_playlist_actions_use_partial_overview_refresh():
+    js = (REPO / "assets" / "js" / "playlists.js").read_text(encoding="utf-8")
+    assert "async function refreshOverview" in js
+    assert "function refreshSection" in js
+    assert "function updateMappingActions" in js
+    assert 'refreshOverview(["mappings", "activity"])' in js
+    assert "await reload(true)" not in js
+
+
+def test_playlists_initial_load_uses_page_shell_and_section_skeletons():
+    js = (REPO / "assets" / "js" / "playlists.js").read_text(encoding="utf-8")
+    assert "loaded: false" in js
+    assert "loading: false" in js
+    assert "function renderSkeleton" in js
+    assert "state.loading && !state.loaded" in js
+    assert "state.loading = true" in js
+    assert "Fetching endpoints, mappings, rulesets and activity" not in js
+
+
+def test_playlists_provider_and_experimental_banners():
+    js = (REPO / "assets" / "js" / "playlists.js").read_text(encoding="utf-8")
+    assert "PLAYLIST_COMPATIBLE_PROVIDERS" in js
+    assert '["PLEX", "TRAKT", "MDBLIST", "JELLYFIN", "EMBY", "PUBLICMETADB", "SIMKL"]' in js
+    assert "Playlists need at least one compatible provider" in js
+    assert "Plex, Trakt, MDBList, Jellyfin, Emby, PublicMetaDB or SIMKL" in js
+    assert "Playlists are highly experimental and cause issues" in js
+    assert "SIMKL Custom Lists are not supported" in js
+    assert "pl-ep-simkl-warning" in js
+    assert "pl-map-simkl-warning" in js
+    assert "data-action=\"open-connections\"" in js
+    assert "function openConnections" in js
+
+
+def test_endpoint_and_mapping_tables_use_compact_icon_actions():
+    js = (REPO / "assets" / "js" / "playlists.js").read_text(encoding="utf-8")
+    assert "function endpointRef" in js
+    assert "function mappingTargetRefs" in js
+    assert "function actionButton" in js
+    assert ".pl-action-btn.sync" in js
+    assert ".pl-action-btn.edit" in js
+    assert ".pl-action-btn.delete" in js
+    assert '<select id="pl-map-targets">${selectOptions(endpointOpts, target)}</select>' in js
+    assert '<select id="pl-map-targets" multiple' not in js
+    assert 'target_endpoints: val("#pl-map-targets", root) ? [val("#pl-map-targets", root)] : []' in js
+    assert 'data-action="endpoint-clone"' not in js
+    assert 'data-action="mapping-clone"' not in js
+    assert "assigned_pair_label" not in js
+    assert '<th aria-label="Actions"></th>' in js
+    assert '<th>Actions</th></tr></thead>' in js
+
+
+def test_playlist_modals_use_styled_scrollbars_and_muted_selection():
+    js = (REPO / "assets" / "js" / "playlists.js").read_text(encoding="utf-8")
+    assert "--pl-scroll-track" in js
+    assert "--pl-scroll-thumb" in js
+    assert "--pl-select-active-bg" in js
+    assert ".pl-dialog-body::-webkit-scrollbar" in js
+    assert ".pl-dialog .pl-table-wrap::-webkit-scrollbar" in js
+    assert ".pl-field select[multiple]::-webkit-scrollbar" in js
+    assert "max-height:min(34vh,260px)" in js
+    assert "box-shadow:inset 3px 0 0 var(--pl-green)" in js
+    assert "#4167b7" not in js
+
+
+def test_pair_overlay_playlist_manage_button_requires_enabled_playlist_feature():
+    js = (REPO / "assets" / "js" / "connections.pairs.overlay.js").read_text(encoding="utf-8")
+    assert "const hasPlaylistMappings" in js
+    assert "window.cxOpenPlaylistMappingsForPair = openPlaylistMappingsForPair" in js
+    assert '${hasPlaylistMappings(f.playlists) ? `<button class="icon-btn" data-tip="Manage playlist mappings"' in js
+    assert '${f.playlists ? `<button class="icon-btn" data-tip="Manage playlist mappings"' not in js
+    assert "window.showTab(\"playlists\")" in js
+    assert "api?.openMappingForPair" in js
+    assert "returnToSyncPairs: true" in js
+
+
+def test_playlists_module_exposes_pair_mapping_modal_entrypoint():
+    js = (REPO / "assets" / "js" / "playlists.js").read_text(encoding="utf-8")
+    assert "pairMappings: (id) => request(`${BASE}/pairs/${encodeURIComponent(id)}/mappings`)" in js
+    assert "async function openMappingForPair" in js
+    assert "function returnToSyncPairsOverview" in js
+    assert 'window.showTab("settings")' in js
+    assert 'window.cwSettingsSelect("sync")' in js
+    assert "openMappingModal({ mapping, trigger, onDone:" in js
+    assert "returnToSyncPairs ? returnToSyncPairsOverview : null" in js
+    assert "mappingDone: ctx.opts.onDone" in js
+    assert "window.Playlists = { mount: init, openMappingForPair }" in js
+
+
+def test_main_hub_treats_playlists_as_first_class_feature():
+    main = (REPO / "assets" / "js" / "main.js").read_text(encoding="utf-8")
+    css = (REPO / "assets" / "crosswatch.css").read_text(encoding="utf-8")
+    assert '["playlists", "queue_music"]' in main
+    assert "progress: true, playlists: true" in main
+    assert 'const getDisplayFeats = () => FEATS' in main
+    assert 'enabled.progress ? "progress" : "playlists"' not in main
+    assert "lanes-count-${displayFeats.length}" in main
+    assert ".lanes.lanes-count-5{grid-template-columns:repeat(6,minmax(0,1fr))}" in css
+    assert ".lanes.lanes-count-5>.lane:nth-child(-n+2){grid-column:span 3}" in css
+    assert ".lanes.lanes-count-5>.lane:nth-child(n+3){grid-column:span 2}" in css
+
+
+def test_insights_settings_enables_playlist_statistics():
+    insights = (REPO / "assets" / "js" / "insights.js").read_text(encoding="utf-8")
+    modal = (REPO / "assets" / "js" / "modals" / "insight-settings" / "index.js").read_text(encoding="utf-8")
+    assert "playlists: f.playlists !== false" in insights
+    assert "playlists: f.playlists !== false" in modal
+    assert "Show playlist sync tiles." in modal
+    assert "Not supported currently." not in modal
+    assert "key === \"playlists\"" not in modal
+    assert 'seg.dataset.count = String(Math.max(1, _visibleFeats.length))' in insights
+
+
+def test_insights_playlist_statistics_use_endpoint_counts():
+    api = (REPO / "api" / "insightAPI.py").read_text(encoding="utf-8")
+    svc = (REPO / "services" / "playlists.py").read_text(encoding="utf-8")
+    assert "def provider_count_summary" in svc
+    assert "playlists_svc.provider_count_summary(cfg)" in api
+    assert "def _playlist_endpoint_provider_counts" not in api
+    assert "def _playlist_mapping_provider_counts" not in api
+    assert 'providers_by_feature.setdefault("playlists"' in api
+    assert 'providers_instances_by_feature.setdefault("playlists"' in api
+
+
+def test_playlist_runner_emits_live_summary_events():
+    runner = (REPO / "cw_platform" / "playlists_runner.py").read_text(encoding="utf-8")
+    assert '"apply:add:done"' in runner
+    assert '"apply:remove:done"' in runner
+    assert '"apply:update:done"' in runner
+    assert 'feature="playlists"' in runner
+    assert "def _spotlight_items" in runner
+
+
+def test_ruleset_modal_uses_guided_visual_builder():
+    js = (REPO / "assets" / "js" / "playlists.js").read_text(encoding="utf-8")
+    assert "RULESET_PRESETS" in js
+    assert "Direct sync" in js
+    assert "Mirror source" in js
+    assert "Split large playlists" in js
+    assert "Merge playlists" in js
+    assert "Limited account sharing" in js
+    assert "function rulesetBuilderHtml" in js
+    assert "function detectRulesetPreset" in js
+    assert "function rulesetPreview" in js
+    assert "function validateRulesetBuilder" in js
+    assert "Readable summary" in js
+    assert "Advanced policies" in js
+    assert "Source item count" in js
+    assert "Split into target lists" in js
+    assert "data-rs-field" in js
+
+
+def test_ruleset_builder_preserves_payload_shape():
+    js = (REPO / "assets" / "js" / "playlists.js").read_text(encoding="utf-8")
+    for key in [
+        "direction",
+        "initial_sync",
+        "read_mode",
+        "write_mode",
+        "membership",
+        "order",
+        "deduplicate",
+        "allocation",
+        "rebalance",
+        "overflow",
+        "per_endpoint_capacity",
+        "aggregate_capacity",
+        "maximum_targets",
+        "track_assignments",
+    ]:
+        assert f"{key}:" in js
+    assert "pl-limit-partition" in js
+    assert "pl-limit-aggregate" in js
+    assert "The current backend only supports blocking overflow." in js
+
+
+def test_playlists_api_routes_registered():
+    from api.playlistsAPI import router
+
+    paths = {r.path for r in router.routes}
+    assert "/api/playlists/providers" in paths
+    assert "/api/playlists/resources" in paths
+    assert "/api/playlists/endpoints" in paths
+    assert "/api/playlists/mappings" in paths
+    assert "/api/playlists/overview" in paths
+    assert "/api/playlists/rulesets" in paths
+    assert "/api/playlists/rulesets/{ruleset_id}" in paths
+    assert "/api/playlists/rulesets/{ruleset_id}/clone" in paths
+    assert "/api/playlists/mappings/{mapping_id}/preview" in paths
+    assert "/api/playlists/mappings/{mapping_id}/run" in paths
+    assert "/api/playlists/pairs/{pair_id}/mappings" in paths

--- a/tests/test_snapshot_prepare_hook.py
+++ b/tests/test_snapshot_prepare_hook.py
@@ -1,0 +1,136 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import pytest
+
+from cw_platform.orchestrator import _snapshots
+from cw_platform.orchestrator._snapshots import (
+    build_snapshots_for_feature,
+    prepare_source_snapshot,
+)
+
+
+class _Ops:
+    def __init__(self, name: str, index: Mapping[str, Any], trace: list[str], *, hook: bool = False):
+        self._name = name
+        self._index = dict(index)
+        self._trace = trace
+        self.prepared: list[tuple[str, dict[str, Any]]] = []
+        if hook:
+            setattr(self, "prepare_source_snapshot", self._prepare)
+
+    def name(self) -> str:
+        return self._name
+
+    def features(self) -> Mapping[str, bool]:
+        return {"history": True}
+
+    def build_index(self, cfg: Mapping[str, Any], *, feature: str) -> Mapping[str, dict[str, Any]]:
+        self._trace.append(f"build:{self._name}")
+        return dict(self._index)
+
+    def _prepare(self, cfg: Mapping[str, Any], *, feature: str, items: Mapping[str, Any]) -> int:
+        self._trace.append(f"prepare:{self._name}")
+        self.prepared.append((feature, dict(items)))
+        return len(items)
+
+
+def _run(providers, *, build_order, on_snapshot, monkeypatch):
+    monkeypatch.setattr(_snapshots, "provider_configured", lambda _cfg, _name: True)
+    return build_snapshots_for_feature(
+        feature="history",
+        config={},
+        providers=providers,
+        snap_cache={},
+        snap_ttl_sec=0,
+        dbg=lambda *a, **k: None,
+        emit_info=lambda _m: None,
+        build_order=build_order,
+        on_snapshot=on_snapshot,
+    )
+
+
+def test_source_is_prepared_before_destination_is_built(monkeypatch: pytest.MonkeyPatch) -> None:
+    trace: list[str] = []
+    item = {
+        "type": "episode",
+        "season": 2,
+        "episode": 4,
+        "ids": {"tvdb": "5057304"},
+        "show_ids": {"tmdb": "42009"},
+    }
+    src = _Ops("SRC", {"tmdb:42009#s02e04": item}, trace)
+    dst = _Ops("DST", {}, trace, hook=True)
+
+    def _on_snapshot(name: str, idx: Mapping[str, Any]) -> None:
+        if name == "SRC":
+            prepare_source_snapshot(dst, config={}, feature="history", items=idx)
+
+    snaps = _run({"SRC": src, "DST": dst}, build_order=["SRC", "DST"], on_snapshot=_on_snapshot, monkeypatch=monkeypatch)
+
+    assert trace == ["build:SRC", "prepare:DST", "build:DST"]
+    assert set(snaps) == {"SRC", "DST"}
+    assert dst.prepared and dst.prepared[0][0] == "history"
+    assert list(dst.prepared[0][1].values())[0]["ids"] == {"tvdb": "5057304"}
+
+
+def test_build_order_is_respected(monkeypatch: pytest.MonkeyPatch) -> None:
+    trace: list[str] = []
+    a = _Ops("A", {}, trace)
+    b = _Ops("B", {}, trace)
+
+    _run({"A": a, "B": b}, build_order=["B", "A"], on_snapshot=None, monkeypatch=monkeypatch)
+
+    assert trace == ["build:B", "build:A"]
+
+
+def test_provider_without_hook_is_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    trace: list[str] = []
+    src = _Ops("SRC", {"k1": {"type": "episode"}}, trace)
+    dst = _Ops("DST", {}, trace)
+
+    assert not hasattr(dst, "prepare_source_snapshot")
+
+    def _on_snapshot(name: str, idx: Mapping[str, Any]) -> None:
+        if name == "SRC":
+            assert prepare_source_snapshot(dst, config={}, feature="history", items=idx) is False
+
+    _run({"SRC": src, "DST": dst}, build_order=["SRC", "DST"], on_snapshot=_on_snapshot, monkeypatch=monkeypatch)
+
+    assert trace == ["build:SRC", "build:DST"]
+
+
+def test_prepare_hook_failure_does_not_break_snapshotting(monkeypatch: pytest.MonkeyPatch) -> None:
+    trace: list[str] = []
+    src = _Ops("SRC", {"k1": {"type": "episode"}}, trace)
+    dst = _Ops("DST", {}, trace, hook=True)
+
+    def _boom(cfg, *, feature, items):
+        raise RuntimeError("hook exploded")
+
+    setattr(dst, "prepare_source_snapshot", _boom)
+
+    def _on_snapshot(name: str, idx: Mapping[str, Any]) -> None:
+        if name == "SRC":
+            assert prepare_source_snapshot(dst, config={}, feature="history", items=idx) is False
+
+    snaps = _run({"SRC": src, "DST": dst}, build_order=["SRC", "DST"], on_snapshot=_on_snapshot, monkeypatch=monkeypatch)
+
+    assert trace == ["build:SRC", "build:DST"]
+    assert set(snaps) == {"SRC", "DST"}
+
+
+def test_empty_source_snapshot_skips_hook(monkeypatch: pytest.MonkeyPatch) -> None:
+    trace: list[str] = []
+    src = _Ops("SRC", {}, trace)
+    dst = _Ops("DST", {}, trace, hook=True)
+
+    def _on_snapshot(name: str, idx: Mapping[str, Any]) -> None:
+        if name == "SRC":
+            assert prepare_source_snapshot(dst, config={}, feature="history", items=idx) is False
+
+    _run({"SRC": src, "DST": dst}, build_order=["SRC", "DST"], on_snapshot=_on_snapshot, monkeypatch=monkeypatch)
+
+    assert dst.prepared == []

--- a/tests/test_twoway_remove_accounting.py
+++ b/tests/test_twoway_remove_accounting.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from cw_platform.id_map import canonical_key
+from cw_platform.orchestrator import _pairs_twoway as twoway
+
+
+WATCHED_AT = "2023-10-12T12:28:00.000Z"
+WATCHED_EPOCH = 1697113680
+
+
+def _ep(n):
+    return {
+        "type": "episode",
+        "title": f"E{n}",
+        "season": 1,
+        "episode": n,
+        "watched_at": WATCHED_AT,
+        "ids": {"tvdb": str(900000 + n)},
+        "show_ids": {"tmdb": "1402", "tvdb": "153021"},
+    }
+
+
+def _key(n):
+    return canonical_key(_ep(n))
+
+
+class _StateStore:
+    def __init__(self, state):
+        self.state = state
+        self.tomb: dict[str, Any] = {"keys": {}}
+
+    def load_state(self):
+        return self.state
+
+    def save_state(self, value):
+        self.state = value
+
+    def load_tomb(self):
+        return self.tomb
+
+    def save_tomb(self, value):
+        self.tomb = value
+
+
+class _Ops:
+    def __init__(self, remove_result):
+        self.removed: list[dict[str, Any]] = []
+        self._remove_result = remove_result
+
+    def add(self, _cfg, items, *, feature, dry_run=False):
+        return {"ok": True, "count": len(items), "confirmed_keys": [], "unresolved": []}
+
+    def remove(self, _cfg, items, *, feature, dry_run=False):
+        lst = [dict(i) for i in items]
+        self.removed.extend(lst)
+        return self._remove_result(lst)
+
+    def update(self, *_a, **_k):
+        return {"ok": True, "count": 0}
+
+    def capabilities(self):
+        return {"history": {"observed_deletes": False}}
+
+
+def _run(monkeypatch, *, count, n_items, remove_result):
+    for name, val in (
+        ("_supports_feature", lambda _o, _f: True),
+        ("_health_feature_ok", lambda _h, _f: True),
+        ("_health_status", lambda _h: "up"),
+        ("_resolve_flags", lambda _f, _s: {"allow_adds": False, "allow_removals": True}),
+        ("_anime_pair_feature_options", lambda *_a, **_k: {"use_anime_mapping": False}),
+        ("_anime_config_with_pair_feature_options", lambda cfg, _o: cfg),
+        ("_index_semantics", lambda *_a, **_k: "full"),
+        ("prev_checkpoint", lambda *_a, **_k: None),
+        ("module_checkpoint", lambda *_a, **_k: None),
+        ("keys_for_feature", lambda *_a, **_k: {}),
+        ("_manual_policy", lambda *_a, **_k: ([], set())),
+        ("_provider_ignore_dropped_enabled", lambda *_a, **_k: False),
+        ("apply_blocklist", lambda _s, items, **_k: list(items)),
+        ("_maybe_block_massdelete", lambda items, **_k: list(items)),
+        ("effective_chunk_size", lambda *_a, **_k: 100),
+        ("load_blackbox_keys", lambda *_a, **_k: set()),
+        ("record_attempts", lambda *_a, **_k: {"ok": True, "count": 0}),
+        ("record_success", lambda *_a, **_k: {"ok": True, "count": 0}),
+    ):
+        monkeypatch.setattr(twoway, name, val)
+
+    recorded: list[dict[str, Any]] = []
+    cleared: list[list[str]] = []
+    monkeypatch.setattr(
+        twoway, "record_unresolved",
+        lambda dst, feature, items, *, hint="": recorded.append({"hint": hint, "items": [dict(i) for i in items]}) or {"ok": True},
+    )
+    monkeypatch.setattr(twoway, "clear_unresolved", lambda dst, feature, keys: cleared.append(list(keys)) or {"ok": True})
+
+    items = {_key(n): _ep(n) for n in range(1, n_items + 1)}
+    monkeypatch.setattr(twoway, "build_snapshots_for_feature", lambda **_k: {"TRAKT": dict(items), "SIMKL": {}})
+
+    state = {"providers": {"SIMKL": {"history": {"baseline": {"items": dict(items)}}}}}
+    store = _StateStore(state)
+    trakt = _Ops(remove_result)
+    ctx = SimpleNamespace(
+        config={"sync": {"include_observed_deletes": False, "blackbox": {"enabled": False}}, "runtime": {}},
+        providers={"TRAKT": trakt, "SIMKL": _Ops(lambda _l: {"ok": True, "count": 0})},
+        emit=lambda *_a, **_k: None,
+        emit_info=lambda *_a, **_k: None,
+        dbg=lambda *_a, **_k: None,
+        dry_run=False,
+        snap_cache={},
+        snap_ttl_sec=0,
+        state_store=store,
+        stats_manual_blocked=0,
+        apply_chunk_pause_ms=0,
+    )
+    result = twoway._two_way_sync(ctx, "TRAKT", "SIMKL", feature="history", fcfg={}, health_map={})
+    return result, trakt, store, recorded, cleared
+
+
+def _tomb_keys(store):
+    return {k for k in (store.tomb.get("keys") or {})}
+
+
+def test_twoway_exact_keys_tombstone_only_confirmed(monkeypatch):
+    confirmed = [canonical_key(_ep(1)), canonical_key(_ep(2))]
+
+    result, trakt, store, recorded, cleared = _run(
+        monkeypatch,
+        count=5,
+        n_items=5,
+        remove_result=lambda lst: {"ok": True, "count": 5, "confirmed_keys": confirmed, "unresolved": []},
+    )
+
+    assert len(trakt.removed) == 5
+    assert result["rem_from_A"] == 2
+
+    tombs = _tomb_keys(store)
+    assert any(canonical_key(_ep(1)) in t for t in tombs)
+    assert not any(canonical_key(_ep(5)) in t for t in tombs)
+
+    assert cleared == [confirmed]
+    assert len(recorded) == 1
+    assert recorded[0]["hint"] == "two:apply:remove:unconfirmed"
+    assert len(recorded[0]["items"]) == 3
+
+
+def test_twoway_ambiguous_partial_tombstones_nothing(monkeypatch):
+    result, trakt, store, recorded, cleared = _run(
+        monkeypatch,
+        count=4,
+        n_items=10,
+        remove_result=lambda lst: {"ok": True, "count": 4, "confirmed_keys": [], "unresolved": []},
+    )
+
+    assert len(trakt.removed) == 10
+    assert result["rem_from_A"] == 0
+    assert _tomb_keys(store) == set()
+    assert cleared == []
+    assert len(recorded) == 1
+    assert len(recorded[0]["items"]) == 10
+
+
+def test_twoway_clean_full_count_without_exact_keys_is_accepted(monkeypatch):
+    result, trakt, store, recorded, cleared = _run(
+        monkeypatch,
+        count=3,
+        n_items=3,
+        remove_result=lambda lst: {"ok": True, "count": 3, "confirmed_keys": [], "unresolved": []},
+    )
+
+    assert result["rem_from_A"] == 3
+    assert len(_tomb_keys(store)) >= 3
+    assert cleared and len(cleared[0]) == 3
+    assert recorded == []


### PR DESCRIPTION
# Pull request

## Change

- Add tests for the playlists model, runner, rulesets, service, orchestration, editor endpoints and page markup.
- Add provider playlist tests for Plex, Trakt, MDBList, Jellyfin, Emby, PublicMetaDB and SIMKL.
- Add SIMKL history tests for anime mapping, cold state, delta merge, remove verification and season zero handling.
- Add tests for the analyzer attention model,

## Why

NA

## Testing

NA

## Issue

Relates to #439
