### PR TITLE
Fix: MDBList reverse anime episode matching

### DIFF
--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -828,6 +828,15 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
         toks: set[str] = set(coord_aliases.tokens(it))
 
         if typ == "episode":
+            if show_ids:
+                for k in ("tmdb", "imdb", "tvdb", "trakt"):
+                    v = ids.get(k)
+                    if v is None or str(v) == "":
+                        continue
+                    show_v = show_ids.get(k)
+                    if show_v is not None and str(show_v).lower() == str(v).lower():
+                        continue
+                    toks.add(f"{str(k).lower()}:{str(v).lower()}")
             try:
                 season_raw = it.get("season") if it.get("season") is not None else it.get("season_number")
                 episode_raw = it.get("episode") if it.get("episode") is not None else it.get("episode_number")

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -702,14 +702,23 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
 
     def _typed_tokens(it: Mapping[str, Any]) -> set[str]:
         typ = str(it.get("type") or "").strip().lower()
-        if typ in ("episode", "season"):
-            ids_raw = it.get("show_ids") or it.get("ids") or {}
-        else:
-            ids_raw = it.get("ids") or {}
-        ids = ids_raw if isinstance(ids_raw, Mapping) else {}
+        show_ids_raw = it.get("show_ids") if isinstance(it.get("show_ids"), Mapping) else {}
+        ids_raw = it.get("ids") if isinstance(it.get("ids"), Mapping) else {}
+        show_ids = dict(show_ids_raw or {})
+        ids = dict(ids_raw or {})
+        coord_ids: Mapping[str, Any] = (show_ids or ids) if typ in ("episode", "season") else ids
         toks: set[str] = set(coord_aliases.tokens(it))
 
         if typ == "episode":
+            if show_ids:
+                for k in ("tmdb", "imdb", "tvdb", "trakt"):
+                    v = ids.get(k)
+                    if v is None or str(v) == "":
+                        continue
+                    show_v = show_ids.get(k)
+                    if show_v is not None and str(show_v).lower() == str(v).lower():
+                        continue
+                    toks.add(f"{str(k).lower()}:{str(v).lower()}")
             try:
                 season_raw = it.get("season") if it.get("season") is not None else it.get("season_number")
                 episode_raw = it.get("episode") if it.get("episode") is not None else it.get("episode_number")
@@ -719,7 +728,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                 s, e = -1, 0
             if s >= 0 and e > 0:
                 frag = f"#s{s:02d}e{e:02d}"
-                for k, v in ids.items():
+                for k, v in coord_ids.items():
                     if v is None or str(v) == "":
                         continue
                     toks.add(f"{str(k).lower()}:{str(v).lower()}{frag}")
@@ -732,7 +741,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                 s = -1
             if s >= 0:
                 frag = f"#season:{s}"
-                for k, v in ids.items():
+                for k, v in coord_ids.items():
                     if v is None or str(v) == "":
                         continue
                     toks.add(f"{str(k).lower()}:{str(v).lower()}{frag}")

--- a/cw_platform/orchestrator/_planner.py
+++ b/cw_platform/orchestrator/_planner.py
@@ -30,6 +30,23 @@ def _strong_keys(item: Mapping[str, Any]) -> set[str]:
                 out.add(t)
         return out
 
+    show_ids: Mapping[str, Any] = {}
+    show_ids_raw = item.get("show_ids")
+    if isinstance(show_ids_raw, Mapping) and show_ids_raw:
+        show_ids = coalesce_ids(show_ids_raw) or {}
+
+    if typ == "episode" and show_ids:
+        for k in _STRONG_ID_KEYS:
+            own = ids.get(k)
+            if own is None or str(own).strip() == "":
+                continue
+            show = show_ids.get(k)
+            if show is not None and str(show).strip().lower() == str(own).strip().lower():
+                continue
+            t = _tok(k, own)
+            if t:
+                out.add(t)
+
     s = item.get("season") if item.get("season") is not None else item.get("season_number")
     e = item.get("episode") if item.get("episode") is not None else item.get("episode_number")
     try:
@@ -55,10 +72,7 @@ def _strong_keys(item: Mapping[str, Any]) -> set[str]:
                 out.add(t)
         return out
 
-    source_ids: Mapping[str, Any] = ids
-    show_ids_raw = item.get("show_ids")
-    if isinstance(show_ids_raw, Mapping) and show_ids_raw:
-        source_ids = coalesce_ids(show_ids_raw) or ids
+    source_ids: Mapping[str, Any] = show_ids or ids
 
     for k in _STRONG_ID_KEYS:
         t = _tok(k, source_ids.get(k))

--- a/providers/sync/mdblist/_history.py
+++ b/providers/sync/mdblist/_history.py
@@ -316,26 +316,51 @@ def _comparison_alias_keys_for_episode(
 ) -> dict[str, dict[str, Any]]:
     if _type_norm(item.get("type")) != "episode":
         return {}
-    try:
-        res = resolve_absolute(item, release_tag=release_tag)
-    except Exception:
-        res = None
-    if res is None or int(res.absolute) <= 0:
+    absolute = _as_int(item.get("episode"))
+    season = _as_int(item.get("season"))
+    native_ids = _anime_native_ids(item)
+    coords: set[tuple[int, int]] = set()
+
+    # MDBList can return long-running anime with the absolute number in the
+    # episode field even when the season field is not season 1, e.g. One Piece
+    # S23E1156. In that case resolving the raw S/E as an aired coordinate can
+    # double-count the absolute offset, so use the episode value as absolute.
+    absolute_like = bool(absolute is not None and absolute >= 50 and season is not None and season > 1)
+    if absolute_like and native_ids:
+        try:
+            coords.update(resolve_axis_coordinates(native_ids, absolute, release_tag=release_tag))
+        except Exception:
+            pass
+        if coords:
+            coords.add((1, absolute))
+        else:
+            absolute = None
+    else:
+        absolute = None
+
+    if absolute_like and not native_ids:
         return {}
 
-    native_ids = {str(res.namespace): str(res.target_id)}
-    coords: set[tuple[int, int]] = set()
-    try:
-        coords.update(resolve_axis_coordinates(native_ids, int(res.absolute), release_tag=release_tag))
-    except Exception:
-        pass
-    try:
-        src_coord = resolve_source_coordinate(native_ids, int(res.absolute), release_tag=release_tag)
-    except Exception:
-        src_coord = None
-    if src_coord is not None:
-        coords.add((int(src_coord.season), int(src_coord.episode)))
-    coords.add((1, int(res.absolute)))
+    if absolute is None:
+        try:
+            res = resolve_absolute(item, release_tag=release_tag)
+        except Exception:
+            res = None
+        if res is None or int(res.absolute) <= 0:
+            return {}
+        absolute = int(res.absolute)
+        native_ids = {str(res.namespace): str(res.target_id)}
+        try:
+            coords.update(resolve_axis_coordinates(native_ids, absolute, release_tag=release_tag))
+        except Exception:
+            pass
+        try:
+            src_coord = resolve_source_coordinate(native_ids, absolute, release_tag=release_tag)
+        except Exception:
+            src_coord = None
+        if src_coord is not None:
+            coords.add((int(src_coord.season), int(src_coord.episode)))
+        coords.add((1, absolute))
 
     out: dict[str, dict[str, Any]] = {}
     current = (_as_int(item.get("season")), _as_int(item.get("episode")))

--- a/providers/tests/test_mdblist_history_anime_mapping.py
+++ b/providers/tests/test_mdblist_history_anime_mapping.py
@@ -78,6 +78,60 @@ def test_destination_comparison_view_respects_pair_toggle(monkeypatch: Any) -> N
     assert m.destination_comparison_view(index, adapter) == index
 
 
+def test_destination_comparison_view_handles_absolute_episode_in_late_season(monkeypatch: Any) -> None:
+    from providers.sync.mdblist import _history as m
+
+    def fake_axis(ids: Mapping[str, Any], absolute: Any, **_: Any) -> set[tuple[int, int]]:
+        assert int(absolute) == 1156
+        return {(22, 1156), (23, 1)}
+
+    def fail_resolve_absolute(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("raw S23E1156 must not be resolved as an aired coordinate")
+
+    monkeypatch.setattr(m, "resolve_axis_coordinates", fake_axis)
+    monkeypatch.setattr(m, "resolve_absolute", fail_resolve_absolute)
+    monkeypatch.setattr(m, "resolve_source_coordinate", lambda *_args, **_kwargs: None)
+
+    adapter = Adapter(anime_mapping=True)
+    raw = _episode(
+        show_tmdb="37854",
+        season=23,
+        episode=1156,
+        ids={"tvdb": "11526346"},
+        show_ids={"tmdb": "37854", "tvdb": "81797", "mal": "21", "anidb": "69"},
+        series_title="One Piece",
+    )
+    index = {m._history_key(adapter, raw): raw}
+
+    out = m.destination_comparison_view(index, adapter)
+
+    assert "tmdb:37854#s23e01" in out
+    assert "tmdb:37854#s22e2311" not in out
+    assert out["tmdb:37854#s23e01"]["episode"] == 1
+
+
+def test_destination_comparison_view_skips_absolute_like_row_without_native_ids(monkeypatch: Any) -> None:
+    from providers.sync.mdblist import _history as m
+
+    def fail_resolve_absolute(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("absolute-like provider rows without native ids should not double-resolve")
+
+    monkeypatch.setattr(m, "resolve_absolute", fail_resolve_absolute)
+
+    adapter = Adapter(anime_mapping=True)
+    raw = _episode(
+        show_tmdb="37854",
+        season=23,
+        episode=1156,
+        ids={"tmdb": "7099881", "tvdb": "11526346"},
+        show_ids={"tmdb": "37854", "imdb": "tt0388629", "trakt": "37696", "mdblist": "8xaa"},
+        series_title="One Piece",
+    )
+    index = {m._history_key(adapter, raw): raw}
+
+    assert m.destination_comparison_view(index, adapter) == index
+
+
 def test_bucketize_prefers_tmdb_anime_coordinate_for_mdblist(monkeypatch: Any) -> None:
     from providers.sync.mdblist import _history as m
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -20,6 +20,56 @@ def test_diff_adds_and_removes_minimally() -> None:
     assert set(adds[0].keys()) >= {"type", "title", "year", "ids"}
 
 
+def test_diff_matches_episode_level_ids_when_coordinates_differ() -> None:
+    src = {
+        "tmdb:37854#s23e01": {
+            "type": "episode",
+            "series_title": "One Piece",
+            "season": 23,
+            "episode": 1,
+            "ids": {"tvdb": "11526346"},
+            "show_ids": {"tmdb": "37854", "tvdb": "81797"},
+        }
+    }
+    dst = {
+        "tmdb:37854#s23e1156": {
+            "type": "episode",
+            "series_title": "One Piece",
+            "season": 23,
+            "episode": 1156,
+            "ids": {"tmdb": "7099881", "tvdb": "11526346"},
+            "show_ids": {"tmdb": "37854", "tvdb": "81797"},
+        }
+    }
+
+    assert diff(src, dst) == ([], [])
+
+
+def test_diff_does_not_match_inherited_show_ids_as_episode_ids() -> None:
+    src = {
+        "tmdb:37854#s23e01": {
+            "type": "episode",
+            "season": 23,
+            "episode": 1,
+            "ids": {"tmdb": "37854"},
+            "show_ids": {"tmdb": "37854"},
+        }
+    }
+    dst = {
+        "tmdb:37854#s23e02": {
+            "type": "episode",
+            "season": 23,
+            "episode": 2,
+            "ids": {"tmdb": "37854"},
+            "show_ids": {"tmdb": "37854"},
+        }
+    }
+
+    adds, removes = diff(src, dst)
+    assert len(adds) == 1
+    assert len(removes) == 1
+
+
 def test_diff_ratings_upserts_and_unrates() -> None:
     src = {
         "imdb:tt01": {"type": "movie", "title": "A", "year": 2000, "ids": {"imdb": "tt01"}, "rating": 7},


### PR DESCRIPTION
# Pull request

## Change

- Match episode-level ids during history comparison when providers use different season/episode coordinates.
- Also avoids bad MDBList anime aliases for absolute-style episode rows without native anime ids.

## Why

- MDBList can return One Piece anime as `S23E1156` while SIMKL has the same episode as `S23E01`.
- They share the same real TVDB episode id, so we should treat them as the same watched episode instead of planning false adds.

## Testing

- tests/test_planner.py 
- providers/tests/test_mdblist_history_anime_mapping.py 
- providers/tests/test_mdblist_progress.py 
- providers/tests/test_simkl_history_anime_mapping.py

## Issue

Relates to #660