### PR TITLE
Add: dashboard data by profile

### DIFF
--- a/api/dashboardAPI.py
+++ b/api/dashboardAPI.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude
 from __future__ import annotations
 
-from fastapi import APIRouter, Query
+from typing import cast
+
+from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
 
 from services.dashboard_widgets import dashboard_widgets_payload
@@ -13,20 +15,31 @@ router = APIRouter(prefix="/api/dashboard", tags=["dashboard"])
 
 @router.get("/widgets")
 def dashboard_widgets(
+    request: Request = cast(Request, None),
     history_limit: int = Query(8, ge=1, le=24),
     ratings_limit: int = Query(12, ge=1, le=24),
     scrobble_limit: int = Query(8, ge=1, le=24),
     progress_limit: int = Query(8, ge=1, le=24),
     playlists_limit: int = Query(8, ge=1, le=24),
     include: str = Query("history,ratings,scrobble,progress,playlists"),
+    user_profile: str = Query("", alias="user_profile"),
 ) -> JSONResponse:
     try:
-        from cw_platform.config_base import CONFIG
+        from cw_platform.config_base import CONFIG, load_config
         from cw_platform.orchestrator._state_store import StateStore
+        from api.appAuthAPI import COOKIE_NAME, effective_user_profile_id
+        from cw_platform.provider_instances import instances_for_user_profile
 
         requested = {part.strip() for part in include.split(",") if part.strip()}
         state_features = requested & {"history", "ratings", "progress"}
         state = StateStore(CONFIG).load_state_features(state_features) if state_features else {}
+        cfg = load_config() or {}
+        token = request.cookies.get(COOKIE_NAME) if request is not None else None
+        profile = effective_user_profile_id(cfg, token, user_profile)
+        scoped = bool(str(profile or "").strip())
+        user_filter = instances_for_user_profile(cfg, profile) if scoped else {}
+        if scoped and not user_filter:
+            user_filter = {"__NONE__": ["__NONE__"]}
         payload = dashboard_widgets_payload(
             state,
             history_limit=history_limit,
@@ -35,7 +48,10 @@ def dashboard_widgets(
             progress_limit=progress_limit,
             playlists_limit=playlists_limit,
             include=requested,
+            user_filter=user_filter,
         )
+        if scoped:
+            payload["user_profile"] = str(profile or "").strip()
         return JSONResponse(payload, headers={"Cache-Control": "no-store"})
     except Exception:
         return JSONResponse(

--- a/api/scrobbleAPI.py
+++ b/api/scrobbleAPI.py
@@ -9,14 +9,16 @@ import secrets
 import hmac
 import urllib.parse
 import xml.etree.ElementTree as ET
-from typing import Any
+from typing import Any, cast
 
 from fastapi import APIRouter, Query, Request, HTTPException, Body
 from fastapi.responses import JSONResponse
 from urllib.parse import parse_qs
 
+from cw_platform.account_match import media_account_allowed
+from cw_platform.access_policy import media_account_allowlist_for_profile
 from cw_platform.config_base import load_config, save_config
-from cw_platform.provider_instances import build_provider_config_view, list_instance_ids, normalize_instance_id
+from cw_platform.provider_instances import build_provider_config_view, instances_for_user_profile, list_instance_ids, normalize_instance_id
 from cw_platform.provider_usage import webhook_source_enabled
 from providers.webhooks.config import apply_webhook_settings, media_source_connected, webhook_sinks
 from providers.scrobble.routes import build_route_cfg_by_id, normalize_route_options, normalize_routes
@@ -487,7 +489,7 @@ async def api_webhook_regenerate(payload: dict[str, Any] | None = Body(default=N
     )
 
 
-def _env_logs(request: Request | None = None) -> tuple[dict[str, list[str]], int]:
+def _env_logs(request: Request = cast(Request, None)) -> tuple[dict[str, list[str]], int]:
     if request is not None:
         try:
             lb = getattr(request.app.state, "LOG_BUFFERS", None)
@@ -1091,11 +1093,67 @@ def api_plex_pms(instance: str | None = Query(None)) -> JSONResponse:
 
 
 
+def _currently_watching_user_filter(cfg: dict[str, Any], request: Request | None, requested_profile: Any) -> dict[str, Any]:
+    try:
+        from api.appAuthAPI import COOKIE_NAME, effective_user_profile_id
+        token = request.cookies.get(COOKIE_NAME) if request is not None else None
+        profile = effective_user_profile_id(cfg, token, requested_profile)
+    except Exception:
+        profile = "__none__"
+    if not str(profile or "").strip():
+        return {}
+    user_filter = instances_for_user_profile(cfg, profile)
+    return {
+        "instances": user_filter if user_filter else {"__NONE__": ["__NONE__"]},
+        "accounts": media_account_allowlist_for_profile(cfg, profile),
+    }
+
+
+def _currently_watching_provider(value: Any) -> str:
+    raw = str(value or "").strip().upper()
+    if raw in {"PLEXWATCHER", "PLEXTRAKT"}:
+        return "PLEX"
+    if raw in {"JELLYFINTRAKT"}:
+        return "JELLYFIN"
+    if raw in {"EMBYTRAKT"}:
+        return "EMBY"
+    return raw
+
+
+def _currently_watching_matches_user(item: dict[str, Any], user_filter: dict[str, Any]) -> bool:
+    if not user_filter:
+        return True
+    instance_filter = user_filter.get("instances") if isinstance(user_filter.get("instances"), dict) else user_filter
+    account_filter = user_filter.get("accounts") if isinstance(user_filter.get("accounts"), dict) else {}
+    provider = _currently_watching_provider(item.get("source") or item.get("provider") or item.get("source_provider"))
+    instance = normalize_instance_id(item.get("provider_instance") or item.get("source_instance") or item.get("instance"))
+    allowed = {normalize_instance_id(v) for v in instance_filter.get(provider, [])} if isinstance(instance_filter, dict) else set()
+    if not bool(provider and instance in allowed):
+        return False
+    allow = []
+    explicit_account_scope = False
+    if isinstance(account_filter, dict):
+        by_provider = account_filter.get(provider)
+        if isinstance(by_provider, dict):
+            explicit_account_scope = instance in by_provider
+            allow = by_provider.get(instance) or []
+    if not allow:
+        return not explicit_account_scope
+    return media_account_allowed(
+        allow,
+        item.get("account") or item.get("username") or item.get("user") or "",
+        account_id=item.get("account_id") or item.get("user_id") or "",
+        account_uuid=item.get("account_uuid") or item.get("user_uuid") or "",
+    )
+
+
 @router.get("/api/watch/currently_watching")
-def api_currently_watching() -> JSONResponse:
+def api_currently_watching(request: Request = cast(Request, None), user_profile: str = Query("")) -> JSONResponse:
     data: Any = None
     streams: list[dict[str, Any]] = []
     streams_count = 0
+    cfg = load_config() or {}
+    user_filter = _currently_watching_user_filter(cfg, request, user_profile)
     try:
         data = _cw_load_state()
     except Exception as e:
@@ -1131,6 +1189,9 @@ def api_currently_watching() -> JSONResponse:
                 return (active_rank, -int(it.get("updated") or 0))
 
             active_items = [it for it in items if _is_active(it.get("state"))]
+            if user_filter:
+                items = [it for it in items if _currently_watching_matches_user(it, user_filter)]
+                active_items = [it for it in active_items if _currently_watching_matches_user(it, user_filter)]
             active_items.sort(key=_prio)
             streams = active_items or items
             streams_count = len(active_items)
@@ -1139,6 +1200,11 @@ def api_currently_watching() -> JSONResponse:
             data = primary
         except Exception:
             pass
+
+    if user_filter and isinstance(data, dict) and not _currently_watching_matches_user(data, user_filter):
+        data = None
+        streams = []
+        streams_count = 0
 
     if not streams_count:
         streams_count = len(streams) if streams else (1 if isinstance(data, dict) and data.get("title") else 0)

--- a/assets/js/dashboard-widgets.js
+++ b/assets/js/dashboard-widgets.js
@@ -14,6 +14,7 @@
   let dirtyVersion = 1;
   let lastLoadedAt = 0;
   let lastSettings = null;
+  let currentConfig = null;
   let scrobbleStopRefreshTimer = null;
   const PAGE_STEP = 9;
   const RATING_PAGE_STEP = 9;
@@ -36,7 +37,8 @@
     watchlist: { title: "No watchlist items yet", copy: "Synced watchlist titles will appear here." },
     error: { title: "Could not load this widget", copy: "Try refreshing again in a moment." },
   };
-  const LAYOUT_KEY = "cw.dashboardWidgets.layout.v3";
+  const ON_PROFILE_PAGE = !!document.getElementById("profile-hero");
+  const LAYOUT_KEY = ON_PROFILE_PAGE ? "cw.profileWidgets.layout.v1" : "cw.dashboardWidgets.layout.v3";
   const SETTINGS_KEY = "cw.dashboardWidgets.settings.v1";
   const WIDGETS = [
     { key: "watchlist", id: "placeholder-card", label: "Watchlist" },
@@ -390,12 +392,29 @@
     throw lastError || new Error("dashboard_widgets_failed");
   }
 
+  function overviewProfileId() {
+    return String(window.CW?.OverviewProfile?.id || "").trim();
+  }
+
   async function getConfig(force = false) {
     if (cfgPromise) return cfgPromise;
     cfgPromise = (async () => {
       try {
         if (window.CW?.API?.Config?.load) return window.CW.API.Config.load(!!force);
-        return await fetchJSON("/api/config");
+        try {
+          if (document.documentElement?.dataset?.cwRole === "user") {
+            const meta = await fetchJSON("/api/config/meta");
+            const ui = meta && typeof meta.ui === "object" ? meta.ui : {};
+            return { ok: true, __public_meta: true, ui, user_interface: ui, tmdb_configured: meta?.tmdb_configured === true, tmdb: meta?.tmdb_configured === true ? { api_key: "configured" } : {} };
+          }
+          return await fetchJSON("/api/config");
+        } catch (e) {
+          const msg = String(e?.message || e || "");
+          if (!msg.includes("401") && !msg.includes("403")) throw e;
+          const meta = await fetchJSON("/api/config/meta");
+          const ui = meta && typeof meta.ui === "object" ? meta.ui : {};
+          return { ok: true, __public_meta: true, ui, user_interface: ui, tmdb_configured: meta?.tmdb_configured === true, tmdb: meta?.tmdb_configured === true ? { api_key: "configured" } : {} };
+        }
       } finally {
         window.setTimeout(() => { cfgPromise = null; }, 1500);
       }
@@ -404,6 +423,7 @@
   }
 
   function isOnMain() {
+    if (ON_PROFILE_PAGE) return true;
     const tab = String(document.documentElement.dataset.tab || "").toLowerCase();
     if (tab) return tab === "main";
     return !!document.getElementById("tab-main")?.classList.contains("active");
@@ -421,6 +441,7 @@
   }
 
   function hasTmdbKeyInConfig(cfg) {
+    if (cfg?.tmdb_configured === true) return true;
     const pickFromBlock = (block) => {
       if (!block || typeof block !== "object") return "";
       const direct = String(block.api_key || "").trim();
@@ -436,18 +457,63 @@
     return !!pickFromBlock(cfg?.tmdb);
   }
 
+  function configProviderBlock(provider) {
+    const key = String(provider || "").trim().toLowerCase();
+    if (!key || !currentConfig || typeof currentConfig !== "object") return null;
+    const keys = key === "crosswatch" ? ["crosswatch", "cw"] : key === "tmdb" ? ["tmdb_sync", "tmdb"] : [key];
+    for (const item of keys) {
+      const block = currentConfig[item];
+      if (block && typeof block === "object") return block;
+    }
+    return null;
+  }
+
+  function configuredInstanceLabel(provider, instance) {
+    const inst = String(instance || "default").trim() || "default";
+    const block = configProviderBlock(provider);
+    const node = inst.toLowerCase() === "default"
+      ? block
+      : (block?.instances && typeof block.instances === "object" ? block.instances[inst] : null);
+    const friendly = String(node?.label || "").trim();
+    if (friendly) return friendly;
+    return inst.toLowerCase() === "default" ? "Default" : inst;
+  }
+
   function hideDashboardWidgets() {
     $("#dashboard-widgets-card")?.classList.add("hidden");
   }
 
+  const LAYOUT_TOOLS = [
+    ["customize", "tune", "Customize widgets"],
+    ["show-all", "visibility", "Show all widgets"],
+    ["reset", "restart_alt", "Reset widget layout"],
+  ];
+
   function updateLayoutToolbar() {
     const card = $("#dashboard-widgets-card");
-    card?.classList.toggle("is-customizing", customizeOpen);
+    if (!card) return;
+    if (!ON_PROFILE_PAGE) {
+      customizeOpen = false;
+      card.classList.remove("is-customizing");
+      card.querySelector(".cw-dashboard-layout-toolbar")?.remove();
+      return;
+    }
+    card.classList.toggle("is-customizing", customizeOpen);
+    let bar = card.querySelector(".cw-dashboard-layout-toolbar");
+    if (!bar) {
+      bar = document.createElement("div");
+      bar.className = "cw-dashboard-layout-toolbar";
+      bar.innerHTML = `<div class="cw-dashboard-layout-tools">${LAYOUT_TOOLS.map(([action, icon, label]) => `
+        <button type="button" class="cw-dashboard-layout-btn" data-cw-dashboard-layout="${action}" title="${label}" aria-label="${label}"><span class="material-symbols-rounded" aria-hidden="true">${icon}</span></button>`).join("")}</div>`;
+      card.prepend(bar);
+    }
+    let hidden = 0;
+    try { hidden = hiddenWidgetCount(); } catch { hidden = 0; }
+    bar.classList.toggle("has-hidden", hidden > 0);
+    bar.querySelector('[data-cw-dashboard-layout="show-all"]')?.toggleAttribute("disabled", hidden === 0);
   }
 
   function ensureLayoutToolbar() {
-    const card = $("#dashboard-widgets-card");
-    card?.querySelector(".cw-dashboard-layout-toolbar")?.remove();
     updateLayoutToolbar();
   }
 
@@ -571,6 +637,10 @@
 
   function ensureWidgetControls() {
     const card = $("#dashboard-widgets-card");
+    if (!ON_PROFILE_PAGE) {
+      card?.querySelectorAll(".cw-dash-layout-controls").forEach((node) => node.remove());
+      return;
+    }
     if (card && !card.__cwDashboardDropWired) {
       card.addEventListener("dragover", (ev) => {
         if (dragWidgetKey) updateDashboardDragScroll(ev);
@@ -703,17 +773,19 @@
     for (const src of Array.isArray(sources) ? sources : []) {
       const provider = String(src?.provider || "").trim().toUpperCase();
       const instance = String(src?.instance || "default").trim() || "default";
+      const instanceLabel = String(src?.instance_label || src?.profile_label || src?.label || "").trim();
       const key = `${provider}:${instance}`;
       if (!provider || seen.has(key)) continue;
       seen.add(key);
-      rows.push({ provider, instance });
+      rows.push({ provider, instance, instanceLabel });
       if (rows.length >= max) break;
     }
     return rows;
   }
 
-  function sourceLabel({ provider, instance }) {
-    return instance.toLowerCase() === "default" ? providerLabel(provider) : `${providerLabel(provider)} (${instance})`;
+  function sourceLabel({ provider, instance, instanceLabel }) {
+    const label = String(instanceLabel || configuredInstanceLabel(provider, instance)).trim();
+    return instance.toLowerCase() === "default" && label === "Default" ? providerLabel(provider) : `${providerLabel(provider)} (${label})`;
   }
 
   function sourceRouteTitle(sources) {
@@ -724,9 +796,9 @@
   }
 
   function sourceIcons(sources, max = 4) {
-    return sourceRows(sources, max).map(({ provider, instance }) => {
+    return sourceRows(sources, max).map(({ provider, instance, instanceLabel }) => {
       const logo = providerLogo(provider);
-      const label = sourceLabel({ provider, instance });
+      const label = sourceLabel({ provider, instance, instanceLabel });
       return logo
         ? `<span class="cw-dash-source"><img src="${esc(logo)}" alt="${esc(label)} logo"></span>`
         : `<span class="cw-dash-source cw-dash-source--text" aria-label="${esc(label)}">${esc(providerShort(provider).slice(0, 3))}</span>`;
@@ -738,9 +810,9 @@
   }
 
   function ratingSourceIcons(sources, max = 3) {
-    return sourceRows(sources, max).map(({ provider, instance }) => {
+    return sourceRows(sources, max).map(({ provider, instance, instanceLabel }) => {
       const logo = providerLogo(provider);
-      const label = sourceLabel({ provider, instance });
+      const label = sourceLabel({ provider, instance, instanceLabel });
       return logo
         ? `<span class="cw-rating-provider-icon" title="${esc(label)}" aria-label="${esc(label)}"><img src="${esc(logo)}" alt=""></span>`
         : `<span class="cw-rating-provider-icon cw-rating-provider-icon--text" title="${esc(label)}" aria-label="${esc(label)}">${esc(providerShort(provider).slice(0, 3))}</span>`;
@@ -758,7 +830,7 @@
     const provider = String(source?.provider || "").trim().toUpperCase();
     if (!provider) return "";
     const instance = String(source?.instance || "default").trim() || "default";
-    const profile = scrobbleProfileLabel(instance);
+    const profile = String(source?.instanceLabel || source?.instance_label || source?.profile_label || "").trim() || scrobbleProfileLabel(instance);
     const providerName = providerLabel(provider);
     const logo = providerMeta().logLogoPath?.(provider) || providerLogo(provider);
     const providerIcon = logo
@@ -781,10 +853,11 @@
     const add = (row) => {
       const provider = String(row?.provider || "").trim().toUpperCase();
       const instance = String(row?.instance || "default").trim() || "default";
+      const instanceLabel = String(row?.instanceLabel || row?.instance_label || row?.profile_label || row?.label || "").trim();
       const key = `${provider}:${instance}`;
       if (!provider || seen.has(key)) return;
       seen.add(key);
-      rows.push({ provider, instance });
+      rows.push({ provider, instance, instanceLabel });
     };
     add(scrobbleSourceRow(item));
     sourceRows(item?.targets, 8)
@@ -965,8 +1038,8 @@
   }
 
   function detailSources(item) {
-    return sourceRows(item?.sources, 6).map(({ provider, instance }) => ({
-      label: sourceLabel({ provider, instance }),
+    return sourceRows(item?.sources, 6).map(({ provider, instance, instanceLabel }) => ({
+      label: sourceLabel({ provider, instance, instanceLabel }),
       short: providerShort(provider),
       logo: providerLogo(provider),
     }));
@@ -1468,6 +1541,7 @@
     if (forceConfig) cfgPromise = null;
     const seq = ++loadSeq;
     const refreshVersion = dirtyVersion;
+    try { await window.CW?.OverviewProfile?.ready; } catch {}
     let cfg;
     try {
       cfg = await getConfig(forceConfig);
@@ -1484,6 +1558,7 @@
       return;
     }
     const settings = widgetSettings(cfg?.ui || cfg?.user_interface || {});
+    currentConfig = cfg;
     lastSettings = settings;
     if (seq !== loadSeq || !isOnMain()) return;
     if (!preserve || !hasLoaded) {
@@ -1529,6 +1604,8 @@
         progress_limit: String(MAX_WIDGET_ITEMS),
         playlists_limit: String(MAX_WIDGET_ITEMS),
       });
+      const userProfile = overviewProfileId();
+      if (userProfile) params.set("user_profile", userProfile);
       const data = await fetchWidgetPayload(`/api/dashboard/widgets?${params.toString()}`);
       if (seq !== loadSeq || !isOnMain()) return;
 
@@ -1695,6 +1772,8 @@
       } else hideDashboardWidgets();
     });
     window.addEventListener("settings-changed", () => markWidgetsDirty(300, { forceConfig: true }));
+    window.addEventListener("cw-user-profiles-changed", () => markWidgetsDirty(150, { forceConfig: true, preserve: hasLoaded }));
+    window.addEventListener("cw:overview-profile-changed", () => markWidgetsDirty(0, { preserve: hasLoaded }));
     window.addEventListener("activity-log-cleared", () => markWidgetsDirty(100));
     window.addEventListener("sync-complete", () => markWidgetsDirty(250));
     window.addEventListener("cw:scrobble-stopped", scheduleScrobbleStopRefresh);

--- a/assets/js/main-status.js
+++ b/assets/js/main-status.js
@@ -85,6 +85,22 @@
     return false;
   }
 
+  function isManagedUser() {
+    const auth = window.CW?.AuthState?.read?.();
+    if (auth && typeof auth === "object") return !!auth.isManaged;
+    return document.documentElement?.dataset?.cwRole === "user";
+  }
+
+  function isStatusProviderVisible(key, data, cfg = getCachedConfig()) {
+    if (!data || typeof data !== "object") return false;
+    const managed = isManagedUser();
+    if (!managed && !isProviderConfigured(key, cfg)) return false;
+    const instances = data.instances && typeof data.instances === "object" ? data.instances : null;
+    const summary = data.instances_summary && typeof data.instances_summary === "object" ? data.instances_summary : null;
+    if (!!(instances && Object.keys(instances).length) || Number(summary?.total || 0) > 0) return true;
+    return isProviderConfigured(key, cfg);
+  }
+
   function ensureDot(head) {
     const existing = head.querySelector(".auth-dot");
     if (existing) return existing;
@@ -367,7 +383,7 @@
     host.classList.add("vip-badges");
     if (btn && host.contains(btn)) host.removeChild(btn);
 
-    const keys = Object.keys(providers).filter((k) => isProviderConfigured(k, cfg)).sort();
+    const keys = Object.keys(providers).filter((k) => isStatusProviderVisible(k, providers[k], cfg)).sort();
     const none = !keys.length;
     host.classList.toggle("hidden", none);
     if (none) {

--- a/services/dashboard_widgets.py
+++ b/services/dashboard_widgets.py
@@ -9,6 +9,7 @@ import re
 from typing import Any, Iterable, Mapping
 
 from services.activity import list_events
+from cw_platform.provider_instances import normalize_instance_id, provider_display_key
 
 try:
     from _logging import log as _cw_log
@@ -652,7 +653,45 @@ def _resolve_missing_art_rows(
 
 
 def _provider_ref(provider: str, instance: str) -> dict[str, str]:
-    return {"provider": str(provider or "").upper(), "instance": str(instance or _DEFAULT_INSTANCE)}
+    return {"provider": provider_display_key(provider), "instance": normalize_instance_id(instance)}
+
+
+def _normalize_user_filter(user_filter: Mapping[str, Any] | None) -> dict[str, set[str]]:
+    if not isinstance(user_filter, Mapping):
+        return {}
+    out: dict[str, set[str]] = {}
+    for provider, raw_instances in user_filter.items():
+        prov = provider_display_key(provider)
+        if not prov:
+            continue
+        values = raw_instances if isinstance(raw_instances, list) else [raw_instances]
+        instances = {normalize_instance_id(instance) for instance in values if str(instance or "").strip()}
+        if instances:
+            out[prov] = instances
+    return out
+
+
+def _endpoint_matches_user(provider: Any, instance: Any, user_filter: Mapping[str, Any] | None) -> bool:
+    filt = _normalize_user_filter(user_filter)
+    if not filt:
+        return True
+    prov = provider_display_key(provider)
+    return bool(prov) and normalize_instance_id(instance) in filt.get(prov, set())
+
+
+def _sources_match_user(sources: Any, user_filter: Mapping[str, Any] | None) -> bool:
+    filt = _normalize_user_filter(user_filter)
+    if not filt:
+        return True
+    if not isinstance(sources, list):
+        return False
+    for source in sources:
+        if not isinstance(source, Mapping):
+            continue
+        prov = provider_display_key(source.get("provider"))
+        if prov and normalize_instance_id(source.get("instance")) in filt.get(prov, set()):
+            return True
+    return False
 
 
 def _sources_from_item(item: Mapping[str, Any], *, default_provider: str = "CROSSWATCH") -> list[dict[str, str]]:
@@ -779,6 +818,14 @@ def _merge_rating_row(prev: Mapping[str, Any], row: Mapping[str, Any]) -> dict[s
     prev_tracker = bool(prev_row.get(_RATING_TRACKER_FLAG))
     next_tracker = bool(next_row.get(_RATING_TRACKER_FLAG))
     if prev_tracker == next_tracker:
+        if _rating_value(prev_row) == _rating_value(next_row):
+            prev_epoch = int(prev_row.get("sort_epoch") or 0)
+            next_epoch = int(next_row.get("sort_epoch") or 0)
+            if prev_epoch > 0 and next_epoch > 0 and prev_epoch != next_epoch:
+                chosen, other = (prev_row, next_row) if prev_epoch < next_epoch else (next_row, prev_row)
+                _merge_sources(chosen, other)
+                _copy_richer_media_fields(chosen, other)
+                return chosen
         return _merge_media_row(prev_row, next_row, sort_key="sort_epoch")
     chosen, other = (prev_row, next_row) if prev_tracker else (next_row, prev_row)
     _merge_sources(chosen, other)
@@ -804,6 +851,7 @@ def latest_ratings_widget(
     *,
     limit: int = 12,
     tracker_items: Mapping[str, Any] | None = None,
+    user_filter: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     rows: dict[str, dict[str, Any]] = {}
     aliases: dict[str, str] = {}
@@ -827,6 +875,8 @@ def latest_ratings_widget(
         item = _unwrap_rating_item(raw_item)
         row = _rating_row(str(raw_key), item, _sources_from_item(item))
         if row:
+            if not _sources_match_user(row.get("sources"), user_filter):
+                continue
             row[_RATING_TRACKER_FLAG] = True
             put(row)
 
@@ -834,6 +884,8 @@ def latest_ratings_widget(
     provider_keys = sorted({str(p).upper() for p in providers.keys()}) if isinstance(providers, Mapping) else []
     for provider in provider_keys:
         for instance, block in _provider_blocks(state, provider):
+            if not _endpoint_matches_user(provider, instance, user_filter):
+                continue
             for raw_key, raw_item in _feature_items(block, "ratings").items():
                 item = _unwrap_rating_item(raw_item)
                 row = _rating_row(str(raw_key), item, [_provider_ref(provider, instance)])
@@ -899,6 +951,11 @@ def _activity_row(event: Mapping[str, Any]) -> dict[str, Any]:
         "status": str(event.get("status") or "").lower(),
         "event": str(event.get("event") or "").lower(),
         "method": str(event.get("method") or "").lower(),
+        "runtime_minutes": _as_float(event.get("runtime_minutes")),
+        "duration_minutes": _as_float(event.get("duration_minutes")),
+        "duration_ms": _as_float(event.get("duration_ms")),
+        "duration": _as_float(event.get("duration")),
+        "runtime": _as_float(event.get("runtime")),
         "ids": _ids(event),
         "tmdb": _tmdb_id(event),
         "source": source,
@@ -1001,12 +1058,14 @@ def _history_aliases(row: Mapping[str, Any], alias_map: Mapping[str, str] | None
     return aliases
 
 
-def _latest_history_state_rows(state: Mapping[str, Any]) -> list[dict[str, Any]]:
+def _latest_history_state_rows(state: Mapping[str, Any], *, user_filter: Mapping[str, Any] | None = None) -> list[dict[str, Any]]:
     rows: dict[str, dict[str, Any]] = {}
     providers = state.get("providers") if isinstance(state.get("providers"), Mapping) else {}
     provider_keys = sorted({str(p).upper() for p in providers.keys()}) if isinstance(providers, Mapping) else []
     for provider in provider_keys:
         for instance, block in _provider_blocks(state, provider):
+            if not _endpoint_matches_user(provider, instance, user_filter):
+                continue
             for raw_key, raw_item in _feature_items(block, "history").items():
                 item = _unwrap_history_item(raw_item)
                 row = _history_state_row(str(raw_key), item, [_provider_ref(provider, instance)])
@@ -1027,12 +1086,14 @@ def _latest_history_state_rows(state: Mapping[str, Any]) -> list[dict[str, Any]]
     return sorted(rows.values(), key=lambda x: int(x.get("sort_epoch") or 0), reverse=True)
 
 
-def _latest_history_tracker_rows(items: Mapping[str, Any]) -> list[dict[str, Any]]:
+def _latest_history_tracker_rows(items: Mapping[str, Any], *, user_filter: Mapping[str, Any] | None = None) -> list[dict[str, Any]]:
     rows: dict[str, dict[str, Any]] = {}
     for raw_key, raw_item in (items or {}).items():
         item = _unwrap_history_item(raw_item)
         row = _history_state_row(str(raw_key), item, _sources_from_item(item))
         if not row:
+            continue
+        if not _sources_match_user(row.get("sources"), user_filter):
             continue
         rows[str(row["key"])] = row
     return sorted(rows.values(), key=lambda x: int(x.get("sort_epoch") or 0), reverse=True)
@@ -1072,25 +1133,76 @@ def recent_history_widget(
     *,
     limit: int = 8,
     tracker_items: Mapping[str, Any] | None = None,
+    user_filter: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     cap = max(1, min(int(limit or 8), 24))
-    state_rows = _latest_history_state_rows(state or {})
-    tracker_rows = _latest_history_tracker_rows(tracker_items or {})
+    state_rows = _latest_history_state_rows(state or {}, user_filter=user_filter)
+    tracker_rows = _latest_history_tracker_rows(tracker_items or {}, user_filter=user_filter)
     rows = _merge_history_rows(state_rows, tracker_rows, alias_map=_history_alias_representatives())
     selected = _resolve_missing_art_rows(rows[:cap], size="w300", episode_still=True)
     return {"ok": True, "items": selected, "total": len(rows)}
 
 
-def recent_scrobble_widget(*, limit: int = 8) -> dict[str, Any]:
+def recent_scrobble_widget(*, limit: int = 8, user_filter: Mapping[str, Any] | None = None) -> dict[str, Any]:
     cap = max(1, min(int(limit or 8), 24))
     payload = list_events(limit=max(cap, 12), offset=0, status="ok", kind="all", group_routes=True)
     rows = [
-        _activity_row(item)
+        row
         for item in payload.get("items") or []
+        for row in [_activity_row(item)]
         if isinstance(item, Mapping) and str(item.get("kind") or "").strip().lower() in {"scrobble", "history_sync"}
+        if _sources_match_user(row.get("sources"), user_filter)
     ]
     selected = _resolve_missing_art_rows(rows[:cap], size="w300", episode_still=True)
-    return {"ok": True, "items": selected, "total": len(rows)}
+    scrobble = _scrobble_summary(user_filter=user_filter)
+    return {
+        "ok": True,
+        "items": selected,
+        "total": len(rows),
+        "scrobble_total": scrobble["total"],
+        "scrobble_hours": scrobble["hours"],
+    }
+
+
+def _scrobble_total(*, user_filter: Mapping[str, Any] | None = None) -> int:
+    return int(_scrobble_summary(user_filter=user_filter).get("total") or 0)
+
+
+def _duration_minutes(item: Mapping[str, Any]) -> float:
+    direct = _as_float(item.get("runtime_minutes") or item.get("duration_minutes"))
+    if direct and direct > 0:
+        return direct
+    duration_ms = _as_float(item.get("duration_ms"))
+    if duration_ms and duration_ms > 0:
+        return duration_ms / 60000.0
+    raw = _as_float(item.get("duration") or item.get("runtime"))
+    if raw and raw > 0:
+        return raw / 60.0 if raw > 300 else raw
+    return 115.0 if _media_type(item) == "movie" else 45.0
+
+
+def _scrobble_summary(*, user_filter: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    try:
+        payload = list_events(
+            limit=1000,
+            offset=0,
+            status="ok",
+            kind="scrobble",
+            group_routes=True,
+        )
+    except Exception:
+        return {"total": 0, "hours": 0.0}
+    rows = [
+        row
+        for item in payload.get("items") or []
+        for row in [_activity_row(item)]
+        if isinstance(item, Mapping) and _sources_match_user(row.get("sources"), user_filter)
+    ]
+    total = len(rows) if _normalize_user_filter(user_filter) else max(0, int(payload.get("total") or 0))
+    minutes = sum(_duration_minutes(row) for row in rows)
+    if total > len(rows) and rows:
+        minutes = (minutes / len(rows)) * total
+    return {"total": total, "hours": round(minutes / 60.0, 1)}
 
 
 def _progress_epoch(item: Mapping[str, Any], raw_key: str = "") -> int:
@@ -1148,6 +1260,7 @@ def recent_progress_widget(
     *,
     limit: int = 8,
     tracker_items: Mapping[str, Any] | None = None,
+    user_filter: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     rows: dict[str, dict[str, Any]] = {}
 
@@ -1162,12 +1275,16 @@ def recent_progress_widget(
         item = raw_item if isinstance(raw_item, Mapping) else {}
         row = _progress_row(str(raw_key), item, _sources_from_item(item))
         if row:
+            if not _sources_match_user(row.get("sources"), user_filter):
+                continue
             put(row)
 
     providers = (state or {}).get("providers") if isinstance((state or {}).get("providers"), Mapping) else {}
     provider_keys = sorted({str(p).upper() for p in providers.keys()}) if isinstance(providers, Mapping) else []
     for provider in provider_keys:
         for instance, block in _provider_blocks(state or {}, provider):
+            if not _endpoint_matches_user(provider, instance, user_filter):
+                continue
             for raw_key, raw_item in _feature_items(block, "progress").items():
                 item = raw_item if isinstance(raw_item, Mapping) else {}
                 row = _progress_row(str(raw_key), item, [_provider_ref(provider, instance)])
@@ -1180,12 +1297,17 @@ def recent_progress_widget(
     return {"ok": True, "items": selected, "total": len(items)}
 
 
-def recent_playlists_widget(*, limit: int = 8) -> dict[str, Any]:
+def recent_playlists_widget(*, limit: int = 8, user_filter: Mapping[str, Any] | None = None) -> dict[str, Any]:
     try:
         from cw_platform.config_base import load_config
         from services import playlists
 
         rows = playlists.activity(load_config() or {}, limit=max(1, min(int(limit or 8), 24)))
+        if _normalize_user_filter(user_filter):
+            rows = [
+                row for row in rows
+                if isinstance(row, Mapping) and _sources_match_user(_sources_from_item(row, default_provider=""), user_filter)
+            ]
     except Exception:
         rows = []
     return {"ok": True, "items": rows, "total": len(rows)}
@@ -1200,6 +1322,7 @@ def dashboard_widgets_payload(
     progress_limit: int = 8,
     playlists_limit: int = 8,
     include: set[str] | None = None,
+    user_filter: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     requested = {str(key).strip().lower() for key in include} if include is not None else {
         "history",
@@ -1214,21 +1337,24 @@ def dashboard_widgets_payload(
             state,
             limit=history_limit,
             tracker_items=_tracker_feature_items("history"),
+            user_filter=user_filter,
         )
     if "scrobble" in requested:
-        payload["recent_scrobble"] = recent_scrobble_widget(limit=scrobble_limit)
+        payload["recent_scrobble"] = recent_scrobble_widget(limit=scrobble_limit, user_filter=user_filter)
     if "ratings" in requested:
         payload["latest_ratings"] = latest_ratings_widget(
             state,
             limit=ratings_limit,
             tracker_items=_tracker_feature_items("ratings"),
+            user_filter=user_filter,
         )
     if "progress" in requested:
         payload["recent_progress"] = recent_progress_widget(
             state,
             limit=progress_limit,
             tracker_items=_tracker_feature_items("progress"),
+            user_filter=user_filter,
         )
     if "playlists" in requested:
-        payload["recent_playlists"] = recent_playlists_widget(limit=playlists_limit)
+        payload["recent_playlists"] = recent_playlists_widget(limit=playlists_limit, user_filter=user_filter)
     return payload

--- a/tests/test_currently_watching_db.py
+++ b/tests/test_currently_watching_db.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import pytest
 
 from cw_platform.local_db import close_conn
 from providers.scrobble import currently_watching
+
+
+def _loads_body(body: bytes | memoryview[int]) -> Any:
+    return json.loads(bytes(body))
 
 
 @pytest.fixture()
@@ -45,7 +50,7 @@ def test_currently_watching_round_trips_through_db_and_api(isolated_db) -> None:
     from api.scrobbleAPI import api_currently_watching
 
     response = api_currently_watching()
-    payload = json.loads(response.body)
+    payload = _loads_body(response.body)
 
     assert payload["streams_count"] == 1
     assert payload["currently_watching"]["_key"] == "plex:P01:session-1"

--- a/tests/test_dashboard_widgets.py
+++ b/tests/test_dashboard_widgets.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import pytest
 
 from services import activity, dashboard_widgets
+
+
+def _loads_body(body: bytes | memoryview[int]) -> Any:
+    return json.loads(bytes(body))
 
 
 FLATTENED_PROVIDERS = (
@@ -22,11 +27,12 @@ FLATTENED_PROVIDERS = (
 
 class FakeMetadataManager:
     def __init__(self) -> None:
-        self.calls: list[dict[str, object]] = []
+        self.calls: list[dict[str, Any]] = []
 
     def resolve(self, **kwargs):
         self.calls.append(dict(kwargs))
-        ids = kwargs.get("ids") if isinstance(kwargs.get("ids"), dict) else {}
+        raw_ids = kwargs.get("ids")
+        ids: dict[str, Any] = raw_ids if isinstance(raw_ids, dict) else {}
         if ids.get("title") == "Behind the Attraction":
             return {"ids": {"tmdb": 100, "trakt": ids.get("trakt")}, "title": "Behind the Attraction"}
         if ids.get("title") == "Heat":
@@ -559,6 +565,54 @@ def test_latest_ratings_widget_merges_provider_local_movie_ids_and_inherits_art(
     assert {source["provider"] for source in payload["items"][0]["sources"]} == {"SIMKL", "TRAKT"}
 
 
+def test_latest_ratings_widget_keeps_original_provider_time_over_same_rating_sync_echo() -> None:
+    state = {
+        "providers": {
+            "SCROB": {
+                "ratings": {
+                    "baseline": {
+                        "items": {
+                            "tmdb:1151272": {
+                                "type": "movie",
+                                "title": "Sirat",
+                                "year": 2025,
+                                "ids": {"tmdb": 1151272},
+                                "rating": 6,
+                                "rated_at": "2026-08-17T00:13:57.000Z",
+                            }
+                        }
+                    }
+                }
+            },
+            "TRAKT": {
+                "ratings": {
+                    "baseline": {
+                        "items": {
+                            "tmdb:1151272": {
+                                "type": "movie",
+                                "title": "Sirat",
+                                "year": 2025,
+                                "ids": {"tmdb": 1151272},
+                                "rating": 6,
+                                "rated_at": "2026-04-03T21:03:13.000Z",
+                            }
+                        }
+                    }
+                }
+            },
+        }
+    }
+
+    payload = dashboard_widgets.latest_ratings_widget(state, limit=5)
+
+    assert payload["total"] == 1
+    item = payload["items"][0]
+    assert item["rating"] == 6
+    assert item["rated_at"] == "2026-04-03T21:03:13.000Z"
+    assert item["sort_epoch"] == 1775250193
+    assert {source["provider"] for source in item["sources"]} == {"SCROB", "TRAKT"}
+
+
 def test_latest_ratings_widget_keeps_tracker_rated_at_over_destination_sync_time() -> None:
     tracker_items = {
         "movie|imdb:tt0113277": {
@@ -885,6 +939,74 @@ def test_recent_scrobble_widget_uses_nested_history_sync_item_art(tmp_path, monk
         {"provider": "TRAKT", "instance": "default"},
         {"provider": "CROSSWATCH", "instance": "default"},
     ]
+    assert payload["scrobble_total"] == 0
+    assert payload["scrobble_hours"] == 0.0
+
+
+def test_recent_scrobble_widget_reports_scrobble_total_separately(monkeypatch) -> None:
+    def fake_list_events(**kwargs: Any) -> dict[str, Any]:
+        if kwargs.get("kind") == "scrobble":
+            return {"ok": True, "total": 5, "items": []}
+        return {
+            "ok": True,
+            "items": [
+                {
+                    "id": "history-1",
+                    "kind": "history_sync",
+                    "status": "ok",
+                    "source": "trakt",
+                    "target": "crosswatch",
+                    "media_type": "movie",
+                    "title": "Imported Movie",
+                    "watched_at": 1767225600,
+                }
+            ],
+        }
+
+    monkeypatch.setattr(dashboard_widgets, "list_events", fake_list_events)
+
+    payload = dashboard_widgets.recent_scrobble_widget(limit=3)
+
+    assert payload["total"] == 1
+    assert payload["scrobble_total"] == 5
+    assert payload["scrobble_hours"] == 0.0
+
+
+def test_recent_scrobble_widget_reports_scrobble_hours(monkeypatch) -> None:
+    monkeypatch.setattr(
+        dashboard_widgets,
+        "list_events",
+        lambda **_kwargs: {
+            "ok": True,
+            "total": 2,
+            "items": [
+                {
+                    "id": "movie-1",
+                    "kind": "scrobble",
+                    "status": "ok",
+                    "source": "plex",
+                    "media_type": "movie",
+                    "title": "Short Movie",
+                    "duration_minutes": 100,
+                    "watched_at": 1767225600,
+                },
+                {
+                    "id": "episode-1",
+                    "kind": "scrobble",
+                    "status": "ok",
+                    "source": "plex",
+                    "media_type": "episode",
+                    "title": "Pilot",
+                    "watched_at": 1767312000,
+                },
+            ],
+        },
+    )
+
+    payload = dashboard_widgets.recent_scrobble_widget(limit=3)
+
+    assert payload["scrobble_total"] == 2
+    assert payload["scrobble_hours"] == 2.4
 
 
 def test_recent_progress_widget_uses_sync_state_not_live_provider_endpoints() -> None:
@@ -1075,7 +1197,7 @@ def test_dashboard_widgets_api_reads_state_widgets_from_db(monkeypatch, tmp_path
         playlists_limit=8,
         include="history,ratings,progress",
     )
-    payload = json.loads(response.body)
+    payload = _loads_body(response.body)
 
     assert payload["ok"] is True
     assert payload["recent_history"]["items"][0]["tmdb"] == "949"
@@ -1113,7 +1235,76 @@ def test_dashboard_widgets_api_reads_scrobble_from_activity_db(monkeypatch, tmp_
         playlists_limit=8,
         include="scrobble",
     )
-    payload = json.loads(response.body)
+    payload = _loads_body(response.body)
 
     assert payload["ok"] is True
     assert payload["recent_scrobble"]["items"][0]["tmdb"] == "949"
+
+
+def test_recent_history_widget_filters_by_user_profile_instances() -> None:
+    state = {
+        "providers": {
+            "PLEX": {
+                "history": {
+                    "baseline": {
+                        "items": {
+                            "tmdb:1@1": {"type": "movie", "title": "Alice Movie", "ids": {"tmdb": 1}, "watched_at": 1767225600}
+                        }
+                    }
+                },
+                "instances": {
+                    "PLEX-P02": {
+                        "history": {
+                            "baseline": {
+                                "items": {
+                                    "tmdb:2@2": {"type": "movie", "title": "Bob Movie", "ids": {"tmdb": 2}, "watched_at": 1767312000}
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+        }
+    }
+
+    payload = dashboard_widgets.recent_history_widget(state, user_filter={"PLEX": ["PLEX-P02"]})
+
+    assert payload["total"] == 1
+    assert payload["items"][0]["title"] == "Bob Movie"
+
+
+def test_recent_scrobble_widget_filters_by_user_profile_instances(monkeypatch) -> None:
+    monkeypatch.setattr(
+        dashboard_widgets,
+        "list_events",
+        lambda **_kwargs: {
+            "ok": True,
+            "items": [
+                {
+                    "id": "a",
+                    "kind": "scrobble",
+                    "status": "ok",
+                    "source": "plex",
+                    "source_instance": "default",
+                    "media_type": "movie",
+                    "title": "Alice Movie",
+                    "watched_at": 1767225600,
+                },
+                {
+                    "id": "b",
+                    "kind": "scrobble",
+                    "status": "ok",
+                    "source": "plex",
+                    "source_instance": "PLEX-P02",
+                    "media_type": "movie",
+                    "title": "Bob Movie",
+                    "watched_at": 1767312000,
+                },
+            ],
+        },
+    )
+
+    payload = dashboard_widgets.recent_scrobble_widget(user_filter={"PLEX": "PLEX-P02"})
+
+    assert payload["total"] == 1
+    assert payload["items"][0]["title"] == "Bob Movie"


### PR DESCRIPTION
# Pull request

## Change

Scope dashboard widgets and currently watching data to the active user profile.

## Why

Managed users should only see dashboard activity, progress, ratings, and streams from assigned provider instances.

## Testing

- tests/test_dashboard_widgets.py 
- tests/test_crosswatch_profiles.py 
- tests/test_currently_watching_db.py

## Issue

Relates to #728