### PR TITLE
Fix: Kodi drops anime IDs

### DIFF
--- a/cw_platform/anime_mapping/episodes.py
+++ b/cw_platform/anime_mapping/episodes.py
@@ -164,6 +164,10 @@ def resolve_absolute(
         agreed = {hit[0] for hit in found.values() if hit[0] > 0}
         if not agreed:
             continue
+        if _native_identity_conflict(ids, found):
+            native = _native_passthrough(tag, ids, season, episode)
+            if native is not None:
+                return native
         if len(agreed) != 1:
             return None
         absolute = agreed.pop()
@@ -178,6 +182,17 @@ def resolve_absolute(
                     entry=basis,
                 )
     return _native_passthrough(tag, ids, season, episode)
+
+
+def _native_identity_conflict(ids: Mapping[str, str], found: Mapping[str, tuple[int, str]]) -> bool:
+    for namespace in NATIVE_ORDER:
+        own = str(ids.get(namespace) or "").strip()
+        hit = found.get(namespace)
+        if not own or not hit or hit[0] <= 0 or not hit[1]:
+            continue
+        if hit[1] != own:
+            return True
+    return False
 
 
 def _native_passthrough(tag: str, ids: Mapping[str, str], season: int, episode: int) -> Resolution | None:

--- a/providers/scrobble/kodi/watch.py
+++ b/providers/scrobble/kodi/watch.py
@@ -20,7 +20,7 @@ from providers.scrobble.currently_watching import update_from_event as _cw_updat
 from providers.scrobble.currently_watching import update_from_payload as _cw_update_payload
 from providers.scrobble.scrobble import Dispatcher, ScrobbleEvent, ScrobbleSink, mask_account
 from providers.scrobble.sources import source_enabled
-from providers.sync.kodi._common import path_scope_status
+from providers.sync.kodi._common import EXTERNAL_ID_KEYS, path_scope_status, uniqueid_name, uniqueid_namespace
 
 BASE_POLL_SECONDS = 1.75
 MIN_POLL_SECONDS = 1.5
@@ -111,7 +111,7 @@ def _stable_server_uuid(server: str) -> str:
 
 
 def _norm_unique_key(key: Any) -> str:
-    return "".join(ch for ch in str(key or "").strip().lower() if ch.isalnum())
+    return uniqueid_name(key)
 
 
 def _normalize_uniqueids(uniqueid: Any, media_type: str) -> dict[str, str]:
@@ -129,13 +129,7 @@ def _normalize_uniqueids(uniqueid: Any, media_type: str) -> dict[str, str]:
             continue
         nk = _norm_unique_key(key)
         is_show = media_type == "episode" and any(part in nk for part in ("show", "tvshow", "series"))
-        target = None
-        if "imdb" in nk or text.lower().startswith("tt"):
-            target = "imdb"
-        elif "tmdb" in nk or "themoviedb" in nk:
-            target = "tmdb"
-        elif "tvdb" in nk or "thetvdb" in nk:
-            target = "tvdb"
+        target = uniqueid_namespace(nk, text)
         if target:
             if media_type == "episode":
                 put(f"{target}_show" if is_show else f"{target}_episode", text)
@@ -150,7 +144,7 @@ def _has_show_ids(ids: Mapping[str, Any]) -> bool:
 
 def _show_ids_from_uniqueids(uniqueid: Any) -> dict[str, str]:
     base = _normalize_uniqueids(uniqueid, "movie")
-    return {f"{key}_show": value for key, value in base.items() if key in {"imdb", "tmdb", "tvdb"} and value}
+    return {f"{key}_show": value for key, value in base.items() if key in EXTERNAL_ID_KEYS and value}
 
 
 def _item_identity(item: Mapping[str, Any], media_type: str) -> str:

--- a/providers/sync/kodi/_common.py
+++ b/providers/sync/kodi/_common.py
@@ -221,6 +221,32 @@ def to_float(value: Any) -> float | None:
         return None
 
 
+EXTERNAL_ID_KEYS: tuple[str, ...] = ("tmdb", "imdb", "tvdb", "anidb", "anilist", "mal", "kitsu")
+
+UNIQUEID_NAMESPACES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("anidb", ("anidb",)),
+    ("anilist", ("anilist",)),
+    ("kitsu", ("kitsu",)),
+    ("mal", ("myanimelist", "mal")),
+    ("imdb", ("imdb",)),
+    ("tmdb", ("tmdb", "themoviedb")),
+    ("tvdb", ("tvdb", "thetvdb")),
+)
+
+
+def uniqueid_name(key: Any) -> str:
+    return "".join(ch for ch in str(key or "").strip().lower() if ch.isalnum())
+
+
+def uniqueid_namespace(name: str, text: str) -> str | None:
+    if text.lower().startswith("tt"):
+        return "imdb"
+    for namespace, needles in UNIQUEID_NAMESPACES:
+        if any(needle in name for needle in needles):
+            return namespace
+    return None
+
+
 def normalize_uniqueids(uniqueid: Any) -> dict[str, str]:
     raw = uniqueid if isinstance(uniqueid, Mapping) else {}
     out: dict[str, str] = {}
@@ -228,13 +254,9 @@ def normalize_uniqueids(uniqueid: Any) -> dict[str, str]:
         text = str(value or "").strip()
         if not text:
             continue
-        name = "".join(ch for ch in str(key or "").strip().lower() if ch.isalnum())
-        if "imdb" in name or text.lower().startswith("tt"):
-            out.setdefault("imdb", text)
-        elif "tmdb" in name or "themoviedb" in name:
-            out.setdefault("tmdb", text)
-        elif "tvdb" in name or "thetvdb" in name:
-            out.setdefault("tvdb", text)
+        namespace = uniqueid_namespace(uniqueid_name(key), text)
+        if namespace:
+            out.setdefault(namespace, text)
     return out
 
 
@@ -298,7 +320,7 @@ def _has_external_identifiers(item: Mapping[str, Any]) -> bool:
     if isinstance(show_ids, Mapping):
         sources.append(show_ids)
     for src in sources:
-        if any(str(src.get(k) or "").strip() for k in ("tmdb", "imdb", "tvdb")):
+        if any(str(src.get(k) or "").strip() for k in EXTERNAL_ID_KEYS):
             return True
     return False
 

--- a/providers/tests/test_kodi_sync.py
+++ b/providers/tests/test_kodi_sync.py
@@ -335,3 +335,50 @@ def test_external_id_source_does_not_fallback_to_title_year():
     assert result["count"] == 0
     assert result["reason_counts"]["not_found"] == 1
     assert client.movie_writes == []
+
+
+def test_normalize_uniqueids_carries_native_anime_namespaces():
+    got = common.normalize_uniqueids(
+        {"anidb": "16627", "tvdb": "369144", "AniList": "139092", "MyAnimeList": "49784", "kitsu": "45154"}
+    )
+
+    assert got == {
+        "anidb": "16627",
+        "tvdb": "369144",
+        "anilist": "139092",
+        "mal": "49784",
+        "kitsu": "45154",
+    }
+
+
+def test_normalize_uniqueids_keeps_existing_namespace_behaviour():
+    assert common.normalize_uniqueids({"imdb": "tt2543164", "themoviedb": "329865", "thetvdb": "280619"}) == {
+        "imdb": "tt2543164",
+        "tmdb": "329865",
+        "tvdb": "280619",
+    }
+    assert common.normalize_uniqueids({"unknown": "tt99"}) == {"imdb": "tt99"}
+    assert common.normalize_uniqueids({"shoko": "12", "": "9"}) == {}
+
+
+def test_anidb_scraped_episode_keeps_native_show_identity():
+    ad = adapter(
+        FakeKodiClient(
+            [],
+            [episode(uniqueid={"tvdb": "9378874"}, season=1, episode=14, showtitle="Mairimashita! Iruma-kun")],
+            [tvshow(uniqueid={"anidb": "16627", "tvdb": "369144"})],
+        )
+    )
+
+    index = mod.feat_history.build_index(ad)
+    row = next(iter(index.values()))
+
+    assert row["show_ids"] == {"anidb": "16627", "tvdb": "369144"}
+    assert (row["season"], row["episode"]) == (1, 14)
+
+
+def test_native_only_show_ids_are_treated_as_external():
+    item = {"type": "episode", "show_ids": {"anidb": "16627"}, "season": 1, "episode": 14}
+
+    assert common._has_external_identifiers(item) is True
+    assert not any("|title:" in key for key in common.resolution_keys(item))

--- a/tests/test_anime_episodes.py
+++ b/tests/test_anime_episodes.py
@@ -37,6 +37,16 @@ MAPPINGS: dict[str, Any] = {
         "anilist:701": {"1-12": "1-12"},
     },
     "tvdb_show:702:s1": {"anidb:702:S": {"1-12": "1-12"}},
+    "tvdb_show:369144:s1": {
+        "anidb:14660:R": {"1-23": "1-23"},
+        "anilist:107693": {"1-23": "1-23"},
+        "mal:39196": {"1-23": "1-23"},
+    },
+    "tvdb_show:369144:s3": {
+        "anidb:16627:R": {"1-21": "1-21"},
+        "anilist:139092": {"1-21": "1-21"},
+        "mal:49784": {"1-21": "1-21"},
+    },
 }
 
 
@@ -165,3 +175,29 @@ def test_migration_keeps_custom_entries() -> None:
     _normalize_anime_mapping(cfg)
     assert cfg["anime_mapping"]["use_for_pairs"][0] == "*"
     assert set(cfg["anime_mapping"]["features"]) >= {"watchlist", "ratings", "history"}
+
+
+def test_native_id_outranks_aired_axis_inference(index: Path) -> None:
+    got = resolve_absolute(_episode({"tvdb": "369144", "anidb": "16627"}, 1, 14))
+    assert got is not None
+    assert (got.absolute, got.namespace, got.target_id) == (14, "anidb", "16627")
+    assert got.entry == "anidb_native"
+
+
+def test_aired_axis_is_kept_without_a_native_id(index: Path) -> None:
+    got = resolve_absolute(_episode({"tvdb": "369144"}, 1, 14))
+    assert got is not None
+    assert (got.absolute, got.namespace, got.target_id) == (14, "anidb", "14660")
+    assert got.entry == "tvdb_direct"
+
+
+def test_agreeing_native_id_does_not_divert(index: Path) -> None:
+    got = resolve_absolute(_episode({"tvdb": "369144", "anidb": "14660"}, 1, 14))
+    assert got is not None
+    assert (got.absolute, got.target_id, got.basis) == (14, "14660", "anibridge_absolute")
+
+
+def test_conflicting_native_id_outside_season_one_keeps_aired_result(index: Path) -> None:
+    got = resolve_absolute(_episode({"tvdb": "81472", "anilist": "999"}, 2, 13))
+    assert got is not None
+    assert (got.absolute, got.basis) == (52, "anibridge_absolute")

--- a/tests/test_anime_overrides.py
+++ b/tests/test_anime_overrides.py
@@ -348,3 +348,24 @@ def test_stats_reports_the_store(config_base: Path) -> None:
     assert got["shows"] == 1
     assert got["movies"] == 1
     assert got["episode_rules"] == 1
+
+
+def test_anidb_keyed_override_applies_to_an_anidb_scraped_library(index: Path) -> None:
+    ov.upsert_override(
+        _rule(
+            title="Mairimashita! Iruma-kun",
+            match_provider="anidb",
+            match_id="16627",
+            match_season=1,
+            target_namespace="simkl",
+            target_id="1728821",
+            episode_from=1,
+            episode_to=21,
+            episode_start_at=1,
+        )
+    )
+
+    got = resolve_absolute(_episode({"tvdb": "369144", "anidb": "16627"}, 1, 14))
+
+    assert got is not None
+    assert (got.absolute, got.namespace, got.target_id, got.basis) == (14, "simkl", "1728821", "user_override")

--- a/tests/test_kodi_watch.py
+++ b/tests/test_kodi_watch.py
@@ -443,3 +443,56 @@ def test_scrobble_source_whitelist_ignores_unselected_paths(monkeypatch):
     assert logs[-1][0] == "DEBUG"
     assert "event filtered by scrobble whitelist" in logs[-1][1]
     assert "allowed=['/movies']" in logs[-1][1]
+
+
+def test_watcher_normalizes_native_anime_uniqueids():
+    got = kodi_watch._normalize_uniqueids(
+        {"anidb": "17969", "tvshow.anidb": "17969", "tvdb": "9515852", "tvshow.tvdb": "393478"},
+        "episode",
+    )
+
+    assert got == {
+        "anidb_episode": "17969",
+        "anidb_show": "17969",
+        "tvdb_episode": "9515852",
+        "tvdb_show": "393478",
+    }
+    assert kodi_watch._has_show_ids(got) is True
+
+
+def test_watcher_show_ids_carry_native_anime_namespaces():
+    got = kodi_watch._show_ids_from_uniqueids({"anidb": "17969", "tvdb": "393478", "MyAnimeList": "54918"})
+
+    assert got == {"anidb_show": "17969", "tvdb_show": "393478", "mal_show": "54918"}
+    assert kodi_watch._has_show_ids({"anidb_show": "17969"}) is False
+    assert kodi_watch._has_show_ids({"tvdb_show": "393478"}) is True
+
+
+def test_anidb_scraped_episode_scrobbles_as_anime(monkeypatch):
+    monkeypatch.setattr(kodi_watch, "_cw_update", lambda *a, **k: None)
+    script = RpcScript(
+        **{
+            "Player.GetActivePlayers": [active()],
+            "Player.GetItem": [
+                {
+                    "item": episode_item(
+                        title="Episode 5",
+                        showtitle="Tokyo Revengers: Tenjiku Hen",
+                        season=1,
+                        episode=5,
+                        uniqueid={"tvdb": "9515852", "tvshow.anidb": "17969", "tvshow.tvdb": "393478"},
+                    )
+                }
+            ],
+            "Player.GetProperties": [props(1, 12)],
+            "Profiles.GetCurrentProfile": [profile("Cinema")],
+        }
+    )
+    service, disp = svc(script)
+
+    assert service._tick() is True
+
+    ev = disp.events[-1]
+    assert ev.ids["anidb_show"] == "17969"
+    assert ev.ids["tvdb_show"] == "393478"
+    assert simkl_sink._show_ids(ev)["anidb"] == "17969"


### PR DESCRIPTION
# Pull request

## Change

- Kodi now keeps anidb, anilist, mal and kitsu uniqueids 
- Native anime IDs now count as external IDs, so an anidb only item no longer falls back to title matching
- Anime mapping now trusts the ID on the item over the season it was handed
- 
## Why

- Kodi libraries scraped with the anidb scraper number every show from season 1, but the scraper also writes the parent tvdb series ID
- CW kept the tvdb ID and threw the anidb one away, so the item became tvdb:369144 s01e14, which is a show ID and a season number from two different numbering schemes
- That resolves to anidb 14660 (Iruma season 1, simkl 1034469) instead of anidb 16627 (season 3, simkl 1728821)
- It also made manual anime overrides useless: a rule keyed on anidb can never match an item with no anidb ID, so every rule was skipped

## Testing

- tests/test_anime_episodes.py 
- tests/test_anime_overrides.py 
- tests/test_kodi_watch.py 
- providers/tests/test_kodi_sync.py

## Issue

Relates to #801
