### PR TITLE
Fix: absolute anime history aliases

### DIFF
--- a/cw_platform/anime_mapping/history_coords.py
+++ b/cw_platform/anime_mapping/history_coords.py
@@ -153,6 +153,7 @@ class HistoryCoordinateAliases:
                 for season, episode in self._axis_coordinates(show_ids_of(item), absolute):
                     frag = f"#s{season:02d}e{episode:02d}"
                     tokens.update(f"{p}{frag}" for p in prefixes)
+            return tokens
 
         coord = _episode_coordinate(item)
         if coord is not None and coord[0] > 0:

--- a/tests/test_anime_history_coords.py
+++ b/tests/test_anime_history_coords.py
@@ -148,6 +148,18 @@ def test_one_piece_matches_a_destination_that_numbers_episodes_absolutely(config
     assert "tmdb:37854#abs:75" in aliases.tokens(source)
 
 
+def test_a_row_with_its_own_absolute_never_claims_its_episode_number_is_one(config_base: Path) -> None:
+    dst_index = _mdblist_run(MDBLIST_ONE_PIECE_IDS, [(1, list(range(1, 21)))])
+    source = _episode(ONE_PIECE_IDS, 3, 11, absolute=21)
+    aliases = build_history_coordinate_aliases(CFG, "history", (dst_index,))
+
+    tokens = aliases.tokens(source)
+
+    assert "tmdb:37854#abs:21" in tokens
+    assert "tmdb:37854#abs:11" not in tokens
+    assert not _matched(aliases, source, dst_index["tmdb:37854#s01e11"])
+
+
 def test_per_season_restart_numbering_is_not_treated_as_absolute(config_base: Path) -> None:
     dst_index = _mdblist_run(MDBLIST_DBZ_IDS, [(1, list(range(1, 40))), (2, list(range(1, 36)))])
 


### PR DESCRIPTION
# Pull request

## Change

Return alias tokens after absolute coordinate expansion.

## Why

Prevents episode numbers from being treated as absolute ids.

## Testing

- tests/test_anime_history_coords.py

## Issue

NA