### PR TITLE
Add: scheduler webhook callbacks

### DIFF
--- a/api/schedulingAPI.py
+++ b/api/schedulingAPI.py
@@ -70,6 +70,154 @@ def _env() -> tuple[
         return _load_cfg, _save_cfg, _DummyScheduler(), {}, _compute_next_run_from_cfg, _ui_host_logger
 
 
+def _clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        text = _clean_text(item)
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+    return out
+
+
+def _pair_maps(cfg: dict[str, Any]) -> tuple[set[str], set[str]]:
+    known: set[str] = set()
+    enabled: set[str] = set()
+    for pair in _as_list(cfg.get("pairs")):
+        if not isinstance(pair, dict):
+            continue
+        pair_id = _clean_text(pair.get("id") or pair.get("pair_id") or pair.get("name") or pair.get("label"))
+        if not pair_id:
+            continue
+        known.add(pair_id)
+        if pair.get("enabled", True) is not False:
+            enabled.add(pair_id)
+    return known, enabled
+
+
+def _blank_adv_job(job: dict[str, Any]) -> bool:
+    days = _as_list(job.get("days"))
+    return (
+        not _clean_text(job.get("pair_id"))
+        and not _clean_text(job.get("at"))
+        and not _clean_text(job.get("after"))
+        and not days
+    )
+
+
+def _blank_workflow(workflow: dict[str, Any]) -> bool:
+    return not any(_clean_text(step.get("pair_id")) for step in _as_list(workflow.get("steps")) if isinstance(step, dict))
+
+
+def _scrobble_event_route_ids(cfg: dict[str, Any]) -> dict[str, set[str]]:
+    out: dict[str, set[str]] = {"watcher": set(), "webhook": set()}
+    try:
+        from providers.scrobble.routes import normalize_routes
+        from providers.scrobble.sources import scrobble_sources
+
+        sc = _as_dict(cfg.get("scrobble"))
+        sources = scrobble_sources(sc)
+        if sources.get("watcher"):
+            for route in normalize_routes(cfg):
+                if not isinstance(route, dict) or route.get("enabled") is False:
+                    continue
+                route_id = _clean_text(route.get("id"))
+                provider = _clean_text(route.get("provider"))
+                sink = _clean_text(route.get("sink"))
+                if route_id and provider and sink:
+                    out["watcher"].add(route_id)
+        if sources.get("webhook"):
+            out["webhook"].update({"plex", "jellyfin", "emby"})
+    except Exception:
+        pass
+    return out
+
+
+def _scheduling_warning_summary(cfg: dict[str, Any]) -> dict[str, Any]:
+    scfg = _as_dict(cfg.get("scheduling"))
+    adv = _as_dict(scfg.get("advanced"))
+    warnings: list[str] = []
+
+    if bool(scfg.get("enabled")) and not bool(adv.get("enabled")):
+        mode = _clean_text(scfg.get("mode")).lower()
+        if mode in {"custom", "custom_interval"}:
+            try:
+                minutes = max(15, int(scfg.get("custom_interval_minutes") or 60))
+            except Exception:
+                minutes = 60
+            if minutes < 60:
+                warnings.append(
+                    "Standard schedule: Custom schedules shorter than 1 hour can be seen as abusing trackers API's and may result in a ban. Use them carefully."
+                )
+
+    if not bool(adv.get("enabled")):
+        return {"warning": bool(warnings), "warnings": _dedupe(warnings)}
+
+    _, enabled_pairs = _pair_maps(cfg)
+    jobs = _as_list(adv.get("jobs"))
+    workflows = _as_list(adv.get("workflows"))
+    event_rules = _as_list(adv.get("event_rules") or adv.get("eventRules"))
+
+    timed_pair_issue = False
+    for job in jobs:
+        if not isinstance(job, dict) or job.get("active", True) is False or _blank_adv_job(job):
+            continue
+        pair_id = _clean_text(job.get("pair_id"))
+        if pair_id and pair_id not in enabled_pairs:
+            timed_pair_issue = True
+    if timed_pair_issue:
+        warnings.append("Timed steps: Update the disabled or missing sync pair used by one or more timed steps.")
+
+    workflow_pair_issue = False
+    for workflow in workflows:
+        if not isinstance(workflow, dict) or workflow.get("active", True) is False or _blank_workflow(workflow):
+            continue
+        steps = [step for step in _as_list(workflow.get("steps")) if isinstance(step, dict) and step.get("active", True) is not False]
+        active_pair_steps = [step for step in steps if _clean_text(step.get("pair_id"))]
+        if any(_clean_text(step.get("pair_id")) not in enabled_pairs for step in active_pair_steps):
+            workflow_pair_issue = True
+    if workflow_pair_issue:
+        warnings.append("Recurring workflows: Update the disabled or missing sync pair used by one or more recurring workflows.")
+
+    route_ids = _scrobble_event_route_ids(cfg)
+    event_pair_issue = False
+    event_bad_route = False
+    for rule in event_rules:
+        if not isinstance(rule, dict) or rule.get("active", True) is False:
+            continue
+        filters = _as_dict(rule.get("filters"))
+        action = _as_dict(rule.get("action"))
+        pair_id = _clean_text(action.get("pair_id") or action.get("pairId") or rule.get("pair_id"))
+        route_id = _clean_text(filters.get("route_id") or filters.get("routeId"))
+        if not pair_id and not route_id:
+            continue
+        source = _clean_text(rule.get("source")).lower()
+        if route_id and source in route_ids and route_ids[source] and route_id not in route_ids[source]:
+            event_bad_route = True
+        if pair_id and pair_id not in enabled_pairs:
+            event_pair_issue = True
+    if event_bad_route:
+        warnings.append("Event triggers: Choose a valid watcher or webhook route for one or more event triggers.")
+    if event_pair_issue:
+        warnings.append("Event triggers: Update the disabled or missing sync pair used by one or more event triggers.")
+
+    return {"warning": bool(warnings), "warnings": _dedupe(warnings)}
+
+
 @router.post("/replan_now")
 def replan_now() -> dict[str, Any]:
     load_config, _, scheduler, hint, compute_next, log = _env()
@@ -231,6 +379,9 @@ def sched_status() -> dict[str, Any]:
         hint_val = int((hint.get("next_run_at") or 0)) if isinstance(hint, dict) else 0
         if not live and hint_val:
             st["next_run_at"] = hint_val
+        warning_summary = _scheduling_warning_summary(cfg)
+        st["scheduling_warnings"] = warning_summary["warnings"]
+        st["warning"] = bool(warning_summary["warning"])
     except Exception:
         pass
 

--- a/assets/js/scheduler.js
+++ b/assets/js/scheduler.js
@@ -29,21 +29,24 @@
   document.head.appendChild(Object.assign(el("style"), { id: "sch-css", textContent: `
 #sec-scheduling{--sch-shell-bg:#171a22;--sch-card-bg:#20242d;--sch-card-bg-soft:#242936;--sch-input-bg:#252b36;--sch-input-bg-hover:#2a303d;--sch-border:rgba(255,255,255,.14);--sch-border-soft:rgba(255,255,255,.12);--sch-shadow:none;--sch-fg:#f3f7ff;--sch-fg-soft:rgba(215,222,235,.76)}
 #sec-scheduling .cw-subpanel[data-sub]{padding-top:6px}
-#sec-scheduling .cw-subpanel[data-sub="basic"] .auth-card,#schAdv{position:relative;border:1px solid var(--sch-border);border-radius:22px;background:var(--sch-shell-bg);box-shadow:var(--sch-shadow);overflow:hidden}
-#sec-scheduling .cw-subpanel[data-sub="basic"] .auth-card::before,#schAdv::before{content:none;display:none}
+#sec-scheduling .cw-subpanel[data-sub="basic"] .auth-card,#schAdv,#schWebhooks{position:relative;border:1px solid var(--sch-border);border-radius:22px;background:var(--sch-shell-bg);box-shadow:var(--sch-shadow);overflow:hidden}
+#sec-scheduling .cw-subpanel[data-sub="basic"] .auth-card::before,#schAdv::before,#schWebhooks::before{content:none;display:none}
 #sec-scheduling .cw-subpanel[data-sub="basic"] .auth-card-fields{position:relative;z-index:1;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;padding:16px}
 #sec-scheduling .cw-subpanel[data-sub="basic"] .field{display:grid;gap:8px;padding:14px 16px;border:1px solid var(--sch-border-soft);border-radius:14px;background:var(--sch-card-bg);box-shadow:none}
 #sec-scheduling .cw-subpanel[data-sub="basic"] .field:first-child{grid-column:1 / -1}
 #sec-scheduling .cw-subpanel[data-sub="basic"] .field>.muted{margin:0!important;font-size:11px;font-weight:800;letter-spacing:.14em;text-transform:uppercase;color:rgba(214,223,238,.58)}
-#sec-scheduling .cw-subpanel[data-sub="basic"] .field>.muted .th-help{display:inline-flex;align-items:center;gap:8px}
-#sec-scheduling .cw-subpanel[data-sub="basic"] .sch-help{position:relative;display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:999px;border:1px solid rgba(255,255,255,.16);background:#2b313d;color:#edf4ff;cursor:help;box-shadow:none}
-#sec-scheduling .cw-subpanel[data-sub="basic"] .sch-help::before{content:"help";font-family:"Material Symbols Rounded","Material Symbols Outlined","Segoe UI Symbol",sans-serif;font-size:18px;line-height:1}
+#sec-scheduling .cw-subpanel[data-sub="basic"] .field>.muted .th-help{display:inline-flex;align-items:center;gap:8px;line-height:1.15;vertical-align:middle}
+#sec-scheduling .cw-subpanel[data-sub="basic"] .sch-help{position:relative;display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;min-width:30px;padding:0;border-radius:999px;border:1px solid rgba(255,255,255,.16);background:#2b313d;color:#edf4ff;cursor:help;box-shadow:none;vertical-align:middle}
+#sec-scheduling .cw-subpanel[data-sub="basic"] .sch-help::before{content:"help";font-family:"Material Symbols Rounded","Material Symbols Outlined","Segoe UI Symbol",sans-serif;font-size:22px;line-height:1}
 #sec-scheduling .cw-subpanel[data-sub="basic"] .sch-help:focus-visible{outline:none;box-shadow:0 0 0 3px rgba(125,134,201,.16)}
 #sec-scheduling .cw-subpanel[data-sub="basic"] .auth-card-notes{margin-top:0;color:var(--sch-fg-soft);font-size:12px;line-height:1.45}
-#sec-scheduling .cw-subpanel[data-sub="basic"] select,#sec-scheduling .cw-subpanel[data-sub="basic"] input[type=time],#sec-scheduling .cw-subpanel[data-sub="basic"] input[type=number],.sch-adv select,.sch-adv input[type=time],.sch-adv input[type=number],.sch-adv input[type=text]{width:100%;min-height:46px;padding:0 14px;border:1px solid rgba(136,151,190,.22);border-radius:12px;background:var(--sch-input-bg);color:var(--sch-fg);box-shadow:inset 0 1px 0 rgba(255,255,255,.035);transition:border-color .14s ease,background .14s ease,box-shadow .14s ease}
-#sec-scheduling .cw-subpanel[data-sub="basic"] select:hover,#sec-scheduling .cw-subpanel[data-sub="basic"] input[type=time]:hover,#sec-scheduling .cw-subpanel[data-sub="basic"] input[type=number]:hover,.sch-adv select:hover,.sch-adv input[type=time]:hover,.sch-adv input[type=number]:hover,.sch-adv input[type=text]:hover{border-color:rgba(160,176,220,.30);background:var(--sch-input-bg-hover)}
-#sec-scheduling .cw-subpanel[data-sub="basic"] select:focus,#sec-scheduling .cw-subpanel[data-sub="basic"] input[type=time]:focus,#sec-scheduling .cw-subpanel[data-sub="basic"] input[type=number]:focus,.sch-adv select:focus,.sch-adv input[type=time]:focus,.sch-adv input[type=number]:focus,.sch-adv input[type=text]:focus{outline:none;border-color:rgba(125,134,201,.52);box-shadow:0 0 0 3px rgba(125,134,201,.16)}
+#sec-scheduling .cw-subpanel[data-sub="basic"] select,#sec-scheduling .cw-subpanel[data-sub="basic"] input[type=time],#sec-scheduling .cw-subpanel[data-sub="basic"] input[type=number],.sch-adv select,.sch-adv input[type=time],.sch-adv input[type=number],.sch-adv input[type=text],.sch-adv input[type=url]{width:100%;min-height:46px;padding:0 14px;border:1px solid rgba(136,151,190,.22);border-radius:12px;background:var(--sch-input-bg);color:var(--sch-fg);box-shadow:inset 0 1px 0 rgba(255,255,255,.035);transition:border-color .14s ease,background .14s ease,box-shadow .14s ease}
+#sec-scheduling .cw-subpanel[data-sub="basic"] select:hover,#sec-scheduling .cw-subpanel[data-sub="basic"] input[type=time]:hover,#sec-scheduling .cw-subpanel[data-sub="basic"] input[type=number]:hover,.sch-adv select:hover,.sch-adv input[type=time]:hover,.sch-adv input[type=number]:hover,.sch-adv input[type=text]:hover,.sch-adv input[type=url]:hover{border-color:rgba(160,176,220,.30);background:var(--sch-input-bg-hover)}
+#sec-scheduling .cw-subpanel[data-sub="basic"] select:focus,#sec-scheduling .cw-subpanel[data-sub="basic"] input[type=time]:focus,#sec-scheduling .cw-subpanel[data-sub="basic"] input[type=number]:focus,.sch-adv select:focus,.sch-adv input[type=time]:focus,.sch-adv input[type=number]:focus,.sch-adv input[type=text]:focus,.sch-adv input[type=url]:focus{outline:none;border-color:rgba(125,134,201,.52);box-shadow:0 0 0 3px rgba(125,134,201,.16)}
 .sch-adv{padding:16px}
+.sch-webhooks{margin-top:14px}
+.sch-webhooks [data-webhook-format-for]{display:none!important}
+.sch-webhooks[data-payload-format="crosswatch"] [data-webhook-format-for~="crosswatch"],.sch-webhooks[data-payload-format="notifiarr"] [data-webhook-format-for~="notifiarr"]{display:grid!important}
 .sch-adv .cw-panel-head{position:relative;z-index:1;display:flex;align-items:center;min-height:104px;margin:0 0 14px;padding:14px 16px;border:none;border-radius:0;background:transparent;box-shadow:none}
 .sch-adv .cw-panel-head .cx-toggle{margin-top:20px}
 .sch-adv .mini,.sch-adv .status{position:relative;z-index:1}
@@ -58,9 +61,9 @@
 .sch-adv-section-copy.sch-workflow-intro{max-width:none;white-space:nowrap}
 .sch-adv table{position:relative;z-index:1;width:100%;border-collapse:separate;border-spacing:0 10px;margin-top:0;table-layout:fixed}
 .sch-adv thead th{padding:0 10px 6px;text-align:left;font-size:11px;font-weight:800;letter-spacing:.12em;text-transform:uppercase;color:rgba(214,223,238,.56);border-bottom:none}
-.sch-adv .th-help{display:inline-flex;align-items:center;gap:8px}
-.sch-adv .sch-help{position:relative;display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:999px;border:1px solid rgba(255,255,255,.16);background:#2b313d;color:#edf4ff;cursor:help;box-shadow:none}
-.sch-adv .sch-help::before{content:"help";font-family:"Material Symbols Rounded","Material Symbols Outlined","Segoe UI Symbol",sans-serif;font-size:18px;line-height:1}
+.sch-adv .th-help{display:inline-flex;align-items:center;gap:8px;line-height:1.15;vertical-align:middle}
+.sch-adv .sch-help{position:relative;display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;min-width:30px;padding:0;border-radius:999px;border:1px solid rgba(255,255,255,.16);background:#2b313d;color:#edf4ff;cursor:help;box-shadow:none;vertical-align:middle}
+.sch-adv .sch-help::before{content:"help";font-family:"Material Symbols Rounded","Material Symbols Outlined","Segoe UI Symbol",sans-serif;font-size:22px;line-height:1}
 .sch-adv .sch-help:focus-visible{outline:none;box-shadow:0 0 0 3px rgba(125,134,201,.16)}
 .sch-adv tbody tr{background:var(--sch-card-bg);box-shadow:none}
 .sch-adv tbody td{position:relative;overflow:visible;padding:12px 10px;vertical-align:middle;border-top:1px solid var(--sch-border-soft);border-bottom:1px solid var(--sch-border-soft)}
@@ -90,7 +93,8 @@
 .sch-adv .stack{display:grid;gap:8px}
 .sch-adv .stack.two{grid-template-columns:repeat(2,minmax(0,1fr))}
 .sch-adv .stack.three{grid-template-columns:repeat(3,minmax(0,1fr))}
-.sch-adv .subnote{font-size:10px;font-weight:800;letter-spacing:.1em;text-transform:uppercase;color:rgba(214,223,238,.5)}
+.sch-adv .subnote{font-size:10px;font-weight:800;letter-spacing:.1em;line-height:1.15;text-transform:uppercase;color:rgba(214,223,238,.5)}
+.sch-adv .field-mini .subnote{display:flex;align-items:center;min-height:30px}
 .sch-adv .field-mini{display:grid;gap:6px;min-width:0}
 .sch-adv .capture-provider-stack{grid-template-columns:minmax(190px,1.4fr) minmax(150px,1fr)}
 .sch-adv td[data-label="Feature"]{min-width:150px}
@@ -192,7 +196,8 @@ html[data-cw-theme="flat-light"] .sch-adv .chipdays label:has(input:checked){
   document.head.appendChild(Object.assign(el("style"), { id: "sch-css-refine", textContent: `
 #sec-scheduling .cw-subpanel[data-sub="basic"] .auth-card{display:grid;gap:10px;padding:0!important}
 #sec-scheduling #sched-provider-panel,#sec-scheduling #sched-provider-panel .cw-subpanels,#sec-scheduling #sched-provider-panel .cw-subpanel.active{width:100%;box-sizing:border-box}
-#sec-scheduling .cw-subpanel[data-sub="basic"] .auth-card,#sec-scheduling #schAdv{width:100%;max-width:none;margin:0!important;box-sizing:border-box}
+#sec-scheduling .cw-subpanel[data-sub="basic"] .auth-card,#sec-scheduling #schAdv,#sec-scheduling #schWebhooks{width:100%;max-width:none;margin:0!important;box-sizing:border-box}
+#sec-scheduling #schWebhooks{margin-top:14px!important}
 #sec-scheduling .sch-std-head{position:relative;z-index:1;display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:end;gap:16px;padding:18px 18px 8px!important}
 #sec-scheduling .sch-std-head-copy{display:grid;gap:6px}
 #sec-scheduling .sch-card-head{display:flex;align-items:flex-start;gap:14px;min-width:0}
@@ -254,7 +259,7 @@ html[data-cw-theme="flat-light"] .sch-adv .chipdays label:has(input:checked){
 .sch-adv tbody td{padding:10px 8px}
 .sch-adv tbody td:first-child{border-radius:16px 0 0 16px}
 .sch-adv tbody td:last-child{border-radius:0 16px 16px 0}
-.sch-adv select,.sch-adv input[type=time],.sch-adv input[type=number],.sch-adv input[type=text]{min-height:42px;padding:0 12px;border-radius:14px}
+.sch-adv select,.sch-adv input[type=time],.sch-adv input[type=number],.sch-adv input[type=text],.sch-adv input[type=url]{min-height:42px;padding:0 12px;border-radius:14px}
 .sch-adv .stack{gap:7px}
 .sch-adv .stack.two{grid-template-columns:minmax(0,1fr) minmax(118px,.92fr)}
 .sch-adv .stack.three{grid-template-columns:repeat(3,minmax(0,1fr))}
@@ -275,6 +280,17 @@ html[data-cw-theme="flat-light"] #sec-scheduling .sch-card-icon{background:#eef2
 
   // state
   let _pairs = [], _jobs = [], _workflows = [], _captureJobs = [], _eventRules = [], _advEnabled = false, _loading = false;
+  let _webhooks = {
+    enabled: false,
+    url: "",
+    base_url: "",
+    start_url: "",
+    success_url: "",
+    failure_url: "",
+    payload_format: "crosswatch",
+    notifiarr_channel_id: "",
+    timeout_seconds: 10
+  };
   let _captureProviders = [];
   let _eventRoutes = { watcher: [], webhook: [] }, _eventRouteError = "";
   const DAY = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"];
@@ -303,7 +319,16 @@ html[data-cw-theme="flat-light"] #sec-scheduling .sch-card-icon{background:#eef2
     event: "Event:\nChoose which playback activity should trigger the rule.\nStart: playback begins or resumes.\nPause: playback is paused.\nStop: playback ends or stops.",
     filters: "Filters:\nMedia: only movies or episodes.\nMin %: require minimum playback progress.",
     action: "Action:\nChoose what happens when the rule matches.\nSync pair:\nRun one specific enabled sync pair immediately.",
-    guardrails: "Mute (min):\nIgnore new triggers for this rule after it runs.\nDedupe (sec):\nSuppress identical repeated events for a short window.\nMax / hour:\nHard safety cap for this rule in one hour."
+    guardrails: "Mute (min):\nIgnore new triggers for this rule after it runs.\nDedupe (sec):\nSuppress identical repeated events for a short window.\nMax / hour:\nHard safety cap for this rule in one hour.",
+    webhook_url: "All events URL:\nOptional http:// or https:// POST destination used for start, success, and failure events.\nUse this for services with one endpoint, including Notifiarr Passthrough.",
+    webhook_notifiarr_url: "Notifiarr passthrough URL:\nPaste the Notifiarr Passthrough endpoint.\nCrossWatch sends start, success, and failure notifications to this same URL.",
+    webhook_format: "Payload format:\nCrossWatch JSON sends the raw scheduler payload.\nNotifiarr Passthrough sends the notification/discord JSON shape expected by Notifiarr.",
+    webhook_base: "Compatible base URL:\nOptional http:// or https:// base ping URL for services that use suffixes.\nStart uses /start, success uses the base URL, and failure uses /fail.",
+    webhook_notifiarr_channel: "Notifiarr channel ID:\nOptional Discord channel id for Notifiarr Passthrough payloads.\nIf your Notifiarr setup requires a channel, enter the numeric Discord channel id here.",
+    webhook_timeout: "Timeout seconds:\nHow long CrossWatch waits for a callback request before logging it as failed.\nCallback failures do not fail the sync.",
+    webhook_start: "Start callback URL:\nOptional explicit http:// or https:// POST destination when a scheduled sync starts.\nThis overrides the compatible base URL for start events.",
+    webhook_success: "Success callback URL:\nOptional explicit http:// or https:// POST destination when a scheduled sync finishes successfully.\nThis overrides the compatible base URL for success events.",
+    webhook_failure: "Failure callback URL:\nOptional explicit http:// or https:// POST destination when a scheduled sync fails.\nThis overrides the compatible base URL for failure events."
   };
   const defaultJob = () => ({ id: genId(), pair_id: null, at: null, days: [], after: null, active: true });
   const defaultWorkflowStep = () => ({ id: genId(), pair_id: null, active: true });
@@ -351,6 +376,27 @@ html[data-cw-theme="flat-light"] #sec-scheduling .sch-card-icon{background:#eef2
     },
     active: true
   });
+  const normalizeWebhooks = (raw = {}) => ({
+    enabled: raw.enabled === true,
+    url: String(raw.url || raw.default_url || raw.defaultUrl || "").trim(),
+    base_url: String(raw.base_url || raw.baseUrl || raw.healthchecks_base_url || raw.healthchecksBaseUrl || "").trim(),
+    start_url: String(raw.start_url || raw.startUrl || "").trim(),
+    success_url: String(raw.success_url || raw.successUrl || "").trim(),
+    failure_url: String(raw.failure_url || raw.failureUrl || "").trim(),
+    payload_format: ["notifiarr", "notifiarr_passthrough"].includes(String(raw.payload_format || raw.payloadFormat || raw.format || "").trim().toLowerCase().replace("-", "_")) ? "notifiarr" : "crosswatch",
+    notifiarr_channel_id: String(raw.notifiarr_channel_id || raw.notifiarrChannelId || "").trim(),
+    timeout_seconds: Math.max(1, Math.min(60, parseInt(raw.timeout_seconds || raw.timeoutSeconds || 10, 10) || 10))
+  });
+  const isHttpUrl = (value) => {
+    const text = String(value || "").trim();
+    if (!text) return true;
+    try {
+      const url = new URL(text);
+      return url.protocol === "http:" || url.protocol === "https:";
+    } catch {
+      return false;
+    }
+  };
   const setBooleanSelect = (sel, v) => {
     if (!sel) return;
     const want = v ? "true" : "false";
@@ -928,6 +974,93 @@ const ensureStdEnabledToggle = () => {
     wrap.appendChild(btn);
     head.appendChild(wrap);
     return stackWrap("field-mini", head, control);
+  };
+  const syncWebhooksFromFields = () => {
+    _webhooks = normalizeWebhooks({
+      enabled: !!$("#schWebhookEnabled")?.checked,
+      url: $("#schWebhookUrl")?.value || "",
+      base_url: $("#schWebhookBase")?.value || "",
+      start_url: $("#schWebhookStart")?.value || "",
+      success_url: $("#schWebhookSuccess")?.value || "",
+      failure_url: $("#schWebhookFailure")?.value || "",
+      payload_format: $("#schWebhookFormat")?.value || "crosswatch",
+      notifiarr_channel_id: $("#schWebhookNotifiarrChannel")?.value || "",
+      timeout_seconds: $("#schWebhookTimeout")?.value || 10
+    });
+    applyWebhookVisibility();
+  };
+  const webhookFormat = () => _webhooks.payload_format === "notifiarr" ? "notifiarr" : "crosswatch";
+  const applyWebhookVisibility = () => {
+    const root = $("#schWebhooks");
+    if (!root) return;
+    const format = webhookFormat();
+    root.dataset.payloadFormat = format;
+    const urlLabel = $("#schWebhookUrlLabel", root);
+    const urlHelp = $("#schWebhookUrlHelp", root);
+    const urlInput = $("#schWebhookUrl", root);
+    if (urlLabel) urlLabel.textContent = format === "notifiarr" ? "Notifiarr passthrough URL" : "All events URL";
+    if (urlHelp) {
+      urlHelp.setAttribute("aria-label", `${urlLabel?.textContent || "All events URL"} help`);
+      urlHelp.dataset.helpKey = format === "notifiarr" ? "webhook_notifiarr_url" : "webhook_url";
+      urlHelp.title = HELP_TIPS[urlHelp.dataset.helpKey] || "";
+    }
+    if (urlInput) {
+      urlInput.placeholder = format === "notifiarr"
+        ? "https://notifiarr.com/api/v1/notification/passthrough/YOUR_API_KEY"
+        : "https://hooks.example.com/crosswatch";
+    }
+    root.querySelectorAll("[data-webhook-format-for] input,[data-webhook-format-for] select").forEach((node) => {
+      const holder = node.closest("[data-webhook-format-for]");
+      const formats = String(holder?.dataset?.webhookFormatFor || "").split(/\s+/).filter(Boolean);
+      node.disabled = formats.length > 0 && !formats.includes(format);
+    });
+  };
+  const renderWebhooks = () => {
+    const enabled = $("#schWebhookEnabled");
+    const url = $("#schWebhookUrl");
+    const base = $("#schWebhookBase");
+    const start = $("#schWebhookStart");
+    const success = $("#schWebhookSuccess");
+    const failure = $("#schWebhookFailure");
+    const format = $("#schWebhookFormat");
+    const notifiarrChannel = $("#schWebhookNotifiarrChannel");
+    const timeout = $("#schWebhookTimeout");
+    if (!enabled || !url || !base || !start || !success || !failure || !format || !notifiarrChannel || !timeout) return;
+    enabled.checked = !!_webhooks.enabled;
+    url.value = _webhooks.url || "";
+    base.value = _webhooks.base_url || "";
+    start.value = _webhooks.start_url || "";
+    success.value = _webhooks.success_url || "";
+    failure.value = _webhooks.failure_url || "";
+    format.value = _webhooks.payload_format || "crosswatch";
+    notifiarrChannel.value = _webhooks.notifiarr_channel_id || "";
+    timeout.value = String(_webhooks.timeout_seconds || 10);
+    applyWebhookVisibility();
+  };
+  const webhooksValidation = () => {
+    syncWebhooksFromFields();
+    const entries = webhookFormat() === "notifiarr" ? [
+      ["Notifiarr passthrough URL", _webhooks.url]
+    ] : [
+      ["All events URL", _webhooks.url],
+      ["Compatible base URL", _webhooks.base_url],
+      ["Start callback URL", _webhooks.start_url],
+      ["Success callback URL", _webhooks.success_url],
+      ["Failure callback URL", _webhooks.failure_url]
+    ];
+    const issues = [];
+    entries.forEach(([label, value]) => {
+      if (value && !isHttpUrl(value)) issues.push(`${label}: use an http:// or https:// URL.`);
+    });
+    if (webhookFormat() === "notifiarr" && _webhooks.notifiarr_channel_id && !/^\d+$/.test(_webhooks.notifiarr_channel_id)) {
+      issues.push("Notifiarr channel ID: use the numeric Discord channel id.");
+    }
+    if (_webhooks.enabled && !entries.some(([, value]) => String(value || "").trim())) {
+      issues.push(webhookFormat() === "notifiarr"
+        ? "Scheduler Webhooks: add the Notifiarr passthrough URL or turn webhooks off."
+        : "Scheduler Webhooks: add at least one callback URL or turn webhooks off.");
+    }
+    return issues;
   };
   const alignedField = (control) => stackWrap("field-mini control-align", Object.assign(el("div", "subnote"), { textContent: "Label" }), control);
   const guardInput = ({ id, value, placeholder, title, onChange }) => {
@@ -1863,17 +1996,62 @@ const ensureStdEnabledToggle = () => {
 
 `;
     host.appendChild(adv);
-    adv.querySelectorAll(".sch-help").forEach((btn) => {
-      const tip = HELP_TIPS[btn.dataset.helpKey] || "";
-      if (tip) {
-        btn.title = tip;
-      } else {
-        btn.removeAttribute("title");
-      }
-      btn.onclick = (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-      };
+    const hooks = Object.assign(el("div", "sch-adv sch-webhooks"), { id: "schWebhooks" });
+    hooks.dataset.payloadFormat = "crosswatch";
+    hooks.innerHTML = `
+<div class="cw-panel-head">
+  <div class="sch-adv-head-copy sch-card-head">
+    <span class="material-symbols-rounded sch-card-icon" aria-hidden="true">monitor_heart</span>
+    <div class="sch-card-head-copy">
+      <div class="sch-adv-head-title">Scheduler Webhooks</div>
+      <p>Send outbound POST callbacks when scheduled syncs start, succeed, or fail.</p>
+    </div>
+  </div>
+  <label class="cx-toggle">
+    <input type="checkbox" id="schWebhookEnabled">
+    <span class="cx-toggle-ui" aria-hidden="true"></span>
+    <span class="cx-toggle-text">Enable webhooks</span>
+    <span class="cx-toggle-state" aria-hidden="true"></span>
+  </label>
+</div>
+<section class="sch-adv-section">
+  <div class="stack two">
+    <label class="field-mini"><div class="subnote"><span class="th-help"><span id="schWebhookUrlLabel">All events URL</span><button id="schWebhookUrlHelp" type="button" class="sch-help" aria-label="All events URL help" data-help-key="webhook_url"></button></span></div><input id="schWebhookUrl" name="schWebhookUrl" type="url" inputmode="url" pattern="https?://.+" autocomplete="off" placeholder="https://hooks.example.com/crosswatch"></label>
+    <label class="field-mini"><div class="subnote"><span class="th-help">Payload format<button type="button" class="sch-help" aria-label="Payload format help" data-help-key="webhook_format"></button></span></div><select id="schWebhookFormat" name="schWebhookFormat"><option value="crosswatch">CrossWatch JSON</option><option value="notifiarr">Notifiarr Passthrough</option></select></label>
+  </div>
+  <div class="stack two">
+    <label class="field-mini" data-webhook-format-for="crosswatch"><div class="subnote"><span class="th-help">Compatible base URL<button type="button" class="sch-help" aria-label="Compatible base URL help" data-help-key="webhook_base"></button></span></div><input id="schWebhookBase" name="schWebhookBase" type="url" inputmode="url" pattern="https?://.+" autocomplete="off" placeholder="https://monitor.example/ping/crosswatch"></label>
+    <label class="field-mini"><div class="subnote"><span class="th-help">Timeout seconds<button type="button" class="sch-help" aria-label="Timeout seconds help" data-help-key="webhook_timeout"></button></span></div><input id="schWebhookTimeout" name="schWebhookTimeout" type="number" min="1" max="60"></label>
+  </div>
+  <div class="stack" data-webhook-format-for="notifiarr">
+    <label class="field-mini"><div class="subnote"><span class="th-help">Notifiarr channel ID<button type="button" class="sch-help" aria-label="Notifiarr channel ID help" data-help-key="webhook_notifiarr_channel"></button></span></div><input id="schWebhookNotifiarrChannel" name="schWebhookNotifiarrChannel" type="text" inputmode="numeric" pattern="[0-9]*" autocomplete="off" placeholder="123456789012345678"></label>
+  </div>
+  <div class="stack three" data-webhook-format-for="crosswatch">
+    <label class="field-mini"><div class="subnote"><span class="th-help">Start callback URL<button type="button" class="sch-help" aria-label="Start callback URL help" data-help-key="webhook_start"></button></span></div><input id="schWebhookStart" name="schWebhookStart" type="url" inputmode="url" pattern="https?://.+" autocomplete="off" placeholder="https://hooks.example.com/crosswatch/start"></label>
+    <label class="field-mini"><div class="subnote"><span class="th-help">Success callback URL<button type="button" class="sch-help" aria-label="Success callback URL help" data-help-key="webhook_success"></button></span></div><input id="schWebhookSuccess" name="schWebhookSuccess" type="url" inputmode="url" pattern="https?://.+" autocomplete="off" placeholder="https://hooks.example.com/crosswatch/success"></label>
+    <label class="field-mini"><div class="subnote"><span class="th-help">Failure callback URL<button type="button" class="sch-help" aria-label="Failure callback URL help" data-help-key="webhook_failure"></button></span></div><input id="schWebhookFailure" name="schWebhookFailure" type="url" inputmode="url" pattern="https?://.+" autocomplete="off" placeholder="https://hooks.example.com/crosswatch/failure"></label>
+  </div>
+</section>
+`;
+    const hooksHost = $("#sec-scheduling .body") || host;
+    hooksHost.appendChild(hooks);
+    hooks.querySelectorAll("input,select").forEach((node) => {
+      node.addEventListener("input", syncWebhooksFromFields);
+      node.addEventListener("change", syncWebhooksFromFields);
+    });
+    [adv, hooks].forEach((root) => {
+      root.querySelectorAll(".sch-help").forEach((btn) => {
+        const tip = HELP_TIPS[btn.dataset.helpKey] || "";
+        if (tip) {
+          btn.title = tip;
+        } else {
+          btn.removeAttribute("title");
+        }
+        btn.onclick = (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+        };
+      });
     });
 
     $("#btnAddStep").onclick = () => { _jobs.push(defaultJob()); renderJobs(); };
@@ -2088,11 +2266,13 @@ const ensureStdEnabledToggle = () => {
       _captureJobs = Array.isArray(adv.capture_jobs || adv.captureJobs) ? (adv.capture_jobs || adv.captureJobs).map(normalizeCaptureJob) : [];
       _captureJobs = mergeCaptureJobs(_captureJobs, getCaptureDraftJobs());
       _eventRules = Array.isArray(adv.event_rules || adv.eventRules) ? (adv.event_rules || adv.eventRules).map(normalizeEventRule) : [];
+      _webhooks = normalizeWebhooks(saved?.webhooks || {});
       _eventRules.forEach(syncRuleRoute);
       renderJobs();
       renderWorkflows();
       renderCaptureJobs();
       renderEventRules();
+      renderWebhooks();
       const pendingCapturePrefills = getPendingCapturePrefills();
       if (pendingCapturePrefills.length) {
         setPendingCapturePrefills([]);
@@ -2172,11 +2352,13 @@ const ensureStdEnabledToggle = () => {
     const workflowState = serializableWorkflows();
     const captureState = serializableCaptureJobs();
     const ruleState = serializableEventRules();
+    const webhookIssues = webhooksValidation();
     return {
       workflowIssues: workflowState.issues.slice(),
       captureIssues: captureState.issues.slice(),
       eventIssues: ruleState.issues.slice(),
-      issues: [...workflowState.issues, ...captureState.issues, ...ruleState.issues]
+      webhookIssues: webhookIssues.slice(),
+      issues: [...workflowState.issues, ...captureState.issues, ...ruleState.issues, ...webhookIssues]
     };
   };
   window.getSchedulingValidation = schedulingValidation;
@@ -2201,13 +2383,18 @@ const ensureStdEnabledToggle = () => {
       if (strict) throw new Error(validation.eventIssues[0]);
       return null;
     }
+    if (validation.webhookIssues.length) {
+      if (strict) throw new Error(validation.webhookIssues[0]);
+      return null;
+    }
+    syncWebhooksFromFields();
     const advanced = serializeAdvanced();
 
     // Advanced plan disables standard scheduling
     const stdEnabled = ($("#schEnabled")?.value || "").trim() === "true";
     const enabled = advanced.enabled ? false : stdEnabled;
 
-    return { enabled, mode, every_n_hours, daily_time, custom_interval_minutes, advanced };
+    return { enabled, mode, every_n_hours, daily_time, custom_interval_minutes, webhooks: normalizeWebhooks(_webhooks), advanced };
   };
 
   // boot

--- a/assets/js/schedulerbanner.js
+++ b/assets/js/schedulerbanner.js
@@ -19,10 +19,19 @@
       .filter(r=>r&&typeof r==="object"&&r.active!==false&&String(r?.provider||"").trim()&&String(r?.feature||"").trim()&&String(r?.at||"").trim()).length,
     activeEventRules=c=>(((c?.scheduling||c||{})?.advanced?.event_rules)||((c?.scheduling||c||{})?.advanced?.eventRules)||[])
       .filter(r=>r&&typeof r==="object"&&r.active!==false&&String(r?.action?.kind||"sync_pair")==="sync_pair"&&String(r?.action?.pair_id||r?.action?.pairId||r?.pair_id||"").trim()&&String(r?.filters?.route_id||r?.filters?.routeId||"").trim()).length,
+    webhookState=c=>{
+      const wh=(c?.scheduling||c||{})?.webhooks||{};
+      if (!wh||typeof wh!=="object"||wh.enabled!==true) return {active:false,label:""};
+      const format=String(wh.payload_format||wh.payloadFormat||wh.format||"crosswatch").trim().toLowerCase().replace("-","_"),
+        label=format==="notifiarr"||format==="notifiarr_passthrough"?"Notifiarr Passthrough":"CrossWatch JSON",
+        url=String(wh.url||wh.default_url||wh.defaultUrl||"").trim(),
+        urls=[url,wh.base_url,wh.healthchecks_base_url,wh.start_url,wh.success_url,wh.failure_url].map(v=>String(v||"").trim()).filter(Boolean);
+      return {active:label==="Notifiarr Passthrough"?!!url:urls.length>0,label};
+    },
     chipText={pairs:"Sync pairs",sched:"Scheduler",watch:"Watcher",hook:"Webhook",health:"CrossWatch health",update:"Updates"},
     chipIcon={pairs:"sync_alt",sched:"calendar_month",watch:"visibility",hook:"webhook",health:"arrow_upward",update:"notifications"},
     chipNav={pairs:{target:"pairs",label:"Open sync pair settings"},sched:{target:"scheduling",label:"Open scheduler settings"},watch:{target:"watcher",label:"Open watcher settings"},hook:{target:"webhook",label:"Open webhook settings"},health:{target:"maintenance",label:"Open Maintenance tools"},update:{target:"refresh-update",label:"Re-check for updates"}},
-    S={cfg:null,pairs:{total:0,active:0},sched:{enabled:false,running:false,next:0,advanced:false,captures:0},evt:{enabled:false,count:0},watch:{...blank(),alive:false},hook:blank(),system:{health:{known:false,ok:false,status:"checking"},update:{known:false,available:false,current:"",latest:"",url:""}},timers:{sched:null,scrob:null,health:null,wait:null,rotate:null},debounce:null,last:{watcher:"",webhook:""}};
+    S={cfg:null,pairs:{total:0,active:0},sched:{enabled:false,running:false,next:0,advanced:false,captures:0,webhooks:false,webhookLabel:"",warning:false,warnings:[]},evt:{enabled:false,count:0},watch:{...blank(),alive:false},hook:blank(),system:{health:{known:false,ok:false,status:"checking"},update:{known:false,available:false,current:"",latest:"",url:""}},timers:{sched:null,scrob:null,health:null,wait:null,rotate:null},debounce:null,last:{watcher:"",webhook:""}};
   const SHARED_WATCH_KEY="__CW_CURRENT_WATCHING_SHARED__",SHARED_WATCH_TTL_MS=3000,WATCHER_UNAVAILABLE_GRACE_MS=35000;
   let scrobPollSeq=0;
 
@@ -77,6 +86,7 @@
 #ops-card #sched-inline-log .sched.has-copy .label,#ops-card #sched-inline-log .sched.has-copy .value,#ops-card #sched-inline-log .sched.has-copy .meta,#ops-card #sched-inline-log .sched.has-copy .badges{position:static!important;top:auto!important;transform:none!important;margin:0!important;padding:0!important;height:auto!important;line-height:1.15!important;}
 #ops-card #sched-inline-log .sched.has-copy .label{grid-column:1!important;grid-row:1!important;font-size:10px!important;font-weight:850!important;letter-spacing:.11em!important;color:var(--hub-muted)!important;}
 #ops-card #sched-inline-log .sched.has-copy .value{grid-column:2!important;grid-row:1!important;font-size:11px!important;font-weight:850!important;color:var(--service-state)!important;}
+#ops-card #sched-inline-log #chip-sched .cw-sched-warning-icon{display:inline-flex!important;align-items:center!important;justify-content:center!important;font-size:15px!important;line-height:1!important;font-variation-settings:"FILL" 1,"wght" 500,"GRAD" 0,"opsz" 20;}
 #ops-card #sched-inline-log .sched.has-copy .value:empty{display:none!important;}
 #ops-card #sched-inline-log .sched.has-copy .meta{grid-column:1 / -1!important;grid-row:2!important;font-size:10px!important;font-weight:650!important;color:var(--hub-muted)!important;overflow:hidden!important;text-overflow:ellipsis!important;}
 #ops-card #sched-inline-log .sched.has-copy .badges{grid-column:3!important;grid-row:1!important;display:inline-flex!important;gap:4px!important;}
@@ -291,6 +301,14 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
       if (el.progressValue) el.progressValue.textContent=hasProgress?`${Math.round(pct)}%`:"";
     }
     el.value.textContent=value==null?"-":String(value);
+    const schedWarnings=(Array.isArray(S.sched?.warnings)?S.sched.warnings:[]).map(x=>String(x||"").trim()).filter(Boolean);
+    const schedHasWarning=el.chip?.id==="chip-sched"&&(!!S.sched?.warning||schedWarnings.length>0);
+    if (schedHasWarning) {
+      el.value.innerHTML=`<span class="material-symbols-rounded cw-sched-warning-icon" aria-hidden="true">warning</span>`;
+      el.value.setAttribute("aria-label","Scheduler issue");
+    } else {
+      el.value.removeAttribute("aria-label");
+    }
     el.meta.textContent=meta||"";
     el.meta.style.display=meta?"inline":"none";
     if (el.badges) {
@@ -299,6 +317,7 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
       el.badges.style.display=badgeHtml?"inline-flex":"none";
     }
     tip=String(tip||"").trim().replace(/\s*\u2022\s*/,"\n");
+    if (el.chip?.id==="chip-sched"&&schedWarnings.length) tip=[tip,...schedWarnings.map(text=>`Warning: ${text}`)].filter(Boolean).join("\n");
     const action=el.chip.dataset.navLabel||"";
     const aria=[tip,action].filter(Boolean).join("\n");
     renderTip(el,tip,action);
@@ -315,7 +334,10 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
       hookItem=currentItem(S.hook),
       watchLive=!!(watchItem&&S.watch.alive),
       hookLive=!!hookItem,
-      schedBadges=[S.sched.captures?`C${S.sched.captures}`:"",S.evt.enabled&&S.evt.count?`E${S.evt.count}`:""].filter(Boolean);
+      schedBadges=[S.sched.captures?`C${S.sched.captures}`:"",S.evt.enabled&&S.evt.count?`E${S.evt.count}`:"",S.sched.webhooks?"WH":""].filter(Boolean),
+      schedWarnings=(Array.isArray(S.sched.warnings)?S.sched.warnings:[]).map(x=>String(x||"").trim()).filter(Boolean),
+      schedWarning=!!S.sched.warning||schedWarnings.length>0,
+      schedWebhookTip=S.sched.webhooks?` • scheduler webhooks active${S.sched.webhookLabel?` (${S.sched.webhookLabel})`:""}`:"";
 
     const pairTotal=Number(S.pairs?.total)||0, pairActive=Number(S.pairs?.active)||0;
     paint(pairs,pairTotal===0?{
@@ -332,11 +354,12 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
     paint(sched,!S.sched.enabled?{
       show:false
     }:{
-      value:S.sched.running?"":(S.sched.advanced?"advanced":"scheduled"),
+      value:schedWarning?"":(S.sched.running?"":(S.sched.advanced?"advanced":"scheduled")),
       meta:S.sched.next?`next ${clock(S.sched.next,true)}`:"",
       badges:schedBadges,
-      live:S.sched.running,
-      tip:`Scheduler ${S.sched.running?"running":(S.sched.advanced?"advanced":"scheduled")}${S.sched.next?` • next ${clock(S.sched.next,true)}`:""}${S.sched.advanced?" • advanced mode":""}${S.sched.captures?` • ${S.sched.captures} capture schedule${S.sched.captures===1?"":"s"}`:""}${S.evt.enabled&&S.evt.count?` • ${S.evt.count} event trigger${S.evt.count===1?"":"s"}`:""}`
+      live:S.sched.running&&!schedWarning,
+      ok:!schedWarning,
+      tip:`Scheduler ${S.sched.running?"running":(S.sched.advanced?"advanced":"scheduled")}${S.sched.next?` • next ${clock(S.sched.next,true)}`:""}${S.sched.advanced?" • advanced mode":""}${S.sched.captures?` • ${S.sched.captures} capture schedule${S.sched.captures===1?"":"s"}`:""}${S.evt.enabled&&S.evt.count?` • ${S.evt.count} event trigger${S.evt.count===1?"":"s"}`:""}${schedWebhookTip}`
     });
 
     paint(watch,!S.watch.enabled?{
@@ -464,10 +487,11 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
     if (document.hidden) return scheduleSched();
     try {
       const st=await API().Scheduling.status(force), sc=st?.config||S.cfg?.scheduling||{};
-      const adv=advancedOn(sc), captures=adv?activeCaptureJobs(sc):0, events=adv?activeEventRules(sc):0;
-      S.sched={enabled:schedulingOn(sc),advanced:adv,running:!!st?.running,next:+(st?.next_run_at||st?.next_run||0)||0,captures:captures};
+      const adv=advancedOn(sc), captures=adv?activeCaptureJobs(sc):0, events=adv?activeEventRules(sc):0, wh=webhookState(sc);
+      const warnings=(Array.isArray(st?.scheduling_warnings)?st.scheduling_warnings:(Array.isArray(st?.warnings)?st.warnings:[])).map(x=>String(x||"").trim()).filter(Boolean);
+      S.sched={enabled:schedulingOn(sc),advanced:adv,running:!!st?.running,next:+(st?.next_run_at||st?.next_run||0)||0,captures:captures,webhooks:!!wh.active,webhookLabel:wh.label||"",warning:!!st?.warning||warnings.length>0,warnings};
       S.evt={enabled:adv&&events>0,count:events};
-    } catch { S.sched={enabled:false,running:false,next:0,advanced:false,captures:0}; S.evt={enabled:false,count:0}; }
+    } catch { S.sched={enabled:false,running:false,next:0,advanced:false,captures:0,webhooks:false,webhookLabel:"",warning:false,warnings:[]}; S.evt={enabled:false,count:0}; }
     render();
     scheduleSched();
   }
@@ -557,14 +581,14 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
     [S.cfg]=await Promise.all([readConfig(forceCfg),pollPairs(forceCfg),pollHealth()]);
     applyUpdateStatus();
     if (!schedulingOn(S.cfg?.scheduling) && !S.cfg?.scrobble?.enabled) {
-      S.sched={enabled:false,running:false,next:0,advanced:false,captures:0};
+      S.sched={enabled:false,running:false,next:0,advanced:false,captures:0,webhooks:false,webhookLabel:"",warning:false,warnings:[]};
       S.evt={enabled:false,count:0};
       S.watch={...blank(),alive:false};
       S.hook=blank();
       clear("rotate");
       return render();
     }
-    schedulingOn(S.cfg?.scheduling)?await pollSched(true):(S.sched={enabled:false,running:false,next:0,advanced:false,captures:0},S.evt={enabled:false,count:0});
+    schedulingOn(S.cfg?.scheduling)?await pollSched(true):(S.sched={enabled:false,running:false,next:0,advanced:false,captures:0,webhooks:false,webhookLabel:"",warning:false,warnings:[]},S.evt={enabled:false,count:0});
     S.cfg?.scrobble?.enabled?await pollScrob(true):(S.watch.enabled=S.hook.enabled=false,render());
   }
 

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, cast
+from urllib.parse import urlsplit
 
 
 def _current_version_norm() -> str:
@@ -38,6 +39,18 @@ def CONFIG_BASE() -> Path:
 
 CONFIG: Path = CONFIG_BASE()
 CONFIG.mkdir(parents=True, exist_ok=True)
+
+DEFAULT_SCHEDULER_WEBHOOKS: dict[str, Any] = {
+    "enabled": False,
+    "url": "",
+    "base_url": "",
+    "start_url": "",
+    "success_url": "",
+    "failure_url": "",
+    "payload_format": "crosswatch",
+    "notifiarr_channel_id": "",
+    "timeout_seconds": 10,
+}
 
 _ENC_PREFIX = "enc:v1:"
 
@@ -144,6 +157,10 @@ def _is_sensitive_path(path: tuple[str, ...]) -> bool:
 
     if len(clean) >= 2 and clean[0] == "security" and clean[1] == "webhook_ids":
         return True
+
+    if len(clean) >= 3 and clean[0] == "scheduling" and clean[1] == "webhooks":
+        if clean[-1] in {"url", "default_url", "base_url", "healthchecks_base_url", "start_url", "success_url", "failure_url"}:
+            return True
 
     leaf = clean[-1]
     exact = {
@@ -588,6 +605,7 @@ DEFAULT_CFG: dict[str, Any] = {
         # Execution behavior:
         "verify_after_write": False,                    # When supported, re-check destination after writes
         "dry_run": False,                               # Plan and log only; do not perform writes
+        "write_state_json": True,                       # Write state.json baselines/stats; leave on true
         "drop_guard": False,                            # Guard against sudden inventory shrink (protects from bad/suspect snapshots)
         "allow_mass_delete": True,                      # If False, block large delete plans (e.g., >~10% of baseline)
         "tombstone_ttl_days": 1,                        # How long “observed deletes” (tombstones) stay valid
@@ -715,6 +733,7 @@ DEFAULT_CFG: dict[str, Any] = {
         "every_n_hours": 12,                            # When mode=every_n_hours, run every N hours (2+ recommended)
         "daily_time": "03:30",                          # When mode=daily_time, run at this time (HH:MM, 24h)
         "custom_interval_minutes": 60,                  # When mode=custom_interval, run every N minutes (minimum 15)
+        "webhooks": dict(DEFAULT_SCHEDULER_WEBHOOKS),    # Optional outbound scheduler lifecycle callbacks
         "advanced": {
             "enabled": False,                           # Advanced scheduler master toggle
             "jobs": [],
@@ -924,6 +943,55 @@ def _get_nested_value(src: dict[str, Any], path: str | Iterable[str]) -> tuple[b
             return False, None
         cur = cur[part]
     return True, cur
+
+
+def _normalize_scheduler_webhooks(value: Any) -> dict[str, Any]:
+    src = value if isinstance(value, dict) else {}
+    out = dict(DEFAULT_SCHEDULER_WEBHOOKS)
+    enabled = src.get("enabled")
+    if isinstance(enabled, bool):
+        out["enabled"] = enabled
+    elif isinstance(enabled, (int, float)):
+        out["enabled"] = bool(enabled)
+    else:
+        out["enabled"] = str(enabled or "").strip().lower() in {"1", "true", "yes", "on"}
+    out["url"] = _http_url_or_blank(src.get("url") or src.get("default_url"))
+    out["base_url"] = _http_url_or_blank(src.get("base_url") or src.get("healthchecks_base_url"))
+    for key in ("start_url", "success_url", "failure_url"):
+        out[key] = _http_url_or_blank(src.get(key))
+    out["payload_format"] = _scheduler_webhook_payload_format(src.get("payload_format") or src.get("format"))
+    out["notifiarr_channel_id"] = _digits_or_blank(src.get("notifiarr_channel_id") or src.get("notifiarrChannelId"))
+    try:
+        timeout = int(src.get("timeout_seconds", 10) or 10)
+    except Exception:
+        timeout = 10
+    out["timeout_seconds"] = max(1, min(60, timeout))
+    return out
+
+
+def _http_url_or_blank(value: Any) -> str:
+    url = str(value or "").strip()
+    if not url:
+        return ""
+    try:
+        parts = urlsplit(url)
+    except Exception:
+        return ""
+    if parts.scheme.lower() not in {"http", "https"} or not parts.netloc:
+        return ""
+    return url
+
+
+def _scheduler_webhook_payload_format(value: Any) -> str:
+    text = str(value or "").strip().lower().replace("-", "_")
+    if text in {"notifiarr", "notifiarr_passthrough"}:
+        return "notifiarr"
+    return "crosswatch"
+
+
+def _digits_or_blank(value: Any) -> str:
+    text = str(value or "").strip()
+    return text if text.isdigit() else ""
 
 
 def _set_nested_value(dst: dict[str, Any], path: str | Iterable[str], value: Any) -> None:
@@ -1480,6 +1548,7 @@ def _normalize_scheduling(cfg: dict[str, Any]) -> None:
     if custom_minutes < 15:
         custom_minutes = 15
     s["custom_interval_minutes"] = custom_minutes
+    s["webhooks"] = _normalize_scheduler_webhooks(s.get("webhooks"))
 
     adv = _ensure_dict(s, "advanced")
     adv["enabled"] = bool(adv.get("enabled", False))

--- a/services/scheduler_webhooks.py
+++ b/services/scheduler_webhooks.py
@@ -1,0 +1,318 @@
+# services/scheduler_webhooks.py
+# CrossWatch - outbound callbacks for scheduled sync runs
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any, Callable
+from urllib.parse import urlsplit, urlunsplit
+
+import requests
+
+SCHEDULED_SYNC_MODES = {"standard", "advanced", "advanced_workflow"}
+EVENTS = {"start", "success", "failure"}
+
+DEFAULT_WEBHOOKS: dict[str, Any] = {
+    "enabled": False,
+    "url": "",
+    "base_url": "",
+    "start_url": "",
+    "success_url": "",
+    "failure_url": "",
+    "payload_format": "crosswatch",
+    "notifiarr_channel_id": "",
+    "timeout_seconds": 10,
+}
+
+
+def normalize_scheduler_webhooks(value: Any) -> dict[str, Any]:
+    src = value if isinstance(value, dict) else {}
+    out = dict(DEFAULT_WEBHOOKS)
+    out["enabled"] = _as_bool(src.get("enabled"), False)
+    out["url"] = _http_url_or_blank(src.get("url") or src.get("default_url"))
+    out["base_url"] = _http_url_or_blank(src.get("base_url") or src.get("healthchecks_base_url"))
+    for key in ("start_url", "success_url", "failure_url"):
+        out[key] = _http_url_or_blank(src.get(key))
+    out["payload_format"] = _payload_format(src.get("payload_format") or src.get("format"))
+    out["notifiarr_channel_id"] = _digits_or_blank(src.get("notifiarr_channel_id") or src.get("notifiarrChannelId"))
+    out["timeout_seconds"] = _as_int(src.get("timeout_seconds"), 10, minimum=1, maximum=60)
+    return out
+
+
+def is_scheduled_sync_context(context: Any) -> bool:
+    ctx = context if isinstance(context, dict) else {}
+    if str(ctx.get("source") or "").strip().lower() != "scheduler":
+        return False
+    mode = str(ctx.get("scheduler_mode") or "").strip().lower()
+    return mode in SCHEDULED_SYNC_MODES
+
+
+def callback_url(webhooks: dict[str, Any], event: str) -> str:
+    ev = str(event or "").strip().lower()
+    if ev not in EVENTS:
+        return ""
+
+    if _payload_format(webhooks.get("payload_format") or webhooks.get("format")) == "notifiarr":
+        return str(webhooks.get("url") or webhooks.get("default_url") or "").strip()
+
+    explicit_key = {"start": "start_url", "success": "success_url", "failure": "failure_url"}[ev]
+    explicit = str(webhooks.get(explicit_key) or "").strip()
+    if explicit:
+        return explicit
+
+    common = str(webhooks.get("url") or webhooks.get("default_url") or "").strip()
+    if common:
+        return common
+
+    base = str(webhooks.get("base_url") or webhooks.get("healthchecks_base_url") or "").strip()
+    if not base:
+        return ""
+    if ev == "start":
+        return _with_path_suffix(base, "start")
+    if ev == "failure":
+        return _with_path_suffix(base, "fail")
+    return base
+
+
+def build_payload(
+    event: str,
+    context: dict[str, Any] | None,
+    summary: dict[str, Any] | None,
+    payload_format: str = "crosswatch",
+) -> dict[str, Any]:
+    ctx = dict(context or {})
+    snap = dict(summary or {})
+    ev = str(event or "").strip().lower()
+    exit_code = snap.get("exit_code")
+    try:
+        exit_code = int(exit_code) if exit_code is not None else None
+    except Exception:
+        exit_code = None
+
+    payload = {
+        "event": ev,
+        "status": "ok" if ev == "success" else "failed" if ev == "failure" else "started",
+        "run_id": str(ctx.get("run_id") or snap.get("run_id") or ""),
+        "scheduler_mode": str(ctx.get("scheduler_mode") or ""),
+        "job_id": str(ctx.get("job_id") or ""),
+        "workflow_id": str(ctx.get("workflow_id") or ""),
+        "workflow_step_id": str(ctx.get("workflow_step_id") or ""),
+        "pair_id": str(ctx.get("pair_id") or ctx.get("pair_scope") or ""),
+        "started_at": snap.get("started_at"),
+        "finished_at": snap.get("finished_at"),
+        "duration_sec": snap.get("duration_sec"),
+        "exit_code": exit_code,
+        "summary": _summary_counts(snap),
+    }
+    payload = {k: v for k, v in payload.items() if v not in ("", None, {})}
+    if _payload_format(payload_format) == "notifiarr":
+        return _notifiarr_payload(payload, ctx, snap)
+    return payload
+
+
+def notify_scheduler_webhook(
+    cfg: dict[str, Any] | None,
+    event: str,
+    context: dict[str, Any] | None,
+    summary: dict[str, Any] | None = None,
+    *,
+    log_fn: Callable[[str], None] | None = None,
+) -> bool:
+    if not is_scheduled_sync_context(context):
+        return False
+
+    sch = (cfg or {}).get("scheduling") if isinstance(cfg, dict) else {}
+    sch = sch if isinstance(sch, dict) else {}
+    webhooks = normalize_scheduler_webhooks(sch.get("webhooks"))
+    if not webhooks.get("enabled"):
+        return False
+
+    url = callback_url(webhooks, event)
+    if not url:
+        return False
+
+    payload = build_payload(event, context, summary, str(webhooks.get("payload_format") or "crosswatch"))
+    if webhooks.get("payload_format") == "notifiarr":
+        channel_id = str(webhooks.get("notifiarr_channel_id") or "").strip()
+        if channel_id:
+            payload.setdefault("discord", {}).setdefault("ids", {})["channel"] = int(channel_id)
+    timeout = int(webhooks.get("timeout_seconds") or 10)
+    try:
+        resp = requests.post(
+            url,
+            json=payload,
+            timeout=timeout,
+            headers={"User-Agent": "CrossWatch scheduler webhook"},
+        )
+        resp.raise_for_status()
+        _log(log_fn, f"[i] Scheduler webhook {event}: delivered")
+        return True
+    except Exception as exc:
+        _log(log_fn, f"[!] Scheduler webhook {event}: {type(exc).__name__}")
+        return False
+
+
+def _summary_counts(summary: dict[str, Any]) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for key in ("added", "removed", "updated"):
+        direct = summary.get(f"{key}_last")
+        if direct is not None:
+            out[key] = _as_int(direct, 0, minimum=0)
+
+    features = summary.get("features")
+    enabled = summary.get("enabled")
+    if isinstance(features, dict):
+        totals = {"added": 0, "removed": 0, "updated": 0}
+        for name, lane in features.items():
+            if isinstance(enabled, dict) and enabled.get(name) is False:
+                continue
+            if not isinstance(lane, dict):
+                continue
+            for key in totals:
+                totals[key] += _as_int(lane.get(key), 0, minimum=0)
+        for key, value in totals.items():
+            out[key] = max(out.get(key, 0), value)
+
+    for key in ("unresolved", "errors", "blocked", "skipped"):
+        value = summary.get(key)
+        if value is not None:
+            out[key] = _as_int(value, 0, minimum=0)
+    return {k: v for k, v in out.items() if v}
+
+
+def _notifiarr_payload(payload: dict[str, Any], context: dict[str, Any], summary: dict[str, Any]) -> dict[str, Any]:
+    event = str(payload.get("event") or "").strip().lower()
+    status = str(payload.get("status") or event or "").strip()
+    title_event = {
+        "start": "started",
+        "success": "succeeded",
+        "failure": "failed",
+    }.get(event, status or "updated")
+    color = {
+        "start": "4F8CFF",
+        "success": "2ECC71",
+        "failure": "FF5A5F",
+    }.get(event, "7D86C9")
+
+    fields: list[dict[str, Any]] = []
+    for title, key in (
+        ("Run", "run_id"),
+        ("Mode", "scheduler_mode"),
+        ("Job", "job_id"),
+        ("Workflow", "workflow_id"),
+        ("Step", "workflow_step_id"),
+        ("Pair", "pair_id"),
+        ("Exit", "exit_code"),
+        ("Duration", "duration_sec"),
+    ):
+        value = payload.get(key)
+        if value in ("", None, {}):
+            continue
+        fields.append({"title": title, "text": str(value), "inline": True})
+
+    counts = payload.get("summary") if isinstance(payload.get("summary"), dict) else {}
+    for key in ("added", "removed", "updated", "errors", "blocked", "skipped", "unresolved"):
+        value = counts.get(key) if isinstance(counts, dict) else None
+        if value:
+            fields.append({"title": key.replace("_", " ").title(), "text": str(value), "inline": True})
+
+    description = f"Scheduled sync {title_event}."
+    if event == "failure":
+        description = "Scheduled sync failed. Check the CrossWatch sync logs for details."
+    elif event == "success":
+        description = "Scheduled sync completed successfully."
+
+    run_id = str(payload.get("run_id") or context.get("run_id") or summary.get("run_id") or "")
+    notification_event = run_id or f"crosswatch-{event or 'scheduler'}"
+    return {
+        "notification": {
+            "update": False,
+            "name": "CrossWatch",
+            "event": notification_event,
+        },
+        "discord": {
+            "color": color,
+            "ping": {
+                "pingUser": 0,
+                "pingRole": 0,
+            },
+            "images": {
+                "thumbnail": "",
+                "image": "",
+            },
+            "text": {
+                "title": f"CrossWatch scheduled sync {title_event}",
+                "icon": "",
+                "content": "",
+                "description": description,
+                "fields": fields[:25],
+                "footer": "CrossWatch Scheduler",
+            },
+        },
+    }
+
+
+def _with_path_suffix(url: str, suffix: str) -> str:
+    parts = urlsplit(url)
+    path = (parts.path or "").rstrip("/") + "/" + suffix.strip("/")
+    return urlunsplit((parts.scheme, parts.netloc, path, parts.query, parts.fragment))
+
+
+def _http_url_or_blank(value: Any) -> str:
+    url = str(value or "").strip()
+    if not url:
+        return ""
+    try:
+        parts = urlsplit(url)
+    except Exception:
+        return ""
+    if parts.scheme.lower() not in {"http", "https"} or not parts.netloc:
+        return ""
+    return url
+
+
+def _payload_format(value: Any) -> str:
+    text = str(value or "").strip().lower().replace("-", "_")
+    if text in {"notifiarr", "notifiarr_passthrough"}:
+        return "notifiarr"
+    return "crosswatch"
+
+
+def _digits_or_blank(value: Any) -> str:
+    text = str(value or "").strip()
+    return text if text.isdigit() else ""
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return bool(default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    return bool(default)
+
+
+def _as_int(value: Any, default: int = 0, *, minimum: int | None = None, maximum: int | None = None) -> int:
+    try:
+        out = int(value)
+    except Exception:
+        out = int(default)
+    if minimum is not None:
+        out = max(int(minimum), out)
+    if maximum is not None:
+        out = min(int(maximum), out)
+    return out
+
+
+def _log(log_fn: Callable[[str], None] | None, message: str) -> None:
+    if not log_fn:
+        return
+    try:
+        log_fn(message)
+    except Exception:
+        pass

--- a/services/scheduling.py
+++ b/services/scheduling.py
@@ -10,6 +10,7 @@ import os
 import json
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
+from urllib.parse import urlsplit
 
 try:
     from zoneinfo import ZoneInfo  # py39+
@@ -21,6 +22,18 @@ def _env_timezone_name() -> str:
     return tz
 
 # safety config defaults due to autostart and potential for misconfiguration
+DEFAULT_WEBHOOKS: dict[str, Any] = {
+    "enabled": False,
+    "url": "",
+    "base_url": "",
+    "start_url": "",
+    "success_url": "",
+    "failure_url": "",
+    "payload_format": "crosswatch",
+    "notifiarr_channel_id": "",
+    "timeout_seconds": 10,
+}
+
 DEFAULT_SCHEDULING: dict[str, Any] = {
     "enabled": False,
     "mode": "disabled",
@@ -29,6 +42,7 @@ DEFAULT_SCHEDULING: dict[str, Any] = {
     "custom_interval_minutes": 60,
     "timezone": "",
     "jitter_seconds": 0,
+    "webhooks": dict(DEFAULT_WEBHOOKS),
     "advanced": {
         "enabled": False,
         "jobs": [],
@@ -120,6 +134,45 @@ def _as_bool(value: Any, default: bool = False) -> bool:
     return bool(default)
 
 
+def _normalize_scheduler_webhooks(value: Any) -> dict[str, Any]:
+    src = value if isinstance(value, dict) else {}
+    out = dict(DEFAULT_WEBHOOKS)
+    out["enabled"] = _as_bool(src.get("enabled"), False)
+    out["url"] = _http_url_or_blank(src.get("url") or src.get("default_url"))
+    out["base_url"] = _http_url_or_blank(src.get("base_url") or src.get("healthchecks_base_url"))
+    for key in ("start_url", "success_url", "failure_url"):
+        out[key] = _http_url_or_blank(src.get(key))
+    out["payload_format"] = _payload_format(src.get("payload_format") or src.get("format"))
+    out["notifiarr_channel_id"] = _digits_or_blank(src.get("notifiarr_channel_id") or src.get("notifiarrChannelId"))
+    out["timeout_seconds"] = _as_int(src.get("timeout_seconds"), 10, minimum=1, maximum=60)
+    return out
+
+
+def _http_url_or_blank(value: Any) -> str:
+    url = str(value or "").strip()
+    if not url:
+        return ""
+    try:
+        parts = urlsplit(url)
+    except Exception:
+        return ""
+    if parts.scheme.lower() not in {"http", "https"} or not parts.netloc:
+        return ""
+    return url
+
+
+def _payload_format(value: Any) -> str:
+    text = str(value or "").strip().lower().replace("-", "_")
+    if text in {"notifiarr", "notifiarr_passthrough"}:
+        return "notifiarr"
+    return "crosswatch"
+
+
+def _digits_or_blank(value: Any) -> str:
+    text = str(value or "").strip()
+    return text if text.isdigit() else ""
+
+
 def _normalize_event_name(value: Any) -> str:
     raw = str(value or "").strip().lower()
     if raw.startswith("/scrobble/"):
@@ -169,6 +222,7 @@ def merge_defaults(s: dict[str, Any]) -> dict[str, Any]:
             out["advanced"] = out_adv
     if not isinstance(out.get("advanced"), dict):
         out["advanced"] = dict(DEFAULT_SCHEDULING["advanced"])
+    out["webhooks"] = _normalize_scheduler_webhooks(out.get("webhooks"))
     return out
 
 def _align_next_hour_in_tz(now_tz: datetime) -> datetime:

--- a/tests/test_scheduler_webhooks.py
+++ b/tests/test_scheduler_webhooks.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import threading
+import types
+from typing import Any
+
+
+def test_scheduler_webhook_healthchecks_urls_preserve_query() -> None:
+    from services.scheduler_webhooks import callback_url, normalize_scheduler_webhooks
+
+    webhooks = normalize_scheduler_webhooks({
+        "enabled": True,
+        "base_url": "https://hc-ping.com/abc123?rid=crosswatch",
+    })
+
+    assert callback_url(webhooks, "start") == "https://hc-ping.com/abc123/start?rid=crosswatch"
+    assert callback_url(webhooks, "success") == "https://hc-ping.com/abc123?rid=crosswatch"
+    assert callback_url(webhooks, "failure") == "https://hc-ping.com/abc123/fail?rid=crosswatch"
+
+
+def test_scheduler_webhook_explicit_url_wins_over_healthchecks_base() -> None:
+    from services.scheduler_webhooks import callback_url, normalize_scheduler_webhooks
+
+    webhooks = normalize_scheduler_webhooks({
+        "enabled": True,
+        "base_url": "https://hc-ping.com/abc123",
+        "failure_url": "https://monitor.example/fail",
+    })
+
+    assert callback_url(webhooks, "failure") == "https://monitor.example/fail"
+
+
+def test_scheduler_webhook_common_url_wins_over_compatible_base() -> None:
+    from services.scheduler_webhooks import callback_url, normalize_scheduler_webhooks
+
+    webhooks = normalize_scheduler_webhooks({
+        "enabled": True,
+        "url": "https://notifiarr.com/api/v1/notification/passthrough/key",
+        "base_url": "https://hc-ping.com/abc123",
+    })
+
+    assert callback_url(webhooks, "start") == "https://notifiarr.com/api/v1/notification/passthrough/key"
+    assert callback_url(webhooks, "success") == "https://notifiarr.com/api/v1/notification/passthrough/key"
+    assert callback_url(webhooks, "failure") == "https://notifiarr.com/api/v1/notification/passthrough/key"
+
+
+def test_scheduler_webhook_notifiarr_format_uses_single_passthrough_url() -> None:
+    from services.scheduler_webhooks import callback_url, normalize_scheduler_webhooks
+
+    webhooks = normalize_scheduler_webhooks({
+        "enabled": True,
+        "payload_format": "notifiarr",
+        "url": "https://notifiarr.com/api/v1/notification/passthrough/key",
+        "failure_url": "https://hooks.example.com/old-failure-url",
+        "base_url": "https://hc-ping.com/abc123",
+    })
+
+    assert callback_url(webhooks, "start") == "https://notifiarr.com/api/v1/notification/passthrough/key"
+    assert callback_url(webhooks, "success") == "https://notifiarr.com/api/v1/notification/passthrough/key"
+    assert callback_url(webhooks, "failure") == "https://notifiarr.com/api/v1/notification/passthrough/key"
+
+
+def test_scheduler_webhook_urls_must_be_http_or_https() -> None:
+    from services.scheduler_webhooks import callback_url, normalize_scheduler_webhooks
+
+    webhooks = normalize_scheduler_webhooks({
+        "enabled": True,
+        "base_url": "ftp://monitor.example/ping",
+        "start_url": "monitor.example/start",
+        "success_url": "http://monitor.example/success",
+        "failure_url": "https://monitor.example/failure",
+    })
+
+    assert webhooks["base_url"] == ""
+    assert webhooks["start_url"] == ""
+    assert callback_url(webhooks, "start") == ""
+    assert callback_url(webhooks, "success") == "http://monitor.example/success"
+    assert callback_url(webhooks, "failure") == "https://monitor.example/failure"
+
+
+def test_scheduler_webhook_payload_includes_context_and_summary_counts() -> None:
+    from services.scheduler_webhooks import build_payload
+
+    payload = build_payload(
+        "success",
+        {
+            "run_id": "run-1",
+            "scheduler_mode": "advanced_workflow",
+            "workflow_id": "wf",
+            "workflow_step_id": "step",
+            "pair_id": "plex-trakt",
+        },
+        {
+            "started_at": "2026-08-03T10:00:00Z",
+            "finished_at": "2026-08-03T10:00:04Z",
+            "duration_sec": 4.2,
+            "exit_code": 0,
+            "features": {
+                "watchlist": {"added": 2, "removed": 1, "updated": 0},
+                "ratings": {"added": 3, "removed": 0, "updated": 1},
+            },
+        },
+    )
+
+    assert payload["event"] == "success"
+    assert payload["status"] == "ok"
+    assert payload["run_id"] == "run-1"
+    assert payload["scheduler_mode"] == "advanced_workflow"
+    assert payload["workflow_id"] == "wf"
+    assert payload["workflow_step_id"] == "step"
+    assert payload["pair_id"] == "plex-trakt"
+    assert payload["summary"] == {"added": 5, "removed": 1, "updated": 1}
+
+
+def test_scheduler_webhook_notifiarr_payload_shape() -> None:
+    from services.scheduler_webhooks import build_payload
+
+    payload = build_payload(
+        "failure",
+        {
+            "run_id": "run-9",
+            "scheduler_mode": "standard",
+            "pair_id": "plex-trakt",
+        },
+        {
+            "exit_code": 1,
+            "errors": 2,
+        },
+        "notifiarr",
+    )
+
+    assert payload["notification"]["name"] == "CrossWatch"
+    assert payload["notification"]["event"] == "run-9"
+    assert payload["discord"]["color"] == "FF5A5F"
+    assert payload["discord"]["text"]["title"] == "CrossWatch scheduled sync failed"
+    assert {"title": "Pair", "text": "plex-trakt", "inline": True} in payload["discord"]["text"]["fields"]
+    assert {"title": "Errors", "text": "2", "inline": True} in payload["discord"]["text"]["fields"]
+
+
+def test_scheduler_webhook_notifiarr_notify_adds_channel(monkeypatch) -> None:
+    import services.scheduler_webhooks as webhooks
+
+    posted: dict[str, Any] = {}
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+    def fake_post(url: str, **kwargs: Any) -> FakeResponse:
+        posted["url"] = url
+        posted["json"] = kwargs.get("json")
+        return FakeResponse()
+
+    monkeypatch.setattr(webhooks.requests, "post", fake_post)
+
+    ok = webhooks.notify_scheduler_webhook(
+        {
+            "scheduling": {
+                "webhooks": {
+                    "enabled": True,
+                    "url": "https://notifiarr.com/api/v1/notification/passthrough/key",
+                    "payload_format": "notifiarr",
+                    "notifiarr_channel_id": "123456789012345678",
+                }
+            }
+        },
+        "success",
+        {"source": "scheduler", "scheduler_mode": "standard", "run_id": "run-10"},
+        {"exit_code": 0},
+    )
+
+    assert ok is True
+    assert posted["url"] == "https://notifiarr.com/api/v1/notification/passthrough/key"
+    assert posted["json"]["discord"]["ids"]["channel"] == 123456789012345678
+
+
+def test_scheduler_webhook_notify_is_best_effort(monkeypatch) -> None:
+    import services.scheduler_webhooks as webhooks
+
+    def fail_post(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("offline")
+
+    logs: list[str] = []
+    monkeypatch.setattr(webhooks.requests, "post", fail_post)
+
+    ok = webhooks.notify_scheduler_webhook(
+        {
+            "scheduling": {
+                "webhooks": {
+                    "enabled": True,
+                    "failure_url": "https://monitor.example/fail",
+                    "timeout_seconds": 1,
+                }
+            }
+        },
+        "failure",
+        {"source": "scheduler", "scheduler_mode": "standard", "run_id": "run-2"},
+        {"exit_code": 1},
+        log_fn=logs.append,
+    )
+
+    assert ok is False
+    assert logs and "Scheduler webhook failure" in logs[0]
+
+
+def test_scheduling_webhook_config_is_normalized_and_sensitive() -> None:
+    from cw_platform.config_base import _is_sensitive_path, _normalize_scheduling
+
+    cfg = {
+        "scheduling": {
+                "webhooks": {
+                "enabled": True,
+                "url": "https://notifiarr.com/api/v1/notification/passthrough/key",
+                "base_url": "https://hc-ping.com/abc123",
+                "start_url": "ftp://monitor.example/start",
+                "payload_format": "notifiarr-passthrough",
+                "notifiarr_channel_id": "123456789012345678",
+                "timeout_seconds": 999,
+            }
+        }
+    }
+
+    _normalize_scheduling(cfg)
+
+    hooks = cfg["scheduling"]["webhooks"]
+    assert hooks["enabled"] is True
+    assert hooks["url"] == "https://notifiarr.com/api/v1/notification/passthrough/key"
+    assert hooks["base_url"] == "https://hc-ping.com/abc123"
+    assert hooks["start_url"] == ""
+    assert hooks["payload_format"] == "notifiarr"
+    assert hooks["notifiarr_channel_id"] == "123456789012345678"
+    assert hooks["timeout_seconds"] == 60
+    assert _is_sensitive_path(("scheduling", "webhooks", "url")) is True
+    assert _is_sensitive_path(("scheduling", "webhooks", "base_url")) is True
+    assert _is_sensitive_path(("scheduling", "webhooks", "failure_url")) is True
+
+
+def test_scheduled_sync_thread_dispatches_start_and_success_webhooks(monkeypatch, tmp_path) -> None:
+    import api.syncAPI as sync
+    import sys
+
+    log_buffers: dict[str, list[str]] = {"SYNC": []}
+
+    def append_log(kind: str, message: str) -> None:
+        log_buffers.setdefault(kind, []).append(str(message))
+
+    fake_crosswatch = types.SimpleNamespace(
+        LOG_BUFFERS=log_buffers,
+        RUNNING_PROCS={"SYNC": object()},
+        SYNC_PROC_LOCK=threading.Lock(),
+        STATE_PATH=tmp_path / "state.json",
+        STATE_PATHS=[],
+        STATS=types.SimpleNamespace(refresh_from_state=lambda _state: None, record_summary=lambda *_args: None),
+        REPORT_DIR=tmp_path,
+        strip_ansi=lambda value: str(value),
+        _append_log=append_log,
+        minimal=lambda value: value,
+        canonical_key=lambda value: str(value),
+    )
+    monkeypatch.setitem(sys.modules, "crosswatch", fake_crosswatch)
+
+    cfg = {
+        "pairs": [{"id": "plex-trakt", "enabled": True, "source": "PLEX", "target": "TRAKT"}],
+        "scheduling": {
+            "webhooks": {
+                "enabled": True,
+                "base_url": "https://hc-ping.com/abc123",
+            }
+        },
+    }
+    monkeypatch.setattr(sync, "_env", lambda: (lambda: cfg, lambda _cfg: None))
+    monkeypatch.setattr(sync, "_load_state", lambda: None)
+    monkeypatch.setattr(sync, "_counts_from_state", lambda _state: None)
+    monkeypatch.setattr(sync, "_provider_count_defaults", lambda: {})
+
+    class FakeOrchestrator:
+        def __init__(self, config: dict[str, Any]) -> None:
+            self.config = config
+
+        def run_pairs(self, **kwargs: Any) -> dict[str, int]:
+            progress = kwargs["progress"]
+            progress('{"event":"apply:add:done","feature":"watchlist","count":2}')
+            return {"added": 2, "removed": 0, "updated": 0, "errors": 0}
+
+    fake_orchestrator_module = types.SimpleNamespace(Orchestrator=FakeOrchestrator, __file__="fake-orchestrator.py")
+    monkeypatch.setattr(
+        sync.importlib,
+        "import_module",
+        lambda name: fake_orchestrator_module if name == "cw_platform.orchestrator" else __import__(name),
+    )
+
+    calls: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+
+    def fake_notify(cfg_arg: dict[str, Any] | None, event: str, context: dict[str, Any] | None, summary: dict[str, Any] | None = None, **_kwargs: Any) -> bool:
+        calls.append((event, dict(context or {}), dict(summary or {})))
+        return True
+
+    monkeypatch.setattr(sync, "notify_scheduler_webhook", fake_notify)
+
+    sync._run_pairs_thread(
+        "run-123",
+        {
+            "source": "scheduler",
+            "scheduler_mode": "advanced",
+            "job_id": "job-1",
+            "pair_id": "plex-trakt",
+        },
+    )
+
+    assert [event for event, _, _ in calls] == ["start", "success"]
+    assert calls[0][1]["run_id"] == "run-123"
+    assert calls[0][1]["scheduler_mode"] == "advanced"
+    assert calls[0][1]["job_id"] == "job-1"
+    assert calls[0][1]["pair_id"] == "plex-trakt"
+    assert calls[1][2]["exit_code"] == 0
+    assert calls[1][2]["added_last"] == 2
+
+
+def test_scheduled_sync_thread_dispatches_failure_webhook_on_exception(monkeypatch, tmp_path) -> None:
+    import api.syncAPI as sync
+    import sys
+
+    log_buffers: dict[str, list[str]] = {"SYNC": []}
+
+    def append_log(kind: str, message: str) -> None:
+        log_buffers.setdefault(kind, []).append(str(message))
+
+    fake_crosswatch = types.SimpleNamespace(
+        LOG_BUFFERS=log_buffers,
+        RUNNING_PROCS={"SYNC": object()},
+        SYNC_PROC_LOCK=threading.Lock(),
+        STATE_PATH=tmp_path / "state.json",
+        STATE_PATHS=[],
+        STATS=types.SimpleNamespace(refresh_from_state=lambda _state: None, record_summary=lambda *_args: None),
+        REPORT_DIR=tmp_path,
+        strip_ansi=lambda value: str(value),
+        _append_log=append_log,
+        minimal=lambda value: value,
+        canonical_key=lambda value: str(value),
+    )
+    monkeypatch.setitem(sys.modules, "crosswatch", fake_crosswatch)
+
+    cfg = {
+        "pairs": [{"id": "plex-trakt", "enabled": True, "source": "PLEX", "target": "TRAKT"}],
+        "scheduling": {
+            "webhooks": {
+                "enabled": True,
+                "failure_url": "https://monitor.example/fail",
+            }
+        },
+    }
+    monkeypatch.setattr(sync, "_env", lambda: (lambda: cfg, lambda _cfg: None))
+    monkeypatch.setattr(sync, "_load_state", lambda: None)
+    monkeypatch.setattr(sync, "_counts_from_state", lambda _state: None)
+    monkeypatch.setattr(sync, "_provider_count_defaults", lambda: {})
+
+    class FailingOrchestrator:
+        def __init__(self, config: dict[str, Any]) -> None:
+            self.config = config
+
+        def run_pairs(self, **_kwargs: Any) -> dict[str, int]:
+            raise RuntimeError("boom")
+
+    fake_orchestrator_module = types.SimpleNamespace(Orchestrator=FailingOrchestrator, __file__="fake-orchestrator.py")
+    monkeypatch.setattr(
+        sync.importlib,
+        "import_module",
+        lambda name: fake_orchestrator_module if name == "cw_platform.orchestrator" else __import__(name),
+    )
+
+    calls: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+
+    def fake_notify(cfg_arg: dict[str, Any] | None, event: str, context: dict[str, Any] | None, summary: dict[str, Any] | None = None, **_kwargs: Any) -> bool:
+        calls.append((event, dict(context or {}), dict(summary or {})))
+        return True
+
+    monkeypatch.setattr(sync, "notify_scheduler_webhook", fake_notify)
+
+    sync._run_pairs_thread(
+        "run-456",
+        {
+            "source": "scheduler",
+            "scheduler_mode": "standard",
+        },
+    )
+
+    assert [event for event, _, _ in calls] == ["start", "failure"]
+    assert calls[1][1]["run_id"] == "run-456"
+    assert calls[1][2]["exit_code"] == 1


### PR DESCRIPTION
# Pull request

## Change

- Adds optional scheduler webhook callbacks for scheduled sync runs.
- Supports generic CrossWatch JSON callbacks and Notifiarr Passthrough payloads. 

Also adds the Scheduling UI fields, helper text, URL validation, and a small banner indicator when webhooks are active.

## Why

Monitor scheduled sync starts, successes and failures from external tools.

## Testing

- test_scheduler_webhooks.py 

Not live tested yet.

## Issue

Relates to #633