### PR TITLE
Fix: hide exception details in API error responses

### DIFF
--- a/api/snapshotsAPI.py
+++ b/api/snapshotsAPI.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import logging
 from typing import Any, Literal, cast
 
 from fastapi import APIRouter, Body, Query, Request
@@ -29,6 +30,7 @@ from services.snapshots import (
 )
 
 router = APIRouter(prefix="/api/snapshots", tags=["snapshots"])
+_LOG = logging.getLogger("crosswatch.api.snapshots")
 
 RestoreMode = Literal["merge", "clear_restore"]
 Feature = Literal["watchlist", "ratings", "history", "progress", "all"]
@@ -46,6 +48,16 @@ _SAFE_ERROR_PREFIXES = (
     "Advanced compare supports",
     "Invalid capture contents",
     "Invalid compare kind",
+    "snapshot_manifest_failed",
+    "snapshot_list_failed",
+    "snapshot_read_failed",
+    "snapshot_diff_failed",
+    "snapshot_create_failed",
+    "snapshot_progress_failed",
+    "snapshot_restore_failed",
+    "snapshot_delete_failed",
+    "snapshot_clear_failed",
+    "snapshot_tools_clear_failed",
 )
 
 
@@ -66,6 +78,10 @@ def _err(msg: str, *, status_code: int = 400, extra: dict[str, Any] | None = Non
     if extra:
         payload.update(extra)
     return JSONResponse(payload, status_code=status_code)
+
+
+def _log_failure(action: str, exc: Exception) -> None:
+    _LOG.warning("%s failed", action, exc_info=True)
 
 
 def _is_admin_request(request: Request | None) -> bool:
@@ -114,7 +130,8 @@ def api_snapshots_manifest(request: Request = cast(Request, None)) -> JSONRespon
             providers = scoped
         return _ok({"providers": providers})
     except Exception as e:
-        return _err(str(e))
+        _log_failure("snapshot manifest request", e)
+        return _err("snapshot_manifest_failed")
 
 
 @router.get("/list")
@@ -123,7 +140,8 @@ def api_snapshots_list(request: Request = cast(Request, None)) -> JSONResponse:
         cfg = load_config() or {}
         return _ok({"snapshots": _filter_snapshot_rows(cfg, request, list_snapshots())})
     except Exception as e:
-        return _err(str(e))
+        _log_failure("snapshot list request", e)
+        return _err("snapshot_list_failed")
 
 
 @router.get("/read")
@@ -135,7 +153,8 @@ def api_snapshots_read(path: str = Query(..., description="Relative path under /
             return _scope_denied()
         return _ok({"snapshot": snap})
     except Exception as e:
-        return _err(str(e))
+        _log_failure("snapshot read request", e)
+        return _err("snapshot_read_failed")
 
 
 
@@ -154,7 +173,8 @@ def api_snapshots_diff(
         res = diff_snapshots(a, b, limit=limit, max_changes=max_changes)
         return _ok({"diff": res})
     except Exception as e:
-        return _err(str(e))
+        _log_failure("snapshot diff request", e)
+        return _err("snapshot_diff_failed")
 
 
 @router.get("/diff/extended")
@@ -187,7 +207,8 @@ def api_snapshots_diff_extended(
         )
         return _ok({"diff": res})
     except Exception as e:
-        return _err(str(e))
+        _log_failure("snapshot extended diff request", e)
+        return _err("snapshot_diff_failed")
 
 @router.post("/create")
 def api_snapshots_create(body: dict[str, Any] = Body(...), request: Request = cast(Request, None)) -> JSONResponse:
@@ -207,7 +228,8 @@ def api_snapshots_create(body: dict[str, Any] = Body(...), request: Request = ca
         res = create_snapshot(provider, feature, label=label, instance_id=instance, progress_id=progress_id or None)  # type: ignore[arg-type]
         return _ok({"snapshot": res})
     except Exception as e:
-        return _err(str(e))
+        _log_failure("snapshot create request", e)
+        return _err("snapshot_create_failed")
 
 
 @router.get("/capture-progress/{progress_id}")
@@ -218,7 +240,8 @@ def api_snapshots_capture_progress(progress_id: str) -> JSONResponse:
             return _ok({"progress": {"ok": False, "done": False, "stage": "waiting", "message": "Waiting for capture to start.", "percent": 0}})
         return _ok({"progress": progress})
     except Exception as e:
-        return _err(str(e))
+        _log_failure("snapshot capture progress request", e)
+        return _err("snapshot_progress_failed")
 
 
 @router.post("/restore")
@@ -241,7 +264,8 @@ def api_snapshots_restore(body: dict[str, Any] = Body(...), request: Request = c
         res = restore_snapshot(path, mode=mode, instance_id=instance)  # type: ignore[arg-type]
         return _ok({"result": res})
     except Exception as e:
-        return _err(str(e))
+        _log_failure("snapshot restore request", e)
+        return _err("snapshot_restore_failed")
 
 
 @router.post("/delete")
@@ -255,7 +279,8 @@ def api_snapshots_delete(body: dict[str, Any] = Body(...), request: Request = ca
         res = delete_snapshot(path, delete_children=delete_children)
         return _ok({"result": res})
     except Exception as e:
-        return _err(str(e))
+        _log_failure("snapshot delete request", e)
+        return _err("snapshot_delete_failed")
 
 
 @router.post("/clear")
@@ -265,10 +290,11 @@ def api_snapshots_clear(request: Request = cast(Request, None)) -> JSONResponse:
             return _scope_denied()
         result = delete_all_snapshots()
         if not result.get("ok"):
-            return _err("snapshot_clear_failed", extra={"result": result})
+            return _err("snapshot_clear_failed")
         return _ok({"result": result, "summary": result.get("summary") or {}})
     except Exception as e:
-        return _err(str(e))
+        _log_failure("snapshot clear request", e)
+        return _err("snapshot_clear_failed")
 
 
 @router.post("/tools/clear")
@@ -294,4 +320,5 @@ def api_snapshots_tools_clear(body: dict[str, Any] = Body(...), request: Request
         res = clear_provider_features(provider, features, instance_id=instance)  # type: ignore[arg-type]
         return _ok({"result": res})
     except Exception as e:
-        return _err(str(e))
+        _log_failure("snapshot tools clear request", e)
+        return _err("snapshot_tools_clear_failed")

--- a/services/watchlist.py
+++ b/services/watchlist.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Mapping, cast
@@ -15,6 +16,8 @@ from cw_platform.local_db import watchlist_hide as sqlite_watchlist_hide
 from cw_platform.modules_registry import load_sync_ops, sync_provider_names
 from cw_platform.orchestrator._state_store import StateStore
 from cw_platform.provider_instances import build_config_view, list_instance_ids, normalize_instance_id
+
+_LOG = logging.getLogger("crosswatch.services.watchlist")
 
 try:
     from plexapi.myplex import MyPlexAccount
@@ -299,7 +302,7 @@ def _ids_from_key_or_item(key: str, item: dict[str, Any]) -> dict[str, Any]:
     if len(parts) >= 2:
         k = parts[-2].lower().strip()
         v = parts[-1].strip()
-        if k in {"tmdb", "imdb", "tvdb", "trakt", "slug", "jellyfin", "emby", "anilist", "mal"} and v:
+        if k in {"tmdb", "imdb", "tvdb", "trakt", "simkl", "mdblist", "slug", "jellyfin", "emby", "anilist", "mal"} and v:
             ids.setdefault(k, v)
     if "thetvdb" in ids and "tvdb" not in ids:
         ids["tvdb"] = ids.get("thetvdb")
@@ -313,6 +316,7 @@ def _ids_from_key_or_item(key: str, item: dict[str, Any]) -> dict[str, Any]:
         "tvdb",
         "trakt",
         "simkl",
+        "mdblist",
         "slug",
         "jellyfin",
         "emby",
@@ -328,7 +332,7 @@ def _ids_from_key_or_item(key: str, item: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
-_WATCHLIST_ALIAS_ID_KEYS = ("tmdb", "imdb", "tvdb", "trakt", "slug", "anilist", "mal")
+_WATCHLIST_ALIAS_ID_KEYS = ("tmdb", "imdb", "tvdb", "trakt", "simkl", "mdblist", "slug", "anilist", "mal")
 
 
 def _watchlist_alias_tokens(key: str, item: dict[str, Any]) -> set[str]:
@@ -383,7 +387,7 @@ def _group_watchlist_refs(
 
 def _preferred_watchlist_key(alias_keys: list[str], info: dict[str, Any], typ: str) -> str:
     ids = _ids_from_key_or_item("", info)
-    ordered = ("tmdb", "imdb", "tvdb", "trakt", "slug", "anilist", "mal")
+    ordered = ("tmdb", "imdb", "tvdb", "trakt", "simkl", "mdblist", "slug", "anilist", "mal")
 
     for name in ordered:
         value = ids.get(name)
@@ -1634,8 +1638,9 @@ def delete_watchlist_batch(
                     if _del_key_from_provider_items(state, p, k, instance_id=inst):
                         removed.add(k)
                 per_instance[inst] = {"ok": True, "removed": len(removed)}
-            except Exception as e:
-                per_instance[inst] = {"ok": False, "error": str(e)}
+            except Exception:
+                _LOG.warning("watchlist batch delete failed for %s/%s", p, inst, exc_info=True)
+                per_instance[inst] = {"ok": False, "error": "delete_failed"}
         return {"ok": any(v.get("ok") for v in per_instance.values()), "per_instance": per_instance, "removed": len(removed)}
 
     if prov == "ALL":
@@ -1675,17 +1680,19 @@ def delete_watchlist_item(
     allowed_instances: Mapping[str, list[str]] | None = None,
 ) -> dict[str, Any]:
     prov = (provider or "ALL").upper().strip()
-    try:
-        state = _load_sync_state(_sync_state_base(state_path))
-    except Exception as e:
-        return {"ok": False, "status": "error", "provider": prov, "key": key, "error": str(e)}
-
     def _log(level: str, msg: str) -> None:
         try:
             if callable(log):
                 log(level, msg)
         except Exception:
             pass
+
+    try:
+        state = _load_sync_state(_sync_state_base(state_path))
+    except Exception:
+        _LOG.warning("watchlist delete failed while loading state", exc_info=True)
+        _log("SYNC", f"[WL] delete {key} on {prov} failed")
+        return {"ok": False, "status": "error", "provider": prov, "key": key, "error": "delete_failed"}
 
     try:
         res = delete_watchlist_batch(
@@ -1700,9 +1707,10 @@ def delete_watchlist_item(
         _log("SYNC", f"[WL] delete {key} on {prov}: {'OK' if res.get('ok') else 'NOOP'}")
         res.setdefault("key", key)
         return res
-    except Exception as e:
-        _log("SYNC", f"[WL] delete {key} on {prov} failed: {e}")
-        return {"ok": False, "status": "error", "provider": prov, "key": key, "error": str(e)}
+    except Exception:
+        _LOG.warning("watchlist delete failed for provider %s", prov, exc_info=True)
+        _log("SYNC", f"[WL] delete {key} on {prov} failed")
+        return {"ok": False, "status": "error", "provider": prov, "key": key, "error": "delete_failed"}
 
 def detect_available_watchlist_providers(
     cfg: dict[str, Any],

--- a/tests/test_auth_security_responses.py
+++ b/tests/test_auth_security_responses.py
@@ -209,6 +209,57 @@ def test_app_auth_mutation_errors_do_not_expose_exception_text(monkeypatch) -> N
         assert _json_body(resp)["error"] == expected_error
 
 
+def test_snapshots_api_errors_do_not_expose_exception_text(monkeypatch) -> None:
+    from api import snapshotsAPI
+
+    secret = "Traceback C:\\secret\\snapshots.json <script>alert(1)</script>"
+
+    def _boom() -> list[dict[str, Any]]:
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(snapshotsAPI, "list_snapshots", _boom)
+
+    resp = snapshotsAPI.api_snapshots_list(_request("/api/snapshots/list", method="GET"))
+    body = resp.body.decode("utf-8")
+
+    assert resp.status_code == 400
+    assert secret not in body
+    assert _json_body(resp)["error"] == "snapshot_list_failed"
+
+
+def test_watchlist_delete_errors_do_not_expose_exception_text(monkeypatch) -> None:
+    from api import watchlistAPI
+    import cw_platform.config_base as config_base
+
+    secret = "Traceback C:\\secret\\watchlist.json <script>alert(1)</script>"
+
+    monkeypatch.setattr(config_base, "load_config", lambda: {})
+    monkeypatch.setattr(
+        watchlistAPI,
+        "delete_watchlist_item",
+        lambda **_kwargs: {
+            "ok": False,
+            "status": "error",
+            "provider": "PLEX",
+            "error": secret,
+            "details": {"default": {"ok": False, "error": secret}},
+        },
+    )
+
+    resp = watchlistAPI.api_watchlist_delete(
+        "tmdb:603",
+        request=_request("/api/watchlist/tmdb:603", method="DELETE"),
+        provider="PLEX",
+    )
+    body = resp.body.decode("utf-8")
+    payload = _json_body(resp)
+
+    assert resp.status_code == 400
+    assert secret not in body
+    assert payload["error"] == "delete_failed"
+    assert payload["details"]["default"]["error"] == "delete_failed"
+
+
 def test_oidc_link_conflict_does_not_expose_exception_text(monkeypatch) -> None:
     from api import appAuthAPI as auth
     from api import authOidcAPI as oidc_api


### PR DESCRIPTION
# Pull request

## Change

Hide raw exception details from snapshot and watchlist delete API responses.

## Why

CodeQL flagged stack trace exposure in those response paths.

## Testing

- tests/test_auth_security_responses.py 
- tests/test_watchlist_delete_scope.py 
- tests/test_capture_service.py

## Issue

Relates to CodeQL alerts #332 and #333