### PR TITLE
Change: trust direct SIMKL anime episode overrides

### DIFF
--- a/providers/sync/simkl/_history.py
+++ b/providers/sync/simkl/_history.py
@@ -2296,9 +2296,11 @@ def _anime_retry_episode_number(
         alias_native = _confirmed_alias_native_number(ids, item, s_num, e_num, alias_cache)
         if alias_native is not None:
             return alias_native
+    override_absolute = _simkl_override_absolute(item, ids)
     rows = _anime_episode_rows(session, headers, timeout, str(ids.get("simkl") or ""), episode_cache)
+    if override_absolute is not None and not rows:
+        return override_absolute
     if rows:
-        override_absolute = _simkl_override_absolute(item, ids)
         if override_absolute is not None:
             abs_hits = [row for row in rows if _row_anime_episode_number(row) == override_absolute]
             if len(abs_hits) == 1:
@@ -2316,6 +2318,7 @@ def _anime_retry_episode_number(
                 if len(abs_hits) == 1:
                     return override_absolute
                 rows = refreshed
+            return override_absolute
         direct = [
             row for row in rows
             if isinstance(row.get("tvdb"), Mapping)

--- a/providers/tests/test_simkl_history_anime_mapping.py
+++ b/providers/tests/test_simkl_history_anime_mapping.py
@@ -613,6 +613,40 @@ def test_simkl_target_override_beats_source_tvdb_redirect(monkeypatch):
     assert not any(call["url"] == m.URL_REDIRECT for call in session.gets)
 
 
+def test_simkl_target_override_is_authoritative_without_catalog_rows(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _Session(episodes_map={"2532478": []})
+    item = {
+        "type": "episode",
+        "season": 1,
+        "episode": 13,
+        "watched_at": "2024-01-01T00:00:00Z",
+        "show_ids": {"tmdb": "207468"},
+        "series_title": "Kaiju No. 8",
+        "_cw_anime_map": {
+            "absolute": 1,
+            "namespace": "simkl",
+            "target_id": "2532478",
+            "entry": "override:ovr_kaiju_s2n4p7",
+            "release_tag": "v3",
+        },
+    }
+
+    mapped = m._anime_retry_episode_number(
+        item,
+        {"simkl": "2532478"},
+        session=session,
+        headers={},
+        timeout=5,
+        episode_cache={},
+        resolve_state=m._AnimeResolveState({}, {}),
+    )
+
+    assert mapped == 1
+
+
 def test_read_back_native_e01_maps_to_tvdb_s04e17():
     import sync.simkl._history as m
 


### PR DESCRIPTION
# Pull request

## Change

Treat direct SIMKL anime episode overrides as authoritative when building the anime history retry payload.

## Why

Mapped anime episodes could still fall back to the normal show payload when catalog verification failed, causing SIMKL episode not found errors for valid custom mappings.

## Testing

- providers/tests/test_simkl_history_anime_mapping.py

## Issue

Relates to #660