### PR TITLE
Fix: local tracker storage handling

### DIFF
--- a/cw_platform/tracker_storage.py
+++ b/cw_platform/tracker_storage.py
@@ -4,12 +4,15 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+import logging
+import os
 from pathlib import Path
 from typing import Any
 import shutil
 
-from .provider_instances import get_provider_block, normalize_instance_id
+from .provider_instances import list_instance_ids, normalize_instance_id
 
+_LOG = logging.getLogger("crosswatch.tracker_storage")
 _TRACKER_MARKERS = {
     "watchlist.json",
     "history.json",
@@ -19,32 +22,51 @@ _TRACKER_MARKERS = {
     "snapshots",
     "profiles",
 }
+_DEFAULT_TRACKER_ROOT = "/config/.cw_provider"
 
 
-def _configured_crosswatch_block(cfg: Mapping[str, Any], instance_id: Any = None) -> dict[str, Any]:
-    block = get_provider_block(cfg, "crosswatch", instance_id)
-    if block:
-        return block
-    raw = cfg.get("crosswatch") or cfg.get("CrossWatch")
-    return dict(raw or {}) if isinstance(raw, Mapping) else {}
+def _configured_instance(cfg: Mapping[str, Any], instance_id: Any = None) -> str:
+    requested = normalize_instance_id(instance_id)
+    if requested == "default":
+        return "default"
+    for candidate in list_instance_ids(cfg, "crosswatch"):
+        inst = normalize_instance_id(candidate)
+        if inst == requested:
+            return inst
+    return "default"
+
+
+def _safe_profile_dir(instance_id: Any) -> str:
+    raw = normalize_instance_id(instance_id)
+    safe = "".join(ch for ch in raw if ch.isalnum() or ch in "._-").strip("._- ")
+    return safe or "default"
+
+
+def _managed_base_root() -> Path:
+    return Path(_DEFAULT_TRACKER_ROOT)
 
 
 def crosswatch_storage_root(cfg: Mapping[str, Any], instance_id: Any = None) -> str:
-    inst = normalize_instance_id(instance_id)
-    block = _configured_crosswatch_block(cfg, inst)
-    root = str(block.get("root_dir") or "").strip()
-    if root:
-        return root
-    base = _configured_crosswatch_block(cfg, "default")
-    base_root = str(base.get("root_dir") or "/config/.cw_provider").strip() or "/config/.cw_provider"
-    return base_root if inst == "default" else f"{base_root.rstrip('/').rstrip(chr(92))}/profiles/{inst}"
+    inst = _configured_instance(cfg, instance_id)
+    base_root = str(_managed_base_root())
+    return base_root if inst == "default" else f"{base_root}/profiles/{_safe_profile_dir(inst)}"
+
+
+def _normalize_under_managed_root(path: Path) -> tuple[Path | None, str]:
+    try:
+        managed = os.path.realpath(str(_managed_base_root()))
+        candidate = os.path.realpath(str(path))
+        if os.path.commonpath([managed, candidate]) != managed:
+            return None, "outside_tracker_root"
+        return Path(candidate), ""
+    except Exception:
+        return None, "invalid_path"
 
 
 def _safe_tracker_path(path: Path) -> tuple[bool, str]:
-    try:
-        resolved = path.expanduser().resolve(strict=False)
-    except Exception:
-        return False, "invalid_path"
+    resolved, reason = _normalize_under_managed_root(path)
+    if resolved is None:
+        return False, reason
 
     if not str(resolved).strip():
         return False, "empty_path"
@@ -81,7 +103,7 @@ def _safe_tracker_path(path: Path) -> tuple[bool, str]:
 
 
 def remove_crosswatch_storage(cfg: Mapping[str, Any], instance_id: Any = None) -> dict[str, Any]:
-    inst = normalize_instance_id(instance_id)
+    inst = _configured_instance(cfg, instance_id)
     raw_root = crosswatch_storage_root(cfg, inst)
     path = Path(raw_root)
     ok, reason = _safe_tracker_path(path)
@@ -89,10 +111,13 @@ def remove_crosswatch_storage(cfg: Mapping[str, Any], instance_id: Any = None) -
         return {"ok": False, "error": reason, "path": raw_root, "instance": inst}
 
     try:
-        resolved = path.expanduser().resolve(strict=False)
+        resolved, reason = _normalize_under_managed_root(path)
+        if resolved is None:
+            return {"ok": False, "error": reason, "path": raw_root, "instance": inst}
         if resolved.exists():
             shutil.rmtree(resolved)
             return {"ok": True, "removed": True, "path": str(resolved), "instance": inst}
         return {"ok": True, "removed": False, "path": str(resolved), "instance": inst}
     except Exception as exc:
-        return {"ok": False, "error": "remove_failed", "detail": str(exc), "path": raw_root, "instance": inst}
+        _LOG.warning("CW tracker storage cleanup failed", exc_info=True)
+        return {"ok": False, "error": "remove_failed", "path": raw_root, "instance": inst}

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -13,6 +13,7 @@ import api.insightAPI as insight_api
 import api.authenticationAPI as auth_api
 import services.editor as editor_service
 import services.export as export_service
+import cw_platform.tracker_storage as tracker_storage
 from cw_platform.provider_instances import build_pair_config_view, get_provider_block
 from providers.sync._mod_CROSSWATCH import CROSSWATCHModule
 
@@ -326,6 +327,7 @@ def test_crosswatch_profile_delete_removes_profile_storage(tmp_path: Path, monke
     profile_root.mkdir(parents=True)
     (profile_root / "watchlist.json").write_text("{}", "utf-8")
     store: dict[str, Any] = {"crosswatch": {"root_dir": str(root), "instances": {"CW-P04": {"label": "Desk"}}}}
+    monkeypatch.setattr(tracker_storage, "_DEFAULT_TRACKER_ROOT", str(root))
 
     def fake_load() -> dict[str, Any]:
         return json.loads(json.dumps(store))
@@ -354,6 +356,7 @@ def test_crosswatch_disconnect_removes_connection_and_storage(tmp_path: Path, mo
     root.mkdir()
     (root / "watchlist.json").write_text("{}", "utf-8")
     store: dict[str, Any] = {"crosswatch": {"root_dir": str(root), "retention_days": 30}}
+    monkeypatch.setattr(tracker_storage, "_DEFAULT_TRACKER_ROOT", str(root))
 
     def fake_load() -> dict[str, Any]:
         return json.loads(json.dumps(store))


### PR DESCRIPTION
# Pull request

## Change

Local tracker storage deletion and avoids returning cleanup exception details through the API.

## Why

CodeQL flagged storage paths and error responses. 
Deletion now stays inside the managed local tracker storage and detailed failures stay out of user-facing responses.

## Testing

- tests/test_crosswatch_profiles.py
- tests/test_maintenance_api.py

## Issue

NA