### PR TITLE
Add: view as profile for admins

### DIFF
--- a/api/probesAPI.py
+++ b/api/probesAPI.py
@@ -18,7 +18,7 @@ import requests
 from fastapi import FastAPI, Query, Request
 from fastapi.responses import JSONResponse
 
-from cw_platform.access_policy import filter_pairs_for_user, managed_profile_instances, request_user
+from cw_platform.access_policy import filter_pairs_for_profile, filter_pairs_for_user, managed_profile_instances, profile_instances_map, request_user
 from cw_platform.config_base import load_config as _load_config
 
 from cw_platform.provider_instances import get_provider_block, list_instance_ids, normalize_instance_id, provider_key
@@ -2008,11 +2008,21 @@ USERINFO_FNS: dict[str, Callable[..., dict[str, Any]]] = {
 
 # Registry API
 def register_probes(app: FastAPI, load_config_fn: Callable[[], dict[str, Any]]) -> None:
+    def _status_scope_profile(cfg: Mapping[str, Any], request: Request, requested: Any) -> str:
+        try:
+            from api.appAuthAPI import COOKIE_NAME, effective_user_profile_id
+
+            token = request.cookies.get(COOKIE_NAME) if request is not None else None
+            return str(effective_user_profile_id(dict(cfg or {}), token, requested) or "").strip()
+        except Exception:
+            return ""
+
     @app.get("/api/status", tags=["Probes"])
-    def api_status(request: Request, fresh: int = Query(0)) -> JSONResponse:
+    def api_status(request: Request, fresh: int = Query(0), user_profile: str = Query("")) -> JSONResponse:
         cfg0 = load_config_fn() or {}
         scoped_user = request_user(request)
-        managed_scope = bool(scoped_user and not scoped_user.get("is_admin"))
+        scope_profile = _status_scope_profile(cfg0, request, user_profile)
+        managed_scope = bool(scope_profile) or bool(scoped_user and not scoped_user.get("is_admin"))
         now = time.time()
         cached = STATUS_CACHE["data"]
         age = (now - STATUS_CACHE["ts"]) if cached else 1e9
@@ -2028,7 +2038,9 @@ def register_probes(app: FastAPI, load_config_fn: Callable[[], dict[str, Any]]) 
 
             cfg = cfg0 if managed_scope else (load_config_fn() or {})
             pairs = cfg.get("pairs") or []
-            if managed_scope:
+            if scope_profile:
+                pairs = filter_pairs_for_profile(cfg, scope_profile, [p for p in pairs if isinstance(p, dict)])
+            elif managed_scope:
                 pairs = filter_pairs_for_user(cfg, scoped_user, [p for p in pairs if isinstance(p, dict)])
             enabled_pairs = [p for p in pairs if isinstance(p, dict) and p.get("enabled", True) is not False]
             any_pair_ready = any(_pair_ready(cfg, p) for p in enabled_pairs)
@@ -2100,7 +2112,11 @@ def register_probes(app: FastAPI, load_config_fn: Callable[[], dict[str, Any]]) 
                     _add(s, "default")
                 return out
 
-            allowed_instances = managed_profile_instances(cfg, scoped_user) if managed_scope else {}
+            allowed_instances = (
+                profile_instances_map(cfg, scope_profile)
+                if scope_profile
+                else (managed_profile_instances(cfg, scoped_user) if managed_scope else {})
+            )
 
             def _scope_allows(prov: str, inst: Any) -> bool:
                 if not managed_scope:

--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -1934,8 +1934,8 @@ class PairPatch(BaseModel):
 
 def _request_user(request: Request | None) -> dict[str, Any] | None:
     try:
-        user = getattr(getattr(request, "state", None), "cw_user", None)
-        return user if isinstance(user, dict) else None
+        user = request_user(request)
+        return dict(user) if isinstance(user, Mapping) else None
     except Exception:
         return None
 

--- a/assets/crosswatch.css
+++ b/assets/crosswatch.css
@@ -311,3 +311,11 @@ html[data-cw-role=user][data-cw-perm-write=off] #cw-quick-add{display:none!impor
 html[data-cw-role=user][data-cw-perm-dashboard=off] #tab-main:not([data-cw-profile-home]){display:none!important}
 html[data-cw-role=user][data-cw-perm-playback=off] #tab-playback_progress{display:none!important}
 html[data-cw-role=user][data-cw-perm-watchlist=off] #tab-watchlist{display:none!important}
+.cw-view-as{display:inline-flex;align-items:center;min-width:0;max-width:220px;margin-left:auto;flex:0 0 auto}
+.cw-view-as.hidden{display:none!important}
+.cw-view-as .cw-icon-select{min-width:150px;max-width:220px}
+.cw-view-as .cw-icon-select-btn{min-height:34px;padding:0 10px;border-radius:999px;font-size:12px;font-weight:700}
+#stats-card .cw-main-card-head{align-items:center}
+#stats-card .cw-view-as .cw-icon-select-btn{min-height:30px;padding:0 9px;font-size:11px}
+html[data-overview-profile=scoped] .cw-view-as .cw-icon-select-btn{border-color:rgba(124,92,255,0.55);background:rgba(124,92,255,0.16);color:#e6dfff}
+html[data-overview-profile=scoped] #ops-card.card.cw-main-card,html[data-overview-profile=scoped] #stats-card.card.cw-main-card{box-shadow:inset 0 0 0 1px rgba(124,92,255,0.45)}

--- a/assets/helpers/api.js
+++ b/assets/helpers/api.js
@@ -7,6 +7,14 @@
   const authSetupPending = () => window.cwIsAuthSetupPending?.() === true;
   const isManagedUser = () => document.documentElement?.dataset?.cwRole === "user";
   const canManagedWrite = () => document.documentElement?.dataset?.cwPermWrite === "on";
+  const VIEW_AS_HEADER = "X-CW-View-As";
+  const VIEW_AS_WRITE_PATHS = ["/api/run", "/api/export", "/api/import"];
+  const viewAsProfile = () => (isManagedUser() ? "" : String(window.CW?.OverviewProfile?.id || "").trim());
+
+  function viewAsAllowed(method, pathname){
+    if (method === "GET" || method === "HEAD") return true;
+    return VIEW_AS_WRITE_PATHS.some((base) => pathname === base || pathname.startsWith(`${base}/`));
+  }
 
   (function installManagedFetchGuard(){
     const original = window.fetch;
@@ -24,6 +32,18 @@
             } else if (url.pathname === "/api/update") {
               return new Response('{"update_available":false}', { status: 200, headers: { "Content-Type": "application/json", "Cache-Control": "no-store" } });
             }
+          }
+        } catch {}
+      }
+      const profile = viewAsProfile();
+      if (profile) {
+        try {
+          const raw = typeof resource === "string" ? resource : String(resource?.url || "");
+          const url = new URL(raw, location.origin);
+          if (url.origin === location.origin && url.pathname.startsWith("/api/") && viewAsAllowed(method, url.pathname)) {
+            const headers = new Headers(init?.headers || (typeof resource === "string" ? undefined : resource?.headers) || {});
+            headers.set(VIEW_AS_HEADER, profile);
+            init = { ...(init || {}), headers };
           }
         } catch {}
       }
@@ -81,9 +101,9 @@
   function invalidate(keys){
     const list = !keys ? [..._memo.keys()] : (Array.isArray(keys) ? keys : [keys]);
     list.forEach((key) => {
-      if (key === KEY.pairs) {
+      if (key === KEY.pairs || key === KEY.status) {
         [..._memo.keys()].forEach((memoKey) => {
-          if (String(memoKey).startsWith(`${KEY.pairs}:`)) _memo.delete(memoKey);
+          if (String(memoKey).startsWith(`${key}:`)) _memo.delete(memoKey);
         });
       }
       const s = _memo.get(key);
@@ -205,7 +225,13 @@
     currentlyWatching(force = false){ return memo(KEY.currentlyWatching, TTL.currentlyWatching, () => j('/api/watch/currently_watching'), force); }
   };
 
-  const Status = { get(force = false){ return memo(KEY.status, TTL.status, () => j('/api/status'), force); } };
+  const Status = {
+    get(force = false){
+      const profile = String(window.CW?.OverviewProfile?.id || "").trim();
+      const url = profile ? `/api/status?user_profile=${encodeURIComponent(profile)}` : '/api/status';
+      return memo(`${KEY.status}:${profile || "all"}`, TTL.status, () => j(url), force);
+    }
+  };
   const Insights = { get(force = false){ return memo(KEY.insights, TTL.insights, () => j('/api/insights'), force); } };
   const Settings = { overview(force = false){ return memo(KEY.settingsOverview, TTL.settingsOverview, () => j('/api/settings/overview'), force); } };
 

--- a/assets/helpers/core.js
+++ b/assets/helpers/core.js
@@ -78,6 +78,7 @@
   const PAIRS_CACHE_KEY = "cw.pairs.v1";
   const PAIRS_TTL_MS = 15_000;
   const STATUS_CACHE_KEY = "cw.status.v1";
+  const statusCacheKey = () => `${STATUS_CACHE_KEY}.${String(window.CW?.OverviewProfile?.id || "").trim() || "all"}`;
   const DETAILS_MAX_LINES = 300;
   const authSetupPending = () => window.cwIsAuthSetupPending?.() === true;
   const ROUTE_TABS = new Set(["main", "watchlist", "playback_progress", "snapshots", "playlists", "editor", "settings"]);
@@ -662,13 +663,13 @@
 
   function saveStatusCache(providers) {
     try {
-      localStorage.setItem(STATUS_CACHE_KEY, JSON.stringify({ providers: normalizeProviders(providers), updatedAt: Date.now(), v: 1 }));
+      localStorage.setItem(statusCacheKey(), JSON.stringify({ providers: normalizeProviders(providers), updatedAt: Date.now(), v: 1 }));
     } catch {}
   }
 
   function loadStatusCache(maxAgeMs = 10 * 60 * 1000) {
     try {
-      const cached = JSON.parse(localStorage.getItem(STATUS_CACHE_KEY) || "null");
+      const cached = JSON.parse(localStorage.getItem(statusCacheKey()) || "null");
       if (!cached?.providers) return null;
       if ((Date.now() - (cached.updatedAt || 0)) > maxAgeMs) return null;
       return { providers: normalizeProviders(cached.providers), updatedAt: cached.updatedAt };
@@ -1253,6 +1254,8 @@
   });
 
   window.addEventListener("cw:overview-profile-changed", () => {
+    try { window.CW?.Cache?.invalidate?.(["status"]); } catch {}
+    queueSafe(() => { refreshStatus(true); });
     const current = normalizeRouteTab(state.currentTab || document.documentElement?.dataset?.tab || document.body?.dataset?.tab || "main");
     const tab = allowedRouteTab(current);
     if (tab !== current) Promise.resolve(showTab(tab)).catch(() => {});

--- a/assets/js/main-status.js
+++ b/assets/js/main-status.js
@@ -96,8 +96,22 @@
     return document.documentElement?.dataset?.cwRole === "user";
   }
 
+  function overviewProfileScope() {
+    const profile = window.CW?.OverviewProfile;
+    return String(profile?.id || "").trim() ? profile : null;
+  }
+
+  function matchesOverviewProfile(key, data) {
+    const profile = overviewProfileScope();
+    if (!profile) return true;
+    const instances = data?.instances && typeof data.instances === "object" ? Object.keys(data.instances) : [];
+    if (!instances.length) return profile.matchesEndpoint(key, "default");
+    return instances.some((instance) => profile.matchesEndpoint(key, instance));
+  }
+
   function isStatusProviderVisible(key, data, cfg = getCachedConfig(), configured = null) {
     if (!data || typeof data !== "object") return false;
+    if (!matchesOverviewProfile(key, data)) return false;
     const set = configured || configuredProviderSet(cfg);
     const managed = isManagedUser();
     if (!managed && !isProviderConfigured(key, cfg, set)) return false;
@@ -548,6 +562,10 @@
     },
     true
   );
+
+  window.addEventListener("cw:overview-profile-changed", () => {
+    try { renderProviders(); } catch {}
+  });
 
   window.addEventListener("auth-changed", () => {
     const done = dots ? dots.onConfigChanged() : refreshAuthDots(true);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -705,6 +705,8 @@
       safe(esSummary?.close?.bind(esSummary));
       const url = new URL("/api/run/summary/stream", document.baseURI);
       url.searchParams.set("_ts", String(nowTs()));
+      const viewAs = String(window.CW?.OverviewProfile?.id || "").trim();
+      if (viewAs) url.searchParams.set("user_profile", viewAs);
       esSummary = new EventSource(url.toString());
       window.esSum = esSummary;
       esSummary.onmessage = (ev) => {
@@ -774,6 +776,12 @@
     openSummaryStream();
     openLogStream();
     pullSummary().then(renderAll);
+  });
+
+  window.addEventListener("cw:overview-profile-changed", () => {
+    safe(() => window.openSummaryStream?.());
+    safe(() => pullSummary());
+    safe(queuePairsRefresh);
   });
 
   window.addEventListener("cw-auth-setup-pending", (ev) => {

--- a/assets/js/overview-profile.js
+++ b/assets/js/overview-profile.js
@@ -7,8 +7,10 @@
   const providerKey = (value) => window.CW?.ProviderMeta?.keyOf?.(value) || String(value || "").trim().toUpperCase();
   const instanceKey = (value) => String(value || DEFAULT_INSTANCE).trim() || DEFAULT_INSTANCE;
 
+  const STORE_KEY = "cw.overview.profile";
   let profiles = [];
   let activeId = "";
+  let isAdmin = false;
   let authUser = null;
   let readyResolve = null;
   const SHELL_MANAGED = document.documentElement?.dataset?.cwRole === "user";
@@ -27,6 +29,17 @@
       if (insts.length) out[prov] = [...new Set(insts)].slice(0, 1);
     }
     return out;
+  }
+
+  function storedId() {
+    try { return String(localStorage.getItem(STORE_KEY) || "").trim(); } catch { return ""; }
+  }
+
+  function storeId(id) {
+    try {
+      if (id) localStorage.setItem(STORE_KEY, id);
+      else localStorage.removeItem(STORE_KEY);
+    } catch {}
   }
 
   function activeProfile() {
@@ -110,8 +123,42 @@
     }
   }
 
+  function setActive(id) {
+    if (!isAdmin) return false;
+    const next = String(id || "").trim();
+    const valid = next && profiles.some((row) => row.id === next) ? next : "";
+    if (valid === activeId) return false;
+    activeId = valid;
+    storeId(valid);
+    render();
+    emit();
+    return true;
+  }
+
+  function renderPicker() {
+    const host = $("#cw-view-as");
+    const select = $("#cw-view-as-select");
+    if (!host || !select) return;
+    host.classList.toggle("hidden", !isAdmin);
+    if (!isAdmin) return;
+    const rows = profiles.length ? [{ id: "", label: "All profiles" }, ...profiles] : [{ id: "", label: "No profiles" }];
+    const signature = rows.map((row) => `${row.id}::${row.label}`).join("|");
+    if (select.dataset.signature !== signature) {
+      select.innerHTML = rows.map((row) => `<option value="${esc(row.id)}">${esc(row.label)}</option>`).join("");
+      select.dataset.signature = signature;
+    }
+    select.value = activeId;
+    select.disabled = profiles.length === 0;
+    if (!select.dataset.bound) {
+      select.dataset.bound = "1";
+      select.addEventListener("change", () => setActive(select.value));
+    }
+    try { window.CW?.ProfileSelect?.enhanceProfile?.(select, { className: "cw-view-as-picker" }); } catch {}
+  }
+
   function render() {
     renderProfileLink();
+    renderPicker();
   }
 
   async function hydrateCurrentUserProfile() {
@@ -148,23 +195,25 @@
   function applyAuthStatus(status) {
     const state = window.CW?.AuthState?.apply ? window.CW.AuthState.apply(status) : null;
     authUser = state?.user || status?.user || null;
-    const isAdmin = Boolean(state?.isAdmin || status?.is_admin || authUser?.is_admin);
+    isAdmin = Boolean(state?.isAdmin || status?.is_admin || authUser?.is_admin);
     const managed = Boolean(state?.isManaged || SHELL_MANAGED || (authUser && authUser.is_admin === false));
     if (!isAdmin && managed) activeId = String(state?.profileId || authUser?.profile_id || SHELL_PROFILE_ID || "").trim();
-    else activeId = "";
+    else activeId = isAdmin ? storedId() : "";
   }
 
   async function refresh() {
+    try { await window.__cwAuthBootstrapPromise; } catch {}
     try {
       try {
         applyAuthStatus(await fetchJSON("/api/app-auth/status"));
       } catch {
         const state = window.CW?.AuthState?.read?.() || {};
         authUser = state.user || (SHELL_PROFILE_ID ? { is_admin: false, profile_id: SHELL_PROFILE_ID, permissions: {} } : null);
-        activeId = state.profileId || SHELL_PROFILE_ID;
+        isAdmin = Boolean(state.isAdmin) && !SHELL_MANAGED;
+        activeId = isAdmin ? storedId() : (state.profileId || SHELL_PROFILE_ID);
       }
       await hydrateCurrentUserProfile();
-      if (activeId) {
+      if (activeId || isAdmin) {
         const data = await fetchJSON("/api/user-profiles");
         profiles = (Array.isArray(data?.items) ? data.items : [])
           .map((row) => ({
@@ -176,7 +225,13 @@
       } else {
         profiles = [];
       }
-    } catch {
+      if (isAdmin && !profiles.length) console.warn("[OverviewProfile] /api/user-profiles returned no usable rows");
+      if (isAdmin && activeId && !profiles.some((row) => row.id === activeId)) {
+        activeId = "";
+        storeId("");
+      }
+    } catch (err) {
+      console.warn("[OverviewProfile] refresh failed", err);
       profiles = [];
     }
     render();
@@ -190,6 +245,9 @@
     ready,
     refresh,
     render,
+    setActive,
+    get profiles() { return profiles.slice(); },
+    get isAdmin() { return isAdmin; },
     get id() { return activeId; },
     get label() { return activeProfile()?.label || ""; },
     get profile() { return activeProfile(); },
@@ -200,6 +258,9 @@
   };
 
   window.addEventListener("cw-user-profiles-changed", () => refresh());
+  window.addEventListener("cw-auth-setup-pending", (event) => {
+    if (event?.detail?.pending === false) refresh();
+  });
   window.addEventListener("cw:auth-state-changed", (event) => {
     const next = event?.detail?.user;
     if (next && typeof next === "object") {

--- a/cw_platform/access_policy.py
+++ b/cw_platform/access_policy.py
@@ -76,13 +76,71 @@ def profile_allows_instance(profile_instances: Mapping[str, list[str]], provider
     return bool(prov and inst and inst in list(profile_instances.get(prov) or []))
 
 
+VIEW_AS_HEADER = "x-cw-view-as"
+
+
+def requested_view_as_profile(request: Any) -> str:
+    raw = ""
+    try:
+        headers = getattr(request, "headers", None)
+        if headers is not None:
+            raw = headers.get(VIEW_AS_HEADER) or ""
+    except Exception:
+        raw = ""
+    if not raw:
+        try:
+            raw = request.query_params.get("user_profile") or ""
+        except Exception:
+            raw = ""
+    return normalize_user_profile_id(raw)
+
+
+def impersonated_user(user: Mapping[str, Any], profile_id: str) -> dict[str, Any]:
+    return {
+        "id": user.get("id"),
+        "username": user.get("username"),
+        "is_admin": False,
+        "profile_id": profile_id,
+        "permissions": {"dashboard": True, "watchlist": True, "playback": True, "write": True},
+        "view_as": True,
+        "view_as_admin_id": user.get("id"),
+    }
+
+
 def request_user(request: Any) -> Mapping[str, Any] | None:
     try:
         state = getattr(request, "state", None)
         user = getattr(state, "cw_user", None) or getattr(state, "user", None)
     except Exception:
         return None
-    return user if isinstance(user, Mapping) else None
+    if not isinstance(user, Mapping):
+        return None
+    if not bool(user.get("is_admin")):
+        return user
+    pid = requested_view_as_profile(request)
+    if not pid:
+        return user
+    state = getattr(request, "state", None)
+    cached = getattr(state, "cw_view_as", None) if state is not None else None
+    if isinstance(cached, tuple) and len(cached) == 2 and cached[0] == pid:
+        return cached[1] or user
+
+    def _remember(value: dict[str, Any] | None) -> Mapping[str, Any]:
+        try:
+            setattr(state, "cw_view_as", (pid, value))
+        except Exception:
+            pass
+        return value or user
+
+    try:
+        from .config_base import load_config
+
+        cfg = load_config() or {}
+    except Exception:
+        return _remember(None)
+    if not valid_user_profile_id(cfg, pid):
+        return _remember(None)
+    return _remember(impersonated_user(user, pid))
 
 
 def user_can_access_instance(cfg: Mapping[str, Any], user: Mapping[str, Any] | None, provider: Any, instance: Any) -> bool:
@@ -240,6 +298,18 @@ def filter_pairs_for_user(cfg: Mapping[str, Any], user: Mapping[str, Any] | None
     if not isinstance(user, Mapping) or bool(user.get("is_admin")):
         return [decorate_pair_profile(cfg, pair) for pair in pairs if isinstance(pair, Mapping)]
     return [decorate_pair_profile(cfg, pair) for pair in pairs if isinstance(pair, Mapping) and user_can_access_pair(cfg, user, pair)]
+
+
+def filter_pairs_for_profile(cfg: Mapping[str, Any], profile_id: Any, pairs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    pid = normalize_user_profile_id(profile_id)
+    if not pid:
+        return [decorate_pair_profile(cfg, pair) for pair in pairs if isinstance(pair, Mapping)]
+    instances = profile_instances_map(cfg, pid)
+    return [
+        decorate_pair_profile(cfg, pair)
+        for pair in pairs
+        if isinstance(pair, Mapping) and pair_profile_id(pair) == pid and profile_allows_pair(instances, pair)
+    ]
 
 
 def pair_ids_for_user(cfg: Mapping[str, Any], user: Mapping[str, Any] | None) -> set[str]:

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -1934,8 +1934,12 @@ def test_overview_profile_helper_locks_managed_shell_to_profile() -> None:
     assert "dataset?.cwProfileId" in js
     assert 'status?.is_admin || authUser?.is_admin' in js
     assert 'activeId = String(state?.profileId || authUser?.profile_id || SHELL_PROFILE_ID || "").trim();' in js
-    assert 'else activeId = "";' in js
-    assert "localStorage" not in js
+    assert 'else activeId = isAdmin ? storedId() : "";' in js
+    assert 'if (!isAdmin) return false;' in js
+    assert 'host.classList.toggle("hidden", !isAdmin);' in js
+    assert 'isAdmin = Boolean(state.isAdmin) && !SHELL_MANAGED;' in js
+    assert 'await window.__cwAuthBootstrapPromise;' in js
+    assert 'cw-auth-setup-pending' in js
     assert "overview-profile-select" not in js
 
 
@@ -2696,3 +2700,144 @@ def test_dockerfile_stamps_version_into_the_image() -> None:
     # the stamp must be written in the runtime stage, after the app is copied
     assert dockerfile.index("COPY --from=appsrc") < dockerfile.index("/app/VERSION")
     assert "VERSION" in Path(".gitignore").read_text("utf-8")
+
+
+def test_filter_pairs_for_profile_scopes_by_assignment_and_instances() -> None:
+    from cw_platform.access_policy import filter_pairs_for_profile
+
+    cfg = {
+        "user_profiles": {
+            ALICE_PROFILE_ID: {"label": "Alice", "instances": {"PLEX": ["PLEX-P01"], "CROSSWATCH": ["CW-P01"]}},
+            BOB_PROFILE_ID: {"label": "Bob", "instances": {"PLEX": ["PLEX-P02"]}},
+        },
+    }
+    _configured_refs(cfg, [("PLEX", "PLEX-P01"), ("PLEX", "PLEX-P02"), ("CROSSWATCH", "CW-P01")])
+    pairs = [
+        {"id": "own", "profile_id": ALICE_PROFILE_ID, "source": "PLEX", "source_instance": "PLEX-P01", "target": "CROSSWATCH", "target_instance": "CW-P01"},
+        {"id": "wrong_instance", "profile_id": ALICE_PROFILE_ID, "source": "PLEX", "source_instance": "PLEX-P02", "target": "CROSSWATCH", "target_instance": "CW-P01"},
+        {"id": "unassigned", "profile_id": "", "source": "PLEX", "source_instance": "PLEX-P01", "target": "CROSSWATCH", "target_instance": "CW-P01"},
+        {"id": "other_profile", "profile_id": BOB_PROFILE_ID, "source": "PLEX", "source_instance": "PLEX-P02", "target": "CROSSWATCH", "target_instance": "CW-P01"},
+    ]
+
+    kept = [row.get("id") for row in filter_pairs_for_profile(cfg, ALICE_PROFILE_ID, pairs)]
+    assert kept == ["own"]
+
+    assert [row.get("id") for row in filter_pairs_for_profile(cfg, "", pairs)] == ["own", "wrong_instance", "unassigned", "other_profile"]
+
+
+def test_status_probe_scope_accepts_admin_requested_profile(monkeypatch) -> None:
+    import api.probesAPI as probes_api
+
+    cfg = {
+        "user_profiles": {ALICE_PROFILE_ID: {"label": "Alice", "instances": {"PLEX": ["PLEX-P01"]}}},
+    }
+    _configured_refs(cfg, [("PLEX", "PLEX-P01")])
+
+    from api.appAuthAPI import effective_user_profile_id
+
+    assert effective_user_profile_id(cfg, None, ALICE_PROFILE_ID) == ALICE_PROFILE_ID
+    assert effective_user_profile_id(cfg, None, "") == ""
+
+    src = Path("api/probesAPI.py").read_text("utf-8")
+    assert 'def api_status(request: Request, fresh: int = Query(0), user_profile: str = Query(""))' in src
+    assert "scope_profile = _status_scope_profile(cfg0, request, user_profile)" in src
+    assert "managed_scope = bool(scope_profile) or bool(scoped_user and not scoped_user.get(\"is_admin\"))" in src
+    assert "filter_pairs_for_profile(cfg, scope_profile," in src
+    assert probes_api is not None
+
+
+def test_status_frontend_sends_selected_profile() -> None:
+    api_js = Path("assets/helpers/api.js").read_text("utf-8")
+    core_js = Path("assets/helpers/core.js").read_text("utf-8")
+
+    assert "`/api/status?user_profile=${encodeURIComponent(profile)}`" in api_js
+    assert '`${KEY.status}:${profile || "all"}`' in api_js
+    assert "key === KEY.pairs || key === KEY.status" in api_js
+    assert "const statusCacheKey = ()" in core_js
+    assert "localStorage.setItem(statusCacheKey()" in core_js
+    assert 'window.CW?.Cache?.invalidate?.(["status"])' in core_js
+
+
+def _view_as_request(user: dict[str, Any], *, header: str = "", query: str = "") -> Any:
+    return SimpleNamespace(
+        state=SimpleNamespace(cw_user=user),
+        headers={"x-cw-view-as": header} if header else {},
+        query_params={"user_profile": query} if query else {},
+    )
+
+
+def _view_as_cfg() -> dict[str, Any]:
+    cfg = {"user_profiles": {ALICE_PROFILE_ID: {"label": "Alice", "instances": {"PLEX": ["PLEX-P01"]}}}}
+    _configured_refs(cfg, [("PLEX", "PLEX-P01")])
+    return cfg
+
+
+def test_request_user_impersonates_profile_for_admin(monkeypatch) -> None:
+    from cw_platform import access_policy
+
+    cfg = _view_as_cfg()
+    monkeypatch.setattr("cw_platform.config_base.load_config", lambda *a, **k: cfg)
+    admin = {"id": "administrator", "username": "admin", "is_admin": True}
+
+    plain = access_policy.request_user(_view_as_request(admin))
+    assert plain is admin
+
+    scoped = access_policy.request_user(_view_as_request(admin, header=ALICE_PROFILE_ID))
+    assert scoped is not None
+    assert scoped["is_admin"] is False
+    assert scoped["profile_id"] == ALICE_PROFILE_ID
+    assert scoped["view_as"] is True
+    assert scoped["permissions"]["write"] is True
+
+    via_query = access_policy.request_user(_view_as_request(admin, query=ALICE_PROFILE_ID))
+    assert via_query is not None and via_query["profile_id"] == ALICE_PROFILE_ID
+
+    unknown = access_policy.request_user(_view_as_request(admin, header="0" * 32))
+    assert unknown is admin
+
+
+def test_managed_user_cannot_impersonate_another_profile(monkeypatch) -> None:
+    from cw_platform import access_policy
+
+    cfg = _view_as_cfg()
+    cfg["user_profiles"][BOB_PROFILE_ID] = {"label": "Bob", "instances": {"PLEX": ["PLEX-P01"]}}
+    monkeypatch.setattr("cw_platform.config_base.load_config", lambda *a, **k: cfg)
+    managed = {"id": "bob", "is_admin": False, "profile_id": BOB_PROFILE_ID, "permissions": {"write": False}}
+
+    scoped = access_policy.request_user(_view_as_request(managed, header=ALICE_PROFILE_ID))
+    assert scoped is managed
+    assert scoped["profile_id"] == BOB_PROFILE_ID
+
+
+def test_view_as_leaves_audit_identity_untouched(monkeypatch) -> None:
+    from cw_platform import access_policy
+
+    cfg = _view_as_cfg()
+    monkeypatch.setattr("cw_platform.config_base.load_config", lambda *a, **k: cfg)
+    admin = {"id": "administrator", "username": "admin", "is_admin": True}
+    request = _view_as_request(admin, header=ALICE_PROFILE_ID)
+
+    access_policy.request_user(request)
+    assert request.state.cw_user is admin
+    assert request.state.cw_user["is_admin"] is True
+
+
+def test_view_as_header_transport_is_scoped_to_safe_and_allowlisted_calls() -> None:
+    api_js = Path("assets/helpers/api.js").read_text("utf-8")
+    sync_api = Path("api/syncAPI.py").read_text("utf-8")
+
+    assert 'const VIEW_AS_HEADER = "X-CW-View-As";' in api_js
+    assert 'const VIEW_AS_WRITE_PATHS = ["/api/run", "/api/export", "/api/import"];' in api_js
+    assert 'const viewAsProfile = () => (isManagedUser() ? "" : String(window.CW?.OverviewProfile?.id || "").trim());' in api_js
+    assert 'if (method === "GET" || method === "HEAD") return true;' in api_js
+    assert "user = request_user(request)" in sync_api
+
+
+def test_status_badges_hide_out_of_scope_providers() -> None:
+    js = Path("assets/js/main-status.js").read_text("utf-8")
+
+    assert "function matchesOverviewProfile(key, data)" in js
+    assert "if (!matchesOverviewProfile(key, data)) return false;" in js
+    assert 'return instances.some((instance) => profile.matchesEndpoint(key, instance));' in js
+    assert 'return profile.matchesEndpoint(key, "default");' in js
+    assert 'window.addEventListener("cw:overview-profile-changed", () => {' in js

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -660,6 +660,9 @@ html[data-cw-initial-tab="settings"] #page-settings{display:block!important}
       <div class="cw-main-card-head-copy">
         <div class="cw-main-card-kicker">Statistics</div>
       </div>
+      <div id="cw-view-as" class="cw-view-as hidden">
+        <select id="cw-view-as-select" aria-label="View data as profile"></select>
+      </div>
     </div>
 
     <div class="stats-modern v2">


### PR DESCRIPTION
# Pull request

## Change

- Adds a profile picker in the Statistics header, admin only
- Picking a profile scopes the main page to that profile: 
  - statistics, widgets, sync hub cards, recent syncs, activity, playback, watchlist preview
- Analyzer, events, import and export, view details and synchronize follow the same scope
- Admins send X-CW-View-As and request_user hands back a scoped user,
- Header only goes out on reads plus run, export and import, so settings and pair editing stay on admin scope
- Audit trail keeps logging the real admin, and a managed user cannot use the header to reach another profile

## Why

Admins had no way to see what a profile actually looks like without logging in as that user.

## Testing

- tests/test_crosswatch_profiles.py

## Issue

Relates to #728