### PR TITLE
Fix: CW chained sync state

### DIFF
--- a/providers/sync/crosswatch/_common.py
+++ b/providers/sync/crosswatch/_common.py
@@ -115,6 +115,27 @@ def latest_state_file(root: Path, stem: str) -> Path | None:
         return candidates[-1]
 
 
+def state_file_for_read(root: Path, stem: str, scoped: Path) -> Path:
+    if not pair_scoped():
+        return scoped
+
+    src = str(os.getenv("CW_PAIR_SRC") or "").strip().upper()
+    if src != "CROSSWATCH":
+        return scoped
+
+    latest = latest_state_file(root, stem)
+    if latest is None or latest == scoped:
+        return scoped
+    if not scoped.exists():
+        return latest
+    try:
+        if latest.stat().st_mtime_ns > scoped.stat().st_mtime_ns:
+            return latest
+    except Exception:
+        pass
+    return scoped
+
+
 def latest_snapshot_file(root: Path, feature: str) -> Path | None:
     snaps = root / "snapshots"
     if not snaps.exists() or not snaps.is_dir():

--- a/providers/sync/crosswatch/_history.py
+++ b/providers/sync/crosswatch/_history.py
@@ -23,6 +23,7 @@ from ._common import (
     make_logger,
     pair_scoped,
     scoped_file,
+    state_file_for_read,
 )
 
 _dbg, _info, _warn, _error = make_logger("history")
@@ -85,7 +86,8 @@ def _load_state(adapter: Any) -> dict[str, Any]:
         except Exception:
             return None
 
-    raw = _read_json(path)
+    read_path = state_file_for_read(root, "history", path)
+    raw = _read_json(read_path)
     if raw is None:
         alt = latest_state_file(root, "history")
         if alt and alt != path:

--- a/providers/sync/crosswatch/_progress.py
+++ b/providers/sync/crosswatch/_progress.py
@@ -24,6 +24,7 @@ from ._common import (
     make_logger,
     pair_scoped,
     scoped_file,
+    state_file_for_read,
 )
 
 _dbg, _info, _warn, _error = make_logger("progress")
@@ -134,7 +135,8 @@ def _load_state(adapter: Any) -> dict[str, Any]:
         except Exception:
             return None
 
-    raw = _read_json(path)
+    read_path = state_file_for_read(root, "progress", path)
+    raw = _read_json(read_path)
     if raw is None:
         alt = latest_state_file(root, "progress")
         if alt and alt != path:

--- a/providers/sync/crosswatch/_ratings.py
+++ b/providers/sync/crosswatch/_ratings.py
@@ -24,6 +24,7 @@ from ._common import (
     make_logger,
     pair_scoped,
     scoped_file,
+    state_file_for_read,
 )
 
 _dbg, _info, _warn, _error = make_logger("ratings")
@@ -93,7 +94,8 @@ def _load_state(adapter: Any) -> dict[str, Any]:
         except Exception:
             return None
 
-    raw = _read_json(path)
+    read_path = state_file_for_read(root, "ratings", path)
+    raw = _read_json(read_path)
     if raw is None:
         alt = latest_state_file(root, "ratings")
         if alt and alt != path:

--- a/providers/sync/crosswatch/_watchlist.py
+++ b/providers/sync/crosswatch/_watchlist.py
@@ -26,6 +26,7 @@ from ._common import (
     make_logger,
     pair_scoped,
     scoped_file,
+    state_file_for_read,
 )
 
 _dbg, _info, _warn, _error = make_logger("watchlist")
@@ -114,7 +115,8 @@ def _load_state(adapter: Any) -> dict[str, Any]:
         except Exception:
             return None
 
-    raw = _read_json(path)
+    read_path = state_file_for_read(root, "watchlist", path)
+    raw = _read_json(read_path)
     if raw is None:
         alt = latest_state_file(root, "watchlist")
         if alt and alt != path:

--- a/tests/test_crosswatch_chain_state.py
+++ b/tests/test_crosswatch_chain_state.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def _adapter(root: Path) -> Any:
+    return type("Adapter", (), {"cfg": type("Cfg", (), {"base_path": str(root)})()})()
+
+
+def _write_state(path: Path, key: str, tmdb: str, mtime: int) -> None:
+    path.write_text(
+        json.dumps({"ts": mtime, "items": {key: {"type": "movie", "ids": {"tmdb": tmdb}}}}),
+        "utf-8",
+    )
+    os.utime(path, (mtime, mtime))
+
+
+def test_crosswatch_source_reads_newer_pair_scoped_state(tmp_path: Path, monkeypatch) -> None:
+    from providers.sync.crosswatch import _watchlist
+
+    monkeypatch.setenv("CW_CROSSWATCH_PAIR_SCOPED", "1")
+    monkeypatch.setenv("CW_PAIR_SCOPE", "downstream")
+    monkeypatch.setenv("CW_PAIR_SRC", "CROSSWATCH")
+    _write_state(tmp_path / "watchlist.downstream.json", "tmdb:1", "1", 100)
+    _write_state(tmp_path / "watchlist.upstream.json", "tmdb:2", "2", 200)
+
+    index = _watchlist.build_index(_adapter(tmp_path))
+
+    assert "tmdb:2" in index
+    assert "tmdb:1" not in index
+
+
+def test_crosswatch_target_keeps_current_pair_scoped_state(tmp_path: Path, monkeypatch) -> None:
+    from providers.sync.crosswatch import _watchlist
+
+    monkeypatch.setenv("CW_CROSSWATCH_PAIR_SCOPED", "1")
+    monkeypatch.setenv("CW_PAIR_SCOPE", "downstream")
+    monkeypatch.setenv("CW_PAIR_SRC", "SIMKL")
+    _write_state(tmp_path / "watchlist.downstream.json", "tmdb:1", "1", 100)
+    _write_state(tmp_path / "watchlist.upstream.json", "tmdb:2", "2", 200)
+
+    index = _watchlist.build_index(_adapter(tmp_path))
+
+    assert "tmdb:1" in index
+    assert "tmdb:2" not in index


### PR DESCRIPTION
# Pull request

## Change

Fixes CW reading stale pair-scoped state when it is used as the middle step in a chained sync.
When CW is the source, it now reads the newest matching CWstate instead of sticking to an older scoped file for the current pair.

## Why

A flow like this could need another run before the second pair saw the data.

## Testing

tests/test_crosswatch_chain_state.py

## Issue

NA