### PR TITLE
Fix: NUVIO history timestamps

### DIFF
--- a/providers/sync/nuvio/_common.py
+++ b/providers/sync/nuvio/_common.py
@@ -39,6 +39,7 @@ __all__ = [
     "epoch_ms",
     "ids_for_content_id",
     "is_configured",
+    "iso_from_epoch_ms",
     "library_lock",
     "make_item",
     "metadata_title_for_content_id",
@@ -121,6 +122,18 @@ def epoch_ms(value: Any) -> int | None:
 
         parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
         return int(parsed.timestamp() * 1000)
+    except Exception:
+        return None
+
+
+def iso_from_epoch_ms(value: Any) -> str | None:
+    ms = epoch_ms(value)
+    if ms is None:
+        return None
+    try:
+        from datetime import datetime, timezone
+
+        return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
     except Exception:
         return None
 

--- a/providers/sync/nuvio/_history.py
+++ b/providers/sync/nuvio/_history.py
@@ -14,6 +14,7 @@ from providers.sync._log import log as cw_log
 from ._common import (
     canonical_item_key,
     epoch_ms,
+    iso_from_epoch_ms,
     make_item,
     metadata_title_for_content_id,
     payload_item_key,
@@ -65,11 +66,11 @@ def _item_from_row(adapter: Any, row: Mapping[str, Any]) -> tuple[str | None, di
         title=title,
         year=row.get("year"),
     )
-    watched_at = epoch_ms(row.get("watched_at"))
+    watched_at = iso_from_epoch_ms(row.get("watched_at"))
     if not item or watched_at is None:
         return None, None, "nuvio_history_invalid"
     item["watched"] = True
-    item["watched_at"] = int(watched_at)
+    item["watched_at"] = watched_at
     item["_nuvio_content_id"] = str(row.get("content_id") or "").strip()
     item["_nuvio_profile_id"] = row.get("profile_id")
     key = canonical_item_key(item)

--- a/providers/sync/nuvio/_progress.py
+++ b/providers/sync/nuvio/_progress.py
@@ -15,6 +15,7 @@ from providers.sync._progress_policy import decide_progress_write, progress_mate
 from ._common import (
     canonical_item_key,
     epoch_ms,
+    iso_from_epoch_ms,
     make_item,
     metadata_title_for_content_id,
     payload_item_key,
@@ -103,9 +104,10 @@ def _item_from_row(adapter: Any, row: Mapping[str, Any]) -> tuple[str | None, di
     position = to_int(row.get("position"))
     duration = positive_int(row.get("duration"))
     last_watched = epoch_ms(row.get("last_watched"))
+    progress_at = iso_from_epoch_ms(last_watched)
     video_id = str(row.get("video_id") or "").strip()
     content_id = str(row.get("content_id") or "").strip()
-    if not base or position is None or position < 0 or duration is None or last_watched is None or not video_id:
+    if not base or position is None or position < 0 or duration is None or last_watched is None or progress_at is None or not video_id:
         return None, None, "nuvio_progress_invalid"
 
     item = dict(base)
@@ -113,7 +115,7 @@ def _item_from_row(adapter: Any, row: Mapping[str, Any]) -> tuple[str | None, di
         {
             "progress_ms": int(position),
             "duration_ms": int(duration),
-            "progress_at": int(last_watched),
+            "progress_at": progress_at,
             "progress_percent": _progress_percent(int(position), int(duration)),
             "progress_key": str(row.get("progress_key") or progress_key(item) or "").strip(),
             "_nuvio_content_id": content_id,

--- a/providers/tests/test_nuvio_history.py
+++ b/providers/tests/test_nuvio_history.py
@@ -78,6 +78,58 @@ def test_history_reads_and_deletes_episode_with_official_key_shape() -> None:
     assert delete["p_keys"] == [{"content_id": "tmdb:1396", "season": 1, "episode": 1}]
 
 
+def test_history_index_exposes_watched_at_as_iso8601() -> None:
+    from providers.sync.nuvio import _history
+
+    adapter = FakeAdapter(
+        [
+            {
+                "content_id": "tmdb:1396",
+                "content_type": "series",
+                "title": "Breaking Bad",
+                "season": 1,
+                "episode": 1,
+                "watched_at": 1_785_000_000_000,
+            }
+        ]
+    )
+
+    item = _history.build_index(adapter)["tmdb:1396#s01e01"]
+
+    assert item["watched_at"] == "2026-07-25T17:20:00Z"
+
+
+def test_history_write_payload_sends_epoch_ms_for_iso_source_item() -> None:
+    from providers.sync.nuvio import _history
+
+    adapter = FakeAdapter([])
+    result = _history.add(adapter, [{"type": "movie", "ids": {"tmdb": "550"}, "title": "Fight Club", "watched_at": "2026-07-25T17:20:00Z"}])
+
+    assert result["ok"] is True
+    push = [body for name, body in adapter.client.calls if name == "sync_push_watched_items"][0]
+    assert push["p_items"][0]["watched_at"] == 1_785_000_000_000
+
+
+def test_history_skips_unchanged_when_index_is_iso_and_source_is_epoch_ms() -> None:
+    from providers.sync.nuvio import _history
+
+    adapter = FakeAdapter(
+        [
+            {
+                "content_id": "tmdb:550",
+                "content_type": "movie",
+                "title": "Fight Club",
+                "watched_at": 1_785_000_000_000,
+            }
+        ]
+    )
+
+    result = _history.add(adapter, [{"type": "movie", "ids": {"tmdb": "550"}, "title": "Fight Club", "watched_at": 1_785_000_000_000}])
+
+    assert result["skipped"] == 1
+    assert [name for name, _ in adapter.client.calls if name == "sync_push_watched_items"] == []
+
+
 def test_history_read_enriches_episode_code_title_from_tmdb(monkeypatch: Any) -> None:
     from providers.metadata import _meta_TMDB
     from providers.sync.nuvio import _history

--- a/providers/tests/test_nuvio_progress.py
+++ b/providers/tests/test_nuvio_progress.py
@@ -80,7 +80,7 @@ def test_build_index_maps_movies_and_skips_malformed_rows() -> None:
     assert item["ids"] == {"imdb": "tt1234567"}
     assert item["progress_ms"] == 120_000
     assert item["duration_ms"] == 600_000
-    assert item["progress_at"] == 1_785_000_000_000
+    assert item["progress_at"] == "2026-07-25T17:20:00Z"
     assert item["_nuvio_video_id"] == "tt1234567"
     assert item["progress_key"] == "tt1234567"
 
@@ -93,7 +93,7 @@ def test_build_index_merges_duplicate_movie_progress_by_newest_last_watched() ->
     index = _progress.build_index(adapter)
 
     assert index["tmdb:550"]["progress_ms"] == 20_000
-    assert index["tmdb:550"]["progress_at"] == 1_785_000_001_000
+    assert index["tmdb:550"]["progress_at"] == "2026-07-25T17:20:01Z"
 
 
 def test_build_index_enriches_series_progress_title_from_tmdb(monkeypatch: Any) -> None:
@@ -255,6 +255,32 @@ def test_add_is_idempotent_for_unchanged_progress_and_allows_newer_rewind() -> N
     assert rewind["attempted"] == 1
     assert rewind["confirmed_keys"] == ["tmdb:550"]
     assert _progress.build_index(adapter)["tmdb:550"]["progress_ms"] == 60_000
+
+
+def test_progress_write_payload_sends_epoch_ms_for_iso_source_item() -> None:
+    from providers.sync.nuvio import _progress
+
+    adapter = FakeAdapter([])
+    item = {"type": "movie", "ids": {"tmdb": "550"}, "progress_ms": 200_000, "duration_ms": 600_000, "progress_at": "2026-07-25T17:20:00Z"}
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is True
+    push = [body for name, body in adapter.client.calls if name == "sync_push_watch_progress"][0]
+    assert push["p_entries"][0]["last_watched"] == 1_785_000_000_000
+
+
+def test_progress_skips_unchanged_when_index_is_iso_and_source_is_epoch_ms() -> None:
+    from providers.sync.nuvio import _progress
+
+    adapter = FakeAdapter([_row("tmdb:550", position=120_000, duration=600_000, last_watched=1_785_000_000_000)])
+    item = {"type": "movie", "ids": {"tmdb": "550"}, "progress_ms": 120_000, "duration_ms": 600_000, "progress_at": 1_785_000_000_000}
+
+    result = _progress.add(adapter, [item])
+
+    assert result["attempted"] == 0
+    assert result["skipped"] == 1
+    assert not any(name == "sync_push_watch_progress" for name, _body in adapter.client.calls)
 
 
 def test_remove_deletes_by_progress_key_and_treats_missing_as_idempotent() -> None:


### PR DESCRIPTION
# Pull request

## Change

- Add iso_from_epoch_ms() to NUVIO _common.py
- NUVIO history index now emits ISO-8601 watched_at instead of epoch-ms
- NUVIO progress index does the same for progress_at
- RPC payloads stay on epoch-ms, which is what the API wants
- Update the NUVIO history/progress tests for the new index contract

## Why

NUVIO was the only provider putting an int epoch-ms into watched_at in the shared item shape.
Everything else emits an ISO string and SIMKL's history writer type-checks for one, so it threw the item out as missing_watched_at even though the timestamp was right there in state.json. 

The progress half is consistency, not a bug. Nothing breaks on the int today, but leaving one feature on ints after converting the other is asking for trouble later.

## Testing

- New tests both sides: index emits ISO, payload still sends ms.

## Issue

Relates to #559