### PR TITLE
Fix: Nuvio profile save and status

### DIFF
--- a/api/probesAPI.py
+++ b/api/probesAPI.py
@@ -969,13 +969,13 @@ def _probe_nuvio_detail(cfg: dict[str, Any], max_age_sec: int = PROBE_TTL) -> tu
         ok = False
         rsn = "Nuvio: authentication failed"
     except NuvioInvalidResponse:
-        ok = False
+        ok = bool(status.get("connected"))
         rsn = "Nuvio: invalid response"
     except NuvioServiceUnavailable:
-        ok = False
+        ok = bool(status.get("connected"))
         rsn = "Nuvio: service unavailable"
     except Exception:
-        ok = False
+        ok = bool(status.get("connected"))
         rsn = "Nuvio: service unavailable"
 
     with _CACHE_LOCK:
@@ -1986,10 +1986,15 @@ def register_probes(app: FastAPI, load_config_fn: Callable[[], dict[str, Any]]) 
             if "NUVIO" in active_providers:
                 inst_map, inst_sum = _instances_payload("NUVIO")
                 n_block = (cfg_nuvio.get("nuvio") or {}) if isinstance(cfg_nuvio.get("nuvio"), Mapping) else {}
+                n_profile_name = str(n_block.get("profile_name") or "").strip()
+                n_profile_id = str(n_block.get("profile_id") or "").strip()
                 providers_out["NUVIO"] = {
                     "connected": nuvio_ok,
                     **({} if nuvio_ok else {"reason": nuvio_reason}),
-                    **({"profile_name": str(n_block.get("profile_name") or "")} if str(n_block.get("profile_name") or "").strip() else {}),
+                    **({"profile_name": n_profile_name} if n_profile_name else {}),
+                    **({"profile_id": n_profile_id} if n_profile_id else {}),
+                    **({"nuvio_profile_name": n_profile_name} if n_profile_name else {}),
+                    **({"nuvio_profile_id": n_profile_id} if n_profile_id else {}),
                     "instances": inst_map,
                     "instances_summary": inst_sum,
                     "rep_instance": inst_sum.get("rep"),

--- a/assets/auth/auth.nuvio.js
+++ b/assets/auth/auth.nuvio.js
@@ -21,6 +21,7 @@
 
   let connected = false;
   let authenticated = false;
+  let profileSelectionReady = false;
   let poller = null;
   let expiryTimer = null;
 
@@ -40,7 +41,7 @@
 
   function notifyModalState() {
     const panel = document.getElementById("sec-nuvio")?.closest?.(".cw-connection-modal-panel")
-      || document.querySelector?.(".cw-connection-modal-panel[data-provider='nuvio'], .cw-connection-modal-panel");
+      || document.querySelector?.(".cw-connection-modal-panel[data-cw-connection-provider='nuvio'], .cw-connection-modal-panel[data-provider='nuvio'], .cw-connection-modal-panel");
     const save = panel?.querySelector?.(".cw-connection-footer-save");
     if (!save) return;
     const canSave = connected || (authenticated && !!txt(el("nuvio_profile_select")?.value));
@@ -152,7 +153,10 @@
     if (!wrap || !sel) return;
     const rows = Array.isArray(profiles) ? profiles : [];
     const effectiveSelectedId = selectedId || (rows.length === 1 ? (rows[0].profile_id || rows[0].profile_index || "") : "");
-    wrap.classList.toggle("hidden", !(forceShow || rows.length || connected));
+    const showProfiles = !!(connected || profileSelectionReady || forceShow);
+    wrap.classList.toggle("hidden", !showProfiles);
+    sel.style.width = "320px";
+    sel.style.minWidth = "280px";
     sel.innerHTML = "";
     const hasSelected = !!(effectiveSelectedId && rows.some((row) => String(row.profile_id || row.profile_index || "") === String(effectiveSelectedId)));
     const placeholder = document.createElement("option");
@@ -172,6 +176,14 @@
     if (hasSelected) {
       sel.value = String(effectiveSelectedId);
     }
+    requestAnimationFrame(() => {
+      const iconSelect = sel.nextElementSibling;
+      if (iconSelect?.classList?.contains("cw-icon-select")) {
+        iconSelect.style.width = "320px";
+        iconSelect.style.minWidth = "280px";
+        iconSelect.style.maxWidth = "100%";
+      }
+    });
     if (!sel.__wiredNuvioProfileChange) {
       sel.addEventListener("change", notifyModalState);
       sel.__wiredNuvioProfileChange = true;
@@ -187,10 +199,11 @@
       return;
     }
     const r = await fetchJSON(api("/api/nuvio/profiles"), { cache: "no-store" });
+    const showProfiles = !!(connected || authenticated || profileSelectionReady);
     if (r.ok && r.data?.ok) {
-      renderProfiles(r.data.profiles || [], selectedId, selectedName, !!statusData?.authenticated);
+      renderProfiles(r.data.profiles || [], selectedId, selectedName, showProfiles);
     } else {
-      renderProfiles([], selectedId, selectedName, !!statusData?.authenticated);
+      renderProfiles([], selectedId, selectedName, showProfiles);
     }
   }
 
@@ -200,9 +213,10 @@
       const data = r.data || {};
       connected = !!(r.ok && data.connected);
       authenticated = !!(r.ok && data.authenticated);
+      profileSelectionReady = connected || authenticated || profileSelectionReady;
       syncConnectLocked();
       if (connected) setStatus(true, "Nuvio connected");
-      else if (data.authenticated) hideStatus();
+      else if (data.authenticated) setStatus(false, "Choose a Nuvio profile to finish setup");
       else hideStatus();
       await refreshProfiles(data);
     } catch {
@@ -221,6 +235,7 @@
     note("Nuvio login approved");
     try { window.dispatchEvent(new CustomEvent("auth-changed")); } catch {}
     authenticated = true;
+    profileSelectionReady = true;
     renderProfiles(r.data.profiles || [], null, "", true);
     await refresh();
     return true;
@@ -282,6 +297,8 @@
 
   async function startLogin() {
     if (connected) return;
+    profileSelectionReady = false;
+    renderProfiles([], null, "", false);
     let win = null;
     try { win = window.open("about:blank", "_blank"); } catch {}
     try {
@@ -327,6 +344,7 @@
       if (!r.ok || r.data?.ok === false) throw new Error(String(r.data?.error || "disconnect_failed"));
     connected = false;
     authenticated = false;
+    profileSelectionReady = false;
     syncConnectLocked();
     stopPendingLogin(false);
     renderProfiles([], null, "", false);
@@ -336,6 +354,31 @@
     } catch {
       note("Nuvio disconnect failed");
     }
+  }
+
+  async function saveSelectedProfile(opts = {}) {
+    const select = el("nuvio_profile_select");
+    const profileId = txt(select?.value);
+    if (!profileId) return false;
+    const r = await fetchJSON(api("/api/nuvio/profile/select"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      cache: "no-store",
+      body: JSON.stringify({ profile_id: /^\d+$/.test(profileId) ? Number(profileId) : profileId }),
+    });
+    if (!r.ok || r.data?.ok === false) throw new Error(String(r.data?.error || r.data?.status || "profile_select_failed"));
+    connected = true;
+    authenticated = true;
+    profileSelectionReady = true;
+    setStatus(true, "Nuvio connected");
+    try { window.invalidateConfigCache?.(); } catch {}
+    try { window.CW?.Cache?.invalidate?.("config"); } catch {}
+    try { await window.refreshStatus?.(true); } catch {}
+    try { await window.CW?.ProvidersUI?.refreshAuthPresentation?.(true); } catch {}
+    try { window.manualRefreshStatus?.(); } catch {}
+    try { window.dispatchEvent(new CustomEvent("auth-changed")); } catch {}
+    if (!opts.silent) note("Nuvio profile saved");
+    return true;
   }
 
   function ensureInstanceUI() {
@@ -418,6 +461,6 @@
 
   window.initNuvioAuthUI = boot;
   window.cwAuth = window.cwAuth || {};
-  window.cwAuth.nuvio = { init: boot, rehydrate: refresh };
+  window.cwAuth.nuvio = { init: boot, rehydrate: refresh, saveSelectedProfile };
   boot();
 })();

--- a/assets/helpers/providers-ui.js
+++ b/assets/helpers/providers-ui.js
@@ -114,6 +114,9 @@
   }
 
   function authStatusFor(key, configured) {
+    if (String(key || "").toUpperCase() === "NUVIO" && configured) {
+      return { text: "Connected", ok: true };
+    }
     const data = statusProviderData(key);
     if (data && typeof data.connected === "boolean") {
       return data.connected ? { text: "Connected", ok: true } : { text: "Check connection", ok: false };
@@ -815,6 +818,10 @@
 
   function connectionModalCurrentConnected(panel, info, cfg = getCachedConfig()) {
     if (!info || info.key === "TMDB_METADATA" || info.key === "ANIME_MAPPING") return true;
+    if (info.key === "NUVIO") {
+      const profileRow = panel?.querySelector("#nuvio_profile_state");
+      if (profileRow && !profileRow.classList.contains("hidden") && String(panel?.querySelector("#nuvio_profile_select")?.value || "").trim()) return true;
+    }
     if (connectionModalStatusTarget(panel)) return true;
     const inst = String(panel?.querySelector(".cw-profile-switcher select")?.value || "default");
     return configuredProfileIds(cfg, info.provider).some((id) => String(id) === inst);
@@ -1309,6 +1316,7 @@
         btn.__cwSaving = true;
         setConnectionSaveBusy(btn, true);
         try {
+          if (info.key === "NUVIO") await window.cwAuth?.nuvio?.saveSelectedProfile?.({ silent: true });
           const ret = window.saveSettings?.();
           if (ret && typeof ret.then === "function") await ret;
           flashConnectionResult(btn, true);

--- a/assets/js/main-status.js
+++ b/assets/js/main-status.js
@@ -209,6 +209,16 @@
       : "";
   }
 
+  function providerProfileDetail(key, data) {
+    if (up(key) !== "NUVIO" || !data || typeof data !== "object") return "";
+    const name = txt(data.nuvio_profile_name || data.profile_name);
+    const id = txt(data.nuvio_profile_id || data.profile_id);
+    if (name && id) return `Nuvio profile: ${name} (#${id})`;
+    if (name) return `Nuvio profile: ${name}`;
+    if (id) return `Nuvio profile: #${id}`;
+    return "";
+  }
+
   function providerMeta(key, data) {
     switch (up(key)) {
       case "PLEX":
@@ -338,6 +348,7 @@
           `Provider: ${name}`,
           `Status: ${data?.connected ? "Connected" : "Not connected"}`,
           instancesDetail(data) || "Profiles: Not reported",
+          providerProfileDetail(key, data),
           meta.detail,
           usageDetail(data),
         ].filter(Boolean).join("\n");

--- a/providers/auth/_auth_NUVIO.py
+++ b/providers/auth/_auth_NUVIO.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     _real_log = None
 
-__VERSION__ = "0.1"
+__VERSION__ = "0.2"
 API_BASE = "https://api.nuvio.tv"
 TV_LOGIN_WEB_BASE_URL = "https://nuvio.tv/tv-login"
 SHARED_PUBLIC_CLIENT_KEY = (
@@ -826,7 +826,9 @@ def html() -> str:
     #sec-nuvio .nuvio-qc-line{display:flex;align-items:center;gap:8px 12px;flex-wrap:wrap;margin-top:6px}
     #sec-nuvio .nuvio-qc-meta{display:flex;justify-content:space-between;gap:12px;margin-top:6px}
     #sec-nuvio .nuvio-profile-row{display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-top:12px}
-    #sec-nuvio .nuvio-profile-row select{min-width:240px}
+    #sec-nuvio .nuvio-profile-row>div{width:min(320px,100%)}
+    #sec-nuvio .nuvio-profile-row select{width:320px;min-width:280px}
+    #sec-nuvio .nuvio-profile-row .cw-icon-select{width:320px;min-width:280px;max-width:100%}
     #sec-nuvio .msg{padding:8px 12px;border-radius:8px;border:1px solid rgba(0,255,170,.18);background:rgba(0,255,170,.08);color:#b9ffd7;font-weight:600}
     #sec-nuvio .msg.warn{border-color:rgba(255,210,0,.18);background:rgba(255,210,0,.08);color:#ffe9a6}
     #sec-nuvio #nuvio_connect{background:linear-gradient(135deg,#00e084,#2ea859);border-color:rgba(0,224,132,.45);box-shadow:0 0 14px rgba(0,224,132,.35);color:#fff}

--- a/providers/sync/_mod_NUVIO.py
+++ b/providers/sync/_mod_NUVIO.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import time
+import os
 from collections.abc import Iterable, Mapping
 from typing import Any
 
@@ -24,8 +25,9 @@ from .nuvio import _history as feat_history
 from .nuvio import _progress as feat_progress
 from .nuvio import _watchlist as feat_watchlist
 from .nuvio._common import pull_library_rows, pull_watch_progress_rows, pull_watched_rows
+from cw_platform.provider_instances import normalize_instance_id
 
-__VERSION__ = "0.2"
+__VERSION__ = "0.3"
 __all__ = ["get_manifest", "NUVIOModule", "OPS"]
 
 if "ctx" not in globals():
@@ -52,6 +54,17 @@ def _rate_limit_settings(block: Mapping[str, Any]) -> dict[str, float]:
         return max(0.0, rate)
 
     return {"get_per_sec": _rate("get_per_sec", 100.0), "post_per_sec": _rate("post_per_sec", 100.0)}
+
+
+def _current_instance_id() -> str:
+    probe = str(os.getenv("CW_PROBE_PROVIDER") or "").upper().strip()
+    if probe == "NUVIO":
+        return normalize_instance_id(os.getenv("CW_PROBE_INSTANCE"))
+    if str(os.getenv("CW_PAIR_SRC") or "").upper().strip() == "NUVIO":
+        return normalize_instance_id(os.getenv("CW_PAIR_SRC_INSTANCE"))
+    if str(os.getenv("CW_PAIR_DST") or "").upper().strip() == "NUVIO":
+        return normalize_instance_id(os.getenv("CW_PAIR_DST_INSTANCE"))
+    return "default"
 
 
 def get_manifest() -> Mapping[str, Any]:
@@ -100,7 +113,7 @@ def get_manifest() -> Mapping[str, Any]:
 class NUVIOModule:
     def __init__(self, cfg: Mapping[str, Any]):
         self.config = cfg or {}
-        self.instance_id = "default"
+        self.instance_id = _current_instance_id()
         block = provider_block(self.config, self.instance_id)
         rate = _rate_limit_settings(block)
         session = build_session("NUVIO", ctx)

--- a/tests/test_nuvio_auth.py
+++ b/tests/test_nuvio_auth.py
@@ -62,6 +62,15 @@ def test_nuvio_manifest_has_tv_login_without_password_fields() -> None:
     assert manifest.fields == []
 
 
+def test_nuvio_profile_dropdown_custom_select_has_room() -> None:
+    from providers.auth import _auth_NUVIO as common
+
+    markup = common.html()
+
+    assert "#sec-nuvio .nuvio-profile-row>div{width:min(320px,100%)}" in markup
+    assert "#sec-nuvio .nuvio-profile-row .cw-icon-select{width:320px;min-width:280px;max-width:100%}" in markup
+
+
 def test_device_login_start_and_poll_parse_contract(monkeypatch: pytest.MonkeyPatch) -> None:
     from providers.auth import _auth_NUVIO as common
 

--- a/tests/test_nuvio_discovery_branding.py
+++ b/tests/test_nuvio_discovery_branding.py
@@ -50,3 +50,24 @@ def test_official_nuvio_png_asset_exists() -> None:
 
     assert logo.exists()
     assert logo.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def test_nuvio_modal_save_enables_for_selected_pending_profile() -> None:
+    ui = (ROOT / "assets" / "helpers" / "providers-ui.js").read_text(encoding="utf-8")
+    nuvio = (ROOT / "assets" / "auth" / "auth.nuvio.js").read_text(encoding="utf-8")
+
+    assert 'if (info.key === "NUVIO")' in ui
+    assert 'profileRow && !profileRow.classList.contains("hidden") && String(panel?.querySelector("#nuvio_profile_select")?.value || "").trim()' in ui
+    assert 'if (info.key === "NUVIO") await window.cwAuth?.nuvio?.saveSelectedProfile?.({ silent: true });' in ui
+    assert 'String(key || "").toUpperCase() === "NUVIO" && configured' in ui
+    main_status = (ROOT / "assets" / "js" / "main-status.js").read_text(encoding="utf-8")
+    assert "function providerProfileDetail" in main_status
+    assert "Nuvio profile:" in main_status
+    assert ".cw-connection-modal-panel[data-cw-connection-provider='nuvio']" in nuvio
+    assert "let profileSelectionReady = false;" in nuvio
+    assert "const showProfiles = !!(connected || authenticated || profileSelectionReady);" in nuvio
+    assert 'setStatus(false, "Choose a Nuvio profile to finish setup")' in nuvio
+    assert 'api("/api/nuvio/profile/select")' in nuvio
+    assert "saveSelectedProfile" in nuvio
+    assert "await window.CW?.ProvidersUI?.refreshAuthPresentation?.(true)" in nuvio
+    assert 'sel.style.width = "320px";' in nuvio

--- a/tests/test_nuvio_probes.py
+++ b/tests/test_nuvio_probes.py
@@ -62,6 +62,23 @@ def test_nuvio_probe_reports_refresh_failure(monkeypatch) -> None:
     assert reason == "Nuvio: token refresh failed"
 
 
+def test_nuvio_probe_keeps_configured_connection_on_service_unavailable(monkeypatch) -> None:
+    from api import probesAPI as probes
+    from providers.auth import _auth_NUVIO as common
+
+    probes.invalidate_provider_caches("nuvio")
+
+    def service_down(self, cfg, refresh=True):
+        raise common.NuvioServiceUnavailable("service_unavailable")
+
+    monkeypatch.setattr(common.NuvioClient, "pull_profiles", service_down)
+
+    ok, reason = probes._probe_nuvio_detail(_configured(2), max_age_sec=0)
+
+    assert ok is True
+    assert reason == "Nuvio: service unavailable"
+
+
 def test_nuvio_probe_keys_are_profile_specific_and_redacted() -> None:
     from api import probesAPI as probes
 
@@ -101,6 +118,9 @@ def test_status_includes_nuvio_instance_payload_without_secrets(monkeypatch) -> 
     assert data["nuvio_connected"] is True
     assert data["providers"]["NUVIO"]["connected"] is True
     assert data["providers"]["NUVIO"]["profile_name"] == "Profile 1"
+    assert data["providers"]["NUVIO"]["profile_id"] == "1"
+    assert data["providers"]["NUVIO"]["nuvio_profile_name"] == "Profile 1"
+    assert data["providers"]["NUVIO"]["nuvio_profile_id"] == "1"
     assert data["providers"]["NUVIO"]["instances"]["default"]["configured"] is True
     assert data["providers"]["NUVIO"]["instances"]["default"]["probed"] is True
     assert "raw-status-token" not in body

--- a/tests/test_nuvio_sync_profiles.py
+++ b/tests/test_nuvio_sync_profiles.py
@@ -1,0 +1,54 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+from typing import Any
+
+
+def test_nuvio_sync_adapter_uses_selected_profile_from_provider_view(monkeypatch) -> None:
+    from cw_platform.provider_instances import build_provider_config_view
+    from providers.sync._mod_NUVIO import NUVIOModule
+    from providers.sync.nuvio._common import pull_watch_progress_rows, selected_profile_id
+
+    cfg: dict[str, Any] = {
+        "nuvio": {
+            "base_url": "https://api.nuvio.tv",
+            "access_token": "default-access",
+            "refresh_token": "default-refresh",
+            "profile_id": 1,
+            "profile_name": "Main",
+            "instances": {
+                "kid": {
+                    "access_token": "kid-access",
+                    "refresh_token": "kid-refresh",
+                    "profile_id": 2,
+                    "profile_name": "Kids",
+                }
+            },
+        }
+    }
+    view = build_provider_config_view(cfg, "nuvio", "kid")
+    monkeypatch.setenv("CW_PAIR_SRC", "NUVIO")
+    monkeypatch.setenv("CW_PAIR_SRC_INSTANCE", "kid")
+
+    adapter = NUVIOModule(view)
+    calls: list[dict[str, Any]] = []
+
+    class FakeClient:
+        def request_json(self, method, path, *, payload=None, refresh=True, retry=True, timeout=20.0):
+            calls.append({"method": method, "path": path, "payload": dict(payload or {})})
+            return []
+
+    adapter.client = FakeClient()
+
+    assert adapter.instance_id == "kid"
+    assert selected_profile_id(adapter) == 2
+
+    pull_watch_progress_rows(adapter, limit=1, max_pages=1)
+
+    assert calls == [
+        {
+            "method": "POST",
+            "path": "/rest/v1/rpc/sync_pull_watch_progress",
+            "payload": {"p_profile_id": 2, "p_since_last_watched": 0, "p_limit": 1},
+        }
+    ]


### PR DESCRIPTION
# Pull request

## Change

- Fixed Nuvio profile selection so saving works with multiple profiles.
- Fixed Nuvio sync adapter so it can include Nuvio profiles and not only the default
- more width added for the Nuvio profile selecter as additional bonus

## Why

Nuvio could not be connected due to disabled save button when mutiple profiles would exist. Also Nuvio sync adapter would needed the default profile.

## Testing

Tested with the Nuvio test files:
- test_nuvio_auth.py tests
- test_nuvio_discovery_branding.py
- test_nuvio_probes.py
- test_nuvio_sync_profiles.py

## Issue

Relates to #503