### PR TITLE
Change: improve analyzer matching

### DIFF
--- a/services/analyzer.py
+++ b/services/analyzer.py
@@ -2278,7 +2278,8 @@ def _target_has_peer(
             return _alias_peer_present(ctx, dst_key, alias_dest, item)
         exact_key = _history_exact_key(item)
         if exact_key is not None:
-            return exact_key in (ctx.history_exact.get(dst_key) or set())
+            if exact_key in (ctx.history_exact.get(dst_key) or set()):
+                return True
     target_aliases = ctx.aliases.get((dst_key, feat_key)) or {}
     return any(alias in target_aliases for alias in _alias_keys(vv))
 
@@ -3455,7 +3456,7 @@ def _problems(
                     "message": "Item has fallback IDs but no TMDB ID. Sync may still work, but some providers rely on TMDB for stronger matching.",
                 }
             )
-        if ids and not any(ids.get(ns) for ns in core):
+        if ids and not any((id_view.get(ns) or ids.get(ns)) for ns in core):
             probs.append(
                 {
                     "severity": "info",

--- a/tests/test_analyzer_history_aliases.py
+++ b/tests/test_analyzer_history_aliases.py
@@ -209,6 +209,37 @@ def test_unaliased_translation_still_counts_as_unsynced(cws) -> None:
     assert stats["synced"] == 0
 
 
+def test_episode_ids_match_when_source_lacks_show_ids(cws) -> None:
+    simkl = {
+        "imdb:tt7228262#s00e04": {
+            "type": "episode",
+            "title": "S00E04",
+            "series_title": "Fullmetal Alchemist: Brotherhood",
+            "season": 0,
+            "episode": 4,
+            "watched_at": WATCHED,
+            "ids": {"imdb": "tt7228262", "tvdb": "2832871"},
+        }
+    }
+    trakt = {
+        "tmdb:31911#s00e04": {
+            "type": "episode",
+            "title": "Yet Another Man's Battlefield",
+            "series_title": "Fullmetal Alchemist: Brotherhood",
+            "season": 0,
+            "episode": 4,
+            "watched_at": WATCHED,
+            "ids": {"imdb": "tt7228262", "tvdb": "2832871"},
+            "show_ids": {"tmdb": "31911"},
+        }
+    }
+
+    stats = _synced(_state(simkl, trakt), _cfg())
+
+    assert stats["total"] == 1
+    assert stats["synced"] == 1
+
+
 def test_state_baselines_are_not_rewritten(cws) -> None:
     simkl = {"tmdb:12971#s01e40": _episode(12971, 1, 40, series="Dragon Ball Z")}
     trakt = {"tmdb:12971#s02e01": _episode(12971, 2, 1, series="Dragon Ball Z", ep_trakt=498798)}


### PR DESCRIPTION
# Pull request

## Change

Improve history analyzer matching when one provider has show ids and the other only has episode ids.

## Why

Some valid Emby/Plex history rows were showing as unsynced even though the episode IMDb/TVDB ids matched.

## Testing

NA

## Issue

NA