### PR TITLE
Fix: Punchplay history readback

### DIFF
--- a/providers/sync/_mod_PUNCHPLAY.py
+++ b/providers/sync/_mod_PUNCHPLAY.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from cw_platform.provider_instances import normalize_instance_id
 from providers.auth._auth_PUNCHPLAY import ME_URL, is_configured as auth_is_configured
-from providers.sync._mod_common import SimpleRateLimiter, build_op_result, build_session
+from providers.sync._mod_common import SimpleRateLimiter, build_op_result, build_session, dedup_keys
 from providers.sync.punchplay import _history as feat_history
 from providers.sync.punchplay import _progress as feat_progress
 from providers.sync.punchplay import _ratings as feat_ratings
@@ -24,7 +24,7 @@ from providers.sync.punchplay._common import (
     request_id_of,
 )
 
-__VERSION__ = "0.1"
+__VERSION__ = "0.2"
 __all__ = ["get_manifest", "PUNCHPLAYModule", "OPS", "feat_history", "feat_progress", "feat_ratings", "feat_watchlist"]
 
 if "ctx" not in globals():
@@ -131,11 +131,22 @@ def _result_from(raw: Mapping[str, Any] | None) -> dict[str, Any]:
     data = dict(raw or {})
     confirmed = [str(k) for k in (data.get("confirmed_keys") or []) if k]
     unresolved_keys = [str(k) for k in (data.get("unresolved_keys") or []) if k]
+    skipped = [str(k) for k in (data.get("skipped_keys") or []) if k]
     deferred = [str(k) for k in (data.get("deferred_keys") or []) if k]
+    skipped_all = dedup_keys(list(skipped) + list(deferred))
+    accepted_raw = [str(k) for k in (data.get("accepted_keys") or []) if k]
+    accepted = dedup_keys(accepted_raw or (list(confirmed) + list(skipped_all)))
     extra: dict[str, Any] = {}
+    if skipped_all:
+        extra["skipped_keys"] = skipped_all
+        extra["skipped"] = len(skipped_all)
     if deferred:
         extra["deferred_keys"] = deferred
         extra["deferred"] = len(deferred)
+    if accepted:
+        extra["accepted_keys"] = accepted
+    if isinstance(data.get("status_counts"), Mapping):
+        extra["status_counts"] = dict(data.get("status_counts") or {})
     return build_op_result(
         ok=bool(data.get("ok", True)),
         count=len(confirmed),

--- a/providers/sync/punchplay/_common.py
+++ b/providers/sync/punchplay/_common.py
@@ -586,10 +586,13 @@ def classify_bulk_results(
     key_by_index: Mapping[int, str],
 ) -> dict[str, Any]:
     confirmed: list[str] = []
+    skipped_keys: list[str] = []
     unresolved_keys: list[str] = []
     deferred_keys: list[str] = []
+    accepted_keys: list[str] = []
     unresolved: list[dict[str, Any]] = []
     resolved_tmdb: dict[str, int] = {}
+    status_counts: dict[str, int] = {}
 
     rows = results if isinstance(results, list) else []
     seen_index: set[int] = set()
@@ -608,13 +611,23 @@ def classify_bulk_results(
         status = str(row.get("status") or "").strip()
         if not key:
             continue
-        if status in ("inserted", "updated", "removed", "skipped"):
+        if status:
+            status_counts[status] = status_counts.get(status, 0) + 1
+        if status in ("inserted", "updated", "removed"):
             confirmed.append(key)
+            accepted_keys.append(key)
+            tmdb = _as_int(row.get("resolved_tmdb_id"))
+            if tmdb:
+                resolved_tmdb[key] = tmdb
+        elif status == "skipped":
+            skipped_keys.append(key)
+            accepted_keys.append(key)
             tmdb = _as_int(row.get("resolved_tmdb_id"))
             if tmdb:
                 resolved_tmdb[key] = tmdb
         elif status == "deferred":
             deferred_keys.append(key)
+            accepted_keys.append(key)
         else:
             unresolved_keys.append(key)
             unresolved.append({
@@ -630,10 +643,13 @@ def classify_bulk_results(
 
     return {
         "confirmed_keys": confirmed,
+        "skipped_keys": skipped_keys,
         "unresolved_keys": unresolved_keys,
         "deferred_keys": deferred_keys,
+        "accepted_keys": accepted_keys,
         "unresolved": unresolved,
         "resolved_tmdb": resolved_tmdb,
+        "status_counts": status_counts,
     }
 
 
@@ -649,10 +665,13 @@ def bulk_write(
         raise PunchPlayError(f"unsupported bulk resource: {resource}")
 
     confirmed: list[str] = []
+    skipped_keys: list[str] = []
     unresolved_keys: list[str] = []
     deferred_keys: list[str] = []
+    accepted_keys: list[str] = []
     unresolved: list[dict[str, Any]] = []
     resolved_tmdb: dict[str, int] = {}
+    status_counts: dict[str, int] = {}
     ok = True
 
     for batch in chunk_items(items):
@@ -701,10 +720,14 @@ def bulk_write(
             key_by_index,
         )
         confirmed.extend(parsed["confirmed_keys"])
+        skipped_keys.extend(parsed["skipped_keys"])
         unresolved_keys.extend(parsed["unresolved_keys"])
         deferred_keys.extend(parsed["deferred_keys"])
+        accepted_keys.extend(parsed["accepted_keys"])
         unresolved.extend(parsed["unresolved"])
         resolved_tmdb.update(parsed["resolved_tmdb"])
+        for status, count in (parsed.get("status_counts") or {}).items():
+            status_counts[str(status)] = status_counts.get(str(status), 0) + int(count or 0)
 
         _dbg(
             feature,
@@ -714,6 +737,7 @@ def bulk_write(
             inserted=body.get("inserted") if isinstance(body, Mapping) else None,
             updated=body.get("updated") if isinstance(body, Mapping) else None,
             removed=body.get("removed") if isinstance(body, Mapping) else None,
+            skipped=body.get("skipped") if isinstance(body, Mapping) else None,
             deferred=body.get("deferred") if isinstance(body, Mapping) else None,
             invalid=body.get("invalid") if isinstance(body, Mapping) else None,
         )
@@ -721,8 +745,11 @@ def bulk_write(
     return {
         "ok": ok,
         "confirmed_keys": confirmed,
+        "skipped_keys": skipped_keys,
         "unresolved_keys": unresolved_keys,
         "deferred_keys": deferred_keys,
+        "accepted_keys": accepted_keys,
         "unresolved": unresolved,
         "resolved_tmdb": resolved_tmdb,
+        "status_counts": status_counts,
     }

--- a/providers/sync/punchplay/_history.py
+++ b/providers/sync/punchplay/_history.py
@@ -24,6 +24,7 @@ from ._common import (
     punchplay_request,
     request_id_of,
     safe_json,
+    snapshot_pages,
     title_path_id,
     _dbg,
     _info,
@@ -53,16 +54,46 @@ def _as_int(value: Any) -> int | None:
     return out
 
 
+def _pick(row: Mapping[str, Any], *names: str) -> Any:
+    for name in names:
+        if name in row and row.get(name) is not None:
+            return row.get(name)
+    return None
+
+
+def _row_data(row: Mapping[str, Any]) -> Mapping[str, Any]:
+    data = row.get("data")
+    if not isinstance(data, Mapping):
+        return row
+    merged = dict(data)
+    for name in ("id", "history_id", "historyId", "watch_history_id", "watchHistoryId"):
+        if name in row and name not in merged:
+            merged[name] = row.get(name)
+    return merged
+
+
 def _row_to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
-    typ = str(row.get("type") or "").strip().lower()
-    watched = iso_z(row.get("watchedAt"))
+    data = _row_data(row)
+    typ_raw = str(_pick(data, "kind", "type", "mediaType", "media_type") or "").strip().lower()
+    if typ_raw in ("episode", "episodes"):
+        typ = "episode"
+    elif typ_raw in ("movie", "movies", "film"):
+        typ = "movie"
+    elif _pick(data, "season") is not None and _pick(data, "episode") is not None:
+        typ = "episode"
+    else:
+        typ = "movie"
+
+    watched = iso_z(_pick(data, "watched_at", "watchedAt"))
     if not watched:
         return None
 
     if typ == "episode":
-        show_tmdb = _as_int(row.get("showTmdbId"))
-        season = _as_int(row.get("season"))
-        episode = _as_int(row.get("episode"))
+        show_tmdb = _as_int(_pick(data, "show_tmdb_id", "showTmdbId", "showTmdbID", "title_tmdb_id", "titleTmdbId"))
+        if not show_tmdb:
+            show_tmdb = _as_int(_pick(data, "tmdb_id", "tmdbId"))
+        season = _as_int(_pick(data, "season"))
+        episode = _as_int(_pick(data, "episode"))
         if not show_tmdb or season is None or episode is None:
             return None
         out: dict[str, Any] = {
@@ -72,40 +103,74 @@ def _row_to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
             "season": season,
             "episode": episode,
         }
-        ep_tmdb = _as_int(row.get("tmdbId"))
+        ep_tmdb = _as_int(_pick(data, "episode_tmdb_id", "episodeTmdbId"))
+        if not ep_tmdb and _pick(data, "show_tmdb_id", "showTmdbId", "showTmdbID") is not None:
+            ep_tmdb = _as_int(_pick(data, "tmdbId"))
         if ep_tmdb:
             out["ids"] = {"tmdb": str(ep_tmdb)}
-        series_title = str(row.get("title") or "").strip()
+        series_title = str(_pick(data, "series_title", "show_title", "showTitle", "title") or "").strip()
         if series_title:
             out["series_title"] = series_title
-        ep_title = str(row.get("episodeTitle") or "").strip()
+        ep_title = str(_pick(data, "episode_title", "episodeTitle") or "").strip()
         if ep_title:
             out["title"] = ep_title
     else:
-        tmdb = _as_int(row.get("tmdbId"))
+        tmdb = _as_int(_pick(data, "tmdb_id", "tmdbId", "title_tmdb_id", "titleTmdbId", "resolved_tmdb_id"))
         if not tmdb:
             return None
         out = {"type": "movie", "ids": {"tmdb": str(tmdb)}}
-        title = str(row.get("title") or "").strip()
+        title = str(_pick(data, "title", "name") or "").strip()
         if title:
             out["title"] = title
-        year = _as_int(row.get("year"))
+        year = _as_int(_pick(data, "year"))
         if year:
             out["year"] = year
 
     out["watched_at"] = watched
-    entry_id = _as_int(row.get("id"))
+    entry_id = _as_int(_pick(data, "id", "history_id", "historyId", "watch_history_id", "watchHistoryId"))
     if entry_id:
         out[HISTORY_ID_FIELD] = [str(entry_id)]
         out[HISTORY_EVENT_ID_FIELD] = str(entry_id)
     return out
 
 
-def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
-    section = cfg_section(adapter) or {}
-    per_page = max(1, min(cfg_int(section, "history_per_page", HISTORY_PAGE_MAX), HISTORY_PAGE_MAX))
-    max_pages = cfg_int(section, "history_max_pages", 5000)
+def _collect_history_rows(rows: Any, collected: dict[str, dict[str, Any]]) -> int:
+    row_list = [r for r in rows if isinstance(r, Mapping)] if isinstance(rows, list) else []
+    for row in row_list:
+        minimal = _row_to_minimal(row)
+        if not minimal:
+            continue
+        key = _key_of(minimal)
+        if not key:
+            continue
+        existing = collected.get(key)
+        if existing is None:
+            collected[key] = minimal
+            continue
+        ids = list(existing.get(HISTORY_ID_FIELD) or [])
+        for hid in minimal.get(HISTORY_ID_FIELD) or []:
+            if hid not in ids:
+                ids.append(hid)
+        if str(minimal.get("watched_at") or "") > str(existing.get("watched_at") or ""):
+            minimal[HISTORY_ID_FIELD] = ids
+            collected[key] = minimal
+        else:
+            existing[HISTORY_ID_FIELD] = ids
+    return len(row_list)
 
+
+def _index_from_snapshot(adapter: Any, *, per_page: int) -> dict[str, dict[str, Any]]:
+    collected: dict[str, dict[str, Any]] = {}
+    pages = 0
+    rows = 0
+    for page in snapshot_pages(adapter, "history", feature=FEATURE, limit=per_page):
+        pages += 1
+        rows += _collect_history_rows(page, collected)
+    _dbg(FEATURE, "snapshot_scanned", rows=rows, indexed=len(collected), pages=pages)
+    return collected
+
+
+def _index_from_history_endpoint(adapter: Any, *, per_page: int, max_pages: int) -> dict[str, dict[str, Any]]:
     collected: dict[str, dict[str, Any]] = {}
     cursor: str | None = None
     pages = 0
@@ -126,34 +191,28 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
         if not isinstance(data, Mapping):
             break
         rows = data.get("items")
-        rows = [r for r in rows if isinstance(r, Mapping)] if isinstance(rows, list) else []
-
-        for row in rows:
-            minimal = _row_to_minimal(row)
-            if not minimal:
-                continue
-            key = _key_of(minimal)
-            if not key:
-                continue
-            existing = collected.get(key)
-            if existing is None:
-                collected[key] = minimal
-                continue
-            ids = list(existing.get(HISTORY_ID_FIELD) or [])
-            for hid in minimal.get(HISTORY_ID_FIELD) or []:
-                if hid not in ids:
-                    ids.append(hid)
-            if str(minimal.get("watched_at") or "") > str(existing.get("watched_at") or ""):
-                minimal[HISTORY_ID_FIELD] = ids
-                collected[key] = minimal
-            else:
-                existing[HISTORY_ID_FIELD] = ids
+        row_count = _collect_history_rows(rows, collected)
 
         cursor = data.get("nextCursor") or None
-        if not cursor or not rows:
+        if not cursor or row_count <= 0:
             break
 
-    _info(FEATURE, "index_done", count=len(collected), pages=pages)
+    _dbg(FEATURE, "history_endpoint_scanned", indexed=len(collected), pages=pages)
+    return collected
+
+
+def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
+    section = cfg_section(adapter) or {}
+    per_page = max(1, min(cfg_int(section, "history_per_page", HISTORY_PAGE_MAX), HISTORY_PAGE_MAX))
+    max_pages = cfg_int(section, "history_max_pages", 5000)
+
+    collected = _index_from_snapshot(adapter, per_page=per_page)
+    source = "snapshot"
+    if not collected:
+        collected = _index_from_history_endpoint(adapter, per_page=per_page, max_pages=max_pages)
+        source = "history"
+
+    _info(FEATURE, "index_done", count=len(collected), source=source)
     return collected
 
 

--- a/tests/test_punchplay_sync.py
+++ b/tests/test_punchplay_sync.py
@@ -167,6 +167,42 @@ def test_deferred_is_not_treated_as_unresolved(monkeypatch: pytest.MonkeyPatch) 
     assert res["confirmed_keys"] == ["tmdb:550"]
 
 
+def test_skipped_is_not_counted_as_confirmed(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _watchlist as wl
+
+    http = FakeHTTP([_Resp(200, {"results": [
+        {"index": 0, "status": "skipped", "resolved_tmdb_id": 550},
+    ], "skipped": 1})])
+    _patch(monkeypatch, wl, http)
+
+    res = wl.add(Adapter(), [{"type": "movie", "title": "Fight Club", "ids": {"tmdb": "550"}}])
+
+    assert res["confirmed_keys"] == []
+    assert res["skipped_keys"] == ["tmdb:550"]
+    assert res["accepted_keys"] == ["tmdb:550"]
+
+
+def test_module_result_treats_deferred_as_skipped_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync._mod_PUNCHPLAY import OPS
+    from providers.sync.punchplay import _watchlist as wl
+
+    http = FakeHTTP([_Resp(200, {"results": [
+        {"index": 0, "status": "deferred", "reason": "unmatched", "client_item_id": "a"},
+    ], "deferred": 1})])
+    _patch(monkeypatch, wl, http)
+
+    res = OPS.add({"punchplay": {"access_token": "at"}}, [
+        {"type": "movie", "title": "A", "ids": {"imdb": "tt0000001"}},
+    ], feature="watchlist")
+
+    assert res["count"] == 0
+    assert res["confirmed_keys"] == []
+    assert res["deferred_keys"] == ["imdb:tt0000001"]
+    assert res["skipped_keys"] == ["imdb:tt0000001"]
+    assert res["accepted_keys"] == ["imdb:tt0000001"]
+    assert res["unresolved_keys"] == []
+
+
 def test_http_failure_marks_batch_unresolved(monkeypatch: pytest.MonkeyPatch) -> None:
     from providers.sync.punchplay import _watchlist as wl
 
@@ -393,21 +429,38 @@ def test_ratings_episode_scope(monkeypatch: pytest.MonkeyPatch) -> None:
 
 # --- history ------------------------------------------------------------------
 
-def test_history_index_uses_cursor_paginated_history_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_history_index_prefers_sync_snapshot_history(monkeypatch: pytest.MonkeyPatch) -> None:
     from providers.sync.punchplay import _history as hi
 
     http = FakeHTTP([_Resp(200, {"items": [
-        {"id": 7, "type": "movie", "tmdbId": 550, "title": "Fight Club", "year": 1999, "watchedAt": "2026-01-01T20:00:00.000Z"},
-    ], "nextCursor": None})])
+        {"id": 7, "kind": "movie", "tmdb_id": 550, "title": "Fight Club", "year": 1999, "watched_at": "2026-01-01T20:00:00.000Z"},
+    ], "hasMore": False, "nextAfter": None})])
     _patch(monkeypatch, hi, http)
 
     idx = hi.build_index(Adapter())
 
     assert "tmdb:550" in idx
     assert http.calls[0]["method"] == "GET"
-    assert http.calls[0]["url"].endswith("/me/history")
+    assert http.calls[0]["url"].endswith("/me/sync/snapshot")
+    assert http.calls[0]["params"]["resource"] == "history"
     assert http.calls[0]["params"]["limit"] == 100
-    assert "cursor" not in http.calls[0]["params"]
+    assert http.calls[0]["params"]["after"] == 0
+
+
+def test_history_index_reads_episode_from_sync_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _history as hi
+
+    http = FakeHTTP([_Resp(200, {"items": [
+        {"id": 49, "kind": "episode", "tmdb_id": 46260, "season": 1, "episode": 49,
+         "title": "Naruto", "episode_title": "Lee's Hidden Strength", "watched_at": "2026-01-01T20:00:00.000Z"},
+    ], "hasMore": False, "nextAfter": None})])
+    _patch(monkeypatch, hi, http)
+
+    idx = hi.build_index(Adapter())
+
+    assert idx["tmdb:46260#s01e49"]["show_ids"] == {"tmdb": "46260"}
+    assert idx["tmdb:46260#s01e49"]["season"] == 1
+    assert idx["tmdb:46260#s01e49"]["episode"] == 49
 
 
 def test_history_client_item_id_is_per_play(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -464,9 +517,9 @@ def test_history_index_collects_entry_ids_for_rewatches(monkeypatch: pytest.Monk
     from providers.sync.punchplay import _history as hi
 
     http = FakeHTTP([_Resp(200, {"items": [
-        {"id": 7, "type": "movie", "tmdbId": 550, "title": "Fight Club", "year": 1999, "watchedAt": "2026-01-01T20:00:00.000Z"},
-        {"id": 9, "type": "movie", "tmdbId": 550, "title": "Fight Club", "year": 1999, "watchedAt": "2026-06-01T20:00:00.000Z"},
-    ], "nextCursor": None})])
+        {"id": 7, "kind": "movie", "tmdb_id": 550, "title": "Fight Club", "year": 1999, "watched_at": "2026-01-01T20:00:00.000Z"},
+        {"id": 9, "kind": "movie", "tmdb_id": 550, "title": "Fight Club", "year": 1999, "watched_at": "2026-06-01T20:00:00.000Z"},
+    ], "hasMore": False, "nextAfter": None})])
     _patch(monkeypatch, hi, http)
 
     idx = hi.build_index(Adapter())


### PR DESCRIPTION
# Pull request

## Change

Use Punchplay sync snapshot for history readback and handle skipped/deferred bulk results separately from confirmed writes.

## Why

Prevents history items from being re-added every sync when Punchplay accepted them but they were not read back through the mirror endpoint.

## Testing

- test_punchplay_sync.py

## Issue

NA