### PR TITLE
Add: TMDb resolution caching

### DIFF
--- a/api/metaAPI.py
+++ b/api/metaAPI.py
@@ -554,6 +554,9 @@ def _entity_from_kind(kind: Any) -> str:
     return "movie" if str(kind or "").strip().lower() == "movie" else "show"
 
 
+_RESOLVED_ENTITY_MEMO: dict[str, str] = {}
+
+
 def _resolve_entity(
     entity: str,
     tmdb_id: str | int,
@@ -581,10 +584,15 @@ def _resolve_entity(
     except Exception:
         return entity
 
+    memo = _RESOLVED_ENTITY_MEMO.get(key)
+    if memo is not None:
+        return memo
+
     record = read_resolution_cache(cache_dir, key)
     if isinstance(record, dict):
         if str(record.get("status") or "") == "resolved":
             resolved = _entity_from_kind(record.get("resolved_type"))
+            _RESOLVED_ENTITY_MEMO[key] = resolved
             _meta_debug(
                 "resolution_cache_hit",
                 tmdb_id=tmdb_id,
@@ -631,6 +639,7 @@ def _resolve_entity(
         },
     )
     if status == "resolved":
+        _RESOLVED_ENTITY_MEMO[key] = resolved
         write_resolution_index(cache_dir, entity, tmdb_id, resolved)
         if resolved != entity:
             _meta_debug(

--- a/providers/metadata/_meta_TMDB.py
+++ b/providers/metadata/_meta_TMDB.py
@@ -121,7 +121,7 @@ class TmdbProvider:
         msg = event if not suffix else f"{event} {suffix}"
         log(msg, level="debug", module="META", extra=clean or None)
 
-    def _get(self, url: str, params: dict[str, Any] | None = None) -> Any:
+    def _get(self, url: str, params: dict[str, Any] | None = None, *, quiet_404: bool = False) -> Any:
         q = dict(params or {})
         q["api_key"] = self._apikey()
         ck = url + "?" + "&".join(sorted(f"{k}={v}" for k, v in q.items()))
@@ -169,13 +169,14 @@ class TmdbProvider:
                 status = getattr(getattr(e, "response", None), "status_code", None)
                 retryable = (status == 429) or (status is None) or (500 <= int(status or 0) < 600)
                 if (not retryable) or (attempt >= max_retries):
-                    lvl = "INFO" if int(status or 0) == 404 else "WARNING"
-                    log(
-                        f"TMDb request failed ({status or 'n/a'}) at {url}",
-                        level=lvl,
-                        module="META",
-                        extra={"status": status, "url": url},
-                    )
+                    if not (quiet_404 and int(status or 0) == 404):
+                        lvl = "INFO" if int(status or 0) == 404 else "WARNING"
+                        log(
+                            f"TMDb request failed ({status or 'n/a'}) at {url}",
+                            level=lvl,
+                            module="META",
+                            extra={"status": status, "url": url},
+                        )
                     raise
                 time.sleep(self._retry_delay(attempt, base_s, max_s))
                 attempt += 1
@@ -251,7 +252,7 @@ class TmdbProvider:
     def _try_details(self, kind: str, tmdb_id: str, lang: str) -> tuple[dict[str, Any] | None, bool]:
         base = "https://api.themoviedb.org/3"
         try:
-            data = self._get(f"{base}/{kind}/{tmdb_id}", {"language": lang})
+            data = self._get(f"{base}/{kind}/{tmdb_id}", {"language": lang}, quiet_404=True)
             return (data if isinstance(data, dict) else None), True
         except requests.exceptions.RequestException as e:
             status = int(getattr(getattr(e, "response", None), "status_code", 0) or 0)
@@ -269,7 +270,7 @@ class TmdbProvider:
     ) -> tuple[str | None, bool]:
         base = "https://api.themoviedb.org/3"
         try:
-            data = self._get(f"{base}/find/{external_id}", {"external_source": source})
+            data = self._get(f"{base}/find/{external_id}", {"external_source": source}, quiet_404=True)
         except requests.exceptions.RequestException as e:
             status = int(getattr(getattr(e, "response", None), "status_code", 0) or 0)
             if status != 404:
@@ -298,7 +299,7 @@ class TmdbProvider:
         if year is not None:
             params["primary_release_year" if kind == "movie" else "first_air_date_year"] = year
         try:
-            data = self._get(f"{base}/search/{kind}", params)
+            data = self._get(f"{base}/search/{kind}", params, quiet_404=True)
         except requests.exceptions.RequestException as e:
             status = int(getattr(getattr(e, "response", None), "status_code", 0) or 0)
             if status != 404:

--- a/tests/test_metadata_namespace_resolution.py
+++ b/tests/test_metadata_namespace_resolution.py
@@ -32,7 +32,7 @@ class FakeTmdb(TmdbProvider):
         self.routes = routes
         self.calls: list[str] = []
 
-    def _get(self, url: str, params: dict | None = None) -> object:
+    def _get(self, url: str, params: dict | None = None, *, quiet_404: bool = False) -> object:
         path = url.replace("https://api.themoviedb.org/3", "")
         self.calls.append(path)
         if path not in self.routes:
@@ -60,6 +60,7 @@ def _install(monkeypatch, tmp_path, provider, resolve_result=None):
     monkeypatch.setattr(metaAPI, "_cfg_meta_ttl_secs", lambda: 720 * 3600)
     monkeypatch.setattr(metaAPI, "_cfg_ui_locale", lambda: "en-US")
     metaAPI._resolve_tmdb_cached.cache_clear()
+    metaAPI._RESOLVED_ENTITY_MEMO.clear()
 
 
 def test_wrong_tv_namespace_resolves_to_movie() -> None:


### PR DESCRIPTION
# Pull request

## Change

Added a small in-memory memo for resolved TMDb entity types and made expected TMDb 404 probes quiet.
 Updated the metadata resolution test setup for the new memo cache.

## Why

Keeps repeated namespace when TMDb 404s are part of normal resolution probing.

## Testing

Included test script

## Issue

NA