### PR TITLE
Add: Reverse anime mapping and SIMKL lookup

### DIFF
--- a/api/animeMappingAPI.py
+++ b/api/animeMappingAPI.py
@@ -28,6 +28,15 @@ from cw_platform.anime_mapping.overrides import (
     stats as override_stats,
     upsert_override,
 )
+from cw_platform.anime_mapping.simkl_catalog import (
+    SimklCatalogError,
+    SimklNotConfigured,
+    configured as simkl_configured,
+    instances as simkl_instances,
+    plan_rules as simkl_plan_rules,
+    resolve_instance as simkl_resolve_instance,
+    search as simkl_search,
+)
 from cw_platform.anime_mapping.storage import normalize_release_tag, rebuild_sqlite_from_mappings
 from cw_platform.anime_mapping.updater import status as mapping_status, update as mapping_update
 from cw_platform.config_base import ANIME_MAPPING_PAIRS_DEFAULT, load_config, save_config
@@ -257,6 +266,72 @@ def api_anime_mapping_overrides_list() -> JSONResponse:
             extra={"error_type": e.__class__.__name__, "error": str(e)},
         )
         return JSONResponse({"ok": False, "error": e.__class__.__name__, "message": _client_error_message("override list")}, status_code=500)
+
+
+@router.get("/simkl/status")
+def api_anime_mapping_simkl_status(instance: str = "") -> JSONResponse:
+    resolved, key = simkl_resolve_instance(instance or None)
+    return JSONResponse(
+        {
+            "ok": True,
+            "configured": bool(key),
+            "instance": resolved if key else "",
+            "instances": simkl_instances(),
+        }
+    )
+
+
+@router.get("/simkl/search")
+def api_anime_mapping_simkl_search(q: str = "", limit: int = 25, instance: str = "") -> JSONResponse:
+    term = str(q or "").strip()
+    if not term:
+        return JSONResponse({"ok": True, "results": [], "configured": bool(simkl_configured(instance or None))})
+    try:
+        results = simkl_search(term, limit=limit, instance_id=instance or None)
+    except SimklNotConfigured as e:
+        return JSONResponse({"ok": False, "error": "simkl_not_configured", "message": str(e)}, status_code=409)
+    except SimklCatalogError as e:
+        log(
+            "simkl_search_failed",
+            level="warn",
+            module="ANIME_MAPPING",
+            extra={"error_type": e.__class__.__name__, "error": str(e)},
+        )
+        return JSONResponse({"ok": False, "error": "simkl_search_failed", "message": str(e)}, status_code=502)
+    return JSONResponse({"ok": True, "configured": True, "results": [r.as_dict() for r in results]})
+
+
+@router.post("/simkl/plan")
+def api_anime_mapping_simkl_plan(payload: dict[str, Any] | None = Body(default=None)) -> JSONResponse:
+    data = payload if isinstance(payload, dict) else {}
+    try:
+        plan = simkl_plan_rules(
+            data.get("simkl"),
+            match_provider=str(data.get("match_provider") or ""),
+            match_id=str(data.get("match_id") or ""),
+            match_season=data.get("match_season"),
+            title=str(data.get("title") or ""),
+            instance_id=str(data.get("instance") or "") or None,
+        )
+    except SimklNotConfigured as e:
+        return JSONResponse({"ok": False, "error": "simkl_not_configured", "message": str(e)}, status_code=409)
+    except SimklCatalogError as e:
+        return JSONResponse({"ok": False, "error": "simkl_plan_failed", "message": str(e)}, status_code=400)
+    except Exception as e:
+        log(
+            "simkl_plan_failed",
+            level="error",
+            module="ANIME_MAPPING",
+            extra={"error_type": e.__class__.__name__, "error": str(e)},
+        )
+        return JSONResponse({"ok": False, "error": e.__class__.__name__, "message": _client_error_message("season plan")}, status_code=500)
+    log(
+        "simkl_plan_built",
+        level="debug",
+        module="ANIME_MAPPING",
+        extra={"rules": len(plan.get("rules") or []), "episodes": plan.get("total_episodes")},
+    )
+    return JSONResponse({"ok": True, **plan})
 
 
 @router.get("/overrides/export")

--- a/assets/js/modals/anime-overrides/index.js
+++ b/assets/js/modals/anime-overrides/index.js
@@ -84,6 +84,8 @@ export default {
     let schema = { match_providers: [], target_namespaces: [], media_types: ["show", "movie"] };
     let editingId = "";
     let busy = false;
+    let simklReady = false;
+    let findResults = [];
 
     root.innerHTML = `
       <div class="cw-anime-overrides">
@@ -136,10 +138,33 @@ export default {
                 <div class="ao-rule-legend">Treat it as</div>
                 <div class="ao-inline">
                   <select id="ao-target-namespace"></select>
-                  <input id="ao-target-id" type="text" placeholder="ID" maxlength="64">
+                  <div class="ao-target-id">
+                    <input id="ao-target-id" type="text" placeholder="ID" maxlength="64">
+                    <button type="button" class="ao-find" id="ao-find" hidden>
+                      <span class="material-symbols-rounded" aria-hidden="true">search</span>
+                    </button>
+                  </div>
                 </div>
+                <p class="ao-find-note" id="ao-find-note" hidden></p>
               </div>
             </div>
+
+            <section class="ao-finder" id="ao-finder" hidden>
+              <div class="ao-finder-head">
+                <span class="material-symbols-rounded" aria-hidden="true">travel_explore</span>
+                <div>
+                  <strong>Look up on SIMKL</strong>
+                  <p>SIMKL targets only. Seasons are separate records there, so pick the exact one, or build the whole season chain in one go.</p>
+                </div>
+                <button type="button" class="ao-icon" id="ao-finder-close" title="Close lookup"><span class="material-symbols-rounded" aria-hidden="true">close</span></button>
+              </div>
+              <div class="ao-finder-search">
+                <input id="ao-finder-q" type="text" placeholder="Search SIMKL by title" maxlength="200">
+                <button type="button" class="ao-btn" id="ao-finder-go">Search</button>
+              </div>
+              <p class="ao-finder-status" id="ao-finder-status"></p>
+              <div class="ao-finder-list" id="ao-finder-list"></div>
+            </section>
 
             <div class="ao-episodes" id="ao-episodes">
               <div class="ao-rule-legend">Episode numbers (optional)</div>
@@ -210,15 +235,44 @@ export default {
       if (!busy) syncMediaType();
     }
 
+    async function refreshSimklStatus() {
+      try {
+        const data = await apiJson("/api/anime-mapping/simkl/status");
+        simklReady = !!data.configured;
+      } catch {
+        simklReady = false;
+      }
+      syncTargetTools();
+    }
+
     function fillSelect(node, values, current) {
       node.innerHTML = values.map((v) => `<option value="${esc(v)}">${esc(label(v))}</option>`).join("");
       if (current) node.value = current;
+    }
+
+    function syncTargetTools() {
+      const find = el("ao-find");
+      const note = el("ao-find-note");
+      if (!simklReady) {
+        find.hidden = true;
+        note.hidden = true;
+        el("ao-finder").hidden = true;
+        return;
+      }
+      const isSimkl = el("ao-target-namespace").value === "simkl";
+      find.hidden = false;
+      find.disabled = busy || !isSimkl;
+      find.title = isSimkl ? "Look this up on SIMKL" : "Lookup is available for SIMKL targets only";
+      note.hidden = isSimkl;
+      note.textContent = isSimkl ? "" : "Lookup is available for SIMKL targets only.";
+      if (!isSimkl) el("ao-finder").hidden = true;
     }
 
     function syncMediaType() {
       const isMovie = el("ao-media-type").value === "movie";
       el("ao-episodes").hidden = isMovie;
       el("ao-season-wrap").hidden = isMovie;
+      syncTargetTools();
       renderPreview();
     }
 
@@ -327,8 +381,130 @@ export default {
       fillSelect(el("ao-match-provider"), schema.match_providers || [], el("ao-match-provider").value);
       fillSelect(el("ao-target-namespace"), schema.target_namespaces || [], el("ao-target-namespace").value);
       renderList();
+      syncTargetTools();
     }
 
+    function setFindStatus(message, tone = "") {
+      el("ao-finder-status").textContent = message || "";
+      el("ao-finder-status").dataset.tone = tone;
+    }
+
+    function renderFindResults() {
+      if (!findResults.length) {
+        el("ao-finder-list").innerHTML = "";
+        return;
+      }
+      el("ao-finder-list").innerHTML = findResults.map((row, i) => `
+        <div class="ao-finder-row" data-i="${i}">
+          <div class="ao-finder-main">
+            <div class="ao-finder-title">${esc(row.label || row.title)}</div>
+            <div class="ao-finder-meta">
+              SIMKL ${esc(row.simkl)}${row.year ? ` &middot; ${esc(row.year)}` : ""}${row.tmdb ? ` &middot; TMDB ${esc(row.tmdb)}` : " &middot; no TMDB id"}
+            </div>
+          </div>
+          <div class="ao-finder-actions">
+            <button type="button" class="ao-btn" data-act="use">Use id</button>
+            <button type="button" class="ao-btn primary" data-act="plan">Build seasons</button>
+          </div>
+        </div>
+      `).join("");
+    }
+
+    async function runFind() {
+      const term = String(el("ao-finder-q").value || "").trim();
+      if (!term) { setFindStatus("Type a title to search for.", "err"); return; }
+      setBusy(true);
+      setFindStatus("Searching SIMKL...");
+      try {
+        const data = await apiJson(`/api/anime-mapping/simkl/search?q=${encodeURIComponent(term)}`);
+        findResults = Array.isArray(data.results) ? data.results : [];
+        renderFindResults();
+        setFindStatus(findResults.length ? `${findResults.length} result${findResults.length === 1 ? "" : "s"}.` : "Nothing found on SIMKL for that title.", findResults.length ? "ok" : "err");
+      } catch (e) {
+        findResults = [];
+        renderFindResults();
+        setFindStatus(String(e.message || e), "err");
+      } finally {
+        setBusy(false);
+        syncTargetTools();
+      }
+    }
+
+    async function buildSeasonRules(row) {
+      const form = readForm();
+      if (!form.match_id) { setFindStatus("Fill in the source ID first, the rules are built against it.", "err"); return; }
+      setBusy(true);
+      setFindStatus("Building the season chain...");
+      try {
+        const plan = await apiJson("/api/anime-mapping/simkl/plan", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            simkl: row.simkl,
+            match_provider: form.match_provider,
+            match_id: form.match_id,
+            match_season: form.match_season == null ? 1 : form.match_season,
+            title: form.title || row.title,
+          }),
+        });
+        const planned = Array.isArray(plan.rules) ? plan.rules : [];
+        if (!planned.length) { setFindStatus("SIMKL returned no aired seasons for that entry.", "err"); return; }
+        const summary = planned
+          .map((r) => `  ${form.match_provider.toUpperCase()} S${r.match_season} E${r.episode_from}-${r.episode_to}  ->  SIMKL ${r.target_id}  (${r.note})`)
+          .join("\n");
+        const skipped = (plan.skipped || []).length ? `\n\nSkipped ${plan.skipped.length} unaired entr${plan.skipped.length === 1 ? "y" : "ies"}.` : "";
+        if (!window.confirm(`Add ${planned.length} rules covering ${plan.total_episodes} episodes?\n\n${summary}${skipped}`)) {
+          setFindStatus("Nothing added.");
+          return;
+        }
+        let added = 0;
+        for (const rule of planned) {
+          await apiJson(API, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(rule) });
+          added += 1;
+        }
+        await refresh();
+        resetForm();
+        el("ao-finder").hidden = true;
+        setIoStatus(`Added ${added} season rule${added === 1 ? "" : "s"} from SIMKL.`, "ok");
+        window.CW?.DOM?.showToast?.(`Added ${added} anime mapping rules`, true);
+      } catch (e) {
+        setFindStatus(String(e.message || e), "err");
+      } finally {
+        setBusy(false);
+        syncTargetTools();
+      }
+    }
+
+    el("ao-find").addEventListener("click", () => {
+      if (busy || !simklReady || el("ao-target-namespace").value !== "simkl") return;
+      const panel = el("ao-finder");
+      panel.hidden = !panel.hidden;
+      if (panel.hidden) return;
+      if (!el("ao-finder-q").value) el("ao-finder-q").value = el("ao-title").value || "";
+      el("ao-finder-q").focus();
+      if (el("ao-finder-q").value) runFind();
+    });
+
+    el("ao-finder-close").addEventListener("click", () => { el("ao-finder").hidden = true; });
+    el("ao-finder-go").addEventListener("click", runFind);
+    el("ao-finder-q").addEventListener("keydown", (ev) => { if (ev.key === "Enter") { ev.preventDefault(); runFind(); } });
+
+    el("ao-finder-list").addEventListener("click", async (ev) => {
+      const btn = ev.target.closest("button[data-act]");
+      if (!btn || busy) return;
+      const row = findResults[Number(btn.closest(".ao-finder-row")?.dataset.i)];
+      if (!row) return;
+      if (btn.dataset.act === "use") {
+        el("ao-target-id").value = row.simkl;
+        if (!el("ao-title").value) el("ao-title").value = row.title || "";
+        setFindStatus(`Using SIMKL ${row.simkl}.`, "ok");
+        renderPreview();
+        return;
+      }
+      await buildSeasonRules(row);
+    });
+
+    el("ao-target-namespace").addEventListener("change", syncTargetTools);
     el("ao-close").addEventListener("click", () => window.cxCloseModal?.());
     el("ao-media-type").addEventListener("change", syncMediaType);
     ["ao-ep-from", "ao-ep-to", "ao-ep-start", "ao-match-season"].forEach((id) => {
@@ -466,5 +642,6 @@ export default {
     } catch (e) {
       setStatus(`Could not load rules: ${e.message || e}`, "err");
     }
+    await refreshSimklStatus();
   },
 };

--- a/assets/js/modals/anime-overrides/styles.css
+++ b/assets/js/modals/anime-overrides/styles.css
@@ -32,6 +32,32 @@
 .cw-anime-overrides .ao-rule-legend{font-size:12px;font-weight:900;color:var(--ao-muted);letter-spacing:.06em;text-transform:uppercase}
 .cw-anime-overrides .ao-inline{display:grid;grid-template-columns:minmax(0,1.1fr) minmax(0,1fr);gap:8px}
 .cw-anime-overrides .ao-arrow{display:grid;place-items:center;font-size:26px;color:var(--ao-accent)}
+.cw-anime-overrides .ao-target-id{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:6px}
+.cw-anime-overrides .ao-find{display:inline-flex;align-items:center;justify-content:center;width:42px;min-width:42px;height:42px;padding:0;border:1px solid color-mix(in srgb,var(--ao-accent) 40%,var(--ao-border));border-radius:12px;background:color-mix(in srgb,var(--ao-accent) 16%,var(--ao-card));color:var(--ao-accent);cursor:pointer}
+.cw-anime-overrides .ao-find[hidden]{display:none}
+.cw-anime-overrides .ao-find:disabled{opacity:.4;cursor:not-allowed;border-color:var(--ao-border);background:color-mix(in srgb,var(--ao-panel) 86%,#0b1321);color:var(--ao-muted)}
+.cw-anime-overrides .ao-find .material-symbols-rounded{font-size:20px}
+.cw-anime-overrides .ao-find-note{margin:0;font-size:12px;color:var(--ao-muted);opacity:.85}
+.cw-anime-overrides .ao-find-note[hidden]{display:none}
+
+.cw-anime-overrides .ao-finder{margin-top:12px;padding:12px;border:1px solid color-mix(in srgb,var(--ao-accent) 30%,var(--ao-border));border-radius:12px;background:color-mix(in srgb,var(--ao-accent) 7%,color-mix(in srgb,var(--ao-panel) 88%,#091321))}
+.cw-anime-overrides .ao-finder[hidden]{display:none}
+.cw-anime-overrides .ao-finder-head{display:grid;grid-template-columns:32px minmax(0,1fr) auto;align-items:start;gap:10px}
+.cw-anime-overrides .ao-finder-head>.material-symbols-rounded{width:32px;height:32px;display:grid;place-items:center;font-size:20px;color:var(--ao-accent)}
+.cw-anime-overrides .ao-finder-head strong{font-size:14px}
+.cw-anime-overrides .ao-finder-head p{margin:3px 0 0;font-size:12.5px}
+.cw-anime-overrides .ao-finder-search{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:8px;margin-top:10px}
+.cw-anime-overrides .ao-finder-search .ao-btn{min-height:42px}
+.cw-anime-overrides .ao-finder-status{min-height:18px;margin:8px 0 0;font-size:12.5px;color:var(--ao-muted)}
+.cw-anime-overrides .ao-finder-status[data-tone="ok"]{color:var(--ao-good)}
+.cw-anime-overrides .ao-finder-status[data-tone="err"]{color:var(--ao-danger)}
+.cw-anime-overrides .ao-finder-list{display:grid;gap:6px;margin-top:6px;max-height:260px;overflow:auto}
+.cw-anime-overrides .ao-finder-row{display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:center;gap:10px;padding:9px 11px;border:1px solid var(--ao-border);border-radius:10px;background:color-mix(in srgb,var(--ao-panel) 90%,#0b1321)}
+.cw-anime-overrides .ao-finder-main{min-width:0;display:grid;gap:3px}
+.cw-anime-overrides .ao-finder-title{font-size:14px;font-weight:850;word-break:break-word}
+.cw-anime-overrides .ao-finder-meta{font-size:12px;color:var(--ao-muted)}
+.cw-anime-overrides .ao-finder-actions{display:flex;align-items:center;gap:6px}
+.cw-anime-overrides .ao-finder-actions .ao-btn{min-height:34px;padding:0 12px;font-size:12.5px}
 .cw-anime-overrides .ao-season[hidden]{display:none}
 .cw-anime-overrides .ao-episodes{margin-top:12px;display:grid;gap:8px}
 .cw-anime-overrides .ao-episodes[hidden]{display:none}
@@ -79,5 +105,7 @@
   .cw-anime-overrides .ao-tools select{min-width:0;flex:1 1 100%}
   .cw-anime-overrides .ao-rule-row{grid-template-columns:minmax(0,1fr)}
   .cw-anime-overrides .ao-arrow{transform:rotate(90deg)}
+  .cw-anime-overrides .ao-finder-row{grid-template-columns:minmax(0,1fr)}
+  .cw-anime-overrides .ao-finder-actions{justify-content:flex-start}
   .cw-anime-overrides .ao-grid,.cw-anime-overrides .ao-grid-3{grid-template-columns:minmax(0,1fr)}
 }

--- a/cw_platform/anime_mapping/episodes.py
+++ b/cw_platform/anime_mapping/episodes.py
@@ -8,11 +8,12 @@ from dataclasses import dataclass
 from typing import Any, Callable
 
 from .coordinates import covers, translate
-from .overrides import find_episode_override
+from .overrides import find_episode_override, find_source_override
 from .storage import normalize_release_tag, query_edges, query_show_pair
 
 NATIVE_ORDER = ("anidb", "mal", "anilist")
 AIRED_ORDER = ("tvdb", "tmdb")
+REVERSE_NAMESPACES = ("simkl", "anidb", "mal", "anilist", "kitsu")
 _ANIDB_REGULAR = "R"
 
 
@@ -21,6 +22,16 @@ class Resolution:
     absolute: int
     namespace: str
     target_id: str
+    basis: str
+    entry: str
+
+
+@dataclass(frozen=True)
+class SourceCoordinate:
+    provider: str
+    ident: str
+    season: int
+    episode: int
     basis: str
     entry: str
 
@@ -192,6 +203,113 @@ def _native_passthrough(tag: str, ids: Mapping[str, str], season: int, episode: 
             entry=f"{namespace}_native",
         )
     return None
+
+
+def _scope_season(scope: Any) -> int | None:
+    text = str(scope or "").strip().lower()
+    if not text.startswith("s") or not text[1:].isdigit():
+        return None
+    return int(text[1:])
+
+
+def _override_source_coordinate(ids: Mapping[str, str], absolute: int) -> SourceCoordinate | None:
+    for namespace in REVERSE_NAMESPACES:
+        ident = ids.get(namespace, "")
+        if not ident:
+            continue
+        try:
+            ruled = find_source_override(namespace, ident, absolute)
+        except Exception:
+            ruled = None
+        if ruled is None:
+            continue
+        return SourceCoordinate(
+            provider=ruled.provider,
+            ident=ruled.ident,
+            season=ruled.season,
+            episode=ruled.episode,
+            basis="user_override",
+            entry=f"override:{ruled.rule_id}",
+        )
+    return None
+
+
+def _bridge_source_coordinate(tag: str, ids: Mapping[str, str], absolute: int) -> SourceCoordinate | None:
+    found: dict[tuple[str, str], tuple[int, int]] = {}
+    for namespace in NATIVE_ORDER:
+        ident = ids.get(namespace, "")
+        if not ident:
+            continue
+        try:
+            rows = query_edges(tag, namespace, ident)
+        except Exception:
+            continue
+        for row in rows:
+            if not int(row.get("reverse") or 0):
+                continue
+            if namespace == "anidb" and str(row.get("source_scope") or "").strip().upper() != _ANIDB_REGULAR:
+                continue
+            provider = str(row.get("target_provider") or "").strip().lower()
+            if provider not in AIRED_ORDER:
+                continue
+            if str(row.get("target_kind") or "").strip().lower() != "show":
+                continue
+            season = _scope_season(row.get("target_scope"))
+            if season is None or season <= 0:
+                continue
+            target_id = str(row.get("target_id") or "").strip()
+            if not target_id:
+                continue
+            episode = translate(row.get("source_range"), row.get("target_range"), absolute)
+            if episode is None or episode <= 0:
+                continue
+            key = (provider, target_id)
+            prior = found.get(key)
+            if prior is not None and prior != (season, episode):
+                return None
+            found[key] = (season, episode)
+
+    if not found:
+        return None
+    coords = set(found.values())
+    if len(coords) != 1:
+        return None
+    season, episode = coords.pop()
+    for provider in AIRED_ORDER:
+        for (row_provider, target_id), _coord in found.items():
+            if row_provider != provider:
+                continue
+            return SourceCoordinate(
+                provider=provider,
+                ident=target_id,
+                season=season,
+                episode=episode,
+                basis="anibridge_reverse",
+                entry=f"{provider}_reverse",
+            )
+    return None
+
+
+def resolve_source_coordinate(
+    ids: Mapping[str, Any] | None,
+    absolute: Any,
+    *,
+    release_tag: str = "v3",
+) -> SourceCoordinate | None:
+    abs_num = _as_int(absolute)
+    if abs_num is None or abs_num <= 0:
+        return None
+    clean = {
+        str(k).strip().lower(): str(v).strip()
+        for k, v in dict(ids or {}).items()
+        if str(v or "").strip()
+    }
+    if not clean:
+        return None
+    ruled = _override_source_coordinate(clean, abs_num)
+    if ruled is not None:
+        return ruled
+    return _bridge_source_coordinate(normalize_release_tag(release_tag), clean, abs_num)
 
 
 def resolution_matches_ids(resolution: Resolution | None, ids: Mapping[str, Any] | None) -> bool:

--- a/cw_platform/anime_mapping/overrides.py
+++ b/cw_platform/anime_mapping/overrides.py
@@ -69,6 +69,15 @@ class EpisodeOverride:
     rule_id: str
 
 
+@dataclass(frozen=True)
+class SourceOverride:
+    provider: str
+    ident: str
+    season: int
+    episode: int
+    rule_id: str
+
+
 def overrides_path() -> Path:
     return (CONFIG_BASE() / ".cw_state" / "anime_mapping_overrides.json").resolve()
 
@@ -385,6 +394,59 @@ def find_episode_override(
             rule_id=str(row.get("id") or ""),
         )
     return None
+
+
+def find_source_override(
+    namespace: Any,
+    target_id: Any,
+    absolute: Any,
+    *,
+    rows: list[dict[str, Any]] | None = None,
+) -> SourceOverride | None:
+    ns = str(namespace or "").strip().lower()
+    tid = str(target_id or "").strip()
+    abs_num = _as_int(absolute)
+    if not ns or not tid or abs_num is None or abs_num <= 0:
+        return None
+
+    found: SourceOverride | None = None
+    for row in rows if rows is not None else load_overrides():
+        if not row.get("enabled", True) or row.get("media_type") != "show":
+            continue
+        if str(row.get("target_namespace") or "") != ns or str(row.get("target_id") or "") != tid:
+            continue
+        ep_from = row.get("episode_from")
+        ep_start = row.get("episode_start_at")
+        season = row.get("match_season")
+        if ep_from is None or ep_start is None or season is None:
+            continue
+        offset = abs_num - int(ep_start)
+        if offset < 0:
+            continue
+        episode = int(ep_from) + offset
+        ep_to = row.get("episode_to")
+        if ep_to is not None and episode > int(ep_to):
+            continue
+        candidate = SourceOverride(
+            provider=str(row.get("match_provider") or ""),
+            ident=str(row.get("match_id") or ""),
+            season=int(season),
+            episode=episode,
+            rule_id=str(row.get("id") or ""),
+        )
+        if not candidate.provider or not candidate.ident:
+            continue
+        if found is None:
+            found = candidate
+            continue
+        if (found.provider, found.ident, found.season, found.episode) != (
+            candidate.provider,
+            candidate.ident,
+            candidate.season,
+            candidate.episode,
+        ):
+            return None
+    return found
 
 
 def find_identity_overrides(

--- a/cw_platform/anime_mapping/simkl_catalog.py
+++ b/cw_platform/anime_mapping/simkl_catalog.py
@@ -1,0 +1,313 @@
+# /cw_platform/anime_mapping/simkl_catalog.py
+# CrossWatch - SIMKL catalog lookups for the custom anime mapping editor
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from cw_platform.config_base import load_config
+from cw_platform.provider_instances import get_provider_block, list_instance_ids, normalize_instance_id
+
+from .overrides import MATCH_PROVIDERS
+
+BASE = "https://api.simkl.com"
+SEARCH_PATH = "/search/anime"
+DETAIL_PATH = "/anime"
+SEARCH_PARAM = "q"
+SEASON_TYPES = ("tv",)
+CHAIN_RELATION = "sequel"
+MAX_RESULTS = 25
+MAX_CHAIN = 40
+TIMEOUT = 20.0
+
+
+class SimklCatalogError(RuntimeError):
+    pass
+
+
+class SimklNotConfigured(SimklCatalogError):
+    pass
+
+
+@dataclass(frozen=True)
+class Entry:
+    simkl: str
+    title: str
+    label: str
+    year: int | None
+    kind: str
+    tmdb: str
+    total_episodes: int | None
+    poster: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "simkl": self.simkl,
+            "title": self.title,
+            "label": self.label,
+            "year": self.year,
+            "kind": self.kind,
+            "tmdb": self.tmdb,
+            "total_episodes": self.total_episodes,
+            "poster": self.poster,
+        }
+
+
+@dataclass
+class Chain:
+    entries: list[Entry] = field(default_factory=list)
+    skipped: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _text(value: Any, limit: int = 300) -> str:
+    return str(value or "").strip()[:limit]
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        out = int(str(value).strip())
+    except Exception:
+        return None
+    return out
+
+
+def _key_of(cfg: Mapping[str, Any], instance_id: Any) -> str:
+    block = get_provider_block(cfg, "simkl", instance_id) or {}
+    return _text(block.get("api_key") or block.get("client_id"), 200)
+
+
+def resolve_instance(instance_id: Any = None) -> tuple[str, str]:
+    cfg = load_config() or {}
+    wanted = normalize_instance_id(instance_id)
+    key = _key_of(cfg, wanted)
+    if key:
+        return wanted, key
+    for candidate in list_instance_ids(cfg, "simkl"):
+        if normalize_instance_id(candidate) == wanted:
+            continue
+        key = _key_of(cfg, candidate)
+        if key:
+            return normalize_instance_id(candidate), key
+    return wanted, ""
+
+
+def instances() -> list[str]:
+    cfg = load_config() or {}
+    return [inst for inst in list_instance_ids(cfg, "simkl") if _key_of(cfg, inst)]
+
+
+def client_id(instance_id: Any = None) -> str:
+    return resolve_instance(instance_id)[1]
+
+
+def configured(instance_id: Any = None) -> bool:
+    return bool(client_id(instance_id))
+
+
+def _app_version() -> str:
+    try:
+        from providers.sync.simkl._common import simkl_app_version
+
+        return str(simkl_app_version())
+    except Exception:
+        return "1.0"
+
+
+def _request(path: str, *, instance_id: Any = None, **params: Any) -> Any:
+    key = client_id(instance_id)
+    if not key:
+        raise SimklNotConfigured("SIMKL is not connected")
+    try:
+        import requests
+    except Exception as exc:
+        raise SimklCatalogError("HTTP client unavailable") from exc
+
+    version = _app_version()
+    query: dict[str, Any] = {"client_id": key, "app-name": "crosswatch", "app-version": version}
+    query.update({k: v for k, v in params.items() if v is not None})
+    try:
+        resp = requests.get(
+            f"{BASE}{path}",
+            headers={"Accept": "application/json", "User-Agent": f"crosswatch/{version}"},
+            params=query,
+            timeout=TIMEOUT,
+        )
+    except Exception as exc:
+        raise SimklCatalogError("SIMKL request failed") from exc
+    if resp.status_code == 401 or resp.status_code == 403:
+        raise SimklNotConfigured("SIMKL rejected the client id")
+    if resp.status_code >= 400:
+        raise SimklCatalogError(f"SIMKL returned {resp.status_code}")
+    try:
+        return resp.json()
+    except Exception as exc:
+        raise SimklCatalogError("SIMKL returned an unreadable response") from exc
+
+
+def _ids_of(row: Mapping[str, Any]) -> dict[str, str]:
+    ids = row.get("ids") if isinstance(row.get("ids"), Mapping) else {}
+    out: dict[str, str] = {}
+    for k, v in (ids or {}).items():
+        text = _text(v, 64)
+        if text:
+            out[str(k).strip().lower()] = text
+    return out
+
+
+def _simkl_id(ids: Mapping[str, str]) -> str:
+    return _text(ids.get("simkl") or ids.get("simkl_id"), 64)
+
+
+def _kind_of(row: Mapping[str, Any]) -> str:
+    return _text(row.get("anime_type") or row.get("type"), 32).lower()
+
+
+def _entry_from_row(row: Mapping[str, Any], *, total_episodes: int | None = None) -> Entry | None:
+    ids = _ids_of(row)
+    simkl = _simkl_id(ids)
+    if not simkl:
+        return None
+    title = _text(row.get("title")) or _text(row.get("title_romaji")) or f"SIMKL {simkl}"
+    label = _text(row.get("title_en")) or _text(row.get("en_title")) or title
+    return Entry(
+        simkl=simkl,
+        title=title,
+        label=label,
+        year=_int_or_none(row.get("year")),
+        kind=_kind_of(row),
+        tmdb=_text(ids.get("tmdb"), 64),
+        total_episodes=total_episodes if total_episodes is not None else _int_or_none(row.get("total_episodes")),
+        poster=_text(row.get("poster"), 200),
+    )
+
+
+def search(query: str, *, limit: int = MAX_RESULTS, instance_id: Any = None) -> list[Entry]:
+    term = _text(query, 200)
+    if not term:
+        return []
+    body = _request(
+        SEARCH_PATH,
+        instance_id=instance_id,
+        **{SEARCH_PARAM: term},
+        limit=max(1, min(int(limit or MAX_RESULTS), MAX_RESULTS)),
+        page=1,
+    )
+    rows = body if isinstance(body, list) else []
+    out: list[Entry] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        entry = _entry_from_row(row)
+        if entry is None or entry.kind not in SEASON_TYPES:
+            continue
+        out.append(entry)
+    return out
+
+
+def detail(simkl_id: Any, *, instance_id: Any = None) -> dict[str, Any]:
+    ident = _text(simkl_id, 64)
+    if not ident or not ident.isdigit():
+        raise SimklCatalogError("Invalid SIMKL id")
+    body = _request(f"{DETAIL_PATH}/{ident}", instance_id=instance_id)
+    return dict(body) if isinstance(body, Mapping) else {}
+
+
+def _sequel_ids(body: Mapping[str, Any]) -> list[str]:
+    raw = body.get("relations")
+    relations: list[Any] = raw if isinstance(raw, list) else []
+    out: list[str] = []
+    for rel in relations:
+        if not isinstance(rel, Mapping):
+            continue
+        if _text(rel.get("relation_type"), 32).lower() != CHAIN_RELATION:
+            continue
+        if _kind_of(rel) not in SEASON_TYPES:
+            continue
+        ident = _simkl_id(_ids_of(rel))
+        if ident and ident not in out:
+            out.append(ident)
+    return out
+
+
+def season_chain(simkl_id: Any, *, instance_id: Any = None) -> Chain:
+    root = detail(simkl_id, instance_id=instance_id)
+    chain = Chain()
+    seen: set[str] = set()
+    skipped: list[dict[str, Any]] = []
+
+    def consider(body: Mapping[str, Any]) -> None:
+        entry = _entry_from_row(body)
+        if entry is None or entry.simkl in seen:
+            return
+        seen.add(entry.simkl)
+        if entry.year is None or entry.total_episodes is None or entry.total_episodes <= 0:
+            skipped.append({"simkl": entry.simkl, "label": entry.label, "reason": "not aired yet"})
+            return
+        chain.entries.append(entry)
+
+    consider(root)
+    for ident in _sequel_ids(root)[:MAX_CHAIN]:
+        try:
+            consider(detail(ident, instance_id=instance_id))
+        except SimklCatalogError:
+            skipped.append({"simkl": ident, "label": "", "reason": "lookup failed"})
+
+    chain.entries.sort(key=lambda e: (e.year or 0, e.simkl))
+    chain.skipped = skipped
+    return chain
+
+
+def plan_rules(
+    simkl_id: Any,
+    *,
+    match_provider: str,
+    match_id: str,
+    match_season: Any = 1,
+    title: str = "",
+    instance_id: Any = None,
+) -> dict[str, Any]:
+    provider = _text(match_provider, 32).lower()
+    if provider not in MATCH_PROVIDERS:
+        raise SimklCatalogError("Unsupported match provider")
+    ident = _text(match_id, 64)
+    if not ident:
+        raise SimklCatalogError("A source id is required")
+    season = _int_or_none(match_season)
+    if season is None or season < 0:
+        season = 1
+
+    chain = season_chain(simkl_id, instance_id=instance_id)
+    if not chain.entries:
+        raise SimklCatalogError("No aired seasons found for that SIMKL entry")
+
+    base_title = _text(title) or chain.entries[0].title
+    rules: list[dict[str, Any]] = []
+    cursor = 1
+    for entry in chain.entries:
+        count = int(entry.total_episodes or 0)
+        rules.append(
+            {
+                "media_type": "show",
+                "title": base_title,
+                "note": entry.label,
+                "match_provider": provider,
+                "match_id": ident,
+                "match_season": season,
+                "target_namespace": "simkl",
+                "target_id": entry.simkl,
+                "episode_from": cursor,
+                "episode_to": cursor + count - 1,
+                "episode_start_at": 1,
+                "enabled": True,
+            }
+        )
+        cursor += count
+
+    return {
+        "rules": rules,
+        "chain": [e.as_dict() for e in chain.entries],
+        "skipped": chain.skipped,
+        "total_episodes": cursor - 1,
+    }

--- a/providers/sync/simkl/_history.py
+++ b/providers/sync/simkl/_history.py
@@ -10,7 +10,7 @@ from difflib import SequenceMatcher
 from itertools import chain
 from typing import Any, Iterable, Mapping, cast
 
-from cw_platform.anime_mapping.episodes import resolve_absolute
+from cw_platform.anime_mapping.episodes import SourceCoordinate, resolve_absolute, resolve_source_coordinate
 from cw_platform.anime_mapping.service import (
     PAIR_FEATURE_OPTIONS_KEY,
     mapping_enabled_for_feature,
@@ -889,6 +889,42 @@ def _source_episode_id_aliases() -> dict[tuple[str, str], dict[str, Any]]:
     return out
 
 
+_AIRED_ID_KEYS = ("tmdb", "tvdb", "imdb")
+
+
+def _anime_source_coordinate(
+    show_ids: Mapping[str, Any],
+    native_number: int,
+    release_tag: str,
+    cache: dict[tuple[str, int], SourceCoordinate | None],
+) -> SourceCoordinate | None:
+    if not release_tag:
+        return None
+    key = (_show_identity_key(show_ids), int(native_number))
+    if key in cache:
+        return cache[key]
+    try:
+        found = resolve_source_coordinate(show_ids, native_number, release_tag=release_tag)
+    except Exception as exc:
+        _dbg("anibridge_reverse_failed", error=exc.__class__.__name__)
+        found = None
+    cache[key] = found
+    return found
+
+
+def _source_coordinate_show_ids(show_ids: Mapping[str, Any], coord: SourceCoordinate) -> dict[str, Any]:
+    provider = str(coord.provider or "").strip().lower()
+    ident = str(coord.ident or "").strip()
+    out = dict(show_ids)
+    if not provider or not ident or str(out.get(provider) or "").strip() == ident:
+        return out
+    out[provider] = ident
+    for other in _AIRED_ID_KEYS:
+        if other != provider:
+            out.pop(other, None)
+    return out
+
+
 def _apply_since_limit(
     out: dict[str, dict[str, Any]],
     *,
@@ -990,6 +1026,7 @@ def _parse_rows(
     headers: Mapping[str, str] | None = None,
     timeout: float | None = None,
     limit: int | None,
+    bridge_tag: str = "",
 ) -> tuple[dict[str, dict[str, Any]], set[str], int | None, int | None, int | None, int, int]:
     """Parse raw API rows into history event dicts. Returns (out, thaw, latest_movies, latest_shows, latest_anime, movies_cnt, eps_cnt)."""
     out: dict[str, dict[str, Any]] = {}
@@ -1005,11 +1042,14 @@ def _parse_rows(
     source_title_alias_cache: dict[str, dict[str, dict[str, Any]]] = {}
     source_abs_alias_cache: dict[str, dict[int, dict[str, Any]]] = {}
     source_ep_id_alias_cache: dict[tuple[str, str], dict[str, Any]] | None = None
+    source_coord_cache: dict[tuple[str, int], SourceCoordinate | None] = {}
     watched_coords_by_show = _watched_coordinates_by_show(show_rows)
     stat_with_ids = 0
     stat_no_ids = 0
     stat_exact_hit = 0
     stat_collision = 0
+    stat_coord_override = 0
+    stat_coord_bridge = 0
 
     for row in movie_rows:
         if not isinstance(row, Mapping):
@@ -1119,6 +1159,7 @@ def _parse_rows(
                 e_num = e_num_internal
                 alias: Mapping[str, Any] | None = None
                 show_key = ""
+                ep_show_ids: Mapping[str, Any] = show_ids
                 src_ep_ids = _episode_exact_ids(episode)
                 if src_ep_ids:
                     if source_ep_id_alias_cache is None:
@@ -1180,7 +1221,13 @@ def _parse_rows(
                                     e_num_internal,
                                 )
                     tvdb_map = episode.get("tvdb")
-                    if alias is not None:
+                    coord = _anime_source_coordinate(show_ids, e_num_internal, bridge_tag, source_coord_cache)
+                    if coord is not None and coord.basis == "user_override":
+                        s_num = coord.season
+                        e_num = coord.episode
+                        ep_show_ids = _source_coordinate_show_ids(show_ids, coord)
+                        stat_coord_override += 1
+                    elif alias is not None:
                         s_m = _int_or_none(alias.get("season"))
                         e_m = _int_or_none(alias.get("episode"))
                         if s_m is not None and s_m >= 0 and e_m is not None and e_m > 0:
@@ -1192,6 +1239,11 @@ def _parse_rows(
                         if s_m is not None and s_m >= 0 and e_m is not None and e_m >= 1:
                             s_num = s_m
                             e_num = e_m
+                    elif coord is not None:
+                        s_num = coord.season
+                        e_num = coord.episode
+                        ep_show_ids = _source_coordinate_show_ids(show_ids, coord)
+                        stat_coord_bridge += 1
                     elif session is not None and headers is not None and timeout is not None:
                         mapped = _anime_tvdb_season_episode_for_number(
                             session,
@@ -1223,12 +1275,12 @@ def _parse_rows(
                     "type": "episode",
                     "season": s_num,
                     "episode": e_num,
-                    "ids": dict(alias_ids or episode_ids or alias_show_ids or show_ids),
+                    "ids": dict(alias_ids or episode_ids or alias_show_ids or ep_show_ids),
                     "title": alias_title if isinstance(alias_title, str) and alias_title.strip() else f"S{s_num:02d}E{e_num:02d}",
                     "year": None,
                     "series_title": alias_series_title if isinstance(alias_series_title, str) and alias_series_title.strip() else series_name,
                     "series_year": alias_series_year if alias_series_year not in (None, "") else show_year,
-                    "show_ids": dict(alias_show_ids or show_ids),
+                    "show_ids": dict(alias_show_ids or ep_show_ids),
                     "watched": True,
                     "watched_at": watched_at,
                     "simkl_bucket": row_kind,
@@ -1262,6 +1314,8 @@ def _parse_rows(
         alias_rejected_collision=stat_collision,
         alias_table_size=len(source_ep_id_alias_cache or {}),
     )
+    if stat_coord_override or stat_coord_bridge:
+        _info("anibridge_readback", overrides=stat_coord_override, reverse=stat_coord_bridge)
     return out, thaw, latest_ts_movies, latest_ts_shows, latest_ts_anime, movies_cnt, eps_cnt
 
 
@@ -1346,6 +1400,7 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
         headers=headers,
         timeout=timeout,
         limit=None,  # apply limit to final result only
+        bridge_tag=_anibridge_release_tag(adapter),
     )
     if not rewatches:
         _dedupe_history_movies(fetched)
@@ -1674,6 +1729,13 @@ def _anibridge_config(adapter: Any) -> Mapping[str, Any] | None:
         if opts.get("use_anime_mapping") is False:
             return None
     return block
+
+
+def _anibridge_release_tag(adapter: Any) -> str:
+    block = _anibridge_config(adapter)
+    if block is None:
+        return ""
+    return str(block.get("release_tag") or "v3")
 
 
 def _with_anibridge_map(adapter: Any, item: Mapping[str, Any], block: Mapping[str, Any] | None) -> Mapping[str, Any]:

--- a/tests/test_anime_reverse_mapping.py
+++ b/tests/test_anime_reverse_mapping.py
@@ -1,0 +1,252 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cw_platform.anime_mapping import overrides as ov
+from cw_platform.anime_mapping import storage
+from cw_platform.anime_mapping.episodes import resolve_absolute, resolve_source_coordinate
+from cw_platform.id_map import canonical_key
+from providers.sync.simkl import _history as simkl_history
+
+DBZ_MAPPINGS: dict[str, Any] = {
+    "tvdb_show:81472:s1": {"mal:813": {"1-39": "1-39"}},
+    "tvdb_show:81472:s2": {"mal:813": {"1-35": "40-74"}},
+    "tvdb_show:81472:s3": {"mal:813": {"1-33": "75-107"}},
+}
+
+
+@pytest.fixture()
+def dbz_index(config_base: Path) -> Path:
+    paths = storage.paths("v3")
+    paths["root"].mkdir(parents=True, exist_ok=True)
+    paths["mappings"].write_text(json.dumps(DBZ_MAPPINGS), encoding="utf-8")
+    storage.rebuild_sqlite_from_mappings(release_tag="v3")
+    return paths["db"]
+
+
+def _dandadan_rules() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "ovr_dandadan_s1",
+            "media_type": "show",
+            "match_provider": "tmdb",
+            "match_id": "240411",
+            "match_season": 1,
+            "target_namespace": "simkl",
+            "target_id": "2308514",
+            "episode_from": 1,
+            "episode_to": 12,
+            "episode_start_at": 1,
+        },
+        {
+            "id": "ovr_dandadan_s2",
+            "media_type": "show",
+            "match_provider": "tmdb",
+            "match_id": "240411",
+            "match_season": 1,
+            "target_namespace": "simkl",
+            "target_id": "2665178",
+            "episode_from": 13,
+            "episode_to": 24,
+            "episode_start_at": 1,
+        },
+    ]
+
+
+def test_override_reverse_recovers_the_source_coordinate(config_base: Path) -> None:
+    for rule in _dandadan_rules():
+        ov.upsert_override(rule)
+
+    coord = resolve_source_coordinate({"simkl": "2665178", "tmdb": "299464"}, 1)
+
+    assert coord is not None
+    assert coord.basis == "user_override"
+    assert (coord.provider, coord.ident) == ("tmdb", "240411")
+    assert (coord.season, coord.episode) == (1, 13)
+
+
+def test_override_reverse_round_trips_the_forward_map(config_base: Path) -> None:
+    for rule in _dandadan_rules():
+        ov.upsert_override(rule)
+
+    for episode in range(13, 25):
+        forward = resolve_absolute(
+            {"type": "episode", "show_ids": {"tmdb": "240411"}, "season": 1, "episode": episode}
+        )
+        assert forward is not None
+        assert (forward.namespace, forward.target_id) == ("simkl", "2665178")
+
+        back = resolve_source_coordinate({"simkl": forward.target_id}, forward.absolute)
+        assert back is not None
+        assert (back.provider, back.ident, back.season, back.episode) == ("tmdb", "240411", 1, episode)
+
+
+def test_override_reverse_picks_the_range_that_contains_the_episode(config_base: Path) -> None:
+    seasons = [(1, 1, 39, 1), (2, 1, 35, 40), (3, 1, 33, 75)]
+    for season, ep_from, ep_to, start in seasons:
+        ov.upsert_override(
+            {
+                "id": f"ovr_dbz_s{season}",
+                "media_type": "show",
+                "match_provider": "tmdb",
+                "match_id": "12971",
+                "match_season": season,
+                "target_namespace": "simkl",
+                "target_id": "41487",
+                "episode_from": ep_from,
+                "episode_to": ep_to,
+                "episode_start_at": start,
+            }
+        )
+
+    assert resolve_source_coordinate({"simkl": "41487"}, 39).season == 1
+    assert resolve_source_coordinate({"simkl": "41487"}, 40).season == 2
+    assert resolve_source_coordinate({"simkl": "41487"}, 40).episode == 1
+    assert resolve_source_coordinate({"simkl": "41487"}, 74).episode == 35
+    assert resolve_source_coordinate({"simkl": "41487"}, 75).season == 3
+    assert resolve_source_coordinate({"simkl": "41487"}, 999) is None
+
+
+def test_anibridge_reverse_maps_absolute_back_to_aired(dbz_index: Path) -> None:
+    coord = resolve_source_coordinate({"mal": "813", "tvdb": "81472"}, 40)
+
+    assert coord is not None
+    assert coord.basis == "anibridge_reverse"
+    assert (coord.provider, coord.ident) == ("tvdb", "81472")
+    assert (coord.season, coord.episode) == (2, 1)
+
+
+def test_anibridge_reverse_round_trips_every_dbz_season(dbz_index: Path) -> None:
+    for season, count, offset in ((1, 39, 0), (2, 35, 39), (3, 33, 74)):
+        for episode in range(1, count + 1):
+            forward = resolve_absolute(
+                {"type": "episode", "show_ids": {"tvdb": "81472"}, "season": season, "episode": episode}
+            )
+            assert forward is not None
+            assert forward.absolute == offset + episode
+
+            back = resolve_source_coordinate({"mal": forward.target_id}, forward.absolute)
+            assert back is not None
+            assert (back.season, back.episode) == (season, episode)
+
+
+def test_user_override_outranks_the_downloaded_dataset(dbz_index: Path) -> None:
+    ov.upsert_override(
+        {
+            "id": "ovr_dbz_custom",
+            "media_type": "show",
+            "match_provider": "tmdb",
+            "match_id": "12971",
+            "match_season": 5,
+            "target_namespace": "mal",
+            "target_id": "813",
+            "episode_from": 1,
+            "episode_to": 35,
+            "episode_start_at": 40,
+        }
+    )
+
+    coord = resolve_source_coordinate({"mal": "813", "tvdb": "81472"}, 40)
+
+    assert coord is not None
+    assert coord.basis == "user_override"
+    assert (coord.provider, coord.ident, coord.season, coord.episode) == ("tmdb", "12971", 5, 1)
+
+
+def test_reverse_returns_nothing_without_ids_or_a_usable_number(dbz_index: Path) -> None:
+    assert resolve_source_coordinate({}, 40) is None
+    assert resolve_source_coordinate({"mal": "813"}, 0) is None
+    assert resolve_source_coordinate({"mal": "813"}, None) is None
+    assert resolve_source_coordinate({"mal": "99999"}, 40) is None
+
+
+def _floppy_episode(tmdb: str, season: int, episode: int) -> dict[str, Any]:
+    return {
+        "type": "episode",
+        "show_ids": {"tmdb": tmdb},
+        "season": season,
+        "episode": episode,
+        "watched_at": "2026-08-03T13:35:19Z",
+    }
+
+
+def _simkl_anime_row(show_ids: dict[str, Any], numbers: list[int]) -> dict[str, Any]:
+    return {
+        "show": {"title": "Anime", "ids": dict(show_ids)},
+        "seasons": [
+            {
+                "number": 1,
+                "episodes": [{"number": n, "watched_at": "2026-08-03T13:35:19Z"} for n in numbers],
+            }
+        ],
+    }
+
+
+def _episodes_from(out: dict[str, Any]) -> list[dict[str, Any]]:
+    return [v for v in out.values() if str(v.get("type")) == "episode"]
+
+
+def test_readback_uses_an_override_to_match_the_source_key(config_base: Path, monkeypatch) -> None:
+    for rule in _dandadan_rules():
+        ov.upsert_override(rule)
+    monkeypatch.setattr(simkl_history, "_load_source_aliases", lambda: {})
+
+    row = _simkl_anime_row({"simkl": 2665178, "tmdb": "299464"}, [1, 2, 3])
+    out, *_ = simkl_history._parse_rows([], [], [row], limit=None, bridge_tag="v3")
+
+    eps = sorted(_episodes_from(out), key=lambda e: e["episode"])
+    assert [(e["season"], e["episode"]) for e in eps] == [(1, 13), (1, 14), (1, 15)]
+    assert [e["show_ids"]["tmdb"] for e in eps] == ["240411"] * 3
+    assert canonical_key(eps[0]) == canonical_key(_floppy_episode("240411", 1, 13))
+
+
+def test_readback_without_the_bridge_keeps_the_unmatched_key(config_base: Path, monkeypatch) -> None:
+    for rule in _dandadan_rules():
+        ov.upsert_override(rule)
+    monkeypatch.setattr(simkl_history, "_load_source_aliases", lambda: {})
+
+    row = _simkl_anime_row({"simkl": 2665178, "tmdb": "299464"}, [1])
+    out, *_ = simkl_history._parse_rows([], [], [row], limit=None)
+
+    ep = _episodes_from(out)[0]
+    assert (ep["season"], ep["episode"]) == (1, 1)
+    assert canonical_key(ep) != canonical_key(_floppy_episode("240411", 1, 13))
+
+
+def test_readback_reverses_dbz_absolute_numbers_through_anibridge(dbz_index: Path, monkeypatch) -> None:
+    monkeypatch.setattr(simkl_history, "_load_source_aliases", lambda: {})
+
+    row = _simkl_anime_row({"simkl": 41487, "tmdb": "12971", "tvdb": "81472", "mal": "813"}, [39, 40, 74, 75])
+    out, *_ = simkl_history._parse_rows([], [], [row], limit=None, bridge_tag="v3")
+
+    eps = sorted(_episodes_from(out), key=lambda e: (e["season"], e["episode"]))
+    assert [(e["season"], e["episode"]) for e in eps] == [(1, 39), (2, 1), (2, 35), (3, 1)]
+    assert canonical_key(eps[1]) == canonical_key(_floppy_episode("12971", 2, 1))
+    assert all(e["show_ids"]["tmdb"] == "12971" for e in eps)
+
+
+def test_readback_leaves_non_anime_rows_alone(dbz_index: Path, monkeypatch) -> None:
+    monkeypatch.setattr(simkl_history, "_load_source_aliases", lambda: {})
+
+    show_row = {
+        "show": {"title": "Loki", "ids": {"simkl": 1074318, "tmdb": "331223"}},
+        "seasons": [{"number": 2, "episodes": [{"number": 4, "watched_at": "2023-12-29T17:47:00Z"}]}],
+    }
+    out, *_ = simkl_history._parse_rows([], [show_row], [], limit=None, bridge_tag="v3")
+
+    ep = _episodes_from(out)[0]
+    assert (ep["season"], ep["episode"]) == (2, 4)
+    assert ep["show_ids"]["tmdb"] == "331223"
+
+
+def test_disabled_rules_do_not_reverse_map(config_base: Path) -> None:
+    rule = dict(_dandadan_rules()[1])
+    rule["enabled"] = False
+    ov.upsert_override(rule)
+
+    assert resolve_source_coordinate({"simkl": "2665178"}, 1) is None

--- a/tests/test_simkl_catalog.py
+++ b/tests/test_simkl_catalog.py
@@ -1,0 +1,245 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cw_platform.anime_mapping import simkl_catalog as sc
+
+DANDADAN_SEARCH: list[dict[str, Any]] = [
+    {
+        "endpoint_type": "anime",
+        "ids": {"simkl_id": 2308514, "slug": "dan-da-dan", "tmdb": "240411"},
+        "title": "Dan Da Dan",
+        "title_romaji": "Dan Da Dan",
+        "type": "tv",
+        "year": 2024,
+    },
+    {
+        "endpoint_type": "anime",
+        "ids": {"simkl_id": 2665178, "slug": "dan-da-dan", "tmdb": "299464"},
+        "title": "Dan Da Dan",
+        "title_en": "Dan Da Dan Season 2",
+        "type": "tv",
+        "year": 2025,
+    },
+    {
+        "endpoint_type": "anime",
+        "ids": {"simkl_id": 2884140, "slug": "dan-da-dan"},
+        "title": "Dan Da Dan",
+        "title_en": "Dan Da Dan Season 3",
+        "type": "tv",
+    },
+    {
+        "endpoint_type": "anime",
+        "ids": {"simkl_id": 2833324, "slug": "recap"},
+        "title": "Dan Da Dan Recap",
+        "type": "movie",
+        "year": 2025,
+    },
+]
+
+DETAILS: dict[str, dict[str, Any]] = {
+    "2308514": {
+        "ids": {"simkl": 2308514, "tmdb": "240411"},
+        "title": "Dan Da Dan",
+        "year": 2024,
+        "anime_type": "tv",
+        "total_episodes": 12,
+        "relations": [
+            {"anime_type": "tv", "ids": {"simkl": 2665178}, "relation_type": "sequel", "title": "Dan Da Dan", "year": 2025},
+            {"anime_type": "tv", "ids": {"simkl": 2884140}, "relation_type": "sequel", "title": "Dan Da Dan", "year": None},
+            {"anime_type": "movie", "ids": {"simkl": 999999}, "relation_type": "sequel", "title": "A movie", "year": 2025},
+            {"anime_type": "tv", "ids": {"simkl": 111111}, "relation_type": "prequel", "title": "A prequel", "year": 2010},
+        ],
+    },
+    "2665178": {
+        "ids": {"simkl": 2665178, "tmdb": "299464"},
+        "title": "Dan Da Dan",
+        "en_title": "Dan Da Dan Season 2",
+        "year": 2025,
+        "anime_type": "tv",
+        "total_episodes": 12,
+        "relations": [],
+    },
+    "2884140": {
+        "ids": {"simkl": 2884140},
+        "title": "Dan Da Dan",
+        "en_title": "Dan Da Dan Season 3",
+        "year": None,
+        "anime_type": "tv",
+        "total_episodes": None,
+        "relations": [],
+    },
+}
+
+REZERO_DETAILS: dict[str, dict[str, Any]] = {
+    "509292": {
+        "ids": {"simkl": 509292, "tmdb": "65942"},
+        "title": "Re:Zero kara Hajimeru Isekai Seikatsu",
+        "en_title": "Re:Zero - Starting Life in Another World",
+        "year": 2016,
+        "anime_type": "tv",
+        "total_episodes": 25,
+        "relations": [
+            {"anime_type": "tv", "ids": {"simkl": 2125704}, "relation_type": "sequel", "year": 2024},
+            {"anime_type": "tv", "ids": {"simkl": 1063491}, "relation_type": "sequel", "year": 2020},
+            {"anime_type": "tv", "ids": {"simkl": 2743422}, "relation_type": "sequel", "year": 2026},
+            {"anime_type": "tv", "ids": {"simkl": 1367345}, "relation_type": "sequel", "year": 2021},
+        ],
+    },
+    "1063491": {"ids": {"simkl": 1063491}, "title": "Re:Zero", "en_title": "S2", "year": 2020, "anime_type": "tv", "total_episodes": 13, "relations": []},
+    "1367345": {"ids": {"simkl": 1367345}, "title": "Re:Zero", "en_title": "Part 2", "year": 2021, "anime_type": "tv", "total_episodes": 12, "relations": []},
+    "2125704": {"ids": {"simkl": 2125704}, "title": "Re:Zero", "en_title": "S3", "year": 2024, "anime_type": "tv", "total_episodes": 16, "relations": []},
+    "2743422": {"ids": {"simkl": 2743422, "tmdb": "328061"}, "title": "Re:Zero", "en_title": "S4", "year": 2026, "anime_type": "tv", "total_episodes": 11, "relations": []},
+}
+
+
+@pytest.fixture()
+def simkl(monkeypatch, config_base: Path):
+    calls: list[tuple[str, dict[str, Any]]] = []
+    details: dict[str, dict[str, Any]] = dict(DETAILS)
+    search_rows: list[dict[str, Any]] = list(DANDADAN_SEARCH)
+
+    def fake_request(path: str, **params: Any) -> Any:
+        calls.append((path, dict(params)))
+        if path == sc.SEARCH_PATH:
+            return list(search_rows)
+        if path.startswith(f"{sc.DETAIL_PATH}/"):
+            ident = path.rsplit("/", 1)[-1]
+            if ident not in details:
+                raise sc.SimklCatalogError("SIMKL returned 404")
+            return dict(details[ident])
+        raise AssertionError(f"unexpected path {path}")
+
+    monkeypatch.setattr(sc, "client_id", lambda: "test-client-id")
+    monkeypatch.setattr(sc, "_request", fake_request)
+    return {"calls": calls, "details": details, "search_rows": search_rows}
+
+
+def test_search_keeps_split_seasons_and_drops_non_tv(simkl) -> None:
+    results = sc.search("Dan Da Dan")
+
+    assert [r.simkl for r in results] == ["2308514", "2665178", "2884140"]
+    assert results[1].label == "Dan Da Dan Season 2"
+    assert results[1].tmdb == "299464"
+    assert results[2].tmdb == ""
+    assert simkl["calls"][0][1][sc.SEARCH_PARAM] == "Dan Da Dan"
+
+
+def test_search_falls_back_to_title_when_there_is_no_english_label(simkl) -> None:
+    results = sc.search("Dan Da Dan")
+    assert results[0].label == "Dan Da Dan"
+
+
+def test_season_chain_drops_unaired_entries(simkl) -> None:
+    chain = sc.season_chain("2308514")
+
+    assert [e.simkl for e in chain.entries] == ["2308514", "2665178"]
+    assert [e.total_episodes for e in chain.entries] == [12, 12]
+    assert chain.skipped and chain.skipped[0]["simkl"] == "2884140"
+
+
+def test_plan_builds_contiguous_ranges_for_dandadan(simkl) -> None:
+    plan = sc.plan_rules("2308514", match_provider="tmdb", match_id="240411", match_season=1)
+
+    ranges = [(r["episode_from"], r["episode_to"], r["target_id"], r["episode_start_at"]) for r in plan["rules"]]
+    assert ranges == [(1, 12, "2308514", 1), (13, 24, "2665178", 1)]
+    assert plan["total_episodes"] == 24
+    assert all(r["match_provider"] == "tmdb" and r["match_id"] == "240411" for r in plan["rules"])
+    assert all(r["match_season"] == 1 and r["target_namespace"] == "simkl" for r in plan["rules"])
+
+
+def test_plan_orders_the_chain_by_year_not_api_order(simkl, monkeypatch) -> None:
+    simkl["details"].clear()
+    simkl["details"].update(REZERO_DETAILS)
+
+    plan = sc.plan_rules("509292", match_provider="tmdb", match_id="65942", match_season=1)
+
+    ranges = [(r["episode_from"], r["episode_to"], r["target_id"]) for r in plan["rules"]]
+    assert ranges == [
+        (1, 25, "509292"),
+        (26, 38, "1063491"),
+        (39, 50, "1367345"),
+        (51, 66, "2125704"),
+        (67, 77, "2743422"),
+    ]
+    assert plan["total_episodes"] == 77
+
+
+def test_plan_rejects_a_bad_provider_or_missing_source_id(simkl) -> None:
+    with pytest.raises(sc.SimklCatalogError):
+        sc.plan_rules("2308514", match_provider="netflix", match_id="240411")
+    with pytest.raises(sc.SimklCatalogError):
+        sc.plan_rules("2308514", match_provider="tmdb", match_id="")
+
+
+def test_plan_survives_a_failing_sequel_lookup(simkl) -> None:
+    simkl["details"].pop("2665178")
+
+    plan = sc.plan_rules("2308514", match_provider="tmdb", match_id="240411")
+
+    assert [r["target_id"] for r in plan["rules"]] == ["2308514"]
+    assert any(row["reason"] == "lookup failed" for row in plan["skipped"])
+
+
+def test_detail_rejects_a_non_numeric_id(simkl) -> None:
+    with pytest.raises(sc.SimklCatalogError):
+        sc.detail("../../etc/passwd")
+
+
+def test_lookups_require_a_configured_client_id(monkeypatch, config_base: Path) -> None:
+    monkeypatch.setattr(sc, "client_id", lambda instance_id=None: "")
+    assert sc.configured() is False
+    with pytest.raises(sc.SimklNotConfigured):
+        sc._request("/search/anime", q="x")
+
+
+def _with_config(monkeypatch, cfg: dict[str, Any]) -> None:
+    monkeypatch.setattr(sc, "load_config", lambda: cfg)
+
+
+def test_client_id_reads_the_default_profile(monkeypatch, config_base: Path) -> None:
+    _with_config(monkeypatch, {"simkl": {"api_key": "base-key"}})
+
+    assert sc.resolve_instance() == ("default", "base-key")
+    assert sc.configured() is True
+    assert sc.instances() == ["default"]
+
+
+def test_client_id_falls_back_to_a_named_profile(monkeypatch, config_base: Path) -> None:
+    _with_config(monkeypatch, {"simkl": {"instances": {"second": {"api_key": "profile-key"}}}})
+
+    assert sc.resolve_instance() == ("second", "profile-key")
+    assert sc.configured() is True
+    assert sc.instances() == ["second"]
+
+
+def test_a_named_profile_can_override_the_client_id(monkeypatch, config_base: Path) -> None:
+    _with_config(
+        monkeypatch,
+        {"simkl": {"api_key": "base-key", "instances": {"second": {"api_key": "other-key"}}}},
+    )
+
+    assert sc.resolve_instance("second") == ("second", "other-key")
+    assert sc.resolve_instance() == ("default", "base-key")
+    assert sc.instances() == ["default", "second"]
+
+
+def test_a_profile_without_its_own_key_inherits_the_base_one(monkeypatch, config_base: Path) -> None:
+    _with_config(
+        monkeypatch,
+        {"simkl": {"api_key": "base-key", "instances": {"second": {"access_token": "t"}}}},
+    )
+
+    assert sc.resolve_instance("second") == ("second", "base-key")
+
+
+def test_no_profile_anywhere_reports_unconfigured(monkeypatch, config_base: Path) -> None:
+    _with_config(monkeypatch, {"simkl": {"instances": {"second": {"access_token": "t"}}}})
+
+    assert sc.resolve_instance("second") == ("second", "")
+    assert sc.configured() is False
+    assert sc.instances() == []


### PR DESCRIPTION
# Pull request

## Change

- Overrides work both ways now. A reverse lookup maps a SIMKL entry and episode number back to the source
- SIMKL read path uses the AniBridge reverse edges. They were in the index but never queried
- Read back rewrites the show ids when the source id differs. Split season entries key the same as the source
- New search icon in the rules editor. Looks a title up on SIMKL and fills in the target id
- Build seasons walks the sequel chain. It generates the whole rule set with contiguous ranges

## Why

- Writes landed on SIMKL but were never recognised again. The same items got re-added and reported unresolved every run
- SIMKL splits some anime into per season entries with their own tmdb ids. Others collapse into one flat absolute numbered
- Writing rules by hand meant copying simkl ids out of browser urls. Getting the episode ranges wrong was easy


## Testing

- tests/test_anime_reverse_mapping.py 
- tests/test_simkl_catalog.py 
- tests/test_anime_overrides.py

## Issue

Relates to #660
