### PR TITLE
Fix: open enriched Connections  immediately

### DIFF
--- a/assets/helpers/providers-ui.js
+++ b/assets/helpers/providers-ui.js
@@ -1413,6 +1413,7 @@
     section.classList.add("open");
     section.querySelector(":scope > .head")?.setAttribute("aria-expanded", "true");
     openAuthOverlay("form", info.key);
+    enhanceConnectionModal(section, overlay, info.key);
     try { await window.cwEnsureAuthSection?.(info.sectionId); } catch {}
     const providerId = connectionInfoForKey(info.key)?.provider || String(info.key || "").toLowerCase();
     try { window.cwAuth?.[providerId]?.init?.(); } catch {}


### PR DESCRIPTION
# Pull request

## Change

Connections now applies the enriched modal layout as soon as the provider form opens. 

## Why

The modal briefly showed the plain layout before getting upgraded, which felt like a two-step load.

## Testing

Manual tested

## Issue

NA