### PR TITLE
Fix: playback progress provider timeouts

### DIFF
--- a/assets/js/playback_progress.js
+++ b/assets/js/playback_progress.js
@@ -21,7 +21,7 @@
     return `<img src="${esc(providerLogLogo(provider))}" alt="" onerror="this.remove()">`;
   };
   const PLAYBACK_PROVIDER_KEYS = ["crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy"];
-  const DEFAULT_PROVIDER_TIMEOUT_SECONDS = 12;
+  const DEFAULT_PROVIDER_TIMEOUT_SECONDS = 20;
   const state = {
     mounted: false,
     page: 1,
@@ -423,7 +423,7 @@
     dlg.classList.remove("hidden");
     const data = await api("/api/playback_progress/settings");
     state.settings = data;
-    timeout.value = String(Math.round(Number(data.provider_timeout_seconds || 12)));
+    timeout.value = String(Math.round(Number(data.provider_timeout_seconds || DEFAULT_PROVIDER_TIMEOUT_SECONDS)));
     list.innerHTML = renderSettingsProfiles(data);
     updateSettingsCount();
   }

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -396,7 +396,7 @@ DEFAULT_CFG: dict[str, Any] = {
 
     "playback_progress": {
         "disabled_profiles": [],                        # Provider profiles excluded from Continue Watching, e.g. ["trakt:default"]
-        "provider_timeout_seconds": 12.0,               # Max time this screen waits for provider profiles during one refresh
+        "provider_timeout_seconds": 20.0,               # Max time this screen waits for provider profiles during one refresh
     },
     
      "tautulli": {

--- a/providers/metadata/_meta_TMDB.py
+++ b/providers/metadata/_meta_TMDB.py
@@ -33,6 +33,7 @@ IMG_BASE = "https://image.tmdb.org/t/p"
 class TmdbProvider:
     name = "TMDB"
     UA = "CrossWatch/1.0"
+    CACHE_MAX_ENTRIES = 4096
 
     @staticmethod
     def manifest() -> dict[str, Any]:
@@ -72,6 +73,18 @@ class TmdbProvider:
         except Exception:
             hours = 720
         return max(1, hours) * 3600
+
+    def _prune_cache(self) -> None:
+        if len(self._cache) < self.CACHE_MAX_ENTRIES:
+            return
+        ttl = self._ttl_seconds()
+        now = time.time()
+        for key in [k for k, (ts, _) in self._cache.items() if (now - ts) >= ttl]:
+            self._cache.pop(key, None)
+        overflow = len(self._cache) - self.CACHE_MAX_ENTRIES
+        if overflow > 0:
+            for key, _ in sorted(self._cache.items(), key=lambda kv: kv[1][0])[:overflow]:
+                self._cache.pop(key, None)
 
     def _backoff_params(self) -> tuple[int, float, float]:
         cfg = self.load_cfg() or {}
@@ -162,6 +175,7 @@ class TmdbProvider:
 
                 r.raise_for_status()
                 data = r.json()
+                self._prune_cache()
                 self._cache[h] = (time.time(), data)
                 return data
 

--- a/services/playback_progress/adapters/base.py
+++ b/services/playback_progress/adapters/base.py
@@ -4,11 +4,18 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Mapping
+from concurrent.futures import ThreadPoolExecutor
+from threading import RLock
+from typing import Any, Callable, Mapping, Sequence, TypeVar
 
 from providers.metadata._meta_TMDB import TmdbProvider
 
 from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult
+
+ENRICH_WORKERS = 8
+
+_T = TypeVar("_T")
+_R = TypeVar("_R")
 
 
 class PlaybackProgressAdapter:
@@ -157,6 +164,21 @@ def rating_from_sources(*sources: Any) -> float | None:
     return None
 
 
+def has_metadata_ids(ids: Mapping[str, Any]) -> bool:
+    return any(str(ids.get(key) or "").strip() for key in ("tmdb", "imdb", "tvdb"))
+
+
+def enrich_parallel(entries: Sequence[_T], worker: Callable[[_T], _R]) -> list[_R]:
+    if len(entries) < 2:
+        return [worker(entry) for entry in entries]
+    with ThreadPoolExecutor(max_workers=min(ENRICH_WORKERS, len(entries))) as pool:
+        return list(pool.map(worker, entries))
+
+
+_TMDB_PROVIDER_LOCK = RLock()
+_TMDB_PROVIDERS: dict[str, TmdbProvider] = {}
+
+
 def tmdb_metadata_provider(config_view: Mapping[str, Any]) -> TmdbProvider | None:
     def _as_mapping(value: Any) -> Mapping[str, Any]:
         return value if isinstance(value, Mapping) else {}
@@ -172,10 +194,18 @@ def tmdb_metadata_provider(config_view: Mapping[str, Any]) -> TmdbProvider | Non
 
     tmdb = _as_mapping(config_view.get("tmdb"))
     metadata = _as_mapping(config_view.get("metadata"))
-    if not _first_str(tmdb.get("api_key"), metadata.get("tmdb_api_key")):
+    api_key = _first_str(tmdb.get("api_key"), metadata.get("tmdb_api_key"))
+    if not api_key:
         return None
     cfg = dict(config_view)
-    return TmdbProvider(lambda: cfg, lambda _cfg: None)
+    with _TMDB_PROVIDER_LOCK:
+        provider = _TMDB_PROVIDERS.get(api_key)
+        if provider is None:
+            provider = TmdbProvider(lambda: cfg, lambda _cfg: None)
+            _TMDB_PROVIDERS[api_key] = provider
+        else:
+            provider.load_cfg = lambda: cfg
+    return provider
 
 
 def metadata_rating(

--- a/services/playback_progress/adapters/crosswatch.py
+++ b/services/playback_progress/adapters/crosswatch.py
@@ -10,7 +10,7 @@ from cw_platform.id_map import canonical_key, minimal as id_minimal
 from providers.sync._mod_CROSSWATCH import OPS as CROSSWATCH_OPS
 
 from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
-from .base import PlaybackProgressAdapter, public_failure, tmdb_metadata_provider
+from .base import PlaybackProgressAdapter, enrich_parallel, public_failure, tmdb_metadata_provider
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:
@@ -192,7 +192,8 @@ class CrossWatchPlaybackAdapter(PlaybackProgressAdapter):
         except Exception:
             return PlaybackListResult(False, self.provider, instance_id, error_code="provider_error", message="CrossWatch tracker progress request failed.", retryable=True)
         metadata = tmdb_metadata_provider(config_view)
-        items = [self._record(key, item, instance_id, instance_label, caps, metadata) for key, item in dict(index).items() if isinstance(item, Mapping)]
+        pending = [(key, item) for key, item in dict(index).items() if isinstance(item, Mapping)]
+        items = enrich_parallel(pending, lambda entry: self._record(entry[0], entry[1], instance_id, instance_label, caps, metadata))
         return PlaybackListResult(True, self.provider, instance_id, items=[item for item in items if item], refreshed_at=utc_now_iso())
 
     def _record(self, key: Any, item: Mapping[str, Any], instance_id: str, instance_label: str, caps: PlaybackCapabilities, metadata: Any = None) -> PlaybackRecord | None:

--- a/services/playback_progress/adapters/mdblist.py
+++ b/services/playback_progress/adapters/mdblist.py
@@ -9,7 +9,7 @@ from cw_platform.id_map import canonical_key, minimal as id_minimal
 from providers.sync._mod_MDBLIST import MDBLISTModule, OPS as MDBLIST_OPS
 
 from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
-from .base import PlaybackProgressAdapter, metadata_rating, public_failure, rating_from_sources, tmdb_metadata_provider
+from .base import PlaybackProgressAdapter, enrich_parallel, has_metadata_ids, metadata_rating, public_failure, rating_from_sources, tmdb_metadata_provider
 
 
 MDBLIST_PLAYBACK_REASON = ""
@@ -232,7 +232,7 @@ class MDBListPlaybackAdapter(PlaybackProgressAdapter):
                         rows.extend(row for row in value if isinstance(row, Mapping))
             caps = self.capabilities(config_view, instance_id=instance_id, instance_label=instance_label)
             metadata = tmdb_metadata_provider(config_view)
-            items = [self._normalize(row, instance_id, instance_label, caps, metadata) for row in rows]
+            items = enrich_parallel(rows, lambda row: self._normalize(row, instance_id, instance_label, caps, metadata))
             return PlaybackListResult(
                 ok=True,
                 provider=self.provider,
@@ -329,7 +329,8 @@ class MDBListPlaybackAdapter(PlaybackProgressAdapter):
             show_rating_ids = clean_mapping(history_item.get("show_ids") if isinstance(history_item.get("show_ids"), Mapping) else {})
             rating_ids = ids if media_type == "movie" else show_rating_ids or ids
             rating_title = title if media_type == "movie" else series_title or title
-            rating = metadata_rating(metadata, media_type=media_type, ids=rating_ids, title=rating_title, year=year)
+            if has_metadata_ids(rating_ids):
+                rating = metadata_rating(metadata, media_type=media_type, ids=rating_ids, title=rating_title, year=year)
         return PlaybackRecord(
             provider=self.provider,
             provider_label=self.provider_label,

--- a/services/playback_progress/adapters/media_servers.py
+++ b/services/playback_progress/adapters/media_servers.py
@@ -9,7 +9,15 @@ from cw_platform.id_map import canonical_key, minimal as id_minimal
 from providers.metadata._meta_TMDB import TmdbProvider
 
 from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
-from .base import PlaybackProgressAdapter, metadata_rating, public_failure, rating_from_sources
+from .base import (
+    PlaybackProgressAdapter,
+    enrich_parallel,
+    has_metadata_ids,
+    metadata_rating,
+    public_failure,
+    rating_from_sources,
+    tmdb_metadata_provider,
+)
 
 try:
     from providers.sync._mod_EMBY import OPS as EMBY_OPS
@@ -138,19 +146,6 @@ def _successful_write(result: Mapping[str, Any]) -> bool:
     return count == 0 and isinstance(unresolved, list) and len(unresolved) == 0
 
 
-def _has_metadata_ids(ids: Mapping[str, Any]) -> bool:
-    return any(_first_str(ids.get(key)) for key in ("tmdb", "imdb", "tvdb"))
-
-
-def _metadata_provider(config_view: Mapping[str, Any]) -> TmdbProvider | None:
-    tmdb = _as_mapping(config_view.get("tmdb"))
-    metadata = _as_mapping(config_view.get("metadata"))
-    if not _first_str(tmdb.get("api_key"), metadata.get("tmdb_api_key")):
-        return None
-    cfg = dict(config_view)
-    return TmdbProvider(lambda: cfg, lambda _cfg: None)
-
-
 def _resolve_with_metadata(
     provider: TmdbProvider | None,
     *,
@@ -159,7 +154,7 @@ def _resolve_with_metadata(
     year: Any,
     ids: Mapping[str, Any],
 ) -> dict[str, Any]:
-    if _has_metadata_ids(ids):
+    if has_metadata_ids(ids):
         return dict(ids)
     if provider is None or not title:
         return dict(ids)
@@ -268,14 +263,13 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
                         retryable=status != "auth_failed",
                     )
             rows = ops.build_index(config_view, feature="progress")
-            metadata_provider = _metadata_provider(config_view)
-            items = [
-                record
-                for key, row in (rows or {}).items()
-                if isinstance(row, Mapping)
-                for record in [self._normalize(str(key), row, metadata_provider, instance_id, instance_label, caps)]
-                if record is not None
-            ]
+            metadata_provider = tmdb_metadata_provider(config_view)
+            pending = [(str(key), row) for key, row in (rows or {}).items() if isinstance(row, Mapping)]
+            records = enrich_parallel(
+                pending,
+                lambda entry: self._normalize(entry[0], entry[1], metadata_provider, instance_id, instance_label, caps),
+            )
+            items = [record for record in records if record is not None]
             return PlaybackListResult(ok=True, provider=self.provider, instance_id=instance_id, items=items, refreshed_at=utc_now_iso())
         except Exception:
             return PlaybackListResult(ok=False, provider=self.provider, instance_id=instance_id, error_code="provider_error", message=f"{self.provider_label} playback request failed.", retryable=True)
@@ -322,9 +316,11 @@ class _MediaServerPlaybackAdapter(PlaybackProgressAdapter):
             }
         )
         canonical = canonical_key(item) or key or ""
-        rating_ids = show_ids if media_type in {"episode", "anime_episode"} and _has_metadata_ids(show_ids) else ids
+        rating_ids = show_ids if media_type in {"episode", "anime_episode"} and has_metadata_ids(show_ids) else ids
         rating_title = (series_title or title) if media_type in {"episode", "anime_episode"} else title
-        rating = rating_from_sources(row) or metadata_rating(metadata_provider, media_type=media_type, ids=rating_ids, title=rating_title, year=row.get("year"))
+        rating = rating_from_sources(row)
+        if rating is None and has_metadata_ids(rating_ids):
+            rating = metadata_rating(metadata_provider, media_type=media_type, ids=rating_ids, title=rating_title, year=row.get("year"))
         return PlaybackRecord(
             provider=self.provider,
             provider_label=self.provider_label,

--- a/services/playback_progress/adapters/nuvio.py
+++ b/services/playback_progress/adapters/nuvio.py
@@ -11,7 +11,7 @@ from cw_platform.id_map import canonical_key, minimal as id_minimal
 from providers.sync._mod_NUVIO import OPS as NUVIO_OPS
 
 from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
-from .base import PlaybackProgressAdapter, public_failure, tmdb_metadata_provider
+from .base import PlaybackProgressAdapter, enrich_parallel, public_failure, tmdb_metadata_provider
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:
@@ -216,7 +216,8 @@ class NuvioPlaybackAdapter(PlaybackProgressAdapter):
         except Exception:
             return PlaybackListResult(False, self.provider, instance_id, error_code="provider_error", message="Nuvio progress request failed.", retryable=True)
         metadata = tmdb_metadata_provider(config_view)
-        items = [self._record(key, item, instance_id, instance_label, caps, metadata) for key, item in dict(index).items() if isinstance(item, Mapping)]
+        pending = [(key, item) for key, item in dict(index).items() if isinstance(item, Mapping)]
+        items = enrich_parallel(pending, lambda entry: self._record(entry[0], entry[1], instance_id, instance_label, caps, metadata))
         return PlaybackListResult(True, self.provider, instance_id, items=[item for item in items if item], refreshed_at=utc_now_iso())
 
     def _record(self, key: Any, item: Mapping[str, Any], instance_id: str, instance_label: str, caps: PlaybackCapabilities, metadata: Any = None) -> PlaybackRecord | None:

--- a/services/playback_progress/adapters/publicmetadb.py
+++ b/services/playback_progress/adapters/publicmetadb.py
@@ -10,7 +10,7 @@ from providers.metadata._meta_TMDB import TmdbProvider
 from providers.sync._mod_PUBLICMETADB import OPS as PUBLICMETADB_OPS, PUBLICMETADBModule
 
 from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
-from .base import PlaybackProgressAdapter, metadata_rating, public_failure, rating_from_sources
+from .base import PlaybackProgressAdapter, enrich_parallel, has_metadata_ids, metadata_rating, public_failure, rating_from_sources, tmdb_metadata_provider
 
 
 def _int(value: Any) -> int | None:
@@ -79,15 +79,6 @@ def _first_nested_int(row: Mapping[str, Any], *keys: str) -> int | None:
             if value is not None:
                 return value
     return None
-
-
-def _metadata_provider(config_view: Mapping[str, Any]) -> TmdbProvider | None:
-    tmdb = _as_mapping(config_view.get("tmdb"))
-    metadata = _as_mapping(config_view.get("metadata"))
-    if not _first_str(tmdb.get("api_key"), metadata.get("tmdb_api_key")):
-        return None
-    cfg = dict(config_view)
-    return TmdbProvider(lambda: cfg, lambda _cfg: None)
 
 
 def _metadata_title(
@@ -265,8 +256,8 @@ class PublicMetaDBPlaybackAdapter(PlaybackProgressAdapter):
                 page += 1
 
             caps = self.capabilities(config_view, instance_id=instance_id, instance_label=instance_label)
-            metadata = _metadata_provider(config_view)
-            items = [self._normalize(row, instance_id, instance_label, caps, metadata) for row in rows]
+            metadata = tmdb_metadata_provider(config_view)
+            items = enrich_parallel(rows, lambda row: self._normalize(row, instance_id, instance_label, caps, metadata))
             return PlaybackListResult(
                 ok=True,
                 provider=self.provider,
@@ -353,7 +344,9 @@ class PublicMetaDBPlaybackAdapter(PlaybackProgressAdapter):
             progress = round((float(progress_ms) / float(runtime_ms)) * 100.0, 3)
         canonical = canonical_key(item) or ""
         duration_seconds = _ms_to_seconds(runtime_ms)
-        rating = rating_from_sources(row) or metadata_rating(metadata, media_type=media_type, ids=ids, title=title, year=year)
+        rating = rating_from_sources(row)
+        if rating is None and has_metadata_ids(ids):
+            rating = metadata_rating(metadata, media_type=media_type, ids=ids, title=title, year=year)
         return PlaybackRecord(
             provider=self.provider,
             provider_label=self.provider_label,

--- a/services/playback_progress/adapters/simkl.py
+++ b/services/playback_progress/adapters/simkl.py
@@ -11,7 +11,7 @@ from providers.sync._mod_SIMKL import OPS as SIMKL_OPS, SIMKLModule, __VERSION__
 from providers.sync.simkl._common import build_headers
 
 from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
-from .base import PlaybackProgressAdapter, public_failure, rating_from_sources, tmdb_metadata_provider
+from .base import PlaybackProgressAdapter, enrich_parallel, has_metadata_ids, public_failure, rating_from_sources, tmdb_metadata_provider
 
 
 def _int(value: Any) -> int | None:
@@ -295,7 +295,7 @@ class SimklPlaybackAdapter(PlaybackProgressAdapter):
                     if isinstance(bucket, list):
                         rows.extend([r for r in bucket if isinstance(r, Mapping)])
             metadata = tmdb_metadata_provider(config_view)
-            items = [self._normalize(row, instance_id, instance_label, caps, metadata) for row in rows]
+            items = enrich_parallel(rows, lambda row: self._normalize(row, instance_id, instance_label, caps, metadata))
             return PlaybackListResult(ok=True, provider=self.provider, instance_id=instance_id, items=[x for x in items if x], refreshed_at=utc_now_iso())
         except Exception:
             return PlaybackListResult(ok=False, provider=self.provider, instance_id=instance_id, error_code="provider_error", message="SIMKL playback request failed.", retryable=True)
@@ -352,7 +352,7 @@ class SimklPlaybackAdapter(PlaybackProgressAdapter):
         rating_ids = container_ids if media_type == "movie" else (container_ids or episode_ids)
         rating_title = title if media_type == "movie" else series_title or title
         rating = rating_from_sources(row, container, episode)
-        if duration is None or rating is None:
+        if (duration is None or rating is None) and has_metadata_ids(rating_ids):
             meta_rating, meta_duration = _metadata_rating_duration(
                 metadata,
                 media_type=media_type,

--- a/services/playback_progress/adapters/stremio.py
+++ b/services/playback_progress/adapters/stremio.py
@@ -11,7 +11,7 @@ from providers.sync._mod_STREMIO import OPS as STREMIO_OPS
 from providers.sync.stremio._common import DEFAULT_STREMIO_PROFILE_ID
 
 from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
-from .base import PlaybackProgressAdapter, public_failure, tmdb_metadata_provider
+from .base import PlaybackProgressAdapter, enrich_parallel, public_failure, tmdb_metadata_provider
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:
@@ -187,7 +187,8 @@ class StremioPlaybackAdapter(PlaybackProgressAdapter):
         except Exception:
             return PlaybackListResult(False, self.provider, instance_id, error_code="provider_error", message="Stremio progress request failed.", retryable=True)
         metadata = tmdb_metadata_provider(config_view)
-        items = [self._record(key, item, instance_id, instance_label, caps, metadata) for key, item in dict(index).items() if isinstance(item, Mapping)]
+        pending = [(key, item) for key, item in dict(index).items() if isinstance(item, Mapping)]
+        items = enrich_parallel(pending, lambda entry: self._record(entry[0], entry[1], instance_id, instance_label, caps, metadata))
         return PlaybackListResult(True, self.provider, instance_id, items=[item for item in items if item], refreshed_at=utc_now_iso())
 
     def _record(self, key: Any, item: Mapping[str, Any], instance_id: str, instance_label: str, caps: PlaybackCapabilities, metadata: Any = None) -> PlaybackRecord | None:

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -34,7 +34,7 @@ from .models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResu
 LOG = BASE_LOG.child("PLAYBACK")
 CACHE_TTL_SECONDS = 60.0
 MAX_WORKERS = 6
-DEFAULT_PROVIDER_TIMEOUT_SECONDS = 12.0
+DEFAULT_PROVIDER_TIMEOUT_SECONDS = 20.0
 GROUP_PROGRESS_TOLERANCE = 2.0
 PHASE1_PROVIDERS = ("crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy")
 SORT_VALUES = {"last_updated", "progress_high", "progress_low", "remaining_time", "rating_high", "title", "provider"}
@@ -973,12 +973,13 @@ class PlaybackProgressService:
         if result.ok:
             result = _apply_progress_edit_policy(result, adapter)
         elapsed_ms = int((time.monotonic() - started) * 1000)
+        stored_at = time.time()
         with self._lock:
             if result.ok:
-                self._cache[key] = {"ts": now, "result": result, "activity_marker": marker, "refreshed_at": result.refreshed_at}
+                self._cache[key] = {"ts": stored_at, "result": result, "activity_marker": marker, "refreshed_at": result.refreshed_at}
                 LOG.debug(f"provider listed provider={provider} instance={instance_id} items={len(result.items)} elapsed_ms={elapsed_ms}")
             else:
-                self._cache[key] = {"ts": now, "result": result, "activity_marker": marker, "error": result.to_error()}
+                self._cache[key] = {"ts": stored_at, "result": result, "activity_marker": marker, "error": result.to_error()}
                 LOG.warn(f"provider list failed provider={provider} instance={instance_id} error={result.error_code or 'provider_error'} status={result.remote_status or ''} elapsed_ms={elapsed_ms}")
         return result
 

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import threading
+import time
 from pathlib import Path
 from typing import cast
+
+from providers.metadata._meta_TMDB import TmdbProvider
 
 from services.playback_progress.service import (
     _combine_records,
@@ -14,7 +18,9 @@ from services.playback_progress.service import (
     PlaybackProgressService,
 )
 from services.playback_progress.models import PlaybackCapabilities
-from services.playback_progress.adapters.base import PlaybackProgressAdapter
+from services.playback_progress.adapters.base import PlaybackProgressAdapter, enrich_parallel
+import services.playback_progress.adapters.base as base_adapter
+import services.playback_progress.adapters.media_servers as media_servers_adapter
 import services.playback_progress.service as playback_service
 import services.playback_progress.adapters.floppy as floppy_playback_adapter
 import services.playback_progress.adapters.nuvio as nuvio_playback_adapter
@@ -1102,3 +1108,130 @@ def test_nuvio_playback_progress_enriches_episode_metadata_from_tvdb_id(monkeypa
     assert record is not None
     assert record.title == "The Boys"
     assert record.series_title == "The Boys"
+
+
+class _CountingTmdb:
+    def __init__(self, *, resolves=True):
+        self.resolves = resolves
+        self.calls = []
+
+    def fetch(self, *, entity, ids, need=None):
+        self.calls.append(dict(ids))
+        if not self.resolves:
+            return {}
+        return {"vote_average": 8.0, "ids": {"tmdb": "999"}}
+
+
+def _progress_rows(count, *, with_ids):
+    rows = {}
+    for i in range(count):
+        ids = {"plex": str(9000 + i)}
+        if with_ids:
+            ids["imdb"] = f"tt{i:07d}"
+        rows[f"movie:{i}"] = {
+            "type": "movie",
+            "title": f"Movie {i}",
+            "year": 2026,
+            "ids": ids,
+            "progress_ms": 60000,
+            "duration_ms": 600000,
+        }
+    return rows
+
+
+def _plex_adapter(rows):
+    class _Ops:
+        def is_configured(self, cfg):
+            return True
+
+        def health(self, cfg):
+            return {"ok": True, "status": "ok"}
+
+        def build_index(self, cfg, feature=None):
+            return rows
+
+    adapter = media_servers_adapter.PlexPlaybackAdapter()
+    adapter.ops = _Ops()
+    return adapter
+
+
+def test_playback_progress_does_not_search_twice_for_unresolvable_rows(monkeypatch):
+    tmdb = _CountingTmdb(resolves=False)
+    monkeypatch.setattr(media_servers_adapter, "tmdb_metadata_provider", lambda cfg: tmdb)
+
+    result = _plex_adapter(_progress_rows(5, with_ids=False)).list_progress(
+        {"tmdb": {"api_key": "key"}}, instance_id="default", instance_label="Default"
+    )
+
+    assert result.ok is True
+    assert len(result.items) == 5
+    assert all(record.rating is None for record in result.items)
+    assert len(tmdb.calls) == 5
+
+
+def test_playback_progress_keeps_ratings_for_rows_resolved_by_search(monkeypatch):
+    tmdb = _CountingTmdb()
+    monkeypatch.setattr(media_servers_adapter, "tmdb_metadata_provider", lambda cfg: tmdb)
+
+    result = _plex_adapter(_progress_rows(5, with_ids=False)).list_progress(
+        {"tmdb": {"api_key": "key"}}, instance_id="default", instance_label="Default"
+    )
+
+    assert result.ok is True
+    assert all(record.rating == 8.0 for record in result.items)
+
+
+def test_playback_progress_skips_resolve_when_external_ids_exist(monkeypatch):
+    tmdb = _CountingTmdb()
+    monkeypatch.setattr(media_servers_adapter, "tmdb_metadata_provider", lambda cfg: tmdb)
+
+    result = _plex_adapter(_progress_rows(5, with_ids=True)).list_progress(
+        {"tmdb": {"api_key": "key"}}, instance_id="default", instance_label="Default"
+    )
+
+    assert result.ok is True
+    assert all(record.rating == 8.0 for record in result.items)
+    assert len(tmdb.calls) == 5
+    assert all(call.get("imdb") for call in tmdb.calls)
+
+
+def test_enrich_parallel_preserves_order_and_runs_concurrently():
+    barrier = threading.Barrier(4, timeout=10)
+
+    def worker(value):
+        barrier.wait()
+        return value * 2
+
+    assert enrich_parallel(list(range(4)), worker) == [0, 2, 4, 6]
+
+
+def test_enrich_parallel_handles_small_inputs():
+    assert enrich_parallel([], lambda value: value) == []
+    assert enrich_parallel([7], lambda value: value * 3) == [21]
+
+
+def test_tmdb_metadata_provider_is_reused_across_refreshes():
+    cfg = {"tmdb": {"api_key": "shared-key"}, "metadata": {"ttl_hours": 720}}
+
+    first = base_adapter.tmdb_metadata_provider(cfg)
+    first._cache["probe"] = (time.time(), {"cached": True})
+    second = base_adapter.tmdb_metadata_provider(cfg)
+
+    assert first is second
+    assert "probe" in second._cache
+    assert base_adapter.tmdb_metadata_provider({}) is None
+
+
+def test_tmdb_cache_is_bounded(monkeypatch):
+    provider = TmdbProvider(lambda: {"metadata": {"ttl_hours": 1}}, lambda cfg: None)
+    monkeypatch.setattr(TmdbProvider, "CACHE_MAX_ENTRIES", 10)
+    now = time.time()
+    provider._cache["expired"] = (now - 7200, "old")
+    for i in range(12):
+        provider._cache[f"fresh{i}"] = (now + i, i)
+
+    provider._prune_cache()
+
+    assert "expired" not in provider._cache
+    assert len(provider._cache) <= 10
+    assert "fresh11" in provider._cache


### PR DESCRIPTION
# Pull request

## Change

- Reuse one TMDb provider per API key so the metadata cache survives refreshes
- Enrich playback rows in parallel across all 7 adapters that hit TMDb
- Skip the redundant second TMDb search when a row cannot be resolved
- Bound the TMDb response cache now that it is long lived
- Raise the default provider timeout from 12s to 20s

## Why

The playback list enriched every row against TMDb one at a time.

## Testing

- test_playback_progress.py

## Issue

Relates to #676
