### PR TITLE
Add: Stremio sync adapter

### DIFF
--- a/providers/sync/_mod_STREMIO.py
+++ b/providers/sync/_mod_STREMIO.py
@@ -1,0 +1,231 @@
+# providers/sync/_mod_STREMIO.py
+# CrossWatch Stremio sync module
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from cw_platform.provider_instances import normalize_instance_id
+from providers.auth._auth_STREMIO import StremioClient, StremioAuthError
+from providers.sync._mod_common import SimpleRateLimiter, build_op_result, build_session
+from providers.sync.stremio import _history as feat_history
+from providers.sync.stremio import _progress as feat_progress
+from providers.sync.stremio import _ratings as feat_ratings
+from providers.sync.stremio import _watchlist as feat_watchlist
+from providers.sync.stremio._common import DEFAULT_STREMIO_PROFILE_ID, datastore_meta, is_configured
+
+__VERSION__ = "0.1"
+__all__ = ["get_manifest", "STREMIOModule", "OPS", "feat_history", "feat_progress", "feat_ratings", "feat_watchlist"]
+
+if "ctx" not in globals():
+    class _NullCtx:
+        def emit(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    ctx = _NullCtx()  # type: ignore[assignment]
+
+
+_FEATURES = {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False}
+_FEATURE_MODULES = {"history": feat_history, "progress": feat_progress, "ratings": feat_ratings, "watchlist": feat_watchlist}
+
+
+def _detail_text(value: Any) -> str:
+    text = str(value or "").replace("\n", " ").replace("\r", " ").strip()
+    for token in ("authKey", "auth_key", "password"):
+        text = text.replace(token, f"{token[0]}***")
+    return text[:180]
+
+
+def _error_api(exc: StremioAuthError | None, status: str) -> dict[str, Any]:
+    out: dict[str, Any] = {"status": getattr(exc, "status_code", None) or status}
+    endpoint = str(getattr(exc, "endpoint", "") or "").strip()
+    if endpoint:
+        out["endpoint"] = endpoint
+    detail = _detail_text(getattr(exc, "detail", None))
+    if detail:
+        out["detail"] = detail
+    return out
+
+
+def _current_instance_id() -> str:
+    if str(os.getenv("CW_PROBE_PROVIDER") or "").upper().strip() == "STREMIO":
+        return normalize_instance_id(os.getenv("CW_PROBE_INSTANCE"))
+    if str(os.getenv("CW_PAIR_SRC") or "").upper().strip() == "STREMIO":
+        return normalize_instance_id(os.getenv("CW_PAIR_SRC_INSTANCE"))
+    if str(os.getenv("CW_PAIR_DST") or "").upper().strip() == "STREMIO":
+        return normalize_instance_id(os.getenv("CW_PAIR_DST_INSTANCE"))
+    return "default"
+
+
+def get_manifest() -> Mapping[str, Any]:
+    return {
+        "name": "STREMIO",
+        "label": "Stremio",
+        "version": __VERSION__,
+        "type": "sync",
+        "bidirectional": True,
+        "experimental": True,
+        "features": dict(_FEATURES),
+        "requires": ["requests"],
+        "capabilities": {
+            "bidirectional": True,
+            "experimental": True,
+            "provides_ids": True,
+            "index_semantics": "present",
+            "multi_profile": False,
+            "features": dict(_FEATURES),
+            "history": {
+                "read": True,
+                "write": True,
+                "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+                "upsert": True,
+                "remove": True,
+                "observed_deletes": True,
+                "requires_ids": ["imdb"],
+            },
+            "watchlist": {
+                "read": True,
+                "write": True,
+                "types": {"movies": True, "shows": True, "seasons": False, "episodes": False},
+                "upsert": True,
+                "remove": True,
+                "observed_deletes": True,
+                "requires_ids": ["imdb"],
+                "custom_lists": False,
+            },
+            "ratings": {
+                "read": False,
+                "write": True,
+                "types": {"movies": True, "shows": True, "seasons": False, "episodes": False},
+                "upsert": True,
+                "remove": True,
+                "observed_deletes": False,
+                "accepted_ids": ["imdb"],
+                "mode": "stremio_reactions",
+                "direction": "destination_only",
+                "thresholds": {"liked_min": 6.0, "loved_min": 8.0},
+            },
+            "progress": {
+                "read": True,
+                "write": True,
+                "index_semantics": "present",
+                "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+                "upsert": True,
+                "remove": True,
+                "observed_deletes": True,
+                "requires_ids": ["imdb"],
+                "requires_duration": True,
+                "completion_policy": {"progress_write": {"mode": "none"}},
+            },
+        },
+    }
+
+
+class STREMIOModule:
+    def __init__(self, cfg: Mapping[str, Any]):
+        self.config = cfg or {}
+        self.instance_id = _current_instance_id()
+        self.stremio_profile_id = DEFAULT_STREMIO_PROFILE_ID
+        session = build_session("STREMIO", ctx)
+        try:
+            session._rate_limiter = SimpleRateLimiter(rates_per_sec={"GET": 20.0, "POST": 20.0})
+            session._rate_limiter_meta = {"get_per_sec": 20.0, "post_per_sec": 20.0}
+        except Exception:
+            pass
+        self.client = StremioClient(self.config, instance_id=self.instance_id, session=session)
+
+    @staticmethod
+    def supported_features() -> dict[str, bool]:
+        return dict(_FEATURES)
+
+    def manifest(self) -> Mapping[str, Any]:
+        return get_manifest()
+
+    def health(self) -> Mapping[str, Any]:
+        start = time.perf_counter()
+        ok = False
+        status = "not_configured"
+        reason = None
+        api: dict[str, Any] = {}
+        try:
+            if not is_configured(self.config, self.instance_id):
+                reason = "missing_authentication"
+            else:
+                datastore_meta(self)
+                ok = True
+                status = "ok"
+                api["datastoreMeta"] = {"status": 200}
+        except StremioAuthError as exc:
+            reason = str(getattr(exc, "reason", "error") or "error")
+            status = "auth_failed" if reason in {"missing_auth_key", "invalid_credentials"} else reason
+            api["datastoreMeta"] = _error_api(exc, status)
+        except Exception:
+            status = "service_unavailable"
+            reason = "service_unavailable"
+            api["datastoreMeta"] = {"status": status}
+        if not ok:
+            try:
+                ctx.emit("debug", msg="stremio.health.failed", status=status, reason=reason, api=api)
+            except Exception:
+                pass
+        return {
+            "ok": ok,
+            "status": status,
+            "latency_ms": int((time.perf_counter() - start) * 1000),
+            "features": {name: bool(ok and enabled) for name, enabled in _FEATURES.items()},
+            "details": {"reason": reason} if reason else None,
+            "api": api,
+        }
+
+    def build_index(self, feature: str, **kwargs: Any) -> Mapping[str, dict[str, Any]]:
+        mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
+        return mod.build_index(self, **kwargs) if mod else {}
+
+    def add(self, feature: str, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+        mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
+        return mod.add(self, items, dry_run=dry_run) if mod else build_op_result(ok=True, count=0, unsupported=True)
+
+    def remove(self, feature: str, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+        mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
+        return mod.remove(self, items, dry_run=dry_run) if mod else build_op_result(ok=True, count=0, unsupported=True)
+
+
+class _STREMIOOPS:
+    def name(self) -> str:
+        return "STREMIO"
+
+    def label(self) -> str:
+        return "Stremio"
+
+    def features(self) -> Mapping[str, bool]:
+        return dict(_FEATURES)
+
+    def state_read_features(self) -> Mapping[str, bool]:
+        return dict(_FEATURES)
+
+    def capabilities(self) -> Mapping[str, Any]:
+        return get_manifest()["capabilities"]
+
+    def is_configured(self, cfg: Mapping[str, Any]) -> bool:
+        return is_configured(cfg, "default")
+
+    def _adapter(self, cfg: Mapping[str, Any]) -> STREMIOModule:
+        return STREMIOModule(cfg)
+
+    def health(self, cfg: Mapping[str, Any]) -> Mapping[str, Any]:
+        return self._adapter(cfg).health()
+
+    def build_index(self, cfg: Mapping[str, Any], *, feature: str) -> Mapping[str, dict[str, Any]]:
+        return self._adapter(cfg).build_index(feature)
+
+    def add(self, cfg: Mapping[str, Any], items: Iterable[Mapping[str, Any]], *, feature: str, dry_run: bool = False) -> dict[str, Any]:
+        return self._adapter(cfg).add(feature, items, dry_run=dry_run)
+
+    def remove(self, cfg: Mapping[str, Any], items: Iterable[Mapping[str, Any]], *, feature: str, dry_run: bool = False) -> dict[str, Any]:
+        return self._adapter(cfg).remove(feature, items, dry_run=dry_run)
+
+
+OPS = _STREMIOOPS()

--- a/providers/sync/stremio/__init__.py
+++ b/providers/sync/stremio/__init__.py
@@ -1,0 +1,5 @@
+# providers/sync/stremio/__init__.py
+# CrossWatch Stremio sync package
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+

--- a/providers/sync/stremio/_common.py
+++ b/providers/sync/stremio/_common.py
@@ -1,0 +1,301 @@
+# providers/sync/stremio/_common.py
+# CrossWatch Stremio sync helpers
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+import copy
+import os
+import time
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+from cw_platform.id_map import canonical_key, ids_from, merge_ids, minimal as id_minimal
+from cw_platform.provider_instances import get_provider_block
+from providers.auth._auth_STREMIO import is_configured as auth_is_configured
+
+COLLECTION = "libraryItem"
+DEFAULT_STREMIO_PROFILE_ID = "default"
+
+
+def is_capture_mode() -> bool:
+    return str(os.getenv("CW_CAPTURE_MODE") or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def configured_block(cfg: Mapping[str, Any] | None, instance_id: Any = "default") -> dict[str, Any]:
+    return get_provider_block(cfg or {}, "stremio", instance_id)
+
+
+def is_configured(cfg: Mapping[str, Any] | None, instance_id: Any = "default") -> bool:
+    return auth_is_configured(configured_block(cfg, instance_id))
+
+
+def stremio_profile_id(adapter: Any = None) -> str:
+    value = getattr(adapter, "stremio_profile_id", DEFAULT_STREMIO_PROFILE_ID) if adapter is not None else DEFAULT_STREMIO_PROFILE_ID
+    return str(value or DEFAULT_STREMIO_PROFILE_ID).strip() or DEFAULT_STREMIO_PROFILE_ID
+
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def now_iso() -> str:
+    return iso_from_epoch_ms(now_ms()) or datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def to_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(float(str(value).strip()))
+    except Exception:
+        return None
+
+
+def positive_int(value: Any) -> int | None:
+    number = to_int(value)
+    return number if number is not None and number > 0 else None
+
+
+def epoch_ms(value: Any) -> int | None:
+    number = to_int(value)
+    if number is not None:
+        return number * 1000 if 0 < number < 10_000_000_000 else number
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        return int(parsed.timestamp() * 1000)
+    except Exception:
+        return None
+
+
+def iso_from_epoch_ms(value: Any) -> str | None:
+    ms = epoch_ms(value)
+    if ms is None:
+        return None
+    try:
+        return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    except Exception:
+        return None
+
+
+def imdb_id(value: Any) -> str | None:
+    raw = str(value or "").strip()
+    if raw.startswith("tt") and raw[2:].isdigit():
+        return raw
+    return None
+
+
+def imdb_ids_from_item(item: Mapping[str, Any]) -> dict[str, str]:
+    ids = merge_ids(ids_from(item), ids_from(id_minimal(item)))
+    show_ids = item.get("show_ids")
+    if isinstance(show_ids, Mapping):
+        ids = merge_ids(ids, {str(k): v for k, v in show_ids.items()})
+    direct = imdb_id(item.get("_stremio_id") or item.get("stremio_id") or item.get("content_id"))
+    if direct:
+        ids["imdb"] = direct
+    return ids
+
+
+def stremio_id_for_item(item: Mapping[str, Any]) -> str | None:
+    direct = imdb_id(item.get("_stremio_id") or item.get("stremio_id") or item.get("content_id"))
+    if direct:
+        return direct
+    if str(item.get("type") or "").strip().lower() in {"episode", "episodes"}:
+        show_ids = item.get("show_ids")
+        if isinstance(show_ids, Mapping):
+            direct = imdb_id(show_ids.get("imdb"))
+            if direct:
+                return direct
+    return imdb_id(imdb_ids_from_item(item).get("imdb"))
+
+
+def video_id_for_episode(item: Mapping[str, Any], show_id: str) -> str | None:
+    direct = str(item.get("_stremio_video_id") or item.get("video_id") or "").strip()
+    if direct:
+        return direct
+    season = positive_int(item.get("season"))
+    episode = positive_int(item.get("episode"))
+    return f"{show_id}:{season}:{episode}" if season and episode else None
+
+
+def tmdb_metadata_provider(adapter: Any) -> Any | None:
+    cached = getattr(adapter, "_stremio_tmdb_provider", None)
+    if cached is not None:
+        return cached
+    cfg = getattr(adapter, "config", None) or getattr(adapter, "raw_cfg", None) or {}
+    if not isinstance(cfg, Mapping):
+        return None
+    tmdb_raw = cfg.get("tmdb")
+    metadata_raw = cfg.get("metadata")
+    tmdb: Mapping[str, Any] = tmdb_raw if isinstance(tmdb_raw, Mapping) else {}
+    metadata: Mapping[str, Any] = metadata_raw if isinstance(metadata_raw, Mapping) else {}
+    if not str(tmdb.get("api_key") or metadata.get("tmdb_api_key") or "").strip():
+        return None
+    try:
+        from providers.metadata._meta_TMDB import TmdbProvider
+
+        provider = TmdbProvider(lambda: dict(cfg), lambda _cfg: None)
+        setattr(adapter, "_stremio_tmdb_provider", provider)
+        return provider
+    except Exception:
+        return None
+
+
+def canonical_item_key(item: Mapping[str, Any]) -> str:
+    return canonical_key(id_minimal(item))
+
+
+def state_of(record: Mapping[str, Any]) -> Mapping[str, Any]:
+    state = record.get("state")
+    return state if isinstance(state, Mapping) else {}
+
+
+def record_id(record: Mapping[str, Any]) -> str:
+    return str(record.get("_id") or "").strip()
+
+
+def _extract_records(data: Any) -> list[Mapping[str, Any]]:
+    source = data.get("result") if isinstance(data, Mapping) and "result" in data else data
+    if isinstance(source, list):
+        return [row for row in source if isinstance(row, Mapping)]
+    if isinstance(source, Mapping):
+        if isinstance(source.get("items"), list):
+            return [row for row in source["items"] if isinstance(row, Mapping)]
+        if isinstance(source.get(COLLECTION), list):
+            return [row for row in source[COLLECTION] if isinstance(row, Mapping)]
+        if all(isinstance(v, Mapping) for v in source.values()):
+            return [v for v in source.values() if isinstance(v, Mapping)]
+    return []
+
+
+def datastore_get(adapter: Any, *, ids: list[str] | None = None, all_records: bool = False) -> list[Mapping[str, Any]]:
+    payload: dict[str, Any] = {"collection": COLLECTION, "ids": list(ids or [])}
+    if all_records:
+        payload["all"] = True
+    return _extract_records(adapter.client.request_json("datastoreGet", payload))
+
+
+def datastore_meta(adapter: Any) -> list[Mapping[str, Any]]:
+    return _extract_records(adapter.client.request_json("datastoreMeta", {"collection": COLLECTION}))
+
+
+def datastore_put(adapter: Any, changes: list[Mapping[str, Any]]) -> Any:
+    return adapter.client.request_json("datastorePut", {"collection": COLLECTION, "changes": [dict(x) for x in changes]})
+
+
+def library_records(adapter: Any, *, incremental: bool = False) -> list[Mapping[str, Any]]:
+    cache_attr = f"_stremio_mtime_cache_{stremio_profile_id(adapter)}"
+    if is_capture_mode():
+        return datastore_get(adapter, ids=[], all_records=True)
+    if not incremental:
+        rows = datastore_get(adapter, ids=[], all_records=True)
+        setattr(adapter, cache_attr, {record_id(row): epoch_ms(row.get("_mtime")) or 0 for row in rows if record_id(row)})
+        return rows
+    meta = datastore_meta(adapter)
+    old = getattr(adapter, cache_attr, {})
+    old_map = old if isinstance(old, Mapping) else {}
+    changed = [record_id(row) for row in meta if record_id(row) and (epoch_ms(row.get("_mtime")) or 0) > (to_int(old_map.get(record_id(row))) or 0)]
+    if not changed:
+        return []
+    rows = datastore_get(adapter, ids=changed, all_records=False)
+    new_map = dict(old_map)
+    for row in meta:
+        rid = record_id(row)
+        if rid:
+            new_map[rid] = epoch_ms(row.get("_mtime")) or 0
+    setattr(adapter, cache_attr, new_map)
+    return rows
+
+
+def default_record(stremio_id: str, item_type: str, item: Mapping[str, Any] | None = None, *, timestamp: Any = None) -> dict[str, Any]:
+    ts = iso_from_epoch_ms(timestamp) or now_iso()
+    typ = "series" if item_type in {"series", "show", "episode", "episodes"} else "movie"
+    src = item or {}
+    poster = str(src.get("poster") or src.get("poster_url") or src.get("posterUrl") or "").strip()
+    poster_value = poster if poster.startswith(("http://", "https://")) else ""
+    return {
+        "_id": stremio_id,
+        "name": str(src.get("series_title") or src.get("show_title") or src.get("title") or stremio_id),
+        "type": typ,
+        "poster": poster_value,
+        "posterShape": src.get("poster_shape") or "poster",
+        "removed": True,
+        "temp": True,
+        "_ctime": ts,
+        "_mtime": ts,
+        "state": {
+            "lastWatched": "",
+            "timeWatched": 0,
+            "timeOffset": 0,
+            "overallTimeWatched": 0,
+            "timesWatched": 0,
+            "flaggedWatched": 0,
+            "duration": 0,
+            "video_id": "",
+            "watched": "",
+            "noNotif": False,
+            "season": 0,
+            "episode": 0,
+        },
+        "behaviorHints": {
+            "defaultVideoId": None,
+            "featuredVideoId": None,
+            "hasScheduledVideos": False,
+        },
+    }
+
+
+def read_merge_write(
+    adapter: Any,
+    stremio_id: str,
+    item_type: str,
+    item: Mapping[str, Any],
+    mutate: Callable[[dict[str, Any]], None],
+) -> dict[str, Any]:
+    rows = datastore_get(adapter, ids=[stremio_id], all_records=False)
+    record = copy.deepcopy(dict(rows[0])) if rows else default_record(stremio_id, item_type, item)
+    state = record.get("state")
+    if not isinstance(state, dict):
+        record["state"] = {}
+    mutate(record)
+    datastore_put(adapter, [record])
+    return record
+
+
+def item_from_movie_record(record: Mapping[str, Any]) -> dict[str, Any] | None:
+    rid = imdb_id(record_id(record))
+    if not rid:
+        return None
+    item: dict[str, Any] = {"type": "movie", "ids": {"imdb": rid}, "_stremio_id": rid}
+    title = str(record.get("name") or "").strip()
+    if title:
+        item["title"] = title
+    poster = str(record.get("poster") or "").strip()
+    if poster:
+        item["poster"] = poster
+    return item
+
+
+def item_from_episode(show_id: str, season: Any, episode: Any, record: Mapping[str, Any], video: Mapping[str, Any] | None = None) -> dict[str, Any] | None:
+    sid = imdb_id(show_id)
+    sn = positive_int(season)
+    ep = positive_int(episode)
+    if not sid or not sn or not ep:
+        return None
+    item: dict[str, Any] = {"type": "episode", "show_ids": {"imdb": sid}, "ids": {"imdb": sid}, "season": sn, "episode": ep, "_stremio_id": sid}
+    title = str((video or {}).get("title") or "").strip()
+    if title:
+        item["title"] = title
+    series_title = str(record.get("name") or "").strip()
+    if series_title:
+        item["series_title"] = series_title
+    video_id = str((video or {}).get("id") or "").strip()
+    if video_id:
+        item["_stremio_video_id"] = video_id
+    poster = str((video or {}).get("thumbnail") or record.get("poster") or "").strip()
+    if poster:
+        item["poster"] = poster
+    return item

--- a/providers/sync/stremio/_history.py
+++ b/providers/sync/stremio/_history.py
@@ -1,0 +1,384 @@
+# providers/sync/stremio/_history.py
+# CrossWatch Stremio history functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+import base64
+import copy
+import math
+import zlib
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+import requests
+
+from cw_platform.id_map import minimal as id_minimal
+from providers.auth._auth_STREMIO import StremioAuthError
+from providers.sync._mod_common import build_op_result, unresolved_keys
+
+from ._common import (
+    canonical_item_key,
+    datastore_get,
+    datastore_put,
+    default_record,
+    imdb_ids_from_item,
+    imdb_id,
+    iso_from_epoch_ms,
+    item_from_episode,
+    item_from_movie_record,
+    library_records,
+    now_iso,
+    positive_int,
+    record_id,
+    state_of,
+    stremio_id_for_item,
+    tmdb_metadata_provider,
+    video_id_for_episode,
+)
+
+CINEMETA_BASE = "https://v3-cinemeta.strem.io"
+
+
+def _bits_from_bytes(raw: bytes, length: int) -> list[bool]:
+    return [bool(raw[i // 8] & (1 << (i % 8))) if i // 8 < len(raw) else False for i in range(max(0, length))]
+
+
+def _bytes_from_bits(bits: list[bool]) -> bytes:
+    raw = bytearray(max(0, math.ceil(len(bits) / 8)))
+    for i, value in enumerate(bits):
+        if value:
+            raw[i // 8] |= 1 << (i % 8)
+    return bytes(raw)
+
+
+def _parse_serialized(value: str) -> tuple[str, int, bytes]:
+    parts = str(value or "").split(":")
+    if len(parts) < 3:
+        raise ValueError("malformed_watched_bitfield")
+    payload = parts[-1]
+    anchor_length = int(parts[-2])
+    anchor_id = ":".join(parts[:-2])
+    if not anchor_id or anchor_length < 0:
+        raise ValueError("malformed_watched_bitfield")
+    return anchor_id, anchor_length, zlib.decompress(base64.b64decode(payload))
+
+
+def watched_bits(value: Any, video_ids: list[str]) -> list[bool]:
+    raw_value = str(value or "").strip()
+    if not raw_value:
+        return [False] * len(video_ids)
+    anchor_id, anchor_length, packed = _parse_serialized(raw_value)
+    try:
+        anchor_index = video_ids.index(anchor_id)
+    except ValueError:
+        return [False] * len(video_ids)
+    if anchor_index == anchor_length - 1:
+        bits = _bits_from_bytes(packed, len(video_ids))
+        return bits[: len(video_ids)] + [False] * max(0, len(video_ids) - len(bits))
+    old_bits = _bits_from_bytes(packed, anchor_length)
+    offset = (anchor_length - 1) - anchor_index
+    return [old_bits[i + offset] if 0 <= i + offset < len(old_bits) else False for i in range(len(video_ids))]
+
+
+def serialize_watched_bits(bits: list[bool], video_ids: list[str]) -> str:
+    last = -1
+    for idx, value in enumerate(bits):
+        if value:
+            last = idx
+    if last < 0:
+        return ""
+    packed = zlib.compress(_bytes_from_bits(bits))
+    return f"{video_ids[last]}:{last + 1}:{base64.b64encode(packed).decode('ascii')}"
+
+
+def decode_watched_episodes(value: Any, video_ids: list[str]) -> set[str]:
+    return {video_ids[i] for i, value in enumerate(watched_bits(value, video_ids)) if value}
+
+
+def set_episode_watched_value(value: Any, video_ids: list[str], video_id: str, watched: bool) -> str:
+    bits = watched_bits(value, video_ids)
+    index = video_ids.index(video_id)
+    bits[index] = bool(watched)
+    return serialize_watched_bits(bits, video_ids)
+
+
+def cinemeta_videos(adapter: Any, imdb: str) -> list[Mapping[str, Any]]:
+    cache = getattr(adapter, "_stremio_cinemeta_cache", None)
+    if not isinstance(cache, dict):
+        cache = {}
+        setattr(adapter, "_stremio_cinemeta_cache", cache)
+    if imdb in cache:
+        return cache[imdb]
+    resp = requests.get(f"{CINEMETA_BASE}/meta/series/{imdb}.json", timeout=15)
+    resp.raise_for_status()
+    data = resp.json()
+    meta = data.get("meta") if isinstance(data, Mapping) else None
+    videos = meta.get("videos") if isinstance(meta, Mapping) else None
+    if not isinstance(videos, list):
+        raise ValueError("cinemeta_invalid")
+    rows = [row for row in videos if isinstance(row, Mapping) and str(row.get("id") or "").strip()]
+    cache[imdb] = rows
+    return rows
+
+
+def parse_movie_history_record(record: Mapping[str, Any]) -> dict[str, Any] | None:
+    item = item_from_movie_record(record)
+    if not item:
+        return None
+    state = state_of(record)
+    watched = (positive_int(state.get("timesWatched")) or 0) > 0 or (positive_int(state.get("flaggedWatched")) or 0) > 0
+    item["watched"] = watched
+    watched_at = iso_from_epoch_ms(state.get("lastWatched")) or iso_from_epoch_ms(record.get("_mtime"))
+    if watched_at:
+        item["watched_at"] = watched_at
+    return item
+
+
+def _image_url(detail: Mapping[str, Any], kind: str) -> str:
+    images = detail.get("images")
+    image_map = images if isinstance(images, Mapping) else {}
+    rows = image_map.get(kind)
+    if not isinstance(rows, list):
+        return ""
+    for row in rows:
+        if isinstance(row, Mapping):
+            url = str(row.get("url") or "").strip()
+            if url:
+                return url
+    return ""
+
+
+def _metadata_enriched(adapter: Any, item: Mapping[str, Any], typ: str) -> dict[str, Any]:
+    out = dict(item)
+    if stremio_id_for_item(out) and str(out.get("poster") or out.get("poster_url") or "").strip():
+        return out
+    provider = tmdb_metadata_provider(adapter)
+    if provider is None:
+        return out
+    show_ids_raw = out.get("show_ids")
+    show_ids: Mapping[str, Any] = show_ids_raw if isinstance(show_ids_raw, Mapping) else {}
+    source: Mapping[str, Any] = show_ids if typ in {"episode", "episodes"} and show_ids else imdb_ids_from_item(out)
+    lookup = {k: str(source.get(k) or "").strip() for k in ("tmdb", "imdb", "tvdb") if str(source.get(k) or "").strip()}
+    title = str(out.get("series_title") or out.get("show_title") or out.get("title") or "").strip()
+    if title:
+        lookup["title"] = title
+    if out.get("year"):
+        lookup["year"] = str(out.get("year"))
+    if not lookup:
+        return out
+    try:
+        detail = provider.fetch(entity="tv" if typ in {"episode", "episodes"} else "movie", ids=lookup, need={"poster": True, "backdrop": False, "ids": True})
+    except Exception:
+        return out
+    if not isinstance(detail, Mapping):
+        return out
+    ids_raw = detail.get("ids")
+    ids: Mapping[str, Any] = ids_raw if isinstance(ids_raw, Mapping) else {}
+    imdb = imdb_id(ids.get("imdb"))
+    if imdb:
+        if typ in {"episode", "episodes"}:
+            merged: dict[str, Any] = dict(show_ids)
+            merged["imdb"] = imdb
+            out["show_ids"] = merged
+        else:
+            out_ids_raw = out.get("ids")
+            out_ids: Mapping[str, Any] = out_ids_raw if isinstance(out_ids_raw, Mapping) else {}
+            merged = dict(out_ids)
+            merged["imdb"] = imdb
+            out["ids"] = merged
+    poster = str(out.get("poster") or out.get("poster_url") or "").strip()
+    if not poster:
+        poster = _image_url(detail, "poster")
+        if poster:
+            out["poster"] = poster
+    return out
+
+
+def build_index(adapter: Any, **kwargs: Any) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for record in library_records(adapter, incremental=bool(kwargs.get("incremental"))):
+        typ = str(record.get("type") or "").strip().lower()
+        if typ == "movie":
+            item = parse_movie_history_record(record)
+            if not item or not item.get("watched"):
+                continue
+            out[canonical_item_key(item)] = item
+        elif typ in {"series", "show"}:
+            show_id = imdb_id(record.get("_id"))
+            watched_value = state_of(record).get("watched")
+            if not show_id or not str(watched_value or "").strip():
+                continue
+            try:
+                videos = cinemeta_videos(adapter, show_id)
+                video_ids = [str(v.get("id") or "").strip() for v in videos]
+                watched_ids = decode_watched_episodes(watched_value, video_ids)
+            except Exception:
+                continue
+            by_id = {str(v.get("id") or "").strip(): v for v in videos}
+            for video_id in watched_ids:
+                video = by_id.get(video_id) or {}
+                item = item_from_episode(show_id, video.get("season"), video.get("episode"), record, video)
+                if not item:
+                    continue
+                item["watched"] = True
+                fallback_ts = iso_from_epoch_ms(record.get("_mtime"))
+                if fallback_ts:
+                    item["_stremio_changed_at"] = fallback_ts
+                out[canonical_item_key(item)] = item
+    return out
+
+
+def _history_ts(item: Mapping[str, Any]) -> str:
+    return iso_from_epoch_ms(item.get("watched_at") or item.get("last_watched_at") or item.get("lastWatchedAt")) or now_iso()
+
+
+def _unresolved(item: Mapping[str, Any], reason: str) -> dict[str, Any]:
+    return {"status": "unresolved", "reason": reason, "item": id_minimal(item)}
+
+
+def _api_failure(item: Mapping[str, Any], key: str, exc: StremioAuthError, fallback: str) -> dict[str, Any]:
+    entry = {"status": "failed", "reason": str(getattr(exc, "reason", "") or fallback), "item": id_minimal(item), "canonical_key": key}
+    detail = str(getattr(exc, "detail", "") or "").replace("\n", " ").replace("\r", " ").strip()
+    if detail:
+        for token in ("authKey", "auth_key", "password"):
+            detail = detail.replace(token, f"{token[0]}***")
+        entry["detail"] = detail[:180]
+    return entry
+
+
+def _apply_poster(record: dict[str, Any], item: Mapping[str, Any]) -> None:
+    poster = str(item.get("poster") or item.get("poster_url") or item.get("posterUrl") or "").strip()
+    if poster.startswith(("http://", "https://")) and not str(record.get("poster") or "").strip():
+        record["poster"] = poster
+
+
+def _apply_movie(record: dict[str, Any], item: Mapping[str, Any], watched: bool) -> None:
+    ts = now_iso()
+    state = record.setdefault("state", {})
+    _apply_poster(record, item)
+    record["_mtime"] = ts
+    if watched:
+        state["lastWatched"] = _history_ts(item)
+        state["timesWatched"] = max(1, positive_int(state.get("timesWatched")) or 0)
+        state["flaggedWatched"] = 1
+        state["timeOffset"] = 0
+    else:
+        state["lastWatched"] = ""
+        state["timesWatched"] = 0
+        state["flaggedWatched"] = 0
+        state["timeOffset"] = 0
+
+
+def _apply_episode(adapter: Any, record: dict[str, Any], item: Mapping[str, Any], watched: bool) -> str | None:
+    show_id = imdb_id(record.get("_id"))
+    if not show_id:
+        return "stremio_id_missing"
+    videos = cinemeta_videos(adapter, show_id)
+    video_ids = [str(v.get("id") or "").strip() for v in videos]
+    video_id = video_id_for_episode(item, show_id)
+    if not video_id or video_id not in video_ids:
+        return "stremio_episode_unresolved"
+    state = record.setdefault("state", {})
+    _apply_poster(record, item)
+    try:
+        state["watched"] = set_episode_watched_value(state.get("watched"), video_ids, video_id, watched)
+    except Exception:
+        return "stremio_watched_bitfield_malformed"
+    record["_mtime"] = now_iso()
+    return None
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, items, True, dry_run=dry_run)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, items, False, dry_run=dry_run)
+
+
+def _write(adapter: Any, items: Iterable[Mapping[str, Any]], watched: bool, *, dry_run: bool = False) -> dict[str, Any]:
+    confirmed: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    grouped: dict[tuple[str, str], list[tuple[str, dict[str, Any], str]]] = {}
+    attempted = 0
+    for item in [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]:
+        key = canonical_item_key(item)
+        typ = str(item.get("type") or id_minimal(item).get("type") or "").strip().lower()
+        item = _metadata_enriched(adapter, item, typ)
+        stremio_id = stremio_id_for_item(item)
+        if not stremio_id or typ not in {"movie", "episode", "episodes"}:
+            entry = _unresolved(item, "stremio_id_missing")
+            unresolved.append(entry)
+            results.append(entry)
+            continue
+        attempted += 1
+        if dry_run:
+            confirmed.append(key)
+            results.append({"status": "dry_run", "item": id_minimal(item), "canonical_key": key})
+            continue
+        grouped.setdefault((stremio_id, "movie" if typ == "movie" else "series"), []).append((key, item, typ))
+    if grouped and not dry_run:
+        ids = list(dict.fromkeys(stremio_id for stremio_id, _item_type in grouped))
+        try:
+            current = {record_id(row): copy.deepcopy(dict(row)) for row in datastore_get(adapter, ids=ids, all_records=False)}
+        except StremioAuthError as exc:
+            for ops in grouped.values():
+                for key, item, _typ in ops:
+                    entry = _api_failure(item, key, exc, "stremio_history_write_failed")
+                    unresolved.append(entry)
+                    results.append(entry)
+            return build_op_result(ok=False, count=0, confirmed_keys=[], unresolved_keys=unresolved_keys(unresolved, canonical_item_key), unresolved=unresolved, results=results, attempted=attempted)
+        prepared: list[tuple[dict[str, Any], list[tuple[str, dict[str, Any]]]]] = []
+        for (stremio_id, item_type), ops in grouped.items():
+            record = current.get(stremio_id) or default_record(stremio_id, item_type, ops[0][1])
+            applied: list[tuple[str, dict[str, Any]]] = []
+            for key, item, typ in ops:
+                try:
+                    reason = None
+                    if typ == "movie":
+                        _apply_movie(record, item, watched)
+                    else:
+                        reason = _apply_episode(adapter, record, item, watched)
+                    if reason:
+                        raise ValueError(reason)
+                except ValueError as exc:
+                    entry = _unresolved(item, str(exc) or "stremio_history_write_failed")
+                    unresolved.append(entry)
+                    results.append(entry)
+                    continue
+                except Exception:
+                    entry = {"status": "failed", "reason": "stremio_history_write_failed", "item": id_minimal(item), "canonical_key": key}
+                    unresolved.append(entry)
+                    results.append(entry)
+                    continue
+                applied.append((key, item))
+            if applied:
+                prepared.append((record, applied))
+        pending = prepared
+        if prepared:
+            try:
+                datastore_put(adapter, [record for record, _ops in prepared])
+            except Exception:
+                pending = []
+                for record, ops in prepared:
+                    try:
+                        datastore_put(adapter, [record])
+                    except StremioAuthError as exc:
+                        for key, item in ops:
+                            entry = _api_failure(item, key, exc, "stremio_history_write_failed")
+                            unresolved.append(entry)
+                            results.append(entry)
+                        continue
+                    except Exception:
+                        for key, item in ops:
+                            entry = {"status": "failed", "reason": "stremio_history_write_failed", "item": id_minimal(item), "canonical_key": key}
+                            unresolved.append(entry)
+                            results.append(entry)
+                        continue
+                    pending.append((record, ops))
+        for _record, ops in pending:
+            for key, item in ops:
+                confirmed.append(key)
+                results.append({"status": "applied", "item": id_minimal(item), "canonical_key": key})
+    return build_op_result(ok=not unresolved, count=len(confirmed), confirmed_keys=confirmed, unresolved_keys=unresolved_keys(unresolved, canonical_item_key), unresolved=unresolved, results=results, attempted=attempted)

--- a/providers/sync/stremio/_progress.py
+++ b/providers/sync/stremio/_progress.py
@@ -1,0 +1,315 @@
+# providers/sync/stremio/_progress.py
+# CrossWatch Stremio progress functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from cw_platform.id_map import minimal as id_minimal
+from providers.auth._auth_STREMIO import StremioAuthError
+from providers.sync._mod_common import build_op_result, unresolved_keys
+from providers.sync._progress_policy import select_progress_record
+
+from ._common import (
+    canonical_item_key,
+    imdb_ids_from_item,
+    imdb_id,
+    iso_from_epoch_ms,
+    item_from_episode,
+    item_from_movie_record,
+    library_records,
+    now_iso,
+    positive_int,
+    read_merge_write,
+    state_of,
+    stremio_id_for_item,
+    tmdb_metadata_provider,
+    to_int,
+    video_id_for_episode,
+)
+
+
+def _progress_percent(position: int, duration: int) -> float | None:
+    return round((position / duration) * 100.0, 3) if duration > 0 and position >= 0 else None
+
+
+def _duration_ms(item: Mapping[str, Any]) -> int | None:
+    for key in ("duration_ms", "durationMs", "duration", "runtime_ms", "runtimeMs"):
+        number = positive_int(item.get(key))
+        if number is not None:
+            return number
+    for key in ("duration_seconds", "durationSeconds", "runtime_seconds", "runtimeSeconds"):
+        number = positive_int(item.get(key))
+        if number is not None:
+            return number * 1000
+    for key in ("runtime_minutes", "runtimeMinutes", "duration_minutes", "durationMinutes", "runtime"):
+        number = positive_int(item.get(key))
+        if number is not None:
+            return number * 60_000
+    return None
+
+
+def _progress_percent_value(item: Mapping[str, Any]) -> float | None:
+    for key in ("progress_percent", "progressPercent", "percent", "position_percent", "resume_percent"):
+        value = item.get(key)
+        if value is None or isinstance(value, bool):
+            continue
+        try:
+            percent = float(value)
+            if percent == percent:
+                return max(0.0, min(100.0, percent))
+        except Exception:
+            continue
+    return None
+
+
+def _progress_ms(item: Mapping[str, Any], duration: int | None = None) -> int | None:
+    for key in ("progress_ms", "progressMs", "position", "position_ms", "positionMs", "viewOffset", "timeOffset", "progress"):
+        number = to_int(item.get(key))
+        if number is not None:
+            return max(0, number)
+    percent = _progress_percent_value(item)
+    if percent is not None and duration:
+        return max(0, int(round((percent / 100.0) * duration)))
+    return None
+
+
+def _image_url(detail: Mapping[str, Any], kind: str) -> str:
+    images = detail.get("images")
+    image_map = images if isinstance(images, Mapping) else {}
+    rows = image_map.get(kind)
+    if not isinstance(rows, list):
+        return ""
+    for row in rows:
+        if isinstance(row, Mapping):
+            url = str(row.get("url") or "").strip()
+            if url:
+                return url
+    return ""
+
+
+def _metadata_enriched(adapter: Any, item: Mapping[str, Any], typ: str) -> dict[str, Any]:
+    out = dict(item)
+    if stremio_id_for_item(out) and _duration_ms(out):
+        return out
+    provider = tmdb_metadata_provider(adapter)
+    if provider is None:
+        return out
+    show_ids_raw = out.get("show_ids")
+    show_ids: Mapping[str, Any] = show_ids_raw if isinstance(show_ids_raw, Mapping) else {}
+    source: Mapping[str, Any] = show_ids if typ in {"episode", "episodes"} and show_ids else imdb_ids_from_item(out)
+    lookup = {k: str(source.get(k) or "").strip() for k in ("tmdb", "imdb", "tvdb") if str(source.get(k) or "").strip()}
+    title = str(out.get("series_title") or out.get("show_title") or out.get("title") or "").strip()
+    if title:
+        lookup["title"] = title
+    if out.get("year"):
+        lookup["year"] = str(out.get("year"))
+    if not lookup:
+        return out
+    try:
+        detail = provider.fetch(entity="tv" if typ in {"episode", "episodes"} else "movie", ids=lookup, need={"poster": True, "backdrop": False, "ids": True, "runtime_minutes": True})
+    except Exception:
+        return out
+    if not isinstance(detail, Mapping):
+        return out
+    ids_raw = detail.get("ids")
+    ids: Mapping[str, Any] = ids_raw if isinstance(ids_raw, Mapping) else {}
+    imdb = imdb_id(ids.get("imdb"))
+    if imdb:
+        if typ in {"episode", "episodes"}:
+            merged: dict[str, Any] = dict(show_ids)
+            merged["imdb"] = imdb
+            out["show_ids"] = merged
+        else:
+            out_ids_raw = out.get("ids")
+            out_ids: Mapping[str, Any] = out_ids_raw if isinstance(out_ids_raw, Mapping) else {}
+            merged = dict(out_ids)
+            merged["imdb"] = imdb
+            out["ids"] = merged
+    duration = positive_int(detail.get("runtime_minutes"))
+    if duration is None and typ in {"episode", "episodes"}:
+        tmdb = str(ids.get("tmdb") or lookup.get("tmdb") or "").strip()
+        fetch = getattr(provider, "_get", None)
+        season = positive_int(out.get("season"))
+        episode = positive_int(out.get("episode"))
+        if callable(fetch) and tmdb and season and episode:
+            try:
+                ep = fetch(f"https://api.themoviedb.org/3/tv/{tmdb}/season/{season}/episode/{episode}")
+            except Exception:
+                ep = {}
+            if isinstance(ep, Mapping):
+                duration = positive_int(ep.get("runtime"))
+    if duration:
+        out.setdefault("duration_ms", duration * 60_000)
+    poster = str(out.get("poster") or out.get("poster_url") or "").strip()
+    if not poster:
+        poster = _image_url(detail, "poster")
+        if poster:
+            out["poster"] = poster
+    return out
+
+
+def parse_movie_progress_record(record: Mapping[str, Any]) -> dict[str, Any] | None:
+    state = state_of(record)
+    position = to_int(state.get("timeOffset"))
+    duration = positive_int(state.get("duration"))
+    if position is None or position <= 0 or not duration:
+        return None
+    item = item_from_movie_record(record)
+    if not item:
+        return None
+    item["progress_ms"] = position
+    item["duration_ms"] = duration
+    item["progress_percent"] = _progress_percent(position, duration)
+    ts = iso_from_epoch_ms(state.get("lastWatched")) or iso_from_epoch_ms(record.get("_mtime"))
+    if ts:
+        item["progress_at"] = ts
+    return item
+
+
+def parse_episode_progress_record(record: Mapping[str, Any]) -> dict[str, Any] | None:
+    state = state_of(record)
+    position = to_int(state.get("timeOffset"))
+    duration = positive_int(state.get("duration"))
+    if position is None or position <= 0 or not duration:
+        return None
+    show_id = imdb_id(record.get("_id"))
+    video_id = str(state.get("video_id") or state.get("videoId") or "").strip()
+    season = positive_int(state.get("season"))
+    episode = positive_int(state.get("episode"))
+    if video_id:
+        parts = video_id.split(":")
+        if len(parts) >= 3 and imdb_id(parts[0]):
+            show_id = parts[0]
+            season = positive_int(parts[-2])
+            episode = positive_int(parts[-1])
+    elif show_id and season and episode:
+        video_id = f"{show_id}:{season}:{episode}"
+    if not show_id or not season or not episode:
+        return None
+    item = item_from_episode(show_id, season, episode, record, {"id": video_id, "season": season, "episode": episode})
+    if not item:
+        return None
+    item["progress_ms"] = position
+    item["duration_ms"] = duration
+    item["progress_percent"] = _progress_percent(position, duration)
+    ts = iso_from_epoch_ms(state.get("lastWatched")) or iso_from_epoch_ms(record.get("_mtime"))
+    if ts:
+        item["progress_at"] = ts
+    return item
+
+
+def build_index(adapter: Any, **kwargs: Any) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for record in library_records(adapter, incremental=bool(kwargs.get("incremental"))):
+        typ = str(record.get("type") or "").strip().lower()
+        item = parse_movie_progress_record(record) if typ == "movie" else parse_episode_progress_record(record) if typ in {"series", "show"} else None
+        if not item:
+            continue
+        key = canonical_item_key(item)
+        selected, _reason = select_progress_record(out.get(key), item)
+        out[key] = selected
+    return out
+
+
+def _unresolved(item: Mapping[str, Any], reason: str) -> dict[str, Any]:
+    return {"status": "unresolved", "reason": reason, "item": id_minimal(item)}
+
+
+def _api_failure(item: Mapping[str, Any], key: str, exc: StremioAuthError, fallback: str) -> dict[str, Any]:
+    entry = {"status": "failed", "reason": str(getattr(exc, "reason", "") or fallback), "item": id_minimal(item), "canonical_key": key}
+    detail = str(getattr(exc, "detail", "") or "").replace("\n", " ").replace("\r", " ").strip()
+    if detail:
+        for token in ("authKey", "auth_key", "password"):
+            detail = detail.replace(token, f"{token[0]}***")
+        entry["detail"] = detail[:180]
+    return entry
+
+
+def _apply_progress(record: dict[str, Any], item: Mapping[str, Any], clear: bool) -> str | None:
+    state = record.setdefault("state", {})
+    poster = str(item.get("poster") or item.get("poster_url") or item.get("posterUrl") or "").strip()
+    if poster.startswith(("http://", "https://")) and not str(record.get("poster") or "").strip():
+        record["poster"] = poster
+    duration = _duration_ms(item) or positive_int(state.get("duration"))
+    position = _progress_ms(item, duration)
+    if clear:
+        position = 0
+    if position is None:
+        return "stremio_duration_missing" if _progress_percent_value(item) is not None and not duration else "stremio_progress_missing"
+    if not duration and not clear:
+        return "stremio_duration_missing"
+    typ = str(item.get("type") or id_minimal(item).get("type") or "").strip().lower()
+    if typ in {"episode", "episodes"}:
+        show_id = imdb_id(record.get("_id"))
+        if not show_id:
+            return "stremio_id_missing"
+        video_id = video_id_for_episode(item, show_id)
+        season = positive_int(item.get("season"))
+        episode = positive_int(item.get("episode"))
+        if not video_id or not season or not episode:
+            return "stremio_episode_unresolved"
+        state["video_id"] = video_id
+        state["season"] = season
+        state["episode"] = episode
+    state["timeOffset"] = int(position)
+    if duration:
+        state["duration"] = int(duration)
+    record["_mtime"] = now_iso()
+    return None
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, items, False, dry_run=dry_run)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, items, True, dry_run=dry_run)
+
+
+def _write(adapter: Any, items: Iterable[Mapping[str, Any]], clear: bool, *, dry_run: bool = False) -> dict[str, Any]:
+    confirmed: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    attempted = 0
+    for item in [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]:
+        key = canonical_item_key(item)
+        typ = str(item.get("type") or id_minimal(item).get("type") or "").strip().lower()
+        item = _metadata_enriched(adapter, item, typ)
+        stremio_id = stremio_id_for_item(item)
+        if not stremio_id or typ not in {"movie", "episode", "episodes"}:
+            entry = _unresolved(item, "stremio_id_missing")
+            unresolved.append(entry)
+            results.append(entry)
+            continue
+        attempted += 1
+        if dry_run:
+            confirmed.append(key)
+            results.append({"status": "dry_run", "item": id_minimal(item), "canonical_key": key})
+            continue
+        try:
+            def mutate(record: dict[str, Any]) -> None:
+                reason = _apply_progress(record, item, clear)
+                if reason:
+                    raise ValueError(reason)
+
+            read_merge_write(adapter, stremio_id, "movie" if typ == "movie" else "series", item, mutate)
+        except ValueError as exc:
+            entry = _unresolved(item, str(exc) or "stremio_progress_write_failed")
+            unresolved.append(entry)
+            results.append(entry)
+            continue
+        except StremioAuthError as exc:
+            entry = _api_failure(item, key, exc, "stremio_progress_write_failed")
+            unresolved.append(entry)
+            results.append(entry)
+            continue
+        except Exception:
+            entry = {"status": "failed", "reason": "stremio_progress_write_failed", "item": id_minimal(item), "canonical_key": key}
+            unresolved.append(entry)
+            results.append(entry)
+            continue
+        confirmed.append(key)
+        results.append({"status": "applied", "item": id_minimal(item), "canonical_key": key})
+    return build_op_result(ok=not unresolved, count=len(confirmed), confirmed_keys=confirmed, unresolved_keys=unresolved_keys(unresolved, canonical_item_key), unresolved=unresolved, results=results, attempted=attempted)

--- a/providers/sync/stremio/_ratings.py
+++ b/providers/sync/stremio/_ratings.py
@@ -1,0 +1,286 @@
+# providers/sync/stremio/_ratings.py
+# CrossWatch Stremio ratings functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+from cw_platform.id_map import ids_from, minimal as id_minimal
+from providers.auth._auth_STREMIO import StremioAuthError
+from providers.sync._mod_common import build_op_result, unresolved_keys
+
+from ._common import canonical_item_key, configured_block, imdb_id, imdb_ids_from_item, is_capture_mode, stremio_profile_id, tmdb_metadata_provider
+
+LIKES_URL = "https://likes.stremio.com/api/send"
+LIKES_STATUS_URL = "https://likes.stremio.com/api/get_status"
+STATE_DIR = Path("/config/.cw_state")
+
+
+def _safe_scope(value: str) -> str:
+    out = "".join(ch if ch.isalnum() or ch in ("-", "_", ".") else "_" for ch in str(value or ""))
+    while "__" in out:
+        out = out.replace("__", "_")
+    return (out.strip("_ ") or "unscoped")[:96]
+
+
+def _cache_path(adapter: Any) -> Path:
+    scope = _safe_scope(os.getenv("CW_PAIR_KEY") or os.getenv("CW_PAIR_SCOPE") or os.getenv("CW_SYNC_PAIR") or os.getenv("CW_PAIR") or "unscoped")
+    profile = _safe_scope(stremio_profile_id(adapter))
+    return STATE_DIR / f"stremio_ratings.{profile}.{scope}.json"
+
+
+def _load_cache(adapter: Any) -> dict[str, dict[str, Any]]:
+    if is_capture_mode():
+        return {}
+    try:
+        data = json.loads(_cache_path(adapter).read_text("utf-8") or "{}")
+    except Exception:
+        return {}
+    rows = data.get("items") if isinstance(data, Mapping) else None
+    return {str(k): dict(v) for k, v in (rows or {}).items() if isinstance(v, Mapping)}
+
+
+def _save_cache(adapter: Any, rows: Mapping[str, Mapping[str, Any]]) -> None:
+    if is_capture_mode():
+        return
+    try:
+        path = _cache_path(adapter)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps({"items": dict(rows)}, ensure_ascii=False, sort_keys=True), "utf-8")
+        os.replace(tmp, path)
+    except Exception:
+        pass
+
+
+def _rating_number(value: Any) -> float | None:
+    try:
+        number = float(str(value).strip())
+    except Exception:
+        return None
+    if 10 < number <= 100:
+        number /= 10.0
+    return number if 0 < number <= 10 else None
+
+
+def _float_setting(value: Any, default: float) -> float:
+    try:
+        out = float(str(value).strip())
+    except Exception:
+        return default
+    return out if 0 <= out <= 10 else default
+
+
+def _rating_thresholds(adapter: Any) -> tuple[float, float]:
+    block = configured_block(getattr(adapter, "config", None), getattr(adapter, "instance_id", "default"))
+    raw = block.get("ratings")
+    ratings = raw if isinstance(raw, Mapping) else {}
+    liked_min = _float_setting(ratings.get("liked_min"), 6.0)
+    loved_min = _float_setting(ratings.get("loved_min"), 8.0)
+    if loved_min < liked_min:
+        loved_min = liked_min
+    return liked_min, loved_min
+
+
+def _status_for_rating(adapter: Any, value: Any) -> str | None:
+    number = _rating_number(value)
+    if number is None:
+        return None
+    liked_min, loved_min = _rating_thresholds(adapter)
+    if liked_min <= number < loved_min:
+        return "liked"
+    if loved_min <= number <= 10.0:
+        return "loved"
+    return None
+
+
+def _media_type(item: Mapping[str, Any]) -> str | None:
+    typ = str(item.get("type") or id_minimal(item).get("type") or "").strip().lower()
+    if typ == "movie":
+        return "movie"
+    if typ in {"show", "series", "tv"}:
+        return "series"
+    return None
+
+
+def _enriched_item(adapter: Any, item: Mapping[str, Any]) -> dict[str, Any]:
+    out = dict(item)
+    if imdb_id(imdb_ids_from_item(out).get("imdb")):
+        return out
+    provider = tmdb_metadata_provider(adapter)
+    if provider is None:
+        return out
+    media_type = _media_type(out)
+    if media_type is None:
+        return out
+    ids = ids_from(out)
+    lookup = {k: str(ids.get(k) or "").strip() for k in ("tmdb", "imdb", "tvdb") if str(ids.get(k) or "").strip()}
+    title = str(out.get("title") or out.get("series_title") or out.get("show_title") or "").strip()
+    if title:
+        lookup["title"] = title
+    if out.get("year"):
+        lookup["year"] = str(out.get("year"))
+    if not lookup:
+        return out
+    try:
+        detail = provider.fetch(entity="tv" if media_type == "series" else "movie", ids=lookup, need={"poster": False, "backdrop": False, "ids": True})
+    except Exception:
+        return out
+    ids_raw = detail.get("ids") if isinstance(detail, Mapping) else None
+    ids_map: Mapping[str, Any] = ids_raw if isinstance(ids_raw, Mapping) else {}
+    found = imdb_id(ids_map.get("imdb"))
+    if found:
+        merged = dict(ids)
+        merged["imdb"] = found
+        out["ids"] = merged
+    return out
+
+
+def _media_id(item: Mapping[str, Any]) -> str | None:
+    for field in ("_stremio_id", "stremio_id", "content_id"):
+        direct = str(item.get(field) or "").strip()
+        found = imdb_id(direct)
+        if found:
+            return found
+    imdb = imdb_id(imdb_ids_from_item(item).get("imdb"))
+    if imdb:
+        return imdb
+    return None
+
+
+def _response_detail(resp: Any) -> str:
+    try:
+        data = resp.json()
+    except Exception:
+        data = None
+    if isinstance(data, Mapping):
+        for key in ("message", "error", "detail"):
+            value = data.get(key)
+            if value:
+                return str(value)[:180]
+    return str(getattr(resp, "text", "") or "")[:180]
+
+
+def _remote_status(adapter: Any, media_id: str, media_type: str) -> str | None:
+    resp = adapter.client.session.get(
+        LIKES_STATUS_URL,
+        params={"authToken": adapter.client.auth_key(), "mediaId": media_id, "mediaType": media_type},
+        headers={"Accept": "application/json"},
+        timeout=20,
+    )
+    if resp.status_code in (401, 403):
+        raise StremioAuthError("Stremio rejected the credentials", reason="invalid_credentials", status_code=resp.status_code, endpoint="likes/get_status")
+    if resp.status_code >= 400:
+        raise StremioAuthError("Stremio rating status failed", reason="request_failed", detail=_response_detail(resp), status_code=resp.status_code, endpoint="likes/get_status")
+    try:
+        data = resp.json()
+    except Exception:
+        return None
+    if not isinstance(data, Mapping):
+        return None
+    value = data.get("status")
+    return str(value).strip().lower() if value else None
+
+
+def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
+    return _load_cache(adapter)
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, items, clear_missing=False, dry_run=dry_run)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, items, clear_missing=True, dry_run=dry_run)
+
+
+def _write(adapter: Any, items: Iterable[Mapping[str, Any]], *, clear_missing: bool, dry_run: bool = False) -> dict[str, Any]:
+    confirmed: list[str] = []
+    skipped: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    cache = _load_cache(adapter)
+    attempted = 0
+    for raw in [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]:
+        key = canonical_item_key(raw)
+        item = _enriched_item(adapter, raw)
+        media_type = _media_type(item)
+        media_id = _media_id(item)
+        status = None if clear_missing else _status_for_rating(adapter, item.get("rating"))
+        if not media_type or not media_id:
+            entry = {"status": "unresolved", "reason": "stremio_rating_id_missing", "item": id_minimal(item), "canonical_key": key}
+            unresolved.append(entry)
+            results.append(entry)
+            continue
+        if not clear_missing and status is None:
+            skipped.append(key)
+            if not dry_run:
+                cached = id_minimal(item)
+                cached["rating"] = item.get("rating")
+                if item.get("rated_at"):
+                    cached["rated_at"] = item.get("rated_at")
+                cached["_stremio_reaction"] = None
+                cached["_stremio_skip_reason"] = "below_threshold"
+                cache[key] = cached
+            results.append({"status": "skipped", "reason": "stremio_rating_below_threshold", "item": id_minimal(item), "canonical_key": key})
+            continue
+        attempted += 1
+        if dry_run:
+            confirmed.append(key)
+            results.append({"status": "dry_run", "item": id_minimal(item), "canonical_key": key})
+            continue
+        try:
+            if not clear_missing:
+                existing = _remote_status(adapter, media_id, media_type)
+                if existing == status:
+                    skipped.append(key)
+                    cached = id_minimal(item)
+                    cached["rating"] = item.get("rating")
+                    if item.get("rated_at"):
+                        cached["rated_at"] = item.get("rated_at")
+                    cached["_stremio_reaction"] = status
+                    cache[key] = cached
+                    results.append({"status": "skipped", "reason": "stremio_rating_already_set", "item": id_minimal(item), "canonical_key": key})
+                    continue
+            resp = adapter.client.session.post(
+                LIKES_URL,
+                json={"authToken": adapter.client.auth_key(), "mediaId": media_id, "mediaType": media_type, "status": status},
+                headers={"Accept": "application/json", "Content-Type": "application/json"},
+                timeout=20,
+            )
+            if resp.status_code in (401, 403):
+                raise StremioAuthError("Stremio rejected the credentials", reason="invalid_credentials", status_code=resp.status_code, endpoint="likes/send")
+            if resp.status_code >= 400:
+                raise StremioAuthError("Stremio rating write failed", reason="request_failed", detail=_response_detail(resp), status_code=resp.status_code, endpoint="likes/send")
+        except StremioAuthError as exc:
+            reason = str(getattr(exc, "reason", "") or "stremio_rating_write_failed")
+            entry = {"status": "failed", "reason": reason, "item": id_minimal(item), "canonical_key": key}
+            detail = str(getattr(exc, "detail", "") or "").strip()
+            if detail:
+                entry["hint"] = detail
+            unresolved.append(entry)
+            results.append(entry)
+            continue
+        except Exception:
+            entry = {"status": "failed", "reason": "stremio_rating_write_failed", "item": id_minimal(item), "canonical_key": key}
+            unresolved.append(entry)
+            results.append(entry)
+            continue
+        confirmed.append(key)
+        if clear_missing:
+            cache.pop(key, None)
+        else:
+            cached = id_minimal(item)
+            cached["rating"] = item.get("rating")
+            if item.get("rated_at"):
+                cached["rated_at"] = item.get("rated_at")
+            cached["_stremio_reaction"] = status
+            cache[key] = cached
+        results.append({"status": "applied", "item": id_minimal(item), "canonical_key": key})
+    if (confirmed or skipped) and not dry_run:
+        _save_cache(adapter, cache)
+    return build_op_result(ok=not unresolved, count=len(confirmed), confirmed_keys=confirmed, unresolved_keys=unresolved_keys(unresolved, canonical_item_key), unresolved=unresolved, results=results, attempted=attempted, skipped=len(skipped), skipped_keys=skipped)

--- a/providers/sync/stremio/_watchlist.py
+++ b/providers/sync/stremio/_watchlist.py
@@ -1,0 +1,176 @@
+# providers/sync/stremio/_watchlist.py
+# CrossWatch Stremio watchlist functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+import copy
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from cw_platform.id_map import ids_from, merge_ids, minimal as id_minimal
+from providers.sync._mod_common import build_op_result, unresolved_keys
+
+from ._common import (
+    canonical_item_key,
+    datastore_get,
+    datastore_put,
+    default_record,
+    imdb_id,
+    imdb_ids_from_item,
+    item_from_movie_record,
+    library_records,
+    now_iso,
+    record_id,
+    stremio_id_for_item,
+    tmdb_metadata_provider,
+)
+
+
+def _image_url(detail: Mapping[str, Any], kind: str) -> str:
+    images = detail.get("images")
+    image_map = images if isinstance(images, Mapping) else {}
+    rows = image_map.get(kind)
+    if not isinstance(rows, list):
+        return ""
+    for row in rows:
+        if isinstance(row, Mapping):
+            url = str(row.get("url") or "").strip()
+            if url:
+                return url
+    return ""
+
+
+def _item_from_series_record(record: Mapping[str, Any]) -> dict[str, Any] | None:
+    rid = imdb_id(record_id(record))
+    if not rid:
+        return None
+    item: dict[str, Any] = {"type": "show", "ids": {"imdb": rid}, "_stremio_id": rid}
+    title = str(record.get("name") or "").strip()
+    if title:
+        item["title"] = title
+    poster = str(record.get("poster") or "").strip()
+    if poster:
+        item["poster"] = poster
+    return item
+
+
+def _is_listed(record: Mapping[str, Any]) -> bool:
+    return record.get("removed") is False and record.get("temp") is False
+
+
+def _metadata_enriched(adapter: Any, item: Mapping[str, Any], typ: str) -> dict[str, Any]:
+    out = dict(item)
+    if stremio_id_for_item(out) and str(out.get("poster") or out.get("poster_url") or "").strip():
+        return out
+    provider = tmdb_metadata_provider(adapter)
+    if provider is None:
+        return out
+    ids = merge_ids(ids_from(out), imdb_ids_from_item(out))
+    lookup = {k: str(ids.get(k) or "").strip() for k in ("tmdb", "imdb", "tvdb") if str(ids.get(k) or "").strip()}
+    title = str(out.get("series_title") or out.get("show_title") or out.get("title") or "").strip()
+    if title:
+        lookup["title"] = title
+    if out.get("year"):
+        lookup["year"] = str(out.get("year"))
+    if not lookup:
+        return out
+    try:
+        detail = provider.fetch(entity="tv" if typ in {"show", "series", "tv"} else "movie", ids=lookup, need={"poster": True, "backdrop": False, "ids": True})
+    except Exception:
+        return out
+    if not isinstance(detail, Mapping):
+        return out
+    detail_ids = detail.get("ids")
+    ids_map: Mapping[str, Any] = detail_ids if isinstance(detail_ids, Mapping) else {}
+    found = imdb_id(ids_map.get("imdb"))
+    if found:
+        out_ids_raw = out.get("ids")
+        out_ids: Mapping[str, Any] = out_ids_raw if isinstance(out_ids_raw, Mapping) else {}
+        merged = dict(out_ids)
+        merged["imdb"] = found
+        out["ids"] = merged
+    if not str(out.get("title") or out.get("series_title") or "").strip() and str(detail.get("title") or "").strip():
+        out["title"] = str(detail.get("title") or "").strip()
+    if not str(out.get("poster") or out.get("poster_url") or "").strip():
+        poster = _image_url(detail, "poster")
+        if poster:
+            out["poster"] = poster
+    return out
+
+
+def build_index(adapter: Any, **kwargs: Any) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for record in library_records(adapter, incremental=bool(kwargs.get("incremental"))):
+        if not _is_listed(record):
+            continue
+        typ = str(record.get("type") or "").strip().lower()
+        item = item_from_movie_record(record) if typ == "movie" else _item_from_series_record(record) if typ in {"series", "show"} else None
+        if item:
+            out[canonical_item_key(item)] = item
+    return out
+
+
+def _unresolved(item: Mapping[str, Any], reason: str) -> dict[str, Any]:
+    return {"status": "unresolved", "reason": reason, "item": id_minimal(item)}
+
+
+def _apply_membership(record: dict[str, Any], item: Mapping[str, Any], listed: bool) -> None:
+    poster = str(item.get("poster") or item.get("poster_url") or item.get("posterUrl") or "").strip()
+    if poster.startswith(("http://", "https://")) and not str(record.get("poster") or "").strip():
+        record["poster"] = poster
+    record["removed"] = not listed
+    record["temp"] = False
+    record["_mtime"] = now_iso()
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, items, True, dry_run=dry_run)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, items, False, dry_run=dry_run)
+
+
+def _write(adapter: Any, items: Iterable[Mapping[str, Any]], listed: bool, *, dry_run: bool = False) -> dict[str, Any]:
+    confirmed: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    attempted = 0
+    for raw in [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]:
+        typ = str(id_minimal(raw).get("type") or raw.get("type") or "").strip().lower()
+        if typ in {"episode", "episodes", "season", "seasons"}:
+            entry = _unresolved(raw, "stremio_watchlist_type_unsupported")
+            unresolved.append(entry)
+            results.append(entry)
+            continue
+        item = _metadata_enriched(adapter, raw, typ)
+        key = canonical_item_key(item)
+        stremio_id = stremio_id_for_item(item)
+        if not stremio_id or typ not in {"movie", "show", "series", "tv"}:
+            entry = _unresolved(item, "stremio_id_missing")
+            unresolved.append(entry)
+            results.append(entry)
+            continue
+        attempted += 1
+        if dry_run:
+            confirmed.append(key)
+            results.append({"status": "dry_run", "item": id_minimal(item), "canonical_key": key})
+            continue
+        try:
+            rows = datastore_get(adapter, ids=[stremio_id], all_records=False)
+            if not rows and not listed:
+                results.append({"status": "skipped", "reason": "already_absent", "item": id_minimal(item), "canonical_key": key})
+                continue
+            record = copy.deepcopy(dict(rows[0])) if rows else default_record(stremio_id, "movie" if typ == "movie" else "series", item)
+            if not isinstance(record.get("state"), dict):
+                record["state"] = {}
+            _apply_membership(record, item, listed)
+            datastore_put(adapter, [record])
+        except Exception:
+            entry = {"status": "failed", "reason": "stremio_watchlist_write_failed", "item": id_minimal(item), "canonical_key": key}
+            unresolved.append(entry)
+            results.append(entry)
+            continue
+        confirmed.append(key)
+        results.append({"status": "applied", "item": id_minimal(item), "canonical_key": key})
+    return build_op_result(ok=not unresolved, count=len(confirmed), confirmed_keys=confirmed, unresolved_keys=unresolved_keys(unresolved, canonical_item_key), unresolved=unresolved, results=results, attempted=attempted)

--- a/providers/tests/test_stremio_sync.py
+++ b/providers/tests/test_stremio_sync.py
@@ -1,0 +1,621 @@
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from providers.sync import _mod_STREMIO as mod
+from providers.sync.stremio import _common, _history, _progress, _ratings, _watchlist
+
+
+class FakeClient:
+    def __init__(self, records: list[dict[str, Any]]):
+        self.records = {str(row["_id"]): copy.deepcopy(row) for row in records}
+        self.puts: list[list[dict[str, Any]]] = []
+
+    def request_json(self, path: str, payload: dict[str, Any] | None = None, **_kwargs: Any) -> dict[str, Any]:
+        payload = dict(payload or {})
+        if path == "datastoreGet":
+            if payload.get("all"):
+                return {"result": list(copy.deepcopy(list(self.records.values())))}
+            ids = [str(x) for x in payload.get("ids") or []]
+            return {"result": [copy.deepcopy(self.records[x]) for x in ids if x in self.records]}
+        if path == "datastoreMeta":
+            return {"result": [{"_id": key, "_mtime": value.get("_mtime")} for key, value in self.records.items()]}
+        if path == "datastorePut":
+            changes = [copy.deepcopy(row) for row in payload.get("changes") or []]
+            self.puts.append(changes)
+            for row in changes:
+                self.records[str(row["_id"])] = row
+            return {"result": {"success": True}}
+        raise AssertionError(path)
+
+
+class FakeAdapter:
+    def __init__(self, records: list[dict[str, Any]]):
+        self.client = FakeClient(records)
+
+
+class FakeResponse:
+    def __init__(self, status_code: int = 200, text: str = "", payload: dict[str, Any] | None = None):
+        self.status_code = status_code
+        self.text = text
+        self.payload = payload if payload is not None else {}
+
+    def json(self) -> dict[str, Any]:
+        return dict(self.payload)
+
+
+class FakeLikesSession:
+    def __init__(self):
+        self.remote: dict[tuple[str, str], str | None] = {}
+        self.gets: list[dict[str, Any]] = []
+        self.posts: list[dict[str, Any]] = []
+
+    def get(self, url: str, **kwargs: Any) -> FakeResponse:
+        self.gets.append({"url": url, **kwargs})
+        params = kwargs.get("params") or {}
+        key = (str(params.get("mediaId") or ""), str(params.get("mediaType") or ""))
+        return FakeResponse(payload={"status": self.remote.get(key)})
+
+    def post(self, url: str, **kwargs: Any) -> FakeResponse:
+        self.posts.append({"url": url, **kwargs})
+        payload = kwargs.get("json") or {}
+        key = (str(payload.get("mediaId") or ""), str(payload.get("mediaType") or ""))
+        self.remote[key] = payload.get("status")
+        return FakeResponse()
+
+
+class FakeLikesClient:
+    def __init__(self):
+        self.session = FakeLikesSession()
+
+    def auth_key(self) -> str:
+        return "auth"
+
+
+class FakeLikesAdapter:
+    def __init__(self, config: dict[str, Any] | None = None):
+        self.client = FakeLikesClient()
+        self.config = config or {}
+        self.instance_id = "default"
+
+
+def movie_record(**extra: Any) -> dict[str, Any]:
+    row = {
+        "_id": "tt0137523",
+        "type": "movie",
+        "name": "Fight Club",
+        "poster": "https://image.example/fight-club.jpg",
+        "_mtime": 1_785_441_200_000,
+        "state": {
+            "lastWatched": 1_785_441_100_000,
+            "timesWatched": 1,
+            "flaggedWatched": 1,
+            "timeOffset": 0,
+            "duration": 8_400_000,
+        },
+    }
+    row.update(extra)
+    return row
+
+
+def series_record(watched: str = "") -> dict[str, Any]:
+    return {
+        "_id": "tt0903747",
+        "type": "series",
+        "name": "Breaking Bad",
+        "poster": "https://image.example/breaking-bad.jpg",
+        "_mtime": 1_785_441_200_000,
+        "state": {
+            "watched": watched,
+            "lastWatched": 1_785_441_100_000,
+            "timesWatched": 7,
+            "flaggedWatched": 1,
+            "timeOffset": 0,
+            "duration": 0,
+            "video_id": None,
+            "season": None,
+            "episode": None,
+        },
+    }
+
+
+def bb_videos() -> list[dict[str, Any]]:
+    return [{"id": f"tt0903747:1:{episode}", "season": 1, "episode": episode, "title": f"Episode {episode}"} for episode in range(1, 8)]
+
+
+def test_parse_watched_movie_record() -> None:
+    item = _history.parse_movie_history_record(movie_record())
+
+    assert item is not None
+    assert item["watched"] is True
+    assert item["ids"] == {"imdb": "tt0137523"}
+    assert item["poster"] == "https://image.example/fight-club.jpg"
+
+
+def test_parse_unwatched_movie_record() -> None:
+    item = _history.parse_movie_history_record(movie_record(state={"lastWatched": None, "timesWatched": 0, "flaggedWatched": 0}))
+
+    assert item is not None
+    assert item["watched"] is False
+
+
+def test_decode_breaking_bad_watched_value_as_s01e01() -> None:
+    watched = _history.decode_watched_episodes("tt0903747:1:1:6:eJxTYIACAAEpACE=", [row["id"] for row in bb_videos()])
+
+    assert watched == {"tt0903747:1:1"}
+
+
+def test_mark_s01e02_watched_preserves_s01e01() -> None:
+    video_ids = [row["id"] for row in bb_videos()]
+    updated = _history.set_episode_watched_value("tt0903747:1:1:6:eJxTYIACAAEpACE=", video_ids, "tt0903747:1:2", True)
+
+    assert _history.decode_watched_episodes(updated, video_ids) == {"tt0903747:1:1", "tt0903747:1:2"}
+
+
+def test_mark_s01e01_unwatched_preserves_other_episodes() -> None:
+    video_ids = [row["id"] for row in bb_videos()]
+    both = _history.set_episode_watched_value("tt0903747:1:1:6:eJxTYIACAAEpACE=", video_ids, "tt0903747:1:2", True)
+    updated = _history.set_episode_watched_value(both, video_ids, "tt0903747:1:1", False)
+
+    assert _history.decode_watched_episodes(updated, video_ids) == {"tt0903747:1:2"}
+
+
+def test_episode_history_read_does_not_expose_stremio_mtime_as_watched_at(monkeypatch) -> None:
+    monkeypatch.setattr(_history, "cinemeta_videos", lambda _adapter, _imdb: bb_videos())
+    adapter = FakeAdapter([series_record("tt0903747:1:1:6:eJxTYIACAAEpACE=")])
+
+    index = _history.build_index(adapter)
+    item = index["imdb:tt0903747#s01e01"]
+
+    assert item["watched"] is True
+    assert "watched_at" not in item
+    assert item["_stremio_changed_at"] == "2026-07-30T19:53:20Z"
+
+
+def test_history_write_enriches_episode_poster_from_tmdb(monkeypatch) -> None:
+    class Provider:
+        def fetch(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "ids": {"tmdb": "124800", "imdb": "tt14586350"},
+                "images": {"poster": [{"url": "https://image.tmdb.org/t/p/w780/love-death.jpg"}]},
+            }
+
+    monkeypatch.setattr(_history, "tmdb_metadata_provider", lambda _adapter: Provider())
+    monkeypatch.setattr(_history, "cinemeta_videos", lambda _adapter, _imdb: [{"id": "tt14586350:1:7", "season": 1, "episode": 7}])
+    adapter = FakeAdapter([])
+    item = {
+        "type": "episode",
+        "series_title": "Love & Death",
+        "show_ids": {"tmdb": "124800"},
+        "season": 1,
+        "episode": 7,
+        "watched_at": "2026-07-30T20:00:00Z",
+    }
+
+    result = _history.add(adapter, [item])
+    written = adapter.client.puts[-1][0]
+
+    assert result["count"] == 1
+    assert written["_id"] == "tt14586350"
+    assert written["poster"] == "https://image.tmdb.org/t/p/w780/love-death.jpg"
+    assert _history.decode_watched_episodes(written["state"]["watched"], ["tt14586350:1:7"]) == {"tt14586350:1:7"}
+
+
+def test_history_write_batches_episodes_per_series(monkeypatch) -> None:
+    monkeypatch.setattr(_history, "cinemeta_videos", lambda _adapter, _imdb: bb_videos())
+    adapter = FakeAdapter([])
+    items = [
+        {"type": "episode", "series_title": "Breaking Bad", "show_ids": {"imdb": "tt0903747"}, "season": 1, "episode": 1},
+        {"type": "episode", "series_title": "Breaking Bad", "show_ids": {"imdb": "tt0903747"}, "season": 1, "episode": 2},
+    ]
+
+    result = _history.add(adapter, items)
+    written = adapter.client.puts[-1][0]
+
+    assert result["count"] == 2
+    assert len(adapter.client.puts) == 1
+    assert len(adapter.client.puts[-1]) == 1
+    assert _history.decode_watched_episodes(written["state"]["watched"], [row["id"] for row in bb_videos()]) == {"tt0903747:1:1", "tt0903747:1:2"}
+
+
+def test_movie_unwatch_write_uses_empty_last_watched() -> None:
+    adapter = FakeAdapter([movie_record()])
+    item = {"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club"}
+
+    result = _history.remove(adapter, [item])
+    written = adapter.client.puts[-1][0]
+
+    assert result["count"] == 1
+    assert written["state"]["lastWatched"] == ""
+    assert written["state"]["timesWatched"] == 0
+    assert written["state"]["flaggedWatched"] == 0
+
+
+def test_stremio_reuses_tmdb_metadata_provider(monkeypatch) -> None:
+    class Provider:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+    adapter = FakeAdapter([])
+    adapter.config = {"tmdb": {"api_key": "key"}}
+    monkeypatch.setattr("providers.metadata._meta_TMDB.TmdbProvider", Provider)
+
+    first = _common.tmdb_metadata_provider(adapter)
+    second = _common.tmdb_metadata_provider(adapter)
+
+    assert first is second
+
+
+def test_parse_movie_progress_from_time_offset_and_duration() -> None:
+    item = _progress.parse_movie_progress_record(movie_record(state={"timeOffset": 120_000, "duration": 600_000, "lastWatched": 1_785_441_100_000}))
+
+    assert item is not None
+    assert item["progress_ms"] == 120_000
+    assert item["duration_ms"] == 600_000
+    assert item["progress_percent"] == 20.0
+
+
+def test_parse_episode_progress_uses_video_id() -> None:
+    record = series_record()
+    record["state"].update({"video_id": "tt0903747:1:2", "season": 1, "episode": 2, "timeOffset": 60_000, "duration": 600_000})
+
+    item = _progress.parse_episode_progress_record(record)
+
+    assert item is not None
+    assert item["show_ids"] == {"imdb": "tt0903747"}
+    assert item["season"] == 1
+    assert item["episode"] == 2
+    assert item["_stremio_video_id"] == "tt0903747:1:2"
+
+
+def test_progress_write_preserves_history_bitfield_and_unknown_fields() -> None:
+    record = series_record("tt0903747:1:1:6:eJxTYIACAAEpACE=")
+    record["unknown"] = {"keep": True}
+    adapter = FakeAdapter([record])
+    item = {
+        "type": "episode",
+        "show_ids": {"imdb": "tt0903747"},
+        "season": 1,
+        "episode": 2,
+        "progress_ms": 120_000,
+        "duration_ms": 600_000,
+    }
+
+    result = _progress.add(adapter, [item])
+    written = adapter.client.puts[-1][0]
+
+    assert result["count"] == 1
+    assert written["unknown"] == {"keep": True}
+    assert written["state"]["watched"] == "tt0903747:1:1:6:eJxTYIACAAEpACE="
+    assert written["state"]["timesWatched"] == 7
+    assert written["state"]["flaggedWatched"] == 1
+    assert written["state"]["lastWatched"] == 1_785_441_100_000
+    assert written["state"]["video_id"] == "tt0903747:1:2"
+    assert isinstance(written["_mtime"], str)
+    assert written["_mtime"].endswith("Z")
+
+
+def test_progress_write_enriches_percent_only_episode_from_tmdb(monkeypatch) -> None:
+    class Provider:
+        def fetch(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "ids": {"tmdb": "124800", "imdb": "tt14586350"},
+                "runtime_minutes": None,
+                "images": {"poster": [{"url": "https://image.tmdb.org/t/p/w780/love-death.jpg"}]},
+            }
+
+        def _get(self, _url: str) -> dict[str, Any]:
+            return {"runtime": 49}
+
+    monkeypatch.setattr(_progress, "tmdb_metadata_provider", lambda _adapter: Provider())
+    adapter = FakeAdapter([])
+    item = {
+        "type": "episode",
+        "series_title": "Love & Death",
+        "show_ids": {"tmdb": "124800"},
+        "season": 1,
+        "episode": 7,
+        "progress_percent": 10.0,
+    }
+
+    result = _progress.add(adapter, [item])
+    written = adapter.client.puts[-1][0]
+
+    assert result["count"] == 1
+    assert written["_id"] == "tt14586350"
+    assert written["poster"] == "https://image.tmdb.org/t/p/w780/love-death.jpg"
+    assert written["state"]["video_id"] == "tt14586350:1:7"
+    assert written["state"]["duration"] == 2_940_000
+    assert written["state"]["timeOffset"] == 294_000
+
+
+def test_progress_percent_without_duration_reports_duration_missing() -> None:
+    adapter = FakeAdapter([series_record()])
+    item = {"type": "episode", "show_ids": {"imdb": "tt0903747"}, "season": 1, "episode": 2, "progress_percent": 10.0}
+
+    result = _progress.add(adapter, [item])
+
+    assert result["count"] == 0
+    assert result["unresolved"][0]["reason"] == "stremio_duration_missing"
+
+
+def test_created_record_uses_stremio_library_shape() -> None:
+    record = _common.default_record("tt0137523", "movie", {"title": "Fight Club", "poster": "not-a-url"}, timestamp=1_785_441_200_000)
+
+    assert record["_ctime"] == _common.iso_from_epoch_ms(1_785_441_200_000)
+    assert record["_mtime"] == _common.iso_from_epoch_ms(1_785_441_200_000)
+    assert record["poster"] == ""
+    assert record["state"]["lastWatched"] == ""
+    assert record["state"]["video_id"] == ""
+    assert record["state"]["watched"] == ""
+    assert record["state"]["noNotif"] is False
+    assert record["state"]["season"] == 0
+    assert record["state"]["episode"] == 0
+    assert record["behaviorHints"] == {"defaultVideoId": None, "featuredVideoId": None, "hasScheduledVideos": False}
+
+
+def test_watchlist_reads_explicit_library_movies_and_series() -> None:
+    movie = movie_record(removed=False, temp=False)
+    show = series_record()
+    show["removed"] = False
+    show["temp"] = False
+    adapter = FakeAdapter([movie, show])
+
+    index = _watchlist.build_index(adapter)
+
+    assert set(index) == {"imdb:tt0137523", "imdb:tt0903747"}
+    assert index["imdb:tt0903747"]["type"] == "show"
+
+
+def test_watchlist_excludes_temporary_history_progress_records() -> None:
+    movie = movie_record(removed=True, temp=True)
+    adapter = FakeAdapter([movie])
+
+    assert _watchlist.build_index(adapter) == {}
+
+
+def test_watchlist_removed_marker_is_observed_as_absent() -> None:
+    movie = movie_record(removed=True, temp=False)
+    adapter = FakeAdapter([movie])
+
+    assert _watchlist.build_index(adapter) == {}
+
+
+def test_watchlist_add_existing_history_record_preserves_history() -> None:
+    record = movie_record(removed=True, temp=True)
+    adapter = FakeAdapter([record])
+    item = {"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club"}
+
+    result = _watchlist.add(adapter, [item])
+    written = adapter.client.puts[-1][0]
+
+    assert result["count"] == 1
+    assert written["removed"] is False
+    assert written["temp"] is False
+    assert written["state"]["lastWatched"] == 1_785_441_100_000
+    assert written["state"]["timesWatched"] == 1
+    assert written["state"]["flaggedWatched"] == 1
+
+
+def test_watchlist_remove_preserves_history_and_progress() -> None:
+    record = series_record("tt0903747:1:1:6:eJxTYIACAAEpACE=")
+    record["removed"] = False
+    record["temp"] = False
+    record["state"].update({"timeOffset": 120_000, "duration": 600_000, "video_id": "tt0903747:1:2", "season": 1, "episode": 2})
+    adapter = FakeAdapter([record])
+    item = {"type": "show", "ids": {"imdb": "tt0903747"}, "title": "Breaking Bad"}
+
+    result = _watchlist.remove(adapter, [item])
+    written = adapter.client.puts[-1][0]
+
+    assert result["count"] == 1
+    assert written["removed"] is True
+    assert written["temp"] is False
+    assert isinstance(written["_mtime"], str)
+    assert written["_mtime"].endswith("Z")
+    assert written["state"]["watched"] == "tt0903747:1:1:6:eJxTYIACAAEpACE="
+    assert written["state"]["lastWatched"] == 1_785_441_100_000
+    assert written["state"]["timesWatched"] == 7
+    assert written["state"]["flaggedWatched"] == 1
+    assert written["state"]["timeOffset"] == 120_000
+    assert written["state"]["duration"] == 600_000
+    assert written["state"]["video_id"] == "tt0903747:1:2"
+
+
+def test_ratings_write_maps_numeric_rating_to_stremio_reaction(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(_ratings, "STATE_DIR", tmp_path)
+    monkeypatch.setenv("CW_PAIR_KEY", "trakt-stremio")
+    adapter = FakeLikesAdapter()
+    items = [
+        {"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club", "rating": 7.9},
+        {"type": "show", "ids": {"imdb": "tt0903747"}, "title": "Breaking Bad", "rating": 8.0},
+    ]
+
+    result = _ratings.add(adapter, items)
+    payloads = [row["json"] for row in adapter.client.session.posts]
+
+    assert result["count"] == 2
+    assert payloads[0]["status"] == "liked"
+    assert payloads[0]["mediaType"] == "movie"
+    assert payloads[1]["status"] == "loved"
+    assert payloads[1]["mediaType"] == "series"
+    assert _ratings.build_index(adapter)["imdb:tt0137523"]["rating"] == 7.9
+
+
+def test_ratings_write_uses_configured_stremio_thresholds(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(_ratings, "STATE_DIR", tmp_path)
+    monkeypatch.setenv("CW_PAIR_KEY", "trakt-stremio")
+    adapter = FakeLikesAdapter({"stremio": {"ratings": {"liked_min": 5.0, "loved_min": 9.0}}})
+    items = [
+        {"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club", "rating": 8.5},
+        {"type": "movie", "ids": {"imdb": "tt0111161"}, "title": "The Shawshank Redemption", "rating": 9.0},
+    ]
+
+    result = _ratings.add(adapter, items)
+    payloads = [row["json"] for row in adapter.client.session.posts]
+
+    assert result["count"] == 2
+    assert payloads[0]["status"] == "liked"
+    assert payloads[1]["status"] == "loved"
+
+
+def test_ratings_write_skips_values_below_stremio_threshold(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(_ratings, "STATE_DIR", tmp_path)
+    monkeypatch.setenv("CW_PAIR_KEY", "simkl-stremio")
+    adapter = FakeLikesAdapter()
+
+    result = _ratings.add(adapter, [{"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club", "rating": 5.9}])
+
+    assert result["count"] == 0
+    assert result["skipped"] == 1
+    assert result["unresolved"] == []
+    assert adapter.client.session.posts == []
+    cached = _ratings.build_index(adapter)["imdb:tt0137523"]
+    assert cached["rating"] == 5.9
+    assert cached["_stremio_reaction"] is None
+
+
+def test_ratings_write_updates_below_threshold_cache_when_rating_becomes_liked(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(_ratings, "STATE_DIR", tmp_path)
+    monkeypatch.setenv("CW_PAIR_KEY", "simkl-stremio")
+    adapter = FakeLikesAdapter()
+
+    _ratings.add(adapter, [{"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club", "rating": 5}])
+    result = _ratings.add(adapter, [{"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club", "rating": 6}])
+
+    assert result["count"] == 1
+    assert adapter.client.session.posts[-1]["json"]["status"] == "liked"
+    assert _ratings.build_index(adapter)["imdb:tt0137523"]["_stremio_reaction"] == "liked"
+
+
+def test_ratings_write_skips_when_remote_reaction_already_matches_after_cache_clear(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(_ratings, "STATE_DIR", tmp_path)
+    monkeypatch.setenv("CW_PAIR_KEY", "simkl-stremio")
+    adapter = FakeLikesAdapter()
+    adapter.client.session.remote[("tt0137523", "movie")] = "liked"
+
+    result = _ratings.add(adapter, [{"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club", "rating": 7}])
+
+    assert result["count"] == 0
+    assert result["skipped"] == 1
+    assert adapter.client.session.posts == []
+    assert _ratings.build_index(adapter)["imdb:tt0137523"]["_stremio_reaction"] == "liked"
+
+
+def test_ratings_below_threshold_cache_preserves_source_keyspace(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(_ratings, "STATE_DIR", tmp_path)
+    monkeypatch.setenv("CW_PAIR_KEY", "simkl-stremio")
+    adapter = FakeLikesAdapter()
+
+    _ratings.add(adapter, [{"type": "movie", "ids": {"tmdb": "1111873", "imdb": "tt27489557"}, "title": "Abigail", "rating": 2}])
+
+    assert list(_ratings.build_index(adapter)) == ["tmdb:1111873"]
+
+
+def test_ratings_cache_is_ignored_in_capture_mode(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(_ratings, "STATE_DIR", tmp_path)
+    monkeypatch.setenv("CW_PAIR_KEY", "simkl-stremio")
+    adapter = FakeLikesAdapter()
+
+    _ratings.add(adapter, [{"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club", "rating": 8}])
+    assert _ratings.build_index(adapter)
+
+    monkeypatch.setenv("CW_CAPTURE_MODE", "1")
+    assert _ratings.build_index(adapter) == {}
+
+
+def test_ratings_remove_clears_stremio_reaction(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(_ratings, "STATE_DIR", tmp_path)
+    monkeypatch.setenv("CW_PAIR_KEY", "trakt-stremio")
+    adapter = FakeLikesAdapter()
+    item = {"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club", "rating": 8}
+
+    _ratings.add(adapter, [item])
+    result = _ratings.remove(adapter, [item])
+
+    assert result["count"] == 1
+    assert adapter.client.session.posts[-1]["json"]["status"] is None
+    assert _ratings.build_index(adapter) == {}
+
+
+def test_ratings_write_requires_stremio_imdb_id(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(_ratings, "STATE_DIR", tmp_path)
+    monkeypatch.setenv("CW_PAIR_KEY", "tmdb-stremio")
+    adapter = FakeLikesAdapter()
+
+    result = _ratings.add(adapter, [{"type": "movie", "ids": {"tmdb": "550"}, "title": "Fight Club", "rating": 8.5}])
+
+    assert result["count"] == 0
+    assert result["unresolved"][0]["reason"] == "stremio_rating_id_missing"
+    assert adapter.client.session.posts == []
+
+
+def test_capability_set_advertises_history_progress_and_watchlist() -> None:
+    caps = mod.OPS.capabilities()
+
+    assert mod.OPS.features() == {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False}
+    assert caps["history"]["read"] is True
+    assert caps["history"]["write"] is True
+    assert caps["progress"]["read"] is True
+    assert caps["progress"]["write"] is True
+    assert caps["watchlist"]["read"] is True
+    assert caps["watchlist"]["write"] is True
+    assert caps["watchlist"]["custom_lists"] is False
+    assert caps["ratings"]["read"] is False
+    assert caps["ratings"]["write"] is True
+    assert caps["ratings"]["direction"] == "destination_only"
+    assert caps["ratings"]["thresholds"] == {"liked_min": 6.0, "loved_min": 8.0}
+    assert caps["ratings"]["accepted_ids"] == ["imdb"]
+    assert caps["progress"]["index_semantics"] == "present"
+    assert caps["progress"]["requires_duration"] is True
+    assert caps["progress"]["completion_policy"]["progress_write"] == {"mode": "none"}
+    assert caps.get("multi_profile") is not True
+    assert "stremio_profile_id" not in caps
+    assert "server_completion_percent" not in caps["progress"]
+
+
+def test_incremental_cache_is_stremio_profile_scoped() -> None:
+    adapter = FakeAdapter([movie_record()])
+
+    _progress.build_index(adapter)
+
+    assert getattr(adapter, "_stremio_mtime_cache_default") == {"tt0137523": 1_785_441_200_000}
+    assert not hasattr(adapter, "_stremio_mtime_cache")
+
+
+def test_incremental_cache_accepts_stremio_iso_mtime() -> None:
+    first = movie_record(_mtime="2026-07-30T18:33:20Z")
+    adapter = FakeAdapter([first])
+
+    _common.library_records(adapter)
+    adapter.client.records["tt0137523"]["_mtime"] = "2026-07-30T18:34:20Z"
+    rows = _common.library_records(adapter, incremental=True)
+
+    assert [row["_id"] for row in rows] == ["tt0137523"]
+    assert getattr(adapter, "_stremio_mtime_cache_default") == {"tt0137523": _common.epoch_ms("2026-07-30T18:34:20Z")}
+
+
+def test_library_records_capture_mode_forces_full_read(monkeypatch) -> None:
+    adapter = FakeAdapter([movie_record(), movie_record(_id="tt0903747", _mtime=1)])
+
+    _common.library_records(adapter)
+    monkeypatch.setenv("CW_CAPTURE_MODE", "1")
+    rows = _common.library_records(adapter, incremental=True)
+
+    assert {row["_id"] for row in rows} == {"tt0137523", "tt0903747"}
+
+
+def test_health_reports_stremio_api_error_detail(monkeypatch) -> None:
+    def fail(_adapter):
+        raise mod.StremioAuthError("bad", reason="request_failed", detail={"message": "bad authKey"}, status_code=200, endpoint="datastoreMeta")
+
+    monkeypatch.setattr(mod, "datastore_meta", fail)
+
+    health = mod.STREMIOModule({"stremio": {"auth_key": "key"}}).health()
+
+    assert health["status"] == "request_failed"
+    assert health["details"] == {"reason": "request_failed"}
+    assert health["api"]["datastoreMeta"]["status"] == 200
+    assert health["api"]["datastoreMeta"]["endpoint"] == "datastoreMeta"
+    assert "authKey" not in health["api"]["datastoreMeta"]["detail"]


### PR DESCRIPTION
# Pull request

## Change

Adds the Stremio sync adapter backend.

Includes support for Stremio history, progress, watchlist, and destination-only ratings reactions using the existing CW patterns.

## Why

Stremio needs provider-side sync support now that auth and connection handling are in place.

## Testing

Added Stremio sync tests for history, progress, watchlist, ratings, bitfield handling, record writes, and capabilities.

## Issue

NA