### PR TITLE
Add: profile filter to the events modal

### DIFF
--- a/assets/js/modals/events/index.js
+++ b/assets/js/modals/events/index.js
@@ -8,11 +8,25 @@ const esc = (s) => String(s ?? "").replace(/[&<>"']/g, (c) => (
   { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]
 ));
 
+let eventScope = null;
+
+function withEventScope(u) {
+  if (eventScope === null) return u;
+  try {
+    const url = new URL(u, location.origin);
+    if (!url.pathname.startsWith("/api/events/")) return u;
+    url.searchParams.set("user_profile", eventScope || "all");
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return u;
+  }
+}
+
 const fjson = async (u, o = {}) => {
   const ctrl = new AbortController();
   const t = setTimeout(() => ctrl.abort("timeout"), 30000);
   try {
-    const r = await fetch(u, { ...o, signal: ctrl.signal });
+    const r = await fetch(withEventScope(u), { ...o, signal: ctrl.signal });
     if (!r.ok) throw new Error(r.status);
     return await r.json();
   } finally { clearTimeout(t); }
@@ -586,6 +600,15 @@ export default {
     const ddOrigin = createDropdown({ label: "Any origin", items: [{ value: "", label: "Any origin" }], onChange: () => load(0) });
     const ddFeature = createDropdown({ label: "Any feature", items: [{ value: "", label: "Any feature" }, ...["history", "ratings", "watchlist", "progress"].map((f) => ({ value: f, label: FEATURE_LABEL[f] }))], onChange: () => load(0) });
     const ddPair = createDropdown({ label: "Any pair", items: [{ value: "", label: "Any pair" }], onChange: () => load(0) });
+    const ddProfile = createDropdown({
+      label: "All profiles",
+      items: [{ value: "", label: "All profiles" }],
+      onChange: (v) => {
+        eventScope = v;
+        if (view === "statistics") loadStats();
+        else load(0);
+      },
+    });
     const ddCategory = createDropdown({
       label: "Any outcome", align: "right",
       items: OUTCOME_ITEMS[domain] || OUTCOME_ITEMS.sync,
@@ -593,7 +616,23 @@ export default {
     });
     Q("#ev-cat", root).appendChild(ddCategory.el);
     Q("#ev-range", root).appendChild(ddRange.el);
-    const hiddenDds = [ddType, ddProvider, ddOrigin, ddFeature, ddPair];
+    if (isAdmin) {
+      eventScope = String(window.CW?.OverviewProfile?.id || "").trim();
+      ddProfile.value = eventScope;
+      (async () => {
+        try {
+          const data = await fjson("/api/user-profiles", { cache: "no-store" });
+          const rows = (Array.isArray(data?.items) ? data.items : [])
+            .map((row) => ({ value: String(row?.id || "").trim(), label: String(row?.label || row?.id || "").trim() }))
+            .filter((row) => row.value && row.label);
+          if (!rows.length) return;
+          ddProfile.setItems([{ value: "", label: "All profiles" }, ...rows]);
+          ddProfile.value = eventScope;
+        } catch {}
+      })();
+    }
+
+    const hiddenDds = [ddType, ddProvider, ddOrigin, ddFeature, ddPair, ...(isAdmin ? [ddProfile] : [])];
     for (const dd of hiddenDds) filtersEl.appendChild(dd.el);
     dropdowns.push(ddCategory, ddRange, ...hiddenDds);
 
@@ -662,7 +701,7 @@ export default {
       tabsRightEl.innerHTML = `<span class="ev-statsrange-label" id="ev-statsrange-label"></span><div class="ev-seg ev-seg-range">${RANGE_TABS.map(([v, l]) => `<button type="button" class="ev-seg-btn${v === statsRange ? " on" : ""}" data-r="${v}">${l}</button>`).join("")}</div><button class="ev-tbtn" id="ev-stats-refresh" type="button"><span class="material-symbols-rounded" aria-hidden="true">refresh</span><span>Refresh</span></button>`;
       tabsRightEl.querySelectorAll(".ev-seg-btn").forEach((b) => b.addEventListener("click", () => {
         if (b.dataset.r === statsRange) return;
-        statsRange = b.dataset.r; lset("cw.events.stats.range", statsRange); renderStatsRange(); loadStats();
+        statsRange = b.dataset.r; lset("cw.events.stats.range", statsRange); renderStatsRange(); placeProfileDd(); loadStats();
       }));
       Q("#ev-stats-refresh", root)?.addEventListener("click", () => loadStats());
     };
@@ -676,6 +715,14 @@ export default {
 
     const loadStats = async () => { const d = await statsView.load({ range: statsRange, force: true }); if (d) setStatsLabel(d); };
 
+    const placeProfileDd = () => {
+      if (!isAdmin) return;
+      const stats = view === "statistics";
+      const host = stats ? tabsRightEl : filtersEl;
+      if (ddProfile.el.parentElement !== host) host.insertBefore(ddProfile.el, host.firstChild);
+      ddProfile.el.style.display = domain === "audit" && !stats ? "none" : "";
+    };
+
     const applyView = () => {
       const stats = view === "statistics";
       toolbarEl.style.display = stats ? "none" : "";
@@ -684,6 +731,7 @@ export default {
       tabsRightEl.hidden = !stats;
       renderViewTabs();
       if (stats) { renderStatsRange(); loadStats(); }
+      placeProfileDd();
     };
 
     const setView = (v) => {

--- a/cw_platform/access_policy.py
+++ b/cw_platform/access_policy.py
@@ -79,20 +79,28 @@ def profile_allows_instance(profile_instances: Mapping[str, list[str]], provider
 VIEW_AS_HEADER = "x-cw-view-as"
 
 
+VIEW_AS_ALL = {"all", "__all__"}
+
+
 def requested_view_as_profile(request: Any) -> str:
-    raw = ""
+    query_raw = ""
+    try:
+        query_raw = str(request.query_params.get("user_profile") or "").strip()
+    except Exception:
+        query_raw = ""
+    if query_raw.lower() in VIEW_AS_ALL:
+        return ""
+    pid = normalize_user_profile_id(query_raw)
+    if pid:
+        return pid
+    header_raw = ""
     try:
         headers = getattr(request, "headers", None)
         if headers is not None:
-            raw = headers.get(VIEW_AS_HEADER) or ""
+            header_raw = headers.get(VIEW_AS_HEADER) or ""
     except Exception:
-        raw = ""
-    if not raw:
-        try:
-            raw = request.query_params.get("user_profile") or ""
-        except Exception:
-            raw = ""
-    return normalize_user_profile_id(raw)
+        header_raw = ""
+    return normalize_user_profile_id(header_raw)
 
 
 def impersonated_user(user: Mapping[str, Any], profile_id: str) -> dict[str, Any]:

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -2841,3 +2841,40 @@ def test_status_badges_hide_out_of_scope_providers() -> None:
     assert 'return instances.some((instance) => profile.matchesEndpoint(key, instance));' in js
     assert 'return profile.matchesEndpoint(key, "default");' in js
     assert 'window.addEventListener("cw:overview-profile-changed", () => {' in js
+
+
+def test_view_as_query_overrides_ambient_header(monkeypatch) -> None:
+    from cw_platform import access_policy
+
+    cfg = _view_as_cfg()
+    cfg["user_profiles"][BOB_PROFILE_ID] = {"label": "Bob", "instances": {"PLEX": ["PLEX-P01"]}}
+    monkeypatch.setattr("cw_platform.config_base.load_config", lambda *a, **k: cfg)
+    admin = {"id": "administrator", "is_admin": True}
+
+    def req(header: str = "", query: str = "") -> Any:
+        return SimpleNamespace(
+            state=SimpleNamespace(cw_user=admin),
+            headers={"x-cw-view-as": header} if header else {},
+            query_params={"user_profile": query} if query else {},
+        )
+
+    both = access_policy.request_user(req(header=ALICE_PROFILE_ID, query=BOB_PROFILE_ID))
+    assert both is not None and both["profile_id"] == BOB_PROFILE_ID
+
+    explicit_all = access_policy.request_user(req(header=ALICE_PROFILE_ID, query="all"))
+    assert explicit_all is admin
+
+    header_only = access_policy.request_user(req(header=ALICE_PROFILE_ID))
+    assert header_only is not None and header_only["profile_id"] == ALICE_PROFILE_ID
+
+
+def test_events_modal_has_profile_filter_in_more_filters() -> None:
+    js = Path("assets/js/modals/events/index.js").read_text("utf-8")
+
+    assert "function withEventScope(u)" in js
+    assert 'if (!url.pathname.startsWith("/api/events/")) return u;' in js
+    assert 'url.searchParams.set("user_profile", eventScope || "all");' in js
+    assert "const ddProfile = createDropdown({" in js
+    assert "const placeProfileDd = () => {" in js
+    assert "const host = stats ? tabsRightEl : filtersEl;" in js
+    assert "renderStatsRange(); placeProfileDd(); loadStats();" in js


### PR DESCRIPTION
# Pull request

## Change

- Adds a profile filter to More filters in the events modal, admin only
- Starts on whatever the Statistics picker is set to, then acts as a local override for the modal
- Moves itself into the stats range bar on the Statistics view, since the toolbar is hidden there
- Events calls now carry user_profile, and picking All profiles sends all

## Why

NA

## Testing

- tests/test_crosswatch_profiles.py

## Issue

Relates to #728
