### PR TITLE
Fix: PUBLICMETADB ratings 409 conflict handling

### DIFF
--- a/providers/sync/_mod_PUBLICMETADB.py
+++ b/providers/sync/_mod_PUBLICMETADB.py
@@ -365,7 +365,20 @@ class PUBLICMETADBModule:
             cnt, unresolved = feat_ratings.add(self, lst)
         else:
             cnt, unresolved = feat_watchlist.add(self, lst)
-        return {"ok": True, "count": int(cnt), "unresolved": unresolved, "confirmed_keys": _confirmed_keys(lst, unresolved)}
+        skipped_keys = (
+            [str(k) for k in getattr(self, "_publicmetadb_rating_skipped_keys", []) if k]
+            if feature == "ratings"
+            else []
+        )
+        skipped_set = set(skipped_keys)
+        confirmed_keys = [k for k in _confirmed_keys(lst, unresolved) if k not in skipped_set]
+        return {
+            "ok": True,
+            "count": int(cnt),
+            "unresolved": unresolved,
+            "confirmed_keys": confirmed_keys,
+            "skipped_keys": skipped_keys,
+        }
 
     def remove(self, feature: str, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
         lst = list(items or [])

--- a/providers/sync/publicmetadb/_ratings.py
+++ b/providers/sync/publicmetadb/_ratings.py
@@ -336,11 +336,28 @@ def _payload_for_item(adapter: Any, item: Mapping[str, Any]) -> tuple[str | None
     )
 
 
+def _accept_remote_item(
+    item: Mapping[str, Any],
+    mini: Mapping[str, Any],
+    label: str | None,
+    fallback: Any,
+) -> tuple[str, dict[str, Any]]:
+    rid = str(item.get("id") or item.get("rating_id") or "").strip()
+    accepted = dict(mini)
+    accepted["rating"] = _response_rating(item, fallback)
+    accepted["label"] = label or "Overall"
+    if rid:
+        accepted["rating_id"] = rid
+        accepted["_publicmetadb_rating_id"] = rid
+    return rid, accepted
+
+
 def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
     items_list = list(items or [])
     shadow = _shadow_load()
     remote_ids: dict[str, Any] = dict(shadow.get("items") or {})
     unresolved: list[dict[str, Any]] = []
+    skipped_keys: list[str] = []
     ok = 0
 
     for it in items_list:
@@ -373,22 +390,48 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         if 200 <= r.status_code < 300:
             data = adapter.client.safe_json(r)
             item = data.get("item") if isinstance(data, Mapping) else None
-            rid = str(item.get("id") or "").strip() if isinstance(item, Mapping) else ""
-            accepted = dict(mini)
-            accepted["rating"] = _response_rating(
-                item,
+            rid, accepted = _accept_remote_item(
+                item if isinstance(item, Mapping) else {},
+                mini,
+                label,
                 mini.get("rating") if "rating" in mini else it.get("rating"),
             )
-            accepted["label"] = label or "Overall"
-            if rid:
-                accepted["rating_id"] = rid
-                accepted["_publicmetadb_rating_id"] = rid
             remote_ids[key] = {"id": rid, "label": label or "Overall", "item": accepted}
             ok += 1
+        elif r.status_code == 409:
+            lookup_item = dict(mini)
+            lookup_item["label"] = label or "Overall"
+            lookup_path, lookup_params = _remote_lookup_params(lookup_item)
+            found = None
+            if lookup_path and lookup_params:
+                data = adapter.client.get_json(lookup_path, params=lookup_params)
+                want = _response_rating(payload, payload.get("score"))
+                for row in _rows(data):
+                    if not isinstance(row, Mapping):
+                        continue
+                    if _response_rating(row, None) == want:
+                        found = row
+                        break
+            if isinstance(found, Mapping):
+                rid, accepted = _accept_remote_item(
+                    found,
+                    mini,
+                    label,
+                    mini.get("rating") if "rating" in mini else it.get("rating"),
+                )
+                remote_ids[key] = {"id": rid, "label": label or "Overall", "item": accepted}
+                skipped_keys.append(canonical_key(mini))
+            else:
+                _warn("write_failed", op="add_conflict", status=r.status_code, body=(r.text or "")[:200])
+                unresolved.append({"item": mini, "hint": "http:409"})
         else:
             _warn("write_failed", op="add", status=r.status_code, body=(r.text or "")[:200])
             unresolved.append({"item": mini, "hint": f"http:{r.status_code}"})
     _shadow_save(remote_ids)
+    try:
+        adapter._publicmetadb_rating_skipped_keys = skipped_keys
+    except Exception:
+        pass
     _info("write_done", op="add", applied=ok, unresolved=len(unresolved))
     return ok, unresolved
 

--- a/providers/tests/test_publicmetadb_ratings.py
+++ b/providers/tests/test_publicmetadb_ratings.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from providers.sync._mod_PUBLICMETADB import PUBLICMETADBModule
 from providers.sync.publicmetadb import _ratings
 
 
@@ -32,7 +33,9 @@ class FakeClient:
 
     def post_once(self, path: str, **kw: Any) -> FakeResp:
         self.calls.append({"method": "POST", "path": path, "json": kw.get("json")})
-        return FakeResp(200, self.responses.get(("POST", path), {"item": {"id": "new-rating", "score": 50}}))
+        payload = self.responses.get(("POST", path), {"item": {"id": "new-rating", "score": 50}})
+        status = int(payload.get("status", 200)) if isinstance(payload, dict) else 200
+        return FakeResp(status, payload)
 
     def delete(self, path: str, **kw: Any) -> FakeResp:
         self.calls.append({"method": "DELETE", "path": path, "json": kw.get("json")})
@@ -145,3 +148,69 @@ def test_add_recreates_when_existing_shadow_rating_id_is_already_missing(monkeyp
         ("DELETE", "/api/external/ratings/rating-gone"),
         ("POST", "/api/external/ratings"),
     ]
+
+
+def test_add_treats_matching_409_conflict_as_existing_rating(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(_ratings, "state_file", lambda name: tmp_path / name)
+    client = FakeClient(
+        {
+            ("POST", "/api/external/ratings"): {"status": 409, "error": "already_exists"},
+            ("GET", "/api/external/ratings"): {
+                "items": [
+                    {
+                        "id": "rating-existing",
+                        "tmdb_id": 550,
+                        "media_type": "movie",
+                        "score": 50,
+                        "label": "Overall",
+                    }
+                ]
+            },
+        }
+    )
+
+    adapter = FakeAdapter(client)
+    count, unresolved = _ratings.add(
+        adapter,
+        [{"type": "movie", "ids": {"tmdb": "550"}, "rating": 5, "label": "Overall"}],
+    )
+
+    assert count == 0
+    assert unresolved == []
+    assert adapter._publicmetadb_rating_skipped_keys == ["tmdb:550"]
+    assert [(c["method"], c["path"]) for c in client.calls] == [
+        ("POST", "/api/external/ratings"),
+        ("GET", "/api/external/ratings"),
+    ]
+    index = _ratings.build_index(FakeAdapter(FakeClient()))
+    assert index["tmdb:550#rating:overall"]["rating_id"] == "rating-existing"
+
+
+def test_module_reports_matching_409_conflict_as_skipped(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(_ratings, "state_file", lambda name: tmp_path / name)
+    mod = PUBLICMETADBModule.__new__(PUBLICMETADBModule)
+    mod.cfg = FakeCfg()
+    mod.client = FakeClient(
+        {
+            ("POST", "/api/external/ratings"): {"status": 409, "error": "already_exists"},
+            ("GET", "/api/external/ratings"): {
+                "items": [
+                    {
+                        "id": "rating-existing",
+                        "tmdb_id": 550,
+                        "media_type": "movie",
+                        "score": 50,
+                        "label": "Overall",
+                    }
+                ]
+            },
+        }
+    )
+    mod.config = {"publicmetadb": {"api_key": "k", "ratings_label": "Overall"}}
+
+    res = mod.add("ratings", [{"type": "movie", "ids": {"tmdb": "550"}, "rating": 5, "label": "Overall"}])
+
+    assert res["count"] == 0
+    assert res["confirmed_keys"] == []
+    assert res["skipped_keys"] == ["tmdb:550"]
+    assert res["unresolved"] == []


### PR DESCRIPTION
# Pull request

## Change

- Treat a 409 on rating add as an existing rating when the remote score matches what we posted, and adopt it into the shadow.
- Report those as skipped_keys instead of unresolved, and drop them from confirmed_keys.
- Keep non-matching 409s unresolved.

## Why

PUBLICMETADB returns 409 when a rating is already there. 
CW counted that as unresolved, so every run retried the same rating and it never settled. 
A 409 with the same score means the rating is already correct, so it's a skip, not a failure.

## Testing

- test_publicmetadb_ratings.py

## Issue

Relates to #661
