### PR TITLE
Change: apply provider caps to progress planning

### DIFF
--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -9,6 +9,8 @@ import os
 import re
 import datetime as _dt
 
+from ._progress_completion import fcfg_for_progress_target
+
 
 def _emit_item_failures(emit, provider, feature, pair, keys, key2item, bb_res) -> None:
     try:
@@ -1097,7 +1099,8 @@ def run_one_way_feature(
         except Exception:
             dst_for_src = dict(dst_full or {})
 
-        adds, mirror_removes = diff_progress(src_idx, dst_for_src, fcfg=fcfg)
+        dst_progress_fcfg = fcfg_for_progress_target(fcfg, dst_ops)
+        adds, mirror_removes = diff_progress(src_idx, dst_for_src, fcfg=dst_progress_fcfg)
         
         # Mirror-mode clears for progress:
         if (

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -60,6 +60,7 @@ except Exception:  # pragma: no cover
 
 from ..provider_instances import normalize_instance_id
 from ._planner import diff_ratings, diff_progress, _pick_rating
+from ._progress_completion import fcfg_for_progress_target
 try:
     from ._pairs_oneway import _ratings_filter_index as _rate_filter
 except Exception:
@@ -992,14 +993,15 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
             B_for_A = dict(B_eff or {})
             A_for_B = dict(A_eff or {})
 
-        up_B, clr_B = diff_progress(A_eff, B_for_A, fcfg=fcfg, propagate_timestamp_updates=False)
-        up_A, clr_A = diff_progress(B_eff, A_for_B, fcfg=fcfg, propagate_timestamp_updates=False)
+        fcfg_to_B = fcfg_for_progress_target(fcfg, bops)
+        fcfg_to_A = fcfg_for_progress_target(fcfg, aops)
+        up_B, clr_B = diff_progress(A_eff, B_for_A, fcfg=fcfg_to_B, propagate_timestamp_updates=False)
+        up_A, clr_A = diff_progress(B_eff, A_for_B, fcfg=fcfg_to_A, propagate_timestamp_updates=False)
 
         # progress clears from missing items
         try:
             cfgp = dict(fcfg or {})
             min_seconds = int(cfgp.get("min_seconds") or cfgp.get("minSeconds") or 60)
-            max_percent = float(cfgp.get("max_percent") or cfgp.get("maxPercent") or 95)
             clear_below_min = bool(cfgp.get("clear_below_min") or cfgp.get("clearBelowMin") or False)
             min_ms = max(0, min_seconds) * 1000
 
@@ -1052,11 +1054,33 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                 except Exception:
                     return None
 
+            def _max_percent_for(direction_fcfg: Mapping[str, Any]) -> float:
+                return float(direction_fcfg.get("max_percent") or direction_fcfg.get("maxPercent") or 95)
+
+            def _max_percent_min_duration_seconds_for(direction_fcfg: Mapping[str, Any]) -> int:
+                return int(
+                    direction_fcfg.get("max_percent_min_duration_seconds")
+                    or direction_fcfg.get("maxPercentMinDurationSeconds")
+                    or 0
+                )
+
+            def _at_completion_cutoff(pp: float | None, pit: Mapping[str, Any], direction_fcfg: Mapping[str, Any]) -> bool:
+                if pp is None or pp < _max_percent_for(direction_fcfg):
+                    return False
+                min_duration_seconds = _max_percent_min_duration_seconds_for(direction_fcfg)
+                if min_duration_seconds <= 0:
+                    return True
+                dur = _dur(pit)
+                if dur is None:
+                    return True
+                return dur >= min_duration_seconds * 1000
+
             def _infer_clears(
                 missing: set[str],
                 prev_idx: dict[str, Any],
                 other_eff: dict[str, Any],
                 other_alias: dict[str, str],
+                direction_fcfg: Mapping[str, Any],
             ) -> list[dict[str, Any]]:
                 out: list[dict[str, Any]] = []
                 for ck0 in (missing or set()):
@@ -1075,7 +1099,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                             # Not synced then don't propagate the clear either (unless clear_below_min)
                             continue
                     pp = _pct(pms, _dur(pit)) if pms > 0 else pp_explicit
-                    if pp is not None and pp >= max_percent:
+                    if _at_completion_cutoff(pp, pit, direction_fcfg):
                         # Near completion then let history sync handle played state
                         continue
 
@@ -1095,8 +1119,8 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                 # A missing => clear on B, B missing => clear on A
                 clr_B = list(clr_B or [])
                 clr_A = list(clr_A or [])
-                clr_B += _infer_clears(obsA, prevA, B_eff, B_alias_tmp)
-                clr_A += _infer_clears(obsB, prevB, A_eff, A_alias_tmp)
+                clr_B += _infer_clears(obsA, prevA, B_eff, B_alias_tmp, fcfg_to_B)
+                clr_A += _infer_clears(obsB, prevB, A_eff, A_alias_tmp, fcfg_to_A)
 
                 # Tomb-based shit:
                 tck: set[str] = set()
@@ -1114,7 +1138,11 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                 miss_on_B = {k for k in tck if k in (A_eff or {}) and k not in (B_eff or {})}
                 miss_on_A = {k for k in tck if k in (B_eff or {}) and k not in (A_eff or {})}
 
-                def _infer_from_present(present_keys: set[str], present_eff: dict[str, Any]) -> list[dict[str, Any]]:
+                def _infer_from_present(
+                    present_keys: set[str],
+                    present_eff: dict[str, Any],
+                    direction_fcfg: Mapping[str, Any],
+                ) -> list[dict[str, Any]]:
                     out: list[dict[str, Any]] = []
                     for ck0 in (present_keys or set()):
                         pit = present_eff.get(ck0)
@@ -1130,7 +1158,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                             else:
                                 continue
                         pp = _pct(pms, _dur(pit)) if pms > 0 else pp_explicit
-                        if pp is not None and pp >= max_percent:
+                        if _at_completion_cutoff(pp, pit, direction_fcfg):
                             continue
                         base = _minimal(pit)
                         base["progress_ms"] = 0
@@ -1138,8 +1166,8 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                         out.append(base)
                     return out
 
-                clr_A += _infer_from_present(miss_on_B, A_eff)
-                clr_B += _infer_from_present(miss_on_A, B_eff)
+                clr_A += _infer_from_present(miss_on_B, A_eff, fcfg_to_A)
+                clr_B += _infer_from_present(miss_on_A, B_eff, fcfg_to_B)
 
                 emit("debug", msg="progress.infer_clears", obsA=len(obsA), obsB=len(obsB), tomb=len(tomb or set()),
                      tomb_missing_on_A=len(miss_on_A), tomb_missing_on_B=len(miss_on_B), clear_below_min=bool(clear_below_min))

--- a/cw_platform/orchestrator/_planner.py
+++ b/cw_platform/orchestrator/_planner.py
@@ -225,6 +225,11 @@ def diff_progress(
     min_seconds = int(cfg.get("min_seconds") or cfg.get("minSeconds") or 60)
     delta_seconds = int(cfg.get("delta_seconds") or cfg.get("deltaSeconds") or 30)
     max_percent = float(cfg.get("max_percent") or cfg.get("maxPercent") or 95)
+    max_percent_min_duration_seconds = int(
+        cfg.get("max_percent_min_duration_seconds")
+        or cfg.get("maxPercentMinDurationSeconds")
+        or 0
+    )
 
     def _as_int(v: Any) -> int | None:
         try:
@@ -305,6 +310,16 @@ def diff_progress(
         except Exception:
             return None
 
+    def _at_completion_cutoff(percent: float | None, it: Mapping[str, Any]) -> bool:
+        if percent is None or percent < max_percent:
+            return False
+        if max_percent_min_duration_seconds <= 0:
+            return True
+        dur = _duration_ms(it)
+        if dur is None:
+            return True
+        return dur >= max_percent_min_duration_seconds * 1000
+
     def _pack_progress(it: Mapping[str, Any]) -> dict[str, Any]:
         base = minimal(it)
         pm = _progress_ms(it)
@@ -339,7 +354,7 @@ def diff_progress(
             continue
         s_dur = _duration_ms(s_it)
         p = _pct(s_ms, s_dur) if s_ms is not None else s_percent
-        if p is not None and p >= max_percent:
+        if _at_completion_cutoff(p, s_it):
             # Near completion: let history sync handle the played state.
             continue
 

--- a/cw_platform/orchestrator/_progress_completion.py
+++ b/cw_platform/orchestrator/_progress_completion.py
@@ -1,0 +1,96 @@
+# cw_platform/orchestrator/_progress_completion.py
+# Progress completion policy helpers for provider-aware planning.
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        if value is None or isinstance(value, bool):
+            return None
+        out = float(value)
+        if out == out:
+            return out
+    except Exception:
+        return None
+    return None
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        if value is None or isinstance(value, bool):
+            return None
+        return int(float(value))
+    except Exception:
+        return None
+
+
+def progress_caps_from_ops(ops: Any) -> Mapping[str, Any]:
+    try:
+        caps = ops.capabilities() or {}
+    except Exception:
+        return {}
+    if not isinstance(caps, Mapping):
+        return {}
+    progress = caps.get("progress")
+    return progress if isinstance(progress, Mapping) else {}
+
+
+def progress_write_completion_policy(progress_caps: Mapping[str, Any] | None) -> dict[str, Any]:
+    caps = progress_caps if isinstance(progress_caps, Mapping) else {}
+    raw = caps.get("completion_policy")
+    policy = raw if isinstance(raw, Mapping) else {}
+    write_raw = policy.get("progress_write")
+    write = write_raw if isinstance(write_raw, Mapping) else {}
+
+    percent = (
+        _as_float(write.get("percent"))
+        or _as_float(write.get("auto_completes_at_percent"))
+        or _as_float(write.get("default_percent"))
+        or _as_float(caps.get("server_completion_percent"))
+    )
+    min_duration = _as_int(write.get("min_duration_seconds") or write.get("minDurationSeconds"))
+
+    mode = str(write.get("mode") or "").strip().lower()
+    if not mode and percent is not None:
+        mode = "auto_complete"
+
+    if percent is None or mode in {"", "none", "stop_only", "stop_scrobble"}:
+        return {}
+
+    out: dict[str, Any] = {
+        "mode": mode,
+        "percent": max(0.0, min(100.0, float(percent))),
+    }
+    if min_duration is not None and min_duration > 0:
+        out["min_duration_seconds"] = int(min_duration)
+    setting = str(write.get("setting") or "").strip()
+    if setting:
+        out["setting"] = setting
+    return out
+
+
+def fcfg_for_progress_target(
+    fcfg: Mapping[str, Any] | None,
+    target_ops: Any = None,
+    *,
+    target_caps: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    out = dict(fcfg or {})
+    caps = target_caps if isinstance(target_caps, Mapping) else progress_caps_from_ops(target_ops)
+    policy = progress_write_completion_policy(caps)
+    percent = _as_float(policy.get("percent"))
+    if percent is None:
+        return out
+
+    configured = _as_float(out.get("max_percent") or out.get("maxPercent"))
+    out["max_percent"] = min(float(configured), percent) if configured is not None else percent
+    min_duration = _as_int(policy.get("min_duration_seconds"))
+    if min_duration is not None and min_duration > 0:
+        out["max_percent_min_duration_seconds"] = int(min_duration)
+    out["target_progress_completion_policy"] = policy
+    return out

--- a/tests/test_progress_completion_policy.py
+++ b/tests/test_progress_completion_policy.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from cw_platform.orchestrator._planner import diff_progress
+from cw_platform.orchestrator._progress_completion import fcfg_for_progress_target
+
+
+class _Ops:
+    def __init__(self, progress_caps: Mapping[str, Any]):
+        self._progress_caps = dict(progress_caps)
+
+    def capabilities(self) -> dict[str, Any]:
+        return {"progress": dict(self._progress_caps)}
+
+
+def _movie(progress_percent: float, *, duration_ms: int = 7_200_000) -> dict[str, Any]:
+    return {
+        "type": "movie",
+        "title": "Example",
+        "year": 2026,
+        "ids": {"tmdb": "100"},
+        "progress_percent": progress_percent,
+        "duration_ms": duration_ms,
+    }
+
+
+def test_publicmetadb_progress_write_policy_skips_at_eighty_percent() -> None:
+    target = _Ops({"completion_policy": {"progress_write": {"mode": "auto_complete", "percent": 80}}})
+    fcfg = fcfg_for_progress_target({}, target)
+
+    adds_79, clears_79 = diff_progress({"tmdb:100": _movie(79)}, {}, fcfg=fcfg)
+    adds_80, clears_80 = diff_progress({"tmdb:100": _movie(80)}, {}, fcfg=fcfg)
+
+    assert len(adds_79) == 1
+    assert clears_79 == []
+    assert adds_80 == []
+    assert clears_80 == []
+
+
+def test_nuvio_progress_write_policy_uses_ninety_percent_with_duration_floor() -> None:
+    target = _Ops({
+        "completion_policy": {
+            "progress_write": {
+                "mode": "auto_complete",
+                "percent": 90,
+                "min_duration_seconds": 60,
+            }
+        }
+    })
+    fcfg = fcfg_for_progress_target({}, target)
+
+    adds_89, _ = diff_progress({"tmdb:100": _movie(89)}, {}, fcfg=fcfg)
+    adds_90, _ = diff_progress({"tmdb:100": _movie(90)}, {}, fcfg=fcfg)
+    short_90, _ = diff_progress({"tmdb:100": _movie(90, duration_ms=30_000)}, {}, fcfg=fcfg)
+
+    assert len(adds_89) == 1
+    assert adds_90 == []
+    assert len(short_90) == 1
+
+
+def test_stop_scrobble_threshold_does_not_cap_progress_writes() -> None:
+    target = _Ops({
+        "completion_policy": {
+            "progress_write": {"mode": "none"},
+            "stop_scrobble": {"marks_watched_percent": 80, "comparison": "gte"},
+        }
+    })
+    fcfg = fcfg_for_progress_target({}, target)
+
+    adds_80, clears_80 = diff_progress({"tmdb:100": _movie(80)}, {}, fcfg=fcfg)
+
+    assert len(adds_80) == 1
+    assert clears_80 == []


### PR DESCRIPTION
# Pull request

## Change

Uses provider completion policy as a safety cap for the existing progress “ignore near complete” setting.

## Why

Some providers complete progress earlier than our default pair setting. PublicMetaDB completes resume writes at 80%, while other providers behave differently.

## Testing

- `pytest tests/test_progress_completion_policy.py`
- `pytest tests/test_percent_progress_sync.py`
- `pytest tests/test_planner.py`

## Issue

Relates to #545