### PR TITLE
Fix: Plex progress writes reach the server again

### DIFF
--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -229,6 +229,19 @@ def _split_keys(lst: Iterable[Mapping[str, Any]], unresolved: Any) -> tuple[list
     return attempted, sorted(ukeys), confirmed
 
 
+def _progress_skipped_keys(results: Any) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for row in results or []:
+        if not isinstance(row, Mapping) or str(row.get("status") or "") != "skipped":
+            continue
+        key = str(row.get("key") or "").strip()
+        if key and key not in seen:
+            seen.add(key)
+            out.append(key)
+    return out
+
+
 _PLEX_HISTORY_META_FIELDS = (
     "accepted_keys",
     "presence_confirmed_keys",
@@ -1429,13 +1442,19 @@ class PLEXModule:
         try:
             cnt, unresolved = mod.add(self, lst)
             _attempted, unresolved_keys, confirmed_keys = _split_keys(lst, unresolved)
+            results = list(getattr(self, "_progress_write_results", [])) if feature == "progress" else []
+            skipped_keys = _progress_skipped_keys(results)
+            if skipped_keys:
+                skipped_set = set(skipped_keys)
+                confirmed_keys = [k for k in confirmed_keys if k not in skipped_set]
             res: dict[str, Any] = {
                 "ok": True,
                 "count": int(cnt),
                 "unresolved": unresolved,
                 "confirmed_keys": confirmed_keys,
                 "unresolved_keys": unresolved_keys,
-                "results": list(getattr(self, "_progress_write_results", [])) if feature == "progress" else [],
+                "skipped_keys": skipped_keys,
+                "results": results,
             }
             if feature == "history":
                 hm = getattr(self, "_plex_history_write_meta", None)

--- a/providers/sync/plex/_progress.py
+++ b/providers/sync/plex/_progress.py
@@ -775,7 +775,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                     or int(getattr(obj, "viewCount", 0) or 0) > 0
                 )
                 source_timestamp = it0.get("progress_at") or it0.get("lastViewedAt")
-                target_timestamp = getattr(obj, "lastViewedAt", None) or getattr(obj, "viewedAt", None) or getattr(obj, "updatedAt", None)
+                target_timestamp = getattr(obj, "lastViewedAt", None) or getattr(obj, "viewedAt", None)
                 target_progress = _to_int(getattr(obj, "viewOffset", None))
                 duration = _to_int(getattr(obj, "duration", None)) or _to_int(it0.get("duration_ms")) or 0
                 ms_i = _progress_ms_for_write(it0, duration)
@@ -802,6 +802,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                 )
                 context = {
                     "provider": "plex", "provider_instance": os.getenv("CW_PAIR_DST_INSTANCE") or "default",
+                    "key": str(canonical_key(id_minimal(it0)) or ""),
                     "remote_item_id": str(rk), "library_id": _library_id(obj) or it0.get("library_id"),
                     "source_timestamp": source_timestamp, "target_timestamp": target_timestamp,
                     "source_progress": ms_i, "target_progress": target_progress, "reason": decision.reason,

--- a/tests/test_plex_progress_write_accounting.py
+++ b/tests/test_plex_progress_write_accounting.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any
+
+from providers.sync._mod_PLEX import _progress_skipped_keys
+
+
+def _row(status: str, key: str) -> dict[str, Any]:
+    return {"status": status, "key": key, "provider": "plex", "remote_item_id": "1"}
+
+
+def test_only_skipped_rows_are_collected() -> None:
+    results = [
+        _row("applied", "tmdb:1"),
+        _row("skipped", "tmdb:2"),
+        _row("skipped", "tmdb:3"),
+        {"status": "unresolved", "reason": "not_found", "item": {}},
+        _row("failed", "tmdb:4"),
+    ]
+
+    assert _progress_skipped_keys(results) == ["tmdb:2", "tmdb:3"]
+
+
+def test_duplicates_and_keyless_rows_are_dropped() -> None:
+    results = [_row("skipped", "tmdb:2"), _row("skipped", "tmdb:2"), _row("skipped", "")]
+
+    assert _progress_skipped_keys(results) == ["tmdb:2"]
+
+
+def test_non_progress_results_yield_nothing() -> None:
+    assert _progress_skipped_keys([]) == []
+    assert _progress_skipped_keys(None) == []
+
+
+def test_issue_790_run_no_longer_reports_skipped_writes_as_added() -> None:
+    from cw_platform.orchestrator._applier import _normalize
+
+    attempted = [{"type": "movie", "ids": {"tmdb": str(n)}} for n in range(1, 13)]
+    skipped_keys = [f"tmdb:{n}" for n in range(1, 11)]
+    unresolved = [
+        {"status": "unresolved", "reason": "not_found", "item": attempted[10]},
+        {"status": "unresolved", "reason": "not_found", "item": attempted[11]},
+    ]
+
+    res = {
+        "ok": True,
+        "count": 0,
+        "unresolved": unresolved,
+        "confirmed_keys": [],
+        "unresolved_keys": ["tmdb:11", "tmdb:12"],
+        "skipped_keys": skipped_keys,
+    }
+
+    out = _normalize(
+        res,
+        attempted,
+        "apply:add",
+        dst="PLEX",
+        feature="progress",
+        emit=lambda *a, **k: None,
+    )
+
+    assert out["attempted"] == 12
+    assert out["confirmed"] == 0
+    assert out["skipped"] == 10
+    assert out["unresolved"] == 2

--- a/tests/test_progress_target_timestamp_sources.py
+++ b/tests/test_progress_target_timestamp_sources.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import Any
+
+from providers.sync import _progress_policy as policy
+
+
+SOURCE_TS = "2026-08-04 16:39:44.925Z"
+RECENT_METADATA_TS = "2026-08-19T06:10:02Z"
+PROGRESS_MS = 1_800_000
+RUNTIME_MS = 12_000_000
+
+
+def _decide(**overrides: Any) -> policy.ProgressDecision:
+    kwargs: dict[str, Any] = {
+        "active_session": False,
+        "source_timestamp": SOURCE_TS,
+        "target_timestamp": None,
+        "source_progress_ms": PROGRESS_MS,
+        "source_duration_ms": RUNTIME_MS,
+        "target_progress_ms": None,
+        "target_duration_ms": RUNTIME_MS,
+        "target_watched": False,
+        "same_origin": False,
+        "replay_enabled": False,
+        "timestamp_tolerance_seconds": 30,
+    }
+    kwargs.update(overrides)
+    return policy.decide_progress_write(**kwargs)
+
+
+def test_never_played_target_accepts_the_write() -> None:
+    decision = _decide()
+
+    assert decision.apply is True
+    assert decision.reason == "apply"
+
+
+def test_a_metadata_timestamp_would_have_blocked_the_write() -> None:
+    decision = _decide(target_timestamp=RECENT_METADATA_TS)
+
+    assert decision.apply is False
+    assert decision.reason == "target_newer"
+
+
+class _PlexObj:
+    type = "movie"
+    ratingKey = "11"
+    librarySectionID = "1"
+    viewOffset = None
+    viewCount = 0
+    duration = RUNTIME_MS
+    lastViewedAt = None
+    viewedAt = None
+    updatedAt = RECENT_METADATA_TS
+    isWatched = False
+    isPlayed = False
+
+
+class _Srv:
+    @staticmethod
+    def fetchItem(rating_key):
+        return _PlexObj()
+
+    @staticmethod
+    def sessions():
+        return []
+
+
+class _PlexAdapter:
+    client = type("C", (), {"server": _Srv()})()
+
+
+def _run_plex_add(monkeypatch):
+    from providers.sync.plex import _progress as pr
+
+    written: list[dict[str, Any]] = []
+    monkeypatch.setattr(pr, "home_scope_enter", lambda _a: (False, False, None, None))
+    monkeypatch.setattr(pr, "home_scope_exit", lambda _a, _b: None)
+    monkeypatch.setattr(pr, "_resolve_rating_key", lambda _a, _i: "11")
+    monkeypatch.setattr(pr, "_same_plex_endpoint", lambda: False)
+    monkeypatch.setattr(pr, "_progress_write_options", lambda _a: (False, 30))
+    monkeypatch.setattr(
+        pr,
+        "_timeline_progress",
+        lambda adapter, srv, rk, ms, dur: written.append({"rk": rk, "ms": ms, "duration": dur}),
+    )
+
+    adapter = _PlexAdapter()
+    item = {
+        "type": "movie",
+        "title": "The Godfather Part II",
+        "ids": {"tmdb": "240"},
+        "progress_at": SOURCE_TS,
+        "progress_ms": PROGRESS_MS,
+        "duration_ms": RUNTIME_MS,
+    }
+    applied, unresolved = pr.add(adapter, [item])
+    return pr, adapter, applied, unresolved, written
+
+
+def test_never_played_plex_item_gets_the_resume_position_written(monkeypatch) -> None:
+    pr, adapter, applied, unresolved, written = _run_plex_add(monkeypatch)
+
+    assert unresolved == []
+    assert applied == 1
+    assert written == [{"rk": "11", "ms": PROGRESS_MS, "duration": RUNTIME_MS}]
+
+    results = getattr(adapter, "_progress_write_results", [])
+    assert [row["status"] for row in results] == ["applied"]
+
+
+def test_write_results_carry_the_canonical_key_for_accounting(monkeypatch) -> None:
+    from providers.sync._mod_PLEX import _progress_skipped_keys
+
+    pr, adapter, _applied, _unresolved, _written = _run_plex_add(monkeypatch)
+    results = getattr(adapter, "_progress_write_results", [])
+
+    assert results[0]["key"] == "tmdb:240"
+    assert _progress_skipped_keys(results) == []

--- a/tests/test_provider_counts_empty_vs_failure.py
+++ b/tests/test_provider_counts_empty_vs_failure.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from api import syncAPI
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    before = dict(syncAPI._PROVIDER_COUNTS_CACHE)
+    syncAPI._PROVIDER_COUNTS_CACHE["ts"] = 0.0
+    syncAPI._PROVIDER_COUNTS_CACHE["data"] = None
+    yield
+    syncAPI._PROVIDER_COUNTS_CACHE.update(before)
+
+
+def _stub_store(monkeypatch, counts: Any) -> None:
+    class _Store:
+        def __init__(self, _cfg):
+            pass
+
+        def provider_feature_counts(self, _feature):
+            if isinstance(counts, Exception):
+                raise counts
+            return counts
+
+    monkeypatch.setattr(
+        "cw_platform.orchestrator._state_store.StateStore", _Store, raising=True
+    )
+
+
+def test_no_recorded_rows_is_empty_not_failure(monkeypatch) -> None:
+    _stub_store(monkeypatch, {})
+
+    assert syncAPI._provider_counts_from_db() == {}
+
+
+def test_store_failure_still_reports_none(monkeypatch) -> None:
+    _stub_store(monkeypatch, RuntimeError("db gone"))
+
+    assert syncAPI._provider_counts_from_db() is None
+
+
+def test_populated_rows_are_returned(monkeypatch) -> None:
+    _stub_store(monkeypatch, {"plex": 12, "trakt": 9})
+
+    out = syncAPI._provider_counts_from_db()
+
+    assert out is not None
+    assert out["PLEX"] == 12
+    assert out["TRAKT"] == 9
+
+
+def test_empty_result_falls_back_to_cache(monkeypatch) -> None:
+    _stub_store(monkeypatch, {})
+    syncAPI._PROVIDER_COUNTS_CACHE["data"] = {"PLEX": 7}
+
+    assert syncAPI._provider_counts_current() == {"PLEX": 7}
+
+
+def test_empty_result_does_not_overwrite_cached_counts(monkeypatch) -> None:
+    _stub_store(monkeypatch, {})
+    syncAPI._PROVIDER_COUNTS_CACHE["data"] = {"PLEX": 7}
+
+    assert syncAPI._provider_counts_fast(force=True) == {"PLEX": 7}
+    assert syncAPI._PROVIDER_COUNTS_CACHE["data"] == {"PLEX": 7}


### PR DESCRIPTION
# Pull request

## Change

- Plex no longer treats updatedAt as a playback timestamp, so never-played items stop being blocked by the target newer guard
- Plex progress write results carry the canonical key
- The Plex adapter reports skipped_keys, so policy skipped writes are no longer counted as added

## Why

- updatedAt is a metadata scan time and is almost always newer than an imported resume position
- Every resolvable item was skipped, so nothing was written to Plex at all

## Testing

- tests/test_progress_target_timestamp_sources.py 
- tests/test_plex_progress_write_accounting.py

## Issue

Relates to #790
