### PR TITLE
Fix: details log performance and stale sync state

### DIFF
--- a/assets/helpers/details-log.js
+++ b/assets/helpers/details-log.js
@@ -26,11 +26,12 @@ if (typeof window.debugBuf === "undefined") window.debugBuf = [];
 if (typeof window._debugFlushRAF === "undefined") window._debugFlushRAF = null;
 if (typeof window._detailsTabsWired === "undefined") window._detailsTabsWired = false;
 if (typeof window._detailsTab === "undefined") window._detailsTab = "sync";
-if (typeof window.DETAILS_MAX_LINES === "undefined") window.DETAILS_MAX_LINES = 500;
-if (typeof window.DETAILS_STREAM_TAIL === "undefined") window.DETAILS_STREAM_TAIL = 220;
-if (typeof window.DETAILS_QUEUE_MAX === "undefined") window.DETAILS_QUEUE_MAX = 700;
-if (typeof window.DETAILS_BATCH_ROWS === "undefined") window.DETAILS_BATCH_ROWS = 45;
-if (typeof window.DETAILS_FRAME_BUDGET_MS === "undefined") window.DETAILS_FRAME_BUDGET_MS = 5;
+if (typeof window.DETAILS_MAX_LINES === "undefined") window.DETAILS_MAX_LINES = 300;
+if (typeof window.DETAILS_STREAM_TAIL === "undefined") window.DETAILS_STREAM_TAIL = 120;
+if (typeof window.DETAILS_STREAM_BACKLOG === "undefined") window.DETAILS_STREAM_BACKLOG = 160;
+if (typeof window.DETAILS_QUEUE_MAX === "undefined") window.DETAILS_QUEUE_MAX = 300;
+if (typeof window.DETAILS_BATCH_ROWS === "undefined") window.DETAILS_BATCH_ROWS = 24;
+if (typeof window.DETAILS_FRAME_BUDGET_MS === "undefined") window.DETAILS_FRAME_BUDGET_MS = 3;
 if (typeof window._detOpenSeq === "undefined") window._detOpenSeq = 0;
 if (typeof window.syncBuf === "undefined") window.syncBuf = [];
 if (typeof window._syncFlushRAF === "undefined") window._syncFlushRAF = null;
@@ -40,6 +41,9 @@ if (typeof window._detReplayCursor === "undefined") window._detReplayCursor = 0;
 if (typeof window._detDidConnectOnce === "undefined") window._detDidConnectOnce = false;
 if (typeof window._detLastSeq === "undefined") window._detLastSeq = 0;
 if (typeof window._debugLastSeq === "undefined") window._debugLastSeq = 0;
+if (typeof window._detClearSeq === "undefined") window._detClearSeq = 0;
+if (typeof window._debugClearSeq === "undefined") window._debugClearSeq = 0;
+if (typeof window._watchSkipBacklog === "undefined") window._watchSkipBacklog = false;
 if (typeof window._detailsDropped === "undefined") window._detailsDropped = { sync: 0, watcher: 0, debug: 0 };
 if (typeof window._detailsStatusRAF === "undefined") window._detailsStatusRAF = null;
 if (typeof window._detailsOpenRAF === "undefined") window._detailsOpenRAF = null;
@@ -96,6 +100,14 @@ function _scrollDetailsToBottom(el, tab, afterScroll) {
     afterScroll?.();
     _scheduleDetailsConsoleStatus();
   });
+}
+
+function _followDetailsLog(el, tab, afterScroll) {
+  if (!el) return;
+  _setDetailsStickBottom(tab, true);
+  _markDetailsProgrammaticScroll(90);
+  el.scrollTop = el.scrollHeight;
+  afterScroll?.();
 }
 
 function _pruneSeenDetailLines() {
@@ -440,12 +452,6 @@ function _scheduleDetailsConsoleStatus() {
 }
 
 function _wireDetailsConsoleStatus() {
-  for (const id of ["det-log", "det-watch-log", "det-debug-log"]) {
-    const el = document.getElementById(id);
-    if (!el || el.__cwStatusObserver) continue;
-    el.__cwStatusObserver = new MutationObserver(_scheduleDetailsConsoleStatus);
-    el.__cwStatusObserver.observe(el, { childList: true });
-  }
   _updateDetailsConsoleStatus();
 }
 
@@ -569,9 +575,19 @@ function initDetailsTabs() {
     btnClear.addEventListener("click", () => {
       const el = _activeDetailsLogEl();
       if (el) el.innerHTML = "";
-      if (window._detailsTab === "watcher") window.watchBuf.length = 0;
-      if (window._detailsTab === "debug") window.debugBuf.length = 0;
-      if (window._detailsTab === "sync") window.syncBuf.length = 0;
+      if (window._detailsTab === "watcher") {
+        window.watchBuf.length = 0;
+        window._watchSkipBacklog = true;
+      }
+      if (window._detailsTab === "debug") {
+        window.debugBuf.length = 0;
+        window._debugClearSeq = Math.max(Number(window._debugClearSeq || 0) || 0, Number(window._debugLastSeq || 0) || 0);
+      }
+      if (window._detailsTab === "sync") {
+        window.syncBuf.length = 0;
+        window._detSeenLines = [];
+        window._detClearSeq = Math.max(Number(window._detClearSeq || 0) || 0, Number(window._detLastSeq || 0) || 0);
+      }
       _resetDetailsDropped(window._detailsTab || "sync");
       _updateDetailsConsoleStatus();
     });
@@ -670,8 +686,9 @@ function openDebugLog() {
       el.__cwScrollWired = true;
     }
 
-    const debugSince = Math.max(0, Number(window._debugLastSeq || 0) || 0);
-    const debugReconnect = debugSince > 0 && el.childElementCount > 0;
+    const debugClearSeq = Math.max(0, Number(window._debugClearSeq || 0) || 0);
+    const debugSince = Math.max(Number(window._debugLastSeq || 0) || 0, debugClearSeq);
+    const debugReconnect = debugSince > 0 && (el.childElementCount > 0 || debugClearSeq > 0);
     if (!debugReconnect) {
       el.innerHTML = "";
       window.debugStickBottom = true;
@@ -693,7 +710,7 @@ function openDebugLog() {
           const shouldFollow = !!window.debugStickBottom;
           el.appendChild(frag);
           _pruneDetailsLog(el);
-          if (shouldFollow) _scrollDetailsToBottom(el, "debug");
+          if (shouldFollow) _followDetailsLog(el, "debug");
           _scheduleDetailsConsoleStatus();
         }, scheduleFlush);
       });
@@ -703,6 +720,7 @@ function openDebugLog() {
     url.searchParams.set("tag", "DEBUG");
     if (debugReconnect) url.searchParams.set("since", String(debugSince));
     else url.searchParams.set("tail", String(_detailsLimit("DETAILS_STREAM_TAIL", 400)));
+    url.searchParams.set("max_backlog", String(_detailsLimit("DETAILS_STREAM_BACKLOG", 160)));
     url.searchParams.set("plain", "1");
     url.searchParams.set("_ts", String(Date.now()));
 
@@ -754,7 +772,13 @@ function openDebugLog() {
       document.removeEventListener("visibilitychange", window._debugVisibilityHandler);
     }
     window._debugVisibilityHandler = () => {
-      if (document.visibilityState !== "visible") return;
+      if (document.visibilityState !== "visible") {
+        try { window.esDebug?.close?.(); } catch {}
+        window.esDebug = null;
+        tabDebug?.classList.remove("connected");
+        _updateDetailsConsoleStatus();
+        return;
+      }
       if (_detailsVisible() && window._detailsTab === "debug") { try { openDebugLog(); } catch {} }
     };
     document.addEventListener("visibilitychange", window._debugVisibilityHandler);
@@ -784,7 +808,9 @@ async function openWatcherLog() {
     const uniq = _watchLogTagsFromConfig(cfg);
 
     const url = new URL("/api/logs/watcher", document.baseURI);
-    url.searchParams.set("tail", "200");
+    url.searchParams.set("tail", "120");
+    url.searchParams.set("max_backlog", "80");
+    if (window._watchSkipBacklog) url.searchParams.set("skip_backlog", "1");
     url.searchParams.set("plain", "1");
     if (uniq.length) url.searchParams.set("tags", uniq.join(","));
 
@@ -822,7 +848,7 @@ async function openWatcherLog() {
           const shouldFollow = !!window.watchStickBottom;
           el.appendChild(frag);
           _pruneDetailsLog(el);
-          if (shouldFollow) _scrollDetailsToBottom(el, "watcher");
+          if (shouldFollow) _followDetailsLog(el, "watcher");
           _scheduleDetailsConsoleStatus();
         }, scheduleFlush);
       });
@@ -865,7 +891,13 @@ async function openWatcherLog() {
       document.removeEventListener("visibilitychange", window._watchVisibilityHandler);
     }
     window._watchVisibilityHandler = () => {
-      if (document.visibilityState !== "visible") return;
+      if (document.visibilityState !== "visible") {
+        try { window.esWatch?.close?.(); } catch {}
+        window.esWatch = null;
+        tabWatch?.classList.remove("connected");
+        _updateDetailsConsoleStatus();
+        return;
+      }
       if (_detailsVisible() && window._detailsTab === "watcher") { try { openWatcherLog(); } catch {} }
     };
     document.addEventListener("visibilitychange", window._watchVisibilityHandler);
@@ -901,8 +933,9 @@ async function openDetailsLog() {
   window._detSeenLines = [];
   window._detReplayActive = false;
   window._detReplayCursor = 0;
-  window._detDidConnectOnce = false;
-  window._detLastSeq = 0;
+  const detClearSeq = Math.max(0, Number(window._detClearSeq || 0) || 0);
+  window._detDidConnectOnce = detClearSeq > 0;
+  window._detLastSeq = detClearSeq;
 
   try { window.esDet?.close(); } catch {}
   try { window.esDetSummary?.close(); } catch {}
@@ -937,13 +970,13 @@ async function openDetailsLog() {
     });
   }
 
-  const appendRaw = (s) => {
+  const appendRaw = (s, target = el) => {
     const lines = String(s).replace(/\r\n/g, "\n").split("\n");
     for (const line of lines) {
       if (!line) continue;
       const row = _structuredLogRow(_decodeLogLine(line), "SYNC");
       row.classList.add("det-plain-line");
-      el.appendChild(row);
+      target.appendChild(row);
     }
   };
 
@@ -955,12 +988,14 @@ async function openDetailsLog() {
     if (window._syncFlushRAF || window._detailsTab !== "sync") return;
     window._syncFlushRAF = requestAnimationFrame(() => {
       window._syncFlushRAF = null;
+      const frag = document.createDocumentFragment();
       _runDetailsBatch(window.syncBuf, (line) => {
-        appendRaw(line);
+        appendRaw(line, frag);
       }, () => {
         const shouldFollow = !!window.detStickBottom;
+        el.appendChild(frag);
         _pruneDetailsLog(el);
-        if (shouldFollow) _scrollDetailsToBottom(el, "sync", updateSlider);
+        if (shouldFollow) _followDetailsLog(el, "sync", updateSlider);
         else updateSlider();
         _scheduleDetailsConsoleStatus();
       }, scheduleFlush);
@@ -977,6 +1012,7 @@ async function openDetailsLog() {
     url.searchParams.set("tag", "SYNC");
     if (!initialConnect && since > 0) url.searchParams.set("since", String(since));
     else url.searchParams.set("tail", String(_detailsLimit("DETAILS_STREAM_TAIL", 400)));
+    url.searchParams.set("max_backlog", String(_detailsLimit("DETAILS_STREAM_BACKLOG", 160)));
     url.searchParams.set("plain", "1");
     url.searchParams.set("_ts", String(Date.now()));
     window.esDet = new EventSource(url.toString());
@@ -1058,7 +1094,13 @@ async function openDetailsLog() {
   }, STALE_MS);
 
   window._detVisibilityHandler = () => {
-    if (document.visibilityState !== "visible") return;
+    if (document.visibilityState !== "visible") {
+      try { window.esDet?.close?.(); } catch {}
+      window.esDet = null;
+      tabSync?.classList.remove("connected");
+      _updateDetailsConsoleStatus();
+      return;
+    }
     if (window._detailsTab === "sync" && (!window.esDet || (Date.now() - lastMsgAt > STALE_MS))) connect();
   };
   document.addEventListener("visibilitychange", window._detVisibilityHandler);
@@ -1074,6 +1116,9 @@ async function openDetailsLog() {
 function closeDetailsLog() {
   window._detReplayActive = false;
   window._detReplayCursor = 0;
+  window._detClearSeq = 0;
+  window._debugClearSeq = 0;
+  window._watchSkipBacklog = false;
   try { closeSyncLog(); } catch {}
   try { closeWatcherLog(); } catch {}
   try { closeDebugLog(); } catch {}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -480,6 +480,7 @@
     if (!arr.length) return void (enabledFromPairs = EMPTY_ENABLED());
     const enabled = EMPTY_ENABLED();
     for (const pair of arr) {
+      if (pair?.enabled === false) continue;
       const feats = pair?.features || {};
       for (const key of FEAT_KEYS) if (feats[key] && (feats[key].enable === true || feats[key].enabled === true)) enabled[key] = true;
     }

--- a/assets/js/syncbar.js
+++ b/assets/js/syncbar.js
@@ -6,6 +6,13 @@
   const Anch = Object.freeze({ start0: 0, preStart: 35, preEnd: 57, postEnd: 67, done: 100 });
   const clamp = (n, lo = 0, hi = 100) => Math.max(lo, Math.min(hi, Math.round(n)));
   const POST_DONE_GRACE_MS = 20000;
+  const AGE_REFRESH_MS = 30000;
+  const asEpochSec = (v) => {
+    if (v == null || v === "") return 0;
+    const n = typeof v === "number" ? v : Date.parse(v);
+    if (!Number.isFinite(n) || n <= 0) return 0;
+    return Math.floor(n > 1e12 ? n / 1000 : n);
+  };
 
   const PhaseAgg = {
     snap: { done: 0, total: 0, started: false, finished: false },
@@ -116,6 +123,8 @@
       this._exitCode = null;
       this._hadError = false;
       this._unresolved = 0;
+      this._finishedAt = 0;
+      this._ageTimer = null;
       this.render();
     }
 
@@ -165,7 +174,8 @@
         _successExit0Seen: false,
         _exitCode: null,
         _hadError: false,
-        _unresolved: 0
+        _unresolved: 0,
+        _finishedAt: 0
       });
       PhaseAgg.snap = { done: 0, total: 0, started: false, finished: false };
       PhaseAgg.apply = { done: 0, total: 0, started: false, finished: false };
@@ -314,6 +324,9 @@
       const unresolved = Number(sum?.unresolved || 0);
       if (Number.isFinite(unresolved) && unresolved >= 0) this._unresolved = unresolved;
 
+      const finishedAt = asEpochSec(sum?.finished_at);
+      if (finishedAt) this._finishedAt = finishedAt;
+
       if (exitCode != null) {
         if (exitCode === 0) this.success();
         else this.fail(exitCode);
@@ -370,6 +383,14 @@
       if (typeof p === "number") {
         this._pctMemo = Math.max(this._pctMemo, clamp(p));
         this.render();
+      }
+    }
+
+    _trackAge(active) {
+      if (active && !this._ageTimer) this._ageTimer = setInterval(() => this.render(), AGE_REFRESH_MS);
+      else if (!active && this._ageTimer) {
+        clearInterval(this._ageTimer);
+        this._ageTimer = null;
       }
     }
 
@@ -460,13 +481,16 @@
       const shouldFlow = isRunning && !hardDone;
       const currentStep = hardDone ? "done" : this.timeline.post ? "syncing" : this.timeline.pre ? "discovering" : this.timeline.start ? "start" : "";
       const statusText = this._hadError ? "Error" : hardDone ? "Synced" : this._pendingDone ? "Finalizing" : this.timeline.post ? "Syncing" : this.timeline.pre ? "Discovering" : isRunning ? "Starting" : "Idle";
+      const settled = hardDone || this._hadError;
+      const doneAge = settled && this._finishedAt ? (window.relTimeFromEpoch?.(this._finishedAt) || "") : "";
       const phaseLabel = (this._hadError
         ? `Sync failed${this._exitCode != null ? ` (code ${this._exitCode})` : ""}`
         : hardDone ? "Completed successfully"
         : this._pendingDone ? "Wrapping up final tasks"
         : this.timeline.post ? "Applying changes across enabled features"
         : this.timeline.pre ? "Scanning current state before applying changes"
-        : "Waiting for the next sync run");
+        : "Waiting for the next sync run") + (doneAge ? ` · ${doneAge}` : "");
+      this._trackAge(!!doneAge);
 
       badge.textContent = statusText;
       badge.classList.toggle("running", isRunning && !hardDone && !this._hadError);

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -891,6 +891,7 @@ async def api_logs_stream_initial(
     tag: str = Query("SYNC"),
     tail: int | None = Query(None, ge=1, le=MAX_LOG_LINES),
     since: int | None = Query(None, ge=1),
+    max_backlog: int | None = Query(None, ge=1, le=MAX_LOG_LINES),
     plain: bool = Query(False),
 ):
     tag = _norm_log_tag(tag)
@@ -922,6 +923,11 @@ async def api_logs_stream_initial(
             start_idx = int(start_seq - base)
             if start_idx < 0:
                 start_idx = 0
+            if max_backlog:
+                backlog = len(new_buf) - start_idx
+                if backlog > max_backlog:
+                    start_idx = max(0, len(new_buf) - int(max_backlog))
+                    last_seq = base + start_idx - 1
             for i in range(start_idx, len(new_buf)):
                 line = new_buf[i]
                 seq = base + i
@@ -950,6 +956,8 @@ async def api_logs_watcher(
     request: Request,
     tail: int = Query(200, ge=1, le=3000),
     tags: str = Query("", description="Optional CSV override"),
+    max_backlog: int | None = Query(None, ge=1, le=3000),
+    skip_backlog: bool = Query(False),
     plain: bool = Query(False),
 ):
     tags_sel = _watch_log_selection(tags)
@@ -959,10 +967,11 @@ async def api_logs_watcher(
 
         for t in tags_sel:
             buf = _get_log_buf(t)
-            start = max(0, len(buf) - int(tail))
-            for line in buf[start:]:
-                safe = _log_stream_text(line, plain)
-                yield f"event: {t}\ndata: {safe}\n\n"
+            if not skip_backlog:
+                start = max(0, len(buf) - int(tail))
+                for line in buf[start:]:
+                    safe = _log_stream_text(line, plain)
+                    yield f"event: {t}\ndata: {safe}\n\n"
             base = int(LOG_BASE_SEQ.get(t, int(LOG_NEXT_SEQ.get(t, 1))))
             last_seq[t] = base + len(buf) - 1
 
@@ -981,6 +990,11 @@ async def api_logs_watcher(
                 start_idx = int(start_seq - base)
                 if start_idx < 0:
                     start_idx = 0
+                if max_backlog:
+                    backlog = len(buf) - start_idx
+                    if backlog > max_backlog:
+                        start_idx = max(0, len(buf) - int(max_backlog))
+                        seen = base + start_idx - 1
                 for i in range(start_idx, len(buf)):
                     line = buf[i]
                     safe = _log_stream_text(line, plain)


### PR DESCRIPTION
# Pull request

## Change

Ported from dev-db to dev/main:
* Batched sync log rows into a `DocumentFragment` instead of appending each row into the live DOM.
* Replaced the double `scrollHeight` read in the log auto-follow path with a single read.
* Reduced details log buffers: retained rows 500 to 300
* Closed the sync, watcher, and debug log streams while the browser tab is hidden.

## Why

The details log console rendered every streamed line straight into the live DOM, with a mutation observer firing on each append and a duplicated layout read on every auto-scroll. 
During a sync this saturated the main thread and made the UI stutter. 
Hidden browser tabs kept buffering, and a reconnect after a gap could dump thousands of lines into the DOM in one task.

## Testing

* Sync, watcher, and debug log stream URLs across first open, reconnect, clear
* Watcher backlog suppression after a clear
* Sync bar phase label across idle, running, just finished, aged, new run, and failed run
* Clear watermark reset on details panel close

## Issue

NA
