### PR TITLE
Add: user profile filter to playback progress

### DIFF
--- a/assets/js/playback_progress.js
+++ b/assets/js/playback_progress.js
@@ -35,7 +35,8 @@
     providers: [],
     errors: [],
     selected: new Map(),
-    filters: { provider: "", media_type: "", progress: "", age: "", rating: "", search: "", sort: "last_updated" },
+    filters: { user_profile: "", provider: "", media_type: "", progress: "", age: "", rating: "", search: "", sort: "last_updated" },
+    userProfileTouched: false,
     busy: false,
     loaded: false,
     settings: null,
@@ -62,6 +63,7 @@
       <div class="pp-status" id="pp-status"></div>
       <div class="pp-toolbar">
         <input class="pp-field" id="pp-search" type="search" placeholder="Search">
+        <select class="pp-field hidden" id="pp-user-profile" aria-label="User profile"><option value="">All User Profiles</option></select>
         <select class="pp-field" id="pp-provider"><option value="">Loading providers...</option></select>
         <select class="pp-field" id="pp-type"><option value="">All Types</option><option value="movie">Movies</option><option value="episode">TV Episodes</option><option value="anime_episode">Anime Episodes</option></select>
         <select class="pp-field" id="pp-progress"><option value="">All Progress</option><option value="0:24.99">Under 25 percent</option><option value="25:50">25 to 50 percent</option><option value="50:75">50 to 75 percent</option><option value="75:100">Over 75 percent</option><option value="90:100">Nearly Finished</option></select>
@@ -222,7 +224,7 @@
     let label = String(p.instance_label || p.instance_id || "").trim();
     for (const prefix of [providerLabel, provider]) {
       if (prefix && label.toLowerCase().startsWith(prefix.toLowerCase())) {
-        label = label.slice(prefix.length).trim();
+        label = label.slice(prefix.length).replace(/^[\s_-]+/, "").trim();
       }
     }
     return label || (String(p.instance_id || "").trim() || "Default");
@@ -230,13 +232,7 @@
   const compactProfileLabel = (p) => {
     const id = String(p?.instance_id || "default").trim() || "default";
     if (id.toLowerCase() === "default") return "";
-    const label = profileLabel(p);
-    for (const value of [label, id]) {
-      const match = String(value || "").trim().match(/^(?:profile[\s_-]*)?p?0*(\d{1,2})$/i)
-        || String(value || "").trim().match(/(?:^|[\s_-])(?:profile[\s_-]*)?p?0*(\d{1,2})$/i);
-      if (match) return `P${String(match[1]).padStart(2, "0")}`;
-    }
-    return label;
+    return profileLabel(p);
   };
   const settingsProviderOrder = (provider) => {
     const p = String(provider || "").toLowerCase();
@@ -248,7 +244,7 @@
     const id = String(p.instance_id || "default");
     if (id === "default") return "Default";
     if (String(p.provider || "").toLowerCase() === "crosswatch" && /^CW-P\d+$/i.test(id)) return id.toUpperCase();
-    return String(p.instance_label || id);
+    return profileLabel(p);
   };
   const settingsProviderCard = (provider, profiles) => {
     const key = String(provider || "").toLowerCase();
@@ -469,11 +465,42 @@
     await load(true);
   }
 
+  function userProfiles() {
+    const op = window.CW?.OverviewProfile;
+    if (!op?.isAdmin) return [];
+    const rows = Array.isArray(op.profiles) ? op.profiles : [];
+    return rows.filter((row) => String(row?.id || "").trim());
+  }
+
+  function userProfileOptions() {
+    const select = document.getElementById("pp-user-profile");
+    if (!select) return;
+    const rows = userProfiles();
+    select.classList.toggle("hidden", !rows.length);
+    if (!rows.length) return;
+    const opts = ['<option value="">All User Profiles</option>'];
+    rows.forEach((row) => {
+      const id = String(row.id || "");
+      const label = String(row.label || row.name || id).trim() || id;
+      opts.push(`<option value="${esc(id)}">${esc(label)}</option>`);
+    });
+    const signature = opts.join("");
+    if (select.dataset.signature !== signature) {
+      select.innerHTML = signature;
+      select.dataset.signature = signature;
+    }
+    const want = state.userProfileTouched
+      ? String(state.filters.user_profile || "")
+      : String(window.CW?.OverviewProfile?.id || "");
+    select.value = [...select.options].some((o) => o.value === want) ? want : "";
+    state.filters.user_profile = select.value;
+  }
+
   function providerOptions() {
     const readable = state.providers.filter((p) => p.read && p.configured && p.included !== false);
     const opts = ['<option value="">All Providers</option>'];
     readable.forEach((p) => {
-      const label = compactProfileLabel(p);
+      const label = String(p.instance_label || "").trim() || profileLabel(p);
       const provider = String(p.provider || "");
       const instance = String(p.instance_id || "default");
       opts.push(`<option value="${esc(provider)}:${esc(instance)}" data-provider="${esc(provider)}" data-profile-label="${esc(label)}">${esc(label || providerLabel(provider))}</option>`);
@@ -489,7 +516,7 @@
         const provider = option?.dataset?.provider || String(value).split(":")[0];
         const label = option?.dataset?.profileLabel || "";
         return {
-          label: label || "Default",
+          label: label || providerLabel(provider),
           icons: [{ src: providerLogLogo(provider), alt: providerLabel(provider) }]
         };
       }
@@ -707,7 +734,8 @@
 
   function query(force = false, all = false) {
     const params = new URLSearchParams();
-    const profileId = String(window.CW?.OverviewProfile?.id || "").trim();
+    const scoped = String(state.filters.user_profile || "").trim();
+    const profileId = scoped || (state.userProfileTouched ? "" : String(window.CW?.OverviewProfile?.id || "").trim());
     if (profileId) params.set("user_profile", profileId);
     const [provider, instance] = String(state.filters.provider || "").split(":");
     if (provider) params.set("provider", provider);
@@ -746,6 +774,7 @@
       if (!state.lastRefreshFailed) state.lastSyncAt = Date.now();
       state.total = Number(data.total || 0);
       state.page = Number(data.page || 1);
+      userProfileOptions();
       providerOptions();
       renderStatus();
       renderErrors();
@@ -829,6 +858,12 @@
     r.addEventListener("change", (e) => {
       const t = e.target;
       if (!t) return;
+      if (t.id === "pp-user-profile") {
+        state.userProfileTouched = true;
+        state.selected.clear();
+        state.filters.provider = "";
+        update("user_profile", t.value);
+      }
       if (t.id === "pp-provider") update("provider", t.value);
       if (t.id === "pp-type") update("media_type", t.value);
       if (t.id === "pp-progress") update("progress", t.value);
@@ -932,9 +967,11 @@
     const page = document.getElementById("page-playback_progress");
     if (page && !page.classList.contains("hidden")) load(false);
   });
+  window.addEventListener("cw-user-profiles-changed", () => userProfileOptions());
   window.addEventListener("cw:overview-profile-changed", () => {
     state.selected.clear();
     state.page = 1;
+    userProfileOptions();
     const page = document.getElementById("page-playback_progress");
     if (page && !page.classList.contains("hidden")) load(false);
   });

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -728,10 +728,10 @@ def _path_value(block: Mapping[str, Any], path: str) -> Any:
 
 def _profile_has_explicit_identity(cfg: Mapping[str, Any], provider: str, instance_id: Any) -> bool:
     inst = normalize_instance_id(instance_id)
-    if inst == "default":
-        return True
     provider_key = str(provider or "").strip().lower()
     if provider_key in {"cw", "crosswatch"}:
+        if inst == "default":
+            return True
         base = cfg.get("crosswatch") if isinstance(cfg, Mapping) else None
         insts = (base or {}).get("instances") if isinstance(base, Mapping) else None
         return bool(isinstance(insts, Mapping) and inst in insts and isinstance(insts.get(inst), Mapping))

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -1336,3 +1336,96 @@ def test_tmdb_cache_is_bounded(monkeypatch):
     assert "expired" not in provider._cache
     assert len(provider._cache) <= 10
     assert "fresh11" in provider._cache
+
+
+def test_provider_filter_uses_friendly_instance_labels() -> None:
+    js = Path("assets/js/playback_progress.js").read_text("utf-8")
+    block = js.split("function providerOptions(", 1)[1].split("function loadingCard(", 1)[0]
+
+    assert 'String(p.instance_label || "").trim() || profileLabel(p)' in block
+    assert "compactProfileLabel(p)" not in block
+    assert 'label: label || providerLabel(provider)' in block
+    assert 'label: label || "Default"' not in block
+
+
+def test_provider_pills_use_friendly_instance_labels() -> None:
+    js = Path("assets/js/playback_progress.js").read_text("utf-8")
+    pills = js.split("const providerPills = (it)", 1)[1].split("const profileLabel = (p)", 1)[0]
+    compact = js.split("const compactProfileLabel = (p)", 1)[1].split("const settingsProviderOrder", 1)[0]
+
+    assert "compactProfileLabel(p)" in pills
+    assert "return profileLabel(p);" in compact
+    assert "padStart(2" not in compact
+    assert 'if (id.toLowerCase() === "default") return "";' in compact
+
+
+def test_profile_label_drops_the_separator_left_by_the_prefix() -> None:
+    js = Path("assets/js/playback_progress.js").read_text("utf-8")
+    block = js.split("const profileLabel = (p)", 1)[1].split("const compactProfileLabel", 1)[0]
+
+    assert r'replace(/^[\s_-]+/, "")' in block
+
+
+def test_user_profile_filter_narrows_the_provider_instances() -> None:
+    from cw_platform.provider_instances import instances_for_user_profile
+    from services.playback_progress import get_service
+
+    cfg = {
+        "plex": {"instances": {"PLEX-P01": {"account_token": "t"}}},
+        "scrob": {"instances": {"SCROB-P01": {"server_url": "u", "api_key": "k", "username": "u", "password": "p"}}},
+        "user_profiles": {"up1": {"label": "Pazzie", "instances": {"PLEX": ["PLEX-P01"]}}},
+    }
+    service = get_service()
+
+    unscoped = {(s["provider"], s["instance_id"]) for s in service.provider_instances(cfg)}
+    scoped = {
+        (s["provider"], s["instance_id"])
+        for s in service.provider_instances(cfg, user_filter=instances_for_user_profile(cfg, "up1"))
+    }
+
+    assert ("plex", "PLEX-P01") in unscoped
+    assert ("scrob", "SCROB-P01") in unscoped
+    assert scoped == {("plex", "PLEX-P01")}
+
+
+def test_playback_page_has_a_hidden_user_profile_filter() -> None:
+    js = Path("assets/js/playback_progress.js").read_text("utf-8")
+
+    assert '<select class="pp-field hidden" id="pp-user-profile"' in js
+    assert '<option value="">All User Profiles</option>' in js
+
+
+def test_user_profile_filter_is_admin_only_and_hides_without_profiles() -> None:
+    js = Path("assets/js/playback_progress.js").read_text("utf-8")
+    rows = js.split("function userProfiles(", 1)[1].split("function userProfileOptions(", 1)[0]
+    opts = js.split("function userProfileOptions(", 1)[1].split("function providerOptions(", 1)[0]
+
+    assert "if (!op?.isAdmin) return [];" in rows
+    assert 'select.classList.toggle("hidden", !rows.length);' in opts
+    assert "if (!rows.length) return;" in opts
+
+
+def test_user_profile_filter_overrides_the_global_picker() -> None:
+    js = Path("assets/js/playback_progress.js").read_text("utf-8")
+    block = js.split("function query(", 1)[1].split("async function load(", 1)[0]
+
+    assert 'const scoped = String(state.filters.user_profile || "").trim();' in block
+    assert "state.userProfileTouched" in block
+    assert 'params.set("user_profile", profileId)' in block
+
+
+def test_user_profile_filter_mirrors_the_global_picker_until_touched() -> None:
+    js = Path("assets/js/playback_progress.js").read_text("utf-8")
+    block = js.split("function userProfileOptions(", 1)[1].split("function providerOptions(", 1)[0]
+
+    assert "state.userProfileTouched" in block
+    assert 'String(window.CW?.OverviewProfile?.id || "")' in block
+
+
+def test_settings_modal_shows_profile_names_without_the_provider() -> None:
+    js = Path("assets/js/playback_progress.js").read_text("utf-8")
+    block = js.split("const settingsProfileLabel = (p)", 1)[1].split("const settingsProviderCard", 1)[0]
+
+    assert "return profileLabel(p);" in block
+    assert "String(p.instance_label || id)" not in block
+    assert 'if (id === "default") return "Default";' in block

--- a/tests/test_playback_progress_unconfigured_default.py
+++ b/tests/test_playback_progress_unconfigured_default.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cw_platform.provider_instances import build_provider_config_view
+from services.playback_progress import get_service
+from services.playback_progress.service import _profile_has_explicit_identity
+
+
+SCROB_CREDS = {"server_url": "http://scrob.local", "api_key": "k", "username": "u", "password": "p"}
+NAMED_ONLY = {"scrob": {"instances": {"SCROB-P01": dict(SCROB_CREDS)}}}
+
+
+def _scrob_specs(cfg: Any) -> list[str]:
+    return [s["instance_id"] for s in get_service().provider_instances(cfg) if s["provider"] == "scrob"]
+
+
+def test_unconfigured_default_is_not_enumerated() -> None:
+    assert _profile_has_explicit_identity(NAMED_ONLY, "scrob", "default") is False
+
+
+def test_named_profile_is_enumerated() -> None:
+    assert _profile_has_explicit_identity(NAMED_ONLY, "scrob", "SCROB-P01") is True
+
+
+def test_only_the_named_profile_reaches_the_refresh() -> None:
+    assert _scrob_specs(NAMED_ONLY) == ["SCROB-P01"]
+
+
+def test_legacy_single_instance_default_still_enumerated() -> None:
+    cfg = {"scrob": dict(SCROB_CREDS)}
+
+    assert _profile_has_explicit_identity(cfg, "scrob", "default") is True
+    assert _scrob_specs(cfg) == ["default"]
+
+
+@pytest.mark.parametrize(
+    "cfg",
+    [
+        {"plex": {"account_token": "tok"}},
+        {"plex": {"account_token": "tok", "instances": {"PLEX-P01": {"account_token": "t2"}}}},
+    ],
+    ids=["legacy_only", "legacy_plus_named"],
+)
+def test_configured_default_is_still_enumerated(cfg: dict[str, Any]) -> None:
+    assert _profile_has_explicit_identity(cfg, "plex", "default") is True
+
+
+def test_configured_default_still_reports_readable_capabilities() -> None:
+    cfg = {"scrob": dict(SCROB_CREDS)}
+    adapter = get_service()._adapter("scrob")
+    assert adapter is not None
+
+    cap = adapter.capabilities(
+        build_provider_config_view(cfg, "scrob", "default"),
+        instance_id="default",
+        instance_label="Default",
+    )
+
+    assert cap.configured is True
+    assert cap.read is True
+
+
+def test_crosswatch_default_is_always_enumerated(tmp_path) -> None:
+    cfg = {"crosswatch": {"root_dir": str(tmp_path), "instances": {"CW-P01": {"label": "Desk"}}}}
+
+    assert _profile_has_explicit_identity(cfg, "crosswatch", "default") is True
+    assert _profile_has_explicit_identity(cfg, "crosswatch", "CW-P01") is True
+    assert _profile_has_explicit_identity(cfg, "crosswatch", "CW-NOPE") is False


### PR DESCRIPTION
# Pull request

## Change

- New User profile filter on the playback page, admin only, hidden when there are no profiles
- It follows the overview picker until you change it, then it wins for that page
- Unconfigured default profiles are no longer listed or refreshed, so scrob stops erroring
- Provider and settings dropdowns show friendly profile names instead of P01

## Why

- Picking a profile in the overview did not carry over to playback
- A default profile was always enumerated even when nothing was configured for it.

## Testing

- tests/test_playback_progress.py 
- tests/test_playback_progress_unconfigured_default.py

## Issue

NA
