### PR TITLE
Change: status views for managed users

### DIFF
--- a/api/probesAPI.py
+++ b/api/probesAPI.py
@@ -15,9 +15,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Callable, Mapping
 
 import requests
-from fastapi import FastAPI, Query
+from fastapi import FastAPI, Query, Request
 from fastapi.responses import JSONResponse
 
+from cw_platform.access_policy import filter_pairs_for_user, managed_profile_instances, request_user
 from cw_platform.config_base import load_config as _load_config
 
 from cw_platform.provider_instances import get_provider_block, list_instance_ids, normalize_instance_id, provider_key
@@ -2008,22 +2009,27 @@ USERINFO_FNS: dict[str, Callable[..., dict[str, Any]]] = {
 # Registry API
 def register_probes(app: FastAPI, load_config_fn: Callable[[], dict[str, Any]]) -> None:
     @app.get("/api/status", tags=["Probes"])
-    def api_status(fresh: int = Query(0)) -> JSONResponse:
+    def api_status(request: Request, fresh: int = Query(0)) -> JSONResponse:
+        cfg0 = load_config_fn() or {}
+        scoped_user = request_user(request)
+        managed_scope = bool(scoped_user and not scoped_user.get("is_admin"))
         now = time.time()
         cached = STATUS_CACHE["data"]
         age = (now - STATUS_CACHE["ts"]) if cached else 1e9
-        if not fresh and cached and age < STATUS_TTL:
+        if not managed_scope and not fresh and cached and age < STATUS_TTL:
             return JSONResponse(cached, headers={"Cache-Control": "no-store"})
 
         with STATUS_LOCK:
             now = time.time()
             cached = STATUS_CACHE["data"]
             age = (now - STATUS_CACHE["ts"]) if cached else 1e9
-            if not fresh and cached and age < STATUS_TTL:
+            if not managed_scope and not fresh and cached and age < STATUS_TTL:
                 return JSONResponse(cached, headers={"Cache-Control": "no-store"})
 
-            cfg = load_config_fn() or {}
+            cfg = cfg0 if managed_scope else (load_config_fn() or {})
             pairs = cfg.get("pairs") or []
+            if managed_scope:
+                pairs = filter_pairs_for_user(cfg, scoped_user, [p for p in pairs if isinstance(p, dict)])
             enabled_pairs = [p for p in pairs if isinstance(p, dict) and p.get("enabled", True) is not False]
             any_pair_ready = any(_pair_ready(cfg, p) for p in enabled_pairs)
 
@@ -2094,6 +2100,13 @@ def register_probes(app: FastAPI, load_config_fn: Callable[[], dict[str, Any]]) 
                     _add(s, "default")
                 return out
 
+            allowed_instances = managed_profile_instances(cfg, scoped_user) if managed_scope else {}
+
+            def _scope_allows(prov: str, inst: Any) -> bool:
+                if not managed_scope:
+                    return True
+                return normalize_instance_id(inst) in set(allowed_instances.get(prov) or [])
+
             pair_targets = _pair_targets()
             watcher_targets = _watcher_targets(cfg)
 
@@ -2104,7 +2117,7 @@ def register_probes(app: FastAPI, load_config_fn: Callable[[], dict[str, Any]]) 
 
             for prov, inst in pair_targets:
                 c = _canon_probe_code(prov)
-                if not c:
+                if not c or not _scope_allows(c, inst):
                     continue
                 targets.add((c, inst))
                 prov_sources.setdefault(c, set()).add("pair")
@@ -2112,7 +2125,7 @@ def register_probes(app: FastAPI, load_config_fn: Callable[[], dict[str, Any]]) 
 
             for prov, inst in watcher_targets:
                 c = _canon_probe_code(prov)
-                if not c:
+                if not c or not _scope_allows(c, inst):
                     continue
                 targets.add((c, inst))
                 prov_sources.setdefault(c, set()).add("watcher")
@@ -2125,7 +2138,9 @@ def register_probes(app: FastAPI, load_config_fn: Callable[[], dict[str, Any]]) 
                     normalize_instance_id(inst)
                     for inst in list_instance_ids(cfg, ck)
                 }
-                if prov == "NUVIO":
+                if managed_scope:
+                    insts &= set(allowed_instances.get(prov) or [])
+                if managed_scope or prov == "NUVIO":
                     insts = {
                         inst
                         for inst in insts
@@ -2620,8 +2635,9 @@ def register_probes(app: FastAPI, load_config_fn: Callable[[], dict[str, Any]]) 
                 "providers": providers_out,
             }
 
-            STATUS_CACHE["ts"] = now
-            STATUS_CACHE["data"] = data
+            if not managed_scope:
+                STATUS_CACHE["ts"] = now
+                STATUS_CACHE["data"] = data
             return JSONResponse(data, headers={"Cache-Control": "no-store"})
 
     @app.post("/api/debug/clear_probe_cache", tags=["Probes"])

--- a/assets/helpers/details-log.js
+++ b/assets/helpers/details-log.js
@@ -57,6 +57,39 @@ function _activeDetailsLogEl() {
   return document.getElementById("det-log");
 }
 
+function _detailsManagedUser() {
+  try {
+    const state = window.CW?.AuthState?.read?.() || {};
+    if (state.is_admin || state.isAdmin) return false;
+    if (state.managed || state.is_managed || state.isManaged) return true;
+    const role = String(state.role || document.documentElement?.dataset?.cwRole || "").toLowerCase();
+    return role === "user" || role === "managed";
+  } catch {
+    return false;
+  }
+}
+
+function _syncManagedDetailsTabs() {
+  const managed = _detailsManagedUser();
+  const tabWatch = document.getElementById("det-tab-watcher");
+  const tabDebug = document.getElementById("det-tab-debug");
+  const watchPanel = document.getElementById("det-panel-watcher");
+  const debugPanel = document.getElementById("det-panel-debug");
+  [tabWatch, tabDebug, watchPanel, debugPanel].forEach((el) => {
+    if (!el) return;
+    el.hidden = managed;
+    el.setAttribute("aria-hidden", String(managed));
+  });
+  if (managed && (window._detailsTab === "watcher" || window._detailsTab === "debug")) {
+    window._detailsTab = "sync";
+  }
+  if (managed) {
+    try { closeWatcherLog(); } catch {}
+    try { closeDebugLog(); } catch {}
+  }
+  return managed;
+}
+
 function _pruneDetailsLog(el) {
   const max = Number(window.DETAILS_MAX_LINES || 0) || 600;
   if (!el || !el.childNodes || el.childNodes.length <= max) return;
@@ -510,7 +543,8 @@ async function _copyDetailsLog(btn) {
 }
 
 function setDetailsTab(tab) {
-  const t = (tab === "watcher" || tab === "debug") ? tab : "sync";
+  const managed = _syncManagedDetailsTabs();
+  const t = managed ? "sync" : ((tab === "watcher" || tab === "debug") ? tab : "sync");
   window._detailsTab = t;
 
   const syncPanel  = document.getElementById("det-panel-sync");
@@ -551,6 +585,7 @@ function setDetailsTab(tab) {
 }
 
 function initDetailsTabs() {
+  _syncManagedDetailsTabs();
   if (window._detailsTabsWired) return;
   const tabSync  = document.getElementById("det-tab-sync");
   const tabWatch = document.getElementById("det-tab-watcher");
@@ -560,8 +595,8 @@ function initDetailsTabs() {
   _wireDetailsConsoleStatus();
 
   tabSync.addEventListener("click", () => setDetailsTab("sync"));
-  tabWatch.addEventListener("click", () => setDetailsTab("watcher"));
-  tabDebug.addEventListener("click", () => setDetailsTab("debug"));
+  tabWatch.addEventListener("click", () => { if (!_detailsManagedUser()) setDetailsTab("watcher"); });
+  tabDebug.addEventListener("click", () => { if (!_detailsManagedUser()) setDetailsTab("debug"); });
 
   const btnCopy = document.getElementById("det-copy");
   if (btnCopy) {
@@ -668,6 +703,7 @@ function closeDebugLog() {
 }
 
 function openDebugLog() {
+  if (_detailsManagedUser()) return;
   const el = document.getElementById("det-debug-log");
   const details = document.getElementById("details");
   const tabDebug = document.getElementById("det-tab-debug");
@@ -788,6 +824,7 @@ function openDebugLog() {
 }
 
 async function openWatcherLog() {
+  if (_detailsManagedUser()) return;
   const el = document.getElementById("det-watch-log");
   const details = document.getElementById("details");
   const tabWatch = document.getElementById("det-tab-watcher");

--- a/assets/js/schedulerbanner.js
+++ b/assets/js/schedulerbanner.js
@@ -34,26 +34,33 @@
     S={cfg:null,pairs:{total:0,active:0},sched:{enabled:false,running:false,next:0,advanced:false,captures:0,webhooks:false,webhookLabel:"",warning:false,warnings:[]},evt:{enabled:false,count:0},watch:{...blank(),alive:false},hook:blank(),system:{health:{known:false,ok:false,status:"checking"},update:{known:false,available:false,current:"",latest:"",url:""}},timers:{sched:null,scrob:null,health:null,wait:null,rotate:null},debounce:null,last:{watcher:"",webhook:""}};
   const SHARED_WATCH_KEY="__CW_CURRENT_WATCHING_SHARED__",SHARED_WATCH_TTL_MS=3000,WATCHER_UNAVAILABLE_GRACE_MS=35000;
   let scrobPollSeq=0;
+  const isManaged=()=>document.documentElement?.dataset?.cwRole==="user";
 
   if (!$("#sched-banner-css")) {
     const st=document.createElement("style");
     st.id="sched-banner-css";
-    st.textContent=`#ops-card .action-row{display:flex;align-items:flex-end;justify-content:flex-start;gap:12px;flex-wrap:wrap}#ops-card .action-buttons{display:flex;gap:10px;flex:1 1 640px;min-width:min(100%,540px);align-items:center;flex-wrap:wrap;order:1}#ops-card .cw-status-dock{display:flex;flex:1 1 100%;width:100%;min-width:0;justify-content:flex-end;align-items:center;margin-left:0;order:2}#sched-inline-log{position:static;z-index:2;pointer-events:none;display:flex;gap:10px;align-items:center;justify-content:flex-end;flex-wrap:wrap;max-width:100%;width:100%}#sched-inline-log .sched,#sched-inline-log .sched *,#sched-inline-log .sched *::before,#sched-inline-log .sched *::after{box-sizing:border-box}#sched-inline-log .sched{--chip-accent:#ef4444;position:relative;display:inline-flex;align-items:center;gap:10px;min-height:34px;max-width:min(420px,100%);padding:5px 12px;border-radius:999px;background:linear-gradient(180deg,rgba(17,21,29,.96),rgba(10,13,20,.98));backdrop-filter:blur(6px);border:1px solid rgba(255,255,255,.08);box-shadow:inset 0 1px 0 rgba(255,255,255,.03),0 8px 18px rgba(0,0,0,.24);overflow:hidden;pointer-events:auto;white-space:nowrap}#sched-inline-log .sched.ok,#sched-inline-log .sched.live{--chip-accent:#22c55e}#sched-inline-log .sched.idle{--chip-accent:#ef4444;background:linear-gradient(180deg,rgba(17,21,29,.94),rgba(10,13,20,.96));border-color:rgba(255,255,255,.07)}#sched-inline-log .sched.warn{--chip-accent:#ef4444;background:linear-gradient(180deg,rgba(30,16,18,.96),rgba(18,10,12,.98));border-color:rgba(211,106,106,.18)}#sched-inline-log .ic{position:relative;display:inline-flex!important;align-items:center!important;justify-content:center!important;align-self:center!important;flex:0 0 auto;z-index:1}#sched-inline-log .ic.dot{width:10px;height:10px;border-radius:50%;background:var(--chip-accent);box-shadow:0 0 0 1px rgba(0,0,0,.48),0 0 10px color-mix(in srgb,var(--chip-accent) 40%,transparent)}#sched-inline-log .sched.live .ic.dot::after{content:"";position:absolute;inset:-4px;border-radius:50%;border:1px solid color-mix(in srgb,var(--chip-accent) 42%,transparent);opacity:.7;animation:ringPulse 1.7s ease-out infinite}#sched-inline-log .copy{position:relative;z-index:1;display:inline-flex!important;align-items:center!important;align-self:center!important;gap:7px;min-width:0;max-width:100%;height:20px;line-height:20px;overflow:hidden}#sched-inline-log .label{display:inline-flex!important;align-items:center!important;align-self:center!important;vertical-align:middle!important;height:20px;line-height:20px;margin:0!important;padding:0!important;position:relative;top:0!important;bottom:auto!important;transform:none!important;font-size:10px;font-weight:800;letter-spacing:.14em;text-transform:uppercase;color:rgba(181,190,208,.76);flex:0 0 auto}#sched-inline-log .value,#sched-inline-log .meta,#sched-inline-log .badges{position:relative;top:-1.5px!important}#sched-inline-log .value,#sched-inline-log .meta{display:inline-flex!important;align-items:center!important;align-self:center!important;vertical-align:middle!important;height:20px;line-height:20px;margin:0!important;padding:0!important;bottom:auto!important;transform:none!important}#sched-inline-log .value{font-size:12px;font-weight:800;letter-spacing:.02em;color:#eef3ff;flex:0 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis}#sched-inline-log .meta{min-width:0;overflow:hidden;text-overflow:ellipsis;font-size:12px;font-weight:700;color:rgba(188,197,214,.68)}#sched-inline-log .badges{display:inline-flex!important;align-items:center!important;align-self:center!important;gap:6px;flex:0 0 auto;height:20px}#sched-inline-log .badge{display:inline-flex;align-items:center;justify-content:center;min-width:24px;height:18px;padding:0 6px;border-radius:999px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.05);color:rgba(232,238,250,.82);font-size:10px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;line-height:18px}#sched-inline-log .sched[data-tip]{cursor:help;transition:transform .16s ease,box-shadow .16s ease,border-color .16s ease,background .16s ease}#sched-inline-log .sched[data-tip]:hover{transform:translateY(-1px);border-color:rgba(255,255,255,.12);background:linear-gradient(180deg,rgba(20,24,32,.98),rgba(12,15,22,.99));box-shadow:inset 0 1px 0 rgba(255,255,255,.04),0 10px 22px rgba(0,0,0,.28)}#sched-inline-log .sched.warn[data-tip]:hover{background:linear-gradient(180deg,rgba(34,18,21,.98),rgba(22,11,14,.99))}#sched-inline-log .sched[data-tip]::after{content:attr(data-tip);position:absolute;left:50%;bottom:calc(100% + 8px);transform:translateX(-50%) translateY(4px);opacity:0;pointer-events:none;min-width:180px;max-width:min(320px,72vw);padding:8px 10px;border-radius:12px;background:rgba(10,13,20,.98);border:1px solid rgba(255,255,255,.08);box-shadow:0 10px 30px rgba(0,0,0,.34);color:#edf4ff;font-size:11px;font-weight:700;line-height:1.35;white-space:pre-line;text-align:left;transition:opacity .16s ease,transform .16s ease}#sched-inline-log .sched[data-tip]:hover::after{opacity:1;transform:translateX(-50%) translateY(0)}@keyframes ringPulse{0%{transform:scale(.72);opacity:.8}80%{transform:scale(1.28);opacity:0}100%{transform:scale(1.28);opacity:0}}@media (max-width:640px){#sched-inline-log{gap:8px}#sched-inline-log .sched{min-height:32px;padding:4px 10px;max-width:100%}#sched-inline-log .copy{gap:6px;height:18px;line-height:18px}#sched-inline-log .label,#sched-inline-log .value,#sched-inline-log .meta{height:18px;line-height:18px}#sched-inline-log .label{font-size:9px}#sched-inline-log .value,#sched-inline-log .meta{font-size:11px}#sched-inline-log .value,#sched-inline-log .meta,#sched-inline-log .badges{top:-1px!important}#sched-inline-log .badges{height:18px}#sched-inline-log .badge{height:17px;min-width:22px;padding:0 5px;font-size:9px;line-height:17px}}`;
+    st.textContent=`#ops-card .action-row{display:flex;align-items:center;justify-content:flex-start;gap:12px;flex-wrap:nowrap}#ops-card .action-buttons{display:flex;gap:10px;flex:0 0 auto;min-width:0;align-items:center;flex-wrap:nowrap;order:1}#ops-card .cw-status-dock{display:flex;flex:1 1 auto;width:auto;min-width:0;justify-content:flex-end;align-items:center;margin-left:auto;order:2}#ops-card .cw-status-dock:not(:has(.sched)){display:none}#sched-inline-log{position:static;z-index:2;pointer-events:none;display:flex;gap:10px;align-items:center;justify-content:flex-end;flex-wrap:wrap;max-width:100%;width:100%}#sched-inline-log .sched,#sched-inline-log .sched *,#sched-inline-log .sched *::before,#sched-inline-log .sched *::after{box-sizing:border-box}#sched-inline-log .sched{--chip-accent:#ef4444;position:relative;display:inline-flex;align-items:center;gap:10px;min-height:34px;max-width:min(420px,100%);padding:5px 12px;border-radius:999px;background:linear-gradient(180deg,rgba(17,21,29,.96),rgba(10,13,20,.98));backdrop-filter:blur(6px);border:1px solid rgba(255,255,255,.08);box-shadow:inset 0 1px 0 rgba(255,255,255,.03),0 8px 18px rgba(0,0,0,.24);overflow:hidden;pointer-events:auto;white-space:nowrap}#sched-inline-log .sched.ok,#sched-inline-log .sched.live{--chip-accent:#22c55e}#sched-inline-log .sched.idle{--chip-accent:#ef4444;background:linear-gradient(180deg,rgba(17,21,29,.94),rgba(10,13,20,.96));border-color:rgba(255,255,255,.07)}#sched-inline-log .sched.warn{--chip-accent:#ef4444;background:linear-gradient(180deg,rgba(30,16,18,.96),rgba(18,10,12,.98));border-color:rgba(211,106,106,.18)}#sched-inline-log .ic{position:relative;display:inline-flex!important;align-items:center!important;justify-content:center!important;align-self:center!important;flex:0 0 auto;z-index:1}#sched-inline-log .ic.dot{width:10px;height:10px;border-radius:50%;background:var(--chip-accent);box-shadow:0 0 0 1px rgba(0,0,0,.48),0 0 10px color-mix(in srgb,var(--chip-accent) 40%,transparent)}#sched-inline-log .sched.live .ic.dot::after{content:"";position:absolute;inset:-4px;border-radius:50%;border:1px solid color-mix(in srgb,var(--chip-accent) 42%,transparent);opacity:.7;animation:ringPulse 1.7s ease-out infinite}#sched-inline-log .copy{position:relative;z-index:1;display:inline-flex!important;align-items:center!important;align-self:center!important;gap:7px;min-width:0;max-width:100%;height:20px;line-height:20px;overflow:hidden}#sched-inline-log .label{display:inline-flex!important;align-items:center!important;align-self:center!important;vertical-align:middle!important;height:20px;line-height:20px;margin:0!important;padding:0!important;position:relative;top:0!important;bottom:auto!important;transform:none!important;font-size:10px;font-weight:800;letter-spacing:.14em;text-transform:uppercase;color:rgba(181,190,208,.76);flex:0 0 auto}#sched-inline-log .value,#sched-inline-log .meta,#sched-inline-log .badges{position:relative;top:-1.5px!important}#sched-inline-log .value,#sched-inline-log .meta{display:inline-flex!important;align-items:center!important;align-self:center!important;vertical-align:middle!important;height:20px;line-height:20px;margin:0!important;padding:0!important;bottom:auto!important;transform:none!important}#sched-inline-log .value{font-size:12px;font-weight:800;letter-spacing:.02em;color:#eef3ff;flex:0 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis}#sched-inline-log .meta{min-width:0;overflow:hidden;text-overflow:ellipsis;font-size:12px;font-weight:700;color:rgba(188,197,214,.68)}#sched-inline-log .badges{display:inline-flex!important;align-items:center!important;align-self:center!important;gap:6px;flex:0 0 auto;height:20px}#sched-inline-log .badge{display:inline-flex;align-items:center;justify-content:center;min-width:24px;height:18px;padding:0 6px;border-radius:999px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.05);color:rgba(232,238,250,.82);font-size:10px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;line-height:18px}#sched-inline-log .sched[data-tip]{cursor:help;transition:transform .16s ease,box-shadow .16s ease,border-color .16s ease,background .16s ease}#sched-inline-log .sched[data-tip]:hover{transform:translateY(-1px);border-color:rgba(255,255,255,.12);background:linear-gradient(180deg,rgba(20,24,32,.98),rgba(12,15,22,.99));box-shadow:inset 0 1px 0 rgba(255,255,255,.04),0 10px 22px rgba(0,0,0,.28)}#sched-inline-log .sched.warn[data-tip]:hover{background:linear-gradient(180deg,rgba(34,18,21,.98),rgba(22,11,14,.99))}#sched-inline-log .sched[data-tip]::after{content:attr(data-tip);position:absolute;left:50%;bottom:calc(100% + 8px);transform:translateX(-50%) translateY(4px);opacity:0;pointer-events:none;min-width:180px;max-width:min(320px,72vw);padding:8px 10px;border-radius:12px;background:rgba(10,13,20,.98);border:1px solid rgba(255,255,255,.08);box-shadow:0 10px 30px rgba(0,0,0,.34);color:#edf4ff;font-size:11px;font-weight:700;line-height:1.35;white-space:pre-line;text-align:left;transition:opacity .16s ease,transform .16s ease}#sched-inline-log .sched[data-tip]:hover::after{opacity:1;transform:translateX(-50%) translateY(0)}@keyframes ringPulse{0%{transform:scale(.72);opacity:.8}80%{transform:scale(1.28);opacity:0}100%{transform:scale(1.28);opacity:0}}@media (max-width:640px){#ops-card .action-row{flex-wrap:wrap}#ops-card .action-buttons{width:100%;flex-wrap:wrap}#ops-card .cw-status-dock{width:100%;margin-left:0}#sched-inline-log{gap:8px}#sched-inline-log .sched{min-height:32px;padding:4px 10px;max-width:100%}#sched-inline-log .copy{gap:6px;height:18px;line-height:18px}#sched-inline-log .label,#sched-inline-log .value,#sched-inline-log .meta{height:18px;line-height:18px}#sched-inline-log .label{font-size:9px}#sched-inline-log .value,#sched-inline-log .meta{font-size:11px}#sched-inline-log .value,#sched-inline-log .meta,#sched-inline-log .badges{top:-1px!important}#sched-inline-log .badges{height:18px}#sched-inline-log .badge{height:17px;min-width:22px;padding:0 5px;font-size:9px;line-height:17px}}`;
     st.textContent+=`
-#ops-card .action-row{--hub-service-good:#57b58a;--hub-service-bad:#e06470;--hub-service-disabled:#788291;--hub-action-bg:rgba(255,255,255,.035);--hub-action-hover:rgba(255,255,255,.065);--hub-card-bg:linear-gradient(180deg,rgba(20,24,34,.96),rgba(12,15,23,.98));--hub-card-border:rgba(255,255,255,.09);--hub-text:#eef3ff;--hub-muted:rgba(188,198,217,.68);display:grid!important;grid-template-columns:minmax(0,1fr)!important;justify-items:start!important;align-items:center!important;gap:14px!important;margin-top:14px!important;padding:14px!important;}
-#ops-card .action-buttons{display:flex!important;flex:0 1 auto!important;min-width:0!important;width:auto!important;align-items:center!important;justify-content:flex-start!important;gap:10px!important;order:1!important;}
-#ops-card .action-buttons .cw-hub-action{display:inline-flex!important;align-items:center!important;justify-content:center!important;gap:9px!important;min-width:132px!important;min-height:46px!important;height:46px!important;padding:0 16px!important;border-radius:14px!important;background:var(--hub-action-bg)!important;border:1px solid var(--hub-card-border)!important;color:var(--hub-text)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.035)!important;}
+#ops-card{--hub-service-good:#57b58a;--hub-service-bad:#e06470;--hub-service-disabled:#788291;--hub-action-bg:rgba(255,255,255,.035);--hub-action-hover:rgba(255,255,255,.065);--hub-card-bg:linear-gradient(180deg,rgba(20,24,34,.96),rgba(12,15,23,.98));--hub-card-border:rgba(255,255,255,.09);--hub-text:#eef3ff;--hub-muted:rgba(188,198,217,.68);}
+#ops-card .action-row{display:flex!important;align-items:center!important;justify-content:flex-start!important;flex-wrap:nowrap!important;gap:14px!important;margin-top:14px!important;padding:14px!important;}
+#ops-card .action-buttons{display:flex!important;flex:0 0 auto!important;min-width:0!important;width:auto!important;align-items:center!important;justify-content:flex-start!important;gap:10px!important;order:1!important;flex-wrap:nowrap!important;}
+#ops-card .action-buttons .cw-hub-action{display:inline-flex!important;align-items:center!important;justify-content:center!important;gap:9px!important;flex:0 0 auto!important;min-width:132px!important;min-height:46px!important;height:46px!important;padding:0 16px!important;border-radius:14px!important;background:var(--hub-action-bg)!important;border:1px solid var(--hub-card-border)!important;color:var(--hub-text)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.035)!important;white-space:nowrap!important;line-height:1!important;}
 #ops-card .action-buttons .cw-hub-action:hover{background:var(--hub-action-hover)!important;border-color:rgba(255,255,255,.16)!important;transform:translateY(-1px)!important;}
 #ops-card .action-buttons .cw-action-icon{font-size:21px!important;line-height:1!important;font-variation-settings:"FILL" 0,"wght" 450,"GRAD" 0,"opsz" 24;}
 #ops-card .action-buttons .cw-hub-action .cw-action-icon{color:var(--hub-text)!important;}
 #ops-card .action-buttons .cw-split-run .cw-sync-action-icon{color:var(--hub-service-good)!important;}
-#ops-card .cw-split-run{min-height:46px!important;height:46px!important;}
+#ops-card .cw-split-run{flex:0 0 auto!important;align-items:stretch!important;min-height:46px!important;height:46px!important;}
 #ops-card .cw-split-run .btn{min-height:44px!important;height:44px!important;}
-#ops-card .cw-split-run .cw-split-main{display:inline-flex!important;align-items:center!important;justify-content:center!important;gap:9px!important;min-width:146px!important;}
+#ops-card .cw-split-run .cw-split-main{display:inline-flex!important;align-items:center!important;justify-content:center!important;gap:9px!important;min-width:146px!important;white-space:nowrap!important;line-height:1!important;}
+#ops-card .action-buttons :is(.cw-hub-action,.cw-split-main,.cw-split-edge){box-sizing:border-box!important;display:inline-flex!important;align-items:center!important;justify-content:center!important;height:46px!important;min-height:46px!important;line-height:1!important;vertical-align:middle!important;font-size:14px!important;font-weight:850!important;}
+#ops-card .action-buttons .cw-split-edge{width:46px!important;min-width:46px!important;padding:0!important;}
+#ops-card .action-buttons :is(.cw-hub-action,.cw-split-main,.cw-split-edge)>span{display:inline-flex!important;align-items:center!important;justify-content:center!important;line-height:1!important;margin:0!important;position:static!important;transform:none!important;}
+#ops-card .action-buttons .material-symbols-rounded{width:24px!important;min-width:24px!important;height:24px!important;font-size:22px!important;line-height:24px!important;text-align:center!important;overflow:hidden!important;font-variation-settings:"FILL" 0,"wght" 450,"GRAD" 0,"opsz" 24!important;}
+#ops-card .action-buttons :is(.cw-hub-action,.cw-split-main)>span:not(.material-symbols-rounded){height:22px!important;line-height:22px!important;}
 #ops-card #run:is(.loading,.glass) .cw-sync-action-icon{animation:cwHubSyncSpin .8s linear infinite!important;}
-#ops-card .cw-status-dock{display:flex!important;flex:0 1 auto!important;box-sizing:border-box!important;width:100%!important;min-width:0!important;align-items:center!important;justify-content:flex-start!important;margin:0!important;padding-top:12px!important;border-top:1px solid var(--hub-card-border)!important;order:2!important;overflow:visible!important;}
-#ops-card .cw-status-dock:not(:has(.sched)){border-top-color:transparent!important;}
-#sched-inline-log{display:flex!important;width:100%!important;max-width:100%!important;align-items:flex-start!important;justify-content:flex-start!important;gap:18px!important;flex-wrap:nowrap!important;overflow:visible!important;}
+#ops-card .cw-status-dock{display:flex!important;flex:0 0 auto!important;box-sizing:border-box!important;width:100%!important;min-width:0!important;align-items:center!important;justify-content:flex-start!important;margin:10px 0 0!important;padding-top:12px!important;border-top:1px solid rgba(255,255,255,.08)!important;order:initial!important;overflow:visible!important;}
+#ops-card .cw-status-dock:not(:has(.sched)){display:none!important;}
+#sched-inline-log{display:flex!important;width:100%!important;max-width:100%!important;align-items:center!important;justify-content:flex-start!important;gap:18px!important;flex-wrap:nowrap!important;overflow:visible!important;}
 #ops-card #sched-inline-log .hub-status-group{position:relative;display:block;min-width:0;overflow:visible;}
 #ops-card #sched-inline-log .hub-status-group.is-hidden{display:none;}
 #ops-card #sched-inline-log .hub-group-system{margin-left:auto;}
@@ -109,22 +116,26 @@
 #ops-card #sched-inline-log .hub-status-group:first-child .sched:first-child[data-tip]:hover>.cw-hub-tip,#ops-card #sched-inline-log .hub-status-group:first-child .sched:first-child[data-tip]:focus-visible>.cw-hub-tip{transform:translateX(0) translateY(0);}
 #ops-card #sched-inline-log .hub-group-system .sched:last-child .cw-hub-tip{left:auto;right:0;transform:translateX(0) translateY(4px);}
 #ops-card #sched-inline-log .hub-group-system .sched:last-child[data-tip]:hover>.cw-hub-tip,#ops-card #sched-inline-log .hub-group-system .sched:last-child[data-tip]:focus-visible>.cw-hub-tip{transform:translateX(0) translateY(0);}
-html[data-cw-theme="flat-dark"] #ops-card .action-row{--hub-service-good:#57b58a;--hub-service-bad:#d86672;--hub-service-disabled:#7c8491;--hub-action-bg:#20242d;--hub-action-hover:#272c36;--hub-card-bg:#20242d;--hub-card-border:rgba(255,255,255,.13);--hub-text:#eef1f6;--hub-muted:#a9b0bd;}
-html[data-cw-theme="flat-light"] #ops-card .action-row{--hub-service-good:#276348;--hub-service-bad:#a93f4d;--hub-service-disabled:#98a2b3;--hub-action-bg:#fff;--hub-action-hover:#eef2f7;--hub-card-bg:#fff;--hub-card-border:rgba(16,24,40,.16);--hub-text:#172033;--hub-muted:#667085;}
-html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-service-bad:#e06470;--hub-service-disabled:#77808f;--hub-action-bg:rgba(255,255,255,.035);--hub-action-hover:rgba(255,255,255,.065);--hub-card-bg:linear-gradient(180deg,rgba(20,24,34,.96),rgba(12,15,23,.98));--hub-card-border:rgba(255,255,255,.09);--hub-text:#eef3ff;--hub-muted:rgba(188,198,217,.68);}
+html[data-cw-theme="flat-dark"] #ops-card{--hub-service-good:#57b58a;--hub-service-bad:#d86672;--hub-service-disabled:#7c8491;--hub-action-bg:#20242d;--hub-action-hover:#272c36;--hub-card-bg:#20242d;--hub-card-border:rgba(255,255,255,.13);--hub-text:#eef1f6;--hub-muted:#a9b0bd;}
+html[data-cw-theme="flat-light"] #ops-card{--hub-service-good:#276348;--hub-service-bad:#a93f4d;--hub-service-disabled:#98a2b3;--hub-action-bg:#fff;--hub-action-hover:#eef2f7;--hub-card-bg:#fff;--hub-card-border:rgba(16,24,40,.16);--hub-text:#172033;--hub-muted:#667085;}
+html.cw-theme-original #ops-card{--hub-service-good:#57b58a;--hub-service-bad:#e06470;--hub-service-disabled:#77808f;--hub-action-bg:rgba(255,255,255,.035);--hub-action-hover:rgba(255,255,255,.065);--hub-card-bg:linear-gradient(180deg,rgba(20,24,34,.96),rgba(12,15,23,.98));--hub-card-border:rgba(255,255,255,.09);--hub-text:#eef3ff;--hub-muted:rgba(188,198,217,.68);}
 #ops-card #sched-inline-log #chip-update.update-available::after{content:"";position:absolute;z-index:0;inset:0;border-radius:inherit;background:color-mix(in srgb,var(--hub-service-good) 22%,transparent);opacity:0;pointer-events:none;animation:cwHubUpdateBlink 2.8s ease-in-out infinite;}
 @keyframes cwHubUpdateBlink{0%,100%{opacity:0}50%{opacity:1}}
 @keyframes cwHubSyncSpin{to{transform:rotate(360deg)}}
 @media(prefers-reduced-motion:reduce){#ops-card #sched-inline-log #chip-update.update-available::after{animation:none;opacity:.7;}}
-@media(max-width:760px){#ops-card .action-buttons{width:100%!important;}#ops-card .action-buttons>.cw-split-run,#ops-card .action-buttons>.cw-hub-action{flex:1 1 150px!important;}#sched-inline-log{flex-wrap:wrap!important;}#ops-card #sched-inline-log .hub-group-system{margin-left:0;}}
+@media(max-width:760px){#ops-card .action-buttons{width:100%!important;flex-wrap:wrap!important;}#ops-card .action-buttons>.cw-split-run,#ops-card .action-buttons>.cw-hub-action{flex:1 1 150px!important;}#sched-inline-log{flex-wrap:wrap!important;}#ops-card #sched-inline-log .hub-group-system{margin-left:0;}}
 @media(max-width:480px){#ops-card .action-buttons>.cw-split-run,#ops-card .action-buttons>.cw-hub-action{flex:1 1 100%!important;}#ops-card #sched-inline-log .sched[data-tip]::after{left:0!important;transform:translateX(0) translateY(4px)!important;}#ops-card #sched-inline-log .sched[data-tip]:hover::after,#ops-card #sched-inline-log .sched[data-tip]:focus-visible::after{transform:translateX(0) translateY(0)!important;}}
 `;
     document.head.appendChild(st);
   }
 
-  const findBox=()=>$("#ops-card .cw-status-dock")||(()=>{
-    const row=$("#ops-card .action-row");
-    if (row) return row.appendChild(Object.assign(document.createElement("div"),{className:"cw-status-dock"}));
+  const findBox=()=>$("#ops-card>.cw-status-dock")||(()=>{
+    const card=$("#ops-card"), row=$("#ops-card .action-row"), existing=$("#ops-card .cw-status-dock");
+    if (card&&row) {
+      const dock=existing||Object.assign(document.createElement("div"),{className:"cw-status-dock"});
+      if (dock.parentElement!==card||dock.previousElementSibling!==row) row.insertAdjacentElement("afterend",dock);
+      return dock;
+    }
     for (const s of ["#ops-card","#ops-out","#ops_log","#sync-output",".sync-output","#ops"]) { const n=$(s); if (n) return n; }
     const h=[...document.querySelectorAll("h2,h3,h4,div.head,.head")].find(x=>(x.textContent||"").trim().toUpperCase()==="SYNC OUTPUT");
     return h?.parentElement?.querySelector("pre,textarea,.box,.card,div")||null;
@@ -158,10 +169,10 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
     if (!wrap) {
       wrap=document.createElement("div");
       wrap.id="sched-inline-log";
-      const statusTile=k=>{const nav=chipNav[k];return `<div class="sched idle${["sched","watch","hook"].includes(k)?" has-copy":""}" id="chip-${k}" role="${nav?"button":"status"}" tabindex="0"${nav?` data-nav="${nav.target}" data-nav-label="${nav.label}"`:""}><span class="ic service-icon material-symbols-rounded" aria-hidden="true">${chipIcon[k]}</span><span class="copy"><span class="label">${chipText[k]}</span><span class="value" id="${k}-value">-</span><span class="meta" id="${k}-meta"></span><span class="badges" id="${k}-badges"></span></span>${["watch","hook"].includes(k)?`<span class="watch-progress" aria-hidden="true"><span class="watch-progress-value" id="${k}-progress-value"></span></span>`:""}<span class="cw-hub-tip" aria-hidden="true"></span></div>`};
+      const statusTile=k=>{const nav=!isManaged()?chipNav[k]:null;return `<div class="sched idle${["sched","watch","hook"].includes(k)?" has-copy":""}" id="chip-${k}" role="${nav?"button":"status"}"${nav?` tabindex="0" data-nav="${nav.target}" data-nav-label="${nav.label}"`:""}><span class="ic service-icon material-symbols-rounded" aria-hidden="true">${chipIcon[k]}</span><span class="copy"><span class="label">${chipText[k]}</span><span class="value" id="${k}-value">-</span><span class="meta" id="${k}-meta"></span><span class="badges" id="${k}-badges"></span></span>${["watch","hook"].includes(k)?`<span class="watch-progress" aria-hidden="true"><span class="watch-progress-value" id="${k}-progress-value"></span></span>`:""}<span class="cw-hub-tip" aria-hidden="true"></span></div>`};
       wrap.innerHTML=`
         <div class="hub-status-group hub-group-monitoring">
-          <div class="hub-group-items">${["sched","watch","hook"].map(statusTile).join("")}</div>
+          <div class="hub-group-items">${(isManaged()?["watch","hook"]:["sched","watch","hook"]).map(statusTile).join("")}</div>
         </div>
         <div class="hub-status-group hub-group-system">
           <div class="hub-group-items">${["pairs","health","update"].map(statusTile).join("")}</div>
@@ -328,8 +339,9 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
   function render(){
     const host=ensureBanner();
     if (!host) return;
-    const E=k=>{const chip=$(`#chip-${k}`,host);return {chip,icon:$(".service-icon",chip),value:$(`#${k}-value`,host),meta:$(`#${k}-meta`,host),badges:$(`#${k}-badges`,host),tip:$(".cw-hub-tip",chip),progress:["watch","hook"].includes(k)?$(".watch-progress",chip):null,progressValue:["watch","hook"].includes(k)?$(`#${k}-progress-value`,host):null};},
+    const E=k=>{const chip=$(`#chip-${k}`,host);return {chip,icon:chip?$(".service-icon",chip):null,value:$(`#${k}-value`,host),meta:$(`#${k}-meta`,host),badges:$(`#${k}-badges`,host),tip:chip?$(".cw-hub-tip",chip):null,progress:["watch","hook"].includes(k)&&chip?$(".watch-progress",chip):null,progressValue:["watch","hook"].includes(k)?$(`#${k}-progress-value`,host):null};},
       pairs=E("pairs"), sched=E("sched"), watch=E("watch"), hook=E("hook"), health=E("health"), update=E("update"),
+      managed=isManaged(),
       watchItem=currentItem(S.watch),
       hookItem=currentItem(S.hook),
       watchLive=!!(watchItem&&S.watch.alive),
@@ -342,7 +354,7 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
     const pairTotal=Number(S.pairs?.total)||0, pairActive=Number(S.pairs?.active)||0;
     paint(pairs,pairTotal===0?{
       value:"none", ok:false, idle:true,
-      tip:"Sync pairs\nStatus: none configured\nCreate a sync pair to enable synchronization"
+      tip:managed?"Sync pairs\nStatus: none assigned":"Sync pairs\nStatus: none configured\nCreate a sync pair to enable synchronization"
     }:pairActive===0?{
       value:"available", ok:false, disabled:true,
       tip:`Sync pairs\nStatus: available but disabled\nConfigured: ${pairTotal}\nEnabled: 0`
@@ -351,7 +363,7 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
       tip:`Sync pairs\nStatus: active\nEnabled: ${pairActive} of ${pairTotal}`
     });
 
-    paint(sched,!S.sched.enabled?{
+    paint(sched,managed||!S.sched.enabled?{
       show:false
     }:{
       value:schedWarning?"":(S.sched.running?"":(S.sched.advanced?"advanced":"scheduled")),
@@ -385,7 +397,7 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
       tip:hookLive?tooltipFor(`Webhook • ${S.hook.streams} active stream${S.hook.streams===1?"":"s"}`,S.hook.items):"Webhook listening"
     });
     emit("webhook",hookLive?{title:hookItem.title,progress:Number(hookItem.progress)||0,state:hookItem.state||"playing",_streams_count:S.hook.streams}:{state:"stopped"});
-    $(".hub-group-monitoring",host)?.classList.toggle("is-hidden",[sched,watch,hook].every(item=>item.chip?.classList.contains("is-hidden")));
+    $(".hub-group-monitoring",host)?.classList.toggle("is-hidden",[(managed?null:sched),watch,hook].filter(Boolean).every(item=>item.chip?.classList.contains("is-hidden")));
 
     const healthState=S.system.health||{};
     if (health.icon) health.icon.textContent=healthState.known&&!healthState.ok?"arrow_downward":"arrow_upward";
@@ -401,7 +413,10 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
     });
 
     const updateState=S.system.update||{};
-    paint(update,!updateState.known?{
+    paint(update,managed?{
+      value:"admin", ok:false, disabled:true,
+      tip:"Updates\nManaged by administrator"
+    }:!updateState.known?{
       value:"checking", ok:false, disabled:true,
       tip:"Updates\nStatus: checking"
     }:updateState.available?{
@@ -560,7 +575,7 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
   }
 
   const scheduleHealth=()=>S.timers.health=setTimeout(()=>pollHealth(),30000),
-    scheduleSched=()=>S.sched.enabled&&(S.timers.sched=setTimeout(()=>pollSched(false),30000)),
+    scheduleSched=()=>S.sched.enabled&&!isManaged()&&(S.timers.sched=setTimeout(()=>pollSched(false),30000)),
     scheduleScrob=()=>S.cfg?.scrobble?.enabled&&(S.timers.scrob=setTimeout(()=>pollScrob(false),scrobSources().webhook?5000:15000)),
     stop=()=>["sched","scrob","health","rotate"].forEach(clear);
 
@@ -580,7 +595,7 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
     stop();
     [S.cfg]=await Promise.all([readConfig(forceCfg),pollPairs(forceCfg),pollHealth()]);
     applyUpdateStatus();
-    if (!schedulingOn(S.cfg?.scheduling) && !S.cfg?.scrobble?.enabled) {
+    if ((isManaged()||!schedulingOn(S.cfg?.scheduling)) && !S.cfg?.scrobble?.enabled) {
       S.sched={enabled:false,running:false,next:0,advanced:false,captures:0,webhooks:false,webhookLabel:"",warning:false,warnings:[]};
       S.evt={enabled:false,count:0};
       S.watch={...blank(),alive:false};
@@ -588,7 +603,7 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
       clear("rotate");
       return render();
     }
-    schedulingOn(S.cfg?.scheduling)?await pollSched(true):(S.sched={enabled:false,running:false,next:0,advanced:false,captures:0,webhooks:false,webhookLabel:"",warning:false,warnings:[]},S.evt={enabled:false,count:0});
+    !isManaged()&&schedulingOn(S.cfg?.scheduling)?await pollSched(true):(S.sched={enabled:false,running:false,next:0,advanced:false,captures:0,webhooks:false,webhookLabel:"",warning:false,warnings:[]},S.evt={enabled:false,count:0});
     S.cfg?.scrobble?.enabled?await pollScrob(true):(S.watch.enabled=S.hook.enabled=false,render());
   }
 
@@ -612,7 +627,7 @@ html.cw-theme-original #ops-card .action-row{--hub-service-good:#57b58a;--hub-se
     document.addEventListener("cx-state-change",refreshPairs);
     document.addEventListener("cw-update-status",event=>{applyUpdateStatus(event?.detail);render();});
     window.addEventListener("auth-changed",()=>queueRefresh(true));
-    document.addEventListener("scheduling-status-refresh",()=>pollSched(true));
+    document.addEventListener("scheduling-status-refresh",()=>!isManaged()&&pollSched(true));
     document.addEventListener("watcher-status-refresh",()=>pollScrob(true));
     document.addEventListener("tab-changed",e=>["main","settings"].includes(e?.detail?.id)&&queueRefresh(false));
     window.addEventListener("focus",()=>queueRefresh(false));


### PR DESCRIPTION
# Pull request

## Change

Scope provider status output for managed users and hide admin-only run/debug status UI.

## Why

Managed users should only see the status and logs tied to their assigned profile access.

## Testing

- tests/test_crosswatch_profiles.py
- tests/test_access_audit_fixes.py

## Issue

Relates to #728