### PR TITLE
Fix: SIMKL anime movies mistyped as shows

### DIFF
--- a/providers/sync/simkl/_ratings.py
+++ b/providers/sync/simkl/_ratings.py
@@ -610,7 +610,7 @@ def build_index(adapter: Any, *, since_iso: str | None = None) -> dict[str, dict
                 m["type"] = "movie"
             elif kind == "anime":
                 raw = media0.get("anime") if isinstance(media0, Mapping) else None
-                at = (raw.get("anime_type") or raw.get("animeType")) if isinstance(raw, Mapping) else None
+                at = row.get("anime_type") or row.get("animeType") or ((raw.get("anime_type") or raw.get("animeType")) if isinstance(raw, Mapping) else None)
                 anime_type = at.strip().lower() if isinstance(at, str) and at.strip() else None
                 m["type"] = "movie" if anime_type == "movie" else "show"
                 if anime_type:

--- a/providers/sync/simkl/_watchlist.py
+++ b/providers/sync/simkl/_watchlist.py
@@ -259,7 +259,7 @@ def _normalize_row(bucket: str, row: Any) -> dict[str, Any]:
         title = node.get("title")
         year = node.get("year")
 
-        at = node.get("anime_type") or node.get("animeType")
+        at = row.get("anime_type") or row.get("animeType") or node.get("anime_type") or node.get("animeType")
         if isinstance(at, str) and at.strip():
             anime_type = at.strip().lower()
 


### PR DESCRIPTION
# Pull request

## Change

Read anime_type from the SIMKL row instead of the nested show data for watchlist and ratings.

## Why

SIMKL returns anime_type next to the show data, not inside it. Because CrossWatch read it from the wrong location, anime movies such as Ponyo were incorrectly treated as shows.

This caused the TMDB ID to be looked up as a television show on Trakt, where it matched an unrelated title. 
Reading anime_type from the correct level ensures anime movies are handled as movies and resolve correctly.

History was not affected because it already reads anime_type from the row level.

## Testing

* Confirmed Ponyo is now identified as a movie using the real SIMKL response
* All SIMKL provider tests pass

## Issue

NA

