### PR TITLE
Fix: enable anime episode mapping

### DIFF
--- a/api/animeMappingAPI.py
+++ b/api/animeMappingAPI.py
@@ -14,7 +14,7 @@ from cw_platform.anime_mapping.auto_update import refresh_from_config as refresh
 from cw_platform.anime_mapping.auto_update import status as auto_update_status
 from cw_platform.anime_mapping.storage import normalize_release_tag, rebuild_sqlite_from_mappings
 from cw_platform.anime_mapping.updater import status as mapping_status, update as mapping_update
-from cw_platform.config_base import load_config, save_config
+from cw_platform.config_base import ANIME_MAPPING_PAIRS_DEFAULT, load_config, save_config
 
 router = APIRouter(prefix="/api/anime-mapping", tags=["anime-mapping"])
 
@@ -87,7 +87,7 @@ def api_anime_mapping_settings(payload: dict[str, Any] | None = Body(default=Non
             block["stale_after_days"] = _int_at_least(data.get("stale_after_days"), 14, 1)
         if "use_for_pairs" in data:
             providers = _provider_list(data.get("use_for_pairs"))
-            block["use_for_pairs"] = providers or ["anilist"]
+            block["use_for_pairs"] = providers or list(ANIME_MAPPING_PAIRS_DEFAULT)
 
         cfg["anime_mapping"] = block
         save_config(cfg)
@@ -99,7 +99,7 @@ def api_anime_mapping_settings(payload: dict[str, Any] | None = Body(default=Non
                 "enabled": bool(block.get("enabled", False)),
                 "auto_update": bool(block.get("auto_update", True)),
                 "release_tag": str(block.get("release_tag") or "v3"),
-                "use_for_pairs": ",".join(_provider_list(block.get("use_for_pairs")) or ["anilist"]),
+                "use_for_pairs": ",".join(_provider_list(block.get("use_for_pairs")) or ANIME_MAPPING_PAIRS_DEFAULT),
             },
         )
         st = mapping_status(cfg=cfg)

--- a/assets/helpers/settings-ui.js
+++ b/assets/helpers/settings-ui.js
@@ -699,7 +699,6 @@ async function cwAnimeMappingSaveSettings() {
         enabled,
         auto_update: autoUpdate,
         provider: "anibridge",
-        use_for_pairs: ["anilist"],
       }),
     });
     const data = await r.json().catch(() => ({}));
@@ -710,7 +709,6 @@ async function cwAnimeMappingSaveSettings() {
       enabled,
       auto_update: autoUpdate,
       provider: "anibridge",
-      use_for_pairs: ["anilist"],
     };
     if (data.status) window.__animeMappingStatus = data.status;
     cwAnimeMappingRenderStatus(data.status || window.__animeMappingStatus || {});

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -1671,6 +1671,10 @@ def _normalize_scheduling(cfg: dict[str, Any]) -> None:
     adv["workflows"] = wf_out
 
 
+ANIME_MAPPING_PAIRS_DEFAULT: list[str] = ["anilist", "simkl"]
+ANIME_MAPPING_FEATURES_DEFAULT: list[str] = ["watchlist", "ratings", "history"]
+
+
 def _normalize_anime_mapping(cfg: dict[str, Any]) -> None:
     am = _ensure_dict(cfg, "anime_mapping")
     am["enabled"] = bool(am.get("enabled", False))
@@ -1708,8 +1712,20 @@ def _normalize_anime_mapping(cfg: dict[str, Any]) -> None:
             out.append(name)
         return out or list(default)
 
-    am["use_for_pairs"] = _string_list(am.get("use_for_pairs"), ["anilist", "simkl"])
-    am["features"] = _string_list(am.get("features"), ["watchlist", "ratings", "history"])
+    def _string_list_union(value: Any, default: list[str]) -> list[str]:
+        raw = value if isinstance(value, list) else []
+        out: list[str] = []
+        seen: set[str] = set()
+        for item in list(raw) + list(default):
+            name = str(item or "").strip().lower()
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            out.append(name)
+        return out or list(default)
+
+    am["use_for_pairs"] = _string_list_union(am.get("use_for_pairs"), ANIME_MAPPING_PAIRS_DEFAULT)
+    am["features"] = _string_list_union(am.get("features"), ANIME_MAPPING_FEATURES_DEFAULT)
 
 
 def _normalize_scrobble_webhook(cfg: dict[str, Any]) -> None:

--- a/tests/test_anime_episodes.py
+++ b/tests/test_anime_episodes.py
@@ -147,3 +147,21 @@ def test_resolution_matches_ids_guards_wrong_entry(index: Path) -> None:
     assert resolution_matches_ids(got, {"mal": "99999"}) is False
     assert resolution_matches_ids(got, {}) is False
     assert resolution_matches_ids(None, {"anilist": "813"}) is False
+
+
+def test_existing_config_is_migrated_to_include_simkl_and_history() -> None:
+    from cw_platform.config_base import _normalize_anime_mapping
+
+    cfg = {"anime_mapping": {"enabled": True, "use_for_pairs": ["anilist"], "features": ["watchlist", "ratings"]}}
+    _normalize_anime_mapping(cfg)
+    assert "simkl" in cfg["anime_mapping"]["use_for_pairs"]
+    assert "history" in cfg["anime_mapping"]["features"]
+
+
+def test_migration_keeps_custom_entries() -> None:
+    from cw_platform.config_base import _normalize_anime_mapping
+
+    cfg = {"anime_mapping": {"enabled": True, "use_for_pairs": ["*"], "features": ["history"]}}
+    _normalize_anime_mapping(cfg)
+    assert cfg["anime_mapping"]["use_for_pairs"][0] == "*"
+    assert set(cfg["anime_mapping"]["features"]) >= {"watchlist", "ratings", "history"}


### PR DESCRIPTION
# Pull request

## Change

* Stopped the settings page from writing a hardcoded use_for_pairs list on every Anime ID Mapping save.
* Added shared defaults for anime mapping pairs and features, and used them for the API fallbacks.
* Changed anime mapping config normalization to merge stored values with the defaults 

## Why

Anime episode mapping could not be switched on by anyone. 

## Testing

* Full suite against the pre-change baseline

## Issue

Relates to #660
