### PR TITLE
Change: stop CW tracker reads writing state

### DIFF
--- a/providers/sync/crosswatch/_common.py
+++ b/providers/sync/crosswatch/_common.py
@@ -196,6 +196,15 @@ def _restore_state_path(adapter: Any, stem: str) -> Path:
 
 # Write
 
+def readonly(adapter: Any) -> bool:
+    cfg = getattr(adapter, "config", None)
+    return bool(isinstance(cfg, Mapping) and cfg.get("_cw_readonly"))
+
+
+def may_persist(adapter: Any, path: Path) -> bool:
+    return not readonly(adapter) and not pair_scoped() and not path.exists()
+
+
 def _atomic_write(path: Path, payload: Any) -> None:
     if _capture_mode() or _pair_scope() is None:
         return
@@ -354,7 +363,7 @@ def _maybe_restore(
     feature: str,
     save_fn: Callable[[Any, Mapping[str, Any]], None],
 ) -> None:
-    if _capture_mode():
+    if _capture_mode() or readonly(adapter):
         return
     cfg = getattr(adapter, "cfg", None)
     restore_id = getattr(cfg, f"restore_{feature}", None)

--- a/providers/sync/crosswatch/_history.py
+++ b/providers/sync/crosswatch/_history.py
@@ -22,7 +22,9 @@ from ._common import (
     latest_snapshot_file,
     latest_state_file,
     make_logger,
+    may_persist,
     pair_scoped,
+    readonly,
     scoped_file,
     state_file_for_read,
 )
@@ -126,7 +128,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
                 continue
             items[key] = _history_minimal(adapter, obj, key)
         state = {"ts": 0, "items": items}
-        if not pair_scoped() and items and not path.exists():
+        if items and may_persist(adapter, path):
             _atomic_write(path, {"ts": int(time.time()), "items": items})
         return state
 
@@ -143,7 +145,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
                     continue
                 items[ck] = _history_minimal(adapter, value, key)
             state = {"ts": ts, "items": items}
-            if not pair_scoped() and items and not path.exists():
+            if items and may_persist(adapter, path):
                 _atomic_write(path, {"ts": ts or int(time.time()), "items": items})
             return state
 
@@ -156,7 +158,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
                 continue
             items[ck] = _history_minimal(adapter, value, key)
         state = {"ts": 0, "items": items}
-        if not pair_scoped() and items and not path.exists():
+        if items and may_persist(adapter, path):
             _atomic_write(path, {"ts": int(time.time()), "items": items})
         return state
 
@@ -164,7 +166,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
 
 
 def _save_state(adapter: Any, items: Mapping[str, Mapping[str, Any]]) -> None:
-    if _capture_mode() or _pair_scope() is None:
+    if _capture_mode() or readonly(adapter) or _pair_scope() is None:
         return
     payload = {"ts": int(time.time()), "items": dict(items or {})}
     _atomic_write(_history_path(adapter), payload)

--- a/providers/sync/crosswatch/_progress.py
+++ b/providers/sync/crosswatch/_progress.py
@@ -22,7 +22,9 @@ from ._common import (
     latest_snapshot_file,
     latest_state_file,
     make_logger,
+    may_persist,
     pair_scoped,
+    readonly,
     scoped_file,
     state_file_for_read,
 )
@@ -225,7 +227,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
                 continue
             items[key] = accepted
         state = {"ts": 0, "items": items}
-        if not pair_scoped() and items and not path.exists():
+        if items and may_persist(adapter, path):
             _atomic_write(path, {"ts": int(time.time()), "items": items})
         return state
 
@@ -246,7 +248,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
                     continue
                 items2[ck] = accepted
             state = {"ts": ts, "items": items2}
-            if not pair_scoped() and items2 and not path.exists():
+            if items2 and may_persist(adapter, path):
                 _atomic_write(path, {"ts": ts or int(time.time()), "items": items2})
             return state
 
@@ -263,7 +265,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
                 continue
             items3[ck] = accepted
         state = {"ts": 0, "items": items3}
-        if not pair_scoped() and items3 and not path.exists():
+        if items3 and may_persist(adapter, path):
             _atomic_write(path, {"ts": int(time.time()), "items": items3})
         return state
 
@@ -271,7 +273,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
 
 
 def _save_state(adapter: Any, items: Mapping[str, Mapping[str, Any]]) -> None:
-    if _capture_mode() or _pair_scope() is None:
+    if _capture_mode() or readonly(adapter) or _pair_scope() is None:
         return
     payload = {"ts": int(time.time()), "items": dict(items or {})}
     _atomic_write(_progress_path(adapter), payload)

--- a/providers/sync/crosswatch/_ratings.py
+++ b/providers/sync/crosswatch/_ratings.py
@@ -22,7 +22,9 @@ from ._common import (
     latest_snapshot_file,
     latest_state_file,
     make_logger,
+    may_persist,
     pair_scoped,
+    readonly,
     scoped_file,
     state_file_for_read,
 )
@@ -117,7 +119,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
                 continue
             items[key] = _accepted(obj)
         state = {"ts": 0, "items": items}
-        if not pair_scoped() and items and not path.exists():
+        if items and may_persist(adapter, path):
             _atomic_write(path, {"ts": int(time.time()), "items": items})
         return state
 
@@ -134,7 +136,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
                     continue
                 items2[ck] = _accepted(value)
             state = {"ts": ts, "items": items2}
-            if not pair_scoped() and items2 and not path.exists():
+            if items2 and may_persist(adapter, path):
                 _atomic_write(path, {"ts": ts or int(time.time()), "items": items2})
             return state
 
@@ -147,7 +149,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
                 continue
             items3[ck] = _accepted(value)
         state = {"ts": 0, "items": items3}
-        if not pair_scoped() and items3 and not path.exists():
+        if items3 and may_persist(adapter, path):
             _atomic_write(path, {"ts": int(time.time()), "items": items3})
         return state
 
@@ -155,7 +157,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
 
 
 def _save_state(adapter: Any, items: Mapping[str, Mapping[str, Any]]) -> None:
-    if _capture_mode() or _pair_scope() is None:
+    if _capture_mode() or readonly(adapter) or _pair_scope() is None:
         return
     payload = {"ts": int(time.time()), "items": dict(items or {})}
     _atomic_write(_ratings_path(adapter), payload)

--- a/providers/sync/crosswatch/_watchlist.py
+++ b/providers/sync/crosswatch/_watchlist.py
@@ -24,7 +24,9 @@ from ._common import (
     latest_snapshot_file,
     latest_state_file,
     make_logger,
+    may_persist,
     pair_scoped,
+    readonly,
     scoped_file,
     state_file_for_read,
 )
@@ -138,7 +140,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
                 continue
             items[key] = id_minimal(obj)
         state = {"ts": 0, "items": items}
-        if not pair_scoped() and items and not path.exists():
+        if items and may_persist(adapter, path):
             _atomic_write(path, {"ts": int(time.time()), "items": items})
         return state
     if isinstance(raw, Mapping):
@@ -154,7 +156,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
                     continue
                 items2[ck] = id_minimal(value)
             state = {"ts": ts, "items": items2}
-            if not pair_scoped() and items2 and not path.exists():
+            if items2 and may_persist(adapter, path):
                 _atomic_write(path, {"ts": ts or int(time.time()), "items": items2})
             return state
         items3: dict[str, dict[str, Any]] = {}
@@ -166,14 +168,14 @@ def _load_state(adapter: Any) -> dict[str, Any]:
                 continue
             items3[ck] = id_minimal(value)
         state = {"ts": 0, "items": items3}
-        if not pair_scoped() and items3 and not path.exists():
+        if items3 and may_persist(adapter, path):
             _atomic_write(path, {"ts": int(time.time()), "items": items3})
         return state
     return {"ts": 0, "items": {}}
 
 
 def _save_state(adapter: Any, items: Mapping[str, Mapping[str, Any]]) -> None:
-    if _capture_mode() or _pair_scope() is None:
+    if _capture_mode() or readonly(adapter) or _pair_scope() is None:
         return
     payload = {"ts": int(time.time()), "items": dict(items or {})}
     _atomic_write(_watchlist_path(adapter), payload)


### PR DESCRIPTION
# Pull request

## Change

- Add a readonly flag to the CW tracker, set through `_cw_readonly` on the provider config
- Skip the snapshot self-heal write on all 12 read paths across history, ratings, watchlist and progress when the flag is set
- Make `_save_state` and `_maybe_restore` no-ops when the flag is set

## Why

Reading the tracker could write to it. When the live state file is missing but a snapshot is still there, the read path rebuilds the state file from that snapshot. 
That is fine during a sync, but the importer preview and the editor both go through the same read path, so previewing a file straight after clearing the tracker put everything back and then reported it all as already present.

## Testing

-  tests/test_importer.py

## Issue

NA
