### PR TITLE
Change: Punchplay scrobbler destinations

### DIFF
--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -57,6 +57,7 @@ WEBHOOK_SETTING_KEYS = {
     "plex_mdblist_ratings",
     "plex_crosswatch_ratings",
     "plex_floppy_ratings",
+    "plex_punchplay_ratings",
     "pause_debounce_seconds",
     "suppress_start_at",
 }
@@ -266,7 +267,7 @@ def _normalize_webhook_settings(cfg: Mapping[str, Any], provider: str, body: Map
         if key in body:
             out[key] = _normalize_filters(body.get(key), provider, key)
     if provider == "plex":
-        for key in ("plex_trakt_ratings", "plex_simkl_ratings", "plex_mdblist_ratings", "plex_crosswatch_ratings", "plex_floppy_ratings"):
+        for key in ("plex_trakt_ratings", "plex_simkl_ratings", "plex_mdblist_ratings", "plex_crosswatch_ratings", "plex_floppy_ratings", "plex_punchplay_ratings"):
             if key in body:
                 out[key] = bool(body.get(key))
     for key in ("pause_debounce_seconds", "suppress_start_at"):

--- a/assets/js/modals/scrobbler-route/index.js
+++ b/assets/js/modals/scrobbler-route/index.js
@@ -1,6 +1,6 @@
 /* CrossWatch - Scrobbler Route Modal */
 const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
-const label = (v) => ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", kodi: "Kodi", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
+const label = (v) => ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", kodi: "Kodi", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy", punchplay: "PunchPlay" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
 const sources = ["plex", "jellyfin", "emby", "kodi"];
 const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay"];
 const ratingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay"];

--- a/assets/js/modals/scrobbler-webhook/index.js
+++ b/assets/js/modals/scrobbler-webhook/index.js
@@ -1,6 +1,6 @@
 /* CrossWatch - Scrobbler Webhook Modal */
 const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
-const label = (v) => window.CW?.ProviderMeta?.label?.(v) || ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
+const label = (v) => window.CW?.ProviderMeta?.label?.(v) || ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy", punchplay: "PunchPlay" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
 const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay"];
 const ratingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay"];
 const webhookSources = new Set(["plex", "jellyfin", "emby"]);
@@ -271,29 +271,38 @@ function sinksUsedBySource() {
     .map((w) => String(w.sink || "").toLowerCase()));
 }
 
+function availableSinks() {
+  return sinks.filter((s) => sinkProfiles(s).length > 0);
+}
+
+function availableRatingSinks() {
+  return ratingSinks.filter((s) => sinkProfiles(s).length > 0);
+}
+
 function selectedSinkKey() {
   const cur = selectedWebhook();
-  if (cur.sink) return String(cur.sink).toLowerCase();
+  const current = String(cur.sink || "").toLowerCase();
+  if (current && sinkProfiles(current).length) return current;
   const used = sinksUsedBySource();
-  return sinks.find((s) => sinkProfiles(s).length && !used.has(s)) || sinks.find((s) => sinkProfiles(s).length) || "trakt";
+  const available = availableSinks();
+  return available.find((s) => !used.has(s)) || available[0] || "";
 }
 
 function selectedSinkInstance(sink) {
   const cur = selectedWebhook();
   if (String(cur.sink || "").toLowerCase() === sink && cur.sink_instance) return String(cur.sink_instance);
-  return String(sinkProfiles(sink)[0]?.instance || "default");
+  return String(sinkProfiles(sink)[0]?.instance || "");
 }
 
 function sinkSelect(current) {
-  return sinks.map((s) => {
-    const ok = sinkProfiles(s).length > 0;
-    return `<option value="${esc(s)}" ${s === current ? "selected" : ""} ${ok ? "" : "disabled"}>${esc(label(s))}${ok ? "" : " (not connected)"}</option>`;
-  }).join("");
+  const available = availableSinks();
+  if (!available.length) return `<option value="" selected disabled>No configured destination provider</option>`;
+  return available.map((s) => `<option value="${esc(s)}" ${s === current ? "selected" : ""}>${esc(label(s))}</option>`).join("");
 }
 
 function sinkProfileSelect(sink, currentInst) {
   const profiles = sinkProfiles(sink);
-  if (!profiles.length) return `<option value="default">Not connected</option>`;
+  if (!profiles.length) return `<option value="" selected disabled>No configured profile</option>`;
   const cur = String(currentInst || "default");
   return profiles.map((p) => `<option value="${esc(p.instance)}" ${p.instance === cur ? "selected" : ""}>${esc(profileName(p.instance))}</option>`).join("");
 }
@@ -324,6 +333,7 @@ function fieldIcon(icon, labelText, html) {
 function sourcePanel(current) {
   const sink = selectedSinkKey();
   const sinkInst = selectedSinkInstance(sink);
+  const sinkDisabled = sink ? "" : "disabled";
   return `
     <section class="scrm-panel ${activeTab === "source" ? "active" : ""}" data-panel="source">
       <div class="scrm-journey scrm-journey-compact">
@@ -343,8 +353,8 @@ function sourcePanel(current) {
         <div class="scrm-provider-card ${providerClass(sink)}">
           <div class="scrm-card-head"><span class="scrm-provider-mark">${providerIcon(sink)}</span><div><strong>Destination</strong><small>${esc(label(sink))}</small></div></div>
           <div class="scrm-fields">
-            ${fieldIcon("gps_fixed", "Tracker", `<select class="input" id="scw-sink">${sinkSelect(sink)}</select>`)}
-            ${fieldIcon("person", "Profile", `<select class="input" id="scw-sink-instance">${sinkProfileSelect(sink, sinkInst)}</select>`)}
+            ${fieldIcon("gps_fixed", "Tracker", `<select class="input" id="scw-sink" ${sinkDisabled}>${sinkSelect(sink)}</select>`)}
+            ${fieldIcon("person", "Profile", `<select class="input" id="scw-sink-instance" ${sinkDisabled}>${sinkProfileSelect(sink, sinkInst)}</select>`)}
           </div>
         </div>
       </div>
@@ -404,11 +414,12 @@ function filtersPanel(provider, filt) {
 
 function globalRatingTargets() {
   const g = props.overview?.source_state?.global_plex_ratings || {};
-  return ratingSinks.filter((s) => g[s]);
+  return availableRatingSinks().filter((s) => g[s]);
 }
 
 function ratingsPanel(provider, ratingsTargets) {
   if (provider !== "plex") return "";
+  const targets = availableRatingSinks();
   const globalTargets = globalRatingTargets();
   const globalWarn = globalTargets.length
     ? `<div class="scrm-note is-warn"><span class="material-symbols-rounded">warning</span><span>Global Plex ratings is on and already forwarding to <strong>${esc(globalTargets.map(label).join(", "))}</strong>. This webhook sends ratings <em>in addition</em> to the global one — only enable trackers here if this profile needs different destinations.</span></div>`
@@ -420,7 +431,7 @@ function ratingsPanel(provider, ratingsTargets) {
         <div><strong>Plex ratings</strong><p>Forward Plex ratings received on this webhook to the selected trackers.</p></div>
       </div>
       ${globalWarn}
-      <div class="scrm-targets">${ratingSinks.map((sink) => `<label class="scrm-target"><input type="checkbox" data-rating="${esc(sink)}" ${ratingsTargets.includes(sink) ? "checked" : ""}><span class="scrm-target-mark">${providerIcon(sink)}</span><span>${esc(label(sink))}</span></label>`).join("")}</div>
+      <div class="scrm-targets">${targets.length ? targets.map((sink) => `<label class="scrm-target"><input type="checkbox" data-rating="${esc(sink)}" ${ratingsTargets.includes(sink) ? "checked" : ""}><span class="scrm-target-mark">${providerIcon(sink)}</span><span>${esc(label(sink))}</span></label>`).join("") : `<span class="scrm-muted">No configured rating destinations</span>`}</div>
     </section>
   `;
 }
@@ -540,7 +551,7 @@ function payload() {
   const instance = src.instance || "default";
   const body = { provider, provider_instance: instance };
   const sink = String(root.querySelector("#scw-sink")?.value || "").trim().toLowerCase();
-  if (sink && sinks.includes(sink)) {
+  if (sink && availableSinks().includes(sink)) {
     body.sinks = [sink];
     body.sink_instances = { [sink]: root.querySelector("#scw-sink-instance")?.value || "default" };
     if (originalSink && originalSink !== sink) body.prev_sink = originalSink;

--- a/providers/scrobble/routes.py
+++ b/providers/scrobble/routes.py
@@ -9,8 +9,8 @@ from cw_platform.provider_instances import get_provider_block, normalize_instanc
 
 DEFAULT_INSTANCE_ID = "default"
 ROUTE_PROVIDERS = {"plex", "emby", "jellyfin", "kodi"}
-ROUTE_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy"}
-ROUTE_RATING_SINKS = {"trakt", "simkl", "mdblist"}
+ROUTE_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay"}
+ROUTE_RATING_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay"}
 ROUTE_OPTION_STATES = {"inherit", "on", "off"}
 ROUTE_RATINGS_MODES = {"off", "custom"}
 ROUTE_SCROBBLE_POLICY_RANGES = {

--- a/providers/webhooks/config.py
+++ b/providers/webhooks/config.py
@@ -9,13 +9,14 @@ from typing import Any
 
 from cw_platform.provider_instances import get_provider_block, normalize_instance_id
 
-_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy"}
+_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay"}
 
 _SINK_CREDENTIALS: dict[str, tuple[str, ...]] = {
     "trakt": ("access_token",),
     "simkl": ("access_token",),
     "mdblist": ("api_key", "access_token"),
     "floppy": ("server_url", "api_token"),
+    "punchplay": ("access_token",),
 }
 
 _MEDIA_CREDENTIALS: dict[str, tuple[str, ...]] = {

--- a/tests/test_punchplay_scrobble.py
+++ b/tests/test_punchplay_scrobble.py
@@ -77,6 +77,30 @@ def test_sink_is_registered_in_the_factory() -> None:
     assert isinstance(made, PunchPlaySink)
 
 
+def test_punchplay_is_available_as_configured_watcher_destination() -> None:
+    from api.scrobblerManagementAPI import _destination_availability
+    from providers.scrobble.routes import ROUTE_RATING_SINKS, ROUTE_SINKS, build_route_cfg, normalize_route
+    from providers.webhooks.config import sink_configured, webhook_sinks
+
+    cfg = {
+        "plex": {"account_token": "source-token"},
+        "punchplay": {"access_token": "at", "device_id": "crosswatch-abc"},
+        "scrobble": {"webhook": {"sinks": ["punchplay"]}},
+    }
+    route = normalize_route({"id": "R1", "provider": "plex", "sink": "punchplay"}, "R1")
+    view = build_route_cfg(cfg, route)
+
+    assert "punchplay" in ROUTE_SINKS
+    assert "punchplay" in ROUTE_RATING_SINKS
+    assert route["sink"] == "punchplay"
+    assert view["punchplay"]["access_token"] == "at"
+    assert sink_configured(cfg, "punchplay", "default") is True
+    assert "punchplay" in webhook_sinks(cfg, "plex", "default")
+
+    availability = {row["provider"]: row for row in _destination_availability(cfg)}
+    assert availability["punchplay"]["profiles"][0]["configured"] is True
+
+
 def test_start_pause_resume_stop_lifecycle(sink) -> None:
     s, calls = sink
 
@@ -110,14 +134,81 @@ def test_new_session_key_gets_a_new_session_id(sink) -> None:
     assert calls[0]["json"]["playback_session_id"] != calls[1]["json"]["playback_session_id"]
 
 
-def test_stop_below_threshold_is_downgraded_to_pause(sink) -> None:
+def test_stop_below_threshold_is_an_incomplete_stop(sink) -> None:
     s, calls = sink
 
     s.send(Event(action="start", progress=5.0))
     s.send(Event(action="stop", progress=40.0))
 
-    assert [_action_of(c) for c in calls] == ["start", "pause"]
-    assert "watched" not in calls[1]["json"]
+    assert [_action_of(c) for c in calls] == ["start", "stop"]
+    assert calls[1]["json"]["watched"] is False, "an incomplete stop saves resume progress, never a watch"
+
+
+def test_pause_without_a_live_session_becomes_an_incomplete_stop(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="pause", progress=40.0))
+
+    assert [_action_of(c) for c in calls] == ["stop"], "a standalone pause is rejected with 409"
+    assert calls[0]["json"]["watched"] is False
+
+
+def test_failed_start_is_retried_as_a_start(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.punchplay import sink as s
+
+    calls: list[str] = []
+    codes = iter([500, 200, 200])
+
+    def fake(adapter: Any, method: str, url: str, **kw: Any) -> _Resp:
+        calls.append(url.rsplit("/", 1)[-1])
+        return _Resp(next(codes, 200), {"error": "server_error"})
+
+    monkeypatch.setattr(s, "punchplay_request", fake)
+    s._SESSIONS.clear()
+
+    a = s.PunchPlaySink(cfg_provider=lambda: dict(CFG))
+    a.send(Event(action="start", progress=1.0))
+    a.send(Event(action="start", progress=5.0))
+
+    assert calls == ["start", "start"], "a rejected start must not leave a phantom local session"
+    assert len(s._SESSIONS) == 1
+
+
+def test_failed_stop_keeps_the_session_for_a_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.punchplay import sink as s
+
+    calls: list[str] = []
+    codes = iter([200, 500, 200])
+
+    def fake(adapter: Any, method: str, url: str, **kw: Any) -> _Resp:
+        calls.append(url.rsplit("/", 1)[-1])
+        return _Resp(next(codes, 200), {"error": "server_error"})
+
+    monkeypatch.setattr(s, "punchplay_request", fake)
+    s._SESSIONS.clear()
+
+    a = s.PunchPlaySink(cfg_provider=lambda: dict(CFG))
+    a.send(Event(action="start", progress=5.0))
+    a.send(Event(action="stop", progress=95.0))
+    a.send(Event(action="stop", progress=95.0))
+
+    assert calls == ["start", "stop", "stop"]
+
+
+def test_zero_threshold_omits_watched_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.punchplay import sink as s
+
+    captured: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        s, "punchplay_request",
+        lambda adapter, method, url, **kw: captured.append(kw["json"]) or _Resp(200, {}),
+    )
+    s._SESSIONS.clear()
+
+    cfg = {**CFG, "scrobble": {"punchplay": {"watched_at": 0}}}
+    s.PunchPlaySink(cfg_provider=lambda: cfg).send(Event(action="stop", progress=95.0))
+
+    assert "watched_threshold" not in captured[0], "the spec requires watched_threshold > 0"
 
 
 def test_stop_above_threshold_marks_watched(sink) -> None:
@@ -154,11 +245,34 @@ def test_episode_payload_carries_season_and_episode(sink) -> None:
     s, calls = sink
 
     s.send(Event(action="start", media_type="episode", season=1, number=2,
-                 ids={"tmdb": "95396"}, title="Severance"))
+                 ids={"tmdb": "5978363", "tmdb_show": "95396"}, title="Severance"))
     p = calls[0]["json"]
 
     assert p["media_type"] == "episode"
     assert p["season"] == 1 and p["episode"] == 2
+
+
+def test_episode_payload_identifies_the_show(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", media_type="episode", season=6, number=2,
+                 ids={"tmdb": "5978363", "imdb": "tt35707151", "tvdb": "10958852",
+                      "tmdb_show": "69478", "imdb_show": "tt5834204", "tvdb_show": "328487"},
+                 title="The Handmaid's Tale"))
+    p = calls[0]["json"]
+
+    assert p["tmdb_id"] == 69478, "episode playback must identify the show, not the episode"
+    assert p["imdb_id"] == "tt5834204"
+    assert p["tvdb_id"] == 328487
+
+
+def test_episode_without_show_ids_is_skipped(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", media_type="episode", season=1, number=2,
+                 ids={"tmdb": "5978363"}, title="Severance"))
+
+    assert calls == []
 
 
 def test_episode_without_numbering_is_skipped(sink) -> None:
@@ -406,30 +520,49 @@ def test_rating_sink_lists_include_punchplay() -> None:
         "assets/js/modals/scrobbler-webhook/index.js",
     ):
         text = (root / rel).read_text(encoding="utf-8")
+        assert '"punchplay"' in text.split("const sinks")[1].split("]")[0], rel
         assert '"punchplay"' in text.split("ratingSinks")[1].split("]")[0], rel
+        assert 'punchplay: "PunchPlay"' in text, rel
+
+    webhook = (root / "assets/js/modals/scrobbler-webhook/index.js").read_text(encoding="utf-8")
+    assert '" (not connected)"' not in webhook
+    assert "availableSinks().includes(sink)" in webhook
+    assert "availableRatingSinks()" in webhook
 
     api = (root / "api" / "scrobblerManagementAPI.py").read_text(encoding="utf-8")
     assert '"punchplay": bool(watch.get("plex_punchplay_ratings"))' in api
+    assert '"plex_punchplay_ratings"' in api
 
 
-def test_payload_validates_against_the_spec() -> None:
-    import yaml
-    from pathlib import Path
+# PlaybackInput from https://docs.punchplay.tv/openapi.yaml; the schema is additionalProperties: false
+PLAYBACK_INPUT_FIELDS = {
+    "event_id", "media_type", "title", "year", "imdb_id", "tmdb_id", "tvdb_id", "punchplay_id",
+    "season", "episode", "episode_end", "absolute_episode", "episode_title", "multi_episode",
+    "anime", "progress", "duration_seconds", "position_seconds", "device_id",
+    "playback_session_id", "event_created_at", "client_version", "watched", "watched_threshold",
+    "raw_filename", "jellyfin_user_id",
+}
+PLAYBACK_INPUT_REQUIRED = {"event_id", "event_created_at", "media_type", "playback_session_id", "title"}
 
-    spec_path = Path("C:/Users/pasca/AppData/Local/Temp/claude/c--Users-pasca-source-repos-GITHUB-repos-CrossWatch/4849a183-4294-45db-bfc8-af09e4d4b2b8/scratchpad/ppdocs/openapi.yaml")
-    if not spec_path.exists():
-        pytest.skip("openapi.yaml not vendored")
 
-    schema = yaml.safe_load(spec_path.read_text(encoding="utf-8"))["components"]["schemas"]["PlaybackInput"]
-    props = schema.get("properties") or {}
-
+@pytest.mark.parametrize("action,progress", [("start", 5.0), ("pause", 40.0), ("stop", 95.0)])
+def test_payload_validates_against_the_spec(monkeypatch: pytest.MonkeyPatch, action: str, progress: float) -> None:
     from providers.scrobble.punchplay import sink as s
 
     captured: list[dict[str, Any]] = []
-    s.punchplay_request = lambda adapter, method, url, **kw: captured.append(kw["json"]) or _Resp(200, {})  # type: ignore[assignment]
+    monkeypatch.setattr(
+        s, "punchplay_request",
+        lambda adapter, method, url, **kw: captured.append(kw["json"]) or _Resp(200, {}),
+    )
     s._SESSIONS.clear()
-    s.PunchPlaySink(cfg_provider=lambda: dict(CFG)).send(Event(action="stop", progress=95.0))
 
-    payload = captured[0]
-    for key in payload:
-        assert key in props, f"field {key!r} is not declared in PlaybackInput"
+    a = s.PunchPlaySink(cfg_provider=lambda: dict(CFG))
+    a.send(Event(action="start", progress=1.0))
+    a.send(Event(action=action, progress=progress))
+
+    for payload in captured:
+        unknown = set(payload) - PLAYBACK_INPUT_FIELDS
+        assert not unknown, f"fields not declared in PlaybackInput: {sorted(unknown)}"
+        assert PLAYBACK_INPUT_REQUIRED <= set(payload)
+        assert 0.0 <= payload["progress"] <= 1.0
+        assert payload.get("watched_threshold", 1.0) > 0.0


### PR DESCRIPTION
# Pull request

## Change

- Adds Punchplay to scrobbler watcher and webhook destinations.
- Hides disconnected webhook destinations from the picker.

## Why

Punchplay could be connected but still show as unavailable.

## Testing

- tests/test_punchplay_scrobble.py

## Issue

NA