### PR TITLE
Change: improve Plex history write performance

### DIFF
--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -214,6 +214,7 @@ from ._tombstones import clear_items_for_feature
 
 
 from ._pairs_utils import (
+    config_with_pair_libraries as _config_with_pair_libraries,
     _supports_feature,
     _resolve_flags,
     _health_status,
@@ -698,6 +699,7 @@ def run_one_way_feature(
     dst_ops = provs.get(dst)
     anime_pair_opts = _anime_pair_feature_options(cfg, fcfg, feature, src, dst, anime_only_default=(dst == "ANILIST"))
     provider_cfg = _anime_config_with_pair_feature_options(cfg, anime_pair_opts)
+    provider_cfg = _config_with_pair_libraries(provider_cfg, fcfg, feature, (src, dst))
 
     emit("feature:start", src=src, dst=dst, feature=feature)
 

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -101,6 +101,7 @@ from ._phantoms import PhantomGuard  # type: ignore[attr-defined]
 from ._pairs_blocklist import apply_blocklist
 from ._pairs_massdelete import maybe_block_mass_delete as _maybe_block_massdelete
 from ._pairs_utils import (
+    config_with_pair_libraries as _config_with_pair_libraries,
     supports_feature as _supports_feature,
     resolve_flags as _resolve_flags,
     health_status as _health_status,
@@ -347,6 +348,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
     bops = provs.get(b)
     anime_pair_opts = _anime_pair_feature_options(cfg, fcfg, feature, a, b, anime_only_default=(a == "ANILIST" or b == "ANILIST"))
     provider_cfg = _anime_config_with_pair_feature_options(cfg, anime_pair_opts)
+    provider_cfg = _config_with_pair_libraries(provider_cfg, fcfg, feature, (a, b))
     if not aops or not bops:
         info(f"[!] Missing provider ops for {a}<->{b}")
         return {"ok": False, "adds_to_A": 0, "adds_to_B": 0, "rem_from_A": 0, "rem_from_B": 0}

--- a/cw_platform/orchestrator/_pairs_utils.py
+++ b/cw_platform/orchestrator/_pairs_utils.py
@@ -8,6 +8,58 @@ import importlib
 from collections.abc import Mapping as _Mapping
 from ..id_map import canonical_key as _ck, ID_KEYS
 
+LIBRARY_SCOPED_FEATURES = frozenset({"history", "ratings", "progress"})
+
+LIBRARY_PROVIDER_KEYS = {
+    "PLEX": "plex",
+    "JELLYFIN": "jellyfin",
+    "EMBY": "emby",
+    "KODI": "kodi",
+}
+
+
+def pair_feature_libraries(fcfg: Any, provider: str) -> list[str]:
+    lib_cfg = (fcfg or {}).get("libraries") if isinstance(fcfg, Mapping) else None
+    if not isinstance(lib_cfg, Mapping):
+        return []
+    name = str(provider or "").strip()
+    per = lib_cfg.get(name.upper())
+    if per is None:
+        per = lib_cfg.get(name.lower())
+    if not isinstance(per, (list, tuple)):
+        return []
+    return [str(x).strip() for x in per if str(x).strip()]
+
+
+def config_with_pair_libraries(
+    cfg: Mapping[str, Any],
+    fcfg: Any,
+    feature: str,
+    providers: Any,
+) -> dict[str, Any]:
+    base = dict(cfg or {})
+    if str(feature or "").strip().lower() not in LIBRARY_SCOPED_FEATURES:
+        return base
+
+    out: dict[str, Any] | None = None
+    for provider in providers or ():
+        key = LIBRARY_PROVIDER_KEYS.get(str(provider or "").strip().upper())
+        if not key:
+            continue
+        libs = pair_feature_libraries(fcfg, provider)
+        if not libs:
+            continue
+        if out is None:
+            out = dict(base)
+        block = dict(out.get(key) or {})
+        feat = dict(block.get(feature) or {})
+        feat["libraries"] = list(libs)
+        block[feature] = feat
+        out[key] = block
+
+    return out if out is not None else base
+
+
 def supports_feature(ops, feature: str) -> bool:
     try:
         feats = (ops.capabilities() or {}).get("features", {})

--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -40,7 +40,7 @@ def _error(event: str, **fields: Any) -> None:
 def _log(msg: str) -> None:
     _dbg(msg)
 
-__VERSION__ = "2.2"
+__VERSION__ = "2.3"
 os.environ.setdefault("CW_PLEX_VERSION", __VERSION__)
 os.environ.setdefault("CW_PLEX_UA", f"CrossWatch/{__VERSION__} (Plex)")
 __all__ = ["get_manifest", "PLEXModule", "PLEXClient", "PLEXError", "PLEXAuthError", "PLEXNotFound", "OPS"]
@@ -659,7 +659,7 @@ class PLEXClient:
                     self.server._session = self.session  # type: ignore[attr-defined]
                     self._pms_baseurl = str(getattr(self.server, "baseurl", None) or self.cfg.baseurl or "")
                     if self._pms_baseurl and (pms_token or cloud_token):
-                        configure_plex_context(baseurl=str(self._pms_baseurl), token=str(pms_token or cloud_token))
+                        configure_plex_context(baseurl=str(self._pms_baseurl), token=str(pms_token or cloud_token), account_token=cloud_token)
                 except Exception as e:
                     _warn("pms_connect_failed", baseurl=str(self.cfg.baseurl or ""), error=str(e), mode="account_only")
                     self._post_connect_user_scope(str(pms_token or cloud_token))
@@ -679,7 +679,7 @@ class PLEXClient:
                 if pms_token:
                     self._apply_pms_token(pms_token)
                     if self._pms_baseurl:
-                        configure_plex_context(baseurl=str(self._pms_baseurl), token=str(pms_token))
+                        configure_plex_context(baseurl=str(self._pms_baseurl), token=str(pms_token), account_token=cloud_token)
 
                 self._post_connect_user_scope(str(pms_token or cloud_token))
                 _dbg(
@@ -704,7 +704,7 @@ class PLEXClient:
                     pms_token = res_tok
                     self._apply_pms_token(pms_token)
                 if self._pms_baseurl and (pms_token or cloud_token):
-                    configure_plex_context(baseurl=str(self._pms_baseurl), token=str(pms_token or cloud_token))
+                    configure_plex_context(baseurl=str(self._pms_baseurl), token=str(pms_token or cloud_token), account_token=cloud_token)
             except Exception as e:
                 _warn("pms_resource_connect_failed", error=str(e), mode="account_only")
                 self._post_connect_user_scope(str(pms_token or cloud_token))

--- a/providers/sync/plex/_common.py
+++ b/providers/sync/plex/_common.py
@@ -109,12 +109,19 @@ try:
 except ImportError:
     from _id_map import minimal as id_minimal, ids_from_guid  # type: ignore
 
-_PLEX_CTX: dict[str, str | None] = {"baseurl": None, "token": None}
+_PLEX_CTX: dict[str, str | None] = {"baseurl": None, "token": None, "account_token": None}
 
 
-def configure_plex_context(*, baseurl: str | None, token: str | None) -> None:
+def configure_plex_context(
+    *,
+    baseurl: str | None,
+    token: str | None,
+    account_token: str | None = None,
+) -> None:
     _PLEX_CTX["baseurl"] = baseurl.rstrip("/") if isinstance(baseurl, str) else None
     _PLEX_CTX["token"] = token or None
+    if account_token:
+        _PLEX_CTX["account_token"] = account_token
 
 
 DISCOVER = "https://discover.provider.plex.tv"
@@ -938,6 +945,8 @@ def hydrate_external_ids(token: str | None, rating_key: str | None) -> dict[str,
             return {}
 
     headers = plex_headers(token)
+    cloud_token = str(_PLEX_CTX.get("account_token") or "").strip() or token
+    cloud_headers = plex_headers(cloud_token) if cloud_token != token else headers
     base = str(_PLEX_CTX.get("baseurl") or "").strip().rstrip("/")
 
     meta_status: int | None = None
@@ -973,7 +982,12 @@ def hydrate_external_ids(token: str | None, rating_key: str | None) -> dict[str,
 
     for url, kind in urls:
         try:
-            r = requests.get(url, headers=headers, params={"includeGuids": 1}, timeout=10)
+            r = requests.get(
+                url,
+                headers=cloud_headers if kind == "meta" else headers,
+                params={"includeGuids": 1},
+                timeout=10,
+            )
             if kind == "meta":
                 meta_status = r.status_code
             if r.status_code == 401:
@@ -1076,12 +1090,17 @@ def ids_from_discover_row(row: Mapping[str, Any]) -> dict[str, str]:
     return {k: v for k, v in ids.items() if v and str(v).strip().lower() not in ("none", "null")}
 
 
-def normalize_discover_row(row: Mapping[str, Any], *, token: str | None = None) -> dict[str, Any]:
+def normalize_discover_row(
+    row: Mapping[str, Any],
+    *,
+    token: str | None = None,
+    hydrate_item_ids: bool = True,
+) -> dict[str, Any]:
     if token is None:
         token = _PLEX_CTX["token"]
     t = (row.get("type") or "movie").lower()
     ids = ids_from_discover_row(row)
-    if not any(k in ids for k in ("tmdb", "imdb", "tvdb")) and token:
+    if hydrate_item_ids and not any(k in ids for k in ("tmdb", "imdb", "tvdb")) and token:
         rk = row.get("ratingKey")
         ids.update(hydrate_external_ids(token, str(rk) if rk else None))
         ids = {k: v for k, v in ids.items() if v}

--- a/providers/sync/plex/_history.py
+++ b/providers/sync/plex/_history.py
@@ -27,7 +27,6 @@ from ._common import (
     home_scope_exit,
     iso_from_epoch as _iso,
     item_guid_candidates,
-    meta_guids,
     minimal_from_history_row,
     normalize as plex_normalize,
     normalize_discover_row,
@@ -175,6 +174,74 @@ def _clear_guid_index() -> None:
     _GUID_INDEX_KEY = None
 
 
+def _row_guids(row: Mapping[str, Any]) -> list[str]:
+    vals: list[str] = []
+    g = row.get("guid")
+    if g:
+        vals.append(str(g))
+    for gg in row.get("Guid") or []:
+        gid = gg.get("id") if isinstance(gg, Mapping) else None
+        if gid:
+            vals.append(str(gid))
+    return vals
+
+
+def _fetch_section_guid_rows(srv: Any, section_id: str, plex_type: int) -> tuple[list[Mapping[str, Any]], int]:
+    base = _as_base_url(srv)
+    ses = getattr(srv, "_session", None)
+    token = getattr(srv, "token", None) or getattr(srv, "_token", None) or ""
+    if not (base and ses and token and section_id):
+        return [], 0
+
+    headers = dict(getattr(ses, "headers", {}) or {})
+    headers.update(plex_headers(token))
+    headers["Accept"] = "application/json"
+
+    page_size = 1000
+    out: list[Mapping[str, Any]] = []
+    seen_pages: set[tuple[str, ...]] = set()
+    start = 0
+    made = 0
+
+    while True:
+        params = {
+            "type": plex_type,
+            "includeGuids": 1,
+            "X-Plex-Container-Start": start,
+            "X-Plex-Container-Size": page_size,
+        }
+        try:
+            r = ses.get(f"{base}/library/sections/{section_id}/all", params=params, headers=headers, timeout=20)
+        except Exception:
+            break
+        made += 1
+        if not getattr(r, "ok", False):
+            break
+        try:
+            ctype = (r.headers.get("content-type") or "").lower()
+            data = (r.json() or {}) if "application/json" in ctype else _xml_to_container(r.text or "")
+            mc = data.get("MediaContainer") or {}
+            rows = [x for x in (mc.get("Metadata") or []) if isinstance(x, Mapping)]
+            total = mc.get("totalSize")
+            total_i = int(total) if total is not None else None
+        except Exception:
+            break
+        if not rows:
+            break
+        signature = tuple(str(row.get("ratingKey") or row.get("key") or "") for row in rows)
+        if signature in seen_pages:
+            break
+        seen_pages.add(signature)
+        out.extend(rows)
+        start += len(rows)
+        if total_i is not None and start >= total_i:
+            break
+        if len(rows) < page_size:
+            break
+
+    return out, made
+
+
 def _build_guid_index(adapter: Any, allow: set[str], *, force: bool = False) -> None:
     global _GUID_INDEX_KEY
     srv = getattr(getattr(adapter, "client", None), "server", None)
@@ -187,6 +254,7 @@ def _build_guid_index(adapter: Any, allow: set[str], *, force: bool = False) -> 
         _dbg("index_cache_hit", source="guid_index", movies=len(_GUID_INDEX_MOVIE), shows=len(_GUID_INDEX_SHOW))
         return
     try:
+        requests_made = 0
         for sec in adapter.libraries(types=("movie", "show")) or []:
             sid = str(getattr(sec, "key", "") or "").strip()
             if allow and sid and sid not in allow:
@@ -194,23 +262,28 @@ def _build_guid_index(adapter: Any, allow: set[str], *, force: bool = False) -> 
             libtype = "movie" if getattr(sec, "type", "") == "movie" else "show"
             dst = _GUID_INDEX_MOVIE if libtype == "movie" else _GUID_INDEX_SHOW
             try:
-                for obj in (sec.all() or []):
-                    try:
-                        rk = str(getattr(obj, "ratingKey", "") or "").strip()
-                        if not rk:
-                            continue
-                        for g in meta_guids(obj):
-                            gg = str(g or "").strip().lower()
-                            if gg and gg not in dst:
-                                dst[gg] = rk
-                    except Exception:
+                rows, n = _fetch_section_guid_rows(srv, sid, 1 if libtype == "movie" else 2)
+                requests_made += n
+                for row in rows:
+                    rk = str(row.get("ratingKey") or "").strip()
+                    if not rk:
                         continue
+                    for g in _row_guids(row):
+                        gg = str(g or "").strip().lower()
+                        if gg and gg not in dst:
+                            dst[gg] = rk
             except Exception:
                 continue
         if srv:
             _save_guid_index(srv, allow)
         _GUID_INDEX_KEY = key
-        _dbg("index_fetch_counts", source="guid_index", movies=len(_GUID_INDEX_MOVIE), shows=len(_GUID_INDEX_SHOW))
+        _dbg(
+            "index_fetch_counts",
+            source="guid_index",
+            movies=len(_GUID_INDEX_MOVIE),
+            shows=len(_GUID_INDEX_SHOW),
+            requests=requests_made,
+        )
     except Exception:
         pass
 
@@ -487,6 +560,33 @@ def build_catalog_from_entries(entries: Iterable[Mapping[str, Any]]) -> HistoryC
 
 def _emit(evt: dict[str, Any]) -> None:
     emit(evt, default_feature="history")
+
+
+class _WriteProgress:
+    __slots__ = ("phase", "total", "_last_at", "_last_done", "_step", "_interval")
+
+    def __init__(self, phase: str, total: int, *, step: int = 100, interval_s: float = 3.0) -> None:
+        self.phase = phase
+        self.total = int(total or 0)
+        self._last_at = time.time()
+        self._last_done = -1
+        self._step = max(1, int(step))
+        self._interval = float(interval_s)
+
+    def tick(self, done: int, *, force: bool = False) -> None:
+        d = int(done or 0)
+        if not force:
+            now = time.time()
+            if d == self._last_done:
+                return
+            if (d % self._step) and (now - self._last_at) < self._interval:
+                return
+            self._last_at = now
+        self._last_done = d
+        _emit({
+            "event": "plex.write", "action": "progress", "feature": "history", "level": "info",
+            "phase": self.phase, "done": d, "total": self.total,
+        })
 
 
 def _epoch_from_history_entry(entry: Any) -> int | None:
@@ -994,8 +1094,12 @@ def _populate_catalog_episode_leaves(adapter: Any, allow: set[str], cat: History
                 break
             seen_pages.add(signature)
             scanned += len(rows)
+            _emit({
+                "event": "plex.catalog", "action": "episode_leaves_progress", "feature": "history", "level": "info",
+                "section_id": section_id, "scanned": scanned, "total": total_i,
+            })
             for row in rows:
-                meta = normalize_discover_row(row, token=token) or {}
+                meta = normalize_discover_row(row, token=token, hydrate_item_ids=False) or {}
                 ids = dict(meta.get("ids") or {})
                 rk = str(ids.get("plex") or row.get("ratingKey") or "").strip()
                 if not rk:
@@ -1674,7 +1778,12 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             if _populate_catalog_episode_leaves(adapter, allow, cat):
                 _store_history_catalog(adapter, allow, cat)
 
-        for item in items or []:
+        item_list = list(items or [])
+        resolve_progress = _WriteProgress("resolve", len(item_list))
+        resolve_progress.tick(0, force=True)
+
+        for resolved_n, item in enumerate(item_list, 1):
+            resolve_progress.tick(resolved_n)
             key = canonical_key(item) or ""
             ts = _as_epoch(item.get("watched_at"))
             if not ts:
@@ -1717,17 +1826,30 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
 
             to_scrobble.append((item, key, str(rk), int(ts)))
 
+        resolve_progress.tick(len(item_list), force=True)
+
         write_workers = 0
         write_ms = 0
         if to_scrobble:
             write_workers = plex_worker_count(adapter, "history_workers", "CW_PLEX_HISTORY_WORKERS", 12)
             _ensure_session_pool(srv, write_workers)
+            write_progress = _WriteProgress("scrobble", len(to_scrobble))
+            write_progress.tick(0, force=True)
             _t_write = time.time()
             if write_workers > 1 and len(to_scrobble) > 1:
+                scrobble_ok = []
                 with ThreadPoolExecutor(max_workers=write_workers, thread_name_prefix="plex-scrobble") as ex:
-                    scrobble_ok = list(ex.map(lambda t: _scrobble_with_date(srv, t[2], t[3]), to_scrobble))
+                    for done_n, success in enumerate(
+                        ex.map(lambda t: _scrobble_with_date(srv, t[2], t[3]), to_scrobble), 1
+                    ):
+                        scrobble_ok.append(success)
+                        write_progress.tick(done_n)
             else:
-                scrobble_ok = [_scrobble_with_date(srv, rk, ts) for (_item, _key, rk, ts) in to_scrobble]
+                scrobble_ok = []
+                for done_n, (_item, _key, rk, ts) in enumerate(to_scrobble, 1):
+                    scrobble_ok.append(_scrobble_with_date(srv, rk, ts))
+                    write_progress.tick(done_n)
+            write_progress.tick(len(to_scrobble), force=True)
             write_ms = int((time.time() - _t_write) * 1000)
 
             for (item, key, _rk, _ts), success in zip(to_scrobble, scrobble_ok):

--- a/tests/test_pair_library_scope.py
+++ b/tests/test_pair_library_scope.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cw_platform.orchestrator._pairs_utils import (
+    config_with_pair_libraries,
+    pair_feature_libraries,
+)
+
+
+def _cfg() -> dict[str, Any]:
+    return {
+        "plex": {"server_url": "http://pms", "history": {"libraries": ["2", "3", "4", "5", "8", "9"]}},
+        "emby": {"server": "http://emby", "history": {"libraries": []}},
+    }
+
+
+def test_pair_libraries_narrow_the_provider_scope() -> None:
+    cfg = _cfg()
+    fcfg = {"libraries": {"PLEX": ["3"]}}
+
+    out = config_with_pair_libraries(cfg, fcfg, "history", ("EMBY", "PLEX"))
+
+    assert out["plex"]["history"]["libraries"] == ["3"]
+
+
+def test_original_config_is_not_mutated() -> None:
+    cfg = _cfg()
+    fcfg = {"libraries": {"PLEX": ["3"]}}
+
+    config_with_pair_libraries(cfg, fcfg, "history", ("EMBY", "PLEX"))
+
+    assert cfg["plex"]["history"]["libraries"] == ["2", "3", "4", "5", "8", "9"]
+
+
+def test_other_provider_settings_survive() -> None:
+    cfg = _cfg()
+    fcfg = {"libraries": {"PLEX": ["3"]}}
+
+    out = config_with_pair_libraries(cfg, fcfg, "history", ("EMBY", "PLEX"))
+
+    assert out["plex"]["server_url"] == "http://pms"
+    assert out["emby"]["server"] == "http://emby"
+
+
+def test_both_sides_are_narrowed() -> None:
+    cfg = _cfg()
+    fcfg = {"libraries": {"PLEX": ["3"], "EMBY": ["4255"]}}
+
+    out = config_with_pair_libraries(cfg, fcfg, "history", ("EMBY", "PLEX"))
+
+    assert out["plex"]["history"]["libraries"] == ["3"]
+    assert out["emby"]["history"]["libraries"] == ["4255"]
+
+
+def test_empty_pair_selection_falls_back_to_connection_scope() -> None:
+    cfg = _cfg()
+    fcfg = {"libraries": {"PLEX": []}}
+
+    out = config_with_pair_libraries(cfg, fcfg, "history", ("EMBY", "PLEX"))
+
+    assert out["plex"]["history"]["libraries"] == ["2", "3", "4", "5", "8", "9"]
+
+
+@pytest.mark.parametrize("feature", ["watchlist", "playlists"])
+def test_features_without_library_scope_are_untouched(feature) -> None:
+    cfg = _cfg()
+    fcfg = {"libraries": {"PLEX": ["3"]}}
+
+    out = config_with_pair_libraries(cfg, fcfg, feature, ("EMBY", "PLEX"))
+
+    assert out["plex"]["history"]["libraries"] == ["2", "3", "4", "5", "8", "9"]
+
+
+@pytest.mark.parametrize("feature", ["history", "ratings", "progress"])
+def test_all_library_scoped_features_are_handled(feature) -> None:
+    cfg = {"plex": {feature: {"libraries": ["1", "2"]}}}
+    fcfg = {"libraries": {"PLEX": ["2"]}}
+
+    out = config_with_pair_libraries(cfg, fcfg, feature, ("PLEX",))
+
+    assert out["plex"][feature]["libraries"] == ["2"]
+
+
+def test_non_library_providers_are_ignored() -> None:
+    cfg = {"trakt": {"history": {}}, "plex": {"history": {"libraries": ["1"]}}}
+    fcfg = {"libraries": {"TRAKT": ["x"], "PLEX": ["1"]}}
+
+    out = config_with_pair_libraries(cfg, fcfg, "history", ("TRAKT", "PLEX"))
+
+    assert "libraries" not in out["trakt"]["history"]
+
+
+def test_kodi_path_style_libraries_pass_through() -> None:
+    cfg = {"kodi": {"history": {"libraries": []}}}
+    fcfg = {"libraries": {"KODI": ["/media/movies/", "/media/tv/"]}}
+
+    out = config_with_pair_libraries(cfg, fcfg, "history", ("KODI",))
+
+    assert out["kodi"]["history"]["libraries"] == ["/media/movies/", "/media/tv/"]
+
+
+def test_missing_provider_block_is_created() -> None:
+    out = config_with_pair_libraries({}, {"libraries": {"PLEX": ["3"]}}, "history", ("PLEX",))
+
+    assert out["plex"]["history"]["libraries"] == ["3"]
+
+
+@pytest.mark.parametrize("fcfg", [None, {}, {"libraries": None}, {"libraries": {"PLEX": "3"}}])
+def test_malformed_pair_config_is_ignored(fcfg) -> None:
+    cfg = _cfg()
+
+    out = config_with_pair_libraries(cfg, fcfg, "history", ("PLEX",))
+
+    assert out["plex"]["history"]["libraries"] == ["2", "3", "4", "5", "8", "9"]
+
+
+def test_pair_feature_libraries_accepts_either_case() -> None:
+    assert pair_feature_libraries({"libraries": {"PLEX": ["3"]}}, "plex") == ["3"]
+    assert pair_feature_libraries({"libraries": {"plex": ["3"]}}, "PLEX") == ["3"]
+    assert pair_feature_libraries({"libraries": {"PLEX": [" 3 ", ""]}}, "PLEX") == ["3"]

--- a/tests/test_plex_episode_catalog_hydrate.py
+++ b/tests/test_plex_episode_catalog_hydrate.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+EPISODE_ROW = {
+    "type": "episode",
+    "ratingKey": "5001",
+    "title": "Ep 1",
+    "guid": "com.plexapp.agents.hama://tvdb-81797/1/1?lang=en",
+    "grandparentGuid": "com.plexapp.agents.hama://tvdb-81797?lang=en",
+    "grandparentRatingKey": "900",
+    "grandparentTitle": "Some Show",
+    "parentIndex": 1,
+    "index": 1,
+    "librarySectionID": 2,
+}
+
+
+def _patch(monkeypatch, calls: list[str]):
+    from providers.sync.plex import _common as c
+
+    def _hydrate(token, rating_key):
+        rk = str(rating_key or "")
+        calls.append(rk)
+        return {"tvdb": "81797"} if rk == "900" else {"tvdb": "999001"}
+
+    monkeypatch.setattr(c, "hydrate_external_ids", _hydrate)
+    return c
+
+
+def test_episode_ids_are_not_hydrated_when_disabled(monkeypatch) -> None:
+    calls: list[str] = []
+    c = _patch(monkeypatch, calls)
+
+    c.normalize_discover_row(EPISODE_ROW, token="T", hydrate_item_ids=False)
+
+    assert "5001" not in calls, "episode rating key must not be hydrated"
+
+
+def test_show_ids_are_still_hydrated_when_disabled(monkeypatch) -> None:
+    calls: list[str] = []
+    c = _patch(monkeypatch, calls)
+
+    out = c.normalize_discover_row(EPISODE_ROW, token="T", hydrate_item_ids=False)
+
+    assert "900" in calls, "grandparent rating key must still be hydrated"
+    assert out["show_ids"].get("tvdb") == "81797"
+
+
+def test_default_still_hydrates_item_ids(monkeypatch) -> None:
+    calls: list[str] = []
+    c = _patch(monkeypatch, calls)
+
+    c.normalize_discover_row(EPISODE_ROW, token="T")
+
+    assert "5001" in calls
+
+
+def _catalog_from(rows: list[dict[str, Any]], *, hydrate: bool):
+    from providers.sync.plex import _common as c
+    from providers.sync.plex._history import HistoryCatalog
+
+    cat = HistoryCatalog()
+    for row in rows:
+        meta = c.normalize_discover_row(row, token="T", hydrate_item_ids=hydrate) or {}
+        ids = dict(meta.get("ids") or {})
+        rk = str(ids.get("plex") or row.get("ratingKey") or "").strip()
+        cat.add(
+            {
+                "rk": rk,
+                "type": "episode",
+                "title": meta.get("title"),
+                "series_title": meta.get("series_title"),
+                "library_id": meta.get("library_id"),
+                "ids": ids,
+                "show_ids": dict(meta.get("show_ids") or {}),
+                "show_rk": (meta.get("show_ids") or {}).get("plex"),
+                "season": meta.get("season"),
+                "episode": meta.get("episode"),
+            }
+        )
+    return cat
+
+
+@pytest.mark.parametrize("count", [1, 5])
+def test_episode_index_is_identical_with_and_without_item_hydration(monkeypatch, count) -> None:
+    rows = []
+    for i in range(1, count + 1):
+        row = dict(EPISODE_ROW)
+        row["ratingKey"] = str(5000 + i)
+        row["index"] = i
+        rows.append(row)
+
+    calls_a: list[str] = []
+    _patch(monkeypatch, calls_a)
+    with_hydrate = _catalog_from(rows, hydrate=True)
+
+    calls_b: list[str] = []
+    _patch(monkeypatch, calls_b)
+    without = _catalog_from(rows, hydrate=False)
+
+    assert without.episode_index == with_hydrate.episode_index
+    assert without.show_tokens == with_hydrate.show_tokens
+    assert set(without.by_rk) == set(with_hydrate.by_rk)
+    assert len(calls_b) < len(calls_a)

--- a/tests/test_plex_guid_index_fetch.py
+++ b/tests/test_plex_guid_index_fetch.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+class _Resp:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.ok = True
+        self.status_code = 200
+        self.headers = {"content-type": "application/json"}
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+    @property
+    def text(self) -> str:
+        return json.dumps(self._payload)
+
+
+MOVIE_ROWS = [
+    {"ratingKey": "11", "guid": "plex://movie/aaa", "Guid": [{"id": "tmdb://603"}, {"id": "imdb://tt0133093"}]},
+    {"ratingKey": "12", "guid": "plex://movie/bbb", "Guid": [{"id": "tmdb://604"}]},
+]
+SHOW_ROWS = [
+    {"ratingKey": "21", "guid": "plex://show/ccc", "Guid": [{"id": "tvdb://81797"}]},
+]
+
+
+class _Section:
+    def __init__(self, key: str, type_: str) -> None:
+        self.key = key
+        self.type = type_
+
+
+class _Adapter:
+    def __init__(self, sections) -> None:
+        self._sections = sections
+        self.client = type("C", (), {"server": _Server()})()
+
+    def libraries(self, types=()):
+        return self._sections
+
+
+class _Session:
+    headers: dict[str, str] = {}
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def get(self, url, params=None, headers=None, timeout=None):
+        self.calls.append({"url": url, "params": dict(params or {})})
+        sid = url.rsplit("/all", 1)[0].rsplit("/", 1)[-1]
+        start = int((params or {}).get("X-Plex-Container-Start") or 0)
+        rows = MOVIE_ROWS if sid == "1" else SHOW_ROWS
+        page = rows[start:]
+        return _Resp({"MediaContainer": {"Metadata": page, "totalSize": len(rows)}})
+
+
+class _Server:
+    _session = None
+    _token = "TOK"
+
+    def url(self, path):
+        return f"http://pms{path}"
+
+
+def _setup(monkeypatch):
+    from providers.sync.plex import _history as h
+
+    ses = _Session()
+    srv = _Server()
+    srv._session = ses
+    adapter = _Adapter([_Section("1", "movie"), _Section("2", "show")])
+    adapter.client = type("C", (), {"server": srv})()
+
+    monkeypatch.setattr(h, "_as_base_url", lambda _s: "http://pms")
+    monkeypatch.setattr(h, "_load_guid_index", lambda *a, **k: False)
+    monkeypatch.setattr(h, "_save_guid_index", lambda *a, **k: None)
+    h._clear_guid_index()
+    h._GUID_INDEX_KEY = None
+    return h, adapter, ses
+
+
+def test_guid_index_is_built_from_paged_rows(monkeypatch) -> None:
+    h, adapter, ses = _setup(monkeypatch)
+
+    h._build_guid_index(adapter, set(), force=True)
+
+    assert h._GUID_INDEX_MOVIE == {
+        "plex://movie/aaa": "11",
+        "tmdb://603": "11",
+        "imdb://tt0133093": "11",
+        "plex://movie/bbb": "12",
+        "tmdb://604": "12",
+    }
+    assert h._GUID_INDEX_SHOW == {"plex://show/ccc": "21", "tvdb://81797": "21"}
+
+
+def test_requests_ask_for_guids_and_correct_types(monkeypatch) -> None:
+    h, adapter, ses = _setup(monkeypatch)
+
+    h._build_guid_index(adapter, set(), force=True)
+
+    assert all(c["params"].get("includeGuids") == 1 for c in ses.calls)
+    types = {c["url"].rsplit("/all", 1)[0].rsplit("/", 1)[-1]: c["params"]["type"] for c in ses.calls}
+    assert types["1"] == 1, "movie sections must query type=1"
+    assert types["2"] == 2, "show sections must query type=2 (show, not episode)"
+
+
+def test_one_request_per_page_not_per_item(monkeypatch) -> None:
+    h, adapter, ses = _setup(monkeypatch)
+
+    h._build_guid_index(adapter, set(), force=True)
+
+    assert len(ses.calls) == 2, f"expected one request per section, got {len(ses.calls)}"
+
+
+def test_allow_filter_skips_other_sections(monkeypatch) -> None:
+    h, adapter, ses = _setup(monkeypatch)
+
+    h._build_guid_index(adapter, {"1"}, force=True)
+
+    assert len(ses.calls) == 1
+    assert h._GUID_INDEX_SHOW == {}
+
+
+def test_row_guids_reads_attribute_and_children() -> None:
+    from providers.sync.plex._history import _row_guids
+
+    assert _row_guids(MOVIE_ROWS[0]) == ["plex://movie/aaa", "tmdb://603", "imdb://tt0133093"]
+    assert _row_guids({"ratingKey": "9"}) == []

--- a/tests/test_plex_hydrate_cloud_token.py
+++ b/tests/test_plex_hydrate_cloud_token.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+PMS = "http://pms.local:32400"
+
+
+class _Resp:
+    def __init__(self, status: int, ids: list[str] | None = None) -> None:
+        self.status_code = status
+        self.ok = 200 <= status < 300
+        self.headers = {"content-type": "application/json"}
+        self._ids = ids or []
+
+    def json(self) -> dict[str, Any]:
+        return {"MediaContainer": {"Metadata": [{"Guid": [{"id": i} for i in self._ids]}]}}
+
+    @property
+    def text(self) -> str:
+        return "{}"
+
+
+@pytest.fixture
+def plex(monkeypatch):
+    from providers.sync.plex import _common as c
+
+    with c._HYDRATE_LOCK:
+        c._GUID_CACHE.clear()
+        c._HYDRATE_404.clear()
+    calls: list[tuple[str, str]] = []
+
+    def _get(url, headers=None, params=None, timeout=None):
+        tok = (headers or {}).get("X-Plex-Token", "")
+        calls.append((url, tok))
+        if url.startswith(c.METADATA):
+            return _Resp(200, ["tmdb://603"]) if tok == "ACCOUNT" else _Resp(401)
+        return _Resp(404)
+
+    monkeypatch.setattr(c.requests, "get", _get)
+    return c, calls
+
+
+def test_cloud_url_uses_the_account_token(plex) -> None:
+    c, calls = plex
+    c.configure_plex_context(baseurl=PMS, token="PMS-TOKEN", account_token="ACCOUNT")
+
+    ids = c.hydrate_external_ids("PMS-TOKEN", "1234")
+
+    assert ids == {"tmdb": "603"}
+    pms_call = next(u for u, _ in calls if u.startswith(PMS))
+    meta_tok = next(t for u, t in calls if u.startswith(c.METADATA))
+    assert pms_call.endswith("/library/metadata/1234")
+    assert meta_tok == "ACCOUNT", "cloud metadata must use the account token"
+
+
+def test_pms_url_still_uses_the_server_token(plex) -> None:
+    c, calls = plex
+    c.configure_plex_context(baseurl=PMS, token="PMS-TOKEN", account_token="ACCOUNT")
+
+    c.hydrate_external_ids("PMS-TOKEN", "1234")
+
+    pms_tok = next(t for u, t in calls if u.startswith(PMS))
+    assert pms_tok == "PMS-TOKEN"
+
+
+def test_falls_back_to_the_given_token_when_no_account_token(plex) -> None:
+    c, calls = plex
+    c._PLEX_CTX["account_token"] = None
+    c.configure_plex_context(baseurl=PMS, token="ACCOUNT")
+
+    ids = c.hydrate_external_ids("ACCOUNT", "1234")
+
+    assert ids == {"tmdb": "603"}
+    assert all(t == "ACCOUNT" for _, t in calls)
+
+
+def test_account_token_is_kept_across_home_user_switches(plex) -> None:
+    c, _ = plex
+    c.configure_plex_context(baseurl=PMS, token="PMS-TOKEN", account_token="ACCOUNT")
+
+    c.configure_plex_context(baseurl=PMS, token="HOME-USER-TOKEN")
+
+    assert c._PLEX_CTX["token"] == "HOME-USER-TOKEN"
+    assert c._PLEX_CTX["account_token"] == "ACCOUNT"

--- a/tests/test_plex_write_progress.py
+++ b/tests/test_plex_write_progress.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    from providers.sync.plex import _history as h
+
+    events: list[dict[str, Any]] = []
+    monkeypatch.setattr(h, "_emit", lambda evt: events.append(evt))
+    return h, events
+
+
+def _progress(events, phase):
+    return [
+        e for e in events
+        if e.get("event") == "plex.write" and e.get("action") == "progress" and e.get("phase") == phase
+    ]
+
+
+def test_first_and_last_tick_always_emit(captured) -> None:
+    h, events = captured
+    p = h._WriteProgress("resolve", 1102)
+
+    p.tick(0, force=True)
+    p.tick(1102, force=True)
+
+    got = _progress(events, "resolve")
+    assert [e["done"] for e in got] == [0, 1102]
+    assert all(e["total"] == 1102 for e in got)
+
+
+def test_ticks_emit_on_the_step_boundary(captured) -> None:
+    h, events = captured
+    p = h._WriteProgress("resolve", 1000, step=100, interval_s=9999)
+
+    for i in range(1, 351):
+        p.tick(i)
+
+    assert [e["done"] for e in _progress(events, "resolve")] == [100, 200, 300]
+
+
+def test_repeated_same_value_does_not_spam(captured) -> None:
+    h, events = captured
+    p = h._WriteProgress("scrobble", 10, step=1, interval_s=0)
+
+    p.tick(5)
+    p.tick(5)
+    p.tick(5)
+
+    assert len(_progress(events, "scrobble")) == 1
+
+
+def test_slow_progress_still_reports_on_the_interval(captured, monkeypatch) -> None:
+    h, events = captured
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(h.time, "time", lambda: clock["t"])
+
+    p = h._WriteProgress("resolve", 500, step=100, interval_s=3.0)
+
+    p.tick(7)
+    p.tick(8)
+    assert len(_progress(events, "resolve")) == 0, "should be throttled inside the interval"
+
+    clock["t"] += 4.0
+    p.tick(9)
+    assert len(_progress(events, "resolve")) == 1, "should report once the interval passes"
+
+    p.tick(10)
+    assert len(_progress(events, "resolve")) == 1, "interval restarts after an emit"
+
+
+def test_phase_is_carried_through(captured) -> None:
+    h, events = captured
+
+    h._WriteProgress("resolve", 5).tick(0, force=True)
+    h._WriteProgress("scrobble", 5).tick(0, force=True)
+
+    assert {e["phase"] for e in events} == {"resolve", "scrobble"}


### PR DESCRIPTION
# Pull request

## Change

- Stop hydrating episode ids while building the catalog
- Build the guid index with a raw paged fetch and includeGuids
- Emit progress during the resolve and scrobble phases

## Why

Writing history to Plex cost time proportional to how big the server is instead of how much you are syncing. 

## Testing

- tests/test_plex_episode_catalog_hydrate.py 
- tests/test_plex_guid_index_fetch.py 
- tests/test_plex_write_progress.py 
- tests/test_plex_hydrate_cloud_token.py 
- tests/test_pair_library_scope.py

## Issue

NA
