### PR TITLE
Change: improved Emby sync

### DIFF
--- a/providers/sync/_mod_EMBY.py
+++ b/providers/sync/_mod_EMBY.py
@@ -111,7 +111,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "2.1"
+__VERSION__ = "2.2"
 os.environ.setdefault("CW_EMBY_VERSION", __VERSION__)
 os.environ.setdefault("CW_EMBY_UA", f"CrossWatch/{__VERSION__} (Emby)")
 __all__ = ["get_manifest", "EMBYModule", "OPS"]

--- a/providers/sync/emby/_common.py
+++ b/providers/sync/emby/_common.py
@@ -1700,7 +1700,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
                     continue
                 nm = (row.get("Name") or "").strip().lower()
                 yr = row.get("ProductionYear")
-                if (nm == title_lc or nm.startswith(title_lc)) and (
+                if nm == title_lc and (
                     (year is None) or (isinstance(yr, int) and abs(yr - year) <= 1)
                 ):
                     cand2.append(row)

--- a/providers/sync/emby/_history.py
+++ b/providers/sync/emby/_history.py
@@ -174,28 +174,45 @@ def _prefetch_played_ts(
             _cache.setdefault(iid, 0)
             
 # unresolved tracking
+_UNRES_CACHE: dict[str, dict[str, Any]] = {}
+_UNRES_DIRTY: set[str] = set()
+
+
 def _unres_load() -> dict[str, Any]:
     if _is_capture_mode() or _pair_scope() is None:
         return {}
-    try:
-        with open(_unresolved_path(), "r", encoding="utf-8") as f:
-            return json.load(f) or {}
-    except Exception:
-        return {}
+    path = _unresolved_path()
+    cached = _UNRES_CACHE.get(path)
+    if cached is None:
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                cached = json.load(f) or {}
+        except Exception:
+            cached = {}
+        _UNRES_CACHE[path] = cached
+    return cached
 
 
 def _unres_save(obj: Mapping[str, Any]) -> None:
     if _is_capture_mode() or _pair_scope() is None:
         return
-    try:
-        path = _unresolved_path()
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        tmp = f"{path}.tmp"
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(obj, f, ensure_ascii=False, indent=2, sort_keys=True)
-        os.replace(tmp, path)
-    except Exception:
-        pass
+    path = _unresolved_path()
+    if _UNRES_CACHE.get(path) is not obj:
+        _UNRES_CACHE[path] = dict(obj)
+    _UNRES_DIRTY.add(path)
+
+
+def _unres_flush() -> None:
+    for path in sorted(_UNRES_DIRTY):
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            tmp = f"{path}.tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(_UNRES_CACHE.get(path) or {}, f, ensure_ascii=False, indent=2, sort_keys=True)
+            os.replace(tmp, path)
+        except Exception:
+            pass
+    _UNRES_DIRTY.clear()
 
 
 def _freeze(item: Mapping[str, Any], *, reason: str) -> None:
@@ -1329,6 +1346,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
     _bb_save(bb)
     if confirmed_keys:
         _thaw_if_present(confirmed_keys)
+    _unres_flush()
 
     _set_write_meta(adapter, {
         "confirmed_keys": confirmed_keys,
@@ -1383,6 +1401,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
     _shadow_save(shadow)
     if confirmed_keys:
         _thaw_if_present(confirmed_keys)
+    _unres_flush()
 
     _set_write_meta(adapter, {
         "confirmed_keys": confirmed_keys,

--- a/providers/sync/emby/_ratings.py
+++ b/providers/sync/emby/_ratings.py
@@ -61,28 +61,45 @@ def _meta_save(meta: Mapping[str, Mapping[str, Any]]) -> None:
 _dbg, _info, _warn, _error = make_logger("ratings")
 
 
+_UNRES_CACHE: dict[str, dict[str, Any]] = {}
+_UNRES_DIRTY: set[str] = set()
+
+
 def _load() -> dict[str, Any]:
     if _is_capture_mode() or _pair_scope() is None:
         return {}
-    try:
-        with open(_unresolved_path(), "r", encoding="utf-8") as f:
-            return json.load(f) or {}
-    except Exception:
-        return {}
+    path = _unresolved_path()
+    cached = _UNRES_CACHE.get(path)
+    if cached is None:
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                cached = json.load(f) or {}
+        except Exception:
+            cached = {}
+        _UNRES_CACHE[path] = cached
+    return cached
 
 
 def _save(obj: Mapping[str, Any]) -> None:
     if _is_capture_mode() or _pair_scope() is None:
         return
-    try:
-        path = _unresolved_path()
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        tmp = f"{path}.tmp"
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(obj, f, ensure_ascii=False, indent=2, sort_keys=True)
-        os.replace(tmp, path)
-    except Exception:
-        pass
+    path = _unresolved_path()
+    if _UNRES_CACHE.get(path) is not obj:
+        _UNRES_CACHE[path] = dict(obj)
+    _UNRES_DIRTY.add(path)
+
+
+def _flush() -> None:
+    for path in sorted(_UNRES_DIRTY):
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            tmp = f"{path}.tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(_UNRES_CACHE.get(path) or {}, f, ensure_ascii=False, indent=2, sort_keys=True)
+            os.replace(tmp, path)
+        except Exception:
+            pass
+    _UNRES_DIRTY.clear()
 
 
 def _freeze(item: Mapping[str, Any], *, reason: str) -> None:
@@ -368,6 +385,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         thumbs_cleared=stats["thumbs_cleared"],
         write_failed=stats["write_failed"],
     )
+    _flush()
     return ok, unresolved
 
 
@@ -414,4 +432,5 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
     if meta_changed:
         _meta_save(meta)
     _info("write_done", op="remove", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
+    _flush()
     return ok, unresolved

--- a/providers/sync/emby/_watchlist.py
+++ b/providers/sync/emby/_watchlist.py
@@ -47,27 +47,45 @@ def _unresolved_path() -> str:
 _dbg, _info, _warn, _error = make_logger("watchlist")
 
 
+_UNRES_CACHE: dict[str, dict[str, Any]] = {}
+_UNRES_DIRTY: set[str] = set()
+
+
 def _load() -> dict[str, Any]:
     if _is_capture_mode():
         return {}
-    try:
-        with open(_unresolved_path(), "r", encoding="utf-8") as f:
-            return json.load(f) or {}
-    except Exception:
-        return {}
+    path = _unresolved_path()
+    cached = _UNRES_CACHE.get(path)
+    if cached is None:
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                cached = json.load(f) or {}
+        except Exception:
+            cached = {}
+        _UNRES_CACHE[path] = cached
+    return cached
 
 
 def _save(obj: Mapping[str, Any]) -> None:
     if _is_capture_mode():
         return
-    try:
-        os.makedirs(os.path.dirname(_unresolved_path()), exist_ok=True)
-        tmp = _unresolved_path() + ".tmp"
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(obj, f, ensure_ascii=False, indent=2, sort_keys=True)
-        os.replace(tmp, _unresolved_path())
-    except Exception:
-        pass
+    path = _unresolved_path()
+    if _UNRES_CACHE.get(path) is not obj:
+        _UNRES_CACHE[path] = dict(obj)
+    _UNRES_DIRTY.add(path)
+
+
+def _flush() -> None:
+    for path in sorted(_UNRES_DIRTY):
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            tmp = path + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(_UNRES_CACHE.get(path) or {}, f, ensure_ascii=False, indent=2, sort_keys=True)
+            os.replace(tmp, path)
+        except Exception:
+            pass
+    _UNRES_DIRTY.clear()
 
 
 def _freeze(item: Mapping[str, Any], *, reason: str) -> None:
@@ -181,6 +199,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
                 progress=prog,
             )
         _thaw_if_present(out.keys())
+        _flush()
         _info("index_done", count=len(out), mode="playlist", name=name)
         return out
 
@@ -219,6 +238,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
                     except Exception:
                         pass
         _thaw_if_present(out.keys())
+        _flush()
         _info("index_done", count=len(out), mode="collections", name=name)
         return out
 
@@ -285,6 +305,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
             break
 
     _thaw_if_present(out.keys())
+    _flush()
     _info("index_done", count=len(out), mode="favorites")
     return out
 
@@ -777,6 +798,7 @@ def add(
     else:
         ok, unresolved = _add_favorites(adapter, items)
     _info("write_done", op="add", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved), mode=cfg.watchlist_mode)
+    _flush()
     return ok, unresolved
 
 
@@ -792,4 +814,5 @@ def remove(
     else:
         ok, unresolved = _remove_favorites(adapter, items)
     _info("write_done", op="remove", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved), mode=cfg.watchlist_mode)
+    _flush()
     return ok, unresolved


### PR DESCRIPTION
# Pull request

## Change

- Save the unresolved list once at the end of a run instead of rewriting it after every item
- Show titles now need an exact match instead of just a matching start
- Updated the Emby module to 2.2

## Why

Emby had the same slow bit that Jellyfin did. Every time an item could not be matched, the whole unresolved list got read and written back to disk. With a big watch history and a lot of stuff you do not own, that piles up fast and most of a sync ends up waiting on disk instead of doing anything useful.

The title change is a small safety thing. A show with no tmdb, imdb or tvdb id in Emby used to match on a title that merely started the same, so Star could pick up Star Trek. It needs an exact match now.

## Testing

- test_emby_playlists.py

## Issue

Relates to #618
