### PR TITLE
Change: auth forms and watchlist data

### DIFF
--- a/providers/auth/registry.py
+++ b/providers/auth/registry.py
@@ -174,7 +174,7 @@ def auth_providers_html() -> str:
         return (
             f'<div class="section open" id="{gid}">'
             f'  <div class="head" data-toggle-section="{gid}"><span class="chev"></span><strong>{title}</strong></div>'
-            f'  <div class="body">{body}</div>'
+            f'  <div class="body"><form class="cw-password-form-scope" autocomplete="off" onsubmit="return false">{body}</form></div>'
             f'</div>'
         )
 

--- a/services/watchlist.py
+++ b/services/watchlist.py
@@ -976,6 +976,18 @@ def build_watchlist(state: dict[str, Any], tmdb_ok: bool) -> list[dict[str, Any]
 
         tmdb_str = str(tmdb_id)
         tmdb_value = int(tmdb_str) if tmdb_str.isdigit() else tmdb_id
+        extra_meta = {
+            k: info.get(k)
+            for k in (
+                "genres",
+                "genre",
+                "release_date",
+                "first_air_date",
+                "released",
+                "release",
+            )
+            if info.get(k) not in (None, "", [], {})
+        }
 
         out.append(
             {
@@ -997,6 +1009,7 @@ def build_watchlist(state: dict[str, Any], tmdb_ok: bool) -> list[dict[str, Any]
                 "added_instance": added_instance,
                 "categories": [],
                 "ids": _ids_from_key_or_item(key, info),
+                **extra_meta,
             }
         )
 


### PR DESCRIPTION
# Pull request

## Change

Wrapped auth provider fields in a proper form scope.

Also passes through extra watchlist metadata like genre and release dates.

## Why

Avoids browser form warnings and keeps useful metadata available in the UI.

## Testing

NA

## Issue

NA