### PR TITLE
Add: Anime history coordinate translation

### DIFF
--- a/cw_platform/anime_mapping/episodes.py
+++ b/cw_platform/anime_mapping/episodes.py
@@ -290,6 +290,66 @@ def _bridge_source_coordinate(tag: str, ids: Mapping[str, str], absolute: int) -
     return None
 
 
+def _axis_coordinates(tag: str, ids: Mapping[str, str], absolute: int) -> dict[tuple[str, str], tuple[int, int]]:
+    found: dict[tuple[str, str], tuple[int, int] | None] = {}
+    for namespace in NATIVE_ORDER:
+        ident = ids.get(namespace, "")
+        if not ident:
+            continue
+        try:
+            rows = query_edges(tag, namespace, ident)
+        except Exception:
+            continue
+        for row in rows:
+            if not int(row.get("reverse") or 0):
+                continue
+            if namespace == "anidb" and str(row.get("source_scope") or "").strip().upper() != _ANIDB_REGULAR:
+                continue
+            provider = str(row.get("target_provider") or "").strip().lower()
+            if provider not in AIRED_ORDER:
+                continue
+            if str(row.get("target_kind") or "").strip().lower() != "show":
+                continue
+            season = _scope_season(row.get("target_scope"))
+            if season is None or season <= 0:
+                continue
+            target_id = str(row.get("target_id") or "").strip()
+            if not target_id:
+                continue
+            episode = translate(row.get("source_range"), row.get("target_range"), absolute)
+            if episode is None or episode <= 0:
+                continue
+            key = (provider, target_id)
+            coord = (season, episode)
+            if key in found and found[key] != coord:
+                found[key] = None
+            elif key not in found:
+                found[key] = coord
+    return {k: v for k, v in found.items() if v is not None}
+
+
+def resolve_axis_coordinates(
+    ids: Mapping[str, Any] | None,
+    absolute: Any,
+    *,
+    release_tag: str = "v3",
+) -> set[tuple[int, int]]:
+    abs_num = _as_int(absolute)
+    if abs_num is None or abs_num <= 0:
+        return set()
+    clean = {
+        str(k).strip().lower(): str(v).strip()
+        for k, v in dict(ids or {}).items()
+        if str(v or "").strip()
+    }
+    if not clean:
+        return set()
+    ruled = _override_source_coordinate(clean, abs_num)
+    if ruled is not None:
+        return {(ruled.season, ruled.episode)}
+    return set(_axis_coordinates(normalize_release_tag(release_tag), clean, abs_num).values())
+
+
 def resolve_source_coordinate(
     ids: Mapping[str, Any] | None,
     absolute: Any,

--- a/cw_platform/anime_mapping/history_coords.py
+++ b/cw_platform/anime_mapping/history_coords.py
@@ -1,0 +1,181 @@
+# /cw_platform/anime_mapping/history_coords.py
+# CrossWatch - Anime History Coordinate Aliases
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Iterable
+
+from .episodes import resolve_axis_coordinates
+from .storage import index_ready, normalize_release_tag
+
+NATIVE_ANIME_ID_KEYS = ("mal", "anilist", "anidb", "kitsu")
+ABSOLUTE_FRAGMENT = "#abs:"
+_MIN_ABSOLUTE_RUN = 2
+_MAX_DUPLICATE_RATIO = 0.98
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(str(value).strip())
+    except Exception:
+        return None
+
+
+def _is_episode(item: Mapping[str, Any]) -> bool:
+    return str(item.get("type") or "").strip().lower() == "episode"
+
+
+def show_ids_of(item: Mapping[str, Any]) -> dict[str, str]:
+    raw = item.get("show_ids") if isinstance(item.get("show_ids"), Mapping) else item.get("ids")
+    out: dict[str, str] = {}
+    for key, value in (raw if isinstance(raw, Mapping) else {}).items():
+        text = str(value or "").strip()
+        if text:
+            out[str(key).strip().lower()] = text
+    return out
+
+
+def show_tokens(item: Mapping[str, Any]) -> set[str]:
+    return {f"{k}:{v.lower()}" for k, v in show_ids_of(item).items()}
+
+
+def native_anime_absolute(item: Mapping[str, Any]) -> int | None:
+    if not _is_episode(item):
+        return None
+    absolute = _as_int(item.get("_simkl_episode_number"))
+    if absolute is None or absolute <= 0:
+        return None
+    ids = show_ids_of(item)
+    if not any(ids.get(key) for key in NATIVE_ANIME_ID_KEYS):
+        return None
+    return absolute
+
+
+def _episode_coordinate(item: Mapping[str, Any]) -> tuple[int, int] | None:
+    season = _as_int(item.get("season") if item.get("season") is not None else item.get("season_number"))
+    episode = _as_int(item.get("episode") if item.get("episode") is not None else item.get("episode_number"))
+    if season is None or episode is None or season < 0 or episode <= 0:
+        return None
+    return season, episode
+
+
+def _absolute_numbered_shows_in(index: Mapping[str, Any] | None) -> dict[str, set[int]]:
+    per_show: dict[str, list[int]] = {}
+    for item in (index or {}).values():
+        if not isinstance(item, Mapping) or not _is_episode(item):
+            continue
+        coord = _episode_coordinate(item)
+        if coord is None or coord[0] <= 0:
+            continue
+        for token in show_tokens(item):
+            per_show.setdefault(token, []).append(coord[1])
+
+    out: dict[str, set[int]] = {}
+    for token, numbers in per_show.items():
+        if len(numbers) < _MIN_ABSOLUTE_RUN:
+            continue
+        unique = set(numbers)
+        if len(unique) < len(numbers) * _MAX_DUPLICATE_RATIO:
+            continue
+        if min(unique) != 1 or max(unique) != len(unique):
+            continue
+        counts: dict[int, int] = {}
+        for number in numbers:
+            counts[number] = counts.get(number, 0) + 1
+        unambiguous = {n for n, c in counts.items() if c == 1}
+        if unambiguous:
+            out[token] = unambiguous
+    return out
+
+
+def absolute_numbered_shows(*indexes: Mapping[str, Any] | None) -> dict[str, set[int]]:
+    out: dict[str, set[int]] = {}
+    for index in indexes:
+        for token, numbers in _absolute_numbered_shows_in(index).items():
+            out.setdefault(token, set()).update(numbers)
+    return out
+
+
+class HistoryCoordinateAliases:
+    def __init__(
+        self,
+        *indexes: Mapping[str, Any] | None,
+        release_tag: str = "v3",
+        enabled: bool = True,
+    ) -> None:
+        self.enabled = bool(enabled)
+        self.release_tag = normalize_release_tag(release_tag)
+        self._absolute_shows: dict[str, set[int]] = absolute_numbered_shows(*indexes) if self.enabled else {}
+        self._coord_cache: dict[tuple[str, int], frozenset[tuple[int, int]]] = {}
+        self._ready: bool | None = None
+
+    @classmethod
+    def disabled(cls) -> "HistoryCoordinateAliases":
+        return cls(enabled=False)
+
+    def _mapping_ready(self) -> bool:
+        if self._ready is None:
+            try:
+                self._ready = index_ready(self.release_tag)
+            except Exception:
+                self._ready = False
+        return bool(self._ready)
+
+    def _axis_coordinates(self, ids: Mapping[str, str], absolute: int) -> frozenset[tuple[int, int]]:
+        key = ("|".join(f"{k}={ids[k]}" for k in sorted(ids)), absolute)
+        cached = self._coord_cache.get(key)
+        if cached is None:
+            try:
+                found = resolve_axis_coordinates(ids, absolute, release_tag=self.release_tag)
+            except Exception:
+                found = set()
+            cached = frozenset(found)
+            self._coord_cache[key] = cached
+        return cached
+
+    def stats(self) -> dict[str, int]:
+        return {"absolute_shows": len(self._absolute_shows), "coord_cache": len(self._coord_cache)}
+
+    def tokens(self, item: Mapping[str, Any]) -> set[str]:
+        if not self.enabled or not isinstance(item, Mapping) or not _is_episode(item):
+            return set()
+
+        tokens: set[str] = set()
+        prefixes = show_tokens(item)
+        if not prefixes:
+            return tokens
+
+        absolute = native_anime_absolute(item)
+        if absolute is not None:
+            tokens.update(f"{p}{ABSOLUTE_FRAGMENT}{absolute}" for p in prefixes)
+            if self._mapping_ready():
+                for season, episode in self._axis_coordinates(show_ids_of(item), absolute):
+                    frag = f"#s{season:02d}e{episode:02d}"
+                    tokens.update(f"{p}{frag}" for p in prefixes)
+
+        coord = _episode_coordinate(item)
+        if coord is not None and coord[0] > 0:
+            for prefix in prefixes:
+                if coord[1] in self._absolute_shows.get(prefix, ()):
+                    tokens.add(f"{prefix}{ABSOLUTE_FRAGMENT}{coord[1]}")
+
+        return tokens
+
+
+def build_history_coordinate_aliases(
+    cfg: Mapping[str, Any] | None,
+    feature: Any,
+    indexes: Iterable[Mapping[str, Any] | None] = (),
+) -> HistoryCoordinateAliases:
+    if str(feature or "").strip().lower() != "history":
+        return HistoryCoordinateAliases.disabled()
+    block = cfg.get("anime_mapping") if isinstance(cfg, Mapping) else {}
+    block = block if isinstance(block, Mapping) else {}
+    if not bool(block.get("enabled", False)):
+        return HistoryCoordinateAliases.disabled()
+    return HistoryCoordinateAliases(
+        *list(indexes),
+        release_tag=str(block.get("release_tag") or "v3"),
+        enabled=True,
+    )

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -207,6 +207,10 @@ from ..anime_mapping.service import (
     config_with_pair_feature_options as _anime_config_with_pair_feature_options,
     enrich_index_for_pair as _anime_enrich_index_for_pair,
 )
+from ..anime_mapping.history_coords import (
+    HistoryCoordinateAliases as _HistoryCoordinateAliases,
+    build_history_coordinate_aliases as _build_history_coordinate_aliases,
+)
 from ._snapshots import (
     build_snapshots_for_feature,
     bust_snapshot_cache,
@@ -812,6 +816,8 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
         except Exception:
             pass
 
+    coord_aliases: _HistoryCoordinateAliases = _HistoryCoordinateAliases.disabled()
+
     def _typed_tokens(it: Mapping[str, Any]) -> set[str]:
         typ = str(it.get("type") or "").strip().lower()
         show_ids_raw = it.get("show_ids") if isinstance(it.get("show_ids"), Mapping) else {}
@@ -819,7 +825,7 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
         show_ids = dict(show_ids_raw or {})
         ids = dict(ids_raw or {})
 
-        toks: set[str] = set()
+        toks: set[str] = set(coord_aliases.tokens(it))
 
         if typ == "episode":
             try:
@@ -1165,6 +1171,10 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
             dst_full = collapse_history_latest(dst_full)
             prev_src = collapse_history_latest(prev_src)
             prev_dst = collapse_history_latest(prev_dst)
+
+    coord_aliases = _build_history_coordinate_aliases(cfg, feature, (src_idx, dst_full))
+    if coord_aliases.enabled:
+        dbg("anime_mapping.history_coords", feature=feature, src=src, dst=dst, **coord_aliases.stats())
 
     dst_canonical: dict[str, Any] = {}
     if feature == "history" and not history_event_mode:

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -82,6 +82,7 @@ from ..anime_mapping.service import (
     config_with_pair_feature_options as _anime_config_with_pair_feature_options,
     enrich_index_for_pair as _anime_enrich_index_for_pair,
 )
+from ..anime_mapping.history_coords import build_history_coordinate_aliases as _build_history_coordinate_aliases
 from ._snapshots import (
     build_snapshots_for_feature,
     bust_snapshot_cache,
@@ -695,6 +696,10 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
     if manual_adds_B:
         B_eff = _merge_manual_adds(B_eff, manual_adds_B)
 
+    coord_aliases = _build_history_coordinate_aliases(cfg, feature, (A_eff, B_eff))
+    if coord_aliases.enabled:
+        dbg("anime_mapping.history_coords", feature=feature, a=a, b=b, **coord_aliases.stats())
+
     def _typed_tokens(it: Mapping[str, Any]) -> set[str]:
         typ = str(it.get("type") or "").strip().lower()
         if typ in ("episode", "season"):
@@ -702,7 +707,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
         else:
             ids_raw = it.get("ids") or {}
         ids = ids_raw if isinstance(ids_raw, Mapping) else {}
-        toks: set[str] = set()
+        toks: set[str] = set(coord_aliases.tokens(it))
 
         if typ == "episode":
             try:

--- a/tests/test_anime_history_coords.py
+++ b/tests/test_anime_history_coords.py
@@ -1,0 +1,289 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cw_platform.anime_mapping import storage
+from cw_platform.anime_mapping.episodes import resolve_axis_coordinates, resolve_source_coordinate
+from cw_platform.anime_mapping.history_coords import (
+    HistoryCoordinateAliases,
+    absolute_numbered_shows,
+    build_history_coordinate_aliases,
+    native_anime_absolute,
+)
+
+MAPPINGS: dict[str, Any] = {
+    "tvdb_show:76666:s1": {"mal:223": {"1-13": "1-13"}},
+    "tvdb_show:76666:s2": {"mal:223": {"1-15": "14-28"}},
+    "tvdb_show:76666:s3": {"mal:223": {"1-40": "29-68"}},
+    "tmdb_show:12609:s1": {"mal:223": {"1-153": "1-153"}},
+    "tvdb_show:81472:s1": {"mal:813": {"1-39": "1-39"}},
+    "tvdb_show:81472:s2": {"mal:813": {"1-35": "40-74"}},
+    "tmdb_show:12971:s1": {"mal:813": {"1-39": "1-39"}},
+}
+
+DRAGON_BALL_IDS = {"tmdb": "12609", "imdb": "tt0088509", "tvdb": "76666", "mal": "223", "anilist": "223"}
+DBZ_IDS = {"tmdb": "12971", "imdb": "tt0121220", "tvdb": "81472", "mal": "813", "anilist": "813"}
+ONE_PIECE_IDS = {"tmdb": "37854", "imdb": "tt0388629", "tvdb": "81797", "mal": "21", "anilist": "21"}
+
+MDBLIST_DRAGON_BALL_IDS = {"tmdb": "12609", "imdb": "tt0088509", "trakt": "12553"}
+MDBLIST_DBZ_IDS = {"tmdb": "12971", "imdb": "tt0121220", "trakt": "12915"}
+MDBLIST_ONE_PIECE_IDS = {"tmdb": "37854", "imdb": "tt0388629", "trakt": "37696"}
+
+CFG = {"anime_mapping": {"enabled": True, "release_tag": "v3"}}
+
+
+@pytest.fixture()
+def anime_index(config_base: Path) -> Path:
+    paths = storage.paths("v3")
+    paths["root"].mkdir(parents=True, exist_ok=True)
+    paths["mappings"].write_text(json.dumps(MAPPINGS), encoding="utf-8")
+    storage.rebuild_sqlite_from_mappings(release_tag="v3")
+    return paths["db"]
+
+
+def _episode(show_ids: dict[str, str], season: int, episode: int, absolute: int | None = None) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "type": "episode",
+        "title": f"S{season:02d}E{episode:02d}",
+        "season": season,
+        "episode": episode,
+        "watched": True,
+        "watched_at": "2024-01-01T00:00:00Z",
+        "ids": {},
+        "show_ids": dict(show_ids),
+    }
+    if absolute is not None:
+        out["_simkl_episode_number"] = absolute
+        out["simkl_bucket"] = "anime"
+    return out
+
+
+def _mdblist_run(show_ids: dict[str, str], seasons: list[tuple[int, list[int]]]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for season, numbers in seasons:
+        for number in numbers:
+            out[f"tmdb:{show_ids['tmdb']}#s{season:02d}e{number:02d}"] = _episode(show_ids, season, number)
+    return out
+
+
+def _base_tokens(item: dict[str, Any]) -> set[str]:
+    if str(item.get("type") or "") != "episode":
+        return {f"{k}:{str(v).lower()}" for k, v in (item.get("ids") or {}).items() if v}
+    season = item.get("season")
+    episode = item.get("episode")
+    if season is None or episode is None:
+        return set()
+    frag = f"#s{int(season):02d}e{int(episode):02d}"
+    out: set[str] = set()
+    for source in (item.get("show_ids") or {}, item.get("ids") or {}):
+        out.update(f"{k}:{str(v).lower()}{frag}" for k, v in source.items() if v)
+    return out
+
+
+def _typed_tokens(aliases: HistoryCoordinateAliases, item: dict[str, Any]) -> set[str]:
+    return _base_tokens(item) | aliases.tokens(item)
+
+
+def _matched(aliases: HistoryCoordinateAliases, source: dict[str, Any], destination: dict[str, Any]) -> bool:
+    return bool(_typed_tokens(aliases, source) & _typed_tokens(aliases, destination))
+
+
+def test_axis_coordinates_return_both_axes_where_the_unanimous_resolver_refuses(anime_index: Path) -> None:
+    assert resolve_source_coordinate(DRAGON_BALL_IDS, 14) is None
+
+    coords = resolve_axis_coordinates(DRAGON_BALL_IDS, 14)
+
+    assert coords == {(2, 1), (1, 14)}
+
+
+def test_dragon_ball_simkl_shape_translates_to_the_mdblist_flat_coordinate(anime_index: Path) -> None:
+    aliases = build_history_coordinate_aliases(CFG, "history", ())
+
+    tokens = aliases.tokens(_episode(DRAGON_BALL_IDS, 2, 1, absolute=14))
+
+    assert "tmdb:12609#s01e14" in tokens
+    assert "tvdb:76666#s02e01" in tokens
+
+
+def test_dragon_ball_z_flat_shape_translates_to_the_mdblist_aired_coordinate(anime_index: Path) -> None:
+    aliases = build_history_coordinate_aliases(CFG, "history", ())
+
+    tokens = aliases.tokens(_episode(DBZ_IDS, 1, 40, absolute=40))
+
+    assert "tvdb:81472#s02e01" in tokens
+
+
+def test_dragon_ball_pair_compares_as_already_synced(anime_index: Path) -> None:
+    source = _episode(DRAGON_BALL_IDS, 2, 1, absolute=14)
+    destination = _episode(MDBLIST_DRAGON_BALL_IDS, 1, 14)
+    aliases = build_history_coordinate_aliases(CFG, "history", ({"a": source}, {"b": destination}))
+
+    assert _matched(aliases, source, destination)
+
+
+def test_dragon_ball_z_pair_compares_as_already_synced(anime_index: Path) -> None:
+    source = _episode(DBZ_IDS, 1, 40, absolute=40)
+    destination = _episode(MDBLIST_DBZ_IDS, 2, 1)
+    dst_index = _mdblist_run(MDBLIST_DBZ_IDS, [(1, list(range(1, 40))), (2, list(range(1, 36)))])
+    aliases = build_history_coordinate_aliases(CFG, "history", ({"a": source}, dst_index))
+
+    assert _matched(aliases, source, destination)
+
+
+def test_one_piece_matches_a_destination_that_numbers_episodes_absolutely(config_base: Path) -> None:
+    dst_index = _mdblist_run(
+        MDBLIST_ONE_PIECE_IDS,
+        [(1, list(range(1, 62))), (22, list(range(62, 100)))],
+    )
+    source = _episode(ONE_PIECE_IDS, 3, 7, absolute=75)
+    destination = dst_index["tmdb:37854#s22e75"]
+    aliases = build_history_coordinate_aliases(CFG, "history", ({"a": source}, dst_index))
+
+    assert _matched(aliases, source, destination)
+    assert "tmdb:37854#abs:75" in aliases.tokens(source)
+
+
+def test_per_season_restart_numbering_is_not_treated_as_absolute(config_base: Path) -> None:
+    dst_index = _mdblist_run(MDBLIST_DBZ_IDS, [(1, list(range(1, 40))), (2, list(range(1, 36)))])
+
+    assert absolute_numbered_shows(dst_index) == {}
+
+
+def test_specials_only_shows_never_produce_an_absolute_token(config_base: Path) -> None:
+    oad = {"tmdb": "256378", "imdb": "tt2560140"}
+    dst_index = {
+        f"tmdb:256378#s00e{n:02d}": _episode(oad, 0, n) for n in (1, 2, 4, 6)
+    }
+
+    assert absolute_numbered_shows(dst_index) == {}
+
+    aliases = build_history_coordinate_aliases(CFG, "history", (dst_index,))
+    assert aliases.tokens(dst_index["tmdb:256378#s00e01"]) == set()
+
+
+def test_a_few_misfiled_rows_do_not_disqualify_the_whole_show(config_base: Path) -> None:
+    dst_index = _mdblist_run(MDBLIST_ONE_PIECE_IDS, [(1, list(range(1, 100)))])
+    dst_index["tmdb:37854#s08e04"] = _episode(MDBLIST_ONE_PIECE_IDS, 8, 4)
+    dst_index["tmdb:37854#s08e05"] = _episode(MDBLIST_ONE_PIECE_IDS, 8, 5)
+
+    numbers = absolute_numbered_shows(dst_index)["tmdb:37854"]
+
+    assert 75 in numbers
+    assert 4 not in numbers
+    assert 5 not in numbers
+
+
+def test_a_source_index_cannot_mask_an_absolutely_numbered_destination(config_base: Path) -> None:
+    dst_index = _mdblist_run(MDBLIST_ONE_PIECE_IDS, [(1, list(range(1, 62))), (22, list(range(62, 100)))])
+    src_index = {"tmdb:37854#s03e07": _episode(ONE_PIECE_IDS, 3, 7, absolute=75)}
+
+    assert "tmdb:37854" in absolute_numbered_shows(src_index, dst_index)
+
+
+def test_translated_episode_is_not_planned_again_on_a_second_sync(anime_index: Path) -> None:
+    source = _episode(DRAGON_BALL_IDS, 2, 1, absolute=14)
+    destination = _episode(MDBLIST_DRAGON_BALL_IDS, 1, 14)
+    src_index = {"tmdb:12609#s02e01": source}
+    dst_index = {"tmdb:12609#s01e14": destination}
+
+    for _ in range(2):
+        aliases = build_history_coordinate_aliases(CFG, "history", (src_index, dst_index))
+        alias_map = {tok: key for key, item in dst_index.items() for tok in aliases.tokens(item)}
+        alias_map.update({f"tmdb:12609#s01e14": "tmdb:12609#s01e14"})
+        assert any(tok in alias_map for tok in aliases.tokens(source))
+
+
+def test_a_translated_destination_row_is_not_planned_for_removal(anime_index: Path) -> None:
+    source = _episode(DRAGON_BALL_IDS, 2, 1, absolute=14)
+    destination = _episode(MDBLIST_DRAGON_BALL_IDS, 1, 14)
+    src_index = {"tmdb:12609#s02e01": source}
+    dst_index = {"tmdb:12609#s01e14": destination}
+    aliases = build_history_coordinate_aliases(CFG, "history", (src_index, dst_index))
+
+    src_base = {tok for item in src_index.values() for tok in _base_tokens(item)}
+    src_tokens = {tok for item in src_index.values() for tok in _typed_tokens(aliases, item)}
+
+    assert _base_tokens(destination) & src_base == set()
+    assert _typed_tokens(aliases, destination) & src_tokens
+
+
+def test_a_genuinely_absent_episode_is_still_planned_for_removal(anime_index: Path) -> None:
+    source = _episode(DRAGON_BALL_IDS, 2, 1, absolute=14)
+    orphan = _episode(MDBLIST_DRAGON_BALL_IDS, 1, 99)
+    src_index = {"tmdb:12609#s02e01": source}
+    dst_index = {"tmdb:12609#s01e14": _episode(MDBLIST_DRAGON_BALL_IDS, 1, 14), "tmdb:12609#s01e99": orphan}
+    aliases = build_history_coordinate_aliases(CFG, "history", (src_index, dst_index))
+
+    src_tokens = {tok for item in src_index.values() for tok in _typed_tokens(aliases, item)}
+
+    assert _typed_tokens(aliases, orphan) & src_tokens == set()
+
+
+def test_regular_television_produces_no_alias_tokens(anime_index: Path) -> None:
+    aliases = build_history_coordinate_aliases(CFG, "history", ())
+    regular = _episode({"tmdb": "100088", "imdb": "tt3581920", "tvdb": "392256"}, 1, 2)
+
+    assert native_anime_absolute(regular) is None
+    assert aliases.tokens(regular) == set()
+
+
+def test_movies_produce_no_alias_tokens(anime_index: Path) -> None:
+    aliases = build_history_coordinate_aliases(CFG, "history", ())
+    movie = {"type": "movie", "title": "Akira", "year": 1988, "ids": {"tmdb": "149"}}
+
+    assert aliases.tokens(movie) == set()
+
+
+def test_absolute_without_a_native_anime_id_is_ignored(anime_index: Path) -> None:
+    aliases = build_history_coordinate_aliases(CFG, "history", ())
+    row = _episode({"tmdb": "100088", "tvdb": "392256"}, 1, 2)
+    row["_simkl_episode_number"] = 2
+
+    assert native_anime_absolute(row) is None
+    assert aliases.tokens(row) == set()
+
+
+def test_native_anime_id_without_an_absolute_is_ignored(anime_index: Path) -> None:
+    aliases = build_history_coordinate_aliases(CFG, "history", ())
+    row = _episode(DRAGON_BALL_IDS, 2, 1)
+
+    assert native_anime_absolute(row) is None
+    assert aliases.tokens(row) == set()
+
+
+def test_non_history_features_are_disabled(anime_index: Path) -> None:
+    for feature in ("watchlist", "ratings", "progress"):
+        aliases = build_history_coordinate_aliases(CFG, feature, ())
+        assert not aliases.enabled
+        assert aliases.tokens(_episode(DRAGON_BALL_IDS, 2, 1, absolute=14)) == set()
+
+
+def test_disabled_anime_mapping_produces_no_tokens(anime_index: Path) -> None:
+    aliases = build_history_coordinate_aliases({"anime_mapping": {"enabled": False}}, "history", ())
+
+    assert not aliases.enabled
+    assert aliases.tokens(_episode(DRAGON_BALL_IDS, 2, 1, absolute=14)) == set()
+
+
+def test_missing_mapping_index_still_allows_absolute_matching(config_base: Path) -> None:
+    dst_index = _mdblist_run(MDBLIST_ONE_PIECE_IDS, [(1, list(range(1, 62)))])
+    source = _episode(ONE_PIECE_IDS, 1, 3, absolute=3)
+    aliases = build_history_coordinate_aliases(CFG, "history", (dst_index,))
+
+    assert _matched(aliases, source, dst_index["tmdb:37854#s01e03"])
+
+
+def test_episode_rows_without_episode_ids_keep_empty_ids(anime_index: Path) -> None:
+    aliases = build_history_coordinate_aliases(CFG, "history", ())
+    source = _episode(DRAGON_BALL_IDS, 2, 1, absolute=14)
+    before = json.dumps(source, sort_keys=True)
+
+    aliases.tokens(source)
+
+    assert source["ids"] == {}
+    assert json.dumps(source, sort_keys=True) == before

--- a/tests/test_anime_history_coords_orchestrator.py
+++ b/tests/test_anime_history_coords_orchestrator.py
@@ -1,0 +1,147 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+import pytest
+
+from cw_platform.anime_mapping import storage
+from cw_platform.orchestrator.facade import Orchestrator
+
+MAPPINGS: dict[str, Any] = {
+    "tvdb_show:76666:s1": {"mal:223": {"1-13": "1-13"}},
+    "tvdb_show:76666:s2": {"mal:223": {"1-15": "14-28"}},
+    "tmdb_show:12609:s1": {"mal:223": {"1-153": "1-153"}},
+}
+
+SRC_SHOW_IDS = {"tmdb": "12609", "imdb": "tt0088509", "tvdb": "76666", "mal": "223", "anilist": "223"}
+DST_SHOW_IDS = {"tmdb": "12609", "imdb": "tt0088509", "trakt": "12553"}
+
+
+@dataclass
+class FakeOps:
+    provider: str
+    index: dict[str, dict[str, Any]]
+    add_calls: list[list[dict[str, Any]]] = field(default_factory=list)
+    remove_calls: list[list[dict[str, Any]]] = field(default_factory=list)
+
+    def name(self) -> str:
+        return self.provider
+
+    def label(self) -> str:
+        return self.provider
+
+    def features(self) -> Mapping[str, bool]:
+        return {"history": True}
+
+    def capabilities(self) -> Mapping[str, Any]:
+        return {
+            "features": {"history": True},
+            "observed_deletes": False,
+            "index_semantics": "present",
+        }
+
+    def is_configured(self, cfg: Mapping[str, Any]) -> bool:
+        return True
+
+    def health(self, cfg: Mapping[str, Any], **_: Any) -> dict[str, Any]:
+        return {"ok": True, "status": "ok", "features": {"history": True}, "api": {}}
+
+    def build_index(self, cfg: Mapping[str, Any], *, feature: str) -> Mapping[str, dict[str, Any]]:
+        return dict(self.index)
+
+    def add(self, cfg, items: Iterable[Mapping[str, Any]], *, feature: str, dry_run: bool = False) -> dict[str, Any]:
+        batch = [dict(x) for x in items]
+        self.add_calls.append(batch)
+        return {"ok": True, "added": len(batch), "count": len(batch)}
+
+    def remove(self, cfg, items: Iterable[Mapping[str, Any]], *, feature: str, dry_run: bool = False) -> dict[str, Any]:
+        batch = [dict(x) for x in items]
+        self.remove_calls.append(batch)
+        return {"ok": True, "removed": len(batch), "count": len(batch)}
+
+
+@pytest.fixture()
+def anime_index(config_base: Path) -> Path:
+    paths = storage.paths("v3")
+    paths["root"].mkdir(parents=True, exist_ok=True)
+    paths["mappings"].write_text(json.dumps(MAPPINGS), encoding="utf-8")
+    storage.rebuild_sqlite_from_mappings(release_tag="v3")
+    return paths["db"]
+
+
+def _episode(show_ids: dict[str, str], season: int, episode: int, absolute: int | None = None) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "type": "episode",
+        "title": f"S{season:02d}E{episode:02d}",
+        "series_title": "Dragon Ball",
+        "season": season,
+        "episode": episode,
+        "watched": True,
+        "watched_at": "2024-01-01T00:00:00Z",
+        "ids": {},
+        "show_ids": dict(show_ids),
+    }
+    if absolute is not None:
+        out["_simkl_episode_number"] = absolute
+        out["simkl_bucket"] = "anime"
+    return out
+
+
+def _cfg(anime_enabled: bool) -> dict[str, Any]:
+    return {
+        "runtime": {"debug": False, "snapshot_ttl_sec": 0, "apply_chunk_size": 0, "apply_chunk_pause_ms": 0},
+        "anime_mapping": {"enabled": anime_enabled, "release_tag": "v3", "use_for_pairs": ["anilist", "simkl"]},
+        "sync": {
+            "dry_run": False,
+            "enable_add": True,
+            "enable_remove": False,
+            "include_observed_deletes": False,
+            "allow_mass_delete": False,
+        },
+        "pairs": [
+            {
+                "id": "p1",
+                "enabled": True,
+                "source": "CROSSWATCH",
+                "target": "MDBLIST",
+                "mode": "one-way",
+                "feature": "history",
+                "features": {"history": {"enable": True, "add": True, "remove": False}},
+            }
+        ],
+    }
+
+
+def _run(monkeypatch: pytest.MonkeyPatch, anime_enabled: bool) -> FakeOps:
+    src = FakeOps("CROSSWATCH", {"tmdb:12609#s02e01": _episode(SRC_SHOW_IDS, 2, 1, absolute=14)})
+    dst = FakeOps("MDBLIST", {"tmdb:12609#s01e14": _episode(DST_SHOW_IDS, 1, 14)})
+    monkeypatch.setattr(
+        "cw_platform.orchestrator.facade.load_sync_providers",
+        lambda: {"CROSSWATCH": src, "MDBLIST": dst},
+    )
+    monkeypatch.setattr("cw_platform.orchestrator._snapshots.provider_configured", lambda _cfg, _name: True)
+    Orchestrator(_cfg(anime_enabled)).run()
+    return dst
+
+
+def test_orchestrator_plans_a_false_add_without_the_anime_toggle(
+    anime_index: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dst = _run(monkeypatch, anime_enabled=False)
+
+    planned = [it for batch in dst.add_calls for it in batch]
+    assert len(planned) == 1
+    assert (planned[0].get("season"), planned[0].get("episode")) == (2, 1)
+
+
+def test_orchestrator_plans_no_add_with_the_anime_toggle_on(
+    anime_index: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dst = _run(monkeypatch, anime_enabled=True)
+
+    planned = [it for batch in dst.add_calls for it in batch]
+    assert planned == []


### PR DESCRIPTION
# Pull request

## Change

- New coordinate alias layer in cw_platform/anime_mapping/history_coords.py
- Wired into _typed_tokens in the one way and two way pair modules
- New resolve_axis_coordinates in episodes.py, returns every aired coordinate instead of refusing when tvdb and tmdb disagree
- Two tiers: mapping range translation, plus matching against destinations that number episodes absolutely

## Why

Some improvements for Anime

## Testing

- tests/test_anime_history_coords.py 
- tests/test_anime_history_coords_orchestrator.py

## Issue

- Relates to #660
