### PR TITLE
Add: provider progress completion metadata

### DIFF
--- a/providers/sync/_mod_EMBY.py
+++ b/providers/sync/_mod_EMBY.py
@@ -111,7 +111,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "2.0"
+__VERSION__ = "2.1"
 os.environ.setdefault("CW_EMBY_VERSION", __VERSION__)
 os.environ.setdefault("CW_EMBY_UA", f"CrossWatch/{__VERSION__} (Emby)")
 __all__ = ["get_manifest", "EMBYModule", "OPS"]
@@ -192,6 +192,21 @@ _PLAYLIST_CAPABILITIES: dict[str, Any] = {
     "unordered_endpoint_types": ["collection"],
 }
 
+_PROGRESS_CAPABILITIES: dict[str, Any] = {
+    "index_semantics": "present",
+    "observed_deletes": True,
+    "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+    "upsert": True,
+    "remove": True,
+    "requires_duration": True,
+    "completion_policy": {
+        "progress_write": {
+            "mode": "server_configurable",
+            "setting": "LibraryOptions.MaxResumePct",
+        },
+    },
+}
+
 _HEALTH_SHADOW_NAME = "emby.health.shadow.json"
 
 
@@ -238,6 +253,7 @@ def get_manifest() -> Mapping[str, Any]:
                 "unrate": True,
                 "from_date": False,
             },
+            "progress": _PROGRESS_CAPABILITIES,
             "playlists": _PLAYLIST_CAPABILITIES,
         },
     }
@@ -699,6 +715,7 @@ class _EmbyOPS:
                 "unrate": True,
                 "from_date": False,
             },
+            "progress": _PROGRESS_CAPABILITIES,
             "playlists": _PLAYLIST_CAPABILITIES,
         }
 

--- a/providers/sync/_mod_JELLYFIN.py
+++ b/providers/sync/_mod_JELLYFIN.py
@@ -107,7 +107,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "2.0"
+__VERSION__ = "2.1"
 _MIN_PROGRESS_WRITE_VERSION = (10, 9)
 _JF_VERSION_CACHE: dict[str, tuple[float, str | None]] = {}
 
@@ -184,6 +184,22 @@ _PLAYLIST_CAPABILITIES: dict[str, Any] = {
     "unordered_endpoint_types": ["collection"],
 }
 
+_PROGRESS_CAPABILITIES: dict[str, Any] = {
+    "index_semantics": "present",
+    "observed_deletes": True,
+    "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+    "upsert": True,
+    "remove": True,
+    "requires_duration": True,
+    "completion_policy": {
+        "progress_write": {
+            "mode": "server_configurable",
+            "default_percent": 90,
+            "setting": "MaxResumePct",
+        },
+    },
+}
+
 _HEALTH_SHADOW_NAME = "jellyfin.health.shadow.json"
 
 
@@ -247,6 +263,7 @@ def get_manifest() -> Mapping[str, Any]:
                 "unrate": True,
                 "from_date": False,
             },
+            "progress": _PROGRESS_CAPABILITIES,
             "playlists": _PLAYLIST_CAPABILITIES,
         },
     }
@@ -724,6 +741,7 @@ class _JellyfinOPS:
                 "unrate": True,
                 "from_date": False,
             },
+            "progress": _PROGRESS_CAPABILITIES,
             "playlists": _PLAYLIST_CAPABILITIES,
         }
 

--- a/providers/sync/_mod_KODI.py
+++ b/providers/sync/_mod_KODI.py
@@ -12,7 +12,7 @@ from providers.sync.kodi import _progress as feat_progress
 from providers.sync.kodi import _ratings as feat_ratings
 from providers.sync.kodi._common import KodiClient, health_payload, is_configured, item_key, make_config, pick_instance_id
 
-__VERSION__ = "0.1"
+__VERSION__ = "0.2"
 __all__ = ["get_manifest", "KODIModule", "OPS"]
 
 _FEATURES = {"watchlist": False, "ratings": True, "history": True, "progress": True, "playlists": False}
@@ -55,6 +55,13 @@ def get_manifest() -> Mapping[str, Any]:
             "upsert": True,
             "remove": True,
             "requires_duration": False,
+            "completion_policy": {
+                "progress_write": {
+                    "mode": "server_configurable",
+                    "default_percent": 90,
+                    "setting": "playcountminimumpercent",
+                },
+            },
         },
     }
     return {

--- a/providers/sync/_mod_MDBLIST.py
+++ b/providers/sync/_mod_MDBLIST.py
@@ -101,7 +101,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.3"
+__VERSION__ = "1.4"
 __all__ = ["get_manifest", "MDBLISTModule", "OPS"]
 
 def _health(status: str, ok: bool, latency_ms: int) -> None:
@@ -228,6 +228,10 @@ def get_manifest() -> Mapping[str, Any]:
                 "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
                 "upsert": True,
                 "remove": True,
+                "completion_policy": {
+                    "progress_write": {"mode": "none"},
+                    "stop_scrobble": {"marks_watched_percent": 80, "comparison": "gte"},
+                },
             },
             "playlists": _PLAYLIST_CAPABILITIES,
         },
@@ -796,6 +800,10 @@ class _MDBLISTOPS:
                 "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
                 "upsert": True,
                 "remove": True,
+                "completion_policy": {
+                    "progress_write": {"mode": "none"},
+                    "stop_scrobble": {"marks_watched_percent": 80, "comparison": "gte"},
+                },
             },
             "playlists": _PLAYLIST_CAPABILITIES,
         }

--- a/providers/sync/_mod_NUVIO.py
+++ b/providers/sync/_mod_NUVIO.py
@@ -27,7 +27,7 @@ from .nuvio import _watchlist as feat_watchlist
 from .nuvio._common import pull_library_rows, pull_watch_progress_rows, pull_watched_rows
 from cw_platform.provider_instances import normalize_instance_id
 
-__VERSION__ = "0.3"
+__VERSION__ = "0.4"
 __all__ = ["get_manifest", "NUVIOModule", "OPS"]
 
 if "ctx" not in globals():
@@ -91,6 +91,13 @@ def get_manifest() -> Mapping[str, Any]:
                 "observed_deletes": True,
                 "requires_ids": ["tmdb", "imdb", "tvdb"],
                 "requires_duration": True,
+                "completion_policy": {
+                    "progress_write": {
+                        "mode": "auto_complete",
+                        "percent": 90,
+                        "min_duration_seconds": 60,
+                    },
+                },
             },
             "history": {
                 "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},

--- a/providers/sync/_mod_PUBLICMETADB.py
+++ b/providers/sync/_mod_PUBLICMETADB.py
@@ -25,7 +25,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.0"
+__VERSION__ = "1.1"
 __all__ = ["get_manifest", "PUBLICMETADBModule", "OPS"]
 
 
@@ -120,6 +120,9 @@ def get_manifest() -> Mapping[str, Any]:
                 "requires_ids": ["tmdb"],
                 "requires_duration": True,
                 "server_completion_percent": 80,
+                "completion_policy": {
+                    "progress_write": {"mode": "auto_complete", "percent": 80},
+                },
             },
             "playlists": _PLAYLIST_CAPABILITIES,
         },

--- a/providers/sync/_mod_SIMKL.py
+++ b/providers/sync/_mod_SIMKL.py
@@ -256,6 +256,10 @@ def get_manifest() -> Mapping[str, Any]:
                 "types": {"movies": True, "shows": False, "seasons": False, "episodes": True, "anime": True},
                 "upsert": True,
                 "remove": True,
+                "completion_policy": {
+                    "progress_write": {"mode": "none"},
+                    "stop_scrobble": {"marks_watched_percent": 80, "comparison": "gte"},
+                },
             },
             "playlists": dict(_PLAYLIST_CAPABILITIES),
         },
@@ -747,6 +751,10 @@ class _SIMKLOPS:
                 "types": {"movies": True, "shows": False, "seasons": False, "episodes": True, "anime": True},
                 "upsert": True,
                 "remove": True,
+                "completion_policy": {
+                    "progress_write": {"mode": "none"},
+                    "stop_scrobble": {"marks_watched_percent": 80, "comparison": "gte"},
+                },
             },
             "playlists": dict(_PLAYLIST_CAPABILITIES),
         }

--- a/providers/sync/_mod_TRAKT.py
+++ b/providers/sync/_mod_TRAKT.py
@@ -95,7 +95,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.4"
+__VERSION__ = "1.5"
 __all__ = ["get_manifest", "TRAKTModule", "OPS"]
 
 os.environ.setdefault("CW_TRAKT_UA", f"CrossWatch TRAKT/{__VERSION__}")
@@ -180,6 +180,10 @@ def get_manifest() -> Mapping[str, Any]:
                 "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
                 "upsert": True,
                 "remove": True,
+                "completion_policy": {
+                    "progress_write": {"mode": "none"},
+                    "stop_scrobble": {"marks_watched_percent": 80, "comparison": "above"},
+                },
             },
             "playlists": _PLAYLIST_CAPABILITIES,
         },
@@ -738,6 +742,10 @@ class _TraktOPS:
                 "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
                 "upsert": True,
                 "remove": True,
+                "completion_policy": {
+                    "progress_write": {"mode": "none"},
+                    "stop_scrobble": {"marks_watched_percent": 80, "comparison": "above"},
+                },
             },
             "playlists": _PLAYLIST_CAPABILITIES,
         }

--- a/providers/tests/test_manifests.py
+++ b/providers/tests/test_manifests.py
@@ -81,6 +81,27 @@ CASES: tuple[ProviderCase, ...] = (
     ),
 )
 
+MEDIA_SERVER_PROGRESS_CASES: tuple[ProviderCase, ...] = (
+    ProviderCase(
+        module_path="sync._mod_PLEX",
+        expected_name="PLEX",
+        minimal_cfg={"plex": {"token": "tok", "baseurl": "http://localhost"}},
+        empty_configured=False,
+    ),
+    ProviderCase(
+        module_path="sync._mod_EMBY",
+        expected_name="EMBY",
+        minimal_cfg={"emby": {"server": "http://localhost", "access_token": "tok", "user_id": "u"}},
+        empty_configured=False,
+    ),
+    ProviderCase(
+        module_path="sync._mod_JELLYFIN",
+        expected_name="JELLYFIN",
+        minimal_cfg={"jellyfin": {"server": "http://localhost", "access_token": "tok", "user_id": "u"}},
+        empty_configured=False,
+    ),
+)
+
 
 def _import_provider(case: ProviderCase):
     if case.expected_name == "PLEX":
@@ -150,3 +171,24 @@ def test_module_requires_config(case: ProviderCase, monkeypatch: pytest.MonkeyPa
     else:
         manifest = mod.get_manifest()
     assert manifest.get("name") == case.expected_name
+
+
+@pytest.mark.parametrize("case", MEDIA_SERVER_PROGRESS_CASES)
+def test_media_server_progress_capabilities(case: ProviderCase):
+    mod = _import_provider(case)
+    expected_types = {"movies": True, "shows": False, "seasons": False, "episodes": True}
+
+    for caps in (mod.get_manifest()["capabilities"], mod.OPS.capabilities()):
+        progress = caps.get("progress")
+        assert isinstance(progress, Mapping)
+        assert progress.get("index_semantics") == "present"
+        assert progress.get("observed_deletes") is True
+        assert progress.get("types") == expected_types
+        assert progress.get("upsert") is True
+        assert progress.get("remove") is True
+        assert progress.get("requires_duration") is True
+        policy = progress.get("completion_policy")
+        assert isinstance(policy, Mapping)
+        write_policy = policy.get("progress_write")
+        assert isinstance(write_policy, Mapping)
+        assert write_policy.get("mode") == "server_configurable"

--- a/providers/tests/test_mdblist_progress.py
+++ b/providers/tests/test_mdblist_progress.py
@@ -188,3 +188,5 @@ def test_mdblist_module_exposes_progress_feature() -> None:
     assert mdblist_mod.OPS.features()["progress"] is True
     assert mdblist_mod.OPS.capabilities()["progress"]["upsert"] is True
     assert mdblist_mod.OPS.capabilities()["progress"]["remove"] is True
+    assert mdblist_mod.OPS.capabilities()["progress"]["completion_policy"]["progress_write"]["mode"] == "none"
+    assert mdblist_mod.OPS.capabilities()["progress"]["completion_policy"]["stop_scrobble"]["marks_watched_percent"] == 80

--- a/providers/tests/test_nuvio_module.py
+++ b/providers/tests/test_nuvio_module.py
@@ -37,6 +37,8 @@ def test_nuvio_ops_and_manifest_enable_supported_sync_features() -> None:
     assert mod.OPS.capabilities()["verify_after_write"] is True
     assert mod.OPS.capabilities()["features"] == expected
     assert mod.OPS.capabilities()["progress"]["types"] == {"movies": True, "shows": False, "seasons": False, "episodes": True}
+    assert mod.OPS.capabilities()["progress"]["completion_policy"]["progress_write"]["percent"] == 90
+    assert mod.OPS.capabilities()["progress"]["completion_policy"]["progress_write"]["min_duration_seconds"] == 60
     assert mod.OPS.capabilities()["history"]["remove"] is True
     assert mod.OPS.capabilities()["watchlist"]["types"] == {"movies": True, "shows": True, "seasons": False, "episodes": False}
 

--- a/providers/tests/test_publicmetadb_playlists.py
+++ b/providers/tests/test_publicmetadb_playlists.py
@@ -164,12 +164,14 @@ def test_reorder_is_unsupported():
     assert pl.reorder(FakeAdapter(FakeClient()), "list-a", ["tmdb:1"])["unsupported"] is True
 
 
-def test_publicmetadb_1_0_manifest_and_auth_capabilities_cover_supported_features():
-    assert pmdb.__VERSION__ == "1.0"
+def test_publicmetadb_manifest_and_auth_capabilities_cover_supported_features():
+    assert pmdb.__VERSION__ == "1.1"
     assert pmdb_auth.__VERSION__ == "1.0"
 
     features = pmdb.get_manifest()["features"]
+    progress = pmdb.get_manifest()["capabilities"]["progress"]
     auth_caps = pmdb_auth.PROVIDER.capabilities()
     for feature in ("watchlist", "ratings", "history", "progress", "playlists"):
         assert features[feature] is True
         assert auth_caps[feature] is True
+    assert progress["completion_policy"]["progress_write"] == {"mode": "auto_complete", "percent": 80}

--- a/providers/tests/test_simkl_progress.py
+++ b/providers/tests/test_simkl_progress.py
@@ -212,3 +212,5 @@ def test_simkl_module_exposes_progress_feature() -> None:
     assert simkl_mod.OPS.features()["progress"] is True
     assert simkl_mod.OPS.capabilities()["progress"]["upsert"] is True
     assert simkl_mod.OPS.capabilities()["progress"]["remove"] is True
+    assert simkl_mod.OPS.capabilities()["progress"]["completion_policy"]["progress_write"]["mode"] == "none"
+    assert simkl_mod.OPS.capabilities()["progress"]["completion_policy"]["stop_scrobble"]["marks_watched_percent"] == 80

--- a/providers/tests/test_trakt_progress.py
+++ b/providers/tests/test_trakt_progress.py
@@ -252,3 +252,5 @@ def test_trakt_module_exposes_progress_feature() -> None:
     assert trakt_mod.OPS.features()["progress"] is True
     assert trakt_mod.OPS.capabilities()["progress"]["upsert"] is True
     assert trakt_mod.OPS.capabilities()["progress"]["remove"] is True
+    assert trakt_mod.OPS.capabilities()["progress"]["completion_policy"]["progress_write"]["mode"] == "none"
+    assert trakt_mod.OPS.capabilities()["progress"]["completion_policy"]["stop_scrobble"]["marks_watched_percent"] == 80


### PR DESCRIPTION
# Pull request

## Change

Adds progress completion policy metadata to providers.

## Why

Some providers turn resume progress into watched state at different percentages. CW needs to know those limits.

## Testing

- test_manifests.py
- test_nuvio_module.py 
- test_publicmetadb_playlists.py
- test_trakt_progress.py
- test_simkl_progress.py
- test_mdblist_progress.py

## Issue

Relates to #545