### PR TITLE
Fix: Custom mappings survive maintenance

### DIFF
--- a/api/animeMappingAPI.py
+++ b/api/animeMappingAPI.py
@@ -3,9 +3,11 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import json
+import time
 from typing import Any
 
-from fastapi import APIRouter, Body, Path as PathParam
+from fastapi import APIRouter, Body, Path as PathParam, Response
 from fastapi.responses import JSONResponse
 
 from _logging import log
@@ -13,11 +15,14 @@ from _logging import log
 from cw_platform.anime_mapping.auto_update import refresh_from_config as refresh_auto_update
 from cw_platform.anime_mapping.auto_update import status as auto_update_status
 from cw_platform.anime_mapping.overrides import (
+    IMPORT_MODES,
     MATCH_PROVIDERS,
     MEDIA_TYPES,
     TARGET_NAMESPACES,
     OverrideError,
     delete_override,
+    export_payload,
+    import_overrides,
     load_overrides,
     safe_override_error,
     stats as override_stats,
@@ -252,6 +257,61 @@ def api_anime_mapping_overrides_list() -> JSONResponse:
             extra={"error_type": e.__class__.__name__, "error": str(e)},
         )
         return JSONResponse({"ok": False, "error": e.__class__.__name__, "message": _client_error_message("override list")}, status_code=500)
+
+
+@router.get("/overrides/export")
+def api_anime_mapping_overrides_export() -> Response:
+    try:
+        payload = export_payload()
+    except Exception as e:
+        log(
+            "overrides_export_failed",
+            level="error",
+            module="ANIME_MAPPING",
+            extra={"error_type": e.__class__.__name__, "error": str(e)},
+        )
+        return JSONResponse({"ok": False, "error": e.__class__.__name__, "message": _client_error_message("override export")}, status_code=500)
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    log("overrides_exported", level="debug", module="ANIME_MAPPING", extra={"rules": len(payload.get("overrides") or [])})
+    return Response(
+        content=json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="crosswatch-anime-mappings-{stamp}.json"'},
+    )
+
+
+@router.post("/overrides/import")
+def api_anime_mapping_overrides_import(payload: dict[str, Any] | None = Body(default=None)) -> JSONResponse:
+    data = payload if isinstance(payload, dict) else {}
+    mode = str(data.get("mode") or "merge").strip().lower()
+    if mode not in IMPORT_MODES:
+        return JSONResponse({"ok": False, "error": "invalid_mode", "message": "mode must be 'merge' or 'replace'"}, status_code=400)
+    source = data.get("payload") if "payload" in data else data
+    try:
+        result = import_overrides(source, mode=mode)
+    except OverrideError as e:
+        return JSONResponse({"ok": False, "error": "invalid_import", "message": safe_override_error(e)}, status_code=400)
+    except Exception as e:
+        log(
+            "overrides_import_failed",
+            level="error",
+            module="ANIME_MAPPING",
+            extra={"error_type": e.__class__.__name__, "error": str(e)},
+        )
+        return JSONResponse({"ok": False, "error": e.__class__.__name__, "message": _client_error_message("override import")}, status_code=500)
+    log(
+        "overrides_imported",
+        level="debug",
+        module="ANIME_MAPPING",
+        extra={
+            "mode": result.get("mode"),
+            "added": result.get("added"),
+            "updated": result.get("updated"),
+            "skipped": result.get("skipped_count"),
+            "total": result.get("total"),
+        },
+    )
+    return JSONResponse({"ok": True, "result": result, "overrides": load_overrides(), "stats": override_stats()})
 
 
 @router.post("/overrides")

--- a/api/maintenanceAPI.py
+++ b/api/maintenanceAPI.py
@@ -58,7 +58,7 @@ SYNC_STATE_PATTERNS = (
 )
 
 CW_STATE_KEEP_DIRS = {"id"}
-CW_STATE_KEEP_FILES: set[str] = set()
+CW_STATE_KEEP_FILES: set[str] = {"anime_mapping_overrides.json"}
 
 
 def _is_sync_state_file(name: str) -> bool:
@@ -706,7 +706,7 @@ def maintenance_action_status(action: str) -> dict[str, Any]:
         retry_files = sum(1 for item in files if any(token in str(item.get("name") or "").lower() for token in retry_names))
         response.update(
             title="Retry provider items",
-            note="Clears provider runtime caches such as retry guards, phantom records and provider health. Sync aliases, mappings, history indexes, watermarks and tombstones stay untouched.",
+            note="Clears provider runtime caches such as retry guards, phantom records and provider health. Sync aliases, mappings, history indexes, watermarks, tombstones and your custom anime mapping rules stay untouched.",
             metrics=[
                 _metric("Runtime files", len(files)),
                 _metric("Retry / guard files", retry_files),

--- a/assets/js/modals/anime-overrides/index.js
+++ b/assets/js/modals/anime-overrides/index.js
@@ -163,13 +163,27 @@ export default {
           </section>
 
           <section class="ao-card">
-            <div class="ao-card-head compact">
+            <div class="ao-card-head compact has-tools">
               <span class="material-symbols-rounded" aria-hidden="true">list</span>
               <div>
                 <h3>Your rules <span class="ao-count" id="ao-count"></span></h3>
                 <p>Rules are checked in order, top first. Disabled rules are ignored.</p>
               </div>
+              <div class="ao-tools">
+                <select id="ao-import-mode" title="How an imported file is applied">
+                  <option value="merge">Merge into my rules</option>
+                  <option value="replace">Replace all rules</option>
+                </select>
+                <button type="button" class="ao-btn ao-btn-icon" id="ao-import">
+                  <span class="material-symbols-rounded" aria-hidden="true">upload</span>Import
+                </button>
+                <button type="button" class="ao-btn ao-btn-icon" id="ao-export">
+                  <span class="material-symbols-rounded" aria-hidden="true">download</span>Export
+                </button>
+                <input type="file" id="ao-file" accept="application/json,.json" hidden>
+              </div>
             </div>
+            <p class="ao-io-status" id="ao-io-status"></p>
             <div id="ao-list" class="ao-list"></div>
           </section>
         </div>
@@ -178,10 +192,16 @@ export default {
 
     const el = (id) => $(`#${id}`, root);
     const statusEl = el("ao-status");
+    const ioStatusEl = el("ao-io-status");
 
     function setStatus(message, tone = "") {
       statusEl.textContent = message || "";
       statusEl.dataset.tone = tone;
+    }
+
+    function setIoStatus(message, tone = "") {
+      ioStatusEl.textContent = message || "";
+      ioStatusEl.dataset.tone = tone;
     }
 
     function setBusy(on) {
@@ -333,6 +353,77 @@ export default {
       } catch (e) {
         setStatus(String(e.message || e), "err");
       } finally {
+        setBusy(false);
+      }
+    });
+
+    el("ao-export").addEventListener("click", async () => {
+      if (busy) return;
+      if (!rows.length) { setIoStatus("There is nothing to export yet.", "err"); return; }
+      setBusy(true);
+      setIoStatus("Preparing download...");
+      let url = "";
+      try {
+        const r = await fetch(`${API}/export`, { cache: "no-store", credentials: "same-origin" });
+        if (!r.ok) throw new Error(`${r.status} ${r.statusText || ""}`.trim());
+        const blob = await r.blob();
+        const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\..+$/, "Z");
+        url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `crosswatch-anime-mappings-${stamp}.json`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        setIoStatus(`Exported ${rows.length} rule${rows.length === 1 ? "" : "s"}.`, "ok");
+      } catch (e) {
+        setIoStatus(`Export failed: ${e.message || e}`, "err");
+      } finally {
+        if (url) window.setTimeout(() => URL.revokeObjectURL(url), 10_000);
+        setBusy(false);
+      }
+    });
+
+    el("ao-import").addEventListener("click", () => {
+      if (busy) return;
+      el("ao-file").value = "";
+      el("ao-file").click();
+    });
+
+    el("ao-file").addEventListener("change", async (ev) => {
+      const file = ev.target.files?.[0];
+      if (!file) return;
+      const mode = el("ao-import-mode").value;
+      if (mode === "replace" && rows.length && !window.confirm(`Replace all ${rows.length} existing rules with the contents of ${file.name}?`)) {
+        el("ao-file").value = "";
+        return;
+      }
+      setBusy(true);
+      setIoStatus(`Importing ${file.name}...`);
+      try {
+        let parsed;
+        try {
+          parsed = JSON.parse(await file.text());
+        } catch {
+          throw new Error("That file is not valid JSON");
+        }
+        const data = await apiJson(`${API}/import`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ mode, payload: parsed }),
+        });
+        await refresh();
+        const res = data.result || {};
+        const parts = [`${res.added || 0} added`, `${res.updated || 0} updated`];
+        if (res.skipped_count) parts.push(`${res.skipped_count} skipped`);
+        setIoStatus(`Imported ${file.name}: ${parts.join(", ")}.`, res.skipped_count ? "" : "ok");
+        window.CW?.DOM?.showToast?.(`Anime mappings imported (${res.total || 0} rules)`, true);
+        const first = (res.skipped || [])[0];
+        if (first) setIoStatus(`${parts.join(", ")}. First skipped rule: ${first.title || `#${first.index}`} - ${first.reason}`, "err");
+      } catch (e) {
+        setIoStatus(`Import failed: ${e.message || e}`, "err");
+      } finally {
+        el("ao-file").value = "";
         setBusy(false);
       }
     });

--- a/assets/js/modals/anime-overrides/styles.css
+++ b/assets/js/modals/anime-overrides/styles.css
@@ -46,6 +46,16 @@
 .cw-anime-overrides .ao-btn.primary{border-color:color-mix(in srgb,var(--ao-accent) 46%,var(--ao-border));background:color-mix(in srgb,var(--ao-accent) 24%,var(--ao-card))}
 .cw-anime-overrides .ao-btn:disabled{opacity:.55;cursor:default}
 
+.cw-anime-overrides .ao-card-head.has-tools{grid-template-columns:44px minmax(0,1fr) auto;align-items:center}
+.cw-anime-overrides .ao-tools{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end}
+.cw-anime-overrides .ao-tools select{width:auto;min-width:180px;min-height:38px;font-size:13px}
+.cw-anime-overrides .ao-btn-icon{display:inline-flex;align-items:center;gap:7px;min-height:38px;padding:0 14px;font-size:13px}
+.cw-anime-overrides .ao-btn-icon .material-symbols-rounded{font-size:19px}
+.cw-anime-overrides .ao-io-status{min-height:18px;margin:0 0 10px;font-size:12.5px;color:var(--ao-muted)}
+.cw-anime-overrides .ao-io-status[data-tone="ok"]{color:var(--ao-good)}
+.cw-anime-overrides .ao-io-status[data-tone="err"]{color:var(--ao-danger)}
+.cw-anime-overrides .ao-io-status:empty{min-height:0;margin:0}
+
 .cw-anime-overrides .ao-list{display:grid;gap:8px}
 .cw-anime-overrides .ao-row{display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:center;gap:12px;padding:12px 14px;border:1px solid var(--ao-border);border-radius:12px;background:color-mix(in srgb,var(--ao-panel) 88%,#091321)}
 .cw-anime-overrides .ao-row.is-off{opacity:.55}
@@ -64,6 +74,9 @@
 .cw-anime-overrides .ao-empty .material-symbols-rounded{font-size:32px;opacity:.7}
 
 @media (max-width:760px){
+  .cw-anime-overrides .ao-card-head.has-tools{grid-template-columns:44px minmax(0,1fr)}
+  .cw-anime-overrides .ao-tools{grid-column:1/-1;justify-content:flex-start}
+  .cw-anime-overrides .ao-tools select{min-width:0;flex:1 1 100%}
   .cw-anime-overrides .ao-rule-row{grid-template-columns:minmax(0,1fr)}
   .cw-anime-overrides .ao-arrow{transform:rotate(90deg)}
   .cw-anime-overrides .ao-grid,.cw-anime-overrides .ao-grid-3{grid-template-columns:minmax(0,1fr)}

--- a/cw_platform/anime_mapping/overrides.py
+++ b/cw_platform/anime_mapping/overrides.py
@@ -48,8 +48,13 @@ _SAFE_OVERRIDE_ERRORS: dict[str, str] = {
         "The last episode cannot be lower than the first",
         "An episode rule needs a season",
         f"At most {_MAX_OVERRIDES} rules are supported",
+        "mode must be 'merge' or 'replace'",
+        "The file does not contain a list of rules",
+        "The file contains no valid rules",
     )
 }
+
+IMPORT_MODES = ("merge", "replace")
 
 
 def safe_override_error(exc: Exception) -> str:
@@ -254,6 +259,82 @@ def delete_override(rule_id: Any) -> bool:
             return False
         save_overrides(kept)
     return True
+
+
+def export_payload() -> dict[str, Any]:
+    return {"overrides": load_overrides(), "updated_at": int(time.time())}
+
+
+def _rows_from_payload(raw: Any) -> list[Any]:
+    if isinstance(raw, list):
+        return list(raw)
+    if isinstance(raw, Mapping):
+        rows = raw.get("overrides")
+        if isinstance(rows, list):
+            return list(rows)
+    raise OverrideError("The file does not contain a list of rules")
+
+
+def import_overrides(raw: Any, *, mode: str = "merge") -> dict[str, Any]:
+    wanted = str(mode or "merge").strip().lower()
+    if wanted not in IMPORT_MODES:
+        raise OverrideError("mode must be 'merge' or 'replace'")
+
+    incoming = _rows_from_payload(raw)
+    if len(incoming) > _MAX_OVERRIDES:
+        raise OverrideError(f"At most {_MAX_OVERRIDES} rules are supported")
+
+    parsed: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for index, row in enumerate(incoming):
+        if not isinstance(row, Mapping):
+            skipped.append({"index": index, "title": "", "reason": GENERIC_OVERRIDE_ERROR})
+            continue
+        try:
+            clean = normalize_override(row)
+        except OverrideError as e:
+            skipped.append({"index": index, "title": _text(row.get("title"), 64), "reason": safe_override_error(e)})
+            continue
+        clean["updated_at"] = _as_int(row.get("updated_at")) or clean["updated_at"]
+        parsed.append(clean)
+
+    if incoming and not parsed:
+        raise OverrideError("The file contains no valid rules")
+
+    added = 0
+    updated = 0
+    with _LOCK:
+        current = load_overrides() if wanted == "merge" else []
+        by_id: dict[str, dict[str, Any]] = {}
+        order: list[str] = []
+        for row in current:
+            rid = str(row.get("id") or "")
+            by_id[rid] = dict(row)
+            order.append(rid)
+        for clean in parsed:
+            rid = str(clean.get("id") or "")
+            previous = by_id.get(rid)
+            if previous is None:
+                order.append(rid)
+                added += 1
+            else:
+                clean["created_at"] = previous.get("created_at") or clean["created_at"]
+                updated += 1
+            by_id[rid] = clean
+        if len(order) > _MAX_OVERRIDES:
+            raise OverrideError(f"At most {_MAX_OVERRIDES} rules are supported")
+        save_overrides([by_id[rid] for rid in order])
+
+    return {
+        "mode": wanted,
+        "received": len(incoming),
+        "imported": len(parsed),
+        "added": added,
+        "updated": updated,
+        "skipped": skipped[:50],
+        "skipped_count": len(skipped),
+        "total": len(order),
+    }
 
 
 def _ids_of(item: Mapping[str, Any]) -> dict[str, str]:

--- a/services/backups.py
+++ b/services/backups.py
@@ -13,6 +13,8 @@ import json
 import os
 import re
 import shutil
+import sqlite3
+import tempfile
 import uuid
 import zipfile
 
@@ -48,6 +50,8 @@ _FULL_DIRS = (
 _OPTIONAL_RESTORE_DIRS = (
     "cache",
 )
+_SQLITE_SUFFIXES = (".sqlite3", ".sqlite", ".db")
+_SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
 
 
 def _utc_now() -> datetime:
@@ -226,6 +230,36 @@ def _candidate_roots(
     return out
 
 
+def _is_sqlite_db(rel: str) -> bool:
+    name = PurePosixPath(rel).name
+    return any(name.endswith(suffix) for suffix in _SQLITE_SUFFIXES)
+
+
+def _sqlite_sidecar_owner(rel: str) -> str | None:
+    posix = PurePosixPath(rel)
+    name = posix.name
+    for suffix in _SQLITE_SIDECAR_SUFFIXES:
+        if not name.endswith(suffix):
+            continue
+        base = name[: -len(suffix)]
+        if _is_sqlite_db(base):
+            return str(posix.with_name(base))
+    return None
+
+
+def _snapshot_sqlite(src: Path, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    source = sqlite3.connect(str(src), timeout=15.0)
+    try:
+        target = sqlite3.connect(str(dst), timeout=15.0)
+        try:
+            source.backup(target)
+        finally:
+            target.close()
+    finally:
+        source.close()
+
+
 def _sha256_file(path: Path) -> str:
     h = hashlib.sha256()
     with path.open("rb") as f:
@@ -310,7 +344,8 @@ def create_backup(
         },
     )
 
-    files: list[Path] = []
+    members: list[tuple[str, Path]] = []
+    sidecars: dict[str, list[tuple[str, Path]]] = {}
     seen: set[str] = set()
     for root in _candidate_roots(sc, include_snapshots=include_snapshots, include_reports=include_reports, include_cache=include_cache):
         for file_path in _iter_files_under(root):
@@ -318,16 +353,41 @@ def create_backup(
             if rel_file in seen:
                 continue
             seen.add(rel_file)
-            files.append(file_path)
+            owner = _sqlite_sidecar_owner(rel_file)
+            if owner is not None:
+                sidecars.setdefault(owner, []).append((rel_file, file_path))
+                continue
+            members.append((rel_file, file_path))
 
-    LOG.debug("backup file selection completed", extra={"scope": sc, "file_count": len(files)})
+    LOG.debug("backup file selection completed", extra={"scope": sc, "file_count": len(members)})
 
     manifest_files: list[dict[str, Any]] = []
     total_size = 0
+    snapshot_dir: tempfile.TemporaryDirectory[str] | None = None
+    db_snapshots = 0
+    db_snapshot_errors: list[str] = []
     try:
+        for idx, (rel_file, src) in enumerate(members):
+            if not _is_sqlite_db(rel_file):
+                continue
+            if snapshot_dir is None:
+                snapshot_dir = tempfile.TemporaryDirectory(prefix="cw-backup-db-", dir=str(_backups_dir()))
+            dst = Path(snapshot_dir.name) / f"{idx}-{PurePosixPath(rel_file).name}"
+            try:
+                _snapshot_sqlite(src, dst)
+            except Exception as e:
+                db_snapshot_errors.append(f"{rel_file}: {type(e).__name__}")
+                members.extend(sidecars.get(rel_file) or ())
+                continue
+            members[idx] = (rel_file, dst)
+            db_snapshots += 1
+
+        if db_snapshot_errors:
+            LOG.warn(f"backup could not snapshot {len(db_snapshot_errors)} database(s); copied raw files instead")
+            LOG.debug("backup database snapshot errors", extra={"scope": sc, "errors": _safe_log_errors(db_snapshot_errors)})
+
         with zipfile.ZipFile(tmp, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
-            for file_path in files:
-                rel_file = _rel_from_config(file_path)
+            for rel_file, file_path in members:
                 st = file_path.stat()
                 total_size += int(st.st_size)
                 digest = _sha256_file(file_path)
@@ -357,6 +417,7 @@ def create_backup(
                 "master_key_included": key_included,
                 "external_key_required": bool(encrypted and not key_included),
                 "env_key_configured": _is_env_key_configured(),
+                "database_snapshots": db_snapshots,
             }
             zf.writestr(MANIFEST_NAME, json.dumps(manifest, indent=2, sort_keys=False) + "\n")
         os.replace(tmp, target)
@@ -368,6 +429,12 @@ def create_backup(
         LOG.error(f"backup create failed scope={sc} trigger={trigger or 'manual'}: {type(e).__name__}")
         LOG.debug(f"backup create failure detail: {_error_text(e)}", extra={"scope": sc, "target": rel})
         raise
+    finally:
+        if snapshot_dir is not None:
+            try:
+                snapshot_dir.cleanup()
+            except Exception:
+                pass
 
     result = {
         "ok": True,
@@ -630,6 +697,19 @@ def restore_backup(path: str, *, create_pre_restore: bool = True) -> dict[str, A
     except zipfile.BadZipFile:
         LOG.warn(f"backup restore failed invalid archive path={rel}")
         return {"ok": False, "error": "invalid_backup_archive", "restored": restored, "errors": errors}
+
+    restored_set = set(restored)
+    for member in restored:
+        if not _is_sqlite_db(member):
+            continue
+        for suffix in _SQLITE_SIDECAR_SUFFIXES:
+            sidecar = f"{member}{suffix}"
+            if sidecar in restored_set:
+                continue
+            try:
+                _resolve_restore_target(sidecar).unlink(missing_ok=True)
+            except Exception as e:
+                errors.append(f"{sidecar}: {type(e).__name__}")
 
     result = {
         "ok": len(errors) == 0,

--- a/tests/test_anime_overrides.py
+++ b/tests/test_anime_overrides.py
@@ -80,6 +80,79 @@ def test_delete_removes_only_the_named_rule(config_base: Path) -> None:
     assert ov.delete_override("nope") is False
 
 
+def test_export_round_trips_through_import(config_base: Path) -> None:
+    ov.upsert_override(_rule(match_id="1", title="One"))
+    ov.upsert_override(_rule(match_id="2", title="Two"))
+    payload = ov.export_payload()
+    assert len(payload["overrides"]) == 2
+
+    ov.save_overrides([])
+    result = ov.import_overrides(payload, mode="merge")
+
+    assert result["added"] == 2
+    assert result["updated"] == 0
+    assert result["skipped_count"] == 0
+    assert [r["title"] for r in ov.load_overrides()] == ["One", "Two"]
+
+
+def test_import_merge_keeps_untouched_rules_and_preserves_created_at(config_base: Path) -> None:
+    keep = ov.upsert_override(_rule(match_id="1", title="Keep"))
+    existing = ov.upsert_override(_rule(match_id="2", title="Old"))
+
+    result = ov.import_overrides(
+        {"overrides": [_rule(id=existing["id"], match_id="2", title="New"), _rule(match_id="3", title="Fresh")]},
+        mode="merge",
+    )
+
+    rows = {r["id"]: r for r in ov.load_overrides()}
+    assert result["added"] == 1
+    assert result["updated"] == 1
+    assert len(rows) == 3
+    assert rows[keep["id"]]["title"] == "Keep"
+    assert rows[existing["id"]]["title"] == "New"
+    assert rows[existing["id"]]["created_at"] == existing["created_at"]
+
+
+def test_import_replace_drops_rules_not_in_the_file(config_base: Path) -> None:
+    ov.upsert_override(_rule(match_id="1", title="Gone"))
+    result = ov.import_overrides([_rule(match_id="9", title="Only")], mode="replace")
+
+    assert result["mode"] == "replace"
+    assert [r["title"] for r in ov.load_overrides()] == ["Only"]
+    assert result["total"] == 1
+
+
+def test_import_skips_invalid_rules_but_keeps_the_valid_ones(config_base: Path) -> None:
+    result = ov.import_overrides(
+        {
+            "overrides": [
+                _rule(match_id="1", title="Good"),
+                _rule(match_id="2", title="Bad", match_provider="nope"),
+                "not-a-rule",
+            ]
+        },
+        mode="merge",
+    )
+
+    assert result["imported"] == 1
+    assert result["skipped_count"] == 2
+    assert result["skipped"][0]["title"] == "Bad"
+    assert [r["title"] for r in ov.load_overrides()] == ["Good"]
+
+
+def test_import_rejects_a_file_with_no_usable_rules(config_base: Path) -> None:
+    ov.upsert_override(_rule(match_id="1", title="Keep"))
+
+    with pytest.raises(ov.OverrideError):
+        ov.import_overrides({"overrides": [_rule(match_provider="nope")]}, mode="replace")
+    with pytest.raises(ov.OverrideError):
+        ov.import_overrides({"rules": []}, mode="merge")
+    with pytest.raises(ov.OverrideError):
+        ov.import_overrides({"overrides": []}, mode="wipe")
+
+    assert [r["title"] for r in ov.load_overrides()] == ["Keep"]
+
+
 @pytest.mark.parametrize(
     "patch",
     [

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import zipfile
 from datetime import datetime
 from pathlib import Path
@@ -43,6 +44,83 @@ def test_restore_config_backup_creates_pre_restore_backup(tmp_path: Path, monkey
     assert restored["ok"] is True
     assert restored["pre_restore_backup"]["path"]
     assert json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))["version"] == "before"
+
+
+def _seed_wal_database(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(str(path))
+    try:
+        con.execute("PRAGMA journal_mode=WAL")
+        con.execute("CREATE TABLE IF NOT EXISTS rows (v TEXT)")
+        con.execute("DELETE FROM rows")
+        con.execute("INSERT INTO rows (v) VALUES (?)", (value,))
+        con.commit()
+    finally:
+        con.close()
+
+
+def test_app_state_backup_captures_overrides_and_database_snapshot(tmp_path: Path, monkeypatch) -> None:
+    _patch_config_dir(monkeypatch, tmp_path)
+    import services.backups as backups
+
+    (tmp_path / "config.json").write_text("{}\n", encoding="utf-8")
+    overrides = tmp_path / ".cw_state" / "anime_mapping_overrides.json"
+    overrides.parent.mkdir(parents=True, exist_ok=True)
+    overrides.write_text('{"overrides":[{"id":"ovr_1"}]}', encoding="utf-8")
+
+    db = tmp_path / ".cw_databases" / "crosswatch.sqlite3"
+    _seed_wal_database(db, "committed")
+    live = sqlite3.connect(str(db))
+    live.execute("PRAGMA journal_mode=WAL")
+
+    try:
+        res = backups.create_backup(scope="app_state", label="unit", trigger="test")
+    finally:
+        live.close()
+
+    validation = backups.validate_backup(res["path"])
+    assert validation["ok"] is True
+
+    manifest = validation["manifest"]
+    paths = {row["path"] for row in manifest["files"]}
+    assert ".cw_state/anime_mapping_overrides.json" in paths
+    assert ".cw_databases/crosswatch.sqlite3" in paths
+    assert not any(p.endswith(("-wal", "-shm")) for p in paths)
+    assert manifest["database_snapshots"] == 1
+
+    _, archive = backups._resolve_backup_file(res["path"])
+    extracted = tmp_path / "extracted.sqlite3"
+    with zipfile.ZipFile(archive, "r") as zf, zf.open(".cw_databases/crosswatch.sqlite3") as src:
+        extracted.write_bytes(src.read())
+    con = sqlite3.connect(str(extracted))
+    try:
+        assert con.execute("SELECT v FROM rows").fetchone()[0] == "committed"
+    finally:
+        con.close()
+
+
+def test_restore_drops_stale_wal_sidecar(tmp_path: Path, monkeypatch) -> None:
+    _patch_config_dir(monkeypatch, tmp_path)
+    import services.backups as backups
+
+    (tmp_path / "config.json").write_text("{}\n", encoding="utf-8")
+    db = tmp_path / ".cw_databases" / "crosswatch.sqlite3"
+    _seed_wal_database(db, "before")
+    res = backups.create_backup(scope="app_state", label="unit", trigger="test")
+
+    _seed_wal_database(db, "after")
+    stale = Path(str(db) + "-wal")
+    stale.write_bytes(b"stale-wal")
+
+    restored = backups.restore_backup(res["path"], create_pre_restore=False)
+
+    assert restored["ok"] is True
+    assert not stale.exists()
+    con = sqlite3.connect(str(db))
+    try:
+        assert con.execute("SELECT v FROM rows").fetchone()[0] == "before"
+    finally:
+        con.close()
 
 
 def test_validate_rejects_archive_member_outside_restore_allowlist(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_maintenance_api.py
+++ b/tests/test_maintenance_api.py
@@ -452,7 +452,7 @@ def test_clear_provider_cache_preserves_pair_scoped_history_mapping_state(tmp_pa
         "emby.health.shadow.json",
         "currently_watching.json",
     }
-    preserved = set()
+    preserved = {"anime_mapping_overrides.json"}
 
     for name in sync_owned_state | runtime_cache | preserved:
         (state_dir / name).write_text("{}", encoding="utf-8")


### PR DESCRIPTION
# Pull request

## Change

- Retry provider items no longer deletes anime_mapping_overrides.json
- Backups snapshot the sqlite files in .cw_databases instead of copying them raw
- Restore drops stale wal and shm sidecars that are not in the archive
- Import and export added to the custom anime mappings modal
- Import takes merge or replace, skips bad rows, rejects a file where nothing parses

## Why

- Custom rules were wiped every time Retry provider items ran
- No way to move rules in or out other than the UI one at a time
- Copying live WAL databases file by file can produce a torn or corrupt restore

## Testing

- test_anime_overrides.py 
- tests/test_backups.py 
- tests/test_maintenance_api.py

## Issue

Relates to #660
