### PR TITLE
Fix: SIMKL anime custom episode overrides

### DIFF
--- a/providers/sync/simkl/_history.py
+++ b/providers/sync/simkl/_history.py
@@ -1873,6 +1873,21 @@ def _anibridge_absolute(
     return absolute
 
 
+def _simkl_override_absolute(item: Mapping[str, Any], ids: Mapping[str, str]) -> int | None:
+    raw = item.get("_cw_anime_map")
+    if not isinstance(raw, Mapping):
+        return None
+    namespace = str(raw.get("namespace") or "").strip().lower()
+    if namespace != "simkl":
+        return None
+    target_id = str(raw.get("target_id") or "").strip()
+    simkl_id = str(ids.get("simkl") or "").strip()
+    if not target_id or target_id != simkl_id:
+        return None
+    absolute = _int_or_none(raw.get("absolute"))
+    return absolute if absolute is not None and absolute > 0 else None
+
+
 def _log_anime_resolve_summary(state: _AnimeResolveState) -> None:
     if state.checked <= 0:
         return
@@ -2279,6 +2294,11 @@ def _anime_retry_episode_number(
             return alias_native
     rows = _anime_episode_rows(session, headers, timeout, str(ids.get("simkl") or ""), episode_cache)
     if rows:
+        override_absolute = _simkl_override_absolute(item, ids)
+        if override_absolute is not None:
+            abs_hits = [row for row in rows if _row_anime_episode_number(row) == override_absolute]
+            if len(abs_hits) == 1:
+                return override_absolute
         direct = [
             row for row in rows
             if isinstance(row.get("tvdb"), Mapping)

--- a/providers/tests/test_simkl_history_anime_mapping.py
+++ b/providers/tests/test_simkl_history_anime_mapping.py
@@ -124,6 +124,12 @@ _DBZ_EPISODES = {"41487": [{"episode": n, "title": f"dbz{n}", "tvdb": {"season":
 # Attack on Titan's parent TVDB redirects to a cour whose native map only covers S1 (no S4).
 _AOT_REDIRECT = {"267440": "39687"}
 _AOT_EPISODES = {"39687": [{"episode": n, "title": f"aot{n}", "tvdb": {"season": 1, "episode": n}} for n in range(1, 26)]}
+_KAIJU_EPISODES = {
+    "2532478": [
+        {"episode": 1, "title": "Kaiju Weapon", "tvdb": {"season": 2, "episode": 1}},
+        {"episode": 2, "title": "The Next Generation's Trial", "tvdb": {"season": 2, "episode": 2}},
+    ]
+}
 
 
 def _shows_of(session, url):
@@ -492,6 +498,39 @@ def test_dbz_absolute_fallback_group_mapping(monkeypatch):
         episode_cache={},
     )
     assert mapped == {m._thaw_key(item): 40}
+
+
+def test_simkl_target_override_maps_split_target_native_episode(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _Session(episodes_map=_KAIJU_EPISODES)
+    adapter = _adapter(session)
+    item = {
+        "type": "episode",
+        "season": 1,
+        "episode": 13,
+        "watched_at": "2024-01-01T00:00:00Z",
+        "show_ids": {"tmdb": "207468"},
+        "series_title": "Kaiju No. 8",
+        "_cw_anime_map": {
+            "absolute": 1,
+            "namespace": "simkl",
+            "target_id": "2532478",
+            "entry": "override:ovr_kaiju_s2n4p7",
+            "release_tag": "v3",
+        },
+    }
+
+    mapped = m._anime_retry_episode_numbers_for_group(
+        [item],
+        {"simkl": "2532478"},
+        session=session,
+        headers={},
+        timeout=5,
+        episode_cache={},
+    )
+    assert mapped == {m._thaw_key(item): 1}
 
 
 def test_read_back_native_e01_maps_to_tvdb_s04e17():


### PR DESCRIPTION
# Pull request

## Change

Use direct SIMKL custom overrides as the native anime episode number when the SIMKL episode catalog confirms it.

## Why

Some anime seasons have separate SIMKL IDs, but the source reports them as one continuous season. 
The old resolver found the right SIMKL record, then still failed because the catalog TVDB season did not match the source season.

## Testing

- tests/test_simkl_history_anime_mapping.py

## Issue

NA