### PR TITLE
Change: prefer Metahub artwork for IMDb-backed Stremio

### DIFF
--- a/providers/sync/stremio/_common.py
+++ b/providers/sync/stremio/_common.py
@@ -112,6 +112,18 @@ def stremio_id_for_item(item: Mapping[str, Any]) -> str | None:
     return imdb_id(imdb_ids_from_item(item).get("imdb"))
 
 
+def metahub_poster_url(stremio_id: Any) -> str:
+    found = imdb_id(stremio_id)
+    return f"https://images.metahub.space/poster/small/{found}/img" if found else ""
+
+
+def poster_url_from_item(item: Mapping[str, Any], stremio_id: Any = None) -> str:
+    poster = str(item.get("poster") or item.get("poster_url") or item.get("posterUrl") or "").strip()
+    if poster.startswith(("http://", "https://")):
+        return poster
+    return metahub_poster_url(stremio_id or stremio_id_for_item(item))
+
+
 def video_id_for_episode(item: Mapping[str, Any], show_id: str) -> str | None:
     direct = str(item.get("_stremio_video_id") or item.get("video_id") or "").strip()
     if direct:
@@ -214,8 +226,7 @@ def default_record(stremio_id: str, item_type: str, item: Mapping[str, Any] | No
     ts = iso_from_epoch_ms(timestamp) or now_iso()
     typ = "series" if item_type in {"series", "show", "episode", "episodes"} else "movie"
     src = item or {}
-    poster = str(src.get("poster") or src.get("poster_url") or src.get("posterUrl") or "").strip()
-    poster_value = poster if poster.startswith(("http://", "https://")) else ""
+    poster_value = poster_url_from_item(src, stremio_id)
     return {
         "_id": stremio_id,
         "name": str(src.get("series_title") or src.get("show_title") or src.get("title") or stremio_id),

--- a/providers/sync/stremio/_history.py
+++ b/providers/sync/stremio/_history.py
@@ -151,7 +151,10 @@ def _image_url(detail: Mapping[str, Any], kind: str) -> str:
 
 def _metadata_enriched(adapter: Any, item: Mapping[str, Any], typ: str) -> dict[str, Any]:
     out = dict(item)
-    if stremio_id_for_item(out) and str(out.get("poster") or out.get("poster_url") or "").strip():
+    stremio_id = stremio_id_for_item(out)
+    if stremio_id:
+        if not str(out.get("poster") or out.get("poster_url") or "").strip():
+            out["poster"] = poster_url_from_item(out, stremio_id)
         return out
     provider = tmdb_metadata_provider(adapter)
     if provider is None:
@@ -187,9 +190,8 @@ def _metadata_enriched(adapter: Any, item: Mapping[str, Any], typ: str) -> dict[
             merged = dict(out_ids)
             merged["imdb"] = imdb
             out["ids"] = merged
-    poster = str(out.get("poster") or out.get("poster_url") or "").strip()
-    if not poster:
-        poster = _image_url(detail, "poster")
+    if not str(out.get("poster") or out.get("poster_url") or "").strip():
+        poster = poster_url_from_item(out, imdb) or _image_url(detail, "poster")
         if poster:
             out["poster"] = poster
     return out

--- a/providers/sync/stremio/_history.py
+++ b/providers/sync/stremio/_history.py
@@ -32,6 +32,7 @@ from ._common import (
     record_id,
     state_of,
     stremio_id_for_item,
+    poster_url_from_item,
     tmdb_metadata_provider,
     video_id_for_episode,
 )
@@ -247,8 +248,8 @@ def _api_failure(item: Mapping[str, Any], key: str, exc: StremioAuthError, fallb
 
 
 def _apply_poster(record: dict[str, Any], item: Mapping[str, Any]) -> None:
-    poster = str(item.get("poster") or item.get("poster_url") or item.get("posterUrl") or "").strip()
-    if poster.startswith(("http://", "https://")) and not str(record.get("poster") or "").strip():
+    poster = poster_url_from_item(item, record.get("_id"))
+    if poster and not str(record.get("poster") or "").strip():
         record["poster"] = poster
 
 

--- a/providers/sync/stremio/_progress.py
+++ b/providers/sync/stremio/_progress.py
@@ -24,6 +24,7 @@ from ._common import (
     read_merge_write,
     state_of,
     stremio_id_for_item,
+    poster_url_from_item,
     tmdb_metadata_provider,
     to_int,
     video_id_for_episode,
@@ -229,8 +230,8 @@ def _api_failure(item: Mapping[str, Any], key: str, exc: StremioAuthError, fallb
 
 def _apply_progress(record: dict[str, Any], item: Mapping[str, Any], clear: bool) -> str | None:
     state = record.setdefault("state", {})
-    poster = str(item.get("poster") or item.get("poster_url") or item.get("posterUrl") or "").strip()
-    if poster.startswith(("http://", "https://")) and not str(record.get("poster") or "").strip():
+    poster = poster_url_from_item(item, record.get("_id"))
+    if poster and not str(record.get("poster") or "").strip():
         record["poster"] = poster
     duration = _duration_ms(item) or positive_int(state.get("duration"))
     position = _progress_ms(item, duration)

--- a/providers/sync/stremio/_progress.py
+++ b/providers/sync/stremio/_progress.py
@@ -92,8 +92,12 @@ def _image_url(detail: Mapping[str, Any], kind: str) -> str:
 
 def _metadata_enriched(adapter: Any, item: Mapping[str, Any], typ: str) -> dict[str, Any]:
     out = dict(item)
-    if stremio_id_for_item(out) and _duration_ms(out):
-        return out
+    stremio_id = stremio_id_for_item(out)
+    if stremio_id:
+        if not str(out.get("poster") or out.get("poster_url") or "").strip():
+            out["poster"] = poster_url_from_item(out, stremio_id)
+        if _duration_ms(out):
+            return out
     provider = tmdb_metadata_provider(adapter)
     if provider is None:
         return out
@@ -143,9 +147,8 @@ def _metadata_enriched(adapter: Any, item: Mapping[str, Any], typ: str) -> dict[
                 duration = positive_int(ep.get("runtime"))
     if duration:
         out.setdefault("duration_ms", duration * 60_000)
-    poster = str(out.get("poster") or out.get("poster_url") or "").strip()
-    if not poster:
-        poster = _image_url(detail, "poster")
+    if not str(out.get("poster") or out.get("poster_url") or "").strip():
+        poster = poster_url_from_item(out, imdb) or _image_url(detail, "poster")
         if poster:
             out["poster"] = poster
     return out

--- a/providers/sync/stremio/_watchlist.py
+++ b/providers/sync/stremio/_watchlist.py
@@ -20,6 +20,7 @@ from ._common import (
     item_from_movie_record,
     library_records,
     now_iso,
+    poster_url_from_item,
     record_id,
     stremio_id_for_item,
     tmdb_metadata_provider,
@@ -115,8 +116,8 @@ def _unresolved(item: Mapping[str, Any], reason: str) -> dict[str, Any]:
 
 
 def _apply_membership(record: dict[str, Any], item: Mapping[str, Any], listed: bool) -> None:
-    poster = str(item.get("poster") or item.get("poster_url") or item.get("posterUrl") or "").strip()
-    if poster.startswith(("http://", "https://")) and not str(record.get("poster") or "").strip():
+    poster = poster_url_from_item(item, record.get("_id"))
+    if poster and not str(record.get("poster") or "").strip():
         record["poster"] = poster
     record["removed"] = not listed
     record["temp"] = False

--- a/providers/sync/stremio/_watchlist.py
+++ b/providers/sync/stremio/_watchlist.py
@@ -61,7 +61,10 @@ def _is_listed(record: Mapping[str, Any]) -> bool:
 
 def _metadata_enriched(adapter: Any, item: Mapping[str, Any], typ: str) -> dict[str, Any]:
     out = dict(item)
-    if stremio_id_for_item(out) and str(out.get("poster") or out.get("poster_url") or "").strip():
+    stremio_id = stremio_id_for_item(out)
+    if stremio_id:
+        if not str(out.get("poster") or out.get("poster_url") or "").strip():
+            out["poster"] = poster_url_from_item(out, stremio_id)
         return out
     provider = tmdb_metadata_provider(adapter)
     if provider is None:
@@ -93,7 +96,7 @@ def _metadata_enriched(adapter: Any, item: Mapping[str, Any], typ: str) -> dict[
     if not str(out.get("title") or out.get("series_title") or "").strip() and str(detail.get("title") or "").strip():
         out["title"] = str(detail.get("title") or "").strip()
     if not str(out.get("poster") or out.get("poster_url") or "").strip():
-        poster = _image_url(detail, "poster")
+        poster = poster_url_from_item(out, found) or _image_url(detail, "poster")
         if poster:
             out["poster"] = poster
     return out

--- a/providers/tests/test_stremio_sync.py
+++ b/providers/tests/test_stremio_sync.py
@@ -173,7 +173,7 @@ def test_episode_history_read_does_not_expose_stremio_mtime_as_watched_at(monkey
     assert item["_stremio_changed_at"] == "2026-07-30T19:53:20Z"
 
 
-def test_history_write_enriches_episode_poster_from_tmdb(monkeypatch) -> None:
+def test_history_write_resolves_imdb_with_tmdb_and_uses_metahub_poster(monkeypatch) -> None:
     class Provider:
         def fetch(self, **_kwargs: Any) -> dict[str, Any]:
             return {
@@ -198,7 +198,7 @@ def test_history_write_enriches_episode_poster_from_tmdb(monkeypatch) -> None:
 
     assert result["count"] == 1
     assert written["_id"] == "tt14586350"
-    assert written["poster"] == "https://image.tmdb.org/t/p/w780/love-death.jpg"
+    assert written["poster"] == "https://images.metahub.space/poster/small/tt14586350/img"
     assert _history.decode_watched_episodes(written["state"]["watched"], ["tt14586350:1:7"]) == {"tt14586350:1:7"}
 
 
@@ -324,7 +324,7 @@ def test_progress_write_enriches_percent_only_episode_from_tmdb(monkeypatch) -> 
 
     assert result["count"] == 1
     assert written["_id"] == "tt14586350"
-    assert written["poster"] == "https://image.tmdb.org/t/p/w780/love-death.jpg"
+    assert written["poster"] == "https://images.metahub.space/poster/small/tt14586350/img"
     assert written["state"]["video_id"] == "tt14586350:1:7"
     assert written["state"]["duration"] == 2_940_000
     assert written["state"]["timeOffset"] == 294_000
@@ -358,6 +358,21 @@ def test_created_record_uses_stremio_library_shape() -> None:
 def test_history_write_backfills_empty_poster_from_metahub() -> None:
     record = movie_record(poster="")
     adapter = FakeAdapter([record])
+    item = {"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club"}
+
+    result = _history.add(adapter, [item])
+    written = adapter.client.puts[-1][0]
+
+    assert result["count"] == 1
+    assert written["poster"] == "https://images.metahub.space/poster/small/tt0137523/img"
+
+
+def test_history_write_skips_tmdb_for_imdb_only_poster(monkeypatch) -> None:
+    def fail_provider(_adapter: Any) -> Any:
+        raise AssertionError("tmdb should not be used")
+
+    monkeypatch.setattr(_history, "tmdb_metadata_provider", fail_provider)
+    adapter = FakeAdapter([])
     item = {"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club"}
 
     result = _history.add(adapter, [item])

--- a/providers/tests/test_stremio_sync.py
+++ b/providers/tests/test_stremio_sync.py
@@ -345,7 +345,7 @@ def test_created_record_uses_stremio_library_shape() -> None:
 
     assert record["_ctime"] == _common.iso_from_epoch_ms(1_785_441_200_000)
     assert record["_mtime"] == _common.iso_from_epoch_ms(1_785_441_200_000)
-    assert record["poster"] == ""
+    assert record["poster"] == "https://images.metahub.space/poster/small/tt0137523/img"
     assert record["state"]["lastWatched"] == ""
     assert record["state"]["video_id"] == ""
     assert record["state"]["watched"] == ""
@@ -353,6 +353,18 @@ def test_created_record_uses_stremio_library_shape() -> None:
     assert record["state"]["season"] == 0
     assert record["state"]["episode"] == 0
     assert record["behaviorHints"] == {"defaultVideoId": None, "featuredVideoId": None, "hasScheduledVideos": False}
+
+
+def test_history_write_backfills_empty_poster_from_metahub() -> None:
+    record = movie_record(poster="")
+    adapter = FakeAdapter([record])
+    item = {"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club"}
+
+    result = _history.add(adapter, [item])
+    written = adapter.client.puts[-1][0]
+
+    assert result["count"] == 1
+    assert written["poster"] == "https://images.metahub.space/poster/small/tt0137523/img"
 
 
 def test_watchlist_reads_explicit_library_movies_and_series() -> None:


### PR DESCRIPTION
# Pull request

## Change

Prefer Metahub poster URLs for Stremio records when an IMDb/Stremio ID is already known.

This applies to Stremio history, progress, and watchlist writes without replacing existing posters. TMDb is still used when CW needs enrichment, such as resolving TMDb to IMDb or getting runtime for percent-only progress.

## Why

Stremio already has an IMDb-based artwork path through Metahub, so CW should not call TMDb just to fill a poster when the Stremio ID is already known.

## Testing

- test_stremio_sync.py

## Issue

NA