### PR TITLE
Fix: refresh stale SIMKL anime episode cache for overrides

### DIFF
--- a/providers/sync/simkl/_history.py
+++ b/providers/sync/simkl/_history.py
@@ -2065,12 +2065,14 @@ def _anime_episode_rows(
     timeout: float,
     simkl_id: str,
     cache: dict[str, list[dict[str, Any]]],
+    *,
+    force_refresh: bool = False,
 ) -> list[dict[str, Any]]:
     simkl_id = str(simkl_id or "").strip()
     if not simkl_id:
         return []
     cached = cache.get(simkl_id)
-    if isinstance(cached, list):
+    if isinstance(cached, list) and not force_refresh:
         return cached
     try:
         resp = session.get(
@@ -2081,17 +2083,17 @@ def _anime_episode_rows(
         )
     except Exception as exc:
         _dbg("anime_episode_map_failed", simkl=simkl_id, error=exc.__class__.__name__)
-        return []
+        return cached if isinstance(cached, list) else []
     if not (200 <= getattr(resp, "status_code", 0) < 300):
         _dbg("anime_episode_map_miss", simkl=simkl_id, status=getattr(resp, "status_code", None))
-        return []
+        return cached if isinstance(cached, list) else []
     try:
         payload = resp.json() if (getattr(resp, "text", "") or "").strip() else []
     except Exception as exc:
         _dbg("anime_episode_map_malformed", simkl=simkl_id, error=exc.__class__.__name__)
         return []
     if not isinstance(payload, list):
-        return []
+        return cached if isinstance(cached, list) else []
     rows: list[dict[str, Any]] = []
     for row in payload:
         if not isinstance(row, Mapping):
@@ -2113,6 +2115,8 @@ def _anime_episode_rows(
     if rows:
         cache[simkl_id] = rows
         _save_anime_episode_map_cache(cache)
+    elif isinstance(cached, list):
+        return cached
     return rows
 
 
@@ -2299,6 +2303,19 @@ def _anime_retry_episode_number(
             abs_hits = [row for row in rows if _row_anime_episode_number(row) == override_absolute]
             if len(abs_hits) == 1:
                 return override_absolute
+            refreshed = _anime_episode_rows(
+                session,
+                headers,
+                timeout,
+                str(ids.get("simkl") or ""),
+                episode_cache,
+                force_refresh=True,
+            )
+            if refreshed is not rows:
+                abs_hits = [row for row in refreshed if _row_anime_episode_number(row) == override_absolute]
+                if len(abs_hits) == 1:
+                    return override_absolute
+                rows = refreshed
         direct = [
             row for row in rows
             if isinstance(row.get("tvdb"), Mapping)

--- a/providers/tests/test_simkl_history_anime_mapping.py
+++ b/providers/tests/test_simkl_history_anime_mapping.py
@@ -533,6 +533,48 @@ def test_simkl_target_override_maps_split_target_native_episode(monkeypatch):
     assert mapped == {m._thaw_key(item): 1}
 
 
+def test_simkl_target_override_refreshes_stale_episode_cache(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    saved: list[dict] = []
+    monkeypatch.setattr(m, "_save_anime_episode_map_cache", lambda rows: saved.append(dict(rows)))
+    session = _Session(episodes_map=_KAIJU_EPISODES)
+    item = {
+        "type": "episode",
+        "season": 1,
+        "episode": 13,
+        "watched_at": "2024-01-01T00:00:00Z",
+        "show_ids": {"tmdb": "207468"},
+        "series_title": "Kaiju No. 8",
+        "_cw_anime_map": {
+            "absolute": 1,
+            "namespace": "simkl",
+            "target_id": "2532478",
+            "entry": "override:ovr_kaiju_s2n4p7",
+            "release_tag": "v3",
+        },
+    }
+    stale_cache = {
+        "2532478": [
+            {"episode": 6, "title": "The Next Generation's Trial", "tvdb": {"season": 2, "episode": 6}}
+        ]
+    }
+
+    mapped = m._anime_retry_episode_numbers_for_group(
+        [item],
+        {"simkl": "2532478"},
+        session=session,
+        headers={},
+        timeout=5,
+        episode_cache=stale_cache,
+    )
+
+    assert mapped == {m._thaw_key(item): 1}
+    assert any("/anime/episodes/2532478" in call["url"] for call in session.gets)
+    assert saved and stale_cache["2532478"][0]["episode"] == 1
+
+
 def test_read_back_native_e01_maps_to_tvdb_s04e17():
     import sync.simkl._history as m
 


### PR DESCRIPTION
# Pull request

## Change

Refresh SIMKL anime episode rows when a direct SIMKL anime override points to an episode that is missing from the cached episode map.

## Why

Custom anime overrides could resolve to the right SIMKL season id, but still fail if the local anime episode cache was stale or incomplete.

## Testing

- providers/tests/test_simkl_history_anime_mapping.py

## Issue

Relates to #660