### PR TITLE
Fix: SIMKL anime mapping error exposure

### DIFF
--- a/api/animeMappingAPI.py
+++ b/api/animeMappingAPI.py
@@ -48,6 +48,10 @@ def _client_error_message(action: str) -> str:
     return f"Anime Mapping {action} failed. Check the server logs for details."
 
 
+def _simkl_not_configured_message() -> str:
+    return "SIMKL lookup is not configured. Connect SIMKL and try again."
+
+
 def _release_tag(payload: dict[str, Any] | None = None) -> str:
     cfg = load_config() or {}
     data: dict[str, Any] = payload if isinstance(payload, dict) else {}
@@ -289,7 +293,16 @@ def api_anime_mapping_simkl_search(q: str = "", limit: int = 25, instance: str =
     try:
         results = simkl_search(term, limit=limit, instance_id=instance or None)
     except SimklNotConfigured as e:
-        return JSONResponse({"ok": False, "error": "simkl_not_configured", "message": str(e)}, status_code=409)
+        log(
+            "simkl_search_not_configured",
+            level="warn",
+            module="ANIME_MAPPING",
+            extra={"error_type": e.__class__.__name__, "error": str(e)},
+        )
+        return JSONResponse(
+            {"ok": False, "error": "simkl_not_configured", "message": _simkl_not_configured_message()},
+            status_code=409,
+        )
     except SimklCatalogError as e:
         log(
             "simkl_search_failed",
@@ -297,7 +310,10 @@ def api_anime_mapping_simkl_search(q: str = "", limit: int = 25, instance: str =
             module="ANIME_MAPPING",
             extra={"error_type": e.__class__.__name__, "error": str(e)},
         )
-        return JSONResponse({"ok": False, "error": "simkl_search_failed", "message": str(e)}, status_code=502)
+        return JSONResponse(
+            {"ok": False, "error": "simkl_search_failed", "message": _client_error_message("SIMKL search")},
+            status_code=502,
+        )
     return JSONResponse({"ok": True, "configured": True, "results": [r.as_dict() for r in results]})
 
 
@@ -314,9 +330,27 @@ def api_anime_mapping_simkl_plan(payload: dict[str, Any] | None = Body(default=N
             instance_id=str(data.get("instance") or "") or None,
         )
     except SimklNotConfigured as e:
-        return JSONResponse({"ok": False, "error": "simkl_not_configured", "message": str(e)}, status_code=409)
+        log(
+            "simkl_plan_not_configured",
+            level="warn",
+            module="ANIME_MAPPING",
+            extra={"error_type": e.__class__.__name__, "error": str(e)},
+        )
+        return JSONResponse(
+            {"ok": False, "error": "simkl_not_configured", "message": _simkl_not_configured_message()},
+            status_code=409,
+        )
     except SimklCatalogError as e:
-        return JSONResponse({"ok": False, "error": "simkl_plan_failed", "message": str(e)}, status_code=400)
+        log(
+            "simkl_plan_failed",
+            level="warn",
+            module="ANIME_MAPPING",
+            extra={"error_type": e.__class__.__name__, "error": str(e)},
+        )
+        return JSONResponse(
+            {"ok": False, "error": "simkl_plan_failed", "message": _client_error_message("SIMKL season plan")},
+            status_code=400,
+        )
     except Exception as e:
         log(
             "simkl_plan_failed",

--- a/tests/test_anime_overrides_api.py
+++ b/tests/test_anime_overrides_api.py
@@ -103,3 +103,68 @@ def test_rules_survive_a_dataset_rebuild(client: TestClient, config_base: Path) 
     storage.rebuild_sqlite_from_mappings(release_tag="v3")
 
     assert [x["id"] for x in ov.load_overrides()] == [created["id"]]
+
+
+def test_simkl_search_errors_do_not_expose_exception_text(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from api import animeMappingAPI as api
+
+    def fail_search(*_args, **_kwargs):
+        raise api.SimklCatalogError("secret upstream path /srv/crosswatch/simkl.py")
+
+    monkeypatch.setattr(api, "simkl_search", fail_search)
+
+    r = client.get("/api/anime-mapping/simkl/search", params={"q": "frieren"})
+
+    assert r.status_code == 502
+    body = r.json()
+    assert body["error"] == "simkl_search_failed"
+    assert "secret upstream path" not in body["message"]
+    assert "server logs" in body["message"]
+
+
+def test_simkl_plan_errors_do_not_expose_exception_text(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from api import animeMappingAPI as api
+
+    def fail_plan(*_args, **_kwargs):
+        raise api.SimklCatalogError("secret plan input /srv/crosswatch/rules.py")
+
+    monkeypatch.setattr(api, "simkl_plan_rules", fail_plan)
+
+    r = client.post("/api/anime-mapping/simkl/plan", json={"simkl": "12345"})
+
+    assert r.status_code == 400
+    body = r.json()
+    assert body["error"] == "simkl_plan_failed"
+    assert "secret plan input" not in body["message"]
+    assert "server logs" in body["message"]
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "kwargs"),
+    [
+        ("get", "/api/anime-mapping/simkl/search", {"params": {"q": "frieren"}}),
+        ("post", "/api/anime-mapping/simkl/plan", {"json": {"simkl": "12345"}}),
+    ],
+)
+def test_simkl_not_configured_errors_do_not_expose_exception_text(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    method: str,
+    path: str,
+    kwargs: dict[str, object],
+) -> None:
+    from api import animeMappingAPI as api
+
+    def fail_lookup(*_args, **_kwargs):
+        raise api.SimklNotConfigured("SIMKL rejected client id secret-client-id")
+
+    monkeypatch.setattr(api, "simkl_search", fail_lookup)
+    monkeypatch.setattr(api, "simkl_plan_rules", fail_lookup)
+
+    r = getattr(client, method)(path, **kwargs)
+
+    assert r.status_code == 409
+    body = r.json()
+    assert body["error"] == "simkl_not_configured"
+    assert "secret-client-id" not in body["message"]
+    assert body["message"] == "SIMKL lookup is not configured. Connect SIMKL and try again."


### PR DESCRIPTION
# Pull request

## Change

Stop returning raw SIMKL exception text from anime mapping search and plan errors.

## Why

CodeQL flagged these responses as stack trace exposure risks. 

## Testing

- tests/test_anime_overrides_api.py

## Issue

Relates to code scanning alerts 312-315