### PR TITLE
Change: extend Nuvio playback metadata

### DIFF
--- a/providers/metadata/_meta_TMDB.py
+++ b/providers/metadata/_meta_TMDB.py
@@ -561,7 +561,8 @@ class TmdbProvider:
             return {}
 
         tmdb_id = str(ids.get("tmdb") or ids.get("id") or "").strip()
-        imdb_id = (ids.get("imdb") or "").strip()
+        imdb_id = str(ids.get("imdb") or "").strip()
+        tvdb_id = str(ids.get("tvdb") or ids.get("tvdb_id") or "").strip()
         title = (ids.get("title") or "").strip()
         year_in = (ids.get("year") or "").strip()
 
@@ -587,6 +588,25 @@ class TmdbProvider:
                         ent_in = "tv"
             except Exception as e:
                 self._log_exc("TMDb find by IMDb failed", e)
+
+        if not tmdb_id and tvdb_id:
+            try:
+                found = self._get(f"{base}/find/{tvdb_id}", {"external_source": "tvdb_id"})
+                if ent_in == "movie":
+                    hit = self._pick_first(found.get("movie_results") or [])
+                else:
+                    hit = self._pick_first(found.get("tv_results") or [])
+                tmdb_id = str(hit.get("id")) if hit else ""
+                if not tmdb_id:
+                    m = self._pick_first(found.get("movie_results") or [])
+                    t = self._pick_first(found.get("tv_results") or [])
+                    tmdb_id = str((m or t or {}).get("id") or "") if (m or t) else ""
+                    if m and not t:
+                        ent_in = "movie"
+                    if t and not m:
+                        ent_in = "tv"
+            except Exception as e:
+                self._log_exc("TMDb find by TVDB failed", e)
 
         if not tmdb_id and title:
             try:

--- a/services/playback_progress/adapters/nuvio.py
+++ b/services/playback_progress/adapters/nuvio.py
@@ -109,22 +109,54 @@ def _progress_item_with_percent(record: Mapping[str, Any], progress_percent: flo
     return clean_mapping(item)
 
 
-def _metadata_title(provider: Any, *, media_type: str, ids: Mapping[str, Any], show_ids: Mapping[str, Any]) -> tuple[str, int | None]:
+def _image_url(meta: Mapping[str, Any], kind: str) -> str:
+    images_obj = meta.get("images")
+    images: Mapping[str, Any] = images_obj if isinstance(images_obj, Mapping) else {}
+    rows = images.get(kind)
+    if not isinstance(rows, list):
+        return ""
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        url = str(row.get("url") or "").strip()
+        if url:
+            return url
+    return ""
+
+
+def _metadata_detail(provider: Any, *, media_type: str, ids: Mapping[str, Any], show_ids: Mapping[str, Any]) -> dict[str, Any]:
     lookup_ids = show_ids if media_type == "episode" and show_ids else ids
-    tmdb = str(lookup_ids.get("tmdb") or "").strip()
-    if provider is None or not tmdb:
-        return "", None
+    fetch_ids = {
+        key: str(lookup_ids.get(key) or "").strip()
+        for key in ("tmdb", "imdb", "tvdb")
+        if str(lookup_ids.get(key) or "").strip()
+    }
+    if provider is None or not fetch_ids:
+        return {}
     try:
         detail = provider.fetch(
             entity="tv" if media_type == "episode" else "movie",
-            ids={"tmdb": tmdb},
-            need={"poster": False, "backdrop": False, "ids": False},
+            ids=fetch_ids,
+            need={"poster": True, "backdrop": True, "ids": False},
         )
     except Exception:
-        return "", None
+        return {}
     if not isinstance(detail, Mapping):
-        return "", None
-    return str(detail.get("title") or "").strip(), _num(detail.get("year"))
+        return {}
+    out: dict[str, Any] = {}
+    title = str(detail.get("title") or "").strip()
+    if title:
+        out["title"] = title
+    year = _num(detail.get("year"))
+    if year is not None:
+        out["year"] = year
+    poster = _image_url(detail, "poster")
+    if poster:
+        out["poster_url"] = poster
+    backdrop = _image_url(detail, "backdrop")
+    if backdrop:
+        out["backdrop_url"] = backdrop
+    return out
 
 
 def _is_placeholder_title(value: Any) -> bool:
@@ -198,15 +230,19 @@ class NuvioPlaybackAdapter(PlaybackProgressAdapter):
             title = ""
         if media_type == "episode" and _is_placeholder_title(series_title):
             series_title = ""
-        if not title or (media_type == "episode" and not series_title):
-            resolved_title, resolved_year = _metadata_title(metadata, media_type=media_type, ids=ids, show_ids=show_ids)
-            if resolved_title:
-                if media_type == "episode" and not series_title:
-                    series_title = resolved_title
-                if not title:
-                    title = resolved_title
-            if mini.get("year") in (None, "") and item.get("year") in (None, "") and resolved_year is not None:
-                mini["year"] = resolved_year
+        has_art = bool(str(item.get("poster") or item.get("poster_url") or "").strip()) and bool(
+            str(item.get("background") or item.get("backdrop") or item.get("backdrop_url") or "").strip()
+        )
+        needs_metadata = not title or (media_type == "episode" and not series_title) or not has_art
+        resolved = _metadata_detail(metadata, media_type=media_type, ids=ids, show_ids=show_ids) if needs_metadata else {}
+        resolved_title = str(resolved.get("title") or "").strip()
+        if resolved_title and (not title or (media_type == "episode" and not series_title)):
+            if media_type == "episode" and not series_title:
+                series_title = resolved_title
+            if not title:
+                title = resolved_title
+        if mini.get("year") in (None, "") and item.get("year") in (None, "") and resolved.get("year") is not None:
+            mini["year"] = resolved["year"]
         episode_title = title if media_type == "episode" and title != series_title else ""
         canonical = canonical_key(mini) or str(key or "")
         progress = _progress_percent(item)
@@ -236,6 +272,8 @@ class NuvioPlaybackAdapter(PlaybackProgressAdapter):
             can_mark_watched=caps.mark_watched,
             can_update_progress=bool(caps.update_progress and _duration_seconds(item)),
             capability_messages=[] if caps.configured else [caps.reason],
+            poster_url=str(item.get("poster") or item.get("poster_url") or resolved.get("poster_url") or "").strip(),
+            backdrop_url=str(item.get("background") or item.get("backdrop") or item.get("backdrop_url") or resolved.get("backdrop_url") or "").strip(),
             provider_metadata={"progress_item": clean_mapping(item), "show_ids": show_ids},
         )
 

--- a/tests/test_metadata_namespace_resolution.py
+++ b/tests/test_metadata_namespace_resolution.py
@@ -63,6 +63,28 @@ def _install(monkeypatch, tmp_path, provider, resolve_result=None):
     metaAPI._RESOLVED_ENTITY_MEMO.clear()
 
 
+def test_fetch_resolves_tvdb_id_to_tv_details() -> None:
+    provider = _provider(
+        {
+            "/find/355567": {"tv_results": [{"id": 69478}], "movie_results": []},
+            "/tv/69478": {"id": 69478, "name": "The Boys", "first_air_date": "2019-07-25"},
+            "/tv/69478/images": {"posters": [{"file_path": "/poster.jpg"}], "backdrops": []},
+        }
+    )
+
+    out = provider.fetch(
+        entity="tv",
+        ids={"tvdb": "355567"},
+        need={"poster": True, "backdrop": False, "ids": False},
+    )
+
+    assert out["title"] == "The Boys"
+    assert out["year"] == 2019
+    assert out["ids"] == {"tmdb": "69478"}
+    assert out["images"]["poster"][0]["url"] == "https://image.tmdb.org/t/p/w780/poster.jpg"
+    assert provider.calls[:2] == ["/find/355567", "/tv/69478"]
+
+
 def test_wrong_tv_namespace_resolves_to_movie() -> None:
     provider = _provider({"/movie/8392": TOTORO, "/tv/8392": POPEYE})
     outcome = provider.resolve_namespace(

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -292,12 +292,19 @@ def test_playback_progress_uses_explicit_nuvio_adapter(monkeypatch):
     assert result["items"][0]["progress_percent"] == 20.0
 
 
-def test_nuvio_playback_progress_enriches_missing_episode_title_from_tmdb(monkeypatch):
+def test_nuvio_playback_progress_enriches_missing_episode_metadata_from_content_id(monkeypatch):
     class FakeMetadata:
         def fetch(self, *, entity, ids, locale=None, need=None):
             assert entity == "tv"
             assert ids == {"tmdb": "69478"}
-            return {"title": "The Boys", "year": 2019}
+            return {
+                "title": "The Boys",
+                "year": 2019,
+                "images": {
+                    "poster": [{"url": "https://image.tmdb.org/t/p/w342/poster.jpg"}],
+                    "backdrop": [{"url": "https://image.tmdb.org/t/p/w780/backdrop.jpg"}],
+                },
+            }
 
     caps = nuvio_playback_adapter.NuvioPlaybackAdapter().capabilities(
         {"nuvio": {"profile_id": 1}},
@@ -329,3 +336,43 @@ def test_nuvio_playback_progress_enriches_missing_episode_title_from_tmdb(monkey
     assert record.title == "The Boys"
     assert record.series_title == "The Boys"
     assert record.year == 2019
+    assert record.poster_url == "https://image.tmdb.org/t/p/w342/poster.jpg"
+    assert record.backdrop_url == "https://image.tmdb.org/t/p/w780/backdrop.jpg"
+
+
+def test_nuvio_playback_progress_enriches_episode_metadata_from_tvdb_id(monkeypatch):
+    class FakeMetadata:
+        def fetch(self, *, entity, ids, locale=None, need=None):
+            assert entity == "tv"
+            assert ids == {"tvdb": "355567"}
+            return {"title": "The Boys", "year": 2019}
+
+    caps = nuvio_playback_adapter.NuvioPlaybackAdapter().capabilities(
+        {"nuvio": {"profile_id": 1}},
+        instance_id="default",
+        instance_label="Default",
+    )
+    item = {
+        "type": "episode",
+        "ids": {},
+        "show_ids": {"tvdb": "355567"},
+        "series_title": "Untitled",
+        "season": 6,
+        "episode": 2,
+        "progress_ms": 703000,
+        "duration_ms": 3307930,
+        "progress_at": 1784848068000,
+    }
+
+    record = nuvio_playback_adapter.NuvioPlaybackAdapter()._record(
+        "tvdb:355567#s06e02",
+        item,
+        "default",
+        "Default",
+        caps,
+        FakeMetadata(),
+    )
+
+    assert record is not None
+    assert record.title == "The Boys"
+    assert record.series_title == "The Boys"


### PR DESCRIPTION
# Pull request

## Change

Extend Nuvio playback progress by using configured TMDB metadata to resolve missing titles and artwork.
TMDB metadata is basically required for a good Nuvio experience, especially for titles, artwork, and resolving TVDB-backed items.

I also added TVDB ID lookup support in the TMDB metadata provider. Nuvio’s documented content IDs are tmdb:<id> and IMDb-style tt... IDs, so CW can now use configured TMDB metadata to translate TVDB-backed progress items into TMDB metadata for display.

## Why

Nuvio progress entries could show as `Untitled` even when CrossWatch had enough IDs to resolve them through metadata.

## Testing

- test_nuvio_progress.py
- test_playback_progress.py
- test_metadata_namespace_resolution.py

## Issue

Relates to #486

Note: it is still unclear what the long-term impact of this is and how heavily this may end up leaning on TMDB metadata for Nuvio-related lookups.