### PR TITLE
Fix: editor shows managed users instances

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -919,11 +919,11 @@
       }))
       .filter(x => x.id);
 
-    if (!norm.some(x => x.id === "default")) norm.unshift({ id: "default", label: "Default" });
+    if (!norm.length) norm.push({ id: "default", label: "Default" });
 
     const ids = norm.map(x => x.id);
     let next = String(current || "");
-    if (!next || !ids.includes(next)) next = "default";
+    if (!next || !ids.includes(next)) next = ids.includes("default") ? "default" : ids[0];
     const opts = norm.map(x => `<option value="${_escapeHtml(x.id)}">${_escapeHtml(x.label || x.id)}</option>`).join("");
     selectEl.innerHTML = opts;
     selectEl.value = next;


### PR DESCRIPTION
# Pull request

## Change

- Editor profile picker now trusts the instance list from the server
- Default is only added when the list comes back empty
- Selection falls back to the first allowed profile instead of default

## Why

- Backend already scopes /api/provider-instances per user
- Frontend put Default back on top of the filtered list
- Managed users saw a profile they could not read, picking it gave a 403

## Testing

- tests/test_access_audit_fixes.py

## Issue

NA
