### PR TITLE
Fix: provider autofill breaking unrelated saves

### DIFF
--- a/assets/auth/auth.crosswatch.js
+++ b/assets/auth/auth.crosswatch.js
@@ -56,6 +56,8 @@
     if (!el) return;
     el.value = value == null ? "" : String(value);
     try { el.dispatchEvent(new Event("change", { bubbles: true })); } catch {}
+    el.dataset.loaded = "1";
+    el.dataset.touched = "";
   }
 
   function setSelect(id, value) {
@@ -63,6 +65,8 @@
     if (!el) return;
     el.value = String(value);
     try { w.CW?.IconSelect?.refresh?.(el); } catch {}
+    el.dataset.loaded = "1";
+    el.dataset.touched = "";
   }
 
   function snapshotLabel(name) {
@@ -114,6 +118,8 @@
         sel.appendChild(opt);
       });
       sel.value = groups[feature].includes(wanted[feature]) ? wanted[feature] : "latest";
+      sel.dataset.loaded = "1";
+      sel.dataset.touched = "";
     });
   }
 
@@ -146,13 +152,18 @@
   }
 
   function wireFields() {
-    ["cw_tracker_retention_days", "cw_tracker_auto_snapshot", "cw_tracker_max_snapshots", "cw_tracker_label"].forEach((id) => {
+    [
+      "cw_tracker_retention_days", "cw_tracker_auto_snapshot", "cw_tracker_max_snapshots", "cw_tracker_label",
+      "cw_tracker_restore_watchlist", "cw_tracker_restore_history", "cw_tracker_restore_ratings", "cw_tracker_restore_progress"
+    ].forEach((id) => {
       const el = $(id);
       if (!el || el.__cwTrackerWired) return;
       el.__cwTrackerWired = true;
       el.addEventListener("input", () => {
+        el.dataset.touched = "1";
         if (id === "cw_tracker_label" && el.value.length > 12) el.value = el.value.slice(0, 12);
       });
+      el.addEventListener("change", () => { el.dataset.touched = "1"; });
     });
     const connect = $("cw_crosswatch_connect");
     if (connect && !connect.__cwTrackerWired) {

--- a/assets/auth/auth.floppy.js
+++ b/assets/auth/auth.floppy.js
@@ -64,8 +64,18 @@
     const f = cfgBlock(cfg);
     const server = txt(f?.server_url || "");
     const hasToken = !!txt(f?.api_token || "");
-    if (el("floppy_server")) el("floppy_server").value = server;
-    if (el("floppy_verify_ssl")) el("floppy_verify_ssl").checked = f?.verify_ssl === true;
+    const serverEl = el("floppy_server");
+    if (serverEl) {
+      serverEl.value = server;
+      serverEl.dataset.loaded = "1";
+      serverEl.dataset.touched = "";
+    }
+    const verifyEl = el("floppy_verify_ssl");
+    if (verifyEl) {
+      verifyEl.checked = f?.verify_ssl === true;
+      verifyEl.dataset.loaded = "1";
+      verifyEl.dataset.touched = "";
+    }
     Shared.maskSecret(el("floppy_token"), hasToken);
     await refresh();
   }
@@ -119,6 +129,18 @@
     if (token && !token.__wiredSecret) {
       Shared.wireSecretInput(token);
       token.__wiredSecret = true;
+    }
+    const server = el("floppy_server");
+    if (server && !server.__wiredTouched) {
+      server.addEventListener("input", () => { server.dataset.touched = "1"; });
+      server.addEventListener("change", () => { server.dataset.touched = "1"; });
+      server.__wiredTouched = true;
+    }
+    const verify = el("floppy_verify_ssl");
+    if (verify && !verify.__wiredTouched) {
+      verify.addEventListener("input", () => { verify.dataset.touched = "1"; });
+      verify.addEventListener("change", () => { verify.dataset.touched = "1"; });
+      verify.__wiredTouched = true;
     }
   }
 

--- a/assets/auth/auth.tautulli.js
+++ b/assets/auth/auth.tautulli.js
@@ -41,7 +41,9 @@
     const key = String(code || "").trim();
     switch (key) {
       case "server_url_required": return "Enter Tautulli server URL";
+      case "server_url required": return "Enter Tautulli server URL";
       case "api_key_required": return "Enter your Tautulli API key";
+      case "api_key required": return "Enter your Tautulli API key";
       case "invalid_api_key": return "Invalid Tautulli API key";
       case "validation_timeout": return "Tautulli validation timed out";
       case "validation_failed": return "Could not connect to Tautulli";
@@ -95,8 +97,19 @@
     const hasKey = !!txt((t && t.api_key) || "");
     const userId = txt((h && h.user_id) || "");
 
-    if (el("tautulli_server")) el("tautulli_server").value = server;
-    if (el("tautulli_user_id")) el("tautulli_user_id").value = userId;
+    const serverEl = el("tautulli_server");
+    if (serverEl) {
+      serverEl.value = server;
+      serverEl.dataset.loaded = "1";
+      serverEl.dataset.touched = "";
+    }
+
+    const userIdEl = el("tautulli_user_id");
+    if (userIdEl) {
+      userIdEl.value = userId;
+      userIdEl.dataset.loaded = "1";
+      userIdEl.dataset.touched = "";
+    }
 
     maskKey(el("tautulli_key"), hasKey);
     el("tautulli_hint")?.classList.toggle("hidden", hasKey);
@@ -123,7 +136,7 @@
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ server_url: server, api_key: key, user_id }),
       });
-      if (!r.ok || (r.data && r.data.ok === false)) throw new Error(friendlyError(r.data?.error || "save_failed"));
+      if (!r.ok || (r.data && r.data.ok === false)) throw new Error(friendlyError(r.data?.error || r.data?.detail || "save_failed"));
 
       if (key) maskKey(keyInput, true);
       el("tautulli_hint")?.classList.add("hidden");
@@ -163,9 +176,17 @@
       k.__wiredSecret = true;
     }
 
+    const server = el("tautulli_server");
+    if (server && !server.__wiredTouched) {
+      server.addEventListener("input", () => { server.dataset.touched = "1"; });
+      server.addEventListener("change", () => { server.dataset.touched = "1"; });
+      server.__wiredTouched = true;
+    }
+
     const u = el("tautulli_user_id");
     if (u && !u.__wiredUser) {
       u.addEventListener("input", () => { u.dataset.touched = "1"; });
+      u.addEventListener("change", () => { u.dataset.touched = "1"; });
       u.__wiredUser = true;
     }
   }
@@ -193,9 +214,12 @@
 
     const inst = getTautulliInstance();
 
-    const server = txt(el("tautulli_server")?.value || "");
+    const serverEl = el("tautulli_server");
+    const server = txt(serverEl?.value || "");
+    const serverTouched = !!serverEl?.dataset.touched;
     const keyEl = el("tautulli_key");
     let key = txt(keyEl?.value || "");
+    const keyTouched = !!keyEl?.dataset.touched;
 
     const userIdEl = el("tautulli_user_id");
     const user_id = txt(userIdEl?.value || "");
@@ -205,7 +229,7 @@
       key = "";
     }
 
-    if (!server && !key && !user_id && !uidTouched) return;
+    if (!serverTouched && !keyTouched && !uidTouched) return;
 
     cfg.tautulli = cfg.tautulli || {};
     let t = cfg.tautulli;
@@ -215,10 +239,10 @@
       t = t.instances[inst];
     }
 
-    if (server) t.server_url = server;
-    if (key) t.api_key = key;
+    if (serverTouched && server) t.server_url = server;
+    if (keyTouched && key) t.api_key = key;
 
-    if (user_id || uidTouched) {
+    if (uidTouched) {
       t.history = t.history || {};
       t.history.user_id = user_id;
     }

--- a/assets/helpers/settings-save.js
+++ b/assets/helpers/settings-save.js
@@ -9,6 +9,13 @@ const _cwSecretIds = [
   "tmdb_api_key", "tmdb_sync_api_key", "tmdb_sync_session_id", "mdblist_key", "publicmetadb_key", "tautulli_key", "floppy_token",
   "kodi_password"
 ];
+const _cwTouchedIds = [
+  ..._cwSecretIds,
+  "tautulli_server", "tautulli_user_id",
+  "floppy_server", "floppy_verify_ssl",
+  "cw_tracker_label", "cw_tracker_retention_days", "cw_tracker_auto_snapshot", "cw_tracker_max_snapshots",
+  "cw_tracker_restore_watchlist", "cw_tracker_restore_history", "cw_tracker_restore_ratings", "cw_tracker_restore_progress"
+];
 
 function _cwEl(id) { return document.getElementById(id); }
 function _getVal(id) { return _cwNorm(_cwEl(id)?.value); }
@@ -238,11 +245,17 @@ function _cwAbortSave(msg) {
   throw err;
 }
 
-function _cwWireTouched(ids = _cwSecretIds) {
+function _cwTouched(id) {
+  return !!_cwEl(id)?.dataset?.touched;
+}
+
+function _cwWireTouched(ids = _cwTouchedIds) {
   ids.forEach((id) => {
     const el = _cwEl(id);
     if (el && !el.__touchedWired) {
-      el.addEventListener("input", () => { el.dataset.touched = "1"; });
+      const markTouched = () => { el.dataset.touched = "1"; };
+      el.addEventListener("input", markTouched);
+      el.addEventListener("change", markTouched);
       el.__touchedWired = true;
     }
   });
@@ -282,8 +295,8 @@ function _cwReadSecret(id, previousValue) {
 function _cwProviderAuthError(provider, code) {
   const key = _cwNorm(code);
   if (provider === "tautulli") {
-    if (key === "server_url_required") return "Enter Tautulli server URL";
-    if (key === "api_key_required") return "Enter your Tautulli API key";
+    if (key === "server_url_required" || key === "server_url required") return "Enter Tautulli server URL";
+    if (key === "api_key_required" || key === "api_key required") return "Enter your Tautulli API key";
     if (key === "invalid_api_key") return "Invalid Tautulli API key";
     if (key === "validation_timeout") return "Tautulli validation timed out";
     if (key === "validation_failed") return "Could not connect to Tautulli";
@@ -663,7 +676,12 @@ async function saveSettings() {
 
     try {
       const trackerLabelEl = _cwEl("cw_tracker_label");
-      if (trackerLabelEl) {
+      const trackerFieldIds = [
+        "cw_tracker_label", "cw_tracker_retention_days", "cw_tracker_auto_snapshot", "cw_tracker_max_snapshots",
+        "cw_tracker_restore_watchlist", "cw_tracker_restore_history", "cw_tracker_restore_ratings", "cw_tracker_restore_progress"
+      ];
+      const trackerTouched = trackerFieldIds.some((id) => _cwTouched(id));
+      if (trackerLabelEl && trackerTouched) {
         const inst = _cwSelectedInst("crosswatch", "cw.ui.crosswatch.auth.instance.v1");
         const prevRoot = serverCfg?.crosswatch && typeof serverCfg.crosswatch === "object" ? serverCfg.crosswatch : {};
         const prevBlock = _cwInstBlock(prevRoot, inst);
@@ -684,13 +702,13 @@ async function saveSettings() {
         };
         const labelEl = _cwEl("cw_tracker_label");
         if (labelEl && labelEl.value.length > 12) labelEl.value = labelEl.value.slice(0, 12);
-        set("label", _cwNorm(labelEl?.value).slice(0, 12), _cwNorm(prevBlock?.label).slice(0, 12));
-        set("retention_days", intOr("cw_tracker_retention_days", Number(prevBlock?.retention_days), 30), Number.isFinite(prevBlock?.retention_days) ? Number(prevBlock.retention_days) : 30);
-        set("auto_snapshot", _cwTruthy(_cwEl("cw_tracker_auto_snapshot")?.value), prevBlock?.auto_snapshot !== false);
-        set("max_snapshots", intOr("cw_tracker_max_snapshots", Number(prevBlock?.max_snapshots), 64), Number.isFinite(prevBlock?.max_snapshots) ? Number(prevBlock.max_snapshots) : 64);
+        if (_cwTouched("cw_tracker_label")) set("label", _cwNorm(labelEl?.value).slice(0, 12), _cwNorm(prevBlock?.label).slice(0, 12));
+        if (_cwTouched("cw_tracker_retention_days")) set("retention_days", intOr("cw_tracker_retention_days", Number(prevBlock?.retention_days), 30), Number.isFinite(prevBlock?.retention_days) ? Number(prevBlock.retention_days) : 30);
+        if (_cwTouched("cw_tracker_auto_snapshot")) set("auto_snapshot", _cwTruthy(_cwEl("cw_tracker_auto_snapshot")?.value), prevBlock?.auto_snapshot !== false);
+        if (_cwTouched("cw_tracker_max_snapshots")) set("max_snapshots", intOr("cw_tracker_max_snapshots", Number(prevBlock?.max_snapshots), 64), Number.isFinite(prevBlock?.max_snapshots) ? Number(prevBlock.max_snapshots) : 64);
         ["watchlist", "history", "ratings", "progress"].forEach((key) => {
           const el = _cwEl(`cw_tracker_restore_${key}`);
-          if (!el) return;
+          if (!el || !_cwTouched(`cw_tracker_restore_${key}`)) return;
           const next = _cwNorm(el.value) || "latest";
           set(`restore_${key}`, next, _cwNorm(prevBlock?.[`restore_${key}`] || "latest") || "latest");
         });
@@ -736,24 +754,25 @@ async function saveSettings() {
       const tautulliInst = _cwSelectedInst("tautulli");
       const tautulliPrev = _cwInstBlock(serverCfg?.tautulli, tautulliInst);
       const tautulliServer = _cwNorm(_cwEl("tautulli_server")?.value || "");
+      const tautulliServerTouched = _cwTouched("tautulli_server");
       const tautulliKey = _cwReadSecret("tautulli_key", _cwNorm(tautulliPrev?.api_key));
       const tautulliUserEl = _cwEl("tautulli_user_id");
       const tautulliUser = _cwNorm(tautulliUserEl?.value || "");
       const tautulliUserTouched = !!tautulliUserEl?.dataset?.touched;
       const tautulliPayload = {};
-      const tautulliServerChanged = !!tautulliServer && tautulliServer !== _cwNorm(tautulliPrev?.server_url);
-      if (tautulliServer) tautulliPayload.server_url = tautulliServer;
+      const tautulliServerChanged = tautulliServerTouched && !!tautulliServer && tautulliServer !== _cwNorm(tautulliPrev?.server_url);
+      if (tautulliServer && (tautulliServerChanged || (tautulliKey.changed && tautulliKey.set))) tautulliPayload.server_url = tautulliServer;
       if (tautulliKey.changed && tautulliKey.set) tautulliPayload.api_key = tautulliKey.set;
-      if (tautulliUser || tautulliUserTouched) tautulliPayload.user_id = tautulliUser;
+      if (tautulliUserTouched) tautulliPayload.user_id = tautulliUser;
       if (tautulliServerChanged || (tautulliKey.changed && tautulliKey.set)) {
         await _cwValidateTautulliSecret(tautulliInst, tautulliPayload);
       }
-      if (tautulliServerChanged || tautulliKey.changed || tautulliUser || tautulliUserTouched) {
+      if (tautulliServerChanged || tautulliKey.changed || tautulliUserTouched) {
         cfg.tautulli = cfg.tautulli && typeof cfg.tautulli === "object" ? cfg.tautulli : {};
         const ttarget = _cwEnsureInstBlock(cfg.tautulli, tautulliInst);
-        if (tautulliServer) ttarget.server_url = tautulliServer;
+        if (tautulliServerChanged) ttarget.server_url = tautulliServer;
         if (tautulliKey.changed) _cwApplySecret(ttarget, "api_key", tautulliKey);
-        if (tautulliUser || tautulliUserTouched) {
+        if (tautulliUserTouched) {
           ttarget.history = ttarget.history && typeof ttarget.history === "object" ? ttarget.history : {};
           ttarget.history.user_id = tautulliUser;
         }
@@ -763,24 +782,25 @@ async function saveSettings() {
       const floppyInst = _cwSelectedInst("floppy", "cw.ui.floppy.auth.instance.v1");
       const floppyPrev = _cwInstBlock(serverCfg?.floppy, floppyInst);
       const floppyServer = _cwNorm(_cwEl("floppy_server")?.value || "");
+      const floppyServerTouched = _cwTouched("floppy_server");
       const floppyToken = _cwReadSecret("floppy_token", _cwNorm(floppyPrev?.api_token));
       const floppyVerifyEl = _cwEl("floppy_verify_ssl");
       const floppyVerify = floppyVerifyEl ? !!floppyVerifyEl.checked : floppyPrev?.verify_ssl === true;
-      const floppyServerChanged = !!floppyServer && floppyServer !== _cwNorm(floppyPrev?.server_url);
-      const floppyVerifyChanged = !!floppyVerifyEl && floppyVerify !== (floppyPrev?.verify_ssl === true);
+      const floppyServerChanged = floppyServerTouched && !!floppyServer && floppyServer !== _cwNorm(floppyPrev?.server_url);
+      const floppyVerifyChanged = _cwTouched("floppy_verify_ssl") && floppyVerify !== (floppyPrev?.verify_ssl === true);
       const floppyPayload = {};
-      if (floppyServer) floppyPayload.server_url = floppyServer;
+      if (floppyServer && (floppyServerChanged || (floppyToken.changed && floppyToken.set) || floppyVerifyChanged)) floppyPayload.server_url = floppyServer;
       if (floppyToken.changed && floppyToken.set) floppyPayload.api_token = floppyToken.set;
-      if (floppyVerifyEl) floppyPayload.verify_ssl = floppyVerify;
+      if (floppyVerifyEl && (floppyVerifyChanged || floppyServerChanged || (floppyToken.changed && floppyToken.set))) floppyPayload.verify_ssl = floppyVerify;
       if (floppyServerChanged || (floppyToken.changed && floppyToken.set) || floppyVerifyChanged) {
         await _cwValidateFloppySecret(floppyInst, floppyPayload);
       }
       if (floppyServerChanged || floppyToken.changed || floppyVerifyChanged) {
         cfg.floppy = cfg.floppy && typeof cfg.floppy === "object" ? cfg.floppy : {};
         const ftarget = _cwEnsureInstBlock(cfg.floppy, floppyInst);
-        if (floppyServer) ftarget.server_url = floppyServer;
+        if (floppyServerChanged) ftarget.server_url = floppyServer;
         if (floppyToken.changed) _cwApplySecret(ftarget, "api_token", floppyToken);
-        if (floppyVerifyEl) ftarget.verify_ssl = floppyVerify;
+        if (floppyVerifyChanged) ftarget.verify_ssl = floppyVerify;
         mark();
       }
     } catch (e) {

--- a/providers/auth/_auth_ANILIST.py
+++ b/providers/auth/_auth_ANILIST.py
@@ -208,11 +208,11 @@ def html() -> str:
             <div class="grid2">
                   <div>
                     <label for="anilist_client_id">Client ID</label>
-                    <input id="anilist_client_id" name="anilist_client_id" placeholder="Your AniList client_id" autocomplete="off" />
+                    <input id="anilist_client_id" name="anilist_client_id" placeholder="Your AniList client_id" autocomplete="off" spellcheck="false" autocapitalize="off" />
                   </div>
                   <div>
                     <label for="anilist_client_secret">Client Secret</label>
-                    <input id="anilist_client_secret" name="anilist_client_secret" placeholder="Your AniList client_secret" type="password" autocomplete="off" />
+                    <input id="anilist_client_secret" name="anilist_client_secret" placeholder="Your AniList client_secret" type="password" autocomplete="off" spellcheck="false" autocapitalize="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true" />
                   </div>
                 </div>
             

--- a/providers/auth/_auth_CROSSWATCH.py
+++ b/providers/auth/_auth_CROSSWATCH.py
@@ -115,21 +115,21 @@ def html() -> str:
                       <label for="cw_tracker_label">Label</label>
                       <button type="button" class="cw-field-help material-symbols-rounded" title="Label: Short name for your own administration. Maximum 12 characters and only used inside CrossWatch." aria-label="Local tracker label setting help">help</button>
                     </div>
-                    <input id="cw_tracker_label" name="cw_tracker_label" type="text" maxlength="12" placeholder="Personal" />
+                    <input id="cw_tracker_label" name="cw_tracker_label" type="text" maxlength="12" placeholder="Personal" autocomplete="off" spellcheck="false" autocapitalize="off" />
                   </div>
                   <div>
                     <div class="cw-field-label-row">
                       <label for="cw_tracker_retention_days">Retention (days)</label>
                       <button type="button" class="cw-field-help material-symbols-rounded" title="Retention days: Number of days CrossWatch keeps local tracker snapshots. Use 0 to keep snapshots forever." aria-label="Local tracker retention setting help">help</button>
                     </div>
-                    <input id="cw_tracker_retention_days" name="cw_tracker_retention_days" type="number" min="0" step="1" placeholder="30" />
+                    <input id="cw_tracker_retention_days" name="cw_tracker_retention_days" type="number" min="0" step="1" placeholder="30" autocomplete="off" />
                   </div>
                   <div>
                     <div class="cw-field-label-row">
                       <label for="cw_tracker_auto_snapshot">Auto snapshot</label>
                       <button type="button" class="cw-field-help material-symbols-rounded" title="Auto snapshot: Creates a snapshot before CrossWatch writes local tracker data, so changes can be restored." aria-label="Local tracker auto snapshot setting help">help</button>
                     </div>
-                    <select id="cw_tracker_auto_snapshot" name="cw_tracker_auto_snapshot">
+                    <select id="cw_tracker_auto_snapshot" name="cw_tracker_auto_snapshot" autocomplete="off">
                       <option value="true">On (before writes)</option>
                       <option value="false">Off</option>
                     </select>
@@ -139,7 +139,7 @@ def html() -> str:
                       <label for="cw_tracker_max_snapshots">Max snapshots per feature</label>
                       <button type="button" class="cw-field-help material-symbols-rounded" title="Max snapshots per feature: Maximum snapshots kept for watchlist, history, ratings and progress. Use 0 for unlimited." aria-label="Local tracker max snapshots setting help">help</button>
                     </div>
-                    <input id="cw_tracker_max_snapshots" name="cw_tracker_max_snapshots" type="number" min="0" step="1" placeholder="64" />
+                    <input id="cw_tracker_max_snapshots" name="cw_tracker_max_snapshots" type="number" min="0" step="1" placeholder="64" autocomplete="off" />
                   </div>
                 </div>
               </section>
@@ -158,28 +158,28 @@ def html() -> str:
                       <label for="cw_tracker_restore_watchlist">Watchlist snapshot</label>
                       <button type="button" class="cw-field-help material-symbols-rounded" title="Watchlist snapshot: Snapshot used when restoring or reading this local tracker profile's watchlist. Latest follows the newest snapshot." aria-label="Local tracker watchlist restore help">help</button>
                     </div>
-                    <select id="cw_tracker_restore_watchlist" name="cw_tracker_restore_watchlist"></select>
+                    <select id="cw_tracker_restore_watchlist" name="cw_tracker_restore_watchlist" autocomplete="off"></select>
                   </div>
                   <div>
                     <div class="cw-field-label-row">
                       <label for="cw_tracker_restore_history">History snapshot</label>
                       <button type="button" class="cw-field-help material-symbols-rounded" title="History snapshot: Snapshot used when restoring or reading this local tracker profile's history. Latest follows the newest snapshot." aria-label="Local tracker history restore help">help</button>
                     </div>
-                    <select id="cw_tracker_restore_history" name="cw_tracker_restore_history"></select>
+                    <select id="cw_tracker_restore_history" name="cw_tracker_restore_history" autocomplete="off"></select>
                   </div>
                   <div>
                     <div class="cw-field-label-row">
                       <label for="cw_tracker_restore_ratings">Ratings snapshot</label>
                       <button type="button" class="cw-field-help material-symbols-rounded" title="Ratings snapshot: Snapshot used when restoring or reading this local tracker profile's ratings. Latest follows the newest snapshot." aria-label="Local tracker ratings restore help">help</button>
                     </div>
-                    <select id="cw_tracker_restore_ratings" name="cw_tracker_restore_ratings"></select>
+                    <select id="cw_tracker_restore_ratings" name="cw_tracker_restore_ratings" autocomplete="off"></select>
                   </div>
                   <div>
                     <div class="cw-field-label-row">
                       <label for="cw_tracker_restore_progress">Progress snapshot</label>
                       <button type="button" class="cw-field-help material-symbols-rounded" title="Progress snapshot: Snapshot used when restoring or reading this local tracker profile's playback progress. Latest follows the newest snapshot." aria-label="Local tracker progress restore help">help</button>
                     </div>
-                    <select id="cw_tracker_restore_progress" name="cw_tracker_restore_progress"></select>
+                    <select id="cw_tracker_restore_progress" name="cw_tracker_restore_progress" autocomplete="off"></select>
                   </div>
                 </div>
               </section>

--- a/providers/auth/_auth_EMBY.py
+++ b/providers/auth/_auth_EMBY.py
@@ -279,7 +279,7 @@ def html() -> str:
               <div style="grid-column:1 / -1">
                 <label for="emby_server">Server URL</label>
                 <div class="inp-row">
-                  <input id="emby_server" name="emby_server" class="grow" placeholder="http://host:8096/">
+                  <input id="emby_server" name="emby_server" class="grow" placeholder="http://host:8096/" autocomplete="off" spellcheck="false" autocapitalize="off">
                   <label class="verify"><input id="emby_verify_ssl" type="checkbox"> Verify SSL</label>
                 </div>
               </div>
@@ -287,11 +287,11 @@ def html() -> str:
             <div class="grid2" style="margin-top:8px">
               <div>
                 <label for="emby_user">Username</label>
-                <input id="emby_user" name="emby_user" placeholder="username">
+                <input id="emby_user" name="emby_user" placeholder="username" autocomplete="username">
               </div>
               <div>
                 <label for="emby_pass">Password</label>
-                <input id="emby_pass" name="emby_pass" type="password" placeholder="********">
+                <input id="emby_pass" name="emby_pass" type="password" placeholder="********" autocomplete="current-password">
               </div>
             </div>
             <div class="inline" style="margin-top:10px">
@@ -305,17 +305,17 @@ def html() -> str:
             <div style="max-width:820px">
               <label for="emby_server_url">Server URL</label>
               <div class="inp-row">
-                <input id="emby_server_url" name="emby_server_url" class="grow" placeholder="http://host:8096/">
+                <input id="emby_server_url" name="emby_server_url" class="grow" placeholder="http://host:8096/" autocomplete="off" spellcheck="false" autocapitalize="off">
                 <label class="verify"><input id="emby_verify_ssl_dup" type="checkbox"> Verify SSL</label>
               </div>
               <div class="sub">Leave blank to discover.</div>
 
               <label for="emby_username" style="margin-top:10px">Username</label>
-              <input id="emby_username" name="emby_username" placeholder="Display name">
+                <input id="emby_username" name="emby_username" placeholder="Display name" autocomplete="off" spellcheck="false" autocapitalize="off">
 
               <label for="emby_user_id" style="margin-top:10px">User_ID</label>
               <div class="inp-row">
-                <input id="emby_user_id" name="emby_user_id" class="grow" placeholder="e.g. 6f7a0b3b-... (GUID)">
+                <input id="emby_user_id" name="emby_user_id" class="grow" placeholder="e.g. 6f7a0b3b-... (GUID)" autocomplete="off" spellcheck="false" autocapitalize="off">
                 <button id="emby_pick_user" class="cw-userpick-icon material-symbols-rounded" type="button" data-cw-emby="pick-user" title="Pick user" aria-label="Pick user">person_search</button>
               </div>
               <div class="sub">Uses your signed-in account. Admin accounts show all users; otherwise you'll only see yourself.</div>

--- a/providers/auth/_auth_FLOPPY.py
+++ b/providers/auth/_auth_FLOPPY.py
@@ -194,11 +194,11 @@ def html() -> str:
             <div class="grid2">
               <div>
                 <label for="floppy_server">Server URL</label>
-                <input id="floppy_server" name="floppy_server" type="text" placeholder="http://localhost:8000">
+                <input id="floppy_server" name="floppy_server" type="text" placeholder="http://localhost:8000" autocomplete="off" spellcheck="false" autocapitalize="off">
               </div>
               <div>
                 <label for="floppy_token">API token</label>
-                <input id="floppy_token" name="floppy_token" type="password" placeholder="********">
+                <input id="floppy_token" name="floppy_token" type="password" placeholder="********" autocomplete="off" spellcheck="false" autocapitalize="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true">
               </div>
             </div>
             <label class="verify"><input id="floppy_verify_ssl" type="checkbox"> Verify SSL</label>

--- a/providers/auth/_auth_JELLYFIN.py
+++ b/providers/auth/_auth_JELLYFIN.py
@@ -404,7 +404,7 @@ def html() -> str:
               <div style="grid-column:1 / -1">
                 <label for="jfy_server">Server URL</label>
                 <div class="inp-row">
-                  <input id="jfy_server" name="jfy_server" class="grow" placeholder="http://host:8096/">
+                  <input id="jfy_server" name="jfy_server" class="grow" placeholder="http://host:8096/" autocomplete="off" spellcheck="false" autocapitalize="off">
                   <label class="verify"><input id="jfy_verify_ssl" type="checkbox"> Verify SSL</label>
                 </div>
               </div>
@@ -468,17 +468,17 @@ def html() -> str:
             <div style="max-width:820px">
               <label for="jfy_server_url">Server URL</label>
               <div class="inp-row">
-                <input id="jfy_server_url" name="jfy_server_url" class="grow" placeholder="http://host:8096/">
+                <input id="jfy_server_url" name="jfy_server_url" class="grow" placeholder="http://host:8096/" autocomplete="off" spellcheck="false" autocapitalize="off">
                 <label class="verify"><input id="jfy_verify_ssl_dup" type="checkbox"> Verify SSL</label>
               </div>
               <div class="sub">Leave blank to discover.</div>
 
               <label for="jfy_username" style="margin-top:10px">Username</label>
-              <input id="jfy_username" name="jfy_username" placeholder="Display name">
+                <input id="jfy_username" name="jfy_username" placeholder="Display name" autocomplete="off" spellcheck="false" autocapitalize="off">
 
               <label for="jfy_user_id" style="margin-top:10px">User_ID</label>
               <div class="inp-row">
-                <input id="jfy_user_id" name="jfy_user_id" class="grow" placeholder="e.g. 6f7a0b3b-... (GUID)">
+                <input id="jfy_user_id" name="jfy_user_id" class="grow" placeholder="e.g. 6f7a0b3b-... (GUID)" autocomplete="off" spellcheck="false" autocapitalize="off">
                 <button id="jfy_pick_user" class="cw-userpick-icon material-symbols-rounded" type="button" title="Pick user" aria-label="Pick user">person_search</button>
               </div>
               <div class="sub">Uses your signed-in account. Admin accounts show all users; otherwise you'll only see yourself.</div>

--- a/providers/auth/_auth_KODI.py
+++ b/providers/auth/_auth_KODI.py
@@ -372,7 +372,7 @@ def html() -> str:
               <div style="grid-column:1 / -1">
                 <label for="kodi_server">Server URL</label>
                 <div class="inp-row">
-                  <input id="kodi_server" name="kodi_server" class="grow" placeholder="http://host:8080">
+                <input id="kodi_server" name="kodi_server" class="grow" placeholder="http://host:8080" autocomplete="off" spellcheck="false" autocapitalize="off">
                   <label class="verify"><input id="kodi_verify_ssl" type="checkbox"> Verify SSL</label>
                 </div>
               </div>

--- a/providers/auth/_auth_MDBLIST.py
+++ b/providers/auth/_auth_MDBLIST.py
@@ -289,7 +289,7 @@ def html() -> str:
                 <div>
                   <label for="mdblist_key">API Key</label>
                   <div class="mdbl-api-field-row">
-                    <input id="mdblist_key" name="mdblist_key" type="password" placeholder="********" />
+                    <input id="mdblist_key" name="mdblist_key" type="password" placeholder="********" autocomplete="off" spellcheck="false" autocapitalize="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true" />
                     <div id="mdblist_hint" class="msg warn">
                       Create API key at
                       <a href="https://mdblist.com/preferences/#api" target="_blank" rel="noopener">MDBList Preferences</a>.

--- a/providers/auth/_auth_NUVIO.py
+++ b/providers/auth/_auth_NUVIO.py
@@ -864,7 +864,7 @@ def html() -> str:
             <div id="nuvio_profile_state" class="nuvio-profile-row hidden">
               <div>
                 <label for="nuvio_profile_select">Nuvio profile</label>
-                <select id="nuvio_profile_select"></select>
+                <select id="nuvio_profile_select" autocomplete="off"></select>
               </div>
             </div>
             <div id="nuvio_login_state" class="nuvio-qc hidden">

--- a/providers/auth/_auth_PLEX.py
+++ b/providers/auth/_auth_PLEX.py
@@ -345,7 +345,7 @@ def html() -> str:
             <div style="max-width:820px">
               <label for="plex_server_url">Server URL</label>
               <div class="fieldline">
-                <input id="plex_server_url" name="plex_server_url" placeholder="http://host:32400" list="plex_server_suggestions">
+                  <input id="plex_server_url" name="plex_server_url" placeholder="http://host:32400" list="plex_server_suggestions" autocomplete="off" spellcheck="false" autocapitalize="off">
                 <datalist id="plex_server_suggestions"></datalist>
                 <label class="sslopt" title="Verify server TLS certificate">
                   <input type="checkbox" id="plex_verify_ssl">
@@ -356,15 +356,15 @@ def html() -> str:
 
               <label for="plex_username" style="margin-top:10px">Username</label>
               <div class="fieldline userpick">
-                <input id="plex_username" name="plex_username" placeholder="Plex Home profile">
+                <input id="plex_username" name="plex_username" placeholder="Plex Home profile" autocomplete="off" spellcheck="false" autocapitalize="off">
                 <button class="cw-userpick-icon material-symbols-rounded" id="plex_user_pick_btn" type="button" title="Choose from server users" aria-label="Choose from server users">person_search</button>
               </div>
 
               <label for="plex_account_id" style="margin-top:10px">Account_ID</label>
-              <input id="plex_account_id" name="plex_account_id" type="number" min="1" placeholder="e.g. 1">
+                <input id="plex_account_id" name="plex_account_id" type="number" min="1" placeholder="e.g. 1" autocomplete="off">
 
               <label for="plex_home_pin" style="margin-top:10px">Home PIN (optional)</label>
-              <input id="plex_home_pin" name="plex_home_pin" type="password" inputmode="numeric" autocomplete="new-password" placeholder="4 digits">
+              <input id="plex_home_pin" name="plex_home_pin" type="password" inputmode="numeric" autocomplete="off" placeholder="4 digits" spellcheck="false" autocapitalize="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true">
               <div class="sub">Only needed if the selected Plex Home user is PIN-protected.</div>
 
               <div class="plex-btnrow">

--- a/providers/auth/_auth_PUBLICMETADB.py
+++ b/providers/auth/_auth_PUBLICMETADB.py
@@ -188,7 +188,7 @@ def html() -> str:
             <div class="grid2">
               <div>
                 <label for="publicmetadb_key">API Key</label>
-                <input id="publicmetadb_key" name="publicmetadb_key" type="password" placeholder="pm-..." />
+                <input id="publicmetadb_key" name="publicmetadb_key" type="password" placeholder="pm-..." autocomplete="off" spellcheck="false" autocapitalize="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true" />
               </div>
             </div>
 

--- a/providers/auth/_auth_SIMKL.py
+++ b/providers/auth/_auth_SIMKL.py
@@ -478,11 +478,11 @@ def html() -> str:
               <div class="grid2">
                 <div>
                   <label for="simkl_client_id">Client ID</label>
-                  <input id="simkl_client_id" name="simkl_client_id" placeholder="Your SIMKL client id">
+                  <input id="simkl_client_id" name="simkl_client_id" placeholder="Your SIMKL client id" autocomplete="off" spellcheck="false" autocapitalize="off">
                 </div>
                 <div>
                   <label for="simkl_client_secret">Client Secret</label>
-                  <input id="simkl_client_secret" name="simkl_client_secret" placeholder="Your SIMKL client secret" type="password">
+                  <input id="simkl_client_secret" name="simkl_client_secret" placeholder="Your SIMKL client secret" type="password" autocomplete="off" spellcheck="false" autocapitalize="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true">
                 </div>
               </div>
 

--- a/providers/auth/_auth_TAUTULLI.py
+++ b/providers/auth/_auth_TAUTULLI.py
@@ -224,17 +224,17 @@ def html() -> str:
             <div class="grid2">
               <div>
                 <label for="tautulli_server">Server URL</label>
-                <input id="tautulli_server" name="tautulli_server" type="text" placeholder="http://localhost:8181" />
+                <input id="tautulli_server" name="tautulli_server" type="text" placeholder="http://localhost:8181" autocomplete="off" spellcheck="false" autocapitalize="off" />
               </div>
               <div>
                 <label for="tautulli_key">API Key</label>
-                <input id="tautulli_key" name="tautulli_key" type="password" placeholder="********" />
+                <input id="tautulli_key" name="tautulli_key" type="password" placeholder="********" autocomplete="off" spellcheck="false" autocapitalize="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true" />
               </div>
             </div>
 
             <div style="margin-top:10px;max-width:240px">
               <label for="tautulli_user_id">User ID (optional)<span class="cw-help" title="If this is empty, CrossWatch imports history for all Tautulli users. Normally you only want one user ID.">?</span></label>
-              <input id="tautulli_user_id" name="tautulli_user_id" type="text" placeholder="1" />
+              <input id="tautulli_user_id" name="tautulli_user_id" type="text" placeholder="1" autocomplete="off" spellcheck="false" autocapitalize="off" />
             </div>
 
             <div id="tautulli_hint" class="msg warn" style="margin-top:10px">

--- a/providers/auth/_auth_TMDB.py
+++ b/providers/auth/_auth_TMDB.py
@@ -186,7 +186,7 @@ def _tmdb_sync_html() -> str:
                 <div class="grid2">
                   <div>
                     <label for="tmdb_sync_api_key">API Key (v3)</label>
-                    <input id="tmdb_sync_api_key" name="tmdb_sync_api_key" type="password" autocomplete="new-password" placeholder="Enter TMDb API key" spellcheck="false" autocapitalize="off" />
+                    <input id="tmdb_sync_api_key" name="tmdb_sync_api_key" type="password" autocomplete="off" placeholder="Enter TMDb API key" spellcheck="false" autocapitalize="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true" />
                     <div id="tmdb_sync_hint" class="msg warn" style="margin-top:8px">
                       Create one at
                       <a href="https://www.themoviedb.org/settings/api" target="_blank" rel="noopener">TMDb Preferences</a>

--- a/providers/auth/_auth_TRAKT.py
+++ b/providers/auth/_auth_TRAKT.py
@@ -247,11 +247,11 @@ class _TraktProvider:
             <div class="grid2">
               <div>
                 <label for="trakt_client_id">Client ID</label>
-                <input id="trakt_client_id" name="trakt_client_id" placeholder="Enter your Trakt Client ID">
+                <input id="trakt_client_id" name="trakt_client_id" placeholder="Enter your Trakt Client ID" autocomplete="off" spellcheck="false" autocapitalize="off">
               </div>
               <div>
                 <label for="trakt_client_secret">Client Secret</label>
-                <input id="trakt_client_secret" name="trakt_client_secret" type="password" placeholder="Enter your Trakt Client Secret">
+                <input id="trakt_client_secret" name="trakt_client_secret" type="password" placeholder="Enter your Trakt Client Secret" autocomplete="off" spellcheck="false" autocapitalize="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true">
               </div>
             </div>
 


### PR DESCRIPTION
# Pull request

## Change

- Gated  Tautulli, Floppy and CW Tracker save handling
- Added autocomplete/password-manager hints to provider auth fields

## Why

Browser autofill could put stray values into provider fields, then global Save would try to validate an untouched provider and block saving something else.

## Testing

```
{
  "untouched": {
    "error": null,
    "tautulliSaveCalls": 0
  },
  "touched": {
    "error": "Enter your Tautulli API key",
    "tautulliSaveCalls": 1
  }
```
}

## Issue

Relates to #634
Credits: @AnshulJ999