### PR TITLE
Fix: Watcher default controls in UI

### DIFF
--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -471,6 +471,7 @@ def build_overview(cfg: dict[str, Any], request: Request) -> dict[str, Any]:
     sc = _dict(cfg.get("scrobble"))
     watch = _dict(sc.get("watch"))
     wh = _dict(sc.get("webhook"))
+    trakt_policy = _dict(sc.get("trakt"))
     global_settings = {
         "enabled": bool(sc.get("enabled")),
         "sources": {
@@ -483,6 +484,8 @@ def build_overview(cfg: dict[str, Any], request: Request) -> dict[str, Any]:
         "global_auto_remove_watchlist": bool(sc.get("delete_plex")),
         "global_auto_remove_types": _clone(sc.get("delete_plex_types") or ["movie"]),
         "watch_defaults": {
+            "watched_at": trakt_policy.get("watched_at"),
+            "force_stop_at": trakt_policy.get("force_stop_at"),
             "pause_debounce_seconds": watch.get("pause_debounce_seconds"),
             "suppress_start_at": watch.get("suppress_start_at"),
         },
@@ -863,6 +866,17 @@ def api_scrobbler_settings(request: Request, payload: dict[str, Any] = Body(...)
             src_key = f"watch_{key}"
             if src_key in payload:
                 watch[key] = _coerce_int(payload.get(src_key), src_key)
+        trakt_policy = sc.setdefault("trakt", {})
+        if not isinstance(trakt_policy, dict):
+            trakt_policy = {}
+            sc["trakt"] = trakt_policy
+        for key in ("watched_at", "force_stop_at"):
+            src_key = f"watch_{key}"
+            if src_key in payload:
+                val = _coerce_int(payload.get(src_key), src_key)
+                if val < 0 or val > 100:
+                    raise ValidationFailure([_err(src_key, "invalid_range", "Value must be between 0 and 100")])
+                trakt_policy[key] = val
         wh = sc.setdefault("webhook", {})
         if not isinstance(wh, dict):
             wh = {}

--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -486,6 +486,7 @@ def build_overview(cfg: dict[str, Any], request: Request) -> dict[str, Any]:
         "watch_defaults": {
             "watched_at": trakt_policy.get("watched_at"),
             "force_stop_at": trakt_policy.get("force_stop_at"),
+            "progress_step": trakt_policy.get("progress_step"),
             "pause_debounce_seconds": watch.get("pause_debounce_seconds"),
             "suppress_start_at": watch.get("suppress_start_at"),
         },
@@ -865,7 +866,11 @@ def api_scrobbler_settings(request: Request, payload: dict[str, Any] = Body(...)
         for key in ("pause_debounce_seconds", "suppress_start_at"):
             src_key = f"watch_{key}"
             if src_key in payload:
-                watch[key] = _coerce_int(payload.get(src_key), src_key)
+                val = _coerce_int(payload.get(src_key), src_key)
+                max_val = 100 if key == "suppress_start_at" else 3600
+                if val < 0 or val > max_val:
+                    raise ValidationFailure([_err(src_key, "invalid_range", f"Value must be between 0 and {max_val}")])
+                watch[key] = val
         trakt_policy = sc.setdefault("trakt", {})
         if not isinstance(trakt_policy, dict):
             trakt_policy = {}
@@ -877,6 +882,11 @@ def api_scrobbler_settings(request: Request, payload: dict[str, Any] = Body(...)
                 if val < 0 or val > 100:
                     raise ValidationFailure([_err(src_key, "invalid_range", "Value must be between 0 and 100")])
                 trakt_policy[key] = val
+        if "watch_progress_step" in payload:
+            val = _coerce_int(payload.get("watch_progress_step"), "watch_progress_step")
+            if val < 1 or val > 25:
+                raise ValidationFailure([_err("watch_progress_step", "invalid_range", "Value must be between 1 and 25")])
+            trakt_policy["progress_step"] = val
         wh = sc.setdefault("webhook", {})
         if not isinstance(wh, dict):
             wh = {}

--- a/assets/crosswatch.css
+++ b/assets/crosswatch.css
@@ -202,7 +202,7 @@ header{position:sticky;top:0;z-index:10;background:rgba(13,15,20,.96);padding:10
 #cfg-conn .row .spacer{flex:1}
 .history-badges .sep{display:inline-block;width:8px}
 #ops-card.card{padding-block:20px 38px}
-#placeholder-card,#dashboard-widgets-card{grid-column:1/-1}
+#dashboard-widgets-card{grid-column:1/-1}
 .meta-card{background:linear-gradient(180deg,rgba(255,255,255,.02),transparent),var(--panel);border:1px solid var(--border);border-radius:14px;padding:12px;box-shadow:0 0 40px #000 inset}
 .card{background:linear-gradient(180deg,rgba(255,255,255,.02),transparent),var(--panel);border:1px solid var(--border);border-radius:20px;padding:16px;box-shadow:0 0 40px #000 inset}
 .auth-card-actions .btn{padding:6px 10px;border-radius:8px;background:var(--chip,#1f1f1f);border:1px solid var(--line,#2a2a2a);cursor:pointer}
@@ -908,10 +908,10 @@ html[data-cw-theme=flat-light] #ops-card #details{--det-console-bg:#fff;--det-co
 }
 .lane{position:relative;border:1px solid rgba(255,255,255,.08);border-radius:20px;padding:14px 16px;background:radial-gradient(720px 180px at 0 0,rgba(124,92,255,.1),transparent 52%),linear-gradient(180deg,rgba(255,255,255,.03),rgba(255,255,255,.012));box-shadow:0 14px 28px rgba(0,0,0,.18),inset 0 1px 0 rgba(255,255,255,.02);transition:transform .15s ease,border-color .15s ease,box-shadow .15s ease}
 .lane:hover{transform:translateY(-1px);border-color:rgba(255,255,255,.12);box-shadow:0 16px 32px rgba(0,0,0,.22),inset 0 1px 0 rgba(255,255,255,.03)}
-.lane.is-dragging{opacity:.58;transform:scale(.992)}
-.lane.is-drop-target{border-color:rgba(124,92,255,.56);box-shadow:0 0 0 2px rgba(124,92,255,.16),0 16px 32px rgba(0,0,0,.22),inset 0 1px 0 rgba(255,255,255,.03)}
-.lane.is-drop-target::before{content:"";position:absolute;left:12px;right:12px;top:-7px;height:3px;border-radius:999px;background:#7c5cff;box-shadow:0 0 12px rgba(124,92,255,.64);pointer-events:none}
-.lane.is-drop-target.drop-after::before{top:auto;bottom:-7px}
+.lane.is-dragging{opacity:.48;transform:scale(.992);filter:saturate(.75)}
+.lane.is-drop-target{border-color:rgba(169,176,189,.38);box-shadow:none;background:linear-gradient(180deg,rgba(32,36,45,.92),rgba(23,27,36,.94))}
+.lane.is-drop-target::before{content:"";position:absolute;left:12px;right:12px;top:6px;height:2px;border-radius:999px;background:rgba(169,176,189,.56);box-shadow:none;pointer-events:none}
+.lane.is-drop-target[data-drop-position=after]::before{top:auto;bottom:6px}
 .lane.disabled{opacity:.45;filter:saturate(.5) brightness(.95)}
 .lane.shake{animation:laneShake .42s cubic-bezier(.36,.07,.19,.97)}
 @keyframes laneShake{10%,90%{transform:translateX(-1px)}
@@ -971,38 +971,43 @@ html[data-cw-theme=flat-light] #ops-card #details{--det-console-bg:#fff;--det-co
 .cw-hub-layout-toggle{position:relative}
 .cw-hub-layout-toggle .material-symbols-rounded{font-size:20px;line-height:1}
 .cw-hub-layout-strip.has-hidden .cw-hub-layout-toggle::after{content:"";position:absolute;right:5px;top:5px;width:7px;height:7px;border-radius:999px;background:#7c5cff;box-shadow:0 0 8px rgba(124,92,255,.75)}
-.cw-hub-layout-actions{display:none!important;align-items:center;gap:6px}
-.cw-hub-layout-strip.is-open .cw-hub-layout-actions{display:inline-flex!important}
-.cw-hub-refresh-proxy,.cw-hub-unhide-all{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;padding:0;border-radius:12px;border:1px solid rgba(255,255,255,.10);background:rgba(255,255,255,.035);color:rgba(236,241,252,.76);cursor:pointer}
-.cw-hub-refresh-proxy:hover,.cw-hub-refresh-proxy:focus-visible,.cw-hub-unhide-all:hover,.cw-hub-unhide-all:focus-visible{background:rgba(255,255,255,.075);border-color:rgba(255,255,255,.18);color:#fff;outline:none}
-.cw-hub-refresh-proxy .material-symbols-rounded,.cw-hub-unhide-all .material-symbols-rounded{font-size:20px;line-height:1}
+.cw-hub-layout-toggle,.cw-hub-refresh-proxy,.cw-hub-unhide-all{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;padding:0;border-radius:12px;border:1px solid rgba(255,255,255,.10);background:rgba(255,255,255,.035);color:rgba(236,241,252,.76);cursor:pointer}
+.cw-hub-layout-toggle:hover,.cw-hub-layout-toggle:focus-visible,.cw-hub-refresh-proxy:hover,.cw-hub-refresh-proxy:focus-visible,.cw-hub-unhide-all:hover,.cw-hub-unhide-all:focus-visible{background:rgba(255,255,255,.075);border-color:rgba(255,255,255,.18);color:#fff;outline:none}
+.cw-hub-layout-toggle .material-symbols-rounded,.cw-hub-refresh-proxy .material-symbols-rounded,.cw-hub-unhide-all .material-symbols-rounded{font-size:20px;line-height:1}
 .cw-hub-unhide-all:disabled{opacity:.34;cursor:not-allowed;filter:saturate(.6)}
 .cw-hub-unhide-all:disabled:hover{background:rgba(255,255,255,.035);border-color:rgba(255,255,255,.10);color:rgba(236,241,252,.76)}
 #ops-card .cw-main-card-head-actions>#btn-status-refresh{display:none!important}
 .cw-hub-refresh-proxy svg{display:block}
-@media(max-width:700px){.lane-badges{flex-wrap:wrap;justify-content:flex-end}.lane-controls{opacity:1}.lane-control{width:30px;height:30px}.cw-hub-layout-strip,.cw-hub-layout-actions{gap:4px}.cw-hub-refresh-proxy,.cw-hub-unhide-all{width:34px;height:34px}}
+@media(max-width:700px){.lane-badges{flex-wrap:wrap;justify-content:flex-end}.lane-controls{opacity:1}.lane-control{width:30px;height:30px}.cw-hub-layout-strip{gap:4px}.cw-hub-layout-toggle,.cw-hub-refresh-proxy,.cw-hub-unhide-all{width:34px;height:34px}}
 #stats-card .stats-modern{padding:16px;border:1px solid rgba(255,255,255,.08);border-radius:20px;background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(255,255,255,.012));box-shadow:0 14px 28px rgba(0,0,0,.18),inset 0 1px 0 rgba(255,255,255,.02)}
 #stats-card.stat-tiles{margin-top:14px}
 #stats-card .stat-block{margin-top:16px;padding:14px;border:1px solid rgba(255,255,255,.08);border-radius:20px;background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(255,255,255,.012));box-shadow:0 14px 28px rgba(0,0,0,.16),inset 0 1px 0 rgba(255,255,255,.02)}
 #sync-history .history-item{padding:12px 14px;border-radius:16px;background:linear-gradient(180deg,rgba(255,255,255,.032),rgba(255,255,255,.012));border:1px solid rgba(255,255,255,.07)}
-#placeholder-card.cw-main-card{padding:14px 18px 10px}
-#placeholder-card .cw-main-card-head{align-items:center;margin-bottom:10px;padding-bottom:8px;border-color:rgba(255,255,255,.1)}
-#placeholder-card .cw-main-card-kicker{margin:0;font-size:18px;font-weight:850;line-height:1.1;letter-spacing:0;text-transform:none;color:#f4f7ff}
-#placeholder-card .cw-widget-count-chip{box-sizing:border-box;flex:0 0 auto;min-width:36px;width:auto;height:36px;margin-left:auto;padding:0 10px;border-radius:12px;border-color:rgba(255,255,255,.095);background:rgba(255,255,255,.045);color:#f4f7ff;box-shadow:none;font-size:16px;letter-spacing:-.02em}
-#placeholder-card .cw-watchlist-see-all{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;margin-left:0;padding:0;border:1px solid rgba(255,255,255,.095);border-radius:12px;background:rgba(255,255,255,.045);color:#f4f7ff;font:inherit;font-size:13px;font-weight:850;line-height:1;text-decoration:none;cursor:pointer;transition:background .14s ease,border-color .14s ease,transform .14s ease}
+#placeholder-card.cw-main-card{padding:12px 14px 12px;background:linear-gradient(180deg,rgba(24,29,41,.50),rgba(12,15,23,.58));box-shadow:inset 0 1px 0 rgba(255,255,255,.025);backdrop-filter:blur(14px) saturate(112%);-webkit-backdrop-filter:blur(14px) saturate(112%)}
+#placeholder-card .cw-main-card-head{align-items:center;margin-bottom:8px;padding-bottom:7px;border-color:rgba(255,255,255,.07)}
+#placeholder-card .cw-main-card-kicker{margin:0;font-size:15px;font-weight:850;line-height:1.1;letter-spacing:0;text-transform:none;color:rgba(246,249,255,.96)}
+#placeholder-card .cw-widget-count-chip{box-sizing:border-box;flex:0 0 auto;min-width:30px;width:auto;height:30px;margin-left:auto;padding:0 9px;border-radius:10px;border-color:rgba(255,255,255,.07);background:rgba(255,255,255,.032);color:rgba(246,249,255,.90);box-shadow:none;font-size:13px;letter-spacing:-.01em}
+#placeholder-card .cw-watchlist-see-all{display:inline-flex;align-items:center;justify-content:center;width:auto;min-width:0;height:30px;margin-left:0;padding:0 9px;border:1px solid rgba(255,255,255,.07);border-radius:10px;background:rgba(255,255,255,.025);color:rgba(232,238,252,.78);font:inherit;font-size:11px;font-weight:800;line-height:1;text-decoration:none;cursor:pointer;transition:background .14s ease,border-color .14s ease,transform .14s ease,color .14s ease}
 #placeholder-card .cw-widget-count-chip.hidden+.cw-watchlist-see-all{margin-left:auto}
-#placeholder-card .cw-watchlist-see-all:hover{transform:translateY(-1px);background:rgba(255,255,255,.075);border-color:rgba(255,255,255,.16)}
-#placeholder-card .cw-watchlist-see-all .material-symbols-rounded{font-size:18px;line-height:1}
+#placeholder-card .cw-watchlist-see-all:hover{transform:translateY(-1px);background:rgba(255,255,255,.06);border-color:rgba(255,255,255,.13);color:#fff}
+#placeholder-card .cw-watchlist-see-all .material-symbols-rounded{font-size:16px;line-height:1}
 #placeholder-card .wall-msg{display:inline-flex;align-items:center;gap:8px;margin:0 0 10px;padding:8px 10px;border-radius:12px;border:1px solid var(--cw-flat-border,rgba(255,255,255,.12));background:var(--cw-flat-panel-2,rgba(255,255,255,.035));color:var(--cw-flat-muted,rgba(185,193,230,.78))}
-#placeholder-card .wall-msg.is-empty{display:flex;width:100%;min-height:70px;margin:0;justify-content:center;border-style:dashed}
+#placeholder-card .wall-msg.is-empty{display:grid;grid-template-rows:28px 16px 16px;place-items:center;align-content:center;gap:5px;width:100%;height:92px;min-height:92px;margin:0;justify-content:center;border:0;background:transparent;text-align:center}
+#placeholder-card .wall-msg.is-empty>.material-symbols-rounded{display:grid;place-items:center;width:32px;height:28px;border-radius:10px;border:0;background:transparent;color:rgba(190,199,216,.58);font-size:20px;opacity:.78}
+#placeholder-card .wall-msg.is-empty>strong{max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:rgba(246,249,255,.94);font-size:13px;font-weight:850;line-height:1.15}
+#placeholder-card .wall-msg.is-empty>small{display:block;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--cw-flat-muted,rgba(185,193,230,.58));font-size:11px;line-height:1.35}
 #placeholder-card .wall-wrap{margin:0;padding:0 42px;min-height:0;border:0;border-radius:0;background:0 0;box-shadow:none;overflow:visible}
 #placeholder-card .wall-wrap.is-empty{display:none}
-#placeholder-card #poster-row.row-scroll{--poster-gap:14px;display:grid;grid-auto-flow:column;grid-auto-columns:clamp(142px,9vw,184px);align-items:start;gap:var(--poster-gap);width:100%;max-width:100%;padding:2px 4px 0;overflow-x:auto;overflow-y:hidden;scroll-snap-type:x proximity;scrollbar-width:none}
+#placeholder-card #poster-row.row-scroll{--poster-gap:14px;display:grid;grid-auto-flow:column;grid-auto-columns:clamp(124px,8vw,156px);align-items:start;gap:var(--poster-gap);width:100%;max-width:100%;padding:2px 4px 0;overflow-x:auto;overflow-y:hidden;scroll-snap-type:x proximity;scrollbar-width:none}
 #placeholder-card #poster-row.row-scroll::-webkit-scrollbar{display:none}
-#placeholder-card .poster{width:100%;min-width:0;border-radius:14px;border-color:rgba(255,255,255,.14);box-shadow:none}
-#placeholder-card .poster:hover{transform:translateY(-2px);border-color:rgba(255,255,255,.22);box-shadow:0 12px 26px rgba(0,0,0,.2)}
+#placeholder-card .poster{width:100%;min-width:0;border-radius:14px;border-color:rgba(255,255,255,.105);box-shadow:none;opacity:.88}
+#placeholder-card .poster:hover{opacity:1;transform:translateY(-2px);border-color:rgba(255,255,255,.2);box-shadow:0 10px 22px rgba(0,0,0,.16)}
 #placeholder-card .poster .ovr{top:7px;left:7px;right:7px}
 #placeholder-card .poster .pill{display:inline-flex;align-items:center;justify-content:center;height:24px;min-height:0;padding:0 9px;border-radius:999px;background:rgba(15,19,28,.62);border:1px solid rgba(255,255,255,.15);color:#f5f7ff;-webkit-text-fill-color:#f5f7ff;box-shadow:none;line-height:1;backdrop-filter:blur(8px) saturate(120%);-webkit-backdrop-filter:blur(8px) saturate(120%)}
+#placeholder-card .poster .hover{padding:28px 8px 8px;border-top:0;background:linear-gradient(180deg,transparent 0,rgba(4,6,10,.58) 45%,rgba(4,6,10,.82) 100%);backdrop-filter:none;-webkit-backdrop-filter:none}
+#placeholder-card .poster .hover .titleline{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:12px;font-weight:850;letter-spacing:0}
+#placeholder-card .poster .hover .meta{margin:5px 0 0;gap:5px}
+#placeholder-card .poster .hover .chip{height:20px;padding:0 7px;border-color:rgba(255,255,255,.12);background:rgba(15,19,28,.58);font-size:10px}
 #placeholder-card .edge{top:0;bottom:0;width:42px;opacity:.82}
 #placeholder-card .edge.left{left:0;background:linear-gradient(90deg,var(--cw-flat-panel,#171a22) 0,rgba(23,26,34,.72) 46%,transparent 100%)}
 #placeholder-card .edge.right{right:0;background:linear-gradient(270deg,var(--cw-flat-panel,#171a22) 0,rgba(23,26,34,.72) 46%,transparent 100%)}
@@ -1011,6 +1016,17 @@ html[data-cw-theme=flat-light] #ops-card #details{--det-console-bg:#fff;--det-co
 #placeholder-card .nav.prev{left:2px}
 #placeholder-card .nav.next{right:2px}
 #placeholder-card .nav:hover{background:#303642;border-color:var(--cw-flat-border-strong,rgba(255,255,255,.19))}
+#placeholder-card[data-widget-size=small]{min-height:0}
+#placeholder-card[data-widget-size=small] .cw-main-card-head{margin-bottom:8px}
+#placeholder-card[data-widget-size=small] .wall-wrap{padding:0;overflow:hidden}
+#placeholder-card[data-widget-size=small] #poster-row.row-scroll{grid-auto-columns:82px;gap:10px;padding:0;max-height:124px;overflow:hidden}
+#placeholder-card[data-widget-size=small] .poster{border-radius:12px;opacity:.82}
+#placeholder-card[data-widget-size=small] .poster:nth-child(n+5){display:none}
+#placeholder-card[data-widget-size=small] .edge,#placeholder-card[data-widget-size=small] .nav{display:none}
+#placeholder-card[data-widget-size=small] .poster .pill{height:20px;padding:0 7px;font-size:10px}
+#placeholder-card[data-widget-size=small] .poster .hover{padding:24px 6px 6px;background:linear-gradient(180deg,transparent 0,rgba(4,6,10,.48) 42%,rgba(4,6,10,.82) 100%);transform:translateY(0)}
+#placeholder-card[data-widget-size=small] .poster .hover .titleline{font-size:10px;line-height:1.12;white-space:nowrap}
+#placeholder-card[data-widget-size=small] .poster .hover .meta{display:none}
 html[data-cw-theme=flat-light] #placeholder-card .cw-main-card-head{border-color:rgba(16,24,40,.12)}
 html[data-cw-theme=flat-light] #placeholder-card .cw-main-card-kicker{color:#172033}
 html[data-cw-theme=flat-light] #placeholder-card .cw-widget-count-chip{background:#f5f7fb;border-color:rgba(16,24,40,.16);color:#667085}
@@ -1024,31 +1040,58 @@ html[data-cw-theme=flat-light] #placeholder-card .edge.left{background:linear-gr
 html[data-cw-theme=flat-light] #placeholder-card .edge.right{background:linear-gradient(270deg,#fff 0,rgba(255,255,255,.76) 46%,transparent 100%)}
 html[data-cw-theme=flat-light] #placeholder-card .nav{background:#f5f7fb;border-color:rgba(16,24,40,.18);color:#172033}
 html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;border-color:rgba(16,24,40,.26)}
-.cw-dashboard-widgets{display:grid;grid-template-columns:minmax(360px,1fr) minmax(360px,.84fr) minmax(360px,1fr);gap:16px;align-items:start}
-.cw-dash-widget{--dash-panel:linear-gradient(180deg,rgba(18,21,30,.94),rgba(9,11,18,.96));--dash-panel-soft:rgba(255,255,255,.045);--dash-panel-strong:rgba(5,8,14,.64);--dash-border:rgba(255,255,255,.095);--dash-border-strong:rgba(255,255,255,.16);--dash-text:#f4f7ff;--dash-muted:rgba(190,199,216,.72);position:relative;align-self:start;min-width:0;overflow:hidden;border:1px solid var(--dash-border);border-radius:20px;background:radial-gradient(110% 90% at 8% 0,rgba(84,95,173,.14),transparent 54%),radial-gradient(90% 80% at 100% 100%,rgba(34,140,112,.10),transparent 58%),var(--dash-panel);box-shadow:0 18px 42px rgba(0,0,0,.22),inset 0 1px 0 rgba(255,255,255,.04);padding:16px;color:var(--dash-text)}
-.cw-dash-widget--ratings{background:radial-gradient(90% 75% at 0 0,rgba(141,103,54,.14),transparent 54%),radial-gradient(88% 80% at 100% 100%,rgba(91,82,167,.12),transparent 58%),var(--dash-panel)}
-.cw-dash-widget--scrobble{background:radial-gradient(90% 70% at 0 0,rgba(87,181,138,.14),transparent 52%),radial-gradient(90% 80% at 100% 100%,rgba(125,134,201,.13),transparent 58%),var(--dash-panel)}
-.cw-dash-widget-head{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:14px}
+.cw-dashboard-widgets{--cw-widget-masonry-row:8px;position:relative;display:grid;grid-template-columns:repeat(3,minmax(320px,1fr));grid-auto-rows:var(--cw-widget-masonry-row);grid-auto-flow:dense;gap:14px;align-items:start}
+.cw-dashboard-widgets.has-only-hidden-widgets{min-height:44px}
+.cw-dashboard-layout-toolbar{grid-column:1/-1;order:-999;position:relative;height:0;z-index:6}
+.cw-dashboard-layout-tools{position:absolute;right:0;top:-44px;display:inline-flex;align-items:center;gap:6px}
+.cw-dashboard-layout-btn{position:relative;display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;padding:0;border:0;border-radius:10px;background:transparent;color:rgba(232,238,252,.62);cursor:pointer;transition:background .14s ease,color .14s ease,transform .14s ease}
+.cw-dashboard-layout-btn:hover,.cw-dashboard-layout-btn:focus-visible{background:rgba(255,255,255,.06);color:#fff;outline:none;transform:translateY(-1px)}
+.cw-dashboard-layout-btn[disabled]{opacity:.28;cursor:not-allowed;transform:none}
+.cw-dashboard-layout-toolbar.has-hidden .cw-dashboard-layout-btn[data-cw-dashboard-layout=customize]::after{content:"";position:absolute;right:5px;top:5px;width:7px;height:7px;border-radius:999px;background:#7c5cff;box-shadow:0 0 8px rgba(124,92,255,.72)}
+.cw-dashboard-layout-btn .material-symbols-rounded{font-size:21px;line-height:1}
+.cw-dash-widget{--dash-panel:linear-gradient(180deg,rgba(23,28,39,.48),rgba(13,16,24,.56));--dash-panel-soft:rgba(255,255,255,.026);--dash-panel-strong:rgba(5,8,14,.38);--dash-border:rgba(255,255,255,.065);--dash-border-strong:rgba(255,255,255,.12);--dash-text:#f4f7ff;--dash-muted:rgba(190,199,216,.64);--dash-icon:rgba(190,199,216,.58);position:relative;align-self:start;min-width:0;overflow:hidden;border:1px solid var(--dash-border);border-radius:12px;background:var(--dash-panel);box-shadow:inset 0 1px 0 rgba(255,255,255,.025);backdrop-filter:blur(14px) saturate(112%);-webkit-backdrop-filter:blur(14px) saturate(112%);padding:12px;color:var(--dash-text)}
+.cw-dash-widget[data-widget-size=large]{grid-column:span 2}
+.cw-dash-widget--watchlist[data-widget-size=large]{grid-column:1/-1}
+.cw-dash-widget.is-dragging{opacity:.48;filter:saturate(.75)}
+.cw-dash-widget.is-drop-target{outline:1px solid rgba(169,176,189,.38);outline-offset:3px;background:linear-gradient(180deg,rgba(32,36,45,.92),rgba(23,27,36,.94))}
+.cw-dash-widget.is-drop-target::after{content:"";position:absolute;left:12px;right:12px;top:6px;height:2px;border-radius:999px;background:rgba(169,176,189,.56);pointer-events:none}
+.cw-dash-widget.is-drop-target[data-drop-position=after]::after{top:auto;bottom:6px}
+.cw-dashboard-widgets.is-customizing .cw-dash-widget.is-layout-hidden{opacity:.44;filter:saturate(.55)}
+.cw-dashboard-widgets.is-customizing .cw-dash-widget.is-layout-hidden:hover{opacity:.62}
+.cw-dash-layout-controls{position:absolute;right:156px;top:12px;z-index:5;display:flex;align-items:center;gap:4px;opacity:0;pointer-events:none;transform:translateY(-2px);transition:opacity .14s ease,transform .14s ease}
+#placeholder-card .cw-dash-layout-controls{right:168px;top:12px}
+.cw-dash-widget:hover .cw-dash-layout-controls,.cw-dash-widget:focus-within .cw-dash-layout-controls,.cw-dashboard-widgets.is-customizing .cw-dash-layout-controls{opacity:1;pointer-events:auto;transform:translateY(0)}
+.cw-dash-layout-control{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;padding:0;border-radius:9px;border:1px solid rgba(255,255,255,.045);background:rgba(8,11,18,.24);color:rgba(190,199,216,.46);opacity:.72;cursor:pointer;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px)}
+.cw-dash-layout-control:hover,.cw-dash-layout-control:focus-visible{background:rgba(255,255,255,.055);border-color:rgba(255,255,255,.12);color:rgba(232,238,252,.86);opacity:1;outline:none}
+.cw-dash-layout-control .material-symbols-rounded{font-size:18px;line-height:1}
+.cw-dash-widget--ratings,.cw-dash-widget--scrobble,.cw-dash-widget--progress,.cw-dash-widget--playlists{background:var(--dash-panel)}
+.cw-dash-widget-head{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:9px;padding-bottom:7px;border-bottom:1px solid rgba(255,255,255,.045)}
 .cw-dash-title-row{display:flex;align-items:center;gap:10px;min-width:0}
-.cw-dash-title-row .material-symbols-rounded{display:inline-flex;align-items:center;justify-content:center;width:34px;height:34px;border-radius:12px;border:1px solid var(--dash-border);background:var(--dash-panel-soft);color:var(--dash-text);font-size:21px}
-.cw-dash-title-row h3{margin:0;font-size:18px;font-weight:850;line-height:1.1;color:var(--dash-text);letter-spacing:0}
+.cw-dash-title-row .material-symbols-rounded{display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border-radius:8px;border:0;background:transparent;color:var(--dash-icon);font-size:18px;opacity:.82}
+.cw-dash-title-row h3{margin:0;font-size:14px;font-weight:850;line-height:1.1;color:rgba(246,249,255,.94);letter-spacing:0}
 .cw-dash-head-actions{display:flex;align-items:center;justify-content:flex-end;gap:8px;flex:0 0 auto}
 .cw-widget-count-chip{display:inline-flex;align-items:center;justify-content:center;min-width:30px;height:30px;padding:0 8px;border-radius:10px;border:1px solid rgba(139,149,255,.18);background:linear-gradient(145deg,rgba(91,99,214,.18),rgba(34,40,82,.12));color:var(--dash-text,#f4f7ff);box-shadow:inset 0 1px 0 rgba(255,255,255,.04),0 8px 18px rgba(0,0,0,.14);font-size:12px;font-weight:900;font-variant-numeric:tabular-nums;line-height:1;white-space:nowrap}
-.cw-dash-widget .cw-widget-count-chip{box-sizing:border-box;flex:0 0 auto;min-width:36px;width:auto;height:36px;padding:0 10px;border-radius:12px;border-color:var(--dash-border);background:var(--dash-panel-soft);color:var(--dash-text);box-shadow:none;font-size:16px;letter-spacing:-.02em}
-.cw-dash-ghost{display:inline-flex;align-items:center;justify-content:center;flex:0 0 auto;width:36px;height:36px;border-radius:12px;border:1px solid var(--dash-border);background:var(--dash-panel-soft);color:var(--dash-text);cursor:pointer;font-size:20px;line-height:1;transition:background .14s ease,border-color .14s ease,transform .14s ease}
+.cw-dash-widget .cw-widget-count-chip{box-sizing:border-box;flex:0 0 auto;min-width:28px;width:auto;height:28px;padding:0 8px;border-radius:9px;border-color:var(--dash-border);background:var(--dash-panel-soft);color:rgba(246,249,255,.88);box-shadow:none;font-size:12px;letter-spacing:0}
+.cw-dash-ghost{display:inline-flex;align-items:center;justify-content:center;flex:0 0 auto;width:28px;height:28px;border-radius:9px;border:1px solid var(--dash-border);background:var(--dash-panel-soft);color:var(--dash-icon);cursor:pointer;font-size:18px;line-height:1;transition:background .14s ease,border-color .14s ease,transform .14s ease,color .14s ease}
 .cw-dash-ghost:hover{background:rgba(255,255,255,.075);border-color:var(--dash-border-strong);transform:translateY(-1px)}
 .cw-dash-ghost.spinning .material-symbols-rounded{animation:spin .8s linear infinite}
-.cw-history-widget-list{display:grid;grid-auto-rows:max-content;align-content:start;align-items:start;gap:10px;max-height:650px;overflow:auto;padding-right:2px}
+.cw-history-widget-list{display:grid;grid-auto-rows:max-content;align-content:start;align-items:start;gap:8px;max-height:650px;overflow:auto;padding-right:2px}
 .cw-widget-scrollbar{scrollbar-width:thin;scrollbar-color:var(--cw-scrollbar-thumb) var(--cw-scrollbar-track)}
 .cw-widget-scrollbar::-webkit-scrollbar{width:10px;height:10px}
 .cw-widget-scrollbar::-webkit-scrollbar-corner{background:0 0}
 .cw-widget-scrollbar::-webkit-scrollbar-track{background:var(--cw-scrollbar-track-soft);border-radius:12px;box-shadow:inset 0 0 0 1px var(--cw-scrollbar-track-ring)}
 .cw-widget-scrollbar::-webkit-scrollbar-thumb{border-radius:12px;background:var(--cw-scrollbar-thumb);border:2px solid var(--cw-scrollbar-thumb-border);box-shadow:var(--cw-scrollbar-thumb-shadow)}
 .cw-widget-scrollbar::-webkit-scrollbar-thumb:hover{background:var(--cw-scrollbar-thumb-hover);box-shadow:var(--cw-scrollbar-thumb-hover-shadow)}
-.cw-history-widget-item{position:relative;display:grid;grid-template-columns:126px minmax(0,1fr) auto;gap:14px;align-items:center;height:90px;min-height:90px;padding:0 14px 0 0;border-radius:16px;border:1px solid var(--dash-border);background:linear-gradient(180deg,rgba(255,255,255,.045),rgba(255,255,255,.022));color:inherit;text-decoration:none;overflow:hidden;transition:background .14s ease,border-color .14s ease,transform .14s ease}
-.cw-history-widget-item:hover{background:linear-gradient(180deg,rgba(255,255,255,.065),rgba(255,255,255,.032));border-color:var(--dash-border-strong);transform:translateY(-1px)}
-.cw-history-thumb{position:relative;display:block;width:126px;height:90px;min-height:0;align-self:stretch;border-radius:15px 0 0 15px;overflow:hidden;background:var(--dash-panel-strong);border:0;border-right:1px solid var(--dash-border)}
+.cw-history-widget-item{position:relative;display:grid;grid-template-columns:104px minmax(0,1fr) auto;gap:11px;align-items:center;height:76px;min-height:76px;padding:0 11px 0 0;border-radius:11px;border:1px solid rgba(255,255,255,.055);background:linear-gradient(180deg,rgba(255,255,255,.022),rgba(255,255,255,.008));color:inherit;text-decoration:none;overflow:hidden;transition:background .14s ease,border-color .14s ease,transform .14s ease}
+.cw-history-widget-item:hover{background:linear-gradient(180deg,rgba(255,255,255,.038),rgba(255,255,255,.014));border-color:var(--dash-border-strong);transform:translateY(-1px)}
+.cw-history-thumb{position:relative;display:block;width:104px;height:76px;min-height:0;align-self:stretch;border-radius:10px 0 0 10px;overflow:hidden;background:var(--dash-panel-strong);border:0;border-right:1px solid var(--dash-border)}
 .cw-history-thumb img{display:block;width:100%;height:100%;object-fit:cover}
+.cw-history-thumb--icon{display:grid;place-items:center;width:64px;background:linear-gradient(180deg,rgba(255,255,255,.05),rgba(255,255,255,.018))}
+.cw-history-thumb--icon .material-symbols-rounded{font-size:24px;color:var(--dash-icon);opacity:.82}
+.cw-history-widget-item--plain{grid-template-columns:64px minmax(0,1fr) auto}
+.cw-playlist-widget-item{grid-template-columns:32px minmax(0,1fr) auto;height:54px;min-height:54px;padding:7px 10px;gap:10px}
+.cw-playlist-widget-item .cw-history-thumb--icon{width:32px;height:32px;align-self:center;border:1px solid rgba(255,255,255,.06);border-radius:9px;background:rgba(255,255,255,.02)}
+.cw-playlist-widget-item .cw-history-thumb--icon .material-symbols-rounded{font-size:19px}
 .cw-history-episode{position:absolute;right:6px;bottom:6px;display:inline-flex;align-items:center;justify-content:center;min-height:22px;padding:0 7px;border-radius:8px;background:rgba(6,8,13,.76);border:1px solid rgba(255,255,255,.14);font-size:11px;font-weight:850;color:#fff}
 .cw-history-copy{display:grid;gap:4px;min-width:0}
 .cw-history-copy strong{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:14px;font-weight:850;color:var(--dash-text)}
@@ -1059,14 +1102,15 @@ html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;b
 .cw-dash-source--text{width:auto;min-width:28px;padding:0 7px;font-size:10px;font-weight:900;color:var(--dash-text)}
 .cw-scrobble-route{display:grid;justify-items:end;gap:7px;min-width:0}
 .cw-scrobble-source{display:inline-flex;align-items:center;justify-content:center;gap:6px;min-height:22px;padding:0 9px 0 7px;border-radius:999px;border:1px solid rgba(var(--cw-source-rgb),.38);background:rgba(var(--cw-source-rgb),.13);box-shadow:inset 0 1px 0 rgba(255,255,255,.06),0 0 14px rgba(var(--cw-source-rgb),.10);color:rgb(var(--cw-source-rgb));font-size:10px;font-weight:900;letter-spacing:.03em;white-space:nowrap}.cw-scrobble-source>img{display:block;width:14px;height:14px;object-fit:contain;flex:0 0 14px}.cw-scrobble-source-icon--text{display:inline-grid;place-items:center;width:14px;height:14px;flex:0 0 14px;border-radius:5px;background:rgba(var(--cw-source-rgb),.18);font-size:7px;line-height:1}
-.cw-dash-see-more{display:inline-flex;align-items:center;justify-content:center;width:100%;min-height:38px;border-radius:14px;border:1px solid var(--dash-border);background:var(--dash-panel-soft);color:var(--dash-text);cursor:pointer;transition:background .14s ease,border-color .14s ease,transform .14s ease}
+.cw-dash-see-more{display:inline-flex;align-items:center;justify-content:center;width:100%;min-height:30px;border-radius:10px;border:1px solid rgba(255,255,255,.055);background:rgba(255,255,255,.018);color:rgba(232,238,252,.70);cursor:pointer;transition:background .14s ease,border-color .14s ease,transform .14s ease,color .14s ease}
 .cw-dash-see-more:hover{background:rgba(255,255,255,.075);border-color:var(--dash-border-strong);transform:translateY(-1px)}
 .cw-dash-see-more:disabled{opacity:.58;cursor:default;transform:none}
 .cw-dash-see-more .material-symbols-rounded{font-size:22px;line-height:1}
+.cw-dash-see-more-label{font-size:11px;font-weight:800;color:rgba(232,238,252,.64)}
 .cw-ratings-widget-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
 .cw-ratings-widget-grid>.cw-dash-see-more{grid-column:1/-1}
-.cw-rating-widget-card{position:relative;display:flex;align-items:flex-end;min-width:0;aspect-ratio:2/3;overflow:hidden;border-radius:16px;border:1px solid var(--dash-border);background:var(--dash-panel-strong);color:#fff;text-decoration:none;box-shadow:0 12px 26px rgba(0,0,0,.24);transition:transform .16s ease,border-color .16s ease,box-shadow .16s ease}
-.cw-rating-widget-card:hover{transform:translateY(-2px);border-color:var(--dash-border-strong);box-shadow:0 18px 34px rgba(0,0,0,.28)}
+.cw-rating-widget-card{position:relative;display:flex;align-items:flex-end;min-width:0;aspect-ratio:2/3;overflow:hidden;border-radius:13px;border:1px solid rgba(255,255,255,.065);background:var(--dash-panel-strong);color:#fff;text-decoration:none;box-shadow:none;transition:transform .16s ease,border-color .16s ease,box-shadow .16s ease}
+.cw-rating-widget-card:hover{transform:translateY(-2px);border-color:var(--dash-border-strong);box-shadow:0 10px 22px rgba(0,0,0,.16)}
 .cw-rating-widget-card::before{content:"";position:absolute;inset:0;z-index:1;background:linear-gradient(180deg,transparent 62%,rgba(3,5,9,.38) 100%);pointer-events:none}
 .cw-rating-widget-card>img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover}
 .cw-rating-score{position:absolute;z-index:3;top:0;right:0;display:block;width:34px;height:34px;border:0;border-radius:0 15px 0 0;background:#e3363b;clip-path:polygon(100% 0,100% 100%,0 0);box-shadow:none;color:#fff}
@@ -1077,7 +1121,15 @@ html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;b
 .cw-rating-overlay .cw-dash-source img{height:12px;max-width:17px}
 .cw-rating-overlay .cw-dash-source--text{width:auto;min-width:20px;padding:0 3px}
 .cw-rating-age{min-width:0;overflow:hidden;text-overflow:ellipsis;color:#fff;font-size:10px;font-weight:850;line-height:1;white-space:nowrap}
-.cw-dash-empty{display:flex;align-items:center;justify-content:center;min-height:118px;padding:14px;border-radius:16px;border:1px dashed var(--dash-border);background:rgba(255,255,255,.026);color:var(--dash-muted);font-size:13px;text-align:center}
+.cw-dash-empty{display:grid;grid-template-rows:26px 16px 16px;place-items:center;align-content:center;gap:5px;height:92px;min-height:92px;padding:10px 12px;border-radius:10px;border:0;background:transparent;color:var(--dash-muted);font-size:12px;text-align:center}
+.cw-dash-empty>.material-symbols-rounded{display:grid;place-items:center;width:30px;height:26px;border-radius:9px;border:0;background:transparent;color:var(--dash-icon);font-size:19px;opacity:.78}
+.cw-dash-empty>strong{max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:rgba(246,249,255,.90);font-size:12px;font-weight:850;line-height:1.15}
+.cw-dash-empty>small{display:block;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:rgba(190,199,216,.56);font-size:11px;line-height:1.32}
+.cw-dash-widget.is-auto-collapsed .cw-dash-widget-head{margin-bottom:7px}
+.cw-dash-widget.is-auto-collapsed .cw-dash-empty{height:92px;min-height:92px;padding:10px 12px;text-align:center}
+.cw-dash-widget.is-auto-collapsed .cw-dash-empty>small{display:block}
+.cw-dash-status-pill{display:inline-flex;align-items:center;justify-content:center;min-height:24px;padding:0 8px;border-radius:999px;border:1px solid var(--dash-border);background:rgba(255,255,255,.035);color:rgba(232,238,252,.72);font-size:10px;font-weight:900;text-transform:uppercase;white-space:nowrap}
+.cw-dash-status-pill--error{border-color:rgba(255,98,114,.22);background:rgba(255,98,114,.08);color:#ffb7c1}
 .cw-ratings-widget-grid>.cw-dash-empty{grid-column:1/-1}
 .cw-dash-skeleton{pointer-events:none;overflow:hidden}
 .cw-dash-skeleton::after,.cw-skel-block::after,.cw-skel-line::after,.cw-skel-dot::after,.cw-skel-shine{content:"";position:absolute;inset:0;background:linear-gradient(110deg,transparent 0%,rgba(255,255,255,.06) 42%,rgba(255,255,255,.18) 50%,rgba(255,255,255,.06) 58%,transparent 100%);transform:translateX(-120%);animation:cwDashShimmer 1.35s ease-in-out infinite}
@@ -1092,8 +1144,10 @@ html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;b
 .cw-dash-skeleton-poster::before{display:none}
 @keyframes cwDashShimmer{to{transform:translateX(120%)}}
 @media(prefers-reduced-motion:reduce){.cw-dash-skeleton::after,.cw-skel-block::after,.cw-skel-line::after,.cw-skel-dot::after,.cw-skel-shine{animation:none;transform:none;opacity:.35}}
-html[data-cw-theme=flat-dark] .cw-dash-widget{--dash-panel:#171a22;--dash-panel-soft:#20242d;--dash-panel-strong:#12151c;--dash-border:rgba(255,255,255,.13);--dash-border-strong:rgba(255,255,255,.19);--dash-text:#eef1f6;--dash-muted:#a9b0bd;background:#171a22!important;box-shadow:none!important;border-radius:12px!important}
+html[data-cw-theme=flat-dark] .cw-dash-widget{--dash-panel:#171a22;--dash-panel-soft:#20242d;--dash-panel-strong:#12151c;--dash-border:rgba(255,255,255,.13);--dash-border-strong:rgba(255,255,255,.19);--dash-text:#eef1f6;--dash-muted:#a9b0bd;--dash-icon:rgba(169,176,189,.52);background:#171a22!important;box-shadow:none!important;border-radius:12px!important}
 html[data-cw-theme=flat-dark] .cw-history-widget-item,html[data-cw-theme=flat-dark] .cw-dash-title-row .material-symbols-rounded,html[data-cw-theme=flat-dark] .cw-dash-ghost,html[data-cw-theme=flat-dark] .cw-dash-see-more,html[data-cw-theme=flat-dark] .cw-dash-source,html[data-cw-theme=flat-dark] .cw-dash-empty{background:#20242d!important;box-shadow:none!important}
+html[data-cw-theme=flat-dark] .cw-dash-title-row .material-symbols-rounded,html[data-cw-theme=flat-dark] .cw-dash-empty>.material-symbols-rounded,html[data-cw-theme=flat-dark] .cw-history-thumb--icon .material-symbols-rounded{background:transparent!important;color:var(--dash-icon)!important;opacity:.72}
+html[data-cw-theme=flat-dark] .cw-dash-empty{background:#20242d!important}
 html[data-cw-theme=flat-light] .cw-dash-widget{--dash-panel:#fff;--dash-panel-soft:#f5f7fb;--dash-panel-strong:#eef2f7;--dash-border:rgba(16,24,40,.16);--dash-border-strong:rgba(16,24,40,.26);--dash-text:#172033;--dash-muted:#667085;background:#fff!important;box-shadow:none!important;color:#172033}
 html[data-cw-theme=flat-light] .cw-history-widget-item,html[data-cw-theme=flat-light] .cw-dash-title-row .material-symbols-rounded,html[data-cw-theme=flat-light] .cw-dash-ghost,html[data-cw-theme=flat-light] .cw-dash-see-more,html[data-cw-theme=flat-light] .cw-dash-source,html[data-cw-theme=flat-light] .cw-dash-empty{background:#f5f7fb!important;color:#172033}
 html[data-cw-theme=flat-light] .cw-skel-block,html[data-cw-theme=flat-light] .cw-skel-line,html[data-cw-theme=flat-light] .cw-skel-dot{background:rgba(16,24,40,.08)}
@@ -1101,8 +1155,8 @@ html[data-cw-theme=flat-light] .cw-dash-skeleton-poster{background:linear-gradie
 html[data-cw-theme=flat-light] .cw-dash-skeleton::after,html[data-cw-theme=flat-light] .cw-skel-block::after,html[data-cw-theme=flat-light] .cw-skel-line::after,html[data-cw-theme=flat-light] .cw-skel-dot::after,html[data-cw-theme=flat-light] .cw-skel-shine{background:linear-gradient(110deg,transparent 0%,rgba(255,255,255,.12) 42%,rgba(255,255,255,.72) 50%,rgba(255,255,255,.12) 58%,transparent 100%)}
 html[data-cw-theme=flat-light] .cw-history-copy strong,html[data-cw-theme=flat-light] .cw-dash-title-row h3{color:#172033}
 html[data-cw-theme=flat-light] .cw-history-copy span{color:#667085}
-@media(max-width:1280px){.cw-dashboard-widgets{grid-template-columns:repeat(2,minmax(0,1fr))}.cw-dash-widget--scrobble{grid-column:1/-1}}
-@media(max-width:1180px){.cw-dashboard-widgets{grid-template-columns:1fr}.cw-ratings-widget-grid{grid-template-columns:repeat(6,minmax(0,1fr))}}
+@media(max-width:1280px){.cw-dashboard-widgets{grid-template-columns:repeat(2,minmax(0,1fr))}.cw-dash-widget[data-widget-size=large]{grid-column:1/-1}}
+@media(max-width:1180px){.cw-dashboard-widgets{grid-template-columns:1fr;grid-auto-rows:auto}.cw-dash-widget[data-widget-size=large]{grid-column:1/-1}.cw-ratings-widget-grid{grid-template-columns:repeat(6,minmax(0,1fr))}}
 @media(max-width:820px){.cw-ratings-widget-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.cw-history-widget-item{grid-template-columns:104px minmax(0,1fr);gap:11px;height:76px;min-height:76px;padding-right:12px}.cw-history-thumb{width:104px;height:76px;min-height:0}.cw-history-sources{grid-column:2;justify-content:flex-start}.cw-scrobble-route{display:flex;align-items:center;justify-content:flex-start;grid-column:2}.cw-dash-widget{padding:14px}.cw-dash-widget-head{align-items:flex-start}.cw-dash-head-actions{display:grid;justify-items:end}}
 @media(max-width:460px){.cw-ratings-widget-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.cw-dash-title-row h3{font-size:16px}.cw-dashboard-widgets{gap:12px}.cw-history-widget-item{grid-template-columns:1fr;height:auto;min-height:0;padding:0 0 12px;gap:10px}.cw-history-thumb{width:100%;height:auto;min-height:0;aspect-ratio:16/9;border-radius:15px 15px 0 0;border-right:0;border-bottom:1px solid var(--dash-border)}.cw-history-copy,.cw-history-sources,.cw-scrobble-route{padding:0 12px}.cw-history-sources,.cw-scrobble-route{grid-column:auto;justify-content:flex-start}}
 @media(max-width:1180px){.cw-main-card-head{flex-direction:column;align-items:flex-start}
@@ -1116,7 +1170,7 @@ html[data-cw-theme=flat-light] .cw-history-copy span{color:#667085}
 #ops-card .action-buttons{gap:8px}
 #update-banner{width:100%;justify-content:space-between}
 }
-@media(max-width:700px){#placeholder-card #poster-row.row-scroll{grid-auto-columns:132px}}
+@media(max-width:700px){#placeholder-card:not([data-widget-size=small]) #poster-row.row-scroll{grid-auto-columns:132px}#placeholder-card[data-widget-size=small] #poster-row.row-scroll{grid-auto-columns:76px}.cw-dashboard-layout-tools{top:-40px}.cw-dash-layout-controls{right:128px;top:10px}#placeholder-card .cw-dash-layout-controls{right:136px;top:10px}.cw-playlist-widget-item{grid-template-columns:34px minmax(0,1fr);height:auto;min-height:58px}.cw-playlist-widget-item .cw-history-sources{grid-column:2;padding:0}}
 #page-settings{padding-bottom:0}
 #cw-settings-shell{display:grid;grid-template-columns:284px minmax(0,1fr);gap:24px;align-items:start;margin-top:12px;padding-bottom:calc(132px + env(safe-area-inset-bottom,0px))}
 #cw-settings-nav{position:sticky;top:12px;display:grid;gap:16px}
@@ -1967,10 +2021,7 @@ html[data-cw-theme=flat-light] body #btn-status-refresh:hover,html[data-cw-theme
 html[data-cw-theme] body #btn-status-refresh,html.cw-theme-original body #btn-status-refresh{width:42px!important;height:42px!important;padding:0!important;border:0!important;border-radius:0!important;background:transparent!important;box-shadow:none!important;opacity:.82!important}
 html[data-cw-theme] body #btn-status-refresh:hover,html.cw-theme-original body #btn-status-refresh:hover{border:0!important;background:transparent!important;box-shadow:none!important;opacity:1!important;transform:none!important}
 html[data-cw-theme] body #btn-status-refresh:focus-visible,html.cw-theme-original body #btn-status-refresh:focus-visible{outline:2px solid rgba(87,181,138,.5)!important;outline-offset:2px!important}
-#ops-card .cw-main-card-head-actions .cw-hub-layout-strip:not(.is-open) .cw-hub-layout-actions,
-#ops-card .cw-main-card-head-actions .cw-hub-layout-strip:not(.is-open) :is(.cw-hub-refresh-proxy,.cw-hub-unhide-all){display:none!important}
-#ops-card .cw-main-card-head-actions .cw-hub-layout-strip.is-open .cw-hub-layout-actions{display:inline-flex!important}
-#ops-card .cw-main-card-head-actions .cw-hub-layout-strip.is-open :is(.cw-hub-refresh-proxy,.cw-hub-unhide-all){display:inline-flex!important}
+#ops-card .cw-main-card-head-actions .cw-hub-layout-strip :is(.cw-hub-refresh-proxy,.cw-hub-unhide-all){display:inline-flex!important}
 #ops-card .cw-main-card-head-actions>#btn-status-refresh{display:none!important}
 html[data-cw-theme=flat-light] body #conn-badges .conn-pill.ok.has-vip::before{background:#eef1fb!important}
 html[data-cw-theme=flat-light] body #conn-badges .conn-provider-visual{background:radial-gradient(88% 72% at 18% 14%,rgba(var(--conn-provider-rgb,16,24,40),.28),transparent 54%),radial-gradient(72% 58% at 82% 76%,rgba(var(--conn-provider-rgb,16,24,40),.16),transparent 68%),rgba(16,24,40,.045)}
@@ -2308,6 +2359,12 @@ html[data-cw-theme=flat-light] #page-settings #sc-sec-webhook,html[data-cw-theme
 .sc2-legacy-note:hover{border-color:rgba(245,158,11,.5)!important;background:rgba(245,158,11,.13)!important;transform:translateY(-1px)}
 .sc2-defaults-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
 .sc2-field{display:grid;gap:6px;min-width:0;font-size:12px;font-weight:800;color:rgba(210,218,238,.8)}
+.sc2-label-text{display:flex;align-items:center;gap:6px;min-width:0}
+.sc2-field-help{display:inline-grid!important;place-items:center!important;width:17px;height:17px;flex:0 0 auto;border-radius:999px;color:rgba(155,188,255,.9);font-size:16px!important;line-height:1!important;cursor:help;outline:none}
+.sc2-field-help:hover,.sc2-field-help:focus-visible{color:#d8e5ff;background:rgba(95,141,255,.14)}
+.scrm-label-text{display:flex;align-items:center;gap:6px;min-width:0}
+.scrm-field-help{display:inline-grid!important;place-items:center!important;width:17px;height:17px;flex:0 0 auto;border-radius:999px;color:rgba(var(--scrm-c1),.92);font-size:16px!important;line-height:1!important;cursor:help;outline:none}
+.scrm-field-help:hover,.scrm-field-help:focus-visible{color:#fff;background:rgba(var(--scrm-c1),.16)}
 .sc2-field .input{width:100%}
 .sc2-rating-targets{display:flex;flex-wrap:wrap;gap:10px}
 .sc2-rating-pill{display:inline-flex;align-items:center;gap:8px;min-height:40px;padding:0 14px;border-radius:999px;border:1px solid rgba(138,151,176,.2);background:rgba(255,255,255,.04);color:rgba(214,224,244,.8);font-size:13px;font-weight:850;cursor:pointer;transition:border-color .15s ease,background .15s ease,transform .12s ease}

--- a/assets/js/modals/scrobbler-route/index.js
+++ b/assets/js/modals/scrobbler-route/index.js
@@ -373,12 +373,13 @@ function optionsPanel(r) {
     <section class="scrm-panel ${activeTab === "options" ? "active" : ""}" data-panel="options">
       <div class="scrm-journey scrm-journey-compact">
         <span class="material-symbols-rounded scrm-journey-icon">tune</span>
-        <div><strong>Route-level behavior</strong><p>Leave a field empty to inherit the global Watcher default from Scrobbler settings.</p></div>
+        <div><strong>Route-level behavior</strong><p>These settings apply to this route and override the global defaults.<br><b>Leave them at their defaults unless you know what you are doing.</b></p></div>
       </div>
       <div class="scrm-fields three">
         ${field("Auto remove from Watchlists", `<select class="input" id="scr-auto"><option value="inherit" ${r.options.auto_remove_watchlist === "inherit" ? "selected" : ""}>Inherit</option><option value="on" ${r.options.auto_remove_watchlist === "on" ? "selected" : ""}>On</option><option value="off" ${r.options.auto_remove_watchlist === "off" ? "selected" : ""}>Off</option></select>`, "", "Override whether watched items are removed from watchlists for this route.")}
         ${field("Watched threshold (%)", `<input class="input" id="scr-watched" type="number" min="0" max="100" value="${esc(r.options.scrobble?.watched_at ?? "")}" placeholder="Global">`, "", "Progress percentage that counts an item as watched for this route.")}
         ${field("Final-stop trust (%)", `<input class="input" id="scr-force" type="number" min="0" max="100" value="${esc(r.options.scrobble?.force_stop_at ?? "")}" placeholder="Global">`, "", "At or above this progress, a final stop event is trusted for this route.")}
+        ${field("Progress step (%)", `<input class="input" id="scr-progress-step" type="number" min="1" max="25" value="${esc(r.options.scrobble?.progress_step ?? "")}" placeholder="Global">`, "", "Minimum progress change required before sending another watching update. Leave this at the default, as it significantly affects API usage.")}
         ${field("Pause debounce (s)", `<input class="input" id="scr-watch-pause" type="number" min="0" max="3600" value="${esc(r.options.watch?.pause_debounce_seconds ?? "")}" placeholder="Global">`, "", "Seconds to ignore tiny pause/start flaps just after playback starts for this route.")}
         ${field("Suppress start (%)", `<input class="input" id="scr-watch-suppress" type="number" min="0" max="100" value="${esc(r.options.watch?.suppress_start_at ?? "")}" placeholder="Global">`, "", "Ignore new start events at or above this progress for this route.")}
       </div>
@@ -522,8 +523,10 @@ function collect() {
   const scrobble = {};
   const watched = root.querySelector("#scr-watched")?.value;
   const force = root.querySelector("#scr-force")?.value;
+  const progressStep = root.querySelector("#scr-progress-step")?.value;
   if (watched !== "") scrobble.watched_at = Number(watched);
   if (force !== "") scrobble.force_stop_at = Number(force);
+  if (progressStep !== "") scrobble.progress_step = Number(progressStep);
   const watch = {};
   const pause = root.querySelector("#scr-watch-pause")?.value;
   const suppress = root.querySelector("#scr-watch-suppress")?.value;

--- a/assets/js/modals/scrobbler-route/index.js
+++ b/assets/js/modals/scrobbler-route/index.js
@@ -110,7 +110,7 @@ function defaultRoute() {
     sink,
     sink_instance: allSinkProfiles(sink)[0]?.instance || "",
     filters: {},
-    options: { auto_remove_watchlist: "inherit", ratings: { mode: "off", targets: [] }, scrobble: {} },
+    options: { auto_remove_watchlist: "inherit", ratings: { mode: "off", targets: [] }, scrobble: {}, watch: {} },
   };
 }
 
@@ -121,6 +121,7 @@ function ensureDraft() {
   draft.options = draft.options || {};
   draft.options.ratings = draft.options.ratings || { mode: "off", targets: [] };
   draft.options.scrobble = draft.options.scrobble || {};
+  draft.options.watch = draft.options.watch || {};
   return draft;
 }
 
@@ -266,8 +267,13 @@ function navButton(key, icon, title, copy) {
   return `<button type="button" class="cw-subtile scrm-nav-item ${activeTab === key ? "active" : ""}" data-tab="${esc(key)}" aria-selected="${activeTab === key ? "true" : "false"}"><span class="material-symbols-rounded cw-connection-nav-icon">${esc(icon)}</span><span class="cw-connection-nav-copy"><strong>${esc(title)}</strong><small>${esc(copy)}</small></span><span class="material-symbols-rounded cw-connection-nav-chev">chevron_right</span></button>`;
 }
 
-function field(labelText, html, extra = "") {
-  return `<label class="scrm-field ${extra}"><span>${esc(labelText)}</span>${html}</label>`;
+function fieldHelp(text) {
+  const tip = esc(text);
+  return `<span class="scrm-field-help material-symbols-rounded" tabindex="0" role="img" aria-label="Help: ${tip}" title="${tip}">help</span>`;
+}
+
+function field(labelText, html, extra = "", helpText = "") {
+  return `<label class="scrm-field ${extra}"><span class="scrm-label-text">${esc(labelText)}${helpText ? fieldHelp(helpText) : ""}</span>${html}</label>`;
 }
 
 function journeyHelp(key) {
@@ -367,12 +373,14 @@ function optionsPanel(r) {
     <section class="scrm-panel ${activeTab === "options" ? "active" : ""}" data-panel="options">
       <div class="scrm-journey scrm-journey-compact">
         <span class="material-symbols-rounded scrm-journey-icon">tune</span>
-        <div><strong>Route-level behavior</strong><p>Only options supported by the Watcher route schema are stored here. Global debounce and progress cadence stay in Scrobbler settings.</p></div>
+        <div><strong>Route-level behavior</strong><p>Leave a field empty to inherit the global Watcher default from Scrobbler settings.</p></div>
       </div>
       <div class="scrm-fields three">
-        ${field("Auto remove from Watchlists", `<select class="input" id="scr-auto"><option value="inherit" ${r.options.auto_remove_watchlist === "inherit" ? "selected" : ""}>Inherit</option><option value="on" ${r.options.auto_remove_watchlist === "on" ? "selected" : ""}>On</option><option value="off" ${r.options.auto_remove_watchlist === "off" ? "selected" : ""}>Off</option></select>`)}
-        ${field("Watched threshold", `<input class="input" id="scr-watched" type="number" min="0" max="100" value="${esc(r.options.scrobble?.watched_at ?? "")}" placeholder="Global">`)}
-        ${field("Final-stop trust", `<input class="input" id="scr-force" type="number" min="0" max="100" value="${esc(r.options.scrobble?.force_stop_at ?? "")}" placeholder="Global">`)}
+        ${field("Auto remove from Watchlists", `<select class="input" id="scr-auto"><option value="inherit" ${r.options.auto_remove_watchlist === "inherit" ? "selected" : ""}>Inherit</option><option value="on" ${r.options.auto_remove_watchlist === "on" ? "selected" : ""}>On</option><option value="off" ${r.options.auto_remove_watchlist === "off" ? "selected" : ""}>Off</option></select>`, "", "Override whether watched items are removed from watchlists for this route.")}
+        ${field("Watched threshold (%)", `<input class="input" id="scr-watched" type="number" min="0" max="100" value="${esc(r.options.scrobble?.watched_at ?? "")}" placeholder="Global">`, "", "Progress percentage that counts an item as watched for this route.")}
+        ${field("Final-stop trust (%)", `<input class="input" id="scr-force" type="number" min="0" max="100" value="${esc(r.options.scrobble?.force_stop_at ?? "")}" placeholder="Global">`, "", "At or above this progress, a final stop event is trusted for this route.")}
+        ${field("Pause debounce (s)", `<input class="input" id="scr-watch-pause" type="number" min="0" max="3600" value="${esc(r.options.watch?.pause_debounce_seconds ?? "")}" placeholder="Global">`, "", "Seconds to ignore tiny pause/start flaps just after playback starts for this route.")}
+        ${field("Suppress start (%)", `<input class="input" id="scr-watch-suppress" type="number" min="0" max="100" value="${esc(r.options.watch?.suppress_start_at ?? "")}" placeholder="Global">`, "", "Ignore new start events at or above this progress for this route.")}
       </div>
     </section>
   `;
@@ -516,6 +524,11 @@ function collect() {
   const force = root.querySelector("#scr-force")?.value;
   if (watched !== "") scrobble.watched_at = Number(watched);
   if (force !== "") scrobble.force_stop_at = Number(force);
+  const watch = {};
+  const pause = root.querySelector("#scr-watch-pause")?.value;
+  const suppress = root.querySelector("#scr-watch-suppress")?.value;
+  if (pause !== "") watch.pause_debounce_seconds = Number(pause);
+  if (suppress !== "") watch.suppress_start_at = Number(suppress);
   const ratingsMode = root.querySelector("#scr-ratings-mode")?.value || "off";
   return {
     id: draft.id,
@@ -528,6 +541,7 @@ function collect() {
     options: {
       auto_remove_watchlist: root.querySelector("#scr-auto")?.value || "inherit",
       scrobble,
+      watch,
       ratings: provider === "plex" ? {
         mode: ratingsMode,
         targets: [...root.querySelectorAll("[data-rating-target]:checked")].map((x) => x.dataset.ratingTarget),

--- a/assets/js/scrobbler.js
+++ b/assets/js/scrobbler.js
@@ -42,6 +42,11 @@
     return `<span class="sc2-logo brand-${esc(provider)}">${src ? `<img src="${esc(src)}" alt="">` : `<span>${esc(label(provider).slice(0, 1))}</span>`}</span>`;
   }
 
+  function fieldHelp(text) {
+    const tip = esc(text);
+    return `<span class="sc2-field-help material-symbols-rounded" tabindex="0" role="img" aria-label="Help: ${tip}" title="${tip}">help</span>`;
+  }
+
   function webhookState(x) {
     if (x.enabled && x.source_configured) return ["Connected", "ok"];
     if (x.enabled) return ["Needs setup", "warn"];
@@ -202,7 +207,7 @@
     const wd = st.watch_defaults || {};
     const open = state.panels.watcherDefaults;
     const autoOn = !!st.global_auto_remove_watchlist;
-    const summary = `Auto-remove ${autoOn ? "On" : "Off"} · Pause ${wd.pause_debounce_seconds ?? "default"} · Suppress ${wd.suppress_start_at ?? "default"}`;
+    const summary = `Auto-remove ${autoOn ? "On" : "Off"} · Watched ${wd.watched_at ?? "default"} · Final-stop ${wd.force_stop_at ?? "default"} · Pause ${wd.pause_debounce_seconds ?? "default"} · Suppress ${wd.suppress_start_at ?? "default"}`;
     return `
       <section class="sc2-section sc2-collapse ${open ? "is-open" : ""}" id="sc-sec-watch-defaults">
         <button type="button" class="sc2-collapse-head" data-collapse="watcherDefaults" aria-expanded="${open ? "true" : "false"}">
@@ -214,8 +219,10 @@
           <div class="sc2-inline-note"><span class="material-symbols-rounded">info</span><span>These apply to every route unless that route sets its own Options.</span></div>
           <button type="button" class="sc2-setting-row ${autoOn ? "is-on" : "is-off"}" data-setting-toggle="auto-remove" title="${autoOn ? "Disable auto-remove" : "Enable auto-remove"}" aria-pressed="${autoOn ? "true" : "false"}"><span class="sc2-setting-ico material-symbols-rounded">bookmark_remove</span><span class="sc2-setting-copy"><strong>Auto-remove from Watchlists</strong><small>Remove watched items from watchlists automatically.</small></span><span class="sc2-setting-state">${autoOn ? "On" : "Off"}</span></button>
           <div class="sc2-defaults-grid">
-            <label class="sc2-field"><span>Pause debounce (s)</span><input class="input" type="number" min="0" max="3600" data-setting-num="watch_pause_debounce_seconds" value="${esc(wd.pause_debounce_seconds ?? "")}" placeholder="Default"></label>
-            <label class="sc2-field"><span>Suppress start (%)</span><input class="input" type="number" min="0" max="3600" data-setting-num="watch_suppress_start_at" value="${esc(wd.suppress_start_at ?? "")}" placeholder="Default"></label>
+            <label class="sc2-field"><span class="sc2-label-text">Watched threshold (%)${fieldHelp("Progress percentage that counts an item as watched for completion and auto-remove. Route options can override it.")}</span><input class="input" type="number" min="0" max="100" data-setting-num="watch_watched_at" value="${esc(wd.watched_at ?? "")}" placeholder="Default"></label>
+            <label class="sc2-field"><span class="sc2-label-text">Final-stop trust (%)${fieldHelp("At or above this progress, a final stop event is trusted even if the source is noisy near the end. Route options can override it.")}</span><input class="input" type="number" min="0" max="100" data-setting-num="watch_force_stop_at" value="${esc(wd.force_stop_at ?? "")}" placeholder="Default"></label>
+            <label class="sc2-field"><span class="sc2-label-text">Pause debounce (s)${fieldHelp("Seconds to ignore tiny pause/start flaps just after playback starts.")}</span><input class="input" type="number" min="0" max="3600" data-setting-num="watch_pause_debounce_seconds" value="${esc(wd.pause_debounce_seconds ?? "")}" placeholder="Default"></label>
+            <label class="sc2-field"><span class="sc2-label-text">Suppress start (%)${fieldHelp("Ignore new start events at or above this progress to avoid credits and near-end restarts.")}</span><input class="input" type="number" min="0" max="3600" data-setting-num="watch_suppress_start_at" value="${esc(wd.suppress_start_at ?? "")}" placeholder="Default"></label>
           </div>
         </div>
       </section>

--- a/assets/js/scrobbler.js
+++ b/assets/js/scrobbler.js
@@ -207,7 +207,7 @@
     const wd = st.watch_defaults || {};
     const open = state.panels.watcherDefaults;
     const autoOn = !!st.global_auto_remove_watchlist;
-    const summary = `Auto-remove ${autoOn ? "On" : "Off"} · Watched ${wd.watched_at ?? "default"} · Final-stop ${wd.force_stop_at ?? "default"} · Pause ${wd.pause_debounce_seconds ?? "default"} · Suppress ${wd.suppress_start_at ?? "default"}`;
+    const summary = `Auto-remove ${autoOn ? "On" : "Off"} · Watched ${wd.watched_at ?? "default"} · Final-stop ${wd.force_stop_at ?? "default"} · Step ${wd.progress_step ?? "default"} · Pause ${wd.pause_debounce_seconds ?? "default"} · Suppress ${wd.suppress_start_at ?? "default"}`;
     return `
       <section class="sc2-section sc2-collapse ${open ? "is-open" : ""}" id="sc-sec-watch-defaults">
         <button type="button" class="sc2-collapse-head" data-collapse="watcherDefaults" aria-expanded="${open ? "true" : "false"}">
@@ -216,13 +216,14 @@
           <span class="sc2-collapse-chev material-symbols-rounded">expand_more</span>
         </button>
         <div class="sc2-collapse-body">
-          <div class="sc2-inline-note"><span class="material-symbols-rounded">info</span><span>These apply to every route unless that route sets its own Options.</span></div>
           <button type="button" class="sc2-setting-row ${autoOn ? "is-on" : "is-off"}" data-setting-toggle="auto-remove" title="${autoOn ? "Disable auto-remove" : "Enable auto-remove"}" aria-pressed="${autoOn ? "true" : "false"}"><span class="sc2-setting-ico material-symbols-rounded">bookmark_remove</span><span class="sc2-setting-copy"><strong>Auto-remove from Watchlists</strong><small>Remove watched items from watchlists automatically.</small></span><span class="sc2-setting-state">${autoOn ? "On" : "Off"}</span></button>
+          <div class="sc2-inline-note"><span class="material-symbols-rounded">info</span><span>These settings apply to all routes unless overridden.<br><strong>Leave them at their defaults unless you know what you are doing.</strong></span></div>
           <div class="sc2-defaults-grid">
             <label class="sc2-field"><span class="sc2-label-text">Watched threshold (%)${fieldHelp("Progress percentage that counts an item as watched for completion and auto-remove. Route options can override it.")}</span><input class="input" type="number" min="0" max="100" data-setting-num="watch_watched_at" value="${esc(wd.watched_at ?? "")}" placeholder="Default"></label>
             <label class="sc2-field"><span class="sc2-label-text">Final-stop trust (%)${fieldHelp("At or above this progress, a final stop event is trusted even if the source is noisy near the end. Route options can override it.")}</span><input class="input" type="number" min="0" max="100" data-setting-num="watch_force_stop_at" value="${esc(wd.force_stop_at ?? "")}" placeholder="Default"></label>
+            <label class="sc2-field"><span class="sc2-label-text">Progress step (%)${fieldHelp("Minimum progress change required before sending another watching update. Leave this at the default, as it significantly affects API usage.")}</span><input class="input" type="number" min="1" max="25" data-setting-num="watch_progress_step" value="${esc(wd.progress_step ?? "")}" placeholder="Default"></label>
             <label class="sc2-field"><span class="sc2-label-text">Pause debounce (s)${fieldHelp("Seconds to ignore tiny pause/start flaps just after playback starts.")}</span><input class="input" type="number" min="0" max="3600" data-setting-num="watch_pause_debounce_seconds" value="${esc(wd.pause_debounce_seconds ?? "")}" placeholder="Default"></label>
-            <label class="sc2-field"><span class="sc2-label-text">Suppress start (%)${fieldHelp("Ignore new start events at or above this progress to avoid credits and near-end restarts.")}</span><input class="input" type="number" min="0" max="3600" data-setting-num="watch_suppress_start_at" value="${esc(wd.suppress_start_at ?? "")}" placeholder="Default"></label>
+            <label class="sc2-field"><span class="sc2-label-text">Suppress start (%)${fieldHelp("Ignore new start events at or above this progress to avoid credits and near-end restarts.")}</span><input class="input" type="number" min="0" max="100" data-setting-num="watch_suppress_start_at" value="${esc(wd.suppress_start_at ?? "")}" placeholder="Default"></label>
           </div>
         </div>
       </section>

--- a/providers/scrobble/mdblist/sink.py
+++ b/providers/scrobble/mdblist/sink.py
@@ -184,10 +184,10 @@ def _progress_step(cfg: dict[str, Any]) -> int:
         s = cfg.get("scrobble") or {}
         step = (s.get("mdblist") or {}).get("progress_step")
         if step is None:
-            step = (s.get("trakt") or {}).get("progress_step", 5)
+            step = (s.get("trakt") or {}).get("progress_step", 25)
         step_i = int(step)
     except Exception:
-        step_i = 5
+        step_i = 25
     return max(1, min(25, step_i))
 
 

--- a/providers/scrobble/routes.py
+++ b/providers/scrobble/routes.py
@@ -13,6 +13,10 @@ ROUTE_SINKS = {"trakt", "simkl", "mdblist"}
 ROUTE_OPTION_STATES = {"inherit", "on", "off"}
 ROUTE_RATINGS_MODES = {"off", "custom"}
 ROUTE_SCROBBLE_POLICY_KEYS = {"watched_at", "force_stop_at"}
+ROUTE_WATCH_POLICY_RANGES = {
+    "pause_debounce_seconds": (0, 3600),
+    "suppress_start_at": (0, 100),
+}
 
 
 def _deep_clone(v: Any) -> Any:
@@ -87,6 +91,22 @@ def normalize_route_options(options: Any) -> dict[str, Any]:
         if 0.0 <= val <= 100.0:
             scrobble[key] = val
 
+    watch_raw = raw.get("watch")
+    watch_src: dict[str, Any] = watch_raw if isinstance(watch_raw, dict) else {}
+    watch: dict[str, int] = {}
+    for key, (min_val, max_val) in ROUTE_WATCH_POLICY_RANGES.items():
+        if key not in watch_src:
+            continue
+        src_val = watch_src.get(key)
+        if src_val is None:
+            continue
+        try:
+            val = int(src_val)
+        except Exception:
+            continue
+        if min_val <= val <= max_val:
+            watch[key] = val
+
     return {
         "auto_remove_watchlist": auto_remove,
         "ratings": {
@@ -96,6 +116,7 @@ def normalize_route_options(options: Any) -> dict[str, Any]:
             "webhook_token": webhook_token,
         },
         "scrobble": scrobble,
+        "watch": watch,
     }
 
 
@@ -192,6 +213,11 @@ def build_route_cfg(cfg: dict[str, Any], route: dict[str, Any]) -> dict[str, Any
     w["route_sink"] = r["sink"]
     w["route_sink_instance"] = r["sink_instance"]
     w["route_options"] = _deep_clone(r.get("options") or {})
+    watch_policy = (w.get("route_options") or {}).get("watch")
+    if isinstance(watch_policy, dict):
+        for key in ROUTE_WATCH_POLICY_RANGES:
+            if key in watch_policy:
+                w[key] = watch_policy[key]
     if r["sink"] in ROUTE_SINKS:
         policy = (w.get("route_options") or {}).get("scrobble")
         if isinstance(policy, dict):

--- a/providers/scrobble/routes.py
+++ b/providers/scrobble/routes.py
@@ -12,7 +12,12 @@ ROUTE_PROVIDERS = {"plex", "emby", "jellyfin"}
 ROUTE_SINKS = {"trakt", "simkl", "mdblist"}
 ROUTE_OPTION_STATES = {"inherit", "on", "off"}
 ROUTE_RATINGS_MODES = {"off", "custom"}
-ROUTE_SCROBBLE_POLICY_KEYS = {"watched_at", "force_stop_at"}
+ROUTE_SCROBBLE_POLICY_RANGES = {
+    "watched_at": (0.0, 100.0),
+    "force_stop_at": (0.0, 100.0),
+    "progress_step": (1.0, 25.0),
+}
+ROUTE_SCROBBLE_POLICY_KEYS = set(ROUTE_SCROBBLE_POLICY_RANGES)
 ROUTE_WATCH_POLICY_RANGES = {
     "pause_debounce_seconds": (0, 3600),
     "suppress_start_at": (0, 100),
@@ -78,7 +83,7 @@ def normalize_route_options(options: Any) -> dict[str, Any]:
     scrobble_raw = raw.get("scrobble")
     scrobble_src: dict[str, Any] = scrobble_raw if isinstance(scrobble_raw, dict) else {}
     scrobble: dict[str, float] = {}
-    for key in ROUTE_SCROBBLE_POLICY_KEYS:
+    for key, (min_val, max_val) in ROUTE_SCROBBLE_POLICY_RANGES.items():
         if key not in scrobble_src:
             continue
         src_val = scrobble_src.get(key)
@@ -88,7 +93,7 @@ def normalize_route_options(options: Any) -> dict[str, Any]:
             val = float(src_val)
         except Exception:
             continue
-        if 0.0 <= val <= 100.0:
+        if min_val <= val <= max_val:
             scrobble[key] = val
 
     watch_raw = raw.get("watch")

--- a/providers/scrobble/simkl/sink.py
+++ b/providers/scrobble/simkl/sink.py
@@ -202,10 +202,10 @@ def _progress_step(cfg: dict[str, Any]) -> int:
         s = cfg.get("scrobble") or {}
         step = (s.get("simkl") or {}).get("progress_step")
         if step is None:
-            step = (s.get("trakt") or {}).get("progress_step", 5)
+            step = (s.get("trakt") or {}).get("progress_step", 25)
         step_i = int(step)
     except Exception:
-        step_i = 5
+        step_i = 25
     return max(1, min(25, step_i))
 
 

--- a/providers/scrobble/trakt/sink.py
+++ b/providers/scrobble/trakt/sink.py
@@ -298,10 +298,10 @@ def _trakt_progress_step(cfg: dict[str, Any]) -> int:
         s = (cfg.get("scrobble") or {}).get("trakt") or {}
         step = s.get("progress_step")
         if step is None:
-            step = (cfg.get("trakt") or {}).get("progress_step", 5)
+            step = (cfg.get("trakt") or {}).get("progress_step", 25)
         step = int(step)
     except Exception:
-        step = 5
+        step = 25
     return max(1, min(25, step))
 
 


### PR DESCRIPTION
# Pull request

## Change

- Added missing Watcher default controls for watched threshold.
  - final-stop trust, progress step, pause debounce, and suppress start, plus helper tooltips.
- Added route-level overrides for watched threshold, final-stop trust, progress step, pause debounce, and suppress start.
- Corrected the `progress_step` fallback to use the documented default of `25`.

## Why

These settings were already part of the watcher/scrobble behavior, but some were missing from the global defaults UI and route Options UI. This makes the configurable watcher behavior visible and editable in the right places.

## Testing

temp test files, not part of test suite.
- test_routing_set.py
- test_config_api.py

## Issue

Relates to #462

Note: combined PR, css file has other UI adjustments