### PR TITLE
Add: Kodi pair library whitelisting

### DIFF
--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -30,8 +30,10 @@ const isTrakt=(v)=>same(v,"trakt");
 const isMDBList=(v)=>same(v,"mdblist");
 const isPublicMetaDB=(v)=>same(v,"publicmetadb");
 const isPlex = (v) => same(v, "plex");
+const isKodi = (v) => same(v, "kodi");
 const isCrossWatch = (v) => same(v, "crosswatch");
 function hasPlex(state){ return isPlex(state?.src) || isPlex(state?.dst) }
+function hasKodi(state){ return isKodi(state?.src) || isKodi(state?.dst) }
 const isMedia = (v) => isPlex(v) || isEmby(v) || isJelly(v);
 function providerSupportsProgress(state, name){ return !!(byName(state, name)?.features || {}).progress }
 function isProgressPair(state){ return providerSupportsProgress(state, state?.src) && providerSupportsProgress(state, state?.dst) }
@@ -516,6 +518,7 @@ const {
   hasPlex,
   hasJelly,
   hasEmby,
+  hasKodi,
   getOpts,
   onLibrariesChanged: (state) => refreshProviderCardSummaries(state),
 });
@@ -527,6 +530,7 @@ function renderProviderSelects(state){
   if(state.src) srcSel.value=state.src;if(state.dst) dstSel.value=state.dst;
   const providerKind=(name)=>{
     if(isMedia(name)) return "Media server";
+    if(isKodi(name)) return "Media client";
     if(isCrossWatch(name)) return "Tracker";
     if(isTrakt(name)||isSimkl(name)||same(name,"mdblist")||same(name,"publicmetadb")||same(name,"tautulli")) return "Tracker";
     if(same(name,"tmdb")||same(name,"anilist")) return "Metadata";
@@ -711,6 +715,9 @@ function getProviderOverrideCount(state, providerKey){
     if (checked("em-strict-ids", getPairProviderStrictValue(state, "emby")) !== strictDefault) count++;
     return count + countProviderLibraries(state, "EMBY");
   }
+  if (providerKey === "kodi") {
+    return countProviderLibraries(state, "KODI");
+  }
   return 0;
 }
 
@@ -722,7 +729,7 @@ function getProviderSummaryText(state, providerKey){
 }
 
 function refreshProviderCardSummaries(state){
-  [["plex","prov-plex-summary"],["jellyfin","prov-jelly-summary"],["emby","prov-emby-summary"]].forEach(([key, id]) => {
+  [["plex","prov-plex-summary"],["jellyfin","prov-jelly-summary"],["emby","prov-emby-summary"],["kodi","prov-kodi-summary"]].forEach(([key, id]) => {
     const el = ID(id);
     if (el) el.textContent = getProviderSummaryText(state, key);
   });
@@ -749,6 +756,7 @@ function renderFeaturePanel(state){
     const providerHintText = (providerKey) => {
       if (providerKey === "plex") return "Tune Plex matching, retries, workers, and pair library scope";
       if (providerKey === "jellyfin") return "Tune Jellyfin matching, longer timeouts and pair library scope.";
+      if (providerKey === "kodi") return "Tune Kodi pair library scope.";
       return "Tune Emby matching, longer timeouts and pair-level library scope.";
     };
 
@@ -878,7 +886,43 @@ function renderFeaturePanel(state){
         </div>
       </details>`);
 
-    left.innerHTML=`<div class="panel-title"><span class="material-symbols-rounded" style="vertical-align:-3px;margin-right:6px;">dns</span>Media Servers</div>
+    if (hasKodi(state)) providerCards.push(`
+      <details class="mods fold provider-card provider-kodi" id="prov-kodi">
+        <summary class="fold-head provider-card-head">
+          <span class="provider-card-main">
+            <span class="provider-card-badge">Kodi</span>
+            <span class="provider-card-copy">
+              <span class="provider-card-title">Kodi</span>
+              <span class="provider-card-sub" id="prov-kodi-summary">${getProviderSummaryText(state, "kodi")}</span>
+            </span>
+          </span>
+          <span class="provider-card-meta">
+            <span class="provider-card-hint">${providerHintText("kodi")}</span>
+            <span class="chev">expand_more</span>
+          </span>
+        </summary>
+        <div class="fold-body provider-card-body">
+          <div class="prov-box" id="kodi-pair-libs">
+            <div class="panel-title small">Pair library whitelist</div>
+            <div class="muted">Empty = use connection-level whitelist.</div>
+            <div class="opt-row">
+              <div class="field-label">History</div>
+              <div class="chip-row" id="kodi-hist-libs"></div>
+            </div>
+            <div class="opt-row">
+              <div class="field-label">Ratings</div>
+              <div class="chip-row" id="kodi-rate-libs"></div>
+            </div>
+            <div class="opt-row">
+              <div class="field-label">Progress</div>
+              <div class="chip-row" id="kodi-prog-libs"></div>
+            </div>
+            <button type="button" class="cx-btn small" id="kodi-libs-load">Load libraries</button>
+          </div>
+        </div>
+      </details>`);
+
+    left.innerHTML=`<div class="panel-title"><span class="material-symbols-rounded" style="vertical-align:-3px;margin-right:6px;">dns</span>Providers</div>
       <div class="providers-intro">
         <div class="providers-intro-copy">
           <div class="providers-intro-title">Advanced provider tuning</div>
@@ -886,10 +930,10 @@ function renderFeaturePanel(state){
         </div>
         <div class="providers-intro-badge">${providerCards.length} ${providerCards.length === 1 ? "provider" : "providers"} in this pair</div>
       </div>
-      <div class="provider-card-list">${providerCards.length ? providerCards.join("") : `<div class="providers-empty">This connection does not include a media server with provider-specific controls.</div>`}</div>
+      <div class="provider-card-list">${providerCards.length ? providerCards.join("") : `<div class="providers-empty">This connection does not include a provider with provider-specific controls.</div>`}</div>
       <div class="providers-note" role="note" aria-live="polite">
         <div class="providers-note-title"><span class="material-symbols-rounded">info</span>Optional advanced controls</div>
-        <div class="providers-note-body">Library whitelists only appear for media servers that are actually part of this pair.</div>
+        <div class="providers-note-body">Library whitelists only appear for providers that support pair-specific library scope and are actually part of this pair.</div>
       </div>`;
 
     right.innerHTML = "";

--- a/assets/js/modals/pair-config/libraries.js
+++ b/assets/js/modals/pair-config/libraries.js
@@ -7,6 +7,7 @@ export function createLibraryController({
   hasPlex,
   hasJelly,
   hasEmby,
+  hasKodi,
   getOpts,
   onLibrariesChanged,
 }) {
@@ -42,6 +43,7 @@ export function createLibraryController({
     if (kind === "PLEX") url = "/api/plex/libraries";
     else if (kind === "JELLYFIN") url = "/api/jellyfin/libraries";
     else if (kind === "EMBY") url = "/api/emby/libraries";
+    else if (kind === "KODI") url = "/api/kodi/libraries";
     if (!url) return Promise.resolve([]);
     return fetch(url + "?cb=" + Date.now(), { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : null))
@@ -65,6 +67,7 @@ export function createLibraryController({
       if (kind === "PLEX") prov = "plex";
       else if (kind === "JELLYFIN") prov = "jellyfin";
       else if (kind === "EMBY") prov = "emby";
+      else if (kind === "KODI") prov = "kodi";
       if (!prov) return libs;
       const f = feature === "history" ? "history" : feature === "ratings" ? "ratings" : feature;
       const serverLibs = cfg?.[prov]?.[f]?.libraries;
@@ -94,6 +97,9 @@ export function createLibraryController({
     else if (kind === "EMBY" && feature === "history") hostId = "em-hist-libs";
     else if (kind === "EMBY" && feature === "ratings") hostId = "em-rate-libs";
     else if (kind === "EMBY" && feature === "progress") hostId = "em-prog-libs";
+    else if (kind === "KODI" && feature === "history") hostId = "kodi-hist-libs";
+    else if (kind === "KODI" && feature === "ratings") hostId = "kodi-rate-libs";
+    else if (kind === "KODI" && feature === "progress") hostId = "kodi-prog-libs";
     const host = ID(hostId);
     if (!host) return;
     const info = getFeatureLibraries(state, feature, kind);
@@ -128,7 +134,11 @@ export function createLibraryController({
   }
 
   function wireProviderLibraries(state, kind) {
-    const btnId = kind === "PLEX" ? "plx-libs-load" : kind === "JELLYFIN" ? "jf-libs-load" : "em-libs-load";
+    const btnId =
+      kind === "PLEX" ? "plx-libs-load" :
+      kind === "JELLYFIN" ? "jf-libs-load" :
+      kind === "EMBY" ? "em-libs-load" :
+      kind === "KODI" ? "kodi-libs-load" : "";
     const btn = ID(btnId);
     const load = () => {
       if (btn) {
@@ -168,12 +178,15 @@ export function createLibraryController({
     const hasPL = hasPlex(state);
     const hasJF = hasJelly(state);
     const hasEM = hasEmby(state);
+    const hasKO = hasKodi(state);
     const plBox = ID("plx-pair-libs");
     const jfBox = ID("jf-pair-libs");
     const emBox = ID("em-pair-libs");
+    const koBox = ID("kodi-pair-libs");
     if (plBox) plBox.style.display = hasPL ? "" : "none";
     if (jfBox) jfBox.style.display = hasJF ? "" : "none";
     if (emBox) emBox.style.display = hasEM ? "" : "none";
+    if (koBox) koBox.style.display = hasKO ? "" : "none";
 
     if (hasPL) wireProviderLibraries(state, "PLEX");
     else if (ID("plx-libs-load")) ID("plx-libs-load").disabled = true;
@@ -183,6 +196,9 @@ export function createLibraryController({
 
     if (hasEM) wireProviderLibraries(state, "EMBY");
     else if (ID("em-libs-load")) ID("em-libs-load").disabled = true;
+
+    if (hasKO) wireProviderLibraries(state, "KODI");
+    else if (ID("kodi-libs-load")) ID("kodi-libs-load").disabled = true;
   }
 
   return {

--- a/cw_platform/orchestrator/_pairs.py
+++ b/cw_platform/orchestrator/_pairs.py
@@ -34,17 +34,19 @@ def _deep_merge_provider_overrides(dst: dict[str, Any], src: Mapping[str, Any]) 
             dst[kk] = v
 
 
-def _config_with_pair_progress_options(
+def _config_with_pair_feature_options(
     cfg: dict[str, Any],
     fcfg: Mapping[str, Any],
     providers: tuple[str, str],
+    feature: str,
 ) -> dict[str, Any]:
+    feature_key = str(feature or "").strip().lower()
     lib_cfg = fcfg.get("libraries")
     overrides: dict[str, list[str]] = {}
     provider_keys: list[str] = []
     for provider in providers:
         name = str(provider or "").upper().strip()
-        if name not in {"PLEX", "EMBY", "JELLYFIN"}:
+        if name not in {"PLEX", "EMBY", "JELLYFIN", "KODI"}:
             continue
         provider_key = name.lower()
         if provider_key not in provider_keys:
@@ -56,8 +58,8 @@ def _config_with_pair_progress_options(
                 if values:
                     overrides[provider_key] = values
 
-    has_replay = "replay_enabled" in fcfg
-    has_tolerance = "timestamp_tolerance_seconds" in fcfg
+    has_replay = feature_key == "progress" and "replay_enabled" in fcfg
+    has_tolerance = feature_key == "progress" and "timestamp_tolerance_seconds" in fcfg
     if not provider_keys or (not overrides and not has_replay and not has_tolerance):
         return cfg
 
@@ -67,22 +69,29 @@ def _config_with_pair_progress_options(
         if not isinstance(provider_cfg, dict):
             provider_cfg = {}
             out[provider_key] = provider_cfg
-        progress_cfg = provider_cfg.setdefault("progress", {})
-        if not isinstance(progress_cfg, dict):
-            progress_cfg = {}
-            provider_cfg["progress"] = progress_cfg
+        feature_cfg = provider_cfg.setdefault(feature_key, {})
+        if not isinstance(feature_cfg, dict):
+            feature_cfg = {}
+            provider_cfg[feature_key] = feature_cfg
         if provider_key in overrides:
-            progress_cfg["libraries"] = overrides[provider_key]
+            feature_cfg["libraries"] = overrides[provider_key]
         if has_replay:
-            progress_cfg["replay_enabled"] = coerce_bool(fcfg.get("replay_enabled", False))
+            feature_cfg["replay_enabled"] = coerce_bool(fcfg.get("replay_enabled", False))
         if has_tolerance:
             try:
                 tolerance = int(fcfg.get("timestamp_tolerance_seconds", 30))
             except (TypeError, ValueError):
                 tolerance = 30
-            progress_cfg["timestamp_tolerance_seconds"] = max(0, min(300, tolerance))
+            feature_cfg["timestamp_tolerance_seconds"] = max(0, min(300, tolerance))
     return out
 
+
+def _config_with_pair_progress_options(
+    cfg: dict[str, Any],
+    fcfg: Mapping[str, Any],
+    providers: tuple[str, str],
+) -> dict[str, Any]:
+    return _config_with_pair_feature_options(cfg, fcfg, providers, "progress")
 
 
 try:
@@ -410,11 +419,7 @@ def run_pairs(ctx) -> dict[str, Any]:
 
             with _pair_env(pair, i=i, src=src, dst=dst, mode=mode, feature=feature):
                 prev_cfg = ctx.config
-                ctx.config = (
-                    _config_with_pair_progress_options(pair_cfg_view, fcfg, (src, dst))
-                    if feature == "progress"
-                    else pair_cfg_view
-                )
+                ctx.config = _config_with_pair_feature_options(pair_cfg_view, fcfg, (src, dst), feature)
                 try:
                     if not injected:
                         inject_ctx_into_provider(sops, ctx)

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -229,6 +229,7 @@ _PROVIDER_KEY_MAP = {
     "PLEX": "plex",
     "JELLYFIN": "jellyfin",
     "EMBY": "emby",
+    "KODI": "kodi",
 }
 
 
@@ -999,8 +1000,8 @@ def run_one_way_feature(
     libs_src: list[str] = _effective_library_whitelist(cfg, src, feature, fcfg)
     libs_dst: list[str] = _effective_library_whitelist(cfg, dst, feature, fcfg)
 
-    allow_unknown_src = (str(src).upper() == "PLEX" and feature == "history")
-    allow_unknown_dst = (str(dst).upper() == "PLEX" and feature == "history")
+    allow_unknown_src = (str(src).upper() == "PLEX" and feature == "history") or str(src).upper() == "KODI"
+    allow_unknown_dst = (str(dst).upper() == "PLEX" and feature == "history") or str(dst).upper() == "KODI"
 
     if libs_src:
         prev_src = _filter_index_by_libraries(prev_src, libs_src, allow_unknown=allow_unknown_src)


### PR DESCRIPTION
# Pull request

## Change

Adds Kodi to pair-specific library whitelisting.

This includes:
- Kodi provider controls in the pair configuration modal
- Kodi library loading in pair-level provider tuning
- pair-level Kodi library overrides for history, ratings and progress
- orchestrator support for applying pair feature library scope to Kodi

## Why

Kodi can expose multiple video sources and users may not want every Kodi source included in a specific sync pair. 
This brings Kodi in line with the media-provider whitelist flow. Same as for plex, jellyfin etc.

## Testing

Tested through the pair config UI and existing sync flow.

## Issue

Relates to #519