### PR TITLE
Change:  Scrob watcher source availability

### DIFF
--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -13,6 +13,7 @@ from fastapi.responses import JSONResponse
 from cw_platform.config_base import load_config, save_config
 from cw_platform.provider_instances import get_provider_block, list_instance_ids, normalize_instance_id
 from cw_platform.provider_usage import WEBHOOK_SOURCE_PROVIDERS, provider_label, webhook_source_enabled
+from providers.auth import runtime as auth_runtime
 from providers.scrobble.routes import (
     ROUTE_PROVIDERS,
     ROUTE_SINKS,
@@ -116,6 +117,9 @@ def _scrobble_source_connected(cfg: Mapping[str, Any], provider: str, instance: 
     if key == "kodi":
         block = get_provider_block(_dict(cfg), "kodi", normalize_instance_id(instance))
         return bool(str(block.get("server") or "").strip() and block.get("connection_verified") is True)
+    if key == "scrob":
+        block = get_provider_block(_dict(cfg), "scrob", normalize_instance_id(instance))
+        return auth_runtime.is_configured("scrob", block)
     return media_source_connected(cfg, key, instance)
 
 

--- a/tests/test_scrob_integration.py
+++ b/tests/test_scrob_integration.py
@@ -164,6 +164,14 @@ def test_scrobbler_management_lists_scrob_as_a_watcher_source():
     assert "scrob" in SINK_PROVIDERS
 
 
+def test_scrobbler_management_marks_scrob_watcher_source_configured():
+    from api.scrobblerManagementAPI import _scrobble_source_connected
+
+    full = {"server_url": "http://s", "api_key": "k", "username": "u", "password": "p"}
+    assert _scrobble_source_connected({"scrob": full}, "scrob", "default") is True
+    assert _scrobble_source_connected({"scrob": {**full, "password": ""}}, "scrob", "default") is False
+
+
 def test_playback_progress_registers_the_scrob_adapter():
     from services.playback_progress.service import PHASE1_PROVIDERS
     from services.playback_progress.adapters.scrob import ScrobPlaybackAdapter


### PR DESCRIPTION
# Pull request

## Change

Make configured Scrob profiles show up as watcher route sources.

## Why

Scrob was listed as a route source, but the modal filtered it out with the webhook source check.

## Testing

- tests\test_scrob_integration.py

## Issue

Relates to #693