### PR TITLE
Fix: MDBList unresolved episode reporting

### DIFF
--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -733,6 +733,8 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
         errors = _merge_total("errors")
         blocked = _merge_total("blocked")
         extra = f", Total blocked: {blocked}"
+        for key, value in (("skipped", skipped), ("unresolved", unresolved), ("errors", errors), ("blocked", blocked)):
+            _summary_set(key, value)
 
         _sync_progress_ui(
             f"[i] Done. Total added: {added}, Total removed: {removed}, Total updated: {updated}, "
@@ -743,7 +745,8 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
                 _emit_unresolved_details(unresolved)
             except Exception:
                 pass
-        _sync_progress_ui("[SYNC] exit code: 0")
+        final_exit_code = 1 if unresolved > 0 or errors > 0 else 0
+        _sync_progress_ui(f"[SYNC] exit code: {final_exit_code}")
     except Exception as e:
         _sync_progress_ui(f"[!] Sync error: {e}")
         _sync_progress_ui("[SYNC] exit code: 1")
@@ -764,7 +767,10 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
             snap = _summary_snapshot()
             exit_code = snap.get("exit_code")
             if exit_code is not None:
-                event = "success" if int(exit_code) == 0 else "failure"
+                unresolved_count = int(snap.get("unresolved") or 0)
+                errors_count = int(snap.get("errors") or 0)
+                is_clean = int(exit_code) == 0 and unresolved_count == 0 and errors_count == 0
+                event = "success" if is_clean else "failure"
                 notify_scheduler_webhook(
                     scheduler_webhook_cfg,
                     event,

--- a/cw_platform/orchestrator/_applier.py
+++ b/cw_platform/orchestrator/_applier.py
@@ -253,6 +253,16 @@ def _normalize(
         unresolved_keys = [k for k in unresolved_keys if k and (k not in seen and not seen.add(k))]
 
     unresolved = len(unresolved_list) if isinstance(unresolved_list, list) else int(unresolved_list or 0)
+    if unresolved_keys:
+        unresolved_key_set = set(unresolved_keys)
+        if ckeys:
+            ckeys = [k for k in ckeys if k not in unresolved_key_set]
+            confirmed = len(ckeys)
+        elif unresolved > 0:
+            confirmed = min(int(confirmed), max(0, attempted - unresolved))
+    elif unresolved > 0 and not ckeys:
+        confirmed = min(int(confirmed), max(0, attempted - unresolved))
+
     errors = int(res.get("errors") or 0)
     skipped_reported_raw = res.get("skipped")
     skipped_exact = len(skeys)

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -89,7 +89,9 @@ def compute_effective_add(
     verify_after_write,
     provider_skipped,
 ) -> dict[str, Any]:
-    conf = list(confirmed_keys or [])
+    unres = set(still_unresolved or set())
+    skset = set(skipped_keys or set())
+    conf = [k for k in (confirmed_keys or []) if k not in unres and k not in skset]
     pc = int(prov_confirmed or 0)
     if have_exact_keys:
         pc = min(pc or len(conf), len(conf))
@@ -99,7 +101,6 @@ def compute_effective_add(
         eff = 0
     else:
         eff = len(conf) if (verify_after_write or have_exact_keys) else min(pc, len(conf))
-    skset = set(skipped_keys or set())
     skipped_success = [k for k in (attempted_keys or []) if k in skset]
     success_keys = conf if (verify_after_write or have_exact_keys) else conf[:eff]
     success_keys = list(dict.fromkeys(list(success_keys) + skipped_success))
@@ -1656,6 +1657,7 @@ def run_one_way_feature(
             )
             prov_confirmed = _decision["prov_confirmed"]
             added_effective = _decision["effective"]
+            added_provider_reported = prov_confirmed
             ambiguous_partial = _decision["ambiguous_partial"]
             success_keys = _decision["success_keys"]
             failed_keys = _decision["failed_keys"]

--- a/providers/scrobble/mdblist/sink.py
+++ b/providers/scrobble/mdblist/sink.py
@@ -773,6 +773,7 @@ class MDBListSink(ScrobbleSink):
             bodies = [b0] + [b for b in bodies if _body_ids_desc(b) != best_desc]
 
         sent_ok = False
+        last_err: dict[str, Any] | None = None
         for i, body in enumerate(bodies):
             if not (best_skel is not None and i == 0):
                 intent_prog = int(float(body.get("progress") or p_send))
@@ -781,6 +782,7 @@ class MDBListSink(ScrobbleSink):
 
             res = self._send_http(path, body, api_key, cfg)
             if not res.get("ok"):
+                last_err = dict(res)
                 _log(f"{path} failed for {name}: {res}", "WARN")
                 continue
 
@@ -821,4 +823,5 @@ class MDBListSink(ScrobbleSink):
             _auto_remove_across(ev, cfg, scope=f"mdblist:{self._instance_id}")
             self._completed[done_key] = p_send
         elif not sent_ok and action in ("start", "stop"):
-            self._note_watch(ev, action, cfg, p_send, status="fail")
+            reason = str((last_err or {}).get("status") or (last_err or {}).get("error") or "")
+            self._note_watch(ev, action, cfg, p_send, status="fail", reason=reason or None)

--- a/providers/sync/_mod_MDBLIST.py
+++ b/providers/sync/_mod_MDBLIST.py
@@ -24,6 +24,36 @@ from ._mod_common import (
 )
 
 
+def _unresolved_keys(key_of, unresolved: Any) -> list[str]:
+    keys: list[str] = []
+    seen: set[str] = set()
+
+    def add(value: Any) -> None:
+        key = str(value or "").strip()
+        if key and key not in seen:
+            seen.add(key)
+            keys.append(key)
+
+    if unresolved:
+        for u in unresolved:
+            obj: Any = u
+            if isinstance(u, Mapping):
+                add(u.get("key"))
+                if isinstance(u.get("unresolved_key"), str):
+                    add(u.get("unresolved_key"))
+                if "item" in u:
+                    obj = u.get("item")
+            if isinstance(obj, str) and obj:
+                add(obj)
+                continue
+            if isinstance(obj, Mapping):
+                try:
+                    add(key_of(obj))
+                except Exception:
+                    pass
+    return keys
+
+
 def _confirmed_keys(key_of, items: Iterable[Mapping[str, Any]], unresolved: Any) -> list[str]:
     attempted: list[str] = []
     for it in items or []:
@@ -34,34 +64,37 @@ def _confirmed_keys(key_of, items: Iterable[Mapping[str, Any]], unresolved: Any)
         if k:
             attempted.append(k)
 
-    unresolved_keys: set[str] = set()
-    if unresolved:
-        for u in unresolved:
-            obj: Any = u
-            if isinstance(u, Mapping):
-                if isinstance(u.get("key"), str) and u.get("key"):
-                    unresolved_keys.add(str(u.get("key")))
-                    continue
-                if "item" in u:
-                    obj = u.get("item")
-            if isinstance(obj, str) and obj:
-                unresolved_keys.add(obj)
-                continue
-            if isinstance(obj, Mapping):
-                try:
-                    k = str(key_of(obj) or "").strip()
-                except Exception:
-                    k = ""
-                if k:
-                    unresolved_keys.add(k)
+    unresolved_key_set = set(_unresolved_keys(key_of, unresolved))
 
     out: list[str] = []
     seen: set[str] = set()
     for k in attempted:
-        if k in unresolved_keys or k in seen:
+        if k in unresolved_key_set or k in seen:
             continue
         out.append(k)
         seen.add(k)
+    return out
+
+
+def _write_result(raw: Any, items: list[Mapping[str, Any]]) -> dict[str, Any]:
+    if isinstance(raw, Mapping):
+        out = dict(raw)
+        out.setdefault("ok", True)
+        out.setdefault("unresolved", [])
+    else:
+        _cnt, unresolved = raw
+        out = {"ok": True, "unresolved": unresolved}
+
+    unresolved_keys = _unresolved_keys(_mdblist_key_of, out.get("unresolved") or [])
+    confirmed_keys = (
+        [str(x) for x in (out.get("confirmed_keys") or []) if x]
+        if isinstance(out.get("confirmed_keys"), list)
+        else _confirmed_keys(_mdblist_key_of, items, out.get("unresolved") or [])
+    )
+    unresolved_set = set(unresolved_keys)
+    out["unresolved_keys"] = unresolved_keys
+    out["confirmed_keys"] = [k for k in confirmed_keys if k not in unresolved_set]
+    out["count"] = len(out["confirmed_keys"])
     return out
 
 def _mdblist_key_of(obj: Any) -> str:
@@ -101,7 +134,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.4"
+__VERSION__ = "1.5"
 __all__ = ["get_manifest", "MDBLISTModule", "OPS"]
 
 def _health(status: str, ok: bool, latency_ms: int) -> None:
@@ -711,19 +744,7 @@ class MDBLISTModule:
             return {"ok": True, "count": 0, "unresolved": []}
         try:
             raw = mod.add(self, lst)
-            if isinstance(raw, Mapping):
-                out = dict(raw)
-                out.setdefault("ok", True)
-                out.setdefault("unresolved", [])
-                out.setdefault("confirmed_keys", [])
-                if isinstance(out.get("confirmed_keys"), list):
-                    out["count"] = len([x for x in out.get("confirmed_keys") or [] if x])
-                else:
-                    out.setdefault("count", int(out.get("count", 0) or 0))
-                return out
-            cnt, unresolved = raw
-            confirmed_keys = _confirmed_keys(_mdblist_key_of, lst, unresolved)
-            return {"ok": True, "count": int(cnt), "unresolved": unresolved, "confirmed_keys": confirmed_keys}
+            return _write_result(raw, lst)
         except Exception as e:
             return {"ok": False, "error": str(e)}
 
@@ -748,19 +769,7 @@ class MDBLISTModule:
             return {"ok": True, "count": 0, "unresolved": []}
         try:
             raw = mod.remove(self, lst)
-            if isinstance(raw, Mapping):
-                out = dict(raw)
-                out.setdefault("ok", True)
-                out.setdefault("unresolved", [])
-                out.setdefault("confirmed_keys", [])
-                if isinstance(out.get("confirmed_keys"), list):
-                    out["count"] = len([x for x in out.get("confirmed_keys") or [] if x])
-                else:
-                    out.setdefault("count", int(out.get("count", 0) or 0))
-                return out
-            cnt, unresolved = raw
-            confirmed_keys = _confirmed_keys(_mdblist_key_of, lst, unresolved)
-            return {"ok": True, "count": int(cnt), "unresolved": unresolved, "confirmed_keys": confirmed_keys}
+            return _write_result(raw, lst)
         except Exception as e:
             return {"ok": False, "error": str(e)}
 

--- a/providers/sync/mdblist/_history.py
+++ b/providers/sync/mdblist/_history.py
@@ -911,6 +911,66 @@ def _stable_show_key(ids: Mapping[str, Any]) -> str:
     return json.dumps(keep, sort_keys=True)
 
 
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except Exception:
+        return None
+
+
+def _unresolved_entry(item: Mapping[str, Any], hint: str) -> dict[str, Any]:
+    minimal_item = id_minimal(item)
+    entry: dict[str, Any] = {"item": minimal_item, "hint": hint}
+    try:
+        key = str(canonical_key(minimal_item) or "").strip()
+    except Exception:
+        key = ""
+    if key:
+        entry["key"] = key
+    return entry
+
+
+def _items_for_not_found(row: Mapping[str, Any], kind: str) -> list[dict[str, Any]]:
+    ids = row.get("ids") if isinstance(row.get("ids"), Mapping) else {}
+    item_type = kind[:-1]
+    if kind != "shows":
+        return [{"type": item_type, "ids": dict(ids or {})}]
+
+    seasons = row.get("seasons")
+    if not isinstance(seasons, list) or not seasons:
+        return [{"type": "show", "ids": dict(ids or {})}]
+
+    out: list[dict[str, Any]] = []
+    for season in seasons:
+        if not isinstance(season, Mapping):
+            continue
+        season_number = _as_int(season.get("number"))
+        episodes = season.get("episodes")
+        if isinstance(episodes, list) and episodes:
+            for episode in episodes:
+                if not isinstance(episode, Mapping):
+                    continue
+                out.append(
+                    {
+                        "type": "episode",
+                        "ids": dict(ids or {}),
+                        "show_ids": dict(ids or {}),
+                        "season": season_number,
+                        "episode": _as_int(episode.get("number")),
+                    }
+                )
+        else:
+            out.append(
+                {
+                    "type": "season",
+                    "ids": dict(ids or {}),
+                    "show_ids": dict(ids or {}),
+                    "season": season_number,
+                }
+            )
+    return out or [{"type": "show", "ids": dict(ids or {})}]
+
+
 def _bucketize(items: Iterable[Mapping[str, Any]], *, unwatch: bool) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     movies: list[dict[str, Any]] = []
     shows_nested: dict[str, dict[str, Any]] = {}
@@ -1155,8 +1215,8 @@ def _write(
             for row_nf in rows_nf:
                 if not isinstance(row_nf, Mapping):
                     continue
-                ids_nf = row_nf.get("ids") or {}
-                unresolved.append({"item": id_minimal({"type": item_type, "ids": ids_nf}), "hint": "not_found"})
+                for item_nf in _items_for_not_found(row_nf, kind):
+                    unresolved.append(_unresolved_entry(item_nf, "not_found"))
 
         updated = data.get("updated") or {}
         added = data.get("added") or {}
@@ -1287,12 +1347,7 @@ def _write(
                             continue
 
                         ids2 = single.get("ids") or {}
-                        unresolved.append(
-                            {
-                                "item": id_minimal({"type": "show", "ids": ids2}),
-                                "hint": f"http:{r2.status_code}",
-                            }
-                        )
+                        unresolved.append(_unresolved_entry({"type": "show", "ids": ids2}, f"http:{r2.status_code}"))
                     break
 
                 _warn(
@@ -1306,7 +1361,11 @@ def _write(
                 for x in part:
                     ids = x.get("ids") or {}
                     t = "show" if bucket == "shows" else "movie"
-                    unresolved.append({"item": id_minimal({"type": t, "ids": ids}), "hint": f"http:{r.status_code}"})
+                    if bucket == "shows":
+                        for item_nf in _items_for_not_found(x, "shows"):
+                            unresolved.append(_unresolved_entry(item_nf, f"http:{r.status_code}"))
+                    else:
+                        unresolved.append(_unresolved_entry({"type": t, "ids": ids}, f"http:{r.status_code}"))
                 break
 
     if ok > 0 and not unresolved:

--- a/tests/test_history_specials.py
+++ b/tests/test_history_specials.py
@@ -7,7 +7,8 @@ from types import SimpleNamespace
 from cw_platform.id_map import canonical_key, minimal
 from cw_platform.orchestrator import _applier, _unresolved
 from cw_platform.orchestrator._pairs_oneway import compute_effective_add
-from providers.sync.mdblist._history import _bucketize
+from providers.sync.mdblist._history import _bucketize, _items_for_not_found
+from providers.sync import _mod_MDBLIST as mdblist_mod
 from providers.sync.publicmetadb._history import _payload_for_item, _to_minimal
 from providers.sync._mod_SIMKL import _confirmed_keys
 from providers.sync.simkl import _history as simkl_history
@@ -95,6 +96,42 @@ def test_mdblist_groups_multiple_specials_under_one_season() -> None:
         }
     ]
     assert len(accepted) == 2
+
+
+def test_mdblist_not_found_keeps_episode_unresolved_key(monkeypatch) -> None:
+    monkeypatch.setattr(_applier, "record_unresolved", lambda *a, **k: {"ok": True})
+    item = {
+        "type": "episode",
+        "title": "Episode 1",
+        "series_title": "Japanology Plus",
+        "ids": {"tmdb": "1359983"},
+        "show_ids": {"tmdb": "73679"},
+        "season": 2014,
+        "episode": 1,
+        "watched_at": WATCHED_AT,
+    }
+    attempted_key = canonical_key(item)
+    row = {"ids": {"tmdb": 73679}, "seasons": [{"number": 2014, "episodes": [{"number": 1}]}]}
+
+    matches = _items_for_not_found(row, "shows")
+    unresolved = [{"item": minimal(matches[0]), "hint": "not_found", "key": attempted_key}]
+    confirmed = mdblist_mod._confirmed_keys(mdblist_mod._mdblist_key_of, [item], unresolved)
+
+    assert [canonical_key(match) for match in matches] == [attempted_key]
+    assert confirmed == []
+
+    norm = _applier._normalize(
+        {"ok": True, "count": 1, "unresolved": unresolved, "unresolved_keys": [attempted_key]},
+        [item],
+        "apply:add",
+        dst="MDBLIST",
+        feature="history",
+        emit=lambda *a, **k: None,
+    )
+
+    assert norm["confirmed"] == 0
+    assert norm["unresolved"] == 1
+    assert norm["unresolved_keys"] == [attempted_key]
 
 
 def test_trakt_special_episode_add_and_remove_shapes() -> None:

--- a/tests/test_scheduler_webhooks.py
+++ b/tests/test_scheduler_webhooks.py
@@ -498,6 +498,81 @@ def test_scheduled_sync_thread_dispatches_start_and_success_webhooks(monkeypatch
     assert calls[1][2]["added_last"] == 2
 
 
+def test_scheduled_sync_thread_dispatches_failure_webhook_on_unresolved(monkeypatch, tmp_path) -> None:
+    import api.syncAPI as sync
+    import sys
+
+    log_buffers: dict[str, list[str]] = {"SYNC": []}
+
+    def append_log(kind: str, message: str) -> None:
+        log_buffers.setdefault(kind, []).append(str(message))
+
+    fake_crosswatch = types.SimpleNamespace(
+        LOG_BUFFERS=log_buffers,
+        RUNNING_PROCS={"SYNC": object()},
+        SYNC_PROC_LOCK=threading.Lock(),
+        STATS=types.SimpleNamespace(refresh_from_state=lambda _state: None, record_summary=lambda *_args: None),
+        REPORT_DIR=tmp_path,
+        strip_ansi=lambda value: str(value),
+        _append_log=append_log,
+        minimal=lambda value: value,
+        canonical_key=lambda value: str(value),
+    )
+    monkeypatch.setitem(sys.modules, "crosswatch", fake_crosswatch)
+
+    cfg = {
+        "pairs": [{"id": "plex-mdblist", "enabled": True, "source": "PLEX", "target": "MDBLIST"}],
+        "scheduling": {
+            "webhooks": {
+                "enabled": True,
+                "base_url": "https://hc-ping.com/abc123",
+            }
+        },
+    }
+    monkeypatch.setattr(sync, "_env", lambda: (lambda: cfg, lambda _cfg: None))
+    monkeypatch.setattr(sync, "_load_state", lambda: None)
+    monkeypatch.setattr(sync, "_counts_from_state", lambda _state: None)
+    monkeypatch.setattr(sync, "_provider_count_defaults", lambda: {})
+
+    class UnresolvedOrchestrator:
+        def __init__(self, config: dict[str, Any]) -> None:
+            self.config = config
+
+        def run_pairs(self, **kwargs: Any) -> dict[str, int]:
+            progress = kwargs["progress"]
+            progress('{"event":"apply:add:done","feature":"history","attempted":1,"added":0,"unresolved":1,"errors":0}')
+            return {"added": 0, "removed": 0, "updated": 0, "unresolved": 1, "errors": 0}
+
+    fake_orchestrator_module = types.SimpleNamespace(Orchestrator=UnresolvedOrchestrator, __file__="fake-orchestrator.py")
+    monkeypatch.setattr(
+        sync.importlib,
+        "import_module",
+        lambda name: fake_orchestrator_module if name == "cw_platform.orchestrator" else __import__(name),
+    )
+
+    calls: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+
+    def fake_notify(cfg_arg: dict[str, Any] | None, event: str, context: dict[str, Any] | None, summary: dict[str, Any] | None = None, **_kwargs: Any) -> bool:
+        calls.append((event, dict(context or {}), dict(summary or {})))
+        return True
+
+    monkeypatch.setattr(sync, "notify_scheduler_webhook", fake_notify)
+
+    sync._run_pairs_thread(
+        "run-unresolved",
+        {
+            "source": "scheduler",
+            "scheduler_mode": "advanced",
+            "job_id": "job-mdblist",
+            "pair_id": "plex-mdblist",
+        },
+    )
+
+    assert [event for event, _, _ in calls] == ["start", "failure"]
+    assert calls[1][2]["exit_code"] == 1
+    assert calls[1][2]["unresolved"] == 1
+
+
 def test_scheduled_sync_thread_dispatches_failure_webhook_on_exception(monkeypatch, tmp_path) -> None:
     import api.syncAPI as sync
     import sys


### PR DESCRIPTION
# Pull request

## Change

MDBList sync now reports episodes rejected by MDBList as unresolved instead of counting them as successfully added.

## Why

MDBList can reject episodes when the season/episode numbering does not exist on their side

## Testing
- test_history_specials.py::test_mdblist_not_found_keeps_episode_unresolved_key
- test_mdblist_groups_multiple_specials_under_one_season 
- test_applier_prefers_provider_unresolved_keys 
- test_history_specials.py::test_exact_skipped_add_keys_count_as_success_without_added_count
- test_scheduler_webhooks.py::test_scheduled_sync_thread_dispatches_failure_webhook_on_unresolved 
- test_scheduler_webhooks.py::test_scheduled_sync_thread_dispatches_start_and_success_webhooks tests/test_kodi_watch.py

## Issue

Relates to #654