### PR TITLE
Fix: pair config hides the default profile

### DIFF
--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -729,9 +729,13 @@ function renderInstanceSelects(state){
     const gated=all.some(row=>typeof row.configured==="boolean");
     let rows=gated?all.filter(row=>row.configured!==false):all.slice();
     if(pin&&pin===want&&!rows.some(row=>row.id===pin)){
-      const known=all.find(row=>row.id===pin)||{id:pin,label:pin==="default"?"Default":pin};
-      const stale={...known,stale:true};
-      rows=pin==="default"?[stale,...rows]:[...rows,stale];
+      const known=all.find(row=>row.id===pin);
+      const neverConfigured=pin==="default"&&known&&known.configured===false;
+      if(!neverConfigured||!rows.length){
+        const base=known||{id:pin,label:pin==="default"?"Default":pin};
+        const stale={...base,stale:true};
+        rows=pin==="default"?[stale,...rows]:[...rows,stale];
+      }
     }
     if(!rows.length) rows=[{id:"default",label:"Default",stale:!!state.instancesLoaded}];
     const ids=rows.map(row=>row.id);


### PR DESCRIPTION
# Pull request

## Change

- Drop `default` from the pair profile dropdown when it has no config behind it
- Still show a pinned profile that was configured and later disconnected

## Why

- A pair saved on `default` kept selecting a dead profile even when a real one existed
- That pair cannot run, the orchestrator just skips it on auth_failed

## Testing

- Manual: open a saved pair on a provider that only has a P01 profile

## Issue

NA