### PR TITLE
Fix: Floppy icon in watcher modal

### DIFF
--- a/assets/js/modals/scrobbler-route/index.js
+++ b/assets/js/modals/scrobbler-route/index.js
@@ -173,19 +173,7 @@ function duplicateRoute(r) {
 }
 
 function logo(provider) {
-  const shared = window.CW?.ProviderMeta?.logoPath?.(provider);
-  if (shared) return shared;
-  return ({
-    plex: "/assets/img/PLEX.svg",
-    jellyfin: "/assets/img/JELLYFIN.svg",
-    emby: "/assets/img/EMBY.svg",
-    kodi: "/assets/img/KODI.png",
-    trakt: "/assets/img/TRAKT.svg",
-    simkl: "/assets/img/SIMKL.svg",
-    mdblist: "/assets/img/MDBLIST.svg",
-    crosswatch: "/assets/img/CROSSWATCH.svg",
-    floppy: "/assets/img/FLOPPY.png",
-  }[String(provider || "").toLowerCase()] || "");
+  return window.CW?.ProviderMeta?.logoPath?.(provider) || "";
 }
 
 function providerIcon(provider) {

--- a/assets/js/modals/scrobbler-route/index.js
+++ b/assets/js/modals/scrobbler-route/index.js
@@ -173,6 +173,8 @@ function duplicateRoute(r) {
 }
 
 function logo(provider) {
+  const shared = window.CW?.ProviderMeta?.logoPath?.(provider);
+  if (shared) return shared;
   return ({
     plex: "/assets/img/PLEX.svg",
     jellyfin: "/assets/img/JELLYFIN.svg",
@@ -182,6 +184,7 @@ function logo(provider) {
     simkl: "/assets/img/SIMKL.svg",
     mdblist: "/assets/img/MDBLIST.svg",
     crosswatch: "/assets/img/CROSSWATCH.svg",
+    floppy: "/assets/img/FLOPPY.png",
   }[String(provider || "").toLowerCase()] || "");
 }
 


### PR DESCRIPTION
# Pull request

## Change

- Updated the watcher route modal to use the shared provider logo helper.
- Removed the legacy fallback code.

## Why

Floppy showed as a letter instead of its provider icon in the route editor.

## Testing

NA

## Issue

NA