### PR TITLE
Add: Scrob playback and webhook support

### DIFF
--- a/cw_platform/provider_usage.py
+++ b/cw_platform/provider_usage.py
@@ -30,6 +30,10 @@ _PROVIDER_LABELS = {
     "trakt": "Trakt",
     "simkl": "SIMKL",
     "mdblist": "MDBList",
+    "crosswatch": "CrossWatch",
+    "floppy": "Floppy",
+    "punchplay": "PunchPlay",
+    "scrob": "Scrob",
 }
 
 
@@ -120,6 +124,7 @@ def _enabled_webhook_sources(cfg: Mapping[str, Any]) -> list[tuple[str, str]]:
 
 
 def _webhook_usage(cfg: Mapping[str, Any], provider: str, instance: str) -> list[dict[str, Any]]:
+    from providers.scrobble.routes import ROUTE_SINKS
     from providers.webhooks.config import webhook_settings, webhook_sink_instance, webhook_sinks
 
     out: list[dict[str, Any]] = []
@@ -137,7 +142,7 @@ def _webhook_usage(cfg: Mapping[str, Any], provider: str, instance: str) -> list
             )
             continue
 
-        if provider not in {"trakt", "simkl", "mdblist"}:
+        if provider not in ROUTE_SINKS:
             continue
 
         settings = webhook_settings(cfg, source_prov, source_inst)

--- a/providers/webhooks/config.py
+++ b/providers/webhooks/config.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from cw_platform.provider_instances import get_provider_block, normalize_instance_id
 
-_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay"}
+_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "scrob"}
 
 _SINK_CREDENTIALS: dict[str, tuple[str, ...]] = {
     "trakt": ("access_token",),
@@ -17,6 +17,7 @@ _SINK_CREDENTIALS: dict[str, tuple[str, ...]] = {
     "mdblist": ("api_key", "access_token"),
     "floppy": ("server_url", "api_token"),
     "punchplay": ("access_token",),
+    "scrob": ("api_key",),
 }
 
 _MEDIA_CREDENTIALS: dict[str, tuple[str, ...]] = {

--- a/providers/webhooks/dispatch.py
+++ b/providers/webhooks/dispatch.py
@@ -81,6 +81,14 @@ def _make_sink(name: str, instance_id: str, cfg_provider: Callable[[], dict[str,
         from providers.scrobble.floppy.sink import FloppySink
 
         cls = FloppySink
+    elif sink == "punchplay":
+        from providers.scrobble.punchplay.sink import PunchPlaySink
+
+        cls = PunchPlaySink
+    elif sink == "scrob":
+        from providers.scrobble.scrob.sink import ScrobSink
+
+        cls = ScrobSink
     else:
         raise ValueError(f"Unknown sink: {sink}")
     for kwargs in (

--- a/services/playback_progress/adapters/scrob.py
+++ b/services/playback_progress/adapters/scrob.py
@@ -1,0 +1,284 @@
+# /services/playback_progress/adapters/scrob.py
+# CrossWatch - Scrob Playback Progress Adapter
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any, Mapping, cast
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from providers.sync._mod_SCROB import OPS as SCROB_OPS
+from providers.sync.scrob._progress import MEDIA_ID_FIELD
+
+from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
+from .base import PlaybackProgressAdapter, public_failure
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _num(value: Any) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(float(str(value).strip()))
+    except Exception:
+        return None
+
+
+def _float(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(str(value).strip())
+    except Exception:
+        return None
+
+
+def _duration_seconds(item: Mapping[str, Any]) -> int | None:
+    duration = _num(item.get("duration_ms"))
+    return max(1, round(duration / 1000)) if duration and duration > 0 else None
+
+
+def _position_seconds(item: Mapping[str, Any]) -> int | None:
+    position = _num(item.get("progress_ms"))
+    return max(0, round(position / 1000)) if position is not None else None
+
+
+def _remaining_seconds(item: Mapping[str, Any]) -> int | None:
+    duration = _num(item.get("duration_ms"))
+    position = _num(item.get("progress_ms"))
+    if duration is None or position is None or duration <= 0:
+        return None
+    return max(0, round((duration - position) / 1000))
+
+
+def _progress_percent(item: Mapping[str, Any]) -> float | None:
+    direct = _float(item.get("progress_percent"))
+    if direct is not None:
+        return round(direct, 3)
+    position = _float(item.get("progress_ms"))
+    duration = _float(item.get("duration_ms"))
+    if position is None or duration is None or duration <= 0:
+        return None
+    return round((position / duration) * 100.0, 3)
+
+
+def _progress_item(record: Mapping[str, Any]) -> dict[str, Any]:
+    meta = _mapping(record.get("provider_metadata"))
+    stored = meta.get("progress_item")
+    if isinstance(stored, Mapping):
+        return clean_mapping(stored)
+    media_type = str(record.get("media_type") or "").strip().lower()
+    item: dict[str, Any] = {
+        "type": "episode" if media_type in {"episode", "anime_episode"} else "movie",
+        "ids": clean_mapping(_mapping(record.get("ids"))),
+        "title": record.get("episode_title") or record.get("title") or record.get("series_title"),
+        "year": record.get("year"),
+    }
+    if item["type"] == "episode":
+        item["show_ids"] = clean_mapping(_mapping(meta.get("show_ids"))) or clean_mapping(_mapping(record.get("ids")))
+        item["series_title"] = record.get("series_title")
+        item["season"] = record.get("season")
+        item["episode"] = record.get("episode")
+    duration_seconds = _num(record.get("duration_seconds"))
+    if duration_seconds:
+        item["duration_ms"] = duration_seconds * 1000
+    media_id = str(meta.get(MEDIA_ID_FIELD) or "").strip()
+    if media_id:
+        item[MEDIA_ID_FIELD] = media_id
+    return clean_mapping(item)
+
+
+def _progress_item_with_percent(record: Mapping[str, Any], progress_percent: float) -> dict[str, Any]:
+    item = _progress_item(record)
+    duration_ms = _num(item.get("duration_ms"))
+    if duration_ms is None:
+        duration_seconds = _num(record.get("duration_seconds"))
+        if duration_seconds:
+            duration_ms = duration_seconds * 1000
+    percent = round(max(0.0, min(100.0, float(progress_percent))), 3)
+    if duration_ms and duration_ms > 0:
+        item["duration_ms"] = duration_ms
+        item["progress_ms"] = max(1, min(duration_ms - 1, round((percent / 100.0) * float(duration_ms))))
+    item["progress_percent"] = percent
+    item["progress_at"] = utc_now_iso()
+    return clean_mapping(item)
+
+
+class ScrobPlaybackAdapter(PlaybackProgressAdapter):
+    provider = "scrob"
+    provider_label = "Scrob"
+    ops = SCROB_OPS
+
+    def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
+        try:
+            configured = bool(SCROB_OPS.is_configured(config_view))
+        except Exception:
+            configured = False
+        caps = _mapping(SCROB_OPS.capabilities())
+        progress = _mapping(caps.get("progress"))
+        history = _mapping(caps.get("history"))
+        types = progress.get("types")
+        type_set = {str(t).strip().lower() for t in types} if isinstance(types, (list, tuple, set)) else set()
+        reason = "" if configured else "Scrob is not connected for this instance."
+        return PlaybackCapabilities(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            configured=configured,
+            read=bool(configured and progress),
+            remove_progress=bool(configured and progress.get("remove")),
+            mark_watched=bool(configured and history.get("upsert")),
+            update_progress=bool(configured and progress.get("upsert")),
+            bulk_remove_progress=bool(configured and progress.get("remove")),
+            bulk_mark_watched=bool(configured and history.get("upsert")),
+            bulk_update_progress=bool(configured and progress.get("upsert")),
+            supports_movies=bool(configured and "movie" in type_set),
+            supports_episodes=bool(configured and "episode" in type_set),
+            supports_anime=False,
+            reason=reason,
+        )
+
+    def list_progress(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str, force_refresh: bool = False) -> PlaybackListResult:
+        caps = self.capabilities(config_view, instance_id=instance_id, instance_label=instance_label)
+        if not caps.read:
+            return PlaybackListResult(
+                False,
+                self.provider,
+                instance_id,
+                error_code="unsupported" if caps.configured else "not_configured",
+                message=caps.reason or "Scrob does not support playback listing.",
+            )
+        try:
+            index = SCROB_OPS.build_index(config_view, feature="progress", instance_id=instance_id) or {}
+        except Exception:
+            return PlaybackListResult(False, self.provider, instance_id, error_code="provider_error", message="Scrob progress request failed.", retryable=True)
+        items = [self._record(key, item, instance_id, instance_label, caps) for key, item in dict(index).items() if isinstance(item, Mapping)]
+        return PlaybackListResult(True, self.provider, instance_id, items=[item for item in items if item], refreshed_at=utc_now_iso())
+
+    def _record(self, key: Any, item: Mapping[str, Any], instance_id: str, instance_label: str, caps: PlaybackCapabilities) -> PlaybackRecord | None:
+        mini = id_minimal(item)
+        typ = str(mini.get("type") or item.get("type") or "").strip().lower()
+        media_type = "episode" if typ == "episode" else "movie"
+        ids = clean_mapping(_mapping(mini.get("ids") or item.get("ids")))
+        show_ids = clean_mapping(_mapping(mini.get("show_ids") or item.get("show_ids")))
+        title = str(mini.get("title") or item.get("title") or item.get("series_title") or "").strip()
+        series_title = str(mini.get("series_title") or item.get("series_title") or "").strip()
+        canonical = canonical_key(mini) or str(key or "")
+        progress = _progress_percent(item)
+        position = _position_seconds(item)
+        if not canonical or (progress is None and position is None):
+            return None
+        return PlaybackRecord(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            remote_id=str(item.get(MEDIA_ID_FIELD) or key or canonical),
+            canonical_key=canonical,
+            media_type=media_type,
+            title=series_title or title,
+            episode_title=title if media_type == "episode" and title != series_title else "",
+            series_title=series_title,
+            season=_num(mini.get("season") or item.get("season")),
+            episode=_num(mini.get("episode") or item.get("episode")),
+            year=_num(mini.get("year") or item.get("year")),
+            ids=ids,
+            progress_percent=progress,
+            remaining_seconds=_remaining_seconds(item),
+            duration_seconds=_duration_seconds(item),
+            progress_at=str(item.get("progress_at") or "").strip() or None,
+            updated_at=str(item.get("progress_at") or "").strip() or None,
+            can_remove_progress=bool(caps.remove_progress and item.get(MEDIA_ID_FIELD)),
+            can_mark_watched=caps.mark_watched,
+            can_update_progress=bool(caps.update_progress and _duration_seconds(item)),
+            capability_messages=[] if caps.configured else [caps.reason],
+            provider_metadata={
+                "progress_item": clean_mapping(item),
+                "show_ids": show_ids,
+                "position_seconds": position,
+                MEDIA_ID_FIELD: str(item.get(MEDIA_ID_FIELD) or ""),
+            },
+        )
+
+    def remove_progress(self, config_view: Mapping[str, Any], record: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackActionResult:
+        try:
+            result = SCROB_OPS.remove(config_view, [_progress_item(record)], feature="progress", dry_run=False, instance_id=instance_id) or {}
+            ok = bool(result.get("ok")) and bool(result.get("confirmed_keys"))
+            return PlaybackActionResult(
+                ok,
+                self.provider,
+                instance_id,
+                "remove_progress",
+                remote_id=str(record.get("remote_id") or ""),
+                canonical_key=str(record.get("canonical_key") or ""),
+                message="Playback record removed." if ok else "Scrob remove progress failed.",
+                error_code="" if ok else "progress_failed",
+                decision_context=clean_mapping(result),
+            )
+        except Exception:
+            return public_failure(
+                provider=self.provider,
+                instance_id=instance_id,
+                operation="remove_progress",
+                message="Scrob remove progress failed.",
+                retryable=True,
+                remote_id=str(record.get("remote_id") or ""),
+                canonical_key=str(record.get("canonical_key") or ""),
+            )
+
+    def mark_watched(self, config_view: Mapping[str, Any], record: Mapping[str, Any], *, instance_id: str, instance_label: str, watched_at: str | None = None) -> PlaybackActionResult:
+        item = _progress_item(record)
+        item["watched_at"] = watched_at or utc_now_iso()
+        try:
+            result = SCROB_OPS.add(config_view, [item], feature="history", dry_run=False, instance_id=instance_id) or {}
+            ok = bool(result.get("ok")) and bool(result.get("confirmed_keys"))
+            return PlaybackActionResult(
+                ok,
+                self.provider,
+                instance_id,
+                "mark_watched",
+                remote_id=str(record.get("remote_id") or ""),
+                canonical_key=str(record.get("canonical_key") or ""),
+                message="Marked watched on Scrob." if ok else "Scrob mark watched failed.",
+                error_code="" if ok else "history_failed",
+                history_result=clean_mapping(result),
+            )
+        except Exception:
+            return public_failure(
+                provider=self.provider,
+                instance_id=instance_id,
+                operation="mark_watched",
+                message="Scrob mark watched failed.",
+                retryable=True,
+                remote_id=str(record.get("remote_id") or ""),
+                canonical_key=str(record.get("canonical_key") or ""),
+            )
+
+    def update_progress(self, config_view: Mapping[str, Any], record: Mapping[str, Any], progress_percent: float, *, instance_id: str, instance_label: str) -> PlaybackActionResult:
+        try:
+            result = SCROB_OPS.add(config_view, [_progress_item_with_percent(record, progress_percent)], feature="progress", dry_run=False, instance_id=instance_id) or {}
+            ok = bool(result.get("ok")) and bool(result.get("confirmed_keys"))
+            return PlaybackActionResult(
+                ok,
+                self.provider,
+                instance_id,
+                "update_progress",
+                remote_id=str(record.get("remote_id") or ""),
+                canonical_key=str(record.get("canonical_key") or ""),
+                message=f"Progress updated on Scrob to {progress_percent:g}%." if ok else "Scrob update progress failed.",
+                error_code="" if ok else "progress_failed",
+                decision_context=clean_mapping(result),
+            )
+        except Exception:
+            return public_failure(
+                provider=self.provider,
+                instance_id=instance_id,
+                operation="update_progress",
+                message="Scrob update progress failed.",
+                retryable=True,
+                remote_id=str(record.get("remote_id") or ""),
+                canonical_key=str(record.get("canonical_key") or ""),
+            )

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -25,6 +25,7 @@ from .adapters.mdblist import MDBListPlaybackAdapter
 from .adapters.nuvio import NuvioPlaybackAdapter
 from .adapters.publicmetadb import PublicMetaDBPlaybackAdapter
 from .adapters.punchplay import PunchPlayPlaybackAdapter
+from .adapters.scrob import ScrobPlaybackAdapter
 from .adapters.simkl import SimklPlaybackAdapter
 from .adapters.stremio import StremioPlaybackAdapter
 from .adapters.trakt import TraktPlaybackAdapter
@@ -36,7 +37,7 @@ CACHE_TTL_SECONDS = 60.0
 MAX_WORKERS = 6
 DEFAULT_PROVIDER_TIMEOUT_SECONDS = 20.0
 GROUP_PROGRESS_TOLERANCE = 2.0
-PHASE1_PROVIDERS = ("crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "punchplay", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy")
+PHASE1_PROVIDERS = ("crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "punchplay", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy", "scrob")
 SORT_VALUES = {"last_updated", "progress_high", "progress_low", "remaining_time", "rating_high", "title", "provider"}
 LIVE_MEDIA_PROVIDERS = {"plex", "emby", "jellyfin", "kodi"}
 LIVE_ACTIVE_STATES = {"playing", "paused", "buffering"}
@@ -752,6 +753,7 @@ def _profile_has_explicit_identity(cfg: Mapping[str, Any], provider: str, instan
         "stremio": ("auth_key", "authKey"),
         "floppy": ("server_url", "api_token"),
         "punchplay": ("access_token", "refresh_token", "user_id", "username"),
+        "scrob": ("server_url", "api_key", "username"),
     }.get(str(provider or "").strip().lower(), ())
     return any(str(_path_value(raw, path) or "").strip() for path in identity_paths)
 
@@ -824,6 +826,7 @@ class PlaybackProgressService:
             "stremio": StremioPlaybackAdapter(),
             "floppy": FloppyPlaybackAdapter(),
             "punchplay": PunchPlayPlaybackAdapter(),
+            "scrob": ScrobPlaybackAdapter(),
             "crosswatch": CrossWatchPlaybackAdapter(),
         }
         self._cache: dict[tuple[str, str, str], dict[str, Any]] = {}

--- a/tests/test_provider_usage_coverage.py
+++ b/tests/test_provider_usage_coverage.py
@@ -1,0 +1,151 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cw_platform.provider_usage import (
+    WEBHOOK_SOURCE_PROVIDERS,
+    _PROVIDER_LABELS,
+    find_provider_usage,
+    provider_label,
+)
+from providers.scrobble.routes import ROUTE_PROVIDERS, ROUTE_SINKS
+
+
+def webhook_cfg(sinks: list[str]) -> dict[str, Any]:
+    return {
+        "scrobble": {"enabled": True, "sources": {"webhook": True}, "webhook": {"sinks": list(sinks)}},
+        "plex": {"account_token": "t"},
+    }
+
+
+def route_cfg(provider: str, sink: str) -> dict[str, Any]:
+    return {
+        "scrobble": {
+            "enabled": True,
+            "sources": {"watcher": True},
+            "watch": {"routes": [{"id": "R1", "enabled": True, "provider": provider, "sink": sink}]},
+        }
+    }
+
+
+@pytest.mark.parametrize("sink", sorted(ROUTE_SINKS))
+def test_every_webhook_sink_is_protected_from_deletion(sink: str):
+    usages = find_provider_usage(webhook_cfg(sorted(ROUTE_SINKS)), sink)
+    assert usages, f"{sink} is an enabled webhook destination but the delete guard does not see it"
+    assert any(u["feature"] == "webhook" and u["role"] == "sink" for u in usages), usages
+
+
+@pytest.mark.parametrize("sink", sorted(ROUTE_SINKS))
+def test_a_sink_that_is_not_selected_stays_deletable(sink: str):
+    others = [s for s in sorted(ROUTE_SINKS) if s != sink]
+    assert find_provider_usage(webhook_cfg(others), sink) == []
+
+
+@pytest.mark.parametrize("provider", sorted(ROUTE_PROVIDERS))
+def test_every_watcher_route_provider_is_protected(provider: str):
+    usages = find_provider_usage(route_cfg(provider, "trakt"), provider)
+    assert any(u["feature"] == "watcher" and u["role"] == "provider" for u in usages), usages
+
+
+@pytest.mark.parametrize("sink", sorted(ROUTE_SINKS))
+def test_every_watcher_route_sink_is_protected(sink: str):
+    usages = find_provider_usage(route_cfg("plex", sink), sink)
+    assert any(u["feature"] == "watcher" and u["role"] == "sink" for u in usages), usages
+
+
+@pytest.mark.parametrize("provider", sorted(ROUTE_PROVIDERS | ROUTE_SINKS | set(WEBHOOK_SOURCE_PROVIDERS)))
+def test_scrobbler_providers_have_a_display_label(provider: str):
+    assert provider in _PROVIDER_LABELS, (
+        f"{provider} can appear in the Scrobbler screen and the delete-conflict message, "
+        "so it needs a label or it renders as an uppercase key"
+    )
+    assert provider_label(provider) == _PROVIDER_LABELS[provider]
+
+
+def test_label_falls_back_without_crashing():
+    assert provider_label("totally-unknown") == "TOTALLY-UNKNOWN"
+    assert provider_label("") == "provider"
+
+
+def test_instance_labels_are_suffixed():
+    assert provider_label("scrob", "default") == "Scrob"
+    assert provider_label("scrob", "second") == "Scrob second"
+
+
+def test_webhook_source_role_is_still_detected():
+    usages = find_provider_usage(webhook_cfg(["trakt"]), "plex")
+    assert any(u["feature"] == "webhook" and u["role"] == "provider" for u in usages), usages
+
+
+def test_disabled_webhook_source_releases_its_sinks():
+    cfg = webhook_cfg(sorted(ROUTE_SINKS))
+    cfg["scrobble"]["sources"]["webhook"] = False
+    for sink in sorted(ROUTE_SINKS):
+        assert find_provider_usage(cfg, sink) == []
+
+
+@pytest.mark.parametrize("sink", sorted(ROUTE_SINKS))
+def test_every_route_sink_is_buildable_by_both_sink_factories(sink: str):
+    from providers.scrobble.watch_manager import _make_sink as watcher_sink
+    from providers.webhooks.dispatch import _make_sink as webhook_sink
+
+    assert webhook_sink(sink, "default", lambda: {}) is not None, (
+        f"{sink} can be selected as a webhook destination but the webhook dispatcher cannot build it"
+    )
+    assert watcher_sink(sink, lambda: {}, "default") is not None, (
+        f"{sink} can be selected as a watcher route sink but the watcher cannot build it"
+    )
+
+
+def test_selectable_webhook_sinks_match_the_route_sinks():
+    from providers.webhooks.config import _SINK_CREDENTIALS, _SINKS
+
+    assert _SINKS == ROUTE_SINKS
+    assert set(_SINK_CREDENTIALS) | {"crosswatch"} == ROUTE_SINKS
+
+
+def read_asset(rel: str) -> str:
+    from pathlib import Path
+
+    return (Path(__file__).resolve().parents[1] / rel).read_text(encoding="utf-8", errors="ignore")
+
+
+def test_route_modal_never_offers_a_provider_as_its_own_destination():
+    js = read_asset("assets/js/modals/scrobbler-route/index.js")
+
+    assert 'function sinkProviders(selected = "", source = "") {' in js
+    assert 'const available = sinks.filter((p) => p !== self && allSinkProfiles(p).length);' in js
+    assert 'if (current === self) return available;' in js
+
+    assert 'function ratingSinkProviders(selected = [], source = "") {' in js
+    assert 'ratingSinks.includes(x) && x !== self' in js
+
+    assert 'optionsForProviders("sink", r.sink, r.provider)' in js
+    assert 'const sink = sinkProviders("", srcProvider)[0] || "";' in js
+    assert 'ratingSinkProviders(ratingTargets, r.provider)' in js
+    assert 'if (draft.sink === draft.provider) draft.sink = sinkProviders("", draft.provider)[0] || "";' in js
+
+
+def test_webhook_modal_never_offers_a_provider_as_its_own_destination():
+    js = read_asset("assets/js/modals/scrobbler-webhook/index.js")
+
+    assert "function sourceProviderKey() {" in js
+    assert "return sinks.filter((s) => s !== self && sinkProfiles(s).length > 0);" in js
+    assert "return ratingSinks.filter((s) => s !== self && sinkProfiles(s).length > 0);" in js
+
+
+def test_both_modals_offer_every_route_sink():
+    for rel in ("assets/js/modals/scrobbler-route/index.js", "assets/js/modals/scrobbler-webhook/index.js"):
+        js = read_asset(rel)
+        listed = js.split("const sinks = [", 1)[1].split("]", 1)[0]
+        offered = {p.strip().strip('"') for p in listed.split(",") if p.strip()}
+        assert offered == ROUTE_SINKS, f"{rel} offers {offered}, ROUTE_SINKS is {ROUTE_SINKS}"
+
+
+def test_scrob_is_the_only_provider_that_could_self_route():
+    from providers.scrobble.routes import ROUTE_PROVIDERS
+
+    assert ROUTE_PROVIDERS & ROUTE_SINKS == {"scrob"}

--- a/tests/test_punchplay_auth.py
+++ b/tests/test_punchplay_auth.py
@@ -493,7 +493,7 @@ def test_discovery_branding_and_frontend_wiring() -> None:
     assert "#punchplay_disconnect" in auth_css
     assert 'punchplay: "/assets/auth/auth.punchplay.js"' in loader
     assert '"sec-punchplay": "punchplay"' in loader
-    assert 'keys: ["CROSSWATCH", "TRAKT", "SIMKL", "TMDB", "MDBLIST", "PUBLICMETADB", "ANILIST", "PUNCHPLAY", "FLOPPY"]' in ui
+    assert '"ANILIST", "PUNCHPLAY", "FLOPPY"' in ui
     assert 'provider: "punchplay", logo: "PUNCHPLAY"' in ui
     assert '"244,64,15", "0,132,216", "PUNCHPLAY"' in ui
     assert "--cw-auth-c1:244,64,15;--cw-auth-c2:0,132,216" in auth_ui


### PR DESCRIPTION
# Pull request

## Change

Adds Scrob support for playback progress, webhook sinks and provider usage checks.

## Why

Scrob can be used by the remaining runtime paths outside sync and scrobble routes.

## Testing

- test_provider_usage_coverage.py

## Issue

Relates to #693