### PR TITLE
Add: Nuvio sync registry integration

### DIFF
--- a/api/editorAPI.py
+++ b/api/editorAPI.py
@@ -15,7 +15,7 @@ from fastapi.responses import StreamingResponse
 
 from cw_platform.config_base import load_config
 from cw_platform.id_map import canonical_key, merge_ids, minimal
-from cw_platform.modules_registry import load_sync_ops, state_read_features
+from cw_platform.modules_registry import load_sync_ops, state_read_features, sync_provider_names
 from cw_platform.orchestrator._snapshots import module_checkpoint
 from cw_platform.orchestrator._state_store import StateStore
 from cw_platform.playlists import PlaylistSnapshot, supports_playlists
@@ -1471,10 +1471,9 @@ def api_editor_state_import_providers() -> dict[str, Any]:
         return {"enabled": False, "providers": []}
 
     cfg = load_config()
-    names = ["PLEX", "SIMKL", "TRAKT", "TMDB", "ANILIST", "JELLYFIN", "EMBY", "MDBLIST", "PUBLICMETADB", "TAUTULLI"]
     out: list[dict[str, Any]] = []
 
-    for name in names:
+    for name in sync_provider_names(upper=True):
         ops = load_sync_ops(name)
         if not ops:
             continue

--- a/api/insightAPI.py
+++ b/api/insightAPI.py
@@ -14,6 +14,8 @@ from typing import Any, Callable
 from fastapi import FastAPI, Query, Request
 from fastapi.responses import JSONResponse
 
+from cw_platform.modules_registry import sync_provider_names
+
 def _env() -> tuple[
     Any | None,
     Callable[[], dict[str, Any]],
@@ -38,6 +40,7 @@ _AUTH_KEYS = {
     "anilist": ("access_token", "token"),
     "mdblist": ("api_key", "access_token"),
     "publicmetadb": ("api_key",),
+    "nuvio": ("access_token", "refresh_token", "profile_id"),
 }
 _SETTINGS_PROVIDERS = [*_AUTH_KEYS, "tmdb", "tautulli"]
 
@@ -74,6 +77,9 @@ def _settings_auth_summary(cfg: dict[str, Any]) -> dict[str, Any]:
         if provider == "tautulli":
             tb = _dict(block) or _dict(cfg.get("tautulli")) or _dict(_dict(cfg.get("auth")).get("tautulli"))
             return bool(_txt(tb.get("server_url") or tb.get("server")))
+        if provider == "nuvio":
+            b = _dict(block)
+            return bool(_txt(b.get("profile_id"))) and _has(b, "access_token", "refresh_token")
         return _has(block, *_AUTH_KEYS.get(provider, ("access_token", "api_key", "token")))
 
     profiles: list[dict[str, Any]] = []
@@ -1717,8 +1723,7 @@ def register_insights(app: FastAPI) -> None:
                 state = None
 
         prov_block: dict[str, Any] = (state or {}).get("providers") or {}
-        _PROVIDER_ORDER = ("plex", "simkl", "trakt", "jellyfin", "emby", "mdblist", "publicmetadb", "tmdb", "crosswatch", "anilist")
-        providers_set: set[str] = set(_PROVIDER_ORDER)
+        providers_set: set[str] = set(sync_provider_names(upper=False))
         try:
             providers_set.update(
                 str(k).strip().lower()

--- a/api/manualAPI.py
+++ b/api/manualAPI.py
@@ -11,7 +11,7 @@ import requests
 from fastapi import APIRouter, Body
 from fastapi.responses import JSONResponse
 
-from cw_platform.modules_registry import load_sync_ops
+from cw_platform.modules_registry import load_sync_ops, sync_provider_names
 from cw_platform.provider_instances import build_provider_config_view, list_instance_ids, normalize_instance_id
 
 router = APIRouter(prefix="/api/manual", tags=["manual"])
@@ -138,18 +138,7 @@ def _manual_external_ids(media_type: str, tmdb_id: Any) -> dict[str, Any]:
 def _manual_history_targets(cfg: dict[str, Any]) -> list[dict[str, Any]]:
     merged: dict[tuple[str, str], dict[str, Any]] = {}
 
-    for provider in (
-        "PLEX",
-        "SIMKL",
-        "ANILIST",
-        "TRAKT",
-        "TMDB",
-        "JELLYFIN",
-        "EMBY",
-        "MDBLIST",
-        "PUBLICMETADB",
-        "CROSSWATCH",
-    ):
+    for provider in sync_provider_names(upper=True):
         ops = load_sync_ops(provider)
         if not ops:
             continue

--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -9,12 +9,13 @@ from pathlib import Path
 from datetime import datetime, timezone, date
 from contextlib import contextmanager
 
-import dataclasses as _dc, importlib, inspect, json, os, pkgutil, re, shlex, shutil, threading, time, uuid
+import dataclasses as _dc, importlib, inspect, json, os, re, shlex, shutil, threading, time, uuid
 import asyncio
 
 from fastapi import APIRouter, Body, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel
+from cw_platform.modules_registry import get_sync_module_path_by_name, sync_provider_names, sync_provider_supports_feature
 from cw_platform.reason_labels import friendly_reason
 from cw_platform.value_coercion import coerce_bool
 
@@ -168,24 +169,18 @@ def _normalize_features(f: dict | None) -> dict:
             f[k]["anime_only_sync"] = coerce_bool(f[k].get("anime_only_sync", False)) if use_map else False
     return f
 
-_PROGRESS_ALLOWED = {"PLEX", "EMBY", "JELLYFIN", "PUBLICMETADB", "CROSSWATCH"}
-_RATINGS_ALLOWED = {"PLEX", "SIMKL", "TRAKT", "TMDB", "MDBLIST", "PUBLICMETADB", "CROSSWATCH", "ANILIST"}
-
 def _enforce_pair_feature_constraints(pair: dict[str, Any]) -> None:
-    try:
-        src = str(pair.get("source") or "").strip().upper()
-        dst = str(pair.get("target") or "").strip().upper()
-        feats = pair.get("features")
-        if not isinstance(feats, dict) or not feats:
-            return
-
-        # Progress is only supported between providers that currently expose progress sync.
-        if src not in _PROGRESS_ALLOWED or dst not in _PROGRESS_ALLOWED:
-            feats.pop("progress", None)
-        if src not in _RATINGS_ALLOWED or dst not in _RATINGS_ALLOWED:
-            feats.pop("ratings", None)
-    except Exception:
+    src = str(pair.get("source") or "").strip().upper()
+    dst = str(pair.get("target") or "").strip().upper()
+    feats = pair.get("features")
+    if not isinstance(feats, dict) or not feats:
         return
+
+    # Progress/ratings are only supported between providers that expose the feature via sync OPS.
+    if not sync_provider_supports_feature(src, "progress") or not sync_provider_supports_feature(dst, "progress"):
+        feats.pop("progress", None)
+    if not sync_provider_supports_feature(src, "ratings") or not sync_provider_supports_feature(dst, "ratings"):
+        feats.pop("ratings", None)
 
 def _normalize_pair_providers(p: Any) -> dict[str, Any]:
     if not isinstance(p, dict):
@@ -299,9 +294,9 @@ def _seed_summary_provider_counts(phase: str) -> None:
     if ph not in ("pre", "post"):
         return
     try:
-        counts = _counts_from_state(_load_state()) or {k: 0 for k in _PROVIDER_ORDER}
+        counts = _counts_from_state(_load_state()) or _provider_count_defaults()
     except Exception:
-        counts = {k: 0 for k in _PROVIDER_ORDER}
+        counts = _provider_count_defaults()
     if not isinstance(counts, dict):
         return
     _summary_set(f"provider_counts_{ph}", counts)
@@ -686,7 +681,7 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
                     counts = _counts_from_state(state)
                     if counts is None:
                         _append_log("SYNC", "[!] Provider-counts: state malformed; keeping last known counts")
-                        counts = dict(_PROVIDER_COUNTS_CACHE.get("data") or {k: 0 for k in _PROVIDER_ORDER})
+                        counts = dict(_PROVIDER_COUNTS_CACHE.get("data") or _provider_count_defaults())
                     if counts:
                         _PROVIDER_COUNTS_CACHE["ts"] = time.time()
                         _PROVIDER_COUNTS_CACHE["data"] = counts
@@ -733,7 +728,7 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
             state2 = _load_state()
             counts2 = _counts_from_state(state2) if state2 else None
             if counts2 is None:
-                counts2 = dict(_PROVIDER_COUNTS_CACHE.get("data") or {k: 0 for k in _PROVIDER_ORDER})
+                counts2 = dict(_PROVIDER_COUNTS_CACHE.get("data") or _provider_count_defaults())
             if counts2:
                 _PROVIDER_COUNTS_CACHE["ts"] = time.time()
                 _PROVIDER_COUNTS_CACHE["data"] = counts2
@@ -1622,7 +1617,6 @@ def _is_sync_running() -> bool:
 @router.get("/sync/providers")
 def api_sync_providers() -> JSONResponse:
     HIDDEN = {"BASE"}
-    PKG_CANDIDATES = ("providers.sync",)
     FEATURE_KEYS = ("watchlist", "ratings", "history", "playlists", "progress")
     try:
         from cw_platform.config_base import load_config
@@ -1709,8 +1703,10 @@ def api_sync_providers() -> JSONResponse:
                     getattr(info, "hidden", False) or getattr(info, "is_template", False)
                 ):
                     return None
+                supported_features = getattr(cls, "supported_features", None)
                 try:
-                    feats = dict(cls.supported_features()) if hasattr(cls, "supported_features") else {}
+                    raw_feats = supported_features() if callable(supported_features) else {}
+                    feats = dict(raw_feats) if isinstance(raw_feats, Mapping) else {}
                 except Exception:
                     feats = {}
                 return {
@@ -1746,33 +1742,27 @@ def api_sync_providers() -> JSONResponse:
 
     items: list[dict[str, Any]] = []
     seen: set[str] = set()
-    for pkg_name in PKG_CANDIDATES:
+    for prov_key in sync_provider_names(upper=True):
+        if prov_key in HIDDEN:
+            continue
+        module_path = get_sync_module_path_by_name(prov_key)
+        if not module_path:
+            continue
         try:
-            pkg = importlib.import_module(pkg_name)
+            mod = importlib.import_module(module_path)
         except Exception:
             continue
-        for pkg_path in getattr(pkg, "__path__", []):
-            for m in pkgutil.iter_modules([str(pkg_path)]):
-                if not m.name.startswith("_mod_"):
-                    continue
-                prov_key = m.name.replace("_mod_", "").upper()
-                if prov_key in HIDDEN:
-                    continue
-                try:
-                    mod = importlib.import_module(f"{pkg_name}.{m.name}")
-                except Exception:
-                    continue
-                mf = _manifest_from_module(mod)
-                if not mf:
-                    continue
-                mf["name"] = (mf["name"] or prov_key).upper()
-                mf["label"] = mf.get("label") or mf["name"].title()
-                mf["features"] = _norm_features(mf.get("features"))
-                mf["capabilities"] = _norm_caps(mf.get("capabilities"))
-                if mf["name"] in seen:
-                    continue
-                seen.add(mf["name"])
-                items.append(mf)
+        mf = _manifest_from_module(mod)
+        if not mf:
+            continue
+        mf["name"] = (mf["name"] or prov_key).upper()
+        mf["label"] = mf.get("label") or mf["name"].title()
+        mf["features"] = _norm_features(mf.get("features"))
+        mf["capabilities"] = _norm_caps(mf.get("capabilities"))
+        if mf["name"] in seen:
+            continue
+        seen.add(mf["name"])
+        items.append(mf)
     items.sort(key=lambda x: (x.get("label") or x.get("name") or "").lower())
     return JSONResponse(items)
 
@@ -2022,7 +2012,15 @@ def api_pairs_delete(pair_id: str, purge_state: bool = True) -> dict[str, Any]:
 
 # Provider counts endpoint
 _PROVIDER_COUNTS_CACHE = {"ts": 0.0, "data": None}
-_PROVIDER_ORDER = ("PLEX", "SIMKL", "TRAKT", "JELLYFIN", "EMBY", "MDBLIST", "PUBLICMETADB", "TMDB", "CROSSWATCH", "ANILIST")
+
+def _provider_count_defaults(extra: Any = None) -> dict[str, int]:
+    names = sync_provider_names(upper=True)
+    if isinstance(extra, Mapping):
+        for name in extra.keys():
+            key = str(name or "").strip().upper()
+            if key and key not in names:
+                names.append(key)
+    return {name: 0 for name in names}
 
 def _counts_from_state(state: dict | None) -> dict | None:
     if not isinstance(state, dict):
@@ -2031,12 +2029,12 @@ def _counts_from_state(state: dict | None) -> dict | None:
     if not isinstance(provs, dict) or not provs:
         return None
 
-    out = {k: 0 for k in _PROVIDER_ORDER}
+    out = _provider_count_defaults(provs)
     _append_log = _rt()[8]
 
     for name, pdata in provs.items():
         key = str(name or "").upper()
-        if key not in out:
+        if not key:
             continue
 
         if not isinstance(pdata, dict):
@@ -2135,7 +2133,7 @@ def _provider_counts_fast(*, max_age: int = 30, force: bool = False) -> dict:
         return dict(_PROVIDER_COUNTS_CACHE["data"])
     counts = _counts_from_state(_load_state())
     if counts is None:
-        counts = dict(_PROVIDER_COUNTS_CACHE.get("data") or {k: 0 for k in _PROVIDER_ORDER})
+        counts = dict(_PROVIDER_COUNTS_CACHE.get("data") or _provider_count_defaults())
     _PROVIDER_COUNTS_CACHE["ts"] = now
     _PROVIDER_COUNTS_CACHE["data"] = counts
     return counts
@@ -2148,7 +2146,7 @@ def api_provider_counts(
 ) -> dict:
     src = (source or "state").lower().strip()
     if src in ("state", "auto"):
-        return _counts_from_state(_load_state()) or {k: 0 for k in _PROVIDER_ORDER}
+        return _counts_from_state(_load_state()) or _provider_count_defaults()
     return _provider_counts_fast(max_age=max_age, force=bool(force))
 
 # Trigger sync run endpoint
@@ -2211,9 +2209,9 @@ def api_run_summary() -> JSONResponse:
         snap["timeline"] = tl
 
     try:
-        snap["provider_counts"] = _counts_from_state(_load_state()) or {k: 0 for k in _PROVIDER_ORDER}
+        snap["provider_counts"] = _counts_from_state(_load_state()) or _provider_count_defaults()
     except Exception:
-        snap["provider_counts"] = {k: 0 for k in _PROVIDER_ORDER}
+        snap["provider_counts"] = _provider_count_defaults()
 
     try:
         _hydrate_summary_spotlights_from_log(snap)
@@ -2326,6 +2324,14 @@ async def api_run_summary_stream(request: Request) -> StreamingResponse:
             return tuple(sorted((str(k), coerce_bool(v)) for k, v in enabled.items()))
         except Exception:
             return ()
+
+    def _provider_counts_key(counts: Any) -> tuple[Any, ...]:
+        if not isinstance(counts, Mapping):
+            return ()
+        try:
+            return tuple(sorted((str(k).upper(), int(v or 0)) for k, v in counts.items()))
+        except Exception:
+            return ()
     async def agen():
         last_key = None
         last_idx = 0
@@ -2374,15 +2380,7 @@ async def api_run_summary_stream(request: Request) -> StreamingResponse:
             key = (
                 snap.get("running"),
                 snap.get("exit_code"),
-                snap.get("plex_post"),
-                snap.get("simkl_post"),
-                snap.get("trakt_post"),
-                snap.get("jellyfin_post"),
-                snap.get("emby_post"),
-                snap.get("mdblist_post"),
-                snap.get("publicmetadb_post"),
-                snap.get("tmdb_post"),
-                snap.get("crosswatch_post"),
+                _provider_counts_key(snap.get("provider_counts") or snap.get("provider_counts_post")),
                 snap.get("result"),
                 snap.get("duration_sec"),
                 (snap.get("timeline", {}) or {}).get("done"),

--- a/assets/helpers/core.js
+++ b/assets/helpers/core.js
@@ -37,41 +37,14 @@
   };
   const raf = (fn) => (window.requestAnimationFrame || ((cb) => setTimeout(cb, 0)))(fn);
 
-  const PROVIDER_ORDER = META.order || [
-    "CROSSWATCH", "PLEX", "JELLYFIN", "EMBY", "SIMKL", "TRAKT", "ANILIST", "TMDB", "MDBLIST", "PUBLICMETADB", "NUVIO", "TAUTULLI"
-  ];
-  const STATUS_PROVIDERS = typeof META.statusProviders === "function" ? META.statusProviders() : [
-    { key: "PLEX", badgeId: "badge-plex", legacy: ["plex_connected", "plex"] },
-    { key: "SIMKL", badgeId: "badge-simkl", legacy: ["simkl_connected", "simkl"] },
-    { key: "TRAKT", badgeId: "badge-trakt", legacy: ["trakt_connected", "trakt"] },
-    { key: "ANILIST", badgeId: "badge-anilist", legacy: ["anilist_connected", "anilist"] },
-    { key: "TMDB", badgeId: "badge-tmdb", legacy: ["tmdb_connected", "tmdb"] },
-    { key: "JELLYFIN", badgeId: "badge-jellyfin", legacy: ["jellyfin_connected", "jellyfin"] },
-    { key: "EMBY", badgeId: "badge-emby", legacy: ["emby_connected", "emby"] },
-    { key: "MDBLIST", badgeId: "badge-mdblist", legacy: ["mdblist_connected", "mdblist"] },
-    { key: "PUBLICMETADB", badgeId: "badge-publicmetadb", legacy: ["publicmetadb_connected", "publicmetadb"] },
-    { key: "NUVIO", badgeId: "badge-nuvio", legacy: ["nuvio_connected", "nuvio"] },
-    { key: "TAUTULLI", badgeId: "badge-tautulli", legacy: ["tautulli_connected", "tautulli"] },
-  ];
+  const PROVIDER_ORDER = Array.isArray(META.order) ? META.order : [];
+  const STATUS_PROVIDERS = typeof META.statusProviders === "function" ? META.statusProviders() : [];
   const BADGE_IDS = Object.fromEntries([
     ...STATUS_PROVIDERS.map((p) => [p.key, p.badgeId]),
     ["CROSSWATCH", typeof META.badgeId === "function" ? (META.badgeId("CROSSWATCH") || "badge-crosswatch") : "badge-crosswatch"],
   ]);
-  const PAIR_ACTIVE_KEYS = ["PLEX", "SIMKL", "TRAKT", "ANILIST", "TMDB", "JELLYFIN", "EMBY", "MDBLIST", "PUBLICMETADB", "NUVIO", "TAUTULLI", "CROSSWATCH"];
-  const PROVIDER_ALIASES = typeof META.aliasesMap === "function" ? META.aliasesMap() : {
-    CROSSWATCH: ["CROSSWATCH"],
-    PLEX: ["PLEX"],
-    SIMKL: ["SIMKL"],
-    TRAKT: ["TRAKT"],
-    ANILIST: ["ANILIST", "ANI LIST", "ANI-LIST"],
-    TMDB: ["TMDB", "TMDBSYNC", "TMDB SYNC", "TMDB-SYNC"],
-    JELLYFIN: ["JELLYFIN"],
-    EMBY: ["EMBY"],
-    MDBLIST: ["MDBLIST", "MDB LIST", "MDB-LIST"],
-    PUBLICMETADB: ["PUBLICMETADB", "PUBLIC META DB", "PUBLIC-META-DB", "PMDB"],
-    NUVIO: ["NUVIO"],
-    TAUTULLI: ["TAUTULLI"],
-  };
+  const PAIR_ACTIVE_KEYS = [...PROVIDER_ORDER.filter((key) => key !== "CROSSWATCH"), "CROSSWATCH"];
+  const PROVIDER_ALIASES = typeof META.aliasesMap === "function" ? META.aliasesMap() : {};
   const SIMPLE_PROVIDER_CHECKS = [
     { key: "PLEX", paths: [["plex"]], keys: ["account_token", "token"] },
     { key: "SIMKL", paths: [["simkl"], ["auth", "simkl"]], keys: ["access_token"] },
@@ -130,6 +103,18 @@
     const match = (block) => {
       if (!block || typeof block !== "object") return false;
       return ((hasValue(block.api_key) && hasValue(block.session_id)) || hasValue(block.account_id));
+    };
+    if (match(root)) return true;
+    const instances = root.instances;
+    if (!instances || typeof instances !== "object") return false;
+    return Object.values(instances).some(match);
+  }
+
+  function hasNuvioConfig(root) {
+    if (!root || typeof root !== "object") return false;
+    const match = (block) => {
+      if (!block || typeof block !== "object") return false;
+      return hasValue(block.profile_id) && (hasValue(block.access_token) || hasValue(block.refresh_token));
     };
     if (match(root)) return true;
     const instances = root.instances;
@@ -283,9 +268,11 @@
   function getConfiguredProviders(cfg = window._cfgCache || {}) {
     const set = new Set();
     for (const def of SIMPLE_PROVIDER_CHECKS) {
+      if (def.key === "NUVIO") continue;
       if (def.paths.some((path) => hasAnyConfigValue(pathGet(cfg, path), def.keys))) set.add(def.key);
     }
 
+    if ([cfg?.nuvio, cfg?.auth?.nuvio].some(hasNuvioConfig)) set.add("NUVIO");
     if ([cfg?.tmdb_sync, cfg?.auth?.tmdb_sync].some(hasTmdbConfig)) set.add("TMDB");
     if ([cfg?.tautulli, cfg?.auth?.tautulli].some((block) => hasAnyConfigValue(block, ["api_key", "server_url", "server"]))) set.add("TAUTULLI");
 

--- a/assets/js/modals/insight-settings/index.js
+++ b/assets/js/modals/insight-settings/index.js
@@ -259,6 +259,12 @@ const hasTmdbConfig = (root) => {
   const inst = root?.instances;
   return !!(inst && typeof inst === "object" && Object.values(inst).some(match));
 };
+const hasNuvioConfig = (root) => {
+  const match = (block) => !!(block && typeof block === "object" && hasValue(block.profile_id) && (hasValue(block.access_token) || hasValue(block.refresh_token)));
+  if (match(root)) return true;
+  const inst = root?.instances;
+  return !!(inst && typeof inst === "object" && Object.values(inst).some(match));
+};
 const getAllowedProviders = (cfg = window._cfgCache || {}) => {
   try {
     if (typeof window.getConfiguredProviders === "function") return new Set(Array.from(window.getConfiguredProviders(cfg) || []).map(canonProv).filter(Boolean));
@@ -274,6 +280,7 @@ const getAllowedProviders = (cfg = window._cfgCache || {}) => {
     { key: "PUBLICMETADB", paths: [["publicmetadb"], ["auth", "publicmetadb"]], keys: ["api_key"] },
   ];
   for (const def of checks) if (def.paths.some((path) => hasAnyConfigValue(pathGet(cfg, path), def.keys))) set.add(def.key);
+  if ([cfg?.nuvio, cfg?.auth?.nuvio].some(hasNuvioConfig)) set.add("NUVIO");
   if ([cfg?.tmdb_sync, cfg?.tmdb, cfg?.auth?.tmdb_sync].some(hasTmdbConfig)) set.add("TMDB");
   if ([cfg?.tautulli, cfg?.auth?.tautulli].some((block) => hasAnyConfigValue(block, ["api_key", "server_url", "server"]))) set.add("TAUTULLI");
   if ((cfg?.crosswatch || cfg?.CrossWatch || {}).enabled !== false) set.add("CROSSWATCH");
@@ -282,7 +289,9 @@ const getAllowedProviders = (cfg = window._cfgCache || {}) => {
 
 const buildProviders = async () => {
   const labels = {}, byProvider = {}, [instApi, cfg] = await Promise.all([jget(`/api/provider-instances?cb=${Date.now()}`), jget(`/api/config?cb=${Date.now()}`)]);
-  const instMap = instApi || {}, allowed = getAllowedProviders(cfg || window._cfgCache || {}), relevant = new Set(["CROSSWATCH", "PLEX", "SIMKL", "TRAKT", "ANILIST", "MDBLIST", "PUBLICMETADB", "JELLYFIN", "EMBY", "TAUTULLI", "TMDB"]);
+  const metaOrder = ProviderMeta().order || [];
+  const relevant = new Set((Array.isArray(metaOrder) ? metaOrder : []).map(canonProv));
+  const instMap = instApi || {}, allowed = getAllowedProviders(cfg || window._cfgCache || {});
   const getRaw = async (key) => {
     const up = canonProv(key), candidates = [up, key, up.toLowerCase(), ...(up === "TMDB" ? ["TMDB_SYNC", "tmdb_sync"] : [])];
     for (const k of candidates) if (k && Object.prototype.hasOwnProperty.call(instMap, k)) return instMap[k];

--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -307,15 +307,8 @@ async function loadProviderInstances(state){
 
 async function loadProviders(state){
   const list=await getJSON("/api/sync/providers?cb="+Date.now());
-  state.providers=Array.isArray(list)?list:[
-    {name:"PLEX",label:"Plex",features:{watchlist:true,ratings:true,history:true,progress:true,playlists:true},capabilities:{bidirectional:true},version:"1.0.0"},
-    {name:"CROSSWATCH",label:"CW Tracker",features:{watchlist:true,ratings:true,history:true,progress:true,playlists:false},capabilities:{bidirectional:true},version:"1.0.0"},
-    {name:"SIMKL",label:"Simkl",features:{watchlist:true,ratings:true,history:true,progress:false,playlists:false},capabilities:{bidirectional:true},version:"1.0.0"},
-    {name:"TRAKT",label:"Trakt",features:{watchlist:true,ratings:true,history:true,progress:false,playlists:true},capabilities:{bidirectional:true},version:"1.0.0"},
-    {name:"ANILIST",label:"AniList",features:{watchlist:true,ratings:true,history:false,progress:false,playlists:false},capabilities:{bidirectional:true},version:"0.1"},
-    {name:"JELLYFIN",label:"Jellyfin",features:{watchlist:true,ratings:false,history:true,progress:true,playlists:true},capabilities:{bidirectional:true},version:"1.2.1"},
-    {name:"EMBY",label:"Emby",features:{watchlist:true,ratings:false,history:true,progress:true,playlists:true},capabilities:{bidirectional:true},version:"1.0.0"} 
-  ]
+  if(!Array.isArray(list)) throw new Error("Invalid sync providers response");
+  state.providers=list
 }
 
 async function loadConfigBits(state){

--- a/cw_platform/modules_registry.py
+++ b/cw_platform/modules_registry.py
@@ -44,6 +44,20 @@ def get_sync_module_path_by_name(name: str) -> str | None:
     return MODULES["SYNC"].get(key)
 
 
+def sync_provider_names(*, upper: bool = True) -> list[str]:
+    names = [
+        str(key).replace("_mod_", "")
+        for key in (MODULES.get("SYNC") or {}).keys()
+        if str(key).startswith("_mod_")
+    ]
+    out: list[str] = []
+    for name in names:
+        value = name.upper() if upper else name.lower()
+        if value and value not in {"BASE", "base"} and value not in out:
+            out.append(value)
+    return out
+
+
 def load_sync_ops(name: str) -> Any | None:
     path = get_sync_module_path_by_name(name)
     if not path:
@@ -52,11 +66,23 @@ def load_sync_ops(name: str) -> Any | None:
     return getattr(mod, "OPS", None)
 
 
+def sync_provider_supports_feature(name: str, feature: str) -> bool:
+    provider = str(name or "").strip().lower()
+    feat = str(feature or "").strip().lower()
+    if not provider or not feat:
+        return False
+    ops = load_sync_ops(provider)
+    if not ops:
+        return False
+    features = ops.features() if callable(getattr(ops, "features", None)) else {}
+    if isinstance(features, Mapping) and features.get(feat) is not True:
+        return False
+    caps = ops.capabilities() if callable(getattr(ops, "capabilities", None)) else {}
+    cap = caps.get(feat) if isinstance(caps, Mapping) else None
+    return bool(cap) if isinstance(cap, Mapping) else bool(isinstance(features, Mapping) and features.get(feat))
+
+
 def state_read_features(ops: Any) -> dict[str, bool]:
-    """Return features that can provide a complete provider-state inventory.
-    Providers may still support writes for a feature that cannot be enumerated
-    completely. Captures and provider-state imports must only use the latter.
-    """
     fn = getattr(ops, "state_read_features", None)
     if not callable(fn):
         fn = getattr(ops, "features", None)

--- a/cw_platform/orchestrator/_providers.py
+++ b/cw_platform/orchestrator/_providers.py
@@ -3,45 +3,21 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
-import importlib
-import pkgutil
-from pathlib import Path
-from types import ModuleType
-from collections.abc import Iterator
-
+from cw_platform.modules_registry import load_sync_ops, sync_provider_names
 from ._types import InventoryOps
-
-
-def _iter_sync_modules() -> Iterator[ModuleType]:
-    import providers.sync as syncpkg  # user package
-
-    pkg_path = Path(syncpkg.__file__).parent
-    for m in pkgutil.iter_modules([str(pkg_path)]):
-        if not m.name.startswith("_mod_"):
-            continue
-        try:
-            yield importlib.import_module(f"providers.sync.{m.name}")
-        except Exception as e:
-            print(f"[providers] load_failed {m.name}: {e}")
-
-
-def _resolve_ops_from_module(mod: ModuleType) -> InventoryOps | None:
-    needed = ("name", "label", "features", "capabilities", "build_index", "add", "remove")
-    for attr in ("OPS", "ADAPTER", "ProviderOps", "InventoryOps"):
-        obj = getattr(mod, attr, None)
-        if obj and all(hasattr(obj, fn) for fn in needed):
-            return obj  # type: ignore[return-value]
-    return None
 
 
 def load_sync_providers() -> dict[str, InventoryOps]:
     out: dict[str, InventoryOps] = {}
-    for mod in _iter_sync_modules():
-        ops = _resolve_ops_from_module(mod)
+    needed = ("name", "label", "features", "capabilities", "build_index", "add", "remove")
+    for name in sync_provider_names(upper=True):
+        ops = load_sync_ops(name)
         if not ops:
             continue
+        if not all(hasattr(ops, fn) for fn in needed):
+            continue
         try:
-            out[str(ops.name()).upper()] = ops
+            out[str(ops.name()).upper()] = ops  # type: ignore[assignment]
         except Exception:
             continue
     return out

--- a/providers/tests/conftest.py
+++ b/providers/tests/conftest.py
@@ -198,17 +198,23 @@ class _AuthProviderStub:
 
 
 def _ensure_auth_stubs() -> None:
-    for base in ("providers", "providers.auth", "providers.auth._auth_TRAKT"):
-        if base in sys.modules:
-            continue
-        _install_stub(base)
-    sys.modules["providers.auth._auth_TRAKT"].PROVIDER = _AuthProviderStub()  # type: ignore[attr-defined]
+    try:
+        import providers.auth._auth_TRAKT  # noqa: F401
+    except Exception:
+        for base in ("providers", "providers.auth", "providers.auth._auth_TRAKT"):
+            if base in sys.modules:
+                continue
+            _install_stub(base)
+        sys.modules["providers.auth._auth_TRAKT"].PROVIDER = _AuthProviderStub()  # type: ignore[attr-defined]
 
-    for base in ("auth", "auth._auth_TRAKT"):
-        if base in sys.modules:
-            continue
-        _install_stub(base)
-    sys.modules["auth._auth_TRAKT"].PROVIDER = _AuthProviderStub()  # type: ignore[attr-defined]
+    try:
+        import auth._auth_TRAKT  # noqa: F401
+    except Exception:
+        for base in ("auth", "auth._auth_TRAKT"):
+            if base in sys.modules:
+                continue
+            _install_stub(base)
+        sys.modules["auth._auth_TRAKT"].PROVIDER = _AuthProviderStub()  # type: ignore[attr-defined]
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/services/analyzer.py
+++ b/services/analyzer.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import logging
 import time
 from collections import defaultdict
@@ -19,6 +20,7 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
 
 from cw_platform.config_base import CONFIG as CONFIG_DIR, load_config
+from cw_platform.modules_registry import get_sync_module_path_by_name, sync_provider_names
 from cw_platform.provider_instances import normalize_instance_id
 from cw_platform.reason_labels import TRACKER_TO_MEDIA_SERVER_MESSAGE, reason_message
 
@@ -1537,11 +1539,19 @@ def _validate_manifest_shape(path: Path, module_name: str, manifest: Any, expect
 def _provider_module_diagnostics() -> list[dict[str, Any]]:
     probs: list[dict[str, Any]] = []
     required_ops = ("name", "label", "features", "capabilities", "build_index", "add", "remove")
-    for path in sorted(PROVIDERS_SYNC_DIR.glob("_mod_*.py")):
-        if path.name == "_mod_common.py":
+    for expected_name in sync_provider_names(upper=True):
+        if expected_name == "BASE":
             continue
-        expected_name = path.stem.removeprefix("_mod_").upper()
-        module_name = f"providers.sync.{path.stem}"
+        module_name = get_sync_module_path_by_name(expected_name)
+        if not module_name:
+            continue
+        path = PROVIDERS_SYNC_DIR / f"_mod_{expected_name}.py"
+        try:
+            spec = importlib.util.find_spec(module_name)
+            if spec and spec.origin:
+                path = Path(spec.origin)
+        except Exception:
+            pass
         try:
             mod = importlib.import_module(module_name)
         except Exception as e:

--- a/services/snapshots.py
+++ b/services/snapshots.py
@@ -15,7 +15,7 @@ import re
 import uuid
 
 from cw_platform.config_base import CONFIG, load_config
-from cw_platform.modules_registry import MODULES as MR_MODULES, load_sync_ops, state_read_features
+from cw_platform.modules_registry import load_sync_ops, state_read_features, sync_provider_names
 from cw_platform.provider_instances import build_provider_config_view, list_instance_ids, normalize_instance_id
 
 Feature = Literal["watchlist", "ratings", "history", "progress"]
@@ -32,7 +32,7 @@ def _utc_now() -> datetime:
 
 
 def _registry_sync_providers() -> list[str]:
-    return [k.replace("_mod_", "").upper() for k in (MR_MODULES.get("SYNC") or {}).keys()]
+    return sync_provider_names(upper=True)
 
 
 def _safe_label(label: str) -> str:

--- a/services/watchlist.py
+++ b/services/watchlist.py
@@ -12,7 +12,7 @@ from urllib.parse import urlencode
 import requests
 
 from cw_platform.config_base import CONFIG
-from cw_platform.modules_registry import MODULES as MR_MODULES, load_sync_ops
+from cw_platform.modules_registry import load_sync_ops, sync_provider_names
 from cw_platform.provider_instances import build_config_view, list_instance_ids, normalize_instance_id
 
 try:
@@ -69,26 +69,17 @@ def _save_state_dict(path: Path, state: dict[str, Any]) -> None:
 
 # Registry and provider helpers
 def _registry_sync_providers() -> list[str]:
-    return [
-        k.replace("_mod_", "").upper()
-        for k in (MR_MODULES.get("SYNC") or {}).keys()
-    ]
+    return sync_provider_names(upper=True)
 
 
 def _normalize_label(pid: str) -> str:
-    mapping = {
-        "PLEX": "Plex",
-        "SIMKL": "SIMKL",
-        "TRAKT": "Trakt",
-        "ANILIST": "AniList",
-        "JELLYFIN": "Jellyfin",
-        "EMBY": "Emby",
-        "MDBLIST": "MDBList",
-        "PUBLICMETADB": "PublicMetaDB",
-        "TMDB": "TMDb",
-        "CROSSWATCH": "CrossWatch",
-    }
-    return mapping.get(pid.upper(), pid.title())
+    key = str(pid or "").strip().upper()
+    ops = load_sync_ops(key)
+    if ops:
+        label = str(ops.label() or "").strip()
+        if label:
+            return label
+    return key.title()
 
 
 def _feat_enabled(fmap: dict[str, Any] | None, name: str) -> bool:
@@ -122,6 +113,19 @@ def _configured_via_registry(pid: str, cfg: dict[str, Any]) -> bool:
         return False
     except Exception:
         return False
+
+
+def _ops_supports_watchlist_remove(pid: str) -> bool:
+    ops = load_sync_ops(pid)
+    if not ops:
+        return False
+    feats = ops.features() or {}
+    if feats and not _feat_enabled(dict(feats), "watchlist"):
+        return False
+    caps = ops.capabilities() or {}
+    watchlist = caps.get("watchlist") if isinstance(caps, Mapping) else None
+    return isinstance(watchlist, Mapping) and bool(watchlist.get("remove"))
+
 
 _DEFAULT_INSTANCE = "default"
 
@@ -1461,6 +1465,35 @@ def _delete_on_publicmetadb_batch(
         raise RuntimeError(f"PUBLICMETADB delete unresolved: {res.get('unresolved')}")
 
 
+def _delete_on_ops_watchlist_batch(
+    provider: str,
+    items: list[dict[str, Any]],
+    cfg: dict[str, Any],
+) -> None:
+    ops = load_sync_ops(provider)
+    if not ops:
+        raise RuntimeError(f"{provider} sync module unavailable")
+
+    payload: list[dict[str, Any]] = []
+    for it in items or []:
+        obj = dict(it.get("item") or {}) if isinstance(it.get("item"), dict) else {}
+        ids = _ids_from_key_or_item(str(it.get("key") or ""), obj)
+        if ids:
+            existing = obj.get("ids")
+            obj["ids"] = (dict(existing) | dict(ids)) if isinstance(existing, dict) else dict(ids)
+        typ = str(it.get("type") or obj.get("type") or "").strip().lower()
+        obj["type"] = "show" if typ in {"tv", "show", "series"} else "movie"
+        payload.append(obj)
+
+    if not payload:
+        raise RuntimeError(f"{provider} delete: no items")
+    res = ops.remove(cfg, payload, feature="watchlist", dry_run=False) or {}
+    if not isinstance(res, dict) or not bool(res.get("ok", True)):
+        raise RuntimeError(f"{provider} delete failed: {res}")
+    if int(res.get("count") or 0) <= 0 and res.get("unresolved"):
+        raise RuntimeError(f"{provider} delete unresolved: {res.get('unresolved')}")
+
+
 # Delete watchlist items
 def delete_watchlist_batch(
     keys: list[str],
@@ -1539,6 +1572,9 @@ def delete_watchlist_batch(
         if p == "CROSSWATCH":
             _delete_on_crosswatch_batch(items, cfg_view)
             return
+        if _ops_supports_watchlist_remove(p):
+            _delete_on_ops_watchlist_batch(p, items, cfg_view)
+            return
         raise RuntimeError(f"delete not supported: {p}")
 
     def _delete_for_provider(p: str) -> dict[str, Any]:
@@ -1556,17 +1592,12 @@ def delete_watchlist_batch(
                 per_instance[inst] = {"ok": False, "error": str(e)}
         return {"ok": any(v.get("ok") for v in per_instance.values()), "per_instance": per_instance, "removed": len(removed)}
 
-    supported = {"CROSSWATCH", "ANILIST", "PLEX", "SIMKL", "TRAKT", "TMDB", "JELLYFIN", "EMBY", "MDBLIST", "PUBLICMETADB"}
-
     if prov == "ALL":
         details: dict[str, Any] = {}
         ok_any = False
         deleted_sum = 0
 
         for p in _registry_sync_providers():
-            if p not in supported:
-                details[p] = {"ok": False, "error": "delete not supported"}
-                continue
             res = _delete_for_provider(p)
             details[p] = res
             ok_any |= bool(res.get("ok"))
@@ -1577,7 +1608,7 @@ def delete_watchlist_batch(
 
         return {"ok": ok_any, "deleted": deleted_sum, "provider": "ALL", "details": details, "status": "ok" if ok_any else "error"}
 
-    if prov not in supported:
+    if prov not in set(_registry_sync_providers()):
         raise RuntimeError(f"unknown provider: {prov}")
 
     res = _delete_for_provider(prov)


### PR DESCRIPTION
# Pull request

## Change

Integrate Nuvio into the CW sync/provider registry paths.

This updates sync provider discovery, pair feature checks, provider counts, insights, captures, editor imports, manual history targets and generic watchlist delete handling to use the registry.

## Why

Integrate Nuvio like the existing sync providers and be discovered through the standard architecture.

## Testing

- test_editor_state_import_registry.py
- test_nuvio_analyzer_integration.py
- test_nuvio_capture_manifest.py
- test_nuvio_syncapi_acceptance.py
- test_watchlist_generic_ops_delete.py

## Issue

Relates to #321 