### PR TITLE
Add: dev-db image workflow

### DIFF
--- a/.github/workflows/dev-db-image.yml
+++ b/.github/workflows/dev-db-image.yml
@@ -1,0 +1,49 @@
+name: dev-db-image
+
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/crosswatch-dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check branch
+        if: github.ref_name != 'dev-db'
+        run: |
+          echo "Run this from the dev-db branch, got ${{ github.ref_name }}"
+          exit 1
+
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=dev-db
+            type=sha,prefix=dev-db-
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
# Pull request

## Change

- Add dev-db-image workflow, builds and pushes ghcr.io/cenodude/crosswatch-dev:dev-db

## Why

Same package as dev-image, only the tag differs.

## Testing

NA

## Issue

NA
