### PR TITLE
Add: SIMKL progress sync

### DIFF
--- a/providers/sync/_mod_SIMKL.py
+++ b/providers/sync/_mod_SIMKL.py
@@ -75,7 +75,7 @@ def _confirmed_keys(key_of, items: Iterable[Mapping[str, Any]], unresolved: Any)
         seen.add(k)
     return out
 
-__VERSION__ = "1.6"
+__VERSION__ = "1.7"
 __all__ = ["get_manifest", "SIMKLModule", "OPS"]
 
 
@@ -110,6 +110,12 @@ try:
 except Exception as e:
     feat_ratings = None
     _log("feature_import_failed", level="warn", import_feature="ratings", error=str(e))
+
+try:
+    from .simkl import _progress as feat_progress
+except Exception as e:
+    feat_progress = None
+    _log("feature_import_failed", level="warn", import_feature="progress", error=str(e))
 
 try:
     from .simkl import _playlists as feat_playlists
@@ -172,6 +178,8 @@ if feat_history:
     _FEATURES["history"] = feat_history
 if feat_ratings:
     _FEATURES["ratings"] = feat_ratings
+if feat_progress:
+    _FEATURES["progress"] = feat_progress
 
 _PLAYLIST_CAPABILITIES = {
     "read": True,
@@ -195,6 +203,7 @@ def _features_flags() -> dict[str, bool]:
         "watchlist": "watchlist" in _FEATURES,
         "ratings": "ratings" in _FEATURES,
         "history": "history" in _FEATURES,
+        "progress": "progress" in _FEATURES,
         "playlists": feat_playlists is not None,
     }
 
@@ -204,6 +213,7 @@ def supported_features() -> dict[str, bool]:
         "watchlist": True,
         "ratings": True,
         "history": True,
+        "progress": True,
         "playlists": True,
     }
     present = _features_flags()
@@ -239,6 +249,13 @@ def get_manifest() -> Mapping[str, Any]:
                 "upsert": True,
                 "unrate": True,
                 "from_date": True,
+            },
+            "progress": {
+                "index_semantics": "present",
+                "observed_deletes": True,
+                "types": {"movies": True, "shows": False, "seasons": False, "episodes": True, "anime": True},
+                "upsert": True,
+                "remove": True,
             },
             "playlists": dict(_PLAYLIST_CAPABILITIES),
         },
@@ -427,6 +444,7 @@ class SIMKLModule:
             "watchlist": bool(enabled.get("watchlist") and "watchlist" in _FEATURES and core_ok),
             "ratings": bool(enabled.get("ratings") and "ratings" in _FEATURES and core_ok),
             "history": bool(enabled.get("history") and "history" in _FEATURES and core_ok),
+            "progress": bool(enabled.get("progress") and "progress" in _FEATURES and core_ok),
             "playlists": bool(enabled.get("playlists") and feat_playlists and core_ok),
         }
 
@@ -600,7 +618,18 @@ class SIMKLModule:
         if not mod:
             _log("write_skipped", feature=feature, level="info", op="add", reason="module_missing")
             return {"ok": True, "count": 0, "unresolved": []}
-        count, unresolved = mod.add(self, lst)
+        raw = mod.add(self, lst)
+        if isinstance(raw, Mapping):
+            out = dict(raw)
+            out.setdefault("ok", True)
+            out.setdefault("unresolved", [])
+            out.setdefault("confirmed_keys", [])
+            if isinstance(out.get("confirmed_keys"), list):
+                out["count"] = len([x for x in out.get("confirmed_keys") or [] if x])
+            else:
+                out.setdefault("count", int(out.get("count", 0) or 0))
+            return out
+        count, unresolved = raw
         exact_confirmed = getattr(self, "_simkl_history_add_confirmed_keys", None) if feature == "history" else None
         exact_skipped = getattr(self, "_simkl_history_add_skipped_keys", None) if feature == "history" else None
         confirmed_keys = [str(k) for k in exact_confirmed if k] if isinstance(exact_confirmed, list) else _confirmed_keys(self.key_of, lst, unresolved)
@@ -631,7 +660,18 @@ class SIMKLModule:
         if feature == "history":
             setattr(self, "_simkl_history_remove_confirmed_keys", [])
             setattr(self, "_simkl_history_remove_skipped_keys", [])
-        count, unresolved = mod.remove(self, lst)
+        raw = mod.remove(self, lst)
+        if isinstance(raw, Mapping):
+            out = dict(raw)
+            out.setdefault("ok", True)
+            out.setdefault("unresolved", [])
+            out.setdefault("confirmed_keys", [])
+            if isinstance(out.get("confirmed_keys"), list):
+                out["count"] = len([x for x in out.get("confirmed_keys") or [] if x])
+            else:
+                out.setdefault("count", int(out.get("count", 0) or 0))
+            return out
+        count, unresolved = raw
         exact_confirmed = getattr(self, "_simkl_history_remove_confirmed_keys", None) if feature == "history" else None
         exact_skipped = getattr(self, "_simkl_history_remove_skipped_keys", None) if feature == "history" else None
         if isinstance(exact_confirmed, list):
@@ -700,6 +740,13 @@ class _SIMKLOPS:
             "ratings": {
                 "index_semantics": "present",
                 "observed_deletes": True,
+            },
+            "progress": {
+                "index_semantics": "present",
+                "observed_deletes": True,
+                "types": {"movies": True, "shows": False, "seasons": False, "episodes": True, "anime": True},
+                "upsert": True,
+                "remove": True,
             },
             "playlists": dict(_PLAYLIST_CAPABILITIES),
         }

--- a/providers/sync/simkl/_progress.py
+++ b/providers/sync/simkl/_progress.py
@@ -1,0 +1,514 @@
+# /providers/sync/simkl/_progress.py
+# CrossWatch SIMKL progress functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import math
+import os
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from providers.sync._log import log as cw_log
+from providers.sync._progress_policy import decide_progress_write, progress_materially_equal, select_progress_record
+
+from ._common import _fix_imdb
+
+
+_PROVIDER = "SIMKL"
+_FEATURE = "progress"
+
+
+def _dbg(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "debug", event, **fields)
+
+
+def _info(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "info", event, **fields)
+
+
+def _warn(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "warn", event, **fields)
+
+
+def _float(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        number = float(value)
+        return number if math.isfinite(number) else None
+    except Exception:
+        return None
+
+
+def _int(value: Any) -> int | None:
+    try:
+        if value is None or value == "" or isinstance(value, bool):
+            return None
+        return int(float(value))
+    except Exception:
+        return None
+
+
+def _positive_int(value: Any) -> int | None:
+    number = _int(value)
+    return number if number is not None and number > 0 else None
+
+
+def _ids(source: Any, allowed: Iterable[str], *, integer_keys: Iterable[str] = ()) -> dict[str, Any]:
+    raw = _fix_imdb(dict(source or {}) if isinstance(source, Mapping) else {})
+    integer = {str(k) for k in integer_keys}
+    out: dict[str, Any] = {}
+    for key in allowed:
+        value = raw.get(key)
+        if value in (None, ""):
+            continue
+        if key in integer:
+            number = _positive_int(value)
+            if number is not None:
+                out[key] = number
+            continue
+        text = str(value).strip()
+        if text:
+            out[key] = text
+    return out
+
+
+def _movie_ids(source: Any) -> dict[str, Any]:
+    return _ids(
+        source,
+        ("simkl", "imdb", "tmdb", "netflix", "traktslug", "letterboxd", "boxd"),
+        integer_keys=("simkl", "tmdb", "netflix"),
+    )
+
+
+def _show_ids(source: Any) -> dict[str, Any]:
+    return _ids(
+        source,
+        ("simkl", "imdb", "tmdb", "tvdb", "netflix", "hulu", "traktslug", "zap2it", "tvcom", "mdl"),
+        integer_keys=("simkl", "tmdb", "netflix", "hulu"),
+    )
+
+
+def _anime_ids(source: Any) -> dict[str, Any]:
+    return _ids(
+        source,
+        ("simkl", "imdb", "tmdb", "tvdb", "mal", "anidb", "anilist", "kitsu", "anisearch", "animeplanet", "livechart", "anfo", "ann"),
+        integer_keys=("simkl", "tmdb", "mal", "anidb", "anilist", "kitsu", "anisearch", "livechart", "anfo", "ann"),
+    )
+
+
+def _episode_ids(source: Any) -> dict[str, Any]:
+    return _ids(source, ("tvdb", "anidb"), integer_keys=("tvdb", "anidb"))
+
+
+def _duration_ms(*sources: Mapping[str, Any]) -> int | None:
+    for source in sources:
+        for key in ("duration_ms", "durationMs", "runtime_ms", "runtimeMs"):
+            value = _positive_int(source.get(key))
+            if value is not None:
+                return value
+        for key in ("duration_seconds", "durationSeconds", "runtime_seconds", "runtimeSeconds"):
+            value = _positive_int(source.get(key))
+            if value is not None:
+                return value * 1000
+        runtime = _positive_int(source.get("runtime"))
+        if runtime is not None:
+            return runtime * 60_000
+    return None
+
+
+def _progress_ms(progress_percent: Any, duration_ms: int | None) -> int | None:
+    progress = _float(progress_percent)
+    if progress is None or progress <= 0 or duration_ms is None or duration_ms <= 0:
+        return None
+    return int(round(float(duration_ms) * max(0.0, min(progress, 100.0)) / 100.0))
+
+
+def _container(row: Mapping[str, Any]) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
+    row_type = str(row.get("type") or "").strip().lower()
+    movie_raw = row.get("movie")
+    movie = movie_raw if isinstance(movie_raw, Mapping) else None
+    show_raw = row.get("show")
+    show = show_raw if isinstance(show_raw, Mapping) else None
+    anime_raw = row.get("anime")
+    anime = anime_raw if isinstance(anime_raw, Mapping) else None
+    episode_raw = row.get("episode")
+    episode: Mapping[str, Any] = episode_raw if isinstance(episode_raw, Mapping) else {}
+    if movie is not None or row_type == "movie":
+        return "movie", movie or row, {}
+    if anime is not None:
+        return "anime", anime, episode
+    return "show", show or row, episode
+
+
+def _episode_number(episode: Mapping[str, Any], row: Mapping[str, Any]) -> int | None:
+    return _positive_int(episode.get("number") or episode.get("episode") or row.get("episode") or row.get("episode_number"))
+
+
+def _item_from_row(row: Mapping[str, Any]) -> tuple[str | None, dict[str, Any] | None, str | None]:
+    playback_id = _positive_int(row.get("id"))
+    progress = _float(row.get("progress"))
+    if playback_id is None or progress is None or progress <= 0:
+        return None, None, "simkl_progress_invalid"
+
+    media_kind, payload, episode = _container(row)
+    duration = _duration_ms(payload, episode, row)
+    position = _progress_ms(progress, duration)
+    progress_at = str(row.get("paused_at") or row.get("watched_at") or "").strip()
+
+    if media_kind == "movie":
+        item = id_minimal(
+            {
+                "type": "movie",
+                "title": payload.get("title"),
+                "year": payload.get("year"),
+                "ids": _movie_ids(payload.get("ids")),
+            }
+        )
+    else:
+        parent_ids = _anime_ids(payload.get("ids")) if media_kind == "anime" else _show_ids(payload.get("ids"))
+        item = id_minimal(
+            {
+                "type": "episode",
+                "title": episode.get("title") or payload.get("title"),
+                "series_title": payload.get("title"),
+                "year": payload.get("year"),
+                "season": episode.get("season") or row.get("season"),
+                "episode": _episode_number(episode, row),
+                "ids": _episode_ids(episode.get("ids")),
+                "show_ids": parent_ids,
+            }
+        )
+        if media_kind == "anime":
+            item["simkl_bucket"] = "anime"
+            if payload.get("anime_type"):
+                item["anime_type"] = payload.get("anime_type")
+
+    key = canonical_key(item)
+    if not key:
+        return None, None, "simkl_id_missing"
+
+    item["progress_percent"] = round(progress, 3)
+    if position is not None and duration is not None:
+        item["progress_ms"] = int(position)
+        item["duration_ms"] = int(duration)
+    if progress_at:
+        item["progress_at"] = progress_at
+    item["_simkl_playback_id"] = playback_id
+    return key, item, None
+
+
+def _request(adapter: Any, method: str, path: str, **kwargs: Any) -> Any:
+    url = f"{adapter.client.BASE}{path}"
+    fn = getattr(adapter.client, "_request", None)
+    if callable(fn):
+        return fn(method, url, **kwargs)
+    method_fn = getattr(adapter.client, method.lower())
+    return method_fn(url, **kwargs)
+
+
+def _playback_rows(adapter: Any) -> list[Mapping[str, Any]] | None:
+    try:
+        limit = max(1, min(10000, int(getattr(adapter.cfg, "progress_limit", 10000) or 10000)))
+    except Exception:
+        limit = 10000
+    params: dict[str, Any] = {"limit": limit, "hide_watched": "true"}
+    date_from = str(getattr(adapter.cfg, "date_from", "") or "").strip()
+    if date_from:
+        params["date_from"] = date_from
+    response = _request(adapter, "GET", "/sync/playback", params=params)
+    if not (200 <= int(getattr(response, "status_code", 0) or 0) < 300):
+        _warn("index_http_failed", status=getattr(response, "status_code", None))
+        return None
+    data = response.json() if (getattr(response, "text", "") or "").strip() else []
+    if isinstance(data, list):
+        return [row for row in data if isinstance(row, Mapping)]
+    if isinstance(data, Mapping):
+        rows: list[Mapping[str, Any]] = []
+        for key in ("playback", "items", "movies", "episodes", "shows", "anime"):
+            bucket = data.get(key)
+            if isinstance(bucket, list):
+                rows.extend([row for row in bucket if isinstance(row, Mapping)])
+        return rows
+    return []
+
+
+def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
+    rows = _playback_rows(adapter)
+    if rows is None:
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    skipped: dict[str, int] = {}
+    for row in rows:
+        key, item, reason = _item_from_row(row)
+        if not key or item is None:
+            if reason:
+                skipped[reason] = skipped.get(reason, 0) + 1
+            continue
+        selected, action = select_progress_record(out.get(key), item)
+        out[key] = selected
+        _dbg("item", canonical_key=key, media_type=item.get("type"), progress_percent=item.get("progress_percent"), action=action)
+    _info("index_done", count=len(out), rows=len(rows), skipped=sum(skipped.values()), skipped_reasons=skipped)
+    return out
+
+
+def _progress_values(item: Mapping[str, Any]) -> tuple[int | None, int | None, float | None]:
+    progress = None
+    for key in ("progress_ms", "progressMs", "viewOffset", "progress"):
+        progress = _positive_int(item.get(key))
+        if progress is not None:
+            break
+    duration = None
+    for key in ("duration_ms", "durationMs", "duration", "runtime_ms", "runtimeMs"):
+        duration = _positive_int(item.get(key))
+        if duration is not None:
+            break
+    if progress is not None and duration is not None and duration > 0:
+        return progress, duration, round((float(progress) / float(duration)) * 100.0, 2)
+    for key in ("progress_percent", "progressPercent", "percent", "position_percent", "resume_percent"):
+        percent = _float(item.get(key))
+        if percent is not None:
+            return progress, duration, round(max(0.0, min(percent, 100.0)), 2)
+    return progress, duration, None
+
+
+def _movie_body(item: Mapping[str, Any], progress_percent: float) -> tuple[dict[str, Any] | None, str | None]:
+    ids = _movie_ids(item.get("ids"))
+    if not ids:
+        return None, "simkl_movie_id_missing"
+    movie: dict[str, Any] = {"ids": ids}
+    title = str(item.get("title") or "").strip()
+    if title:
+        movie["title"] = title
+    year = _int(item.get("year"))
+    if year is not None:
+        movie["year"] = year
+    return {"progress": progress_percent, "movie": movie}, None
+
+
+def _episode_body(item: Mapping[str, Any], progress_percent: float) -> tuple[dict[str, Any] | None, str | None]:
+    episode_ids = _episode_ids(item.get("ids"))
+    season = _int(item.get("season") if item.get("season") is not None else item.get("season_number"))
+    number = _positive_int(item.get("episode") if item.get("episode") is not None else item.get("number"))
+
+    show_ids_raw = item.get("show_ids")
+    show_ids_map = dict(show_ids_raw) if isinstance(show_ids_raw, Mapping) else {}
+    wants_anime = str(item.get("simkl_bucket") or "").strip().lower() == "anime" or bool(
+        _anime_ids(show_ids_map)
+        and any(str(k) in show_ids_map for k in ("mal", "anidb", "anilist", "kitsu", "anisearch", "animeplanet", "livechart"))
+    )
+    parent_ids = _anime_ids(item.get("show_ids")) if wants_anime else _show_ids(item.get("show_ids"))
+    if not parent_ids:
+        return None, "simkl_parent_id_missing"
+
+    episode: dict[str, Any]
+    if season is not None and season >= 0 and number is not None:
+        episode = {"season": season, "number": number}
+    elif episode_ids:
+        episode = {"ids": episode_ids}
+    else:
+        return None, "simkl_episode_id_missing"
+
+    parent_key = "anime" if wants_anime else "show"
+    parent: dict[str, Any] = {"ids": parent_ids}
+    series_title = str(item.get("series_title") or item.get("title") or "").strip()
+    if series_title:
+        parent["title"] = series_title
+    year = _int(item.get("series_year") or item.get("year"))
+    if year is not None:
+        parent["year"] = year
+    return {"progress": progress_percent, parent_key: parent, "episode": episode}, None
+
+
+def _scrobble_body(item: Mapping[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    progress_ms, duration_ms, percent = _progress_values(item)
+    if percent is None:
+        return None, "simkl_progress_missing" if progress_ms is None else "simkl_duration_missing"
+    if percent <= 0 or percent >= 100:
+        return None, "simkl_progress_invalid"
+    media_type = str(item.get("type") or "").strip().lower()
+    if media_type == "movie":
+        return _movie_body(item, percent)
+    if media_type == "episode":
+        return _episode_body(item, percent)
+    return None, "simkl_media_type_unsupported"
+
+
+def _unresolved(item: Mapping[str, Any], reason: str, status: str = "unresolved", **extra: Any) -> dict[str, Any]:
+    out = {"status": status, "reason": reason, "item": id_minimal(item)}
+    out.update(extra)
+    key = canonical_key(item)
+    if key:
+        out["canonical_key"] = key
+    return out
+
+
+def _result(ok: bool, count: int, attempted: int, confirmed: list[str], unresolved: list[dict[str, Any]], results: list[dict[str, Any]], skipped: int, **extra: Any) -> dict[str, Any]:
+    unresolved_keys: list[str] = []
+    for row in unresolved:
+        key = str(row.get("canonical_key") or "")
+        if key:
+            unresolved_keys.append(key)
+            continue
+        item = row.get("item")
+        if isinstance(item, Mapping):
+            key = canonical_key(item)
+            if key:
+                unresolved_keys.append(key)
+    out = {
+        "ok": bool(ok),
+        "count": int(count),
+        "attempted": int(attempted),
+        "confirmed_keys": list(dict.fromkeys(k for k in confirmed if k)),
+        "unresolved": unresolved,
+        "unresolved_keys": list(dict.fromkeys(unresolved_keys)),
+        "results": results,
+        "skipped": int(skipped),
+        "errors": sum(1 for row in unresolved if str(row.get("status") or "") == "failed"),
+    }
+    out.update(extra)
+    return out
+
+
+def _same_simkl_endpoint() -> bool:
+    src = str(os.getenv("CW_PAIR_SRC") or "").upper().strip()
+    dst = str(os.getenv("CW_PAIR_DST") or "").upper().strip()
+    src_instance = str(os.getenv("CW_PAIR_SRC_INSTANCE") or "default").strip().lower() or "default"
+    dst_instance = str(os.getenv("CW_PAIR_DST_INSTANCE") or "default").strip().lower() or "default"
+    return src == dst == "SIMKL" and src_instance == dst_instance
+
+
+def _percent_equal(source: Mapping[str, Any], target: Mapping[str, Any]) -> bool:
+    _sp, _sd, source_percent = _progress_values(source)
+    target_percent = _float(target.get("progress_percent"))
+    if source_percent is None or target_percent is None:
+        return False
+    return abs(float(source_percent) - float(target_percent)) <= 0.1
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    src = [dict(item or {}) for item in items or [] if isinstance(item, Mapping)]
+    current = build_index(adapter)
+    unresolved: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    pending: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+    skipped = 0
+
+    for item in src:
+        key = canonical_key(item) or ""
+        body, reason = _scrobble_body(item)
+        if body is None:
+            row = _unresolved(item, reason or "simkl_progress_invalid")
+            unresolved.append(row)
+            results.append(row)
+            continue
+        target = current.get(key)
+        progress_ms, duration_ms, source_percent = _progress_values(item)
+        if isinstance(target, Mapping) and _percent_equal(item, target):
+            skipped += 1
+            results.append({"status": "skipped", "reason": "progress_unchanged", "canonical_key": key, "item": id_minimal(item)})
+            continue
+        decision = decide_progress_write(
+            active_session=False,
+            source_timestamp=item.get("progress_at") or item.get("progressAt") or item.get("last_played") or item.get("lastViewedAt"),
+            target_timestamp=(target or {}).get("progress_at") if isinstance(target, Mapping) else None,
+            source_progress_ms=progress_ms,
+            source_duration_ms=duration_ms,
+            target_progress_ms=(target or {}).get("progress_ms") if isinstance(target, Mapping) else None,
+            target_duration_ms=(target or {}).get("duration_ms") if isinstance(target, Mapping) else None,
+            target_watched=False,
+            same_origin=_same_simkl_endpoint(),
+            replay_enabled=True,
+        )
+        if not decision.apply:
+            skipped += 1
+            results.append({"status": "skipped", "reason": decision.reason, "canonical_key": key, "item": id_minimal(item), "progress_percent": source_percent})
+            continue
+        pending.append((key, item, body))
+        results.append({"status": "pending" if not dry_run else "dry_run", "canonical_key": key, "item": id_minimal(item)})
+
+    if dry_run:
+        return _result(len(unresolved) == 0, len(pending), len(pending), [], unresolved, results, skipped, dry_run=True)
+
+    failed = False
+    for key, item, body in pending:
+        response = _request(adapter, "POST", "/scrobble/pause", json=body)
+        status = int(getattr(response, "status_code", 0) or 0)
+        if status != 201:
+            failed = True
+            row = _unresolved(item, f"http:{status}", status="failed", remote_status=status)
+            unresolved.append(row)
+            results.append(row)
+            _warn("write_failed", op="add", canonical_key=key, status=status)
+
+    after = build_index(adapter) if pending and not failed else current
+    confirmed: list[str] = []
+    for key, item, _body in ([] if failed else pending):
+        target = after.get(key)
+        if isinstance(target, Mapping) and (
+            progress_materially_equal(item.get("progress_ms"), item.get("duration_ms"), target.get("progress_ms"), target.get("duration_ms"))
+            or _percent_equal(item, target)
+        ):
+            confirmed.append(key)
+        else:
+            row = _unresolved(item, "simkl_progress_verification_failed", status="failed")
+            unresolved.append(row)
+            results.append(row)
+
+    ok = len(unresolved) == 0
+    _info("write_done", op="add", ok=ok, attempted=len(pending), confirmed=len(confirmed), skipped=skipped, unresolved=len(unresolved))
+    return _result(ok, len(confirmed), len(pending), confirmed, unresolved, results, skipped)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    src = [dict(item or {}) for item in items or [] if isinstance(item, Mapping)]
+    current = build_index(adapter)
+    unresolved: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    pending: list[tuple[str, int, dict[str, Any]]] = []
+    skipped = 0
+
+    for item in src:
+        key = canonical_key(item) or ""
+        target = current.get(key)
+        if not isinstance(target, Mapping):
+            skipped += 1
+            results.append({"status": "skipped", "reason": "already_absent", "canonical_key": key, "item": id_minimal(item)})
+            continue
+        playback_id = _positive_int(target.get("_simkl_playback_id") or item.get("_simkl_playback_id"))
+        if playback_id is None:
+            row = _unresolved(item, "simkl_playback_id_missing")
+            unresolved.append(row)
+            results.append(row)
+            continue
+        pending.append((key, playback_id, item))
+        results.append({"status": "pending" if not dry_run else "dry_run", "canonical_key": key, "remote_id": playback_id, "item": id_minimal(item)})
+
+    if dry_run:
+        return _result(len(unresolved) == 0, len(pending), len(pending), [], unresolved, results, skipped, dry_run=True)
+
+    failed = False
+    for key, playback_id, item in pending:
+        response = _request(adapter, "DELETE", f"/sync/playback/{playback_id}")
+        status = int(getattr(response, "status_code", 0) or 0)
+        if status != 204:
+            failed = True
+            row = _unresolved(item, f"http:{status}", status="failed", remote_status=status)
+            unresolved.append(row)
+            results.append(row)
+            _warn("write_failed", op="remove", canonical_key=key, playback_id=playback_id, status=status)
+
+    after = build_index(adapter) if pending and not failed else current
+    verified: list[str] = []
+    for key, _playback_id, item in ([] if failed else pending):
+        if key not in after:
+            verified.append(key)
+        else:
+            row = _unresolved(item, "simkl_progress_delete_unconfirmed", status="failed")
+            unresolved.append(row)
+            results.append(row)
+
+    ok = len(unresolved) == 0
+    _info("write_done", op="remove", ok=ok, attempted=len(pending), confirmed=len(verified), skipped=skipped, unresolved=len(unresolved))
+    return _result(ok, len(verified), len(pending), verified, unresolved, results, skipped)

--- a/providers/tests/test_publicmetadb_progress.py
+++ b/providers/tests/test_publicmetadb_progress.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+
+def test_payload_for_item_derives_position_from_percent_and_duration() -> None:
+    from providers.sync.publicmetadb import _progress
+
+    payload, reason = _progress._payload_for_item(
+        {
+            "type": "movie",
+            "ids": {"tmdb": "550"},
+            "progress_percent": 25,
+            "duration_ms": 600_000,
+        }
+    )
+
+    assert reason is None
+    assert payload is not None
+    assert payload["position_ms"] == 150_000
+    assert payload["runtime_ms"] == 600_000
+
+
+def test_payload_for_item_reports_missing_duration_for_percent_only_media_server_target() -> None:
+    from providers.sync.publicmetadb import _progress
+
+    payload, reason = _progress._payload_for_item(
+        {
+            "type": "movie",
+            "ids": {"tmdb": "550"},
+            "progress_percent": 25,
+        }
+    )
+
+    assert payload is None
+    assert reason == "missing_duration"
+
+
+def test_payload_for_episode_prefers_show_tmdb_when_ids_duplicate_show_id() -> None:
+    from providers.sync.publicmetadb import _progress
+
+    payload, reason = _progress._payload_for_item(
+        {
+            "type": "episode",
+            "ids": {"tmdb": "94997"},
+            "show_ids": {"tmdb": "94997"},
+            "season": 2,
+            "episode": 7,
+            "progress_percent": 25,
+            "duration_ms": 600_000,
+        }
+    )
+
+    assert reason is None
+    assert payload is not None
+    assert payload["tmdb_id"] == 94997
+    assert payload["media_type"] == "tv"
+    assert payload["season"] == 2
+    assert payload["episode"] == 7

--- a/providers/tests/test_simkl_progress.py
+++ b/providers/tests/test_simkl_progress.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+
+class Response:
+    def __init__(self, status_code: int, payload: Any = None) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = "" if payload is None else json.dumps(payload)
+        self.headers: dict[str, str] = {}
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeClient:
+    BASE = "https://api.simkl.com"
+
+    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
+        self.rows = list(rows or [])
+        self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
+        self.next_id = 1000
+
+    def _request(self, method: str, url: str, **kwargs: Any) -> Response:
+        if method == "GET":
+            self.calls.append(("GET", url, kwargs.get("params")))
+            return Response(200, list(self.rows))
+        if method == "POST":
+            body = dict(kwargs.get("json") or {})
+            self.calls.append(("POST", url, body))
+            self.next_id += 1
+            if "movie" in body:
+                movie = dict(body["movie"])
+                self.rows = [row for row in self.rows if not (row.get("type") == "movie" and (row.get("movie") or {}).get("ids") == movie.get("ids"))]
+                self.rows.append({"id": self.next_id, "type": "movie", "progress": body["progress"], "paused_at": "2026-07-25T12:00:00Z", "movie": movie})
+            elif "show" in body:
+                show = dict(body["show"])
+                episode = dict(body["episode"])
+                self.rows.append({"id": self.next_id, "type": "episode", "progress": body["progress"], "paused_at": "2026-07-25T12:00:00Z", "show": show, "episode": episode})
+            elif "anime" in body:
+                anime = dict(body["anime"])
+                episode = dict(body["episode"])
+                self.rows.append({"id": self.next_id, "type": "episode", "progress": body["progress"], "paused_at": "2026-07-25T12:00:00Z", "anime": anime, "episode": episode})
+            return Response(201, {"id": self.next_id, "action": "pause", "progress": body.get("progress")})
+        if method == "DELETE":
+            self.calls.append(("DELETE", url, None))
+            playback_id = int(url.rsplit("/", 1)[-1])
+            self.rows = [row for row in self.rows if int(row.get("id") or 0) != playback_id]
+            return Response(204)
+        return Response(405, {})
+
+
+class FakeAdapter:
+    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
+        self.client = FakeClient(rows)
+        self.cfg = type("Cfg", (), {"progress_limit": 10000, "date_from": ""})()
+
+
+def movie_row(progress: float = 20.0) -> dict[str, Any]:
+    return {
+        "id": 42,
+        "type": "movie",
+        "progress": progress,
+        "paused_at": "2026-07-25T10:00:00Z",
+        "movie": {
+            "title": "Fight Club",
+            "year": 1999,
+            "runtime": 10,
+            "ids": {"simkl": 10, "slug": "fight-club", "imdb": "tt0137523", "tmdb": 550},
+        },
+    }
+
+
+def episode_row() -> dict[str, Any]:
+    return {
+        "id": 43,
+        "type": "episode",
+        "progress": 50,
+        "paused_at": "2026-07-25T10:00:00Z",
+        "episode": {"season": 1, "number": 3, "title": "Holly Jolly", "runtime": 40},
+        "show": {"title": "Stranger Things", "year": 2016, "ids": {"simkl": 39687, "imdb": "tt4574334", "tvdb": 305288}},
+    }
+
+
+def test_build_index_maps_official_playback_rows() -> None:
+    from providers.sync.simkl import _progress
+
+    index = _progress.build_index(FakeAdapter([movie_row(), episode_row()]))
+
+    assert index["tmdb:550"]["progress_ms"] == 120_000
+    assert index["tmdb:550"]["duration_ms"] == 600_000
+    assert index["tmdb:550"]["progress_percent"] == 20.0
+    assert index["tmdb:550"]["_simkl_playback_id"] == 42
+    assert index["imdb:tt4574334#s01e03"]["progress_ms"] == 1_200_000
+
+
+def test_add_movie_uses_documented_scrobble_pause_payload() -> None:
+    from providers.sync.simkl import _progress
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "movie",
+        "title": "Fight Club",
+        "year": 1999,
+        "ids": {"tmdb": "550", "slug": "fight-club"},
+        "progress_ms": 120_000,
+        "duration_ms": 600_000,
+        "progress_at": "2026-07-25T11:00:00Z",
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tmdb:550"]
+    post = [call for call in adapter.client.calls if call[0] == "POST"][0]
+    assert post[1] == "https://api.simkl.com/scrobble/pause"
+    assert post[2] == {"progress": 20.0, "movie": {"ids": {"tmdb": 550}, "title": "Fight Club", "year": 1999}}
+
+
+def test_add_episode_uses_show_and_episode_shape() -> None:
+    from providers.sync.simkl import _progress
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "episode",
+        "series_title": "Stranger Things",
+        "show_ids": {"tvdb": "305288", "slug": "stranger-things"},
+        "season": 1,
+        "episode": 3,
+        "progress_ms": 1_200_000,
+        "duration_ms": 2_400_000,
+        "progress_at": "2026-07-25T11:00:00Z",
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is True
+    post = [call for call in adapter.client.calls if call[0] == "POST"][0]
+    assert post[2] == {
+        "progress": 50.0,
+        "show": {"ids": {"tvdb": "305288"}, "title": "Stranger Things"},
+        "episode": {"season": 1, "number": 3},
+    }
+
+
+def test_add_episode_prefers_show_coordinate_when_ids_duplicate_show_id() -> None:
+    from providers.sync.simkl import _progress
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "episode",
+        "series_title": "House of the Dragon",
+        "ids": {"tmdb": "94997"},
+        "show_ids": {"tmdb": "94997"},
+        "season": 2,
+        "episode": 7,
+        "progress_percent": 21.0,
+        "progress_at": "2026-07-25T20:41:00Z",
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tmdb:94997#s02e07"]
+    post = [call for call in adapter.client.calls if call[0] == "POST"][0]
+    assert post[2] == {
+        "progress": 21.0,
+        "show": {"ids": {"tmdb": 94997}, "title": "House of the Dragon"},
+        "episode": {"season": 2, "number": 7},
+    }
+
+
+def test_add_episode_requires_documented_parent_or_episode_identity() -> None:
+    from providers.sync.simkl import _progress
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "episode",
+        "show_ids": {"slug": "stranger-things"},
+        "season": 1,
+        "episode": 3,
+        "progress_ms": 1_200_000,
+        "duration_ms": 2_400_000,
+        "progress_at": "2026-07-25T11:00:00Z",
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is False
+    assert result["attempted"] == 0
+    assert result["unresolved"][0]["reason"] == "simkl_parent_id_missing"
+    assert not any(call[0] == "POST" for call in adapter.client.calls)
+
+
+def test_remove_deletes_current_playback_id() -> None:
+    from providers.sync.simkl import _progress
+
+    adapter = FakeAdapter([movie_row()])
+
+    result = _progress.remove(adapter, [{"type": "movie", "ids": {"tmdb": "550"}}])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tmdb:550"]
+    assert ("DELETE", "https://api.simkl.com/sync/playback/42", None) in adapter.client.calls
+
+
+def test_simkl_module_exposes_progress_feature() -> None:
+    import providers.sync._mod_SIMKL as simkl_mod
+
+    assert simkl_mod.OPS.features()["progress"] is True
+    assert simkl_mod.OPS.capabilities()["progress"]["upsert"] is True
+    assert simkl_mod.OPS.capabilities()["progress"]["remove"] is True

--- a/providers/tests/test_trakt_progress.py
+++ b/providers/tests/test_trakt_progress.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+
+class Response:
+    def __init__(self, status_code: int, payload: Any = None) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = "" if payload is None else json.dumps(payload)
+        self.headers: dict[str, str] = {}
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeClient:
+    BASE = "https://api.trakt.tv"
+
+    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
+        self.rows = list(rows or [])
+        self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
+        self.next_id = 1000
+
+    def get(self, url: str, **kwargs: Any) -> Response:
+        self.calls.append(("GET", url, kwargs.get("params")))
+        if url.endswith("/sync/playback/movies"):
+            rows = [row for row in self.rows if row.get("type") == "movie"]
+        elif url.endswith("/sync/playback/episodes"):
+            rows = [row for row in self.rows if row.get("type") == "episode"]
+        else:
+            rows = []
+        return Response(200, rows)
+
+    def post(self, url: str, json: Mapping[str, Any], **_: Any) -> Response:
+        self.calls.append(("POST", url, dict(json)))
+        self.next_id += 1
+        if "movie" in json:
+            movie = dict(json["movie"])
+            movie.setdefault("runtime", 10)
+            self.rows = [row for row in self.rows if not (row.get("type") == "movie" and (row.get("movie") or {}).get("ids") == movie.get("ids"))]
+            self.rows.append({"id": self.next_id, "type": "movie", "progress": json["progress"], "paused_at": "2026-07-25T12:00:00Z", "movie": movie})
+        elif "episode" in json:
+            episode = dict(json["episode"])
+            episode.setdefault("runtime", 20)
+            episode.setdefault("season", 1)
+            episode.setdefault("number", 1)
+            episode.setdefault("title", "Pilot")
+            self.rows = [row for row in self.rows if not (row.get("type") == "episode" and (row.get("episode") or {}).get("ids") == episode.get("ids"))]
+            show = dict(json.get("show") or {"title": "Show", "year": 2026, "ids": {"trakt": 1, "slug": "show"}})
+            self.rows.append({"id": self.next_id, "type": "episode", "progress": json["progress"], "paused_at": "2026-07-25T12:00:00Z", "episode": episode, "show": show})
+        return Response(201, {"id": self.next_id, "progress": json["progress"], "action": "pause"})
+
+    def delete(self, url: str, **_: Any) -> Response:
+        self.calls.append(("DELETE", url, None))
+        playback_id = int(url.rsplit("/", 1)[-1])
+        self.rows = [row for row in self.rows if int(row.get("id") or 0) != playback_id]
+        return Response(204)
+
+
+class FakeAdapter:
+    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
+        self.client = FakeClient(rows)
+        self.cfg = type("Cfg", (), {"progress_per_page": 100, "progress_max_pages": 10})()
+
+
+def movie_row(progress: float = 20.0) -> dict[str, Any]:
+    return {
+        "id": 42,
+        "type": "movie",
+        "progress": progress,
+        "paused_at": "2026-07-25T10:00:00Z",
+        "movie": {
+            "title": "Fight Club",
+            "year": 1999,
+            "runtime": 10,
+            "ids": {"trakt": 1, "slug": "fight-club-1999", "imdb": "tt0137523", "tmdb": 550},
+        },
+    }
+
+
+def test_build_index_maps_official_playback_rows() -> None:
+    from providers.sync.trakt import _progress
+
+    index = _progress.build_index(FakeAdapter([movie_row()]))
+
+    assert list(index) == ["tmdb:550"]
+    item = index["tmdb:550"]
+    assert item["progress_ms"] == 120_000
+    assert item["duration_ms"] == 600_000
+    assert item["progress_at"] == "2026-07-25T10:00:00Z"
+    assert item["_trakt_playback_id"] == 42
+
+
+def test_add_movie_uses_documented_scrobble_pause_payload() -> None:
+    from providers.sync.trakt import _progress
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "movie",
+        "title": "Fight Club",
+        "year": 1999,
+        "ids": {"tmdb": "550"},
+        "progress_ms": 120_000,
+        "duration_ms": 600_000,
+        "progress_at": "2026-07-25T11:00:00Z",
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tmdb:550"]
+    post = [call for call in adapter.client.calls if call[0] == "POST"][0]
+    assert post[1] == "https://api.trakt.tv/scrobble/pause"
+    assert post[2] == {"progress": 20.0, "movie": {"title": "Fight Club", "year": 1999, "ids": {"tmdb": 550}}}
+
+
+def test_add_movie_accepts_percent_only_progress() -> None:
+    from providers.sync.trakt import _progress
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "movie",
+        "title": "Fight Club",
+        "year": 1999,
+        "ids": {"tmdb": "550"},
+        "progress_percent": 21.0,
+        "progress_at": "2026-07-25T11:00:00Z",
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tmdb:550"]
+    post = [call for call in adapter.client.calls if call[0] == "POST"][0]
+    assert post[2] == {"progress": 21.0, "movie": {"title": "Fight Club", "year": 1999, "ids": {"tmdb": 550}}}
+
+
+def test_add_episode_requires_episode_or_show_identity() -> None:
+    from providers.sync.trakt import _progress
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "episode",
+        "season": 1,
+        "episode": 1,
+        "progress_ms": 120_000,
+        "duration_ms": 1_200_000,
+        "progress_at": "2026-07-25T11:00:00Z",
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is False
+    assert result["attempted"] == 0
+    assert result["unresolved"][0]["reason"] == "trakt_episode_id_missing"
+    assert not any(call[0] == "POST" for call in adapter.client.calls)
+
+
+def test_add_episode_accepts_documented_episode_tmdb_id() -> None:
+    from providers.sync.trakt import _progress
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "episode",
+        "ids": {"tmdb": "62085"},
+        "show_ids": {"trakt": "1"},
+        "season": 1,
+        "episode": 1,
+        "progress_ms": 120_000,
+        "duration_ms": 1_200_000,
+        "progress_at": "2026-07-25T11:00:00Z",
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is True
+    post = [call for call in adapter.client.calls if call[0] == "POST"][0]
+    assert post[2] == {"progress": 10.0, "show": {"ids": {"trakt": 1}}, "episode": {"season": 1, "number": 1}}
+
+
+def test_add_episode_accepts_show_coordinate_and_percent_only_progress() -> None:
+    from providers.sync.trakt import _progress
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "episode",
+        "series_title": "The Handmaid's Tale",
+        "year": 2017,
+        "show_ids": {"tmdb": "69478"},
+        "season": 6,
+        "episode": 2,
+        "progress_percent": 21.0,
+        "progress_at": "2026-07-25T11:00:00Z",
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tmdb:69478#s06e02"]
+    post = [call for call in adapter.client.calls if call[0] == "POST"][0]
+    assert post[2] == {
+        "progress": 21.0,
+        "show": {"ids": {"tmdb": 69478}, "title": "The Handmaid's Tale", "year": 2017},
+        "episode": {"season": 6, "number": 2},
+    }
+
+
+def test_add_episode_prefers_show_coordinate_when_ids_duplicate_show_id() -> None:
+    from providers.sync.trakt import _progress
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "episode",
+        "series_title": "House of the Dragon",
+        "ids": {"tmdb": "94997"},
+        "show_ids": {"tmdb": "94997"},
+        "season": 2,
+        "episode": 7,
+        "progress_percent": 21.0,
+        "progress_at": "2026-07-25T20:41:00Z",
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tmdb:94997#s02e07"]
+    post = [call for call in adapter.client.calls if call[0] == "POST"][0]
+    assert post[2] == {
+        "progress": 21.0,
+        "show": {"ids": {"tmdb": 94997}, "title": "House of the Dragon"},
+        "episode": {"season": 2, "number": 7},
+    }
+
+
+def test_remove_deletes_current_playback_id() -> None:
+    from providers.sync.trakt import _progress
+
+    adapter = FakeAdapter([movie_row()])
+
+    result = _progress.remove(adapter, [{"type": "movie", "ids": {"tmdb": "550"}}])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == ["tmdb:550"]
+    assert ("DELETE", "https://api.trakt.tv/sync/playback/42", None) in adapter.client.calls
+
+
+def test_trakt_module_exposes_progress_feature() -> None:
+    import providers.sync._mod_TRAKT as trakt_mod
+
+    assert trakt_mod.OPS.features()["progress"] is True
+    assert trakt_mod.OPS.capabilities()["progress"]["upsert"] is True
+    assert trakt_mod.OPS.capabilities()["progress"]["remove"] is True

--- a/tests/test_percent_progress_sync.py
+++ b/tests/test_percent_progress_sync.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_diff_progress_upserts_percent_only_source() -> None:
+    from cw_platform.orchestrator._planner import diff_progress
+
+    adds, clears = diff_progress(
+        {
+            "tmdb:69478#s06e02": {
+                "type": "episode",
+                "show_ids": {"tmdb": "69478"},
+                "season": 6,
+                "episode": 2,
+                "progress_percent": 21.0,
+                "progress_at": "2026-07-25T19:30:00Z",
+            }
+        },
+        {},
+    )
+
+    assert clears == []
+    assert len(adds) == 1
+    assert adds[0]["progress_percent"] == 21.0
+
+
+def test_diff_progress_clears_percent_only_source() -> None:
+    from cw_platform.orchestrator._planner import diff_progress
+
+    adds, clears = diff_progress(
+        {
+            "tmdb:69478#s06e02": {
+                "type": "episode",
+                "show_ids": {"tmdb": "69478"},
+                "season": 6,
+                "episode": 2,
+                "progress_percent": 0,
+            }
+        },
+        {
+            "tmdb:69478#s06e02": {
+                "type": "episode",
+                "show_ids": {"tmdb": "69478"},
+                "season": 6,
+                "episode": 2,
+                "progress_percent": 21,
+            }
+        },
+    )
+
+    assert adds == []
+    assert len(clears) == 1
+    assert clears[0]["progress_ms"] == 0
+
+
+def test_two_way_minimal_progress_preserves_percent_only_source() -> None:
+    from cw_platform.orchestrator._pairs_twoway import _minimal_keep_progress
+
+    item = {
+        "type": "episode",
+        "show_ids": {"tmdb": "69478"},
+        "season": 6,
+        "episode": 2,
+        "progress_percent": 21.1234,
+        "progress_at": "2026-07-25T19:30:00Z",
+    }
+
+    out = _minimal_keep_progress(item)
+
+    assert out["progress_percent"] == 21.123
+    assert out["progress_at"] == "2026-07-25T19:30:00Z"
+
+
+def test_crosswatch_progress_accepts_percent_only_items(tmp_path: Path, monkeypatch) -> None:
+    from providers.sync.crosswatch import _progress
+
+    monkeypatch.setenv("CW_CROSSWATCH_PAIR_SCOPED", "1")
+    monkeypatch.setenv("CW_PAIR_SCOPE", "SIMKL-CROSSWATCH")
+    adapter = type("Adapter", (), {"cfg": type("Cfg", (), {"base_path": str(tmp_path)})()})()
+    item = {
+        "type": "episode",
+        "show_ids": {"tmdb": "69478"},
+        "season": 6,
+        "episode": 2,
+        "progress_percent": 21.0,
+        "progress_at": "2026-07-25T19:30:00Z",
+    }
+
+    count, unresolved = _progress.add(adapter, [item])
+    index = _progress.build_index(adapter)
+
+    assert count == 1
+    assert unresolved == []
+    assert index["tmdb:69478#s06e02"]["progress_percent"] == 21.0


### PR DESCRIPTION
# Pull request

## Change

Used CW progress blueprint and adds SIMKL progress sync support.

Includes:
- reading playback progress
- writing progress with SIMKL pause scrobble
- removing playback items

## Why

CW can sync resume/progress state with SIMKL like the other progress providers.

## Testing

Tested:
- test_simkl_progress.py
Based on progress blueprint and test suite.

## Issue

Relates to #484

Added the Trakt and PublicMetaDB test scripts to this PR because I forgot to include them earlier.