### PR TITLE
Change: improve Nuvio sync ID handling

### DIFF
--- a/providers/sync/_mod_NUVIO.py
+++ b/providers/sync/_mod_NUVIO.py
@@ -25,7 +25,7 @@ from .nuvio import _progress as feat_progress
 from .nuvio import _watchlist as feat_watchlist
 from .nuvio._common import pull_library_rows, pull_watch_progress_rows, pull_watched_rows
 
-__VERSION__ = "0.1"
+__VERSION__ = "0.2"
 __all__ = ["get_manifest", "NUVIOModule", "OPS"]
 
 
@@ -55,7 +55,7 @@ def get_manifest() -> Mapping[str, Any]:
                 "upsert": True,
                 "remove": True,
                 "observed_deletes": True,
-                "requires_ids": ["imdb", "tmdb", "trakt"],
+                "requires_ids": ["tmdb", "imdb", "tvdb"],
                 "requires_duration": True,
             },
             "history": {
@@ -63,14 +63,14 @@ def get_manifest() -> Mapping[str, Any]:
                 "upsert": True,
                 "remove": True,
                 "observed_deletes": True,
-                "requires_ids": ["imdb", "tmdb", "trakt"],
+                "requires_ids": ["tmdb", "imdb", "tvdb"],
             },
             "watchlist": {
                 "types": {"movies": True, "shows": True, "seasons": False, "episodes": False},
                 "upsert": True,
                 "remove": True,
                 "observed_deletes": True,
-                "requires_ids": ["imdb", "tmdb", "trakt"],
+                "requires_ids": ["tmdb", "imdb", "tvdb"],
             },
         },
     }

--- a/providers/sync/nuvio/_common.py
+++ b/providers/sync/nuvio/_common.py
@@ -41,11 +41,14 @@ __all__ = [
     "is_configured",
     "library_lock",
     "make_item",
+    "metadata_title_for_content_id",
+    "payload_item_key",
     "positive_int",
     "progress_key",
     "pull_library_rows",
     "pull_watch_progress_rows",
     "pull_watched_rows",
+    "resolve_content_id_for_item",
     "resolve_episode",
     "rpc",
     "selected_profile_id",
@@ -131,10 +134,6 @@ def ids_for_content_id(content_id: Any) -> dict[str, str] | None:
         value = raw.split(":", 1)[1].strip()
         if value.isdigit():
             return {"tmdb": value}
-    if low.startswith("trakt:"):
-        value = raw.split(":", 1)[1].strip()
-        if value.isdigit():
-            return {"trakt": value}
     return None
 
 
@@ -159,10 +158,89 @@ def content_id_for_item(item: Mapping[str, Any]) -> str | None:
     imdb = str(raw_ids.get("imdb") or "").strip()
     if imdb.startswith("tt") and imdb[2:].isdigit():
         return imdb
-    trakt = str(raw_ids.get("trakt") or "").strip()
-    if trakt.isdigit():
-        return f"trakt:{trakt}"
     return None
+
+
+def _tmdb_metadata_provider(adapter: Any) -> Any | None:
+    cfg = getattr(adapter, "config", None) or getattr(adapter, "raw_cfg", None) or {}
+    if not isinstance(cfg, Mapping):
+        return None
+    tmdb_obj = cfg.get("tmdb")
+    tmdb: Mapping[str, Any] = tmdb_obj if isinstance(tmdb_obj, Mapping) else {}
+    metadata_obj = cfg.get("metadata")
+    metadata: Mapping[str, Any] = metadata_obj if isinstance(metadata_obj, Mapping) else {}
+    if not str(tmdb.get("api_key") or metadata.get("tmdb_api_key") or "").strip():
+        return None
+    try:
+        from providers.metadata._meta_TMDB import TmdbProvider
+
+        return TmdbProvider(lambda: dict(cfg), lambda _cfg: None)
+    except Exception:
+        return None
+
+
+def _metadata_lookup_ids(item: Mapping[str, Any], item_type: str) -> dict[str, str]:
+    source: Mapping[str, Any] | None = None
+    show_ids = item.get("show_ids")
+    if item_type in {"episode", "episodes", "season", "seasons"} and isinstance(show_ids, Mapping):
+        source = show_ids
+    if source is None:
+        source = merge_ids(ids_from(item), ids_from(id_minimal(item)))
+        if isinstance(show_ids, Mapping):
+            source = merge_ids(source, {str(k): v for k, v in show_ids.items()})
+        content_ids = ids_for_content_id(item.get("content_id"))
+        if content_ids:
+            source = merge_ids(source, content_ids)
+    return {
+        key: str(source.get(key) or "").strip()
+        for key in ("tmdb", "imdb", "tvdb")
+        if str(source.get(key) or "").strip()
+    }
+
+
+def resolve_content_id_for_item(adapter: Any, item: Mapping[str, Any]) -> str | None:
+    remote_content_id = str(item.get("_nuvio_content_id") or "").strip()
+    if remote_content_id and ids_for_content_id(remote_content_id):
+        return remote_content_id
+    direct = content_id_for_item(item)
+    if direct and direct.lower().startswith("tmdb:"):
+        return direct
+    item_type = str(item.get("type") or id_minimal(item).get("type") or "").strip().lower()
+    lookup_ids = _metadata_lookup_ids(item, item_type)
+    if not lookup_ids:
+        return None
+    provider = _tmdb_metadata_provider(adapter)
+    if provider is None:
+        return None
+    try:
+        detail = provider.fetch(
+            entity="tv" if item_type in {"episode", "episodes", "season", "seasons", "show", "series", "tv"} else "movie",
+            ids=lookup_ids,
+            need={"poster": False, "backdrop": False, "ids": True},
+        )
+    except Exception:
+        return None
+    if not isinstance(detail, Mapping):
+        return None
+    ids = detail.get("ids")
+    if not isinstance(ids, Mapping):
+        return None
+    tmdb = str(ids.get("tmdb") or "").strip()
+    return f"tmdb:{tmdb}" if tmdb.isdigit() else None
+
+
+def metadata_title_for_content_id(adapter: Any, content_id: Any, entity: str) -> str:
+    ids = ids_for_content_id(content_id) or {}
+    if not ids:
+        return ""
+    provider = _tmdb_metadata_provider(adapter)
+    if provider is None:
+        return ""
+    try:
+        detail = provider.fetch(entity=entity, ids=ids, need={"poster": False, "backdrop": False, "ids": False})
+    except Exception:
+        return ""
+    return str(detail.get("title") or "").strip() if isinstance(detail, Mapping) else ""
 
 
 def make_item(
@@ -213,6 +291,20 @@ def canonical_item_key(item: Mapping[str, Any]) -> str:
     return canonical_key(id_minimal(item))
 
 
+def payload_item_key(payload: Mapping[str, Any]) -> str:
+    return canonical_item_key(
+        make_item(
+            content_id=payload.get("content_id"),
+            content_type=payload.get("content_type"),
+            season=payload.get("season"),
+            episode=payload.get("episode"),
+            title=payload.get("name"),
+            year=payload.get("release_info"),
+        )
+        or {}
+    )
+
+
 def content_id_key(item: Mapping[str, Any]) -> str:
     content_id = content_id_for_item(item)
     season = positive_int(item.get("season"))
@@ -237,7 +329,7 @@ def progress_key(item: Mapping[str, Any]) -> str | None:
 
 
 def resolve_episode(adapter: Any, item: Mapping[str, Any], *, current_rows: Any = None) -> EpisodeMapResult:
-    content_id = content_id_for_item(item)
+    content_id = resolve_content_id_for_item(adapter, item)
     season = positive_int(item.get("season"))
     episode = positive_int(item.get("episode"))
     if not content_id:

--- a/providers/sync/nuvio/_history.py
+++ b/providers/sync/nuvio/_history.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable, Mapping
 from typing import Any
 
@@ -12,11 +13,13 @@ from providers.sync._log import log as cw_log
 
 from ._common import (
     canonical_item_key,
-    content_id_for_item,
     epoch_ms,
     make_item,
+    metadata_title_for_content_id,
+    payload_item_key,
     positive_int,
     pull_watched_rows,
+    resolve_content_id_for_item,
     resolve_episode,
     rpc,
     selected_profile_id,
@@ -31,13 +34,35 @@ def _warn(event: str, **fields: Any) -> None:
     cw_log("NUVIO", "history", "warn", event, **fields)
 
 
-def _item_from_row(row: Mapping[str, Any]) -> tuple[str | None, dict[str, Any] | None, str | None]:
+def _is_episode_code(value: Any) -> bool:
+    return bool(re.fullmatch(r"S\d{1,3}E\d{1,4}", str(value or "").strip(), re.I))
+
+
+def _series_title_from_episode_label(value: Any) -> str:
+    match = re.fullmatch(r"\s*(.+?)\s+-\s+S\d{1,3}E\d{1,4}\s*", str(value or "").strip(), re.I)
+    return match.group(1).strip() if match else str(value or "").strip()
+
+
+def _episode_title(item: Mapping[str, Any], season: Any, episode: Any) -> str:
+    code = f"S{int(season):02d}E{int(episode):02d}" if positive_int(season) and positive_int(episode) else ""
+    series = str(item.get("series_title") or item.get("show_title") or "").strip()
+    title = str(item.get("title") or "").strip()
+    if series:
+        return f"{series} - {code}" if code else series
+    return title or code
+
+
+def _item_from_row(adapter: Any, row: Mapping[str, Any]) -> tuple[str | None, dict[str, Any] | None, str | None]:
+    ctype = str(row.get("content_type") or "").strip().lower()
+    title = str(row.get("title") or row.get("name") or "").strip()
+    if ctype in {"series", "show"}:
+        title = metadata_title_for_content_id(adapter, row.get("content_id"), "tv") if not title or _is_episode_code(title) else _series_title_from_episode_label(title)
     item = make_item(
         content_id=row.get("content_id"),
-        content_type=row.get("content_type"),
+        content_type=ctype,
         season=row.get("season"),
         episode=row.get("episode"),
-        title=row.get("title") or row.get("name"),
+        title=title,
         year=row.get("year"),
     )
     watched_at = epoch_ms(row.get("watched_at"))
@@ -58,7 +83,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
     out: dict[str, dict[str, Any]] = {}
     skipped = 0
     for row in rows:
-        key, item, reason = _item_from_row(row)
+        key, item, reason = _item_from_row(adapter, row)
         if not key or not item:
             if reason:
                 skipped += 1
@@ -75,7 +100,7 @@ def _payload_for_item(adapter: Any, item: Mapping[str, Any], current_rows: Any =
     it = dict(item or {})
     mini = id_minimal(it)
     typ = str(mini.get("type") or it.get("type") or "").strip().lower()
-    content_id = content_id_for_item(it)
+    content_id = resolve_content_id_for_item(adapter, it)
     watched_at = epoch_ms(mini.get("watched_at") if isinstance(mini, Mapping) else None)
     if watched_at is None:
         watched_at = epoch_ms(it.get("watched_at") or it.get("last_watched_at") or it.get("lastWatchedAt"))
@@ -84,7 +109,6 @@ def _payload_for_item(adapter: Any, item: Mapping[str, Any], current_rows: Any =
     if watched_at is None:
         return None, "nuvio_history_write_failed"
 
-    title = str(it.get("title") or it.get("series_title") or "").strip()
     if typ in {"episode", "episodes"}:
         resolved = resolve_episode(adapter, it, current_rows=current_rows)
         if not resolved.ok:
@@ -92,18 +116,19 @@ def _payload_for_item(adapter: Any, item: Mapping[str, Any], current_rows: Any =
         return {
             "content_id": resolved.content_id,
             "content_type": "series",
-            "title": title,
+            "title": _episode_title(it, resolved.destination_season, resolved.destination_episode),
             "season": resolved.destination_season,
             "episode": resolved.destination_episode,
             "watched_at": int(watched_at),
         }, None
     if typ not in {"movie", "movies"}:
         return None, "nuvio_id_missing"
+    title = str(it.get("title") or "").strip()
     return {"content_id": content_id, "content_type": "movie", "title": title, "watched_at": int(watched_at)}, None
 
 
-def _delete_key_for_item(item: Mapping[str, Any]) -> dict[str, Any] | None:
-    content_id = content_id_for_item(item)
+def _delete_key_for_item(adapter: Any, item: Mapping[str, Any]) -> dict[str, Any] | None:
+    content_id = resolve_content_id_for_item(adapter, item)
     if not content_id:
         return None
     key: dict[str, Any] = {"content_id": content_id}
@@ -143,6 +168,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
     results: list[dict[str, Any]] = []
     payloads: list[dict[str, Any]] = []
     keys: list[str] = []
+    verify_keys: list[str] = []
     pending_items: list[dict[str, Any]] = []
     skipped = 0
 
@@ -154,13 +180,15 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
             unresolved.append(entry)
             results.append(entry)
             continue
-        target = current.get(key)
+        verify_key = payload_item_key(payload) or key
+        target = current.get(verify_key) or current.get(key)
         if target and (epoch_ms(target.get("watched_at")) or 0) >= int(payload.get("watched_at") or 0):
             skipped += 1
             results.append({"status": "skipped", "reason": "history_unchanged", "item": id_minimal(item), "canonical_key": key})
             continue
         payloads.append(payload)
         keys.append(key)
+        verify_keys.append(verify_key)
         pending_items.append(item)
         results.append({"status": "pending" if not dry_run else "dry_run", "item": id_minimal(item), "canonical_key": key})
 
@@ -178,8 +206,8 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
 
     after = build_index(adapter) if payloads and not failed else current
     confirmed: list[str] = []
-    for key in ([] if failed else keys):
-        if key in after:
+    for key, verify_key in ([] if failed else zip(keys, verify_keys)):
+        if verify_key in after:
             confirmed.append(key)
         else:
             unresolved.append({"status": "failed", "reason": "nuvio_history_verification_failed", "canonical_key": key})
@@ -196,23 +224,26 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
     results: list[dict[str, Any]] = []
     keys_payload: list[dict[str, Any]] = []
     item_keys: list[str] = []
+    verify_keys: list[str] = []
     pending_items: list[dict[str, Any]] = []
     skipped = 0
 
     for item in src:
         item_key = canonical_item_key(item)
-        payload = _delete_key_for_item(current.get(item_key) or item)
+        payload = _delete_key_for_item(adapter, current.get(item_key) or item)
         if not payload:
             entry = _unresolved(item, "nuvio_id_missing")
             unresolved.append(entry)
             results.append(entry)
             continue
-        if item_key and item_key not in current:
+        verify_key = payload_item_key(payload) or item_key
+        if verify_key and verify_key not in current:
             skipped += 1
             results.append({"status": "skipped", "reason": "already_absent", "item": id_minimal(item), "canonical_key": item_key})
             continue
         keys_payload.append(payload)
         item_keys.append(item_key)
+        verify_keys.append(verify_key)
         pending_items.append(item)
         results.append({"status": "pending" if not dry_run else "dry_run", "item": id_minimal(item), "canonical_key": item_key})
 
@@ -230,8 +261,8 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
 
     after = build_index(adapter) if keys_payload and not failed else current
     confirmed: list[str] = []
-    for key in ([] if failed else item_keys):
-        if key and key not in after:
+    for key, verify_key in ([] if failed else zip(item_keys, verify_keys)):
+        if key and verify_key not in after:
             confirmed.append(key)
         elif key:
             unresolved.append({"status": "failed", "reason": "nuvio_history_verification_failed", "canonical_key": key})

--- a/providers/sync/nuvio/_progress.py
+++ b/providers/sync/nuvio/_progress.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable, Mapping
 from typing import Any
 
@@ -13,12 +14,14 @@ from providers.sync._progress_policy import decide_progress_write, progress_mate
 
 from ._common import (
     canonical_item_key,
-    content_id_for_item,
     epoch_ms,
     make_item,
+    metadata_title_for_content_id,
+    payload_item_key,
     positive_int,
     progress_key,
     pull_watch_progress_rows,
+    resolve_content_id_for_item,
     resolve_episode,
     rpc,
     selected_profile_id,
@@ -56,13 +59,21 @@ def _duration_ms(item: Mapping[str, Any]) -> int | None:
     return None
 
 
-def _item_from_row(row: Mapping[str, Any]) -> tuple[str | None, dict[str, Any] | None, str | None]:
+def _is_episode_code(value: Any) -> bool:
+    return bool(re.fullmatch(r"S\d{1,3}E\d{1,4}", str(value or "").strip(), re.I))
+
+
+def _item_from_row(adapter: Any, row: Mapping[str, Any]) -> tuple[str | None, dict[str, Any] | None, str | None]:
+    ctype = str(row.get("content_type") or "").strip().lower()
+    title = str(row.get("title") or row.get("name") or "").strip()
+    if ctype in {"series", "show"} and (not title or _is_episode_code(title)):
+        title = metadata_title_for_content_id(adapter, row.get("content_id"), "tv")
     base = make_item(
         content_id=row.get("content_id"),
-        content_type=row.get("content_type"),
+        content_type=ctype,
         season=row.get("season"),
         episode=row.get("episode"),
-        title=row.get("title") or row.get("name"),
+        title=title,
         year=row.get("year"),
     )
     position = to_int(row.get("position"))
@@ -98,7 +109,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
     out: dict[str, dict[str, Any]] = {}
     skipped = 0
     for row in rows:
-        key, item, reason = _item_from_row(row)
+        key, item, reason = _item_from_row(adapter, row)
         if not key or not item:
             if reason:
                 skipped += 1
@@ -114,7 +125,7 @@ def _payload_for_item(adapter: Any, item: Mapping[str, Any], current_rows: Any =
     it = dict(item or {})
     mini = id_minimal(it)
     typ = str(mini.get("type") or it.get("type") or "").strip().lower()
-    content_id = content_id_for_item(it)
+    content_id = resolve_content_id_for_item(adapter, it)
     if not content_id:
         return None, "nuvio_id_missing"
 
@@ -200,7 +211,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
     rows = pull_watch_progress_rows(adapter)
     current: dict[str, dict[str, Any]] = {}
     for row in rows:
-        key, item, _reason = _item_from_row(row)
+        key, item, _reason = _item_from_row(adapter, row)
         if key and item:
             current[key] = item
 
@@ -208,6 +219,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
     results: list[dict[str, Any]] = []
     entries: list[dict[str, Any]] = []
     keys: list[str] = []
+    verify_keys: list[str] = []
     pending_items: list[dict[str, Any]] = []
     skipped = 0
 
@@ -219,7 +231,8 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
             unresolved.append(entry)
             results.append(entry)
             continue
-        target = current.get(key)
+        verify_key = payload_item_key(payload) or key
+        target = current.get(verify_key) or current.get(key)
         decision = decide_progress_write(
             active_session=False,
             source_timestamp=payload.get("last_watched"),
@@ -238,6 +251,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
             continue
         entries.append(payload)
         keys.append(key)
+        verify_keys.append(verify_key)
         pending_items.append(item)
         results.append({"status": "pending" if not dry_run else "dry_run", "item": id_minimal(item), "canonical_key": key})
 
@@ -255,26 +269,34 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
 
     after = build_index(adapter) if entries and not write_failed else current
     confirmed: list[str] = []
-    for key, payload in ([] if write_failed else zip(keys, entries)):
-        if _confirmed_after_write(after, key, payload):
+    for key, verify_key, payload in ([] if write_failed else zip(keys, verify_keys, entries)):
+        if _confirmed_after_write(after, verify_key, payload):
             confirmed.append(key)
         else:
-            unresolved.append({"status": "failed", "reason": "nuvio_progress_verification_failed", "canonical_key": key, "item": dict(after.get(key) or {})})
+            unresolved.append({"status": "failed", "reason": "nuvio_progress_verification_failed", "canonical_key": key, "item": dict(after.get(verify_key) or {})})
 
     ok = len(unresolved) == 0
     _info("write_done", op="add", ok=ok, attempted=len(entries), confirmed=len(confirmed), skipped=skipped, unresolved=len(unresolved))
     return _result(ok, len(confirmed), len(entries), confirmed, unresolved, results, skipped)
 
 
-def _remote_key_for_item(current: Mapping[str, Mapping[str, Any]], item: Mapping[str, Any]) -> tuple[str | None, str | None]:
+def _remote_key_for_item(adapter: Any, current: Mapping[str, Mapping[str, Any]], item: Mapping[str, Any]) -> tuple[str | None, str | None, str | None]:
     item_key = canonical_item_key(item)
-    row = current.get(item_key)
+    content_id = resolve_content_id_for_item(adapter, item)
+    resolved_item = make_item(
+        content_id=content_id,
+        content_type="series" if str(item.get("type") or "").strip().lower() in {"episode", "episodes", "show", "series", "tv"} else "movie",
+        season=item.get("season"),
+        episode=item.get("episode"),
+    ) if content_id else None
+    verify_key = canonical_item_key(resolved_item or {}) or item_key
+    row = current.get(verify_key) or current.get(item_key)
     if isinstance(row, Mapping):
         remote = progress_key(row)
         if remote:
-            return remote, item_key
+            return remote, item_key, verify_key
     remote = progress_key(item)
-    return remote, item_key
+    return remote, item_key, verify_key
 
 
 def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
@@ -284,22 +306,24 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
     results: list[dict[str, Any]] = []
     remote_keys: list[str] = []
     item_keys: list[str] = []
+    verify_keys: list[str] = []
     pending_items: list[dict[str, Any]] = []
     skipped = 0
 
     for item in src:
-        remote_key, item_key = _remote_key_for_item(current, item)
+        remote_key, item_key, verify_key = _remote_key_for_item(adapter, current, item)
         if not remote_key:
             entry = _unresolved(item, "nuvio_video_id_missing")
             unresolved.append(entry)
             results.append(entry)
             continue
-        if item_key and item_key not in current:
+        if verify_key and verify_key not in current:
             skipped += 1
             results.append({"status": "skipped", "reason": "already_absent", "item": id_minimal(item), "canonical_key": item_key})
             continue
         remote_keys.append(remote_key)
         item_keys.append(item_key or "")
+        verify_keys.append(verify_key or item_key or "")
         pending_items.append(item)
         results.append({"status": "pending" if not dry_run else "dry_run", "item": id_minimal(item), "canonical_key": item_key})
 
@@ -317,11 +341,11 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
 
     after = build_index(adapter) if remote_keys and not delete_failed else current
     confirmed: list[str] = []
-    for item_key in ([] if delete_failed else item_keys):
-        if item_key and item_key not in after:
+    for item_key, verify_key in ([] if delete_failed else zip(item_keys, verify_keys)):
+        if item_key and verify_key not in after:
             confirmed.append(item_key)
         elif item_key:
-            unresolved.append({"status": "failed", "reason": "nuvio_progress_verification_failed", "canonical_key": item_key, "item": dict(after.get(item_key) or {})})
+            unresolved.append({"status": "failed", "reason": "nuvio_progress_verification_failed", "canonical_key": item_key, "item": dict(after.get(verify_key) or {})})
 
     ok = len(unresolved) == 0
     _info("write_done", op="remove", ok=ok, attempted=len(remote_keys), confirmed=len(confirmed), skipped=skipped, unresolved=len(unresolved))

--- a/providers/sync/nuvio/_watchlist.py
+++ b/providers/sync/nuvio/_watchlist.py
@@ -10,7 +10,7 @@ from cw_platform.id_map import canonical_key, ids_from, minimal as id_minimal
 
 from providers.sync._log import log as cw_log
 
-from ._common import canonical_item_key, content_id_for_item, epoch_ms, library_lock, make_item, pull_library_rows, rpc, selected_profile_id
+from ._common import canonical_item_key, epoch_ms, library_lock, make_item, payload_item_key, pull_library_rows, resolve_content_id_for_item, rpc, selected_profile_id
 
 _METADATA_FIELDS = (
     "name",
@@ -174,7 +174,7 @@ def _tmdb_enrichment(adapter: Any, item: Mapping[str, Any], *, content_id: str, 
 
 
 def _remote_for_item(adapter: Any, item: Mapping[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
-    content_id = content_id_for_item(item)
+    content_id = resolve_content_id_for_item(adapter, item)
     if not content_id:
         return None, "nuvio_id_missing"
     typ = str(item.get("type") or "").strip().lower()
@@ -200,6 +200,15 @@ def _remote_for_item(adapter: Any, item: Mapping[str, Any]) -> tuple[dict[str, A
         if out.get(key) in (None, "", []) and value not in (None, "", []):
             out[key] = value
     return out, None
+
+
+def _verify_key_for_item(adapter: Any, item: Mapping[str, Any]) -> str:
+    content_id = resolve_content_id_for_item(adapter, item)
+    if not content_id:
+        return canonical_item_key(item)
+    typ = str(item.get("type") or "").strip().lower()
+    content_type = "series" if typ in {"show", "series", "tv"} else "movie"
+    return payload_item_key({"content_id": content_id, "content_type": content_type}) or canonical_item_key(item)
 
 
 def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
@@ -272,6 +281,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
         changed = False
         attempted = 0
         pending_keys: list[str] = []
+        verify_keys: list[str] = []
         pending_items: list[dict[str, Any]] = []
 
         for item in src:
@@ -282,13 +292,16 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
                 unresolved.append(entry)
                 results.append(entry)
                 continue
+            verify_key = payload_item_key(payload) or key
             attempted += 1
-            existing = remote.get(key)
+            existing = remote.get(verify_key) or remote.get(key)
             merged = _merge_metadata(existing, payload)
             if existing != merged:
-                remote[key] = merged
+                remote.pop(key, None)
+                remote[verify_key] = merged
                 changed = True
             pending_keys.append(key)
+            verify_keys.append(verify_key)
             pending_items.append(item)
             results.append({"status": "pending" if not dry_run else "dry_run", "item": id_minimal(item), "canonical_key": key})
 
@@ -301,8 +314,8 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
                 return _result(False, 0, attempted, [], [{"status": "failed", "reason": "nuvio_library_replace_failed"}], results, 0)
 
         after = build_index(adapter)
-        confirmed = [key for key in pending_keys if key in after]
-        unresolved.extend({"status": "failed", "reason": "nuvio_library_verification_failed", "item": id_minimal(item), "canonical_key": key} for item, key in zip(pending_items, pending_keys) if key not in after)
+        confirmed = [key for key, verify_key in zip(pending_keys, verify_keys) if verify_key in after]
+        unresolved.extend({"status": "failed", "reason": "nuvio_library_verification_failed", "item": id_minimal(item), "canonical_key": key} for item, key, verify_key in zip(pending_items, pending_keys, verify_keys) if verify_key not in after)
         ok = len(unresolved) == 0
         _info("write_done", op="add", ok=ok, attempted=attempted, confirmed=len(confirmed), unresolved=len(unresolved))
         return _result(ok, len(confirmed), attempted, confirmed, unresolved, results, 0)
@@ -317,22 +330,25 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
         attempted = 0
         skipped = 0
         pending_keys: list[str] = []
+        verify_keys: list[str] = []
         pending_items: list[dict[str, Any]] = []
 
         for item in src:
             key = canonical_item_key(item)
+            verify_key = _verify_key_for_item(adapter, item)
             if not key or key == "unknown:":
                 entry = {"status": "unresolved", "reason": "nuvio_id_missing", "item": id_minimal(item)}
                 unresolved.append(entry)
                 results.append(entry)
                 continue
-            if key not in remote:
+            if verify_key not in remote:
                 skipped += 1
                 results.append({"status": "skipped", "reason": "already_absent", "item": id_minimal(item), "canonical_key": key})
                 continue
             attempted += 1
-            remote.pop(key, None)
+            remote.pop(verify_key, None)
             pending_keys.append(key)
+            verify_keys.append(verify_key)
             pending_items.append(item)
             results.append({"status": "pending" if not dry_run else "dry_run", "item": id_minimal(item), "canonical_key": key})
 
@@ -346,10 +362,10 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
 
         after = build_index(adapter)
         confirmed: list[str] = []
-        for item, key in zip(pending_items, pending_keys):
-            if key and key not in after:
+        for item, key, verify_key in zip(pending_items, pending_keys, verify_keys):
+            if key and verify_key not in after:
                 confirmed.append(key)
-            elif key in current:
+            elif verify_key in current:
                 unresolved.append({"status": "failed", "reason": "nuvio_library_verification_failed", "item": id_minimal(item), "canonical_key": key})
         ok = len(unresolved) == 0
         _info("write_done", op="remove", ok=ok, attempted=attempted, confirmed=len(confirmed), skipped=skipped, unresolved=len(unresolved))

--- a/providers/tests/test_nuvio_history.py
+++ b/providers/tests/test_nuvio_history.py
@@ -78,17 +78,98 @@ def test_history_reads_and_deletes_episode_with_official_key_shape() -> None:
     assert delete["p_keys"] == [{"content_id": "tmdb:1396", "season": 1, "episode": 1}]
 
 
+def test_history_read_enriches_episode_code_title_from_tmdb(monkeypatch: Any) -> None:
+    from providers.metadata import _meta_TMDB
+    from providers.sync.nuvio import _history
+
+    class FakeTmdb:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
+            assert entity == "tv"
+            assert ids == {"tmdb": "299167"}
+            return {"title": "Example Show"}
+
+    adapter = FakeAdapter(
+        [
+            {
+                "content_id": "tmdb:299167",
+                "content_type": "series",
+                "title": "S01E08",
+                "season": 1,
+                "episode": 8,
+                "watched_at": 1_783_890_886_000,
+            }
+        ]
+    )
+    adapter.config["tmdb"] = {"api_key": "tmdb-key"}
+    monkeypatch.setattr(_meta_TMDB, "TmdbProvider", FakeTmdb)
+
+    item = _history.build_index(adapter)["tmdb:299167#s01e08"]
+
+    assert item["series_title"] == "Example Show"
+
+
+def test_history_read_strips_episode_code_from_series_title() -> None:
+    from providers.sync.nuvio import _history
+
+    adapter = FakeAdapter(
+        [
+            {
+                "content_id": "tmdb:1396",
+                "content_type": "series",
+                "title": "Breaking Bad - S01E03",
+                "season": 1,
+                "episode": 3,
+                "watched_at": 1_785_000_000_000,
+            }
+        ]
+    )
+
+    item = _history.build_index(adapter)["tmdb:1396#s01e03"]
+
+    assert item["series_title"] == "Breaking Bad"
+    assert item["season"] == 1
+    assert item["episode"] == 3
+
+
 def test_history_adds_movie_and_verifies() -> None:
     from providers.sync.nuvio import _history
 
     adapter = FakeAdapter([])
+    result = _history.add(adapter, [{"type": "movie", "ids": {"tmdb": "550"}, "title": "Fight Club", "watched_at": 1_785_000_000_000}])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tmdb:550"]
+    push = [body for name, body in adapter.client.calls if name == "sync_push_watched_items"][0]
+    assert push["p_items"][0]["content_id"] == "tmdb:550"
+    assert push["p_items"][0]["content_type"] == "movie"
+
+
+def test_history_adds_movie_resolves_imdb_to_tmdb_content_id_when_tmdb_configured(monkeypatch: Any) -> None:
+    from providers.metadata import _meta_TMDB
+    from providers.sync.nuvio import _history
+
+    class FakeTmdb:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
+            assert entity == "movie"
+            assert ids == {"imdb": "tt0137523"}
+            return {"ids": {"tmdb": "550"}}
+
+    adapter = FakeAdapter([])
+    adapter.config["tmdb"] = {"api_key": "tmdb-key"}
+    monkeypatch.setattr(_meta_TMDB, "TmdbProvider", FakeTmdb)
+
     result = _history.add(adapter, [{"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club", "watched_at": 1_785_000_000_000}])
 
     assert result["ok"] is True
     assert result["confirmed_keys"] == ["imdb:tt0137523"]
     push = [body for name, body in adapter.client.calls if name == "sync_push_watched_items"][0]
-    assert push["p_items"][0]["content_id"] == "tt0137523"
-    assert push["p_items"][0]["content_type"] == "movie"
+    assert push["p_items"][0]["content_id"] == "tmdb:550"
 
 
 def test_history_adds_episode_with_show_tmdb_id_not_episode_tmdb_id() -> None:
@@ -100,6 +181,7 @@ def test_history_adds_episode_with_show_tmdb_id_not_episode_tmdb_id() -> None:
         "ids": {"tmdb": "5978363", "imdb": "tt35707151"},
         "show_ids": {"tmdb": "69478"},
         "series_title": "The Boys",
+        "title": "The Big Ride",
         "season": 6,
         "episode": 2,
         "watched_at": 1_785_000_000_000,
@@ -113,5 +195,44 @@ def test_history_adds_episode_with_show_tmdb_id_not_episode_tmdb_id() -> None:
     row = push["p_items"][0]
     assert row["content_id"] == "tmdb:69478"
     assert row["content_type"] == "series"
+    assert row["title"] == "The Boys - S06E02"
+    assert row["season"] == 6
+    assert row["episode"] == 2
+
+
+def test_history_adds_episode_resolves_tvdb_to_tmdb_content_id_when_tmdb_configured(monkeypatch: Any) -> None:
+    from providers.metadata import _meta_TMDB
+    from providers.sync.nuvio import _history
+
+    class FakeTmdb:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
+            assert entity == "tv"
+            assert ids == {"tvdb": "355567"}
+            return {"ids": {"tmdb": "69478"}}
+
+    adapter = FakeAdapter([])
+    adapter.config["tmdb"] = {"api_key": "tmdb-key"}
+    monkeypatch.setattr(_meta_TMDB, "TmdbProvider", FakeTmdb)
+    item = {
+        "type": "episode",
+        "show_ids": {"tvdb": "355567"},
+        "series_title": "The Boys",
+        "season": 6,
+        "episode": 2,
+        "watched_at": 1_785_000_000_000,
+    }
+
+    result = _history.add(adapter, [item])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tvdb:355567#s06e02"]
+    push = [body for name, body in adapter.client.calls if name == "sync_push_watched_items"][0]
+    row = push["p_items"][0]
+    assert row["content_id"] == "tmdb:69478"
+    assert row["content_type"] == "series"
+    assert row["title"] == "The Boys - S06E02"
     assert row["season"] == 6
     assert row["episode"] == 2

--- a/providers/tests/test_nuvio_progress.py
+++ b/providers/tests/test_nuvio_progress.py
@@ -96,26 +96,86 @@ def test_build_index_merges_duplicate_movie_progress_by_newest_last_watched() ->
     assert index["tmdb:550"]["progress_at"] == 1_785_000_001_000
 
 
-def test_add_encodes_imdb_tmdb_trakt_and_verifies_exact_keys() -> None:
+def test_build_index_enriches_series_progress_title_from_tmdb(monkeypatch: Any) -> None:
+    from providers.metadata import _meta_TMDB
+    from providers.sync.nuvio import _progress
+
+    class FakeTmdb:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
+            assert entity == "tv"
+            assert ids == {"tmdb": "69478"}
+            return {"title": "The Boys"}
+
+    adapter = FakeAdapter(
+        [
+            {
+                "content_id": "tmdb:69478",
+                "content_type": "series",
+                "video_id": "tmdb:69478:6:2",
+                "season": 6,
+                "episode": 2,
+                "progress_key": "tmdb:69478_s6e2",
+                "position": 703_000,
+                "duration": 3_307_930,
+                "last_watched": 1_784_848_068_000,
+            }
+        ]
+    )
+    adapter.config["tmdb"] = {"api_key": "tmdb-key"}
+    monkeypatch.setattr(_meta_TMDB, "TmdbProvider", FakeTmdb)
+
+    item = _progress.build_index(adapter)["tmdb:69478#s06e02"]
+
+    assert item["series_title"] == "The Boys"
+
+
+def test_add_encodes_tmdb_and_verifies_exact_keys() -> None:
     from providers.sync.nuvio import _progress
 
     adapter = FakeAdapter([])
     items = [
-        {"type": "movie", "ids": {"imdb": "tt1234567"}, "progress_ms": 100_000, "duration_ms": 500_000, "progress_at": 1_785_000_000_000},
         {"type": "movie", "ids": {"tmdb": "550"}, "progress_ms": 200_000, "duration_ms": 600_000, "progress_at": 1_785_000_100_000},
-        {"type": "movie", "ids": {"trakt": "12"}, "progress_ms": 300_000, "duration_ms": 700_000, "progress_at": 1_785_000_200_000},
     ]
 
     result = _progress.add(adapter, items)
 
     assert result["ok"] is True
-    assert result["attempted"] == 3
-    assert set(result["confirmed_keys"]) == {"imdb:tt1234567", "tmdb:550", "trakt:12"}
+    assert result["attempted"] == 1
+    assert result["confirmed_keys"] == ["tmdb:550"]
     push = [body for name, body in adapter.client.calls if name == "sync_push_watch_progress"][0]
     assert push["p_profile_id"] == 1
-    assert [entry["content_id"] for entry in push["p_entries"]] == ["tt1234567", "tmdb:550", "trakt:12"]
+    assert [entry["content_id"] for entry in push["p_entries"]] == ["tmdb:550"]
     assert all(entry["duration"] for entry in push["p_entries"])
-    assert push["p_entries"][0]["last_watched"] == 1_785_000_000_000
+    assert push["p_entries"][0]["last_watched"] == 1_785_000_100_000
+
+
+def test_add_movie_progress_resolves_imdb_to_tmdb_content_id_when_tmdb_configured(monkeypatch: Any) -> None:
+    from providers.metadata import _meta_TMDB
+    from providers.sync.nuvio import _progress
+
+    class FakeTmdb:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
+            assert entity == "movie"
+            assert ids == {"imdb": "tt0137523"}
+            return {"ids": {"tmdb": "550"}}
+
+    adapter = FakeAdapter([])
+    adapter.config["tmdb"] = {"api_key": "tmdb-key"}
+    monkeypatch.setattr(_meta_TMDB, "TmdbProvider", FakeTmdb)
+    item = {"type": "movie", "ids": {"imdb": "tt0137523"}, "progress_ms": 100_000, "duration_ms": 500_000, "progress_at": 1_785_000_000_000}
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["imdb:tt0137523"]
+    push = [body for name, body in adapter.client.calls if name == "sync_push_watch_progress"][0]
+    assert push["p_entries"][0]["content_id"] == "tmdb:550"
 
 
 def test_add_returns_unresolved_for_unsupported_id_and_missing_duration() -> None:
@@ -126,6 +186,8 @@ def test_add_returns_unresolved_for_unsupported_id_and_missing_duration() -> Non
         adapter,
         [
             {"type": "movie", "ids": {"tvdb": "99"}, "progress_ms": 100_000, "duration_ms": 500_000, "progress_at": 1_785_000_000_000},
+            {"type": "movie", "ids": {"imdb": "tt0137523"}, "progress_ms": 100_000, "duration_ms": 500_000, "progress_at": 1_785_000_000_000},
+            {"type": "movie", "ids": {"trakt": "12"}, "progress_ms": 100_000, "duration_ms": 500_000, "progress_at": 1_785_000_000_000},
             {"type": "movie", "ids": {"tmdb": "550"}, "progress_ms": 100_000, "progress_at": 1_785_000_000_000},
         ],
         dry_run=True,
@@ -134,6 +196,28 @@ def test_add_returns_unresolved_for_unsupported_id_and_missing_duration() -> Non
     assert result["ok"] is False
     assert result["attempted"] == 0
     assert {row["reason"] for row in result["unresolved"]} == {"nuvio_id_missing", "nuvio_duration_missing"}
+    assert not any(name == "sync_push_watch_progress" for name, _body in adapter.client.calls)
+
+
+def test_add_does_not_write_title_only_unresolved_item() -> None:
+    from providers.sync.nuvio import _progress
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "movie",
+        "title": "Untold UK Liverpool's Miracle of Istanbul",
+        "year": 2026,
+        "ids": {"jellyfin": "26889526862003328"},
+        "progress_ms": 100_000,
+        "duration_ms": 500_000,
+        "progress_at": 1_785_000_000_000,
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is False
+    assert result["attempted"] == 0
+    assert result["unresolved"][0]["reason"] == "nuvio_id_missing"
     assert not any(name == "sync_push_watch_progress" for name, _body in adapter.client.calls)
 
 
@@ -216,6 +300,42 @@ def test_add_episode_progress_prefers_show_tmdb_id_over_episode_tmdb_id() -> Non
 
     assert result["ok"] is True
     assert result["confirmed_keys"] == ["tmdb:69478#s06e02"]
+    push = [body for name, body in adapter.client.calls if name == "sync_push_watch_progress"][0]
+    entry = push["p_entries"][0]
+    assert entry["content_id"] == "tmdb:69478"
+    assert entry["video_id"] == "tmdb:69478:6:2"
+
+
+def test_add_episode_progress_resolves_tvdb_to_tmdb_content_id_when_tmdb_configured(monkeypatch: Any) -> None:
+    from providers.metadata import _meta_TMDB
+    from providers.sync.nuvio import _progress
+
+    class FakeTmdb:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
+            assert entity == "tv"
+            assert ids == {"tvdb": "355567"}
+            return {"ids": {"tmdb": "69478"}}
+
+    adapter = FakeAdapter([])
+    adapter.config["tmdb"] = {"api_key": "tmdb-key"}
+    monkeypatch.setattr(_meta_TMDB, "TmdbProvider", FakeTmdb)
+    item = {
+        "type": "episode",
+        "show_ids": {"tvdb": "355567"},
+        "season": 6,
+        "episode": 2,
+        "progress_ms": 703_000,
+        "duration_ms": 3_307_930,
+        "progress_at": 1_785_000_000_000,
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tvdb:355567#s06e02"]
     push = [body for name, body in adapter.client.calls if name == "sync_push_watch_progress"][0]
     entry = push["p_entries"][0]
     assert entry["content_id"] == "tmdb:69478"

--- a/providers/tests/test_nuvio_watchlist.py
+++ b/providers/tests/test_nuvio_watchlist.py
@@ -85,6 +85,32 @@ def test_watchlist_add_uses_canonical_id_for_verification() -> None:
     assert push["p_items"][0]["content_id"] == "tmdb:550"
 
 
+def test_watchlist_add_resolves_imdb_to_tmdb_content_id_when_tmdb_configured(monkeypatch: Any) -> None:
+    from providers.metadata import _meta_TMDB
+    from providers.sync.nuvio import _watchlist
+
+    class FakeTmdb:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
+            assert entity == "movie"
+            assert ids == {"imdb": "tt0137523"}
+            return {"ids": {"tmdb": "550"}}
+
+    adapter = FakeAdapter([])
+    adapter.config["tmdb"] = {"api_key": "tmdb-key"}
+    monkeypatch.setattr(_meta_TMDB, "TmdbProvider", FakeTmdb)
+    monkeypatch.setattr(_watchlist, "_tmdb_enrichment", lambda *_args, **_kwargs: {})
+
+    result = _watchlist.add(adapter, [{"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club"}])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["imdb:tt0137523"]
+    push = [body for name, body in adapter.client.calls if name == "sync_push_library"][0]
+    assert push["p_items"][0]["content_id"] == "tmdb:550"
+
+
 def test_watchlist_add_skips_tmdb_enrichment_without_metadata_config() -> None:
     from providers.sync.nuvio import _watchlist
 
@@ -129,6 +155,33 @@ def test_watchlist_add_enriches_nuvio_payload_from_configured_tmdb(monkeypatch: 
     assert row["genres"] == ["Drama"]
 
 
+def test_watchlist_add_resolves_tvdb_to_tmdb_content_id_when_tmdb_configured(monkeypatch: Any) -> None:
+    from providers.metadata import _meta_TMDB
+    from providers.sync.nuvio import _watchlist
+
+    class FakeTmdb:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
+            assert entity == "tv"
+            assert ids == {"tvdb": "355567"}
+            return {"ids": {"tmdb": "69478"}}
+
+    adapter = FakeAdapter([])
+    adapter.config["tmdb"] = {"api_key": "tmdb-key"}
+    monkeypatch.setattr(_meta_TMDB, "TmdbProvider", FakeTmdb)
+    monkeypatch.setattr(_watchlist, "_tmdb_enrichment", lambda *_args, **_kwargs: {})
+
+    result = _watchlist.add(adapter, [{"type": "show", "ids": {"tvdb": "355567"}, "title": "The Boys"}])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tvdb:355567"]
+    push = [body for name, body in adapter.client.calls if name == "sync_push_library"][0]
+    assert push["p_items"][0]["content_id"] == "tmdb:69478"
+    assert push["p_items"][0]["content_type"] == "series"
+
+
 def test_watchlist_remove_full_replaces_library_without_removed_item() -> None:
     from providers.sync.nuvio import _watchlist
 
@@ -153,7 +206,7 @@ def test_watchlist_failed_verification_reports_numeric_errors() -> None:
     adapter = FakeAdapter([])
     adapter.client = NonPersistingClient([])
 
-    result = _watchlist.add(adapter, [{"type": "movie", "ids": {"imdb": "tt0137523"}}])
+    result = _watchlist.add(adapter, [{"type": "movie", "ids": {"tmdb": "550"}}])
 
     assert result["ok"] is False
     assert result["errors"] == 1


### PR DESCRIPTION
# Pull request

## Change

Improved Nuvio watchlist, history, and progress sync so CW resolves and verifies items using the Nuvio-compatible content IDs.
Nuvio now writes documented tmdb:<id> IDs where possible, keeps existing Nuvio remote IDs when round-tripping, and can resolve IMDb / TVDB-backed items through configured TMDB metadata when needed.

History episode writes now use a cleaner CW-style title for Nuvio, like Breaking Bad - S01E03 when reading those rows back.

Progress writes stay within Nuvio’s documented progress fields.

## Why

Some providers send IMDb or TVDB IDs instead of direct TMDB IDs. Nuvio needs compatible content IDs.
CW has to resolve those before writing and verify against the resolved remote key.

This also improves Nuvio-sourced history/progress rows in CW by avoiding placeholder or duplicated episode labels.

## Testing

- test_nuvio_watchlist.py
- test_nuvio_progress.py
- test_nuvio_history.py
- test_nuvio_module.py

## Issue

Relates to #321 