### PR TITLE
Add:  show progress provider failures

### DIFF
--- a/assets/js/playback_progress.js
+++ b/assets/js/playback_progress.js
@@ -61,6 +61,7 @@ html[data-cw-theme=flat-dark] #${ROOT_ID} .pp-toolbar,html[data-cw-theme=flat-da
 html[data-cw-theme=flat-light] #${ROOT_ID} .pp-toolbar,html[data-cw-theme=flat-light] #${ROOT_ID} .pp-pager{--pp-matrix-line:rgba(16,24,40,.065);--pp-matrix-glow:rgba(76,68,170,.050)}
 .pp-loading-grid{min-height:0}.pp-loading-card{cursor:default!important;pointer-events:none}.pp-loading-card:hover{border-color:var(--pp-border)!important;transform:none!important}.pp-loading-card .pp-body:before{opacity:.18!important}.pp-loading-shape{position:relative;display:block;overflow:hidden;background:color-mix(in srgb,var(--pp-soft) 12%,transparent)}.pp-loading-shape:after{content:"";position:absolute;inset:0;background:linear-gradient(110deg,transparent 0%,rgba(255,255,255,.035) 40%,rgba(255,255,255,.16) 50%,rgba(255,255,255,.035) 60%,transparent 100%);transform:translateX(-120%);animation:ppSkeletonShimmer 1.35s ease-in-out infinite}.pp-loading-art{height:100%;background:color-mix(in srgb,var(--pp-soft) 10%,var(--pp-panel-bg-strong))}.pp-loading-copy{display:grid;gap:8px;align-content:start}.pp-loading-line{height:12px;border-radius:999px}.pp-loading-line.title{width:min(62%,240px);height:16px}.pp-loading-line.meta{width:min(40%,150px);opacity:.76}.pp-loading-chip{width:58px;height:22px;border-radius:999px}.pp-loading-progress{gap:5px}.pp-loading-progress .pp-loading-line{width:30%;height:12px}.pp-loading-bar{height:8px;border-radius:999px}.pp-loading-actions{gap:6px;align-self:end}.pp-loading-action{width:58px;height:28px;border-radius:999px}.pp-loading-status{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}.is-loading #pp-refresh .material-symbols-rounded{animation:ppLoadingSpin .8s linear infinite}.is-loading .pp-toolbar{pointer-events:none;transition:opacity .16s ease}.is-initial-loading .pp-toolbar{opacity:.72}.is-initial-loading .pp-status,.is-initial-loading .pp-pager{display:none!important}.cw-compact .pp-loading-card:nth-child(n+4){display:none}@keyframes ppSkeletonShimmer{to{transform:translateX(120%)}}@keyframes ppLoadingSpin{to{transform:rotate(360deg)}}@media(max-width:980px){.pp-loading-card:nth-child(n+4){display:none}}@media(prefers-reduced-motion:reduce){.pp-loading-shape:after,.is-loading #pp-refresh .material-symbols-rounded{animation:none!important}.pp-loading-shape:after{transform:none;opacity:.35}}
 html[data-cw-theme=flat-dark] #${ROOT_ID} .pp-loading-shape{background:#2a2f39}html[data-cw-theme=flat-dark] #${ROOT_ID} .pp-loading-art{background:#242a34}html[data-cw-theme=flat-light] #${ROOT_ID} .pp-loading-shape{background:#e2e7ef}html[data-cw-theme=flat-light] #${ROOT_ID} .pp-loading-art{background:#e9edf3}html[data-cw-theme=flat-light] #${ROOT_ID} .pp-loading-shape:after{background:linear-gradient(110deg,transparent 0%,rgba(255,255,255,.16) 40%,rgba(255,255,255,.76) 50%,rgba(255,255,255,.16) 60%,transparent 100%)}
+.pp-errors{display:grid!important;gap:10px!important;padding:12px!important;background:linear-gradient(180deg,rgba(118,28,46,.20),rgba(10,12,18,.72))!important;border-color:rgba(255,138,160,.24)!important;color:var(--pp-danger-fg);font-size:13px}.pp-errors.hidden{display:none!important}.pp-error-head{display:flex;align-items:center;justify-content:space-between;gap:12px}.pp-error-title{display:flex;align-items:center;gap:9px;font-weight:900}.pp-error-title .material-symbols-rounded{font-size:22px;color:#ff9aaa}.pp-error-copy{color:var(--pp-soft);font-size:12px}.pp-error-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:10px}.pp-error-item{display:grid;grid-template-columns:42px minmax(0,1fr);gap:10px;align-items:center;min-width:0;padding:10px;border-radius:12px;border:1px solid rgba(255,255,255,.09);background:rgba(255,255,255,.035)}.pp-error-logo{display:grid;place-items:center;width:42px;height:42px;border-radius:11px;border:1px solid rgba(255,255,255,.11);background:rgba(255,255,255,.045)}.pp-error-logo img{max-width:30px;max-height:22px;object-fit:contain}.pp-error-main{min-width:0;display:grid;gap:4px}.pp-error-name{font-weight:900;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.pp-error-message{color:var(--pp-soft);line-height:1.35}.pp-error-meta{display:flex;gap:6px;flex-wrap:wrap}.pp-error-chip{display:inline-flex;align-items:center;min-height:20px;padding:0 7px;border-radius:999px;border:1px solid rgba(255,255,255,.10);background:rgba(255,255,255,.035);color:var(--pp-soft);font-size:11px;font-weight:800}.pp-error-actions{display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end}.pp-error-actions .pp-btn{min-height:30px;border-radius:999px;font-size:12px}html[data-cw-theme=flat-light] #${ROOT_ID} .pp-errors{background:linear-gradient(180deg,#fff1f3,#fff)!important;border-color:rgba(169,63,77,.28)!important}html[data-cw-theme=flat-light] #${ROOT_ID} .pp-error-item{background:rgba(169,63,77,.035);border-color:rgba(169,63,77,.12)}@media(max-width:640px){.pp-error-head{display:grid}.pp-error-actions{justify-content:flex-start}.pp-error-list{grid-template-columns:1fr}}
 .pp-settings-dialog.cw-insight-set{width:min(1180px,calc(100vw - 24px))!important;max-width:min(1180px,calc(100vw - 24px))!important;max-height:min(720px,calc(100vh - 28px))!important;padding:0!important;gap:0!important;border-radius:16px;overflow:hidden;display:grid;grid-template-rows:auto minmax(0,1fr) auto;background:linear-gradient(180deg,rgba(17,21,31,.98),rgba(13,17,25,.99))!important;border:1px solid rgba(255,255,255,.11)!important;box-shadow:0 30px 90px rgba(0,0,0,.48)!important;color:var(--pp-fg)}
 .pp-settings-dialog.cw-insight-set .cx-head{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:18px 24px 14px;border-bottom:1px solid var(--pp-border);background:rgba(255,255,255,.015)}.pp-settings-dialog .head-copy{display:grid;gap:4px;min-width:0}.pp-settings-dialog .head-title{font-size:28px;font-weight:900;line-height:1.05;letter-spacing:0}.pp-settings-dialog .head-sub{font-size:14px;color:var(--pp-soft);line-height:1.35}.pp-settings-dialog .head-actions{display:flex;align-items:center;gap:12px}.pp-settings-dialog .head-chip,.pp-settings-dialog .close-btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;height:42px;padding:0 16px;border-radius:8px;border:1px solid var(--pp-border);background:rgba(255,255,255,.035);color:var(--pp-fg);font-size:13px;font-weight:850;text-transform:uppercase;cursor:pointer}.pp-settings-dialog .head-chip .material-symbols-rounded,.pp-settings-dialog .close-btn .material-symbols-rounded{font-size:19px}
 .pp-settings-dialog .body{overflow:auto;padding:18px 24px 20px}.pp-settings-dialog .layout{display:grid;grid-template-columns:minmax(290px,320px) minmax(0,1fr);gap:22px;align-items:start}.pp-settings-dialog .panel{border-radius:16px;border:1px solid var(--pp-border);background:linear-gradient(180deg,rgba(255,255,255,.035),rgba(255,255,255,.018));overflow:hidden}.pp-settings-dialog .panel-head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:16px 18px 10px;border-bottom:1px solid var(--pp-border-soft)}.pp-settings-dialog .panel-title{font-size:16px;font-weight:900;text-transform:uppercase;letter-spacing:.03em}.pp-settings-dialog .panel-sub{margin-top:4px;color:var(--pp-soft);font-size:12px}.pp-settings-dialog .panel-body{padding:14px}.pp-settings-dialog .settings-stack{display:grid;gap:10px}.pp-settings-dialog .setting-card{display:grid;grid-template-columns:38px minmax(0,1fr) 92px;align-items:center;gap:12px;min-height:66px;padding:12px;border-radius:12px;border:1px solid rgba(124,92,255,.28);background:linear-gradient(180deg,rgba(124,92,255,.12),rgba(124,92,255,.045))}.pp-settings-dialog .setting-icon{display:grid;place-items:center;width:34px;height:34px;border-radius:10px;color:#b69cff;background:rgba(124,92,255,.12)}.pp-settings-dialog .setting-icon .material-symbols-rounded{font-size:24px}.pp-settings-dialog .setting-name{font-size:13px;font-weight:900}.pp-settings-dialog .setting-copy{margin-top:3px;color:var(--pp-soft);font-size:12px}.pp-settings-dialog .setting-card input{width:100%;height:38px;border-radius:9px;border:1px solid var(--pp-border);background:var(--pp-input-bg);color:var(--pp-fg);padding:0 10px;font-weight:850}
@@ -558,10 +559,47 @@ html[data-cw-theme=flat-dark] .pp-settings-dialog.cw-insight-set{background:#171
     wrap.classList.remove("hidden");
   }
 
+  function errorProviderName(e) {
+    const provider = String(e.provider || "").trim();
+    const label = String(e.provider_label || providerLabel(provider)).trim();
+    const instance = String(e.instance_label || e.instance_id || "").trim();
+    if (!instance || instance.toLowerCase() === "default" || instance.toLowerCase() === label.toLowerCase()) return label || "Provider";
+    return `${label || "Provider"} - ${instance}`;
+  }
+
+  function errorTitle(e) {
+    const code = String(e.error_code || "").toLowerCase();
+    if (code === "provider_timeout") return "Provider timed out";
+    if (code === "provider_unavailable") return "Provider unavailable";
+    if (code === "not_configured") return "Connection needs attention";
+    if (code.startsWith("http:")) return `Remote service returned ${code.slice(5)}`;
+    if (e.retryable) return "Provider could not refresh";
+    return "Provider notice";
+  }
+
+  function errorItem(e) {
+    const provider = String(e.provider || "").trim();
+    const status = e.remote_status ? `HTTP ${e.remote_status}` : String(e.error_code || "").replace(/_/g, " ");
+    const retry = e.retryable ? `<span class="pp-error-chip">Retryable</span>` : "";
+    return `<article class="pp-error-item">
+      <span class="pp-error-logo">${provider ? `<img src="${esc(providerLogLogo(provider))}" alt="" onerror="this.remove()">` : icon("warning")}</span>
+      <span class="pp-error-main">
+        <span class="pp-error-name">${esc(errorProviderName(e))}</span>
+        <span class="pp-error-message"><strong>${esc(errorTitle(e))}.</strong> ${esc(e.message || e.error_code || "Playback progress could not be refreshed.")}</span>
+        <span class="pp-error-meta">${status ? `<span class="pp-error-chip">${esc(status)}</span>` : ""}${retry}</span>
+      </span>
+    </article>`;
+  }
+
   function renderErrors() {
     const el = document.getElementById("pp-errors");
     if (!state.errors.length) return el.classList.add("hidden");
-    el.innerHTML = state.errors.map((e) => `${esc(e.provider || "Provider")} ${esc(e.instance_id || "")}: ${esc(e.message || e.error_code || "failed")}`).join("<br>");
+    const count = state.errors.length;
+    const partial = state.items.length > 0;
+    el.innerHTML = `<div class="pp-error-head">
+      <div><div class="pp-error-title">${icon(partial ? "sync_problem" : "error")}<span>${partial ? "Some providers could not refresh" : "Playback Progress could not refresh"}</span></div><div class="pp-error-copy">${partial ? "Showing available records from the providers that responded." : "Check the provider connection or try again in a moment."}</div></div>
+      <div class="pp-error-actions"><button class="pp-btn" type="button" data-pp-error-action="settings">${icon("settings")}Settings</button><button class="pp-btn" type="button" data-pp-error-action="retry">${icon("refresh")}Retry</button></div>
+    </div><div class="pp-error-list">${state.errors.slice(0, 6).map(errorItem).join("")}</div>${count > 6 ? `<div class="pp-error-copy">${esc(count - 6)} more provider notice${count - 6 === 1 ? "" : "s"} hidden.</div>` : ""}`;
     el.classList.remove("hidden");
   }
 
@@ -672,6 +710,9 @@ html[data-cw-theme=flat-dark] .pp-settings-dialog.cw-insight-set{background:#171
       state.items = Array.isArray(data.items) ? data.items : [];
       state.providers = Array.isArray(data.providers) ? data.providers : [];
       state.errors = Array.isArray(data.errors) ? data.errors : [];
+      if (data.ok === false && !state.errors.length) {
+        state.errors = [{ provider: "playback_progress", provider_label: "Playback Progress", message: data.message || data.error || "Playback Progress request failed.", retryable: true }];
+      }
       state.total = Number(data.total || 0);
       state.page = Number(data.page || 1);
       providerOptions();
@@ -766,6 +807,8 @@ html[data-cw-theme=flat-dark] .pp-settings-dialog.cw-insight-set{background:#171
     r.addEventListener("click", async (e) => {
       const btn = e.target?.closest?.("button");
       if (btn) {
+        if (btn.dataset?.ppErrorAction === "retry") return load(true);
+        if (btn.dataset?.ppErrorAction === "settings") return openSettings();
         if (btn.id === "pp-settings") return openSettings();
         if (btn.id === "pp-settings-cancel") return closeSettings();
         if (btn.id === "pp-settings-reset") { resetSettingsDraft(); return; }

--- a/services/playback_progress/adapters/media_servers.py
+++ b/services/playback_progress/adapters/media_servers.py
@@ -172,6 +172,19 @@ def _resolve_with_metadata(
     return out
 
 
+def _health_remote_status(health: Mapping[str, Any]) -> int | None:
+    api = health.get("api")
+    if not isinstance(api, Mapping):
+        return None
+    for value in api.values():
+        if not isinstance(value, Mapping):
+            continue
+        code = _int(value.get("status"))
+        if code:
+            return code
+    return None
+
+
 class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
     provider = ""
     provider_label = ""
@@ -181,20 +194,21 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
     def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
         configured = False
         reason = ""
-        if self.ops is None:
+        ops = self.ops
+        if ops is None:
             reason = f"{self.provider_label} playback support is unavailable in this installation."
         else:
             try:
-                configured = bool(self.ops.is_configured(config_view))
+                configured = bool(ops.is_configured(config_view))
             except Exception:
                 configured = False
             if not configured:
                 reason = f"{self.provider_label} is not connected for this instance."
-        can_use = bool(configured and self.ops is not None)
+        can_use = bool(configured and ops is not None)
         can_write = can_use
-        if can_use and self.provider == "jellyfin" and hasattr(self.ops, "progress_write_capability"):
+        if can_use and ops is not None and self.provider == "jellyfin" and hasattr(ops, "progress_write_capability"):
             try:
-                can_write, write_reason, _version = self.ops.progress_write_capability(config_view)
+                can_write, write_reason, _version = ops.progress_write_capability(config_view)
                 if not can_write:
                     reason = write_reason or "unsupported_server_version"
             except Exception:
@@ -220,11 +234,29 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
         )
 
     def list_progress(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str, force_refresh: bool = False) -> PlaybackListResult:
-        if self.ops is None:
+        ops = self.ops
+        if ops is None:
             return PlaybackListResult(ok=False, provider=self.provider, instance_id=instance_id, error_code="provider_unavailable", message=f"{self.provider_label} playback support is unavailable.", retryable=False)
         try:
             caps = self.capabilities(config_view, instance_id=instance_id, instance_label=instance_label)
-            rows = self.ops.build_index(config_view, feature="progress")
+            health_fn = getattr(ops, "health", None)
+            if callable(health_fn):
+                health = health_fn(config_view)
+                if isinstance(health, Mapping) and health.get("ok") is False:
+                    status = str(health.get("status") or "down").strip().lower()
+                    details_value = health.get("details")
+                    details = details_value if isinstance(details_value, Mapping) else {}
+                    reason = str(details.get("reason") or status or "server_unavailable").strip()
+                    return PlaybackListResult(
+                        ok=False,
+                        provider=self.provider,
+                        instance_id=instance_id,
+                        error_code="auth_failed" if status == "auth_failed" else "provider_unavailable",
+                        message=f"{self.provider_label} server is not reachable." if status == "down" else f"{self.provider_label} playback refresh failed: {reason}.",
+                        remote_status=_health_remote_status(health),
+                        retryable=status != "auth_failed",
+                    )
+            rows = ops.build_index(config_view, feature="progress")
             metadata_provider = _metadata_provider(config_view)
             items = [
                 record

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -604,6 +604,35 @@ def _provider_timeout_seconds(cfg: Mapping[str, Any]) -> float:
     return max(3.0, min(raw, 60.0))
 
 
+def _capability_error(cap: PlaybackCapabilities) -> dict[str, Any]:
+    reason = str(cap.reason or "").strip()
+    error_code = "unsupported" if cap.configured else "not_configured"
+    message = reason or "Provider does not support playback listing."
+    if cap.configured and "unavailable" in message.lower():
+        error_code = "provider_unavailable"
+    return {
+        "ok": False,
+        "provider": cap.provider,
+        "provider_label": cap.provider_label,
+        "instance_id": cap.instance_id,
+        "instance_label": cap.instance_label,
+        "operation": "list_progress",
+        "error_code": error_code,
+        "message": message,
+        "retryable": False,
+        "remote_status": None,
+    }
+
+
+def _enrich_list_error(error: dict[str, Any], cap: PlaybackCapabilities | None) -> dict[str, Any]:
+    if cap is None:
+        return error
+    out = dict(error)
+    out.setdefault("provider_label", cap.provider_label)
+    out.setdefault("instance_label", cap.instance_label)
+    return out
+
+
 class PlaybackProgressService:
     def __init__(self) -> None:
         self.adapters: dict[str, PlaybackProgressAdapter] = {
@@ -787,12 +816,15 @@ class PlaybackProgressService:
             and (not instance_filter or spec["instance_id"] == instance_filter)
         ]
         readable_specs: list[dict[str, str]] = []
+        skipped_errors: list[dict[str, Any]] = []
         capabilities = self.capabilities(cfg)
         cap_by_key = {(cap.provider, cap.instance_id): cap for cap in capabilities}
         for spec in specs:
             cap = cap_by_key.get((spec["provider"], spec["instance_id"]))
             if cap and cap.read and cap.included:
                 readable_specs.append(dict(spec))
+            elif cap and cap.included and cap.configured:
+                skipped_errors.append(_capability_error(cap))
 
         LOG.info(
             f"list requested providers={len(readable_specs)} force_refresh={bool(force_refresh)} "
@@ -829,7 +861,11 @@ class PlaybackProgressService:
             finally:
                 pool.shutdown(wait=False, cancel_futures=True)
 
-        errors = [r.to_error() for r in results if not r.ok]
+        errors = skipped_errors + [
+            _enrich_list_error(r.to_error(), cap_by_key.get((r.provider, r.instance_id)))
+            for r in results
+            if not r.ok
+        ]
         items = [_with_remaining_fallback(item.to_dict()) for result in results if result.ok for item in result.items]
         _overlay_live_streams(items)
         filtered = self._apply_filters(items, media_type=media_type, progress_min=progress_min, progress_max=progress_max, age=age, rating_min=rating_min, search=search)

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -7,8 +7,10 @@ from services.playback_progress.service import (
     _record_group_keys,
     PlaybackProgressService,
 )
+from services.playback_progress.models import PlaybackCapabilities
 import services.playback_progress.service as playback_service
 import services.playback_progress.adapters.nuvio as nuvio_playback_adapter
+from services.playback_progress.adapters.media_servers import JellyfinPlaybackAdapter
 from services.playback_progress.adapters.trakt import _trakt_image_url
 
 
@@ -235,6 +237,101 @@ def test_playback_progress_settings_reports_disabled_profiles_and_clamped_timeou
     assert data["provider_timeout_seconds"] == 60.0
     assert by_key["trakt:default"]["included"] is True
     assert by_key["trakt:TRAKT-P01"]["included"] is False
+
+
+class _UnreadPlaybackAdapter:
+    provider = "trakt"
+    provider_label = "Trakt"
+
+    def __init__(self, *, configured=True):
+        self.configured = configured
+
+    def capabilities(self, config_view, *, instance_id, instance_label):
+        return PlaybackCapabilities(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            configured=self.configured,
+            read=False,
+            reason="Trakt playback support is unavailable in this installation." if self.configured else "Trakt is not connected for this instance.",
+        )
+
+
+def test_playback_progress_items_reports_included_unreadable_provider(monkeypatch):
+    cfg = {"trakt": {"access_token": "default-token", "client_id": "client-id"}}
+
+    monkeypatch.setattr(playback_service, "load_config", lambda: cfg)
+
+    service = PlaybackProgressService()
+    service.adapters["trakt"] = _UnreadPlaybackAdapter()
+    result = service.items(provider="trakt", force_refresh=True)
+
+    assert result["items"] == []
+    assert result["errors"] == [
+        {
+            "ok": False,
+            "provider": "trakt",
+            "provider_label": "Trakt",
+            "instance_id": "default",
+            "instance_label": "Trakt Default",
+            "operation": "list_progress",
+            "error_code": "provider_unavailable",
+            "message": "Trakt playback support is unavailable in this installation.",
+            "retryable": False,
+            "remote_status": None,
+        }
+    ]
+
+
+def test_playback_progress_items_ignores_included_unconfigured_provider(monkeypatch):
+    cfg = {"trakt": {"access_token": "default-token", "client_id": "client-id"}}
+
+    monkeypatch.setattr(playback_service, "load_config", lambda: cfg)
+
+    service = PlaybackProgressService()
+    service.adapters["trakt"] = _UnreadPlaybackAdapter(configured=False)
+    result = service.items(provider="trakt", force_refresh=True)
+
+    assert result["items"] == []
+    assert result["errors"] == []
+
+
+class _DownJellyfinOps:
+    def is_configured(self, cfg):
+        return True
+
+    def progress_write_capability(self, cfg):
+        return True, "", "10.10.0"
+
+    def health(self, cfg):
+        return {
+            "ok": False,
+            "status": "down",
+            "details": {"reason": "server_unreachable"},
+            "api": {"user": {"status": None}},
+        }
+
+    def build_index(self, cfg, *, feature):
+        raise AssertionError("server-down health should stop before build_index")
+
+
+def test_media_server_playback_reports_configured_server_down():
+    adapter = JellyfinPlaybackAdapter()
+    adapter.ops = _DownJellyfinOps()
+
+    result = adapter.list_progress(
+        {"jellyfin": {"server": "http://jellyfin.local", "access_token": "token", "user_id": "u1"}},
+        instance_id="default",
+        instance_label="Jellyfin Default",
+        force_refresh=True,
+    )
+
+    assert result.ok is False
+    assert result.provider == "jellyfin"
+    assert result.error_code == "provider_unavailable"
+    assert result.message == "Jellyfin server is not reachable."
+    assert result.retryable is True
 
 
 class _FakeNuvioOps:


### PR DESCRIPTION
# Pull request

## Change

Adds visible Playback Progress warnings when included provider profiles cannot refresh:
- Renders provider refresh failures.
- Preserves warnings for configured included providers that are unavailable or fail refresh.

## Why

When a configured provider was unavailable or a media server was down, users could see only “No playback records found” with no explanation. Media servers could return an empty index when unreachable, which made Playback Progress treat the refresh as successful.

## Testing

- test_playback_progress.py

## Issue

NA