### PR TITLE
Fix: watcher route icons with shared metedata

### DIFF
--- a/assets/js/scrobbler.js
+++ b/assets/js/scrobbler.js
@@ -3,8 +3,9 @@
 /* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
 (function (w, d) {
   const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
-  const label = (v) => ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", kodi: "Kodi", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
-  const logo = (v) => ({ plex: "/assets/img/PLEX.svg", jellyfin: "/assets/img/JELLYFIN.svg", emby: "/assets/img/EMBY.svg", kodi: "/assets/img/KODI.png", trakt: "/assets/img/TRAKT.svg", simkl: "/assets/img/SIMKL.svg", mdblist: "/assets/img/MDBLIST.svg" }[String(v || "").toLowerCase()] || "");
+  const providerMeta = () => w.CW?.ProviderMeta || {};
+  const label = (v) => providerMeta().label?.(v) || String(v || "").toUpperCase();
+  const logo = (v) => providerMeta().logoPath?.(v) || "";
   const state = { root: null, overview: null, busy: false, panels: { watcherDefaults: false, ratings: false, webhookDefaults: false }, delBtn: null, delTimer: 0, regenBtn: null, regenTimer: 0, legacyConfirm: false, legacyTimer: 0, hybridDismissed: false };
 
   async function j(url, options = {}) {

--- a/tests/test_crosswatch_watcher_sink.py
+++ b/tests/test_crosswatch_watcher_sink.py
@@ -125,6 +125,7 @@ def test_crosswatch_watcher_sink_writes_progress_and_history(monkeypatch, tmp_pa
 
 def test_scrobbler_route_modal_lists_crosswatch_sink() -> None:
     text = (ROOT / "assets" / "js" / "modals" / "scrobbler-route" / "index.js").read_text("utf-8")
+    scrobbler = (ROOT / "assets" / "js" / "scrobbler.js").read_text("utf-8")
     css = (ROOT / "assets" / "css" / "providers.css").read_text("utf-8")
     meta = (ROOT / "assets" / "helpers" / "provider-meta.js").read_text("utf-8")
 
@@ -133,5 +134,7 @@ def test_scrobbler_route_modal_lists_crosswatch_sink() -> None:
     assert 'crosswatch: "/assets/img/CROSSWATCH.svg"' in text
     assert ".scrm-provider-card.provider-crosswatch" in css
     assert ".scrm-provider-card.provider-crosswatch::after{background-image:url(/assets/img/CROSSWATCH.svg)}" in css
+    assert "providerMeta().logoPath?.(v)" in scrobbler
+    assert 'mdblist: "/assets/img/MDBLIST.svg"' not in scrobbler
     assert "CROSSWATCH:" in meta
     assert "scrobblerSink: true" in meta


### PR DESCRIPTION
# Pull request

## Change

Uses the shared provider metadata for watcher route labels and icons.

## Why

NA

## Testing

NA

## Issue

NA