### PR TITLE
Change: improved Jellyfin sync

### DIFF
--- a/providers/sync/_mod_JELLYFIN.py
+++ b/providers/sync/_mod_JELLYFIN.py
@@ -107,7 +107,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "2.1"
+__VERSION__ = "2.2"
 _MIN_PROGRESS_WRITE_VERSION = (10, 9)
 _JF_VERSION_CACHE: dict[str, tuple[float, str | None]] = {}
 

--- a/providers/sync/jellyfin/_common.py
+++ b/providers/sync/jellyfin/_common.py
@@ -1047,13 +1047,23 @@ def _pick_from_candidates(
 
 
 def _direct_query_by_pairs(
+    adapter: Any,
     http: Any,
     uid: str,
     pairs: list[str],
     include_types: str,
     scope: Mapping[str, Any],
 ) -> list[Mapping[str, Any]]:
-    if not pairs:
+    if not pairs or getattr(adapter, "_jellyfin_provider_filter_ignored", False):
+        return []
+    wanted: set[tuple[str, str]] = set()
+    for pair in pairs:
+        namespace, _, value = str(pair or "").partition(".")
+        namespace = namespace.strip().lower()
+        value = value.strip().lower()
+        if namespace and value:
+            wanted.add((namespace, value))
+    if not wanted:
         return []
     q: dict[str, Any] = {
         "AnyProviderIdEquals": ",".join(pairs),
@@ -1072,9 +1082,33 @@ def _direct_query_by_pairs(
             r = http.get("/Items", params={**query, "userId": uid})
             if getattr(r, "status_code", 0) == 200:
                 rows.extend((r.json() or {}).get("Items") or [])
-        return rows
     except Exception:
         return []
+
+    matched: list[Mapping[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        row_ids = _ids_from_provider_ids(row.get("ProviderIds"))
+        for namespace, value in wanted:
+            have = str(row_ids.get(namespace) or "").strip().lower()
+            if not have:
+                continue
+            if have == value or (have.isdigit() and value.isdigit() and int(have) == int(value)):
+                matched.append(row)
+                break
+    if rows and not matched:
+        disabled = len(rows) >= 10
+        if disabled:
+            setattr(adapter, "_jellyfin_provider_filter_ignored", True)
+        _dbg(
+            'provider_id_filter_ignored',
+            requested=sorted(f"{ns}.{val}" for ns, val in wanted),
+            include_types=include_types,
+            returned=len(rows),
+            disabled_for_run=disabled,
+        )
+    return matched
 
 
 def _episode_number_matches(row: Mapping[str, Any], season: Any, episode: Any) -> bool:
@@ -1193,8 +1227,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
             except Exception:
                 pass
         _dbg('resolve_miss', kind='movie', title=title, year=year)
-        if outside_scope_seen:
-            setattr(adapter, "_jellyfin_last_resolve_hint", "outside_library_scope")
+        setattr(adapter, "_jellyfin_last_resolve_hint", "outside_library_scope" if outside_scope_seen else "unmatched_in_jellyfin")
         return None
 
     # Shows
@@ -1231,7 +1264,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
                         continue
                     nm = (row.get("Name") or "").strip().lower()
                     yr = row.get("ProductionYear")
-                    if (nm == title_lc or nm.startswith(title_lc)) and (
+                    if nm == title_lc and (
                         (year is None) or (isinstance(yr, int) and abs(yr - year) <= 1)
                     ):
                         cand.append(row)
@@ -1244,14 +1277,13 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
             except Exception:
                 pass
         _dbg('resolve_miss', kind='series', title=title, year=year)
-        if outside_scope_seen:
-            setattr(adapter, "_jellyfin_last_resolve_hint", "outside_library_scope")
+        setattr(adapter, "_jellyfin_last_resolve_hint", "outside_library_scope" if outside_scope_seen else "unmatched_in_jellyfin")
         return None
 
     # Episodes
     scope = jf_library_scope(adapter.cfg, feature)
     for pref in episode_pairs:
-        rows = _direct_query_by_pairs(http, uid, [pref], "Episode,Series", scope)
+        rows = _direct_query_by_pairs(adapter, http, uid, [pref], "Episode,Series", scope)
         episode_rows: list[Mapping[str, Any]] = []
         seen_episode_ids: set[str] = set()
         filtered_rows = jf_filter_library_candidates(rows, selected_libs, trust_query_scope=True)
@@ -1309,8 +1341,9 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
 
     series_row: dict[str, Any] | None = None
     matched_series_pair: str | None = None
+    series_id_confirmed = False
     for pref in series_pairs:
-        rows = _direct_query_by_pairs(http, uid, [pref], "Series", scope)
+        rows = _direct_query_by_pairs(adapter, http, uid, [pref], "Series", scope)
         scoped_rows = jf_filter_library_candidates(rows, selected_libs, trust_query_scope=True)
         if rows and not scoped_rows and selected_libs:
             outside_scope_seen = True
@@ -1318,6 +1351,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
         if series_rows:
             series_row = dict(series_rows[0])
             matched_series_pair = pref
+            series_id_confirmed = True
             break
     if not series_row and series_pairs:
         idx = build_provider_index(adapter) if feature == "history" else build_provider_index(adapter, feature=feature)
@@ -1332,41 +1366,21 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
             )
             if series_row:
                 matched_series_pair = pref
+                series_id_confirmed = True
                 break
-    if not series_row and series_title and not strict:
-        try:
-            q = {
-                "userId": uid,
-                "recursive": True,
-                "includeItemTypes": "Series",
-                "SearchTerm": series_title,
-                "Fields": "ProviderIds,ProductionYear,Type",
-                "Limit": 50,
-            }
-            t_l = series_title.lower()
-            cands = []
-            raw_rows = jf_get_scoped_items(http, uid, q, adapter.cfg, feature)
-            scoped_rows = jf_filter_library_candidates(raw_rows, selected_libs, trust_query_scope=True)
-            if raw_rows and not scoped_rows and selected_libs:
-                outside_scope_seen = True
-            for row in scoped_rows:
-                if (row.get("Type") or "") != "Series":
-                    continue
-                nm = (row.get("Name") or "").strip().lower()
-                if nm == t_l:
-                    cands.append(row)
-            cands.sort(key=lambda x: 0 if (x.get("ProviderIds") or {}) else 1)
-            if cands:
-                series_row = cands[0]
-                _dbg('resolve_hit', kind='series', method='title_candidate', series_title=series_title)
-        except Exception:
-            pass
-
-    if series_row and season is not None and episode is not None:
+    if series_row and series_id_confirmed and season is not None and episode is not None:
         sid = series_row.get("Id")
         if sid:
-            eps = get_series_episodes(http, uid, sid, start=0, limit=10000)
-            for row in eps.get("Items") or []:
+            episode_cache = getattr(adapter, "_jellyfin_series_episodes_cache", None)
+            if not isinstance(episode_cache, dict):
+                episode_cache = {}
+                setattr(adapter, "_jellyfin_series_episodes_cache", episode_cache)
+            eps_rows = episode_cache.get(str(sid))
+            if eps_rows is None:
+                eps_rows = get_series_episodes(http, uid, sid, start=0, limit=10000).get("Items") or []
+                episode_cache[str(sid)] = eps_rows
+                _dbg('series_episodes_cached', series_id=str(sid), count=len(eps_rows))
+            for row in eps_rows:
                 s = row.get("ParentIndexNumber")
                 e = row.get("IndexNumber")
                 if isinstance(s, int) and isinstance(e, int) and s == int(season) and e == int(episode):
@@ -1384,38 +1398,8 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
                         )
                         return str(iid)
 
-    if title and not strict:
-        try:
-            q = {
-                "userId": uid,
-                "recursive": True,
-                "includeItemTypes": "Episode",
-                "SearchTerm": title,
-                "Fields": "ProviderIds,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesId",
-                "Limit": 50,
-            }
-            t_l = title.lower()
-            raw_rows = jf_get_scoped_items(http, uid, q, adapter.cfg, feature)
-            scoped_rows = jf_filter_library_candidates(raw_rows, selected_libs, trust_query_scope=True)
-            if raw_rows and not scoped_rows and selected_libs:
-                outside_scope_seen = True
-            for row in scoped_rows:
-                if (row.get("Type") or "") != "Episode":
-                    continue
-                nm = (row.get("Name") or "").strip().lower()
-                s = row.get("ParentIndexNumber")
-                e = row.get("IndexNumber")
-                if nm == t_l and ((season is None) or s == season) and ((episode is None) or e == episode):
-                    iid = row.get("Id")
-                    if iid and not looks_like_bad_id(iid):
-                        _dbg('resolve_hit', kind='episode', method='search', title=title, season=season, episode=episode, item_id=str(iid))
-                        return str(iid)
-        except Exception:
-            pass
-
     _dbg('resolve_miss', kind='episode', title=title, series_title=series_title, season=season, episode=episode)
-    if outside_scope_seen:
-        setattr(adapter, "_jellyfin_last_resolve_hint", "outside_library_scope")
+    setattr(adapter, "_jellyfin_last_resolve_hint", "outside_library_scope" if outside_scope_seen else "unmatched_in_jellyfin")
     return None
 
 
@@ -1444,9 +1428,6 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "his
     t = _lookup_type(it)
     title = (it.get("title") or "").strip()
     year = it.get("year")
-    season = it.get("season")
-    episode = it.get("episode")
-    series_title = (it.get("series_title") or "").strip()
 
     strict = bool(getattr(getattr(adapter, "cfg", None), "strict_id_matching", False))
 
@@ -1505,55 +1486,6 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "his
                     if nm != t_l:
                         continue
                     if (year is not None) and not (isinstance(yr, int) and abs(int(yr) - int(year)) <= 1):
-                        continue
-                    iid = _valid(row.get("Id"))
-                    if iid and iid not in found:
-                        found.append(iid)
-            except Exception:
-                pass
-
-    # Episodes
-    if t == "episode":
-        for pref in pairs:
-            rows = jf_filter_library_candidates(idx.get(pref) or [], selected_libs)
-            cands = [row for row in rows if (row.get("Type") or "") == "Episode"]
-            for row in cands:
-                try:
-                    s_ok = (season is None) or (int(row.get("ParentIndexNumber") or 0) == int(season))
-                    e_ok = (episode is None) or (int(row.get("IndexNumber") or 0) == int(episode))
-                except Exception:
-                    s_ok, e_ok = True, True
-                if not (s_ok and e_ok):
-                    continue
-                iid = _valid(row.get("Id"))
-                if iid and iid not in found:
-                    found.append(iid)
-            if found:
-                return found
-
-        if series_title and not strict:
-            try:
-                q: dict[str, Any] = {
-                    "userId": uid,
-                    "recursive": True,
-                    "includeItemTypes": "Episode",
-                    "SearchTerm": series_title,
-                    "Fields": "ProviderIds,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesName",
-                    "Limit": 200,
-                }
-                st_l = series_title.lower()
-                for row in jf_filter_library_candidates(jf_get_scoped_items(http, uid, q, adapter.cfg, feature), selected_libs, trust_query_scope=True):
-                    if (row.get("Type") or "") != "Episode":
-                        continue
-                    sn = (row.get("SeriesName") or "").strip().lower()
-                    if sn != st_l:
-                        continue
-                    try:
-                        s_ok = (season is None) or (int(row.get("ParentIndexNumber") or 0) == int(season))
-                        e_ok = (episode is None) or (int(row.get("IndexNumber") or 0) == int(episode))
-                    except Exception:
-                        s_ok, e_ok = True, True
-                    if not (s_ok and e_ok):
                         continue
                     iid = _valid(row.get("Id"))
                     if iid and iid not in found:

--- a/providers/sync/jellyfin/_history.py
+++ b/providers/sync/jellyfin/_history.py
@@ -42,28 +42,45 @@ _dbg, _info, _warn = make_logger("history")
 
 
 # unresolved
+_UNRES_CACHE: dict[str, dict[str, Any]] = {}
+_UNRES_DIRTY: set[str] = set()
+
+
 def _unres_load() -> dict[str, Any]:
     if _is_capture_mode() or _pair_scope() is None:
         return {}
-    try:
-        with open(_unresolved_path(), "r", encoding="utf-8") as f:
-            return json.load(f) or {}
-    except Exception:
-        return {}
+    path = _unresolved_path()
+    cached = _UNRES_CACHE.get(path)
+    if cached is None:
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                cached = json.load(f) or {}
+        except Exception:
+            cached = {}
+        _UNRES_CACHE[path] = cached
+    return cached
 
 
 def _unres_save(obj: Mapping[str, Any]) -> None:
     if _is_capture_mode() or _pair_scope() is None:
         return
-    try:
-        path = _unresolved_path()
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        tmp = path + ".tmp"
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(obj, f, ensure_ascii=False, indent=2, sort_keys=True)
-        os.replace(tmp, path)
-    except Exception:
-        pass
+    path = _unresolved_path()
+    if _UNRES_CACHE.get(path) is not obj:
+        _UNRES_CACHE[path] = dict(obj)
+    _UNRES_DIRTY.add(path)
+
+
+def _unres_flush() -> None:
+    for path in sorted(_UNRES_DIRTY):
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            tmp = path + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(_UNRES_CACHE.get(path) or {}, f, ensure_ascii=False, indent=2, sort_keys=True)
+            os.replace(tmp, path)
+        except Exception:
+            pass
+    _UNRES_DIRTY.clear()
 
 
 def _freeze(item: Mapping[str, Any], *, reason: str) -> None:
@@ -841,9 +858,10 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         if iid:
             mids.append((k, str(iid)))
         else:
-            unresolved.append({"item": id_minimal(m), "key": k, "hint": "resolve_failed", "reason": "resolve_failed"})
+            hint = str(getattr(adapter, "_jellyfin_last_resolve_hint", "") or "unmatched_in_jellyfin")
+            unresolved.append({"item": id_minimal(m), "key": k, "hint": hint, "reason": "resolve_failed"})
             _freeze(m, reason="resolve_failed")
-            results.append(_result_row(k, _ST_RESOLVE_FAILED, action="resolve", reason="resolve_failed"))
+            results.append(_result_row(k, _ST_RESOLVE_FAILED, action="resolve", reason=hint))
             reason_counts["resolve_failed"] = reason_counts.get("resolve_failed", 0) + 1
 
     shadow = _shadow_load()
@@ -948,6 +966,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
     _bb_save(bb)
     if confirmed_keys:
         _thaw_if_present(confirmed_keys)
+    _unres_flush()
 
     _set_write_meta(adapter, {
         "confirmed_keys": confirmed_keys,
@@ -1002,9 +1021,10 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
         if iid:
             mids.append((k, str(iid)))
         else:
-            unresolved.append({"item": id_minimal(m), "key": k, "hint": "resolve_failed", "reason": "resolve_failed"})
+            hint = str(getattr(adapter, "_jellyfin_last_resolve_hint", "") or "unmatched_in_jellyfin")
+            unresolved.append({"item": id_minimal(m), "key": k, "hint": hint, "reason": "resolve_failed"})
             _freeze(m, reason="resolve_failed")
-            results.append(_result_row(k, _ST_RESOLVE_FAILED, action="resolve", reason="resolve_failed"))
+            results.append(_result_row(k, _ST_RESOLVE_FAILED, action="resolve", reason=hint))
             reason_counts["resolve_failed"] = reason_counts.get("resolve_failed", 0) + 1
     ok = 0
     for chunk in chunked(mids, qlim):
@@ -1059,6 +1079,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
     _shadow_save(shadow)
     if confirmed_keys:
         _thaw_if_present(confirmed_keys)
+    _unres_flush()
 
     _set_write_meta(adapter, {
         "confirmed_keys": confirmed_keys,

--- a/providers/sync/jellyfin/_ratings.py
+++ b/providers/sync/jellyfin/_ratings.py
@@ -100,28 +100,45 @@ def _dbg_enabled() -> bool:
 
 
 # unresolved store
+_UNRES_CACHE: dict[str, dict[str, Any]] = {}
+_UNRES_DIRTY: set[str] = set()
+
+
 def _load() -> dict[str, Any]:
     if _is_capture_mode() or _pair_scope() is None:
         return {}
-    try:
-        with open(_unresolved_path(), "r", encoding="utf-8") as f:
-            return json.load(f) or {}
-    except Exception:
-        return {}
+    path = _unresolved_path()
+    cached = _UNRES_CACHE.get(path)
+    if cached is None:
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                cached = json.load(f) or {}
+        except Exception:
+            cached = {}
+        _UNRES_CACHE[path] = cached
+    return cached
 
 
 def _save(obj: Mapping[str, Any]) -> None:
     if _is_capture_mode() or _pair_scope() is None:
         return
-    try:
-        path = _unresolved_path()
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        tmp = path + ".tmp"
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(obj, f, ensure_ascii=False, indent=2, sort_keys=True)
-        os.replace(tmp, path)
-    except Exception:
-        pass
+    path = _unresolved_path()
+    if _UNRES_CACHE.get(path) is not obj:
+        _UNRES_CACHE[path] = dict(obj)
+    _UNRES_DIRTY.add(path)
+
+
+def _flush() -> None:
+    for path in sorted(_UNRES_DIRTY):
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            tmp = path + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(_UNRES_CACHE.get(path) or {}, f, ensure_ascii=False, indent=2, sort_keys=True)
+            os.replace(tmp, path)
+        except Exception:
+            pass
+    _UNRES_DIRTY.clear()
 
 
 def _freeze(item: Mapping[str, Any], *, reason: str) -> None:
@@ -381,6 +398,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
             _dbg("cache_merged", source="shadow", added=added)
 
     _thaw_if_present(out.keys())
+    _flush()
     _info("index_done", count=len(out))
     if meta_changed:
         _meta_save(meta)
@@ -459,6 +477,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         _meta_save(meta)
 
     _info("write_done", op="add", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
+    _flush()
     return ok, unresolved
 
 
@@ -521,4 +540,5 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
         _meta_save(meta)
 
     _info("write_done", op="remove", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
+    _flush()
     return ok, unresolved

--- a/providers/sync/jellyfin/_watchlist.py
+++ b/providers/sync/jellyfin/_watchlist.py
@@ -40,27 +40,45 @@ def _unresolved_path() -> str:
 _dbg, _info, _warn = make_logger("watchlist")
 
 
+_UNRES_CACHE: dict[str, dict[str, Any]] = {}
+_UNRES_DIRTY: set[str] = set()
+
+
 def _load() -> dict[str, Any]:
     if _is_capture_mode() or _pair_scope() is None:
         return {}
-    try:
-        with open(_unresolved_path(), "r", encoding="utf-8") as f:
-            return json.load(f) or {}
-    except Exception:
-        return {}
+    path = _unresolved_path()
+    cached = _UNRES_CACHE.get(path)
+    if cached is None:
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                cached = json.load(f) or {}
+        except Exception:
+            cached = {}
+        _UNRES_CACHE[path] = cached
+    return cached
 
 
 def _save(obj: Mapping[str, Any]) -> None:
     if _is_capture_mode() or _pair_scope() is None:
         return
-    try:
-        os.makedirs(os.path.dirname(_unresolved_path()), exist_ok=True)
-        tmp = _unresolved_path() + ".tmp"
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(obj, f, ensure_ascii=False, indent=2, sort_keys=True)
-        os.replace(tmp, _unresolved_path())
-    except Exception:
-        pass
+    path = _unresolved_path()
+    if _UNRES_CACHE.get(path) is not obj:
+        _UNRES_CACHE[path] = dict(obj)
+    _UNRES_DIRTY.add(path)
+
+
+def _flush() -> None:
+    for path in sorted(_UNRES_DIRTY):
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            tmp = path + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(_UNRES_CACHE.get(path) or {}, f, ensure_ascii=False, indent=2, sort_keys=True)
+            os.replace(tmp, path)
+        except Exception:
+            pass
+    _UNRES_DIRTY.clear()
 
 
 def _freeze(item: Mapping[str, Any], *, reason: str) -> None:
@@ -173,6 +191,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
                         pass
 
         _thaw_if_present(out.keys())
+        _flush()
         _info("index_done", mode="playlist", name=name, count=len(out))
         return out
 
@@ -213,6 +232,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
                         pass
 
         _thaw_if_present(out.keys())
+        _flush()
         _info("index_done", mode="collection", name=name, count=len(out))
         return out
 
@@ -278,6 +298,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
             break
 
     _thaw_if_present(out.keys())
+    _flush()
     _info("index_done", mode="favorites", count=len(out))
     return out
 
@@ -645,6 +666,7 @@ def add(
     else:
         ok, unresolved = _add_favorites(adapter, items)
     _info("write_done", op="add", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved), mode=cfg.watchlist_mode)
+    _flush()
     return ok, unresolved
 
 
@@ -660,4 +682,5 @@ def remove(
     else:
         ok, unresolved = _remove_favorites(adapter, items)
     _info("write_done", op="remove", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved), mode=cfg.watchlist_mode)
+    _flush()
     return ok, unresolved

--- a/services/watchlist.py
+++ b/services/watchlist.py
@@ -857,29 +857,46 @@ def _jf_index_watchlist(
 def _jf_lookup_by_provider_ids(
     cfg: dict[str, Any],
     headers: dict[str, str],
-    tokens: list[str],
+    ids: dict[str, Any],
 ) -> str | None:
-    if not tokens:
-        return None
-    for tok in tokens:
-        try:
-            j = _jf_get(
-                _jf_base(cfg),
-                f"Users/{_jf_require_user(cfg)}/Items",
-                headers,
-                {
-                    "Recursive": "true",
-                    "IncludeItemTypes": "Movie,Series",
-                    "AnyProviderIdEquals": tok,
-                    "Limit": 1,
-                    "Fields": "ProviderIds",
-                },
-            )
-            items = (j.get("Items") or []) if isinstance(j, dict) else []
-            if items and items[0].get("Id"):
-                return str(items[0]["Id"])
-        except Exception:
+    wanted: dict[str, str] = {}
+    for k in ("tmdb", "imdb", "tvdb"):
+        v = ids.get(k)
+        if v in (None, "", 0):
             continue
+        wanted[k] = str(v).strip().lower()
+    if not wanted:
+        return None
+    try:
+        j = _jf_get(
+            _jf_base(cfg),
+            f"Users/{_jf_require_user(cfg)}/Items",
+            headers,
+            {
+                "Recursive": "true",
+                "IncludeItemTypes": "Movie,Series",
+                "AnyProviderIdEquals": ",".join(f"{k}.{v}" for k, v in wanted.items()),
+                "Limit": 500,
+                "Fields": "ProviderIds",
+            },
+        )
+    except Exception:
+        return None
+    for it in (j.get("Items") or []) if isinstance(j, dict) else []:
+        iid = str((it or {}).get("Id") or "")
+        if not iid:
+            continue
+        prov = it.get("ProviderIds") or {}
+        low = {str(pk).strip().lower(): pv for pk, pv in prov.items() if pv}
+        for k, v in wanted.items():
+            have = low.get(k)
+            if isinstance(have, list):
+                have = have[0] if have else None
+            have = str(have or "").strip().lower()
+            if not have:
+                continue
+            if have == v or (have.isdigit() and v.isdigit() and int(have) == int(v)):
+                return iid
     return None
 
 
@@ -1313,11 +1330,7 @@ def _delete_on_jellyfin_batch(
                 (by_token.get(t) for t in _jf_provider_tokens(ids) if by_token.get(t)),
                 None,
             )
-            or _jf_lookup_by_provider_ids(
-                cfg,
-                hdr,
-                _jf_provider_tokens(ids),
-            )
+            or _jf_lookup_by_provider_ids(cfg, hdr, ids)
         )
         if jf_id:
             jf_ids.append(str(jf_id))


### PR DESCRIPTION
# Pull request

## Change

- Stop hammering Jellyfin with a filter it ignores, we now notice once and skip it for the rest of the run
- Cache the episode list per show instead of pulling it again for every single episode
- Save the unresolved list once at the end of a run instead of rewriting it after every item
- Check every item Jellyfin sends back against the id we asked for and throw away the ones that do not match
- Only fall back to season and episode numbers when the show itself matched on a real id
- Stop guessing by title, a failed lookup now says unmatched_in_jellyfin instead of a generic error
- Updated the Jellyfin module to 2.2

## Why

Jellyfin never implemented the provider id filter (jellyfin/jellyfin#1990). It accepts the parameter, ignores it, and hands back the first 50 items in your library. That meant six wasted calls per episode, plus the unresolved list being rewritten from scratch every time an item failed. A run that took an hour now takes about a minute.d.

Note: a show with no tmdb, imdb or tvdb id in Jellyfin will no longer match on title alone, those episodes now report unmatched_in_jellyfin. Fix the match in Jellyfin and they sync fine.

## Testing

- test_jellyfin_resolver.py

## Issue

Relates to #618
