### PR TITLE
Add: provider progress limits in playback UI

### DIFF
--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -1645,9 +1645,35 @@ def api_sync_providers() -> JSONResponse:
             for k in FEATURE_KEYS
         }
 
+    def _norm_progress_caps(caps: Any) -> dict:
+        if not isinstance(caps, Mapping):
+            return {}
+
+        out: dict[str, Any] = {}
+        for key in ("server_completion_percent", "requires_duration"):
+            if key in caps:
+                out[key] = caps.get(key)
+
+        policy = caps.get("completion_policy")
+        if isinstance(policy, Mapping):
+            write = policy.get("progress_write")
+            if isinstance(write, Mapping):
+                clean_write: dict[str, Any] = {}
+                for key in ("mode", "percent", "auto_completes_at_percent", "default_percent", "min_duration_seconds", "setting"):
+                    if key in write:
+                        clean_write[key] = write.get(key)
+                if clean_write:
+                    out["completion_policy"] = {"progress_write": clean_write}
+
+        return out
+
     def _norm_caps(caps: dict | None) -> dict:
         caps = dict(caps or {})
-        return {"bidirectional": bool(caps.get("bidirectional", False))}
+        out: dict[str, Any] = {"bidirectional": bool(caps.get("bidirectional", False))}
+        progress = _norm_progress_caps(caps.get("progress"))
+        if progress:
+            out["progress"] = progress
+        return out
 
     def _configured_state(mod, provider_name: str) -> bool:
         ops = getattr(mod, "OPS", None)

--- a/assets/js/playback_progress.js
+++ b/assets/js/playback_progress.js
@@ -73,7 +73,7 @@
       <div class="pp-modal hidden" id="pp-progress-dialog" role="dialog" aria-modal="true" aria-labelledby="pp-progress-dialog-title">
         <div class="pp-dialog">
           <div><div class="pp-dialog-title" id="pp-progress-dialog-title">Edit Progress</div><div class="pp-dialog-sub" id="pp-progress-dialog-sub"></div></div>
-          <div class="pp-progress-edit"><input id="pp-progress-range" type="range" min="2" max="79" step="1"><input id="pp-progress-value" type="number" min="2" max="79" step="1"></div>
+          <div class="pp-progress-edit"><input id="pp-progress-range" type="range" min="2" max="99" step="1"><input id="pp-progress-value" type="number" min="2" max="99" step="0.01"></div>
           <div class="pp-dialog-error" id="pp-progress-error"></div>
           <div class="pp-dialog-actions"><button class="pp-btn" id="pp-progress-cancel">Cancel</button><button class="pp-btn" id="pp-progress-apply">Apply</button></div>
         </div>
@@ -328,10 +328,20 @@
     canonical_key: record.canonical_key,
     record
   })));
-  const avgProgress = (items) => {
+  const editableMaxExclusive = (records) => {
+    const values = records.map((it) => Number(it.editable_progress_max_exclusive || 100)).filter((v) => Number.isFinite(v) && v > 2);
+    return values.length ? Math.min(...values, 100) : 100;
+  };
+  const progressSliderMax = (maxExclusive) => Math.max(2, Math.ceil(Math.min(Number(maxExclusive) || 100, 100)) - 1);
+  const progressMaxLabel = (maxExclusive) => {
+    const n = Number(maxExclusive);
+    return Number.isFinite(n) ? String(Math.round(n * 100) / 100) : "100";
+  };
+  const avgProgress = (items, maxExclusive = 100) => {
     const values = items.flatMap((it) => recordsOf(it)).map((it) => Number(it.progress_percent)).filter(Number.isFinite);
-    if (!values.length) return 25;
-    return Math.max(2, Math.min(79, Math.round(values.reduce((a, b) => a + b, 0) / values.length)));
+    const sliderMax = progressSliderMax(maxExclusive);
+    if (!values.length) return Math.min(25, sliderMax);
+    return Math.max(2, Math.min(sliderMax, Math.round(values.reduce((a, b) => a + b, 0) / values.length)));
   };
   const actionTitle = (action) => action === "mark_watched" ? "Mark as Watched" : action === "update_progress" ? "Edit Progress" : "Remove Progress";
 
@@ -344,7 +354,7 @@
     toast._t = setTimeout(() => el.classList.add("hidden"), 2400);
   }
 
-  function askProgress(defaultValue, count) {
+  function askProgress(defaultValue, count, maxExclusive = 100) {
     return new Promise((resolve) => {
       const dlg = document.getElementById("pp-progress-dialog");
       const range = document.getElementById("pp-progress-range");
@@ -354,7 +364,11 @@
       const apply = document.getElementById("pp-progress-apply");
       const cancel = document.getElementById("pp-progress-cancel");
       if (!dlg || !range || !value || !sub || !err || !apply || !cancel) return resolve(null);
-      const initial = Math.max(2, Math.min(79, Math.round(Number(defaultValue) || 25)));
+      const upper = Math.max(3, Math.min(Number(maxExclusive) || 100, 100));
+      const sliderMax = progressSliderMax(upper);
+      const initial = Math.max(2, Math.min(sliderMax, Math.round(Number(defaultValue) || 25)));
+      range.max = String(sliderMax);
+      value.max = String(Math.round((upper - 0.01) * 100) / 100);
       range.value = String(initial);
       value.value = String(initial);
       sub.textContent = `${count || 1} provider record${count === 1 ? "" : "s"}`;
@@ -363,7 +377,7 @@
       value.focus();
       value.select?.();
       const syncFromRange = () => { value.value = range.value; err.textContent = ""; };
-      const syncFromValue = () => { range.value = String(Math.max(2, Math.min(79, Math.round(Number(value.value) || initial)))); err.textContent = ""; };
+      const syncFromValue = () => { range.value = String(Math.max(2, Math.min(sliderMax, Math.round(Number(value.value) || initial)))); err.textContent = ""; };
       const done = (result) => {
         dlg.classList.add("hidden");
         range.removeEventListener("input", syncFromRange);
@@ -376,8 +390,8 @@
       };
       const onApply = () => {
         const n = Number(value.value);
-        if (!Number.isFinite(n) || n < 2 || n >= 80) {
-          err.textContent = "Use 2-79%. Use Watched for completed items.";
+        if (!Number.isFinite(n) || n < 2 || n >= upper) {
+          err.textContent = `Use at least 2% and below ${progressMaxLabel(upper)}%. Use Watched for completed items.`;
           return;
         }
         done(Math.round(n * 100) / 100);
@@ -745,7 +759,9 @@
     let progressPercent = null;
     if (bulkAction === "update_progress") {
       if (!payloads.length) return toast("Edit Progress is unsupported for this record.");
-      progressPercent = await askProgress(avgProgress([item]), payloads.length);
+      const editableRecords = payloads.map((payload) => payload.record);
+      const maxExclusive = editableMaxExclusive(editableRecords);
+      progressPercent = await askProgress(avgProgress(editableRecords, maxExclusive), payloads.length, maxExclusive);
       if (progressPercent == null) return;
     }
     if (payloads.length > 1 || item.is_combined) {
@@ -778,7 +794,9 @@
     if (!payloads.length) return toast(`${actionTitle(action)} is unsupported for the selected records.`);
     let progressPercent = null;
     if (action === "update_progress") {
-      progressPercent = await askProgress(avgProgress(selected), payloads.length);
+      const editableRecords = payloads.map((payload) => payload.record);
+      const maxExclusive = editableMaxExclusive(editableRecords);
+      progressPercent = await askProgress(avgProgress(editableRecords, maxExclusive), payloads.length, maxExclusive);
       if (progressPercent == null) return;
     } else if (!confirm(`${actionTitle(action)} for ${payloads.length} eligible provider record(s)? ${unsupported ? `${unsupported} unsupported provider record(s) will be skipped.` : ""}`)) return;
     const res = await api("/api/playback_progress/actions/bulk", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ action, progress_percent: progressPercent, items: payloads }) });

--- a/services/playback_progress/adapters/mdblist.py
+++ b/services/playback_progress/adapters/mdblist.py
@@ -172,6 +172,7 @@ def _progress_body_from_record(record: Mapping[str, Any], progress_percent: floa
 class MDBListPlaybackAdapter(PlaybackProgressAdapter):
     provider = "mdblist"
     provider_label = "MDBList"
+    ops = MDBLIST_OPS
 
     def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
         configured = False

--- a/services/playback_progress/adapters/nuvio.py
+++ b/services/playback_progress/adapters/nuvio.py
@@ -169,6 +169,7 @@ def _is_placeholder_title(value: Any) -> bool:
 class NuvioPlaybackAdapter(PlaybackProgressAdapter):
     provider = "nuvio"
     provider_label = "Nuvio"
+    ops = NUVIO_OPS
 
     def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
         try:

--- a/services/playback_progress/adapters/publicmetadb.py
+++ b/services/playback_progress/adapters/publicmetadb.py
@@ -200,6 +200,7 @@ def _progress_payload_from_record(record: Mapping[str, Any], progress_percent: f
 class PublicMetaDBPlaybackAdapter(PlaybackProgressAdapter):
     provider = "publicmetadb"
     provider_label = "PublicMetaDB"
+    ops = PUBLICMETADB_OPS
 
     def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
         configured = False

--- a/services/playback_progress/adapters/simkl.py
+++ b/services/playback_progress/adapters/simkl.py
@@ -217,6 +217,7 @@ def _metadata_rating_duration(
 class SimklPlaybackAdapter(PlaybackProgressAdapter):
     provider = "simkl"
     provider_label = "SIMKL"
+    ops = SIMKL_OPS
 
     def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
         configured = False

--- a/services/playback_progress/adapters/trakt.py
+++ b/services/playback_progress/adapters/trakt.py
@@ -146,6 +146,7 @@ def _module(config_view: Mapping[str, Any]) -> TRAKTModule:
 class TraktPlaybackAdapter(PlaybackProgressAdapter):
     provider = "trakt"
     provider_label = "Trakt"
+    ops = TRAKT_OPS
 
     def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
         configured = False

--- a/services/playback_progress/models.py
+++ b/services/playback_progress/models.py
@@ -102,6 +102,8 @@ class PlaybackRecord:
     can_remove_progress: bool = False
     can_mark_watched: bool = False
     can_update_progress: bool = False
+    editable_progress_min_percent: float = 2.0
+    editable_progress_max_exclusive: float = 100.0
     capability_messages: list[str] = field(default_factory=list)
     provider_metadata: dict[str, Any] = field(default_factory=dict)
 

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -15,6 +15,7 @@ from typing import Any, Mapping, cast
 from _logging import log as BASE_LOG
 from cw_platform.config_base import load_config, save_config
 from cw_platform.id_map import canonical_key, minimal as id_minimal
+from cw_platform.orchestrator._progress_completion import progress_caps_from_ops, progress_write_completion_policy
 from cw_platform.provider_instances import build_provider_config_view, get_instance_block, get_provider_block, list_instance_ids, normalize_instance_id
 
 from .adapters.base import PlaybackProgressAdapter, configured_label
@@ -38,6 +39,8 @@ LIVE_MEDIA_PROVIDERS = {"plex", "emby", "jellyfin", "kodi"}
 LIVE_ACTIVE_STATES = {"playing", "paused", "buffering"}
 LIVE_MAX_AGE_SECONDS = 10 * 60
 CANONICAL_TMDB_RE = re.compile(r"^tmdb:(\d+)(?:#|$)", re.I)
+EDITABLE_PROGRESS_MIN_PERCENT = 2.0
+EDITABLE_PROGRESS_DEFAULT_MAX_EXCLUSIVE = 100.0
 
 
 def _parse_iso(value: Any) -> datetime | None:
@@ -582,15 +585,76 @@ def _group_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     ]
 
 
-def _validated_progress_percent(value: Any) -> tuple[float | None, str]:
+def _duration_seconds_from_record(record: Mapping[str, Any]) -> int | None:
+    try:
+        duration = record.get("duration_seconds")
+        if duration not in (None, ""):
+            value = int(float(duration))
+            return value if value > 0 else None
+    except Exception:
+        pass
+    meta = _as_mapping(record.get("provider_metadata"))
+    for key in ("progress_item", "resume_item"):
+        item = _as_mapping(meta.get(key))
+        for field in ("duration_ms", "duration"):
+            try:
+                raw = item.get(field)
+                if raw in (None, ""):
+                    continue
+                value = int(float(raw))
+                if value > 0:
+                    return max(1, round(value / 1000))
+            except Exception:
+                continue
+    return None
+
+
+def _progress_edit_max_exclusive(adapter: PlaybackProgressAdapter | None, record: Mapping[str, Any]) -> float:
+    ops = getattr(adapter, "ops", None)
+    policy = progress_write_completion_policy(progress_caps_from_ops(ops))
+    raw_percent = policy.get("percent")
+    if raw_percent is None:
+        cutoff = EDITABLE_PROGRESS_DEFAULT_MAX_EXCLUSIVE
+    else:
+        try:
+            cutoff = float(raw_percent)
+        except Exception:
+            cutoff = EDITABLE_PROGRESS_DEFAULT_MAX_EXCLUSIVE
+    if not math.isfinite(cutoff) or cutoff <= EDITABLE_PROGRESS_MIN_PERCENT or cutoff > EDITABLE_PROGRESS_DEFAULT_MAX_EXCLUSIVE:
+        cutoff = EDITABLE_PROGRESS_DEFAULT_MAX_EXCLUSIVE
+    try:
+        min_duration = int(policy.get("min_duration_seconds") or 0)
+    except Exception:
+        min_duration = 0
+    if min_duration > 0:
+        duration = _duration_seconds_from_record(record)
+        if duration is not None and duration < min_duration:
+            cutoff = EDITABLE_PROGRESS_DEFAULT_MAX_EXCLUSIVE
+    return round(float(cutoff), 3)
+
+
+def _apply_progress_edit_policy(result: PlaybackListResult, adapter: PlaybackProgressAdapter | None) -> PlaybackListResult:
+    for record in result.items:
+        record.editable_progress_min_percent = EDITABLE_PROGRESS_MIN_PERCENT
+        record.editable_progress_max_exclusive = _progress_edit_max_exclusive(adapter, record.to_dict())
+    return result
+
+
+def _validated_progress_percent(value: Any, *, max_exclusive: float = EDITABLE_PROGRESS_DEFAULT_MAX_EXCLUSIVE) -> tuple[float | None, str]:
     try:
         progress = float(value)
     except Exception:
         return None, "Progress must be a number."
     if not math.isfinite(progress):
         return None, "Progress must be a finite number."
-    if progress < 2 or progress >= 80:
-        return None, "Progress must be between 2 and 79 percent. Use Mark as Watched for completed items."
+    try:
+        upper = float(max_exclusive)
+    except Exception:
+        upper = EDITABLE_PROGRESS_DEFAULT_MAX_EXCLUSIVE
+    if not math.isfinite(upper) or upper <= EDITABLE_PROGRESS_MIN_PERCENT or upper > EDITABLE_PROGRESS_DEFAULT_MAX_EXCLUSIVE:
+        upper = EDITABLE_PROGRESS_DEFAULT_MAX_EXCLUSIVE
+    if progress < EDITABLE_PROGRESS_MIN_PERCENT or progress >= upper:
+        return None, f"Progress must be at least {EDITABLE_PROGRESS_MIN_PERCENT:g} and below {upper:g} percent. Use Mark as Watched for completed items."
     return round(progress, 2), ""
 
 
@@ -865,6 +929,8 @@ class PlaybackProgressService:
             instance_label=spec["instance_label"],
             force_refresh=force_refresh,
         )
+        if result.ok:
+            result = _apply_progress_edit_policy(result, adapter)
         elapsed_ms = int((time.monotonic() - started) * 1000)
         with self._lock:
             if result.ok:
@@ -1196,15 +1262,11 @@ class PlaybackProgressService:
                     continue
                 results.append(self.mark_watched(item))
             elif action == "update_progress":
-                progress, reason = _validated_progress_percent(payload.get("progress_percent"))
-                if progress is None:
-                    results.append({"ok": False, "provider": item.get("provider"), "instance_id": item.get("instance_id"), "operation": action, "remote_id": item.get("remote_id"), "canonical_key": item.get("canonical_key"), "error_code": "invalid_progress", "message": reason})
-                    continue
                 if not record.get("can_update_progress"):
                     results.append({"ok": False, "provider": item.get("provider"), "instance_id": item.get("instance_id"), "operation": action, "remote_id": item.get("remote_id"), "canonical_key": item.get("canonical_key"), "error_code": "unsupported", "message": "Edit Progress is unsupported for this record."})
                     continue
                 update_item = dict(item)
-                update_item["progress_percent"] = progress
+                update_item["progress_percent"] = payload.get("progress_percent")
                 results.append(self.update_progress(update_item))
             else:
                 results.append({"ok": False, "operation": action, "error_code": "unsupported_action", "message": "Unsupported bulk action."})
@@ -1221,12 +1283,8 @@ class PlaybackProgressService:
         }
 
     def update_progress(self, payload: Mapping[str, Any]) -> dict[str, Any]:
-        progress, reason = _validated_progress_percent(payload.get("progress_percent"))
         provider = str(payload.get("provider") or "").lower()
         instance_id = normalize_instance_id(payload.get("instance_id"))
-        if progress is None:
-            LOG.warn(f"update progress rejected provider={provider} instance={instance_id} reason={reason}")
-            return PlaybackActionResult(False, provider, instance_id, "update_progress", error_code="invalid_progress", message=reason).to_dict()
         cfg = load_config()
         record_value = payload.get("record")
         record = _as_mapping(record_value) if isinstance(record_value, Mapping) else payload
@@ -1234,6 +1292,10 @@ class PlaybackProgressService:
         if adapter is None:
             LOG.warn(f"update progress requested unknown provider={provider} instance={inst}")
             return PlaybackActionResult(False, provider, inst, "update_progress", error_code="unknown_provider", message="Unknown provider.").to_dict()
+        progress, reason = _validated_progress_percent(payload.get("progress_percent"), max_exclusive=_progress_edit_max_exclusive(adapter, record))
+        if progress is None:
+            LOG.warn(f"update progress rejected provider={provider} instance={instance_id} reason={reason}")
+            return PlaybackActionResult(False, provider, instance_id, "update_progress", error_code="invalid_progress", message=reason).to_dict()
         if not record.get("can_update_progress"):
             LOG.warn(f"update progress unsupported provider={provider} instance={inst} remote_id={record.get('remote_id') or ''}")
             return PlaybackActionResult(False, provider, inst, "update_progress", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), error_code="unsupported", message="Edit Progress is unsupported for this record.").to_dict()

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
+
 
 def test_config_migrate_clears_pending_upgrade_marker(monkeypatch) -> None:
     from api import configAPI as cfg_api
@@ -40,3 +43,41 @@ def test_config_migrate_clears_pending_upgrade_marker(monkeypatch) -> None:
 
     assert res["ok"] is True
     assert "_pending_upgrade_from_version" not in (saved.get("ui") or {})
+
+
+def test_sync_providers_exposes_progress_completion_policy(monkeypatch) -> None:
+    from api import syncAPI as sync_api
+    from cw_platform import config_base, provider_instances
+
+    dummy = SimpleNamespace(
+        get_manifest=lambda: {
+            "name": "PUBLICMETADB",
+            "label": "PublicMetaDB",
+            "features": {"progress": True},
+            "capabilities": {
+                "bidirectional": True,
+                "progress": {
+                    "server_completion_percent": 80,
+                    "completion_policy": {
+                        "progress_write": {
+                            "mode": "auto_complete",
+                            "percent": 80,
+                        }
+                    },
+                },
+            },
+        }
+    )
+
+    monkeypatch.setattr(config_base, "load_config", lambda: {})
+    monkeypatch.setattr(provider_instances, "list_instance_ids", lambda *_: ["default"])
+    monkeypatch.setattr(provider_instances, "build_provider_config_view", lambda cfg, *_: cfg)
+    monkeypatch.setattr(sync_api, "sync_provider_names", lambda upper=True: ["PUBLICMETADB"])
+    monkeypatch.setattr(sync_api, "get_sync_module_path_by_name", lambda name: "dummy.publicmetadb")
+    monkeypatch.setattr(sync_api.importlib, "import_module", lambda path: dummy)
+
+    response = sync_api.api_sync_providers()
+    data = json.loads(response.body)
+
+    assert data[0]["capabilities"]["progress"]["server_completion_percent"] == 80
+    assert data[0]["capabilities"]["progress"]["completion_policy"]["progress_write"]["percent"] == 80

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -5,9 +5,11 @@ from pathlib import Path
 from services.playback_progress.service import (
     _combine_records,
     _overlay_live_streams,
+    _progress_edit_max_exclusive,
     _profile_has_explicit_identity,
     _record_group_keys,
     _share_artwork_metadata,
+    _validated_progress_percent,
     PlaybackProgressService,
 )
 from services.playback_progress.models import PlaybackCapabilities
@@ -44,6 +46,7 @@ def _record(**overrides):
 
 def test_playback_bulk_footer_uses_wide_management_layout():
     js = (ROOT / "assets" / "js" / "playback_progress.js").read_text(encoding="utf-8")
+    css = (ROOT / "assets" / "css" / "pages.css").read_text(encoding="utf-8")
     shell = js[js.index("function shell()") : js.index('      <div class="pp-modal hidden" id="pp-progress-dialog"')]
 
     assert 'class="pp-bulk-summary"' in shell
@@ -54,18 +57,72 @@ def test_playback_bulk_footer_uses_wide_management_layout():
     assert 'class="pp-btn pp-bulk-choice pp-bulk-clear" id="pp-clear-selection">${icon("cancel")}<span>Clear Selection</span>' in shell
     assert 'class="pp-selected-pill"' not in shell
     assert 'class="pp-bulk-divider"' not in shell
-    assert "#${ROOT_ID} .pp-bulk{position:sticky;bottom:12px;z-index:20;display:grid;grid-template-columns:minmax(220px,1fr) auto minmax(170px,1fr)" in js
-    assert "#${ROOT_ID} .pp-bulk-actions .pp-bulk-icon{width:48px;min-width:48px;height:48px;min-height:48px" in js
-    assert "#${ROOT_ID} .pp-bulk-actions #pp-bulk-edit{background:linear-gradient(180deg,rgba(63,126,255,.56)" in js
-    assert "#${ROOT_ID} .pp-bulk-actions #pp-bulk-watch{background:linear-gradient(180deg,rgba(64,166,105,.48)" in js
-    assert "#${ROOT_ID} .pp-bulk-actions #pp-bulk-remove{background:linear-gradient(180deg,rgba(181,48,68,.58)" in js
-    assert "#${ROOT_ID} .pp-card.selected:before,#${ROOT_ID} .pp-card.selected:after{content:none!important;display:none!important}" in js
+    assert "#playback-progress-root .pp-bulk{position:sticky;bottom:12px;z-index:20;display:grid;grid-template-columns:minmax(220px,1fr)auto minmax(170px,1fr)" in css
+    assert "#playback-progress-root .pp-bulk-actions .pp-bulk-icon{width:48px;min-width:48px;height:48px;min-height:48px" in css
+    assert "#playback-progress-root .pp-bulk-actions #pp-bulk-edit{background:linear-gradient(180deg,rgba(63,126,255,0.56)" in css
+    assert "#playback-progress-root .pp-bulk-actions #pp-bulk-watch{background:linear-gradient(180deg,rgba(64,166,105,0.48)" in css
+    assert "#playback-progress-root .pp-bulk-actions #pp-bulk-remove{background:linear-gradient(180deg,rgba(181,48,68,0.58)" in css
+    assert "#playback-progress-root .pp-card.selected:before,#playback-progress-root .pp-card.selected:after{content:none !important;display:none !important}" in css
 
 
 def test_playback_progress_frontend_includes_kodi_provider_key():
     js = (ROOT / "assets" / "js" / "playback_progress.js").read_text(encoding="utf-8")
 
     assert 'const PLAYBACK_PROVIDER_KEYS = ["trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi"];' in js
+
+
+class _PolicyOps:
+    def __init__(self, progress_caps):
+        self._progress_caps = progress_caps
+
+    def capabilities(self):
+        return {"progress": self._progress_caps}
+
+
+class _PolicyAdapter:
+    def __init__(self, progress_caps):
+        self.ops = _PolicyOps(progress_caps)
+
+
+def test_playback_progress_edit_validation_uses_progress_write_cutoff():
+    adapter = _PolicyAdapter({"completion_policy": {"progress_write": {"mode": "auto_complete", "percent": 80}}})
+    record = _record(duration_seconds=3600)
+    max_exclusive = _progress_edit_max_exclusive(adapter, record)
+
+    assert max_exclusive == 80
+    assert _validated_progress_percent(79.5, max_exclusive=max_exclusive) == (79.5, "")
+    progress, reason = _validated_progress_percent(80, max_exclusive=max_exclusive)
+    assert progress is None
+    assert "below 80 percent" in reason
+
+
+def test_playback_progress_edit_validation_ignores_stop_only_cutoff():
+    adapter = _PolicyAdapter({
+        "completion_policy": {
+            "progress_write": {"mode": "none"},
+            "stop_scrobble": {"marks_watched_percent": 80, "comparison": "gte"},
+        }
+    })
+
+    max_exclusive = _progress_edit_max_exclusive(adapter, _record(duration_seconds=3600))
+
+    assert max_exclusive == 100
+    assert _validated_progress_percent(95, max_exclusive=max_exclusive) == (95, "")
+
+
+def test_playback_progress_edit_validation_honors_duration_floor():
+    adapter = _PolicyAdapter({
+        "completion_policy": {
+            "progress_write": {
+                "mode": "auto_complete",
+                "percent": 90,
+                "min_duration_seconds": 60,
+            }
+        }
+    })
+
+    assert _progress_edit_max_exclusive(adapter, _record(duration_seconds=3600)) == 90
+    assert _progress_edit_max_exclusive(adapter, _record(duration_seconds=30)) == 100
 
 
 def test_combined_record_keeps_available_artwork_regardless_of_input_order():


### PR DESCRIPTION
# Pull request

## Change

Uses provider progress completion limits in the Playback Progress manager and pair config modal.

## Why

Some targets treat high resume progress as watched. The UI should avoid offering unsafe progress values and show the right pair recommendation.

## Testing

- test_playback_progress.py
- test_config_api.py

## Issue

Relates to #545