### PR TITLE
Fix: Floppy multi-instance scoped config lookup

### DIFF
--- a/providers/auth/_auth_FLOPPY.py
+++ b/providers/auth/_auth_FLOPPY.py
@@ -37,8 +37,21 @@ def normalize_server_url(value: Any) -> str:
     return server.rstrip("/")
 
 
+def provider_block(cfg: Mapping[str, Any] | None, instance_id: Any = None) -> dict[str, Any]:
+    block = get_provider_block(cfg or {}, "floppy", instance_id)
+    if block:
+        return block
+    base = (cfg or {}).get("floppy") if isinstance(cfg, Mapping) else None
+    if not isinstance(base, Mapping):
+        return {}
+    inst = normalize_instance_id(instance_id)
+    if inst == "default" or "instances" not in base:
+        return dict(base)
+    return {}
+
+
 def _block(cfg: Mapping[str, Any], instance_id: Any = None) -> dict[str, Any]:
-    return get_provider_block(cfg or {}, "floppy", instance_id)
+    return provider_block(cfg, instance_id)
 
 
 def is_configured(block: Mapping[str, Any] | None) -> bool:

--- a/providers/sync/floppy/_common.py
+++ b/providers/sync/floppy/_common.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from cw_platform.id_map import canonical_key, ids_from, minimal as id_minimal
-from providers.auth._auth_FLOPPY import FloppyAuthError, is_configured as auth_is_configured
+from providers.auth._auth_FLOPPY import FloppyAuthError, is_configured as auth_is_configured, provider_block
 from providers.sync._mod_common import safe_json
 
 
@@ -30,9 +30,7 @@ def int_or_none(value: Any) -> int | None:
 
 
 def configured_block(cfg: Mapping[str, Any] | None, instance_id: str = "default") -> dict[str, Any]:
-    from cw_platform.provider_instances import get_provider_block
-
-    return get_provider_block(cfg or {}, "floppy", instance_id)
+    return provider_block(cfg or {}, instance_id)
 
 
 def is_configured(cfg: Mapping[str, Any] | None, instance_id: str = "default") -> bool:

--- a/tests/test_floppy_sync.py
+++ b/tests/test_floppy_sync.py
@@ -82,6 +82,47 @@ def test_floppy_module_uses_shared_rate_limiter() -> None:
     assert mod.client.session._rate_limiter_meta == {"get_per_sec": 12.0, "post_per_sec": 9.0}
 
 
+def test_floppy_module_uses_non_default_provider_config_view(monkeypatch: Any) -> None:
+    from cw_platform.provider_instances import build_provider_config_view
+    from providers.sync._mod_FLOPPY import FLOPPYModule
+    from providers.sync.floppy._common import is_configured
+
+    cfg = {
+        "floppy": {
+            "server_url": "https://default.local",
+            "api_token": "default-token",
+            "instances": {
+                "FLOPPY-P01": {
+                    "server_url": "https://p01.local",
+                    "api_token": "p01-token",
+                    "verify_ssl": True,
+                }
+            },
+        }
+    }
+    view = build_provider_config_view(cfg, "floppy", "FLOPPY-P01")
+    monkeypatch.setenv("CW_PAIR_DST", "FLOPPY")
+    monkeypatch.setenv("CW_PAIR_DST_INSTANCE", "FLOPPY-P01")
+
+    mod = FLOPPYModule(view)
+
+    assert is_configured(view, "FLOPPY-P01") is True
+    assert mod.client.server_url == "https://p01.local"
+    assert mod.client.api_token == "p01-token"
+    assert mod.client.verify_ssl is True
+
+
+def test_floppy_non_default_missing_instance_does_not_reuse_default_block() -> None:
+    from cw_platform.provider_instances import build_provider_config_view
+    from providers.sync.floppy._common import configured_block, is_configured
+
+    cfg = {"floppy": {"server_url": "https://default.local", "api_token": "default-token"}}
+    view = build_provider_config_view(cfg, "floppy", "FLOPPY-P01")
+
+    assert configured_block(view, "FLOPPY-P01") == {}
+    assert is_configured(view, "FLOPPY-P01") is False
+
+
 def test_floppy_watchlist_reads_configured_custom_list() -> None:
     from providers.sync.floppy import _watchlist
 


### PR DESCRIPTION
# Pull request

## Change

Fix Floppy config resolution for scoped provider views.

## Why

Multi-instance Floppy sync could report missing_authentication after the config was already flattened to the selected instance.

## Testing

- tests/test_floppy_sync.py 
- tests/test_floppy_auth.py

## Issue

Relates to #727