### PR TITLE
Fix: Floppy sink watched threshold

### DIFF
--- a/providers/scrobble/floppy/sink.py
+++ b/providers/scrobble/floppy/sink.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+from pathlib import Path
 from typing import Any
 
 from cw_platform.event_archive import record_watch
+from cw_platform.local_db.ttl_dedupe import once_per_ttl
 from cw_platform.provider_instances import build_provider_config_view, normalize_instance_id
 from providers.auth._auth_FLOPPY import FloppyAuthError, FloppyClient, is_configured
+from providers.scrobble._auto_remove_watchlist import remove_across_providers_by_ids as _rm_across
 from providers.scrobble.scrobble import ScrobbleEvent, ScrobbleSink, mask_account
 from providers.sync.floppy._common import api_post
 from services.activity import record_scrobble_event
@@ -51,6 +54,26 @@ def _clamp(value: Any) -> float:
     except Exception:
         raw = 0.0
     return max(0.0, min(100.0, raw))
+
+
+DEFAULT_WATCHED_AT = 90.0
+_COMPLETE_TTL = 6 * 3600
+_AR_TTL = 60
+
+
+def _dedupe_base_path() -> Path:
+    return Path("/config") if Path("/config/config.json").exists() else Path(".")
+
+
+def _watched_at(cfg: Mapping[str, Any]) -> float:
+    try:
+        sc = cfg.get("scrobble") if isinstance(cfg, Mapping) else {}
+        value = ((sc or {}).get("floppy") or {}).get("watched_at")
+        if value is None:
+            value = ((sc or {}).get("trakt") or {}).get("watched_at", DEFAULT_WATCHED_AT)
+        return max(0.0, min(100.0, float(value)))
+    except Exception:
+        return DEFAULT_WATCHED_AT
 
 
 def _route_source(cfg: Mapping[str, Any]) -> tuple[str, str]:
@@ -97,14 +120,15 @@ def _position_ms(raw: Any, progress: float, duration_ms: int | None) -> int | No
     return max(0, min(value, duration_ms)) if duration_ms else max(0, value)
 
 
-def _completed(position_ms: int | None, duration_ms: int | None, progress: float) -> bool | None:
+def _completed(position_ms: int | None, duration_ms: int | None, progress: float, watched_at: float = DEFAULT_WATCHED_AT) -> bool | None:
     if position_ms is None:
         return None
+    threshold = max(0.0, min(100.0, float(watched_at)))
     if duration_ms and duration_ms > 0:
-        position = max(0, round(position_ms / 1000.0))
-        duration = max(1, round(duration_ms / 1000.0))
-        return position >= max(0, duration - 30)
-    return progress >= 95.0
+        position = max(0.0, position_ms / 1000.0)
+        duration = max(1.0, duration_ms / 1000.0)
+        return (position / duration) * 100.0 >= threshold
+    return progress >= threshold
 
 
 def _ids(ev: ScrobbleEvent) -> dict[str, str]:
@@ -123,7 +147,7 @@ def _ids(ev: ScrobbleEvent) -> dict[str, str]:
     return out
 
 
-def _payload(ev: ScrobbleEvent) -> dict[str, Any] | None:
+def _payload(ev: ScrobbleEvent, watched_at: float = DEFAULT_WATCHED_AT) -> dict[str, Any] | None:
     progress = _clamp(ev.progress)
     ids = _ids(ev)
     if not ids:
@@ -151,18 +175,62 @@ def _payload(ev: ScrobbleEvent) -> dict[str, Any] | None:
     if position is not None:
         body["position_seconds"] = max(0, round(position / 1000.0))
     if body["action"] == "stop":
-        complete = _completed(position, duration, progress)
+        complete = _completed(position, duration, progress, watched_at)
         if complete is not None:
             body["completed"] = complete
         body["played_at"] = utc_now_iso()
     return {k: v for k, v in body.items() if v not in (None, "", {}, [])}
 
 
+def _norm_media_type(value: str) -> str:
+    text = (value or "").strip().lower()
+    if text.endswith("s"):
+        text = text[:-1]
+    return "show" if text == "serie" or text == "series" else text
+
+
+def _auto_remove_enabled(cfg: Mapping[str, Any], media_type: str) -> bool:
+    scrobble = (cfg.get("scrobble") or {}) if isinstance(cfg, Mapping) else {}
+    watch = scrobble.get("watch") or {}
+    route_opts = watch.get("route_options") if isinstance(watch.get("route_options"), Mapping) else {}
+    mode = str((route_opts or {}).get("auto_remove_watchlist") or "inherit").strip().lower()
+    if mode == "off":
+        return False
+    if not scrobble.get("delete_plex") and mode != "on":
+        return False
+    types = scrobble.get("delete_plex_types") or []
+    mt = _norm_media_type(media_type)
+    if isinstance(types, str):
+        return _norm_media_type(types) == mt
+    try:
+        return mt in {_norm_media_type(str(x)) for x in types if str(x).strip()}
+    except Exception:
+        return False
+
+
+def _auto_remove_across(ev: ScrobbleEvent, cfg: Mapping[str, Any], scope: str = "") -> None:
+    media_type = "episode" if getattr(ev, "media_type", "") == "episode" else "movie"
+    if not _auto_remove_enabled(cfg, media_type):
+        return
+    ids = _ids(ev)
+    if not ids:
+        return
+    key = f"{scope}|{media_type}|" + ",".join(f"{k}={v}" for k, v in sorted(ids.items()))
+    try:
+        if not once_per_ttl(_dedupe_base_path(), "auto_remove_seen", key, ttl_seconds=_AR_TTL):
+            return
+    except Exception:
+        pass
+    try:
+        _rm_across(ids, media_type, scope=scope)
+    except Exception:
+        pass
+
+
 class FloppySink(ScrobbleSink):
     def __init__(self, cfg_provider: Callable[[], dict[str, Any]] | None = None, instance_id: str | None = None) -> None:
         self._cfg_provider = cfg_provider
         self._instance_id = normalize_instance_id(instance_id)
-        self._completed: set[str] = set()
 
     def _cfg(self, cfg: dict[str, Any] | None = None) -> dict[str, Any]:
         if isinstance(cfg, dict):
@@ -202,12 +270,15 @@ class FloppySink(ScrobbleSink):
         if not is_configured(view):
             _log(f"Floppy disabled for sink profile {self._instance_id}; skipping", "WARNING")
             return
-        body = _payload(ev)
+        body = _payload(ev, _watched_at(cfgd))
         if not body:
             _log("Floppy sink skipped event without enough identity", "DEBUG")
             return
         complete_key = self._key(ev)
-        if body.get("action") == "stop" and body.get("completed") is True and complete_key in self._completed:
+        is_complete_stop = body.get("action") == "stop" and body.get("completed") is True
+        if is_complete_stop and not once_per_ttl(
+            _dedupe_base_path(), "floppy_scrobble_completed", complete_key, ttl_seconds=_COMPLETE_TTL
+        ):
             return
         src, src_inst = _route_source(cfgd)
         try:
@@ -225,7 +296,7 @@ class FloppySink(ScrobbleSink):
         action = str(body.get("action") or ev.action)
         record_watch(ev, action=action, source_provider=src, source_instance=src_inst, destination_provider="floppy", destination_instance=self._instance_id, progress=progress)
         if action == "stop" and body.get("completed") is True:
-            self._completed.add(complete_key)
+            _auto_remove_across(ev, cfgd, scope=f"floppy:{self._instance_id}")
             try:
                 record_scrobble_event(ev, source=src, source_instance=src_inst, target="floppy", target_instance=self._instance_id, progress=progress)
             except Exception:

--- a/tests/test_floppy_watcher_sink.py
+++ b/tests/test_floppy_watcher_sink.py
@@ -12,6 +12,25 @@ from providers.scrobble.routes import build_route_cfg, normalize_route
 from providers.scrobble.scrobble import ScrobbleEvent
 from providers.webhooks.config import sink_configured, webhook_sinks
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_floppy_dedupe(monkeypatch):
+    """Floppy dedupe is persistent (SQLite); give every test a clean slate."""
+    seen: set[tuple[str, str]] = set()
+
+    def fake_once_per_ttl(base_path, namespace, key, *, ttl_seconds, max_entries=2000):
+        entry = (str(namespace), str(key))
+        if entry in seen:
+            return False
+        seen.add(entry)
+        return True
+
+    monkeypatch.setattr(floppy_sink, "once_per_ttl", fake_once_per_ttl)
+    return seen
+
+
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -206,8 +225,114 @@ def test_scrobbler_route_modal_lists_floppy_sink() -> None:
     text = (ROOT / "assets" / "js" / "modals" / "scrobbler-route" / "index.js").read_text("utf-8")
     meta = (ROOT / "assets" / "helpers" / "provider-meta.js").read_text("utf-8")
 
-    assert 'const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy"];' in text
+    assert '"floppy"' in text.split("const sinks")[1].split("]")[0]
     assert 'floppy: "Floppy"' in text
-    assert 'const ratingSinks = ["trakt", "simkl", "mdblist"];' in text
+    assert '"floppy"' in text.split("const ratingSinks")[1].split("]")[0]
     assert "FLOPPY:" in meta
     assert "scrobblerSink: true" in meta
+
+
+def test_scrobbler_webhook_modal_lists_floppy_sink() -> None:
+    text = (ROOT / "assets" / "js" / "modals" / "scrobbler-webhook" / "index.js").read_text("utf-8")
+
+    assert '"floppy"' in text.split("const sinks")[1].split("]")[0]
+    assert '"floppy"' in text.split("const ratingSinks")[1].split("]")[0]
+    assert 'floppy: "Floppy"' in text
+    assert 'floppy: "/assets/img/FLOPPY.png"' in text
+    assert "for (const sink of ratingSinks)" in text
+
+
+# --- sink parity fixes --------------------------------------------------------
+
+def test_completion_honours_the_configured_watched_threshold() -> None:
+    from providers.scrobble.floppy import sink as s
+
+    # 80% watched of a 1000s title
+    assert s._completed(800_000, 1_000_000, 80.0, 80.0) is True
+    assert s._completed(800_000, 1_000_000, 80.0, 95.0) is False
+    # no duration -> fall back to the reported percentage
+    assert s._completed(1, None, 85.0, 80.0) is True
+    assert s._completed(1, None, 85.0, 90.0) is False
+
+
+def test_watched_threshold_reads_provider_then_trakt_then_default() -> None:
+    from providers.scrobble.floppy import sink as s
+
+    assert s._watched_at({"scrobble": {"floppy": {"watched_at": 75}}}) == 75.0
+    assert s._watched_at({"scrobble": {"trakt": {"watched_at": 85}}}) == 85.0
+    assert s._watched_at({}) == s.DEFAULT_WATCHED_AT
+
+
+def test_payload_uses_the_configured_threshold() -> None:
+    from providers.scrobble.floppy import sink as s
+    from providers.scrobble.scrobble import ScrobbleEvent
+
+    ev = ScrobbleEvent(
+        action="stop", media_type="movie", ids={"tmdb": "550"}, title="Fight Club", year=1999,
+        season=None, number=None, progress=82.0, account="u", server_uuid="srv", session_key="k",
+        raw={}, position_ms=820_000, duration_ms=1_000_000,
+    )
+
+    lenient = s._payload(ev, 80.0)
+    strict = s._payload(ev, 95.0)
+    assert lenient is not None and strict is not None
+    assert lenient["completed"] is True
+    assert strict["completed"] is False
+
+
+def test_floppy_sink_has_parity_with_other_sinks() -> None:
+    text = (ROOT / "providers" / "scrobble" / "floppy" / "sink.py").read_text("utf-8")
+
+    for symbol in ("record_watch", "record_scrobble_event", "mask_account", "once_per_ttl", "_rm_across"):
+        assert symbol in text, f"floppy sink is missing {symbol}"
+    assert "self._completed" not in text, "completion dedupe must be persistent, not in-memory"
+
+
+def test_completed_stop_is_deduped_across_restarts(monkeypatch, _isolate_floppy_dedupe) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(floppy_sink, "api_post", lambda adapter, path, **kw: calls.append(kw) or {})
+    monkeypatch.setattr(floppy_sink, "record_watch", lambda *a, **k: None)
+    monkeypatch.setattr(floppy_sink, "record_scrobble_event", lambda *a, **k: None)
+    monkeypatch.setattr(floppy_sink, "_rm_across", lambda *a, **k: None)
+
+    event = _episode(progress=99.5)
+    FloppySink(cfg_provider=_cfg).send(event)
+    # a brand new sink instance stands in for a process restart
+    FloppySink(cfg_provider=_cfg).send(event)
+
+    assert len(calls) == 1, "persistent dedupe must survive a new sink instance"
+
+
+def _cfg_with_auto_remove() -> dict[str, Any]:
+    cfg = dict(_cfg())
+    scrobble = dict(cfg.get("scrobble") or {})
+    scrobble["delete_plex"] = True
+    scrobble["delete_plex_types"] = ["movie", "show", "episode"]
+    cfg["scrobble"] = scrobble
+    return cfg
+
+
+def test_completed_stop_auto_removes_when_enabled(monkeypatch, _isolate_floppy_dedupe) -> None:
+    removed: list[tuple[Any, ...]] = []
+    monkeypatch.setattr(floppy_sink, "api_post", lambda adapter, path, **kw: {})
+    monkeypatch.setattr(floppy_sink, "record_watch", lambda *a, **k: None)
+    monkeypatch.setattr(floppy_sink, "record_scrobble_event", lambda *a, **k: None)
+    monkeypatch.setattr(floppy_sink, "_rm_across", lambda ids, mt, scope="": removed.append((ids, mt, scope)))
+
+    FloppySink(cfg_provider=_cfg_with_auto_remove).send(_episode(progress=99.5))
+
+    assert removed, "a completed stop should auto-remove when the feature is enabled"
+    assert removed[0][1] == "episode"
+    assert removed[0][2].startswith("floppy:")
+
+
+def test_auto_remove_is_off_unless_configured(monkeypatch, _isolate_floppy_dedupe) -> None:
+    removed: list[Any] = []
+    monkeypatch.setattr(floppy_sink, "api_post", lambda adapter, path, **kw: {})
+    monkeypatch.setattr(floppy_sink, "record_watch", lambda *a, **k: None)
+    monkeypatch.setattr(floppy_sink, "record_scrobble_event", lambda *a, **k: None)
+    monkeypatch.setattr(floppy_sink, "_rm_across", lambda ids, mt, scope="": removed.append(ids))
+
+    FloppySink(cfg_provider=_cfg).send(_episode(progress=99.5))
+
+    assert removed == [], "auto-remove must never fire unless the user enabled it"


### PR DESCRIPTION
# Pull request

## Change

- Read the watched threshold from config instead of hardcoding it, same lookup order the other sinks use
- Mark watched on percentage watched rather than a raw position
- Gate auto remove from watchlists behind its config switch
- Swap the in memory completed set for the shared TTL dedupe so restarts do not replay
- Update the Floppy sink tests

## Why

Bringing Floppy in line with the other sinks, which alreadywork this way, so the same settings mean the same thing everywhere.
Dedupe living in a set on the instance meant a restart wiped it and the next stop event scrobbled again. 

## Issue

NA
