### PR TITLE
Fix: Jellyfin scoped resolver matches

### DIFF
--- a/providers/sync/jellyfin/_common.py
+++ b/providers/sync/jellyfin/_common.py
@@ -261,6 +261,10 @@ def jf_filter_library_candidates(
     return []
 
 
+def _trust_provider_index_scope(selected_libs: set[str]) -> bool:
+    return bool(selected_libs)
+
+
 def jf_scope_ratings(cfg: CfgLike) -> dict[str, Any]:
     return jf_library_scope(cfg, "ratings")
 
@@ -1202,7 +1206,11 @@ def _path_match_item_id(
                 seen.add(iid)
                 rows.append(row)
 
-    scoped = jf_filter_library_candidates(rows, selected_libs)
+    scoped = jf_filter_library_candidates(
+        rows,
+        selected_libs,
+        trust_query_scope=_trust_provider_index_scope(selected_libs),
+    )
     if item_type == "episode":
         scoped = [row for row in scoped if (row.get("Type") or "") == "Episode"]
         numbered = [row for row in scoped if _episode_number_matches(row, season, episode)]
@@ -1303,7 +1311,11 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
         idx = build_provider_index(adapter) if feature == "history" else build_provider_index(adapter, feature=feature)
         for pref in pairs:
             raw_cands = idx.get(pref) or []
-            cands = jf_filter_library_candidates(raw_cands, selected_libs)
+            cands = jf_filter_library_candidates(
+                raw_cands,
+                selected_libs,
+                trust_query_scope=_trust_provider_index_scope(selected_libs),
+            )
             if raw_cands and not cands and selected_libs:
                 outside_scope_seen = True
             iid = _pick_from_candidates(cands, want_type="movie", want_year=year)
@@ -1350,7 +1362,11 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
         idx = build_provider_index(adapter) if feature == "history" else build_provider_index(adapter, feature=feature)
         for pref in pairs:
             raw_rows = idx.get(pref) or []
-            rows = jf_filter_library_candidates(raw_rows, selected_libs)
+            rows = jf_filter_library_candidates(
+                raw_rows,
+                selected_libs,
+                trust_query_scope=_trust_provider_index_scope(selected_libs),
+            )
             if raw_rows and not rows and selected_libs:
                 outside_scope_seen = True
             cands = [row for row in rows if (row.get("Type") or "").strip() == "Series"]
@@ -1399,7 +1415,11 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
     idx = build_provider_index(adapter) if feature == "history" else build_provider_index(adapter, feature=feature)
     for pref in episode_pairs:
         raw_rows = idx.get(pref) or []
-        rows = jf_filter_library_candidates(raw_rows, selected_libs)
+        rows = jf_filter_library_candidates(
+            raw_rows,
+            selected_libs,
+            trust_query_scope=_trust_provider_index_scope(selected_libs),
+        )
         if raw_rows and not rows and selected_libs:
             outside_scope_seen = True
         episode_rows: list[Mapping[str, Any]] = []
@@ -1459,7 +1479,11 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
     series_id_confirmed = False
     for pref in series_pairs:
         raw_rows = idx.get(pref) or []
-        scoped_rows = jf_filter_library_candidates(raw_rows, selected_libs)
+        scoped_rows = jf_filter_library_candidates(
+            raw_rows,
+            selected_libs,
+            trust_query_scope=_trust_provider_index_scope(selected_libs),
+        )
         if raw_rows and not scoped_rows and selected_libs:
             outside_scope_seen = True
         series_rows = [row for row in scoped_rows if (row.get("Type") or "") == "Series"]
@@ -1550,7 +1574,11 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "his
     # Movies
     if t == "movie":
         for pref in pairs:
-            rows = jf_filter_library_candidates(idx.get(pref) or [], selected_libs)
+            rows = jf_filter_library_candidates(
+                idx.get(pref) or [],
+                selected_libs,
+                trust_query_scope=_trust_provider_index_scope(selected_libs),
+            )
             cands = [row for row in rows if (row.get("Type") or "") == "Movie"]
             if isinstance(year, int):
                 yr = int(year)

--- a/providers/tests/test_jellyfin_resolver.py
+++ b/providers/tests/test_jellyfin_resolver.py
@@ -50,6 +50,7 @@ class FakeCfg:
     strict_id_matching = False
     watchlist_guid_priority = None
     history_guid_priority = None
+    history_libraries = None
 
 
 class FakeAdapter:
@@ -133,6 +134,17 @@ def test_jellyfin_long_numeric_item_ids_are_valid_backend_ids():
     item = {"type": "movie", "title": "Encanto", "year": 2021, "ids": {"tmdb": "568124"}}
 
     assert common.resolve_item_id(adapter, item, feature="history") == "7214430293560476068"
+
+
+def test_jellyfin_scoped_provider_index_trusts_rows_without_library_metadata():
+    row = jf_row("M1", "Movie", "Encanto", tmdb="568124")
+    adapter = FakeAdapter(FakeHttp([row]))
+    adapter.cfg.history_libraries = ["LIB1"]
+
+    item = {"type": "movie", "title": "Encanto", "year": 2021, "ids": {"tmdb": "568124"}}
+
+    assert common.resolve_item_id(adapter, item, feature="history") == "M1"
+    assert any(call["params"].get("ParentId") == "LIB1" for call in adapter.client.calls)
 
 
 def test_jellyfin_mark_played_uses_date_played_param_name():


### PR DESCRIPTION
# Pull request

## Change

Fix Jellyfin history matching when library-scoped item rows do not include library metadata.

## Why

Some Jellyfin servers return valid matches from a scoped `ParentId` query without `LibraryId`, `CollectionFolderId`, or `AncestorIds`, so CW treated them as outside the library.

## Testing

NA

## Issue

Relates to #618