### PR TITLE
Fix: PunchPlay progress fields

### DIFF
--- a/cw_platform/history_events.py
+++ b/cw_platform/history_events.py
@@ -48,11 +48,13 @@ EVENT_ID_FIELDS = (
     "_history_id",
     "_simkl_history_id",
     "_simkl_rewatch_id",
+    "_punchplay_history_id",
     "rewatch_id",
 )
 
 EVENT_META_FIELDS = (
     *EVENT_ID_FIELDS,
+    "_punchplay_history_ids",
     "is_rewatch",
     "rewatch_status",
     "_cw_event_key",

--- a/providers/sync/punchplay/_common.py
+++ b/providers/sync/punchplay/_common.py
@@ -124,6 +124,18 @@ class RateGovernor:
             wait = max(wait, hits[0] + window - now)
         return wait
 
+    def try_acquire(self, method: str, url: str) -> float:
+        with self._lock:
+            now = time.monotonic()
+            buckets = self._buckets_for(method, url)
+            wait = max((self._wait_for(b, now) for b in buckets), default=0.0)
+            if wait > 0.0:
+                return wait
+            for b in buckets:
+                if b in self._budgets:
+                    self._hits.setdefault(b, []).append(now)
+            return 0.0
+
     def acquire(self, method: str, url: str) -> float:
         slept = 0.0
         for _ in range(8):
@@ -429,6 +441,13 @@ def idempotency_key(resource: str, payload: Mapping[str, Any], *, attempt: int =
     return f"cw-{hashlib.sha256(seed.encode('utf-8')).hexdigest()}"
 
 
+class PunchPlayRateLimited(RuntimeError):
+    def __init__(self, retry_after: float, bucket: str = "") -> None:
+        super().__init__(f"rate_limited retry_after={int(retry_after)}s bucket={bucket or 'token'}")
+        self.retry_after = int(max(1.0, retry_after))
+        self.bucket = bucket or "token"
+
+
 def punchplay_request(adapter: Any, method: str, url: str, **kwargs: Any) -> requests.Response:
     cfg = getattr(adapter, "config", None) or getattr(adapter, "raw_cfg", None) or {}
     session = getattr(adapter, "session", None)
@@ -441,7 +460,15 @@ def punchplay_request(adapter: Any, method: str, url: str, **kwargs: Any) -> req
     inst = instance_id(adapter)
 
     gov = rate_governor(inst, section)
-    slept = gov.acquire(method, url)
+    if bool(kwargs.pop("no_wait", False)):
+        wait = gov.try_acquire(method, url)
+        if wait > 0.0:
+            bucket = _endpoint_bucket(method, url) or "token"
+            _warn("ratelimit", "client_throttle_refused", method=str(method).upper(), bucket=bucket, retry_after_s=int(wait))
+            raise PunchPlayRateLimited(wait, bucket)
+        slept = 0.0
+    else:
+        slept = gov.acquire(method, url)
     if slept > 0.25:
         _dbg("ratelimit", "client_throttle", method=str(method).upper(), bucket=_endpoint_bucket(method, url) or "token", slept_s=round(slept, 2))
 

--- a/providers/sync/punchplay/_history.py
+++ b/providers/sync/punchplay/_history.py
@@ -33,6 +33,7 @@ from ._common import (
 FEATURE = "history"
 
 HISTORY_ID_FIELD = "_punchplay_history_ids"
+HISTORY_EVENT_ID_FIELD = "_punchplay_history_id"
 
 
 def _key_of(obj: Mapping[str, Any]) -> str:
@@ -96,6 +97,7 @@ def _row_to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
     entry_id = _as_int(row.get("id"))
     if entry_id:
         out[HISTORY_ID_FIELD] = [str(entry_id)]
+        out[HISTORY_EVENT_ID_FIELD] = str(entry_id)
     return out
 
 
@@ -260,6 +262,8 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
 
         typ = str(item.get("type") or "").strip().lower()
         entry_ids = [str(x) for x in (item.get(HISTORY_ID_FIELD) or []) if str(x or "").strip()]
+        if not entry_ids and str(item.get(HISTORY_EVENT_ID_FIELD) or "").strip():
+            entry_ids = [str(item.get(HISTORY_EVENT_ID_FIELD)).strip()]
 
         if entry_ids:
             deleted = 0

--- a/providers/sync/punchplay/_progress.py
+++ b/providers/sync/punchplay/_progress.py
@@ -3,12 +3,15 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import time
 from typing import Any, Iterable, Mapping
 
 from cw_platform.id_map import canonical_key, minimal as id_minimal
 
 from ._common import (
     URL_IN_PROGRESS,
+    cfg_section,
+    instance_id,
     URL_IN_PROGRESS_ITEM,
     URL_PLAYBACK,
     error_of,
@@ -53,6 +56,56 @@ def _as_float(value: Any) -> float | None:
         return None
 
 
+def _first_number(item: Mapping[str, Any], keys: tuple[str, ...]) -> float | None:
+    for k in keys:
+        v = _as_float(item.get(k))
+        if v is not None:
+            return v
+    return None
+
+
+def _position_ms(item: Mapping[str, Any]) -> float | None:
+    ms = _first_number(item, ("progress_ms", "progressMs", "viewOffset"))
+    if ms is not None:
+        return ms
+    secs = _first_number(item, ("position_seconds", "positionSeconds"))
+    return secs * 1000.0 if secs is not None else None
+
+
+def _duration_ms_of(item: Mapping[str, Any]) -> float | None:
+    ms = _first_number(item, ("duration_ms", "durationMs"))
+    if ms is not None and ms > 0:
+        return ms
+    secs = _first_number(item, ("duration_seconds", "durationSeconds"))
+    return secs * 1000.0 if secs is not None and secs > 0 else None
+
+
+def _percent_of(item: Mapping[str, Any]) -> float | None:
+    pct = _first_number(item, ("progress_percent", "progressPercent", "percent", "position_percent", "resume_percent"))
+    if pct is not None:
+        return max(0.0, min(100.0, pct))
+    pos = _position_ms(item)
+    dur = _duration_ms_of(item)
+    if pos is not None and dur:
+        return max(0.0, min(100.0, (pos / dur) * 100.0))
+    return None
+
+
+def _drop_reason(row: Mapping[str, Any]) -> str:
+    typ = str(row.get("type") or "").strip().lower()
+    if typ == "episode":
+        if not _as_int(row.get("showTmdbId")):
+            return "episode_missing_show_tmdb_id"
+        if _as_int(row.get("season")) is None:
+            return "episode_missing_season"
+        if _as_int(row.get("episode")) is None:
+            return "episode_missing_episode"
+        return "episode_unknown"
+    if not _as_int(row.get("tmdbId")):
+        return "movie_missing_tmdb_id"
+    return f"unhandled_type:{typ or 'empty'}"
+
+
 def _row_to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
     typ = str(row.get("type") or "").strip().lower()
 
@@ -90,17 +143,20 @@ def _row_to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
         if year:
             out["year"] = year
 
-    percent = _as_float(row.get("progressPercent"))
-    if percent is not None:
-        out["progress"] = max(0.0, min(100.0, percent))
     pos = _as_float(row.get("progressSeconds"))
     if pos is not None:
-        out["position_seconds"] = pos
+        out["progress_ms"] = int(round(pos * 1000.0))
     dur = _as_float(row.get("durationSeconds"))
     if dur:
-        out["duration_seconds"] = dur
+        out["duration_ms"] = int(round(dur * 1000.0))
+    percent = _as_float(row.get("progressPercent"))
+    if percent is None and pos is not None and dur:
+        percent = (pos / dur) * 100.0
+    if percent is not None:
+        out["progress_percent"] = round(max(0.0, min(100.0, percent)), 3)
     updated = iso_z(row.get("updatedAt"))
     if updated:
+        out["progress_at"] = updated
         out["updated_at"] = updated
     state = str(row.get("playbackState") or "").strip().lower()
     if state:
@@ -129,16 +185,52 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
         rows = [r for r in data if isinstance(r, Mapping)]
 
     collected: dict[str, dict[str, Any]] = {}
+    dropped: list[str] = []
     for row in rows:
         minimal = _row_to_minimal(row)
         if not minimal:
+            dropped.append(_drop_reason(row))
+            _warn(
+                FEATURE,
+                "index_row_dropped",
+                reason=_drop_reason(row),
+                row_type=str(row.get("type") or ""),
+                entry_id=row.get("id"),
+                tmdb_id=row.get("tmdbId"),
+                show_tmdb_id=row.get("showTmdbId"),
+                season=row.get("season"),
+                episode=row.get("episode"),
+                title=str(row.get("showTitle") or row.get("title") or "")[:80],
+            )
             continue
         key = _key_of(minimal)
-        if key:
-            collected[key] = minimal
+        if not key:
+            dropped.append("no_canonical_key")
+            _warn(FEATURE, "index_row_dropped", reason="no_canonical_key", entry_id=row.get("id"))
+            continue
+        collected[key] = minimal
 
-    _info(FEATURE, "index_done", count=len(collected))
+    _info(
+        FEATURE,
+        "index_done",
+        count=len(collected),
+        rows=len(rows),
+        dropped=len(dropped),
+        drop_reasons=",".join(sorted(set(dropped))) or None,
+    )
     return collected
+
+
+def _session_ids(item: Mapping[str, Any], key: str, *, device_id: str, instance: str, position: float | None) -> dict[str, Any]:
+    scope = f"cw-{instance}-{key}"
+    out: dict[str, Any] = {
+        "playback_session_id": scope,
+        "event_id": f"{scope}@{int(position or 0)}",
+        "event_created_at": int(time.time() * 1000),
+    }
+    if device_id:
+        out["device_id"] = device_id
+    return out
 
 
 def _playback_payload(item: Mapping[str, Any]) -> dict[str, Any] | None:
@@ -181,19 +273,16 @@ def _playback_payload(item: Mapping[str, Any]) -> dict[str, Any] | None:
         if year:
             payload["year"] = year
 
-    pos = _as_float(item.get("position_seconds"))
-    if pos is not None:
-        payload["position_seconds"] = pos
-    dur = _as_float(item.get("duration_seconds"))
-    if dur:
-        payload["duration_seconds"] = dur
+    pos_ms = _position_ms(item)
+    dur_ms = _duration_ms_of(item)
+    if pos_ms is not None:
+        payload["position_seconds"] = round(pos_ms / 1000.0, 3)
+    if dur_ms:
+        payload["duration_seconds"] = round(dur_ms / 1000.0, 3)
 
-    percent = _as_float(item.get("progress"))
+    percent = _percent_of(item)
     if percent is not None:
-        frac = percent / 100.0 if percent > 1.0 else percent
-        payload["progress"] = max(0.0, min(1.0, frac))
-    elif pos is not None and dur:
-        payload["progress"] = max(0.0, min(1.0, pos / dur))
+        payload["progress"] = max(0.0, min(1.0, percent / 100.0))
 
     if item.get("anime") is True:
         payload["anime"] = True
@@ -210,11 +299,25 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
     unresolved: list[dict[str, Any]] = []
     ok = True
 
+    section = cfg_section(adapter) or {}
+    device_id = str(section.get("device_id") or "").strip()
+    instance = str(instance_id(adapter) or "default")
+
     for item in items or []:
         key = _key_of(item)
         if not key:
             continue
         payload = _playback_payload(item)
+        if payload is not None:
+            payload.update(
+                _session_ids(
+                    item,
+                    key,
+                    device_id=device_id,
+                    instance=instance,
+                    position=payload.get("position_seconds"),
+                )
+            )
         if payload is None:
             unresolved_keys.append(key)
             unresolved.append({"key": key, "status": "missing_supported_id_or_position"})

--- a/providers/sync/punchplay/_ratings.py
+++ b/providers/sync/punchplay/_ratings.py
@@ -208,12 +208,18 @@ def _payload_for(item: Mapping[str, Any], *, clear: bool) -> tuple[dict[str, Any
     key = _key_of(item)
     if not key:
         return None
-    payload = ids_for_punchplay(item)
+
+    scope = _scope_of(item)
+    source: Mapping[str, Any] = item
+    if scope in ("season", "episode", "series"):
+        show_ids = item.get("show_ids")
+        if isinstance(show_ids, Mapping) and show_ids:
+            source = {"ids": show_ids}
+    payload = ids_for_punchplay(source)
     if not has_write_id(payload):
         return None
 
     payload["kind"] = _kind_of(item)
-    scope = _scope_of(item)
     if scope != "title":
         payload["scope"] = scope
     if scope in ("season", "episode"):

--- a/tests/test_punchplay_sync.py
+++ b/tests/test_punchplay_sync.py
@@ -488,7 +488,7 @@ def test_progress_write_uses_playback_progress_action(monkeypatch: pytest.Monkey
 
     res = pr.add(Adapter(), [{
         "type": "movie", "title": "Fight Club", "year": 1999, "ids": {"tmdb": "550"},
-        "position_seconds": 1800, "duration_seconds": 8340,
+        "progress_ms": 1800000, "duration_ms": 8340000,
     }])
 
     call = http.calls[0]
@@ -496,6 +496,108 @@ def test_progress_write_uses_playback_progress_action(monkeypatch: pytest.Monkey
     assert call["json"]["media_type"] == "movie"
     assert round(call["json"]["progress"], 4) == 0.2158
     assert res["confirmed_keys"] == ["tmdb:550"]
+
+
+def test_progress_write_reads_canonical_ms_fields() -> None:
+    from providers.sync.punchplay import _progress as pr
+
+    plex_item = {
+        "type": "episode", "title": "Exile", "series_title": "The Handmaid's Tale",
+        "season": 6, "episode": 2, "show_ids": {"tmdb": "69478"},
+        "progress_at": "2026-07-31T19:43:27Z", "progress_ms": 753000, "duration_ms": 3307930,
+    }
+
+    payload = pr._playback_payload(plex_item)
+
+    assert payload is not None
+    assert payload["position_seconds"] == 753.0
+    assert payload["duration_seconds"] == 3307.93
+    assert round(payload["progress"], 4) == 0.2276
+
+
+def test_progress_round_trip_is_lossless_for_two_way() -> None:
+    from cw_platform.orchestrator._planner import diff_progress
+    from providers.sync.punchplay import _progress as pr
+
+    key = "tmdb:69478#s06e02"
+    plex = {key: {
+        "type": "episode", "title": "Exile", "series_title": "The Handmaid's Tale",
+        "season": 6, "episode": 2, "show_ids": {"tmdb": "69478"},
+        "progress_at": "2026-07-31T19:43:27Z", "progress_ms": 753000, "duration_ms": 3307930,
+    }}
+    punchplay_row = {
+        "id": 7, "type": "episode", "tmdbId": 5978363, "showTmdbId": 69478,
+        "showTitle": "The Handmaid's Tale", "episodeTitle": "Exile", "season": 6, "episode": 2,
+        "progressSeconds": 753.0, "durationSeconds": 3307.93, "progressPercent": 22.764,
+        "updatedAt": "2026-07-31T19:43:27.000Z",
+    }
+
+    mirrored = pr._row_to_minimal(punchplay_row)
+    assert mirrored is not None
+    assert mirrored["progress_ms"] == 753000
+    assert mirrored["duration_ms"] == 3307930
+    assert mirrored["progress_at"] == "2026-07-31T19:43:27.000Z"
+
+    adds, removes = diff_progress(plex, {key: mirrored})
+    assert (len(adds), len(removes)) == (0, 0)
+
+
+def test_progress_sends_distinct_session_ids_per_title(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _progress as pr
+
+    http = FakeHTTP([_Resp(200, {}), _Resp(200, {})])
+    _patch(monkeypatch, pr, http)
+
+    adapter = Adapter()
+    adapter.config = {"punchplay": {"access_token": "at", "device_id": "crosswatch-abc"}}
+
+    pr.add(adapter, [
+        {"type": "episode", "show_ids": {"tmdb": "69478"}, "season": 6, "episode": 2,
+         "series_title": "The Handmaid's Tale", "position_seconds": 753, "duration_seconds": 3307},
+        {"type": "episode", "show_ids": {"tmdb": "94997"}, "season": 2, "episode": 7,
+         "series_title": "House of the Dragon", "position_seconds": 1770, "duration_seconds": 3821},
+    ])
+
+    a, b = http.calls[0]["json"], http.calls[1]["json"]
+
+    assert a["playback_session_id"] != b["playback_session_id"]
+    assert a["playback_session_id"] == "cw-default-tmdb:69478#s06e02"
+    assert b["playback_session_id"] == "cw-default-tmdb:94997#s02e07"
+    assert a["event_id"] != b["event_id"]
+    assert a["device_id"] == b["device_id"] == "crosswatch-abc"
+    assert isinstance(a["event_created_at"], int)
+
+
+def test_progress_session_id_is_stable_across_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _progress as pr
+
+    item = {"type": "movie", "ids": {"tmdb": "550"}, "position_seconds": 100, "duration_seconds": 8340}
+
+    first = FakeHTTP([_Resp(200, {})])
+    _patch(monkeypatch, pr, first)
+    pr.add(Adapter(), [dict(item)])
+
+    second = FakeHTTP([_Resp(200, {})])
+    _patch(monkeypatch, pr, second)
+    pr.add(Adapter(), [dict(item)])
+
+    assert first.calls[0]["json"]["playback_session_id"] == second.calls[0]["json"]["playback_session_id"]
+    assert first.calls[0]["json"]["event_id"] == second.calls[0]["json"]["event_id"]
+
+
+def test_progress_index_reports_dropped_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _progress as pr
+
+    http = FakeHTTP([_Resp(200, {"items": [
+        {"id": 1, "type": "episode", "tmdbId": 111, "showTmdbId": 94997, "season": 2, "episode": 7},
+        {"id": 2, "type": "episode", "tmdbId": 222, "showTmdbId": None, "season": 6, "episode": 2},
+    ]})])
+    _patch(monkeypatch, pr, http)
+
+    idx = pr.build_index(Adapter())
+
+    assert list(idx) == ["tmdb:94997#s02e07"]
+    assert pr._drop_reason({"type": "episode", "showTmdbId": None}) == "episode_missing_show_tmdb_id"
 
 
 def test_progress_remove_dismisses_in_progress_entry(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -509,6 +611,58 @@ def test_progress_remove_dismisses_in_progress_entry(monkeypatch: pytest.MonkeyP
     assert http.calls[0]["method"] == "DELETE"
     assert http.calls[0]["url"].endswith("/playback/in-progress/4")
     assert res["confirmed_keys"] == ["tmdb:550"]
+
+
+# --- canonical field contract -------------------------------------------------
+
+def test_ratings_index_is_understood_by_the_planner() -> None:
+    from cw_platform.orchestrator._planner import diff_ratings
+    from providers.sync.punchplay import _ratings as rt
+
+    key = "tmdb:550"
+    src = {key: {"type": "movie", "ids": {"tmdb": "550"}, "title": "Fight Club",
+                 "rating": 8, "rated_at": "2026-01-01T00:00:00Z"}}
+
+    same = rt._to_minimal({"tmdbId": 550, "kind": "movie", "rating": 8.0,
+                           "ratedAt": "2026-01-01T00:00:00Z", "title": "Fight Club"})
+    assert same is not None
+    assert same["rating"] == 8
+    assert "rated_at" in same
+    assert diff_ratings(src, {key: same})[0] == []
+
+    differs = rt._to_minimal({"tmdbId": 550, "kind": "movie", "rating": 5.0,
+                              "ratedAt": "2025-01-01T00:00:00Z", "title": "Fight Club"})
+    assert differs is not None
+    assert len(diff_ratings(src, {key: differs})[0]) == 1
+
+
+def test_history_index_survives_event_normalisation() -> None:
+    from cw_platform.history_events import minimal_history_item, provider_event_id
+    from cw_platform.orchestrator._history_rewatches import filter_history_events
+    from providers.sync.punchplay import _history as h
+
+    item = h._row_to_minimal({
+        "id": 7, "type": "movie", "tmdbId": 550, "title": "Fight Club",
+        "year": 1999, "watchedAt": "2026-01-01T20:00:00.000Z",
+    })
+    assert item is not None
+    assert item["watched_at"] == "2026-01-01T20:00:00.000Z"
+
+    kept = filter_history_events({"tmdb:550": item}, event_mode=False)
+    assert kept, "history item must survive filter_history_events"
+
+    normalised = minimal_history_item(item)
+    assert h.HISTORY_ID_FIELD in normalised, "delete ids must survive normalisation"
+    assert h.HISTORY_EVENT_ID_FIELD in normalised
+    assert provider_event_id(normalised) == "7"
+
+
+def test_punchplay_history_fields_are_registered_in_shared_contract() -> None:
+    from cw_platform.history_events import EVENT_ID_FIELDS, EVENT_META_FIELDS
+    from providers.sync.punchplay import _history as h
+
+    assert h.HISTORY_EVENT_ID_FIELD in EVENT_ID_FIELDS
+    assert h.HISTORY_ID_FIELD in EVENT_META_FIELDS
 
 
 # --- rate limits --------------------------------------------------------------


### PR DESCRIPTION
# Pull request

## Change

- Read and write progress using the canonical progress_ms, duration_ms, progress_percent and progress_at fields
- Send playback_session_id, event_id, device_id and event_created_at on playback writes
- Log dropped in-progress rows with a reason instead of skipping them silently
- Identify episode ratings by the show id with scope episode
- Register the PunchPlay history entry ids so they survive event normalisation
- Add an endpoint aware rate governor with the documented PunchPlay budgets

## Why

Progress used our own field names instead of the canonical ones every provider emits, so items went out with no position or duration, and came back in a shape the planner could not read. Every sync re-added the same items. 
Playback events had no session id either, so two writes collapsed into one row.

Rate limits are per endpoint and some are per IP, so one global rate does not fit.
The governor tracks each bucket and can refuse instead of sleeping, which keeps the UI from hanging.


## Issue

NA
