### PR TITLE
Fix: Support download timeout

### DIFF
--- a/assets/js/modals/support/index.js
+++ b/assets/js/modals/support/index.js
@@ -3,6 +3,8 @@
 /* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
 
 const REQUEST_TIMEOUT_MS = 45_000;
+const DOWNLOAD_TIMEOUT_MS = 600_000;
+const timeoutError = (label, ms) => new Error(`${label} timed out after ${Math.round(ms / 1000)}s`);
 const SECTIONS = [
   { key: "config", label: "Redacted config", desc: "config.json with tokens, keys and hashes masked." },
   { key: "diagnostics", label: "Diagnostics", desc: "Database and event-archive health, environment, baseline shape." },
@@ -15,7 +17,7 @@ const esc = (value) => String(value ?? "").replace(/[&<>"]/g, (ch) => ({ "&": "&
 
 async function fjson(url) {
   const ctrl = new AbortController();
-  const timer = window.setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
+  const timer = window.setTimeout(() => ctrl.abort(timeoutError("Request", REQUEST_TIMEOUT_MS)), REQUEST_TIMEOUT_MS);
   try {
     const r = await fetch(url, { cache: "no-store", signal: ctrl.signal });
     if (!r.ok) throw new Error(`${r.status} ${r.statusText || ""}`.trim());
@@ -27,7 +29,7 @@ async function fjson(url) {
 
 async function fblob(url) {
   const ctrl = new AbortController();
-  const timer = window.setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
+  const timer = window.setTimeout(() => ctrl.abort(timeoutError("Download", DOWNLOAD_TIMEOUT_MS)), DOWNLOAD_TIMEOUT_MS);
   try {
     const r = await fetch(url, { cache: "no-store", signal: ctrl.signal });
     if (!r.ok) throw new Error(`${r.status} ${r.statusText || ""}`.trim());

--- a/tests/test_support_export.py
+++ b/tests/test_support_export.py
@@ -2,10 +2,35 @@ from __future__ import annotations
 
 import io
 import json
+import re
 import zipfile
+from pathlib import Path
 
 from cw_platform.orchestrator._state_store import StateStore
 from services import support
+
+REPO = Path(__file__).resolve().parents[1]
+SUPPORT_JS = REPO / "assets" / "js" / "modals" / "support" / "index.js"
+
+
+def test_support_download_does_not_reuse_the_metadata_timeout() -> None:
+    js = SUPPORT_JS.read_text(encoding="utf-8")
+
+    fblob = js.split("async function fblob(")[1].split("\n}")[0]
+    assert "DOWNLOAD_TIMEOUT_MS" in fblob
+    assert "REQUEST_TIMEOUT_MS" not in fblob
+
+    download_ms = int(re.search(r"DOWNLOAD_TIMEOUT_MS\s*=\s*([\d_]+)", js).group(1).replace("_", ""))
+    request_ms = int(re.search(r"REQUEST_TIMEOUT_MS\s*=\s*([\d_]+)", js).group(1).replace("_", ""))
+    assert download_ms > request_ms
+
+
+def test_support_aborts_carry_a_reason_so_the_ui_never_says_user_aborted() -> None:
+    js = SUPPORT_JS.read_text(encoding="utf-8")
+
+    assert "ctrl.abort()" not in js
+    for call in re.findall(r"ctrl\.abort\((.*?)\), \w+_TIMEOUT_MS\)", js):
+        assert call.strip().startswith("timeoutError(")
 
 
 def _baseline(items: dict) -> dict:


### PR DESCRIPTION
# Pull request

## Change

- Support downloads no longer reuse the 45s timeout meant for the scopes call. 
- State and bundle get their own 600s budget, and both aborts now pass a reason so a timeout reports as a timeout.

Behind a reverse proxy this is only half the story, the proxy read timeout still applies since the endpoints send nothing until the whole payload is built.

## Why

Bundle build time scales with item count, and on big libraries it ran past 45s. 
The timer fired, abort was called with no reason, so the browser default message got shown and a timeout looked like the user cancelled it.

## Testing

- test_support_export.py
- Cold measurements: 26s at 200k items, 69s at 500k.

## Issue

NA