### PR TITLE
Change: auth setup recoverable after factory reset

### DIFF
--- a/api/appAuthAPI.py
+++ b/api/appAuthAPI.py
@@ -321,7 +321,7 @@ def _config_needs_upgrade(cfg: dict[str, Any]) -> bool:
 def setup_lock_required(cfg: dict[str, Any]) -> bool:
     if reset_pending(cfg):
         return True
-    return not auth_required(cfg)
+    return (not auth_required(cfg)) and _config_needs_upgrade(cfg)
 
 
 def _find_session(a: dict[str, Any], token: str | None) -> dict[str, Any] | None:

--- a/assets/crosswatch.js
+++ b/assets/crosswatch.js
@@ -429,6 +429,7 @@ function _cwHasConfiguredValue(v) {
 
 async function _cwShouldOpenSetupWizard(meta) {
   try {
+    if (_cwForceSetupRequested()) return true;
     if ((!meta?.exists) || !!meta?.first_run || !!meta?.autogen) return true;
     if (!!meta?.needs_upgrade) return false;
     if (typeof meta?.setup_wizard_required === "boolean") return meta.setup_wizard_required;
@@ -442,6 +443,16 @@ async function _cwShouldOpenSetupWizard(meta) {
     return _cwConfigLooksLikeFirstRun(cfg);
   } catch (e) {
     console.warn("[crosswatch] setup wizard config check failed", e);
+    return false;
+  }
+}
+
+function _cwForceSetupRequested() {
+  try {
+    const q = new URLSearchParams(window.location.search || "");
+    const raw = String(q.get("setup") || q.get("first_setup") || q.get("auth_setup") || "").trim().toLowerCase();
+    return raw === "1" || raw === "true" || raw === "yes";
+  } catch {
     return false;
   }
 }
@@ -481,8 +492,9 @@ window.cwIsAuthSetupPending = () => window.__cwAuthSetupPending === true;
     (async () => {
       try {
         const boot = await (window.__cwAuthBootstrapPromise || Promise.resolve(null));
-        const meta = boot?.meta || null;
-        if (!meta) return;
+        const forceSetup = _cwForceSetupRequested();
+        const meta = boot?.meta || {};
+        if (!boot?.meta && !forceSetup) return;
 
         async function ensureModals() {
           if (typeof window.openUpgradeWarning === "function" || typeof window.openSetupWizard === "function") return true;
@@ -499,7 +511,16 @@ window.cwIsAuthSetupPending = () => window.__cwAuthSetupPending === true;
         const firstRun = await _cwShouldOpenSetupWizard(meta);
 
         if (firstRun) {
-          if (await ensureModals()) { try { await window.openSetupWizard?.(meta); } catch (e) { console.warn(e); } }
+          if (await ensureModals()) {
+            try {
+              await window.openSetupWizard?.({
+                ...meta,
+                auth_setup_required: true,
+                setup_wizard_required: true,
+                auth_reset_required: !!(meta?.auth_reset_required || boot?.status?.reset_required),
+              });
+            } catch (e) { console.warn(e); }
+          }
           return;
         }
 


### PR DESCRIPTION
# Pull request

## Change

Adds a `?setup=1` escape hatch to force the first-time setup wizard.

Also keeps the auth setup lock limited to reset/upgrade cases.

## Why

After factory reset, CW could land on the main page without a configured login, leaving the UI loaded but unusable.

## Testing

NA

## Issue

Relates to #648