### PR TITLE
Change: improve large state.json handling

### DIFF
--- a/api/editorAPI.py
+++ b/api/editorAPI.py
@@ -42,7 +42,11 @@ def _atomic_write_json(path: Path, payload: Any) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(path.suffix + ".tmp")
-        tmp.write_text(json.dumps(payload, ensure_ascii=False, sort_keys=True), "utf-8")
+        if path.name == "state.json":
+            text = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+        else:
+            text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        tmp.write_text(text, "utf-8")
         os.replace(tmp, path)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to write {path}: {e}")
@@ -114,11 +118,14 @@ def _merge_blocks(a: list[str], b: list[str]) -> list[str]:
 
 
 
-def _load_policy_manual(kind: Kind, provider: str, provider_instance: str | None = None) -> tuple[dict[str, Any], list[str]]:
-    raw = _load_policy()
+def _policy_provider_node(
+    raw: dict[str, Any],
+    provider: str,
+    provider_instance: str | None = None,
+) -> dict[str, Any] | None:
     providers = raw.get("providers") or {}
     if not isinstance(providers, dict):
-        return {}, []
+        return None
 
     node = providers.get(provider)
     if not isinstance(node, dict):
@@ -128,16 +135,29 @@ def _load_policy_manual(kind: Kind, provider: str, provider_instance: str | None
                 node = v
                 break
     if not isinstance(node, dict):
-        return {}, []
+        return None
 
     inst = normalize_instance_id(provider_instance)
     if inst != "default":
         insts = node.get("instances") or {}
         if not isinstance(insts, dict):
-            return {}, []
+            return None
         node = insts.get(inst)
         if not isinstance(node, dict):
-            return {}, []
+            return None
+    return node
+
+
+def _load_policy_manual(
+    kind: Kind,
+    provider: str,
+    provider_instance: str | None = None,
+    raw_policy: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    raw = raw_policy if isinstance(raw_policy, dict) else _load_policy()
+    node = _policy_provider_node(raw, provider, provider_instance)
+    if not isinstance(node, dict):
+        return {}, []
 
     f = node.get(kind) or {}
     if not isinstance(f, dict):
@@ -380,15 +400,18 @@ def _merge_policy(into: dict[str, Any], src: dict[str, Any], mode: str) -> dict[
     return out
 
 
-def _mirror_policy_into_state() -> None:
+def _mirror_policy_into_state(
+    raw_state: dict[str, Any] | None = None,
+    raw_policy: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
     if not _STATE_PATH.exists():
-        return
-    pol = _load_policy()
+        return None
+    pol = raw_policy if isinstance(raw_policy, dict) else _load_policy()
     prov_pol = pol.get("providers")
     if not isinstance(prov_pol, dict) or not prov_pol:
-        return
+        return raw_state if isinstance(raw_state, dict) else None
 
-    raw = _load_current_state()
+    raw = raw_state if isinstance(raw_state, dict) else _load_current_state()
     provs = raw.get("providers")
     if not isinstance(provs, dict):
         provs = {}
@@ -433,8 +456,8 @@ def _mirror_policy_into_state() -> None:
                 continue
             t = _ensure_dict(manual, kind)
 
-            adds_in, blocks_in = _load_policy_manual(kind, str(p), "default")
-            adds_state, blocks_state = _load_state_manual(kind, key, "default")
+            adds_in, blocks_in = _load_policy_manual(kind, str(p), "default", raw_policy=pol)
+            adds_state, blocks_state = _load_state_manual(kind, key, "default", raw_state=raw)
 
             merged_blocks = _merge_blocks(blocks_state or [], blocks_in or [])
             if t.get("blocks") != merged_blocks:
@@ -486,8 +509,8 @@ def _mirror_policy_into_state() -> None:
                     continue
                 t = _ensure_dict(inst_manual, kind)
 
-                adds_in, blocks_in = _load_policy_manual(kind, str(p), inst_id_n)
-                adds_state, blocks_state = _load_state_manual(kind, key, inst_id_n)
+                adds_in, blocks_in = _load_policy_manual(kind, str(p), inst_id_n, raw_policy=pol)
+                adds_state, blocks_state = _load_state_manual(kind, key, inst_id_n, raw_state=raw)
 
                 merged_blocks = _merge_blocks(blocks_state or [], blocks_in or [])
                 if t.get("blocks") != merged_blocks:
@@ -513,6 +536,7 @@ def _mirror_policy_into_state() -> None:
 
     if changed:
         _atomic_write_json(_STATE_PATH, raw)
+    return raw
 
 def _policy_stats(pol: dict[str, Any]) -> dict[str, int]:
     prov = pol.get("providers") or {}
@@ -548,11 +572,14 @@ def _state_providers(raw: dict[str, Any]) -> list[str]:
     return sorted([str(k) for k in providers.keys() if str(k).strip()])
 
 
-def _load_state_items(kind: Kind, provider: str, provider_instance: str | None = None) -> dict[str, Any]:
-    raw = _load_current_state()
+def _state_provider_node(
+    raw: dict[str, Any],
+    provider: str,
+    provider_instance: str | None = None,
+) -> dict[str, Any] | None:
     providers = raw.get("providers") or {}
     if not isinstance(providers, dict):
-        return {}
+        return None
 
     node = providers.get(provider)
     if not isinstance(node, dict):
@@ -562,16 +589,29 @@ def _load_state_items(kind: Kind, provider: str, provider_instance: str | None =
                 node = v
                 break
     if not isinstance(node, dict):
-        return {}
+        return None
 
     inst = normalize_instance_id(provider_instance)
     if inst != "default":
         insts = node.get("instances") or {}
         if not isinstance(insts, dict):
-            return {}
+            return None
         node = insts.get(inst)
         if not isinstance(node, dict):
-            return {}
+            return None
+    return node
+
+
+def _load_state_items(
+    kind: Kind,
+    provider: str,
+    provider_instance: str | None = None,
+    raw_state: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    raw = raw_state if isinstance(raw_state, dict) else _load_current_state()
+    node = _state_provider_node(raw, provider, provider_instance)
+    if not isinstance(node, dict):
+        return {}
 
     feature = node.get(kind) or {}
     if not isinstance(feature, dict):
@@ -632,29 +672,16 @@ def _save_state_items(kind: Kind, provider: str, items: dict[str, Any], provider
     _atomic_write_json(_STATE_PATH, raw)
 
 
-def _load_state_manual(kind: Kind, provider: str, provider_instance: str | None = None) -> tuple[dict[str, Any], list[str]]:
-    raw = _load_current_state()
-    providers = raw.get("providers") or {}
-    if not isinstance(providers, dict):
-        return {}, []
-    node = providers.get(provider)
-    if not isinstance(node, dict):
-        pl = str(provider).lower()
-        for k, v in providers.items():
-            if str(k).lower() == pl and isinstance(v, dict):
-                node = v
-                break
+def _load_state_manual(
+    kind: Kind,
+    provider: str,
+    provider_instance: str | None = None,
+    raw_state: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    raw = raw_state if isinstance(raw_state, dict) else _load_current_state()
+    node = _state_provider_node(raw, provider, provider_instance)
     if not isinstance(node, dict):
         return {}, []
-
-    inst = normalize_instance_id(provider_instance)
-    if inst != "default":
-        insts = node.get("instances") or {}
-        if not isinstance(insts, dict):
-            return {}, []
-        node = insts.get(inst)
-        if not isinstance(node, dict):
-            return {}, []
 
     manual = node.get("manual") or {}
     if not isinstance(manual, dict):
@@ -1215,7 +1242,8 @@ def api_editor_get_state(
         filename = (ws["files"] or {}).get(k)
         items, ts = _tracker_read(ws["root"], filename) if filename else ({}, None)
 
-        pol_adds, pol_blocks = _load_policy_manual(k, _TRACKER_PROVIDER, inst)
+        raw_policy = _load_policy()
+        pol_adds, pol_blocks = _load_policy_manual(k, _TRACKER_PROVIDER, inst, raw_policy=raw_policy)
         st_adds, st_blocks = (
             _load_state_manual(k, _TRACKER_PROVIDER, inst) if _STATE_PATH.exists() else ({}, [])
         )
@@ -1260,12 +1288,11 @@ def api_editor_get_state(
         inst = normalize_instance_id(provider_instance)
 
         if _STATE_PATH.exists() and _POLICY_PATH.exists():
-            _mirror_policy_into_state()
-            raw_state = _load_current_state()
+            raw_state = _mirror_policy_into_state(raw_state, raw_policy) or raw_state
 
-        items = _load_state_items(k, chosen, inst) if raw_state else {}
-        st_adds, st_blocks = _load_state_manual(k, chosen, inst) if raw_state else ({}, [])
-        pol_adds, pol_blocks = _load_policy_manual(k, chosen, inst)
+        items = _load_state_items(k, chosen, inst, raw_state=raw_state) if raw_state else {}
+        st_adds, st_blocks = _load_state_manual(k, chosen, inst, raw_state=raw_state) if raw_state else ({}, [])
+        pol_adds, pol_blocks = _load_policy_manual(k, chosen, inst, raw_policy=raw_policy)
 
         manual_adds = dict(st_adds or {})
         manual_adds.update(dict(pol_adds or {}))
@@ -1311,9 +1338,9 @@ def api_editor_get_state(
             }
 
         inst = normalize_instance_id(provider_instance)
-        pol_adds, pol_blocks = _load_policy_manual(k, chosen, inst)
+        pol_adds, pol_blocks = _load_policy_manual(k, chosen, inst, raw_policy=raw_policy)
         if not pol_adds and not pol_blocks and raw_state:
-            pol_adds, pol_blocks = _load_state_manual(k, chosen, inst)
+            pol_adds, pol_blocks = _load_state_manual(k, chosen, inst, raw_state=raw_state)
 
         ts = None
         try:

--- a/api/maintenanceAPI.py
+++ b/api/maintenanceAPI.py
@@ -321,6 +321,70 @@ def _sync_state_inventory(path: Path) -> tuple[int, int]:
     return len(providers), baseline_count
 
 
+def _sync_state_baseline_inventory(path: Path) -> dict[str, Any]:
+    payload = _read_json(path)
+    providers = payload.get("providers") if isinstance(payload, dict) else None
+    if not isinstance(providers, dict):
+        return {"providers": 0, "baselines": 0, "items": 0, "largest": None}
+
+    feature_names = {"history", "ratings", "watchlist", "playlists", "progress"}
+    baselines = 0
+    items_total = 0
+    largest: dict[str, Any] | None = None
+
+    def _visit_provider(provider_name: str, node: Any, instance: str = "default") -> None:
+        nonlocal baselines, items_total, largest
+        if not isinstance(node, dict):
+            return
+        for name, block in node.items():
+            feature = str(name).lower()
+            if feature not in feature_names or not isinstance(block, dict):
+                continue
+            baseline = block.get("baseline") or {}
+            items = baseline.get("items") if isinstance(baseline, dict) else None
+            count = len(items) if isinstance(items, dict) else 0
+            if block.get("baseline") is not None or block:
+                baselines += 1
+            items_total += count
+            row = {
+                "provider": provider_name,
+                "instance": instance,
+                "feature": feature,
+                "items": count,
+            }
+            if largest is None or count > int(largest.get("items") or 0):
+                largest = row
+
+        insts = node.get("instances")
+        if isinstance(insts, dict):
+            for inst_name, inst_node in insts.items():
+                _visit_provider(provider_name, inst_node, str(inst_name or "default"))
+
+    for provider_name, provider_node in providers.items():
+        _visit_provider(str(provider_name), provider_node)
+
+    return {
+        "providers": len(providers),
+        "baselines": baselines,
+        "items": items_total,
+        "largest": largest,
+    }
+
+
+def _write_json_compact_atomic(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".compact.tmp")
+    try:
+        tmp.write_text(json.dumps(payload, ensure_ascii=False, separators=(",", ":")), "utf-8")
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+
+
 def _currently_playing_count(path: Path) -> int:
     payload = _read_json(path)
     if not isinstance(payload, dict):
@@ -351,6 +415,28 @@ def maintenance_action_status(action: str) -> dict[str, Any]:
                 _metric("Feature baselines", baselines),
                 _metric("Pair mapping files", len(scoped)),
                 _metric("State storage", scoped_usage["bytes"], "bytes"),
+                _metric("Last updated", usage["modified"], "datetime"),
+            ],
+        )
+    elif action == "state-file":
+        path = CONFIG_DIR / "state.json"
+        usage = _path_usage(path)
+        inv = _sync_state_baseline_inventory(path)
+        largest = inv.get("largest") if isinstance(inv.get("largest"), dict) else None
+        largest_label = "None"
+        if largest:
+            inst = str(largest.get("instance") or "default")
+            suffix = "" if inst == "default" else f" ({inst})"
+            largest_label = f"{largest.get('provider')} {largest.get('feature')}{suffix}"
+        response.update(
+            title="State file",
+            note="Inspects the legacy state.json baseline file. Compact rewrites the same JSON without indentation after creating an app-state backup.",
+            metrics=[
+                _metric("File size", usage["bytes"], "bytes"),
+                _metric("Providers", inv.get("providers", 0)),
+                _metric("Feature baselines", inv.get("baselines", 0)),
+                _metric("Baseline items", inv.get("items", 0)),
+                _metric("Largest baseline", largest_label, "text"),
                 _metric("Last updated", usage["modified"], "datetime"),
             ],
         )
@@ -735,6 +821,79 @@ def clear_state_minimal() -> dict[str, Any]:
             "path": str(state_path),
             "existed": bool(existed),
         }
+
+
+@router.post("/state-file/compact")
+def compact_state_file() -> dict[str, Any]:
+    _, CONFIG_DIR, *_ = _cw()
+    state_path = CONFIG_DIR / "state.json"
+    before = _path_usage(state_path)
+
+    if not state_path.exists():
+        return {
+            "ok": True,
+            "path": str(state_path),
+            "existed": False,
+            "backup": None,
+            "summary": {"removed_files": 0, "removed_items": 0, "freed_bytes": 0},
+        }
+
+    payload = _read_json(state_path)
+    if not isinstance(payload, dict):
+        return {
+            "ok": False,
+            "error": "state_json_invalid",
+            "path": str(state_path),
+            "summary": {"removed_files": 0, "removed_items": 0, "freed_bytes": 0},
+        }
+
+    backup: dict[str, Any] | None = None
+    try:
+        from services.backups import create_backup
+
+        backup = create_backup(
+            scope="app_state",
+            label="pre-state-compact",
+            trigger="maintenance_state_compact",
+        )
+    except Exception:
+        _LOG.exception("state compact backup failed")
+        return {
+            "ok": False,
+            "error": "backup_failed",
+            "path": str(state_path),
+            "summary": {"removed_files": 0, "removed_items": 0, "freed_bytes": 0},
+        }
+
+    try:
+        _write_json_compact_atomic(state_path, payload)
+    except Exception:
+        _LOG.exception("state compact write failed")
+        return {
+            "ok": False,
+            "error": "compact_failed",
+            "path": str(state_path),
+            "backup": backup,
+            "summary": {"removed_files": 0, "removed_items": 0, "freed_bytes": 0},
+        }
+
+    after = _path_usage(state_path)
+    summary = {
+        "removed_files": 0,
+        "removed_items": 0,
+        "freed_bytes": max(0, int(before.get("bytes") or 0) - int(after.get("bytes") or 0)),
+    }
+    inv = _sync_state_baseline_inventory(state_path)
+    return {
+        "ok": True,
+        "path": str(state_path),
+        "existed": True,
+        "backup": backup,
+        "before_bytes": int(before.get("bytes") or 0),
+        "after_bytes": int(after.get("bytes") or 0),
+        "summary": summary,
+        "inventory": inv,
+    }
 
 
 @router.post("/crosswatch-tracker/clear")

--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 from cw_platform.modules_registry import get_sync_module_path_by_name, sync_provider_names, sync_provider_supports_feature
 from cw_platform.reason_labels import friendly_reason
 from cw_platform.value_coercion import coerce_bool
+from services.scheduler_webhooks import notify_scheduler_webhook
 
 __all__ = ["router", "_is_sync_running", "_load_state", "_find_state_path"]
 
@@ -511,7 +512,12 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
     rt = _rt()
     LOG_BUFFERS, RUNNING_PROCS, STATE_PATH, _append_log, strip_ansi = rt[0], rt[1], rt[3], rt[8], rt[7]
     overrides = overrides or {}
+    scheduler_context = dict(overrides)
+    scheduler_context["run_id"] = str(run_id)
+    scheduler_webhook_cfg: dict[str, Any] | None = None
+    scheduler_start_sent = False
     _summary_reset()
+    _summary_set("run_id", str(run_id))
     LOG_BUFFERS["SYNC"] = []
     os.environ["CW_RUN_ID"] = str(run_id)
     _sync_progress_ui("::CLEAR::")
@@ -609,6 +615,18 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
     try:
         load_config, _save = _env()
         cfg = load_config()
+        scheduler_webhook_cfg = cfg if isinstance(cfg, dict) else {}
+
+        try:
+            scheduler_start_sent = notify_scheduler_webhook(
+                scheduler_webhook_cfg,
+                "start",
+                scheduler_context,
+                _summary_snapshot(),
+                log_fn=lambda msg: _append_log("SYNC", msg),
+            )
+        except Exception:
+            scheduler_start_sent = False
 
         req_pair_id = ""
         try:
@@ -661,10 +679,16 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
 
             mgr = OrchestratorClass(config=cfg)
             dry = coerce_bool((cfg.get("sync") or {}).get("dry_run", False)) or coerce_bool((overrides or {}).get("dry_run"))
+            runtime_cfg = cfg.get("runtime") or {}
+            sync_cfg = cfg.get("sync") or {}
+            write_state_json = coerce_bool(
+                sync_cfg.get("write_state_json", runtime_cfg.get("write_state_json", True)),
+                True,
+            )
             result = mgr.run_pairs(
                 dry_run=dry,
                 progress=_sync_progress_ui,
-                write_state_json=True,
+                write_state_json=write_state_json,
                 state_path=STATE_PATH,
                 use_snapshot=True,
             )
@@ -672,7 +696,7 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
         added_res = int(result.get("added", 0))
         removed_res = int(result.get("removed", 0))
         try:
-            state = _load_state()
+            state = _load_state() if write_state_json else {}
             if state:
                 _STATS = _rt()[5]
                 _STATS.refresh_from_state(state)
@@ -687,8 +711,10 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
                         _PROVIDER_COUNTS_CACHE["data"] = counts
                 except Exception as e:
                     _append_log("SYNC", f"[!] Provider-counts cache warm failed: {e}")
-            else:
+            elif write_state_json:
                 _append_log("SYNC", "[!] No state found after sync; stats not updated.")
+            else:
+                _append_log("SYNC", "[i] Legacy state.json persistence disabled; state-backed stats skipped.")
         except Exception as e:
             _append_log("SYNC", f"[!] Stats update failed: {e}")
 
@@ -732,6 +758,28 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
             if counts2:
                 _PROVIDER_COUNTS_CACHE["ts"] = time.time()
                 _PROVIDER_COUNTS_CACHE["data"] = counts2
+        except Exception:
+            pass
+        try:
+            snap = _summary_snapshot()
+            exit_code = snap.get("exit_code")
+            if exit_code is not None:
+                event = "success" if int(exit_code) == 0 else "failure"
+                notify_scheduler_webhook(
+                    scheduler_webhook_cfg,
+                    event,
+                    scheduler_context,
+                    snap,
+                    log_fn=lambda msg: _append_log("SYNC", msg),
+                )
+            elif scheduler_start_sent:
+                notify_scheduler_webhook(
+                    scheduler_webhook_cfg,
+                    "failure",
+                    scheduler_context,
+                    snap,
+                    log_fn=lambda msg: _append_log("SYNC", msg),
+                )
         except Exception:
             pass
         RUNNING_PROCS.pop("SYNC", None)

--- a/assets/js/modals/maintenance/index.js
+++ b/assets/js/modals/maintenance/index.js
@@ -56,6 +56,7 @@ const SIMPLE_OPS = {
   "events-health": "/api/maintenance/events-health",
   "events-optimize": "/api/maintenance/events-optimize",
   "events-rebuild": "/api/maintenance/events-rebuild",
+  "state-file": "/api/maintenance/state-file/compact",
 };
 const OPS = [
   {
@@ -73,6 +74,14 @@ const OPS = [
     title: "Retry provider items",
     tag: "runtime",
     desc: "Clears temporary retry and health data so items are tried again.",
+  },
+  {
+    key: "state-file",
+    kind: "state-file",
+    icon: "data_object",
+    title: "Compact state.json",
+    tag: "backup first",
+    desc: "Creates an app-state backup, then rewrites the same state file without indentation.",
   },
   {
     key: "meta",
@@ -185,6 +194,13 @@ const GROUPS = [
     keys: ["state", "cache"],
   },
   {
+    id: "state-file",
+    icon: "data_object",
+    title: "State File",
+    desc: "Inspect and compact the legacy state.json baseline file.",
+    keys: ["state-file"],
+  },
+  {
     id: "playback",
     icon: "play_circle",
     title: "Playback",
@@ -229,7 +245,7 @@ const GROUPS = [
 ];
 
 const OPS_BY_KEY = Object.fromEntries(OPS.map((op) => [op.key, op]));
-const OVERVIEW_EXCLUDED_KEYS = new Set(["tracker", "captures", "defaults", "events-health", "events-optimize", "events-rebuild"]);
+const OVERVIEW_EXCLUDED_KEYS = new Set(["tracker", "captures", "defaults", "events-health", "events-optimize", "events-rebuild", "state-file"]);
 const OVERVIEW_KEYS = GROUPS
   .flatMap((group) => group.keys)
   .filter((key) => !OVERVIEW_EXCLUDED_KEYS.has(key));
@@ -355,6 +371,13 @@ export default {
                     <span class="material-symbols-rounded" aria-hidden="true">history</span>
                     <span>Events</span>
                   </button>
+                </div>
+                <div class="side-nav-item" data-group="state-file">
+                  <button type="button" class="side-nav-btn" data-target="cxm-group-state-file">
+                    <span class="material-symbols-rounded" aria-hidden="true">data_object</span>
+                    <span>State File</span>
+                  </button>
+                  <button type="button" class="category-run-btn" data-run-group="state-file" aria-label="Run all State File tools">Run</button>
                 </div>
                 <div class="side-nav-item" data-group="archive">
                   <button type="button" class="side-nav-btn" data-target="cxm-group-archive">
@@ -581,6 +604,17 @@ export default {
       return null;
     };
 
+    const stateFileReceipt = (res) => {
+      if (!res || typeof res !== "object") return null;
+      const backupPath = res.backup && res.backup.path ? String(res.backup.path) : "";
+      const before = formatBytes(res.before_bytes || 0);
+      const after = formatBytes(res.after_bytes || 0);
+      const freed = formatBytes((res.summary && res.summary.freed_bytes) || 0);
+      const bits = [`${before} → ${after}`, `${freed} reclaimed`];
+      if (backupPath) bits.push(`backup ${backupPath}`);
+      return `Compact state.json completed · ${bits.join(" · ")}.`;
+    };
+
     const formatMetric = ({ value, format }) => {
       if (format === "bytes") return formatBytes(value);
       if (format === "datetime") {
@@ -780,6 +814,11 @@ export default {
         return false;
       }
 
+      if (!skipConfirm && kind === "state-file" && !confirm("Create an app-state backup and compact state.json?\n\nThis keeps the same JSON data and only removes formatting whitespace.")) {
+        setStatus("Cancelled.", "");
+        return false;
+      }
+
       if (manageLock) setOperationBusy(true);
       startActionFeedback(btn);
       const label = btn?.dataset?.label || OPS.find((item) => item.kind === kind)?.title || kind;
@@ -870,7 +909,8 @@ export default {
 
         if (selectedInsightKind === kind) await loadActionInsight(kind);
         const evReceipt = eventsReceipt(kind, res);
-        setStatus(evReceipt || completionReceipt(label, res), "ok");
+        const stateReceipt = kind === "state-file" ? stateFileReceipt(res) : null;
+        setStatus(evReceipt || stateReceipt || completionReceipt(label, res), "ok");
         finishActionFeedback(btn, "success");
         return res || { ok: true };
       } catch (e) {

--- a/assets/js/modals/maintenance/styles.css
+++ b/assets/js/modals/maintenance/styles.css
@@ -25,13 +25,13 @@
 .cw-maint .sidebar-label { margin: 10px 9px 4px; color: var(--maint-muted); font-size: 10px; font-weight: 850; letter-spacing: .1em; text-transform: uppercase; }
 .cw-maint .side-nav { --nav-accent: var(--maint-accent); display: grid; gap: 3px; }
 .cw-maint .side-nav-item { --nav-accent: var(--maint-accent); min-width: 0; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 0; }
-.cw-maint .side-nav-item:is([data-group="archive"], [data-group="events"], [data-group="captures"]) { --nav-accent: var(--maint-good); }
+.cw-maint .side-nav-item:is([data-group="archive"], [data-group="events"], [data-group="state-file"], [data-group="captures"]) { --nav-accent: var(--maint-good); }
 .cw-maint .side-nav-item[data-group="danger"] { --nav-accent: var(--maint-danger); }
 .cw-maint .side-nav-btn { position: relative; width: 100%; min-height: 46px; gap: 10px; padding: 0 12px; border: 1px solid transparent; border-radius: 8px; color: var(--maint-muted); background: transparent; cursor: pointer; text-align: left; font-size: 13px; font-weight: 700; transition: background .14s ease, border-color .14s ease, color .14s ease; }
 .cw-maint .side-nav-btn .material-symbols-rounded { width: 23px; flex: 0 0 23px; font-size: 23px; font-variation-settings: "FILL" 0, "wght" 500, "GRAD" 0, "opsz" 20; }
 .cw-maint .side-nav-btn:hover, .cw-maint .side-nav-btn.active { color: var(--maint-text); border-color: color-mix(in srgb, var(--nav-accent) 38%, var(--maint-border)); background: color-mix(in srgb, var(--nav-accent) 9%, var(--maint-card)); }
 .cw-maint .side-nav-btn.active .material-symbols-rounded { color: var(--nav-accent); }
-.cw-maint .side-nav-btn:is([data-target="cxm-group-archive"], [data-target="cxm-group-events"], [data-target="cxm-group-captures"]) { --nav-accent: var(--maint-good); }
+.cw-maint .side-nav-btn:is([data-target="cxm-group-archive"], [data-target="cxm-group-events"], [data-target="cxm-group-state-file"], [data-target="cxm-group-captures"]) { --nav-accent: var(--maint-good); }
 .cw-maint .side-nav-btn[data-target="cxm-group-danger"] { --nav-accent: var(--maint-danger); }
 .cw-maint .side-nav-btn.danger, .cw-maint .side-nav-btn.danger .material-symbols-rounded { color: var(--maint-danger); }
 .cw-maint .category-run-btn {
@@ -111,7 +111,7 @@
 /* Action cards and feedback */
 .cw-maint .action-row { --inspect-accent: var(--maint-accent); position: relative; overflow: hidden; min-width: 0; min-height: 92px; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 10px; padding: 11px 12px; border: 1px solid var(--maint-border); border-radius: 8px; background: var(--maint-card); box-shadow: none; cursor: pointer; transition: background .14s ease, border-color .14s ease, box-shadow .14s ease, transform .14s ease; }
 .cw-maint .action-row.has-side-actions { grid-template-columns: minmax(0, 1fr) auto auto; }
-.cw-maint .action-row[data-kind="tracker"] { --inspect-accent: var(--maint-good); }
+.cw-maint .action-row[data-kind="tracker"], .cw-maint .action-row[data-kind="state-file"] { --inspect-accent: var(--maint-good); }
 .cw-maint .action-row[data-kind="defaults"] { --inspect-accent: var(--maint-danger); }
 .cw-maint .action-row::before { content: ""; position: absolute; left: 0; top: 12px; bottom: 12px; width: 3px; border-radius: 0 999px 999px 0; background: var(--inspect-accent); opacity: 0; transform: scaleY(.35); transition: opacity .16s ease, transform .2s ease; }
 .cw-maint .action-row.is-inspected { border-color: color-mix(in srgb, var(--inspect-accent) 58%, var(--maint-border)); background: color-mix(in srgb, var(--inspect-accent) 8%, var(--maint-card)); box-shadow: 0 0 0 1px color-mix(in srgb, var(--inspect-accent) 15%, transparent); }
@@ -164,8 +164,8 @@
 .cw-maint .tracker-profile-control .cw-icon-select-caret { flex: 0 0 9px; width: 9px; opacity: .72; }
 .cw-maint .tracker-archive-check input { width: 17px; height: 17px; margin: 0; accent-color: var(--maint-accent); }
 .cxm-tracker-profile-menu .cw-icon-select-label { overflow: visible; text-overflow: clip; white-space: nowrap; }
-.cw-maint :is(.action-group.archive, .action-group.events, .action-group.captures) .group-icon, .cw-maint .action-row[data-op="tracker"] .action-icon { color: var(--maint-good); }
-.cw-maint :is(.action-group.archive, .action-group.events, .action-group.captures) { --group-accent: var(--maint-good); }
+.cw-maint :is(.action-group.archive, .action-group.events, .action-group.state-file, .action-group.captures) .group-icon, .cw-maint .action-row[data-op="tracker"] .action-icon, .cw-maint .action-row[data-op="state-file"] .action-icon { color: var(--maint-good); }
+.cw-maint :is(.action-group.archive, .action-group.events, .action-group.state-file, .action-group.captures) { --group-accent: var(--maint-good); }
 .cw-maint :is(.action-group.playback, .action-group.reports) .group-icon { color: var(--maint-accent); }
 .cw-maint .action-group.danger { --group-accent: var(--maint-danger); border-color: color-mix(in srgb, var(--maint-danger) 38%, var(--maint-border)); background: color-mix(in srgb, var(--maint-danger) 6%, var(--maint-panel)); }
 .cw-maint .action-group.danger .group-icon, .cw-maint .action-group.danger .group-title { color: var(--maint-danger); }

--- a/cw_platform/orchestrator/_pairs.py
+++ b/cw_platform/orchestrator/_pairs.py
@@ -556,10 +556,11 @@ def run_pairs(ctx) -> dict[str, Any]:
         wall["now"] = int(wall.get("now") or 0)
         wall["unresolved"] = int(unresolved_total)
 
-        st = ctx.state_store.load_state() or {}
-        st["wall"] = wall
-        st["last_sync_epoch"] = now
-        ctx.state_store.save_state(st)
+        if getattr(ctx, "write_state_json", True):
+            st = ctx.state_store.load_state() or {}
+            st["wall"] = wall
+            st["last_sync_epoch"] = now
+            ctx.state_store.save_state(st)
 
         emit("stats:overview", overview=wall)
         emit(

--- a/cw_platform/orchestrator/_pairs_metrics.py
+++ b/cw_platform/orchestrator/_pairs_metrics.py
@@ -133,6 +133,8 @@ class ApiMetrics:
             pass
 
 def persist_api_totals(ctx, totals: Mapping[str, Any], *, ts: int | None = None) -> None:
+    if not getattr(ctx, "write_state_json", True):
+        return
     try:
         st = ctx.state_store.load_state() or {}
         st.setdefault("metrics", {}).setdefault("api", {})

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -1862,109 +1862,110 @@ def run_one_way_feature(
              refreshed_count=len(refreshed or {}), first_keys=list(refreshed or {})[:10],
              contains_trace_key=contains_trace, baseline_update_count=base_update)
 
-    try:
-        st = ctx.state_store.load_state() or {}
-        provs_block = st.setdefault("providers", {})
+    if getattr(ctx, "write_state_json", True):
+        try:
+            st = ctx.state_store.load_state() or {}
+            provs_block = st.setdefault("providers", {})
 
-        def _ensure_pf(pmap, prov, inst, feat):
-            pprov = pmap.setdefault(prov, {})
-            if inst != "default":
-                insts = pprov.setdefault("instances", {})
-                pprov = insts.setdefault(inst, {})
-            return pprov.setdefault(feat, {"baseline": {"items": {}}, "checkpoint": None})
-
-        def _commit_baseline(pmap, prov, inst, feat, items):
-            pf = _ensure_pf(pmap, prov, inst, feat)
-            pkey = _PROVIDER_KEY_MAP.get(str(prov or "").upper(), str(prov or "").strip().lower())
-
-            kept: dict[str, Any] = {}
-            for k, v in (items or {}).items():
-                if not isinstance(v, Mapping):
-                    continue
-
-                if v.get("_cw_persist") is False or v.get("_cw_transient") is True or v.get("_cw_skip_persist") is True:
-                    continue
-
-                pobj = v.get(pkey)
-                if isinstance(pobj, Mapping) and pobj.get("ignored") is True:
-                    continue
-
-                mv = _minimal(v)
+            def _ensure_pf(pmap, prov, inst, feat):
+                pprov = pmap.setdefault(prov, {})
                 if inst != "default":
-                    mv["_cw_instance"] = inst
-                kept[str(k)] = mv
+                    insts = pprov.setdefault("instances", {})
+                    pprov = insts.setdefault(inst, {})
+                return pprov.setdefault(feat, {"baseline": {"items": {}}, "checkpoint": None})
 
-            pf["baseline"] = {"items": kept}
+            def _commit_baseline(pmap, prov, inst, feat, items):
+                pf = _ensure_pf(pmap, prov, inst, feat)
+                pkey = _PROVIDER_KEY_MAP.get(str(prov or "").upper(), str(prov or "").strip().lower())
 
-        def _merge_payload(base: Mapping[str, Any], extra: Mapping[str, Any]) -> dict[str, Any]:
-            out = dict(base or {})
-            for k, v in (extra or {}).items():
-                if k in ("ids", "show_ids"):
-                    continue
-                if out.get(k) in (None, "") and v not in (None, ""):
-                    out[k] = v
+                kept: dict[str, Any] = {}
+                for k, v in (items or {}).items():
+                    if not isinstance(v, Mapping):
+                        continue
 
-            for fld in ("ids", "show_ids"):
-                b = out.get(fld) if isinstance(out.get(fld), Mapping) else {}
-                e = extra.get(fld) if isinstance(extra.get(fld), Mapping) else {}
-                if b or e:
-                    merged: dict[str, Any] = dict(b or {})
-                    for kk, vv in (e or {}).items():
-                        if merged.get(kk) in (None, "") and vv not in (None, ""):
-                            merged[kk] = vv
-                    if merged:
-                        out[fld] = merged
+                    if v.get("_cw_persist") is False or v.get("_cw_transient") is True or v.get("_cw_skip_persist") is True:
+                        continue
 
-            if feature == "history":
-                a0 = out.get("watched_at")
-                b0 = extra.get("watched_at")
-                if isinstance(b0, str) and b0 and (not isinstance(a0, str) or not a0 or b0 > a0):
-                    out["watched_at"] = b0
-            elif feature == "ratings":
-                a0 = out.get("rated_at")
-                b0 = extra.get("rated_at")
-                if isinstance(b0, str) and b0 and (not isinstance(a0, str) or not a0 or b0 > a0):
-                    out["rated_at"] = b0
-            elif feature == "progress":
-                a0 = out.get("progress_at")
-                b0 = extra.get("progress_at")
-                if isinstance(b0, str) and b0 and (not isinstance(a0, str) or not a0 or b0 > a0):
-                    out["progress_at"] = b0
-            return out
+                    pobj = v.get(pkey)
+                    if isinstance(pobj, Mapping) and pobj.get("ignored") is True:
+                        continue
+
+                    mv = _minimal(v)
+                    if inst != "default":
+                        mv["_cw_instance"] = inst
+                    kept[str(k)] = mv
+
+                pf["baseline"] = {"items": kept}
+
+            def _merge_payload(base: Mapping[str, Any], extra: Mapping[str, Any]) -> dict[str, Any]:
+                out = dict(base or {})
+                for k, v in (extra or {}).items():
+                    if k in ("ids", "show_ids"):
+                        continue
+                    if out.get(k) in (None, "") and v not in (None, ""):
+                        out[k] = v
+
+                for fld in ("ids", "show_ids"):
+                    b = out.get(fld) if isinstance(out.get(fld), Mapping) else {}
+                    e = extra.get(fld) if isinstance(extra.get(fld), Mapping) else {}
+                    if b or e:
+                        merged: dict[str, Any] = dict(b or {})
+                        for kk, vv in (e or {}).items():
+                            if merged.get(kk) in (None, "") and vv not in (None, ""):
+                                merged[kk] = vv
+                        if merged:
+                            out[fld] = merged
+
+                if feature == "history":
+                    a0 = out.get("watched_at")
+                    b0 = extra.get("watched_at")
+                    if isinstance(b0, str) and b0 and (not isinstance(a0, str) or not a0 or b0 > a0):
+                        out["watched_at"] = b0
+                elif feature == "ratings":
+                    a0 = out.get("rated_at")
+                    b0 = extra.get("rated_at")
+                    if isinstance(b0, str) and b0 and (not isinstance(a0, str) or not a0 or b0 > a0):
+                        out["rated_at"] = b0
+                elif feature == "progress":
+                    a0 = out.get("progress_at")
+                    b0 = extra.get("progress_at")
+                    if isinstance(b0, str) and b0 and (not isinstance(a0, str) or not a0 or b0 > a0):
+                        out["progress_at"] = b0
+                return out
 
 
-        def _commit_checkpoint(pmap, prov, inst, feat, chk):
-            if not chk:
-                return
-            pf = _ensure_pf(pmap, prov, inst, feat)
-            pf["checkpoint"] = chk
+            def _commit_checkpoint(pmap, prov, inst, feat, chk):
+                if not chk:
+                    return
+                pf = _ensure_pf(pmap, prov, inst, feat)
+                pf["checkpoint"] = chk
 
-        def _rekey_state_to_src_keyspace(idx0: dict[str, Any], src_idx0: dict[str, Any]) -> dict[str, Any]:
-            return _rekey_index_to_match_other_keys(
-                idx0,
-                src_idx0,
-                typed_tokens=_typed_tokens,
-                merge_payload=_merge_payload,
-            )
+            def _rekey_state_to_src_keyspace(idx0: dict[str, Any], src_idx0: dict[str, Any]) -> dict[str, Any]:
+                return _rekey_index_to_match_other_keys(
+                    idx0,
+                    src_idx0,
+                    typed_tokens=_typed_tokens,
+                    merge_payload=_merge_payload,
+                )
 
-        if feature in ("ratings", "progress"):
-            dst_full = _rekey_state_to_src_keyspace(dst_full, src_idx)
+            if feature in ("ratings", "progress"):
+                dst_full = _rekey_state_to_src_keyspace(dst_full, src_idx)
 
-        dst_commit = dst_canonical if feature == "history" else dst_full
-        if feature == "history" and len(dst_commit) != len(dst_full):
-            dbg("baseline.provider_native", feature=feature, dst=dst,
-                canonical=len(dst_commit), comparison=len(dst_full))
+            dst_commit = dst_canonical if feature == "history" else dst_full
+            if feature == "history" and len(dst_commit) != len(dst_full):
+                dbg("baseline.provider_native", feature=feature, dst=dst,
+                    canonical=len(dst_commit), comparison=len(dst_full))
 
-        _commit_baseline(provs_block, src, src_inst, feature, src_idx)
-        _commit_baseline(provs_block, dst, dst_inst, feature, dst_commit)
-        _commit_checkpoint(provs_block, src, src_inst, feature, now_cp_src)
-        _commit_checkpoint(provs_block, dst, dst_inst, feature, now_cp_dst)
+            _commit_baseline(provs_block, src, src_inst, feature, src_idx)
+            _commit_baseline(provs_block, dst, dst_inst, feature, dst_commit)
+            _commit_checkpoint(provs_block, src, src_inst, feature, now_cp_src)
+            _commit_checkpoint(provs_block, dst, dst_inst, feature, now_cp_dst)
 
-        import time as _t
-        st["last_sync_epoch"] = int(_t.time())
-        ctx.state_store.save_state(st)
-    except Exception:
-        pass
+            import time as _t
+            st["last_sync_epoch"] = int(_t.time())
+            ctx.state_store.save_state(st)
+        except Exception:
+            pass
 
     emit("feature:done", src=src, dst=dst, feature=feature)
 

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -2175,6 +2175,9 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
     _post_apply_refresh(b, dst_inst, post_apply_B_res, bops, B_eff, b_down)
 
     try:
+        if not getattr(ctx, "write_state_json", True):
+            raise RuntimeError("legacy state persistence disabled")
+
         st = ctx.state_store.load_state() or {}
         provs_block = st.setdefault("providers", {})
 

--- a/cw_platform/orchestrator/_state_store.py
+++ b/cw_platform/orchestrator/_state_store.py
@@ -60,7 +60,11 @@ class StateStore:
         except Exception:
             pass
         tmp = p.with_suffix(p.suffix + ".tmp")
-        tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), "utf-8")
+        if p.name == "state.json":
+            text = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+        else:
+            text = json.dumps(data, ensure_ascii=False, indent=2)
+        tmp.write_text(text, "utf-8")
         tmp.replace(p)
 
 

--- a/cw_platform/orchestrator/facade.py
+++ b/cw_platform/orchestrator/facade.py
@@ -189,10 +189,11 @@ class Orchestrator:
             summary = _run_pairs(self.context)
 
 
-            try:
-                self._persist_state_wall(feature="watchlist")
-            except Exception:
-                pass
+            if self.write_state_json:
+                try:
+                    self._persist_state_wall(feature="watchlist")
+                except Exception:
+                    pass
 
             try:
                 self.state_store.clear_watchlist_hide()
@@ -213,7 +214,7 @@ class Orchestrator:
 
             try:
                 if hasattr(self.stats, "overview"):
-                    st = self.state_store.load_state()
+                    st = self.state_store.load_state() if self.write_state_json else {}
                     ov = self.stats.overview(st)
                     self.emit("stats:overview", overview=ov)
             except Exception:
@@ -395,6 +396,9 @@ class Orchestrator:
         import time as _t
         from typing import Mapping as _MappingType, Dict as _DictType
 
+        if not self.write_state_json:
+            return {}
+
         try:
             from ..id_map import minimal
         except Exception:
@@ -435,6 +439,9 @@ class Orchestrator:
 
     # Watchlist wall
     def _persist_state_wall(self, *, feature: str = "watchlist") -> dict[str, Any]:
+        if not self.write_state_json:
+            return {}
+
         state: dict[str, Any] = self.state_store.load_state() or {}
         providers = dict(state.get("providers") or {})
         wall: list[dict[str, Any]] = []

--- a/docker/run-sync.sh
+++ b/docker/run-sync.sh
@@ -8,11 +8,26 @@ export PYTHONPATH="${PYTHONPATH:-/app}"
 
 python - <<'PY'
 import sys, json, traceback
+from cw_platform.config_base import load_config
 from cw_platform.orchestrator import Orchestrator
 
+def coerce_bool(value, default=False):
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
 try:
-    orc = Orchestrator()
-    result = orc.run_pairs(write_state_json=True)
+    cfg = load_config() or {}
+    runtime_cfg = cfg.get("runtime") or {}
+    sync_cfg = cfg.get("sync") or {}
+    write_state_json = coerce_bool(
+        sync_cfg.get("write_state_json", runtime_cfg.get("write_state_json", True)),
+        True,
+    )
+    orc = Orchestrator(cfg)
+    result = orc.run_pairs(write_state_json=write_state_json)
     print(json.dumps(result, indent=2, ensure_ascii=False))
     sys.exit(int(result.get("exit_code", 0)) if isinstance(result, dict) else 0)
 except Exception as e:

--- a/tests/test_maintenance_api.py
+++ b/tests/test_maintenance_api.py
@@ -181,6 +181,100 @@ def test_state_action_status_counts_provider_feature_baselines(tmp_path, monkeyp
     assert metrics["State storage"] > 0
 
 
+def test_state_file_action_status_reports_largest_baseline(tmp_path, monkeypatch) -> None:
+    state_dir = tmp_path / ".cw_state"
+    state_dir.mkdir()
+    state = {
+        "providers": {
+            "TRAKT": {
+                "history": {"baseline": {"items": {"a": {}, "b": {}}}},
+            },
+            "SIMKL": {
+                "watchlist": {"baseline": {"items": {"c": {}}}},
+            },
+        }
+    }
+    (tmp_path / "state.json").write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+    monkeypatch.setattr(
+        maintenanceAPI,
+        "_cw",
+        lambda: (
+            tmp_path / "cache",
+            tmp_path,
+            state_dir,
+            SimpleNamespace(path=tmp_path / "statistics.json"),
+            None,
+            None,
+        ),
+    )
+
+    result = maintenanceAPI.maintenance_action_status("state-file")
+    metrics = {item["label"]: item["value"] for item in result["metrics"]}
+
+    assert result["ok"] is True
+    assert metrics["Providers"] == 2
+    assert metrics["Feature baselines"] == 2
+    assert metrics["Baseline items"] == 3
+    assert metrics["Largest baseline"] == "TRAKT history"
+
+
+def test_compact_state_file_creates_backup_and_rewrites_json(tmp_path, monkeypatch) -> None:
+    state_dir = tmp_path / ".cw_state"
+    state_dir.mkdir()
+    payload = {"providers": {"TRAKT": {"watchlist": {"baseline": {"items": {"a": {"title": "A"}}}}}}}
+    state_path = tmp_path / "state.json"
+    state_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    before = state_path.stat().st_size
+    backups: list[dict] = []
+
+    def fake_backup(**kwargs):
+        backups.append(kwargs)
+        return {"ok": True, "path": "2026/pre-state-compact.zip"}
+
+    import services.backups as backups_svc
+
+    monkeypatch.setattr(backups_svc, "create_backup", fake_backup)
+    monkeypatch.setattr(
+        maintenanceAPI,
+        "_cw",
+        lambda: (tmp_path / "cache", tmp_path, state_dir, None, None, None),
+    )
+
+    result = maintenanceAPI.compact_state_file()
+
+    assert result["ok"] is True
+    assert result["backup"]["path"] == "2026/pre-state-compact.zip"
+    assert backups and backups[0]["scope"] == "app_state"
+    assert backups[0]["trigger"] == "maintenance_state_compact"
+    assert state_path.stat().st_size < before
+    assert "\n" not in state_path.read_text(encoding="utf-8")
+    assert json.loads(state_path.read_text(encoding="utf-8")) == payload
+
+
+def test_compact_state_file_rejects_invalid_json_without_backup(tmp_path, monkeypatch) -> None:
+    state_dir = tmp_path / ".cw_state"
+    state_dir.mkdir()
+    (tmp_path / "state.json").write_text("{not valid", encoding="utf-8")
+
+    def fail_backup(**_kwargs):
+        raise AssertionError("backup should not be created for invalid JSON")
+
+    import services.backups as backups_svc
+
+    monkeypatch.setattr(backups_svc, "create_backup", fail_backup)
+    monkeypatch.setattr(
+        maintenanceAPI,
+        "_cw",
+        lambda: (tmp_path / "cache", tmp_path, state_dir, None, None, None),
+    )
+
+    result = maintenanceAPI.compact_state_file()
+
+    assert result["ok"] is False
+    assert result["error"] == "state_json_invalid"
+
+
 def test_clear_provider_cache_preserves_pair_scoped_history_mapping_state(tmp_path, monkeypatch) -> None:
     state_dir = tmp_path / ".cw_state"
     state_dir.mkdir()


### PR DESCRIPTION
# Pull request

## Change

- Compact future state.json writes.
- Add a Maintenance action to inspect/compact the legacy state file with a backup first.
- Add a config switch to reduce legacy state.json persistence.

## Why

Large state.json files can slow down the UI and state-backed API paths for some users.

## Testing

- test_maintenance_api.py`

## Issue

Fixed #626