### PR TITLE
Fix: docs provider grid and ordering

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,9 +41,9 @@
 </section>
 
 <section class="cw-provider-wall" aria-label="Supported services">
-  <article class="cw-provider-card is-plex">
-    <img class="cw-provider-mark" src="images/providers/PLEX.svg" alt="" aria-hidden="true">
-    <strong>Plex</strong>
+  <article class="cw-provider-card is-emby">
+    <img class="cw-provider-mark" src="images/providers/EMBY.svg" alt="" aria-hidden="true">
+    <strong>Emby</strong>
     <span>Media server</span>
     <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
   </article>
@@ -53,9 +53,9 @@
     <span>Media server</span>
     <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
   </article>
-  <article class="cw-provider-card is-emby">
-    <img class="cw-provider-mark" src="images/providers/EMBY.svg" alt="" aria-hidden="true">
-    <strong>Emby</strong>
+  <article class="cw-provider-card is-plex">
+    <img class="cw-provider-mark" src="images/providers/PLEX.svg" alt="" aria-hidden="true">
+    <strong>Plex</strong>
     <span>Media server</span>
     <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
   </article>
@@ -65,21 +65,33 @@
     <span>Media client</span>
     <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
   </article>
+  <article class="cw-provider-card is-nuvio">
+    <img class="cw-provider-mark" src="images/providers/NUVIO.png" alt="" aria-hidden="true">
+    <strong>Nuvio</strong>
+    <span>Media client</span>
+    <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
+  </article>
   <article class="cw-provider-card is-stremio">
     <img class="cw-provider-mark" src="images/providers/STREMIO.png" alt="" aria-hidden="true">
     <strong>Stremio</strong>
     <span>Media client</span>
     <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
   </article>
-  <article class="cw-provider-card is-trakt">
-    <img class="cw-provider-mark" src="images/providers/TRAKT.svg" alt="" aria-hidden="true">
-    <strong>Trakt</strong>
+  <article class="cw-provider-card is-anilist">
+    <img class="cw-provider-mark" src="images/providers/ANILIST.svg" alt="" aria-hidden="true">
+    <strong>AniList</strong>
     <span>Tracker</span>
     <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
   </article>
-  <article class="cw-provider-card is-simkl">
-    <img class="cw-provider-mark" src="images/providers/SIMKL.svg" alt="" aria-hidden="true">
-    <strong>SIMKL</strong>
+  <article class="cw-provider-card is-crosswatch">
+    <img class="cw-provider-mark" src="images/providers/CROSSWATCH.svg" alt="" aria-hidden="true">
+    <strong>CrossWatch</strong>
+    <span>Local tracker</span>
+    <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
+  </article>
+  <article class="cw-provider-card is-floppy">
+    <img class="cw-provider-mark" src="images/providers/FLOPPY.png" alt="" aria-hidden="true">
+    <strong>Floppy</strong>
     <span>Tracker</span>
     <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
   </article>
@@ -89,40 +101,34 @@
     <span>Tracker</span>
     <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
   </article>
-  <article class="cw-provider-card is-floppy">
-    <img class="cw-provider-mark" src="images/providers/FLOPPY.png" alt="" aria-hidden="true">
-    <strong>Floppy</strong>
+  <article class="cw-provider-card is-publicmetadb">
+    <img class="cw-provider-mark" src="images/providers/PUBLICMETADB.svg" alt="" aria-hidden="true">
+    <strong>PublicMetaDB</strong>
+    <span>Tracker</span>
+    <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
+  </article>
+  <article class="cw-provider-card is-simkl">
+    <img class="cw-provider-mark" src="images/providers/SIMKL.svg" alt="" aria-hidden="true">
+    <strong>SIMKL</strong>
+    <span>Tracker</span>
+    <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
+  </article>
+  <article class="cw-provider-card is-tautulli">
+    <img class="cw-provider-mark" src="images/providers/TAUTULLI.svg" alt="" aria-hidden="true">
+    <strong>Tautulli</strong>
     <span>Tracker</span>
     <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
   </article>
   <article class="cw-provider-card is-tmdb">
     <img class="cw-provider-mark" src="images/providers/TMDB.svg" alt="" aria-hidden="true">
     <strong>TMDb</strong>
-    <span>Metadata</span>
+    <span>Tracker and metadata</span>
     <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
   </article>
-  <article class="cw-provider-card is-anilist">
-    <img class="cw-provider-mark" src="images/providers/ANILIST.svg" alt="" aria-hidden="true">
-    <strong>AniList</strong>
-    <span>Anime tracker</span>
-    <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
-  </article>
-  <article class="cw-provider-card is-publicmetadb">
-    <img class="cw-provider-mark" src="images/providers/PUBLICMETADB.svg" alt="" aria-hidden="true">
-    <strong>PublicMetaDB</strong>
-    <span>Ratings and metadata</span>
-    <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
-  </article>
-  <article class="cw-provider-card is-tautulli">
-    <img class="cw-provider-mark" src="images/providers/TAUTULLI.svg" alt="" aria-hidden="true">
-    <strong>Tautulli</strong>
-    <span>Plex activity</span>
-    <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
-  </article>
-  <article class="cw-provider-card is-nuvio">
-    <img class="cw-provider-mark" src="images/providers/NUVIO.png" alt="" aria-hidden="true">
-    <strong>Nuvio</strong>
-    <span>Media app</span>
+  <article class="cw-provider-card is-trakt">
+    <img class="cw-provider-mark" src="images/providers/TRAKT.svg" alt="" aria-hidden="true">
+    <strong>Trakt</strong>
+    <span>Tracker</span>
     <b class="cw-provider-dots" aria-hidden="true"><i></i><i></i><i></i><i></i></b>
   </article>
 </section>

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -372,6 +372,7 @@ a[href="#content"],
 .cw-provider-card.is-trakt,
 .cw-provider-card.is-simkl,
 .cw-provider-card.is-floppy,
+.cw-provider-card.is-crosswatch,
 .cw-provider-card.is-anilist,
 .cw-provider-card.is-stremio,
 .cw-provider-card.is-nuvio {

--- a/docs/images/providers/CROSSWATCH.svg
+++ b/docs/images/providers/CROSSWATCH.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  CrossWatch primary icon
+  - Monitor + checkmark only, no wordmark text.
+  - Intended for app chrome, launcher icons, toolbars, and small-brand spots.
+  - Gradient matches the main CrossWatch branding used in the UI.
+-->
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="90" height="90" viewBox="0 0 24 24"
+     role="img" aria-label="CrossWatch icon">
+  <defs>
+    <linearGradient id="cw-g" x1="0" y1="0" x2="24" y2="24" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2de2ff"/>
+      <stop offset=".5" stop-color="#7c5cff"/>
+      <stop offset="1" stop-color="#ff7ae0"/>
+    </linearGradient>
+  </defs>
+  <g id="cw-icon">
+    <rect x="3" y="4" width="18" height="12" rx="2" ry="2"
+          fill="none" stroke="url(#cw-g)" stroke-width="1.7"/>
+    <rect x="8" y="18" width="8" height="1.6" rx=".8"
+          fill="url(#cw-g)"/>
+    <circle cx="8" cy="9" r="1" fill="url(#cw-g)"/>
+    <circle cx="12" cy="11" r="1" fill="url(#cw-g)"/>
+    <circle cx="16" cy="8" r="1" fill="url(#cw-g)"/>
+    <path d="M8 9 L12 11 L16 8"
+          fill="none" stroke="url(#cw-g)"
+          stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>


### PR DESCRIPTION
# Pull request

## Change

Updated the docs provider grid so providers are grouped by type and sorted alphabetically.

Also corrected provider labels and added CrossWatch as a local tracker.

## Why

The provider overview had a few stale labels and was missing CrossWatch from the tracker group.

## Testing

NA

## Issue

NA