### PR TITLE
Add: Kodi playback progress support

### DIFF
--- a/assets/js/playback_progress.js
+++ b/assets/js/playback_progress.js
@@ -21,7 +21,7 @@
   const providerIcon = (provider) => {
     return `<img src="${esc(providerLogLogo(provider))}" alt="" onerror="this.remove()">`;
   };
-  const PLAYBACK_PROVIDER_KEYS = ["trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio"];
+  const PLAYBACK_PROVIDER_KEYS = ["trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi"];
   const DEFAULT_PROVIDER_TIMEOUT_SECONDS = 12;
   const state = {
     mounted: false,

--- a/cw_platform/modules_registry.py
+++ b/cw_platform/modules_registry.py
@@ -29,6 +29,7 @@ MODULES: dict[str, dict[str, str]] = {
         "_mod_TRAKT":      "providers.sync._mod_TRAKT",
         "_mod_JELLYFIN":   "providers.sync._mod_JELLYFIN",
         "_mod_EMBY":       "providers.sync._mod_EMBY",
+        "_mod_KODI":       "providers.sync._mod_KODI",
         "_mod_MDBLIST":    "providers.sync._mod_MDBLIST",
         "_mod_PUBLICMETADB": "providers.sync._mod_PUBLICMETADB",
         "_mod_NUVIO":      "providers.sync._mod_NUVIO",

--- a/providers/tests/test_manifests.py
+++ b/providers/tests/test_manifests.py
@@ -54,6 +54,12 @@ CASES: tuple[ProviderCase, ...] = (
         empty_configured=False,
     ),
     ProviderCase(
+        module_path="sync._mod_KODI",
+        expected_name="KODI",
+        minimal_cfg={"kodi": {"server": "http://localhost:8080", "connection_verified": True}},
+        empty_configured=False,
+    ),
+    ProviderCase(
         module_path="sync._mod_JELLYFIN",
         expected_name="JELLYFIN",
         minimal_cfg={"jellyfin": {"server": "http://localhost", "access_token": "tok", "user_id": "u"}},

--- a/services/playback_progress/adapters/media_servers.py
+++ b/services/playback_progress/adapters/media_servers.py
@@ -22,6 +22,11 @@ except Exception:
     JELLYFIN_OPS = None  # type: ignore[assignment]
 
 try:
+    from providers.sync._mod_KODI import OPS as KODI_OPS
+except Exception:
+    KODI_OPS = None  # type: ignore[assignment]
+
+try:
     from providers.sync._mod_PLEX import OPS as PLEX_OPS, PLEXModule
 except Exception:
     PLEX_OPS = None  # type: ignore[assignment]
@@ -96,11 +101,14 @@ def _history_item(record: Mapping[str, Any], provider: str) -> dict[str, Any]:
                 ids = {}
                 out["ids"] = ids
             ids[provider] = remote_id
+            if provider == "kodi":
+                out["_kodi_id"] = _int(remote_id)
+                out["_kodi_type"] = "episode" if str(out.get("type") or "").lower() == "episode" else "movie"
         return clean_mapping(out)
     media_type = str(record.get("media_type") or "").lower()
     ids = clean_mapping(record.get("ids") if isinstance(record.get("ids"), Mapping) else {})
     remote_id = _first_str(record.get("remote_id"))
-    if remote_id and provider in {"plex", "emby", "jellyfin"}:
+    if remote_id and provider in {"plex", "emby", "jellyfin", "kodi"}:
         ids.setdefault(provider, remote_id)
     item: dict[str, Any] = {
         "type": "episode" if media_type in {"episode", "anime_episode"} else "movie",
@@ -114,6 +122,9 @@ def _history_item(record: Mapping[str, Any], provider: str) -> dict[str, Any]:
     show_ids = _as_mapping(meta.get("show_ids"))
     if show_ids:
         item["show_ids"] = clean_mapping(show_ids)
+    if provider == "kodi" and remote_id:
+        item["_kodi_id"] = _int(remote_id)
+        item["_kodi_type"] = item["type"]
     return clean_mapping(item)
 
 
@@ -279,7 +290,7 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
         caps: PlaybackCapabilities,
     ) -> PlaybackRecord | None:
         ids = clean_mapping(row.get("ids") if isinstance(row.get("ids"), Mapping) else {})
-        remote_id = _first_str(row.get(f"{self.provider}_item_id"), row.get("_item_id"), row.get("ratingKey"), ids.get(self.provider), row.get("id"))
+        remote_id = _first_str(row.get(f"{self.provider}_item_id"), row.get("_kodi_id"), row.get("_item_id"), row.get("ratingKey"), ids.get(self.provider), row.get("id"))
         if not remote_id:
             remote_id = key if key and not key.startswith("unknown:") else ""
         media_type = str(row.get("type") or "movie").strip().lower()
@@ -474,3 +485,9 @@ class JellyfinPlaybackAdapter(_MediaServerPlaybackAdapter):
     provider = "jellyfin"
     provider_label = "Jellyfin"
     ops = JELLYFIN_OPS
+
+
+class KodiPlaybackAdapter(_MediaServerPlaybackAdapter):
+    provider = "kodi"
+    provider_label = "Kodi"
+    ops = KODI_OPS

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -18,7 +18,7 @@ from cw_platform.id_map import canonical_key, minimal as id_minimal
 from cw_platform.provider_instances import build_provider_config_view, get_instance_block, get_provider_block, list_instance_ids, normalize_instance_id
 
 from .adapters.base import PlaybackProgressAdapter, configured_label
-from .adapters.media_servers import EmbyPlaybackAdapter, JellyfinPlaybackAdapter, PlexPlaybackAdapter
+from .adapters.media_servers import EmbyPlaybackAdapter, JellyfinPlaybackAdapter, KodiPlaybackAdapter, PlexPlaybackAdapter
 from .adapters.mdblist import MDBListPlaybackAdapter
 from .adapters.nuvio import NuvioPlaybackAdapter
 from .adapters.publicmetadb import PublicMetaDBPlaybackAdapter
@@ -32,9 +32,9 @@ CACHE_TTL_SECONDS = 60.0
 MAX_WORKERS = 6
 DEFAULT_PROVIDER_TIMEOUT_SECONDS = 12.0
 GROUP_PROGRESS_TOLERANCE = 2.0
-PHASE1_PROVIDERS = ("trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio")
+PHASE1_PROVIDERS = ("trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi")
 SORT_VALUES = {"last_updated", "progress_high", "progress_low", "remaining_time", "rating_high", "title", "provider"}
-LIVE_MEDIA_PROVIDERS = {"plex", "emby", "jellyfin"}
+LIVE_MEDIA_PROVIDERS = {"plex", "emby", "jellyfin", "kodi"}
 LIVE_ACTIVE_STATES = {"playing", "paused", "buffering"}
 LIVE_MAX_AGE_SECONDS = 10 * 60
 CANONICAL_TMDB_RE = re.compile(r"^tmdb:(\d+)(?:#|$)", re.I)
@@ -608,6 +608,7 @@ def _instance_label(cfg: Mapping[str, Any], provider: str, instance_id: str) -> 
         "emby": "Emby",
         "jellyfin": "Jellyfin",
         "nuvio": "Nuvio",
+        "kodi": "Kodi",
     }.get(provider, provider)
     if label.lower() == "default":
         return f"{provider_label} Default"
@@ -658,6 +659,7 @@ def _profile_has_explicit_identity(cfg: Mapping[str, Any], provider: str, instan
         "emby": ("access_token", "user_id"),
         "jellyfin": ("access_token", "user_id"),
         "nuvio": ("access_token", "refresh_token", "profile_id"),
+        "kodi": ("server", "server_url", "connection_verified", "username"),
     }.get(str(provider or "").strip().lower(), ())
     return any(str(_path_value(raw, path) or "").strip() for path in identity_paths)
 
@@ -726,6 +728,7 @@ class PlaybackProgressService:
             "emby": EmbyPlaybackAdapter(),
             "jellyfin": JellyfinPlaybackAdapter(),
             "nuvio": NuvioPlaybackAdapter(),
+            "kodi": KodiPlaybackAdapter(),
         }
         self._cache: dict[tuple[str, str], dict[str, Any]] = {}
         self._lock = threading.RLock()

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -13,7 +13,7 @@ from services.playback_progress.service import (
 from services.playback_progress.models import PlaybackCapabilities
 import services.playback_progress.service as playback_service
 import services.playback_progress.adapters.nuvio as nuvio_playback_adapter
-from services.playback_progress.adapters.media_servers import JellyfinPlaybackAdapter
+from services.playback_progress.adapters.media_servers import JellyfinPlaybackAdapter, KodiPlaybackAdapter
 from services.playback_progress.adapters.trakt import _trakt_image_url
 
 
@@ -60,6 +60,12 @@ def test_playback_bulk_footer_uses_wide_management_layout():
     assert "#${ROOT_ID} .pp-bulk-actions #pp-bulk-watch{background:linear-gradient(180deg,rgba(64,166,105,.48)" in js
     assert "#${ROOT_ID} .pp-bulk-actions #pp-bulk-remove{background:linear-gradient(180deg,rgba(181,48,68,.58)" in js
     assert "#${ROOT_ID} .pp-card.selected:before,#${ROOT_ID} .pp-card.selected:after{content:none!important;display:none!important}" in js
+
+
+def test_playback_progress_frontend_includes_kodi_provider_key():
+    js = (ROOT / "assets" / "js" / "playback_progress.js").read_text(encoding="utf-8")
+
+    assert 'const PLAYBACK_PROVIDER_KEYS = ["trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi"];' in js
 
 
 def test_combined_record_keeps_available_artwork_regardless_of_input_order():
@@ -402,6 +408,85 @@ def test_media_server_playback_reports_configured_server_down():
     assert result.error_code == "provider_unavailable"
     assert result.message == "Jellyfin server is not reachable."
     assert result.retryable is True
+
+
+class _FakeKodiOps:
+    def __init__(self) -> None:
+        self.added = []
+        self.removed = []
+
+    def is_configured(self, cfg):
+        return bool(cfg.get("kodi", {}).get("server"))
+
+    def health(self, cfg):
+        return {"ok": True, "status": "ok"}
+
+    def build_index(self, cfg, *, feature):
+        assert feature == "progress"
+        return {
+            "tmdb:1468683": {
+                "type": "movie",
+                "title": "Heartstopper Forever",
+                "year": 2026,
+                "ids": {"tmdb": "1468683"},
+                "_kodi_id": 134,
+                "_kodi_type": "movie",
+                "progress_ms": 120000,
+                "duration_ms": 6000000,
+            }
+        }
+
+    def remove(self, cfg, items, *, feature, dry_run=False):
+        self.removed.extend(items)
+        return {"ok": True, "count": len(items), "feature": feature, "unresolved": []}
+
+    def add(self, cfg, items, *, feature, dry_run=False):
+        self.added.extend(items)
+        return {"ok": True, "count": len(items), "feature": feature, "unresolved": []}
+
+
+def test_playback_progress_includes_kodi_provider(monkeypatch):
+    kodi_ops = _FakeKodiOps()
+    cfg = {"kodi": {"server": "http://kodi.local:8080", "connection_verified": True}}
+
+    monkeypatch.setattr(playback_service, "load_config", lambda: cfg)
+
+    service = PlaybackProgressService()
+    service.adapters["kodi"].ops = kodi_ops
+    providers = service.provider_instances(cfg)
+    result = service.items(provider="kodi", force_refresh=True)
+    record = result["items"][0]
+
+    assert {"provider": "kodi", "instance_id": "default", "instance_label": "Kodi Default"} in providers
+    assert result["errors"] == []
+    assert record["provider"] == "kodi"
+    assert record["provider_label"] == "Kodi"
+    assert record["remote_id"] == "134"
+    assert record["progress_percent"] == 2.0
+
+    service.remove({"provider": "kodi", "instance_id": "default", "record": record})
+    service.update_progress({"provider": "kodi", "instance_id": "default", "record": record, "progress_percent": 25})
+
+    assert kodi_ops.removed[0]["_kodi_id"] == 134
+    assert kodi_ops.removed[0]["_kodi_type"] == "movie"
+    assert kodi_ops.added[0]["_kodi_id"] == 134
+    assert kodi_ops.added[0]["progress_ms"] == 1500000
+
+
+def test_kodi_playback_adapter_reports_connected_capabilities():
+    adapter = KodiPlaybackAdapter()
+    adapter.ops = _FakeKodiOps()
+
+    caps = adapter.capabilities(
+        {"kodi": {"server": "http://kodi.local:8080", "connection_verified": True}},
+        instance_id="default",
+        instance_label="Kodi Default",
+    )
+
+    assert caps.provider == "kodi"
+    assert caps.provider_label == "Kodi"
+    assert caps.read is True
+    assert caps.update_progress is True
 
 
 class _FakeNuvioOps:


### PR DESCRIPTION
# Pull request

## Change

Adds Kodi to the Playback Progress manager.

This includes:
- showing Kodi progress records in the playback progress UI
- reading Kodi progress from the shared media-server progress adapter path
- keeping Kodi registered as a progress-capable provider
- tests for Kodi playback progress handling

## Why

Kodi can now sync resume/progress data, so the Playback page should include Kodi records.

## Testing

- test_playback_progress.py
- test_manifests.py

## Issue

Relates to #519