### PR TITLE
Fix: provider cards missing for profile only

### DIFF
--- a/assets/helpers/core.js
+++ b/assets/helpers/core.js
@@ -234,6 +234,18 @@
     return Object.values(instances).some(match);
   }
 
+  function hasCrosswatchConfig(root) {
+    if (!root || typeof root !== "object") return false;
+    const match = (block) => {
+      if (!block || typeof block !== "object") return false;
+      return block.connected === true && block.enabled !== false;
+    };
+    if (match(root)) return true;
+    const instances = root.instances;
+    if (!instances || typeof instances !== "object") return false;
+    return Object.values(instances).some(match);
+  }
+
   function hasFloppyConfig(root) {
     if (!root || typeof root !== "object") return false;
     const match = (block) => {
@@ -403,8 +415,7 @@
     if ([cfg?.tmdb_sync, cfg?.auth?.tmdb_sync].some(hasTmdbConfig)) set.add("TMDB");
     if ([cfg?.tautulli, cfg?.auth?.tautulli].some((block) => hasAnyConfigValue(block, ["api_key", "server_url", "server"]))) set.add("TAUTULLI");
 
-    const crosswatch = cfg?.crosswatch || cfg?.CrossWatch || {};
-    if ((cfg?.crosswatch || cfg?.CrossWatch) && crosswatch.connected === true && crosswatch.enabled !== false) set.add("CROSSWATCH");
+    if ([cfg?.crosswatch, cfg?.CrossWatch].some(hasCrosswatchConfig)) set.add("CROSSWATCH");
     return set;
   }
 

--- a/assets/helpers/settings-ui.js
+++ b/assets/helpers/settings-ui.js
@@ -1280,6 +1280,8 @@ function cwBuildTmdbPanel() {
   });
   keyInput.addEventListener("input", () => {
     keyInput.dataset.verified = "";
+    keyInput.dataset.touched = "1";
+    keyInput.dataset.masked = "0";
     const msg = document.getElementById("tmdb_check_msg");
     if (msg) {
       msg.textContent = "";
@@ -2006,8 +2008,8 @@ function cwReadTmdbKeyForVerify() {
   const input = document.getElementById("tmdb_api_key");
   const value = String(input?.value || "").trim();
   const masked = !!value && (input?.dataset?.masked === "1" || value === "********" || /^[*•]+$/.test(value));
-  if (masked) return { has: true, value: "********" };
-  return { has: !!value, value };
+  if (masked) return { has: true, masked: true, value: "********" };
+  return { has: !!value, masked: false, value };
 }
 
 function cwSetTmdbCheckMessage(ok, text) {
@@ -2032,10 +2034,12 @@ async function cwVerifyTmdbKey() {
   try {
     if (btn) btn.disabled = true;
     cwSetTmdbCheckMessage(true, "Checking...");
-    const r = await fetch("/api/tmdb/verify", {
+    const fresh = !state.masked;
+    const r = await fetch(fresh ? "/api/tmdb/save" : "/api/tmdb/verify", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       cache: "no-store",
+      credentials: "same-origin",
       body: JSON.stringify({ api_key: state.value }),
     });
     const data = await r.json().catch(() => ({}));
@@ -2044,6 +2048,12 @@ async function cwVerifyTmdbKey() {
     cwSetTmdbCheckMessage(ok, ok ? "Connected" : (data?.error || "TMDb key check failed."));
     try { cwMetaSettingsHubUpdate(); } catch {}
     if (ok) {
+      if (fresh) {
+        try { await cwRefreshTmdbMetadataState({ force: true, overwrite: true }); } catch {}
+        if (input) input.dataset.verified = "1";
+        try { cwMetaSettingsHubUpdate(); } catch {}
+        try { window.dispatchEvent(new CustomEvent("auth-changed")); } catch {}
+      }
       try { document.dispatchEvent(new CustomEvent("cw-provider-connected", { bubbles: true, detail: { provider: "tmdb", key: "TMDB_METADATA" } })); } catch {}
     }
     return ok;


### PR DESCRIPTION
# Pull request

## Change

- CrossWatch tracker card now checks instances, not just the default block
- TMDb metadata Connect now saves the key instead of only verifying it
- TMDb key field marks itself touched so the settings save no longer skips it

## Why

- A tracker connected as a profile only was never shown on the providers page
- TMDb metadata key was validated but never written to config

## Testing

- Manual: connect a CrossWatch profile without a default, refresh /#settings/providers
- Manual: add a TMDb metadata key, click Connect, check tmdb.api_key in config.json

## Issue

Relates to #728
