### PR TITLE
Fix: dev images report real version

### DIFF
--- a/.github/workflows/dev-db-image.yml
+++ b/.github/workflows/dev-db-image.yml
@@ -20,6 +20,26 @@ jobs:
           exit 1
 
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve dev version
+        id: ver
+        run: |
+          set -euo pipefail
+
+          last="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)"
+          if [ -z "${last}" ]; then
+            echo "No release tag found, leaving the version to the app fallback"
+            echo "app_version=v0.0.0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          IFS=. read -r major minor patch <<< "${last#v}"
+          version="v${major}.${minor}.$((patch + 1))-dev"
+
+          echo "Newest tag ${last}, building as ${version}"
+          echo "app_version=${version}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -43,6 +63,8 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            APP_VERSION=${{ steps.ver.outputs.app_version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -14,6 +14,26 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve dev version
+        id: ver
+        run: |
+          set -euo pipefail
+
+          last="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)"
+          if [ -z "${last}" ]; then
+            echo "No release tag found, leaving the version to the app fallback"
+            echo "app_version=v0.0.0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          IFS=. read -r major minor patch <<< "${last#v}"
+          version="v${major}.${minor}.$((patch + 1))-dev"
+
+          echo "Newest tag ${last}, building as ${version}"
+          echo "app_version=${version}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -37,6 +57,8 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            APP_VERSION=${{ steps.ver.outputs.app_version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/api/versionAPI.py
+++ b/api/versionAPI.py
@@ -24,14 +24,21 @@ VERSION_FILE = Path(__file__).resolve().parent.parent / "VERSION"
 FALLBACK_VERSION = "v0.11.1"
 
 
+def _usable_version(value: Any) -> str:
+    raw = str(value or "").strip()
+    return "" if raw.lower().lstrip("v") in ("", "0.0.0") else raw
+
+
 def resolve_current_version() -> str:
     try:
-        stamped = VERSION_FILE.read_text(encoding="utf-8").strip()
+        stamped = VERSION_FILE.read_text(encoding="utf-8")
     except Exception:
         stamped = ""
-    if stamped:
-        return stamped
-    return (os.getenv("APP_VERSION") or "").strip() or FALLBACK_VERSION
+    for candidate in (stamped, os.getenv("APP_VERSION")):
+        usable = _usable_version(candidate)
+        if usable:
+            return usable
+    return FALLBACK_VERSION
 
 
 CURRENT_VERSION = resolve_current_version()

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -2681,6 +2681,13 @@ def test_version_stamp_file_beats_stale_env(tmp_path, monkeypatch) -> None:
     monkeypatch.delenv("APP_VERSION", raising=False)
     assert versionAPI.resolve_current_version() == versionAPI.FALLBACK_VERSION
 
+    # dev images build without the arg, so the placeholder must fall through
+    stamp.write_text("v0.0.0", encoding="utf-8")
+    monkeypatch.setenv("APP_VERSION", "v0.0.0")
+    assert versionAPI.resolve_current_version() == versionAPI.FALLBACK_VERSION
+    stamp.write_text("0.0.0", encoding="utf-8")
+    assert versionAPI.resolve_current_version() == versionAPI.FALLBACK_VERSION
+
 
 def test_dockerfile_stamps_version_into_the_image() -> None:
     dockerfile = Path("Dockerfile").read_text("utf-8")


### PR DESCRIPTION
# Pull request

## Change

- The dev and dev-db workflows now pass APP_VERSION to the build.
- The version is the newest release tag with the patch bumped, marked as dev, so dev-db becomes v0.11.2-dev.
- Both workflows fetch tags so the newest one can be found.
- v0.0.0 is treated as unset, so a build without the arg falls back to the app version.

## Why

NA

## Testing

NA

## Issue

NA
