### PR TITLE
Change:  percent-only progress support

### DIFF
--- a/providers/sync/crosswatch/_progress.py
+++ b/providers/sync/crosswatch/_progress.py
@@ -42,6 +42,16 @@ def _as_int(v: Any) -> int | None:
         return None
 
 
+def _as_float(v: Any) -> float | None:
+    try:
+        if v is None or isinstance(v, bool):
+            return None
+        n = float(v)
+        return n if n == n else None
+    except Exception:
+        return None
+
+
 def _accepted(obj: Mapping[str, Any]) -> dict[str, Any]:
     base = id_minimal(obj)
     out: dict[str, Any] = dict(base)
@@ -78,9 +88,17 @@ def _accepted(obj: Mapping[str, Any]) -> dict[str, Any]:
         progress_ms = _as_int(obj.get(k))
         if progress_ms is not None:
             break
-    if progress_ms is None:
+    progress_percent = None
+    for k in ("progress_percent", "progressPercent", "percent", "position_percent", "resume_percent"):
+        progress_percent = _as_float(obj.get(k))
+        if progress_percent is not None:
+            break
+    if progress_ms is None and progress_percent is None:
         raise ValueError("progress_ms_missing")
-    out["progress_ms"] = max(0, progress_ms)
+    if progress_ms is not None:
+        out["progress_ms"] = max(0, progress_ms)
+    if progress_percent is not None:
+        out["progress_percent"] = round(max(0.0, min(100.0, float(progress_percent))), 3)
 
     duration_ms = None
     for k in ("duration_ms", "durationMs", "duration"):
@@ -256,18 +274,19 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             unresolved_src.append(obj)
             continue
         new_ms = _as_int(accepted.get("progress_ms"))
-        if new_ms is None or new_ms <= 0:
+        new_percent = _as_float(accepted.get("progress_percent"))
+        if (new_ms is None or new_ms <= 0) and (new_percent is None or new_percent <= 0):
             unresolved_src.append(obj)
             continue
         existing = cur.get(key)
         old_ms = _as_int((existing or {}).get("progress_ms"))
+        old_percent = _as_float((existing or {}).get("progress_percent"))
         new_ts = str(accepted.get("progress_at") or "")
         old_ts = str((existing or {}).get("progress_at") or "")
         should_write = (
             existing is None
-            or old_ms is None
-            or new_ms > old_ms
-            or (new_ms == old_ms and new_ts and old_ts <= new_ts)
+            or (new_ms is not None and (old_ms is None or new_ms > old_ms or (new_ms == old_ms and new_ts and old_ts <= new_ts)))
+            or (new_ms is None and new_percent is not None and (old_percent is None or new_percent > old_percent or (abs(new_percent - old_percent) <= 0.001 and new_ts and old_ts <= new_ts)))
         )
         if should_write:
             cur[key] = accepted

--- a/providers/sync/emby/_progress.py
+++ b/providers/sync/emby/_progress.py
@@ -53,6 +53,47 @@ def _ms_to_ticks(v_ms: Any) -> int | None:
         return None
 
 
+def _to_int(v: Any) -> int | None:
+    if v is None or isinstance(v, bool):
+        return None
+    try:
+        return int(float(str(v).strip()))
+    except Exception:
+        return None
+
+
+def _progress_percent_value(item: Mapping[str, Any]) -> float | None:
+    for key in ("progress_percent", "progressPercent", "percent", "position_percent", "resume_percent"):
+        try:
+            value = item.get(key)
+            if value is None or isinstance(value, bool):
+                continue
+            percent = float(value)
+            if percent == percent:
+                return max(0.0, min(100.0, percent))
+        except Exception:
+            continue
+    return None
+
+
+def _direct_progress_ms(item: Mapping[str, Any]) -> int | None:
+    for key in ("progress_ms", "progressMs", "progress", "viewOffset"):
+        value = _to_int(item.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _progress_ms_for_write(item: Mapping[str, Any], duration_ms: int | None) -> int | None:
+    direct = _direct_progress_ms(item)
+    if direct is not None:
+        return direct
+    percent = _progress_percent_value(item)
+    if percent is None or duration_ms is None or duration_ms <= 0:
+        return None
+    return int(round((percent / 100.0) * float(duration_ms)))
+
+
 def _pick_user_data(row: Mapping[str, Any]) -> Mapping[str, Any]:
     ud = row.get("UserData")
     return ud if isinstance(ud, Mapping) else {}
@@ -299,28 +340,38 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             continue
         _dbg("resolve_hit", canonical_key=str(ck), type=str(it0.get("type") or ""), ids=ids, resolved=len(iids))
 
-        ms = it0.get("progress_ms") or it0.get("progress") or it0.get("viewOffset")
-        ticks = _ms_to_ticks(ms)
-        if ticks is None:
+        direct_ms = _direct_progress_ms(it0)
+        percent = _progress_percent_value(it0)
+        if direct_ms is None and percent is None:
             entry = {"status": "unresolved", "reason": "missing_progress", "item": it0}
             unresolved.append(entry)
             results.append(entry)
             continue
 
-        payload: dict[str, Any] = {"PlaybackPositionTicks": int(ticks)}
         pa = it0.get("progress_at")
-        if isinstance(pa, str) and pa.strip():
-            payload["LastPlayedDate"] = pa.strip()
 
         for iid in iids:
             try:
                 target = _target_state(http, str(uid), str(iid))
+                target_duration = target.get("duration_ms")
+                source_duration = it0.get("duration_ms") or target_duration
+                ms = _progress_ms_for_write(it0, target_duration if target_duration else _to_int(source_duration))
+                ticks = _ms_to_ticks(ms)
+                if ticks is None:
+                    reason = "missing_duration" if percent is not None and not target_duration and not _to_int(it0.get("duration_ms")) else "missing_progress"
+                    entry = {"status": "unresolved", "reason": reason, "item": it0, "remote_item_id": str(iid)}
+                    unresolved.append(entry)
+                    results.append(entry)
+                    continue
+                payload: dict[str, Any] = {"PlaybackPositionTicks": int(ticks)}
+                if isinstance(pa, str) and pa.strip():
+                    payload["LastPlayedDate"] = pa.strip()
                 decision = decide_progress_write(
                     active_session=str(iid) in active_items,
                     source_timestamp=pa,
                     target_timestamp=target.get("timestamp"),
                     source_progress_ms=ms,
-                    source_duration_ms=it0.get("duration_ms"),
+                    source_duration_ms=source_duration,
                     target_progress_ms=target.get("progress_ms"),
                     target_duration_ms=target.get("duration_ms"),
                     target_watched=bool(target.get("watched")),

--- a/providers/sync/jellyfin/_progress.py
+++ b/providers/sync/jellyfin/_progress.py
@@ -54,6 +54,47 @@ def _ms_to_ticks(v_ms: Any) -> int | None:
         return None
 
 
+def _to_int(v: Any) -> int | None:
+    if v is None or isinstance(v, bool):
+        return None
+    try:
+        return int(float(str(v).strip()))
+    except Exception:
+        return None
+
+
+def _progress_percent_value(item: Mapping[str, Any]) -> float | None:
+    for key in ("progress_percent", "progressPercent", "percent", "position_percent", "resume_percent"):
+        try:
+            value = item.get(key)
+            if value is None or isinstance(value, bool):
+                continue
+            percent = float(value)
+            if percent == percent:
+                return max(0.0, min(100.0, percent))
+        except Exception:
+            continue
+    return None
+
+
+def _direct_progress_ms(item: Mapping[str, Any]) -> int | None:
+    for key in ("progress_ms", "progressMs", "progress", "viewOffset"):
+        value = _to_int(item.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _progress_ms_for_write(item: Mapping[str, Any], duration_ms: int | None) -> int | None:
+    direct = _direct_progress_ms(item)
+    if direct is not None:
+        return direct
+    percent = _progress_percent_value(item)
+    if percent is None or duration_ms is None or duration_ms <= 0:
+        return None
+    return int(round((percent / 100.0) * float(duration_ms)))
+
+
 def _pick_user_data(row: Mapping[str, Any]) -> Mapping[str, Any]:
     ud = row.get("UserData")
     return ud if isinstance(ud, Mapping) else {}
@@ -300,28 +341,38 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             continue
         _dbg("resolve_hit", canonical_key=str(ck), type=str(it0.get("type") or ""), ids=ids, resolved=len(iids))
 
-        ms = it0.get("progress_ms") or it0.get("progress") or it0.get("viewOffset")
-        ticks = _ms_to_ticks(ms)
-        if ticks is None:
+        direct_ms = _direct_progress_ms(it0)
+        percent = _progress_percent_value(it0)
+        if direct_ms is None and percent is None:
             entry = {"status": "unresolved", "reason": "missing_progress", "item": it0}
             unresolved.append(entry)
             results.append(entry)
             continue
 
-        payload: dict[str, Any] = {"PlaybackPositionTicks": int(ticks)}
         pa = it0.get("progress_at")
-        if isinstance(pa, str) and pa.strip():
-            payload["LastPlayedDate"] = pa.strip()
 
         for iid in iids:
             try:
                 target = _target_state(http, str(uid), str(iid))
+                target_duration = target.get("duration_ms")
+                source_duration = it0.get("duration_ms") or target_duration
+                ms = _progress_ms_for_write(it0, target_duration if target_duration else _to_int(source_duration))
+                ticks = _ms_to_ticks(ms)
+                if ticks is None:
+                    reason = "missing_duration" if percent is not None and not target_duration and not _to_int(it0.get("duration_ms")) else "missing_progress"
+                    entry = {"status": "unresolved", "reason": reason, "item": it0, "remote_item_id": str(iid)}
+                    unresolved.append(entry)
+                    results.append(entry)
+                    continue
+                payload: dict[str, Any] = {"PlaybackPositionTicks": int(ticks)}
+                if isinstance(pa, str) and pa.strip():
+                    payload["LastPlayedDate"] = pa.strip()
                 decision = decide_progress_write(
                     active_session=str(iid) in active_items,
                     source_timestamp=pa,
                     target_timestamp=target.get("timestamp"),
                     source_progress_ms=ms,
-                    source_duration_ms=it0.get("duration_ms"),
+                    source_duration_ms=source_duration,
                     target_progress_ms=target.get("progress_ms"),
                     target_duration_ms=target.get("duration_ms"),
                     target_watched=bool(target.get("watched")),

--- a/providers/sync/plex/_progress.py
+++ b/providers/sync/plex/_progress.py
@@ -51,6 +51,38 @@ def _to_int(v: Any) -> int | None:
         return None
 
 
+def _progress_percent_value(item: Mapping[str, Any]) -> float | None:
+    for key in ("progress_percent", "progressPercent", "percent", "position_percent", "resume_percent"):
+        try:
+            value = item.get(key)
+            if value is None or isinstance(value, bool):
+                continue
+            percent = float(value)
+            if percent == percent:
+                return max(0.0, min(100.0, percent))
+        except Exception:
+            continue
+    return None
+
+
+def _direct_progress_ms(item: Mapping[str, Any]) -> int | None:
+    for key in ("progress_ms", "progressMs", "viewOffset", "progress"):
+        value = _to_int(item.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _progress_ms_for_write(item: Mapping[str, Any], duration_ms: int | None) -> int | None:
+    direct = _direct_progress_ms(item)
+    if direct is not None:
+        return direct
+    percent = _progress_percent_value(item)
+    if percent is None or duration_ms is None or duration_ms <= 0:
+        return None
+    return int(round((percent / 100.0) * float(duration_ms)))
+
+
 def _iso(v: Any) -> str | None:
     if v is None:
         return None
@@ -676,9 +708,9 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
 
         for it in items or []:
             it0 = dict(it or {})
-            ms = it0.get("progress_ms") or it0.get("viewOffset") or it0.get("progress")
-            ms_i = _to_int(ms)
-            if ms_i is None or ms_i <= 0:
+            direct_ms = _direct_progress_ms(it0)
+            percent = _progress_percent_value(it0)
+            if direct_ms is None and percent is None:
                 entry = {"status": "unresolved", "reason": "missing_progress", "item": it0}
                 unresolved.append(entry)
                 results.append(entry)
@@ -708,6 +740,15 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 target_timestamp = getattr(obj, "lastViewedAt", None) or getattr(obj, "viewedAt", None) or getattr(obj, "updatedAt", None)
                 target_progress = _to_int(getattr(obj, "viewOffset", None))
                 duration = _to_int(getattr(obj, "duration", None)) or _to_int(it0.get("duration_ms")) or 0
+                ms_i = _progress_ms_for_write(it0, duration)
+                if ms_i is None or ms_i <= 0:
+                    reason = "missing_duration" if percent is not None and duration <= 0 else "missing_progress"
+                    entry = {"status": "unresolved", "reason": reason, "item": it0}
+                    unresolved.append(entry)
+                    results.append(entry)
+                    if _mods_debug():
+                        _dbg("add.unresolved", hint=reason, canonical_key=str(canonical_key(id_minimal(it0)) or ""), ids=dict(ids_from(it0)))
+                    continue
                 decision = decide_progress_write(
                     active_session=_currently_playing(srv, rk, account_id=sel_aid, username=sel_uname),
                     source_timestamp=source_timestamp,

--- a/providers/sync/publicmetadb/_progress.py
+++ b/providers/sync/publicmetadb/_progress.py
@@ -72,6 +72,30 @@ def _duration_ms(item: Mapping[str, Any]) -> int | None:
     return None
 
 
+def _progress_percent(item: Mapping[str, Any]) -> float | None:
+    for key in ("progress_percent", "progressPercent", "percent", "position_percent", "resume_percent"):
+        try:
+            value = item.get(key)
+            if value is None or isinstance(value, bool):
+                continue
+            percent = float(value)
+            if percent == percent:
+                return max(0.0, min(100.0, percent))
+        except Exception:
+            continue
+    return None
+
+
+def _progress_ms_for_write(item: Mapping[str, Any], duration_ms: int | None) -> int | None:
+    pos_ms = _progress_ms(item) or as_int(item.get("progress"))
+    if pos_ms is not None:
+        return pos_ms
+    percent = _progress_percent(item)
+    if percent is None or duration_ms is None or duration_ms <= 0:
+        return None
+    return int(round((percent / 100.0) * float(duration_ms)))
+
+
 def _resume_id(item: Mapping[str, Any]) -> str | None:
     rid = str(item.get("_publicmetadb_resume_id") or item.get("resume_id") or item.get("id") or "").strip()
     return rid or None
@@ -185,10 +209,10 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
 
 def _payload_for_item(item: Mapping[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
     mini = id_minimal(item)
-    pos_ms = _progress_ms(mini) or _progress_ms(item) or as_int(item.get("progress"))
     dur_ms = _duration_ms(mini) or _duration_ms(item)
+    pos_ms = _progress_ms_for_write(mini, dur_ms) or _progress_ms_for_write(item, dur_ms)
     if pos_ms is None:
-        return None, "missing_progress"
+        return None, "missing_duration" if (_progress_percent(mini) is not None or _progress_percent(item) is not None) else "missing_progress"
     if pos_ms <= 0:
         return None, "zero_progress"
     if dur_ms is None:


### PR DESCRIPTION
# Pull request

## Change

Added percent-only playback progress support to the existing progress adapters.

CW can now keep percent progress directly and Plex, Emby, Jellyfin and PublicMetaDB convert percent to milliseconds when duration is available.

## Why

Some providers only give progress as a percent. Without this, progress sync could skip valid items.

## Testing

- test_percent_progress_sync.py

## Issue

NA