### PR TITLE
Refactor: editor into modules

### DIFF
--- a/api/editorAPI.py
+++ b/api/editorAPI.py
@@ -17,6 +17,7 @@ from fastapi.responses import StreamingResponse
 from cw_platform.config_base import load_config
 from cw_platform.id_map import canonical_key, merge_ids, minimal
 from cw_platform.modules_registry import load_sync_ops, state_read_features, sync_provider_names
+from cw_platform.orchestrator._applier import apply_add
 from cw_platform.orchestrator._snapshots import module_checkpoint
 from cw_platform.orchestrator._state_store import StateStore
 from cw_platform.playlists import PlaylistSnapshot, supports_playlists
@@ -1195,13 +1196,13 @@ def api_editor_state_providers() -> dict[str, Any]:
 
 @router.get("")
 def api_editor_get_state(
-    kind: str = Query("watchlist"),
-    snapshot: str | None = Query(None),
-    source: str = Query("state"),
-    provider: str | None = Query(None),
-    provider_instance: str | None = Query(None),
-    endpoint: str | None = Query(None),
-    workspace: str | None = Query(None),
+    kind: str = "watchlist",
+    snapshot: str | None = None,
+    source: str = "state",
+    provider: str | None = None,
+    provider_instance: str | None = None,
+    endpoint: str | None = None,
+    workspace: str | None = None,
 ) -> dict[str, Any]:
     k = _normalize_kind(kind)
     src = (source or "state").strip().lower()
@@ -1287,6 +1288,52 @@ def api_editor_get_state(
             "ts": ts,
             "count": len(items),
             "items": items,
+            "manual_adds": manual_adds,
+            "manual_blocks": manual_blocks,
+        }
+    if src in ("manual", "manual-overrides", "policy", "overrides"):
+        raw_state = _load_current_state()
+        raw_policy = _load_policy()
+        providers = _union_providers(raw_state, raw_policy)
+        chosen = (provider or "").strip() or (providers[0] if providers else "")
+        if not chosen:
+            return {
+                "kind": k,
+                "source": "manual",
+                "snapshot": None,
+                "provider": None,
+                "provider_instance": None,
+                "ts": None,
+                "count": 0,
+                "items": {},
+                "manual_adds": {},
+                "manual_blocks": [],
+            }
+
+        inst = normalize_instance_id(provider_instance)
+        pol_adds, pol_blocks = _load_policy_manual(k, chosen, inst)
+        if not pol_adds and not pol_blocks and raw_state:
+            pol_adds, pol_blocks = _load_state_manual(k, chosen, inst)
+
+        ts = None
+        try:
+            if _POLICY_PATH.exists():
+                ts = int(_POLICY_PATH.stat().st_mtime)
+            elif _STATE_PATH.exists():
+                ts = int(_STATE_PATH.stat().st_mtime)
+        except Exception:
+            ts = None
+        manual_adds = dict(pol_adds or {})
+        manual_blocks = _normalize_blocks(pol_blocks or [])
+        return {
+            "kind": k,
+            "source": "manual",
+            "snapshot": None,
+            "provider": chosen,
+            "provider_instance": inst,
+            "ts": ts,
+            "count": len(manual_adds),
+            "items": manual_adds,
             "manual_adds": manual_adds,
             "manual_blocks": manual_blocks,
         }
@@ -1378,10 +1425,10 @@ def api_editor_save_state(payload: dict[str, Any] = Body(...)) -> dict[str, Any]
             "ts": ts,
         }
 
-    if src in ("state", "current"):
+    if src in ("state", "current", "manual", "manual-overrides", "policy", "overrides"):
         provider = str(payload.get("provider") or "").strip()
         if not provider:
-            raise HTTPException(status_code=400, detail="Missing provider for source=state")
+            raise HTTPException(status_code=400, detail=f"Missing provider for source={src}")
         items = _canonicalize_manual_items(items)
 
         inst = normalize_instance_id(payload.get("provider_instance"))
@@ -1401,7 +1448,7 @@ def api_editor_save_state(payload: dict[str, Any] = Body(...)) -> dict[str, Any]
         return {
             "ok": True,
             "kind": kind,
-            "source": "state",
+            "source": "manual" if src not in ("state", "current") else "state",
             "provider": provider,
             "provider_instance": inst,
             "count": len(items),
@@ -1466,6 +1513,320 @@ def _import_enabled() -> bool:
 
 def _state_store() -> StateStore:
     return StateStore(_STATE_PATH.parent)
+
+
+def _editor_send_targets(cfg: dict[str, Any], feature: str) -> list[dict[str, Any]]:
+    feat = str(feature or "").strip().lower()
+    if feat == "rating":
+        feat = "ratings"
+    if feat not in {"watchlist", "history", "ratings", "progress"}:
+        return []
+
+    targets: list[dict[str, Any]] = []
+    for provider in sync_provider_names(upper=True):
+        ops = load_sync_ops(provider)
+        if not ops:
+            continue
+        try:
+            supported = dict(ops.features() or {})
+        except Exception:
+            supported = {}
+        if not bool(supported.get(feat)):
+            continue
+
+        try:
+            instances = list_instance_ids(cfg, provider)
+        except Exception:
+            instances = ["default"]
+
+        for raw_instance in instances:
+            instance = normalize_instance_id(raw_instance)
+            cfg_view = build_provider_config_view(cfg, provider, instance)
+            try:
+                configured = bool(ops.is_configured(cfg_view))
+            except Exception:
+                configured = False
+            if not configured:
+                continue
+
+            label = provider.title()
+            try:
+                label = str(ops.label() or label)
+            except Exception:
+                pass
+
+            targets.append(
+                {
+                    "provider": provider,
+                    "instance": instance,
+                    "label": label,
+                    "display": label if instance == "default" else f"{label} ({instance})",
+                    "feature": feat,
+                    "history_enabled": bool(supported.get("history")),
+                    "ratings_enabled": bool(supported.get("ratings")),
+                    "watchlist_enabled": bool(supported.get("watchlist")),
+                    "progress_enabled": bool(supported.get("progress")),
+                }
+            )
+
+    targets.sort(key=lambda item: (str(item.get("label") or "").lower(), str(item.get("instance") or "")))
+    return targets
+
+
+@router.get("/send/providers")
+def api_editor_send_providers(kind: str = Query("watchlist")) -> dict[str, Any]:
+    cfg = load_config() or {}
+    feature = _normalize_kind(kind)
+    return {"ok": True, "kind": feature, "providers": _editor_send_targets(cfg, feature)}
+
+
+def _normalize_send_item(raw: Any, feature: str) -> dict[str, Any] | None:
+    if not isinstance(raw, Mapping):
+        return None
+    item = dict(raw)
+    key = str(item.pop("key", "") or "").strip()
+    ids = item.get("ids")
+    if not isinstance(ids, dict):
+        ids = {}
+    ids = {str(k).lower(): v for k, v in ids.items() if v not in (None, "")}
+    for id_key in ("imdb", "tmdb", "tvdb", "trakt", "simkl", "anilist", "mal"):
+        val = item.get(id_key)
+        if val not in (None, "") and id_key not in ids:
+            ids[id_key] = val
+        item.pop(id_key, None)
+    if ids:
+        item["ids"] = ids
+
+    show_ids = item.get("show_ids")
+    if isinstance(show_ids, dict):
+        item["show_ids"] = {str(k).lower(): v for k, v in show_ids.items() if v not in (None, "")}
+
+    typ = str(item.get("type") or "").strip().lower()
+    if typ == "tv":
+        typ = "show"
+    if typ:
+        item["type"] = typ
+
+    title = str(item.get("title") or item.get("name") or item.get("series_title") or "").strip()
+    if title:
+        item["title"] = title
+
+    if feature == "ratings":
+        rating = item.get("rating", item.get("user_rating", item.get("score")))
+        try:
+            rating_i = int(float(str(rating).strip()))
+        except Exception:
+            return None
+        if rating_i < 1 or rating_i > 10:
+            return None
+        item["rating"] = rating_i
+    elif feature == "history":
+        watched_at = item.get("watched_at") or item.get("last_watched_at")
+        if not watched_at:
+            return None
+        item["watched_at"] = watched_at
+    elif feature == "progress":
+        has_progress = any(item.get(k) not in (None, "") for k in ("progress_ms", "progressMs", "progress", "progress_percent", "progressPercent"))
+        if not has_progress:
+            return None
+
+    if not ids and not key and not title:
+        return None
+    return item
+
+
+def _items_confirmed_by_send(items: list[dict[str, Any]], result: Mapping[str, Any]) -> list[dict[str, Any]]:
+    key_fields = (
+        "confirmed_keys",
+        "skipped_keys",
+        "accepted_keys",
+        "presence_confirmed_keys",
+        "live_confirmed_keys",
+        "accepted_not_seen_live_keys",
+        "date_confirmed_keys",
+    )
+    keep: set[str] = set()
+    for field in key_fields:
+        values = result.get(field)
+        if isinstance(values, list):
+            keep.update(str(v) for v in values if v)
+    if keep:
+        out: list[dict[str, Any]] = []
+        for item in items:
+            try:
+                key = str(canonical_key(item) or "")
+            except Exception:
+                key = ""
+            if key and key in keep:
+                out.append(item)
+        return out
+
+    confirmed = int(result.get("confirmed", result.get("count", 0)) or 0)
+    if confirmed <= 0:
+        return []
+    return items[: min(confirmed, len(items))]
+
+
+def _merge_sent_items_into_state(provider: str, instance: str, feature: str, items: list[dict[str, Any]]) -> None:
+    if not items:
+        return
+    store = _state_store()
+    state = store.load_state() or {}
+    providers = state.get("providers")
+    if not isinstance(providers, dict):
+        providers = {}
+        state["providers"] = providers
+
+    base = providers.get(provider)
+    if not isinstance(base, dict):
+        base = {}
+        providers[provider] = base
+
+    node = base
+    inst = normalize_instance_id(instance)
+    if inst != "default":
+        insts = node.get("instances")
+        if not isinstance(insts, dict):
+            insts = {}
+            node["instances"] = insts
+        node = insts.get(inst)
+        if not isinstance(node, dict):
+            node = {}
+            insts[inst] = node
+
+    feat_node = node.get(feature)
+    if not isinstance(feat_node, dict):
+        feat_node = {}
+        node[feature] = feat_node
+    baseline = feat_node.get("baseline")
+    if not isinstance(baseline, dict):
+        baseline = {}
+        feat_node["baseline"] = baseline
+    current = baseline.get("items")
+    if not isinstance(current, dict):
+        current = {}
+
+    for item in items:
+        try:
+            key = canonical_key(item)
+        except Exception:
+            key = ""
+        if not key:
+            continue
+        try:
+            current[str(key)] = minimal(item)
+        except Exception:
+            current[str(key)] = dict(item)
+
+    baseline["items"] = current
+    try:
+        import time as _t
+        state["last_sync_epoch"] = int(_t.time())
+    except Exception:
+        pass
+    if feature == "watchlist":
+        _rebuild_watchlist_wall(state)
+    store.save_state(state)
+
+
+@router.post("/send")
+def api_editor_send(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
+    feature = _normalize_kind(str(payload.get("kind") or "watchlist"))
+    raw_items = payload.get("items")
+    items_in = list(raw_items.values()) if isinstance(raw_items, dict) else raw_items
+    if not isinstance(items_in, list) or not items_in:
+        raise HTTPException(status_code=400, detail="No items selected")
+
+    items: list[dict[str, Any]] = []
+    invalid = 0
+    for raw in items_in:
+        item = _normalize_send_item(raw, feature)
+        if item is None:
+            invalid += 1
+            continue
+        items.append(item)
+    if not items:
+        raise HTTPException(status_code=400, detail=f"No selected rows can be sent as {feature}")
+
+    selected_targets = payload.get("providers") or []
+    if not isinstance(selected_targets, list) or not selected_targets:
+        raise HTTPException(status_code=400, detail="No target providers selected")
+
+    dry_run = bool(payload.get("dry_run", False))
+    cfg = load_config() or {}
+    available = _editor_send_targets(cfg, feature)
+    target_map = {
+        (str(it.get("provider") or "").upper(), normalize_instance_id(it.get("instance") or "default")): it
+        for it in available
+    }
+
+    def _emit(event: str, **data: Any) -> None:
+        try:
+            import crosswatch as CW  # type: ignore
+            msg = f"[EDITOR] {event} {data.get('dst') or data.get('provider') or ''} {data.get('feature') or feature} count={data.get('count', data.get('attempted', ''))}"
+            CW._append_log("SYNC", msg)
+        except Exception:
+            pass
+
+    results: list[dict[str, Any]] = []
+    totals = {"attempted": 0, "confirmed": 0, "skipped": 0, "unresolved": 0, "errors": 0}
+
+    for target_raw in selected_targets:
+        if not isinstance(target_raw, Mapping):
+            continue
+        provider = str(target_raw.get("provider") or "").strip().upper()
+        instance = normalize_instance_id(target_raw.get("instance") or target_raw.get("provider_instance") or "default")
+        if (provider, instance) not in target_map:
+            results.append({"provider": provider, "instance": instance, "ok": False, "error": "provider_not_allowed"})
+            totals["errors"] += 1
+            continue
+
+        ops = load_sync_ops(provider)
+        if not ops:
+            results.append({"provider": provider, "instance": instance, "ok": False, "error": "provider_unavailable"})
+            totals["errors"] += 1
+            continue
+
+        cfg_view = build_provider_config_view(cfg, provider, instance)
+        try:
+            res = apply_add(
+                dst_ops=ops,
+                cfg=cfg_view,
+                dst_name=provider,
+                feature=feature,
+                items=items,
+                dry_run=dry_run,
+                emit=_emit,
+                dbg=lambda *a, **k: None,
+                chunk_size=0,
+                chunk_pause_ms=0,
+            )
+        except Exception as exc:
+            results.append({"provider": provider, "instance": instance, "ok": False, "error": "send_failed", "detail": str(exc)})
+            totals["errors"] += 1
+            continue
+
+        entry = {"provider": provider, "instance": instance, "ok": bool(res.get("ok", True)), "result": res}
+        results.append(entry)
+        for key in totals:
+            totals[key] += int(res.get(key, 0) or 0)
+
+        if not dry_run and bool(res.get("ok", True)) and int(res.get("confirmed", res.get("count", 0)) or 0) > 0:
+            try:
+                _merge_sent_items_into_state(provider, instance, feature, _items_confirmed_by_send(items, res))
+            except Exception:
+                pass
+
+    return {
+        "ok": bool(results) and all(bool(r.get("ok")) for r in results),
+        "kind": feature,
+        "selected": len(items_in),
+        "sent": len(items),
+        "invalid": invalid,
+        "dry_run": dry_run,
+        "results": results,
+        **totals,
+    }
 
 
 

--- a/assets/helpers/core.js
+++ b/assets/helpers/core.js
@@ -76,7 +76,7 @@
   const PAIRS_CACHE_KEY = "cw.pairs.v1";
   const PAIRS_TTL_MS = 15_000;
   const STATUS_CACHE_KEY = "cw.status.v1";
-  const DETAILS_MAX_LINES = 2500;
+  const DETAILS_MAX_LINES = 500;
   const authSetupPending = () => window.cwIsAuthSetupPending?.() === true;
   const ROUTE_TABS = new Set(["main", "watchlist", "playback_progress", "snapshots", "playlists", "editor", "settings"]);
   const SETTINGS_PANES = new Set(["overview", "providers", "sync", "scrobbler", "scheduling", "app", "maintenance"]);
@@ -1073,6 +1073,21 @@
 
     if (tab === "editor") {
       try {
+        await ensurePageModule("editor-datetime", "/assets/js/editor/datetime.js", "CrossWatchEditorDateTime");
+        await ensurePageModule("editor-search", "/assets/js/editor/search.js", "CrossWatchEditorSearch");
+        await ensurePageModule("editor-rows", "/assets/js/editor/rows.js", "CrossWatchEditorRows");
+        await ensurePageModule("editor-sources", "/assets/js/editor/sources.js", "CrossWatchEditorSources");
+        await ensurePageModule("editor-importers", "/assets/js/editor/importers.js", "CrossWatchEditorImporters");
+        await ensurePageModule("editor-persistence", "/assets/js/editor/persistence.js", "CrossWatchEditorPersistence");
+        await ensurePageModule("editor-table", "/assets/js/editor/table.js", "CrossWatchEditorTable");
+        await ensurePageModule("editor-chrome", "/assets/js/editor/chrome.js", "CrossWatchEditorChrome");
+        await ensurePageModule("editor-row-editor", "/assets/js/editor/row-editor.js", "CrossWatchEditorRowEditor");
+        await ensurePageModule("editor-table-controller", "/assets/js/editor/table-controller.js", "CrossWatchEditorTableController");
+        await ensurePageModule("editor-file-utils", "/assets/js/editor/file-utils.js", "CrossWatchEditorFileUtils");
+        await ensurePageModule("editor-load-controller", "/assets/js/editor/load-controller.js", "CrossWatchEditorLoadController");
+        await ensurePageModule("editor-extra-editors", "/assets/js/editor/extra-editors.js", "CrossWatchEditorExtraEditors");
+        await ensurePageModule("editor-metadata-replacer", "/assets/js/editor/metadata-replacer.js", "CrossWatchEditorMetadataReplacer");
+        await ensurePageModule("editor-send-modal", "/assets/js/editor/send-modal.js", "CrossWatchEditorSendModal");
         await ensurePageModule("editor", "/assets/js/editor.js", "Editor");
       } catch (e) {
         console.warn("Editor load failed:", e);

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -52,6 +52,32 @@
     sortKey: "title",
     sortDir: "asc",
   };
+  const editorModules = window.CW && window.CW.Editor;
+  if (!editorModules) throw new Error("Editor module registry missing");
+  const requireEditorModule = name => {
+    const mod = editorModules[name];
+    if (!mod) throw new Error(`Editor module missing: ${name}`);
+    return mod;
+  };
+  const editorDateTime = requireEditorModule("DateTime");
+  const editorSearch = requireEditorModule("Search");
+  const editorRows = requireEditorModule("Rows");
+  const editorSources = requireEditorModule("Sources");
+  const editorImporters = requireEditorModule("Importers");
+  const editorPersistence = requireEditorModule("Persistence");
+  const editorTable = requireEditorModule("Table");
+  const editorChrome = requireEditorModule("Chrome");
+  const editorRowEditor = requireEditorModule("RowEditor");
+  const editorTableController = requireEditorModule("TableController");
+  const editorFileUtils = requireEditorModule("FileUtils");
+  const editorLoadController = requireEditorModule("LoadController");
+  const editorExtraEditors = requireEditorModule("ExtraEditors");
+  const editorMetadataReplacer = requireEditorModule("MetadataReplacer");
+  const editorSendModal = requireEditorModule("SendModal");
+  const rowBuilderOptions = () => ({
+    nextRid: () => state.ridSeq++,
+    sort: state.source !== "playlist",
+  });
 
   function restoreUIState() {
     try {
@@ -60,7 +86,7 @@
       if (!raw) return;
       const saved = JSON.parse(raw);
 
-      const sources = ["state", "tracker", "playlist"];
+      const sources = ["state", "manual", "tracker", "playlist"];
       if (saved.source && sources.includes(saved.source)) state.source = saved.source;
 
       if (typeof saved.workspace === "string") state.workspace = saved.workspace;
@@ -88,71 +114,12 @@
   }
   restoreUIState();
 
-  function wireStaticLabels(root) {
-    if (!root) return;
+  host.innerHTML = `<div class="cw-root"><div class="cw-topline cw-page-hero cw-page-hero-editor" data-hero-icon="edit_note"><div class="cw-head-copy cw-page-hero-copy"><div class="cw-page-hero-kicker">EDITOR</div><div class="cw-title-row"><div><div class="cw-title cw-page-hero-title">Editor</div><div class="cw-sub cw-page-hero-sub">Edit your current state, tracker or cache</div></div></div></div><div class="cw-editor-hero-summary cw-page-hero-actions" id="cw-hero-summary" aria-label="Editor summary"><div class="cw-editor-hero-seg"><strong id="cw-pill-source">Current state</strong><span>source</span></div><div class="cw-editor-hero-seg"><strong id="cw-pill-kind">Watchlist</strong><span>view</span></div><div class="cw-editor-hero-seg cw-editor-hero-count"><strong id="cw-pill-count">0</strong><span>rows</span></div><div class="cw-editor-hero-seg cw-editor-hero-sync"><span>Synced</span><strong id="cw-pill-sync">never</strong></div><button id="cw-reload" class="cw-editor-refresh" type="button" title="Refresh editor data" aria-label="Refresh editor data"><span class="material-symbols-rounded" aria-hidden="true">refresh</span></button></div></div><div class="cw-wrap"><div class="cw-main"><div class="cw-controls"><input id="cw-filter" class="cw-input" placeholder="Filter by key / title / id..."><span class="cw-status-text" id="cw-status"></span><div class="cw-controls-spacer"></div><div class="cw-bulk" id="cw-bulk" style="display:none"><span class="cw-bulk-count" id="cw-bulk-count"></span><button id="cw-bulk-remove" class="cw-btn danger" type="button"></button><button id="cw-bulk-restore" class="cw-btn" type="button"></button><button id="cw-bulk-clear" class="cw-btn" type="button">Clear</button></div><button id="cw-add" class="cw-btn" type="button">Add row</button><button id="cw-save" class="cw-btn primary" type="button">Save changes</button></div><div class="cw-table-wrap" id="cw-table-wrap"><div class="cw-table-scroll"><table class="cw-table"><thead><tr><th style="width:34px"><input id="cw-select-page" class="cw-checkbox" type="checkbox" title="Select page"></th><th class="cw-action-head" style="width:46px"></th><th style="width:12%" data-sort="key" class="sortable">Key</th><th style="width:13%" data-sort="type" class="sortable">Type</th><th style="width:33%" data-sort="title" class="sortable">Title</th><th style="width:84px">Year</th><th style="width:12%" id="cw-col-id-a">TMDB</th><th style="width:21%" data-sort="extra" class="sortable">Extra</th></tr></thead><tbody id="cw-tbody"></tbody></table></div></div><div class="cw-pager" id="cw-pager" style="display:none"><button id="cw-prev" class="cw-btn" type="button">Previous</button><span id="cw-page-info" class="cw-page-info"></span><button id="cw-next" class="cw-btn" type="button">Next</button></div><div class="cw-empty" id="cw-empty" role="status" style="display:none"><span class="material-symbols-rounded cw-empty-icon" aria-hidden="true">table_rows</span><div class="cw-empty-text">No rows match this view.</div></div></div><aside class="cw-side"><div class="ins-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">tune</span></div><div class="ins-title">Workspace</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Source</label><select id="cw-source" class="cw-select"><option value="state">Current State</option><option value="manual">Manual Overrides</option><option value="tracker">Local Tracker</option></select><label>Kind</label><select id="cw-kind" class="cw-select"><option value="watchlist">Watchlist</option><option value="history">History</option><option value="ratings">Ratings</option><option value="progress">Progress</option></select><label id="cw-pair-label" style="display:none">Pair</label><select id="cw-pair" class="cw-select" style="display:none"></select><label id="cw-snapshot-label">Snapshot</label><select id="cw-snapshot" class="cw-select"><option value="">Latest</option></select><label id="cw-instance-label" style="display:none">Profile</label><select id="cw-instance" class="cw-select" style="display:none"><option value="default">Default</option></select></div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><div class="field-label">Types</div><div id="cw-type-filter" class="cw-type-filter"><button type="button" data-type="movie" class="cw-type-chip active">Movies</button><button type="button" data-type="show" class="cw-type-chip active">Shows</button><button type="button" data-type="anime" class="cw-type-chip active">Anime</button><button type="button" data-type="season" class="cw-type-chip active">Seasons</button><button type="button" data-type="episode" class="cw-type-chip active">Episodes</button><button type="button" id="cw-blocked-only" class="cw-type-chip">Blocked</button></div></div></div><div class="ins-row" id="cw-state-bulk" style="display:none"><details class="cw-collapse" id="cw-bulk-details" style="width:100%"><summary style="cursor:pointer;font-weight:700;user-select:none">Block rules</summary><div style="display:flex;flex-direction:column;gap:8px;width:100%;margin-top:10px"><select id="cw-bulk-type" class="cw-select" style="width:100%"></select><div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap"><button id="cw-bulk-block-type" class="cw-btn danger" type="button" style="flex:1 1 0;min-width:120px">Block all</button><button id="cw-bulk-unblock-type" class="cw-btn" type="button" style="flex:1 1 0;min-width:120px">Unblock all</button></div><div class="cw-status-text">Current State only • affects baseline items</div></div></details></div><div class="ins-row" id="cw-import-row" style="display:none"><details class="cw-collapse" id="cw-import-details" style="width:100%"><summary style="cursor:pointer;font-weight:700;user-select:none">Import provider state</summary><div style="display:flex;flex-direction:column;gap:10px;width:100%;margin-top:10px"><div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center"><select id="cw-import-provider" class="cw-select" style="flex:1;min-width:200px"></select><select id="cw-import-instance" class="cw-select" style="min-width:180px"></select><select id="cw-import-mode" class="cw-select" style="min-width:180px"><option value="replace">Replace baseline</option><option value="merge">Merge (keep old)</option></select></div><div style="display:flex;gap:12px;flex-wrap:wrap;align-items:center"><label id="cw-import-watchlist-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-watchlist" class="cw-checkbox" type="checkbox" checked>Watchlist </label><label id="cw-import-history-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-history" class="cw-checkbox" type="checkbox" checked>History </label><label id="cw-import-ratings-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-ratings" class="cw-checkbox" type="checkbox" checked>Ratings </label><label id="cw-import-progress-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-progress-cb" class="cw-checkbox" type="checkbox" checked>Progress </label><span style="flex:1 1 auto"></span><button id="cw-import-run" class="cw-btn sm" type="button">Import</button></div><div id="cw-import-progress" style="display:none"><div class="cw-progress"><span></span></div><div class="cw-status-text" id="cw-import-progress-text" style="margin-top:6px"></div></div></div></details></div></div><div class="ins-card"><div class="ins-row" style="align-items:center"><div class="ins-icon"><span class="material-symbol">insights</span></div><div class="ins-title" style="margin-right:auto">Pulse</div><span class="cw-tag" id="cw-tag-status"><span class="cw-tag-dot"></span><span id="cw-tag-label">Idle</span></span></div><div class="ins-row"><div class="ins-metrics"><div class="metric-row"><div class="metric"><span class="material-symbol">view_list</span><div><div class="m-val" id="cw-summary-total">0</div><div class="m-lbl">Total rows</div></div></div><div class="metric"><span class="material-symbol">visibility</span><div><div class="m-val" id="cw-summary-visible">0</div><div class="m-lbl">Rows visible</div></div></div></div><div class="metric-divider"></div><div class="metric-row"><div class="metric"><span class="material-symbol">movie</span><div><div class="m-val" id="cw-summary-movies">0</div><div class="m-lbl">Movies</div></div></div><div class="metric"><span class="material-symbol">monitoring</span><div><div class="m-val" id="cw-summary-shows">0</div><div class="m-lbl">Shows</div></div></div><div class="metric"><span class="material-symbol">layers</span><div><div class="m-val" id="cw-summary-seasons">0</div><div class="m-lbl">Seasons</div></div></div><div class="metric"><span class="material-symbol">live_tv</span><div><div class="m-val" id="cw-summary-episodes">0</div><div class="m-lbl">Episodes</div></div></div></div><div class="metric-divider"></div><div class="metric-row"><div class="metric"><span class="material-symbol">description</span><div><div class="m-val" id="cw-summary-state-files">0</div><div class="m-lbl">State files</div></div></div><div class="metric"><span class="material-symbol">folder_copy</span><div><div class="m-val" id="cw-summary-snapshots">0</div><div class="m-lbl">Snapshots</div></div></div></div><div id="cw-state-hint" class="cw-state-hint" style="display:none"><strong>No tracker data found.</strong> Run a CrossWatch sync with the tracker enabled once. After that, tracker state files and snapshots will appear here and you can edit them. </div></div></div></div><div class="ins-card" id="cw-backup-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">backup</span></div><div class="ins-title">Archive</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Export / Import</label><div class="cw-backup-actions"><button id="cw-download" class="cw-btn" type="button">Download ZIP</button><button id="cw-upload" class="cw-btn" type="button">Import file</button><input id="cw-upload-input" type="file" accept=".zip,.json" style="display:none"></div></div></div></div><div class="ins-card" id="cw-state-backup-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">backup</span></div><div class="ins-title">Policy backup</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Export / Import</label><div class="cw-backup-actions"><button id="cw-state-download" class="cw-btn" type="button">Download JSON</button><button id="cw-state-upload" class="cw-btn" type="button">Import file</button><input id="cw-state-upload-input" type="file" accept=".json" style="display:none"></div></div></div></div></aside></div></div>`;
 
-    const bindPrevLabel = (fieldId) => {
-      const field = root.querySelector(`#${fieldId}`);
-      const label = field?.previousElementSibling;
-      if (label?.tagName === "LABEL") label.htmlFor = fieldId;
-    };
-
-    bindPrevLabel("cw-source");
-    bindPrevLabel("cw-kind");
-    bindPrevLabel("cw-pair");
-    bindPrevLabel("cw-snapshot");
-    bindPrevLabel("cw-instance");
-
-    const convertGroupLabel = (cardId) => {
-      const field = root.querySelector(`#${cardId} .ins-kv`);
-      const label = field?.firstElementChild;
-      if (!field || label?.tagName !== "LABEL") return;
-      const title = document.createElement("div");
-      title.className = "field-label";
-      title.textContent = label.textContent || "";
-      label.replaceWith(title);
-    };
-
-    convertGroupLabel("cw-backup-card");
-    convertGroupLabel("cw-state-backup-card");
-  }
-
-  host.innerHTML = `<div class="cw-root"><div class="cw-topline cw-page-hero cw-page-hero-editor" data-hero-icon="edit_note"><div class="cw-head-copy cw-page-hero-copy"><div class="cw-page-hero-kicker">EDITOR</div><div class="cw-title-row"><div><div class="cw-title cw-page-hero-title">Editor</div><div class="cw-sub cw-page-hero-sub">Edit your current state, tracker or cache</div></div></div></div><div class="cw-editor-hero-summary cw-page-hero-actions" id="cw-hero-summary" aria-label="Editor summary"><div class="cw-editor-hero-seg"><strong id="cw-pill-source">Current state</strong><span>source</span></div><div class="cw-editor-hero-seg"><strong id="cw-pill-kind">Watchlist</strong><span>view</span></div><div class="cw-editor-hero-seg cw-editor-hero-count"><strong id="cw-pill-count">0</strong><span>rows</span></div><div class="cw-editor-hero-seg cw-editor-hero-sync"><span>Synced</span><strong id="cw-pill-sync">never</strong></div><button id="cw-reload" class="cw-editor-refresh" type="button" title="Refresh editor data" aria-label="Refresh editor data"><span class="material-symbols-rounded" aria-hidden="true">refresh</span></button></div></div><div class="cw-wrap"><div class="cw-main"><div class="cw-controls"><input id="cw-filter" class="cw-input" placeholder="Filter by key / title / id..."><span class="cw-status-text" id="cw-status"></span><div class="cw-controls-spacer"></div><div class="cw-bulk" id="cw-bulk" style="display:none"><span class="cw-bulk-count" id="cw-bulk-count"></span><button id="cw-bulk-remove" class="cw-btn danger" type="button"></button><button id="cw-bulk-restore" class="cw-btn" type="button"></button><button id="cw-bulk-clear" class="cw-btn" type="button">Clear</button></div><button id="cw-add" class="cw-btn" type="button">Add row</button><button id="cw-save" class="cw-btn primary" type="button">Save changes</button></div><div class="cw-table-wrap" id="cw-table-wrap"><div class="cw-table-scroll"><table class="cw-table"><thead><tr><th style="width:34px"><input id="cw-select-page" class="cw-checkbox" type="checkbox" title="Select page"></th><th class="cw-action-head" style="width:46px"></th><th style="width:12%" data-sort="key" class="sortable">Key</th><th style="width:13%" data-sort="type" class="sortable">Type</th><th style="width:33%" data-sort="title" class="sortable">Title</th><th style="width:84px">Year</th><th style="width:12%" id="cw-col-id-a">TMDB</th><th style="width:21%" data-sort="extra" class="sortable">Extra</th></tr></thead><tbody id="cw-tbody"></tbody></table></div></div><div class="cw-pager" id="cw-pager" style="display:none"><button id="cw-prev" class="cw-btn" type="button">Previous</button><span id="cw-page-info" class="cw-page-info"></span><button id="cw-next" class="cw-btn" type="button">Next</button></div><div class="cw-empty" id="cw-empty" role="status" style="display:none"><span class="material-symbols-rounded cw-empty-icon" aria-hidden="true">table_rows</span><div class="cw-empty-text">No rows match this view.</div></div></div><aside class="cw-side"><div class="ins-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">tune</span></div><div class="ins-title">Workspace</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Source</label><select id="cw-source" class="cw-select"><option value="state">Current State</option><option value="pair">Pair Cache</option><option value="tracker">Local Tracker</option></select><label>Kind</label><select id="cw-kind" class="cw-select"><option value="watchlist">Watchlist</option><option value="history">History</option><option value="ratings">Ratings</option><option value="progress">Progress</option></select><label id="cw-pair-label" style="display:none">Pair</label><select id="cw-pair" class="cw-select" style="display:none"></select><label id="cw-snapshot-label">Snapshot</label><select id="cw-snapshot" class="cw-select"><option value="">Latest</option></select><label id="cw-instance-label" style="display:none">Profile</label><select id="cw-instance" class="cw-select" style="display:none"><option value="default">Default</option></select></div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><div class="field-label">Types</div><div id="cw-type-filter" class="cw-type-filter"><button type="button" data-type="movie" class="cw-type-chip active">Movies</button><button type="button" data-type="show" class="cw-type-chip active">Shows</button><button type="button" data-type="anime" class="cw-type-chip active">Anime</button><button type="button" data-type="season" class="cw-type-chip active">Seasons</button><button type="button" data-type="episode" class="cw-type-chip active">Episodes</button><button type="button" id="cw-blocked-only" class="cw-type-chip">Blocked</button></div></div></div><div class="ins-row" id="cw-state-bulk" style="display:none"><details class="cw-collapse" id="cw-bulk-details" style="width:100%"><summary style="cursor:pointer;font-weight:700;user-select:none">Block rules</summary><div style="display:flex;flex-direction:column;gap:8px;width:100%;margin-top:10px"><select id="cw-bulk-type" class="cw-select" style="width:100%"></select><div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap"><button id="cw-bulk-block-type" class="cw-btn danger" type="button" style="flex:1 1 0;min-width:120px">Block all</button><button id="cw-bulk-unblock-type" class="cw-btn" type="button" style="flex:1 1 0;min-width:120px">Unblock all</button></div><div class="cw-status-text">Current State only • affects baseline items</div></div></details></div><div class="ins-row" id="cw-import-row" style="display:none"><details class="cw-collapse" id="cw-import-details" style="width:100%"><summary style="cursor:pointer;font-weight:700;user-select:none">Import provider state</summary><div style="display:flex;flex-direction:column;gap:10px;width:100%;margin-top:10px"><div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center"><select id="cw-import-provider" class="cw-select" style="flex:1;min-width:200px"></select><select id="cw-import-instance" class="cw-select" style="min-width:180px"></select><select id="cw-import-mode" class="cw-select" style="min-width:180px"><option value="replace">Replace baseline</option><option value="merge">Merge (keep old)</option></select></div><div style="display:flex;gap:12px;flex-wrap:wrap;align-items:center"><label id="cw-import-watchlist-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-watchlist" class="cw-checkbox" type="checkbox" checked>Watchlist </label><label id="cw-import-history-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-history" class="cw-checkbox" type="checkbox" checked>History </label><label id="cw-import-ratings-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-ratings" class="cw-checkbox" type="checkbox" checked>Ratings </label><label id="cw-import-progress-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-progress-cb" class="cw-checkbox" type="checkbox" checked>Progress </label><span style="flex:1 1 auto"></span><button id="cw-import-run" class="cw-btn sm" type="button">Import</button></div><div id="cw-import-progress" style="display:none"><div class="cw-progress"><span></span></div><div class="cw-status-text" id="cw-import-progress-text" style="margin-top:6px"></div></div></div></details></div></div><div class="ins-card"><div class="ins-row" style="align-items:center"><div class="ins-icon"><span class="material-symbol">insights</span></div><div class="ins-title" style="margin-right:auto">Pulse</div><span class="cw-tag" id="cw-tag-status"><span class="cw-tag-dot"></span><span id="cw-tag-label">Idle</span></span></div><div class="ins-row"><div class="ins-metrics"><div class="metric-row"><div class="metric"><span class="material-symbol">view_list</span><div><div class="m-val" id="cw-summary-total">0</div><div class="m-lbl">Total rows</div></div></div><div class="metric"><span class="material-symbol">visibility</span><div><div class="m-val" id="cw-summary-visible">0</div><div class="m-lbl">Rows visible</div></div></div></div><div class="metric-divider"></div><div class="metric-row"><div class="metric"><span class="material-symbol">movie</span><div><div class="m-val" id="cw-summary-movies">0</div><div class="m-lbl">Movies</div></div></div><div class="metric"><span class="material-symbol">monitoring</span><div><div class="m-val" id="cw-summary-shows">0</div><div class="m-lbl">Shows</div></div></div><div class="metric"><span class="material-symbol">layers</span><div><div class="m-val" id="cw-summary-seasons">0</div><div class="m-lbl">Seasons</div></div></div><div class="metric"><span class="material-symbol">live_tv</span><div><div class="m-val" id="cw-summary-episodes">0</div><div class="m-lbl">Episodes</div></div></div></div><div class="metric-divider"></div><div class="metric-row"><div class="metric"><span class="material-symbol">description</span><div><div class="m-val" id="cw-summary-state-files">0</div><div class="m-lbl">State files</div></div></div><div class="metric"><span class="material-symbol">folder_copy</span><div><div class="m-val" id="cw-summary-snapshots">0</div><div class="m-lbl">Snapshots</div></div></div></div><div id="cw-state-hint" class="cw-state-hint" style="display:none"><strong>No tracker data found.</strong> Run a CrossWatch sync with the tracker enabled once. After that, tracker state files and snapshots will appear here and you can edit them. </div></div></div></div><div class="ins-card" id="cw-backup-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">backup</span></div><div class="ins-title">Archive</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Export / Import</label><div class="cw-backup-actions"><button id="cw-download" class="cw-btn" type="button">Download ZIP</button><button id="cw-upload" class="cw-btn" type="button">Import file</button><input id="cw-upload-input" type="file" accept=".zip,.json" style="display:none"></div></div></div></div><div class="ins-card" id="cw-state-backup-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">backup</span></div><div class="ins-title">Policy backup</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Export / Import</label><div class="cw-backup-actions"><button id="cw-state-download" class="cw-btn" type="button">Download JSON</button><button id="cw-state-upload" class="cw-btn" type="button">Import file</button><input id="cw-state-upload-input" type="file" accept=".json" style="display:none"></div></div></div></div></aside></div></div>`;
-
-  wireStaticLabels(host);
-
-  const sourceSelectBoot = document.getElementById("cw-source");
-  if (sourceSelectBoot) {
-    sourceSelectBoot.querySelector('option[value="pair"]')?.remove();
-    if (!sourceSelectBoot.querySelector('option[value="tracker"]')) {
-      const trackerOpt = document.createElement("option");
-      trackerOpt.value = "tracker";
-      trackerOpt.textContent = "Local Tracker";
-      sourceSelectBoot.appendChild(trackerOpt);
-    } else {
-      sourceSelectBoot.querySelector('option[value="tracker"]').textContent = "Local Tracker";
-    }
-    if (!sourceSelectBoot.querySelector('option[value="playlist"]')) {
-      const opt = document.createElement("option");
-      opt.value = "playlist";
-      opt.textContent = "Playlist Endpoint";
-      sourceSelectBoot.appendChild(opt);
-    }
-  }
-  const subBoot = host.querySelector(".cw-sub");
-  if (subBoot) subBoot.textContent = "Edit your current state or playlist endpoints";
-
-  const trackerNoticeBoot = document.createElement("div");
-  trackerNoticeBoot.id = "cw-tracker-notice";
-  trackerNoticeBoot.className = "cw-state-hint";
-  trackerNoticeBoot.style.display = "none";
-  trackerNoticeBoot.innerHTML =
-    "<strong>Local Tracker</strong> stores data inside CrossWatch. Changes here affect future syncs from Local Tracker but only for one-way syncs.";
-  host.querySelector(".cw-controls")?.insertAdjacentElement("afterend", trackerNoticeBoot);
-
-  host.querySelectorAll("input,select,textarea").forEach((field, idx) => {
-    if (!field.name) field.name = field.id || `cw-field-${idx + 1}`;
-  });
+  editorChrome.wireStaticLabels(host);
+  editorChrome.prepareSourceOptions(host);
+  editorChrome.addTrackerNotice(host);
+  editorChrome.ensureFieldNames(host);
 
   const $ = id => document.getElementById(id);
   const pickEls = spec => Object.fromEntries(Object.entries(spec).map(([key, id]) => [key, $(id)]));
@@ -243,189 +210,42 @@
     bulkUnblockTypeBtn: "cw-bulk-unblock-type",
   });
 
+  const bulkSendBtn = document.createElement("button");
+  bulkSendBtn.id = "cw-bulk-send";
+  bulkSendBtn.className = "cw-btn";
+  bulkSendBtn.type = "button";
+  bulkWrap?.insertBefore(bulkSendBtn, bulkRemoveBtn || bulkClearBtn || null);
+
   if (backupCard) backupCard.remove();
   [summaryStateFiles, summarySnapshots].forEach(el => el?.closest(".metric")?.remove());
 
-  function decorateImportPanel() {
-    const details = document.getElementById("cw-import-details");
-    if (!details || details.dataset.decorated === "1") return;
-    details.dataset.decorated = "1";
-    details.classList.add("cw-import-panel");
-
-    const summary = details.querySelector("summary");
-    if (summary) {
-      summary.classList.add("cw-import-summary");
-      summary.innerHTML =
-        '<span class="cw-import-title">Import provider state</span>' +
-        '<span class="cw-import-help material-symbol" title="Imports selected Watchlist, History, Ratings, or Progress data from a configured provider profile into Current State. Replace baseline refreshes those datasets from the provider; Merge keeps existing baseline rows and adds or updates provider rows. Provider accounts are not changed." aria-label="Import provider state help">help</span>';
-    }
-
-    const body = summary ? summary.nextElementSibling : null;
-    if (body instanceof HTMLElement) {
-      body.classList.add("cw-import-body");
-      body.style.cssText = "";
-      const rows = Array.from(body.children).filter(el => el instanceof HTMLElement);
-      const fields = rows[0];
-      const actions = rows[1];
-      if (fields instanceof HTMLElement) {
-        fields.classList.add("cw-import-fields");
-        fields.style.cssText = "";
-      }
-      if (actions instanceof HTMLElement) {
-        actions.classList.add("cw-import-actions");
-        actions.style.cssText = "";
-      }
-    }
-
-    const wrapField = (el, label) => {
-      if (!(el instanceof HTMLElement) || el.parentElement?.classList.contains("cw-import-field")) return;
-      const field = document.createElement("label");
-      field.className = "cw-import-field";
-      const text = document.createElement("span");
-      text.className = "cw-import-field-label";
-      text.textContent = label;
-      el.parentNode.insertBefore(field, el);
-      field.append(text, el);
-    };
-
-    wrapField(importProviderSel, "Provider");
-    wrapField(importInstanceSel, "Profile");
-    wrapField(importModeSel, "Mode");
-
-    const featureWrap = document.createElement("div");
-    featureWrap.className = "cw-import-features";
-    [importWatchlistWrap, importHistoryWrap, importRatingsWrap, importProgressFeatWrap].forEach(wrap => {
-      if (!(wrap instanceof HTMLElement)) return;
-      wrap.classList.add("cw-import-feature");
-      wrap.style.cssText = "";
-      featureWrap.append(wrap);
-    });
-
-    const runRow = document.createElement("div");
-    runRow.className = "cw-import-run-row";
-    if (importRunBtn) runRow.append(importRunBtn);
-
-    const actions = details.querySelector(".cw-import-actions");
-    if (actions) {
-      actions.textContent = "";
-      actions.append(featureWrap, runRow);
-    }
-
-    if (importProgressWrap) importProgressWrap.classList.add("cw-import-progress-row");
-  }
-
-  decorateImportPanel();
-
-  function decoratePolicyBackupPanel() {
-    if (!stateBackupCard || stateBackupCard.dataset.decorated === "1") return;
-    stateBackupCard.dataset.decorated = "1";
-    stateBackupCard.className = "ins-row cw-policy-row";
-    if (importRow && importRow.parentNode && stateBackupCard.parentNode !== importRow.parentNode) {
-      importRow.insertAdjacentElement("afterend", stateBackupCard);
-    }
-
-    const details = document.createElement("details");
-    details.id = "cw-policy-details";
-    details.className = "cw-collapse cw-policy-panel";
-    details.style.width = "100%";
-
-    const summary = document.createElement("summary");
-    summary.className = "cw-import-summary";
-    summary.innerHTML =
-      '<span class="cw-import-title">Policy backup</span>' +
-      '<span class="cw-import-help material-symbol" title="Exports or imports the local Current State policy JSON used by manual baseline edits and block rules. It does not change provider accounts." aria-label="Policy backup help">help</span>';
-
-    const body = document.createElement("div");
-    body.className = "cw-policy-body";
-
-    const copy = document.createElement("div");
-    copy.className = "cw-policy-copy";
-    copy.textContent = "Export or import the local Current State policy as JSON.";
-
-    const actions = document.createElement("div");
-    actions.className = "cw-policy-actions";
-
-    const exportAction = document.createElement("div");
-    exportAction.className = "cw-policy-action";
-    exportAction.innerHTML = "<span>Export</span>";
-    if (stateDownloadBtn) exportAction.append(stateDownloadBtn);
-
-    const importAction = document.createElement("div");
-    importAction.className = "cw-policy-action";
-    importAction.innerHTML = "<span>Import</span>";
-    if (stateUploadBtn) importAction.append(stateUploadBtn);
-    if (stateUploadInput) importAction.append(stateUploadInput);
-
-    actions.append(exportAction, importAction);
-    body.append(copy, actions);
-    details.append(summary, body);
-    stateBackupCard.textContent = "";
-    stateBackupCard.append(details);
-  }
-
-  decoratePolicyBackupPanel();
-
-  function decorateEditorChrome() {
-    const typeIcons = {
-      movie: "movie",
-      show: "tv",
-      anime: "theater_comedy",
-      season: "layers",
-      episode: "play_circle",
-      blocked: "block",
-    };
-    const setButtonIcon = (btn, icon, label) => {
-      if (!btn) return;
-      btn.innerHTML = `<span class="material-symbols-rounded" aria-hidden="true">${icon}</span><span>${label}</span>`;
-      btn.setAttribute("aria-label", label);
-    };
-
-    setButtonIcon(addBtn, "add", "Add row");
-    setButtonIcon(saveBtn, "check", "Save changes");
-
-    if (typeFilterWrap && typeFilterWrap.dataset.decorated !== "1") {
-      typeFilterWrap.dataset.decorated = "1";
-      const field = typeFilterWrap.closest(".ins-kv");
-      const label = field?.querySelector(".field-label");
-      if (field && label) {
-        const shell = document.createElement("div");
-        shell.className = "cw-type-filter-shell";
-        const head = document.createElement("div");
-        head.className = "cw-type-filter-head";
-        const title = document.createElement("div");
-        title.className = "field-label";
-        title.textContent = label.textContent || "Types";
-        const clear = document.createElement("button");
-        clear.type = "button";
-        clear.className = "cw-type-filter-clear";
-        clear.innerHTML = 'Clear <span class="material-symbol" aria-hidden="true">filter_alt</span>';
-        clear.setAttribute("aria-label", "Clear type filters");
-        clear.addEventListener("click", () => {
-          ["movie", "show", "anime", "season", "episode"].forEach(t => {
-            state.typeFilter[t] = true;
-          });
-          state.blockedOnly = false;
-          syncTypeFilterUI();
-          state.page = 0;
-          persistUIState();
-          renderRows();
-        });
-        head.append(title, clear);
-        label.replaceWith(shell);
-        shell.append(head, typeFilterWrap);
-      }
-
-      typeFilterWrap.querySelectorAll("button").forEach(btn => {
-        const type = btn.dataset.type || (btn.id === "cw-blocked-only" ? "blocked" : "");
-        const text = (btn.textContent || "").trim();
-        btn.innerHTML =
-          `<span class="material-symbol cw-type-icon" aria-hidden="true">${typeIcons[type] || "category"}</span>` +
-          `<span>${_escapeHtml(text)}</span>`;
-      });
-    }
-  }
-
-  decorateEditorChrome();
+  editorChrome.decorateImportPanel({
+    importProviderSel,
+    importInstanceSel,
+    importModeSel,
+    importWatchlistWrap,
+    importHistoryWrap,
+    importRatingsWrap,
+    importProgressFeatWrap,
+    importRunBtn,
+    importProgressWrap,
+  });
+  editorChrome.decoratePolicyBackupPanel({
+    stateBackupCard,
+    importRow,
+    stateDownloadBtn,
+    stateUploadBtn,
+    stateUploadInput,
+  });
+  editorChrome.decorateEditorChrome({
+    addBtn,
+    saveBtn,
+    typeFilterWrap,
+    state,
+    syncTypeFilterUI,
+    persistUIState,
+    renderRows,
+  });
   const sortHeaders = Array.from(host.querySelectorAll(".cw-table th[data-sort]"));
   const providerMeta = window.CW?.ProviderMeta || {};
   const providerKey = (name) => String(name || "").trim().toUpperCase();
@@ -485,48 +305,116 @@
   }
 
   function syncSnapshotControlVisibility() {
-    const show = !isTrackerSource();
-    if (snapLabel) snapLabel.style.display = show ? "" : "none";
-    if (snapSel) {
-      snapSel.style.display = show ? "" : "none";
-      const wrap = snapSel.nextElementSibling && snapSel.nextElementSibling.classList?.contains("cw-icon-select")
-        ? snapSel.nextElementSibling
-        : null;
-      if (wrap) wrap.style.display = show ? "" : "none";
-    }
+    return editorSources.syncSnapshotControlVisibility(sourceContext());
+  }
+
+  function sourceContext() {
+    return {
+      state,
+      host,
+      sourceSel,
+      pairLabel,
+      pairSel,
+      snapLabel,
+      snapSel,
+      kindSel,
+      instanceLabel,
+      instanceSel,
+      backupCard,
+      stateBackupCard,
+      blockedOnlyBtn,
+      trackerNotice,
+      stateHint,
+      escapeHtml: _escapeHtml,
+      providerLabel,
+      fetchJSON,
+      syncProviderIconSelect,
+      syncProfileIconSelect,
+      renderInstanceOptions,
+      loadInstanceOptions,
+      persistUIState,
+      syncKindUI,
+      syncTypeFilterUI,
+      syncStateBulkUI,
+      syncImportUI,
+      syncActionButtons,
+      syncHeaderPills,
+    };
+  }
+
+  function importContext() {
+    return {
+      state,
+      importRow,
+      importProviderSel,
+      importInstanceSel,
+      importWatchlistCb,
+      importHistoryCb,
+      importRatingsCb,
+      importProgressCb,
+      importModeSel,
+      importRunBtn,
+      importWatchlistWrap,
+      importHistoryWrap,
+      importRatingsWrap,
+      importProgressFeatWrap,
+      importProgressWrap,
+      importProgressText,
+      providerLabel,
+      fetchJSON,
+      syncProviderIconSelect,
+      syncProfileIconSelect,
+      renderInstanceOptions,
+      persistUIState,
+      setTag,
+      setStatus,
+      setStatusSticky,
+      loadSnapshots,
+      loadState,
+    };
+  }
+
+  function persistenceContext() {
+    return {
+      state,
+      fetchJSON,
+      setTag,
+      setStatus,
+      syncActionButtons,
+      loadState,
+      loadSnapshots,
+      isPolicySource,
+      isProviderPickerSource,
+      isTrackerSource,
+      isManualSource,
+      confirm: message => window.confirm(message),
+    };
   }
 
   let statusStickyUntil = 0;
 
-  const SOURCES = ["state", "tracker", "playlist"];
-
   function isTrackerSource() {
-    return state.source === "tracker";
+    return editorSources.isTrackerSource(state);
+  }
+
+  function isManualSource() {
+    return editorSources.isManualSource(state);
+  }
+
+  function isProviderPickerSource() {
+    return editorSources.isProviderPickerSource(state);
   }
 
   function isPolicySource() {
-    return state.source === "state" || state.source === "tracker";
+    return editorSources.isPolicySource(state);
   }
 
   function normalizeSource(value) {
-    const s = String(value || "").trim();
-    if (!SOURCES.includes(s)) return "state";
-    return s;
+    return editorSources.normalizeSource(value);
   }
 
   function ensureTrackerOption() {
-    if (!sourceSel) return;
-    const existing = sourceSel.querySelector('option[value="tracker"]');
-    if (existing) {
-      existing.textContent = "Local Tracker";
-      return;
-    }
-    const opt = document.createElement("option");
-    opt.value = "tracker";
-    opt.textContent = "Local Tracker";
-    const playlistOpt = sourceSel.querySelector('option[value="playlist"]');
-    if (playlistOpt) sourceSel.insertBefore(opt, playlistOpt);
-    else sourceSel.appendChild(opt);
+    return editorSources.ensureTrackerOption(sourceSel);
   }
 
   function formatEpisodeVisualTitle(row) {
@@ -540,19 +428,15 @@
   }
 
   function currentTrackerWorkspace() {
-    const id = String(state.workspace || "").trim();
-    const list = state.trackerWorkspaces || [];
-    return list.find(w => String(w && w.id || "") === id) || list[0] || null;
+    return editorSources.currentTrackerWorkspace(state);
   }
 
   function trackerKinds() {
-    const ws = currentTrackerWorkspace();
-    const feats = (ws && ws.features) || {};
-    return ["watchlist", "history", "ratings", "progress"].filter(k => feats[k]);
+    return editorSources.trackerKinds(state);
   }
 
   function syncHeaderPills(visible, total) {
-    const srcMap = { state: "Current state", tracker: "Local tracker", playlist: "Playlist endpoint" };
+    const srcMap = { state: "Current state", manual: "Manual overrides", tracker: "Local tracker", playlist: "Playlist endpoint" };
     const kindMap = { watchlist: "Watchlist", history: "History", ratings: "Ratings", progress: "Progress", playlist: "Playlist" };
     if (pillSource) pillSource.textContent = srcMap[state.source] || "Source";
     if (pillKind) pillKind.textContent = state.source === "playlist" ? "Playlist" : (kindMap[state.kind] || "Kind");
@@ -591,7 +475,10 @@
     if (/rows visible/i.test(String(statusEl.textContent || ""))) statusEl.textContent = "";
   }
 
-  if (filterInput && state.filter) filterInput.value = state.filter;
+  if (filterInput) {
+    filterInput.placeholder = "Filter by title / S01 / S01E02 / id...";
+    if (state.filter) filterInput.value = state.filter;
+  }
 
   const KIND_LABELS = { watchlist: "Watchlist", history: "History", ratings: "Ratings", progress: "Progress" };
 
@@ -613,14 +500,11 @@
   }
 
   function currentPlaylistEndpoint() {
-    const id = String(state.snapshot || "").trim();
-    return (state.playlistEndpoints || []).find(ep => String(ep && ep.id || "") === id) || null;
+    return editorSources.currentPlaylistEndpoint(state);
   }
 
   function playlistEditable() {
-    if (state.source !== "playlist") return true;
-    const r = state.playlistResource || {};
-    return !!r && !r.smart && !!(r.can_add || r.can_remove || r.can_reorder);
+    return editorSources.playlistEditable(state);
   }
 
   function syncActionButtons() {
@@ -643,7 +527,7 @@
       : ["movie", "show", "anime", "season", "episode"];
   }
   function isAnilistMode() {
-    return state.source === "state" && String(state.snapshot || "").trim().toUpperCase() === "ANILIST";
+    return isProviderPickerSource() && String(state.snapshot || "").trim().toUpperCase() === "ANILIST";
   }
 
   function syncIdColumnHeaders() {
@@ -690,16 +574,7 @@
   }
 
   function setImportBusy(on, message) {
-    if (importProgressWrap) importProgressWrap.style.display = on ? "" : "none";
-    if (importProgressText) importProgressText.textContent = message || "";
-    const disabled = !!on;
-    if (importRunBtn) importRunBtn.disabled = disabled;
-    if (importProviderSel) importProviderSel.disabled = disabled;
-    if (importModeSel) importModeSel.disabled = disabled;
-    if (importWatchlistCb) importWatchlistCb.disabled = disabled || importWatchlistCb.disabled;
-    if (importHistoryCb) importHistoryCb.disabled = disabled || importHistoryCb.disabled;
-    if (importRatingsCb) importRatingsCb.disabled = disabled || importRatingsCb.disabled;
-    if (importProgressCb) importProgressCb.disabled = disabled || importProgressCb.disabled;
+    return editorImporters.setImportBusy(on, message, importContext());
   }
 
   
@@ -745,170 +620,20 @@
 
 
   function syncImportUI() {
-    if (!importRow) return;
-    const show = state.source === "state" && state.importEnabled;
-    importRow.style.display = show ? "" : "none";
-    if (!show) return;
-
-    if (importModeSel) importModeSel.value = state.importMode || "replace";
-
-    const all = Array.isArray(state.importProviders) ? state.importProviders : [];
-    const list = all.filter(p => p && p.configured && p.name);
-
-    if (importProviderSel) {
-      const current = importProviderSel.value || state.importProvider || "";
-      const opts = list
-        .map(p => {
-          const name = p && p.name ? String(p.name) : "";
-          const label = providerLabel(name, p && p.label ? String(p.label) : name);
-          return `<option value="${name}">${label}</option>`;
-        })
-        .join("");
-
-      importProviderSel.innerHTML = opts || `<option value="">No configured providers</option>`;
-
-      const names = list.map(p => String(p.name));
-      let next = current;
-
-      if (!next || !names.includes(next)) {
-        next = state.snapshot && names.includes(state.snapshot) ? state.snapshot : "";
-      }
-      if (!next) next = names[0] || "";
-
-      state.importProvider = next;
-      importProviderSel.value = next;
-      importProviderSel.disabled = !names.length;
-      syncProviderIconSelect(importProviderSel, true);
-    }
-
-    const sel = state.importProvider || (importProviderSel ? importProviderSel.value : "");
-    const p = list.find(x => String((x || {}).name || "") === String(sel || ""));
-    const feats = (p && p.features) ? p.features : {};
-
-    if (importInstanceSel) {
-      const ids = (p && Array.isArray(p.instances)) ? p.instances : ["default"];
-      const instObjs = ids.map(x => ({ id: String(x), label: String(x) }));
-      const nextInst = renderInstanceOptions(importInstanceSel, instObjs, state.importProviderInstance);
-      if (nextInst !== state.importProviderInstance) {
-        state.importProviderInstance = nextInst;
-        persistUIState();
-      }
-      const instanceField = importInstanceSel.closest(".cw-import-field");
-      if (instanceField) instanceField.style.display = state.importProvider ? "" : "none";
-      else importInstanceSel.style.display = state.importProvider ? "" : "none";
-      syncProfileIconSelect(importInstanceSel, !!state.importProvider);
-    }
-
-    const setCb = (wrap, cb, key) => {
-      const supported = !!feats[key];
-      if (wrap) wrap.style.display = supported ? "" : "none";
-      if (!cb) return;
-      cb.disabled = !supported;
-      if (!supported) cb.checked = false;
-      else if (state.importFeatures && typeof state.importFeatures[key] === "boolean") cb.checked = !!state.importFeatures[key];
-    };
-
-    setCb(importWatchlistWrap, importWatchlistCb, "watchlist");
-    setCb(importHistoryWrap, importHistoryCb, "history");
-    setCb(importRatingsWrap, importRatingsCb, "ratings");
-    setCb(importProgressFeatWrap, importProgressCb, "progress");
-
-    if (importRunBtn) importRunBtn.disabled = !state.importProvider;
+    return editorImporters.syncImportUI(importContext());
   }
 
   async function loadImportProviders() {
-    state.importEnabled = false;
-    state.importProviders = [];
-    if (!importRow) return;
-    try {
-      const data = await fetchJSON("/api/editor/state/import/providers");
-      state.importEnabled = !!(data && data.enabled);
-      state.importProviders = Array.isArray(data && data.providers) ? data.providers : [];
-    } catch (e) {
-      state.importEnabled = false;
-      state.importProviders = [];
-    }
-    syncImportUI();
+    return editorImporters.loadImportProviders(importContext());
   }
 
   function _collectImportFeatures() {
-    const feats = [];
-    if (importWatchlistCb && importWatchlistCb.checked && !importWatchlistCb.disabled) feats.push("watchlist");
-    if (importHistoryCb && importHistoryCb.checked && !importHistoryCb.disabled) feats.push("history");
-    if (importRatingsCb && importRatingsCb.checked && !importRatingsCb.disabled) feats.push("ratings");
-    if (importProgressCb && importProgressCb.checked && !importProgressCb.disabled) feats.push("progress");
-    return feats;
+    return editorImporters.collectImportFeatures(importContext());
   }
 
   async function runStateImport() {
-    if (state.source !== "state") return;
-    const provider = (importProviderSel ? importProviderSel.value : state.importProvider) || "";
-    const features = _collectImportFeatures();
-    const mode = (importModeSel ? importModeSel.value : state.importMode) || "replace";
-
-    if (!provider) {
-      setStatusSticky("Pick a provider first", 3000);
-      return;
-    }
-    if (!features.length) {
-      setStatusSticky("Pick at least one dataset", 3000);
-      return;
-    }
-
-    state.importProvider = provider;
-    state.importMode = mode;
-    state.importFeatures = {
-      watchlist: features.includes("watchlist"),
-      history: features.includes("history"),
-      ratings: features.includes("ratings"),
-      progress: features.includes("progress"),
-    };
-
-    try {
-      const msg = `Importing ${features.join(", ")} from ${provider}…`;
-      setImportBusy(true, msg);
-      setTag("warn", "Importing…");
-      setStatus(msg);
-
-      const res = await fetchJSON("/api/editor/state/import", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ provider, provider_instance: state.importProviderInstance || "default", features, mode }),
-      });
-
-      const featsOut = (res && res.features) ? res.features : {};
-      const bits = [];
-      let totalMs = 0;
-
-      for (const k of Object.keys(featsOut)) {
-        const r = featsOut[k] || {};
-        if (r.skipped) continue;
-        if (r.ok) bits.push(`${k}:${r.count}`);
-        if (typeof r.elapsed_ms === "number") totalMs += r.elapsed_ms;
-      }
-
-      let done = "Imported " + (bits.length ? bits.join(" • ") : "done");
-      if (totalMs) done += ` (${(totalMs / 1000).toFixed(1)}s)`;
-
-      setTag("loaded", "Imported");
-      setStatusSticky(done, 6000);
-      if (window.cxToast) window.cxToast(done);
-
-      state.snapshot = provider;
-      state.instance = state.importProviderInstance || "default";
-      persistUIState();
-      await loadSnapshots();
-      await loadState();
-    } catch (e) {
-      console.error(e);
-      setTag("error", "Import failed");
-      setStatus(String(e));
-    } finally {
-      setImportBusy(false, "");
-      syncImportUI();
-    }
+    return editorImporters.runStateImport(importContext());
   }
-
 
   syncKindUI();
   syncTypeFilterUI();
@@ -945,6 +670,7 @@
       btn.title = label;
       btn.setAttribute("aria-label", label);
     };
+    setIconOnly(bulkSendBtn, "send", "Send to...");
     if (isPolicySource()) {
       setIconOnly(bulkRemoveBtn, "block", "Block selected");
       setIconOnly(bulkRestoreBtn, "undo", "Unblock selected");
@@ -955,6 +681,46 @@
     setIconOnly(bulkClearBtn, "close", "Clear selection");
   }
 
+  function selectedRowsForSend() {
+    const sel = state.selected || new Set();
+    return (state.rows || []).filter(row => sel.has(row._rid) && !row.deleted);
+  }
+
+  function rowToSendItem(row) {
+    const raw = JSON.parse(JSON.stringify(row?.raw || {}));
+    const ids = raw.ids && typeof raw.ids === "object" ? raw.ids : {};
+    if (row.imdb) ids.imdb = row.imdb;
+    if (row.tmdb) ids.tmdb = row.tmdb;
+    if (row.trakt) ids.trakt = row.trakt;
+    if (row.mal) ids.mal = row.mal;
+    if (row.anilist) ids.anilist = row.anilist;
+    raw.ids = ids;
+    raw.key = String(row.key || "").trim();
+    raw.type = row.type || raw.type || null;
+    raw.title = row.title || raw.title || raw.series_title || null;
+    const y = String(row.year || "").trim();
+    if (y) {
+      const n = parseInt(y, 10);
+      raw.year = Number.isFinite(n) ? n : y;
+    }
+    return raw;
+  }
+
+  async function openEditorSendModal() {
+    return editorSendModal.open({
+      state,
+      selectedRowsForSend,
+      rowToSendItem,
+      fetchJSON,
+      escapeHtml: _escapeHtml,
+      currentPlaylistEndpoint,
+      isProviderPickerSource,
+      isTrackerSource,
+      setStatusSticky,
+      clearSelection,
+      loadState,
+    });
+  }
   function clearSelection() {
     if (!state.selected) state.selected = new Set();
     state.selected.clear();
@@ -992,12 +758,16 @@
       markChanged();
       renderRows();
       const verb = flag
-        ? isPolicySource()
-          ? "Blocked"
-          : "Deleted"
-        : isPolicySource()
-          ? "Unblocked"
-          : "Restored";
+        ? isManualSource()
+          ? "Removed"
+          : isPolicySource()
+            ? "Blocked"
+            : "Deleted"
+        : isManualSource()
+          ? "Restored"
+          : isPolicySource()
+            ? "Unblocked"
+            : "Restored";
       setStatusSticky(`${verb} ${changed} item${changed === 1 ? "" : "s"}`, 3000);
     }
   }
@@ -1027,77 +797,11 @@
   }
 
   function syncSourceUI() {
-    state.source = normalizeSource(state.source);
-    if (sourceSel) {
-      sourceSel.querySelector('option[value="pair"]')?.remove();
-      if (!sourceSel.querySelector('option[value="playlist"]')) {
-        sourceSel.insertAdjacentHTML("beforeend", '<option value="playlist">Playlist Endpoint</option>');
-      }
-      ensureTrackerOption();
-    }
-    const isState = state.source === "state";
-    const isTracker = isTrackerSource();
-    const isPlaylist = state.source === "playlist";
-    const policy = isPolicySource();
-    if (sourceSel) sourceSel.value = state.source;
-    if (pairLabel) pairLabel.style.display = "none";
-    if (pairSel) pairSel.style.display = "none";
-    if (snapLabel) snapLabel.textContent = isState ? "Provider" : "Endpoint";
-    syncSnapshotControlVisibility();
-    if (kindSel) kindSel.disabled = isPlaylist;
-    if (instanceLabel) instanceLabel.style.display = (isState || isTracker) ? "" : "none";
-    if (instanceSel) instanceSel.style.display = (isState || isTracker) ? "" : "none";
-    if (backupCard) backupCard.style.display = "none";
-    if (stateBackupCard) stateBackupCard.style.display = policy ? "" : "none";
-    if (blockedOnlyBtn) blockedOnlyBtn.style.display = policy ? "" : "none";
-    if (trackerNotice) trackerNotice.style.display = isTracker ? "block" : "none";
-
-    const sub = host.querySelector(".cw-sub");
-    if (sub) {
-      sub.textContent = isTracker
-        ? "Edit what CrossWatch sends from its local tracker. Connected provider accounts are not changed."
-        : "Edit your current state or playlist endpoints";
-    }
-
-    if (isPlaylist) {
-      state.kind = "watchlist";
-      state.instance = "default";
-    }
-    syncKindUI();
-
-    if (!policy && state.blockedOnly) {
-      state.blockedOnly = false;
-      syncTypeFilterUI();
-      persistUIState();
-    }
-    syncStateBulkUI();
-    syncImportUI();
-    syncTypeFilterUI();
-    syncActionButtons();
-    syncHeaderPills();
+    return editorSources.syncSourceUI(sourceContext());
   }
 
   function showStateHint(mode) {
-    if (!stateHint) return;
-    if (mode === "state") {
-      stateHint.innerHTML =
-        "<strong>No state.json found.</strong> Run a CrossWatch sync once to generate it. After that, your manual adds and blocks will show up here.";
-      stateHint.style.display = "block";
-      return;
-    }
-    if (mode === "playlist") {
-      stateHint.innerHTML =
-        "<strong>No playlist endpoints found.</strong> Create an endpoint on the Playlists page first. Then select it here to edit its items.";
-      stateHint.style.display = "block";
-      return;
-    }
-    if (mode === "tracker") {
-      stateHint.innerHTML =
-        "<strong>No Local Tracker data found.</strong> Run a sync pair that uses Local Tracker first.";
-      stateHint.style.display = "block";
-      return;
-    }
-    stateHint.style.display = "none";
+    return editorSources.showStateHint(mode, sourceContext());
   }
 
   function setTag(mode, label) {
@@ -1173,103 +877,35 @@
   }
 
   function formatHistoryLabel(iso) {
-    if (!iso) return "";
-    const d = new Date(iso);
-    if (Number.isNaN(d.getTime())) return iso;
-    const pad = n => String(n).padStart(2, "0");
-    return (
-      d.getFullYear() +
-      "-" +
-      pad(d.getMonth() + 1) +
-      "-" +
-      pad(d.getDate()) +
-      " " +
-      pad(d.getHours()) +
-      ":" +
-      pad(d.getMinutes())
-    );
+    return editorDateTime.formatHistoryLabel(iso);
   }
+
   function formatSxxEyy(season, episode) {
-    const s = season == null ? NaN : parseInt(String(season), 10);
-    if (!Number.isFinite(s)) return "";
-    const pad = n => String(n).padStart(2, "0");
-    const e = episode == null ? NaN : parseInt(String(episode), 10);
-    if (Number.isFinite(e)) return `S${pad(s)}E${pad(e)}`;
-    return `S${pad(s)}`;
+    return editorDateTime.formatSxxEyy(season, episode);
   }
 
 
 
   function formatMs(ms) {
-    const n = ms == null ? NaN : Number(ms);
-    if (!Number.isFinite(n) || n <= 0) return "";
-    const total = Math.floor(n / 1000);
-    const pad = x => String(x).padStart(2, "0");
-    const h = Math.floor(total / 3600);
-    const m = Math.floor((total % 3600) / 60);
-    const s = total % 60;
-    if (h > 0) return `${h}:${pad(m)}:${pad(s)}`;
-    return `${m}:${pad(s)}`;
+    return editorDateTime.formatMs(ms);
   }
 
-  const PROGRESS_PERCENT_KEYS = ["progress_percent", "progressPercent", "percent", "position_percent", "resume_percent"];
-  const clampProgressPercent = value => {
-    const n = value == null || value === "" ? NaN : Number(value);
-    return Number.isFinite(n) ? Math.max(0, Math.min(100, n)) : null;
-  };
+  const clampProgressPercent = value => editorDateTime.clampProgressPercent(value);
 
   function progressPercentValue(raw) {
-    if (!raw) return null;
-    const pm = Number(raw.progress_ms);
-    const dm = Number(raw.duration_ms);
-    if (Number.isFinite(pm) && pm > 0 && Number.isFinite(dm) && dm > 0) return clampProgressPercent((pm / dm) * 100);
-    for (const key of PROGRESS_PERCENT_KEYS) {
-      const n = clampProgressPercent(raw[key]);
-      if (n != null) return n;
-    }
-    return null;
+    return editorDateTime.progressPercentValue(raw);
   }
 
   function formatProgressPercent(value) {
-    const n = clampProgressPercent(value);
-    if (n == null) return "";
-    const rounded = Math.round(n * 10) / 10;
-    return `${Number.isInteger(rounded) ? Math.trunc(rounded) : rounded}%`;
+    return editorDateTime.formatProgressPercent(value);
   }
 
   function parseProgressPercent(v) {
-    const s = (v == null ? "" : String(v)).trim().replace(/%$/, "").trim();
-    return s ? clampProgressPercent(s) : null;
+    return editorDateTime.parseProgressPercent(v);
   }
 
   function parseTimeToMs(v) {
-    const s = (v == null ? "" : String(v)).trim();
-    if (!s) return null;
-
-    const lower = s.toLowerCase();
-    if (lower.endsWith("ms")) {
-      const num = parseFloat(lower.slice(0, -2));
-      return Number.isFinite(num) ? Math.max(0, Math.floor(num)) : null;
-    }
-
-    if (s.includes(":")) {
-      const parts = s.split(":").map(p => p.trim()).filter(Boolean);
-      if (!parts.length) return null;
-      const nums = parts.map(x => parseInt(x, 10));
-      if (nums.some(n => !Number.isFinite(n))) return null;
-
-      let sec = 0;
-      if (nums.length === 3) sec = nums[0] * 3600 + nums[1] * 60 + nums[2];
-      else if (nums.length === 2) sec = nums[0] * 60 + nums[1];
-      else sec = nums[0];
-      return Math.max(0, sec * 1000);
-    }
-
-    const num = parseFloat(s);
-    if (!Number.isFinite(num)) return null;
-    // Heuristic: large numbers are probably milliseconds.
-    if (num >= 100000) return Math.max(0, Math.floor(num));
-    return Math.max(0, Math.floor(num * 1000));
+    return editorDateTime.parseTimeToMs(v);
   }
 
   function appendPopupTitle(pop, text, marginTop = "") {
@@ -1302,6 +938,22 @@
     return state.kind === "ratings" || state.kind === "history" || state.kind === "progress";
   }
 
+  function manualCorrectionKindLabel(kind = state.kind) {
+    const k = String(kind || "").toLowerCase();
+    if (k === "history") return "history date";
+    if (k === "ratings") return "rating";
+    if (k === "progress") return "progress";
+    return "extra field";
+  }
+
+  function extraCorrectionStatus(row, promoted) {
+    if (!isPolicySource() || !row || !isExtraKindEditable()) return "";
+    const label = manualCorrectionKindLabel();
+    if (promoted) return `A local ${label} correction was created. Save changes to use it on the next sync.`;
+    if (row._origin === "manual") return `Updated local ${label} correction. Save changes to use it on the next sync.`;
+    return "";
+  }
+
   function promoteBaselineEdit(row) {
     if (!isPolicySource() || !row || row._origin !== "baseline") return false;
     row._origin = "manual";
@@ -1309,88 +961,16 @@
     return true;
   }
 
-  const REPLACEABLE_TYPES = ["movie", "show", "anime", "season", "episode"];
-
   function rowType(row) {
     return String((row && row.type) || "").toLowerCase();
   }
 
   function canReplaceRow(row) {
-    if (!isPolicySource()) return false;
-    return REPLACEABLE_TYPES.includes(rowType(row));
+    return !!editorMetadataReplacer.canReplaceRow(row, { isPolicySource });
   }
 
   function usesCoordinateReplacer(row) {
-    const t = rowType(row);
-    return t === "episode" || t === "season";
-  }
-
-  const EPISODE_ID_FIELDS = [
-    { key: "tvdb", label: "TVDB episode ID" },
-    { key: "tmdb", label: "TMDB episode ID" },
-    { key: "simkl", label: "SIMKL episode ID" },
-  ];
-
-  const PROVIDER_HISTORY_ID_FIELDS = [
-    "_trakt_history_id",
-    "history_id",
-    "_simkl_history_id",
-    "_plex_history_id",
-    "watched_id",
-    "play_id",
-  ];
-
-  function coordinateKeyFor(row, season, episode) {
-    const base = String((row && row.key) || "").split("#")[0].trim();
-    if (!base) return "";
-    if (rowType(row) === "season") return `${base}#season:${season}`;
-    const s = String(Math.max(0, season)).padStart(2, "0");
-    const e = String(Math.max(0, episode)).padStart(2, "0");
-    return `${base}#s${s}e${e}`;
-  }
-
-  function carryOverFields(row, drop) {
-    const src = (row && row.raw) || {};
-    const out = {};
-    for (const [k, v] of Object.entries(src)) {
-      if (drop.includes(k) || PROVIDER_HISTORY_ID_FIELDS.includes(k)) continue;
-      out[k] = JSON.parse(JSON.stringify(v === undefined ? null : v));
-    }
-    return out;
-  }
-
-  function correctedEpisodeItem(row, season, episode, watchedAt, extraIds) {
-    const isSeason = rowType(row) === "season";
-    const out = carryOverFields(row, ["ids", "season", "episode", "title"]);
-    out.type = isSeason ? "season" : "episode";
-    out.season = season;
-    if (isSeason) {
-      out.title = `Season ${season}`;
-    } else {
-      out.episode = episode;
-      out.title = `S${String(season).padStart(2, "0")}E${String(episode).padStart(2, "0")}`;
-      out.watched_at = watchedAt || null;
-    }
-    const ids = {};
-    for (const [k, v] of Object.entries(extraIds || {})) {
-      const val = String(v || "").trim();
-      if (val) ids[k] = val;
-    }
-    out.ids = ids;
-    return out;
-  }
-
-  function correctedMetadataItem(row, draft) {
-    const out = carryOverFields(row, [
-      "ids", "title", "year", "type",
-      "season", "episode", "series_title", "series_year", "show_ids",
-    ]);
-    const picked = (draft && draft.raw) || {};
-    out.type = picked.type || draft.type || "movie";
-    out.title = picked.title || draft.title || null;
-    out.year = picked.year != null ? picked.year : null;
-    out.ids = { ...(picked.ids || {}) };
-    return out;
+    return !!editorMetadataReplacer.usesCoordinateReplacer(row);
   }
 
   function commitReplacement(row, corrected, key, sameMessage) {
@@ -1413,212 +993,32 @@
     return "";
   }
 
+  function metadataReplacerContext() {
+    return {
+      isPolicySource,
+      openPopup,
+      appendPopupTitle,
+      appendPopupActions,
+      fetchJSON,
+      updateTypeDisplay,
+      formatEpisodeVisualTitle,
+      setStatusSticky,
+      markChanged,
+      renderRows,
+      commitReplacement,
+    };
+  }
+
   function openItemReplacer(row, anchor) {
-    if (usesCoordinateReplacer(row)) return openEpisodeReplacer(row, anchor);
-    return openMetadataReplacer(row, anchor);
-  }
-
-  function openMetadataReplacer(row, anchor) {
-    const draft = {
-      _rid: -1,
-      key: String(row.key || ""),
-      type: rowType(row),
-      title: String(row.title || ""),
-      year: String(row.year || ""),
-      imdb: "",
-      tmdb: "",
-      trakt: "",
-      mal: "",
-      anilist: "",
-      raw: JSON.parse(JSON.stringify(row.raw || {})),
-      deleted: false,
-      episode: false,
-    };
-    const stub = () => document.createElement("input");
-    const refs = {
-      keyIn: stub(),
-      titleIn: stub(),
-      yearIn: stub(),
-      imdbIn: stub(),
-      tmdbIn: stub(),
-      traktIn: stub(),
-      typeBtn: document.createElement("button"),
-      onApplied: applied => {
-        const key = String(applied.key || "").trim();
-        if (!key) {
-          setStatusSticky("That result has no usable identifier.", 5000);
-          return;
-        }
-        if (key.toLowerCase() === String(row.key || "").trim().toLowerCase()) {
-          setStatusSticky("The corrected item is the same as the current one.", 5000);
-          return;
-        }
-        const corrected = correctedMetadataItem(row, applied);
-        const err = commitReplacement(row, corrected, key, "The corrected local item was updated.");
-        if (err) setStatusSticky(err, 5000);
-      },
-    };
-    openTitleSearchEditor(draft, anchor, refs);
-  }
-
-  function openEpisodeReplacer(row, anchor) {
-    const isSeason = rowType(row) === "season";
-    openPopup(anchor, (pop, close) => {
-      appendPopupTitle(pop, isSeason ? "Replace season" : "Replace episode");
-
-      const raw = (row && row.raw) || {};
-      const curSeason = Number(raw.season || 0);
-      const curEpisode = Number(raw.episode || 0);
-      const seriesTitle = String(raw.series_title || row.title || "").trim() || "Unknown series";
-
-      const info = document.createElement("div");
-      info.className = "cw-search-meta";
-      info.textContent = isSeason
-        ? `${seriesTitle} - currently season ${curSeason}`
-        : `${seriesTitle} - currently S${String(curSeason).padStart(2, "0")}E${String(curEpisode).padStart(2, "0")}`;
-      pop.appendChild(info);
-
-      appendPopupTitle(pop, isSeason ? "Corrected season" : "Corrected episode", "10px");
-
-      const grid = document.createElement("div");
-      grid.className = "cw-datetime-grid";
-      grid.style.gridTemplateColumns = isSeason ? "minmax(0,1fr)" : "minmax(0,1fr) minmax(0,1fr)";
-
-      const seasonIn = document.createElement("input");
-      seasonIn.type = "number";
-      seasonIn.min = "0";
-      seasonIn.placeholder = "Season";
-      seasonIn.value = String(curSeason);
-
-      const episodeIn = document.createElement("input");
-      episodeIn.type = "number";
-      episodeIn.min = "0";
-      episodeIn.placeholder = "Episode";
-      episodeIn.value = String(curEpisode);
-
-      grid.appendChild(seasonIn);
-      if (!isSeason) grid.appendChild(episodeIn);
-      pop.appendChild(grid);
-
-      const dateInput = document.createElement("input");
-      dateInput.type = "date";
-      const timeInput = document.createElement("input");
-      timeInput.type = "time";
-      timeInput.step = 60;
-
-      if (!isSeason) {
-        appendPopupTitle(pop, "Watched at", "10px");
-        const whenGrid = document.createElement("div");
-        whenGrid.className = "cw-datetime-grid";
-        fillDateTimeInputs(raw.watched_at, dateInput, timeInput);
-        whenGrid.appendChild(dateInput);
-        whenGrid.appendChild(timeInput);
-        pop.appendChild(whenGrid);
-      }
-
-      const advanced = document.createElement("details");
-      advanced.className = "cw-collapse";
-      advanced.style.marginTop = "10px";
-      const summary = document.createElement("summary");
-      summary.style.cursor = "pointer";
-      summary.style.fontWeight = "700";
-      summary.style.userSelect = "none";
-      summary.textContent = "Advanced";
-      advanced.appendChild(summary);
-
-      const advGrid = document.createElement("div");
-      advGrid.className = "cw-datetime-grid";
-      advGrid.style.marginTop = "8px";
-      const idInputs = {};
-      EPISODE_ID_FIELDS.forEach(field => {
-        const input = document.createElement("input");
-        input.type = "text";
-        input.placeholder = field.label;
-        idInputs[field.key] = input;
-        advGrid.appendChild(input);
-      });
-      advanced.appendChild(advGrid);
-      pop.appendChild(advanced);
-
-      const status = document.createElement("div");
-      status.className = "cw-search-status";
-      status.style.marginTop = "8px";
-      pop.appendChild(status);
-
-      const apply = () => {
-        const season = parseInt(seasonIn.value, 10);
-        const episode = isSeason ? 0 : parseInt(episodeIn.value, 10);
-        const seasonOk = Number.isFinite(season) && season >= 0;
-        const episodeOk = isSeason || (Number.isFinite(episode) && episode > 0);
-        if (!seasonOk || !episodeOk) {
-          status.textContent = isSeason
-            ? "Enter a valid corrected season."
-            : "Enter a valid corrected season and episode.";
-          return;
-        }
-        if (season === curSeason && (isSeason || episode === curEpisode)) {
-          status.textContent = isSeason
-            ? "The corrected season is the same as the current one."
-            : "The corrected episode is the same as the current one.";
-          return;
-        }
-        const key = coordinateKeyFor(row, season, episode);
-        if (!key) {
-          status.textContent = "This row has no usable series identifier.";
-          return;
-        }
-
-        const watchedAt = dateTimeInputsToIso(dateInput.value, timeInput.value) || raw.watched_at || null;
-        const extraIds = {};
-        EPISODE_ID_FIELDS.forEach(field => {
-          extraIds[field.key] = idInputs[field.key].value;
-        });
-        const corrected = correctedEpisodeItem(row, season, episode, watchedAt, extraIds);
-        const err = commitReplacement(
-          row,
-          corrected,
-          key,
-          isSeason ? "The corrected local season was updated." : "The corrected local episode was updated."
-        );
-        if (err) {
-          status.textContent = err;
-          return;
-        }
-        close();
-      };
-
-      appendPopupActions(pop, [
-        { label: "Close", kind: "ghost", onClick: close },
-        { label: "Replace episode", kind: "primary", onClick: apply },
-      ]);
-
-      seasonIn.focus();
-    });
+    return editorMetadataReplacer.openItemReplacer(row, anchor, metadataReplacerContext());
   }
 
   function applyManualRow(row, item, key) {
-    row.key = key;
-    row.raw = item;
-    row.type = "episode";
-    row.episode = true;
-    row.title = String(item.series_title || row.title || "");
-    row.year = item.series_year != null ? String(item.series_year) : row.year || "";
-    row.imdb = "";
-    row.tmdb = item.ids && item.ids.tmdb ? String(item.ids.tmdb) : "";
-    row.trakt = "";
-    row.deleted = false;
-    row._origin = "manual";
-    return row;
+    return editorRows.applyManualRow(row, item, key);
   }
 
   function buildManualRow(item, key, replacedKey) {
-    const row = applyManualRow(
-      { _rid: state.ridSeq++, mal: "", anilist: "" },
-      item,
-      key
-    );
-    if (replacedKey) row._replacedKey = replacedKey;
-    return row;
+    return editorRows.buildManualRow(item, key, replacedKey, rowBuilderOptions());
   }
 
   function renderLockedPopup(pop, close) {
@@ -1630,31 +1030,23 @@
   }
 
   function fillDateTimeInputs(iso, dateInput, timeInput) {
-    if (!iso) return;
-    const d = new Date(iso);
-    if (Number.isNaN(d.getTime())) return;
-    const pad = n => String(n).padStart(2, "0");
-    dateInput.value = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
-    timeInput.value = `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    editorDateTime.fillDateTimeInputs(iso, dateInput, timeInput);
   }
 
   function dateTimeInputsToIso(dateValue, timeValue) {
-    if (!dateValue) return null;
-    const parts = dateValue.split("-");
-    const y = parseInt(parts[0], 10);
-    const m = parseInt(parts[1], 10);
-    const dDay = parseInt(parts[2], 10);
-    const [hhRaw, mmRaw] = (timeValue || "").split(":");
-    const hh = parseInt(hhRaw, 10) || 0;
-    const mm = parseInt(mmRaw, 10) || 0;
-    return new Date(y, m - 1, dDay, hh, mm, 0).toISOString().replace(/\.\d{3}Z$/, ".000Z");
+    return editorDateTime.dateTimeInputsToIso(dateValue, timeValue);
+  }
+
+  function appendUtcHint(pop) {
+    editorDateTime.appendUtcHint(pop);
   }
 
   function finishExtraChange(row, displayEl, close) {
     const promoted = promoteBaselineEdit(row);
     updateExtraDisplay(row, displayEl);
     markChanged();
-    if (promoted) setStatusSticky("A local correction was created for this row.", 4500);
+    const status = extraCorrectionStatus(row, promoted);
+    if (status) setStatusSticky(status, 6000);
     close();
     if (promoted) renderRows();
   }
@@ -1665,677 +1057,144 @@
     if (rerender) renderRows();
   }
 
+  function extraEditorContext() {
+    return {
+      state,
+      openPopup,
+      appendPopupTitle,
+      appendPopupActions,
+      finishExtraChange,
+    };
+  }
+
   function updateExtraDisplay(row, el) {
-    let label = "";
-    let placeholder = "";
-    let icon = "";
-    if (state.kind === "ratings") {
-      icon = "star";
-      const r = row.raw && row.raw.rating;
-      if (r == null || r === "") placeholder = "Set rating";
-      else label = String(r) + "/10";
-    } else if (state.kind === "history") {
-      icon = "schedule";
-      const w = row.raw && row.raw.watched_at;
-      if (!w) placeholder = "Set time";
-      else label = formatHistoryLabel(w);
-    } else if (state.kind === "progress") {
-      icon = "play_circle";
-      const p = row.raw && row.raw.progress_ms;
-      const d = row.raw && row.raw.duration_ms;
-      const percent = progressPercentValue(row.raw);
-      const pm = p == null ? NaN : Number(p);
-      const dm = d == null ? NaN : Number(d);
-      if (!Number.isFinite(pm) || pm <= 0) {
-        if (percent != null) label = formatProgressPercent(percent);
-        else placeholder = "Set progress";
-      }
-      else {
-        const left = formatMs(pm);
-        const right = Number.isFinite(dm) && dm > 0 ? formatMs(dm) : "";
-        const pct = percent != null ? ` (${formatProgressPercent(percent)})` : "";
-        label = right ? `${left} / ${right}${pct}` : left;
-      }
-    } else {
-      placeholder = "";
-    }
+    return editorExtraEditors.updateExtraDisplay(row, el, extraEditorContext());
+  }
 
-    el.innerHTML = "";
-    const text = document.createElement("span");
-    text.className = "cw-extra-display-label";
-    if (label) {
-      text.textContent = label;
-      text.classList.add("cw-extra-display-value");
-    } else {
-      text.textContent = placeholder || "";
-      text.classList.add("cw-extra-display-placeholder");
-    }
-    el.appendChild(text);
-
-    if (icon) {
-      const iconEl = document.createElement("span");
-      iconEl.className = "material-symbol cw-extra-display-icon";
-      iconEl.textContent = icon;
-      el.appendChild(iconEl);
-    }
+  function rowEditorContext() {
+    return {
+      state,
+      openPopup,
+      appendPopupTitle,
+      appendPopupActions,
+      allowedTypesForKind,
+      isRowLocked,
+      renderLockedPopup,
+      finishPopupChange,
+      isPolicySource,
+      markChanged,
+      renderRows,
+    };
   }
 
   function updateTypeDisplay(row, el) {
-    let label = "";
-    let icon = "category";
-    const t = (row.type || "").toLowerCase();
-    if (t === "movie") {
-      label = "Movie";
-      icon = "movie";
-    } else if (t === "show") {
-      label = "Show";
-      icon = "monitoring";
-    } else if (t === "anime") {
-      label = "Anime";
-      icon = "auto_awesome";
-    } else if (t === "season") {
-      label = "Season";
-      icon = "layers";
-    } else if (t === "episode") {
-      label = "Episode";
-      icon = "open_in_new";
-    }
-
-    el.innerHTML = "";
-    ["type-movie", "type-show", "type-anime", "type-season", "type-episode"].forEach(cls => el.classList.remove(cls));
-    if (t) el.classList.add(`type-${t}`);
-    const text = document.createElement("span");
-    text.className = "cw-extra-display-label";
-    if (label) {
-      text.textContent = label;
-      text.classList.add("cw-extra-display-value");
-    } else {
-      text.textContent = "Set type";
-      text.classList.add("cw-extra-display-placeholder");
-    }
-    el.appendChild(text);
-
-    const iconEl = document.createElement("span");
-    iconEl.className = "material-symbol cw-extra-display-icon";
-    iconEl.textContent = icon;
-    el.appendChild(iconEl);
+    return editorRowEditor.updateTypeDisplay(row, el);
   }
 
   function imdbFromKey(key) {
-    const s = (key || "") + "";
-    if (!s.startsWith("imdb:")) return "";
-    return s.slice(5).split("#")[0];
+    return editorRows.imdbFromKey(key);
   }
 
   function buildRows(items) {
-    const rows = [];
-    for (const [key, raw] of Object.entries(items || {})) {
-      const ids = raw.ids || {};
-      const showIds = raw.show_ids || {};
-      const type = raw.type || "";
-      const isEpisode = type === "episode";
-      const baseTitle = raw.title || raw.series_title || "";
-      rows.push({
-        _rid: state.ridSeq++,
-        key,
-        type,
-        title: baseTitle,
-        year: raw.year != null ? String(raw.year) : "",
-        imdb: ids.imdb || (type === "season" ? showIds.imdb || imdbFromKey(key) : ""),
-        tmdb: ids.tmdb || showIds.tmdb || "",
-        trakt: ids.trakt || showIds.trakt || "",
-        mal: ids.mal || "",
-        anilist: ids.anilist || "",
-        raw: JSON.parse(JSON.stringify(raw)),
-        deleted: false,
-        episode: isEpisode,
-      });
-    }
-    if (state.source !== "playlist") rows.sort((a, b) => (a.title || "").localeCompare(b.title || ""));
-    return rows;
+    return editorRows.buildRows(items, rowBuilderOptions());
+  }
+
+  function buildManualOverrideRows(items, blocks) {
+    return editorRows.buildManualOverrideRows(items, blocks, rowBuilderOptions());
+  }
+
+  function normalizeSearchText(value) {
+    return editorSearch.normalizeSearchText(value);
+  }
+
+  function parseSeasonEpisodeText(value) {
+    return editorSearch.parseSeasonEpisodeText(value);
+  }
+
+  function rowSeasonEpisode(row) {
+    return editorSearch.rowSeasonEpisode(row);
+  }
+
+  function rowSearchHaystack(row) {
+    return editorSearch.rowSearchHaystack(row, { formatEpisodeVisualTitle, formatSxxEyy });
+  }
+  function tableControllerContext() {
+    return {
+      state,
+      host,
+      pageSize: PAGE_SIZE,
+      sortHeaders,
+      tbody,
+      empty,
+      pager,
+      prevBtn,
+      nextBtn,
+      pageInfo,
+      summaryVisible,
+      summaryTotal,
+      summaryMovies,
+      summaryShows,
+      summarySeasons,
+      summaryEpisodes,
+      editorTable,
+      normalizeSearchText,
+      parseSeasonEpisodeText,
+      rowSeasonEpisode,
+      rowSearchHaystack,
+      closePopup,
+      syncIdColumnHeaders,
+      syncHeaderPills,
+      isPolicySource,
+      isTrackerSource,
+      isAnilistMode,
+      isRowLocked,
+      isExtraKindEditable,
+      canReplaceRow,
+      usesCoordinateReplacer,
+      rowType,
+      markChanged,
+      renderRows,
+      syncBulkBar,
+      syncSelectPageCheckbox,
+      updateTypeDisplay,
+      updateExtraDisplay,
+      formatEpisodeVisualTitle,
+      formatSxxEyy,
+      openTypeEditor,
+      openTitleSearchEditor,
+      openItemReplacer,
+      openRawFieldsModal,
+      openRatingEditor,
+      openHistoryEditor,
+      openProgressEditor,
+      setStatus,
+      setRowsStatus,
+    };
   }
 
   function applyFilter(rows) {
-    const q = (state.filter || "").trim().toLowerCase();
-    const filters = state.typeFilter || {};
-    const hasTypeFilter = filters.movie || filters.show || filters.anime || filters.season || filters.episode;
-
-    return rows.filter(r => {
-      if (hasTypeFilter) {
-        const t = (r.type || "").toLowerCase();
-        const known = t === "movie" || t === "show" || t === "anime" || t === "season" || t === "episode";
-        let allowed = true;
-        if (known) {
-          if (t === "movie") allowed = !!filters.movie;
-          else if (t === "show") allowed = !!filters.show;
-          else if (t === "anime") allowed = !!filters.anime;
-          else if (t === "season") allowed = !!filters.season;
-          else if (t === "episode") allowed = !!filters.episode;
-        }
-        if (!allowed) return false;
-      }
-
-      if (state.blockedOnly && isPolicySource()) {
-        if (!(r.deleted && r._origin === "baseline")) return false;
-      }
-
-      if (!q) return true;
-
-      const parts = [
-        r.key,
-        r.title,
-        r.type,
-        r.year,
-        r.imdb,
-        r.tmdb,
-        r.trakt,
-        r.mal,
-        r.anilist,
-        r.raw && r.raw.series_title ? r.raw.series_title : "",
-      ]
-        .join(" ")
-        .toLowerCase();
-
-      return parts.includes(q);
-    });
+    return editorTableController.applyFilter(rows, tableControllerContext());
   }
 
   function openHistoryEditor(row, anchor, displayEl) {
-    openPopup(anchor, (pop, close) => {
-      appendPopupTitle(pop, "Watched at");
-
-      const grid = document.createElement("div");
-      grid.className = "cw-datetime-grid";
-
-      const dateInput = document.createElement("input");
-      dateInput.type = "date";
-
-      const timeInput = document.createElement("input");
-      timeInput.type = "time";
-      timeInput.step = 60;
-
-      fillDateTimeInputs(row.raw && row.raw.watched_at, dateInput, timeInput);
-
-      grid.appendChild(dateInput);
-      grid.appendChild(timeInput);
-      pop.appendChild(grid);
-
-      appendPopupActions(pop, [
-        { label: "Clear", kind: "ghost", onClick: () => { row.raw.watched_at = null; finishExtraChange(row, displayEl, close); } },
-        { label: "Close", kind: "ghost", onClick: close },
-        { label: "Save", kind: "primary", onClick: () => { row.raw.watched_at = dateTimeInputsToIso(dateInput.value, timeInput.value); finishExtraChange(row, displayEl, close); } },
-      ]);
-
-      dateInput.focus();
-    });
+    return editorExtraEditors.openHistoryEditor(row, anchor, displayEl, extraEditorContext());
   }
 
 
   function openProgressEditor(row, anchor, displayEl) {
-    openPopup(anchor, (pop, close) => {
-      appendPopupTitle(pop, "Progress");
-
-      const makeInput = (type, props = {}) => Object.assign(document.createElement("input"), { type, ...props });
-      const makeField = (label, child, extraClass = "") => {
-        const field = document.createElement("label");
-        field.className = `cw-progress-edit-field ${extraClass}`.trim();
-        const labelEl = Object.assign(document.createElement("span"), { className: "cw-progress-edit-label", textContent: label });
-        field.appendChild(labelEl);
-        field.appendChild(child);
-        return field;
-      };
-
-      const grid = document.createElement("div");
-      grid.className = "cw-progress-edit-grid";
-
-      const curPos = row.raw && row.raw.progress_ms;
-      const curDur = row.raw && row.raw.duration_ms;
-      const curPercent = progressPercentValue(row.raw);
-      const posInput = makeInput("text", { placeholder: "mm:ss", value: curPos != null ? formatMs(curPos) : "" });
-      const durInput = makeInput("text", { placeholder: "mm:ss", value: curDur != null ? formatMs(curDur) : "" });
-
-      grid.appendChild(makeField("Position", posInput));
-      grid.appendChild(makeField("Duration", durInput));
-      pop.appendChild(grid);
-
-      const percentInput = makeInput("number", {
-        min: "0",
-        max: "100",
-        step: "0.1",
-        placeholder: "0-100",
-        value: curPercent != null ? String(Math.round(curPercent * 10) / 10) : "",
-      });
-      const percentWrap = document.createElement("div");
-      percentWrap.className = "cw-progress-percent-wrap";
-      percentWrap.append(percentInput, Object.assign(document.createElement("span"), { className: "cw-progress-percent-suffix", textContent: "%" }));
-      pop.appendChild(makeField("Percent", percentWrap, "cw-progress-percent-field"));
-
-      appendPopupTitle(pop, "Updated at", "10px");
-
-      const whenGrid = document.createElement("div");
-      whenGrid.className = "cw-datetime-grid";
-
-      const dateInput = makeInput("date");
-      const timeInput = makeInput("time", { step: 60 });
-
-      fillDateTimeInputs(row.raw && row.raw.progress_at, dateInput, timeInput);
-
-      whenGrid.appendChild(dateInput);
-      whenGrid.appendChild(timeInput);
-      pop.appendChild(whenGrid);
-
-      const saveProgress = () => {
-        const posMs = parseTimeToMs(posInput.value);
-        const durMs = parseTimeToMs(durInput.value);
-        const percent = parseProgressPercent(percentInput.value);
-
-        row.raw.progress_ms = posMs != null && posMs > 0 ? posMs : null;
-        row.raw.duration_ms = durMs != null && durMs > 0 ? durMs : null;
-        row.raw.progress_percent = row.raw.progress_ms != null && row.raw.duration_ms != null
-          ? Math.round((row.raw.progress_ms / row.raw.duration_ms) * 1000) / 10
-          : percent;
-        row.raw.progress_at = dateTimeInputsToIso(dateInput.value, timeInput.value);
-        if (!row.raw.progress_at && (row.raw.progress_ms != null || row.raw.progress_percent != null)) row.raw.progress_at = new Date().toISOString().replace(/\.\d{3}Z$/, ".000Z");
-        finishExtraChange(row, displayEl, close);
-      };
-
-      appendPopupActions(pop, [
-        {
-          label: "Clear",
-          kind: "ghost",
-          onClick: () => {
-            for (const key of ["progress_ms", "duration_ms", "progress_percent", "progress_at"]) row.raw[key] = null;
-            finishExtraChange(row, displayEl, close);
-          }
-        },
-        { label: "Close", kind: "ghost", onClick: close },
-        { label: "Save", kind: "primary", onClick: saveProgress },
-      ]);
-
-      posInput.focus();
-    });
+    return editorExtraEditors.openProgressEditor(row, anchor, displayEl, extraEditorContext());
   }
 
   function openRatingEditor(row, anchor, displayEl) {
-    openPopup(anchor, (pop, close) => {
-      appendPopupTitle(pop, "Rating");
-
-      const grid = document.createElement("div");
-      grid.className = "cw-rating-grid";
-      const current = row.raw && row.raw.rating != null ? Number(row.raw.rating) : null;
-
-      for (let i = 1; i <= 10; i += 1) {
-        const pill = document.createElement("button");
-        pill.type = "button";
-        pill.className = "cw-rating-pill" + (current === i ? " active" : "");
-        pill.textContent = String(i);
-        pill.onclick = () => {
-          row.raw.rating = i;
-          finishExtraChange(row, displayEl, close);
-        };
-        grid.appendChild(pill);
-      }
-
-      pop.appendChild(grid);
-      appendPopupActions(pop, [
-        { label: "Clear", kind: "ghost", onClick: () => { row.raw.rating = null; finishExtraChange(row, displayEl, close); } },
-        { label: "Close", kind: "ghost", onClick: close },
-      ]);
-    });
+    return editorExtraEditors.openRatingEditor(row, anchor, displayEl, extraEditorContext());
   }
 
   function openTitleSearchEditor(row, anchor, refs) {
-    openPopup(anchor, (pop, close) => {
-      const title = document.createElement("div");
-      title.className = "cw-pop-title";
-      title.textContent = "Search metadata";
-      pop.appendChild(title);
-
-      const bar = document.createElement("div");
-      bar.className = "cw-search-bar";
-
-      const qInput = document.createElement("input");
-      qInput.type = "text";
-      qInput.id = "cw_meta_search_title";
-      qInput.name = qInput.id;
-      qInput.placeholder = "Title...";
-      qInput.value = row.title || "";
-      bar.appendChild(qInput);
-
-      const yearInput = document.createElement("input");
-      yearInput.type = "number";
-      yearInput.id = "cw_meta_search_year";
-      yearInput.name = yearInput.id;
-      yearInput.placeholder = "Year";
-      if (row.year) yearInput.value = row.year;
-      bar.appendChild(yearInput);
-
-      const typeSelect = document.createElement("select");
-      typeSelect.id = "cw_meta_search_type";
-      typeSelect.name = typeSelect.id;
-      [["movie", "Movie"], ["show", "Show"], ["anime", "Anime"]].forEach(([val, label]) => {
-        const opt = document.createElement("option");
-        opt.value = val;
-        opt.textContent = label;
-        typeSelect.appendChild(opt);
-      });
-      typeSelect.value = row.type === "anime" ? "anime" : row.type === "show" || row.type === "episode" ? "show" : "movie";
-      bar.appendChild(typeSelect);
-
-      pop.appendChild(bar);
-
-      const actions = document.createElement("div");
-      actions.className = "cw-pop-actions";
-
-      const searchBtn = document.createElement("button");
-      searchBtn.type = "button";
-      searchBtn.className = "cw-pop-btn primary";
-      searchBtn.textContent = "Search";
-      actions.appendChild(searchBtn);
-
-      const closeBtn = document.createElement("button");
-      closeBtn.type = "button";
-      closeBtn.className = "cw-pop-btn ghost";
-      closeBtn.textContent = "Close";
-      closeBtn.onclick = close;
-      actions.appendChild(closeBtn);
-
-      pop.appendChild(actions);
-
-      const status = document.createElement("div");
-      status.className = "cw-search-status";
-      pop.appendChild(status);
-
-      const resultsBox = document.createElement("div");
-      resultsBox.className = "cw-search-results";
-      pop.appendChild(resultsBox);
-
-      async function doSearch() {
-        const q = (qInput.value || "").trim();
-        const yearVal = parseInt(yearInput.value || "", 10);
-        if (q.length < 2) {
-          status.textContent = "Type at least 2 characters.";
-          resultsBox.innerHTML = "";
-          return;
-        }
-        const typ = String(typeSelect.value || "").toLowerCase();
-        const makeUrl = t => {
-          let u = `/api/metadata/search?q=${encodeURIComponent(q)}&typ=${encodeURIComponent(t)}`;
-          if (!Number.isNaN(yearVal)) u += `&year=${yearVal}`;
-          return u;
-        };
-
-        status.textContent = "Searching...";
-        resultsBox.innerHTML = "";
-        try {
-          let items = [];
-          if (typ === "anime") {
-            const [showRes, movieRes] = await Promise.all([fetchJSON(makeUrl("show")), fetchJSON(makeUrl("movie"))]);
-
-            const showOk = !!(showRes && showRes.ok !== false);
-            const movieOk = !!(movieRes && movieRes.ok !== false);
-
-            if (!showOk && !movieOk) {
-              const msg = (showRes && showRes.error) || (movieRes && movieRes.error) || "Search failed.";
-              status.textContent = msg;
-              return;
-            }
-
-            const a = showOk && Array.isArray(showRes.results) ? showRes.results : [];
-            const b = movieOk && Array.isArray(movieRes.results) ? movieRes.results : [];
-
-            items = [...a.map(x => ({ ...x, _resolve_entity: "show" })), ...b.map(x => ({ ...x, _resolve_entity: "movie" }))];
-
-            const seen = new Set();
-            items = items.filter(it => {
-              const k = `${String(it.tmdb || "")}:${String(it.type || "")}`;
-              if (!k || seen.has(k)) return false;
-              seen.add(k);
-              return true;
-            });
-          } else {
-            const data = await fetchJSON(makeUrl(typ));
-            if (!data || data.ok === false) {
-              status.textContent = data && data.error ? data.error : "Search failed.";
-              return;
-            }
-            items = Array.isArray(data.results) ? data.results : [];
-          }
-          if (!items.length) {
-            resultsBox.innerHTML = '<div class="cw-search-empty">No results.</div>';
-            status.textContent = "";
-            return;
-          }
-
-          resultsBox.innerHTML = "";
-          items.forEach(item => {
-            const btn = document.createElement("button");
-            btn.type = "button";
-            btn.className = "cw-search-item";
-
-            const posterWrap = document.createElement("div");
-            posterWrap.className = "cw-search-poster";
-
-            if (item.poster_path) {
-              const img = document.createElement("img");
-              img.src = `/art/tmdb/${item.type === "show" ? "tv" : "movie"}/${encodeURIComponent(String(item.tmdb))}?size=w92`;
-              img.alt = "";
-              img.onerror = () => {
-                img.remove();
-                const ph = document.createElement("div");
-                ph.className = "cw-search-poster-placeholder";
-                ph.textContent = item.type === "show" ? "TV" : "MOV";
-                posterWrap.appendChild(ph);
-              };
-              posterWrap.appendChild(img);
-            } else {
-              const ph = document.createElement("div");
-              ph.className = "cw-search-poster-placeholder";
-              ph.textContent = item.type === "show" ? "TV" : "MOV";
-              posterWrap.appendChild(ph);
-            }
-
-            btn.appendChild(posterWrap);
-
-            const content = document.createElement("div");
-            content.className = "cw-search-content";
-
-            const titleLine = document.createElement("div");
-            titleLine.className = "cw-search-title-line";
-
-            const t = document.createElement("div");
-            t.className = "cw-search-title";
-            const yearTxt = item.year ? ` (${item.year})` : "";
-            t.textContent = (item.title || "") + yearTxt;
-            titleLine.appendChild(t);
-
-            const tag2 = document.createElement("span");
-            tag2.className = "cw-search-tag";
-            tag2.textContent = item.type === "show" ? "Show" : "Movie";
-            titleLine.appendChild(tag2);
-
-            content.appendChild(titleLine);
-
-            const meta = document.createElement("div");
-            meta.className = "cw-search-meta";
-            const bits = [];
-            if (item.year) bits.push(String(item.year));
-            bits.push(item.type === "show" ? "TV" : "Movie");
-            if (item.tmdb) bits.push(`TMDb ${item.tmdb}`);
-            meta.textContent = bits.join(" - ");
-            content.appendChild(meta);
-
-            if (item.overview) {
-              const ov = document.createElement("div");
-              ov.className = "cw-search-overview";
-              ov.textContent = item.overview;
-              content.appendChild(ov);
-            }
-
-            btn.appendChild(content);
-
-            btn.onclick = async () => {
-              const picked = item;
-              const newTitle = picked.title || row.title || "";
-              row.title = newTitle;
-              row.raw.title = newTitle || null;
-              refs.titleIn.value = formatEpisodeVisualTitle(row) || newTitle;
-
-              if (picked.year) {
-                row.year = String(picked.year);
-                row.raw.year = picked.year;
-                refs.yearIn.value = row.year;
-              }
-
-              const wantsAnime = String(typeSelect.value || "").toLowerCase() === "anime";
-              const pickedType = String(picked.type || "movie").toLowerCase();
-
-              const newType = wantsAnime ? "anime" : pickedType;
-              const resolveEntity = wantsAnime ? picked._resolve_entity || pickedType || "movie" : newType;
-
-              row.type = newType;
-              row.raw.type = newType;
-              row.episode = false;
-              updateTypeDisplay(row, refs.typeBtn);
-
-              const tmdbId = picked.tmdb;
-              if (tmdbId != null) {
-                const tmdbStr = String(tmdbId);
-                row.tmdb = tmdbStr;
-                row.raw.ids = row.raw.ids || {};
-                row.raw.ids.tmdb = tmdbId;
-                if (refs.tmdbIn) refs.tmdbIn.value = tmdbStr;
-                const prevKey = (row.key || "").trim();
-                if (!prevKey || /^(tmdb|imdb|trakt|tvdb|slug):/i.test(prevKey)) {
-                  row.key = `tmdb:${tmdbStr}`;
-                  if (refs.keyIn) refs.keyIn.value = row.key;
-                }
-              }
-
-              if (tmdbId != null) {
-                try {
-                  const metaRes = await fetchJSON("/api/metadata/resolve", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ entity: resolveEntity, ids: { tmdb: tmdbId } }),
-                  });
-
-                  if (metaRes && metaRes.ok && metaRes.result && metaRes.result.ids) {
-                    const ids = metaRes.result.ids || {};
-                    row.raw.ids = row.raw.ids || {};
-
-                    if (ids.imdb) {
-                      row.imdb = ids.imdb;
-                      row.raw.ids.imdb = ids.imdb;
-                      refs.imdbIn.value = ids.imdb;
-                    }
-                    if (ids.tmdb) {
-                      const tVal = String(ids.tmdb);
-                      row.tmdb = tVal;
-                      row.raw.ids.tmdb = ids.tmdb;
-                      if (refs.tmdbIn) refs.tmdbIn.value = tVal;
-                      const prevKey = (row.key || "").trim();
-                      if (!prevKey || /^(tmdb|imdb|trakt|tvdb|slug):/i.test(prevKey)) {
-                        row.key = `tmdb:${tVal}`;
-                        if (refs.keyIn) refs.keyIn.value = row.key;
-                      }
-                    }
-                    if (ids.trakt) {
-                      const trVal = String(ids.trakt);
-                      row.trakt = trVal;
-                      row.raw.ids.trakt = ids.trakt;
-                      if (refs.traktIn) refs.traktIn.value = trVal;
-                    }
-                  }
-                } catch (err) {
-                  console.error("metadata resolve failed", err);
-                }
-              }
-
-              if (typeof refs.onApplied === "function") {
-                close();
-                refs.onApplied(row);
-                return;
-              }
-
-              markChanged();
-              setStatusSticky("Row updated from metadata", 2500);
-              close();
-              renderRows();
-            };
-
-            resultsBox.appendChild(btn);
-          });
-
-          status.textContent = `${items.length} result${items.length === 1 ? "" : "s"} found.`;
-        } catch (err) {
-          console.error("search failed", err);
-          status.textContent = "Search failed.";
-        }
-      }
-
-      searchBtn.onclick = () => doSearch();
-
-      qInput.addEventListener("keydown", ev => {
-        if (ev.key === "Enter") {
-          ev.preventDefault();
-          doSearch();
-        }
-      });
-
-      if ((row.title || "").trim().length >= 3) doSearch();
-      else status.textContent = "Enter a title and press Enter or Search.";
-    });
+    return editorMetadataReplacer.openTitleSearchEditor(row, anchor, refs, metadataReplacerContext());
   }
 
   function openTypeEditor(row, anchor) {
-    const locked = isRowLocked(row);
-
-    openPopup(anchor, (pop, close) => {
-      appendPopupTitle(pop, "Type");
-      if (locked) return renderLockedPopup(pop, close);
-
-      const grid = document.createElement("div");
-      grid.className = "cw-type-grid";
-      const current = (row.type || "").toLowerCase();
-      const allowed = allowedTypesForKind(state.kind);
-      const options = [
-        { key: "movie", label: "Movie" },
-        { key: "show", label: "Show" },
-        { key: "anime", label: "Anime" },
-        { key: "season", label: "Season" },
-        { key: "episode", label: "Episode" },
-      ].filter(o => allowed.includes(o.key));
-
-      options.forEach(opt => {
-        const pill = document.createElement("button");
-        pill.type = "button";
-        pill.className = "cw-type-pill" + (current === opt.key ? " active" : "");
-        pill.textContent = opt.label;
-        pill.onclick = () => {
-          row.type = opt.key;
-          row.raw.type = opt.key;
-          row.episode = opt.key === "episode";
-          finishPopupChange(close, true);
-        };
-        grid.appendChild(pill);
-      });
-
-      pop.appendChild(grid);
-      appendPopupActions(pop, [
-        {
-          label: "Clear",
-          kind: "ghost",
-          onClick: () => {
-            row.type = "";
-            row.raw.type = null;
-            row.episode = false;
-            finishPopupChange(close, true);
-          }
-        },
-        { label: "Close", kind: "ghost", onClick: close },
-      ]);
-    });
+    return editorRowEditor.openTypeEditor(row, anchor, rowEditorContext());
   }
 
   async function openRawFieldsModal(row) {
@@ -2362,413 +1221,16 @@
     }
   }
 
-  function compareValues(aVal, bVal) {
-    if (typeof aVal === "number" && typeof bVal === "number") {
-      if (aVal < bVal) return -1;
-      if (aVal > bVal) return 1;
-      return 0;
-    }
-    const aStr = aVal == null ? "" : String(aVal).toLowerCase();
-    const bStr = bVal == null ? "" : String(bVal).toLowerCase();
-    if (aStr < bStr) return -1;
-    if (aStr > bStr) return 1;
-    return 0;
-  }
-
   function sortRows(rows) {
-    const key = state.sortKey;
-    const dir = state.sortDir === "desc" ? -1 : 1;
-    if (!key) return rows;
-    return rows.slice().sort((a, b) => {
-      let av;
-      let bv;
-      if (key === "title") {
-        av = a.title || "";
-        bv = b.title || "";
-      } else if (key === "type") {
-        av = a.type || "";
-        bv = b.type || "";
-      } else if (key === "key") {
-        av = a.key || "";
-        bv = b.key || "";
-      } else if (key === "extra") {
-        if (state.kind === "ratings") {
-          av = a.raw && a.raw.rating != null ? Number(a.raw.rating) : -Infinity;
-          bv = b.raw && b.raw.rating != null ? Number(b.raw.rating) : -Infinity;
-        } else if (state.kind === "history") {
-          const aw = a.raw && a.raw.watched_at;
-          const bw = b.raw && b.raw.watched_at;
-          av = aw ? Date.parse(aw) || 0 : 0;
-          bv = bw ? Date.parse(bw) || 0 : 0;
-        } else {
-          av = "";
-          bv = "";
-        }
-      } else {
-        av = "";
-        bv = "";
-      }
-      return compareValues(av, bv) * dir;
-    });
+    return editorTableController.sortRows(rows, tableControllerContext());
   }
 
   function updateSortUI() {
-    sortHeaders.forEach(th => {
-      const k = th.dataset.sort;
-      th.classList.remove("sort-asc", "sort-desc");
-      if (k === state.sortKey) th.classList.add(state.sortDir === "desc" ? "sort-desc" : "sort-asc");
-    });
+    return editorTableController.updateSortUI(tableControllerContext());
   }
 
   function renderRows() {
-    closePopup();
-    updateSortUI();
-    syncIdColumnHeaders();
-
-    let filtered = applyFilter(state.rows);
-    const totalFiltered = filtered.length;
-    const totalAll = state.rows.length;
-    syncHeaderPills(totalFiltered, totalAll);
-
-    filtered = sortRows(filtered);
-
-    let movies = 0;
-    let shows = 0;
-    let seasons = 0;
-    let episodes = 0;
-    for (const row of state.rows) {
-      const t = (row.type || "").toLowerCase();
-      if (t === "movie") movies += 1;
-      else if (t === "show") shows += 1;
-      else if (t === "season") seasons += 1;
-      else if (t === "episode") episodes += 1;
-    }
-    if (summaryMovies) summaryMovies.textContent = String(movies);
-    if (summaryShows) summaryShows.textContent = String(shows);
-    if (summarySeasons) summarySeasons.textContent = String(seasons);
-    if (summaryEpisodes) summaryEpisodes.textContent = String(episodes);
-
-    if (tbody) tbody.innerHTML = "";
-
-    const actionHead = host.querySelector(".cw-action-head");
-    const wideActions = isPolicySource();
-    if (actionHead) {
-      actionHead.classList.toggle("cw-action-wide", wideActions);
-      actionHead.style.width = wideActions ? "132px" : "46px";
-    }
-
-    if (!totalFiltered) {
-      if (empty) empty.style.display = "block";
-      empty?.closest(".cw-main")?.classList.add("cw-main-empty");
-      if (pager) pager.style.display = "none";
-      if (summaryVisible) summaryVisible.textContent = "0";
-      if (summaryTotal) summaryTotal.textContent = String(totalAll || 0);
-      setStatus("0 rows visible");
-      state.pageRids = [];
-      syncSelectPageCheckbox();
-      clearSelection();
-      if (pageInfo) pageInfo.textContent = "";
-      return;
-    }
-
-    if (empty) empty.style.display = "none";
-    empty?.closest(".cw-main")?.classList.remove("cw-main-empty");
-
-    const pageCount = Math.max(1, Math.ceil(totalFiltered / PAGE_SIZE));
-    if (state.page >= pageCount) state.page = pageCount - 1;
-    if (state.page < 0) state.page = 0;
-
-    const start = state.page * PAGE_SIZE;
-    const end = start + PAGE_SIZE;
-    const rows = filtered.slice(start, end);
-
-    state.pageRids = rows.map(r => r._rid);
-    syncSelectPageCheckbox();
-    syncBulkBar();
-
-    const frag = document.createDocumentFragment();
-    const anilistMode = isAnilistMode();
-    rows.forEach(row => {
-      const tr = document.createElement("tr");
-      const locked = isRowLocked(row);
-      const fieldName = suffix => `cw-row-${row._rid || "new"}-${suffix}`;
-      if (row.episode) tr.classList.add("cw-row-episode");
-      if (row.deleted) tr.classList.add("cw-row-deleted");
-
-      const cell = inner => {
-        const td = document.createElement("td");
-        td.appendChild(inner);
-        return td;
-      };
-
-      const selCb = document.createElement("input");
-      selCb.type = "checkbox";
-      selCb.name = fieldName("selected");
-      selCb.className = "cw-checkbox";
-      selCb.checked = (state.selected || new Set()).has(row._rid);
-      selCb.onchange = () => {
-        if (!state.selected) state.selected = new Set();
-        if (selCb.checked) state.selected.add(row._rid);
-        else state.selected.delete(row._rid);
-        syncBulkBar();
-        syncSelectPageCheckbox();
-      };
-      tr.appendChild(cell(selCb));
-
-      const blockMode = isPolicySource();
-      const baselineRow = blockMode && row._origin === "baseline";
-      const delBtn = document.createElement("button");
-      delBtn.type = "button";
-      delBtn.className = "cw-btn cw-btn-del danger";
-      delBtn.innerHTML = `<span class="material-symbol">${blockMode ? "block" : "delete"}</span>`;
-      delBtn.title = blockMode
-        ? (baselineRow
-            ? (row.deleted ? "Restore for future syncs" : "Block from future syncs")
-            : (row.deleted ? "Restore row" : "Remove manual correction"))
-        : (row.deleted ? "Restore row" : "Delete row");
-      delBtn.onclick = () => {
-        row.deleted = !row.deleted;
-        markChanged();
-        renderRows();
-      };
-      const delTd = cell(delBtn);
-      delTd.className = "cw-action-cell";
-      if (wideActions) delTd.classList.add("cw-action-wide");
-      if (canReplaceRow(row)) {
-        const t = rowType(row);
-        const repBtn = document.createElement("button");
-        repBtn.type = "button";
-        repBtn.className = "cw-btn cw-btn-del";
-        repBtn.innerHTML = '<span class="material-symbol">published_with_changes</span>';
-        repBtn.title = t === "episode" ? "Replace episode" : t === "season" ? "Replace season" : "Replace item";
-        repBtn.style.marginLeft = "4px";
-        repBtn.onclick = () => openItemReplacer(row, repBtn);
-        delTd.appendChild(repBtn);
-      }
-      if (isPolicySource()) {
-        const rawBtn = document.createElement("button");
-        rawBtn.type = "button";
-        rawBtn.className = "cw-btn cw-btn-del";
-        rawBtn.innerHTML = '<span class="material-symbol">data_object</span>';
-        rawBtn.title = "Advanced fields";
-        rawBtn.setAttribute("aria-label", "Advanced fields");
-        rawBtn.style.marginLeft = "4px";
-        rawBtn.onclick = () => openRawFieldsModal(row);
-        delTd.appendChild(rawBtn);
-      }
-      tr.appendChild(delTd);
-
-      const keyIn = document.createElement("input");
-      keyIn.name = fieldName("key");
-      keyIn.value = row.key || "";
-      keyIn.className = "cw-key";
-      keyIn.disabled = locked;
-      keyIn.oninput = e => {
-        row.key = e.target.value;
-        markChanged();
-      };
-      tr.appendChild(cell(keyIn));
-
-      const typeBtn = document.createElement("button");
-      typeBtn.type = "button";
-      typeBtn.className = "cw-extra-display cw-type-display";
-      typeBtn.disabled = locked;
-      if (locked) {
-        typeBtn.style.opacity = "0.6";
-        typeBtn.style.cursor = "not-allowed";
-      }
-      updateTypeDisplay(row, typeBtn);
-      typeBtn.onclick = () => {
-        if (typeBtn.disabled) return;
-        openTypeEditor(row, typeBtn);
-      };
-      tr.appendChild(cell(typeBtn));
-
-      const titleCell = document.createElement("div");
-      titleCell.className = "cw-title-cell";
-
-      const titleRow = document.createElement("div");
-      titleRow.className = "cw-title-row";
-      titleCell.appendChild(titleRow);
-
-      const titleIn = document.createElement("input");
-      titleIn.name = fieldName("title");
-      titleIn.value = formatEpisodeVisualTitle(row) || row.title || "";
-      titleIn.disabled = locked;
-      titleIn.onfocus = () => {
-        const visual = formatEpisodeVisualTitle(row);
-        if (visual) titleIn.value = row.title || "";
-      };
-      titleIn.oninput = e => {
-        row.title = e.target.value;
-        row.raw.title = e.target.value || null;
-        markChanged();
-      };
-      titleIn.onblur = () => {
-        const visual = formatEpisodeVisualTitle(row);
-        if (visual) titleIn.value = visual;
-      };
-      titleRow.appendChild(titleIn);
-
-      const yearIn = document.createElement("input");
-      yearIn.name = fieldName("year");
-      yearIn.value = row.year || "";
-      yearIn.disabled = locked;
-      yearIn.oninput = e => {
-        row.year = e.target.value;
-        const v = e.target.value.trim();
-        const n = v ? parseInt(v, 10) : NaN;
-        row.raw.year = Number.isFinite(n) ? n : null;
-        markChanged();
-      };
-
-      const imdbIn = document.createElement("input");
-      imdbIn.name = fieldName("imdb");
-      imdbIn.value = row.imdb || "";
-      imdbIn.disabled = locked;
-      imdbIn.oninput = e => {
-        row.imdb = e.target.value;
-        row.raw.ids = row.raw.ids || {};
-        if (e.target.value) row.raw.ids.imdb = e.target.value;
-        else delete row.raw.ids.imdb;
-        markChanged();
-      };
-      const idAIn = document.createElement("input");
-      idAIn.name = fieldName(anilistMode ? "mal" : "tmdb");
-      idAIn.value = anilistMode ? (row.mal || "") : (row.tmdb || "");
-      idAIn.placeholder = anilistMode ? "MAL…" : "TMDB…";
-      idAIn.disabled = locked;
-      idAIn.oninput = e => {
-        const v = e.target.value;
-        row.raw.ids = row.raw.ids || {};
-        if (anilistMode) {
-          row.mal = v;
-          if (v) row.raw.ids.mal = v;
-          else delete row.raw.ids.mal;
-        } else {
-          row.tmdb = v;
-          if (v) row.raw.ids.tmdb = v;
-          else delete row.raw.ids.tmdb;
-        }
-        markChanged();
-      };
-
-      const idBIn = document.createElement("input");
-      idBIn.name = fieldName(anilistMode ? "anilist" : "trakt");
-      idBIn.value = anilistMode ? (row.anilist || "") : (row.trakt || "");
-      idBIn.placeholder = anilistMode ? "AniList…" : "Trakt…";
-      idBIn.disabled = locked;
-      idBIn.oninput = e => {
-        const v = e.target.value;
-        row.raw.ids = row.raw.ids || {};
-        if (anilistMode) {
-          row.anilist = v;
-          if (v) row.raw.ids.anilist = v;
-          else delete row.raw.ids.anilist;
-        } else {
-          row.trakt = v;
-          if (v) row.raw.ids.trakt = v;
-          else delete row.raw.ids.trakt;
-        }
-        markChanged();
-      };
-
-      const searchBtn = document.createElement("button");
-      searchBtn.type = "button";
-      searchBtn.className = "cw-title-search-btn";
-      searchBtn.innerHTML = '<span class="material-symbol">search</span>';
-      const searchUsesCorrection = locked && canReplaceRow(row);
-      searchBtn.title = searchUsesCorrection
-        ? (usesCoordinateReplacer(row) ? "Replace episode" : "Search and add correction")
-        : "Search and fill IDs";
-      searchBtn.disabled = locked && !searchUsesCorrection;
-      if (searchBtn.disabled) {
-        searchBtn.style.opacity = "0.6";
-        searchBtn.style.cursor = "not-allowed";
-      }
-      searchBtn.onclick = () => {
-        if (searchBtn.disabled) return;
-        if (searchUsesCorrection) {
-          openItemReplacer(row, searchBtn);
-          return;
-        }
-        openTitleSearchEditor(row, searchBtn, {
-          keyIn,
-          titleIn,
-          yearIn,
-          imdbIn,
-          tmdbIn: anilistMode ? null : idAIn,
-          traktIn: null,
-          typeBtn,
-        });
-      };
-      titleRow.appendChild(searchBtn);
-
-      const subType = (((row.raw && row.raw.type) || row.type || "") + "").toLowerCase();
-      if (subType === "season" && row.raw && row.raw.series_title) {
-        const sub = document.createElement("div");
-        sub.className = "cw-title-sub";
-        let label = row.raw.series_title;
-        const code = subType === "episode" ? formatSxxEyy(row.raw.season, row.raw.episode) : formatSxxEyy(row.raw.season, null);
-        if (code) label += " - " + code;
-        sub.textContent = label;
-        titleCell.appendChild(sub);
-      }
-      if (isTrackerSource() && row._origin !== "baseline") {
-        const origin = document.createElement("div");
-        origin.className = "cw-title-sub";
-        origin.textContent = "Manual correction";
-        titleCell.appendChild(origin);
-      }
-      tr.appendChild(cell(titleCell));
-
-      const yearTd = cell(yearIn);
-      yearTd.className = "cw-col-year";
-      tr.appendChild(yearTd);
-      tr.appendChild(cell(idAIn));
-
-      const extraBtn = document.createElement("button");
-      extraBtn.type = "button";
-      extraBtn.className = "cw-extra-display";
-      updateExtraDisplay(row, extraBtn);
-
-      const extraEditable = isExtraKindEditable();
-      if (!extraEditable) {
-        extraBtn.disabled = true;
-        extraBtn.style.opacity = "0.6";
-        extraBtn.style.cursor = "default";
-      } else if (state.kind === "ratings") {
-        extraBtn.onclick = () => openRatingEditor(row, extraBtn, extraBtn);
-      } else if (state.kind === "history") {
-        extraBtn.onclick = () => openHistoryEditor(row, extraBtn, extraBtn);
-      } else if (state.kind === "progress") {
-        extraBtn.onclick = () => openProgressEditor(row, extraBtn, extraBtn);
-      }
-
-      tr.appendChild(cell(extraBtn));
-
-      frag.appendChild(tr);
-    });
-
-    if (tbody) tbody.appendChild(frag);
-
-    const vis = rows.length;
-    const first = start + 1;
-    const last = start + vis;
-
-    if (summaryVisible) summaryVisible.textContent = String(vis);
-    if (summaryTotal) summaryTotal.textContent = String(totalAll);
-
-    if (pageInfo) pageInfo.textContent = `Page ${state.page + 1} of ${pageCount} • Rows ${first}-${last} of ${totalFiltered}`;
-    if (pager) pager.style.display = pageCount > 1 ? "flex" : "none";
-    if (prevBtn) prevBtn.disabled = state.page <= 0;
-    if (nextBtn) nextBtn.disabled = state.page >= pageCount - 1;
-
-    if (totalFiltered > vis) {
-      setRowsStatus(`${vis} rows visible (rows ${first}-${last} of ${totalFiltered} filtered, ${totalAll} total)`);
-    } else {
-      setRowsStatus(`${vis} rows visible, ${totalAll} total`);
-    }
+    return editorTableController.renderRows(tableControllerContext());
   }
 
   function formatSnapshotLabel(s) {
@@ -2792,602 +1254,81 @@
   }
 
   function playlistEndpointLabel(ep) {
-    if (!ep) return "Endpoint";
-    const name = String(ep.name || ep.id || "Endpoint");
-    const provider = String(ep.provider_label || ep.provider || "").trim();
-    const playlist = String(ep.playlist_name || ep.playlist_id || "").trim();
-    const type = String(ep.playlist_type || ep.resource_kind || ep.kind || "").trim();
-    const parts = [name];
-    if (provider) parts.push(provider);
-    if (playlist && playlist !== name) parts.push(playlist);
-    if (type) parts.push(type);
-    return parts.join(" - ");
+    return editorSources.playlistEndpointLabel(ep);
   }
 
   function rebuildSnapshots() {
-    if (!snapSel) return;
-    const isState = state.source === "state";
-    const isTracker = isTrackerSource();
-    const isPlaylist = state.source === "playlist";
-    if (snapLabel) snapLabel.textContent = isState ? "Provider" : "Endpoint";
-    syncSnapshotControlVisibility();
-    if (instanceLabel) instanceLabel.style.display = (isState || isTracker) ? "" : "none";
-    if (instanceSel) instanceSel.style.display = (isState || isTracker) ? "" : "none";
-    syncProfileIconSelect(instanceSel, isState || isTracker);
-
-    if (isTracker) {
-      const list = Array.isArray(state.trackerWorkspaces) ? state.trackerWorkspaces : [];
-      const options = list
-        .map(w => `<option value="${_escapeHtml(w && w.id)}">${_escapeHtml((w && w.label) || "Local tracker")}</option>`)
-        .join("");
-      snapSel.innerHTML = options || `<option value="">No workspaces</option>`;
-      const opts = Array.from(snapSel.options).map(o => o.value);
-      const next = opts.includes(state.workspace) ? state.workspace : opts[0] || "";
-      if (next !== state.workspace) state.workspace = next;
-      snapSel.value = state.workspace || "";
-      syncProviderIconSelect(snapSel, false);
-      syncSnapshotControlVisibility();
-      return;
-    }
-
-    if (isPlaylist) {
-      const list = Array.isArray(state.playlistEndpoints) ? state.playlistEndpoints : [];
-      const options = list
-        .map(ep => `<option value="${_escapeHtml(ep && ep.id)}">${_escapeHtml(playlistEndpointLabel(ep))}</option>`)
-        .join("");
-      snapSel.innerHTML = options || `<option value="">No endpoints</option>`;
-      const opts = Array.from(snapSel.options).map(o => o.value);
-      const next = opts.includes(state.snapshot) ? state.snapshot : opts[0] || "";
-      if (next !== state.snapshot) state.snapshot = next;
-      snapSel.value = state.snapshot || "";
-      syncProviderIconSelect(snapSel, false);
-      syncSnapshotControlVisibility();
-      return;
-    }
-
-    if (isState) {
-      const list = Array.isArray(state.snapshots) ? state.snapshots : [];
-      const options = list.map(p => `<option value="${p}">${providerLabel(p, p)}</option>`).join("");
-      snapSel.innerHTML = options;
-      const opts = Array.from(snapSel.options).map(o => o.value);
-      const next = opts.includes(state.snapshot) ? state.snapshot : opts[0] || "";
-      if (next !== state.snapshot) state.snapshot = next;
-      snapSel.value = state.snapshot || "";
-      syncProviderIconSelect(snapSel, isState);
-      syncSnapshotControlVisibility();
-      return;
-    }
+    return editorSources.rebuildSnapshots(sourceContext());
   }
 
 const on = (el, ev, fn) => el && el.addEventListener(ev, fn);
 
 async function fetchJSON(url, opts) {
-  if (window.cwIsAuthSetupPending?.() === true) throw new Error("auth setup pending");
-  const res = await fetch(url, Object.assign({ cache: "no-store" }, opts || {}));
-  if (!res.ok) {
-    let detail = "";
-    try {
-      const data = await res.json();
-      detail = data && (data.detail || data.error || data.message) ? String(data.detail || data.error || data.message) : "";
-    } catch (_) {}
-    throw new Error(detail || `Request failed: ${res.status}`);
-  }
-  return await res.json();
-}
-
-async function fetchBlob(url) {
-  const res = await fetch(url, { cache: "no-store" });
-  if (!res.ok) throw new Error(`Download failed: ${res.status}`);
-  return await res.blob();
-}
-
-function saveBlob(blob, filename) {
-  const href = URL.createObjectURL(blob);
-  const a = Object.assign(document.createElement("a"), { href, download: filename });
-  document.body.appendChild(a);
-  a.click();
-  setTimeout(() => {
-    URL.revokeObjectURL(href);
-    a.remove();
-  }, 0);
+  return editorFileUtils.fetchJSON(url, opts);
 }
 
 async function downloadFile(url, filename, toast) {
-  try {
-    setTag("warn", "Preparing download…");
-    saveBlob(await fetchBlob(url), filename);
-    setTag("loaded", "Ready");
-    if (toast && window.cxToast) window.cxToast(toast);
-  } catch (e) {
-    console.error(e);
-    setTag("error", "Download failed");
-    setStatus(String(e));
-  }
+  return editorFileUtils.downloadFile(url, filename, toast, { setTag, setStatus });
 }
 
-async function uploadJSON(url, file) {
-  const fd = new FormData();
-  fd.append("file", file);
-  const res = await fetch(url, { method: "POST", body: fd });
-  if (!res.ok) {
-    let msg = `Import failed: ${res.status}`;
-    try {
-      const err = await res.json();
-      if (err && err.detail) msg += ` – ${err.detail}`;
-    } catch (_) {}
-    throw new Error(msg);
-  }
-  return await res.json();
-}
-
-const listParts = (data, defs) => defs.flatMap(([k, label]) => data && data[k] != null ? [`${data[k]} ${label}${data[k] === 1 ? "" : "s"}`] : []);
+const listParts = (data, defs) => editorFileUtils.listParts(data, defs);
 
 function bindFileImport(btn, input, url, done) {
-  if (!btn || !input) return;
-  on(btn, "click", () => input.click());
-  on(input, "change", async () => {
-    const file = input.files && input.files[0];
-    if (!file) return;
-    try {
-      setTag("warn", "Importing…");
-      setStatus("");
-      await done(await uploadJSON(url, file));
-    } catch (e) {
-      console.error(e);
-      setTag("error", "Import failed");
-      setStatus(String(e));
-    } finally {
-      try { input.value = ""; } catch (_) {}
-    }
-  });
+  return editorFileUtils.bindFileImport(btn, input, url, done, { on, setTag, setStatus });
 }
 
   async function loadTrackerWorkspaces() {
-    try {
-      if (instanceSel) {
-        const nextInst = await loadInstanceOptions("CROSSWATCH", instanceSel, state.instance || "default");
-        if (nextInst !== state.instance) {
-          state.instance = nextInst;
-          persistUIState();
-        }
-      }
-      const params = new URLSearchParams({ provider_instance: state.instance || "default" });
-      const data = await fetchJSON(`/api/editor/tracker/workspaces?${params.toString()}`);
-      const list = Array.isArray(data && data.workspaces) ? data.workspaces : [];
-      state.trackerWorkspaces = list;
-      state.trackerAvailable = list.length > 0;
-      if (state.workspace && !list.some(w => String(w && w.id || "") === String(state.workspace))) {
-        state.workspace = "";
-        persistUIState();
-      }
-    } catch (_) {
-      state.trackerWorkspaces = [];
-      state.trackerAvailable = false;
-    }
-    ensureTrackerOption();
-    return state.trackerWorkspaces;
+    return editorSources.loadTrackerWorkspaces(sourceContext());
   }
 
   async function loadSnapshots() {
-    try {
-      if (isTrackerSource()) {
-        await loadTrackerWorkspaces();
-        rebuildSnapshots();
-        syncKindUI();
-        if (!state.trackerWorkspaces.length) showStateHint("tracker");
-        else showStateHint(null);
-        return;
-      }
-      if (state.source === "playlist") {
-        const data = await fetchJSON("/api/editor/playlists/endpoints");
-        state.playlistEndpoints = Array.isArray(data && data.endpoints) ? data.endpoints : [];
-        state.snapshots = state.playlistEndpoints;
-        rebuildSnapshots();
-        if (!state.playlistEndpoints.length) showStateHint("playlist");
-        else showStateHint(null);
-        return;
-      }
-      if (state.source === "state") {
-        const data = await fetchJSON(`/api/editor/state/providers`);
-        state.snapshots = Array.isArray(data.providers) ? data.providers : [];
-        rebuildSnapshots();
+    return editorSources.loadSnapshots(sourceContext());
+  }
 
-        const prov = state.snapshot || (snapSel ? (snapSel.value || "") : "");
-        if (prov) {
-          const nextInst = await loadInstanceOptions(prov, instanceSel, state.instance);
-          if (prov !== state.snapshot || nextInst !== state.instance) {
-            state.snapshot = prov;
-            state.instance = nextInst;
-            persistUIState();
-          }
-        } else {
-          const nextInst = renderInstanceOptions(instanceSel, [{ id: "default", label: "Default" }], "default");
-          if (state.instance !== nextInst) {
-            state.instance = nextInst;
-            persistUIState();
-          }
-        }
-
-        if (!state.snapshots.length) showStateHint("state");
-        else showStateHint(null);
-        return;
-      }
-      state.source = "state";
-      rebuildSnapshots();
-      return;
-    } catch (e) {
-      console.error(e);
-    }
+  function loadControllerContext() {
+    return {
+      state,
+      host,
+      snapSel,
+      instanceSel,
+      isTrackerSource,
+      isProviderPickerSource,
+      isPolicySource,
+      isManualSource,
+      normalizeSource,
+      fetchJSON,
+      buildRows,
+      buildManualOverrideRows,
+      loadSnapshots,
+      renderRows,
+      showStateHint,
+      setTag,
+      setStatus,
+      syncActionButtons,
+      syncHeaderPills,
+      syncProviderIconSelect,
+      syncProfileIconSelect,
+    };
   }
 
   async function settleStateView(maxAttempts = 3, delayMs = 300) {
-    if (state.source !== "state") return;
-    for (let i = 0; i < maxAttempts; i += 1) {
-      const missingProvider = !String(state.snapshot || "").trim();
-      const hasRows = Array.isArray(state.rows) && state.rows.length > 0;
-      const hasSnapshots = Array.isArray(state.snapshots) && state.snapshots.length > 0;
-      if (!missingProvider && (hasRows || !hasSnapshots)) return;
-      await new Promise(resolve => setTimeout(resolve, delayMs));
-      await loadSnapshots();
-      await loadState();
-    }
+    return editorLoadController.settleStateView(loadControllerContext(), maxAttempts, delayMs);
   }
 
   async function loadState() {
-    if (state.source === "playlist") {
-      const endpointId = String(state.snapshot || "").trim();
-      if (!endpointId) {
-        state.items = {};
-        state.rows = [];
-        state.selected = new Set();
-        state.pageRids = [];
-        state.ridSeq = 1;
-        state.hasChanges = false;
-        state.page = 0;
-        state.playlistResource = null;
-        state.playlistWarnings = [];
-        state.playlistOriginalKeys = [];
-        renderRows();
-        showStateHint("playlist");
-        setTag("loaded", "No endpoint");
-        setStatus("");
-        syncActionButtons();
-        return;
-      }
-    }
-    if (isTrackerSource() && !String(state.workspace || "").trim()) {
-      state.baselineItems = {};
-      state.manualAdds = {};
-      state.manualBlocks = [];
-      state.items = {};
-      state.rows = [];
-      state.selected = new Set();
-      state.pageRids = [];
-      state.ridSeq = 1;
-      state.hasChanges = false;
-      state.page = 0;
-      renderRows();
-      showStateHint("tracker");
-      setTag("loaded", "No workspace");
-      setStatus("");
-      syncActionButtons();
-      return;
-    }
-    state.source = normalizeSource(state.source);
-    state.loading = true;
-    setTag("warn", "Loading");
-    try {
-      const params = new URLSearchParams({ kind: state.kind, source: state.source });
-      if (state.source === "state" && state.snapshot) {
-        params.set("provider", state.snapshot);
-        params.set("provider_instance", state.instance || "default");
-      }
-      if (isTrackerSource()) {
-        params.set("workspace", state.workspace);
-        params.set("provider_instance", state.instance || "default");
-      }
-      if (state.source === "playlist" && state.snapshot) params.set("endpoint", state.snapshot);
-
-      const data = await fetchJSON(`/api/editor?${params.toString()}`);
-      if (data && data.ok === false) throw new Error(data.error || data.detail || "Load failed");
-
-      if (state.source === "playlist") {
-        state.playlistResource = data.resource || null;
-        state.playlistWarnings = Array.isArray(data.resource && data.resource.warnings) ? data.resource.warnings.map(String) : [];
-        state.playlistOriginalKeys = Array.isArray(data.original_keys) ? data.original_keys.map(String) : [];
-        state.items = data.items || {};
-        state.selected = new Set();
-        state.pageRids = [];
-        state.ridSeq = 1;
-        state.rows = buildRows(state.items);
-      } else if (isPolicySource()) {
-        if (state.source === "state" && data && typeof data.provider === "string" && data.provider.trim()) {
-          state.snapshot = data.provider.trim();
-          if (snapSel) {
-            snapSel.value = state.snapshot;
-            syncProviderIconSelect(snapSel, true);
-          }
-        }
-        if (isTrackerSource() && data && typeof data.workspace === "string" && data.workspace.trim()) {
-          state.workspace = data.workspace.trim();
-          if (snapSel) snapSel.value = state.workspace;
-        }
-        state.baselineItems = data.items || {};
-        state.manualAdds = data.manual_adds || {};
-        state.manualBlocks = Array.isArray(data.manual_blocks) ? data.manual_blocks : [];
-
-        if (isPolicySource() && data && typeof data.provider_instance === "string") {
-          state.instance = data.provider_instance;
-          if (instanceSel) {
-            instanceSel.value = state.instance;
-            syncProfileIconSelect(instanceSel, true);
-          }
-        }
-
-        const merged = Object.assign({}, state.baselineItems || {});
-        const manualKeys = new Set();
-        for (const [k, v] of Object.entries(state.manualAdds || {})) {
-          const key = String(k || "").trim();
-          if (!key) continue;
-          const existingKey = Object.keys(merged).find(x => String(x || "").toLowerCase() === key.toLowerCase());
-          const finalKey = existingKey || key;
-          merged[finalKey] = v;
-          manualKeys.add(finalKey.toLowerCase());
-        }
-
-        state.items = merged;
-        state.selected = new Set();
-        state.pageRids = [];
-        state.ridSeq = 1;
-        state.rows = buildRows(state.items);
-
-        const baselineKeys = new Set(Object.keys(state.baselineItems || {}));
-        const blocked = new Set(
-          (state.manualBlocks || []).map(x => String(x || "").trim()).filter(Boolean)
-        );
-
-        for (const row of state.rows) {
-          const rowKey = String(row.key || "").toLowerCase();
-          row._origin = manualKeys.has(rowKey) ? "manual" : baselineKeys.has(row.key) ? "baseline" : "manual";
-          if (row._origin === "baseline") row.deleted = blocked.has(row.key);
-        }
-      }
-
-      state.hasChanges = false;
-      state.page = 0;
-      renderRows();
-
-      if (isPolicySource()) {
-        const hasBaseline = state.baselineItems && Object.keys(state.baselineItems).length > 0;
-        const hasManual = state.manualAdds && Object.keys(state.manualAdds).length > 0;
-        const hasBlocks = Array.isArray(state.manualBlocks) && state.manualBlocks.length > 0;
-        const emptyMode = isTrackerSource() ? "tracker" : "state";
-        showStateHint(hasBaseline || hasManual || hasBlocks ? null : emptyMode);
-      } else if (state.source === "playlist") {
-        showStateHint(state.snapshot ? null : "playlist");
-      }
-
-      setTag("loaded", "Ready");
-      if (state.source === "playlist" && state.playlistWarnings.length) {
-        setStatus(state.playlistWarnings[0]);
-      }
-    } catch (e) {
-      console.error(e);
-      const msg = String(e || "");
-
-      if (
-        isTrackerSource() &&
-        (msg.includes("404") || /local tracker/i.test(msg) || /workspace/i.test(msg))
-      ) {
-        showStateHint("tracker");
-        state.baselineItems = {};
-        state.manualAdds = {};
-        state.manualBlocks = [];
-        state.items = {};
-        state.rows = [];
-        state.selected = new Set();
-        state.pageRids = [];
-        state.ridSeq = 1;
-        state.workspace = "";
-        renderRows();
-        setTag("warn", "No tracker data");
-        setStatus("");
-      } else if (
-        state.source === "state" &&
-        (msg.includes("404") || /state\.json/i.test(msg) || /missing state/i.test(msg))
-      ) {
-        showStateHint("state");
-        state.items = {};
-        state.rows = [];
-        renderRows();
-        setTag("warn", "Missing state");
-        setStatus("");
-      } else {
-        setTag("error", "Load failed");
-        setStatus(msg);
-      }
-    } finally {
-      state.loading = false;
-      syncActionButtons();
-    }
+    return editorLoadController.loadState(loadControllerContext());
   }
 
   function findRowsMissingKey() {
-    const missing = [];
-    for (const row of state.rows) {
-      if (row.deleted) continue;
-      const key = (row.key || "").trim();
-      if (key) continue;
-
-      const hasOther =
-        (row.title && row.title.trim()) ||
-        (row.type && row.type.trim()) ||
-        (row.year && String(row.year).trim()) ||
-        (row.imdb && row.imdb.trim()) ||
-        (row.tmdb && row.tmdb.trim()) ||
-        (row.trakt && row.trakt.trim());
-
-      if (hasOther) missing.push(row);
-    }
-    return missing;
+    return editorPersistence.findRowsMissingKey(state);
   }
 
   async function saveState() {
-    if (state.saving) return;
-
-    const missing = findRowsMissingKey();
-    if (missing.length) {
-      setTag("error", "Missing key");
-      setStatus(
-        `Cannot save: ${missing.length} row${missing.length === 1 ? "" : "s"} have data but no Key. Fill the Key or remove the row.`
-      );
-      if (window.cxToast) window.cxToast("Fill Key for all rows with data before saving");
-      return;
-    }
-
-    state.saving = true;
-    setTag("warn", "Saving");
-    syncActionButtons();
-
-    try {
-      const items = {};
-      const blocks = [];
-      const seenBlocks = new Set();
-
-      for (const row of state.rows) {
-        if (row.deleted) {
-          if (isPolicySource() && row._origin === "baseline") {
-            const k = (row.key || "").trim();
-            if (k) {
-              const kl = k.toLowerCase();
-              if (!seenBlocks.has(kl)) {
-                seenBlocks.add(kl);
-                blocks.push(k);
-              }
-            }
-          }
-          continue;
-        }
-
-        if (isPolicySource() && row._origin === "baseline") continue;
-
-        if (isPolicySource() && row._replacedKey) {
-          const rk = String(row._replacedKey).trim();
-          const rkl = rk.toLowerCase();
-          if (rk && !seenBlocks.has(rkl)) {
-            seenBlocks.add(rkl);
-            blocks.push(rk);
-          }
-        }
-
-        const key = (row.key || "").trim();
-        if (!key) continue;
-
-        const raw = row.raw || {};
-        const ids = raw.ids || {};
-
-        if (row.imdb) ids.imdb = row.imdb;
-        else delete ids.imdb;
-
-        if (row.tmdb) ids.tmdb = row.tmdb;
-        else delete ids.tmdb;
-
-        if (row.trakt) ids.trakt = row.trakt;
-        else delete ids.trakt;
-
-        raw.ids = ids;
-        raw.type = row.type || raw.type || null;
-        raw.title = row.title ? row.title : raw.title || null;
-
-        const y = (row.year || "").trim();
-        const n = y ? parseInt(y, 10) : NaN;
-        raw.year = Number.isFinite(n) ? n : null;
-
-        items[key] = raw;
-      }
-
-      const payload = { kind: state.kind, source: state.source, items };
-      if (state.source === "state") {
-        payload.provider = state.snapshot;
-        payload.provider_instance = state.instance || "default";
-        payload.blocks = blocks;
-      }
-      if (isTrackerSource()) {
-        payload.workspace = state.workspace;
-        payload.provider_instance = state.instance || "default";
-        payload.blocks = blocks;
-      }
-      if (state.source === "playlist") {
-        payload.endpoint = state.snapshot;
-        const currentKeys = new Set((state.playlistOriginalKeys || []).map(String));
-        const nextKeys = new Set(Object.keys(items));
-        const removals = Array.from(currentKeys).filter(k => !nextKeys.has(k)).length;
-        if (removals && state.playlistWarnings.length) {
-          const text = state.playlistWarnings.join("\n");
-          if (!window.confirm(`${text}\n\nRemove ${removals} item${removals === 1 ? "" : "s"} from this playlist endpoint?`)) {
-            state.saving = false;
-            setTag("warn", "Unsaved changes");
-            setStatus("Save cancelled");
-            syncActionButtons();
-            return;
-          }
-        }
-      }
-
-      const res = await fetchJSON("/api/editor", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-
-      state.hasChanges = false;
-      setTag("warn", "Saved");
-      if (state.source === "playlist") {
-        const added = Number(res.added || 0);
-        const removed = Number(res.removed || 0);
-        const reordered = Number(res.reordered || 0);
-        const unresolved = Number(res.unresolved_count || 0);
-        const parts = [`+${added}`, `-${removed}`];
-        if (reordered) parts.push(`${reordered} reordered`);
-        if (unresolved) parts.push(`${unresolved} unresolved`);
-        setStatus(`Applied playlist changes: ${parts.join(", ")}`);
-        await loadState();
-      } else if (isTrackerSource()) {
-        setStatus(`Saved ${res.count || Object.keys(items).length} corrections`);
-        await loadState();
-      } else {
-        setStatus(`Saved ${res.count || Object.keys(items).length} items`);
-        await loadSnapshots();
-      }
-    } catch (e) {
-      console.error(e);
-      setTag("error", "Save failed");
-      setStatus(String(e));
-    } finally {
-      state.saving = false;
-      syncActionButtons();
-    }
+    return editorPersistence.saveState(persistenceContext());
   }
 
   function addRow() {
-    const raw = { ids: {}, type: "movie", title: "", year: null };
-    state.rows.unshift({
-      _rid: state.ridSeq++,
-      key: "",
-      type: raw.type,
-      title: "",
-      year: "",
-      imdb: "",
-      tmdb: "",
-      trakt: "",
-      raw,
-      deleted: false,
-      episode: false,
-      _origin: isPolicySource() ? "manual" : "playlist",
-    });
-    state.page = 0;
-    markChanged();
-    renderRows();
+    return editorRowEditor.addRow(rowEditorContext());
   }
 
   on(prevBtn, "click", () => {
@@ -3485,7 +1426,7 @@ function bindFileImport(btn, input, url, done) {
       syncTypeFilterUI();
       syncStateBulkUI();
       clearSelection();
-      if (state.source !== "state" && !isTrackerSource()) state.snapshot = "";
+      if (!isProviderPickerSource() && !isTrackerSource()) state.snapshot = "";
       state.page = 0;
       persistUIState();
       await loadSnapshots();
@@ -3509,13 +1450,13 @@ function bindFileImport(btn, input, url, done) {
         return;
       }
       state.snapshot = snapSel.value || "";
-      if (state.source === "state") syncProviderIconSelect(snapSel, true);
-      if (state.source === "state") {
+      if (isProviderPickerSource()) syncProviderIconSelect(snapSel, true);
+      if (isProviderPickerSource()) {
         state.instance = await loadInstanceOptions(state.snapshot, instanceSel, state.instance);
         persistUIState();
       }
       state.page = 0;
-      if (state.source !== "state") persistUIState();
+      if (!isProviderPickerSource()) persistUIState();
       await loadState();
     });
   }
@@ -3567,43 +1508,25 @@ if (importProviderSel) {
     filterInput.addEventListener("input", () => {
       state.filter = filterInput.value || "";
       state.page = 0;
-      clearSelection();
       persistUIState();
       renderRows();
     });
   }
 
   function editorIsVisible() {
-    return !!host && !!document.getElementById("page-editor") && host.getClientRects().length > 0;
+    return editorLoadController.editorIsVisible(loadControllerContext());
   }
 
   function syncSelectedScopeFromControls() {
-    if (isTrackerSource()) {
-      state.workspace = (snapSel && snapSel.value) ? snapSel.value : state.workspace || "";
-      state.snapshot = "";
-      state.instance = (instanceSel && instanceSel.value) ? instanceSel.value : state.instance || "default";
-      return;
-    }
-    if (state.source === "state") {
-      state.snapshot = (snapSel && snapSel.value) ? snapSel.value : state.snapshot || "";
-      state.instance = (instanceSel && instanceSel.value) ? instanceSel.value : state.instance || "default";
-      return;
-    }
-    if (state.source === "playlist") {
-      state.snapshot = (snapSel && snapSel.value) ? snapSel.value : state.snapshot || "";
-      state.instance = "default";
-    }
+    return editorLoadController.syncSelectedScopeFromControls(loadControllerContext());
   }
 
   async function refreshEditor({ force = false } = {}) {
-    if (!force && (!editorIsVisible() || state.hasChanges || state.loading || state.saving)) return;
-    syncSelectedScopeFromControls();
-    state.page = 0;
-    await loadSnapshots();
-    await loadState();
-    await settleStateView();
-    state.lastSyncAt = Date.now();
-    syncHeaderPills();
+    return editorLoadController.refreshEditor(loadControllerContext(), { force });
+  }
+
+  function queueEditorRefresh(delay = 250) {
+    return editorLoadController.queueEditorRefresh(loadControllerContext(), delay);
   }
 
   if (reloadBtn) {
@@ -3621,15 +1544,6 @@ if (importProviderSel) {
         syncActionButtons();
       }
     });
-  }
-
-  let deferredRefreshTimer = null;
-  function queueEditorRefresh(delay = 250) {
-    if (deferredRefreshTimer) window.clearTimeout(deferredRefreshTimer);
-    deferredRefreshTimer = window.setTimeout(() => {
-      deferredRefreshTimer = null;
-      refreshEditor().catch(e => console.warn("[editor] refresh failed", e));
-    }, delay);
   }
 
   window.addEventListener("sync-complete", () => queueEditorRefresh(350));
@@ -3651,6 +1565,7 @@ if (importProviderSel) {
   on(bulkRemoveBtn, "click", () => bulkSetDeletedForSelected(true));
   on(bulkRestoreBtn, "click", () => bulkSetDeletedForSelected(false));
   on(bulkClearBtn, "click", () => { clearSelection(); renderRows(); });
+  on(bulkSendBtn, "click", () => openEditorSendModal());
   on(bulkBlockTypeBtn, "click", () => bulkSetBlocksByType(bulkTypeSel && bulkTypeSel.value, true));
   on(bulkUnblockTypeBtn, "click", () => bulkSetBlocksByType(bulkTypeSel && bulkTypeSel.value, false));
 

--- a/assets/js/editor/chrome.js
+++ b/assets/js/editor/chrome.js
@@ -1,0 +1,284 @@
+/* assets/js/editor/chrome.js */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const NS = (window.CW ||= {});
+  const Editor = (NS.Editor ||= {});
+
+  function esc(s) {
+    return String(s == null ? "" : s).replace(/[&<>"']/g, c => ({
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    }[c]));
+  }
+
+  function wireStaticLabels(root) {
+    if (!root) return;
+
+    const bindPrevLabel = (fieldId) => {
+      const field = root.querySelector(`#${fieldId}`);
+      const label = field?.previousElementSibling;
+      if (label?.tagName === "LABEL") label.htmlFor = fieldId;
+    };
+
+    bindPrevLabel("cw-source");
+    bindPrevLabel("cw-kind");
+    bindPrevLabel("cw-pair");
+    bindPrevLabel("cw-snapshot");
+    bindPrevLabel("cw-instance");
+
+    const convertGroupLabel = (cardId) => {
+      const field = root.querySelector(`#${cardId} .ins-kv`);
+      const label = field?.firstElementChild;
+      if (!field || label?.tagName !== "LABEL") return;
+      const title = document.createElement("div");
+      title.className = "field-label";
+      title.textContent = label.textContent || "";
+      label.replaceWith(title);
+    };
+
+    convertGroupLabel("cw-backup-card");
+    convertGroupLabel("cw-state-backup-card");
+  }
+
+  function prepareSourceOptions(root) {
+    const sourceSelect = document.getElementById("cw-source");
+    if (sourceSelect) {
+      sourceSelect.querySelector('option[value="pair"]')?.remove();
+      if (!sourceSelect.querySelector('option[value="manual"]')) {
+        const manualOpt = document.createElement("option");
+        manualOpt.value = "manual";
+        manualOpt.textContent = "Manual Overrides";
+        const trackerOpt = sourceSelect.querySelector('option[value="tracker"]');
+        if (trackerOpt) sourceSelect.insertBefore(manualOpt, trackerOpt);
+        else sourceSelect.appendChild(manualOpt);
+      } else {
+        sourceSelect.querySelector('option[value="manual"]').textContent = "Manual Overrides";
+      }
+      if (!sourceSelect.querySelector('option[value="tracker"]')) {
+        const trackerOpt = document.createElement("option");
+        trackerOpt.value = "tracker";
+        trackerOpt.textContent = "Local Tracker";
+        sourceSelect.appendChild(trackerOpt);
+      } else {
+        sourceSelect.querySelector('option[value="tracker"]').textContent = "Local Tracker";
+      }
+      if (!sourceSelect.querySelector('option[value="playlist"]')) {
+        const opt = document.createElement("option");
+        opt.value = "playlist";
+        opt.textContent = "Playlist Endpoint";
+        sourceSelect.appendChild(opt);
+      }
+    }
+
+    const sub = root?.querySelector(".cw-sub");
+    if (sub) sub.textContent = "Edit your current state or playlist endpoints";
+  }
+
+  function addTrackerNotice(root) {
+    if (!root || document.getElementById("cw-tracker-notice")) return;
+    const trackerNotice = document.createElement("div");
+    trackerNotice.id = "cw-tracker-notice";
+    trackerNotice.className = "cw-state-hint";
+    trackerNotice.style.display = "none";
+    trackerNotice.innerHTML =
+      "<strong>Local Tracker</strong> stores data inside CrossWatch. Changes here affect future syncs from Local Tracker but only for one-way syncs.";
+    root.querySelector(".cw-controls")?.insertAdjacentElement("afterend", trackerNotice);
+  }
+
+  function ensureFieldNames(root) {
+    root?.querySelectorAll("input,select,textarea").forEach((field, idx) => {
+      if (!field.name) field.name = field.id || `cw-field-${idx + 1}`;
+    });
+  }
+
+  function decorateImportPanel(ctx = {}) {
+    const details = document.getElementById("cw-import-details");
+    if (!details || details.dataset.decorated === "1") return;
+    details.dataset.decorated = "1";
+    details.classList.add("cw-import-panel");
+
+    const summary = details.querySelector("summary");
+    if (summary) {
+      summary.classList.add("cw-import-summary");
+      summary.innerHTML =
+        '<span class="cw-import-title">Import provider state</span>' +
+        '<span class="cw-import-help material-symbol" title="Imports selected Watchlist, History, Ratings, or Progress data from a configured provider profile into Current State. Replace baseline refreshes those datasets from the provider; Merge keeps existing baseline rows and adds or updates provider rows. Provider accounts are not changed." aria-label="Import provider state help">help</span>';
+    }
+
+    const body = summary ? summary.nextElementSibling : null;
+    if (body instanceof HTMLElement) {
+      body.classList.add("cw-import-body");
+      body.style.cssText = "";
+      const rows = Array.from(body.children).filter(el => el instanceof HTMLElement);
+      const fields = rows[0];
+      const actions = rows[1];
+      if (fields instanceof HTMLElement) {
+        fields.classList.add("cw-import-fields");
+        fields.style.cssText = "";
+      }
+      if (actions instanceof HTMLElement) {
+        actions.classList.add("cw-import-actions");
+        actions.style.cssText = "";
+      }
+    }
+
+    const wrapField = (el, label) => {
+      if (!(el instanceof HTMLElement) || el.parentElement?.classList.contains("cw-import-field")) return;
+      const field = document.createElement("label");
+      field.className = "cw-import-field";
+      const text = document.createElement("span");
+      text.className = "cw-import-field-label";
+      text.textContent = label;
+      el.parentNode.insertBefore(field, el);
+      field.append(text, el);
+    };
+
+    wrapField(ctx.importProviderSel, "Provider");
+    wrapField(ctx.importInstanceSel, "Profile");
+    wrapField(ctx.importModeSel, "Mode");
+
+    const featureWrap = document.createElement("div");
+    featureWrap.className = "cw-import-features";
+    [ctx.importWatchlistWrap, ctx.importHistoryWrap, ctx.importRatingsWrap, ctx.importProgressFeatWrap].forEach(wrap => {
+      if (!(wrap instanceof HTMLElement)) return;
+      wrap.classList.add("cw-import-feature");
+      wrap.style.cssText = "";
+      featureWrap.append(wrap);
+    });
+
+    const runRow = document.createElement("div");
+    runRow.className = "cw-import-run-row";
+    if (ctx.importRunBtn) runRow.append(ctx.importRunBtn);
+
+    const actions = details.querySelector(".cw-import-actions");
+    if (actions) {
+      actions.textContent = "";
+      actions.append(featureWrap, runRow);
+    }
+
+    if (ctx.importProgressWrap) ctx.importProgressWrap.classList.add("cw-import-progress-row");
+  }
+
+  function decoratePolicyBackupPanel(ctx = {}) {
+    const { stateBackupCard, importRow, stateDownloadBtn, stateUploadBtn, stateUploadInput } = ctx;
+    if (!stateBackupCard || stateBackupCard.dataset.decorated === "1") return;
+    stateBackupCard.dataset.decorated = "1";
+    stateBackupCard.className = "ins-row cw-policy-row";
+    if (importRow && importRow.parentNode && stateBackupCard.parentNode !== importRow.parentNode) {
+      importRow.insertAdjacentElement("afterend", stateBackupCard);
+    }
+
+    const details = document.createElement("details");
+    details.id = "cw-policy-details";
+    details.className = "cw-collapse cw-policy-panel";
+    details.style.width = "100%";
+
+    const summary = document.createElement("summary");
+    summary.className = "cw-import-summary";
+    summary.innerHTML =
+      '<span class="cw-import-title">Policy backup</span>' +
+      '<span class="cw-import-help material-symbol" title="Exports or imports the local Current State policy JSON used by manual baseline edits and block rules. It does not change provider accounts." aria-label="Policy backup help">help</span>';
+
+    const body = document.createElement("div");
+    body.className = "cw-policy-body";
+
+    const copy = document.createElement("div");
+    copy.className = "cw-policy-copy";
+    copy.textContent = "Export or import the local Current State policy as JSON.";
+
+    const actions = document.createElement("div");
+    actions.className = "cw-policy-actions";
+
+    const exportAction = document.createElement("div");
+    exportAction.className = "cw-policy-action";
+    exportAction.innerHTML = "<span>Export</span>";
+    if (stateDownloadBtn) exportAction.append(stateDownloadBtn);
+
+    const importAction = document.createElement("div");
+    importAction.className = "cw-policy-action";
+    importAction.innerHTML = "<span>Import</span>";
+    if (stateUploadBtn) importAction.append(stateUploadBtn);
+    if (stateUploadInput) importAction.append(stateUploadInput);
+
+    actions.append(exportAction, importAction);
+    body.append(copy, actions);
+    details.append(summary, body);
+    stateBackupCard.textContent = "";
+    stateBackupCard.append(details);
+  }
+
+  function decorateEditorChrome(ctx = {}) {
+    const typeIcons = {
+      movie: "movie",
+      show: "tv",
+      anime: "theater_comedy",
+      season: "layers",
+      episode: "play_circle",
+      blocked: "block",
+    };
+    const setButtonIcon = (btn, icon, label) => {
+      if (!btn) return;
+      btn.innerHTML = `<span class="material-symbols-rounded" aria-hidden="true">${icon}</span><span>${label}</span>`;
+      btn.setAttribute("aria-label", label);
+    };
+
+    setButtonIcon(ctx.addBtn, "add", "Add row");
+    setButtonIcon(ctx.saveBtn, "check", "Save changes");
+
+    const typeFilterWrap = ctx.typeFilterWrap;
+    if (typeFilterWrap && typeFilterWrap.dataset.decorated !== "1") {
+      typeFilterWrap.dataset.decorated = "1";
+      const field = typeFilterWrap.closest(".ins-kv");
+      const label = field?.querySelector(".field-label");
+      if (field && label) {
+        const shell = document.createElement("div");
+        shell.className = "cw-type-filter-shell";
+        const head = document.createElement("div");
+        head.className = "cw-type-filter-head";
+        const title = document.createElement("div");
+        title.className = "field-label";
+        title.textContent = label.textContent || "Types";
+        const clear = document.createElement("button");
+        clear.type = "button";
+        clear.className = "cw-type-filter-clear";
+        clear.innerHTML = 'Clear <span class="material-symbol" aria-hidden="true">filter_alt</span>';
+        clear.setAttribute("aria-label", "Clear type filters");
+        clear.addEventListener("click", () => {
+          ["movie", "show", "anime", "season", "episode"].forEach(t => {
+            ctx.state.typeFilter[t] = true;
+          });
+          ctx.state.blockedOnly = false;
+          ctx.syncTypeFilterUI?.();
+          ctx.state.page = 0;
+          ctx.persistUIState?.();
+          ctx.renderRows?.();
+        });
+        head.append(title, clear);
+        label.replaceWith(shell);
+        shell.append(head, typeFilterWrap);
+      }
+
+      typeFilterWrap.querySelectorAll("button").forEach(btn => {
+        const type = btn.dataset.type || (btn.id === "cw-blocked-only" ? "blocked" : "");
+        const text = (btn.textContent || "").trim();
+        btn.innerHTML =
+          `<span class="material-symbol cw-type-icon" aria-hidden="true">${typeIcons[type] || "category"}</span>` +
+          `<span>${esc(text)}</span>`;
+      });
+    }
+  }
+
+  Editor.Chrome = {
+    wireStaticLabels,
+    prepareSourceOptions,
+    addTrackerNotice,
+    ensureFieldNames,
+    decorateImportPanel,
+    decoratePolicyBackupPanel,
+    decorateEditorChrome,
+  };
+  window.CrossWatchEditorChrome = Editor.Chrome;
+})();

--- a/assets/js/editor/datetime.js
+++ b/assets/js/editor/datetime.js
@@ -1,0 +1,149 @@
+/* assets/js/editor/datetime.js */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const NS = (window.CW ||= {});
+  const Editor = (NS.Editor ||= {});
+
+  function pad2(n) {
+    return String(n).padStart(2, "0");
+  }
+
+  function formatHistoryLabel(iso) {
+    if (!iso) return "";
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return (
+      d.getUTCFullYear() +
+      "-" +
+      pad2(d.getUTCMonth() + 1) +
+      "-" +
+      pad2(d.getUTCDate()) +
+      " " +
+      pad2(d.getUTCHours()) +
+      ":" +
+      pad2(d.getUTCMinutes()) +
+      " UTC"
+    );
+  }
+
+  function formatSxxEyy(season, episode) {
+    const s = season == null ? NaN : parseInt(String(season), 10);
+    if (!Number.isFinite(s)) return "";
+    const e = episode == null ? NaN : parseInt(String(episode), 10);
+    if (Number.isFinite(e)) return `S${pad2(s)}E${pad2(e)}`;
+    return `S${pad2(s)}`;
+  }
+
+  function formatMs(ms) {
+    const n = ms == null ? NaN : Number(ms);
+    if (!Number.isFinite(n) || n <= 0) return "";
+    const total = Math.floor(n / 1000);
+    const h = Math.floor(total / 3600);
+    const m = Math.floor((total % 3600) / 60);
+    const s = total % 60;
+    if (h > 0) return `${h}:${pad2(m)}:${pad2(s)}`;
+    return `${m}:${pad2(s)}`;
+  }
+
+  const PROGRESS_PERCENT_KEYS = ["progress_percent", "progressPercent", "percent", "position_percent", "resume_percent"];
+
+  function clampProgressPercent(value) {
+    const n = value == null || value === "" ? NaN : Number(value);
+    return Number.isFinite(n) ? Math.max(0, Math.min(100, n)) : null;
+  }
+
+  function progressPercentValue(raw) {
+    if (!raw) return null;
+    const pm = Number(raw.progress_ms);
+    const dm = Number(raw.duration_ms);
+    if (Number.isFinite(pm) && pm > 0 && Number.isFinite(dm) && dm > 0) return clampProgressPercent((pm / dm) * 100);
+    for (const key of PROGRESS_PERCENT_KEYS) {
+      const n = clampProgressPercent(raw[key]);
+      if (n != null) return n;
+    }
+    return null;
+  }
+
+  function formatProgressPercent(value) {
+    const n = clampProgressPercent(value);
+    if (n == null) return "";
+    const rounded = Math.round(n * 10) / 10;
+    return `${Number.isInteger(rounded) ? Math.trunc(rounded) : rounded}%`;
+  }
+
+  function parseProgressPercent(v) {
+    const s = (v == null ? "" : String(v)).trim().replace(/%$/, "").trim();
+    return s ? clampProgressPercent(s) : null;
+  }
+
+  function parseTimeToMs(v) {
+    const s = (v == null ? "" : String(v)).trim();
+    if (!s) return null;
+
+    const lower = s.toLowerCase();
+    if (lower.endsWith("ms")) {
+      const num = parseFloat(lower.slice(0, -2));
+      return Number.isFinite(num) ? Math.max(0, Math.floor(num)) : null;
+    }
+
+    if (s.includes(":")) {
+      const parts = s.split(":").map(p => p.trim()).filter(Boolean);
+      if (!parts.length) return null;
+      const nums = parts.map(x => parseInt(x, 10));
+      if (nums.some(n => !Number.isFinite(n))) return null;
+
+      let sec = 0;
+      if (nums.length === 3) sec = nums[0] * 3600 + nums[1] * 60 + nums[2];
+      else if (nums.length === 2) sec = nums[0] * 60 + nums[1];
+      else sec = nums[0];
+      return Math.max(0, sec * 1000);
+    }
+
+    const num = parseFloat(s);
+    if (!Number.isFinite(num)) return null;
+    if (num >= 100000) return Math.max(0, Math.floor(num));
+    return Math.max(0, Math.floor(num * 1000));
+  }
+
+  function fillDateTimeInputs(iso, dateInput, timeInput) {
+    if (!iso) return;
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return;
+    dateInput.value = `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+    timeInput.value = `${pad2(d.getUTCHours())}:${pad2(d.getUTCMinutes())}`;
+  }
+
+  function dateTimeInputsToIso(dateValue, timeValue) {
+    if (!dateValue) return null;
+    const parts = dateValue.split("-");
+    const y = parseInt(parts[0], 10);
+    const m = parseInt(parts[1], 10);
+    const dDay = parseInt(parts[2], 10);
+    const [hhRaw, mmRaw] = (timeValue || "").split(":");
+    const hh = parseInt(hhRaw, 10) || 0;
+    const mm = parseInt(mmRaw, 10) || 0;
+    return new Date(Date.UTC(y, m - 1, dDay, hh, mm, 0)).toISOString().replace(/\.\d{3}Z$/, ".000Z");
+  }
+
+  function appendUtcHint(pop) {
+    const hint = document.createElement("div");
+    hint.className = "cw-search-status";
+    hint.textContent = "Times are shown and saved in UTC.";
+    pop.appendChild(hint);
+  }
+
+  Editor.DateTime = {
+    formatHistoryLabel,
+    formatSxxEyy,
+    formatMs,
+    clampProgressPercent,
+    progressPercentValue,
+    formatProgressPercent,
+    parseProgressPercent,
+    parseTimeToMs,
+    fillDateTimeInputs,
+    dateTimeInputsToIso,
+    appendUtcHint,
+  };
+  window.CrossWatchEditorDateTime = Editor.DateTime;
+})();

--- a/assets/js/editor/extra-editors.js
+++ b/assets/js/editor/extra-editors.js
@@ -1,0 +1,226 @@
+/* assets/js/editor/extra-editors.js */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const NS = (window.CW ||= {});
+  const Editor = (NS.Editor ||= {});
+
+  const DT = () => {
+    const dt = window.CW && window.CW.Editor && window.CW.Editor.DateTime;
+    if (!dt) throw new Error("Editor module missing: DateTime");
+    return dt;
+  };
+
+  function updateExtraDisplay(row, el, ctx = {}) {
+    const state = ctx.state || {};
+    const dt = DT();
+    let label = "";
+    let placeholder = "";
+    let icon = "";
+    if (state.kind === "ratings") {
+      icon = "star";
+      const r = row.raw && row.raw.rating;
+      if (r == null || r === "") placeholder = "Set rating";
+      else label = String(r) + "/10";
+    } else if (state.kind === "history") {
+      icon = "schedule";
+      const w = row.raw && row.raw.watched_at;
+      if (!w) placeholder = "Set time";
+      else label = dt.formatHistoryLabel ? dt.formatHistoryLabel(w) : String(w || "");
+    } else if (state.kind === "progress") {
+      icon = "play_circle";
+      const p = row.raw && row.raw.progress_ms;
+      const d = row.raw && row.raw.duration_ms;
+      const percent = dt.progressPercentValue ? dt.progressPercentValue(row.raw) : null;
+      const pm = p == null ? NaN : Number(p);
+      const dm = d == null ? NaN : Number(d);
+      if (!Number.isFinite(pm) || pm <= 0) {
+        if (percent != null) label = dt.formatProgressPercent ? dt.formatProgressPercent(percent) : `${percent}%`;
+        else placeholder = "Set progress";
+      }
+      else {
+        const left = dt.formatMs ? dt.formatMs(pm) : "";
+        const right = Number.isFinite(dm) && dm > 0 && dt.formatMs ? dt.formatMs(dm) : "";
+        const pct = percent != null && dt.formatProgressPercent ? ` (${dt.formatProgressPercent(percent)})` : "";
+        label = right ? `${left} / ${right}${pct}` : left;
+      }
+    } else {
+      placeholder = "";
+    }
+
+    el.innerHTML = "";
+    const text = document.createElement("span");
+    text.className = "cw-extra-display-label";
+    if (label) {
+      text.textContent = label;
+      text.classList.add("cw-extra-display-value");
+    } else {
+      text.textContent = placeholder || "";
+      text.classList.add("cw-extra-display-placeholder");
+    }
+    el.appendChild(text);
+
+    if (icon) {
+      const iconEl = document.createElement("span");
+      iconEl.className = "material-symbol cw-extra-display-icon";
+      iconEl.textContent = icon;
+      el.appendChild(iconEl);
+    }
+  }
+
+  function openHistoryEditor(row, anchor, displayEl, ctx = {}) {
+    const dt = DT();
+    ctx.openPopup(anchor, (pop, close) => {
+      ctx.appendPopupTitle(pop, "Watched at");
+      const grid = document.createElement("div");
+      grid.className = "cw-datetime-grid";
+
+      const dateInput = document.createElement("input");
+      dateInput.type = "date";
+      dateInput.id = "cw_history_date";
+      dateInput.name = dateInput.id;
+      const timeInput = document.createElement("input");
+      timeInput.type = "time";
+      timeInput.id = "cw_history_time";
+      timeInput.name = timeInput.id;
+      timeInput.step = 60;
+
+      dt.fillDateTimeInputs?.(row.raw && row.raw.watched_at, dateInput, timeInput);
+
+      grid.appendChild(dateInput);
+      grid.appendChild(timeInput);
+      pop.appendChild(grid);
+      dt.appendUtcHint?.(pop);
+
+      ctx.appendPopupActions(pop, [
+        { label: "Clear", kind: "ghost", onClick: () => { row.raw.watched_at = null; ctx.finishExtraChange(row, displayEl, close); } },
+        { label: "Close", kind: "ghost", onClick: close },
+        { label: "Save", kind: "primary", onClick: () => { row.raw.watched_at = dt.dateTimeInputsToIso?.(dateInput.value, timeInput.value) || null; ctx.finishExtraChange(row, displayEl, close); } },
+      ]);
+
+      dateInput.focus();
+    });
+  }
+
+  function openProgressEditor(row, anchor, displayEl, ctx = {}) {
+    const dt = DT();
+    ctx.openPopup(anchor, (pop, close) => {
+      ctx.appendPopupTitle(pop, "Progress");
+
+      const makeInput = (type, props = {}) => Object.assign(document.createElement("input"), { type, ...props });
+      const makeField = (label, child, extraClass = "") => {
+        const field = document.createElement("label");
+        field.className = `cw-progress-edit-field ${extraClass}`.trim();
+        const labelEl = Object.assign(document.createElement("span"), { className: "cw-progress-edit-label", textContent: label });
+        field.appendChild(labelEl);
+        field.appendChild(child);
+        return field;
+      };
+
+      const grid = document.createElement("div");
+      grid.className = "cw-progress-edit-grid";
+
+      const curPos = row.raw && row.raw.progress_ms;
+      const curDur = row.raw && row.raw.duration_ms;
+      const curPercent = dt.progressPercentValue ? dt.progressPercentValue(row.raw) : null;
+      const posInput = makeInput("text", { placeholder: "mm:ss", value: curPos != null && dt.formatMs ? dt.formatMs(curPos) : "" });
+      const durInput = makeInput("text", { placeholder: "mm:ss", value: curDur != null && dt.formatMs ? dt.formatMs(curDur) : "" });
+
+      grid.appendChild(makeField("Position", posInput));
+      grid.appendChild(makeField("Duration", durInput));
+      pop.appendChild(grid);
+
+      const percentInput = makeInput("number", {
+        min: "0",
+        max: "100",
+        step: "0.1",
+        placeholder: "0-100",
+        value: curPercent != null ? String(Math.round(curPercent * 10) / 10) : "",
+      });
+      const percentWrap = document.createElement("div");
+      percentWrap.className = "cw-progress-percent-wrap";
+      percentWrap.append(percentInput, Object.assign(document.createElement("span"), { className: "cw-progress-percent-suffix", textContent: "%" }));
+      pop.appendChild(makeField("Percent", percentWrap, "cw-progress-percent-field"));
+
+      ctx.appendPopupTitle(pop, "Updated at", "10px");
+
+      const whenGrid = document.createElement("div");
+      whenGrid.className = "cw-datetime-grid";
+
+      const dateInput = makeInput("date");
+      const timeInput = makeInput("time", { step: 60 });
+
+      dt.fillDateTimeInputs?.(row.raw && row.raw.progress_at, dateInput, timeInput);
+
+      whenGrid.appendChild(dateInput);
+      whenGrid.appendChild(timeInput);
+      pop.appendChild(whenGrid);
+      dt.appendUtcHint?.(pop);
+
+      const saveProgress = () => {
+        const posMs = dt.parseTimeToMs ? dt.parseTimeToMs(posInput.value) : null;
+        const durMs = dt.parseTimeToMs ? dt.parseTimeToMs(durInput.value) : null;
+        const percent = dt.parseProgressPercent ? dt.parseProgressPercent(percentInput.value) : null;
+
+        row.raw.progress_ms = posMs != null && posMs > 0 ? posMs : null;
+        row.raw.duration_ms = durMs != null && durMs > 0 ? durMs : null;
+        row.raw.progress_percent = row.raw.progress_ms != null && row.raw.duration_ms != null
+          ? Math.round((row.raw.progress_ms / row.raw.duration_ms) * 1000) / 10
+          : percent;
+        row.raw.progress_at = dt.dateTimeInputsToIso?.(dateInput.value, timeInput.value) || null;
+        if (!row.raw.progress_at && (row.raw.progress_ms != null || row.raw.progress_percent != null)) row.raw.progress_at = new Date().toISOString().replace(/\.\d{3}Z$/, ".000Z");
+        ctx.finishExtraChange(row, displayEl, close);
+      };
+
+      ctx.appendPopupActions(pop, [
+        {
+          label: "Clear",
+          kind: "ghost",
+          onClick: () => {
+            for (const key of ["progress_ms", "duration_ms", "progress_percent", "progress_at"]) row.raw[key] = null;
+            ctx.finishExtraChange(row, displayEl, close);
+          }
+        },
+        { label: "Close", kind: "ghost", onClick: close },
+        { label: "Save", kind: "primary", onClick: saveProgress },
+      ]);
+
+      posInput.focus();
+    });
+  }
+
+  function openRatingEditor(row, anchor, displayEl, ctx = {}) {
+    ctx.openPopup(anchor, (pop, close) => {
+      ctx.appendPopupTitle(pop, "Rating");
+
+      const grid = document.createElement("div");
+      grid.className = "cw-rating-grid";
+      const current = row.raw && row.raw.rating != null ? Number(row.raw.rating) : null;
+
+      for (let i = 1; i <= 10; i += 1) {
+        const pill = document.createElement("button");
+        pill.type = "button";
+        pill.className = "cw-rating-pill" + (current === i ? " active" : "");
+        pill.textContent = String(i);
+        pill.onclick = () => {
+          row.raw.rating = i;
+          ctx.finishExtraChange(row, displayEl, close);
+        };
+        grid.appendChild(pill);
+      }
+
+      pop.appendChild(grid);
+      ctx.appendPopupActions(pop, [
+        { label: "Clear", kind: "ghost", onClick: () => { row.raw.rating = null; ctx.finishExtraChange(row, displayEl, close); } },
+        { label: "Close", kind: "ghost", onClick: close },
+      ]);
+    });
+  }
+
+  Editor.ExtraEditors = {
+    updateExtraDisplay,
+    openHistoryEditor,
+    openProgressEditor,
+    openRatingEditor,
+  };
+  window.CrossWatchEditorExtraEditors = Editor.ExtraEditors;
+})();

--- a/assets/js/editor/file-utils.js
+++ b/assets/js/editor/file-utils.js
@@ -1,0 +1,90 @@
+/* assets/js/editor/file-utils.js */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const NS = (window.CW ||= {});
+  const Editor = (NS.Editor ||= {});
+
+  async function fetchJSON(url, opts) {
+    if (window.cwIsAuthSetupPending?.() === true) throw new Error("auth setup pending");
+    const res = await fetch(url, Object.assign({ cache: "no-store" }, opts || {}));
+    if (!res.ok) {
+      let detail = "";
+      try {
+        const data = await res.json();
+        detail = data && (data.detail || data.error || data.message) ? String(data.detail || data.error || data.message) : "";
+      } catch (_) {}
+      throw new Error(detail || `Request failed: ${res.status}`);
+    }
+    return await res.json();
+  }
+
+  async function fetchBlob(url) {
+    const res = await fetch(url, { cache: "no-store" });
+    if (!res.ok) throw new Error(`Download failed: ${res.status}`);
+    return await res.blob();
+  }
+
+  function saveBlob(blob, filename) {
+    const href = URL.createObjectURL(blob);
+    const a = Object.assign(document.createElement("a"), { href, download: filename });
+    document.body.appendChild(a);
+    a.click();
+    setTimeout(() => {
+      URL.revokeObjectURL(href);
+      a.remove();
+    }, 0);
+  }
+
+  async function downloadFile(url, filename, toast, ctx = {}) {
+    try {
+      ctx.setTag("warn", "Preparing download...");
+      saveBlob(await fetchBlob(url), filename);
+      ctx.setTag("loaded", "Ready");
+      if (toast && window.cxToast) window.cxToast(toast);
+    } catch (e) {
+      console.error(e);
+      ctx.setTag("error", "Download failed");
+      ctx.setStatus(String(e));
+    }
+  }
+
+  async function uploadJSON(url, file) {
+    const fd = new FormData();
+    fd.append("file", file);
+    const res = await fetch(url, { method: "POST", body: fd });
+    if (!res.ok) {
+      let msg = `Import failed: ${res.status}`;
+      try {
+        const err = await res.json();
+        if (err && err.detail) msg += ` - ${err.detail}`;
+      } catch (_) {}
+      throw new Error(msg);
+    }
+    return await res.json();
+  }
+
+  const listParts = (data, defs) => defs.flatMap(([k, label]) => data && data[k] != null ? [`${data[k]} ${label}${data[k] === 1 ? "" : "s"}`] : []);
+
+  function bindFileImport(btn, input, url, done, ctx = {}) {
+    if (!btn || !input) return;
+    ctx.on(btn, "click", () => input.click());
+    ctx.on(input, "change", async () => {
+      const file = input.files && input.files[0];
+      if (!file) return;
+      try {
+        ctx.setTag("warn", "Importing...");
+        ctx.setStatus("");
+        await done(await uploadJSON(url, file));
+      } catch (e) {
+        console.error(e);
+        ctx.setTag("error", "Import failed");
+        ctx.setStatus(String(e));
+      } finally {
+        try { input.value = ""; } catch (_) {}
+      }
+    });
+  }
+
+  Editor.FileUtils = { fetchJSON, fetchBlob, saveBlob, downloadFile, uploadJSON, listParts, bindFileImport };
+  window.CrossWatchEditorFileUtils = Editor.FileUtils;
+})();

--- a/assets/js/editor/importers.js
+++ b/assets/js/editor/importers.js
@@ -1,0 +1,200 @@
+/* assets/js/editor/importers.js */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const NS = (window.CW ||= {});
+  const Editor = (NS.Editor ||= {});
+
+  function stateOf(ctx) {
+    return (ctx && ctx.state) || {};
+  }
+
+  function setImportBusy(on, message, ctx = {}) {
+    if (ctx.importProgressWrap) ctx.importProgressWrap.style.display = on ? "" : "none";
+    if (ctx.importProgressText) ctx.importProgressText.textContent = message || "";
+    const disabled = !!on;
+    if (ctx.importRunBtn) ctx.importRunBtn.disabled = disabled;
+    if (ctx.importProviderSel) ctx.importProviderSel.disabled = disabled;
+    if (ctx.importModeSel) ctx.importModeSel.disabled = disabled;
+    if (ctx.importWatchlistCb) ctx.importWatchlistCb.disabled = disabled || ctx.importWatchlistCb.disabled;
+    if (ctx.importHistoryCb) ctx.importHistoryCb.disabled = disabled || ctx.importHistoryCb.disabled;
+    if (ctx.importRatingsCb) ctx.importRatingsCb.disabled = disabled || ctx.importRatingsCb.disabled;
+    if (ctx.importProgressCb) ctx.importProgressCb.disabled = disabled || ctx.importProgressCb.disabled;
+  }
+
+  function syncImportUI(ctx = {}) {
+    const state = stateOf(ctx);
+    if (!ctx.importRow) return;
+    const show = state.source === "state" && state.importEnabled;
+    ctx.importRow.style.display = show ? "" : "none";
+    if (!show) return;
+
+    if (ctx.importModeSel) ctx.importModeSel.value = state.importMode || "replace";
+
+    const all = Array.isArray(state.importProviders) ? state.importProviders : [];
+    const list = all.filter(p => p && p.configured && p.name);
+
+    if (ctx.importProviderSel) {
+      const current = ctx.importProviderSel.value || state.importProvider || "";
+      const opts = list
+        .map(p => {
+          const name = p && p.name ? String(p.name) : "";
+          const label = ctx.providerLabel?.(name, p && p.label ? String(p.label) : name) || name;
+          return `<option value="${name}">${label}</option>`;
+        })
+        .join("");
+
+      ctx.importProviderSel.innerHTML = opts || `<option value="">No configured providers</option>`;
+
+      const names = list.map(p => String(p.name));
+      let next = current;
+
+      if (!next || !names.includes(next)) {
+        next = state.snapshot && names.includes(state.snapshot) ? state.snapshot : "";
+      }
+      if (!next) next = names[0] || "";
+
+      state.importProvider = next;
+      ctx.importProviderSel.value = next;
+      ctx.importProviderSel.disabled = !names.length;
+      ctx.syncProviderIconSelect?.(ctx.importProviderSel, true);
+    }
+
+    const sel = state.importProvider || (ctx.importProviderSel ? ctx.importProviderSel.value : "");
+    const p = list.find(x => String((x || {}).name || "") === String(sel || ""));
+    const feats = (p && p.features) ? p.features : {};
+
+    if (ctx.importInstanceSel) {
+      const ids = (p && Array.isArray(p.instances)) ? p.instances : ["default"];
+      const instObjs = ids.map(x => ({ id: String(x), label: String(x) }));
+      const nextInst = ctx.renderInstanceOptions?.(ctx.importInstanceSel, instObjs, state.importProviderInstance);
+      if (nextInst !== state.importProviderInstance) {
+        state.importProviderInstance = nextInst;
+        ctx.persistUIState?.();
+      }
+      const instanceField = ctx.importInstanceSel.closest(".cw-import-field");
+      if (instanceField) instanceField.style.display = state.importProvider ? "" : "none";
+      else ctx.importInstanceSel.style.display = state.importProvider ? "" : "none";
+      ctx.syncProfileIconSelect?.(ctx.importInstanceSel, !!state.importProvider);
+    }
+
+    const setCb = (wrap, cb, key) => {
+      const supported = !!feats[key];
+      if (wrap) wrap.style.display = supported ? "" : "none";
+      if (!cb) return;
+      cb.disabled = !supported;
+      if (!supported) cb.checked = false;
+      else if (state.importFeatures && typeof state.importFeatures[key] === "boolean") cb.checked = !!state.importFeatures[key];
+    };
+
+    setCb(ctx.importWatchlistWrap, ctx.importWatchlistCb, "watchlist");
+    setCb(ctx.importHistoryWrap, ctx.importHistoryCb, "history");
+    setCb(ctx.importRatingsWrap, ctx.importRatingsCb, "ratings");
+    setCb(ctx.importProgressFeatWrap, ctx.importProgressCb, "progress");
+
+    if (ctx.importRunBtn) ctx.importRunBtn.disabled = !state.importProvider;
+  }
+
+  async function loadImportProviders(ctx = {}) {
+    const state = stateOf(ctx);
+    state.importEnabled = false;
+    state.importProviders = [];
+    if (!ctx.importRow) return;
+    try {
+      const data = await ctx.fetchJSON("/api/editor/state/import/providers");
+      state.importEnabled = !!(data && data.enabled);
+      state.importProviders = Array.isArray(data && data.providers) ? data.providers : [];
+    } catch (_) {
+      state.importEnabled = false;
+      state.importProviders = [];
+    }
+    syncImportUI(ctx);
+  }
+
+  function collectImportFeatures(ctx = {}) {
+    const feats = [];
+    if (ctx.importWatchlistCb && ctx.importWatchlistCb.checked && !ctx.importWatchlistCb.disabled) feats.push("watchlist");
+    if (ctx.importHistoryCb && ctx.importHistoryCb.checked && !ctx.importHistoryCb.disabled) feats.push("history");
+    if (ctx.importRatingsCb && ctx.importRatingsCb.checked && !ctx.importRatingsCb.disabled) feats.push("ratings");
+    if (ctx.importProgressCb && ctx.importProgressCb.checked && !ctx.importProgressCb.disabled) feats.push("progress");
+    return feats;
+  }
+
+  async function runStateImport(ctx = {}) {
+    const state = stateOf(ctx);
+    if (state.source !== "state") return;
+    const provider = (ctx.importProviderSel ? ctx.importProviderSel.value : state.importProvider) || "";
+    const features = collectImportFeatures(ctx);
+    const mode = (ctx.importModeSel ? ctx.importModeSel.value : state.importMode) || "replace";
+
+    if (!provider) {
+      ctx.setStatusSticky?.("Pick a provider first", 3000);
+      return;
+    }
+    if (!features.length) {
+      ctx.setStatusSticky?.("Pick at least one dataset", 3000);
+      return;
+    }
+
+    state.importProvider = provider;
+    state.importMode = mode;
+    state.importFeatures = {
+      watchlist: features.includes("watchlist"),
+      history: features.includes("history"),
+      ratings: features.includes("ratings"),
+      progress: features.includes("progress"),
+    };
+
+    try {
+      const msg = `Importing ${features.join(", ")} from ${provider}...`;
+      setImportBusy(true, msg, ctx);
+      ctx.setTag?.("warn", "Importing...");
+      ctx.setStatus?.(msg);
+
+      const res = await ctx.fetchJSON("/api/editor/state/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider, provider_instance: state.importProviderInstance || "default", features, mode }),
+      });
+
+      const featsOut = (res && res.features) ? res.features : {};
+      const bits = [];
+      let totalMs = 0;
+
+      for (const k of Object.keys(featsOut)) {
+        const r = featsOut[k] || {};
+        if (r.skipped) continue;
+        if (r.ok) bits.push(`${k}:${r.count}`);
+        if (typeof r.elapsed_ms === "number") totalMs += r.elapsed_ms;
+      }
+
+      let done = "Imported " + (bits.length ? bits.join(" - ") : "done");
+      if (totalMs) done += ` (${(totalMs / 1000).toFixed(1)}s)`;
+
+      ctx.setTag?.("loaded", "Imported");
+      ctx.setStatusSticky?.(done, 6000);
+      if (window.cxToast) window.cxToast(done);
+
+      state.snapshot = provider;
+      state.instance = state.importProviderInstance || "default";
+      ctx.persistUIState?.();
+      await ctx.loadSnapshots?.();
+      await ctx.loadState?.();
+    } catch (e) {
+      console.error(e);
+      ctx.setTag?.("error", "Import failed");
+      ctx.setStatus?.(String(e));
+    } finally {
+      setImportBusy(false, "", ctx);
+      syncImportUI(ctx);
+    }
+  }
+
+  Editor.Importers = {
+    setImportBusy,
+    syncImportUI,
+    loadImportProviders,
+    collectImportFeatures,
+    runStateImport,
+  };
+  window.CrossWatchEditorImporters = Editor.Importers;
+})();

--- a/assets/js/editor/load-controller.js
+++ b/assets/js/editor/load-controller.js
@@ -1,0 +1,261 @@
+/* assets/js/editor/load-controller.js */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const NS = (window.CW ||= {});
+  const Editor = (NS.Editor ||= {});
+  let deferredRefreshTimer = null;
+
+  function editorIsVisible(ctx = {}) {
+    const host = ctx.host;
+    return !!host && !!document.getElementById("page-editor") && host.getClientRects().length > 0;
+  }
+
+  function syncSelectedScopeFromControls(ctx = {}) {
+    const state = ctx.state;
+    if (ctx.isTrackerSource()) {
+      state.workspace = (ctx.snapSel && ctx.snapSel.value) ? ctx.snapSel.value : state.workspace || "";
+      state.snapshot = "";
+      state.instance = (ctx.instanceSel && ctx.instanceSel.value) ? ctx.instanceSel.value : state.instance || "default";
+      return;
+    }
+    if (ctx.isProviderPickerSource()) {
+      state.snapshot = (ctx.snapSel && ctx.snapSel.value) ? ctx.snapSel.value : state.snapshot || "";
+      state.instance = (ctx.instanceSel && ctx.instanceSel.value) ? ctx.instanceSel.value : state.instance || "default";
+      return;
+    }
+    if (state.source === "playlist") {
+      state.snapshot = (ctx.snapSel && ctx.snapSel.value) ? ctx.snapSel.value : state.snapshot || "";
+      state.instance = "default";
+    }
+  }
+
+  async function settleStateView(ctx = {}, maxAttempts = 3, delayMs = 300) {
+    const state = ctx.state;
+    if (state.source !== "state") return;
+    for (let i = 0; i < maxAttempts; i += 1) {
+      const missingProvider = !String(state.snapshot || "").trim();
+      const hasRows = Array.isArray(state.rows) && state.rows.length > 0;
+      const hasSnapshots = Array.isArray(state.snapshots) && state.snapshots.length > 0;
+      if (!missingProvider && (hasRows || !hasSnapshots)) return;
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+      await ctx.loadSnapshots();
+      await loadState(ctx);
+    }
+  }
+
+  async function loadState(ctx = {}) {
+    const state = ctx.state;
+    if (state.source === "playlist") {
+      const endpointId = String(state.snapshot || "").trim();
+      if (!endpointId) {
+        state.items = {};
+        state.rows = [];
+        state.selected = new Set();
+        state.pageRids = [];
+        state.ridSeq = 1;
+        state.hasChanges = false;
+        state.page = 0;
+        state.playlistResource = null;
+        state.playlistWarnings = [];
+        state.playlistOriginalKeys = [];
+        ctx.renderRows();
+        ctx.showStateHint("playlist");
+        ctx.setTag("loaded", "No endpoint");
+        ctx.setStatus("");
+        ctx.syncActionButtons();
+        return;
+      }
+    }
+    if (ctx.isTrackerSource() && !String(state.workspace || "").trim()) {
+      state.baselineItems = {};
+      state.manualAdds = {};
+      state.manualBlocks = [];
+      state.items = {};
+      state.rows = [];
+      state.selected = new Set();
+      state.pageRids = [];
+      state.ridSeq = 1;
+      state.hasChanges = false;
+      state.page = 0;
+      ctx.renderRows();
+      ctx.showStateHint("tracker");
+      ctx.setTag("loaded", "No workspace");
+      ctx.setStatus("");
+      ctx.syncActionButtons();
+      return;
+    }
+    state.source = ctx.normalizeSource(state.source);
+    state.loading = true;
+    ctx.setTag("warn", "Loading");
+    try {
+      const params = new URLSearchParams({ kind: state.kind, source: state.source });
+      if (ctx.isProviderPickerSource() && state.snapshot) {
+        params.set("provider", state.snapshot);
+        params.set("provider_instance", state.instance || "default");
+      }
+      if (ctx.isTrackerSource()) {
+        params.set("workspace", state.workspace);
+        params.set("provider_instance", state.instance || "default");
+      }
+      if (state.source === "playlist" && state.snapshot) params.set("endpoint", state.snapshot);
+
+      const data = await ctx.fetchJSON(`/api/editor?${params.toString()}`);
+      if (data && data.ok === false) throw new Error(data.error || data.detail || "Load failed");
+
+      if (state.source === "playlist") {
+        state.playlistResource = data.resource || null;
+        state.playlistWarnings = Array.isArray(data.resource && data.resource.warnings) ? data.resource.warnings.map(String) : [];
+        state.playlistOriginalKeys = Array.isArray(data.original_keys) ? data.original_keys.map(String) : [];
+        state.items = data.items || {};
+        state.selected = new Set();
+        state.pageRids = [];
+        state.ridSeq = 1;
+        state.rows = ctx.buildRows(state.items);
+      } else if (ctx.isPolicySource()) {
+        if (ctx.isProviderPickerSource() && data && typeof data.provider === "string" && data.provider.trim()) {
+          state.snapshot = data.provider.trim();
+          if (ctx.snapSel) {
+            ctx.snapSel.value = state.snapshot;
+            ctx.syncProviderIconSelect(ctx.snapSel, true);
+          }
+        }
+        if (ctx.isTrackerSource() && data && typeof data.workspace === "string" && data.workspace.trim()) {
+          state.workspace = data.workspace.trim();
+          if (ctx.snapSel) ctx.snapSel.value = state.workspace;
+        }
+        state.baselineItems = data.items || {};
+        state.manualAdds = data.manual_adds || {};
+        state.manualBlocks = Array.isArray(data.manual_blocks) ? data.manual_blocks : [];
+
+        if (ctx.isPolicySource() && data && typeof data.provider_instance === "string") {
+          state.instance = data.provider_instance;
+          if (ctx.instanceSel) {
+            ctx.instanceSel.value = state.instance;
+            ctx.syncProfileIconSelect(ctx.instanceSel, true);
+          }
+        }
+
+        state.selected = new Set();
+        state.pageRids = [];
+        state.ridSeq = 1;
+        if (ctx.isManualSource()) {
+          state.items = Object.assign({}, state.manualAdds || {});
+          state.rows = ctx.buildManualOverrideRows(state.items, state.manualBlocks || []);
+        } else {
+          const merged = Object.assign({}, state.baselineItems || {});
+          const manualKeys = new Set();
+          for (const [k, v] of Object.entries(state.manualAdds || {})) {
+            const key = String(k || "").trim();
+            if (!key) continue;
+            const existingKey = Object.keys(merged).find(x => String(x || "").toLowerCase() === key.toLowerCase());
+            const finalKey = existingKey || key;
+            merged[finalKey] = v;
+            manualKeys.add(finalKey.toLowerCase());
+          }
+
+          state.items = merged;
+          state.rows = ctx.buildRows(state.items);
+
+          const baselineKeys = new Set(Object.keys(state.baselineItems || {}));
+          const blocked = new Set(
+            (state.manualBlocks || []).map(x => String(x || "").trim()).filter(Boolean)
+          );
+
+          for (const row of state.rows) {
+            const rowKey = String(row.key || "").toLowerCase();
+            row._origin = manualKeys.has(rowKey) ? "manual" : baselineKeys.has(row.key) ? "baseline" : "manual";
+            if (row._origin === "baseline") row.deleted = blocked.has(row.key);
+          }
+        }
+      }
+
+      state.hasChanges = false;
+      state.page = 0;
+      ctx.renderRows();
+
+      if (ctx.isPolicySource()) {
+        const hasBaseline = state.baselineItems && Object.keys(state.baselineItems).length > 0;
+        const hasManual = state.manualAdds && Object.keys(state.manualAdds).length > 0;
+        const hasBlocks = Array.isArray(state.manualBlocks) && state.manualBlocks.length > 0;
+        const emptyMode = ctx.isManualSource() ? "manual" : ctx.isTrackerSource() ? "tracker" : "state";
+        ctx.showStateHint(hasBaseline || hasManual || hasBlocks ? null : emptyMode);
+      } else if (state.source === "playlist") {
+        ctx.showStateHint(state.snapshot ? null : "playlist");
+      }
+
+      ctx.setTag("loaded", "Ready");
+      if (state.source === "playlist" && state.playlistWarnings.length) {
+        ctx.setStatus(state.playlistWarnings[0]);
+      }
+    } catch (e) {
+      console.error(e);
+      const msg = String(e || "");
+
+      if (
+        ctx.isTrackerSource() &&
+        (msg.includes("404") || /local tracker/i.test(msg) || /workspace/i.test(msg))
+      ) {
+        ctx.showStateHint("tracker");
+        state.baselineItems = {};
+        state.manualAdds = {};
+        state.manualBlocks = [];
+        state.items = {};
+        state.rows = [];
+        state.selected = new Set();
+        state.pageRids = [];
+        state.ridSeq = 1;
+        state.workspace = "";
+        ctx.renderRows();
+        ctx.setTag("warn", "No tracker data");
+        ctx.setStatus("");
+      } else if (
+        state.source === "state" &&
+        (msg.includes("404") || /state\.json/i.test(msg) || /missing state/i.test(msg))
+      ) {
+        ctx.showStateHint("state");
+        state.items = {};
+        state.rows = [];
+        ctx.renderRows();
+        ctx.setTag("warn", "Missing state");
+        ctx.setStatus("");
+      } else {
+        ctx.setTag("error", "Load failed");
+        ctx.setStatus(msg);
+      }
+    } finally {
+      state.loading = false;
+      ctx.syncActionButtons();
+    }
+  }
+
+  async function refreshEditor(ctx = {}, options = {}) {
+    const state = ctx.state;
+    const force = !!options.force;
+    if (!force && (!editorIsVisible(ctx) || state.hasChanges || state.loading || state.saving)) return;
+    syncSelectedScopeFromControls(ctx);
+    state.page = 0;
+    await ctx.loadSnapshots();
+    await loadState(ctx);
+    await settleStateView(ctx);
+    state.lastSyncAt = Date.now();
+    ctx.syncHeaderPills();
+  }
+
+  function queueEditorRefresh(ctx = {}, delay = 250) {
+    if (deferredRefreshTimer) window.clearTimeout(deferredRefreshTimer);
+    deferredRefreshTimer = window.setTimeout(() => {
+      deferredRefreshTimer = null;
+      refreshEditor(ctx).catch(e => console.warn("[editor] refresh failed", e));
+    }, delay);
+  }
+
+  Editor.LoadController = {
+    editorIsVisible,
+    syncSelectedScopeFromControls,
+    settleStateView,
+    loadState,
+    refreshEditor,
+    queueEditorRefresh,
+  };
+  window.CrossWatchEditorLoadController = Editor.LoadController;
+})();

--- a/assets/js/editor/metadata-replacer.js
+++ b/assets/js/editor/metadata-replacer.js
@@ -1,0 +1,585 @@
+/* assets/js/editor/metadata-replacer.js */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const NS = (window.CW ||= {});
+  const Editor = (NS.Editor ||= {});
+
+  const REPLACEABLE_TYPES = ["movie", "show", "anime", "season", "episode"];
+  const EPISODE_ID_FIELDS = [
+    { key: "tvdb", label: "TVDB episode ID" },
+    { key: "tmdb", label: "TMDB episode ID" },
+    { key: "simkl", label: "SIMKL episode ID" },
+  ];
+  const PROVIDER_HISTORY_ID_FIELDS = [
+    "_trakt_history_id",
+    "history_id",
+    "_simkl_history_id",
+    "_plex_history_id",
+    "watched_id",
+    "play_id",
+  ];
+
+  function rowType(row) {
+    return String((row && row.type) || "").toLowerCase();
+  }
+
+  function canReplaceRow(row, ctx = {}) {
+    if (typeof ctx.isPolicySource === "function" && !ctx.isPolicySource()) return false;
+    return REPLACEABLE_TYPES.includes(rowType(row));
+  }
+
+  function usesCoordinateReplacer(row) {
+    const t = rowType(row);
+    return t === "episode" || t === "season";
+  }
+
+  function coordinateKeyFor(row, season, episode) {
+    const base = String((row && row.key) || "").split("#")[0].trim();
+    if (!base) return "";
+    if (rowType(row) === "season") return `${base}#season:${season}`;
+    const s = String(Math.max(0, season)).padStart(2, "0");
+    const e = String(Math.max(0, episode)).padStart(2, "0");
+    return `${base}#s${s}e${e}`;
+  }
+
+  function carryOverFields(row, drop) {
+    const src = (row && row.raw) || {};
+    const out = {};
+    for (const [k, v] of Object.entries(src)) {
+      if (drop.includes(k) || PROVIDER_HISTORY_ID_FIELDS.includes(k)) continue;
+      out[k] = JSON.parse(JSON.stringify(v === undefined ? null : v));
+    }
+    return out;
+  }
+
+  function correctedEpisodeItem(row, season, episode, watchedAt, extraIds) {
+    const isSeason = rowType(row) === "season";
+    const out = carryOverFields(row, ["ids", "season", "episode", "title"]);
+    out.type = isSeason ? "season" : "episode";
+    out.season = season;
+    if (isSeason) {
+      out.title = `Season ${season}`;
+    } else {
+      out.episode = episode;
+      out.title = `S${String(season).padStart(2, "0")}E${String(episode).padStart(2, "0")}`;
+      out.watched_at = watchedAt || null;
+    }
+    const ids = {};
+    for (const [k, v] of Object.entries(extraIds || {})) {
+      const val = String(v || "").trim();
+      if (val) ids[k] = val;
+    }
+    out.ids = ids;
+    return out;
+  }
+
+  function correctedMetadataItem(row, draft) {
+    const out = carryOverFields(row, [
+      "ids", "title", "year", "type",
+      "season", "episode", "series_title", "series_year", "show_ids",
+    ]);
+    const picked = (draft && draft.raw) || {};
+    out.type = picked.type || draft.type || "movie";
+    out.title = picked.title || draft.title || null;
+    out.year = picked.year != null ? picked.year : null;
+    out.ids = { ...(picked.ids || {}) };
+    return out;
+  }
+
+  function openItemReplacer(row, anchor, ctx = {}) {
+    if (usesCoordinateReplacer(row)) return openEpisodeReplacer(row, anchor, ctx);
+    return openMetadataReplacer(row, anchor, ctx);
+  }
+
+  function openMetadataReplacer(row, anchor, ctx = {}) {
+    const draft = {
+      _rid: -1,
+      key: String(row.key || ""),
+      type: rowType(row),
+      title: String(row.title || ""),
+      year: String(row.year || ""),
+      imdb: "",
+      tmdb: "",
+      trakt: "",
+      mal: "",
+      anilist: "",
+      raw: JSON.parse(JSON.stringify(row.raw || {})),
+      deleted: false,
+      episode: false,
+    };
+    const stub = () => document.createElement("input");
+    const refs = {
+      keyIn: stub(),
+      titleIn: stub(),
+      yearIn: stub(),
+      imdbIn: stub(),
+      tmdbIn: stub(),
+      traktIn: stub(),
+      typeBtn: document.createElement("button"),
+      onApplied: applied => {
+        const key = String(applied.key || "").trim();
+        if (!key) {
+          ctx.setStatusSticky?.("That result has no usable identifier.", 5000);
+          return;
+        }
+        if (key.toLowerCase() === String(row.key || "").trim().toLowerCase()) {
+          ctx.setStatusSticky?.("The corrected item is the same as the current one.", 5000);
+          return;
+        }
+        const corrected = correctedMetadataItem(row, applied);
+        const err = ctx.commitReplacement?.(row, corrected, key, "The corrected local item was updated.");
+        if (err) ctx.setStatusSticky?.(err, 5000);
+      },
+    };
+    openTitleSearchEditor(draft, anchor, refs, ctx);
+  }
+
+  function openEpisodeReplacer(row, anchor, ctx = {}) {
+    const isSeason = rowType(row) === "season";
+    const dt = window.CW && window.CW.Editor && window.CW.Editor.DateTime;
+    if (!dt) throw new Error("Editor module missing: DateTime");
+    ctx.openPopup(anchor, (pop, close) => {
+      ctx.appendPopupTitle(pop, isSeason ? "Replace season" : "Replace episode");
+
+      const raw = (row && row.raw) || {};
+      const curSeason = Number(raw.season || 0);
+      const curEpisode = Number(raw.episode || 0);
+      const seriesTitle = String(raw.series_title || row.title || "").trim() || "Unknown series";
+
+      const info = document.createElement("div");
+      info.className = "cw-search-meta";
+      info.textContent = isSeason
+        ? `${seriesTitle} - currently season ${curSeason}`
+        : `${seriesTitle} - currently S${String(curSeason).padStart(2, "0")}E${String(curEpisode).padStart(2, "0")}`;
+      pop.appendChild(info);
+
+      ctx.appendPopupTitle(pop, isSeason ? "Corrected season" : "Corrected episode", "10px");
+
+      const grid = document.createElement("div");
+      grid.className = "cw-datetime-grid";
+      grid.style.gridTemplateColumns = isSeason ? "minmax(0,1fr)" : "minmax(0,1fr) minmax(0,1fr)";
+
+      const seasonIn = document.createElement("input");
+      seasonIn.type = "number";
+      seasonIn.min = "0";
+      seasonIn.placeholder = "Season";
+      seasonIn.value = String(curSeason);
+
+      const episodeIn = document.createElement("input");
+      episodeIn.type = "number";
+      episodeIn.min = "0";
+      episodeIn.placeholder = "Episode";
+      episodeIn.value = String(curEpisode);
+
+      grid.appendChild(seasonIn);
+      if (!isSeason) grid.appendChild(episodeIn);
+      pop.appendChild(grid);
+
+      const dateInput = document.createElement("input");
+      dateInput.type = "date";
+      const timeInput = document.createElement("input");
+      timeInput.type = "time";
+      timeInput.step = 60;
+
+      if (!isSeason) {
+        ctx.appendPopupTitle(pop, "Watched at", "10px");
+        const whenGrid = document.createElement("div");
+        whenGrid.className = "cw-datetime-grid";
+        dt.fillDateTimeInputs?.(raw.watched_at, dateInput, timeInput);
+        whenGrid.appendChild(dateInput);
+        whenGrid.appendChild(timeInput);
+        pop.appendChild(whenGrid);
+      }
+
+      const advanced = document.createElement("details");
+      advanced.className = "cw-collapse";
+      advanced.style.marginTop = "10px";
+      const summary = document.createElement("summary");
+      summary.style.cursor = "pointer";
+      summary.style.fontWeight = "700";
+      summary.style.userSelect = "none";
+      summary.textContent = "Advanced";
+      advanced.appendChild(summary);
+
+      const advGrid = document.createElement("div");
+      advGrid.className = "cw-datetime-grid";
+      advGrid.style.marginTop = "8px";
+      const idInputs = {};
+      EPISODE_ID_FIELDS.forEach(field => {
+        const input = document.createElement("input");
+        input.type = "text";
+        input.placeholder = field.label;
+        idInputs[field.key] = input;
+        advGrid.appendChild(input);
+      });
+      advanced.appendChild(advGrid);
+      pop.appendChild(advanced);
+
+      const status = document.createElement("div");
+      status.className = "cw-search-status";
+      status.style.marginTop = "8px";
+      pop.appendChild(status);
+
+      const apply = () => {
+        const season = parseInt(seasonIn.value, 10);
+        const episode = isSeason ? 0 : parseInt(episodeIn.value, 10);
+        const seasonOk = Number.isFinite(season) && season >= 0;
+        const episodeOk = isSeason || (Number.isFinite(episode) && episode > 0);
+        if (!seasonOk || !episodeOk) {
+          status.textContent = isSeason
+            ? "Enter a valid corrected season."
+            : "Enter a valid corrected season and episode.";
+          return;
+        }
+        if (season === curSeason && (isSeason || episode === curEpisode)) {
+          status.textContent = isSeason
+            ? "The corrected season is the same as the current one."
+            : "The corrected episode is the same as the current one.";
+          return;
+        }
+        const key = coordinateKeyFor(row, season, episode);
+        if (!key) {
+          status.textContent = "This row has no usable series identifier.";
+          return;
+        }
+
+        const watchedAt = dt.dateTimeInputsToIso?.(dateInput.value, timeInput.value) || raw.watched_at || null;
+        const extraIds = {};
+        EPISODE_ID_FIELDS.forEach(field => {
+          extraIds[field.key] = idInputs[field.key].value;
+        });
+        const corrected = correctedEpisodeItem(row, season, episode, watchedAt, extraIds);
+        const err = ctx.commitReplacement?.(
+          row,
+          corrected,
+          key,
+          isSeason ? "The corrected local season was updated." : "The corrected local episode was updated."
+        );
+        if (err) {
+          status.textContent = err;
+          return;
+        }
+        close();
+      };
+
+      ctx.appendPopupActions(pop, [
+        { label: "Close", kind: "ghost", onClick: close },
+        { label: "Replace episode", kind: "primary", onClick: apply },
+      ]);
+
+      seasonIn.focus();
+    });
+  }
+
+  function openTitleSearchEditor(row, anchor, refs, ctx = {}) {
+    ctx.openPopup(anchor, (pop, close) => {
+      const title = document.createElement("div");
+      title.className = "cw-pop-title";
+      title.textContent = "Search metadata";
+      pop.appendChild(title);
+
+      const bar = document.createElement("div");
+      bar.className = "cw-search-bar";
+
+      const qInput = document.createElement("input");
+      qInput.type = "text";
+      qInput.id = "cw_meta_search_title";
+      qInput.name = qInput.id;
+      qInput.placeholder = "Title...";
+      qInput.value = row.title || "";
+      bar.appendChild(qInput);
+
+      const yearInput = document.createElement("input");
+      yearInput.type = "number";
+      yearInput.id = "cw_meta_search_year";
+      yearInput.name = yearInput.id;
+      yearInput.placeholder = "Year";
+      if (row.year) yearInput.value = row.year;
+      bar.appendChild(yearInput);
+
+      const typeSelect = document.createElement("select");
+      typeSelect.id = "cw_meta_search_type";
+      typeSelect.name = typeSelect.id;
+      [["movie", "Movie"], ["show", "Show"], ["anime", "Anime"]].forEach(([val, label]) => {
+        const opt = document.createElement("option");
+        opt.value = val;
+        opt.textContent = label;
+        typeSelect.appendChild(opt);
+      });
+      typeSelect.value = row.type === "anime" ? "anime" : row.type === "show" || row.type === "episode" ? "show" : "movie";
+      bar.appendChild(typeSelect);
+
+      pop.appendChild(bar);
+
+      const actions = document.createElement("div");
+      actions.className = "cw-pop-actions";
+
+      const searchBtn = document.createElement("button");
+      searchBtn.type = "button";
+      searchBtn.className = "cw-pop-btn primary";
+      searchBtn.textContent = "Search";
+      actions.appendChild(searchBtn);
+
+      const closeBtn = document.createElement("button");
+      closeBtn.type = "button";
+      closeBtn.className = "cw-pop-btn ghost";
+      closeBtn.textContent = "Close";
+      closeBtn.onclick = close;
+      actions.appendChild(closeBtn);
+
+      pop.appendChild(actions);
+
+      const status = document.createElement("div");
+      status.className = "cw-search-status";
+      pop.appendChild(status);
+
+      const resultsBox = document.createElement("div");
+      resultsBox.className = "cw-search-results";
+      pop.appendChild(resultsBox);
+
+      async function doSearch() {
+        const q = (qInput.value || "").trim();
+        const yearVal = parseInt(yearInput.value || "", 10);
+        if (q.length < 2) {
+          status.textContent = "Type at least 2 characters.";
+          resultsBox.innerHTML = "";
+          return;
+        }
+        const typ = String(typeSelect.value || "").toLowerCase();
+        const makeUrl = t => {
+          let u = `/api/metadata/search?q=${encodeURIComponent(q)}&typ=${encodeURIComponent(t)}`;
+          if (!Number.isNaN(yearVal)) u += `&year=${yearVal}`;
+          return u;
+        };
+
+        status.textContent = "Searching...";
+        resultsBox.innerHTML = "";
+        try {
+          let items = [];
+          if (typ === "anime") {
+            const [showRes, movieRes] = await Promise.all([ctx.fetchJSON(makeUrl("show")), ctx.fetchJSON(makeUrl("movie"))]);
+
+            const showOk = !!(showRes && showRes.ok !== false);
+            const movieOk = !!(movieRes && movieRes.ok !== false);
+
+            if (!showOk && !movieOk) {
+              const msg = (showRes && showRes.error) || (movieRes && movieRes.error) || "Search failed.";
+              status.textContent = msg;
+              return;
+            }
+
+            const a = showOk && Array.isArray(showRes.results) ? showRes.results : [];
+            const b = movieOk && Array.isArray(movieRes.results) ? movieRes.results : [];
+
+            items = [...a.map(x => ({ ...x, _resolve_entity: "show" })), ...b.map(x => ({ ...x, _resolve_entity: "movie" }))];
+
+            const seen = new Set();
+            items = items.filter(it => {
+              const k = `${String(it.tmdb || "")}:${String(it.type || "")}`;
+              if (!k || seen.has(k)) return false;
+              seen.add(k);
+              return true;
+            });
+          } else {
+            const data = await ctx.fetchJSON(makeUrl(typ));
+            if (!data || data.ok === false) {
+              status.textContent = data && data.error ? data.error : "Search failed.";
+              return;
+            }
+            items = Array.isArray(data.results) ? data.results : [];
+          }
+          if (!items.length) {
+            resultsBox.innerHTML = '<div class="cw-search-empty">No results.</div>';
+            status.textContent = "";
+            return;
+          }
+
+          resultsBox.innerHTML = "";
+          items.forEach(item => {
+            const btn = document.createElement("button");
+            btn.type = "button";
+            btn.className = "cw-search-item";
+
+            const posterWrap = document.createElement("div");
+            posterWrap.className = "cw-search-poster";
+
+            if (item.poster_path) {
+              const img = document.createElement("img");
+              img.src = `/art/tmdb/${item.type === "show" ? "tv" : "movie"}/${encodeURIComponent(String(item.tmdb))}?size=w92`;
+              img.alt = "";
+              img.onerror = () => {
+                img.remove();
+                const ph = document.createElement("div");
+                ph.className = "cw-search-poster-placeholder";
+                ph.textContent = item.type === "show" ? "TV" : "MOV";
+                posterWrap.appendChild(ph);
+              };
+              posterWrap.appendChild(img);
+            } else {
+              const ph = document.createElement("div");
+              ph.className = "cw-search-poster-placeholder";
+              ph.textContent = item.type === "show" ? "TV" : "MOV";
+              posterWrap.appendChild(ph);
+            }
+
+            btn.appendChild(posterWrap);
+
+            const content = document.createElement("div");
+            content.className = "cw-search-content";
+
+            const titleLine = document.createElement("div");
+            titleLine.className = "cw-search-title-line";
+
+            const t = document.createElement("div");
+            t.className = "cw-search-title";
+            const yearTxt = item.year ? ` (${item.year})` : "";
+            t.textContent = (item.title || "") + yearTxt;
+            titleLine.appendChild(t);
+
+            const tag2 = document.createElement("span");
+            tag2.className = "cw-search-tag";
+            tag2.textContent = item.type === "show" ? "Show" : "Movie";
+            titleLine.appendChild(tag2);
+
+            content.appendChild(titleLine);
+
+            const meta = document.createElement("div");
+            meta.className = "cw-search-meta";
+            const bits = [];
+            if (item.year) bits.push(String(item.year));
+            bits.push(item.type === "show" ? "TV" : "Movie");
+            if (item.tmdb) bits.push(`TMDb ${item.tmdb}`);
+            meta.textContent = bits.join(" - ");
+            content.appendChild(meta);
+
+            if (item.overview) {
+              const ov = document.createElement("div");
+              ov.className = "cw-search-overview";
+              ov.textContent = item.overview;
+              content.appendChild(ov);
+            }
+
+            btn.appendChild(content);
+
+            btn.onclick = async () => {
+              const picked = item;
+              const newTitle = picked.title || row.title || "";
+              row.title = newTitle;
+              row.raw.title = newTitle || null;
+              refs.titleIn.value = ctx.formatEpisodeVisualTitle(row) || newTitle;
+
+              if (picked.year) {
+                row.year = String(picked.year);
+                row.raw.year = picked.year;
+                refs.yearIn.value = row.year;
+              }
+
+              const wantsAnime = String(typeSelect.value || "").toLowerCase() === "anime";
+              const pickedType = String(picked.type || "movie").toLowerCase();
+
+              const newType = wantsAnime ? "anime" : pickedType;
+              const resolveEntity = wantsAnime ? picked._resolve_entity || pickedType || "movie" : newType;
+
+              row.type = newType;
+              row.raw.type = newType;
+              row.episode = false;
+              ctx.updateTypeDisplay(row, refs.typeBtn);
+
+              const tmdbId = picked.tmdb;
+              if (tmdbId != null) {
+                const tmdbStr = String(tmdbId);
+                row.tmdb = tmdbStr;
+                row.raw.ids = row.raw.ids || {};
+                row.raw.ids.tmdb = tmdbId;
+                if (refs.tmdbIn) refs.tmdbIn.value = tmdbStr;
+                const prevKey = (row.key || "").trim();
+                if (!prevKey || /^(tmdb|imdb|trakt|tvdb|slug):/i.test(prevKey)) {
+                  row.key = `tmdb:${tmdbStr}`;
+                  if (refs.keyIn) refs.keyIn.value = row.key;
+                }
+              }
+
+              if (tmdbId != null) {
+                try {
+                  const metaRes = await ctx.fetchJSON("/api/metadata/resolve", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ entity: resolveEntity, ids: { tmdb: tmdbId } }),
+                  });
+
+                  if (metaRes && metaRes.ok && metaRes.result && metaRes.result.ids) {
+                    const ids = metaRes.result.ids || {};
+                    row.raw.ids = row.raw.ids || {};
+
+                    if (ids.imdb) {
+                      row.imdb = ids.imdb;
+                      row.raw.ids.imdb = ids.imdb;
+                      refs.imdbIn.value = ids.imdb;
+                    }
+                    if (ids.tmdb) {
+                      const tVal = String(ids.tmdb);
+                      row.tmdb = tVal;
+                      row.raw.ids.tmdb = ids.tmdb;
+                      if (refs.tmdbIn) refs.tmdbIn.value = tVal;
+                      const prevKey = (row.key || "").trim();
+                      if (!prevKey || /^(tmdb|imdb|trakt|tvdb|slug):/i.test(prevKey)) {
+                        row.key = `tmdb:${tVal}`;
+                        if (refs.keyIn) refs.keyIn.value = row.key;
+                      }
+                    }
+                    if (ids.trakt) {
+                      const trVal = String(ids.trakt);
+                      row.trakt = trVal;
+                      row.raw.ids.trakt = ids.trakt;
+                      if (refs.traktIn) refs.traktIn.value = trVal;
+                    }
+                  }
+                } catch (err) {
+                  console.error("metadata resolve failed", err);
+                }
+              }
+
+              if (typeof refs.onApplied === "function") {
+                close();
+                refs.onApplied(row);
+                return;
+              }
+
+              ctx.markChanged?.();
+              ctx.setStatusSticky?.("Row updated from metadata", 2500);
+              close();
+              ctx.renderRows?.();
+            };
+
+            resultsBox.appendChild(btn);
+          });
+
+          status.textContent = `${items.length} result${items.length === 1 ? "" : "s"} found.`;
+        } catch (err) {
+          console.error("search failed", err);
+          status.textContent = "Search failed.";
+        }
+      }
+
+      searchBtn.onclick = () => doSearch();
+
+      qInput.addEventListener("keydown", ev => {
+        if (ev.key === "Enter") {
+          ev.preventDefault();
+          doSearch();
+        }
+      });
+
+      if ((row.title || "").trim().length >= 3) doSearch();
+      else status.textContent = "Enter a title and press Enter or Search.";
+    });
+  }
+
+  Editor.MetadataReplacer = {
+    canReplaceRow,
+    usesCoordinateReplacer,
+    openItemReplacer,
+    openTitleSearchEditor,
+  };
+  window.CrossWatchEditorMetadataReplacer = Editor.MetadataReplacer;
+})();

--- a/assets/js/editor/persistence.js
+++ b/assets/js/editor/persistence.js
@@ -1,0 +1,195 @@
+/* assets/js/editor/persistence.js */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const NS = (window.CW ||= {});
+  const Editor = (NS.Editor ||= {});
+
+  function stateOf(ctx) {
+    return (ctx && ctx.state) || {};
+  }
+
+  function findRowsMissingKey(state) {
+    const missing = [];
+    for (const row of state.rows || []) {
+      if (row.deleted) continue;
+      const key = (row.key || "").trim();
+      if (key) continue;
+
+      const hasOther =
+        (row.title && row.title.trim()) ||
+        (row.type && row.type.trim()) ||
+        (row.year && String(row.year).trim()) ||
+        (row.imdb && row.imdb.trim()) ||
+        (row.tmdb && row.tmdb.trim()) ||
+        (row.trakt && row.trakt.trim());
+
+      if (hasOther) missing.push(row);
+    }
+    return missing;
+  }
+
+  function buildSaveData(ctx = {}) {
+    const state = stateOf(ctx);
+    const items = {};
+    const blocks = [];
+    const seenBlocks = new Set();
+
+    for (const row of state.rows || []) {
+      if (row.deleted) {
+        if (ctx.isPolicySource?.() && row._origin === "baseline") {
+          const k = (row.key || "").trim();
+          if (k) {
+            const kl = k.toLowerCase();
+            if (!seenBlocks.has(kl)) {
+              seenBlocks.add(kl);
+              blocks.push(k);
+            }
+          }
+        }
+        continue;
+      }
+
+      if (ctx.isPolicySource?.() && row._origin === "baseline") continue;
+
+      if (ctx.isPolicySource?.() && row._replacedKey) {
+        const rk = String(row._replacedKey).trim();
+        const rkl = rk.toLowerCase();
+        if (rk && !seenBlocks.has(rkl)) {
+          seenBlocks.add(rkl);
+          blocks.push(rk);
+        }
+      }
+
+      const key = (row.key || "").trim();
+      if (!key) continue;
+
+      const raw = row.raw || {};
+      const ids = raw.ids || {};
+
+      if (row.imdb) ids.imdb = row.imdb;
+      else delete ids.imdb;
+
+      if (row.tmdb) ids.tmdb = row.tmdb;
+      else delete ids.tmdb;
+
+      if (row.trakt) ids.trakt = row.trakt;
+      else delete ids.trakt;
+
+      raw.ids = ids;
+      raw.type = row.type || raw.type || null;
+      raw.title = row.title ? row.title : raw.title || null;
+
+      const y = (row.year || "").trim();
+      const n = y ? parseInt(y, 10) : NaN;
+      raw.year = Number.isFinite(n) ? n : null;
+
+      items[key] = raw;
+    }
+
+    const payload = { kind: state.kind, source: state.source, items };
+    if (ctx.isProviderPickerSource?.()) {
+      payload.provider = state.snapshot;
+      payload.provider_instance = state.instance || "default";
+      payload.blocks = blocks;
+    }
+    if (ctx.isTrackerSource?.()) {
+      payload.workspace = state.workspace;
+      payload.provider_instance = state.instance || "default";
+      payload.blocks = blocks;
+    }
+    if (state.source === "playlist") {
+      payload.endpoint = state.snapshot;
+    }
+
+    return { items, blocks, payload };
+  }
+
+  function confirmPlaylistRemovals(ctx, items) {
+    const state = stateOf(ctx);
+    if (state.source !== "playlist") return true;
+
+    const currentKeys = new Set((state.playlistOriginalKeys || []).map(String));
+    const nextKeys = new Set(Object.keys(items || {}));
+    const removals = Array.from(currentKeys).filter(k => !nextKeys.has(k)).length;
+    if (!removals || !state.playlistWarnings.length) return true;
+
+    const text = state.playlistWarnings.join("\n");
+    const confirmFn = typeof ctx.confirm === "function" ? ctx.confirm : window.confirm;
+    return confirmFn(`${text}\n\nRemove ${removals} item${removals === 1 ? "" : "s"} from this playlist endpoint?`);
+  }
+
+  async function saveState(ctx = {}) {
+    const state = stateOf(ctx);
+    if (state.saving) return;
+
+    const missing = findRowsMissingKey(state);
+    if (missing.length) {
+      ctx.setTag?.("error", "Missing key");
+      ctx.setStatus?.(
+        `Cannot save: ${missing.length} row${missing.length === 1 ? "" : "s"} have data but no Key. Fill the Key or remove the row.`
+      );
+      if (window.cxToast) window.cxToast("Fill Key for all rows with data before saving");
+      return;
+    }
+
+    state.saving = true;
+    ctx.setTag?.("warn", "Saving");
+    ctx.syncActionButtons?.();
+
+    try {
+      const { items, payload } = buildSaveData(ctx);
+
+      if (!confirmPlaylistRemovals(ctx, items)) {
+        state.saving = false;
+        ctx.setTag?.("warn", "Unsaved changes");
+        ctx.setStatus?.("Save cancelled");
+        ctx.syncActionButtons?.();
+        return;
+      }
+
+      const res = await ctx.fetchJSON("/api/editor", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      state.hasChanges = false;
+      ctx.setTag?.("warn", "Saved");
+      if (state.source === "playlist") {
+        const added = Number(res.added || 0);
+        const removed = Number(res.removed || 0);
+        const reordered = Number(res.reordered || 0);
+        const unresolved = Number(res.unresolved_count || 0);
+        const parts = [`+${added}`, `-${removed}`];
+        if (reordered) parts.push(`${reordered} reordered`);
+        if (unresolved) parts.push(`${unresolved} unresolved`);
+        ctx.setStatus?.(`Applied playlist changes: ${parts.join(", ")}`);
+        await ctx.loadState?.();
+      } else if (ctx.isTrackerSource?.()) {
+        ctx.setStatus?.(`Saved ${res.count || Object.keys(items).length} corrections`);
+        await ctx.loadState?.();
+      } else if (ctx.isManualSource?.()) {
+        ctx.setStatus?.(`Saved ${res.count || Object.keys(items).length} overrides`);
+        await ctx.loadState?.();
+      } else {
+        ctx.setStatus?.(`Saved ${res.count || Object.keys(items).length} items`);
+        await ctx.loadSnapshots?.();
+      }
+    } catch (e) {
+      console.error(e);
+      ctx.setTag?.("error", "Save failed");
+      ctx.setStatus?.(String(e));
+    } finally {
+      state.saving = false;
+      ctx.syncActionButtons?.();
+    }
+  }
+
+  Editor.Persistence = {
+    findRowsMissingKey,
+    buildSaveData,
+    confirmPlaylistRemovals,
+    saveState,
+  };
+  window.CrossWatchEditorPersistence = Editor.Persistence;
+})();

--- a/assets/js/editor/row-editor.js
+++ b/assets/js/editor/row-editor.js
@@ -1,0 +1,124 @@
+/* assets/js/editor/row-editor.js */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const NS = (window.CW ||= {});
+  const Editor = (NS.Editor ||= {});
+
+  function updateTypeDisplay(row, el) {
+    if (!el) return;
+    let label = "";
+    let icon = "category";
+    const t = (row?.type || "").toLowerCase();
+    if (t === "movie") {
+      label = "Movie";
+      icon = "movie";
+    } else if (t === "show") {
+      label = "Show";
+      icon = "monitoring";
+    } else if (t === "anime") {
+      label = "Anime";
+      icon = "auto_awesome";
+    } else if (t === "season") {
+      label = "Season";
+      icon = "layers";
+    } else if (t === "episode") {
+      label = "Episode";
+      icon = "open_in_new";
+    }
+
+    el.innerHTML = "";
+    ["type-movie", "type-show", "type-anime", "type-season", "type-episode"].forEach(cls => el.classList.remove(cls));
+    if (t) el.classList.add(`type-${t}`);
+    const text = document.createElement("span");
+    text.className = "cw-extra-display-label";
+    if (label) {
+      text.textContent = label;
+      text.classList.add("cw-extra-display-value");
+    } else {
+      text.textContent = "Set type";
+      text.classList.add("cw-extra-display-placeholder");
+    }
+    el.appendChild(text);
+
+    const iconEl = document.createElement("span");
+    iconEl.className = "material-symbol cw-extra-display-icon";
+    iconEl.textContent = icon;
+    el.appendChild(iconEl);
+  }
+
+  function openTypeEditor(row, anchor, ctx = {}) {
+    const locked = !!ctx.isRowLocked(row);
+
+    ctx.openPopup(anchor, (pop, close) => {
+      ctx.appendPopupTitle(pop, "Type");
+      if (locked) return ctx.renderLockedPopup(pop, close);
+
+      const grid = document.createElement("div");
+      grid.className = "cw-type-grid";
+      const current = (row.type || "").toLowerCase();
+      const allowed = ctx.allowedTypesForKind(ctx.state.kind);
+      const options = [
+        { key: "movie", label: "Movie" },
+        { key: "show", label: "Show" },
+        { key: "anime", label: "Anime" },
+        { key: "season", label: "Season" },
+        { key: "episode", label: "Episode" },
+      ].filter(o => allowed.includes(o.key));
+
+      options.forEach(opt => {
+        const pill = document.createElement("button");
+        pill.type = "button";
+        pill.className = "cw-type-pill" + (current === opt.key ? " active" : "");
+        pill.textContent = opt.label;
+        pill.onclick = () => {
+          row.type = opt.key;
+          row.raw.type = opt.key;
+          row.episode = opt.key === "episode";
+          ctx.finishPopupChange(close, true);
+        };
+        grid.appendChild(pill);
+      });
+
+      pop.appendChild(grid);
+      ctx.appendPopupActions(pop, [
+        {
+          label: "Clear",
+          kind: "ghost",
+          onClick: () => {
+            row.type = "";
+            row.raw.type = null;
+            row.episode = false;
+            ctx.finishPopupChange(close, true);
+          }
+        },
+        { label: "Close", kind: "ghost", onClick: close },
+      ]);
+    });
+  }
+
+  function addRow(ctx = {}) {
+    const state = ctx.state;
+    const raw = { ids: {}, type: "movie", title: "", year: null };
+    if (!Array.isArray(state.rows)) state.rows = [];
+    state.rows.unshift({
+      _rid: state.ridSeq++,
+      key: "",
+      type: raw.type,
+      title: "",
+      year: "",
+      imdb: "",
+      tmdb: "",
+      trakt: "",
+      raw,
+      deleted: false,
+      episode: false,
+      _origin: ctx.isPolicySource() ? "manual" : "playlist",
+    });
+    state.page = 0;
+    ctx.markChanged();
+    ctx.renderRows();
+  }
+
+  Editor.RowEditor = { updateTypeDisplay, openTypeEditor, addRow };
+  window.CrossWatchEditorRowEditor = Editor.RowEditor;
+})();

--- a/assets/js/editor/rows.js
+++ b/assets/js/editor/rows.js
@@ -1,0 +1,117 @@
+/* assets/js/editor/rows.js */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const NS = (window.CW ||= {});
+  const Editor = (NS.Editor ||= {});
+
+  function cloneRaw(raw) {
+    try {
+      return JSON.parse(JSON.stringify(raw || {}));
+    } catch (_) {
+      return {};
+    }
+  }
+
+  function nextRid(options) {
+    return typeof options.nextRid === "function" ? options.nextRid() : 0;
+  }
+
+  function imdbFromKey(key) {
+    const s = (key || "") + "";
+    if (!s.startsWith("imdb:")) return "";
+    return s.slice(5).split("#")[0];
+  }
+
+  function applyManualRow(row, item, key) {
+    row.key = key;
+    row.raw = item;
+    row.type = "episode";
+    row.episode = true;
+    row.title = String(item.series_title || row.title || "");
+    row.year = item.series_year != null ? String(item.series_year) : row.year || "";
+    row.imdb = "";
+    row.tmdb = item.ids && item.ids.tmdb ? String(item.ids.tmdb) : "";
+    row.trakt = "";
+    row.deleted = false;
+    row._origin = "manual";
+    return row;
+  }
+
+  function buildManualRow(item, key, replacedKey, options = {}) {
+    const row = applyManualRow(
+      { _rid: nextRid(options), mal: "", anilist: "" },
+      item,
+      key
+    );
+    if (replacedKey) row._replacedKey = replacedKey;
+    return row;
+  }
+
+  function buildRows(items, options = {}) {
+    const rows = [];
+    for (const [key, raw] of Object.entries(items || {})) {
+      const ids = raw.ids || {};
+      const showIds = raw.show_ids || {};
+      const type = raw.type || "";
+      const isEpisode = type === "episode";
+      const baseTitle = raw.title || raw.series_title || "";
+      rows.push({
+        _rid: nextRid(options),
+        key,
+        type,
+        title: baseTitle,
+        year: raw.year != null ? String(raw.year) : "",
+        imdb: ids.imdb || (type === "season" ? showIds.imdb || imdbFromKey(key) : ""),
+        tmdb: ids.tmdb || showIds.tmdb || "",
+        trakt: ids.trakt || showIds.trakt || "",
+        mal: ids.mal || "",
+        anilist: ids.anilist || "",
+        raw: cloneRaw(raw),
+        deleted: false,
+        episode: isEpisode,
+      });
+    }
+    if (options.sort !== false) rows.sort((a, b) => (a.title || "").localeCompare(b.title || ""));
+    return rows;
+  }
+
+  function buildManualOverrideRows(items, blocks, options = {}) {
+    const rows = buildRows(items || {}, options);
+    const itemKeys = new Set(rows.map(row => String(row.key || "").toLowerCase()));
+    for (const blockKey of blocks || []) {
+      const key = String(blockKey || "").trim();
+      if (!key || itemKeys.has(key.toLowerCase())) continue;
+      rows.push({
+        _rid: nextRid(options),
+        key,
+        type: "",
+        title: "",
+        year: "",
+        imdb: imdbFromKey(key),
+        tmdb: key.startsWith("tmdb:") ? key.slice(5).split("#")[0] : "",
+        trakt: key.startsWith("trakt:") ? key.slice(6).split("#")[0] : "",
+        mal: "",
+        anilist: "",
+        raw: { ids: {}, type: null, title: null },
+        deleted: true,
+        episode: false,
+        _origin: "baseline",
+        _manualBlock: true,
+      });
+    }
+    rows.sort((a, b) => {
+      if (a.deleted !== b.deleted) return a.deleted ? 1 : -1;
+      return String(a.title || a.key || "").localeCompare(String(b.title || b.key || ""));
+    });
+    return rows;
+  }
+
+  Editor.Rows = {
+    imdbFromKey,
+    applyManualRow,
+    buildManualRow,
+    buildRows,
+    buildManualOverrideRows,
+  };
+  window.CrossWatchEditorRows = Editor.Rows;
+})();

--- a/assets/js/editor/search.js
+++ b/assets/js/editor/search.js
@@ -1,0 +1,119 @@
+/* assets/js/editor/search.js */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const NS = (window.CW ||= {});
+  const Editor = (NS.Editor ||= {});
+
+  function normalizeSearchText(value) {
+    return String(value == null ? "" : value)
+      .toLowerCase()
+      .replace(/['"`]/g, "")
+      .replace(/[^a-z0-9]+/g, " ")
+      .trim()
+      .replace(/\s+/g, " ");
+  }
+
+  function searchInt(value) {
+    if (value == null || value === "") return null;
+    const n = parseInt(String(value).trim(), 10);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  function parseSeasonEpisodeText(value) {
+    const s = String(value || "").toLowerCase();
+    let m = s.match(/\bs\s*0*(\d{1,3})\s*e\s*0*(\d{1,3})\b/);
+    if (m) return { season: parseInt(m[1], 10), episode: parseInt(m[2], 10) };
+    m = s.match(/\b0*(\d{1,3})\s*x\s*0*(\d{1,3})\b/);
+    if (m) return { season: parseInt(m[1], 10), episode: parseInt(m[2], 10) };
+    m = s.match(/\bseason\s*0*(\d{1,3})(?:\s*episode\s*0*(\d{1,3}))?\b/);
+    if (m) return { season: parseInt(m[1], 10), episode: m[2] ? parseInt(m[2], 10) : null };
+    m = s.match(/\bs\s*0*(\d{1,3})\b/);
+    if (m) return { season: parseInt(m[1], 10), episode: null };
+    m = s.match(/\bepisode\s*0*(\d{1,3})\b/);
+    if (m) return { season: null, episode: parseInt(m[1], 10) };
+    return { season: null, episode: null };
+  }
+
+  function rowSeasonEpisode(row) {
+    const raw = row && row.raw ? row.raw : {};
+    let season = searchInt(raw.season);
+    let episode = searchInt(raw.episode);
+    if (season == null || episode == null) {
+      const parsed = parseSeasonEpisodeText([
+        row?.title,
+        raw.title,
+        raw.name,
+        raw.series_title,
+        row?.key,
+      ].join(" "));
+      if (season == null) season = parsed.season;
+      if (episode == null) episode = parsed.episode;
+    }
+    return { season, episode };
+  }
+
+  function rowSearchHaystack(row, options = {}) {
+    const raw = row && row.raw ? row.raw : {};
+    const ids = raw.ids && typeof raw.ids === "object" ? raw.ids : {};
+    const showIds = raw.show_ids && typeof raw.show_ids === "object" ? raw.show_ids : {};
+    const { season, episode } = rowSeasonEpisode(row);
+    const visualTitle = typeof options.formatEpisodeVisualTitle === "function"
+      ? options.formatEpisodeVisualTitle(row)
+      : "";
+    const pieces = [
+      row?.key,
+      row?.title,
+      visualTitle,
+      raw.title,
+      raw.name,
+      raw.series_title,
+      raw.show_title,
+      raw.original_title,
+      raw.type,
+      row?.type,
+      raw.year,
+      row?.year,
+      row?.imdb,
+      row?.tmdb,
+      row?.trakt,
+      row?.mal,
+      row?.anilist,
+      ids.imdb,
+      ids.tmdb,
+      ids.trakt,
+      ids.tvdb,
+      ids.simkl,
+      ids.mal,
+      ids.anilist,
+      showIds.imdb,
+      showIds.tmdb,
+      showIds.trakt,
+      showIds.tvdb,
+      showIds.simkl,
+    ];
+    if (season != null) {
+      const s2 = String(season).padStart(2, "0");
+      pieces.push(`season ${season}`, `season ${s2}`, `s${s2}`, `s${season}`);
+    }
+    if (episode != null) {
+      const e2 = String(episode).padStart(2, "0");
+      pieces.push(`episode ${episode}`, `episode ${e2}`, `e${e2}`, `e${episode}`);
+    }
+    if (season != null && episode != null) {
+      const s2 = String(season).padStart(2, "0");
+      const e2 = String(episode).padStart(2, "0");
+      pieces.push(`s${s2}e${e2}`, `${season}x${episode}`, `${s2}x${e2}`, `season ${season} episode ${episode}`);
+    } else if (season != null && typeof options.formatSxxEyy === "function") {
+      pieces.push(options.formatSxxEyy(season, null));
+    }
+    return normalizeSearchText(pieces.join(" "));
+  }
+
+  Editor.Search = {
+    normalizeSearchText,
+    parseSeasonEpisodeText,
+    rowSeasonEpisode,
+    rowSearchHaystack,
+  };
+  window.CrossWatchEditorSearch = Editor.Search;
+})();

--- a/assets/js/editor/send-modal.js
+++ b/assets/js/editor/send-modal.js
@@ -1,0 +1,352 @@
+/* assets/js/editor/send-modal.js */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const NS = (window.CW ||= {});
+  const Editor = (NS.Editor ||= {});
+
+  function escFactory(ctx) {
+    if (typeof ctx?.escapeHtml === "function") return ctx.escapeHtml;
+    return (value) => String(value ?? "").replace(/[&<>"']/g, ch => ({
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    }[ch]));
+  }
+
+  function providerCapabilityKey(kind) {
+    if (kind === "ratings") return "ratings_enabled";
+    return `${kind}_enabled`;
+  }
+
+  function providerDisplayName(provider) {
+    const PM = window.CW?.ProviderMeta;
+    const p = String(provider?.provider || "").toUpperCase();
+    const label = provider?.display || provider?.label || PM?.label?.(p) || p;
+    return String(label || p);
+  }
+
+  function providerLogoHtml(provider, esc) {
+    const PM = window.CW?.ProviderMeta;
+    const p = String(provider?.provider || "").toUpperCase();
+    if (typeof PM?.logoHtml === "function") return PM.logoHtml(p, "cw-editor-send-logo");
+    const src = PM?.logoPath?.(p) || "";
+    return src
+      ? `<img class="cw-editor-send-logo" src="${esc(src)}" alt="${esc(p)} logo" width="36" height="36" loading="lazy">`
+      : `<span class="material-symbols-rounded" aria-hidden="true">hub</span>`;
+  }
+
+  function providerToneStyle(provider, esc) {
+    const PM = window.CW?.ProviderMeta;
+    const p = String(provider?.provider || "").toUpperCase();
+    const rgb = PM?.tone?.(p)?.rgb || "124,92,255";
+    return `--send-rgb:${esc(String(rgb))}`;
+  }
+
+  function sendKindLabel(kind) {
+    const k = String(kind || "").toLowerCase();
+    return ({ watchlist: "Watchlist", history: "History", ratings: "Ratings", progress: "Progress" }[k] || (k ? k[0].toUpperCase() + k.slice(1) : "Data"));
+  }
+
+  function sendKindIcon(kind) {
+    const k = String(kind || "").toLowerCase();
+    return ({ watchlist: "bookmark_add", history: "history", ratings: "star", progress: "resume" }[k] || "send");
+  }
+
+  function formatSendResult(data, esc) {
+    const confirmed = Number(data?.confirmed || 0);
+    const attempted = Number(data?.attempted || data?.sent || 0);
+    const skipped = Number(data?.skipped || 0);
+    const unresolved = Number(data?.unresolved || 0);
+    const errors = Number(data?.errors || 0);
+    const invalid = Number(data?.invalid || 0);
+    const ok = errors === 0 && unresolved === 0;
+    const done = confirmed + skipped;
+    const pct = attempted ? Math.max(0, Math.min(100, Math.round((done / attempted) * 100))) : (ok ? 100 : 0);
+    const providers = Array.isArray(data?.results) ? data.results : [];
+    const rows = providers.map(r => {
+      const result = r?.result || {};
+      const name = providerDisplayName(r || {});
+      const parts = [
+        `${Number(result.confirmed || result.count || 0)} sent`,
+        Number(result.skipped || 0) ? `${Number(result.skipped || 0)} skipped` : "",
+        Number(result.unresolved || 0) ? `${Number(result.unresolved || 0)} unresolved` : "",
+        Number(result.errors || 0) ? `${Number(result.errors || 0)} errors` : "",
+        r?.error ? String(r.error) : "",
+      ].filter(Boolean).join(" - ");
+      return `<div class="cw-editor-send-result-row ${r?.ok ? "ok" : "bad"}" style="${providerToneStyle(r, esc)}">
+        <span class="cw-editor-send-result-icon">${providerLogoHtml(r, esc)}</span>
+        <strong>${esc(name)}</strong>
+        <small>${esc(parts || (r?.ok ? "Done" : "Failed"))}</small>
+      </div>`;
+    }).join("");
+    return `<div class="cw-editor-send-progress ${ok ? "done" : "error"}">
+      <div class="cw-editor-send-progress-head">
+        <div>
+          <strong>${ok ? "Send complete" : "Send finished with issues"}</strong>
+          <span>${esc(providers.length ? `${providers.length} provider target${providers.length === 1 ? "" : "s"} processed` : "Provider send processed")}</span>
+        </div>
+        <span class="material-symbols-rounded" aria-hidden="true">${ok ? "check_circle" : "error"}</span>
+      </div>
+      <div class="cw-editor-send-progress-bar" aria-hidden="true"><span style="width:${pct}%"></span></div>
+      <div class="cw-editor-send-progress-grid">
+        <div><span>sent</span><b>${confirmed}</b></div>
+        <div><span>attempted</span><b>${attempted}</b></div>
+        <div><span>skipped</span><b>${skipped}</b></div>
+        <div><span>unresolved</span><b>${unresolved}</b></div>
+        <div><span>errors</span><b>${errors}</b></div>
+        ${invalid ? `<div><span>invalid</span><b>${invalid}</b></div>` : ""}
+      </div>
+      ${rows ? `<div class="cw-editor-send-result-list">${rows}</div>` : ""}
+    </div>`;
+  }
+
+  function formatSendRunning(targetCount) {
+    return `<div class="cw-editor-send-progress active">
+      <div class="cw-editor-send-progress-head">
+        <div><strong>Sending selected rows</strong><span>${Number(targetCount || 0)} provider target${Number(targetCount || 0) === 1 ? "" : "s"} queued</span></div>
+        <span class="material-symbols-rounded" aria-hidden="true">sync</span>
+      </div>
+      <div class="cw-editor-send-progress-bar" aria-hidden="true"><span style="width:24%"></span></div>
+      <div class="cw-editor-send-progress-message">Sending selected rows to the chosen provider profile${Number(targetCount || 0) === 1 ? "" : "s"}...</div>
+    </div>`;
+  }
+
+  function close() {
+    document.getElementById("cw-editor-send-modal")?.remove();
+  }
+
+  function notify(message, ok = false) {
+    const msg = String(message || "");
+    try {
+      if (window.CW?.DOM?.showToast) {
+        window.CW.DOM.showToast(msg, ok);
+        return;
+      }
+      if (window.cxToast) {
+        window.cxToast(msg);
+        return;
+      }
+    } catch (_) {}
+    const el = document.createElement("div");
+    el.className = `save-toast ${ok ? "ok" : "error"}`;
+    el.textContent = msg;
+    document.body.appendChild(el);
+    setTimeout(() => el.remove(), 3800);
+  }
+
+  async function open(ctx = {}) {
+    const esc = escFactory(ctx);
+    const state = ctx.state || {};
+    const rows = ctx.selectedRowsForSend();
+    if (!rows.length) {
+      notify("Select at least one active row to send");
+      return;
+    }
+    const kind = String(state.kind || "watchlist").toLowerCase();
+    let providers = [];
+    const rememberedKey = `cw.editorSend.${kind}.providers`;
+    let selected = new Set();
+    const providerKey = p => `${String(p.provider || "").toUpperCase()}:${String(p.instance || "default")}`;
+    const currentSourceProviderKey = () => {
+      if (ctx.isProviderPickerSource() && state.snapshot) {
+        return providerKey({ provider: state.snapshot, instance: state.instance || "default" });
+      }
+      if (ctx.isTrackerSource()) {
+        return providerKey({ provider: "CROSSWATCH", instance: state.instance || "default" });
+      }
+      if (state.source === "playlist") {
+        const ep = ctx.currentPlaylistEndpoint();
+        if (ep && ep.provider) return providerKey({ provider: ep.provider, instance: ep.instance || "default" });
+      }
+      return "";
+    };
+
+    close();
+    const shell = document.createElement("div");
+    shell.id = "cw-editor-send-modal";
+    shell.className = "cw-editor-send-overlay";
+    const kindLabel = sendKindLabel(kind);
+    const kindIcon = sendKindIcon(kind);
+    shell.innerHTML = `
+      <div class="modal-backdrop"></div>
+      <div id="cx-modal" class="cx-card cw-editor-send-card" role="dialog" aria-modal="true" aria-label="Send selected rows">
+        <div class="cx-head">
+          <div class="cw-editor-send-head-left">
+            <div class="cw-editor-send-head-icon"><span class="material-symbols-rounded" aria-hidden="true">send</span></div>
+            <div>
+              <div class="cw-editor-send-title">Send selected rows</div>
+              <div class="cw-editor-send-sub">${rows.length} selected ${esc(kindLabel)} row${rows.length === 1 ? "" : "s"}</div>
+            </div>
+          </div>
+          <button type="button" class="cx-btn cw-editor-send-close" data-send-close aria-label="Close"><span class="material-symbols-rounded" aria-hidden="true">close</span></button>
+        </div>
+        <div class="body">
+          <section class="cw-editor-send-section cw-editor-send-target-card">
+            <div class="cw-editor-send-list">
+              <div class="cw-editor-send-empty">Loading providers...</div>
+            </div>
+          </section>
+          <section class="cw-editor-send-section cw-editor-send-data-card">
+            <div class="cw-editor-send-section-head compact">
+              <span class="material-symbols-rounded" aria-hidden="true">${esc(kindIcon)}</span>
+              <div>
+                <h3>Data to send</h3>
+                <p>${rows.length} selected ${esc(kindLabel)} row${rows.length === 1 ? "" : "s"} will be sent to selected provider profiles.</p>
+              </div>
+            </div>
+            <div class="cw-editor-send-data-grid">
+              <div><span>feature</span><b>${esc(kindLabel)}</b></div>
+              <div><span>rows</span><b>${rows.length}</b></div>
+              <div><span>mode</span><b>Selective send</b></div>
+            </div>
+          </section>
+          <section class="cw-editor-send-run-card">
+            <div class="cw-editor-send-warning">
+              <span class="material-symbols-rounded" aria-hidden="true">warning</span>
+              <div>This sends selected ${esc(kindLabel)} rows to the selected provider profile(s).</div>
+            </div>
+            <div class="cw-editor-send-run-actions">
+              <button type="button" class="cx-btn primary" data-send-submit disabled><span class="material-symbols-rounded" aria-hidden="true">send</span><span>Send selected data</span></button>
+            </div>
+            <div class="cw-editor-send-status" data-send-status aria-live="polite"></div>
+          </section>
+        </div>
+      </div>`;
+    document.body.appendChild(shell);
+    const list = shell.querySelector(".cw-editor-send-list");
+    const submit = shell.querySelector("[data-send-submit]");
+    const status = shell.querySelector("[data-send-status]");
+    const body = shell.querySelector(".body");
+    const scrollSendStatusIntoView = () => {
+      window.requestAnimationFrame(() => {
+        body?.scrollTo({ top: body.scrollHeight, behavior: "smooth" });
+      });
+    };
+
+    const syncButtons = () => {
+      shell.querySelectorAll("[data-provider-key]").forEach(btn => {
+        const key = btn.getAttribute("data-provider-key") || "";
+        const on = selected.has(key);
+        btn.classList.toggle("active", on);
+        btn.setAttribute("aria-pressed", on ? "true" : "false");
+      });
+      if (submit && !submit.classList.contains("busy")) submit.disabled = !selected.size;
+    };
+
+    const renderProviderList = () => {
+      if (!list) return;
+      list.innerHTML = providers.length ? providers.map(p => {
+        const key = providerKey(p);
+        const providerClass = `provider-${String(p.provider || "").toLowerCase().replace(/[^a-z0-9_-]+/g, "")}`;
+        return `<button type="button" class="cw-editor-send-provider ${providerClass} ${selected.has(key) ? "active" : ""}" data-provider-key="${esc(key)}" aria-pressed="${selected.has(key) ? "true" : "false"}" style="${providerToneStyle(p, esc)}">
+          <span class="cw-editor-send-provider-icon">${providerLogoHtml(p, esc)}</span>
+          <span><strong>${esc(providerDisplayName(p))}</strong><small>${esc(String(p.instance || "default"))}</small></span>
+          <span class="cw-editor-send-check"><span class="material-symbols-rounded" aria-hidden="true">check</span></span>
+        </button>`;
+      }).join("") : `<div class="cw-editor-send-empty">No other configured provider supports ${esc(kind)} sends.</div>`;
+      syncButtons();
+    };
+
+    shell.addEventListener("click", async ev => {
+      const target = ev.target instanceof Element ? ev.target : ev.target?.parentElement;
+      if (!target) return;
+      if (target.closest("[data-send-close],.modal-backdrop")) {
+        close();
+        return;
+      }
+      const providerBtn = target.closest("[data-provider-key]");
+      if (providerBtn) {
+        const key = providerBtn.getAttribute("data-provider-key") || "";
+        if (selected.has(key)) selected.delete(key);
+        else selected.add(key);
+        syncButtons();
+        return;
+      }
+      if (!target.closest("[data-send-submit]")) return;
+      if (!selected.size) return;
+      const targets = providers
+        .filter(p => selected.has(providerKey(p)))
+        .map(p => ({ provider: p.provider, instance: p.instance || "default" }));
+      if (submit) {
+        submit.disabled = true;
+        submit.classList.add("busy");
+      }
+      if (status) {
+        status.innerHTML = formatSendRunning(targets.length);
+        scrollSendStatusIntoView();
+      }
+      try {
+        const data = await ctx.fetchJSON("/api/editor/send", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ kind, providers: targets, items: rows.map(ctx.rowToSendItem) }),
+        });
+        try { localStorage.setItem(rememberedKey, JSON.stringify([...selected])); } catch (_) {}
+        const confirmed = Number(data.confirmed || 0);
+        const unresolved = Number(data.unresolved || 0);
+        const skipped = Number(data.skipped || 0);
+        const parts = [`${confirmed} sent`];
+        if (skipped) parts.push(`${skipped} skipped`);
+        if (unresolved) parts.push(`${unresolved} unresolved`);
+        ctx.setStatusSticky(parts.join(", "), 5000);
+        window.dispatchEvent(new CustomEvent("cw:editor-send-complete", { detail: data }));
+        ctx.clearSelection();
+        await ctx.loadState();
+        if (status) {
+          status.innerHTML = formatSendResult(data, esc);
+          scrollSendStatusIntoView();
+        }
+        if (submit) {
+          submit.disabled = false;
+          submit.classList.remove("busy");
+          submit.innerHTML = '<span class="material-symbols-rounded" aria-hidden="true">send</span><span>Send again</span>';
+        }
+      } catch (err) {
+        if (status) {
+          status.innerHTML = `<div class="cw-editor-send-progress error">
+          <div class="cw-editor-send-progress-head">
+            <div><strong>Send failed</strong><span>${esc(String(err?.message || "Could not send selected rows"))}</span></div>
+            <span class="material-symbols-rounded" aria-hidden="true">error</span>
+          </div>
+          <div class="cw-editor-send-progress-bar" aria-hidden="true"><span style="width:100%"></span></div>
+          <div class="cw-editor-send-progress-message">${esc(String(err?.message || "Send failed"))}</div>
+        </div>`;
+          scrollSendStatusIntoView();
+        }
+        if (submit) {
+          submit.classList.remove("busy");
+          submit.disabled = false;
+        }
+      }
+    });
+
+    try {
+      const data = await ctx.fetchJSON(`/api/editor/send/providers?kind=${encodeURIComponent(kind)}`);
+      const capKey = providerCapabilityKey(kind);
+      const sourceKey = currentSourceProviderKey();
+      providers = (Array.isArray(data.providers) ? data.providers : [])
+        .filter(p => !!p?.[capKey])
+        .filter(p => providerKey(p) !== sourceKey);
+      try {
+        const saved = JSON.parse(localStorage.getItem(rememberedKey) || "[]");
+        if (Array.isArray(saved)) selected = new Set(saved.map(String));
+      } catch (_) {}
+      selected = new Set([...selected].filter(k => providers.some(p => providerKey(p) === k)));
+      if (!selected.size && providers.length === 1) selected.add(providerKey(providers[0]));
+      if (status) status.innerHTML = providers.length
+        ? ""
+        : `<div class="cw-editor-send-status-line">No other configured target provider is available for this view.</div>`;
+      renderProviderList();
+    } catch (err) {
+      const msg = String(err?.message || "Could not load providers");
+      if (list) list.innerHTML = `<div class="cw-editor-send-empty">Could not load providers.</div>`;
+      if (status) status.innerHTML = `<div class="cw-editor-send-status-line err">${esc(msg)}</div>`;
+      if (submit) submit.disabled = true;
+    }
+  }
+
+  Editor.SendModal = { open, close };
+  window.CrossWatchEditorSendModal = Editor.SendModal;
+})();

--- a/assets/js/editor/sources.js
+++ b/assets/js/editor/sources.js
@@ -1,0 +1,358 @@
+/* assets/js/editor/sources.js */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const NS = (window.CW ||= {});
+  const Editor = (NS.Editor ||= {});
+
+  const SOURCES = ["state", "manual", "tracker", "playlist"];
+
+  function stateOf(ctx) {
+    return (ctx && ctx.state) || {};
+  }
+
+  function normalizeSource(value) {
+    const s = String(value || "").trim();
+    if (!SOURCES.includes(s)) return "state";
+    return s;
+  }
+
+  function isTrackerSource(state) {
+    return stateOf({ state }).source === "tracker";
+  }
+
+  function isManualSource(state) {
+    return stateOf({ state }).source === "manual";
+  }
+
+  function isProviderPickerSource(state) {
+    const s = stateOf({ state });
+    return s.source === "state" || isManualSource(s);
+  }
+
+  function isPolicySource(state) {
+    const s = stateOf({ state });
+    return s.source === "state" || isManualSource(s) || s.source === "tracker";
+  }
+
+  function ensureTrackerOption(sourceSel) {
+    if (!sourceSel) return;
+    const manual = sourceSel.querySelector('option[value="manual"]');
+    if (manual) {
+      manual.textContent = "Manual Overrides";
+    } else {
+      const opt = document.createElement("option");
+      opt.value = "manual";
+      opt.textContent = "Manual Overrides";
+      const trackerOpt = sourceSel.querySelector('option[value="tracker"]');
+      if (trackerOpt) sourceSel.insertBefore(opt, trackerOpt);
+      else sourceSel.appendChild(opt);
+    }
+    const existing = sourceSel.querySelector('option[value="tracker"]');
+    if (existing) {
+      existing.textContent = "Local Tracker";
+      return;
+    }
+    const opt = document.createElement("option");
+    opt.value = "tracker";
+    opt.textContent = "Local Tracker";
+    const playlistOpt = sourceSel.querySelector('option[value="playlist"]');
+    if (playlistOpt) sourceSel.insertBefore(opt, playlistOpt);
+    else sourceSel.appendChild(opt);
+  }
+
+  function currentTrackerWorkspace(state) {
+    const s = stateOf({ state });
+    const id = String(s.workspace || "").trim();
+    const list = s.trackerWorkspaces || [];
+    return list.find(w => String(w && w.id || "") === id) || list[0] || null;
+  }
+
+  function trackerKinds(state) {
+    const ws = currentTrackerWorkspace(state);
+    const feats = (ws && ws.features) || {};
+    return ["watchlist", "history", "ratings", "progress"].filter(k => feats[k]);
+  }
+
+  function currentPlaylistEndpoint(state) {
+    const s = stateOf({ state });
+    const id = String(s.snapshot || "").trim();
+    return (s.playlistEndpoints || []).find(ep => String(ep && ep.id || "") === id) || null;
+  }
+
+  function playlistEditable(state) {
+    const s = stateOf({ state });
+    if (s.source !== "playlist") return true;
+    const r = s.playlistResource || {};
+    return !!r && !r.smart && !!(r.can_add || r.can_remove || r.can_reorder);
+  }
+
+  function syncSnapshotControlVisibility(ctx = {}) {
+    const state = stateOf(ctx);
+    const show = !isTrackerSource(state);
+    if (ctx.snapLabel) ctx.snapLabel.style.display = show ? "" : "none";
+    if (ctx.snapSel) {
+      ctx.snapSel.style.display = show ? "" : "none";
+      const wrap = ctx.snapSel.nextElementSibling && ctx.snapSel.nextElementSibling.classList?.contains("cw-icon-select")
+        ? ctx.snapSel.nextElementSibling
+        : null;
+      if (wrap) wrap.style.display = show ? "" : "none";
+    }
+  }
+
+  function playlistEndpointLabel(ep) {
+    if (!ep) return "Endpoint";
+    const name = String(ep.name || ep.id || "Endpoint");
+    const provider = String(ep.provider_label || ep.provider || "").trim();
+    const playlist = String(ep.playlist_name || ep.playlist_id || "").trim();
+    const type = String(ep.playlist_type || ep.resource_kind || ep.kind || "").trim();
+    const parts = [name];
+    if (provider) parts.push(provider);
+    if (playlist && playlist !== name) parts.push(playlist);
+    if (type) parts.push(type);
+    return parts.join(" - ");
+  }
+
+  function rebuildSnapshots(ctx = {}) {
+    const state = stateOf(ctx);
+    const snapSel = ctx.snapSel;
+    if (!snapSel) return;
+    const providerPicker = isProviderPickerSource(state);
+    const isTracker = isTrackerSource(state);
+    const isPlaylist = state.source === "playlist";
+    const esc = typeof ctx.escapeHtml === "function" ? ctx.escapeHtml : (s => String(s || ""));
+
+    if (ctx.snapLabel) ctx.snapLabel.textContent = providerPicker ? "Provider" : "Endpoint";
+    syncSnapshotControlVisibility(ctx);
+    if (ctx.instanceLabel) ctx.instanceLabel.style.display = (providerPicker || isTracker) ? "" : "none";
+    if (ctx.instanceSel) ctx.instanceSel.style.display = (providerPicker || isTracker) ? "" : "none";
+    ctx.syncProfileIconSelect?.(ctx.instanceSel, providerPicker || isTracker);
+
+    if (isTracker) {
+      const list = Array.isArray(state.trackerWorkspaces) ? state.trackerWorkspaces : [];
+      const options = list
+        .map(w => `<option value="${esc(w && w.id)}">${esc((w && w.label) || "Local tracker")}</option>`)
+        .join("");
+      snapSel.innerHTML = options || `<option value="">No workspaces</option>`;
+      const opts = Array.from(snapSel.options).map(o => o.value);
+      const next = opts.includes(state.workspace) ? state.workspace : opts[0] || "";
+      if (next !== state.workspace) state.workspace = next;
+      snapSel.value = state.workspace || "";
+      ctx.syncProviderIconSelect?.(snapSel, false);
+      syncSnapshotControlVisibility(ctx);
+      return;
+    }
+
+    if (isPlaylist) {
+      const list = Array.isArray(state.playlistEndpoints) ? state.playlistEndpoints : [];
+      const options = list
+        .map(ep => `<option value="${esc(ep && ep.id)}">${esc(playlistEndpointLabel(ep))}</option>`)
+        .join("");
+      snapSel.innerHTML = options || `<option value="">No endpoints</option>`;
+      const opts = Array.from(snapSel.options).map(o => o.value);
+      const next = opts.includes(state.snapshot) ? state.snapshot : opts[0] || "";
+      if (next !== state.snapshot) state.snapshot = next;
+      snapSel.value = state.snapshot || "";
+      ctx.syncProviderIconSelect?.(snapSel, false);
+      syncSnapshotControlVisibility(ctx);
+      return;
+    }
+
+    if (providerPicker) {
+      const list = Array.isArray(state.snapshots) ? state.snapshots : [];
+      const label = typeof ctx.providerLabel === "function" ? ctx.providerLabel : ((p, fallback) => fallback || p);
+      snapSel.innerHTML = list.map(p => `<option value="${p}">${label(p, p)}</option>`).join("");
+      const opts = Array.from(snapSel.options).map(o => o.value);
+      const next = opts.includes(state.snapshot) ? state.snapshot : opts[0] || "";
+      if (next !== state.snapshot) state.snapshot = next;
+      snapSel.value = state.snapshot || "";
+      ctx.syncProviderIconSelect?.(snapSel, true);
+      syncSnapshotControlVisibility(ctx);
+    }
+  }
+
+  function syncSourceUI(ctx = {}) {
+    const state = stateOf(ctx);
+    state.source = normalizeSource(state.source);
+    if (ctx.sourceSel) {
+      ctx.sourceSel.querySelector('option[value="pair"]')?.remove();
+      if (!ctx.sourceSel.querySelector('option[value="playlist"]')) {
+        ctx.sourceSel.insertAdjacentHTML("beforeend", '<option value="playlist">Playlist Endpoint</option>');
+      }
+      ensureTrackerOption(ctx.sourceSel);
+    }
+    const isManual = isManualSource(state);
+    const providerPicker = isProviderPickerSource(state);
+    const isTracker = isTrackerSource(state);
+    const isPlaylist = state.source === "playlist";
+    const policy = isPolicySource(state);
+    if (ctx.sourceSel) ctx.sourceSel.value = state.source;
+    if (ctx.pairLabel) ctx.pairLabel.style.display = "none";
+    if (ctx.pairSel) ctx.pairSel.style.display = "none";
+    if (ctx.snapLabel) ctx.snapLabel.textContent = providerPicker ? "Provider" : "Endpoint";
+    syncSnapshotControlVisibility(ctx);
+    if (ctx.kindSel) ctx.kindSel.disabled = isPlaylist;
+    if (ctx.instanceLabel) ctx.instanceLabel.style.display = (providerPicker || isTracker) ? "" : "none";
+    if (ctx.instanceSel) ctx.instanceSel.style.display = (providerPicker || isTracker) ? "" : "none";
+    if (ctx.backupCard) ctx.backupCard.style.display = "none";
+    if (ctx.stateBackupCard) ctx.stateBackupCard.style.display = policy ? "" : "none";
+    if (ctx.blockedOnlyBtn) ctx.blockedOnlyBtn.style.display = policy ? "" : "none";
+    if (ctx.trackerNotice) ctx.trackerNotice.style.display = isTracker ? "block" : "none";
+
+    const sub = ctx.host?.querySelector(".cw-sub");
+    if (sub) {
+      sub.textContent = isManual
+        ? "Edit the manual override policy applied during future syncs."
+        : isTracker
+          ? "Edit what CrossWatch sends from its local tracker. Connected provider accounts are not changed."
+          : "Edit your current state or playlist endpoints";
+    }
+
+    if (isPlaylist) {
+      state.kind = "watchlist";
+      state.instance = "default";
+    }
+    ctx.syncKindUI?.();
+
+    if (!policy && state.blockedOnly) {
+      state.blockedOnly = false;
+      ctx.syncTypeFilterUI?.();
+      ctx.persistUIState?.();
+    }
+    ctx.syncStateBulkUI?.();
+    ctx.syncImportUI?.();
+    ctx.syncTypeFilterUI?.();
+    ctx.syncActionButtons?.();
+    ctx.syncHeaderPills?.();
+  }
+
+  function showStateHint(mode, ctx = {}) {
+    const stateHint = ctx.stateHint;
+    if (!stateHint) return;
+    if (mode === "state") {
+      stateHint.innerHTML =
+        "<strong>No state.json found.</strong> Run a CrossWatch sync once to generate it. After that, your manual adds and blocks will show up here.";
+      stateHint.style.display = "block";
+      return;
+    }
+    if (mode === "playlist") {
+      stateHint.innerHTML =
+        "<strong>No playlist endpoints found.</strong> Create an endpoint on the Playlists page first. Then select it here to edit its items.";
+      stateHint.style.display = "block";
+      return;
+    }
+    if (mode === "tracker") {
+      stateHint.innerHTML =
+        "<strong>No Local Tracker data found.</strong> Run a sync pair that uses Local Tracker first.";
+      stateHint.style.display = "block";
+      return;
+    }
+    if (mode === "manual") {
+      stateHint.innerHTML =
+        "<strong>No manual overrides found.</strong> Add a row here or edit a baseline row in Current State to create an override.";
+      stateHint.style.display = "block";
+      return;
+    }
+    stateHint.style.display = "none";
+  }
+
+  async function loadTrackerWorkspaces(ctx = {}) {
+    const state = stateOf(ctx);
+    try {
+      if (ctx.instanceSel) {
+        const nextInst = await ctx.loadInstanceOptions?.("CROSSWATCH", ctx.instanceSel, state.instance || "default");
+        if (nextInst !== state.instance) {
+          state.instance = nextInst;
+          ctx.persistUIState?.();
+        }
+      }
+      const params = new URLSearchParams({ provider_instance: state.instance || "default" });
+      const data = await ctx.fetchJSON(`/api/editor/tracker/workspaces?${params.toString()}`);
+      const list = Array.isArray(data && data.workspaces) ? data.workspaces : [];
+      state.trackerWorkspaces = list;
+      state.trackerAvailable = list.length > 0;
+      if (state.workspace && !list.some(w => String(w && w.id || "") === String(state.workspace))) {
+        state.workspace = "";
+        ctx.persistUIState?.();
+      }
+    } catch (_) {
+      state.trackerWorkspaces = [];
+      state.trackerAvailable = false;
+    }
+    ensureTrackerOption(ctx.sourceSel);
+    return state.trackerWorkspaces;
+  }
+
+  async function loadSnapshots(ctx = {}) {
+    const state = stateOf(ctx);
+    try {
+      if (isTrackerSource(state)) {
+        await loadTrackerWorkspaces(ctx);
+        rebuildSnapshots(ctx);
+        ctx.syncKindUI?.();
+        if (!state.trackerWorkspaces.length) showStateHint("tracker", ctx);
+        else showStateHint(null, ctx);
+        return;
+      }
+      if (state.source === "playlist") {
+        const data = await ctx.fetchJSON("/api/editor/playlists/endpoints");
+        state.playlistEndpoints = Array.isArray(data && data.endpoints) ? data.endpoints : [];
+        state.snapshots = state.playlistEndpoints;
+        rebuildSnapshots(ctx);
+        if (!state.playlistEndpoints.length) showStateHint("playlist", ctx);
+        else showStateHint(null, ctx);
+        return;
+      }
+      if (isProviderPickerSource(state)) {
+        const data = await ctx.fetchJSON(`/api/editor/state/providers`);
+        state.snapshots = Array.isArray(data.providers) ? data.providers : [];
+        rebuildSnapshots(ctx);
+
+        const prov = state.snapshot || (ctx.snapSel ? (ctx.snapSel.value || "") : "");
+        if (prov) {
+          const nextInst = await ctx.loadInstanceOptions?.(prov, ctx.instanceSel, state.instance);
+          if (prov !== state.snapshot || nextInst !== state.instance) {
+            state.snapshot = prov;
+            state.instance = nextInst;
+            ctx.persistUIState?.();
+          }
+        } else {
+          const nextInst = ctx.renderInstanceOptions?.(ctx.instanceSel, [{ id: "default", label: "Default" }], "default");
+          if (state.instance !== nextInst) {
+            state.instance = nextInst;
+            ctx.persistUIState?.();
+          }
+        }
+
+        if (!state.snapshots.length) showStateHint(isManualSource(state) ? "manual" : "state", ctx);
+        else showStateHint(null, ctx);
+        return;
+      }
+      state.source = "state";
+      rebuildSnapshots(ctx);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  Editor.Sources = {
+    SOURCES,
+    normalizeSource,
+    isTrackerSource,
+    isManualSource,
+    isProviderPickerSource,
+    isPolicySource,
+    ensureTrackerOption,
+    currentTrackerWorkspace,
+    trackerKinds,
+    currentPlaylistEndpoint,
+    playlistEditable,
+    syncSnapshotControlVisibility,
+    playlistEndpointLabel,
+    rebuildSnapshots,
+    syncSourceUI,
+    showStateHint,
+    loadTrackerWorkspaces,
+    loadSnapshots,
+  };
+  window.CrossWatchEditorSources = Editor.Sources;
+})();

--- a/assets/js/editor/table-controller.js
+++ b/assets/js/editor/table-controller.js
@@ -1,0 +1,239 @@
+/* assets/js/editor/table-controller.js */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const NS = (window.CW ||= {});
+  const Editor = (NS.Editor ||= {});
+
+  function compareValues(aVal, bVal) {
+    if (typeof aVal === "number" && typeof bVal === "number") {
+      if (aVal < bVal) return -1;
+      if (aVal > bVal) return 1;
+      return 0;
+    }
+    const aStr = aVal == null ? "" : String(aVal).toLowerCase();
+    const bStr = bVal == null ? "" : String(bVal).toLowerCase();
+    if (aStr < bStr) return -1;
+    if (aStr > bStr) return 1;
+    return 0;
+  }
+
+  function applyFilter(rows, ctx = {}) {
+    const state = ctx.state;
+    const rawQ = (state.filter || "").trim();
+    const q = ctx.normalizeSearchText(rawQ);
+    const queryCoord = ctx.parseSeasonEpisodeText(rawQ);
+    const queryTokens = q ? q.split(" ").filter(Boolean) : [];
+    const filters = state.typeFilter || {};
+    const hasTypeFilter = filters.movie || filters.show || filters.anime || filters.season || filters.episode;
+
+    return (rows || []).filter(r => {
+      if (hasTypeFilter) {
+        const t = (r.type || "").toLowerCase();
+        const known = t === "movie" || t === "show" || t === "anime" || t === "season" || t === "episode";
+        let allowed = true;
+        if (known) {
+          if (t === "movie") allowed = !!filters.movie;
+          else if (t === "show") allowed = !!filters.show;
+          else if (t === "anime") allowed = !!filters.anime;
+          else if (t === "season") allowed = !!filters.season;
+          else if (t === "episode") allowed = !!filters.episode;
+        }
+        if (!allowed) return false;
+      }
+
+      if (state.blockedOnly && ctx.isPolicySource()) {
+        if (!(r.deleted && r._origin === "baseline")) return false;
+      }
+
+      if (!q) return true;
+
+      const rowCoord = ctx.rowSeasonEpisode(r);
+      if (queryCoord.season != null && rowCoord.season !== queryCoord.season) return false;
+      if (queryCoord.episode != null && rowCoord.episode !== queryCoord.episode) return false;
+
+      const haystack = ctx.rowSearchHaystack(r);
+      return haystack.includes(q) || queryTokens.every(token => haystack.includes(token));
+    });
+  }
+
+  function sortRows(rows, ctx = {}) {
+    const state = ctx.state;
+    const key = state.sortKey;
+    const dir = state.sortDir === "desc" ? -1 : 1;
+    if (!key) return rows;
+    return (rows || []).slice().sort((a, b) => {
+      let av;
+      let bv;
+      if (key === "title") {
+        av = a.title || "";
+        bv = b.title || "";
+      } else if (key === "type") {
+        av = a.type || "";
+        bv = b.type || "";
+      } else if (key === "key") {
+        av = a.key || "";
+        bv = b.key || "";
+      } else if (key === "extra") {
+        if (state.kind === "ratings") {
+          av = a.raw && a.raw.rating != null ? Number(a.raw.rating) : -Infinity;
+          bv = b.raw && b.raw.rating != null ? Number(b.raw.rating) : -Infinity;
+        } else if (state.kind === "history") {
+          const aw = a.raw && a.raw.watched_at;
+          const bw = b.raw && b.raw.watched_at;
+          av = aw ? Date.parse(aw) || 0 : 0;
+          bv = bw ? Date.parse(bw) || 0 : 0;
+        } else {
+          av = "";
+          bv = "";
+        }
+      } else {
+        av = "";
+        bv = "";
+      }
+      return compareValues(av, bv) * dir;
+    });
+  }
+
+  function updateSortUI(ctx = {}) {
+    const state = ctx.state;
+    ctx.sortHeaders.forEach(th => {
+      const k = th.dataset.sort;
+      th.classList.remove("sort-asc", "sort-desc");
+      if (k === state.sortKey) th.classList.add(state.sortDir === "desc" ? "sort-desc" : "sort-asc");
+    });
+  }
+
+  function tableRowContext(ctx = {}, anilistMode, wideActions) {
+    return {
+      state: ctx.state,
+      anilistMode,
+      wideActions,
+      isPolicySource: ctx.isPolicySource,
+      isTrackerSource: ctx.isTrackerSource,
+      isRowLocked: ctx.isRowLocked,
+      isExtraKindEditable: ctx.isExtraKindEditable,
+      canReplaceRow: ctx.canReplaceRow,
+      usesCoordinateReplacer: ctx.usesCoordinateReplacer,
+      rowType: ctx.rowType,
+      markChanged: ctx.markChanged,
+      renderRows: ctx.renderRows,
+      syncBulkBar: ctx.syncBulkBar,
+      syncSelectPageCheckbox: ctx.syncSelectPageCheckbox,
+      updateTypeDisplay: ctx.updateTypeDisplay,
+      updateExtraDisplay: ctx.updateExtraDisplay,
+      formatEpisodeVisualTitle: ctx.formatEpisodeVisualTitle,
+      formatSxxEyy: ctx.formatSxxEyy,
+      openTypeEditor: ctx.openTypeEditor,
+      openTitleSearchEditor: ctx.openTitleSearchEditor,
+      openItemReplacer: ctx.openItemReplacer,
+      openRawFieldsModal: ctx.openRawFieldsModal,
+      openRatingEditor: ctx.openRatingEditor,
+      openHistoryEditor: ctx.openHistoryEditor,
+      openProgressEditor: ctx.openProgressEditor,
+    };
+  }
+
+  function renderRows(ctx = {}) {
+    const state = ctx.state;
+    ctx.closePopup();
+    updateSortUI(ctx);
+    ctx.syncIdColumnHeaders();
+
+    let filtered = applyFilter(state.rows || [], ctx);
+    const totalFiltered = filtered.length;
+    const totalAll = (state.rows || []).length;
+    ctx.syncHeaderPills(totalFiltered, totalAll);
+
+    filtered = sortRows(filtered, ctx);
+
+    let movies = 0;
+    let shows = 0;
+    let seasons = 0;
+    let episodes = 0;
+    for (const row of state.rows || []) {
+      const t = (row.type || "").toLowerCase();
+      if (t === "movie") movies += 1;
+      else if (t === "show") shows += 1;
+      else if (t === "season") seasons += 1;
+      else if (t === "episode") episodes += 1;
+    }
+    if (ctx.summaryMovies) ctx.summaryMovies.textContent = String(movies);
+    if (ctx.summaryShows) ctx.summaryShows.textContent = String(shows);
+    if (ctx.summarySeasons) ctx.summarySeasons.textContent = String(seasons);
+    if (ctx.summaryEpisodes) ctx.summaryEpisodes.textContent = String(episodes);
+
+    if (ctx.tbody) ctx.tbody.innerHTML = "";
+
+    const actionHead = ctx.host.querySelector(".cw-action-head");
+    const wideActions = !!ctx.isPolicySource();
+    if (actionHead) {
+      actionHead.classList.toggle("cw-action-wide", wideActions);
+      actionHead.style.width = wideActions ? "132px" : "46px";
+    }
+
+    if (!totalFiltered) {
+      if (ctx.empty) ctx.empty.style.display = "block";
+      if (ctx.empty) {
+        const main = ctx.empty.closest(".cw-main");
+        if (main) main.classList.add("cw-main-empty");
+      }
+      if (ctx.pager) ctx.pager.style.display = "none";
+      if (ctx.summaryVisible) ctx.summaryVisible.textContent = "0";
+      if (ctx.summaryTotal) ctx.summaryTotal.textContent = String(totalAll || 0);
+      ctx.setStatus("0 rows visible");
+      state.pageRids = [];
+      ctx.syncSelectPageCheckbox();
+      ctx.syncBulkBar();
+      if (ctx.pageInfo) ctx.pageInfo.textContent = "";
+      return;
+    }
+
+    if (ctx.empty) ctx.empty.style.display = "none";
+    if (ctx.empty) {
+      const main = ctx.empty.closest(".cw-main");
+      if (main) main.classList.remove("cw-main-empty");
+    }
+
+    const pageSize = ctx.pageSize || 100;
+    const pageCount = Math.max(1, Math.ceil(totalFiltered / pageSize));
+    if (state.page >= pageCount) state.page = pageCount - 1;
+    if (state.page < 0) state.page = 0;
+
+    const start = state.page * pageSize;
+    const end = start + pageSize;
+    const rows = filtered.slice(start, end);
+
+    state.pageRids = rows.map(r => r._rid);
+    ctx.syncSelectPageCheckbox();
+    ctx.syncBulkBar();
+
+    const frag = document.createDocumentFragment();
+    const rowCtx = tableRowContext(ctx, ctx.isAnilistMode(), wideActions);
+    rows.forEach(row => {
+      const tr = ctx.editorTable.createRowElement(row, rowCtx);
+      if (tr) frag.appendChild(tr);
+    });
+    if (ctx.tbody) ctx.tbody.appendChild(frag);
+
+    const vis = rows.length;
+    const first = start + 1;
+    const last = start + vis;
+
+    if (ctx.summaryVisible) ctx.summaryVisible.textContent = String(vis);
+    if (ctx.summaryTotal) ctx.summaryTotal.textContent = String(totalAll);
+
+    if (ctx.pageInfo) ctx.pageInfo.textContent = `Page ${state.page + 1} of ${pageCount} • Rows ${first}-${last} of ${totalFiltered}`;
+    if (ctx.pager) ctx.pager.style.display = pageCount > 1 ? "flex" : "none";
+    if (ctx.prevBtn) ctx.prevBtn.disabled = state.page <= 0;
+    if (ctx.nextBtn) ctx.nextBtn.disabled = state.page >= pageCount - 1;
+
+    if (totalFiltered > vis) {
+      ctx.setRowsStatus(`${vis} rows visible (rows ${first}-${last} of ${totalFiltered} filtered, ${totalAll} total)`);
+    } else {
+      ctx.setRowsStatus(`${vis} rows visible, ${totalAll} total`);
+    }
+  }
+
+  Editor.TableController = { applyFilter, sortRows, updateSortUI, renderRows };
+  window.CrossWatchEditorTableController = Editor.TableController;
+})();

--- a/assets/js/editor/table.js
+++ b/assets/js/editor/table.js
@@ -1,0 +1,284 @@
+/* assets/js/editor/table.js */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(function () {
+  const NS = (window.CW ||= {});
+  const Editor = (NS.Editor ||= {});
+
+  function call(ctx, name, ...args) {
+    const fn = ctx && ctx[name];
+    return typeof fn === "function" ? fn(...args) : undefined;
+  }
+
+  function cell(inner) {
+    const td = document.createElement("td");
+    td.appendChild(inner);
+    return td;
+  }
+
+  function createRowElement(row, ctx = {}) {
+    const state = ctx.state || {};
+    const anilistMode = !!ctx.anilistMode;
+    const locked = !!call(ctx, "isRowLocked", row);
+    const blockMode = !!call(ctx, "isPolicySource");
+    const tr = document.createElement("tr");
+    const fieldName = suffix => `cw-row-${row._rid || "new"}-${suffix}`;
+
+    if (row.episode) tr.classList.add("cw-row-episode");
+    if (row.deleted) tr.classList.add("cw-row-deleted");
+
+    const selCb = document.createElement("input");
+    selCb.type = "checkbox";
+    selCb.name = fieldName("selected");
+    selCb.className = "cw-checkbox";
+    selCb.checked = (state.selected || new Set()).has(row._rid);
+    selCb.onchange = () => {
+      if (!state.selected) state.selected = new Set();
+      if (selCb.checked) state.selected.add(row._rid);
+      else state.selected.delete(row._rid);
+      call(ctx, "syncBulkBar");
+      call(ctx, "syncSelectPageCheckbox");
+    };
+    tr.appendChild(cell(selCb));
+
+    const baselineRow = blockMode && row._origin === "baseline";
+    const delBtn = document.createElement("button");
+    delBtn.type = "button";
+    delBtn.className = "cw-btn cw-btn-del danger";
+    delBtn.innerHTML = `<span class="material-symbol">${blockMode ? "block" : "delete"}</span>`;
+    delBtn.title = blockMode
+      ? (baselineRow
+          ? (row.deleted ? "Restore for future syncs" : "Block from future syncs")
+          : (row.deleted ? "Restore row" : "Remove manual correction"))
+      : (row.deleted ? "Restore row" : "Delete row");
+    delBtn.onclick = () => {
+      row.deleted = !row.deleted;
+      call(ctx, "markChanged");
+      call(ctx, "renderRows");
+    };
+    const delTd = cell(delBtn);
+    delTd.className = "cw-action-cell";
+    if (ctx.wideActions) delTd.classList.add("cw-action-wide");
+
+    if (call(ctx, "canReplaceRow", row)) {
+      const t = String(call(ctx, "rowType", row) || "").toLowerCase();
+      const repBtn = document.createElement("button");
+      repBtn.type = "button";
+      repBtn.className = "cw-btn cw-btn-del";
+      repBtn.innerHTML = '<span class="material-symbol">published_with_changes</span>';
+      repBtn.title = t === "episode" ? "Replace episode" : t === "season" ? "Replace season" : "Replace item";
+      repBtn.style.marginLeft = "4px";
+      repBtn.onclick = () => call(ctx, "openItemReplacer", row, repBtn);
+      delTd.appendChild(repBtn);
+    }
+
+    if (blockMode) {
+      const rawBtn = document.createElement("button");
+      rawBtn.type = "button";
+      rawBtn.className = "cw-btn cw-btn-del";
+      rawBtn.innerHTML = '<span class="material-symbol">data_object</span>';
+      rawBtn.title = "Advanced fields";
+      rawBtn.setAttribute("aria-label", "Advanced fields");
+      rawBtn.style.marginLeft = "4px";
+      rawBtn.onclick = () => call(ctx, "openRawFieldsModal", row);
+      delTd.appendChild(rawBtn);
+    }
+    tr.appendChild(delTd);
+
+    const keyIn = document.createElement("input");
+    keyIn.name = fieldName("key");
+    keyIn.value = row.key || "";
+    keyIn.className = "cw-key";
+    keyIn.disabled = locked;
+    keyIn.oninput = e => {
+      row.key = e.target.value;
+      call(ctx, "markChanged");
+    };
+    tr.appendChild(cell(keyIn));
+
+    const typeBtn = document.createElement("button");
+    typeBtn.type = "button";
+    typeBtn.className = "cw-extra-display cw-type-display";
+    typeBtn.disabled = locked;
+    if (locked) {
+      typeBtn.style.opacity = "0.6";
+      typeBtn.style.cursor = "not-allowed";
+    }
+    call(ctx, "updateTypeDisplay", row, typeBtn);
+    typeBtn.onclick = () => {
+      if (typeBtn.disabled) return;
+      call(ctx, "openTypeEditor", row, typeBtn);
+    };
+    tr.appendChild(cell(typeBtn));
+
+    const titleCell = document.createElement("div");
+    titleCell.className = "cw-title-cell";
+
+    const titleRow = document.createElement("div");
+    titleRow.className = "cw-title-row";
+    titleCell.appendChild(titleRow);
+
+    const titleIn = document.createElement("input");
+    titleIn.name = fieldName("title");
+    titleIn.value = call(ctx, "formatEpisodeVisualTitle", row) || row.title || "";
+    titleIn.disabled = locked;
+    titleIn.onfocus = () => {
+      const visual = call(ctx, "formatEpisodeVisualTitle", row);
+      if (visual) titleIn.value = row.title || "";
+    };
+    titleIn.oninput = e => {
+      row.title = e.target.value;
+      row.raw.title = e.target.value || null;
+      call(ctx, "markChanged");
+    };
+    titleIn.onblur = () => {
+      const visual = call(ctx, "formatEpisodeVisualTitle", row);
+      if (visual) titleIn.value = visual;
+    };
+    titleRow.appendChild(titleIn);
+
+    const yearIn = document.createElement("input");
+    yearIn.name = fieldName("year");
+    yearIn.value = row.year || "";
+    yearIn.disabled = locked;
+    yearIn.oninput = e => {
+      row.year = e.target.value;
+      const v = e.target.value.trim();
+      const n = v ? parseInt(v, 10) : NaN;
+      row.raw.year = Number.isFinite(n) ? n : null;
+      call(ctx, "markChanged");
+    };
+
+    const imdbIn = document.createElement("input");
+    imdbIn.name = fieldName("imdb");
+    imdbIn.value = row.imdb || "";
+    imdbIn.disabled = locked;
+    imdbIn.oninput = e => {
+      row.imdb = e.target.value;
+      row.raw.ids = row.raw.ids || {};
+      if (e.target.value) row.raw.ids.imdb = e.target.value;
+      else delete row.raw.ids.imdb;
+      call(ctx, "markChanged");
+    };
+
+    const idAIn = document.createElement("input");
+    idAIn.name = fieldName(anilistMode ? "mal" : "tmdb");
+    idAIn.value = anilistMode ? (row.mal || "") : (row.tmdb || "");
+    idAIn.placeholder = anilistMode ? "MAL..." : "TMDB...";
+    idAIn.disabled = locked;
+    idAIn.oninput = e => {
+      const v = e.target.value;
+      row.raw.ids = row.raw.ids || {};
+      if (anilistMode) {
+        row.mal = v;
+        if (v) row.raw.ids.mal = v;
+        else delete row.raw.ids.mal;
+      } else {
+        row.tmdb = v;
+        if (v) row.raw.ids.tmdb = v;
+        else delete row.raw.ids.tmdb;
+      }
+      call(ctx, "markChanged");
+    };
+
+    const idBIn = document.createElement("input");
+    idBIn.name = fieldName(anilistMode ? "anilist" : "trakt");
+    idBIn.value = anilistMode ? (row.anilist || "") : (row.trakt || "");
+    idBIn.placeholder = anilistMode ? "AniList..." : "Trakt...";
+    idBIn.disabled = locked;
+    idBIn.oninput = e => {
+      const v = e.target.value;
+      row.raw.ids = row.raw.ids || {};
+      if (anilistMode) {
+        row.anilist = v;
+        if (v) row.raw.ids.anilist = v;
+        else delete row.raw.ids.anilist;
+      } else {
+        row.trakt = v;
+        if (v) row.raw.ids.trakt = v;
+        else delete row.raw.ids.trakt;
+      }
+      call(ctx, "markChanged");
+    };
+
+    const searchBtn = document.createElement("button");
+    searchBtn.type = "button";
+    searchBtn.className = "cw-title-search-btn";
+    searchBtn.innerHTML = '<span class="material-symbol">search</span>';
+    const searchUsesCorrection = locked && call(ctx, "canReplaceRow", row);
+    searchBtn.title = searchUsesCorrection
+      ? (call(ctx, "usesCoordinateReplacer", row) ? "Replace episode" : "Search and add correction")
+      : "Search and fill IDs";
+    searchBtn.disabled = locked && !searchUsesCorrection;
+    if (searchBtn.disabled) {
+      searchBtn.style.opacity = "0.6";
+      searchBtn.style.cursor = "not-allowed";
+    }
+    searchBtn.onclick = () => {
+      if (searchBtn.disabled) return;
+      if (searchUsesCorrection) {
+        call(ctx, "openItemReplacer", row, searchBtn);
+        return;
+      }
+      call(ctx, "openTitleSearchEditor", row, searchBtn, {
+        keyIn,
+        titleIn,
+        yearIn,
+        imdbIn,
+        tmdbIn: anilistMode ? null : idAIn,
+        traktIn: null,
+        typeBtn,
+      });
+    };
+    titleRow.appendChild(searchBtn);
+
+    const subType = (((row.raw && row.raw.type) || row.type || "") + "").toLowerCase();
+    if (subType === "season" && row.raw && row.raw.series_title) {
+      const sub = document.createElement("div");
+      sub.className = "cw-title-sub";
+      let label = row.raw.series_title;
+      const code = subType === "episode"
+        ? call(ctx, "formatSxxEyy", row.raw.season, row.raw.episode)
+        : call(ctx, "formatSxxEyy", row.raw.season, null);
+      if (code) label += " - " + code;
+      sub.textContent = label;
+      titleCell.appendChild(sub);
+    }
+    if (call(ctx, "isTrackerSource") && row._origin !== "baseline") {
+      const origin = document.createElement("div");
+      origin.className = "cw-title-sub";
+      origin.textContent = "Manual correction";
+      titleCell.appendChild(origin);
+    }
+    tr.appendChild(cell(titleCell));
+
+    const yearTd = cell(yearIn);
+    yearTd.className = "cw-col-year";
+    tr.appendChild(yearTd);
+    tr.appendChild(cell(idAIn));
+
+    const extraBtn = document.createElement("button");
+    extraBtn.type = "button";
+    extraBtn.className = "cw-extra-display";
+    call(ctx, "updateExtraDisplay", row, extraBtn);
+
+    if (!call(ctx, "isExtraKindEditable")) {
+      extraBtn.disabled = true;
+      extraBtn.style.opacity = "0.6";
+      extraBtn.style.cursor = "default";
+    } else if (state.kind === "ratings") {
+      extraBtn.onclick = () => call(ctx, "openRatingEditor", row, extraBtn, extraBtn);
+    } else if (state.kind === "history") {
+      extraBtn.onclick = () => call(ctx, "openHistoryEditor", row, extraBtn, extraBtn);
+    } else if (state.kind === "progress") {
+      extraBtn.onclick = () => call(ctx, "openProgressEditor", row, extraBtn, extraBtn);
+    }
+    tr.appendChild(cell(extraBtn));
+
+    return tr;
+  }
+
+  Editor.Table = {
+    createRowElement,
+  };
+  window.CrossWatchEditorTable = Editor.Table;
+})();

--- a/tests/test_editor_playlists.py
+++ b/tests/test_editor_playlists.py
@@ -137,34 +137,85 @@ def test_editor_blocks_readonly_playlist_endpoint(monkeypatch, editor_playlist) 
 def test_editor_ui_exposes_playlist_source() -> None:
     from pathlib import Path
 
-    js = (Path(__file__).resolve().parents[1] / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
-    assert 'option[value="playlist"]' in js
-    assert "/api/editor/playlists/endpoints" in js
-    assert "payload.endpoint = state.snapshot" in js
-    assert "state.playlistOriginalKeys" in js
-    assert 'const SOURCES = ["state", "tracker", "playlist"];' in js
-    assert "state.source = normalizeSource(state.source);" in js
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    chrome_js = (root / "assets" / "js" / "editor" / "chrome.js").read_text(encoding="utf-8")
+    load_js = (root / "assets" / "js" / "editor" / "load-controller.js").read_text(encoding="utf-8")
+    sources_js = (root / "assets" / "js" / "editor" / "sources.js").read_text(encoding="utf-8")
+    persistence_js = (root / "assets" / "js" / "editor" / "persistence.js").read_text(encoding="utf-8")
+    assert 'option[value="playlist"]' in chrome_js
+    assert 'option[value="manual"]' in chrome_js
+    assert "Manual Overrides" in chrome_js
+    assert "/api/editor/playlists/endpoints" in sources_js
+    assert "payload.endpoint = state.snapshot" in persistence_js
+    assert "state.playlistOriginalKeys" in load_js
+    assert 'const SOURCES = ["state", "manual", "tracker", "playlist"];' in sources_js
+    assert "state.source = ctx.normalizeSource(state.source);" in load_js
 
 
 def test_editor_ui_allows_extra_policy_corrections() -> None:
     from pathlib import Path
 
-    js = (Path(__file__).resolve().parents[1] / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    table_js = (root / "assets" / "js" / "editor" / "table.js").read_text(encoding="utf-8")
+    load_js = (root / "assets" / "js" / "editor" / "load-controller.js").read_text(encoding="utf-8")
     assert "function promoteBaselineEdit(row)" in js
-    assert "const extraEditable = isExtraKindEditable();" in js
-    assert 'row._origin = manualKeys.has(rowKey) ? "manual"' in js
+    assert "function manualCorrectionKindLabel" in js
+    assert 'if (k === "history") return "history date";' in js
+    assert 'if (k === "ratings") return "rating";' in js
+    assert "Save changes to use it on the next sync." in js
+    assert "const status = extraCorrectionStatus(row, promoted);" in js
+    assert 'call(ctx, "isExtraKindEditable")' in table_js
+    assert 'row._origin = manualKeys.has(rowKey) ? "manual"' in load_js
+
+
+def test_editor_manual_override_source_loads_policy_only(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(api, "_STATE_PATH", tmp_path / "state.json")
+    monkeypatch.setattr(api, "_POLICY_PATH", tmp_path / "state.manual.json")
+
+    api.api_editor_save_state(
+        {
+            "source": "manual",
+            "kind": "history",
+            "provider": "TRAKT",
+            "provider_instance": "default",
+            "items": {
+                "tmdb:76479#s01e01": {
+                    "type": "episode",
+                    "series_title": "The Boys",
+                    "season": 1,
+                    "episode": 1,
+                    "watched_at": "2019-07-25T08:02:00.000Z",
+                    "show_ids": {"tmdb": "76479"},
+                }
+            },
+            "blocks": ["tmdb:76479#s01e02"],
+        }
+    )
+
+    data = api.api_editor_get_state(kind="history", source="manual", provider="TRAKT")
+
+    assert data["source"] == "manual"
+    assert data["provider"] == "TRAKT"
+    assert list(data["items"]) == ["tmdb:76479#s01e01"]
+    assert data["manual_blocks"] == ["tmdb:76479#s01e02"]
 
 
 def test_editor_ui_displays_percent_only_progress() -> None:
     from pathlib import Path
 
-    js = (Path(__file__).resolve().parents[1] / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    datetime_js = (root / "assets" / "js" / "editor" / "datetime.js").read_text(encoding="utf-8")
+    extra_js = (root / "assets" / "js" / "editor" / "extra-editors.js").read_text(encoding="utf-8")
     assert "function progressPercentValue(raw)" in js
-    assert '"progress_percent", "progressPercent", "percent", "position_percent", "resume_percent"' in js
-    assert "if (percent != null) label = formatProgressPercent(percent);" in js
-    assert "row.raw.progress_percent = row.raw.progress_ms != null" in js
-    assert "cw-progress-edit-grid" in js
-    assert "cw-progress-percent-suffix" in js
+    assert "function progressPercentValue(raw)" in datetime_js
+    assert '"progress_percent", "progressPercent", "percent", "position_percent", "resume_percent"' in datetime_js
+    assert "if (percent != null) label = dt.formatProgressPercent" in extra_js
+    assert "row.raw.progress_percent = row.raw.progress_ms != null" in extra_js
+    assert "cw-progress-edit-grid" in extra_js
+    assert "cw-progress-percent-suffix" in extra_js
 
 
 def test_editor_ui_exposes_raw_fields_modal() -> None:
@@ -172,22 +223,350 @@ def test_editor_ui_exposes_raw_fields_modal() -> None:
 
     root = Path(__file__).resolve().parents[1]
     js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    table_js = (root / "assets" / "js" / "editor" / "table.js").read_text(encoding="utf-8")
     modals = (root / "assets" / "js" / "modals.js").read_text(encoding="utf-8")
+    css = (root / "assets" / "css" / "components.css").read_text(encoding="utf-8")
     raw_modal = root / "assets" / "js" / "modals" / "editor-raw" / "index.js"
 
     assert raw_modal.exists()
     assert "function openRawFieldsModal(row)" in js
-    assert "data_object" in js
+    assert "data_object" in table_js
     assert "window.openEditorRawModal" in modals
     assert "ModalRegistry.register('editor-raw'" in modals
+    assert ".cx-modal-shell:has(#cx-modal.editor-raw-modal)" in css
+    assert "#cx-modal.editor-raw-modal .raw-path" in css
 
 
 def test_editor_refresh_is_source_aware() -> None:
     from pathlib import Path
 
-    js = (Path(__file__).resolve().parents[1] / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    load_js = (root / "assets" / "js" / "editor" / "load-controller.js").read_text(encoding="utf-8")
     assert "function syncSelectedScopeFromControls()" in js
-    assert "state.workspace = (snapSel && snapSel.value)" in js
+    assert "function syncSelectedScopeFromControls(ctx = {})" in load_js
+    assert "state.workspace = (ctx.snapSel && ctx.snapSel.value)" in load_js
     assert 'state.snapshot = "";' in js
-    assert "await refreshEditor({ force: true });" in js
+    assert 'state.snapshot = "";' in load_js
+    assert "await refreshEditor({ force: true });" in js or "refreshEditor({ force: true });" in js
     assert 'window.addEventListener("sync-complete"' in js
+
+
+def test_editor_filter_supports_season_episode_queries() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    search_js = (root / "assets" / "js" / "editor" / "search.js").read_text(encoding="utf-8")
+    core_js = (root / "assets" / "helpers" / "core.js").read_text(encoding="utf-8")
+    assert 'await ensurePageModule("editor-search", "/assets/js/editor/search.js", "CrossWatchEditorSearch");' in core_js
+    assert 'filterInput.placeholder = "Filter by title / S01 / S01E02 / id...";' in js
+    assert 'const editorSearch = requireEditorModule("Search");' in js
+    assert "function parseSeasonEpisodeText(value)" in search_js
+    assert "function rowSearchHaystack(row, options = {})" in search_js
+    assert 'pieces.push(`season ${season}`, `season ${s2}`, `s${s2}`, `s${season}`);' in search_js
+    assert 'pieces.push(`s${s2}e${e2}`, `${season}x${episode}`, `${s2}x${e2}`, `season ${season} episode ${episode}`);' in search_js
+    table_controller_js = (root / "assets" / "js" / "editor" / "table-controller.js").read_text(encoding="utf-8")
+    assert "queryTokens.every(token => haystack.includes(token))" in table_controller_js
+    assert "state.page = 0;\n      clearSelection();\n      persistUIState();" not in js
+    assert "state.pageRids = [];\n      syncSelectPageCheckbox();\n      clearSelection();" not in js
+
+
+def test_editor_send_button_opens_visible_modal() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    send_js = (root / "assets" / "js" / "editor" / "send-modal.js").read_text(encoding="utf-8")
+    core_js = (root / "assets" / "helpers" / "core.js").read_text(encoding="utf-8")
+    css = (root / "assets" / "css" / "pages.css").read_text(encoding="utf-8")
+    assert 'await ensurePageModule("editor-send-modal", "/assets/js/editor/send-modal.js", "CrossWatchEditorSendModal");' in core_js
+    assert 'const editorSendModal = requireEditorModule("SendModal");' in js
+    assert "return editorSendModal.open({" in js
+    assert 'shell.className = "cw-editor-send-overlay";' in send_js
+    assert "Loading providers..." in send_js
+    assert "Could not load providers." in send_js
+    assert 'PM.logoHtml(p, "cw-editor-send-logo")' in send_js
+    assert "function formatSendResult(data, esc)" in send_js
+    assert "Send complete" in send_js
+    assert "attempted</span>" in send_js
+    assert "Provider target" not in js
+    assert "Provider target" not in send_js
+    assert "Data to send" in send_js
+    assert "Send selected data" in send_js
+    assert "const currentSourceProviderKey = () =>" in send_js
+    assert ".filter(p => providerKey(p) !== sourceKey)" in send_js
+    assert "No other configured target provider is available for this view." in send_js
+    assert 'body?.scrollTo({ top: body.scrollHeight, behavior: "smooth" });' in send_js
+    assert "cw-editor-send-result-icon" in send_js
+    assert ".cw-editor-send-overlay{position:fixed" in css
+    assert ".cw-editor-send-provider.active .cw-editor-send-check" in css
+    assert ".cw-editor-send-list{display:grid;grid-template-columns:repeat(3,minmax(0,1fr))" in css
+    assert ".cw-editor-send-progress-bar" in css
+    assert ".cw-editor-send-run-card" in css
+    assert ".cw-editor-send-result-icon" in css
+    assert ".cw-editor-send-card .body::-webkit-scrollbar-thumb" in css
+
+
+def test_editor_bulk_action_buttons_use_playback_action_colors() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    css = (root / "assets" / "css" / "pages.css").read_text(encoding="utf-8")
+    assert "#page-editor .cw-bulk .cw-btn.cw-icon-only{box-sizing:border-box !important;width:44px !important;min-width:44px !important;height:44px !important;min-height:44px !important;padding:0 !important;border-radius:13px !important" in css
+    assert "#page-editor .cw-bulk #cw-bulk-send.cw-icon-only{background:linear-gradient(180deg,rgba(63,126,255,0.56),rgba(35,78,188,0.74))!important" in css
+    assert "#page-editor .cw-bulk #cw-bulk-restore.cw-icon-only{background:linear-gradient(180deg,rgba(64,166,105,0.48),rgba(34,119,76,0.68))!important" in css
+    assert "#page-editor .cw-bulk #cw-bulk-remove.cw-icon-only{background:linear-gradient(180deg,rgba(139,41,64,0.64),rgba(95,29,46,0.78))!important" in css
+    assert "#page-editor .cw-bulk #cw-bulk-clear.cw-icon-only{background:rgba(12,16,25,0.34)!important" in css
+    assert "#page-editor .cw-bulk .cw-btn.cw-icon-only .material-symbols-rounded{color:currentColor !important;-webkit-text-fill-color:currentColor !important}" in css
+
+
+def test_editor_datetime_fields_use_utc() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    datetime_js = (root / "assets" / "js" / "editor" / "datetime.js").read_text(encoding="utf-8")
+    extra_js = (root / "assets" / "js" / "editor" / "extra-editors.js").read_text(encoding="utf-8")
+    core_js = (root / "assets" / "helpers" / "core.js").read_text(encoding="utf-8")
+    assert 'await ensurePageModule("editor-datetime", "/assets/js/editor/datetime.js", "CrossWatchEditorDateTime");' in core_js
+    assert 'await ensurePageModule("editor-extra-editors", "/assets/js/editor/extra-editors.js", "CrossWatchEditorExtraEditors");' in core_js
+    assert 'const editorDateTime = requireEditorModule("DateTime");' in js
+    assert 'const editorExtraEditors = requireEditorModule("ExtraEditors");' in js
+    assert "editorExtraEditors.openHistoryEditor" in js
+    assert "editorExtraEditors.openProgressEditor" in js
+    assert "editorExtraEditors.openRatingEditor" in js
+    assert "d.getUTCFullYear()" in datetime_js
+    assert "d.getUTCHours()" in datetime_js
+    assert "new Date(Date.UTC(y, m - 1, dDay, hh, mm, 0))" in datetime_js
+    assert "Times are shown and saved in UTC." in datetime_js
+    assert "function openHistoryEditor(row, anchor, displayEl, ctx = {})" in extra_js
+    assert "function openProgressEditor(row, anchor, displayEl, ctx = {})" in extra_js
+    assert "function updateExtraDisplay(row, el, ctx = {})" in extra_js
+
+
+def test_editor_metadata_replacer_is_extracted() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    meta_js = (root / "assets" / "js" / "editor" / "metadata-replacer.js").read_text(encoding="utf-8")
+    core_js = (root / "assets" / "helpers" / "core.js").read_text(encoding="utf-8")
+    assert 'await ensurePageModule("editor-metadata-replacer", "/assets/js/editor/metadata-replacer.js", "CrossWatchEditorMetadataReplacer");' in core_js
+    assert "function metadataReplacerContext()" in js
+    assert 'const editorMetadataReplacer = requireEditorModule("MetadataReplacer");' in js
+    assert "editorMetadataReplacer.openItemReplacer" in js
+    assert "editorMetadataReplacer.openTitleSearchEditor" in js
+    assert "function openTitleSearchEditor(row, anchor, refs, ctx = {})" in meta_js
+    assert "function openMetadataReplacer(row, anchor, ctx = {})" in meta_js
+    assert "function openEpisodeReplacer(row, anchor, ctx = {})" in meta_js
+    assert "function coordinateKeyFor(row, season, episode)" in meta_js
+    assert "Search metadata" in meta_js
+    assert "Replace episode" in meta_js
+    assert "function correctedEpisodeItem" not in js
+    assert "const EPISODE_ID_FIELDS" not in js
+
+
+def test_editor_row_building_is_extracted() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    rows_js = (root / "assets" / "js" / "editor" / "rows.js").read_text(encoding="utf-8")
+    core_js = (root / "assets" / "helpers" / "core.js").read_text(encoding="utf-8")
+    assert 'await ensurePageModule("editor-rows", "/assets/js/editor/rows.js", "CrossWatchEditorRows");' in core_js
+    assert 'const editorRows = requireEditorModule("Rows");' in js
+    assert "function buildRows(items, options = {})" in rows_js
+    assert "function buildManualOverrideRows(items, blocks, options = {})" in rows_js
+    assert "function applyManualRow(row, item, key)" in rows_js
+    assert "function imdbFromKey(key)" in rows_js
+    assert "JSON.parse(JSON.stringify(raw))" not in js
+    assert "window.CrossWatchEditorRows = Editor.Rows;" in rows_js
+
+
+def test_editor_table_row_rendering_is_extracted() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    table_js = (root / "assets" / "js" / "editor" / "table.js").read_text(encoding="utf-8")
+    table_controller_js = (root / "assets" / "js" / "editor" / "table-controller.js").read_text(encoding="utf-8")
+    core_js = (root / "assets" / "helpers" / "core.js").read_text(encoding="utf-8")
+    assert 'await ensurePageModule("editor-table", "/assets/js/editor/table.js", "CrossWatchEditorTable");' in core_js
+    assert 'await ensurePageModule("editor-table-controller", "/assets/js/editor/table-controller.js", "CrossWatchEditorTableController");' in core_js
+    assert 'const editorTable = requireEditorModule("Table");' in js
+    assert 'const editorTableController = requireEditorModule("TableController");' in js
+    assert "function tableControllerContext()" in js
+    assert "function tableRowContext(ctx = {}, anilistMode, wideActions)" in table_controller_js
+    assert "ctx.editorTable.createRowElement(row, rowCtx)" in table_controller_js
+    assert "function renderRows(ctx = {})" in table_controller_js
+    assert "function applyFilter(rows, ctx = {})" in table_controller_js
+    assert "function sortRows(rows, ctx = {})" in table_controller_js
+    assert "function createRowElement(row, ctx = {})" in table_js
+    assert "cw-title-search-btn" in table_js
+    assert "openRawFieldsModal" in table_js
+    assert "openTitleSearchEditor" in table_js
+    assert "const fieldName = suffix => `cw-row-${row._rid || \"new\"}-${suffix}`;" not in js
+    assert "function tableRowContext(anilistMode, wideActions)" not in js
+    assert "window.CrossWatchEditorTable = Editor.Table;" in table_js
+    assert "window.CrossWatchEditorTableController = Editor.TableController;" in table_controller_js
+
+
+def test_editor_row_editor_is_extracted() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    row_editor_js = (root / "assets" / "js" / "editor" / "row-editor.js").read_text(encoding="utf-8")
+    core_js = (root / "assets" / "helpers" / "core.js").read_text(encoding="utf-8")
+    assert 'await ensurePageModule("editor-row-editor", "/assets/js/editor/row-editor.js", "CrossWatchEditorRowEditor");' in core_js
+    assert 'const editorRowEditor = requireEditorModule("RowEditor");' in js
+    assert "function rowEditorContext()" in js
+    assert "return editorRowEditor.updateTypeDisplay(row, el);" in js
+    assert "return editorRowEditor.openTypeEditor(row, anchor, rowEditorContext());" in js
+    assert "return editorRowEditor.addRow(rowEditorContext());" in js
+    assert "function updateTypeDisplay(row, el)" in row_editor_js
+    assert "function openTypeEditor(row, anchor, ctx = {})" in row_editor_js
+    assert "function addRow(ctx = {})" in row_editor_js
+    assert "window.CrossWatchEditorRowEditor = Editor.RowEditor;" in row_editor_js
+    assert "const raw = { ids: {}, type: \"movie\", title: \"\", year: null };" not in js
+
+
+def test_editor_file_utils_are_extracted() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    files_js = (root / "assets" / "js" / "editor" / "file-utils.js").read_text(encoding="utf-8")
+    core_js = (root / "assets" / "helpers" / "core.js").read_text(encoding="utf-8")
+    assert 'await ensurePageModule("editor-file-utils", "/assets/js/editor/file-utils.js", "CrossWatchEditorFileUtils");' in core_js
+    assert 'const editorFileUtils = requireEditorModule("FileUtils");' in js
+    assert "return editorFileUtils.fetchJSON(url, opts);" in js
+    assert "return editorFileUtils.downloadFile(url, filename, toast, { setTag, setStatus });" in js
+    assert "return editorFileUtils.bindFileImport(btn, input, url, done, { on, setTag, setStatus });" in js
+    assert "async function fetchBlob(url)" in files_js
+    assert "function saveBlob(blob, filename)" in files_js
+    assert "async function uploadJSON(url, file)" in files_js
+    assert "function bindFileImport(btn, input, url, done, ctx = {})" in files_js
+    assert "window.CrossWatchEditorFileUtils = Editor.FileUtils;" in files_js
+    assert "URL.createObjectURL(blob)" not in js
+
+
+def test_editor_load_controller_is_extracted() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    load_js = (root / "assets" / "js" / "editor" / "load-controller.js").read_text(encoding="utf-8")
+    core_js = (root / "assets" / "helpers" / "core.js").read_text(encoding="utf-8")
+    assert 'await ensurePageModule("editor-load-controller", "/assets/js/editor/load-controller.js", "CrossWatchEditorLoadController");' in core_js
+    assert 'const editorLoadController = requireEditorModule("LoadController");' in js
+    assert "function loadControllerContext()" in js
+    assert "return editorLoadController.loadState(loadControllerContext());" in js
+    assert "return editorLoadController.refreshEditor(loadControllerContext(), { force });" in js
+    assert "return editorLoadController.queueEditorRefresh(loadControllerContext(), delay);" in js
+    assert "async function loadState(ctx = {})" in load_js
+    assert "async function refreshEditor(ctx = {}, options = {})" in load_js
+    assert "function queueEditorRefresh(ctx = {}, delay = 250)" in load_js
+    assert "window.CrossWatchEditorLoadController = Editor.LoadController;" in load_js
+    assert "const endpointId = String(state.snapshot || \"\").trim();" not in js
+
+
+def test_editor_chrome_decoration_is_extracted() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    chrome_js = (root / "assets" / "js" / "editor" / "chrome.js").read_text(encoding="utf-8")
+    core_js = (root / "assets" / "helpers" / "core.js").read_text(encoding="utf-8")
+    assert 'await ensurePageModule("editor-chrome", "/assets/js/editor/chrome.js", "CrossWatchEditorChrome");' in core_js
+    assert 'const editorChrome = requireEditorModule("Chrome");' in js
+    assert "editorChrome.wireStaticLabels(host);" in js
+    assert "editorChrome.decorateImportPanel({" in js
+    assert "editorChrome.decoratePolicyBackupPanel({" in js
+    assert "editorChrome.decorateEditorChrome({" in js
+    assert "function wireStaticLabels(root)" in chrome_js
+    assert "function prepareSourceOptions(root)" in chrome_js
+    assert "function decorateImportPanel(ctx = {})" in chrome_js
+    assert "function decoratePolicyBackupPanel(ctx = {})" in chrome_js
+    assert "function decorateEditorChrome(ctx = {})" in chrome_js
+    assert "window.CrossWatchEditorChrome = Editor.Chrome;" in chrome_js
+    assert "function wireStaticLabels(root)" not in js
+    assert "function decorateImportPanel()" not in js
+    assert "function decoratePolicyBackupPanel()" not in js
+    assert "function decorateEditorChrome()" not in js
+
+
+def test_editor_source_loading_is_extracted() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    sources_js = (root / "assets" / "js" / "editor" / "sources.js").read_text(encoding="utf-8")
+    core_js = (root / "assets" / "helpers" / "core.js").read_text(encoding="utf-8")
+    assert 'await ensurePageModule("editor-sources", "/assets/js/editor/sources.js", "CrossWatchEditorSources");' in core_js
+    assert 'const editorSources = requireEditorModule("Sources");' in js
+    assert "function sourceContext()" in js
+    assert "return editorSources.syncSourceUI(sourceContext());" in js
+    assert "return editorSources.loadSnapshots(sourceContext());" in js
+    assert "function syncSourceUI(ctx = {})" in sources_js
+    assert "async function loadSnapshots(ctx = {})" in sources_js
+    assert "async function loadTrackerWorkspaces(ctx = {})" in sources_js
+    assert "function rebuildSnapshots(ctx = {})" in sources_js
+    assert "function showStateHint(mode, ctx = {})" in sources_js
+    assert "window.CrossWatchEditorSources = Editor.Sources;" in sources_js
+
+
+def test_editor_import_panel_is_extracted() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    importers_js = (root / "assets" / "js" / "editor" / "importers.js").read_text(encoding="utf-8")
+    core_js = (root / "assets" / "helpers" / "core.js").read_text(encoding="utf-8")
+    assert 'await ensurePageModule("editor-importers", "/assets/js/editor/importers.js", "CrossWatchEditorImporters");' in core_js
+    assert 'const editorImporters = requireEditorModule("Importers");' in js
+    assert "function importContext()" in js
+    assert "return editorImporters.syncImportUI(importContext());" in js
+    assert "return editorImporters.loadImportProviders(importContext());" in js
+    assert "return editorImporters.runStateImport(importContext());" in js
+    assert "function syncImportUI(ctx = {})" in importers_js
+    assert "async function loadImportProviders(ctx = {})" in importers_js
+    assert "function collectImportFeatures(ctx = {})" in importers_js
+    assert "async function runStateImport(ctx = {})" in importers_js
+    assert "/api/editor/state/import/providers" in importers_js
+    assert "/api/editor/state/import" in importers_js
+    assert "window.CrossWatchEditorImporters = Editor.Importers;" in importers_js
+
+
+def test_editor_persistence_is_extracted() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    persistence_js = (root / "assets" / "js" / "editor" / "persistence.js").read_text(encoding="utf-8")
+    core_js = (root / "assets" / "helpers" / "core.js").read_text(encoding="utf-8")
+    assert 'await ensurePageModule("editor-persistence", "/assets/js/editor/persistence.js", "CrossWatchEditorPersistence");' in core_js
+    assert 'const editorPersistence = requireEditorModule("Persistence");' in js
+    assert "function persistenceContext()" in js
+    assert "return editorPersistence.findRowsMissingKey(state);" in js
+    assert "return editorPersistence.saveState(persistenceContext());" in js
+    assert "function findRowsMissingKey(state)" in persistence_js
+    assert "function buildSaveData(ctx = {})" in persistence_js
+    assert "function confirmPlaylistRemovals(ctx, items)" in persistence_js
+    assert "async function saveState(ctx = {})" in persistence_js
+    assert "/api/editor" in persistence_js
+    assert "payload.blocks = blocks;" in persistence_js
+    assert "window.CrossWatchEditorPersistence = Editor.Persistence;" in persistence_js
+
+
+def test_editor_uses_page_scroll_for_table() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    css = (root / "assets" / "css" / "pages.css").read_text(encoding="utf-8")
+    assert 'const tableScroll = host.querySelector(".cw-table-scroll");' not in js
+    assert "function wireLinkedTableScroll()" not in js
+    assert "scrollDocumentByTableDelta(delta)" not in js
+    assert '#page-editor .cw-table-scroll{position:static!important;inset:auto!important;overflow:visible!important}' in css


### PR DESCRIPTION
# Pull request

## Change

Split the large editor script into focused editor modules and keep the editor API wiring aligned.

## Why

Keeps the editor code easier to work on without changing the overall behavior.

## Testing

- test_editor_playlists.py

## Issue

Relates to #614