### PR TITLE
Fix: CW Tracker help copy

### DIFF
--- a/assets/helpers/help-links.js
+++ b/assets/helpers/help-links.js
@@ -15,6 +15,7 @@
     publicmetadb: "crosswatch/settings/connections/trackers/publicmetadb",
     anilist: "crosswatch/settings/connections/trackers/anilist",
     floppy: "crosswatch/settings/connections/trackers/floppy",
+    crosswatch: "crosswatch/settings/connections/trackers/crosswatch",
     nuvio: "crosswatch/settings/connections/media-clients/nuvio",
     kodi: "crosswatch/settings/connections/media-clients/kodi",
     stremio: "crosswatch/settings/connections/media-clients/stremio",

--- a/assets/helpers/providers-ui.js
+++ b/assets/helpers/providers-ui.js
@@ -581,10 +581,10 @@
       actions: [{ row: "#tautulli_actions_row", status: "#tautulli_msg", buttons: "#tautulli_save" }]
     },
     CROSSWATCH: {
-      provider: "crosswatch", logo: "CROSSWATCH", help: window.CW.HelpLinks.url("connection-profiles"), deleteSelector: "#cw_crosswatch_disconnect",
+      provider: "crosswatch", logo: "CROSSWATCH", help: window.CW.HelpLinks.url("crosswatch"), deleteSelector: "#cw_crosswatch_disconnect",
       tabs: { auth: ["lock", "Authentication", "Connect local tracker"], settings: ["database", "Settings", "Storage and restore"] },
       copy: { auth: ["CrossWatch Authentication", "Connect this local tracker profile."], settings: ["CrossWatch Local Tracker", "Configure storage and restore snapshots for this tracker profile."] },
-      journey: ["Connect Local Tracker", "Use CrossWatch Local Tracker as a normal sync connection. Create CW-P profiles when you need separate local tracker data while keeping account-level provider credentials and schedules shared.", "124,92,255", "98,194,255", "CROSSWATCH"],
+      journey: ["Connect Local Tracker", "Enable the built-in CrossWatch tracker as a normal connection. Use profiles when you want separate local watchlist, ratings, history or progress data.", "124,92,255", "98,194,255", "CROSSWATCH"],
       steps: [["1", "Choose profile", "Use Default or create CW-P profiles"], ["2", "Connect locally", "Enable the selected profile as a connection"], ["3", "Sync locally", "Use the profile in normal sync pairs"]],
       introSubs: ["auth"],
       order: [".cw-tracker-auth-card", ".cw-tracker-settings-stack"],


### PR DESCRIPTION
# Pull request

## Change

Updated the CWLocal Tracker connection modal copy.

Also added the CW tracker wiki URL to the shared help link helper and switched the modal to use it.

## Why

The old text was linked to the generic profiles page instead of the CW tracker page.

## Testing

NA

## Issue

NA