### PR TITLE
Fix: version comes from the image,

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ playwright/.auth/
 # Temporary files
 *.tmp
 *.bak
+
+# build-time version stamp (written by Dockerfile)
+VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/run-sync.sh
 # --- runtime env ---
 ARG APP_VERSION=v0.0.0
 ENV APP_VERSION=${APP_VERSION}
+RUN printf '%s' "${APP_VERSION}" > /app/VERSION && chmod 0444 /app/VERSION
 ENV RUNTIME_DIR=/config \
     WEB_HOST=0.0.0.0 \
     WEB_PORT=8787 \

--- a/api/versionAPI.py
+++ b/api/versionAPI.py
@@ -9,6 +9,7 @@ import re
 import time
 from functools import lru_cache
 from importlib import import_module
+from pathlib import Path
 from typing import Any
 
 import requests
@@ -19,7 +20,21 @@ __all__ = ["router"]
 
 router = APIRouter(prefix="/api", tags=["version"])
 
-CURRENT_VERSION = os.getenv("APP_VERSION", "v0.11.1")
+VERSION_FILE = Path(__file__).resolve().parent.parent / "VERSION"
+FALLBACK_VERSION = "v0.11.1"
+
+
+def resolve_current_version() -> str:
+    try:
+        stamped = VERSION_FILE.read_text(encoding="utf-8").strip()
+    except Exception:
+        stamped = ""
+    if stamped:
+        return stamped
+    return (os.getenv("APP_VERSION") or "").strip() or FALLBACK_VERSION
+
+
+CURRENT_VERSION = resolve_current_version()
 REPO = os.getenv("GITHUB_REPO", "cenodude/CrossWatch")
 
 

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -2657,3 +2657,35 @@ def test_scrobbler_modals_have_conditional_user_profile_selector() -> None:
     assert 'title="${esc(p.instance)}"' in route_js
     assert 'title="${esc(p.instance)}"' in webhook_js
     assert ".scrm-profile-row" in css
+
+
+def test_version_stamp_file_beats_stale_env(tmp_path, monkeypatch) -> None:
+    from api import versionAPI
+
+    stamp = tmp_path / "VERSION"
+    monkeypatch.setattr(versionAPI, "VERSION_FILE", stamp)
+
+    # a container env pinned by Portainer or Watchtower must not win
+    stamp.write_text("v0.11.1", encoding="utf-8")
+    monkeypatch.setenv("APP_VERSION", "v0.11.0")
+    assert versionAPI.resolve_current_version() == "v0.11.1"
+
+    # without a stamp the env still works, for bare python runs
+    stamp.unlink()
+    assert versionAPI.resolve_current_version() == "v0.11.0"
+
+    # an empty or truncated stamp must not blank the version
+    stamp.write_text("   ", encoding="utf-8")
+    assert versionAPI.resolve_current_version() == "v0.11.0"
+
+    monkeypatch.delenv("APP_VERSION", raising=False)
+    assert versionAPI.resolve_current_version() == versionAPI.FALLBACK_VERSION
+
+
+def test_dockerfile_stamps_version_into_the_image() -> None:
+    dockerfile = Path("Dockerfile").read_text("utf-8")
+
+    assert 'RUN printf \'%s\' "${APP_VERSION}" > /app/VERSION' in dockerfile
+    # the stamp must be written in the runtime stage, after the app is copied
+    assert dockerfile.index("COPY --from=appsrc") < dockerfile.index("/app/VERSION")
+    assert "VERSION" in Path(".gitignore").read_text("utf-8")


### PR DESCRIPTION
# Pull request

## Change

- The Dockerfile writes the build version to /app/VERSION.
- CrossWatch reads that file first and only falls back to APP_VERSION.
- Added VERSION to gitignore so a local stamp never lands in a build.

## Why

NA

## Testing

NA

## Issue

NA
