### PR TITLE
Change: avoid false SIMKL history adds

### DIFF
--- a/providers/sync/simkl/_history.py
+++ b/providers/sync/simkl/_history.py
@@ -2615,6 +2615,36 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 _apply_response_classification(items_list, payload)
 
             unknown_failed = len(not_found["movies"])
+            reported_total = (
+                int(added_new.get("movies") or 0)
+                + int(added_new.get("shows") or 0)
+                + int(added_new.get("episodes") or 0)
+            )
+            has_not_found = bool(not_found["shows"] or not_found["movies"] or not_found["episodes"])
+            if main_items_list and reported_total == 0 and not has_not_found:
+                hint = "simkl_write_response_unconfirmed:add"
+                _freeze_failed_adds(main_items_list, hint)
+                unresolved.extend(_unresolved_for_items(main_items_list, hint))
+                setattr(adapter, "_simkl_history_add_confirmed_keys", [])
+                setattr(adapter, "_simkl_history_add_skipped_keys", [])
+                _info(
+                    "write_done",
+                    op="add",
+                    ok=False,
+                    applied=0,
+                    unresolved=len(unresolved),
+                    movies=len(movies),
+                    shows_payload=len(shows_payload),
+                    seasons=seasons_count,
+                    episodes=eps_count,
+                    not_found=0,
+                    anime_retry=0,
+                    reported_movies=0,
+                    reported_shows=0,
+                    reported_episodes=0,
+                    reason=hint,
+                )
+                return 0, unresolved
             if not_found["shows"] or not_found["movies"] or not_found["episodes"]:
                 _dbg("resolve_miss", op="add", movies=len(not_found["movies"]), shows=len(not_found["shows"]), episodes=len(not_found["episodes"]))
 
@@ -3103,4 +3133,3 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
     ok = len(confirmed_keys)
     _info("write_done", op="remove", ok=len(unresolved) == 0 and ok > 0, applied=ok, unresolved=len(unresolved))
     return ok, unresolved
-

--- a/providers/tests/test_simkl_history_anime_mapping.py
+++ b/providers/tests/test_simkl_history_anime_mapping.py
@@ -327,6 +327,25 @@ def test_mixed_response_confirms_all_but_not_found(monkeypatch):
     assert len(unresolved) == 1
 
 
+def test_zero_reported_add_without_not_found_is_unconfirmed(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    injected = []
+    monkeypatch.setattr(m, "_inject_adds_into_cache", lambda items: injected.extend(items))
+    session = _Session(post_handler=lambda url, body: _Resp(200, _ok_add(episodes=0)))
+    adapter = _adapter(session)
+
+    item = _episode("11256175", "2190", 27, 6, "South Park")
+    ok, unresolved = m.add(adapter, [item])
+
+    assert ok == 0
+    assert len(unresolved) == 1
+    assert unresolved[0]["hint"] == "simkl_write_response_unconfirmed:add"
+    assert getattr(adapter, "_simkl_history_add_confirmed_keys") == []
+    assert injected == []
+
+
 def test_anime_like_s00_unmapped_is_unresolved(monkeypatch):
     import sync.simkl._history as m
 
@@ -1081,4 +1100,3 @@ def test_show_no_abs_or_title_mapping_applied(monkeypatch):
     eps = [v for v in out.values() if str(v.get("type")) == "episode"]
     assert len(eps) == 1
     assert (eps[0]["season"], eps[0]["episode"]) == (1, 7)
-


### PR DESCRIPTION
# Pull request

## Change

Stop counting SIMKL history adds as confirmed when SIMKL returns OK but reports zero added items.

## Why

This avoids fake results.

## Testing

- test_simkl_history_anime_mapping.py 

## Issue

NA