### PR TITLE
Change: capture tools by profile

### DIFF
--- a/api/snapshotsAPI.py
+++ b/api/snapshotsAPI.py
@@ -3,11 +3,14 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
-from fastapi import APIRouter, Body, Query
+from fastapi import APIRouter, Body, Query, Request
 from fastapi.responses import JSONResponse
 
+from cw_platform.access_policy import filter_instances_for_user, request_user, user_can_access_instance
+from cw_platform.config_base import load_config
+from cw_platform.provider_instances import normalize_instance_id, provider_display_key
 from services.snapshots import (
     clear_provider_features,
     create_snapshot,
@@ -65,26 +68,71 @@ def _err(msg: str, *, status_code: int = 400, extra: dict[str, Any] | None = Non
     return JSONResponse(payload, status_code=status_code)
 
 
+def _is_admin_request(request: Request | None) -> bool:
+    user = request_user(request)
+    return not user or bool(user.get("is_admin"))
+
+
+def _scope_denied() -> JSONResponse:
+    return JSONResponse({"ok": False, "error": "profile_scope_denied"}, status_code=403)
+
+
+def _snapshot_allowed(cfg: dict[str, Any], request: Request | None, snap: dict[str, Any]) -> bool:
+    provider = provider_display_key(snap.get("provider"))
+    instance = normalize_instance_id(snap.get("instance") or snap.get("instance_id") or snap.get("profile") or "default")
+    return user_can_access_instance(cfg, request_user(request), provider, instance)
+
+
+def _filter_snapshot_rows(cfg: dict[str, Any], request: Request | None, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if _is_admin_request(request):
+        return rows
+    return [row for row in rows if isinstance(row, dict) and _snapshot_allowed(cfg, request, row)]
+
+
 @router.get("/manifest")
-def api_snapshots_manifest() -> JSONResponse:
+def api_snapshots_manifest(request: Request = cast(Request, None)) -> JSONResponse:
     try:
-        return _ok({"providers": snapshot_manifest()})
+        cfg = load_config() or {}
+        providers = snapshot_manifest(cfg)
+        user = request_user(request)
+        if user and not bool(user.get("is_admin")):
+            scoped: list[dict[str, Any]] = []
+            for provider in providers:
+                if not isinstance(provider, dict):
+                    continue
+                insts = provider.get("instances")
+                if not isinstance(insts, list):
+                    continue
+                allowed_ids = set(filter_instances_for_user(cfg, user, provider.get("id"), [normalize_instance_id(inst.get("id")) for inst in insts if isinstance(inst, dict)]))
+                keep = [inst for inst in insts if isinstance(inst, dict) and normalize_instance_id(inst.get("id")) in allowed_ids]
+                if not keep:
+                    continue
+                row = dict(provider)
+                row["instances"] = keep
+                row["configured"] = any(bool(inst.get("configured")) for inst in keep)
+                scoped.append(row)
+            providers = scoped
+        return _ok({"providers": providers})
     except Exception as e:
         return _err(str(e))
 
 
 @router.get("/list")
-def api_snapshots_list() -> JSONResponse:
+def api_snapshots_list(request: Request = cast(Request, None)) -> JSONResponse:
     try:
-        return _ok({"snapshots": list_snapshots()})
+        cfg = load_config() or {}
+        return _ok({"snapshots": _filter_snapshot_rows(cfg, request, list_snapshots())})
     except Exception as e:
         return _err(str(e))
 
 
 @router.get("/read")
-def api_snapshots_read(path: str = Query(..., description="Relative path under /config/snapshots")) -> JSONResponse:
+def api_snapshots_read(path: str = Query(..., description="Relative path under /config/snapshots"), request: Request = cast(Request, None)) -> JSONResponse:
     try:
         snap = read_snapshot(path)
+        cfg = load_config() or {}
+        if not _snapshot_allowed(cfg, request, snap):
+            return _scope_denied()
         return _ok({"snapshot": snap})
     except Exception as e:
         return _err(str(e))
@@ -97,8 +145,12 @@ def api_snapshots_diff(
     b: str = Query(..., description="Snapshot B path (relative under /config/snapshots)"),
     limit: int = Query(200, ge=1, le=2000),
     max_changes: int = Query(25, ge=1, le=200),
+    request: Request = cast(Request, None),
 ) -> JSONResponse:
     try:
+        cfg = load_config() or {}
+        if not _snapshot_allowed(cfg, request, read_snapshot(a)) or not _snapshot_allowed(cfg, request, read_snapshot(b)):
+            return _scope_denied()
         res = diff_snapshots(a, b, limit=limit, max_changes=max_changes)
         return _ok({"diff": res})
     except Exception as e:
@@ -116,8 +168,12 @@ def api_snapshots_diff_extended(
     limit: int = Query(5000, ge=1, le=20000),
     max_changes: int = Query(250, ge=1, le=1000),
     max_depth: int = Query(6, ge=1, le=12),
+    request: Request = cast(Request, None),
 ) -> JSONResponse:
     try:
+        cfg = load_config() or {}
+        if not _snapshot_allowed(cfg, request, read_snapshot(a)) or not _snapshot_allowed(cfg, request, read_snapshot(b)):
+            return _scope_denied()
         res = diff_snapshots_extended(
             a,
             b,
@@ -134,7 +190,7 @@ def api_snapshots_diff_extended(
         return _err(str(e))
 
 @router.post("/create")
-def api_snapshots_create(body: dict[str, Any] = Body(...)) -> JSONResponse:
+def api_snapshots_create(body: dict[str, Any] = Body(...), request: Request = cast(Request, None)) -> JSONResponse:
     provider = str(body.get("provider") or "").strip()
     instance = str(body.get("instance") or body.get("instance_id") or body.get("profile") or "").strip()
     feature = str(body.get("feature") or "").strip().lower()
@@ -142,6 +198,9 @@ def api_snapshots_create(body: dict[str, Any] = Body(...)) -> JSONResponse:
     progress_id = str(body.get("progress_id") or body.get("progressId") or "").strip()
     background = bool(body.get("background") or body.get("async") or body.get("async_job"))
     try:
+        cfg = load_config() or {}
+        if not user_can_access_instance(cfg, request_user(request), provider, instance):
+            return _scope_denied()
         if background:
             job = start_capture_job(provider, feature, label=label, instance_id=instance, progress_id=progress_id or None)  # type: ignore[arg-type]
             return _ok({"job": job, "progress_id": job["progress_id"]}, status_code=202)
@@ -163,13 +222,19 @@ def api_snapshots_capture_progress(progress_id: str) -> JSONResponse:
 
 
 @router.post("/restore")
-def api_snapshots_restore(body: dict[str, Any] = Body(...)) -> JSONResponse:
+def api_snapshots_restore(body: dict[str, Any] = Body(...), request: Request = cast(Request, None)) -> JSONResponse:
     path = str(body.get("path") or "").strip()
     mode = str(body.get("mode") or "merge").strip().lower()
     instance = str(body.get("instance") or body.get("instance_id") or body.get("profile") or "").strip()
     progress_id = str(body.get("progress_id") or body.get("progressId") or "").strip()
     background = bool(body.get("background") or body.get("async") or body.get("async_job"))
     try:
+        cfg = load_config() or {}
+        snap = read_snapshot(path)
+        provider = provider_display_key(snap.get("provider"))
+        target_instance = normalize_instance_id(instance or snap.get("instance") or snap.get("instance_id") or snap.get("profile") or "default")
+        if not _snapshot_allowed(cfg, request, snap) or not user_can_access_instance(cfg, request_user(request), provider, target_instance):
+            return _scope_denied()
         if background:
             job = start_restore_job(path, mode=mode, instance_id=instance, progress_id=progress_id or None)  # type: ignore[arg-type]
             return _ok({"job": job, "progress_id": job["progress_id"]}, status_code=202)
@@ -180,10 +245,13 @@ def api_snapshots_restore(body: dict[str, Any] = Body(...)) -> JSONResponse:
 
 
 @router.post("/delete")
-def api_snapshots_delete(body: dict[str, Any] = Body(...)) -> JSONResponse:
+def api_snapshots_delete(body: dict[str, Any] = Body(...), request: Request = cast(Request, None)) -> JSONResponse:
     path = str(body.get("path") or "").strip()
     delete_children = bool(body.get("delete_children", True))
     try:
+        cfg = load_config() or {}
+        if not _snapshot_allowed(cfg, request, read_snapshot(path)):
+            return _scope_denied()
         res = delete_snapshot(path, delete_children=delete_children)
         return _ok({"result": res})
     except Exception as e:
@@ -191,8 +259,10 @@ def api_snapshots_delete(body: dict[str, Any] = Body(...)) -> JSONResponse:
 
 
 @router.post("/clear")
-def api_snapshots_clear() -> JSONResponse:
+def api_snapshots_clear(request: Request = cast(Request, None)) -> JSONResponse:
     try:
+        if not _is_admin_request(request):
+            return _scope_denied()
         result = delete_all_snapshots()
         if not result.get("ok"):
             return _err("snapshot_clear_failed", extra={"result": result})
@@ -202,7 +272,7 @@ def api_snapshots_clear() -> JSONResponse:
 
 
 @router.post("/tools/clear")
-def api_snapshots_tools_clear(body: dict[str, Any] = Body(...)) -> JSONResponse:
+def api_snapshots_tools_clear(body: dict[str, Any] = Body(...), request: Request = cast(Request, None)) -> JSONResponse:
     provider = str(body.get("provider") or "").strip()
     instance = str(body.get("instance") or body.get("instance_id") or body.get("profile") or "").strip()
     progress_id = str(body.get("progress_id") or body.get("progressId") or "").strip()
@@ -215,6 +285,9 @@ def api_snapshots_tools_clear(body: dict[str, Any] = Body(...)) -> JSONResponse:
             if s:
                 features.append(s)
     try:
+        cfg = load_config() or {}
+        if not user_can_access_instance(cfg, request_user(request), provider, instance):
+            return _scope_denied()
         if background:
             job = start_provider_cleanup_job(provider, features, instance_id=instance, progress_id=progress_id or None)  # type: ignore[arg-type]
             return _ok({"job": job, "progress_id": job["progress_id"]}, status_code=202)

--- a/assets/js/snapshots.js
+++ b/assets/js/snapshots.js
@@ -3,6 +3,8 @@
 /* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
 (function () {
   const authSetupPending = () => window.cwIsAuthSetupPending?.() === true;
+  const isManagedUser = () => document.documentElement?.dataset?.cwRole === "user";
+  const schedulerAvailable = () => !isManagedUser();
   let authRetryWired = false;
 
   const $ = (sel, root = document) => root.querySelector(sel);
@@ -566,7 +568,9 @@ function bundleKey(s) {
       window.setTimeout(() => refresh(true, false), 80);
     });
     $("#ss-create", page)?.addEventListener("click", () => onCreate());
-    $("#ss-add-schedule", page)?.addEventListener("click", () => onAddToScheduler());
+    const addScheduleBtn = $("#ss-add-schedule", page);
+    if (schedulerAvailable()) addScheduleBtn?.addEventListener("click", () => onAddToScheduler());
+    else addScheduleBtn?.remove();
     $("#ss-send-schedule-queue", page)?.addEventListener("click", () => onSendScheduleQueue());
     $("#ss-clear-schedule-queue", page)?.addEventListener("click", () => {
       state.scheduleQueue = [];
@@ -1846,7 +1850,7 @@ function renderSelected() {
     const clearBtn = $("#ss-clear-schedule-queue", page);
     if (!host) return;
     const items = Array.isArray(state.scheduleQueue) ? state.scheduleQueue : [];
-    if (wrap) wrap.classList.toggle("hidden", !items.length);
+    if (wrap) wrap.classList.toggle("hidden", !schedulerAvailable() || !items.length);
     if (sendBtn) sendBtn.disabled = !items.length;
     if (clearBtn) clearBtn.disabled = !items.length;
     if (!items.length) {

--- a/tests/test_capture_restore_compare_tools.py
+++ b/tests/test_capture_restore_compare_tools.py
@@ -621,7 +621,7 @@ def test_captures_ui_scheduler_queue_hides_when_empty() -> None:
     queue_body = js[js.index("function renderScheduleQueue()") : js.index("  function setScheduleQueueFeedback(")]
 
     assert 'id="ss-schedule-queue-wrap" class="ss-queue hidden"' in js
-    assert 'wrap.classList.toggle("hidden", !items.length);' in queue_body
+    assert 'wrap.classList.toggle("hidden", !schedulerAvailable() || !items.length);' in queue_body
     assert 'host.innerHTML = "";' in queue_body
     assert '.join(" / ")' in queue_body
     assert "Ã" not in queue_body


### PR DESCRIPTION
# Pull request

## Change

Scope snapshot manifests, reads, restores, deletes, and cleanup tools by profile access.

## Why

Managed users should only work with captures for provider instances assigned to them.

## Testing

- tests/test_capture_restore_compare_tools.py
- tests/test_crosswatch_profiles.py

## Issue

Relates to #728