### PR TITLE
Add: shared rating inc PunchPlay webhook ratings

### DIFF
--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -55,6 +55,8 @@ WEBHOOK_SETTING_KEYS = {
     "plex_trakt_ratings",
     "plex_simkl_ratings",
     "plex_mdblist_ratings",
+    "plex_crosswatch_ratings",
+    "plex_floppy_ratings",
     "pause_debounce_seconds",
     "suppress_start_at",
 }
@@ -264,7 +266,7 @@ def _normalize_webhook_settings(cfg: Mapping[str, Any], provider: str, body: Map
         if key in body:
             out[key] = _normalize_filters(body.get(key), provider, key)
     if provider == "plex":
-        for key in ("plex_trakt_ratings", "plex_simkl_ratings", "plex_mdblist_ratings"):
+        for key in ("plex_trakt_ratings", "plex_simkl_ratings", "plex_mdblist_ratings", "plex_crosswatch_ratings", "plex_floppy_ratings"):
             if key in body:
                 out[key] = bool(body.get(key))
     for key in ("pause_debounce_seconds", "suppress_start_at"):
@@ -507,6 +509,9 @@ def build_overview(cfg: dict[str, Any], request: Request) -> dict[str, Any]:
             "trakt": bool(watch.get("plex_trakt_ratings")),
             "simkl": bool(watch.get("plex_simkl_ratings")),
             "mdblist": bool(watch.get("plex_mdblist_ratings")),
+            "crosswatch": bool(watch.get("plex_crosswatch_ratings")),
+            "floppy": bool(watch.get("plex_floppy_ratings")),
+            "punchplay": bool(watch.get("plex_punchplay_ratings")),
             "endpoint_url": _global_plex_ratings_url(request, cfg),
         },
     }
@@ -860,7 +865,7 @@ def api_scrobbler_settings(request: Request, payload: dict[str, Any] = Body(...)
             watch["autostart"] = bool(payload.get("watch_autostart"))
         ratings_raw = payload.get("global_plex_ratings")
         if isinstance(ratings_raw, Mapping):
-            for sink in ("trakt", "simkl", "mdblist"):
+            for sink in ("trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay"):
                 watch[f"plex_{sink}_ratings"] = bool(ratings_raw.get(sink))
         if bool(payload.get("regenerate_global_plex_ratings_webhook")):
             sec = after.setdefault("security", {})

--- a/assets/js/scrobbler.js
+++ b/assets/js/scrobbler.js
@@ -6,6 +6,7 @@
   const providerMeta = () => w.CW?.ProviderMeta || {};
   const label = (v) => providerMeta().label?.(v) || String(v || "").toUpperCase();
   const logo = (v) => providerMeta().logoPath?.(v) || "";
+  const plexRatingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay"];
   const state = { root: null, overview: null, busy: false, panels: { watcherDefaults: false, ratings: false, webhookDefaults: false }, delBtn: null, delTimer: 0, regenBtn: null, regenTimer: 0, legacyConfirm: false, legacyTimer: 0, hybridDismissed: false };
 
   async function j(url, options = {}) {
@@ -242,7 +243,7 @@
     const r = st.global_plex_ratings || {};
     const open = state.panels.ratings;
     const url = r.endpoint_url || "";
-    const on = ["simkl", "trakt", "mdblist"].filter((k) => r[k]);
+    const on = plexRatingSinks.filter((k) => r[k]);
     const summary = on.length ? `→ ${on.map(label).join(", ")}` : "No destinations selected";
     return `
       <section class="sc2-section sc2-collapse ${open ? "is-open" : ""}" id="sc-sec-ratings">
@@ -253,7 +254,7 @@
         </button>
         <div class="sc2-collapse-body">
           <div class="sc2-rating-targets">
-            ${["simkl", "trakt", "mdblist"].map((k) => `<button type="button" class="sc2-rating-pill provider-${k} ${r[k] ? "is-on" : ""}" data-rating-target="${k}"><span class="material-symbols-rounded">${r[k] ? "check_circle" : "radio_button_unchecked"}</span>${esc(label(k))}</button>`).join("")}
+            ${plexRatingSinks.map((k) => `<button type="button" class="sc2-rating-pill provider-${k} ${r[k] ? "is-on" : ""}" data-rating-target="${k}"><span class="material-symbols-rounded">${r[k] ? "check_circle" : "radio_button_unchecked"}</span>${esc(label(k))}</button>`).join("")}
           </div>
           <div class="sc2-endpoint">
             <code title="${esc(url)}">${esc(url || "Global Plex ratings URL is unavailable until a token exists")}</code>
@@ -562,7 +563,7 @@
         e.preventDefault();
         const cur = state.overview?.source_state?.global_plex_ratings || {};
         const key = ratingTarget.getAttribute("data-rating-target");
-        await saveSettings({ global_plex_ratings: { simkl: !!cur.simkl, trakt: !!cur.trakt, mdblist: !!cur.mdblist, [key]: !cur[key] } }, ratingTarget);
+        await saveSettings({ global_plex_ratings: Object.fromEntries(plexRatingSinks.map((sink) => [sink, sink === key ? !cur[sink] : !!cur[sink]])) }, ratingTarget);
         return;
       }
       const copyUrl = e.target.closest("[data-copy-url]");

--- a/providers/scrobble/plex/ratings_sync.py
+++ b/providers/scrobble/plex/ratings_sync.py
@@ -1,0 +1,169 @@
+# providers/scrobble/plex/ratings_sync.py
+# CrossWatch - Plex rating writes for sync-backed local sinks
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Iterable, Mapping
+from typing import Any
+
+from cw_platform.provider_instances import build_provider_config_view, normalize_instance_id
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        if value in (None, ""):
+            return None
+        return int(float(value))
+    except Exception:
+        return None
+
+
+def _clean_ids(ids: Mapping[str, Any] | None) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key in ("tmdb", "imdb", "tvdb", "trakt", "simkl", "mdblist", "plex"):
+        value = (ids or {}).get(key)
+        if value in (None, ""):
+            continue
+        out[key] = value
+    return out
+
+
+def _year(md: Mapping[str, Any]) -> int | None:
+    direct = _as_int(md.get("year"))
+    if direct:
+        return direct
+    date = str(md.get("originallyAvailableAt") or md.get("originally_available_at") or "").strip()
+    if len(date) >= 4 and date[:4].isdigit():
+        return int(date[:4])
+    return None
+
+
+def item_from_plex_rating(
+    media_type: str,
+    md: Mapping[str, Any],
+    ids: Mapping[str, Any],
+    rating: int | None,
+    *,
+    show_ids: Mapping[str, Any] | None = None,
+    episode_ids: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    mt = str(media_type or "").strip().lower()
+    if mt not in {"movie", "show", "episode"}:
+        return None
+
+    clean = _clean_ids(ids)
+    item: dict[str, Any] = {"type": "movie" if mt == "movie" else mt}
+
+    if mt == "episode":
+        season = _as_int(md.get("parentIndex") or md.get("season"))
+        episode = _as_int(md.get("index") or md.get("episode"))
+        if season is None or episode is None:
+            return None
+        ep_ids = _clean_ids(episode_ids) or clean
+        sh_ids = _clean_ids(show_ids) or clean
+        if not ep_ids and not sh_ids:
+            return None
+        item.update({
+            "ids": ep_ids,
+            "show_ids": sh_ids,
+            "season": season,
+            "episode": episode,
+            "series_title": str(md.get("grandparentTitle") or md.get("showTitle") or "").strip(),
+            "title": str(md.get("title") or f"S{season:02d}E{episode:02d}").strip(),
+        })
+    else:
+        if not clean:
+            return None
+        item["ids"] = clean
+        title = str(md.get("title") or "").strip()
+        if title:
+            item["title"] = title
+        year = _year(md)
+        if year:
+            item["year"] = year
+
+    if rating is not None and rating > 0:
+        item["rating"] = int(rating)
+        item["rated_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    return {k: v for k, v in item.items() if v not in (None, "", {}, [])}
+
+
+def _ops(provider: str) -> Any | None:
+    if provider == "crosswatch":
+        from providers.sync._mod_CROSSWATCH import OPS
+
+        return OPS
+    if provider == "floppy":
+        from providers.sync._mod_FLOPPY import OPS
+
+        return OPS
+    if provider == "punchplay":
+        from providers.sync._mod_PUNCHPLAY import OPS
+
+        return OPS
+    return None
+
+
+OPS_RATING_SINKS: tuple[str, ...] = ("crosswatch", "floppy", "punchplay")
+RATING_SINKS: tuple[str, ...] = ("trakt", "simkl", "mdblist", *OPS_RATING_SINKS)
+
+
+def dispatch_ops_ratings(
+    media_type: str,
+    md: Mapping[str, Any],
+    ids: Mapping[str, Any],
+    rating: int | None,
+    cfg: Mapping[str, Any],
+    *,
+    enabled: Iterable[str],
+    instance_for: Callable[[str], Any],
+    show_ids: Mapping[str, Any] | None = None,
+    episode_ids: Mapping[str, Any] | None = None,
+) -> dict[str, dict[str, Any]]:
+    targets = [s for s in OPS_RATING_SINKS if s in {str(x or "").strip().lower() for x in (enabled or ())}]
+    if not targets:
+        return {}
+
+    try:
+        item = item_from_plex_rating(
+            media_type,
+            md,
+            ids,
+            int(rating or 0) if rating else None,
+            show_ids=show_ids,
+            episode_ids=episode_ids,
+        )
+    except Exception as exc:
+        return {sink: {"ok": False, "error": str(exc)} for sink in targets}
+
+    if not item:
+        return {sink: {"ok": False, "error": "no_ids"} for sink in targets}
+
+    out: dict[str, dict[str, Any]] = {}
+    for sink in targets:
+        out[sink] = send_rating(sink, cfg, instance_for(sink), item, int(rating or 0))
+    return out
+
+
+def send_rating(provider: str, cfg: Mapping[str, Any], instance: Any, item: Mapping[str, Any], rating: int | None) -> dict[str, Any]:
+    sink = str(provider or "").strip().lower()
+    ops = _ops(sink)
+    if ops is None:
+        return {"ok": False, "error": "unsupported_rating_sink"}
+
+    view = build_provider_config_view(dict(cfg or {}), sink, normalize_instance_id(instance))
+    clear = rating is None or int(rating or 0) <= 0
+    try:
+        res = (ops.remove if clear else ops.add)(view, [dict(item)], feature="ratings", dry_run=False)
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+
+    body = dict(res or {}) if isinstance(res, Mapping) else {"raw": res}
+    unresolved = list(body.get("unresolved_keys") or [])
+    skipped = list(body.get("skipped_keys") or [])
+    confirmed = list(body.get("confirmed_keys") or [])
+    ok = bool(body.get("ok", True)) and not unresolved
+    if skipped and not confirmed:
+        ok = False
+        body.setdefault("error", "unsupported_media_type")
+    return {"ok": ok, "resp": body}

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -1744,12 +1744,18 @@ def process_rating_webhook(
         enable_trakt = "trakt" in custom_targets
         enable_simkl = "simkl" in custom_targets
         enable_mdblist = "mdblist" in custom_targets
+        enable_crosswatch = "crosswatch" in custom_targets
+        enable_floppy = "floppy" in custom_targets
+        enable_punchplay = "punchplay" in custom_targets
     else:
         enable_trakt = bool(watch_cfg.get("plex_trakt_ratings"))
         enable_simkl = bool(watch_cfg.get("plex_simkl_ratings"))
         enable_mdblist = bool(watch_cfg.get("plex_mdblist_ratings"))
+        enable_crosswatch = bool(watch_cfg.get("plex_crosswatch_ratings"))
+        enable_floppy = bool(watch_cfg.get("plex_floppy_ratings"))
+        enable_punchplay = bool(watch_cfg.get("plex_punchplay_ratings"))
 
-    if not (enable_trakt or enable_simkl or enable_mdblist):
+    if not (enable_trakt or enable_simkl or enable_mdblist or enable_crosswatch or enable_floppy or enable_punchplay):
         return {"ok": True, "ignored": True}
 
     if not payload:
@@ -1788,7 +1794,7 @@ def process_rating_webhook(
         rating_val = 0
 
 
-    if media_type == "episode" and not enable_trakt:
+    if media_type == "episode" and not (enable_trakt or enable_crosswatch or enable_punchplay):
         return {"ok": True, "ignored": True}
 
     acc_key = _account_key(payload)
@@ -1830,4 +1836,24 @@ def process_rating_webhook(
         results["simkl"] = _simkl_send_rating(media_type, ids, rating_val, cfg, logger)
     if enable_mdblist and media_type in ("movie", "show"):
         results["mdblist"] = _mdblist_send_rating(media_type, ids, rating_val, cfg, logger)
+    ops_enabled = [
+        name
+        for name, on in (("crosswatch", enable_crosswatch), ("floppy", enable_floppy), ("punchplay", enable_punchplay))
+        if on
+    ]
+    if ops_enabled:
+        from providers.scrobble.plex.ratings_sync import dispatch_ops_ratings
+
+        sink_inst = str(watch_cfg.get("route_sink_instance") or "default").strip() or "default"
+        results.update(
+            dispatch_ops_ratings(
+                media_type,
+                md,
+                ids,
+                rating_val,
+                cfg,
+                enabled=ops_enabled,
+                instance_for=lambda _sink: sink_inst,
+            )
+        )
     return results

--- a/providers/webhooks/plex.py
+++ b/providers/webhooks/plex.py
@@ -23,8 +23,9 @@ except Exception:
 from providers.scrobble.currently_watching import update_from_payload as _cw_update
 from providers.scrobble._auto_remove_watchlist import remove_across_providers_by_ids as _rm_across
 from providers.scrobble.scrobble import mask_account as _mask_account
+from providers.scrobble.plex.ratings_sync import RATING_SINKS
 from providers.scrobble.sources import source_enabled
-from providers.webhooks.config import configured_webhook_sinks
+from providers.webhooks.config import configured_webhook_sinks, webhook_sink_instance
 from providers.webhooks.dispatch import dispatch_scrobble as _dispatch_scrobble
 
 try:
@@ -57,6 +58,9 @@ _DEF_WEBHOOK: dict[str, Any] = {
     "plex_trakt_ratings": False,
     "plex_simkl_ratings": False,
     "plex_mdblist_ratings": False,
+    "plex_crosswatch_ratings": False,
+    "plex_floppy_ratings": False,
+    "plex_punchplay_ratings": False,
 }
 
 _DEF_TRAKT: dict[str, Any] = {
@@ -203,13 +207,17 @@ def _ensure_scrobble(cfg: dict[str, Any]) -> dict[str, Any]:
     if "probe_session_progress" not in wh:
         wh["probe_session_progress"] = _DEF_WEBHOOK["probe_session_progress"]
         changed = True
-    if "plex_trakt_ratings" not in wh:
-        wh["plex_trakt_ratings"] = _DEF_WEBHOOK.get("plex_trakt_ratings", False)
-    if "plex_simkl_ratings" not in wh:
-        wh["plex_simkl_ratings"] = _DEF_WEBHOOK.get("plex_simkl_ratings", False)
-    if "plex_mdblist_ratings" not in wh:
-        wh["plex_mdblist_ratings"] = _DEF_WEBHOOK.get("plex_mdblist_ratings", False)
-        changed = True
+    for key in (
+        "plex_trakt_ratings",
+        "plex_simkl_ratings",
+        "plex_mdblist_ratings",
+        "plex_crosswatch_ratings",
+        "plex_floppy_ratings",
+        "plex_punchplay_ratings",
+    ):
+        if key not in wh:
+            wh[key] = _DEF_WEBHOOK.get(key, False)
+            changed = True
 
 
     flt = wh.setdefault("filters_plex", {})
@@ -1133,6 +1141,9 @@ def process_webhook(
     enable_trakt_ratings = bool(wh.get("plex_trakt_ratings", False)) and "trakt" in selected_rating_sinks
     enable_simkl_ratings = bool(wh.get("plex_simkl_ratings", False)) and "simkl" in selected_rating_sinks
     enable_mdblist_ratings = bool(wh.get("plex_mdblist_ratings", False)) and "mdblist" in selected_rating_sinks
+    enable_crosswatch_ratings = bool(wh.get("plex_crosswatch_ratings", False)) and "crosswatch" in selected_rating_sinks
+    enable_floppy_ratings = bool(wh.get("plex_floppy_ratings", False)) and "floppy" in selected_rating_sinks
+    enable_punchplay_ratings = bool(wh.get("plex_punchplay_ratings", False)) and "punchplay" in selected_rating_sinks
     flt = (wh.get("filters_plex") or {})
     allow_users = {str(x).strip() for x in (flt.get("username_whitelist") or []) if str(x).strip()}
     srv_uuid_allow = _as_filter_set(flt.get("server_uuid_whitelist"))
@@ -1210,7 +1221,7 @@ def process_webhook(
     _emit(logger, f"ids resolved: {media_name_dbg} -> {_describe_ids((show_ids or epi_ids) or all_ids)}", "DEBUG")
 
     if event == "media.rate":
-        if not (enable_trakt_ratings or enable_simkl_ratings or enable_mdblist_ratings):
+        if not (enable_trakt_ratings or enable_simkl_ratings or enable_mdblist_ratings or enable_crosswatch_ratings or enable_floppy_ratings):
             _emit(logger, "rating forwarding disabled", "DEBUG")
             return {"ok": True, "ignored": True}
 
@@ -1275,11 +1286,38 @@ def process_webhook(
                     sent = True
                     results["mdblist"] = _mdblist_send_rating(media_type, ids_all2, int(rating_val or 0), cfg, logger)
 
+        ops_enabled = [
+            name
+            for name, on in (
+                ("crosswatch", enable_crosswatch_ratings),
+                ("floppy", enable_floppy_ratings),
+                ("punchplay", enable_punchplay_ratings),
+            )
+            if on
+        ]
+        if ops_enabled:
+            from providers.scrobble.plex.ratings_sync import dispatch_ops_ratings
+
+            sent = True
+            results.update(
+                dispatch_ops_ratings(
+                    media_type,
+                    md,
+                    ids_all2,
+                    rating_val,
+                    cfg,
+                    enabled=ops_enabled,
+                    instance_for=lambda sink: webhook_sink_instance(wh, sink),
+                    show_ids=show_ids,
+                    episode_ids=epi_ids,
+                )
+            )
+
         if not sent:
             _emit(logger, "no usable rating target; ignored", "DEBUG")
             return {"ok": True, "ignored": True}
 
-        target_results = [v for k, v in results.items() if k in {"trakt", "simkl", "mdblist"} and isinstance(v, dict)]
+        target_results = [v for k, v in results.items() if k in RATING_SINKS and isinstance(v, dict)]
         ok = any(bool(item.get("ok")) for item in target_results)
         results["ok"] = ok
         results["status"] = 200 if ok else 502

--- a/tests/test_plex_webhook_ratings.py
+++ b/tests/test_plex_webhook_ratings.py
@@ -1,0 +1,58 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+from typing import Any
+
+
+def test_plex_webhook_ratings_forward_to_crosswatch_and_floppy(monkeypatch) -> None:
+    from providers.scrobble.plex import ratings_sync
+    from providers.webhooks import plex
+
+    sent: list[dict[str, Any]] = []
+
+    def fake_send_rating(provider: str, cfg: dict[str, Any], instance: str, item: dict[str, Any], rating: int) -> dict[str, Any]:
+        sent.append({"provider": provider, "instance": instance, "item": item, "rating": rating})
+        return {"ok": True, "resp": {"confirmed_keys": ["tmdb:550"]}}
+
+    monkeypatch.setattr(plex, "_save_config", lambda _cfg: None)
+    monkeypatch.setattr(ratings_sync, "send_rating", fake_send_rating)
+    plex._LAST_RATING_BY_ACC.clear()
+
+    cfg = {
+        "scrobble": {
+            "enabled": True,
+            "sources": {"webhook": True},
+            "webhook": {
+                "sinks": ["crosswatch", "floppy"],
+                "sink_instances": {"crosswatch": "CW-P01", "floppy": "F1"},
+                "plex_crosswatch_ratings": True,
+                "plex_floppy_ratings": True,
+            },
+        },
+        "crosswatch": {"connected": True, "instances": {"CW-P01": {"connected": True}}},
+        "floppy": {
+            "server_url": "http://floppy.test",
+            "api_token": "token",
+            "instances": {"F1": {"server_url": "http://floppy.test", "api_token": "token"}},
+        },
+    }
+    payload = {
+        "event": "media.rate",
+        "Account": {"title": "pasca"},
+        "Metadata": {
+            "type": "movie",
+            "title": "Fight Club",
+            "year": 1999,
+            "ratingKey": "rk-550",
+            "userRating": 8,
+            "Guid": [{"id": "tmdb://550"}],
+        },
+    }
+
+    result = plex.process_webhook(payload, {}, cfg=cfg)
+
+    assert result["ok"] is True
+    assert {call["provider"] for call in sent} == {"crosswatch", "floppy"}
+    assert {call["instance"] for call in sent} == {"CW-P01", "F1"}
+    assert all(call["item"]["ids"]["tmdb"] == 550 for call in sent)
+    assert all(call["rating"] == 8 for call in sent)


### PR DESCRIPTION
# Pull request

## Change

- Add ratings_sync with one dispatch for the OPS backed rating sinks
- Call it from both the Plex watcher and the Plex webhook
- Send PunchPlay ratings from the webhook, which it never did
- Use one shared sink list when deciding if a rating run succeeded

## Why

The watcher and the webhook each had their own copy of the same block.

## Issue

NA
