### PR TITLE
Fix: Scrob history sync accounting

### DIFF
--- a/cw_platform/orchestrator/_applier.py
+++ b/cw_platform/orchestrator/_applier.py
@@ -148,6 +148,33 @@ def _normalize(
     except Exception:  # pragma: no cover
         _ckey = None  # type: ignore
 
+    try:
+        from ..history_events import history_event_key as _history_event_key  # type: ignore
+    except Exception:  # pragma: no cover
+        _history_event_key = None  # type: ignore
+
+    def _accounting_keys(item: Mapping[str, Any]) -> list[str]:
+        keys: list[str] = []
+
+        def _add(value: Any) -> None:
+            raw = str(value or "").strip()
+            if raw and raw not in keys:
+                keys.append(raw)
+
+        if str(feature or "").lower() == "history":
+            _add(item.get("_cw_event_key"))
+            if _history_event_key:
+                try:
+                    _add(_history_event_key(item, item.get("_cw_event_key")))
+                except Exception:
+                    pass
+        if _ckey:
+            try:
+                _add(_ckey(item) or "")
+            except Exception:
+                pass
+        return keys
+
     if isinstance(unresolved_list, list) and unresolved_list:
         def _unwrap(x: Mapping[str, Any]) -> tuple[Mapping[str, Any], str | None]:
             inner = x.get("item")
@@ -278,17 +305,12 @@ def _normalize(
         for it in items:
             if not isinstance(it, Mapping):
                 continue
-            k = ""
-            if _ckey:
-                try:
-                    k = str(_ckey(it) or "")
-                except Exception:
-                    k = ""
-            if k and k in accounted:
+            item_keys = _accounting_keys(it)
+            if any(k in accounted for k in item_keys):
                 continue
             leftover.append(it)
-            if k:
-                unresolved_keys.append(k)
+            if item_keys:
+                unresolved_keys.append(item_keys[0])
         if leftover:
             unresolved += len(leftover)
             try:

--- a/tests/test_scrob_sync.py
+++ b/tests/test_scrob_sync.py
@@ -213,6 +213,24 @@ def test_history_add_sends_watched_at_for_movies():
     assert body == {"completed": True, "watched_at": "2026-08-01T20:00:00.000Z", "media_type": "movie", "tmdb_id": 550}
 
 
+def test_history_add_event_keys_are_accounted_by_applier(monkeypatch: pytest.MonkeyPatch):
+    from cw_platform.orchestrator import _applier
+
+    unresolved_writes: list[Any] = []
+    monkeypatch.setattr(_applier, "record_unresolved", lambda *a, **k: unresolved_writes.append((a, k)) or {"ok": True})
+
+    adapter = FakeAdapter({("POST", "history"): ResponseStub(200, {"status": "ok"})})
+    item = {"type": "movie", "ids": {"tmdb": "550"}, "watched_at": "2026-08-01T20:00:00.000Z", "_cw_event_key": "tmdb:550@1754078400"}
+    raw = _history.add(adapter, [item])
+
+    normalized = _applier._normalize(raw, [item], "apply:add", dst="SCROB", feature="history", emit=lambda *a, **k: None)
+
+    assert normalized["confirmed"] == 1
+    assert normalized["unresolved"] == 0
+    assert normalized["unresolved_keys"] == []
+    assert unresolved_writes == []
+
+
 def test_history_add_sends_full_episode_context():
     adapter = FakeAdapter({("POST", "history"): ResponseStub(200, {"status": "ok"})})
     item = {


### PR DESCRIPTION
# Pull request

## Change

Account SCROB history adds with event keys during apply normalization.

## Why

Successful Scrob history writes were being marked unresolved because the applier compared event keys against plain media keys.

## Testing

- tests/test_scrob_sync.py

## Issue

NA