### PR TITLE
Change: ignore Kodi baselines in capture

### DIFF
--- a/providers/sync/kodi/_common.py
+++ b/providers/sync/kodi/_common.py
@@ -422,7 +422,13 @@ def _progress_signature(item: Mapping[str, Any]) -> tuple[int | None, int | None
     )
 
 
+def _is_capture_mode() -> bool:
+    return str(os.getenv("CW_CAPTURE_MODE") or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _load_kodi_feature_baseline(adapter: Any, feature: str) -> Mapping[str, Mapping[str, Any]]:
+    if _is_capture_mode():
+        return {}
     name = str(feature or "").strip().lower()
     injected = getattr(adapter, f"_kodi_{name}_baseline", None)
     if isinstance(injected, Mapping):

--- a/tests/test_kodi_timezone.py
+++ b/tests/test_kodi_timezone.py
@@ -194,6 +194,33 @@ def test_kodi_ratings_keep_prior_timestamp_when_rating_is_unchanged(monkeypatch)
     assert row["rated_at_source"] == "kodi_first_observed"
 
 
+def test_kodi_capture_mode_ignores_synthetic_timestamp_baseline(monkeypatch) -> None:
+    from providers.sync.kodi import _common
+    from providers.sync.kodi._common import KodiConfig, feature_index
+
+    monkeypatch.setenv("CW_CAPTURE_MODE", "1")
+    monkeypatch.setattr(_common, "_utc_now_iso", lambda: "2026-07-29T00:47:01Z")
+    adapter = SimpleNamespace(
+        cfg=KodiConfig(server="http://kodi.local:8080"),
+        client=_FakeKodiClient(),
+        _kodi_library_index_ratings=_rated_movie_index(7),
+        _kodi_ratings_baseline={
+            "tmdb:329865": {
+                "type": "movie",
+                "ids": {"tmdb": "329865"},
+                "rating": 7,
+                "rated_at": "2026-07-28T10:00:00Z",
+                "rated_at_source": "kodi_first_observed",
+            }
+        },
+    )
+
+    row = feature_index(adapter, "ratings")["tmdb:329865"]
+
+    assert row["rated_at"] == "2026-07-29T00:47:01Z"
+    assert row["rated_at_source"] == "kodi_first_observed"
+
+
 def test_kodi_ratings_update_timestamp_when_rating_changes(monkeypatch) -> None:
     from providers.sync.kodi import _common
     from providers.sync.kodi._common import KodiConfig, feature_index


### PR DESCRIPTION
# Pull request

## Change

Make Kodi ignore stored feature baselines while CW is running in capture mode.

## Why

Capture/snapshot runs should reflect the live provider state. 
Reusing the saved Kodi baseline there can hide real provider data and make captures look stale.

## Testing

- added coverage for Kodi capture mode baseline behavior.

## Issue

NA