### PR TITLE
Fix: PublicMetaDB rating updates

### DIFF
--- a/providers/sync/publicmetadb/_ratings.py
+++ b/providers/sync/publicmetadb/_ratings.py
@@ -131,14 +131,36 @@ def _rating_from_score(value: Any) -> int | None:
     return max(1, min(10, int(round(score / 10.0))))
 
 
+def _response_rating(item: Mapping[str, Any] | None, fallback: Any) -> int | None:
+    if isinstance(item, Mapping):
+        for key in ("score", "rating"):
+            if item.get(key) is not None:
+                rating = _rating_from_score(item.get(key))
+                if rating is not None:
+                    return rating
+    return _valid_rating(fallback)
+
+
 def _rating_id(item: Mapping[str, Any]) -> str | None:
     rid = str(item.get("_publicmetadb_rating_id") or item.get("rating_id") or "").strip()
     return rid or None
 
 
+def _rows(data: Any) -> list[Any]:
+    if isinstance(data, list):
+        return data
+    if not isinstance(data, Mapping):
+        return []
+    for key in ("items", "results", "data"):
+        val = data.get(key)
+        if isinstance(val, list):
+            return val
+    return []
+
+
 def _to_minimal(row: Mapping[str, Any], *, episode_rating: bool) -> dict[str, Any] | None:
     tmdb = tmdb_id_for_item(row)
-    rating = _rating_from_score(row.get("score") or row.get("rating"))
+    rating = _response_rating(row, None)
     if tmdb is None or rating is None:
         return None
     label = str(row.get("label") or "Overall").strip() or "Overall"
@@ -173,6 +195,73 @@ def _to_minimal(row: Mapping[str, Any], *, episode_rating: bool) -> dict[str, An
     return mini
 
 
+def _remote_lookup_params(item: Mapping[str, Any]) -> tuple[str | None, dict[str, Any] | None]:
+    mini = id_minimal(item)
+    typ = str(mini.get("type") or item.get("type") or "").strip().lower()
+    label = str(mini.get("label") or item.get("label") or "Overall").strip() or "Overall"
+    if typ == "episode":
+        tmdb = _show_tmdb_for_item(mini) or _show_tmdb_for_item(item)
+        season = as_int(mini.get("season") or item.get("season"))
+        episode = as_int(mini.get("episode") or item.get("episode"))
+        if tmdb is None or season is None or episode is None:
+            return None, None
+        return (
+            "/api/external/episode-ratings",
+            {
+                "tmdb_id": int(tmdb),
+                "media_type": "tv",
+                "season": int(season),
+                "episode": int(episode),
+                "label": label,
+            },
+        )
+
+    tmdb = tmdb_id_for_item(mini) or tmdb_id_for_item(item)
+    if tmdb is None:
+        return None, None
+    media = media_type_for_item(mini)
+    if media not in ("movie", "tv"):
+        media = "movie"
+    return (
+        "/api/external/ratings",
+        {"tmdb_id": int(tmdb), "media_type": media, "label": label},
+    )
+
+
+def _refresh_shadow_entry(adapter: Any, entry: Mapping[str, Any]) -> dict[str, Any] | None:
+    item_obj = entry.get("item")
+    item: Mapping[str, Any] = item_obj if isinstance(item_obj, Mapping) else entry
+    rid = str(entry.get("id") or item.get("_publicmetadb_rating_id") or item.get("rating_id") or "").strip()
+    if not rid:
+        return None
+    path, params = _remote_lookup_params(item)
+    if not path or not params:
+        return None
+
+    try:
+        data = adapter.client.get_json(path, params=params)
+    except Exception as e:
+        _dbg("shadow_refresh_failed", error=f"{type(e).__name__}: {e}")
+        return None
+
+    episode_rating = path.endswith("/episode-ratings")
+    for row in _rows(data):
+        if not isinstance(row, Mapping):
+            continue
+        remote_id = str(row.get("id") or row.get("rating_id") or "").strip()
+        if remote_id != rid:
+            continue
+        mini = _to_minimal(row, episode_rating=episode_rating)
+        if not mini:
+            return None
+        label = str(mini.get("label") or item.get("label") or entry.get("label") or "Overall").strip() or "Overall"
+        mini["label"] = label
+        mini["rating_id"] = rid
+        mini["_publicmetadb_rating_id"] = rid
+        return {"id": rid, "label": label, "item": mini}
+    return None
+
+
 def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
     shadow = _shadow_load()
     raw: dict[str, Any] = dict(shadow.get("items") or {})
@@ -180,6 +269,9 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
     remote_ids: dict[str, Any] = {}
     for key, entry in raw.items():
         if isinstance(entry, Mapping):
+            refreshed = _refresh_shadow_entry(adapter, entry)
+            if isinstance(refreshed, Mapping):
+                entry = refreshed
             item_obj = entry.get("item")
             item: Mapping[str, Any] = item_obj if isinstance(item_obj, Mapping) else entry
             mini = id_minimal(item)
@@ -264,6 +356,18 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         if not _quota_take(adapter, quota_bucket):
             unresolved.append({"item": mini, "hint": f"publicmetadb_hourly_rating_{quota_bucket}_limit"})
             continue
+        if prior_id:
+            old_path = (
+                "/api/external/episode-ratings"
+                if str(mini.get("type") or "").lower() == "episode"
+                else "/api/external/ratings"
+            )
+            old = cast(_ResponseLike, adapter.client.delete(f"{old_path}/{prior_id}"))
+            if not (200 <= old.status_code < 300) and old.status_code != 404:
+                _warn("write_failed", op="replace_delete_old", status=old.status_code, body=(old.text or "")[:200])
+                unresolved.append({"item": mini, "hint": f"http:{old.status_code}:replace_delete_old"})
+                continue
+            remote_ids.pop(key, None)
         post = getattr(adapter.client, "post_once", None)
         r = cast(_ResponseLike, post(path, json=payload) if callable(post) else adapter.client.post(path, json=payload))
         if 200 <= r.status_code < 300:
@@ -271,17 +375,15 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             item = data.get("item") if isinstance(data, Mapping) else None
             rid = str(item.get("id") or "").strip() if isinstance(item, Mapping) else ""
             accepted = dict(mini)
-            accepted["rating"] = _valid_rating(mini.get("rating") or it.get("rating"))
+            accepted["rating"] = _response_rating(
+                item,
+                mini.get("rating") if "rating" in mini else it.get("rating"),
+            )
             accepted["label"] = label or "Overall"
             if rid:
                 accepted["rating_id"] = rid
                 accepted["_publicmetadb_rating_id"] = rid
             remote_ids[key] = {"id": rid, "label": label or "Overall", "item": accepted}
-            if prior_id and prior_id != rid:
-                old_path = "/api/external/episode-ratings" if str(mini.get("type") or "").lower() == "episode" else "/api/external/ratings"
-                old = cast(_ResponseLike, adapter.client.delete(f"{old_path}/{prior_id}"))
-                if not (200 <= old.status_code < 300):
-                    _warn("write_failed", op="replace_delete_old", status=old.status_code, body=(old.text or "")[:200])
             ok += 1
         else:
             _warn("write_failed", op="add", status=r.status_code, body=(r.text or "")[:200])

--- a/providers/tests/test_publicmetadb_ratings.py
+++ b/providers/tests/test_publicmetadb_ratings.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from typing import Any
+
+from providers.sync.publicmetadb import _ratings
+
+
+class FakeResp:
+    def __init__(self, status: int, payload: Any = None):
+        self.status_code = status
+        self._payload = payload
+        self.text = "x" if payload is not None else ""
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeCfg:
+    ratings_label = "Overall"
+    ratings_submit_per_hour = 200
+    ratings_update_per_hour = 100
+
+
+class FakeClient:
+    def __init__(self, responses: dict[tuple[str, str], Any] | None = None):
+        self.responses = responses or {}
+        self.calls: list[dict[str, Any]] = []
+
+    def get_json(self, path: str, **kw: Any) -> dict[str, Any]:
+        self.calls.append({"method": "GET", "path": path, "params": kw.get("params")})
+        return dict(self.responses.get(("GET", path), {"items": []}))
+
+    def post_once(self, path: str, **kw: Any) -> FakeResp:
+        self.calls.append({"method": "POST", "path": path, "json": kw.get("json")})
+        return FakeResp(200, self.responses.get(("POST", path), {"item": {"id": "new-rating", "score": 50}}))
+
+    def delete(self, path: str, **kw: Any) -> FakeResp:
+        self.calls.append({"method": "DELETE", "path": path, "json": kw.get("json")})
+        payload = self.responses.get(("DELETE", path), {"success": True})
+        status = int(payload.get("status", 200)) if isinstance(payload, dict) else 200
+        return FakeResp(status, payload)
+
+    @staticmethod
+    def safe_json(resp: Any) -> Any:
+        return resp.json()
+
+
+class FakeAdapter:
+    def __init__(self, client: FakeClient):
+        self.cfg = FakeCfg()
+        self.client = client
+        self.instance_id = "default"
+        self.config = {"publicmetadb": {"api_key": "k", "ratings_label": "Overall"}}
+
+
+def test_build_index_refreshes_stale_shadow_rating_from_remote_record(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(_ratings, "state_file", lambda name: tmp_path / name)
+    _ratings._shadow_save(
+        {
+            "tmdb:550#rating:overall": {
+                "id": "rating-old",
+                "label": "Overall",
+                "item": {"type": "movie", "ids": {"tmdb": "550"}, "rating": 5, "label": "Overall"},
+            }
+        }
+    )
+
+    client = FakeClient(
+        {
+            ("GET", "/api/external/ratings"): {
+                "items": [
+                    {
+                        "id": "rating-old",
+                        "tmdb_id": 550,
+                        "media_type": "movie",
+                        "score": 40,
+                        "label": "Overall",
+                    }
+                ]
+            }
+        }
+    )
+
+    index = _ratings.build_index(FakeAdapter(client))
+
+    assert index["tmdb:550#rating:overall"]["rating"] == 4
+    assert client.calls[0]["params"] == {"tmdb_id": 550, "media_type": "movie", "label": "Overall"}
+
+
+def test_add_replaces_existing_shadow_rating_by_delete_then_post(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(_ratings, "state_file", lambda name: tmp_path / name)
+    _ratings._shadow_save(
+        {
+            "tmdb:550#rating:overall": {
+                "id": "rating-old",
+                "label": "Overall",
+                "item": {"type": "movie", "ids": {"tmdb": "550"}, "rating": 4, "label": "Overall"},
+            }
+        }
+    )
+    client = FakeClient({("POST", "/api/external/ratings"): {"item": {"id": "rating-new", "score": 50}}})
+
+    count, unresolved = _ratings.add(
+        FakeAdapter(client),
+        [{"type": "movie", "ids": {"tmdb": "550"}, "rating": 5, "label": "Overall"}],
+    )
+
+    assert count == 1
+    assert unresolved == []
+    assert [(c["method"], c["path"]) for c in client.calls] == [
+        ("DELETE", "/api/external/ratings/rating-old"),
+        ("POST", "/api/external/ratings"),
+    ]
+    index = _ratings.build_index(FakeAdapter(FakeClient()))
+    assert index["tmdb:550#rating:overall"]["rating"] == 5
+    assert index["tmdb:550#rating:overall"]["rating_id"] == "rating-new"
+
+
+def test_add_recreates_when_existing_shadow_rating_id_is_already_missing(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(_ratings, "state_file", lambda name: tmp_path / name)
+    _ratings._shadow_save(
+        {
+            "tmdb:550#rating:overall": {
+                "id": "rating-gone",
+                "label": "Overall",
+                "item": {"type": "movie", "ids": {"tmdb": "550"}, "rating": 4, "label": "Overall"},
+            }
+        }
+    )
+    client = FakeClient(
+        {
+            ("DELETE", "/api/external/ratings/rating-gone"): {"status": 404},
+            ("POST", "/api/external/ratings"): {"item": {"id": "rating-new", "score": 50}},
+        }
+    )
+
+    count, unresolved = _ratings.add(
+        FakeAdapter(client),
+        [{"type": "movie", "ids": {"tmdb": "550"}, "rating": 5, "label": "Overall"}],
+    )
+
+    assert count == 1
+    assert unresolved == []
+    assert [(c["method"], c["path"]) for c in client.calls] == [
+        ("DELETE", "/api/external/ratings/rating-gone"),
+        ("POST", "/api/external/ratings"),
+    ]


### PR DESCRIPTION
# Pull request

## Change

Refreshes stored PublicMetaDB rating IDs against the remote API before building the local index.

Also deletes the old remote rating before replacing it, and uses the rating value returned by PublicMetaDB when available.

## Why

Prevents stale shadow data from causing duplicate or outdated ratings.

## Testing

Added PublicMetaDB rating tests.

## Issue

Relates to #533