### PR TITLE
Fix: PunchPlay progress dropped continue watching row

### DIFF
--- a/providers/sync/punchplay/_progress.py
+++ b/providers/sync/punchplay/_progress.py
@@ -10,7 +10,6 @@ from typing import Any, Iterable, Mapping
 from cw_platform.id_map import canonical_key, minimal as id_minimal
 
 from ._common import (
-    URL_CONTINUE_WATCHING,
     URL_IN_PROGRESS,
     cfg_section,
     instance_id,
@@ -96,6 +95,8 @@ def _percent_of(item: Mapping[str, Any]) -> float | None:
 
 def _drop_reason(row: Mapping[str, Any]) -> str:
     typ = str(row.get("type") or "").strip().lower()
+    if not typ:
+        return "show_row_not_a_playback_item" if _as_int(row.get("showTmdbId")) else "missing_type"
     if typ == "episode":
         if not _as_int(row.get("showTmdbId")):
             return "episode_missing_show_tmdb_id"
@@ -263,22 +264,6 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
             return
         collected[key] = minimal
 
-    continue_rows = 0
-    resp = punchplay_request(adapter, "GET", URL_CONTINUE_WATCHING)
-    if resp.status_code != 200:
-        _warn(FEATURE, "continue_watching_fetch_failed", status=resp.status_code, error=error_of(resp), request_id=request_id_of(resp))
-    else:
-        data = safe_json(resp)
-        rows: list[Mapping[str, Any]] = []
-        if isinstance(data, Mapping):
-            raw = data.get("items")
-            rows = [r for r in raw if isinstance(r, Mapping)] if isinstance(raw, list) else []
-        elif isinstance(data, list):
-            rows = [r for r in data if isinstance(r, Mapping)]
-        for row in rows:
-            continue_rows += 1
-            collect(row, source="continue_watching")
-
     resp = punchplay_request(adapter, "GET", URL_IN_PROGRESS)
     if resp.status_code != 200:
         _warn(FEATURE, "in_progress_fetch_failed", status=resp.status_code, error=error_of(resp), request_id=request_id_of(resp))
@@ -304,7 +289,6 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
         "index_done",
         count=len(collected),
         rows=rows_seen,
-        continue_rows=continue_rows,
         snapshot_rows=snapshot_rows,
         dropped=len(dropped),
         drop_reasons=",".join(sorted(set(dropped))) or None,

--- a/tests/test_punchplay_sync.py
+++ b/tests/test_punchplay_sync.py
@@ -507,7 +507,6 @@ def test_progress_index_uses_in_progress_endpoint(monkeypatch: pytest.MonkeyPatc
     from providers.sync.punchplay import _progress as pr
 
     http = FakeHTTP([
-        _Resp(200, {"items": []}),
         _Resp(200, [
             {"id": 4, "type": "movie", "tmdbId": 550, "title": "Fight Club", "year": 1999,
              "progressSeconds": 1800, "durationSeconds": 8340, "progressPercent": 21.58,
@@ -520,21 +519,20 @@ def test_progress_index_uses_in_progress_endpoint(monkeypatch: pytest.MonkeyPatc
     idx = pr.build_index(Adapter())
 
     assert idx["tmdb:550"]["_punchplay_progress_id"] == "4"
-    assert http.calls[1]["method"] == "GET"
-    assert http.calls[1]["url"].endswith("/playback/in-progress")
+    assert http.calls[0]["method"] == "GET"
+    assert http.calls[0]["url"].endswith("/playback/in-progress")
 
 
-def test_progress_index_reads_continue_watching_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_progress_index_does_not_read_continue_watching(monkeypatch: pytest.MonkeyPatch) -> None:
     from providers.sync.punchplay import _progress as pr
 
     http = FakeHTTP([
-        _Resp(200, {"items": [
+        _Resp(200, [
             {"id": 9, "type": "episode", "tmdbId": 5978363, "showTmdbId": 69478,
              "showTitle": "The Handmaid's Tale", "episodeTitle": "Exile", "season": 6, "episode": 2,
              "progressSeconds": 753.0, "durationSeconds": 3307.93, "progressPercent": 22.764,
              "updatedAt": "2026-07-31T19:43:27.000Z"},
-        ]}),
-        _Resp(200, {"items": []}),
+        ]),
         _Resp(200, {"items": [], "hasMore": False, "nextAfter": None}),
     ])
     _patch(monkeypatch, pr, http)
@@ -542,15 +540,27 @@ def test_progress_index_reads_continue_watching_endpoint(monkeypatch: pytest.Mon
     idx = pr.build_index(Adapter())
 
     assert idx["tmdb:69478#s06e02"]["progress_ms"] == 753000
-    assert http.calls[0]["method"] == "GET"
-    assert http.calls[0]["url"].endswith("/me/continue-watching")
+    assert not any("/me/continue-watching" in call["url"] for call in http.calls)
+
+
+def test_continue_watching_show_rows_are_not_playback_items() -> None:
+    from providers.sync.punchplay import _progress as pr
+
+    row = {
+        "showTmdbId": 138502, "sourceId": 41, "mediaSource": "tmdb", "title": "X-Men '97",
+        "year": 2024, "overallPercent": 41.6, "minutesWatched": 132, "minutesRemaining": 185,
+        "episodeRuntimeMinutes": 33, "lastWatchedAt": "2026-08-14T14:34:49.000Z",
+        "lastWatchedSeason": 2, "lastWatchedEpisode": 2, "nextSeason": 2, "nextEpisode": 3,
+    }
+
+    assert pr._row_to_minimal(row) is None
+    assert pr._drop_reason(row) == "show_row_not_a_playback_item"
 
 
 def test_progress_index_merges_sync_snapshot_playback(monkeypatch: pytest.MonkeyPatch) -> None:
     from providers.sync.punchplay import _progress as pr
 
     http = FakeHTTP([
-        _Resp(200, {"items": []}),
         _Resp(200, {"items": []}),
         _Resp(200, {"items": [
             {"id": 7, "type": "episode", "tmdbId": 5978363, "showTmdbId": 69478,
@@ -564,8 +574,8 @@ def test_progress_index_merges_sync_snapshot_playback(monkeypatch: pytest.Monkey
     idx = pr.build_index(Adapter())
 
     assert idx["tmdb:69478#s06e02"]["progress_ms"] == 753000
-    assert http.calls[2]["url"].endswith("/me/sync/snapshot")
-    assert http.calls[2]["params"]["resource"] == "playback"
+    assert http.calls[1]["url"].endswith("/me/sync/snapshot")
+    assert http.calls[1]["params"]["resource"] == "playback"
 
 
 def test_progress_write_uses_incomplete_stop_for_passive_sync(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
# Pull request

## Change

- Progress no longer reads /me/continue-watching, that endpoint has no resume position
- Progress now comes from /playback/in-progress and the playback snapshot only
- Drop reason for a row with no type is now show_row_not_a_playback_item or missing_type instead of movie_missing_tmdb_id

## Why

- /me/continue-watching returns show level rows, no type, no tmdbId, no season or episode, no progressSeconds
- Per show detail has no resume position either, so there is nothing to parse. 
- Both continue watching endpoints are watched state, not progress

## Testing

- tests/test_punchplay_sync.py

## Issue

NA
