### PR TITLE
Add: Nuvio sync implementation

### DIFF
--- a/providers/sync/_mod_NUVIO.py
+++ b/providers/sync/_mod_NUVIO.py
@@ -19,12 +19,18 @@ from providers.auth._auth_NUVIO import (
     provider_block,
 )
 
+from ._mod_common import build_op_result
+from .nuvio import _history as feat_history
+from .nuvio import _progress as feat_progress
+from .nuvio import _watchlist as feat_watchlist
+from .nuvio._common import pull_library_rows, pull_watch_progress_rows, pull_watched_rows
+
 __VERSION__ = "0.1"
 __all__ = ["get_manifest", "NUVIOModule", "OPS"]
 
 
 def _features_flags() -> dict[str, bool]:
-    return {"watchlist": False, "ratings": False, "history": False, "progress": False, "playlists": False}
+    return {"watchlist": True, "ratings": False, "history": True, "progress": True, "playlists": False}
 
 
 def get_manifest() -> Mapping[str, Any]:
@@ -33,11 +39,40 @@ def get_manifest() -> Mapping[str, Any]:
         "label": "Nuvio",
         "version": __VERSION__,
         "type": "sync",
-        "bidirectional": False,
+        "bidirectional": True,
         "experimental": True,
         "features": _features_flags(),
         "requires": [],
-        "capabilities": {"bidirectional": False, "experimental": True},
+        "capabilities": {
+            "bidirectional": True,
+            "experimental": True,
+            "verify_after_write": True,
+            "provides_ids": True,
+            "index_semantics": "present",
+            "features": _features_flags(),
+            "progress": {
+                "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+                "upsert": True,
+                "remove": True,
+                "observed_deletes": True,
+                "requires_ids": ["imdb", "tmdb", "trakt"],
+                "requires_duration": True,
+            },
+            "history": {
+                "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+                "upsert": True,
+                "remove": True,
+                "observed_deletes": True,
+                "requires_ids": ["imdb", "tmdb", "trakt"],
+            },
+            "watchlist": {
+                "types": {"movies": True, "shows": True, "seasons": False, "episodes": False},
+                "upsert": True,
+                "remove": True,
+                "observed_deletes": True,
+                "requires_ids": ["imdb", "tmdb", "trakt"],
+            },
+        },
     }
 
 
@@ -76,6 +111,9 @@ class NUVIOModule:
                     status = "profile_unavailable"
                     reason = "profile_unavailable"
                 else:
+                    pull_watch_progress_rows(self, limit=1, max_pages=1)
+                    pull_watched_rows(self, page_size=1, max_pages=1)
+                    pull_library_rows(self, limit=1, max_pages=1)
                     ok = True
                     status = "ok"
         except NuvioTokenRefreshError:
@@ -103,8 +141,38 @@ class NUVIOModule:
             "latency_ms": latency_ms,
             "features": _features_flags(),
             "details": {"reason": reason} if reason else None,
-            "api": {"profiles": {"status": status}},
+            "api": {"profiles": {"status": status}, "progress": {"status": status}, "history": {"status": status}, "library": {"status": status}},
         }
+
+    def build_index(self, feature: str, **kwargs: Any) -> dict[str, dict[str, Any]]:
+        feature_name = str(feature or "").strip().lower()
+        if feature_name == "progress":
+            return feat_progress.build_index(self)
+        if feature_name == "history":
+            return feat_history.build_index(self)
+        if feature_name == "watchlist":
+            return feat_watchlist.build_index(self)
+        return {}
+
+    def add(self, feature: str, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+        feature_name = str(feature or "").strip().lower()
+        if feature_name == "progress":
+            return feat_progress.add(self, items, dry_run=dry_run)
+        if feature_name == "history":
+            return feat_history.add(self, items, dry_run=dry_run)
+        if feature_name == "watchlist":
+            return feat_watchlist.add(self, items, dry_run=dry_run)
+        return build_op_result(ok=True, count=0, unsupported=True)
+
+    def remove(self, feature: str, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+        feature_name = str(feature or "").strip().lower()
+        if feature_name == "progress":
+            return feat_progress.remove(self, items, dry_run=dry_run)
+        if feature_name == "history":
+            return feat_history.remove(self, items, dry_run=dry_run)
+        if feature_name == "watchlist":
+            return feat_watchlist.remove(self, items, dry_run=dry_run)
+        return build_op_result(ok=True, count=0, unsupported=True)
 
 
 class _NUVIOOPS:
@@ -133,13 +201,13 @@ class _NUVIOOPS:
         return self._adapter(cfg).health()
 
     def build_index(self, cfg: Mapping[str, Any], *, feature: str) -> Mapping[str, dict[str, Any]]:
-        return {}
+        return self._adapter(cfg).build_index(feature)
 
     def add(self, cfg: Mapping[str, Any], items: Iterable[Mapping[str, Any]], *, feature: str, dry_run: bool = False) -> dict[str, Any]:
-        return {"ok": False, "count": 0, "unresolved": list(items or []), "unsupported": True}
+        return self._adapter(cfg).add(feature, items, dry_run=dry_run)
 
     def remove(self, cfg: Mapping[str, Any], items: Iterable[Mapping[str, Any]], *, feature: str, dry_run: bool = False) -> dict[str, Any]:
-        return {"ok": False, "count": 0, "unresolved": list(items or []), "unsupported": True}
+        return self._adapter(cfg).remove(feature, items, dry_run=dry_run)
 
 
 OPS = _NUVIOOPS()

--- a/providers/sync/nuvio/__init__.py
+++ b/providers/sync/nuvio/__init__.py
@@ -1,0 +1,4 @@
+# providers/sync/nuvio/__init__.py
+# CrossWatch Nuvio sync package
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations

--- a/providers/sync/nuvio/_common.py
+++ b/providers/sync/nuvio/_common.py
@@ -1,0 +1,326 @@
+# providers/sync/nuvio/_common.py
+# CrossWatch Nuvio sync helpers
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import threading
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from cw_platform.id_map import canonical_key, ids_from, merge_ids, minimal as id_minimal
+
+from providers.auth._auth_NUVIO import (
+    NuvioAuthError,
+    NuvioClient,
+    NuvioError,
+    NuvioInvalidResponse,
+    NuvioProfileUnavailable,
+    NuvioServiceUnavailable,
+    NuvioTokenRefreshError,
+    is_configured as auth_is_configured,
+    profile_id_value,
+    provider_block,
+)
+
+__all__ = [
+    "EpisodeMapResult",
+    "NuvioAuthError",
+    "NuvioClient",
+    "NuvioError",
+    "NuvioInvalidResponse",
+    "NuvioProfileUnavailable",
+    "NuvioServiceUnavailable",
+    "NuvioTokenRefreshError",
+    "canonical_item_key",
+    "configured_block",
+    "content_id_for_item",
+    "content_id_key",
+    "epoch_ms",
+    "ids_for_content_id",
+    "is_configured",
+    "library_lock",
+    "make_item",
+    "positive_int",
+    "progress_key",
+    "pull_library_rows",
+    "pull_watch_progress_rows",
+    "pull_watched_rows",
+    "resolve_episode",
+    "rpc",
+    "selected_profile_id",
+    "to_int",
+]
+
+_LIBRARY_LOCKS: dict[str, threading.Lock] = {}
+_LIBRARY_LOCKS_GUARD = threading.Lock()
+
+
+@dataclass(frozen=True)
+class EpisodeMapResult:
+    ok: bool
+    reason: str
+    match_basis: str | None = None
+    content_id: str | None = None
+    video_id: str | None = None
+    source_season: int | None = None
+    source_episode: int | None = None
+    destination_season: int | None = None
+    destination_episode: int | None = None
+
+
+def configured_block(cfg: Mapping[str, Any] | None, instance_id: Any = "default") -> dict[str, Any]:
+    return provider_block(cfg or {}, instance_id)
+
+
+def is_configured(cfg: Mapping[str, Any] | None, instance_id: Any = "default") -> bool:
+    return auth_is_configured(configured_block(cfg, instance_id))
+
+
+def selected_profile_id(adapter: Any) -> int:
+    block = configured_block(getattr(adapter, "config", None) or getattr(adapter, "raw_cfg", None) or {}, getattr(adapter, "instance_id", "default"))
+    pid = profile_id_value(block)
+    if pid is None:
+        raise NuvioProfileUnavailable("nuvio_profile_unavailable")
+    return int(pid)
+
+
+def rpc(adapter: Any, name: str, payload: Mapping[str, Any] | None = None) -> Any:
+    client = getattr(adapter, "client", None)
+    if client is None:
+        raise NuvioServiceUnavailable("service_unavailable")
+    return client.request_json("POST", f"/rest/v1/rpc/{str(name).strip()}", payload=dict(payload or {}), refresh=True, retry=True)
+
+
+def to_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(float(str(value).strip()))
+    except Exception:
+        return None
+
+
+def positive_int(value: Any) -> int | None:
+    number = to_int(value)
+    return number if number is not None and number > 0 else None
+
+
+def epoch_ms(value: Any) -> int | None:
+    number = to_int(value)
+    if number is not None:
+        return number * 1000 if 0 < number < 10_000_000_000 else number
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        from datetime import datetime
+
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        return int(parsed.timestamp() * 1000)
+    except Exception:
+        return None
+
+
+def ids_for_content_id(content_id: Any) -> dict[str, str] | None:
+    raw = str(content_id or "").strip()
+    low = raw.lower()
+    if raw.startswith("tt") and raw[2:].isdigit():
+        return {"imdb": raw}
+    if low.startswith("tmdb:"):
+        value = raw.split(":", 1)[1].strip()
+        if value.isdigit():
+            return {"tmdb": value}
+    if low.startswith("trakt:"):
+        value = raw.split(":", 1)[1].strip()
+        if value.isdigit():
+            return {"trakt": value}
+    return None
+
+
+def content_id_for_item(item: Mapping[str, Any]) -> str | None:
+    raw = str(item.get("_nuvio_content_id") or item.get("content_id") or "").strip()
+    if raw and ids_for_content_id(raw):
+        return raw
+    item_type = str(item.get("type") or "").strip().lower()
+    show_ids_obj = item.get("show_ids")
+    if item_type in {"episode", "episodes", "season", "seasons"}:
+        if isinstance(show_ids_obj, Mapping):
+            raw_ids = merge_ids({str(k): v for k, v in show_ids_obj.items()}, {})
+        else:
+            return None
+    else:
+        raw_ids = merge_ids(ids_from(item), ids_from(id_minimal(item)))
+        if isinstance(show_ids_obj, Mapping):
+            raw_ids = merge_ids(raw_ids, {str(k): v for k, v in show_ids_obj.items()})
+    tmdb = str(raw_ids.get("tmdb") or "").strip()
+    if tmdb.isdigit():
+        return f"tmdb:{tmdb}"
+    imdb = str(raw_ids.get("imdb") or "").strip()
+    if imdb.startswith("tt") and imdb[2:].isdigit():
+        return imdb
+    trakt = str(raw_ids.get("trakt") or "").strip()
+    if trakt.isdigit():
+        return f"trakt:{trakt}"
+    return None
+
+
+def make_item(
+    *,
+    content_id: Any,
+    content_type: Any,
+    season: Any = None,
+    episode: Any = None,
+    title: Any = None,
+    year: Any = None,
+) -> dict[str, Any] | None:
+    ids = ids_for_content_id(content_id)
+    if not ids:
+        return None
+    ctype = str(content_type or "").strip().lower()
+    season_n = positive_int(season)
+    episode_n = positive_int(episode)
+    if ctype in {"series", "show", "tv"} and not (season_n and episode_n):
+        item = {"type": "show", "ids": dict(ids)}
+        if title:
+            item["title"] = str(title)
+        if year is not None:
+            item["year"] = year
+        return item
+
+    if ctype in {"episode"} or (season_n and episode_n):
+        if season_n is None or episode_n is None:
+            return None
+        item: dict[str, Any] = {
+            "type": "episode",
+            "show_ids": dict(ids),
+            "ids": dict(ids),
+            "season": season_n,
+            "episode": episode_n,
+        }
+        if title:
+            item["series_title"] = str(title)
+    else:
+        item = {"type": "movie", "ids": dict(ids)}
+        if title:
+            item["title"] = str(title)
+        if year is not None:
+            item["year"] = year
+    return item
+
+
+def canonical_item_key(item: Mapping[str, Any]) -> str:
+    return canonical_key(id_minimal(item))
+
+
+def content_id_key(item: Mapping[str, Any]) -> str:
+    content_id = content_id_for_item(item)
+    season = positive_int(item.get("season"))
+    episode = positive_int(item.get("episode"))
+    if content_id and season and episode:
+        return f"{content_id}:{season}:{episode}"
+    return str(content_id or "")
+
+
+def progress_key(item: Mapping[str, Any]) -> str | None:
+    direct = str(item.get("_nuvio_progress_key") or item.get("progress_key") or "").strip()
+    if direct:
+        return direct
+    content_id = content_id_for_item(item)
+    if not content_id:
+        return None
+    season = positive_int(item.get("season"))
+    episode = positive_int(item.get("episode"))
+    if season and episode:
+        return f"{content_id}_s{season}e{episode}"
+    return content_id
+
+
+def resolve_episode(adapter: Any, item: Mapping[str, Any], *, current_rows: Any = None) -> EpisodeMapResult:
+    content_id = content_id_for_item(item)
+    season = positive_int(item.get("season"))
+    episode = positive_int(item.get("episode"))
+    if not content_id:
+        return EpisodeMapResult(False, "nuvio_id_missing")
+    if not season or not episode:
+        return EpisodeMapResult(False, "nuvio_episode_not_found", content_id=content_id)
+
+    video_id = str(item.get("_nuvio_video_id") or item.get("video_id") or "").strip()
+    if video_id:
+        return EpisodeMapResult(True, "ok", "existing_video_id", content_id, video_id, season, episode, season, episode)
+
+    for row in current_rows or []:
+        if not isinstance(row, Mapping):
+            continue
+        if str(row.get("content_id") or "").strip() != content_id:
+            continue
+        if positive_int(row.get("season")) != season or positive_int(row.get("episode")) != episode:
+            continue
+        row_video = str(row.get("video_id") or "").strip()
+        if row_video:
+            return EpisodeMapResult(True, "ok", "existing_remote_identity", content_id, row_video, season, episode, season, episode)
+
+    return EpisodeMapResult(True, "ok", "canonical_episode_identifier", content_id, f"{content_id}:{season}:{episode}", season, episode, season, episode)
+
+
+def _rows(data: Any, reason: str) -> list[Mapping[str, Any]]:
+    if not isinstance(data, list):
+        raise NuvioInvalidResponse(reason)
+    return [row for row in data if isinstance(row, Mapping)]
+
+
+def pull_watch_progress_rows(adapter: Any, *, limit: int = 1000, max_pages: int = 1000) -> list[Mapping[str, Any]]:
+    pid = selected_profile_id(adapter)
+    per_page = max(1, min(int(limit or 1000), 1000))
+    pages = max(1, int(max_pages or 1000))
+    cursor = 0
+    out: list[Mapping[str, Any]] = []
+
+    for _ in range(pages):
+        data = rpc(adapter, "sync_pull_watch_progress", {"p_profile_id": pid, "p_since_last_watched": cursor, "p_limit": per_page})
+        rows = _rows(data, "nuvio_progress_invalid")
+        out.extend(rows)
+        if len(rows) < per_page:
+            break
+        next_cursor = max((epoch_ms(row.get("last_watched")) or cursor for row in rows), default=cursor)
+        if next_cursor <= cursor:
+            raise NuvioInvalidResponse("nuvio_progress_invalid")
+        cursor = next_cursor
+    return out
+
+
+def pull_watched_rows(adapter: Any, *, page_size: int = 900, max_pages: int = 1000) -> list[Mapping[str, Any]]:
+    pid = selected_profile_id(adapter)
+    size = max(1, min(int(page_size or 900), 1000))
+    out: list[Mapping[str, Any]] = []
+    for page in range(1, max(1, int(max_pages or 1000)) + 1):
+        data = rpc(adapter, "sync_pull_watched_items", {"p_profile_id": pid, "p_page": page, "p_page_size": size})
+        rows = _rows(data, "nuvio_history_invalid")
+        out.extend(rows)
+        if len(rows) < size:
+            break
+    return out
+
+
+def pull_library_rows(adapter: Any, *, limit: int = 500, max_pages: int = 1000) -> list[Mapping[str, Any]]:
+    pid = selected_profile_id(adapter)
+    size = max(1, min(int(limit or 500), 500))
+    out: list[Mapping[str, Any]] = []
+    for page in range(max(1, int(max_pages or 1000))):
+        offset = page * size
+        data = rpc(adapter, "sync_pull_library", {"p_profile_id": pid, "p_limit": size, "p_offset": offset})
+        rows = _rows(data, "nuvio_library_read_failed")
+        out.extend(rows)
+        if len(rows) < size:
+            break
+    return out
+
+
+def library_lock(adapter: Any) -> threading.Lock:
+    key = f"{getattr(adapter, 'instance_id', 'default')}:{selected_profile_id(adapter)}"
+    with _LIBRARY_LOCKS_GUARD:
+        lock = _LIBRARY_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _LIBRARY_LOCKS[key] = lock
+        return lock

--- a/providers/sync/nuvio/_history.py
+++ b/providers/sync/nuvio/_history.py
@@ -1,0 +1,241 @@
+# providers/sync/nuvio/_history.py
+# CrossWatch Nuvio history functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+
+from providers.sync._log import log as cw_log
+
+from ._common import (
+    canonical_item_key,
+    content_id_for_item,
+    epoch_ms,
+    make_item,
+    positive_int,
+    pull_watched_rows,
+    resolve_episode,
+    rpc,
+    selected_profile_id,
+)
+
+
+def _info(event: str, **fields: Any) -> None:
+    cw_log("NUVIO", "history", "info", event, **fields)
+
+
+def _warn(event: str, **fields: Any) -> None:
+    cw_log("NUVIO", "history", "warn", event, **fields)
+
+
+def _item_from_row(row: Mapping[str, Any]) -> tuple[str | None, dict[str, Any] | None, str | None]:
+    item = make_item(
+        content_id=row.get("content_id"),
+        content_type=row.get("content_type"),
+        season=row.get("season"),
+        episode=row.get("episode"),
+        title=row.get("title") or row.get("name"),
+        year=row.get("year"),
+    )
+    watched_at = epoch_ms(row.get("watched_at"))
+    if not item or watched_at is None:
+        return None, None, "nuvio_history_invalid"
+    item["watched"] = True
+    item["watched_at"] = int(watched_at)
+    item["_nuvio_content_id"] = str(row.get("content_id") or "").strip()
+    item["_nuvio_profile_id"] = row.get("profile_id")
+    key = canonical_item_key(item)
+    if not key or key == "unknown:":
+        return None, None, "nuvio_id_missing"
+    return key, item, None
+
+
+def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
+    rows = pull_watched_rows(adapter)
+    out: dict[str, dict[str, Any]] = {}
+    skipped = 0
+    for row in rows:
+        key, item, reason = _item_from_row(row)
+        if not key or not item:
+            if reason:
+                skipped += 1
+                _warn("row_skipped", reason=reason)
+            continue
+        existing = out.get(key)
+        if not existing or (epoch_ms(item.get("watched_at")) or 0) >= (epoch_ms(existing.get("watched_at")) or 0):
+            out[key] = item
+    _info("index_done", count=len(out), rows=len(rows), skipped=skipped)
+    return out
+
+
+def _payload_for_item(adapter: Any, item: Mapping[str, Any], current_rows: Any = None) -> tuple[dict[str, Any] | None, str | None]:
+    it = dict(item or {})
+    mini = id_minimal(it)
+    typ = str(mini.get("type") or it.get("type") or "").strip().lower()
+    content_id = content_id_for_item(it)
+    watched_at = epoch_ms(mini.get("watched_at") if isinstance(mini, Mapping) else None)
+    if watched_at is None:
+        watched_at = epoch_ms(it.get("watched_at") or it.get("last_watched_at") or it.get("lastWatchedAt"))
+    if not content_id:
+        return None, "nuvio_id_missing"
+    if watched_at is None:
+        return None, "nuvio_history_write_failed"
+
+    title = str(it.get("title") or it.get("series_title") or "").strip()
+    if typ in {"episode", "episodes"}:
+        resolved = resolve_episode(adapter, it, current_rows=current_rows)
+        if not resolved.ok:
+            return None, resolved.reason
+        return {
+            "content_id": resolved.content_id,
+            "content_type": "series",
+            "title": title,
+            "season": resolved.destination_season,
+            "episode": resolved.destination_episode,
+            "watched_at": int(watched_at),
+        }, None
+    if typ not in {"movie", "movies"}:
+        return None, "nuvio_id_missing"
+    return {"content_id": content_id, "content_type": "movie", "title": title, "watched_at": int(watched_at)}, None
+
+
+def _delete_key_for_item(item: Mapping[str, Any]) -> dict[str, Any] | None:
+    content_id = content_id_for_item(item)
+    if not content_id:
+        return None
+    key: dict[str, Any] = {"content_id": content_id}
+    season = positive_int(item.get("season"))
+    episode = positive_int(item.get("episode"))
+    if season and episode:
+        key["season"] = season
+        key["episode"] = episode
+    return key
+
+
+def _unresolved(item: Mapping[str, Any], reason: str) -> dict[str, Any]:
+    return {"status": "unresolved", "reason": reason, "item": id_minimal(item)}
+
+
+def _result(ok: bool, count: int, attempted: int, confirmed: list[str], unresolved: list[dict[str, Any]], results: list[dict[str, Any]], skipped: int, **extra: Any) -> dict[str, Any]:
+    out = {
+        "ok": bool(ok),
+        "count": int(count),
+        "attempted": int(attempted),
+        "confirmed_keys": list(dict.fromkeys(k for k in confirmed if k)),
+        "unresolved": unresolved,
+        "unresolved_keys": list(dict.fromkeys(canonical_key((u.get("item") or {}) if isinstance(u, Mapping) else {}) for u in unresolved)),
+        "results": results,
+        "skipped": int(skipped),
+        "errors": sum(1 for u in unresolved if str(u.get("status") or "") == "failed"),
+    }
+    out.update(extra)
+    return out
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    src = [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]
+    rows = pull_watched_rows(adapter)
+    current = build_index(adapter)
+    unresolved: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    payloads: list[dict[str, Any]] = []
+    keys: list[str] = []
+    pending_items: list[dict[str, Any]] = []
+    skipped = 0
+
+    for item in src:
+        key = canonical_item_key(item)
+        payload, reason = _payload_for_item(adapter, item, current_rows=rows)
+        if payload is None:
+            entry = _unresolved(item, reason or "nuvio_history_write_failed")
+            unresolved.append(entry)
+            results.append(entry)
+            continue
+        target = current.get(key)
+        if target and (epoch_ms(target.get("watched_at")) or 0) >= int(payload.get("watched_at") or 0):
+            skipped += 1
+            results.append({"status": "skipped", "reason": "history_unchanged", "item": id_minimal(item), "canonical_key": key})
+            continue
+        payloads.append(payload)
+        keys.append(key)
+        pending_items.append(item)
+        results.append({"status": "pending" if not dry_run else "dry_run", "item": id_minimal(item), "canonical_key": key})
+
+    if dry_run:
+        return _result(len(unresolved) == 0, len(payloads), len(payloads), [], unresolved, results, skipped, dry_run=True)
+
+    failed = False
+    if payloads:
+        try:
+            rpc(adapter, "sync_push_watched_items", {"p_profile_id": selected_profile_id(adapter), "p_items": payloads})
+        except Exception:
+            failed = True
+            for item, key in zip(pending_items, keys):
+                unresolved.append({"status": "failed", "reason": "nuvio_history_write_failed", "item": id_minimal(item), "canonical_key": key})
+
+    after = build_index(adapter) if payloads and not failed else current
+    confirmed: list[str] = []
+    for key in ([] if failed else keys):
+        if key in after:
+            confirmed.append(key)
+        else:
+            unresolved.append({"status": "failed", "reason": "nuvio_history_verification_failed", "canonical_key": key})
+
+    ok = len(unresolved) == 0
+    _info("write_done", op="add", ok=ok, attempted=len(payloads), confirmed=len(confirmed), skipped=skipped, unresolved=len(unresolved))
+    return _result(ok, len(confirmed), len(payloads), confirmed, unresolved, results, skipped)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    src = [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]
+    current = build_index(adapter)
+    unresolved: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    keys_payload: list[dict[str, Any]] = []
+    item_keys: list[str] = []
+    pending_items: list[dict[str, Any]] = []
+    skipped = 0
+
+    for item in src:
+        item_key = canonical_item_key(item)
+        payload = _delete_key_for_item(current.get(item_key) or item)
+        if not payload:
+            entry = _unresolved(item, "nuvio_id_missing")
+            unresolved.append(entry)
+            results.append(entry)
+            continue
+        if item_key and item_key not in current:
+            skipped += 1
+            results.append({"status": "skipped", "reason": "already_absent", "item": id_minimal(item), "canonical_key": item_key})
+            continue
+        keys_payload.append(payload)
+        item_keys.append(item_key)
+        pending_items.append(item)
+        results.append({"status": "pending" if not dry_run else "dry_run", "item": id_minimal(item), "canonical_key": item_key})
+
+    if dry_run:
+        return _result(len(unresolved) == 0, len(keys_payload), len(keys_payload), [], unresolved, results, skipped, dry_run=True)
+
+    failed = False
+    if keys_payload:
+        try:
+            rpc(adapter, "sync_delete_watched_items", {"p_profile_id": selected_profile_id(adapter), "p_keys": keys_payload})
+        except Exception:
+            failed = True
+            for item, key in zip(pending_items, item_keys):
+                unresolved.append({"status": "failed", "reason": "nuvio_history_write_failed", "item": id_minimal(item), "canonical_key": key})
+
+    after = build_index(adapter) if keys_payload and not failed else current
+    confirmed: list[str] = []
+    for key in ([] if failed else item_keys):
+        if key and key not in after:
+            confirmed.append(key)
+        elif key:
+            unresolved.append({"status": "failed", "reason": "nuvio_history_verification_failed", "canonical_key": key})
+
+    ok = len(unresolved) == 0
+    _info("write_done", op="remove", ok=ok, attempted=len(keys_payload), confirmed=len(confirmed), skipped=skipped, unresolved=len(unresolved))
+    return _result(ok, len(confirmed), len(keys_payload), confirmed, unresolved, results, skipped)

--- a/providers/sync/nuvio/_progress.py
+++ b/providers/sync/nuvio/_progress.py
@@ -1,0 +1,328 @@
+# providers/sync/nuvio/_progress.py
+# CrossWatch Nuvio progress functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+
+from providers.sync._log import log as cw_log
+from providers.sync._progress_policy import decide_progress_write, progress_materially_equal, select_progress_record
+
+from ._common import (
+    canonical_item_key,
+    content_id_for_item,
+    epoch_ms,
+    make_item,
+    positive_int,
+    progress_key,
+    pull_watch_progress_rows,
+    resolve_episode,
+    rpc,
+    selected_profile_id,
+    to_int,
+)
+
+
+def _info(event: str, **fields: Any) -> None:
+    cw_log("NUVIO", "progress", "info", event, **fields)
+
+
+def _warn(event: str, **fields: Any) -> None:
+    cw_log("NUVIO", "progress", "warn", event, **fields)
+
+
+def _progress_percent(position: int, duration: int) -> float | None:
+    if position < 0 or duration <= 0:
+        return None
+    return round((float(position) / float(duration)) * 100.0, 3)
+
+
+def _progress_ms(item: Mapping[str, Any]) -> int | None:
+    for key in ("progress_ms", "progressMs", "position", "position_ms", "positionMs", "viewOffset", "progress"):
+        number = to_int(item.get(key))
+        if number is not None:
+            return number
+    return None
+
+
+def _duration_ms(item: Mapping[str, Any]) -> int | None:
+    for key in ("duration_ms", "durationMs", "duration", "runtime_ms", "runtimeMs"):
+        number = positive_int(item.get(key))
+        if number is not None:
+            return number
+    return None
+
+
+def _item_from_row(row: Mapping[str, Any]) -> tuple[str | None, dict[str, Any] | None, str | None]:
+    base = make_item(
+        content_id=row.get("content_id"),
+        content_type=row.get("content_type"),
+        season=row.get("season"),
+        episode=row.get("episode"),
+        title=row.get("title") or row.get("name"),
+        year=row.get("year"),
+    )
+    position = to_int(row.get("position"))
+    duration = positive_int(row.get("duration"))
+    last_watched = epoch_ms(row.get("last_watched"))
+    video_id = str(row.get("video_id") or "").strip()
+    content_id = str(row.get("content_id") or "").strip()
+    if not base or position is None or position < 0 or duration is None or last_watched is None or not video_id:
+        return None, None, "nuvio_progress_invalid"
+
+    item = dict(base)
+    item.update(
+        {
+            "progress_ms": int(position),
+            "duration_ms": int(duration),
+            "progress_at": int(last_watched),
+            "progress_percent": _progress_percent(int(position), int(duration)),
+            "progress_key": str(row.get("progress_key") or progress_key(item) or "").strip(),
+            "_nuvio_content_id": content_id,
+            "_nuvio_video_id": video_id,
+            "_nuvio_profile_id": row.get("profile_id"),
+            "_nuvio_last_watched": int(last_watched),
+        }
+    )
+    key = canonical_item_key(item)
+    if not key or key == "unknown:":
+        return None, None, "nuvio_id_missing"
+    return key, item, None
+
+
+def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
+    rows = pull_watch_progress_rows(adapter)
+    out: dict[str, dict[str, Any]] = {}
+    skipped = 0
+    for row in rows:
+        key, item, reason = _item_from_row(row)
+        if not key or not item:
+            if reason:
+                skipped += 1
+                _warn("row_skipped", reason=reason)
+            continue
+        chosen, _action = select_progress_record(out.get(key), item)
+        out[key] = chosen
+    _info("index_done", count=len(out), rows=len(rows), skipped=skipped)
+    return out
+
+
+def _payload_for_item(adapter: Any, item: Mapping[str, Any], current_rows: Any = None) -> tuple[dict[str, Any] | None, str | None]:
+    it = dict(item or {})
+    mini = id_minimal(it)
+    typ = str(mini.get("type") or it.get("type") or "").strip().lower()
+    content_id = content_id_for_item(it)
+    if not content_id:
+        return None, "nuvio_id_missing"
+
+    position = _progress_ms(mini) if isinstance(mini, Mapping) else None
+    if position is None:
+        position = _progress_ms(it)
+    if position is None or position < 0:
+        return None, "nuvio_progress_invalid"
+
+    duration = _duration_ms(mini) if isinstance(mini, Mapping) else None
+    if duration is None:
+        duration = _duration_ms(it)
+    if duration is None:
+        return None, "nuvio_duration_missing"
+
+    last_watched = epoch_ms(mini.get("progress_at") if isinstance(mini, Mapping) else None)
+    if last_watched is None:
+        last_watched = epoch_ms(it.get("progress_at") or it.get("last_watched") or it.get("lastViewedAt") or it.get("last_played"))
+    if last_watched is None:
+        return None, "nuvio_progress_invalid"
+
+    if typ in {"episode", "episodes"}:
+        resolved = resolve_episode(adapter, it, current_rows=current_rows)
+        if not resolved.ok:
+            return None, resolved.reason
+        return {
+            "content_id": resolved.content_id,
+            "content_type": "series",
+            "video_id": resolved.video_id,
+            "season": resolved.destination_season,
+            "episode": resolved.destination_episode,
+            "position": int(position),
+            "duration": int(duration),
+            "last_watched": int(last_watched),
+        }, None
+
+    if typ not in {"movie", "movies"}:
+        return None, "nuvio_id_missing"
+
+    return {
+        "content_id": content_id,
+        "content_type": "movie",
+        "video_id": content_id,
+        "season": None,
+        "episode": None,
+        "position": int(position),
+        "duration": int(duration),
+        "last_watched": int(last_watched),
+    }, None
+
+
+def _unresolved(item: Mapping[str, Any], reason: str) -> dict[str, Any]:
+    return {"status": "unresolved", "reason": reason, "item": id_minimal(item)}
+
+
+def _confirmed_after_write(after: Mapping[str, Mapping[str, Any]], key: str, payload: Mapping[str, Any]) -> bool:
+    row = after.get(key)
+    return bool(
+        isinstance(row, Mapping)
+        and progress_materially_equal(payload.get("position"), payload.get("duration"), row.get("progress_ms"), row.get("duration_ms"))
+        and (epoch_ms(row.get("progress_at")) or 0) >= (epoch_ms(payload.get("last_watched")) or 0)
+    )
+
+
+def _result(ok: bool, count: int, attempted: int, confirmed: list[str], unresolved: list[dict[str, Any]], results: list[dict[str, Any]], skipped: int, **extra: Any) -> dict[str, Any]:
+    out = {
+        "ok": bool(ok),
+        "count": int(count),
+        "attempted": int(attempted),
+        "confirmed_keys": list(dict.fromkeys(k for k in confirmed if k)),
+        "unresolved": unresolved,
+        "unresolved_keys": list(dict.fromkeys(canonical_key((u.get("item") or {}) if isinstance(u, Mapping) else {}) for u in unresolved)),
+        "results": results,
+        "skipped": int(skipped),
+        "errors": sum(1 for u in unresolved if str(u.get("status") or "") == "failed"),
+    }
+    out.update(extra)
+    return out
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    src = [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]
+    rows = pull_watch_progress_rows(adapter)
+    current: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        key, item, _reason = _item_from_row(row)
+        if key and item:
+            current[key] = item
+
+    unresolved: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    entries: list[dict[str, Any]] = []
+    keys: list[str] = []
+    pending_items: list[dict[str, Any]] = []
+    skipped = 0
+
+    for item in src:
+        key = canonical_item_key(item)
+        payload, reason = _payload_for_item(adapter, item, current_rows=rows)
+        if payload is None:
+            entry = _unresolved(item, reason or "nuvio_progress_invalid")
+            unresolved.append(entry)
+            results.append(entry)
+            continue
+        target = current.get(key)
+        decision = decide_progress_write(
+            active_session=False,
+            source_timestamp=payload.get("last_watched"),
+            target_timestamp=(target or {}).get("progress_at") if isinstance(target, Mapping) else None,
+            source_progress_ms=payload.get("position"),
+            source_duration_ms=payload.get("duration"),
+            target_progress_ms=(target or {}).get("progress_ms") if isinstance(target, Mapping) else None,
+            target_duration_ms=(target or {}).get("duration_ms") if isinstance(target, Mapping) else None,
+            target_watched=False,
+            same_origin=False,
+            replay_enabled=True,
+        )
+        if not decision.apply:
+            skipped += 1
+            results.append({"status": "skipped", "reason": decision.reason, "item": id_minimal(item), "canonical_key": key})
+            continue
+        entries.append(payload)
+        keys.append(key)
+        pending_items.append(item)
+        results.append({"status": "pending" if not dry_run else "dry_run", "item": id_minimal(item), "canonical_key": key})
+
+    if dry_run:
+        return _result(len(unresolved) == 0, len(entries), len(entries), [], unresolved, results, skipped, dry_run=True)
+
+    write_failed = False
+    if entries:
+        try:
+            rpc(adapter, "sync_push_watch_progress", {"p_profile_id": selected_profile_id(adapter), "p_entries": entries})
+        except Exception:
+            write_failed = True
+            for item, key in zip(pending_items, keys):
+                unresolved.append({"status": "failed", "reason": "nuvio_progress_write_failed", "item": id_minimal(item), "canonical_key": key})
+
+    after = build_index(adapter) if entries and not write_failed else current
+    confirmed: list[str] = []
+    for key, payload in ([] if write_failed else zip(keys, entries)):
+        if _confirmed_after_write(after, key, payload):
+            confirmed.append(key)
+        else:
+            unresolved.append({"status": "failed", "reason": "nuvio_progress_verification_failed", "canonical_key": key, "item": dict(after.get(key) or {})})
+
+    ok = len(unresolved) == 0
+    _info("write_done", op="add", ok=ok, attempted=len(entries), confirmed=len(confirmed), skipped=skipped, unresolved=len(unresolved))
+    return _result(ok, len(confirmed), len(entries), confirmed, unresolved, results, skipped)
+
+
+def _remote_key_for_item(current: Mapping[str, Mapping[str, Any]], item: Mapping[str, Any]) -> tuple[str | None, str | None]:
+    item_key = canonical_item_key(item)
+    row = current.get(item_key)
+    if isinstance(row, Mapping):
+        remote = progress_key(row)
+        if remote:
+            return remote, item_key
+    remote = progress_key(item)
+    return remote, item_key
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    src = [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]
+    current = build_index(adapter)
+    unresolved: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    remote_keys: list[str] = []
+    item_keys: list[str] = []
+    pending_items: list[dict[str, Any]] = []
+    skipped = 0
+
+    for item in src:
+        remote_key, item_key = _remote_key_for_item(current, item)
+        if not remote_key:
+            entry = _unresolved(item, "nuvio_video_id_missing")
+            unresolved.append(entry)
+            results.append(entry)
+            continue
+        if item_key and item_key not in current:
+            skipped += 1
+            results.append({"status": "skipped", "reason": "already_absent", "item": id_minimal(item), "canonical_key": item_key})
+            continue
+        remote_keys.append(remote_key)
+        item_keys.append(item_key or "")
+        pending_items.append(item)
+        results.append({"status": "pending" if not dry_run else "dry_run", "item": id_minimal(item), "canonical_key": item_key})
+
+    if dry_run:
+        return _result(len(unresolved) == 0, len(remote_keys), len(remote_keys), [], unresolved, results, skipped, dry_run=True)
+
+    delete_failed = False
+    if remote_keys:
+        try:
+            rpc(adapter, "sync_delete_watch_progress", {"p_profile_id": selected_profile_id(adapter), "p_keys": remote_keys})
+        except Exception:
+            delete_failed = True
+            for item, key in zip(pending_items, item_keys):
+                unresolved.append({"status": "failed", "reason": "nuvio_progress_delete_failed", "item": id_minimal(item), "canonical_key": key})
+
+    after = build_index(adapter) if remote_keys and not delete_failed else current
+    confirmed: list[str] = []
+    for item_key in ([] if delete_failed else item_keys):
+        if item_key and item_key not in after:
+            confirmed.append(item_key)
+        elif item_key:
+            unresolved.append({"status": "failed", "reason": "nuvio_progress_verification_failed", "canonical_key": item_key, "item": dict(after.get(item_key) or {})})
+
+    ok = len(unresolved) == 0
+    _info("write_done", op="remove", ok=ok, attempted=len(remote_keys), confirmed=len(confirmed), skipped=skipped, unresolved=len(unresolved))
+    return _result(ok, len(confirmed), len(remote_keys), confirmed, unresolved, results, skipped)

--- a/providers/sync/nuvio/_watchlist.py
+++ b/providers/sync/nuvio/_watchlist.py
@@ -1,0 +1,356 @@
+# providers/sync/nuvio/_watchlist.py
+# CrossWatch Nuvio Library watchlist functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from cw_platform.id_map import canonical_key, ids_from, minimal as id_minimal
+
+from providers.sync._log import log as cw_log
+
+from ._common import canonical_item_key, content_id_for_item, epoch_ms, library_lock, make_item, pull_library_rows, rpc, selected_profile_id
+
+_METADATA_FIELDS = (
+    "name",
+    "poster",
+    "poster_shape",
+    "background",
+    "description",
+    "release_info",
+    "imdb_rating",
+    "genres",
+    "addon_base_url",
+    "added_at",
+)
+
+
+def _info(event: str, **fields: Any) -> None:
+    cw_log("NUVIO", "watchlist", "info", event, **fields)
+
+
+def _warn(event: str, **fields: Any) -> None:
+    cw_log("NUVIO", "watchlist", "warn", event, **fields)
+
+
+def _item_from_row(row: Mapping[str, Any]) -> tuple[str | None, dict[str, Any] | None, str | None]:
+    ctype = str(row.get("content_type") or "").strip().lower()
+    if ctype not in {"movie", "series", "show"}:
+        return None, None, "nuvio_id_missing"
+    item = make_item(content_id=row.get("content_id"), content_type="series" if ctype in {"series", "show"} else "movie", title=row.get("name") or row.get("title"), year=row.get("release_info"))
+    if not item:
+        return None, None, "nuvio_id_missing"
+    if item.get("type") == "episode":
+        return None, None, "nuvio_id_missing"
+    if ctype in {"series", "show"}:
+        item["type"] = "show"
+        item.pop("season", None)
+        item.pop("episode", None)
+    item["_nuvio_content_id"] = str(row.get("content_id") or "").strip()
+    item["_nuvio_profile_id"] = row.get("profile_id")
+    for field in _METADATA_FIELDS:
+        if field in row:
+            item[f"_nuvio_{field}"] = row.get(field)
+    key = canonical_item_key(item)
+    if not key or key == "unknown:":
+        return None, None, "nuvio_id_missing"
+    return key, item, None
+
+
+def _remote_for_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for field in _METADATA_FIELDS:
+        value = row.get(field)
+        if value not in (None, ""):
+            out[field] = value
+    out["content_id"] = str(row.get("content_id") or "").strip()
+    out["content_type"] = str(row.get("content_type") or "movie").strip().lower() or "movie"
+    if not out.get("name"):
+        out["name"] = str(row.get("title") or "Untitled").strip() or "Untitled"
+    out["poster_shape"] = str(out.get("poster_shape") or "POSTER").strip().upper() or "POSTER"
+    if not isinstance(out.get("genres"), list):
+        out["genres"] = []
+    return out
+
+
+def _tmdb_metadata_api_key(adapter: Any) -> str:
+    cfg = getattr(adapter, "config", {}) or {}
+    if not isinstance(cfg, Mapping):
+        return ""
+    tmdb_obj = cfg.get("tmdb")
+    tmdb: Mapping[str, Any] = tmdb_obj if isinstance(tmdb_obj, Mapping) else {}
+    metadata_obj = cfg.get("metadata")
+    metadata: Mapping[str, Any] = metadata_obj if isinstance(metadata_obj, Mapping) else {}
+    return str(tmdb.get("api_key") or metadata.get("tmdb_api_key") or "").strip()
+
+
+def _tmdb_metadata_locale(adapter: Any) -> str:
+    cfg = getattr(adapter, "config", {}) or {}
+    if not isinstance(cfg, Mapping):
+        return "en-US"
+    metadata_obj = cfg.get("metadata")
+    metadata: Mapping[str, Any] = metadata_obj if isinstance(metadata_obj, Mapping) else {}
+    ui_obj = cfg.get("ui")
+    ui: Mapping[str, Any] = ui_obj if isinstance(ui_obj, Mapping) else {}
+    return str(metadata.get("locale") or ui.get("locale") or "en-US").strip() or "en-US"
+
+
+def _image_url(meta: Mapping[str, Any], kind: str) -> str:
+    images_obj = meta.get("images")
+    images: Mapping[str, Any] = images_obj if isinstance(images_obj, Mapping) else {}
+    rows = images.get(kind)
+    if not isinstance(rows, list):
+        return ""
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        url = str(row.get("url") or "").strip()
+        if url:
+            return url
+    return ""
+
+
+def _tmdb_enrichment(adapter: Any, item: Mapping[str, Any], *, content_id: str, content_type: str) -> dict[str, Any]:
+    if not content_id.startswith("tmdb:"):
+        return {}
+    tmdb_id = content_id.split(":", 1)[1].strip()
+    if not tmdb_id.isdigit():
+        return {}
+    api_key = _tmdb_metadata_api_key(adapter)
+    if not api_key:
+        return {}
+
+    locale = _tmdb_metadata_locale(adapter)
+    ids = ids_from(item)
+    try:
+        from api.metaAPI import get_meta
+
+        data = get_meta(
+            api_key,
+            "tv" if content_type == "series" else "movie",
+            tmdb_id,
+            ".cache",
+            need={
+                "title": True,
+                "year": True,
+                "overview": True,
+                "genres": True,
+                "poster": True,
+                "backdrop": True,
+            },
+            locale=locale,
+            title=str(item.get("title") or item.get("series_title") or item.get("name") or "").strip() or None,
+            year=item.get("year") or item.get("series_year"),
+            imdb_id=ids.get("imdb"),
+            tvdb_id=ids.get("tvdb"),
+        )
+    except Exception as exc:
+        _warn("tmdb_enrichment_failed", error_type=exc.__class__.__name__)
+        return {}
+    if not isinstance(data, Mapping):
+        return {}
+
+    out: dict[str, Any] = {}
+    title = data.get("title")
+    if title:
+        out["name"] = str(title)
+    poster = _image_url(data, "poster")
+    if poster:
+        out["poster"] = poster
+    backdrop = _image_url(data, "backdrop")
+    if backdrop:
+        out["background"] = backdrop
+    overview = str(data.get("overview") or "").strip()
+    if overview:
+        out["description"] = overview
+    year = data.get("year")
+    if year not in (None, ""):
+        out["release_info"] = str(year)
+    genres = [str(g) for g in (data.get("genres") or []) if str(g or "").strip()]
+    if genres:
+        out["genres"] = genres
+    return out
+
+
+def _remote_for_item(adapter: Any, item: Mapping[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    content_id = content_id_for_item(item)
+    if not content_id:
+        return None, "nuvio_id_missing"
+    typ = str(item.get("type") or "").strip().lower()
+    if typ in {"episode", "season"}:
+        return None, "nuvio_id_missing"
+    content_type = "series" if typ in {"show", "series", "tv"} else "movie"
+    title = str(item.get("title") or item.get("series_title") or item.get("name") or "Untitled").strip() or "Untitled"
+    out: dict[str, Any] = {
+        "content_id": content_id,
+        "content_type": content_type,
+        "name": title,
+        "poster_shape": "POSTER",
+        "genres": [],
+    }
+    year = item.get("year") or item.get("series_year")
+    if year not in (None, ""):
+        out["release_info"] = str(year)
+    added_at = epoch_ms(item.get("listed_at") or item.get("added_at") or item.get("watched_at"))
+    if added_at is not None:
+        out["added_at"] = int(added_at)
+    enriched = _tmdb_enrichment(adapter, item, content_id=content_id, content_type=content_type)
+    for key, value in enriched.items():
+        if out.get(key) in (None, "", []) and value not in (None, "", []):
+            out[key] = value
+    return out, None
+
+
+def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
+    rows = pull_library_rows(adapter)
+    out: dict[str, dict[str, Any]] = {}
+    skipped = 0
+    for row in rows:
+        key, item, reason = _item_from_row(row)
+        if not key or not item:
+            if reason:
+                skipped += 1
+                _warn("row_skipped", reason=reason)
+            continue
+        out[key] = item
+    _info("index_done", count=len(out), rows=len(rows), skipped=skipped)
+    return out
+
+
+def _pull_remote_by_key(adapter: Any) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    rows = pull_library_rows(adapter)
+    items: dict[str, dict[str, Any]] = {}
+    remote: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        key, item, _reason = _item_from_row(row)
+        if key and item:
+            items[key] = item
+            remote[key] = _remote_for_row(row)
+    return items, remote
+
+
+def _merge_metadata(existing: Mapping[str, Any] | None, incoming: Mapping[str, Any]) -> dict[str, Any]:
+    out = dict(existing or {})
+    for key, value in incoming.items():
+        if key in {"content_id", "content_type"}:
+            out[key] = value
+            continue
+        if out.get(key) in (None, "", []) and value not in (None, "", []):
+            out[key] = value
+    if not out.get("name"):
+        out["name"] = "Untitled"
+    if not out.get("poster_shape"):
+        out["poster_shape"] = "POSTER"
+    if not isinstance(out.get("genres"), list):
+        out["genres"] = []
+    return out
+
+
+def _result(ok: bool, count: int, attempted: int, confirmed: list[str], unresolved: list[dict[str, Any]], results: list[dict[str, Any]], skipped: int, **extra: Any) -> dict[str, Any]:
+    out = {
+        "ok": bool(ok),
+        "count": int(count),
+        "attempted": int(attempted),
+        "confirmed_keys": list(dict.fromkeys(k for k in confirmed if k)),
+        "unresolved": unresolved,
+        "unresolved_keys": list(dict.fromkeys(canonical_key((u.get("item") or {}) if isinstance(u, Mapping) else {}) for u in unresolved)),
+        "results": results,
+        "skipped": int(skipped),
+        "errors": sum(1 for u in unresolved if str(u.get("status") or "") == "failed"),
+    }
+    out.update(extra)
+    return out
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    src = [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]
+    with library_lock(adapter):
+        current, remote = _pull_remote_by_key(adapter)
+        unresolved: list[dict[str, Any]] = []
+        results: list[dict[str, Any]] = []
+        changed = False
+        attempted = 0
+        pending_keys: list[str] = []
+        pending_items: list[dict[str, Any]] = []
+
+        for item in src:
+            key = canonical_item_key(item)
+            payload, reason = _remote_for_item(adapter, item)
+            if payload is None:
+                entry = {"status": "unresolved", "reason": reason or "nuvio_id_missing", "item": id_minimal(item)}
+                unresolved.append(entry)
+                results.append(entry)
+                continue
+            attempted += 1
+            existing = remote.get(key)
+            merged = _merge_metadata(existing, payload)
+            if existing != merged:
+                remote[key] = merged
+                changed = True
+            pending_keys.append(key)
+            pending_items.append(item)
+            results.append({"status": "pending" if not dry_run else "dry_run", "item": id_minimal(item), "canonical_key": key})
+
+        if dry_run:
+            return _result(len(unresolved) == 0, attempted, attempted, [], unresolved, results, 0, dry_run=True)
+        if changed:
+            try:
+                rpc(adapter, "sync_push_library", {"p_profile_id": selected_profile_id(adapter), "p_items": list(remote.values())})
+            except Exception:
+                return _result(False, 0, attempted, [], [{"status": "failed", "reason": "nuvio_library_replace_failed"}], results, 0)
+
+        after = build_index(adapter)
+        confirmed = [key for key in pending_keys if key in after]
+        unresolved.extend({"status": "failed", "reason": "nuvio_library_verification_failed", "item": id_minimal(item), "canonical_key": key} for item, key in zip(pending_items, pending_keys) if key not in after)
+        ok = len(unresolved) == 0
+        _info("write_done", op="add", ok=ok, attempted=attempted, confirmed=len(confirmed), unresolved=len(unresolved))
+        return _result(ok, len(confirmed), attempted, confirmed, unresolved, results, 0)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    src = [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]
+    with library_lock(adapter):
+        current, remote = _pull_remote_by_key(adapter)
+        unresolved: list[dict[str, Any]] = []
+        results: list[dict[str, Any]] = []
+        attempted = 0
+        skipped = 0
+        pending_keys: list[str] = []
+        pending_items: list[dict[str, Any]] = []
+
+        for item in src:
+            key = canonical_item_key(item)
+            if not key or key == "unknown:":
+                entry = {"status": "unresolved", "reason": "nuvio_id_missing", "item": id_minimal(item)}
+                unresolved.append(entry)
+                results.append(entry)
+                continue
+            if key not in remote:
+                skipped += 1
+                results.append({"status": "skipped", "reason": "already_absent", "item": id_minimal(item), "canonical_key": key})
+                continue
+            attempted += 1
+            remote.pop(key, None)
+            pending_keys.append(key)
+            pending_items.append(item)
+            results.append({"status": "pending" if not dry_run else "dry_run", "item": id_minimal(item), "canonical_key": key})
+
+        if dry_run:
+            return _result(len(unresolved) == 0, attempted, attempted, [], unresolved, results, skipped, dry_run=True)
+        if attempted:
+            try:
+                rpc(adapter, "sync_push_library", {"p_profile_id": selected_profile_id(adapter), "p_items": list(remote.values())})
+            except Exception:
+                return _result(False, 0, attempted, [], [{"status": "failed", "reason": "nuvio_library_replace_failed"}], results, skipped)
+
+        after = build_index(adapter)
+        confirmed: list[str] = []
+        for item, key in zip(pending_items, pending_keys):
+            if key and key not in after:
+                confirmed.append(key)
+            elif key in current:
+                unresolved.append({"status": "failed", "reason": "nuvio_library_verification_failed", "item": id_minimal(item), "canonical_key": key})
+        ok = len(unresolved) == 0
+        _info("write_done", op="remove", ok=ok, attempted=attempted, confirmed=len(confirmed), skipped=skipped, unresolved=len(unresolved))
+        return _result(ok, len(confirmed), attempted, confirmed, unresolved, results, skipped)

--- a/providers/tests/test_nuvio_history.py
+++ b/providers/tests/test_nuvio_history.py
@@ -1,0 +1,117 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+class FakeClient:
+    def __init__(self, rows: list[dict[str, Any]] | None = None):
+        self.rows = list(rows or [])
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def request_json(self, method: str, path: str, *, payload: Mapping[str, Any] | None = None, **_: Any) -> Any:
+        body = dict(payload or {})
+        name = path.rsplit("/", 1)[-1]
+        self.calls.append((name, body))
+        if name == "sync_pull_watched_items":
+            page = int(body.get("p_page") or 1)
+            size = int(body.get("p_page_size") or 900)
+            start = (page - 1) * size
+            return self.rows[start : start + size]
+        if name == "sync_push_watched_items":
+            for entry in body.get("p_items") or []:
+                row = dict(entry)
+                row["profile_id"] = body.get("p_profile_id")
+                self.rows.append(row)
+            return {}
+        if name == "sync_delete_watched_items":
+            keys = body.get("p_keys") or []
+            for key in keys:
+                if not isinstance(key, Mapping):
+                    continue
+                self.rows = [
+                    row
+                    for row in self.rows
+                    if not (
+                        row.get("content_id") == key.get("content_id")
+                        and row.get("season") == key.get("season")
+                        and row.get("episode") == key.get("episode")
+                    )
+                ]
+            return {}
+        return {}
+
+
+class FakeAdapter:
+    def __init__(self, rows: list[dict[str, Any]] | None = None):
+        self.config = {"nuvio": {"base_url": "https://api.nuvio.tv", "refresh_token": "refresh", "profile_id": 1}}
+        self.instance_id = "default"
+        self.client = FakeClient(rows)
+
+
+def test_history_reads_and_deletes_episode_with_official_key_shape() -> None:
+    from providers.sync.nuvio import _history
+
+    adapter = FakeAdapter(
+        [
+            {
+                "profile_id": 1,
+                "content_id": "tmdb:1396",
+                "content_type": "series",
+                "title": "Breaking Bad",
+                "season": 1,
+                "episode": 1,
+                "watched_at": 1_785_000_000_000,
+            }
+        ]
+    )
+
+    index = _history.build_index(adapter)
+    assert list(index) == ["tmdb:1396#s01e01"]
+
+    result = _history.remove(adapter, [{"type": "episode", "show_ids": {"tmdb": "1396"}, "season": 1, "episode": 1}])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tmdb:1396#s01e01"]
+    delete = [body for name, body in adapter.client.calls if name == "sync_delete_watched_items"][0]
+    assert delete["p_keys"] == [{"content_id": "tmdb:1396", "season": 1, "episode": 1}]
+
+
+def test_history_adds_movie_and_verifies() -> None:
+    from providers.sync.nuvio import _history
+
+    adapter = FakeAdapter([])
+    result = _history.add(adapter, [{"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club", "watched_at": 1_785_000_000_000}])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["imdb:tt0137523"]
+    push = [body for name, body in adapter.client.calls if name == "sync_push_watched_items"][0]
+    assert push["p_items"][0]["content_id"] == "tt0137523"
+    assert push["p_items"][0]["content_type"] == "movie"
+
+
+def test_history_adds_episode_with_show_tmdb_id_not_episode_tmdb_id() -> None:
+    from providers.sync.nuvio import _history
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "episode",
+        "ids": {"tmdb": "5978363", "imdb": "tt35707151"},
+        "show_ids": {"tmdb": "69478"},
+        "series_title": "The Boys",
+        "season": 6,
+        "episode": 2,
+        "watched_at": 1_785_000_000_000,
+    }
+
+    result = _history.add(adapter, [item])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tmdb:69478#s06e02"]
+    push = [body for name, body in adapter.client.calls if name == "sync_push_watched_items"][0]
+    row = push["p_items"][0]
+    assert row["content_id"] == "tmdb:69478"
+    assert row["content_type"] == "series"
+    assert row["season"] == 6
+    assert row["episode"] == 2

--- a/providers/tests/test_nuvio_module.py
+++ b/providers/tests/test_nuvio_module.py
@@ -19,20 +19,26 @@ def _cfg(profile_id: int = 1) -> dict[str, Any]:
     }
 
 
-def test_nuvio_ops_and_manifest_keep_all_sync_features_disabled() -> None:
+def test_nuvio_ops_and_manifest_enable_supported_sync_features() -> None:
     import sync._mod_NUVIO as mod
 
     manifest = mod.get_manifest()
+    expected = {"watchlist": True, "ratings": False, "history": True, "progress": True, "playlists": False}
 
     assert manifest["name"] == "NUVIO"
     assert manifest["label"] == "Nuvio"
     assert manifest["type"] == "sync"
-    assert manifest["bidirectional"] is False
+    assert manifest["bidirectional"] is True
     assert manifest["experimental"] is True
-    assert manifest["features"] == {"watchlist": False, "ratings": False, "history": False, "progress": False, "playlists": False}
+    assert manifest["features"] == expected
     assert mod.OPS.features() == manifest["features"]
     assert mod.OPS.state_read_features() == manifest["features"]
-    assert mod.OPS.capabilities()["bidirectional"] is False
+    assert mod.OPS.capabilities()["bidirectional"] is True
+    assert mod.OPS.capabilities()["verify_after_write"] is True
+    assert mod.OPS.capabilities()["features"] == expected
+    assert mod.OPS.capabilities()["progress"]["types"] == {"movies": True, "shows": False, "seasons": False, "episodes": True}
+    assert mod.OPS.capabilities()["history"]["remove"] is True
+    assert mod.OPS.capabilities()["watchlist"]["types"] == {"movies": True, "shows": True, "seasons": False, "episodes": False}
 
 
 def test_nuvio_is_configured_requires_auth_and_profile() -> None:
@@ -50,12 +56,15 @@ def test_nuvio_health_success_and_no_write(monkeypatch: pytest.MonkeyPatch) -> N
 
     monkeypatch.setattr(common, "save_config", lambda _cfg: pytest.fail("health must not write config"))
     monkeypatch.setattr(mod.NuvioClient, "pull_profiles", lambda self, cfg, refresh=True: [{"profile_id": 1, "name": "Profile 1"}])
+    monkeypatch.setattr(mod, "pull_watch_progress_rows", lambda self, limit=1, max_pages=1: [])
+    monkeypatch.setattr(mod, "pull_watched_rows", lambda self, page_size=1, max_pages=1: [])
+    monkeypatch.setattr(mod, "pull_library_rows", lambda self, limit=1, max_pages=1: [])
 
     health = mod.NUVIOModule(_cfg()).health()
 
     assert health["ok"] is True
     assert health["status"] == "ok"
-    assert health["features"] == {"watchlist": False, "ratings": False, "history": False, "progress": False, "playlists": False}
+    assert health["features"] == {"watchlist": True, "ratings": False, "history": True, "progress": True, "playlists": False}
 
 
 def test_nuvio_health_reports_profile_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/providers/tests/test_nuvio_progress.py
+++ b/providers/tests/test_nuvio_progress.py
@@ -1,0 +1,271 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+class FakeClient:
+    def __init__(self, rows: list[dict[str, Any]] | None = None):
+        self.rows = list(rows or [])
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def request_json(self, method: str, path: str, *, payload: Mapping[str, Any] | None = None, **_: Any) -> Any:
+        body = dict(payload or {})
+        name = path.rsplit("/", 1)[-1]
+        self.calls.append((name, body))
+        if name == "sync_pull_watch_progress":
+            since = int(body.get("p_since_last_watched") or 0)
+            limit = int(body.get("p_limit") or 1000)
+            rows = [row for row in self.rows if int(row.get("last_watched") or 0) > since]
+            return rows[:limit]
+        if name == "sync_push_watch_progress":
+            for entry in body.get("p_entries") or []:
+                row = dict(entry)
+                row["id"] = row.get("content_id")
+                row["progress_key"] = row.get("content_id") if not row.get("season") else f"{row.get('content_id')}_s{row.get('season')}e{row.get('episode')}"
+                row["profile_id"] = body.get("p_profile_id")
+                self.rows = [old for old in self.rows if old.get("progress_key") != row["progress_key"]]
+                self.rows.append(row)
+            return {}
+        if name == "sync_delete_watch_progress":
+            keys = set(str(x) for x in body.get("p_keys") or [])
+            single = str(body.get("p_progress_key") or "")
+            if single:
+                keys.add(single)
+            self.rows = [row for row in self.rows if str(row.get("progress_key") or "") not in keys]
+            return {}
+        return {}
+
+
+class FakeAdapter:
+    def __init__(self, rows: list[dict[str, Any]] | None = None, profile_id: int = 1):
+        self.config = {
+            "nuvio": {
+                "base_url": "https://api.nuvio.tv",
+                "access_token": "access",
+                "refresh_token": "refresh",
+                "profile_id": profile_id,
+            }
+        }
+        self.instance_id = "default"
+        self.client = FakeClient(rows)
+
+
+def _row(content_id: str, position: int = 120_000, duration: int = 600_000, last_watched: int = 1_785_000_000_000) -> dict[str, Any]:
+    return {
+        "id": content_id,
+        "profile_id": 1,
+        "content_id": content_id,
+        "content_type": "movie",
+        "video_id": content_id,
+        "season": None,
+        "episode": None,
+        "progress_key": content_id,
+        "position": position,
+        "duration": duration,
+        "last_watched": last_watched,
+    }
+
+
+def test_build_index_maps_movies_and_skips_malformed_rows() -> None:
+    from providers.sync.nuvio import _progress
+
+    adapter = FakeAdapter([_row("tt1234567"), {"content_type": "movie", "content_id": "bad"}, {"content_type": "series", "content_id": "tmdb:99"}])
+
+    index = _progress.build_index(adapter)
+
+    assert list(index) == ["imdb:tt1234567"]
+    item = index["imdb:tt1234567"]
+    assert item["type"] == "movie"
+    assert item["ids"] == {"imdb": "tt1234567"}
+    assert item["progress_ms"] == 120_000
+    assert item["duration_ms"] == 600_000
+    assert item["progress_at"] == 1_785_000_000_000
+    assert item["_nuvio_video_id"] == "tt1234567"
+    assert item["progress_key"] == "tt1234567"
+
+
+def test_build_index_merges_duplicate_movie_progress_by_newest_last_watched() -> None:
+    from providers.sync.nuvio import _progress
+
+    adapter = FakeAdapter([_row("tmdb:550", position=10_000, last_watched=1_785_000_000_000), _row("tmdb:550", position=20_000, last_watched=1_785_000_001_000)])
+
+    index = _progress.build_index(adapter)
+
+    assert index["tmdb:550"]["progress_ms"] == 20_000
+    assert index["tmdb:550"]["progress_at"] == 1_785_000_001_000
+
+
+def test_add_encodes_imdb_tmdb_trakt_and_verifies_exact_keys() -> None:
+    from providers.sync.nuvio import _progress
+
+    adapter = FakeAdapter([])
+    items = [
+        {"type": "movie", "ids": {"imdb": "tt1234567"}, "progress_ms": 100_000, "duration_ms": 500_000, "progress_at": 1_785_000_000_000},
+        {"type": "movie", "ids": {"tmdb": "550"}, "progress_ms": 200_000, "duration_ms": 600_000, "progress_at": 1_785_000_100_000},
+        {"type": "movie", "ids": {"trakt": "12"}, "progress_ms": 300_000, "duration_ms": 700_000, "progress_at": 1_785_000_200_000},
+    ]
+
+    result = _progress.add(adapter, items)
+
+    assert result["ok"] is True
+    assert result["attempted"] == 3
+    assert set(result["confirmed_keys"]) == {"imdb:tt1234567", "tmdb:550", "trakt:12"}
+    push = [body for name, body in adapter.client.calls if name == "sync_push_watch_progress"][0]
+    assert push["p_profile_id"] == 1
+    assert [entry["content_id"] for entry in push["p_entries"]] == ["tt1234567", "tmdb:550", "trakt:12"]
+    assert all(entry["duration"] for entry in push["p_entries"])
+    assert push["p_entries"][0]["last_watched"] == 1_785_000_000_000
+
+
+def test_add_returns_unresolved_for_unsupported_id_and_missing_duration() -> None:
+    from providers.sync.nuvio import _progress
+
+    adapter = FakeAdapter([])
+    result = _progress.add(
+        adapter,
+        [
+            {"type": "movie", "ids": {"tvdb": "99"}, "progress_ms": 100_000, "duration_ms": 500_000, "progress_at": 1_785_000_000_000},
+            {"type": "movie", "ids": {"tmdb": "550"}, "progress_ms": 100_000, "progress_at": 1_785_000_000_000},
+        ],
+        dry_run=True,
+    )
+
+    assert result["ok"] is False
+    assert result["attempted"] == 0
+    assert {row["reason"] for row in result["unresolved"]} == {"nuvio_id_missing", "nuvio_duration_missing"}
+    assert not any(name == "sync_push_watch_progress" for name, _body in adapter.client.calls)
+
+
+def test_add_is_idempotent_for_unchanged_progress_and_allows_newer_rewind() -> None:
+    from providers.sync.nuvio import _progress
+
+    same = {"type": "movie", "ids": {"tmdb": "550"}, "progress_ms": 120_000, "duration_ms": 600_000, "progress_at": 1_785_000_000_000}
+    adapter = FakeAdapter([_row("tmdb:550", position=120_000, duration=600_000, last_watched=1_785_000_000_000)])
+
+    unchanged = _progress.add(adapter, [same])
+    rewind = _progress.add(adapter, [{**same, "progress_ms": 60_000, "progress_at": 1_785_001_000_000}])
+
+    assert unchanged["attempted"] == 0
+    assert unchanged["skipped"] == 1
+    assert rewind["attempted"] == 1
+    assert rewind["confirmed_keys"] == ["tmdb:550"]
+    assert _progress.build_index(adapter)["tmdb:550"]["progress_ms"] == 60_000
+
+
+def test_remove_deletes_by_progress_key_and_treats_missing_as_idempotent() -> None:
+    from providers.sync.nuvio import _progress
+
+    adapter = FakeAdapter([_row("tmdb:550")])
+    item = {"type": "movie", "ids": {"tmdb": "550"}}
+
+    removed = _progress.remove(adapter, [item])
+    removed_again = _progress.remove(adapter, [item])
+
+    assert removed["ok"] is True
+    assert removed["confirmed_keys"] == ["tmdb:550"]
+    assert removed_again["ok"] is True
+    assert removed_again["attempted"] == 0
+    assert removed_again["skipped"] == 1
+    assert _progress.build_index(adapter) == {}
+
+
+def test_add_episode_progress_uses_documented_series_payload() -> None:
+    from providers.sync.nuvio import _progress
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "episode",
+        "show_ids": {"tmdb": "1396"},
+        "season": 1,
+        "episode": 1,
+        "progress_ms": 100_000,
+        "duration_ms": 2_600_000,
+        "progress_at": 1_785_000_000_000,
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tmdb:1396#s01e01"]
+    push = [body for name, body in adapter.client.calls if name == "sync_push_watch_progress"][0]
+    entry = push["p_entries"][0]
+    assert entry["content_id"] == "tmdb:1396"
+    assert entry["content_type"] == "series"
+    assert entry["video_id"] == "tmdb:1396:1:1"
+    assert entry["season"] == 1
+    assert entry["episode"] == 1
+
+
+def test_add_episode_progress_prefers_show_tmdb_id_over_episode_tmdb_id() -> None:
+    from providers.sync.nuvio import _progress
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "episode",
+        "ids": {"tmdb": "5978363", "imdb": "tt35707151"},
+        "show_ids": {"tmdb": "69478"},
+        "season": 6,
+        "episode": 2,
+        "progress_ms": 703_000,
+        "duration_ms": 3_307_930,
+        "progress_at": 1_785_000_000_000,
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tmdb:69478#s06e02"]
+    push = [body for name, body in adapter.client.calls if name == "sync_push_watch_progress"][0]
+    entry = push["p_entries"][0]
+    assert entry["content_id"] == "tmdb:69478"
+    assert entry["video_id"] == "tmdb:69478:6:2"
+
+
+def test_add_episode_progress_requires_show_ids() -> None:
+    from providers.sync.nuvio import _progress
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "episode",
+        "ids": {"tmdb": "5978363"},
+        "season": 6,
+        "episode": 2,
+        "progress_ms": 703_000,
+        "duration_ms": 3_307_930,
+        "progress_at": 1_785_000_000_000,
+    }
+
+    result = _progress.add(adapter, [item], dry_run=True)
+
+    assert result["ok"] is False
+    assert result["unresolved"][0]["reason"] == "nuvio_id_missing"
+
+
+def test_dry_run_does_not_write() -> None:
+    from cw_platform.id_map import canonical_key
+    from providers.sync.nuvio import _progress
+
+    adapter = FakeAdapter([])
+    item = {"type": "movie", "ids": {"tmdb": "550"}, "progress_ms": 100_000, "duration_ms": 500_000, "progress_at": 1_785_000_000_000}
+
+    result = _progress.add(adapter, [item], dry_run=True)
+
+    assert result["ok"] is True
+    assert result["attempted"] == 1
+    assert result["confirmed_keys"] == []
+    assert not any(name == "sync_push_watch_progress" for name, _body in adapter.client.calls)
+    assert canonical_key(item) == "tmdb:550"
+
+
+def test_profile_id_is_sent_with_progress_requests() -> None:
+    from providers.sync.nuvio import _progress
+
+    adapter = FakeAdapter([], profile_id=3)
+    item = {"type": "movie", "ids": {"tmdb": "550"}, "progress_ms": 100_000, "duration_ms": 500_000, "progress_at": 1_785_000_000_000}
+
+    _progress.add(adapter, [item])
+
+    calls = [body for name, body in adapter.client.calls if name in {"sync_pull_watch_progress", "sync_push_watch_progress"}]
+    assert calls
+    assert {body["p_profile_id"] for body in calls} == {3}

--- a/providers/tests/test_nuvio_watchlist.py
+++ b/providers/tests/test_nuvio_watchlist.py
@@ -1,0 +1,159 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+class FakeClient:
+    def __init__(self, rows: list[dict[str, Any]] | None = None):
+        self.rows = list(rows or [])
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def request_json(self, method: str, path: str, *, payload: Mapping[str, Any] | None = None, **_: Any) -> Any:
+        body = dict(payload or {})
+        name = path.rsplit("/", 1)[-1]
+        self.calls.append((name, body))
+        if name == "sync_pull_library":
+            offset = int(body.get("p_offset") or 0)
+            limit = int(body.get("p_limit") or 500)
+            return self.rows[offset : offset + limit]
+        if name == "sync_push_library":
+            self.rows = [dict(row) for row in body.get("p_items") or []]
+            return {}
+        return {}
+
+
+class FakeAdapter:
+    def __init__(self, rows: list[dict[str, Any]] | None = None):
+        self.config = {"nuvio": {"base_url": "https://api.nuvio.tv", "refresh_token": "refresh", "profile_id": 1}}
+        self.instance_id = "default"
+        self.client = FakeClient(rows)
+
+
+class NonPersistingClient(FakeClient):
+    def request_json(self, method: str, path: str, *, payload: Mapping[str, Any] | None = None, **kwargs: Any) -> Any:
+        name = path.rsplit("/", 1)[-1]
+        if name == "sync_push_library":
+            self.calls.append((name, dict(payload or {})))
+            return {}
+        return super().request_json(method, path, payload=payload, **kwargs)
+
+
+def test_watchlist_reads_library_movies_and_series() -> None:
+    from providers.sync.nuvio import _watchlist
+
+    adapter = FakeAdapter(
+        [
+            {"content_id": "tt0137523", "content_type": "movie", "name": "Fight Club", "poster": "poster.jpg"},
+            {"content_id": "tmdb:1396", "content_type": "series", "name": "Breaking Bad"},
+        ]
+    )
+
+    index = _watchlist.build_index(adapter)
+
+    assert sorted(index) == ["imdb:tt0137523", "tmdb:1396"]
+    assert index["tmdb:1396"]["type"] == "show"
+    assert index["imdb:tt0137523"]["_nuvio_poster"] == "poster.jpg"
+
+
+def test_watchlist_add_preserves_existing_library_rows_and_verifies() -> None:
+    from providers.sync.nuvio import _watchlist
+
+    adapter = FakeAdapter([{"content_id": "tt0137523", "content_type": "movie", "name": "Fight Club", "poster": "poster.jpg"}])
+
+    result = _watchlist.add(adapter, [{"type": "show", "ids": {"tmdb": "1396"}, "title": "Breaking Bad", "year": 2008}])
+
+    assert result["ok"] is True
+    assert set(result["confirmed_keys"]) == {"tmdb:1396"}
+    push = [body for name, body in adapter.client.calls if name == "sync_push_library"][0]
+    assert [row["content_id"] for row in push["p_items"]] == ["tt0137523", "tmdb:1396"]
+    assert push["p_items"][0]["poster"] == "poster.jpg"
+    assert push["p_items"][1]["content_type"] == "series"
+
+
+def test_watchlist_add_uses_canonical_id_for_verification() -> None:
+    from providers.sync.nuvio import _watchlist
+
+    adapter = FakeAdapter([])
+
+    result = _watchlist.add(adapter, [{"type": "movie", "ids": {"tmdb": "550", "imdb": "tt0137523"}, "title": "Fight Club"}])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tmdb:550"]
+    push = [body for name, body in adapter.client.calls if name == "sync_push_library"][0]
+    assert push["p_items"][0]["content_id"] == "tmdb:550"
+
+
+def test_watchlist_add_skips_tmdb_enrichment_without_metadata_config() -> None:
+    from providers.sync.nuvio import _watchlist
+
+    adapter = FakeAdapter([])
+
+    result = _watchlist.add(adapter, [{"type": "movie", "ids": {"tmdb": "550"}, "title": "Fight Club"}])
+
+    assert result["ok"] is True
+    push = [body for name, body in adapter.client.calls if name == "sync_push_library"][0]
+    assert "poster" not in push["p_items"][0]
+
+
+def test_watchlist_add_enriches_nuvio_payload_from_configured_tmdb(monkeypatch: Any) -> None:
+    from api import metaAPI
+    from providers.sync.nuvio import _watchlist
+
+    adapter = FakeAdapter([])
+    adapter.config["tmdb"] = {"api_key": "tmdb-key"}
+
+    def fake_get_meta(*_: Any, **__: Any) -> dict[str, Any]:
+        return {
+            "title": "Fight Club",
+            "year": 1999,
+            "overview": "A restless office worker finds a new outlet.",
+            "genres": ["Drama"],
+            "images": {
+                "poster": [{"url": "https://image.tmdb.org/t/p/w780/poster.jpg"}],
+                "backdrop": [{"url": "https://image.tmdb.org/t/p/w1280/backdrop.jpg"}],
+            },
+        }
+
+    monkeypatch.setattr(metaAPI, "get_meta", fake_get_meta)
+
+    result = _watchlist.add(adapter, [{"type": "movie", "ids": {"tmdb": "550"}, "title": "Fight Club"}])
+
+    assert result["ok"] is True
+    push = [body for name, body in adapter.client.calls if name == "sync_push_library"][0]
+    row = push["p_items"][0]
+    assert row["poster"] == "https://image.tmdb.org/t/p/w780/poster.jpg"
+    assert row["background"] == "https://image.tmdb.org/t/p/w1280/backdrop.jpg"
+    assert row["description"] == "A restless office worker finds a new outlet."
+    assert row["genres"] == ["Drama"]
+
+
+def test_watchlist_remove_full_replaces_library_without_removed_item() -> None:
+    from providers.sync.nuvio import _watchlist
+
+    adapter = FakeAdapter(
+        [
+            {"content_id": "tt0137523", "content_type": "movie", "name": "Fight Club"},
+            {"content_id": "tmdb:1396", "content_type": "series", "name": "Breaking Bad"},
+        ]
+    )
+
+    result = _watchlist.remove(adapter, [{"type": "movie", "ids": {"imdb": "tt0137523"}}])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["imdb:tt0137523"]
+    push = [body for name, body in adapter.client.calls if name == "sync_push_library"][0]
+    assert [row["content_id"] for row in push["p_items"]] == ["tmdb:1396"]
+
+
+def test_watchlist_failed_verification_reports_numeric_errors() -> None:
+    from providers.sync.nuvio import _watchlist
+
+    adapter = FakeAdapter([])
+    adapter.client = NonPersistingClient([])
+
+    result = _watchlist.add(adapter, [{"type": "movie", "ids": {"imdb": "tt0137523"}}])
+
+    assert result["ok"] is False
+    assert result["errors"] == 1


### PR DESCRIPTION
# Pull request

## Change

Adds the Nuvio sync adapter implementation with:
- Watchlist/library
- History
- Progress

Watchlist included TMDB enrichments for the cover art in library.

Ratings and Libraries are not supported.

## Why

This is the final phase  for Nuvio sync support in CrossWatch. 
Followed the existing provider sync module structure as much as possible.

## Testing

- test_nuvio_module.py
- test_nuvio_history.py
- test_nuvio_progress.py
- test_nuvio_watchlist.py 

One-way Provider to Nuvio watchlist/progress/history synced correctly.
Tested Progress Manager


## Issue

Relates to #321 