### PR TITLE
Add: watchlist views by profile

### DIFF
--- a/api/wallAPI.py
+++ b/api/wallAPI.py
@@ -4,14 +4,15 @@
 from __future__ import annotations
 
 import threading
-from typing import Any
-from fastapi import FastAPI, Query
+from typing import Any, cast
+from fastapi import FastAPI, Query, Request
 
 from cw_platform.config_base import CONFIG, config_path, load_config
 from cw_platform.local_db import manual_policy as sqlite_manual_policy
 from cw_platform.local_db import state as sqlite_state
 from cw_platform.local_db import watchlist_hide as sqlite_watchlist_hide
 from cw_platform.orchestrator._state_store import StateStore
+from cw_platform.provider_instances import instances_for_user_profile, normalize_instance_id, provider_display_key
 from services.watchlist import build_watchlist, detect_available_watchlist_providers
 
 
@@ -29,7 +30,7 @@ def _path_key(path: Any) -> tuple[str, int, int]:
         return (str(path or ""), 0, 0)
 
 
-def _cache_key(*, both_only: bool, active_only: bool, limit: int) -> tuple[Any, ...]:
+def _cache_key(*, both_only: bool, active_only: bool, limit: int, user_profile: str = "") -> tuple[Any, ...]:
     return (
         sqlite_state.fingerprint(CONFIG, {"watchlist"}),
         sqlite_manual_policy.fingerprint(CONFIG, {"watchlist"}),
@@ -38,6 +39,7 @@ def _cache_key(*, both_only: bool, active_only: bool, limit: int) -> tuple[Any, 
         bool(both_only),
         bool(active_only),
         int(limit or 0),
+        str(user_profile or "").strip(),
     )
 
 
@@ -102,21 +104,85 @@ def _configured_provider_ids(cfg: dict[str, Any]) -> list[str]:
     ]
 
 
+def _item_matches_user_filter(item: dict[str, Any], user_filter: dict[str, list[str]]) -> bool:
+    if not user_filter:
+        return True
+    wanted = {
+        provider_display_key(provider): {normalize_instance_id(inst) for inst in (instances or [])}
+        for provider, instances in user_filter.items()
+    }
+    sources = item.get("sources_by_provider") or item.get("sourcesByProvider")
+    if isinstance(sources, dict):
+        for provider, raw_instances in sources.items():
+            prov = provider_display_key(provider)
+            values = raw_instances if isinstance(raw_instances, list) else [raw_instances]
+            for inst in values:
+                if normalize_instance_id(inst) in wanted.get(prov, set()):
+                    return True
+    provider = item.get("added_src") or item.get("source") or item.get("provider")
+    instance = item.get("added_instance") or item.get("source_instance") or item.get("instance")
+    prov = provider_display_key(provider)
+    return bool(prov) and normalize_instance_id(instance) in wanted.get(prov, set())
+
+
+def _item_for_user_filter(item: dict[str, Any], user_filter: dict[str, list[str]]) -> dict[str, Any] | None:
+    if not user_filter:
+        return item
+    wanted = {
+        provider_display_key(provider): {normalize_instance_id(inst) for inst in (instances or [])}
+        for provider, instances in user_filter.items()
+    }
+    sources = item.get("sources_by_provider") or item.get("sourcesByProvider")
+    if not isinstance(sources, dict):
+        return item if _item_matches_user_filter(item, user_filter) else None
+    scoped_sources: dict[str, list[str]] = {}
+    for provider, raw_instances in sources.items():
+        prov = provider_display_key(provider)
+        values = raw_instances if isinstance(raw_instances, list) else [raw_instances]
+        keep = [
+            normalize_instance_id(inst)
+            for inst in values
+            if normalize_instance_id(inst) in wanted.get(prov, set())
+        ]
+        if keep:
+            scoped_sources[str(provider).lower()] = keep
+    if not scoped_sources:
+        return None
+    out = dict(item)
+    providers = sorted(scoped_sources.keys())
+    out["sources_by_provider"] = scoped_sources
+    out["sourcesByProvider"] = scoped_sources
+    out["sources"] = providers
+    out["status"] = f"{providers[0]}_only" if len(providers) == 1 else "both"
+    out["sync_count"] = len(providers)
+    return out
+
+
 def register_wall(app: FastAPI) -> None:
     @app.get("/api/state/wall", tags=["wall"])
     def api_state_wall(
+        request: Request = cast(Request, None),
         both_only: bool = Query(False, description="Keep only items present on multiple providers"),
         active_only: bool = Query(False, description="Keep only items from configured providers"),
         limit: int = Query(0, ge=0, le=100, description="Optional item limit"),
+        user_profile: str = Query("", description="Optional user profile id to scope provider instances"),
     ) -> dict[str, Any]:
-        key = _cache_key(both_only=both_only, active_only=active_only, limit=limit)
+        from api.appAuthAPI import COOKIE_NAME, effective_user_profile_id
+
+        cfg = load_config() or {}
+        token = request.cookies.get(COOKIE_NAME) if request is not None else None
+        profile = effective_user_profile_id(cfg, token, user_profile)
+        key = _cache_key(both_only=both_only, active_only=active_only, limit=limit, user_profile=profile)
         with _WALL_CACHE_LOCK:
             if _WALL_CACHE.get("key") == key and isinstance(_WALL_CACHE.get("data"), dict):
                 return dict(_WALL_CACHE["data"])
 
-        cfg = load_config() or {}
         st = _load_state()
         api_key = _tmdb_api_key(cfg)
+        scoped = bool(str(profile or "").strip())
+        user_filter = instances_for_user_profile(cfg, profile) if scoped else {}
+        if scoped and not user_filter:
+            user_filter = {"__NONE__": ["__NONE__"]}
 
         items = build_watchlist(st, tmdb_ok=bool(api_key)) or []
         active = {pid.lower(): True for pid in _configured_provider_ids(cfg)}
@@ -127,10 +193,19 @@ def register_wall(app: FastAPI) -> None:
                 return False
             if active_only and status.endswith("_only"):
                 base = status[:-5]
-                return active.get(base, False)
+                if not active.get(base, False):
+                    return False
+            if not _item_matches_user_filter(it, user_filter):
+                return False
             return True
 
-        items = [it for it in items if keep(it)]
+        items = [
+            scoped
+            for it in items
+            if keep(it)
+            for scoped in [_item_for_user_filter(it, user_filter)]
+            if scoped is not None
+        ]
         total = len(items)
         if limit:
             items = items[:limit]

--- a/api/watchlistAPI.py
+++ b/api/watchlistAPI.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import urllib.parse
 from typing import Any, Literal, cast
 
-from fastapi import APIRouter, Body, Path as FPath, Query
+from fastapi import APIRouter, Body, Path as FPath, Query, Request
 from fastapi.responses import JSONResponse
 
+from cw_platform.provider_instances import instances_for_user_profile, normalize_instance_id, provider_display_key
 from services.watchlist import (
     _feat_enabled,
     _find_item_in_state,
@@ -120,6 +121,108 @@ def _active_pair_watchlist_providers(cfg: dict[str, Any]) -> list[str]:
     return out
 
 
+def _item_matches_user_filter(item: dict[str, Any], user_filter: dict[str, list[str]]) -> bool:
+    if not user_filter:
+        return True
+    wanted = {
+        provider_display_key(provider): {normalize_instance_id(inst) for inst in (instances or [])}
+        for provider, instances in user_filter.items()
+    }
+    sources = item.get("sources_by_provider") or item.get("sourcesByProvider")
+    if isinstance(sources, dict):
+        for provider, raw_instances in sources.items():
+            prov = provider_display_key(provider)
+            values = raw_instances if isinstance(raw_instances, list) else [raw_instances]
+            for inst in values:
+                if normalize_instance_id(inst) in wanted.get(prov, set()):
+                    return True
+    provider = item.get("added_src") or item.get("source") or item.get("provider")
+    instance = item.get("added_instance") or item.get("source_instance") or item.get("instance")
+    prov = provider_display_key(provider)
+    return bool(prov) and normalize_instance_id(instance) in wanted.get(prov, set())
+
+
+def _item_for_user_filter(item: dict[str, Any], user_filter: dict[str, list[str]]) -> dict[str, Any] | None:
+    if not user_filter:
+        return item
+    wanted = {
+        provider_display_key(provider): {normalize_instance_id(inst) for inst in (instances or [])}
+        for provider, instances in user_filter.items()
+    }
+    sources = item.get("sources_by_provider") or item.get("sourcesByProvider")
+    if not isinstance(sources, dict):
+        return item if _item_matches_user_filter(item, user_filter) else None
+    scoped_sources: dict[str, list[str]] = {}
+    for provider, raw_instances in sources.items():
+        prov = provider_display_key(provider)
+        values = raw_instances if isinstance(raw_instances, list) else [raw_instances]
+        keep = [
+            normalize_instance_id(inst)
+            for inst in values
+            if normalize_instance_id(inst) in wanted.get(prov, set())
+        ]
+        if keep:
+            scoped_sources[str(provider).lower()] = keep
+    if not scoped_sources:
+        return None
+    out = dict(item)
+    providers = sorted(scoped_sources.keys())
+    out["sources_by_provider"] = scoped_sources
+    out["sourcesByProvider"] = scoped_sources
+    out["sources"] = providers
+    out["status"] = f"{providers[0]}_only" if len(providers) == 1 else "both"
+    out["sync_count"] = len(providers)
+    return out
+
+
+def _effective_user_filter(cfg: dict[str, Any], request: Request | None, requested_profile: str) -> tuple[str, dict[str, list[str]]]:
+    try:
+        from api.appAuthAPI import COOKIE_NAME, effective_user_profile_id
+
+        token = request.cookies.get(COOKIE_NAME) if request is not None else None
+        profile = effective_user_profile_id(cfg, token, requested_profile)
+    except Exception:
+        profile = "__none__"
+    scoped = bool(str(profile or "").strip())
+    user_filter = instances_for_user_profile(cfg, profile) if scoped else {}
+    if scoped and not user_filter:
+        user_filter = {"__NONE__": ["__NONE__"]}
+    return str(profile or "").strip(), user_filter
+
+
+def _delete_scope(cfg: dict[str, Any], request: Request | None) -> dict[str, list[str]] | None:
+    profile, user_filter = _effective_user_filter(cfg, request, "")
+    if not profile:
+        return None
+    allowed: dict[str, list[str]] = {}
+    for provider, raw in (user_filter or {}).items():
+        prov = provider_display_key(provider)
+        values = raw if isinstance(raw, list) else [raw]
+        keep = [normalize_instance_id(value) for value in values if normalize_instance_id(value)]
+        if prov and keep:
+            allowed[prov] = keep
+    return allowed
+
+
+def _scope_permits(allowed: dict[str, list[str]] | None, provider: str, instance: Any) -> bool:
+    if allowed is None:
+        return True
+    if not allowed:
+        return False
+    prov = provider_display_key(provider)
+    if not prov or prov == "ALL":
+        return True
+    owned = allowed.get(prov) or []
+    if not owned:
+        return False
+    inst = normalize_instance_id(instance) if str(instance or "").strip() else ""
+    return inst in owned if inst else True
+
+
+def _scope_denied() -> JSONResponse:
+    return JSONResponse({"ok": False, "error": "profile_scope_denied"}, status_code=403)
+
+
 def _tmdb_api_key(cfg: dict[str, Any]) -> str:
     def _pick_from_block(blk: Any) -> str:
         if not isinstance(blk, dict):
@@ -189,7 +292,7 @@ def _candidate_keys_from_ids(ids: dict[str, Any]) -> list[str]:
             out.append(k)
     return out
 
-def _bulk_delete(provider: str, keys_raw: list[Any], provider_instance: str | None = None) -> dict[str, Any]:
+def _bulk_delete(provider: str, keys_raw: list[Any], provider_instance: str | None = None, allowed_instances: dict[str, list[str]] | None = None) -> dict[str, Any]:
     from cw_platform.config_base import load_config
     from crosswatch import STATS, _append_log
 
@@ -220,6 +323,11 @@ def _bulk_delete(provider: str, keys_raw: list[Any], provider_instance: str | No
             return {"ok": False, "error": f"provider '{prov}' not connected"}
         targets = [prov]
 
+    if allowed_instances is not None:
+        targets = [p for p in targets if allowed_instances.get(provider_display_key(p))]
+        if not targets:
+            return {"ok": False, "error": "profile_scope_denied"}
+
     results: list[dict[str, Any]] = []
     deleted_sum = 0
 
@@ -229,13 +337,22 @@ def _bulk_delete(provider: str, keys_raw: list[Any], provider_instance: str | No
             deleted = 0
             for spec in specs:
                 primary_key = str(spec.get("key") or "")
-                resolved_key = _resolve_key_spec_for_provider(state, p, spec, instance_id=inst_p)
+                if allowed_instances is None:
+                    resolved_key = _resolve_key_spec_for_provider(state, p, spec, instance_id=inst_p)
+                else:
+                    resolved_key = None
+                    for owned in allowed_instances.get(provider_display_key(p)) or []:
+                        if inst_p and normalize_instance_id(inst_p) != owned:
+                            continue
+                        resolved_key = _resolve_key_spec_for_provider(state, p, spec, instance_id=owned)
+                        if resolved_key:
+                            break
                 if not resolved_key:
                     per_key.append({"key": primary_key, "deleted": 0, "attempted": False, "reason": "not_in_state"})
                     continue
                 kind, label = _item_label(state, resolved_key, p)
                 safe_label = (label or "").replace("'", "’")
-                r = delete_watchlist_batch([resolved_key], p, state, cfg, provider_instance=inst_p) or {}
+                r = delete_watchlist_batch([resolved_key], p, state, cfg, provider_instance=inst_p, allowed_instances=allowed_instances) or {}
                 d = int(r.get("deleted", 0)) if isinstance(r, dict) else 0
                 per_key.append({"key": primary_key, "resolved_key": resolved_key, "deleted": d, "attempted": True})
                 deleted += d
@@ -403,6 +520,7 @@ def remove_from_plex_by_ids(
 @router.get("", include_in_schema=False)
 @router.get("/")
 def api_watchlist(
+    request: Request = cast(Request, None),
     overview: Literal["none", "short", "full"] = Query(
         "none",
         description="Attach overview from TMDb",
@@ -423,6 +541,7 @@ def api_watchlist(
         le=2000,
         description="Cap enriched items",
     ),
+    user_profile: str = Query("", description="Optional user profile id to scope provider instances"),
 ) -> JSONResponse:
 
     try:
@@ -451,9 +570,26 @@ def api_watchlist(
             status_code=200,
         )
 
+    profile, user_filter = _effective_user_filter(cfg, request, user_profile)
+    if user_filter:
+        items = [
+            scoped
+            for it in items
+            if isinstance(it, dict)
+            for scoped in [_item_for_user_filter(it, user_filter)]
+            if scoped is not None
+        ]
+
     if not items:
         return JSONResponse(
-            {"ok": False, "error": "No snapshot data found.", "missing_tmdb_key": not has_key},
+            {
+                "ok": bool(profile),
+                "items": [],
+                "error": "" if profile else "No snapshot data found.",
+                "missing_tmdb_key": not has_key,
+                "last_sync_epoch": st.get("last_sync_epoch"),
+                "meta_enriched": 0,
+            },
             status_code=200,
         )
 
@@ -530,6 +666,7 @@ def api_watchlist(
 @router.delete("/{key}")
 def api_watchlist_delete(
     key: str = FPath(...),
+    request: Request = cast(Request, None),
     provider: str | None = Query("ALL", description="Provider id or ALL"),
     provider_instance: str | None = Query(None, description="Provider instance id (optional)"),
 ) -> JSONResponse:
@@ -540,13 +677,18 @@ def api_watchlist_delete(
         key = urllib.parse.unquote(key)
 
     prov = (provider or "ALL").upper().strip()
+    cfg = load_config()
+    allowed = _delete_scope(cfg, request)
+    if not _scope_permits(allowed, prov, provider_instance):
+        return _scope_denied()
     raw_res = delete_watchlist_item(
         key=key,
         state_path=None,
-        cfg=load_config(),
+        cfg=cfg,
         provider=prov,
         provider_instance=provider_instance,
         log=_append_log,
+        allowed_instances=allowed,
     )
 
     res: dict[str, Any]
@@ -568,17 +710,23 @@ def api_watchlist_delete(
     res = _sanitize_response_errors(res, "delete_failed")
     return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
 
-@router.post("/delete")
-def api_watchlist_delete_multi(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
+def _scoped_bulk_delete(request: Request | None, payload: dict[str, Any]) -> Any:
+    from cw_platform.config_base import load_config
+
     provider = str(payload.get("provider") or "ALL").strip().upper()
     provider_instance = payload.get("provider_instance")
     keys = payload.get("keys") or []
-    return _bulk_delete(provider, keys, provider_instance=provider_instance)
+    allowed = _delete_scope(load_config(), request)
+    if not _scope_permits(allowed, provider, provider_instance):
+        return _scope_denied()
+    return _bulk_delete(provider, keys, provider_instance=provider_instance, allowed_instances=allowed)
+
+
+@router.post("/delete")
+def api_watchlist_delete_multi(request: Request = cast(Request, None), payload: dict[str, Any] = Body(...)) -> Any:
+    return _scoped_bulk_delete(request, payload)
 
 
 @router.post("/delete_batch")
-def api_watchlist_delete_batch(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
-    provider = str(payload.get("provider") or "ALL").strip().upper()
-    provider_instance = payload.get("provider_instance")
-    keys = payload.get("keys") or []
-    return _bulk_delete(provider, keys, provider_instance=provider_instance)
+def api_watchlist_delete_batch(request: Request = cast(Request, None), payload: dict[str, Any] = Body(...)) -> Any:
+    return _scoped_bulk_delete(request, payload)

--- a/assets/helpers/watchlist-preview.js
+++ b/assets/helpers/watchlist-preview.js
@@ -44,7 +44,16 @@
   const getConfig = async () => {
     if (window.CW?.API?.Config?.load) return window.CW.API.Config.load(false);
     if (window._cfgCache) return window._cfgCache;
-    const cfg = await json("/api/config");
+    let cfg;
+    try {
+      cfg = document.documentElement?.dataset?.cwRole === "user" ? await json("/api/config/meta") : await json("/api/config");
+    } catch (e) {
+      const msg = String(e?.message || e || "");
+      if (!msg.includes("401") && !msg.includes("403")) throw e;
+      const meta = await json("/api/config/meta");
+      const ui = meta && typeof meta.ui === "object" ? meta.ui : {};
+      cfg = { ok: true, __public_meta: true, ui, user_interface: ui, tmdb_configured: meta?.tmdb_configured === true, tmdb: meta?.tmdb_configured === true ? { api_key: "configured" } : {} };
+    }
     window._cfgCache = cfg;
     return cfg;
   };
@@ -83,9 +92,12 @@
     try { localStorage.setItem("wl_hidden", JSON.stringify([...set])); } catch {}
   };
 
+  const overviewProfileId = () => String(window.CW?.OverviewProfile?.id || "").trim();
+  const wallCacheKey = () => `${WALL_PREVIEW_CACHE_KEY}.${overviewProfileId() || "all"}`;
+
   const readWallCache = () => {
     try {
-      const raw = localStorage.getItem(WALL_PREVIEW_CACHE_KEY);
+      const raw = localStorage.getItem(wallCacheKey());
       if (!raw) return null;
       const data = JSON.parse(raw);
       return Array.isArray(data?.items) ? data : null;
@@ -96,12 +108,12 @@
 
   const writeWallCache = (items, lastSyncEpoch, total = null) => {
     try {
-      localStorage.setItem(WALL_PREVIEW_CACHE_KEY, JSON.stringify({ items, last_sync_epoch: lastSyncEpoch || 0, total }));
+      localStorage.setItem(wallCacheKey(), JSON.stringify({ items, last_sync_epoch: lastSyncEpoch || 0, total }));
     } catch {}
   };
 
   const clearWallCache = () => {
-    try { localStorage.removeItem(WALL_PREVIEW_CACHE_KEY); } catch {}
+    try { localStorage.removeItem(wallCacheKey()); } catch {}
   };
 
   const hasRenderedWall = (row = document.getElementById("poster-row")) => !!(row?.childElementCount && !row.classList.contains("hidden"));
@@ -372,7 +384,7 @@
     previewCard = window.CW.PlayingCard.mount({
       id: "cw-wall-preview-detail",
       variant: "watchlist",
-      tabScope: "main",
+      tabScope: document.documentElement?.dataset?.cwPage === "profile" ? "" : "main",
       label: "Watchlist preview details",
       width: "min(860px,calc(100vw - 32px))",
       onClose: closePreviewDrawer,
@@ -736,7 +748,10 @@
     }
 
     const limit = Number.isFinite(window.MAX_WALL_POSTERS) ? Math.max(1, Number(window.MAX_WALL_POSTERS)) : 20;
-    const wallDataPromise = json(`/api/state/wall?both_only=0&active_only=1&limit=${encodeURIComponent(limit)}`)
+    const params = new URLSearchParams({ both_only: "0", active_only: "1", limit: String(limit) });
+    const userProfile = overviewProfileId();
+    if (userProfile) params.set("user_profile", userProfile);
+    const wallDataPromise = json(`/api/state/wall?${params.toString()}`)
       .then((data) => ({ data }), (error) => ({ error }));
 
     try {
@@ -787,6 +802,7 @@
 
   async function hasTmdbKey() {
     const pick = (cfg) => {
+      if (cfg?.tmdb_configured === true) return true;
       const fromBlock = (blk) => {
         if (!blk || typeof blk !== "object") return "";
         const direct = String(blk.api_key || "").trim();
@@ -810,6 +826,7 @@
   }
 
   function isOnMain() {
+    if (document.getElementById("profile-hero")) return true;
     const tab = String(document.documentElement.dataset.tab || "").toLowerCase();
     if (tab) return tab === "main";
     return !!document.getElementById("tab-main")?.classList.contains("active");
@@ -903,11 +920,14 @@
   });
   window.addEventListener("sync-complete", markWatchlistPreviewDirty);
   window.addEventListener("watchlist:refresh", markWatchlistPreviewDirty);
+  window.addEventListener("cw:overview-profile-changed", markWatchlistPreviewDirty);
 
   const WatchlistPreview = {
     updateEdges,
     scrollWall,
     initWallInteractions,
+    openPreviewDrawer,
+    closePreviewDrawer,
     artUrl,
     applyWidgetView,
     prewarmWallImages,

--- a/assets/js/watchlist.js
+++ b/assets/js/watchlist.js
@@ -56,11 +56,14 @@
   const providerOptions=(empty="All")=>`<option value="">${empty}</option>${visibleProviders().map(p=>`<option value="${p}">${providerLabel(p)}</option>`).join("")}`;
   const deleteProviderOptions=pick=>`<option value="ALL">ALL (default)</option>${(pick ? PROVIDERS.filter(p=>pick.has(p)) : visibleProviders()).map(p=>`<option value="${p}">${providerLabel(p)}</option>`).join("")}`;
   const cwProfileOptions=()=>crosswatchProfiles.map(p=>`<option value="${escOpt(p.id)}">${escOpt(p.label || p.id)}</option>`).join("");
+  const isProfileUser = () => document.documentElement?.dataset?.cwRole === "user";
   const hasFloppyConfig = root => {
     const match = block => block && typeof block === "object" && (block.server_url || block.server) && (block.api_token || block.token);
     return !!(match(root) || (root?.instances && Object.values(root.instances).some(match)));
   };
   host.innerHTML=`<div class="wl-topline cw-page-hero cw-page-hero-watchlist" data-hero-icon="bookmark_added"><div class="wl-title-stack cw-page-hero-copy"><div class="cw-page-hero-kicker">WATCHLIST</div><div class="wl-title cw-page-hero-title">Watchlist</div><div class="wl-sub cw-page-hero-sub">Browse and manage your unified watchlist</div></div><div class="wl-hero-summary cw-page-hero-actions" id="wl-hero-summary" aria-label="Watchlist summary"><div class="wl-hero-seg"><strong id="wl-stat-total">0</strong><span>items</span></div><div class="wl-hero-seg"><strong id="wl-stat-visible">0</strong><span>visible</span></div><div class="wl-hero-seg wl-hero-sync"><span>Synced</span><strong id="wl-stat-sync">never</strong></div><button id="wl-refresh" class="wl-hero-refresh" title="Sync watchlist" aria-label="Sync watchlist"><span class="material-symbol ss-refresh-icon">refresh</span></button></div></div><div class="wl-wrap" id="watchlist-root"><div class="wl-main-shell"><div class="wl-toolbar"><div class="wl-toolbar-left"><label class="wl-chip wl-selectall"><input id="wl-select-all" type="checkbox"><span>Select all</span></label><span id="wl-count" class="wl-chip is-filter">0 selected</span></div><div class="wl-toolbar-right"><span id="wl-filter-state" class="wl-chip is-filter">All items</span></div></div><div id="wl-posters" class="wl-grid" style="display:none"></div><div id="wl-list" class="wl-table-wrap" style="display:none"><table class="wl-table"><colgroup><col class="c-sel"><col class="c-poster"><col class="c-title"><col class="c-rel"><col class="c-genre"><col class="c-type"><col class="c-sync"></colgroup><thead><tr><th style="text-align:center"><input id="wl-list-select-all" type="checkbox"></th><th class="sortable" data-sort="poster" data-col="poster" style="position:relative">Poster<span class="wl-resize"></span></th><th class="sortable" data-sort="title" data-col="title" style="position:relative">Title<span class="wl-resize"></span></th><th class="sortable" data-sort="release" data-col="rel" style="position:relative">Release<span class="wl-resize"></span></th><th class="sortable" data-sort="genre" data-col="genre" style="position:relative">Genre<span class="wl-resize"></span></th><th class="sortable" data-sort="type" data-col="type" style="position:relative">Type<span class="wl-resize"></span></th><th class="sortable" data-sort="sync" data-col="sync" style="position:relative">Sync<span class="wl-resize"></span></th></tr></thead><tbody id="wl-tbody"></tbody></table></div><div id="wl-pagination" class="wl-pagination" style="display:none"><button id="wl-page-prev" class="wl-btn">Previous</button><span id="wl-page-label" class="wl-muted">Page 1 of 1 • Rows 0–0 of 0</span><button id="wl-page-next" class="wl-btn">Next</button></div><div id="wl-empty" class="wl-empty wl-muted" style="display:none">No items match the current filters.</div></div><aside class="wl-side"><div class="ins-card"><div class="ins-row wl-ref-row" style="align-items:center"><div class="ins-icon"><span class="material-symbol">tune</span></div><div class="ins-title" style="margin-right:auto">Filters</div></div><div class="ins-row"><div class="ins-kv"><label for="wl-view">View</label><select id="wl-view" name="wl-view" class="wl-input" style="width:auto;padding:6px 10px"><option value="posters">Posters</option><option value="list">List</option></select><label for="wl-q">Search</label><input id="wl-q" name="wl-q" class="wl-input" placeholder="Search title..."><label for="wl-type">Type</label><select id="wl-type" name="wl-type" class="wl-input"><option value="">All types</option><option value="movie">Movies</option><option value="tv">Shows</option><option value="anime">Anime</option></select><label for="wl-provider">Provider</label><select id="wl-provider" name="wl-provider" class="wl-input">${providerOptions()}</select><label id="wl-size-label" for="wl-size">Size</label><input id="wl-size" name="wl-size" type="range" min="120" max="320" step="10" class="wl-input" style="padding:0"></div></div><div class="ins-row" id="wl-more-panel" style="display:none"><div class="ins-kv"><label for="wl-released">Released</label><select id="wl-released" name="wl-released" class="wl-input"><option value="both">Both</option><option value="released">Released</option><option value="unreleased">Upcoming</option></select><label id="wl-overlays-label" for="wl-overlays">Overlays</label><select id="wl-overlays" name="wl-overlays" class="wl-input"><option value="yes">On</option><option value="no">Off</option></select><label for="wl-genre">Genre</label><select id="wl-genre" name="wl-genre" class="wl-input"><option value="">All</option></select><label for="wl-show-hidden">Hidden</label><label class="wl-chip" style="justify-content:flex-start"><input id="wl-show-hidden" type="checkbox"><span>Include local hidden</span></label><div id="wl-cols-label" class="field-label">Columns</div><div id="wl-cols" class="wl-cols"><label class="wl-colchip"><input type="checkbox" name="wl-col" data-col="poster">Poster</label><label class="wl-colchip"><input type="checkbox" name="wl-col" data-col="rel">Release</label><label class="wl-colchip"><input type="checkbox" name="wl-col" data-col="genre">Genre</label><label class="wl-colchip"><input type="checkbox" name="wl-col" data-col="type">Type</label><label class="wl-colchip"><input type="checkbox" name="wl-col" data-col="sync">Sync</label></div></div></div><div class="ins-row" style="justify-content:flex-end;gap:8px"><button id="wl-more" class="wl-btn" aria-expanded="false">More</button><button id="wl-clear" class="wl-btn">Reset</button></div></div><div class="ins-card"><div class="ins-row wl-action-head"><div class="wl-action-title"><div class="ins-icon"><span class="material-symbol">flash_on</span></div><div class="ins-title">Actions</div></div><button type="button" class="wl-action-help" aria-label="Watchlist actions help" title="Delete selected items from the chosen provider, or from all providers. Hide local only removes selected items from the local CrossWatch view. Unhide all restores locally hidden items."><span class="material-symbol">help</span></button></div><div class="ins-row"><div class="wl-actions-panel"><div class="wl-action-row"><div class="wl-action-copy"><div class="wl-action-label">Delete from</div><div class="wl-action-hint">Selected items only</div></div><div class="wl-action-control is-select"><select id="wl-delete-provider" name="wl-delete-provider" class="wl-input">${deleteProviderOptions()}</select><button id="wl-delete" class="wl-btn danger" disabled>Delete</button></div></div><div class="wl-action-row"><div class="wl-action-copy"><div class="wl-action-label">Visibility</div><div class="wl-action-hint">Local view only</div></div><div class="wl-action-control"><button id="wl-hide" class="wl-btn" disabled>Hide local</button><button id="wl-unhide" class="wl-btn">Unhide all</button></div></div></div></div></div><div class="ins-card"><div class="ins-row"><div class="ins-icon"><span class="material-symbol">monitoring</span></div><div class="ins-title">Coverage Pulse</div></div><div class="ins-row"><div id="wl-metrics" class="ins-metrics"></div></div></div></aside></div><div id="wl-snack" class="wl-snack wl-hidden" role="status" aria-live="polite"></div>`;
+  host.querySelector(".wl-actions-panel")?.closest(".ins-card")?.classList.add("wl-action-card");
+  host.classList.toggle("wl-readonly", isProfileUser());
 
   /* References to elements */
   const $ = id => document.getElementById(id);
@@ -843,6 +846,11 @@
   const parseReleaseDate = s => { if (typeof s !== "string" || !(s = s.trim())) return null; let y, m, d; if (/^\d{4}-\d{2}-\d{2}$/.test(s)) ([y, m, d] = s.split("-").map(Number)); else if (/^\d{2}-\d{2}-\d{4}$/.test(s)) { const a = s.split("-").map(Number); d = a[0]; m = a[1]; y = a[2]; } else return null; const t = Date.UTC(y, (m || 1) - 1, d || 1), dt = new Date(t); return Number.isFinite(dt.getTime()) ? dt : null; };
   const fmtDateSmart = (raw, loc) => { const dt = parseReleaseDate(raw); if (!dt) return ""; try { return new Intl.DateTimeFormat(loc || toLocale(), { day:"2-digit", month:"2-digit", year:"numeric", timeZone:"UTC" }).format(dt); } catch { return ""; } };
   const providersOf = it => Array.isArray(it.sources) ? it.sources.map(providerKey).filter(Boolean) : [];
+  const addActiveProvidersFromItems = list => {
+    for (const it of (Array.isArray(list) ? list : [])) {
+      for (const provider of providersOf(it)) activeProviders.add(provider);
+    }
+  };
     const getReleaseIso = it => {
     const tv = /^(tv|show|anime)$/i.test(String(it.type || ""));
     let iso = tv ? (it.first_air_date || it.firstAired || it.aired) : (it.release_date || it.released);
@@ -1002,7 +1010,21 @@
 
   const fetchConfig = async () => {
     if (authSetupPending()) return {};
-    try { const r = await fetch("/api/config", { cache: "no-store" }); return r.ok ? await r.json() : {}; }
+    try {
+      const managed = document.documentElement?.dataset?.cwRole === "user";
+      const r = await fetch(managed ? "/api/config/meta" : "/api/config", { cache: "no-store" });
+      if (!r.ok) return {};
+      const cfg = await r.json();
+      if (!managed) return cfg || {};
+      return {
+        providers: cfg?.providers || {},
+        provider_instances: cfg?.provider_instances || {},
+        user_profiles: cfg?.user_profiles || {},
+        features: cfg?.features || {},
+        ui: cfg?.ui || {},
+        auth: { setup_required: false },
+      };
+    }
     catch { return {}; }
   };
 
@@ -1493,6 +1515,7 @@ const normReleased = v => (v === "yes" ? "released" : v === "no" ? "unreleased" 
     postersEl.replaceChildren();
     const frag=document.createDocumentFragment();
     const canTMDB=(typeof TMDB_OK==="undefined")?true:!!TMDB_OK;
+    const readOnly = isProfileUser();
 
     const start = pageInfo.start;
     const end = pageInfo.end;
@@ -1508,7 +1531,7 @@ const normReleased = v => (v === "yes" ? "released" : v === "no" ? "unreleased" 
       const relYear = String(it.year || yearFromIso(d.iso) || "").trim();
       const providerCount = providersOf(it).length;
       const card=document.createElement("div");
-      card.className=`wl-card ${selected.has(key)?"selected":""}`;
+      card.className=`wl-card ${!readOnly && selected.has(key)?"selected":""}`;
 
       const provHtml = providersOf(it).map(p => posterProviderIcon(p)).join("");
       const eager=i<24?`loading="eager" fetchpriority="high"`:`loading="lazy"`;
@@ -1527,8 +1550,10 @@ const normReleased = v => (v === "yes" ? "released" : v === "no" ? "unreleased" 
         </div>`;
 
       card.addEventListener("click",()=>{
-        selected.has(key)?selected.delete(key):selected.add(key);
-        card.classList.toggle("selected"); updateSelCount();
+        if (!isProfileUser()) {
+          selected.has(key)?selected.delete(key):selected.add(key);
+          card.classList.toggle("selected"); updateSelCount();
+        }
         if(canTMDB) getMetaFor(it, "detail").then(m=>renderDetail(it,m||{})); else renderDetail(it,{});
       },true);
 
@@ -1548,6 +1573,7 @@ const normReleased = v => (v === "yes" ? "released" : v === "no" ? "unreleased" 
     const frag = document.createDocumentFragment();
     const sorted = sortFilteredForList(filtered);
     const canTMDB=(typeof TMDB_OK==="undefined")?true:!!TMDB_OK;
+    const readOnly = isProfileUser();
     const start = pageInfo.start;
     const end = pageInfo.end;
     const rows = sorted.slice(start, end);
@@ -1599,7 +1625,7 @@ const normReleased = v => (v === "yes" ? "released" : v === "no" ? "unreleased" 
         <td style="text-align:center"><input type="checkbox" name="wl-select" data-k="${key}" ${selected.has(key) ? "checked" : ""}></td>
         ${columns.map(column => cellHtml[column] || "").join("")}
       `;
-      tr.classList.toggle("selected", selected.has(key));
+      tr.classList.toggle("selected", !readOnly && selected.has(key));
 
       if (d.relFmt || d.genresText) hydrateRow(it, tr);
       const posterCell = tr.querySelector(".wl-poster-cell");
@@ -1617,15 +1643,18 @@ const normReleased = v => (v === "yes" ? "released" : v === "no" ? "unreleased" 
       posterCell?.addEventListener("focusout", hideFromCover, true);
       const rowCheckbox = tr.querySelector('input[type=checkbox]');
       const setRowSelected = checked => {
+        if (isProfileUser()) return;
         checked ? selected.add(key) : selected.delete(key);
         tr.classList.toggle("selected", checked);
         if (rowCheckbox) rowCheckbox.checked = checked;
         if (listSelectAll) listSelectAll.checked = filtered.length > 0 && filtered.every(x => selected.has(normKey(x)));
         updateSelCount();
       };
+      if (readOnly && rowCheckbox) rowCheckbox.disabled = true;
       rowCheckbox?.addEventListener("click", e => e.stopPropagation(), true);
       rowCheckbox?.addEventListener("change", e => setRowSelected(!!e.target.checked), true);
       tr.addEventListener("click", e => {
+        if (isProfileUser()) return;
         if (e.target?.closest?.("input,button,a,select,textarea,label,.wl-resize")) return;
         setRowSelected(!selected.has(key));
       }, true);
@@ -1662,11 +1691,12 @@ const normReleased = v => (v === "yes" ? "released" : v === "no" ? "unreleased" 
   }
 
   function updateSelCount(){
+    if (isProfileUser()) selected.clear();
     selCount.textContent = `${selected.size} selected`;
     selCount.classList.toggle("is-accent", selected.size > 0);
     rebuildDeleteProviderOptions();
-    document.getElementById("wl-delete").disabled = !(delProv.value && selected.size);
-    document.getElementById("wl-hide").disabled = selected.size === 0;
+    document.getElementById("wl-delete").disabled = isProfileUser() || !(delProv.value && selected.size);
+    document.getElementById("wl-hide").disabled = isProfileUser() || selected.size === 0;
     updateHeaderSummary();
   }
 
@@ -1784,9 +1814,16 @@ const normReleased = v => (v === "yes" ? "released" : v === "no" ? "unreleased" 
   on([genreSel], ["change","input"], () => { prefs.genre = genreSel.value || ""; writePrefs(prefs); applyFilters(); });
   showHiddenChk?.addEventListener("change", () => { prefs.showHidden = !!showHiddenChk.checked; writePrefs(prefs); applyFilters(); }, true);
 
-  const selectAll = chk => { selected.clear(); if (chk.checked) filtered.forEach(it => { const k = normKey(it); if (k) selected.add(k); }); };
+  const selectAll = chk => { selected.clear(); if (!isProfileUser() && chk.checked) filtered.forEach(it => { const k = normKey(it); if (k) selected.add(k); }); };
   selAll?.addEventListener("change", () => { selectAll(selAll); (viewMode === "posters" ? renderPosters : renderList)(); updateSelCount(); }, true);
   listSelectAll?.addEventListener("change", () => { selectAll(listSelectAll); renderList(); updateSelCount(); }, true);
+
+  window.addEventListener("cw:overview-profile-changed", () => {
+    host.classList.toggle("wl-readonly", isProfileUser());
+    if (isProfileUser()) selected.clear();
+    render();
+    updateSelCount();
+  });
 
   clearBtn.addEventListener("click", () => {
     qEl.value = ""; tEl.value = ""; providerSel.value = "";
@@ -1850,7 +1887,7 @@ const normReleased = v => (v === "yes" ? "released" : v === "no" ? "unreleased" 
   });
 
   document.addEventListener("keydown", e => {
-    if (e.key === "Delete" && !document.getElementById("wl-delete").disabled) document.getElementById("wl-delete").click();
+    if (e.key === "Delete" && !isProfileUser() && !document.getElementById("wl-delete").disabled) document.getElementById("wl-delete").click();
     if (e.key === "Escape" && !document.getElementById("cw-trailer")?.classList.contains("show")) forceHideDetail();
   }, true);
 
@@ -1881,7 +1918,7 @@ const normReleased = v => (v === "yes" ? "released" : v === "no" ? "unreleased" 
   }, true);
 
   async function hardReloadWatchlist(){
-    try{ items=await fetchWatchlist(); populateGenreOptions(buildGenreIndex(items)); applyFilters(); rebuildDeleteProviderOptions(); }
+    try{ items=await fetchWatchlist(); addActiveProvidersFromItems(items); rebuildProviderOptions(); populateGenreOptions(buildGenreIndex(items)); applyFilters(); rebuildDeleteProviderOptions(); }
     catch(e){ console.warn("watchlist reload failed:", e); }
   }
   function _wlBusy(on){ const b=document.getElementById("wl-refresh"); if(!b)return; b.disabled=!!on; b.classList.toggle("loading",!!on); b.classList.toggle("spin",!!on); }
@@ -1946,6 +1983,8 @@ const normReleased = v => (v === "yes" ? "released" : v === "no" ? "unreleased" 
     await loadCrosswatchProfiles();
     rebuildProviderOptions();
     items = await fetchWatchlist();
+    addActiveProvidersFromItems(items);
+    rebuildProviderOptions();
     populateGenreOptions(buildGenreIndex(items));
     applyOverlayPrefUI(); applyFilters(); rebuildDeleteProviderOptions(); wireSortableHeaders(); updateHeaderSummary();
 

--- a/services/watchlist.py
+++ b/services/watchlist.py
@@ -1536,6 +1536,7 @@ def delete_watchlist_batch(
     cfg: dict[str, Any],
     provider_instance: str | None = None,
     state_path: Path | None = None,
+    allowed_instances: Mapping[str, list[str]] | None = None,
 ) -> dict[str, Any]:
     prov = (prov or "").upper().strip()
     keys = [k for k in (keys or []) if isinstance(k, str) and k.strip()]
@@ -1549,10 +1550,21 @@ def delete_watchlist_batch(
     if prov == "ALL":
         inst_sel = None
 
+    def _allowed_for(p: str) -> set[str] | None:
+        if allowed_instances is None:
+            return None
+        raw = allowed_instances.get(str(p or "").upper()) or []
+        return {normalize_instance_id(v) for v in (raw if isinstance(raw, list) else [raw]) if normalize_instance_id(v)}
+
     def _instance_targets(p: str) -> list[str]:
+        allow = _allowed_for(p)
+        if allow is not None and not allow:
+            return []
         hits: set[str] = set()
         for inst_id, blk in _iter_provider_instance_blocks(state, p):
             if inst_sel and inst_id != inst_sel:
+                continue
+            if allow is not None and normalize_instance_id(inst_id) not in allow:
                 continue
             items = _items_from_block(blk)
             if not isinstance(items, dict) or not items:
@@ -1560,9 +1572,9 @@ def delete_watchlist_batch(
             for k in keys:
                 if k in items:
                     hits.add(inst_id)
-        if not hits and inst_sel:
+        if not hits and inst_sel and (allow is None or inst_sel in allow):
             hits.add(inst_sel)
-        if not hits:
+        if not hits and allow is None:
             hits.add(_DEFAULT_INSTANCE)
         return sorted(hits, key=lambda x: (x != _DEFAULT_INSTANCE, x))
 
@@ -1632,6 +1644,8 @@ def delete_watchlist_batch(
         deleted_sum = 0
 
         for p in _registry_sync_providers():
+            if allowed_instances is not None and not _allowed_for(p):
+                continue
             res = _delete_for_provider(p)
             details[p] = res
             ok_any |= bool(res.get("ok"))
@@ -1658,6 +1672,7 @@ def delete_watchlist_item(
     log: Any = None,
     provider: str | None = None,
     provider_instance: str | None = None,
+    allowed_instances: Mapping[str, list[str]] | None = None,
 ) -> dict[str, Any]:
     prov = (provider or "ALL").upper().strip()
     try:
@@ -1680,6 +1695,7 @@ def delete_watchlist_item(
             cfg=cfg,
             provider_instance=provider_instance,
             state_path=state_path,
+            allowed_instances=allowed_instances,
         ) or {}
         _log("SYNC", f"[WL] delete {key} on {prov}: {'OK' if res.get('ok') else 'NOOP'}")
         res.setdefault("key", key)

--- a/tests/test_wall_api.py
+++ b/tests/test_wall_api.py
@@ -1,8 +1,13 @@
 from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from typing import cast
 
 from api import wallAPI
 from cw_platform.orchestrator._state_store import StateStore
+import cw_platform.provider_instances as provider_instances
 import services.watchlist as watchlist_service
+
+BOB_PROFILE_ID = "22222222222242228222222222222222"
 
 
 def test_wall_total_counts_filtered_items_before_limit(monkeypatch):
@@ -27,7 +32,7 @@ def test_wall_total_counts_filtered_items_before_limit(monkeypatch):
         ],
     )
 
-    endpoint = next(route.endpoint for route in app.routes if getattr(route, "path", "") == "/api/state/wall")
+    endpoint = next(cast(APIRoute, route).endpoint for route in app.routes if getattr(route, "path", "") == "/api/state/wall")
     data = endpoint(both_only=False, active_only=False, limit=2)
 
     assert data["ok"] is True
@@ -52,6 +57,52 @@ def test_wall_cache_key_tracks_db_watchlist(monkeypatch, tmp_path):
     assert after != before
 
 
+def test_wall_endpoint_filters_by_user_profile(monkeypatch):
+    app = FastAPI()
+    wallAPI.register_wall(app)
+    wallAPI._WALL_CACHE.clear()
+    wallAPI._WALL_CACHE.update({"key": None, "data": None})
+    cfg = {
+        "tmdb": {"api_key": "tmdb-key"},
+        "plex": {"instances": {"PLEX-P02": {}}},
+        "mdblist": {"instances": {"MDBLIST-P01": {}}},
+        "user_profiles": {BOB_PROFILE_ID: {"label": "Bob", "instances": {"PLEX": ["PLEX-P02"], "MDBLIST": ["MDBLIST-P01"]}}},
+    }
+    provider_instances.ensure_provider_instance_uids(cfg)
+
+    monkeypatch.setattr(wallAPI, "load_config", lambda: cfg)
+    monkeypatch.setattr(wallAPI, "_load_state", lambda: {"last_sync_epoch": 123})
+    monkeypatch.setattr(wallAPI.sqlite_state, "fingerprint", lambda *_args, **_kwargs: ("state", 1))
+    monkeypatch.setattr(wallAPI.sqlite_manual_policy, "fingerprint", lambda *_args, **_kwargs: ("manual", 1))
+    monkeypatch.setattr(wallAPI.sqlite_watchlist_hide, "fingerprint", lambda *_args, **_kwargs: ("hidden", 1))
+    monkeypatch.setattr(wallAPI, "config_path", lambda: "config.json")
+    monkeypatch.setattr(
+        wallAPI,
+        "build_watchlist",
+        lambda _state, tmdb_ok: [
+            {"key": "alice", "status": "both", "sources_by_provider": {"plex": ["default"]}},
+            {
+                "key": "bob",
+                "status": "both",
+                "sources": ["plex", "mdblist", "simkl"],
+                "sources_by_provider": {
+                    "mdblist": ["MDBLIST-P01"],
+                    "plex": ["PLEX-P02"],
+                    "simkl": ["default"],
+                },
+            },
+        ],
+    )
+
+    endpoint = next(cast(APIRoute, route).endpoint for route in app.routes if getattr(route, "path", "") == "/api/state/wall")
+    data = endpoint(both_only=False, active_only=False, limit=20, user_profile=BOB_PROFILE_ID)
+
+    assert data["total"] == 1
+    assert data["items"][0]["key"] == "bob"
+    assert data["items"][0]["sources"] == ["mdblist", "plex"]
+    assert data["items"][0]["sources_by_provider"] == {"mdblist": ["MDBLIST-P01"], "plex": ["PLEX-P02"]}
+
+
 def test_wall_endpoint_reads_db_watchlist(monkeypatch, tmp_path):
     app = FastAPI()
     wallAPI.register_wall(app)
@@ -69,7 +120,7 @@ def test_wall_endpoint_reads_db_watchlist(monkeypatch, tmp_path):
         last_sync_epoch=123,
     )
 
-    endpoint = next(route.endpoint for route in app.routes if getattr(route, "path", "") == "/api/state/wall")
+    endpoint = next(cast(APIRoute, route).endpoint for route in app.routes if getattr(route, "path", "") == "/api/state/wall")
     data = endpoint(both_only=False, active_only=False, limit=20)
 
     assert data["total"] == 1

--- a/tests/test_watchlist_api.py
+++ b/tests/test_watchlist_api.py
@@ -1,0 +1,111 @@
+# tests/test_watchlist_api.py
+# CrossWatch - Watchlist API regression checks
+
+from __future__ import annotations
+
+import json
+
+from starlette.requests import Request
+
+
+def _request(path: str, headers: dict[str, str] | None = None) -> Request:
+    raw_headers = [(b"host", b"testserver")]
+    for key, value in (headers or {}).items():
+        raw_headers.append((str(key).lower().encode("latin-1"), str(value).encode("latin-1")))
+    return Request(
+        {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": path,
+            "raw_path": path.encode("latin-1"),
+            "query_string": b"",
+            "headers": raw_headers,
+            "client": ("127.0.0.1", 12345),
+            "server": ("testserver", 80),
+        }
+    )
+
+
+def _json_body(resp) -> dict:
+    return json.loads(resp.body.decode("utf-8"))
+
+
+def test_watchlist_api_filters_non_admin_to_assigned_profile(monkeypatch) -> None:
+    from api import appAuthAPI as auth
+    from api import watchlistAPI
+    import cw_platform.config_base as config_base
+    import cw_platform.provider_instances as provider_instances
+
+    profile_id = "11111111111141118111111111111111"
+    cfg = {
+        "tmdb": {"api_key": "tmdb-key"},
+        "plex": {"instances": {"PLEX-P02": {}}},
+        "mdblist": {"instances": {"MDBLIST-P01": {}}},
+        "user_profiles": {
+            profile_id: {"label": "Bob", "instances": {"PLEX": ["PLEX-P02"], "MDBLIST": ["MDBLIST-P01"]}},
+        },
+        "app_auth": {
+            "enabled": True,
+            "username": "admin",
+            "reset_required": False,
+            "remember_session_enabled": False,
+            "remember_session_days": 30,
+            "password": auth._password_hash("secrett1"),
+            "session": {"token_hash": "", "expires_at": 0},
+            "sessions": [],
+            "last_login_at": 0,
+            "users": {
+                "aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa": {
+                    "username": "bob",
+                    "enabled": True,
+                    "role": "user",
+                    "profile_id": profile_id,
+                    "permissions": {"dashboard": True, "watchlist": True},
+                    "password": auth._password_hash("secrett2"),
+                }
+            },
+        },
+    }
+    provider_instances.ensure_provider_instance_uids(cfg)
+    user = auth._public_user("aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa", cfg["app_auth"]["users"]["aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa"])
+    token, _exp = auth._issue_session(cfg, _request("/api/app-auth/login"), user)
+
+    monkeypatch.setattr(config_base, "load_config", lambda: cfg)
+    monkeypatch.setattr(watchlistAPI, "_load_watchlist_state", lambda: {"last_sync_epoch": 123})
+    monkeypatch.setattr(
+        watchlistAPI,
+        "build_watchlist",
+        lambda _state, tmdb_ok: [
+            {
+                "key": "alice",
+                "title": "Alice Item",
+                "sources": ["plex"],
+                "sources_by_provider": {"plex": ["default"]},
+            },
+            {
+                "key": "bob",
+                "title": "Bob Item",
+                "sources": ["plex", "mdblist", "simkl", "scrob", "trakt"],
+                "sources_by_provider": {
+                    "mdblist": ["MDBLIST-P01"],
+                    "plex": ["PLEX-P02"],
+                    "scrob": ["default"],
+                    "simkl": ["default"],
+                    "trakt": ["default"],
+                },
+            },
+        ],
+    )
+
+    request = _request("/api/watchlist", headers={"cookie": f"{auth.COOKIE_NAME}={token}"})
+    data = _json_body(watchlistAPI.api_watchlist(request=request, limit=0, max_meta=0, user_profile=""))
+
+    assert data["ok"] is True
+    assert data["last_sync_epoch"] == 123
+    assert [item["key"] for item in data["items"]] == ["bob"]
+    assert data["items"][0]["sources"] == ["mdblist", "plex"]
+    assert data["items"][0]["sources_by_provider"] == {"mdblist": ["MDBLIST-P01"], "plex": ["PLEX-P02"]}
+    assert data["items"][0]["sync_count"] == 2

--- a/tests/test_watchlist_delete_scope.py
+++ b/tests/test_watchlist_delete_scope.py
@@ -1,0 +1,188 @@
+# tests/test_watchlist_delete_scope.py
+# CrossWatch - Watchlist delete profile-scope checks
+
+from __future__ import annotations
+
+import json
+
+from starlette.requests import Request
+
+PROFILE_ID = "11111111111141118111111111111111"
+USER_ID = "aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa"
+
+
+def _request(path: str, headers: dict[str, str] | None = None) -> Request:
+    raw_headers = [(b"host", b"testserver")]
+    for key, value in (headers or {}).items():
+        raw_headers.append((str(key).lower().encode("latin-1"), str(value).encode("latin-1")))
+    return Request(
+        {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": path,
+            "raw_path": path.encode("latin-1"),
+            "query_string": b"",
+            "headers": raw_headers,
+            "client": ("127.0.0.1", 12345),
+            "server": ("testserver", 80),
+        }
+    )
+
+
+def _cfg(auth):
+    return {
+        "plex": {"instances": {"PLEX-P01": {}, "PLEX-P02": {}}},
+        "user_profiles": {
+            PROFILE_ID: {"label": "Bob", "instances": {"PLEX": ["PLEX-P02"]}},
+        },
+        "app_auth": {
+            "enabled": True,
+            "username": "admin",
+            "reset_required": False,
+            "remember_session_enabled": False,
+            "remember_session_days": 30,
+            "password": auth._password_hash("secrett1"),
+            "session": {"token_hash": "", "expires_at": 0},
+            "sessions": [],
+            "last_login_at": 0,
+            "users": {
+                USER_ID: {
+                    "username": "bob",
+                    "enabled": True,
+                    "role": "user",
+                    "profile_id": PROFILE_ID,
+                    "permissions": {"dashboard": True, "watchlist": True, "write": True},
+                    "password": auth._password_hash("secrett2"),
+                }
+            },
+        },
+    }
+
+
+def _managed_request(monkeypatch):
+    from api import appAuthAPI as auth
+    import cw_platform.config_base as config_base
+    import cw_platform.provider_instances as provider_instances
+
+    cfg = _cfg(auth)
+    provider_instances.ensure_provider_instance_uids(cfg)
+    user = auth._public_user(USER_ID, cfg["app_auth"]["users"][USER_ID])
+    token, _exp = auth._issue_session(cfg, _request("/api/app-auth/login"), user)
+    monkeypatch.setattr(config_base, "load_config", lambda: cfg)
+    return _request("/api/watchlist/delete", headers={"cookie": f"{auth.COOKIE_NAME}={token}"}), cfg
+
+
+def test_managed_user_cannot_delete_other_profile_instance(monkeypatch) -> None:
+    from api import watchlistAPI
+
+    request, _cfg_obj = _managed_request(monkeypatch)
+    called: list = []
+    monkeypatch.setattr(watchlistAPI, "_bulk_delete", lambda *a, **k: called.append((a, k)))
+
+    resp = watchlistAPI.api_watchlist_delete_multi(
+        request=request,
+        payload={"provider": "PLEX", "provider_instance": "PLEX-P01", "keys": ["tmdb:603"]},
+    )
+
+    assert resp.status_code == 403
+    assert json.loads(resp.body.decode("utf-8"))["error"] == "profile_scope_denied"
+    assert called == []
+
+
+def test_managed_user_can_delete_own_instance(monkeypatch) -> None:
+    from api import watchlistAPI
+
+    request, _cfg_obj = _managed_request(monkeypatch)
+    seen: dict = {}
+
+    def _fake(provider, keys, provider_instance=None, allowed_instances=None):
+        seen.update(provider=provider, keys=keys, instance=provider_instance, allowed=allowed_instances)
+        return {"ok": True}
+
+    monkeypatch.setattr(watchlistAPI, "_bulk_delete", _fake)
+
+    out = watchlistAPI.api_watchlist_delete_multi(
+        request=request,
+        payload={"provider": "PLEX", "provider_instance": "PLEX-P02", "keys": ["tmdb:603"]},
+    )
+
+    assert out == {"ok": True}
+    assert seen["provider"] == "PLEX"
+    assert seen["instance"] == "PLEX-P02"
+    assert seen["allowed"] == {"PLEX": ["PLEX-P02"]}
+
+
+def test_managed_user_all_provider_is_scoped_to_own_instances(monkeypatch) -> None:
+    from api import watchlistAPI
+
+    request, _cfg_obj = _managed_request(monkeypatch)
+    seen: dict = {}
+
+    def _fake(provider, keys, provider_instance=None, allowed_instances=None):
+        seen.update(provider=provider, allowed=allowed_instances)
+        return {"ok": True}
+
+    monkeypatch.setattr(watchlistAPI, "_bulk_delete", _fake)
+
+    watchlistAPI.api_watchlist_delete_multi(request=request, payload={"provider": "ALL", "keys": ["tmdb:603"]})
+
+    assert seen["provider"] == "ALL"
+    assert seen["allowed"] == {"PLEX": ["PLEX-P02"]}
+
+
+def test_admin_delete_stays_unscoped(monkeypatch) -> None:
+    from api import appAuthAPI as auth
+    from api import watchlistAPI
+    import cw_platform.config_base as config_base
+    import cw_platform.provider_instances as provider_instances
+
+    cfg = _cfg(auth)
+    provider_instances.ensure_provider_instance_uids(cfg)
+    monkeypatch.setattr(config_base, "load_config", lambda: cfg)
+    seen: dict = {}
+
+    def _fake(provider, keys, provider_instance=None, allowed_instances=None):
+        seen.update(allowed=allowed_instances)
+        return {"ok": True}
+
+    monkeypatch.setattr(watchlistAPI, "_bulk_delete", _fake)
+
+    watchlistAPI.api_watchlist_delete_multi(
+        request=_request("/api/watchlist/delete"),
+        payload={"provider": "ALL", "keys": ["tmdb:603"]},
+    )
+
+    assert seen["allowed"] is None
+
+
+def test_delete_watchlist_batch_never_loads_foreign_instance_credentials(monkeypatch) -> None:
+    import services.watchlist as wl
+
+    state = {
+        "providers": {
+            "PLEX": {
+                "instances": {
+                    "PLEX-P01": {"watchlist": {"baseline": {"items": {"tmdb:603": {"title": "A"}}}}},
+                    "PLEX-P02": {"watchlist": {"baseline": {"items": {"tmdb:603": {"title": "A"}}}}},
+                }
+            }
+        }
+    }
+    views: list = []
+    monkeypatch.setattr(wl, "build_config_view", lambda cfg, sel: views.append(sel) or {})
+    monkeypatch.setattr(wl, "_registry_sync_providers", lambda: ["PLEX", "TRAKT"])
+    monkeypatch.setattr(wl, "_delete_on_plex_batch", lambda *a, **k: None)
+    monkeypatch.setattr(wl, "_save_sync_state", lambda *a, **k: None)
+
+    wl.delete_watchlist_batch(
+        ["tmdb:603"],
+        "ALL",
+        state,
+        {},
+        allowed_instances={"PLEX": ["PLEX-P02"]},
+    )
+
+    assert views == [{"PLEX": "PLEX-P02"}]


### PR DESCRIPTION
# Pull request

## Change

Scope watchlist and wall results to the active user profile.

## Why

Managed users should only see and delete items from provider instances assigned to their profile.

## Testing

- tests/test_watchlist_api.py 
- tests/test_watchlist_delete_scope.py 
- tests/test_wall_api.py

## Issue

Relates to #728