### PR TITLE
Fix: absolute numbering guess for new seasons

### DIFF
--- a/cw_platform/anime_mapping/history_coords.py
+++ b/cw_platform/anime_mapping/history_coords.py
@@ -13,6 +13,7 @@ NATIVE_ANIME_ID_KEYS = ("mal", "anilist", "anidb", "kitsu")
 ABSOLUTE_FRAGMENT = "#abs:"
 _MIN_ABSOLUTE_RUN = 2
 _MAX_DUPLICATE_RATIO = 0.98
+_MAX_ORDINARY_SEASON = 50
 
 
 def _as_int(value: Any) -> int | None:
@@ -60,8 +61,8 @@ def _episode_coordinate(item: Mapping[str, Any]) -> tuple[int, int] | None:
     return season, episode
 
 
-def _absolute_numbered_shows_in(index: Mapping[str, Any] | None) -> dict[str, set[int]]:
-    per_show: dict[str, list[int]] = {}
+def _absolute_runs_in(index: Mapping[str, Any] | None) -> dict[str, tuple[set[int], set[int]]]:
+    per_show: dict[str, list[tuple[int, int]]] = {}
     for item in (index or {}).values():
         if not isinstance(item, Mapping) or not _is_episode(item):
             continue
@@ -69,10 +70,11 @@ def _absolute_numbered_shows_in(index: Mapping[str, Any] | None) -> dict[str, se
         if coord is None or coord[0] <= 0:
             continue
         for token in show_tokens(item):
-            per_show.setdefault(token, []).append(coord[1])
+            per_show.setdefault(token, []).append(coord)
 
-    out: dict[str, set[int]] = {}
-    for token, numbers in per_show.items():
+    out: dict[str, tuple[set[int], set[int]]] = {}
+    for token, coords in per_show.items():
+        numbers = [episode for _, episode in coords]
         if len(numbers) < _MIN_ABSOLUTE_RUN:
             continue
         unique = set(numbers)
@@ -80,21 +82,30 @@ def _absolute_numbered_shows_in(index: Mapping[str, Any] | None) -> dict[str, se
             continue
         if min(unique) != 1 or max(unique) != len(unique):
             continue
+        seasons = {season for season, _ in coords}
+        if len(seasons) < 2 and max(unique) <= _MAX_ORDINARY_SEASON:
+            continue
         counts: dict[int, int] = {}
         for number in numbers:
             counts[number] = counts.get(number, 0) + 1
         unambiguous = {n for n, c in counts.items() if c == 1}
         if unambiguous:
-            out[token] = unambiguous
+            out[token] = (unambiguous, seasons)
+    return out
+
+
+def absolute_numbered_runs(*indexes: Mapping[str, Any] | None) -> dict[str, tuple[set[int], set[int]]]:
+    out: dict[str, tuple[set[int], set[int]]] = {}
+    for index in indexes:
+        for token, (numbers, seasons) in _absolute_runs_in(index).items():
+            merged = out.setdefault(token, (set(), set()))
+            merged[0].update(numbers)
+            merged[1].update(seasons)
     return out
 
 
 def absolute_numbered_shows(*indexes: Mapping[str, Any] | None) -> dict[str, set[int]]:
-    out: dict[str, set[int]] = {}
-    for index in indexes:
-        for token, numbers in _absolute_numbered_shows_in(index).items():
-            out.setdefault(token, set()).update(numbers)
-    return out
+    return {token: numbers for token, (numbers, _) in absolute_numbered_runs(*indexes).items()}
 
 
 class HistoryCoordinateAliases:
@@ -106,7 +117,7 @@ class HistoryCoordinateAliases:
     ) -> None:
         self.enabled = bool(enabled)
         self.release_tag = normalize_release_tag(release_tag)
-        self._absolute_shows: dict[str, set[int]] = absolute_numbered_shows(*indexes) if self.enabled else {}
+        self._absolute_runs: dict[str, tuple[set[int], set[int]]] = absolute_numbered_runs(*indexes) if self.enabled else {}
         self._coord_cache: dict[tuple[str, int], frozenset[tuple[int, int]]] = {}
         self._ready: bool | None = None
 
@@ -135,7 +146,7 @@ class HistoryCoordinateAliases:
         return cached
 
     def stats(self) -> dict[str, int]:
-        return {"absolute_shows": len(self._absolute_shows), "coord_cache": len(self._coord_cache)}
+        return {"absolute_shows": len(self._absolute_runs), "coord_cache": len(self._coord_cache)}
 
     def tokens(self, item: Mapping[str, Any]) -> set[str]:
         if not self.enabled or not isinstance(item, Mapping) or not _is_episode(item):
@@ -158,7 +169,8 @@ class HistoryCoordinateAliases:
         coord = _episode_coordinate(item)
         if coord is not None and coord[0] > 0:
             for prefix in prefixes:
-                if coord[1] in self._absolute_shows.get(prefix, ()):
+                numbers, seasons = self._absolute_runs.get(prefix, ((), ()))
+                if coord[0] in seasons and coord[1] in numbers:
                     tokens.add(f"{prefix}{ABSOLUTE_FRAGMENT}{coord[1]}")
 
         return tokens

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -948,6 +948,14 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
             return True
         return False
 
+    def _coord_only_present(idx: dict[str, Any], alias: dict[str, str], it: Mapping[str, Any]) -> bool:
+        coord_toks = coord_aliases.tokens(it) if coord_aliases.enabled else set()
+        if not coord_toks or _ck(it) in idx:
+            return False
+        if any(tok in alias for tok in (_typed_tokens(it) - coord_toks)):
+            return False
+        return any(tok in alias for tok in coord_toks)
+
     def _find_in_idx(idx: dict[str, Any], alias: dict[str, str], it: Mapping[str, Any]) -> Mapping[str, Any] | None:
         ck = _ck(it)
         if ck and ck in idx:
@@ -1382,11 +1390,16 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
             adds = [it for it in adds if not _present(dst_full, dst_alias, it)]
         elif feature == "history" and not history_event_mode:
             pruned: list[dict[str, Any]] = []
+            coord_pruned = 0
             for it in adds:
                 ck = _ck(it) or ""
                 if ck and _history_ts_from_key(ck) is None and _present(dst_full, dst_alias, it):
+                    if _coord_only_present(dst_full, dst_alias, it):
+                        coord_pruned += 1
                     continue
                 pruned.append(it)
+            if coord_pruned:
+                dbg("anime_mapping.coord_pruned", feature=feature, src=src, dst=dst, adds=coord_pruned)
             adds = pruned
 
     removes: list[dict[str, Any]] = []

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -820,6 +820,14 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
             return True
         return False
 
+    def _coord_only_present(idx: dict[str, Any], alias: dict[str, str], it: Mapping[str, Any]) -> bool:
+        coord_toks = coord_aliases.tokens(it) if coord_aliases.enabled else set()
+        if not coord_toks or _ck(it) in idx:
+            return False
+        if any(tok in alias for tok in (_typed_tokens(it) - coord_toks)):
+            return False
+        return any(tok in alias for tok in coord_toks)
+
     def _find_in_idx(idx: dict[str, Any], alias: dict[str, str], it: Mapping[str, Any]) -> Mapping[str, Any] | None:
         """Find a matching row in idx for it using canonical key or token overlap."""
         ck = _ck(it)
@@ -1612,8 +1620,12 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                 else:
                     add_to_A.append(_minimal(v))
         elif not (feature == "history" and history_event_mode):
+            coord_pruned_to_B = 0
+            coord_pruned_to_A = 0
             for _k, v in A_eff.items():
                 if _present(B_eff, B_alias, v):
+                    if _coord_only_present(B_eff, B_alias, v):
+                        coord_pruned_to_B += 1
                     continue
                 tomb_blocks = _tomb_blocks_remove(v, prev_self=prevA, prev_self_alias=prevA_alias)
                 if allow_removals and (tomb_blocks or (_ck(v) in obsB) or (_ck(v) in shrinkB)) and (_prev_had(prevB, prevB_alias, v) or tomb_blocks):
@@ -1622,12 +1634,16 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                     add_to_B.append(_minimal(v))
             for _k, v in B_eff.items():
                 if _present(A_eff, A_alias, v):
+                    if _coord_only_present(A_eff, A_alias, v):
+                        coord_pruned_to_A += 1
                     continue
                 tomb_blocks = _tomb_blocks_remove(v, prev_self=prevB, prev_self_alias=prevB_alias)
                 if allow_removals and (tomb_blocks or (_ck(v) in obsA) or (_ck(v) in shrinkA)) and (_prev_had(prevA, prevA_alias, v) or tomb_blocks):
                     rem_from_B.append(_minimal(v))
                 else:
                     add_to_A.append(_minimal(v))
+            if coord_pruned_to_A or coord_pruned_to_B:
+                dbg("anime_mapping.coord_pruned", feature=feature, a=a, b=b, to_a=coord_pruned_to_A, to_b=coord_pruned_to_B)
     if not allow_adds:
         add_to_A.clear()
         add_to_B.clear()

--- a/tests/test_anime_history_coords.py
+++ b/tests/test_anime_history_coords.py
@@ -197,6 +197,30 @@ def test_a_source_index_cannot_mask_an_absolutely_numbered_destination(config_ba
     assert "tmdb:37854" in absolute_numbered_shows(src_index, dst_index)
 
 
+def test_a_single_completed_season_is_not_treated_as_absolute(config_base: Path) -> None:
+    xmen = {"tmdb": "138502", "imdb": "tt16026746", "tvdb": "412432"}
+    dst_index = _mdblist_run(xmen, [(1, list(range(1, 11)))])
+
+    assert absolute_numbered_shows(dst_index) == {}
+
+
+def test_a_new_season_does_not_alias_onto_the_first_season(config_base: Path) -> None:
+    xmen = {"tmdb": "138502", "imdb": "tt16026746", "tvdb": "412432"}
+    dst_index = _mdblist_run(xmen, [(1, list(range(1, 11)))])
+    source = _episode(xmen, 2, 1)
+    aliases = build_history_coordinate_aliases(CFG, "history", ({"a": source}, dst_index))
+
+    assert not _matched(aliases, source, dst_index["tmdb:138502#s01e01"])
+
+
+def test_an_absolute_run_never_claims_a_season_it_was_not_seen_in(config_base: Path) -> None:
+    dst_index = _mdblist_run(MDBLIST_ONE_PIECE_IDS, [(1, list(range(1, 62))), (22, list(range(62, 100)))])
+    aliases = build_history_coordinate_aliases(CFG, "history", (dst_index,))
+
+    assert "tmdb:37854#abs:7" in aliases.tokens(_episode(MDBLIST_ONE_PIECE_IDS, 1, 7))
+    assert aliases.tokens(_episode(MDBLIST_ONE_PIECE_IDS, 3, 7)) == set()
+
+
 def test_translated_episode_is_not_planned_again_on_a_second_sync(anime_index: Path) -> None:
     source = _episode(DRAGON_BALL_IDS, 2, 1, absolute=14)
     destination = _episode(MDBLIST_DRAGON_BALL_IDS, 1, 14)


### PR DESCRIPTION
# Pull request

## Change

- Absolute run detection now keeps the season, so a show with one finished season is no longer read as absolute numbered
- Absolute tokens are only emitted for seasons the run was actually seen in, so S02E01 can no longer collide with S01E01
- Added a coord_pruned debug line in oneway and twoway so alias drops stop being invisible in logs

## Why
Anime ID mapping:
- The heuristic only looked at episode numbers. Any show where you watched exactly one season straight through looked like an absolute run
- SIMKL held X-Men 97 S01E01 to E10, a clean 1 to 10 run, so S02E01 aliased onto S01E01 and got dropped from the plan with nothing in the logs
- Self perpetuating too, since SIMKL never got season 2 it stayed a clean run forever

## Testing

- tests/test_anime_history_coords.py

## Issue

Relates to #742
