### PR TITLE
Add: Kodi sync implementation

### DIFF
--- a/cw_platform/id_map.py
+++ b/cw_platform/id_map.py
@@ -322,6 +322,7 @@ def minimal(item: Mapping[str, Any]) -> dict[str, Any]:
         "progress_percent",
         "duration_ms",
         "progress_at",
+        "progress_at_source",
     ):
         if opt in item:
             out[opt] = item.get(opt)

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -109,6 +109,7 @@ _PROVIDER_KEY_MAP = {
     "PLEX": "plex",
     "JELLYFIN": "jellyfin",
     "EMBY": "emby",
+    "KODI": "kodi",
 }
 
 def _index_semantics(ops, feature: str, *, cfg: Mapping[str, Any] | None = None, provider: str = "") -> str:
@@ -280,6 +281,9 @@ def _minimal_keep_progress(it: Mapping[str, Any]) -> dict[str, Any]:
         pa = it.get("progress_at") or it.get("progressAt") or it.get("last_played") or it.get("lastViewedAt")
         if isinstance(pa, str) and pa.strip():
             out["progress_at"] = pa.strip()
+        pas = it.get("progress_at_source") or it.get("progressAtSource")
+        if isinstance(pas, str) and pas.strip():
+            out["progress_at_source"] = pas.strip()
     except Exception:
         pass
     return out
@@ -497,8 +501,8 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
     libs_A = _effective_library_whitelist(cfg, a, feature, fcfg)
     libs_B = _effective_library_whitelist(cfg, b, feature, fcfg)
 
-    allow_unknown_A = (str(a).upper() == "PLEX" and feature == "history")
-    allow_unknown_B = (str(b).upper() == "PLEX" and feature == "history")
+    allow_unknown_A = (str(a).upper() == "PLEX" and feature == "history") or str(a).upper() == "KODI"
+    allow_unknown_B = (str(b).upper() == "PLEX" and feature == "history") or str(b).upper() == "KODI"
 
     if libs_A:
         prevA = _filter_index_by_libraries(prevA, libs_A, allow_unknown=allow_unknown_A)
@@ -1198,6 +1202,17 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
             except Exception:
                 return None
 
+        def _kodi_first_observed(provider: str, it: Mapping[str, Any]) -> bool:
+            if str(provider or "").strip().upper() != "KODI":
+                return False
+            source = str(it.get("progress_at_source") or it.get("progressAtSource") or "").strip().lower()
+            return source == "kodi_first_observed"
+
+        def _real_prog_epoch(provider: str, it: Mapping[str, Any]) -> int | None:
+            if _kodi_first_observed(provider, it):
+                return None
+            return _prog_epoch(it)
+
         bi = sync_cfg.get("bidirectional") or {}
         sot = (bi.get("source_of_truth") or bi.get("sourceOfTruth") or "").strip().upper()
         prefer = sot if sot in (a, b) else a
@@ -1216,10 +1231,20 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
             a_it = (A_eff.get(k) or upB.get(k) or clB.get(k) or {})
             b_it = (B_eff.get(k) or upA.get(k) or clA.get(k) or {})
 
+            if _kodi_first_observed(a, a_it) and _real_prog_epoch(b, b_it) is not None:
+                if _prog_ms(b_it) > 0 or _prog_percent(b_it) is not None:
+                    addA.append(_minimal_keep_progress(b_it))
+                continue
+
+            if _kodi_first_observed(b, b_it) and _real_prog_epoch(a, a_it) is not None:
+                if _prog_ms(a_it) > 0 or _prog_percent(a_it) is not None:
+                    addB.append(_minimal_keep_progress(a_it))
+                continue
+
             # Both want to set progress.
             if k in upA and k in upB:
-                ta = _prog_epoch(a_it)
-                tb = _prog_epoch(b_it)
+                ta = _real_prog_epoch(a, a_it)
+                tb = _real_prog_epoch(b, b_it)
                 if ta is not None and tb is not None and ta != tb:
                     win = a if ta > tb else b
                 else:
@@ -1246,8 +1271,8 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
             # Clear vs set conflicts.
             if (k in clB) and (k in upA):
                 # A explicitly cleared; B has progress. Decide by timestamp, then prefer.
-                ta = _prog_epoch(clB[k])
-                tb = _prog_epoch(b_it)
+                ta = _real_prog_epoch(a, clB[k])
+                tb = _real_prog_epoch(b, b_it)
                 if ta is not None and tb is not None and ta != tb:
                     win = a if ta > tb else b
                 else:
@@ -1260,8 +1285,8 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                 continue
 
             if (k in clA) and (k in upB):
-                tb = _prog_epoch(clA[k])
-                ta = _prog_epoch(a_it)
+                tb = _real_prog_epoch(b, clA[k])
+                ta = _real_prog_epoch(a, a_it)
                 if ta is not None and tb is not None and ta != tb:
                     win = a if ta > tb else b
                 else:

--- a/providers/sync/_mod_KODI.py
+++ b/providers/sync/_mod_KODI.py
@@ -1,0 +1,152 @@
+# providers/sync/_mod_KODI.py
+# CrossWatch Kodi sync module
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from providers.sync._mod_common import build_op_result
+from providers.sync.kodi import _history as feat_history
+from providers.sync.kodi import _progress as feat_progress
+from providers.sync.kodi import _ratings as feat_ratings
+from providers.sync.kodi._common import KodiClient, health_payload, is_configured, item_key, make_config, pick_instance_id
+
+__VERSION__ = "0.1"
+__all__ = ["get_manifest", "KODIModule", "OPS"]
+
+_FEATURES = {"watchlist": False, "ratings": True, "history": True, "progress": True, "playlists": False}
+_FEATURE_MODULES = {"history": feat_history, "ratings": feat_ratings, "progress": feat_progress}
+
+
+def get_manifest() -> Mapping[str, Any]:
+    caps = {
+        "bidirectional": True,
+        "experimental": True,
+        "provides_ids": True,
+        "index_semantics": "present",
+        "compatibility": {
+            "minimum_kodi": "21.0",
+            "minimum_jsonrpc": "13.5.0",
+            "tested_jsonrpc": "13.5.x",
+        },
+        "history": {
+            "read": True,
+            "write": True,
+            "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+            "upsert": True,
+            "remove": True,
+            "observed_deletes": True,
+            "aggregated": True,
+        },
+        "ratings": {
+            "read": True,
+            "write": True,
+            "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+            "upsert": True,
+            "remove": True,
+            "scale": "1-10",
+            "from_date": False,
+        },
+        "progress": {
+            "read": True,
+            "write": True,
+            "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+            "upsert": True,
+            "remove": True,
+            "requires_duration": False,
+        },
+    }
+    return {
+        "name": "KODI",
+        "label": "Kodi",
+        "version": __VERSION__,
+        "type": "sync",
+        "bidirectional": True,
+        "experimental": True,
+        "features": dict(_FEATURES),
+        "requires": ["requests"],
+        "capabilities": caps,
+    }
+
+
+class KODIModule:
+    def __init__(self, cfg: Mapping[str, Any]):
+        self.config = cfg or {}
+        self.instance_id = pick_instance_id()
+        self.cfg = make_config(self.config, self.instance_id)
+        if not self.cfg.server:
+            raise RuntimeError("Kodi config requires server")
+        self.client = KodiClient(self.cfg)
+        self._kodi_library_index = None
+
+    @staticmethod
+    def supported_features() -> dict[str, bool]:
+        return dict(_FEATURES)
+
+    def manifest(self) -> Mapping[str, Any]:
+        return get_manifest()
+
+    def health(self) -> Mapping[str, Any]:
+        payload = health_payload(self)
+        features = {name: bool(payload.get("ok") and enabled) for name, enabled in _FEATURES.items()}
+        payload["features"] = features
+        return payload
+
+    @staticmethod
+    def key_of(obj: Mapping[str, Any]) -> str:
+        return item_key(obj)
+
+    def build_index(self, feature: str, **kwargs: Any) -> Mapping[str, dict[str, Any]]:
+        mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
+        return mod.build_index(self, **kwargs) if mod else {}
+
+    def add(self, feature: str, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+        mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
+        if not mod:
+            return build_op_result(ok=True, count=0, unsupported=True)
+        return mod.add(self, items, dry_run=dry_run)
+
+    def remove(self, feature: str, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+        mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
+        if not mod:
+            return build_op_result(ok=True, count=0, unsupported=True)
+        return mod.remove(self, items, dry_run=dry_run)
+
+
+class _KODIOPS:
+    def name(self) -> str:
+        return "KODI"
+
+    def label(self) -> str:
+        return "Kodi"
+
+    def features(self) -> Mapping[str, bool]:
+        return dict(_FEATURES)
+
+    def state_read_features(self) -> Mapping[str, bool]:
+        return dict(_FEATURES)
+
+    def capabilities(self) -> Mapping[str, Any]:
+        return get_manifest()["capabilities"]
+
+    def is_configured(self, cfg: Mapping[str, Any]) -> bool:
+        return is_configured(cfg, "default")
+
+    def _adapter(self, cfg: Mapping[str, Any]) -> KODIModule:
+        return KODIModule(cfg)
+
+    def health(self, cfg: Mapping[str, Any]) -> Mapping[str, Any]:
+        return self._adapter(cfg).health()
+
+    def build_index(self, cfg: Mapping[str, Any], *, feature: str) -> Mapping[str, dict[str, Any]]:
+        return self._adapter(cfg).build_index(feature)
+
+    def add(self, cfg: Mapping[str, Any], items: Iterable[Mapping[str, Any]], *, feature: str, dry_run: bool = False) -> dict[str, Any]:
+        return self._adapter(cfg).add(feature, items, dry_run=dry_run)
+
+    def remove(self, cfg: Mapping[str, Any], items: Iterable[Mapping[str, Any]], *, feature: str, dry_run: bool = False) -> dict[str, Any]:
+        return self._adapter(cfg).remove(feature, items, dry_run=dry_run)
+
+
+OPS = _KODIOPS()

--- a/providers/sync/kodi/_common.py
+++ b/providers/sync/kodi/_common.py
@@ -3,12 +3,14 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude
 from __future__ import annotations
 
+import json
 import os
 import time
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from cw_platform.config_base import load_config, save_config
@@ -358,6 +360,67 @@ def progress_ms_for_write(item: Mapping[str, Any], target_duration_ms: int | Non
     return pos, duration
 
 
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _progress_signature(item: Mapping[str, Any]) -> tuple[int | None, int | None, float | None]:
+    pct = to_float(item.get("progress_percent") or item.get("percent"))
+    return (
+        to_int(item.get("progress_ms") or item.get("progress") or item.get("viewOffset")),
+        to_int(item.get("duration_ms")),
+        round(pct, 3) if pct is not None else None,
+    )
+
+
+def _load_kodi_progress_baseline(adapter: Any) -> Mapping[str, Mapping[str, Any]]:
+    injected = getattr(adapter, "_kodi_progress_baseline", None)
+    if isinstance(injected, Mapping):
+        return {str(k): dict(v) for k, v in injected.items() if isinstance(v, Mapping)}
+    try:
+        from cw_platform.config_base import CONFIG_BASE
+
+        path = Path(CONFIG_BASE()) / "state.json"
+        if not path.exists():
+            return {}
+        state = json.loads(path.read_text("utf-8"))
+        providers = state.get("providers") if isinstance(state, Mapping) else None
+        providers = providers if isinstance(providers, Mapping) else {}
+        kodi = providers.get("KODI") or providers.get("kodi")
+        if not isinstance(kodi, Mapping):
+            return {}
+        instance_id = normalize_instance_id(getattr(adapter, "instance_id", "default"))
+        nodes: list[Mapping[str, Any]] = []
+        instances = kodi.get("instances")
+        if isinstance(instances, Mapping):
+            inst_node = instances.get(instance_id) or instances.get(str(instance_id))
+            if isinstance(inst_node, Mapping):
+                nodes.append(inst_node)
+        nodes.append(kodi)
+        for node in nodes:
+            progress = node.get("progress")
+            progress = progress if isinstance(progress, Mapping) else {}
+            baseline = progress.get("baseline")
+            baseline = baseline if isinstance(baseline, Mapping) else {}
+            items = baseline.get("items")
+            if isinstance(items, Mapping):
+                return {str(k): dict(v) for k, v in items.items() if isinstance(v, Mapping)}
+    except Exception:
+        return {}
+    return {}
+
+
+def _managed_progress_metadata(prior: Mapping[str, Any] | None, item: Mapping[str, Any], now_iso: str) -> tuple[str, str]:
+    if isinstance(prior, Mapping):
+        previous = str(prior.get("progress_at") or prior.get("updated_at") or "").strip()
+        if previous and _progress_signature(prior) == _progress_signature(item):
+            source = str(prior.get("progress_at_source") or "kodi_first_observed").strip()
+            return previous, source
+        if previous:
+            return now_iso, "kodi_resume_changed"
+    return now_iso, "kodi_first_observed"
+
+
 def fetch_libraries_from_cfg(cfg: dict[str, Any] | None = None, instance_id: Any = None) -> list[dict[str, Any]]:
     cfg2 = cfg or load_config()
     ensure_whitelist_defaults(cfg2, instance_id=instance_id)
@@ -595,6 +658,8 @@ def library_index(adapter: Any, feature: str = "") -> LibraryIndex:
 def feature_index(adapter: Any, feature: str) -> dict[str, dict[str, Any]]:
     idx = library_index(adapter, feature)
     out: dict[str, dict[str, Any]] = {}
+    prior_progress = _load_kodi_progress_baseline(adapter) if feature == "progress" else {}
+    now_iso = _utc_now_iso() if feature == "progress" else ""
     for base in idx.items:
         item = dict(base)
         raw_obj = item.get("_kodi_raw")
@@ -621,7 +686,12 @@ def feature_index(adapter: Any, feature: str) -> dict[str, dict[str, Any]]:
                 item["progress_percent"] = pct
         else:
             continue
-        out[item_key(item)] = item
+        key = item_key(item)
+        if feature == "progress":
+            progress_at, progress_at_source = _managed_progress_metadata(prior_progress.get(key), item, now_iso)
+            item["progress_at"] = progress_at
+            item["progress_at_source"] = progress_at_source
+        out[key] = item
     log(feature, "info", "index_done", count=len(out))
     return out
 

--- a/providers/sync/kodi/_history.py
+++ b/providers/sync/kodi/_history.py
@@ -1,0 +1,27 @@
+# providers/sync/kodi/_history.py
+# CrossWatch Kodi history synchronization
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from ._common import feature_index, operation_result, watched_at_to_kodi
+
+
+def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
+    return feature_index(adapter, "history")
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    def payload(source: Mapping[str, Any], _target: Mapping[str, Any]) -> tuple[dict[str, Any], str | None]:
+        return {"playcount": max(1, int(source.get("playcount") or 1)), "lastplayed": watched_at_to_kodi(source.get("watched_at"))}, None
+
+    return operation_result(adapter, "history", "add", items, payload, dry_run=dry_run)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    def payload(_source: Mapping[str, Any], _target: Mapping[str, Any]) -> tuple[dict[str, Any], str | None]:
+        return {"playcount": 0, "lastplayed": ""}, None
+
+    return operation_result(adapter, "history", "remove", items, payload, dry_run=dry_run)

--- a/providers/sync/kodi/_progress.py
+++ b/providers/sync/kodi/_progress.py
@@ -1,0 +1,36 @@
+# providers/sync/kodi/_progress.py
+# CrossWatch Kodi playback progress synchronization
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from ._common import feature_index, operation_result, progress_ms_for_write, resume_ms
+
+
+def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
+    return feature_index(adapter, "progress")
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    def payload(source: Mapping[str, Any], target: Mapping[str, Any]) -> tuple[dict[str, Any], str | None]:
+        raw_obj = target.get("_kodi_raw")
+        raw: Mapping[str, Any] = raw_obj if isinstance(raw_obj, Mapping) else {}
+        _target_pos, target_total, _pct = resume_ms(raw)
+        pos, total = progress_ms_for_write(source, target_total)
+        if pos is None:
+            return {}, "missing_progress"
+        return {"resume": {"position": max(0.0, pos / 1000.0), "total": max(0.0, (total or 0) / 1000.0)}}, None
+
+    return operation_result(adapter, "progress", "add", items, payload, dry_run=dry_run)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    def payload(_source: Mapping[str, Any], target: Mapping[str, Any]) -> tuple[dict[str, Any], str | None]:
+        raw_obj = target.get("_kodi_raw")
+        raw: Mapping[str, Any] = raw_obj if isinstance(raw_obj, Mapping) else {}
+        _target_pos, target_total, _pct = resume_ms(raw)
+        return {"resume": {"position": 0.0, "total": max(0.0, (target_total or 0) / 1000.0)}}, None
+
+    return operation_result(adapter, "progress", "remove", items, payload, dry_run=dry_run)

--- a/providers/sync/kodi/_ratings.py
+++ b/providers/sync/kodi/_ratings.py
@@ -1,0 +1,30 @@
+# providers/sync/kodi/_ratings.py
+# CrossWatch Kodi ratings synchronization
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from ._common import feature_index, operation_result, rating_for_write
+
+
+def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
+    return feature_index(adapter, "ratings")
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    def payload(source: Mapping[str, Any], _target: Mapping[str, Any]) -> tuple[dict[str, Any], str | None]:
+        rating = rating_for_write(source)
+        if rating is None:
+            return {}, "missing_rating"
+        return {"userrating": rating}, None
+
+    return operation_result(adapter, "ratings", "add", items, payload, dry_run=dry_run)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    def payload(_source: Mapping[str, Any], _target: Mapping[str, Any]) -> tuple[dict[str, Any], str | None]:
+        return {"userrating": 0}, None
+
+    return operation_result(adapter, "ratings", "remove", items, payload, dry_run=dry_run)

--- a/providers/tests/test_kodi_sync.py
+++ b/providers/tests/test_kodi_sync.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from providers.sync import _mod_KODI as mod
+from providers.sync.kodi import _common as common
+from providers.auth._auth_KODI import KodiAuthError
+
+
+class FakeKodiClient:
+    def __init__(self, movies=None, episodes=None, tvshows=None):
+        self.movies = list(movies or [])
+        self.episodes = list(episodes or [])
+        self.tvshows = list(tvshows or [])
+        self.movie_writes = []
+        self.episode_writes = []
+
+    def get_movies(self, *_args, **_kwargs):
+        return self.movies
+
+    def get_episodes(self, *_args, **_kwargs):
+        return self.episodes
+
+    def get_tvshows(self, *_args, **_kwargs):
+        return self.tvshows
+
+    def set_movie(self, movieid: int, payload: dict[str, Any]):
+        self.movie_writes.append((movieid, payload))
+        return "OK"
+
+    def set_episode(self, episodeid: int, payload: dict[str, Any]):
+        self.episode_writes.append((episodeid, payload))
+        return "OK"
+
+
+def adapter(client: FakeKodiClient):
+    return SimpleNamespace(client=client, _kodi_library_index=None)
+
+
+def movie(**extra):
+    row = {
+        "movieid": 10,
+        "title": "Arrival",
+        "year": 2016,
+        "uniqueid": {"imdb": "tt2543164", "tmdb": "329865"},
+        "playcount": 1,
+        "lastplayed": "2026-01-02 03:04:05",
+        "userrating": 8,
+        "resume": {"position": 120.5, "total": 6000.0},
+    }
+    row.update(extra)
+    return row
+
+
+def episode(**extra):
+    row = {
+        "episodeid": 20,
+        "tvshowid": 5,
+        "title": "The Target",
+        "showtitle": "The Expanse",
+        "year": 2015,
+        "season": 1,
+        "episode": 1,
+        "uniqueid": {"tvdb": "5534478"},
+        "playcount": 1,
+        "lastplayed": "2026-02-03 04:05:06",
+        "userrating": 9,
+        "resume": {"position": 300.0, "total": 2700.0},
+    }
+    row.update(extra)
+    return row
+
+
+def tvshow(**extra):
+    row = {"tvshowid": 5, "title": "The Expanse", "year": 2015, "uniqueid": {"tmdb": "63639", "tvdb": "280619"}}
+    row.update(extra)
+    return row
+
+
+def test_kodi_manifest_capabilities_are_scoped():
+    manifest = mod.get_manifest()
+
+    assert manifest["features"] == {"watchlist": False, "ratings": True, "history": True, "progress": True, "playlists": False}
+    assert manifest["capabilities"]["history"]["read"] is True
+    assert manifest["capabilities"]["ratings"]["write"] is True
+    assert manifest["capabilities"]["progress"]["types"]["episodes"] is True
+
+
+def test_kodi_sync_properties_match_jsonrpc_v13_5_contract():
+    movie_allowed = {"title", "year", "uniqueid", "playcount", "lastplayed", "userrating", "resume"}
+    episode_allowed = {"title", "showtitle", "season", "episode", "tvshowid", "uniqueid", "playcount", "lastplayed", "userrating", "resume"}
+    show_allowed = {"title", "year", "uniqueid"}
+
+    for feature in ("history", "ratings", "progress", ""):
+        movie_props, episode_props, show_props = common.properties_for_feature(feature)
+        assert set(movie_props) <= movie_allowed
+        assert set(episode_props) <= episode_allowed
+        assert set(show_props) <= show_allowed
+        assert "year" not in episode_props
+
+
+def test_history_index_reads_movies_and_episodes():
+    ad = adapter(FakeKodiClient([movie()], [episode()], [tvshow()]))
+
+    index = mod.feat_history.build_index(ad)
+
+    assert "tmdb:329865" in index
+    assert index["tmdb:329865"]["watched"] is True
+    assert index["tmdb:329865"]["watched_at"] == "2026-01-02T03:04:05Z"
+    ep = index["tmdb:63639#s01e01"]
+    assert ep["type"] == "episode"
+    assert ep["title"] == "The Target"
+    assert ep["series_title"] == "The Expanse"
+    assert ep["show_ids"]["tmdb"] == "63639"
+    assert ep["season"] == 1
+    assert ep["episode"] == 1
+
+
+def test_history_index_requests_only_history_properties():
+    class RecordingClient(FakeKodiClient):
+        def __init__(self):
+            super().__init__([movie()], [episode()], [tvshow()])
+            self.calls: list[tuple[str, list[str]]] = []
+
+        def get_movies(self, properties=None):
+            self.calls.append(("movies", list(properties or [])))
+            return self.movies
+
+        def get_episodes(self, properties=None):
+            self.calls.append(("episodes", list(properties or [])))
+            return self.episodes
+
+        def get_tvshows(self, properties=None):
+            self.calls.append(("tvshows", list(properties or [])))
+            return self.tvshows
+
+    client = RecordingClient()
+
+    mod.feat_history.build_index(adapter(client))
+
+    props = {name: values for name, values in client.calls}
+    assert "playcount" in props["movies"]
+    assert "lastplayed" in props["episodes"]
+    assert "year" not in props["episodes"]
+    assert "userrating" not in props["movies"]
+    assert "resume" not in props["episodes"]
+
+
+def test_kodi_library_rows_falls_back_after_batch_error(monkeypatch):
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def batch_fail(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise KodiAuthError("Kodi JSON-RPC error for 0:VideoLibrary.GetMovies: Invalid params. (-32602)", reason="jsonrpc_error")
+
+    def rpc_ok(_server: str, method: str, *, params=None, **_kwargs: Any) -> dict[str, Any]:
+        calls.append((method, dict(params or {})))
+        if method == "VideoLibrary.GetMovies":
+            return {"movies": [movie()]}
+        if method == "VideoLibrary.GetEpisodes":
+            return {"episodes": [episode()]}
+        if method == "VideoLibrary.GetTVShows":
+            return {"tvshows": [tvshow()]}
+        return {}
+
+    monkeypatch.setattr(common, "jsonrpc_batch_call", batch_fail)
+    monkeypatch.setattr(common, "jsonrpc_call", rpc_ok)
+
+    client = common.KodiClient(common.KodiConfig(server="http://kodi.local", connection_verified=True))
+    movies, episodes, tvshows = client.library_rows("history")
+
+    assert len(movies) == 1
+    assert len(episodes) == 1
+    assert len(tvshows) == 1
+    assert [call[0] for call in calls] == ["VideoLibrary.GetMovies", "VideoLibrary.GetEpisodes", "VideoLibrary.GetTVShows"]
+    assert "userrating" not in calls[0][1]["properties"]
+    assert "resume" not in calls[1][1]["properties"]
+
+
+def test_kodi_library_rows_uses_v13_5_path_filters_without_extra_properties(monkeypatch):
+    seen: list[tuple[str, dict[str, Any]]] = []
+
+    def batch_ok(_server: str, calls, **_kwargs: Any) -> dict[str, Any]:
+        for method, params in calls:
+            seen.append((method, dict(params or {})))
+        return {"0:VideoLibrary.GetMovies": {"movies": []}, "1:VideoLibrary.GetEpisodes": {"episodes": []}, "2:VideoLibrary.GetTVShows": {"tvshows": []}}
+
+    monkeypatch.setattr(common, "jsonrpc_batch_call", batch_ok)
+
+    client = common.KodiClient(common.KodiConfig(server="http://kodi.local", connection_verified=True))
+    filt = common.path_filter_for(["/media/movies"], ["/media/movies/private"])
+    client.library_rows("history", path_filter=filt)
+
+    assert [call[0] for call in seen] == ["VideoLibrary.GetMovies", "VideoLibrary.GetEpisodes", "VideoLibrary.GetTVShows"]
+    for _, params in seen:
+        assert params["filter"]["and"][0] == {"field": "path", "operator": "startswith", "value": "/media/movies"}
+        assert params["filter"]["and"][1] == {"field": "path", "operator": "doesnotcontain", "value": "/media/movies/private"}
+        assert "file" not in params["properties"]
+        assert "path" not in params["properties"]
+
+
+def test_kodi_sync_logs_library_scope_filter_when_configured(monkeypatch):
+    logs: list[tuple[str, str, str, dict[str, Any]]] = []
+    monkeypatch.setattr(common, "log", lambda feature, level, event, **fields: logs.append((feature, level, event, fields)))
+    ad = SimpleNamespace(
+        client=FakeKodiClient([movie()], [], []),
+        config={"kodi": {"history": {"libraries": ["/media/movies"]}}},
+        instance_id="default",
+    )
+
+    common.library_index(ad, "history")
+
+    assert logs
+    feature, level, event, fields = logs[-1]
+    assert (feature, level, event) == ("history", "debug", "index_fetch_counts")
+    assert fields["source"] == "selected_libraries"
+    assert fields["count"] == 1
+    assert fields["allowed_library_paths"] == ["/media/movies"]
+    assert fields["movies"] == 1
+
+
+def test_ratings_and_progress_indexes_normalize_values():
+    ad = adapter(FakeKodiClient([movie(userrating=0), movie(movieid=11, userrating=7)], [episode()], [tvshow()]))
+
+    ratings = mod.feat_ratings.build_index(ad)
+    progress = mod.feat_progress.build_index(ad)
+
+    assert "tmdb:329865" in ratings
+    assert ratings["tmdb:329865"]["rating"] == 7
+    assert progress["tmdb:329865"]["progress_ms"] == 120500
+    assert progress["tmdb:329865"]["duration_ms"] == 6000000
+    assert int(progress["tmdb:63639#s01e01"]["progress_percent"]) == 11
+
+
+def test_kodi_progress_assigns_managed_timestamp_for_new_resume(monkeypatch):
+    monkeypatch.setattr(common, "_utc_now_iso", lambda: "2026-07-27T21:00:00Z")
+    ad = adapter(FakeKodiClient([movie()], [], []))
+    ad._kodi_progress_baseline = {}
+
+    progress = mod.feat_progress.build_index(ad)
+
+    assert progress["tmdb:329865"]["progress_at"] == "2026-07-27T21:00:00Z"
+    assert progress["tmdb:329865"]["progress_at_source"] == "kodi_first_observed"
+
+
+def test_kodi_progress_reuses_timestamp_until_resume_changes(monkeypatch):
+    monkeypatch.setattr(common, "_utc_now_iso", lambda: "2026-07-29T21:00:00Z")
+    old = {
+        "type": "movie",
+        "ids": {"tmdb": "329865"},
+        "title": "Arrival",
+        "year": 2016,
+        "progress_ms": 120500,
+        "duration_ms": 6000000,
+        "progress_percent": 2.008,
+        "progress_at": "2026-07-27T21:00:00Z",
+        "progress_at_source": "kodi_first_observed",
+    }
+    ad = adapter(FakeKodiClient([movie()], [], []))
+    ad._kodi_progress_baseline = {"tmdb:329865": old}
+
+    unchanged = mod.feat_progress.build_index(ad)
+    assert unchanged["tmdb:329865"]["progress_at"] == "2026-07-27T21:00:00Z"
+    assert unchanged["tmdb:329865"]["progress_at_source"] == "kodi_first_observed"
+
+    ad2 = adapter(FakeKodiClient([movie(resume={"position": 240.0, "total": 6000.0})], [], []))
+    ad2._kodi_progress_baseline = {"tmdb:329865": old}
+    changed = mod.feat_progress.build_index(ad2)
+
+    assert changed["tmdb:329865"]["progress_ms"] == 240000
+    assert changed["tmdb:329865"]["progress_at"] == "2026-07-29T21:00:00Z"
+    assert changed["tmdb:329865"]["progress_at_source"] == "kodi_resume_changed"
+
+
+def test_writes_history_ratings_and_progress_to_resolved_library_items():
+    client = FakeKodiClient([movie()], [episode()], [tvshow()])
+    cfg = {"kodi": {"server": "http://localhost:8080", "connection_verified": True}}
+    module = mod.KODIModule(cfg)
+    module.client = client
+
+    source_movie = {"type": "movie", "ids": {"tmdb": "329865"}, "watched_at": "2026-06-01T12:00:00Z", "rating": 6, "progress_ms": 90000, "duration_ms": 6000000}
+    source_ep = {"type": "episode", "show_ids": {"tmdb": "63639"}, "season": 1, "episode": 1, "rating": 10, "progress_ms": 1000}
+
+    assert module.add("history", [source_movie])["count"] == 1
+    assert module.add("ratings", [source_ep])["count"] == 1
+    assert module.add("progress", [source_movie])["count"] == 1
+
+    assert client.movie_writes[0] == (10, {"playcount": 1, "lastplayed": "2026-06-01 12:00:00"})
+    assert client.episode_writes[0] == (20, {"userrating": 10})
+    assert client.movie_writes[1] == (10, {"resume": {"position": 90.0, "total": 6000.0}})
+
+
+def test_removes_clear_kodi_fields():
+    client = FakeKodiClient([movie()], [episode()], [tvshow()])
+    module = mod.KODIModule({"kodi": {"server": "http://localhost:8080", "connection_verified": True}})
+    module.client = client
+
+    source_movie = {"type": "movie", "ids": {"tmdb": "329865"}}
+
+    assert module.remove("history", [source_movie])["count"] == 1
+    assert module.remove("ratings", [source_movie])["count"] == 1
+    assert module.remove("progress", [source_movie])["count"] == 1
+
+    assert client.movie_writes[0] == (10, {"playcount": 0, "lastplayed": ""})
+    assert client.movie_writes[1] == (10, {"userrating": 0})
+    assert client.movie_writes[2] == (10, {"resume": {"position": 0.0, "total": 6000.0}})
+
+
+def test_ambiguous_library_resolution_is_unresolved():
+    client = FakeKodiClient(
+        [
+            movie(movieid=1, uniqueid={}, title="Twin", year=2020),
+            movie(movieid=2, uniqueid={}, title="Twin", year=2020),
+        ],
+        [],
+        [],
+    )
+    module = mod.KODIModule({"kodi": {"server": "http://localhost:8080", "connection_verified": True}})
+    module.client = client
+
+    result = module.add("ratings", [{"type": "movie", "title": "Twin", "year": 2020, "rating": 8}])
+
+    assert result["count"] == 0
+    assert result["reason_counts"]["ambiguous"] == 1
+    assert client.movie_writes == []
+
+
+def test_external_id_source_does_not_fallback_to_title_year():
+    client = FakeKodiClient([movie(uniqueid={}, title="Arrival", year=2016)], [], [])
+    module = mod.KODIModule({"kodi": {"server": "http://localhost:8080", "connection_verified": True}})
+    module.client = client
+
+    result = module.add("ratings", [{"type": "movie", "ids": {"tmdb": "329865"}, "title": "Arrival", "year": 2016, "rating": 8}])
+
+    assert result["count"] == 0
+    assert result["reason_counts"]["not_found"] == 1
+    assert client.movie_writes == []

--- a/tests/test_percent_progress_sync.py
+++ b/tests/test_percent_progress_sync.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from cw_platform.id_map import canonical_key
 
 
 def test_diff_progress_upserts_percent_only_source() -> None:
@@ -72,6 +76,23 @@ def test_two_way_minimal_progress_preserves_percent_only_source() -> None:
     assert out["progress_at"] == "2026-07-25T19:30:00Z"
 
 
+def test_two_way_minimal_progress_preserves_kodi_managed_timestamp_source() -> None:
+    from cw_platform.orchestrator._pairs_twoway import _minimal_keep_progress
+
+    item = {
+        "type": "movie",
+        "ids": {"tmdb": "329865"},
+        "progress_ms": 120000,
+        "duration_ms": 6000000,
+        "progress_at": "2026-07-27T21:00:00Z",
+        "progress_at_source": "kodi_first_observed",
+    }
+
+    out = _minimal_keep_progress(item)
+
+    assert out["progress_at_source"] == "kodi_first_observed"
+
+
 def test_crosswatch_progress_accepts_percent_only_items(tmp_path: Path, monkeypatch) -> None:
     from providers.sync.crosswatch import _progress
 
@@ -93,3 +114,104 @@ def test_crosswatch_progress_accepts_percent_only_items(tmp_path: Path, monkeypa
     assert count == 1
     assert unresolved == []
     assert index["tmdb:69478#s06e02"]["progress_percent"] == 21.0
+
+
+class _ProgressStateStore:
+    def load_state(self) -> dict[str, Any]:
+        return {}
+
+    def save_state(self, _value: dict[str, Any]) -> None:
+        return None
+
+    def load_tomb(self) -> dict[str, Any]:
+        return {}
+
+    def save_tomb(self, _value: dict[str, Any]) -> None:
+        return None
+
+
+class _ProgressOps:
+    def __init__(self) -> None:
+        self.added: list[dict[str, Any]] = []
+
+    def add(self, _cfg: dict[str, Any], items, *, feature: str, dry_run: bool = False) -> dict[str, Any]:
+        rows = [dict(item) for item in items]
+        self.added.extend(rows)
+        return {"ok": True, "count": len(rows), "confirmed_keys": [canonical_key(item) for item in rows], "unresolved": []}
+
+    def remove(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"ok": True, "count": 0}
+
+    def update(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"ok": True, "count": 0}
+
+    def capabilities(self) -> dict[str, Any]:
+        return {"progress": {"observed_deletes": False}}
+
+
+def test_two_way_progress_trusts_real_remote_over_kodi_first_observed(monkeypatch) -> None:
+    from cw_platform.orchestrator import _pairs_twoway as twoway
+
+    for name, val in (
+        ("_supports_feature", lambda _ops, _feature: True),
+        ("_health_feature_ok", lambda _health, _feature: True),
+        ("_health_status", lambda _health: "up"),
+        ("_resolve_flags", lambda _fcfg, _sync: {"allow_adds": True, "allow_removals": False}),
+        ("_anime_pair_feature_options", lambda *_args, **_kwargs: {"use_anime_mapping": False}),
+        ("_anime_config_with_pair_feature_options", lambda cfg, _opts: cfg),
+        ("_index_semantics", lambda *_args, **_kwargs: "full"),
+        ("prev_checkpoint", lambda *_args, **_kwargs: None),
+        ("module_checkpoint", lambda *_args, **_kwargs: None),
+        ("keys_for_feature", lambda *_args, **_kwargs: {}),
+        ("_manual_policy", lambda *_args, **_kwargs: ([], set())),
+        ("_provider_ignore_dropped_enabled", lambda *_args, **_kwargs: False),
+        ("apply_blocklist", lambda _state, items, **_kwargs: list(items)),
+        ("_maybe_block_massdelete", lambda items, **_kwargs: list(items)),
+        ("effective_chunk_size", lambda *_args, **_kwargs: 100),
+        ("load_blackbox_keys", lambda *_args, **_kwargs: set()),
+        ("record_attempts", lambda *_args, **_kwargs: {"ok": True, "count": 0}),
+        ("record_success", lambda *_args, **_kwargs: {"ok": True, "count": 0}),
+    ):
+        monkeypatch.setattr(twoway, name, val)
+
+    key = "tmdb:329865"
+    kodi_row = {
+        "type": "movie",
+        "title": "Arrival",
+        "year": 2016,
+        "ids": {"tmdb": "329865"},
+        "progress_ms": 4_200_000,
+        "duration_ms": 6_000_000,
+        "progress_at": "2026-07-27T21:00:00Z",
+        "progress_at_source": "kodi_first_observed",
+    }
+    trakt_row = {
+        **kodi_row,
+        "progress_ms": 3_000_000,
+        "progress_at": "2026-07-25T21:00:00Z",
+    }
+    trakt_row.pop("progress_at_source", None)
+    monkeypatch.setattr(twoway, "build_snapshots_for_feature", lambda **_kwargs: {"KODI": {key: kodi_row}, "TRAKT": {key: trakt_row}})
+
+    kodi = _ProgressOps()
+    trakt = _ProgressOps()
+    ctx = SimpleNamespace(
+        config={"sync": {"include_observed_deletes": False, "blackbox": {"enabled": False}}, "runtime": {}},
+        providers={"KODI": kodi, "TRAKT": trakt},
+        emit=lambda *_args, **_kwargs: None,
+        emit_info=lambda *_args, **_kwargs: None,
+        dbg=lambda *_args, **_kwargs: None,
+        dry_run=False,
+        snap_cache={},
+        snap_ttl_sec=0,
+        state_store=_ProgressStateStore(),
+        stats_manual_blocked=0,
+        apply_chunk_pause_ms=0,
+    )
+
+    result = twoway._two_way_sync(ctx, "KODI", "TRAKT", feature="progress", fcfg={}, health_map={})
+
+    assert result["adds_to_A"] == 1
+    assert result["adds_to_B"] == 0
+    assert kodi.added[0]["progress_ms"] == 3_000_000
+    assert trakt.added == []


### PR DESCRIPTION
# Pull request

## Change

Adds Kodi as a sync provider for history, ratings and playback progress.

This includes:
- reading/writing Kodi movie and episode history
- reading/writing Kodi user ratings
- reading/writing Kodi resume progress
- Kodi JSON-RPC library indexing and safe item resolution
- Kodi-owned progress timestamps so progress can sync cleanly to other providers

## Why

Require sync adaption.

## Testing

- test_percent_progress_sync.py

## Issue

Relates to #519

Note: Kodi does not include timestamps in progression. Other providers require that, so CW is creating timestamps.