### PR TITLE
Fix: profile scoped scrobble account filters

### DIFF
--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -10,8 +10,10 @@ from typing import Any
 from fastapi import APIRouter, Body, Request
 from fastapi.responses import JSONResponse
 
+from cw_platform.access_policy import managed_profile_id, profile_label_for_id, request_user, route_effective_profile_id, webhook_effective_profile_id
 from cw_platform.config_base import load_config, save_config
-from cw_platform.provider_instances import get_provider_block, list_instance_ids, normalize_instance_id
+from cw_platform.provider_instances import get_provider_block, list_instance_ids, list_user_profiles, normalize_instance_id, normalize_user_profile_id, sanitize_instance_label
+from cw_platform.user_profile_resources import webhook_assigned_profile_id, webhook_resource_id
 from cw_platform.provider_usage import WEBHOOK_SOURCE_PROVIDERS, provider_label, webhook_source_enabled
 from providers.auth import runtime as auth_runtime
 from providers.scrobble.routes import (
@@ -20,6 +22,7 @@ from providers.scrobble.routes import (
     normalize_route,
     normalize_route_options,
     normalize_routes,
+    route_needs_account_filter,
 )
 from providers.scrobble.sources import legacy_mode_for_sources, scrobble_sources
 from providers.webhooks.config import (
@@ -106,6 +109,15 @@ def _instances(cfg: Mapping[str, Any], provider: str) -> list[str]:
         return [normalize_instance_id(x) for x in list_instance_ids(cfg, provider)]
     except Exception:
         return ["default"]
+
+
+def _instance_display_label(cfg: Mapping[str, Any], provider: str, instance: Any) -> str:
+    inst = normalize_instance_id(instance)
+    block = get_provider_block(_dict(cfg), provider, inst)
+    friendly = sanitize_instance_label(block.get("label") if isinstance(block, Mapping) else "")
+    if friendly:
+        return friendly
+    return "Default" if inst == "default" else inst
 
 
 def _profile_exists(cfg: Mapping[str, Any], provider: str, instance: str) -> bool:
@@ -336,7 +348,7 @@ def _destination_availability(cfg: Mapping[str, Any]) -> list[dict[str, Any]]:
                 {
                     "provider": sink,
                     "instance": inst,
-                    "label": provider_label(sink, inst),
+                    "label": _instance_display_label(cfg, sink, inst),
                     "configured": ready,
                     "reason": "" if ready else "not_configured",
                 }
@@ -356,7 +368,7 @@ def _eligible_sources(cfg: Mapping[str, Any]) -> list[dict[str, Any]]:
                 {
                     "provider": provider,
                     "instance": inst,
-                    "label": provider_label(provider, inst),
+                    "label": _instance_display_label(cfg, provider, inst),
                     "configured": configured,
                     "eligible": configured,
                     "explicit": explicit,
@@ -399,10 +411,11 @@ def _webhook_cards(cfg: dict[str, Any], request: Request) -> list[dict[str, Any]
                         "provider": provider,
                         "provider_label": provider_label(provider),
                         "provider_instance": inst,
-                        "profile_label": provider_label(provider, inst),
+                        "profile_label": _instance_display_label(cfg, provider, inst),
                         "sink": sink,
                         "sink_label": provider_label(sink),
                         "sink_instance": sink_inst,
+                        "sink_profile_label": _instance_display_label(cfg, sink, sink_inst),
                         "sink_ready": ready,
                         "enabled": src_enabled,
                         "source_configured": source_configured,
@@ -410,6 +423,8 @@ def _webhook_cards(cfg: dict[str, Any], request: Request) -> list[dict[str, Any]
                         "active": bool(src_enabled and source_configured and ready),
                         "endpoint_url": endpoint,
                         "webhook_token": token,
+                        "id": webhook_resource_id(provider, inst, sink, sink_inst),
+                        "profile_id": webhook_assigned_profile_id(cfg, webhook_resource_id(provider, inst, sink, sink_inst)),
                         "effective_settings": safe_eff,
                         "explicit_settings": safe_expl,
                     }
@@ -456,10 +471,21 @@ def _normalized_routes(cfg: dict[str, Any], request: Request) -> list[dict[str, 
         row["options"] = options
         row["runtime"] = {"running": bool(running_by_id.get(str(route.get("id") or "")))}
         row["ratings_webhook_url"] = _route_ratings_url(request, ratings)
-        row["source_label"] = provider_label(str(row.get("provider") or ""), row.get("provider_instance"))
-        row["sink_label"] = provider_label(str(row.get("sink") or ""), row.get("sink_instance"))
+        row["source_label"] = _instance_display_label(cfg, str(row.get("provider") or ""), row.get("provider_instance"))
+        row["sink_label"] = _instance_display_label(cfg, str(row.get("sink") or ""), row.get("sink_instance"))
+        profile_id = str(row.get("profile_id") or "").strip()
+        if profile_id:
+            row["profile_label"] = profile_label_for_id(cfg, profile_id)
+        row["needs_account_filter"] = route_needs_account_filter(cfg, route)
         out.append(row)
     return out
+
+
+def _user_can_access_route(cfg: Mapping[str, Any], user: Mapping[str, Any] | None, route: Mapping[str, Any]) -> bool:
+    if not isinstance(user, Mapping) or bool(user.get("is_admin")):
+        return True
+    pid = managed_profile_id(user)
+    return bool(pid and route_effective_profile_id(cfg, route) == pid)
 
 
 def _summary(cfg: dict[str, Any], request: Request, webhooks: list[dict[str, Any]], routes: list[dict[str, Any]], runtime: dict[str, Any]) -> dict[str, Any]:
@@ -483,6 +509,11 @@ def build_overview(cfg: dict[str, Any], request: Request) -> dict[str, Any]:
     sources = scrobble_sources(cfg)
     webhooks = _webhook_cards(cfg, request)
     routes = _normalized_routes(cfg, request)
+    user = request_user(request)
+    if isinstance(user, Mapping) and not bool(user.get("is_admin")):
+        pid = managed_profile_id(user)
+        webhooks = [row for row in webhooks if pid and webhook_effective_profile_id(cfg, row) == pid]
+        routes = [row for row in routes if _user_can_access_route(cfg, user, row)]
     runtime = _runtime_status(request, cfg)
     sc = _dict(cfg.get("scrobble"))
     watch = _dict(sc.get("watch"))
@@ -601,6 +632,16 @@ def _route_key(route: Mapping[str, Any]) -> tuple[str, str, str, str]:
     )
 
 
+def _normalize_route_profile_id(cfg: Mapping[str, Any], value: Any) -> str:
+    pid = normalize_user_profile_id(value)
+    if not pid:
+        return ""
+    for row in list_user_profiles(cfg):
+        if normalize_user_profile_id(row.get("id")) == pid:
+            return pid
+    return ""
+
+
 def _validate_route(cfg: Mapping[str, Any], route: dict[str, Any]) -> dict[str, Any]:
     normalized = normalize_route(route, str(route.get("id") or "R1"))
     provider = str(normalized.get("provider") or "").strip().lower()
@@ -613,6 +654,11 @@ def _validate_route(cfg: Mapping[str, Any], route: dict[str, Any]) -> dict[str, 
     _require_sink_profile(cfg, sink, str(normalized.get("sink_instance") or "default"))
     normalized["filters"] = _normalize_filters(normalized.get("filters"), provider, "filters")
     normalized["options"] = normalize_route_options(normalized.get("options"))
+    profile_id = _normalize_route_profile_id(cfg, route.get("profile_id") or route.get("profileId") or normalized.get("profile_id"))
+    if profile_id:
+        normalized["profile_id"] = profile_id
+    else:
+        normalized.pop("profile_id", None)
     ratings = _dict(_dict(normalized.get("options")).get("ratings"))
     targets = [str(t or "").strip().lower() for t in (ratings.get("targets") or []) if str(t or "").strip()]
     if ratings.get("mode") == "custom":

--- a/assets/js/scrobbler.js
+++ b/assets/js/scrobbler.js
@@ -56,10 +56,12 @@
   }
 
   function webhookProfileName(x) {
-    return x.provider_instance === "default" ? "Default" : x.provider_instance;
+    return String(x.profile_label || x.source_label || x.provider_instance || "default").trim() || "Default";
   }
 
-  function instanceName(v) {
+  function instanceName(v, labelValue = "") {
+    const labelText = String(labelValue || "").trim();
+    if (labelText) return labelText;
     return String(v || "default") === "default" ? "Default" : String(v || "default");
   }
 
@@ -121,7 +123,7 @@
               <div class="sc2-route-flow-wrap">
                 <div class="sc2-route-endpoint">${providerLogo(x.provider)}<div><strong>${esc(label(x.provider))}</strong><span>${esc(webhookProfileName(x))}</span></div></div>
                 <div class="sc2-rt-conn"><span class="sc2-rt-conn-line"></span></div>
-                <div class="sc2-route-endpoint sc2-route-endpoint-sink"><div><strong>${esc(label(x.sink))}</strong><span>${esc(instanceName(x.sink_instance))}</span></div>${providerLogo(x.sink)}</div>
+                <div class="sc2-route-endpoint sc2-route-endpoint-sink"><div><strong>${esc(label(x.sink))}</strong><span>${esc(instanceName(x.sink_instance, x.sink_profile_label))}</span></div>${providerLogo(x.sink)}</div>
               </div>
               <div class="sc2-route-meta">
                 <span class="sc2-route-type"><span class="material-symbols-rounded">webhook</span>Webhook</span>
@@ -157,14 +159,15 @@
           ${rows.length ? rows.map((r) => `
             <article class="sc2-route sc2-route-card ${r.enabled ? "is-enabled" : "is-disabled"} ${r.runtime?.running ? "is-live" : "is-idle"}" data-action="edit-route" data-route="${esc(r.id)}" title="Edit route">
               <div class="sc2-route-flow-wrap">
-                <div class="sc2-route-endpoint">${providerLogo(r.provider)}<div><strong>${esc(label(r.provider))}</strong><span>${esc(instanceName(r.provider_instance))}</span></div></div>
+                <div class="sc2-route-endpoint">${providerLogo(r.provider)}<div><strong>${esc(label(r.provider))}</strong><span>${esc(instanceName(r.provider_instance, r.source_label))}</span></div></div>
                 <div class="sc2-rt-conn"><span class="sc2-rt-conn-line"></span></div>
-                <div class="sc2-route-endpoint sc2-route-endpoint-sink"><div><strong>${esc(label(r.sink))}</strong><span>${esc(instanceName(r.sink_instance))}</span></div>${providerLogo(r.sink)}</div>
+                <div class="sc2-route-endpoint sc2-route-endpoint-sink"><div><strong>${esc(label(r.sink))}</strong><span>${esc(instanceName(r.sink_instance, r.sink_label))}</span></div>${providerLogo(r.sink)}</div>
               </div>
               <div class="sc2-route-meta">
                 <span class="sc2-route-type"><span class="material-symbols-rounded">sensors</span>Watcher</span>
                 <span class="sc2-route-id">${esc(r.id || "Route")}</span>
                 <span class="sc2-route-filters sc2-muted">${esc(routeFilterSummary(r.filters))}</span>
+                ${r.needs_account_filter ? `<span class="sc2-route-warn" title="This route is assigned to a user profile but has no account whitelist, so play events are blocked."><span class="material-symbols-rounded">warning</span>No account filter</span>` : ""}
               </div>
               <div class="sc2-route-actions">
                 <button type="button" class="btn small sc2-round-action sc2-route-toggle ${r.enabled ? "is-on" : "is-off"}" data-action="toggle-route" data-route="${esc(r.id)}" title="${esc(r.enabled ? "Disable route" : "Enable route")}" aria-label="${esc(r.enabled ? "Disable route" : "Enable route")}"><span class="material-symbols-rounded">power_settings_new</span><span>${esc(r.enabled ? "On" : "Off")}</span></button>

--- a/cw_platform/account_match.py
+++ b/cw_platform/account_match.py
@@ -1,0 +1,47 @@
+# cw_platform/account_match.py
+# CrossWatch - Media account matching helpers
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+
+def normalize_media_account_name(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", "", str(value or "").lower())
+
+
+def media_account_allowed(allow: Any, account: Any = "", *, account_id: Any = "", account_uuid: Any = "", user_id: Any = "", default_allow: bool = True) -> bool:
+    if not allow:
+        return bool(default_allow)
+    has_mapping_account = isinstance(account, Mapping)
+    if has_mapping_account and isinstance(account.get("Account"), Mapping):
+        acc = account.get("Account")
+    elif has_mapping_account:
+        acc = account
+    else:
+        acc = {}
+    flat = "" if has_mapping_account else str(account or "").strip()
+    title = str((acc.get("title") if isinstance(acc, Mapping) else "") or flat).strip()
+    acc_id = str((acc.get("id") if isinstance(acc, Mapping) else "") or account_id or "").strip()
+    acc_uuid = str((acc.get("uuid") if isinstance(acc, Mapping) else "") or account_uuid or "").strip().lower()
+    values = allow if isinstance(allow, list) else [allow]
+    for entry in values:
+        raw = str(entry or "").strip()
+        if not raw:
+            continue
+        lowered = raw.lower()
+        if lowered.startswith("id:"):
+            wanted = lowered.split(":", 1)[1].strip()
+            if wanted and wanted == acc_id.lower():
+                return True
+            continue
+        if lowered.startswith("uuid:"):
+            wanted = lowered.split(":", 1)[1].strip()
+            if wanted and wanted == acc_uuid:
+                return True
+            continue
+        if normalize_media_account_name(raw) == normalize_media_account_name(title):
+            return True
+    return False

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -19,6 +19,7 @@ except Exception:
     BASE_LOG = None
 
 from cw_platform.config_base import load_config, save_config
+from cw_platform.account_match import media_account_allowed, normalize_media_account_name
 from cw_platform.provider_instances import ensure_instance_block, normalize_instance_id
 from providers.scrobble.scrobble import (
     Dispatcher,
@@ -1404,7 +1405,7 @@ def _emit(logger: Callable[..., None] | None, msg: str, level: str = "INFO") -> 
 
 
 def _norm_user(s: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "", (s or "").lower())
+    return normalize_media_account_name(s)
 
 
 def _account_key(payload: dict[str, Any]) -> str:
@@ -1422,27 +1423,8 @@ def _account_key(payload: dict[str, Any]) -> str:
     return "unknown"
 
 
-def _account_allowed(allow: Any, payload: dict[str, Any]) -> bool:
-    if not allow:
-        return True
-    allow_list = allow if isinstance(allow, list) else [allow]
-    acc = payload.get("Account") or {}
-    title = str((acc.get("title") if isinstance(acc, dict) else "") or "")
-    acc_id = str((acc.get("id") if isinstance(acc, dict) else "") or "")
-    acc_uuid = str((acc.get("uuid") if isinstance(acc, dict) else "") or "").lower()
-
-    for e in allow_list:
-        s = str(e).strip()
-        if not s:
-            continue
-        sl = s.lower()
-        if sl.startswith("id:") and acc_id and sl.split(":", 1)[1].strip() == acc_id:
-            return True
-        if sl.startswith("uuid:") and acc_uuid and sl.split(":", 1)[1].strip() == acc_uuid:
-            return True
-        if not sl.startswith(("id:", "uuid:")) and _norm_user(s) == _norm_user(title):
-            return True
-    return False
+def _account_allowed(allow: Any, payload: dict[str, Any], *, default_allow: bool = True) -> bool:
+    return media_account_allowed(allow, payload, default_allow=default_allow)
 
 
 def _server_allowed(want_uuid: str, payload: dict[str, Any]) -> bool:
@@ -1772,7 +1754,10 @@ def process_rating_webhook(
     if not _server_filters_allowed(filt, payload):
         return {"ok": True, "ignored": True}
 
-    if not _account_allowed(wl, payload):
+    scoped = bool(str(watch_cfg.get("route_profile_id") or "").strip())
+    if not _account_allowed(wl, payload, default_allow=not scoped):
+        if not wl and scoped:
+            _emit(logger, f"route {watch_cfg.get('route_id') or '?'}: rating blocked - profile-scoped route has no username whitelist", "WARNING")
         return {"ok": True, "ignored": True}
 
     if not _library_allowed(cfg, payload):

--- a/providers/scrobble/routes.py
+++ b/providers/scrobble/routes.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 from typing import Any
-from cw_platform.provider_instances import get_provider_block, normalize_instance_id
+from cw_platform.provider_instances import get_provider_block, normalize_instance_id, normalize_user_profile_id
 
 
 
@@ -147,8 +147,9 @@ def normalize_route(route: dict[str, Any], fallback_id: str) -> dict[str, Any]:
     if not isinstance(filters, dict):
         filters = {}
     options = normalize_route_options(r.get("options"))
+    profile_id = normalize_user_profile_id(r.get("profile_id") or r.get("profileId"))
 
-    return {
+    out = {
         "id": rid,
         "enabled": enabled,
         "provider": prov,
@@ -158,6 +159,9 @@ def normalize_route(route: dict[str, Any], fallback_id: str) -> dict[str, Any]:
         "filters": filters,
         "options": options,
     }
+    if profile_id:
+        out["profile_id"] = profile_id
+    return out
 
 
 def normalize_routes(cfg: dict[str, Any]) -> list[dict[str, Any]]:
@@ -171,6 +175,34 @@ def normalize_routes(cfg: dict[str, Any]) -> list[dict[str, Any]]:
             continue
         out.append(normalize_route(raw, f"R{i + 1}"))
     return out
+
+
+def route_profile_id(cfg: dict[str, Any], route: dict[str, Any]) -> str:
+    try:
+        from cw_platform.access_policy import route_effective_profile_id
+
+        return route_effective_profile_id(cfg, route)
+    except Exception:
+        return normalize_user_profile_id((route or {}).get("profile_id"))
+
+
+def route_assigned_profile_id(cfg: dict[str, Any], route: dict[str, Any]) -> str:
+    raw = (route or {}).get("profile_id") or (route or {}).get("profileId")
+    try:
+        from cw_platform.access_policy import valid_user_profile_id
+
+        return valid_user_profile_id(cfg, raw)
+    except Exception:
+        return normalize_user_profile_id(raw)
+
+
+def route_needs_account_filter(cfg: dict[str, Any], route: dict[str, Any]) -> bool:
+    if not route_assigned_profile_id(cfg, route):
+        return False
+    filters = (route or {}).get("filters")
+    raw = filters.get("username_whitelist") if isinstance(filters, dict) else None
+    values = raw if isinstance(raw, list) else ([raw] if raw else [])
+    return not any(str(value or "").strip() for value in values)
 
 
 def find_route(cfg: dict[str, Any], route_id: str | None) -> dict[str, Any] | None:
@@ -223,6 +255,8 @@ def build_route_cfg(cfg: dict[str, Any], route: dict[str, Any]) -> dict[str, Any
 
     w["filters"] = _deep_clone(r.get("filters") or {})
     w["route_id"] = r["id"]
+    w["route_profile_id"] = route_assigned_profile_id(out, r)
+    w["route_effective_profile_id"] = route_profile_id(out, r)
     w["route_provider"] = r["provider"]
     w["route_provider_instance"] = r["provider_instance"]
     w["route_sink"] = r["sink"]

--- a/providers/scrobble/scrobble.py
+++ b/providers/scrobble/scrobble.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Literal, Protocol
 
+from cw_platform.account_match import media_account_allowed, normalize_media_account_name
+
 try:
     from _logging import log as BASE_LOG
 except Exception:
@@ -69,7 +71,7 @@ def _ids_from_meta(meta: dict[str, Any]) -> dict[str, str]:
 
 
 def _norm_user(s: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "", (s or "").lower())
+    return normalize_media_account_name(s)
 
 
 def _as_filter_set(value: Any) -> set[str]:
@@ -442,32 +444,15 @@ class Dispatcher:
             if want_user != user_id:
                 return False
 
-        if not wl:
-            return _allow()
+        scoped = bool(str(((cfg.get("scrobble") or {}).get("watch") or {}).get("route_profile_id") or "").strip())
+        if not wl and scoped:
+            rid = str(((cfg.get("scrobble") or {}).get("watch") or {}).get("route_id") or "?")
+            _log(f"route {rid}: blocked account '{ev.account or '?'}' - profile-scoped route has no username whitelist", "WARNING")
+            return False
 
-        def norm(s: str) -> str:
-            return _norm_user(s)
-
-        wl_list = wl if isinstance(wl, list) else [wl]
-
-        if any(
-            not str(x).lower().startswith(("id:", "uuid:"))
-            and norm(str(x)) == norm(ev.account or "")
-            for x in wl_list
-        ):
-            return _allow()
-
-        for e in wl_list:
-            s = str(e).strip().lower()
-            if s.startswith("id:") and acc_id and s.split(":", 1)[1].strip() == acc_id:
-                return _allow()
-            if s.startswith("uuid:") and acc_uuid and s.split(":", 1)[1].strip() == acc_uuid:
-                return _allow()
-            if s.startswith("id:") and user_id and s.split(":", 1)[1].strip().lower() == user_id:
-                return _allow()
-            if s.startswith("uuid:") and user_id and s.split(":", 1)[1].strip().lower() == user_id:
-                return _allow()
-        return False
+        if not media_account_allowed(wl, ev.account or "", account_id=acc_id, account_uuid=acc_uuid, user_id=user_id, default_allow=not scoped):
+            return False
+        return _allow()
 
     def _should_send(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> bool:
         sk = ev.session_key or "?"

--- a/providers/webhooks/config.py
+++ b/providers/webhooks/config.py
@@ -84,6 +84,14 @@ def webhook_sink_instance(settings: Mapping[str, Any] | None, sink: str) -> str:
     return normalize_instance_id(str(instances.get(str(sink or "").strip().lower()) or "default"))
 
 
+def profile_scoped_webhook(cfg: Mapping[str, Any] | None, provider: str, provider_instance: Any = None) -> bool:
+    try:
+        from cw_platform.user_profile_resources import webhook_profile_scoped
+    except Exception:
+        return False
+    return webhook_profile_scoped(_dict(cfg), provider, provider_instance)
+
+
 def sink_configured(cfg: Mapping[str, Any] | None, sink: str, instance_id: Any = None) -> bool:
     key = str(sink or "").strip().lower()
     if key == "crosswatch":

--- a/providers/webhooks/dispatch.py
+++ b/providers/webhooks/dispatch.py
@@ -8,6 +8,8 @@ from collections.abc import Callable, Mapping
 from typing import Any
 
 from cw_platform.provider_instances import normalize_instance_id
+from cw_platform.access_policy import webhook_effective_profile_id
+from cw_platform.user_profile_resources import webhook_assigned_profile_id, webhook_resource_id
 from providers.scrobble.scrobble import ScrobbleAction, ScrobbleEvent
 from providers.webhooks.config import sink_configured, webhook_settings, webhook_sink_instance, webhook_sinks
 
@@ -112,12 +114,32 @@ def _route_cfg(cfg: dict[str, Any], provider: str, provider_instance: str, sink:
     out = copy.deepcopy(cfg) if isinstance(cfg, dict) else {}
     sc = out.setdefault("scrobble", {})
     watch = sc.setdefault("watch", {})
+    wh = webhook_settings(out, provider, provider_instance)
+    resource_id = webhook_resource_id(provider, provider_instance, sink, sink_instance)
+    assigned_profile_id = webhook_assigned_profile_id(out, resource_id)
+    effective_profile_id = webhook_effective_profile_id(
+        out,
+        {
+            "provider": provider,
+            "provider_instance": provider_instance,
+            "sink": sink,
+            "sink_instance": sink_instance,
+        },
+    )
     watch["route_id"] = f"webhook:{provider}:{normalize_instance_id(provider_instance)}:{sink}:{sink_instance}"
     watch["route_provider"] = provider
     watch["route_provider_instance"] = normalize_instance_id(provider_instance)
     watch["route_sink"] = sink
     watch["route_sink_instance"] = sink_instance
     watch["event_method"] = "webhook"
+    watch["route_profile_id"] = assigned_profile_id
+    watch["route_effective_profile_id"] = effective_profile_id
+    if provider == "plex":
+        watch["filters"] = dict(wh.get("filters_plex") or {})
+    elif provider == "emby":
+        watch["filters"] = dict(wh.get("filters_emby") or {})
+    elif provider == "jellyfin":
+        watch["filters"] = dict(wh.get("filters_jellyfin") or {})
     return out
 
 

--- a/providers/webhooks/emby.py
+++ b/providers/webhooks/emby.py
@@ -20,7 +20,7 @@ from providers.scrobble.currently_watching import update_from_payload as _cw_upd
 from providers.scrobble._auto_remove_watchlist import remove_across_providers_by_ids as _rm_across
 from providers.scrobble.scrobble import mask_account as _mask_account
 from providers.scrobble.sources import source_enabled
-from providers.webhooks.config import configured_webhook_sinks
+from providers.webhooks.config import configured_webhook_sinks, profile_scoped_webhook
 from providers.webhooks.dispatch import dispatch_scrobble as _dispatch_scrobble
 try:
     from api.watchlistAPI import remove_across_providers_by_ids as _rm_across_api
@@ -938,6 +938,10 @@ def process_webhook(
             or (payload.get("Server") or {}).get("UserName")
             or "unknown"
         ).strip()
+
+        if not allow_users and profile_scoped_webhook(cfg, "emby", provider_instance):
+            _emit(logger, "blocked - profile-scoped webhook has no username whitelist", "WARNING")
+            return {"ok": True, "ignored": True}
 
         if allow_users and acc_title and acc_title not in allow_users:
             _emit(logger, f"user '{_mask_account(acc_title)}' blocked by filters_emby", "DEBUG")

--- a/providers/webhooks/jellyfin.py
+++ b/providers/webhooks/jellyfin.py
@@ -18,7 +18,7 @@ from providers.scrobble.currently_watching import update_from_payload as _cw_upd
 from providers.scrobble._auto_remove_watchlist import remove_across_providers_by_ids as _rm_across
 from providers.scrobble.scrobble import mask_account as _mask_account
 from providers.scrobble.sources import source_enabled
-from providers.webhooks.config import configured_webhook_sinks
+from providers.webhooks.config import configured_webhook_sinks, profile_scoped_webhook
 from providers.webhooks.dispatch import dispatch_scrobble as _dispatch_scrobble
 try:
     from api.watchlistAPI import remove_across_providers_by_ids as _rm_across_api
@@ -1115,6 +1115,10 @@ def process_webhook(
                 pass
 
         _emit(logger, f"incoming '{event}' user='{_mask_account(acc_title)}' media='{media_name_dbg}'", "DEBUG")
+
+        if not allow_users and profile_scoped_webhook(cfg, "jellyfin", provider_instance):
+            _emit(logger, "blocked - profile-scoped webhook has no username whitelist", "WARNING")
+            return {"ok": True, "ignored": True}
 
         if allow_users and acc_title and acc_title not in allow_users:
             _emit(logger, f"ignored user '{_mask_account(acc_title)}'", "DEBUG")

--- a/providers/webhooks/plex.py
+++ b/providers/webhooks/plex.py
@@ -25,7 +25,7 @@ from providers.scrobble._auto_remove_watchlist import remove_across_providers_by
 from providers.scrobble.scrobble import mask_account as _mask_account
 from providers.scrobble.plex.ratings_sync import RATING_SINKS
 from providers.scrobble.sources import source_enabled
-from providers.webhooks.config import configured_webhook_sinks, webhook_sink_instance
+from providers.webhooks.config import configured_webhook_sinks, profile_scoped_webhook, webhook_sink_instance
 from providers.webhooks.dispatch import dispatch_scrobble as _dispatch_scrobble
 
 try:
@@ -1187,6 +1187,10 @@ def process_webhook(
 
     if srv_uuid_allow and (not srv_uuid_evt or srv_uuid_evt not in srv_uuid_allow):
         _emit(logger, f"ignored server '{srv_uuid_evt or 'none'}' (allowed={sorted(srv_uuid_allow)})", "DEBUG")
+        return {"ok": True, "ignored": True}
+
+    if not allow_users and profile_scoped_webhook(cfg, "plex", provider_instance):
+        _emit(logger, "blocked - profile-scoped webhook has no username whitelist", "WARNING")
         return {"ok": True, "ignored": True}
 
     if not _account_matches(allow_users, payload, logger=logger):

--- a/tests/test_scrobble_account_scope.py
+++ b/tests/test_scrobble_account_scope.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from typing import Any
+
+PROFILE_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+INSTANCE_UID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+
+def _cfg(*, profile: bool, whitelist: list[str] | None, assign: bool = True) -> dict[str, Any]:
+    filters: dict[str, Any] = {}
+    if whitelist is not None:
+        filters["username_whitelist"] = whitelist
+    cfg: dict[str, Any] = {
+        "plex": {"server_url": "http://plex:32400", "account_token": "t", "instances": {}},
+        "trakt": {"client_id": "c", "client_secret": "s", "instances": {}},
+        "provider_instance_ids": {INSTANCE_UID: {"provider": "PLEX", "instance": "default"}},
+        "user_profiles": {},
+        "scrobble": {
+            "watch": {
+                "routes": [
+                    {
+                        "id": "R1",
+                        "enabled": True,
+                        "provider": "plex",
+                        "provider_instance": "default",
+                        "sink": "trakt",
+                        "sink_instance": "default",
+                        "filters": filters,
+                    }
+                ]
+            }
+        },
+    }
+    if profile:
+        cfg["user_profiles"] = {PROFILE_ID: {"label": "Alice", "instance_uids": [INSTANCE_UID]}}
+        if assign:
+            cfg["scrobble"]["watch"]["routes"][0]["profile_id"] = PROFILE_ID
+    return cfg
+
+
+def _event(account: str):
+    from providers.scrobble.scrobble import ScrobbleEvent
+
+    return ScrobbleEvent(
+        action="start",
+        media_type="movie",
+        ids={"imdb": "tt1"},
+        title="Movie",
+        year=2020,
+        season=None,
+        number=None,
+        progress=10.0,
+        account=account,
+        server_uuid=None,
+        session_key="s1",
+        raw={},
+    )
+
+
+def _passes(cfg: dict[str, Any], account: str) -> bool:
+    from providers.scrobble.routes import build_route_cfg
+    from providers.scrobble.scrobble import Dispatcher
+
+    route = (cfg["scrobble"]["watch"]["routes"])[0]
+    route_cfg = build_route_cfg(cfg, route)
+    return Dispatcher([], cfg_provider=lambda: route_cfg)._passes_filters(_event(account), route_cfg)
+
+
+def test_route_cfg_carries_assigned_and_effective_profile_ids() -> None:
+    from providers.scrobble.routes import build_route_cfg
+
+    cfg = _cfg(profile=True, whitelist=None)
+    built = build_route_cfg(cfg, cfg["scrobble"]["watch"]["routes"][0])
+    assert built["scrobble"]["watch"]["route_profile_id"] == PROFILE_ID
+    assert built["scrobble"]["watch"]["route_effective_profile_id"] == PROFILE_ID
+
+    cfg_derived = _cfg(profile=True, whitelist=None, assign=False)
+    built_derived = build_route_cfg(cfg_derived, cfg_derived["scrobble"]["watch"]["routes"][0])
+    assert built_derived["scrobble"]["watch"]["route_profile_id"] == ""
+    assert built_derived["scrobble"]["watch"]["route_effective_profile_id"] == PROFILE_ID
+
+    cfg_plain = _cfg(profile=False, whitelist=None)
+    built_plain = build_route_cfg(cfg_plain, cfg_plain["scrobble"]["watch"]["routes"][0])
+    assert built_plain["scrobble"]["watch"]["route_profile_id"] == ""
+    assert built_plain["scrobble"]["watch"]["route_effective_profile_id"] == ""
+
+
+def test_unscoped_route_without_whitelist_still_accepts_every_account() -> None:
+    assert _passes(_cfg(profile=False, whitelist=None), "kid") is True
+    assert _passes(_cfg(profile=False, whitelist=[]), "kid") is True
+
+
+def test_owned_instance_alone_never_blocks_scrobbling() -> None:
+    assert _passes(_cfg(profile=True, whitelist=None, assign=False), "dad") is True
+    assert _passes(_cfg(profile=True, whitelist=[], assign=False), "dad") is True
+
+
+def test_assigned_route_without_whitelist_blocks_every_account() -> None:
+    assert _passes(_cfg(profile=True, whitelist=None), "dad") is False
+    assert _passes(_cfg(profile=True, whitelist=[]), "dad") is False
+    assert _passes(_cfg(profile=True, whitelist=["   "]), "dad") is False
+
+
+def test_profile_scoped_route_with_whitelist_still_matches_normally() -> None:
+    cfg = _cfg(profile=True, whitelist=["dad"])
+    assert _passes(cfg, "dad") is True
+    assert _passes(cfg, "kid") is False
+
+
+def test_media_account_allowed_default_allow_flag() -> None:
+    from cw_platform.account_match import media_account_allowed
+
+    assert media_account_allowed([], "kid") is True
+    assert media_account_allowed([], "kid", default_allow=False) is False
+    assert media_account_allowed(["dad"], "dad", default_allow=False) is True
+    assert media_account_allowed(["dad"], "kid", default_allow=False) is False
+
+
+def test_route_needs_account_filter_flag() -> None:
+    from providers.scrobble.routes import route_needs_account_filter
+
+    scoped = _cfg(profile=True, whitelist=None)
+    assert route_needs_account_filter(scoped, scoped["scrobble"]["watch"]["routes"][0]) is True
+
+    scoped_ok = _cfg(profile=True, whitelist=["dad"])
+    assert route_needs_account_filter(scoped_ok, scoped_ok["scrobble"]["watch"]["routes"][0]) is False
+
+    derived = _cfg(profile=True, whitelist=None, assign=False)
+    assert route_needs_account_filter(derived, derived["scrobble"]["watch"]["routes"][0]) is False
+
+    plain = _cfg(profile=False, whitelist=None)
+    assert route_needs_account_filter(plain, plain["scrobble"]["watch"]["routes"][0]) is False
+
+
+def test_overview_route_row_exposes_flag() -> None:
+    from api.scrobblerManagementAPI import _normalized_routes
+
+    cfg = _cfg(profile=True, whitelist=None)
+    rows = _normalized_routes(cfg, None)
+    assert rows and rows[0]["needs_account_filter"] is True
+
+
+def _webhook_cfg(*, profile: bool, whitelist: list[str] | None) -> dict[str, Any]:
+    wh: dict[str, Any] = {
+        "sinks": ["trakt"],
+        "sink_instances": {"trakt": "default"},
+        "filters_emby": {"username_whitelist": whitelist if whitelist is not None else []},
+        "filters_jellyfin": {"username_whitelist": whitelist if whitelist is not None else []},
+        "filters_plex": {"username_whitelist": whitelist if whitelist is not None else []},
+    }
+    if profile:
+        wh["user_profile_assignments"] = {"emby:default:trakt:default": PROFILE_ID, "jellyfin:default:trakt:default": PROFILE_ID, "plex:default:trakt:default": PROFILE_ID}
+    return {
+        "user_profiles": {PROFILE_ID: {"label": "Alice", "instance_uids": [INSTANCE_UID]}} if profile else {},
+        "provider_instance_ids": {INSTANCE_UID: {"provider": "EMBY", "instance": "default"}},
+        "scrobble": {"sources": {"webhook": True}, "webhook": wh},
+    }
+
+
+def test_webhook_profile_scoped_detection() -> None:
+    from providers.webhooks.config import profile_scoped_webhook
+
+    assert profile_scoped_webhook(_webhook_cfg(profile=True, whitelist=None), "emby", "default") is True
+    assert profile_scoped_webhook(_webhook_cfg(profile=False, whitelist=None), "emby", "default") is False
+    assert profile_scoped_webhook(_webhook_cfg(profile=True, whitelist=None), "jellyfin", "default") is True
+    assert profile_scoped_webhook(_webhook_cfg(profile=True, whitelist=None), "plex", "default") is True
+
+
+def test_webhook_profile_scoped_detection_ignores_unassigned_sink() -> None:
+    from providers.webhooks.config import profile_scoped_webhook
+
+    cfg = _webhook_cfg(profile=True, whitelist=None)
+    cfg["scrobble"]["webhook"]["sink_instances"] = {"trakt": "alt"}
+    assert profile_scoped_webhook(cfg, "emby", "default") is False
+
+
+def _stream(account: str) -> dict[str, Any]:
+    return {"source": "plex", "provider_instance": "default", "account": account, "title": "Movie"}
+
+
+def _card_filter(cfg: dict[str, Any]) -> dict[str, Any]:
+    from cw_platform.access_policy import media_account_allowlist_for_profile
+
+    return {"instances": {"PLEX": ["default"]}, "accounts": media_account_allowlist_for_profile(cfg, PROFILE_ID)}
+
+
+def test_card_visible_when_owned_route_has_no_whitelist() -> None:
+    from api.scrobbleAPI import _currently_watching_matches_user
+
+    for cfg in (_cfg(profile=True, whitelist=None, assign=False), _cfg(profile=True, whitelist=[], assign=False), _cfg(profile=True, whitelist=None)):
+        assert _currently_watching_matches_user(_stream("dad"), _card_filter(cfg)) is True
+
+
+def test_card_scoped_by_route_whitelist() -> None:
+    from api.scrobbleAPI import _currently_watching_matches_user
+
+    cfg = _cfg(profile=True, whitelist=["dad"])
+    assert _currently_watching_matches_user(_stream("dad"), _card_filter(cfg)) is True
+    assert _currently_watching_matches_user(_stream("kid"), _card_filter(cfg)) is False
+
+
+def test_card_ignores_streams_from_unowned_instance() -> None:
+    from api.scrobbleAPI import _currently_watching_matches_user
+
+    cfg = _cfg(profile=True, whitelist=["dad"])
+    stream = dict(_stream("dad"), provider_instance="other")
+    assert _currently_watching_matches_user(stream, _card_filter(cfg)) is False


### PR DESCRIPTION
# Pull request

## Change

Block profile scoped scrobble and webhook routes when no account filter is set.

## Why

Profile assigned routes need an account filter so shared provider instances do not scrobble the wrong user.

## Testing

- tests/test_scrobble_account_scope.py 

## Issue

Relates to #728