### PR TITLE
Fix: forced status refresh no longer serves a stale

### DIFF
--- a/api/probesAPI.py
+++ b/api/probesAPI.py
@@ -2051,7 +2051,7 @@ def register_probes(app: FastAPI, load_config_fn: Callable[[], dict[str, Any]]) 
             enabled_pairs = [p for p in pairs if isinstance(p, dict) and p.get("enabled", True) is not False]
             any_pair_ready = any(_pair_ready(cfg, p) for p in enabled_pairs)
 
-            probe_age = 0 if fresh else PROBE_TTL
+            probe_age = PROBE_TTL
             user_age = USERINFO_TTL
 
             def _pair_targets() -> set[tuple[str, str]]:

--- a/assets/helpers/api.js
+++ b/assets/helpers/api.js
@@ -228,7 +228,10 @@
   const Status = {
     get(force = false){
       const profile = String(window.CW?.OverviewProfile?.id || "").trim();
-      const url = profile ? `/api/status?user_profile=${encodeURIComponent(profile)}` : '/api/status';
+      const qs = [];
+      if (profile) qs.push(`user_profile=${encodeURIComponent(profile)}`);
+      if (force) qs.push('fresh=1');
+      const url = qs.length ? `/api/status?${qs.join('&')}` : '/api/status';
       return memo(`${KEY.status}:${profile || "all"}`, TTL.status, () => j(url), force);
     }
   };

--- a/assets/helpers/core.js
+++ b/assets/helpers/core.js
@@ -823,7 +823,7 @@
       await refreshPairedProviders(force ? 0 : 5000);
       const payload = typeof API.Status?.get === "function"
         ? await API.Status.get(!!force)
-        : await requestJSON("/api/status", {}, 15000);
+        : await requestJSON(force ? "/api/status?fresh=1" : "/api/status", {}, 15000);
       state.appDebug = !!payload?.debug;
       const providers = extractProviderStatus(payload);
       renderConnectorStatus(providers, { stale: false });

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -2789,7 +2789,7 @@ def test_status_frontend_sends_selected_profile() -> None:
     api_js = Path("assets/helpers/api.js").read_text("utf-8")
     core_js = Path("assets/helpers/core.js").read_text("utf-8")
 
-    assert "`/api/status?user_profile=${encodeURIComponent(profile)}`" in api_js
+    assert "qs.push(`user_profile=${encodeURIComponent(profile)}`)" in api_js
     assert '`${KEY.status}:${profile || "all"}`' in api_js
     assert "key === KEY.pairs || key === KEY.status" in api_js
     assert "const statusCacheKey = ()" in core_js

--- a/tests/test_status_force_refresh.py
+++ b/tests/test_status_force_refresh.py
@@ -1,0 +1,132 @@
+# CrossWatch test scripts
+from __future__ import annotations
+
+import copy
+import pathlib
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.probesAPI as probes
+import providers.auth._auth_SCROB as scrob_auth
+
+
+PROFILE = "SCROB-P01"
+
+
+def _cfg(instance: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "scrob": {
+            "server_url": "",
+            "api_key": "",
+            "username": "",
+            "password": "",
+            "access_token": "",
+            "expires_at": 0,
+            "instances": {PROFILE: dict(instance)},
+        },
+        "pairs": [],
+    }
+
+
+CONNECTED = {
+    "server_url": "http://host:7330",
+    "api_key": "KEY",
+    "username": "frank",
+    "password": "pw",
+    "api_prefix": "/api/proxy",
+    "access_token": "TOKEN",
+    "expires_at": 4102444800,
+    "label": "SC-Frank",
+}
+
+
+class _Ok:
+    status_code = 200
+
+    def json(self) -> dict[str, Any]:
+        return {"id": 42, "username": "frank"}
+
+
+def _client(monkeypatch, state: dict[str, Any]) -> TestClient:
+    monkeypatch.setattr(scrob_auth.ScrobClient, "request", lambda self, method, path, **kw: _Ok())
+    probes.STATUS_CACHE["data"] = None
+    probes.STATUS_CACHE["ts"] = 0
+    probes.PROBE_DETAIL_CACHE.clear()
+    app = FastAPI()
+    probes.register_probes(app, lambda: copy.deepcopy(state["cfg"]))
+    return TestClient(app)
+
+
+def _connected(client: TestClient, url: str) -> Any:
+    providers = client.get(url).json().get("providers") or {}
+    return (providers.get("SCROB") or {}).get("connected")
+
+
+def test_fresh_status_sees_a_profile_connected_after_the_cache_was_warmed_empty(monkeypatch) -> None:
+    state = {"cfg": _cfg({})}
+    client = _client(monkeypatch, state)
+
+    assert _connected(client, "/api/status") is False
+
+    state["cfg"] = _cfg(CONNECTED)
+
+    assert _connected(client, "/api/status") is False
+    assert _connected(client, "/api/status?fresh=1") is True
+
+
+def test_status_cache_still_serves_repeat_calls_without_the_fresh_flag(monkeypatch) -> None:
+    state = {"cfg": _cfg(CONNECTED)}
+    client = _client(monkeypatch, state)
+
+    assert _connected(client, "/api/status") is True
+
+    state["cfg"] = _cfg({})
+
+    assert _connected(client, "/api/status") is True
+    assert _connected(client, "/api/status?fresh=1") is False
+
+
+def test_a_fresh_refresh_does_not_reprobe_providers_that_did_not_change(monkeypatch) -> None:
+    state = {"cfg": _cfg(CONNECTED)}
+    state["cfg"]["plex"] = {"account_token": "PT"}
+    state["cfg"]["trakt"] = {"client_id": "CID", "access_token": "TT", "expires_at": 4102444800}
+    client = _client(monkeypatch, state)
+    probes._USERINFO_CACHE.clear()
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        probes,
+        "_http_get",
+        lambda url, headers=None, timeout=None, **kw: (calls.append(url), (200, '{"user_id":1,"username":"u","ids":{"slug":"u"}}'))[1],
+    )
+    monkeypatch.setattr(scrob_auth.ScrobClient, "request", lambda self, method, path, **kw: (calls.append(self.url_for(path, prefix=kw.get("prefix"))), _Ok())[1])
+
+    client.get("/api/status")
+    calls.clear()
+
+    client.get("/api/status?fresh=1")
+    assert calls == []
+
+    changed = dict(CONNECTED)
+    changed["api_key"] = "ROTATED"
+    state["cfg"] = _cfg(changed)
+    state["cfg"]["plex"] = {"account_token": "PT"}
+    state["cfg"]["trakt"] = {"client_id": "CID", "access_token": "TT", "expires_at": 4102444800}
+
+    assert _connected(client, "/api/status?fresh=1") is True
+    assert calls
+    assert all("7330" in url for url in calls)
+
+
+def test_client_sends_the_fresh_flag_only_on_a_forced_status_refresh() -> None:
+    api_js = pathlib.Path("assets/helpers/api.js").read_text(encoding="utf-8")
+    lines = api_js.split("\n")
+    start = next(i for i, line in enumerate(lines) if "const qs = [];" in line)
+    body = "\n".join(line.strip() for line in lines[start - 1:start + 4])
+
+    assert "if (force) qs.push('fresh=1');" in body
+
+    core_js = pathlib.Path("assets/helpers/core.js").read_text(encoding="utf-8")
+    assert 'requestJSON(force ? "/api/status?fresh=1" : "/api/status", {}, 15000)' in core_js


### PR DESCRIPTION
# Pull request

## Change

- Send `fresh=1` when the UI forces a status refresh
- Keep the per provider probe cache on a forced refresh, so only providers whose credentials changed get contacted
- Normal refreshes are unchanged and still use the 60s cache

## Why

- Connecting a provider profile and saving left the card stuck on check connection
- The forced refresh only skipped the browser memo, so the server replayed the payload it cached before the save
- Nothing polls status, so it never corrected itself until the manual refresh button
- The same payload drives the Run button, so that could stay disabled for the same reason

## Testing

- `tests/test_status_force_refresh.py`

## Issue

Relates to #728
