### PR TITLE
Change: episode lookup caching

### DIFF
--- a/providers/sync/emby/_common.py
+++ b/providers/sync/emby/_common.py
@@ -684,7 +684,7 @@ def find_series_in_index(adapter: Any, pairs: Iterable[str]) -> dict[str, Any] |
 
 
 # Shows/episodes
-def get_series_episodes(http: Any, user_id: str, series_id: str, start: int = 0, limit: int = 500) -> dict[str, Any]:
+def get_series_episodes(http: Any, user_id: str, series_id: str, start: int = 0, limit: int = 500) -> dict[str, Any] | None:
     q = {
         "UserId": user_id,
         "StartIndex": max(0, int(start)),
@@ -694,8 +694,11 @@ def get_series_episodes(http: Any, user_id: str, series_id: str, start: int = 0,
     }
     r = http.get(f"/Shows/{series_id}/Episodes", params=q)
     if getattr(r, "status_code", 0) != 200:
-        return {"Items": [], "TotalRecordCount": 0}
-    data = r.json() or {}
+        return None
+    try:
+        data = r.json() or {}
+    except Exception:
+        return None
     data.setdefault("Items", [])
     data.setdefault("TotalRecordCount", len(data["Items"]))
     return data
@@ -819,12 +822,14 @@ def _fetch_all_series_episodes(
     sid: str,
     *,
     page_size: int,
-) -> list[Mapping[str, Any]]:
+) -> list[Mapping[str, Any]] | None:
     start = 0
     total: int | None = None
     out: list[Mapping[str, Any]] = []
     while True:
         body = get_series_episodes(http, uid, sid, start=start, limit=page_size)
+        if body is None:
+            return None
         rows: list[Mapping[str, Any]] = body.get("Items") or []
         if total is None:
             total = int(body.get("TotalRecordCount") or 0)
@@ -833,6 +838,25 @@ def _fetch_all_series_episodes(
         if not rows or (total is not None and start >= total):
             break
     return out
+
+
+def _series_episodes_cached(adapter: Any, http: Any, uid: str, sid: str) -> list[Mapping[str, Any]]:
+    cache = getattr(adapter, "_emby_series_episodes_cache", None)
+    if not isinstance(cache, dict):
+        cache = {}
+        try:
+            setattr(adapter, "_emby_series_episodes_cache", cache)
+        except Exception:
+            pass
+    key = str(sid)
+    rows = cache.get(key)
+    if rows is None:
+        rows = _fetch_all_series_episodes(http, uid, sid, page_size=500)
+        if rows is not None:
+            cache[key] = rows
+        else:
+            cw_log("EMBY", "common", "debug", "series_episodes_fetch_failed", series_id=key)
+    return rows or []
 
 
 def _fetch_all_collection_items(
@@ -1539,7 +1563,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
         if ser_row and season is not None and episode is not None:
             sid = ser_row.get("Id")
             if sid:
-                eps = _fetch_all_series_episodes(http, uid, sid, page_size=500)
+                eps = _series_episodes_cached(adapter, http, uid, sid)
                 for ep in eps:
                     if (
                         int(ep.get("ParentIndexNumber") or -1) == int(season)
@@ -1617,7 +1641,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
         if series_row and season is not None and episode is not None:
             sid = series_row.get("Id")
             if sid:
-                eps = _fetch_all_series_episodes(http, uid, sid, page_size=500)
+                eps = _series_episodes_cached(adapter, http, uid, sid)
                 for row in eps:
                     s = row.get("ParentIndexNumber")
                     e = row.get("IndexNumber")

--- a/providers/sync/emby/_watchlist.py
+++ b/providers/sync/emby/_watchlist.py
@@ -562,7 +562,7 @@ def _add_playlist(
             if not sid:
                 _freeze(it, reason="resolve_failed")
                 continue
-            eps = _fetch_all_series_episodes(http, uid, sid, page_size=page_size)
+            eps = _fetch_all_series_episodes(http, uid, sid, page_size=page_size) or []
             eps = [ep for ep in eps if not _is_future_episode(ep)]
             if not eps:
                 _freeze(it, reason="future_episode")

--- a/providers/sync/jellyfin/_common.py
+++ b/providers/sync/jellyfin/_common.py
@@ -798,7 +798,7 @@ def get_series_episodes(
     series_id: str,
     start: int = 0,
     limit: int = 500,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     q = {
         "userId": user_id,
         "StartIndex": max(0, int(start)),
@@ -808,8 +808,11 @@ def get_series_episodes(
     }
     r = http.get(f"/Shows/{series_id}/Episodes", params=q)
     if getattr(r, "status_code", 0) != 200:
-        return {"Items": [], "TotalRecordCount": 0}
-    data = r.json() or {}
+        return None
+    try:
+        data = r.json() or {}
+    except Exception:
+        return None
     data.setdefault("Items", [])
     data.setdefault("TotalRecordCount", len(data["Items"]))
     return data
@@ -1501,9 +1504,14 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
                 setattr(adapter, "_jellyfin_series_episodes_cache", episode_cache)
             eps_rows = episode_cache.get(str(sid))
             if eps_rows is None:
-                eps_rows = get_series_episodes(http, uid, sid, start=0, limit=10000).get("Items") or []
-                episode_cache[str(sid)] = eps_rows
-                _dbg('series_episodes_cached', series_id=str(sid), count=len(eps_rows))
+                body = get_series_episodes(http, uid, sid, start=0, limit=10000)
+                if body is None:
+                    eps_rows = []
+                    _dbg('series_episodes_fetch_failed', series_id=str(sid))
+                else:
+                    eps_rows = body.get("Items") or []
+                    episode_cache[str(sid)] = eps_rows
+                    _dbg('series_episodes_cached', series_id=str(sid), count=len(eps_rows))
             for row in eps_rows:
                 s = row.get("ParentIndexNumber")
                 e = row.get("IndexNumber")

--- a/providers/sync/plex/_common.py
+++ b/providers/sync/plex/_common.py
@@ -1312,66 +1312,107 @@ def season_rating_key_from_show(show_obj: Any, season: Any) -> str | None:
     return None
 
 
-def episode_rating_key_from_show(show_obj: Any, season: Any, episode: Any) -> str | None:
-    def _match(ep: Any) -> str | None:
-        try:
-            season_ok = season is None or getattr(ep, "parentIndex", None) == season or getattr(ep, "seasonNumber", None) == season
-            episode_ok = episode is None or getattr(ep, "index", None) == episode
-            if season_ok and episode_ok:
-                rk = getattr(ep, "ratingKey", None)
-                return str(rk) if rk else None
-        except Exception:
-            return None
-        return None
+_SHOW_EPISODE_CACHE: dict[str, dict[str, Any]] = {}
+_SHOW_EPISODE_CACHE_TTL = 300.0
+_SHOW_EPISODE_CACHE_MAX = 256
 
-    try:
-        try:
-            episodes = show_obj.episodes() or []
-        except Exception:
-            episodes = []
-        for ep in episodes:
-            rk = _match(ep)
-            if rk:
-                return rk
-    except Exception:
-        pass
 
-    try:
+def _show_episode_cache_entry(show_obj: Any) -> dict[str, Any]:
+    rk = getattr(show_obj, "ratingKey", None)
+    key = None
+    if rk:
         srv = getattr(show_obj, "_server", None) or getattr(show_obj, "server", None)
-        obj_id = getattr(show_obj, "ratingKey", None)
-        if not (srv and obj_id and hasattr(srv, "_session")):
-            return None
-
-        def _scan(path: str) -> str | None:
+        sid = getattr(srv, "machineIdentifier", None) or _as_base_url(srv) or ""
+        key = f"{sid}:{rk}"
+    now = time.monotonic()
+    if key:
+        entry = _SHOW_EPISODE_CACHE.get(key)
+        if entry is not None and (now - float(entry.get("ts") or 0.0)) <= _SHOW_EPISODE_CACHE_TTL:
+            return entry
+    entry = {"ts": now, "api": None, "children": None, "leaves": None}
+    if key:
+        for stale in [k for k, v in list(_SHOW_EPISODE_CACHE.items())
+                      if (now - float(v.get("ts") or 0.0)) > _SHOW_EPISODE_CACHE_TTL]:
+            _SHOW_EPISODE_CACHE.pop(stale, None)
+        while len(_SHOW_EPISODE_CACHE) >= _SHOW_EPISODE_CACHE_MAX:
             try:
-                resp = srv._session.get(
-                    srv.url(path),
-                    params={"X-Plex-Container-Start": 0, "X-Plex-Container-Size": 5000},
-                    timeout=12,
-                )
-                if not resp.ok:
-                    return None
-                root = ET.fromstring(resp.text or "")
-                for ep in root.findall(".//Video"):
-                    try:
-                        season_ok = season is None or int(ep.attrib.get("parentIndex", "0") or "0") == int(season)
-                        episode_ok = episode is None or int(ep.attrib.get("index", "0") or "0") == int(episode)
-                        if season_ok and episode_ok:
-                            rk = ep.attrib.get("ratingKey")
-                            if rk:
-                                return str(rk)
-                    except Exception:
-                        continue
-            except Exception:
-                return None
-            return None
+                _SHOW_EPISODE_CACHE.pop(next(iter(_SHOW_EPISODE_CACHE)))
+            except StopIteration:
+                break
+        _SHOW_EPISODE_CACHE[key] = entry
+    return entry
 
-        rk = _scan(f"/library/metadata/{obj_id}/children")
-        if rk:
+
+def episode_rating_key_from_show(show_obj: Any, season: Any, episode: Any) -> str | None:
+    entry = _show_episode_cache_entry(show_obj)
+
+    api_rows: list[tuple[Any, Any, Any, str]] | None = entry["api"]
+    if api_rows is None:
+        rows: list[tuple[Any, Any, Any, str]] = []
+        try:
+            for ep in (show_obj.episodes() or []):
+                try:
+                    rk = getattr(ep, "ratingKey", None)
+                    if rk:
+                        rows.append((
+                            getattr(ep, "parentIndex", None),
+                            getattr(ep, "seasonNumber", None),
+                            getattr(ep, "index", None),
+                            str(rk),
+                        ))
+                except Exception:
+                    continue
+        except Exception:
+            rows = []
+        else:
+            entry["api"] = rows
+        api_rows = rows
+
+    for parent_index, season_number, index, rk in api_rows:
+        season_ok = season is None or parent_index == season or season_number == season
+        episode_ok = episode is None or index == episode
+        if season_ok and episode_ok:
             return rk
-        return _scan(f"/library/metadata/{obj_id}/allLeaves")
-    except Exception:
+
+    srv = getattr(show_obj, "_server", None) or getattr(show_obj, "server", None)
+    obj_id = getattr(show_obj, "ratingKey", None)
+    if not (srv and obj_id and hasattr(srv, "_session")):
         return None
+
+    def _rows(path: str) -> list[tuple[str, str, str]] | None:
+        out: list[tuple[str, str, str]] = []
+        try:
+            resp = srv._session.get(
+                srv.url(path),
+                params={"X-Plex-Container-Start": 0, "X-Plex-Container-Size": 5000},
+                timeout=12,
+            )
+            if not resp.ok:
+                return None
+            root = ET.fromstring(resp.text or "")
+            for ep in root.findall(".//Video"):
+                rk = ep.attrib.get("ratingKey")
+                if rk:
+                    out.append((ep.attrib.get("parentIndex", "0") or "0", ep.attrib.get("index", "0") or "0", str(rk)))
+        except Exception:
+            return None
+        return out
+
+    for source, path in (("children", f"/library/metadata/{obj_id}/children"), ("leaves", f"/library/metadata/{obj_id}/allLeaves")):
+        cached = entry[source]
+        if cached is None:
+            cached = _rows(path)
+            if cached is not None:
+                entry[source] = cached
+        for parent_index, index, rk in (cached or ()):
+            try:
+                season_ok = season is None or int(parent_index) == int(season)
+                episode_ok = episode is None or int(index) == int(episode)
+            except Exception:
+                continue
+            if season_ok and episode_ok:
+                return rk
+    return None
 
 def _iso8601_any(v: Any) -> str | None:
     try:


### PR DESCRIPTION
# Pull request

## Change

- Cache a show's episode list per rating key in Plex, with expiry and a 256 entry cap.
- Cache a series' episode list per sync operation in Emby.
- Stop caching failed episode fetches in Plex, Emby and Jellyfin.
- Return failure instead of a truncated list when Emby paging dies partway.

## Why

Episode resolution runs once per item, so syncing a season refetched the same show's full episode list 20 times. 
Plex and Jellyfin also cached empty results on HTTP errors, which meant one bad response made the rest of that show unresolvable until the cache expired. Jellyfin already had the cache, it just cached failures too.

The Plex cache is module level so it needed the cap. 
Emby and Jellyfin hang theirs off the adapter, which is rebuilt per operation, so those clean themselves up.

## Testing

existing test scripts for plex,jellyfin and emby
scripts are not changed.

## Issue

NA
