### PR TITLE
Change: clean up local tracker source

### DIFF
--- a/api/editorAPI.py
+++ b/api/editorAPI.py
@@ -8,7 +8,6 @@ from typing import Any, Mapping
 import io
 import json
 import os
-import re
 from pathlib import Path
 
 from fastapi import APIRouter, Body, File, HTTPException, Query, UploadFile
@@ -715,221 +714,6 @@ def api_editor_playlist_endpoint_save(endpoint_id: str, payload: dict[str, Any] 
     result["ok"] = result["unresolved_count"] == 0
     return result
 
-_TRACKER_PROVIDER = "CROSSWATCH"
-_TRACKER_FEATURES: tuple[str, ...] = ("watchlist", "history", "ratings", "progress")
-_TRACKER_RESERVED_SCOPES = frozenset({"unresolved", "restore_state", "tmp", "snapshots"})
-_TRACKER_DEFAULT_ROOT = Path("/config/.cw_provider")
-
-
-def _safe_tracker_profile_dir(instance_id: Any) -> str:
-    raw = normalize_instance_id(instance_id)
-    safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", raw).strip("._- ")
-    return safe or "default"
-
-
-def _tracker_base_root(cfg: Mapping[str, Any]) -> Path:
-    node = cfg.get("crosswatch") if isinstance(cfg, dict) else {}
-    raw = ""
-    if isinstance(node, dict):
-        raw = str(node.get("root_dir") or "").strip()
-    try:
-        root = Path(raw or _TRACKER_DEFAULT_ROOT).expanduser().resolve(strict=False)
-    except Exception:
-        return _TRACKER_DEFAULT_ROOT
-    try:
-        if root == Path(root.anchor):
-            return _TRACKER_DEFAULT_ROOT
-    except Exception:
-        return _TRACKER_DEFAULT_ROOT
-    return root
-
-
-def _tracker_configured_instance(cfg: Mapping[str, Any], provider_instance: Any = None) -> str:
-    requested = normalize_instance_id(provider_instance)
-    if requested == "default":
-        return "default"
-    node = cfg.get("crosswatch") if isinstance(cfg, dict) else {}
-    instances = node.get("instances") if isinstance(node, dict) else {}
-    if not isinstance(instances, dict):
-        return "default"
-    for key in instances.keys():
-        candidate = normalize_instance_id(key)
-        if candidate == requested:
-            return candidate
-    return "default"
-
-
-def _tracker_root(provider_instance: Any = None) -> Path:
-    cfg: dict[str, Any] = {}
-    try:
-        cfg = load_config() or {}
-    except Exception:
-        cfg = {}
-    inst = _tracker_configured_instance(cfg, provider_instance)
-    base = _tracker_base_root(cfg)
-    if inst == "default":
-        return base
-    return base / "profiles" / _safe_tracker_profile_dir(inst)
-
-
-def _tracker_scan(root: Path) -> dict[str, dict[str, str]]:
-    found: dict[str, dict[str, str]] = {}
-    try:
-        entries = sorted(root.iterdir())
-    except Exception:
-        return found
-    for p in entries:
-        try:
-            if not p.is_file() or p.suffix != ".json":
-                continue
-        except Exception:
-            continue
-        parts = p.name.split(".")
-        if len(parts) == 2:
-            feat, scope = parts[0], ""
-        elif len(parts) == 3:
-            feat, scope = parts[0], parts[1]
-            if scope.lower() in _TRACKER_RESERVED_SCOPES:
-                continue
-        else:
-            continue
-        if feat not in _TRACKER_FEATURES:
-            continue
-        found.setdefault(scope, {})[feat] = p.name
-    return found
-
-
-def _tracker_provider_label(name: str) -> str:
-    n = str(name or "").strip().upper()
-    if not n:
-        return ""
-    if n == _TRACKER_PROVIDER:
-        return "Local Tracker"
-    try:
-        ops = load_sync_ops(n)
-        label = str((getattr(ops, "label", None) or (lambda: ""))() or "").strip()
-        if label:
-            return label
-    except Exception:
-        pass
-    return n.title()
-
-
-def _tracker_pair_labels() -> dict[str, str]:
-    out: dict[str, str] = {}
-    try:
-        from cw_platform.orchestrator._pairs import _pair_scope_key
-        from providers.sync.crosswatch._common import _safe_scope
-    except Exception:
-        return out
-    try:
-        pairs = (load_config() or {}).get("pairs") or []
-    except Exception:
-        return out
-    if not isinstance(pairs, list):
-        return out
-    for i, pair in enumerate(pairs):
-        if not isinstance(pair, dict):
-            continue
-        src = str(pair.get("source") or "").strip().upper()
-        dst = str(pair.get("target") or "").strip().upper()
-        if not src or not dst or _TRACKER_PROVIDER not in (src, dst):
-            continue
-        mode = str(pair.get("mode") or "one-way").strip().lower()
-        try:
-            scope = _safe_scope(_pair_scope_key(pair, i=i, src=src, dst=dst, mode=mode))
-        except Exception:
-            continue
-        if scope and scope not in out:
-            out[scope] = f"{_tracker_provider_label(src)} → {_tracker_provider_label(dst)}"
-    return out
-
-
-def _tracker_workspace_index(provider_instance: Any = None) -> dict[str, dict[str, Any]]:
-    inst = normalize_instance_id(provider_instance)
-    root = _tracker_root(inst)
-    found = _tracker_scan(root)
-    if not found:
-        return {}
-    pair_labels = _tracker_pair_labels()
-    out: dict[str, dict[str, Any]] = {}
-    fallback = 0
-    for scope in sorted(found.keys(), key=lambda s: (s != "", s)):
-        files = found[scope]
-        wid = "default" if not scope else scope
-        if wid in out:
-            n = 2
-            while f"{wid}-{n}" in out:
-                n += 1
-            wid = f"{wid}-{n}"
-        if not scope:
-            label = "Default"
-        else:
-            label = pair_labels.get(scope) or ""
-            if not label:
-                fallback += 1
-                label = "Local tracker" if fallback == 1 else f"Local tracker {fallback}"
-        out[wid] = {
-            "id": wid,
-            "label": label,
-            "features": {f: (f in files) for f in _TRACKER_FEATURES},
-            "files": files,
-            "root": root,
-            "profile_id": inst,
-        }
-    return out
-
-
-def _tracker_workspaces(provider_instance: Any = None) -> list[dict[str, Any]]:
-    return [
-        {"id": w["id"], "label": w["label"], "features": w["features"], "profile_id": w["profile_id"]}
-        for w in _tracker_workspace_index(provider_instance).values()
-    ]
-
-
-def _tracker_workspace(workspace: Any, provider_instance: Any = None) -> dict[str, Any]:
-    index = _tracker_workspace_index(provider_instance)
-    if not index:
-        raise HTTPException(status_code=404, detail="No Local Tracker data found")
-    wid = str(workspace or "").strip()
-    if not wid:
-        wid = next(iter(index))
-    node = index.get(wid)
-    if node is None:
-        raise HTTPException(status_code=404, detail="Unknown Local Tracker workspace")
-    return node
-
-
-def _tracker_read(root: Path, filename: str) -> tuple[dict[str, Any], int | None]:
-    path = root / filename
-    try:
-        raw = json.loads(path.read_text("utf-8"))
-    except Exception:
-        return {}, None
-    if not isinstance(raw, dict):
-        return {}, None
-    items_raw = raw.get("items")
-    items: dict[str, Any] = {}
-    if isinstance(items_raw, dict):
-        for key, val in items_raw.items():
-            k = str(key or "").strip()
-            if k:
-                items[k] = dict(val) if isinstance(val, dict) else {}
-    ts: int | None = None
-    ts_raw = raw.get("ts")
-    if isinstance(ts_raw, (int, float, str)):
-        try:
-            ts = int(ts_raw)
-        except (TypeError, ValueError):
-            ts = None
-    if ts is None:
-        try:
-            ts = int(path.stat().st_mtime)
-        except OSError:
-            ts = None
-    return items, ts
-
-
 def _normalize_blocks(blocks_raw: Any) -> list[str]:
     keys: Any
     if isinstance(blocks_raw, dict):
@@ -952,14 +736,6 @@ def _normalize_blocks(blocks_raw: Any) -> list[str]:
     return blocks
 
 
-@router.get("/tracker/workspaces")
-def api_editor_tracker_workspaces(
-    provider_instance: str | None = Query("default"),
-) -> dict[str, Any]:
-    inst = normalize_instance_id(provider_instance)
-    return {"provider_instance": inst, "workspaces": _tracker_workspaces(inst)}
-
-
 @router.get("/state/providers")
 def api_editor_state_providers() -> dict[str, Any]:
     state_providers = StateStore(_STATE_BASE).provider_names()
@@ -975,42 +751,11 @@ def api_editor_get_state(
     provider: str | None = None,
     provider_instance: str | None = None,
     endpoint: str | None = None,
-    workspace: str | None = None,
 ) -> dict[str, Any]:
     k = _normalize_kind(kind)
     src = (source or "state").strip().lower()
     if src in ("playlist", "playlists", "playlist-endpoint"):
         return api_editor_playlist_endpoint((endpoint or snapshot or "").strip())
-
-    if src in ("tracker", "crosswatch"):
-        inst = normalize_instance_id(provider_instance)
-        ws = _tracker_workspace(workspace or snapshot, inst)
-        filename = (ws["files"] or {}).get(k)
-        items, ts = _tracker_read(ws["root"], filename) if filename else ({}, None)
-
-        raw_policy = _load_policy()
-        pol_adds, pol_blocks = _load_policy_manual(k, _TRACKER_PROVIDER, inst, raw_policy=raw_policy)
-        st_adds, st_blocks = (
-            _load_state_manual(k, _TRACKER_PROVIDER, inst, raw_state=_load_current_state_features({k})) if _state_exists() else ({}, [])
-        )
-        manual_adds = dict(st_adds or {})
-        manual_adds.update(dict(pol_adds or {}))
-        manual_blocks = _merge_blocks(st_blocks or [], pol_blocks or [])
-
-        return {
-            "kind": k,
-            "source": "tracker",
-            "workspace": ws["id"],
-            "label": ws["label"],
-            "features": ws["features"],
-            "provider": _TRACKER_PROVIDER,
-            "provider_instance": inst,
-            "ts": ts,
-            "count": len(items),
-            "items": items,
-            "manual_adds": manual_adds,
-            "manual_blocks": manual_blocks,
-        }
 
     if src in ("state", "current"):
         raw_state = _load_current_state_features({k})
@@ -1186,29 +931,6 @@ def api_editor_save_state(payload: dict[str, Any] = Body(...)) -> dict[str, Any]
     if src in ("playlist", "playlists", "playlist-endpoint"):
         endpoint_id = str(payload.get("endpoint") or payload.get("snapshot") or "").strip()
         return api_editor_playlist_endpoint_save(endpoint_id, payload)
-
-    if src in ("tracker", "crosswatch"):
-        inst = normalize_instance_id(payload.get("provider_instance"))
-        ws = _tracker_workspace(payload.get("workspace") or payload.get("snapshot"), inst)
-        items = _canonicalize_manual_items(items, kind)
-        blocks = _normalize_blocks(payload.get("blocks"))
-        _save_policy_manual(kind, _TRACKER_PROVIDER, items, blocks, inst)
-        ts = None
-        try:
-            ts = _policy_mtime()
-        except Exception:
-            ts = None
-        return {
-            "ok": True,
-            "kind": kind,
-            "source": "tracker",
-            "workspace": ws["id"],
-            "provider": _TRACKER_PROVIDER,
-            "provider_instance": inst,
-            "count": len(items),
-            "blocks": len(blocks),
-            "ts": ts,
-        }
 
     if src in ("state", "current", "manual", "manual-overrides", "policy", "overrides"):
         provider = str(payload.get("provider") or "").strip()

--- a/api/maintenanceAPI.py
+++ b/api/maintenanceAPI.py
@@ -11,7 +11,7 @@ import os
 import shutil
 import threading
 from collections.abc import Mapping
-from datetime import datetime
+from datetime import datetime, timezone
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
@@ -226,7 +226,7 @@ def _file_meta(path: Path) -> dict[str, Any]:
     return {
         "name": path.name,
         "size": st.st_size,
-        "mtime": datetime.utcfromtimestamp(st.st_mtime).strftime(
+        "mtime": datetime.fromtimestamp(st.st_mtime, timezone.utc).strftime(
             "%Y-%m-%dT%H:%M:%SZ"
         ),
     }
@@ -1001,7 +1001,7 @@ def _scan_cw_tracker(root: Path) -> dict[str, Any]:
 
     state_files.sort(key=lambda x: x.get("name") or "")
     snapshots.sort(key=lambda x: x.get("mtime") or "")
-    core_names = {"history.json", "ratings.json", "watchlist.json"}
+    core_names = {"history.json", "ratings.json", "watchlist.json", "progress.json"}
     state_count = sum(
         1 for f in state_files
         if (f.get("name") or "") in core_names

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -54,12 +54,10 @@
     snapshots: [],
     instance: "default",
     playlistEndpoints: [],
+    playlistEndpointsLoaded: false,
     playlistResource: null,
     playlistWarnings: [],
     playlistOriginalKeys: [],
-    workspace: "",
-    trackerWorkspaces: [],
-    trackerAvailable: false,
     importEnabled: false,
     importProviders: [],
     importProvider: "",
@@ -138,10 +136,8 @@
       if (!raw) return;
       const saved = JSON.parse(raw);
 
-      const sources = ["state", "manual", "tracker", "playlist"];
+      const sources = ["state", "manual", "playlist"];
       if (saved.source && sources.includes(saved.source)) state.source = saved.source;
-
-      if (typeof saved.workspace === "string") state.workspace = saved.workspace;
 
       if (typeof saved.blockedOnly === "boolean") state.blockedOnly = saved.blockedOnly;
 
@@ -180,7 +176,7 @@
   }
   restoreUIState();
 
-  host.innerHTML = `<div class="cw-root"><div class="cw-topline cw-page-hero cw-page-hero-editor" data-hero-icon="edit_note"><div class="cw-head-copy cw-page-hero-copy"><div class="cw-page-hero-kicker">EDITOR</div><div class="cw-title-row"><div><div class="cw-title cw-page-hero-title">Editor</div><div class="cw-sub cw-page-hero-sub">Edit your current state, tracker or cache</div></div></div></div><div class="cw-editor-hero-summary cw-page-hero-actions" id="cw-hero-summary" aria-label="Editor summary"><div class="cw-editor-hero-seg"><strong id="cw-pill-source">Current state</strong><span>source</span></div><div class="cw-editor-hero-seg"><strong id="cw-pill-kind">Watchlist</strong><span>view</span></div><div class="cw-editor-hero-seg cw-editor-hero-count"><strong id="cw-pill-count">0</strong><span>rows</span></div><div class="cw-editor-hero-seg cw-editor-hero-sync"><span>Synced</span><strong id="cw-pill-sync">never</strong></div><button id="cw-reload" class="cw-editor-refresh" type="button" title="Refresh editor data" aria-label="Refresh editor data"><span class="material-symbols-rounded" aria-hidden="true">refresh</span></button></div></div><div class="cw-wrap"><div class="cw-main"><div class="cw-controls"><input id="cw-filter" class="cw-input" placeholder="Filter by key / title / id..."><span class="cw-status-text" id="cw-status"></span><label class="cw-page-size-control" for="cw-page-size"><span>Rows</span><select id="cw-page-size" class="cw-select"><option value="50">50</option><option value="100">100</option><option value="150">150</option><option value="200">200</option></select></label><div class="cw-controls-spacer"></div><div class="cw-bulk" id="cw-bulk" style="display:none"><span class="cw-bulk-count" id="cw-bulk-count"></span><button id="cw-bulk-remove" class="cw-btn danger" type="button"></button><button id="cw-bulk-restore" class="cw-btn" type="button"></button><button id="cw-bulk-clear" class="cw-btn" type="button">Clear</button></div><button id="cw-add" class="cw-btn" type="button">Add row</button><button id="cw-save" class="cw-btn primary" type="button">Save changes</button></div><div class="cw-table-wrap" id="cw-table-wrap"><div class="cw-table-scroll"><table class="cw-table"><thead><tr><th style="width:34px"><input id="cw-select-page" class="cw-checkbox" type="checkbox" title="Select page"></th><th class="cw-action-head" style="width:46px"></th><th class="cw-col-key sortable" style="width:12%" data-sort="key">Key</th><th class="cw-col-type sortable" style="width:13%" data-sort="type">Type</th><th class="cw-col-title sortable" style="width:33%" data-sort="title">Title</th><th class="cw-col-year" style="width:84px">Year</th><th class="cw-col-id cw-col-id-a" style="width:12%" id="cw-col-id-a">TMDB</th><th class="cw-col-extra sortable" style="width:21%" data-sort="extra">Extra</th></tr></thead><tbody id="cw-tbody"></tbody></table></div></div><div class="cw-pager" id="cw-pager" style="display:none"><button id="cw-prev" class="cw-btn" type="button">Previous</button><span id="cw-page-info" class="cw-page-info"></span><button id="cw-next" class="cw-btn" type="button">Next</button></div><div class="cw-empty" id="cw-empty" role="status" style="display:none"><span class="material-symbols-rounded cw-empty-icon" aria-hidden="true">table_rows</span><div class="cw-empty-text">No rows match this view.</div></div></div><aside class="cw-side"><div class="ins-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">tune</span></div><div class="ins-title">Workspace</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Source</label><select id="cw-source" class="cw-select"><option value="state">Current State</option><option value="manual">Manual Overrides</option><option value="tracker">Local Tracker</option></select><label>Kind</label><select id="cw-kind" class="cw-select"><option value="watchlist">Watchlist</option><option value="history">History</option><option value="ratings">Ratings</option><option value="progress">Progress</option></select><label id="cw-pair-label" style="display:none">Pair</label><select id="cw-pair" class="cw-select" style="display:none"></select><label id="cw-snapshot-label">Snapshot</label><select id="cw-snapshot" class="cw-select"><option value="">Latest</option></select><label id="cw-instance-label" style="display:none">Profile</label><select id="cw-instance" class="cw-select" style="display:none"><option value="default">Default</option></select></div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><div class="field-label">Types</div><div id="cw-type-filter" class="cw-type-filter"><button type="button" data-type="movie" class="cw-type-chip active">Movies</button><button type="button" data-type="show" class="cw-type-chip active">Shows</button><button type="button" data-type="anime" class="cw-type-chip active">Anime</button><button type="button" data-type="season" class="cw-type-chip active">Seasons</button><button type="button" data-type="episode" class="cw-type-chip active">Episodes</button><button type="button" id="cw-blocked-only" class="cw-type-chip">Blocked</button></div></div></div><div class="ins-row" id="cw-state-bulk" style="display:none"><details class="cw-collapse" id="cw-bulk-details" style="width:100%"><summary style="cursor:pointer;font-weight:700;user-select:none">Block rules</summary><div style="display:flex;flex-direction:column;gap:8px;width:100%;margin-top:10px"><select id="cw-bulk-type" class="cw-select" style="width:100%"></select><div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap"><button id="cw-bulk-block-type" class="cw-btn danger" type="button" style="flex:1 1 0;min-width:120px">Block all</button><button id="cw-bulk-unblock-type" class="cw-btn" type="button" style="flex:1 1 0;min-width:120px">Unblock all</button></div><div class="cw-status-text">Current State only • affects baseline items</div></div></details></div><div class="ins-row" id="cw-import-row" style="display:none"><details class="cw-collapse" id="cw-import-details" style="width:100%"><summary style="cursor:pointer;font-weight:700;user-select:none">Import provider state</summary><div style="display:flex;flex-direction:column;gap:10px;width:100%;margin-top:10px"><div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center"><select id="cw-import-provider" class="cw-select" style="flex:1;min-width:200px"></select><select id="cw-import-instance" class="cw-select" style="min-width:180px"></select><select id="cw-import-mode" class="cw-select" style="min-width:180px"><option value="replace">Replace baseline</option><option value="merge">Merge (keep old)</option></select></div><div style="display:flex;gap:12px;flex-wrap:wrap;align-items:center"><label id="cw-import-watchlist-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-watchlist" class="cw-checkbox" type="checkbox" checked>Watchlist </label><label id="cw-import-history-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-history" class="cw-checkbox" type="checkbox" checked>History </label><label id="cw-import-ratings-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-ratings" class="cw-checkbox" type="checkbox" checked>Ratings </label><label id="cw-import-progress-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-progress-cb" class="cw-checkbox" type="checkbox" checked>Progress </label><span style="flex:1 1 auto"></span><button id="cw-import-run" class="cw-btn sm" type="button">Import</button></div><div id="cw-import-progress" style="display:none"><div class="cw-progress"><span></span></div><div class="cw-status-text" id="cw-import-progress-text" style="margin-top:6px"></div></div></div></details></div></div><div class="ins-card"><div class="ins-row" style="align-items:center"><div class="ins-icon"><span class="material-symbol">insights</span></div><div class="ins-title" style="margin-right:auto">Pulse</div><span class="cw-tag" id="cw-tag-status"><span class="cw-tag-dot"></span><span id="cw-tag-label">Idle</span></span></div><div class="ins-row"><div class="ins-metrics"><div class="metric-row"><div class="metric"><span class="material-symbol">view_list</span><div><div class="m-val" id="cw-summary-total">0</div><div class="m-lbl">Total rows</div></div></div><div class="metric"><span class="material-symbol">visibility</span><div><div class="m-val" id="cw-summary-visible">0</div><div class="m-lbl">Rows visible</div></div></div></div><div class="metric-divider"></div><div class="metric-row"><div class="metric"><span class="material-symbol">movie</span><div><div class="m-val" id="cw-summary-movies">0</div><div class="m-lbl">Movies</div></div></div><div class="metric"><span class="material-symbol">monitoring</span><div><div class="m-val" id="cw-summary-shows">0</div><div class="m-lbl">Shows</div></div></div><div class="metric"><span class="material-symbol">layers</span><div><div class="m-val" id="cw-summary-seasons">0</div><div class="m-lbl">Seasons</div></div></div><div class="metric"><span class="material-symbol">live_tv</span><div><div class="m-val" id="cw-summary-episodes">0</div><div class="m-lbl">Episodes</div></div></div></div><div class="metric-divider"></div><div class="metric-row"><div class="metric"><span class="material-symbol">description</span><div><div class="m-val" id="cw-summary-state-files">0</div><div class="m-lbl">State files</div></div></div><div class="metric"><span class="material-symbol">folder_copy</span><div><div class="m-val" id="cw-summary-snapshots">0</div><div class="m-lbl">Snapshots</div></div></div></div><div id="cw-state-hint" class="cw-state-hint" style="display:none"><strong>No tracker data found.</strong> Run a CrossWatch sync with the tracker enabled once. After that, tracker state files and snapshots will appear here and you can edit them. </div></div></div></div><div class="ins-card" id="cw-backup-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">backup</span></div><div class="ins-title">Archive</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Export / Import</label><div class="cw-backup-actions"><button id="cw-download" class="cw-btn" type="button">Download ZIP</button><button id="cw-upload" class="cw-btn" type="button">Import file</button><input id="cw-upload-input" type="file" accept=".zip,.json" style="display:none"></div></div></div></div><div class="ins-card" id="cw-state-backup-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">backup</span></div><div class="ins-title">Policy backup</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Export / Import</label><div class="cw-backup-actions"><button id="cw-state-download" class="cw-btn" type="button">Download JSON</button><button id="cw-state-upload" class="cw-btn" type="button">Import file</button><input id="cw-state-upload-input" type="file" accept=".json" style="display:none"></div></div></div></div></aside></div></div>`;
+  host.innerHTML = `<div class="cw-root"><div class="cw-topline cw-page-hero cw-page-hero-editor" data-hero-icon="edit_note"><div class="cw-head-copy cw-page-hero-copy"><div class="cw-page-hero-kicker">EDITOR</div><div class="cw-title-row"><div><div class="cw-title cw-page-hero-title">Editor</div><div class="cw-sub cw-page-hero-sub">Edit your current state or playlist endpoints</div></div></div></div><div class="cw-editor-hero-summary cw-page-hero-actions" id="cw-hero-summary" aria-label="Editor summary"><div class="cw-editor-hero-seg"><strong id="cw-pill-source">Current state</strong><span>source</span></div><div class="cw-editor-hero-seg"><strong id="cw-pill-kind">Watchlist</strong><span>view</span></div><div class="cw-editor-hero-seg cw-editor-hero-count"><strong id="cw-pill-count">0</strong><span>rows</span></div><div class="cw-editor-hero-seg cw-editor-hero-sync"><span>Synced</span><strong id="cw-pill-sync">never</strong></div><button id="cw-reload" class="cw-editor-refresh" type="button" title="Refresh editor data" aria-label="Refresh editor data"><span class="material-symbols-rounded" aria-hidden="true">refresh</span></button></div></div><div class="cw-wrap"><div class="cw-main"><div class="cw-controls"><input id="cw-filter" class="cw-input" placeholder="Filter by key / title / id..."><span class="cw-status-text" id="cw-status"></span><label class="cw-page-size-control" for="cw-page-size"><span>Rows</span><select id="cw-page-size" class="cw-select"><option value="50">50</option><option value="100">100</option><option value="150">150</option><option value="200">200</option></select></label><div class="cw-controls-spacer"></div><div class="cw-bulk" id="cw-bulk" style="display:none"><span class="cw-bulk-count" id="cw-bulk-count"></span><button id="cw-bulk-remove" class="cw-btn danger" type="button"></button><button id="cw-bulk-restore" class="cw-btn" type="button"></button><button id="cw-bulk-clear" class="cw-btn" type="button">Clear</button></div><button id="cw-add" class="cw-btn" type="button">Add row</button><button id="cw-save" class="cw-btn primary" type="button">Save changes</button></div><div class="cw-table-wrap" id="cw-table-wrap"><div class="cw-table-scroll"><table class="cw-table"><thead><tr><th style="width:34px"><input id="cw-select-page" class="cw-checkbox" type="checkbox" title="Select page"></th><th class="cw-action-head" style="width:46px"></th><th class="cw-col-key sortable" style="width:12%" data-sort="key">Key</th><th class="cw-col-type sortable" style="width:13%" data-sort="type">Type</th><th class="cw-col-title sortable" style="width:33%" data-sort="title">Title</th><th class="cw-col-year" style="width:84px">Year</th><th class="cw-col-id cw-col-id-a" style="width:12%" id="cw-col-id-a">TMDB</th><th class="cw-col-extra sortable" style="width:21%" data-sort="extra">Extra</th></tr></thead><tbody id="cw-tbody"></tbody></table></div></div><div class="cw-pager" id="cw-pager" style="display:none"><button id="cw-prev" class="cw-btn" type="button">Previous</button><span id="cw-page-info" class="cw-page-info"></span><button id="cw-next" class="cw-btn" type="button">Next</button></div><div class="cw-empty" id="cw-empty" role="status" style="display:none"><span class="material-symbols-rounded cw-empty-icon" aria-hidden="true">table_rows</span><div class="cw-empty-text">No rows match this view.</div></div></div><aside class="cw-side"><div class="ins-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">tune</span></div><div class="ins-title">Workspace</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Source</label><select id="cw-source" class="cw-select"><option value="state">Current State</option><option value="manual">Manual Overrides</option></select><label>Kind</label><select id="cw-kind" class="cw-select"><option value="watchlist">Watchlist</option><option value="history">History</option><option value="ratings">Ratings</option><option value="progress">Progress</option></select><label id="cw-pair-label" style="display:none">Pair</label><select id="cw-pair" class="cw-select" style="display:none"></select><label id="cw-snapshot-label">Snapshot</label><select id="cw-snapshot" class="cw-select"><option value="">Latest</option></select><label id="cw-instance-label" style="display:none">Profile</label><select id="cw-instance" class="cw-select" style="display:none"><option value="default">Default</option></select></div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><div class="field-label">Types</div><div id="cw-type-filter" class="cw-type-filter"><button type="button" data-type="movie" class="cw-type-chip active">Movies</button><button type="button" data-type="show" class="cw-type-chip active">Shows</button><button type="button" data-type="anime" class="cw-type-chip active">Anime</button><button type="button" data-type="season" class="cw-type-chip active">Seasons</button><button type="button" data-type="episode" class="cw-type-chip active">Episodes</button><button type="button" id="cw-blocked-only" class="cw-type-chip">Blocked</button></div></div></div><div class="ins-row" id="cw-state-bulk" style="display:none"><details class="cw-collapse" id="cw-bulk-details" style="width:100%"><summary style="cursor:pointer;font-weight:700;user-select:none">Block rules</summary><div style="display:flex;flex-direction:column;gap:8px;width:100%;margin-top:10px"><select id="cw-bulk-type" class="cw-select" style="width:100%"></select><div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap"><button id="cw-bulk-block-type" class="cw-btn danger" type="button" style="flex:1 1 0;min-width:120px">Block all</button><button id="cw-bulk-unblock-type" class="cw-btn" type="button" style="flex:1 1 0;min-width:120px">Unblock all</button></div><div class="cw-status-text">Current State only â€¢ affects baseline items</div></div></details></div><div class="ins-row" id="cw-import-row" style="display:none"><details class="cw-collapse" id="cw-import-details" style="width:100%"><summary style="cursor:pointer;font-weight:700;user-select:none">Import provider state</summary><div style="display:flex;flex-direction:column;gap:10px;width:100%;margin-top:10px"><div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center"><select id="cw-import-provider" class="cw-select" style="flex:1;min-width:200px"></select><select id="cw-import-instance" class="cw-select" style="min-width:180px"></select><select id="cw-import-mode" class="cw-select" style="min-width:180px"><option value="replace">Replace baseline</option><option value="merge">Merge (keep old)</option></select></div><div style="display:flex;gap:12px;flex-wrap:wrap;align-items:center"><label id="cw-import-watchlist-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-watchlist" class="cw-checkbox" type="checkbox" checked>Watchlist </label><label id="cw-import-history-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-history" class="cw-checkbox" type="checkbox" checked>History </label><label id="cw-import-ratings-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-ratings" class="cw-checkbox" type="checkbox" checked>Ratings </label><label id="cw-import-progress-wrap" style="display:flex;gap:6px;align-items:center;font-size:12px;width:auto;margin:0"><input id="cw-import-progress-cb" class="cw-checkbox" type="checkbox" checked>Progress </label><span style="flex:1 1 auto"></span><button id="cw-import-run" class="cw-btn sm" type="button">Import</button></div><div id="cw-import-progress" style="display:none"><div class="cw-progress"><span></span></div><div class="cw-status-text" id="cw-import-progress-text" style="margin-top:6px"></div></div></div></details></div></div><div class="ins-card"><div class="ins-row" style="align-items:center"><div class="ins-icon"><span class="material-symbol">insights</span></div><div class="ins-title" style="margin-right:auto">Pulse</div><span class="cw-tag" id="cw-tag-status"><span class="cw-tag-dot"></span><span id="cw-tag-label">Idle</span></span></div><div class="ins-row"><div class="ins-metrics"><div class="metric-row"><div class="metric"><span class="material-symbol">view_list</span><div><div class="m-val" id="cw-summary-total">0</div><div class="m-lbl">Total rows</div></div></div><div class="metric"><span class="material-symbol">visibility</span><div><div class="m-val" id="cw-summary-visible">0</div><div class="m-lbl">Rows visible</div></div></div></div><div class="metric-divider"></div><div class="metric-row"><div class="metric"><span class="material-symbol">movie</span><div><div class="m-val" id="cw-summary-movies">0</div><div class="m-lbl">Movies</div></div></div><div class="metric"><span class="material-symbol">monitoring</span><div><div class="m-val" id="cw-summary-shows">0</div><div class="m-lbl">Shows</div></div></div><div class="metric"><span class="material-symbol">layers</span><div><div class="m-val" id="cw-summary-seasons">0</div><div class="m-lbl">Seasons</div></div></div><div class="metric"><span class="material-symbol">live_tv</span><div><div class="m-val" id="cw-summary-episodes">0</div><div class="m-lbl">Episodes</div></div></div></div><div class="metric-divider"></div><div class="metric-row"><div class="metric"><span class="material-symbol">description</span><div><div class="m-val" id="cw-summary-state-files">0</div><div class="m-lbl">State files</div></div></div><div class="metric"><span class="material-symbol">folder_copy</span><div><div class="m-val" id="cw-summary-snapshots">0</div><div class="m-lbl">Snapshots</div></div></div></div><div id="cw-state-hint" class="cw-state-hint" style="display:none"><strong>No sync state found.</strong> Run a CrossWatch sync once to generate it.</div></div></div></div><div class="ins-card" id="cw-backup-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">backup</span></div><div class="ins-title">Archive</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Export / Import</label><div class="cw-backup-actions"><button id="cw-download" class="cw-btn" type="button">Download ZIP</button><button id="cw-upload" class="cw-btn" type="button">Import file</button><input id="cw-upload-input" type="file" accept=".zip,.json" style="display:none"></div></div></div></div><div class="ins-card" id="cw-state-backup-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">backup</span></div><div class="ins-title">Policy backup</div></div><div class="ins-row"><div class="ins-kv" style="width:100%"><label>Export / Import</label><div class="cw-backup-actions"><button id="cw-state-download" class="cw-btn" type="button">Download JSON</button><button id="cw-state-upload" class="cw-btn" type="button">Import file</button><input id="cw-state-upload-input" type="file" accept=".json" style="display:none"></div></div></div></div></aside></div></div>`;
 
   editorChrome.wireStaticLabels(host);
   editorChrome.prepareSourceOptions(host);
@@ -513,16 +509,8 @@
     return `${series} - ${code}`;
   }
 
-  function currentTrackerWorkspace() {
-    return editorSources.currentTrackerWorkspace(state);
-  }
-
-  function trackerKinds() {
-    return editorSources.trackerKinds(state);
-  }
-
   function syncHeaderPills(visible, total) {
-    const srcMap = { state: "Current state", manual: "Manual overrides", tracker: "Local tracker", playlist: "Playlist endpoint" };
+    const srcMap = { state: "Current state", manual: "Manual overrides", playlist: "Playlist endpoint" };
     const kindMap = { watchlist: "Watchlist", history: "History", ratings: "Ratings", progress: "Progress", playlist: "Playlist" };
     if (pillSource) pillSource.textContent = srcMap[state.source] || "Source";
     if (pillKind) pillKind.textContent = state.source === "playlist" ? "Playlist" : (kindMap[state.kind] || "Kind");
@@ -571,10 +559,6 @@
   function syncKindUI() {
     if (!kindSel) return;
     let allowed = ["watchlist", "history", "ratings", "progress"];
-    if (isTrackerSource()) {
-      const supported = trackerKinds();
-      if (supported.length) allowed = supported;
-    }
     if (!allowed.includes(state.kind)) state.kind = allowed[0] || "watchlist";
     const current = Array.from(kindSel.options).map(o => o.value);
     if (current.join("|") !== allowed.join("|")) {
@@ -992,7 +976,6 @@
         source: state.source,
         kind: state.kind,
         snapshot: state.snapshot,
-        workspace: state.workspace,
         instance: state.instance,
         filter: state.filter,
         pageSize: state.pageSize,
@@ -1738,10 +1721,6 @@ function bindFileImport(btn, input, url, done) {
   return editorFileUtils.bindFileImport(btn, input, url, done, { on, setTag, setStatus });
 }
 
-  async function loadTrackerWorkspaces() {
-    return editorSources.loadTrackerWorkspaces(sourceContext());
-  }
-
   async function loadSnapshots() {
     return editorSources.loadSnapshots(sourceContext());
   }
@@ -1879,9 +1858,6 @@ function bindFileImport(btn, input, url, done) {
         state.kind = "watchlist";
         state.instance = "default";
       }
-      if (isTrackerSource()) {
-        state.workspace = "";
-      }
       persistUIState();
       syncSourceUI();
       clearSelection();
@@ -1910,7 +1886,7 @@ function bindFileImport(btn, input, url, done) {
       syncTypeFilterUI();
       syncStateBulkUI();
       clearSelection();
-      if (!isProviderPickerSource() && !isTrackerSource()) state.snapshot = "";
+      if (!isProviderPickerSource()) state.snapshot = "";
       state.page = 0;
       persistUIState();
       await loadSnapshots();
@@ -1922,17 +1898,6 @@ function bindFileImport(btn, input, url, done) {
 
   if (snapSel) {
     snapSel.addEventListener("change", async () => {
-      if (isTrackerSource()) {
-        state.workspace = snapSel.value || "";
-        state.page = 0;
-        clearSelection();
-        syncKindUI();
-        syncTypeFilterUI();
-        syncStateBulkUI();
-        persistUIState();
-        await loadState();
-        return;
-      }
       state.snapshot = snapSel.value || "";
       if (isProviderPickerSource()) syncProviderIconSelect(snapSel, true);
       if (isProviderPickerSource()) {
@@ -1951,11 +1916,6 @@ function bindFileImport(btn, input, url, done) {
       state.instance = instanceSel.value || "default";
       state.page = 0;
       persistUIState();
-      if (isTrackerSource()) {
-        state.workspace = "";
-        clearSelection();
-        await loadSnapshots();
-      }
       await loadState();
     });
   }
@@ -2073,12 +2033,10 @@ if (importProviderSel) {
   });
 
   (async () => {
-    await loadTrackerWorkspaces();
     const wanted = state.source;
     state.source = normalizeSource(wanted);
     if (state.source !== wanted) {
       state.snapshot = "";
-      state.workspace = "";
       state.instance = "default";
       persistUIState();
     }
@@ -2086,11 +2044,9 @@ if (importProviderSel) {
     await loadImportProviders();
     setTag(
       "warn",
-      isTrackerSource()
-        ? "Loading Local Tracker…"
-        : state.source === "state"
-          ? "Loading current state…"
-          : "Loading playlist endpoint…"
+      state.source === "state"
+        ? "Loading current state..."
+        : "Loading playlist endpoint..."
     );
     await loadSnapshots();
     await loadState();

--- a/assets/js/editor/chrome.js
+++ b/assets/js/editor/chrome.js
@@ -47,30 +47,16 @@
     const sourceSelect = document.getElementById("cw-source");
     if (sourceSelect) {
       sourceSelect.querySelector('option[value="pair"]')?.remove();
+      sourceSelect.querySelector('option[value="tracker"]')?.remove();
       if (!sourceSelect.querySelector('option[value="manual"]')) {
         const manualOpt = document.createElement("option");
         manualOpt.value = "manual";
         manualOpt.textContent = "Manual Overrides";
-        const trackerOpt = sourceSelect.querySelector('option[value="tracker"]');
-        if (trackerOpt) sourceSelect.insertBefore(manualOpt, trackerOpt);
-        else sourceSelect.appendChild(manualOpt);
+        sourceSelect.appendChild(manualOpt);
       } else {
         sourceSelect.querySelector('option[value="manual"]').textContent = "Manual Overrides";
       }
-      if (!sourceSelect.querySelector('option[value="tracker"]')) {
-        const trackerOpt = document.createElement("option");
-        trackerOpt.value = "tracker";
-        trackerOpt.textContent = "Local Tracker";
-        sourceSelect.appendChild(trackerOpt);
-      } else {
-        sourceSelect.querySelector('option[value="tracker"]').textContent = "Local Tracker";
-      }
-      if (!sourceSelect.querySelector('option[value="playlist"]')) {
-        const opt = document.createElement("option");
-        opt.value = "playlist";
-        opt.textContent = "Playlist Endpoint";
-        sourceSelect.appendChild(opt);
-      }
+      sourceSelect.querySelector('option[value="playlist"]')?.remove();
     }
 
     const sub = root?.querySelector(".cw-sub");
@@ -78,14 +64,7 @@
   }
 
   function addTrackerNotice(root) {
-    if (!root || document.getElementById("cw-tracker-notice")) return;
-    const trackerNotice = document.createElement("div");
-    trackerNotice.id = "cw-tracker-notice";
-    trackerNotice.className = "cw-state-hint";
-    trackerNotice.style.display = "none";
-    trackerNotice.innerHTML =
-      "<strong>Local Tracker</strong> stores data inside CrossWatch. Changes here affect future syncs from Local Tracker but only for one-way syncs.";
-    root.querySelector(".cw-controls")?.insertAdjacentElement("afterend", trackerNotice);
+    root?.querySelector("#cw-tracker-notice")?.remove();
   }
 
   function ensureFieldNames(root) {

--- a/assets/js/editor/load-controller.js
+++ b/assets/js/editor/load-controller.js
@@ -12,12 +12,6 @@
 
   function syncSelectedScopeFromControls(ctx = {}) {
     const state = ctx.state;
-    if (ctx.isTrackerSource()) {
-      state.workspace = (ctx.snapSel && ctx.snapSel.value) ? ctx.snapSel.value : state.workspace || "";
-      state.snapshot = "";
-      state.instance = (ctx.instanceSel && ctx.instanceSel.value) ? ctx.instanceSel.value : state.instance || "default";
-      return;
-    }
     if (ctx.isProviderPickerSource()) {
       state.snapshot = (ctx.snapSel && ctx.snapSel.value) ? ctx.snapSel.value : state.snapshot || "";
       state.instance = (ctx.instanceSel && ctx.instanceSel.value) ? ctx.instanceSel.value : state.instance || "default";
@@ -66,24 +60,6 @@
         return;
       }
     }
-    if (ctx.isTrackerSource() && !String(state.workspace || "").trim()) {
-      state.baselineItems = {};
-      state.manualAdds = {};
-      state.manualBlocks = [];
-      state.items = {};
-      state.rows = [];
-      state.selected = new Set();
-      state.pageRids = [];
-      state.ridSeq = 1;
-      state.hasChanges = false;
-      state.page = 0;
-      ctx.renderRows();
-      ctx.showStateHint("tracker");
-      ctx.setTag("loaded", "No workspace");
-      ctx.setStatus("");
-      ctx.syncActionButtons();
-      return;
-    }
     state.source = ctx.normalizeSource(state.source);
     state.loading = true;
     ctx.setTag("warn", "Loading");
@@ -91,10 +67,6 @@
       const params = new URLSearchParams({ kind: state.kind, source: state.source });
       if (ctx.isProviderPickerSource() && state.snapshot) {
         params.set("provider", state.snapshot);
-        params.set("provider_instance", state.instance || "default");
-      }
-      if (ctx.isTrackerSource()) {
-        params.set("workspace", state.workspace);
         params.set("provider_instance", state.instance || "default");
       }
       if (state.source === "playlist" && state.snapshot) params.set("endpoint", state.snapshot);
@@ -118,10 +90,6 @@
             ctx.snapSel.value = state.snapshot;
             ctx.syncProviderIconSelect(ctx.snapSel, true);
           }
-        }
-        if (ctx.isTrackerSource() && data && typeof data.workspace === "string" && data.workspace.trim()) {
-          state.workspace = data.workspace.trim();
-          if (ctx.snapSel) ctx.snapSel.value = state.workspace;
         }
         state.baselineItems = data.items || {};
         state.manualAdds = data.manual_adds || {};
@@ -177,7 +145,7 @@
         const hasBaseline = state.baselineItems && Object.keys(state.baselineItems).length > 0;
         const hasManual = state.manualAdds && Object.keys(state.manualAdds).length > 0;
         const hasBlocks = Array.isArray(state.manualBlocks) && state.manualBlocks.length > 0;
-        const emptyMode = ctx.isManualSource() ? "manual" : ctx.isTrackerSource() ? "tracker" : "state";
+        const emptyMode = ctx.isManualSource() ? "manual" : "state";
         ctx.showStateHint(hasBaseline || hasManual || hasBlocks ? null : emptyMode);
       } else if (state.source === "playlist") {
         ctx.showStateHint(state.snapshot ? null : "playlist");
@@ -192,23 +160,6 @@
       const msg = String(e || "");
 
       if (
-        ctx.isTrackerSource() &&
-        (msg.includes("404") || /local tracker/i.test(msg) || /workspace/i.test(msg))
-      ) {
-        ctx.showStateHint("tracker");
-        state.baselineItems = {};
-        state.manualAdds = {};
-        state.manualBlocks = [];
-        state.items = {};
-        state.rows = [];
-        state.selected = new Set();
-        state.pageRids = [];
-        state.ridSeq = 1;
-        state.workspace = "";
-        ctx.renderRows();
-        ctx.setTag("warn", "No tracker data");
-        ctx.setStatus("");
-      } else if (
         state.source === "state" &&
         (msg.includes("404") || /state\.json/i.test(msg) || /missing state/i.test(msg))
       ) {

--- a/assets/js/editor/persistence.js
+++ b/assets/js/editor/persistence.js
@@ -87,11 +87,6 @@
       payload.provider_instance = state.instance || "default";
       payload.blocks = blocks;
     }
-    if (ctx.isTrackerSource?.()) {
-      payload.workspace = state.workspace;
-      payload.provider_instance = state.instance || "default";
-      payload.blocks = blocks;
-    }
     if (state.source === "playlist") {
       payload.endpoint = state.snapshot;
     }
@@ -159,9 +154,6 @@
         if (reordered) parts.push(`${reordered} reordered`);
         if (unresolved) parts.push(`${unresolved} unresolved`);
         ctx.setStatus?.(`Applied playlist changes: ${parts.join(", ")}`);
-        await ctx.loadState?.();
-      } else if (ctx.isTrackerSource?.()) {
-        ctx.setStatus?.(`Saved ${res.count || Object.keys(items).length} corrections`);
         await ctx.loadState?.();
       } else if (ctx.isManualSource?.()) {
         ctx.setStatus?.(`Saved ${res.count || Object.keys(items).length} overrides`);

--- a/assets/js/editor/send-modal.js
+++ b/assets/js/editor/send-modal.js
@@ -153,9 +153,6 @@
       if (ctx.isProviderPickerSource() && state.snapshot) {
         return providerKey({ provider: state.snapshot, instance: state.instance || "default" });
       }
-      if (ctx.isTrackerSource()) {
-        return providerKey({ provider: "CROSSWATCH", instance: state.instance || "default" });
-      }
       if (state.source === "playlist") {
         const ep = ctx.currentPlaylistEndpoint();
         if (ep && ep.provider) return providerKey({ provider: ep.provider, instance: ep.instance || "default" });

--- a/assets/js/editor/sources.js
+++ b/assets/js/editor/sources.js
@@ -4,7 +4,7 @@
   const NS = (window.CW ||= {});
   const Editor = (NS.Editor ||= {});
 
-  const SOURCES = ["state", "manual", "tracker", "playlist"];
+  const SOURCES = ["state", "manual", "playlist"];
 
   function stateOf(ctx) {
     return (ctx && ctx.state) || {};
@@ -17,7 +17,7 @@
   }
 
   function isTrackerSource(state) {
-    return stateOf({ state }).source === "tracker";
+    return false;
   }
 
   function isManualSource(state) {
@@ -31,11 +31,28 @@
 
   function isPolicySource(state) {
     const s = stateOf({ state });
-    return s.source === "state" || isManualSource(s) || s.source === "tracker";
+    return s.source === "state" || isManualSource(s);
   }
 
-  function ensureTrackerOption(sourceSel) {
+  function hasPlaylistEndpoints(state) {
+    const s = stateOf({ state });
+    return Array.isArray(s.playlistEndpoints) && s.playlistEndpoints.length > 0;
+  }
+
+  function playlistEndpointsLoaded(state) {
+    return stateOf({ state }).playlistEndpointsLoaded === true;
+  }
+
+  function ensureSourceOptions(sourceSel, state) {
     if (!sourceSel) return;
+    sourceSel.querySelector('option[value="tracker"]')?.remove();
+    const showPlaylist = hasPlaylistEndpoints(state);
+    const playlistOpt = sourceSel.querySelector('option[value="playlist"]');
+    if (!showPlaylist) {
+      playlistOpt?.remove();
+    } else if (playlistOpt) {
+      playlistOpt.textContent = "Playlist Endpoint";
+    }
     const manual = sourceSel.querySelector('option[value="manual"]');
     if (manual) {
       manual.textContent = "Manual Overrides";
@@ -43,34 +60,16 @@
       const opt = document.createElement("option");
       opt.value = "manual";
       opt.textContent = "Manual Overrides";
-      const trackerOpt = sourceSel.querySelector('option[value="tracker"]');
-      if (trackerOpt) sourceSel.insertBefore(opt, trackerOpt);
+      const currentPlaylistOpt = sourceSel.querySelector('option[value="playlist"]');
+      if (currentPlaylistOpt) sourceSel.insertBefore(opt, currentPlaylistOpt);
       else sourceSel.appendChild(opt);
     }
-    const existing = sourceSel.querySelector('option[value="tracker"]');
-    if (existing) {
-      existing.textContent = "Local Tracker";
-      return;
+    if (showPlaylist && !sourceSel.querySelector('option[value="playlist"]')) {
+      const opt = document.createElement("option");
+      opt.value = "playlist";
+      opt.textContent = "Playlist Endpoint";
+      sourceSel.appendChild(opt);
     }
-    const opt = document.createElement("option");
-    opt.value = "tracker";
-    opt.textContent = "Local Tracker";
-    const playlistOpt = sourceSel.querySelector('option[value="playlist"]');
-    if (playlistOpt) sourceSel.insertBefore(opt, playlistOpt);
-    else sourceSel.appendChild(opt);
-  }
-
-  function currentTrackerWorkspace(state) {
-    const s = stateOf({ state });
-    const id = String(s.workspace || "").trim();
-    const list = s.trackerWorkspaces || [];
-    return list.find(w => String(w && w.id || "") === id) || list[0] || null;
-  }
-
-  function trackerKinds(state) {
-    const ws = currentTrackerWorkspace(state);
-    const feats = (ws && ws.features) || {};
-    return ["watchlist", "history", "ratings", "progress"].filter(k => feats[k]);
   }
 
   function currentPlaylistEndpoint(state) {
@@ -88,14 +87,13 @@
 
   function syncSnapshotControlVisibility(ctx = {}) {
     const state = stateOf(ctx);
-    const show = !isTrackerSource(state);
-    if (ctx.snapLabel) ctx.snapLabel.style.display = show ? "" : "none";
+    if (ctx.snapLabel) ctx.snapLabel.style.display = "";
     if (ctx.snapSel) {
-      ctx.snapSel.style.display = show ? "" : "none";
+      ctx.snapSel.style.display = "";
       const wrap = ctx.snapSel.nextElementSibling && ctx.snapSel.nextElementSibling.classList?.contains("cw-icon-select")
         ? ctx.snapSel.nextElementSibling
         : null;
-      if (wrap) wrap.style.display = show ? "" : "none";
+      if (wrap) wrap.style.display = "";
     }
   }
 
@@ -117,30 +115,14 @@
     const snapSel = ctx.snapSel;
     if (!snapSel) return;
     const providerPicker = isProviderPickerSource(state);
-    const isTracker = isTrackerSource(state);
     const isPlaylist = state.source === "playlist";
     const esc = typeof ctx.escapeHtml === "function" ? ctx.escapeHtml : (s => String(s || ""));
 
     if (ctx.snapLabel) ctx.snapLabel.textContent = providerPicker ? "Provider" : "Endpoint";
     syncSnapshotControlVisibility(ctx);
-    if (ctx.instanceLabel) ctx.instanceLabel.style.display = (providerPicker || isTracker) ? "" : "none";
-    if (ctx.instanceSel) ctx.instanceSel.style.display = (providerPicker || isTracker) ? "" : "none";
-    ctx.syncProfileIconSelect?.(ctx.instanceSel, providerPicker || isTracker);
-
-    if (isTracker) {
-      const list = Array.isArray(state.trackerWorkspaces) ? state.trackerWorkspaces : [];
-      const options = list
-        .map(w => `<option value="${esc(w && w.id)}">${esc((w && w.label) || "Local tracker")}</option>`)
-        .join("");
-      snapSel.innerHTML = options || `<option value="">No workspaces</option>`;
-      const opts = Array.from(snapSel.options).map(o => o.value);
-      const next = opts.includes(state.workspace) ? state.workspace : opts[0] || "";
-      if (next !== state.workspace) state.workspace = next;
-      snapSel.value = state.workspace || "";
-      ctx.syncProviderIconSelect?.(snapSel, false);
-      syncSnapshotControlVisibility(ctx);
-      return;
-    }
+    if (ctx.instanceLabel) ctx.instanceLabel.style.display = providerPicker ? "" : "none";
+    if (ctx.instanceSel) ctx.instanceSel.style.display = providerPicker ? "" : "none";
+    ctx.syncProfileIconSelect?.(ctx.instanceSel, providerPicker);
 
     if (isPlaylist) {
       const list = Array.isArray(state.playlistEndpoints) ? state.playlistEndpoints : [];
@@ -173,16 +155,16 @@
   function syncSourceUI(ctx = {}) {
     const state = stateOf(ctx);
     state.source = normalizeSource(state.source);
+    if (state.source === "playlist" && playlistEndpointsLoaded(state) && !hasPlaylistEndpoints(state)) {
+      state.source = "state";
+      state.snapshot = "";
+    }
     if (ctx.sourceSel) {
       ctx.sourceSel.querySelector('option[value="pair"]')?.remove();
-      if (!ctx.sourceSel.querySelector('option[value="playlist"]')) {
-        ctx.sourceSel.insertAdjacentHTML("beforeend", '<option value="playlist">Playlist Endpoint</option>');
-      }
-      ensureTrackerOption(ctx.sourceSel);
+      ensureSourceOptions(ctx.sourceSel, state);
     }
     const isManual = isManualSource(state);
     const providerPicker = isProviderPickerSource(state);
-    const isTracker = isTrackerSource(state);
     const isPlaylist = state.source === "playlist";
     const policy = isPolicySource(state);
     if (ctx.sourceSel) ctx.sourceSel.value = state.source;
@@ -191,20 +173,18 @@
     if (ctx.snapLabel) ctx.snapLabel.textContent = providerPicker ? "Provider" : "Endpoint";
     syncSnapshotControlVisibility(ctx);
     if (ctx.kindSel) ctx.kindSel.disabled = isPlaylist;
-    if (ctx.instanceLabel) ctx.instanceLabel.style.display = (providerPicker || isTracker) ? "" : "none";
-    if (ctx.instanceSel) ctx.instanceSel.style.display = (providerPicker || isTracker) ? "" : "none";
+    if (ctx.instanceLabel) ctx.instanceLabel.style.display = providerPicker ? "" : "none";
+    if (ctx.instanceSel) ctx.instanceSel.style.display = providerPicker ? "" : "none";
     if (ctx.backupCard) ctx.backupCard.style.display = "none";
     if (ctx.stateBackupCard) ctx.stateBackupCard.style.display = policy ? "" : "none";
     if (ctx.blockedOnlyBtn) ctx.blockedOnlyBtn.style.display = policy ? "" : "none";
-    if (ctx.trackerNotice) ctx.trackerNotice.style.display = isTracker ? "block" : "none";
+    if (ctx.trackerNotice) ctx.trackerNotice.style.display = "none";
 
     const sub = ctx.host?.querySelector(".cw-sub");
     if (sub) {
       sub.textContent = isManual
         ? "Edit the manual override policy applied during future syncs."
-        : isTracker
-          ? "Edit what CrossWatch sends from its local tracker. Connected provider accounts are not changed."
-          : "Edit your current state or playlist endpoints";
+        : "Edit your current state or playlist endpoints";
     }
 
     if (isPlaylist) {
@@ -240,12 +220,6 @@
       stateHint.style.display = "block";
       return;
     }
-    if (mode === "tracker") {
-      stateHint.innerHTML =
-        "<strong>No Local Tracker data found.</strong> Run a sync pair that uses Local Tracker first.";
-      stateHint.style.display = "block";
-      return;
-    }
     if (mode === "manual") {
       stateHint.innerHTML =
         "<strong>No manual overrides found.</strong> Add a row here or edit a baseline row in Current State to create an override.";
@@ -255,47 +229,20 @@
     stateHint.style.display = "none";
   }
 
-  async function loadTrackerWorkspaces(ctx = {}) {
-    const state = stateOf(ctx);
-    try {
-      if (ctx.instanceSel) {
-        const nextInst = await ctx.loadInstanceOptions?.("CROSSWATCH", ctx.instanceSel, state.instance || "default");
-        if (nextInst !== state.instance) {
-          state.instance = nextInst;
-          ctx.persistUIState?.();
-        }
-      }
-      const params = new URLSearchParams({ provider_instance: state.instance || "default" });
-      const data = await ctx.fetchJSON(`/api/editor/tracker/workspaces?${params.toString()}`);
-      const list = Array.isArray(data && data.workspaces) ? data.workspaces : [];
-      state.trackerWorkspaces = list;
-      state.trackerAvailable = list.length > 0;
-      if (state.workspace && !list.some(w => String(w && w.id || "") === String(state.workspace))) {
-        state.workspace = "";
-        ctx.persistUIState?.();
-      }
-    } catch (_) {
-      state.trackerWorkspaces = [];
-      state.trackerAvailable = false;
-    }
-    ensureTrackerOption(ctx.sourceSel);
-    return state.trackerWorkspaces;
-  }
-
   async function loadSnapshots(ctx = {}) {
     const state = stateOf(ctx);
     try {
-      if (isTrackerSource(state)) {
-        await loadTrackerWorkspaces(ctx);
-        rebuildSnapshots(ctx);
-        ctx.syncKindUI?.();
-        if (!state.trackerWorkspaces.length) showStateHint("tracker", ctx);
-        else showStateHint(null, ctx);
-        return;
+      const endpointData = await ctx.fetchJSON("/api/editor/playlists/endpoints").catch(() => null);
+      state.playlistEndpoints = Array.isArray(endpointData && endpointData.endpoints) ? endpointData.endpoints : [];
+      state.playlistEndpointsLoaded = true;
+      if (state.source === "playlist" && !state.playlistEndpoints.length) {
+        state.source = "state";
+        state.snapshot = "";
+        ctx.persistUIState?.();
       }
+      ensureSourceOptions(ctx.sourceSel, state);
+      if (ctx.sourceSel) ctx.sourceSel.value = state.source;
       if (state.source === "playlist") {
-        const data = await ctx.fetchJSON("/api/editor/playlists/endpoints");
-        state.playlistEndpoints = Array.isArray(data && data.endpoints) ? data.endpoints : [];
         state.snapshots = state.playlistEndpoints;
         rebuildSnapshots(ctx);
         if (!state.playlistEndpoints.length) showStateHint("playlist", ctx);
@@ -341,9 +288,8 @@
     isManualSource,
     isProviderPickerSource,
     isPolicySource,
-    ensureTrackerOption,
-    currentTrackerWorkspace,
-    trackerKinds,
+    ensureTrackerOption: ensureSourceOptions,
+    ensureSourceOptions,
     currentPlaylistEndpoint,
     playlistEditable,
     syncSnapshotControlVisibility,
@@ -351,7 +297,6 @@
     rebuildSnapshots,
     syncSourceUI,
     showStateHint,
-    loadTrackerWorkspaces,
     loadSnapshots,
   };
   window.CrossWatchEditorSources = Editor.Sources;

--- a/assets/js/editor/table.js
+++ b/assets/js/editor/table.js
@@ -238,12 +238,6 @@
       sub.textContent = label;
       titleCell.appendChild(sub);
     }
-    if (call(ctx, "isTrackerSource") && row._origin !== "baseline") {
-      const origin = document.createElement("div");
-      origin.className = "cw-title-sub";
-      origin.textContent = "Manual correction";
-      titleCell.appendChild(origin);
-    }
     dataCells.title = cell(titleCell, "cw-col-title");
 
     const yearTd = cell(yearIn);

--- a/services/editor.py
+++ b/services/editor.py
@@ -349,6 +349,7 @@ def import_tracker_zip(fp: IO[bytes], provider_instance: Any = None) -> TrackerI
                 "watchlist.json",
                 "history.json",
                 "ratings.json",
+                "progress.json",
             ):
                 stats["states"] += 1
 

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+import io
 import json
+import zipfile
 
 import api.providerInstancesAPI as provider_api
 import api.editorAPI as editor_api
 import api.insightAPI as insight_api
 import api.authenticationAPI as auth_api
+import api.maintenanceAPI as maintenance_api
 import services.editor as editor_service
 import services.export as export_service
 import cw_platform.tracker_storage as tracker_storage
@@ -74,84 +77,37 @@ def test_crosswatch_module_uses_profile_root_from_config_view(tmp_path: Path) ->
     assert str(mod.cfg.base_path).replace("\\", "/").endswith("/cw_provider/profiles/CW-P03")
 
 
-def test_editor_tracker_workspaces_select_crosswatch_profile_root(tmp_path: Path, monkeypatch) -> None:
-    root = tmp_path / "cw_provider"
-    default_root = root
-    profile_root = root / "profiles" / "CW-P01"
-    default_root.mkdir(parents=True)
-    profile_root.mkdir(parents=True)
-    (default_root / "watchlist.json").write_text('{"items":{"movie:default":{"title":"Default"}}}', "utf-8")
-    (profile_root / "watchlist.json").write_text('{"items":{"movie:p01":{"title":"P01"}}}', "utf-8")
-
-    cfg = {"crosswatch": {"root_dir": str(root), "instances": {"CW-P01": {"label": "Desk"}}}}
-    monkeypatch.setattr(editor_api, "load_config", lambda: cfg)
-
-    workspaces = editor_api.api_editor_tracker_workspaces("CW-P01")
-    loaded = editor_api.api_editor_get_state(
-        kind="watchlist",
-        source="tracker",
-        provider_instance="CW-P01",
-        workspace="default",
-    )
-
-    assert workspaces["provider_instance"] == "CW-P01"
-    assert workspaces["workspaces"][0]["profile_id"] == "CW-P01"
-    assert loaded["provider_instance"] == "CW-P01"
-    assert set(loaded["items"].keys()) == {"movie:p01"}
-
-
-def test_editor_tracker_root_keeps_profile_under_profiles_dir(tmp_path: Path, monkeypatch) -> None:
-    root = tmp_path / "cw_provider"
-    monkeypatch.setattr(editor_api, "load_config", lambda: {
-        "crosswatch": {
-            "root_dir": str(root),
-            "instances": {"CW-P01": {"root_dir": str(tmp_path / "outside")}},
-        }
-    })
-
-    configured = editor_api._tracker_root("CW-P01")
-    rejected = editor_api._tracker_root("../outside")
-
-    assert configured == root.resolve(strict=False) / "profiles" / "CW-P01"
-    assert rejected == root.resolve(strict=False)
-
-
-def test_editor_hides_local_tracker_workspace_selector() -> None:
+def test_editor_removes_local_tracker_source() -> None:
     editor_js = Path("assets/js/editor.js").read_text("utf-8")
     sources_js = Path("assets/js/editor/sources.js").read_text("utf-8")
+    chrome_js = Path("assets/js/editor/chrome.js").read_text("utf-8")
+    load_js = Path("assets/js/editor/load-controller.js").read_text("utf-8")
 
-    assert "function syncSnapshotControlVisibility()" in editor_js
-    assert "const show = !isTrackerSource(state);" in sources_js
-    assert "if (ctx.snapLabel) ctx.snapLabel.style.display = show ? \"\" : \"none\";" in sources_js
+    assert 'option value="tracker"' not in editor_js
+    assert 'const SOURCES = ["state", "manual", "playlist"];' in sources_js
+    assert "sourceSel.querySelector('option[value=\"tracker\"]')?.remove();" in sources_js
+    assert "sourceSelect.querySelector('option[value=\"tracker\"]')?.remove();" in chrome_js
+    assert "/api/editor/tracker/workspaces" not in sources_js
+    assert "state.workspace" not in load_js
     assert "if (ctx.snapLabel) ctx.snapLabel.textContent = providerPicker ? \"Provider\" : \"Endpoint\";" in sources_js
-    assert 'isTracker ? "Workspace"' not in sources_js
 
 
-def test_editor_tracker_manual_policy_is_stored_per_crosswatch_profile(tmp_path: Path, monkeypatch) -> None:
-    root = tmp_path / "cw_provider"
-    profile_root = root / "profiles" / "CW-P02"
-    profile_root.mkdir(parents=True)
-    (profile_root / "watchlist.json").write_text('{"items":{"movie:base":{"title":"Base"}}}', "utf-8")
+def test_editor_rejects_local_tracker_source() -> None:
+    assert not hasattr(editor_api, "api_editor_tracker_workspaces")
 
-    monkeypatch.setattr(editor_api, "load_config", lambda: {
-        "crosswatch": {"root_dir": str(root), "instances": {"CW-P02": {}}},
-    })
-    monkeypatch.setattr(editor_api, "_STATE_BASE", tmp_path)
+    try:
+        editor_api.api_editor_get_state(kind="watchlist", source="tracker")
+    except Exception as exc:
+        assert getattr(exc, "status_code", None) == 400
+    else:
+        raise AssertionError("tracker source should not load")
 
-    res = editor_api.api_editor_save_state({
-        "kind": "watchlist",
-        "source": "tracker",
-        "provider_instance": "CW-P02",
-        "workspace": "default",
-        "items": {"movie:manual": {"title": "Manual", "type": "movie"}},
-        "blocks": ["movie:base"],
-    })
-    adds, blocks = editor_api._load_policy_manual("watchlist", "CROSSWATCH", "CW-P02")
-
-    assert res["provider_instance"] == "CW-P02"
-    assert list(adds.values()) == [{"title": "Manual", "type": "movie"}]
-    assert blocks == ["movie:base"]
-    assert editor_api._load_policy_manual("watchlist", "CROSSWATCH", "default") == ({}, [])
+    try:
+        editor_api.api_editor_save_state({"kind": "watchlist", "source": "tracker", "items": {}})
+    except Exception as exc:
+        assert getattr(exc, "status_code", None) == 400
+    else:
+        raise AssertionError("tracker source should not save")
 
 
 def test_tracker_archive_json_import_uses_crosswatch_profile_snapshot_dir(tmp_path: Path, monkeypatch) -> None:
@@ -320,6 +276,65 @@ def test_maintenance_tracker_archive_uses_profile_selector_toolbar() -> None:
     assert "menuMinWidth" in icon_select_js
     assert "menuClassName" in icon_select_js
     assert "{ ...cfg, className:" in profile_select_js
+
+
+def test_maintenance_tracker_archive_exports_and_imports_profile_storage(tmp_path: Path, monkeypatch) -> None:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    config_dir = tmp_path / "config"
+    cache_dir = tmp_path / "cache"
+    state_dir = tmp_path / "state"
+    root = config_dir / ".cw_provider"
+    profile_root = root / "profiles" / "CW-P01"
+    snapshot_root = profile_root / "snapshots"
+    snapshot_root.mkdir(parents=True)
+    cfg = {"crosswatch": {"root_dir": str(root), "instances": {"CW-P01": {"label": "Desk"}}}}
+    (config_dir / "config.json").write_text(json.dumps(cfg), "utf-8")
+    (profile_root / "watchlist.json").write_text('{"items":{"tmdb:1":{"title":"One"}}}', "utf-8")
+    (profile_root / "progress.json").write_text('{"items":{"tmdb:2":{"title":"Two"}}}', "utf-8")
+    (snapshot_root / "20260101T000000Z-watchlist.json").write_text('{"items":{}}', "utf-8")
+
+    class Stats:
+        path = config_dir / "statistics.json"
+
+    monkeypatch.setattr(
+        maintenance_api,
+        "_cw",
+        lambda: (cache_dir, config_dir, state_dir, Stats(), lambda: {}, lambda *_args, **_kwargs: None),
+    )
+    monkeypatch.setattr(editor_service, "load_config", lambda: cfg)
+    app = FastAPI()
+    app.include_router(maintenance_api.router)
+    client = TestClient(app)
+
+    status = client.get("/api/maintenance/crosswatch-tracker", params={"provider_instance": "CW-P01"}).json()
+    exported = client.get("/api/maintenance/crosswatch-tracker/export", params={"provider_instance": "CW-P01"})
+
+    assert status["counts"]["state_files"] == 2
+    assert exported.status_code == 200
+    with zipfile.ZipFile(io.BytesIO(exported.content)) as archive:
+        assert set(archive.namelist()) == {
+            "watchlist.json",
+            "progress.json",
+            "snapshots/20260101T000000Z-watchlist.json",
+        }
+
+    for path in profile_root.rglob("*.json"):
+        path.unlink()
+
+    imported = client.post(
+        "/api/maintenance/crosswatch-tracker/import",
+        params={"provider_instance": "CW-P01"},
+        files={"file": ("crosswatch-tracker.zip", exported.content, "application/zip")},
+    ).json()
+
+    assert imported["ok"] is True
+    assert imported["states"] == 2
+    assert imported["snapshots"] == 1
+    assert (profile_root / "watchlist.json").exists()
+    assert (profile_root / "progress.json").exists()
+    assert (snapshot_root / "20260101T000000Z-watchlist.json").exists()
 
 
 def test_crosswatch_profile_delete_removes_profile_storage(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_editor_playlists.py
+++ b/tests/test_editor_playlists.py
@@ -143,13 +143,17 @@ def test_editor_ui_exposes_playlist_source() -> None:
     load_js = (root / "assets" / "js" / "editor" / "load-controller.js").read_text(encoding="utf-8")
     sources_js = (root / "assets" / "js" / "editor" / "sources.js").read_text(encoding="utf-8")
     persistence_js = (root / "assets" / "js" / "editor" / "persistence.js").read_text(encoding="utf-8")
-    assert 'option[value="playlist"]' in chrome_js
+    assert 'sourceSelect.querySelector(\'option[value="playlist"]\')?.remove();' in chrome_js
     assert 'option[value="manual"]' in chrome_js
     assert "Manual Overrides" in chrome_js
     assert "/api/editor/playlists/endpoints" in sources_js
+    assert "function hasPlaylistEndpoints(state)" in sources_js
+    assert "state.playlistEndpointsLoaded = true;" in sources_js
+    assert "if (showPlaylist && !sourceSel.querySelector('option[value=\"playlist\"]'))" in sources_js
     assert "payload.endpoint = state.snapshot" in persistence_js
     assert "state.playlistOriginalKeys" in load_js
-    assert 'const SOURCES = ["state", "manual", "tracker", "playlist"];' in sources_js
+    assert 'const SOURCES = ["state", "manual", "playlist"];' in sources_js
+    assert "/api/editor/tracker/workspaces" not in sources_js
     assert "state.source = ctx.normalizeSource(state.source);" in load_js
 
 
@@ -244,9 +248,8 @@ def test_editor_refresh_is_source_aware() -> None:
     load_js = (root / "assets" / "js" / "editor" / "load-controller.js").read_text(encoding="utf-8")
     assert "function syncSelectedScopeFromControls()" in js
     assert "function syncSelectedScopeFromControls(ctx = {})" in load_js
-    assert "state.workspace = (ctx.snapSel && ctx.snapSel.value)" in load_js
+    assert "state.workspace = (ctx.snapSel && ctx.snapSel.value)" not in load_js
     assert 'state.snapshot = "";' in js
-    assert 'state.snapshot = "";' in load_js
     assert "await refreshEditor({ force: true });" in js or "refreshEditor({ force: true });" in js
     assert 'window.addEventListener("sync-complete"' in js
 
@@ -548,7 +551,7 @@ def test_editor_source_loading_is_extracted() -> None:
     assert "return editorSources.loadSnapshots(sourceContext());" in js
     assert "function syncSourceUI(ctx = {})" in sources_js
     assert "async function loadSnapshots(ctx = {})" in sources_js
-    assert "async function loadTrackerWorkspaces(ctx = {})" in sources_js
+    assert "async function loadTrackerWorkspaces(ctx = {})" not in sources_js
     assert "function rebuildSnapshots(ctx = {})" in sources_js
     assert "function showStateHint(mode, ctx = {})" in sources_js
     assert "window.CrossWatchEditorSources = Editor.Sources;" in sources_js


### PR DESCRIPTION
# Pull request

## Change

- Remove the old Local Tracker source from Editor.
- Only show Playlist Endpoint when playlist endpoints exist.
- Keep the maintenance archive flow working for CW profile storage.

## Why

CW is now the provider path for local tracker data, the separate Editor source was confusing.

## Testing

- tests\test_editor_playlists.py 
- tests\test_crosswatch_profiles.py 

## Issue

NA