### PR TITLE
Fix: SIMKL history uses the watermark again

### DIFF
--- a/providers/sync/simkl/_history.py
+++ b/providers/sync/simkl/_history.py
@@ -441,15 +441,26 @@ def _cache_load() -> dict[str, dict[str, Any]]:
     return out
 
 
-def _cache_doc_is_stale() -> bool:
+def _cache_doc_mode() -> bool:
+    data = _load_json(_cache_path())
+    return bool(data.get("rewatches")) if isinstance(data, dict) else False
+
+
+def _cache_doc_is_stale(rewatches: bool | None = None) -> bool:
     data = _load_json(_cache_path())
     if not isinstance(data, dict) or not data:
         return False
-    return int(data.get("schema") or 0) != _CACHE_SCHEMA
+    if int(data.get("schema") or 0) != _CACHE_SCHEMA:
+        return True
+    return rewatches is not None and bool(data.get("rewatches")) != bool(rewatches)
 
 
-def _cache_save(items: Mapping[str, Any]) -> None:
-    _save_json(_cache_path(), {"schema": _CACHE_SCHEMA, "generated_at": _as_iso(_now_epoch()), "items": dict(items)})
+def _cache_save(items: Mapping[str, Any], *, rewatches: bool | None = None) -> None:
+    mode = _cache_doc_mode() if rewatches is None else bool(rewatches)
+    _save_json(
+        _cache_path(),
+        {"schema": _CACHE_SCHEMA, "generated_at": _as_iso(_now_epoch()), "rewatches": mode, "items": dict(items)},
+    )
 
 
 def _with_native_identity(item: Mapping[str, Any], info: Mapping[str, Any] | None) -> Mapping[str, Any]:
@@ -538,6 +549,9 @@ def _inject_adds_into_cache(items_list: list[Mapping[str, Any]]) -> None:
             anime_type = str(item.get("anime_type") or "").strip().lower()
             if anime_type:
                 entry["anime_type"] = anime_type
+        scope = _history_scope(entry, event_key=event_key)
+        if scope:
+            entry["_cw_scope"] = scope
         entry["_cw_injected_at"] = int(time.time())
         to_inject[event_key] = entry
 
@@ -962,6 +976,115 @@ def _show_identity_key(show_ids: Mapping[str, Any]) -> str:
     return json.dumps({str(k): str(v) for k, v in show_ids.items() if v not in (None, "")}, sort_keys=True)
 
 
+_SCOPE_ID_PRIORITY = ("simkl", "anidb", "mal", "anilist", "kitsu", "tmdb", "imdb", "trakt", "tvdb")
+_SCOPE_ID_PRIORITY_ANIME = tuple(k for k in _SCOPE_ID_PRIORITY if k != "tvdb")
+
+
+def _scope_id(value: Any) -> str:
+    if value in (None, "", True, False):
+        return ""
+    text = str(value).strip()
+    return text.lower() if text.lower().startswith("tt") else text
+
+
+def _scope_ids(item: Mapping[str, Any], field: str) -> Mapping[str, Any]:
+    value = item.get(field)
+    return value if isinstance(value, Mapping) else {}
+
+
+def _scope_priority(item: Mapping[str, Any]) -> tuple[str, ...]:
+    bucket = str(item.get("simkl_bucket") or "").strip().lower()
+    if bucket == "anime" or str(item.get("anime_type") or "").strip():
+        return _SCOPE_ID_PRIORITY_ANIME
+    return _SCOPE_ID_PRIORITY
+
+
+def _scope_tokens(prefix: str, ids: Mapping[str, Any], priority: tuple[str, ...]) -> set[str]:
+    out: set[str] = set()
+    for key in priority:
+        value = _scope_id((ids or {}).get(key))
+        if value:
+            out.add(f"{prefix}:{key}:{value}")
+    return out
+
+
+def _primary_scope(prefix: str, ids: Mapping[str, Any], priority: tuple[str, ...]) -> str:
+    for key in priority:
+        value = _scope_id((ids or {}).get(key))
+        if value:
+            return f"{prefix}:{key}:{value}"
+    return ""
+
+
+def _history_scope(item: Mapping[str, Any], *, event_key: str | None = None) -> str:
+    typ = str(item.get("type") or "").strip().lower()
+    priority = _scope_priority(item)
+    if typ == "episode":
+        scope = _primary_scope("show", _scope_ids(item, "show_ids"), priority)
+        if scope:
+            return scope
+        if event_key and "#" in event_key:
+            return f"show:key:{str(event_key).split('@', 1)[0].split('#', 1)[0]}"
+        return ""
+    return _primary_scope(typ or "item", _scope_ids(item, "ids"), priority) or (str(event_key).split("@", 1)[0] if event_key else "")
+
+
+_SCOPE_FALLBACK_NS = "key"
+
+
+def _history_scope_map(item: Mapping[str, Any], *, event_key: str | None = None) -> dict[str, str]:
+    typ = str(item.get("type") or "").strip().lower()
+    priority = _scope_priority(item)
+    out: dict[str, str] = {}
+    if typ == "episode":
+        for token in _scope_tokens("show", _scope_ids(item, "show_ids"), priority):
+            out[token.split(":", 2)[1]] = token
+        if event_key and "#" in event_key:
+            out[_SCOPE_FALLBACK_NS] = f"show:key:{str(event_key).split('@', 1)[0].split('#', 1)[0]}"
+    else:
+        for token in _scope_tokens(typ or "item", _scope_ids(item, "ids"), priority):
+            out[token.split(":", 2)[1]] = token
+        if event_key:
+            out[_SCOPE_FALLBACK_NS] = str(event_key).split("@", 1)[0]
+    stored = str(item.get("_cw_scope") or "").strip()
+    if stored:
+        parts = stored.split(":", 2)
+        if len(parts) == 3:
+            out.setdefault(parts[1], stored)
+    return {ns: token for ns, token in out.items() if token}
+
+
+def _delta_replace_cache(
+    cached: Mapping[str, Any],
+    fetched: Mapping[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    touched: dict[str, set[str]] = {}
+    for key, value in fetched.items():
+        if not isinstance(value, Mapping):
+            continue
+        for ns, token in _history_scope_map(value, event_key=str(key)).items():
+            touched.setdefault(ns, set()).add(token)
+    if not touched:
+        return {str(k): dict(v) for k, v in cached.items() if isinstance(v, Mapping)}
+
+    final: dict[str, dict[str, Any]] = {}
+    for key, value in cached.items():
+        if not isinstance(value, Mapping):
+            continue
+        scope = _history_scope_map(value, event_key=str(key))
+        replaced = False
+        for ns in (*_scope_priority(value), _SCOPE_FALLBACK_NS):
+            token = scope.get(ns)
+            if token is None or ns not in touched:
+                continue
+            replaced = token in touched[ns]
+            break
+        if not replaced:
+            final[str(key)] = dict(value)
+    final.update({str(k): dict(v) for k, v in fetched.items() if isinstance(v, Mapping)})
+    return final
+
+
 def _watched_raw_coordinates(row: Mapping[str, Any]) -> set[tuple[int, int]]:
     coords: set[tuple[int, int]] = set()
     for season in row.get("seasons") or []:
@@ -1070,6 +1193,9 @@ def _parse_rows(
         event_key = f"{bucket_key}@{ts}"
         if event_key in out:
             continue
+        scope = _history_scope(movie_norm, event_key=event_key)
+        if scope:
+            movie_norm["_cw_scope"] = scope
         out[event_key] = movie_norm
         thaw.add(bucket_key)
         movies_cnt += 1
@@ -1136,6 +1262,9 @@ def _parse_rows(
                     bucket_key = simkl_key_of(movie_item)
                     event_key = f"{bucket_key}@{ts}"
                     if event_key not in out:
+                        scope = _history_scope(movie_item, event_key=event_key)
+                        if scope:
+                            movie_item["_cw_scope"] = scope
                         out[event_key] = movie_item
                         thaw.add(bucket_key)
                         added += 1
@@ -1295,6 +1424,9 @@ def _parse_rows(
                 event_key = f"{bucket_key}@{ts}"
                 if event_key in out:
                     continue
+                scope = _history_scope(ep, event_key=event_key)
+                if scope:
+                    ep["_cw_scope"] = scope
                 out[event_key] = ep
                 thaw.add(bucket_key)
                 eps_cnt += 1
@@ -1325,10 +1457,11 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
     normalize_flat_watermarks()
     rewatches = _rewatches_enabled(adapter)
 
-    cached = {} if rewatches else _cache_load()
-    cache_stale = True if rewatches else _cache_doc_is_stale()
+    cached = _cache_load()
+    cache_stale = _cache_doc_is_stale(rewatches)
     wm = "" if cache_stale else (get_watermark("history") or "")
     removed_wm = get_watermark("history_removed") or ""
+    expired_injection = bool(cached and _has_expired_injection(cached))
 
     acts, _ = fetch_activities(session, _headers(adapter, force_refresh=True), timeout=timeout)
 
@@ -1347,9 +1480,8 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
         removal_changed = bool(removed_wm) and any(t > removed_wm for t in removal_candidates)
 
         unchanged = bool(wm) and (not act_latest or act_latest <= wm) and not removal_changed
-        if unchanged and cached and _has_expired_injection(cached):
+        if unchanged and expired_injection:
             unchanged = False
-            _dbg("index_reconcile", reason="injected_grace_expired", strategy="full_replace")
         if unchanged and cached:
             _dbg("index_cache_hit", source="cache", reason="activities_unchanged", watermark=wm, count=len(cached))
             _info("index_done", count=len(cached), source="cache")
@@ -1370,10 +1502,14 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
         date_from: str | None = None
         strategy = "full"
         reason = "cold_start"
-    else:
+    elif removal_changed or expired_injection:
         date_from = None
         strategy = "full_replace"
-        reason = "removed_from_list_changed" if removal_changed else "activities_changed"
+        reason = "removed_from_list_changed" if removal_changed else "injected_grace_expired"
+    else:
+        date_from = wm
+        strategy = "delta_replace"
+        reason = "activities_changed"
 
     _dbg("index_reconcile", reason=reason, strategy=strategy, date_from=date_from or "-", watermark=wm or "-")
 
@@ -1406,7 +1542,14 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
         _dedupe_history_movies(fetched)
     _dbg("index_fetch_counts", movies=movies_cnt, episodes=eps_cnt, from_date=date_from or "")
 
-    final = fetched
+    if strategy == "delta_replace":
+        final = _delta_replace_cache(cached, fetched)
+        if not rewatches:
+            _dedupe_history_movies(final)
+        if not fetched and movies_cnt == 0 and eps_cnt == 0:
+            _dbg("index_reconcile", reason="incremental_empty", strategy="delta_keep_cache", watermark=wm or "-")
+    else:
+        final = fetched
     carried = 0
     now_epoch = int(time.time())
     for k, v in cached.items():
@@ -1420,19 +1563,17 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
     if carried:
         _dbg("index_reconcile", reason="injected_write_grace", carried=carried, strategy=strategy)
 
-    if not rewatches:
-        _cache_save(final)
+    _cache_save(final, rewatches=rewatches)
 
-    if not rewatches:
-        latest_any = max([t for t in (latest_ts_movies, latest_ts_shows, latest_ts_anime) if isinstance(t, int)], default=None)
-        if act_latest:
-            update_watermark_if_new("history", act_latest)
-        elif latest_any is not None:
-            update_watermark_if_new("history", _as_iso(latest_any))
+    latest_any = max([t for t in (latest_ts_movies, latest_ts_shows, latest_ts_anime) if isinstance(t, int)], default=None)
+    if act_latest:
+        update_watermark_if_new("history", act_latest)
+    elif latest_any is not None:
+        update_watermark_if_new("history", _as_iso(latest_any))
 
-        removal_candidates = [t for t in (rm_m, rm_s, rm_a) if isinstance(t, str) and t]
-        if removal_candidates:
-            update_watermark_if_new("history_removed", max(removal_candidates))
+    removal_candidates = [t for t in (rm_m, rm_s, rm_a) if isinstance(t, str) and t]
+    if removal_candidates:
+        update_watermark_if_new("history_removed", max(removal_candidates))
 
     if not rewatches:
         _unfreeze(thaw)

--- a/providers/tests/test_simkl_history_delta_merge.py
+++ b/providers/tests/test_simkl_history_delta_merge.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 
 AOT_SHOW_IDS = {"tmdb": "1429", "tvdb": "267440", "simkl": 1429000}
+BB_SHOW_IDS = {"tmdb": "1396", "tvdb": "81189", "simkl": 1396000}
 OLD_WATCHED = "2024-01-01T00:00:00Z"
 NEW_WATCHED = "2024-06-01T00:00:00Z"
 
@@ -17,14 +18,22 @@ def _state_store(monkeypatch, m):
     return store
 
 
-def _aot_row(coords, watched_at=OLD_WATCHED):
+def _show_row(coords, watched_at=OLD_WATCHED, *, title="Attack on Titan", year=2013, ids=None):
     seasons: dict[int, list[dict]] = {}
     for s, e in coords:
         seasons.setdefault(s, []).append({"number": e, "watched_at": watched_at})
     return {
-        "show": {"title": "Attack on Titan", "year": 2013, "ids": dict(AOT_SHOW_IDS)},
+        "show": {"title": title, "year": year, "ids": dict(ids or AOT_SHOW_IDS)},
         "seasons": [{"number": s, "episodes": eps} for s, eps in sorted(seasons.items())],
     }
+
+
+def _aot_row(coords, watched_at=OLD_WATCHED):
+    return _show_row(coords, watched_at, title="Attack on Titan", year=2013, ids=AOT_SHOW_IDS)
+
+
+def _bb_row(coords, watched_at=OLD_WATCHED):
+    return _show_row(coords, watched_at, title="Breaking Bad", year=2008, ids=BB_SHOW_IDS)
 
 
 def _coords_of(index):
@@ -32,6 +41,14 @@ def _coords_of(index):
         (v["season"], v["episode"])
         for v in index.values()
         if str(v.get("type")) == "episode" and v.get("series_title") == "Attack on Titan"
+    )
+
+
+def _series_coords_of(index, title):
+    return sorted(
+        (v["season"], v["episode"])
+        for v in index.values()
+        if str(v.get("type")) == "episode" and v.get("series_title") == title
     )
 
 
@@ -63,7 +80,7 @@ def _seed_cache(m, coords, watched_at=OLD_WATCHED):
     return seed
 
 
-def test_activity_change_refetches_full_library_without_date_from(monkeypatch):
+def test_activity_change_fetches_delta_with_watermark_and_replaces_touched_show(monkeypatch):
     import sync.simkl._history as m
 
     _state_store(monkeypatch, m)
@@ -97,7 +114,7 @@ def test_activity_change_refetches_full_library_without_date_from(monkeypatch):
 
     out = m.build_index(adapter)
 
-    assert since_seen == [None]
+    assert since_seen == [OLD_WATCHED]
     assert _coords_of(out) == sorted(seeded + [(4, 29)])
     assert out[stale_key]["series_title"] == "Attack on Titan"
     assert m._cache_load().keys() == out.keys()
@@ -109,6 +126,10 @@ def test_absent_episode_is_dropped_immediately(monkeypatch):
     _state_store(monkeypatch, m)
     seeded = [(1, 1), (1, 2), (2, 1)]
     _seed_cache(m, seeded)
+    legacy = m._cache_load()
+    for row in legacy.values():
+        row.pop("_cw_scope", None)
+    m._cache_save(legacy)
 
     surviving = {"movies": [], "shows": [_aot_row([(1, 1), (2, 1)], OLD_WATCHED)], "anime": []}
     adapter = _patch_index_env(
@@ -124,6 +145,163 @@ def test_absent_episode_is_dropped_immediately(monkeypatch):
 
     assert _coords_of(out) == [(1, 1), (2, 1)]
     assert m._cache_load().keys() == out.keys()
+
+
+def test_delta_touching_one_show_leaves_other_show_cached(monkeypatch):
+    import sync.simkl._history as m
+
+    _state_store(monkeypatch, m)
+    seed, *_ = m._parse_rows([], [_aot_row([(1, 1)]), _bb_row([(1, 1), (1, 2)])], [], limit=None)
+    m._cache_save(seed)
+
+    rows = {"movies": [], "shows": [_aot_row([(1, 1), (1, 2)], NEW_WATCHED)], "anime": []}
+    adapter = _patch_index_env(
+        monkeypatch,
+        m,
+        watermark=OLD_WATCHED,
+        removed_watermark="",
+        acts=_acts(NEW_WATCHED),
+        rows=rows,
+    )
+
+    out = m.build_index(adapter)
+
+    assert _series_coords_of(out, "Attack on Titan") == [(1, 1), (1, 2)]
+    assert _series_coords_of(out, "Breaking Bad") == [(1, 1), (1, 2)]
+
+
+DBZ_S1_IDS = {"tmdb": "12971", "tvdb": "81472", "simkl": 46128}
+DBZ_S2_IDS = {"tmdb": "12972", "tvdb": "81472", "simkl": 46129}
+
+
+def _anime_row(coords, watched_at=OLD_WATCHED, *, title, ids):
+    row = _show_row(coords, watched_at, title=title, year=1989, ids=ids)
+    row["anime_type"] = "tv"
+    return row
+
+
+def test_delta_on_split_anime_record_keeps_the_sibling_record(monkeypatch):
+    import sync.simkl._history as m
+
+    _state_store(monkeypatch, m)
+    seed, *_ = m._parse_rows(
+        [],
+        [],
+        [
+            _anime_row([(1, 1), (1, 2)], title="Dragon Ball Z", ids=DBZ_S1_IDS),
+            _anime_row([(1, 1), (1, 2)], title="Dragon Ball Z Season 2", ids=DBZ_S2_IDS),
+        ],
+        limit=None,
+    )
+    m._cache_save(seed)
+    assert _series_coords_of(seed, "Dragon Ball Z Season 2") == [(1, 1), (1, 2)]
+
+    rows = {
+        "movies": [],
+        "shows": [],
+        "anime": [_anime_row([(1, 1), (1, 2), (1, 3)], NEW_WATCHED, title="Dragon Ball Z", ids=DBZ_S1_IDS)],
+    }
+    adapter = _patch_index_env(
+        monkeypatch,
+        m,
+        watermark=OLD_WATCHED,
+        removed_watermark="",
+        acts=_acts(NEW_WATCHED),
+        rows=rows,
+    )
+
+    out = m.build_index(adapter)
+
+    assert _series_coords_of(out, "Dragon Ball Z") == [(1, 1), (1, 2), (1, 3)]
+    assert _series_coords_of(out, "Dragon Ball Z Season 2") == [(1, 1), (1, 2)]
+
+
+def test_empty_delta_keeps_cache(monkeypatch):
+    import sync.simkl._history as m
+
+    _state_store(monkeypatch, m)
+    seed = _seed_cache(m, [(1, 1), (1, 2)])
+    since_seen: list = []
+    adapter = _patch_index_env(
+        monkeypatch,
+        m,
+        watermark=OLD_WATCHED,
+        removed_watermark="",
+        acts=_acts(NEW_WATCHED),
+        rows={"movies": [], "shows": [], "anime": []},
+    )
+    monkeypatch.setattr(
+        m, "_fetch_all_items",
+        lambda *a, since_iso=None, **k: (since_seen.append(since_iso), {"movies": [], "shows": [], "anime": []})[1],
+    )
+
+    out = m.build_index(adapter)
+
+    assert since_seen == [OLD_WATCHED]
+    assert out == seed
+
+
+def test_rewatch_mode_uses_the_watermark_and_keeps_cache(monkeypatch):
+    import sync.simkl._history as m
+
+    _state_store(monkeypatch, m)
+    seed, *_ = m._parse_rows([], [_aot_row([(1, 1)]), _bb_row([(1, 1), (1, 2)])], [], limit=None)
+    m._cache_save(seed, rewatches=True)
+
+    since_seen: list = []
+    rows = {"movies": [], "shows": [_aot_row([(1, 1), (1, 2)], NEW_WATCHED)], "anime": []}
+    adapter = _patch_index_env(
+        monkeypatch,
+        m,
+        watermark=OLD_WATCHED,
+        removed_watermark="",
+        acts=_acts(NEW_WATCHED),
+        rows=rows,
+    )
+    adapter.config = {"_cw_history_rewatches": True}
+    monkeypatch.setattr(m, "_rewatch_account_ok", lambda *a, **k: True)
+    monkeypatch.setattr(
+        m, "_fetch_all_items",
+        lambda *a, since_iso=None, **k: (since_seen.append(since_iso), dict(rows))[1],
+    )
+
+    out = m.build_index(adapter)
+
+    assert since_seen == [OLD_WATCHED]
+    assert _series_coords_of(out, "Attack on Titan") == [(1, 1), (1, 2)]
+    assert _series_coords_of(out, "Breaking Bad") == [(1, 1), (1, 2)]
+
+
+def test_rewatch_toggle_forces_a_cold_full_pull(monkeypatch):
+    import sync.simkl._history as m
+
+    _state_store(monkeypatch, m)
+    seed = _seed_cache(m, [(1, 1), (1, 2)])
+    m._cache_save(seed, rewatches=False)
+    assert m._cache_doc_is_stale(True) is True
+    assert m._cache_doc_is_stale(False) is False
+
+    since_seen: list = []
+    rows = {"movies": [], "shows": [_aot_row([(1, 1)], NEW_WATCHED)], "anime": []}
+    adapter = _patch_index_env(
+        monkeypatch,
+        m,
+        watermark=OLD_WATCHED,
+        removed_watermark="",
+        acts=_acts(NEW_WATCHED),
+        rows=rows,
+    )
+    adapter.config = {"_cw_history_rewatches": True}
+    monkeypatch.setattr(m, "_rewatch_account_ok", lambda *a, **k: True)
+    monkeypatch.setattr(
+        m, "_fetch_all_items",
+        lambda *a, since_iso=None, **k: (since_seen.append(since_iso), dict(rows))[1],
+    )
+
+    out = m.build_index(adapter)
+
+    assert since_seen == [None]
+    assert _coords_of(out) == [(1, 1)]
 
 
 def test_removal_refresh_replaces_cache_and_prunes(monkeypatch):
@@ -150,7 +328,7 @@ def test_removal_refresh_replaces_cache_and_prunes(monkeypatch):
     assert m._cache_load().keys() == out.keys()
 
 
-def test_injected_episode_survives_full_replace_within_grace(monkeypatch):
+def test_injected_episode_survives_delta_replace_within_grace(monkeypatch):
     import sync.simkl._history as m
 
     _state_store(monkeypatch, m)

--- a/providers/tests/test_simkl_history_remove_verify.py
+++ b/providers/tests/test_simkl_history_remove_verify.py
@@ -142,7 +142,7 @@ def test_verification_failure_confirms_nothing(monkeypatch):
     _no_sleep(monkeypatch, m)
     items = list(_parsed(m, _aot_rows([1, 2], [])).values())
     saved: list = []
-    monkeypatch.setattr(m, "_cache_save", lambda payload: saved.append(payload))
+    monkeypatch.setattr(m, "_cache_save", lambda payload, **_kw: saved.append(payload))
     forgotten: list = []
     monkeypatch.setattr(m, "_forget_source_aliases", lambda its: forgotten.extend(its))
 

--- a/tests/test_history_specials.py
+++ b/tests/test_history_specials.py
@@ -890,7 +890,7 @@ def test_simkl_special_episode_remove_uses_episode_lookup_ids(monkeypatch) -> No
             payload = {"movies": [], "shows": [], "anime": []}
             return SimpleNamespace(status_code=200, ok=True, text="json", headers={}, json=lambda: payload)
 
-    monkeypatch.setattr(simkl_history, "_cache_save", lambda _items: None)
+    monkeypatch.setattr(simkl_history, "_cache_save", lambda _items, **_kw: None)
     monkeypatch.setattr(simkl_history, "_forget_source_aliases", lambda _items: None)
     monkeypatch.setattr(simkl_history, "_unfreeze", lambda _keys: None)
     adapter = SimpleNamespace(
@@ -2517,16 +2517,24 @@ def test_black_mirror_episode_not_found_reaches_retry(monkeypatch) -> None:
 # --- SIMKL delta must expose deletions; Trakt exact-identity deletion ---
 
 
-def _simkl_index_env(monkeypatch, tmp_path, *, cached, rows, acts):
+def _simkl_index_env(monkeypatch, tmp_path, *, cached, rows, acts, history_removed=""):
     import providers.sync.simkl._history as sh
 
     calls = {"since": [], "saved": []}
 
     monkeypatch.setattr(sh, "_cache_load", lambda: dict(cached))
-    monkeypatch.setattr(sh, "_cache_doc_is_stale", lambda: False)
-    monkeypatch.setattr(sh, "_cache_save", lambda items: calls["saved"].append(dict(items)))
+    monkeypatch.setattr(sh, "_cache_doc_is_stale", lambda *_a, **_kw: False)
+    monkeypatch.setattr(sh, "_cache_save", lambda items, **_kw: calls["saved"].append(dict(items)))
     monkeypatch.setattr(sh, "normalize_flat_watermarks", lambda: None)
-    monkeypatch.setattr(sh, "get_watermark", lambda name: "2024-01-01T00:00:00Z" if name == "history" else "")
+    monkeypatch.setattr(
+        sh,
+        "get_watermark",
+        lambda name: (
+            "2024-01-01T00:00:00Z"
+            if name == "history"
+            else (history_removed if name == "history_removed" else "")
+        ),
+    )
     monkeypatch.setattr(sh, "update_watermark_if_new", lambda *a, **k: None)
     monkeypatch.setattr(sh, "_unfreeze", lambda *a, **k: None)
     monkeypatch.setattr(sh, "fetch_activities", lambda *a, **k: (acts, None))
@@ -2547,16 +2555,30 @@ def _simkl_adapter():
     )
 
 
-def _simkl_acts(*, movies=None, shows=None, anime=None):
-    return {"tv_shows": {"all": shows or "2024-01-01T00:00:00Z"},
-            "movies": {"all": movies or "2024-01-01T00:00:00Z"},
-            "anime": {"all": anime or "2024-01-01T00:00:00Z"}}
+def _simkl_acts(*, movies=None, shows=None, anime=None, removed_movies=None, removed_shows=None, removed_anime=None):
+    out = {"tv_shows": {"all": shows or "2024-01-01T00:00:00Z"},
+           "movies": {"all": movies or "2024-01-01T00:00:00Z"},
+           "anime": {"all": anime or "2024-01-01T00:00:00Z"}}
+    if removed_movies:
+        out["movies"]["removed_from_list"] = removed_movies
+    if removed_shows:
+        out["tv_shows"]["removed_from_list"] = removed_shows
+    if removed_anime:
+        out["anime"]["removed_from_list"] = removed_anime
+    return out
 
 
 def test_simkl_anime_removal_triggers_full_replacement(monkeypatch, tmp_path) -> None:
     cached = {"tmdb:12971#s01e40@1704067200": {"type": "episode", "season": 1, "episode": 40}}
-    acts = _simkl_acts(anime="2026-07-21T00:00:00Z")
-    sh, calls = _simkl_index_env(monkeypatch, tmp_path, cached=cached, rows={"movies": [], "shows": [], "anime": []}, acts=acts)
+    acts = _simkl_acts(anime="2026-07-21T00:00:00Z", removed_anime="2026-07-21T00:00:00Z")
+    sh, calls = _simkl_index_env(
+        monkeypatch,
+        tmp_path,
+        cached=cached,
+        rows={"movies": [], "shows": [], "anime": []},
+        acts=acts,
+        history_removed="2024-01-01T00:00:00Z",
+    )
 
     out = sh.build_index(_simkl_adapter())
 
@@ -2567,8 +2589,15 @@ def test_simkl_anime_removal_triggers_full_replacement(monkeypatch, tmp_path) ->
 
 def test_simkl_regular_show_removal_triggers_full_replacement(monkeypatch, tmp_path) -> None:
     cached = {"tmdb:225634#s01e01@1704067200": {"type": "episode", "season": 1, "episode": 1}}
-    acts = _simkl_acts(shows="2026-07-21T00:00:00Z")
-    sh, calls = _simkl_index_env(monkeypatch, tmp_path, cached=cached, rows={"movies": [], "shows": [], "anime": []}, acts=acts)
+    acts = _simkl_acts(shows="2026-07-21T00:00:00Z", removed_shows="2026-07-21T00:00:00Z")
+    sh, calls = _simkl_index_env(
+        monkeypatch,
+        tmp_path,
+        cached=cached,
+        rows={"movies": [], "shows": [], "anime": []},
+        acts=acts,
+        history_removed="2024-01-01T00:00:00Z",
+    )
 
     out = sh.build_index(_simkl_adapter())
 


### PR DESCRIPTION
# Pull request

## Change

- SIMKL history sends date_from again on the delta path, strategy delta_replace
- Replaces only the item and show scopes the delta returned, so unwatched episodes drop right away
- Full pull stays for cold start, removed_from_list and expired write injections
- Rewatch mode uses the cache and date_from too, no more full pull with allow_rewatch
- Cache remembers which mode built it, a toggle forces one cold pull
- Scope match uses the best namespace both sides share, simkl first
- tvdb is not used to group anime scopes, SIMKL splits anime seasons across records that share one tvdb id
- Dedupe runs on the merged index again

Returned older code back.

## Why

SIMKL wants activities first, then all-items with the saved timestamp. 
Due to some recent changes, mistakes where made.

## Testing

- providers/tests/test_simkl_history_delta_merge.py
- live against SIMKL, delta fetched 1 item where it used to fetch 1553

## Issue

Relates to #787
