### PR TITLE
Fix: keep Plex discovery on the server bound

### DIFF
--- a/providers/sync/plex/_utils.py
+++ b/providers/sync/plex/_utils.py
@@ -347,7 +347,7 @@ _DISCOVERY_PROBE_MAX = int(os.environ.get("CW_PLEX_DISCOVERY_PROBE_MAX", "6"))
 _DISCOVERY_PROBE_TIMEOUT_S = float(os.environ.get("CW_PLEX_DISCOVERY_PROBE_TIMEOUT_S", "3"))
 
 
-def _rank_server_candidates(xml_text: str) -> list[dict[str, Any]]:
+def _rank_server_candidates(xml_text: str, machine_id: str = "") -> list[dict[str, Any]]:
     try:
         root = ET.fromstring(xml_text)
     except Exception:  # noqa: BLE001
@@ -379,7 +379,16 @@ def _rank_server_candidates(xml_text: str) -> list[dict[str, Any]]:
                 }
             )
 
-    out.sort(key=lambda c: (-int(c["score"]), not c["owned"], str(c["name"]), str(c["uri"])))
+    pin = str(machine_id or "").strip()
+    out.sort(
+        key=lambda c: (
+            not (pin and str(c["machine_id"]) == pin),
+            -int(c["score"]),
+            not c["owned"],
+            str(c["name"]),
+            str(c["uri"]),
+        )
+    )
     return out
 
 
@@ -403,8 +412,10 @@ def _probe_identity(uri: str, token: str, timeout: float) -> bool:
     return False
 
 
-def _pick_server_url_from_resources(xml_text: str, account_token: str = "", probe: bool = False) -> str:
-    candidates = _rank_server_candidates(xml_text)
+def _pick_server_url_from_resources(
+    xml_text: str, account_token: str = "", probe: bool = False, machine_id: str = ""
+) -> str:
+    candidates = _rank_server_candidates(xml_text, machine_id)
     if not candidates:
         return ""
     if not probe:
@@ -424,6 +435,7 @@ def _pick_server_url_from_resources(xml_text: str, account_token: str = "", prob
                 server_url=str(cand["uri"]),
                 server_name=str(cand.get("name") or ""),
                 owned=bool(cand.get("owned")),
+                pinned=bool(machine_id and str(cand["machine_id"]) == str(machine_id).strip()),
             )
             return str(cand["uri"])
 
@@ -432,7 +444,9 @@ def _pick_server_url_from_resources(xml_text: str, account_token: str = "", prob
     return fallback
 
 
-def discover_server_url_from_cloud(token: str, timeout: float = 10.0, probe: bool = True) -> str | None:
+def discover_server_url_from_cloud(
+    token: str, timeout: float = 10.0, probe: bool = True, machine_id: str = ""
+) -> str | None:
     try:
         response = requests.get(
             "https://plex.tv/api/resources?includeHttps=1&includeRelay=1&includeIPv6=1",
@@ -440,7 +454,9 @@ def discover_server_url_from_cloud(token: str, timeout: float = 10.0, probe: boo
             timeout=timeout,
         )
         if response.ok and (response.text or "").lstrip().startswith("<"):
-            picked = _pick_server_url_from_resources(response.text, account_token=token, probe=probe)
+            picked = _pick_server_url_from_resources(
+                response.text, account_token=token, probe=probe, machine_id=machine_id
+            )
             return picked or None
     except Exception:  # noqa: BLE001
         pass
@@ -878,7 +894,8 @@ def fetch_libraries_from_cfg(
     if not cloud_token:
         return []
     if not base:
-        base_url = discover_server_url_from_cloud(cloud_token) or ""
+        pin = (plex.get("machine_id") or "").strip()
+        base_url = discover_server_url_from_cloud(cloud_token, machine_id=pin) or ""
         if base_url:
             _insert_key_first_inplace(plex, "server_url", base_url)
             if persist:
@@ -962,7 +979,7 @@ def inspect_and_persist(cfg: dict[str, Any] | None = None, instance_id: Any = No
 
 
     if token and not base:
-        base_url = discover_server_url_from_cloud(token) or ""
+        base_url = discover_server_url_from_cloud(token, machine_id=machine_id) or ""
         if base_url:
             _insert_key_first_inplace(plex, "server_url", base_url)
             save_config(cfg)

--- a/tests/test_plex_server_binding.py
+++ b/tests/test_plex_server_binding.py
@@ -223,6 +223,81 @@ def test_candidate_ranking_is_deterministic_not_document_order() -> None:
         assert u._pick_server_url_from_resources(xml, probe=False) == SERVER_A
 
 
+MULTI_SERVER_XML = """<MediaContainer>
+  <Device name="Owned Server" provides="server" owned="1" clientIdentifier="mid-owned" accessToken="T">
+    <Connection protocol="https" uri="{owned}" local="0" relay="0"/>
+  </Device>
+  <Device name="Shared Server" provides="server" owned="0" clientIdentifier="mid-shared" accessToken="T">
+    <Connection protocol="https" uri="{shared}" local="0" relay="0"/>
+  </Device>
+</MediaContainer>""".format(owned=SERVER_A, shared=SERVER_B)
+
+
+def test_discovery_stays_on_the_bound_server(monkeypatch) -> None:
+    from providers.sync.plex import _utils as u
+
+    monkeypatch.setattr(u, "_probe_identity", lambda *a, **k: True)
+
+    assert u._pick_server_url_from_resources(MULTI_SERVER_XML, probe=True) == SERVER_A
+    assert (
+        u._pick_server_url_from_resources(MULTI_SERVER_XML, probe=True, machine_id="mid-shared")
+        == SERVER_B
+    )
+
+
+def test_bound_server_is_preferred_before_reachability_order(monkeypatch) -> None:
+    from providers.sync.plex import _utils as u
+
+    probed: list[str] = []
+
+    def _probe(uri, token, timeout):
+        probed.append(uri)
+        return True
+
+    monkeypatch.setattr(u, "_probe_identity", _probe)
+    u._pick_server_url_from_resources(MULTI_SERVER_XML, probe=True, machine_id="mid-shared")
+
+    assert probed[0] == SERVER_B
+
+
+def test_unknown_binding_falls_back_to_normal_ranking(monkeypatch) -> None:
+    from providers.sync.plex import _utils as u
+
+    monkeypatch.setattr(u, "_probe_identity", lambda *a, **k: True)
+
+    assert (
+        u._pick_server_url_from_resources(MULTI_SERVER_XML, probe=True, machine_id="gone")
+        == SERVER_A
+    )
+
+
+def test_rediscovery_reuses_the_stored_machine_id(monkeypatch) -> None:
+    from providers.sync.plex import _utils as u
+
+    block: dict[str, Any] = {
+        "account_token": "ACCOUNT",
+        "machine_id": "mid-shared",
+        "server_url": "",
+    }
+    cfg = {"plex": block}
+    seen: dict[str, Any] = {}
+
+    def _discover(token, timeout=10.0, probe=True, machine_id=""):
+        seen["machine_id"] = machine_id
+        return SERVER_B
+
+    monkeypatch.setattr(u, "discover_server_url_from_cloud", _discover)
+    monkeypatch.setattr(u, "save_config", lambda _c: None)
+    monkeypatch.setattr(u, "_resolve_verify_from_cfg", lambda *a, **k: True)
+    monkeypatch.setattr(u, "_resource_token_for_connection", lambda *a, **k: ("mid-shared", "PMS-B"))
+    _patch_transport(monkeypatch, lambda s, b, p, timeout=10.0: _Resp(200, SECTIONS_B))
+
+    u.fetch_libraries_from_cfg(cfg)
+
+    assert seen["machine_id"] == "mid-shared"
+    assert block["server_url"] == SERVER_B
+
+
 def test_media_override_drops_a_token_bound_to_another_server() -> None:
     import api.authenticationAPI as auth
 


### PR DESCRIPTION
# Pull request

## Change

- Prefer connections belonging to the stored machine_id when discovery runs
- Log pinned=true/false on the probe result so it is visible which server was picked and why

## Why

CW already stores machine_id and pms_token_server for the server you ended up on, but discovery only ever got the account token and re-decided from scratch. On an account with more than one Plex resource, a working setup can drift to a different server after discovery runs again.

## Testing

- test_plex_server_binding.py

## Issue

Relates to discussion #665
