### PR TITLE
Add: PunchPlay watcher sink and playback progress adapter

### DIFF
--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -633,7 +633,7 @@ function renderProviderSelects(state){
     if(isMedia(name)) return "Media server";
     if(isKodi(name)) return "Media client";
     if(isCrossWatch(name)) return "Tracker";
-    if(isTrakt(name)||isSimkl(name)||same(name,"mdblist")||same(name,"publicmetadb")||same(name,"floppy")||same(name,"tautulli")) return "Tracker";
+    if(isTrakt(name)||isSimkl(name)||same(name,"mdblist")||same(name,"publicmetadb")||same(name,"floppy")||same(name,"punchplay")||same(name,"tautulli")) return "Tracker";
     if(same(name,"tmdb")||same(name,"anilist")) return "Metadata";
     return "Provider";
   };

--- a/assets/js/modals/scrobbler-route/index.js
+++ b/assets/js/modals/scrobbler-route/index.js
@@ -2,8 +2,8 @@
 const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 const label = (v) => ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", kodi: "Kodi", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
 const sources = ["plex", "jellyfin", "emby", "kodi"];
-const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy"];
-const ratingSinks = ["trakt", "simkl", "mdblist"];
+const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay"];
+const ratingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay"];
 
 function flashCopied(btn) {
   if (!btn) return;

--- a/assets/js/modals/scrobbler-webhook/index.js
+++ b/assets/js/modals/scrobbler-webhook/index.js
@@ -1,7 +1,8 @@
 /* CrossWatch - Scrobbler Webhook Modal */
 const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
-const label = (v) => ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
-const sinks = ["trakt", "simkl", "mdblist"];
+const label = (v) => window.CW?.ProviderMeta?.label?.(v) || ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
+const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay"];
+const ratingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay"];
 const webhookSources = new Set(["plex", "jellyfin", "emby"]);
 
 function flashCopied(btn) {
@@ -228,13 +229,15 @@ function duplicateWebhook(current) {
 }
 
 function logo(provider) {
-  return ({
+  return window.CW?.ProviderMeta?.logoPath?.(provider) || ({
     plex: "/assets/img/PLEX.svg",
     jellyfin: "/assets/img/JELLYFIN.svg",
     emby: "/assets/img/EMBY.svg",
     trakt: "/assets/img/TRAKT.svg",
     simkl: "/assets/img/SIMKL.svg",
     mdblist: "/assets/img/MDBLIST.svg",
+    crosswatch: "/assets/img/CROSSWATCH.svg",
+    floppy: "/assets/img/FLOPPY.png",
   }[String(provider || "").toLowerCase()] || "");
 }
 
@@ -401,7 +404,7 @@ function filtersPanel(provider, filt) {
 
 function globalRatingTargets() {
   const g = props.overview?.source_state?.global_plex_ratings || {};
-  return ["trakt", "simkl", "mdblist"].filter((s) => g[s]);
+  return ratingSinks.filter((s) => g[s]);
 }
 
 function ratingsPanel(provider, ratingsTargets) {
@@ -417,7 +420,7 @@ function ratingsPanel(provider, ratingsTargets) {
         <div><strong>Plex ratings</strong><p>Forward Plex ratings received on this webhook to the selected trackers.</p></div>
       </div>
       ${globalWarn}
-      <div class="scrm-targets">${sinks.map((sink) => `<label class="scrm-target"><input type="checkbox" data-rating="${esc(sink)}" ${ratingsTargets.includes(sink) ? "checked" : ""}><span class="scrm-target-mark">${providerIcon(sink)}</span><span>${esc(label(sink))}</span></label>`).join("")}</div>
+      <div class="scrm-targets">${ratingSinks.map((sink) => `<label class="scrm-target"><input type="checkbox" data-rating="${esc(sink)}" ${ratingsTargets.includes(sink) ? "checked" : ""}><span class="scrm-target-mark">${providerIcon(sink)}</span><span>${esc(label(sink))}</span></label>`).join("")}</div>
     </section>
   `;
 }
@@ -486,7 +489,7 @@ function render(errs = []) {
   const fKey = filterKey(provider);
   const effective = settings();
   const filt = effective[fKey] || {};
-  const ratingsTargets = ["trakt", "simkl", "mdblist"].filter((sink) => effective[`plex_${sink}_ratings`]);
+  const ratingsTargets = ratingSinks.filter((sink) => effective[`plex_${sink}_ratings`]);
   if (provider !== "plex" && activeTab === "ratings") activeTab = "source";
   const dup = duplicateWebhook(current);
   root.innerHTML = `
@@ -549,7 +552,7 @@ function payload() {
     body.filters.server_uuid = body.filters.server_uuid_whitelist[0] || "";
   }
   if (provider === "plex") {
-    for (const sink of sinks) body[`plex_${sink}_ratings`] = !!root.querySelector(`[data-rating="${sink}"]`)?.checked;
+    for (const sink of ratingSinks) body[`plex_${sink}_ratings`] = !!root.querySelector(`[data-rating="${sink}"]`)?.checked;
   }
   if (root.querySelector("#scw-override-options")?.checked) {
     const pause = root.querySelector("#scw-pause")?.value;

--- a/assets/js/playback_progress.js
+++ b/assets/js/playback_progress.js
@@ -20,7 +20,7 @@
   const providerIcon = (provider) => {
     return `<img src="${esc(providerLogLogo(provider))}" alt="" onerror="this.remove()">`;
   };
-  const PLAYBACK_PROVIDER_KEYS = ["crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy"];
+  const PLAYBACK_PROVIDER_KEYS = ["crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "punchplay", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy"];
   const DEFAULT_PROVIDER_TIMEOUT_SECONDS = 20;
   const state = {
     mounted: false,

--- a/providers/scrobble/punchplay/__init__.py
+++ b/providers/scrobble/punchplay/__init__.py
@@ -1,0 +1,4 @@
+# providers/scrobble/punchplay/__init__.py
+# CrossWatch - PunchPlay scrobble package
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations

--- a/providers/scrobble/punchplay/sink.py
+++ b/providers/scrobble/punchplay/sink.py
@@ -1,0 +1,433 @@
+# providers/scrobble/punchplay/sink.py
+# CrossWatch - Scrobble PunchPlay Sink
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import hashlib
+import threading
+import time
+import uuid
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import requests
+
+from cw_platform.config_base import load_config
+from cw_platform.event_archive import record_watch
+from cw_platform.local_db.ttl_dedupe import once_per_ttl
+from cw_platform.provider_instances import get_provider_block, normalize_instance_id
+from services.activity import record_scrobble_event
+
+try:
+    from _logging import log as BASE_LOG
+except Exception:
+    BASE_LOG = None
+
+from providers.scrobble._auto_remove_watchlist import remove_across_providers_by_ids as _rm_across
+from providers.scrobble._watched_gate import resolve_stop_action
+
+try:
+    from providers.scrobble.scrobble import ScrobbleEvent, ScrobbleSink, mask_account  # type: ignore
+except ImportError:
+    class ScrobbleSink:  # pragma: no cover
+        def send(self, event: Any) -> None: ...
+
+    class ScrobbleEvent:  # pragma: no cover
+        ...
+
+    def mask_account(value: Any) -> str:  # pragma: no cover
+        s = str(value or "").strip()
+        if not s:
+            return "unknown"
+        return s[0] + "*" if len(s) <= 2 else s[:2] + "***"
+
+from providers.sync.punchplay._common import (
+    URL_PLAYBACK,
+    error_of,
+    punchplay_request,
+    request_id_of,
+)
+
+APP_AGENT = "CrossWatch/Watcher/1.0"
+DEFAULT_WATCHED_AT = 90.0
+SESSION_TTL_SEC = 6 * 3600
+_AR_TTL = 60
+
+_STATE_LOCK = threading.Lock()
+_SESSIONS: dict[str, dict[str, Any]] = {}
+
+
+def _route_source(cfg: Mapping[str, Any]) -> tuple[str, str]:
+    watch = ((cfg.get("scrobble") or {}).get("watch") or {}) if isinstance(cfg, Mapping) else {}
+    source = str(watch.get("route_provider") or "watcher").strip().lower() or "watcher"
+    source_instance = str(watch.get("route_provider_instance") or "default").strip() or "default"
+    return source, source_instance
+
+
+def _ar_seen(key: str) -> bool:
+    try:
+        return not once_per_ttl(None, "auto_remove_seen", key, ttl_seconds=_AR_TTL)
+    except Exception:
+        return False
+
+
+def _norm_media_type(value: str) -> str:
+    text = (value or "").strip().lower()
+    if text.endswith("s"):
+        text = text[:-1]
+    return "show" if text == "serie" or text == "series" else text
+
+
+def _auto_remove_enabled(cfg: Mapping[str, Any], media_type: str) -> bool:
+    scrobble = (cfg.get("scrobble") or {}) if isinstance(cfg, Mapping) else {}
+    watch = scrobble.get("watch") or {}
+    route_opts = watch.get("route_options") if isinstance(watch.get("route_options"), Mapping) else {}
+    mode = str((route_opts or {}).get("auto_remove_watchlist") or "inherit").strip().lower()
+    if mode == "off":
+        return False
+    if not scrobble.get("delete_plex") and mode != "on":
+        return False
+    types = scrobble.get("delete_plex_types") or []
+    mt = _norm_media_type(media_type)
+    if isinstance(types, str):
+        return _norm_media_type(types) == mt
+    try:
+        return mt in {_norm_media_type(str(x)) for x in types if str(x).strip()}
+    except Exception:
+        return False
+
+
+def _auto_remove_across(event: Any, cfg: Mapping[str, Any], scope: str = "") -> None:
+    media_type = "episode" if str(getattr(event, "media_type", "") or "").lower() == "episode" else "movie"
+    if not _auto_remove_enabled(cfg, media_type):
+        return
+    ids = {k: str(v) for k, v in (getattr(event, "ids", None) or {}).items() if v}
+    if not ids:
+        return
+    key = f"{scope}|{media_type}|" + ",".join(f"{k}={v}" for k, v in sorted(ids.items()))
+    if _ar_seen(key):
+        return
+    try:
+        _rm_across(ids, media_type, scope=scope)
+    except Exception:
+        pass
+
+
+def _cfg() -> dict[str, Any]:
+    try:
+        return load_config() or {}
+    except Exception:
+        return {}
+
+
+def _is_debug() -> bool:
+    try:
+        return bool((_cfg().get("runtime") or {}).get("debug"))
+    except Exception:
+        return False
+
+
+def _log(msg: str, lvl: str = "INFO") -> None:
+    level = (str(lvl) or "INFO").upper()
+    if level == "DEBUG" and not _is_debug():
+        return
+    if BASE_LOG is not None:
+        try:
+            BASE_LOG(msg, level=level, module="SCROBBLE")
+            return
+        except Exception:
+            pass
+    print(f"[SCROBBLE] {level}: {msg}")
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(str(value).strip())
+    except Exception:
+        return None
+
+
+def _imdb(value: Any) -> str | None:
+    text = str(value or "").strip().lower()
+    if not text:
+        return None
+    if not text.startswith("tt"):
+        text = f"tt{text.lstrip('t')}"
+    rest = text[2:]
+    return text if rest.isdigit() and rest else None
+
+
+def _prune_sessions(now: float) -> None:
+    stale = [k for k, v in _SESSIONS.items() if now - float(v.get("seen", 0.0)) > SESSION_TTL_SEC]
+    for k in stale:
+        _SESSIONS.pop(k, None)
+
+
+def _session_scope(event: Any, instance: str) -> str:
+    parts = [
+        str(getattr(event, "server_uuid", "") or ""),
+        str(getattr(event, "session_key", "") or ""),
+    ]
+    scope = ":".join(p for p in parts if p)
+    if not scope:
+        ids = getattr(event, "ids", None) or {}
+        seed = "|".join(f"{k}={v}" for k, v in sorted(ids.items()) if v)
+        seed = seed or str(getattr(event, "title", "") or "")
+        scope = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:24]
+    return f"{instance}:{scope}"
+
+
+class PunchPlaySink(ScrobbleSink):
+    name = "punchplay"
+
+    def __init__(self, cfg_provider: Callable[[], dict[str, Any]] | None = None, instance_id: Any = None) -> None:
+        self._cfg_provider = cfg_provider
+        self.instance_id = normalize_instance_id(instance_id)
+        self.session = requests.Session()
+        try:
+            self.session.headers.setdefault("Accept", "application/json")
+            self.session.headers.setdefault("User-Agent", APP_AGENT)
+        except Exception:
+            pass
+
+    @property
+    def config(self) -> dict[str, Any]:
+        if self._cfg_provider is not None:
+            try:
+                cfg = self._cfg_provider()
+                if isinstance(cfg, Mapping):
+                    return dict(cfg)
+            except Exception:
+                pass
+        return _cfg()
+
+    def _block(self, cfg: Mapping[str, Any]) -> dict[str, Any]:
+        try:
+            return get_provider_block(cfg, "punchplay", self.instance_id) or {}
+        except Exception:
+            block = cfg.get("punchplay") if isinstance(cfg, Mapping) else None
+            return dict(block) if isinstance(block, Mapping) else {}
+
+    def _watched_at(self, cfg: Mapping[str, Any]) -> float:
+        try:
+            sc = cfg.get("scrobble") if isinstance(cfg, Mapping) else {}
+            value = ((sc or {}).get("punchplay") or {}).get("watched_at")
+            if value is None:
+                value = ((sc or {}).get("trakt") or {}).get("watched_at", DEFAULT_WATCHED_AT)
+            return max(0.0, min(100.0, float(value)))
+        except Exception:
+            return DEFAULT_WATCHED_AT
+
+    def _ids_payload(self, event: Any) -> dict[str, Any]:
+        ids = getattr(event, "ids", None) or {}
+        out: dict[str, Any] = {}
+        tmdb = _as_int(ids.get("tmdb"))
+        if tmdb and tmdb > 0:
+            out["tmdb_id"] = tmdb
+        imdb = _imdb(ids.get("imdb"))
+        if imdb:
+            out["imdb_id"] = imdb
+        tvdb = _as_int(ids.get("tvdb"))
+        if tvdb and tvdb > 0:
+            out["tvdb_id"] = tvdb
+        return out
+
+    def _resolve_action(self, scope: str, action: str, now: float) -> tuple[str, str]:
+        with _STATE_LOCK:
+            _prune_sessions(now)
+            state = _SESSIONS.get(scope)
+            if state is None:
+                state = {"session_id": str(uuid.uuid4()), "paused": False, "seen": now}
+                _SESSIONS[scope] = state
+            state["seen"] = now
+
+            if action == "pause":
+                state["paused"] = True
+                return "pause", str(state["session_id"])
+            if action == "stop":
+                session_id = str(state["session_id"])
+                _SESSIONS.pop(scope, None)
+                return "stop", session_id
+            if state.get("paused"):
+                state["paused"] = False
+                return "resume", str(state["session_id"])
+            if state.get("started"):
+                return "progress", str(state["session_id"])
+            state["started"] = True
+            return "start", str(state["session_id"])
+
+    def send(self, event: Any) -> None:
+        cfg = self.config
+        block = self._block(cfg)
+        if not str(block.get("access_token") or "").strip():
+            _log("PUNCHPLAY: skip scrobble, not connected", "DEBUG")
+            return
+
+        raw_action = str(getattr(event, "action", "") or "").strip().lower()
+        if raw_action not in ("start", "pause", "stop"):
+            return
+
+        ids_payload = self._ids_payload(event)
+        if not ids_payload:
+            _log("PUNCHPLAY: skip scrobble, no supported ids", "DEBUG")
+            return
+
+        try:
+            progress_pct = max(0.0, min(100.0, float(getattr(event, "progress", 0.0) or 0.0)))
+        except Exception:
+            progress_pct = 0.0
+
+        watched_at = self._watched_at(cfg)
+        effective = raw_action
+        if raw_action == "stop":
+            effective = resolve_stop_action(progress_pct, watched_at)
+
+        now = time.time()
+        scope = _session_scope(event, self.instance_id)
+        action, session_id = self._resolve_action(scope, effective, now)
+
+        media_type = "episode" if str(getattr(event, "media_type", "") or "").lower() == "episode" else "movie"
+        payload: dict[str, Any] = dict(ids_payload)
+        payload["media_type"] = media_type
+        payload["event_id"] = str(uuid.uuid4())
+        payload["playback_session_id"] = session_id
+        payload["event_created_at"] = int(now * 1000)
+        payload["client_version"] = APP_AGENT
+
+        title = str(getattr(event, "title", "") or "").strip()
+        if title:
+            payload["title"] = title
+        year = _as_int(getattr(event, "year", None))
+        if year:
+            payload["year"] = year
+
+        if media_type == "episode":
+            season = _as_int(getattr(event, "season", None))
+            number = _as_int(getattr(event, "number", None))
+            if season is None or number is None:
+                _log("PUNCHPLAY: skip scrobble, episode missing season/episode", "DEBUG")
+                return
+            payload["season"] = season
+            payload["episode"] = number
+
+        position_ms = _as_int(getattr(event, "position_ms", None))
+        duration_ms = _as_int(getattr(event, "duration_ms", None))
+        if duration_ms and duration_ms > 0:
+            payload["duration_seconds"] = int(round(duration_ms / 1000.0))
+        if position_ms is not None and position_ms >= 0:
+            payload["position_seconds"] = int(round(position_ms / 1000.0))
+        elif duration_ms and duration_ms > 0:
+            payload["position_seconds"] = int(round(duration_ms * (progress_pct / 100.0) / 1000.0))
+
+        payload["progress"] = round(progress_pct / 100.0, 4)
+
+        device_id = str(block.get("device_id") or "").strip()
+        if device_id:
+            payload["device_id"] = device_id
+
+        if action == "stop":
+            payload["watched_threshold"] = round(watched_at / 100.0, 4)
+            payload["watched"] = progress_pct >= watched_at
+
+        watched = bool(payload.get("watched"))
+        self._post(cfg, event, action, payload, progress_pct, watched=watched)
+
+    def _post(
+        self,
+        cfg: Mapping[str, Any],
+        event: Any,
+        action: str,
+        payload: Mapping[str, Any],
+        progress_pct: float,
+        *,
+        watched: bool = False,
+    ) -> None:
+        adapter = _Adapter(dict(cfg), self.instance_id, self.session)
+        src, src_inst = _route_source(cfg)
+        archived = action in ("start", "stop")
+        title = str(payload.get("title") or "")
+
+        try:
+            resp = punchplay_request(adapter, "POST", URL_PLAYBACK.format(action=action), json=dict(payload))
+        except Exception as exc:
+            reason = exc.__class__.__name__
+            _log(f"PUNCHPLAY: scrobble {action} failed ({reason})", "WARN")
+            if archived:
+                self._archive(event, action, src, src_inst, progress_pct, status="fail", reason=reason)
+            return
+
+        code = int(getattr(resp, "status_code", 0) or 0)
+        if not (200 <= code < 300):
+            reason = error_of(resp) or f"http:{code}"
+            _log(
+                f"PUNCHPLAY: scrobble {action} rejected status={code} error={reason} request_id={request_id_of(resp)}",
+                "WARN",
+            )
+            if archived:
+                self._archive(event, action, src, src_inst, progress_pct, status="fail", reason=reason)
+            return
+
+        if archived:
+            self._archive(event, action, src, src_inst, progress_pct)
+
+        if action == "stop" and watched:
+            try:
+                record_scrobble_event(
+                    event,
+                    source=src,
+                    source_instance=src_inst,
+                    target="punchplay",
+                    target_instance=self.instance_id,
+                    progress=progress_pct,
+                )
+            except Exception:
+                pass
+            _auto_remove_across(event, cfg, scope=f"punchplay:{self.instance_id}")
+
+        _log(
+            f"PUNCHPLAY: scrobble {action} user='{mask_account(getattr(event, 'account', None))}' "
+            f"p={progress_pct:.1f}% media={title!r}",
+            "DEBUG" if action == "progress" else "INFO",
+        )
+
+    def _archive(
+        self,
+        event: Any,
+        action: str,
+        src: str,
+        src_inst: str,
+        progress_pct: float,
+        *,
+        status: str = "",
+        reason: str = "",
+    ) -> None:
+        try:
+            extra: dict[str, Any] = {}
+            if status:
+                extra["status"] = status
+            if reason:
+                extra["reason"] = reason
+            record_watch(
+                event,
+                action=action,
+                source_provider=src,
+                source_instance=src_inst,
+                destination_provider="punchplay",
+                destination_instance=self.instance_id,
+                progress=progress_pct,
+                **extra,
+            )
+        except Exception:
+            pass
+
+
+class _Adapter:
+    def __init__(self, cfg: dict[str, Any], instance_id: str, session: requests.Session) -> None:
+        self.config = cfg
+        self.instance_id = instance_id
+        self.session = session
+
+
+__all__ = ["PunchPlaySink"]

--- a/providers/scrobble/watch_manager.py
+++ b/providers/scrobble/watch_manager.py
@@ -166,6 +166,10 @@ def _make_sink(name: str, cfg_provider: Callable[[], dict[str, Any]], instance_i
         from providers.scrobble.floppy.sink import FloppySink
 
         cls = FloppySink
+    elif sink == "punchplay":
+        from providers.scrobble.punchplay.sink import PunchPlaySink
+
+        cls = PunchPlaySink
     else:
         raise ValueError(f"Unknown sink: {sink}")
 

--- a/services/playback_progress/adapters/punchplay.py
+++ b/services/playback_progress/adapters/punchplay.py
@@ -1,0 +1,306 @@
+# /services/playback_progress/adapters/punchplay.py
+# CrossWatch - PunchPlay Playback Progress Adapter
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any, Mapping, cast
+
+import requests
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from providers.sync._mod_PUNCHPLAY import OPS as PUNCHPLAY_OPS
+from providers.sync.punchplay import _progress as feat_progress
+from providers.sync.punchplay._common import (
+    PunchPlayRateLimited,
+    URL_IN_PROGRESS_ITEM,
+    URL_PLAYBACK,
+    error_of,
+    punchplay_request,
+)
+
+from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, utc_now_iso
+from .base import PlaybackProgressAdapter, enrich_parallel, tmdb_metadata_provider
+
+PROGRESS_ID_FIELD = feat_progress.PROGRESS_ID_FIELD
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _num(value: Any) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(float(str(value).strip()))
+    except Exception:
+        return None
+
+
+def _float(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(str(value).strip())
+    except Exception:
+        return None
+
+
+class _Adapter:
+    def __init__(self, cfg: Mapping[str, Any], instance_id: str, session: requests.Session) -> None:
+        self.config = dict(cfg or {})
+        self.instance_id = instance_id
+        self.session = session
+
+
+class PunchPlayPlaybackAdapter(PlaybackProgressAdapter):
+    provider = "punchplay"
+    provider_label = "PunchPlay"
+
+    def __init__(self) -> None:
+        self._session = requests.Session()
+
+    def _client(self, config_view: Mapping[str, Any], instance_id: str) -> _Adapter:
+        return _Adapter(config_view, instance_id or "default", self._session)
+
+    def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
+        try:
+            configured = bool(PUNCHPLAY_OPS.is_configured(config_view))
+        except Exception:
+            configured = False
+        caps = _mapping(PUNCHPLAY_OPS.capabilities())
+        progress = _mapping(caps.get("progress"))
+        history = _mapping(caps.get("history"))
+        types = _mapping(progress.get("types"))
+        reason = "" if configured else "PunchPlay is not connected for this instance."
+        return PlaybackCapabilities(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            configured=configured,
+            read=bool(configured and progress),
+            remove_progress=bool(configured and progress.get("remove")),
+            mark_watched=bool(configured and history.get("write")),
+            update_progress=bool(configured and progress.get("upsert")),
+            bulk_remove_progress=bool(configured and progress.get("remove")),
+            bulk_mark_watched=bool(configured and history.get("write")),
+            bulk_update_progress=bool(configured and progress.get("upsert")),
+            supports_movies=bool(configured and types.get("movies")),
+            supports_episodes=bool(configured and types.get("episodes")),
+            supports_anime=bool(configured),
+            reason=reason,
+        )
+
+    def list_progress(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str, force_refresh: bool = False) -> PlaybackListResult:
+        caps = self.capabilities(config_view, instance_id=instance_id, instance_label=instance_label)
+        if not caps.read:
+            return PlaybackListResult(
+                False,
+                self.provider,
+                instance_id,
+                error_code="unsupported" if caps.configured else "not_configured",
+                message=caps.reason or "PunchPlay does not support playback listing.",
+            )
+        try:
+            index = PUNCHPLAY_OPS.build_index(config_view, feature="progress") or {}
+        except Exception:
+            return PlaybackListResult(
+                False,
+                self.provider,
+                instance_id,
+                error_code="provider_error",
+                message="PunchPlay progress request failed.",
+                retryable=True,
+            )
+        metadata = tmdb_metadata_provider(config_view)
+        pending = [(key, item) for key, item in dict(index).items() if isinstance(item, Mapping)]
+        items = enrich_parallel(pending, lambda entry: self._record(entry[0], entry[1], instance_id, instance_label, metadata))
+        return PlaybackListResult(True, self.provider, instance_id, items=[i for i in items if i], refreshed_at=utc_now_iso())
+
+    def _record(self, key: Any, item: Mapping[str, Any], instance_id: str, instance_label: str, metadata: Any = None) -> PlaybackRecord | None:
+        mini = id_minimal(item)
+        ids = dict(mini.get("ids") or {})
+        media_type = "episode" if str(item.get("type") or "").lower() == "episode" else "movie"
+        remote_id = str(item.get(PROGRESS_ID_FIELD) or "").strip()
+
+        duration_ms = _float(item.get("duration_ms"))
+        progress_ms = _float(item.get("progress_ms"))
+        percent = _float(item.get("progress_percent"))
+        if percent is None and progress_ms is not None and duration_ms:
+            percent = (progress_ms / duration_ms) * 100.0
+
+        remaining = None
+        if duration_ms and progress_ms is not None:
+            remaining = max(0, int((duration_ms - progress_ms) / 1000.0))
+
+        return PlaybackRecord(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            remote_id=remote_id,
+            canonical_key=str(key or canonical_key(mini) or ""),
+            media_type=media_type,
+            title=str(item.get("title") or ""),
+            episode_title=str(item.get("title") or "") if media_type == "episode" else "",
+            series_title=str(item.get("series_title") or ""),
+            season=_num(item.get("season")),
+            episode=_num(item.get("episode")),
+            year=_num(item.get("year")),
+            ids=ids,
+            progress_percent=round(percent, 3) if percent is not None else None,
+            remaining_seconds=remaining,
+            duration_seconds=int(duration_ms / 1000.0) if duration_ms else None,
+            progress_at=item.get("progress_at") or item.get("updated_at"),
+            updated_at=item.get("updated_at"),
+            source_app=str(item.get("playback_state") or ""),
+        )
+
+    def _rate_limited(self, exc: PunchPlayRateLimited, operation: str, instance_id: str, record: Mapping[str, Any]) -> PlaybackActionResult:
+        return PlaybackActionResult(
+            ok=False,
+            provider=self.provider,
+            instance_id=instance_id,
+            operation=operation,
+            remote_id=str(record.get("remote_id") or ""),
+            canonical_key=str(record.get("canonical_key") or ""),
+            error_code="rate_limited",
+            message=f"PunchPlay rate limit reached, retry in {exc.retry_after}s.",
+            retryable=True,
+            remote_status=429,
+        )
+
+    def _failed(self, operation: str, instance_id: str, record: Mapping[str, Any], *, code: str, message: str, status: int | None = None, retryable: bool = False) -> PlaybackActionResult:
+        return PlaybackActionResult(
+            ok=False,
+            provider=self.provider,
+            instance_id=instance_id,
+            operation=operation,
+            remote_id=str(record.get("remote_id") or ""),
+            canonical_key=str(record.get("canonical_key") or ""),
+            error_code=code,
+            message=message,
+            retryable=retryable,
+            remote_status=status,
+        )
+
+    def _applied(self, operation: str, instance_id: str, record: Mapping[str, Any]) -> PlaybackActionResult:
+        return PlaybackActionResult(
+            ok=True,
+            provider=self.provider,
+            instance_id=instance_id,
+            operation=operation,
+            remote_id=str(record.get("remote_id") or ""),
+            canonical_key=str(record.get("canonical_key") or ""),
+        )
+
+    def _item_from_record(self, record: Mapping[str, Any]) -> dict[str, Any]:
+        media_type = str(record.get("media_type") or "movie").lower()
+        ids = dict(record.get("ids") or {})
+        item: dict[str, Any] = {"type": "episode" if media_type == "episode" else "movie"}
+        if media_type == "episode":
+            item["show_ids"] = ids
+            item["season"] = _num(record.get("season"))
+            item["episode"] = _num(record.get("episode"))
+            item["series_title"] = str(record.get("series_title") or "")
+            item["title"] = str(record.get("episode_title") or record.get("title") or "")
+        else:
+            item["ids"] = ids
+            item["title"] = str(record.get("title") or "")
+            year = _num(record.get("year"))
+            if year:
+                item["year"] = year
+        duration = _num(record.get("duration_seconds"))
+        if duration:
+            item["duration_ms"] = duration * 1000
+        return item
+
+    def _send_playback(self, config_view: Mapping[str, Any], instance_id: str, action: str, payload: Mapping[str, Any]) -> Any:
+        client = self._client(config_view, instance_id)
+        return punchplay_request(client, "POST", URL_PLAYBACK.format(action=action), json=dict(payload), no_wait=True)
+
+    def remove_progress(self, config_view: Mapping[str, Any], record: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackActionResult:
+        remote_id = str(record.get("remote_id") or "").strip()
+        if not remote_id:
+            return self._failed("remove_progress", instance_id, record, code="missing_remote_id", message="PunchPlay in-progress id is unknown; refresh the list first.")
+        client = self._client(config_view, instance_id)
+        try:
+            resp = punchplay_request(client, "DELETE", URL_IN_PROGRESS_ITEM.format(entry_id=remote_id), no_wait=True)
+        except PunchPlayRateLimited as exc:
+            return self._rate_limited(exc, "remove_progress", instance_id, record)
+        except Exception:
+            return self._failed("remove_progress", instance_id, record, code="provider_error", message="PunchPlay dismiss request failed.", retryable=True)
+        code = int(getattr(resp, "status_code", 0) or 0)
+        if 200 <= code < 300 or code == 404:
+            return self._applied("remove_progress", instance_id, record)
+        return self._failed("remove_progress", instance_id, record, code=error_of(resp) or "provider_error", message="PunchPlay rejected the dismiss request.", status=code, retryable=code >= 500 or code == 429)
+
+    def update_progress(self, config_view: Mapping[str, Any], record: Mapping[str, Any], progress_percent: float, *, instance_id: str, instance_label: str) -> PlaybackActionResult:
+        item = self._item_from_record(record)
+        percent = max(0.0, min(100.0, float(progress_percent or 0.0)))
+        duration_ms = _float(item.get("duration_ms"))
+        if duration_ms:
+            item["progress_ms"] = int(duration_ms * (percent / 100.0))
+        else:
+            item["progress_percent"] = percent
+
+        payload = feat_progress._playback_payload(item)
+        if payload is None:
+            return self._failed("update_progress", instance_id, record, code="missing_ids", message="PunchPlay needs a TMDB, IMDb or TVDB id for this item.")
+        payload.update(
+            feat_progress._session_ids(
+                item,
+                str(record.get("canonical_key") or ""),
+                device_id=str((_mapping(config_view.get("punchplay")).get("device_id")) or ""),
+                instance=instance_id or "default",
+                position=payload.get("position_seconds"),
+            )
+        )
+        try:
+            resp = self._send_playback(config_view, instance_id, "progress", payload)
+        except PunchPlayRateLimited as exc:
+            return self._rate_limited(exc, "update_progress", instance_id, record)
+        except Exception:
+            return self._failed("update_progress", instance_id, record, code="provider_error", message="PunchPlay progress update failed.", retryable=True)
+        code = int(getattr(resp, "status_code", 0) or 0)
+        if 200 <= code < 300:
+            return self._applied("update_progress", instance_id, record)
+        return self._failed("update_progress", instance_id, record, code=error_of(resp) or "provider_error", message="PunchPlay rejected the progress update.", status=code, retryable=code >= 500 or code == 429)
+
+    def mark_watched(self, config_view: Mapping[str, Any], record: Mapping[str, Any], *, instance_id: str, instance_label: str, watched_at: str | None = None) -> PlaybackActionResult:
+        item = self._item_from_record(record)
+        duration_ms = _float(item.get("duration_ms"))
+        if duration_ms:
+            item["progress_ms"] = int(duration_ms)
+        item["progress_percent"] = 100.0
+
+        payload = feat_progress._playback_payload(item)
+        if payload is None:
+            return self._failed("mark_watched", instance_id, record, code="missing_ids", message="PunchPlay needs a TMDB, IMDb or TVDB id for this item.")
+        payload.update(
+            feat_progress._session_ids(
+                item,
+                str(record.get("canonical_key") or ""),
+                device_id=str((_mapping(config_view.get("punchplay")).get("device_id")) or ""),
+                instance=instance_id or "default",
+                position=payload.get("position_seconds"),
+            )
+        )
+        payload["watched"] = True
+        payload["watched_threshold"] = 0.9
+        payload["progress"] = 1.0
+
+        try:
+            resp = self._send_playback(config_view, instance_id, "stop", payload)
+        except PunchPlayRateLimited as exc:
+            return self._rate_limited(exc, "mark_watched", instance_id, record)
+        except Exception:
+            return self._failed("mark_watched", instance_id, record, code="provider_error", message="PunchPlay watched request failed.", retryable=True)
+        code = int(getattr(resp, "status_code", 0) or 0)
+        if 200 <= code < 300:
+            return self._applied("mark_watched", instance_id, record)
+        return self._failed("mark_watched", instance_id, record, code=error_of(resp) or "provider_error", message="PunchPlay rejected the watched request.", status=code, retryable=code >= 500 or code == 429)
+
+
+__all__ = ["PunchPlayPlaybackAdapter"]

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -24,6 +24,7 @@ from .adapters.media_servers import EmbyPlaybackAdapter, JellyfinPlaybackAdapter
 from .adapters.mdblist import MDBListPlaybackAdapter
 from .adapters.nuvio import NuvioPlaybackAdapter
 from .adapters.publicmetadb import PublicMetaDBPlaybackAdapter
+from .adapters.punchplay import PunchPlayPlaybackAdapter
 from .adapters.simkl import SimklPlaybackAdapter
 from .adapters.stremio import StremioPlaybackAdapter
 from .adapters.trakt import TraktPlaybackAdapter
@@ -821,6 +822,7 @@ class PlaybackProgressService:
             "kodi": KodiPlaybackAdapter(),
             "stremio": StremioPlaybackAdapter(),
             "floppy": FloppyPlaybackAdapter(),
+            "punchplay": PunchPlayPlaybackAdapter(),
             "crosswatch": CrossWatchPlaybackAdapter(),
         }
         self._cache: dict[tuple[str, str, str], dict[str, Any]] = {}

--- a/tests/test_crosswatch_watcher_sink.py
+++ b/tests/test_crosswatch_watcher_sink.py
@@ -129,12 +129,24 @@ def test_scrobbler_route_modal_lists_crosswatch_sink() -> None:
     css = (ROOT / "assets" / "css" / "providers.css").read_text("utf-8")
     meta = (ROOT / "assets" / "helpers" / "provider-meta.js").read_text("utf-8")
 
-    assert 'const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy"];' in text
+    assert '"crosswatch"' in text.split("const sinks")[1].split("]")[0]
+    assert '"crosswatch"' in text.split("const ratingSinks")[1].split("]")[0]
     assert 'crosswatch: "CrossWatch"' in text
-    assert 'crosswatch: "/assets/img/CROSSWATCH.svg"' in text
+    assert "window.CW?.ProviderMeta?.logoPath?.(provider)" in text
     assert ".scrm-provider-card.provider-crosswatch" in css
     assert ".scrm-provider-card.provider-crosswatch::after{background-image:url(/assets/img/CROSSWATCH.svg)}" in css
     assert "providerMeta().logoPath?.(v)" in scrobbler
+    assert '"crosswatch"' in scrobbler.split("plexRatingSinks")[1].split("]")[0]
     assert 'mdblist: "/assets/img/MDBLIST.svg"' not in scrobbler
     assert "CROSSWATCH:" in meta
     assert "scrobblerSink: true" in meta
+
+
+def test_scrobbler_webhook_modal_lists_crosswatch_sink() -> None:
+    text = (ROOT / "assets" / "js" / "modals" / "scrobbler-webhook" / "index.js").read_text("utf-8")
+
+    assert '"crosswatch"' in text.split("const sinks")[1].split("]")[0]
+    assert '"crosswatch"' in text.split("const ratingSinks")[1].split("]")[0]
+    assert 'crosswatch: "CrossWatch"' in text
+    assert 'crosswatch: "/assets/img/CROSSWATCH.svg"' in text
+    assert "for (const sink of ratingSinks)" in text

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -79,7 +79,9 @@ def test_playback_bulk_footer_uses_wide_management_layout():
 def test_playback_progress_frontend_includes_kodi_provider_key():
     js = (ROOT / "assets" / "js" / "playback_progress.js").read_text(encoding="utf-8")
 
-    assert 'const PLAYBACK_PROVIDER_KEYS = ["crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy"];' in js
+    keys = js.split("PLAYBACK_PROVIDER_KEYS")[1].split("]")[0]
+    for provider in ("crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy"):
+        assert f'"{provider}"' in keys, provider
 
 
 class _PolicyOps:

--- a/tests/test_punchplay_playback.py
+++ b/tests/test_punchplay_playback.py
@@ -1,0 +1,219 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+
+class _Resp:
+    def __init__(self, status_code: int = 200, payload: Any = None) -> None:
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = json.dumps(self._payload)
+        self.headers: dict[str, str] = {}
+
+    def json(self) -> Any:
+        return self._payload
+
+
+CFG = {"punchplay": {"access_token": "at", "device_id": "crosswatch-abc"}}
+
+RECORD = {
+    "remote_id": "42",
+    "canonical_key": "tmdb:69478#s06e02",
+    "media_type": "episode",
+    "ids": {"tmdb": "69478"},
+    "season": 6,
+    "episode": 2,
+    "series_title": "The Handmaid's Tale",
+    "episode_title": "Exile",
+    "duration_seconds": 3307,
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_governor():
+    from providers.sync.punchplay import _common as c
+
+    c._GOVERNORS.clear()
+    yield
+    c._GOVERNORS.clear()
+
+
+@pytest.fixture()
+def adapter(monkeypatch: pytest.MonkeyPatch):
+    from services.playback_progress.adapters import punchplay as mod
+
+    calls: list[dict[str, Any]] = []
+
+    def fake(client: Any, method: str, url: str, **kw: Any) -> _Resp:
+        calls.append({"method": method, "url": url, **kw})
+        return _Resp(200, {})
+
+    monkeypatch.setattr(mod, "punchplay_request", fake)
+    return mod.PunchPlayPlaybackAdapter(), calls
+
+
+def test_adapter_is_registered_in_the_service() -> None:
+    from services.playback_progress.adapters.punchplay import PunchPlayPlaybackAdapter
+    from services.playback_progress.service import PlaybackProgressService
+
+    found = PlaybackProgressService()._adapter("punchplay")
+    assert isinstance(found, PunchPlayPlaybackAdapter)
+
+
+def test_capabilities_reflect_connection_state() -> None:
+    from services.playback_progress.adapters.punchplay import PunchPlayPlaybackAdapter
+
+    a = PunchPlayPlaybackAdapter()
+    on = a.capabilities(CFG, instance_id="default", instance_label="Default")
+    off = a.capabilities({"punchplay": {}}, instance_id="default", instance_label="Default")
+
+    assert (on.configured, on.read, on.remove_progress, on.mark_watched, on.update_progress) == (True, True, True, True, True)
+    assert (off.configured, off.read) == (False, False)
+    assert off.reason
+
+
+def test_remove_progress_dismisses_by_remote_id(adapter) -> None:
+    a, calls = adapter
+
+    res = a.remove_progress(CFG, RECORD, instance_id="default", instance_label="Default")
+
+    assert res.ok is True
+    assert calls[0]["method"] == "DELETE"
+    assert calls[0]["url"].endswith("/playback/in-progress/42")
+    assert calls[0]["no_wait"] is True
+
+
+def test_remove_without_remote_id_fails_cleanly(adapter) -> None:
+    a, calls = adapter
+
+    res = a.remove_progress(CFG, dict(RECORD, remote_id=""), instance_id="default", instance_label="Default")
+
+    assert res.ok is False
+    assert res.error_code == "missing_remote_id"
+    assert calls == []
+
+
+def test_update_progress_posts_progress_action(adapter) -> None:
+    a, calls = adapter
+
+    res = a.update_progress(CFG, RECORD, 50.0, instance_id="default", instance_label="Default")
+
+    assert res.ok is True
+    p = calls[0]["json"]
+    assert calls[0]["url"].endswith("/playback/progress")
+    assert p["media_type"] == "episode"
+    assert p["tmdb_id"] == 69478
+    assert p["season"] == 6 and p["episode"] == 2
+    assert abs(p["progress"] - 0.5) < 0.01
+    assert p["playback_session_id"] and p["event_id"]
+
+
+def test_mark_watched_posts_stop_with_watched_flag(adapter) -> None:
+    a, calls = adapter
+
+    res = a.mark_watched(CFG, RECORD, instance_id="default", instance_label="Default")
+
+    assert res.ok is True
+    p = calls[0]["json"]
+    assert calls[0]["url"].endswith("/playback/stop")
+    assert p["watched"] is True
+    assert p["progress"] == 1.0
+
+
+def test_missing_ids_fails_without_a_request(adapter) -> None:
+    a, calls = adapter
+
+    res = a.update_progress(CFG, dict(RECORD, ids={"anidb": "99"}), 50.0, instance_id="default", instance_label="Default")
+
+    assert res.ok is False
+    assert res.error_code == "missing_ids"
+    assert calls == []
+
+
+# --- rate limiting is the whole point of this adapter -------------------------
+
+def test_writes_use_no_wait_so_the_ui_never_blocks(adapter) -> None:
+    a, calls = adapter
+
+    a.update_progress(CFG, RECORD, 25.0, instance_id="default", instance_label="Default")
+    a.mark_watched(CFG, RECORD, instance_id="default", instance_label="Default")
+    a.remove_progress(CFG, RECORD, instance_id="default", instance_label="Default")
+
+    assert all(c.get("no_wait") is True for c in calls), "playback UI calls must not sleep on the governor"
+
+
+def test_exhausted_playback_budget_returns_retryable_instead_of_hanging(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _common as c
+    from services.playback_progress.adapters.punchplay import PunchPlayPlaybackAdapter
+
+    slept: list[float] = []
+    monkeypatch.setattr(c.time, "sleep", lambda s: slept.append(s))
+
+    gov = c.rate_governor("default", CFG["punchplay"])
+    limit, _window = c.RATE_BUDGETS["playback"]
+    url = c.URL_PLAYBACK.format(action="progress")
+    for _ in range(limit):
+        assert gov.try_acquire("POST", url) == 0.0
+
+    a = PunchPlayPlaybackAdapter()
+    res = a.update_progress(CFG, RECORD, 50.0, instance_id="default", instance_label="Default")
+
+    assert res.ok is False
+    assert res.error_code == "rate_limited"
+    assert res.retryable is True
+    assert res.remote_status == 429
+    assert "retry in" in res.message
+    assert slept == [], "must fail fast, not sleep"
+
+
+def test_playback_budget_matches_the_documented_limit() -> None:
+    from providers.sync.punchplay._common import RATE_BUDGETS
+
+    assert RATE_BUDGETS["playback"] == (120, 300.0)
+
+
+def test_list_progress_builds_records_from_the_index(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync import _mod_PUNCHPLAY as mod
+    from services.playback_progress.adapters.punchplay import PunchPlayPlaybackAdapter
+
+    index = {
+        "tmdb:69478#s06e02": {
+            "type": "episode",
+            "show_ids": {"tmdb": "69478"},
+            "ids": {"tmdb": "5978363"},
+            "season": 6,
+            "episode": 2,
+            "series_title": "The Handmaid's Tale",
+            "title": "Exile",
+            "progress_ms": 753000,
+            "duration_ms": 3307930,
+            "progress_percent": 22.764,
+            "progress_at": "2026-07-31T19:43:27.000Z",
+            "_punchplay_progress_id": "7",
+        }
+    }
+    monkeypatch.setattr(mod.OPS, "build_index", lambda cfg, *, feature: dict(index))
+
+    res = PunchPlayPlaybackAdapter().list_progress(CFG, instance_id="default", instance_label="Default")
+
+    assert res.ok is True
+    assert len(res.items) == 1
+    rec = res.items[0]
+    assert rec.remote_id == "7"
+    assert rec.media_type == "episode"
+    assert rec.season == 6 and rec.episode == 2
+    assert rec.progress_percent is not None and abs(rec.progress_percent - 22.764) < 0.01
+    assert rec.duration_seconds == 3307
+
+
+def test_playback_ui_list_includes_punchplay() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "playback_progress.js").read_text(encoding="utf-8")
+    keys = js.split("PLAYBACK_PROVIDER_KEYS")[1].split("]")[0]
+    assert '"punchplay"' in keys

--- a/tests/test_punchplay_scrobble.py
+++ b/tests/test_punchplay_scrobble.py
@@ -1,0 +1,435 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+
+class _Resp:
+    def __init__(self, status_code: int = 200, payload: Any = None) -> None:
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = json.dumps(self._payload)
+        self.headers: dict[str, str] = {}
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class Event:
+    def __init__(self, **kw: Any) -> None:
+        self.action = kw.get("action", "start")
+        self.media_type = kw.get("media_type", "movie")
+        self.ids = kw.get("ids", {"tmdb": "550"})
+        self.title = kw.get("title", "Fight Club")
+        self.year = kw.get("year", 1999)
+        self.season = kw.get("season")
+        self.number = kw.get("number")
+        self.progress = kw.get("progress", 10.0)
+        self.account = kw.get("account", "u")
+        self.server_uuid = kw.get("server_uuid", "srv-1")
+        self.session_key = kw.get("session_key", "sess-1")
+        self.raw = kw.get("raw", {})
+        self.position_ms = kw.get("position_ms", 100000)
+        self.duration_ms = kw.get("duration_ms", 1000000)
+
+
+CFG = {
+    "punchplay": {"access_token": "at", "device_id": "crosswatch-abc"},
+    "scrobble": {"watch": {"watched_at": 90}},
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_sessions():
+    from providers.scrobble.punchplay import sink as s
+
+    s._SESSIONS.clear()
+    yield
+    s._SESSIONS.clear()
+
+
+@pytest.fixture()
+def sink(monkeypatch: pytest.MonkeyPatch):
+    from providers.scrobble.punchplay import sink as s
+
+    calls: list[dict[str, Any]] = []
+
+    def fake(adapter: Any, method: str, url: str, **kw: Any) -> _Resp:
+        calls.append({"method": method, "url": url, **kw})
+        return _Resp(200, {})
+
+    monkeypatch.setattr(s, "punchplay_request", fake)
+    return s.PunchPlaySink(cfg_provider=lambda: dict(CFG)), calls
+
+
+def _action_of(call: dict[str, Any]) -> str:
+    return call["url"].rsplit("/", 1)[-1]
+
+
+def test_sink_is_registered_in_the_factory() -> None:
+    from providers.scrobble.punchplay.sink import PunchPlaySink
+    from providers.scrobble.watch_manager import _make_sink
+
+    made = _make_sink("punchplay", lambda: dict(CFG), "default")
+    assert isinstance(made, PunchPlaySink)
+
+
+def test_start_pause_resume_stop_lifecycle(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", progress=5.0))
+    s.send(Event(action="pause", progress=20.0))
+    s.send(Event(action="start", progress=25.0))
+    s.send(Event(action="stop", progress=95.0))
+
+    assert [_action_of(c) for c in calls] == ["start", "pause", "resume", "stop"]
+
+    session_ids = {c["json"]["playback_session_id"] for c in calls}
+    assert len(session_ids) == 1, "all events in one viewing session share a session id"
+
+
+def test_repeat_start_becomes_progress(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", progress=5.0))
+    s.send(Event(action="start", progress=15.0))
+    s.send(Event(action="start", progress=25.0))
+
+    assert [_action_of(c) for c in calls] == ["start", "progress", "progress"]
+
+
+def test_new_session_key_gets_a_new_session_id(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", session_key="sess-1"))
+    s.send(Event(action="start", session_key="sess-2"))
+
+    assert calls[0]["json"]["playback_session_id"] != calls[1]["json"]["playback_session_id"]
+
+
+def test_stop_below_threshold_is_downgraded_to_pause(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", progress=5.0))
+    s.send(Event(action="stop", progress=40.0))
+
+    assert [_action_of(c) for c in calls] == ["start", "pause"]
+    assert "watched" not in calls[1]["json"]
+
+
+def test_stop_above_threshold_marks_watched(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", progress=5.0))
+    s.send(Event(action="stop", progress=95.0))
+
+    stop = calls[1]["json"]
+    assert _action_of(calls[1]) == "stop"
+    assert stop["watched"] is True
+    assert stop["watched_threshold"] == 0.9
+
+
+def test_payload_shape_matches_playback_input(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", progress=10.0, position_ms=100000, duration_ms=1000000))
+    p = calls[0]["json"]
+
+    assert p["media_type"] == "movie"
+    assert p["tmdb_id"] == 550
+    assert p["title"] == "Fight Club"
+    assert p["year"] == 1999
+    assert p["position_seconds"] == 100
+    assert p["duration_seconds"] == 1000
+    assert p["progress"] == 0.1
+    assert p["device_id"] == "crosswatch-abc"
+    assert isinstance(p["event_created_at"], int)
+    assert p["event_id"] and p["playback_session_id"]
+
+
+def test_episode_payload_carries_season_and_episode(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", media_type="episode", season=1, number=2,
+                 ids={"tmdb": "95396"}, title="Severance"))
+    p = calls[0]["json"]
+
+    assert p["media_type"] == "episode"
+    assert p["season"] == 1 and p["episode"] == 2
+
+
+def test_episode_without_numbering_is_skipped(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", media_type="episode", season=None, number=None))
+
+    assert calls == []
+
+
+def test_event_ids_are_unique_per_event(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", progress=5.0))
+    s.send(Event(action="start", progress=15.0))
+
+    assert calls[0]["json"]["event_id"] != calls[1]["json"]["event_id"]
+
+
+def test_skips_when_not_connected(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.punchplay import sink as s
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(s, "punchplay_request", lambda *a, **k: calls.append(k) or _Resp(200, {}))
+
+    disconnected = {"punchplay": {"access_token": ""}}
+    s.PunchPlaySink(cfg_provider=lambda: disconnected).send(Event(action="start"))
+
+    assert calls == []
+
+
+def test_skips_when_no_supported_ids(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", ids={"anidb": "99"}))
+
+    assert calls == []
+
+
+# --- CrossWatch cross-cutting behaviour ---------------------------------------
+
+def test_sink_has_parity_with_other_scrobble_sinks() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    ours = (root / "providers" / "scrobble" / "punchplay" / "sink.py").read_text(encoding="utf-8")
+
+    for symbol in ("record_watch", "record_scrobble_event", "mask_account", "once_per_ttl", "_rm_across", "resolve_stop_action"):
+        assert symbol in ours, f"punchplay sink is missing {symbol}"
+
+
+def test_start_and_stop_are_written_to_the_event_archive(sink, monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.punchplay import sink as s
+
+    archived: list[dict[str, Any]] = []
+    monkeypatch.setattr(s, "record_watch", lambda ev, **kw: archived.append(kw))
+
+    a, _calls = sink
+    a.send(Event(action="start", progress=5.0))
+    a.send(Event(action="start", progress=15.0))
+    a.send(Event(action="stop", progress=95.0))
+
+    actions = [x["action"] for x in archived]
+    assert actions == ["start", "stop"], "progress ticks must not spam the archive"
+    assert archived[0]["destination_provider"] == "punchplay"
+    assert archived[-1]["progress"] == 95.0
+
+
+def test_failed_scrobble_is_archived_as_a_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.punchplay import sink as s
+
+    archived: list[dict[str, Any]] = []
+    monkeypatch.setattr(s, "record_watch", lambda ev, **kw: archived.append(kw))
+    monkeypatch.setattr(s, "punchplay_request", lambda *a, **k: _Resp(500, {"error": "server_error"}))
+    s._SESSIONS.clear()
+
+    s.PunchPlaySink(cfg_provider=lambda: dict(CFG)).send(Event(action="start", progress=5.0))
+
+    assert archived and archived[0]["status"] == "fail"
+    assert archived[0]["reason"]
+
+
+def test_watched_stop_records_activity_and_auto_removes(sink, monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.punchplay import sink as s
+
+    activity: list[dict[str, Any]] = []
+    removed: list[tuple[Any, ...]] = []
+    monkeypatch.setattr(s, "record_scrobble_event", lambda ev, **kw: activity.append(kw))
+    monkeypatch.setattr(s, "_rm_across", lambda ids, mt, scope="": removed.append((ids, mt, scope)))
+    monkeypatch.setattr(s, "_ar_seen", lambda key: False)
+
+    enabled = dict(CFG)
+    enabled["scrobble"] = {**CFG["scrobble"], "delete_plex": True, "delete_plex_types": ["movie", "show"]}
+    a = s.PunchPlaySink(cfg_provider=lambda: enabled)
+    a.send(Event(action="start", progress=5.0))
+    a.send(Event(action="stop", progress=95.0))
+
+    assert len(activity) == 1
+    assert activity[0]["target"] == "punchplay"
+    assert removed and removed[0][1] == "movie"
+
+
+def test_auto_remove_is_off_unless_configured(sink, monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.punchplay import sink as s
+
+    removed: list[Any] = []
+    monkeypatch.setattr(s, "record_scrobble_event", lambda ev, **kw: None)
+    monkeypatch.setattr(s, "_rm_across", lambda ids, mt, scope="": removed.append(ids))
+    monkeypatch.setattr(s, "_ar_seen", lambda key: False)
+
+    a, _calls = sink
+    a.send(Event(action="start", progress=5.0))
+    a.send(Event(action="stop", progress=95.0))
+
+    assert removed == [], "auto-remove must never fire unless the user enabled it"
+
+
+def test_unwatched_stop_does_not_record_activity_or_remove(sink, monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.punchplay import sink as s
+
+    activity: list[dict[str, Any]] = []
+    removed: list[Any] = []
+    monkeypatch.setattr(s, "record_scrobble_event", lambda ev, **kw: activity.append(kw))
+    monkeypatch.setattr(s, "_rm_across", lambda ids, mt, scope="": removed.append(ids))
+
+    a, _calls = sink
+    a.send(Event(action="start", progress=5.0))
+    a.send(Event(action="stop", progress=40.0))
+
+    assert activity == []
+    assert removed == []
+
+
+# --- ratings (webhook / watcher rating sink) ----------------------------------
+
+def test_punchplay_is_a_registered_rating_sink() -> None:
+    from providers.scrobble.plex.ratings_sync import _ops
+    from providers.sync._mod_PUNCHPLAY import OPS
+
+    assert _ops("punchplay") is OPS
+
+
+def test_send_rating_writes_a_movie_rating(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.plex.ratings_sync import send_rating
+    from providers.sync.punchplay import _common
+
+    sent: list[dict[str, Any]] = []
+
+    def fake(adapter: Any, method: str, url: str, **kw: Any) -> _Resp:
+        sent.append({"url": url, **kw})
+        return _Resp(200, {"results": [{"index": 0, "status": "updated", "resolved_tmdb_id": 550}]})
+
+    monkeypatch.setattr(_common, "punchplay_request", fake)
+
+    from providers.scrobble.plex.ratings_sync import item_from_plex_rating
+
+    item = item_from_plex_rating("movie", {"type": "movie", "title": "Fight Club", "year": 1999}, {"tmdb": "550"}, 8)
+    assert item is not None
+    res = send_rating("punchplay", CFG, "default", item, 8)
+
+    assert res["ok"] is True
+    assert sent[0]["url"].endswith("/sync/ratings")
+    assert sent[0]["json"]["items"][0]["rating"] == 8
+    assert "Idempotency-Key" in sent[0]["headers"]
+
+
+def test_send_rating_zero_clears_the_rating(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.plex.ratings_sync import send_rating
+    from providers.sync.punchplay import _common
+
+    sent: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        _common, "punchplay_request",
+        lambda adapter, method, url, **kw: (sent.append(kw), _Resp(200, {"results": [{"index": 0, "status": "updated", "resolved_tmdb_id": 550}]}))[1],
+    )
+
+    send_rating("punchplay", CFG, "default", {"type": "movie", "ids": {"tmdb": "550"}}, 0)
+
+    assert sent[0]["json"]["items"][0]["rating"] is None
+
+
+def test_send_rating_handles_episode_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.plex.ratings_sync import send_rating
+    from providers.sync.punchplay import _common
+
+    sent: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        _common, "punchplay_request",
+        lambda adapter, method, url, **kw: (sent.append(kw), _Resp(200, {"results": [{"index": 0, "status": "updated", "resolved_tmdb_id": 69478}]}))[1],
+    )
+
+    from providers.scrobble.plex.ratings_sync import item_from_plex_rating
+
+    md = {"type": "episode", "parentIndex": 6, "index": 2,
+          "grandparentTitle": "The Handmaid's Tale", "title": "Exile"}
+    item = item_from_plex_rating("episode", md, {}, 9,
+                                 show_ids={"tmdb": "69478"}, episode_ids={"tmdb": "5978363"})
+    assert item is not None
+    res = send_rating("punchplay", CFG, "default", item, 9)
+
+    p = sent[0]["json"]["items"][0]
+    assert res["ok"] is True
+    assert p["tmdb_id"] == 69478, "episode ratings must identify the show, not the episode"
+    assert p["scope"] == "episode"
+    assert p["season"] == 6 and p["episode"] == 2
+    assert p["rating"] == 9
+
+
+def test_plex_watch_exposes_punchplay_rating_toggle() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    watch = (root / "providers" / "scrobble" / "plex" / "watch.py").read_text(encoding="utf-8")
+
+    assert 'enable_punchplay = "punchplay" in custom_targets' in watch
+    assert 'enable_punchplay = bool(watch_cfg.get("plex_punchplay_ratings"))' in watch
+    assert "dispatch_ops_ratings" in watch
+
+    from providers.scrobble.plex.ratings_sync import OPS_RATING_SINKS, RATING_SINKS
+
+    assert "punchplay" in OPS_RATING_SINKS
+    assert "punchplay" in RATING_SINKS
+
+
+def test_punchplay_ratings_reach_the_plex_webhook() -> None:
+    from pathlib import Path
+
+    import providers.webhooks.plex as wh
+
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "providers" / "webhooks" / "plex.py").read_text(encoding="utf-8")
+
+    assert 'enable_punchplay_ratings = bool(wh.get("plex_punchplay_ratings", False))' in text
+    assert "dispatch_ops_ratings" in text
+    assert "plex_punchplay_ratings" in wh._DEF_WEBHOOK
+    assert "punchplay" in wh.RATING_SINKS
+
+
+def test_rating_sink_lists_include_punchplay() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    for rel in (
+        "assets/js/modals/scrobbler-route/index.js",
+        "assets/js/modals/scrobbler-webhook/index.js",
+    ):
+        text = (root / rel).read_text(encoding="utf-8")
+        assert '"punchplay"' in text.split("ratingSinks")[1].split("]")[0], rel
+
+    api = (root / "api" / "scrobblerManagementAPI.py").read_text(encoding="utf-8")
+    assert '"punchplay": bool(watch.get("plex_punchplay_ratings"))' in api
+
+
+def test_payload_validates_against_the_spec() -> None:
+    import yaml
+    from pathlib import Path
+
+    spec_path = Path("C:/Users/pasca/AppData/Local/Temp/claude/c--Users-pasca-source-repos-GITHUB-repos-CrossWatch/4849a183-4294-45db-bfc8-af09e4d4b2b8/scratchpad/ppdocs/openapi.yaml")
+    if not spec_path.exists():
+        pytest.skip("openapi.yaml not vendored")
+
+    schema = yaml.safe_load(spec_path.read_text(encoding="utf-8"))["components"]["schemas"]["PlaybackInput"]
+    props = schema.get("properties") or {}
+
+    from providers.scrobble.punchplay import sink as s
+
+    captured: list[dict[str, Any]] = []
+    s.punchplay_request = lambda adapter, method, url, **kw: captured.append(kw["json"]) or _Resp(200, {})  # type: ignore[assignment]
+    s._SESSIONS.clear()
+    s.PunchPlaySink(cfg_provider=lambda: dict(CFG)).send(Event(action="stop", progress=95.0))
+
+    payload = captured[0]
+    for key in payload:
+        assert key in props, f"field {key!r} is not declared in PlaybackInput"


### PR DESCRIPTION
# Pull request

## Change

- Add the PunchPlay watcher sink and register it in the sink factory
- Map CW start, pause and stop onto the full PunchPlay lifecycle, including resume and progress
- Add the PunchPlay playback progress adapter for list, dismiss, update and mark watched
- Show PunchPlay in the sink, playback and pair provider lists

## Why

Part of PunchPlay implementation

## Issue

Relates to #680
