### PR TITLE
Fix: TMDB metadata namespace resolution

### DIFF
--- a/api/metaAPI.py
+++ b/api/metaAPI.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import random
 import re
 import time
+from email.utils import parsedate_to_datetime
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import lru_cache
 from pathlib import Path
@@ -30,7 +32,12 @@ from cw_platform.metadata_cache import (
     metadata_cache_path,
     prune_metadata_cache,
     read_metadata_cache,
+    read_resolution_cache,
+    read_resolution_index,
+    resolution_cache_key,
     write_metadata_cache,
+    write_resolution_cache,
+    write_resolution_index,
 )
 
 try:
@@ -211,17 +218,70 @@ def _tmdb_include_image_language(locale: str | None) -> str:
     return ",".join(parts)
 
 
+def _tmdb_retry_policy() -> tuple[int, float, float]:
+    try:
+        md = (load_config() or {}).get("metadata") or {}
+        max_retries = int(md.get("backoff_max_retries", 4))
+        base_s = int(md.get("backoff_base_ms", 500)) / 1000.0
+        max_s = int(md.get("backoff_max_ms", 4000)) / 1000.0
+    except Exception:
+        return 4, 0.5, 4.0
+    return max(0, max_retries), max(0.05, base_s), max(0.1, max_s)
+
+
+def _tmdb_retry_after_seconds(header: str | None) -> float | None:
+    text = str(header or "").strip()
+    if not text:
+        return None
+    if text.isdigit():
+        return float(text)
+    try:
+        return max(0.0, parsedate_to_datetime(text).timestamp() - time.time())
+    except Exception:
+        return None
+
+
+def _tmdb_get_json(
+    url: str,
+    params: dict[str, Any] | None = None,
+    *,
+    timeout: float = 20.0,
+) -> Any | None:
+    max_retries, base_s, max_s = _tmdb_retry_policy()
+    attempt = 0
+    while True:
+        try:
+            r = requests.get(url, params=params or {}, timeout=timeout)
+            status = r.status_code
+            if status == 429 or 500 <= status < 600:
+                if attempt >= max_retries:
+                    return None
+                if status == 429:
+                    wait = _tmdb_retry_after_seconds(r.headers.get("Retry-After"))
+                else:
+                    wait = None
+                if wait is None:
+                    wait = min(max_s, base_s * (2**attempt)) + random.uniform(0.0, 0.25)
+                time.sleep(wait)
+                attempt += 1
+                continue
+            if not r.ok:
+                return None
+            return r.json()
+        except requests.exceptions.RequestException:
+            if attempt >= max_retries:
+                return None
+            time.sleep(min(max_s, base_s * (2**attempt)) + random.uniform(0.0, 0.25))
+            attempt += 1
+        except Exception:
+            return None
+
+
 def _tmdb_fetch_posters(api_key: str, typ: str, tmdb_id: str, locale: str | None) -> list[dict[str, Any]]:
     kind = "movie" if typ == "movie" else "tv"
     url = f"https://api.themoviedb.org/3/{kind}/{tmdb_id}/images"
     params = {"api_key": api_key, "include_image_language": _tmdb_include_image_language(locale)}
-    try:
-        r = requests.get(url, params=params, timeout=20)
-        if not r.ok:
-            return []
-        data = r.json()
-    except Exception:
-        return []
+    data = _tmdb_get_json(url, params)
     posters = data.get("posters") if isinstance(data, dict) else None
     if not isinstance(posters, list):
         return []
@@ -251,13 +311,7 @@ def _tmdb_fetch_episode_stills(
     episode: int,
 ) -> list[dict[str, Any]]:
     url = f"https://api.themoviedb.org/3/tv/{show_tmdb_id}/season/{season}/episode/{episode}/images"
-    try:
-        r = requests.get(url, params={"api_key": api_key}, timeout=20)
-        if not r.ok:
-            return []
-        data = r.json()
-    except Exception:
-        return []
+    data = _tmdb_get_json(url, {"api_key": api_key})
     stills = data.get("stills") if isinstance(data, dict) else None
     if not isinstance(stills, list):
         return []
@@ -485,6 +539,110 @@ def _ttl_bucket(seconds: int) -> int:
     return int(time.time() // max(1, seconds))
 
 
+def _tmdb_provider() -> Any | None:
+    _METADATA, _, _ = _env()
+    providers = getattr(_METADATA, "providers", None)
+    if not isinstance(providers, dict):
+        return None
+    for name, prov in providers.items():
+        if str(name).upper() == "TMDB" and hasattr(prov, "resolve_namespace"):
+            return prov
+    return None
+
+
+def _entity_from_kind(kind: Any) -> str:
+    return "movie" if str(kind or "").strip().lower() == "movie" else "show"
+
+
+def _resolve_entity(
+    entity: str,
+    tmdb_id: str | int,
+    *,
+    title: str | None = None,
+    year: int | str | None = None,
+    imdb_id: str | None = None,
+    tvdb_id: str | int | None = None,
+    locale: str | None = None,
+) -> str:
+    cache_dir = _meta_cache_dir()
+
+    if not str(title or "").strip():
+        indexed = read_resolution_index(cache_dir, entity, tmdb_id)
+        return indexed or entity
+
+    try:
+        key = resolution_cache_key(
+            tmdb_id,
+            imdb_id=imdb_id,
+            tvdb_id=tvdb_id,
+            title=title,
+            year=year,
+        )
+    except Exception:
+        return entity
+
+    record = read_resolution_cache(cache_dir, key)
+    if isinstance(record, dict):
+        if str(record.get("status") or "") == "resolved":
+            resolved = _entity_from_kind(record.get("resolved_type"))
+            _meta_debug(
+                "resolution_cache_hit",
+                tmdb_id=tmdb_id,
+                requested=entity,
+                resolved=resolved,
+                reason=record.get("reason"),
+            )
+            return resolved
+        return entity
+
+    provider = _tmdb_provider()
+    if provider is None:
+        return entity
+
+    try:
+        outcome = provider.resolve_namespace(
+            tmdb_id=tmdb_id,
+            requested_type=entity,
+            title=title,
+            year=year,
+            imdb_id=imdb_id,
+            tvdb_id=tvdb_id,
+            locale=locale,
+        )
+    except Exception:
+        return entity
+
+    if not isinstance(outcome, dict):
+        _meta_debug("resolution_transient_failure", tmdb_id=tmdb_id, requested=entity)
+        return entity
+
+    resolved = _entity_from_kind(outcome.get("resolved_type"))
+    status = str(outcome.get("status") or "unresolved")
+    write_resolution_cache(
+        cache_dir,
+        key,
+        {
+            "tmdb_id": str(tmdb_id),
+            "title": str(title or ""),
+            "year": year,
+            "resolved_type": resolved,
+            "status": status,
+            "reason": outcome.get("reason"),
+        },
+    )
+    if status == "resolved":
+        write_resolution_index(cache_dir, entity, tmdb_id, resolved)
+        if resolved != entity:
+            _meta_debug(
+                "resolution_namespace_corrected",
+                tmdb_id=tmdb_id,
+                requested=entity,
+                resolved=resolved,
+                reason=outcome.get("reason"),
+            )
+    return resolved if status == "resolved" else entity
+
+
 @lru_cache(maxsize=4096)
 def _resolve_tmdb_cached(
     ttl_key: int,
@@ -519,11 +677,25 @@ def get_meta(
     *,
     need: dict[str, Any] | None = None,
     locale: str | None = None,
+    title: str | None = None,
+    year: int | str | None = None,
+    imdb_id: str | None = None,
+    tvdb_id: str | int | None = None,
 ) -> dict[str, Any]:
-    entity = "movie" if str(typ).lower() == "movie" else "show"
+    requested_entity = "movie" if str(typ).lower() == "movie" else "show"
     eff_need = need or {"poster": True, "backdrop": True, "logo": False}
     need_key = tuple(sorted(k for k, v in eff_need.items() if v))
     eff_locale = locale or _cfg_ui_locale()
+    entity = _resolve_entity(
+        requested_entity,
+        tmdb_id,
+        title=title,
+        year=year,
+        imdb_id=imdb_id,
+        tvdb_id=tvdb_id,
+        locale=eff_locale,
+    )
+    cached = None
     if _meta_cache_enabled():
         cached = _read_meta_cache(entity, tmdb_id, eff_locale or "en-US")
         if cached and _need_satisfied(cached, eff_need):
@@ -533,6 +705,7 @@ def get_meta(
                 tmdb_id=tmdb_id,
                 locale=eff_locale or "en-US",
             )
+            cached["resolved_type"] = entity
             return cached
         _meta_debug(
             "meta_cache_miss",
@@ -560,6 +733,8 @@ def get_meta(
         except Exception:
             pass
 
+    if res:
+        res["resolved_type"] = entity
     return res or {}
 
 
@@ -634,12 +809,33 @@ def get_art_file(
     locale: str | None = None,
     *,
     kind: str = "poster",
+    title: str | None = None,
+    year: int | str | None = None,
 ) -> tuple[str, str]:
     cache_root = _cache_subdir(cache_dir, "art")
     cache_root.mkdir(parents=True, exist_ok=True)
 
     art_kind = "backdrop" if str(kind).strip().lower() == "backdrop" else "poster"
     eff_locale = locale or _cfg_ui_locale() or None
+
+    requested_entity = "movie" if str(typ).strip().lower() == "movie" else "show"
+    resolved_entity = _resolve_entity(
+        requested_entity,
+        tmdb_id,
+        title=title,
+        year=year,
+        locale=eff_locale,
+    )
+    if resolved_entity != requested_entity:
+        typ = "movie" if resolved_entity == "movie" else "tv"
+        _meta_debug(
+            "art_namespace_corrected",
+            tmdb_id=tmdb_id,
+            requested=requested_entity,
+            resolved=resolved_entity,
+            kind=art_kind,
+        )
+
     loc_tag = _safe_cache_part(_locale_tag(eff_locale), default="any")
     safe_typ = _safe_cache_part(typ, default="media")
     safe_tmdb_id = _safe_cache_part(tmdb_id)
@@ -667,7 +863,16 @@ def get_art_file(
         )
         return str(cached_art), mime
 
-    meta = get_meta(api_key, typ, str(tmdb_id), cache_dir=cache_dir, need={art_kind: True}, locale=eff_locale) or {}
+    meta = get_meta(
+        api_key,
+        typ,
+        str(tmdb_id),
+        cache_dir=cache_dir,
+        need={art_kind: True},
+        locale=eff_locale,
+        title=title,
+        year=year,
+    ) or {}
     eff_locale = eff_locale or meta.get("locale") or None
 
     art = _art_candidates(meta, art_kind)
@@ -838,9 +1043,9 @@ def _tmdb_external_ids(entity: str, tmdb_id: str | int) -> dict[str, str]:
         base = "movie" if str(entity).lower() == "movie" else "tv"
         url = f"https://api.themoviedb.org/3/{base}/{tmdb_id}/external_ids"
 
-        r = requests.get(url, params={"api_key": api_key}, timeout=8)
-        r.raise_for_status()
-        data = r.json() or {}
+        data = _tmdb_get_json(url, {"api_key": api_key}, timeout=8) or {}
+        if not isinstance(data, dict):
+            return {}
     except Exception:
         return {}
 
@@ -876,6 +1081,8 @@ def api_tmdb_art(
     season: int | None = Query(None, ge=0),
     episode: int | None = Query(None, ge=1),
     locale: str | None = Query(None),
+    title: str | None = Query(None),
+    year: int | None = Query(None),
 ):
     t = typ.lower()
     if t == "show":
@@ -925,6 +1132,8 @@ def api_tmdb_art(
                 base,
                 locale=eff_locale,
                 kind=kind,
+                title=title,
+                year=year,
             )
         return FileResponse(
             str(local_path),
@@ -978,12 +1187,9 @@ def api_metadata_search(
         else:
             params["first_air_date_year"] = year
 
-    try:
-        r = requests.get(url, params=params, timeout=8)
-        r.raise_for_status()
-        data = r.json() or {}
-    except Exception:
-        LOG.exception("TMDb search failed")
+    data = _tmdb_get_json(url, params, timeout=8)
+    if not isinstance(data, dict):
+        LOG.warning("TMDb search failed")
         return JSONResponse({"ok": False, "error": "search failed"}, status_code=200)
 
     out: list[dict[str, Any]] = []
@@ -1054,8 +1260,21 @@ def api_metadata_resolve(
         if not tmdb_id:
             tmdb_id = ids.get("tmdb")
 
+        resolved_entity = entity
+        if tmdb_id:
+            resolved_entity = _resolve_entity(
+                entity,
+                tmdb_id,
+                title=base_ids.get("title") if isinstance(base_ids, dict) else None,
+                year=base_ids.get("year") if isinstance(base_ids, dict) else None,
+                imdb_id=base_ids.get("imdb") if isinstance(base_ids, dict) else None,
+                tvdb_id=base_ids.get("tvdb") if isinstance(base_ids, dict) else None,
+                locale=payload.locale,
+            )
+        res["resolved_type"] = resolved_entity
+
         if tmdb_id and not ids.get("imdb"):
-            extra_ids = _tmdb_external_ids(entity, tmdb_id)
+            extra_ids = _tmdb_external_ids(resolved_entity, tmdb_id)
             imdb_id = extra_ids.get("imdb")
             if imdb_id:
                 ids["imdb"] = imdb_id
@@ -1150,6 +1369,8 @@ def api_metadata_bulk(
         if not tmdb_id:
             return key, {"ok": False, "error": "missing tmdb id"}
         item["type"] = typ
+        raw_item_ids = item.get("ids")
+        item_ids: dict[str, Any] = raw_item_ids if isinstance(raw_item_ids, dict) else {}
         try:
             meta = (
                 get_meta(
@@ -1159,6 +1380,10 @@ def api_metadata_bulk(
                     base_cache,
                     need=req_need,
                     locale=eff_locale,
+                    title=item.get("title") or item_ids.get("title"),
+                    year=item.get("year") or item_ids.get("year"),
+                    imdb_id=item.get("imdb") or item_ids.get("imdb"),
+                    tvdb_id=item.get("tvdb") or item_ids.get("tvdb"),
                 )
                 or {}
             )
@@ -1188,6 +1413,8 @@ def api_metadata_bulk(
         for k in keep:
             if k != "type" and k in meta:
                 out[k] = meta[k]
+        if meta.get("resolved_type"):
+            out["resolved_type"] = meta["resolved_type"]
         if overview == "short" and out.get("overview"):
             out["overview"] = _shorten(out["overview"], 280)
         if "score" not in out:

--- a/api/watchlistAPI.py
+++ b/api/watchlistAPI.py
@@ -480,6 +480,8 @@ def api_watchlist(
                 continue
 
             it["type"] = _norm_type(it.get("type") or it.get("entity") or it.get("media_type"))
+            raw_item_ids = it.get("ids")
+            item_ids: dict[str, Any] = raw_item_ids if isinstance(raw_item_ids, dict) else {}
             try:
                 meta = get_meta(
                     api_key,
@@ -488,7 +490,13 @@ def api_watchlist(
                     CACHE_DIR,
                     need={"overview": True, "tagline": True, "title": True, "year": True},
                     locale=eff_locale,
+                    title=it.get("title"),
+                    year=it.get("year"),
+                    imdb_id=item_ids.get("imdb"),
+                    tvdb_id=item_ids.get("tvdb"),
                 ) or {}
+                if meta.get("resolved_type"):
+                    it["resolved_type"] = meta["resolved_type"]
                 desc = meta.get("overview") or ""
                 if not desc:
                     continue

--- a/assets/helpers/watchlist-preview.js
+++ b/assets/helpers/watchlist-preview.js
@@ -161,7 +161,8 @@
   function artUrl(item, size = "w342") {
     const tmdb = item?.tmdb;
     if (!tmdb) return null;
-    return `/art/tmdb/${isTV(item.type || item.entity || item.media_type) ? "tv" : "movie"}/${tmdb}?size=${encodeURIComponent(size)}`;
+    const kind = isTV(item.type || item.entity || item.media_type) ? "tv" : "movie";
+    return `/art/tmdb/${kind}/${tmdb}?size=${encodeURIComponent(size)}${artEvidenceOf(item)}`;
   }
 
   const providerLogoPath = (name) => window.CW?.ProviderMeta?.logoPath?.(name) || "";
@@ -194,14 +195,24 @@
     return raw === "movie" ? "movie" : "show";
   }
 
-  function artTypeOf(item) {
+  function artTypeOf(item, meta = null) {
+    const resolved = String(meta?.resolved_type || "").toLowerCase();
+    if (resolved) return resolved === "movie" ? "movie" : "tv";
     return mediaTypeOf(item) === "movie" ? "movie" : "tv";
   }
 
-  function mediaLabelOf(item) {
+  function artEvidenceOf(item) {
+    const title = item?.title ? `&title=${encodeURIComponent(String(item.title))}` : "";
+    const year = item?.year ? `&year=${encodeURIComponent(String(item.year))}` : "";
+    return title + year;
+  }
+
+  function mediaLabelOf(item, meta = null) {
+    const resolved = String(meta?.resolved_type || "").toLowerCase();
+    if (resolved === "movie") return "Movie";
     const raw = String(item?.type || item?.entity || item?.media_type || "").toLowerCase();
     if (raw === "movie") return "Movie";
-    if (raw === "anime") return "Anime";
+    if (raw === "anime") return resolved === "show" ? "Show" : "Anime";
     return "Show";
   }
 
@@ -226,7 +237,7 @@
   function backdropUrl(item, meta = null) {
     const tmdb = tmdbIdOf(item, meta);
     if (!tmdb) return "";
-    return `/art/tmdb/${artTypeOf(item)}/${encodeURIComponent(String(tmdb))}?kind=backdrop&size=w1280&locale=${encodeURIComponent(window.__CW_LOCALE || navigator.language || "en-US")}`;
+    return `/art/tmdb/${artTypeOf(item, meta)}/${encodeURIComponent(String(tmdb))}?kind=backdrop&size=w1280&locale=${encodeURIComponent(window.__CW_LOCALE || navigator.language || "en-US")}${artEvidenceOf(item)}`;
   }
 
   function runtimeLabel(mins) {
@@ -263,7 +274,7 @@
   function tmdbUrl(item, meta = null) {
     const tmdb = tmdbIdOf(item, meta);
     if (!tmdb) return "";
-    return `https://www.themoviedb.org/${mediaTypeOf(item) === "movie" ? "movie" : "tv"}/${encodeURIComponent(String(tmdb))}`;
+    return `https://www.themoviedb.org/${artTypeOf(item, meta)}/${encodeURIComponent(String(tmdb))}`;
   }
 
   function imdbUrl(item, meta = null) {
@@ -287,7 +298,13 @@
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            items: [{ type, tmdb }],
+            items: [{
+              type,
+              tmdb,
+              title: item?.title || "",
+              year: item?.year || "",
+              ids: { imdb: imdbIdOf(item) || "", tvdb: item?.ids?.tvdb || "" },
+            }],
             need: { overview: 1, runtime_minutes: 1, ids: 1, videos: 1, genres: 1, certification: 1, score: 1, release: 1, backdrop: 1 },
             concurrency: 1,
           }),
@@ -565,7 +582,7 @@
     const year = String(item?.year || meta?.year || yearFromIso(releaseIso) || "").trim();
     const genres = (Array.isArray(meta?.genres) ? meta.genres : Array.isArray(meta?.detail?.genres) ? meta.detail.genres : Array.isArray(item?.genres) ? item.genres : []).slice(0, 3);
     const chips = [
-      mediaLabelOf(item),
+      mediaLabelOf(item, meta),
       year,
       runtimeLabel(meta?.runtime_minutes),
       dateLabel(releaseIso),
@@ -773,7 +790,7 @@
       itemMap.set(itemKey, item);
 
       link.className = "poster";
-      link.href = `https://www.themoviedb.org/${isTV(item.type) ? "tv" : "movie"}/${item.tmdb}`;
+      link.href = tmdbUrl(item, previewMetaCache.get(previewMetaKey(item))) || `https://www.themoviedb.org/${isTV(item.type) ? "tv" : "movie"}/${item.tmdb}`;
       link.target = "_blank";
       link.rel = "noopener";
       link.style.cursor = "pointer";

--- a/assets/js/dashboard-widgets.js
+++ b/assets/js/dashboard-widgets.js
@@ -232,6 +232,7 @@
     const raw = String(item?.type || "").toLowerCase();
     if (raw === "episode") return item?.episode_label || "Episode";
     if (raw === "season") return "Season";
+    if (String(item?.art_type || "").toLowerCase() === "movie") return "Movie";
     if (raw === "show") return "Show";
     return "Movie";
   }
@@ -264,7 +265,10 @@
     const tmdb = item?.tmdb;
     if (!tmdb) return "/assets/img/placeholder_poster.svg";
     const kind = String(item?.art_type || item?.type || "").toLowerCase() === "movie" ? "movie" : "tv";
-    return `/art/tmdb/${kind}/${encodeURIComponent(String(tmdb))}?size=${encodeURIComponent(size)}`;
+    const isEpisode = String(item?.type || "").toLowerCase() === "episode";
+    const title = item?.title && !isEpisode ? `&title=${encodeURIComponent(String(item.title))}` : "";
+    const year = item?.year && !isEpisode ? `&year=${encodeURIComponent(String(item.year))}` : "";
+    return `/art/tmdb/${kind}/${encodeURIComponent(String(tmdb))}?size=${encodeURIComponent(size)}${title}${year}`;
   }
 
   function tmdbLink(item) {

--- a/assets/js/playback_progress.js
+++ b/assets/js/playback_progress.js
@@ -167,7 +167,10 @@ html[data-cw-theme=flat-dark] #${ROOT_ID} .pp-loading-shape{background:#2a2f39}h
     const tmdb = source?.tmdb || it?.tmdb;
     if (!tmdb) return "";
     const typ = media === "movie" ? "movie" : "tv";
-    return `/art/tmdb/${typ}/${encodeURIComponent(String(tmdb))}?kind=${encodeURIComponent(kind)}&size=${encodeURIComponent(size)}&locale=${encodeURIComponent(window.__CW_LOCALE || navigator.language || "en-US")}`;
+    const evidenceTitle = media === "movie" ? it?.title : it?.series_title;
+    const title = evidenceTitle ? `&title=${encodeURIComponent(String(evidenceTitle))}` : "";
+    const year = media === "movie" && it?.year ? `&year=${encodeURIComponent(String(it.year))}` : "";
+    return `/art/tmdb/${typ}/${encodeURIComponent(String(tmdb))}?kind=${encodeURIComponent(kind)}&size=${encodeURIComponent(size)}&locale=${encodeURIComponent(window.__CW_LOCALE || navigator.language || "en-US")}${title}${year}`;
   };
   const providerPills = (it) => {
     const providers = Array.isArray(it.providers) && it.providers.length

--- a/assets/js/playingcard.js
+++ b/assets/js/playingcard.js
@@ -55,23 +55,35 @@
   const buildTmdbUrl = (p) => {
     const id = tmdbIdOf(p);
     if (!id) return "";
-    const type = String(p?.media_type || p?.type || "").toLowerCase() === "movie" ? "movie" : "tv";
+    const resolved = metaCache.get(metaKey(p))?.resolved_type;
+    const type = String(resolved || p?.media_type || p?.type || "").toLowerCase() === "movie" ? "movie" : "tv";
     return `https://www.themoviedb.org/${type}/${encodeURIComponent(String(id))}`;
+  };
+
+  const artTypeOf = (p) => {
+    const type = p?.media_type || p?.type || "";
+    return String(type).toLowerCase() === "movie" ? "movie" : "tv";
+  };
+
+  const artEvidenceOf = (p) => {
+    const mt = String(p?.media_type || p?.type || "").toLowerCase();
+    if (mt === "episode" || p?.season != null || p?.episode != null) return "";
+    const t = p?.title ? `&title=${encodeURIComponent(String(p.title))}` : "";
+    const y = p?.year ? `&year=${encodeURIComponent(String(p.year))}` : "";
+    return t + y;
   };
 
   const buildArtUrl = (p) => {
     if (p?.cover) return p.cover;
     const id = tmdbIdOf(p);
     if (!id) return "/assets/img/placeholder_poster.svg";
-    const type = String(p?.media_type || p?.type || "").toLowerCase() === "movie" ? "movie" : "tv";
-    return `/art/tmdb/${type}/${encodeURIComponent(String(id))}?size=w342`;
+    return `/art/tmdb/${artTypeOf(p)}/${encodeURIComponent(String(id))}?size=w342${artEvidenceOf(p)}`;
   };
 
   const buildBackdropUrl = (p) => {
     const id = tmdbIdOf(p);
     if (!id) return "";
-    const type = String(p?.media_type || p?.type || "").toLowerCase() === "movie" ? "movie" : "tv";
-    return `/art/tmdb/${type}/${encodeURIComponent(String(id))}?kind=backdrop&size=w1280`;
+    return `/art/tmdb/${artTypeOf(p)}/${encodeURIComponent(String(id))}?kind=backdrop&size=w1280${artEvidenceOf(p)}`;
   };
 
   const runtimeLabel = (mins) => {
@@ -170,7 +182,7 @@
   const backdropFromMeta = (meta) => {
     const id = meta?.ids?.tmdb;
     if (!id) return "";
-    const type = String(meta?.type || "").toLowerCase() === "movie" ? "movie" : "tv";
+    const type = String(meta?.resolved_type || meta?.type || "").toLowerCase() === "movie" ? "movie" : "tv";
     return `/art/tmdb/${type}/${encodeURIComponent(String(id))}?kind=backdrop&size=w1280`;
   };
 
@@ -188,6 +200,7 @@
     if (!tmdb) return null;
     const mt = String(p?.media_type || p?.type || "").toLowerCase();
     const type = mt === "movie" ? "movie" : "show";
+    const isEpisode = mt === "episode" || p?.season != null || p?.episode != null;
     const need = { overview: 1, runtime_minutes: 1, ids: 1, videos: 1, genres: 1, certification: 1, score: 1, vote_count: 1, release: 1, backdrop: 1 };
     if (type === "show") need.series_info = 1;
 
@@ -197,7 +210,13 @@
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          items: [{ type, tmdb }],
+          items: [{
+            type,
+            tmdb,
+            title: isEpisode ? "" : (p?.title || ""),
+            year: isEpisode ? "" : (p?.year || ""),
+            ids: { imdb: p?.ids?.imdb || "", tvdb: p?.ids?.tvdb || "" },
+          }],
           need,
           concurrency: 1
         })

--- a/assets/js/watchlist.js
+++ b/assets/js/watchlist.js
@@ -254,6 +254,10 @@ const actionCss=`#page-watchlist .wl-action-head{justify-content:space-between}#
         inflightKey,
         tmdb,
         type: k.startsWith("movie:") ? "movie" : "show",
+        title: it?.title || "",
+        year: it?.year || "",
+        imdb: it?.ids?.imdb || "",
+        tvdb: it?.ids?.tvdb || "",
       });
     }
 
@@ -264,7 +268,13 @@ const actionCss=`#page-watchlist .wl-action-head{justify-content:space-between}#
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-              items: missing.map((x) => ({ type: x.type, tmdb: x.tmdb })),
+              items: missing.map((x) => ({
+                type: x.type,
+                tmdb: x.tmdb,
+                title: x.title,
+                year: x.year,
+                ids: { imdb: x.imdb, tvdb: x.tvdb },
+              })),
               need,
               concurrency: Math.min(Math.max(missing.length, 1), 6),
             })
@@ -329,7 +339,9 @@ const actionCss=`#page-watchlist .wl-action-head{justify-content:space-between}#
   const cmp = (a, b) => a < b ? -1 : a > b ? 1 : 0;
   const cmpDir = v => (sortDir === "asc" ? v : -v);
   const normKey = it => it.key || it.guid || it.id || (it.ids?.tmdb && `tmdb:${it.ids.tmdb}`) || (it.ids?.imdb && `imdb:${it.ids.imdb}`) || (it.ids?.tvdb && `tvdb:${it.ids.tvdb}`) || "";
-  const artUrl=(it,size,kind="poster")=>(!TMDB_OK||!(it?.tmdb||it?.ids?.tmdb))?"":`/art/tmdb/${(((it?.type||it?.media_type||"")+"").toLowerCase()==="movie"?"movie":"tv")}/${encodeURIComponent(String(it?.tmdb||it?.ids?.tmdb))}?kind=${encodeURIComponent(kind)}&size=${encodeURIComponent(size||"w342")}&locale=${encodeURIComponent(window.__CW_LOCALE||navigator.language||"en-US")}`;
+  const artType=it=>(((it?.type||it?.media_type||"")+"").toLowerCase()==="movie"?"movie":"tv");
+  const artEvidence=it=>{const t=it?.title?`&title=${encodeURIComponent(String(it.title))}`:"";const y=it?.year?`&year=${encodeURIComponent(String(it.year))}`:"";return t+y;};
+  const artUrl=(it,size,kind="poster")=>(!TMDB_OK||!(it?.tmdb||it?.ids?.tmdb))?"":`/art/tmdb/${artType(it)}/${encodeURIComponent(String(it?.tmdb||it?.ids?.tmdb))}?kind=${encodeURIComponent(kind)}&size=${encodeURIComponent(size||"w342")}&locale=${encodeURIComponent(window.__CW_LOCALE||navigator.language||"en-US")}${artEvidence(it)}`;
   const parseReleaseDate = s => { if (typeof s !== "string" || !(s = s.trim())) return null; let y, m, d; if (/^\d{4}-\d{2}-\d{2}$/.test(s)) ([y, m, d] = s.split("-").map(Number)); else if (/^\d{2}-\d{2}-\d{4}$/.test(s)) { const a = s.split("-").map(Number); d = a[0]; m = a[1]; y = a[2]; } else return null; const t = Date.UTC(y, (m || 1) - 1, d || 1), dt = new Date(t); return Number.isFinite(dt.getTime()) ? dt : null; };
   const fmtDateSmart = (raw, loc) => { const dt = parseReleaseDate(raw); if (!dt) return ""; try { return new Intl.DateTimeFormat(loc || toLocale(), { day:"2-digit", month:"2-digit", year:"numeric", timeZone:"UTC" }).format(dt); } catch { return ""; } };
   const providersOf = it => Array.isArray(it.sources) ? it.sources.map(providerKey).filter(Boolean) : [];
@@ -346,16 +358,21 @@ const actionCss=`#page-watchlist .wl-action-head{justify-content:space-between}#
     return typeof iso === "string" ? iso.trim() : "";
   };
 
+  const resolvedTypeFor = it => String(metaCache.get(metaKey(it))?.resolved_type || "").toLowerCase();
   const typeLabelFor = it => {
+    const resolved = resolvedTypeFor(it);
+    if (resolved === "movie") return "Movie";
     const raw = String(it?.type || "").toLowerCase();
     if (raw === "movie") return "Movie";
-    if (raw === "anime") return "Anime";
+    if (raw === "anime") return resolved === "show" ? "Show" : "Anime";
     return "Show";
   };
   const posterTypeLabelFor = it => {
+    const resolved = resolvedTypeFor(it);
+    if (resolved === "movie") return "M";
     const raw = String(it?.type || "").toLowerCase();
     if (raw === "movie") return "M";
-    if (raw === "anime") return "A";
+    if (raw === "anime") return resolved === "show" ? "S" : "A";
     return "S";
   };
   const yearFromIso = iso => (typeof iso === "string" && /^\d{4}/.test(iso) ? iso.slice(0,4) : "");
@@ -880,8 +897,8 @@ const normReleased = v => (v === "yes" ? "released" : v === "no" ? "unreleased" 
   function backdropFromMeta(it, meta){
   const tmdb = it?.tmdb || it?.ids?.tmdb || meta?.ids?.tmdb;
   if (!tmdb) return "";
-  const type = (((it?.type||it?.media_type||meta?.type||"")+"").toLowerCase()==="movie"?"movie":"tv");
-  return `/art/tmdb/${type}/${encodeURIComponent(String(tmdb))}?kind=backdrop&size=w1280&locale=${encodeURIComponent(window.__CW_LOCALE||navigator.language||"en-US")}`;
+  const type = artType(it);
+  return `/art/tmdb/${type}/${encodeURIComponent(String(tmdb))}?kind=backdrop&size=w1280&locale=${encodeURIComponent(window.__CW_LOCALE||navigator.language||"en-US")}${artEvidence(it)}`;
 }
 
   function renderDetail(it, meta) {

--- a/cw_platform/metadata_cache.py
+++ b/cw_platform/metadata_cache.py
@@ -3,16 +3,40 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
 import time
+import unicodedata
 from pathlib import Path
 from threading import RLock
 from typing import Any, Mapping
 
 _LOCALE_RE = re.compile(r"[a-zA-Z0-9]{1,8}(?:-[a-zA-Z0-9]{1,8})*")
 _WRITE_LOCK = RLock()
+_INDEX_LOCK = RLock()
+_INDEX_MEMO: dict[str, tuple[tuple[int, int], dict[str, Any]]] = {}
+
+RESOLUTION_DIRNAME = "resolution"
+RESOLUTION_INDEX_NAME = "_index.json"
+UNRESOLVED_TTL_SECONDS = 7 * 24 * 3600
+
+_APOSTROPHES = dict.fromkeys(map(ord, "’ʼ‘`´"), "'")
+_DASHES = dict.fromkeys(map(ord, "‐‑‒–—―−"), "-")
+_PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
+_SPACE_RE = re.compile(r"\s+")
+
+
+def normalize_title(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    text = text.translate(_APOSTROPHES).translate(_DASHES)
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(ch for ch in text if not unicodedata.combining(ch))
+    text = _PUNCT_RE.sub(" ", text)
+    return _SPACE_RE.sub(" ", text).strip().casefold()
 
 
 def _cache_tmdb_id(value: Any) -> str:
@@ -119,12 +143,199 @@ def write_metadata_cache(
         return False
 
 
+def _resolution_media(value: Any) -> str:
+    return "movie" if str(value or "").strip().lower() == "movie" else "show"
+
+
+def resolution_cache_key(
+    tmdb_id: str | int,
+    *,
+    imdb_id: str | None = None,
+    tvdb_id: str | int | None = None,
+    title: str | None = None,
+    year: int | str | None = None,
+) -> str:
+    cache_id = _cache_tmdb_id(tmdb_id)
+    imdb = str(imdb_id or "").strip().lower()
+    tvdb = str(tvdb_id or "").strip().lower()
+    if imdb:
+        evidence = f"tmdb:{cache_id}|imdb:{imdb}"
+    elif tvdb:
+        evidence = f"tmdb:{cache_id}|tvdb:{tvdb}"
+    else:
+        norm_title = normalize_title(title)
+        year_text = str(year or "").strip()
+        if norm_title:
+            evidence = f"tmdb:{cache_id}|title:{norm_title}|year:{year_text}"
+        else:
+            evidence = f"tmdb:{cache_id}"
+    digest = hashlib.sha256(evidence.encode("utf-8")).hexdigest()[:32]
+    return f"{cache_id}_{digest}"
+
+
+def _resolution_root(cache_root: Path | str, *, create: bool = True) -> Path:
+    root = os.path.realpath(os.fspath(cache_root))
+    target = os.path.realpath(os.path.join(root, RESOLUTION_DIRNAME))
+    root_prefix = root if root.endswith(os.sep) else root + os.sep
+    if not target.startswith(root_prefix):
+        raise ValueError("Resolution cache path escaped its root")
+    if create:
+        Path(target).mkdir(parents=True, exist_ok=True)
+    return Path(target)
+
+
+def resolution_cache_path(cache_root: Path | str, key: str) -> Path:
+    safe_key = str(key or "").strip()
+    if not safe_key or not re.fullmatch(r"[A-Za-z0-9_]+", safe_key):
+        raise ValueError("Resolution cache key must be alphanumeric")
+    base = _resolution_root(cache_root)
+    path = os.path.realpath(os.path.join(os.fspath(base), f"{safe_key}.json"))
+    base_prefix = os.fspath(base)
+    base_prefix = base_prefix if base_prefix.endswith(os.sep) else base_prefix + os.sep
+    if not path.startswith(base_prefix):
+        raise ValueError("Resolution cache path escaped its root")
+    return Path(path)
+
+
+def read_resolution_cache(
+    cache_root: Path | str,
+    key: str,
+    *,
+    unresolved_ttl_seconds: int | None = UNRESOLVED_TTL_SECONDS,
+) -> dict[str, Any] | None:
+    try:
+        data = json.loads(resolution_cache_path(cache_root, key).read_text("utf-8"))
+        if not isinstance(data, dict):
+            return None
+        if str(data.get("status") or "") == "resolved":
+            return data
+        if unresolved_ttl_seconds is None:
+            return data
+        resolved_at = float(data.get("resolved_at") or 0.0)
+        if resolved_at <= 0 or (time.time() - resolved_at) > max(1, int(unresolved_ttl_seconds)):
+            return None
+        return data
+    except Exception:
+        return None
+
+
+def write_resolution_cache(
+    cache_root: Path | str,
+    key: str,
+    payload: Mapping[str, Any],
+) -> bool:
+    try:
+        target = resolution_cache_path(cache_root, key)
+        data = dict(payload)
+        data.setdefault("resolved_at", time.time())
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        with _WRITE_LOCK:
+            tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+            tmp.replace(target)
+        return True
+    except Exception:
+        return False
+
+
+def _resolution_index_path(cache_root: Path | str, *, create: bool = True) -> Path:
+    return _resolution_root(cache_root, create=create) / RESOLUTION_INDEX_NAME
+
+
+def _load_resolution_index(cache_root: Path | str) -> dict[str, Any]:
+    path = _resolution_index_path(cache_root, create=False)
+    memo_key = os.fspath(path)
+    try:
+        stat = path.stat()
+        stamp = (stat.st_mtime_ns, stat.st_size)
+    except Exception:
+        with _INDEX_LOCK:
+            _INDEX_MEMO.pop(memo_key, None)
+        return {}
+
+    with _INDEX_LOCK:
+        hit = _INDEX_MEMO.get(memo_key)
+        if hit is not None and hit[0] == stamp:
+            return hit[1]
+
+    try:
+        data = json.loads(path.read_text("utf-8"))
+    except Exception:
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+
+    with _INDEX_LOCK:
+        _INDEX_MEMO[memo_key] = (stamp, data)
+    return data
+
+
+def read_resolution_index(
+    cache_root: Path | str,
+    requested_type: str,
+    tmdb_id: str | int,
+) -> str | None:
+    try:
+        cache_id = _cache_tmdb_id(tmdb_id)
+        entry = _load_resolution_index(cache_root).get(f"{_resolution_media(requested_type)}:{cache_id}")
+        if not isinstance(entry, dict) or entry.get("ambiguous"):
+            return None
+        resolved = str(entry.get("resolved_type") or "").strip().lower()
+        return resolved if resolved in {"movie", "show"} else None
+    except Exception:
+        return None
+
+
+def write_resolution_index(
+    cache_root: Path | str,
+    requested_type: str,
+    tmdb_id: str | int,
+    resolved_type: str,
+) -> bool:
+    try:
+        cache_id = _cache_tmdb_id(tmdb_id)
+        resolved = _resolution_media(resolved_type)
+        index_key = f"{_resolution_media(requested_type)}:{cache_id}"
+        target = _resolution_index_path(cache_root)
+        with _WRITE_LOCK:
+            try:
+                data = json.loads(target.read_text("utf-8"))
+            except Exception:
+                data = {}
+            if not isinstance(data, dict):
+                data = {}
+
+            entry = data.get(index_key)
+            if isinstance(entry, dict):
+                if entry.get("ambiguous"):
+                    return True
+                if str(entry.get("resolved_type") or "") == resolved:
+                    return True
+                data[index_key] = {"ambiguous": True}
+            else:
+                data[index_key] = {"resolved_type": resolved}
+
+            tmp = target.with_suffix(target.suffix + ".tmp")
+            tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+            tmp.replace(target)
+            with _INDEX_LOCK:
+                _INDEX_MEMO.pop(os.fspath(target), None)
+        return True
+    except Exception:
+        return False
+
+
 def prune_metadata_cache(cache_root: Path | str, *, max_mb: int) -> int:
     if int(max_mb or 0) <= 0:
         return 0
     try:
         root = Path(cache_root).resolve()
-        files = [path for path in root.rglob("*.json") if path.is_file() and not path.is_symlink()]
+        files = [
+            path
+            for path in root.rglob("*.json")
+            if path.is_file()
+            and not path.is_symlink()
+            and RESOLUTION_DIRNAME not in path.relative_to(root).parts
+        ]
         total = sum(path.stat().st_size for path in files)
         cap = int(max_mb) * 1024 * 1024
         if total <= cap:

--- a/providers/metadata/_meta_TMDB.py
+++ b/providers/metadata/_meta_TMDB.py
@@ -12,6 +12,8 @@ from typing import Any, Callable
 
 import requests
 
+from cw_platform.metadata_cache import normalize_title
+
 try:
     from _logging import log as _real_log
 except ImportError:
@@ -198,6 +200,188 @@ class TmdbProvider:
     @staticmethod
     def _pick_first(arr: list[Any] | None) -> Any | None:
         return arr[0] if isinstance(arr, list) and arr else None
+
+    @staticmethod
+    def _entity_kind(value: Any) -> str:
+        text = str(value or "").strip().lower()
+        return "movie" if text in {"movie", "movies", "film", "films"} else "tv"
+
+    @staticmethod
+    def _detail_titles(det: Mapping[str, Any], kind: str) -> list[str]:
+        keys = ("title", "original_title") if kind == "movie" else ("name", "original_name")
+        return [str(det.get(k) or "") for k in keys if det.get(k)]
+
+    def _detail_year(self, det: Mapping[str, Any], kind: str) -> int | None:
+        field = "release_date" if kind == "movie" else "first_air_date"
+        return self._safe_int_year(det.get(field))
+
+    @staticmethod
+    def _expected_titles(title: str | None, year: int | None) -> set[str]:
+        want = normalize_title(title)
+        if not want:
+            return set()
+        wants = {want}
+        if year is not None:
+            suffix = f" {int(year)}"
+            if want.endswith(suffix):
+                trimmed = want[: -len(suffix)].strip()
+                if trimmed:
+                    wants.add(trimmed)
+        return wants
+
+    def _matches_expected(
+        self,
+        det: Mapping[str, Any],
+        kind: str,
+        title: str | None,
+        year: int | None,
+    ) -> bool:
+        wants = self._expected_titles(title, year)
+        if not wants:
+            return False
+        if not any(normalize_title(t) in wants for t in self._detail_titles(det, kind)):
+            return False
+        if year is None:
+            return True
+        got = self._detail_year(det, kind)
+        if got is None:
+            return True
+        return abs(int(got) - int(year)) <= 1
+
+    def _try_details(self, kind: str, tmdb_id: str, lang: str) -> tuple[dict[str, Any] | None, bool]:
+        base = "https://api.themoviedb.org/3"
+        try:
+            data = self._get(f"{base}/{kind}/{tmdb_id}", {"language": lang})
+            return (data if isinstance(data, dict) else None), True
+        except requests.exceptions.RequestException as e:
+            status = int(getattr(getattr(e, "response", None), "status_code", 0) or 0)
+            if status == 404:
+                return None, True
+            return None, False
+        except Exception:
+            return None, False
+
+    def _find_by_external(
+        self,
+        external_id: str,
+        source: str,
+        tmdb_id: str,
+    ) -> tuple[str | None, bool]:
+        base = "https://api.themoviedb.org/3"
+        try:
+            data = self._get(f"{base}/find/{external_id}", {"external_source": source})
+        except requests.exceptions.RequestException as e:
+            status = int(getattr(getattr(e, "response", None), "status_code", 0) or 0)
+            if status != 404:
+                return None, False
+            return None, True
+        except Exception:
+            return None, False
+        if not isinstance(data, dict):
+            return None, True
+        for bucket, kind in (("movie_results", "movie"), ("tv_results", "tv")):
+            for row in data.get(bucket) or []:
+                if isinstance(row, dict) and str(row.get("id") or "") == str(tmdb_id):
+                    return kind, True
+        return None, True
+
+    def _search_confirms(
+        self,
+        kind: str,
+        tmdb_id: str,
+        title: str,
+        year: int | None,
+        lang: str,
+    ) -> tuple[bool, bool]:
+        base = "https://api.themoviedb.org/3"
+        params: dict[str, Any] = {"query": title, "language": lang, "include_adult": False}
+        if year is not None:
+            params["primary_release_year" if kind == "movie" else "first_air_date_year"] = year
+        try:
+            data = self._get(f"{base}/search/{kind}", params)
+        except requests.exceptions.RequestException as e:
+            status = int(getattr(getattr(e, "response", None), "status_code", 0) or 0)
+            if status != 404:
+                return False, False
+            return False, True
+        except Exception:
+            return False, False
+        if not isinstance(data, dict):
+            return False, True
+        for row in data.get("results") or []:
+            if not isinstance(row, dict) or str(row.get("id") or "") != str(tmdb_id):
+                continue
+            if self._matches_expected(row, kind, title, year):
+                return True, True
+        return False, True
+
+    def resolve_namespace(
+        self,
+        *,
+        tmdb_id: str | int,
+        requested_type: str,
+        title: str | None = None,
+        year: int | str | None = None,
+        imdb_id: str | None = None,
+        tvdb_id: str | int | None = None,
+        locale: str | None = None,
+    ) -> dict[str, Any] | None:
+        tid = str(tmdb_id or "").strip()
+        if not tid.isdecimal() or int(tid) <= 0:
+            return None
+
+        requested = self._entity_kind(requested_type)
+        alternate = "tv" if requested == "movie" else "movie"
+        lang = locale or "en-US"
+
+        want_title = str(title or "").strip()
+        try:
+            want_year: int | None = int(str(year)[:4]) if str(year or "").strip() else None
+        except Exception:
+            want_year = None
+
+        if not want_title:
+            return None
+
+        req_det, req_ok = self._try_details(requested, tid, lang)
+        if not req_ok:
+            return None
+        if req_det and self._matches_expected(req_det, requested, want_title, want_year):
+            return {"resolved_type": requested, "status": "resolved", "reason": "requested_title_year_match"}
+
+        alt_det, alt_ok = self._try_details(alternate, tid, lang)
+        if not alt_ok:
+            return None
+
+        alt_match = bool(alt_det) and self._matches_expected(alt_det or {}, alternate, want_title, want_year)
+
+        if alt_match:
+            return {"resolved_type": alternate, "status": "resolved", "reason": "alternate_title_year_match"}
+        if req_det and not alt_det:
+            return {"resolved_type": requested, "status": "resolved", "reason": "only_requested_namespace_exists"}
+        if alt_det and not req_det:
+            return {"resolved_type": alternate, "status": "resolved", "reason": "only_alternate_namespace_exists"}
+
+        external = str(imdb_id or "").strip() if requested == "movie" else str(tvdb_id or "").strip()
+        source = "imdb_id" if requested == "movie" else "tvdb_id"
+        if not external:
+            external = str(tvdb_id or "").strip() if requested == "movie" else str(imdb_id or "").strip()
+            source = "tvdb_id" if requested == "movie" else "imdb_id"
+        if external:
+            found, ok = self._find_by_external(external, source, tid)
+            if not ok:
+                return None
+            if found:
+                return {"resolved_type": found, "status": "resolved", "reason": f"external_id_{source}"}
+
+        for kind in (requested, alternate):
+            confirmed, ok = self._search_confirms(kind, tid, want_title, want_year, lang)
+            if not ok:
+                return None
+            if confirmed:
+                return {"resolved_type": kind, "status": "resolved", "reason": "search_title_year_match"}
+
+        return {"resolved_type": requested, "status": "unresolved", "reason": "inconclusive"}
 
     def _images(self, tmdb_id: str, kind: str, lang: str, need: Mapping[str, bool]) -> dict[str, list[dict[str, Any]]]:
         want_poster = bool(need.get("poster"))

--- a/services/dashboard_widgets.py
+++ b/services/dashboard_widgets.py
@@ -405,6 +405,27 @@ def _episode_still_url(item: Mapping[str, Any], *, size: str) -> str:
     return f"/art/tmdb/tv/{tmdb}?kind=still&season={season}&episode={episode}&size={size}&artv=2"
 
 
+def _resolved_art_type(item: Mapping[str, Any], tmdb: Any) -> str:
+    requested = _art_type(item)
+    if _media_type(item) == "episode":
+        return requested
+    try:
+        from api.metaAPI import _resolve_entity
+
+        ids = _ids(item)
+        resolved = _resolve_entity(
+            "movie" if requested == "movie" else "show",
+            tmdb,
+            title=_title(item),
+            year=_year(item),
+            imdb_id=ids.get("imdb"),
+            tvdb_id=ids.get("tvdb"),
+        )
+    except Exception:
+        return requested
+    return "movie" if resolved == "movie" else "tv"
+
+
 def _poster_url(item: Mapping[str, Any], *, size: str = "w342", episode_still: bool = False) -> str:
     if episode_still:
         still = _episode_still_url(item, size=size)
@@ -413,7 +434,7 @@ def _poster_url(item: Mapping[str, Any], *, size: str = "w342", episode_still: b
     tmdb = _tmdb_id(item)
     if tmdb in (None, "", 0, False):
         return ""
-    return f"/art/tmdb/{_art_type(item)}/{tmdb}?size={size}"
+    return f"/art/tmdb/{_resolved_art_type(item, tmdb)}/{tmdb}?size={size}"
 
 
 def _metadata_manager() -> Any | None:
@@ -613,7 +634,7 @@ def _rating_row(raw_key: str, item: Mapping[str, Any], sources: list[dict[str, s
     return {
         "key": _canonical_key(raw_key, item),
         "type": typ,
-        "art_type": _art_type(item),
+        "art_type": _resolved_art_type(item, _tmdb_id(item)),
         "title": _title(item),
         "year": _year(item),
         "season": _season_number(item),
@@ -843,16 +864,61 @@ def _history_state_row(raw_key: str, item: Mapping[str, Any], sources: list[dict
     }
 
 
-def _history_aliases(row: Mapping[str, Any]) -> list[str]:
+def _history_alias_representatives() -> dict[str, str]:
+    try:
+        import json
+
+        from cw_platform.config_base import load_config
+        from services.analyzer import CWS_DIR, _alias_destination_key, _expected_alias_scopes
+    except Exception:
+        return {}
+    if not CWS_DIR.exists() or not CWS_DIR.is_dir():
+        return {}
+    try:
+        expected = _expected_alias_scopes(load_config() or {})
+    except Exception:
+        return {}
+    if not expected:
+        return {}
+
+    out: dict[str, str] = {}
+    for path in sorted(CWS_DIR.glob("*history.pair_alias*.json")):
+        try:
+            doc = json.loads(path.read_text("utf-8"))
+        except Exception:
+            continue
+        if not isinstance(doc, Mapping):
+            continue
+        if str(doc.get("scope") or "").strip() not in expected:
+            continue
+        items = doc.get("items")
+        if not isinstance(items, Mapping):
+            continue
+        for src_event_key, rec in items.items():
+            if not isinstance(rec, Mapping):
+                continue
+            dest = _alias_destination_key(rec)
+            src_base = str(src_event_key or "").split("@", 1)[0]
+            if not dest or not src_base or dest == src_base:
+                continue
+            out[src_base] = dest
+            out[dest] = dest
+    return out
+
+
+def _history_aliases(row: Mapping[str, Any], alias_map: Mapping[str, str] | None = None) -> list[str]:
+    rep = (alias_map or {}).get(str(row.get("id") or "").split("@", 1)[0])
     title = _norm_text(row.get("title"))
     if not title:
-        return []
+        return [f"history|xalias|{rep}"] if rep else []
     typ = str(row.get("type") or "").strip().lower() or "movie"
     bucket = _time_bucket(row.get("sort_epoch") or row.get("watched_at"))
     year = _as_int(row.get("year"))
     season = _as_int(row.get("season"))
     episode = _as_int(row.get("episode"))
     aliases: list[str] = []
+    if rep:
+        aliases.append(f"history|xalias|{rep}")
     if typ == "episode" and season is not None and episode is not None:
         aliases.append(f"history|episode|{title}|s{season}|e{episode}|b{bucket}")
         aliases.append(f"history|episode|{title}|s{season}|e{episode}")
@@ -903,7 +969,10 @@ def _latest_history_tracker_rows(items: Mapping[str, Any]) -> list[dict[str, Any
     return sorted(rows.values(), key=lambda x: int(x.get("sort_epoch") or 0), reverse=True)
 
 
-def _merge_history_rows(*groups: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+def _merge_history_rows(
+    *groups: Iterable[Mapping[str, Any]],
+    alias_map: Mapping[str, str] | None = None,
+) -> list[dict[str, Any]]:
     rows: dict[str, dict[str, Any]] = {}
     aliases: dict[str, str] = {}
     for group in groups:
@@ -913,7 +982,7 @@ def _merge_history_rows(*groups: Iterable[Mapping[str, Any]]) -> list[dict[str, 
             if not key:
                 continue
             match_key = key
-            for alias in _history_aliases(row):
+            for alias in _history_aliases(row, alias_map):
                 if alias in aliases:
                     match_key = aliases[alias]
                     break
@@ -922,8 +991,10 @@ def _merge_history_rows(*groups: Iterable[Mapping[str, Any]]) -> list[dict[str, 
                 rows[match_key] = row
             else:
                 rows[match_key] = _merge_media_row(prev, row, sort_key="sort_epoch")
-            for alias in _history_aliases(rows[match_key]):
+            for alias in _history_aliases(rows[match_key], alias_map):
                 aliases[alias] = match_key
+            for alias in _history_aliases(row, alias_map):
+                aliases.setdefault(alias, match_key)
     return sorted(rows.values(), key=lambda x: int(x.get("sort_epoch") or 0), reverse=True)
 
 
@@ -936,7 +1007,7 @@ def recent_history_widget(
     cap = max(1, min(int(limit or 8), 24))
     state_rows = _latest_history_state_rows(state or {})
     tracker_rows = _latest_history_tracker_rows(tracker_items or {})
-    rows = _merge_history_rows(state_rows, tracker_rows)
+    rows = _merge_history_rows(state_rows, tracker_rows, alias_map=_history_alias_representatives())
     selected = _resolve_missing_art_rows(rows[:cap], size="w300", episode_still=True)
     return {"ok": True, "items": selected, "total": len(rows)}
 


### PR DESCRIPTION
# Pull request

## Change

- Added  resolver that checks whether a TMDB ID actually belongs to movie or TV, using title and year from the item
- Cache confirmed resolutions on disk so the work only happens once per item
- Split metadata and artwork caches so a movie and a show sharing the same TMDB ID never overwrite each other
- Pass title and year along to the artwork endpoint so posters resolve correctly on first load
- Wire the same shit  through watchlist, the main page widget, the playing card, the dashboard widgets and playback progress
- Type badges and TMDB links now follow the resolved type instead of the provider type
- Retry TMDB requests properly on rate limits and server errors instead of silently returning nothing

## Why

TMDB keeps movies and shows in separate ID namespaces, so the same number can be a movie and a completely unrelated show. CW trusted whatever type the provider handed over, and when that type was wrong you got the wrong poster and the wrong description.

This mostly hit anime films. SIMKL files them as shows, TMDB files them as movies, and the ID collides with some random series. My Neighbor Totoro showing up as Popeye as example.

The fix keeps the TMDB ID as the primary identifier and only checks which namespace it really lives in. 
Provider types and sync behaviour are untouched, the resolved type is used for metadata and artwork only.

Also fixed along the way: titles that arrive with the year glued on, like Paprika 2006, now match correctly.

## Testing

- 27 new tests covering the resolver, the caches and the retry logic
- Verified live against My Neighbor Totoro, Paprika and The Cat Returns on a real SIMKL to Trakt sync
- Checked the watchlist page, the main page widget and the detail card all show correct art on first load
- Confirmed a genuine show sharing a numeric ID still resolves as a show

## Issue

Relates to #441
