### PR TITLE
Add: playback progress by profile

### DIFF
--- a/api/playbackProgressAPI.py
+++ b/api/playbackProgressAPI.py
@@ -3,29 +3,44 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
-from fastapi import APIRouter, Body, Query
+from fastapi import APIRouter, Body, Query, Request
 from fastapi.responses import JSONResponse
 
 from services.playback_progress import get_service
 from services.playback_progress.models import utc_now_iso
+from cw_platform.config_base import load_config
+from cw_platform.provider_instances import instances_for_user_profile
 
 router = APIRouter(prefix="/api/playback_progress", tags=["playback_progress"])
 
 
+def _playback_user_filter(request: Request | None, requested_profile: str = "") -> dict[str, list[str]]:
+    try:
+        from api.appAuthAPI import COOKIE_NAME, effective_user_profile_id
+        cfg = load_config() or {}
+        token = request.cookies.get(COOKIE_NAME) if request is not None else None
+        profile = effective_user_profile_id(cfg, token, requested_profile)
+        if not str(profile or "").strip():
+            return {}
+        return instances_for_user_profile(cfg, profile) or {"__NONE__": ["__NONE__"]}
+    except Exception:
+        return {"__NONE__": ["__NONE__"]}
+
+
 @router.get("/providers")
-def api_playback_progress_providers() -> dict[str, Any]:
+def api_playback_progress_providers(request: Request = cast(Request, None), user_profile: str = Query("")) -> dict[str, Any]:
     service = get_service()
     return {
-        "providers": [cap.to_dict() for cap in service.capabilities()],
+        "providers": [cap.to_dict() for cap in service.capabilities(user_filter=_playback_user_filter(request, user_profile))],
         "refreshed_at": utc_now_iso(),
     }
 
 
 @router.get("/settings")
-def api_playback_progress_settings() -> dict[str, Any]:
-    return get_service().settings()
+def api_playback_progress_settings(request: Request = cast(Request, None), user_profile: str = Query("")) -> dict[str, Any]:
+    return get_service().settings(user_filter=_playback_user_filter(request, user_profile))
 
 
 @router.post("/settings")
@@ -36,6 +51,7 @@ def api_playback_progress_save_settings(payload: dict[str, Any] = Body(...)) -> 
 
 @router.get("/items")
 def api_playback_progress_items(
+    request: Request = cast(Request, None),
     provider: str | None = Query(None),
     instance_id: str | None = Query(None),
     media_type: str | None = Query(None),
@@ -48,6 +64,7 @@ def api_playback_progress_items(
     page: int = Query(1, ge=1),
     page_size: int = Query(50, ge=1, le=250),
     force_refresh: bool = Query(False),
+    user_profile: str = Query(""),
 ) -> dict[str, Any]:
     service = get_service()
     return service.items(
@@ -63,27 +80,34 @@ def api_playback_progress_items(
         page=page,
         page_size=page_size,
         force_refresh=force_refresh,
+        user_filter=_playback_user_filter(request, user_profile),
     )
 
 
+def _action_status(result: dict[str, Any]) -> int:
+    if result.get("ok"):
+        return 200
+    return 403 if result.get("error_code") == "profile_scope_denied" else 400
+
+
 @router.post("/actions/remove")
-def api_playback_progress_remove(payload: dict[str, Any] = Body(...)) -> JSONResponse:
-    result = get_service().remove(payload)
-    return JSONResponse(result, status_code=200 if result.get("ok") else 400)
+def api_playback_progress_remove(request: Request = cast(Request, None), payload: dict[str, Any] = Body(...)) -> JSONResponse:
+    result = get_service().remove(payload, user_filter=_playback_user_filter(request))
+    return JSONResponse(result, status_code=_action_status(result))
 
 
 @router.post("/actions/mark_watched")
-def api_playback_progress_mark_watched(payload: dict[str, Any] = Body(...)) -> JSONResponse:
-    result = get_service().mark_watched(payload)
-    return JSONResponse(result, status_code=200 if result.get("ok") else 400)
+def api_playback_progress_mark_watched(request: Request = cast(Request, None), payload: dict[str, Any] = Body(...)) -> JSONResponse:
+    result = get_service().mark_watched(payload, user_filter=_playback_user_filter(request))
+    return JSONResponse(result, status_code=_action_status(result))
 
 
 @router.post("/actions/update_progress")
-def api_playback_progress_update_progress(payload: dict[str, Any] = Body(...)) -> JSONResponse:
-    result = get_service().update_progress(payload)
-    return JSONResponse(result, status_code=200 if result.get("ok") else 400)
+def api_playback_progress_update_progress(request: Request = cast(Request, None), payload: dict[str, Any] = Body(...)) -> JSONResponse:
+    result = get_service().update_progress(payload, user_filter=_playback_user_filter(request))
+    return JSONResponse(result, status_code=_action_status(result))
 
 
 @router.post("/actions/bulk")
-def api_playback_progress_bulk(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
-    return get_service().bulk(payload)
+def api_playback_progress_bulk(request: Request = cast(Request, None), payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
+    return get_service().bulk(payload, user_filter=_playback_user_filter(request))

--- a/assets/js/playback_progress.js
+++ b/assets/js/playback_progress.js
@@ -22,6 +22,10 @@
   };
   const PLAYBACK_PROVIDER_KEYS = ["crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "punchplay", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy"];
   const DEFAULT_PROVIDER_TIMEOUT_SECONDS = 20;
+  const isManagedUser = () => document.documentElement?.dataset?.cwRole === "user";
+  const canWrite = () => document.documentElement?.dataset?.cwPermWrite === "on";
+  const isReadOnly = () => isManagedUser() && !canWrite();
+  const canEditSettings = () => !isManagedUser();
   const state = {
     mounted: false,
     page: 1,
@@ -413,6 +417,7 @@
   }
 
   async function openSettings() {
+    if (!canEditSettings()) return;
     const dlg = document.getElementById("pp-settings-dialog");
     const list = document.getElementById("pp-settings-list");
     const timeout = document.getElementById("pp-settings-timeout");
@@ -433,6 +438,7 @@
   }
 
   async function saveSettings() {
+    if (!canEditSettings()) return;
     const dlg = document.getElementById("pp-settings-dialog");
     const list = document.getElementById("pp-settings-list");
     const timeout = document.getElementById("pp-settings-timeout");
@@ -610,9 +616,10 @@
     if (!state.errors.length) return el.classList.add("hidden");
     const count = state.errors.length;
     const partial = state.items.length > 0;
+    const settingsAction = canEditSettings() ? `<button class="pp-btn" type="button" data-pp-error-action="settings">${icon("settings")}Settings</button>` : "";
     el.innerHTML = `<div class="pp-error-head">
       <div><div class="pp-error-title">${icon(partial ? "sync_problem" : "error")}<span>${partial ? "Some providers could not refresh" : "Playback Progress could not refresh"}</span></div><div class="pp-error-copy">${partial ? "Showing available records from the providers that responded." : "Check the provider connection or try again in a moment."}</div></div>
-      <div class="pp-error-actions"><button class="pp-btn" type="button" data-pp-error-action="settings">${icon("settings")}Settings</button><button class="pp-btn" type="button" data-pp-error-action="retry">${icon("refresh")}Retry</button></div>
+      <div class="pp-error-actions">${settingsAction}<button class="pp-btn" type="button" data-pp-error-action="retry">${icon("refresh")}Retry</button></div>
     </div><div class="pp-error-list">${state.errors.slice(0, 6).map(errorItem).join("")}</div>${count > 6 ? `<div class="pp-error-copy">${esc(count - 6)} more provider notice${count - 6 === 1 ? "" : "s"} hidden.</div>` : ""}`;
     el.classList.remove("hidden");
   }
@@ -636,10 +643,11 @@
     const ratingText = fmtRating(it.rating);
     const ratingChip = ratingText ? `<span class="pp-rating-chip" title="Rating ${esc(ratingText)}" aria-label="Rating ${esc(ratingText)}">${icon("star")}${esc(ratingText)}</span>` : "";
     const timing = [remaining ? `<span>${esc(remaining)}</span>` : "", paused ? `<span class="${live ? "pp-live" : "pp-paused"}">${esc(paused)}</span>` : ""].filter(Boolean).join("");
-    const actionWatch = it.can_mark_watched ? `<button class="pp-btn pp-action-btn pp-action-watch" data-action="watch" data-key="${esc(key)}" title="Mark as watched" aria-label="Mark as watched">${icon("check_circle")}<span>Watched</span></button>` : "";
-    const actionEdit = it.can_update_progress ? `<button class="pp-btn pp-action-btn pp-action-edit" data-action="edit" data-key="${esc(key)}" title="Edit progress" aria-label="Edit progress">${icon("edit")}<span>Edit</span></button>` : "";
-    const actionRemove = it.can_remove_progress ? `<button class="pp-btn pp-action-btn pp-action-remove" data-action="remove" data-key="${esc(key)}" title="Remove progress" aria-label="Remove progress">${icon("delete")}<span>Remove</span></button>` : "";
-    return `<article class="pp-card${selected}" data-key="${esc(key)}" role="checkbox" aria-checked="${state.selected.has(key) ? "true" : "false"}" tabindex="0"${backdropStyle}>
+    const actionsAllowed = !isReadOnly();
+    const actionWatch = actionsAllowed && it.can_mark_watched ? `<button class="pp-btn pp-action-btn pp-action-watch" data-action="watch" data-key="${esc(key)}" title="Mark as watched" aria-label="Mark as watched">${icon("check_circle")}<span>Watched</span></button>` : "";
+    const actionEdit = actionsAllowed && it.can_update_progress ? `<button class="pp-btn pp-action-btn pp-action-edit" data-action="edit" data-key="${esc(key)}" title="Edit progress" aria-label="Edit progress">${icon("edit")}<span>Edit</span></button>` : "";
+    const actionRemove = actionsAllowed && it.can_remove_progress ? `<button class="pp-btn pp-action-btn pp-action-remove" data-action="remove" data-key="${esc(key)}" title="Remove progress" aria-label="Remove progress">${icon("delete")}<span>Remove</span></button>` : "";
+    return `<article class="pp-card${selected}" data-key="${esc(key)}"${actionsAllowed ? ` role="checkbox" aria-checked="${state.selected.has(key) ? "true" : "false"}" tabindex="0"` : ""}${backdropStyle}>
       <div class="pp-art"><img src="${esc(posterImg)}"${posterFallbackAttr} data-poster-key="${esc(posterKey)}" alt="" loading="lazy" decoding="async" onerror="const fallback=this.dataset.fallbackSrc;if(fallback){delete this.dataset.fallbackSrc;this.src=fallback}else{this.onerror=null;this.src='/assets/img/placeholder_poster.svg'}"></div>
       <div class="pp-body">
         <div class="pp-top">
@@ -656,6 +664,11 @@
 
   function updateBulk() {
     const bulk = document.getElementById("pp-bulk");
+    if (isReadOnly()) {
+      state.selected.clear();
+      bulk?.classList.add("hidden");
+      return;
+    }
     const count = state.selected.size;
     document.getElementById("pp-selected-count").textContent = String(count);
     bulk.classList.toggle("hidden", count === 0);
@@ -694,6 +707,8 @@
 
   function query(force = false, all = false) {
     const params = new URLSearchParams();
+    const profileId = String(window.CW?.OverviewProfile?.id || "").trim();
+    if (profileId) params.set("user_profile", profileId);
     const [provider, instance] = String(state.filters.provider || "").split(":");
     if (provider) params.set("provider", provider);
     if (instance) params.set("instance_id", instance);
@@ -755,6 +770,7 @@
   }
 
   async function act(action, item) {
+    if (isReadOnly()) return;
     const bulkAction = action === "watch" ? "mark_watched" : action === "edit" ? "update_progress" : "remove_progress";
     const payloads = actionPayloads([item], bulkAction);
     let progressPercent = null;
@@ -787,6 +803,7 @@
   }
 
   async function bulk(action) {
+    if (isReadOnly()) return;
     const selected = [...state.selected.values()];
     if (!selected.length) return;
     const allRecords = selected.flatMap((it) => recordsOf(it));
@@ -866,7 +883,7 @@
         return;
       }
       const card = e.target?.closest?.(".pp-card[data-key]");
-      if (card) {
+      if (card && !isReadOnly()) {
         const item = state.items.find((it) => recordKey(it) === card.dataset.key);
         if (!item) return;
         if (state.selected.has(card.dataset.key)) state.selected.delete(card.dataset.key);
@@ -880,6 +897,7 @@
         return;
       }
       if (e.key !== " " && e.key !== "Enter") return;
+      if (isReadOnly()) return;
       const card = e.target?.closest?.(".pp-card[data-key]");
       if (!card) return;
       e.preventDefault();
@@ -899,6 +917,9 @@
       bind();
       state.mounted = true;
     }
+    el.classList.toggle("is-readonly", isReadOnly());
+    document.getElementById("pp-settings")?.classList.toggle("hidden", !canEditSettings());
+    if (isReadOnly()) state.selected.clear();
     startSyncClock();
     load(false);
   }
@@ -908,6 +929,12 @@
     if ((e.detail?.id || e.detail?.tab) === "playback_progress") mount();
   });
   window.addEventListener("currently-watching-updated", () => {
+    const page = document.getElementById("page-playback_progress");
+    if (page && !page.classList.contains("hidden")) load(false);
+  });
+  window.addEventListener("cw:overview-profile-changed", () => {
+    state.selected.clear();
+    state.page = 1;
     const page = document.getElementById("page-playback_progress");
     if (page && !page.classList.contains("hidden")) load(false);
   });

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -706,6 +706,17 @@ def _profile_key(provider: Any, instance_id: Any) -> str:
     return f"{str(provider or '').strip().lower()}:{normalize_instance_id(instance_id)}"
 
 
+def _user_filter_allows(user_filter: Mapping[str, Any] | None, provider: Any, instance_id: Any) -> bool:
+    if not isinstance(user_filter, Mapping) or not user_filter:
+        return True
+    prov = str(provider or "").strip().upper()
+    allowed = user_filter.get(prov)
+    if not isinstance(allowed, list):
+        return False
+    inst = normalize_instance_id(instance_id)
+    return inst in {normalize_instance_id(value) for value in allowed}
+
+
 def _path_value(block: Mapping[str, Any], path: str) -> Any:
     value: Any = block
     for part in path.split("."):
@@ -836,12 +847,14 @@ class PlaybackProgressService:
         provider_key = str(provider or "").strip().lower()
         return self.adapters.get(provider_key)
 
-    def provider_instances(self, cfg: Mapping[str, Any] | None = None) -> list[dict[str, str]]:
+    def provider_instances(self, cfg: Mapping[str, Any] | None = None, user_filter: Mapping[str, Any] | None = None) -> list[dict[str, str]]:
         config = cfg or load_config()
         out: list[dict[str, str]] = []
         for provider in PHASE1_PROVIDERS:
             for instance_id in list_instance_ids(config, provider):
                 inst = normalize_instance_id(instance_id)
+                if not _user_filter_allows(user_filter, provider, inst):
+                    continue
                 if not _profile_has_explicit_identity(config, provider, inst):
                     continue
                 out.append(
@@ -853,10 +866,10 @@ class PlaybackProgressService:
                 )
         return out
 
-    def capabilities(self, cfg: Mapping[str, Any] | None = None) -> list[PlaybackCapabilities]:
+    def capabilities(self, cfg: Mapping[str, Any] | None = None, user_filter: Mapping[str, Any] | None = None) -> list[PlaybackCapabilities]:
         config = cfg or load_config()
         out: list[PlaybackCapabilities] = []
-        for spec in self.provider_instances(config):
+        for spec in self.provider_instances(config, user_filter=user_filter):
             provider = spec["provider"]
             adapter = self._adapter(provider)
             if not adapter:
@@ -996,19 +1009,20 @@ class PlaybackProgressService:
         page: int = 1,
         page_size: int = 50,
         force_refresh: bool = False,
+        user_filter: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
         cfg = load_config()
         provider_filter = str(provider or "").strip().lower()
         instance_filter = normalize_instance_id(instance_id) if instance_id else ""
         specs = [
             spec
-            for spec in self.provider_instances(cfg)
+            for spec in self.provider_instances(cfg, user_filter=user_filter)
             if (not provider_filter or spec["provider"] == provider_filter)
             and (not instance_filter or spec["instance_id"] == instance_filter)
         ]
         readable_specs: list[dict[str, str]] = []
         skipped_errors: list[dict[str, Any]] = []
-        capabilities = self.capabilities(cfg)
+        capabilities = self.capabilities(cfg, user_filter=user_filter)
         cap_by_key = {(cap.provider, cap.instance_id): cap for cap in capabilities}
         for spec in specs:
             cap = cap_by_key.get((spec["provider"], spec["instance_id"]))
@@ -1081,11 +1095,11 @@ class PlaybackProgressService:
             "refreshed_at": utc_now_iso(),
         }
 
-    def settings(self, cfg: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    def settings(self, cfg: Mapping[str, Any] | None = None, user_filter: Mapping[str, Any] | None = None) -> dict[str, Any]:
         config = cfg or load_config()
         disabled = _disabled_profiles(config)
         profiles = []
-        for cap in self.capabilities(config):
+        for cap in self.capabilities(config, user_filter=user_filter):
             key = _profile_key(cap.provider, cap.instance_id)
             profiles.append(
                 {
@@ -1223,10 +1237,16 @@ class PlaybackProgressService:
             return None, {}, inst
         return adapter, build_provider_config_view(cfg, provider_key, inst), inst
 
-    def remove(self, payload: Mapping[str, Any]) -> dict[str, Any]:
-        cfg = load_config()
+    def _scope_denied(self, provider: str, instance_id: str, operation: str) -> dict[str, Any]:
+        LOG.warn(f"{operation} denied by profile scope provider={provider} instance={instance_id}")
+        return PlaybackActionResult(False, provider, instance_id, operation, error_code="profile_scope_denied", message="This provider instance is not assigned to your profile.").to_dict()
+
+    def remove(self, payload: Mapping[str, Any], *, user_filter: Mapping[str, Any] | None = None) -> dict[str, Any]:
         provider = str(payload.get("provider") or "").lower()
         instance_id = normalize_instance_id(payload.get("instance_id"))
+        if not _user_filter_allows(user_filter, provider, instance_id):
+            return self._scope_denied(provider, instance_id, "remove_progress")
+        cfg = load_config()
         record_value = payload.get("record")
         record = _as_mapping(record_value) if isinstance(record_value, Mapping) else payload
         adapter, config_view, inst = self._adapter_for_action(cfg, provider, instance_id)
@@ -1243,10 +1263,12 @@ class PlaybackProgressService:
             LOG.warn(f"remove progress failed provider={provider} instance={inst} error={result.error_code or 'provider_error'}")
         return result.to_dict()
 
-    def mark_watched(self, payload: Mapping[str, Any]) -> dict[str, Any]:
-        cfg = load_config()
+    def mark_watched(self, payload: Mapping[str, Any], *, user_filter: Mapping[str, Any] | None = None) -> dict[str, Any]:
         provider = str(payload.get("provider") or "").lower()
         instance_id = normalize_instance_id(payload.get("instance_id"))
+        if not _user_filter_allows(user_filter, provider, instance_id):
+            return self._scope_denied(provider, instance_id, "mark_watched")
+        cfg = load_config()
         record_value = payload.get("record")
         record = _as_mapping(record_value) if isinstance(record_value, Mapping) else payload
         adapter, config_view, inst = self._adapter_for_action(cfg, provider, instance_id)
@@ -1280,7 +1302,7 @@ class PlaybackProgressService:
             return PlaybackActionResult(True, provider, instance_id, "remove_progress", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), message="Cleanup skipped because remove progress is unsupported.")
         return adapter.remove_progress(config_view, record, instance_id=instance_id, instance_label=instance_label)
 
-    def bulk(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+    def bulk(self, payload: Mapping[str, Any], *, user_filter: Mapping[str, Any] | None = None) -> dict[str, Any]:
         action = str(payload.get("action") or "").strip().lower()
         items_value = payload.get("items")
         items: list[Any] = items_value if isinstance(items_value, list) else []
@@ -1295,19 +1317,19 @@ class PlaybackProgressService:
                 if not record.get("can_remove_progress"):
                     results.append({"ok": False, "provider": item.get("provider"), "instance_id": item.get("instance_id"), "operation": action, "remote_id": item.get("remote_id"), "canonical_key": item.get("canonical_key"), "error_code": "unsupported", "message": "Remove Progress is unsupported for this record."})
                     continue
-                results.append(self.remove(item))
+                results.append(self.remove(item, user_filter=user_filter))
             elif action == "mark_watched":
                 if not record.get("can_mark_watched"):
                     results.append({"ok": False, "provider": item.get("provider"), "instance_id": item.get("instance_id"), "operation": action, "remote_id": item.get("remote_id"), "canonical_key": item.get("canonical_key"), "error_code": "unsupported", "message": "Mark as Watched is unsupported for this record."})
                     continue
-                results.append(self.mark_watched(item))
+                results.append(self.mark_watched(item, user_filter=user_filter))
             elif action == "update_progress":
                 if not record.get("can_update_progress"):
                     results.append({"ok": False, "provider": item.get("provider"), "instance_id": item.get("instance_id"), "operation": action, "remote_id": item.get("remote_id"), "canonical_key": item.get("canonical_key"), "error_code": "unsupported", "message": "Edit Progress is unsupported for this record."})
                     continue
                 update_item = dict(item)
                 update_item["progress_percent"] = payload.get("progress_percent")
-                results.append(self.update_progress(update_item))
+                results.append(self.update_progress(update_item, user_filter=user_filter))
             else:
                 results.append({"ok": False, "operation": action, "error_code": "unsupported_action", "message": "Unsupported bulk action."})
         successful = sum(1 for r in results if r.get("ok"))
@@ -1322,9 +1344,11 @@ class PlaybackProgressService:
             "unsupported": unsupported,
         }
 
-    def update_progress(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+    def update_progress(self, payload: Mapping[str, Any], *, user_filter: Mapping[str, Any] | None = None) -> dict[str, Any]:
         provider = str(payload.get("provider") or "").lower()
         instance_id = normalize_instance_id(payload.get("instance_id"))
+        if not _user_filter_allows(user_filter, provider, instance_id):
+            return self._scope_denied(provider, instance_id, "update_progress")
         cfg = load_config()
         record_value = payload.get("record")
         record = _as_mapping(record_value) if isinstance(record_value, Mapping) else payload

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -14,6 +14,7 @@ from services.playback_progress.service import (
     _profile_has_explicit_identity,
     _record_group_keys,
     _share_artwork_metadata,
+    _user_filter_allows,
     _validated_progress_percent,
     PlaybackProgressService,
 )
@@ -82,6 +83,36 @@ def test_playback_progress_frontend_includes_kodi_provider_key():
     keys = js.split("PLAYBACK_PROVIDER_KEYS")[1].split("]")[0]
     for provider in ("crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy"):
         assert f'"{provider}"' in keys, provider
+
+
+def test_playback_progress_frontend_is_readonly_for_managed_users():
+    js = (ROOT / "assets" / "js" / "playback_progress.js").read_text(encoding="utf-8")
+
+    assert 'document.documentElement?.dataset?.cwRole === "user"' in js
+    assert "if (isReadOnly()) return;" in js
+    assert "user_profile" in js
+    assert "window.CW?.OverviewProfile?.id" in js
+    assert 'window.addEventListener("cw:overview-profile-changed"' in js
+    assert "CARD.cacheScope" not in js
+
+
+def test_playback_progress_provider_instances_respect_user_filter():
+    service = PlaybackProgressService()
+    cfg = {
+        "plex": {
+            "instances": {
+                "PLEX-P01": {"server_url": "http://plex-a"},
+                "PLEX-P02": {"server_url": "http://plex-b"},
+            }
+        },
+        "trakt": {"access_token": "token"},
+    }
+
+    specs = service.provider_instances(cfg, user_filter={"PLEX": ["PLEX-P02"]})
+
+    assert _user_filter_allows({"PLEX": ["PLEX-P02"]}, "plex", "PLEX-P02") is True
+    assert _user_filter_allows({"PLEX": ["PLEX-P02"]}, "plex", "PLEX-P01") is False
+    assert [(row["provider"], row["instance_id"]) for row in specs] == [("plex", "PLEX-P02")]
 
 
 class _PolicyOps:
@@ -259,7 +290,7 @@ def test_media_server_episode_metadata_resolution_passes_show_year():
             "progress_ms": 1119000,
             "duration_ms": 2675904,
         },
-        metadata,
+        cast(TmdbProvider, metadata),
         "P01",
         "Plex P01",
         caps,
@@ -1216,8 +1247,10 @@ def test_tmdb_metadata_provider_is_reused_across_refreshes():
     cfg = {"tmdb": {"api_key": "shared-key"}, "metadata": {"ttl_hours": 720}}
 
     first = base_adapter.tmdb_metadata_provider(cfg)
+    assert first is not None
     first._cache["probe"] = (time.time(), {"cached": True})
     second = base_adapter.tmdb_metadata_provider(cfg)
+    assert second is not None
 
     assert first is second
     assert "probe" in second._cache


### PR DESCRIPTION
# Pull request

## Change

Scope playback progress providers, items, and actions to the active user profile.

## Why

Managed users should only see and update playback records from their assigned provider instances.

## Testing

- tests/test_playback_progress.py

## Issue

Relates to #728