### PR TITLE
Change: maintenance sync state ownership

### DIFF
--- a/api/maintenanceAPI.py
+++ b/api/maintenanceAPI.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import threading
 from datetime import datetime
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +21,20 @@ _LOG = logging.getLogger("crosswatch.api.maintenance")
 
 router = APIRouter(prefix="/api/maintenance", tags=["maintenance"])
 
+SYNC_STATE_PATTERNS = (
+    "*pair_alias*.json",
+    "*source_alias*.json",
+    "*anime_episode_alias*.json",
+    "*anime_episode_map*.json",
+    "*anime_resolve*.json",
+    "*.unresolved*.json",
+    "*history.cache*.json",
+    "*_history.index*.json",
+    "*watermark*.json",
+    "tombstones.json",
+    "*.tombstones.json",
+)
+
 CW_STATE_KEEP_DIRS = {"id"}
 CW_STATE_KEEP_FILES = {
     "activity_history.json",
@@ -27,6 +42,23 @@ CW_STATE_KEEP_FILES = {
     "auto_remove_seen.json",
     "watchlist_wl_autoremove.json",
 }
+
+
+def _is_sync_state_file(name: str) -> bool:
+    candidate = str(name or "")
+    return any(fnmatch(candidate, pattern) for pattern in SYNC_STATE_PATTERNS)
+
+
+def _sync_state_files() -> list[Path]:
+    _, _, CW_STATE_DIR, *_ = _cw()
+    if not CW_STATE_DIR.exists():
+        return []
+    found: dict[str, Path] = {}
+    for pattern in SYNC_STATE_PATTERNS:
+        for p in CW_STATE_DIR.glob(pattern):
+            if p.is_file() and p.name not in CW_STATE_KEEP_FILES:
+                found[p.name] = p
+    return [found[name] for name in sorted(found)]
 
 
 def _cw() -> tuple[Any, Any, Any, Any, Any, Any]:
@@ -59,7 +91,7 @@ def _clear_cw_state_files() -> list[str]:
                 continue
             continue
         if p.is_file():
-            if p.name in CW_STATE_KEEP_FILES:
+            if p.name in CW_STATE_KEEP_FILES or _is_sync_state_file(p.name):
                 continue
             try:
                 p.unlink(missing_ok=True)
@@ -247,13 +279,16 @@ def maintenance_action_status(action: str) -> dict[str, Any]:
         path = CONFIG_DIR / "state.json"
         usage = _path_usage(path)
         providers, baselines = _sync_state_inventory(path)
+        scoped = _sync_state_files()
+        scoped_usage = _paths_usage([path, *scoped])
         response.update(
             title="Rebuild sync state",
-            note="These provider baselines are removed; the next sync reads fresh provider data.",
+            note="These provider baselines are removed together with pair-scoped history aliases, mapping caches, watermarks and tombstones; the next sync reads fresh provider data and rebuilds translated aliases.",
             metrics=[
                 _metric("Providers", providers),
                 _metric("Feature baselines", baselines),
-                _metric("State storage", usage["bytes"], "bytes"),
+                _metric("Pair mapping files", len(scoped)),
+                _metric("State storage", scoped_usage["bytes"], "bytes"),
                 _metric("Last updated", usage["modified"], "datetime"),
             ],
         )
@@ -264,7 +299,7 @@ def maintenance_action_status(action: str) -> dict[str, Any]:
         retry_files = sum(1 for item in files if any(token in str(item.get("name") or "").lower() for token in retry_names))
         response.update(
             title="Retry provider items",
-            note="Clears provider runtime caches: retry guards, tombstones, phantom records, provider health, plus history, watermark and mapping index caches. Playback and activity files stay untouched.",
+            note="Clears provider runtime caches such as retry guards, phantom records and provider health. Sync aliases, mappings, history indexes, watermarks and tombstones stay untouched.",
             metrics=[
                 _metric("Runtime files", len(files)),
                 _metric("Retry / guard files", retry_files),
@@ -454,7 +489,7 @@ def _scan_provider_cache() -> dict[str, Any]:
     except Exception:
         candidates = []
     for p in candidates:
-        if p.name in CW_STATE_KEEP_FILES:
+        if p.name in CW_STATE_KEEP_FILES or _is_sync_state_file(p.name):
             continue
         if p.is_file():
             files.append(_file_meta(p))
@@ -603,14 +638,20 @@ def clear_state_minimal() -> dict[str, Any]:
     _, CONFIG_DIR, *_ = _cw()
     state_path = CONFIG_DIR / "state.json"
     existed = state_path.exists()
-    before_usage = _path_usage(state_path)
+    scoped = _sync_state_files()
+    before_usage = _paths_usage([state_path, *scoped])
     try:
         state_path.unlink(missing_ok=True)
-        after_usage = _path_usage(state_path)
+        removed_scoped: list[str] = []
+        for p in scoped:
+            if _safe_remove_path(p):
+                removed_scoped.append(p.name)
+        after_usage = _paths_usage([state_path, *_sync_state_files()])
         return {
             "ok": True,
             "path": str(state_path),
             "existed": bool(existed),
+            "removed_sync_state": removed_scoped,
             "summary": _cleanup_summary(before_usage, after_usage),
         }
     except Exception as e:

--- a/assets/css/shell-overrides.css
+++ b/assets/css/shell-overrides.css
@@ -120,7 +120,6 @@ html[data-cw-theme=flat-light] :is(#cw-settings-menu.cw-menu,#cw-about-menu.cw-m
 #page-settings .cw-maint-action-copy strong{font-size:14px;line-height:1.15;color:var(--cw-ov-fg)!important}
 #page-settings .cw-maint-action-copy small{font-size:12px;line-height:1.35;color:var(--cw-ov-soft)!important;font-weight:700;white-space:normal}
 #page-settings .cw-maint-action.backup .cw-maint-action-icon{background:rgba(34,197,94,.11);border-color:rgba(34,197,94,.18);color:#d9fff0}
-#page-settings .cw-maint-action.archive .cw-maint-action-icon{background:rgba(58,165,185,.12);border-color:rgba(58,165,185,.22);color:#dffbff}
 #page-settings .cw-maint-action.tools .cw-maint-action-icon{background:rgba(125,134,201,.14);border-color:rgba(125,134,201,.22);color:#edf2ff}
 #page-settings .cw-maint-action.restart .cw-maint-action-icon{background:rgba(255,92,112,.10);border-color:rgba(255,120,138,.22);color:#ffdce2}
 #page-settings .cw-maint-action.restart{border-color:rgba(255,120,138,.18)!important}

--- a/assets/js/modals/maintenance/index.js
+++ b/assets/js/modals/maintenance/index.js
@@ -175,13 +175,6 @@ const GROUPS = [
     keys: ["state", "cache"],
   },
   {
-    id: "archive",
-    icon: "inventory_2",
-    title: "Archive & Recovery",
-    desc: "Manage CW Tracker state, snapshots and archive files.",
-    keys: ["tracker"],
-  },
-  {
     id: "playback",
     icon: "play_circle",
     title: "Playback",
@@ -201,6 +194,13 @@ const GROUPS = [
     title: "Events",
     desc: "Check, optimize and rebuild the event history archive.",
     keys: ["events-health", "events-optimize", "events-rebuild"],
+  },
+  {
+    id: "archive",
+    icon: "inventory_2",
+    title: "Archive & Recovery",
+    desc: "Manage CW Tracker state, snapshots and archive files.",
+    keys: ["tracker"],
   },
   {
     id: "captures",
@@ -325,13 +325,6 @@ export default {
                   </button>
                   <button type="button" class="category-run-btn" data-run-group="sync" aria-label="Run all Sync tools">Run</button>
                 </div>
-                <div class="side-nav-item" data-group="archive">
-                  <button type="button" class="side-nav-btn" data-target="cxm-group-archive">
-                    <span class="material-symbols-rounded" aria-hidden="true">inventory_2</span>
-                    <span>Archive & Recovery</span>
-                  </button>
-                  <button type="button" class="category-run-btn" data-run-group="archive" aria-label="Run all Archive and Recovery tools">Run</button>
-                </div>
                 <div class="side-nav-item" data-group="playback">
                   <button type="button" class="side-nav-btn" data-target="cxm-group-playback">
                     <span class="material-symbols-rounded" aria-hidden="true">play_arrow</span>
@@ -351,6 +344,13 @@ export default {
                     <span class="material-symbols-rounded" aria-hidden="true">history</span>
                     <span>Events</span>
                   </button>
+                </div>
+                <div class="side-nav-item" data-group="archive">
+                  <button type="button" class="side-nav-btn" data-target="cxm-group-archive">
+                    <span class="material-symbols-rounded" aria-hidden="true">inventory_2</span>
+                    <span>Archive & Recovery</span>
+                  </button>
+                  <button type="button" class="category-run-btn" data-run-group="archive" aria-label="Run all Archive and Recovery tools">Run</button>
                 </div>
                 <div class="side-nav-item" data-group="captures">
                   <button type="button" class="side-nav-btn" data-target="cxm-group-captures">

--- a/assets/js/modals/maintenance/styles.css
+++ b/assets/js/modals/maintenance/styles.css
@@ -25,13 +25,13 @@
 .cw-maint .sidebar-label { margin: 10px 9px 4px; color: var(--maint-muted); font-size: 10px; font-weight: 850; letter-spacing: .1em; text-transform: uppercase; }
 .cw-maint .side-nav { --nav-accent: var(--maint-accent); display: grid; gap: 3px; }
 .cw-maint .side-nav-item { --nav-accent: var(--maint-accent); min-width: 0; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 0; }
-.cw-maint .side-nav-item[data-group="archive"] { --nav-accent: var(--maint-good); }
+.cw-maint .side-nav-item:is([data-group="archive"], [data-group="events"], [data-group="captures"]) { --nav-accent: var(--maint-good); }
 .cw-maint .side-nav-item[data-group="danger"] { --nav-accent: var(--maint-danger); }
 .cw-maint .side-nav-btn { position: relative; width: 100%; min-height: 46px; gap: 10px; padding: 0 12px; border: 1px solid transparent; border-radius: 8px; color: var(--maint-muted); background: transparent; cursor: pointer; text-align: left; font-size: 13px; font-weight: 700; transition: background .14s ease, border-color .14s ease, color .14s ease; }
 .cw-maint .side-nav-btn .material-symbols-rounded { width: 23px; flex: 0 0 23px; font-size: 23px; font-variation-settings: "FILL" 0, "wght" 500, "GRAD" 0, "opsz" 20; }
 .cw-maint .side-nav-btn:hover, .cw-maint .side-nav-btn.active { color: var(--maint-text); border-color: color-mix(in srgb, var(--nav-accent) 38%, var(--maint-border)); background: color-mix(in srgb, var(--nav-accent) 9%, var(--maint-card)); }
 .cw-maint .side-nav-btn.active .material-symbols-rounded { color: var(--nav-accent); }
-.cw-maint .side-nav-btn[data-target="cxm-group-archive"] { --nav-accent: var(--maint-good); }
+.cw-maint .side-nav-btn:is([data-target="cxm-group-archive"], [data-target="cxm-group-events"], [data-target="cxm-group-captures"]) { --nav-accent: var(--maint-good); }
 .cw-maint .side-nav-btn[data-target="cxm-group-danger"] { --nav-accent: var(--maint-danger); }
 .cw-maint .side-nav-btn.danger, .cw-maint .side-nav-btn.danger .material-symbols-rounded { color: var(--maint-danger); }
 .cw-maint .category-run-btn {
@@ -149,8 +149,8 @@
 .cw-maint .archive-actions { grid-column: 1 / -1; display: flex; flex-wrap: wrap; gap: 7px; margin-top: 8px; }
 .cw-maint .archive-actions .run-btn { min-height: 34px; min-width: 118px; }
 .cw-maint .archive-actions .run-btn.secondary { color: var(--maint-text); }
-.cw-maint .action-group.archive .group-icon, .cw-maint .action-row[data-op="tracker"] .action-icon { color: var(--maint-good); }
-.cw-maint .action-group.archive { --group-accent: var(--maint-good); }
+.cw-maint :is(.action-group.archive, .action-group.events, .action-group.captures) .group-icon, .cw-maint .action-row[data-op="tracker"] .action-icon { color: var(--maint-good); }
+.cw-maint :is(.action-group.archive, .action-group.events, .action-group.captures) { --group-accent: var(--maint-good); }
 .cw-maint :is(.action-group.playback, .action-group.reports) .group-icon { color: var(--maint-accent); }
 .cw-maint .action-group.danger { --group-accent: var(--maint-danger); border-color: color-mix(in srgb, var(--maint-danger) 38%, var(--maint-border)); background: color-mix(in srgb, var(--maint-danger) 6%, var(--maint-panel)); }
 .cw-maint .action-group.danger .group-icon, .cw-maint .action-group.danger .group-title { color: var(--maint-danger); }

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -1244,13 +1244,6 @@ def _get_index_html_static() -> str:
                       <small>Create archives, validate backups, restore state, or manage schedules.</small>
                     </span>
                   </button>
-                  <button class="btn cw-maint-action archive" type="button" onclick="openMaintenanceModal({group:'archive'})">
-                    <span class="material-symbols-rounded cw-maint-action-icon" aria-hidden="true">inventory_2</span>
-                    <span class="cw-maint-action-copy">
-                      <strong>Archive & Recovery</strong>
-                      <small>Manage CW Tracker snapshots, ZIP exports, and imports.</small>
-                    </span>
-                  </button>
                   <button class="btn cw-maint-action tools" type="button" onclick="openMaintenanceModal()">
                     <span class="material-symbols-rounded cw-maint-action-icon" aria-hidden="true">tune</span>
                     <span class="cw-maint-action-copy">


### PR DESCRIPTION
# Pull request

## Change
- Move pair-scoped sync files 
- Delete those files alongside state.json in clear_state_minimal and report them as removed_sync_state
- Size the rebuild sync state status from state.json plus the scoped files, and add a Pair mapping files metric

## Why
Retry provider items was clearing alias and mapping caches that belong to sync state, so a retry pass threw away translated aliases and history indexes that were expensive to rebuild and were not the cause of the retry. Those files now live with rebuild sync state, where wiping them is the point, and the two notes no longer describe overlapping scopes.

## Testing
- test scripts uploaded to /tests

## Issue
NA
