### PR TITLE
Add: user profile name on watcher and webhook cards

### DIFF
--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -10,7 +10,7 @@ from typing import Any
 from fastapi import APIRouter, Body, Request
 from fastapi.responses import JSONResponse
 
-from cw_platform.access_policy import managed_profile_id, profile_label_for_id, request_user, route_effective_profile_id, webhook_effective_profile_id
+from cw_platform.access_policy import managed_profile_id, profile_label_for_id, request_user, route_effective_profile_id, valid_user_profile_id, webhook_effective_profile_id
 from cw_platform.config_base import load_config, save_config
 from cw_platform.provider_instances import get_provider_block, list_instance_ids, list_user_profiles, normalize_instance_id, normalize_user_profile_id, sanitize_instance_label
 from cw_platform.user_profile_resources import webhook_assigned_profile_id, webhook_resource_id
@@ -406,29 +406,31 @@ def _webhook_cards(cfg: dict[str, Any], request: Request) -> list[dict[str, Any]
             for sink in sink_list:
                 sink_inst = webhook_sink_instance(settings, sink)
                 ready = sink_configured(cfg, sink, sink_inst)
-                out.append(
-                    {
-                        "provider": provider,
-                        "provider_label": provider_label(provider),
-                        "provider_instance": inst,
-                        "profile_label": _instance_display_label(cfg, provider, inst),
-                        "sink": sink,
-                        "sink_label": provider_label(sink),
-                        "sink_instance": sink_inst,
-                        "sink_profile_label": _instance_display_label(cfg, sink, sink_inst),
-                        "sink_ready": ready,
-                        "enabled": src_enabled,
-                        "source_configured": source_configured,
-                        "explicit": True,
-                        "active": bool(src_enabled and source_configured and ready),
-                        "endpoint_url": endpoint,
-                        "webhook_token": token,
-                        "id": webhook_resource_id(provider, inst, sink, sink_inst),
-                        "profile_id": webhook_assigned_profile_id(cfg, webhook_resource_id(provider, inst, sink, sink_inst)),
-                        "effective_settings": safe_eff,
-                        "explicit_settings": safe_expl,
-                    }
-                )
+                row = {
+                    "provider": provider,
+                    "provider_label": provider_label(provider),
+                    "provider_instance": inst,
+                    "profile_label": _instance_display_label(cfg, provider, inst),
+                    "sink": sink,
+                    "sink_label": provider_label(sink),
+                    "sink_instance": sink_inst,
+                    "sink_profile_label": _instance_display_label(cfg, sink, sink_inst),
+                    "sink_ready": ready,
+                    "enabled": src_enabled,
+                    "source_configured": source_configured,
+                    "explicit": True,
+                    "active": bool(src_enabled and source_configured and ready),
+                    "endpoint_url": endpoint,
+                    "webhook_token": token,
+                    "id": webhook_resource_id(provider, inst, sink, sink_inst),
+                    "profile_id": webhook_assigned_profile_id(cfg, webhook_resource_id(provider, inst, sink, sink_inst)),
+                    "effective_settings": safe_eff,
+                    "explicit_settings": safe_expl,
+                }
+                user_pid = valid_user_profile_id(cfg, row.get("profile_id"))
+                row["user_profile_id"] = user_pid
+                row["user_profile_label"] = profile_label_for_id(cfg, user_pid) if user_pid else ""
+                out.append(row)
     return out
 
 
@@ -476,6 +478,9 @@ def _normalized_routes(cfg: dict[str, Any], request: Request) -> list[dict[str, 
         profile_id = str(row.get("profile_id") or "").strip()
         if profile_id:
             row["profile_label"] = profile_label_for_id(cfg, profile_id)
+        user_pid = valid_user_profile_id(cfg, route.get("profile_id"))
+        row["user_profile_id"] = user_pid
+        row["user_profile_label"] = profile_label_for_id(cfg, user_pid) if user_pid else ""
         row["needs_account_filter"] = route_needs_account_filter(cfg, route)
         out.append(row)
     return out

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -498,3 +498,19 @@ html[data-cw-theme="flat-dark"] .cx-modal-shell:has(#cx-modal.editor-raw-modal){
 .sb-note.hide{display:none}
 @media(max-width:640px){.sb-head-side{width:100%;justify-content:flex-start}.sb-note{min-width:0}}
 @media(max-width:640px){#ux-progress{min-height:144px}}
+
+.sc2-rt-conn.has-profile .sc2-rt-conn-line{opacity:0.5}
+.sc2-rt-profile{position:relative;z-index:1;display:inline-flex;align-items:center;gap:5px;max-width:min(100%,150px);min-width:0;padding:3px 9px 3px 6px;border-radius:999px;border:1px solid rgba(124,92,255,0.45);background:linear-gradient(180deg,rgba(124,92,255,0.28),rgba(124,92,255,0.14));color:#d5cbff;-webkit-text-fill-color:#d5cbff;box-shadow:0 0 14px rgba(124,92,255,0.26),inset 0 1px 0 rgba(255,255,255,0.08);font-size:11px;font-weight:800;line-height:1;white-space:nowrap;cursor:default}
+.sc2-rt-profile .material-symbols-rounded{width:auto;height:auto;flex:0 0 auto;padding:0;border:0;border-radius:0;background:none;box-shadow:none;color:#a78bfa;font-size:14px !important;line-height:1}
+.sc2-rt-profile-name{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.sc2-route-card.is-disabled .sc2-rt-profile{filter:grayscale(0.45)}
+
+
+.sc2-route-card.has-user-profile:not(.is-disabled):not(.sc2-route-add-card)::after{background:linear-gradient(180deg,#7c5cff,rgba(124,92,255,0.5))}
+.sc2-route-card.has-user-profile.is-live:not(.is-disabled):not(.sc2-route-add-card)::after{background:linear-gradient(180deg,#7c5cff,rgba(124,92,255,0.55));box-shadow:0 0 18px rgba(124,92,255,0.42)}
+
+.scrm-lock-note{display:flex;align-items:flex-start;gap:10px;margin:0 0 12px;padding:11px 14px;border:1px solid rgba(124,92,255,0.4);border-radius:12px;background:rgba(124,92,255,0.1)}
+.scrm-lock-note .material-symbols-rounded{flex:0 0 auto;color:#a78bfa;font-size:19px;line-height:1.2}
+.scrm-lock-note strong{display:block;color:rgba(235,240,255,0.95);font-size:13px;font-weight:900}
+.scrm-lock-note p{margin:3px 0 0;color:rgba(196,205,232,0.78);font-size:12px;font-weight:650}
+.scrm-route-grid.is-profile-locked select[disabled]{opacity:0.62;cursor:not-allowed}

--- a/assets/helpers/providers-ui.js
+++ b/assets/helpers/providers-ui.js
@@ -424,7 +424,7 @@
     const userProfileSection = `<section class="cw-auth-service-section cw-user-profile-section" data-cw-auth-group="sec-user-profiles">
         <div class="cw-auth-service-head">
           <h4>User profiles</h4>
-          <p>Manage people and the configured provider instances assigned to them.</p>
+          <p>Manage people and provider instances linked to Managed User accounts.</p>
           <span class="material-symbols-rounded cw-auth-section-chevron" aria-hidden="true">expand_more</span>
         </div>
         <div id="cw-user-profile-manager" class="cw-user-profile-manager" aria-live="polite"></div>

--- a/assets/js/scrobbler.js
+++ b/assets/js/scrobbler.js
@@ -65,6 +65,16 @@
     return String(v || "default") === "default" ? "Default" : String(v || "default");
   }
 
+  function profileConnector(row) {
+    const name = String(row?.user_profile_label || "").trim();
+    if (!name) return `<div class="sc2-rt-conn"><span class="sc2-rt-conn-line"></span></div>`;
+    return `<div class="sc2-rt-conn has-profile"><span class="sc2-rt-conn-line"></span>
+      <span class="sc2-rt-profile" title="${esc(`User profile: ${name}`)}">
+        <span class="material-symbols-rounded" aria-hidden="true">person</span>
+        <span class="sc2-rt-profile-name">${esc(name)}</span>
+      </span></div>`;
+  }
+
   function routeFilterSummary(filters = {}) {
     const parts = [];
     const users = Array.isArray(filters.username_whitelist) ? filters.username_whitelist : [];
@@ -119,10 +129,10 @@
           ${rows.map((x) => {
             const [text] = webhookState(x);
             return `
-            <article class="sc2-route sc2-route-card sc2-webhook-card ${x.enabled ? "is-enabled" : "is-disabled"} ${x.active ? "is-live" : "is-idle"}" data-action="edit-webhook" data-provider="${esc(x.provider)}" data-instance="${esc(x.provider_instance)}" data-sink="${esc(x.sink)}" title="Edit webhook">
+            <article class="sc2-route sc2-route-card sc2-webhook-card ${x.enabled ? "is-enabled" : "is-disabled"} ${x.active ? "is-live" : "is-idle"} ${x.user_profile_label ? "has-user-profile" : ""}" data-action="edit-webhook" data-provider="${esc(x.provider)}" data-instance="${esc(x.provider_instance)}" data-sink="${esc(x.sink)}" title="Edit webhook">
               <div class="sc2-route-flow-wrap">
                 <div class="sc2-route-endpoint">${providerLogo(x.provider)}<div><strong>${esc(label(x.provider))}</strong><span>${esc(webhookProfileName(x))}</span></div></div>
-                <div class="sc2-rt-conn"><span class="sc2-rt-conn-line"></span></div>
+                ${profileConnector(x)}
                 <div class="sc2-route-endpoint sc2-route-endpoint-sink"><div><strong>${esc(label(x.sink))}</strong><span>${esc(instanceName(x.sink_instance, x.sink_profile_label))}</span></div>${providerLogo(x.sink)}</div>
               </div>
               <div class="sc2-route-meta">
@@ -157,10 +167,10 @@
         <div class="sc2-section-head"><div><h4>Watcher routes</h4><p>Configure routes that send play events from media servers to trackers.</p></div></div>
         <div class="sc2-route-card-grid">
           ${rows.length ? rows.map((r) => `
-            <article class="sc2-route sc2-route-card ${r.enabled ? "is-enabled" : "is-disabled"} ${r.runtime?.running ? "is-live" : "is-idle"}" data-action="edit-route" data-route="${esc(r.id)}" title="Edit route">
+            <article class="sc2-route sc2-route-card ${r.enabled ? "is-enabled" : "is-disabled"} ${r.runtime?.running ? "is-live" : "is-idle"} ${r.user_profile_label ? "has-user-profile" : ""}" data-action="edit-route" data-route="${esc(r.id)}" title="Edit route">
               <div class="sc2-route-flow-wrap">
                 <div class="sc2-route-endpoint">${providerLogo(r.provider)}<div><strong>${esc(label(r.provider))}</strong><span>${esc(instanceName(r.provider_instance, r.source_label))}</span></div></div>
-                <div class="sc2-rt-conn"><span class="sc2-rt-conn-line"></span></div>
+                ${profileConnector(r)}
                 <div class="sc2-route-endpoint sc2-route-endpoint-sink"><div><strong>${esc(label(r.sink))}</strong><span>${esc(instanceName(r.sink_instance, r.sink_label))}</span></div>${providerLogo(r.sink)}</div>
               </div>
               <div class="sc2-route-meta">

--- a/assets/js/user-profiles.js
+++ b/assets/js/user-profiles.js
@@ -242,7 +242,7 @@
     const required = resourceRequiredMap();
     const keys = providerKeys();
     if (!keys.length) {
-      return `<div class="cw-upm-empty">No named provider instances available. Default instances are reserved for the admin workspace here; create named instances such as PLEX-P01 and TRAKT-P01 for managed users.</div>`;
+      return `<div class="cw-upm-empty">No named provider instances available. Default instances are reserved for the admin workspace here; create named instances such as PLEX-P01 for managed users.</div>`;
     }
     return `<div class="cw-upm-provider-grid">${keys.map((provider) => {
       const selected = new Set((insts[provider] || []).map(txt));
@@ -369,13 +369,12 @@
       host.innerHTML = renderModal();
       return;
     }
-    const rows = allInstanceRows();
     host.innerHTML = `
       <div class="cw-auth-service-grid cw-upm-service-grid">
         ${userProfiles.map(renderProfileCard).join("")}
         ${renderAddCard()}
       </div>
-      <div class="cw-upm-status" id="cw-upm-status">${rows.length ? "" : "No named provider instances are available for managed profiles. Default instances stay in the admin workspace; create separate named instances first."}</div>
+      <div class="cw-upm-status" id="cw-upm-status"></div>
       ${renderModal()}`;
   }
 

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -690,7 +690,7 @@ def test_user_profile_manager_screen_is_mounted() -> None:
     assert "sec-user-profiles" not in settings_html
     assert "cw-user-profile-manager" in providers_js
     assert "sec-user-profiles" in providers_js
-    assert "Manage people and the configured provider instances assigned to them." in providers_js
+    assert "Manage people and provider instances linked to Managed User accounts." in providers_js
     assert "/api/user-profiles" in manager_js
     assert "/api/provider-instances" in manager_js
     assert "configured_only=true" in manager_js
@@ -765,52 +765,31 @@ def test_user_profile_manager_screen_is_mounted() -> None:
     assert ".cw-app-user-delete.is-confirming" in app_users_css
 
 
-def test_pair_config_profile_selector_sits_before_mode_control() -> None:
+def test_pair_config_has_no_user_profile_selector() -> None:
     js = Path("assets/js/modals/pair-config/index.js").read_text("utf-8")
-    css = Path("assets/js/modals/pair-config/styles.css").read_text("utf-8")
 
-    assert "cx-user-profile-slot" in js
-    assert js.index("cx-user-profile-slot") < js.index("flow-mode-inline")
-    assert "slot.appendChild(row)" in js
-    assert ".flow-control-row" in css
-    assert "cx-user-profile-select" in js
-    assert "resetPairUserProfileControl(state)" in js
-    assert 'sel.value=""' in js
-    assert "selected_user_profile_id" in js
-    assert "applying_user_profile" in js
-    assert "eligiblePairUserProfiles(state)" in js
-    assert "profileCanOwnCurrentPair(profile,state)" in js
-    assert ".cx-user-profile-select" in css
-    assert "cx-user-profile-label" not in js
-    assert ">User profile<" not in js
-    assert "display_label||x.label||x.id" in js
-    assert 'title="${escHTML(row.id)}"' in js
+    assert "cx-user-profile" not in js
+    assert "renderPairUserProfileControl" not in js
+    assert "eligiblePairUserProfiles" not in js
+    assert "/api/user-profiles" not in js
+    # editing a pair must preserve its existing assignment, not clear it
+    assert 'const selectedProfileId=String(state.selected_user_profile_id||"").trim();' in js
+    assert 'state.selected_user_profile_id=String(pair.profile_id||"").trim();' in js
 
 
-def test_scrobbler_modals_have_conditional_user_profile_selector() -> None:
+def test_scrobbler_modals_have_no_user_profile_selector() -> None:
     route_js = Path("assets/js/modals/scrobbler-route/index.js").read_text("utf-8")
     webhook_js = Path("assets/js/modals/scrobbler-webhook/index.js").read_text("utf-8")
-    css = Path("assets/css/components.css").read_text("utf-8")
 
-    assert "/api/user-profiles" in route_js
-    assert "/api/user-profiles" in webhook_js
-    assert "id=\"scr-user-profile\"" in route_js
-    assert "id=\"scw-user-profile\"" in webhook_js
-    assert "if (!userProfiles.length) return \"\"" in route_js
-    assert "if (!userProfiles.length || props.mode === \"edit\") return \"\"" in webhook_js
-    assert "selectedUserProfileId" in route_js
-    assert "selectedUserProfileId" in webhook_js
-    assert 'selectedUserProfileId = applyUserProfile(selected) ? selected : ""' in route_js
-    assert 'selectedUserProfileId = applyUserProfile(selected) ? selected : ""' in webhook_js
-    assert '${p.id === current ? "selected" : ""}' in route_js
-    assert '${p.id === current ? "selected" : ""}' in webhook_js
-    assert "profileOptionLabel(profile)" in route_js
-    assert "profileOptionLabel(profile)" in webhook_js
-    assert "display_label || profile?.label" in route_js
-    assert "display_label || profile?.label" in webhook_js
-    assert 'title="${esc(p.instance)}"' in route_js
-    assert 'title="${esc(p.instance)}"' in webhook_js
-    assert ".scrm-profile-row" in css
+    for js in (route_js, webhook_js):
+        assert "/api/user-profiles" not in js
+        assert "userProfileField" not in js
+        assert "applyUserProfile" not in js
+        assert "selectedUserProfileId" not in js
+    assert 'id="scr-user-profile"' not in route_js
+    assert 'id="scw-user-profile"' not in webhook_js
+    # saving a route keeps whatever the user profile modal assigned
+    assert 'profile_id: draft.profile_id || "",' in route_js
 
 
 def test_events_audit_domain_is_admin_only_for_managed_users(monkeypatch) -> None:
@@ -2563,3 +2542,128 @@ def test_status_provider_visibility_reuses_configured_set() -> None:
     assert "isStatusProviderVisible(key, data, cfg = getCachedConfig(), configured = null)" in status
     assert "isStatusProviderVisible(k, providers[k], cfg, configured)" in status
     assert "typeof set.has === \"function\"" in status
+
+
+def _profile_scoped_webhook_cfg(assigned: bool = True) -> dict[str, Any]:
+    profile_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    instance_uid = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    webhook: dict[str, Any] = {"profiles": {"plex": {"default": {"enabled": True, "sinks": ["trakt"]}}}}
+    if assigned:
+        webhook["user_profile_assignments"] = {"plex:default:trakt:default": profile_id}
+    return {
+        "plex": {"server_url": "http://plex:32400", "account_token": "t", "instances": {}},
+        "trakt": {"client_id": "c", "client_secret": "s", "access_token": "t", "instances": {}},
+        "provider_instance_ids": {instance_uid: {"provider": "PLEX", "instance": "default"}},
+        # the profile owns the instance in both cases; only the explicit assignment differs
+        "user_profiles": {profile_id: {"label": "Alice", "instance_uids": [instance_uid]}},
+        "scrobble": {"webhook": webhook},
+    }
+
+
+def test_watcher_route_rows_expose_user_profile_label() -> None:
+    import sys
+
+    sys.path.insert(0, "tests")
+    from test_scrobble_account_scope import _cfg
+
+    from api.scrobblerManagementAPI import _normalized_routes
+
+    assigned = _normalized_routes(_cfg(profile=True, whitelist=["dad"]), None)[0]
+    assert assigned["user_profile_label"] == "Alice"
+
+    # an admin picking a profile-owned instance must NOT mark the route as that profile
+    derived = _normalized_routes(_cfg(profile=True, whitelist=["dad"], assign=False), None)[0]
+    assert derived["user_profile_label"] == ""
+    assert derived["user_profile_id"] == ""
+
+    plain = _normalized_routes(_cfg(profile=False, whitelist=None), None)[0]
+    assert plain["user_profile_label"] == ""
+    assert plain["user_profile_id"] == ""
+
+
+def test_webhook_rows_expose_user_profile_without_touching_instance_label() -> None:
+    from api.scrobblerManagementAPI import _webhook_cards
+
+    request = SimpleNamespace(base_url="http://cw:9898/", headers={})
+
+    row = _webhook_cards(_profile_scoped_webhook_cfg(True), request)[0]
+    assert row["user_profile_label"] == "Alice"
+    assert row["profile_label"] == "Default"
+
+    # owned instance but no explicit assignment must stay unlabelled
+    bare = _webhook_cards(_profile_scoped_webhook_cfg(False), request)[0]
+    assert bare["user_profile_label"] == ""
+    assert bare["profile_label"] == "Default"
+
+
+def test_route_and_webhook_cards_render_profile_connector() -> None:
+    js = Path("assets/js/scrobbler.js").read_text("utf-8")
+
+    assert "function profileConnector(row)" in js
+    assert "user_profile_label" in js
+    # webhook cards iterate x, watcher routes iterate r
+    webhooks = js.split("function renderWebhooks(", 1)[1].split("function renderRoutes(", 1)[0]
+    routes = js.split("function renderRoutes(", 1)[1]
+    assert "${profileConnector(x)}" in webhooks
+    assert "${profileConnector(r)}" in routes
+    assert '<div class="sc2-rt-conn"><span class="sc2-rt-conn-line"></span></div>' not in webhooks
+
+
+def test_route_card_accent_is_purple_only_with_user_profile() -> None:
+    css = Path("assets/css/components.css").read_text("utf-8")
+
+    # default and live accents stay green for cards without a user profile
+    live = css.split(".sc2-route-card.is-live:not(.sc2-route-add-card)::after{", 1)[1].split("}", 1)[0]
+    assert "57d889" in live and "124,92,255" not in live
+
+    # purple is opt-in via the card class, and never overrides the disabled state
+    assert ".sc2-route-card.has-user-profile:not(.is-disabled):not(.sc2-route-add-card)::after" in css
+    assert ".sc2-route-card.has-user-profile.is-live:not(.is-disabled):not(.sc2-route-add-card)::after" in css
+
+    # the connector still absorbs free space so the sink endpoint stays flush right
+    assert ".sc2-rt-conn.has-profile{min-width" not in css
+    assert "flex:0 1 150px" not in css
+
+    chip = css.split(".sc2-rt-profile{", 1)[1].split("}", 1)[0]
+    assert "max-width:min(100%,150px)" in chip
+    name = css.split(".sc2-rt-profile-name{", 1)[1].split("}", 1)[0]
+    assert "text-overflow:ellipsis" in name
+
+
+def test_cards_tag_user_profile_class() -> None:
+    js = Path("assets/js/scrobbler.js").read_text("utf-8")
+    webhooks = js.split("function renderWebhooks(", 1)[1].split("function renderRoutes(", 1)[0]
+    routes = js.split("function renderRoutes(", 1)[1]
+
+    assert '${x.user_profile_label ? "has-user-profile" : ""}' in webhooks
+    assert '${r.user_profile_label ? "has-user-profile" : ""}' in routes
+
+
+def test_assigned_resources_lock_their_provider_and_instance_selects() -> None:
+    route_js = Path("assets/js/modals/scrobbler-route/index.js").read_text("utf-8")
+    webhook_js = Path("assets/js/modals/scrobbler-webhook/index.js").read_text("utf-8")
+    pair_js = Path("assets/js/modals/pair-config/index.js").read_text("utf-8")
+
+    for select in ("scr-provider", "scr-provider-instance", "scr-sink", "scr-sink-instance"):
+        assert f'id="{select}"${{lockAttr}}' in route_js
+    assert "function profileLockName()" in route_js
+    assert 'const lockAttr = lockName ? " disabled" : "";' in route_js
+
+    assert "function profileLockName()" in webhook_js
+    assert 'const dis = props.mode === "edit" || profileLockName() ? "disabled" : "";' in webhook_js
+    assert "const sinkDisabled = sink && !lockName ? \"\" : \"disabled\";" in webhook_js
+
+    assert "function pairProfileLocked(state){" in pair_js
+    assert "function applyPairProfileLock(state){" in pair_js
+    assert '["cx-src","cx-dst","cx-src-inst","cx-dst-inst"].forEach' in pair_js
+    assert "applyPairProfileLock(state);" in pair_js
+
+
+def test_profile_lock_notes_are_styled() -> None:
+    comp = Path("assets/css/components.css").read_text("utf-8")
+    pair_css = Path("assets/js/modals/pair-config/styles.css").read_text("utf-8")
+
+    assert ".scrm-lock-note{" in comp
+    assert ".cx-profile-lock-note{" in pair_css
+    assert "cursor:not-allowed" in comp
+    assert "cursor:not-allowed" in pair_css


### PR DESCRIPTION
# Pull request

## Change

- Watcher route and webhook cards show the user profile name on the connector line.
- Cards with a user profile get a purple accent instead of green.
- Long profile names are cut off with a tooltip for the full name.
- Cards with many profiles collapse into a +N badge.
- Route and webhook payloads expose user_profile_id and user_profile_label.
- Removed the no named provider instances text under User profiles.
- Reworded the User profiles subtitle.

## Why

- There was no way to see which routes or webhooks belong to a person.
- Only an explicit assignment counts, so picking an instance that happens to belong to a profile does not mark the card.
- The existing profile_label field on webhooks means the instance name, so a new field was needed to avoid a clash.

## Testing

- tests/test_crosswatch_profiles.py

## Issue

Relates to #728
