### PR TITLE
Change: activity and insights by profile

### DIFF
--- a/api/activityAPI.py
+++ b/api/activityAPI.py
@@ -3,44 +3,115 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
 
+from cw_platform.access_policy import request_user
+from cw_platform.config_base import load_config
+from cw_platform.provider_instances import instances_for_user_profile, normalize_instance_id, provider_display_key
 from services.activity import clear_events, list_events
 
 router = APIRouter(prefix="/api/activity", tags=["activity"])
 
 
+def _matches_user_profile(item: dict[str, Any], user_filter: dict[str, list[str]]) -> bool:
+    if not user_filter:
+        return True
+    wanted = {
+        provider_display_key(provider): {normalize_instance_id(inst) for inst in (instances or [])}
+        for provider, instances in user_filter.items()
+    }
+
+    def hit(provider: Any, instance: Any) -> bool:
+        prov = provider_display_key(provider)
+        return bool(prov) and normalize_instance_id(instance) in wanted.get(prov, set())
+
+    if hit(item.get("source"), item.get("source_instance")):
+        return True
+    if hit(item.get("provider"), item.get("provider_instance") or item.get("instance")):
+        return True
+    targets = item.get("targets")
+    if isinstance(targets, list):
+        for target in targets:
+            if isinstance(target, dict) and hit(target.get("target") or target.get("provider"), target.get("target_instance") or target.get("instance")):
+                return True
+    return hit(item.get("target"), item.get("target_instance"))
+
+
+def _apply_user_profile(payload: dict[str, Any], user_profile: str) -> dict[str, Any]:
+    profile = str(user_profile or "").strip()
+    if not profile:
+        return payload
+    try:
+        user_filter = instances_for_user_profile(load_config() or {}, profile)
+    except Exception:
+        user_filter = {}
+    if not user_filter:
+        return {**payload, "items": [], "total": 0, "user_profile": profile}
+    items = [item for item in (payload.get("items") or []) if isinstance(item, dict) and _matches_user_profile(item, user_filter)]
+    return {**payload, "items": items, "total": len(items), "user_profile": profile}
+
+
+def _effective_profile_from_request(request: Request | None, requested: str) -> str:
+    try:
+        from api.appAuthAPI import COOKIE_NAME, effective_user_profile_id
+
+        cfg = load_config() or {}
+        token = request.cookies.get(COOKIE_NAME) if request is not None else None
+        return effective_user_profile_id(cfg, token, requested)
+    except Exception:
+        return "__none__"
+
+
 @router.get("/recent")
 def activity_recent(
+    request: Request = cast(Request, None),
     limit: int = Query(10, ge=1, le=50),
     since: int | None = Query(None, ge=0),
+    user_profile: str = Query(""),
 ) -> JSONResponse:
-    return JSONResponse(list_events(limit=limit, offset=0, since=since), headers={"Cache-Control": "no-store"})
+    profile = _effective_profile_from_request(request, user_profile)
+    raw_limit = 500 if str(profile or "").strip() else limit
+    payload = _apply_user_profile(list_events(limit=raw_limit, offset=0, since=since), profile)
+    if str(profile or "").strip():
+        payload["items"] = list(payload.get("items") or [])[:limit]
+    return JSONResponse(payload, headers={"Cache-Control": "no-store"})
 
 
 @router.get("/history")
 def activity_history(
+    request: Request = cast(Request, None),
     limit: int = Query(100, ge=1, le=500),
     offset: int = Query(0, ge=0),
     media_type: str = Query("all"),
     status: str = Query("all"),
     q: str = Query(""),
     since: int | None = Query(None, ge=0),
+    user_profile: str = Query(""),
 ) -> JSONResponse:
+    profile = _effective_profile_from_request(request, user_profile)
+    scoped = bool(str(profile or "").strip())
     payload: dict[str, Any] = list_events(
-        limit=limit,
-        offset=offset,
+        limit=500 if scoped else limit,
+        offset=0 if scoped else offset,
         media_type=media_type,
         status=status,
         query=q,
         since=since,
     )
+    payload = _apply_user_profile(payload, profile)
+    if scoped:
+        items = list(payload.get("items") or [])
+        payload["items"] = items[offset:offset + limit]
+        payload["has_more"] = offset + limit < len(items)
     return JSONResponse(payload, headers={"Cache-Control": "no-store"})
 
 
 @router.delete("/history")
-def activity_clear() -> JSONResponse:
+def activity_clear(request: Request = cast(Request, None)) -> JSONResponse:
+    user = request_user(request)
+    if user and not bool(user.get("is_admin")):
+        return JSONResponse({"ok": False, "error": "profile_scope_denied"}, status_code=403, headers={"Cache-Control": "no-store"})
     return JSONResponse(clear_events(), headers={"Cache-Control": "no-store"})

--- a/api/insightAPI.py
+++ b/api/insightAPI.py
@@ -19,8 +19,10 @@ from cw_platform.modules_registry import sync_provider_names
 from cw_platform.provider_instances import (
     ensure_instance_block,
     get_provider_block,
+    instances_for_user_profile,
     list_instance_ids,
     normalize_instance_id,
+    provider_display_key,
     sanitize_instance_label,
 )
 
@@ -343,10 +345,12 @@ def register_insights(app: FastAPI) -> None:
 
     @app.get("/api/insights", tags=["insight"])
     def api_insights(
+        request: Request,
         limit_samples: int = Query(60),
         history: int = Query(3),
         runtime: int = Query(0),
         include_events: int = Query(1),
+        user_profile: str = Query(""),
     ) -> JSONResponse:
         CW, load_config, _, get_runtime = _env()
         STATS = getattr(CW, "STATS", None)
@@ -1068,6 +1072,105 @@ def register_insights(app: FastAPI) -> None:
         state: dict[str, Any] | None = _load_state_features(state_features)
         events_raw: list[dict[str, Any]] = []
         _lane_cache: dict[tuple[int, int, int], tuple[dict[str, dict[str, Any]], dict[str, bool]]] = {}
+        cfg = load_config() or {}
+        scoped_profile = ""
+        user_filter: dict[str, list[str]] = {}
+
+        try:
+            from api.appAuthAPI import COOKIE_NAME, effective_user_profile_id
+
+            token = request.cookies.get(COOKIE_NAME)
+            scoped_profile = effective_user_profile_id(cfg, token, user_profile)
+        except Exception:
+            scoped_profile = "__none__"
+
+        if str(scoped_profile or "").strip():
+            user_filter = instances_for_user_profile(cfg, scoped_profile)
+            if not user_filter:
+                user_filter = {"__NONE__": ["__NONE__"]}
+
+        wanted_instances: dict[str, set[str]] = {}
+        for provider, instances in user_filter.items():
+            prov = provider_display_key(provider)
+            vals = {
+                normalize_instance_id(inst)
+                for inst in (instances if isinstance(instances, list) else [instances])
+                if normalize_instance_id(inst)
+            }
+            if prov and vals:
+                wanted_instances[prov] = vals
+
+        def _allows_instance(provider: Any, instance: Any) -> bool:
+            if not wanted_instances:
+                return True
+            prov = provider_display_key(provider)
+            inst = normalize_instance_id(instance)
+            return bool(prov and inst and inst in wanted_instances.get(prov, set()))
+
+        def _item_matches_scope(item: dict[str, Any]) -> bool:
+            if not wanted_instances:
+                return True
+            sources = item.get("sources_by_provider") or item.get("sourcesByProvider")
+            if isinstance(sources, dict):
+                for provider, raw_instances in sources.items():
+                    values = raw_instances if isinstance(raw_instances, list) else [raw_instances]
+                    if any(_allows_instance(provider, inst) for inst in values):
+                        return True
+            return _allows_instance(
+                item.get("provider") or item.get("source") or item.get("added_src"),
+                item.get("provider_instance") or item.get("source_instance") or item.get("added_instance") or item.get("instance"),
+            )
+
+        def _event_matches_scope(item: dict[str, Any]) -> bool:
+            if not wanted_instances:
+                return True
+            checks = (
+                (item.get("provider"), item.get("provider_instance") or item.get("instance")),
+                (item.get("source"), item.get("source_instance")),
+                (item.get("target"), item.get("target_instance")),
+            )
+            if any(_allows_instance(provider, instance) for provider, instance in checks):
+                return True
+            targets = item.get("targets")
+            if isinstance(targets, list):
+                for target in targets:
+                    if isinstance(target, dict) and _allows_instance(target.get("target") or target.get("provider"), target.get("target_instance") or target.get("instance")):
+                        return True
+            return False
+
+        def _scope_state(src: dict[str, Any] | None) -> dict[str, Any] | None:
+            if not wanted_instances or not isinstance(src, dict):
+                return src
+            out = dict(src)
+            providers = src.get("providers")
+            if isinstance(providers, dict):
+                scoped_providers: dict[str, Any] = {}
+                for provider, pdata in providers.items():
+                    prov = provider_display_key(provider)
+                    allowed = wanted_instances.get(prov)
+                    if not allowed or not isinstance(pdata, dict):
+                        continue
+                    next_data: dict[str, Any] = {}
+                    if "default" in allowed:
+                        next_data.update({k: v for k, v in pdata.items() if k != "instances"})
+                    insts = pdata.get("instances")
+                    if isinstance(insts, dict):
+                        keep = {
+                            str(iid): idata
+                            for iid, idata in insts.items()
+                            if normalize_instance_id(iid) in allowed and isinstance(idata, dict)
+                        }
+                        if keep:
+                            next_data["instances"] = keep
+                    if next_data:
+                        scoped_providers[str(provider)] = next_data
+                out["providers"] = scoped_providers
+            wall_items = src.get("wall")
+            if isinstance(wall_items, list):
+                out["wall"] = [item for item in wall_items if isinstance(item, dict) and _item_matches_scope(item)]
+            return out
+
+        state = _scope_state(state)
 
         def _safe_parse_epoch(v: Any) -> int:
             try:
@@ -1488,9 +1591,11 @@ def register_insights(app: FastAPI) -> None:
             try:
                 with lock:
                     data = STATS.data or {}
-                samples_raw = list((data or {}).get("samples") or [])
+                samples_raw = [] if wanted_instances else list((data or {}).get("samples") or [])
                 
                 events_raw = list((data or {}).get("events") or [])
+                if wanted_instances:
+                    events_raw = [e for e in events_raw if isinstance(e, dict) and _event_matches_scope(e)]
                 if int(include_events):
                     state_for_maps = state or {}
                     key_map, id_map = _build_show_title_maps(state_for_maps)
@@ -1513,7 +1618,7 @@ def register_insights(app: FastAPI) -> None:
                     events = _sort_events(events)
                 else:
                     events = []
-                http_block = dict((data or {}).get("http") or {})
+                http_block = {} if wanted_instances else dict((data or {}).get("http") or {})
                 generated_at = (data or {}).get("generated_at")
 
                 samples: list[dict[str, Any]] = [r for r in samples_raw if isinstance(r, dict)]
@@ -1537,7 +1642,7 @@ def register_insights(app: FastAPI) -> None:
         rows: list[dict[str, Any]] = []
         try:
             history_limit = max(0, int(history))
-            if history_limit > 0:
+            if history_limit > 0 and not wanted_instances:
                 from cw_platform.local_db.sync_reports import base_path_from_report_dir, list_reports
 
                 rows = list_reports(
@@ -1557,8 +1662,9 @@ def register_insights(app: FastAPI) -> None:
 
         if not wall and state:
             wall = list(state.get("wall") or [])
+        if wanted_instances:
+            wall = [item for item in wall if isinstance(item, dict) and _item_matches_scope(item)]
 
-        cfg = load_config() or {}
         api_key = str(((cfg.get("tmdb") or {}).get("api_key") or "")).strip()
         use_tmdb = bool(api_key) and bool(int(runtime)) and CACHE_DIR is not None
 
@@ -1631,6 +1737,8 @@ def register_insights(app: FastAPI) -> None:
                 profiles: list[dict[str, str]] = []
                 for inst in list_instance_ids(cfg, "crosswatch"):
                     norm = normalize_instance_id(inst)
+                    if wanted_instances and not _allows_instance("crosswatch", norm):
+                        continue
                     block = get_provider_block(cfg, "crosswatch", norm)
                     if not block and norm != "default":
                         continue
@@ -1640,7 +1748,7 @@ def register_insights(app: FastAPI) -> None:
 
                 info["_profiles"] = profiles
                 info["_by_profile"] = by_profile
-                info.update(by_profile.get("default") or {})
+                info.update(by_profile.get("default") or (by_profile.get(profiles[0]["id"]) if profiles else {}) or {})
             except Exception:
                 pass
             return info
@@ -1698,7 +1806,7 @@ def register_insights(app: FastAPI) -> None:
         }
 
         prov_block: dict[str, Any] = (state or {}).get("providers") or {}
-        providers_set: set[str] = set(sync_provider_names(upper=False))
+        providers_set: set[str] = {provider.lower() for provider in wanted_instances} if wanted_instances else set(sync_provider_names(upper=False))
         try:
             providers_set.update(
                 str(k).strip().lower()
@@ -1711,6 +1819,10 @@ def register_insights(app: FastAPI) -> None:
         try:
             raw_pairs = (cfg.get("pairs") or cfg.get("connections") or [])
             cfg_pairs: list[Any] = raw_pairs if isinstance(raw_pairs, list) else []
+            if wanted_instances:
+                from cw_platform.access_policy import profile_allows_pair
+
+                cfg_pairs = [p for p in cfg_pairs if isinstance(p, dict) and profile_allows_pair(user_filter, p)]
             for p in cfg_pairs:
                 if not isinstance(p, dict):
                     continue
@@ -1723,7 +1835,7 @@ def register_insights(app: FastAPI) -> None:
         except Exception:
             cfg_pairs = []
 
-        active: dict[str, bool] = {k: False for k in providers_set}
+        active: dict[str, bool] = {k: bool(wanted_instances) for k in providers_set}
         try:
             for p in (cfg_pairs or []):
                 if not isinstance(p, dict):
@@ -1854,6 +1966,11 @@ def register_insights(app: FastAPI) -> None:
                 instances_by_provider[key] = insts
         except Exception:
             pass
+        if wanted_instances:
+            instances_by_provider = {
+                provider.lower(): sorted(instances)
+                for provider, instances in wanted_instances.items()
+            }
 
         providers_instances_by_feature: dict[str, dict[str, dict[str, int]]] = {
             feat: {k: {"default": 0} for k in providers_set} for feat in feature_keys
@@ -1871,7 +1988,7 @@ def register_insights(app: FastAPI) -> None:
                     inst_counts: dict[str, int] = {}
                     for inst_id, node in _iter_provider_feature_nodes(pdata, feat):
                         inst_counts[inst_id] = _count_items(node, feat)
-                    if "default" not in inst_counts:
+                    if "default" not in inst_counts and not wanted_instances:
                         inst_counts["default"] = 0
                     providers_instances_by_feature[feat][key] = inst_counts
                     providers_by_feature[feat][key] = sum(int(v or 0) for v in inst_counts.values())
@@ -1931,7 +2048,7 @@ def register_insights(app: FastAPI) -> None:
                             "episodes": int(per_counts.get("episodes") or 0),
                         }
 
-                    if "default" not in inst_mse:
+                    if "default" not in inst_mse and not wanted_instances:
                         inst_mse["default"] = {"movies": 0, "shows": 0, "anime": 0, "episodes": 0}
 
                     providers_instances_mse_by_feature[feat][key] = inst_mse
@@ -2105,4 +2222,6 @@ def register_insights(app: FastAPI) -> None:
             "added": int(wl.get("added", 0) or 0),
             "removed": int(wl.get("removed", 0) or 0),
         }
+        if scoped_profile:
+            payload["user_profile"] = str(scoped_profile or "").strip()
         return JSONResponse(payload)

--- a/assets/js/activity.js
+++ b/assets/js/activity.js
@@ -186,7 +186,18 @@
     if (configCheck) return configCheck;
     configCheck = (async () => {
       try {
-        const cfg = await fetchJSON("/api/config");
+        let cfg;
+        if (window.CW?.API?.Config?.load) {
+          cfg = await window.CW.API.Config.load(false);
+        } else {
+          try {
+            cfg = document.documentElement?.dataset?.cwRole === "user" ? await fetchJSON("/api/config/meta") : await fetchJSON("/api/config");
+          } catch (e) {
+            const msg = String(e?.message || e || "");
+            if (!msg.includes("401") && !msg.includes("403")) throw e;
+            cfg = await fetchJSON("/api/config/meta");
+          }
+        }
         if (cfg && typeof cfg === "object") window._cfgCache = cfg;
         const ui = cfg && typeof cfg.ui === "object" ? cfg.ui : {};
         const enabled = typeof ui.show_recent_activity === "boolean" ? !!ui.show_recent_activity : true;
@@ -223,6 +234,8 @@
       const display = recentDisplay();
       const params = new URLSearchParams({ limit: String(display.limit) });
       if (display.mode === "hours" && display.since) params.set("since", String(display.since));
+      const userProfile = String(window.CW?.OverviewProfile?.id || "").trim();
+      if (userProfile) params.set("user_profile", userProfile);
       const data = await fetchJSON(`/api/activity/recent?${params.toString()}`);
       if (!data || data.ok !== true || !Array.isArray(data.items)) {
         throw new Error("invalid_activity_response");
@@ -289,7 +302,8 @@
     const q = encodeURIComponent(String($("#activity-q", modal)?.value || ""));
     const media = encodeURIComponent(String($("#activity-media", modal)?.value || "all"));
     const status = encodeURIComponent(String($("#activity-status", modal)?.value || "all"));
-    return `limit=${PAGE_SIZE}&offset=${state.offset}&media_type=${media}&status=${status}&q=${q}`;
+    const userProfile = encodeURIComponent(String(window.CW?.OverviewProfile?.id || "").trim());
+    return `limit=${PAGE_SIZE}&offset=${state.offset}&media_type=${media}&status=${status}&q=${q}${userProfile ? `&user_profile=${userProfile}` : ""}`;
   }
 
   async function loadActivityPage(reset) {
@@ -365,6 +379,10 @@
   });
   window.addEventListener("settings-changed", () => setTimeout(refreshRecentActivity, 300));
   window.addEventListener("activity-log-cleared", () => {
+    refreshRecentActivity();
+    if (state.modal && !state.modal.classList.contains("hidden")) loadActivityPage(true);
+  });
+  window.addEventListener("cw:overview-profile-changed", () => {
     refreshRecentActivity();
     if (state.modal && !state.modal.classList.contains("hidden")) loadActivityPage(true);
   });

--- a/assets/js/insights.js
+++ b/assets/js/insights.js
@@ -17,6 +17,16 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
   const featureLabel = v => featureMeta.label?.(v) || FEAT_LABEL[lc(v)] || String(v || "");
   const providerLabel = v => providerMeta.label?.(v) || String(v || "");
   const providerLogo = v => providerMeta.logoPath?.(v) || "";
+  const overviewProfile = () => w.CW?.OverviewProfile || null;
+  const overviewProfileId = () => String(overviewProfile()?.id || "").trim();
+  const overviewFilter = () => overviewProfile()?.filter || {};
+  const overviewInstancesFor = prov => {
+    const filter = overviewFilter();
+    const up = String(prov || "").trim().toUpperCase();
+    const low = lc(prov);
+    return Array.isArray(filter[up]) ? filter[up].map(String) : Array.isArray(filter[low]) ? filter[low].map(String) : null;
+  };
+  const overviewHasScope = () => !!Object.keys(overviewFilter() || {}).length;
   const titleOf = x => x?.display_title || x?.title || x?.series_title || x?.name || (x?.type === "episode" && x?.series_title && Number.isInteger(x?.season) && Number.isInteger(x?.episode) ? `${x.series_title} S${String(x.season).padStart(2,"0")}E${String(x.episode).padStart(2,"0")}` : x?.key) || "item";
   const subtitleOf = x => x?.display_subtitle || "";
   const readJSON = (key, fallback = {}) => { try { return JSON.parse(localStorage.getItem(key) || "{}") || fallback; } catch { return fallback; } };
@@ -127,6 +137,10 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
 
   const getConfiguredProviders = async force => {
     try {
+      if (document.documentElement?.dataset?.cwRole === "user") {
+        const keys = Object.keys(overviewFilter() || {}).map(k => String(k || "").trim()).filter(Boolean);
+        if (keys.length) return new Set(keys);
+      }
       let cfg = w._cfgCache;
       const needsConfigLoad = force || !cfg || typeof cfg !== "object" || !Object.keys(cfg).length;
       if (needsConfigLoad && typeof w.CW?.API?.Config?.load === "function") {
@@ -165,25 +179,31 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
 
   function filterProviderTotals(block, instancesByProvider = {}) {
     const raw = block?.raw || {}, instCounts = raw.providers_instances, instMse = raw.providers_instances_mse;
-    if (!selectionDiffers(_prefs, instancesByProvider) || !instCounts || typeof instCounts !== "object") {
+    const activeOverviewFilter = overviewFilter();
+    const hasOverviewFilter = !!Object.keys(activeOverviewFilter || {}).length;
+    if (!hasOverviewFilter && (!selectionDiffers(_prefs, instancesByProvider) || !instCounts || typeof instCounts !== "object")) {
       return { providers: block.providers || {}, mse: raw.providers_mse || null, now: block.now };
     }
     const out = {}, outMse = {}, selected = _prefs?.instances || {}, zero = () => ({ movies:0, shows:0, anime:0, episodes:0 });
     for (const [prov, byInst] of Object.entries(instCounts || {})) {
       const key = lc(prov), map = byInst && typeof byInst === "object" ? byInst : {}, keys = Object.keys(map), want = Array.isArray(selected[key]) ? selected[key].map(String) : selected[key] === undefined ? keys : [];
-      out[key] = want.reduce((sum, id) => sum + (map[id] | 0), 0);
+      const overviewWant = activeOverviewFilter[String(prov || "").toUpperCase()] || activeOverviewFilter[String(prov || "").toLowerCase()];
+      const finalWant = hasOverviewFilter ? want.filter(id => (overviewWant || []).map(String).includes(String(id))) : want;
+      out[key] = finalWant.reduce((sum, id) => sum + (map[id] | 0), 0);
       const mseMap = instMse?.[key] && typeof instMse[key] === "object" ? instMse[key] : {}, agg = zero();
-      for (const id of want) {
+      for (const id of finalWant) {
         const part = mseMap[id];
         if (!part || typeof part !== "object") continue;
         agg.movies += part.movies | 0; agg.shows += part.shows | 0; agg.anime += part.anime | 0; agg.episodes += part.episodes | 0;
       }
       outMse[key] = agg;
     }
-    for (const [prov, v] of Object.entries(block.providers || {})) if (out[lc(prov)] === undefined) out[lc(prov)] = v | 0;
-    for (const [prov, v] of Object.entries(raw.providers_mse || {})) if (outMse[lc(prov)] === undefined) outMse[lc(prov)] = v;
+    if (!hasOverviewFilter) {
+      for (const [prov, v] of Object.entries(block.providers || {})) if (out[lc(prov)] === undefined) out[lc(prov)] = v | 0;
+      for (const [prov, v] of Object.entries(raw.providers_mse || {})) if (outMse[lc(prov)] === undefined) outMse[lc(prov)] = v;
+    }
     const vals = Object.values(out).map(v => v | 0).filter(v => v > 0);
-    return { providers: out, mse: outMse, now: vals.length ? Math.max(...vals) : block.now | 0 };
+    return { providers: out, mse: outMse, now: vals.length ? Math.max(...vals) : hasOverviewFilter ? 0 : block.now | 0 };
   }
 
   function pickBlock(data, feat) {
@@ -285,20 +305,25 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
   w.addEventListener("resize", refitProviderNumbers, { passive: true });
 
   const footWrap = () => {
+    const stats = $("#stats-card");
+    if (!stats) {
+      $("#insights-footer")?.remove();
+      return null;
+    }
     let foot = $("#insights-footer");
     if (!foot) {
       foot = d.createElement("div");
       foot.id = "insights-footer";
       foot.className = "ins-footer";
       foot.innerHTML = '<div class="ins-foot-wrap"></div>';
-      ($("#stats-card") || d.body).appendChild(foot);
+      stats.appendChild(foot);
     }
     return $(".ins-foot-wrap", foot) || foot;
   };
 
   function placeSwitchBeforeTiles() {
     const wrap = footWrap(), sw = $("#insights-switch"), grid = $("#stat-providers");
-    if (!sw) return;
+    if (!wrap || !sw) return;
     if (!wrap.contains(sw)) wrap.appendChild(sw);
     const ref = grid?.parentNode === wrap ? grid : null;
     if (sw.nextSibling !== ref) try { wrap.insertBefore(sw, ref); } catch {}
@@ -323,6 +348,7 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
 
   function ensureSwitch() {
     const wrap = footWrap();
+    if (!wrap) return;
     let host = $("#insights-switch");
     if (!host) {
       host = d.createElement("div");
@@ -356,13 +382,23 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
     markActiveSwitcher();
   }
 
-  const providerSelected = prov => {
+  const providerSelected = (prov, instancesByProvider = {}) => {
+    const scoped = overviewInstancesFor(prov);
+    if (overviewHasScope() && !Array.isArray(scoped)) return false;
     const cur = _prefs?.instances?.[lc(prov)];
-    return cur === undefined || !Array.isArray(cur) ? cur !== false : cur.length > 0;
+    const selected = cur === undefined || !Array.isArray(cur)
+      ? (cur !== false ? (instancesByProvider?.[lc(prov)] || instancesByProvider?.[String(prov || "").toUpperCase()] || []) : [])
+      : cur.map(String);
+    if (!overviewHasScope()) return cur === undefined || !Array.isArray(cur) ? cur !== false : cur.length > 0;
+    if (!Array.isArray(scoped)) return false;
+    if (!selected.length) return scoped.length > 0;
+    const allowed = new Set(scoped.map(String));
+    return selected.some(id => allowed.has(String(id)));
   };
 
   function renderProviderStats(provTotals = {}, provActive = {}, configuredSet = new Set(), breakdownMap = {}, instancesByProvider = {}, animate = true) {
     const wrap = footWrap();
+    if (!wrap) return;
     let host = $("#stat-providers");
     if (!host) {
       host = d.createElement("div");
@@ -371,6 +407,7 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
     } else if (host.parentNode !== wrap) wrap.appendChild(host);
     if (!host.dataset.bound) {
       host.addEventListener("click", ev => {
+        if (document.documentElement?.dataset?.cwRole === "user") return;
         const tile = ev.target.closest('.tile[data-provider="crosswatch"]');
         if (tile && _feature !== "playlists") openCrosswatchSnapshotPicker(_feature);
       });
@@ -491,9 +528,11 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
     const list = $(".list", wrap);
     if (!list) return;
     const display = recentSyncsDisplay();
+    const profile = window.CW?.OverviewProfile;
     const rows = (Array.isArray(hist) ? hist : []).slice()
       .sort((a, b) => new Date(b.finished_at || b.started_at || 0) - new Date(a.finished_at || a.started_at || 0))
       .filter(row => row?.features_enabled?.[_feature] !== false)
+      .filter(row => !profile?.filter || !Object.keys(profile.filter || {}).length || profile.matchesEndpoint(row?.source, row?.source_instance) || profile.matchesEndpoint(row?.target, row?.target_instance))
       .filter(row => display.mode !== "hours" || ((rowTs(row) || 0) >= display.sinceMs))
       .slice(0, display.limit);
     if (!rows.length) return void (list.innerHTML = `<div class="history-item"><div class="history-meta muted">${display.mode === "hours" ? `No runs in the last ${display.hours} hours` : "No runs for this feature"}</div></div>`);
@@ -555,8 +594,9 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
   async function refreshInsights(force = false) {
     if (authSetupPending()) return;
     try {
+      const profileParam = overviewProfileId() ? `&user_profile=${encodeURIComponent(overviewProfileId())}` : "";
       const [data] = await Promise.all([
-        fetchJSON(`/api/insights?limit_samples=60&history=60${force ? `&t=${Date.now()}` : ""}`),
+        fetchJSON(`/api/insights?limit_samples=60&history=60${profileParam}${force ? `&t=${Date.now()}` : ""}`),
         getConfiguredProviders(force).catch(() => null),
       ]);
       await renderFromData(data, false, force);
@@ -573,8 +613,9 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
     if (!force && now - _lastStatsFetch < 900) return;
     _lastStatsFetch = now;
     try {
+      const profileParam = overviewProfileId() ? `&user_profile=${encodeURIComponent(overviewProfileId())}` : "";
       const [data] = await Promise.all([
-        fetchJSON(`/api/insights?limit_samples=0&history=0&include_events=0${force ? `&t=${Date.now()}` : ""}`),
+        fetchJSON(`/api/insights?limit_samples=0&history=0&include_events=0${profileParam}${force ? `&t=${Date.now()}` : ""}`),
         getConfiguredProviders(force).catch(() => null),
       ]);
       await renderFromData(data, true, force);
@@ -596,6 +637,7 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
   }
 
   w.addEventListener("insights:settings-changed", () => { _prefs = loadPrefs(); _visibleFeats = visibleFeatures(_prefs); _feature = clampFeature(_feature); localStorage.setItem("insights.feature", _feature); refreshInsightsFastThenFull(true); });
+  w.addEventListener("cw:overview-profile-changed", () => refreshInsightsFastThenFull(true));
 
   w.Insights = Object.assign(w.Insights || {}, {
     renderSparkline, refreshInsights, refreshStats, fetchJSON, animateNumber, animateChart, titleOf, subtitleOf,

--- a/assets/js/modals/insight-settings/index.js
+++ b/assets/js/modals/insight-settings/index.js
@@ -44,6 +44,14 @@ const canonProv = (v) => {
 const provKey = (v) => canonProv(v).toLowerCase();
 const instKey = (v) => String(v || "default").trim() || "default";
 const provLabel = (v) => ProviderMeta().label?.(canonProv(v)) || canonProv(v);
+const overviewFilter = () => window.CW?.OverviewProfile?.filter || {};
+const overviewHasScope = () => !!Object.keys(overviewFilter() || {}).length;
+const overviewInstancesFor = (provider) => {
+  const filter = overviewFilter();
+  const up = canonProv(provider);
+  const low = provKey(provider);
+  return Array.isArray(filter[up]) ? filter[up].map(instKey) : Array.isArray(filter[low]) ? filter[low].map(instKey) : null;
+};
 
 const HTML = `
   <div class="cx-head">
@@ -86,7 +94,6 @@ const parseInstanceList = (raw) => {
     const label = typeof it === "object" && it ? String(it.label || "").trim() : "";
     if (label) out.labels[id] = label;
   }
-  if (!out.ids.includes("default")) out.ids.unshift("default");
   return out;
 };
 
@@ -173,7 +180,7 @@ const getAllowedProviders = (cfg = window._cfgCache || {}) => {
 };
 
 const buildProviders = async () => {
-  const labels = {}, byProvider = {}, [instApi, cfg] = await Promise.all([jget(`/api/provider-instances?cb=${Date.now()}`), jget(`/api/config?cb=${Date.now()}`)]);
+  const labels = {}, byProvider = {}, [instApi, cfg] = await Promise.all([jget(`/api/provider-instances?configured_only=true&cb=${Date.now()}`), jget(`/api/config?cb=${Date.now()}`)]);
   const metaOrder = ProviderMeta().order || [];
   const relevant = new Set((Array.isArray(metaOrder) ? metaOrder : []).map(canonProv));
   const instMap = instApi || {}, allowed = getAllowedProviders(cfg || window._cfgCache || {});
@@ -184,8 +191,13 @@ const buildProviders = async () => {
   };
   for (const prov of Array.from(allowed).filter((key) => relevant.has(key)).map(provKey).filter(Boolean).sort((a, b) => a.localeCompare(b))) {
     const parsed = parseInstanceList(await getRaw(prov));
-    if (!parsed.ids.length) continue;
-    byProvider[prov] = parsed.ids;
+    const scoped = overviewInstancesFor(prov);
+    if (overviewHasScope() && !Array.isArray(scoped)) continue;
+    const ids = Array.isArray(scoped)
+      ? parsed.ids.filter((id) => scoped.includes(instKey(id)))
+      : parsed.ids;
+    if (!ids.length) continue;
+    byProvider[prov] = ids;
     labels[prov] = parsed.labels;
   }
   return { byProvider, labels };
@@ -226,7 +238,7 @@ export default {
 
       const provKeys = Object.keys(byProvider).sort((a, b) => a.localeCompare(b));
       if (!provKeys.length) {
-        if (loading) loading.textContent = "No configured providers yet.";
+        if (loading) loading.textContent = overviewHasScope() ? "No provider instances assigned to this profile." : "No configured providers yet.";
       } else {
         if (loading) loading.style.display = "none";
         if (grid) {

--- a/services/activity.py
+++ b/services/activity.py
@@ -382,7 +382,7 @@ def list_events(
 
     display_items = _group_route_fanout(items) if group_routes else items
     start = max(0, int(offset or 0))
-    cap = max(1, min(500, int(limit or 100)))
+    cap = max(1, min(DEFAULT_LIMIT, int(limit or 100)))
     page = display_items[start:start + cap]
     return {
         "ok": True,


### PR DESCRIPTION
# Pull request

## Change

Scope activity feeds and insights data to the active user profile.

## Why

Managed users should only see activity, stats, and insight provider counts for their assigned instances.

## Testing

- tests/test_crosswatch_profiles.py
- tests/test_activity_db.py

## Issue

Relates to #728