### PR TITLE
Add: Kodi watcher integration

### DIFF
--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Body, Request
 from fastapi.responses import JSONResponse
 
 from cw_platform.config_base import load_config, save_config
-from cw_platform.provider_instances import list_instance_ids, normalize_instance_id
+from cw_platform.provider_instances import get_provider_block, list_instance_ids, normalize_instance_id
 from cw_platform.provider_usage import WEBHOOK_SOURCE_PROVIDERS, provider_label, webhook_source_enabled
 from providers.scrobble.routes import (
     ROUTE_PROVIDERS,
@@ -36,6 +36,7 @@ from .scrobbleAPI import _ensure_media_profile_webhook_ids, _ensure_route_rating
 router = APIRouter(prefix="/api/scrobbler", tags=["scrobbler-management"])
 
 SOURCE_PROVIDERS = tuple(WEBHOOK_SOURCE_PROVIDERS)
+WATCHER_SOURCE_PROVIDERS = ("plex", "jellyfin", "emby", "kodi")
 SINK_PROVIDERS = tuple(sorted(ROUTE_SINKS))
 ALLOWED_FILTER_KEYS = {
     "username_whitelist",
@@ -107,11 +108,19 @@ def _profile_exists(cfg: Mapping[str, Any], provider: str, instance: str) -> boo
     return normalize_instance_id(instance) in set(_instances(cfg, provider))
 
 
+def _scrobble_source_connected(cfg: Mapping[str, Any], provider: str, instance: str) -> bool:
+    key = str(provider or "").strip().lower()
+    if key == "kodi":
+        block = get_provider_block(_dict(cfg), "kodi", normalize_instance_id(instance))
+        return bool(str(block.get("server") or "").strip() and block.get("connection_verified") is True)
+    return media_source_connected(cfg, key, instance)
+
+
 def _require_source_profile(cfg: Mapping[str, Any], provider: str, instance: str) -> None:
     errors: list[dict[str, str]] = []
     if not _profile_exists(cfg, provider, instance):
         errors.append(_err("provider_instance", "profile_not_found", "Source profile does not exist"))
-    elif not media_source_connected(cfg, provider, instance):
+    elif not _scrobble_source_connected(cfg, provider, instance):
         errors.append(_err("provider_instance", "profile_not_configured", "Source profile is not configured"))
     if errors:
         raise ValidationFailure(errors)
@@ -331,10 +340,10 @@ def _destination_availability(cfg: Mapping[str, Any]) -> list[dict[str, Any]]:
 
 def _eligible_sources(cfg: Mapping[str, Any]) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
-    for provider in SOURCE_PROVIDERS:
+    for provider in WATCHER_SOURCE_PROVIDERS:
         profiles: list[dict[str, Any]] = []
         for inst in _instances(cfg, provider):
-            configured = media_source_connected(cfg, provider, inst)
+            configured = _scrobble_source_connected(cfg, provider, inst)
             explicit = bool(_profile_override(cfg, provider, inst))
             profiles.append(
                 {
@@ -447,7 +456,7 @@ def _normalized_routes(cfg: dict[str, Any], request: Request) -> list[dict[str, 
 
 
 def _summary(cfg: dict[str, Any], request: Request, webhooks: list[dict[str, Any]], routes: list[dict[str, Any]], runtime: dict[str, Any]) -> dict[str, Any]:
-    eligible = sum(1 for p in SOURCE_PROVIDERS for i in _instances(cfg, p) if media_source_connected(cfg, p, i))
+    eligible = sum(1 for p in WATCHER_SOURCE_PROVIDERS for i in _instances(cfg, p) if _scrobble_source_connected(cfg, p, i))
     active_webhooks = sum(1 for w in webhooks if w.get("active"))
     enabled_routes = sum(1 for r in routes if r.get("enabled"))
     return {

--- a/assets/js/modals/scrobbler-route/index.js
+++ b/assets/js/modals/scrobbler-route/index.js
@@ -1,7 +1,7 @@
 /* CrossWatch - Scrobbler Route Modal */
 const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
-const label = (v) => ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
-const sources = ["plex", "jellyfin", "emby"];
+const label = (v) => ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", kodi: "Kodi", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
+const sources = ["plex", "jellyfin", "emby", "kodi"];
 const sinks = ["trakt", "simkl", "mdblist"];
 
 function flashCopied(btn) {
@@ -176,6 +176,7 @@ function logo(provider) {
     plex: "/assets/img/PLEX.svg",
     jellyfin: "/assets/img/JELLYFIN.svg",
     emby: "/assets/img/EMBY.svg",
+    kodi: "/assets/img/KODI.png",
     trakt: "/assets/img/TRAKT.svg",
     simkl: "/assets/img/SIMKL.svg",
     mdblist: "/assets/img/MDBLIST.svg",

--- a/assets/js/scrobbler.js
+++ b/assets/js/scrobbler.js
@@ -3,8 +3,8 @@
 /* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
 (function (w, d) {
   const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
-  const label = (v) => ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
-  const logo = (v) => ({ plex: "/assets/img/PLEX.svg", jellyfin: "/assets/img/JELLYFIN.svg", emby: "/assets/img/EMBY.svg", trakt: "/assets/img/TRAKT.svg", simkl: "/assets/img/SIMKL.svg", mdblist: "/assets/img/MDBLIST.svg" }[String(v || "").toLowerCase()] || "");
+  const label = (v) => ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", kodi: "Kodi", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
+  const logo = (v) => ({ plex: "/assets/img/PLEX.svg", jellyfin: "/assets/img/JELLYFIN.svg", emby: "/assets/img/EMBY.svg", kodi: "/assets/img/KODI.png", trakt: "/assets/img/TRAKT.svg", simkl: "/assets/img/SIMKL.svg", mdblist: "/assets/img/MDBLIST.svg" }[String(v || "").toLowerCase()] || "");
   const state = { root: null, overview: null, busy: false, panels: { watcherDefaults: false, ratings: false, webhookDefaults: false }, delBtn: null, delTimer: 0, regenBtn: null, regenTimer: 0, legacyConfirm: false, legacyTimer: 0, hybridDismissed: false };
 
   async function j(url, options = {}) {

--- a/providers/scrobble/kodi/__init__.py
+++ b/providers/scrobble/kodi/__init__.py
@@ -1,0 +1,2 @@
+"""Kodi HTTP polling watcher."""
+

--- a/providers/scrobble/kodi/watch.py
+++ b/providers/scrobble/kodi/watch.py
@@ -1,0 +1,643 @@
+# providers/scrobble/kodi/watch.py
+# CrossWatch - Kodi HTTP JSON-RPC Watcher Service
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+import hashlib
+import threading
+import time
+from collections.abc import Callable, Mapping
+from typing import Any
+
+try:
+    from _logging import log as BASE_LOG
+except Exception:
+    BASE_LOG = None
+
+from cw_platform.config_base import load_config
+from providers.auth._auth_KODI import KodiAuthError, clean_base, jsonrpc_call
+from providers.scrobble.currently_watching import update_from_event as _cw_update
+from providers.scrobble.currently_watching import update_from_payload as _cw_update_payload
+from providers.scrobble.scrobble import Dispatcher, ScrobbleEvent, ScrobbleSink, mask_account
+from providers.scrobble.sources import source_enabled
+from providers.sync.kodi._common import path_scope_status
+
+BASE_POLL_SECONDS = 1.75
+MIN_POLL_SECONDS = 1.5
+MAX_BASE_POLL_SECONDS = 2.0
+MAX_IDLE_POLL_SECONDS = 6.0
+OFFLINE_INITIAL_RETRY_SECONDS = 30.0
+OFFLINE_MAX_RETRY_SECONDS = 300.0
+OFFLINE_TIMEOUT_SECONDS = 2.0
+PROFILE_CACHE_SECONDS = 60.0
+SEEK_JUMP_PERCENT = 10.0
+
+
+def _log(msg: str, level: str = "INFO") -> None:
+    lvl = (str(level) or "INFO").upper()
+    if BASE_LOG is not None:
+        try:
+            BASE_LOG(str(msg), level=lvl, module="KODI-WATCH")
+            return
+        except Exception:
+            pass
+    try:
+        print(f"[KODI-WATCH:{lvl}] {msg}")
+    except Exception:
+        pass
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _to_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(float(str(value).strip()))
+    except Exception:
+        return None
+
+
+def _clamp_float(value: Any, default: float, low: float, high: float) -> float:
+    try:
+        num = float(value)
+    except Exception:
+        num = default
+    return max(low, min(high, num))
+
+
+def _time_parts_to_seconds(value: Any) -> float | None:
+    if not isinstance(value, Mapping):
+        return None
+    try:
+        return (
+            int(value.get("hours") or 0) * 3600
+            + int(value.get("minutes") or 0) * 60
+            + int(value.get("seconds") or 0)
+            + int(value.get("milliseconds") or 0) / 1000.0
+        )
+    except Exception:
+        return None
+
+
+def _progress_from_props(props: Mapping[str, Any]) -> tuple[float, int | None]:
+    pct_raw = props.get("percentage")
+    try:
+        if pct_raw is not None:
+            pct = max(0.0, min(100.0, float(pct_raw)))
+            total = _time_parts_to_seconds(props.get("totaltime"))
+            return pct, int(total * 1000) if total and total > 0 else None
+    except Exception:
+        pass
+
+    pos = _time_parts_to_seconds(props.get("time"))
+    total = _time_parts_to_seconds(props.get("totaltime"))
+    if pos is None or not total or total <= 0:
+        return 0.0, int(total * 1000) if total and total > 0 else None
+    return max(0.0, min(100.0, (pos / total) * 100.0)), int(total * 1000)
+
+
+def _file_hash(value: Any) -> str:
+    text = str(value or "").strip()
+    digest = hashlib.sha1(text.encode("utf-8", "ignore")).hexdigest()[:16]
+    return f"file:{digest}"
+
+
+def _stable_server_uuid(server: str) -> str:
+    base = clean_base(server)
+    return "kodi:" + hashlib.sha1(base.encode("utf-8", "ignore")).hexdigest()[:16] if base else "kodi"
+
+
+def _norm_unique_key(key: Any) -> str:
+    return "".join(ch for ch in str(key or "").strip().lower() if ch.isalnum())
+
+
+def _normalize_uniqueids(uniqueid: Any, media_type: str) -> dict[str, str]:
+    ids: dict[str, str] = {}
+    raw = uniqueid if isinstance(uniqueid, Mapping) else {}
+
+    def put(name: str, value: Any) -> None:
+        text = str(value or "").strip()
+        if text and name not in ids:
+            ids[name] = text
+
+    for key, value in raw.items():
+        text = str(value or "").strip()
+        if not text:
+            continue
+        nk = _norm_unique_key(key)
+        is_show = media_type == "episode" and any(part in nk for part in ("show", "tvshow", "series"))
+        target = None
+        if "imdb" in nk or text.lower().startswith("tt"):
+            target = "imdb"
+        elif "tmdb" in nk or "themoviedb" in nk:
+            target = "tmdb"
+        elif "tvdb" in nk or "thetvdb" in nk:
+            target = "tvdb"
+        if target:
+            if media_type == "episode":
+                put(f"{target}_show" if is_show else f"{target}_episode", text)
+            else:
+                put(target, text)
+    return ids
+
+
+def _has_show_ids(ids: Mapping[str, Any]) -> bool:
+    return any(str(ids.get(key) or "").strip() for key in ("imdb_show", "tmdb_show", "tvdb_show"))
+
+
+def _show_ids_from_uniqueids(uniqueid: Any) -> dict[str, str]:
+    base = _normalize_uniqueids(uniqueid, "movie")
+    return {f"{key}_show": value for key, value in base.items() if key in {"imdb", "tmdb", "tvdb"} and value}
+
+
+def _item_identity(item: Mapping[str, Any], media_type: str) -> str:
+    item_id = item.get("id")
+    if item_id not in (None, "", -1):
+        return f"id:{item_id}"
+    return _file_hash(item.get("file") or item.get("title") or media_type)
+
+
+def _metadata_from_item(item: Mapping[str, Any], props: Mapping[str, Any]) -> dict[str, Any] | None:
+    media_type = str(item.get("type") or "").strip().lower()
+    if media_type not in {"movie", "episode"}:
+        return None
+    if bool(props.get("live")):
+        return None
+
+    episode_title = str(item.get("title") or "").strip()
+    show_title = str(item.get("showtitle") or "").strip()
+    title = (show_title or episode_title) if media_type == "episode" else episode_title
+    ids = _normalize_uniqueids(item.get("uniqueid"), media_type)
+    duration = _to_int(item.get("duration"))
+    return {
+        "media_type": media_type,
+        "ids": ids,
+        "title": title or None,
+        "episode_title": episode_title or None,
+        "year": _to_int(item.get("year")),
+        "season": _to_int(item.get("season")) if media_type == "episode" else None,
+        "number": _to_int(item.get("episode")) if media_type == "episode" else None,
+        "item_identity": _item_identity(item, media_type),
+        "duration_ms": duration * 1000 if duration and duration > 0 else None,
+    }
+
+
+class KodiWatchService:
+    def __init__(
+        self,
+        sinks: list[ScrobbleSink] | None = None,
+        *,
+        dispatcher: Any | None = None,
+        cfg_provider: Callable[[], dict[str, Any]] | None = None,
+        instance_id: Any = "default",
+        poll_secs: float = BASE_POLL_SECONDS,
+        quiet_startup: bool = False,
+    ) -> None:
+        self._cfg_provider = cfg_provider
+        self._instance_id = str(instance_id or "default").strip() or "default"
+        self._dispatch = dispatcher or Dispatcher(list(sinks or []), cfg_provider=self._active_cfg)
+        self._base_poll = _clamp_float(poll_secs, BASE_POLL_SECONDS, MIN_POLL_SECONDS, MAX_BASE_POLL_SECONDS)
+        self._stop = threading.Event()
+        self._bg: threading.Thread | None = None
+        self._sessions: dict[str, dict[str, Any]] = {}
+        self._player_session: dict[int, str] = {}
+        self._empty_success_polls = 0
+        self._idle_poll = self._base_poll
+        self._profile: tuple[float, str | None] = (0.0, None)
+        self._last_error: tuple[str, float] = ("", 0.0)
+        self._last_filter: dict[str, float] = {}
+        self._quiet_startup = bool(quiet_startup)
+        self._show_ids_cache: dict[int, dict[str, str] | None] = {}
+        self._offline = False
+        self._offline_failures = 0
+        self._offline_retry = OFFLINE_INITIAL_RETRY_SECONDS
+
+    def _active_cfg(self) -> dict[str, Any]:
+        if self._cfg_provider:
+            try:
+                cfg = self._cfg_provider() or {}
+                return cfg if isinstance(cfg, dict) else {}
+            except Exception:
+                return {}
+        try:
+            cfg = load_config() or {}
+            return cfg if isinstance(cfg, dict) else {}
+        except Exception:
+            return {}
+
+    def _kodi_cfg(self, cfg: Mapping[str, Any]) -> dict[str, Any]:
+        return _dict(_dict(cfg).get("kodi"))
+
+    def _configured(self, cfg: Mapping[str, Any]) -> bool:
+        kodi = self._kodi_cfg(cfg)
+        return bool(str(kodi.get("server") or "").strip() and kodi.get("connection_verified") is True)
+
+    def _rpc(self, method: str, params: Mapping[str, Any] | None = None) -> Any:
+        cfg = self._active_cfg()
+        kodi = self._kodi_cfg(cfg)
+        timeout = float(kodi.get("timeout", 6.0) or 6.0)
+        if self._offline or self._offline_failures:
+            timeout = min(timeout, OFFLINE_TIMEOUT_SECONDS)
+        return jsonrpc_call(
+            str(kodi.get("server") or ""),
+            method,
+            params=params,
+            username=str(kodi.get("username") or "").strip(),
+            password=str(kodi.get("password") or ""),
+            verify_ssl=bool(kodi.get("verify_ssl", False)),
+            timeout=timeout,
+        )
+
+    def _log_error_limited(self, key: str, message: str) -> None:
+        now = time.time()
+        last_key, last_ts = self._last_error
+        if key != last_key or (now - last_ts) >= 30.0:
+            _log(message, "WARNING")
+            self._last_error = (key, now)
+
+    def _mark_offline(self, exc: Exception) -> None:
+        self._offline_failures += 1
+        if not self._offline:
+            self._offline = True
+            self._offline_retry = OFFLINE_INITIAL_RETRY_SECONDS
+            _log(f"Kodi watcher offline: {exc}; retrying with backoff", "WARNING")
+            return
+        self._offline_retry = min(OFFLINE_MAX_RETRY_SECONDS, max(OFFLINE_INITIAL_RETRY_SECONDS, self._offline_retry * 2.0))
+
+    def _mark_online(self) -> None:
+        if self._offline:
+            _log("Kodi watcher reconnected", "INFO")
+        self._offline = False
+        self._offline_failures = 0
+        self._offline_retry = OFFLINE_INITIAL_RETRY_SECONDS
+        self._last_error = ("", 0.0)
+
+    def _log_filter_limited(self, key: str, message: str) -> None:
+        now = time.time()
+        last_ts = float(self._last_filter.get(key) or 0.0)
+        if (now - last_ts) >= 30.0:
+            _log(message, "DEBUG")
+            self._last_filter[key] = now
+
+    def _current_profile(self) -> str | None:
+        now = time.time()
+        ts, cached = self._profile
+        if cached and (now - ts) < PROFILE_CACHE_SECONDS:
+            return cached
+        try:
+            result = self._rpc("Profiles.GetCurrentProfile")
+            profile = str(_dict(result).get("label") or _dict(result).get("profile") or "").strip()
+            self._profile = (now, profile or None)
+        except Exception:
+            if not cached:
+                self._profile = (now, None)
+        return self._profile[1]
+
+    def _progress_step(self) -> float:
+        cfg = self._active_cfg()
+        try:
+            return max(1.0, float((((cfg.get("scrobble") or {}).get("trakt") or {}).get("progress_step") or 25)))
+        except Exception:
+            return 25.0
+
+    def _force_stop_at(self) -> float:
+        cfg = self._active_cfg()
+        try:
+            return max(0.0, min(100.0, float((((cfg.get("scrobble") or {}).get("trakt") or {}).get("force_stop_at") or 95))))
+        except Exception:
+            return 95.0
+
+    def _event(self, session: Mapping[str, Any], action: str, progress: float, props: Mapping[str, Any]) -> ScrobbleEvent:
+        meta = _dict(session.get("meta"))
+        raw = {
+            "provider": "kodi",
+            "provider_instance": self._instance_id,
+            "playerid": session.get("playerid"),
+            "item": session.get("item"),
+            "properties": dict(props or {}),
+            "profile": session.get("account"),
+            "duration_ms": session.get("duration_ms"),
+            "_cw_seek": bool(session.get("seek_pending")),
+            "_cw_preserve_stop": bool(action == "stop" and progress >= self._force_stop_at()),
+        }
+        return ScrobbleEvent(
+            action=action,  # type: ignore[arg-type]
+            media_type=str(meta.get("media_type") or "movie"),  # type: ignore[arg-type]
+            ids=dict(meta.get("ids") or {}),
+            title=meta.get("title"),
+            year=meta.get("year"),
+            season=meta.get("season"),
+            number=meta.get("number"),
+            progress=max(0.0, min(100.0, float(progress or 0.0))),
+            account=session.get("account"),
+            server_uuid=session.get("server_uuid"),
+            session_key=str(session.get("session_key") or ""),
+            raw=raw,
+        )
+
+    def _tvshow_details(self, tvshow_id: int) -> dict[str, Any] | None:
+        if tvshow_id <= 0:
+            return None
+        cached = self._show_ids_cache.get(tvshow_id)
+        if cached is not None:
+            return {"uniqueid": cached}
+        if tvshow_id in self._show_ids_cache:
+            return None
+        try:
+            result = self._rpc("VideoLibrary.GetTVShowDetails", {"tvshowid": tvshow_id, "properties": ["uniqueid", "title", "year"]})
+            details = _dict(_dict(result).get("tvshowdetails"))
+            ids = _show_ids_from_uniqueids(details.get("uniqueid"))
+            self._show_ids_cache[tvshow_id] = ids or None
+            return details if ids else None
+        except Exception:
+            self._show_ids_cache[tvshow_id] = None
+            return None
+
+    def _episode_tvshow_id(self, item: Mapping[str, Any]) -> int | None:
+        tvshow_id = _to_int(item.get("tvshowid"))
+        if tvshow_id:
+            return tvshow_id
+        episode_id = _to_int(item.get("id"))
+        if not episode_id:
+            return None
+        try:
+            result = self._rpc("VideoLibrary.GetEpisodeDetails", {"episodeid": episode_id, "properties": ["tvshowid"]})
+            return _to_int(_dict(_dict(result).get("episodedetails")).get("tvshowid"))
+        except Exception:
+            return None
+
+    def _enrich_episode_show_ids(self, item: Mapping[str, Any], meta: dict[str, Any]) -> None:
+        if meta.get("media_type") != "episode":
+            return
+        ids = meta.get("ids")
+        if not isinstance(ids, dict) or _has_show_ids(ids):
+            return
+        tvshow_id = self._episode_tvshow_id(item)
+        if not tvshow_id:
+            return
+        details = self._tvshow_details(tvshow_id)
+        show_ids = _show_ids_from_uniqueids(_dict(details).get("uniqueid")) if details else {}
+        ids.update(show_ids)
+        if details:
+            if not meta.get("title"):
+                meta["title"] = str(details.get("title") or "").strip() or meta.get("title")
+            if meta.get("year") is None:
+                meta["year"] = _to_int(details.get("year"))
+
+    def _dispatch_event(self, ev: ScrobbleEvent, duration_ms: int | None = None) -> bool:
+        accepted = bool(self._dispatch.dispatch(ev))
+        if accepted:
+            try:
+                _cw_update("kodi", ev, duration_ms=duration_ms, provider_instance=self._instance_id)
+            except Exception:
+                pass
+            _log(f"event {ev.action} {ev.media_type} user={mask_account(ev.account)} p={ev.progress:.1f} sess={ev.session_key}", "DEBUG")
+        elif ev.action == "stop":
+            try:
+                _cw_update_payload(
+                    "kodi",
+                    ev.media_type,
+                    ev.title or "",
+                    ev.year,
+                    ev.season,
+                    ev.number,
+                    ev.progress,
+                    True,
+                    state="stopped",
+                    clear_on_stop=True,
+                    ids=ev.ids,
+                    session_key=ev.session_key,
+                    provider_instance=self._instance_id,
+                )
+            except Exception:
+                pass
+        return accepted
+
+    def _create_session(self, player: Mapping[str, Any], item: Mapping[str, Any], props: Mapping[str, Any]) -> dict[str, Any] | None:
+        meta = _metadata_from_item(item, props)
+        if not meta:
+            return None
+        self._enrich_episode_show_ids(item, meta)
+        allowed, reason, allowed_paths, blocked_paths = path_scope_status(self._active_cfg(), "scrobble", item.get("file"), self._instance_id)
+        if not allowed:
+            item_name = str(meta.get("title") or item.get("title") or "?")
+            file_path = str(item.get("file") or "none")
+            scope_kind = "blacklist" if reason == "blocked_library_scope" else "whitelist"
+            scope_values = blocked_paths if scope_kind == "blacklist" else allowed_paths
+            scope_label = "blocked" if scope_kind == "blacklist" else "allowed"
+            self._log_filter_limited(
+                f"{reason}:{meta.get('item_identity')}",
+                f"event filtered by scrobble {scope_kind}: view={file_path} {scope_label}={scope_values!r} item={item_name}",
+            )
+            return None
+        player_id = int(player.get("playerid") or 0)
+        start_ts = time.time()
+        server = str(self._kodi_cfg(self._active_cfg()).get("server") or "")
+        session_key = f"kodi:{self._instance_id}:{player_id}:{meta['media_type']}:{meta['item_identity']}:{int(start_ts * 1000)}"
+        pct, duration_ms = _progress_from_props(props)
+        if duration_ms is None:
+            duration_ms = meta.get("duration_ms")
+        session = {
+            "playerid": player_id,
+            "session_key": session_key,
+            "started_at": start_ts,
+            "item_identity": meta["item_identity"],
+            "meta": meta,
+            "item": dict(item),
+            "account": self._current_profile(),
+            "server_uuid": _stable_server_uuid(server),
+            "last_action": "",
+            "state": "",
+            "last_progress": pct,
+            "last_emitted_progress": None,
+            "last_successful_poll": time.time(),
+            "duration_ms": duration_ms,
+            "seek_pending": False,
+        }
+        self._sessions[session_key] = session
+        self._player_session[player_id] = session_key
+        return session
+
+    def _active_players(self) -> list[dict[str, Any]]:
+        result = self._rpc("Player.GetActivePlayers")
+        if not isinstance(result, list):
+            raise KodiAuthError("Kodi returned an invalid active player response", reason="invalid_response")
+        return [dict(x) for x in result if isinstance(x, Mapping)]
+
+    def _player_item(self, player_id: int) -> dict[str, Any]:
+        result = self._rpc(
+            "Player.GetItem",
+            {"playerid": player_id, "properties": ["title", "showtitle", "season", "episode", "year", "uniqueid", "file", "duration"]},
+        )
+        item = _dict(result).get("item")
+        if not isinstance(item, Mapping):
+            raise KodiAuthError("Kodi returned an invalid player item response", reason="invalid_response")
+        return dict(item)
+
+    def _player_props(self, player_id: int) -> dict[str, Any]:
+        result = self._rpc(
+            "Player.GetProperties",
+            {"playerid": player_id, "properties": ["speed", "time", "totaltime", "percentage", "live"]},
+        )
+        if not isinstance(result, Mapping):
+            raise KodiAuthError("Kodi returned an invalid player properties response", reason="invalid_response")
+        return dict(result)
+
+    def _maybe_dispatch_progress(self, session: dict[str, Any], props: Mapping[str, Any]) -> None:
+        pct, duration_ms = _progress_from_props(props)
+        speed = _to_int(props.get("speed")) or 0
+        state = "playing" if speed > 0 else "paused"
+        session["last_successful_poll"] = time.time()
+        session["last_progress"] = pct
+        if duration_ms:
+            session["duration_ms"] = duration_ms
+
+        prev_state = str(session.get("state") or "")
+        prev_action = str(session.get("last_action") or "")
+        prev_progress = session.get("last_emitted_progress")
+        emit_action: str | None = None
+
+        if not prev_action:
+            emit_action = "start"
+        elif state == "paused" and prev_state != "paused":
+            emit_action = "pause"
+        elif state == "playing" and prev_state == "paused":
+            emit_action = "start"
+        elif state == "playing" and prev_action == "start":
+            try:
+                last_emit = float(prev_progress if prev_progress is not None else pct)
+            except Exception:
+                last_emit = pct
+            jump = abs(pct - last_emit)
+            if jump >= self._progress_step():
+                emit_action = "start"
+                session["seek_pending"] = bool(jump >= SEEK_JUMP_PERCENT)
+
+        session["state"] = state
+        if emit_action:
+            emit_progress = max(1.0, pct) if emit_action == "start" else pct
+            ev = self._event(session, emit_action, pct, props)
+            if emit_progress != pct:
+                ev = ScrobbleEvent(**{**ev.__dict__, "progress": emit_progress})
+            if self._dispatch_event(ev, session.get("duration_ms")):
+                session["last_action"] = emit_action
+                session["last_emitted_progress"] = emit_progress
+            session["seek_pending"] = False
+
+    def _stop_missing_sessions(self) -> None:
+        for sk, session in list(self._sessions.items()):
+            pct = float(session.get("last_progress") or 0.0)
+            ev = self._event(session, "stop", pct, _dict(session.get("last_properties")))
+            self._dispatch_event(ev, session.get("duration_ms"))
+            self._sessions.pop(sk, None)
+        self._player_session.clear()
+
+    def _tick(self) -> bool:
+        cfg = self._active_cfg()
+        if not self._configured(cfg):
+            return False
+
+        try:
+            players = self._active_players()
+        except Exception as exc:
+            self._mark_offline(exc)
+            return bool(self._sessions)
+
+        self._mark_online()
+        video_players = [p for p in players if str(p.get("type") or "").lower() == "video" and p.get("playerid") is not None]
+        if not video_players:
+            self._empty_success_polls += 1
+            if self._empty_success_polls >= 2 and self._sessions:
+                self._stop_missing_sessions()
+            return False
+
+        self._empty_success_polls = 0
+        active_supported = False
+        seen_player_ids: set[int] = set()
+
+        for player in video_players:
+            player_id = int(player.get("playerid") or 0)
+            seen_player_ids.add(player_id)
+            sk = self._player_session.get(player_id)
+            session = self._sessions.get(sk or "")
+            try:
+                if session is None:
+                    item = self._player_item(player_id)
+                    props = self._player_props(player_id)
+                    session = self._create_session(player, item, props)
+                    if session is None:
+                        continue
+                    active_supported = True
+                    self._maybe_dispatch_progress(session, props)
+                    session["last_properties"] = props
+                else:
+                    props = self._player_props(player_id)
+                    if bool(props.get("live")):
+                        continue
+                    active_supported = True
+                    self._maybe_dispatch_progress(session, props)
+                    session["last_properties"] = props
+            except Exception as exc:
+                self._log_error_limited(f"{type(exc).__name__}:{player_id}", f"Kodi player {player_id} poll failed: {exc}")
+                continue
+
+        for player_id, sk in list(self._player_session.items()):
+            if player_id not in seen_player_ids:
+                self._player_session.pop(player_id, None)
+        return active_supported
+
+    def start(self) -> None:
+        cfg = self._active_cfg()
+        if not source_enabled(cfg, "watcher"):
+            if not self._quiet_startup:
+                _log("Watcher source is disabled; Kodi watcher not started.", "INFO")
+            return
+        if not self._configured(cfg):
+            if not self._quiet_startup:
+                _log("Kodi is not connected; watcher not started.", "WARNING")
+            return
+        self._stop.clear()
+        while not self._stop.is_set():
+            active = self._tick()
+            if self._offline:
+                self._stop.wait(self._offline_retry)
+                continue
+            if active:
+                self._idle_poll = self._base_poll
+            else:
+                self._idle_poll = min(MAX_IDLE_POLL_SECONDS, max(self._base_poll, self._idle_poll + 0.75))
+            self._stop.wait(self._idle_poll)
+
+    def start_async(self) -> None:
+        if self._bg and self._bg.is_alive():
+            return
+        self._stop.clear()
+        self._bg = threading.Thread(target=self.start, name=f"KodiWatch:{self._instance_id}", daemon=True)
+        self._bg.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        bg = self._bg
+        if bg and bg.is_alive() and bg is not threading.current_thread():
+            bg.join(timeout=6.0)
+
+    def is_alive(self) -> bool:
+        bg = self._bg
+        return bool(bg and bg.is_alive() and not self._stop.is_set())
+
+
+def make_default_watch(
+    dispatcher: Any | None = None,
+    cfg_provider: Callable[[], dict[str, Any]] | None = None,
+    instance_id: Any = "default",
+    sinks: list[ScrobbleSink] | None = None,
+) -> KodiWatchService:
+    return KodiWatchService(sinks=sinks, dispatcher=dispatcher, cfg_provider=cfg_provider, instance_id=instance_id)
+
+
+WatchService = KodiWatchService
+
+__all__ = ["KodiWatchService", "WatchService", "make_default_watch"]

--- a/providers/scrobble/routes.py
+++ b/providers/scrobble/routes.py
@@ -8,7 +8,7 @@ from cw_platform.provider_instances import normalize_instance_id
 
 
 DEFAULT_INSTANCE_ID = "default"
-ROUTE_PROVIDERS = {"plex", "emby", "jellyfin"}
+ROUTE_PROVIDERS = {"plex", "emby", "jellyfin", "kodi"}
 ROUTE_SINKS = {"trakt", "simkl", "mdblist"}
 ROUTE_OPTION_STATES = {"inherit", "on", "off"}
 ROUTE_RATINGS_MODES = {"off", "custom"}

--- a/providers/scrobble/watch_manager.py
+++ b/providers/scrobble/watch_manager.py
@@ -192,6 +192,8 @@ def _make_watcher(provider: str, group_dispatcher: MultiDispatcher, cfg_provider
         from providers.scrobble.emby.watch import make_default_watch as make_watch
     elif prov == "jellyfin":
         from providers.scrobble.jellyfin.watch import make_default_watch as make_watch
+    elif prov == "kodi":
+        from providers.scrobble.kodi.watch import make_default_watch as make_watch
     else:
         from providers.scrobble.plex.watch import make_default_watch as make_watch
         prov = "plex"

--- a/tests/test_kodi_watch.py
+++ b/tests/test_kodi_watch.py
@@ -1,0 +1,445 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from providers.auth._auth_KODI import KodiAuthError
+from providers.scrobble.mdblist import sink as mdblist_sink
+from providers.scrobble.simkl import sink as simkl_sink
+from providers.scrobble.trakt.sink import TraktSink
+from providers.scrobble.kodi import watch as kodi_watch
+from providers.scrobble.kodi.watch import KodiWatchService
+
+
+class FakeDispatcher:
+    def __init__(self) -> None:
+        self.events = []
+
+    def dispatch(self, event):
+        self.events.append(event)
+        return True
+
+    def accepts(self, event):
+        return True
+
+
+class RpcScript:
+    def __init__(self, **queues: list[Any]) -> None:
+        self.queues = {k: list(v) for k, v in queues.items()}
+        self.calls = []
+
+    def __call__(self, method: str, params: dict[str, Any] | None = None) -> Any:
+        self.calls.append((method, params))
+        queue = self.queues.setdefault(method, [])
+        if not queue:
+            raise AssertionError(f"Unexpected Kodi RPC call: {method}")
+        value = queue.pop(0)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+def cfg(progress_step: int = 5, kodi_overrides: dict[str, Any] | None = None) -> dict[str, Any]:
+    kodi = {"server": "http://kodi.local:8080", "connection_verified": True, "verify_ssl": False}
+    kodi.update(kodi_overrides or {})
+    return {
+        "kodi": kodi,
+        "scrobble": {
+            "enabled": True,
+            "sources": {"watcher": True},
+            "watch": {"filters": {}},
+            "trakt": {"progress_step": progress_step, "force_stop_at": 95},
+        },
+    }
+
+
+def svc(
+    script: RpcScript,
+    dispatcher: FakeDispatcher | None = None,
+    progress_step: int = 5,
+    kodi_overrides: dict[str, Any] | None = None,
+) -> tuple[KodiWatchService, FakeDispatcher]:
+    disp = dispatcher or FakeDispatcher()
+    service = KodiWatchService(dispatcher=disp, cfg_provider=lambda: cfg(progress_step, kodi_overrides), instance_id="living-room", quiet_startup=True)
+    service._rpc = script  # type: ignore[method-assign]
+    return service, disp
+
+
+def active(player_id: int = 1) -> list[dict[str, Any]]:
+    return [{"playerid": player_id, "type": "video"}]
+
+
+def profile(label: str = "Living Room") -> dict[str, Any]:
+    return {"label": label}
+
+
+def props(speed: int = 1, percentage: float = 10.0, live: bool = False) -> dict[str, Any]:
+    return {
+        "speed": speed,
+        "percentage": percentage,
+        "time": {"hours": 0, "minutes": 10, "seconds": 0, "milliseconds": 0},
+        "totaltime": {"hours": 1, "minutes": 40, "seconds": 0, "milliseconds": 0},
+        "live": live,
+    }
+
+
+def movie_item(**extra: Any) -> dict[str, Any]:
+    item = {
+        "id": 42,
+        "type": "movie",
+        "title": "Arrival",
+        "year": 2016,
+        "uniqueid": {"imdb": "tt2543164", "tmdb": "329865"},
+        "file": "/movies/arrival.mkv",
+        "duration": 6960,
+    }
+    item.update(extra)
+    return item
+
+
+def episode_item(**extra: Any) -> dict[str, Any]:
+    item = {
+        "id": 77,
+        "type": "episode",
+        "title": "The Target",
+        "showtitle": "The Expanse",
+        "season": 1,
+        "episode": 1,
+        "year": 2015,
+        "uniqueid": {"imdb": "tt3230854", "tvdb": "5534478", "tvshow.tmdb": "63639"},
+        "file": "/shows/the-expanse/s01e01.mkv",
+        "duration": 2700,
+    }
+    item.update(extra)
+    return item
+
+
+def test_movie_start_mapping(monkeypatch):
+    monkeypatch.setattr(kodi_watch, "_cw_update", lambda *a, **k: None)
+    script = RpcScript(
+        **{
+            "Player.GetActivePlayers": [active()],
+            "Player.GetItem": [{"item": movie_item()}],
+            "Player.GetProperties": [props(1, 12)],
+            "Profiles.GetCurrentProfile": [profile("Cinema")],
+        }
+    )
+    service, disp = svc(script)
+
+    assert service._tick() is True
+
+    ev = disp.events[-1]
+    assert ev.action == "start"
+    assert ev.media_type == "movie"
+    assert ev.title == "Arrival"
+    assert ev.year == 2016
+    assert ev.ids == {"imdb": "tt2543164", "tmdb": "329865"}
+    assert ev.account == "Cinema"
+    assert ev.session_key.startswith("kodi:living-room:1:movie:id:42:")
+    get_item = next(params for method, params in script.calls if method == "Player.GetItem")
+    assert get_item["properties"] == ["title", "showtitle", "season", "episode", "year", "uniqueid", "file", "duration"]
+    get_props = next(params for method, params in script.calls if method == "Player.GetProperties")
+    assert get_props["properties"] == ["speed", "time", "totaltime", "percentage", "live"]
+
+
+def test_start_progress_is_floored_like_other_watchers(monkeypatch):
+    monkeypatch.setattr(kodi_watch, "_cw_update", lambda *a, **k: None)
+    script = RpcScript(
+        **{
+            "Player.GetActivePlayers": [active()],
+            "Player.GetItem": [{"item": movie_item()}],
+            "Player.GetProperties": [props(1, 0)],
+            "Profiles.GetCurrentProfile": [profile()],
+        }
+    )
+    service, disp = svc(script)
+
+    service._tick()
+
+    assert disp.events[-1].action == "start"
+    assert disp.events[-1].progress == 1.0
+
+
+def test_episode_metadata_and_unique_id_mapping(monkeypatch):
+    monkeypatch.setattr(kodi_watch, "_cw_update", lambda *a, **k: None)
+    script = RpcScript(
+        **{
+            "Player.GetActivePlayers": [active()],
+            "Player.GetItem": [{"item": episode_item()}],
+            "Player.GetProperties": [props(1, 20)],
+            "Profiles.GetCurrentProfile": [profile()],
+        }
+    )
+    service, disp = svc(script)
+
+    assert service._tick() is True
+
+    ev = disp.events[-1]
+    assert ev.action == "start"
+    assert ev.media_type == "episode"
+    assert ev.title == "The Expanse"
+    assert ev.season == 1
+    assert ev.number == 1
+    assert ev.ids["imdb_episode"] == "tt3230854"
+    assert ev.ids["tvdb_episode"] == "5534478"
+    assert ev.ids["tmdb_show"] == "63639"
+    assert "tvdb" not in ev.ids
+
+
+def test_kodi_episode_payloads_use_show_title_not_episode_title(monkeypatch):
+    monkeypatch.setattr(kodi_watch, "_cw_update", lambda *a, **k: None)
+    script = RpcScript(
+        **{
+            "Player.GetActivePlayers": [active()],
+            "Player.GetItem": [{"item": episode_item(title="The Big Top", showtitle="Task", uniqueid={"tvdb": "9621656"})}],
+            "Player.GetProperties": [props(1, 2)],
+            "Profiles.GetCurrentProfile": [profile()],
+        }
+    )
+    service, disp = svc(script)
+
+    assert service._tick() is True
+
+    ev = disp.events[-1]
+    assert ev.title == "Task"
+    mdblist_body = mdblist_sink._bodies(ev, 2.0)[0]
+    simkl_body = simkl_sink._bodies(ev, 2.0)[0]
+    assert ev.ids == {"tvdb_episode": "9621656"}
+    assert mdblist_body["show"]["title"] == "Task"
+    assert simkl_body["show"]["title"] == "Task"
+
+
+def test_kodi_episode_enriches_show_ids_for_scrobble_sinks(monkeypatch):
+    monkeypatch.setattr(kodi_watch, "_cw_update", lambda *a, **k: None)
+    script = RpcScript(
+        **{
+            "Player.GetActivePlayers": [active()],
+            "Player.GetItem": [{"item": episode_item(title="The Manhunt", showtitle="Love & Death", uniqueid={"tvdb": "9621656"})}],
+            "Player.GetProperties": [props(1, 2)],
+            "VideoLibrary.GetEpisodeDetails": [{"episodedetails": {"tvshowid": 9}}],
+            "VideoLibrary.GetTVShowDetails": [{"tvshowdetails": {"tvshowid": 9, "title": "Love & Death", "uniqueid": {"tmdb": "124800", "tvdb": "421130"}}}],
+            "Profiles.GetCurrentProfile": [profile()],
+        }
+    )
+    service, disp = svc(script)
+
+    assert service._tick() is True
+
+    ev = disp.events[-1]
+    assert ev.title == "Love & Death"
+    assert ev.ids["tvdb_episode"] == "9621656"
+    assert ev.ids["tmdb_show"] == "124800"
+    assert ev.ids["tvdb_show"] == "421130"
+    assert "tvdb" not in ev.ids
+
+    mdblist_body = mdblist_sink._bodies(ev, 2.0)[0]
+    trakt_body = TraktSink()._bodies(ev, 2.0)[0]
+    simkl_body = simkl_sink._bodies(ev, 2.0)[0]
+
+    assert mdblist_body["show"]["ids"] == {"tmdb": 124800, "tvdb": 421130}
+    assert trakt_body["show"]["ids"] == {"tmdb": "124800", "tvdb": "421130"}
+    assert simkl_body["show"]["ids"] == {"tmdb": "124800", "tvdb": "421130"}
+
+
+def test_pause_and_resume_detection(monkeypatch):
+    monkeypatch.setattr(kodi_watch, "_cw_update", lambda *a, **k: None)
+    script = RpcScript(
+        **{
+            "Player.GetActivePlayers": [active(), active(), active()],
+            "Player.GetItem": [{"item": movie_item()}],
+            "Player.GetProperties": [props(1, 10), props(0, 11), props(1, 12)],
+            "Profiles.GetCurrentProfile": [profile()],
+        }
+    )
+    service, disp = svc(script)
+
+    service._tick()
+    service._tick()
+    service._tick()
+
+    assert [e.action for e in disp.events] == ["start", "pause", "start"]
+
+
+def test_progress_update_detection(monkeypatch):
+    monkeypatch.setattr(kodi_watch, "_cw_update", lambda *a, **k: None)
+    script = RpcScript(
+        **{
+            "Player.GetActivePlayers": [active(), active(), active()],
+            "Player.GetItem": [{"item": movie_item()}],
+            "Player.GetProperties": [props(1, 10), props(1, 12), props(1, 16)],
+            "Profiles.GetCurrentProfile": [profile()],
+        }
+    )
+    service, disp = svc(script, progress_step=5)
+
+    service._tick()
+    service._tick()
+    service._tick()
+
+    assert [(e.action, int(e.progress)) for e in disp.events] == [("start", 10), ("start", 16)]
+
+
+def test_stop_after_two_successful_empty_polls(monkeypatch):
+    monkeypatch.setattr(kodi_watch, "_cw_update", lambda *a, **k: None)
+    monkeypatch.setattr(kodi_watch, "_cw_update_payload", lambda *a, **k: None)
+    script = RpcScript(
+        **{
+            "Player.GetActivePlayers": [active(), [], []],
+            "Player.GetItem": [{"item": movie_item()}],
+            "Player.GetProperties": [props(1, 92)],
+            "Profiles.GetCurrentProfile": [profile()],
+        }
+    )
+    service, disp = svc(script)
+
+    service._tick()
+    service._tick()
+    assert [e.action for e in disp.events] == ["start"]
+    service._tick()
+
+    assert [e.action for e in disp.events] == ["start", "stop"]
+    assert int(disp.events[-1].progress) == 92
+    assert not service._sessions
+
+
+def test_connection_failure_does_not_generate_stop(monkeypatch):
+    monkeypatch.setattr(kodi_watch, "_cw_update", lambda *a, **k: None)
+    script = RpcScript(
+        **{
+            "Player.GetActivePlayers": [active(), KodiAuthError("timeout", reason="unreachable")],
+            "Player.GetItem": [{"item": movie_item()}],
+            "Player.GetProperties": [props(1, 30)],
+            "Profiles.GetCurrentProfile": [profile()],
+        }
+    )
+    service, disp = svc(script)
+
+    service._tick()
+    assert service._tick() is True
+
+    assert [e.action for e in disp.events] == ["start"]
+    assert service._sessions
+
+
+def test_repeated_offline_failures_backoff_without_log_spam(monkeypatch):
+    logs = []
+    monkeypatch.setattr(kodi_watch, "_log", lambda msg, level="INFO": logs.append((level, msg)))
+    script = RpcScript(
+        **{
+            "Player.GetActivePlayers": [
+                KodiAuthError("Kodi server is unreachable: timeout", reason="unreachable"),
+                KodiAuthError("Kodi server is unreachable: timeout", reason="unreachable"),
+                KodiAuthError("Kodi server is unreachable: timeout", reason="unreachable"),
+            ],
+        }
+    )
+    service, disp = svc(script)
+
+    assert service._tick() is False
+    assert service._offline is True
+    assert service._offline_retry == 30.0
+    assert service._tick() is False
+    assert service._offline_retry == 60.0
+    assert service._tick() is False
+    assert service._offline_retry == 120.0
+
+    assert disp.events == []
+    assert logs == [("WARNING", "Kodi watcher offline: Kodi server is unreachable: timeout; retrying with backoff")]
+
+
+def test_offline_reconnect_resets_backoff_and_logs_once(monkeypatch):
+    monkeypatch.setattr(kodi_watch, "_cw_update", lambda *a, **k: None)
+    logs = []
+    monkeypatch.setattr(kodi_watch, "_log", lambda msg, level="INFO": logs.append((level, msg)))
+    script = RpcScript(
+        **{
+            "Player.GetActivePlayers": [
+                KodiAuthError("Kodi server is unreachable: timeout", reason="unreachable"),
+                active(),
+            ],
+            "Player.GetItem": [{"item": movie_item()}],
+            "Player.GetProperties": [props(1, 33)],
+            "Profiles.GetCurrentProfile": [profile()],
+        }
+    )
+    service, disp = svc(script)
+
+    assert service._tick() is False
+    assert service._offline is True
+    assert service._tick() is True
+
+    assert service._offline is False
+    assert service._offline_retry == 30.0
+    assert disp.events[-1].action == "start"
+    assert int(disp.events[-1].progress) == 33
+    lifecycle_logs = [row for row in logs if row[0] in {"WARNING", "INFO"}]
+    assert lifecycle_logs == [
+        ("WARNING", "Kodi watcher offline: Kodi server is unreachable: timeout; retrying with backoff"),
+        ("INFO", "Kodi watcher reconnected"),
+    ]
+
+
+def test_active_playback_is_recovered_when_watcher_starts(monkeypatch):
+    monkeypatch.setattr(kodi_watch, "_cw_update", lambda *a, **k: None)
+    script = RpcScript(
+        **{
+            "Player.GetActivePlayers": [active()],
+            "Player.GetItem": [{"item": movie_item(title="Dune")}],
+            "Player.GetProperties": [props(1, 43)],
+            "Profiles.GetCurrentProfile": [profile()],
+        }
+    )
+    service, disp = svc(script)
+
+    assert service._tick() is True
+
+    ev = disp.events[-1]
+    assert ev.action == "start"
+    assert ev.title == "Dune"
+    assert int(ev.progress) == 43
+
+
+@pytest.mark.parametrize(
+    ("item", "properties"),
+    [
+        (movie_item(type="musicvideo"), props(1, 10)),
+        (movie_item(), props(1, 10, live=True)),
+    ],
+)
+def test_unsupported_and_live_media_are_ignored(monkeypatch, item, properties):
+    monkeypatch.setattr(kodi_watch, "_cw_update", lambda *a, **k: None)
+    script = RpcScript(
+        **{
+            "Player.GetActivePlayers": [active()],
+            "Player.GetItem": [{"item": item}],
+            "Player.GetProperties": [properties],
+        }
+    )
+    service, disp = svc(script)
+
+    assert service._tick() is False
+    assert disp.events == []
+    assert not service._sessions
+
+
+def test_scrobble_source_whitelist_ignores_unselected_paths(monkeypatch):
+    monkeypatch.setattr(kodi_watch, "_cw_update", lambda *a, **k: None)
+    logs = []
+    monkeypatch.setattr(kodi_watch, "_log", lambda msg, level="INFO": logs.append((level, msg)))
+    script = RpcScript(
+        **{
+            "Player.GetActivePlayers": [active()],
+            "Player.GetItem": [{"item": movie_item(file="/other/arrival.mkv")}],
+            "Player.GetProperties": [props(1, 10)],
+        }
+    )
+    service, disp = svc(script, kodi_overrides={"instances": {"living-room": {"scrobble": {"libraries": ["/movies"]}}}})
+
+    assert service._tick() is False
+    assert disp.events == []
+    assert not service._sessions
+    assert logs
+    assert logs[-1][0] == "DEBUG"
+    assert "event filtered by scrobble whitelist" in logs[-1][1]
+    assert "allowed=['/movies']" in logs[-1][1]

--- a/tests/test_media_watch_offline_backoff.py
+++ b/tests/test_media_watch_offline_backoff.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any
+
+from providers.scrobble.emby import watch as emby_watch
+from providers.scrobble.jellyfin import watch as jellyfin_watch
+from providers.scrobble.plex import watch as plex_watch
+
+
+class FakeDispatcher:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    def dispatch(self, event: Any) -> bool:
+        self.events.append(event)
+        return True
+
+
+def _cfg(provider: str) -> dict[str, Any]:
+    return {
+        provider: {
+            "server": "http://media.local",
+            "access_token": "token",
+            "timeout": 12,
+        },
+        "runtime": {"debug": True},
+    }
+
+
+def test_emby_offline_backoff_is_quiet_and_does_not_stop(monkeypatch):
+    monkeypatch.setattr(emby_watch, "_server_id", lambda *a, **k: "server")
+    service = emby_watch.EmbyWatchService(dispatcher=FakeDispatcher(), cfg_provider=lambda: _cfg("emby"), quiet_startup=True)
+    logs: list[tuple[str, str]] = []
+    service._log = lambda msg, level="INFO": logs.append((level, msg))  # type: ignore[method-assign]
+    service._last["session-1"] = {"p": 33, "ts": 1.0, "meta": {"title": "Movie", "media_type": "movie"}}
+
+    timeouts: list[float | None] = []
+
+    def fail(*args: Any, **kwargs: Any) -> Any:
+        timeouts.append(kwargs.get("timeout"))
+        raise TimeoutError("timeout")
+
+    monkeypatch.setattr(emby_watch, "_get_json", fail)
+
+    assert service._tick() is False
+    assert service._tick() is False
+
+    assert service._offline is True
+    assert service._offline_retry == 60.0
+    assert timeouts == [12.0, 2.0]
+    assert "session-1" in service._last
+    assert logs == [("WARNING", "Emby watcher offline: timeout; retrying with backoff")]
+
+
+def test_jellyfin_offline_backoff_is_quiet_and_recovers(monkeypatch):
+    monkeypatch.setattr(jellyfin_watch, "_server_id", lambda *a, **k: "server")
+    service = jellyfin_watch.JellyfinWatchService(dispatcher=FakeDispatcher(), cfg_provider=lambda: _cfg("jellyfin"), quiet_startup=True)
+    logs: list[tuple[str, str]] = []
+    service._log = lambda msg, level="INFO": logs.append((level, msg))  # type: ignore[method-assign]
+
+    calls = 0
+
+    def flaky(*args: Any, **kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise TimeoutError("timeout")
+        return []
+
+    monkeypatch.setattr(jellyfin_watch, "_get_json", flaky)
+
+    assert service._tick() is False
+    assert service._offline is True
+    assert service._tick() is False
+    assert service._offline is False
+    assert service._offline_retry == 30.0
+    assert logs == [
+        ("WARNING", "Jellyfin watcher offline: timeout; retrying with backoff"),
+        ("INFO", "Jellyfin watcher reconnected"),
+    ]
+
+
+def test_plex_offline_backoff_is_quiet_and_recovers():
+    service = plex_watch.WatchService(dispatcher=FakeDispatcher(), cfg_provider=lambda: {}, quiet_startup=True)
+    logs: list[tuple[str, str]] = []
+    service._log = lambda msg, level="INFO": logs.append((level, msg))  # type: ignore[method-assign]
+
+    service._mark_offline(RuntimeError("down"))
+    service._mark_offline(RuntimeError("down"))
+    service._mark_online()
+
+    assert service._offline is False
+    assert service._offline_retry == 30.0
+    assert logs == [
+        ("WARNING", "Plex watcher offline: down; retrying with backoff"),
+        ("INFO", "Plex watcher reconnected"),
+    ]


### PR DESCRIPTION
# Pull request

## Change

Adds Kodi as a realtime watcher source using HTTP JSON-RPC polling.

This includes:
- Kodi playback start, pause, resume, progress and stop detection
- movie and episode scrobble event mapping
- Kodi route/source registration
- active playback recovery when the watcher starts
- library whitelist filtering for Kodi scrobbling

## Why

Kodi is the first supported realtime path for Kodi playback scrobbling.

## Testing

- test_trakt_scrobble_sink.py
- test_media_watch_offline_backoff.py 

## Issue

Relates to #519