### PR TITLE
Change: exact skipped add keys as handled

### DIFF
--- a/cw_platform/orchestrator/_applier.py
+++ b/cw_platform/orchestrator/_applier.py
@@ -257,7 +257,7 @@ def _normalize(
     skipped_reported_raw = res.get("skipped")
     skipped_exact = len(skeys)
     inferred_remainder = max(0, attempted - int(confirmed) - unresolved - errors)
-    exact_basis = bool(res.get("ambiguous")) or (tag == "apply:add" and bool(ckeys))
+    exact_basis = bool(res.get("ambiguous")) or (tag == "apply:add" and bool(ckeys or skeys))
     if exact_basis:
         skipped = skipped_exact
         skipped_inferred = 0

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -99,8 +99,10 @@ def compute_effective_add(
         eff = 0
     else:
         eff = len(conf) if (verify_after_write or have_exact_keys) else min(pc, len(conf))
-    success_keys = conf if (verify_after_write or have_exact_keys) else conf[:eff]
     skset = set(skipped_keys or set())
+    skipped_success = [k for k in (attempted_keys or []) if k in skset]
+    success_keys = conf if (verify_after_write or have_exact_keys) else conf[:eff]
+    success_keys = list(dict.fromkeys(list(success_keys) + skipped_success))
     sset = set(success_keys)
     failed_keys = [k for k in (attempted_keys or []) if k not in sset and k not in skset]
     return {
@@ -1548,7 +1550,7 @@ def run_one_way_feature(
 
             skipped_keys_set: set[str] = set(prov_skipped_keys)
 
-            have_exact_keys = bool(prov_confirmed_keys)
+            have_exact_keys = bool(prov_confirmed_keys or prov_skipped_keys)
             if have_exact_keys:
                 attempted_set = set(attempted_keys)
                 confirmed_keys = [k for k in prov_confirmed_keys if k in attempted_set]
@@ -1627,6 +1629,7 @@ def run_one_way_feature(
                 if success_keys and not ambiguous_partial:
                     record_success(dst, feature, success_keys, pair=pair_key, cfg=cfg)
                     clear_unresolved(dst, feature, success_keys)
+                    unresolved_new_total = max(0, unresolved_new_total - len(set(success_keys) & set(still_unresolved)))
                     resolved_keys = [k for k in success_keys if k in unresolved_before]
                     if resolved_keys:
                         _emit_item_resolutions(emit, dst, feature, pair_key, resolved_keys, key2item)

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -1887,7 +1887,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
 
             skipped_keys_A: set[str] = set(prov_skipped_keys_A)
 
-            have_exact_keys_A = bool(prov_confirmed_keys_A)
+            have_exact_keys_A = bool(prov_confirmed_keys_A or prov_skipped_keys_A)
             if have_exact_keys_A:
                 attempted_set_A = set(attempted_A)
                 confirmed_A = [k for k in prov_confirmed_keys_A if k in attempted_set_A]
@@ -1940,6 +1940,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                 if success_A:
                     record_success(a, feature, success_A, pair=pair_key, cfg=cfg)
                     clear_unresolved(a, feature, success_A)
+                    unresolved_new_A_total = max(0, unresolved_new_A_total - len(set(success_A) & set(still_unresolved_A)))
                     resolved_A = [k for k in success_A if k in unresolved_before_A]
                     if resolved_A:
                         _emit_item_resolutions(emit, a, feature, pair_key, resolved_A, k2i_A)
@@ -2019,7 +2020,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
 
             skipped_keys_B: set[str] = set(prov_skipped_keys_B)
 
-            have_exact_keys_B = bool(prov_confirmed_keys_B)
+            have_exact_keys_B = bool(prov_confirmed_keys_B or prov_skipped_keys_B)
             if have_exact_keys_B:
                 attempted_set_B = set(attempted_B)
                 confirmed_B = [k for k in prov_confirmed_keys_B if k in attempted_set_B]
@@ -2072,6 +2073,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                 if success_B:
                     record_success(b, feature, success_B, pair=pair_key, cfg=cfg)
                     clear_unresolved(b, feature, success_B)
+                    unresolved_new_B_total = max(0, unresolved_new_B_total - len(set(success_B) & set(still_unresolved_B)))
                     resolved_B = [k for k in success_B if k in unresolved_before_B]
                     if resolved_B:
                         _emit_item_resolutions(emit, b, feature, pair_key, resolved_B, k2i_B)


### PR DESCRIPTION
# Pull request

## Change

Treat provider-reported `skipped_keys` on add operations as exact handled no-ops.

Skipped keys now:
- do not count as added
- do not become unresolved fallback noise
- clear existing unresolved state for those exact keys

## Why

Some providers can say an item was skipped because it was already in the right state. 
That should be considered handled, not failed or unresolved.

## Testing

- Ran orchestrator/Stremio sync tests locally

## Issue

NA
