### PR TITLE
Fix: profile scope on watchlist, playback and activity routes

### DIFF
--- a/api/watchlistAPI.py
+++ b/api/watchlistAPI.py
@@ -393,9 +393,31 @@ def _bulk_delete(provider: str, keys_raw: list[Any], provider_instance: str | No
     }
 
 # Auto-remove code
+def _origin_allowed_instances(cfg: dict[str, Any], origin: Any) -> dict[str, list[str]] | None:
+    if not origin:
+        return None
+    if isinstance(origin, (tuple, list)):
+        parts = list(origin) + ["", ""]
+        prov_raw, inst_raw = parts[0], parts[1]
+    else:
+        prov_raw, _, inst_raw = str(origin).partition(":")
+    if not str(prov_raw or "").strip():
+        return None
+    from cw_platform.access_policy import origin_owner_instances
+
+    return origin_owner_instances(cfg, prov_raw, inst_raw)
+
+
+def _origin_instances_for(allowed: dict[str, list[str]] | None, provider: str) -> list[str | None]:
+    if allowed is None:
+        return [None]
+    return list(allowed.get(provider_display_key(provider)) or [])
+
+
 def remove_across_providers_by_ids(
     ids: dict[str, Any],
     media_type: str | None = None,
+    origin: Any = None,
 ) -> dict[str, Any]:
     from cw_platform.config_base import load_config
     from crosswatch import _append_log
@@ -409,7 +431,10 @@ def remove_across_providers_by_ids(
     if not keys:
         return {"ok": False, "error": "no candidate keys from ids"}
 
+    allowed = _origin_allowed_instances(cfg, origin)
     providers = _active_pair_watchlist_providers(cfg) or _active_providers(cfg)
+    if allowed is not None:
+        providers = [p for p in providers if allowed.get(provider_display_key(p))]
     if not providers:
         return {"ok": False, "error": "no connected providers"}
 
@@ -418,9 +443,12 @@ def remove_across_providers_by_ids(
 
     for prov in providers:
         found_key = None
-        for k in keys:
-            if _find_item_in_state_for_provider(state, k, prov):
-                found_key = k
+        for inst in _origin_instances_for(allowed, prov):
+            for k in keys:
+                if _find_item_in_state_for_provider(state, k, prov, instance_id=inst):
+                    found_key = k
+                    break
+            if found_key:
                 break
 
         if not found_key:
@@ -435,7 +463,7 @@ def remove_across_providers_by_ids(
             continue
 
         try:
-            r = delete_watchlist_batch([found_key], prov, state, cfg) or {}
+            r = delete_watchlist_batch([found_key], prov, state, cfg, allowed_instances=allowed) or {}
             deleted = int(r.get("deleted", 0)) if isinstance(r, dict) else 0
             total_deleted += deleted
             ok = deleted > 0
@@ -469,6 +497,7 @@ def remove_from_provider_by_ids(
     provider: str,
     ids: dict[str, Any],
     media_type: str | None = None,
+    origin: Any = None,
 ) -> dict[str, Any]:
     from cw_platform.config_base import load_config
     from crosswatch import _append_log
@@ -481,21 +510,28 @@ def remove_from_provider_by_ids(
     if prov not in _active_providers(cfg):
         return {"ok": False, "error": f"provider '{prov}' not connected"}
 
+    allowed = _origin_allowed_instances(cfg, origin)
+    if allowed is not None and not allowed.get(provider_display_key(prov)):
+        return {"ok": False, "reason": "profile_scope_denied", "provider": prov}
+
     keys = _candidate_keys_from_ids(ids)
     if not keys:
         return {"ok": False, "error": "no candidate keys from ids"}
 
     found_key = None
-    for k in keys:
-        if _find_item_in_state_for_provider(state, k, prov):
-            found_key = k
+    for inst in _origin_instances_for(allowed, prov):
+        for k in keys:
+            if _find_item_in_state_for_provider(state, k, prov, instance_id=inst):
+                found_key = k
+                break
+        if found_key:
             break
 
     if not found_key:
         return {"ok": False, "reason": "not_in_state"}
 
     try:
-        r = delete_watchlist_batch([found_key], prov, state, cfg) or {}
+        r = delete_watchlist_batch([found_key], prov, state, cfg, allowed_instances=allowed) or {}
         deleted = int(r.get("deleted", 0)) if isinstance(r, dict) else 0
         ok = deleted > 0
         kind, label = _item_label(state, found_key, prov)
@@ -512,8 +548,9 @@ def remove_from_provider_by_ids(
 def remove_from_plex_by_ids(
     ids: dict[str, Any],
     media_type: str | None = None,
+    origin: Any = None,
 ) -> dict[str, Any]:
-    return remove_from_provider_by_ids("PLEX", ids, media_type)
+    return remove_from_provider_by_ids("PLEX", ids, media_type, origin=origin)
 
 
 

--- a/cw_platform/access_policy.py
+++ b/cw_platform/access_policy.py
@@ -45,8 +45,8 @@ def managed_profile_id(user: Mapping[str, Any] | None) -> str:
     return normalize_user_profile_id(user.get("profile_id"))
 
 
-def managed_profile_instances(cfg: Mapping[str, Any], user: Mapping[str, Any] | None) -> dict[str, list[str]]:
-    pid = managed_profile_id(user)
+def profile_instances_map(cfg: Mapping[str, Any], profile_id: Any) -> dict[str, list[str]]:
+    pid = normalize_user_profile_id(profile_id)
     if not pid:
         return {}
     out: dict[str, list[str]] = {}
@@ -57,6 +57,17 @@ def managed_profile_instances(cfg: Mapping[str, Any], user: Mapping[str, Any] | 
         if prov and keep:
             out[prov] = keep
     return out
+
+
+def managed_profile_instances(cfg: Mapping[str, Any], user: Mapping[str, Any] | None) -> dict[str, list[str]]:
+    return profile_instances_map(cfg, managed_profile_id(user))
+
+
+def origin_owner_instances(cfg: Mapping[str, Any], provider: Any, instance: Any) -> dict[str, list[str]] | None:
+    pid = sole_instance_owner_profile_id(cfg, provider, instance)
+    if not pid:
+        return None
+    return profile_instances_map(cfg, pid)
 
 
 def profile_allows_instance(profile_instances: Mapping[str, list[str]], provider: Any, instance: Any) -> bool:

--- a/providers/scrobble/_auto_remove_watchlist.py
+++ b/providers/scrobble/_auto_remove_watchlist.py
@@ -80,7 +80,7 @@ def remove_across_providers_by_ids(
     try:
         import api.watchlistAPI as WLAPI
 
-        res = WLAPI.remove_across_providers_by_ids(norm, media_type or "")
+        res = WLAPI.remove_across_providers_by_ids(norm, media_type or "", origin=scope)
         ok = bool(res.get("ok")) if isinstance(res, dict) else bool(res)
         if ok:
             _log(f"auto-remove OK ids={norm} media={media_type}")
@@ -104,7 +104,14 @@ def remove_across_providers_by_ids(
             keys = list(dict.fromkeys(keys))
             if not keys:
                 return {"ok": False, "error": "no-keys"}
-            res2 = delete_watchlist_batch(keys=keys, prov="ALL", state=st, cfg=cfg) or {}
+            allowed = None
+            if scope:
+                from cw_platform.access_policy import origin_owner_instances
+
+                prov_raw, _, inst_raw = str(scope).partition(":")
+                if str(prov_raw or "").strip():
+                    allowed = origin_owner_instances(cfg, prov_raw, inst_raw)
+            res2 = delete_watchlist_batch(keys=keys, prov="ALL", state=st, cfg=cfg, allowed_instances=allowed) or {}
             ok2 = bool(res2.get("ok"))
             if ok2:
                 _log(f"fallback delete_watchlist_batch OK ids={norm}")
@@ -144,6 +151,7 @@ def _extract_evt(evt: Any) -> dict[str, Any]:
 def auto_remove_if_config_allows(
     evt: Any,
     cfg: dict[str, Any] | None = None,
+    scope: str | None = None,
 ) -> dict[str, Any] | None:
     try:
         if cfg is None:
@@ -186,10 +194,10 @@ def auto_remove_if_config_allows(
         return None
 
     _log(f"auto-remove (WL-AUTO) executing for movie ids={ids}", "INFO")
-    return remove_across_providers_by_ids(ids, "movie")
+    return remove_across_providers_by_ids(ids, "movie", scope=scope)
 
 
-def remove_by_ids(ids: dict[str, Any] | None, media_type: str | None = None) -> dict[str, Any]:
+def remove_by_ids(ids: dict[str, Any] | None, media_type: str | None = None, scope: str | None = None) -> dict[str, Any]:
     mt = str(media_type or "").strip().lower()
     if mt != "movie":
         _log(
@@ -197,4 +205,4 @@ def remove_by_ids(ids: dict[str, Any] | None, media_type: str | None = None) -> 
             "DEBUG",
         )
         return {"ok": False, "skipped": True, "reason": "not_movie"}
-    return remove_across_providers_by_ids(ids or {}, "movie")
+    return remove_across_providers_by_ids(ids or {}, "movie", scope=scope)

--- a/providers/webhooks/emby.py
+++ b/providers/webhooks/emby.py
@@ -810,7 +810,7 @@ def _body_ids_desc(b: dict[str, Any]) -> str:
     return str(ids or "none")
 
 
-def _call_remove_across(ids: dict[str, Any], media_type: str) -> None:
+def _call_remove_across(ids: dict[str, Any], media_type: str, origin: str = "") -> None:
     if not isinstance(ids, dict) or not ids:
         return
     try:
@@ -831,13 +831,13 @@ def _call_remove_across(ids: dict[str, Any], media_type: str) -> None:
         pass
     try:
         if callable(_rm_across):
-            _rm_across(ids, media_type)
+            _rm_across(ids, media_type, scope=origin or None)
             return
     except Exception:
         pass
     try:
         if callable(_rm_across_api):
-            _rm_across_api(ids, media_type)  # type: ignore[misc]
+            _rm_across_api(ids, media_type, origin=origin or None)  # type: ignore[misc]
             return
     except Exception:
         pass
@@ -1120,7 +1120,7 @@ def process_webhook(
         if r.status_code < 400:
             if intended == "/scrobble/stop" and prog >= watched_at and not st.get("wl_removed") is True:
                 try:
-                    _call_remove_across(ids_all or {}, media_type)
+                    _call_remove_across(ids_all or {}, media_type, origin=f"emby:{provider_instance}")
                     st = {**st, "wl_removed": True}
                 except Exception:
                     pass

--- a/providers/webhooks/jellyfin.py
+++ b/providers/webhooks/jellyfin.py
@@ -208,7 +208,7 @@ def _save_config(cfg: dict[str, Any]) -> None:
         pass
 
 
-def _call_remove_across(ids: dict[str, Any], media_type: str) -> None:
+def _call_remove_across(ids: dict[str, Any], media_type: str, origin: str = "") -> None:
     if not isinstance(ids, dict) or not ids:
         return
     try:
@@ -229,13 +229,13 @@ def _call_remove_across(ids: dict[str, Any], media_type: str) -> None:
         pass
     try:
         if callable(_rm_across):
-            _rm_across(ids, media_type)
+            _rm_across(ids, media_type, scope=origin or None)
             return
     except Exception:
         pass
     try:
         if callable(_rm_across_api):
-            _rm_across_api(ids, media_type)  # type: ignore[arg-type]
+            _rm_across_api(ids, media_type, origin=origin or None)  # type: ignore[arg-type]
             return
     except Exception:
         pass
@@ -1502,7 +1502,7 @@ def process_webhook(
                 _LAST_FINISH_BY_ACC[acc_key] = {"ik": item_key, "ts": now}
             if intended == "/scrobble/stop" and prog >= watched_at and not (st.get("wl_removed") is True):
                 try:
-                    _call_remove_across(ids_all or {}, media_type)
+                    _call_remove_across(ids_all or {}, media_type, origin=f"jellyfin:{provider_instance}")
                     st = {**st, "wl_removed": True}
                 except Exception:
                     pass

--- a/providers/webhooks/plex.py
+++ b/providers/webhooks/plex.py
@@ -86,7 +86,7 @@ def _archive(event_type: str, media_type: str, md: dict[str, Any], ids: dict[str
         pass
 
 
-def _call_remove_across(ids: dict[str, Any], media_type: str) -> None:
+def _call_remove_across(ids: dict[str, Any], media_type: str, origin: str = "") -> None:
     if not isinstance(ids, dict) or not ids:
         return
     try:
@@ -107,13 +107,13 @@ def _call_remove_across(ids: dict[str, Any], media_type: str) -> None:
         pass
     try:
         if callable(_rm_across):
-            _rm_across(ids, media_type)
+            _rm_across(ids, media_type, scope=origin or None)
             return
     except Exception:
         pass
     try:
         if callable(_rm_across_api):
-            _rm_across_api(ids, media_type)  # type: ignore[arg-type]
+            _rm_across_api(ids, media_type, origin=origin or None)  # type: ignore[arg-type]
             return
     except Exception:
         pass
@@ -1629,7 +1629,7 @@ def process_webhook(
     if r.status_code < 400:
         if intended == "/scrobble/stop" and prog >= watched_at and not (st.get("wl_removed") is True):
             try:
-                _call_remove_across(ids_all2 or {}, media_type)
+                _call_remove_across(ids_all2 or {}, media_type, origin=f"plex:{provider_instance}")
                 st = {**st, "wl_removed": True}
             except Exception:
                 pass

--- a/tests/test_auto_remove_profile_scope.py
+++ b/tests/test_auto_remove_profile_scope.py
@@ -1,0 +1,124 @@
+# tests/test_auto_remove_profile_scope.py
+# CrossWatch - Auto-remove-after-watch must stay inside the watching profile
+
+from __future__ import annotations
+
+ALICE = "11111111111141118111111111111111"
+BOB = "22222222222242228222222222222222"
+
+
+def _cfg():
+    return {
+        "plex": {"instances": {"PLEX-A": {}, "PLEX-B": {}}},
+        "trakt": {"instances": {"TRAKT-A": {}, "TRAKT-B": {}}},
+        "user_profiles": {
+            ALICE: {"label": "Alice", "instances": {"PLEX": ["PLEX-A"], "TRAKT": ["TRAKT-A"]}},
+            BOB: {"label": "Bob", "instances": {"PLEX": ["PLEX-B"], "TRAKT": ["TRAKT-B"]}},
+        },
+    }
+
+
+def _state():
+    def block(key):
+        return {"watchlist": {"baseline": {"items": {key: {"title": "Movie", "type": "movie"}}}}}
+
+    return {
+        "providers": {
+            "PLEX": {"instances": {"PLEX-A": block("tmdb:603"), "PLEX-B": block("tmdb:603")}},
+            "TRAKT": {"instances": {"TRAKT-A": block("tmdb:603"), "TRAKT-B": block("tmdb:603")}},
+        }
+    }
+
+
+def _prepare(monkeypatch):
+    import cw_platform.provider_instances as provider_instances
+
+    cfg = _cfg()
+    provider_instances.ensure_provider_instance_uids(cfg)
+    return cfg
+
+
+def test_origin_owner_instances_resolves_the_watching_profile(monkeypatch) -> None:
+    from cw_platform.access_policy import origin_owner_instances
+
+    cfg = _prepare(monkeypatch)
+
+    assert origin_owner_instances(cfg, "PLEX", "PLEX-A") == {"PLEX": ["PLEX-A"], "TRAKT": ["TRAKT-A"]}
+    assert origin_owner_instances(cfg, "PLEX", "PLEX-B") == {"PLEX": ["PLEX-B"], "TRAKT": ["TRAKT-B"]}
+
+
+def test_admin_only_instance_stays_unscoped(monkeypatch) -> None:
+    from cw_platform.access_policy import origin_owner_instances
+
+    cfg = _prepare(monkeypatch)
+    cfg["plex"]["instances"]["PLEX-ADMIN"] = {}
+    import cw_platform.provider_instances as provider_instances
+
+    provider_instances.ensure_provider_instance_uids(cfg)
+
+    assert origin_owner_instances(cfg, "PLEX", "PLEX-ADMIN") is None
+
+
+def test_auto_remove_only_touches_the_watching_profile(monkeypatch) -> None:
+    import api.watchlistAPI as WLAPI
+    import cw_platform.config_base as config_base
+    import services.watchlist as wl
+
+    cfg = _prepare(monkeypatch)
+    monkeypatch.setattr(config_base, "load_config", lambda: cfg)
+    monkeypatch.setattr(WLAPI, "_load_watchlist_state", lambda: _state())
+    monkeypatch.setattr(WLAPI, "_active_pair_watchlist_providers", lambda _cfg: ["PLEX", "TRAKT"])
+    monkeypatch.setattr(WLAPI, "_active_providers", lambda _cfg: ["PLEX", "TRAKT"])
+
+    views: list = []
+    monkeypatch.setattr(wl, "build_config_view", lambda c, sel: views.append(sel) or {})
+    monkeypatch.setattr(wl, "_registry_sync_providers", lambda: ["PLEX", "TRAKT"])
+    monkeypatch.setattr(wl, "_delete_on_plex_batch", lambda *a, **k: None)
+    monkeypatch.setattr(wl, "_delete_on_trakt_batch", lambda *a, **k: None)
+    monkeypatch.setattr(wl, "_save_sync_state", lambda *a, **k: None)
+
+    WLAPI.remove_across_providers_by_ids({"tmdb": "603"}, "movie", origin="plex:PLEX-A")
+
+    assert views, "expected at least one provider delete"
+    assert {tuple(sorted(v.items()))[0] for v in views} == {("PLEX", "PLEX-A"), ("TRAKT", "TRAKT-A")}
+    assert not any("PLEX-B" in v.values() or "TRAKT-B" in v.values() for v in views)
+
+
+def test_auto_remove_without_origin_stays_unscoped(monkeypatch) -> None:
+    import api.watchlistAPI as WLAPI
+    import cw_platform.config_base as config_base
+    import services.watchlist as wl
+
+    cfg = _prepare(monkeypatch)
+    monkeypatch.setattr(config_base, "load_config", lambda: cfg)
+    monkeypatch.setattr(WLAPI, "_load_watchlist_state", lambda: _state())
+    monkeypatch.setattr(WLAPI, "_active_pair_watchlist_providers", lambda _cfg: ["PLEX"])
+    monkeypatch.setattr(WLAPI, "_active_providers", lambda _cfg: ["PLEX"])
+
+    views: list = []
+    monkeypatch.setattr(wl, "build_config_view", lambda c, sel: views.append(sel) or {})
+    monkeypatch.setattr(wl, "_registry_sync_providers", lambda: ["PLEX"])
+    monkeypatch.setattr(wl, "_delete_on_plex_batch", lambda *a, **k: None)
+    monkeypatch.setattr(wl, "_save_sync_state", lambda *a, **k: None)
+
+    WLAPI.remove_across_providers_by_ids({"tmdb": "603"}, "movie")
+
+    instances = {v.get("PLEX") for v in views}
+    assert "PLEX-A" in instances and "PLEX-B" in instances
+
+
+def test_shim_forwards_scope_as_origin(monkeypatch) -> None:
+    import api.watchlistAPI as WLAPI
+    import providers.scrobble._auto_remove_watchlist as auto
+
+    seen: dict = {}
+    monkeypatch.setattr(auto, "_once_per_ttl", lambda _k: True)
+    monkeypatch.setattr(
+        WLAPI,
+        "remove_across_providers_by_ids",
+        lambda ids, media_type="", origin=None: seen.update(origin=origin) or {"ok": True},
+    )
+
+    auto.remove_across_providers_by_ids({"tmdb": "603"}, "movie", scope="trakt:TRAKT-A")
+
+    assert seen["origin"] == "trakt:TRAKT-A"


### PR DESCRIPTION
# Pull request

## Change

Scope the write paths to the profile of the caller. 
Watchlist delete, playback progress actions and auto-remove after watch now stay inside the instances owned by that profile. Clearing activity history is admin only. Unsafe methods now need both write and the matching feature permission.

## Why

A managed user with write could delete watchlist items and mark items watched on instances belonging to another profile, using the stored tokens of that profile. 

## Testing

- tests/test_watchlist_delete_scope.py 
- tests/test_action_route_scope.py 
- tests/test_auto_remove_profile_scope.py

## Issue

NA
