### PR TITLE
Add: recurring advanced workflows

### DIFF
--- a/assets/helpers/settings-ui.js
+++ b/assets/helpers/settings-ui.js
@@ -456,8 +456,9 @@ function cwSchedSettingsHubUpdate() {
 
   const adv = patch.advanced || {};
   const jobs = Array.isArray(adv.jobs) ? adv.jobs : [];
-  const active = jobs.filter(j => j && j.active !== false).length;
-  const total = jobs.length;
+  const workflows = Array.isArray(adv.workflows) ? adv.workflows : [];
+  const active = jobs.filter(j => j && j.active !== false).length + workflows.filter(w => w && w.active !== false).length;
+  const total = jobs.length + workflows.length;
 
   set("hub_sch_adv", `Plan: ${adv.enabled ? "On" : "Off"}`);
   set("hub_sch_steps", total ? `Steps: ${active}/${total}` : "Steps: —");

--- a/assets/js/scheduler.js
+++ b/assets/js/scheduler.js
@@ -55,6 +55,7 @@
 .sch-adv-section-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;flex-wrap:wrap}
 .sch-adv-section-title{font-size:12px;font-weight:900;letter-spacing:.12em;text-transform:uppercase;color:#f7f9ff}
 .sch-adv-section-copy{max-width:70ch;font-size:12px;line-height:1.45;color:var(--sch-fg-soft)}
+.sch-adv-section-copy.sch-workflow-intro{max-width:none;white-space:nowrap}
 .sch-adv table{position:relative;z-index:1;width:100%;border-collapse:separate;border-spacing:0 10px;margin-top:0;table-layout:fixed}
 .sch-adv thead th{padding:0 10px 6px;text-align:left;font-size:11px;font-weight:800;letter-spacing:.12em;text-transform:uppercase;color:rgba(214,223,238,.56);border-bottom:none}
 .sch-adv .th-help{display:inline-flex;align-items:center;gap:8px}
@@ -103,6 +104,38 @@
 .sch-adv td[data-label="Action"] .cw-icon-select-text{display:flex;align-items:center;min-width:0}
 .sch-adv td[data-label="Action"] .cw-icon-select-badges{flex-wrap:nowrap;white-space:nowrap}
 .sch-adv td[data-label="Source"] select,.sch-adv td[data-label="Event"] select{min-width:146px}
+.sch-adv .sch-workflow-table{width:min(760px,100%);table-layout:fixed}
+.sch-adv .sch-workflow-table td[data-label="Sync pair"] .cw-icon-select,.sch-adv .sch-workflow-table td[data-label="Sync pair"] select{max-width:520px}
+.sch-workflow-card{display:grid;gap:12px;padding:14px 16px;border:1px solid rgba(255,255,255,.13);border-radius:18px;background:linear-gradient(180deg,rgba(31,37,51,.9),rgba(24,29,41,.96));box-shadow:inset 0 1px 0 rgba(255,255,255,.035)}
+.sch-workflow-top{display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:center;gap:14px}
+.sch-workflow-titleline{display:flex;align-items:center;gap:12px;min-width:0}
+.sch-workflow-state-pill{display:inline-flex;align-items:center;gap:8px;min-height:30px;padding:0 12px;border-radius:999px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.045);color:rgba(238,243,255,.88);font-size:13px;font-weight:800}
+.sch-workflow-state-pill::before{content:"";width:8px;height:8px;border-radius:999px;background:#6ee49b;box-shadow:0 0 10px rgba(110,228,155,.34)}
+.sch-workflow-state-pill.is-paused::before{background:#f2a949;box-shadow:0 0 10px rgba(242,169,73,.34)}
+.sch-workflow-actions{display:flex;align-items:center;justify-content:flex-end;gap:8px;flex-wrap:nowrap}
+.sch-workflow-controls{display:flex;align-items:center;gap:10px}
+.sch-workflow-controls{position:relative}
+.sch-workflow-controls::before{content:"schedule";font-family:"Material Symbols Rounded","Material Symbols Outlined","Segoe UI Symbol",sans-serif;position:absolute;left:18px;top:50%;transform:translateY(-50%);font-size:20px;color:rgba(216,225,243,.68);pointer-events:none;z-index:2}
+.sch-workflow-controls select,.sch-workflow-controls input{box-sizing:border-box;width:220px!important;min-height:38px!important;padding-left:52px!important;padding-right:36px!important;border-radius:14px!important;background:#202636!important;font-weight:800}
+.sch-workflow-controls .cw-icon-select{width:220px!important}
+.sch-workflow-controls .cw-icon-select-btn{min-height:38px!important;padding-left:52px!important;padding-right:14px!important;border-radius:14px!important;background:#202636!important}
+.sch-workflow-controls .cw-icon-select-main{min-width:0}
+.sch-workflow-controls .cw-icon-select-label{font-weight:800}
+.sch-workflow-controls .sch-workflow-number{width:96px!important;padding-left:14px!important;padding-right:12px!important;text-align:center}
+.sch-workflow-unit{display:inline-flex;align-items:center;min-height:38px;padding:0 10px;border:1px solid rgba(255,255,255,.13);border-radius:14px;background:#202636;color:rgba(226,234,250,.78);font-size:11px;font-weight:900;letter-spacing:.08em;text-transform:uppercase}
+.sch-workflow-toggle{flex:0 0 auto}
+.sch-workflow-steps{display:grid;gap:8px;max-width:820px}
+.sch-workflow-step{display:grid;grid-template-columns:26px 32px minmax(260px,520px) auto auto;align-items:center;gap:9px;width:max-content;max-width:100%;padding:8px 10px;border:1px solid rgba(255,255,255,.12);border-radius:15px;background:#20242d}
+.sch-workflow-step.dragging{opacity:.55;border-color:rgba(133,139,216,.55);background:#272d3d}
+.sch-workflow-grip{display:inline-flex;align-items:center;justify-content:center;width:26px;height:34px;border:0;background:transparent;color:rgba(214,223,238,.54);cursor:grab;padding:0}
+.sch-workflow-grip:active{cursor:grabbing}
+.sch-workflow-grip .material-symbols-rounded{font-size:22px;line-height:1}
+.sch-workflow-step-index{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:999px;border:1px solid rgba(142,150,224,.34);background:rgba(133,139,216,.14);color:#f5f7ff;font-size:12px;font-weight:900}
+.sch-workflow-step .cw-icon-select,.sch-workflow-step select{width:100%!important;min-width:0!important}
+.sch-workflow-step input[id^="sched_workflow_active_"]{appearance:none;-webkit-appearance:none;display:inline-grid;place-items:center;width:30px;height:30px;border-radius:9px;background:#858bd8;border:1px solid rgba(168,176,240,.70);box-shadow:none}
+.sch-workflow-step input[id^="sched_workflow_active_"]:checked::after{content:"";width:12px;height:6px;border:3px solid #fff;border-top:0;border-right:0;transform:rotate(-45deg) translate(1px,-1px)}
+.sch-workflow-card>div:last-child{margin-top:0}
+.sch-workflow-card .sch-adv-actions{margin-top:4px}
 .sch-adv .event-filter-stack{width:100%}
 .sch-adv .event-filter-stack select,.sch-adv .event-filter-stack input{width:100%!important;min-width:0!important}
 .sch-adv .checkline{display:flex;align-items:center;gap:8px;min-height:18px;font-size:12px;color:var(--sch-fg-soft)}
@@ -209,6 +242,9 @@ html[data-cw-theme="flat-light"] .sch-adv .chipdays label:has(input:checked){
 .sch-adv .cw-panel-head .cx-toggle{margin-top:16px;justify-self:end}
 .sch-adv-summary{margin:0 18px 4px!important}
 .sch-adv-section{gap:12px;margin-left:18px!important;margin-right:18px!important;padding:16px}
+.sch-workflow-card{margin:0;padding:14px 16px}
+.sch-workflow-top{grid-template-columns:minmax(220px,1fr) auto}
+.sch-workflow-steps{margin-top:2px}
 .sch-adv-summary + .sch-adv-section{margin-top:0!important}
 .sch-adv-section:last-of-type{margin-bottom:18px!important}
 .sch-adv-section-head{align-items:center}
@@ -234,11 +270,11 @@ html[data-cw-theme="flat-light"] .sch-adv .chipdays label:has(input:checked){
 html[data-cw-theme="flat-light"] #sec-scheduling .sch-card-icon{background:#eef2ff;border-color:rgba(65,92,160,.22);color:#3157c8}
 @media (max-width:1180px){.sch-adv .stack.two{grid-template-columns:1fr}}
 @media (max-width:980px){#sec-scheduling .sch-std-head{grid-template-columns:1fr;padding-bottom:4px}#sec-scheduling .sch-std-head .cx-toggle{justify-self:start}#sec-scheduling .sch-std-inline{grid-template-columns:1fr}.sch-adv .cw-panel-head{grid-template-columns:1fr}.sch-adv .cw-panel-head .cx-toggle{justify-self:start}}
-@media (max-width:760px){#sec-scheduling .sch-std-title{font-size:22px}#sec-scheduling .sch-std-wizard{padding:0 16px 16px}.sch-adv .cw-panel-head{padding:16px}.sch-adv-head-title{font-size:22px}.sch-adv .cw-panel-head .cx-toggle{margin-top:10px}}
+@media (max-width:760px){#sec-scheduling .sch-std-title{font-size:22px}#sec-scheduling .sch-std-wizard{padding:0 16px 16px}.sch-adv .cw-panel-head{padding:16px}.sch-adv-head-title{font-size:22px}.sch-adv .cw-panel-head .cx-toggle{margin-top:10px}.sch-workflow-top{grid-template-columns:1fr}.sch-workflow-actions{justify-content:flex-start}.sch-workflow-controls{justify-content:flex-start}.sch-workflow-controls select,.sch-workflow-controls input{width:100%!important}.sch-workflow-step{grid-template-columns:24px 30px minmax(0,1fr) auto auto;width:auto}}
 ` }));
 
   // state
-  let _pairs = [], _jobs = [], _captureJobs = [], _eventRules = [], _advEnabled = false, _loading = false;
+  let _pairs = [], _jobs = [], _workflows = [], _captureJobs = [], _eventRules = [], _advEnabled = false, _loading = false;
   let _captureProviders = [];
   let _eventRoutes = { watcher: [], webhook: [] }, _eventRouteError = "";
   const DAY = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"];
@@ -251,10 +287,12 @@ html[data-cw-theme="flat-light"] #sec-scheduling .sch-card-icon{background:#eef2
     std_every_n_hours: "Every N hours:\nSet how many hours to wait between runs when Frequency is set to Every N hours.",
     std_time: "Time:\nChoose the local time to run each day when Frequency is set to Daily at a fixed time.",
     std_custom_interval: "Custom interval:\nSet a custom repeat interval in minutes or hours.\nCustom schedules are clamped to a minimum of 15 minutes.",
-    time_pair: "Pair:\nChoose which enabled sync pair this timed step should run.",
+    time_pair: "Sync pair:\nChoose which enabled source-to-target sync pair this step should run.",
     time_time: "Time:\nChoose the local time when this step becomes due.",
     time_days: "Days:\nSelect which weekdays this step may run on.\nLeave all days unchecked to allow every day.",
     time_after: "After:\nOptional dependency.\nUse this to run the step only after another earlier step has completed.",
+    workflow_recurrence: "Recurrence:\nChoose how often the full ordered workflow runs.",
+    workflow_steps: "Sync steps:\nEach step runs one configured source-to-target sync pair.",
     capture_target: "Provider:\nChoose the provider profile to capture from.\nOnly configured snapshot-capable profiles are listed.",
     capture_feature: "Feature:\nPick one feature or All to store a full provider capture bundle.",
     capture_label: "Label template:\nOptional template for automated capture labels.\nUse placeholders like {provider}, {instance}, {feature}, {date}, {time}, {datetime}, or {stamp}.",
@@ -268,6 +306,16 @@ html[data-cw-theme="flat-light"] #sec-scheduling .sch-card-icon{background:#eef2
     guardrails: "Mute (min):\nIgnore new triggers for this rule after it runs.\nDedupe (sec):\nSuppress identical repeated events for a short window.\nMax / hour:\nHard safety cap for this rule in one hour."
   };
   const defaultJob = () => ({ id: genId(), pair_id: null, at: null, days: [], after: null, active: true });
+  const defaultWorkflowStep = () => ({ id: genId(), pair_id: null, active: true });
+  const defaultWorkflow = () => ({
+    id: genId(),
+    mode: "hourly",
+    every_n_hours: 1,
+    daily_time: "03:30",
+    custom_interval_minutes: 60,
+    steps: [defaultWorkflowStep()],
+    active: true
+  });
   const defaultCaptureJob = () => ({
     id: genId(),
     provider: "",
@@ -955,7 +1003,7 @@ const ensureStdEnabledToggle = () => {
         },
     });
   };
-  const pairOptions = (selected, includeNoneText = "Select pair") => [
+  const pairOptions = (selected, includeNoneText = "Select sync pair") => [
     ["", includeNoneText],
     ..._pairs.map(p => [p.id, p.label + (p.enabled ? "" : " (disabled)"), { disabled: !p.enabled }])
   ];
@@ -963,7 +1011,7 @@ const ensureStdEnabledToggle = () => {
     const text = String(value || "").trim();
     if (!text) return "";
     return text
-      .replace(/^Step (\d+): select a pair\.$/i, "Next: choose a pair for Step $1")
+      .replace(/^Step (\d+): select a pair\.$/i, "Next: choose a sync pair for Step $1")
       .replace(/^Step (\d+): select a time\.$/i, "Next: set a time for Step $1")
       .replace(/^Capture schedule (\d+): select a provider\.$/i, "Next: choose a provider for Capture schedule $1")
       .replace(/^Capture schedule (\d+): choose a configured provider\.$/i, "Pick a configured provider for Capture schedule $1")
@@ -1028,6 +1076,56 @@ const ensureStdEnabledToggle = () => {
       jobs.push(job);
     });
     return { jobs, issues };
+  };
+  const workflowModeOptions = () => [
+    ["hourly", "Every hour"],
+    ["every_n_hours", "Every N hours"],
+    ["daily_time", "Daily at"],
+    ["custom_interval", "Custom interval"]
+  ];
+  const normalizeWorkflow = (workflow = {}) => ({
+    id: workflow.id || genId(),
+    mode: normalizeStandardMode(workflow.mode || "hourly"),
+    every_n_hours: Math.max(1, parseInt(workflow.every_n_hours || 1, 10) || 1),
+    daily_time: String(workflow.daily_time || "03:30").trim() || "03:30",
+    custom_interval_minutes: Math.max(15, parseInt(workflow.custom_interval_minutes || 60, 10) || 60),
+    steps: Array.isArray(workflow.steps) ? workflow.steps.map((step) => ({
+      id: step.id || genId(),
+      pair_id: step.pair_id || null,
+      active: step.active !== false
+    })) : [],
+    active: workflow.active !== false
+  });
+  const isBlankWorkflow = (workflow) => {
+    const steps = Array.isArray(workflow?.steps) ? workflow.steps : [];
+    const hasPair = steps.some((step) => String(step?.pair_id || "").trim());
+    return !hasPair;
+  };
+  const workflowLabel = (workflow) => `Workflow ${Math.max(0, _workflows.indexOf(workflow)) + 1}`;
+  const workflowIssue = (workflow) => {
+    if (isBlankWorkflow(workflow)) return "";
+    const steps = (Array.isArray(workflow?.steps) ? workflow.steps : []).filter((step) => step.active !== false && String(step?.pair_id || "").trim());
+    const rowName = workflowLabel(workflow);
+    if (!steps.length) return `${rowName}: add at least one active step.`;
+    if (steps.some((step) => step.pair_id && !isEnabled(step.pair_id))) return `${rowName}: update a disabled pair.`;
+    if (workflow.mode === "daily_time" && !String(workflow.daily_time || "").trim()) return `${rowName}: choose a time.`;
+    return "";
+  };
+  const serializableWorkflows = () => {
+    const workflows = [];
+    const issues = [];
+    _workflows.forEach((workflow) => {
+      if (isBlankWorkflow(workflow)) return;
+      const issue = workflowIssue(workflow);
+      if (issue) {
+        issues.push(issue);
+        return;
+      }
+      const normalized = normalizeWorkflow(workflow);
+      normalized.steps = normalized.steps.filter((step) => step.pair_id);
+      workflows.push(normalized);
+    });
+    return { workflows, issues };
   };
   const captureProviderById = (provider) => _captureProviders.find((row) => String(row?.id || "") === String(provider || "").trim().toUpperCase()) || null;
   const captureInstanceOptions = (provider, current = "") => {
@@ -1166,6 +1264,137 @@ const ensureStdEnabledToggle = () => {
       && daysA === daysB;
   };
 
+  const workflowStepRow = (workflow, step) => {
+    const row = el("div", "sch-workflow-step");
+    if (step.active !== false && step.pair_id && !isEnabled(step.pair_id)) row.classList.add("row-disabled");
+    const rowKey = fieldKey(step?.id, `workflow_step_${_workflows.indexOf(workflow) + 1}_${workflow.steps.indexOf(step) + 1}`);
+    row.draggable = true;
+    row.dataset.stepId = step.id || "";
+    row.ondragstart = (event) => {
+      row.classList.add("dragging");
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData("text/plain", step.id || "");
+    };
+    row.ondragend = () => row.classList.remove("dragging");
+    row.ondragover = (event) => {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "move";
+    };
+    row.ondrop = (event) => {
+      event.preventDefault();
+      const fromId = event.dataTransfer.getData("text/plain");
+      const toId = step.id || "";
+      if (!fromId || !toId || fromId === toId) return;
+      const from = workflow.steps.findIndex((item) => String(item.id || "") === String(fromId));
+      const to = workflow.steps.findIndex((item) => String(item.id || "") === String(toId));
+      if (from < 0 || to < 0) return;
+      const [moved] = workflow.steps.splice(from, 1);
+      workflow.steps.splice(to, 0, moved);
+      renderWorkflows();
+    };
+    const grip = Object.assign(el("button", "sch-workflow-grip"), { type: "button", ariaLabel: "Drag to reorder sync step", title: "Drag to reorder" });
+    grip.innerHTML = `<span class="material-symbols-rounded" aria-hidden="true">drag_indicator</span>`;
+    const index = Object.assign(el("span", "sch-workflow-step-index"), { textContent: String(workflow.steps.indexOf(step) + 1) });
+    const sel = buildSelect({
+      id: `sched_workflow_pair_${rowKey}`,
+      value: step.pair_id || "",
+      options: pairOptions(step.pair_id || null),
+      onChange: value => { step.pair_id = value || null; renderWorkflows(); }
+    });
+    const active = Object.assign(el("input"), { type: "checkbox", checked: step.active !== false });
+    active.id = `sched_workflow_active_${rowKey}`;
+    active.name = active.id;
+    active.onchange = () => { step.active = !!active.checked; renderWorkflows(); };
+    const del = Object.assign(el("button"), { className: "btn ghost sch-remove-btn", type: "button", ariaLabel: "Remove workflow step" });
+    del.innerHTML = `<span class="material-symbols-rounded" aria-hidden="true">close</span>`;
+    del.onclick = () => { workflow.steps = workflow.steps.filter((item) => item !== step); renderWorkflows(); };
+    row.append(
+      grip,
+      index,
+      enhanceIconSelect(sel, (value, option) => {
+        const data = pairOptionData(value, String(option?.textContent || "").trim());
+        return data ? { ...data, disabled: !!option?.disabled } : null;
+      }),
+      active,
+      del
+    );
+    return row;
+  };
+
+  const workflowBlock = (workflow) => {
+    const block = el("div", "sch-workflow-card");
+    const rowKey = fieldKey(workflow?.id, `workflow_${_workflows.indexOf(workflow) + 1}`);
+    const mode = buildSelect({
+      id: `sched_workflow_mode_${rowKey}`,
+      value: workflow.mode || "hourly",
+      options: workflowModeOptions(),
+      onChange: value => { workflow.mode = normalizeStandardMode(value); renderWorkflows(); }
+    });
+    const every = buildInput({
+      id: `sched_workflow_hours_${rowKey}`,
+      type: "number",
+      value: String(Math.max(1, parseInt(workflow.every_n_hours || 1, 10) || 1)),
+      min: 1,
+      onChange: value => { workflow.every_n_hours = Math.max(1, parseInt(value || "1", 10) || 1); }
+    });
+    every.classList.add("sch-workflow-number");
+    const daily = buildInput({
+      id: `sched_workflow_time_${rowKey}`,
+      type: "time",
+      value: workflow.daily_time || "03:30",
+      onChange: value => { workflow.daily_time = value || "03:30"; }
+    });
+    const custom = buildInput({
+      id: `sched_workflow_minutes_${rowKey}`,
+      type: "number",
+      value: String(Math.max(15, parseInt(workflow.custom_interval_minutes || 60, 10) || 60)),
+      min: 15,
+      onChange: value => { workflow.custom_interval_minutes = Math.max(15, parseInt(value || "60", 10) || 60); }
+    });
+    custom.classList.add("sch-workflow-number");
+    const active = Object.assign(el("input"), { type: "checkbox", checked: workflow.active !== false });
+    active.id = `sched_workflow_active_${rowKey}`;
+    active.name = active.id;
+    active.setAttribute("aria-label", workflow.active === false ? "Enable workflow" : "Disable workflow");
+    active.onchange = () => { workflow.active = !!active.checked; renderWorkflows(); updateAdvancedStatus(); };
+    const activeWrap = Object.assign(el("label", "cx-toggle sch-workflow-toggle"), { title: workflow.active === false ? "Enable workflow" : "Disable workflow" });
+    const activeUi = el("span", "cx-toggle-ui");
+    activeUi.setAttribute("aria-hidden", "true");
+    activeWrap.append(active, activeUi);
+    const del = Object.assign(el("button"), { className: "btn ghost sch-remove-btn", type: "button", ariaLabel: "Remove workflow" });
+    del.innerHTML = `<span class="material-symbols-rounded" aria-hidden="true">close</span>`;
+    del.onclick = () => { _workflows = _workflows.filter((item) => item !== workflow); renderWorkflows(); };
+    const controls = stackWrap("sch-workflow-controls", mode);
+    if (workflow.mode === "every_n_hours") controls.append(every, Object.assign(el("span", "sch-workflow-unit"), { textContent: "hours" }));
+    if (workflow.mode === "daily_time") controls.append(daily);
+    if (workflow.mode === "custom_interval") controls.append(custom, Object.assign(el("span", "sch-workflow-unit"), { textContent: "min" }));
+    const head = el("div", "sch-workflow-top");
+    const title = el("div");
+    title.append(
+      stackWrap(
+        "sch-workflow-titleline",
+        Object.assign(el("div", "sch-adv-section-title"), { textContent: workflowLabel(workflow) }),
+        Object.assign(el("span", workflow.active === false ? "sch-workflow-state-pill is-paused" : "sch-workflow-state-pill"), { textContent: workflow.active === false ? "Paused" : "Active" })
+      ),
+      Object.assign(el("div", "sch-adv-section-copy"), { textContent: "Run these sync steps in order on the selected recurrence." })
+    );
+    head.append(title, stackWrap("sch-workflow-actions", controls, activeWrap, del));
+    const body = el("div", "sch-workflow-steps");
+    workflow.steps = Array.isArray(workflow.steps) ? workflow.steps : [];
+    if (!workflow.steps.length) workflow.steps.push(defaultWorkflowStep());
+    workflow.steps.forEach((step) => body.appendChild(workflowStepRow(workflow, step)));
+    const actions = el("div", "sch-adv-actions");
+    const add = Object.assign(el("button"), { className: "btn", type: "button", textContent: "Add sync step" });
+    add.onclick = () => { workflow.steps.push(defaultWorkflowStep()); renderWorkflows(); };
+    actions.append(add);
+    block.append(head, body, actions);
+    block.querySelectorAll(".sch-help").forEach((btn) => {
+      const tip = HELP_TIPS[btn.dataset.helpKey] || "";
+      if (tip) btn.title = tip;
+    });
+    return block;
+  };
+
   // row builder
   const jobRow = j => {
     const tr = el("tr"); if (j.active !== false && j.pair_id && !isEnabled(j.pair_id)) tr.classList.add("row-disabled");
@@ -1219,7 +1448,7 @@ const ensureStdEnabledToggle = () => {
 
     const tdDays = tdCell("Days", wrap);
     tr.append(
-      tdCell("Pair", enhanceIconSelect(sel, (value, option) => {
+      tdCell("Sync pair", enhanceIconSelect(sel, (value, option) => {
         const data = pairOptionData(value, String(option?.textContent || "").trim());
         return data ? { ...data, disabled: !!option?.disabled } : null;
       })),
@@ -1547,12 +1776,12 @@ const ensureStdEnabledToggle = () => {
   <div class="sch-adv-section-head">
     <div>
       <div class="sch-adv-section-title">Time Plan</div>
-      <div class="sch-adv-section-copy">Use timed steps for the current advanced schedule. Only enabled pairs are selectable.</div>
+      <div class="sch-adv-section-copy">Use timed steps for the current advanced schedule. Only enabled sync pairs are selectable.</div>
     </div>
   </div>
   <table>
     <thead><tr>
-      <th style="width:32%"><span class="th-help">Pair<button type="button" class="sch-help" aria-label="Pair help" title="Pair help" data-help-key="time_pair"></button></span></th>
+      <th style="width:32%"><span class="th-help">Sync pair<button type="button" class="sch-help" aria-label="Sync pair help" title="Sync pair help" data-help-key="time_pair"></button></span></th>
       <th style="width:14%"><span class="th-help">Time<button type="button" class="sch-help" aria-label="Time help" title="Time help" data-help-key="time_time"></button></span></th>
       <th style="width:30%"><span class="th-help">Days<button type="button" class="sch-help" aria-label="Days help" title="Days help" data-help-key="time_days"></button></span></th>
       <th style="width:14%"><span class="th-help">After<button type="button" class="sch-help" aria-label="After help" title="After help" data-help-key="time_after"></button></span></th>
@@ -1563,8 +1792,23 @@ const ensureStdEnabledToggle = () => {
   </table>
   <div class="sch-adv-actions">
     <button class="btn" id="btnAddStep">Add step</button>
-    <button class="btn" id="btnAutoFromPairs">Auto-create from enabled pairs</button>
+    <button class="btn" id="btnAutoFromPairs">Auto-create from enabled sync pairs</button>
     <div class="status inline" id="schJobsStatus"></div>
+  </div>
+</section>
+
+<section class="sch-adv-section">
+  <div class="sch-adv-section-head">
+    <div>
+      <div class="sch-adv-section-title">Recurring workflows</div>
+      <div class="sch-adv-section-copy sch-workflow-intro">Define an ordered chain of existing sync pairs, then repeat it hourly, daily, or on a custom interval.</div>
+    </div>
+  </div>
+  <div id="schWorkflowsBody"></div>
+  <div class="sch-adv-actions">
+    <button class="btn" id="btnAddWorkflow">Add workflow</button>
+    <button class="btn" id="btnWorkflowFromPairs">Build from sync pair order</button>
+    <div class="status inline" id="schWorkflowStatus"></div>
   </div>
 </section>
 
@@ -1639,6 +1883,15 @@ const ensureStdEnabledToggle = () => {
       if (!_jobs.length) _jobs.push(defaultJob());
       renderJobs();
     };
+    $("#btnAddWorkflow").onclick = () => { _workflows.push(defaultWorkflow()); renderWorkflows(); };
+    $("#btnWorkflowFromPairs").onclick = () => {
+      const eps = _pairs.filter(p => p.enabled);
+      const workflow = defaultWorkflow();
+      workflow.steps = eps.map(p => ({ id: genId(), pair_id: p.id, active: true }));
+      if (!workflow.steps.length) workflow.steps.push(defaultWorkflowStep());
+      _workflows.push(workflow);
+      renderWorkflows();
+    };
     $("#btnAddCaptureJob").onclick = () => { _captureJobs.push(defaultCaptureJob()); renderCaptureJobs(); };
     $("#btnAddEventRule").onclick = () => { _eventRules.push(defaultEventRule()); renderEventRules(); };
     $("#schAdvEnabled").onchange = () => {
@@ -1660,16 +1913,19 @@ const ensureStdEnabledToggle = () => {
   // render
   const updateAdvancedStatus = () => {
     const jobsSt = $("#schJobsStatus");
+    const workflowSt = $("#schWorkflowStatus");
     const captureSt = $("#schCaptureStatus");
     const eventSt = $("#schEventStatus");
     const summaryText = $("#schAdvSummaryText");
     const summaryNote = $("#schAdvSummaryNote");
     const summaryState = $("#schAdvSummaryState");
     statusText(jobsSt);
+    statusText(workflowSt);
     statusText(captureSt);
     statusText(eventSt);
 
     const invalidJobs = serializableJobs().issues;
+    const invalidWorkflows = serializableWorkflows().issues;
     const blockedJobs = _jobs.some(j => j._blocked);
     const invalidCaptureJobs = serializableCaptureJobs().issues;
     const blockedRules = _eventRules.some(r => r._blocked);
@@ -1677,12 +1933,15 @@ const ensureStdEnabledToggle = () => {
     const invalidRules = _eventRules.map(eventRuleIssue).filter(Boolean);
     const timedJobs = _jobs.filter(j => !isBlankJob(j));
     const activeTimedJobs = timedJobs.filter(j => j.active !== false);
+    const workflows = _workflows.filter(w => !isBlankWorkflow(w));
+    const activeWorkflows = workflows.filter(w => w.active !== false);
     const captureJobs = _captureJobs.filter(j => !isBlankCaptureJob(j));
     const activeCaptureJobs = captureJobs.filter(j => j.active !== false);
     const eventRules = _eventRules.filter(eventRuleHasContent);
     const activeEventRules = eventRules.filter(r => r.active !== false);
-    const totalConfigured = timedJobs.length + captureJobs.length + eventRules.length;
+    const totalConfigured = timedJobs.length + workflows.length + captureJobs.length + eventRules.length;
     const timedIssue = invalidJobs[0] || (blockedJobs ? "Some timed steps reference disabled pairs." : "");
+    const workflowIssueText = invalidWorkflows[0] || "";
     const captureIssue = invalidCaptureJobs[0] || "";
     const eventIssue = (
       (eventRules.length ? _eventRouteError : "")
@@ -1692,6 +1951,7 @@ const ensureStdEnabledToggle = () => {
       || ""
     );
     const summaryIssue = issueLabel("Timed steps", timedIssue)
+      || issueLabel("Recurring workflows", workflowIssueText)
       || issueLabel("Capture schedules", captureIssue)
       || issueLabel("Event triggers", eventIssue);
 
@@ -1699,6 +1959,7 @@ const ensureStdEnabledToggle = () => {
       jobsSt,
       timedIssue
     );
+    statusText(workflowSt, workflowIssueText);
     statusText(captureSt, captureIssue);
     statusText(
       eventSt,
@@ -1710,6 +1971,7 @@ const ensureStdEnabledToggle = () => {
       else {
         const parts = [];
         if (timedJobs.length) parts.push(`${activeTimedJobs.length}/${timedJobs.length} timed step${timedJobs.length === 1 ? "" : "s"}`);
+        if (workflows.length) parts.push(`${activeWorkflows.length}/${workflows.length} recurring workflow${workflows.length === 1 ? "" : "s"}`);
         if (captureJobs.length) parts.push(`${activeCaptureJobs.length}/${captureJobs.length} capture schedule${captureJobs.length === 1 ? "" : "s"}`);
         if (eventRules.length) parts.push(`${activeEventRules.length}/${eventRules.length} event trigger${eventRules.length === 1 ? "" : "s"}`);
         summaryText.textContent = parts.join(" • ");
@@ -1718,7 +1980,7 @@ const ensureStdEnabledToggle = () => {
     if (summaryNote) {
       summaryNote.textContent = summaryIssue || (
         totalConfigured
-          ? "Combine timed steps, automated captures, and event triggers in one advanced plan."
+          ? "Combine timed steps, recurring workflows, automated captures, and event triggers in one advanced plan."
           : "Add timed steps, capture schedules, or event triggers to build an advanced automation flow."
       );
     }
@@ -1727,9 +1989,11 @@ const ensureStdEnabledToggle = () => {
         ? (
           summaryIssue.startsWith("Timed steps:")
             ? "Timed steps need attention"
-            : summaryIssue.startsWith("Capture schedules:")
-              ? "Capture schedules need attention"
-              : "Event triggers need attention"
+            : summaryIssue.startsWith("Recurring workflows:")
+              ? "Recurring workflows need attention"
+              : summaryIssue.startsWith("Capture schedules:")
+                ? "Capture schedules need attention"
+                : "Event triggers need attention"
         )
         : (_advEnabled ? "Advanced plan active" : "Advanced plan ready");
       summaryState.classList.toggle("attention", !!summaryIssue);
@@ -1742,6 +2006,15 @@ const ensureStdEnabledToggle = () => {
     if (!_jobs.length) _jobs.push(defaultJob());
     _jobs.forEach(j => j._blocked = j.active !== false && j.pair_id && !isEnabled(j.pair_id));
     _jobs.forEach(j => tbody.appendChild(jobRow(j)));
+    updateAdvancedStatus();
+    try { window.cwSchedSettingsHubUpdate?.(); } catch {}
+  };
+
+  const renderWorkflows = () => {
+    const body = $("#schWorkflowsBody"); if (!body) return;
+    body.innerHTML = "";
+    if (!_workflows.length) _workflows.push(defaultWorkflow());
+    _workflows.forEach((workflow) => body.appendChild(workflowBlock(workflow)));
     updateAdvancedStatus();
     try { window.cwSchedSettingsHubUpdate?.(); } catch {}
   };
@@ -1811,11 +2084,13 @@ const ensureStdEnabledToggle = () => {
         after: j.after || null,
         active: j.active !== false
       })) : [];
+      _workflows = Array.isArray(adv.workflows) ? adv.workflows.map(normalizeWorkflow) : [];
       _captureJobs = Array.isArray(adv.capture_jobs || adv.captureJobs) ? (adv.capture_jobs || adv.captureJobs).map(normalizeCaptureJob) : [];
       _captureJobs = mergeCaptureJobs(_captureJobs, getCaptureDraftJobs());
       _eventRules = Array.isArray(adv.event_rules || adv.eventRules) ? (adv.event_rules || adv.eventRules).map(normalizeEventRule) : [];
       _eventRules.forEach(syncRuleRoute);
       renderJobs();
+      renderWorkflows();
       renderCaptureJobs();
       renderEventRules();
       const pendingCapturePrefills = getPendingCapturePrefills();
@@ -1845,6 +2120,19 @@ const ensureStdEnabledToggle = () => {
       days: Array.isArray(j.days) ? j.days.slice() : [],
       after: j.after || null,
       active: j.active !== false
+    })),
+    workflows: serializableWorkflows().workflows.map(w => ({
+      id: w.id,
+      mode: w.mode || "hourly",
+      every_n_hours: Math.max(1, parseInt(w.every_n_hours || 1, 10) || 1),
+      daily_time: w.daily_time || "03:30",
+      custom_interval_minutes: Math.max(15, parseInt(w.custom_interval_minutes || 60, 10) || 60),
+      steps: (Array.isArray(w.steps) ? w.steps : []).map(step => ({
+        id: step.id,
+        pair_id: step.pair_id || null,
+        active: step.active !== false
+      })),
+      active: w.active !== false
     })),
     capture_jobs: serializableCaptureJobs().jobs.map((job) => ({
       id: job.id,
@@ -1881,12 +2169,14 @@ const ensureStdEnabledToggle = () => {
     }))
   });
   const schedulingValidation = () => {
+    const workflowState = serializableWorkflows();
     const captureState = serializableCaptureJobs();
     const ruleState = serializableEventRules();
     return {
+      workflowIssues: workflowState.issues.slice(),
       captureIssues: captureState.issues.slice(),
       eventIssues: ruleState.issues.slice(),
-      issues: [...captureState.issues, ...ruleState.issues]
+      issues: [...workflowState.issues, ...captureState.issues, ...ruleState.issues]
     };
   };
   window.getSchedulingValidation = schedulingValidation;
@@ -1899,6 +2189,10 @@ const ensureStdEnabledToggle = () => {
     const daily_time = $("#schTime")?.value || "03:30";
     const custom_interval_minutes = getCustomIntervalMinutes();
     const validation = schedulingValidation();
+    if (validation.workflowIssues.length) {
+      if (strict) throw new Error(validation.workflowIssues[0]);
+      return null;
+    }
     if (validation.captureIssues.length) {
       if (strict) throw new Error(validation.captureIssues[0]);
       return null;

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -1459,8 +1459,6 @@ def _normalize_scheduling(cfg: dict[str, Any]) -> None:
             j["after"] = None
         else:
             a = str(after).strip()
-            if a and not _is_hhmm(a):
-                a = ""
             j["after"] = a or None
 
         days0 = j.get("days")
@@ -1481,6 +1479,58 @@ def _normalize_scheduling(cfg: dict[str, Any]) -> None:
         out.append(j)
 
     adv["jobs"] = out
+
+    workflows0 = adv.get("workflows")
+    workflows: list[dict[str, Any]] = []
+    if isinstance(workflows0, list):
+        for it in workflows0:
+            if isinstance(it, dict):
+                workflows.append(dict(it))
+
+    wf_out: list[dict[str, Any]] = []
+    for i, workflow in enumerate(workflows):
+        wid = str(workflow.get("id") or "").strip() or f"workflow_{i+1}"
+        workflow["id"] = wid
+        workflow["name"] = str(workflow.get("name") or "").strip()
+        wf_mode = str(workflow.get("mode") or "hourly").strip().lower()
+        if wf_mode not in {"hourly", "every_n_hours", "daily_time", "custom_interval"}:
+            wf_mode = "hourly"
+        workflow["mode"] = wf_mode
+
+        try:
+            wf_hours = int(workflow.get("every_n_hours", 1) or 1)
+        except Exception:
+            wf_hours = 1
+        workflow["every_n_hours"] = max(1, wf_hours)
+
+        wf_time = str(workflow.get("daily_time", "03:30") or "03:30").strip()
+        if not _is_hhmm(wf_time):
+            wf_time = "03:30"
+        workflow["daily_time"] = wf_time
+
+        try:
+            wf_minutes = int(workflow.get("custom_interval_minutes", 60) or 60)
+        except Exception:
+            wf_minutes = 60
+        workflow["custom_interval_minutes"] = max(15, wf_minutes)
+
+        steps0 = workflow.get("steps")
+        steps: list[dict[str, Any]] = []
+        if isinstance(steps0, list):
+            for si, raw_step in enumerate(steps0):
+                if not isinstance(raw_step, dict):
+                    continue
+                step = dict(raw_step)
+                step["id"] = str(step.get("id") or "").strip() or f"step_{si+1}"
+                pair_id = step.get("pair_id")
+                step["pair_id"] = None if pair_id is None else (str(pair_id).strip() or None)
+                step["active"] = bool(step.get("active", True))
+                steps.append(step)
+        workflow["steps"] = steps
+        workflow["active"] = bool(workflow.get("active", True))
+        wf_out.append(workflow)
+
+    adv["workflows"] = wf_out
 
 
 def _normalize_anime_mapping(cfg: dict[str, Any]) -> None:

--- a/services/scheduling.py
+++ b/services/scheduling.py
@@ -35,6 +35,7 @@ DEFAULT_SCHEDULING: dict[str, Any] = {
         "capture_jobs": [],
         "backup_jobs": [],
         "event_rules": [],
+        "workflows": [],
     },
 }
 
@@ -163,6 +164,8 @@ def merge_defaults(s: dict[str, Any]) -> dict[str, Any]:
                 out_adv["backup_jobs"] = []
             if not isinstance(out_adv.get("event_rules"), list):
                 out_adv["event_rules"] = []
+            if not isinstance(out_adv.get("workflows"), list):
+                out_adv["workflows"] = []
             out["advanced"] = out_adv
     if not isinstance(out.get("advanced"), dict):
         out["advanced"] = dict(DEFAULT_SCHEDULING["advanced"])
@@ -255,6 +258,39 @@ def _normalize_job(j: dict[str, Any]) -> dict[str, Any]:
         "days": days2,
         "after": (str(j.get("after") or "").strip() or None),
         "active": bool(j.get("active", True)),
+    }
+
+
+def _normalize_workflow_step(step: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": str(step.get("id") or "").strip() or f"step_{_now_ts()}",
+        "pair_id": (str(step.get("pair_id") or "").strip() or None),
+        "active": _as_bool(step.get("active"), True),
+    }
+
+
+def _normalize_workflow(raw: dict[str, Any]) -> dict[str, Any]:
+    mode = str(raw.get("mode") or "hourly").strip().lower()
+    if mode not in {"hourly", "every_n_hours", "daily_time", "custom_interval"}:
+        mode = "hourly"
+    steps_raw = raw.get("steps") or []
+    steps: list[dict[str, Any]] = []
+    if isinstance(steps_raw, list):
+        for item in steps_raw:
+            if not isinstance(item, dict):
+                continue
+            step = _normalize_workflow_step(item)
+            if step["active"] and step["pair_id"]:
+                steps.append(step)
+    return {
+        "id": str(raw.get("id") or "").strip() or f"workflow_{_now_ts()}",
+        "name": str(raw.get("name") or "").strip(),
+        "mode": mode,
+        "every_n_hours": _as_int(raw.get("every_n_hours"), 1, minimum=1),
+        "daily_time": str(raw.get("daily_time") or "03:30").strip() or "03:30",
+        "custom_interval_minutes": _as_int(raw.get("custom_interval_minutes"), 60, minimum=15),
+        "steps": steps,
+        "active": _as_bool(raw.get("active"), True),
     }
 
 
@@ -380,6 +416,28 @@ def _iter_adv_jobs(sch: dict[str, Any]) -> list[dict[str, Any]]:
         if not j["at"] or _parse_hhmm(j["at"]) is None:
             continue
         out.append(j)
+    return out
+
+
+def _iter_adv_workflows(sch: dict[str, Any]) -> list[dict[str, Any]]:
+    adv = sch.get("advanced") or {}
+    if not isinstance(adv, dict) or not adv.get("enabled"):
+        return []
+    workflows = adv.get("workflows") or []
+    if not isinstance(workflows, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for raw in workflows:
+        if not isinstance(raw, dict):
+            continue
+        workflow = _normalize_workflow(raw)
+        if not workflow["active"]:
+            continue
+        if not workflow["steps"]:
+            continue
+        if workflow["mode"] == "daily_time" and _parse_hhmm(workflow["daily_time"]) is None:
+            continue
+        out.append(workflow)
     return out
 
 
@@ -535,6 +593,56 @@ def _next_job_time(now_local: datetime, job: dict[str, Any]) -> datetime | None:
     return None
 
 
+def _workflow_slot(now_local: datetime, workflow: dict[str, Any]) -> datetime | None:
+    base = now_local.replace(second=0, microsecond=0)
+    mode = workflow.get("mode")
+    if mode == "daily_time":
+        hhmm = _parse_hhmm(workflow.get("daily_time") or "")
+        if not hhmm:
+            return None
+        hh, mm = hhmm
+        cand = base.replace(hour=hh, minute=mm, second=0, microsecond=0)
+        return cand if cand <= base else None
+
+    if mode == "every_n_hours":
+        interval = max(1, _as_int(workflow.get("every_n_hours"), 1, minimum=1)) * 60
+    elif mode == "custom_interval":
+        interval = max(15, _as_int(workflow.get("custom_interval_minutes"), 60, minimum=15))
+    else:
+        interval = 60
+
+    midnight = base.replace(hour=0, minute=0, second=0, microsecond=0)
+    elapsed = int((base - midnight).total_seconds() // 60)
+    return midnight + timedelta(minutes=(elapsed // interval) * interval)
+
+
+def _next_workflow_time(now_local: datetime, workflow: dict[str, Any]) -> datetime | None:
+    base = now_local.replace(second=0, microsecond=0)
+    mode = workflow.get("mode")
+    if mode == "daily_time":
+        hhmm = _parse_hhmm(workflow.get("daily_time") or "")
+        if not hhmm:
+            return None
+        hh, mm = hhmm
+        cand = base.replace(hour=hh, minute=mm, second=0, microsecond=0)
+        return cand if cand > base else cand + timedelta(days=1)
+
+    if mode == "every_n_hours":
+        interval = max(1, _as_int(workflow.get("every_n_hours"), 1, minimum=1)) * 60
+    elif mode == "custom_interval":
+        interval = max(15, _as_int(workflow.get("custom_interval_minutes"), 60, minimum=15))
+    else:
+        interval = 60
+
+    midnight = base.replace(hour=0, minute=0, second=0, microsecond=0)
+    elapsed = int((base - midnight).total_seconds() // 60)
+    return midnight + timedelta(minutes=((elapsed // interval) + 1) * interval)
+
+
+def _workflow_key(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%d@%H:%M")
+
+
 def _topo_order(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
     by_id = {j["id"]: j for j in jobs}
     pending = list(jobs)
@@ -649,11 +757,24 @@ class SyncScheduler:
 
     def _adv_signature(self, sch: dict[str, Any]) -> str:
         jobs = _iter_adv_jobs(sch)
+        workflows = _iter_adv_workflows(sch)
         capture_jobs = _iter_adv_capture_jobs(sch)
         backup_jobs = _iter_adv_backup_jobs(sch)
         pairs = [
-            ("sync", str(j.get("id") or ""), str(j.get("pair_id") or ""), str(j.get("at") or ""), tuple(j.get("days") or []))
+            ("sync", str(j.get("id") or ""), str(j.get("pair_id") or ""), str(j.get("at") or ""), tuple(j.get("days") or []), str(j.get("after") or ""))
             for j in jobs
+        ]
+        pairs += [
+            (
+                "workflow",
+                str(w.get("id") or ""),
+                str(w.get("mode") or ""),
+                int(w.get("every_n_hours") or 1),
+                str(w.get("daily_time") or ""),
+                int(w.get("custom_interval_minutes") or 60),
+                tuple((str(s.get("id") or ""), str(s.get("pair_id") or ""), bool(s.get("active", True))) for s in (w.get("steps") or [])),
+            )
+            for w in workflows
         ]
         pairs += [
             (
@@ -702,6 +823,12 @@ class SyncScheduler:
             if dt is None or dt >= current:
                 continue
             self._adv_last_key[job["id"]] = f"{today}@{job.get('at')}"
+
+        for workflow in _iter_adv_workflows(sch):
+            dt = _workflow_slot(base, workflow)
+            if dt is None or dt >= current:
+                continue
+            self._adv_last_key[f"workflow:{workflow['id']}"] = _workflow_key(dt)
 
         for job in _iter_adv_capture_jobs(sch):
             dt = _job_due_today(base, job)
@@ -1016,9 +1143,10 @@ class SyncScheduler:
 
     def _adv_next(self, sch: dict[str, Any], now_local: datetime, tz: Any | None) -> datetime | None:
         jobs = _iter_adv_jobs(sch)
+        workflows = _iter_adv_workflows(sch)
         capture_jobs = _iter_adv_capture_jobs(sch)
         backup_jobs = _iter_adv_backup_jobs(sch)
-        if not jobs and not capture_jobs and not backup_jobs:
+        if not jobs and not workflows and not capture_jobs and not backup_jobs:
             return None
 
         now = _as_now_in_tz(tz)
@@ -1035,6 +1163,14 @@ class SyncScheduler:
                 if not dep_key.startswith(today):
                     cand2 = _next_job_time(base + timedelta(days=1), j)
                     cand = cand2 or cand
+            if best is None or cand < best:
+                best = cand
+        for workflow in workflows:
+            cand = _workflow_slot(base, workflow)
+            if cand is None or self._adv_last_key.get(f"workflow:{workflow['id']}") == _workflow_key(cand):
+                cand = _next_workflow_time(base, workflow)
+            if cand is None:
+                continue
             if best is None or cand < best:
                 best = cand
         for j in capture_jobs:
@@ -1071,6 +1207,27 @@ class SyncScheduler:
             if self._adv_last_key.get(j["id"]) == key:
                 continue
             due.append((dt, j))
+
+        due.sort(key=lambda x: (x[0], str(x[1].get("id") or "")))
+        return due
+
+    def _adv_due_workflows(self, sch: dict[str, Any], tz: Any | None) -> list[tuple[datetime, dict[str, Any]]]:
+        workflows = _iter_adv_workflows(sch)
+        if not workflows:
+            return []
+
+        now = _as_now_in_tz(tz)
+        base = now.replace(second=0, microsecond=0)
+
+        due: list[tuple[datetime, dict[str, Any]]] = []
+        for workflow in workflows:
+            dt = _workflow_slot(base, workflow)
+            if dt is None:
+                continue
+            key = _workflow_key(dt)
+            if self._adv_last_key.get(f"workflow:{workflow['id']}") == key:
+                continue
+            due.append((dt, workflow))
 
         due.sort(key=lambda x: (x[0], str(x[1].get("id") or "")))
         return due
@@ -1125,9 +1282,10 @@ class SyncScheduler:
 
     def _adv_run_due(self, sch: dict[str, Any], tz: Any | None) -> bool:
         due = self._adv_due_jobs(sch, tz)
+        due_workflows = self._adv_due_workflows(sch, tz)
         due_capture = self._adv_due_capture_jobs(sch, tz)
         due_backup = self._adv_due_backup_jobs(sch, tz)
-        if not due and not due_capture and not due_backup:
+        if not due and not due_workflows and not due_capture and not due_backup:
             return False
 
         now = _as_now_in_tz(tz)
@@ -1189,6 +1347,65 @@ class SyncScheduler:
 
             self._adv_last_key[j["id"]] = f"{today}@{j.get('at')}"
             executed.add(j["id"])
+
+        for due_at, workflow in due_workflows:
+            if self._stop.is_set():
+                break
+
+            workflow_ok = True
+            steps = list(workflow.get("steps") or [])
+            for step in steps:
+                if self._stop.is_set():
+                    break
+
+                waited = 0
+                while self.is_sync_running_fn() and not self._stop.is_set():
+                    if waited == 0:
+                        self._log("advanced workflow: sync is busy; waiting to run due workflow", level="INFO")
+                    waited += 1
+                    self._sleep_or_poke(2.0)
+                    if self._poke.is_set():
+                        self._poke.clear()
+                        return True
+
+                payload = {
+                    "source": "scheduler",
+                    "scheduler_mode": "advanced_workflow",
+                    "workflow_id": workflow["id"],
+                    "workflow_step_id": step["id"],
+                    "pair_id": step["pair_id"],
+                }
+
+                self._log(f"advanced workflow: running {workflow['id']} step {step['id']} for pair {step['pair_id']}", level="INFO")
+                ok = self._run_sync(payload)
+                if not ok:
+                    ok_all = False
+                    workflow_ok = False
+                    self._log(f"advanced workflow: step {step['id']} failed", level="ERROR")
+                else:
+                    self._log(f"advanced workflow: step {step['id']} ok", level="INFO")
+
+                with self._lock:
+                    self._status["last_run_ok"] = ok
+                    self._status["last_run_at"] = _now_ts()
+                    self._status["last_error"] = "" if ok else "advanced workflow step failed"
+                    self._status["last_job_id"] = step["id"]
+                    self._status["last_pair_id"] = step["pair_id"] or ""
+                    self._status["last_capture_job_id"] = ""
+                    self._status["last_capture_provider"] = ""
+                    self._status["last_capture_feature"] = ""
+                    self._status["last_backup_job_id"] = ""
+                    self._status["last_backup_scope"] = ""
+                    self._status["last_rule_id"] = ""
+                    self._status["last_event_source"] = ""
+                    self._status["last_event_name"] = ""
+
+                if not ok:
+                    break
+
+            self._adv_last_key[f"workflow:{workflow['id']}"] = _workflow_key(due_at)
+            if workflow_ok:
+                self._log(f"advanced workflow: workflow {workflow['id']} ok", level="INFO")
 
         for _, j in due_capture:
             if self._stop.is_set():

--- a/tests/test_standard_scheduling.py
+++ b/tests/test_standard_scheduling.py
@@ -62,3 +62,69 @@ def test_format_display_datetime_uses_configured_timezone() -> None:
     text = _format_display_datetime(ts, {"timezone": "Europe/Amsterdam"})
 
     assert text.startswith("2026-03-18 14:56:00")
+
+
+def test_normalize_scheduling_preserves_after_job_id() -> None:
+    from cw_platform.config_base import _normalize_scheduling
+
+    cfg = {
+        "scheduling": {
+            "advanced": {
+                "enabled": True,
+                "jobs": [
+                    {"id": "first", "pair_id": "a", "at": "10:00"},
+                    {"id": "second", "pair_id": "b", "at": "10:00", "after": "first"},
+                ],
+            }
+        }
+    }
+
+    _normalize_scheduling(cfg)
+
+    assert cfg["scheduling"]["advanced"]["jobs"][1]["after"] == "first"
+
+
+def test_recurring_workflow_runs_pair_steps_in_order(monkeypatch) -> None:
+    import services.scheduling as scheduling
+    from services.scheduling import SyncScheduler
+
+    now = datetime(2026, 3, 18, 10, 5, 0)
+    monkeypatch.setattr(scheduling, "_as_now_in_tz", lambda _tz=None: now)
+    monkeypatch.setattr(scheduling, "_now_ts", lambda: int(now.timestamp()))
+
+    seen: list[str] = []
+    config = {
+        "scheduling": {
+            "enabled": False,
+            "mode": "disabled",
+            "advanced": {
+                "enabled": True,
+                "jobs": [],
+                "workflows": [
+                    {
+                        "id": "hourly-chain",
+                        "mode": "hourly",
+                        "steps": [
+                            {"id": "one", "pair_id": "nuvio-crosswatch"},
+                            {"id": "two", "pair_id": "crosswatch-publicmetadb"},
+                        ],
+                        "active": True,
+                    }
+                ],
+            },
+        }
+    }
+
+    scheduler = SyncScheduler(
+        load_config=lambda: config,
+        save_config=lambda next_cfg: config.update(next_cfg),
+        run_sync_fn=lambda payload=None: seen.append(str((payload or {}).get("pair_id") or "")) or True,
+        is_sync_running_fn=lambda: False,
+    )
+
+    ok = scheduler._adv_run_due(config["scheduling"], None)
+    ran_again = scheduler._adv_run_due(config["scheduling"], None)
+
+    assert ok is True
+    assert ran_again is False
+    assert seen == ["nuvio-crosswatch", "crosswatch-publicmetadb"]


### PR DESCRIPTION
# Pull request

## Change

Adds recurring workflows to Advanced Scheduler.

Users can define an ordered sync chain once, then run it hourly, daily, every N hours, or on a custom minute interval. 

## Why

Advanced Scheduler already had ordering, but repeating an ordered flow was painful because users had to create every single timed step manually.

## Testing

tests/test_standard_scheduling.py

## Issue

Relates to #581