### PR TITLE
Fix: plex libs and server with multiple servers

### DIFF
--- a/api/authenticationAPI.py
+++ b/api/authenticationAPI.py
@@ -57,7 +57,12 @@ def _apply_media_overrides(cfg: Any, provider: str, inst: str, server: str | Non
     block = ensure_instance_block(cfg, provider, inst)
     s = str(server or "").strip()
     if s:
-        block["server_url" if provider == "plex" else "server"] = s
+        key = "server_url" if provider == "plex" else "server"
+        if provider == "plex" and plex_utils._norm_base(s) != plex_utils._norm_base(block.get(key)):
+            block.pop("pms_token", None)
+            block.pop("pms_token_server", None)
+            block.pop("machine_id", None)
+        block[key] = s
     if verify_ssl is not None:
         block["verify_ssl"] = coerce_bool(verify_ssl)
     return block
@@ -594,9 +599,11 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
     def plex_libraries(instance: str | None = Query(None), server: str | None = Query(None), verify_ssl: bool | None = Query(None)) -> dict[str, Any]:
         inst = normalize_instance_id(instance)
         cfg = load_config()
+        override = bool(str(server or "").strip())
         _apply_media_overrides(cfg, "plex", inst, server, verify_ssl)
-        ensure_whitelist_defaults(cfg, instance_id=inst)
-        return {"libraries": fetch_libraries_from_cfg(cfg, instance_id=inst), "instance": inst}
+        ensure_whitelist_defaults(cfg, instance_id=inst, persist=not override)
+        libs = fetch_libraries_from_cfg(cfg, instance_id=inst, persist=not override)
+        return {"libraries": libs, "instance": inst}
 
     
     @app.get("/api/plex/pms/probe", tags=["media providers"])
@@ -634,7 +641,12 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
 
         try:
             verify = plex_utils._resolve_verify_from_cfg(cfg, base, instance_id=inst)
-            pms_token = (plex.get("pms_token") or "").strip()
+            pms_token, _mid, changed = plex_utils.ensure_pms_token_bound(plex, base)
+            if changed and not str(server or "").strip():
+                try:
+                    save_config(cfg)
+                except Exception:
+                    pass
             candidates: list[tuple[str, str]] = []
             if pms_token:
                 candidates.append(("pms_token", pms_token))
@@ -696,23 +708,10 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         pms_rows = []
         if base:
             verify = plex_utils._resolve_verify_from_cfg(cfg, base, instance_id=inst)
-            pms_token = (plex.get("pms_token") or "").strip()
-            if not pms_token:
+            pms_token, _mid, changed = plex_utils.ensure_pms_token_bound(plex, base)
+            if changed and not override:
                 try:
-                    tok2, mid2, url2 = plex_utils.discover_pms_access_from_cloud(token, base_url=base, machine_id=(plex.get("machine_id") or ""), timeout=8.0)
-                    if tok2:
-                        plex["pms_token"] = tok2
-                        pms_token = tok2
-                    if mid2 and not (plex.get("machine_id") or "").strip():
-                        plex["machine_id"] = mid2
-                    if url2 and not (plex.get("server_url") or "").strip():
-                        plex["server_url"] = url2
-                        base = url2
-                    if not override:
-                        try:
-                            save_config(cfg)
-                        except Exception:
-                            pass
+                    save_config(cfg)
                 except Exception:
                     pass
             sess_tok = pms_token or token

--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -49,6 +49,13 @@ function hasMDBList(state){return isMDBList(state?.src)||isMDBList(state?.dst)}
 function hasPublicMetaDB(state){return isPublicMetaDB(state?.src)||isPublicMetaDB(state?.dst)}
 function hasFloppy(state){return isFloppy(state?.src)||isFloppy(state?.dst)}
 function hasStremio(state){return isStremio(state?.src)||isStremio(state?.dst)}
+function pairInstanceForKind(state, kind){
+  const want=String(kind||"").trim().toLowerCase();
+  if(!want) return "default";
+  if(same(state?.src, want)) return String(state?.src_instance||"default")||"default";
+  if(same(state?.dst, want)) return String(state?.dst_instance||"default")||"default";
+  return "default";
+}
 const isAniList=(v)=>same(v,"anilist");
 function hasAniList(state){return isAniList(state?.src)||isAniList(state?.dst)}
 function hasOwn(obj,key){return !!obj&&Object.prototype.hasOwnProperty.call(obj,key)}
@@ -576,6 +583,7 @@ const {
   hasKodi,
   getOpts,
   onLibrariesChanged: (state) => refreshProviderCardSummaries(state),
+  instanceFor: (state, kind) => pairInstanceForKind(state, kind),
 });
 
 function renderProviderSelects(state){
@@ -662,8 +670,9 @@ function renderInstanceSelects(state){
   state.src_instance=norm(srcInstSel.value);
   state.dst_instance=norm(dstInstSel.value);
 
-  srcInstSel.onchange=()=>{state.src_instance=norm(srcInstSel.value)};
-  dstInstSel.onchange=()=>{state.dst_instance=norm(dstInstSel.value)};
+  const onInstChange=()=>{try{renderFeaturePanel(state)}catch{}};
+  srcInstSel.onchange=()=>{state.src_instance=norm(srcInstSel.value);onInstChange()};
+  dstInstSel.onchange=()=>{state.dst_instance=norm(dstInstSel.value);onInstChange()};
 
   try{
     G.CW?.ProfileSelect?.enhanceProfile?.(srcInstSel,{className:"cx-profile-select-glass"});

--- a/assets/js/modals/pair-config/libraries.js
+++ b/assets/js/modals/pair-config/libraries.js
@@ -10,6 +10,7 @@ export function createLibraryController({
   hasKodi,
   getOpts,
   onLibrariesChanged,
+  instanceFor,
 }) {
   let pairServerCfgPromise = null;
   let pairServerCfgAt = 0;
@@ -38,14 +39,30 @@ export function createLibraryController({
     pairServerCfgAt = 0;
   }
 
-  function fetchServerLibraries(kind) {
-    let url = null;
-    if (kind === "PLEX") url = "/api/plex/libraries";
-    else if (kind === "JELLYFIN") url = "/api/jellyfin/libraries";
-    else if (kind === "EMBY") url = "/api/emby/libraries";
-    else if (kind === "KODI") url = "/api/kodi/libraries";
-    if (!url) return Promise.resolve([]);
-    return fetch(url + "?cb=" + Date.now(), { cache: "no-store" })
+  function providerKeyFor(kind) {
+    if (kind === "PLEX") return "plex";
+    if (kind === "JELLYFIN") return "jellyfin";
+    if (kind === "EMBY") return "emby";
+    if (kind === "KODI") return "kodi";
+    return "";
+  }
+
+  function resolveInstance(state, kind) {
+    try {
+      const inst = instanceFor?.(state, kind);
+      return String(inst || "default").trim() || "default";
+    } catch {
+      return "default";
+    }
+  }
+
+  function fetchServerLibraries(state, kind) {
+    const prov = providerKeyFor(kind);
+    if (!prov) return Promise.resolve([]);
+    const url = `/api/${prov}/libraries`;
+    const inst = resolveInstance(state, kind);
+    const qs = `?cb=${Date.now()}&instance=${encodeURIComponent(inst)}`;
+    return fetch(url + qs, { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : null))
       .then((j) => (j && Array.isArray(j.libraries) ? j.libraries : []))
       .catch(() => []);
@@ -61,16 +78,15 @@ export function createLibraryController({
     return pairServerCfgPromise;
   }
 
-  function filterLibsByServerConfig(libs, kind, feature, cfg) {
+  function filterLibsByServerConfig(libs, kind, feature, cfg, instance) {
     try {
-      let prov = "";
-      if (kind === "PLEX") prov = "plex";
-      else if (kind === "JELLYFIN") prov = "jellyfin";
-      else if (kind === "EMBY") prov = "emby";
-      else if (kind === "KODI") prov = "kodi";
+      const prov = providerKeyFor(kind);
       if (!prov) return libs;
       const f = feature === "history" ? "history" : feature === "ratings" ? "ratings" : feature;
-      const serverLibs = cfg?.[prov]?.[f]?.libraries;
+      const root = cfg?.[prov];
+      const inst = String(instance || "default");
+      const block = inst === "default" ? root : root?.instances?.[inst];
+      const serverLibs = block?.[f]?.libraries;
       const ids = Array.isArray(serverLibs) ? serverLibs.map((x) => String(x)) : [];
       if (!ids.length) return libs;
       const set = new Set(ids);
@@ -80,9 +96,10 @@ export function createLibraryController({
     }
   }
 
-  function fetchPairLibraries(kind, feature) {
-    return Promise.all([fetchServerLibraries(kind), fetchPairServerConfig()]).then(([libs, cfg]) =>
-      filterLibsByServerConfig(libs, kind, feature, cfg)
+  function fetchPairLibraries(state, kind, feature) {
+    const inst = resolveInstance(state, kind);
+    return Promise.all([fetchServerLibraries(state, kind), fetchPairServerConfig()]).then(([libs, cfg]) =>
+      filterLibsByServerConfig(libs, kind, feature, cfg, inst)
     );
   }
 
@@ -146,13 +163,13 @@ export function createLibraryController({
         btn.textContent = "Loading...";
       }
       Promise.all([
-        fetchPairLibraries(kind, "history").then((libs) => {
+        fetchPairLibraries(state, kind, "history").then((libs) => {
           renderPairLibChips(state, kind, "history", libs);
         }),
-        fetchPairLibraries(kind, "ratings").then((libs) => {
+        fetchPairLibraries(state, kind, "ratings").then((libs) => {
           renderPairLibChips(state, kind, "ratings", libs);
         }),
-        fetchPairLibraries(kind, "progress").then((libs) => {
+        fetchPairLibraries(state, kind, "progress").then((libs) => {
           renderPairLibChips(state, kind, "progress", libs);
         }),
       ]).finally(() => {
@@ -167,8 +184,9 @@ export function createLibraryController({
       btn.__wired = true;
       btn.addEventListener("click", load);
     }
-    if (!state._libsAutoload[kind]) {
-      state._libsAutoload[kind] = true;
+    const autoKey = `${kind}:${resolveInstance(state, kind)}`;
+    if (!state._libsAutoload[autoKey]) {
+      state._libsAutoload[autoKey] = true;
       load();
     }
   }

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -89,7 +89,10 @@ def _plex_btok(cfg: dict[str, Any], instance_id: Any = None) -> tuple[str, str]:
         if isinstance(pms_blk, dict):
             pms = str(pms_blk.get("token") or pms_blk.get("x_plex_token") or "").strip()
 
-    if pms:
+    bound = str(px.get("pms_token_server") or "").strip().rstrip("/")
+    stale = bool(pms and cloud and bound and bound != base)
+
+    if pms and not stale:
         return base, pms
     pms2, _ = _try_discover_pms_token(cfg, base, cloud, instance_id=instance_id)
     return base, (pms2 or cloud)

--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -522,6 +522,29 @@ def get_manifest() -> Mapping[str, Any]:
             "playlists": _PLAYLIST_CAPABILITIES,
         },
     }
+
+
+def _same_pms_base(a: Any, b: Any) -> bool:
+    return str(a or "").strip().rstrip("/") == str(b or "").strip().rstrip("/")
+
+
+def _resolve_pms_binding(
+    plex_cfg: Mapping[str, Any],
+    pms: Mapping[str, Any],
+    baseurl: Any,
+) -> tuple[Any, Any]:
+    pms_token = plex_cfg.get("pms_token") or pms.get("token") or pms.get("x_plex_token")
+    machine_id = plex_cfg.get("machine_id")
+    bound = plex_cfg.get("pms_token_server")
+    if not (pms_token and bound and baseurl) or _same_pms_base(bound, baseurl):
+        return pms_token, machine_id
+    if not (plex_cfg.get("account_token") or plex_cfg.get("token")):
+        _warn("pms_token_stale_kept", server_url=str(baseurl), bound_to=str(bound), reason="no_account_token")
+        return pms_token, machine_id
+    _warn("pms_token_stale", server_url=str(baseurl), bound_to=str(bound))
+    return None, None
+
+
 @dataclass
 class PLEXConfig:
     token: str | None = None
@@ -612,6 +635,25 @@ class PLEXClient:
             self.session.headers["X-Plex-Token"] = connection_token
 
             if self.cfg.baseurl:
+                # Shared users need a server-scoped resource token for PMS endpoints.
+                mid = (self.cfg.machine_id or "").strip() or None
+                if not pms_token and cloud_token:
+                    try:
+                        m2, t2 = _plex_tv_resource_for_connection(
+                            cloud_token, cid, baseurl=str(self.cfg.baseurl).strip(), timeout=float(self.cfg.timeout)
+                        )
+                        if m2 and not mid:
+                            mid = m2
+                        if t2:
+                            pms_token = t2
+                            self._pms_token = t2
+                            connection_token = t2
+                            self.session.headers["X-Plex-Token"] = t2
+                        if pms_token and mid:
+                            self.cfg.machine_id = mid
+                    except Exception:
+                        pass
+
                 try:
                     self.server = PlexServer(self.cfg.baseurl, connection_token, timeout=self.cfg.timeout)
                     self.server._session = self.session  # type: ignore[attr-defined]
@@ -623,24 +665,12 @@ class PLEXClient:
                     self._post_connect_user_scope(str(pms_token or cloud_token))
                     return self
 
-                # Shared users need a server-scoped resource token for PMS endpoints.
-                if not pms_token:
-                    if not cloud_token:
-                        raise PLEXAuthError("Missing Plex account token for PMS resource discovery")
+                if not pms_token and cloud_token:
                     try:
-                        baseurl = str(self.cfg.baseurl or "").strip()
-                        mid = (self.cfg.machine_id or "").strip() or None
-                        if baseurl:
-                            m2, t2 = _plex_tv_resource_for_connection(cloud_token, cid, baseurl=baseurl, timeout=float(self.cfg.timeout))
-                            if m2 and not mid:
-                                mid = m2
-                            if t2:
-                                pms_token = t2
-                        if not pms_token:
-                            if not mid:
-                                mid = self._infer_machine_id(self.server)
-                            if mid:
-                                pms_token = _plex_tv_resource_access_token(cloud_token, cid, machine_id=mid, timeout=float(self.cfg.timeout))
+                        if not mid:
+                            mid = self._infer_machine_id(self.server)
+                        if mid:
+                            pms_token = _plex_tv_resource_access_token(cloud_token, cid, machine_id=mid, timeout=float(self.cfg.timeout))
                         if pms_token and mid:
                             self.cfg.machine_id = mid
                     except Exception:
@@ -662,10 +692,10 @@ class PLEXClient:
 
             try:
                 account = self._ensure_account()
-                res = self._pick_resource(account)
+                res, srv = self._pick_resource(account)
                 res_tok = str(getattr(res, "accessToken", None) or "").strip() or None
                 res_mid = str(getattr(res, "clientIdentifier", None) or "").strip() or None
-                self.server = res.connect(timeout=self.cfg.timeout)  # type: ignore[assignment]
+                self.server = srv or res.connect(timeout=self.cfg.timeout)  # type: ignore[assignment]
                 self.server._session = self.session  # type: ignore[attr-defined]
                 self._pms_baseurl = str(getattr(self.server, "baseurl", None) or "")
                 if res_mid and not (self.cfg.machine_id or "").strip():
@@ -695,24 +725,46 @@ class PLEXClient:
                 raise PLEXAuthError("Plex authorization failed") from e
             raise PLEXError(f"Plex connect failed: {e}") from e
 
-    def _pick_resource(self, acc: MyPlexAccount):
+    def _pick_resource(self, acc: MyPlexAccount) -> tuple[Any, Any]:
         servers = [r for r in acc.resources() if "server" in (r.provides or "")]
         if self.cfg.machine_id:
             mid = self.cfg.machine_id.lower()
             for r in servers:
                 if (r.clientIdentifier or "").lower() == mid:
-                    return r
+                    return r, None
         if self.cfg.server_name:
             name = self.cfg.server_name.lower()
             for r in servers:
                 if (r.name or "").lower() == name:
-                    return r
-        for r in servers:
-            if getattr(r, "owned", False):
-                return r
-        if servers:
-            return servers[0]
-        raise PLEXNotFound("No Plex Media Server resource found")
+                    return r, None
+        if not servers:
+            raise PLEXNotFound("No Plex Media Server resource found")
+
+        ordered = sorted(
+            servers,
+            key=lambda r: (not bool(getattr(r, "owned", False)), str(getattr(r, "name", "") or "")),
+        )
+        if len(ordered) == 1:
+            return ordered[0], None
+
+        for r in ordered:
+            try:
+                srv = r.connect(timeout=min(float(self.cfg.timeout), 5.0))
+            except Exception:  # noqa: BLE001
+                continue
+            _info(
+                "resource_probe_selected",
+                server_name=str(getattr(r, "name", "") or ""),
+                owned=bool(getattr(r, "owned", False)),
+            )
+            return r, srv
+
+        _warn(
+            "resource_probe_none_reachable",
+            count=len(ordered),
+            fallback=str(getattr(ordered[0], "name", "") or ""),
+        )
+        return ordered[0], None
 
     def _apply_pms_token(self, token: str) -> None:
         tok = str(token or "").strip()
@@ -1126,13 +1178,16 @@ class PLEXModule:
         plex_cfg = dict(cfg.get("plex") or {})
         pms = plex_cfg.get("pms") or {}
         baseurl = plex_cfg.get("baseurl") or plex_cfg.get("server_url") or pms.get("url") or pms.get("baseurl") or pms.get("server_url")
+
+        pms_token, machine_id = _resolve_pms_binding(plex_cfg, pms, baseurl)
+
         self.cfg = PLEXConfig(
             token=plex_cfg.get("account_token") or plex_cfg.get("token"),
-            pms_token=plex_cfg.get("pms_token") or pms.get("token") or pms.get("x_plex_token"),
+            pms_token=pms_token,
             baseurl=baseurl,
             client_id=plex_cfg.get("client_id"),
             server_name=plex_cfg.get("server_name") or plex_cfg.get("server"),
-            machine_id=plex_cfg.get("machine_id"),
+            machine_id=machine_id,
             username=plex_cfg.get("username"),
             account_id=int(plex_cfg["account_id"]) if str(plex_cfg.get("account_id", "")).strip().isdigit() else None,
             home_pin=plex_cfg.get("home_pin"),

--- a/providers/sync/plex/_utils.py
+++ b/providers/sync/plex/_utils.py
@@ -32,10 +32,11 @@ _MIN_HTTP_S = float(os.environ.get("CW_PLEX_MIN_HTTP_INTERVAL_S", "5"))
 
 
 _CACHE: dict[str, dict[str, Any]] = {
-    "libs": {"key": None, "ts": 0.0, "data": []},
+    "libs": {},
     "owner": {"key": None, "ts": 0.0, "data": (None, None)},
     "aid_by_user": {},
 }
+_LIBS_CACHE_MAX = 32
 _LAST_HTTP: dict[str, float] = {}
 
 
@@ -185,6 +186,63 @@ def _resource_token_for_connection(token: str, client_id: str | None, baseurl: s
     return best[1], best[2]
 
 
+def _norm_base(url: Any) -> str:
+    return str(url or "").strip().rstrip("/")
+
+
+def ensure_pms_token_bound(
+    plex: dict[str, Any],
+    base: Any,
+    *,
+    timeout: float = 8.0,
+) -> tuple[str, str, bool]:
+    current = _norm_base(base)
+    pms_token = str(plex.get("pms_token") or "").strip()
+    machine_id = str(plex.get("machine_id") or "").strip()
+    account_token = str(plex.get("account_token") or "").strip()
+    if not current or not account_token:
+        return pms_token, machine_id, False
+
+    bound = _norm_base(plex.get("pms_token_server"))
+    has_creds = bool(pms_token or machine_id)
+    hard_stale = has_creds and bool(bound) and bound != current
+    soft_stale = has_creds and not bound
+    stale = hard_stale or soft_stale
+    if not (stale or not pms_token or not machine_id):
+        return pms_token, machine_id, False
+
+    changed = False
+    rebound = False
+    try:
+        mid2, tok2 = _resource_token_for_connection(
+            account_token, plex.get("client_id"), current, timeout=timeout
+        )
+        if tok2 and (stale or not pms_token):
+            _insert_key_after_inplace(plex, "account_token", "pms_token", tok2)
+            pms_token = tok2
+            changed = True
+        if mid2 and (stale or not machine_id):
+            _insert_key_after_inplace(
+                plex, "client_id" if "client_id" in plex else "pms_token", "machine_id", mid2
+            )
+            machine_id = mid2
+            changed = True
+        if tok2 or mid2:
+            rebound = True
+            if _norm_base(plex.get("pms_token_server")) != current:
+                plex["pms_token_server"] = current
+                changed = True
+            if stale:
+                _info("pms_token_rebound", server_url=current, bound_to=bound or "unknown")
+    except Exception as e:  # noqa: BLE001
+        _warn("pms_token_discovery_failed", error=str(e))
+
+    if hard_stale and not rebound:
+        _warn("pms_token_stale_unresolved", server_url=current, bound_to=bound)
+        return "", "", changed
+    return pms_token, machine_id, changed
+
+
 def _resource_host_flags(uri: str) -> tuple[str, bool, bool]:
     try:
         u = urlparse(uri)
@@ -226,106 +284,6 @@ def _resource_conn_score(uri: str, local: bool, relay: bool) -> int:
     score += 1 if (host and not is_ip) else 0
     return score
 
-
-def discover_pms_access_from_cloud(
-    token: str,
-    base_url: str | None = None,
-    machine_id: str | None = None,
-    timeout: float = 8.0,
-) -> tuple[str | None, str | None, str | None]:
-
-    t = (token or "").strip()
-    if not t:
-        return None, None, None
-
-    want_host = ""
-    want_port = 32400
-    want_scheme = ""
-    if base_url:
-        try:
-            u = urlparse((base_url or "").strip())
-            want_host = (u.hostname or "").strip().lower()
-            want_port = int(u.port or 32400)
-            want_scheme = (u.scheme or "").strip().lower()
-        except Exception:  # noqa: BLE001
-            want_host, want_port, want_scheme = "", 32400, ""
-
-    headers = _plex_headers(t)
-    try:
-        r = requests.get(
-            "https://plex.tv/api/resources",
-            params={"includeHttps": 1, "includeRelay": 1, "includeIPv6": 1},
-            headers=headers,
-            timeout=float(timeout),
-        )
-        if not r.ok or not (r.text or "").lstrip().startswith("<"):
-            return None, None, None
-        root = ET.fromstring(r.text or "")
-    except Exception:  # noqa: BLE001
-        return None, None, None
-
-    best: tuple[int, str | None, str | None, str | None] = (-1, None, None, None)
-
-    for dev in list(root):
-        if (dev.tag or "").lower() != "device":
-            continue
-        attrs = dev.attrib or {}
-        provides = (attrs.get("provides") or "").lower()
-        if "server" not in provides:
-            continue
-
-        dev_mid = (attrs.get("clientIdentifier") or attrs.get("machineIdentifier") or "").strip() or None
-        dev_tok = (attrs.get("accessToken") or "").strip() or None
-        if not dev_tok:
-            continue
-
-        hard_match = False
-        soft_match = False
-        if machine_id and dev_mid and dev_mid == str(machine_id).strip():
-            hard_match = True
-
-        best_uri = ""
-        best_uri_score = -1
-        base_match_score = -1
-
-        for conn in dev.findall(".//Connection"):
-            uri = (conn.attrib.get("uri") or "").strip().rstrip("/")
-            if not uri:
-                continue
-            local = (conn.attrib.get("local") or "").strip().lower() in ("1", "true", "yes")
-            relay = (conn.attrib.get("relay") or "").strip().lower() in ("1", "true", "yes")
-
-            cs = _resource_conn_score(uri, local=local, relay=relay)
-            if cs > best_uri_score:
-                best_uri_score = cs
-                best_uri = uri
-
-            if want_host:
-                try:
-                    cu = urlparse(uri)
-                    host = (cu.hostname or "").strip().lower()
-                    port = int(cu.port or 32400)
-                    scheme = (cu.scheme or "").strip().lower()
-                except Exception:  # noqa: BLE001
-                    continue
-                if host == want_host and port == want_port:
-                    soft_match = True
-                    base_match_score = max(base_match_score, 200 if scheme == want_scheme else 160)
-
-        if not (hard_match or soft_match):
-            continue
-
-        dev_score = best_uri_score
-        if hard_match:
-            dev_score += 1000
-        if soft_match:
-            dev_score += 800
-        dev_score += base_match_score if base_match_score > 0 else 0
-
-        if dev_score > best[0]:
-            best = (dev_score, dev_tok, dev_mid, best_uri or None)
-
-    return best[1], best[2], best[3]
 
 def _resolve_verify_from_cfg(cfg: Mapping[str, Any], url: str, instance_id: Any = None) -> bool:
     if not str(url).lower().startswith("https"):
@@ -385,30 +343,96 @@ def _try_get(session: requests.Session, base: str, path: str, timeout: float) ->
     return None
 
 
-def _pick_server_url_from_resources(xml_text: str) -> str:
+_DISCOVERY_PROBE_MAX = int(os.environ.get("CW_PLEX_DISCOVERY_PROBE_MAX", "6"))
+_DISCOVERY_PROBE_TIMEOUT_S = float(os.environ.get("CW_PLEX_DISCOVERY_PROBE_TIMEOUT_S", "3"))
+
+
+def _rank_server_candidates(xml_text: str) -> list[dict[str, Any]]:
     try:
         root = ET.fromstring(xml_text)
-        best_uri = ""
-        best_score = -1
-        for dev in root.findall(".//Device"):
-            if "server" not in (dev.attrib.get("provides") or ""):
-                continue
-            for conn in dev.findall(".//Connection"):
-                uri = (conn.attrib.get("uri") or "").strip().rstrip("/")
-                if not uri:
-                    continue
-                local = (conn.attrib.get("local") or "").strip().lower() in ("1", "true", "yes")
-                relay = (conn.attrib.get("relay") or "").strip().lower() in ("1", "true", "yes")
-                score = _resource_conn_score(uri, local=local, relay=relay)
-                if score > best_score:
-                    best_score = score
-                    best_uri = uri
-        return best_uri
     except Exception:  # noqa: BLE001
+        return []
+
+    out: list[dict[str, Any]] = []
+    for dev in root.findall(".//Device"):
+        attrs = dev.attrib or {}
+        if "server" not in (attrs.get("provides") or ""):
+            continue
+        owned = (attrs.get("owned") or "").strip().lower() in ("1", "true", "yes")
+        name = (attrs.get("name") or "").strip()
+        mid = (attrs.get("clientIdentifier") or attrs.get("machineIdentifier") or "").strip()
+        dev_token = (attrs.get("accessToken") or "").strip()
+        for conn in dev.findall(".//Connection"):
+            uri = (conn.attrib.get("uri") or "").strip().rstrip("/")
+            if not uri:
+                continue
+            local = (conn.attrib.get("local") or "").strip().lower() in ("1", "true", "yes")
+            relay = (conn.attrib.get("relay") or "").strip().lower() in ("1", "true", "yes")
+            out.append(
+                {
+                    "uri": uri,
+                    "score": _resource_conn_score(uri, local=local, relay=relay),
+                    "owned": owned,
+                    "name": name,
+                    "machine_id": mid,
+                    "token": dev_token,
+                }
+            )
+
+    out.sort(key=lambda c: (-int(c["score"]), not c["owned"], str(c["name"]), str(c["uri"])))
+    return out
+
+
+def _probe_identity(uri: str, token: str, timeout: float) -> bool:
+    url = f"{uri.rstrip('/')}/identity"
+    verifies = (True, False) if uri.lower().startswith("https") else (True,)
+    for verify in verifies:
+        session = None
+        try:
+            session = _build_session(token, verify)
+            if getattr(session.get(url, timeout=timeout), "ok", False):
+                return True
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            if session is not None:
+                try:
+                    session.close()
+                except Exception:  # noqa: BLE001
+                    pass
+    return False
+
+
+def _pick_server_url_from_resources(xml_text: str, account_token: str = "", probe: bool = False) -> str:
+    candidates = _rank_server_candidates(xml_text)
+    if not candidates:
         return ""
+    if not probe:
+        return str(candidates[0]["uri"])
+
+    tried = 0
+    for cand in candidates:
+        if tried >= max(1, _DISCOVERY_PROBE_MAX):
+            break
+        token = str(cand.get("token") or "") or account_token
+        if not token:
+            continue
+        tried += 1
+        if _probe_identity(str(cand["uri"]), token, _DISCOVERY_PROBE_TIMEOUT_S):
+            _info(
+                "server_url_probe_selected",
+                server_url=str(cand["uri"]),
+                server_name=str(cand.get("name") or ""),
+                owned=bool(cand.get("owned")),
+            )
+            return str(cand["uri"])
+
+    fallback = str(candidates[0]["uri"])
+    _warn("server_url_probe_none_reachable", probed=tried, fallback=fallback)
+    return fallback
 
 
-def discover_server_url_from_cloud(token: str, timeout: float = 10.0) -> str | None:
+def discover_server_url_from_cloud(token: str, timeout: float = 10.0, probe: bool = True) -> str | None:
     try:
         response = requests.get(
             "https://plex.tv/api/resources?includeHttps=1&includeRelay=1&includeIPv6=1",
@@ -416,7 +440,7 @@ def discover_server_url_from_cloud(token: str, timeout: float = 10.0) -> str | N
             timeout=timeout,
         )
         if response.ok and (response.text or "").lstrip().startswith("<"):
-            picked = _pick_server_url_from_resources(response.text)
+            picked = _pick_server_url_from_resources(response.text, account_token=token, probe=probe)
             return picked or None
     except Exception:  # noqa: BLE001
         pass
@@ -800,8 +824,8 @@ def fetch_account_id_for_cloud_id(
     return aid
 
 
-def _libs_key(base_url: str, token: str, verify: bool) -> tuple[str, str, bool]:
-    return base_url.rstrip("/"), token or "", bool(verify)
+def _libs_key(base_url: str, token: str, verify: bool) -> str:
+    return f"{_norm_base(base_url)}\n{token or ''}\n{1 if verify else 0}"
 
 
 def fetch_libraries(
@@ -811,11 +835,12 @@ def fetch_libraries(
     timeout: float = 10.0,
 ) -> list[dict[str, Any]]:
     key = _libs_key(base_url, token, verify)
-    ent = _CACHE["libs"]
-    if ent["key"] == key and _cache_hit(ent["ts"], _LIB_TTL_S):
-        return list(ent["data"])
-    if _throttle("/library/sections"):
-        return list(ent["data"])
+    bucket = _CACHE["libs"]
+    ent = bucket.get(key)
+    if ent and _cache_hit(ent.get("ts", 0.0), _LIB_TTL_S):
+        return list(ent.get("data") or [])
+    if _throttle(f"/library/sections\n{key}"):
+        return list(ent.get("data") or []) if ent else []
     libs: list[dict[str, Any]] = []
     try:
         session = _build_session(token, verify)
@@ -830,15 +855,25 @@ def fetch_libraries(
                     libs.append({"key": str(keyv), "title": title, "type": lib_type or "lib"})
     except Exception as e:  # noqa: BLE001
         _warn("sections_fetch_failed", error=str(e))
-    _CACHE["libs"] = {"key": key, "ts": time.time(), "data": list(libs)}
+    if not libs:
+        bucket.pop(key, None)
+        return libs
+    if len(bucket) >= _LIBS_CACHE_MAX:
+        for stale_key in sorted(bucket, key=lambda k: bucket[k].get("ts", 0.0))[: len(bucket) - _LIBS_CACHE_MAX + 1]:
+            bucket.pop(stale_key, None)
+    bucket[key] = {"ts": time.time(), "data": list(libs)}
     return libs
 
 
-def fetch_libraries_from_cfg(cfg: dict[str, Any] | None = None, instance_id: Any = None) -> list[dict[str, Any]]:
+def fetch_libraries_from_cfg(
+    cfg: dict[str, Any] | None = None,
+    instance_id: Any = None,
+    *,
+    persist: bool = True,
+) -> list[dict[str, Any]]:
     cfg = load_config() if cfg is None else cfg
     plex = _plex(cfg, instance_id)
     cloud_token = (plex.get("account_token") or "").strip()
-    pms_token = (plex.get("pms_token") or "").strip()
     base = (plex.get("server_url") or "").strip()
     if not cloud_token:
         return []
@@ -846,30 +881,35 @@ def fetch_libraries_from_cfg(cfg: dict[str, Any] | None = None, instance_id: Any
         base_url = discover_server_url_from_cloud(cloud_token) or ""
         if base_url:
             _insert_key_first_inplace(plex, "server_url", base_url)
-            save_config(cfg)
+            if persist:
+                save_config(cfg)
         base = base_url
     if not base:
         return []
 
-    if not pms_token:
+    pms_token, _, changed = ensure_pms_token_bound(plex, base)
+    if changed and persist:
         try:
-            mid2, tok2 = _resource_token_for_connection(cloud_token, plex.get("client_id"), base, timeout=8.0)
-            if tok2:
-                _insert_key_after_inplace(plex, "account_token", "pms_token", tok2)
-                pms_token = tok2
-            if mid2 and not str(plex.get("machine_id") or "").strip():
-                _insert_key_after_inplace(plex, "client_id" if "client_id" in plex else "pms_token", "machine_id", mid2)
-            if tok2 or mid2:
-                save_config(cfg)
+            save_config(cfg)
         except Exception as e:  # noqa: BLE001
-            _warn("pms_token_discovery_failed", error=str(e))
+            _warn("pms_token_persist_failed", error=str(e))
 
     verify = _resolve_verify_from_cfg(cfg, base, instance_id)
-    libs = fetch_libraries(base, (pms_token or cloud_token), verify=verify)
-    if not libs and verify:
-        _info("libs_retry_insecure")
-        libs = fetch_libraries(base, (pms_token or cloud_token), verify=False)
-    return libs
+    tokens = [t for t in (pms_token, cloud_token) if t]
+    seen: set[str] = set()
+    for token in tokens:
+        if token in seen:
+            continue
+        seen.add(token)
+        libs = fetch_libraries(base, token, verify=verify)
+        if libs:
+            return libs
+        if verify:
+            _info("libs_retry_insecure")
+            libs = fetch_libraries(base, token, verify=False)
+            if libs:
+                return libs
+    return []
 
 
 def inspect_and_persist(cfg: dict[str, Any] | None = None, instance_id: Any = None) -> dict[str, Any]:
@@ -930,25 +970,7 @@ def inspect_and_persist(cfg: dict[str, Any] | None = None, instance_id: Any = No
         base = base_url
 
     if token and base:
-        bound = str(plex.get("pms_token_server") or "").strip().rstrip("/")
-        current = base.rstrip("/")
-        stale = bool(pms_token or machine_id) and bound != current
-
-        if stale or not pms_token or not machine_id:
-            try:
-                mid2, tok2 = _resource_token_for_connection(token, plex.get("client_id"), base, timeout=8.0)
-                if tok2 and (stale or not pms_token):
-                    _insert_key_after_inplace(plex, "account_token", "pms_token", tok2)
-                    pms_token = tok2
-                if mid2 and (stale or not machine_id):
-                    _insert_key_after_inplace(plex, "client_id" if "client_id" in plex else "pms_token", "machine_id", mid2)
-                    machine_id = mid2
-                if tok2 or mid2:
-                    plex["pms_token_server"] = current
-                    if stale:
-                        _info("pms_token_rebound", server_url=current, bound_to=bound or "unknown")
-            except Exception as e:  # noqa: BLE001
-                _warn("pms_token_discovery_failed", error=str(e))
+        pms_token, machine_id, _changed = ensure_pms_token_bound(plex, base)
 
         verify = _resolve_verify_from_cfg(cfg, base, instance_id)
 
@@ -1040,7 +1062,12 @@ def resolve_user_scope(
     return username, (int(aid) if aid is not None else None)
 
 
-def ensure_whitelist_defaults(cfg: dict[str, Any] | None = None, instance_id: Any = None) -> bool:
+def ensure_whitelist_defaults(
+    cfg: dict[str, Any] | None = None,
+    instance_id: Any = None,
+    *,
+    persist: bool = True,
+) -> bool:
     cfg = load_config() if cfg is None else cfg
     plex = _plex(cfg, instance_id)
     changed = False
@@ -1056,7 +1083,7 @@ def ensure_whitelist_defaults(cfg: dict[str, Any] | None = None, instance_id: An
         if libs != norm:
             plex[sec]["libraries"] = norm
             changed = True
-    if changed:
+    if changed and persist:
         save_config(cfg)
         _info("whitelist_defaults_ensured")
     return changed

--- a/tests/test_plex_server_binding.py
+++ b/tests/test_plex_server_binding.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+SERVER_A = "https://192-0-2-10.aaa.plex.direct:32400"
+SERVER_B = "https://198-51-100-20.bbb.plex.direct:32401"
+
+SECTIONS_A = '<MediaContainer><Directory key="1" title="A-Movies" type="movie"/></MediaContainer>'
+SECTIONS_B = '<MediaContainer><Directory key="9" title="B-Shows" type="show"/></MediaContainer>'
+
+
+class _Resp:
+    def __init__(self, status_code: int, text: str = "") -> None:
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self.text = text
+
+
+@pytest.fixture(autouse=True)
+def _reset_plex_caches():
+    from providers.sync.plex import _utils as u
+
+    u._CACHE["libs"] = {}
+    u._LAST_HTTP.clear()
+    yield
+    u._CACHE["libs"] = {}
+    u._LAST_HTTP.clear()
+
+
+def _patch_transport(monkeypatch, responder):
+    from providers.sync.plex import _utils as u
+
+    monkeypatch.setattr(u, "_build_session", lambda token, verify: {"token": token, "verify": verify})
+    monkeypatch.setattr(u, "_try_get", responder)
+
+
+def test_libraries_rebind_pms_token_when_server_url_changes(monkeypatch) -> None:
+    from providers.sync.plex import _utils as u
+
+    block: dict[str, Any] = {
+        "account_token": "ACCOUNT",
+        "pms_token": "PMS-A",
+        "pms_token_server": SERVER_A,
+        "machine_id": "mid-a",
+        "server_url": SERVER_B,
+        "client_id": "cid",
+    }
+    cfg = {"plex": block}
+    saved: list[int] = []
+
+    def _try_get(session, base, path, timeout=10.0):
+        if base.rstrip("/") == SERVER_B and session["token"] == "PMS-B":
+            return _Resp(200, SECTIONS_B)
+        return _Resp(401, "")
+
+    _patch_transport(monkeypatch, _try_get)
+    monkeypatch.setattr(u, "save_config", lambda _c: saved.append(1))
+    monkeypatch.setattr(u, "_resolve_verify_from_cfg", lambda *a, **k: True)
+    monkeypatch.setattr(u, "_resource_token_for_connection", lambda *a, **k: ("mid-b", "PMS-B"))
+
+    libs = u.fetch_libraries_from_cfg(cfg)
+
+    assert [lib["title"] for lib in libs] == ["B-Shows"]
+    assert block["pms_token"] == "PMS-B"
+    assert block["machine_id"] == "mid-b"
+    assert block["pms_token_server"] == SERVER_B
+    assert saved
+
+
+def test_libraries_fall_back_to_account_token_when_pms_token_rejected(monkeypatch) -> None:
+    from providers.sync.plex import _utils as u
+
+    block: dict[str, Any] = {
+        "account_token": "ACCOUNT",
+        "pms_token": "PMS-A",
+        "pms_token_server": SERVER_A,
+        "machine_id": "mid-a",
+        "server_url": SERVER_A,
+        "client_id": "cid",
+    }
+    cfg = {"plex": block}
+
+    def _try_get(session, base, path, timeout=10.0):
+        return _Resp(200, SECTIONS_A) if session["token"] == "ACCOUNT" else _Resp(401, "")
+
+    _patch_transport(monkeypatch, _try_get)
+    monkeypatch.setattr(u, "save_config", lambda _c: None)
+    monkeypatch.setattr(u, "_resolve_verify_from_cfg", lambda *a, **k: True)
+
+    assert [lib["title"] for lib in u.fetch_libraries_from_cfg(cfg)] == ["A-Movies"]
+
+
+def test_stale_token_is_not_reused_when_rediscovery_fails(monkeypatch) -> None:
+    from providers.sync.plex import _utils as u
+
+    block: dict[str, Any] = {
+        "account_token": "ACCOUNT",
+        "pms_token": "PMS-A",
+        "pms_token_server": SERVER_A,
+        "machine_id": "mid-a",
+        "server_url": SERVER_B,
+        "client_id": "cid",
+    }
+
+    monkeypatch.setattr(u, "_resource_token_for_connection", lambda *a, **k: (None, None))
+
+    token, machine_id, changed = u.ensure_pms_token_bound(block, SERVER_B)
+
+    assert token == ""
+    assert machine_id == ""
+    assert changed is False
+    assert block["pms_token"] == "PMS-A"
+
+
+def test_library_cache_is_per_server(monkeypatch) -> None:
+    from providers.sync.plex import _utils as u
+
+    def _try_get(session, base, path, timeout=10.0):
+        return _Resp(200, SECTIONS_A if base.rstrip("/") == SERVER_A else SECTIONS_B)
+
+    _patch_transport(monkeypatch, _try_get)
+
+    first = u.fetch_libraries(SERVER_A, "PMS-A", verify=True)
+    second = u.fetch_libraries(SERVER_B, "PMS-B", verify=True)
+
+    assert [lib["title"] for lib in first] == ["A-Movies"]
+    assert [lib["title"] for lib in second] == ["B-Shows"]
+
+
+def test_a_failed_read_is_not_cached_as_an_empty_library_list(monkeypatch) -> None:
+    from providers.sync.plex import _utils as u
+
+    state = {"ok": False}
+
+    def _try_get(session, base, path, timeout=10.0):
+        return _Resp(200, SECTIONS_A) if state["ok"] else _Resp(503, "")
+
+    _patch_transport(monkeypatch, _try_get)
+    monkeypatch.setattr(u, "_throttle", lambda _p: False)
+
+    assert u.fetch_libraries(SERVER_A, "PMS-A", verify=True) == []
+    state["ok"] = True
+    assert [lib["title"] for lib in u.fetch_libraries(SERVER_A, "PMS-A", verify=True)] == ["A-Movies"]
+
+
+def test_insecure_retry_is_not_swallowed_by_the_throttle(monkeypatch) -> None:
+    from providers.sync.plex import _utils as u
+
+    block: dict[str, Any] = {
+        "account_token": "ACCOUNT",
+        "pms_token": "PMS-A",
+        "pms_token_server": SERVER_A,
+        "machine_id": "mid-a",
+        "server_url": SERVER_A,
+    }
+    cfg = {"plex": block}
+    attempts: list[bool] = []
+
+    def _try_get(session, base, path, timeout=10.0):
+        attempts.append(bool(session["verify"]))
+        return _Resp(200, SECTIONS_A) if not session["verify"] else _Resp(495, "")
+
+    _patch_transport(monkeypatch, _try_get)
+    monkeypatch.setattr(u, "save_config", lambda _c: None)
+    monkeypatch.setattr(u, "_resolve_verify_from_cfg", lambda *a, **k: True)
+
+    libs = u.fetch_libraries_from_cfg(cfg)
+
+    assert [lib["title"] for lib in libs] == ["A-Movies"]
+    assert attempts[:2] == [True, False]
+
+
+RESOURCES_XML = """<MediaContainer>
+  <Device name="Owned Server" provides="server" owned="1" clientIdentifier="mid-a" accessToken="TOK-A">
+    <Connection protocol="https" uri="{unreachable}" local="0" relay="0"/>
+  </Device>
+  <Device name="Shared Server" provides="server" owned="0" clientIdentifier="mid-b" accessToken="TOK-B">
+    <Connection protocol="https" uri="{reachable}" local="0" relay="0"/>
+  </Device>
+</MediaContainer>""".format(unreachable=SERVER_A, reachable=SERVER_B)
+
+
+def test_discovery_skips_unreachable_server_and_picks_a_live_one(monkeypatch) -> None:
+    from providers.sync.plex import _utils as u
+
+    probed: list[str] = []
+
+    def _probe(uri, token, timeout):
+        probed.append(uri)
+        return uri == SERVER_B
+
+    monkeypatch.setattr(u, "_probe_identity", _probe)
+
+    assert u._pick_server_url_from_resources(RESOURCES_XML, account_token="ACCOUNT", probe=True) == SERVER_B
+    assert probed == [SERVER_A, SERVER_B]
+
+
+def test_discovery_falls_back_to_top_candidate_when_nothing_answers(monkeypatch) -> None:
+    from providers.sync.plex import _utils as u
+
+    monkeypatch.setattr(u, "_probe_identity", lambda *a, **k: False)
+
+    assert u._pick_server_url_from_resources(RESOURCES_XML, account_token="ACCOUNT", probe=True) == SERVER_A
+
+
+def test_candidate_ranking_is_deterministic_not_document_order() -> None:
+    from providers.sync.plex import _utils as u
+
+    reversed_xml = """<MediaContainer>
+      <Device name="Shared Server" provides="server" owned="0" clientIdentifier="mid-b" accessToken="T">
+        <Connection protocol="https" uri="{b}" local="0" relay="0"/>
+      </Device>
+      <Device name="Owned Server" provides="server" owned="1" clientIdentifier="mid-a" accessToken="T">
+        <Connection protocol="https" uri="{a}" local="0" relay="0"/>
+      </Device>
+    </MediaContainer>""".format(a=SERVER_A, b=SERVER_B)
+
+    for xml in (RESOURCES_XML, reversed_xml):
+        assert u._pick_server_url_from_resources(xml, probe=False) == SERVER_A
+
+
+def test_media_override_drops_a_token_bound_to_another_server() -> None:
+    import api.authenticationAPI as auth
+
+    cfg = {
+        "plex": {
+            "account_token": "ACCOUNT",
+            "pms_token": "PMS-A",
+            "pms_token_server": SERVER_A,
+            "machine_id": "mid-a",
+            "server_url": SERVER_A,
+        }
+    }
+
+    block = auth._apply_media_overrides(cfg, "plex", "default", SERVER_B, None)
+
+    assert block["server_url"] == SERVER_B
+    assert "pms_token" not in block
+    assert "pms_token_server" not in block
+    assert "machine_id" not in block
+
+
+def test_media_override_keeps_the_token_for_the_same_server() -> None:
+    import api.authenticationAPI as auth
+
+    cfg = {
+        "plex": {
+            "account_token": "ACCOUNT",
+            "pms_token": "PMS-A",
+            "pms_token_server": SERVER_A,
+            "machine_id": "mid-a",
+            "server_url": SERVER_A,
+        }
+    }
+
+    block = auth._apply_media_overrides(cfg, "plex", "default", SERVER_A + "/", None)
+
+    assert block["pms_token"] == "PMS-A"
+    assert block["machine_id"] == "mid-a"
+
+
+def test_live_override_does_not_persist_the_probed_server(monkeypatch) -> None:
+    import api.authenticationAPI as auth
+    from providers.sync.plex import _utils as u
+
+    cfg = {
+        "plex": {
+            "account_token": "ACCOUNT",
+            "pms_token": "PMS-A",
+            "pms_token_server": SERVER_A,
+            "machine_id": "mid-a",
+            "server_url": SERVER_A,
+            "client_id": "cid",
+        }
+    }
+    saved: list[int] = []
+
+    def _try_get(session, base, path, timeout=10.0):
+        if base.rstrip("/") == SERVER_B and session["token"] == "PMS-B":
+            return _Resp(200, SECTIONS_B)
+        return _Resp(401, "")
+
+    monkeypatch.setattr(auth, "load_config", lambda: cfg)
+    monkeypatch.setattr(auth, "save_config", lambda _c: saved.append(1))
+    monkeypatch.setattr(u, "save_config", lambda _c: saved.append(1))
+    monkeypatch.setattr(u, "_resolve_verify_from_cfg", lambda *a, **k: True)
+    monkeypatch.setattr(u, "_resource_token_for_connection", lambda *a, **k: ("mid-b", "PMS-B"))
+    _patch_transport(monkeypatch, _try_get)
+
+    app = FastAPI()
+    auth.register_auth(app)
+    body = TestClient(app).get(f"/api/plex/libraries?server={SERVER_B}").json()
+
+    assert [lib["title"] for lib in body["libraries"]] == ["B-Shows"]
+    assert not saved
+    assert cfg["plex"]["server_url"] == SERVER_B
+
+
+def test_libraries_endpoint_reads_the_requested_instance(monkeypatch) -> None:
+    import api.authenticationAPI as auth
+    from providers.sync.plex import _utils as u
+
+    cfg = {
+        "plex": {
+            "account_token": "ACCOUNT-A",
+            "pms_token": "PMS-A",
+            "pms_token_server": SERVER_A,
+            "machine_id": "mid-a",
+            "server_url": SERVER_A,
+            "instances": {
+                "2": {
+                    "account_token": "ACCOUNT-B",
+                    "pms_token": "PMS-B",
+                    "pms_token_server": SERVER_B,
+                    "machine_id": "mid-b",
+                    "server_url": SERVER_B,
+                }
+            },
+        }
+    }
+
+    def _try_get(session, base, path, timeout=10.0):
+        if base.rstrip("/") == SERVER_A and session["token"] == "PMS-A":
+            return _Resp(200, SECTIONS_A)
+        if base.rstrip("/") == SERVER_B and session["token"] == "PMS-B":
+            return _Resp(200, SECTIONS_B)
+        return _Resp(401, "")
+
+    monkeypatch.setattr(auth, "load_config", lambda: cfg)
+    monkeypatch.setattr(auth, "save_config", lambda _c: None)
+    monkeypatch.setattr(u, "save_config", lambda _c: None)
+    monkeypatch.setattr(u, "_resolve_verify_from_cfg", lambda *a, **k: True)
+    _patch_transport(monkeypatch, _try_get)
+
+    app = FastAPI()
+    auth.register_auth(app)
+    client = TestClient(app)
+
+    default_libs = client.get("/api/plex/libraries").json()
+    inst_libs = client.get("/api/plex/libraries?instance=2").json()
+
+    assert [lib["title"] for lib in default_libs["libraries"]] == ["A-Movies"]
+    assert [lib["title"] for lib in inst_libs["libraries"]] == ["B-Shows"]
+    assert inst_libs["instance"] == "2"
+
+
+def test_sync_adapter_drops_a_token_bound_to_another_server() -> None:
+    from providers.sync._mod_PLEX import _resolve_pms_binding
+
+    plex_cfg = {
+        "account_token": "ACCOUNT",
+        "pms_token": "PMS-A",
+        "machine_id": "mid-a",
+        "pms_token_server": SERVER_A,
+    }
+
+    assert _resolve_pms_binding(plex_cfg, {}, SERVER_B) == (None, None)
+    assert _resolve_pms_binding(plex_cfg, {}, SERVER_A + "/") == ("PMS-A", "mid-a")
+    assert _resolve_pms_binding({"pms_token": "PMS-A"}, {}, SERVER_B) == ("PMS-A", None)
+
+
+def test_sync_adapter_keeps_a_stale_token_when_it_cannot_be_re_derived() -> None:
+    from providers.sync._mod_PLEX import _resolve_pms_binding
+
+    plex_cfg = {"pms_token": "PMS-A", "machine_id": "mid-a", "pms_token_server": SERVER_A}
+
+    assert _resolve_pms_binding(plex_cfg, {}, SERVER_B) == ("PMS-A", "mid-a")
+
+
+def test_watcher_keeps_a_token_bound_to_the_current_server() -> None:
+    from providers.scrobble.plex.watch import _plex_btok
+
+    base, token = _plex_btok(
+        {
+            "plex": {
+                "account_token": "ACCOUNT",
+                "pms_token": "PMS-A",
+                "pms_token_server": SERVER_A,
+                "server_url": SERVER_A,
+            }
+        }
+    )
+    assert (base, token) == (SERVER_A, "PMS-A")
+
+
+def test_watcher_rediscovers_when_the_token_is_bound_elsewhere(monkeypatch) -> None:
+    from providers.scrobble.plex import watch
+
+    monkeypatch.setattr(watch, "_try_discover_pms_token", lambda *a, **k: ("PMS-B", "mid-b"))
+
+    base, token = watch._plex_btok(
+        {
+            "plex": {
+                "account_token": "ACCOUNT",
+                "pms_token": "PMS-A",
+                "pms_token_server": SERVER_A,
+                "server_url": SERVER_B,
+            }
+        }
+    )
+    assert (base, token) == (SERVER_B, "PMS-B")
+
+
+def test_watcher_keeps_a_stale_token_when_there_is_no_account_token() -> None:
+    from providers.scrobble.plex.watch import _plex_btok
+
+    base, token = _plex_btok(
+        {
+            "plex": {
+                "pms_token": "PMS-A",
+                "pms_token_server": SERVER_A,
+                "server_url": SERVER_B,
+            }
+        }
+    )
+    assert (base, token) == (SERVER_B, "PMS-A")


### PR DESCRIPTION
# Pull request

## Change

- Bind the PMS token to the server it was issued for and rebind it when the server URL changes
- Probe servers during discovery instead of taking whatever plex.tv lists first
- Key the library cache per server so profiles stop returning each other's libraries
- Resolve the shared server token before connecting in the sync adapter
- Pass the instance when loading libraries in the pair config modal
- Stop persisting config when a server URL is only being probed
- Drop discover_pms_access_from_cloud, nothing calls it anymore

## Why

A PMS token only works on the server that issued it, but the code only fetched one when it was missing, never when it was stale. Switch servers and it kept sending the old token, got a 401, and showed no libraries. Manual URL overrides looked broken for the same reason.

Discovery just took whatever server plex.tv listed first, reachable or not. It now probes /identity.

The library cache was one slot with a global throttle, so profiles could get each other's libraries, and the insecure retry never actually ran.

## Testing

- test_plex_server_binding.py

## Issue

Relates to #668
Relates to discussion #665

Note:
PR was made during my vacation with limited test resources. Needs proper validation.