### PR TITLE
Change: prepare config cleanup

### DIFF
--- a/api/configAPI.py
+++ b/api/configAPI.py
@@ -647,6 +647,9 @@ def api_config_migrate() -> dict[str, Any]:
     current = dict(env["load"]() or {})
     backup_path = None
     forced_paths: list[str] = []
+    resource_id_paths: list[str] = []
+    profile_cleanup_paths: list[str] = []
+    obsolete_paths: list[str] = []
 
     try:
         try:
@@ -718,6 +721,25 @@ def api_config_migrate() -> dict[str, Any]:
         pass
 
     try:
+        ensure_resource_ids = getattr(base, "ensure_config_resource_ids", None)
+        if callable(ensure_resource_ids):
+            result = ensure_resource_ids(cfg)
+            if isinstance(result, list):
+                resource_id_paths = [str(path) for path in result]
+        cleanup_profiles = getattr(base, "cleanup_invalid_resource_profile_ids", None)
+        if callable(cleanup_profiles):
+            result = cleanup_profiles(cfg)
+            if isinstance(result, list):
+                profile_cleanup_paths = [str(path) for path in result]
+        cleanup_obsolete = getattr(base, "cleanup_obsolete_config_keys", None)
+        if callable(cleanup_obsolete):
+            result = cleanup_obsolete(cfg)
+            if isinstance(result, list):
+                obsolete_paths = [str(path) for path in result]
+    except Exception:
+        return {"ok": False, "error": "resource_id_migration_failed"}
+
+    try:
         ui = cfg.get("ui")
         if isinstance(ui, dict):
             ui.pop("_autogen", None)
@@ -737,4 +759,7 @@ def api_config_migrate() -> dict[str, Any]:
         "ok": True,
         "backup": backup_path,
         "forced_paths": forced_paths,
+        "resource_id_paths": resource_id_paths,
+        "profile_cleanup_paths": profile_cleanup_paths,
+        "obsolete_paths": obsolete_paths,
     }

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -951,6 +951,66 @@ def redact_config(cfg: dict[str, Any]) -> dict[str, Any]:
 
 
 # Helpers: paths, IO, merging, normalization
+CONFIG_TOP_LEVEL_ORDER: tuple[str, ...] = (
+    "version",
+    "security",
+    "app_auth",
+    "user_profiles",
+    "provider_instance_ids",
+    "plex",
+    "jellyfin",
+    "emby",
+    "kodi",
+    "tautulli",
+    "trakt",
+    "simkl",
+    "mdblist",
+    "anilist",
+    "tmdb_sync",
+    "publicmetadb",
+    "punchplay",
+    "nuvio",
+    "stremio",
+    "floppy",
+    "scrob",
+    "crosswatch",
+    "metadata",
+    "tmdb",
+    "anime_mapping",
+    "sync",
+    "pairs",
+    "scrobble",
+    "scheduling",
+    "playlists",
+    "playback_progress",
+    "runtime",
+    "features",
+    "ui",
+)
+
+OBSOLETE_CONFIG_KEYS: tuple[str, ...] = ("mobile_auth",)
+
+
+def cleanup_obsolete_config_keys(cfg: dict[str, Any]) -> list[str]:
+    changed: list[str] = []
+    for key in OBSOLETE_CONFIG_KEYS:
+        if key in cfg:
+            cfg.pop(key, None)
+            changed.append(key)
+    return changed
+
+
+def _order_config_for_write(data: dict[str, Any]) -> dict[str, Any]:
+    ordered: dict[str, Any] = {}
+    for key in CONFIG_TOP_LEVEL_ORDER:
+        if key in data:
+            ordered[key] = data[key]
+    for key, value in data.items():
+        if key not in ordered:
+            ordered[key] = value
+    return ordered
+
+
 def _cfg_file() -> Path:
     return CONFIG / "config.json"
 
@@ -2069,6 +2129,201 @@ def _normalize_pair_profile_ids(cfg: dict[str, Any]) -> None:
             it.pop("profile_id", None)
 
 
+def _new_resource_id(prefix: str) -> str:
+    return f"{prefix}_{secrets.token_hex(6)}"
+
+
+def _clean_resource_id(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _unique_resource_id(prefix: str, used: set[str]) -> str:
+    for _ in range(100):
+        rid = _new_resource_id(prefix)
+        if rid not in used:
+            return rid
+    raise RuntimeError("unable to allocate config resource id")
+
+
+def _replace_string_ref(node: dict[str, Any], key: str, refs: dict[str, str]) -> bool:
+    raw = node.get(key)
+    value = _clean_resource_id(raw)
+    if value and value in refs:
+        node[key] = refs[value]
+        return True
+    return False
+
+
+def _rewrite_scheduler_resource_refs(cfg: dict[str, Any], pair_refs: dict[str, str], route_refs: dict[str, str]) -> list[str]:
+    if not pair_refs and not route_refs:
+        return []
+    changed: list[str] = []
+    scheduling = cfg.get("scheduling")
+    if not isinstance(scheduling, dict):
+        return changed
+    advanced = scheduling.get("advanced")
+    if not isinstance(advanced, dict):
+        return changed
+
+    jobs = advanced.get("jobs")
+    if isinstance(jobs, list):
+        for idx, job in enumerate(jobs):
+            if isinstance(job, dict) and _replace_string_ref(job, "pair_id", pair_refs):
+                changed.append(f"scheduling.advanced.jobs[{idx}].pair_id")
+
+    workflows = advanced.get("workflows")
+    if isinstance(workflows, list):
+        for wi, workflow in enumerate(workflows):
+            steps = workflow.get("steps") if isinstance(workflow, dict) else None
+            if not isinstance(steps, list):
+                continue
+            for si, step in enumerate(steps):
+                if isinstance(step, dict) and _replace_string_ref(step, "pair_id", pair_refs):
+                    changed.append(f"scheduling.advanced.workflows[{wi}].steps[{si}].pair_id")
+
+    event_rules = advanced.get("event_rules")
+    if not isinstance(event_rules, list):
+        event_rules = advanced.get("eventRules")
+    if isinstance(event_rules, list):
+        for ri, rule in enumerate(event_rules):
+            if not isinstance(rule, dict):
+                continue
+            action = rule.get("action")
+            if isinstance(action, dict):
+                if _replace_string_ref(action, "pair_id", pair_refs):
+                    changed.append(f"scheduling.advanced.event_rules[{ri}].action.pair_id")
+                if _replace_string_ref(action, "pairId", pair_refs):
+                    changed.append(f"scheduling.advanced.event_rules[{ri}].action.pairId")
+            elif _replace_string_ref(rule, "pair_id", pair_refs):
+                changed.append(f"scheduling.advanced.event_rules[{ri}].pair_id")
+            source = str(rule.get("source") or "watcher").strip().lower() or "watcher"
+            filters = rule.get("filters")
+            if source == "watcher" and isinstance(filters, dict):
+                if _replace_string_ref(filters, "route_id", route_refs):
+                    changed.append(f"scheduling.advanced.event_rules[{ri}].filters.route_id")
+                if _replace_string_ref(filters, "routeId", route_refs):
+                    changed.append(f"scheduling.advanced.event_rules[{ri}].filters.routeId")
+    return changed
+
+
+def ensure_config_resource_ids(cfg: dict[str, Any]) -> list[str]:
+    """Persist stable IDs for legacy resource rows that used positional fallbacks."""
+    changed: list[str] = []
+    pair_refs: dict[str, str] = {}
+    route_refs: dict[str, str] = {}
+
+    pairs = cfg.get("pairs")
+    if isinstance(pairs, list):
+        used: set[str] = set()
+        for idx, pair in enumerate(pairs):
+            if not isinstance(pair, dict):
+                continue
+            raw_id = _clean_resource_id(pair.get("id"))
+            raw_pair_id = _clean_resource_id(pair.get("pair_id"))
+            candidate = raw_id or raw_pair_id
+            if candidate and candidate not in used:
+                if pair.get("id") != candidate:
+                    pair["id"] = candidate
+                    changed.append(f"pairs[{idx}].id")
+                used.add(candidate)
+                continue
+            rid = _unique_resource_id("pair", used)
+            pair["id"] = rid
+            used.add(rid)
+            changed.append(f"pairs[{idx}].id")
+            legacy = f"pair-{idx + 1}"
+            if not candidate:
+                pair_refs[legacy] = rid
+
+    scrobble = cfg.get("scrobble")
+    watch = scrobble.get("watch") if isinstance(scrobble, dict) else None
+    routes = watch.get("routes") if isinstance(watch, dict) else None
+    if isinstance(routes, list):
+        used_routes: set[str] = set()
+        for idx, route in enumerate(routes):
+            if not isinstance(route, dict):
+                continue
+            raw_id = _clean_resource_id(route.get("id"))
+            raw_route_id = _clean_resource_id(route.get("route_id"))
+            candidate = raw_id or raw_route_id
+            if candidate and candidate not in used_routes:
+                if route.get("id") != candidate:
+                    route["id"] = candidate
+                    changed.append(f"scrobble.watch.routes[{idx}].id")
+                used_routes.add(candidate)
+                continue
+            rid = _unique_resource_id("route", used_routes)
+            route["id"] = rid
+            used_routes.add(rid)
+            changed.append(f"scrobble.watch.routes[{idx}].id")
+            legacy = f"R{idx + 1}"
+            if not candidate:
+                route_refs[legacy] = rid
+
+    changed.extend(_rewrite_scheduler_resource_refs(cfg, pair_refs, route_refs))
+    return changed
+
+
+def cleanup_invalid_resource_profile_ids(cfg: dict[str, Any]) -> list[str]:
+    changed: list[str] = []
+    try:
+        from cw_platform.provider_instances import list_user_profiles, normalize_user_profile_id
+
+        valid = {normalize_user_profile_id(row.get("id")) for row in list_user_profiles(cfg)}
+        valid = {pid for pid in valid if pid}
+    except Exception:
+        return changed
+
+    def clean_pid(value: Any) -> str:
+        pid = normalize_user_profile_id(value)
+        return pid if pid and pid in valid else ""
+
+    scrobble = cfg.get("scrobble")
+    watch = scrobble.get("watch") if isinstance(scrobble, dict) else None
+    routes = watch.get("routes") if isinstance(watch, dict) else None
+    if isinstance(routes, list):
+        for idx, route in enumerate(routes):
+            if not isinstance(route, dict):
+                continue
+            raw = route.get("profile_id") if "profile_id" in route else route.get("profileId")
+            pid = clean_pid(raw)
+            if pid:
+                if route.get("profile_id") != pid:
+                    route["profile_id"] = pid
+                    changed.append(f"scrobble.watch.routes[{idx}].profile_id")
+                if "profileId" in route:
+                    route.pop("profileId", None)
+                    changed.append(f"scrobble.watch.routes[{idx}].profileId")
+            else:
+                if "profile_id" in route:
+                    route.pop("profile_id", None)
+                    changed.append(f"scrobble.watch.routes[{idx}].profile_id")
+                if "profileId" in route:
+                    route.pop("profileId", None)
+                    changed.append(f"scrobble.watch.routes[{idx}].profileId")
+
+    webhook = scrobble.get("webhook") if isinstance(scrobble, dict) else None
+    assignments = webhook.get("user_profile_assignments") if isinstance(webhook, dict) else None
+    if isinstance(webhook, dict) and isinstance(assignments, dict):
+        for resource_id, value in list(assignments.items()):
+            pid = clean_pid(value)
+            if pid:
+                if assignments.get(resource_id) != pid:
+                    assignments[resource_id] = pid
+                    changed.append(f"scrobble.webhook.user_profile_assignments.{resource_id}")
+            else:
+                assignments.pop(resource_id, None)
+                changed.append(f"scrobble.webhook.user_profile_assignments.{resource_id}")
+        if not assignments:
+            webhook.pop("user_profile_assignments", None)
+            changed.append("scrobble.webhook.user_profile_assignments")
+    elif isinstance(webhook, dict) and "user_profile_assignments" in webhook:
+        webhook.pop("user_profile_assignments", None)
+        changed.append("scrobble.webhook.user_profile_assignments")
+
+    return changed
+
+
 def _normalize_app_auth(cfg: dict[str, Any]) -> None:
     a = _ensure_dict(cfg, "app_auth")
     raw_enabled = bool(a.get("enabled", False))
@@ -2436,6 +2691,7 @@ def load_config() -> dict[str, Any]:
                         inst_block["connected"] = True
     except Exception:
         pass
+    cleanup_obsolete_config_keys(cfg)
     _normalize_tmdb_sync(cfg)
     _normalize_trakt(cfg)
     _normalize_simkl(cfg)
@@ -2450,6 +2706,7 @@ def load_config() -> dict[str, Any]:
     _normalize_app_auth(cfg)
     _normalize_scrobble_webhook(cfg)
     _normalize_pair_profile_ids(cfg)
+    cleanup_invalid_resource_profile_ids(cfg)
     pairs = cfg.get("pairs")
     if isinstance(pairs, list):
         for it in pairs:
@@ -2492,6 +2749,7 @@ def save_config(cfg: dict[str, Any]) -> None:
     except Exception:
         pass
     data["version"] = _current_version_norm()
+    cleanup_obsolete_config_keys(data)
     _normalize_tmdb_sync(data)
     _normalize_trakt(data)
     _normalize_simkl(data)
@@ -2502,11 +2760,13 @@ def save_config(cfg: dict[str, Any]) -> None:
     _normalize_floppy(data)
     _normalize_scrob(data)
     _normalize_anime_mapping(data)
+    ensure_config_resource_ids(data)
     _normalize_scheduling(data)
     _normalize_app_auth(data)
     _normalize_scrobble_webhook(data)
     _normalize_ui(data)
     _normalize_pair_profile_ids(data)
+    cleanup_invalid_resource_profile_ids(data)
     try:
         from cw_platform.provider_instances import ensure_provider_instance_uids
 
@@ -2536,7 +2796,8 @@ def save_config(cfg: dict[str, Any]) -> None:
         except Exception:
             pass
 
-    _write_json_atomic(_cfg_file(), cast(dict[str, Any], _encrypt_secret_tree_stable(data, prev_raw)))
+    final_data = _order_config_for_write(cast(dict[str, Any], _encrypt_secret_tree_stable(data, prev_raw)))
+    _write_json_atomic(_cfg_file(), final_data)
 
 
 def update_config(mutator: Any) -> tuple[dict[str, Any], Any]:

--- a/services/support.py
+++ b/services/support.py
@@ -339,19 +339,20 @@ _REDACTED = "<redacted>"
 _IDENTITY_KEYS = frozenset({
     "access_token", "account_id", "api_key", "api_token", "apikey", "auth_key", "authkey",
     "avatar", "base_url", "cert_file", "client_id", "client_secret", "default_url",
-    "device_id", "email", "failure_url", "hash", "home_pin", "host", "hostname", "ip",
-    "key_file", "label", "linked_email", "linked_plex_account_id", "linked_thumb",
-    "linked_username", "machine_id", "name", "passwd", "password", "path", "pin",
-    "playlist_id", "playlist_name", "pms_token", "pms_token_server", "profile_id",
-    "profile_name", "refresh_token", "root", "root_dir", "salt", "server", "server_url",
-    "server_uuid", "session_id", "start_url", "state_dir", "success_url", "thumb", "token",
+    "device_id", "display_name", "email", "failure_url", "file", "hash", "home_pin", "host", "hostname",
+    "ip", "iss", "issuer", "key_file", "label", "linked_email", "linked_plex_account_id",
+    "linked_thumb", "linked_username", "machine_id", "name", "passwd", "password", "path",
+    "pending_secret", "picture", "pin", "playlist_id", "playlist_name", "pms_token", "pms_token_server",
+    "profile_id", "profile_name", "refresh_token", "root", "root_dir", "salt", "secret",
+    "server", "server_url", "server_uuid", "session_id", "start_url", "state_dir", "sub",
+    "success_url", "thumb", "token",
     "token_hash", "ua", "uri", "url", "user", "user_id", "username", "uuid",
     "verification_url", "watchlist_list_id", "watchlist_name", "webhook_id", "webhook_token",
 })
 
 _COUNT_LIST_KEYS = frozenset({
-    "devices", "libraries", "pairings", "server_uuid_blacklist", "server_uuid_whitelist",
-    "sessions", "username_whitelist", "webhook_ids",
+    "devices", "libraries", "pairings", "recovery_codes", "server_uuid_blacklist",
+    "server_uuid_whitelist", "sessions", "username_whitelist", "webhook_ids",
 })
 
 _URLISH_RE = re.compile(r"(?i)^(?:[a-z][a-z0-9+.-]*://|/[^\s]*/|[a-z]:[\\/])")
@@ -604,11 +605,12 @@ def build_bundle(pair_ids: Sequence[str] | None = None, sections: Iterable[str] 
             files.append(name)
 
         write_json("state.json", payload)
-        write_json("pairs.json", {
+        pairs_snapshot = _scrub({
             "generated_at": _iso(),
             "pairs": _pairs(cfg),
             "scrobble_routes": _scrobble_routes(cfg),
         })
+        write_json("pairs.json", pairs_snapshot if isinstance(pairs_snapshot, dict) else {})
 
         if "config" in wanted:
             try:

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -50,6 +50,222 @@ def test_config_migrate_clears_pending_upgrade_marker(monkeypatch) -> None:
     assert "_pending_upgrade_from_version" not in (saved.get("ui") or {})
 
 
+def test_config_migrate_backfills_resource_ids_and_scheduler_refs(monkeypatch) -> None:
+    from api import configAPI as cfg_api
+    from cw_platform import config_base
+
+    current = {
+        "version": "0.10.9",
+        "ui": {"_pending_upgrade_from_version": "0.10.9"},
+        "pairs": [
+            {"source": "plex", "target": "trakt"},
+            {"id": "kept_pair", "source": "jellyfin", "target": "simkl"},
+            {"id": "kept_pair", "source": "emby", "target": "mdblist"},
+        ],
+        "scrobble": {
+            "enabled": True,
+            "sources": {"watcher": True},
+            "watch": {
+                "autostart": True,
+                "routes": [
+                    {"provider": "plex", "sink": "trakt"},
+                    {"id": "kept_route", "provider": "jellyfin", "sink": "simkl"},
+                    {"id": "kept_route", "provider": "emby", "sink": "mdblist"},
+                ],
+            },
+        },
+        "scheduling": {
+            "advanced": {
+                "jobs": [{"id": "job_1", "pair_id": "pair-1"}],
+                "workflows": [{"id": "workflow_1", "steps": [{"id": "step_1", "pair_id": "pair-1"}]}],
+                "event_rules": [
+                    {
+                        "id": "event_1",
+                        "source": "watcher",
+                        "filters": {"route_id": "R1"},
+                        "action": {"pair_id": "pair-1"},
+                    }
+                ],
+            }
+        },
+    }
+    saved: dict = {}
+
+    monkeypatch.setattr(
+        cfg_api,
+        "_env",
+        lambda: {
+            "CW": None,
+            "cfg_base": SimpleNamespace(
+                ensure_config_resource_ids=config_base.ensure_config_resource_ids,
+                _current_version_norm=lambda: "0.11.0",
+            ),
+            "load": lambda: json.loads(json.dumps(current)),
+            "save": lambda cfg: saved.update(cfg),
+            "prune": lambda *_: None,
+            "ensure": lambda *_: None,
+            "norm_pair": lambda *_: None,
+            "probes_cache": None,
+            "probes_status_cache": None,
+            "scheduler": None,
+        },
+    )
+
+    res = cfg_api.api_config_migrate()
+
+    assert res["ok"] is True
+    first_pair_id = saved["pairs"][0]["id"]
+    duplicate_pair_id = saved["pairs"][2]["id"]
+    first_route_id = saved["scrobble"]["watch"]["routes"][0]["id"]
+    duplicate_route_id = saved["scrobble"]["watch"]["routes"][2]["id"]
+
+    assert first_pair_id.startswith("pair_")
+    assert saved["pairs"][1]["id"] == "kept_pair"
+    assert duplicate_pair_id.startswith("pair_")
+    assert duplicate_pair_id != "kept_pair"
+    assert first_route_id.startswith("route_")
+    assert saved["scrobble"]["watch"]["routes"][1]["id"] == "kept_route"
+    assert duplicate_route_id.startswith("route_")
+    assert duplicate_route_id != "kept_route"
+    assert saved["scheduling"]["advanced"]["jobs"][0]["pair_id"] == first_pair_id
+    assert saved["scheduling"]["advanced"]["workflows"][0]["steps"][0]["pair_id"] == first_pair_id
+    assert saved["scheduling"]["advanced"]["event_rules"][0]["action"]["pair_id"] == first_pair_id
+    assert saved["scheduling"]["advanced"]["event_rules"][0]["filters"]["route_id"] == first_route_id
+    assert "pairs[0].id" in res["resource_id_paths"]
+    assert "scrobble.watch.routes[0].id" in res["resource_id_paths"]
+
+
+def test_config_migrate_cleans_invalid_resource_profile_assignments(monkeypatch) -> None:
+    from api import configAPI as cfg_api
+    from cw_platform import config_base
+
+    current = {
+        "version": "0.10.9",
+        "ui": {"_pending_upgrade_from_version": "0.10.9"},
+        "user_profiles": {
+            "valid-profile": {"label": "Valid"},
+        },
+        "scrobble": {
+            "watch": {
+                "routes": [
+                    {"id": "R1", "provider": "plex", "sink": "trakt", "profile_id": "VALID-PROFILE"},
+                    {"id": "R2", "provider": "plex", "sink": "simkl", "profileId": "missing-profile"},
+                ],
+            },
+            "webhook": {
+                "user_profile_assignments": {
+                    "plex:default:trakt:default": "VALID-PROFILE",
+                    "plex:default:simkl:default": "missing-profile",
+                }
+            },
+        },
+    }
+    saved: dict = {}
+
+    monkeypatch.setattr(
+        cfg_api,
+        "_env",
+        lambda: {
+            "CW": None,
+            "cfg_base": SimpleNamespace(
+                ensure_config_resource_ids=config_base.ensure_config_resource_ids,
+                cleanup_invalid_resource_profile_ids=config_base.cleanup_invalid_resource_profile_ids,
+                _current_version_norm=lambda: "0.11.0",
+            ),
+            "load": lambda: json.loads(json.dumps(current)),
+            "save": lambda cfg: saved.update(cfg),
+            "prune": lambda *_: None,
+            "ensure": lambda *_: None,
+            "norm_pair": lambda *_: None,
+            "probes_cache": None,
+            "probes_status_cache": None,
+            "scheduler": None,
+        },
+    )
+
+    res = cfg_api.api_config_migrate()
+
+    assert res["ok"] is True
+    routes = saved["scrobble"]["watch"]["routes"]
+    assignments = saved["scrobble"]["webhook"]["user_profile_assignments"]
+    assert routes[0]["profile_id"] == "valid-profile"
+    assert "profile_id" not in routes[1]
+    assert "profileId" not in routes[1]
+    assert assignments == {"plex:default:trakt:default": "valid-profile"}
+    assert "scrobble.watch.routes[1].profileId" in res["profile_cleanup_paths"]
+    assert "scrobble.webhook.user_profile_assignments.plex:default:simkl:default" in res["profile_cleanup_paths"]
+
+
+def test_config_write_uses_canonical_top_level_order() -> None:
+    from cw_platform import config_base
+
+    ordered = config_base._order_config_for_write(
+        {
+            "ui": {},
+            "plex": {},
+            "tmdb": {},
+            "metadata": {},
+            "tmdb_sync": {},
+            "anime_mapping": {},
+            "version": "0.11.0",
+            "pairs": [],
+            "custom_future_key": True,
+            "app_auth": {},
+        }
+    )
+
+    assert list(ordered.keys()) == [
+        "version",
+        "app_auth",
+        "plex",
+        "tmdb_sync",
+        "metadata",
+        "tmdb",
+        "anime_mapping",
+        "pairs",
+        "ui",
+        "custom_future_key",
+    ]
+
+
+def test_config_migrate_removes_obsolete_mobile_auth(monkeypatch) -> None:
+    from api import configAPI as cfg_api
+    from cw_platform import config_base
+
+    current = {
+        "version": "0.10.9",
+        "mobile_auth": {"enabled": True, "token": "legacy"},
+        "ui": {"_pending_upgrade_from_version": "0.10.9"},
+    }
+    saved: dict = {}
+
+    monkeypatch.setattr(
+        cfg_api,
+        "_env",
+        lambda: {
+            "CW": None,
+            "cfg_base": SimpleNamespace(
+                cleanup_obsolete_config_keys=config_base.cleanup_obsolete_config_keys,
+                _current_version_norm=lambda: "0.11.0",
+            ),
+            "load": lambda: json.loads(json.dumps(current)),
+            "save": lambda cfg: saved.update(cfg),
+            "prune": lambda *_: None,
+            "ensure": lambda *_: None,
+            "norm_pair": lambda *_: None,
+            "probes_cache": None,
+            "probes_status_cache": None,
+            "scheduler": None,
+        },
+    )
+
+    res = cfg_api.api_config_migrate()
+
+    assert res["ok"] is True
+    assert "mobile_auth" not in saved
+    assert res["obsolete_paths"] == ["mobile_auth"]
+
+
 def test_config_save_preserves_blank_stremio_auth_key(monkeypatch) -> None:
     from api import configAPI as cfg_api
 

--- a/tests/test_support_export.py
+++ b/tests/test_support_export.py
@@ -20,8 +20,12 @@ def test_support_download_does_not_reuse_the_metadata_timeout() -> None:
     assert "DOWNLOAD_TIMEOUT_MS" in fblob
     assert "REQUEST_TIMEOUT_MS" not in fblob
 
-    download_ms = int(re.search(r"DOWNLOAD_TIMEOUT_MS\s*=\s*([\d_]+)", js).group(1).replace("_", ""))
-    request_ms = int(re.search(r"REQUEST_TIMEOUT_MS\s*=\s*([\d_]+)", js).group(1).replace("_", ""))
+    download_match = re.search(r"DOWNLOAD_TIMEOUT_MS\s*=\s*([\d_]+)", js)
+    request_match = re.search(r"REQUEST_TIMEOUT_MS\s*=\s*([\d_]+)", js)
+    assert download_match is not None
+    assert request_match is not None
+    download_ms = int(download_match.group(1).replace("_", ""))
+    request_ms = int(request_match.group(1).replace("_", ""))
     assert download_ms > request_ms
 
 
@@ -213,3 +217,126 @@ def test_bundle_masks_config_secrets(tmp_path, monkeypatch) -> None:
 
     assert redacted["trakt"]["access_token"] != "super-secret-token"
     assert redacted["trakt"]["client_id"] == "<redacted>"
+
+
+def test_bundle_masks_managed_users_totp_and_oidc(tmp_path, monkeypatch) -> None:
+    cfg = _setup(tmp_path, monkeypatch)
+    cfg["app_auth"] = {
+        "enabled": True,
+        "username": "admin-user",
+        "password": {"salt": "admin-salt", "hash": "admin-hash"},
+        "session": {"token_hash": "admin-session-token", "expires_at": 1},
+        "sessions": [
+            {
+                "token_hash": "managed-session-token",
+                "ua": "managed-browser",
+                "ip": "192.168.1.5",
+                "user_id": "user-one",
+            }
+        ],
+        "totp": {"enabled": True, "secret": "ADMIN-TOTP", "pending_secret": "ADMIN-PENDING"},
+        "recovery_codes": [{"hash": "admin-recovery-hash", "used_at": 0}],
+        "oidc": {
+            "enabled": True,
+            "issuer": "https://issuer.example",
+            "client_id": "oidc-client",
+            "client_secret": "oidc-secret",
+            "scopes": "openid profile email",
+        },
+        "oidc_identity": {
+            "iss": "https://issuer.example",
+            "sub": "admin-sub",
+            "username": "admin-oidc",
+            "email": "admin@example.com",
+            "picture": "https://issuer.example/admin.png",
+            "linked_at": 1,
+        },
+        "users": {
+            "user-one": {
+                "username": "managed-user",
+                "display_name": "Managed Real Name",
+                "profile_id": "profile-one",
+                "password": {"salt": "user-salt", "hash": "user-hash"},
+                "totp": {"enabled": True, "secret": "USER-TOTP", "pending_secret": "USER-PENDING"},
+                "recovery_codes": [{"hash": "user-recovery-hash", "used_at": 0}],
+                "avatar": {
+                    "file": "abc123456789abc123456789abc12345.png",
+                    "content_type": "image/png",
+                    "updated_at": 1,
+                },
+                "oidc": {
+                    "iss": "https://issuer.example",
+                    "sub": "managed-sub",
+                    "username": "managed-oidc",
+                    "email": "managed@example.com",
+                    "picture": "https://issuer.example/managed.png",
+                    "linked_at": 1,
+                },
+                "plex_sso": {
+                    "account_id": "plex-account",
+                    "username": "plex-user",
+                    "email": "plex@example.com",
+                    "thumb": "https://plex.example/thumb.png",
+                    "linked_at": 1,
+                },
+            }
+        },
+    }
+    cfg["pairs"][0]["profile_id"] = "profile-one"
+
+    archive = zipfile.ZipFile(io.BytesIO(support.build_bundle(None, ["config"])))
+    redacted = json.loads(archive.read("config.redacted.json"))
+    pairs = json.loads(archive.read("pairs.json"))
+    auth = redacted["app_auth"]
+    managed = auth["users"]["user-one"]
+    text = json.dumps({"config": redacted, "pairs": pairs})
+
+    for secret in (
+        "admin-user",
+        "admin-salt",
+        "admin-hash",
+        "admin-session-token",
+        "managed-session-token",
+        "managed-browser",
+        "192.168.1.5",
+        "ADMIN-TOTP",
+        "ADMIN-PENDING",
+        "admin-recovery-hash",
+        "https://issuer.example",
+        "oidc-client",
+        "oidc-secret",
+        "admin-sub",
+        "admin-oidc",
+        "admin@example.com",
+        "managed-user",
+        "Managed Real Name",
+        "profile-one",
+        "user-salt",
+        "user-hash",
+        "USER-TOTP",
+        "USER-PENDING",
+        "user-recovery-hash",
+        "abc123456789abc123456789abc12345.png",
+        "managed-sub",
+        "managed-oidc",
+        "managed@example.com",
+        "plex-account",
+        "plex-user",
+        "plex@example.com",
+    ):
+        assert secret not in text
+
+    assert auth["username"] == "<redacted>"
+    assert auth["session"]["token_hash"] == "<redacted>"
+    assert auth["sessions"] == "<1 item>"
+    assert auth["totp"]["secret"] == "<redacted>"
+    assert auth["recovery_codes"] == "<1 item>"
+    assert auth["oidc"]["client_secret"] == "<redacted>"
+    assert auth["oidc_identity"]["sub"] == "<redacted>"
+    assert managed["display_name"] == "<redacted>"
+    assert managed["totp"]["pending_secret"] == "<redacted>"
+    assert managed["recovery_codes"] == "<1 item>"
+    assert managed["avatar"]["file"] == "<redacted>"
+    assert managed["oidc"]["email"] == "<redacted>"
+    assert managed["plex_sso"]["account_id"] == "<redacted>"
+    assert pairs["pairs"][0]["profile_id"] == "<redacted>"


### PR DESCRIPTION
# Pull request

## Change

Adds 0.11.0 config cleanup for legacy resource IDs, stale managed profile refs, obsolete mobile_auth, and config key order.

Improves support bundle redaction for managed users, 2FA, OIDC, and pair profile IDs.

## Why

Older configs can miss IDs or carry stale fields. Support bundles also need to stay safe with managed users.

## Testing

- tests\test_config_api.py 
- tests\test_support_export.py

## Issue

N/A