### PR TITLE
Add: Stremio to playback progress manager

### DIFF
--- a/assets/js/playback_progress.js
+++ b/assets/js/playback_progress.js
@@ -20,7 +20,7 @@
   const providerIcon = (provider) => {
     return `<img src="${esc(providerLogLogo(provider))}" alt="" onerror="this.remove()">`;
   };
-  const PLAYBACK_PROVIDER_KEYS = ["trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi"];
+  const PLAYBACK_PROVIDER_KEYS = ["trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio"];
   const DEFAULT_PROVIDER_TIMEOUT_SECONDS = 12;
   const state = {
     mounted: false,

--- a/services/playback_progress/adapters/stremio.py
+++ b/services/playback_progress/adapters/stremio.py
@@ -1,0 +1,268 @@
+# /services/playback_progress/adapters/stremio.py
+# CrossWatch - Stremio Playback Progress Adapter
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping, cast
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from providers.sync._mod_STREMIO import OPS as STREMIO_OPS
+from providers.sync.stremio._common import DEFAULT_STREMIO_PROFILE_ID
+
+from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
+from .base import PlaybackProgressAdapter, public_failure, tmdb_metadata_provider
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _num(value: Any) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(float(str(value).strip()))
+    except Exception:
+        return None
+
+
+def _float(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(str(value).strip())
+    except Exception:
+        return None
+
+
+def _iso(value: Any) -> str | None:
+    number = _num(value)
+    if number is not None:
+        seconds = number / 1000.0 if number > 10_000_000_000 else float(number)
+        return datetime.fromtimestamp(seconds, timezone.utc).isoformat().replace("+00:00", "Z")
+    text = str(value or "").strip()
+    return text or None
+
+
+def _progress_percent(item: Mapping[str, Any]) -> float | None:
+    direct = _float(item.get("progress_percent") or item.get("progress"))
+    if direct is not None:
+        return round(direct, 3)
+    position = _float(item.get("progress_ms") or item.get("position") or item.get("position_ms"))
+    duration = _float(item.get("duration_ms") or item.get("duration"))
+    if position is None or duration is None or duration <= 0:
+        return None
+    return round((position / duration) * 100.0, 3)
+
+
+def _duration_seconds(item: Mapping[str, Any]) -> int | None:
+    duration = _num(item.get("duration_ms") or item.get("duration"))
+    return max(1, round(duration / 1000)) if duration and duration > 0 else None
+
+
+def _remaining_seconds(item: Mapping[str, Any]) -> int | None:
+    duration = _num(item.get("duration_ms") or item.get("duration"))
+    position = _num(item.get("progress_ms") or item.get("position") or item.get("position_ms"))
+    if duration is None or position is None or duration <= 0:
+        return None
+    return max(0, round((duration - position) / 1000))
+
+
+def _progress_item(record: Mapping[str, Any]) -> dict[str, Any]:
+    meta = _mapping(record.get("provider_metadata"))
+    stored = meta.get("progress_item")
+    if isinstance(stored, Mapping):
+        return clean_mapping(stored)
+    media_type = str(record.get("media_type") or "").strip().lower()
+    item: dict[str, Any] = {
+        "type": "episode" if media_type in {"episode", "anime_episode"} else "movie",
+        "ids": clean_mapping(_mapping(record.get("ids"))),
+        "title": record.get("episode_title") or record.get("title") or record.get("series_title"),
+        "year": record.get("year"),
+    }
+    if item["type"] == "episode":
+        item["show_ids"] = clean_mapping(_mapping(meta.get("show_ids"))) or clean_mapping(_mapping(record.get("ids")))
+        item["series_title"] = record.get("series_title")
+        item["season"] = record.get("season")
+        item["episode"] = record.get("episode")
+    duration_seconds = _num(record.get("duration_seconds"))
+    if duration_seconds:
+        item["duration_ms"] = duration_seconds * 1000
+    return clean_mapping(item)
+
+
+def _progress_item_with_percent(record: Mapping[str, Any], progress_percent: float) -> dict[str, Any]:
+    item = _progress_item(record)
+    duration_ms = _num(item.get("duration_ms") or item.get("duration"))
+    if duration_ms is None:
+        duration_seconds = _num(record.get("duration_seconds"))
+        if duration_seconds:
+            duration_ms = duration_seconds * 1000
+    if duration_ms and duration_ms > 0:
+        item["duration_ms"] = duration_ms
+        item["progress_ms"] = max(1, min(duration_ms - 1, round((float(progress_percent) / 100.0) * float(duration_ms))))
+    else:
+        item["progress_percent"] = round(max(0.0, min(100.0, float(progress_percent))), 3)
+    item["progress_at"] = utc_now_iso()
+    return clean_mapping(item)
+
+
+def _image_url(meta: Mapping[str, Any], kind: str) -> str:
+    rows = _mapping(meta.get("images")).get(kind)
+    if not isinstance(rows, list):
+        return ""
+    for row in rows:
+        if isinstance(row, Mapping) and str(row.get("url") or "").strip():
+            return str(row.get("url") or "").strip()
+    return ""
+
+
+def _metadata_detail(provider: Any, *, media_type: str, ids: Mapping[str, Any], show_ids: Mapping[str, Any]) -> dict[str, Any]:
+    lookup_ids = show_ids if media_type == "episode" and show_ids else ids
+    fetch_ids = {key: str(lookup_ids.get(key) or "").strip() for key in ("tmdb", "imdb", "tvdb") if str(lookup_ids.get(key) or "").strip()}
+    if provider is None or not fetch_ids:
+        return {}
+    try:
+        detail = provider.fetch(entity="tv" if media_type == "episode" else "movie", ids=fetch_ids, need={"poster": True, "backdrop": True, "ids": False})
+    except Exception:
+        return {}
+    if not isinstance(detail, Mapping):
+        return {}
+    out: dict[str, Any] = {}
+    if str(detail.get("title") or "").strip():
+        out["title"] = str(detail.get("title") or "").strip()
+    if _num(detail.get("year")) is not None:
+        out["year"] = _num(detail.get("year"))
+    poster = _image_url(detail, "poster")
+    if poster:
+        out["poster_url"] = poster
+    backdrop = _image_url(detail, "backdrop")
+    if backdrop:
+        out["backdrop_url"] = backdrop
+    return out
+
+
+class StremioPlaybackAdapter(PlaybackProgressAdapter):
+    provider = "stremio"
+    provider_label = "Stremio"
+    ops = STREMIO_OPS
+    stremio_profile_id = DEFAULT_STREMIO_PROFILE_ID
+
+    def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
+        try:
+            configured = bool(STREMIO_OPS.is_configured(config_view))
+        except Exception:
+            configured = False
+        caps = _mapping(STREMIO_OPS.capabilities())
+        progress = _mapping(caps.get("progress"))
+        history = _mapping(caps.get("history"))
+        types = _mapping(progress.get("types"))
+        reason = "" if configured else "Stremio is not connected for this instance."
+        return PlaybackCapabilities(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            configured=configured,
+            read=bool(configured and progress),
+            remove_progress=bool(configured and progress.get("remove")),
+            mark_watched=bool(configured and history.get("upsert")),
+            update_progress=bool(configured and progress.get("upsert")),
+            bulk_remove_progress=bool(configured and progress.get("remove")),
+            bulk_mark_watched=bool(configured and history.get("upsert")),
+            bulk_update_progress=bool(configured and progress.get("upsert")),
+            supports_movies=bool(configured and types.get("movies")),
+            supports_episodes=bool(configured and types.get("episodes")),
+            supports_anime=False,
+            reason=reason,
+        )
+
+    def list_progress(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str, force_refresh: bool = False) -> PlaybackListResult:
+        caps = self.capabilities(config_view, instance_id=instance_id, instance_label=instance_label)
+        if not caps.read:
+            return PlaybackListResult(False, self.provider, instance_id, error_code="unsupported" if caps.configured else "not_configured", message=caps.reason or "Stremio does not support playback listing.")
+        try:
+            index = STREMIO_OPS.build_index(config_view, feature="progress") or {}
+        except Exception:
+            return PlaybackListResult(False, self.provider, instance_id, error_code="provider_error", message="Stremio progress request failed.", retryable=True)
+        metadata = tmdb_metadata_provider(config_view)
+        items = [self._record(key, item, instance_id, instance_label, caps, metadata) for key, item in dict(index).items() if isinstance(item, Mapping)]
+        return PlaybackListResult(True, self.provider, instance_id, items=[item for item in items if item], refreshed_at=utc_now_iso())
+
+    def _record(self, key: Any, item: Mapping[str, Any], instance_id: str, instance_label: str, caps: PlaybackCapabilities, metadata: Any = None) -> PlaybackRecord | None:
+        mini = id_minimal(item)
+        typ = str(mini.get("type") or item.get("type") or "").strip().lower()
+        media_type = "episode" if typ == "episode" else "movie"
+        ids = clean_mapping(_mapping(mini.get("ids") or item.get("ids")))
+        show_ids = clean_mapping(_mapping(mini.get("show_ids") or item.get("show_ids")))
+        title = str(mini.get("title") or item.get("title") or item.get("series_title") or "").strip()
+        series_title = str(mini.get("series_title") or item.get("series_title") or "").strip()
+        resolved = _metadata_detail(metadata, media_type=media_type, ids=ids, show_ids=show_ids) if not title or (media_type == "episode" and not series_title) or not item.get("poster") else {}
+        if resolved.get("title"):
+            if media_type == "episode" and not series_title:
+                series_title = str(resolved["title"])
+            if not title:
+                title = str(resolved["title"])
+        year = _num(mini.get("year") or item.get("year") or resolved.get("year"))
+        episode_title = title if media_type == "episode" and title != series_title else ""
+        canonical = canonical_key(mini) or str(key or "")
+        progress = _progress_percent(item)
+        if not canonical or progress is None:
+            return None
+        return PlaybackRecord(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            remote_id=str(item.get("_stremio_video_id") or item.get("_stremio_id") or item.get("stremio_id") or key or ""),
+            canonical_key=canonical,
+            media_type=media_type,
+            title=series_title or title,
+            episode_title=episode_title,
+            series_title=series_title,
+            season=_num(mini.get("season") or item.get("season")),
+            episode=_num(mini.get("episode") or item.get("episode")),
+            year=year,
+            ids=ids,
+            progress_percent=progress,
+            remaining_seconds=_remaining_seconds(item),
+            duration_seconds=_duration_seconds(item),
+            progress_at=_iso(item.get("progress_at") or item.get("last_watched")),
+            updated_at=_iso(item.get("progress_at") or item.get("last_watched")),
+            can_remove_progress=caps.remove_progress,
+            can_mark_watched=caps.mark_watched,
+            can_update_progress=bool(caps.update_progress and _duration_seconds(item)),
+            capability_messages=[] if caps.configured else [caps.reason],
+            poster_url=str(item.get("poster") or item.get("poster_url") or resolved.get("poster_url") or "").strip(),
+            backdrop_url=str(item.get("background") or item.get("backdrop") or item.get("backdrop_url") or resolved.get("backdrop_url") or "").strip(),
+            provider_metadata={"progress_item": clean_mapping(item), "show_ids": show_ids, "stremio_profile_id": self.stremio_profile_id},
+        )
+
+    def remove_progress(self, config_view: Mapping[str, Any], record: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackActionResult:
+        item = _progress_item(record)
+        try:
+            result = STREMIO_OPS.remove(config_view, [item], feature="progress", dry_run=False) or {}
+            ok = bool(result.get("ok"))
+            return PlaybackActionResult(ok, self.provider, instance_id, "remove_progress", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), message="Playback record removed." if ok else "Stremio remove progress failed.", error_code="" if ok else "progress_failed", decision_context=clean_mapping(result))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Stremio remove progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+
+    def mark_watched(self, config_view: Mapping[str, Any], record: Mapping[str, Any], *, instance_id: str, instance_label: str, watched_at: str | None = None) -> PlaybackActionResult:
+        item = _progress_item(record)
+        item["watched_at"] = watched_at or utc_now_iso()
+        try:
+            result = STREMIO_OPS.add(config_view, [item], feature="history", dry_run=False) or {}
+            ok = bool(result.get("ok"))
+            return PlaybackActionResult(ok, self.provider, instance_id, "mark_watched", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), message="Marked watched on Stremio." if ok else "Stremio mark watched failed.", error_code="" if ok else "history_failed", history_result=clean_mapping(result))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="mark_watched", message="Stremio mark watched failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+
+    def update_progress(self, config_view: Mapping[str, Any], record: Mapping[str, Any], progress_percent: float, *, instance_id: str, instance_label: str) -> PlaybackActionResult:
+        item = _progress_item_with_percent(record, progress_percent)
+        try:
+            result = STREMIO_OPS.add(config_view, [item], feature="progress", dry_run=False) or {}
+            ok = bool(result.get("ok"))
+            return PlaybackActionResult(ok, self.provider, instance_id, "update_progress", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), message=f"Progress updated on Stremio to {progress_percent:g}%." if ok else "Stremio update progress failed.", error_code="" if ok else "progress_failed", decision_context=clean_mapping(result))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message="Stremio update progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -24,6 +24,7 @@ from .adapters.mdblist import MDBListPlaybackAdapter
 from .adapters.nuvio import NuvioPlaybackAdapter
 from .adapters.publicmetadb import PublicMetaDBPlaybackAdapter
 from .adapters.simkl import SimklPlaybackAdapter
+from .adapters.stremio import StremioPlaybackAdapter
 from .adapters.trakt import TraktPlaybackAdapter
 from .models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, clean_mapping, utc_now_iso
 
@@ -33,7 +34,7 @@ CACHE_TTL_SECONDS = 60.0
 MAX_WORKERS = 6
 DEFAULT_PROVIDER_TIMEOUT_SECONDS = 12.0
 GROUP_PROGRESS_TOLERANCE = 2.0
-PHASE1_PROVIDERS = ("trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi")
+PHASE1_PROVIDERS = ("trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio")
 SORT_VALUES = {"last_updated", "progress_high", "progress_low", "remaining_time", "rating_high", "title", "provider"}
 LIVE_MEDIA_PROVIDERS = {"plex", "emby", "jellyfin", "kodi"}
 LIVE_ACTIVE_STATES = {"playing", "paused", "buffering"}
@@ -673,6 +674,7 @@ def _instance_label(cfg: Mapping[str, Any], provider: str, instance_id: str) -> 
         "jellyfin": "Jellyfin",
         "nuvio": "Nuvio",
         "kodi": "Kodi",
+        "stremio": "Stremio",
     }.get(provider, provider)
     if label.lower() == "default":
         return f"{provider_label} Default"
@@ -724,6 +726,7 @@ def _profile_has_explicit_identity(cfg: Mapping[str, Any], provider: str, instan
         "jellyfin": ("access_token", "user_id"),
         "nuvio": ("access_token", "refresh_token", "profile_id"),
         "kodi": ("server", "server_url", "connection_verified", "username"),
+        "stremio": ("auth_key", "authKey"),
     }.get(str(provider or "").strip().lower(), ())
     return any(str(_path_value(raw, path) or "").strip() for path in identity_paths)
 
@@ -793,8 +796,9 @@ class PlaybackProgressService:
             "jellyfin": JellyfinPlaybackAdapter(),
             "nuvio": NuvioPlaybackAdapter(),
             "kodi": KodiPlaybackAdapter(),
+            "stremio": StremioPlaybackAdapter(),
         }
-        self._cache: dict[tuple[str, str], dict[str, Any]] = {}
+        self._cache: dict[tuple[str, str, str], dict[str, Any]] = {}
         self._lock = threading.RLock()
 
     def _adapter(self, provider: str) -> PlaybackProgressAdapter | None:
@@ -832,7 +836,7 @@ class PlaybackProgressService:
                 cap.included = _profile_included(config, provider, spec["instance_id"])
                 if not cap.included:
                     cap.reason = "Excluded from Playback Progress."
-                cached = self._cache.get((provider, spec["instance_id"]))
+                cached = self._cache.get(self._cache_key(provider, spec["instance_id"], adapter))
                 if cached:
                     cap.last_refresh = cached.get("refreshed_at")
                     err = cached.get("error")
@@ -854,12 +858,16 @@ class PlaybackProgressService:
                 )
         return out
 
-    def _cache_key(self, provider: str, instance_id: str) -> tuple[str, str]:
-        return (str(provider).lower(), normalize_instance_id(instance_id))
+    def _cache_key(self, provider: str, instance_id: str, adapter: PlaybackProgressAdapter | None = None) -> tuple[str, str, str]:
+        prov = str(provider).lower()
+        profile = str(getattr(adapter, "stremio_profile_id", "default") if prov == "stremio" else "default").strip() or "default"
+        return (prov, normalize_instance_id(instance_id), profile)
 
     def invalidate(self, provider: str, instance_id: str) -> None:
         with self._lock:
-            self._cache.pop(self._cache_key(provider, instance_id), None)
+            prefix = (str(provider).lower(), normalize_instance_id(instance_id))
+            for key in [key for key in self._cache if key[:2] == prefix]:
+                self._cache.pop(key, None)
         LOG.debug(f"cache invalidated provider={provider} instance={normalize_instance_id(instance_id)}")
 
     def _activity_marker(self, adapter: PlaybackProgressAdapter, config_view: Mapping[str, Any], *, instance_id: str) -> str:
@@ -898,7 +906,7 @@ class PlaybackProgressService:
                 message=cap.reason or "Provider does not support playback listing.",
             )
 
-        key = self._cache_key(provider, instance_id)
+        key = self._cache_key(provider, instance_id, adapter)
         now = time.time()
         with self._lock:
             cached = self._cache.get(key)

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 from services.playback_progress.service import (
     _combine_records,
@@ -13,8 +14,10 @@ from services.playback_progress.service import (
     PlaybackProgressService,
 )
 from services.playback_progress.models import PlaybackCapabilities
+from services.playback_progress.adapters.base import PlaybackProgressAdapter
 import services.playback_progress.service as playback_service
 import services.playback_progress.adapters.nuvio as nuvio_playback_adapter
+import services.playback_progress.adapters.stremio as stremio_playback_adapter
 from services.playback_progress.adapters.media_servers import JellyfinPlaybackAdapter, KodiPlaybackAdapter
 from services.playback_progress.adapters.trakt import _trakt_image_url
 
@@ -68,7 +71,7 @@ def test_playback_bulk_footer_uses_wide_management_layout():
 def test_playback_progress_frontend_includes_kodi_provider_key():
     js = (ROOT / "assets" / "js" / "playback_progress.js").read_text(encoding="utf-8")
 
-    assert 'const PLAYBACK_PROVIDER_KEYS = ["trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi"];' in js
+    assert 'const PLAYBACK_PROVIDER_KEYS = ["trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio"];' in js
 
 
 class _PolicyOps:
@@ -79,7 +82,9 @@ class _PolicyOps:
         return {"progress": self._progress_caps}
 
 
-class _PolicyAdapter:
+class _PolicyAdapter(PlaybackProgressAdapter):
+    ops: _PolicyOps
+
     def __init__(self, progress_caps):
         self.ops = _PolicyOps(progress_caps)
 
@@ -372,7 +377,7 @@ def test_playback_progress_settings_reports_disabled_profiles_and_clamped_timeou
     assert by_key["trakt:TRAKT-P01"]["included"] is False
 
 
-class _UnreadPlaybackAdapter:
+class _UnreadPlaybackAdapter(PlaybackProgressAdapter):
     provider = "trakt"
     provider_label = "Trakt"
 
@@ -509,7 +514,7 @@ def test_playback_progress_includes_kodi_provider(monkeypatch):
     monkeypatch.setattr(playback_service, "load_config", lambda: cfg)
 
     service = PlaybackProgressService()
-    service.adapters["kodi"].ops = kodi_ops
+    cast(KodiPlaybackAdapter, service.adapters["kodi"]).ops = kodi_ops
     providers = service.provider_instances(cfg)
     result = service.items(provider="kodi", force_refresh=True)
     record = result["items"][0]
@@ -700,6 +705,106 @@ def test_nuvio_playback_progress_enriches_missing_episode_metadata_from_content_
     assert record.year == 2019
     assert record.poster_url == "https://image.tmdb.org/t/p/w342/poster.jpg"
     assert record.backdrop_url == "https://image.tmdb.org/t/p/w780/backdrop.jpg"
+
+
+class _FakeStremioOps:
+    def __init__(self) -> None:
+        self.added = []
+        self.removed = []
+
+    def capabilities(self):
+        return {
+            "progress": {
+                "types": {"movies": True, "episodes": True},
+                "upsert": True,
+                "remove": True,
+            },
+            "history": {"upsert": True},
+        }
+
+    def is_configured(self, cfg):
+        return bool(cfg.get("stremio", {}).get("auth_key"))
+
+    def build_index(self, cfg, *, feature):
+        assert feature == "progress"
+        return {
+            "imdb:tt0903747#s01e02": {
+                "type": "episode",
+                "ids": {"imdb": "tt0903747"},
+                "show_ids": {"imdb": "tt0903747"},
+                "series_title": "Breaking Bad",
+                "season": 1,
+                "episode": 2,
+                "_stremio_id": "tt0903747",
+                "_stremio_video_id": "tt0903747:1:2",
+                "progress_ms": 120000,
+                "duration_ms": 600000,
+                "progress_at": "2026-07-30T20:00:00Z",
+                "poster": "https://image.example/breaking-bad.jpg",
+            }
+        }
+
+    def remove(self, cfg, items, *, feature, dry_run=False):
+        self.removed.extend(items)
+        return {"ok": True, "count": len(items), "feature": feature}
+
+    def add(self, cfg, items, *, feature, dry_run=False):
+        self.added.append((feature, list(items)))
+        return {"ok": True, "count": len(items), "feature": feature}
+
+
+def test_playback_progress_uses_stremio_adapter(monkeypatch):
+    stremio_ops = _FakeStremioOps()
+    cfg = {"stremio": {"auth_key": "secret"}}
+
+    monkeypatch.setattr(stremio_playback_adapter, "STREMIO_OPS", stremio_ops)
+    monkeypatch.setattr(playback_service, "load_config", lambda: cfg)
+
+    service = PlaybackProgressService()
+    providers = service.provider_instances(cfg)
+    result = service.items(provider="stremio", force_refresh=True)
+    record = result["items"][0]
+
+    assert {"provider": "stremio", "instance_id": "default", "instance_label": "Stremio Default"} in providers
+    assert result["errors"] == []
+    assert record["provider"] == "stremio"
+    assert record["provider_label"] == "Stremio"
+    assert record["remote_id"] == "tt0903747:1:2"
+    assert record["progress_percent"] == 20.0
+    assert record["poster_url"] == "https://image.example/breaking-bad.jpg"
+    assert record["provider_metadata"]["stremio_profile_id"] == "default"
+    assert ("stremio", "default", "default") in service._cache
+
+    service.remove({"provider": "stremio", "instance_id": "default", "record": record})
+    service.mark_watched({"provider": "stremio", "instance_id": "default", "record": record})
+    service.update_progress({"provider": "stremio", "instance_id": "default", "record": record, "progress_percent": 25})
+
+    assert stremio_ops.removed[0]["_stremio_video_id"] == "tt0903747:1:2"
+    assert stremio_ops.added[0][0] == "history"
+    assert stremio_ops.added[1][0] == "progress"
+    assert stremio_ops.added[1][1][0]["progress_ms"] == 150000
+
+
+def test_stremio_playback_progress_update_allows_percent_only(monkeypatch):
+    stremio_ops = _FakeStremioOps()
+    monkeypatch.setattr(stremio_playback_adapter, "STREMIO_OPS", stremio_ops)
+    record = {
+        "media_type": "episode",
+        "title": "Love & Death",
+        "series_title": "Love & Death",
+        "season": 1,
+        "episode": 7,
+        "ids": {"tmdb": "124800"},
+        "canonical_key": "tmdb:124800#s01e07",
+        "provider_metadata": {"show_ids": {"tmdb": "124800"}},
+    }
+
+    result = stremio_playback_adapter.StremioPlaybackAdapter().update_progress({"stremio": {"auth_key": "secret"}}, record, 10.63, instance_id="default", instance_label="Stremio Default")
+
+    assert result.ok is True
+    assert stremio_ops.added[0][0] == "progress"
+    assert stremio_ops.added[0][1][0]["progress_percent"] == 10.63
+    assert "progress_ms" not in stremio_ops.added[0][1][0]
 
 
 def test_nuvio_playback_progress_enriches_episode_metadata_from_tvdb_id(monkeypatch):


### PR DESCRIPTION
# Pull request

## Change

Adds Stremio support to the playback progress manager.

This adds Stremio into the Continue Watching provider list and adds a playback adapter for listing, clearing, marking watched, and updating resume progress through the existing Stremio sync module.

## Why

Stremio progress sync works through the provider adapter, but the playback progress manager also needs its own adapter to show and manage Stremio resume items in the UI.

## Testing

- Added playback progress tests for Stremio
- Ran playback progress tests locally

## Issue

NA