### PR TITLE
Fix: large Trakt import preview

### DIFF
--- a/providers/sync/crosswatch/_common.py
+++ b/providers/sync/crosswatch/_common.py
@@ -201,6 +201,11 @@ def readonly(adapter: Any) -> bool:
     return bool(isinstance(cfg, Mapping) and cfg.get("_cw_readonly"))
 
 
+def current_state_only(adapter: Any) -> bool:
+    cfg = getattr(adapter, "config", None)
+    return bool(isinstance(cfg, Mapping) and cfg.get("_cw_current_state_only"))
+
+
 def may_persist(adapter: Any, path: Path) -> bool:
     return not readonly(adapter) and not pair_scoped() and not path.exists()
 

--- a/providers/sync/crosswatch/_history.py
+++ b/providers/sync/crosswatch/_history.py
@@ -19,6 +19,7 @@ from ._common import (
     _record_unresolved,
     _root,
     _snapshot_state,
+    current_state_only,
     latest_snapshot_file,
     latest_state_file,
     make_logger,
@@ -111,6 +112,8 @@ def _load_state(adapter: Any) -> dict[str, Any]:
         alt = latest_state_file(root, "history")
         if alt and alt != path:
             raw = _read_json(alt)
+    if raw is None and current_state_only(adapter):
+        return {"ts": 0, "items": {}}
     if raw is None:
         snap = latest_snapshot_file(root, "history")
         if snap:

--- a/providers/sync/crosswatch/_ratings.py
+++ b/providers/sync/crosswatch/_ratings.py
@@ -19,6 +19,7 @@ from ._common import (
     _record_unresolved,
     _root,
     _snapshot_state,
+    current_state_only,
     latest_snapshot_file,
     latest_state_file,
     make_logger,
@@ -102,6 +103,8 @@ def _load_state(adapter: Any) -> dict[str, Any]:
         alt = latest_state_file(root, "ratings")
         if alt and alt != path:
             raw = _read_json(alt)
+    if raw is None and current_state_only(adapter):
+        return {"ts": 0, "items": {}}
     if raw is None:
         snap = latest_snapshot_file(root, "ratings")
         if snap:

--- a/providers/sync/crosswatch/_watchlist.py
+++ b/providers/sync/crosswatch/_watchlist.py
@@ -21,6 +21,7 @@ from ._common import (
     _record_unresolved,
     _root,
     _snapshot_state,
+    current_state_only,
     latest_snapshot_file,
     latest_state_file,
     make_logger,
@@ -123,6 +124,8 @@ def _load_state(adapter: Any) -> dict[str, Any]:
         alt = latest_state_file(root, "watchlist")
         if alt and alt != path:
             raw = _read_json(alt)
+    if raw is None and current_state_only(adapter):
+        return {"ts": 0, "items": {}}
     if raw is None:
         snap = latest_snapshot_file(root, "watchlist")
         if snap:

--- a/services/importer.py
+++ b/services/importer.py
@@ -32,7 +32,7 @@ router = APIRouter(prefix="/api/import", tags=["import"])
 
 MAX_UPLOAD_BYTES = 25 * 1024 * 1024
 MAX_TEXT_BYTES = 8 * 1024 * 1024
-MAX_ZIP_FILES = 80
+MAX_ZIP_FILES = 1000
 MAX_ZIP_MEMBER_BYTES = 8 * 1024 * 1024
 MAX_ZIP_TOTAL_BYTES = 60 * 1024 * 1024
 MAX_ROWS = 50_000
@@ -1041,11 +1041,18 @@ def _existing_keys(cfg: Mapping[str, Any], instance: str) -> dict[str, Any]:
     if not ops:
         return {f: set() for f in FEATURES}
     cfg_view = build_provider_config_view(cfg, "CROSSWATCH", instance)
+    if hasattr(ops, "is_configured"):
+        try:
+            if not bool(ops.is_configured(cfg_view)):
+                return {f: {} for f in FEATURES}
+        except Exception:
+            return {f: {} for f in FEATURES}
     out: dict[str, Any] = {f: {} for f in FEATURES}
     for feature in FEATURES:
         try:
             view = dict(cfg_view)
             view["_cw_readonly"] = True
+            view["_cw_current_state_only"] = True
             if feature == "history":
                 view["_cw_history_rewatches"] = True
             idx = ops.build_index(view, feature=feature) or {}

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -22,6 +22,33 @@ def test_importer_rejects_zip_member_size() -> None:
     assert getattr(exc.value, "detail", {}).get("code") == importer.ERROR_ZIP_TOO_LARGE
 
 
+def test_importer_accepts_large_paginated_trakt_zip() -> None:
+    import services.importer as importer
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for index in range(127):
+            zf.writestr(f"watched-history-{index + 1}.json", b"[]")
+
+    members = importer._safe_zip_members(buf.getvalue())
+
+    assert len(members) == 127
+
+
+def test_importer_still_rejects_excessive_zip_members() -> None:
+    import services.importer as importer
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for index in range(importer.MAX_ZIP_FILES + 1):
+            zf.writestr(f"watched-history-{index + 1}.json", b"[]")
+
+    with pytest.raises(Exception) as exc:
+        importer._safe_zip_members(buf.getvalue())
+
+    assert getattr(exc.value, "detail", {}).get("code") == importer.ERROR_ZIP_TOO_MANY_FILES
+
+
 def test_letterboxd_preview_shapes_selectable_rows(monkeypatch: pytest.MonkeyPatch) -> None:
     import services.importer as importer
 
@@ -686,9 +713,33 @@ def test_preview_never_writes_to_the_target_tracker(tmp_path: Path) -> None:
     assert state.exists() and snapshots
 
     state.unlink()
-    importer._existing_keys(cfg, "default")
+    existing = importer._existing_keys(cfg, "default")
 
     assert not state.exists(), "preview recreated the tracker state file from a snapshot"
+    assert existing["history"] == {}
+
+
+def test_preview_ignores_existing_keys_when_crosswatch_target_is_disconnected(tmp_path: Path) -> None:
+    import services.importer as importer
+    from cw_platform.modules_registry import load_sync_ops
+    from cw_platform.provider_instances import build_provider_config_view
+
+    ops = load_sync_ops("CROSSWATCH")
+    assert ops is not None
+
+    root = tmp_path / "cw"
+    cfg = {"crosswatch": {"connected": True, "enabled": True, "root_dir": str(root)}}
+    view = dict(build_provider_config_view(cfg, "CROSSWATCH", "default"))
+    ops.add(
+        view,
+        [{"type": "movie", "title": "Heat", "ids": {"tmdb": "949"}, "rating": 8}],
+        feature="ratings",
+    )
+
+    disconnected = {"crosswatch": {"connected": False, "enabled": True, "root_dir": str(root)}}
+    existing = importer._existing_keys(disconnected, "default")
+
+    assert existing == {f: {} for f in importer.FEATURES}
 
 
 def test_preview_status_filter_keeps_full_summary() -> None:


### PR DESCRIPTION
# Pull request

## Change

- Raise the ZIP member limit for large paginated Trakt exports.
- Make import preview check current CrossWatch tracker state only.

## Why

- Large Trakt exports can have more than 80 files.
- Old snapshots could make an empty tracker look like it already had rows.

## Testing

- tests/test_importer.py

## Issue

NA