### PR TITLE
Change: send exact watcher playback positions

### DIFF
--- a/providers/scrobble/crosswatch/sink.py
+++ b/providers/scrobble/crosswatch/sink.py
@@ -182,7 +182,8 @@ def _tmdb_enrich(cfg: Mapping[str, Any], *, media_type: str, ids: Mapping[str, A
 def _item_from_event(ev: ScrobbleEvent, cfg: Mapping[str, Any], progress: float) -> dict[str, Any] | None:
     now = utc_now_iso()
     media_type = "episode" if ev.media_type == "episode" else "movie"
-    duration_ms = _best_duration_ms(ev.raw)
+    duration_ms = _int(getattr(ev, "duration_ms", None)) or _best_duration_ms(ev.raw)
+    position_ms = _int(getattr(ev, "position_ms", None))
 
     if media_type == "movie":
         ids = _ids_for_movie(ev)
@@ -223,7 +224,7 @@ def _item_from_event(ev: ScrobbleEvent, cfg: Mapping[str, Any], progress: float)
 
     if duration_ms and duration_ms > 0:
         item["duration_ms"] = duration_ms
-        item["progress_ms"] = max(0, min(duration_ms, round((progress / 100.0) * float(duration_ms))))
+        item["progress_ms"] = max(0, min(duration_ms, position_ms if position_ms is not None else round((progress / 100.0) * float(duration_ms))))
     return {k: v for k, v in item.items() if v not in (None, "", {}, [])}
 
 

--- a/providers/scrobble/emby/watch.py
+++ b/providers/scrobble/emby/watch.py
@@ -806,6 +806,8 @@ class EmbyWatchService:
         year = item.get("ProductionYear")
         season = item.get("ParentIndexNumber") if mtype == "episode" else None
         number = item.get("IndexNumber") if mtype == "episode" else None
+        duration_ms = _ticks_to_ms(item.get("RunTimeTicks"))
+        position_ms = _ticks_to_ms(_ps.get("PositionTicks") if isinstance(_ps, dict) else None)
 
         mt: MediaType = "episode" if mtype == "episode" else "movie"
         act = "start" if action == "playing" else "pause" if action == "paused" else "stop"
@@ -823,6 +825,8 @@ class EmbyWatchService:
             server_uuid=self._server_id,
             session_key=str(sess.get("Id") or ""),
             raw=sess,
+            position_ms=position_ms,
+            duration_ms=duration_ms,
         )
 
     def _current_sessions(self, cfg: dict[str, Any]) -> list[dict[str, Any]] | None:
@@ -1186,6 +1190,9 @@ class EmbyWatchService:
                 mt: MediaType = "episode" if mt_raw == "episode" else "movie"
 
                 ids_stop = _normalize_ids(dict(meta.get("ids") or {}))
+                best_offset = self._best_offset.get(sid)
+                position_ms = int(best_offset[0]) if best_offset and best_offset[0] is not None else None
+                duration_ms = int(best_offset[1]) if best_offset and best_offset[1] is not None and best_offset[1] > 0 else None
 
                 ev = ScrobbleEvent(
                     action="stop",
@@ -1200,6 +1207,8 @@ class EmbyWatchService:
                     server_uuid=self._server_id,
                     session_key=sid,
                     raw=fake,
+                    position_ms=position_ms,
+                    duration_ms=duration_ms,
                 )
                 last_em = self._last_emit.get(sid)
                 if not (last_em and last_em[0] == "stop"):

--- a/providers/scrobble/floppy/sink.py
+++ b/providers/scrobble/floppy/sink.py
@@ -53,17 +53,6 @@ def _clamp(value: Any) -> float:
     return max(0.0, min(100.0, raw))
 
 
-def _watched_at(cfg: Mapping[str, Any]) -> float:
-    try:
-        sc = cfg.get("scrobble") if isinstance(cfg, Mapping) else {}
-        value = ((sc or {}).get("floppy") or {}).get("watched_at")
-        if value is None:
-            value = ((sc or {}).get("trakt") or {}).get("watched_at", 90.0)
-        return max(0.0, min(100.0, float(value)))
-    except Exception:
-        return 90.0
-
-
 def _route_source(cfg: Mapping[str, Any]) -> tuple[str, str]:
     watch = ((cfg.get("scrobble") or {}).get("watch") or {}) if isinstance(cfg, Mapping) else {}
     source = str(watch.get("route_provider") or "watcher").strip().lower() or "watcher"
@@ -71,27 +60,27 @@ def _route_source(cfg: Mapping[str, Any]) -> tuple[str, str]:
     return source, source_instance
 
 
-def _find_int(raw: Any, keys: set[str]) -> int | None:
+def _find_int(raw: Any, keys: set[str], *, positive: bool = False) -> int | None:
     if isinstance(raw, Mapping):
         for key, value in raw.items():
             if str(key or "").strip().lower() in keys:
                 found = _int(value)
-                if found is not None and found >= 0:
+                if found is not None and found >= (1 if positive else 0):
                     return found
         for value in raw.values():
-            found = _find_int(value, keys)
+            found = _find_int(value, keys, positive=positive)
             if found is not None:
                 return found
     if isinstance(raw, list):
         for value in raw:
-            found = _find_int(value, keys)
+            found = _find_int(value, keys, positive=positive)
             if found is not None:
                 return found
     return None
 
 
 def _duration_ms(raw: Any) -> int | None:
-    value = _find_int(raw, {"duration", "duration_ms", "durationms", "runtime_ms", "totaltime"})
+    value = _find_int(raw, {"duration", "duration_ms", "durationms", "runtime_ms", "totaltime"}, positive=True)
     if value is None or value <= 0:
         return None
     return value * 1000 if value < 10_000 else value
@@ -106,6 +95,16 @@ def _position_ms(raw: Any, progress: float, duration_ms: int | None) -> int | No
     if duration_ms and duration_ms > 10_000 and 0 < value < 10_000:
         value *= 1000
     return max(0, min(value, duration_ms)) if duration_ms else max(0, value)
+
+
+def _completed(position_ms: int | None, duration_ms: int | None, progress: float) -> bool | None:
+    if position_ms is None:
+        return None
+    if duration_ms and duration_ms > 0:
+        position = max(0, round(position_ms / 1000.0))
+        duration = max(1, round(duration_ms / 1000.0))
+        return position >= max(0, duration - 30)
+    return progress >= 95.0
 
 
 def _ids(ev: ScrobbleEvent) -> dict[str, str]:
@@ -124,7 +123,7 @@ def _ids(ev: ScrobbleEvent) -> dict[str, str]:
     return out
 
 
-def _payload(ev: ScrobbleEvent, cfg: Mapping[str, Any]) -> dict[str, Any] | None:
+def _payload(ev: ScrobbleEvent) -> dict[str, Any] | None:
     progress = _clamp(ev.progress)
     ids = _ids(ev)
     if not ids:
@@ -143,14 +142,18 @@ def _payload(ev: ScrobbleEvent, cfg: Mapping[str, Any]) -> dict[str, Any] | None
         body["series_title"] = ev.title
         body["season_number"] = season
         body["episode_number"] = episode
-    duration = _duration_ms(ev.raw)
-    position = _position_ms(ev.raw, progress, duration)
+    duration = _int(getattr(ev, "duration_ms", None)) or _duration_ms(ev.raw)
+    position = _int(getattr(ev, "position_ms", None))
+    if position is None:
+        position = _position_ms(ev.raw, progress, duration)
     if duration:
         body["duration_seconds"] = max(1, round(duration / 1000.0))
     if position is not None:
         body["position_seconds"] = max(0, round(position / 1000.0))
     if body["action"] == "stop":
-        body["completed"] = progress >= _watched_at(cfg)
+        complete = _completed(position, duration, progress)
+        if complete is not None:
+            body["completed"] = complete
         body["played_at"] = utc_now_iso()
     return {k: v for k, v in body.items() if v not in (None, "", {}, [])}
 
@@ -199,7 +202,7 @@ class FloppySink(ScrobbleSink):
         if not is_configured(view):
             _log(f"Floppy disabled for sink profile {self._instance_id}; skipping", "WARNING")
             return
-        body = _payload(ev, cfgd)
+        body = _payload(ev)
         if not body:
             _log("Floppy sink skipped event without enough identity", "DEBUG")
             return

--- a/providers/scrobble/jellyfin/watch.py
+++ b/providers/scrobble/jellyfin/watch.py
@@ -804,6 +804,8 @@ class JellyfinWatchService:
         year = item.get("ProductionYear")
         season = item.get("ParentIndexNumber") if mtype == "episode" else None
         number = item.get("IndexNumber") if mtype == "episode" else None
+        duration_ms = _ticks_to_ms(item.get("RunTimeTicks"))
+        position_ms = _ticks_to_ms(_ps.get("PositionTicks") if isinstance(_ps, dict) else None)
 
         mt: MediaType = "episode" if mtype == "episode" else "movie"
         act = "start" if action == "playing" else "pause" if action == "paused" else "stop"
@@ -821,6 +823,8 @@ class JellyfinWatchService:
             server_uuid=self._server_id,
             session_key=str(sess.get("Id") or ""),
             raw=sess,
+            position_ms=position_ms,
+            duration_ms=duration_ms,
         )
 
     def _current_sessions(self, cfg: dict[str, Any]) -> list[dict[str, Any]] | None:
@@ -1185,6 +1189,9 @@ class JellyfinWatchService:
                 mt: MediaType = "episode" if mt_raw == "episode" else "movie"
 
                 ids_stop = _normalize_ids(dict(meta.get("ids") or {}))
+                best_offset = self._best_offset.get(sid)
+                position_ms = int(best_offset[0]) if best_offset and best_offset[0] is not None else None
+                duration_ms = int(best_offset[1]) if best_offset and best_offset[1] is not None and best_offset[1] > 0 else None
 
                 ev = ScrobbleEvent(
                     action="stop",
@@ -1199,6 +1206,8 @@ class JellyfinWatchService:
                     server_uuid=self._server_id,
                     session_key=sid,
                     raw=fake,
+                    position_ms=position_ms,
+                    duration_ms=duration_ms,
                 )
                 last_em = self._last_emit.get(sid)
                 if not (last_em and last_em[0] == "stop"):

--- a/providers/scrobble/kodi/watch.py
+++ b/providers/scrobble/kodi/watch.py
@@ -312,6 +312,11 @@ class KodiWatchService:
 
     def _event(self, session: Mapping[str, Any], action: str, progress: float, props: Mapping[str, Any]) -> ScrobbleEvent:
         meta = _dict(session.get("meta"))
+        duration_ms = _to_int(session.get("duration_ms"))
+        position_seconds = _time_parts_to_seconds(_dict(props).get("time"))
+        position_ms = int(position_seconds * 1000) if position_seconds is not None else None
+        if position_ms is None and duration_ms and duration_ms > 0:
+            position_ms = round((float(progress or 0.0) / 100.0) * float(duration_ms))
         raw = {
             "provider": "kodi",
             "provider_instance": self._instance_id,
@@ -336,6 +341,8 @@ class KodiWatchService:
             server_uuid=session.get("server_uuid"),
             session_key=str(session.get("session_key") or ""),
             raw=raw,
+            position_ms=position_ms,
+            duration_ms=duration_ms if duration_ms and duration_ms > 0 else None,
         )
 
     def _tvshow_details(self, tvshow_id: int) -> dict[str, Any] | None:

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -1178,6 +1178,8 @@ class WatchService:
                     self._update_best_offset(sk, int(o), int(d))
                 if pct != ev.progress:
                     ev = ScrobbleEvent(**{**ev.__dict__, "progress": pct})
+            if o is not None or d is not None:
+                ev = ScrobbleEvent(**{**ev.__dict__, "position_ms": int(o) if o is not None else None, "duration_ms": int(d) if d is not None and d > 0 else None})
 
             if sk and sk not in self._first_seen:
                 self._first_seen[sk] = time.time()

--- a/providers/scrobble/scrobble.py
+++ b/providers/scrobble/scrobble.py
@@ -184,6 +184,8 @@ class ScrobbleEvent:
     server_uuid: str | None
     session_key: str | None
     raw: dict[str, Any]
+    position_ms: int | None = None
+    duration_ms: int | None = None
 
 
 class ScrobbleSink(Protocol):

--- a/tests/test_floppy_watcher_sink.py
+++ b/tests/test_floppy_watcher_sink.py
@@ -124,7 +124,7 @@ def test_floppy_sink_sends_completed_episode_stop(monkeypatch: Any) -> None:
     monkeypatch.setattr(floppy_sink, "record_scrobble_event", lambda *args, **kwargs: activities.append(kwargs))
     monkeypatch.setattr(floppy_sink, "utc_now_iso", lambda: "2026-08-01T12:00:00Z")
 
-    FloppySink(cfg_provider=_cfg).send(_episode())
+    FloppySink(cfg_provider=_cfg).send(_episode(progress=99.5))
 
     body = calls[0]["body"]
     assert body["action"] == "stop"
@@ -133,11 +133,73 @@ def test_floppy_sink_sends_completed_episode_stop(monkeypatch: Any) -> None:
     assert body["series_title"] == "Love & Death"
     assert body["season_number"] == 1
     assert body["episode_number"] == 7
-    assert body["position_seconds"] == 2760
+    assert body["position_seconds"] == 2985
     assert body["duration_seconds"] == 3000
     assert body["completed"] is True
     assert body["played_at"] == "2026-08-01T12:00:00Z"
     assert activities[0]["target"] == "floppy"
+
+
+def test_floppy_sink_sends_completed_false_for_resume_stop(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(floppy_sink, "api_post", lambda _adapter, path, **kwargs: calls.append({"path": path, "body": kwargs.get("json")}) or {"detail": "ok"})
+    monkeypatch.setattr(floppy_sink, "record_watch", lambda *args, **kwargs: None)
+    monkeypatch.setattr(floppy_sink, "utc_now_iso", lambda: "2026-08-01T12:00:00Z")
+
+    FloppySink(cfg_provider=_cfg).send(_episode(progress=68.0))
+
+    body = calls[0]["body"]
+    assert body["action"] == "stop"
+    assert body["position_seconds"] == 2040
+    assert body["completed"] is False
+
+
+def test_floppy_sink_does_not_let_floppy_fallback_complete_resume_without_duration(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(floppy_sink, "api_post", lambda _adapter, path, **kwargs: calls.append({"path": path, "body": kwargs.get("json")}) or {"detail": "ok"})
+    monkeypatch.setattr(floppy_sink, "record_watch", lambda *args, **kwargs: None)
+    monkeypatch.setattr(floppy_sink, "utc_now_iso", lambda: "2026-08-01T12:00:00Z")
+
+    ev = ScrobbleEvent(**{**_episode(progress=53.0).__dict__, "raw": {"viewOffset": 1886000}})
+
+    FloppySink(cfg_provider=_cfg).send(ev)
+
+    body = calls[0]["body"]
+    assert body["position_seconds"] == 1886
+    assert body["completed"] is False
+    assert "duration_seconds" not in body
+
+
+def test_floppy_sink_prefers_normalized_event_timing(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(floppy_sink, "api_post", lambda _adapter, path, **kwargs: calls.append({"path": path, "body": kwargs.get("json")}) or {"detail": "ok"})
+    monkeypatch.setattr(floppy_sink, "record_watch", lambda *args, **kwargs: None)
+    monkeypatch.setattr(floppy_sink, "utc_now_iso", lambda: "2026-08-01T12:00:00Z")
+
+    ev = ScrobbleEvent(**{**_episode(progress=31.0).__dict__, "raw": {"viewOffset": 749000}, "position_ms": 749000, "duration_ms": 2416000})
+
+    FloppySink(cfg_provider=_cfg).send(ev)
+
+    body = calls[0]["body"]
+    assert body["position_seconds"] == 749
+    assert body["duration_seconds"] == 2416
+    assert body["completed"] is False
+
+
+def test_floppy_sink_uses_nested_duration_when_raw_has_zero_first(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(floppy_sink, "api_post", lambda _adapter, path, **kwargs: calls.append({"path": path, "body": kwargs.get("json")}) or {"detail": "ok"})
+    monkeypatch.setattr(floppy_sink, "record_watch", lambda *args, **kwargs: None)
+    monkeypatch.setattr(floppy_sink, "utc_now_iso", lambda: "2026-08-01T12:00:00Z")
+
+    ev = ScrobbleEvent(**{**_episode(progress=68.0).__dict__, "raw": {"duration": 0, "MediaContainer": {"Metadata": [{"duration": 3000000, "viewOffset": 2040000}]}}})
+
+    FloppySink(cfg_provider=_cfg).send(ev)
+
+    body = calls[0]["body"]
+    assert body["duration_seconds"] == 3000
+    assert body["position_seconds"] == 2040
+    assert body["completed"] is False
 
 
 def test_scrobbler_route_modal_lists_floppy_sink() -> None:


### PR DESCRIPTION
# Pull request

## Change

Watcher events now carry normalized `position_ms` and `duration_ms`.

## Why

It needs the real position and duration when the media server provides them.

## Testing

- test_floppy_watcher_sink.py

## Issue

NA