### PR TITLE
Fix: hide events Clear from managed users

### DIFF
--- a/assets/js/modals/events/index.js
+++ b/assets/js/modals/events/index.js
@@ -474,7 +474,7 @@ export default {
             <span id="ev-mode"></span>
             <button class="ev-tbtn" id="ev-more" type="button" aria-expanded="false"><span class="material-symbols-rounded" aria-hidden="true">tune</span><span>More filters</span><span class="ev-more-dot" id="ev-more-dot" hidden></span><span class="material-symbols-rounded ev-tbtn-caret" aria-hidden="true">expand_more</span></button>
             <button class="ev-tbtn ev-tbtn-refresh" id="ev-refresh" type="button"><span class="material-symbols-rounded" aria-hidden="true">refresh</span><span>Refresh</span></button>
-            <button class="ev-tbtn" id="ev-clear" type="button" title="Delete all events from the archive"><span class="material-symbols-rounded" aria-hidden="true">delete_sweep</span><span>Clear</span></button>
+            ${isAdmin ? `<button class="ev-tbtn" id="ev-clear" type="button" title="Delete all events from the archive"><span class="material-symbols-rounded" aria-hidden="true">delete_sweep</span><span>Clear</span></button>` : ``}
           </div>
           <div class="ev-morefilters" id="ev-morefilters" hidden>
             <div class="ev-mf-row">
@@ -1047,10 +1047,12 @@ export default {
     };
 
     let toastTimer = null;
-    const showToast = (msg, undoFn) => {
+    const showToast = (msg, undoFn, tone) => {
       clearTimeout(toastTimer);
+      const bad = tone === "error";
       toastEl.hidden = false;
-      toastEl.innerHTML = `<span class="material-symbols-rounded ev-toast-ic" aria-hidden="true">check_circle</span><span>${esc(msg)}</span>${undoFn ? `<button type="button" class="ev-toast-undo">Undo</button>` : ""}`;
+      toastEl.classList.toggle("ev-toast-error", bad);
+      toastEl.innerHTML = `<span class="material-symbols-rounded ev-toast-ic" aria-hidden="true">${bad ? "error" : "check_circle"}</span><span>${esc(msg)}</span>${undoFn ? `<button type="button" class="ev-toast-undo">Undo</button>` : ""}`;
       toastEl.querySelector(".ev-toast-undo")?.addEventListener("click", async () => {
         clearTimeout(toastTimer);
         toastEl.hidden = true;
@@ -1831,7 +1833,7 @@ export default {
       btn.classList.toggle("on", open);
     });
     Q("#ev-refresh", root).addEventListener("click", () => doRefresh());
-    Q("#ev-clear", root).addEventListener("click", async () => {
+    Q("#ev-clear", root)?.addEventListener("click", async () => {
       const label = domain === "audit" ? "audit" : (domain === "scrobble" ? "scrobble" : "sync");
       if (!window.confirm(`Delete all ${label} events from the archive?\n\nThis clears the ${label} history from the SQLite event archive.\nThis cannot be undone.`)) return;
       const btn = Q("#ev-clear", root);
@@ -1841,8 +1843,9 @@ export default {
         if (!alive) return;
         state.selected = null; state.collapsed.clear(); clearDetail();
         await load(0);
-        showToast(res?.ok ? `Archive cleared (${state.total} remaining).` : "Clear failed.");
-      } catch (err) { showToast(`Clear failed: ${err.message}`); } finally { btn?.classList.remove("busy"); }
+        if (res?.ok) showToast(`Archive cleared (${state.total} remaining).`);
+        else showToast("Clear failed.", null, "error");
+      } catch (err) { showToast(`Clear failed: ${err.message}`, null, "error"); } finally { btn?.classList.remove("busy"); }
     });
     Q("#ev-prev-top", root).addEventListener("click", () => { if (state.page > 0) load(state.page - 1); });
     Q("#ev-next-top", root).addEventListener("click", () => { if (state.page < pageCount() - 1) load(state.page + 1); });

--- a/assets/js/modals/events/styles.css
+++ b/assets/js/modals/events/styles.css
@@ -199,7 +199,7 @@ html[data-cw-theme=flat-light] .ev-date input::-webkit-calendar-picker-indicator
 .ev-empty-actions{margin-top:2px}.ev-empty-inline{padding:14px;font-size:12.5px;opacity:.55;text-align:left}
 @keyframes ev-spin{to{transform:rotate(360deg)}}
 .ev-toast{position:absolute;left:50%;bottom:52px;transform:translateX(-50%);gap:10px;background:var(--ev-menu);border:1px solid var(--ev-border);border-radius:11px;padding:9px 14px;font-size:13px;box-shadow:var(--shadow,0 16px 44px rgba(0,0,0,.6));z-index:30;color:var(--ev-text)}
-.ev-toast[hidden]{display:none}.ev-toast-ic{font-size:18px;color:var(--ev-ok)}.ev-toast-undo{background:transparent;border:0;color:var(--ev-accent);font-weight:600;cursor:pointer;font-size:13px}
+.ev-toast[hidden]{display:none}.ev-toast-ic{font-size:18px;color:var(--ev-ok)}.ev-toast-error .ev-toast-ic{color:var(--ev-err)}.ev-toast-undo{background:transparent;border:0;color:var(--ev-accent);font-weight:600;cursor:pointer;font-size:13px}
 
 .ev-list,.ev-detail,.ev-dd-body,.ev-tech pre{scrollbar-width:thin;scrollbar-color:var(--cw-scrollbar-thumb,rgba(255,255,255,.18)) var(--cw-scrollbar-track,transparent)}
 .ev-list::-webkit-scrollbar,.ev-detail::-webkit-scrollbar,.ev-dd-body::-webkit-scrollbar,.ev-tech pre::-webkit-scrollbar{width:10px;height:10px}

--- a/tests/test_access_audit_fixes.py
+++ b/tests/test_access_audit_fixes.py
@@ -698,6 +698,29 @@ def test_editor_ui_renders_the_shared_instance_note() -> None:
     assert ".cw-shared-note{" in css
 
 
+def test_events_clear_is_hidden_from_managed_users() -> None:
+    import pathlib
+
+    from api import eventsAPI
+
+    assert 'if _managed_request(request):' in pathlib.Path("api/eventsAPI.py").read_text(encoding="utf-8")
+    assert eventsAPI.events_clear.__module__ == "api.eventsAPI"
+
+    modal = pathlib.Path("assets/js/modals/events/index.js").read_text(encoding="utf-8")
+    assert '${isAdmin ? `<button class="ev-tbtn" id="ev-clear"' in modal
+    assert 'Q("#ev-clear", root)?.addEventListener' in modal
+    assert 'showToast("Clear failed.", null, "error")' in modal
+
+
+def test_editor_profile_picker_does_not_invent_a_default_profile() -> None:
+    import pathlib
+
+    editor = pathlib.Path("assets/js/editor.js").read_text(encoding="utf-8")
+    assert 'norm.unshift({ id: "default", label: "Default" })' not in editor
+    assert 'if (!norm.length) norm.push({ id: "default", label: "Default" });' in editor
+    assert 'next = ids.includes("default") ? "default" : ids[0];' in editor
+
+
 # Profile page: created_at, preferences, and the Main widget grid
 def test_user_shapes_expose_created_at_and_preferences() -> None:
     from api.appAuthAPI import _admin_identity, _public_user, clean_user_preferences


### PR DESCRIPTION
# Pull request

## Change

- Events Clear button only renders for admins
- Adds the missing regression test for the editor profile picker fix

## Why

- /api/events/clear already blocks managed users on purpose, it wipes the whole archive for everyone
- The button was still there so it just gave a 403
- The failure toast looked like a success

## Testing

- tests/test_access_audit_fixes.py

## Issue

NA