### PR TITLE
Add: Stremio pair config rules

### DIFF
--- a/assets/js/modals/pair-config/custom-rules.js
+++ b/assets/js/modals/pair-config/custom-rules.js
@@ -1,0 +1,55 @@
+/* assets/js/modals/pair-config/custom-rules.js */
+/* Provider-specific pair rules for the pair-config modal. */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude */
+
+const same = (a, b) => String(a || "").trim().toLowerCase() === String(b || "").trim().toLowerCase();
+const isTwoWay = state => !!state?.twoWay || String(state?.mode || "").trim().toLowerCase().startsWith("two");
+
+const RATINGS_TYPE_RULES = {
+  SIMKL: { disable: ["seasons", "episodes"] },
+  TMDB: { disable: ["seasons"] },
+  ANILIST: { disable: ["seasons", "episodes"] },
+  STREMIO: { disable: ["seasons", "episodes"] },
+};
+
+export function ratingsDisabledForPair(state) {
+  const names = [state?.src, state?.dst].map(x => String(x || "").trim().toUpperCase());
+  const out = new Set();
+  names.forEach(n => {
+    const rule = RATINGS_TYPE_RULES[n];
+    if (rule && Array.isArray(rule.disable)) rule.disable.forEach(t => out.add(t));
+  });
+  return out;
+}
+
+export function stremioRatingsAllowed(state) {
+  return same(state?.dst, "stremio") && !same(state?.src, "stremio") && !isTwoWay(state);
+}
+
+export function featureAllowedForPair(state, feature) {
+  const key = String(feature || "").trim().toLowerCase();
+  if (key === "ratings" && (same(state?.src, "stremio") || same(state?.dst, "stremio"))) {
+    return stremioRatingsAllowed(state);
+  }
+  return true;
+}
+
+export function sanitizeFeaturesForPair(state, features) {
+  const out = features && typeof features === "object" ? features : {};
+  if (!featureAllowedForPair(state, "ratings") && out.ratings && typeof out.ratings === "object") {
+    Object.assign(out.ratings, { enable: false, add: false, remove: false });
+  }
+  return out;
+}
+
+export function commonFeaturesForPair(state, providerFeatures, isProgressPair) {
+  if (!state?.src || !state?.dst) return [];
+  const a = providerFeatures(state.src);
+  const b = providerFeatures(state.dst);
+  const keys = ["watchlist", "ratings", "history", "progress", "playlists"];
+  return keys.filter(k => {
+    if (!featureAllowedForPair(state, k)) return false;
+    if (k === "progress") return isProgressPair(state) && !!a.progress && !!b.progress;
+    return !!a[k] && !!b[k];
+  });
+}

--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -8,6 +8,7 @@ import { createLibraryController } from "./libraries.js";
 import { providerLogoHTML, providerToneRgb, sharedFeatureOrder, sharedFeatureLabel } from "./meta.js";
 import { ensurePairConfigStyles } from "./styles.js";
 import { createTabsController } from "./tabs.js";
+import { commonFeaturesForPair, ratingsDisabledForPair, sanitizeFeaturesForPair } from "./custom-rules.js";
 
 const TWO_WAY_WARNING =
   "Two-way sync means both sides can write to each other. It keeps both providers aligned, but it also heavily increases the risk of conflicts, duplicates, overwrites, and deletions. Use with extreme caution.";
@@ -31,6 +32,7 @@ const isJelly=(v)=>same(v,"jellyfin");
 const isTrakt=(v)=>same(v,"trakt");
 const isMDBList=(v)=>same(v,"mdblist");
 const isPublicMetaDB=(v)=>same(v,"publicmetadb");
+const isStremio=(v)=>same(v,"stremio");
 const isPlex = (v) => same(v, "plex");
 const isKodi = (v) => same(v, "kodi");
 const isCrossWatch = (v) => same(v, "crosswatch");
@@ -44,6 +46,7 @@ function hasJelly(state){return isJelly(state?.src)||isJelly(state?.dst)}
 function hasTrakt(state){return isTrakt(state?.src)||isTrakt(state?.dst)}
 function hasMDBList(state){return isMDBList(state?.src)||isMDBList(state?.dst)}
 function hasPublicMetaDB(state){return isPublicMetaDB(state?.src)||isPublicMetaDB(state?.dst)}
+function hasStremio(state){return isStremio(state?.src)||isStremio(state?.dst)}
 const isAniList=(v)=>same(v,"anilist");
 function hasAniList(state){return isAniList(state?.src)||isAniList(state?.dst)}
 function hasOwn(obj,key){return !!obj&&Object.prototype.hasOwnProperty.call(obj,key)}
@@ -73,12 +76,8 @@ function normalizeAnimeFeatureOptions(state, feature){
   return opts;
 }
 
-const RATINGS_TYPE_RULES={SIMKL:{disable:["seasons","episodes"]},TMDB:{disable:["seasons"]},ANILIST:{disable:["seasons","episodes"]}};
 function ratingsDisabledFor(state){
-  const names=[state?.src,state?.dst].map(x=>String(x||"").trim().toUpperCase());
-  const out=new Set();
-  names.forEach(n=>{const r=RATINGS_TYPE_RULES[n];if(r&&Array.isArray(r.disable))r.disable.forEach(t=>out.add(t))});
-  return out;
+  return ratingsDisabledForPair(Object.assign({}, state || {}, {twoWay:isTwoWayMode(state)}));
 }
 function applyRatingsTypeRules(state){
   const rt=state.options?.ratings||{};
@@ -412,14 +411,8 @@ function applyProgressMaxRecommendation(state, progress){
   return {maxPercent, recommended, usingRecommendation: useRecommended};
 }
 const commonFeatures=(state)=>{
-  if(!state.src||!state.dst) return [];
-  const a=byName(state,state.src)?.features||{};
-  const b=byName(state,state.dst)?.features||{};
-  const keys=["watchlist","ratings","history","progress","playlists"];
-  return keys.filter(k=>{
-    if(k==="progress") return isProgressPair(state) && !!a.progress && !!b.progress;
-    return !!a[k] && !!b[k];
-  });
+  const ruleState=Object.assign({}, state || {}, {twoWay:isTwoWayMode(state)});
+  return commonFeaturesForPair(ruleState, name => byName(state, name)?.features || {}, isProgressPair);
 };
 const defaultFor=(k)=>
   k==="watchlist"?{enable:false,add:false,remove:false}:
@@ -1362,6 +1355,27 @@ function renderFeaturePanel(state){
       `);
     }
 
+    if (hasStremio(state)) {
+      const sr = ((state.cfgRaw?.stremio) || {}).ratings || {};
+      parts.push(`
+        <div class="panel-title small" style="margin-top:6px">Stremio</div>
+        <details id="cx-st-rt">
+          <summary class="muted" style="margin-bottom:10px;">Stremio ratings controls</summary>
+          <div class="grid2 compact">
+            <div class="opt-row">
+              <label for="st-rt-liked-min">Liked from</label>
+              <input id="st-rt-liked-min" class="input small" type="number" min="0" max="10" step="0.1" value="${sr.liked_min ?? 6.0}">
+            </div>
+            <div class="opt-row">
+              <label for="st-rt-loved-min">Loved from</label>
+              <input id="st-rt-loved-min" class="input small" type="number" min="0" max="10" step="0.1" value="${sr.loved_min ?? 8.0}">
+            </div>
+          </div>
+          <div class="hint">Ratings below Liked from are not sent to Stremio.</div>
+        </details>
+      `);
+    }
+
     if (hasMDBList(state)) {
       const md = (state.cfgRaw?.mdblist) || {};
       parts.push(`
@@ -2270,6 +2284,25 @@ async function saveConfigBits(state){
       cfg.simkl = sm;
     }
 
+    const hasST = String(state.src||"").toUpperCase()==="STREMIO" || String(state.dst||"").toUpperCase()==="STREMIO";
+    if(hasST){
+      const st = Object.assign({}, cfg.stremio||{});
+      const ratings = Object.assign({}, st.ratings||{});
+      const likedEl = ID("st-rt-liked-min");
+      const lovedEl = ID("st-rt-loved-min");
+      const clampFloat = (value, fallback) => {
+        const n = Number.parseFloat(String(value ?? "").trim());
+        return Number.isFinite(n) ? Math.min(10, Math.max(0, Math.round(n * 10) / 10)) : fallback;
+      };
+      if(likedEl || lovedEl){
+        ratings.liked_min = clampFloat(likedEl?.value, 6.0);
+        ratings.loved_min = clampFloat(lovedEl?.value, 8.0);
+        if(ratings.loved_min < ratings.liked_min) ratings.loved_min = ratings.liked_min;
+        st.ratings = ratings;
+        cfg.stremio = st;
+      }
+    }
+
     const hasMD = String(state.src||"").toUpperCase()==="MDBLIST" || String(state.dst||"").toUpperCase()==="MDBLIST";
     if(hasMD){
       const md = Object.assign({}, cfg.mdblist||{});
@@ -2342,7 +2375,8 @@ function buildPayload(state,wrap){
   progress.max_percent = applyProgressMaxRecommendation(state, progress).maxPercent;
   const dis=ratingsDisabledFor({src,dst});
   if(ratings&&Array.isArray(ratings.types)&&dis.size)ratings.types=ratings.types.filter(t=>!dis.has(String(t)));
-  const payload={source:src,target:dst,source_instance:String(srcInst||"default"),target_instance:String(dstInst||"default"),enabled,mode:modeTwo?"two-way":"one-way",features:{watchlist,ratings,history:get("history"),progress,playlists:get("playlists")}};
+  const features=sanitizeFeaturesForPair({src,dst,twoWay:modeTwo},{watchlist,ratings,history:get("history"),progress,playlists:get("playlists")});
+  const payload={source:src,target:dst,source_instance:String(srcInst||"default"),target_instance:String(dstInst||"default"),enabled,mode:modeTwo?"two-way":"one-way",features};
   const prov={};
   const pp=state.pairProviders||{};
   const usePlex=(String(src).toUpperCase()==="PLEX"||String(dst).toUpperCase()==="PLEX");
@@ -2457,7 +2491,7 @@ export default{
     restartFlowAnimation(ID("cx-mode-two")?.checked ? "two" : "one");
 
     ID("cx-enabled").addEventListener("change",()=>updateFlow(state,true));
-    QA('input[name="cx-mode"]').forEach(el=>el.addEventListener("change",()=>{state.mode=ID("cx-mode-two")?.checked?"two-way":"one-way";updateFlow(state,true);renderFeaturePanel(state)}));
+    QA('input[name="cx-mode"]').forEach(el=>el.addEventListener("change",()=>{state.mode=ID("cx-mode-two")?.checked?"two-way":"one-way";sanitizeFeaturesForPair(state,state.options);updateFlow(state,true);refreshTabs(state);renderFeaturePanel(state)}));
     bindChangeHandlers(state,wrap);
     queueMicrotask(() => applyHelpIcons(wrap, { QA }));
     ensureInlineFoot(hostEl);

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -358,6 +358,10 @@ DEFAULT_CFG: dict[str, Any] = {
 
     "stremio": {
         "auth_key": "",
+        "ratings": {
+            "liked_min": 6.0,                           # Numeric ratings from this value up to loved_min become Liked
+            "loved_min": 8.0,                           # Numeric ratings from this value up to 10 become Loved
+        },
     },
 
     "playback_progress": {
@@ -606,11 +610,16 @@ DEFAULT_CFG: dict[str, Any] = {
         "snapshot_ttl_sec": 300,                        # Reuse snapshots within 5 min
         "apply_chunk_size": 100,                        # Sweet spot for apply chunking
         "apply_chunk_pause_ms": 50,                     # Small pause between chunks
-        "apply_chunk_size_by_provider": {               # SIMKL/TRAKT/MDBLIST/PUBLICMETADB/ANILIST/TMDB/TAUTULLI/PLEX/JELLYFIN/EMBY overrides
+        "apply_chunk_size_by_provider": {               # Provider-specific apply chunk overrides
             "SIMKL": 500,
             "MDBLIST": 500,
             "PUBLICMETADB": 500,
-            "STREMIO": 1000
+            "PLEX": 500,
+            "JELLYFIN": 500,
+            "EMBY": 500,
+            "STREMIO": 500,
+            "NUVIO": 500,
+            "KODI": 500
         },
         
         # suspect guard (shrinking inventories protection)
@@ -1330,8 +1339,23 @@ def _normalize_stremio(cfg: dict[str, Any]) -> None:
 
     def _block(block: dict[str, Any]) -> None:
         key = str(block.get("auth_key") or block.get("authKey") or "").strip()
+        raw_ratings = block.get("ratings") if isinstance(block.get("ratings"), dict) else {}
+        ratings = cast(dict[str, Any], raw_ratings)
+
+        def _rating_float(name: str, default: float) -> float:
+            try:
+                value = float(str(ratings.get(name, default)).strip())
+            except Exception:
+                value = default
+            return value if 0 <= value <= 10 else default
+
+        liked_min = _rating_float("liked_min", 6.0)
+        loved_min = _rating_float("loved_min", 8.0)
+        if loved_min < liked_min:
+            loved_min = liked_min
         block.clear()
         block["auth_key"] = key
+        block["ratings"] = {"liked_min": liked_min, "loved_min": loved_min}
 
     _block(s)
     if isinstance(insts, dict):

--- a/tests/test_history_specials.py
+++ b/tests/test_history_specials.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 from cw_platform.id_map import canonical_key, minimal
 from cw_platform.orchestrator import _applier, _unresolved
+from cw_platform.orchestrator._pairs_oneway import compute_effective_add
 from providers.sync.mdblist._history import _bucketize
 from providers.sync.publicmetadb._history import _payload_for_item, _to_minimal
 from providers.sync._mod_SIMKL import _confirmed_keys
@@ -632,6 +633,49 @@ def test_applier_prefers_provider_unresolved_keys(monkeypatch) -> None:
     assert sorted(norm["unresolved_keys"]) == sorted(keys[1:])
     assert norm["confirmed"] == 1
     assert norm["skipped"] == 0
+
+
+def test_applier_exact_skipped_adds_do_not_become_unresolved(monkeypatch) -> None:
+    monkeypatch.setattr(_applier, "record_unresolved", lambda *a, **k: {"ok": True})
+    items = [{"type": "movie", "ids": {"tmdb": str(i)}} for i in range(3)]
+    keys = [canonical_key(it) for it in items]
+    res = {
+        "ok": True,
+        "count": 0,
+        "confirmed_keys": [],
+        "skipped": 3,
+        "skipped_keys": keys,
+        "unresolved": [],
+        "unresolved_keys": [],
+    }
+
+    norm = _applier._normalize(res, items, "apply:add", dst="STREMIO", feature="ratings", emit=lambda *a, **k: None)
+
+    assert norm["confirmed"] == 0
+    assert norm["skipped"] == 3
+    assert norm["skipped_exact"] == 3
+    assert norm["unresolved"] == 0
+    assert norm["unresolved_keys"] == []
+
+
+def test_exact_skipped_add_keys_count_as_success_without_added_count() -> None:
+    keys = ["tmdb:1", "tmdb:2"]
+
+    decision = compute_effective_add(
+        attempted_keys=keys,
+        prov_confirmed=0,
+        confirmed_keys=[],
+        still_unresolved=set(),
+        skipped_keys=set(keys),
+        have_exact_keys=True,
+        verify_after_write=False,
+        provider_skipped=True,
+    )
+
+    assert decision["effective"] == 0
+    assert decision["prov_confirmed"] == 0
+    assert decision["success_keys"] == keys
+    assert decision["failed_keys"] == []
 
 
 def test_unresolved_reports_simkl_source_and_cache_gets_trakt_item(monkeypatch) -> None:


### PR DESCRIPTION
# Pull request

## Change

- Adds provider-specific pair config rules and Stremio ratings controls.
- Adds Stremio rating threshold defaults
- Updates provider chunk defaults

## Why

Stremio ratings only make sense as one-way provider to Stremio. 
The pair modal now hides/disables invalid ratings setups.

## Testing

- Validated pair config JS syntax
- Added/ran tests for exact skipped add accounting

## Issue

Relates to Stremio pair configuration