### PR TITLE
Fix: dashboard widgets resolve TMDB art

### DIFF
--- a/services/dashboard_widgets.py
+++ b/services/dashboard_widgets.py
@@ -600,12 +600,15 @@ def _resolve_missing_art(
     _art_debug(row, "metadata_resolved", tmdb=tmdb)
 
 
-def _ensure_cover_art(row: dict[str, Any], *, size: str) -> None:
-    if row.get("cover"):
-        return
-    cover = _cover_url(row, size=size)
-    if cover:
-        row["cover"] = cover
+def _ensure_art_urls(
+    row: dict[str, Any], *, size: str, episode_still: bool, cover_size: str, backdrop_fallback: bool
+) -> None:
+    if not row.get("poster"):
+        row["poster"] = (
+            _grid_art_url(row, size=size) if backdrop_fallback else _poster_url(row, size=size, episode_still=episode_still)
+        )
+    if not row.get("cover"):
+        row["cover"] = _cover_url(row, size=cover_size)
 
 
 def _resolve_missing_art_rows(
@@ -615,11 +618,16 @@ def _resolve_missing_art_rows(
     episode_still: bool = False,
     cover_size: str = "w342",
     backdrop_fallback: bool = False,
+    resolve_art_type: bool = False,
 ) -> list[dict[str, Any]]:
     for row in rows:
         _resolve_episode_show_title(row)
         _resolve_missing_art(row, size=size, episode_still=episode_still, backdrop_fallback=backdrop_fallback)
-        _ensure_cover_art(row, size=cover_size)
+        if resolve_art_type:
+            row["art_type"] = _resolved_art_type(row, _tmdb_id(row))
+        _ensure_art_urls(
+            row, size=size, episode_still=episode_still, cover_size=cover_size, backdrop_fallback=backdrop_fallback
+        )
     return rows
 
 
@@ -676,7 +684,7 @@ def _rating_row(raw_key: str, item: Mapping[str, Any], sources: list[dict[str, s
     return {
         "key": _canonical_key(raw_key, item),
         "type": typ,
-        "art_type": _resolved_art_type(item, _tmdb_id(item)),
+        "art_type": _art_type(item),
         "title": _title(item),
         "year": _year(item),
         "season": _season_number(item),
@@ -688,8 +696,6 @@ def _rating_row(raw_key: str, item: Mapping[str, Any], sources: list[dict[str, s
         "updated_epoch": _update_epoch(item),
         "ids": _ids(item),
         "tmdb": _tmdb_id(item),
-        "poster": _grid_art_url(item, size="w300"),
-        "cover": _cover_url(item, size="w342"),
         "sources": sources,
     }
 
@@ -825,7 +831,9 @@ def latest_ratings_widget(
         reverse=True,
     )
     cap = max(1, min(int(limit or 12), 24))
-    selected = _resolve_missing_art_rows(items[:cap], size="w300", episode_still=True, backdrop_fallback=True)
+    selected = _resolve_missing_art_rows(
+        items[:cap], size="w300", episode_still=True, backdrop_fallback=True, resolve_art_type=True
+    )
     for row in selected:
         row.pop(_RATING_TRACKER_FLAG, None)
     return {"ok": True, "items": selected, "total": len(items)}
@@ -873,8 +881,6 @@ def _activity_row(event: Mapping[str, Any]) -> dict[str, Any]:
         "method": str(event.get("method") or "").lower(),
         "ids": _ids(event),
         "tmdb": _tmdb_id(event),
-        "poster": _poster_url(event, size="w300", episode_still=True),
-        "cover": _cover_url(event, size="w342"),
         "source": source,
         "targets": clean_targets,
         "sources": clean_sources,
@@ -903,8 +909,6 @@ def _history_state_row(raw_key: str, item: Mapping[str, Any], sources: list[dict
         "method": "sync_state",
         "ids": _ids(item),
         "tmdb": _tmdb_id(item),
-        "poster": _poster_url(item, size="w300", episode_still=True),
-        "cover": _cover_url(item, size="w342"),
         "sources": sources,
     }
 
@@ -1115,8 +1119,6 @@ def _progress_row(raw_key: str, item: Mapping[str, Any], sources: list[dict[str,
         "sort_epoch": sort_epoch,
         "ids": _ids(item),
         "tmdb": _tmdb_id(item),
-        "poster": _poster_url(item, size="w300", episode_still=True),
-        "cover": _cover_url(item, size="w342"),
         "sources": sources,
     }
 

--- a/tests/test_dashboard_widgets.py
+++ b/tests/test_dashboard_widgets.py
@@ -947,6 +947,57 @@ def test_recent_playlists_widget_uses_playlist_activity(monkeypatch) -> None:
     }
 
 
+def _many_movie_items(feature: str, count: int) -> dict:
+    time_key = "rated_at" if feature == "ratings" else "watched_at"
+    return {
+        "providers": {
+            "PLEX": {
+                feature: {
+                    "baseline": {
+                        "items": {
+                            f"tmdb:{n}@17672292{n:02d}": {
+                                "type": "movie",
+                                "title": f"Movie {n}",
+                                "year": 2000 + n,
+                                "ids": {"tmdb": n},
+                                "rating": 8,
+                                time_key: f"2026-01-01T00:00:{n:02d}Z",
+                            }
+                            for n in range(1, count + 1)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    ("feature", "widget", "per_row"),
+    [("history", "recent_history_widget", 2), ("ratings", "latest_ratings_widget", 3), ("progress", "recent_progress_widget", 2)],
+)
+def test_widgets_resolve_art_namespace_only_for_returned_rows(monkeypatch, feature, widget, per_row) -> None:
+    monkeypatch.setattr(
+        dashboard_widgets,
+        "list_events",
+        lambda **_kwargs: {"ok": True, "total": 0, "items": []},
+    )
+    calls: list[object] = []
+    real = dashboard_widgets._resolved_art_type
+    monkeypatch.setattr(
+        dashboard_widgets,
+        "_resolved_art_type",
+        lambda item, tmdb: (calls.append(tmdb), real(item, tmdb))[1],
+    )
+
+    payload = getattr(dashboard_widgets, widget)(_many_movie_items(feature, 60), limit=5)
+
+    assert payload["total"] == 60
+    assert len(payload["items"]) == 5
+    assert len(calls) <= 5 * per_row
+    assert len(set(calls)) == 5
+
+
 def test_dashboard_widgets_payload_only_builds_included_widgets(monkeypatch) -> None:
     calls: list[str] = []
 


### PR DESCRIPTION
# Pull request

## Change

- Move poster, cover and art_type building out of the widget row builders
- Resolve art only for the rows that actually get returned, after the limit slice
- Add resolve_art_type flag so ratings keep their resolved art_type
- Add a regression test that caps art resolves at the widget limit

## Why

The row builders called _poster_url and _cover_url on every item in state, and those go through _resolved_art_type into _resolve_entity, which fires two TMDB detail requests per uncached movie or show. 

## Testing

- test_dashboard_widgets.py

## Issue

NA
