### PR TITLE
Fix: PunchPlay sink session state

### DIFF
--- a/providers/scrobble/punchplay/sink.py
+++ b/providers/scrobble/punchplay/sink.py
@@ -165,18 +165,23 @@ def _prune_sessions(now: float) -> None:
         _SESSIONS.pop(k, None)
 
 
+def _media_fingerprint(event: Any) -> str:
+    ids = getattr(event, "ids", None) or {}
+    seed = "|".join(f"{k}={v}" for k, v in sorted(ids.items()) if v)
+    seed = seed or str(getattr(event, "title", "") or "")
+    if str(getattr(event, "media_type", "") or "").lower() == "episode":
+        seed = f"{seed}|s{getattr(event, 'season', None)}e{getattr(event, 'number', None)}"
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
 def _session_scope(event: Any, instance: str) -> str:
     parts = [
         str(getattr(event, "server_uuid", "") or ""),
         str(getattr(event, "session_key", "") or ""),
     ]
     scope = ":".join(p for p in parts if p)
-    if not scope:
-        ids = getattr(event, "ids", None) or {}
-        seed = "|".join(f"{k}={v}" for k, v in sorted(ids.items()) if v)
-        seed = seed or str(getattr(event, "title", "") or "")
-        scope = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:24]
-    return f"{instance}:{scope}"
+    fingerprint = _media_fingerprint(event)
+    return f"{instance}:{scope}:{fingerprint}" if scope else f"{instance}:{fingerprint}"
 
 
 class PunchPlaySink(ScrobbleSink):
@@ -285,6 +290,19 @@ class PunchPlaySink(ScrobbleSink):
             _log("PUNCHPLAY: skip scrobble, no supported ids", "DEBUG")
             return
 
+        title = str(getattr(event, "title", "") or "").strip()
+        if not title:
+            _log("PUNCHPLAY: skip scrobble, missing title", "DEBUG")
+            return
+
+        season = number = None
+        if media_type == "episode":
+            season = _as_int(getattr(event, "season", None))
+            number = _as_int(getattr(event, "number", None))
+            if season is None or number is None:
+                _log("PUNCHPLAY: skip scrobble, episode missing season/episode", "DEBUG")
+                return
+
         try:
             progress_pct = max(0.0, min(100.0, float(getattr(event, "progress", 0.0) or 0.0)))
         except Exception:
@@ -303,20 +321,13 @@ class PunchPlaySink(ScrobbleSink):
         payload["playback_session_id"] = session_id
         payload["event_created_at"] = int(now * 1000)
         payload["client_version"] = APP_AGENT
+        payload["title"] = title
 
-        title = str(getattr(event, "title", "") or "").strip()
-        if title:
-            payload["title"] = title
         year = _as_int(getattr(event, "year", None))
         if year:
             payload["year"] = year
 
         if media_type == "episode":
-            season = _as_int(getattr(event, "season", None))
-            number = _as_int(getattr(event, "number", None))
-            if season is None or number is None:
-                _log("PUNCHPLAY: skip scrobble, episode missing season/episode", "DEBUG")
-                return
             payload["season"] = season
             payload["episode"] = number
 
@@ -340,6 +351,13 @@ class PunchPlaySink(ScrobbleSink):
             if threshold > 0.0:
                 payload["watched_threshold"] = threshold
             payload["watched"] = watched
+
+        if "position_seconds" not in payload and (
+            action in ("pause", "progress") or (action == "stop" and not watched)
+        ):
+            _log(f"PUNCHPLAY: skip scrobble {action}, no position or duration", "DEBUG")
+            self._rollback(scope, before)
+            return
 
         self._post(cfg, event, action, payload, progress_pct, watched=watched, scope=scope, before=before)
 

--- a/tests/test_punchplay_scrobble.py
+++ b/tests/test_punchplay_scrobble.py
@@ -283,6 +283,53 @@ def test_episode_without_numbering_is_skipped(sink) -> None:
     assert calls == []
 
 
+def test_event_without_a_title_is_skipped(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", title=""))
+
+    assert calls == [], "title is a required field"
+
+
+def test_incomplete_stop_without_a_position_is_skipped(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", progress=5.0))
+    s.send(Event(action="stop", progress=40.0, position_ms=None, duration_ms=None))
+
+    assert [_action_of(c) for c in calls] == ["start"], "an incomplete stop needs a resume position"
+
+
+def test_start_without_a_position_is_still_sent(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", progress=5.0, position_ms=None, duration_ms=None))
+
+    assert [_action_of(c) for c in calls] == ["start"], "start has no position requirement"
+
+
+def test_a_skipped_write_does_not_leave_a_phantom_session(sink) -> None:
+    from providers.scrobble.punchplay import sink as s_mod
+
+    s, calls = sink
+
+    s.send(Event(action="stop", progress=40.0, position_ms=None, duration_ms=None))
+    s.send(Event(action="start", progress=5.0))
+
+    assert [_action_of(c) for c in calls] == ["start"]
+    assert len(s_mod._SESSIONS) == 1
+
+
+def test_a_recycled_session_key_on_new_media_gets_a_new_session_id(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", session_key="42", ids={"tmdb": "550"}, title="Fight Club"))
+    s.send(Event(action="start", session_key="42", ids={"tmdb": "603"}, title="The Matrix"))
+
+    assert calls[0]["json"]["playback_session_id"] != calls[1]["json"]["playback_session_id"]
+    assert [_action_of(c) for c in calls] == ["start", "start"]
+
+
 def test_event_ids_are_unique_per_event(sink) -> None:
     s, calls = sink
 


### PR DESCRIPTION
# Pull request

## Change

- Failed writes no longer advance the local session. A rejected start retries as start.
- Before, the next event went out as a pause and got a 409.
- Stops below threshold send an incomplete stop, not a pause. That is what PunchPlay documents for resume progress.
- Send title always, it is required.
- Send position_seconds for pause, progress and incomplete stop.
- Send watched_threshold only when above zero.

## Why

- The sink never landed a playback write since it was added.
- Part of that was a PunchPlay server side fault, now fixed on their end.
- The rest were real bugs that only showed up once writes started working.

## Testing

- tests/test_punchplay_scrobble.py

## Issue

- Relates to #680