### PR TITLE
Fix: Floppy auth setup text

### DIFF
--- a/assets/helpers/providers-ui.js
+++ b/assets/helpers/providers-ui.js
@@ -529,7 +529,7 @@
       provider: "floppy", logo: "FLOPPY", help: window.CW.HelpLinks.url("floppy"), deleteSelector: "#floppy_disconnect",
       tabs: { auth: ["lock", "Authentication", "Connect your Floppy server"] },
       copy: { auth: ["Floppy Authentication", "Connect Floppy with server URL and API token."] },
-      journey: ["Connect to Floppy", "Create an API token in Floppy Settings > Advanced, then connect your self-hosted server. Sync features are not enabled yet.", "245,101,30", "4,181,220", "FLOPPY"],
+    journey: ["Connect to Floppy", "Create an API token in Floppy Settings > Integrations, then connect your self-hosted server.", "245,101,30", "4,181,220", "FLOPPY"],
       steps: [["1", "Create token", "Generate a token in Floppy"], ["2", "Enter server", "Add your Floppy server URL"], ["3", "Validate access", "CrossWatch confirms the token works"]],
       order: [".grid2", ".verify", "#floppy_actions_row"],
       actions: [{ row: "#floppy_actions_row", status: "#floppy_msg", buttons: "#floppy_connect" }]

--- a/providers/auth/_auth_FLOPPY.py
+++ b/providers/auth/_auth_FLOPPY.py
@@ -115,7 +115,7 @@ class FloppyAuth(AuthProvider):
                 {"key": "floppy.verify_ssl", "label": "Verify SSL", "type": "bool", "required": False, "default": False},
             ],
             actions={"start": False, "finish": True, "refresh": False, "disconnect": True},
-            notes="Create the API token in Floppy > Settings > Advanced.",
+    notes="Create the API token in Floppy > Settings > Integrations.",
         )
 
     def capabilities(self) -> dict[str, Any]:
@@ -188,7 +188,7 @@ def html() -> str:
             <div class="cw-auth-journey" style="--cw-auth-c1:245,101,30;--cw-auth-c2:4,181,220;--cw-auth-logo:url('/assets/img/FLOPPY.png')">
               <div class="cw-auth-journey-text">
                 <div class="cw-auth-journey-title">Connect to Floppy</div>
-                <div class="cw-auth-journey-copy">Create an API token in Floppy &rsaquo; Settings &rsaquo; Advanced, then enter your server URL and token here.</div>
+              <div class="cw-auth-journey-copy">Create an API token in Floppy &rsaquo; Settings &rsaquo; Integrations, then enter your server URL and token here.</div>
               </div>
             </div>
             <div class="grid2">


### PR DESCRIPTION
# Pull request

## Change

Updated the Floppy auth instructions to point users to:

Settings > Integrations

Also removed the old “sync features are not enabled yet” text.

## Why

NA

## Testing

- tests/test_floppy_auth.py

## Issue

Relates to #594