### PR TITLE
Fix: clear filters resets the events profile

### DIFF
--- a/assets/js/modals/events/index.js
+++ b/assets/js/modals/events/index.js
@@ -792,7 +792,9 @@ export default {
       if (all || k === "origin") ddOrigin.reset();
       if (all || k === "feature") ddFeature.reset();
       if (all || k === "pair") ddPair.reset();
-      load(0);
+      if (isAdmin && (all || k === "profile")) { eventScope = ""; ddProfile.value = ""; }
+      if (view === "statistics") loadStats();
+      else load(0);
     };
 
     const updateHidden = () => {
@@ -803,6 +805,7 @@ export default {
       if (ddOrigin.value) chips.push({ k: "origin", label: `Origin: ${ddOrigin.labelOf(ddOrigin.value)}` });
       if (ddFeature.value) chips.push({ k: "feature", label: ddFeature.labelOf(ddFeature.value) });
       if (ddPair.value) chips.push({ k: "pair", label: ddPair.labelOf(ddPair.value) });
+      if (isAdmin && eventScope) chips.push({ k: "profile", label: ddProfile.labelOf(eventScope) });
       const active = chips.length > 0;
       moreDotEl.hidden = !active;
       moreBtn.classList.toggle("has-active", active);

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -2878,6 +2878,8 @@ def test_events_modal_has_profile_filter_in_more_filters() -> None:
     assert "const placeProfileDd = () => {" in js
     assert "const host = stats ? tabsRightEl : filtersEl;" in js
     assert "renderStatsRange(); placeProfileDd(); loadStats();" in js
+    assert 'if (isAdmin && (all || k === "profile")) { eventScope = ""; ddProfile.value = ""; }' in js
+    assert 'if (isAdmin && eventScope) chips.push({ k: "profile", label: ddProfile.labelOf(eventScope) });' in js
 
 
 def test_profile_hero_prefers_last_scrobble_over_history() -> None:


### PR DESCRIPTION
# Pull request

## Change

- Clear filters now resets the profile back to All profiles, not just the other filters
- The profile counts as an active filter again, so it gets a chip and lights up the More filters dot
- Clearing while on Statistics reloads the charts instead of only the event list

## Why

The profile filter was left out of clear filters, so it looked cleared but the events were still scoped.

## Testing

- tests/test_crosswatch_profiles.py

## Issue

NA
