### PR TITLE
Change: tracker maintenance profile-aware

### DIFF
--- a/api/maintenanceAPI.py
+++ b/api/maintenanceAPI.py
@@ -14,8 +14,10 @@ from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Body, File, UploadFile
+from fastapi import APIRouter, Body, File, Query, UploadFile
 from fastapi.responses import StreamingResponse
+
+from cw_platform.provider_instances import get_provider_block, normalize_instance_id
 
 _LOG = logging.getLogger("crosswatch.api.maintenance")
 
@@ -102,13 +104,14 @@ def _clear_cw_state_files() -> list[str]:
 
 
 # --- CrossWatch tracker (.cw_provider) functions ---
-def _cw_tracker_root(config_dir: Path) -> Path:
+def _cw_tracker_root(config_dir: Path, provider_instance: Any = None) -> Path:
     """Resolve CrossWatch tracker root dir from config.json or default."""
     cfg_path = config_dir / "config.json"
     root: str | None = None
     try:
         cfg = json.loads(cfg_path.read_text("utf-8"))
-        cw_cfg = cfg.get("crosswatch") or {}
+        inst = normalize_instance_id(provider_instance)
+        cw_cfg = get_provider_block(cfg, "crosswatch", inst) or cfg.get("crosswatch") or {}
         root = (
             cw_cfg.get("root_dir")
             or cw_cfg.get("root")
@@ -595,23 +598,30 @@ def _scan_cw_tracker(root: Path) -> dict[str, Any]:
 
 
 @router.get("/crosswatch-tracker")
-def crosswatch_tracker_status() -> dict[str, Any]:
+def crosswatch_tracker_status(
+    provider_instance: str | None = Query("default"),
+) -> dict[str, Any]:
     """Inspect CrossWatch tracker folder (.cw_provider)."""
     _, CONFIG_DIR, *_ = _cw()
-    root = _cw_tracker_root(CONFIG_DIR)
+    inst = normalize_instance_id(provider_instance)
+    root = _cw_tracker_root(CONFIG_DIR, inst)
     info = _scan_cw_tracker(root)
     return {
         "ok": True,
+        "provider_instance": inst,
         "root": str(root),
         **info,
     }
 
 
 @router.get("/crosswatch-tracker/export")
-def crosswatch_tracker_export() -> StreamingResponse:
+def crosswatch_tracker_export(
+    provider_instance: str | None = Query("default"),
+) -> StreamingResponse:
     from services.editor import export_tracker_zip
 
-    data = export_tracker_zip()
+    inst = normalize_instance_id(provider_instance)
+    data = export_tracker_zip(inst)
     return StreamingResponse(
         io.BytesIO(data),
         media_type="application/zip",
@@ -620,17 +630,21 @@ def crosswatch_tracker_export() -> StreamingResponse:
 
 
 @router.post("/crosswatch-tracker/import")
-async def crosswatch_tracker_import(file: UploadFile = File(...)) -> dict[str, Any]:
+async def crosswatch_tracker_import(
+    provider_instance: str | None = Query("default"),
+    file: UploadFile = File(...),
+) -> dict[str, Any]:
     from services.editor import import_tracker_upload
 
+    inst = normalize_instance_id(provider_instance)
     payload = await file.read()
     filename = file.filename or "upload.json"
     try:
-        stats = import_tracker_upload(payload, filename)
+        stats = import_tracker_upload(payload, filename, inst)
     except ValueError:
         _LOG.warning("tracker import rejected: %s", filename, exc_info=True)
         return {"ok": False, "error": "Import failed; expected a valid CrossWatch tracker ZIP or JSON file."}
-    return {"ok": True, **stats}
+    return {"ok": True, "provider_instance": inst, **stats}
 
 
 @router.post("/clear-state")
@@ -667,9 +681,11 @@ def clear_state_minimal() -> dict[str, Any]:
 def crosswatch_tracker_clear(
     clear_state: bool = Body(True),
     clear_snapshots: bool = Body(False),
+    provider_instance: str | None = Body("default"),
 ) -> dict[str, Any]:
     _, CONFIG_DIR, *_ = _cw()
-    root = _cw_tracker_root(CONFIG_DIR)
+    inst = normalize_instance_id(provider_instance)
+    root = _cw_tracker_root(CONFIG_DIR, inst)
 
     before = _scan_cw_tracker(root)
     selected_before_paths = []
@@ -703,6 +719,7 @@ def crosswatch_tracker_clear(
 
     return {
         "ok": True,
+        "provider_instance": inst,
         "root": str(root),
         "removed": {
             "state_files": removed_state,

--- a/api/maintenanceAPI.py
+++ b/api/maintenanceAPI.py
@@ -9,6 +9,7 @@ import logging
 import os
 import shutil
 import threading
+from collections.abc import Mapping
 from datetime import datetime
 from fnmatch import fnmatch
 from pathlib import Path
@@ -17,7 +18,7 @@ from typing import Any
 from fastapi import APIRouter, Body, File, Query, UploadFile
 from fastapi.responses import StreamingResponse
 
-from cw_platform.provider_instances import get_provider_block, normalize_instance_id
+from cw_platform.provider_instances import normalize_instance_id
 
 _LOG = logging.getLogger("crosswatch.api.maintenance")
 
@@ -104,23 +105,38 @@ def _clear_cw_state_files() -> list[str]:
 
 
 # --- CrossWatch tracker (.cw_provider) functions ---
-def _cw_tracker_root(config_dir: Path, provider_instance: Any = None) -> Path:
-    """Resolve CrossWatch tracker root dir from config.json or default."""
+def _cw_tracker_config(config_dir: Path) -> dict[str, Any]:
     cfg_path = config_dir / "config.json"
-    root: str | None = None
     try:
         cfg = json.loads(cfg_path.read_text("utf-8"))
-        inst = normalize_instance_id(provider_instance)
-        cw_cfg = get_provider_block(cfg, "crosswatch", inst) or cfg.get("crosswatch") or {}
-        root = (
-            cw_cfg.get("root_dir")
-            or cw_cfg.get("root")
-            or cw_cfg.get("dir")
-            or None
-        )
     except Exception:
-        root = None
+        return {}
+    return cfg if isinstance(cfg, dict) else {}
 
+
+def _cw_tracker_configured_instance(cfg: Mapping[str, Any], provider_instance: Any = None) -> str:
+    requested = normalize_instance_id(provider_instance)
+    if requested == "default":
+        return "default"
+    node = cfg.get("crosswatch") if isinstance(cfg, Mapping) else {}
+    instances = node.get("instances") if isinstance(node, Mapping) else {}
+    if not isinstance(instances, Mapping):
+        return "default"
+    for key in instances.keys():
+        candidate = normalize_instance_id(key)
+        if candidate == requested:
+            return candidate
+    return "default"
+
+
+def _cw_tracker_base_root(config_dir: Path, cfg: Mapping[str, Any]) -> Path:
+    cw_cfg = cfg.get("crosswatch") if isinstance(cfg, Mapping) else {}
+    root = (
+        cw_cfg.get("root_dir")
+        or cw_cfg.get("root")
+        or cw_cfg.get("dir")
+        or None
+    ) if isinstance(cw_cfg, Mapping) else None
     if not root:
         root = ".cw_provider"
 
@@ -128,6 +144,49 @@ def _cw_tracker_root(config_dir: Path, provider_instance: Any = None) -> Path:
     if not p.is_absolute():
         p = config_dir / p
     return p
+
+
+def _cw_tracker_root(config_dir: Path, provider_instance: Any = None) -> Path:
+    cfg = _cw_tracker_config(config_dir)
+    inst = _cw_tracker_configured_instance(cfg, provider_instance)
+    base = _cw_tracker_base_root(config_dir, cfg)
+    if inst == "default":
+        return base
+    return base / "profiles" / inst
+
+
+def _cw_tracker_context(config_dir: Path, provider_instance: Any = None) -> tuple[str, Path]:
+    cfg = _cw_tracker_config(config_dir)
+    inst = _cw_tracker_configured_instance(cfg, provider_instance)
+    base = _cw_tracker_base_root(config_dir, cfg)
+    root = base if inst == "default" else base / "profiles" / inst
+    return inst, root
+
+
+def _json_files_in_dir(root: Path) -> list[Path]:
+    safe_root = root.resolve(strict=False)
+    if not safe_root.exists():
+        return []
+    out: list[Path] = []
+    for path in safe_root.glob("*.json"):
+        resolved = path.resolve(strict=False)
+        try:
+            resolved.relative_to(safe_root)
+        except ValueError:
+            continue
+        if resolved.is_file():
+            out.append(resolved)
+    return out
+
+
+def _cw_tracker_snapshot_dir(root: Path) -> Path:
+    safe_root = root.resolve(strict=False)
+    snaps = (safe_root / "snapshots").resolve(strict=False)
+    try:
+        snaps.relative_to(safe_root)
+    except ValueError as exc:
+        raise ValueError("Invalid tracker snapshot path") from exc
+    return snaps
 
 
 def _file_meta(path: Path) -> dict[str, Any]:
@@ -603,8 +662,7 @@ def crosswatch_tracker_status(
 ) -> dict[str, Any]:
     """Inspect CrossWatch tracker folder (.cw_provider)."""
     _, CONFIG_DIR, *_ = _cw()
-    inst = normalize_instance_id(provider_instance)
-    root = _cw_tracker_root(CONFIG_DIR, inst)
+    inst, root = _cw_tracker_context(CONFIG_DIR, provider_instance)
     info = _scan_cw_tracker(root)
     return {
         "ok": True,
@@ -620,7 +678,8 @@ def crosswatch_tracker_export(
 ) -> StreamingResponse:
     from services.editor import export_tracker_zip
 
-    inst = normalize_instance_id(provider_instance)
+    _, CONFIG_DIR, *_ = _cw()
+    inst, _ = _cw_tracker_context(CONFIG_DIR, provider_instance)
     data = export_tracker_zip(inst)
     return StreamingResponse(
         io.BytesIO(data),
@@ -636,7 +695,8 @@ async def crosswatch_tracker_import(
 ) -> dict[str, Any]:
     from services.editor import import_tracker_upload
 
-    inst = normalize_instance_id(provider_instance)
+    _, CONFIG_DIR, *_ = _cw()
+    inst, _ = _cw_tracker_context(CONFIG_DIR, provider_instance)
     payload = await file.read()
     filename = file.filename or "upload.json"
     try:
@@ -684,37 +744,36 @@ def crosswatch_tracker_clear(
     provider_instance: str | None = Body("default"),
 ) -> dict[str, Any]:
     _, CONFIG_DIR, *_ = _cw()
-    inst = normalize_instance_id(provider_instance)
-    root = _cw_tracker_root(CONFIG_DIR, inst)
+    inst, root = _cw_tracker_context(CONFIG_DIR, provider_instance)
+    state_paths = _json_files_in_dir(root)
+    snapshot_paths = _json_files_in_dir(_cw_tracker_snapshot_dir(root)) if clear_snapshots else []
 
     before = _scan_cw_tracker(root)
     selected_before_paths = []
     if clear_state:
-        selected_before_paths.extend(root.glob("*.json"))
+        selected_before_paths.extend(state_paths)
     if clear_snapshots:
-        selected_before_paths.extend((root / "snapshots").glob("*.json"))
+        selected_before_paths.extend(snapshot_paths)
     before_usage = _paths_usage(list(selected_before_paths))
     removed_state: list[str] = []
     removed_snapshots: list[str] = []
 
-    if clear_state and root.exists():
-        for p in root.glob("*.json"):
+    if clear_state:
+        for p in state_paths:
             if p.is_file() and _safe_remove_path(p):
                 removed_state.append(p.name)
 
     if clear_snapshots:
-        snaps_dir = root / "snapshots"
-        if snaps_dir.exists():
-            for p in snaps_dir.glob("*.json"):
-                if p.is_file() and _safe_remove_path(p):
-                    removed_snapshots.append(p.name)
+        for p in snapshot_paths:
+            if p.is_file() and _safe_remove_path(p):
+                removed_snapshots.append(p.name)
 
     after = _scan_cw_tracker(root)
     selected_after_paths = []
     if clear_state:
-        selected_after_paths.extend(root.glob("*.json"))
+        selected_after_paths.extend(_json_files_in_dir(root))
     if clear_snapshots:
-        selected_after_paths.extend((root / "snapshots").glob("*.json"))
+        selected_after_paths.extend(_json_files_in_dir(_cw_tracker_snapshot_dir(root)))
     after_usage = _paths_usage(list(selected_after_paths))
 
     return {

--- a/assets/helpers/icon-select.js
+++ b/assets/helpers/icon-select.js
@@ -234,7 +234,9 @@
     const viewportHeight = window.innerHeight || d.documentElement.clientHeight || 0;
     const margin = 12;
     const gap = 8;
-    const width = Math.max(0, Math.round(rect.width));
+    const cfg = wrap.__cwNativeSelect?.__cwIconSelectCfg || {};
+    const minWidth = Number(cfg.menuMinWidth || 0);
+    const width = Math.max(0, Math.round(rect.width), Number.isFinite(minWidth) ? minWidth : 0);
     const left = Math.max(margin, Math.min(Math.round(rect.left), Math.max(margin, viewportWidth - width - margin)));
     const spaceBelow = Math.max(0, viewportHeight - rect.bottom - gap - margin);
     const spaceAbove = Math.max(0, rect.top - gap - margin);
@@ -285,6 +287,10 @@
     }
     wrap.__cwNativeSelect = select;
     wrap.className = `cw-icon-select ${String(select.__cwIconSelectCfg?.className || "").trim()}`.trim();
+    if (wrap.__cwMenu) {
+      const hidden = wrap.__cwMenu.classList.contains("hidden");
+      wrap.__cwMenu.className = `cw-icon-select-menu${hidden ? " hidden" : ""} ${String(select.__cwIconSelectCfg?.menuClassName || "").trim()}`.trim();
+    }
 
     const legacyChev = wrap.nextElementSibling;
     if (legacyChev?.classList?.contains("chev")) legacyChev.style.display = "none";

--- a/assets/helpers/profile-select.js
+++ b/assets/helpers/profile-select.js
@@ -18,11 +18,11 @@
   }
 
   function enhanceProvider(select, cfg = {}) {
-    return CW.IconSelect?.enhance?.(select, { className: `cw-profile-select cw-provider-select ${text(cfg.className)}`.trim(), getOptionData: cfg.getOptionData || providerOption });
+    return CW.IconSelect?.enhance?.(select, { ...cfg, className: `cw-profile-select cw-provider-select ${text(cfg.className)}`.trim(), getOptionData: cfg.getOptionData || providerOption });
   }
 
   function enhanceProfile(select, cfg = {}) {
-    return CW.IconSelect?.enhance?.(select, { className: `cw-profile-select cw-profile-instance-select ${text(cfg.className)}`.trim(), getOptionData: cfg.getOptionData || profileOption });
+    return CW.IconSelect?.enhance?.(select, { ...cfg, className: `cw-profile-select cw-profile-instance-select ${text(cfg.className)}`.trim(), getOptionData: cfg.getOptionData || profileOption });
   }
 
   function enhancePair(providerSelect, profileSelect, cfg = {}) {

--- a/assets/js/modals/maintenance/index.js
+++ b/assets/js/modals/maintenance/index.js
@@ -37,6 +37,7 @@ const fjson = async (url, opts = {}) => {
 };
 
 const $ = (sel, root = document) => root.querySelector(sel);
+const escapeHtml = (value) => String(value ?? "").replace(/[&<>"]/g, ch => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;" }[ch]));
 const post = (url, body) =>
   fjson(url, body === undefined ? { method: "POST" } : {
     method: "POST",
@@ -89,15 +90,23 @@ const OPS = [
     tag: "archive & recovery",
     desc: "Manage local tracker state files, snapshots, exports and imports.",
     extra: `
-      <div class="action-options">
-        <label><input type="checkbox" id="cxm-cw-state" checked><span>Tracker state files</span></label>
-        <label><input type="checkbox" id="cxm-cw-snaps"><span>All snapshots</span></label>
+      <div class="action-options tracker-archive-options">
+        <label class="tracker-profile-control">
+          <span>Profile</span>
+          <select id="cxm-cw-profile" class="input"><option value="default">Default</option></select>
+        </label>
+        <label class="tracker-archive-check"><input type="checkbox" id="cxm-cw-state" checked><span>Tracker state files</span></label>
+        <label class="tracker-archive-check"><input type="checkbox" id="cxm-cw-snaps"><span>All snapshots</span></label>
       </div>
     `,
     sideActions: `
       <div class="archive-actions">
-        <button type="button" class="archive-btn secondary" id="cxm-cw-export" data-label="Download tracker archive">Download ZIP</button>
-        <button type="button" class="archive-btn secondary" id="cxm-cw-import" data-label="Import tracker archive">Import file</button>
+        <button type="button" class="archive-btn icon-only secondary" id="cxm-cw-export" data-label="Download tracker archive" title="Download tracker archive" aria-label="Download tracker archive">
+          <span class="material-symbols-rounded" aria-hidden="true">download</span>
+        </button>
+        <button type="button" class="archive-btn icon-only secondary" id="cxm-cw-import" data-label="Import tracker archive" title="Import tracker archive" aria-label="Import tracker archive">
+          <span class="material-symbols-rounded" aria-hidden="true">upload_file</span>
+        </button>
         <input type="file" id="cxm-cw-import-file" accept=".zip,.json" hidden>
       </div>
     `,
@@ -436,10 +445,33 @@ export default {
       statusEl.className = "status-message" + (kind ? " " + kind : "");
       statusEl.hidden = !msg;
     };
+    const trackerProfile = () => String($("#cxm-cw-profile", root)?.value || "default").trim() || "default";
+    const trackerProfileQuery = () => `provider_instance=${encodeURIComponent(trackerProfile())}`;
+    const loadTrackerProfiles = async () => {
+      const sel = $("#cxm-cw-profile", root);
+      if (!sel) return;
+      const current = sel.value || "default";
+      try {
+        const data = await fjson("/api/provider-instances/CROSSWATCH");
+        const list = Array.isArray(data) && data.length ? data : [{ id: "default", label: "Default" }];
+        sel.innerHTML = list
+          .map(p => `<option value="${escapeHtml(String(p?.id || "default"))}">${escapeHtml(String(p?.label || p?.id || "Default"))}</option>`)
+          .join("");
+      } catch {
+        sel.innerHTML = '<option value="default">Default</option>';
+      }
+      const values = Array.from(sel.options).map(o => o.value);
+      sel.value = values.includes(current) ? current : "default";
+      window.CW?.ProfileSelect?.enhanceProfile?.(sel, {
+        className: "cxm-tracker-profile-select",
+        menuClassName: "cxm-tracker-profile-menu",
+        menuMinWidth: 220,
+      });
+    };
 
     const downloadTrackerArchive = () => {
       const a = document.createElement("a");
-      a.href = "/api/maintenance/crosswatch-tracker/export";
+      a.href = `/api/maintenance/crosswatch-tracker/export?${trackerProfileQuery()}`;
       a.download = "crosswatch-tracker.zip";
       document.body.appendChild(a);
       a.click();
@@ -454,7 +486,7 @@ export default {
       setOperationBusy(true);
       setStatus("Importing tracker archive...", "busy");
       try {
-        const data = await fjson("/api/maintenance/crosswatch-tracker/import", {
+        const data = await fjson(`/api/maintenance/crosswatch-tracker/import?${trackerProfileQuery()}`, {
           method: "POST",
           body: form,
         });
@@ -477,7 +509,7 @@ export default {
     function setOperationBusy(busy) {
       if (operationBusy === busy) return;
       operationBusy = busy;
-      const controls = root.querySelectorAll(".run-btn, .archive-btn, .category-run-btn, #cxm-close");
+      const controls = root.querySelectorAll(".run-btn, .archive-btn, .category-run-btn, #cxm-cw-profile, #cxm-close");
       controls.forEach((control) => {
         if (busy) {
           control.dataset.cwWasDisabled = control.disabled ? "1" : "0";
@@ -670,7 +702,7 @@ export default {
     async function refreshSummary() {
       try {
         const [tracker, cache] = await Promise.all([
-          fjson("/api/maintenance/crosswatch-tracker").catch(() => null),
+          fjson(`/api/maintenance/crosswatch-tracker?${trackerProfileQuery()}`).catch(() => null),
           fjson("/api/maintenance/provider-cache").catch(() => null),
         ]);
 
@@ -779,6 +811,7 @@ export default {
           res = await post("/api/maintenance/crosswatch-tracker/clear", {
             clear_state: clearState,
             clear_snapshots: clearSnaps,
+            provider_instance: trackerProfile(),
           });
         } else if (kind === "defaults") {
           const warn = [
@@ -882,7 +915,7 @@ export default {
       const btn = row?.querySelector(".action-run-btn");
       if (btn) btn.addEventListener("click", () => runOp(kind, btn));
       row?.addEventListener("click", (event) => {
-        if (event.target.closest("button, input, label, a, summary")) return;
+        if (event.target.closest("button, input, label, a, summary, .cw-icon-select")) return;
         loadActionInsight(kind);
       });
       row?.addEventListener("keydown", (event) => {
@@ -893,6 +926,10 @@ export default {
     });
 
     root.querySelector("#cxm-cw-export")?.addEventListener("click", downloadTrackerArchive);
+    root.querySelector("#cxm-cw-profile")?.addEventListener("change", async () => {
+      await refreshSummary();
+      if (selectedInsightKind === "tracker") await loadActionInsight("tracker");
+    });
     const archiveInput = root.querySelector("#cxm-cw-import-file");
     root.querySelector("#cxm-cw-import")?.addEventListener("click", () => archiveInput?.click());
     archiveInput?.addEventListener("change", async () => {
@@ -945,6 +982,7 @@ export default {
     }
 
     showOverviewStatus();
+    await loadTrackerProfiles();
     await refreshSummary();
     setStatus("");
     const initialGroup = String(props?.group || props?.target || "").trim().toLowerCase();

--- a/assets/js/modals/maintenance/styles.css
+++ b/assets/js/modals/maintenance/styles.css
@@ -151,6 +151,19 @@
 .cw-maint .archive-actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 7px; margin: 0; }
 .cw-maint .archive-actions .archive-btn { min-height: 34px; min-width: 118px; }
 .cw-maint .archive-actions .archive-btn.secondary { color: var(--maint-text); }
+.cw-maint .archive-actions .archive-btn.icon-only { width: 46px; min-width: 46px; height: 46px; min-height: 46px; display: inline-flex; align-items: center; justify-content: center; padding: 0; border-radius: 11px; }
+.cw-maint .archive-actions .archive-btn.icon-only .material-symbols-rounded { font-size: 21px; font-variation-settings: "FILL" 0, "wght" 650, "GRAD" 0, "opsz" 22; }
+.cw-maint .action-row[data-op="tracker"] { grid-template-columns: minmax(500px, 1fr) minmax(0, max-content) auto; }
+.cw-maint .tracker-archive-options { align-items: center; flex-wrap: nowrap; gap: 9px; margin-top: 10px; }
+.cw-maint .tracker-profile-control, .cw-maint .tracker-archive-check { min-width: 0; display: inline-flex; align-items: center; gap: 6px; color: var(--maint-muted); font-size: 10.5px; font-weight: 760; white-space: nowrap; }
+.cw-maint .tracker-profile-control > span { color: var(--maint-muted); font-size: 10px; font-weight: 850; letter-spacing: .06em; text-transform: uppercase; }
+.cw-maint .tracker-profile-control .cxm-tracker-profile-select { width: 96px; min-width: 96px; flex: 0 0 96px; }
+.cw-maint .tracker-profile-control .cw-icon-select-btn { min-height: 34px; padding: 0 10px; gap: 5px; border-radius: 11px; border-color: var(--maint-border); background: var(--maint-panel); color: var(--maint-text); box-shadow: none; }
+.cw-maint .tracker-profile-control .cw-icon-select-icons { display: none; }
+.cw-maint .tracker-profile-control .cw-icon-select-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; font-weight: 820; }
+.cw-maint .tracker-profile-control .cw-icon-select-caret { flex: 0 0 9px; width: 9px; opacity: .72; }
+.cw-maint .tracker-archive-check input { width: 17px; height: 17px; margin: 0; accent-color: var(--maint-accent); }
+.cxm-tracker-profile-menu .cw-icon-select-label { overflow: visible; text-overflow: clip; white-space: nowrap; }
 .cw-maint :is(.action-group.archive, .action-group.events, .action-group.captures) .group-icon, .cw-maint .action-row[data-op="tracker"] .action-icon { color: var(--maint-good); }
 .cw-maint :is(.action-group.archive, .action-group.events, .action-group.captures) { --group-accent: var(--maint-good); }
 .cw-maint :is(.action-group.playback, .action-group.reports) .group-icon { color: var(--maint-accent); }
@@ -171,6 +184,7 @@ html[data-cw-theme] body .cx-modal-shell.cw-maint-shell .cw-maint :is(.head-icon
 html[data-cw-theme] body .cx-modal-shell.cw-maint-shell .cw-maint .category-run-btn { color: var(--nav-accent) !important; -webkit-text-fill-color: currentColor !important; border-color: color-mix(in srgb, var(--nav-accent) 38%, var(--maint-border)) !important; border-left: 0 !important; background: color-mix(in srgb, var(--nav-accent) 13%, var(--maint-card)) !important; box-shadow: none !important; }
 html[data-cw-theme] body .cx-modal-shell.cw-maint-shell .cw-maint .category-run-btn.busy { color: transparent !important; -webkit-text-fill-color: transparent !important; }
 html[data-cw-theme] body .cx-modal-shell.cw-maint-shell .cw-maint :is(.header-action, .run-btn, .archive-btn, .storage-details summary) { border-color: var(--maint-border) !important; background: var(--maint-card) !important; box-shadow: none !important; }
+html[data-cw-theme] body .cx-modal-shell.cw-maint-shell .cw-maint .tracker-profile-control .cw-icon-select-btn { border-color: var(--maint-border) !important; background: var(--maint-panel) !important; color: var(--maint-text) !important; -webkit-text-fill-color: var(--maint-text) !important; box-shadow: none !important; }
 html[data-cw-theme] body .cx-modal-shell.cw-maint-shell .cw-maint .action-group.danger { border-color: color-mix(in srgb, var(--maint-danger) 38%, var(--maint-border)) !important; background: color-mix(in srgb, var(--maint-danger) 6%, var(--maint-panel)) !important; }
 html[data-cw-theme] body .cx-modal-shell.cw-maint-shell .cw-maint .action-group.danger .action-row { border-color: color-mix(in srgb, var(--maint-danger) 30%, var(--maint-border)) !important; background: color-mix(in srgb, var(--maint-danger) 8%, var(--maint-card)) !important; }
 html[data-cw-theme] body .cx-modal-shell.cw-maint-shell .cw-maint .action-group.danger .group-title, html[data-cw-theme] body .cx-modal-shell.cw-maint-shell .cw-maint .action-row[data-op="defaults"] :is(.action-icon, .run-btn) { color: var(--maint-danger) !important; -webkit-text-fill-color: var(--maint-danger) !important; }
@@ -192,6 +206,9 @@ html[data-cw-theme] body .cx-modal-shell.cw-maint-shell .cw-maint .run-btn.resul
   .cw-maint .maint-layout { grid-template-columns: 240px minmax(0, 1fr); }
   .cw-maint .action-group { grid-template-columns: 125px minmax(0, 1fr); }
   .cw-maint .group-desc { margin-left: 0; }
+  .cw-maint .action-row[data-op="tracker"] { grid-template-columns: 1fr auto; }
+  .cw-maint .action-row[data-op="tracker"] .action-side-actions { grid-column: 1 / -1; grid-row: 2; justify-content: flex-start; }
+  .cw-maint .tracker-archive-options { flex-wrap: wrap; justify-content: flex-start; }
 }
 @media (max-width: 820px) {
   .cx-modal-shell.cw-maint-shell { width: calc(100vw - 20px) !important; max-width: calc(100vw - 20px) !important; height: calc(100vh - 8px) !important; max-height: calc(100vh - 8px) !important; }

--- a/services/editor.py
+++ b/services/editor.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -21,22 +22,50 @@ Kind = Literal["watchlist", "history", "ratings", "progress"]
 
 _JSON_FILE_SUFFIX = ".json"
 
+def _tracker_base_root(cfg: Mapping[str, Any]) -> Path:
+    node = cfg.get("crosswatch") if isinstance(cfg, Mapping) else {}
+    raw = ""
+    if isinstance(node, Mapping):
+        raw = str(node.get("root_dir") or "").strip()
+    p = Path(raw or ".cw_provider")
+    if not p.is_absolute():
+        p = Path(CONFIG) / p
+    return p
+
+
+def _tracker_configured_instance(cfg: Mapping[str, Any], provider_instance: Any = None) -> str:
+    requested = normalize_instance_id(provider_instance)
+    if requested == "default":
+        return "default"
+    node = cfg.get("crosswatch") if isinstance(cfg, Mapping) else {}
+    instances = node.get("instances") if isinstance(node, Mapping) else {}
+    if not isinstance(instances, Mapping):
+        return "default"
+    for key in instances.keys():
+        candidate = normalize_instance_id(key)
+        if candidate == requested:
+            return candidate
+    return "default"
+
+
 def _cw_cfg(provider_instance: Any = None) -> dict[str, Any]:
     try:
         cfg = load_config()
     except Exception:
         return {}
-    inst = normalize_instance_id(provider_instance)
+    inst = _tracker_configured_instance(cfg, provider_instance)
     cw = get_provider_block(cfg, "crosswatch", inst) or cfg.get("crosswatch") or {}
     return cw if isinstance(cw, dict) else {}
 
 def _root_dir(provider_instance: Any = None) -> Path:
-    cw = _cw_cfg(provider_instance)
-    root = cw.get("root_dir") or ".cw_provider"
-    p = Path(root)
-    if not p.is_absolute():
-        p = Path(CONFIG) / p
-    return p
+    try:
+        cfg = load_config() or {}
+    except Exception:
+        cfg = {}
+    inst = _tracker_configured_instance(cfg, provider_instance)
+    if inst == "default":
+        return _tracker_base_root(cfg)
+    return _tracker_base_root(cfg) / "profiles" / inst
 
 
 def _ensure_under_root(root: Path, path: Path) -> Path:

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -169,6 +169,24 @@ def test_tracker_archive_json_import_uses_crosswatch_profile_snapshot_dir(tmp_pa
     assert not (root / "snapshots" / "20260101T000000Z-watchlist.json").exists()
 
 
+def test_tracker_archive_ignores_unconfigured_profile_path_input(tmp_path: Path, monkeypatch) -> None:
+    root = tmp_path / "cw_provider"
+    outside = tmp_path / "outside"
+    monkeypatch.setattr(editor_service, "load_config", lambda: {
+        "crosswatch": {"root_dir": str(root), "instances": {"CW-P04": {"retention_days": 0}}},
+    })
+
+    stats = editor_service.import_tracker_json(
+        b'{"items":{"movie:x":{"title":"X"}}}',
+        "watchlist.json",
+        "../outside",
+    )
+
+    assert stats["target"] == "state"
+    assert (root / "watchlist.json").exists()
+    assert not outside.exists()
+
+
 def test_status_probes_include_crosswatch_profiles(monkeypatch) -> None:
     from fastapi import FastAPI
     from fastapi.testclient import TestClient

--- a/tests/test_maintenance_api.py
+++ b/tests/test_maintenance_api.py
@@ -308,3 +308,40 @@ def test_rebuild_sync_state_reports_pair_mapping_metric(tmp_path, monkeypatch) -
 
     metric = next(m for m in status["metrics"] if m["label"] == "Pair mapping files")
     assert metric["value"] == len(scoped)
+
+
+def test_crosswatch_tracker_clear_rejects_profile_path_input(tmp_path, monkeypatch) -> None:
+    root = tmp_path / ".cw_provider"
+    snaps = root / "snapshots"
+    profile_root = root / "profiles" / "CW-P01"
+    outside = tmp_path / "outside"
+    snaps.mkdir(parents=True)
+    profile_root.mkdir(parents=True)
+    outside.mkdir()
+    (root / "watchlist.json").write_text("{}", encoding="utf-8")
+    (snaps / "20260101T000000Z-watchlist.json").write_text("{}", encoding="utf-8")
+    (profile_root / "watchlist.json").write_text("{}", encoding="utf-8")
+    (outside / "watchlist.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "config.json").write_text(
+        json.dumps({"crosswatch": {"root_dir": str(root), "instances": {"CW-P01": {}}}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        maintenanceAPI,
+        "_cw",
+        lambda: (tmp_path / "cache", tmp_path, tmp_path / ".cw_state", None, None, None),
+    )
+
+    result = maintenanceAPI.crosswatch_tracker_clear(
+        clear_state=True,
+        clear_snapshots=True,
+        provider_instance="../outside",
+    )
+
+    assert result["ok"] is True
+    assert result["provider_instance"] == "default"
+    assert not (root / "watchlist.json").exists()
+    assert not (snaps / "20260101T000000Z-watchlist.json").exists()
+    assert (profile_root / "watchlist.json").exists()
+    assert (outside / "watchlist.json").exists()


### PR DESCRIPTION
# Pull request

## Change

Makes the CW tracker archive tools work per profile and cleans up the maintenance modal controls.

## Why

Export, import and cleanup should target the selected local tracker profile instead of always using the default storage.

## Testing

Existing maintenance tests

## Issue

Relates to #580