### PR TITLE
Fix: PunchPlay progress and watchlist sync

### DIFF
--- a/providers/sync/punchplay/_common.py
+++ b/providers/sync/punchplay/_common.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import secrets
 import threading
 import time
 from datetime import datetime, timezone
@@ -435,9 +436,9 @@ def client_item_id(*parts: Any) -> str:
     return f"cw:{digest}"[:200]
 
 
-def idempotency_key(resource: str, payload: Mapping[str, Any], *, attempt: int = 0) -> str:
+def idempotency_key(resource: str, payload: Mapping[str, Any], *, attempt: int = 0, operation_id: str = "") -> str:
     body = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-    seed = f"{resource}|{attempt}|{body}"
+    seed = f"{resource}|{operation_id}|{attempt}|{body}"
     return f"cw-{hashlib.sha256(seed.encode('utf-8')).hexdigest()}"
 
 
@@ -657,11 +658,12 @@ def bulk_write(
     for batch in chunk_items(items):
         payload = {"items": [dict(entry.get("payload") or {}) for entry in batch]}
         key_by_index = {i: str(entry.get("key") or "") for i, entry in enumerate(batch)}
+        operation_id = f"{time.time_ns()}-{secrets.token_hex(8)}"
 
         attempt = 0
         waits = 0
         while True:
-            headers = {"Idempotency-Key": idempotency_key(resource, payload, attempt=attempt)}
+            headers = {"Idempotency-Key": idempotency_key(resource, payload, attempt=attempt, operation_id=operation_id)}
             resp = punchplay_request(
                 adapter,
                 "POST",

--- a/providers/sync/punchplay/_progress.py
+++ b/providers/sync/punchplay/_progress.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 import time
+import secrets
 from typing import Any, Iterable, Mapping
 
 from cw_platform.id_map import canonical_key, minimal as id_minimal
 
 from ._common import (
+    URL_CONTINUE_WATCHING,
     URL_IN_PROGRESS,
     cfg_section,
     instance_id,
@@ -21,6 +23,7 @@ from ._common import (
     punchplay_request,
     request_id_of,
     safe_json,
+    snapshot_pages,
     _dbg,
     _info,
     _warn,
@@ -106,7 +109,58 @@ def _drop_reason(row: Mapping[str, Any]) -> str:
     return f"unhandled_type:{typ or 'empty'}"
 
 
-def _row_to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
+def _tmdb_metadata_provider(adapter: Any) -> Any | None:
+    cached = getattr(adapter, "_punchplay_progress_tmdb_metadata_provider", None)
+    if cached is not None:
+        return cached
+    cfg = getattr(adapter, "config", None) or getattr(adapter, "raw_cfg", None) or {}
+    if not isinstance(cfg, Mapping):
+        return None
+    tmdb_obj = cfg.get("tmdb")
+    tmdb: Mapping[str, Any] = tmdb_obj if isinstance(tmdb_obj, Mapping) else {}
+    metadata_obj = cfg.get("metadata")
+    metadata: Mapping[str, Any] = metadata_obj if isinstance(metadata_obj, Mapping) else {}
+    if not str(tmdb.get("api_key") or metadata.get("tmdb_api_key") or "").strip():
+        return None
+    try:
+        from providers.metadata._meta_TMDB import TmdbProvider
+
+        provider = TmdbProvider(lambda: dict(cfg), lambda _cfg: None)
+    except Exception:
+        return None
+    try:
+        setattr(adapter, "_punchplay_progress_tmdb_metadata_provider", provider)
+    except Exception:
+        pass
+    return provider
+
+
+def _metadata_show_detail(adapter: Any, show_ids: Mapping[str, Any]) -> dict[str, Any]:
+    provider = _tmdb_metadata_provider(adapter)
+    fetch_ids = {
+        key: str(show_ids.get(key) or "").strip()
+        for key in ("tmdb", "imdb", "tvdb")
+        if str(show_ids.get(key) or "").strip()
+    }
+    if provider is None or not fetch_ids:
+        return {}
+    try:
+        detail = provider.fetch(entity="tv", ids=fetch_ids, need={"poster": False, "backdrop": False, "ids": False})
+    except Exception:
+        return {}
+    if not isinstance(detail, Mapping):
+        return {}
+    out: dict[str, Any] = {}
+    title = str(detail.get("title") or "").strip()
+    if title:
+        out["title"] = title
+    year = _as_int(detail.get("year"))
+    if year is not None:
+        out["year"] = year
+    return out
+
+
+def _row_to_minimal(row: Mapping[str, Any], adapter: Any | None = None) -> dict[str, Any] | None:
     typ = str(row.get("type") or "").strip().lower()
 
     if typ == "episode":
@@ -128,6 +182,12 @@ def _row_to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
         show_title = str(row.get("showTitle") or "").strip()
         if show_title:
             out["series_title"] = show_title
+        elif adapter is not None:
+            detail = _metadata_show_detail(adapter, out["show_ids"])
+            if detail.get("title"):
+                out["series_title"] = detail["title"]
+            if detail.get("year") is not None:
+                out["series_year"] = detail["year"]
         ep_title = str(row.get("episodeTitle") or "").strip()
         if ep_title:
             out["title"] = ep_title
@@ -171,29 +231,22 @@ def _row_to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
 
 
 def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
-    resp = punchplay_request(adapter, "GET", URL_IN_PROGRESS)
-    if resp.status_code != 200:
-        _warn(FEATURE, "in_progress_fetch_failed", status=resp.status_code, error=error_of(resp), request_id=request_id_of(resp))
-        return {}
-
-    data = safe_json(resp)
-    rows: list[Mapping[str, Any]] = []
-    if isinstance(data, Mapping):
-        raw = data.get("items")
-        rows = [r for r in raw if isinstance(r, Mapping)] if isinstance(raw, list) else []
-    elif isinstance(data, list):
-        rows = [r for r in data if isinstance(r, Mapping)]
-
     collected: dict[str, dict[str, Any]] = {}
     dropped: list[str] = []
-    for row in rows:
-        minimal = _row_to_minimal(row)
+    rows_seen = 0
+
+    def collect(row: Mapping[str, Any], *, source: str) -> None:
+        nonlocal rows_seen
+        rows_seen += 1
+        minimal = _row_to_minimal(row, adapter)
         if not minimal:
-            dropped.append(_drop_reason(row))
+            reason = _drop_reason(row)
+            dropped.append(reason)
             _warn(
                 FEATURE,
                 "index_row_dropped",
-                reason=_drop_reason(row),
+                source=source,
+                reason=reason,
                 row_type=str(row.get("type") or ""),
                 entry_id=row.get("id"),
                 tmdb_id=row.get("tmdbId"),
@@ -202,19 +255,57 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
                 episode=row.get("episode"),
                 title=str(row.get("showTitle") or row.get("title") or "")[:80],
             )
-            continue
+            return
         key = _key_of(minimal)
         if not key:
             dropped.append("no_canonical_key")
-            _warn(FEATURE, "index_row_dropped", reason="no_canonical_key", entry_id=row.get("id"))
-            continue
+            _warn(FEATURE, "index_row_dropped", source=source, reason="no_canonical_key", entry_id=row.get("id"))
+            return
         collected[key] = minimal
+
+    continue_rows = 0
+    resp = punchplay_request(adapter, "GET", URL_CONTINUE_WATCHING)
+    if resp.status_code != 200:
+        _warn(FEATURE, "continue_watching_fetch_failed", status=resp.status_code, error=error_of(resp), request_id=request_id_of(resp))
+    else:
+        data = safe_json(resp)
+        rows: list[Mapping[str, Any]] = []
+        if isinstance(data, Mapping):
+            raw = data.get("items")
+            rows = [r for r in raw if isinstance(r, Mapping)] if isinstance(raw, list) else []
+        elif isinstance(data, list):
+            rows = [r for r in data if isinstance(r, Mapping)]
+        for row in rows:
+            continue_rows += 1
+            collect(row, source="continue_watching")
+
+    resp = punchplay_request(adapter, "GET", URL_IN_PROGRESS)
+    if resp.status_code != 200:
+        _warn(FEATURE, "in_progress_fetch_failed", status=resp.status_code, error=error_of(resp), request_id=request_id_of(resp))
+    else:
+        data = safe_json(resp)
+        rows: list[Mapping[str, Any]] = []
+        if isinstance(data, Mapping):
+            raw = data.get("items")
+            rows = [r for r in raw if isinstance(r, Mapping)] if isinstance(raw, list) else []
+        elif isinstance(data, list):
+            rows = [r for r in data if isinstance(r, Mapping)]
+        for row in rows:
+            collect(row, source="in_progress")
+
+    snapshot_rows = 0
+    for page in snapshot_pages(adapter, "playback", feature=FEATURE):
+        for row in page:
+            snapshot_rows += 1
+            collect(row, source="snapshot")
 
     _info(
         FEATURE,
         "index_done",
         count=len(collected),
-        rows=len(rows),
+        rows=rows_seen,
+        continue_rows=continue_rows,
+        snapshot_rows=snapshot_rows,
         dropped=len(dropped),
         drop_reasons=",".join(sorted(set(dropped))) or None,
     )
@@ -223,10 +314,11 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
 
 def _session_ids(item: Mapping[str, Any], key: str, *, device_id: str, instance: str, position: float | None) -> dict[str, Any]:
     scope = f"cw-{instance}-{key}"
+    created = int(time.time() * 1000)
     out: dict[str, Any] = {
         "playback_session_id": scope,
-        "event_id": f"{scope}@{int(position or 0)}",
-        "event_created_at": int(time.time() * 1000),
+        "event_id": f"{scope}@{int(position or 0)}:{created}:{secrets.token_hex(4)}",
+        "event_created_at": created,
     }
     if device_id:
         out["device_id"] = device_id
@@ -293,6 +385,13 @@ def _send(adapter: Any, action: str, payload: Mapping[str, Any]) -> Any:
     return punchplay_request(adapter, "POST", URL_PLAYBACK.format(action=action), json=dict(payload))
 
 
+def _write_action(item: Mapping[str, Any]) -> str:
+    state = str(item.get("playback_state") or "").strip().lower()
+    if item.get("now_playing") is True or state in {"watching", "playing"}:
+        return "progress"
+    return "stop"
+
+
 def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
     confirmed: list[str] = []
     unresolved_keys: list[str] = []
@@ -324,9 +423,22 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
             _dbg(FEATURE, "item_unresolved_before_write", key=key)
             continue
 
-        resp = _send(adapter, "progress", payload)
+        action = _write_action(item)
+        if action == "stop":
+            payload.setdefault("watched", False)
+            payload.setdefault("watched_threshold", 1.0)
+        resp = _send(adapter, action, payload)
         if 200 <= resp.status_code < 300:
-            confirmed.append(key)
+            body = safe_json(resp) or {}
+            ignored = str(body.get("ignored") or "").strip() if isinstance(body, Mapping) else ""
+            ok_body = bool(body.get("ok", True)) if isinstance(body, Mapping) else True
+            if ignored or not ok_body:
+                ok = False
+                unresolved_keys.append(key)
+                unresolved.append({"key": key, "status": "ignored" if ignored else "not_ok", "error": ignored or error_of(resp)})
+                _warn(FEATURE, "progress_write_ignored", key=key, ignored=ignored or None, request_id=request_id_of(resp))
+            else:
+                confirmed.append(key)
         else:
             ok = False
             unresolved_keys.append(key)

--- a/providers/sync/punchplay/_watchlist.py
+++ b/providers/sync/punchplay/_watchlist.py
@@ -22,6 +22,7 @@ from ._common import (
     punchplay_request,
     request_id_of,
     safe_json,
+    snapshot_pages,
     _dbg,
     _info,
     _warn,
@@ -37,6 +38,21 @@ def _key_of(obj: Mapping[str, Any]) -> str:
         return ""
 
 
+def _pick(row: Mapping[str, Any], *names: str) -> Any:
+    for name in names:
+        if name in row and row.get(name) is not None:
+            return row.get(name)
+    return None
+
+
+def _nested(row: Mapping[str, Any], *names: str) -> Mapping[str, Any]:
+    for name in names:
+        value = row.get(name)
+        if isinstance(value, Mapping):
+            return value
+    return {}
+
+
 def _kind_of(item: Mapping[str, Any]) -> str:
     raw = str(item.get("type") or item.get("kind") or "").strip().lower()
     if raw in ("movie", "movies", "film"):
@@ -45,7 +61,8 @@ def _kind_of(item: Mapping[str, Any]) -> str:
 
 
 def _row_type(row: Mapping[str, Any]) -> str:
-    raw = str(row.get("type") or "").strip().lower()
+    title = _nested(row, "title", "item")
+    raw = str(_pick(row, "type", "kind", "mediaType", "media_type") or _pick(title, "type", "kind", "mediaType", "media_type") or "").strip().lower()
     if raw in ("movie", "movies", "film"):
         return "movie"
     if raw in ("show", "tv", "series", "anime"):
@@ -55,7 +72,8 @@ def _row_type(row: Mapping[str, Any]) -> str:
 
 def _to_minimal(row: Mapping[str, Any]) -> dict[str, Any]:
     ids: dict[str, Any] = {}
-    tmdb = row.get("tmdbId")
+    title = _nested(row, "title", "item")
+    tmdb = _pick(row, "tmdbId", "tmdb_id", "resolved_tmdb_id", "titleTmdbId", "title_tmdb_id") or _pick(title, "tmdbId", "tmdb_id")
     try:
         tmdb_i = int(tmdb) if tmdb is not None else None
     except Exception:
@@ -64,13 +82,43 @@ def _to_minimal(row: Mapping[str, Any]) -> dict[str, Any]:
         ids["tmdb"] = str(tmdb_i)
 
     out: dict[str, Any] = {"type": _row_type(row), "ids": ids}
-    title = str(row.get("title") or "").strip()
-    if title:
-        out["title"] = title
-    release = str(row.get("releaseDate") or "").strip()
+    title_text = _pick(row, "title", "name")
+    if isinstance(title_text, Mapping):
+        title_text = _pick(title_text, "title", "name")
+    if not title_text:
+        title_text = _pick(title, "title", "name")
+    title_s = str(title_text or "").strip()
+    if title_s:
+        out["title"] = title_s
+    year = _pick(row, "year") or _pick(title, "year")
+    try:
+        if year is not None:
+            out["year"] = int(year)
+            return out
+    except Exception:
+        pass
+    release = str(_pick(row, "releaseDate", "release_date") or _pick(title, "releaseDate", "release_date") or "").strip()
     if len(release) >= 4 and release[:4].isdigit():
         out["year"] = int(release[:4])
     return out
+
+
+def _row_data(row: Mapping[str, Any]) -> Mapping[str, Any]:
+    data = row.get("data")
+    return data if isinstance(data, Mapping) else row
+
+
+def _row_list_id(row: Mapping[str, Any]) -> str:
+    data = _row_data(row)
+    list_obj = _nested(data, "list")
+    value = _pick(data, "listId", "list_id", "listID") or _pick(list_obj, "id")
+    return str(value).strip() if value is not None else ""
+
+
+def _row_is_watchlist(row: Mapping[str, Any]) -> bool:
+    data = _row_data(row)
+    list_obj = _nested(data, "list")
+    return bool(_pick(data, "isWatchlist", "is_watchlist") or _pick(list_obj, "isWatchlist", "is_watchlist"))
 
 
 def watchlist_ids(adapter: Any) -> list[dict[str, Any]]:
@@ -165,6 +213,35 @@ def _index_dynamic_items(adapter: Any, list_id: Any, collected: dict[str, dict[s
         offset = nxt_i
 
 
+def _index_snapshot_items(adapter: Any, lists: Iterable[Mapping[str, Any]], collected: dict[str, dict[str, Any]]) -> None:
+    list_ids = {str(entry.get("id")).strip() for entry in lists if entry.get("id") is not None}
+    if not list_ids:
+        return
+
+    seen_rows = 0
+    matched_rows = 0
+    for page in snapshot_pages(adapter, "list_item", feature=FEATURE):
+        for row in page:
+            seen_rows += 1
+            data = _row_data(row)
+            if not isinstance(data, Mapping):
+                continue
+            list_id = _row_list_id(row)
+            if list_id:
+                if list_id not in list_ids:
+                    continue
+            elif not _row_is_watchlist(row):
+                continue
+            matched_rows += 1
+            minimal = _to_minimal(data)
+            if not minimal.get("ids"):
+                continue
+            key = _key_of(minimal)
+            if key:
+                collected[key] = minimal
+    _dbg(FEATURE, "snapshot_scanned", rows=seen_rows, matched=matched_rows, indexed=len(collected))
+
+
 def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
     section = cfg_section(adapter)
     if not section:
@@ -184,6 +261,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
             _index_dynamic_items(adapter, list_id, collected)
         else:
             _index_list_detail(adapter, list_id, collected)
+    _index_snapshot_items(adapter, lists, collected)
 
     _info(FEATURE, "index_done", count=len(collected), lists=len(lists))
     return collected

--- a/services/playback_progress/adapters/punchplay.py
+++ b/services/playback_progress/adapters/punchplay.py
@@ -18,7 +18,7 @@ from providers.sync.punchplay._common import (
     punchplay_request,
 )
 
-from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, utc_now_iso
+from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
 from .base import PlaybackProgressAdapter, enrich_parallel, tmdb_metadata_provider
 
 PROGRESS_ID_FIELD = feat_progress.PROGRESS_ID_FIELD
@@ -44,6 +44,48 @@ def _float(value: Any) -> float | None:
         return float(str(value).strip())
     except Exception:
         return None
+
+
+def _image_url(meta: Mapping[str, Any], kind: str) -> str:
+    images = _mapping(meta.get("images"))
+    rows = images.get(kind)
+    if not isinstance(rows, list):
+        return ""
+    for row in rows:
+        if isinstance(row, Mapping) and str(row.get("url") or "").strip():
+            return str(row.get("url") or "").strip()
+    return ""
+
+
+def _metadata_detail(provider: Any, *, media_type: str, ids: Mapping[str, Any], show_ids: Mapping[str, Any]) -> dict[str, Any]:
+    lookup_ids = show_ids if media_type == "episode" and show_ids else ids
+    fetch_ids = {key: str(lookup_ids.get(key) or "").strip() for key in ("tmdb", "imdb", "tvdb") if str(lookup_ids.get(key) or "").strip()}
+    if provider is None or not fetch_ids:
+        return {}
+    try:
+        detail = provider.fetch(entity="tv" if media_type == "episode" else "movie", ids=fetch_ids, need={"poster": True, "backdrop": True, "ids": False})
+    except Exception:
+        return {}
+    if not isinstance(detail, Mapping):
+        return {}
+    out: dict[str, Any] = {}
+    title = str(detail.get("title") or "").strip()
+    if title:
+        out["title"] = title
+    year = _num(detail.get("year"))
+    if year is not None:
+        out["year"] = year
+    poster = _image_url(detail, "poster")
+    if poster:
+        out["poster_url"] = poster
+    backdrop = _image_url(detail, "backdrop")
+    if backdrop:
+        out["backdrop_url"] = backdrop
+    return out
+
+
+def _is_placeholder_title(value: Any) -> bool:
+    return str(value or "").strip().lower() in {"", "untitled"}
 
 
 class _Adapter:
@@ -115,14 +157,35 @@ class PunchPlayPlaybackAdapter(PlaybackProgressAdapter):
             )
         metadata = tmdb_metadata_provider(config_view)
         pending = [(key, item) for key, item in dict(index).items() if isinstance(item, Mapping)]
-        items = enrich_parallel(pending, lambda entry: self._record(entry[0], entry[1], instance_id, instance_label, metadata))
+        items = enrich_parallel(pending, lambda entry: self._record(entry[0], entry[1], instance_id, instance_label, caps, metadata))
         return PlaybackListResult(True, self.provider, instance_id, items=[i for i in items if i], refreshed_at=utc_now_iso())
 
-    def _record(self, key: Any, item: Mapping[str, Any], instance_id: str, instance_label: str, metadata: Any = None) -> PlaybackRecord | None:
+    def _record(self, key: Any, item: Mapping[str, Any], instance_id: str, instance_label: str, caps: PlaybackCapabilities, metadata: Any = None) -> PlaybackRecord | None:
         mini = id_minimal(item)
-        ids = dict(mini.get("ids") or {})
+        ids = clean_mapping(_mapping(mini.get("ids") or item.get("ids")))
+        show_ids = clean_mapping(_mapping(mini.get("show_ids") or item.get("show_ids")))
         media_type = "episode" if str(item.get("type") or "").lower() == "episode" else "movie"
         remote_id = str(item.get(PROGRESS_ID_FIELD) or "").strip()
+        title = str(mini.get("title") or item.get("title") or item.get("series_title") or "").strip()
+        series_title = str(mini.get("series_title") or item.get("series_title") or "").strip()
+        if _is_placeholder_title(title):
+            title = ""
+        if media_type == "episode" and _is_placeholder_title(series_title):
+            series_title = ""
+        needs_metadata = (
+            not title
+            or (media_type == "episode" and not series_title)
+            or not str(item.get("poster") or item.get("poster_url") or "").strip()
+            or not str(item.get("background") or item.get("backdrop") or item.get("backdrop_url") or "").strip()
+        )
+        resolved = _metadata_detail(metadata, media_type=media_type, ids=ids, show_ids=show_ids) if needs_metadata else {}
+        resolved_title = str(resolved.get("title") or "").strip()
+        if resolved_title and (not title or (media_type == "episode" and not series_title)):
+            if media_type == "episode" and not series_title:
+                series_title = resolved_title
+            if not title:
+                title = resolved_title
+        year = _num(mini.get("year") or item.get("year") or resolved.get("year"))
 
         duration_ms = _float(item.get("duration_ms"))
         progress_ms = _float(item.get("progress_ms"))
@@ -142,12 +205,12 @@ class PunchPlayPlaybackAdapter(PlaybackProgressAdapter):
             remote_id=remote_id,
             canonical_key=str(key or canonical_key(mini) or ""),
             media_type=media_type,
-            title=str(item.get("title") or ""),
-            episode_title=str(item.get("title") or "") if media_type == "episode" else "",
-            series_title=str(item.get("series_title") or ""),
+            title=series_title or title,
+            episode_title=title if media_type == "episode" and title != series_title else "",
+            series_title=series_title,
             season=_num(item.get("season")),
             episode=_num(item.get("episode")),
-            year=_num(item.get("year")),
+            year=year,
             ids=ids,
             progress_percent=round(percent, 3) if percent is not None else None,
             remaining_seconds=remaining,
@@ -155,6 +218,13 @@ class PunchPlayPlaybackAdapter(PlaybackProgressAdapter):
             progress_at=item.get("progress_at") or item.get("updated_at"),
             updated_at=item.get("updated_at"),
             source_app=str(item.get("playback_state") or ""),
+            can_remove_progress=caps.remove_progress,
+            can_mark_watched=caps.mark_watched,
+            can_update_progress=bool(caps.update_progress and duration_ms),
+            capability_messages=[] if caps.configured else [caps.reason],
+            poster_url=str(item.get("poster") or item.get("poster_url") or resolved.get("poster_url") or "").strip(),
+            backdrop_url=str(item.get("background") or item.get("backdrop") or item.get("backdrop_url") or resolved.get("backdrop_url") or "").strip(),
+            provider_metadata={"progress_item": clean_mapping(item), "show_ids": show_ids},
         )
 
     def _rate_limited(self, exc: PunchPlayRateLimited, operation: str, instance_id: str, record: Mapping[str, Any]) -> PlaybackActionResult:
@@ -257,8 +327,10 @@ class PunchPlayPlaybackAdapter(PlaybackProgressAdapter):
                 position=payload.get("position_seconds"),
             )
         )
+        payload["watched"] = False
+        payload["watched_threshold"] = 1.0
         try:
-            resp = self._send_playback(config_view, instance_id, "progress", payload)
+            resp = self._send_playback(config_view, instance_id, "stop", payload)
         except PunchPlayRateLimited as exc:
             return self._rate_limited(exc, "update_progress", instance_id, record)
         except Exception:

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -36,7 +36,7 @@ CACHE_TTL_SECONDS = 60.0
 MAX_WORKERS = 6
 DEFAULT_PROVIDER_TIMEOUT_SECONDS = 20.0
 GROUP_PROGRESS_TOLERANCE = 2.0
-PHASE1_PROVIDERS = ("crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy")
+PHASE1_PROVIDERS = ("crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "punchplay", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy")
 SORT_VALUES = {"last_updated", "progress_high", "progress_low", "remaining_time", "rating_high", "title", "provider"}
 LIVE_MEDIA_PROVIDERS = {"plex", "emby", "jellyfin", "kodi"}
 LIVE_ACTIVE_STATES = {"playing", "paused", "buffering"}
@@ -751,6 +751,7 @@ def _profile_has_explicit_identity(cfg: Mapping[str, Any], provider: str, instan
         "kodi": ("server", "server_url", "connection_verified", "username"),
         "stremio": ("auth_key", "authKey"),
         "floppy": ("server_url", "api_token"),
+        "punchplay": ("access_token", "refresh_token", "user_id", "username"),
     }.get(str(provider or "").strip().lower(), ())
     return any(str(_path_value(raw, path) or "").strip() for path in identity_paths)
 

--- a/tests/test_punchplay_playback.py
+++ b/tests/test_punchplay_playback.py
@@ -64,6 +64,21 @@ def test_adapter_is_registered_in_the_service() -> None:
     assert isinstance(found, PunchPlayPlaybackAdapter)
 
 
+def test_provider_instances_include_punchplay_profiles() -> None:
+    from services.playback_progress.service import PlaybackProgressService
+
+    cfg = {
+        "punchplay": {
+            "access_token": "default-token",
+            "instances": {"PUNCHPLAY-P01": {"access_token": "profile-token"}},
+        }
+    }
+
+    specs = [spec for spec in PlaybackProgressService().provider_instances(cfg) if spec["provider"] == "punchplay"]
+
+    assert [spec["instance_id"] for spec in specs] == ["default", "PUNCHPLAY-P01"]
+
+
 def test_capabilities_reflect_connection_state() -> None:
     from services.playback_progress.adapters.punchplay import PunchPlayPlaybackAdapter
 
@@ -97,19 +112,21 @@ def test_remove_without_remote_id_fails_cleanly(adapter) -> None:
     assert calls == []
 
 
-def test_update_progress_posts_progress_action(adapter) -> None:
+def test_update_progress_posts_incomplete_stop(adapter) -> None:
     a, calls = adapter
 
     res = a.update_progress(CFG, RECORD, 50.0, instance_id="default", instance_label="Default")
 
     assert res.ok is True
     p = calls[0]["json"]
-    assert calls[0]["url"].endswith("/playback/progress")
+    assert calls[0]["url"].endswith("/playback/stop")
     assert p["media_type"] == "episode"
     assert p["tmdb_id"] == 69478
     assert p["season"] == 6 and p["episode"] == 2
     assert abs(p["progress"] - 0.5) < 0.01
     assert p["playback_session_id"] and p["event_id"]
+    assert p["watched"] is False
+    assert p["watched_threshold"] == 1.0
 
 
 def test_mark_watched_posts_stop_with_watched_flag(adapter) -> None:
@@ -208,6 +225,49 @@ def test_list_progress_builds_records_from_the_index(monkeypatch: pytest.MonkeyP
     assert rec.season == 6 and rec.episode == 2
     assert rec.progress_percent is not None and abs(rec.progress_percent - 22.764) < 0.01
     assert rec.duration_seconds == 3307
+
+
+def test_list_progress_enriches_missing_episode_title_from_tmdb(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync import _mod_PUNCHPLAY as mod
+    from services.playback_progress.adapters import punchplay as punchplay_adapter
+    from services.playback_progress.adapters.punchplay import PunchPlayPlaybackAdapter
+
+    class _Tmdb:
+        def fetch(self, *, entity: str, ids: dict[str, str], need: dict[str, bool]) -> dict[str, Any]:
+            assert entity == "tv"
+            assert ids == {"tmdb": "69478"}
+            return {
+                "title": "The Handmaid's Tale",
+                "year": 2017,
+                "images": {
+                    "poster": [{"url": "https://img.example/poster.jpg"}],
+                    "backdrop": [{"url": "https://img.example/backdrop.jpg"}],
+                },
+            }
+
+    index = {
+        "tmdb:69478#s06e02": {
+            "type": "episode",
+            "show_ids": {"tmdb": "69478"},
+            "ids": {"tmdb": "5978363"},
+            "season": 6,
+            "episode": 2,
+            "progress_ms": 753000,
+            "duration_ms": 3307930,
+            "progress_percent": 22.764,
+            "_punchplay_progress_id": "7",
+        }
+    }
+    monkeypatch.setattr(mod.OPS, "build_index", lambda cfg, *, feature: dict(index))
+    monkeypatch.setattr(punchplay_adapter, "tmdb_metadata_provider", lambda cfg: _Tmdb())
+
+    res = PunchPlayPlaybackAdapter().list_progress(CFG, instance_id="default", instance_label="Default")
+
+    rec = res.items[0]
+    assert rec.title == "The Handmaid's Tale"
+    assert rec.series_title == "The Handmaid's Tale"
+    assert rec.poster_url == "https://img.example/poster.jpg"
+    assert rec.backdrop_url == "https://img.example/backdrop.jpg"
 
 
 def test_playback_ui_list_includes_punchplay() -> None:

--- a/tests/test_punchplay_sync.py
+++ b/tests/test_punchplay_sync.py
@@ -211,6 +211,22 @@ def test_indeterminate_retries_with_a_new_key(monkeypatch: pytest.MonkeyPatch) -
     assert http.calls[0]["headers"]["Idempotency-Key"] != http.calls[1]["headers"]["Idempotency-Key"]
 
 
+def test_separate_bulk_writes_use_new_idempotency_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _watchlist as wl
+
+    item = {"type": "movie", "title": "A", "ids": {"tmdb": "550"}}
+
+    first = FakeHTTP([_Resp(200, {"results": [{"index": 0, "status": "inserted", "resolved_tmdb_id": 550}]})])
+    _patch(monkeypatch, wl, first)
+    wl.add(Adapter(), [dict(item)])
+
+    second = FakeHTTP([_Resp(200, {"results": [{"index": 0, "status": "inserted", "resolved_tmdb_id": 550}]})])
+    _patch(monkeypatch, wl, second)
+    wl.add(Adapter(), [dict(item)])
+
+    assert first.calls[0]["headers"]["Idempotency-Key"] != second.calls[0]["headers"]["Idempotency-Key"]
+
+
 # --- watchlist ----------------------------------------------------------------
 
 def test_watchlist_remove_sets_remove_flag(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -249,6 +265,7 @@ def test_watchlist_index_parses_tmdb_rows(monkeypatch: pytest.MonkeyPatch) -> No
              "posterPath": None, "addedAt": "2026-01-01T00:00:00.000Z", "runtime": 139,
              "popularity": 1.0, "releaseDate": "1999-10-15T00:00:00.000Z", "watched": False},
         ]}),
+        _Resp(200, {"items": [], "hasMore": False, "nextAfter": None}),
     ])
     _patch(monkeypatch, wl, http)
 
@@ -257,6 +274,7 @@ def test_watchlist_index_parses_tmdb_rows(monkeypatch: pytest.MonkeyPatch) -> No
     assert idx == {"tmdb:550": {"type": "movie", "ids": {"tmdb": "550"}, "title": "Fight Club", "year": 1999}}
     assert http.calls[1]["url"].endswith("/lists/2")
     assert not http.calls[1]["url"].endswith("/lists/2/items")
+    assert http.calls[2]["params"]["resource"] == "list_item"
 
 
 def test_watchlist_index_uses_dynamic_items_endpoint_only_for_dynamic_lists(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -267,6 +285,7 @@ def test_watchlist_index_uses_dynamic_items_endpoint_only_for_dynamic_lists(monk
         _Resp(200, {"items": [
             {"id": 1, "tmdbId": 551, "type": "movie", "title": "Dynamic Movie", "releaseDate": "2000-01-01T00:00:00.000Z"},
         ], "nextOffset": None, "total": 1}),
+        _Resp(200, {"items": [], "hasMore": False, "nextAfter": None}),
     ])
     _patch(monkeypatch, wl, http)
 
@@ -274,6 +293,27 @@ def test_watchlist_index_uses_dynamic_items_endpoint_only_for_dynamic_lists(monk
 
     assert idx == {"tmdb:551": {"type": "movie", "ids": {"tmdb": "551"}, "title": "Dynamic Movie", "year": 2000}}
     assert http.calls[1]["url"].endswith("/lists/7/items")
+
+
+def test_watchlist_index_merges_sync_snapshot_list_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _watchlist as wl
+
+    http = FakeHTTP([
+        _Resp(200, {"items": [{"id": 2, "isWatchlist": True, "externalSource": None}], "nextCursor": None}),
+        _Resp(200, {"id": 2, "isWatchlist": True, "items": []}),
+        _Resp(200, {"items": [
+            {"listId": 2, "tmdb_id": 550, "kind": "movie", "title": "Fight Club", "year": 1999},
+            {"listId": 9, "tmdb_id": 551, "kind": "movie", "title": "Other List", "year": 2000},
+        ], "hasMore": False, "nextAfter": None}),
+    ])
+    _patch(monkeypatch, wl, http)
+
+    idx = wl.build_index(Adapter())
+
+    assert idx == {"tmdb:550": {"type": "movie", "ids": {"tmdb": "550"}, "title": "Fight Club", "year": 1999}}
+    assert http.calls[2]["method"] == "GET"
+    assert http.calls[2]["url"].endswith("/me/sync/snapshot")
+    assert http.calls[2]["params"]["resource"] == "list_item"
 
 
 # --- ratings ------------------------------------------------------------------
@@ -466,21 +506,69 @@ def test_history_episode_remove_without_entry_id_is_unresolved(monkeypatch: pyte
 def test_progress_index_uses_in_progress_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
     from providers.sync.punchplay import _progress as pr
 
-    http = FakeHTTP([_Resp(200, [
-        {"id": 4, "type": "movie", "tmdbId": 550, "title": "Fight Club", "year": 1999,
-         "progressSeconds": 1800, "durationSeconds": 8340, "progressPercent": 21.58,
-         "updatedAt": "2026-01-01T20:00:00.000Z", "nowPlaying": False},
-    ])])
+    http = FakeHTTP([
+        _Resp(200, {"items": []}),
+        _Resp(200, [
+            {"id": 4, "type": "movie", "tmdbId": 550, "title": "Fight Club", "year": 1999,
+             "progressSeconds": 1800, "durationSeconds": 8340, "progressPercent": 21.58,
+             "updatedAt": "2026-01-01T20:00:00.000Z", "nowPlaying": False},
+        ]),
+        _Resp(200, {"items": [], "hasMore": False, "nextAfter": None}),
+    ])
     _patch(monkeypatch, pr, http)
 
     idx = pr.build_index(Adapter())
 
     assert idx["tmdb:550"]["_punchplay_progress_id"] == "4"
+    assert http.calls[1]["method"] == "GET"
+    assert http.calls[1]["url"].endswith("/playback/in-progress")
+
+
+def test_progress_index_reads_continue_watching_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _progress as pr
+
+    http = FakeHTTP([
+        _Resp(200, {"items": [
+            {"id": 9, "type": "episode", "tmdbId": 5978363, "showTmdbId": 69478,
+             "showTitle": "The Handmaid's Tale", "episodeTitle": "Exile", "season": 6, "episode": 2,
+             "progressSeconds": 753.0, "durationSeconds": 3307.93, "progressPercent": 22.764,
+             "updatedAt": "2026-07-31T19:43:27.000Z"},
+        ]}),
+        _Resp(200, {"items": []}),
+        _Resp(200, {"items": [], "hasMore": False, "nextAfter": None}),
+    ])
+    _patch(monkeypatch, pr, http)
+
+    idx = pr.build_index(Adapter())
+
+    assert idx["tmdb:69478#s06e02"]["progress_ms"] == 753000
     assert http.calls[0]["method"] == "GET"
-    assert http.calls[0]["url"].endswith("/playback/in-progress")
+    assert http.calls[0]["url"].endswith("/me/continue-watching")
 
 
-def test_progress_write_uses_playback_progress_action(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_progress_index_merges_sync_snapshot_playback(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _progress as pr
+
+    http = FakeHTTP([
+        _Resp(200, {"items": []}),
+        _Resp(200, {"items": []}),
+        _Resp(200, {"items": [
+            {"id": 7, "type": "episode", "tmdbId": 5978363, "showTmdbId": 69478,
+             "showTitle": "The Handmaid's Tale", "episodeTitle": "Exile", "season": 6, "episode": 2,
+             "progressSeconds": 753.0, "durationSeconds": 3307.93, "progressPercent": 22.764,
+             "updatedAt": "2026-07-31T19:43:27.000Z"},
+        ], "hasMore": False, "nextAfter": None}),
+    ])
+    _patch(monkeypatch, pr, http)
+
+    idx = pr.build_index(Adapter())
+
+    assert idx["tmdb:69478#s06e02"]["progress_ms"] == 753000
+    assert http.calls[2]["url"].endswith("/me/sync/snapshot")
+    assert http.calls[2]["params"]["resource"] == "playback"
+
+
+def test_progress_write_uses_incomplete_stop_for_passive_sync(monkeypatch: pytest.MonkeyPatch) -> None:
     from providers.sync.punchplay import _progress as pr
 
     http = FakeHTTP([_Resp(200, {})])
@@ -492,10 +580,39 @@ def test_progress_write_uses_playback_progress_action(monkeypatch: pytest.Monkey
     }])
 
     call = http.calls[0]
-    assert call["url"].endswith("/playback/progress")
+    assert call["url"].endswith("/playback/stop")
     assert call["json"]["media_type"] == "movie"
     assert round(call["json"]["progress"], 4) == 0.2158
+    assert call["json"]["watched"] is False
+    assert call["json"]["watched_threshold"] == 1.0
     assert res["confirmed_keys"] == ["tmdb:550"]
+
+
+def test_progress_write_uses_progress_action_for_now_playing(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _progress as pr
+
+    http = FakeHTTP([_Resp(200, {})])
+    _patch(monkeypatch, pr, http)
+
+    pr.add(Adapter(), [{
+        "type": "movie", "title": "Fight Club", "year": 1999, "ids": {"tmdb": "550"},
+        "progress_ms": 1800000, "duration_ms": 8340000, "now_playing": True,
+    }])
+
+    assert http.calls[0]["url"].endswith("/playback/progress")
+
+
+def test_progress_write_does_not_confirm_ignored_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _progress as pr
+
+    http = FakeHTTP([_Resp(200, {"ok": True, "ignored": "old_event"})])
+    _patch(monkeypatch, pr, http)
+
+    res = pr.add(Adapter(), [{"type": "movie", "ids": {"tmdb": "550"}, "position_seconds": 1800, "duration_seconds": 8340}])
+
+    assert res["ok"] is False
+    assert res["confirmed_keys"] == []
+    assert res["unresolved_keys"] == ["tmdb:550"]
 
 
 def test_progress_write_reads_canonical_ms_fields() -> None:
@@ -542,6 +659,32 @@ def test_progress_round_trip_is_lossless_for_two_way() -> None:
     assert (len(adds), len(removes)) == (0, 0)
 
 
+def test_progress_index_enriches_missing_episode_series_title(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _progress as pr
+
+    monkeypatch.setattr(
+        pr,
+        "_metadata_show_detail",
+        lambda adapter, show_ids: {"title": "House of the Dragon", "year": 2022},
+    )
+
+    item = pr._row_to_minimal({
+        "id": 7,
+        "type": "episode",
+        "tmdbId": 5978363,
+        "showTmdbId": 94997,
+        "season": 2,
+        "episode": 7,
+        "progressSeconds": 1770.0,
+        "durationSeconds": 3821.0,
+    }, Adapter())
+
+    assert item is not None
+    assert item["series_title"] == "House of the Dragon"
+    assert item["series_year"] == 2022
+    assert item["show_ids"] == {"tmdb": "94997"}
+
+
 def test_progress_sends_distinct_session_ids_per_title(monkeypatch: pytest.MonkeyPatch) -> None:
     from providers.sync.punchplay import _progress as pr
 
@@ -568,7 +711,7 @@ def test_progress_sends_distinct_session_ids_per_title(monkeypatch: pytest.Monke
     assert isinstance(a["event_created_at"], int)
 
 
-def test_progress_session_id_is_stable_across_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_progress_session_id_is_stable_but_event_id_is_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
     from providers.sync.punchplay import _progress as pr
 
     item = {"type": "movie", "ids": {"tmdb": "550"}, "position_seconds": 100, "duration_seconds": 8340}
@@ -582,7 +725,7 @@ def test_progress_session_id_is_stable_across_runs(monkeypatch: pytest.MonkeyPat
     pr.add(Adapter(), [dict(item)])
 
     assert first.calls[0]["json"]["playback_session_id"] == second.calls[0]["json"]["playback_session_id"]
-    assert first.calls[0]["json"]["event_id"] == second.calls[0]["json"]["event_id"]
+    assert first.calls[0]["json"]["event_id"] != second.calls[0]["json"]["event_id"]
 
 
 def test_progress_index_reports_dropped_rows(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
# Pull request

## Change

Fix PunchPlay passive progress writes, progress reads, watchlist snapshot reads and playback progress support.

## Why

There was a bug in PunchPlay API that has been corrected

## Testing

- test_punchplay_sync.py 
- tests\test_punchplay_playback.py 

## Issue

Relates to #680