### PR TITLE
Fix: whole show history add lost watched_at

### DIFF
--- a/providers/sync/simkl/_history.py
+++ b/providers/sync/simkl/_history.py
@@ -1469,7 +1469,11 @@ def _show_add_entry(adapter: Any, item: Mapping[str, Any]) -> dict[str, Any] | N
         return None
     if _is_anime_like(item, ids):
         ids = _maybe_map_tvdb(adapter, ids)
-    return {"ids": ids, "use_tvdb_anime_seasons": True}
+    entry: dict[str, Any] = {"ids": ids, "use_tvdb_anime_seasons": True}
+    watched_at = str(item.get("watched_at") or item.get("watchedAt") or "").strip()
+    if watched_at:
+        entry["watched_at"] = watched_at
+    return entry
 
 
 def _show_scope_entry(
@@ -2795,9 +2799,6 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         bucket = str(item.get("simkl_bucket") or "").strip().lower()
         if typ == "movie" and bucket == "anime":
             entry = _show_add_entry(adapter, item)
-            watched_at = str(item.get("watched_at") or "").strip()
-            if entry and watched_at:
-                entry["watched_at"] = watched_at
             if entry:
                 shows_whole.append(entry)
                 key = _thaw_key(item)

--- a/tests/test_history_specials.py
+++ b/tests/test_history_specials.py
@@ -947,6 +947,51 @@ def test_issue_311_simkl_add_sends_episode_lookup_id(monkeypatch) -> None:
     ]
 
 
+def _simkl_add_capture(monkeypatch) -> list[dict[str, object]]:
+    requests: list[dict[str, object]] = []
+
+    class Session:
+        def post(self, _url, **kwargs):
+            requests.append(kwargs["json"])
+            payload = {
+                "added": {"movies": 1, "shows": 1, "episodes": 0},
+                "not_found": {"movies": [], "shows": [], "episodes": []},
+            }
+            return SimpleNamespace(status_code=201, text="json", json=lambda: payload)
+
+    monkeypatch.setattr(simkl_history, "_unfreeze", lambda _keys: None)
+    monkeypatch.setattr(simkl_history, "_inject_adds_into_cache", lambda _items: None)
+    return requests, SimpleNamespace(
+        client=SimpleNamespace(session=Session()),
+        cfg=SimpleNamespace(timeout=5, api_key="key", access_token="token"),
+    )
+
+
+def test_simkl_whole_show_add_carries_watched_at(monkeypatch) -> None:
+    requests, adapter = _simkl_add_capture(monkeypatch)
+    item = {"type": "show", "ids": {"tmdb": "12971"}, "watched_at": WATCHED_AT}
+
+    simkl_history.add(adapter, [item])
+
+    show = requests[0]["shows"][0]
+    assert "seasons" not in show
+    assert show["watched_at"] == WATCHED_AT
+
+
+def test_simkl_anime_movie_add_keeps_watched_at(monkeypatch) -> None:
+    requests, adapter = _simkl_add_capture(monkeypatch)
+    item = {
+        "type": "movie",
+        "simkl_bucket": "anime",
+        "ids": {"tmdb": "1311031"},
+        "watched_at": WATCHED_AT,
+    }
+
+    simkl_history.add(adapter, [item])
+
+    assert requests[0]["shows"][0]["watched_at"] == WATCHED_AT
+
+
 def test_issue_311_rejected_special_is_blocked_after_first_attempt(monkeypatch, tmp_path) -> None:
     class Session:
         def post(self, _url, **kwargs):


### PR DESCRIPTION
# Pull request

## Change

- Whole show history adds now carry watched_at at entry level
- Anime movies are unchanged, the manual set at the call site is gone because the helper covers it now

## Why

- Additional guard

## Testing

- tests/test_history_specials.py

## Issue

Relates to #741
