### PR TITLE
Change:  Kodi connection status UI

### DIFF
--- a/api/probesAPI.py
+++ b/api/probesAPI.py
@@ -21,6 +21,7 @@ from fastapi.responses import JSONResponse
 from cw_platform.config_base import load_config as _load_config
 
 from cw_platform.provider_instances import get_provider_block, list_instance_ids, normalize_instance_id, provider_key
+from providers.auth._auth_KODI import KodiAuthError, verify_connection as verify_kodi_connection
 from providers.sync.simkl._common import simkl_api_params, simkl_user_agent
 
 
@@ -649,8 +650,7 @@ def probe_kodi(cfg: dict[str, Any], max_age_sec: int = PROBE_TTL) -> bool:
     if now - ts < max_age_sec:
         return ok
 
-    kodi = (cfg.get("kodi") or cfg.get("KODI") or {}) or {}
-    ok = bool((kodi.get("server") or "").strip() and kodi.get("connection_verified") is True)
+    ok, _ = _probe_kodi_detail(cfg, max_age_sec=max_age_sec)
     PROBE_CACHE["kodi"] = (now, ok)
     return ok
 
@@ -1125,6 +1125,38 @@ def _probe_kodi_detail(cfg: dict[str, Any], max_age_sec: int = PROBE_TTL) -> tup
         return False, rsn
     if not verified:
         rsn = "Kodi: connection not verified"
+        with _CACHE_LOCK:
+            PROBE_DETAIL_CACHE[key] = (now, False, rsn)
+        return False, rsn
+
+    try:
+        timeout = max(1.0, min(float(kodi.get("timeout", HTTP_TIMEOUT) or HTTP_TIMEOUT), float(HTTP_TIMEOUT)))
+    except Exception:
+        timeout = float(HTTP_TIMEOUT)
+
+    try:
+        verify_kodi_connection(
+            server,
+            username=str(kodi.get("username") or ""),
+            password=str(kodi.get("password") or ""),
+            verify_ssl=bool(kodi.get("verify_ssl", False)),
+            timeout=timeout,
+        )
+    except KodiAuthError as exc:
+        reason = str(exc.reason or "probe_failed")
+        rsn = {
+            "unreachable": "Kodi: server unreachable",
+            "invalid_credentials": "Kodi: invalid credentials",
+            "not_kodi": "Kodi: not a Kodi server",
+            "version_too_old": "Kodi: version too old",
+            "jsonrpc_too_old": "Kodi: JSON-RPC version too old",
+            "invalid_response": "Kodi: invalid JSON-RPC response",
+        }.get(reason, "Kodi: probe failed")
+        with _CACHE_LOCK:
+            PROBE_DETAIL_CACHE[key] = (now, False, rsn)
+        return False, rsn
+    except Exception:
+        rsn = "Kodi: probe failed"
         with _CACHE_LOCK:
             PROBE_DETAIL_CACHE[key] = (now, False, rsn)
         return False, rsn

--- a/assets/crosswatch.css
+++ b/assets/crosswatch.css
@@ -3,6 +3,12 @@
 /* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
 *{box-sizing:border-box}
 body{margin:0;background:radial-gradient(1200px 600px at 20% -10%,#15152544,transparent),var(--bg);color:var(--fg);font:14px/1.5 ui-sans-serif,system-ui,Segoe UI,Roboto}
+html{scrollbar-width:thin;scrollbar-color:var(--cw-scrollbar-thumb) var(--cw-scrollbar-track)}
+html::-webkit-scrollbar,body::-webkit-scrollbar{width:10px;height:10px}
+html::-webkit-scrollbar-corner,body::-webkit-scrollbar-corner{background:0 0}
+html::-webkit-scrollbar-track,body::-webkit-scrollbar-track{background:var(--cw-scrollbar-track-soft);box-shadow:inset 0 0 0 1px var(--cw-scrollbar-track-ring)}
+html::-webkit-scrollbar-thumb,body::-webkit-scrollbar-thumb{border-radius:12px;background:var(--cw-scrollbar-thumb);border:2px solid var(--cw-scrollbar-thumb-border);box-shadow:var(--cw-scrollbar-thumb-shadow)}
+html::-webkit-scrollbar-thumb:hover,body::-webkit-scrollbar-thumb:hover{background:var(--cw-scrollbar-thumb-hover);box-shadow:var(--cw-scrollbar-thumb-hover-shadow)}
 .brand-ico.plex{color:var(--plex);background:rgba(229,160,13,.12);border-color:rgba(229,160,13,.35)}
 .brand-ico.simkl{color:var(--simkl);background:rgba(0,183,235,.12);border-color:rgba(0,183,235,.35)}
 .brand-ico.anilist{color:var(--anilist);background:rgba(var(--anilist-rgb),.12);border-color:rgba(var(--anilist-rgb),.35)}
@@ -842,6 +848,8 @@ to{left:6px}
 #conn-badges .conn-pill.has-vip .conn-provider-visual{justify-self:center}
 #conn-badges .conn-pill.has-vip .conn-slot{width:var(--crown-size);min-width:var(--crown-size);height:var(--crown-size);display:flex;align-items:center;justify-content:center;padding:0;color:rgba(226,183,82,.78);filter:drop-shadow(0 1px 1px rgba(0,0,0,.9)) drop-shadow(0 3px 5px rgba(0,0,0,.48))}
 #conn-badges .conn-pill.has-vip .conn-slot svg{width:var(--crown-size);height:var(--crown-size);transform:rotate(-8deg)}
+#conn-badges [data-provider-key]{cursor:pointer}
+#conn-badges [data-provider-key]:focus-visible{outline:2px solid rgba(150,166,255,.78);outline-offset:4px}
 #ops-card .action-row{margin-top:16px;padding:12px;border:1px solid rgba(255,255,255,.08);border-radius:18px;background:linear-gradient(180deg,rgba(255,255,255,.032),rgba(255,255,255,.014));box-shadow:inset 0 1px 0 rgba(255,255,255,.02)}
 #ops-card .action-buttons{gap:10px}
 #ops-card .cw-status-dock{box-sizing:border-box;width:100%;min-height:51px}
@@ -1722,6 +1730,21 @@ html[data-cw-theme=flat-light] .cw-history-copy span{color:#667085}
 #page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=jellyfin] .jfy-pane{margin-top:8px}
 #page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=jellyfin] .jfy-actions-row{margin-top:8px}
 #page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=jellyfin] .jfy-pane:empty{display:none}
+#page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=kodi]>.cw-subpanels{padding:34px 54px 20px}
+#page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=kodi] .cw-subpanel.active{gap:10px}
+#page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=kodi] .cw-auth-journey{min-height:92px;margin-bottom:16px!important;padding:16px 24px;gap:16px}
+#page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=kodi] .cw-auth-journey-icon{width:48px;height:48px;flex-basis:48px;font-size:26px}
+#page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=kodi] .cw-auth-journey-text{gap:7px}
+#page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=kodi] .cw-auth-journey-title{font-size:18px}
+#page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=kodi] .cw-auth-journey-copy{font-size:13px;line-height:1.38}
+#page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=kodi] .cw-auth-journey-help{width:40px;height:40px}
+#page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=kodi] .cw-connection-steps{margin-bottom:16px}
+#page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=kodi] .cw-connection-steps>div{gap:9px 18px;padding-right:26px}
+#page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=kodi] .cw-connection-steps>div:not(:last-child)::after{left:62px;right:28px;top:26px}
+#page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=kodi] .cw-connection-steps span{width:48px;height:48px;font-size:19px}
+#page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=kodi] .cw-connection-steps strong{font-size:15px}
+#page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=kodi] .cw-connection-steps small{font-size:13px;line-height:1.34;padding-top:5px}
+#page-settings #auth-providers .cw-connection-modal-panel[data-cw-connection-provider=kodi] .cw-connection-action-row{margin-top:8px}
 #page-settings #auth-providers .cw-connection-modal-panel :is(#trakt_hint,#simkl_hint,#anilist_hint,#tmdb_sync_hint,#tmdb_hint,#mdblist_hint,#publicmetadb_hint,#tautulli_hint){position:relative;display:flex!important;align-items:center;gap:10px 12px;flex-wrap:wrap;box-sizing:border-box;width:100%;max-width:100%;margin:12px 0 0!important;padding:12px 14px!important;border:1px solid rgba(var(--cw-connection-c1,95,141,255),.36)!important;border-radius:13px!important;background:linear-gradient(135deg,rgba(var(--cw-connection-c1,95,141,255),.17),rgba(14,19,30,.78) 58%,rgba(var(--cw-connection-c2,95,141,255),.12))!important;color:rgba(235,241,255,.92)!important;-webkit-text-fill-color:rgba(235,241,255,.92)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.045),0 12px 30px rgba(0,0,0,.16)!important;font-size:13px;line-height:1.45;font-weight:850}
 #page-settings #auth-providers .cw-connection-modal-panel :is(#trakt_hint,#simkl_hint,#anilist_hint,#tmdb_sync_hint,#tmdb_hint,#mdblist_hint,#publicmetadb_hint,#tautulli_hint)::before{content:"key";display:grid;place-items:center;flex:0 0 34px;width:34px;height:34px;border-radius:10px;border:1px solid rgba(var(--cw-connection-c1,95,141,255),.34);background:rgba(var(--cw-connection-c1,95,141,255),.16);color:rgb(var(--cw-connection-c1,95,141,255));-webkit-text-fill-color:rgb(var(--cw-connection-c1,95,141,255));font-family:"Material Symbols Rounded";font-size:20px;line-height:1;font-variation-settings:"FILL"0,"wght"650,"GRAD"0,"opsz"24}
 #page-settings #auth-providers .cw-connection-modal-panel :is(#trakt_hint,#simkl_hint,#anilist_hint,#tmdb_sync_hint,#tmdb_hint,#mdblist_hint,#publicmetadb_hint,#tautulli_hint) a{color:rgb(var(--cw-connection-c1,95,141,255))!important;-webkit-text-fill-color:rgb(var(--cw-connection-c1,95,141,255))!important;text-decoration:none;border-bottom:1px solid rgba(var(--cw-connection-c1,95,141,255),.46);font-weight:950}
@@ -2589,3 +2612,10 @@ html[data-cw-theme=flat-light] .cw-page-hero :is(.pp-hero-summary,.wl-hero-summa
 html[data-cw-theme=flat-light] .cw-page-hero :is(.pp-hero-summary,.wl-hero-summary,.ss-hero-summary,.cw-editor-hero-summary)>*{border-color:rgba(78,96,180,.18)!important;color:#172033!important;-webkit-text-fill-color:currentColor!important}
 html[data-cw-theme=flat-light] .cw-page-hero :is(.pp-hero-summary,.wl-hero-summary,.ss-hero-summary,.cw-editor-hero-summary)>:is(button,.pp-btn,.wl-refresh-btn,.ss-hero-refresh,.cw-editor-refresh):hover{background:rgba(17,24,39,.045)!important;background-image:none!important}
 @media(max-width:760px){.cw-page-hero{grid-template-columns:1fr;min-height:0;padding:22px!important}.cw-page-hero::after{right:12px;font-size:112px;opacity:.72}.cw-page-hero-title{font-size:28px!important}.cw-page-hero-actions{justify-content:flex-start!important}}
+.sc2-logo.brand-kodi{color:#17b5d1}.scrm-modal.provider-kodi{--scrm-c1:23,181,209;--scrm-c2:20,150,200}.scrm-provider-card.provider-kodi{border-color:rgba(23,181,209,.30);background:linear-gradient(180deg,rgba(23,181,209,.12),rgba(255,255,255,.018))}.scrm-provider-card.provider-kodi::after{background-image:url(/assets/img/KODI.png)}
+#conn-badges .conn-provider-visual::after{z-index:0}
+#conn-badges .conn-pill.no .conn-provider-visual::before{content:"";position:absolute;left:50%;top:50%;z-index:1;width:24px;height:24px;border-radius:999px;transform:translate(-50%,-50%) scale(.82);background:radial-gradient(circle,rgba(216,102,114,.32) 0 36%,rgba(216,102,114,.18) 48%,transparent 72%);box-shadow:0 0 0 1px rgba(216,102,114,.22),0 0 18px rgba(216,102,114,.34);opacity:.72;animation:cwProbeOfflineHalo 2.6s ease-in-out infinite;pointer-events:none}
+#conn-badges .conn-pill .dot.no{background:#ef7580!important;color:#ef7580!important;box-shadow:0 0 0 2px rgba(239,117,128,.20),0 0 12px rgba(239,117,128,.46)!important;animation:cwProbeOfflineBreath 2.6s ease-in-out infinite!important}
+@keyframes cwProbeOfflineBreath{0%,100%{box-shadow:0 0 0 2px rgba(239,117,128,.18),0 0 10px rgba(239,117,128,.34)}50%{box-shadow:0 0 0 3px rgba(239,117,128,.28),0 0 16px rgba(239,117,128,.58)}}
+@keyframes cwProbeOfflineHalo{0%,100%{opacity:.42;transform:translate(-50%,-50%) scale(.76)}50%{opacity:.82;transform:translate(-50%,-50%) scale(1.12)}}
+@media(prefers-reduced-motion:reduce){#conn-badges .conn-pill .dot.no,#conn-badges .conn-pill.no .conn-provider-visual::before{animation:none!important}}

--- a/assets/js/main-status.js
+++ b/assets/js/main-status.js
@@ -24,6 +24,33 @@
   let authRetry = 0;
   let dots = null;
 
+  function providerStatusInstance(data) {
+    const probe = data?._cw_probe && typeof data._cw_probe === "object" ? data._cw_probe : null;
+    const summary = data?.instances_summary && typeof data.instances_summary === "object" ? data.instances_summary : null;
+    return txt(probe?.instance || data?.instance || data?.instance_id || data?.rep_instance || summary?.rep || "default") || "default";
+  }
+
+  async function openProviderConnection(key, instance = "default") {
+    const prov = up(key);
+    if (!prov || prov === "CROSSWATCH") return;
+    if (typeof meta.sectionId === "function" && !meta.sectionId(prov)) return;
+    try { localStorage.setItem(`cw.ui.${prov.toLowerCase()}.auth.instance.v1`, txt(instance) || "default"); } catch {}
+    try {
+      window.__cwSettingsPane = "providers";
+      await window.showTab?.("settings");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      window.cwSettingsSelect?.("providers");
+      let opener = window.CW?.ProvidersUI?.openAuthProviderForm || window.openAuthProviderForm;
+      for (let i = 0; !opener && i < 20; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        opener = window.CW?.ProvidersUI?.openAuthProviderForm || window.openAuthProviderForm;
+      }
+      await opener?.(prov);
+    } catch (e) {
+      console.warn("open provider connection failed", e);
+    }
+  }
+
   function activeTab() {
     return String(
       document.documentElement?.dataset?.tab || document.body?.dataset?.tab || "main"
@@ -243,10 +270,11 @@
     }
   }
 
-  function updateConn(wrap, { name, connected, vip, detail, key }) {
+  function updateConn(wrap, { name, connected, vip, detail, key, instance }) {
     const pill = wrap?.querySelector?.(".conn-pill");
     if (!pill) return;
     const provKey = up(key || name);
+    const inst = txt(instance) || "default";
     const dot = pill.querySelector(".dot");
     const brand = pill.querySelector(".conn-brand");
     const hasSlot = !!pill.querySelector(".conn-slot");
@@ -262,11 +290,17 @@
     if (dot && dot.parentElement !== visual) visual.appendChild(dot);
 
     wrap.dataset.prov = provKey;
+    wrap.dataset.providerKey = provKey;
+    wrap.dataset.providerInstance = inst;
     pill.dataset.prov = provKey;
+    pill.dataset.providerKey = provKey;
+    pill.dataset.providerInstance = inst;
     pill.classList.toggle("ok", !!connected);
     pill.classList.toggle("no", !connected);
     pill.classList.toggle("has-vip", !!vip);
-    pill.ariaLabel = `${name} ${connected ? "connected" : "disconnected"}`;
+    pill.role = "button";
+    pill.tabIndex = 0;
+    pill.ariaLabel = `Open ${name} connection settings`;
     if (detail) pill.title = detail;
     else pill.removeAttribute("title");
     const logoSrc = providerLogo(provKey);
@@ -283,15 +317,22 @@
     }
   }
 
-  function makeConn({ name, connected, vip, detail, key }) {
+  function makeConn({ name, connected, vip, detail, key, instance }) {
     const wrap = document.createElement("div");
     const pill = document.createElement("div");
+    const provKey = up(key || name);
+    const inst = txt(instance) || "default";
     wrap.className = "conn-item";
-    wrap.dataset.prov = up(key || name);
+    wrap.dataset.prov = provKey;
+    wrap.dataset.providerKey = provKey;
+    wrap.dataset.providerInstance = inst;
     pill.className = `conn-pill ${connected ? "ok" : "no"}${vip ? " has-vip" : ""}`;
-    pill.dataset.prov = up(key || name);
-    pill.role = "status";
-    pill.ariaLabel = `${name} ${connected ? "connected" : "disconnected"}`;
+    pill.dataset.prov = provKey;
+    pill.dataset.providerKey = provKey;
+    pill.dataset.providerInstance = inst;
+    pill.role = "button";
+    pill.tabIndex = 0;
+    pill.ariaLabel = `Open ${name} connection settings`;
     if (detail) pill.title = detail;
     pill.innerHTML = `<div class="conn-brand">${
       vip ? `<span class="conn-slot">${CROWN}</span>` : ""
@@ -299,7 +340,7 @@
       connected ? "ok" : "no"
     }" aria-hidden="true"></span></span>`;
     wrap.appendChild(pill);
-    updateConn(wrap, { name, connected, vip, detail, key });
+    updateConn(wrap, { name, connected, vip, detail, key, instance: inst });
     return wrap;
   }
 
@@ -353,9 +394,10 @@
           usageDetail(data),
         ].filter(Boolean).join("\n");
         const provKey = up(key);
+        const instance = providerStatusInstance(data);
         const existing = existingByKey.get(provKey);
-        const item = existing || makeConn({ name, connected: !!data.connected, vip: meta.vip, detail, key });
-        updateConn(item, { name, connected: !!data.connected, vip: meta.vip, detail, key });
+        const item = existing || makeConn({ name, connected: !!data.connected, vip: meta.vip, detail, key, instance });
+        updateConn(item, { name, connected: !!data.connected, vip: meta.vip, detail, key, instance });
         return item;
       });
     placeConnItems(host, items);
@@ -381,6 +423,24 @@
     btn.addEventListener("click", (e) => window.manualRefreshStatus?.(e));
   }
 
+  function bindProviderOpeners() {
+    const host = $("conn-badges");
+    if (!host || host.dataset.boundProviderOpen === "1") return;
+    host.dataset.boundProviderOpen = "1";
+    const openFrom = (node) => openProviderConnection(node?.dataset?.providerKey || node?.dataset?.prov, node?.dataset?.providerInstance || "default");
+    host.addEventListener("click", (ev) => {
+      const node = ev.target?.closest?.(".conn-pill[data-provider-key],.conn-item[data-provider-key]");
+      if (node && host.contains(node)) openFrom(node);
+    });
+    host.addEventListener("keydown", (ev) => {
+      if (ev.key !== "Enter" && ev.key !== " ") return;
+      const node = ev.target?.closest?.(".conn-pill[data-provider-key],.conn-item[data-provider-key]");
+      if (!node || !host.contains(node)) return;
+      ev.preventDefault();
+      openFrom(node);
+    });
+  }
+
   function makeDotsController() {
     const create = window.CW?.createAuthDotsController;
     if (typeof create !== "function") return null;
@@ -396,6 +456,7 @@
 
   function init() {
     bindStatusButton();
+    bindProviderOpeners();
     dots = makeDotsController();
     dots?.syncObserver();
     observeMeta(syncMetadataProviderDot);


### PR DESCRIPTION
# Pull request

## Change

Improves provider connection status handling for Kodi and the main status badges.

This includes:
- Kodi probes now verify the live JSON-RPC connection instead of only trusting saved config
- disconnected provider badges get a subtle pulsing offline indicator
- provider badges can be clicked to open the matching connection modal

## Why

Kodi can be connected in config but offline in real life. The UI should show that clearly, and provider badges should help users jump straight to the right connection settings.

## Testing

- test_kodi_discovery_branding.py
- test_probe_badge_styles.py

## Issue

Relates to #519