### PR TITLE
Add: Editor Local Tracker workspace

### DIFF
--- a/api/editorAPI.py
+++ b/api/editorAPI.py
@@ -936,6 +936,211 @@ def api_editor_playlist_endpoint_save(endpoint_id: str, payload: dict[str, Any] 
     result["ok"] = result["unresolved_count"] == 0
     return result
 
+_TRACKER_PROVIDER = "CROSSWATCH"
+_TRACKER_FEATURES: tuple[str, ...] = ("watchlist", "history", "ratings", "progress")
+_TRACKER_RESERVED_SCOPES = frozenset({"unresolved", "restore_state", "tmp", "snapshots"})
+_TRACKER_DEFAULT_ROOT = Path("/config/.cw_provider")
+
+
+def _tracker_root() -> Path:
+    node: Any = {}
+    try:
+        cfg = load_config() or {}
+        node = cfg.get("CrossWatch") or cfg.get("crosswatch") or {}
+    except Exception:
+        node = {}
+    raw = ""
+    if isinstance(node, dict):
+        raw = str(node.get("root_dir") or "").strip()
+    try:
+        return Path(raw or _TRACKER_DEFAULT_ROOT).resolve()
+    except Exception:
+        return _TRACKER_DEFAULT_ROOT
+
+
+def _tracker_scan(root: Path) -> dict[str, dict[str, str]]:
+    found: dict[str, dict[str, str]] = {}
+    try:
+        entries = sorted(root.iterdir())
+    except Exception:
+        return found
+    for p in entries:
+        try:
+            if not p.is_file() or p.suffix != ".json":
+                continue
+        except Exception:
+            continue
+        parts = p.name.split(".")
+        if len(parts) == 2:
+            feat, scope = parts[0], ""
+        elif len(parts) == 3:
+            feat, scope = parts[0], parts[1]
+            if scope.lower() in _TRACKER_RESERVED_SCOPES:
+                continue
+        else:
+            continue
+        if feat not in _TRACKER_FEATURES:
+            continue
+        found.setdefault(scope, {})[feat] = p.name
+    return found
+
+
+def _tracker_provider_label(name: str) -> str:
+    n = str(name or "").strip().upper()
+    if not n:
+        return ""
+    if n == _TRACKER_PROVIDER:
+        return "Local Tracker"
+    try:
+        ops = load_sync_ops(n)
+        label = str((getattr(ops, "label", None) or (lambda: ""))() or "").strip()
+        if label:
+            return label
+    except Exception:
+        pass
+    return n.title()
+
+
+def _tracker_pair_labels() -> dict[str, str]:
+    out: dict[str, str] = {}
+    try:
+        from cw_platform.orchestrator._pairs import _pair_scope_key
+        from providers.sync.crosswatch._common import _safe_scope
+    except Exception:
+        return out
+    try:
+        pairs = (load_config() or {}).get("pairs") or []
+    except Exception:
+        return out
+    if not isinstance(pairs, list):
+        return out
+    for i, pair in enumerate(pairs):
+        if not isinstance(pair, dict):
+            continue
+        src = str(pair.get("source") or "").strip().upper()
+        dst = str(pair.get("target") or "").strip().upper()
+        if not src or not dst or _TRACKER_PROVIDER not in (src, dst):
+            continue
+        mode = str(pair.get("mode") or "one-way").strip().lower()
+        try:
+            scope = _safe_scope(_pair_scope_key(pair, i=i, src=src, dst=dst, mode=mode))
+        except Exception:
+            continue
+        if scope and scope not in out:
+            out[scope] = f"{_tracker_provider_label(src)} → {_tracker_provider_label(dst)}"
+    return out
+
+
+def _tracker_workspace_index() -> dict[str, dict[str, Any]]:
+    root = _tracker_root()
+    found = _tracker_scan(root)
+    if not found:
+        return {}
+    pair_labels = _tracker_pair_labels()
+    out: dict[str, dict[str, Any]] = {}
+    fallback = 0
+    for scope in sorted(found.keys(), key=lambda s: (s != "", s)):
+        files = found[scope]
+        wid = "default" if not scope else scope
+        if wid in out:
+            n = 2
+            while f"{wid}-{n}" in out:
+                n += 1
+            wid = f"{wid}-{n}"
+        if not scope:
+            label = "Default"
+        else:
+            label = pair_labels.get(scope) or ""
+            if not label:
+                fallback += 1
+                label = "Local tracker" if fallback == 1 else f"Local tracker {fallback}"
+        out[wid] = {
+            "id": wid,
+            "label": label,
+            "features": {f: (f in files) for f in _TRACKER_FEATURES},
+            "files": files,
+            "root": root,
+        }
+    return out
+
+
+def _tracker_workspaces() -> list[dict[str, Any]]:
+    return [
+        {"id": w["id"], "label": w["label"], "features": w["features"]}
+        for w in _tracker_workspace_index().values()
+    ]
+
+
+def _tracker_workspace(workspace: Any) -> dict[str, Any]:
+    index = _tracker_workspace_index()
+    if not index:
+        raise HTTPException(status_code=404, detail="No Local Tracker data found")
+    wid = str(workspace or "").strip()
+    if not wid:
+        wid = next(iter(index))
+    node = index.get(wid)
+    if node is None:
+        raise HTTPException(status_code=404, detail="Unknown Local Tracker workspace")
+    return node
+
+
+def _tracker_read(root: Path, filename: str) -> tuple[dict[str, Any], int | None]:
+    path = root / filename
+    try:
+        raw = json.loads(path.read_text("utf-8"))
+    except Exception:
+        return {}, None
+    if not isinstance(raw, dict):
+        return {}, None
+    items_raw = raw.get("items")
+    items: dict[str, Any] = {}
+    if isinstance(items_raw, dict):
+        for key, val in items_raw.items():
+            k = str(key or "").strip()
+            if k:
+                items[k] = dict(val) if isinstance(val, dict) else {}
+    ts: int | None = None
+    ts_raw = raw.get("ts")
+    if isinstance(ts_raw, (int, float, str)):
+        try:
+            ts = int(ts_raw)
+        except (TypeError, ValueError):
+            ts = None
+    if ts is None:
+        try:
+            ts = int(path.stat().st_mtime)
+        except OSError:
+            ts = None
+    return items, ts
+
+
+def _normalize_blocks(blocks_raw: Any) -> list[str]:
+    keys: Any
+    if isinstance(blocks_raw, dict):
+        keys = blocks_raw.keys()
+    elif isinstance(blocks_raw, (list, tuple, set)):
+        keys = blocks_raw
+    else:
+        return []
+    blocks: list[str] = []
+    seen: set[str] = set()
+    for x in keys:
+        s = str(x).strip()
+        if not s:
+            continue
+        sl = s.lower()
+        if sl in seen:
+            continue
+        seen.add(sl)
+        blocks.append(s)
+    return blocks
+
+
+@router.get("/tracker/workspaces")
+def api_editor_tracker_workspaces() -> dict[str, Any]:
+    return {"workspaces": _tracker_workspaces()}
+
+
 @router.get("/state/providers")
 def api_editor_state_providers() -> dict[str, Any]:
     raw_state = _load_current_state()
@@ -951,11 +1156,40 @@ def api_editor_get_state(
     provider: str | None = Query(None),
     provider_instance: str | None = Query(None),
     endpoint: str | None = Query(None),
+    workspace: str | None = Query(None),
 ) -> dict[str, Any]:
     k = _normalize_kind(kind)
     src = (source or "state").strip().lower()
     if src in ("playlist", "playlists", "playlist-endpoint"):
         return api_editor_playlist_endpoint((endpoint or snapshot or "").strip())
+
+    if src in ("tracker", "crosswatch"):
+        ws = _tracker_workspace(workspace or snapshot)
+        filename = (ws["files"] or {}).get(k)
+        items, ts = _tracker_read(ws["root"], filename) if filename else ({}, None)
+
+        pol_adds, pol_blocks = _load_policy_manual(k, _TRACKER_PROVIDER, "default")
+        st_adds, st_blocks = (
+            _load_state_manual(k, _TRACKER_PROVIDER, "default") if _STATE_PATH.exists() else ({}, [])
+        )
+        manual_adds = dict(st_adds or {})
+        manual_adds.update(dict(pol_adds or {}))
+        manual_blocks = _merge_blocks(st_blocks or [], pol_blocks or [])
+
+        return {
+            "kind": k,
+            "source": "tracker",
+            "workspace": ws["id"],
+            "label": ws["label"],
+            "features": ws["features"],
+            "provider": _TRACKER_PROVIDER,
+            "provider_instance": "default",
+            "ts": ts,
+            "count": len(items),
+            "items": items,
+            "manual_adds": manual_adds,
+            "manual_blocks": manual_blocks,
+        }
 
     if src in ("state", "current"):
         raw_state = _load_current_state()
@@ -1074,6 +1308,29 @@ def api_editor_save_state(payload: dict[str, Any] = Body(...)) -> dict[str, Any]
     if src in ("playlist", "playlists", "playlist-endpoint"):
         endpoint_id = str(payload.get("endpoint") or payload.get("snapshot") or "").strip()
         return api_editor_playlist_endpoint_save(endpoint_id, payload)
+
+    if src in ("tracker", "crosswatch"):
+        ws = _tracker_workspace(payload.get("workspace") or payload.get("snapshot"))
+        items = _canonicalize_manual_items(items)
+        blocks = _normalize_blocks(payload.get("blocks"))
+        _save_policy_manual(kind, _TRACKER_PROVIDER, items, blocks, "default")
+        ts = None
+        try:
+            ts = int(_POLICY_PATH.stat().st_mtime)
+        except Exception:
+            ts = None
+        return {
+            "ok": True,
+            "kind": kind,
+            "source": "tracker",
+            "workspace": ws["id"],
+            "provider": _TRACKER_PROVIDER,
+            "provider_instance": "default",
+            "count": len(items),
+            "blocks": len(blocks),
+            "ts": ts,
+        }
+
     if src in ("state", "current"):
         provider = str(payload.get("provider") or "").strip()
         if not provider:
@@ -1082,29 +1339,7 @@ def api_editor_save_state(payload: dict[str, Any] = Body(...)) -> dict[str, Any]
 
         inst = normalize_instance_id(payload.get("provider_instance"))
 
-        blocks_raw = payload.get("blocks") or []
-        blocks: list[str] = []
-        seen: set[str] = set()
-        if isinstance(blocks_raw, (list, tuple, set)):
-            for x in blocks_raw:
-                s = str(x).strip()
-                if not s:
-                    continue
-                sl = s.lower()
-                if sl in seen:
-                    continue
-                seen.add(sl)
-                blocks.append(s)
-        elif isinstance(blocks_raw, dict):
-            for k in blocks_raw.keys():
-                s = str(k).strip()
-                if not s:
-                    continue
-                sl = s.lower()
-                if sl in seen:
-                    continue
-                seen.add(sl)
-                blocks.append(s)
+        blocks = _normalize_blocks(payload.get("blocks"))
 
         _save_policy_manual(kind, provider, items, blocks, inst)
         if _STATE_PATH.exists():

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -2,7 +2,7 @@
 /* refactored */
 /* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
 (function () {
-  const PAGE_SIZE = 50;
+  const PAGE_SIZE = 100;
   const STORAGE_KEY = "cw-editor-ui";
   const ensureStyle = (id, txt) => {
     let s = document.getElementById(id);
@@ -13,7 +13,7 @@
     s.textContent = txt;
     if (!s.parentNode) document.head.appendChild(s);
   };
-  const css = `.cw-root{--cw-shell-bg:linear-gradient(180deg,rgba(7,10,16,.98),rgba(4,6,10,.97));--cw-panel-bg:linear-gradient(180deg,rgba(11,15,22,.96),rgba(6,8,14,.95));--cw-panel-strong:linear-gradient(180deg,rgba(9,12,19,.985),rgba(4,6,10,.975));--cw-border:rgba(255,255,255,.08);--cw-border-soft:rgba(255,255,255,.05);--cw-shadow:0 18px 46px rgba(0,0,0,.38),inset 0 1px 0 rgba(255,255,255,.03);--cw-fg:#f3f6ff;--cw-fg-soft:rgba(204,213,229,.70);--cw-accent:rgba(112,96,245,.34);--cw-accent-strong:rgba(112,96,245,.52);display:flex;flex-direction:column;gap:12px;color:var(--cw-fg)}.cw-topline{display:flex;align-items:flex-start;justify-content:space-between;gap:14px;flex-wrap:wrap;margin-bottom:2px;padding:16px 18px;border-radius:24px;border:1px solid var(--cw-border);background:radial-gradient(120% 130% at 12% 0%,rgba(86,75,196,.13),transparent 42%),radial-gradient(90% 120% at 100% 100%,rgba(70,54,170,.08),transparent 52%),var(--cw-shell-bg);box-shadow:var(--cw-shadow);backdrop-filter:blur(16px) saturate(125%);-webkit-backdrop-filter:blur(16px) saturate(125%)}.cw-head-copy{min-width:0;display:grid;gap:6px}.cw-title-row{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}.cw-title{font-weight:900;font-size:28px;letter-spacing:-.03em;line-height:1.02;color:var(--cw-fg)}.cw-sub{max-width:74ch;color:var(--cw-fg-soft);font-size:14px;line-height:1.45}.cw-head-pills{margin-left:auto;display:flex;align-items:center;justify-content:flex-end;gap:8px;flex-wrap:wrap}.cw-chip{display:inline-flex;align-items:center;justify-content:center;gap:7px;min-height:40px;padding:0 14px;border-radius:999px;border:1px solid rgba(255,255,255,.09);background:linear-gradient(180deg,rgba(255,255,255,.05),rgba(255,255,255,.02));color:var(--cw-fg-soft);font-size:12px;font-weight:700;box-shadow:inset 0 1px 0 rgba(255,255,255,.03)}.cw-chip strong{color:var(--cw-fg);font-weight:800}.cw-wrap{display:grid;grid-template-columns:minmax(0,1fr) 368px;gap:14px;align-items:start}.cw-main,.cw-side{display:flex;flex-direction:column;gap:12px;min-width:0}.cw-table-wrap,.cw-empty,#page-editor .ins-card,.cw-pop{border:1px solid var(--cw-border);background:var(--cw-panel-bg);box-shadow:var(--cw-shadow);backdrop-filter:blur(14px) saturate(124%);-webkit-backdrop-filter:blur(14px) saturate(124%)}.cw-controls{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:12px;border-radius:20px;border:1px solid var(--cw-border);background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(255,255,255,.015));box-shadow:inset 0 1px 0 rgba(255,255,255,.03)}.cw-controls .cw-input{flex:1 1 280px;max-width:none}.cw-controls-spacer{flex:1 1 auto}.cw-status-text{font-size:12px;color:var(--cw-fg-soft)}.cw-input,.cw-select,.cw-btn,.cw-pop-btn,.cw-extra-display{font:inherit;color:var(--cw-fg);outline:none}.cw-input,.cw-select{width:100%;min-height:40px;padding:9px 12px;border-radius:14px;border:1px solid rgba(255,255,255,.08);background:rgba(3,6,11,.86);box-shadow:inset 0 1px 0 rgba(255,255,255,.02);transition:border-color .16s ease,background .16s ease,box-shadow .16s ease,transform .16s ease}.cw-input:hover,.cw-select:hover{border-color:rgba(255,255,255,.12);background:rgba(5,8,14,.92)}.cw-input:focus,.cw-select:focus{border-color:rgba(117,104,240,.34);box-shadow:0 0 0 3px rgba(117,104,240,.11),inset 0 1px 0 rgba(255,255,255,.03);background:rgba(5,8,14,.96)}.cw-btn,.cw-pop-btn{min-height:38px;padding:0 14px;border-radius:999px;border:1px solid rgba(255,255,255,.10);background:linear-gradient(180deg,rgba(255,255,255,.05),rgba(255,255,255,.025));cursor:pointer;display:inline-flex;align-items:center;justify-content:center;gap:7px;white-space:nowrap;font-weight:700;transition:transform .16s ease,background .16s ease,border-color .16s ease,opacity .16s ease,box-shadow .16s ease}.cw-btn:hover,.cw-pop-btn:hover,.cw-extra-display:hover{transform:translateY(-1px);border-color:rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.08),rgba(255,255,255,.04))}.cw-btn:active,.cw-pop-btn:active{transform:translateY(0)}.cw-btn[disabled],.cw-pop-btn[disabled]{opacity:.46;cursor:not-allowed;transform:none}.cw-btn.primary,.cw-pop-btn.primary{background:linear-gradient(180deg,rgba(96,104,242,.40),rgba(68,74,170,.26));border-color:rgba(133,140,255,.24);color:#f8fbff;box-shadow:0 8px 24px rgba(76,82,182,.16),inset 0 1px 0 rgba(255,255,255,.05)}.cw-btn.danger{background:linear-gradient(180deg,rgba(120,35,52,.30),rgba(72,18,29,.22));border-color:rgba(255,132,154,.14);color:#ffe7ee}.cw-btn-del{padding:0;width:30px;min-width:30px;height:30px;border-radius:10px}.cw-btn-del .material-symbol{font-size:15px;line-height:1}.cw-btn.sm{min-height:34px;padding:0 12px;font-size:12px}.cw-side .cw-select,.cw-side .cw-input{width:100%}.cw-backup-actions{display:flex;flex-wrap:wrap;gap:8px}.cw-table-wrap{border-radius:22px;overflow:auto;max-height:70vh;background:var(--cw-panel-strong)}.cw-table{width:100%;border-collapse:separate;border-spacing:0;table-layout:fixed;font-size:12px;color:var(--cw-fg)}.cw-table th,.cw-table td{padding:10px 10px;border-bottom:1px solid rgba(255,255,255,.05);text-align:left;vertical-align:middle;white-space:nowrap}.cw-table th{position:sticky;top:0;z-index:1;font-size:11px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;color:rgba(226,233,246,.68);background:linear-gradient(180deg,rgba(12,16,24,.98),rgba(7,9,15,.96));backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px)}.cw-table th.sortable{cursor:pointer;user-select:none}.cw-table th.sortable::after{content:"";margin-left:6px;opacity:.55;font-size:10px}.cw-table th.sort-asc::after{content:"▲"}.cw-table th.sort-desc::after{content:"▼"}.cw-table tbody tr{transition:background .15s ease,box-shadow .15s ease}.cw-table tbody tr:hover{background:rgba(255,255,255,.028)}.cw-table tr:last-child td{border-bottom:none}.cw-table input:not(.cw-checkbox){width:100%;min-height:34px;padding:7px 9px;background:rgba(3,6,11,.82);border:1px solid rgba(255,255,255,.08);border-radius:10px;font-size:12px;color:var(--cw-fg);transition:border-color .16s ease,box-shadow .16s ease,background .16s ease}.cw-table input:not(.cw-checkbox):focus{border-color:rgba(117,104,240,.36);box-shadow:0 0 0 3px rgba(117,104,240,.10);background:rgba(6,9,14,.95)}.cw-col-year input{min-width:74px}.cw-table .cw-key{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px}.cw-row-episode{background:rgba(96,104,242,.04)}.cw-row-deleted td{opacity:.38;text-decoration:line-through}.cw-title-cell{display:flex;flex-direction:column;align-items:stretch;gap:5px;min-width:0}.cw-title-row{display:flex;align-items:center;gap:8px;min-width:0;flex-wrap:nowrap}.cw-title-sub{font-size:11px;color:var(--cw-fg-soft);line-height:1.25;padding-left:2px;white-space:normal}.cw-title-row>input{flex:1 1 auto;min-width:0;width:auto}.cw-title-search-btn{flex:0 0 auto;width:34px;height:34px;border-radius:999px;border:1px solid rgba(255,255,255,.10);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));color:#eff4ff;display:inline-flex;align-items:center;justify-content:center;cursor:pointer;padding:0;box-shadow:inset 0 1px 0 rgba(255,255,255,.03);transition:transform .16s ease,border-color .16s ease,background .16s ease,box-shadow .16s ease}.cw-title-search-btn:hover{transform:translateY(-1px);border-color:rgba(255,255,255,.15);background:linear-gradient(180deg,rgba(255,255,255,.09),rgba(255,255,255,.04));box-shadow:0 8px 20px rgba(0,0,0,.18)}.cw-title-search-btn .material-symbol{font-size:18px}.cw-pop{position:fixed;z-index:10060;padding:12px 12px 13px;color:var(--cw-fg);width:min(560px,calc(100vw - 28px));max-height:calc(100vh - 120px);overflow:hidden;display:flex;flex-direction:column;border-radius:22px;background:linear-gradient(180deg,rgba(8,11,18,.98),rgba(4,6,10,.97))}.cw-pop-title{font-size:11px;font-weight:800;margin-bottom:6px;letter-spacing:.12em;text-transform:uppercase;color:var(--cw-fg-soft)}.cw-pop-actions{display:flex;justify-content:flex-end;gap:8px;margin-top:10px;flex-wrap:wrap}.cw-pop-btn.ghost{background:rgba(255,255,255,.03)}.cw-search-bar{display:grid;gap:8px;padding:12px;border-radius:18px;border:1px solid rgba(255,255,255,.07);background:linear-gradient(180deg,rgba(255,255,255,.025),rgba(255,255,255,.012));box-shadow:inset 0 1px 0 rgba(255,255,255,.025)}.cw-search-bar input,.cw-search-bar select,.cw-pop input[type="time"]{width:100%;min-height:42px;padding:10px 14px;border-radius:14px;border:1px solid rgba(255,255,255,.08);background:rgba(2,4,9,.92);color:var(--cw-fg);outline:none}.cw-search-bar input:focus,.cw-search-bar select:focus,.cw-pop input[type="time"]:focus{border-color:rgba(117,104,240,.26);box-shadow:0 0 0 3px rgba(117,104,240,.08)}.cw-search-results{margin-top:10px;border:1px solid rgba(255,255,255,.06);border-radius:18px;overflow:auto;background:rgba(255,255,255,.02)}.cw-search-item{display:flex;gap:12px;width:100%;padding:14px;border:0;border-bottom:1px solid rgba(255,255,255,.05);cursor:pointer;transition:background .14s ease,border-color .14s ease,transform .14s ease;background:linear-gradient(180deg,rgba(255,255,255,.028),rgba(255,255,255,.015));color:var(--cw-fg);font:inherit;text-align:left}.cw-search-item:last-child{border-bottom:none}.cw-search-item:hover{background:rgba(255,255,255,.05)}.cw-search-poster{width:52px;height:76px;border-radius:10px;overflow:hidden;background:#050810;border:1px solid rgba(255,255,255,.06);flex:0 0 auto}.cw-search-poster img{width:100%;height:100%;object-fit:cover}.cw-search-poster-placeholder{width:100%;height:100%;display:flex;align-items:center;justify-content:center;color:var(--cw-fg-soft);font-size:11px}.cw-search-content{display:grid;gap:4px;min-width:0;align-content:start}.cw-search-title-line{display:flex;align-items:center;gap:8px;flex-wrap:wrap}.cw-search-title{font-weight:800;color:var(--cw-fg)}.cw-search-tag,.cw-rating-pill,.cw-type-pill,.cw-type-chip,.cw-extra-display,.cw-tag{display:inline-flex;align-items:center;justify-content:center;border-radius:999px;border:1px solid rgba(255,255,255,.09);background:linear-gradient(180deg,rgba(255,255,255,.05),rgba(255,255,255,.025));box-shadow:inset 0 1px 0 rgba(255,255,255,.03)}.cw-search-tag{min-height:22px;padding:0 8px;font-size:10px;font-weight:800;color:rgba(236,242,251,.78);letter-spacing:.04em;text-transform:uppercase}.cw-search-meta,.cw-search-overview,.cw-search-empty,.cw-search-status{font-size:12px;color:var(--cw-fg-soft);line-height:1.4}.cw-search-overview{display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}.cw-search-empty{padding:14px}.cw-datetime-grid,.cw-rating-grid,.cw-type-grid{display:grid;gap:8px}.cw-datetime-grid{grid-template-columns:repeat(auto-fit,minmax(150px,1fr))}.cw-rating-grid{grid-template-columns:repeat(auto-fit,minmax(64px,1fr));margin-top:10px}.cw-rating-pill,.cw-type-pill{min-height:34px;padding:0 10px;font-size:12px;font-weight:800;color:var(--cw-fg-soft);cursor:pointer;transition:transform .16s ease,border-color .16s ease,background .16s ease}.cw-rating-pill:hover,.cw-type-pill:hover,.cw-type-chip:hover{transform:translateY(-1px);border-color:rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.08),rgba(255,255,255,.04))}.cw-rating-pill.active,.cw-type-pill.active,.cw-type-chip.active{color:#f7f9ff;border-color:rgba(133,140,255,.22);background:linear-gradient(180deg,rgba(96,104,242,.24),rgba(70,74,150,.12))}.cw-type-grid{grid-template-columns:repeat(auto-fit,minmax(120px,1fr));margin-top:10px}.cw-type-filter{display:flex;gap:8px;flex-wrap:wrap}.cw-type-chip{min-height:34px;padding:0 12px;font-size:12px;font-weight:800;color:var(--cw-fg-soft);cursor:pointer;transition:transform .16s ease,border-color .16s ease,background .16s ease}.cw-empty{display:grid;place-items:center;min-height:160px;border-radius:22px;padding:18px;text-align:center;color:var(--cw-fg-soft)}.cw-pager{display:flex;align-items:center;justify-content:center;gap:10px;margin-top:2px;color:var(--cw-fg-soft);font-size:12px}.cw-pager .cw-page-info{min-width:200px;text-align:center}.cw-pager .cw-btn{min-width:110px}#page-editor .ins-card{position:relative;border-radius:22px;padding:12px 13px;overflow:hidden}#page-editor .ins-card::before{content:"";position:absolute;inset:0;pointer-events:none;background:radial-gradient(130% 120% at 100% 0%,rgba(94,81,210,.09),transparent 58%)}#page-editor .ins-row{position:relative;z-index:1;display:flex;align-items:center;gap:10px;padding:10px 4px;border-top:1px solid rgba(255,255,255,.05)}#page-editor .ins-row:first-child{border-top:none;padding-top:2px}#page-editor .ins-icon{width:36px;height:36px;border-radius:14px;display:flex;align-items:center;justify-content:center;background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.025));border:1px solid rgba(255,255,255,.08);box-shadow:0 10px 22px rgba(0,0,0,.22)}#page-editor .ins-title{font-weight:900;letter-spacing:-.01em;font-size:15px;color:var(--cw-fg)}#page-editor .ins-kv{display:grid;grid-template-columns:92px minmax(0,1fr);gap:10px;align-items:center;width:100%}#page-editor .ins-kv label{color:var(--cw-fg-soft);font-size:12px;font-weight:700;letter-spacing:.03em}#page-editor .ins-metrics{display:flex;flex-direction:column;gap:8px;width:100%}#page-editor .metric-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:8px}#page-editor .metric-divider{height:1px;background:rgba(255,255,255,.06);margin:2px 0}#page-editor .metric{position:relative;display:grid;grid-template-columns:32px minmax(0,1fr);align-items:center;gap:8px;min-height:60px;padding:10px;border-radius:16px;background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.015));border:1px solid rgba(255,255,255,.07);overflow:hidden}#page-editor .metric::before{content:"";position:absolute;inset:0;pointer-events:none;background:linear-gradient(135deg,rgba(255,255,255,.03),transparent 55%)}#page-editor .metric .material-symbol{font-size:18px;color:#edf3ff;opacity:.92;-webkit-text-fill-color:currentColor}#page-editor .metric .m-val{font-weight:900;font-size:18px;line-height:1;color:#f8fbff}#page-editor .metric .m-lbl{font-size:11px;opacity:.72;letter-spacing:.08em;text-transform:uppercase;margin-top:3px}.cw-tag{position:relative;gap:8px;min-height:34px;padding:0 12px;color:var(--cw-fg-soft);font-size:12px;font-weight:800}.cw-tag-dot{width:8px;height:8px;border-radius:999px;background:#94a3b8;box-shadow:0 0 0 6px rgba(148,163,184,.08)}.cw-tag.loaded{color:#ebfff4;border-color:rgba(108,216,167,.16);background:linear-gradient(180deg,rgba(31,85,58,.18),rgba(255,255,255,.025))}.cw-tag.loaded .cw-tag-dot{background:#42d392;box-shadow:0 0 0 6px rgba(66,211,146,.10)}.cw-tag.warn{color:#fff9ea;border-color:rgba(255,210,109,.18);background:linear-gradient(180deg,rgba(112,88,33,.18),rgba(255,255,255,.025))}.cw-tag.warn .cw-tag-dot{background:#f5c563;box-shadow:0 0 0 6px rgba(245,197,99,.10)}.cw-tag.error{color:#fff0f3;border-color:rgba(255,132,154,.16);background:linear-gradient(180deg,rgba(108,34,49,.18),rgba(255,255,255,.025))}.cw-tag.error .cw-tag-dot{background:#ff879d;box-shadow:0 0 0 6px rgba(255,135,157,.10)}.cw-extra-display{min-height:34px;width:100%;padding:0 12px;display:inline-flex;align-items:center;justify-content:space-between;gap:8px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.03);cursor:pointer;transition:transform .16s ease,border-color .16s ease,background .16s ease}.cw-extra-display-label,.cw-extra-display-placeholder{font-size:11px;font-weight:800;color:var(--cw-fg-soft);letter-spacing:.05em;text-transform:uppercase}.cw-extra-display-value{font-size:12px;font-weight:700;color:var(--cw-fg)}.cw-extra-display-icon{opacity:.7}.cw-state-hint{border:1px dashed rgba(255,255,255,.12);border-radius:16px;padding:12px 13px;background:rgba(255,255,255,.02);color:var(--cw-fg-soft);font-size:12px;line-height:1.5}.cw-state-hint strong{color:var(--cw-fg)}.cw-checkbox{appearance:none;-webkit-appearance:none;position:relative;display:inline-block;vertical-align:middle;flex:none;width:18px!important;height:18px!important;min-width:18px!important;min-height:18px!important;margin:0;padding:0!important;border-radius:6px;border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.015));box-shadow:inset 0 1px 0 rgba(255,255,255,.03),0 4px 12px rgba(0,0,0,.16);cursor:pointer;transition:border-color .16s ease,background .16s ease,box-shadow .16s ease,transform .16s ease}.cw-checkbox:hover{border-color:rgba(255,255,255,.22);background:linear-gradient(180deg,rgba(255,255,255,.065),rgba(255,255,255,.03))}.cw-checkbox:focus-visible{outline:none;box-shadow:0 0 0 3px rgba(104,112,236,.12),inset 0 1px 0 rgba(255,255,255,.04),0 4px 12px rgba(0,0,0,.18)}.cw-checkbox:checked{border-color:rgba(132,140,255,.34);background:linear-gradient(180deg,rgba(84,94,214,.52),rgba(56,63,144,.30));box-shadow:0 0 0 3px rgba(104,112,236,.11),inset 0 1px 0 rgba(255,255,255,.06),0 6px 16px rgba(0,0,0,.18)}.cw-checkbox:checked::after{content:"";position:absolute;left:5px;top:1px;width:5px;height:10px;border-right:2px solid #fff;border-bottom:2px solid #fff;transform:rotate(45deg)}.cw-checkbox:disabled{opacity:.45;cursor:not-allowed;box-shadow:none}.cw-bulk{display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:8px 10px;border-radius:16px;border:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02));box-shadow:inset 0 1px 0 rgba(255,255,255,.02)}.cw-bulk-count{font-size:12px;font-weight:800;color:var(--cw-fg)}.cw-progress{height:10px;border-radius:999px;background:rgba(255,255,255,.06);overflow:hidden;border:1px solid rgba(255,255,255,.07)}.cw-progress>span{display:block;height:100%;width:40%;background:linear-gradient(90deg,rgba(96,104,242,.10),rgba(96,104,242,.72),rgba(122,132,255,.88),rgba(96,104,242,.10));animation:cw-progress-move 1.15s linear infinite}@keyframes cw-progress-move{0%{transform:translateX(-100%)}100%{transform:translateX(250%)}}.cw-collapse summary{list-style:none;color:var(--cw-fg);font-weight:800}.cw-collapse summary::-webkit-details-marker{display:none}@media (max-width:1120px){.cw-wrap{grid-template-columns:minmax(0,1fr)}.cw-head-pills{margin-left:0;justify-content:flex-start}}@media (max-width:760px){.cw-topline{padding:14px}.cw-title{font-size:24px}.cw-sub{font-size:13px}.cw-controls{padding:10px}.cw-table th,.cw-table td{padding:9px 8px}#page-editor .ins-kv{grid-template-columns:1fr;gap:8px}.cw-pager{flex-wrap:wrap}}`;
+  const css = `.cw-root{--cw-shell-bg:linear-gradient(180deg,rgba(7,10,16,.98),rgba(4,6,10,.97));--cw-panel-bg:linear-gradient(180deg,rgba(11,15,22,.96),rgba(6,8,14,.95));--cw-panel-strong:linear-gradient(180deg,rgba(9,12,19,.985),rgba(4,6,10,.975));--cw-border:rgba(255,255,255,.08);--cw-border-soft:rgba(255,255,255,.05);--cw-shadow:0 18px 46px rgba(0,0,0,.38),inset 0 1px 0 rgba(255,255,255,.03);--cw-fg:#f3f6ff;--cw-fg-soft:rgba(204,213,229,.70);--cw-accent:rgba(112,96,245,.34);--cw-accent-strong:rgba(112,96,245,.52);display:flex;flex-direction:column;gap:12px;color:var(--cw-fg)}.cw-topline{display:flex;align-items:flex-start;justify-content:space-between;gap:14px;flex-wrap:wrap;margin-bottom:2px;padding:16px 18px;border-radius:24px;border:1px solid var(--cw-border);background:radial-gradient(120% 130% at 12% 0%,rgba(86,75,196,.13),transparent 42%),radial-gradient(90% 120% at 100% 100%,rgba(70,54,170,.08),transparent 52%),var(--cw-shell-bg);box-shadow:var(--cw-shadow);backdrop-filter:blur(16px) saturate(125%);-webkit-backdrop-filter:blur(16px) saturate(125%)}.cw-head-copy{min-width:0;display:grid;gap:6px}.cw-title-row{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}.cw-title{font-weight:900;font-size:28px;letter-spacing:-.03em;line-height:1.02;color:var(--cw-fg)}.cw-sub{max-width:74ch;color:var(--cw-fg-soft);font-size:14px;line-height:1.45}.cw-head-pills{margin-left:auto;display:flex;align-items:center;justify-content:flex-end;gap:8px;flex-wrap:wrap}.cw-chip{display:inline-flex;align-items:center;justify-content:center;gap:7px;min-height:40px;padding:0 14px;border-radius:999px;border:1px solid rgba(255,255,255,.09);background:linear-gradient(180deg,rgba(255,255,255,.05),rgba(255,255,255,.02));color:var(--cw-fg-soft);font-size:12px;font-weight:700;box-shadow:inset 0 1px 0 rgba(255,255,255,.03)}.cw-chip strong{color:var(--cw-fg);font-weight:800}.cw-wrap{display:grid;grid-template-columns:minmax(0,1fr) 368px;gap:14px;align-items:stretch}.cw-main,.cw-side{display:flex;flex-direction:column;gap:12px;min-width:0;min-height:0}.cw-table-wrap,.cw-empty,#page-editor .ins-card,.cw-pop{border:1px solid var(--cw-border);background:var(--cw-panel-bg);box-shadow:var(--cw-shadow);backdrop-filter:blur(14px) saturate(124%);-webkit-backdrop-filter:blur(14px) saturate(124%)}.cw-controls{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:12px;border-radius:20px;border:1px solid var(--cw-border);background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(255,255,255,.015));box-shadow:inset 0 1px 0 rgba(255,255,255,.03)}.cw-controls .cw-input{flex:1 1 280px;max-width:none}.cw-controls-spacer{flex:1 1 auto}.cw-status-text{font-size:12px;color:var(--cw-fg-soft)}.cw-input,.cw-select,.cw-btn,.cw-pop-btn,.cw-extra-display{font:inherit;color:var(--cw-fg);outline:none}.cw-input,.cw-select{width:100%;min-height:40px;padding:9px 12px;border-radius:14px;border:1px solid rgba(255,255,255,.08);background:rgba(3,6,11,.86);box-shadow:inset 0 1px 0 rgba(255,255,255,.02);transition:border-color .16s ease,background .16s ease,box-shadow .16s ease,transform .16s ease}.cw-input:hover,.cw-select:hover{border-color:rgba(255,255,255,.12);background:rgba(5,8,14,.92)}.cw-input:focus,.cw-select:focus{border-color:rgba(117,104,240,.34);box-shadow:0 0 0 3px rgba(117,104,240,.11),inset 0 1px 0 rgba(255,255,255,.03);background:rgba(5,8,14,.96)}.cw-btn,.cw-pop-btn{min-height:38px;padding:0 14px;border-radius:999px;border:1px solid rgba(255,255,255,.10);background:linear-gradient(180deg,rgba(255,255,255,.05),rgba(255,255,255,.025));cursor:pointer;display:inline-flex;align-items:center;justify-content:center;gap:7px;white-space:nowrap;font-weight:700;transition:transform .16s ease,background .16s ease,border-color .16s ease,opacity .16s ease,box-shadow .16s ease}.cw-btn:hover,.cw-pop-btn:hover,.cw-extra-display:hover{transform:translateY(-1px);border-color:rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.08),rgba(255,255,255,.04))}.cw-btn:active,.cw-pop-btn:active{transform:translateY(0)}.cw-btn[disabled],.cw-pop-btn[disabled]{opacity:.46;cursor:not-allowed;transform:none}.cw-btn.primary,.cw-pop-btn.primary{background:linear-gradient(180deg,rgba(96,104,242,.40),rgba(68,74,170,.26));border-color:rgba(133,140,255,.24);color:#f8fbff;box-shadow:0 8px 24px rgba(76,82,182,.16),inset 0 1px 0 rgba(255,255,255,.05)}.cw-btn.danger{background:linear-gradient(180deg,rgba(120,35,52,.30),rgba(72,18,29,.22));border-color:rgba(255,132,154,.14);color:#ffe7ee}.cw-btn-del{padding:0;width:30px;min-width:30px;height:30px;border-radius:10px}.cw-btn-del .material-symbol{font-size:15px;line-height:1}.cw-btn.sm{min-height:34px;padding:0 12px;font-size:12px}.cw-side .cw-select,.cw-side .cw-input{width:100%}.cw-backup-actions{display:flex;flex-wrap:wrap;gap:8px}.cw-table-wrap{border-radius:22px;position:relative;overflow:hidden;flex:1 1 auto;min-height:420px;background:var(--cw-panel-strong)}.cw-table-scroll{position:absolute;inset:0;overflow:auto;border-radius:22px}.cw-table{width:100%;border-collapse:separate;border-spacing:0;table-layout:fixed;font-size:12px;color:var(--cw-fg)}.cw-table th,.cw-table td{padding:10px 10px;border-bottom:1px solid rgba(255,255,255,.05);text-align:left;vertical-align:middle;white-space:nowrap}.cw-table th{position:sticky;top:0;z-index:1;font-size:11px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;color:rgba(226,233,246,.68);background:linear-gradient(180deg,rgba(12,16,24,.98),rgba(7,9,15,.96));backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px)}.cw-table th.sortable{cursor:pointer;user-select:none}.cw-table th.sortable::after{content:"";margin-left:6px;opacity:.55;font-size:10px}.cw-table th.sort-asc::after{content:"▲"}.cw-table th.sort-desc::after{content:"▼"}.cw-table tbody tr{transition:background .15s ease,box-shadow .15s ease}.cw-table tbody tr:hover{background:rgba(255,255,255,.028)}.cw-table tr:last-child td{border-bottom:none}.cw-table input:not(.cw-checkbox){width:100%;min-height:34px;padding:7px 9px;background:rgba(3,6,11,.82);border:1px solid rgba(255,255,255,.08);border-radius:10px;font-size:12px;color:var(--cw-fg);transition:border-color .16s ease,box-shadow .16s ease,background .16s ease}.cw-table input:not(.cw-checkbox):focus{border-color:rgba(117,104,240,.36);box-shadow:0 0 0 3px rgba(117,104,240,.10);background:rgba(6,9,14,.95)}.cw-col-year input{min-width:74px}.cw-table .cw-key{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px}.cw-row-episode{background:rgba(96,104,242,.04)}.cw-row-deleted td{opacity:.38;text-decoration:line-through}.cw-title-cell{display:flex;flex-direction:column;align-items:stretch;gap:5px;min-width:0}.cw-title-row{display:flex;align-items:center;gap:8px;min-width:0;flex-wrap:nowrap}.cw-title-sub{font-size:11px;color:var(--cw-fg-soft);line-height:1.25;padding-left:2px;white-space:normal}.cw-title-row>input{flex:1 1 auto;min-width:0;width:auto}.cw-title-search-btn{flex:0 0 auto;width:34px;height:34px;border-radius:999px;border:1px solid rgba(255,255,255,.10);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));color:#eff4ff;display:inline-flex;align-items:center;justify-content:center;cursor:pointer;padding:0;box-shadow:inset 0 1px 0 rgba(255,255,255,.03);transition:transform .16s ease,border-color .16s ease,background .16s ease,box-shadow .16s ease}.cw-title-search-btn:hover{transform:translateY(-1px);border-color:rgba(255,255,255,.15);background:linear-gradient(180deg,rgba(255,255,255,.09),rgba(255,255,255,.04));box-shadow:0 8px 20px rgba(0,0,0,.18)}.cw-title-search-btn .material-symbol{font-size:18px}.cw-pop{position:fixed;z-index:10060;padding:12px 12px 13px;color:var(--cw-fg);width:min(560px,calc(100vw - 28px));max-height:calc(100vh - 120px);overflow:hidden;display:flex;flex-direction:column;border-radius:22px;background:linear-gradient(180deg,rgba(8,11,18,.98),rgba(4,6,10,.97))}.cw-pop-title{font-size:11px;font-weight:800;margin-bottom:6px;letter-spacing:.12em;text-transform:uppercase;color:var(--cw-fg-soft)}.cw-pop-actions{display:flex;justify-content:flex-end;gap:8px;margin-top:10px;flex-wrap:wrap}.cw-pop-btn.ghost{background:rgba(255,255,255,.03)}.cw-search-bar{display:grid;gap:8px;padding:12px;border-radius:18px;border:1px solid rgba(255,255,255,.07);background:linear-gradient(180deg,rgba(255,255,255,.025),rgba(255,255,255,.012));box-shadow:inset 0 1px 0 rgba(255,255,255,.025)}.cw-search-bar input,.cw-search-bar select,.cw-pop input[type="time"]{width:100%;min-height:42px;padding:10px 14px;border-radius:14px;border:1px solid rgba(255,255,255,.08);background:rgba(2,4,9,.92);color:var(--cw-fg);outline:none}.cw-search-bar input:focus,.cw-search-bar select:focus,.cw-pop input[type="time"]:focus{border-color:rgba(117,104,240,.26);box-shadow:0 0 0 3px rgba(117,104,240,.08)}.cw-search-results{margin-top:10px;border:1px solid rgba(255,255,255,.06);border-radius:18px;overflow:auto;background:rgba(255,255,255,.02)}.cw-search-item{display:flex;gap:12px;width:100%;padding:14px;border:0;border-bottom:1px solid rgba(255,255,255,.05);cursor:pointer;transition:background .14s ease,border-color .14s ease,transform .14s ease;background:linear-gradient(180deg,rgba(255,255,255,.028),rgba(255,255,255,.015));color:var(--cw-fg);font:inherit;text-align:left}.cw-search-item:last-child{border-bottom:none}.cw-search-item:hover{background:rgba(255,255,255,.05)}.cw-search-poster{width:52px;height:76px;border-radius:10px;overflow:hidden;background:#050810;border:1px solid rgba(255,255,255,.06);flex:0 0 auto}.cw-search-poster img{width:100%;height:100%;object-fit:cover}.cw-search-poster-placeholder{width:100%;height:100%;display:flex;align-items:center;justify-content:center;color:var(--cw-fg-soft);font-size:11px}.cw-search-content{display:grid;gap:4px;min-width:0;align-content:start}.cw-search-title-line{display:flex;align-items:center;gap:8px;flex-wrap:wrap}.cw-search-title{font-weight:800;color:var(--cw-fg)}.cw-search-tag,.cw-rating-pill,.cw-type-pill,.cw-type-chip,.cw-extra-display,.cw-tag{display:inline-flex;align-items:center;justify-content:center;border-radius:999px;border:1px solid rgba(255,255,255,.09);background:linear-gradient(180deg,rgba(255,255,255,.05),rgba(255,255,255,.025));box-shadow:inset 0 1px 0 rgba(255,255,255,.03)}.cw-search-tag{min-height:22px;padding:0 8px;font-size:10px;font-weight:800;color:rgba(236,242,251,.78);letter-spacing:.04em;text-transform:uppercase}.cw-search-meta,.cw-search-overview,.cw-search-empty,.cw-search-status{font-size:12px;color:var(--cw-fg-soft);line-height:1.4}.cw-search-overview{display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}.cw-search-empty{padding:14px}.cw-datetime-grid,.cw-rating-grid,.cw-type-grid{display:grid;gap:8px}.cw-datetime-grid{grid-template-columns:repeat(auto-fit,minmax(150px,1fr))}.cw-rating-grid{grid-template-columns:repeat(auto-fit,minmax(64px,1fr));margin-top:10px}.cw-rating-pill,.cw-type-pill{min-height:34px;padding:0 10px;font-size:12px;font-weight:800;color:var(--cw-fg-soft);cursor:pointer;transition:transform .16s ease,border-color .16s ease,background .16s ease}.cw-rating-pill:hover,.cw-type-pill:hover,.cw-type-chip:hover{transform:translateY(-1px);border-color:rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.08),rgba(255,255,255,.04))}.cw-rating-pill.active,.cw-type-pill.active,.cw-type-chip.active{color:#f7f9ff;border-color:rgba(133,140,255,.22);background:linear-gradient(180deg,rgba(96,104,242,.24),rgba(70,74,150,.12))}.cw-type-grid{grid-template-columns:repeat(auto-fit,minmax(120px,1fr));margin-top:10px}.cw-type-filter{display:flex;gap:8px;flex-wrap:wrap}.cw-type-chip{min-height:34px;padding:0 12px;font-size:12px;font-weight:800;color:var(--cw-fg-soft);cursor:pointer;transition:transform .16s ease,border-color .16s ease,background .16s ease}.cw-empty{display:grid;place-items:center;min-height:160px;border-radius:22px;padding:18px;text-align:center;color:var(--cw-fg-soft)}.cw-pager{display:flex;align-items:center;justify-content:center;gap:10px;margin-top:2px;color:var(--cw-fg-soft);font-size:12px}.cw-pager .cw-page-info{min-width:200px;text-align:center}.cw-pager .cw-btn{min-width:110px}#page-editor .ins-card{position:relative;border-radius:22px;padding:12px 13px;overflow:hidden}#page-editor .ins-card::before{content:"";position:absolute;inset:0;pointer-events:none;background:radial-gradient(130% 120% at 100% 0%,rgba(94,81,210,.09),transparent 58%)}#page-editor .ins-row{position:relative;z-index:1;display:flex;align-items:center;gap:10px;padding:10px 4px;border-top:1px solid rgba(255,255,255,.05)}#page-editor .ins-row:first-child{border-top:none;padding-top:2px}#page-editor .ins-icon{width:36px;height:36px;border-radius:14px;display:flex;align-items:center;justify-content:center;background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.025));border:1px solid rgba(255,255,255,.08);box-shadow:0 10px 22px rgba(0,0,0,.22)}#page-editor .ins-title{font-weight:900;letter-spacing:-.01em;font-size:15px;color:var(--cw-fg)}#page-editor .ins-kv{display:grid;grid-template-columns:92px minmax(0,1fr);gap:10px;align-items:center;width:100%}#page-editor .ins-kv label{color:var(--cw-fg-soft);font-size:12px;font-weight:700;letter-spacing:.03em}#page-editor .ins-metrics{display:flex;flex-direction:column;gap:8px;width:100%}#page-editor .metric-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:8px}#page-editor .metric-divider{height:1px;background:rgba(255,255,255,.06);margin:2px 0}#page-editor .metric{position:relative;display:grid;grid-template-columns:32px minmax(0,1fr);align-items:center;gap:8px;min-height:60px;padding:10px;border-radius:16px;background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.015));border:1px solid rgba(255,255,255,.07);overflow:hidden}#page-editor .metric::before{content:"";position:absolute;inset:0;pointer-events:none;background:linear-gradient(135deg,rgba(255,255,255,.03),transparent 55%)}#page-editor .metric .material-symbol{font-size:18px;color:#edf3ff;opacity:.92;-webkit-text-fill-color:currentColor}#page-editor .metric .m-val{font-weight:900;font-size:18px;line-height:1;color:#f8fbff}#page-editor .metric .m-lbl{font-size:11px;opacity:.72;letter-spacing:.08em;text-transform:uppercase;margin-top:3px}.cw-tag{position:relative;gap:8px;min-height:34px;padding:0 12px;color:var(--cw-fg-soft);font-size:12px;font-weight:800}.cw-tag-dot{width:8px;height:8px;border-radius:999px;background:#94a3b8;box-shadow:0 0 0 6px rgba(148,163,184,.08)}.cw-tag.loaded{color:#ebfff4;border-color:rgba(108,216,167,.16);background:linear-gradient(180deg,rgba(31,85,58,.18),rgba(255,255,255,.025))}.cw-tag.loaded .cw-tag-dot{background:#42d392;box-shadow:0 0 0 6px rgba(66,211,146,.10)}.cw-tag.warn{color:#fff9ea;border-color:rgba(255,210,109,.18);background:linear-gradient(180deg,rgba(112,88,33,.18),rgba(255,255,255,.025))}.cw-tag.warn .cw-tag-dot{background:#f5c563;box-shadow:0 0 0 6px rgba(245,197,99,.10)}.cw-tag.error{color:#fff0f3;border-color:rgba(255,132,154,.16);background:linear-gradient(180deg,rgba(108,34,49,.18),rgba(255,255,255,.025))}.cw-tag.error .cw-tag-dot{background:#ff879d;box-shadow:0 0 0 6px rgba(255,135,157,.10)}.cw-extra-display{min-height:34px;width:100%;padding:0 12px;display:inline-flex;align-items:center;justify-content:space-between;gap:8px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.03);cursor:pointer;transition:transform .16s ease,border-color .16s ease,background .16s ease}.cw-extra-display-label,.cw-extra-display-placeholder{font-size:11px;font-weight:800;color:var(--cw-fg-soft);letter-spacing:.05em;text-transform:uppercase}.cw-extra-display-value{font-size:12px;font-weight:700;color:var(--cw-fg)}.cw-extra-display-icon{opacity:.7}.cw-state-hint{border:1px dashed rgba(255,255,255,.12);border-radius:16px;padding:12px 13px;background:rgba(255,255,255,.02);color:var(--cw-fg-soft);font-size:12px;line-height:1.5}.cw-state-hint strong{color:var(--cw-fg)}.cw-checkbox{appearance:none;-webkit-appearance:none;position:relative;display:inline-block;vertical-align:middle;flex:none;width:18px!important;height:18px!important;min-width:18px!important;min-height:18px!important;margin:0;padding:0!important;border-radius:6px;border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.015));box-shadow:inset 0 1px 0 rgba(255,255,255,.03),0 4px 12px rgba(0,0,0,.16);cursor:pointer;transition:border-color .16s ease,background .16s ease,box-shadow .16s ease,transform .16s ease}.cw-checkbox:hover{border-color:rgba(255,255,255,.22);background:linear-gradient(180deg,rgba(255,255,255,.065),rgba(255,255,255,.03))}.cw-checkbox:focus-visible{outline:none;box-shadow:0 0 0 3px rgba(104,112,236,.12),inset 0 1px 0 rgba(255,255,255,.04),0 4px 12px rgba(0,0,0,.18)}.cw-checkbox:checked{border-color:rgba(132,140,255,.34);background:linear-gradient(180deg,rgba(84,94,214,.52),rgba(56,63,144,.30));box-shadow:0 0 0 3px rgba(104,112,236,.11),inset 0 1px 0 rgba(255,255,255,.06),0 6px 16px rgba(0,0,0,.18)}.cw-checkbox:checked::after{content:"";position:absolute;left:5px;top:1px;width:5px;height:10px;border-right:2px solid #fff;border-bottom:2px solid #fff;transform:rotate(45deg)}.cw-checkbox:disabled{opacity:.45;cursor:not-allowed;box-shadow:none}.cw-bulk{display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:8px 10px;border-radius:16px;border:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02));box-shadow:inset 0 1px 0 rgba(255,255,255,.02)}.cw-bulk-count{font-size:12px;font-weight:800;color:var(--cw-fg)}.cw-progress{height:10px;border-radius:999px;background:rgba(255,255,255,.06);overflow:hidden;border:1px solid rgba(255,255,255,.07)}.cw-progress>span{display:block;height:100%;width:40%;background:linear-gradient(90deg,rgba(96,104,242,.10),rgba(96,104,242,.72),rgba(122,132,255,.88),rgba(96,104,242,.10));animation:cw-progress-move 1.15s linear infinite}@keyframes cw-progress-move{0%{transform:translateX(-100%)}100%{transform:translateX(250%)}}.cw-collapse summary{list-style:none;color:var(--cw-fg);font-weight:800}.cw-collapse summary::-webkit-details-marker{display:none}@media (max-width:1120px){.cw-wrap{grid-template-columns:minmax(0,1fr)}.cw-head-pills{margin-left:0;justify-content:flex-start}}@media (max-width:760px){.cw-topline{padding:14px}.cw-title{font-size:24px}.cw-sub{font-size:13px}.cw-controls{padding:10px}.cw-table th,.cw-table td{padding:9px 8px}#page-editor .ins-kv{grid-template-columns:1fr;gap:8px}.cw-pager{flex-wrap:wrap}}`;
   ensureStyle("editor-styles", css);
   ensureStyle("editor-flat-theme-styles",`
     html[data-cw-theme] #page-editor .cw-root{
@@ -389,7 +389,7 @@
       box-shadow:0 0 0 3px rgba(70,86,166,.18)!important;
     }
   `);
-  ensureStyle("editor-scrollbars",".cw-table-wrap{scrollbar-width:thin;scrollbar-color:#8b5cf6 #10131a}.cw-table-wrap::-webkit-scrollbar{height:10px;width:10px}.cw-table-wrap::-webkit-scrollbar-track{background:rgba(255,255,255,.03);border-radius:12px}.cw-table-wrap::-webkit-scrollbar-thumb{background:linear-gradient(180deg,#8b5cf6 0%,#3b82f6 100%);border-radius:12px;border:2px solid #11141c;box-shadow:inset 0 0 0 1px rgba(139,92,246,.35),0 0 10px rgba(139,92,246,.4)}.cw-table-wrap::-webkit-scrollbar-thumb:hover{background:linear-gradient(180deg,#a78bfa 0%,#60a5fa 100%)}");
+  ensureStyle("editor-scrollbars",".cw-table-scroll{scrollbar-width:thin;scrollbar-color:#8b5cf6 #10131a}.cw-table-scroll::-webkit-scrollbar{height:10px;width:10px}.cw-table-scroll::-webkit-scrollbar-track{background:rgba(255,255,255,.03);border-radius:12px}.cw-table-scroll::-webkit-scrollbar-thumb{background:linear-gradient(180deg,#8b5cf6 0%,#3b82f6 100%);border-radius:12px;border:2px solid #11141c;box-shadow:inset 0 0 0 1px rgba(139,92,246,.35),0 0 10px rgba(139,92,246,.4)}.cw-table-wrap::-webkit-scrollbar-thumb:hover{background:linear-gradient(180deg,#a78bfa 0%,#60a5fa 100%)}");
   ensureStyle("editor-icon-select-styles",".cw-editor-icon-select{min-width:200px;flex:1}.cw-editor-icon-select .cw-icon-select-btn{min-height:40px}.cw-editor-icon-select .cw-icon-select-icon{width:16px;height:16px;filter:drop-shadow(0 1px 2px rgba(0,0,0,.35))}.cw-editor-icon-select .cw-icon-select-label{font-size:13px}");
   ensureStyle("editor-import-styles",".cw-import-panel,.cw-policy-panel{width:100%}.cw-import-summary{display:flex!important;align-items:center;justify-content:space-between;gap:10px;padding:2px 0 4px;cursor:pointer;font-weight:800;user-select:none}.cw-import-title{min-width:0;color:var(--cw-fg);font-weight:900;letter-spacing:-.01em}.cw-import-help{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;width:26px;height:26px;border-radius:999px;border:1px solid rgba(255,255,255,.10);background:rgba(255,255,255,.04);color:rgba(220,228,246,.78);font-size:17px;line-height:1}.cw-import-help:hover{border-color:rgba(133,140,255,.24);background:rgba(133,140,255,.10);color:#fff}.cw-import-body,.cw-policy-body{display:grid!important;gap:12px!important;width:100%!important;margin-top:10px!important}.cw-import-fields{display:grid!important;grid-template-columns:1fr!important;gap:10px!important;align-items:stretch!important}.cw-import-field{display:grid!important;gap:6px!important;width:100%!important;margin:0!important;min-width:0!important}.cw-import-field-label{font-size:10px;font-weight:900;letter-spacing:.10em;text-transform:uppercase;color:rgba(204,213,229,.62)}.cw-import-field .cw-select,.cw-import-field .cw-icon-select{width:100%!important;min-width:0!important;flex:none!important}.cw-import-actions{display:grid!important;grid-template-columns:1fr!important;gap:10px!important;align-items:stretch!important}.cw-import-features{display:flex;flex-wrap:wrap;gap:8px}.cw-import-feature{display:inline-flex!important;align-items:center;gap:7px;min-height:34px;margin:0!important;padding:0 10px;border-radius:999px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.035);color:rgba(225,232,246,.78);font-size:12px;font-weight:800}.cw-import-feature input{flex:0 0 auto}.cw-import-run-row{display:flex!important;justify-content:flex-end!important;gap:8px!important}.cw-import-run-row .cw-btn{min-width:112px}.cw-import-progress-row{width:100%}.cw-policy-row{width:100%;padding-top:0!important}.cw-policy-copy{font-size:12px;line-height:1.45;color:rgba(204,213,229,.68)}.cw-policy-actions{display:grid;grid-template-columns:1fr;gap:8px}.cw-policy-actions .cw-btn{width:100%;justify-content:center}.cw-policy-action{display:grid;gap:5px;padding:10px;border-radius:18px;border:1px solid rgba(255,255,255,.075);background:rgba(255,255,255,.025)}.cw-policy-action span{font-size:10px;font-weight:900;letter-spacing:.10em;text-transform:uppercase;color:rgba(204,213,229,.56)}@media(max-width:760px){.cw-import-run-row{justify-content:stretch!important}.cw-import-run-row .cw-btn{width:100%}}");
 
@@ -425,6 +425,9 @@
     playlistResource: null,
     playlistWarnings: [],
     playlistOriginalKeys: [],
+    workspace: "",
+    trackerWorkspaces: [],
+    trackerAvailable: false,
     importEnabled: false,
     importProviders: [],
     importProvider: "",
@@ -446,8 +449,10 @@
       if (!raw) return;
       const saved = JSON.parse(raw);
 
-      const sources = ["state", "playlist"];
+      const sources = ["state", "tracker", "playlist"];
       if (saved.source && sources.includes(saved.source)) state.source = saved.source;
+
+      if (typeof saved.workspace === "string") state.workspace = saved.workspace;
 
       if (typeof saved.blockedOnly === "boolean") state.blockedOnly = saved.blockedOnly;
 
@@ -501,7 +506,7 @@
     convertGroupLabel("cw-state-backup-card");
   }
 
-  host.innerHTML = `<div class="cw-root"><div class="cw-topline"><div class="cw-head-copy"><div class="cw-title-row"><div><div class="cw-title">Editor</div><div class="cw-sub">Edit your current state, tracker or cache</div></div></div></div><div class="cw-head-pills"><span class="cw-chip"><strong id="cw-pill-source">Current state</strong></span><span class="cw-chip"><strong id="cw-pill-kind">Watchlist</strong></span><span class="cw-chip"><strong id="cw-pill-count">0 rows</strong></span></div></div><div class="cw-wrap"><div class="cw-main"><div class="cw-controls"><input id="cw-filter" class="cw-input" placeholder="Filter by key / title / id..."><span class="cw-status-text" id="cw-status"></span><div class="cw-controls-spacer"></div><div class="cw-bulk" id="cw-bulk" style="display:none"><span class="cw-bulk-count" id="cw-bulk-count"></span><button id="cw-bulk-remove" class="cw-btn danger" type="button"></button><button id="cw-bulk-restore" class="cw-btn" type="button"></button><button id="cw-bulk-clear" class="cw-btn" type="button">Clear</button></div><button id="cw-reload" class="cw-btn" type="button">Reload</button><button id="cw-add" class="cw-btn" type="button">Add row</button><button id="cw-save" class="cw-btn primary" type="button">Save changes</button></div><div class="cw-table-wrap" id="cw-table-wrap"><table class="cw-table"><thead><tr><th style="width:34px"><input id="cw-select-page" class="cw-checkbox" type="checkbox" title="Select page"></th><th class="cw-action-head" style="width:46px"></th><th style="width:12%" data-sort="key" class="sortable">Key</th><th style="width:13%" data-sort="type" class="sortable">Type</th><th style="width:33%" data-sort="title" class="sortable">Title</th><th style="width:84px">Year</th><th style="width:12%" id="cw-col-id-a">TMDB</th><th style="width:21%" data-sort="extra" class="sortable">Extra</th></tr></thead><tbody id="cw-tbody"></tbody></table></div><div class="cw-pager" id="cw-pager" style="display:none"><button id="cw-prev" class="cw-btn" type="button">Previous</button><span id="cw-page-info" class="cw-page-info"></span><button id="cw-next" class="cw-btn" type="button">Next</button></div><div class="cw-empty" id="cw-empty" style="display:none">No rows match this view.</div></div><aside class="cw-side"><div class="ins-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">tune</span></div><div class="ins-title">Workspace</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Source</label><select id="cw-source" class="cw-select"><option value="state">Current State</option><option value="pair">Pair Cache</option><option value="tracker">CW Tracker</option></select><label>Kind</label><select id="cw-kind" class="cw-select"><option value="watchlist">Watchlist</option><option value="history">History</option><option value="ratings">Ratings</option><option value="progress">Progress</option></select><label id="cw-pair-label" style="display:none">Pair</label><select id="cw-pair" class="cw-select" style="display:none"></select><label id="cw-snapshot-label">Snapshot</label><select id="cw-snapshot" class="cw-select"><option value="">Latest</option></select><label id="cw-instance-label" style="display:none">Profile</label><select id="cw-instance" class="cw-select" style="display:none"><option value="default">Default</option></select></div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><div class="field-label">Types</div><div id="cw-type-filter" class="cw-type-filter"><button type="button" data-type="movie" class="cw-type-chip active">Movies</button><button type="button" data-type="show" class="cw-type-chip active">Shows</button><button type="button" data-type="anime" class="cw-type-chip active">Anime</button><button type="button" data-type="season" class="cw-type-chip active">Seasons</button><button type="button" data-type="episode" class="cw-type-chip active">Episodes</button><button type="button" id="cw-blocked-only" class="cw-type-chip">Blocked</button></div></div></div><div class="ins-row" id="cw-state-bulk" style="display:none"><details class="cw-collapse" id="cw-bulk-details" style="width:100%"><summary style="cursor:pointer;font-weight:700;user-select:none">Block rules</summary><div style="display:flex;flex-direction:column;gap:8px;width:100%;margin-top:10px"><select id="cw-bulk-type" class="cw-select" style="width:100%"></select><div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap"><button id="cw-bulk-block-type" class="cw-btn danger" type="button" style="flex:1 1 0;min-width:120px">Block all</button><button id="cw-bulk-unblock-type" class="cw-btn" type="button" style="flex:1 1 0;min-width:120px">Unblock all</button></div><div class="cw-status-text">Current State only • affects baseline items</div></div></details></div><div class="ins-row" id="cw-import-row" style="display:none"><details class="cw-collapse" id="cw-import-details" style="width:100%"><summary style="cursor:pointer;font-weight:700;user-select:none">Import provider state</summary><div style="display:flex;flex-direction:column;gap:10px;width:100%;margin-top:10px"><div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center"><select id="cw-import-provider" class="cw-select" style="flex:1;min-width:200px"></select><select id="cw-import-instance" class="cw-select" style="min-width:180px"></select><select id="cw-import-mode" class="cw-select" style="min-width:180px"><option value="replace">Replace baseline</option><option value="merge">Merge (keep old)</option></select></div><div style="display:flex;gap:12px;flex-wrap:wrap;align-items:center"><label id="cw-import-watchlist-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-watchlist" class="cw-checkbox" type="checkbox" checked>Watchlist </label><label id="cw-import-history-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-history" class="cw-checkbox" type="checkbox" checked>History </label><label id="cw-import-ratings-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-ratings" class="cw-checkbox" type="checkbox" checked>Ratings </label><label id="cw-import-progress-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-progress-cb" class="cw-checkbox" type="checkbox" checked>Progress </label><span style="flex:1 1 auto"></span><button id="cw-import-run" class="cw-btn sm" type="button">Import</button></div><div id="cw-import-progress" style="display:none"><div class="cw-progress"><span></span></div><div class="cw-status-text" id="cw-import-progress-text" style="margin-top:6px"></div></div></div></details></div></div><div class="ins-card"><div class="ins-row" style="align-items:center"><div class="ins-icon"><span class="material-symbol">insights</span></div><div class="ins-title" style="margin-right:auto">Pulse</div><span class="cw-tag" id="cw-tag-status"><span class="cw-tag-dot"></span><span id="cw-tag-label">Idle</span></span></div><div class="ins-row"><div class="ins-metrics"><div class="metric-row"><div class="metric"><span class="material-symbol">view_list</span><div><div class="m-val" id="cw-summary-total">0</div><div class="m-lbl">Total rows</div></div></div><div class="metric"><span class="material-symbol">visibility</span><div><div class="m-val" id="cw-summary-visible">0</div><div class="m-lbl">Rows visible</div></div></div></div><div class="metric-divider"></div><div class="metric-row"><div class="metric"><span class="material-symbol">movie</span><div><div class="m-val" id="cw-summary-movies">0</div><div class="m-lbl">Movies</div></div></div><div class="metric"><span class="material-symbol">monitoring</span><div><div class="m-val" id="cw-summary-shows">0</div><div class="m-lbl">Shows</div></div></div><div class="metric"><span class="material-symbol">layers</span><div><div class="m-val" id="cw-summary-seasons">0</div><div class="m-lbl">Seasons</div></div></div><div class="metric"><span class="material-symbol">live_tv</span><div><div class="m-val" id="cw-summary-episodes">0</div><div class="m-lbl">Episodes</div></div></div></div><div class="metric-divider"></div><div class="metric-row"><div class="metric"><span class="material-symbol">description</span><div><div class="m-val" id="cw-summary-state-files">0</div><div class="m-lbl">State files</div></div></div><div class="metric"><span class="material-symbol">folder_copy</span><div><div class="m-val" id="cw-summary-snapshots">0</div><div class="m-lbl">Snapshots</div></div></div></div><div id="cw-state-hint" class="cw-state-hint" style="display:none"><strong>No tracker data found.</strong> Run a CrossWatch sync with the tracker enabled once. After that, tracker state files and snapshots will appear here and you can edit them. </div></div></div></div><div class="ins-card" id="cw-backup-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">backup</span></div><div class="ins-title">Archive</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Export / Import</label><div class="cw-backup-actions"><button id="cw-download" class="cw-btn" type="button">Download ZIP</button><button id="cw-upload" class="cw-btn" type="button">Import file</button><input id="cw-upload-input" type="file" accept=".zip,.json" style="display:none"></div></div></div></div><div class="ins-card" id="cw-state-backup-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">backup</span></div><div class="ins-title">Policy backup</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Export / Import</label><div class="cw-backup-actions"><button id="cw-state-download" class="cw-btn" type="button">Download JSON</button><button id="cw-state-upload" class="cw-btn" type="button">Import file</button><input id="cw-state-upload-input" type="file" accept=".json" style="display:none"></div></div></div></div></aside></div></div>`;
+  host.innerHTML = `<div class="cw-root"><div class="cw-topline"><div class="cw-head-copy"><div class="cw-title-row"><div><div class="cw-title">Editor</div><div class="cw-sub">Edit your current state, tracker or cache</div></div></div></div><div class="cw-head-pills"><span class="cw-chip"><strong id="cw-pill-source">Current state</strong></span><span class="cw-chip"><strong id="cw-pill-kind">Watchlist</strong></span><span class="cw-chip"><strong id="cw-pill-count">0 rows</strong></span></div></div><div class="cw-wrap"><div class="cw-main"><div class="cw-controls"><input id="cw-filter" class="cw-input" placeholder="Filter by key / title / id..."><span class="cw-status-text" id="cw-status"></span><div class="cw-controls-spacer"></div><div class="cw-bulk" id="cw-bulk" style="display:none"><span class="cw-bulk-count" id="cw-bulk-count"></span><button id="cw-bulk-remove" class="cw-btn danger" type="button"></button><button id="cw-bulk-restore" class="cw-btn" type="button"></button><button id="cw-bulk-clear" class="cw-btn" type="button">Clear</button></div><button id="cw-reload" class="cw-btn" type="button">Reload</button><button id="cw-add" class="cw-btn" type="button">Add row</button><button id="cw-save" class="cw-btn primary" type="button">Save changes</button></div><div class="cw-table-wrap" id="cw-table-wrap"><div class="cw-table-scroll"><table class="cw-table"><thead><tr><th style="width:34px"><input id="cw-select-page" class="cw-checkbox" type="checkbox" title="Select page"></th><th class="cw-action-head" style="width:46px"></th><th style="width:12%" data-sort="key" class="sortable">Key</th><th style="width:13%" data-sort="type" class="sortable">Type</th><th style="width:33%" data-sort="title" class="sortable">Title</th><th style="width:84px">Year</th><th style="width:12%" id="cw-col-id-a">TMDB</th><th style="width:21%" data-sort="extra" class="sortable">Extra</th></tr></thead><tbody id="cw-tbody"></tbody></table></div></div><div class="cw-pager" id="cw-pager" style="display:none"><button id="cw-prev" class="cw-btn" type="button">Previous</button><span id="cw-page-info" class="cw-page-info"></span><button id="cw-next" class="cw-btn" type="button">Next</button></div><div class="cw-empty" id="cw-empty" style="display:none">No rows match this view.</div></div><aside class="cw-side"><div class="ins-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">tune</span></div><div class="ins-title">Workspace</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Source</label><select id="cw-source" class="cw-select"><option value="state">Current State</option><option value="pair">Pair Cache</option><option value="tracker">Local Tracker</option></select><label>Kind</label><select id="cw-kind" class="cw-select"><option value="watchlist">Watchlist</option><option value="history">History</option><option value="ratings">Ratings</option><option value="progress">Progress</option></select><label id="cw-pair-label" style="display:none">Pair</label><select id="cw-pair" class="cw-select" style="display:none"></select><label id="cw-snapshot-label">Snapshot</label><select id="cw-snapshot" class="cw-select"><option value="">Latest</option></select><label id="cw-instance-label" style="display:none">Profile</label><select id="cw-instance" class="cw-select" style="display:none"><option value="default">Default</option></select></div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><div class="field-label">Types</div><div id="cw-type-filter" class="cw-type-filter"><button type="button" data-type="movie" class="cw-type-chip active">Movies</button><button type="button" data-type="show" class="cw-type-chip active">Shows</button><button type="button" data-type="anime" class="cw-type-chip active">Anime</button><button type="button" data-type="season" class="cw-type-chip active">Seasons</button><button type="button" data-type="episode" class="cw-type-chip active">Episodes</button><button type="button" id="cw-blocked-only" class="cw-type-chip">Blocked</button></div></div></div><div class="ins-row" id="cw-state-bulk" style="display:none"><details class="cw-collapse" id="cw-bulk-details" style="width:100%"><summary style="cursor:pointer;font-weight:700;user-select:none">Block rules</summary><div style="display:flex;flex-direction:column;gap:8px;width:100%;margin-top:10px"><select id="cw-bulk-type" class="cw-select" style="width:100%"></select><div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap"><button id="cw-bulk-block-type" class="cw-btn danger" type="button" style="flex:1 1 0;min-width:120px">Block all</button><button id="cw-bulk-unblock-type" class="cw-btn" type="button" style="flex:1 1 0;min-width:120px">Unblock all</button></div><div class="cw-status-text">Current State only • affects baseline items</div></div></details></div><div class="ins-row" id="cw-import-row" style="display:none"><details class="cw-collapse" id="cw-import-details" style="width:100%"><summary style="cursor:pointer;font-weight:700;user-select:none">Import provider state</summary><div style="display:flex;flex-direction:column;gap:10px;width:100%;margin-top:10px"><div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center"><select id="cw-import-provider" class="cw-select" style="flex:1;min-width:200px"></select><select id="cw-import-instance" class="cw-select" style="min-width:180px"></select><select id="cw-import-mode" class="cw-select" style="min-width:180px"><option value="replace">Replace baseline</option><option value="merge">Merge (keep old)</option></select></div><div style="display:flex;gap:12px;flex-wrap:wrap;align-items:center"><label id="cw-import-watchlist-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-watchlist" class="cw-checkbox" type="checkbox" checked>Watchlist </label><label id="cw-import-history-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-history" class="cw-checkbox" type="checkbox" checked>History </label><label id="cw-import-ratings-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-ratings" class="cw-checkbox" type="checkbox" checked>Ratings </label><label id="cw-import-progress-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-progress-cb" class="cw-checkbox" type="checkbox" checked>Progress </label><span style="flex:1 1 auto"></span><button id="cw-import-run" class="cw-btn sm" type="button">Import</button></div><div id="cw-import-progress" style="display:none"><div class="cw-progress"><span></span></div><div class="cw-status-text" id="cw-import-progress-text" style="margin-top:6px"></div></div></div></details></div></div><div class="ins-card"><div class="ins-row" style="align-items:center"><div class="ins-icon"><span class="material-symbol">insights</span></div><div class="ins-title" style="margin-right:auto">Pulse</div><span class="cw-tag" id="cw-tag-status"><span class="cw-tag-dot"></span><span id="cw-tag-label">Idle</span></span></div><div class="ins-row"><div class="ins-metrics"><div class="metric-row"><div class="metric"><span class="material-symbol">view_list</span><div><div class="m-val" id="cw-summary-total">0</div><div class="m-lbl">Total rows</div></div></div><div class="metric"><span class="material-symbol">visibility</span><div><div class="m-val" id="cw-summary-visible">0</div><div class="m-lbl">Rows visible</div></div></div></div><div class="metric-divider"></div><div class="metric-row"><div class="metric"><span class="material-symbol">movie</span><div><div class="m-val" id="cw-summary-movies">0</div><div class="m-lbl">Movies</div></div></div><div class="metric"><span class="material-symbol">monitoring</span><div><div class="m-val" id="cw-summary-shows">0</div><div class="m-lbl">Shows</div></div></div><div class="metric"><span class="material-symbol">layers</span><div><div class="m-val" id="cw-summary-seasons">0</div><div class="m-lbl">Seasons</div></div></div><div class="metric"><span class="material-symbol">live_tv</span><div><div class="m-val" id="cw-summary-episodes">0</div><div class="m-lbl">Episodes</div></div></div></div><div class="metric-divider"></div><div class="metric-row"><div class="metric"><span class="material-symbol">description</span><div><div class="m-val" id="cw-summary-state-files">0</div><div class="m-lbl">State files</div></div></div><div class="metric"><span class="material-symbol">folder_copy</span><div><div class="m-val" id="cw-summary-snapshots">0</div><div class="m-lbl">Snapshots</div></div></div></div><div id="cw-state-hint" class="cw-state-hint" style="display:none"><strong>No tracker data found.</strong> Run a CrossWatch sync with the tracker enabled once. After that, tracker state files and snapshots will appear here and you can edit them. </div></div></div></div><div class="ins-card" id="cw-backup-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">backup</span></div><div class="ins-title">Archive</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Export / Import</label><div class="cw-backup-actions"><button id="cw-download" class="cw-btn" type="button">Download ZIP</button><button id="cw-upload" class="cw-btn" type="button">Import file</button><input id="cw-upload-input" type="file" accept=".zip,.json" style="display:none"></div></div></div></div><div class="ins-card" id="cw-state-backup-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">backup</span></div><div class="ins-title">Policy backup</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Export / Import</label><div class="cw-backup-actions"><button id="cw-state-download" class="cw-btn" type="button">Download JSON</button><button id="cw-state-upload" class="cw-btn" type="button">Import file</button><input id="cw-state-upload-input" type="file" accept=".json" style="display:none"></div></div></div></div></aside></div></div>`;
 
   wireStaticLabels(host);
 
@@ -518,6 +523,14 @@
   }
   const subBoot = host.querySelector(".cw-sub");
   if (subBoot) subBoot.textContent = "Edit your current state or playlist endpoints";
+
+  const trackerNoticeBoot = document.createElement("div");
+  trackerNoticeBoot.id = "cw-tracker-notice";
+  trackerNoticeBoot.className = "cw-state-hint";
+  trackerNoticeBoot.style.display = "none";
+  trackerNoticeBoot.innerHTML =
+    "<strong>Local Tracker</strong> stores data inside CrossWatch. Changes here affect future syncs from Local Tracker but only for one-way syncs.";
+  host.querySelector(".cw-controls")?.insertAdjacentElement("afterend", trackerNoticeBoot);
 
   host.querySelectorAll("input,select,textarea").forEach((field, idx) => {
     if (!field.name) field.name = field.id || `cw-field-${idx + 1}`;
@@ -538,8 +551,9 @@
     importHistoryWrap, importRatingsWrap, importProgressFeatWrap, importProgressWrap,
     importProgressText,
     selectPage, bulkWrap, bulkCount, bulkRemoveBtn, bulkRestoreBtn, bulkClearBtn,
-    stateBulkRow, bulkTypeSel, bulkBlockTypeBtn, bulkUnblockTypeBtn,
+    stateBulkRow, bulkTypeSel, bulkBlockTypeBtn, bulkUnblockTypeBtn, trackerNotice,
   } = pickEls({
+    trackerNotice: "cw-tracker-notice",
     sourceSel: "cw-source",
     kindSel: "cw-kind",
     pairLabel: "cw-pair-label",
@@ -771,8 +785,56 @@
 
   let statusStickyUntil = 0;
 
+  const SOURCES = ["state", "tracker", "playlist"];
+
+  function isTrackerSource() {
+    return state.source === "tracker";
+  }
+
+  function isPolicySource() {
+    return state.source === "state" || state.source === "tracker";
+  }
+
+  function normalizeSource(value) {
+    const s = String(value || "").trim();
+    if (!SOURCES.includes(s)) return "state";
+    if (s === "tracker" && !state.trackerAvailable) return "state";
+    return s;
+  }
+
+  function ensureTrackerOption() {
+    if (!sourceSel) return;
+    const existing = sourceSel.querySelector('option[value="tracker"]');
+    if (!state.trackerAvailable) {
+      existing?.remove();
+      return;
+    }
+    if (existing) {
+      existing.textContent = "Local Tracker";
+      return;
+    }
+    const opt = document.createElement("option");
+    opt.value = "tracker";
+    opt.textContent = "Local Tracker";
+    const playlistOpt = sourceSel.querySelector('option[value="playlist"]');
+    if (playlistOpt) sourceSel.insertBefore(opt, playlistOpt);
+    else sourceSel.appendChild(opt);
+  }
+
+  function currentTrackerWorkspace() {
+    const id = String(state.workspace || "").trim();
+    const list = state.trackerWorkspaces || [];
+    return list.find(w => String(w && w.id || "") === id) || list[0] || null;
+  }
+
+  function trackerKinds() {
+    const ws = currentTrackerWorkspace();
+    const feats = (ws && ws.features) || {};
+    return ["watchlist", "history", "ratings", "progress"].filter(k => feats[k]);
+  }
+
   function syncHeaderPills(visible, total) {
-    const srcMap = { state: "Current state", playlist: "Playlist endpoint" };
+    const srcMap = { state: "Current state", tracker: "Local tracker", playlist: "Playlist endpoint" };
     const kindMap = { watchlist: "Watchlist", history: "History", ratings: "Ratings", progress: "Progress", playlist: "Playlist" };
     if (pillSource) pillSource.textContent = srcMap[state.source] || "Source";
     if (pillKind) pillKind.textContent = state.source === "playlist" ? "Playlist" : (kindMap[state.kind] || "Kind");
@@ -798,10 +860,22 @@
 
   if (filterInput && state.filter) filterInput.value = state.filter;
 
+  const KIND_LABELS = { watchlist: "Watchlist", history: "History", ratings: "Ratings", progress: "Progress" };
+
   function syncKindUI() {
     if (!kindSel) return;
-    const allowed = ["watchlist", "history", "ratings", "progress"];
-    if (!allowed.includes(state.kind)) state.kind = "watchlist";
+    let allowed = ["watchlist", "history", "ratings", "progress"];
+    if (isTrackerSource()) {
+      const supported = trackerKinds();
+      if (supported.length) allowed = supported;
+    }
+    if (!allowed.includes(state.kind)) state.kind = allowed[0] || "watchlist";
+    const current = Array.from(kindSel.options).map(o => o.value);
+    if (current.join("|") !== allowed.join("|")) {
+      kindSel.innerHTML = allowed
+        .map(k => `<option value="${k}">${_escapeHtml(KIND_LABELS[k] || k)}</option>`)
+        .join("");
+    }
     kindSel.value = state.kind;
   }
 
@@ -869,7 +943,7 @@
 
   function syncStateBulkUI() {
     if (!stateBulkRow || !bulkTypeSel || !bulkBlockTypeBtn || !bulkUnblockTypeBtn) return;
-    const show = state.source === "state" && state.kind !== "watchlist";
+    const show = isPolicySource() && state.kind !== "watchlist";
     stateBulkRow.style.display = show ? "" : "none";
     if (!show) return;
 
@@ -1111,6 +1185,7 @@
         source: state.source,
         kind: state.kind,
         snapshot: state.snapshot,
+        workspace: state.workspace,
         instance: state.instance,
         filter: state.filter,
         typeFilter: state.typeFilter,
@@ -1128,7 +1203,7 @@
     bulkWrap.style.display = n ? "flex" : "none";
     if (!n) return;
     bulkCount.textContent = `${n} selected`;
-    if (state.source === "state") {
+    if (isPolicySource()) {
       bulkRemoveBtn.textContent = "Block selected";
       bulkRestoreBtn.textContent = "Unblock selected";
     } else {
@@ -1174,10 +1249,10 @@
       markChanged();
       renderRows();
       const verb = flag
-        ? state.source === "state"
+        ? isPolicySource()
           ? "Blocked"
           : "Deleted"
-        : state.source === "state"
+        : isPolicySource()
           ? "Unblocked"
           : "Restored";
       setStatusSticky(`${verb} ${changed} item${changed === 1 ? "" : "s"}`, 3000);
@@ -1185,7 +1260,7 @@
   }
 
   function bulkSetBlocksByType(type, flag) {
-    if (state.source !== "state") return;
+    if (!isPolicySource()) return;
     const t = String(type || "").toLowerCase();
     if (!t) return;
     let changed = 0;
@@ -1209,34 +1284,45 @@
   }
 
   function syncSourceUI() {
-    if (state.source !== "state" && state.source !== "playlist") state.source = "state";
+    state.source = normalizeSource(state.source);
     if (sourceSel) {
       sourceSel.querySelector('option[value="pair"]')?.remove();
-      sourceSel.querySelector('option[value="tracker"]')?.remove();
       if (!sourceSel.querySelector('option[value="playlist"]')) {
         sourceSel.insertAdjacentHTML("beforeend", '<option value="playlist">Playlist Endpoint</option>');
       }
+      ensureTrackerOption();
     }
     const isState = state.source === "state";
+    const isTracker = isTrackerSource();
     const isPlaylist = state.source === "playlist";
+    const policy = isPolicySource();
     if (sourceSel) sourceSel.value = state.source;
     if (pairLabel) pairLabel.style.display = "none";
     if (pairSel) pairSel.style.display = "none";
-    if (snapLabel) snapLabel.textContent = isState ? "Provider" : "Endpoint";
+    if (snapLabel) snapLabel.textContent = isState ? "Provider" : isTracker ? "Workspace" : "Endpoint";
     if (kindSel) kindSel.disabled = isPlaylist;
-    if (instanceLabel) instanceLabel.style.display = isPlaylist ? "none" : "";
-    if (instanceSel) instanceSel.style.display = isPlaylist ? "none" : "";
+    if (instanceLabel) instanceLabel.style.display = isState ? "" : "none";
+    if (instanceSel) instanceSel.style.display = isState ? "" : "none";
     if (backupCard) backupCard.style.display = "none";
-    if (stateBackupCard) stateBackupCard.style.display = isState ? "" : "none";
-    if (blockedOnlyBtn) blockedOnlyBtn.style.display = isState ? "" : "none";
+    if (stateBackupCard) stateBackupCard.style.display = policy ? "" : "none";
+    if (blockedOnlyBtn) blockedOnlyBtn.style.display = policy ? "" : "none";
+    if (trackerNotice) trackerNotice.style.display = isTracker ? "block" : "none";
+
+    const sub = host.querySelector(".cw-sub");
+    if (sub) {
+      sub.textContent = isTracker
+        ? "Edit what CrossWatch sends from its local tracker. Connected provider accounts are not changed."
+        : "Edit your current state or playlist endpoints";
+    }
 
     if (isPlaylist) {
       state.kind = "watchlist";
       state.instance = "default";
-      syncKindUI();
     }
+    if (isTracker) state.instance = "default";
+    syncKindUI();
 
-    if (!isState && state.blockedOnly) {
+    if (!policy && state.blockedOnly) {
       state.blockedOnly = false;
       syncTypeFilterUI();
       persistUIState();
@@ -1259,6 +1345,12 @@
     if (mode === "playlist") {
       stateHint.innerHTML =
         "<strong>No playlist endpoints found.</strong> Create an endpoint on the Playlists page first. Then select it here to edit its items.";
+      stateHint.style.display = "block";
+      return;
+    }
+    if (mode === "tracker") {
+      stateHint.innerHTML =
+        "<strong>No Local Tracker data found.</strong> Run a sync pair that uses Local Tracker first.";
       stateHint.style.display = "block";
       return;
     }
@@ -1427,6 +1519,322 @@
       actions.appendChild(btn);
     });
     pop.appendChild(actions);
+  }
+
+  function isRowLocked(row) {
+    return isPolicySource() && !!row && row._origin === "baseline";
+  }
+
+  const REPLACEABLE_TYPES = ["movie", "show", "anime", "season", "episode"];
+
+  function rowType(row) {
+    return String((row && row.type) || "").toLowerCase();
+  }
+
+  function canReplaceRow(row) {
+    if (!isTrackerSource()) return false;
+    return REPLACEABLE_TYPES.includes(rowType(row));
+  }
+
+  function usesCoordinateReplacer(row) {
+    const t = rowType(row);
+    return t === "episode" || t === "season";
+  }
+
+  const EPISODE_ID_FIELDS = [
+    { key: "tvdb", label: "TVDB episode ID" },
+    { key: "tmdb", label: "TMDB episode ID" },
+    { key: "simkl", label: "SIMKL episode ID" },
+  ];
+
+  const PROVIDER_HISTORY_ID_FIELDS = [
+    "_trakt_history_id",
+    "history_id",
+    "_simkl_history_id",
+    "_plex_history_id",
+    "watched_id",
+    "play_id",
+  ];
+
+  function coordinateKeyFor(row, season, episode) {
+    const base = String((row && row.key) || "").split("#")[0].trim();
+    if (!base) return "";
+    if (rowType(row) === "season") return `${base}#season:${season}`;
+    const s = String(Math.max(0, season)).padStart(2, "0");
+    const e = String(Math.max(0, episode)).padStart(2, "0");
+    return `${base}#s${s}e${e}`;
+  }
+
+  function carryOverFields(row, drop) {
+    const src = (row && row.raw) || {};
+    const out = {};
+    for (const [k, v] of Object.entries(src)) {
+      if (drop.includes(k) || PROVIDER_HISTORY_ID_FIELDS.includes(k)) continue;
+      out[k] = JSON.parse(JSON.stringify(v === undefined ? null : v));
+    }
+    return out;
+  }
+
+  function correctedEpisodeItem(row, season, episode, watchedAt, extraIds) {
+    const isSeason = rowType(row) === "season";
+    const out = carryOverFields(row, ["ids", "season", "episode", "title"]);
+    out.type = isSeason ? "season" : "episode";
+    out.season = season;
+    if (isSeason) {
+      out.title = `Season ${season}`;
+    } else {
+      out.episode = episode;
+      out.title = `S${String(season).padStart(2, "0")}E${String(episode).padStart(2, "0")}`;
+      out.watched_at = watchedAt || null;
+    }
+    const ids = {};
+    for (const [k, v] of Object.entries(extraIds || {})) {
+      const val = String(v || "").trim();
+      if (val) ids[k] = val;
+    }
+    out.ids = ids;
+    return out;
+  }
+
+  function correctedMetadataItem(row, draft) {
+    const out = carryOverFields(row, [
+      "ids", "title", "year", "type",
+      "season", "episode", "series_title", "series_year", "show_ids",
+    ]);
+    const picked = (draft && draft.raw) || {};
+    out.type = picked.type || draft.type || "movie";
+    out.title = picked.title || draft.title || null;
+    out.year = picked.year != null ? picked.year : null;
+    out.ids = { ...(picked.ids || {}) };
+    return out;
+  }
+
+  function commitReplacement(row, corrected, key, sameMessage) {
+    const clash = (state.rows || []).some(
+      r => r !== row && !r.deleted && String(r.key || "").toLowerCase() === key.toLowerCase()
+    );
+    if (clash) return "A row for that item already exists.";
+
+    if (row._origin === "baseline") {
+      row.deleted = true;
+      state.rows.unshift(buildManualRow(corrected, key, row.key));
+      setStatusSticky("The original item was blocked and a corrected local item was added.", 6000);
+    } else {
+      applyManualRow(row, corrected, key);
+      setStatusSticky(sameMessage, 5000);
+    }
+    state.page = 0;
+    markChanged();
+    renderRows();
+    return "";
+  }
+
+  function openItemReplacer(row, anchor) {
+    if (usesCoordinateReplacer(row)) return openEpisodeReplacer(row, anchor);
+    return openMetadataReplacer(row, anchor);
+  }
+
+  function openMetadataReplacer(row, anchor) {
+    const draft = {
+      _rid: -1,
+      key: String(row.key || ""),
+      type: rowType(row),
+      title: String(row.title || ""),
+      year: String(row.year || ""),
+      imdb: "",
+      tmdb: "",
+      trakt: "",
+      mal: "",
+      anilist: "",
+      raw: JSON.parse(JSON.stringify(row.raw || {})),
+      deleted: false,
+      episode: false,
+    };
+    const stub = () => document.createElement("input");
+    const refs = {
+      keyIn: stub(),
+      titleIn: stub(),
+      yearIn: stub(),
+      imdbIn: stub(),
+      tmdbIn: stub(),
+      traktIn: stub(),
+      typeBtn: document.createElement("button"),
+      onApplied: applied => {
+        const key = String(applied.key || "").trim();
+        if (!key) {
+          setStatusSticky("That result has no usable identifier.", 5000);
+          return;
+        }
+        if (key.toLowerCase() === String(row.key || "").trim().toLowerCase()) {
+          setStatusSticky("The corrected item is the same as the current one.", 5000);
+          return;
+        }
+        const corrected = correctedMetadataItem(row, applied);
+        const err = commitReplacement(row, corrected, key, "The corrected local item was updated.");
+        if (err) setStatusSticky(err, 5000);
+      },
+    };
+    openTitleSearchEditor(draft, anchor, refs);
+  }
+
+  function openEpisodeReplacer(row, anchor) {
+    const isSeason = rowType(row) === "season";
+    openPopup(anchor, (pop, close) => {
+      appendPopupTitle(pop, isSeason ? "Replace season" : "Replace episode");
+
+      const raw = (row && row.raw) || {};
+      const curSeason = Number(raw.season || 0);
+      const curEpisode = Number(raw.episode || 0);
+      const seriesTitle = String(raw.series_title || row.title || "").trim() || "Unknown series";
+
+      const info = document.createElement("div");
+      info.className = "cw-search-meta";
+      info.textContent = isSeason
+        ? `${seriesTitle} - currently season ${curSeason}`
+        : `${seriesTitle} - currently S${String(curSeason).padStart(2, "0")}E${String(curEpisode).padStart(2, "0")}`;
+      pop.appendChild(info);
+
+      appendPopupTitle(pop, isSeason ? "Corrected season" : "Corrected episode", "10px");
+
+      const grid = document.createElement("div");
+      grid.className = "cw-datetime-grid";
+      grid.style.gridTemplateColumns = isSeason ? "minmax(0,1fr)" : "minmax(0,1fr) minmax(0,1fr)";
+
+      const seasonIn = document.createElement("input");
+      seasonIn.type = "number";
+      seasonIn.min = "0";
+      seasonIn.placeholder = "Season";
+      seasonIn.value = String(curSeason);
+
+      const episodeIn = document.createElement("input");
+      episodeIn.type = "number";
+      episodeIn.min = "0";
+      episodeIn.placeholder = "Episode";
+      episodeIn.value = String(curEpisode);
+
+      grid.appendChild(seasonIn);
+      if (!isSeason) grid.appendChild(episodeIn);
+      pop.appendChild(grid);
+
+      const dateInput = document.createElement("input");
+      dateInput.type = "date";
+      const timeInput = document.createElement("input");
+      timeInput.type = "time";
+      timeInput.step = 60;
+
+      if (!isSeason) {
+        appendPopupTitle(pop, "Watched at", "10px");
+        const whenGrid = document.createElement("div");
+        whenGrid.className = "cw-datetime-grid";
+        fillDateTimeInputs(raw.watched_at, dateInput, timeInput);
+        whenGrid.appendChild(dateInput);
+        whenGrid.appendChild(timeInput);
+        pop.appendChild(whenGrid);
+      }
+
+      const advanced = document.createElement("details");
+      advanced.className = "cw-collapse";
+      advanced.style.marginTop = "10px";
+      const summary = document.createElement("summary");
+      summary.style.cursor = "pointer";
+      summary.style.fontWeight = "700";
+      summary.style.userSelect = "none";
+      summary.textContent = "Advanced";
+      advanced.appendChild(summary);
+
+      const advGrid = document.createElement("div");
+      advGrid.className = "cw-datetime-grid";
+      advGrid.style.marginTop = "8px";
+      const idInputs = {};
+      EPISODE_ID_FIELDS.forEach(field => {
+        const input = document.createElement("input");
+        input.type = "text";
+        input.placeholder = field.label;
+        idInputs[field.key] = input;
+        advGrid.appendChild(input);
+      });
+      advanced.appendChild(advGrid);
+      pop.appendChild(advanced);
+
+      const status = document.createElement("div");
+      status.className = "cw-search-status";
+      status.style.marginTop = "8px";
+      pop.appendChild(status);
+
+      const apply = () => {
+        const season = parseInt(seasonIn.value, 10);
+        const episode = isSeason ? 0 : parseInt(episodeIn.value, 10);
+        const seasonOk = Number.isFinite(season) && season >= 0;
+        const episodeOk = isSeason || (Number.isFinite(episode) && episode > 0);
+        if (!seasonOk || !episodeOk) {
+          status.textContent = isSeason
+            ? "Enter a valid corrected season."
+            : "Enter a valid corrected season and episode.";
+          return;
+        }
+        if (season === curSeason && (isSeason || episode === curEpisode)) {
+          status.textContent = isSeason
+            ? "The corrected season is the same as the current one."
+            : "The corrected episode is the same as the current one.";
+          return;
+        }
+        const key = coordinateKeyFor(row, season, episode);
+        if (!key) {
+          status.textContent = "This row has no usable series identifier.";
+          return;
+        }
+
+        const watchedAt = dateTimeInputsToIso(dateInput.value, timeInput.value) || raw.watched_at || null;
+        const extraIds = {};
+        EPISODE_ID_FIELDS.forEach(field => {
+          extraIds[field.key] = idInputs[field.key].value;
+        });
+        const corrected = correctedEpisodeItem(row, season, episode, watchedAt, extraIds);
+        const err = commitReplacement(
+          row,
+          corrected,
+          key,
+          isSeason ? "The corrected local season was updated." : "The corrected local episode was updated."
+        );
+        if (err) {
+          status.textContent = err;
+          return;
+        }
+        close();
+      };
+
+      appendPopupActions(pop, [
+        { label: "Close", kind: "ghost", onClick: close },
+        { label: "Replace episode", kind: "primary", onClick: apply },
+      ]);
+
+      seasonIn.focus();
+    });
+  }
+
+  function applyManualRow(row, item, key) {
+    row.key = key;
+    row.raw = item;
+    row.type = "episode";
+    row.episode = true;
+    row.title = String(item.series_title || row.title || "");
+    row.year = item.series_year != null ? String(item.series_year) : row.year || "";
+    row.imdb = "";
+    row.tmdb = item.ids && item.ids.tmdb ? String(item.ids.tmdb) : "";
+    row.trakt = "";
+    row.deleted = false;
+    row._origin = "manual";
+    return row;
+  }
+
+  function buildManualRow(item, key, replacedKey) {
+    const row = applyManualRow(
+      { _rid: state.ridSeq++, mal: "", anilist: "" },
+      item,
+      key
+    );
+    if (replacedKey) row._replacedKey = replacedKey;
+    return row;
   }
 
   function renderLockedPopup(pop, close) {
@@ -1613,7 +2021,7 @@
         if (!allowed) return false;
       }
 
-      if (state.blockedOnly && state.source === "state") {
+      if (state.blockedOnly && isPolicySource()) {
         if (!(r.deleted && r._origin === "baseline")) return false;
       }
 
@@ -1639,7 +2047,7 @@
   }
 
   function openHistoryEditor(row, anchor, displayEl) {
-    const locked = false;
+    const locked = isRowLocked(row);
 
     openPopup(anchor, (pop, close) => {
       appendPopupTitle(pop, "Watched at");
@@ -1673,7 +2081,7 @@
 
 
   function openProgressEditor(row, anchor, displayEl) {
-    const locked = false;
+    const locked = isRowLocked(row);
 
     openPopup(anchor, (pop, close) => {
       appendPopupTitle(pop, "Progress");
@@ -1750,7 +2158,7 @@
   }
 
   function openRatingEditor(row, anchor, displayEl) {
-    const locked = false;
+    const locked = isRowLocked(row);
 
     openPopup(anchor, (pop, close) => {
       appendPopupTitle(pop, "Rating");
@@ -2048,6 +2456,12 @@
                 }
               }
 
+              if (typeof refs.onApplied === "function") {
+                close();
+                refs.onApplied(row);
+                return;
+              }
+
               markChanged();
               setStatusSticky("Row updated from metadata", 2500);
               close();
@@ -2079,7 +2493,7 @@
   }
 
   function openTypeEditor(row, anchor) {
-    const locked = false;
+    const locked = isRowLocked(row);
 
     openPopup(anchor, (pop, close) => {
       appendPopupTitle(pop, "Type");
@@ -2216,6 +2630,11 @@
 
     if (tbody) tbody.innerHTML = "";
 
+    const actionHead = host.querySelector(".cw-action-head");
+    if (actionHead) {
+      actionHead.style.width = isTrackerSource() ? "84px" : "46px";
+    }
+
     if (!totalFiltered) {
       if (empty) empty.style.display = "block";
       if (pager) pager.style.display = "none";
@@ -2247,7 +2666,7 @@
     const anilistMode = isAnilistMode();
     rows.forEach(row => {
       const tr = document.createElement("tr");
-      const locked = false;
+      const locked = isRowLocked(row);
       const fieldName = suffix => `cw-row-${row._rid || "new"}-${suffix}`;
       if (row.episode) tr.classList.add("cw-row-episode");
       if (row.deleted) tr.classList.add("cw-row-deleted");
@@ -2272,11 +2691,17 @@
       };
       tr.appendChild(cell(selCb));
 
+      const blockMode = isPolicySource();
+      const baselineRow = blockMode && row._origin === "baseline";
       const delBtn = document.createElement("button");
       delBtn.type = "button";
       delBtn.className = "cw-btn cw-btn-del danger";
-      delBtn.innerHTML = '<span class="material-symbol">delete</span>';
-      delBtn.title = locked ? (row.deleted ? "Unblock row" : "Block row") : "Delete row";
+      delBtn.innerHTML = `<span class="material-symbol">${blockMode ? "block" : "delete"}</span>`;
+      delBtn.title = blockMode
+        ? (baselineRow
+            ? (row.deleted ? "Restore for future syncs" : "Block from future syncs")
+            : (row.deleted ? "Restore row" : "Remove manual correction"))
+        : (row.deleted ? "Restore row" : "Delete row");
       delBtn.onclick = () => {
         row.deleted = !row.deleted;
         markChanged();
@@ -2284,6 +2709,17 @@
       };
       const delTd = cell(delBtn);
       delTd.className = "cw-action-cell";
+      if (canReplaceRow(row)) {
+        const t = rowType(row);
+        const repBtn = document.createElement("button");
+        repBtn.type = "button";
+        repBtn.className = "cw-btn cw-btn-del";
+        repBtn.innerHTML = '<span class="material-symbol">published_with_changes</span>';
+        repBtn.title = t === "episode" ? "Replace episode" : t === "season" ? "Replace season" : "Replace item";
+        repBtn.style.marginLeft = "4px";
+        repBtn.onclick = () => openItemReplacer(row, repBtn);
+        delTd.appendChild(repBtn);
+      }
       tr.appendChild(delTd);
 
       const keyIn = document.createElement("input");
@@ -2427,6 +2863,12 @@
         sub.textContent = label;
         titleCell.appendChild(sub);
       }
+      if (isTrackerSource() && row._origin !== "baseline") {
+        const origin = document.createElement("div");
+        origin.className = "cw-title-sub";
+        origin.textContent = "Manual correction";
+        titleCell.appendChild(origin);
+      }
       tr.appendChild(cell(titleCell));
 
       const yearTd = cell(yearIn);
@@ -2514,10 +2956,25 @@
   function rebuildSnapshots() {
     if (!snapSel) return;
     const isState = state.source === "state";
+    const isTracker = isTrackerSource();
     const isPlaylist = state.source === "playlist";
-    if (snapLabel) snapLabel.textContent = isState ? "Provider" : "Endpoint";
-    if (instanceLabel) instanceLabel.style.display = isPlaylist ? "none" : "";
-    if (instanceSel) instanceSel.style.display = isPlaylist ? "none" : "";
+    if (snapLabel) snapLabel.textContent = isState ? "Provider" : isTracker ? "Workspace" : "Endpoint";
+    if (instanceLabel) instanceLabel.style.display = isState ? "" : "none";
+    if (instanceSel) instanceSel.style.display = isState ? "" : "none";
+
+    if (isTracker) {
+      const list = Array.isArray(state.trackerWorkspaces) ? state.trackerWorkspaces : [];
+      const options = list
+        .map(w => `<option value="${_escapeHtml(w && w.id)}">${_escapeHtml((w && w.label) || "Local tracker")}</option>`)
+        .join("");
+      snapSel.innerHTML = options || `<option value="">No workspaces</option>`;
+      const opts = Array.from(snapSel.options).map(o => o.value);
+      const next = opts.includes(state.workspace) ? state.workspace : opts[0] || "";
+      if (next !== state.workspace) state.workspace = next;
+      snapSel.value = state.workspace || "";
+      syncProviderIconSelect(snapSel, false);
+      return;
+    }
 
     if (isPlaylist) {
       const list = Array.isArray(state.playlistEndpoints) ? state.playlistEndpoints : [];
@@ -2629,8 +3086,30 @@ function bindFileImport(btn, input, url, done) {
   });
 }
 
+  async function loadTrackerWorkspaces() {
+    try {
+      const data = await fetchJSON("/api/editor/tracker/workspaces");
+      const list = Array.isArray(data && data.workspaces) ? data.workspaces : [];
+      state.trackerWorkspaces = list;
+      state.trackerAvailable = list.length > 0;
+    } catch (_) {
+      state.trackerWorkspaces = [];
+      state.trackerAvailable = false;
+    }
+    ensureTrackerOption();
+    return state.trackerWorkspaces;
+  }
+
   async function loadSnapshots() {
     try {
+      if (isTrackerSource()) {
+        await loadTrackerWorkspaces();
+        rebuildSnapshots();
+        syncKindUI();
+        if (!state.trackerWorkspaces.length) showStateHint("tracker");
+        else showStateHint(null);
+        return;
+      }
       if (state.source === "playlist") {
         const data = await fetchJSON("/api/editor/playlists/endpoints");
         state.playlistEndpoints = Array.isArray(data && data.endpoints) ? data.endpoints : [];
@@ -2707,7 +3186,25 @@ function bindFileImport(btn, input, url, done) {
         return;
       }
     }
-    if (state.source !== "state" && state.source !== "playlist") state.source = "state";
+    if (isTrackerSource() && !String(state.workspace || "").trim()) {
+      state.baselineItems = {};
+      state.manualAdds = {};
+      state.manualBlocks = [];
+      state.items = {};
+      state.rows = [];
+      state.selected = new Set();
+      state.pageRids = [];
+      state.ridSeq = 1;
+      state.hasChanges = false;
+      state.page = 0;
+      renderRows();
+      showStateHint("tracker");
+      setTag("loaded", "No workspace");
+      setStatus("");
+      syncActionButtons();
+      return;
+    }
+    state.source = normalizeSource(state.source);
     state.loading = true;
     setTag("warn", "Loading");
     try {
@@ -2716,6 +3213,7 @@ function bindFileImport(btn, input, url, done) {
         params.set("provider", state.snapshot);
         params.set("provider_instance", state.instance || "default");
       }
+      if (isTrackerSource()) params.set("workspace", state.workspace);
       if (state.source === "playlist" && state.snapshot) params.set("endpoint", state.snapshot);
 
       const data = await fetchJSON(`/api/editor?${params.toString()}`);
@@ -2730,19 +3228,23 @@ function bindFileImport(btn, input, url, done) {
         state.pageRids = [];
         state.ridSeq = 1;
         state.rows = buildRows(state.items);
-      } else if (state.source === "state") {
-        if (data && typeof data.provider === "string" && data.provider.trim()) {
+      } else if (isPolicySource()) {
+        if (state.source === "state" && data && typeof data.provider === "string" && data.provider.trim()) {
           state.snapshot = data.provider.trim();
           if (snapSel) {
             snapSel.value = state.snapshot;
             syncProviderIconSelect(snapSel, true);
           }
         }
+        if (isTrackerSource() && data && typeof data.workspace === "string" && data.workspace.trim()) {
+          state.workspace = data.workspace.trim();
+          if (snapSel) snapSel.value = state.workspace;
+        }
         state.baselineItems = data.items || {};
         state.manualAdds = data.manual_adds || {};
         state.manualBlocks = Array.isArray(data.manual_blocks) ? data.manual_blocks : [];
 
-        if (data && typeof data.provider_instance === "string") {
+        if (state.source === "state" && data && typeof data.provider_instance === "string") {
           state.instance = data.provider_instance;
           if (instanceSel) instanceSel.value = state.instance;
         }
@@ -2773,11 +3275,12 @@ function bindFileImport(btn, input, url, done) {
       state.page = 0;
       renderRows();
 
-      if (state.source === "state") {
+      if (isPolicySource()) {
         const hasBaseline = state.baselineItems && Object.keys(state.baselineItems).length > 0;
         const hasManual = state.manualAdds && Object.keys(state.manualAdds).length > 0;
         const hasBlocks = Array.isArray(state.manualBlocks) && state.manualBlocks.length > 0;
-        showStateHint(hasBaseline || hasManual || hasBlocks ? null : "state");
+        const emptyMode = isTrackerSource() ? "tracker" : "state";
+        showStateHint(hasBaseline || hasManual || hasBlocks ? null : emptyMode);
       } else if (state.source === "playlist") {
         showStateHint(state.snapshot ? null : "playlist");
       }
@@ -2837,7 +3340,7 @@ function bindFileImport(btn, input, url, done) {
     if (missing.length) {
       setTag("error", "Missing key");
       setStatus(
-        `Cannot save: ${missing.length} row${missing.length === 1 ? "" : "s"} have data but no Key. Fill the Key or delete the row.`
+        `Cannot save: ${missing.length} row${missing.length === 1 ? "" : "s"} have data but no Key. Fill the Key or remove the row.`
       );
       if (window.cxToast) window.cxToast("Fill Key for all rows with data before saving");
       return;
@@ -2854,7 +3357,7 @@ function bindFileImport(btn, input, url, done) {
 
       for (const row of state.rows) {
         if (row.deleted) {
-          if (state.source === "state" && row._origin === "baseline") {
+          if (isPolicySource() && row._origin === "baseline") {
             const k = (row.key || "").trim();
             if (k) {
               const kl = k.toLowerCase();
@@ -2867,7 +3370,16 @@ function bindFileImport(btn, input, url, done) {
           continue;
         }
 
-        if (state.source === "state" && row._origin === "baseline") continue;
+        if (isPolicySource() && row._origin === "baseline") continue;
+
+        if (isPolicySource() && row._replacedKey) {
+          const rk = String(row._replacedKey).trim();
+          const rkl = rk.toLowerCase();
+          if (rk && !seenBlocks.has(rkl)) {
+            seenBlocks.add(rkl);
+            blocks.push(rk);
+          }
+        }
 
         const key = (row.key || "").trim();
         if (!key) continue;
@@ -2899,6 +3411,10 @@ function bindFileImport(btn, input, url, done) {
       if (state.source === "state") {
         payload.provider = state.snapshot;
         payload.provider_instance = state.instance || "default";
+        payload.blocks = blocks;
+      }
+      if (isTrackerSource()) {
+        payload.workspace = state.workspace;
         payload.blocks = blocks;
       }
       if (state.source === "playlist") {
@@ -2936,6 +3452,9 @@ function bindFileImport(btn, input, url, done) {
         if (unresolved) parts.push(`${unresolved} unresolved`);
         setStatus(`Applied playlist changes: ${parts.join(", ")}`);
         await loadState();
+      } else if (isTrackerSource()) {
+        setStatus(`Saved ${res.count || Object.keys(items).length} corrections`);
+        await loadState();
       } else {
         setStatus(`Saved ${res.count || Object.keys(items).length} items`);
         await loadSnapshots();
@@ -2964,7 +3483,7 @@ function bindFileImport(btn, input, url, done) {
       raw,
       deleted: false,
       episode: false,
-      _origin: state.source === "state" ? "manual" : "playlist",
+      _origin: isPolicySource() ? "manual" : "playlist",
     });
     state.page = 0;
     markChanged();
@@ -3028,12 +3547,15 @@ function bindFileImport(btn, input, url, done) {
 
   if (sourceSel) {
     sourceSel.addEventListener("change", async () => {
-      state.source = (sourceSel.value || "state").trim();
-      if (state.source !== "state" && state.source !== "playlist") state.source = "state";
+      state.source = normalizeSource(sourceSel.value);
       state.snapshot = "";
       state.page = 0;
       if (state.source === "playlist") {
         state.kind = "watchlist";
+        state.instance = "default";
+      }
+      if (isTrackerSource()) {
+        state.workspace = "";
         state.instance = "default";
       }
       persistUIState();
@@ -3064,7 +3586,7 @@ function bindFileImport(btn, input, url, done) {
       syncTypeFilterUI();
       syncStateBulkUI();
       clearSelection();
-      if (state.source !== "state") state.snapshot = "";
+      if (state.source !== "state" && !isTrackerSource()) state.snapshot = "";
       state.page = 0;
       persistUIState();
       await loadSnapshots();
@@ -3076,6 +3598,17 @@ function bindFileImport(btn, input, url, done) {
 
   if (snapSel) {
     snapSel.addEventListener("change", async () => {
+      if (isTrackerSource()) {
+        state.workspace = snapSel.value || "";
+        state.page = 0;
+        clearSelection();
+        syncKindUI();
+        syncTypeFilterUI();
+        syncStateBulkUI();
+        persistUIState();
+        await loadState();
+        return;
+      }
       state.snapshot = snapSel.value || "";
       if (state.source === "state") syncProviderIconSelect(snapSel, true);
       if (state.source === "state") {
@@ -3186,15 +3719,25 @@ if (importProviderSel) {
   });
 
   (async () => {
-    if (state.source !== "state" && state.source !== "playlist") {
-      state.source = "state";
+    await loadTrackerWorkspaces();
+    const wanted = state.source;
+    state.source = normalizeSource(wanted);
+    if (state.source !== wanted) {
       state.snapshot = "";
+      state.workspace = "";
       state.instance = "default";
       persistUIState();
     }
     syncSourceUI();
     await loadImportProviders();
-    setTag("warn", state.source === "state" ? "Loading current state…" : "Loading playlist endpoint…");
+    setTag(
+      "warn",
+      isTrackerSource()
+        ? "Loading Local Tracker…"
+        : state.source === "state"
+          ? "Loading current state…"
+          : "Loading playlist endpoint…"
+    );
     await loadSnapshots();
     await loadState();
     await settleStateView();

--- a/assets/js/playback_progress.js
+++ b/assets/js/playback_progress.js
@@ -13,10 +13,16 @@
     return data;
   };
   const icon = (name) => `<span class="material-symbols-rounded" aria-hidden="true">${name}</span>`;
+  const providerMeta = () => window.CW?.ProviderMeta || {};
+  const providerLabel = (provider) => providerMeta().label?.(provider) || String(provider || "").trim().toUpperCase() || "Provider";
+  const providerLogo = (provider) => providerMeta().logoPath?.(provider) || providerMeta().logLogoPath?.(provider) || `/assets/img/${String(provider || "").toUpperCase()}.svg`;
+  const providerLogLogo = (provider) => providerMeta().logLogoPath?.(provider) || `/assets/img/${String(provider || "").toUpperCase()}-log.svg`;
+  const providerTone = (provider) => providerMeta().tone?.(provider)?.rgb || "124,92,255";
   const providerIcon = (provider) => {
-    const p = String(provider || "").toUpperCase();
-    return `<img src="/assets/img/${esc(p)}-log.svg" alt="" onerror="this.remove()">`;
+    return `<img src="${esc(providerLogLogo(provider))}" alt="" onerror="this.remove()">`;
   };
+  const PLAYBACK_PROVIDER_KEYS = ["trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin"];
+  const DEFAULT_PROVIDER_TIMEOUT_SECONDS = 12;
   const state = {
     mounted: false,
     page: 1,
@@ -45,7 +51,7 @@ html[data-cw-theme=flat-dark] .pp-head,html[data-cw-theme=flat-light] .pp-head{b
 html[data-cw-theme=flat-light] .pp-field option{background:#ffffff;color:#111827}.cw-compact #page-playback_progress{display:block!important}.cw-compact #${ROOT_ID}{padding:10px}.cw-compact .pp-toolbar{grid-template-columns:1fr 1fr}.cw-compact .pp-head{display:grid}.cw-compact .pp-grid{grid-template-columns:1fr}.cw-compact .pp-card{grid-template-columns:92px minmax(0,1fr)}.cw-compact .pp-card-title{font-size:15px}
 @media(max-width:980px){.pp-toolbar{grid-template-columns:1fr 1fr}.pp-grid{grid-template-columns:1fr}}@media(max-width:640px){.pp-toolbar{grid-template-columns:1fr}.pp-card{grid-template-columns:88px minmax(0,1fr)}.pp-head-actions{justify-content:flex-start}.pp-bulk{display:grid}.pp-bulk-left,.pp-bulk-actions{justify-content:center}}
 .pp-toolbar{display:flex;align-items:center;gap:10px}.pp-toolbar #pp-search{flex:0 1 320px;min-width:180px}.pp-toolbar .pp-field:not(#pp-search),.pp-toolbar .cw-icon-select{flex:1 1 180px;min-width:170px}.pp-toolbar .cw-icon-select-btn{min-height:38px;border-radius:12px}.pp-toolbar .cw-icon-select-menu{min-width:185px}.pp-grid{align-items:start}.pp-card{grid-template-columns:96px minmax(0,1fr);height:144px;min-height:0;cursor:pointer;border-radius:16px;transition:border-color .16s ease,background .16s ease,transform .16s ease;isolation:isolate}.pp-card:hover{border-color:rgba(126,226,184,.28);transform:translateY(-1px)}.pp-card.selected{border-color:rgba(126,226,184,.68);box-shadow:0 0 0 1px rgba(126,226,184,.28),var(--pp-shadow)}.pp-card.selected:after{content:"";position:absolute;left:10px;top:10px;width:24px;height:24px;border-radius:7px;background:#7ee2b8;box-shadow:0 6px 16px rgba(0,0,0,.28)}.pp-card.selected:before{content:"check";position:absolute;left:10px;top:10px;z-index:2;width:24px;height:24px;display:grid;place-items:center;font-family:"Material Symbols Rounded";font-size:18px;color:#061015}.pp-check{display:none!important}.pp-art{z-index:1}.pp-art:after{content:"";position:absolute;inset:0;pointer-events:none;background:linear-gradient(90deg,rgba(3,5,10,.03),rgba(3,5,10,.16))}.pp-body{position:relative;overflow:hidden;padding:9px 14px;gap:6px}.pp-body:before{content:"";position:absolute;inset:0;z-index:0;pointer-events:none;background:linear-gradient(90deg,rgba(32,36,45,.96),rgba(32,36,45,.86) 54%,rgba(32,36,45,.92)),var(--pp-backdrop,none);background-size:cover;background-position:center;opacity:.48}.pp-body>*{position:relative;z-index:1}.pp-top{gap:4px}.pp-card-head{display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:start;gap:12px;min-width:0}.pp-title-wrap{min-width:0}.pp-card-side{display:grid;gap:6px;justify-items:end;align-content:start}.pp-provider-stack{display:flex;align-items:center;justify-content:flex-end;gap:6px;flex-wrap:wrap;min-width:0}.pp-provider-pill{display:inline-flex;align-items:center;gap:6px;min-height:23px;padding:0 8px;border-radius:999px;border:1px solid var(--pp-border-soft);background:var(--pp-panel-bg);color:var(--pp-soft);font-size:11px;font-weight:850;white-space:nowrap;overflow:visible}.pp-provider-pill img{width:16px;height:16px;max-width:none;max-height:none;object-fit:contain;flex:0 0 16px}.pp-rating-chip{display:inline-flex;align-items:center;gap:4px;min-height:22px;padding:0 8px;border-radius:999px;border:1px solid rgba(255,205,86,.20);background:rgba(255,205,86,.10);color:#ffe29a;font-size:11px;font-weight:850;white-space:nowrap}.pp-rating-chip .material-symbols-rounded{font-size:15px;font-variation-settings:'FILL' 1}.pp-badges,.pp-kind{display:none}.pp-card-title{font-size:18px}.pp-card-sub{font-size:13px}.pp-progress{gap:5px}.pp-progress-row{align-items:center;font-size:13px;flex-wrap:wrap}.pp-progress-row strong{font-size:14px;color:var(--pp-fg)}.pp-timing{display:inline-flex;align-items:center;justify-content:flex-end;gap:12px;margin-left:auto;color:var(--pp-soft);white-space:nowrap}.pp-paused{color:var(--pp-soft);white-space:nowrap}.pp-live{color:#9de4d0;white-space:nowrap}.pp-meta{display:none}.pp-actions{justify-content:flex-end;gap:6px;align-self:end}.pp-actions .pp-btn{min-height:32px;border-radius:12px}.pp-action-btn{min-height:28px!important;padding:0 9px;border-radius:999px!important;background:rgba(255,255,255,.035)!important;border-color:rgba(255,255,255,.08)!important;color:rgba(230,236,248,.74)!important;font-size:12px;font-weight:780;gap:5px;box-shadow:none;opacity:.82}.pp-action-btn .material-symbols-rounded{font-size:19px}.pp-action-btn:hover{opacity:1;color:var(--pp-fg)!important;background:rgba(255,255,255,.07)!important;border-color:rgba(255,255,255,.15)!important}.pp-action-watch .material-symbols-rounded{color:#9de4d0}.pp-action-edit .material-symbols-rounded{color:#9cc7ff}.pp-action-remove{color:rgba(255,214,222,.70)!important;background:rgba(149,48,67,.08)!important;border-color:rgba(255,138,160,.12)!important}.pp-action-remove .material-symbols-rounded{color:#ff9aaa}.pp-action-remove:hover{color:#ffe8ee!important;background:rgba(149,48,67,.16)!important;border-color:rgba(255,138,160,.24)!important}.pp-modal{position:fixed;inset:0;z-index:9998;display:grid;place-items:center;background:rgba(0,0,0,.48);backdrop-filter:blur(4px)}.pp-modal.hidden{display:none!important}.pp-dialog{width:min(420px,calc(100vw - 28px));padding:16px;border-radius:16px;border:1px solid var(--pp-border);background:var(--pp-panel-bg-strong);box-shadow:var(--pp-shadow);display:grid;gap:14px}.pp-dialog-title{font-size:18px;font-weight:850}.pp-dialog-sub{color:var(--pp-soft);font-size:12px}.pp-progress-edit{display:grid;grid-template-columns:1fr 84px;gap:10px;align-items:center}.pp-progress-edit input[type=range]{width:100%;accent-color:#7ee2b8}.pp-progress-edit input[type=number]{height:38px;border-radius:10px;border:1px solid var(--pp-border);background:var(--pp-input-bg);color:var(--pp-fg);padding:0 10px;font-weight:800}.pp-dialog-error{min-height:18px;color:var(--pp-danger-fg);font-size:12px}.pp-dialog-actions{display:flex;justify-content:flex-end;gap:8px}.cw-compact .pp-card{grid-template-columns:90px minmax(0,1fr);height:136px;min-height:0}html[data-cw-theme=flat-dark] .pp-body:before{background:linear-gradient(90deg,rgba(32,36,45,.97),rgba(32,36,45,.88) 54%,rgba(32,36,45,.94)),var(--pp-backdrop,none);opacity:.46}html[data-cw-theme=flat-light] .pp-body:before{background:linear-gradient(90deg,rgba(245,247,251,.96),rgba(245,247,251,.84) 54%,rgba(245,247,251,.92)),var(--pp-backdrop,none);opacity:.42}html[data-cw-theme=flat-light] .pp-art:after{background:linear-gradient(90deg,rgba(255,255,255,.02),rgba(255,255,255,.14))}html[data-cw-theme=flat-light] .pp-rating-chip{background:rgba(184,121,0,.09);border-color:rgba(184,121,0,.18);color:#7a4f00}html[data-cw-theme=flat-light] .pp-action-btn{background:rgba(17,24,39,.035)!important;border-color:rgba(17,24,39,.12)!important;color:rgba(17,24,39,.68)!important}html[data-cw-theme=flat-light] .pp-action-btn:hover{background:rgba(17,24,39,.075)!important;border-color:rgba(17,24,39,.18)!important;color:#111827!important}html[data-cw-theme=flat-light] .pp-action-remove{background:rgba(169,63,77,.08)!important;border-color:rgba(169,63,77,.16)!important;color:#8f2738!important}html[data-cw-theme=flat-dark] .pp-art:after{background:linear-gradient(90deg,rgba(7,10,16,.02),rgba(7,10,16,.16))}.pp-status.hidden{display:none!important}.pp-status-message{grid-column:1/-1;padding:12px 14px;color:var(--pp-soft);font-weight:750;text-align:center}@media(max-width:980px){.pp-toolbar{flex-wrap:wrap}.pp-toolbar #pp-search{flex:1 1 100%;min-width:0}.pp-toolbar .pp-field:not(#pp-search),.pp-toolbar .cw-icon-select{flex:1 1 170px}.pp-card{grid-template-columns:90px minmax(0,1fr);height:136px}}@media(max-width:640px){.pp-toolbar{display:grid;grid-template-columns:1fr}.pp-toolbar #pp-search,.pp-toolbar .pp-field:not(#pp-search),.pp-toolbar .cw-icon-select{min-width:0;flex:auto}.pp-card{grid-template-columns:82px minmax(0,1fr);height:132px}.pp-card-head{grid-template-columns:1fr}.pp-card-side{justify-items:start}.pp-provider-stack{justify-content:flex-start}.pp-card-title{font-size:16px}.pp-timing{margin-left:0;flex-wrap:wrap;justify-content:flex-start;gap:8px}.pp-action-btn{padding:0 8px;font-size:0}.pp-action-btn .material-symbols-rounded{font-size:20px}}
-.pp-toolbar,.pp-pager{position:relative;overflow:hidden;background:linear-gradient(180deg,rgba(255,255,255,.045),rgba(255,255,255,.015)),linear-gradient(90deg,rgba(255,255,255,.045) 1px,transparent 1px),linear-gradient(180deg,rgba(255,255,255,.045) 1px,transparent 1px),var(--pp-panel-bg)!important;background-size:auto,74px 74px,74px 74px,auto;background-position:0 0,0 0,0 0,0 0}.pp-toolbar:before,.pp-pager:before{content:"";position:absolute;inset:0;pointer-events:none;background:radial-gradient(80% 140% at 0% 0%,rgba(126,226,184,.08),transparent 52%),radial-gradient(90% 120% at 100% 100%,rgba(95,182,255,.07),transparent 56%);opacity:.9}.pp-toolbar>*,.pp-pager>*{position:relative;z-index:1}.pp-pager{min-height:58px}html[data-cw-theme=flat-light] .pp-toolbar,html[data-cw-theme=flat-light] .pp-pager{background:linear-gradient(180deg,rgba(255,255,255,.82),rgba(245,247,251,.92)),linear-gradient(90deg,rgba(16,24,40,.07) 1px,transparent 1px),linear-gradient(180deg,rgba(16,24,40,.07) 1px,transparent 1px),var(--pp-panel-bg)!important}html[data-cw-theme=flat-dark] .pp-toolbar,html[data-cw-theme=flat-dark] .pp-pager{background:linear-gradient(180deg,rgba(255,255,255,.035),rgba(255,255,255,.012)),linear-gradient(90deg,rgba(255,255,255,.055) 1px,transparent 1px),linear-gradient(180deg,rgba(255,255,255,.055) 1px,transparent 1px),var(--pp-panel-bg)!important}.pp-bulk{display:flex;width:max-content;max-width:min(940px,calc(100vw - 32px));margin:0 auto;padding:7px 9px;border-radius:999px;justify-content:center;flex-wrap:nowrap;gap:7px;background:linear-gradient(180deg,rgba(24,28,38,.94),rgba(12,14,20,.92));backdrop-filter:blur(14px);box-shadow:0 14px 36px rgba(0,0,0,.34),inset 0 1px 0 rgba(255,255,255,.07)}.pp-bulk .pp-btn{min-height:32px;border-radius:999px;box-shadow:none}.pp-bulk-left,.pp-bulk-actions{flex-wrap:nowrap;gap:6px}.pp-bulk-left{padding-right:0;border-right:0}.pp-selected-pill{display:inline-flex;align-items:center;gap:7px;min-height:32px;padding:0 11px 0 7px;border-radius:999px;border:1px solid var(--pp-border-soft);background:rgba(255,255,255,.045);font-weight:850;white-space:nowrap}.pp-selected-number{display:inline-grid;place-items:center;min-width:22px;height:22px;padding:0 6px;border-radius:999px;background:linear-gradient(135deg,#5fb6ff,#7ee2b8);color:#071016;font-size:12px;line-height:1}.pp-selected-label{color:var(--pp-soft);font-size:12px}.pp-bulk-divider{width:1px;height:28px;margin:0 7px;border-radius:999px;background:linear-gradient(180deg,transparent,rgba(255,255,255,.24),transparent);font-size:0;line-height:0;flex:0 0 1px;align-self:center}.pp-bulk-icon{width:36px;min-width:36px;padding:0!important}.pp-bulk-icon .material-symbols-rounded{font-size:21px}.pp-bulk-icon.danger{background:rgba(149,48,67,.16)!important;border-color:rgba(255,138,160,.20)!important;color:#ffdce4!important}html[data-cw-theme=flat-light] .pp-bulk{background:rgba(255,255,255,.94);box-shadow:0 14px 34px rgba(16,24,40,.14),inset 0 1px 0 rgba(255,255,255,.9)}html[data-cw-theme=flat-light] .pp-selected-pill{background:rgba(17,24,39,.04)}html[data-cw-theme=flat-light] .pp-bulk-divider{background:linear-gradient(180deg,transparent,rgba(17,24,39,.24),transparent)}.pp-settings-dialog{width:min(1040px,calc(100vw - 28px))}.pp-settings-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));align-items:start;gap:12px;max-height:min(560px,64vh);overflow:auto;padding-right:2px}.pp-settings-list>.pp-dialog-sub{grid-column:1/-1}.pp-settings-table{display:grid;gap:8px;min-width:0}.pp-settings-row{display:grid;grid-template-columns:auto minmax(0,1fr) auto;align-items:center;gap:10px;min-height:74px;padding:10px;border-radius:12px;border:1px solid var(--pp-border-soft);background:rgba(255,255,255,.035)}.pp-settings-row input[type=checkbox]{width:18px;height:18px;accent-color:#7ee2b8}.pp-settings-main{min-width:0}.pp-settings-name{display:flex;align-items:center;gap:8px;font-weight:850;min-width:0}.pp-settings-name img{width:16px;height:16px;max-width:none;max-height:none;object-fit:contain;flex:0 0 16px}.pp-settings-sub{margin-top:2px;color:var(--pp-soft);font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.pp-settings-pill{font-size:11px;color:var(--pp-soft);font-weight:800}.pp-settings-timeout{display:flex;align-items:center;justify-content:flex-start;gap:12px;flex-wrap:wrap}.pp-settings-timeout-label{display:inline-flex;align-items:center;gap:6px;min-width:0}.pp-help-icon{display:inline-grid;place-items:center;width:18px;height:18px;border-radius:999px;border:1px solid var(--pp-border-soft);background:rgba(255,255,255,.045);color:var(--pp-soft);cursor:help}.pp-help-icon .material-symbols-rounded{font-size:15px;line-height:1}.pp-settings-timeout input{width:96px;height:38px;border-radius:10px;border:1px solid var(--pp-border);background:var(--pp-input-bg);color:var(--pp-fg);padding:0 10px;font-weight:800}@media(max-width:760px){.pp-settings-list{grid-template-columns:1fr;max-height:min(560px,58vh)}.pp-settings-row{grid-template-columns:auto 1fr}.pp-settings-pill{display:none}.pp-bulk{width:calc(100vw - 24px);border-radius:18px;flex-wrap:wrap}.pp-bulk-left,.pp-bulk-actions{flex-wrap:wrap;justify-content:center}.pp-bulk-divider{display:none}}
+.pp-toolbar,.pp-pager{position:relative;overflow:hidden;background:linear-gradient(180deg,rgba(255,255,255,.045),rgba(255,255,255,.015)),linear-gradient(90deg,rgba(255,255,255,.045) 1px,transparent 1px),linear-gradient(180deg,rgba(255,255,255,.045) 1px,transparent 1px),var(--pp-panel-bg)!important;background-size:auto,74px 74px,74px 74px,auto;background-position:0 0,0 0,0 0,0 0}.pp-toolbar:before,.pp-pager:before{content:"";position:absolute;inset:0;pointer-events:none;background:radial-gradient(80% 140% at 0% 0%,rgba(126,226,184,.08),transparent 52%),radial-gradient(90% 120% at 100% 100%,rgba(95,182,255,.07),transparent 56%);opacity:.9}.pp-toolbar>*,.pp-pager>*{position:relative;z-index:1}.pp-pager{min-height:58px}html[data-cw-theme=flat-light] .pp-toolbar,html[data-cw-theme=flat-light] .pp-pager{background:linear-gradient(180deg,rgba(255,255,255,.82),rgba(245,247,251,.92)),linear-gradient(90deg,rgba(16,24,40,.07) 1px,transparent 1px),linear-gradient(180deg,rgba(16,24,40,.07) 1px,transparent 1px),var(--pp-panel-bg)!important}html[data-cw-theme=flat-dark] .pp-toolbar,html[data-cw-theme=flat-dark] .pp-pager{background:linear-gradient(180deg,rgba(255,255,255,.035),rgba(255,255,255,.012)),linear-gradient(90deg,rgba(255,255,255,.055) 1px,transparent 1px),linear-gradient(180deg,rgba(255,255,255,.055) 1px,transparent 1px),var(--pp-panel-bg)!important}.pp-bulk{display:flex;width:max-content;max-width:min(940px,calc(100vw - 32px));margin:0 auto;padding:7px 9px;border-radius:999px;justify-content:center;flex-wrap:nowrap;gap:7px;background:linear-gradient(180deg,rgba(24,28,38,.94),rgba(12,14,20,.92));backdrop-filter:blur(14px);box-shadow:0 14px 36px rgba(0,0,0,.34),inset 0 1px 0 rgba(255,255,255,.07)}.pp-bulk .pp-btn{min-height:32px;border-radius:999px;box-shadow:none}.pp-bulk-left,.pp-bulk-actions{flex-wrap:nowrap;gap:6px}.pp-bulk-left{padding-right:0;border-right:0}.pp-selected-pill{display:inline-flex;align-items:center;gap:7px;min-height:32px;padding:0 11px 0 7px;border-radius:999px;border:1px solid var(--pp-border-soft);background:rgba(255,255,255,.045);font-weight:850;white-space:nowrap}.pp-selected-number{display:inline-grid;place-items:center;min-width:22px;height:22px;padding:0 6px;border-radius:999px;background:linear-gradient(135deg,#5fb6ff,#7ee2b8);color:#071016;font-size:12px;line-height:1}.pp-selected-label{color:var(--pp-soft);font-size:12px}.pp-bulk-divider{width:1px;height:28px;margin:0 7px;border-radius:999px;background:linear-gradient(180deg,transparent,rgba(255,255,255,.24),transparent);font-size:0;line-height:0;flex:0 0 1px;align-self:center}.pp-bulk-icon{width:36px;min-width:36px;padding:0!important}.pp-bulk-icon .material-symbols-rounded{font-size:21px}.pp-bulk-icon.danger{background:rgba(149,48,67,.16)!important;border-color:rgba(255,138,160,.20)!important;color:#ffdce4!important}html[data-cw-theme=flat-light] .pp-bulk{background:rgba(255,255,255,.94);box-shadow:0 14px 34px rgba(16,24,40,.14),inset 0 1px 0 rgba(255,255,255,.9)}html[data-cw-theme=flat-light] .pp-selected-pill{background:rgba(17,24,39,.04)}html[data-cw-theme=flat-light] .pp-bulk-divider{background:linear-gradient(180deg,transparent,rgba(17,24,39,.24),transparent)}.pp-settings-sub{margin-top:2px;color:var(--pp-soft);font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}@media(max-width:760px){.pp-bulk{width:calc(100vw - 24px);border-radius:18px;flex-wrap:wrap}.pp-bulk-left,.pp-bulk-actions{flex-wrap:wrap;justify-content:center}.pp-bulk-divider{display:none}}
 .pp-toolbar,.pp-pager{--pp-matrix-line:rgba(210,222,248,.055);--pp-matrix-line-strong:rgba(210,222,248,.035);position:relative;isolation:isolate;overflow:hidden;border-radius:20px;background:linear-gradient(180deg,rgba(34,40,55,.90),rgba(26,31,44,.86)),var(--pp-panel-bg)!important;box-shadow:var(--pp-shadow)}.pp-toolbar:before,.pp-pager:before{content:"";position:absolute;inset:-1px;z-index:0;pointer-events:none;background-image:linear-gradient(var(--pp-matrix-line) 1px,transparent 1px),linear-gradient(90deg,var(--pp-matrix-line) 1px,transparent 1px),linear-gradient(rgba(255,255,255,.025),rgba(255,255,255,0) 42%);background-size:58px 58px,58px 58px,100% 100%;background-position:center;opacity:.62}.pp-toolbar:after,.pp-pager:after{content:"";position:absolute;inset:0;z-index:0;pointer-events:none;background:radial-gradient(95% 120% at 100% 0%,rgba(76,68,170,.075),transparent 58%),linear-gradient(90deg,rgba(126,226,184,.035),transparent 18%,transparent 82%,rgba(95,182,255,.025));opacity:.88}.pp-toolbar>*,.pp-pager>*{position:relative;z-index:1}html[data-cw-theme=flat-light] .pp-toolbar,html[data-cw-theme=flat-light] .pp-pager{--pp-matrix-line:rgba(16,24,40,.075);background:linear-gradient(180deg,rgba(255,255,255,.90),rgba(244,247,252,.92)),var(--pp-panel-bg)!important}html[data-cw-theme=flat-light] .pp-toolbar:after,html[data-cw-theme=flat-light] .pp-pager:after{background:radial-gradient(95% 120% at 100% 0%,rgba(76,68,170,.055),transparent 58%)}html[data-cw-theme=flat-dark] .pp-toolbar,html[data-cw-theme=flat-dark] .pp-pager{--pp-matrix-line:rgba(210,222,248,.06);background:linear-gradient(180deg,rgba(34,40,55,.90),rgba(24,29,42,.88)),var(--pp-panel-bg)!important}.pp-pager{background:var(--pp-panel-bg)!important;min-height:0;isolation:auto}.pp-pager:before,.pp-pager:after{content:none!important}
 #${ROOT_ID} .pp-toolbar,#${ROOT_ID} .pp-pager{--pp-matrix-line:rgba(255,255,255,.040);--pp-matrix-glow:rgba(78,68,170,.055);position:relative;isolation:isolate;overflow:hidden;background:var(--pp-panel-bg)!important}
 #${ROOT_ID} .pp-toolbar:before,#${ROOT_ID} .pp-pager:before{content:""!important;position:absolute;inset:-1px;z-index:0;pointer-events:none;background-image:linear-gradient(var(--pp-matrix-line) 1px,transparent 1px),linear-gradient(90deg,var(--pp-matrix-line) 1px,transparent 1px);background-size:58px 58px;background-position:center;opacity:.48}
@@ -55,6 +61,16 @@ html[data-cw-theme=flat-dark] #${ROOT_ID} .pp-toolbar,html[data-cw-theme=flat-da
 html[data-cw-theme=flat-light] #${ROOT_ID} .pp-toolbar,html[data-cw-theme=flat-light] #${ROOT_ID} .pp-pager{--pp-matrix-line:rgba(16,24,40,.065);--pp-matrix-glow:rgba(76,68,170,.050)}
 .pp-loading-grid{min-height:0}.pp-loading-card{cursor:default!important;pointer-events:none}.pp-loading-card:hover{border-color:var(--pp-border)!important;transform:none!important}.pp-loading-card .pp-body:before{opacity:.18!important}.pp-loading-shape{position:relative;display:block;overflow:hidden;background:color-mix(in srgb,var(--pp-soft) 12%,transparent)}.pp-loading-shape:after{content:"";position:absolute;inset:0;background:linear-gradient(110deg,transparent 0%,rgba(255,255,255,.035) 40%,rgba(255,255,255,.16) 50%,rgba(255,255,255,.035) 60%,transparent 100%);transform:translateX(-120%);animation:ppSkeletonShimmer 1.35s ease-in-out infinite}.pp-loading-art{height:100%;background:color-mix(in srgb,var(--pp-soft) 10%,var(--pp-panel-bg-strong))}.pp-loading-copy{display:grid;gap:8px;align-content:start}.pp-loading-line{height:12px;border-radius:999px}.pp-loading-line.title{width:min(62%,240px);height:16px}.pp-loading-line.meta{width:min(40%,150px);opacity:.76}.pp-loading-chip{width:58px;height:22px;border-radius:999px}.pp-loading-progress{gap:5px}.pp-loading-progress .pp-loading-line{width:30%;height:12px}.pp-loading-bar{height:8px;border-radius:999px}.pp-loading-actions{gap:6px;align-self:end}.pp-loading-action{width:58px;height:28px;border-radius:999px}.pp-loading-status{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}.is-loading #pp-refresh .material-symbols-rounded{animation:ppLoadingSpin .8s linear infinite}.is-loading .pp-toolbar{pointer-events:none;transition:opacity .16s ease}.is-initial-loading .pp-toolbar{opacity:.72}.is-initial-loading .pp-status,.is-initial-loading .pp-pager{display:none!important}.cw-compact .pp-loading-card:nth-child(n+4){display:none}@keyframes ppSkeletonShimmer{to{transform:translateX(120%)}}@keyframes ppLoadingSpin{to{transform:rotate(360deg)}}@media(max-width:980px){.pp-loading-card:nth-child(n+4){display:none}}@media(prefers-reduced-motion:reduce){.pp-loading-shape:after,.is-loading #pp-refresh .material-symbols-rounded{animation:none!important}.pp-loading-shape:after{transform:none;opacity:.35}}
 html[data-cw-theme=flat-dark] #${ROOT_ID} .pp-loading-shape{background:#2a2f39}html[data-cw-theme=flat-dark] #${ROOT_ID} .pp-loading-art{background:#242a34}html[data-cw-theme=flat-light] #${ROOT_ID} .pp-loading-shape{background:#e2e7ef}html[data-cw-theme=flat-light] #${ROOT_ID} .pp-loading-art{background:#e9edf3}html[data-cw-theme=flat-light] #${ROOT_ID} .pp-loading-shape:after{background:linear-gradient(110deg,transparent 0%,rgba(255,255,255,.16) 40%,rgba(255,255,255,.76) 50%,rgba(255,255,255,.16) 60%,transparent 100%)}
+.pp-settings-dialog.cw-insight-set{width:min(1180px,calc(100vw - 24px))!important;max-width:min(1180px,calc(100vw - 24px))!important;max-height:min(720px,calc(100vh - 28px))!important;padding:0!important;gap:0!important;border-radius:16px;overflow:hidden;display:grid;grid-template-rows:auto minmax(0,1fr) auto;background:linear-gradient(180deg,rgba(17,21,31,.98),rgba(13,17,25,.99))!important;border:1px solid rgba(255,255,255,.11)!important;box-shadow:0 30px 90px rgba(0,0,0,.48)!important;color:var(--pp-fg)}
+.pp-settings-dialog.cw-insight-set .cx-head{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:18px 24px 14px;border-bottom:1px solid var(--pp-border);background:rgba(255,255,255,.015)}.pp-settings-dialog .head-copy{display:grid;gap:4px;min-width:0}.pp-settings-dialog .head-title{font-size:28px;font-weight:900;line-height:1.05;letter-spacing:0}.pp-settings-dialog .head-sub{font-size:14px;color:var(--pp-soft);line-height:1.35}.pp-settings-dialog .head-actions{display:flex;align-items:center;gap:12px}.pp-settings-dialog .head-chip,.pp-settings-dialog .close-btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;height:42px;padding:0 16px;border-radius:8px;border:1px solid var(--pp-border);background:rgba(255,255,255,.035);color:var(--pp-fg);font-size:13px;font-weight:850;text-transform:uppercase;cursor:pointer}.pp-settings-dialog .head-chip .material-symbols-rounded,.pp-settings-dialog .close-btn .material-symbols-rounded{font-size:19px}
+.pp-settings-dialog .body{overflow:auto;padding:18px 24px 20px}.pp-settings-dialog .layout{display:grid;grid-template-columns:minmax(290px,320px) minmax(0,1fr);gap:22px;align-items:start}.pp-settings-dialog .panel{border-radius:16px;border:1px solid var(--pp-border);background:linear-gradient(180deg,rgba(255,255,255,.035),rgba(255,255,255,.018));overflow:hidden}.pp-settings-dialog .panel-head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:16px 18px 10px;border-bottom:1px solid var(--pp-border-soft)}.pp-settings-dialog .panel-title{font-size:16px;font-weight:900;text-transform:uppercase;letter-spacing:.03em}.pp-settings-dialog .panel-sub{margin-top:4px;color:var(--pp-soft);font-size:12px}.pp-settings-dialog .panel-body{padding:14px}.pp-settings-dialog .settings-stack{display:grid;gap:10px}.pp-settings-dialog .setting-card{display:grid;grid-template-columns:38px minmax(0,1fr) 92px;align-items:center;gap:12px;min-height:66px;padding:12px;border-radius:12px;border:1px solid rgba(124,92,255,.28);background:linear-gradient(180deg,rgba(124,92,255,.12),rgba(124,92,255,.045))}.pp-settings-dialog .setting-icon{display:grid;place-items:center;width:34px;height:34px;border-radius:10px;color:#b69cff;background:rgba(124,92,255,.12)}.pp-settings-dialog .setting-icon .material-symbols-rounded{font-size:24px}.pp-settings-dialog .setting-name{font-size:13px;font-weight:900}.pp-settings-dialog .setting-copy{margin-top:3px;color:var(--pp-soft);font-size:12px}.pp-settings-dialog .setting-card input{width:100%;height:38px;border-radius:9px;border:1px solid var(--pp-border);background:var(--pp-input-bg);color:var(--pp-fg);padding:0 10px;font-weight:850}
+.pp-settings-dialog .providers-shell{background:transparent;border:0;overflow:visible}.pp-settings-dialog .providers-shell .panel-body{padding:0}.pp-settings-dialog .pp-settings-list{max-height:none;overflow:visible;padding-right:0;align-items:stretch}.pp-settings-dialog .loading{padding:14px;border-radius:12px;border:1px dashed var(--pp-border);color:var(--pp-soft);background:rgba(255,255,255,.025)}.pp-settings-dialog .prov-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.pp-settings-dialog .prov-card{--provider-rgb:124,92,255;position:relative;display:grid;gap:12px;min-height:94px;padding:16px;border-radius:11px;border:1px solid rgba(255,255,255,.10);background:radial-gradient(100% 145% at 0% 0%,rgba(var(--provider-rgb),.13),transparent 56%),linear-gradient(180deg,rgba(26,31,43,.94),rgba(16,21,31,.98));overflow:hidden}.pp-settings-dialog .prov-card:after{content:"";position:absolute;left:0;right:0;bottom:0;height:2px;background:linear-gradient(90deg,rgba(var(--provider-rgb),.12),rgba(var(--provider-rgb),.82),rgba(var(--provider-rgb),.12));opacity:.82}.pp-settings-dialog .prov-card>*{position:relative;z-index:1}.pp-settings-dialog .prov-card[data-connected="0"]{filter:grayscale(.7);opacity:.58;background:linear-gradient(180deg,rgba(255,255,255,.035),rgba(255,255,255,.018));border-color:var(--pp-border-soft)}.pp-settings-dialog .prov-card[data-connected="0"]:after{background:rgba(255,255,255,.16)}.pp-settings-dialog .prov-top,.pp-settings-dialog .prov-brand,.pp-settings-dialog .prov-tools{display:flex;align-items:center;gap:12px}.pp-settings-dialog .prov-top{justify-content:space-between;min-width:0}.pp-settings-dialog .prov-brand{min-width:0}.pp-settings-dialog .prov-icon{display:grid;place-items:center;flex:0 0 auto;width:44px;height:44px;border-radius:10px;border:1px solid rgba(var(--provider-rgb),.42);background:linear-gradient(180deg,rgba(var(--provider-rgb),.46),rgba(var(--provider-rgb),.18))}.pp-settings-dialog .prov-icon img{display:block;max-width:28px;max-height:28px;object-fit:contain}.pp-settings-dialog .prov-icon-fallback{font-size:16px;font-weight:950}.pp-settings-dialog .prov-title{min-width:0;font-size:16px;font-weight:900;text-transform:uppercase;letter-spacing:.025em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.pp-settings-dialog .prov-badge,.pp-settings-dialog .mini{height:32px;padding:0 11px;border-radius:8px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.035);color:var(--pp-fg);font-size:11px;font-weight:850;text-transform:uppercase}.pp-settings-dialog .mini{cursor:pointer}.pp-settings-dialog .mini:disabled{opacity:.45;cursor:not-allowed}.pp-settings-dialog .prov-badge.disconnected{letter-spacing:.02em;color:var(--pp-soft)}.pp-settings-dialog [data-list]{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}.pp-settings-dialog .pill{display:flex;min-height:38px;cursor:pointer;user-select:none}.pp-settings-dialog .pill input{position:absolute;opacity:0;pointer-events:none}.pp-settings-dialog .pill .lab{display:flex;align-items:center;justify-content:space-between;gap:8px;width:100%;padding:0 12px;border-radius:8px;border:1px solid rgba(var(--provider-rgb),.48);background:transparent;color:#f7f9ff;font-size:13px;font-weight:850}.pp-settings-dialog .pill .lab span:first-child{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.pp-settings-dialog .pill .material-symbols-rounded{font-size:18px;color:rgba(231,238,255,.92)}.pp-settings-dialog .pill input:not(:checked)+.lab .material-symbols-rounded{opacity:0}.pp-settings-dialog .pill input:checked+.lab{background:rgba(var(--provider-rgb),.12);border-color:rgba(var(--provider-rgb),.68)}.pp-settings-dialog .pill input:disabled+.lab{border-style:dashed;color:var(--pp-soft);opacity:.78}.pp-settings-dialog .prov-card[data-single="1"]{grid-template-columns:minmax(0,1fr) minmax(128px,160px);align-items:center}.pp-settings-dialog .prov-card[data-single="1"] .prov-tools{display:none}.pp-settings-dialog .prov-card[data-single="1"] [data-list]{grid-template-columns:1fr}.pp-settings-dialog .prov-card[data-single="0"]{min-height:132px}
+.pp-settings-dialog .prov-card:before{content:"";position:absolute;z-index:0;pointer-events:none;inset:0;background:var(--provider-wm,none) right 18px center/46% 86% no-repeat;opacity:.12;filter:saturate(1.25) brightness(1.18);mix-blend-mode:screen}.pp-settings-dialog .prov-icon{width:52px!important;height:52px!important}.pp-settings-dialog .prov-icon img{width:36px!important;height:36px!important;max-width:36px!important;max-height:36px!important;object-fit:contain}.pp-settings-dialog .prov-card [data-list],.pp-settings-dialog .prov-card .pill{padding:0!important;border:0!important;border-radius:0!important;background:transparent!important;background-image:none!important;box-shadow:none!important;backdrop-filter:none!important;-webkit-backdrop-filter:none!important}.pp-settings-dialog .prov-card .pill .lab{background:transparent!important;background-image:none!important;box-shadow:none!important;backdrop-filter:none!important;-webkit-backdrop-filter:none!important}.pp-settings-dialog .prov-card .pill input:checked+.lab{background:rgba(var(--provider-rgb),.12)!important;background-image:none!important;box-shadow:none!important}
+#pp-settings-dialog .pp-settings-dialog .prov-card:before{content:""!important;display:block!important;background:var(--provider-wm,none) right 18px center/46% 86% no-repeat!important;opacity:.12!important;filter:saturate(1.25) brightness(1.18)!important;mix-blend-mode:screen!important}#pp-settings-dialog .pp-settings-dialog .prov-card [data-list],#pp-settings-dialog .pp-settings-dialog .prov-card .pill{padding:0!important;border:0!important;border-radius:0!important;background:transparent!important;background-image:none!important;box-shadow:none!important;backdrop-filter:none!important;-webkit-backdrop-filter:none!important}#pp-settings-dialog .pp-settings-dialog .prov-card .pill .lab{background:transparent!important;background-image:none!important;box-shadow:none!important;backdrop-filter:none!important;-webkit-backdrop-filter:none!important}
+#pp-settings-dialog .pp-settings-dialog .prov-card{grid-template-rows:auto 38px;align-content:center}#pp-settings-dialog .pp-settings-dialog .prov-top{display:grid!important;grid-template-columns:minmax(0,1fr) auto;align-items:center!important;gap:14px!important}#pp-settings-dialog .pp-settings-dialog .prov-brand{display:grid!important;grid-template-columns:52px minmax(0,1fr);align-items:center!important;gap:14px!important}#pp-settings-dialog .pp-settings-dialog .prov-tools{display:grid!important;grid-auto-flow:column;grid-auto-columns:max-content;align-items:center!important;justify-content:end!important;gap:8px!important}#pp-settings-dialog .pp-settings-dialog .prov-badge,#pp-settings-dialog .pp-settings-dialog .mini{display:inline-grid!important;place-items:center!important;height:34px!important;min-width:58px!important;padding:0 12px!important;line-height:1!important}#pp-settings-dialog .pp-settings-dialog .prov-card[data-single="1"]{grid-template-columns:minmax(0,1fr) minmax(220px,240px)!important;grid-template-rows:auto!important;column-gap:18px!important}#pp-settings-dialog .pp-settings-dialog .prov-card[data-single="1"] .prov-top{display:block!important;min-width:0!important}#pp-settings-dialog .pp-settings-dialog .prov-card[data-single="1"] [data-list]{align-self:center!important}#pp-settings-dialog .pp-settings-dialog .prov-card:before{background-position:right 12px center!important;background-size:40% 78%!important;opacity:.09!important}
+.pp-settings-dialog .actions{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:12px 24px 14px;border-top:1px solid var(--pp-border);background:rgba(255,255,255,.015)}.pp-settings-dialog .footer-note{display:flex;align-items:center;gap:10px;min-width:0;color:var(--pp-soft);font-size:13px}.pp-settings-dialog .footer-note .material-symbols-rounded{font-size:22px;opacity:.68}.pp-settings-dialog .action-row{display:flex;align-items:center;gap:12px}.pp-settings-dialog .btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;min-width:112px;height:44px;padding:0 16px;border-radius:10px;border:1px solid var(--pp-border);background:rgba(255,255,255,.035);color:var(--pp-fg);font-size:12px;font-weight:900;text-transform:uppercase;cursor:pointer}.pp-settings-dialog .btn.danger{border-color:rgba(255,138,160,.34);background:rgba(118,28,46,.22);color:#ffe7ee}.pp-settings-dialog .btn.good{border-color:rgba(83,217,139,.42);background:linear-gradient(180deg,rgba(50,176,103,.72),rgba(32,135,82,.78));color:#eafff2}.pp-settings-dialog .btn .material-symbols-rounded{font-size:19px}.pp-settings-dialog .pp-dialog-error{padding:0 24px;color:var(--pp-danger-fg)}
+html[data-cw-theme=flat-dark] .pp-settings-dialog.cw-insight-set{background:#171a22!important;box-shadow:none!important}html[data-cw-theme=flat-dark] .pp-settings-dialog .prov-card{background:radial-gradient(100% 145% at 0% 0%,rgba(var(--provider-rgb),.12),transparent 56%),#171a22}html[data-cw-theme=flat-dark] .pp-settings-dialog .prov-card[data-connected="0"]{background:#171a22}html[data-cw-theme=flat-light] .pp-settings-dialog.cw-insight-set{background:#fff!important;box-shadow:none!important;color:#111827}html[data-cw-theme=flat-light] .pp-settings-dialog .prov-card{background:radial-gradient(100% 145% at 0% 0%,rgba(var(--provider-rgb),.09),transparent 56%),linear-gradient(180deg,#fff,#f2f5fa)}html[data-cw-theme=flat-light] .pp-settings-dialog .pill .lab{color:#172033}html[data-cw-theme=flat-light] .pp-settings-dialog .btn.good{color:#fff}
+@media(max-width:1100px){.pp-settings-dialog .layout{grid-template-columns:1fr}.pp-settings-dialog .prov-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}@media(max-width:760px){.pp-settings-dialog.cw-insight-set{width:calc(100vw - 12px)!important;max-width:calc(100vw - 12px)!important;max-height:calc(100dvh - 12px)!important}.pp-settings-dialog.cw-insight-set .cx-head{padding:12px}.pp-settings-dialog .head-title{font-size:20px}.pp-settings-dialog .head-sub,.pp-settings-dialog .head-chip{display:none}.pp-settings-dialog .close-btn{width:42px;min-width:42px;padding:0;font-size:0}.pp-settings-dialog .body{padding:10px}.pp-settings-dialog .layout{gap:10px}.pp-settings-dialog .prov-grid{grid-template-columns:1fr}.pp-settings-dialog .prov-card[data-single="1"]{grid-template-columns:minmax(0,1fr) minmax(112px,136px)}.pp-settings-dialog .actions{padding:9px 10px}.pp-settings-dialog .footer-note{display:none}.pp-settings-dialog .btn{min-width:0;flex:1 1 0}}
     `;
     document.head.appendChild(Object.assign(document.createElement("style"), { id: STYLE_ID, textContent: css }));
   }
@@ -93,12 +109,54 @@ html[data-cw-theme=flat-dark] #${ROOT_ID} .pp-loading-shape{background:#2a2f39}h
         </div>
       </div>
       <div class="pp-modal hidden" id="pp-settings-dialog" role="dialog" aria-modal="true" aria-labelledby="pp-settings-title">
-        <div class="pp-dialog pp-settings-dialog">
-          <div><div class="pp-dialog-title" id="pp-settings-title">Playback Progress Settings</div><div class="pp-dialog-sub">Choose which provider profiles appear on this screen.</div></div>
-          <div class="pp-settings-timeout"><span class="pp-dialog-sub pp-settings-timeout-label">Slow provider timeout <span class="pp-help-icon" tabindex="0" title="How many seconds Playback Progress waits for each provider profile before skipping it for this refresh. Slower providers are shown as timed out instead of blocking the whole page.">${icon("help")}</span></span><input id="pp-settings-timeout" type="number" min="3" max="60" step="1"></div>
-          <div class="pp-settings-list" id="pp-settings-list"></div>
+        <div class="pp-dialog pp-settings-dialog cw-insight-set">
+          <div class="cx-head">
+            <div class="head-copy">
+              <div class="head-title" id="pp-settings-title">Playback Progress Settings</div>
+              <div class="head-sub">Choose which provider profiles appear on this screen.</div>
+            </div>
+            <div class="head-actions">
+              <div class="head-chip"><span class="material-symbols-rounded" aria-hidden="true">stars</span><span id="pp-settings-head-chip">Preparing</span></div>
+              <button class="close-btn" id="pp-settings-cancel" type="button">${icon("close")}<span>Close</span></button>
+            </div>
+          </div>
+          <div class="body">
+            <div class="layout">
+              <section class="panel">
+                <div class="panel-head">
+                  <div>
+                    <div class="panel-title">Playback Progress</div>
+                    <div class="panel-sub">Refresh behavior</div>
+                  </div>
+                </div>
+                <div class="panel-body">
+                  <div class="settings-stack">
+                    <label class="setting-card" for="pp-settings-timeout">
+                      <span class="setting-icon">${icon("timer")}</span>
+                      <span>
+                        <span class="setting-name">Slow provider timeout</span>
+                        <span class="setting-copy">Seconds</span>
+                      </span>
+                      <input id="pp-settings-timeout" type="number" min="3" max="60" step="1">
+                    </label>
+                  </div>
+                </div>
+              </section>
+              <section class="panel providers-shell">
+                <div class="panel-body">
+                  <div class="pp-settings-list prov-grid" id="pp-settings-list"></div>
+                </div>
+              </section>
+            </div>
+          </div>
           <div class="pp-dialog-error" id="pp-settings-error"></div>
-          <div class="pp-dialog-actions"><button class="pp-btn" id="pp-settings-cancel">Cancel</button><button class="pp-btn" id="pp-settings-save">Save</button></div>
+          <div class="actions">
+            <div class="footer-note">${icon("info")}<span>These settings control which provider profiles appear on the playback progress screen.</span></div>
+            <div class="action-row">
+              <button class="btn danger" id="pp-settings-reset" type="button">${icon("restart_alt")}<span>Reset</span></button>
+              <button class="btn good" id="pp-settings-save" type="button">${icon("check_circle")}<span>Apply</span></button>
+            </div>
+          </div>
         </div>
       </div>
       <div class="pp-toast hidden" id="pp-toast"></div>
@@ -189,6 +247,88 @@ html[data-cw-theme=flat-dark] #${ROOT_ID} .pp-loading-shape{background:#2a2f39}h
     }
     return label || (String(p.instance_id || "").trim() || "Default");
   };
+  const settingsProviderOrder = (provider) => {
+    const p = String(provider || "").toLowerCase();
+    const idx = PLAYBACK_PROVIDER_KEYS.indexOf(p);
+    return idx >= 0 ? idx : PLAYBACK_PROVIDER_KEYS.length + p.charCodeAt(0);
+  };
+  const settingsProfileKey = (p) => `${String(p.provider || "").toLowerCase()}:${String(p.instance_id || "default")}`;
+  const settingsProfileLabel = (p) => {
+    const id = String(p.instance_id || "default");
+    if (id === "default") return "Default";
+    return String(p.instance_label || id);
+  };
+  const settingsProviderCard = (provider, profiles) => {
+    const key = String(provider || "").toLowerCase();
+    const label = providerLabel(key);
+    const rows = (Array.isArray(profiles) ? profiles : []).filter((p) => p.configured && p.read);
+    if (!rows.length) return "";
+    const selected = rows.filter((p) => p.included !== false).length;
+    const logo = providerLogo(key);
+    const titleBadge = rows.length > 1
+      ? `<span class="prov-badge" data-badge>${selected}/${rows.length}</span><button class="mini" type="button" data-settings-all>All</button><button class="mini" type="button" data-settings-none>None</button>`
+      : "";
+    return `<section class="prov-card" data-provider="${esc(key)}" data-single="${rows.length === 1 ? 1 : 0}" style="--provider-rgb:${esc(providerTone(key))};--provider-wm:url(&quot;${esc(logo)}&quot;)">
+      <div class="prov-top">
+        <div class="prov-brand">
+          <span class="prov-icon"><img src="${esc(logo)}" alt="${esc(label)} logo" loading="lazy" onerror="this.replaceWith(Object.assign(document.createElement('span'),{className:'prov-icon-fallback',textContent:'${esc((label || key || "?").slice(0, 2).toUpperCase())}'}))"></span>
+          <div class="prov-title">${esc(label)}</div>
+        </div>
+        <div class="prov-tools">${titleBadge}</div>
+      </div>
+      <div data-list>${rows.map((p) => {
+        const checked = p.included !== false;
+        const display = settingsProfileLabel(p);
+        return `<label class="pill" for="pp-set-${esc(settingsProfileKey(p).replace(/[^a-z0-9_-]+/gi, "-"))}">
+          <input type="checkbox" id="pp-set-${esc(settingsProfileKey(p).replace(/[^a-z0-9_-]+/gi, "-"))}" data-key="${esc(settingsProfileKey(p))}" data-provider="${esc(p.provider || key)}" data-instance="${esc(p.instance_id || "default")}" data-included="${p.included !== false ? "true" : "false"}"${checked ? " checked" : ""}>
+          <span class="lab"><span>${esc(display)}</span><span class="material-symbols-rounded" aria-hidden="true">check</span></span>
+        </label>`;
+      }).join("")}</div>
+    </section>`;
+  };
+  const updateSettingsCard = (card) => {
+    if (!card) return;
+    const checks = [...card.querySelectorAll("input[type=checkbox][data-provider]")];
+    const badge = card.querySelector("[data-badge]");
+    const selected = checks.filter((el) => !el.disabled && el.checked).length;
+    if (badge) badge.textContent = `${selected}/${checks.length}`;
+    card.dataset.empty = selected ? "0" : "1";
+  };
+  const renderSettingsProfiles = (data) => {
+    const profiles = Array.isArray(data?.profiles) ? data.profiles : [];
+    const byProvider = new Map();
+    profiles.forEach((p) => {
+      const provider = String(p.provider || "").toLowerCase();
+      if (!provider) return;
+      if (!byProvider.has(provider)) byProvider.set(provider, []);
+      byProvider.get(provider).push(p);
+    });
+    const hidden = profiles
+      .filter((p) => !(p.configured && p.read))
+      .map((p) => `<input type="checkbox" hidden disabled data-provider="${esc(p.provider || "")}" data-instance="${esc(p.instance_id || "default")}" data-included="${p.included !== false ? "true" : "false"}">`)
+      .join("");
+    const cards = [...byProvider.entries()]
+      .sort((a, b) => settingsProviderOrder(a[0]) - settingsProviderOrder(b[0]) || a[0].localeCompare(b[0]))
+      .map(([provider, rows]) => settingsProviderCard(provider, rows))
+      .filter(Boolean)
+      .join("");
+    return cards ? `${cards}${hidden}` : `<div class="loading">No connected playback progress providers were found.</div>${hidden}`;
+  };
+  const updateSettingsCount = () => {
+    const cards = [...document.querySelectorAll("#pp-settings-list .prov-card")];
+    const chip = document.getElementById("pp-settings-head-chip");
+    if (chip) chip.textContent = `${cards.length} provider${cards.length === 1 ? "" : "s"}`;
+    cards.forEach(updateSettingsCard);
+  };
+  const resetSettingsDraft = () => {
+    const timeout = document.getElementById("pp-settings-timeout");
+    if (timeout) timeout.value = String(DEFAULT_PROVIDER_TIMEOUT_SECONDS);
+    document.querySelectorAll("#pp-settings-list input[type=checkbox][data-provider]").forEach((el) => {
+      el.checked = !el.disabled;
+      if (el.disabled) el.dataset.included = "false";
+    });
+    updateSettingsCount();
+  };
   const actionRecords = (item, action) => recordsOf(item).filter((it) => {
     if (action === "mark_watched") return it.can_mark_watched;
     if (action === "update_progress") return it.can_update_progress;
@@ -277,31 +417,13 @@ html[data-cw-theme=flat-dark] #${ROOT_ID} .pp-loading-shape{background:#2a2f39}h
     const err = document.getElementById("pp-settings-error");
     if (!dlg || !list || !timeout || !err) return;
     err.textContent = "";
-    list.innerHTML = `<div class="pp-dialog-sub">Loading provider profiles...</div>`;
+    list.innerHTML = `<div class="loading">Loading provider profiles...</div>`;
     dlg.classList.remove("hidden");
     const data = await api("/api/playback_progress/settings");
     state.settings = data;
     timeout.value = String(Math.round(Number(data.provider_timeout_seconds || 12)));
-    const profiles = Array.isArray(data.profiles) ? data.profiles : [];
-    if (!profiles.length) {
-      list.innerHTML = `<div class="pp-dialog-sub">No compatible provider profiles were found.</div>`;
-      return;
-    }
-    const rows = profiles.map((p) => {
-      const key = `${p.provider}:${p.instance_id}`;
-      const disabled = p.configured && p.read ? "" : " disabled";
-      const status = p.configured && p.read ? "available" : (p.reason || "not configured");
-      return `<label class="pp-settings-row">
-        <input type="checkbox" data-key="${esc(key)}" data-provider="${esc(p.provider)}" data-instance="${esc(p.instance_id)}"${p.included ? " checked" : ""}${disabled}>
-        <span class="pp-settings-main"><span class="pp-settings-name">${providerIcon(p.provider)}${esc(p.instance_label || p.provider_label || key)}</span><span class="pp-settings-sub">${esc(status)}</span></span>
-        <span class="pp-settings-pill">${esc(p.provider_label || p.provider)}</span>
-      </label>`;
-    });
-    const tables = [];
-    for (let i = 0; i < rows.length; i += 5) {
-      tables.push(`<div class="pp-settings-table">${rows.slice(i, i + 5).join("")}</div>`);
-    }
-    list.innerHTML = tables.join("");
+    list.innerHTML = renderSettingsProfiles(data);
+    updateSettingsCount();
   }
 
   function closeSettings() {
@@ -322,7 +444,7 @@ html[data-cw-theme=flat-dark] #${ROOT_ID} .pp-loading-shape{background:#2a2f39}h
     const profiles = [...list.querySelectorAll("input[type=checkbox][data-provider]")].map((el) => ({
       provider: el.dataset.provider,
       instance_id: el.dataset.instance,
-      included: el.checked
+      included: el.disabled ? el.dataset.included !== "false" : el.checked
     }));
     const res = await api("/api/playback_progress/settings", {
       method: "POST",
@@ -600,6 +722,7 @@ html[data-cw-theme=flat-dark] #${ROOT_ID} .pp-loading-shape{background:#2a2f39}h
       if (t.id === "pp-age") update("age", t.value);
       if (t.id === "pp-rating") update("rating", t.value);
       if (t.id === "pp-sort") update("sort", t.value);
+      if (t.matches?.("#pp-settings-list input[type=checkbox][data-provider]")) updateSettingsCard(t.closest(".prov-card"));
     }, true);
     r.addEventListener("input", (e) => {
       if (e.target?.id !== "pp-search") return;
@@ -611,7 +734,14 @@ html[data-cw-theme=flat-dark] #${ROOT_ID} .pp-loading-shape{background:#2a2f39}h
       if (btn) {
         if (btn.id === "pp-settings") return openSettings();
         if (btn.id === "pp-settings-cancel") return closeSettings();
+        if (btn.id === "pp-settings-reset") { resetSettingsDraft(); return; }
         if (btn.id === "pp-settings-save") return saveSettings();
+        if (btn.hasAttribute("data-settings-all") || btn.hasAttribute("data-settings-none")) {
+          const card = btn.closest(".prov-card");
+          card?.querySelectorAll("input[type=checkbox][data-provider]:not(:disabled)").forEach((el) => { el.checked = btn.hasAttribute("data-settings-all"); });
+          updateSettingsCard(card);
+          return;
+        }
         if (btn.id === "pp-refresh") return load(true);
         if (btn.id === "pp-prev" && state.page > 1) { state.page--; return load(false); }
         if (btn.id === "pp-next") { state.page++; return load(false); }

--- a/services/analyzer.py
+++ b/services/analyzer.py
@@ -489,24 +489,47 @@ def _load_manual_state() -> dict[str, Any]:
     except Exception:
         return {}
 
+def _block_keys(raw: Any) -> set[str]:
+    if isinstance(raw, dict):
+        return {str(x) for x in raw.keys() if x}
+    if isinstance(raw, (list, tuple, set)):
+        return {str(x) for x in raw if x}
+    return set()
+
+
 def _manual_add_blocks(manual: dict[str, Any]) -> dict[tuple[str, str], set[str]]:
     out: dict[tuple[str, str], set[str]] = {}
+
+    def collect(token: str, node: Any) -> None:
+        if not isinstance(node, dict):
+            return
+        for feat, feat_data in node.items():
+            if feat == "instances" or not isinstance(feat_data, dict):
+                continue
+            blocks = _block_keys(feat_data.get("blocks"))
+            if blocks:
+                out.setdefault((token, str(feat).lower()), set()).update(blocks)
+
     providers = manual.get("providers") if isinstance(manual, dict) else None
     if not isinstance(providers, dict):
         return out
     for prov, prov_data in providers.items():
         if not isinstance(prov_data, dict):
             continue
-        for feat, feat_data in prov_data.items():
-            if not isinstance(feat_data, dict):
-                continue
-            adds = feat_data.get("adds")
-            if not isinstance(adds, dict):
-                continue
-            blocks = adds.get("blocks")
-            if not isinstance(blocks, list) or not blocks:
-                continue
-            out[(str(prov).upper(), str(feat).lower())] = set(str(x) for x in blocks if x)
+        collect(_prov_token(prov), prov_data)
+        insts = prov_data.get("instances")
+        if isinstance(insts, dict):
+            for inst, inst_data in insts.items():
+                collect(_prov_token(prov, inst), inst_data)
+    return out
+
+
+def _manual_blocks_for(manual_blocks: dict[tuple[str, str], set[str]], prov: str, feat: str) -> set[str]:
+    out: set[str] = set()
+    for token in (prov, _provider_base(prov)):
+        found = manual_blocks.get((token, feat))
+        if found:
+            out |= found
     return out
 
 def _iter_items(s: dict[str, Any]) -> Iterable[tuple[str, str, str, dict[str, Any]]]:
@@ -3314,7 +3337,7 @@ def _problems(
             missing_targets = _missing_targets(analysis, prov, feat, k, v)
 
             if missing_targets:
-                blocks = manual_blocks.get((prov, feat))
+                blocks = _manual_blocks_for(manual_blocks, prov, feat)
                 blocked = False
                 if blocks:
                     for kk in [k, *alias_keys]:
@@ -3895,7 +3918,7 @@ def _detail_for_item(pairs_raw: str | None, provider: str, feature: str, key: st
     alias_keys = _alias_keys(vv)
 
     manual_blocks = _manual_add_blocks(_load_manual_state())
-    blocks = manual_blocks.get((prov_key, feat_key))
+    blocks = _manual_blocks_for(manual_blocks, prov_key, feat_key)
     blocked = bool(blocks and any(kk in blocks for kk in [key, *alias_keys]))
 
     hints = _missing_peer_hints(_unresolved_index(allowed), feat_key, alias_keys, missing_targets, blocked)

--- a/services/editor.py
+++ b/services/editor.py
@@ -55,6 +55,21 @@ def _state_path(kind: Kind) -> Path:
     return _root_dir() / f"{kind}.json"
 
 
+def _write_json_atomic(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, ensure_ascii=False)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except Exception:
+            pass
+        raise
+
+
 def _validated_json_filename(name: str, *, label: str) -> str:
     raw = str(name or "").strip()
     if not raw or not raw.lower().endswith(_JSON_FILE_SUFFIX):
@@ -243,9 +258,8 @@ def save_state(kind: Kind | None, items: dict[str, Any]) -> dict[str, Any]:
         "ts": int(datetime.now(timezone.utc).timestamp()),
     }
     path = _state_path(kind_val)
-    path.parent.mkdir(parents=True, exist_ok=True)
     try:
-        path.write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
+        _write_json_atomic(path, state)
     except Exception:
         pass
     return state
@@ -374,7 +388,7 @@ def import_tracker_json(payload: bytes, filename: str) -> TrackerImportStats:
 
     dest.parent.mkdir(parents=True, exist_ok=True)
     existed = dest.exists()
-    dest.write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
+    _write_json_atomic(dest, state)
 
     if target == "snapshot" and kind is not None:
         _enforce_snapshot_retention(kind)

--- a/tests/test_editor_playlists.py
+++ b/tests/test_editor_playlists.py
@@ -142,4 +142,5 @@ def test_editor_ui_exposes_playlist_source() -> None:
     assert "/api/editor/playlists/endpoints" in js
     assert "payload.endpoint = state.snapshot" in js
     assert "state.playlistOriginalKeys" in js
-    assert 'state.source !== "state" && state.source !== "playlist"' in js
+    assert 'const SOURCES = ["state", "tracker", "playlist"];' in js
+    assert "state.source = normalizeSource(state.source);" in js

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -7,6 +7,7 @@ from services.playback_progress.service import (
     _record_group_keys,
     PlaybackProgressService,
 )
+import services.playback_progress.service as playback_service
 from services.playback_progress.adapters.trakt import _trakt_image_url
 
 
@@ -187,3 +188,56 @@ def test_trakt_image_urls_are_absolute():
     assert _trakt_image_url(path) == f"https://{path}"
     assert _trakt_image_url(f"//{path}") == f"https://{path}"
     assert _trakt_image_url(f"https://{path}") == f"https://{path}"
+
+
+def test_playback_progress_save_settings_stores_selection_timeout_and_ignores_unknown(monkeypatch):
+    cfg = {
+        "trakt": {
+            "access_token": "default-token",
+            "client_id": "client-id",
+            "instances": {"TRAKT-P01": {"access_token": "second-token"}},
+        }
+    }
+    saved = {}
+
+    monkeypatch.setattr(playback_service, "load_config", lambda: cfg)
+    monkeypatch.setattr(playback_service, "save_config", lambda next_cfg: saved.setdefault("cfg", next_cfg))
+
+    result = PlaybackProgressService().save_settings(
+        {
+            "provider_timeout_seconds": 19,
+            "profiles": [
+                {"provider": "trakt", "instance_id": "default", "included": True},
+                {"provider": "trakt", "instance_id": "TRAKT-P01", "included": False},
+                {"provider": "notaprovider", "instance_id": "default", "included": False},
+            ],
+        }
+    )
+
+    block = saved["cfg"]["playback_progress"]
+    assert result["ok"] is True
+    assert block["disabled_profiles"] == ["trakt:TRAKT-P01"]
+    assert block["provider_timeout_seconds"] == 19.0
+
+
+def test_playback_progress_settings_reports_disabled_profiles_and_clamped_timeout(monkeypatch):
+    cfg = {
+        "trakt": {
+            "access_token": "default-token",
+            "client_id": "client-id",
+            "instances": {"TRAKT-P01": {"access_token": "second-token"}},
+        },
+        "playback_progress": {
+            "disabled_profiles": ["trakt:TRAKT-P01"],
+            "provider_timeout_seconds": 999,
+        },
+    }
+
+    monkeypatch.setattr(playback_service, "load_config", lambda: cfg)
+
+    data = PlaybackProgressService().settings()
+    by_key = {row["key"]: row for row in data["profiles"]}
+
+    assert data["provider_timeout_seconds"] == 60.0
+    assert by_key["trakt:default"]["included"] is True
+    assert by_key["trakt:TRAKT-P01"]["included"] is False


### PR DESCRIPTION
# Pull request

## Change

Adds a Local Tracker workspace to the Editor, exposing CrossWatch's internal tracker without presenting it as an external provider.

Users can view their locally stored tracker data (Watchlist, History, Ratings, Progress), block imported items from future downstream syncs, add corrected manual items, and replace a watched episode, season, or movie in one action. 
Corrections are stored through the existing manual additions and blocks policy for provider CROSSWATCH

Also fixes the Analyzer so manual blocks created in the Editor are actually applied. `_manual_add_blocks()` now reads blocks from the correct feature node and resolves instance-scoped providers, so a blocked item is classified as manually blocked instead of a missing peer.

Rounds out the Editor with UX changes shared across sources: baseline rows are genuinely read-only with a block icon, the page shows 100 rows, and the table grid stretches to match the sidebar height.

## Why

The internal tracker had no editing surface, so users could not correct a mistaken local match or stop a bad item from propagating without touching raw files. Treating tracker files as an immutable baseline and layering corrections through the existing CROSSWATCH manual policy keeps corrections persistent across future provider syncs while leaving connected accounts untouched.

The Analyzer fix is required for the same policy to have any effect: blocks were being read from the wrong path, so they were silently ignored, including for per-profile providers.

## Testing

- test_editor_tracker.py
- test_editor_tracker_ui.py
- test_analyzer_manual_blocks.py
- test_editor_playlists.py

## Issue

NA