### PR TITLE
Fix: only index movie and episode history

### DIFF
--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -40,7 +40,7 @@ def _error(event: str, **fields: Any) -> None:
 def _log(msg: str) -> None:
     _dbg(msg)
 
-__VERSION__ = "2.1"
+__VERSION__ = "2.2"
 os.environ.setdefault("CW_PLEX_VERSION", __VERSION__)
 os.environ.setdefault("CW_PLEX_UA", f"CrossWatch/{__VERSION__} (Plex)")
 __all__ = ["get_manifest", "PLEXModule", "PLEXClient", "PLEXError", "PLEXAuthError", "PLEXNotFound", "OPS"]
@@ -127,6 +127,22 @@ _PLAYLIST_CAPABILITIES: dict[str, Any] = {
     "endpoint_types": ["playlist", "collection"],
     "ordered_endpoint_types": ["playlist"],
     "unordered_endpoint_types": ["watchlist", "collection"],
+}
+
+_PROGRESS_CAPABILITIES: dict[str, Any] = {
+    "index_semantics": "present",
+    "observed_deletes": True,
+    "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+    "upsert": True,
+    "remove": True,
+    "requires_duration": True,
+    "completion_policy": {
+        "progress_write": {
+            "mode": "server_configurable",
+            "default_percent": 90,
+            "setting": "Video played threshold",
+        },
+    },
 }
 
 
@@ -502,6 +518,7 @@ def get_manifest() -> Mapping[str, Any]:
                 "unrate": True,
                 "from_date": False,
             },
+            "progress": _PROGRESS_CAPABILITIES,
             "playlists": _PLAYLIST_CAPABILITIES,
         },
     }
@@ -1432,6 +1449,7 @@ class _PlexOPS:
                 "unrate": True,
                 "from_date": False,
             },
+            "progress": _PROGRESS_CAPABILITIES,
             "playlists": _PLAYLIST_CAPABILITIES,
         }
 

--- a/providers/sync/plex/_history.py
+++ b/providers/sync/plex/_history.py
@@ -155,6 +155,11 @@ _dbg, _info, _warn, _error, _log = make_logger("history")
 _GUID_INDEX_MOVIE: dict[str, str] = {}
 _GUID_INDEX_SHOW: dict[str, str] = {}
 _GUID_INDEX_KEY: str | None = None
+_ALLOWED_HISTORY_TYPES = frozenset({"movie", "episode"})
+
+
+def _allowed_history_type(row: Any) -> bool:
+    return str(getattr(row, "type", "") or "").strip().lower() in _ALLOWED_HISTORY_TYPES
 
 
 def _guid_index_key(srv: Any, allow: set[str]) -> str:
@@ -1315,6 +1320,9 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
 
         out: dict[str, dict[str, Any]] = {}
         def _process_history_row(raw: Any) -> tuple[str, dict[str, Any]] | None:
+            if not _allowed_history_type(raw):
+                return None
+
             ts = _epoch_from_history_entry(raw)
             if not ts:
                 return None


### PR DESCRIPTION
# Pull request

## Change

- Fixes Plex history indexing so only movies and episodes are used.
- Also adds Plex progress capabilities to the provider manifest.
- Updates Plex adapter to `v2.2`

## Why

Plex history can include other item types, and those should not be treated as watched history entries.

## Testing

* test_plex_history_types.py

## Issue

Relates to #543