### PR TITLE
Fix: provider profiles work without configuring the default

### DIFF
--- a/api/probesAPI.py
+++ b/api/probesAPI.py
@@ -1253,6 +1253,9 @@ def _probe_scrob_detail(cfg: dict[str, Any], max_age_sec: int = PROBE_TTL) -> tu
             PROBE_DETAIL_CACHE[key] = (now, False, rsn)
         return False, rsn
 
+    hint = cfg.get("_cw_probe") if isinstance(cfg.get("_cw_probe"), Mapping) else {}
+    inst = normalize_instance_id((hint or {}).get("instance"))
+
     ok = False
     reason = "request_failed"
     try:
@@ -1262,7 +1265,7 @@ def _probe_scrob_detail(cfg: dict[str, Any], max_age_sec: int = PROBE_TTL) -> tu
             ok = isinstance(payload, Mapping)
             reason = "" if ok else "validation_bad_response"
         else:
-            client.access_token = scrob.access_token_for(cfg, session=client.session)
+            client.access_token = scrob.access_token_for(cfg, instance_id=inst, session=client.session)
             payload = client.request_json("GET", scrob.ME_PATH)
             ok = isinstance(payload, Mapping) and bool(payload.get("id"))
             reason = "" if ok else "validation_bad_response"
@@ -1560,10 +1563,13 @@ def scrob_user_info(cfg: dict[str, Any], max_age_sec: int = USERINFO_TTL) -> dic
     if not scrob.is_configured(s):
         return {}
 
+    hint = cfg.get("_cw_probe") if isinstance(cfg.get("_cw_probe"), Mapping) else {}
+    inst = normalize_instance_id((hint or {}).get("instance"))
+
     out: dict[str, Any] = {}
     try:
         client = scrob.client_from_block(s)
-        client.access_token = scrob.access_token_for(cfg, session=client.session)
+        client.access_token = scrob.access_token_for(cfg, instance_id=inst, session=client.session)
         payload = client.request_json("GET", scrob.ME_PATH)
         if isinstance(payload, Mapping):
             username = str(payload.get("display_name") or payload.get("username") or "").strip()

--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -2305,7 +2305,7 @@ def _provider_counts_from_db() -> dict[str, int] | None:
     except Exception:
         return None
     if not counts:
-        return None
+        return {}
     out = _provider_count_defaults(counts)
     for key, value in counts.items():
         name = str(key or "").strip().upper()
@@ -2317,7 +2317,7 @@ def _provider_counts_from_db() -> dict[str, int] | None:
 
 def _provider_counts_current() -> dict[str, int]:
     counts = _provider_counts_from_db()
-    if counts is not None:
+    if counts:
         return counts
     cached = _PROVIDER_COUNTS_CACHE.get("data")
     return dict(cached) if isinstance(cached, dict) else _provider_count_defaults()
@@ -2362,7 +2362,7 @@ def _provider_counts_fast(*, max_age: int = 30, force: bool = False) -> dict:
     ):
         return dict(_PROVIDER_COUNTS_CACHE["data"])
     counts = _provider_counts_from_db()
-    if counts is None:
+    if not counts:
         counts = dict(_PROVIDER_COUNTS_CACHE.get("data") or _provider_count_defaults())
     _PROVIDER_COUNTS_CACHE["ts"] = now
     _PROVIDER_COUNTS_CACHE["data"] = counts

--- a/cw_platform/provider_instances.py
+++ b/cw_platform/provider_instances.py
@@ -352,6 +352,19 @@ def get_provider_block(cfg: Mapping[str, Any], provider_name: str, instance_id: 
     return {}
 
 
+def resolve_provider_block(cfg: Mapping[str, Any], provider_name: str, instance_id: Any = None) -> dict[str, Any]:
+    block = get_provider_block(cfg, provider_name, instance_id)
+    if block:
+        return block
+
+    base = cfg.get(provider_key(provider_name)) if isinstance(cfg, Mapping) else None
+    if not isinstance(base, Mapping):
+        return {}
+    if normalize_instance_id(instance_id) == _DEFAULT_INSTANCE or _INSTANCES_KEY not in base:
+        return dict(base)
+    return {}
+
+
 def list_instance_ids(cfg: Mapping[str, Any], provider_name: str) -> list[str]:
     key = provider_key(provider_name)
     base = cfg.get(key) if isinstance(cfg, Mapping) else None

--- a/providers/auth/_auth_ANILIST.py
+++ b/providers/auth/_auth_ANILIST.py
@@ -11,7 +11,7 @@ import requests
 
 from ._auth_base import AuthManifest, AuthProvider, AuthStatus
 
-from cw_platform.provider_instances import get_provider_block, ensure_instance_block, ensure_provider_block, normalize_instance_id
+from cw_platform.provider_instances import ensure_instance_block, ensure_provider_block, normalize_instance_id, resolve_provider_block
 
 try:
     from _logging import log as _real_log
@@ -44,7 +44,7 @@ def _blocks(cfg: Any, instance_id: Any) -> tuple[str, dict[str, Any], dict[str, 
 
 
 def _read(cfg: Mapping[str, Any], instance_id: Any) -> dict[str, Any]:
-    return get_provider_block(cfg, "anilist", instance_id)
+    return resolve_provider_block(cfg, "anilist", instance_id)
 
 
 def _gql_viewer(access_token: str) -> dict[str, Any] | None:

--- a/providers/auth/_auth_CROSSWATCH.py
+++ b/providers/auth/_auth_CROSSWATCH.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping, MutableMapping
 from typing import Any
 
 from ._auth_base import AuthManifest, AuthProvider, AuthStatus
-from cw_platform.provider_instances import get_provider_block, normalize_instance_id
+from cw_platform.provider_instances import normalize_instance_id, resolve_provider_block
 
 
 class CrossWatchAuth(AuthProvider):
@@ -28,7 +28,7 @@ class CrossWatchAuth(AuthProvider):
 
     def get_status(self, cfg: Mapping[str, Any], *, instance_id: Any = None) -> AuthStatus:
         inst = normalize_instance_id(instance_id)
-        block = get_provider_block(cfg or {}, "crosswatch", inst)
+        block = resolve_provider_block(cfg or {}, "crosswatch", inst)
         exists = isinstance((cfg or {}).get("crosswatch"), Mapping) or isinstance((cfg or {}).get("CrossWatch"), Mapping)
         ok = bool(exists) and block.get("connected") is True and block.get("enabled") is not False
         label = "CrossWatch Local Tracker" if inst == "default" else f"CrossWatch Local Tracker ({inst})"

--- a/providers/auth/_auth_FLOPPY.py
+++ b/providers/auth/_auth_FLOPPY.py
@@ -10,7 +10,7 @@ import requests
 
 from ._auth_base import AuthManifest, AuthProvider, AuthStatus
 from cw_platform.config_base import load_config, save_config
-from cw_platform.provider_instances import ensure_instance_block, get_provider_block, normalize_instance_id
+from cw_platform.provider_instances import ensure_instance_block, normalize_instance_id, resolve_provider_block
 
 __VERSION__ = "0.1"
 UA = "CrossWatch/1.0"
@@ -38,16 +38,7 @@ def normalize_server_url(value: Any) -> str:
 
 
 def provider_block(cfg: Mapping[str, Any] | None, instance_id: Any = None) -> dict[str, Any]:
-    block = get_provider_block(cfg or {}, "floppy", instance_id)
-    if block:
-        return block
-    base = (cfg or {}).get("floppy") if isinstance(cfg, Mapping) else None
-    if not isinstance(base, Mapping):
-        return {}
-    inst = normalize_instance_id(instance_id)
-    if inst == "default" or "instances" not in base:
-        return dict(base)
-    return {}
+    return resolve_provider_block(cfg or {}, "floppy", instance_id)
 
 
 def _block(cfg: Mapping[str, Any], instance_id: Any = None) -> dict[str, Any]:

--- a/providers/auth/_auth_KODI.py
+++ b/providers/auth/_auth_KODI.py
@@ -9,7 +9,7 @@ from typing import Any, cast
 import requests
 from requests.auth import HTTPBasicAuth
 
-from cw_platform.provider_instances import ensure_instance_block, get_provider_block, normalize_instance_id
+from cw_platform.provider_instances import ensure_instance_block, normalize_instance_id, resolve_provider_block
 
 from ._auth_base import AuthManifest, AuthProvider, AuthStatus
 
@@ -237,7 +237,7 @@ def verify_connection(
 
 
 def _block(cfg: Mapping[str, Any], instance_id: Any = None) -> dict[str, Any]:
-    return get_provider_block(cfg or {}, "kodi", instance_id)
+    return resolve_provider_block(cfg or {}, "kodi", instance_id)
 
 
 class KodiAuth(AuthProvider):

--- a/providers/auth/_auth_MDBLIST.py
+++ b/providers/auth/_auth_MDBLIST.py
@@ -10,7 +10,7 @@ import requests
 
 from ._auth_base import AuthManifest, AuthProvider, AuthStatus
 from cw_platform.config_base import load_config, save_config
-from cw_platform.provider_instances import ensure_instance_block, get_provider_block, normalize_instance_id
+from cw_platform.provider_instances import ensure_instance_block, normalize_instance_id, resolve_provider_block
 from providers.sync.mdblist import _auth as mdblist_auth
 
 try:
@@ -43,7 +43,7 @@ def _load_config() -> dict[str, Any]:
 
 
 def _block(cfg: Mapping[str, Any], instance_id: Any = None) -> dict[str, Any]:
-    return get_provider_block(cfg or {}, "mdblist", instance_id)
+    return resolve_provider_block(cfg or {}, "mdblist", instance_id)
 
 
 def _get(cfg: Mapping[str, Any], path: str, *, instance_id: Any = None, timeout: int = HTTP_TIMEOUT) -> tuple[int, dict[str, Any]]:

--- a/providers/auth/_auth_PUBLICMETADB.py
+++ b/providers/auth/_auth_PUBLICMETADB.py
@@ -10,7 +10,7 @@ import requests
 
 from ._auth_base import AuthManifest, AuthProvider, AuthStatus
 from cw_platform.config_base import load_config, save_config
-from cw_platform.provider_instances import get_provider_block, ensure_instance_block, normalize_instance_id
+from cw_platform.provider_instances import ensure_instance_block, normalize_instance_id, resolve_provider_block
 
 try:
     from _logging import log as _real_log
@@ -42,7 +42,7 @@ def _load_config() -> dict[str, Any]:
 
 
 def _block(cfg: Mapping[str, Any], instance_id: Any = None) -> dict[str, Any]:
-    return get_provider_block(cfg or {}, "publicmetadb", instance_id)
+    return resolve_provider_block(cfg or {}, "publicmetadb", instance_id)
 
 
 def validate_api_key(api_key: str, *, base_url: str = API_BASE, timeout: float = HTTP_TIMEOUT) -> tuple[bool, str]:

--- a/providers/auth/_auth_SCROB.py
+++ b/providers/auth/_auth_SCROB.py
@@ -14,7 +14,7 @@ import requests
 
 from ._auth_base import AuthManifest, AuthProvider, AuthStatus
 from cw_platform.config_base import load_config, save_config
-from cw_platform.provider_instances import ensure_instance_block, get_provider_block, normalize_instance_id
+from cw_platform.provider_instances import ensure_instance_block, normalize_instance_id, resolve_provider_block
 
 __VERSION__ = "0.1"
 UA = "CrossWatch/1.0"
@@ -74,7 +74,7 @@ def normalize_api_prefix(value: Any) -> str:
 
 
 def _block(cfg: Mapping[str, Any], instance_id: Any = None) -> dict[str, Any]:
-    return get_provider_block(cfg or {}, "scrob", instance_id)
+    return resolve_provider_block(cfg or {}, "scrob", instance_id)
 
 
 def is_configured(block: Mapping[str, Any] | None) -> bool:

--- a/providers/auth/_auth_STREMIO.py
+++ b/providers/auth/_auth_STREMIO.py
@@ -9,7 +9,7 @@ from typing import Any, cast
 import requests
 
 from cw_platform.config_base import _decrypt_secret
-from cw_platform.provider_instances import ensure_instance_block, get_provider_block, normalize_instance_id
+from cw_platform.provider_instances import ensure_instance_block, normalize_instance_id, resolve_provider_block
 
 from ._auth_base import AuthManifest, AuthProvider, AuthStatus
 
@@ -29,7 +29,7 @@ class StremioAuthError(RuntimeError):
 
 
 def _block(cfg: Mapping[str, Any], instance_id: Any = None) -> dict[str, Any]:
-    return get_provider_block(cfg or {}, "stremio", instance_id)
+    return resolve_provider_block(cfg or {}, "stremio", instance_id)
 
 
 def auth_key_value(block: Mapping[str, Any] | None) -> str:

--- a/providers/auth/_auth_TAUTULLI.py
+++ b/providers/auth/_auth_TAUTULLI.py
@@ -10,7 +10,7 @@ import requests
 
 from ._auth_base import AuthManifest, AuthProvider, AuthStatus
 from cw_platform.config_base import load_config, save_config
-from cw_platform.provider_instances import get_provider_block, ensure_instance_block, normalize_instance_id
+from cw_platform.provider_instances import ensure_instance_block, normalize_instance_id, resolve_provider_block
 
 __VERSION__ = "2.0.0"
 UA = "CrossWatch/1.0"
@@ -25,7 +25,7 @@ def _load_config() -> dict[str, Any]:
 
 
 def _block(cfg: Mapping[str, Any], instance_id: Any = None) -> dict[str, Any]:
-    return get_provider_block(cfg or {}, "tautulli", instance_id)
+    return resolve_provider_block(cfg or {}, "tautulli", instance_id)
 
 
 def validate_credentials(server_url: str, api_key: str, *, timeout: float = 12.0, verify_ssl: bool = True) -> tuple[bool, str]:

--- a/providers/scrobble/punchplay/sink.py
+++ b/providers/scrobble/punchplay/sink.py
@@ -15,7 +15,7 @@ import requests
 from cw_platform.config_base import load_config
 from cw_platform.event_archive import record_watch
 from cw_platform.local_db.ttl_dedupe import once_per_ttl
-from cw_platform.provider_instances import get_provider_block, normalize_instance_id
+from cw_platform.provider_instances import normalize_instance_id, resolve_provider_block
 from services.activity import record_scrobble_event
 
 try:
@@ -210,7 +210,7 @@ class PunchPlaySink(ScrobbleSink):
 
     def _block(self, cfg: Mapping[str, Any]) -> dict[str, Any]:
         try:
-            return get_provider_block(cfg, "punchplay", self.instance_id) or {}
+            return resolve_provider_block(cfg, "punchplay", self.instance_id) or {}
         except Exception:
             block = cfg.get("punchplay") if isinstance(cfg, Mapping) else None
             return dict(block) if isinstance(block, Mapping) else {}

--- a/providers/scrobble/scrob/sink.py
+++ b/providers/scrobble/scrob/sink.py
@@ -14,7 +14,7 @@ import requests
 from cw_platform.config_base import load_config
 from cw_platform.event_archive import record_watch
 from cw_platform.local_db.ttl_dedupe import once_per_ttl
-from cw_platform.provider_instances import get_provider_block, normalize_instance_id
+from cw_platform.provider_instances import normalize_instance_id, resolve_provider_block
 from services.activity import record_scrobble_event
 
 try:
@@ -204,7 +204,7 @@ class ScrobSink(ScrobbleSink):
 
     def _block(self, cfg: Mapping[str, Any]) -> dict[str, Any]:
         try:
-            return get_provider_block(cfg, "scrob", self.instance_id) or {}
+            return resolve_provider_block(cfg, "scrob", self.instance_id) or {}
         except Exception:
             block = cfg.get("scrob") if isinstance(cfg, Mapping) else None
             return dict(block) if isinstance(block, Mapping) else {}

--- a/providers/scrobble/scrob/watch.py
+++ b/providers/scrobble/scrob/watch.py
@@ -17,7 +17,7 @@ except Exception:
     BASE_LOG = None
 
 from cw_platform.config_base import load_config
-from cw_platform.provider_instances import get_provider_block, normalize_instance_id
+from cw_platform.provider_instances import normalize_instance_id, resolve_provider_block
 from providers.scrobble.currently_watching import update_from_event as _cw_update
 from providers.scrobble.currently_watching import update_from_payload as _cw_update_payload
 from providers.scrobble.scrob.sink import is_crosswatch_session
@@ -186,7 +186,7 @@ class ScrobWatchService:
 
     def _block(self, cfg: Mapping[str, Any]) -> dict[str, Any]:
         try:
-            return get_provider_block(cfg, "scrob", self._instance_id) or {}
+            return resolve_provider_block(cfg, "scrob", self._instance_id) or {}
         except Exception:
             return _dict(cfg.get("scrob"))
 

--- a/providers/sync/_mod_SCROB.py
+++ b/providers/sync/_mod_SCROB.py
@@ -12,7 +12,7 @@ import requests
 
 from ._log import log as cw_log
 from ._mod_common import build_session
-from cw_platform.provider_instances import get_provider_block, normalize_instance_id
+from cw_platform.provider_instances import normalize_instance_id, resolve_provider_block
 from providers.auth._auth_SCROB import is_configured as auth_configured
 
 try:  # type: ignore[name-defined]
@@ -103,7 +103,7 @@ def _feature_label(method: str, url: str, kw: Mapping[str, Any]) -> str:
 class SCROBModule:
     def __init__(self, cfg: Mapping[str, Any], *, instance_id: Any = None):
         self.instance_id = normalize_instance_id(instance_id)
-        block = get_provider_block(cfg or {}, "scrob", self.instance_id) or {}
+        block = resolve_provider_block(cfg or {}, "scrob", self.instance_id) or {}
         if not auth_configured(block):
             _log("error", "missing config", instance=self.instance_id)
             raise RuntimeError("Scrob is not connected: server_url, api_key, username and password are required")
@@ -202,7 +202,7 @@ class _SCROBOPS:
         return dict(CAPABILITIES)
 
     def is_configured(self, cfg: Mapping[str, Any]) -> bool:
-        block = get_provider_block(cfg or {}, "scrob", None) or {}
+        block = resolve_provider_block(cfg or {}, "scrob", None) or {}
         if auth_configured(block):
             return True
         root = (cfg or {}).get("scrob")

--- a/providers/sync/kodi/_common.py
+++ b/providers/sync/kodi/_common.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from cw_platform.config_base import load_config, save_config
 from cw_platform.id_map import canonical_key, ids_from, keys_for_item, minimal as id_minimal
-from cw_platform.provider_instances import ensure_instance_block, get_provider_block, normalize_instance_id
+from cw_platform.provider_instances import ensure_instance_block, normalize_instance_id, resolve_provider_block
 from providers.auth._auth_KODI import KodiAuthError, jsonrpc_batch_call, jsonrpc_call, verify_connection
 from providers.sync._log import log as cw_log
 
@@ -77,7 +77,7 @@ def pick_instance_id() -> str:
 
 
 def configured_block(cfg: Mapping[str, Any] | None, instance_id: Any = "default") -> dict[str, Any]:
-    return get_provider_block(dict(cfg or {}), "kodi", normalize_instance_id(instance_id))
+    return resolve_provider_block(dict(cfg or {}), "kodi", normalize_instance_id(instance_id))
 
 
 def is_configured(cfg: Mapping[str, Any] | None, instance_id: Any = "default") -> bool:

--- a/providers/sync/scrob/_common.py
+++ b/providers/sync/scrob/_common.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import requests
 
+from cw_platform.provider_instances import resolve_provider_block
+
 from .._log import log as cw_log
 from .._mod_common import SimpleRateLimiter
 from providers.auth._auth_SCROB import (
@@ -67,12 +69,10 @@ def mapping(value: Any) -> dict[str, Any]:
 
 
 def cfg_section(adapter: Any) -> Mapping[str, Any]:
-    cfg = getattr(adapter, "config", None)
-    if isinstance(cfg, Mapping) and isinstance(cfg.get("scrob"), Mapping):
-        return cfg["scrob"]
-    raw = getattr(adapter, "raw_cfg", None)
-    if isinstance(raw, Mapping) and isinstance(raw.get("scrob"), Mapping):
-        return raw["scrob"]
+    inst = instance_id(adapter)
+    for source in (getattr(adapter, "config", None), getattr(adapter, "raw_cfg", None)):
+        if isinstance(source, Mapping) and isinstance(source.get("scrob"), Mapping):
+            return resolve_provider_block(source, "scrob", inst)
     return {}
 
 

--- a/providers/sync/stremio/_common.py
+++ b/providers/sync/stremio/_common.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from cw_platform.id_map import canonical_key, ids_from, merge_ids, minimal as id_minimal
-from cw_platform.provider_instances import get_provider_block
+from cw_platform.provider_instances import resolve_provider_block
 from providers.auth._auth_STREMIO import is_configured as auth_is_configured
 
 COLLECTION = "libraryItem"
@@ -23,7 +23,7 @@ def is_capture_mode() -> bool:
 
 
 def configured_block(cfg: Mapping[str, Any] | None, instance_id: Any = "default") -> dict[str, Any]:
-    return get_provider_block(cfg or {}, "stremio", instance_id)
+    return resolve_provider_block(cfg or {}, "stremio", instance_id)
 
 
 def is_configured(cfg: Mapping[str, Any] | None, instance_id: Any = "default") -> bool:

--- a/tests/test_provider_profile_without_default.py
+++ b/tests/test_provider_profile_without_default.py
@@ -1,0 +1,195 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import pytest
+
+from cw_platform.provider_instances import build_provider_config_view, resolve_provider_block
+
+
+PROFILE = "P01"
+
+PROVIDER_BLOCKS: dict[str, dict[str, Any]] = {
+    "anilist": {"access_token": "T"},
+    "crosswatch": {"connected": True, "root_dir": "/config/.cw_provider/profiles/P01"},
+    "floppy": {"server_url": "http://floppy:8080", "api_token": "T"},
+    "kodi": {"server": "http://kodi:8080", "connection_verified": True},
+    "mdblist": {"api_key": "K"},
+    "nuvio": {"access_token": "T", "refresh_token": "R", "profile_id": 2},
+    "publicmetadb": {"api_key": "K"},
+    "punchplay": {"access_token": "T"},
+    "scrob": {"server_url": "http://scrob:7330", "api_key": "K", "username": "u", "password": "p"},
+    "stremio": {"auth_key": "K"},
+    "tautulli": {"server_url": "http://tautulli:8181", "api_key": "K"},
+}
+
+
+def _profile_only_cfg(provider: str) -> dict[str, Any]:
+    return {provider: {"instances": {PROFILE: dict(PROVIDER_BLOCKS[provider])}}}
+
+
+@pytest.mark.parametrize("provider", sorted(PROVIDER_BLOCKS))
+def test_resolve_provider_block_survives_a_narrowed_config_view(provider: str) -> None:
+    cfg = _profile_only_cfg(provider)
+    view = build_provider_config_view(cfg, provider, PROFILE)
+
+    resolved = resolve_provider_block(view, provider, PROFILE)
+
+    assert resolved
+    for key, value in PROVIDER_BLOCKS[provider].items():
+        assert resolved.get(key) == value
+
+
+@pytest.mark.parametrize("provider", sorted(PROVIDER_BLOCKS))
+def test_resolve_provider_block_reads_the_profile_from_a_full_config(provider: str) -> None:
+    cfg = _profile_only_cfg(provider)
+
+    resolved = resolve_provider_block(cfg, provider, PROFILE)
+    default_block = resolve_provider_block(cfg, provider, "default")
+
+    for key, value in PROVIDER_BLOCKS[provider].items():
+        assert resolved.get(key) == value
+        assert default_block.get(key) is None
+
+
+@pytest.mark.parametrize("provider", sorted(PROVIDER_BLOCKS))
+def test_resolve_provider_block_never_falls_back_to_another_profile(provider: str) -> None:
+    cfg = _profile_only_cfg(provider)
+    cfg[provider].update(PROVIDER_BLOCKS[provider])
+
+    assert resolve_provider_block(cfg, provider, "P02") == {}
+
+
+def test_auth_modules_resolve_profile_credentials_from_a_narrowed_view() -> None:
+    from providers.auth import _auth_KODI, _auth_MDBLIST, _auth_PUBLICMETADB, _auth_SCROB, _auth_STREMIO, _auth_TAUTULLI
+    from providers.auth._auth_FLOPPY import provider_block as floppy_block
+
+    checks = (
+        (_auth_SCROB._block, "scrob", "api_key"),
+        (_auth_STREMIO._block, "stremio", "auth_key"),
+        (_auth_KODI._block, "kodi", "server"),
+        (_auth_MDBLIST._block, "mdblist", "api_key"),
+        (_auth_PUBLICMETADB._block, "publicmetadb", "api_key"),
+        (_auth_TAUTULLI._block, "tautulli", "api_key"),
+        (floppy_block, "floppy", "api_token"),
+    )
+    for resolver, provider, field in checks:
+        view = build_provider_config_view(_profile_only_cfg(provider), provider, PROFILE)
+        assert resolver(view, PROFILE).get(field) == PROVIDER_BLOCKS[provider][field], provider
+
+
+def test_scrob_sync_signs_requests_for_a_profile_without_a_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    import providers.auth._auth_SCROB as scrob_auth
+    from providers.sync._mod_SCROB import SCROBModule
+    from providers.sync.scrob._common import PATH_NOW_PLAYING, scrob_request
+
+    cfg = _profile_only_cfg("scrob")
+    cfg["scrob"]["instances"][PROFILE].update({"access_token": "TOKEN", "expires_at": 4102444800})
+    view = build_provider_config_view(cfg, "scrob", PROFILE)
+
+    sent: list[dict[str, Any]] = []
+
+    class FakeSession:
+        headers: dict[str, str] = {}
+
+        def request(self, method: str, url: str, **kwargs: Any) -> Any:
+            sent.append({"method": method, "url": url, **kwargs})
+
+            class _Resp:
+                status_code = 200
+
+            return _Resp()
+
+    adapter = SCROBModule(view, instance_id=PROFILE)
+    adapter.session = FakeSession()
+
+    scrob_request(adapter, "GET", PATH_NOW_PLAYING)
+
+    assert len(sent) == 1
+    call = sent[0]
+    assert call["url"] == "http://scrob:7330/history/now-playing"
+    assert call["headers"]["X-Api-Key"] == "K"
+    assert call["headers"]["Authorization"] == "Bearer TOKEN"
+    assert scrob_auth.token_expired(scrob_auth._block(view, PROFILE)) is False
+
+
+def test_scrob_scrobble_sink_uses_the_profile_server_not_the_empty_default() -> None:
+    from providers.scrobble.scrob.sink import _Adapter
+    from providers.sync.scrob._common import base_url, cfg_section
+
+    cfg = _profile_only_cfg("scrob")
+    cfg["scrob"].update({"server_url": "", "api_key": "", "username": "", "password": ""})
+
+    adapter = _Adapter(cfg, PROFILE, object())
+
+    assert cfg_section(adapter).get("api_key") == "K"
+    assert base_url(cfg_section(adapter)) == "http://scrob:7330"
+
+
+def test_scrob_probe_refresh_writes_the_token_to_the_probed_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    import api.probesAPI as probes
+    import providers.auth._auth_SCROB as scrob_auth
+
+    stored: dict[str, Any] = _profile_only_cfg("scrob")
+
+    monkeypatch.setattr(scrob_auth, "load_config", lambda: stored)
+    monkeypatch.setattr(scrob_auth, "save_config", lambda cfg: stored.update(cfg))
+    monkeypatch.setattr(scrob_auth, "login", lambda *a, **kw: {"access_token": "FRESH", "expires_at": 4102444800})
+
+    view = probes._cfg_view_for(stored, "SCROB", PROFILE)
+    token = scrob_auth.access_token_for(view, instance_id=PROFILE)
+
+    assert token == "FRESH"
+    assert stored["scrob"]["instances"][PROFILE]["access_token"] == "FRESH"
+    assert not str(stored["scrob"].get("access_token") or "")
+
+
+def test_scrob_status_probe_never_writes_credentials_into_the_default_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    import api.probesAPI as probes
+    import providers.auth._auth_SCROB as scrob_auth
+
+    stored: dict[str, Any] = _profile_only_cfg("scrob")
+    stored["scrob"]["instances"][PROFILE].update({"access_token": "STALE", "expires_at": 1})
+
+    monkeypatch.setattr(scrob_auth, "load_config", lambda: copy.deepcopy(stored))
+    monkeypatch.setattr(scrob_auth, "save_config", lambda cfg: stored.update(copy.deepcopy(cfg)))
+    monkeypatch.setattr(scrob_auth, "login", lambda *a, **kw: {"access_token": "FRESH", "expires_at": 4102444800})
+
+    class _Ok:
+        status_code = 200
+
+        def json(self) -> dict[str, Any]:
+            return {"id": 7, "username": "u"}
+
+    monkeypatch.setattr(scrob_auth.ScrobClient, "request", lambda self, method, path, **kw: _Ok())
+    probes.PROBE_DETAIL_CACHE.clear()
+
+    ok, reason = probes._probe_scrob_detail(probes._cfg_view_for(stored, "SCROB", PROFILE), max_age_sec=0)
+
+    assert (ok, reason) == (True, "")
+    assert stored["scrob"]["instances"][PROFILE]["access_token"] == "FRESH"
+    assert not str(stored["scrob"].get("access_token") or "")
+    assert stored["scrob"].get("reauth_required") is not True
+
+
+def test_scrob_probe_reauth_flag_lands_on_the_probed_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    import providers.auth._auth_SCROB as scrob_auth
+
+    stored: dict[str, Any] = _profile_only_cfg("scrob")
+    stored["scrob"]["instances"][PROFILE].update({"access_token": "STALE", "expires_at": 1})
+
+    monkeypatch.setattr(scrob_auth, "load_config", lambda: copy.deepcopy(stored))
+    monkeypatch.setattr(scrob_auth, "save_config", lambda cfg: stored.update(copy.deepcopy(cfg)))
+
+    def _needs_totp(*a: Any, **kw: Any) -> dict[str, Any]:
+        raise scrob_auth.ScrobAuthError("2fa", reason="totp_required")
+
+    monkeypatch.setattr(scrob_auth, "login", _needs_totp)
+
+    with pytest.raises(scrob_auth.ScrobAuthError):
+        scrob_auth.refresh_token({}, instance_id=PROFILE)
+
+    assert stored["scrob"]["instances"][PROFILE]["reauth_required"] is True
+    assert stored["scrob"].get("reauth_required") is not True


### PR DESCRIPTION
# Pull request

## Change

- Add `resolve_provider_block` and use it in every provider block resolver
- Fix Scrob, Stremio and Kodi losing credentials on a non default profile
- Scrob probes now pass the probed instance

## Why

- Config views strip the `instances` map, so a second narrowing returned an empty block
- Scrob profiles ran with no api key and no token
- Token refresh wrote the profile token into the default block, which is the phantom default showing up in config.json

## Testing

- tests/test_provider_profile_without_default.py

## Issue

Relates to #728
