### PR TITLE
Add: Floppy playback progress support

### DIFF
--- a/assets/js/playback_progress.js
+++ b/assets/js/playback_progress.js
@@ -20,7 +20,7 @@
   const providerIcon = (provider) => {
     return `<img src="${esc(providerLogLogo(provider))}" alt="" onerror="this.remove()">`;
   };
-  const PLAYBACK_PROVIDER_KEYS = ["crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio"];
+  const PLAYBACK_PROVIDER_KEYS = ["crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy"];
   const DEFAULT_PROVIDER_TIMEOUT_SECONDS = 12;
   const state = {
     mounted: false,

--- a/providers/sync/_mod_FLOPPY.py
+++ b/providers/sync/_mod_FLOPPY.py
@@ -12,6 +12,7 @@ from cw_platform.provider_instances import normalize_instance_id
 from providers.auth._auth_FLOPPY import FloppyAuthError, FloppyClient
 from providers.sync._mod_common import SimpleRateLimiter, build_op_result, build_session
 from providers.sync.floppy import _history as feat_history
+from providers.sync.floppy import _progress as feat_progress
 from providers.sync.floppy import _ratings as feat_ratings
 from providers.sync.floppy import _watchlist as feat_watchlist
 from providers.sync.floppy._common import api_delete, api_get, configured_block, is_configured, media_parts_from_item_id, paged
@@ -27,8 +28,8 @@ if "ctx" not in globals():
     ctx = _NullCtx()  # type: ignore[assignment]
 
 
-_FEATURES = {"watchlist": True, "ratings": True, "history": True, "progress": False, "playlists": False}
-_FEATURE_MODULES = {"watchlist": feat_watchlist, "ratings": feat_ratings, "history": feat_history}
+_FEATURES = {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False}
+_FEATURE_MODULES = {"watchlist": feat_watchlist, "ratings": feat_ratings, "history": feat_history, "progress": feat_progress}
 
 
 def _rate_limit_settings(block: Mapping[str, Any]) -> dict[str, float]:
@@ -74,7 +75,7 @@ def get_manifest() -> Mapping[str, Any]:
             "watchlist": {"read": True, "write": True, "types": {"movies": True, "shows": True, "seasons": False, "episodes": False}, "upsert": True, "remove": True, "observed_deletes": True, "requires_ids": ["tmdb"], "custom_lists": True},
             "ratings": {"read": True, "write": True, "types": {"movies": True, "shows": True, "seasons": False, "episodes": False}, "upsert": True, "remove": True, "observed_deletes": True, "requires_ids": ["tmdb"], "scale": "0-10"},
             "history": {"read": True, "write": True, "types": {"movies": True, "shows": False, "seasons": False, "episodes": True}, "upsert": True, "remove": True, "observed_deletes": True, "requires_ids": ["tmdb"]},
-            "progress": {"read": False, "write": False},
+            "progress": {"read": True, "write": True, "types": {"movies": True, "shows": False, "seasons": False, "episodes": True}, "upsert": True, "remove": True, "observed_deletes": False, "requires_ids": ["tmdb"], "units": "seconds", "completion_policy": {"progress_write": {"mode": "none"}}},
             "playlists": {"read": False, "write": False},
         },
     }

--- a/providers/sync/floppy/_progress.py
+++ b/providers/sync/floppy/_progress.py
@@ -1,0 +1,191 @@
+# providers/sync/floppy/_progress.py
+# CrossWatch - Floppy progress sync
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from cw_platform.id_map import minimal as id_minimal
+from providers.sync._mod_common import build_op_result, unresolved_keys
+from providers.sync._progress_policy import select_progress_record
+
+from ._common import api_put, canonical_item_key, failure_reason, paged, tmdb_id_for_item, unresolved
+
+
+def _int(value: Any) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(float(str(value).strip()))
+    except Exception:
+        return None
+
+
+def _float(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(str(value).strip())
+    except Exception:
+        return None
+
+
+def _ms_from_seconds(value: Any) -> int | None:
+    number = _float(value)
+    return max(0, round(number * 1000.0)) if number is not None else None
+
+
+def _seconds_from_ms(value: Any) -> int | None:
+    number = _float(value)
+    return max(0, round(number / 1000.0)) if number is not None else None
+
+
+def _duration_ms(item: Mapping[str, Any]) -> int | None:
+    for key in ("duration_ms", "durationMs", "duration", "runtime_ms", "runtimeMs"):
+        number = _int(item.get(key))
+        if number and number > 0:
+            return number
+    for key in ("duration_seconds", "durationSeconds", "runtime_seconds", "runtimeSeconds"):
+        number = _int(item.get(key))
+        if number and number > 0:
+            return number * 1000
+    return None
+
+
+def _progress_percent(item: Mapping[str, Any]) -> float | None:
+    for key in ("progress_percent", "progressPercent", "percent", "resume_percent"):
+        number = _float(item.get(key))
+        if number is not None:
+            return max(0.0, min(100.0, number))
+    return None
+
+
+def _progress_ms(item: Mapping[str, Any], duration: int | None = None) -> int | None:
+    for key in ("progress_ms", "progressMs", "position_ms", "positionMs", "viewOffset", "position", "timeOffset"):
+        number = _int(item.get(key))
+        if number is not None:
+            return max(0, number)
+    percent = _progress_percent(item)
+    if percent is not None and duration:
+        return max(0, round((percent / 100.0) * float(duration)))
+    return None
+
+
+def _row_item(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    if row.get("completed") is True:
+        return None
+    typ = str(row.get("media_type") or "").strip().lower()
+    ids_raw = row.get("ids")
+    ids = ids_raw if isinstance(ids_raw, Mapping) else {}
+    tmdb = str(ids.get("tmdb") or (row.get("media_id") if str(row.get("source") or "").strip() == "tmdb" else "") or "").strip()
+    if not tmdb:
+        return None
+    if typ == "episode":
+        season = _int(row.get("season_number"))
+        episode = _int(row.get("episode_number"))
+        if season is None or episode is None:
+            return None
+        show_ids = {str(key): value for key, value in ids.items() if key in {"tmdb", "imdb", "tvdb"} and value}
+        show_ids["tmdb"] = tmdb
+        item: dict[str, Any] = {"type": "episode", "show_ids": show_ids, "season": season, "episode": episode}
+        if str(row.get("series_title") or "").strip():
+            item["series_title"] = str(row.get("series_title") or "").strip()
+    elif typ == "movie":
+        item = {"type": "movie", "ids": {"tmdb": tmdb}}
+    else:
+        return None
+    title = str(row.get("title") or "").strip()
+    if title:
+        item["title"] = title
+    position = _ms_from_seconds(row.get("position_seconds"))
+    duration = _ms_from_seconds(row.get("duration_seconds"))
+    if not position:
+        return None
+    item["progress_ms"] = position
+    if duration:
+        item["duration_ms"] = duration
+        item["progress_percent"] = round((position / duration) * 100.0, 3)
+    if str(row.get("updated_at") or "").strip():
+        item["progress_at"] = str(row.get("updated_at") or "").strip()
+    return item
+
+
+def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for row in paged(adapter, "playback/progress", params={"media_type": "movie,episode", "completed": "false"}):
+        item = _row_item(row)
+        if not item:
+            continue
+        key = canonical_item_key(item)
+        selected, _reason = select_progress_record(out.get(key), item)
+        out[key] = selected
+    return out
+
+
+def _payload(item: Mapping[str, Any], *, clear: bool = False) -> tuple[dict[str, Any] | None, str]:
+    typ = str(id_minimal(item).get("type") or "").strip().lower()
+    if typ == "movie":
+        tmdb = tmdb_id_for_item(item)
+        body: dict[str, Any] = {"media_type": "movie", "ids": {"tmdb": str(tmdb or "")}}
+    elif typ == "episode":
+        tmdb = tmdb_id_for_item(item, episode_show=True)
+        season = _int(item.get("season") if item.get("season") is not None else item.get("season_number"))
+        episode = _int(item.get("episode") if item.get("episode") is not None else item.get("episode_number"))
+        body = {"media_type": "episode", "ids": {"tmdb": str(tmdb or "")}, "season_number": season, "episode_number": episode}
+    else:
+        return None, "floppy_progress_type_unsupported"
+    if not str(body["ids"].get("tmdb") or "").strip():
+        return None, "floppy_tmdb_id_missing"
+    if typ == "episode" and (body.get("season_number") is None or body.get("episode_number") is None):
+        return None, "floppy_episode_id_missing"
+    if clear:
+        return body, ""
+    duration = _duration_ms(item)
+    position = _progress_ms(item, duration)
+    if position is None or position <= 0:
+        return None, "floppy_progress_missing"
+    if not duration:
+        return None, "floppy_duration_missing"
+    body["position_seconds"] = _seconds_from_ms(position)
+    body["duration_seconds"] = max(1, _seconds_from_ms(duration) or 0)
+    return body, ""
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, items, clear=False, dry_run=dry_run)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, items, clear=True, dry_run=dry_run)
+
+
+def _write(adapter: Any, items: Iterable[Mapping[str, Any]], *, clear: bool, dry_run: bool = False) -> dict[str, Any]:
+    confirmed: list[str] = []
+    unresolved_rows: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    for raw in [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]:
+        key = canonical_item_key(raw)
+        body, reason = _payload(raw, clear=clear)
+        if body is None:
+            entry = unresolved(raw, reason or "floppy_progress_unresolved")
+            unresolved_rows.append(entry)
+            results.append(entry)
+            continue
+        if dry_run:
+            confirmed.append(key)
+            results.append({"status": "dry_run", "item": id_minimal(raw), "canonical_key": key})
+            continue
+        try:
+            if clear:
+                api_put(adapter, "playback/progress", json={**body, "position_seconds": None})
+            else:
+                api_put(adapter, "playback/progress", json=body)
+        except Exception as exc:
+            entry = unresolved(raw, failure_reason(exc))
+            unresolved_rows.append(entry)
+            results.append(entry)
+            continue
+        confirmed.append(key)
+        results.append({"status": "applied", "item": id_minimal(raw), "canonical_key": key})
+    return build_op_result(ok=not unresolved_rows, count=len(confirmed), confirmed_keys=confirmed, unresolved_keys=unresolved_keys(unresolved_rows, canonical_item_key), unresolved=unresolved_rows, results=results, attempted=len(confirmed) + len(unresolved_rows))

--- a/providers/sync/plex/_progress.py
+++ b/providers/sync/plex/_progress.py
@@ -321,8 +321,6 @@ def _fetch_resume_items(
                 progress_ms = _to_int(a.get("viewOffset"))
                 if progress_ms is None or progress_ms <= 0:
                     continue
-                if (_to_int(a.get("viewCount")) or 0) > 0:
-                    continue
                 key_id = str(rk)
                 row, ids = _row_with_ids(el, library_id)
                 if key_id in items:

--- a/services/playback_progress/adapters/floppy.py
+++ b/services/playback_progress/adapters/floppy.py
@@ -1,0 +1,216 @@
+# /services/playback_progress/adapters/floppy.py
+# CrossWatch - Floppy Playback Progress Adapter
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from typing import Any, Mapping, cast
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from providers.sync._mod_FLOPPY import OPS as FLOPPY_OPS
+
+from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
+from .base import PlaybackProgressAdapter, public_failure
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _num(value: Any) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(float(str(value).strip()))
+    except Exception:
+        return None
+
+
+def _float(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(str(value).strip())
+    except Exception:
+        return None
+
+
+def _duration_seconds(item: Mapping[str, Any]) -> int | None:
+    duration = _num(item.get("duration_ms") or item.get("duration"))
+    return max(1, round(duration / 1000)) if duration and duration > 0 else None
+
+
+def _remaining_seconds(item: Mapping[str, Any]) -> int | None:
+    duration = _num(item.get("duration_ms") or item.get("duration"))
+    position = _num(item.get("progress_ms") or item.get("position_ms") or item.get("position"))
+    if duration is None or position is None or duration <= 0:
+        return None
+    return max(0, round((duration - position) / 1000))
+
+
+def _progress_percent(item: Mapping[str, Any]) -> float | None:
+    direct = _float(item.get("progress_percent") or item.get("progress"))
+    if direct is not None:
+        return round(direct, 3)
+    position = _float(item.get("progress_ms") or item.get("position_ms") or item.get("position"))
+    duration = _float(item.get("duration_ms") or item.get("duration"))
+    if position is None or duration is None or duration <= 0:
+        return None
+    return round((position / duration) * 100.0, 3)
+
+
+def _position_seconds(item: Mapping[str, Any]) -> int | None:
+    position = _num(item.get("progress_ms") or item.get("position_ms") or item.get("position"))
+    return max(0, round(position / 1000)) if position is not None else None
+
+
+def _progress_item(record: Mapping[str, Any]) -> dict[str, Any]:
+    meta = _mapping(record.get("provider_metadata"))
+    stored = meta.get("progress_item")
+    if isinstance(stored, Mapping):
+        return clean_mapping(stored)
+    media_type = str(record.get("media_type") or "").strip().lower()
+    item: dict[str, Any] = {
+        "type": "episode" if media_type in {"episode", "anime_episode"} else "movie",
+        "ids": clean_mapping(_mapping(record.get("ids"))),
+        "title": record.get("episode_title") or record.get("title") or record.get("series_title"),
+        "year": record.get("year"),
+    }
+    if item["type"] == "episode":
+        item["show_ids"] = clean_mapping(_mapping(meta.get("show_ids"))) or clean_mapping(_mapping(record.get("ids")))
+        item["series_title"] = record.get("series_title")
+        item["season"] = record.get("season")
+        item["episode"] = record.get("episode")
+    duration_seconds = _num(record.get("duration_seconds"))
+    if duration_seconds:
+        item["duration_ms"] = duration_seconds * 1000
+    return clean_mapping(item)
+
+
+def _progress_item_with_percent(record: Mapping[str, Any], progress_percent: float) -> dict[str, Any]:
+    item = _progress_item(record)
+    duration_ms = _num(item.get("duration_ms") or item.get("duration"))
+    if duration_ms is None:
+        duration_seconds = _num(record.get("duration_seconds"))
+        if duration_seconds:
+            duration_ms = duration_seconds * 1000
+    if duration_ms and duration_ms > 0:
+        item["duration_ms"] = duration_ms
+        item["progress_ms"] = max(1, min(duration_ms - 1, round((float(progress_percent) / 100.0) * float(duration_ms))))
+    else:
+        item["progress_percent"] = round(max(0.0, min(100.0, float(progress_percent))), 3)
+    item["progress_at"] = utc_now_iso()
+    return clean_mapping(item)
+
+
+class FloppyPlaybackAdapter(PlaybackProgressAdapter):
+    provider = "floppy"
+    provider_label = "Floppy"
+    ops = FLOPPY_OPS
+
+    def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
+        try:
+            configured = bool(FLOPPY_OPS.is_configured(config_view))
+        except Exception:
+            configured = False
+        caps = _mapping(FLOPPY_OPS.capabilities())
+        progress = _mapping(caps.get("progress"))
+        history = _mapping(caps.get("history"))
+        types = _mapping(progress.get("types"))
+        reason = "" if configured else "Floppy is not connected for this instance."
+        return PlaybackCapabilities(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            configured=configured,
+            read=bool(configured and progress.get("read")),
+            remove_progress=bool(configured and progress.get("remove")),
+            mark_watched=bool(configured and history.get("upsert")),
+            update_progress=bool(configured and progress.get("upsert")),
+            bulk_remove_progress=bool(configured and progress.get("remove")),
+            bulk_mark_watched=bool(configured and history.get("upsert")),
+            bulk_update_progress=bool(configured and progress.get("upsert")),
+            supports_movies=bool(configured and types.get("movies")),
+            supports_episodes=bool(configured and types.get("episodes")),
+            supports_anime=False,
+            reason=reason,
+        )
+
+    def list_progress(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str, force_refresh: bool = False) -> PlaybackListResult:
+        caps = self.capabilities(config_view, instance_id=instance_id, instance_label=instance_label)
+        if not caps.read:
+            return PlaybackListResult(False, self.provider, instance_id, error_code="unsupported" if caps.configured else "not_configured", message=caps.reason or "Floppy does not support playback listing.")
+        try:
+            index = FLOPPY_OPS.build_index(config_view, feature="progress") or {}
+        except Exception:
+            return PlaybackListResult(False, self.provider, instance_id, error_code="provider_error", message="Floppy progress request failed.", retryable=True)
+        items = [self._record(key, item, instance_id, instance_label, caps) for key, item in dict(index).items() if isinstance(item, Mapping)]
+        return PlaybackListResult(True, self.provider, instance_id, items=[item for item in items if item], refreshed_at=utc_now_iso())
+
+    def _record(self, key: Any, item: Mapping[str, Any], instance_id: str, instance_label: str, caps: PlaybackCapabilities) -> PlaybackRecord | None:
+        mini = id_minimal(item)
+        typ = str(mini.get("type") or item.get("type") or "").strip().lower()
+        media_type = "episode" if typ == "episode" else "movie"
+        ids = clean_mapping(_mapping(mini.get("ids") or item.get("ids")))
+        show_ids = clean_mapping(_mapping(mini.get("show_ids") or item.get("show_ids")))
+        title = str(mini.get("title") or item.get("title") or item.get("series_title") or "").strip()
+        series_title = str(mini.get("series_title") or item.get("series_title") or "").strip()
+        canonical = canonical_key(mini) or str(key or "")
+        progress = _progress_percent(item)
+        position = _position_seconds(item)
+        if not canonical or (progress is None and position is None):
+            return None
+        return PlaybackRecord(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            remote_id=str(key or canonical),
+            canonical_key=canonical,
+            media_type=media_type,
+            title=series_title or title,
+            episode_title=title if media_type == "episode" and title != series_title else "",
+            series_title=series_title,
+            season=_num(mini.get("season") or item.get("season")),
+            episode=_num(mini.get("episode") or item.get("episode")),
+            year=_num(mini.get("year") or item.get("year")),
+            ids=ids,
+            progress_percent=progress,
+            remaining_seconds=_remaining_seconds(item),
+            duration_seconds=_duration_seconds(item),
+            progress_at=str(item.get("progress_at") or "").strip() or None,
+            updated_at=str(item.get("progress_at") or "").strip() or None,
+            can_remove_progress=caps.remove_progress,
+            can_mark_watched=caps.mark_watched,
+            can_update_progress=bool(caps.update_progress and _duration_seconds(item)),
+            capability_messages=[] if caps.configured else [caps.reason],
+            poster_url=str(item.get("poster") or item.get("poster_url") or "").strip(),
+            backdrop_url=str(item.get("backdrop") or item.get("backdrop_url") or "").strip(),
+            provider_metadata={"progress_item": clean_mapping(item), "show_ids": show_ids, "position_seconds": position},
+        )
+
+    def remove_progress(self, config_view: Mapping[str, Any], record: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackActionResult:
+        try:
+            result = FLOPPY_OPS.remove(config_view, [_progress_item(record)], feature="progress", dry_run=False) or {}
+            ok = bool(result.get("ok"))
+            return PlaybackActionResult(ok, self.provider, instance_id, "remove_progress", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), message="Playback record removed." if ok else "Floppy remove progress failed.", error_code="" if ok else "progress_failed", decision_context=clean_mapping(result))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="Floppy remove progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+
+    def mark_watched(self, config_view: Mapping[str, Any], record: Mapping[str, Any], *, instance_id: str, instance_label: str, watched_at: str | None = None) -> PlaybackActionResult:
+        item = _progress_item(record)
+        item["watched_at"] = watched_at or utc_now_iso()
+        try:
+            result = FLOPPY_OPS.add(config_view, [item], feature="history", dry_run=False) or {}
+            ok = bool(result.get("ok"))
+            return PlaybackActionResult(ok, self.provider, instance_id, "mark_watched", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), message="Marked watched on Floppy." if ok else "Floppy mark watched failed.", error_code="" if ok else "history_failed", history_result=clean_mapping(result))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="mark_watched", message="Floppy mark watched failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+
+    def update_progress(self, config_view: Mapping[str, Any], record: Mapping[str, Any], progress_percent: float, *, instance_id: str, instance_label: str) -> PlaybackActionResult:
+        try:
+            result = FLOPPY_OPS.add(config_view, [_progress_item_with_percent(record, progress_percent)], feature="progress", dry_run=False) or {}
+            ok = bool(result.get("ok"))
+            return PlaybackActionResult(ok, self.provider, instance_id, "update_progress", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), message=f"Progress updated on Floppy to {progress_percent:g}%." if ok else "Floppy update progress failed.", error_code="" if ok else "progress_failed", decision_context=clean_mapping(result))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message="Floppy update progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))

--- a/services/playback_progress/adapters/media_servers.py
+++ b/services/playback_progress/adapters/media_servers.py
@@ -301,7 +301,7 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
         series_title = _first_str(row.get("series_title")) if media_type in {"episode", "anime_episode"} else ""
         show_ids = clean_mapping(row.get("show_ids") if isinstance(row.get("show_ids"), Mapping) else {})
         if media_type in {"episode", "anime_episode"}:
-            show_ids = _resolve_with_metadata(metadata_provider, entity="tv", title=series_title or title, year=None, ids=show_ids)
+            show_ids = _resolve_with_metadata(metadata_provider, entity="tv", title=series_title or title, year=row.get("year"), ids=show_ids)
         else:
             ids = _resolve_with_metadata(metadata_provider, entity="movie", title=title, year=row.get("year"), ids=ids)
         progress_ms = _int(row.get("progress_ms") or row.get("viewOffset") or row.get("view_offset"))

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -20,6 +20,7 @@ from cw_platform.provider_instances import build_provider_config_view, get_insta
 
 from .adapters.base import PlaybackProgressAdapter, configured_label
 from .adapters.crosswatch import CrossWatchPlaybackAdapter
+from .adapters.floppy import FloppyPlaybackAdapter
 from .adapters.media_servers import EmbyPlaybackAdapter, JellyfinPlaybackAdapter, KodiPlaybackAdapter, PlexPlaybackAdapter
 from .adapters.mdblist import MDBListPlaybackAdapter
 from .adapters.nuvio import NuvioPlaybackAdapter
@@ -35,7 +36,7 @@ CACHE_TTL_SECONDS = 60.0
 MAX_WORKERS = 6
 DEFAULT_PROVIDER_TIMEOUT_SECONDS = 12.0
 GROUP_PROGRESS_TOLERANCE = 2.0
-PHASE1_PROVIDERS = ("crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio")
+PHASE1_PROVIDERS = ("crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy")
 SORT_VALUES = {"last_updated", "progress_high", "progress_low", "remaining_time", "rating_high", "title", "provider"}
 LIVE_MEDIA_PROVIDERS = {"plex", "emby", "jellyfin", "kodi"}
 LIVE_ACTIVE_STATES = {"playing", "paused", "buffering"}
@@ -412,23 +413,44 @@ def _show_ids_for_artwork(item: Mapping[str, Any]) -> dict[str, Any]:
             if not _blank_scalar(value):
                 show_ids[target] = value
                 break
-    if _group_text(item.get("media_type") or item.get("type")) in {"episode", "anime_episode"}:
-        match = CANONICAL_TMDB_RE.match(str(item.get("canonical_key") or "").strip())
-        if match and _blank_scalar(show_ids.get("tmdb")):
-            show_ids["tmdb"] = match.group(1)
     return clean_mapping(show_ids)
+
+
+def _artwork_identity_keys(item: Mapping[str, Any]) -> list[str]:
+    media_type = _group_text(item.get("media_type") or item.get("type"))
+    keys: list[str] = []
+    ids = _as_mapping(item.get("ids"))
+    if media_type == "movie":
+        for provider in ("tmdb", "imdb", "tvdb"):
+            value = ids.get(provider)
+            if not _blank_scalar(value):
+                keys.append(f"movie:{provider}:{_group_text(value)}")
+    elif media_type in {"episode", "anime_episode"}:
+        season = _group_number(item.get("season"))
+        episode = _group_number(item.get("episode"))
+        for provider, value in _show_ids_for_artwork(item).items():
+            if provider in {"tmdb", "imdb", "tvdb"} and not _blank_scalar(value):
+                keys.append(f"episode:{provider}:{_group_text(value)}:{season}:{episode}")
+    fallback = _artwork_identity_key(item)
+    if fallback:
+        keys.append(fallback)
+    return list(dict.fromkeys(keys))
 
 
 def _share_artwork_metadata(items: list[dict[str, Any]]) -> None:
     grouped: dict[str, list[dict[str, Any]]] = {}
     for item in items:
-        key = _artwork_identity_key(item)
-        if key:
+        for key in _artwork_identity_keys(item):
             grouped.setdefault(key, []).append(item)
 
+    seen_groups: set[tuple[int, ...]] = set()
     for records in grouped.values():
         if len(records) < 2:
             continue
+        group_key = tuple(sorted(id(record) for record in records))
+        if group_key in seen_groups:
+            continue
+        seen_groups.add(group_key)
         shared_show_ids: dict[str, Any] = {}
         poster = ""
         backdrop = ""
@@ -676,6 +698,7 @@ def _instance_label(cfg: Mapping[str, Any], provider: str, instance_id: str) -> 
         "nuvio": "Nuvio",
         "kodi": "Kodi",
         "stremio": "Stremio",
+        "floppy": "Floppy",
         "crosswatch": "CrossWatch",
     }.get(provider, provider)
     if label.lower() == "default":
@@ -734,6 +757,7 @@ def _profile_has_explicit_identity(cfg: Mapping[str, Any], provider: str, instan
         "nuvio": ("access_token", "refresh_token", "profile_id"),
         "kodi": ("server", "server_url", "connection_verified", "username"),
         "stremio": ("auth_key", "authKey"),
+        "floppy": ("server_url", "api_token"),
     }.get(str(provider or "").strip().lower(), ())
     return any(str(_path_value(raw, path) or "").strip() for path in identity_paths)
 
@@ -804,6 +828,7 @@ class PlaybackProgressService:
             "nuvio": NuvioPlaybackAdapter(),
             "kodi": KodiPlaybackAdapter(),
             "stremio": StremioPlaybackAdapter(),
+            "floppy": FloppyPlaybackAdapter(),
             "crosswatch": CrossWatchPlaybackAdapter(),
         }
         self._cache: dict[tuple[str, str, str], dict[str, Any]] = {}

--- a/tests/test_floppy_sync.py
+++ b/tests/test_floppy_sync.py
@@ -66,10 +66,11 @@ def test_floppy_capabilities_expose_only_requested_features() -> None:
     features = OPS.features()
     caps = OPS.capabilities()
 
-    assert features == {"watchlist": True, "ratings": True, "history": True, "progress": False, "playlists": False}
+    assert features == {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False}
     assert caps["watchlist"]["custom_lists"] is True
     assert caps["ratings"]["scale"] == "0-10"
-    assert caps["progress"]["read"] is False
+    assert caps["progress"]["read"] is True
+    assert caps["progress"]["write"] is True
 
 
 def test_floppy_module_uses_shared_rate_limiter() -> None:
@@ -243,6 +244,74 @@ def test_floppy_ratings_zero_is_not_written_as_rating() -> None:
     assert res["count"] == 0
     assert res["skipped"] == 1
     assert adapter.client.session.calls == []
+
+
+def test_floppy_progress_reads_movies_and_episodes() -> None:
+    from providers.sync.floppy import _progress
+
+    adapter = AdapterStub(
+        {
+            ("GET", "playback/progress"): {
+                "results": [
+                    {"media_type": "movie", "source": "tmdb", "media_id": "11", "position_seconds": 120, "duration_seconds": 600, "updated_at": "2026-08-01T12:00:00Z"},
+                    {"media_type": "episode", "ids": {"tmdb": "22"}, "season_number": 1, "episode_number": 2, "position_seconds": 300, "duration_seconds": 3000},
+                ],
+                "count": 2,
+            }
+        }
+    )
+
+    out = _progress.build_index(adapter)
+
+    assert out["tmdb:11"]["progress_ms"] == 120000
+    assert out["tmdb:11"]["progress_percent"] == 20.0
+    assert out["tmdb:22#s01e02"]["duration_ms"] == 3000000
+
+
+def test_floppy_progress_reads_position_without_duration() -> None:
+    from providers.sync.floppy import _progress
+
+    adapter = AdapterStub(
+        {
+            ("GET", "playback/progress"): {
+                "results": [
+                    {"media_type": "episode", "ids": {"tmdb": "1407"}, "season_number": 5, "episode_number": 6, "position_seconds": 1886, "duration_seconds": None, "completed": True},
+                    {"media_type": "episode", "ids": {"tmdb": "223300"}, "season_number": 1, "episode_number": 3, "position_seconds": 749, "duration_seconds": None, "completed": False},
+                    {"media_type": "episode", "ids": {"tmdb": "87917"}, "season_number": 4, "episode_number": 1, "position_seconds": 1456, "duration_seconds": 3000, "completed": False},
+                ],
+                "count": 3,
+            }
+        }
+    )
+
+    out = _progress.build_index(adapter)
+
+    assert "tmdb:1407#s05e06" not in out
+    assert out["tmdb:223300#s01e03"]["progress_ms"] == 749000
+    assert "duration_ms" not in out["tmdb:223300#s01e03"]
+    assert "progress_percent" not in out["tmdb:223300#s01e03"]
+    assert out["tmdb:87917#s04e01"]["progress_percent"] == 48.533
+    assert adapter.client.session.calls[0]["params"]["completed"] == "false"
+
+
+def test_floppy_progress_write_and_clear_use_playback_progress_api() -> None:
+    from providers.sync.floppy import _progress
+
+    adapter = AdapterStub(
+        {
+            ("PUT", "playback/progress"): ResponseStub(204, {}),
+        }
+    )
+    item = {"type": "episode", "show_ids": {"tmdb": "22"}, "season": 1, "episode": 2, "progress_ms": 300000, "duration_ms": 3000000}
+
+    add = _progress.add(adapter, [item])
+    remove = _progress.remove(adapter, [item])
+
+    assert add["count"] == 1
+    assert remove["count"] == 1
+    assert adapter.client.session.calls[0]["json"] == {"media_type": "episode", "ids": {"tmdb": "22"}, "season_number": 1, "episode_number": 2, "position_seconds": 300, "duration_seconds": 3000}
+    assert adapter.client.session.calls[1]["method"] == "PUT"
+    assert adapter.client.session.calls[1]["json"] == {"media_type": "episode", "ids": {"tmdb": "22"}, "season_number": 1, "episode_number": 2, "position_seconds": None}
 
 
 def test_floppy_history_reads_movies_and_episodes() -> None:

--- a/tests/test_percent_progress_sync.py
+++ b/tests/test_percent_progress_sync.py
@@ -116,6 +116,50 @@ def test_crosswatch_progress_accepts_percent_only_items(tmp_path: Path, monkeypa
     assert index["tmdb:69478#s06e02"]["progress_percent"] == 21.0
 
 
+def test_plex_progress_keeps_resume_item_with_view_count(monkeypatch) -> None:
+    from providers.sync.plex import _progress
+
+    class Element:
+        def __init__(self, attrib: dict[str, Any], children: list[Any] | None = None) -> None:
+            self.attrib = attrib
+            self._children = children or []
+
+        def __iter__(self):
+            return iter(self._children)
+
+        def findall(self, _path: str):
+            return []
+
+    class Server:
+        def query(self, path: str, params: dict[str, Any] | None = None):
+            if path == "/library/sections":
+                return Element({}, [Element({"key": "3", "type": "show"})])
+            return Element(
+                {"totalSize": "1"},
+                [
+                    Element(
+                        {
+                            "ratingKey": "25517",
+                            "type": "episode",
+                            "title": "Pilot",
+                            "grandparentTitle": "Shelter",
+                            "year": "2023",
+                            "parentIndex": "1",
+                            "index": "1",
+                            "viewOffset": "1159000",
+                            "viewCount": "1",
+                            "duration": "3403296",
+                        }
+                    )
+                ],
+            )
+
+    rows = _progress._fetch_resume_items(Server(), page_size=150, allowed_library_ids={"3"})
+
+    assert "25517" in rows
+    assert rows["25517"][0]["viewOffset"] == "1159000"
+
+
 class _ProgressStateStore:
     def load_state(self) -> dict[str, Any]:
         return {}

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -16,6 +16,7 @@ from services.playback_progress.service import (
 from services.playback_progress.models import PlaybackCapabilities
 from services.playback_progress.adapters.base import PlaybackProgressAdapter
 import services.playback_progress.service as playback_service
+import services.playback_progress.adapters.floppy as floppy_playback_adapter
 import services.playback_progress.adapters.nuvio as nuvio_playback_adapter
 import services.playback_progress.adapters.stremio as stremio_playback_adapter
 from services.playback_progress.adapters.crosswatch import CrossWatchPlaybackAdapter
@@ -72,7 +73,7 @@ def test_playback_bulk_footer_uses_wide_management_layout():
 def test_playback_progress_frontend_includes_kodi_provider_key():
     js = (ROOT / "assets" / "js" / "playback_progress.js").read_text(encoding="utf-8")
 
-    assert 'const PLAYBACK_PROVIDER_KEYS = ["crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio"];' in js
+    assert 'const PLAYBACK_PROVIDER_KEYS = ["crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy"];' in js
 
 
 class _PolicyOps:
@@ -220,6 +221,45 @@ def test_same_episode_profiles_share_only_artwork_metadata():
     assert profile["ids"]["tmdb_show"] == "69478"
     assert profile["poster_url"] == donor["poster_url"]
     assert profile["backdrop_url"] == donor["backdrop_url"]
+
+
+def test_media_server_episode_metadata_resolution_passes_show_year():
+    from services.playback_progress.adapters.media_servers import PlexPlaybackAdapter
+
+    class FakeMetadata:
+        def __init__(self):
+            self.calls = []
+
+        def fetch(self, *, entity, ids, locale=None, need=None):
+            self.calls.append({"entity": entity, "ids": dict(ids)})
+            return {"ids": {"tmdb": "210787", "tvdb": "421123"}}
+
+    adapter = PlexPlaybackAdapter()
+    metadata = FakeMetadata()
+    caps = PlaybackCapabilities("plex", "Plex", "P01", "P01", True, True, True, True, True, True, True, True, True, True, False)
+    record = adapter._normalize(
+        "plex:25515#s01e02",
+        {
+            "type": "episode",
+            "title": "Pak me als je kan",
+            "series_title": "Shelter",
+            "year": 2023,
+            "season": 1,
+            "episode": 2,
+            "ids": {"tmdb": "4524138"},
+            "show_ids": {"plex": "25515"},
+            "progress_ms": 1119000,
+            "duration_ms": 2675904,
+        },
+        metadata,
+        "P01",
+        "Plex P01",
+        caps,
+    )
+
+    assert metadata.calls[0] == {"entity": "tv", "ids": {"plex": "25515", "title": "Shelter", "year": "2023"}}
+    assert record is not None
+    assert record.provider_metadata["show_ids"]["tmdb"] == "210787"
 
 
 def test_unscoped_live_stream_only_updates_default_profile():
@@ -925,6 +965,105 @@ def test_stremio_playback_progress_update_allows_percent_only(monkeypatch):
     assert stremio_ops.added[0][0] == "progress"
     assert stremio_ops.added[0][1][0]["progress_percent"] == 10.63
     assert "progress_ms" not in stremio_ops.added[0][1][0]
+
+
+class _FakeFloppyOps:
+    def __init__(self):
+        self.removed = []
+        self.added = []
+
+    def capabilities(self):
+        return {
+            "progress": {"read": True, "upsert": True, "remove": True, "types": {"movies": True, "episodes": True}},
+            "history": {"upsert": True},
+        }
+
+    def is_configured(self, cfg):
+        return bool(cfg.get("floppy", {}).get("server_url") and cfg.get("floppy", {}).get("api_token"))
+
+    def build_index(self, cfg, *, feature):
+        assert feature == "progress"
+        return {
+            "tmdb:22#s01e02": {
+                "type": "episode",
+                "show_ids": {"tmdb": "22"},
+                "series_title": "Show",
+                "title": "Episode",
+                "season": 1,
+                "episode": 2,
+                "progress_ms": 120000,
+                "duration_ms": 600000,
+                "progress_at": "2026-08-01T12:00:00Z",
+            }
+        }
+
+    def remove(self, cfg, items, *, feature, dry_run=False):
+        self.removed.extend(items)
+        return {"ok": True, "count": len(items), "feature": feature}
+
+    def add(self, cfg, items, *, feature, dry_run=False):
+        self.added.append((feature, list(items)))
+        return {"ok": True, "count": len(items), "feature": feature}
+
+
+def test_playback_progress_uses_floppy_adapter(monkeypatch):
+    floppy_ops = _FakeFloppyOps()
+    cfg = {"floppy": {"server_url": "http://floppy.local", "api_token": "secret"}}
+
+    monkeypatch.setattr(floppy_playback_adapter, "FLOPPY_OPS", floppy_ops)
+    monkeypatch.setattr(playback_service, "load_config", lambda: cfg)
+
+    service = PlaybackProgressService()
+    providers = service.provider_instances(cfg)
+    result = service.items(provider="floppy", force_refresh=True)
+    record = result["items"][0]
+
+    assert {"provider": "floppy", "instance_id": "default", "instance_label": "Floppy Default"} in providers
+    assert result["errors"] == []
+    assert record["provider"] == "floppy"
+    assert record["progress_percent"] == 20.0
+
+    service.remove({"provider": "floppy", "instance_id": "default", "record": record})
+    service.mark_watched({"provider": "floppy", "instance_id": "default", "record": record})
+    service.update_progress({"provider": "floppy", "instance_id": "default", "record": record, "progress_percent": 25})
+
+    assert floppy_ops.removed[0]["show_ids"] == {"tmdb": "22"}
+    assert floppy_ops.added[0][0] == "history"
+    assert floppy_ops.added[1][0] == "progress"
+    assert floppy_ops.added[1][1][0]["progress_ms"] == 150000
+
+
+def test_playback_progress_lists_floppy_position_without_duration(monkeypatch):
+    class PositionOnlyFloppyOps(_FakeFloppyOps):
+        def build_index(self, cfg, *, feature):
+            assert feature == "progress"
+            return {
+                "tmdb:223300#s01e03": {
+                    "type": "episode",
+                    "show_ids": {"tmdb": "223300"},
+                    "series_title": "The Abandons",
+                    "title": "Triage",
+                    "season": 1,
+                    "episode": 3,
+                    "progress_ms": 749000,
+                    "progress_at": "2026-08-01T18:48:14Z",
+                }
+            }
+
+    cfg = {"floppy": {"server_url": "http://floppy.local", "api_token": "secret"}}
+
+    monkeypatch.setattr(floppy_playback_adapter, "FLOPPY_OPS", PositionOnlyFloppyOps())
+    monkeypatch.setattr(playback_service, "load_config", lambda: cfg)
+
+    result = PlaybackProgressService().items(provider="floppy", force_refresh=True)
+    record = result["items"][0]
+
+    assert result["errors"] == []
+    assert record["provider"] == "floppy"
+    assert record["title"] == "The Abandons"
+    assert record["progress_percent"] is None
+    assert record["duration_seconds"] is None
+    assert record["can_update_progress"] is False
 
 
 def test_nuvio_playback_progress_enriches_episode_metadata_from_tvdb_id(monkeypatch):


### PR DESCRIPTION
# Pull request

## Change

Added Floppy playback progress support and wired it into the Playback Progress Manager.

## Why

Floppy now has a playback progress API, so CW can read/write/clear resume positions.

## Testing

- test_floppy_sync.py
- test_percent_progress_sync.py
- test_playback_progress.py

## Issue

Relates to #594