### PR TITLE
Add: customizable dashboard widgets

### DIFF
--- a/api/dashboardAPI.py
+++ b/api/dashboardAPI.py
@@ -16,6 +16,9 @@ def dashboard_widgets(
     history_limit: int = Query(8, ge=1, le=24),
     ratings_limit: int = Query(12, ge=1, le=24),
     scrobble_limit: int = Query(8, ge=1, le=24),
+    progress_limit: int = Query(8, ge=1, le=24),
+    playlists_limit: int = Query(8, ge=1, le=24),
+    include: str = Query("history,ratings,scrobble,progress,playlists"),
 ) -> JSONResponse:
     try:
         from .syncAPI import _load_state
@@ -26,6 +29,9 @@ def dashboard_widgets(
             history_limit=history_limit,
             ratings_limit=ratings_limit,
             scrobble_limit=scrobble_limit,
+            progress_limit=progress_limit,
+            playlists_limit=playlists_limit,
+            include={part.strip() for part in include.split(",") if part.strip()},
         )
         return JSONResponse(payload, headers={"Cache-Control": "no-store"})
     except Exception:

--- a/api/metaAPI.py
+++ b/api/metaAPI.py
@@ -877,7 +877,7 @@ def get_art_file(
         typ,
         str(tmdb_id),
         cache_dir=cache_dir,
-        need={art_kind: True},
+        need={"poster": True, "backdrop": True},
         locale=eff_locale,
         title=title,
         year=year,

--- a/assets/crosswatch.css
+++ b/assets/crosswatch.css
@@ -430,7 +430,8 @@ input[type=checkbox]:not(.cx-toggle input):not(.switch input):not(.toggle input)
 }
 .wl-del.icon-btn{position:absolute;top:8px;right:8px;z-index:6;pointer-events:auto;padding:0}
 .poster:hover,.wl-poster:hover{transform:translateY(-2px) scale(1.01);box-shadow:0 0 24px #7c5cff44}
-.poster img,.wl-poster img{width:100%;height:100%;object-fit:cover;display:block}
+.poster img,.wl-poster img{width:100%;height:100%;object-fit:cover;display:block;transition:transform .85s cubic-bezier(.2,.72,.18,1),filter .85s cubic-bezier(.2,.72,.18,1)}
+.poster:hover img,.wl-poster:hover img{transform:scale(1.085);filter:saturate(1.08) contrast(1.04)}
 .ovr,.wl-ovr{position:absolute;top:8px;right:8px;display:flex;gap:6px}
 .wl-del{position:absolute;top:8px;left:8px;padding:4px 8px;border-radius:999px;font-size:11px;font-weight:800;background:rgba(0,0,0,.5);border:1px solid rgba(255,255,255,.12);backdrop-filter:blur(4px);cursor:pointer}
 .poster:hover .hover,.wl-poster:hover .wl-hover{transform:translateY(0);opacity:1}
@@ -741,7 +742,7 @@ to{left:6px}
 #cw-install .cw-install-btn:hover,.cx-help:hover{background:rgba(255,255,255,.1)}
 .flex-spacer{flex:1 1 auto}
 .sc-autostart{display:inline-flex;align-items:center;gap:8px;margin-top:8px}
-.lane-ico .material-symbol{font-family:"Material Symbols Rounded";font-size:22px;line-height:1;font-variation-settings:"FILL"1}
+.lane-ico .material-symbol{font-family:"Material Symbols Rounded";font-size:22px;line-height:1;color:rgba(190,199,216,.58);opacity:.78;font-variation-settings:"FILL"0,"wght"520,"GRAD"0,"opsz"24}
 .conn-item{position:relative;display:inline-flex;align-items:center;flex:0 0 auto}
 .conn-brand{display:inline-flex;align-items:center}
 .conn-text{font-size:12.6px;white-space:nowrap;line-height:1}
@@ -925,8 +926,8 @@ html[data-cw-theme=flat-light] #ops-card #details{--det-console-bg:#fff;--det-co
 .lane-badges{flex:0 0 auto;margin-left:auto;display:flex;gap:6px;align-items:center;min-width:0}
 .lane-controls{position:absolute;left:50%;bottom:10px;z-index:3;display:flex;align-items:center;gap:4px;margin-left:0;opacity:0;transform:translateX(-50%);transition:opacity .14s ease}
 .lane:hover .lane-controls,.lane:focus-within .lane-controls{opacity:1}
-.lane-control{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;padding:0;border-radius:9px;border:1px solid rgba(255,255,255,.10);background:rgba(255,255,255,.035);color:rgba(236,241,252,.72);cursor:pointer}
-.lane-control:hover,.lane-control:focus-visible{background:rgba(255,255,255,.075);border-color:rgba(255,255,255,.18);color:#fff;outline:none}
+.lane-control{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;padding:0;border-radius:9px;border:1px solid rgba(255,255,255,.045);background:rgba(8,11,18,.24);color:rgba(190,199,216,.46);opacity:.72;cursor:pointer;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px)}
+.lane-control:hover,.lane-control:focus-visible{background:rgba(255,255,255,.055);border-color:rgba(255,255,255,.12);color:rgba(232,238,252,.86);opacity:1;outline:none}
 .lane-control .material-symbols-rounded{font-size:18px;line-height:1}
 .lane-drag{cursor:grab}
 .lane-drag:active{cursor:grabbing}
@@ -971,29 +972,30 @@ html[data-cw-theme=flat-light] #ops-card #details{--det-console-bg:#fff;--det-co
 .cw-hub-layout-toggle{position:relative}
 .cw-hub-layout-toggle .material-symbols-rounded{font-size:20px;line-height:1}
 .cw-hub-layout-strip.has-hidden .cw-hub-layout-toggle::after{content:"";position:absolute;right:5px;top:5px;width:7px;height:7px;border-radius:999px;background:#7c5cff;box-shadow:0 0 8px rgba(124,92,255,.75)}
+.cw-hub-layout-actions{display:none!important;align-items:center;gap:6px}
+.cw-hub-layout-strip.is-open .cw-hub-layout-actions{display:inline-flex!important}
 .cw-hub-layout-toggle,.cw-hub-refresh-proxy,.cw-hub-unhide-all{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;padding:0;border-radius:12px;border:1px solid rgba(255,255,255,.10);background:rgba(255,255,255,.035);color:rgba(236,241,252,.76);cursor:pointer}
 .cw-hub-layout-toggle:hover,.cw-hub-layout-toggle:focus-visible,.cw-hub-refresh-proxy:hover,.cw-hub-refresh-proxy:focus-visible,.cw-hub-unhide-all:hover,.cw-hub-unhide-all:focus-visible{background:rgba(255,255,255,.075);border-color:rgba(255,255,255,.18);color:#fff;outline:none}
 .cw-hub-layout-toggle .material-symbols-rounded,.cw-hub-refresh-proxy .material-symbols-rounded,.cw-hub-unhide-all .material-symbols-rounded{font-size:20px;line-height:1}
-.cw-hub-unhide-all:disabled{opacity:.34;cursor:not-allowed;filter:saturate(.6)}
-.cw-hub-unhide-all:disabled:hover{background:rgba(255,255,255,.035);border-color:rgba(255,255,255,.10);color:rgba(236,241,252,.76)}
+.cw-hub-unhide-all:disabled{opacity:1;cursor:not-allowed;filter:none;color:rgba(190,199,216,.38)}
+.cw-hub-unhide-all:disabled .material-symbols-rounded{opacity:.72}
+.cw-hub-unhide-all:disabled:hover{background:rgba(255,255,255,.035);border-color:rgba(255,255,255,.10);color:rgba(190,199,216,.38)}
 #ops-card .cw-main-card-head-actions>#btn-status-refresh{display:none!important}
 .cw-hub-refresh-proxy svg{display:block}
-@media(max-width:700px){.lane-badges{flex-wrap:wrap;justify-content:flex-end}.lane-controls{opacity:1}.lane-control{width:30px;height:30px}.cw-hub-layout-strip{gap:4px}.cw-hub-layout-toggle,.cw-hub-refresh-proxy,.cw-hub-unhide-all{width:34px;height:34px}}
+@media(max-width:700px){.lane-badges{flex-wrap:wrap;justify-content:flex-end}.lane-controls{opacity:1}.lane-control{width:30px;height:30px}.cw-hub-layout-strip,.cw-hub-layout-actions{gap:4px}.cw-hub-layout-toggle,.cw-hub-refresh-proxy,.cw-hub-unhide-all{width:34px;height:34px}}
 #stats-card .stats-modern{padding:16px;border:1px solid rgba(255,255,255,.08);border-radius:20px;background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(255,255,255,.012));box-shadow:0 14px 28px rgba(0,0,0,.18),inset 0 1px 0 rgba(255,255,255,.02)}
 #stats-card.stat-tiles{margin-top:14px}
 #stats-card .stat-block{margin-top:16px;padding:14px;border:1px solid rgba(255,255,255,.08);border-radius:20px;background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(255,255,255,.012));box-shadow:0 14px 28px rgba(0,0,0,.16),inset 0 1px 0 rgba(255,255,255,.02)}
 #sync-history .history-item{padding:12px 14px;border-radius:16px;background:linear-gradient(180deg,rgba(255,255,255,.032),rgba(255,255,255,.012));border:1px solid rgba(255,255,255,.07)}
 #placeholder-card.cw-main-card{padding:12px 14px 12px;background:linear-gradient(180deg,rgba(24,29,41,.50),rgba(12,15,23,.58));box-shadow:inset 0 1px 0 rgba(255,255,255,.025);backdrop-filter:blur(14px) saturate(112%);-webkit-backdrop-filter:blur(14px) saturate(112%)}
 #placeholder-card .cw-main-card-head{align-items:center;margin-bottom:8px;padding-bottom:7px;border-color:rgba(255,255,255,.07)}
-#placeholder-card .cw-main-card-kicker{margin:0;font-size:15px;font-weight:850;line-height:1.1;letter-spacing:0;text-transform:none;color:rgba(246,249,255,.96)}
 #placeholder-card .cw-widget-count-chip{box-sizing:border-box;flex:0 0 auto;min-width:30px;width:auto;height:30px;margin-left:auto;padding:0 9px;border-radius:10px;border-color:rgba(255,255,255,.07);background:rgba(255,255,255,.032);color:rgba(246,249,255,.90);box-shadow:none;font-size:13px;letter-spacing:-.01em}
 #placeholder-card .cw-watchlist-see-all{display:inline-flex;align-items:center;justify-content:center;width:auto;min-width:0;height:30px;margin-left:0;padding:0 9px;border:1px solid rgba(255,255,255,.07);border-radius:10px;background:rgba(255,255,255,.025);color:rgba(232,238,252,.78);font:inherit;font-size:11px;font-weight:800;line-height:1;text-decoration:none;cursor:pointer;transition:background .14s ease,border-color .14s ease,transform .14s ease,color .14s ease}
 #placeholder-card .cw-widget-count-chip.hidden+.cw-watchlist-see-all{margin-left:auto}
 #placeholder-card .cw-watchlist-see-all:hover{transform:translateY(-1px);background:rgba(255,255,255,.06);border-color:rgba(255,255,255,.13);color:#fff}
 #placeholder-card .cw-watchlist-see-all .material-symbols-rounded{font-size:16px;line-height:1}
 #placeholder-card .wall-msg{display:inline-flex;align-items:center;gap:8px;margin:0 0 10px;padding:8px 10px;border-radius:12px;border:1px solid var(--cw-flat-border,rgba(255,255,255,.12));background:var(--cw-flat-panel-2,rgba(255,255,255,.035));color:var(--cw-flat-muted,rgba(185,193,230,.78))}
-#placeholder-card .wall-msg.is-empty{display:grid;grid-template-rows:28px 16px 16px;place-items:center;align-content:center;gap:5px;width:100%;height:92px;min-height:92px;margin:0;justify-content:center;border:0;background:transparent;text-align:center}
-#placeholder-card .wall-msg.is-empty>.material-symbols-rounded{display:grid;place-items:center;width:32px;height:28px;border-radius:10px;border:0;background:transparent;color:rgba(190,199,216,.58);font-size:20px;opacity:.78}
+#placeholder-card .wall-msg.is-empty{display:grid;grid-template-rows:16px 16px;place-items:center;align-content:center;gap:6px;width:100%;height:92px;min-height:92px;margin:0;justify-content:center;border:0;background:transparent;text-align:center}
 #placeholder-card .wall-msg.is-empty>strong{max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:rgba(246,249,255,.94);font-size:13px;font-weight:850;line-height:1.15}
 #placeholder-card .wall-msg.is-empty>small{display:block;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--cw-flat-muted,rgba(185,193,230,.58));font-size:11px;line-height:1.35}
 #placeholder-card .wall-wrap{margin:0;padding:0 42px;min-height:0;border:0;border-radius:0;background:0 0;box-shadow:none;overflow:visible}
@@ -1002,12 +1004,36 @@ html[data-cw-theme=flat-light] #ops-card #details{--det-console-bg:#fff;--det-co
 #placeholder-card #poster-row.row-scroll::-webkit-scrollbar{display:none}
 #placeholder-card .poster{width:100%;min-width:0;border-radius:14px;border-color:rgba(255,255,255,.105);box-shadow:none;opacity:.88}
 #placeholder-card .poster:hover{opacity:1;transform:translateY(-2px);border-color:rgba(255,255,255,.2);box-shadow:0 10px 22px rgba(0,0,0,.16)}
+#placeholder-card:not([data-widget-view=grid]) .poster::before{content:"";position:absolute;inset:0;z-index:1;background:linear-gradient(180deg,rgba(4,6,10,.02) 38%,rgba(4,6,10,.34) 68%,rgba(4,6,10,.82) 100%);pointer-events:none}
 #placeholder-card .poster .ovr{top:7px;left:7px;right:7px}
+#placeholder-card .poster .wl-age{position:absolute;left:8px;top:8px;z-index:4;display:inline-flex;align-items:center;justify-content:center;max-width:calc(100% - 16px);min-height:22px;padding:0 8px;border-radius:999px;background:rgba(15,19,28,.66);border:1px solid rgba(255,255,255,.13);color:#f5f7ff;font-size:10px;font-weight:900;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px)}
+#placeholder-card .poster .wl-status{top:auto;left:50%;right:auto;bottom:38px;z-index:5;display:flex;align-items:center;justify-content:center;gap:5px;width:max-content;max-width:calc(100% - 16px);transform:translateX(-50%)}
 #placeholder-card .poster .pill{display:inline-flex;align-items:center;justify-content:center;height:24px;min-height:0;padding:0 9px;border-radius:999px;background:rgba(15,19,28,.62);border:1px solid rgba(255,255,255,.15);color:#f5f7ff;-webkit-text-fill-color:#f5f7ff;box-shadow:none;line-height:1;backdrop-filter:blur(8px) saturate(120%);-webkit-backdrop-filter:blur(8px) saturate(120%)}
-#placeholder-card .poster .hover{padding:28px 8px 8px;border-top:0;background:linear-gradient(180deg,transparent 0,rgba(4,6,10,.58) 45%,rgba(4,6,10,.82) 100%);backdrop-filter:none;-webkit-backdrop-filter:none}
-#placeholder-card .poster .hover .titleline{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:12px;font-weight:850;letter-spacing:0}
-#placeholder-card .poster .hover .meta{margin:5px 0 0;gap:5px}
-#placeholder-card .poster .hover .chip{height:20px;padding:0 7px;border-color:rgba(255,255,255,.12);background:rgba(15,19,28,.58);font-size:10px}
+#placeholder-card .poster .cap{position:absolute;left:8px;right:8px;bottom:8px;z-index:4;display:grid!important;justify-items:center;gap:3px;min-width:0;padding:0;background:transparent;text-align:center;text-shadow:0 1px 8px rgba(0,0,0,.45)}
+#placeholder-card .poster .cap strong{display:block;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#fff;font-size:11px;font-weight:900;line-height:1.05}
+#placeholder-card .poster .cap small{display:block;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:rgba(242,246,255,.75);font-size:9px;font-weight:800;line-height:1.1}
+#placeholder-card .poster .wl-meta-horizontal,#placeholder-card .poster .wl-bookmark{display:none}
+#placeholder-card[data-widget-size=large] #poster-row.row-scroll{--poster-visible:4;grid-auto-columns:calc((100% - (var(--poster-gap) * (var(--poster-visible) - 1))) / var(--poster-visible));gap:var(--poster-gap);padding:2px 0 0}
+#placeholder-card[data-widget-size=large] .poster{aspect-ratio:2.18/1;border-radius:9px;opacity:.94;background:#0d111a}
+#placeholder-card[data-widget-size=large] .poster:hover{opacity:1;transform:translateY(-1px);box-shadow:none}
+#placeholder-card[data-widget-size=large] .poster::before{content:"";position:absolute;inset:0;z-index:1;background:linear-gradient(90deg,rgba(5,7,12,.38) 0,rgba(5,7,12,.08) 48%,rgba(5,7,12,.2) 100%),linear-gradient(180deg,rgba(4,6,10,.02) 35%,rgba(4,6,10,.44) 72%,rgba(4,6,10,.86) 100%);pointer-events:none}
+#placeholder-card[data-widget-size=large] .poster .wl-age{display:none}
+#placeholder-card[data-widget-size=large] .poster .wl-status{left:12px;top:10px;right:auto;bottom:auto;max-width:calc(100% - 24px);transform:none}
+#placeholder-card[data-widget-size=large] .poster .wl-status.is-provider{left:auto;top:auto;right:12px;bottom:14px;transform:none}
+#placeholder-card[data-widget-size=large] .poster .pill{height:22px;padding:0 9px;background:rgba(89,76,183,.78);border-color:rgba(158,145,255,.3);color:#fff;-webkit-text-fill-color:#fff;font-size:10px;font-weight:900;letter-spacing:.02em}
+#placeholder-card[data-widget-size=large] .poster .cap{left:12px;right:48px;bottom:16px;justify-items:start;gap:5px;text-align:left;text-shadow:0 1px 8px rgba(0,0,0,.55)}
+#placeholder-card[data-widget-size=large] .poster .cap strong{font-size:15px;line-height:1.08}
+#placeholder-card[data-widget-size=large] .poster .cap small{font-size:10px;line-height:1;text-transform:uppercase;letter-spacing:.04em;color:rgba(242,246,255,.66)}
+#placeholder-card[data-widget-size=large] .poster .wl-meta-compact{display:none}
+#placeholder-card[data-widget-size=large] .poster .wl-meta-horizontal{display:block}
+#placeholder-card[data-widget-size=large] .poster .wl-bookmark{position:absolute;right:12px;bottom:14px;z-index:5;display:block;color:#8b6cff;-webkit-text-fill-color:#8b6cff;font-size:20px;line-height:1;font-variation-settings:"FILL" 1,"wght" 700,"GRAD" 0,"opsz" 24;filter:drop-shadow(0 2px 8px rgba(0,0,0,.45))}
+#placeholder-card[data-widget-size=large][data-widget-view=icon] #poster-row.row-scroll{grid-auto-columns:clamp(132px,8vw,156px);gap:14px;padding:2px 4px 0}
+#placeholder-card[data-widget-size=large][data-widget-view=icon] .poster{aspect-ratio:2/3;border-radius:13px;opacity:.88}
+#placeholder-card[data-widget-size=large][data-widget-view=icon] .poster .wl-age{display:inline-flex}
+#placeholder-card[data-widget-size=large][data-widget-view=icon] .poster .wl-status{left:50%;top:auto;right:auto;bottom:10px;max-width:calc(100% - 16px);transform:translateX(-50%)}
+#placeholder-card[data-widget-size=large][data-widget-view=icon] .poster .wl-status.is-provider{left:50%;top:auto;right:auto;bottom:10px;transform:translateX(-50%)}
+#placeholder-card[data-widget-size=large][data-widget-view=icon] .poster .cap{display:none!important}
+#placeholder-card[data-widget-size=large][data-widget-view=icon] .poster .wl-bookmark{display:none}
 #placeholder-card .edge{top:0;bottom:0;width:42px;opacity:.82}
 #placeholder-card .edge.left{left:0;background:linear-gradient(90deg,var(--cw-flat-panel,#171a22) 0,rgba(23,26,34,.72) 46%,transparent 100%)}
 #placeholder-card .edge.right{right:0;background:linear-gradient(270deg,var(--cw-flat-panel,#171a22) 0,rgba(23,26,34,.72) 46%,transparent 100%)}
@@ -1019,23 +1045,43 @@ html[data-cw-theme=flat-light] #ops-card #details{--det-console-bg:#fff;--det-co
 #placeholder-card[data-widget-size=small]{min-height:0}
 #placeholder-card[data-widget-size=small] .cw-main-card-head{margin-bottom:8px}
 #placeholder-card[data-widget-size=small] .wall-wrap{padding:0;overflow:hidden}
-#placeholder-card[data-widget-size=small] #poster-row.row-scroll{grid-auto-columns:82px;gap:10px;padding:0;max-height:124px;overflow:hidden}
-#placeholder-card[data-widget-size=small] .poster{border-radius:12px;opacity:.82}
-#placeholder-card[data-widget-size=small] .poster:nth-child(n+5){display:none}
+#placeholder-card[data-widget-size=small] #poster-row.row-scroll{grid-auto-flow:row;grid-template-columns:repeat(3,minmax(0,1fr));grid-auto-columns:auto;gap:12px;padding:0;max-height:none;overflow:hidden}
+#placeholder-card[data-widget-size=small] .poster{border-radius:13px;opacity:.88}
+#placeholder-card[data-widget-size=small] .poster:nth-child(n+10){display:none}
 #placeholder-card[data-widget-size=small] .edge,#placeholder-card[data-widget-size=small] .nav{display:none}
 #placeholder-card[data-widget-size=small] .poster .pill{height:20px;padding:0 7px;font-size:10px}
-#placeholder-card[data-widget-size=small] .poster .hover{padding:24px 6px 6px;background:linear-gradient(180deg,transparent 0,rgba(4,6,10,.48) 42%,rgba(4,6,10,.82) 100%);transform:translateY(0)}
-#placeholder-card[data-widget-size=small] .poster .hover .titleline{font-size:10px;line-height:1.12;white-space:nowrap}
-#placeholder-card[data-widget-size=small] .poster .hover .meta{display:none}
+#placeholder-card[data-widget-size=small] .poster .cap strong{font-size:10px;line-height:1.12}
+#placeholder-card[data-widget-size=small] .poster .cap small{display:none}
+#placeholder-card[data-widget-size=small]:not([data-widget-view=grid]) .poster .cap{display:none!important}
+#placeholder-card[data-widget-size=small]:not([data-widget-view=grid]) .poster .wl-status{bottom:10px}
+#placeholder-card[data-widget-size=small]:not([data-widget-view=grid]) .poster .wl-status.is-synced{left:50%;right:auto;transform:translateX(-50%)}
+#placeholder-card[data-widget-size=small]:not([data-widget-view=grid]) .poster .wl-episode{left:auto;right:8px;top:8px;bottom:auto;border-radius:999px;background:rgba(15,19,28,.66);border-color:rgba(255,255,255,.13);font-size:10px;min-height:22px;padding:0 8px;backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px)}
+#placeholder-card[data-widget-size=small][data-widget-view=grid] #poster-row.row-scroll{grid-auto-flow:row;grid-template-columns:1fr;grid-auto-columns:auto;gap:8px;padding:0;overflow:hidden}
+#placeholder-card[data-widget-size=small][data-widget-view=grid] .poster{display:grid;grid-template-columns:104px minmax(0,1fr) auto;align-items:center;aspect-ratio:auto;height:76px;min-height:76px;padding:0 11px 0 0;border-radius:11px;border-color:rgba(255,255,255,.055);background:linear-gradient(135deg,rgba(255,255,255,.035),rgba(255,255,255,.018));opacity:1;transform:none;box-shadow:none}
+#placeholder-card[data-widget-size=small][data-widget-view=grid] .poster:hover{transform:translateY(-1px);border-color:rgba(255,255,255,.12);box-shadow:none}
+#placeholder-card[data-widget-size=small][data-widget-view=grid] .poster:nth-child(n+4){display:grid}
+#placeholder-card[data-widget-size=small][data-widget-view=grid] .poster:nth-child(n+7){display:none}
+#placeholder-card[data-widget-size=small][data-widget-view=grid] .poster>img{position:static;grid-column:1;grid-row:1;width:104px;height:76px;min-height:0;object-fit:cover;border-radius:10px 0 0 10px;border-right:1px solid var(--dash-border)}
+#placeholder-card[data-widget-size=small][data-widget-view=grid] .poster .cap{position:static;grid-column:2;grid-row:1;display:grid!important;justify-items:start;gap:4px;min-width:0;padding:0 0 0 11px;overflow:hidden;background:transparent;text-align:left;text-shadow:none}
+#placeholder-card[data-widget-size=small][data-widget-view=grid] .poster .cap strong{color:var(--dash-text);font-size:14px;font-weight:850;line-height:1.15;text-shadow:none}
+#placeholder-card[data-widget-size=small][data-widget-view=grid] .poster .cap small{display:block;color:var(--dash-muted);font-size:12px;font-weight:650;line-height:1.15;text-shadow:none}
+#placeholder-card[data-widget-size=small][data-widget-view=grid] .poster .wl-status{position:static;grid-column:3;grid-row:1;align-self:center;justify-self:end;display:flex;width:auto!important;max-width:120px;transform:none}
+#placeholder-card[data-widget-size=small][data-widget-view=grid] .poster .pill{height:22px;padding:0 8px;font-size:10px}
+#placeholder-card[data-widget-size=small][data-widget-view=grid] .poster .wl-episode{right:auto;left:66px;bottom:6px}
+#placeholder-card:not([data-widget-size=large]) .poster .wl-meta-horizontal{display:none!important}
 html[data-cw-theme=flat-light] #placeholder-card .cw-main-card-head{border-color:rgba(16,24,40,.12)}
-html[data-cw-theme=flat-light] #placeholder-card .cw-main-card-kicker{color:#172033}
 html[data-cw-theme=flat-light] #placeholder-card .cw-widget-count-chip{background:#f5f7fb;border-color:rgba(16,24,40,.16);color:#667085}
 html[data-cw-theme=flat-light] #placeholder-card .cw-watchlist-see-all{background:#f5f7fb;border-color:rgba(16,24,40,.16);color:#172033}
 html[data-cw-theme=flat-light] #placeholder-card .cw-watchlist-see-all:hover{background:#e9edf5;border-color:rgba(16,24,40,.26)}
 html[data-cw-theme=flat-light] #placeholder-card .wall-msg{border-color:rgba(16,24,40,.16);background:#f5f7fb;color:#475467}
 html[data-cw-theme=flat-light] #placeholder-card .poster{border-color:rgba(16,24,40,.16)}
 html[data-cw-theme=flat-light] #placeholder-card .poster:hover{border-color:rgba(16,24,40,.26);box-shadow:0 12px 24px rgba(15,23,42,.14)}
+html[data-cw-theme=flat-light] #placeholder-card .poster .wl-age{background:rgba(255,255,255,.76);border-color:rgba(16,24,40,.16);color:#172033}
 html[data-cw-theme=flat-light] #placeholder-card .poster .pill{background:rgba(255,255,255,.76);border-color:rgba(16,24,40,.16);color:#172033;-webkit-text-fill-color:#172033}
+html[data-cw-theme=flat-light] #placeholder-card .poster .cap strong{color:#fff}
+html[data-cw-theme=flat-light] #placeholder-card .poster .cap small{color:rgba(255,255,255,.76)}
+html[data-cw-theme=flat-light] #placeholder-card[data-widget-size=small][data-widget-view=grid] .poster .cap strong{color:#172033}
+html[data-cw-theme=flat-light] #placeholder-card[data-widget-size=small][data-widget-view=grid] .poster .cap small{color:#667085}
 html[data-cw-theme=flat-light] #placeholder-card .edge.left{background:linear-gradient(90deg,#fff 0,rgba(255,255,255,.76) 46%,transparent 100%)}
 html[data-cw-theme=flat-light] #placeholder-card .edge.right{background:linear-gradient(270deg,#fff 0,rgba(255,255,255,.76) 46%,transparent 100%)}
 html[data-cw-theme=flat-light] #placeholder-card .nav{background:#f5f7fb;border-color:rgba(16,24,40,.18);color:#172033}
@@ -1050,12 +1096,13 @@ html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;b
 .cw-dashboard-layout-toolbar.has-hidden .cw-dashboard-layout-btn[data-cw-dashboard-layout=customize]::after{content:"";position:absolute;right:5px;top:5px;width:7px;height:7px;border-radius:999px;background:#7c5cff;box-shadow:0 0 8px rgba(124,92,255,.72)}
 .cw-dashboard-layout-btn .material-symbols-rounded{font-size:21px;line-height:1}
 .cw-dash-widget{--dash-panel:linear-gradient(180deg,rgba(23,28,39,.48),rgba(13,16,24,.56));--dash-panel-soft:rgba(255,255,255,.026);--dash-panel-strong:rgba(5,8,14,.38);--dash-border:rgba(255,255,255,.065);--dash-border-strong:rgba(255,255,255,.12);--dash-text:#f4f7ff;--dash-muted:rgba(190,199,216,.64);--dash-icon:rgba(190,199,216,.58);position:relative;align-self:start;min-width:0;overflow:hidden;border:1px solid var(--dash-border);border-radius:12px;background:var(--dash-panel);box-shadow:inset 0 1px 0 rgba(255,255,255,.025);backdrop-filter:blur(14px) saturate(112%);-webkit-backdrop-filter:blur(14px) saturate(112%);padding:12px;color:var(--dash-text)}
-.cw-dash-widget[data-widget-size=large]{grid-column:span 2}
-.cw-dash-widget--watchlist[data-widget-size=large]{grid-column:1/-1}
+.cw-dash-widget[data-widget-size=large]{grid-column:1/-1}
 .cw-dash-widget.is-dragging{opacity:.48;filter:saturate(.75)}
 .cw-dash-widget.is-drop-target{outline:1px solid rgba(169,176,189,.38);outline-offset:3px;background:linear-gradient(180deg,rgba(32,36,45,.92),rgba(23,27,36,.94))}
 .cw-dash-widget.is-drop-target::after{content:"";position:absolute;left:12px;right:12px;top:6px;height:2px;border-radius:999px;background:rgba(169,176,189,.56);pointer-events:none}
 .cw-dash-widget.is-drop-target[data-drop-position=after]::after{top:auto;bottom:6px}
+.cw-dash-widget.is-empty-widget:not(.is-dragging){opacity:.62;filter:saturate(.55)}
+.cw-dash-widget.is-empty-widget:hover,.cw-dash-widget.is-empty-widget:focus-within,.cw-dashboard-widgets.is-customizing .cw-dash-widget.is-empty-widget{opacity:.78;filter:saturate(.72)}
 .cw-dashboard-widgets.is-customizing .cw-dash-widget.is-layout-hidden{opacity:.44;filter:saturate(.55)}
 .cw-dashboard-widgets.is-customizing .cw-dash-widget.is-layout-hidden:hover{opacity:.62}
 .cw-dash-layout-controls{position:absolute;right:156px;top:12px;z-index:5;display:flex;align-items:center;gap:4px;opacity:0;pointer-events:none;transform:translateY(-2px);transition:opacity .14s ease,transform .14s ease}
@@ -1064,7 +1111,14 @@ html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;b
 .cw-dash-layout-control{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;padding:0;border-radius:9px;border:1px solid rgba(255,255,255,.045);background:rgba(8,11,18,.24);color:rgba(190,199,216,.46);opacity:.72;cursor:pointer;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px)}
 .cw-dash-layout-control:hover,.cw-dash-layout-control:focus-visible{background:rgba(255,255,255,.055);border-color:rgba(255,255,255,.12);color:rgba(232,238,252,.86);opacity:1;outline:none}
 .cw-dash-layout-control .material-symbols-rounded{font-size:18px;line-height:1}
-.cw-dash-widget--ratings,.cw-dash-widget--scrobble,.cw-dash-widget--progress,.cw-dash-widget--playlists{background:var(--dash-panel)}
+.cw-dash-widget-drag{cursor:grab}
+.cw-dash-widget-drag:active{cursor:grabbing}
+.cw-dash-widget[data-widget-size=large].cw-dash-widget--playlists .cw-dash-widget-view-toggle{display:none}
+.cw-dash-widget--history{background:radial-gradient(90% 140% at 2% 0%,rgba(115,132,190,.08),transparent 58%),var(--dash-panel)}
+.cw-dash-widget--ratings{background:radial-gradient(100% 130% at 0% 0%,rgba(151,112,255,.075),transparent 60%),var(--dash-panel)}
+.cw-dash-widget--scrobble{background:radial-gradient(96% 130% at 0% 0%,rgba(80,170,156,.07),transparent 62%),var(--dash-panel)}
+.cw-dash-widget--progress{background:radial-gradient(94% 130% at 0% 0%,rgba(97,179,122,.065),transparent 60%),var(--dash-panel)}
+.cw-dash-widget--playlists{background:radial-gradient(92% 130% at 0% 0%,rgba(129,145,190,.07),transparent 62%),var(--dash-panel)}
 .cw-dash-widget-head{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:9px;padding-bottom:7px;border-bottom:1px solid rgba(255,255,255,.045)}
 .cw-dash-title-row{display:flex;align-items:center;gap:10px;min-width:0}
 .cw-dash-title-row .material-symbols-rounded{display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border-radius:8px;border:0;background:transparent;color:var(--dash-icon);font-size:18px;opacity:.82}
@@ -1075,24 +1129,60 @@ html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;b
 .cw-dash-ghost{display:inline-flex;align-items:center;justify-content:center;flex:0 0 auto;width:28px;height:28px;border-radius:9px;border:1px solid var(--dash-border);background:var(--dash-panel-soft);color:var(--dash-icon);cursor:pointer;font-size:18px;line-height:1;transition:background .14s ease,border-color .14s ease,transform .14s ease,color .14s ease}
 .cw-dash-ghost:hover{background:rgba(255,255,255,.075);border-color:var(--dash-border-strong);transform:translateY(-1px)}
 .cw-dash-ghost.spinning .material-symbols-rounded{animation:spin .8s linear infinite}
-.cw-history-widget-list{display:grid;grid-auto-rows:max-content;align-content:start;align-items:start;gap:8px;max-height:650px;overflow:auto;padding-right:2px}
+.cw-history-widget-list{display:grid;grid-auto-rows:max-content;align-content:start;align-items:start;gap:10px;max-height:none;overflow:visible;padding-right:0}
+.cw-widget-view-grid{display:grid;grid-template-columns:1fr;grid-auto-rows:max-content;gap:10px}
+.cw-widget-view-icon{display:grid;grid-template-columns:repeat(3,minmax(0,190px));justify-content:start;gap:12px;max-height:none;overflow:visible;padding-right:0}
+.cw-widget-view-media{display:block;max-height:none;overflow:visible;padding-right:0}
+.cw-ratings-widget-grid.cw-widget-view-grid{grid-template-columns:1fr;gap:10px}
+.cw-ratings-widget-grid.cw-widget-view-icon{grid-template-columns:repeat(3,minmax(0,190px));justify-content:start;gap:12px}
+.cw-dash-widget[data-widget-size=large] .cw-widget-view-icon,.cw-dash-widget[data-widget-size=large] .cw-widget-view-media,.cw-dash-widget[data-widget-size=large] .cw-ratings-widget-grid.cw-widget-view-icon{display:block;max-height:none;overflow:visible;padding-right:0}
+.cw-widget-carousel{position:relative;display:grid;grid-template-columns:34px minmax(0,1fr) 34px;align-items:center;gap:10px;min-width:0}
+.cw-widget-carousel-row{display:grid;grid-auto-flow:column;grid-auto-columns:clamp(132px,8vw,156px);grid-template-columns:none;justify-content:start;gap:14px;min-width:0;overflow-x:auto;overflow-y:hidden;padding:1px 2px;scroll-snap-type:x proximity;scrollbar-width:none}
+.cw-widget-carousel-row::-webkit-scrollbar{display:none}
+.cw-widget-carousel-row.cw-widget-scrollbar{scrollbar-width:none}
+.cw-widget-carousel-row.cw-widget-scrollbar::-webkit-scrollbar{display:none;width:0;height:0}
+.cw-widget-carousel-row>.cw-rating-widget-card,.cw-widget-carousel-row>.cw-media-card{width:100%;scroll-snap-align:start}
+.cw-widget-view-media .cw-widget-carousel-row{--cw-media-gap:14px;grid-auto-columns:calc((100% - (var(--cw-media-gap) * 3)) / 4);gap:var(--cw-media-gap)}
+.cw-widget-carousel-nav{display:inline-flex;align-items:center;justify-content:center;width:34px;height:52px;padding:0;border-radius:999px;border:1px solid rgba(255,255,255,.075);background:rgba(33,39,55,.58);color:rgba(232,238,252,.78);cursor:pointer;box-shadow:inset 0 1px 0 rgba(255,255,255,.04);transition:background .14s ease,border-color .14s ease,color .14s ease,transform .14s ease}
+.cw-widget-carousel-nav:hover,.cw-widget-carousel-nav:focus-visible{background:rgba(49,57,78,.76);border-color:rgba(255,255,255,.14);color:#fff;transform:translateY(-1px);outline:none}
+.cw-widget-carousel-nav:disabled{opacity:.34;cursor:default;transform:none}
+.cw-widget-carousel-nav .material-symbols-rounded{font-size:24px;line-height:1}
+.cw-widget-view-icon>.cw-dash-see-more{grid-column:1/-1}
 .cw-widget-scrollbar{scrollbar-width:thin;scrollbar-color:var(--cw-scrollbar-thumb) var(--cw-scrollbar-track)}
 .cw-widget-scrollbar::-webkit-scrollbar{width:10px;height:10px}
 .cw-widget-scrollbar::-webkit-scrollbar-corner{background:0 0}
 .cw-widget-scrollbar::-webkit-scrollbar-track{background:var(--cw-scrollbar-track-soft);border-radius:12px;box-shadow:inset 0 0 0 1px var(--cw-scrollbar-track-ring)}
 .cw-widget-scrollbar::-webkit-scrollbar-thumb{border-radius:12px;background:var(--cw-scrollbar-thumb);border:2px solid var(--cw-scrollbar-thumb-border);box-shadow:var(--cw-scrollbar-thumb-shadow)}
 .cw-widget-scrollbar::-webkit-scrollbar-thumb:hover{background:var(--cw-scrollbar-thumb-hover);box-shadow:var(--cw-scrollbar-thumb-hover-shadow)}
-.cw-history-widget-item{position:relative;display:grid;grid-template-columns:104px minmax(0,1fr) auto;gap:11px;align-items:center;height:76px;min-height:76px;padding:0 11px 0 0;border-radius:11px;border:1px solid rgba(255,255,255,.055);background:linear-gradient(180deg,rgba(255,255,255,.022),rgba(255,255,255,.008));color:inherit;text-decoration:none;overflow:hidden;transition:background .14s ease,border-color .14s ease,transform .14s ease}
+.cw-history-widget-item{position:relative;display:grid;grid-template-columns:170px minmax(0,1fr) auto;gap:14px;align-items:center;height:105px;min-height:105px;padding:0 14px 0 0;border-radius:12px;border:1px solid rgba(255,255,255,.055);background:linear-gradient(180deg,rgba(255,255,255,.022),rgba(255,255,255,.008));color:inherit;text-decoration:none;overflow:hidden;transition:background .14s ease,border-color .14s ease,transform .14s ease}
 .cw-history-widget-item:hover{background:linear-gradient(180deg,rgba(255,255,255,.038),rgba(255,255,255,.014));border-color:var(--dash-border-strong);transform:translateY(-1px)}
-.cw-history-thumb{position:relative;display:block;width:104px;height:76px;min-height:0;align-self:stretch;border-radius:10px 0 0 10px;overflow:hidden;background:var(--dash-panel-strong);border:0;border-right:1px solid var(--dash-border)}
-.cw-history-thumb img{display:block;width:100%;height:100%;object-fit:cover}
+.cw-history-thumb{position:relative;isolation:isolate;display:block;width:170px;height:105px;min-height:0;align-self:stretch;border-radius:11px 0 0 11px;overflow:hidden;background:var(--dash-panel-strong);border:0;border-right:1px solid var(--dash-border)}
+.cw-history-thumb:not(.cw-history-thumb--icon)::after{content:"";position:absolute;inset:0;z-index:1;background:radial-gradient(90% 80% at 24% 0%,rgba(255,255,255,.12),transparent 45%),linear-gradient(135deg,rgba(255,255,255,.08),transparent 30%,rgba(0,0,0,.18) 100%);opacity:.48;pointer-events:none;transition:opacity .18s ease}
+.cw-history-thumb img{display:block;width:100%;height:100%;object-fit:cover;transition:transform .85s cubic-bezier(.2,.72,.18,1),filter .85s cubic-bezier(.2,.72,.18,1)}
+.cw-history-widget-item:hover .cw-history-thumb:not(.cw-history-thumb--icon)::after{opacity:.64}
+.cw-history-widget-item:hover .cw-history-thumb img{transform:scale(1.085);filter:saturate(1.08) contrast(1.04)}
+.cw-rating-grid-age{position:absolute;left:6px;top:6px;z-index:3;display:inline-flex;align-items:center;justify-content:center;max-width:calc(100% - 38px);min-height:22px;padding:0 8px;border-radius:999px;background:rgba(15,19,28,.66);border:1px solid rgba(255,255,255,.13);color:#f5f7ff;font-size:10px;font-weight:900;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px)}
+.cw-rating-grid-score{position:absolute;right:0;top:0;z-index:3;display:block;width:30px;height:30px;border:0;border-radius:0 9px 0 0;background:#e3363b;clip-path:polygon(100% 0,100% 100%,0 0);color:#fff}
+.cw-rating-grid-score>span{position:absolute;top:4px;right:0;display:block;width:19px;text-align:center;transform:rotate(45deg);font-size:12px;font-weight:900;font-variant-numeric:tabular-nums;line-height:1}
 .cw-history-thumb--icon{display:grid;place-items:center;width:64px;background:linear-gradient(180deg,rgba(255,255,255,.05),rgba(255,255,255,.018))}
 .cw-history-thumb--icon .material-symbols-rounded{font-size:24px;color:var(--dash-icon);opacity:.82}
 .cw-history-widget-item--plain{grid-template-columns:64px minmax(0,1fr) auto}
 .cw-playlist-widget-item{grid-template-columns:32px minmax(0,1fr) auto;height:54px;min-height:54px;padding:7px 10px;gap:10px}
 .cw-playlist-widget-item .cw-history-thumb--icon{width:32px;height:32px;align-self:center;border:1px solid rgba(255,255,255,.06);border-radius:9px;background:rgba(255,255,255,.02)}
 .cw-playlist-widget-item .cw-history-thumb--icon .material-symbols-rounded{font-size:19px}
-.cw-history-episode{position:absolute;right:6px;bottom:6px;display:inline-flex;align-items:center;justify-content:center;min-height:22px;padding:0 7px;border-radius:8px;background:rgba(6,8,13,.76);border:1px solid rgba(255,255,255,.14);font-size:11px;font-weight:850;color:#fff}
+.cw-widget-view-grid .cw-playlist-widget-item{grid-template-columns:76px minmax(0,1fr) auto;height:105px;min-height:105px;padding:0 14px;gap:14px}
+.cw-widget-view-grid .cw-playlist-widget-item .cw-history-thumb--icon{width:56px;height:56px;border-radius:14px;justify-self:center}
+.cw-widget-view-grid .cw-playlist-widget-item .cw-history-thumb--icon .material-symbols-rounded{font-size:27px}
+.cw-history-method-pill{position:absolute;left:7px;bottom:7px;z-index:3;display:inline-flex;align-items:center;gap:4px;max-width:calc(100% - 14px);height:22px;padding:0 8px;border-radius:999px;border:1px solid rgba(255,255,255,.14);background:rgba(11,14,21,.62);color:#f5f7ff;font-size:10px;font-weight:900;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;backdrop-filter:blur(9px) saturate(125%);-webkit-backdrop-filter:blur(9px) saturate(125%)}
+.cw-history-method-pill .material-symbols-rounded{font-size:14px;line-height:1;color:rgb(var(--cw-method-rgb,124,92,255));font-variation-settings:"FILL" 0,"wght" 650,"GRAD" 0,"opsz" 20}
+.cw-history-method-pill--webhook{--cw-method-rgb:207,85,255;background:linear-gradient(135deg,rgba(207,85,255,.26),rgba(11,14,21,.58))}
+.cw-history-method-pill--watcher{--cw-method-rgb:54,211,129;background:linear-gradient(135deg,rgba(54,211,129,.22),rgba(11,14,21,.58))}
+.cw-history-method-pill--history-sync{--cw-method-rgb:124,92,255;background:linear-gradient(135deg,rgba(124,92,255,.22),rgba(11,14,21,.58))}
+.cw-scrobble-source-pill{position:absolute;right:7px;bottom:7px;z-index:3;display:inline-flex;align-items:center;gap:5px;max-width:calc(100% - 14px);height:23px;padding:0 8px;border-radius:999px;border:1px solid rgba(var(--cw-source-rgb,124,92,255),.34);background:linear-gradient(135deg,rgba(var(--cw-source-rgb,124,92,255),.24),rgba(11,14,21,.66));box-shadow:inset 0 1px 0 rgba(255,255,255,.06);color:#f5f7ff;font-size:10px;font-weight:900;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;backdrop-filter:blur(9px) saturate(118%);-webkit-backdrop-filter:blur(9px) saturate(118%)}
+.cw-scrobble-source-pill img{display:block;width:auto;height:14px;max-width:18px;object-fit:contain;filter:drop-shadow(0 1px 3px rgba(0,0,0,.45))}
+.cw-scrobble-source-pill-text{display:inline-grid;place-items:center;width:15px;height:15px;font-size:8px;font-weight:950;line-height:1;color:#fff}
+.cw-history-widget-item--activity .cw-history-episode{right:7px;top:7px;bottom:auto}
+.cw-history-episode{position:absolute;right:6px;bottom:6px;z-index:3;display:inline-flex;align-items:center;justify-content:center;min-height:22px;padding:0 7px;border-radius:8px;background:rgba(6,8,13,.76);border:1px solid rgba(255,255,255,.14);font-size:11px;font-weight:850;color:#fff}
 .cw-history-copy{display:grid;gap:4px;min-width:0}
 .cw-history-copy strong{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:14px;font-weight:850;color:var(--dash-text)}
 .cw-history-copy span{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:12px;font-weight:650;color:var(--dash-muted)}
@@ -1100,9 +1190,32 @@ html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;b
 .cw-dash-source{display:inline-flex;align-items:center;justify-content:center;width:28px;height:24px;border-radius:999px;border:1px solid var(--dash-border);background:rgba(0,0,0,.22)}
 .cw-dash-source img{display:block;height:14px;max-width:20px;object-fit:contain}
 .cw-dash-source--text{width:auto;min-width:28px;padding:0 7px;font-size:10px;font-weight:900;color:var(--dash-text)}
-.cw-scrobble-route{display:grid;justify-items:end;gap:7px;min-width:0}
-.cw-scrobble-source{display:inline-flex;align-items:center;justify-content:center;gap:6px;min-height:22px;padding:0 9px 0 7px;border-radius:999px;border:1px solid rgba(var(--cw-source-rgb),.38);background:rgba(var(--cw-source-rgb),.13);box-shadow:inset 0 1px 0 rgba(255,255,255,.06),0 0 14px rgba(var(--cw-source-rgb),.10);color:rgb(var(--cw-source-rgb));font-size:10px;font-weight:900;letter-spacing:.03em;white-space:nowrap}.cw-scrobble-source>img{display:block;width:14px;height:14px;object-fit:contain;flex:0 0 14px}.cw-scrobble-source-icon--text{display:inline-grid;place-items:center;width:14px;height:14px;flex:0 0 14px;border-radius:5px;background:rgba(var(--cw-source-rgb),.18);font-size:7px;line-height:1}
+.cw-media-card{position:relative;display:block;min-width:0;aspect-ratio:2.16/1;overflow:hidden;border-radius:12px;border:1px solid rgba(255,255,255,.075);background:var(--dash-panel-strong);color:#fff;text-decoration:none;box-shadow:none;transition:transform .16s ease,border-color .16s ease,box-shadow .16s ease}
+.cw-media-card:hover{transform:translateY(-2px);border-color:var(--dash-border-strong);box-shadow:0 10px 22px rgba(0,0,0,.16)}
+.cw-media-card::before{content:"";position:absolute;inset:0;z-index:1;background:linear-gradient(180deg,rgba(2,4,9,.03) 20%,rgba(2,4,9,.24) 56%,rgba(2,4,9,.80) 100%);pointer-events:none}
+.cw-media-card>img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;transition:transform .9s cubic-bezier(.2,.72,.18,1),filter .9s cubic-bezier(.2,.72,.18,1)}
+.cw-media-card:hover>img{transform:scale(1.085);filter:saturate(1.08) contrast(1.04)}
+.cw-media-card-chips{position:absolute;left:11px;top:10px;right:12px;z-index:3;display:flex;align-items:center;gap:6px;max-width:calc(100% - 23px);overflow:hidden}
+.cw-media-card--scrobble .cw-media-card-chips{right:112px}
+.cw-media-card--ratings .cw-media-card-chips{max-width:calc(100% - 58px)}
+.cw-media-card-chip{display:inline-flex;align-items:center;justify-content:center;min-width:0;min-height:23px;padding:0 9px;border-radius:999px;background:rgba(15,19,28,.66);border:1px solid rgba(255,255,255,.14);color:#f5f7ff;font-size:10px;font-weight:900;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px)}
+.cw-media-card-method{position:absolute;right:11px;top:10px;z-index:4;display:flex;align-items:center;justify-content:flex-end;max-width:102px;pointer-events:none}
+.cw-media-card-method .cw-history-method-pill{position:static;left:auto;right:auto;bottom:auto;max-width:102px;height:23px;padding:0 8px}
+.cw-media-card-method .cw-history-method-pill .material-symbols-rounded{font-size:14px}
+.cw-media-card-score{position:absolute;right:0;top:0;z-index:4;display:block;width:34px;height:34px;border:0;border-radius:0 12px 0 0;background:#e3363b;clip-path:polygon(100% 0,100% 100%,0 0);color:#fff}
+.cw-media-card-score>span{position:absolute;top:5px;right:0;display:block;width:22px;text-align:center;transform:rotate(45deg);font-size:13px;font-weight:900;font-variant-numeric:tabular-nums;line-height:1}
+.cw-media-card-copy{position:absolute;left:12px;right:78px;bottom:13px;z-index:3;display:grid;gap:3px;min-width:0;pointer-events:none}
+.cw-media-card-copy strong,.cw-media-card-copy small{max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;text-shadow:0 1px 8px rgba(0,0,0,.46)}
+.cw-media-card-copy strong{font-size:14px;font-weight:900;line-height:1.05;color:#fff}
+.cw-media-card-copy small{font-size:10px;font-weight:850;line-height:1.1;color:rgba(242,246,255,.74);text-transform:none}
+.cw-media-card-sources{position:absolute;right:12px;bottom:11px;z-index:4;display:flex;align-items:center;justify-content:flex-end;gap:5px;max-width:66px}
+.cw-media-card-sources .cw-dash-source{width:24px;height:22px;background:rgba(10,12,20,.36);border-color:rgba(255,255,255,.14);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px)}
+.cw-media-card-sources .cw-dash-source img{height:13px;max-width:18px}
+.cw-media-card-sources .cw-dash-source--text{width:auto;min-width:24px;padding:0 5px;font-size:9px}
+.cw-scrobble-route{display:flex;flex-direction:column-reverse;align-items:flex-end;justify-content:center;gap:6px;min-width:0}
+.cw-scrobble-route .cw-scrobble-source-pill{position:static;right:auto;bottom:auto;max-width:118px;flex:0 1 auto}
 .cw-dash-see-more{display:inline-flex;align-items:center;justify-content:center;width:100%;min-height:30px;border-radius:10px;border:1px solid rgba(255,255,255,.055);background:rgba(255,255,255,.018);color:rgba(232,238,252,.70);cursor:pointer;transition:background .14s ease,border-color .14s ease,transform .14s ease,color .14s ease}
+.cw-widget-view-grid>.cw-dash-see-more{margin-top:4px}
 .cw-dash-see-more:hover{background:rgba(255,255,255,.075);border-color:var(--dash-border-strong);transform:translateY(-1px)}
 .cw-dash-see-more:disabled{opacity:.58;cursor:default;transform:none}
 .cw-dash-see-more .material-symbols-rounded{font-size:22px;line-height:1}
@@ -1110,9 +1223,22 @@ html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;b
 .cw-ratings-widget-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
 .cw-ratings-widget-grid>.cw-dash-see-more{grid-column:1/-1}
 .cw-rating-widget-card{position:relative;display:flex;align-items:flex-end;min-width:0;aspect-ratio:2/3;overflow:hidden;border-radius:13px;border:1px solid rgba(255,255,255,.065);background:var(--dash-panel-strong);color:#fff;text-decoration:none;box-shadow:none;transition:transform .16s ease,border-color .16s ease,box-shadow .16s ease}
+.cw-dash-widget [data-cw-widget-item]{cursor:pointer}
 .cw-rating-widget-card:hover{transform:translateY(-2px);border-color:var(--dash-border-strong);box-shadow:0 10px 22px rgba(0,0,0,.16)}
 .cw-rating-widget-card::before{content:"";position:absolute;inset:0;z-index:1;background:linear-gradient(180deg,transparent 62%,rgba(3,5,9,.38) 100%);pointer-events:none}
-.cw-rating-widget-card>img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover}
+.cw-rating-widget-card>img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;transition:transform .9s cubic-bezier(.2,.72,.18,1),filter .9s cubic-bezier(.2,.72,.18,1)}
+.cw-rating-widget-card:hover>img{transform:scale(1.085);filter:saturate(1.08) contrast(1.04)}
+.cw-widget-poster-card{background:linear-gradient(180deg,rgba(255,255,255,.045),rgba(255,255,255,.018)),var(--dash-panel-strong)}
+.cw-widget-poster-card::after{content:"";position:absolute;inset:0;z-index:1;background:linear-gradient(180deg,rgba(4,6,10,.02) 38%,rgba(4,6,10,.34) 68%,rgba(4,6,10,.82) 100%);pointer-events:none}
+.cw-widget-poster-card .cw-rating-provider-icons,.cw-widget-poster-card .cw-widget-poster-chip{z-index:3}
+.cw-widget-poster-chip{position:absolute;left:8px;top:8px;display:inline-flex;align-items:center;justify-content:center;max-width:calc(100% - 16px);min-height:22px;padding:0 8px;border-radius:999px;background:rgba(15,19,28,.66);border:1px solid rgba(255,255,255,.13);color:#f5f7ff;font-size:10px;font-weight:900;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px)}
+.cw-widget-poster-chip--episode{left:auto;right:8px;max-width:calc(100% - 74px)}
+.cw-widget-poster-fallback{position:absolute;inset:0;z-index:1;display:grid;place-items:center;color:rgba(190,199,216,.42);font-size:42px!important;line-height:1;background:radial-gradient(90% 80% at 50% 20%,rgba(255,255,255,.07),transparent 62%)}
+.cw-widget-view-icon .cw-rating-provider-icons{position:absolute;left:50%;bottom:10px;transform:translateX(-50%);z-index:6;display:flex;align-items:center;justify-content:center;gap:5px;min-width:36px;max-width:calc(100% - 20px);padding:5px 9px;border-radius:999px;background:rgba(10,12,20,.34);border:1px solid rgba(255,255,255,.14);box-shadow:inset 0 1px 0 rgba(255,255,255,.08),0 8px 20px rgba(0,0,0,.22);backdrop-filter:blur(12px) saturate(125%);-webkit-backdrop-filter:blur(12px) saturate(125%);white-space:nowrap}
+.cw-widget-view-icon .cw-rating-provider-icon{display:inline-flex;align-items:center;justify-content:center;flex:0 0 auto;width:16px;height:16px}
+.cw-widget-view-icon .cw-rating-provider-icon img{display:block;width:16px;height:16px;object-fit:contain;filter:drop-shadow(0 1px 3px rgba(0,0,0,.45))}
+.cw-widget-view-icon .cw-rating-provider-icon--text{color:#fff;font-size:9px;font-weight:900;line-height:16px;text-shadow:0 1px 4px rgba(0,0,0,.75)}
+.cw-widget-poster-card .cw-rating-provider-icons{bottom:10px}
 .cw-rating-score{position:absolute;z-index:3;top:0;right:0;display:block;width:34px;height:34px;border:0;border-radius:0 15px 0 0;background:#e3363b;clip-path:polygon(100% 0,100% 100%,0 0);box-shadow:none;color:#fff}
 .cw-rating-score>span{position:absolute;top:5px;right:0;display:block;width:22px;text-align:center;transform:rotate(45deg);font-size:14px;font-weight:900;font-variant-numeric:tabular-nums;line-height:1}
 .cw-rating-overlay{position:absolute;z-index:2;left:50%;bottom:5px;display:flex;align-items:center;justify-content:center;gap:5px;width:max-content;max-width:calc(100% - 10px);min-height:22px;padding:0 7px 0 3px;border:1px solid rgba(255,255,255,.13);border-radius:999px;background:rgba(0,0,0,.58);transform:translateX(-50%)}
@@ -1121,8 +1247,7 @@ html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;b
 .cw-rating-overlay .cw-dash-source img{height:12px;max-width:17px}
 .cw-rating-overlay .cw-dash-source--text{width:auto;min-width:20px;padding:0 3px}
 .cw-rating-age{min-width:0;overflow:hidden;text-overflow:ellipsis;color:#fff;font-size:10px;font-weight:850;line-height:1;white-space:nowrap}
-.cw-dash-empty{display:grid;grid-template-rows:26px 16px 16px;place-items:center;align-content:center;gap:5px;height:92px;min-height:92px;padding:10px 12px;border-radius:10px;border:0;background:transparent;color:var(--dash-muted);font-size:12px;text-align:center}
-.cw-dash-empty>.material-symbols-rounded{display:grid;place-items:center;width:30px;height:26px;border-radius:9px;border:0;background:transparent;color:var(--dash-icon);font-size:19px;opacity:.78}
+.cw-dash-empty{display:grid;grid-template-rows:16px 16px;place-items:center;align-content:center;gap:6px;height:92px;min-height:92px;padding:10px 12px;border-radius:10px;border:0;background:transparent;color:var(--dash-muted);font-size:12px;text-align:center}
 .cw-dash-empty>strong{max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:rgba(246,249,255,.90);font-size:12px;font-weight:850;line-height:1.15}
 .cw-dash-empty>small{display:block;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:rgba(190,199,216,.56);font-size:11px;line-height:1.32}
 .cw-dash-widget.is-auto-collapsed .cw-dash-widget-head{margin-bottom:7px}
@@ -1144,12 +1269,21 @@ html[data-cw-theme=flat-light] #placeholder-card .nav:hover{background:#e9edf5;b
 .cw-dash-skeleton-poster::before{display:none}
 @keyframes cwDashShimmer{to{transform:translateX(120%)}}
 @media(prefers-reduced-motion:reduce){.cw-dash-skeleton::after,.cw-skel-block::after,.cw-skel-line::after,.cw-skel-dot::after,.cw-skel-shine{animation:none;transform:none;opacity:.35}}
+@media(prefers-reduced-motion:reduce){.poster img,.wl-poster img,.cw-history-thumb img,.cw-media-card>img,.cw-rating-widget-card>img{transition:none}.poster:hover img,.wl-poster:hover img,.cw-history-widget-item:hover .cw-history-thumb img,.cw-media-card:hover>img,.cw-rating-widget-card:hover>img{transform:none;filter:none}}
 html[data-cw-theme=flat-dark] .cw-dash-widget{--dash-panel:#171a22;--dash-panel-soft:#20242d;--dash-panel-strong:#12151c;--dash-border:rgba(255,255,255,.13);--dash-border-strong:rgba(255,255,255,.19);--dash-text:#eef1f6;--dash-muted:#a9b0bd;--dash-icon:rgba(169,176,189,.52);background:#171a22!important;box-shadow:none!important;border-radius:12px!important}
-html[data-cw-theme=flat-dark] .cw-history-widget-item,html[data-cw-theme=flat-dark] .cw-dash-title-row .material-symbols-rounded,html[data-cw-theme=flat-dark] .cw-dash-ghost,html[data-cw-theme=flat-dark] .cw-dash-see-more,html[data-cw-theme=flat-dark] .cw-dash-source,html[data-cw-theme=flat-dark] .cw-dash-empty{background:#20242d!important;box-shadow:none!important}
-html[data-cw-theme=flat-dark] .cw-dash-title-row .material-symbols-rounded,html[data-cw-theme=flat-dark] .cw-dash-empty>.material-symbols-rounded,html[data-cw-theme=flat-dark] .cw-history-thumb--icon .material-symbols-rounded{background:transparent!important;color:var(--dash-icon)!important;opacity:.72}
-html[data-cw-theme=flat-dark] .cw-dash-empty{background:#20242d!important}
+html[data-cw-theme=flat-dark] .cw-history-widget-item,html[data-cw-theme=flat-dark] .cw-dash-title-row .material-symbols-rounded,html[data-cw-theme=flat-dark] .cw-dash-ghost,html[data-cw-theme=flat-dark] .cw-dash-see-more,html[data-cw-theme=flat-dark] .cw-dash-source{background:#20242d!important;box-shadow:none!important}
+html[data-cw-theme=flat-dark] .cw-dash-title-row .material-symbols-rounded,html[data-cw-theme=flat-dark] .cw-history-thumb--icon .material-symbols-rounded{background:transparent!important;color:var(--dash-icon)!important;opacity:.72}
+html[data-cw-theme=flat-dark] .cw-dash-empty{background:transparent!important;box-shadow:none!important}
+html[data-cw-theme=flat-dark] .cw-dash-widget--history{background:radial-gradient(92% 140% at 0% 0%,rgba(115,132,190,.08),transparent 58%),#171a22!important}
+html[data-cw-theme=flat-dark] .cw-dash-widget--ratings{background:radial-gradient(100% 140% at 0% 0%,rgba(151,112,255,.07),transparent 60%),#171a22!important}
+html[data-cw-theme=flat-dark] .cw-dash-widget--scrobble{background:radial-gradient(98% 138% at 0% 0%,rgba(80,170,156,.065),transparent 62%),#171a22!important}
+html[data-cw-theme=flat-dark] .cw-dash-widget--progress{background:radial-gradient(96% 136% at 0% 0%,rgba(97,179,122,.06),transparent 60%),#171a22!important}
+html[data-cw-theme=flat-dark] .cw-dash-widget--playlists{background:radial-gradient(94% 136% at 0% 0%,rgba(129,145,190,.065),transparent 62%),#171a22!important}
+html[data-cw-theme=flat-dark] .cw-dash-widget.is-empty-widget:not(.is-dragging){opacity:.58;filter:saturate(.45)}
+html[data-cw-theme=flat-dark] .cw-dash-widget.is-empty-widget:hover,html[data-cw-theme=flat-dark] .cw-dash-widget.is-empty-widget:focus-within,html[data-cw-theme=flat-dark] .cw-dashboard-widgets.is-customizing .cw-dash-widget.is-empty-widget{opacity:.74;filter:saturate(.65)}
 html[data-cw-theme=flat-light] .cw-dash-widget{--dash-panel:#fff;--dash-panel-soft:#f5f7fb;--dash-panel-strong:#eef2f7;--dash-border:rgba(16,24,40,.16);--dash-border-strong:rgba(16,24,40,.26);--dash-text:#172033;--dash-muted:#667085;background:#fff!important;box-shadow:none!important;color:#172033}
-html[data-cw-theme=flat-light] .cw-history-widget-item,html[data-cw-theme=flat-light] .cw-dash-title-row .material-symbols-rounded,html[data-cw-theme=flat-light] .cw-dash-ghost,html[data-cw-theme=flat-light] .cw-dash-see-more,html[data-cw-theme=flat-light] .cw-dash-source,html[data-cw-theme=flat-light] .cw-dash-empty{background:#f5f7fb!important;color:#172033}
+html[data-cw-theme=flat-light] .cw-history-widget-item,html[data-cw-theme=flat-light] .cw-dash-title-row .material-symbols-rounded,html[data-cw-theme=flat-light] .cw-dash-ghost,html[data-cw-theme=flat-light] .cw-dash-see-more,html[data-cw-theme=flat-light] .cw-dash-source{background:#f5f7fb!important;color:#172033}
+html[data-cw-theme=flat-light] .cw-dash-empty{background:transparent!important;color:#172033}
 html[data-cw-theme=flat-light] .cw-skel-block,html[data-cw-theme=flat-light] .cw-skel-line,html[data-cw-theme=flat-light] .cw-skel-dot{background:rgba(16,24,40,.08)}
 html[data-cw-theme=flat-light] .cw-dash-skeleton-poster{background:linear-gradient(180deg,rgba(16,24,40,.08),rgba(16,24,40,.035))}
 html[data-cw-theme=flat-light] .cw-dash-skeleton::after,html[data-cw-theme=flat-light] .cw-skel-block::after,html[data-cw-theme=flat-light] .cw-skel-line::after,html[data-cw-theme=flat-light] .cw-skel-dot::after,html[data-cw-theme=flat-light] .cw-skel-shine{background:linear-gradient(110deg,transparent 0%,rgba(255,255,255,.12) 42%,rgba(255,255,255,.72) 50%,rgba(255,255,255,.12) 58%,transparent 100%)}
@@ -1170,7 +1304,8 @@ html[data-cw-theme=flat-light] .cw-history-copy span{color:#667085}
 #ops-card .action-buttons{gap:8px}
 #update-banner{width:100%;justify-content:space-between}
 }
-@media(max-width:700px){#placeholder-card:not([data-widget-size=small]) #poster-row.row-scroll{grid-auto-columns:132px}#placeholder-card[data-widget-size=small] #poster-row.row-scroll{grid-auto-columns:76px}.cw-dashboard-layout-tools{top:-40px}.cw-dash-layout-controls{right:128px;top:10px}#placeholder-card .cw-dash-layout-controls{right:136px;top:10px}.cw-playlist-widget-item{grid-template-columns:34px minmax(0,1fr);height:auto;min-height:58px}.cw-playlist-widget-item .cw-history-sources{grid-column:2;padding:0}}
+@media(max-width:700px){#placeholder-card:not([data-widget-size=small]) #poster-row.row-scroll{grid-auto-columns:132px}#placeholder-card[data-widget-size=small] #poster-row.row-scroll{grid-auto-flow:row;grid-template-columns:repeat(3,minmax(0,1fr));grid-auto-columns:auto}.cw-dashboard-layout-tools{top:-40px}.cw-dash-layout-controls{right:128px;top:10px}#placeholder-card .cw-dash-layout-controls{right:136px;top:10px}.cw-playlist-widget-item{grid-template-columns:34px minmax(0,1fr);height:auto;min-height:58px}.cw-playlist-widget-item .cw-history-sources{grid-column:2;padding:0}}
+@media(max-width:700px){#placeholder-card[data-widget-size=small][data-widget-view=grid] #poster-row.row-scroll{grid-template-columns:1fr}}
 #page-settings{padding-bottom:0}
 #cw-settings-shell{display:grid;grid-template-columns:284px minmax(0,1fr);gap:24px;align-items:start;margin-top:12px;padding-bottom:calc(132px + env(safe-area-inset-bottom,0px))}
 #cw-settings-nav{position:sticky;top:12px;display:grid;gap:16px}
@@ -1911,6 +2046,7 @@ html[data-cw-theme=flat-dark] .input:focus,html[data-cw-theme=flat-dark]input:no
 html[data-cw-theme=flat-dark] .badge,html[data-cw-theme=flat-dark] .chip,html[data-cw-theme=flat-dark] .conn-pill,html[data-cw-theme=flat-dark] .cw-settings-step-index,html[data-cw-theme=flat-dark] .cw-settings-step-state,html[data-cw-theme=flat-dark] .cx-state,html[data-cw-theme=flat-dark] .cx-toggle-state,html[data-cw-theme=flat-dark] .pill{background:#20242d!important;border-color:rgba(255,255,255,.14)!important;color:#dbe1eb!important;box-shadow:none!important}
 html[data-cw-theme=flat-dark] #ux-lanes .lane .chip:is(.run,.ok){background:rgba(87,181,138,.12)!important;border-color:rgba(87,181,138,.34)!important;color:#8edbb3!important;-webkit-text-fill-color:#8edbb3!important;box-shadow:inset 0 0 0 1px rgba(87,181,138,.05)!important}
 html[data-cw-theme=flat-dark] #ux-lanes .lane .chip.run{background:rgba(87,181,138,.09)!important;border-color:rgba(87,181,138,.27)!important;color:#78cfa3!important;-webkit-text-fill-color:#78cfa3!important}
+html[data-cw-theme=flat-dark] #ux-lanes .lane-ico .material-symbol{background:transparent!important;color:rgba(169,176,189,.52)!important;-webkit-text-fill-color:rgba(169,176,189,.52)!important;opacity:.72!important;font-variation-settings:"FILL"0,"wght"520,"GRAD"0,"opsz"24!important}
 html[data-cw-theme=flat-dark] .auth-dot.on,html[data-cw-theme=flat-dark] .conn-pill .dot.ok,html[data-cw-theme=flat-dark] .cw-hub-dot.on,html[data-cw-theme=flat-dark] .dot.on,html[data-cw-theme=flat-dark] .status-dot.on{background:#57b58a!important;color:#57b58a!important;box-shadow:none!important;animation:none!important}
 html[data-cw-theme=flat-dark] .auth-dot.off,html[data-cw-theme=flat-dark] .conn-pill .dot.no,html[data-cw-theme=flat-dark] .cw-hub-dot.off,html[data-cw-theme=flat-dark] .dot.off,html[data-cw-theme=flat-dark] .status-dot.off{background:#d86672!important;color:#d86672!important;box-shadow:none!important;animation:none!important}
 html[data-cw-theme=flat-dark] #conn-badges .conn-pill,html[data-cw-theme=flat-dark] .conn-pill{height:28px!important;border-radius:999px!important;background:#20242d!important}
@@ -2021,7 +2157,10 @@ html[data-cw-theme=flat-light] body #btn-status-refresh:hover,html[data-cw-theme
 html[data-cw-theme] body #btn-status-refresh,html.cw-theme-original body #btn-status-refresh{width:42px!important;height:42px!important;padding:0!important;border:0!important;border-radius:0!important;background:transparent!important;box-shadow:none!important;opacity:.82!important}
 html[data-cw-theme] body #btn-status-refresh:hover,html.cw-theme-original body #btn-status-refresh:hover{border:0!important;background:transparent!important;box-shadow:none!important;opacity:1!important;transform:none!important}
 html[data-cw-theme] body #btn-status-refresh:focus-visible,html.cw-theme-original body #btn-status-refresh:focus-visible{outline:2px solid rgba(87,181,138,.5)!important;outline-offset:2px!important}
-#ops-card .cw-main-card-head-actions .cw-hub-layout-strip :is(.cw-hub-refresh-proxy,.cw-hub-unhide-all){display:inline-flex!important}
+#ops-card .cw-main-card-head-actions .cw-hub-layout-strip:not(.is-open) .cw-hub-layout-actions,
+#ops-card .cw-main-card-head-actions .cw-hub-layout-strip:not(.is-open) :is(.cw-hub-refresh-proxy,.cw-hub-unhide-all){display:none!important}
+#ops-card .cw-main-card-head-actions .cw-hub-layout-strip.is-open .cw-hub-layout-actions{display:inline-flex!important}
+#ops-card .cw-main-card-head-actions .cw-hub-layout-strip.is-open :is(.cw-hub-refresh-proxy,.cw-hub-unhide-all){display:inline-flex!important}
 #ops-card .cw-main-card-head-actions>#btn-status-refresh{display:none!important}
 html[data-cw-theme=flat-light] body #conn-badges .conn-pill.ok.has-vip::before{background:#eef1fb!important}
 html[data-cw-theme=flat-light] body #conn-badges .conn-provider-visual{background:radial-gradient(88% 72% at 18% 14%,rgba(var(--conn-provider-rgb,16,24,40),.28),transparent 54%),radial-gradient(72% 58% at 82% 76%,rgba(var(--conn-provider-rgb,16,24,40),.16),transparent 68%),rgba(16,24,40,.045)}
@@ -2417,3 +2556,7 @@ html[data-cw-theme=flat-light] .cx-modal-shell:has(.scrm-modal) .cw-connection-f
 html[data-cw-theme=flat-light] .cx-modal-shell:has(.scrm-modal) .cw-connection-footer-save{background:#4656a6!important;border-color:rgba(70,86,166,.62)!important;color:#fff!important;-webkit-text-fill-color:#fff!important;box-shadow:none!important}
 @media(max-width:920px){.cx-modal-shell:has(.scrm-modal){width:min(960px,calc(100vw - 24px))!important;max-width:min(960px,calc(100vw - 24px))!important}.cx-modal-shell:has(.scrm-modal) .cw-connection-modal-footer{grid-template-columns:1fr 1fr!important;padding:14px!important}.cx-modal-shell:has(.scrm-modal) .cw-connection-modal-footer>span{display:none!important}.cx-modal-shell:has(.scrm-modal) .cw-connection-footer-delete{grid-column:1/-1!important}.cx-modal-shell:has(.scrm-modal) .cw-connection-footer-cancel,.cx-modal-shell:has(.scrm-modal) .cw-connection-footer-save{grid-column:auto!important;width:100%!important;min-width:0!important}}
 @media(max-width:640px){.cx-modal-shell:has(.scrm-modal){width:calc(100vw - 16px)!important;max-width:calc(100vw - 16px)!important}.cx-modal-shell:has(.scrm-modal) .cw-connection-modal-footer{grid-template-columns:1fr!important}}
+#ux-lanes .lane .lane-ico .material-symbol{font-family:"Material Symbols Rounded"!important;background:transparent!important;color:rgba(190,199,216,.58)!important;-webkit-text-fill-color:rgba(190,199,216,.58)!important;opacity:.78!important;text-shadow:none!important;filter:none!important;font-variation-settings:"FILL"0,"wght"520,"GRAD"0,"opsz"24!important}
+html[data-cw-theme=flat-dark] #ux-lanes .lane .lane-ico .material-symbol{color:rgba(169,176,189,.52)!important;-webkit-text-fill-color:rgba(169,176,189,.52)!important;opacity:.72!important}
+html[data-cw-theme=flat-dark] #ux-lanes .lane-control{background:rgba(10,13,18,.22)!important;border-color:rgba(255,255,255,.055)!important;color:rgba(169,176,189,.44)!important;box-shadow:none!important}
+html[data-cw-theme=flat-dark] #ux-lanes .lane-control:hover,html[data-cw-theme=flat-dark] #ux-lanes .lane-control:focus-visible{background:rgba(255,255,255,.045)!important;border-color:rgba(255,255,255,.12)!important;color:rgba(225,231,242,.82)!important}

--- a/assets/helpers/settings-save.js
+++ b/assets/helpers/settings-save.js
@@ -579,6 +579,8 @@ async function saveSettings() {
       show_recent_history_widget: typeof serverCfg?.ui?.show_recent_history_widget === "boolean" ? !!serverCfg.ui.show_recent_history_widget : true,
       show_latest_ratings_widget: typeof serverCfg?.ui?.show_latest_ratings_widget === "boolean" ? !!serverCfg.ui.show_latest_ratings_widget : true,
       show_recent_scrobble_widget: typeof serverCfg?.ui?.show_recent_scrobble_widget === "boolean" ? !!serverCfg.ui.show_recent_scrobble_widget : true,
+      show_recent_progress_widget: typeof serverCfg?.ui?.show_recent_progress_widget === "boolean" ? !!serverCfg.ui.show_recent_progress_widget : false,
+      show_recent_playlists_widget: typeof serverCfg?.ui?.show_recent_playlists_widget === "boolean" ? !!serverCfg.ui.show_recent_playlists_widget : false,
       recent_activity_display: normalizeUiDisplay(serverCfg?.ui?.recent_activity_display, Number(serverCfg?.ui?.recent_activity_limit)),
       recent_syncs_display: normalizeUiDisplay(serverCfg?.ui?.recent_syncs_display, Number(serverCfg?.ui?.recent_syncs_limit)),
       show_quick_add_desktop: typeof serverCfg?.ui?.show_quick_add_desktop === "boolean" ? !!serverCfg.ui.show_quick_add_desktop : true,
@@ -590,7 +592,7 @@ async function saveSettings() {
       protocol: _cwNorm(serverCfg?.ui?.protocol).toLowerCase() === "https" ? "https" : "http"
     };
 
-    [["ui_show_watchlist_preview", "show_watchlist_preview"], ["ui_show_playingcard", "show_playingcard"], ["ui_show_recent_activity", "show_recent_activity"], ["ui_show_recent_history_widget", "show_recent_history_widget"], ["ui_show_latest_ratings_widget", "show_latest_ratings_widget"], ["ui_show_recent_scrobble_widget", "show_recent_scrobble_widget"], ["ui_show_quick_add_desktop", "show_quick_add_desktop"], ["ui_show_quick_add_mobile", "show_quick_add_mobile"]].forEach(([id, key]) => {
+    [["ui_show_watchlist_preview", "show_watchlist_preview"], ["ui_show_playingcard", "show_playingcard"], ["ui_show_recent_activity", "show_recent_activity"], ["ui_show_recent_history_widget", "show_recent_history_widget"], ["ui_show_latest_ratings_widget", "show_latest_ratings_widget"], ["ui_show_recent_scrobble_widget", "show_recent_scrobble_widget"], ["ui_show_recent_progress_widget", "show_recent_progress_widget"], ["ui_show_recent_playlists_widget", "show_recent_playlists_widget"], ["ui_show_quick_add_desktop", "show_quick_add_desktop"], ["ui_show_quick_add_mobile", "show_quick_add_mobile"]].forEach(([id, key]) => {
       const el = _cwEl(id);
       if (!el) return;
       const next = el.value !== "false";

--- a/assets/helpers/settings-ui.js
+++ b/assets/helpers/settings-ui.js
@@ -193,6 +193,8 @@ function cwUiSettingsHubInit() {
     "ui_show_recent_history_widget",
     "ui_show_latest_ratings_widget",
     "ui_show_recent_scrobble_widget",
+    "ui_show_recent_progress_widget",
+    "ui_show_recent_playlists_widget",
     "ui_recent_activity_display",
     "ui_recent_syncs_display",
     "ui_show_quick_add_desktop",
@@ -1426,6 +1428,20 @@ async function loadConfig() {
         ? !!ui.show_recent_scrobble_widget
         : true;
       _setSelectValue("ui_show_recent_scrobble_widget", on ? "true" : "false");
+    }
+
+    {
+      const on = (typeof ui.show_recent_progress_widget === "boolean")
+        ? !!ui.show_recent_progress_widget
+        : false;
+      _setSelectValue("ui_show_recent_progress_widget", on ? "true" : "false");
+    }
+
+    {
+      const on = (typeof ui.show_recent_playlists_widget === "boolean")
+        ? !!ui.show_recent_playlists_widget
+        : false;
+      _setSelectValue("ui_show_recent_playlists_widget", on ? "true" : "false");
     }
 
     const normalizeDisplay = (value, fallbackLimit) => {

--- a/assets/helpers/watchlist-preview.js
+++ b/assets/helpers/watchlist-preview.js
@@ -118,6 +118,19 @@
     catch { return {}; }
   };
 
+  function relWallTime(value) {
+    let ts = Number(value || 0);
+    if (!Number.isFinite(ts) || ts <= 0) return "";
+    if (ts > 100000000000) ts = Math.floor(ts / 1000);
+    if (typeof window.relTimeFromEpoch === "function") return window.relTimeFromEpoch(ts);
+    const delta = Math.max(1, Math.floor(Date.now() / 1000) - ts);
+    const units = [["y", 31536000], ["mo", 2592000], ["w", 604800], ["d", 86400], ["h", 3600], ["m", 60]];
+    for (const [name, seconds] of units) {
+      if (delta >= seconds) return `${Math.floor(delta / seconds)}${name} ago`;
+    }
+    return `${delta}s ago`;
+  }
+
   function updateEdges() {
     const row = document.getElementById("poster-row");
     const left = document.getElementById("edgeL");
@@ -163,6 +176,87 @@
     if (!tmdb) return null;
     const kind = isTV(item.type || item.entity || item.media_type) ? "tv" : "movie";
     return `/art/tmdb/${kind}/${tmdb}?size=${encodeURIComponent(size)}${artEvidenceOf(item)}`;
+  }
+
+  function asNumber(value) {
+    const n = Number(value);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  }
+
+  function seasonNumber(item) {
+    return asNumber(item?.season_number ?? item?.episode?.season_number ?? item?.episode?.season ?? item?.season);
+  }
+
+  function episodeNumber(item) {
+    return asNumber(item?.episode_number ?? item?.episode?.episode_number ?? item?.episode?.number ?? item?.number ?? item?.episode);
+  }
+
+  function episodeLabel(item) {
+    const explicit = String(item?.episode_label || item?.episodeLabel || "").trim();
+    if (explicit) return explicit;
+    const season = seasonNumber(item);
+    const episode = episodeNumber(item);
+    return season && episode ? `S${String(season).padStart(2, "0")}E${String(episode).padStart(2, "0")}` : "";
+  }
+
+  function episodeStillUrl(item, size = "w300") {
+    const tmdb = tmdbIdOf(item);
+    const season = seasonNumber(item);
+    const episode = episodeNumber(item);
+    if (!tmdb || !season || !episode || artTypeOf(item) !== "tv") return "";
+    return `/art/tmdb/tv/${encodeURIComponent(String(tmdb))}?kind=still&season=${encodeURIComponent(String(season))}&episode=${encodeURIComponent(String(episode))}&size=${encodeURIComponent(size)}${artEvidenceOf(item)}`;
+  }
+
+  function gridArtUrl(item, size = "w300") {
+    const still = episodeStillUrl(item, size);
+    if (still) return still;
+    const tmdb = tmdbIdOf(item);
+    if (!tmdb) return "";
+    return `/art/tmdb/${artTypeOf(item)}/${encodeURIComponent(String(tmdb))}?kind=backdrop&size=${encodeURIComponent(size)}&locale=${encodeURIComponent(window.__CW_LOCALE || navigator.language || "en-US")}${artEvidenceOf(item)}`;
+  }
+
+  function applyWidgetView(view = "") {
+    const widgetCard = document.getElementById("placeholder-card");
+    const mode = view || widgetCard?.dataset?.widgetView || "icon";
+    document.querySelectorAll("#poster-row .poster img").forEach((img) => {
+      const next = (mode === "media" || mode === "grid") ? img.dataset.gridSrc : img.dataset.coverSrc;
+      if (next && img.getAttribute("src") !== next) img.src = next;
+    });
+  }
+
+  function prewarmWallImages(limit = 12) {
+    const urls = [];
+    document.querySelectorAll("#poster-row .poster img").forEach((img) => {
+      urls.push(img.dataset.coverSrc || "", img.dataset.gridSrc || "");
+    });
+    const list = [...new Set(urls.filter(Boolean))].slice(0, limit);
+    if (!list.length) return;
+    if (navigator.connection?.saveData) return;
+    const run = () => {
+      let index = 0;
+      const next = () => {
+        const url = list[index++];
+        if (!url) return;
+        let settled = false;
+        const preload = new Image();
+        const done = () => {
+          if (settled) return;
+          settled = true;
+          window.setTimeout(next, 160);
+        };
+        preload.onload = done;
+        preload.onerror = done;
+        preload.decoding = "async";
+        preload.src = url;
+        window.setTimeout(done, 3500);
+      };
+      next();
+    };
+    const start = () => {
+      if ("requestIdleCallback" in window) window.requestIdleCallback(run, { timeout: 4000 });
+      else window.setTimeout(run, 800);
+    };
+    window.setTimeout(start, 900);
   }
 
   const providerLogoPath = (name) => window.CW?.ProviderMeta?.logoPath?.(name) || "";
@@ -400,9 +494,12 @@
     row.replaceChildren();
     row.classList.add("hidden");
     row.closest(".wall-wrap")?.classList.add("is-empty");
-    msg.textContent = text;
+    msg.innerHTML = `
+      <strong>${esc(text && text !== "No items to show yet." ? text : "No watchlist items yet")}</strong>
+      <small>Synced watchlist titles will appear here.</small>`;
     msg.classList.add("is-empty");
     msg.classList.remove("hidden");
+    window.dispatchEvent(new CustomEvent("cw:watchlist-widget-state", { detail: { empty: true, count: 0 } }));
   };
 
   function pillFor(status) {
@@ -535,7 +632,6 @@
       link.target = "_blank";
       link.rel = "noopener";
       link.style.cursor = "pointer";
-      link.title = `Show details for ${item.title || "this item"}`;
       link.setAttribute("aria-label", `Show details for ${item.title || "this item"}`);
       link.dataset.type = item.type || "";
       link.dataset.tmdb = String(item.tmdb);
@@ -547,41 +643,64 @@
       img.loading = renderedCount < 4 ? "eager" : "lazy";
       if (renderedCount < 4) img.fetchPriority = "high";
       img.alt = `${item.title || ""} (${item.year || ""})`;
-      img.src = artUrl(item, "w342") || "/assets/img/placeholder_poster.svg";
+      const widgetCard = document.getElementById("placeholder-card");
+      const currentView = widgetCard?.dataset?.widgetView || "icon";
+      const horizontal = widgetCard?.dataset?.widgetSize === "large";
+      const coverSrc = artUrl(item, "w342") || "/assets/img/placeholder_poster.svg";
+      const gridSrc = gridArtUrl(item, horizontal ? "w780" : "w300") || coverSrc;
+      img.src = (currentView === "media" || currentView === "grid") ? gridSrc : coverSrc;
+      img.dataset.coverSrc = coverSrc;
+      img.dataset.gridSrc = gridSrc;
       img.onerror = function () { this.onerror = null; this.src = "/assets/img/placeholder_poster.svg"; };
       link.appendChild(img);
+
+      const timeLabel = relWallTime(getTs(item) || lastSyncEpoch);
+      if (timeLabel) {
+        const age = document.createElement("span");
+        age.className = "wl-age";
+        age.textContent = timeLabel;
+        link.appendChild(age);
+      }
+
+      const epLabel = episodeLabel(item);
+      if (epLabel) {
+        const ep = document.createElement("span");
+        ep.className = "cw-history-episode wl-episode";
+        ep.textContent = epLabel;
+        link.appendChild(ep);
+      }
 
       const overlay = document.createElement("div");
       const currentProviders = providersForItem(item).slice(0, 5);
       const routeTitle = sourceRouteTitle(item);
       const synced = String(source).toLowerCase() === "both";
-      overlay.className = "ovr";
+      overlay.className = `ovr wl-status ${synced ? "is-synced" : "is-provider"}`;
       if (routeTitle) {
-        overlay.title = routeTitle;
         overlay.setAttribute("aria-label", routeTitle);
       }
-      overlay.style.left = "8px";
-      overlay.style.right = synced ? "8px" : "auto";
-      overlay.style.justifyContent = synced ? "center" : "flex-start";
-      overlay.style.width = synced ? "calc(100% - 16px)" : "auto";
       overlay.innerHTML = synced
         ? `<div class="pill ${pill.cls}">${pill.text}</div>`
-        : currentProviders.map(providerIconMarkup).join("");
+        : currentProviders.length ? currentProviders.map(providerIconMarkup).join("") : `<div class="pill ${pill.cls}">${pill.text}</div>`;
       link.appendChild(overlay);
+
+      if (synced) {
+        const marker = document.createElement("span");
+        marker.className = "wl-bookmark material-symbols-rounded";
+        marker.setAttribute("aria-hidden", "true");
+        marker.textContent = "bookmark";
+        link.appendChild(marker);
+      }
 
       const cap = document.createElement("div");
       cap.className = "cap";
-      cap.textContent = `${item.title || ""}${item.year ? ` - ${item.year}` : ""}`;
+      const typeLabel = isTV(item.type || item.entity || item.media_type) ? (epLabel || "TV Series") : "Movie";
+      const compactMeta = [typeLabel, item.year || "", timeLabel ? `updated ${timeLabel}` : ""].filter(Boolean).join(" - ");
+      const horizontalMeta = [typeLabel, item.year || ""].filter(Boolean).join(" \u2022 ");
+      cap.innerHTML = `
+        <strong>${esc(item.title || "")}</strong>
+        <small class="wl-meta-compact">${esc(compactMeta)}</small>
+        <small class="wl-meta-horizontal">${esc(horizontalMeta)}</small>`;
       link.appendChild(cap);
-
-      const hover = document.createElement("div");
-      hover.className = "hover";
-      hover.innerHTML = `
-        <div class="titleline">${item.title || ""}</div>
-        <div class="meta">
-          <div class="chip time">${lastSyncEpoch ? `updated ${window.relTimeFromEpoch?.(lastSyncEpoch) || ""}` : ""}</div>
-        </div>`;
-      link.appendChild(hover);
 
       frag.appendChild(link);
       renderedCount++;
@@ -601,6 +720,9 @@
     msg.classList.add("hidden");
     window.__wallRenderSignature = wallSignature(wallItems, lastSyncEpoch);
     initWallInteractions();
+    applyWidgetView();
+    prewarmWallImages();
+    window.dispatchEvent(new CustomEvent("cw:watchlist-widget-state", { detail: { empty: false, count: renderedCount } }));
     return true;
   }
 
@@ -796,6 +918,8 @@
     scrollWall,
     initWallInteractions,
     artUrl,
+    applyWidgetView,
+    prewarmWallImages,
     loadWall,
     updateWatchlistPreview,
     hasTmdbKey,

--- a/assets/js/dashboard-widgets.js
+++ b/assets/js/dashboard-widgets.js
@@ -15,15 +15,206 @@
   let lastLoadedAt = 0;
   let lastSettings = null;
   let scrobbleStopRefreshTimer = null;
-  const PAGE_STEP = 6;
+  const PAGE_STEP = 9;
   const RATING_PAGE_STEP = 9;
+  const MEDIA_PAGE_STEP = 4;
+  const GRID_PAGE_STEP = 6;
   const MAX_WIDGET_ITEMS = 24;
   const WIDGET_REFRESH_TTL_MS = 60 * 1000;
-  const visibleCounts = { history: PAGE_STEP, ratings: RATING_PAGE_STEP, scrobble: PAGE_STEP };
-  const latestItems = { history: [], ratings: [], scrobble: [] };
+  const WIDGET_FETCH_RETRY_DELAYS = [350, 900, 1800];
+  const IMAGE_PREWARM_MAX = 12;
+  const visibleCounts = { history: GRID_PAGE_STEP, ratings: RATING_PAGE_STEP, scrobble: GRID_PAGE_STEP, progress: GRID_PAGE_STEP, playlists: GRID_PAGE_STEP };
+  const latestItems = { history: [], ratings: [], scrobble: [], progress: [], playlists: [] };
+  const EMPTY_META = {
+    history: { title: "No history yet", copy: "Watched items will appear here." },
+    ratings: { title: "No ratings yet", copy: "Your ratings and scores will appear here." },
+    scrobble: { title: "No scrobbles yet", copy: "Recent scrobbles from your providers will appear here." },
+    progress: { title: "No progress syncs yet", copy: "Resume position sync activity will appear here." },
+    playlists: { title: "No playlist syncs yet", copy: "Recent playlist sync activity will appear here." },
+    watchlist: { title: "No watchlist items yet", copy: "Synced watchlist titles will appear here." },
+    error: { title: "Could not load this widget", copy: "Try refreshing again in a moment." },
+  };
+  const LAYOUT_KEY = "cw.dashboardWidgets.layout.v3";
+  const WIDGETS = [
+    { key: "watchlist", id: "placeholder-card", label: "Watchlist" },
+    { key: "history", id: "recent-history-widget", label: "Recent History" },
+    { key: "ratings", id: "latest-ratings-widget", label: "Latest Ratings" },
+    { key: "scrobble", id: "recent-scrobble-widget", label: "Recent Scrobble" },
+    { key: "progress", id: "recent-progress-widget", label: "Recent Progress" },
+    { key: "playlists", id: "recent-playlists-widget", label: "Recent Playlists" },
+  ];
+  const WIDGET_KEYS = WIDGETS.map((widget) => widget.key);
+  const DEFAULT_LAYOUT = {
+    watchlist: { order: 0, size: "large", view: "icon", horizontalView: "media", hidden: false },
+    history: { order: 1, size: "small", view: "grid", horizontalView: "media", hidden: false },
+    ratings: { order: 2, size: "small", view: "icon", horizontalView: "media", hidden: false },
+    scrobble: { order: 3, size: "small", view: "grid", horizontalView: "media", hidden: false },
+    playlists: { order: 4, size: "small", view: "grid", horizontalView: "poster", hidden: false },
+    progress: { order: 5, size: "small", view: "grid", horizontalView: "media", hidden: false },
+  };
+  let widgetLayout = readLayout();
+  let customizeOpen = false;
+  let dragWidgetKey = "";
+  let dragScrollFrame = 0;
+  let dragScrollDelta = 0;
+  let masonryFrame = 0;
+  let detailCard = null;
+  let detailItem = null;
+  let detailMeta = null;
+  let detailKey = "";
 
   function authPendingError(e) {
     return String(e?.message || e || "").includes("auth setup pending");
+  }
+
+  function normalizeLayout(raw) {
+    const out = {};
+    for (const widget of WIDGETS) {
+      const base = DEFAULT_LAYOUT[widget.key];
+      const row = raw?.[widget.key] && typeof raw[widget.key] === "object" ? raw[widget.key] : {};
+      const allowedSizes = ["small", "large"];
+      out[widget.key] = {
+        order: Number.isFinite(+row.order) ? +row.order : base.order,
+        size: allowedSizes.includes(row.size) ? row.size : base.size,
+        view: ["grid", "icon"].includes(row.view) ? row.view : base.view,
+        horizontalView: ["media", "poster"].includes(row.horizontalView) ? row.horizontalView : base.horizontalView,
+        hidden: row.hidden === true,
+      };
+    }
+    return Object.fromEntries(
+      Object.entries(out)
+        .sort((a, b) => a[1].order - b[1].order || WIDGET_KEYS.indexOf(a[0]) - WIDGET_KEYS.indexOf(b[0]))
+        .map(([key, row], order) => [key, { ...row, order }])
+    );
+  }
+
+  function readLayout() {
+    try { return normalizeLayout(JSON.parse(localStorage.getItem(LAYOUT_KEY) || "null")); }
+    catch { return normalizeLayout(null); }
+  }
+
+  function saveLayout(nextLayout) {
+    widgetLayout = normalizeLayout(nextLayout);
+    try { localStorage.setItem(LAYOUT_KEY, JSON.stringify(widgetLayout)); } catch {}
+    window.dispatchEvent(new CustomEvent("cw:dashboard-widgets-layout-changed"));
+    applyVisibility(lastSettings || {});
+  }
+
+  function resetLayout() {
+    widgetLayout = normalizeLayout(null);
+    try { localStorage.removeItem(LAYOUT_KEY); } catch {}
+    window.dispatchEvent(new CustomEvent("cw:dashboard-widgets-layout-changed"));
+    applyVisibility(lastSettings || {});
+  }
+
+  function patchLayout(key, patch) {
+    if (!widgetLayout[key]) return;
+    saveLayout({ ...widgetLayout, [key]: { ...widgetLayout[key], ...patch } });
+  }
+
+  function widgetNode(key) {
+    const id = WIDGETS.find((widget) => widget.key === key)?.id;
+    return id ? document.getElementById(id) : null;
+  }
+
+  function orderedWidgets(includeHidden = true) {
+    return WIDGETS
+      .map((widget) => ({ ...widget, layout: widgetLayout[widget.key] || DEFAULT_LAYOUT[widget.key] }))
+      .filter((widget) => includeHidden || !widget.layout.hidden)
+      .sort((a, b) => a.layout.order - b.layout.order);
+  }
+
+  function moveWidgetTo(sourceKey, targetKey, after = false) {
+    if (!sourceKey || !targetKey || sourceKey === targetKey || !widgetLayout[sourceKey] || !widgetLayout[targetKey]) return;
+    const keys = orderedWidgets(true).map((widget) => widget.key).filter((key) => key !== sourceKey);
+    const targetIdx = keys.indexOf(targetKey);
+    keys.splice(targetIdx < 0 ? keys.length : targetIdx + (after ? 1 : 0), 0, sourceKey);
+    saveLayout(Object.fromEntries(keys.map((key, order) => [key, { ...widgetLayout[key], order }])));
+  }
+
+  function watchlistPosterCount() {
+    const count = document.querySelectorAll("#poster-row .poster").length;
+    if (count) return count;
+    const chip = document.getElementById("watchlist-count-chip");
+    const value = Number(chip?.textContent || 0);
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  function effectiveSize(key) {
+    const size = widgetLayout[key]?.size || DEFAULT_LAYOUT[key]?.size || "small";
+    return size === "large" ? "large" : "small";
+  }
+
+  function widgetView(key) {
+    if (effectiveSize(key) === "large") {
+      if (key === "playlists") return "icon";
+      const horizontalView = widgetLayout[key]?.horizontalView || DEFAULT_LAYOUT[key]?.horizontalView || "media";
+      return horizontalView === "poster" ? "icon" : "media";
+    }
+    const view = widgetLayout[key]?.view || DEFAULT_LAYOUT[key]?.view || "grid";
+    return view === "icon" ? "icon" : "grid";
+  }
+
+  function widgetPageStep(key) {
+    if (effectiveSize(key) === "large") return widgetView(key) === "media" ? MEDIA_PAGE_STEP : (key === "ratings" ? RATING_PAGE_STEP : PAGE_STEP);
+    return widgetView(key) === "grid" ? GRID_PAGE_STEP : (key === "ratings" ? RATING_PAGE_STEP : PAGE_STEP);
+  }
+
+  function resetVisibleCount(key) {
+    if (!visibleCounts.hasOwnProperty(key)) return;
+    visibleCounts[key] = widgetPageStep(key);
+  }
+
+  function isWidgetEmpty(key) {
+    if (key === "watchlist") {
+      return !watchlistPosterCount() || document.getElementById("wall-msg")?.classList.contains("is-empty");
+    }
+    return !!widgetNode(key)?.querySelector(".cw-dash-empty");
+  }
+
+  function activeWidgetSettings(settings) {
+    return Object.fromEntries(WIDGET_KEYS.map((key) => {
+      const enabled = settings?.[key] !== false;
+      const hidden = !!widgetLayout[key]?.hidden;
+      return [key, enabled && !hidden];
+    }));
+  }
+
+  function setWidgetEmpty(key, empty) {
+    const node = widgetNode(key);
+    if (!node) return;
+    node.classList.toggle("is-empty-widget", !!empty);
+    node.classList.toggle("is-auto-collapsed", !!empty && !customizeOpen);
+    scheduleMasonry();
+  }
+
+  function updateMasonry() {
+    masonryFrame = 0;
+    const card = $("#dashboard-widgets-card");
+    if (!card || card.classList.contains("hidden")) return;
+    const styles = getComputedStyle(card);
+    const row = Number.parseFloat(styles.getPropertyValue("--cw-widget-masonry-row")) || 8;
+    const gap = Number.parseFloat(styles.rowGap || styles.gap) || 14;
+    const singleColumn = window.matchMedia?.("(max-width: 1180px)")?.matches;
+    for (const widget of WIDGETS) {
+      const node = widgetNode(widget.key);
+      if (!node) continue;
+      if (singleColumn || node.classList.contains("hidden")) {
+        node.style.gridRowEnd = "";
+        continue;
+      }
+      node.style.gridRowEnd = "span 1";
+      const height = node.getBoundingClientRect().height;
+      node.style.gridRowEnd = `span ${Math.max(1, Math.ceil((height + gap) / (row + gap)))}`;
+    }
+  }
+
+  function scheduleMasonry() {
+    if (masonryFrame) return;
+    masonryFrame = window.requestAnimationFrame(() => {
+      updateMasonry();
+      window.setTimeout(updateMasonry, 80);
+    });
   }
 
   function scheduleAuthReadyRefresh() {
@@ -69,6 +260,24 @@
     return res.json();
   }
 
+  async function fetchWidgetPayload(url) {
+    let lastError = null;
+    for (let attempt = 0; attempt <= WIDGET_FETCH_RETRY_DELAYS.length; attempt += 1) {
+      try {
+        const data = await fetchJSON(url);
+        if (!data?.ok) throw new Error(data?.error || "dashboard_widgets_failed");
+        return data;
+      } catch (e) {
+        if (authPendingError(e)) throw e;
+        lastError = e;
+        const delay = WIDGET_FETCH_RETRY_DELAYS[attempt];
+        if (!delay) break;
+        await new Promise((resolve) => window.setTimeout(resolve, delay));
+      }
+    }
+    throw lastError || new Error("dashboard_widgets_failed");
+  }
+
   async function getConfig(force = false) {
     if (cfgPromise) return cfgPromise;
     cfgPromise = (async () => {
@@ -90,9 +299,12 @@
 
   function widgetSettings(ui) {
     return {
+      watchlist: typeof ui?.show_watchlist_preview === "boolean" ? !!ui.show_watchlist_preview : true,
       history: typeof ui?.show_recent_history_widget === "boolean" ? !!ui.show_recent_history_widget : true,
       ratings: typeof ui?.show_latest_ratings_widget === "boolean" ? !!ui.show_latest_ratings_widget : true,
       scrobble: typeof ui?.show_recent_scrobble_widget === "boolean" ? !!ui.show_recent_scrobble_widget : true,
+      progress: typeof ui?.show_recent_progress_widget === "boolean" ? !!ui.show_recent_progress_widget : false,
+      playlists: typeof ui?.show_recent_playlists_widget === "boolean" ? !!ui.show_recent_playlists_widget : false,
     };
   }
 
@@ -114,6 +326,231 @@
 
   function hideDashboardWidgets() {
     $("#dashboard-widgets-card")?.classList.add("hidden");
+  }
+
+  function updateLayoutToolbar() {
+    const card = $("#dashboard-widgets-card");
+    card?.classList.toggle("is-customizing", customizeOpen);
+  }
+
+  function ensureLayoutToolbar() {
+    const card = $("#dashboard-widgets-card");
+    card?.querySelector(".cw-dashboard-layout-toolbar")?.remove();
+    updateLayoutToolbar();
+  }
+
+  function showAllWidgets() {
+    saveLayout(Object.fromEntries(WIDGET_KEYS.map((key) => [key, { ...widgetLayout[key], hidden: false }])));
+    markWidgetsDirty(0);
+  }
+
+  function hiddenWidgetCount() {
+    return WIDGET_KEYS.filter((key) => widgetLayout[key]?.hidden).length;
+  }
+
+  function createWidgetControls(key, label) {
+    const controls = document.createElement("div");
+    controls.className = "cw-dash-layout-controls";
+    controls.innerHTML = `
+      <button type="button" class="cw-dash-layout-control cw-dash-widget-drag" draggable="true" data-cw-widget-key="${esc(key)}" title="Drag ${esc(label)}" aria-label="Drag ${esc(label)}">
+        <span class="material-symbols-rounded" aria-hidden="true">drag_indicator</span>
+      </button>
+      <button type="button" class="cw-dash-layout-control" data-cw-widget-action="size" data-cw-widget-key="${esc(key)}" title="Switch ${esc(label)} mode" aria-label="Switch ${esc(label)} mode">
+        <span class="material-symbols-rounded" aria-hidden="true">view_agenda</span>
+      </button>
+      <button type="button" class="cw-dash-layout-control cw-dash-widget-view-toggle" data-cw-widget-action="view" data-cw-widget-key="${esc(key)}" title="Toggle ${esc(label)} view" aria-label="Toggle ${esc(label)} view">
+        <span class="material-symbols-rounded" aria-hidden="true">grid_view</span>
+      </button>
+      <button type="button" class="cw-dash-layout-control" data-cw-widget-action="hide" data-cw-widget-key="${esc(key)}" title="Hide ${esc(label)}" aria-label="Hide ${esc(label)}">
+        <span class="material-symbols-rounded" aria-hidden="true">visibility_off</span>
+      </button>`;
+    const drag = controls.querySelector(".cw-dash-widget-drag");
+    drag?.addEventListener("dragstart", (ev) => {
+      dragWidgetKey = key;
+      ev.dataTransfer.effectAllowed = "move";
+      ev.dataTransfer.setData("text/plain", key);
+      widgetNode(key)?.classList.add("is-dragging");
+    });
+    drag?.addEventListener("dragend", () => {
+      dragWidgetKey = "";
+      stopDashboardDragScroll();
+      clearDashboardDropTargets();
+    });
+    return controls;
+  }
+
+  function dashboardDropTopGuard() {
+    const headerBottom = document.querySelector("header")?.getBoundingClientRect?.().bottom || 0;
+    return Math.max(72, headerBottom + 18);
+  }
+
+  function dashboardDropAfterForNode(ev, node) {
+    const rect = node.getBoundingClientRect();
+    const visibleTop = Math.max(rect.top, dashboardDropTopGuard());
+    const visibleHeight = Math.max(24, rect.bottom - visibleTop);
+    return ev.clientY > visibleTop + visibleHeight / 2;
+  }
+
+  function runDashboardDragScroll() {
+    if (!dragWidgetKey || !dragScrollDelta) {
+      dragScrollFrame = 0;
+      return;
+    }
+    window.scrollBy(0, dragScrollDelta);
+    dragScrollFrame = window.requestAnimationFrame(runDashboardDragScroll);
+  }
+
+  function updateDashboardDragScroll(ev) {
+    if (!dragWidgetKey) return;
+    const topZone = dashboardDropTopGuard() + 34;
+    const bottomZone = window.innerHeight - 76;
+    let nextDelta = 0;
+    if (ev.clientY < topZone) nextDelta = -Math.min(34, Math.max(10, Math.round((topZone - ev.clientY) / 2)));
+    else if (ev.clientY > bottomZone) nextDelta = Math.min(34, Math.max(10, Math.round((ev.clientY - bottomZone) / 2)));
+    dragScrollDelta = nextDelta;
+    if (dragScrollDelta && !dragScrollFrame) dragScrollFrame = window.requestAnimationFrame(runDashboardDragScroll);
+  }
+
+  function stopDashboardDragScroll() {
+    dragScrollDelta = 0;
+    if (dragScrollFrame) window.cancelAnimationFrame(dragScrollFrame);
+    dragScrollFrame = 0;
+  }
+
+  function clearDashboardDropTargets() {
+    document.querySelectorAll(".cw-dash-widget").forEach((node) => {
+      node.classList.remove("is-dragging", "is-drop-target");
+      delete node.dataset.dropPosition;
+    });
+  }
+
+  function markDashboardDropTarget(targetKey, after = false) {
+    document.querySelectorAll(".cw-dash-widget.is-drop-target").forEach((node) => {
+      if (node.dataset.widgetKey === targetKey) return;
+      node.classList.remove("is-drop-target");
+      delete node.dataset.dropPosition;
+    });
+    const node = widgetNode(targetKey);
+    if (!node) return;
+    node.dataset.dropPosition = after ? "after" : "before";
+    node.classList.add("is-drop-target");
+  }
+
+  function resolveDashboardDrop(ev) {
+    const nodes = orderedWidgets(false)
+      .map((widget) => widgetNode(widget.key))
+      .filter((node) => node && node.dataset.widgetKey !== dragWidgetKey && !node.classList.contains("hidden"));
+    if (!nodes.length) return null;
+    const pointerY = ev.clientY;
+    const topGuard = dashboardDropTopGuard();
+    for (const node of nodes) {
+      const rect = node.getBoundingClientRect();
+      const visibleTop = Math.max(rect.top, topGuard);
+      const visibleHeight = Math.max(24, rect.bottom - visibleTop);
+      if (pointerY < visibleTop + visibleHeight / 2) {
+        return { targetKey: node.dataset.widgetKey, after: false };
+      }
+    }
+    return { targetKey: nodes[nodes.length - 1].dataset.widgetKey, after: true };
+  }
+
+  function ensureWidgetControls() {
+    const card = $("#dashboard-widgets-card");
+    if (card && !card.__cwDashboardDropWired) {
+      card.addEventListener("dragover", (ev) => {
+        if (dragWidgetKey) updateDashboardDragScroll(ev);
+        if (!dragWidgetKey || ev.target?.closest?.(".cw-dash-widget")) return;
+        const drop = resolveDashboardDrop(ev);
+        if (!drop) return;
+        ev.preventDefault();
+        ev.dataTransfer.dropEffect = "move";
+        markDashboardDropTarget(drop.targetKey, drop.after);
+      });
+      card.addEventListener("dragleave", (ev) => {
+        if (card.contains(ev.relatedTarget)) return;
+        clearDashboardDropTargets();
+      });
+      card.addEventListener("drop", (ev) => {
+        if (!dragWidgetKey || ev.target?.closest?.(".cw-dash-widget")) return;
+        const drop = resolveDashboardDrop(ev);
+        if (!drop) return;
+        ev.preventDefault();
+        clearDashboardDropTargets();
+        moveWidgetTo(dragWidgetKey || ev.dataTransfer.getData("text/plain"), drop.targetKey, drop.after);
+      });
+      card.__cwDashboardDropWired = true;
+    }
+    for (const widget of WIDGETS) {
+      const node = widgetNode(widget.key);
+      if (!node) continue;
+      node.dataset.widgetKey = widget.key;
+      if (!node.querySelector(".cw-dash-layout-controls")) {
+        node.appendChild(createWidgetControls(widget.key, widget.label));
+      }
+      if (!node.__cwDashboardDropWired) {
+        node.addEventListener("dragover", (ev) => {
+          if (!dragWidgetKey || dragWidgetKey === widget.key) return;
+          ev.preventDefault();
+          updateDashboardDragScroll(ev);
+          ev.dataTransfer.dropEffect = "move";
+          const after = dashboardDropAfterForNode(ev, node);
+          markDashboardDropTarget(widget.key, after);
+        });
+        node.addEventListener("dragleave", () => {
+          node.classList.remove("is-drop-target");
+          delete node.dataset.dropPosition;
+        });
+        node.addEventListener("drop", (ev) => {
+          ev.preventDefault();
+          const after = node.dataset.dropPosition === "after";
+          node.classList.remove("is-drop-target");
+          delete node.dataset.dropPosition;
+          moveWidgetTo(dragWidgetKey || ev.dataTransfer.getData("text/plain"), widget.key, after);
+        });
+        node.__cwDashboardDropWired = true;
+      }
+    }
+  }
+
+  function syncControlIcons() {
+    for (const widget of WIDGETS) {
+      const node = widgetNode(widget.key);
+      const sizeBtn = node?.querySelector("[data-cw-widget-action='size'] .material-symbols-rounded");
+      const viewBtn = node?.querySelector("[data-cw-widget-action='view']");
+      const viewIcon = viewBtn?.querySelector(".material-symbols-rounded");
+      const hideBtn = node?.querySelector("[data-cw-widget-action='hide']");
+      const hideIcon = hideBtn?.querySelector(".material-symbols-rounded");
+      const size = effectiveSize(widget.key);
+      if (sizeBtn) {
+        sizeBtn.textContent = size === "large" ? "view_compact" : "view_agenda";
+        const sizeButton = sizeBtn.closest("button");
+        if (sizeButton) {
+          sizeButton.title = `Switch ${widget.label} to ${size === "large" ? "compact" : "horizontal"} mode`;
+          sizeButton.setAttribute("aria-label", sizeButton.title);
+        }
+      }
+      if (viewBtn && viewIcon) {
+        const hideViewToggle = size === "large" && widget.key === "playlists";
+        viewBtn.hidden = hideViewToggle;
+        if (!hideViewToggle) {
+          const view = widgetView(widget.key);
+          if (size === "large") {
+            viewIcon.textContent = view === "media" ? "view_module" : "view_carousel";
+            viewBtn.title = `Switch ${widget.label} to ${view === "media" ? "poster" : "media card"} view`;
+          } else {
+            viewIcon.textContent = view === "icon" ? "view_list" : "grid_view";
+            viewBtn.title = `Switch ${widget.label} to ${view === "icon" ? "grid" : "poster"} view`;
+          }
+          viewBtn.setAttribute("aria-label", viewBtn.title);
+        }
+      }
+      if (hideBtn && hideIcon) {
+        const hidden = !!widgetLayout[widget.key]?.hidden;
+        hideIcon.textContent = hidden ? "visibility" : "visibility_off";
+        hideBtn.title = `${hidden ? "Show" : "Hide"} ${widget.label}`;
+        hideBtn.setAttribute("aria-label", hideBtn.title);
+      }
+    }
   }
 
   function providerMeta() {
@@ -171,6 +608,10 @@
     }).join("");
   }
 
+  function widgetItemAttrs(kind, index) {
+    return ` data-cw-widget-item="${esc(kind)}" data-cw-widget-index="${esc(index)}"`;
+  }
+
   function ratingSourceIcons(sources, max = 3) {
     return sourceRows(sources, max).map(({ provider, instance }) => {
       const logo = providerLogo(provider);
@@ -188,7 +629,7 @@
     return profile?.[1] || raw;
   }
 
-  function scrobbleSourceLabel(source) {
+  function scrobbleSourcePill(source) {
     const provider = String(source?.provider || "").trim().toUpperCase();
     if (!provider) return "";
     const instance = String(source?.instance || "default").trim() || "default";
@@ -197,11 +638,43 @@
     const logo = providerMeta().logLogoPath?.(provider) || providerLogo(provider);
     const providerIcon = logo
       ? `<img src="${esc(logo)}" alt="" aria-hidden="true">`
-      : `<span class="cw-scrobble-source-icon--text" aria-hidden="true">${esc(providerShort(provider).slice(0, 2))}</span>`;
+      : `<span class="cw-scrobble-source-pill-text" aria-hidden="true">${esc(providerShort(provider).slice(0, 2))}</span>`;
     const tone = providerMeta().tone?.(provider) || {};
     const rgb = String(tone?.rgb || "124,92,255");
-    const description = `${providerName} profile: ${profile}`;
-    return `<span class="cw-scrobble-source" style="--cw-source-rgb:${esc(rgb)}" title="${esc(description)}" aria-label="${esc(description)}">${providerIcon}<span>${esc(profile)}</span></span>`;
+    const label = providerShort(provider);
+    const description = `${providerName} source profile: ${profile}`;
+    return `<span class="cw-scrobble-source-pill" style="--cw-source-rgb:${esc(rgb)}" title="${esc(description)}" aria-label="${esc(description)}">${providerIcon}<span>${esc(label)}</span></span>`;
+  }
+
+  function scrobbleSourceRow(item) {
+    return item?.source || sourceRows(item?.sources, 1)[0] || null;
+  }
+
+  function scrobbleRouteRows(item) {
+    const rows = [];
+    const seen = new Set();
+    const add = (row) => {
+      const provider = String(row?.provider || "").trim().toUpperCase();
+      const instance = String(row?.instance || "default").trim() || "default";
+      const key = `${provider}:${instance}`;
+      if (!provider || seen.has(key)) return;
+      seen.add(key);
+      rows.push({ provider, instance });
+    };
+    add(scrobbleSourceRow(item));
+    sourceRows(item?.targets, 8)
+      .filter(({ provider }) => providerMeta().get?.(provider)?.scrobblerSink === true)
+      .forEach(add);
+    return rows;
+  }
+
+  function scrobbleRouteIcons(item) {
+    const rows = scrobbleRouteRows(item);
+    const route = rows.length ? `Route: ${rows.map(sourceLabel).join(" -> ")}` : "No scrobble route";
+    return {
+      html: ratingSourceIcons(rows, 8),
+      route,
+    };
   }
 
   function scrobbleSinkIcons(targets) {
@@ -235,6 +708,18 @@
     if (String(item?.art_type || "").toLowerCase() === "movie") return "Movie";
     if (raw === "show") return "Show";
     return "Movie";
+  }
+
+  function mediaLabel(item, meta = null) {
+    const resolved = String(meta?.resolved_type || "").toLowerCase();
+    if (resolved === "movie") return "Movie";
+    if (resolved === "tv") return String(item?.type || "").toLowerCase() === "episode" ? (item?.episode_label || "Episode") : "Show";
+    return typeLabel(item);
+  }
+
+  function yearFromIso(value) {
+    const raw = String(value || "");
+    return /^\d{4}/.test(raw) ? raw.slice(0, 4) : "";
   }
 
   function relTime(epoch) {
@@ -271,6 +756,70 @@
     return `/art/tmdb/${kind}/${encodeURIComponent(String(tmdb))}?size=${encodeURIComponent(size)}${title}${year}`;
   }
 
+  function coverPoster(item, size = "w342") {
+    const src = String(item?.cover || item?.poster_cover || "");
+    if (src) return src;
+    const tmdb = item?.tmdb;
+    if (!tmdb) return poster(item, size);
+    const kind = String(item?.art_type || item?.type || "").toLowerCase() === "movie" ? "movie" : "tv";
+    const title = item?.title ? `&title=${encodeURIComponent(String(item.title))}` : "";
+    const year = item?.year ? `&year=${encodeURIComponent(String(item.year))}` : "";
+    return `/art/tmdb/${kind}/${encodeURIComponent(String(tmdb))}?size=${encodeURIComponent(size)}${title}${year}`;
+  }
+
+  function backdropPoster(item, meta = null, size = "w1280") {
+    const tmdb = item?.tmdb || item?.ids?.tmdb || meta?.ids?.tmdb;
+    if (!tmdb) return "";
+    const resolved = String(meta?.resolved_type || "").toLowerCase();
+    const kind = resolved ? (resolved === "movie" ? "movie" : "tv") : (String(item?.art_type || item?.type || "").toLowerCase() === "movie" ? "movie" : "tv");
+    const title = item?.title ? `&title=${encodeURIComponent(String(item.title))}` : "";
+    const year = item?.year ? `&year=${encodeURIComponent(String(item.year))}` : "";
+    return `/art/tmdb/${kind}/${encodeURIComponent(String(tmdb))}?kind=backdrop&size=${encodeURIComponent(size)}&locale=${encodeURIComponent(window.__CW_LOCALE || navigator.language || "en-US")}${title}${year}`;
+  }
+
+  function prewarmImageUrls(urls) {
+    const list = [...new Set((urls || []).filter(Boolean))].slice(0, IMAGE_PREWARM_MAX);
+    if (!list.length) return;
+    if (navigator.connection?.saveData) return;
+    const run = () => {
+      let index = 0;
+      const next = () => {
+        const url = list[index++];
+        if (!url) return;
+        let settled = false;
+        const img = new Image();
+        const done = () => {
+          if (settled) return;
+          settled = true;
+          window.setTimeout(next, 160);
+        };
+        img.onload = done;
+        img.onerror = done;
+        img.decoding = "async";
+        img.src = url;
+        window.setTimeout(done, 3500);
+      };
+      next();
+    };
+    const start = () => {
+      if ("requestIdleCallback" in window) window.requestIdleCallback(run, { timeout: 4000 });
+      else window.setTimeout(run, 800);
+    };
+    window.setTimeout(start, 900);
+  }
+
+  function prewarmWidgetImages(active) {
+    const urls = [];
+    for (const kind of ["history", "ratings", "scrobble", "progress"]) {
+      if (!active?.[kind]) continue;
+      const limit = Math.min(latestItems[kind]?.length || 0, visibleCounts[kind] || PAGE_STEP);
+      for (const item of (latestItems[kind] || []).slice(0, limit)) {
+        urls.push(poster(item), coverPoster(item, "w342"), backdropPoster(item, null, "w780"));
+      }
+    }
+    prewarmImageUrls(urls);
+  }
+
   function tmdbLink(item) {
     const tmdb = item?.tmdb;
     if (!tmdb) return "";
@@ -278,9 +827,107 @@
     return `https://www.themoviedb.org/${kind}/${encodeURIComponent(String(tmdb))}`;
   }
 
-  function historyCard(item) {
+  function imdbLink(item, meta = null) {
+    const raw = String(item?.ids?.imdb || meta?.ids?.imdb || meta?.external_ids?.imdb_id || "").trim();
+    if (!raw) return "";
+    const clean = raw.startsWith("tt") ? raw : `tt${raw}`;
+    return `https://www.imdb.com/title/${encodeURIComponent(clean)}`;
+  }
+
+  async function getDetailMeta(item) {
+    if (!item?.tmdb && !item?.ids?.tmdb) return null;
+    return window.CW?.Meta?.get?.(item, "detail") || null;
+  }
+
+  function detailSources(item) {
+    return sourceRows(item?.sources, 6).map(({ provider, instance }) => ({
+      label: sourceLabel({ provider, instance }),
+      short: providerShort(provider),
+      logo: providerLogo(provider),
+    }));
+  }
+
+  function detailModel(item, meta = null, loading = false) {
+    const resolved = String(meta?.resolved_type || "").toLowerCase();
+    const isMovie = resolved ? resolved === "movie" : String(item?.art_type || item?.type || "").toLowerCase() === "movie";
+    const releaseIso = isMovie
+      ? (meta?.detail?.release_date || meta?.release?.date || item?.release_date || "")
+      : (meta?.detail?.first_air_date || meta?.release?.date || item?.first_air_date || "");
+    const year = String(item?.year || meta?.year || yearFromIso(releaseIso) || "").trim();
+    const rawScore = Number(meta?.score);
+    const rawRating = Number(meta?.vote_average ?? meta?.detail?.vote_average);
+    const ratingValue = Number.isFinite(rawRating) ? rawRating : Number.isFinite(rawScore) ? rawScore / 10 : null;
+    return {
+      title: item?.title || meta?.title || "Unknown title",
+      year: "",
+      isMovie,
+      chips: [
+        { text: mediaLabel(item, meta) },
+        { text: year },
+        { text: window.CW?.PlayingCard?.fmt?.runtimeLabel?.(meta?.runtime_minutes) || "" },
+        { text: meta?.certification || meta?.release?.cert || meta?.detail?.certification || "" },
+      ],
+      overview: meta?.overview || meta?.detail?.overview || meta?.detail?.tagline || (loading ? "Loading details..." : "No description available."),
+      poster: coverPoster(item, "w342") || "/assets/img/placeholder_poster.svg",
+      posterHref: tmdbLink(item),
+      backdrop: backdropPoster(item, meta),
+      information: meta ? window.CW?.PlayingCard?.fmt?.informationFor?.(meta, isMovie) || "loading" : "loading",
+      rating: { value: ratingValue, votes: meta?.vote_count ?? meta?.detail?.vote_count },
+      progress: Number.isFinite(Number(item?.progress)) ? { pct: Number(item.progress) } : null,
+      sources: detailSources(item),
+      links: [
+        { href: tmdbLink(item), text: "TMDb" },
+        { href: imdbLink(item, meta), text: "IMDb" },
+      ],
+    };
+  }
+
+  function ensureDetailCard() {
+    if (detailCard) return detailCard;
+    if (!window.CW?.PlayingCard?.mount) return null;
+    detailCard = window.CW.PlayingCard.mount({
+      id: "cw-dashboard-widget-detail",
+      variant: "watchlist",
+      tabScope: "main",
+      label: "Dashboard media item details",
+      width: "min(860px,calc(100vw - 32px))",
+      onClose: () => { detailKey = ""; detailCard?.hide(); },
+      onTrailer: () => { void window.CW?.Trailer?.openFor?.(detailItem, detailMeta); },
+    });
+    document.addEventListener("keydown", (event) => {
+      if (event.key !== "Escape") return;
+      if (document.getElementById("cw-trailer")?.classList.contains("show")) return;
+      detailKey = "";
+      detailCard?.hide();
+    }, true);
+    return detailCard;
+  }
+
+  function renderDetailCard(item, meta = null, loading = false) {
+    const card = ensureDetailCard();
+    if (!card) return;
+    detailItem = item;
+    detailMeta = meta;
+    card.render(detailModel(item, meta, loading));
+    card.show();
+  }
+
+  async function openDetailCard(kind, index) {
+    const item = latestItems[kind]?.[Number(index)];
+    if (!item || !["history", "ratings", "scrobble", "progress"].includes(kind)) return false;
+    const key = `${kind}:${index}:${item?.key || item?.id || item?.tmdb || item?.title || ""}`;
+    detailKey = key;
+    renderDetailCard(item, null, true);
+    const meta = await getDetailMeta(item);
+    if (!detailCard?.isVisible?.() || detailKey !== key) return true;
+    renderDetailCard(item, meta || null, false);
+    return true;
+  }
+
+  function historyCard(item, index = 0) {
     const title = item?.title || "Untitled";
-    const meta = [typeLabel(item), item?.year || "", relTime(item?.sort_epoch || item?.watched_at)].filter(Boolean).join(" - ");
+    const age = relTime(item?.sort_epoch || item?.watched_at);
+    const meta = [typeLabel(item), item?.year || "", age].filter(Boolean).join(" - ");
     const href = tmdbLink(item);
     const tag = href ? "a" : "div";
     const hrefAttr = href ? ` href="${esc(href)}" target="_blank" rel="noopener"` : "";
@@ -288,9 +935,10 @@
     const artStyle = art ? ` style="--cw-history-art:url(&quot;${esc(art)}&quot;)"` : "";
     const route = sourceRouteTitle(item?.sources);
     return `
-      <${tag} class="cw-history-widget-item"${hrefAttr}${artStyle}>
+      <${tag} class="cw-history-widget-item"${hrefAttr}${artStyle}${widgetItemAttrs("history", index)}>
         <span class="cw-history-thumb">
           <img src="${esc(art)}" alt="" loading="lazy" onerror="this.onerror=null;this.src='/assets/img/placeholder_poster.svg'">
+          ${age ? `<span class="cw-rating-grid-age">${esc(age)}</span>` : ""}
           ${item?.episode_label ? `<span class="cw-history-episode">${esc(item.episode_label)}</span>` : ""}
         </span>
         <span class="cw-history-copy">
@@ -310,20 +958,34 @@
     return "Activity";
   }
 
-  function activityCard(item) {
+  function activityMethodPill(item) {
+    const label = activityLabel(item);
+    const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "activity";
+    const icon = slug === "webhook" ? "webhook" : slug === "watcher" ? "radar" : "bolt";
+    return `
+      <span class="cw-history-method-pill cw-history-method-pill--${esc(slug)}">
+        <span class="material-symbols-rounded" aria-hidden="true">${esc(icon)}</span>
+        <span>${esc(label)}</span>
+      </span>`;
+  }
+
+  function activityCard(item, index = 0) {
     const title = item?.title || "Untitled";
-    const meta = [activityLabel(item), typeLabel(item), relTime(item?.sort_epoch || item?.captured_at || item?.watched_at)].filter(Boolean).join(" - ");
+    const age = relTime(item?.sort_epoch || item?.captured_at || item?.watched_at);
+    const meta = [activityLabel(item), typeLabel(item), age].filter(Boolean).join(" - ");
     const href = tmdbLink(item);
     const tag = href ? "a" : "div";
     const hrefAttr = href ? ` href="${esc(href)}" target="_blank" rel="noopener"` : "";
     const art = poster(item);
     const artStyle = art ? ` style="--cw-history-art:url(&quot;${esc(art)}&quot;)"` : "";
-    const source = item?.source || sourceRows(item?.sources, 1)[0] || null;
+    const source = scrobbleSourceRow(item);
     const sinks = scrobbleSinkIcons(item?.targets);
     return `
-      <${tag} class="cw-history-widget-item cw-history-widget-item--activity"${hrefAttr}${artStyle}>
+      <${tag} class="cw-history-widget-item cw-history-widget-item--activity"${hrefAttr}${artStyle}${widgetItemAttrs("scrobble", index)}>
         <span class="cw-history-thumb">
           <img src="${esc(art)}" alt="" loading="lazy" onerror="this.onerror=null;this.src='/assets/img/placeholder_poster.svg'">
+          ${age ? `<span class="cw-rating-grid-age">${esc(age)}</span>` : ""}
+          ${activityMethodPill(item)}
           ${item?.episode_label ? `<span class="cw-history-episode">${esc(item.episode_label)}</span>` : ""}
         </span>
         <span class="cw-history-copy">
@@ -331,13 +993,131 @@
           <span>${esc(meta || "Activity")}</span>
         </span>
         <span class="cw-scrobble-route">
-          ${scrobbleSourceLabel(source)}
+          ${scrobbleSourcePill(source)}
           <span class="cw-history-sources" title="${esc(sinks.route)}" aria-label="${esc(sinks.route)}">${sinks.html}</span>
         </span>
       </${tag}>`;
   }
 
-  function ratingCard(item) {
+  function progressCard(item, index = 0) {
+    const title = item?.title || "Untitled";
+    const progress = Number(item?.progress);
+    const progressLabel = Number.isFinite(progress) ? `${Math.round(progress)}%` : "";
+    const age = relTime(item?.sort_epoch);
+    const meta = [typeLabel(item), progressLabel ? `${progressLabel} progress` : "Progress sync", age].filter(Boolean).join(" - ");
+    const href = tmdbLink(item);
+    const tag = href ? "a" : "div";
+    const hrefAttr = href ? ` href="${esc(href)}" target="_blank" rel="noopener"` : "";
+    const art = poster(item);
+    const route = sourceRouteTitle(item?.sources);
+    return `
+      <${tag} class="cw-history-widget-item cw-history-widget-item--progress"${hrefAttr}${widgetItemAttrs("progress", index)}>
+        <span class="cw-history-thumb">
+          <img src="${esc(art)}" alt="" loading="lazy" onerror="this.onerror=null;this.src='/assets/img/placeholder_poster.svg'">
+          ${age ? `<span class="cw-rating-grid-age">${esc(age)}</span>` : ""}
+          ${item?.episode_label ? `<span class="cw-history-episode">${esc(item.episode_label)}</span>` : ""}
+        </span>
+        <span class="cw-history-copy">
+          <strong>${esc(title)}</strong>
+          <span>${esc(meta || "Progress sync")}</span>
+        </span>
+        <span class="cw-history-sources" title="${esc(route)}" aria-label="${esc(route || "Sources")}">${sourceIcons(item?.sources, 3)}</span>
+      </${tag}>`;
+  }
+
+  function playlistCard(item) {
+    const title = item?.label || item?.title || "Playlist activity";
+    const status = String(item?.status || "completed");
+    const meta = [item?.type || "Sync", item?.details || "", relTime(item?.ts)].filter(Boolean).join(" - ");
+    return `
+      <div class="cw-history-widget-item cw-history-widget-item--plain cw-playlist-widget-item">
+        <span class="cw-history-thumb cw-history-thumb--icon">
+          <span class="material-symbols-rounded" aria-hidden="true">queue_music</span>
+        </span>
+        <span class="cw-history-copy">
+          <strong>${esc(title)}</strong>
+          <span>${esc(meta || "Playlist sync")}</span>
+        </span>
+        <span class="cw-dash-status-pill cw-dash-status-pill--${esc(status.toLowerCase())}">${esc(status)}</span>
+      </div>`;
+  }
+
+  function playlistPosterCard(item) {
+    const title = item?.label || item?.title || "Playlist activity";
+    const status = String(item?.status || "completed").toUpperCase();
+    const meta = [item?.type || "Sync", relTime(item?.ts)].filter(Boolean).join(" - ");
+    return `
+      <div class="cw-rating-widget-card cw-widget-poster-card cw-widget-poster-card--playlist" title="${esc([title, meta].filter(Boolean).join(" | "))}">
+        <span class="cw-widget-poster-fallback material-symbols-rounded" aria-hidden="true">queue_music</span>
+        <span class="cw-widget-poster-chip">${esc(status)}</span>
+      </div>`;
+  }
+
+  function mediaPosterCard(item, kind = "history", index = 0) {
+    const title = item?.title || "Untitled";
+    const href = tmdbLink(item);
+    const tag = href ? "a" : "div";
+    const hrefAttr = href ? ` href="${esc(href)}" target="_blank" rel="noopener"` : "";
+    const rawType = String(item?.type || "").toLowerCase();
+    const progress = Number(item?.progress);
+    const progressLabel = Number.isFinite(progress) ? `${Math.round(progress)}%` : "";
+    const age = relTime(item?.sort_epoch || item?.captured_at || item?.watched_at || 0);
+    const meta = kind === "progress"
+      ? [progressLabel ? `${progressLabel} progress` : "Progress", age].filter(Boolean).join(" - ")
+      : kind === "scrobble"
+        ? [activityLabel(item), typeLabel(item), age].filter(Boolean).join(" - ")
+        : [typeLabel(item), age].filter(Boolean).join(" - ");
+    const route = kind === "scrobble" ? scrobbleRouteIcons(item) : { html: sourceIcons(item?.sources, 3), route: sourceRouteTitle(item?.sources) };
+    const corner = kind === "progress" && progressLabel ? progressLabel : age;
+    const episodeChip = rawType === "episode" && item?.episode_label ? String(item.episode_label) : "";
+    return `
+      <${tag} class="cw-rating-widget-card cw-widget-poster-card cw-widget-poster-card--${esc(kind)}"${hrefAttr}${widgetItemAttrs(kind, index)} title="${esc([title, meta].filter(Boolean).join(" | "))}">
+        <img src="${esc(coverPoster(item, "w342"))}" alt="" loading="lazy" onerror="this.onerror=null;this.src='/assets/img/placeholder_poster.svg'">
+        ${corner ? `<span class="cw-widget-poster-chip">${esc(corner)}</span>` : ""}
+        ${episodeChip ? `<span class="cw-widget-poster-chip cw-widget-poster-chip--episode">${esc(episodeChip)}</span>` : ""}
+        <span class="cw-rating-provider-icons" title="${esc(route.route || "Sources")}" aria-label="${esc(route.route || "Sources")}">${route.html}</span>
+      </${tag}>`;
+  }
+
+  function mediaLandscapeCard(item, kind = "history", index = 0) {
+    const title = item?.title || "Untitled";
+    const href = tmdbLink(item);
+    const tag = href ? "a" : "div";
+    const hrefAttr = href ? ` href="${esc(href)}" target="_blank" rel="noopener"` : "";
+    const rawType = String(item?.type || "").toLowerCase();
+    const age = relTime(item?.sort_epoch || item?.captured_at || item?.watched_at || 0);
+    const progress = Number(item?.progress);
+    const progressLabel = Number.isFinite(progress) ? `${Math.round(progress)}%` : "";
+    const meta = kind === "ratings"
+      ? [typeLabel(item), item?.rating ? `Rated ${item.rating}` : "", age].filter(Boolean).join(" - ")
+      : kind === "progress"
+        ? [typeLabel(item), progressLabel ? `${progressLabel} progress` : "Progress sync", age].filter(Boolean).join(" - ")
+        : kind === "scrobble"
+          ? [activityLabel(item), typeLabel(item), age].filter(Boolean).join(" - ")
+          : [typeLabel(item), item?.year || "", age].filter(Boolean).join(" - ");
+    const episodeLabel = rawType === "episode" && item?.episode_label ? String(item.episode_label) : "";
+    const chips = episodeLabel
+      ? [age, episodeLabel].filter(Boolean)
+      : [kind === "progress" && progressLabel ? progressLabel : age].filter(Boolean);
+    const art = backdropPoster(item, null, "w780") || poster(item, "w300") || coverPoster(item, "w342");
+    const route = kind === "scrobble"
+      ? { html: sourceIcons(scrobbleRouteRows(item), 3), route: scrobbleRouteIcons(item).route }
+      : { html: sourceIcons(item?.sources, 3), route: sourceRouteTitle(item?.sources) };
+    return `
+      <${tag} class="cw-media-card cw-media-card--${esc(kind)}"${hrefAttr}${widgetItemAttrs(kind, index)} title="${esc([title, meta].filter(Boolean).join(" | "))}">
+        <img src="${esc(art)}" alt="" loading="lazy" onerror="this.onerror=null;this.src='/assets/img/placeholder_poster.svg'">
+        ${chips.length ? `<span class="cw-media-card-chips">${chips.map((chip) => `<span class="cw-media-card-chip">${esc(chip)}</span>`).join("")}</span>` : ""}
+        ${kind === "scrobble" ? `<span class="cw-media-card-method">${activityMethodPill(item)}</span>` : ""}
+        ${kind === "ratings" && item?.rating ? `<span class="cw-media-card-score"><span>${esc(item.rating)}</span></span>` : ""}
+        <span class="cw-media-card-copy">
+          <strong>${esc(title)}</strong>
+          <small>${esc(meta)}</small>
+        </span>
+        <span class="cw-media-card-sources" title="${esc(route.route)}" aria-label="${esc(route.route || "Sources")}">${route.html}</span>
+      </${tag}>`;
+  }
+
+  function ratingCard(item, index = 0) {
     const title = item?.title || "Untitled";
     const href = tmdbLink(item);
     const tag = href ? "a" : "div";
@@ -354,25 +1134,80 @@
         : "";
     const titleParts = [title, mediaDetail ? `${rawType === "season" ? "Season" : "Episode"}: ${mediaDetail}` : "", ratedLabel ? `Rated ${ratedLabel}` : ""].filter(Boolean);
     return `
-      <${tag} class="cw-rating-widget-card"${hrefAttr} title="${esc(titleParts.join(" | "))}">
-        <img src="${esc(poster(item, "w342"))}" alt="" loading="lazy" onerror="this.onerror=null;this.src='/assets/img/placeholder_poster.svg'">
+      <${tag} class="cw-rating-widget-card"${hrefAttr}${widgetItemAttrs("ratings", index)} title="${esc(titleParts.join(" | "))}">
+        <img src="${esc(coverPoster(item, "w342"))}" alt="" loading="lazy" onerror="this.onerror=null;this.src='/assets/img/placeholder_poster.svg'">
         <span class="cw-rating-score"><span>${esc(item?.rating || "")}</span></span>
         ${ratedLabel ? `<span class="cw-rating-age-badge">${esc(ratedLabel)}</span>` : ""}
         <span class="cw-rating-provider-icons" title="${esc(route)}" aria-label="${esc(route || "Sources")}">${ratingSourceIcons(item?.sources, 3)}</span>
       </${tag}>`;
   }
 
-  function setEmpty(host, text) {
-    if (host) host.innerHTML = `<div class="cw-dash-empty">${esc(text)}</div>`;
+  function ratingListCard(item, index = 0) {
+    const title = item?.title || "Untitled";
+    const ratedLabel = relTime(item?.sort_epoch || 0);
+    const meta = [typeLabel(item), item?.rating ? `Rated ${item.rating}` : "", ratedLabel].filter(Boolean).join(" - ");
+    const href = tmdbLink(item);
+    const tag = href ? "a" : "div";
+    const hrefAttr = href ? ` href="${esc(href)}" target="_blank" rel="noopener"` : "";
+    const art = poster(item);
+    const route = sourceRouteTitle(item?.sources);
+    return `
+      <${tag} class="cw-history-widget-item cw-history-widget-item--rating"${hrefAttr}${widgetItemAttrs("ratings", index)}>
+        <span class="cw-history-thumb">
+          <img src="${esc(art)}" alt="" loading="lazy" onerror="this.onerror=null;this.src='/assets/img/placeholder_poster.svg'">
+          ${ratedLabel ? `<span class="cw-rating-grid-age">${esc(ratedLabel)}</span>` : ""}
+          ${item?.rating ? `<span class="cw-rating-grid-score"><span>${esc(item.rating)}</span></span>` : ""}
+          ${item?.episode_label ? `<span class="cw-history-episode">${esc(item.episode_label)}</span>` : ""}
+        </span>
+        <span class="cw-history-copy">
+          <strong>${esc(title)}</strong>
+          <span>${esc(meta || "Rating")}</span>
+        </span>
+        <span class="cw-history-sources" title="${esc(route)}" aria-label="${esc(route || "Sources")}">${sourceIcons(item?.sources, 3)}</span>
+      </${tag}>`;
+  }
+
+  function setEmpty(host, kind, fallbackText = "") {
+    if (!host) return;
+    const meta = EMPTY_META[kind] || EMPTY_META.error;
+    const copy = fallbackText || meta.copy;
+    const widgetKey = WIDGET_KEYS.includes(kind) ? kind : (host.closest(".cw-dash-widget")?.dataset?.widgetKey || kind);
+    setWidgetEmpty(widgetKey, true);
+    host.innerHTML = `
+      <div class="cw-dash-empty cw-dash-empty--${esc(kind || "empty")}">
+        <strong>${esc(meta.title)}</strong>
+        <small>${esc(copy)}</small>
+      </div>`;
   }
 
   function setLoading(host, kind = "list") {
     if (!host) return;
-    if (kind === "ratings") {
-      host.innerHTML = Array.from({ length: 6 }, () => `
-        <div class="cw-rating-widget-card cw-dash-skeleton cw-dash-skeleton-poster" aria-hidden="true">
+    const widgetKey = kind === "list" ? (host.closest(".cw-dash-widget")?.dataset?.widgetKey || kind) : kind;
+    const view = widgetView(widgetKey);
+    setWidgetEmpty(widgetKey, false);
+    host.classList.toggle("cw-widget-view-icon", view === "icon");
+    host.classList.toggle("cw-widget-view-media", view === "media");
+    host.classList.toggle("cw-widget-view-grid", view === "grid");
+    if (view === "icon" || view === "media") {
+      const skeletonClass = view === "media" ? "cw-media-card" : "cw-rating-widget-card";
+      const cards = Array.from({ length: view === "media" ? 4 : (effectiveSize(widgetKey) === "large" ? 3 : PAGE_STEP) }, () => `
+        <div class="${skeletonClass} cw-dash-skeleton cw-dash-skeleton-poster" aria-hidden="true">
           <span class="cw-skel-shine"></span>
         </div>`).join("");
+      if (effectiveSize(widgetKey) === "large") {
+        host.innerHTML = `
+          <div class="cw-widget-carousel">
+            <button type="button" class="cw-widget-carousel-nav cw-widget-carousel-nav--prev" disabled aria-hidden="true">
+              <span class="material-symbols-rounded">chevron_left</span>
+            </button>
+            <div class="cw-widget-carousel-row">${cards}</div>
+            <button type="button" class="cw-widget-carousel-nav cw-widget-carousel-nav--next" disabled aria-hidden="true">
+              <span class="material-symbols-rounded">chevron_right</span>
+            </button>
+          </div>`;
+        return;
+      }
+      host.innerHTML = cards;
       return;
     }
     host.innerHTML = Array.from({ length: 3 }, () => `
@@ -389,31 +1224,107 @@
       </div>`).join("");
   }
 
-  function renderPagedList(host, items, count, cardFn, emptyText, kind, keepPager = false) {
+  function renderCarousel(host, items, count, cardFn, kind) {
+    const visible = Math.min(count, items.length, MAX_WIDGET_ITEMS);
+    const cards = items.slice(0, visible).map(cardFn).join("");
+    host.innerHTML = `
+      <div class="cw-widget-carousel" data-cw-widget-carousel="${esc(kind)}">
+        <button type="button" class="cw-widget-carousel-nav cw-widget-carousel-nav--prev" data-cw-widget-scroll="${esc(kind)}" data-dir="-1" aria-label="Scroll ${esc(kind)} left">
+          <span class="material-symbols-rounded">chevron_left</span>
+        </button>
+        <div class="cw-widget-carousel-row cw-widget-scrollbar">
+          ${cards}
+        </div>
+        <button type="button" class="cw-widget-carousel-nav cw-widget-carousel-nav--next" data-cw-widget-scroll="${esc(kind)}" data-dir="1" aria-label="Scroll ${esc(kind)} right">
+          <span class="material-symbols-rounded">chevron_right</span>
+        </button>
+      </div>`;
+  }
+
+  function renderPagedList(host, items, count, cardFn, emptyText, kind, keepPager = false, horizontal = false) {
     if (!host) return;
     if (!items.length) {
-      setEmpty(host, emptyText);
+      setEmpty(host, kind, emptyText);
+      return;
+    }
+    setWidgetEmpty(kind, false);
+    if (horizontal) {
+      renderCarousel(host, items, count, cardFn, kind);
+      scheduleMasonry();
       return;
     }
     const visible = Math.min(count, items.length);
     const hasMore = visible < items.length;
+    const moreContent = kind === "playlists"
+      ? `<span class="cw-dash-see-more-label">${hasMore ? "View more playlists" : "View all playlists"}</span>`
+      : `<span class="material-symbols-rounded">expand_more</span>`;
     const button = hasMore || keepPager
       ? `<button type="button" class="cw-dash-see-more" data-cw-widget-more="${esc(kind)}" aria-label="${hasMore ? `Show more ${esc(kind)} items` : `All ${esc(kind)} items shown`}"${hasMore ? "" : " disabled"}>
-          <span class="material-symbols-rounded">expand_more</span>
+          ${moreContent}
         </button>`
       : "";
     host.innerHTML = `${items.slice(0, visible).map(cardFn).join("")}${button}`;
+    scheduleMasonry();
+  }
+
+  function renderWidget(kind) {
+    const defs = {
+      history: { host: $("#recent-history-list"), list: historyCard, icon: (item, index) => mediaPosterCard(item, "history", index), media: (item, index) => mediaLandscapeCard(item, "history", index), keepPager: false },
+      ratings: { host: $("#latest-ratings-grid"), list: ratingListCard, icon: ratingCard, media: (item, index) => mediaLandscapeCard(item, "ratings", index), keepPager: false },
+      scrobble: { host: $("#recent-scrobble-list"), list: activityCard, icon: (item, index) => mediaPosterCard(item, "scrobble", index), media: (item, index) => mediaLandscapeCard(item, "scrobble", index), keepPager: true },
+      progress: { host: $("#recent-progress-list"), list: progressCard, icon: (item, index) => mediaPosterCard(item, "progress", index), media: (item, index) => mediaLandscapeCard(item, "progress", index), keepPager: true },
+      playlists: { host: $("#recent-playlists-list"), list: playlistCard, icon: playlistPosterCard, keepPager: true },
+    };
+    const def = defs[kind];
+    if (!def) return;
+    const view = widgetView(kind);
+    def.host?.classList.toggle("cw-widget-view-icon", view === "icon");
+    def.host?.classList.toggle("cw-widget-view-media", view === "media");
+    def.host?.classList.toggle("cw-widget-view-grid", view === "grid");
+    const cardFn = view === "media" && def.media ? def.media : view === "icon" ? def.icon : def.list;
+    renderPagedList(
+      def.host,
+      latestItems[kind] || [],
+      visibleCounts[kind] || widgetPageStep(kind),
+      cardFn,
+      "",
+      kind,
+      def.keepPager,
+      effectiveSize(kind) === "large"
+    );
   }
 
   function applyVisibility(settings) {
     const card = $("#dashboard-widgets-card");
-    const history = $("#recent-history-widget");
-    const ratings = $("#latest-ratings-widget");
-    const scrobble = $("#recent-scrobble-widget");
-    if (history) history.classList.toggle("hidden", !settings.history);
-    if (ratings) ratings.classList.toggle("hidden", !settings.ratings);
-    if (scrobble) scrobble.classList.toggle("hidden", !settings.scrobble);
-    if (card) card.classList.toggle("hidden", !settings.history && !settings.ratings && !settings.scrobble);
+    if (!card) return;
+    ensureLayoutToolbar();
+    ensureWidgetControls();
+    let anyVisible = false;
+    let anyEnabled = false;
+    for (const widget of WIDGETS) {
+      const node = widgetNode(widget.key);
+      if (!node) continue;
+      const layout = widgetLayout[widget.key] || DEFAULT_LAYOUT[widget.key];
+      const enabled = settings?.[widget.key] !== false;
+      const visible = enabled && (!layout.hidden || customizeOpen);
+      anyEnabled = anyEnabled || enabled;
+      const size = effectiveSize(widget.key);
+      node.classList.toggle("hidden", !visible);
+      node.classList.toggle("cw-dash-widget--wide", size === "large");
+      node.classList.toggle("cw-dash-widget--compact", size === "small");
+      node.classList.toggle("is-layout-hidden", !!layout.hidden);
+      node.dataset.widgetSize = size;
+      node.dataset.widgetView = widgetView(widget.key);
+      if (widget.key === "watchlist") window.CW?.WatchlistPreview?.applyWidgetView?.(node.dataset.widgetView);
+      node.style.order = String(layout.order);
+      setWidgetEmpty(widget.key, isWidgetEmpty(widget.key));
+      anyVisible = anyVisible || (enabled && !layout.hidden);
+    }
+    syncControlIcons();
+    updateLayoutToolbar();
+    card.classList.toggle("has-only-hidden-widgets", anyEnabled && !anyVisible);
+    card.classList.toggle("hidden", !anyEnabled);
+    scheduleMasonry();
   }
 
   async function refreshDashboardWidgets({ forceConfig = false, force = false, preserve = false } = {}) {
@@ -450,61 +1361,83 @@
     lastSettings = settings;
     if (seq !== loadSeq || !isOnMain()) return;
     if (!preserve || !hasLoaded) {
-      visibleCounts.history = PAGE_STEP;
-      visibleCounts.ratings = RATING_PAGE_STEP;
-      visibleCounts.scrobble = PAGE_STEP;
+      ["history", "ratings", "scrobble", "progress", "playlists"].forEach(resetVisibleCount);
     }
     applyVisibility(settings);
-    if (!settings.history && !settings.ratings && !settings.scrobble) return;
+    const active = activeWidgetSettings(settings);
+    if (active.watchlist) {
+      Promise.resolve(window.updatePreviewVisibility?.()).catch(() => null);
+    }
+    if (!active.watchlist && !active.history && !active.ratings && !active.scrobble && !active.progress && !active.playlists) return;
     if (!hasTmdbKeyInConfig(cfg)) {
-      hideDashboardWidgets();
-      return;
+      $("#placeholder-card")?.classList.add("hidden");
     }
 
     const historyHost = $("#recent-history-list");
     const ratingsHost = $("#latest-ratings-grid");
     const scrobbleHost = $("#recent-scrobble-list");
+    const progressHost = $("#recent-progress-list");
+    const playlistsHost = $("#recent-playlists-list");
     if (!preserve || !hasLoaded) {
-      if (settings.history) setLoading(historyHost);
-      if (settings.ratings) setLoading(ratingsHost, "ratings");
-      if (settings.scrobble) setLoading(scrobbleHost);
+      if (active.history) setLoading(historyHost);
+      if (active.ratings) setLoading(ratingsHost, "ratings");
+      if (active.scrobble) setLoading(scrobbleHost);
+      if (active.progress) setLoading(progressHost);
+      if (active.playlists) setLoading(playlistsHost);
     }
 
     try {
-      const data = await fetchJSON(`/api/dashboard/widgets?history_limit=${MAX_WIDGET_ITEMS}&ratings_limit=${MAX_WIDGET_ITEMS}&scrobble_limit=${MAX_WIDGET_ITEMS}`);
+      const requestedKinds = ["history", "ratings", "scrobble", "progress", "playlists"].filter((key) => active[key]);
+      if (!requestedKinds.length) {
+        hasLoaded = true;
+        lastLoadedAt = Date.now();
+        widgetsDirty = dirtyVersion !== refreshVersion;
+        return;
+      }
+      const params = new URLSearchParams({
+        include: requestedKinds.join(","),
+        history_limit: String(MAX_WIDGET_ITEMS),
+        ratings_limit: String(MAX_WIDGET_ITEMS),
+        scrobble_limit: String(MAX_WIDGET_ITEMS),
+        progress_limit: String(MAX_WIDGET_ITEMS),
+        playlists_limit: String(MAX_WIDGET_ITEMS),
+      });
+      const data = await fetchWidgetPayload(`/api/dashboard/widgets?${params.toString()}`);
       if (seq !== loadSeq || !isOnMain()) return;
-      if (!data?.ok) throw new Error(data?.error || "dashboard_widgets_failed");
 
       const historyItems = Array.isArray(data?.recent_history?.items) ? data.recent_history.items : [];
       const scrobbleItems = Array.isArray(data?.recent_scrobble?.items) ? data.recent_scrobble.items : [];
       const ratingItems = Array.isArray(data?.latest_ratings?.items) ? data.latest_ratings.items : [];
+      const progressItems = Array.isArray(data?.recent_progress?.items) ? data.recent_progress.items : [];
+      const playlistItems = Array.isArray(data?.recent_playlists?.items) ? data.recent_playlists.items : [];
       setCountChip("recent-history-count-chip", data?.recent_history?.total ?? historyItems.length, "item");
       setCountChip("latest-ratings-count-chip", data?.latest_ratings?.total ?? ratingItems.length, "rating");
       setCountChip("recent-scrobble-count-chip", data?.recent_scrobble?.total ?? scrobbleItems.length, "scrobble");
+      setCountChip("recent-progress-count-chip", data?.recent_progress?.total ?? progressItems.length, "progress sync");
+      setCountChip("recent-playlists-count-chip", data?.recent_playlists?.total ?? playlistItems.length, "playlist sync");
       latestItems.history = historyItems;
       latestItems.ratings = ratingItems;
       latestItems.scrobble = scrobbleItems;
+      latestItems.progress = progressItems;
+      latestItems.playlists = playlistItems;
       hasLoaded = true;
       lastLoadedAt = Date.now();
       widgetsDirty = dirtyVersion !== refreshVersion;
-      if (settings.history) {
-        renderPagedList(historyHost, historyItems, visibleCounts.history, historyCard, "No watched history recorded yet.", "history");
+      for (const kind of ["history", "ratings", "scrobble", "progress", "playlists"]) {
+        if (active[kind]) renderWidget(kind);
       }
-      if (settings.ratings) {
-        renderPagedList(ratingsHost, ratingItems, visibleCounts.ratings, ratingCard, "No ratings recorded yet.", "ratings");
-      }
-      if (settings.scrobble) {
-        renderPagedList(scrobbleHost, scrobbleItems, visibleCounts.scrobble, activityCard, "No recent scrobble recorded yet.", "scrobble", true);
-      }
+      prewarmWidgetImages(active);
     } catch (e) {
       if (authPendingError(e)) {
         scheduleAuthReadyRefresh();
         return;
       }
       if (preserve && hasLoaded) return;
-      if (settings.history) setEmpty(historyHost, "Recent history could not be loaded.");
-      if (settings.ratings) setEmpty(ratingsHost, "Latest ratings could not be loaded.");
-      if (settings.scrobble) setEmpty(scrobbleHost, "Recent scrobble could not be loaded.");
+      if (active.history) setEmpty(historyHost, "error", "Recent history could not be loaded.");
+      if (active.ratings) setEmpty(ratingsHost, "error", "Latest ratings could not be loaded.");
+      if (active.scrobble) setEmpty(scrobbleHost, "error", "Recent scrobble could not be loaded.");
+      if (active.progress) setEmpty(progressHost, "error", "Recent progress could not be loaded.");
+      if (active.playlists) setEmpty(playlistsHost, "error", "Recent playlists could not be loaded.");
     }
   }
 
@@ -526,23 +1459,100 @@
   }
 
   function initDashboardWidgets() {
+    ensureLayoutToolbar();
+    ensureWidgetControls();
     $("#recent-history-refresh")?.addEventListener("click", (e) => refreshFromButton(e.currentTarget));
     $("#latest-ratings-refresh")?.addEventListener("click", (e) => refreshFromButton(e.currentTarget));
     $("#recent-scrobble-refresh")?.addEventListener("click", (e) => refreshFromButton(e.currentTarget));
+    $("#recent-progress-refresh")?.addEventListener("click", (e) => refreshFromButton(e.currentTarget));
+    $("#recent-playlists-refresh")?.addEventListener("click", (e) => refreshFromButton(e.currentTarget));
+    document.addEventListener("dragover", (event) => updateDashboardDragScroll(event), true);
+    document.addEventListener("drop", stopDashboardDragScroll, true);
     $("#dashboard-widgets-card")?.addEventListener("click", (event) => {
+      const dashboardLayoutBtn = event.target?.closest?.("[data-cw-dashboard-layout]");
+      if (dashboardLayoutBtn) {
+        const action = String(dashboardLayoutBtn.dataset.cwDashboardLayout || "");
+        if (action === "customize") {
+          customizeOpen = !customizeOpen;
+          applyVisibility(lastSettings || {});
+        } else if (action === "show-all") {
+          saveLayout(Object.fromEntries(WIDGET_KEYS.map((key) => [key, { ...widgetLayout[key], hidden: false }])));
+          markWidgetsDirty(0);
+        } else if (action === "reset") {
+          resetLayout();
+          markWidgetsDirty(0);
+        }
+        return;
+      }
+      const widgetActionBtn = event.target?.closest?.("[data-cw-widget-action]");
+      if (widgetActionBtn) {
+        const key = String(widgetActionBtn.dataset.cwWidgetKey || "");
+        const action = String(widgetActionBtn.dataset.cwWidgetAction || "");
+        if (!widgetLayout[key]) return;
+        if (action === "hide") {
+          const wasHidden = !!widgetLayout[key].hidden;
+          patchLayout(key, { hidden: !wasHidden });
+          if (wasHidden) markWidgetsDirty(0);
+        } else if (action === "size") {
+          const current = effectiveSize(key);
+          patchLayout(key, { size: current === "large" ? "small" : "large" });
+          resetVisibleCount(key);
+          if (key !== "watchlist") renderWidget(key);
+        } else if (action === "view") {
+          const current = widgetView(key);
+          if (effectiveSize(key) === "large") {
+            if (key === "playlists") return;
+            patchLayout(key, { horizontalView: current === "media" ? "poster" : "media" });
+          } else {
+            patchLayout(key, { view: current === "icon" ? "grid" : "icon" });
+          }
+          resetVisibleCount(key);
+          if (key !== "watchlist") renderWidget(key);
+        }
+        return;
+      }
+      const scrollBtn = event.target?.closest?.("[data-cw-widget-scroll]");
+      if (scrollBtn) {
+        const carousel = scrollBtn.closest(".cw-widget-carousel");
+        const row = carousel?.querySelector(".cw-widget-carousel-row");
+        if (!row) return;
+        const kind = String(scrollBtn.getAttribute("data-cw-widget-scroll") || "");
+        const dir = Number(scrollBtn.dataset.dir || 1) < 0 ? -1 : 1;
+        const amount = Math.max(220, Math.floor(row.clientWidth * 0.82));
+        if (dir > 0 && latestItems[kind]?.length > (visibleCounts[kind] || widgetPageStep(kind))) {
+          const step = widgetPageStep(kind);
+          const previousLeft = row.scrollLeft;
+          visibleCounts[kind] = Math.min((visibleCounts[kind] || step) + step, latestItems[kind].length);
+          renderWidget(kind);
+          requestAnimationFrame(() => {
+            const nextRow = widgetNode(kind)?.querySelector(".cw-widget-carousel-row");
+            if (!nextRow) return;
+            nextRow.scrollLeft = previousLeft;
+            nextRow.scrollBy({ left: amount, behavior: "smooth" });
+          });
+          return;
+        }
+        row.scrollBy({ left: dir * amount, behavior: "smooth" });
+        return;
+      }
+      const itemLink = event.target?.closest?.("[data-cw-widget-item]");
+      if (itemLink && event.currentTarget.contains(itemLink)) {
+        if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+        const kind = String(itemLink.getAttribute("data-cw-widget-item") || "");
+        const index = Number(itemLink.getAttribute("data-cw-widget-index") || -1);
+        if (["history", "ratings", "scrobble", "progress"].includes(kind) && Number.isInteger(index) && index >= 0) {
+          event.preventDefault();
+          void openDetailCard(kind, index);
+          return;
+        }
+      }
       const btn = event.target?.closest?.("[data-cw-widget-more]");
       if (!btn) return;
       const kind = String(btn.getAttribute("data-cw-widget-more") || "");
-      if (kind !== "history" && kind !== "ratings" && kind !== "scrobble") return;
-      const step = kind === "ratings" ? RATING_PAGE_STEP : PAGE_STEP;
+      if (!["history", "ratings", "scrobble", "progress", "playlists"].includes(kind)) return;
+      const step = widgetPageStep(kind);
       visibleCounts[kind] = Math.min((visibleCounts[kind] || step) + step, latestItems[kind].length);
-      if (kind === "history") {
-        renderPagedList($("#recent-history-list"), latestItems.history, visibleCounts.history, historyCard, "No watched history recorded yet.", "history");
-      } else if (kind === "ratings") {
-        renderPagedList($("#latest-ratings-grid"), latestItems.ratings, visibleCounts.ratings, ratingCard, "No ratings recorded yet.", "ratings");
-      } else {
-        renderPagedList($("#recent-scrobble-list"), latestItems.scrobble, visibleCounts.scrobble, activityCard, "No recent scrobble recorded yet.", "scrobble", true);
-      }
+      renderWidget(kind);
     });
     document.addEventListener("tab-changed", (event) => {
       const id = event?.detail?.id || event?.detail?.tab;
@@ -557,13 +1567,18 @@
     window.addEventListener("cw:scrobble-stopped", scheduleScrobbleStopRefresh);
     window.addEventListener("cw:manual-watched-saved", () => markWidgetsDirty(250));
     window.addEventListener("watchlist:refresh", () => markWidgetsDirty(250));
+    window.addEventListener("cw:watchlist-widget-state", (event) => {
+      setWidgetEmpty("watchlist", !!event?.detail?.empty);
+      applyVisibility(lastSettings || {});
+    });
+    window.addEventListener("resize", scheduleMasonry);
     if (authSetupPending()) scheduleAuthReadyRefresh();
     window.addEventListener("load", () => setTimeout(() => refreshDashboardWidgets({ forceConfig: true }), 100), { once: true });
     refreshDashboardWidgets();
   }
 
   window.CW = window.CW || {};
-  window.CW.DashboardWidgets = { refresh: refreshDashboardWidgets };
+  window.CW.DashboardWidgets = { refresh: refreshDashboardWidgets, showAll: showAllWidgets, hiddenCount: hiddenWidgetCount };
 
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", initDashboardWidgets, { once: true });

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -290,7 +290,7 @@
 
   const renderHubLayoutStrip = () => {
     if (!hubLayoutHost) return;
-    const hiddenCount = orderedFeats(true).filter((feat) => feat.layout.hidden).length;
+    const hiddenCount = orderedFeats(true).filter((feat) => feat.layout.hidden).length + (window.CW?.DashboardWidgets?.hiddenCount?.() || 0);
     const unhideAll = hubLayoutHost.querySelector("[data-layout-action='show-all']");
     if (unhideAll) {
       unhideAll.disabled = hiddenCount === 0;
@@ -333,6 +333,7 @@
       } else if (btn.dataset.layoutAction === "show-all") {
         toggleTools(false);
         saveAndRenderLayout(Object.fromEntries(FEAT_KEYS.map((key) => [key, { ...hubLayout[key], hidden: false }])));
+        window.CW?.DashboardWidgets?.showAll?.();
       } else if (btn.classList.contains("cw-hub-refresh-proxy")) {
         toggleTools(false);
         document.getElementById("btn-status-refresh")?.click();
@@ -343,6 +344,7 @@
     });
     renderHubLayoutStrip();
   };
+  window.addEventListener("cw:dashboard-widgets-layout-changed", renderHubLayoutStrip);
 
   const createLaneControls = (feat) => {
     const iconButton = (icon, title, cls = "") => {
@@ -362,7 +364,10 @@
     });
     drag.addEventListener("dragend", () => {
       dragLaneKey = "";
-      document.querySelectorAll("#ux-lanes .lane").forEach((node) => node.classList.remove("is-dragging", "is-drop-target"));
+      document.querySelectorAll("#ux-lanes .lane").forEach((node) => {
+        node.classList.remove("is-dragging", "is-drop-target");
+        delete node.dataset.dropPosition;
+      });
     });
 
     const size = feat.layout.size === "large" ? "small" : "large";
@@ -380,14 +385,22 @@
       ev.preventDefault();
       ev.dataTransfer.dropEffect = "move";
       const r = lane.getBoundingClientRect();
-      lane.classList.toggle("drop-after", ev.clientX > r.left + r.width / 2 || ev.clientY > r.top + r.height * 0.62);
+      const horizontal = r.width >= r.height * 1.25;
+      const after = horizontal
+        ? ev.clientX > r.left + r.width / 2
+        : ev.clientY > r.top + r.height / 2;
+      lane.dataset.dropPosition = after ? "after" : "before";
       lane.classList.add("is-drop-target");
     });
-    lane.addEventListener("dragleave", () => lane.classList.remove("is-drop-target", "drop-after"));
+    lane.addEventListener("dragleave", () => {
+      lane.classList.remove("is-drop-target");
+      delete lane.dataset.dropPosition;
+    });
     lane.addEventListener("drop", (ev) => {
       ev.preventDefault();
-      const after = lane.classList.contains("drop-after");
-      lane.classList.remove("is-drop-target", "drop-after");
+      const after = lane.dataset.dropPosition === "after";
+      lane.classList.remove("is-drop-target");
+      delete lane.dataset.dropPosition;
       moveLaneTo(ev.dataTransfer.getData("text/plain") || dragLaneKey, key, after);
     });
   };
@@ -412,7 +425,7 @@
 
       const chipState = laneState(feat.key);
       const header = Object.assign(document.createElement("div"), { className: "lane-h" });
-      header.innerHTML = `<div class="lane-ico"><span class="material-symbols-outlined material-symbol material-icons">${feat.icon}</span></div><div class="lane-title">${feat.label}</div><div class="lane-badges"><span class="delta"><b>${fmtDelta(added, removed, updated)}</b></span><span class="chip ${chipState}">${!enabled ? "Disabled" : chipState === "err" ? "Failed" : chipState === "ok" ? "Synced" : chipState === "run" ? "Running" : "Skipped"}</span></div>`;
+      header.innerHTML = `<div class="lane-ico"><span class="material-symbols-rounded material-symbol" aria-hidden="true">${feat.icon}</span></div><div class="lane-title">${feat.label}</div><div class="lane-badges"><span class="delta"><b>${fmtDelta(added, removed, updated)}</b></span><span class="chip ${chipState}">${!enabled ? "Disabled" : chipState === "err" ? "Failed" : chipState === "ok" ? "Synced" : chipState === "run" ? "Running" : "Skipped"}</span></div>`;
       header.appendChild(createLaneControls(feat));
       lane.appendChild(header);
 

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -677,6 +677,8 @@ DEFAULT_CFG: dict[str, Any] = {
         "show_recent_history_widget": True,             # Show Recent History widget on Main tab
         "show_latest_ratings_widget": True,             # Show Latest Ratings widget on Main tab
         "show_recent_scrobble_widget": True,            # Show Recent Scrobble widget on Main tab
+        "show_recent_progress_widget": False,           # Show Recent Progress widget on Main tab
+        "show_recent_playlists_widget": False,          # Show Recent Playlists widget on Main tab
         "recent_activity_display": "count:3",           # "count:3|4|5" | "hours:24|48|72"
         "recent_activity_limit": 3,                     # Recent Scrobble rows on Main tab
         "recent_syncs_display": "count:3",              # "count:3|4|5" | "hours:24|48|72"
@@ -1468,6 +1470,8 @@ def _normalize_ui(cfg: dict[str, Any]) -> None:
     ui["show_recent_history_widget"] = bool(ui.get("show_recent_history_widget", True))
     ui["show_latest_ratings_widget"] = bool(ui.get("show_latest_ratings_widget", True))
     ui["show_recent_scrobble_widget"] = bool(ui.get("show_recent_scrobble_widget", True))
+    ui["show_recent_progress_widget"] = bool(ui.get("show_recent_progress_widget", False))
+    ui["show_recent_playlists_widget"] = bool(ui.get("show_recent_playlists_widget", False))
     ui["show_quick_add_desktop"] = bool(ui.get("show_quick_add_desktop", True))
     ui["show_quick_add_mobile"] = bool(ui.get("show_quick_add_mobile", True))
 

--- a/services/dashboard_widgets.py
+++ b/services/dashboard_widgets.py
@@ -63,6 +63,16 @@ def _as_int(value: Any) -> int | None:
         return None
 
 
+def _as_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except Exception:
+        return None
+    return number if number == number else None
+
+
 def _nested_dict(item: Mapping[str, Any], key: str) -> dict[str, Any]:
     return _as_dict(item.get(key))
 
@@ -437,6 +447,20 @@ def _poster_url(item: Mapping[str, Any], *, size: str = "w342", episode_still: b
     return f"/art/tmdb/{_resolved_art_type(item, tmdb)}/{tmdb}?size={size}"
 
 
+def _grid_art_url(item: Mapping[str, Any], *, size: str = "w300") -> str:
+    still = _episode_still_url(item, size=size)
+    if still:
+        return still
+    tmdb = _tmdb_id(item)
+    if tmdb in (None, "", 0, False):
+        return ""
+    return f"/art/tmdb/{_resolved_art_type(item, tmdb)}/{tmdb}?kind=backdrop&size={size}"
+
+
+def _cover_url(item: Mapping[str, Any], *, size: str = "w342") -> str:
+    return _poster_url(item, size=size, episode_still=False)
+
+
 def _metadata_manager() -> Any | None:
     global _METADATA_MANAGER, _METADATA_MANAGER_FAILED
     if _METADATA_MANAGER is not None:
@@ -534,7 +558,9 @@ def _art_debug(row: dict[str, Any], reason: str, **fields: Any) -> None:
         return
 
 
-def _resolve_missing_art(row: dict[str, Any], *, size: str, episode_still: bool = False) -> None:
+def _resolve_missing_art(
+    row: dict[str, Any], *, size: str, episode_still: bool = False, backdrop_fallback: bool = False
+) -> None:
     if row.get("poster") or row.get("tmdb"):
         row["art_reason"] = "existing_tmdb"
         return
@@ -570,14 +596,30 @@ def _resolve_missing_art(row: dict[str, Any], *, size: str, episode_still: bool 
         show_ids.setdefault("tmdb", tmdb)
         current_ids.setdefault("show_ids", show_ids)
     row["ids"] = current_ids
-    row["poster"] = _poster_url(row, size=size, episode_still=episode_still)
+    row["poster"] = _grid_art_url(row, size=size) if backdrop_fallback else _poster_url(row, size=size, episode_still=episode_still)
     _art_debug(row, "metadata_resolved", tmdb=tmdb)
 
 
-def _resolve_missing_art_rows(rows: list[dict[str, Any]], *, size: str, episode_still: bool = False) -> list[dict[str, Any]]:
+def _ensure_cover_art(row: dict[str, Any], *, size: str) -> None:
+    if row.get("cover"):
+        return
+    cover = _cover_url(row, size=size)
+    if cover:
+        row["cover"] = cover
+
+
+def _resolve_missing_art_rows(
+    rows: list[dict[str, Any]],
+    *,
+    size: str,
+    episode_still: bool = False,
+    cover_size: str = "w342",
+    backdrop_fallback: bool = False,
+) -> list[dict[str, Any]]:
     for row in rows:
         _resolve_episode_show_title(row)
-        _resolve_missing_art(row, size=size, episode_still=episode_still)
+        _resolve_missing_art(row, size=size, episode_still=episode_still, backdrop_fallback=backdrop_fallback)
+        _ensure_cover_art(row, size=cover_size)
     return rows
 
 
@@ -646,7 +688,8 @@ def _rating_row(raw_key: str, item: Mapping[str, Any], sources: list[dict[str, s
         "updated_epoch": _update_epoch(item),
         "ids": _ids(item),
         "tmdb": _tmdb_id(item),
-        "poster": _poster_url(item),
+        "poster": _grid_art_url(item, size="w300"),
+        "cover": _cover_url(item, size="w342"),
         "sources": sources,
     }
 
@@ -670,7 +713,7 @@ def _rating_aliases(row: Mapping[str, Any]) -> list[str]:
 
 
 def _copy_richer_media_fields(dst: dict[str, Any], src: Mapping[str, Any]) -> None:
-    for key in ("tmdb", "poster", "ids"):
+    for key in ("tmdb", "poster", "cover", "ids"):
         if not dst.get(key) and src.get(key):
             dst[key] = src[key]
     if not dst.get("art_type") and src.get("art_type"):
@@ -782,7 +825,7 @@ def latest_ratings_widget(
         reverse=True,
     )
     cap = max(1, min(int(limit or 12), 24))
-    selected = _resolve_missing_art_rows(items[:cap], size="w342")
+    selected = _resolve_missing_art_rows(items[:cap], size="w300", episode_still=True, backdrop_fallback=True)
     for row in selected:
         row.pop(_RATING_TRACKER_FLAG, None)
     return {"ok": True, "items": selected, "total": len(items)}
@@ -831,6 +874,7 @@ def _activity_row(event: Mapping[str, Any]) -> dict[str, Any]:
         "ids": _ids(event),
         "tmdb": _tmdb_id(event),
         "poster": _poster_url(event, size="w300", episode_still=True),
+        "cover": _cover_url(event, size="w342"),
         "source": source,
         "targets": clean_targets,
         "sources": clean_sources,
@@ -860,6 +904,7 @@ def _history_state_row(raw_key: str, item: Mapping[str, Any], sources: list[dict
         "ids": _ids(item),
         "tmdb": _tmdb_id(item),
         "poster": _poster_url(item, size="w300", episode_still=True),
+        "cover": _cover_url(item, size="w342"),
         "sources": sources,
     }
 
@@ -1014,10 +1059,114 @@ def recent_history_widget(
 
 def recent_scrobble_widget(*, limit: int = 8) -> dict[str, Any]:
     cap = max(1, min(int(limit or 8), 24))
-    payload = list_events(limit=max(cap, 12), offset=0, status="ok", kind="scrobble", group_routes=True)
-    rows = [_activity_row(item) for item in payload.get("items") or [] if isinstance(item, Mapping)]
+    payload = list_events(limit=max(cap, 12), offset=0, status="ok", kind="all", group_routes=True)
+    rows = [
+        _activity_row(item)
+        for item in payload.get("items") or []
+        if isinstance(item, Mapping) and str(item.get("kind") or "").strip().lower() in {"scrobble", "history_sync"}
+    ]
     selected = _resolve_missing_art_rows(rows[:cap], size="w300", episode_still=True)
     return {"ok": True, "items": selected, "total": len(rows)}
+
+
+def _progress_epoch(item: Mapping[str, Any], raw_key: str = "") -> int:
+    for key in (
+        "progress_at",
+        "updated_at",
+        "last_updated",
+        "synced_at",
+        "captured_at",
+        "created_at",
+        "watched_at",
+    ):
+        epoch = _iso_epoch(item.get(key))
+        if epoch > 0:
+            return epoch
+    return _history_key_epoch(raw_key)
+
+
+def _progress_value(item: Mapping[str, Any]) -> float | None:
+    for key in ("progress_percent", "progress", "percent", "position_percent", "resume_percent"):
+        value = _as_float(item.get(key))
+        if value is not None:
+            return max(0.0, min(100.0, round(value, 1)))
+    progress_ms = _as_float(item.get("progress_ms") or item.get("viewOffset") or item.get("view_offset"))
+    duration_ms = _as_float(item.get("duration_ms") or item.get("duration"))
+    if progress_ms is not None and duration_ms and duration_ms > 0:
+        return max(0.0, min(100.0, round((progress_ms / duration_ms) * 100.0, 1)))
+    return None
+
+
+def _progress_row(raw_key: str, item: Mapping[str, Any], sources: list[dict[str, str]]) -> dict[str, Any] | None:
+    sort_epoch = _progress_epoch(item, raw_key)
+    if sort_epoch <= 0:
+        return None
+    return {
+        "id": str(raw_key or ""),
+        "key": _history_key(raw_key, item),
+        "type": _media_type(item),
+        "art_type": _art_type(item),
+        "title": _title(item),
+        "year": _year(item),
+        "season": _season_number(item),
+        "episode": _episode_number(item),
+        "episode_label": _episode_label(item),
+        "progress": _progress_value(item),
+        "sort_epoch": sort_epoch,
+        "ids": _ids(item),
+        "tmdb": _tmdb_id(item),
+        "poster": _poster_url(item, size="w300", episode_still=True),
+        "cover": _cover_url(item, size="w342"),
+        "sources": sources,
+    }
+
+
+def recent_progress_widget(
+    state: Mapping[str, Any] | None = None,
+    *,
+    limit: int = 8,
+    tracker_items: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    rows: dict[str, dict[str, Any]] = {}
+
+    def put(row: dict[str, Any]) -> None:
+        key = str(row.get("key") or row.get("id") or "")
+        if not key:
+            return
+        prev = rows.get(key)
+        rows[key] = _merge_media_row(prev, row, sort_key="sort_epoch") if prev else row
+
+    for raw_key, raw_item in (tracker_items or {}).items():
+        item = raw_item if isinstance(raw_item, Mapping) else {}
+        row = _progress_row(str(raw_key), item, _sources_from_item(item))
+        if row:
+            put(row)
+
+    providers = (state or {}).get("providers") if isinstance((state or {}).get("providers"), Mapping) else {}
+    provider_keys = sorted({str(p).upper() for p in providers.keys()}) if isinstance(providers, Mapping) else []
+    for provider in provider_keys:
+        for instance, block in _provider_blocks(state or {}, provider):
+            for raw_key, raw_item in _feature_items(block, "progress").items():
+                item = raw_item if isinstance(raw_item, Mapping) else {}
+                row = _progress_row(str(raw_key), item, [_provider_ref(provider, instance)])
+                if row:
+                    put(row)
+
+    items = sorted(rows.values(), key=lambda x: int(x.get("sort_epoch") or 0), reverse=True)
+    cap = max(1, min(int(limit or 8), 24))
+    selected = _resolve_missing_art_rows(items[:cap], size="w300", episode_still=True)
+    return {"ok": True, "items": selected, "total": len(items)}
+
+
+def recent_playlists_widget(*, limit: int = 8) -> dict[str, Any]:
+    try:
+        from cw_platform.config_base import load_config
+        from services import playlists
+
+        rows = playlists.activity(load_config() or {}, limit=max(1, min(int(limit or 8), 24)))
+    except Exception:
+        rows = []
+    return {"ok": True, "items": rows, "total": len(rows)}
 
 
 def dashboard_widgets_payload(
@@ -1026,12 +1175,38 @@ def dashboard_widgets_payload(
     history_limit: int = 8,
     ratings_limit: int = 12,
     scrobble_limit: int = 8,
+    progress_limit: int = 8,
+    playlists_limit: int = 8,
+    include: set[str] | None = None,
 ) -> dict[str, Any]:
-    history_items = _tracker_feature_items("history")
-    ratings_items = _tracker_feature_items("ratings")
-    return {
-        "ok": True,
-        "recent_history": recent_history_widget(state, limit=history_limit, tracker_items=history_items),
-        "recent_scrobble": recent_scrobble_widget(limit=scrobble_limit),
-        "latest_ratings": latest_ratings_widget(state, limit=ratings_limit, tracker_items=ratings_items),
+    requested = {str(key).strip().lower() for key in include} if include is not None else {
+        "history",
+        "ratings",
+        "scrobble",
+        "progress",
+        "playlists",
     }
+    payload: dict[str, Any] = {"ok": True}
+    if "history" in requested:
+        payload["recent_history"] = recent_history_widget(
+            state,
+            limit=history_limit,
+            tracker_items=_tracker_feature_items("history"),
+        )
+    if "scrobble" in requested:
+        payload["recent_scrobble"] = recent_scrobble_widget(limit=scrobble_limit)
+    if "ratings" in requested:
+        payload["latest_ratings"] = latest_ratings_widget(
+            state,
+            limit=ratings_limit,
+            tracker_items=_tracker_feature_items("ratings"),
+        )
+    if "progress" in requested:
+        payload["recent_progress"] = recent_progress_widget(
+            state,
+            limit=progress_limit,
+            tracker_items=_tracker_feature_items("progress"),
+        )
+    if "playlists" in requested:
+        payload["recent_playlists"] = recent_playlists_widget(limit=playlists_limit)
+    return payload

--- a/services/watchlist.py
+++ b/services/watchlist.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Mapping, cast
 from urllib.parse import urlencode
 
 import requests
@@ -240,6 +240,46 @@ def _norm_type(x: str | None) -> str:
     if t in {"movie", "movies", "film", "films"}:
         return "movie"
     return ""
+
+
+def _as_pos_int(value: Any) -> int | None:
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return None
+    return n if n > 0 else None
+
+
+def _season_number(item: dict[str, Any]) -> int | None:
+    raw_episode = item.get("episode")
+    episode: Mapping[str, Any] = raw_episode if isinstance(raw_episode, dict) else {}
+    return (
+        _as_pos_int(item.get("season_number"))
+        or _as_pos_int(episode.get("season_number"))
+        or _as_pos_int(episode.get("season"))
+        or _as_pos_int(item.get("season"))
+    )
+
+
+def _episode_number(item: dict[str, Any]) -> int | None:
+    raw_episode = item.get("episode")
+    episode: Mapping[str, Any] = raw_episode if isinstance(raw_episode, dict) else {}
+    return (
+        _as_pos_int(item.get("episode_number"))
+        or _as_pos_int(episode.get("episode_number"))
+        or _as_pos_int(episode.get("number"))
+        or _as_pos_int(item.get("number"))
+        or _as_pos_int(item.get("episode"))
+    )
+
+
+def _episode_label(item: dict[str, Any]) -> str:
+    explicit = str(item.get("episode_label") or item.get("episodeLabel") or "").strip()
+    if explicit:
+        return explicit
+    season = _season_number(item)
+    episode = _episode_number(item)
+    return f"S{season:02d}E{episode:02d}" if season and episode else ""
 
 
 def _rich_ids_score(item: dict[str, Any] | None) -> int:
@@ -920,6 +960,9 @@ def build_watchlist(state: dict[str, Any], tmdb_ok: bool) -> list[dict[str, Any]
         title = info.get("title") or info.get("name") or ""
         year = info.get("year") or info.get("release_year")
         tmdb_id = (info.get("ids") or {}).get("tmdb") or info.get("tmdb")
+        season = _season_number(info)
+        episode = _episode_number(info)
+        episode_label = _episode_label(info)
 
         if not added_epoch:
             added_when = _pick_added(info)
@@ -937,6 +980,9 @@ def build_watchlist(state: dict[str, Any], tmdb_ok: bool) -> list[dict[str, Any]
                 "type": typ,
                 "title": title,
                 "year": year,
+                "season": season,
+                "episode": episode,
+                "episode_label": episode_label,
                 "tmdb": tmdb_value,
                 "status": status,
                 "sources": sources,

--- a/tests/test_dashboard_widgets.py
+++ b/tests/test_dashboard_widgets.py
@@ -96,8 +96,10 @@ def test_latest_ratings_widget_dedupes_and_sorts_provider_state() -> None:
     assert [item["title"] for item in payload["items"]] == ["Arrival", "Severance"]
     assert payload["items"][0]["rating"] == 9
     assert {source["provider"] for source in payload["items"][0]["sources"]} == {"PLEX", "TRAKT"}
-    assert payload["items"][0]["poster"] == "/art/tmdb/movie/10?size=w342"
-    assert payload["items"][1]["poster"] == "/art/tmdb/tv/20?size=w342"
+    assert payload["items"][0]["poster"] == "/art/tmdb/movie/10?kind=backdrop&size=w300"
+    assert payload["items"][0]["cover"] == "/art/tmdb/movie/10?size=w342"
+    assert payload["items"][1]["poster"] == "/art/tmdb/tv/20?kind=backdrop&size=w300"
+    assert payload["items"][1]["cover"] == "/art/tmdb/tv/20?size=w342"
 
 
 def test_latest_ratings_widget_uses_tracker_items_without_runtime_state() -> None:
@@ -173,7 +175,8 @@ def test_dashboard_widgets_merge_flattened_provider_rows_across_providers(monkey
     assert {source["provider"] for source in history["items"][0]["sources"]} == set(FLATTENED_PROVIDERS)
     assert ratings["total"] == 1
     assert ratings["items"][0]["title"] == "Heat"
-    assert ratings["items"][0]["poster"] == "/art/tmdb/movie/949?size=w342"
+    assert ratings["items"][0]["poster"] == "/art/tmdb/movie/949?kind=backdrop&size=w300"
+    assert ratings["items"][0]["cover"] == "/art/tmdb/movie/949?size=w342"
     assert {source["provider"] for source in ratings["items"][0]["sources"]} == set(FLATTENED_PROVIDERS)
 
 
@@ -209,7 +212,8 @@ def test_latest_ratings_widget_handles_nested_provider_movie_rows(provider: str)
     assert payload["items"][0]["title"] == "Heat"
     assert payload["items"][0]["year"] == 1995
     assert payload["items"][0]["tmdb"] == 949
-    assert payload["items"][0]["poster"] == "/art/tmdb/movie/949?size=w342"
+    assert payload["items"][0]["poster"] == "/art/tmdb/movie/949?kind=backdrop&size=w300"
+    assert payload["items"][0]["cover"] == "/art/tmdb/movie/949?size=w342"
 
 
 def test_recent_history_widget_includes_latest_state_history(monkeypatch) -> None:
@@ -548,7 +552,8 @@ def test_latest_ratings_widget_merges_provider_local_movie_ids_and_inherits_art(
 
     assert payload["total"] == 1
     assert payload["items"][0]["title"] == "Heat"
-    assert payload["items"][0]["poster"] == "/art/tmdb/movie/949?size=w342"
+    assert payload["items"][0]["poster"] == "/art/tmdb/movie/949?kind=backdrop&size=w300"
+    assert payload["items"][0]["cover"] == "/art/tmdb/movie/949?size=w342"
     assert {source["provider"] for source in payload["items"][0]["sources"]} == {"SIMKL", "TRAKT"}
 
 
@@ -641,7 +646,8 @@ def test_latest_ratings_widget_resolves_missing_art_from_metadata(monkeypatch) -
 
     assert payload["total"] == 1
     assert payload["items"][0]["tmdb"] == 949
-    assert payload["items"][0]["poster"] == "/art/tmdb/movie/949?size=w342"
+    assert payload["items"][0]["poster"] == "/art/tmdb/movie/949?kind=backdrop&size=w300"
+    assert payload["items"][0]["cover"] == "/art/tmdb/movie/949?size=w342"
     assert fake.calls[0]["entity"] == "movie"
 
 
@@ -877,3 +883,105 @@ def test_recent_scrobble_widget_uses_nested_history_sync_item_art(tmp_path, monk
         {"provider": "TRAKT", "instance": "default"},
         {"provider": "CROSSWATCH", "instance": "default"},
     ]
+
+
+def test_recent_progress_widget_uses_sync_state_not_live_provider_endpoints() -> None:
+    state = {
+        "providers": {
+            "PLEX": {
+                "progress": {
+                    "baseline": {
+                        "items": {
+                            "tmdb:550": {
+                                "type": "movie",
+                                "title": "Fight Club",
+                                "year": 1999,
+                                "ids": {"tmdb": 550},
+                                "progress_percent": 42.2,
+                                "progress_at": "2026-01-02T02:00:00Z",
+                            },
+                            "tmdb:40": {
+                                "type": "movie",
+                                "title": "Arrival",
+                                "year": 2016,
+                                "ids": {"tmdb": 40},
+                                "progress_ms": 900000,
+                                "duration_ms": 1800000,
+                                "updated_at": "2026-01-01T02:00:00Z",
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    payload = dashboard_widgets.recent_progress_widget(state, limit=5, tracker_items={})
+
+    assert payload["ok"] is True
+    assert payload["total"] == 2
+    assert payload["items"][0]["title"] == "Fight Club"
+    assert payload["items"][0]["progress"] == 42.2
+    assert payload["items"][1]["progress"] == 50.0
+    assert payload["items"][0]["sources"] == [{"provider": "PLEX", "instance": "default"}]
+
+
+def test_recent_playlists_widget_uses_playlist_activity(monkeypatch) -> None:
+    from services import playlists
+
+    monkeypatch.setattr(
+        playlists,
+        "activity",
+        lambda _cfg, limit=25: [
+            {"ts": 1767225600, "type": "Run", "status": "completed", "label": "MAP-01", "details": "+2/-0"}
+        ][:limit],
+    )
+    monkeypatch.setattr("cw_platform.config_base.load_config", lambda: {})
+
+    payload = dashboard_widgets.recent_playlists_widget(limit=3)
+
+    assert payload == {
+        "ok": True,
+        "items": [{"ts": 1767225600, "type": "Run", "status": "completed", "label": "MAP-01", "details": "+2/-0"}],
+        "total": 1,
+    }
+
+
+def test_dashboard_widgets_payload_only_builds_included_widgets(monkeypatch) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(dashboard_widgets, "_tracker_feature_items", lambda kind: calls.append(f"tracker:{kind}") or {})
+    monkeypatch.setattr(
+        dashboard_widgets,
+        "recent_history_widget",
+        lambda *_args, **_kwargs: calls.append("history") or {"ok": True, "items": [], "total": 0},
+    )
+    monkeypatch.setattr(
+        dashboard_widgets,
+        "recent_scrobble_widget",
+        lambda **_kwargs: calls.append("scrobble") or {"ok": True, "items": [], "total": 0},
+    )
+    monkeypatch.setattr(
+        dashboard_widgets,
+        "latest_ratings_widget",
+        lambda *_args, **_kwargs: calls.append("ratings") or {"ok": True, "items": [], "total": 0},
+    )
+    monkeypatch.setattr(
+        dashboard_widgets,
+        "recent_progress_widget",
+        lambda *_args, **_kwargs: calls.append("progress") or {"ok": True, "items": [], "total": 0},
+    )
+    monkeypatch.setattr(
+        dashboard_widgets,
+        "recent_playlists_widget",
+        lambda **_kwargs: calls.append("playlists") or {"ok": True, "items": [], "total": 0},
+    )
+
+    payload = dashboard_widgets.dashboard_widgets_payload({}, include={"ratings", "playlists"})
+
+    assert payload == {
+        "ok": True,
+        "latest_ratings": {"ok": True, "items": [], "total": 0},
+        "recent_playlists": {"ok": True, "items": [], "total": 0},
+    }
+    assert calls == ["tracker:ratings", "ratings", "playlists"]

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -439,31 +439,32 @@ def _get_index_html_static() -> str:
     </div>
   </section>
 
-  <section id="placeholder-card" class="card cw-main-card cw-main-card--wall hidden">
-    <div class="title">Watchlist</div>
-    <div class="cw-main-card-head cw-main-card-head--compact">
-      <div class="cw-main-card-head-copy">
-        <div class="cw-main-card-kicker">Watchlist</div>
-      </div>
-      <span id="watchlist-count-chip" class="cw-widget-count-chip hidden" aria-live="polite"></span>
-      <button class="cw-watchlist-see-all" type="button" onclick="showTab('watchlist')" aria-label="Open Watchlist page">
-        <span class="material-symbols-rounded" aria-hidden="true">apps</span>
-      </button>
-    </div>
-    <div id="wall-msg" class="wall-msg">Loading...</div>
-    <div class="wall-wrap">
-      <div id="edgeL" class="edge left"></div><div id="edgeR" class="edge right"></div>
-      <div id="poster-row" class="row-scroll" aria-label="Watchlist"></div>
-      <button class="nav prev" type="button" onclick="scrollWall(-1)" aria-label="Scroll left"><</button>
-      <button class="nav next" type="button" onclick="scrollWall(1)" aria-label="Scroll right">></button>
-    </div>
-  </section>
-
   <section id="dashboard-widgets-card" class="cw-dashboard-widgets hidden" aria-label="Media widgets">
+    <article id="placeholder-card" class="card cw-main-card cw-main-card--wall cw-dash-widget cw-dash-widget--watchlist cw-dash-widget--wide hidden">
+      <div class="title">Watchlist</div>
+      <div class="cw-main-card-head cw-main-card-head--compact">
+        <div class="cw-main-card-head-copy">
+          <div class="cw-dash-title-row">
+            <span class="material-symbols-rounded" aria-hidden="true">movie</span>
+            <h3>Watchlist</h3>
+          </div>
+        </div>
+        <span id="watchlist-count-chip" class="cw-widget-count-chip hidden" aria-live="polite"></span>
+        <button class="cw-watchlist-see-all" type="button" onclick="showTab('watchlist')" aria-label="Open Watchlist page">View all</button>
+      </div>
+      <div id="wall-msg" class="wall-msg">Loading...</div>
+      <div class="wall-wrap">
+        <div id="edgeL" class="edge left"></div><div id="edgeR" class="edge right"></div>
+        <div id="poster-row" class="row-scroll" aria-label="Watchlist"></div>
+        <button class="nav prev" type="button" onclick="scrollWall(-1)" aria-label="Scroll left"><</button>
+        <button class="nav next" type="button" onclick="scrollWall(1)" aria-label="Scroll right">></button>
+      </div>
+    </article>
+
     <article id="recent-history-widget" class="cw-dash-widget cw-dash-widget--history">
       <div class="cw-dash-widget-head">
         <div class="cw-dash-title-row">
-          <span class="material-symbols-rounded" aria-hidden="true">history</span>
+          <span class="material-symbols-rounded" aria-hidden="true">play_arrow</span>
           <h3>Recent History</h3>
         </div>
         <div class="cw-dash-head-actions">
@@ -500,6 +501,34 @@ def _get_index_html_static() -> str:
         </div>
       </div>
       <div id="recent-scrobble-list" class="cw-history-widget-list cw-widget-scrollbar" aria-live="polite"></div>
+    </article>
+
+    <article id="recent-progress-widget" class="cw-dash-widget cw-dash-widget--progress">
+      <div class="cw-dash-widget-head">
+        <div class="cw-dash-title-row">
+          <span class="material-symbols-rounded" aria-hidden="true">timelapse</span>
+          <h3>Recent Progress</h3>
+        </div>
+        <div class="cw-dash-head-actions">
+          <span id="recent-progress-count-chip" class="cw-widget-count-chip hidden" aria-live="polite"></span>
+          <button id="recent-progress-refresh" class="cw-dash-ghost" type="button" title="Refresh recent progress" aria-label="Refresh recent progress"><span class="material-symbols-rounded" aria-hidden="true">refresh</span></button>
+        </div>
+      </div>
+      <div id="recent-progress-list" class="cw-history-widget-list cw-widget-scrollbar" aria-live="polite"></div>
+    </article>
+
+    <article id="recent-playlists-widget" class="cw-dash-widget cw-dash-widget--playlists">
+      <div class="cw-dash-widget-head">
+        <div class="cw-dash-title-row">
+          <span class="material-symbols-rounded" aria-hidden="true">queue_music</span>
+          <h3>Recent Playlists</h3>
+        </div>
+        <div class="cw-dash-head-actions">
+          <span id="recent-playlists-count-chip" class="cw-widget-count-chip hidden" aria-live="polite"></span>
+          <button id="recent-playlists-refresh" class="cw-dash-ghost" type="button" title="Refresh recent playlists" aria-label="Refresh recent playlists"><span class="material-symbols-rounded" aria-hidden="true">refresh</span></button>
+        </div>
+      </div>
+      <div id="recent-playlists-list" class="cw-history-widget-list cw-widget-scrollbar" aria-live="polite"></div>
     </article>
   </section>
 
@@ -850,6 +879,28 @@ def _get_index_html_static() -> str:
                             <button type="button" class="cw-field-help material-symbols-rounded" title="Recent Scrobble widget: Shows or hides the Main screen recent scrobble widget below Watchlist." aria-label="Recent Scrobble widget setting help">help</button>
                           </div>
                           <select id="ui_show_recent_scrobble_widget" name="ui_show_recent_scrobble_widget">
+                            <option value="true">Show</option>
+                            <option value="false">Hide</option>
+                          </select>
+                        </div>
+
+                        <div>
+                          <div class="cw-field-label-row">
+                            <label for="ui_show_recent_progress_widget">Recent Progress widget</label>
+                            <button type="button" class="cw-field-help material-symbols-rounded" title="Recent Progress widget: Shows or hides the Main screen recent progress sync activity widget." aria-label="Recent Progress widget setting help">help</button>
+                          </div>
+                          <select id="ui_show_recent_progress_widget" name="ui_show_recent_progress_widget">
+                            <option value="true">Show</option>
+                            <option value="false">Hide</option>
+                          </select>
+                        </div>
+
+                        <div>
+                          <div class="cw-field-label-row">
+                            <label for="ui_show_recent_playlists_widget">Recent Playlists widget</label>
+                            <button type="button" class="cw-field-help material-symbols-rounded" title="Recent Playlists widget: Shows or hides the Main screen recent playlist sync activity widget." aria-label="Recent Playlists widget setting help">help</button>
+                          </div>
+                          <select id="ui_show_recent_playlists_widget" name="ui_show_recent_playlists_widget">
                             <option value="true">Show</option>
                             <option value="false">Hide</option>
                           </select>


### PR DESCRIPTION
# Pull request

## Change

Adds a customizable dashboard widget system for Watchlist, Recent History, Latest Ratings, Recent Scrobble, Recent Progress, and Recent Playlists.

Includes draggable widget ordering, compact/large sizing, grid/poster/media-card views, hide/unhide controls, and shared dashboard widget settings. Watchlist is now part of the same dashboard widget layout, while Recent Progress and Recent Playlists are added as first-class widgets.

Also updates widget payloads to support progress/playlists, richer artwork fields, episode labels, and more efficient artwork loading for poster/backdrop use.

## Why

The dashboard widgets needed a more flexible, consistent interface so users can decide which widgets matter, how large they should be and how they should display media.

This also avoids unnecessary widget fetching when widgets are hidden and makes Watchlist, History, Ratings, Scrobble, Progress, and Playlists behave as one coherent dashboard system.

## Testing

- test_dashboard_widgets.py

## Issue

NA