### PR TITLE
Fix: watchlist bulk delete provider handling

### DIFF
--- a/assets/js/watchlist.js
+++ b/assets/js/watchlist.js
@@ -49,14 +49,17 @@
     const keys = providerMeta().watchlistProviders?.();
     return Array.isArray(keys) && keys.length
       ? keys
-      : ["PLEX","SIMKL","ANILIST","TRAKT","TMDB","JELLYFIN","EMBY","MDBLIST","PUBLICMETADB","FLOPPY","CROSSWATCH"];
+      : ["CROSSWATCH","PLEX","JELLYFIN","EMBY","SIMKL","TRAKT","ANILIST","TMDB","MDBLIST","PUBLICMETADB","PUNCHPLAY","FLOPPY","SCROB","NUVIO","STREMIO"];
   };
   const PROVIDERS = watchlistProviderKeys();
   const visibleProviders = () => PROVIDERS.filter((p) => p !== "CROSSWATCH" || activeProviders.has("CROSSWATCH"));
   const providerOptions=(empty="All")=>`<option value="">${empty}</option>${visibleProviders().map(p=>`<option value="${p}">${providerLabel(p)}</option>`).join("")}`;
   const deleteProviderOptions=pick=>`<option value="ALL">ALL (default)</option>${(pick ? PROVIDERS.filter(p=>pick.has(p)) : visibleProviders()).map(p=>`<option value="${p}">${providerLabel(p)}</option>`).join("")}`;
   const cwProfileOptions=()=>crosswatchProfiles.map(p=>`<option value="${escOpt(p.id)}">${escOpt(p.label || p.id)}</option>`).join("");
-  const isProfileUser = () => document.documentElement?.dataset?.cwRole === "user";
+  const isProfileUser = () => {
+    const doc = document.documentElement;
+    return doc?.dataset?.cwRole === "user" && doc?.dataset?.cwPermWrite !== "on";
+  };
   const hasFloppyConfig = root => {
     const match = block => block && typeof block === "object" && (block.server_url || block.server) && (block.api_token || block.token);
     return !!(match(root) || (root?.instances && Object.values(root.instances).some(match)));
@@ -1975,6 +1978,8 @@ const normReleased = v => (v === "yes" ? "released" : v === "no" ? "unreleased" 
         if (cfg?.emby?.access_token || cfg?.emby?.api_key || cfg?.emby?.token) active.add("EMBY");
         if (cfg?.mdblist?.api_key || cfg?.mdblist?.access_token) active.add("MDBLIST");
         if (cfg?.publicmetadb?.api_key) active.add("PUBLICMETADB");
+        if (cfg?.nuvio?.access_token || cfg?.auth?.nuvio?.access_token || cfg?.nuvio?.instances) active.add("NUVIO");
+        if (cfg?.stremio?.auth_key || cfg?.stremio?.authKey || cfg?.auth?.stremio?.auth_key || cfg?.auth?.stremio?.authKey) active.add("STREMIO");
         if ([cfg?.floppy, cfg?.auth?.floppy].some(hasFloppyConfig)) active.add("FLOPPY");
       }
     } catch {}

--- a/providers/sync/_mod_MDBLIST.py
+++ b/providers/sync/_mod_MDBLIST.py
@@ -249,6 +249,12 @@ def get_manifest() -> Mapping[str, Any]:
             "bidirectional": True,
             "provides_ids": True,
             "index_semantics": "present",
+            "watchlist": {
+                "observed_deletes": True,
+                "types": {"movies": True, "shows": True, "seasons": False, "episodes": False},
+                "upsert": True,
+                "remove": True,
+            },
             "history": {
                 "observed_deletes": True,
                 "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
@@ -813,6 +819,12 @@ class _MDBLISTOPS:
             "bidirectional": True,
             "provides_ids": True,
             "index_semantics": "present",
+            "watchlist": {
+                "observed_deletes": True,
+                "types": {"movies": True, "shows": True, "seasons": False, "episodes": False},
+                "upsert": True,
+                "remove": True,
+            },
             "history": {
                 "observed_deletes": True,
                 "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},

--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -511,7 +511,7 @@ def get_manifest() -> Mapping[str, Any]:
             "provides_ids": True,
             "index_semantics": "present",
             "history": {"index_semantics": "present", "observed_deletes": True},
-            "watchlist": {"writes": "discover_first", "pms_fallback": True},
+            "watchlist": {"writes": "discover_first", "pms_fallback": True, "upsert": True, "remove": True},
             "ratings": {
                 "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
                 "upsert": True,
@@ -1497,7 +1497,7 @@ class _PlexOPS:
             "provides_ids": True,
             "index_semantics": "present",
             "history": {"index_semantics": "present", "observed_deletes": True},
-            "watchlist": {"writes": "discover_first", "pms_fallback": True},
+            "watchlist": {"writes": "discover_first", "pms_fallback": True, "upsert": True, "remove": True},
             "ratings": {
                 "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
                 "upsert": True,

--- a/providers/sync/_mod_SIMKL.py
+++ b/providers/sync/_mod_SIMKL.py
@@ -241,6 +241,9 @@ def get_manifest() -> Mapping[str, Any]:
             "watchlist": {
                 "index_semantics": "present",
                 "observed_deletes": True,
+                "types": {"movies": True, "shows": True, "anime": True, "seasons": False, "episodes": False},
+                "upsert": True,
+                "remove": True,
             },
             "history": {
                 "index_semantics": "present",
@@ -742,6 +745,9 @@ class _SIMKLOPS:
             "watchlist": {
                 "index_semantics": "present",
                 "observed_deletes": True,
+                "types": {"movies": True, "shows": True, "anime": True, "seasons": False, "episodes": False},
+                "upsert": True,
+                "remove": True,
             },
             "history": {
                 "index_semantics": "present",

--- a/tests/test_watchlist_delete_scope.py
+++ b/tests/test_watchlist_delete_scope.py
@@ -186,3 +186,53 @@ def test_delete_watchlist_batch_never_loads_foreign_instance_credentials(monkeyp
     )
 
     assert views == [{"PLEX": "PLEX-P02"}]
+
+
+def test_delete_watchlist_batch_routes_generic_watchlist_remove_providers(monkeypatch) -> None:
+    import services.watchlist as wl
+
+    state = {
+        "providers": {
+            "STREMIO": {"watchlist": {"baseline": {"items": {"imdb:tt123": {"type": "movie", "ids": {"imdb": "tt123"}}}}}},
+            "NUVIO": {"watchlist": {"baseline": {"items": {"tmdb:603": {"type": "movie", "ids": {"tmdb": "603"}}}}}},
+        }
+    }
+    called: list[tuple[str, list[str]]] = []
+
+    def _fake_ops(provider, items, cfg):
+        called.append((provider, [str(x.get("key")) for x in items]))
+
+    monkeypatch.setattr(wl, "_registry_sync_providers", lambda: ["STREMIO", "NUVIO"])
+    monkeypatch.setattr(wl, "_ops_supports_watchlist_remove", lambda p: p in {"STREMIO", "NUVIO"})
+    monkeypatch.setattr(wl, "_delete_on_ops_watchlist_batch", _fake_ops)
+    monkeypatch.setattr(wl, "_save_sync_state", lambda *a, **k: None)
+
+    out = wl.delete_watchlist_batch(["imdb:tt123", "tmdb:603"], "ALL", state, {})
+
+    assert out["ok"] is True
+    assert ("STREMIO", ["imdb:tt123", "tmdb:603"]) in called
+    assert ("NUVIO", ["imdb:tt123", "tmdb:603"]) in called
+    assert out["details"]["STREMIO"]["removed"] == 1
+    assert out["details"]["NUVIO"]["removed"] == 1
+
+
+def test_watchlist_aliases_include_simkl_and_mdblist_native_ids(monkeypatch) -> None:
+    import services.watchlist as wl
+
+    monkeypatch.setattr(wl, "_registry_sync_providers", lambda: ["SIMKL", "MDBLIST"])
+    monkeypatch.setattr(wl, "_load_hide_set", lambda: set())
+
+    state = {
+        "providers": {
+            "SIMKL": {"watchlist": {"baseline": {"items": {"simkl:42": {"type": "show", "ids": {"simkl": "42"}, "title": "Native"}}}}},
+            "MDBLIST": {"watchlist": {"baseline": {"items": {"mdblist:99": {"type": "movie", "ids": {"mdblist": "99"}, "title": "Native"}}}}},
+        }
+    }
+
+    rows = wl.build_watchlist(state, tmdb_ok=False)
+    by_key = {row["key"]: row for row in rows}
+
+    assert "simkl:42" in by_key
+    assert "simkl:42" in by_key["simkl:42"]["aliases"]
+    assert "mdblist:99" in by_key
+    assert "mdblist:99" in by_key["mdblist:99"]["aliases"]

--- a/tests/test_watchlist_ui.py
+++ b/tests/test_watchlist_ui.py
@@ -67,6 +67,14 @@ def test_watchlist_delete_all_option_has_no_badge() -> None:
     assert 'providerSelectOptionData(value, option, "ALL (default)", false)' in js
 
 
+def test_watchlist_allows_full_managed_users_to_select_delete() -> None:
+    js = (ROOT / "assets" / "js" / "watchlist.js").read_text(encoding="utf-8")
+
+    assert 'cwPermWrite !== "on"' in js
+    assert 'doc?.dataset?.cwRole === "user" && doc?.dataset?.cwPermWrite !== "on"' in js
+    assert 'if (!isProfileUser() && chk.checked)' in js
+
+
 def test_watchlist_column_resize_can_truncate_without_overflow() -> None:
     js = (ROOT / "assets" / "js" / "watchlist.js").read_text(encoding="utf-8")
     css = (ROOT / "assets" / "css" / "pages.css").read_text(encoding="utf-8")


### PR DESCRIPTION
# Pull request

## Change

Fix watchlist bulk delete for full managed users and align provider delete support for Plex, SIMKL, MDBList, Stremio, and Nuvio.

## Why

Bulk delete could look like it did nothing, and some provider capability metadata was incomplete.

## Testing

- tests/test_watchlist_ui.py 
- tests/test_watchlist_delete_scope.py 
- providers/tests/test_stremio_sync.py 
- providers/tests/test_nuvio_watchlist.py

## Issue

By reddit. 