### PR TITLE
Change: align Floppy anime with SIMKL and Trakt numbering

### DIFF
--- a/cw_platform/id_map.py
+++ b/cw_platform/id_map.py
@@ -349,6 +349,8 @@ def minimal(item: Mapping[str, Any]) -> dict[str, Any]:
         "_simkl_episode_number",
         "_floppy_consumption_id",
         "_floppy_list_item_id",
+        "_floppy_season",
+        "_floppy_episode",
     ):
         if opt in item and item.get(opt) not in (None, ""):
             out[opt] = item.get(opt)

--- a/providers/sync/_mod_FLOPPY.py
+++ b/providers/sync/_mod_FLOPPY.py
@@ -17,7 +17,7 @@ from providers.sync.floppy import _ratings as feat_ratings
 from providers.sync.floppy import _watchlist as feat_watchlist
 from providers.sync.floppy._common import api_delete, api_get, configured_block, is_configured, media_parts_from_item_id, paged
 
-__VERSION__ = "0.1"
+__VERSION__ = "0.2"
 __all__ = ["get_manifest", "FLOPPYModule", "OPS"]
 
 if "ctx" not in globals():
@@ -136,6 +136,20 @@ class FLOPPYModule:
         mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
         return mod.build_index(self, **kwargs) if mod else {}
 
+    def prepare_source_snapshot(self, feature: str, items: Any) -> int:
+        mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
+        hook = getattr(mod, "prepare_source_snapshot", None)
+        if not callable(hook):
+            return 0
+        seq = list(items.values()) if isinstance(items, Mapping) else list(items or [])
+        if not seq:
+            return 0
+        try:
+            produced = hook(seq)
+        except Exception:
+            return 0
+        return produced if isinstance(produced, int) else 0
+
     def add(self, feature: str, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
         mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
         return mod.add(self, items, dry_run=dry_run) if mod else build_op_result(ok=True, count=0, unsupported=True)
@@ -197,6 +211,9 @@ class _FLOPPYOPS:
 
     def build_index(self, cfg: Mapping[str, Any], *, feature: str) -> Mapping[str, dict[str, Any]]:
         return self._adapter(cfg).build_index(feature)
+
+    def prepare_source_snapshot(self, cfg: Mapping[str, Any], *, feature: str, items: Any) -> int:
+        return self._adapter(cfg).prepare_source_snapshot(feature, items)
 
     def add(self, cfg: Mapping[str, Any], items: Iterable[Mapping[str, Any]], *, feature: str, dry_run: bool = False) -> dict[str, Any]:
         return self._adapter(cfg).add(feature, items, dry_run=dry_run)

--- a/providers/sync/floppy/_common.py
+++ b/providers/sync/floppy/_common.py
@@ -14,6 +14,19 @@ from providers.sync._mod_common import safe_json
 PLANNING = 0
 COMPLETED = 3
 PAGE_SIZE = 200
+MAX_PAGES = 200
+MAX_ROWS = 200_000
+MAX_SEASONS = 60
+MAX_EMPTY_SEASONS = 2
+
+_LAYOUT_CACHE: dict[str, list[tuple[int, int]]] = {}
+
+
+def int_or_none(value: Any) -> int | None:
+    try:
+        return int(str(value).strip())
+    except Exception:
+        return None
 
 
 def configured_block(cfg: Mapping[str, Any] | None, instance_id: str = "default") -> dict[str, Any]:
@@ -88,18 +101,38 @@ def api_delete(adapter: Any, path: str, **kwargs: Any) -> Any:
     return api_request(adapter, "DELETE", path, ok=(200, 202, 204, 404), **kwargs)
 
 
-def paged(adapter: Any, path: str, *, params: Mapping[str, Any] | None = None, max_pages: int = 1000) -> list[Mapping[str, Any]]:
+def _page_signature(rows: list[Any]) -> str:
+    parts: list[str] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            parts.append("")
+            continue
+        parts.append("|".join(str(row.get(k) or "") for k in ("item_id", "consumption_id", "id", "media_id", "end_date")))
+    return "\n".join(parts)
+
+
+def paged(adapter: Any, path: str, *, params: Mapping[str, Any] | None = None, max_pages: int = MAX_PAGES) -> list[Mapping[str, Any]]:
     out: list[Mapping[str, Any]] = []
     base = dict(params or {})
     limit = max(1, min(PAGE_SIZE, int(base.pop("limit", PAGE_SIZE) or PAGE_SIZE)))
     offset = max(0, int(base.pop("offset", 0) or 0))
+    previous: str | None = None
     for _ in range(max(1, int(max_pages or 1))):
         data = api_get(adapter, path, params={**base, "limit": limit, "offset": offset})
-        rows = data.get("results") if isinstance(data, Mapping) else data
+        enveloped = isinstance(data, Mapping)
+        rows = data.get("results") if enveloped else data
         if not isinstance(rows, list) or not rows:
             break
+        before = len(out)
         out.extend(row for row in rows if isinstance(row, Mapping))
-        count = data.get("count") if isinstance(data, Mapping) else None
+        if not enveloped:
+            break
+        signature = _page_signature(rows)
+        if previous is not None and signature == previous:
+            del out[before:]
+            break
+        previous = signature
+        count = data.get("count")
         offset += len(rows)
         if len(rows) < limit:
             break
@@ -109,6 +142,8 @@ def paged(adapter: Any, path: str, *, params: Mapping[str, Any] | None = None, m
                     break
             except Exception:
                 pass
+        if len(out) >= MAX_ROWS:
+            break
     return out
 
 
@@ -125,6 +160,63 @@ def media_parts_from_item_id(value: Any) -> tuple[str | None, str | None, str | 
         except Exception:
             season = episode = None
     return typ, source, media_id, season, episode
+
+
+def reset_layout_cache() -> None:
+    _LAYOUT_CACHE.clear()
+
+
+def _row_episode_number(row: Mapping[str, Any]) -> int | None:
+    for key in ("episode_number", "number", "episode"):
+        number = int_or_none(row.get(key))
+        if number is not None and number > 0:
+            return number
+    _, _, _, _, episode = media_parts_from_item_id(row.get("item_id"))
+    return episode if isinstance(episode, int) and episode > 0 else None
+
+
+def _season_episodes(adapter: Any, tmdb_id: str, season: int) -> list[int]:
+    try:
+        rows = paged(adapter, f"media/tv/tmdb/{tmdb_id}/{season}/episodes")
+    except Exception:
+        return []
+    numbers = {n for n in (_row_episode_number(row) for row in rows) if n}
+    return sorted(numbers)
+
+
+def show_layout(adapter: Any, tmdb_id: str) -> list[tuple[int, int]]:
+    key = str(tmdb_id or "").strip()
+    if not key:
+        return []
+    cached = _LAYOUT_CACHE.get(key)
+    if cached is not None:
+        return cached
+    layout: list[tuple[int, int]] = []
+    empty = 0
+    for season in range(1, MAX_SEASONS + 1):
+        numbers = _season_episodes(adapter, key, season)
+        if not numbers:
+            empty += 1
+            if empty >= MAX_EMPTY_SEASONS:
+                break
+            continue
+        empty = 0
+        layout.extend((season, number) for number in numbers)
+    _LAYOUT_CACHE[key] = layout
+    return layout
+
+
+def absolute_to_coord(layout: list[tuple[int, int]], absolute: int) -> tuple[int, int] | None:
+    if not layout or absolute is None or absolute <= 0 or absolute > len(layout):
+        return None
+    return layout[absolute - 1]
+
+
+def has_coord(layout: list[tuple[int, int]], season: int, episode: int) -> bool:
+    try:
+        return (int(season), int(episode)) in layout
+    except Exception:
+        return False
 
 
 def floppy_type_for_item(item: Mapping[str, Any]) -> str | None:

--- a/providers/sync/floppy/_history.py
+++ b/providers/sync/floppy/_history.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import os
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from typing import Any
@@ -10,7 +11,9 @@ from typing import Any
 from cw_platform.id_map import minimal as id_minimal
 from providers.sync._mod_common import build_op_result, unresolved_keys
 
-from ._common import COMPLETED, api_delete, api_patch, api_post, canonical_item_key, failure_reason, item_from_row, paged, tmdb_id_for_item, track_media, unresolved
+from ._common import COMPLETED, absolute_to_coord, api_delete, api_patch, api_post, canonical_item_key, failure_reason, has_coord, int_or_none, item_from_row, paged, reset_layout_cache, show_layout, tmdb_id_for_item, track_media, unresolved
+
+_SRC_SNAPSHOT: dict[str, Any] = {"scope": None, "shows": {}}
 
 
 def _watched_at(item: Mapping[str, Any]) -> str:
@@ -29,6 +32,128 @@ def _episode_numbers(item: Mapping[str, Any]) -> tuple[int | None, int | None]:
     except Exception:
         return None, None
     return season, episode
+
+
+def _explicit_absolute(item: Mapping[str, Any]) -> int | None:
+    for key in ("_simkl_episode_number", "_trakt_number_abs"):
+        number = int_or_none(item.get(key))
+        if number is not None and number > 0:
+            return number
+    return None
+
+
+def _absolute_hint(item: Mapping[str, Any], season: int, episode: int) -> int | None:
+    explicit = _explicit_absolute(item)
+    if explicit is not None:
+        return explicit
+    return episode if season == 1 and episode > 0 else None
+
+
+def _floppy_coord(item: Mapping[str, Any]) -> tuple[int, int] | None:
+    season = int_or_none(item.get("_floppy_season"))
+    episode = int_or_none(item.get("_floppy_episode"))
+    if season is None or episode is None or season < 0 or episode <= 0:
+        return None
+    return season, episode
+
+
+def _pair_scope() -> str:
+    for name in ("CW_PAIR_KEY", "CW_PAIR_SCOPE", "CW_SYNC_PAIR", "CW_PAIR"):
+        value = str(os.getenv(name) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def prepare_source_snapshot(items: Iterable[Mapping[str, Any]]) -> int:
+    shows: dict[str, dict[str, Any]] = {}
+    reset_layout_cache()
+    count = 0
+    for item in items or []:
+        if not isinstance(item, Mapping) or str(item.get("type") or "").strip().lower() != "episode":
+            continue
+        tmdb_id = tmdb_id_for_item(item, episode_show=True)
+        if not tmdb_id:
+            continue
+        season, episode = _episode_numbers(item)
+        if season is None or episode is None or season < 1 or episode < 1:
+            continue
+        record = shows.setdefault(tmdb_id, {"coords": set(), "abs": {}})
+        record["coords"].add((season, episode))
+        hint = _absolute_hint(item, season, episode)
+        if hint is not None:
+            record["abs"][(season, episode)] = hint
+        count += 1
+    _SRC_SNAPSHOT["scope"] = _pair_scope()
+    _SRC_SNAPSHOT["shows"] = shows
+    return count
+
+
+def _rekey_to_source_numbering(adapter: Any, out: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    shows: dict[str, dict[str, Any]] = _SRC_SNAPSHOT.get("shows") or {}
+    if not shows or not out or _SRC_SNAPSHOT.get("scope") != _pair_scope():
+        return out
+    owned_by_show: dict[str, dict[tuple[int, int], str]] = {}
+    for key, item in out.items():
+        if str(item.get("type") or "").strip().lower() != "episode":
+            continue
+        raw_show_ids = item.get("show_ids")
+        show_ids: Mapping[str, Any] = raw_show_ids if isinstance(raw_show_ids, Mapping) else {}
+        show = str(show_ids.get("tmdb") or "").strip()
+        season, episode = _episode_numbers(item)
+        if not show or season is None or episode is None:
+            continue
+        owned_by_show.setdefault(show, {})[(season, episode)] = key
+
+    for show, record in shows.items():
+        owned = owned_by_show.get(show)
+        if not owned:
+            continue
+        wanted: set[tuple[int, int]] = record["coords"]
+        missing = [coord for coord in wanted if coord not in owned]
+        if not missing:
+            continue
+        layout = show_layout(adapter, show)
+        if not layout:
+            continue
+        for coord in sorted(missing):
+            absolute = record["abs"].get(coord)
+            if absolute is None:
+                continue
+            real = absolute_to_coord(layout, absolute)
+            if real is None or real == coord or real in wanted:
+                continue
+            key = owned.get(real)
+            if not key:
+                continue
+            item = out.get(key)
+            if not isinstance(item, Mapping):
+                continue
+            rekeyed = dict(item)
+            rekeyed["_floppy_season"], rekeyed["_floppy_episode"] = real
+            rekeyed["season"], rekeyed["episode"] = coord
+            new_key = canonical_item_key(rekeyed)
+            if new_key in out:
+                continue
+            out.pop(key, None)
+            out[new_key] = rekeyed
+            owned.pop(real, None)
+            owned[coord] = new_key
+    return out
+
+
+def _write_coord(adapter: Any, tmdb_id: str, item: Mapping[str, Any], season: int, episode: int) -> tuple[int, int]:
+    stored = _floppy_coord(item)
+    if stored is not None:
+        return stored
+    absolute = _explicit_absolute(item)
+    if absolute is None:
+        return season, episode
+    layout = show_layout(adapter, tmdb_id)
+    if not layout or has_coord(layout, season, episode):
+        return season, episode
+    real = absolute_to_coord(layout, absolute)
+    return real if real is not None else (season, episode)
 
 
 def _history_id(item: Mapping[str, Any]) -> str | None:
@@ -63,6 +188,8 @@ def _put_latest(out: dict[str, dict[str, Any]], item: dict[str, Any]) -> None:
 def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
     out: dict[str, dict[str, Any]] = {}
     for row in paged(adapter, "media/movie", params={"status": COMPLETED}):
+        if int_or_none(row.get("status")) != COMPLETED and not row.get("end_date"):
+            continue
         item = item_from_row(row, force_type="movie")
         if not item:
             continue
@@ -80,7 +207,7 @@ def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
         item["watched_at"] = row.get("end_date") or row.get("progressed_at") or row.get("created_at")
         item["_floppy_consumption_id"] = row.get("consumption_id")
         _put_latest(out, item)
-    return out
+    return _rekey_to_source_numbering(adapter, out)
 
 
 def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
@@ -124,6 +251,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
                 results.append({"status": "dry_run", "item": id_minimal(raw), "canonical_key": key})
                 continue
             try:
+                season, episode = _write_coord(adapter, tmdb_id, raw, season, episode)
                 if not _episode_history(adapter, tmdb_id, season, episode):
                     api_post(adapter, f"media/tv/tmdb/{tmdb_id}/{season}/episodes/{episode}/watch", json={"end_date": _watched_at(raw)})
             except Exception as exc:
@@ -173,6 +301,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
                 season, episode = _episode_numbers(raw)
                 if not tmdb_id or season is None or episode is None:
                     raise ValueError("missing episode ids")
+                season, episode = _write_coord(adapter, tmdb_id, raw, season, episode)
                 history_id = _history_id(raw)
                 if not history_id:
                     rows = _episode_history(adapter, tmdb_id, season, episode)

--- a/tests/test_floppy_sync.py
+++ b/tests/test_floppy_sync.py
@@ -412,3 +412,230 @@ def test_floppy_raw_ids_survive_minimal_snapshot() -> None:
 
     assert out["_floppy_consumption_id"] == 41
     assert out["_floppy_list_item_id"] == 3
+
+
+def test_floppy_coordinates_survive_minimal_snapshot() -> None:
+    from cw_platform.id_map import minimal
+
+    out = minimal({"type": "episode", "show_ids": {"tmdb": "12971"}, "season": 1, "episode": 100, "_floppy_season": 5, "_floppy_episode": 12})
+
+    assert out["_floppy_season"] == 5
+    assert out["_floppy_episode"] == 12
+
+
+def _dbz_routes(watched: list[tuple[int, int]], layout: dict[int, int]) -> dict[tuple[str, str], Any]:
+    routes: dict[tuple[str, str], Any] = {
+        ("GET", "media/movie"): {"results": [], "count": 0},
+        ("GET", "media/episode"): {
+            "results": [{"item_id": f"tv/tmdb/12971/{s}/{e}", "end_date": "2026-01-02T00:00:00Z", "consumption_id": 1000 + i} for i, (s, e) in enumerate(watched)],
+            "count": len(watched),
+        },
+    }
+    for season, total in layout.items():
+        routes[("GET", f"media/tv/tmdb/12971/{season}/episodes")] = {
+            "results": [{"item_id": f"tv/tmdb/12971/{season}/{n}", "episode_number": n} for n in range(1, total + 1)],
+            "count": total,
+        }
+    return routes
+
+
+def test_floppy_history_rekeys_absolute_source_numbering_onto_aired_episodes() -> None:
+    from providers.sync.floppy import _history
+
+    _history.prepare_source_snapshot([])
+    layout = {1: 39, 2: 35}
+    adapter = AdapterStub(_dbz_routes([(2, 5)], layout))
+
+    produced = _history.prepare_source_snapshot(
+        [{"type": "episode", "show_ids": {"tmdb": "12971"}, "season": 1, "episode": 44, "_simkl_episode_number": 44}]
+    )
+    out = _history.build_index(adapter)
+
+    assert produced == 1
+    assert "tmdb:12971#s01e44" in out
+    assert "tmdb:12971#s02e05" not in out
+    assert out["tmdb:12971#s01e44"]["_floppy_season"] == 2
+    assert out["tmdb:12971#s01e44"]["_floppy_episode"] == 5
+    assert out["tmdb:12971#s01e44"]["_floppy_consumption_id"] == 1000
+
+
+def test_floppy_history_keeps_native_key_when_source_already_matches() -> None:
+    from providers.sync.floppy import _history
+
+    _history.prepare_source_snapshot([])
+    adapter = AdapterStub(_dbz_routes([(2, 5)], {1: 39, 2: 35}))
+
+    _history.prepare_source_snapshot([{"type": "episode", "show_ids": {"tmdb": "12971"}, "season": 2, "episode": 5}])
+    out = _history.build_index(adapter)
+
+    assert list(out) == ["tmdb:12971#s02e05"]
+    assert not any(c["path"].endswith("/episodes") for c in adapter.client.session.calls)
+
+
+def test_floppy_history_does_not_steal_an_episode_the_source_also_asked_for() -> None:
+    from providers.sync.floppy import _history
+
+    _history.prepare_source_snapshot([])
+    adapter = AdapterStub(_dbz_routes([(2, 5)], {1: 39, 2: 35}))
+
+    _history.prepare_source_snapshot(
+        [
+            {"type": "episode", "show_ids": {"tmdb": "12971"}, "season": 1, "episode": 44, "_simkl_episode_number": 44},
+            {"type": "episode", "show_ids": {"tmdb": "12971"}, "season": 2, "episode": 5},
+        ]
+    )
+    out = _history.build_index(adapter)
+
+    assert list(out) == ["tmdb:12971#s02e05"]
+
+
+def test_floppy_history_ignores_a_snapshot_from_another_pair(monkeypatch: Any) -> None:
+    from providers.sync.floppy import _history
+
+    monkeypatch.setenv("CW_PAIR_KEY", "pair_simkl_floppy")
+    _history.prepare_source_snapshot(
+        [{"type": "episode", "show_ids": {"tmdb": "12971"}, "season": 1, "episode": 44, "_simkl_episode_number": 44}]
+    )
+    monkeypatch.setenv("CW_PAIR_KEY", "pair_floppy_trakt")
+    adapter = AdapterStub(_dbz_routes([(2, 5)], {1: 39, 2: 35}))
+
+    out = _history.build_index(adapter)
+
+    assert list(out) == ["tmdb:12971#s02e05"]
+
+
+def test_floppy_history_add_writes_absolute_episode_to_its_aired_coordinate() -> None:
+    from providers.sync.floppy import _history
+
+    _history.prepare_source_snapshot([])
+    _history.reset_layout_cache()
+    routes = _dbz_routes([], {1: 39, 2: 35})
+    routes[("GET", "media/tv/tmdb/12971/2/5/history")] = {"results": [], "count": 0}
+    routes[("POST", "media/tv/tmdb/12971/2/episodes/5/watch")] = {"consumption_id": 77}
+    adapter = AdapterStub(routes)
+
+    res = _history.add(
+        adapter,
+        [{"type": "episode", "show_ids": {"tmdb": "12971"}, "season": 1, "episode": 44, "_simkl_episode_number": 44, "watched_at": "2026-01-02T00:00:00Z"}],
+    )
+
+    assert res["count"] == 1
+    assert [c["path"] for c in adapter.client.session.calls if c["method"] == "POST"] == ["media/tv/tmdb/12971/2/episodes/5/watch"]
+    assert res["confirmed_keys"] == ["tmdb:12971#s01e44"]
+
+
+def test_floppy_history_add_uses_stored_coordinate_without_layout_lookup() -> None:
+    from providers.sync.floppy import _history
+
+    _history.prepare_source_snapshot([])
+    _history.reset_layout_cache()
+    adapter = AdapterStub(
+        {
+            ("GET", "media/tv/tmdb/12971/2/5/history"): {"results": [], "count": 0},
+            ("POST", "media/tv/tmdb/12971/2/episodes/5/watch"): {"consumption_id": 77},
+        }
+    )
+
+    res = _history.add(
+        adapter,
+        [{"type": "episode", "show_ids": {"tmdb": "12971"}, "season": 1, "episode": 44, "_floppy_season": 2, "_floppy_episode": 5}],
+    )
+
+    assert res["count"] == 1
+    assert not any(c["path"].endswith("/episodes") for c in adapter.client.session.calls)
+
+
+def test_floppy_history_add_leaves_regular_shows_untouched() -> None:
+    from providers.sync.floppy import _history
+
+    _history.prepare_source_snapshot([])
+    _history.reset_layout_cache()
+    adapter = AdapterStub(
+        {
+            ("GET", "media/tv/tmdb/22/1/2/history"): {"results": [], "count": 0},
+            ("POST", "media/tv/tmdb/22/1/episodes/2/watch"): {"consumption_id": 5},
+        }
+    )
+
+    res = _history.add(adapter, [{"type": "episode", "show_ids": {"tmdb": "22"}, "season": 1, "episode": 2}])
+
+    assert res["count"] == 1
+    assert [c["path"] for c in adapter.client.session.calls if c["method"] == "POST"] == ["media/tv/tmdb/22/1/episodes/2/watch"]
+
+
+def test_floppy_history_remove_targets_the_real_floppy_coordinate() -> None:
+    from providers.sync.floppy import _history
+
+    _history.prepare_source_snapshot([])
+    _history.reset_layout_cache()
+    adapter = AdapterStub({("DELETE", "media/tv/tmdb/12971/2/5/history/1000"): ResponseStub(204, {})})
+
+    res = _history.remove(
+        adapter,
+        [{"type": "episode", "show_ids": {"tmdb": "12971"}, "season": 1, "episode": 44, "_floppy_season": 2, "_floppy_episode": 5, "_floppy_consumption_id": 1000}],
+    )
+
+    assert res["count"] == 1
+    assert adapter.client.session.calls[0]["path"] == "media/tv/tmdb/12971/2/5/history/1000"
+
+
+def test_floppy_history_movie_index_skips_unwatched_rows() -> None:
+    from providers.sync.floppy import _history
+
+    _history.prepare_source_snapshot([])
+    adapter = AdapterStub(
+        {
+            ("GET", "media/movie"): {
+                "results": [
+                    {"item_id": "movie/tmdb/11", "status": 3, "end_date": "2026-01-01T00:00:00Z"},
+                    {"item_id": "movie/tmdb/12", "status": 0, "end_date": None},
+                    {"item_id": "movie/tmdb/13", "status": 1, "end_date": "2026-01-05T00:00:00Z"},
+                ],
+                "count": 3,
+            },
+            ("GET", "media/episode"): {"results": [], "count": 0},
+        }
+    )
+
+    out = _history.build_index(adapter)
+
+    assert sorted(out) == ["tmdb:11", "tmdb:13"]
+
+
+def test_floppy_paged_stops_when_endpoint_ignores_offset() -> None:
+    from providers.sync.floppy._common import paged
+
+    page = {"results": [{"item_id": f"movie/tmdb/{n}"} for n in range(200)]}
+    adapter = AdapterStub({("GET", "media/movie"): page})
+
+    rows = paged(adapter, "media/movie")
+
+    assert len(rows) == 200
+    assert len(adapter.client.session.calls) == 2
+
+
+def test_floppy_paged_stops_on_unpaginated_list_response() -> None:
+    from providers.sync.floppy._common import paged
+
+    adapter = AdapterStub({("GET", "media/episode"): [{"item_id": f"tv/tmdb/1/1/{n}"} for n in range(300)]})
+
+    rows = paged(adapter, "media/episode")
+
+    assert len(rows) == 300
+    assert len(adapter.client.session.calls) == 1
+
+
+def test_floppy_paged_still_walks_real_pages() -> None:
+    from providers.sync.floppy._common import paged
+
+    def route(call: dict[str, Any]) -> Any:
+        offset = int(call["params"]["offset"])
+        rows = [{"item_id": f"movie/tmdb/{offset + n}"} for n in range(min(200, 450 - offset))]
+        return {"results": rows, "count": 450}
+
+    adapter = AdapterStub({("GET", "media/movie"): route})
+
+    rows = paged(adapter, "media/movie")
+
+    assert len(rows) == 450
+    assert len(adapter.client.session.calls) == 3


### PR DESCRIPTION
# Pull request

## Change

- Adds Floppy history mapping for absolute anime episode numbers from SIMKL and Trakt.
- Floppy can now compare those against its real season/episode layout,

## Why

SIMKL and Trakt can represent anime episodes with absolute numbering, while Floppy exposes grouped anime through TV-style season/episode history.

This avoids false missing history entries for shows like Dragon Ball Z.

## Testing

- test_floppy_sync.py

## Issue

Relates to #632