### PR TITLE
Add: filters for Agregarrr trailers in scrobbler

### DIFF
--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -48,6 +48,11 @@ ALLOWED_FILTER_KEYS = {
     "server_uuid_whitelist",
     "server_uuid_blacklist",
     "ignore_live_tv_dvr",
+    "ignore_agregarr_trailers",
+    "ignored_path_prefixes",
+    "ignored_filename_patterns",
+    "ignored_editions",
+    "ignored_marker_files",
 }
 WEBHOOK_SETTING_KEYS = {
     "enabled",
@@ -247,6 +252,11 @@ def _normalize_filters(value: Any, provider: str, field: str = "filters") -> dic
         out["server_uuid_blacklist"] = _as_list(value.get("server_uuid_blacklist"))
     if provider == "plex" and "ignore_live_tv_dvr" in value:
         out["ignore_live_tv_dvr"] = bool(value.get("ignore_live_tv_dvr"))
+    if "ignore_agregarr_trailers" in value:
+        out["ignore_agregarr_trailers"] = bool(value.get("ignore_agregarr_trailers"))
+    for key in ("ignored_path_prefixes", "ignored_filename_patterns", "ignored_editions", "ignored_marker_files"):
+        if key in value:
+            out[key] = _as_list(value.get(key))
     return out
 
 

--- a/assets/js/modals/scrobbler-route/index.js
+++ b/assets/js/modals/scrobbler-route/index.js
@@ -410,9 +410,13 @@ function filtersPanel(r, f) {
     rows.push(filterRow({ title: "Server UUID allowlist", subtitle: "Control which servers are allowed.", id: "scr-allow", value: listText(f.server_uuid_whitelist || (f.server_uuid ? [f.server_uuid] : [])), placeholder: "One server UUID per line", dot: "scrm-dot-allow", addLabel: "server UUID", actionAttr: `data-fetch-uuid="scr-allow"`, actionIcon: "search", actionTitle: "Fetch server UUID" }));
     rows.push(filterRow({ title: "Server UUID blocklist", subtitle: "Control which servers are blocked.", id: "scr-block", value: listText(f.server_uuid_blacklist), placeholder: "One server UUID per line", dot: "scrm-dot-block", addLabel: "server UUID", actionAttr: `data-fetch-uuid="scr-block"`, actionIcon: "search", actionTitle: "Fetch server UUID" }));
   }
-  const toggle = isPlex
-    ? `<label class="scrm-toggle-row"><span class="scrm-toggle-copy"><span class="material-symbols-rounded">live_tv</span><span><strong>Ignore Plex Live TV &amp; DVR</strong><small>Skip scrobbles from live channels and DVR recordings.</small></span></span><span class="scrm-switch"><input type="checkbox" id="scr-live" ${f.ignore_live_tv_dvr ? "checked" : ""}><span class="scrm-switch-track"></span></span></label>`
-    : "";
+  rows.push(filterRow({ title: "Ignored path prefixes", subtitle: "Skip media files under these placeholder folders.", id: "scr-ignore-paths", value: listText(f.ignored_path_prefixes), placeholder: "One path prefix per line", dot: "scrm-dot-block", addLabel: "path" }));
+  rows.push(filterRow({ title: "Ignored filename patterns", subtitle: "Skip media files whose filename contains these values.", id: "scr-ignore-patterns", value: listText(f.ignored_filename_patterns), placeholder: "{edition-Trailer}", dot: "scrm-dot-block", addLabel: "pattern" }));
+  rows.push(filterRow({ title: "Ignored editions", subtitle: "Skip media with these edition names.", id: "scr-ignore-editions", value: listText(f.ignored_editions), placeholder: "Trailer", dot: "scrm-dot-block", addLabel: "edition" }));
+  const toggles = [
+    `<label class="scrm-toggle-row"><span class="scrm-toggle-copy"><span class="material-symbols-rounded">movie_filter</span><span><strong>Ignore Agregarr placeholder trailers</strong><small>Skip files marked as Trailer editions or stored beside .comingsoon markers.</small></span></span><span class="scrm-switch"><input type="checkbox" id="scr-ignore-agregarr" ${f.ignore_agregarr_trailers ? "checked" : ""}><span class="scrm-switch-track"></span></span></label>`,
+  ];
+  if (isPlex) toggles.push(`<label class="scrm-toggle-row"><span class="scrm-toggle-copy"><span class="material-symbols-rounded">live_tv</span><span><strong>Ignore Plex Live TV &amp; DVR</strong><small>Skip scrobbles from live channels and DVR recordings.</small></span></span><span class="scrm-switch"><input type="checkbox" id="scr-live" ${f.ignore_live_tv_dvr ? "checked" : ""}><span class="scrm-switch-track"></span></span></label>`);
   return `
     <section class="scrm-panel ${activeTab === "filters" ? "active" : ""}" data-panel="filters">
       <div class="scrm-journey scrm-journey-compact">
@@ -421,7 +425,7 @@ function filtersPanel(r, f) {
         ${journeyHelp("scrobbler-filters")}
       </div>
       <div class="scrm-filter-rows">${rows.join("")}</div>
-      ${toggle}
+      ${toggles.join("")}
     </section>
   `;
 }
@@ -539,7 +543,7 @@ function render(errors = []) {
         <div class="scrm-panel-shell" data-scrm-provider="${esc(r.provider)}">
           <nav class="cw-subtiles scrm-nav" aria-label="Route sections">
             ${navButton("route", "route", "Route", "Source and destination")}
-            ${navButton("filters", "filter_alt", "Filters", "Users and server IDs")}
+            ${navButton("filters", "filter_alt", "Filters", "Users and media")}
             ${navButton("options", "tune", "Options", "Watchlist and thresholds")}
             ${r.provider === "plex" ? navButton("ratings", "star", "Ratings", "Plex webhook") : ""}
           </nav>
@@ -576,6 +580,10 @@ function collect() {
     server_uuid: allow[0] || "",
     server_uuid_whitelist: allow,
     server_uuid_blacklist: split(root.querySelector("#scr-block")?.value),
+    ignore_agregarr_trailers: !!root.querySelector("#scr-ignore-agregarr")?.checked,
+    ignored_path_prefixes: split(root.querySelector("#scr-ignore-paths")?.value),
+    ignored_filename_patterns: split(root.querySelector("#scr-ignore-patterns")?.value),
+    ignored_editions: split(root.querySelector("#scr-ignore-editions")?.value),
   };
   if (provider === "plex") filters.ignore_live_tv_dvr = !!root.querySelector("#scr-live")?.checked;
   const scrobble = {};

--- a/assets/js/modals/scrobbler-webhook/index.js
+++ b/assets/js/modals/scrobbler-webhook/index.js
@@ -474,6 +474,9 @@ function filtersPanel(provider, filt) {
     rows.push(filterRow({ title: "Server UUID allowlist", subtitle: "Control which servers are allowed.", id: "scw-allow", value: valuesText(filt.server_uuid_whitelist || (filt.server_uuid ? [filt.server_uuid] : [])), placeholder: "One server UUID per line", dot: "scrm-dot-allow", addLabel: "server UUID", actionAttr: `data-fetch-uuid="scw-allow"`, actionIcon: "search", actionTitle: "Fetch server UUID" }));
     rows.push(filterRow({ title: "Server UUID blocklist", subtitle: "Control which servers are blocked.", id: "scw-block", value: valuesText(filt.server_uuid_blacklist), placeholder: "One server UUID per line", dot: "scrm-dot-block", addLabel: "server UUID", actionAttr: `data-fetch-uuid="scw-block"`, actionIcon: "search", actionTitle: "Fetch server UUID" }));
   }
+  rows.push(filterRow({ title: "Ignored path prefixes", subtitle: "Skip media files under these placeholder folders.", id: "scw-ignore-paths", value: valuesText(filt.ignored_path_prefixes), placeholder: "One path prefix per line", dot: "scrm-dot-block", addLabel: "path" }));
+  rows.push(filterRow({ title: "Ignored filename patterns", subtitle: "Skip media files whose filename contains these values.", id: "scw-ignore-patterns", value: valuesText(filt.ignored_filename_patterns), placeholder: "{edition-Trailer}", dot: "scrm-dot-block", addLabel: "pattern" }));
+  rows.push(filterRow({ title: "Ignored editions", subtitle: "Skip media with these edition names.", id: "scw-ignore-editions", value: valuesText(filt.ignored_editions), placeholder: "Trailer", dot: "scrm-dot-block", addLabel: "edition" }));
   return `
     <section class="scrm-panel ${activeTab === "filters" ? "active" : ""}" data-panel="filters">
       <div class="scrm-journey scrm-journey-compact">
@@ -482,6 +485,7 @@ function filtersPanel(provider, filt) {
         ${journeyHelp("scrobbler-filters")}
       </div>
       <div class="scrm-filter-rows">${rows.join("")}</div>
+      <label class="scrm-toggle-row"><span class="scrm-toggle-copy"><span class="material-symbols-rounded">movie_filter</span><span><strong>Ignore Agregarr placeholder trailers</strong><small>Skip files marked as Trailer editions or stored beside .comingsoon markers.</small></span></span><span class="scrm-switch"><input type="checkbox" id="scw-ignore-agregarr" ${filt.ignore_agregarr_trailers ? "checked" : ""}><span class="scrm-switch-track"></span></span></label>
     </section>
   `;
 }
@@ -588,7 +592,7 @@ function render(errs = []) {
         <div class="scrm-panel-shell" data-scrm-provider="${esc(provider)}">
           <nav class="cw-subtiles scrm-nav" aria-label="Webhook sections">
             ${navButton("source", "webhook", "Source", "Profile, destinations, URL")}
-            ${navButton("filters", "filter_alt", "Filters", "Users and server IDs")}
+            ${navButton("filters", "filter_alt", "Filters", "Users and media")}
             ${navButton("options", "tune", "Options", "Thresholds")}
             ${provider === "plex" ? navButton("ratings", "star", "Ratings", "Plex ratings") : ""}
           </nav>
@@ -630,7 +634,13 @@ function payload() {
     body.sink_instances = { [sink]: root.querySelector("#scw-sink-instance")?.value || "default" };
     if (originalSink && originalSink !== sink) body.prev_sink = originalSink;
   }
-  body.filters = { username_whitelist: splitValues(root.querySelector("#scw-users")?.value) };
+  body.filters = {
+    username_whitelist: splitValues(root.querySelector("#scw-users")?.value),
+    ignore_agregarr_trailers: !!root.querySelector("#scw-ignore-agregarr")?.checked,
+    ignored_path_prefixes: splitValues(root.querySelector("#scw-ignore-paths")?.value),
+    ignored_filename_patterns: splitValues(root.querySelector("#scw-ignore-patterns")?.value),
+    ignored_editions: splitValues(root.querySelector("#scw-ignore-editions")?.value),
+  };
   if (provider === "plex") {
     body.filters.server_uuid_whitelist = splitValues(root.querySelector("#scw-allow")?.value);
     body.filters.server_uuid_blacklist = splitValues(root.querySelector("#scw-block")?.value);

--- a/assets/js/scrobbler.js
+++ b/assets/js/scrobbler.js
@@ -80,11 +80,25 @@
     const users = Array.isArray(filters.username_whitelist) ? filters.username_whitelist : [];
     const allow = Array.isArray(filters.server_uuid_whitelist) ? filters.server_uuid_whitelist : [];
     const block = Array.isArray(filters.server_uuid_blacklist) ? filters.server_uuid_blacklist : [];
+    const paths = Array.isArray(filters.ignored_path_prefixes) ? filters.ignored_path_prefixes : [];
+    const patterns = Array.isArray(filters.ignored_filename_patterns) ? filters.ignored_filename_patterns : [];
+    const editions = Array.isArray(filters.ignored_editions) ? filters.ignored_editions : [];
     if (users.length) parts.push(`${users.length} user${users.length === 1 ? "" : "s"}`);
     if (allow.length || filters.server_uuid) parts.push(`${allow.length || 1} UUID allow`);
     if (block.length) parts.push(`${block.length} UUID block`);
+    if (filters.ignore_agregarr_trailers) parts.push("Agregarr ignored");
+    if (paths.length) parts.push(`${paths.length} path ignored`);
+    if (patterns.length) parts.push(`${patterns.length} pattern ignored`);
+    if (editions.length) parts.push(`${editions.length} edition ignored`);
     if (filters.ignore_live_tv_dvr) parts.push("Live TV ignored");
     return parts.length ? parts.join(" - ") : "No filters";
+  }
+
+  function webhookFilterSummary(row = {}) {
+    const provider = String(row.provider || "").toLowerCase();
+    const key = provider === "plex" ? "filters_plex" : provider === "jellyfin" ? "filters_jellyfin" : "filters_emby";
+    const settings = row.effective_settings || {};
+    return routeFilterSummary(settings[key] || {});
   }
 
   function renderHeader(o) {
@@ -139,6 +153,7 @@
               <div class="sc2-route-meta">
                 <span class="sc2-route-type"><span class="material-symbols-rounded">webhook</span>Webhook</span>
                 <span class="sc2-route-id">${esc(text)}</span>
+                <span class="sc2-route-filters sc2-muted">${esc(webhookFilterSummary(x))}</span>
               </div>
               <div class="sc2-route-actions">
                 <button type="button" class="btn small sc2-round-action sc2-route-toggle ${x.enabled ? "is-on" : "is-off"}" data-action="toggle-webhook" data-provider="${esc(x.provider)}" data-instance="${esc(x.provider_instance)}" data-sink="${esc(x.sink)}" title="${esc(x.enabled ? "Disable source webhooks" : "Enable source webhooks")}" aria-label="${esc(x.enabled ? "Disable source webhooks" : "Enable source webhooks")}"><span class="material-symbols-rounded">power_settings_new</span><span>${x.enabled ? "On" : "Off"}</span></button>

--- a/issues/scrobbler-filters-endusers.md
+++ b/issues/scrobbler-filters-endusers.md
@@ -1,0 +1,169 @@
+# Scrobbler filters - end users
+
+Filters let you control which playback events CrossWatch accepts for Watcher routes and Webhook profiles.
+
+Start with empty filters first. Confirm one movie or episode scrobbles correctly, then add only the filters you need.
+
+## Filter dots
+
+Filter rows use color hints:
+
+* Green dots are allow filters. The event must match when values are set.
+* Red dots are block or ignore filters. Matching events are skipped.
+
+For example, **Username whitelist** is green because it allows selected users. **Ignored filename patterns** is red because matching media is ignored.
+
+Route and webhook cards show a short filter summary, such as `1 user`, `1 UUID allow`, `Agregarr ignored`, `1 pattern ignored`, or `Live TV ignored`.
+
+## Filter scope
+
+Watcher and Webhooks store filters differently.
+
+### Watcher filters
+
+Watcher filters belong to each route.
+
+Two routes from one media server profile can use different filters.
+
+Example:
+
+* Plex Home to Trakt Pascal, with username `Pascal`
+* Plex Home to Trakt Family, with username `Family`
+
+### Webhook filters
+
+Webhook filters belong to the media server profile.
+
+Every tracker destination attached to that profile uses the same webhook filter.
+
+Example: Plex Home can send to both Trakt and SIMKL. Changing its webhook filter changes it for both destinations.
+
+Use Watcher routes when each destination needs different filtering.
+
+## Username whitelist
+
+Use **Username whitelist** to accept playback only from selected users.
+
+Leave it empty to accept all users.
+
+Use the user picker when possible. It uses names returned by the selected media server profile.
+
+## Plex Server UUID lists
+
+Plex supports a Server UUID allowlist and blocklist.
+
+Use the allowlist when only specific Plex servers may send events:
+
+* Empty allowlist: every UUID is accepted unless blocked.
+* Filled allowlist: only matching UUID values are accepted.
+* Matching is exact.
+
+Use the blocklist to reject specific Plex servers.
+
+The blocklist wins over the allowlist. If a UUID appears in both lists, CrossWatch rejects the event.
+
+## Ignore Plex Live TV and DVR
+
+Enable **Ignore Plex Live TV and DVR** to skip Plex Live TV and DVR playback.
+
+This option is available for Plex Watcher routes.
+
+## Ignore Agregarr placeholder trailers
+
+Enable **Ignore Agregarr placeholder trailers** when Agregarr creates placeholder movie folders with trailer files.
+
+CrossWatch skips media that looks like an Agregarr trailer placeholder, including:
+
+* files with `{edition-Trailer}` in the filename
+* media with edition name `Trailer`
+* media stored beside a `.comingsoon` marker file
+
+This checks the file path, filename, edition, and marker files. It does not reject a movie just because the movie title contains the word trailer.
+
+Example skipped file:
+
+```text
+/data/media/placeholder/movies/The Odyssey (2026)/The Odyssey (2026) {tmdb-1368337} {edition-Trailer}.mp4
+```
+
+## Ignored media filters
+
+Use these when you want to skip files based on where they are stored or how they are named.
+
+### Ignored path prefixes
+
+Skips media under matching paths.
+
+Good for placeholder folders, trailer folders, or temporary media roots.
+
+Examples:
+
+```text
+/data/media/placeholder
+Z:\data\media\placeholder
+```
+
+### Ignored filename patterns
+
+Skips media when the filename contains one of the values.
+
+Examples:
+
+```text
+{edition-Trailer}
+-trailer
+/sample
+```
+
+### Ignored editions
+
+Skips media when the edition or version name matches.
+
+Example:
+
+```text
+Trailer
+```
+
+## Provider support
+
+These media ignore filters work for Watcher and Webhooks when the source sends enough media detail.
+
+Supported well:
+
+* Plex Watcher
+* Jellyfin Watcher
+* Emby Watcher
+* Kodi Watcher
+* Plex Webhooks
+* Jellyfin Webhooks
+* Emby Webhooks
+
+Scrob can also be filtered when the incoming payload includes file path, filename, or edition fields.
+
+## Troubleshooting
+
+### No events pass
+
+1. Clear **Username whitelist**.
+2. Clear Plex UUID allowlist and blocklist.
+3. Disable **Ignore Plex Live TV and DVR** for testing.
+4. Disable media ignore filters for testing.
+5. Start a new playback session.
+6. Check the source profile connection.
+7. Review debug logs for the rejected field.
+
+### A trailer still scrobbles
+
+1. Confirm the media source sends a file path or edition.
+2. Add the placeholder folder to **Ignored path prefixes**.
+3. Add `{edition-Trailer}` to **Ignored filename patterns**.
+4. Add `Trailer` to **Ignored editions**.
+5. Start a new playback session.
+
+### Wrong user is scrobbled
+
+1. Use the user picker.
+2. Verify the route or webhook scope.
+3. Confirm the destination profile belongs to that user.
+4. Check for another route or webhook without filters.

--- a/issues/scrobbler-filters-powerusers.md
+++ b/issues/scrobbler-filters-powerusers.md
@@ -1,0 +1,196 @@
+# Scrobbler filters - power users
+
+Filters control whether a playback event is accepted before CrossWatch sends it to a scrobble destination.
+
+Watcher routes use a route-level `filters` object.
+
+Webhook source profiles use provider-specific filters, such as `filters_plex`, `filters_jellyfin`, and `filters_emby`.
+
+## Matching behavior
+
+Username matching ignores letter case. It also normalizes punctuation and spaces for normal names.
+
+A nonmatching whitelist rejects the event. Without a username whitelist, the user filter passes.
+
+Advanced identity values are supported when the source event supplies them:
+
+```text
+id:123
+uuid:abcd1234
+```
+
+* `id:` compares account or user IDs.
+* `uuid:` compares account or user UUID values.
+
+Use advanced values only when normal username matching is ambiguous or unreliable.
+
+Webhook implementations can expose different user fields. Use the event log's exact username when the picker is unavailable.
+
+## Profiles, filters, and libraries
+
+Profiles and filters solve different problems.
+
+A source profile selects the connected server or account configuration. Filters select which events from that profile CrossWatch accepts.
+
+Example:
+
+* Profile: Plex Home Server
+* Username whitelist: Pascal
+* Server UUID allowlist: Home Server UUID
+
+Use profiles for connection separation. Use filters for event separation.
+
+Filters do not replace media server library whitelisting.
+
+Library whitelisting determines which libraries CrossWatch may use. Filters determine which incoming playback events are accepted.
+
+Changing a username or UUID filter cannot bypass a library whitelist rejection.
+
+## Media filter behavior
+
+Media ignore filters are case-insensitive.
+
+Path prefixes are normalized so Windows and Linux style paths can both match.
+
+Examples:
+
+```text
+Z:\data\media\placeholder
+/data/media/placeholder
+```
+
+Filename patterns use simple contains matching. They are not regex.
+
+Edition matching compares the detected edition or version name. `Trailer` matches `trailer`.
+
+When a media ignore filter matches, CrossWatch drops the event before sending scrobbles to Trakt, SIMKL, MDBList, or other destinations.
+
+## Agregarr placeholder trailers
+
+The Agregarr toggle is a shortcut for the common placeholder trailer setup:
+
+```json
+{
+  "ignore_agregarr_trailers": true
+}
+```
+
+It checks the built-in defaults:
+
+```text
+filename contains: {edition-trailer}
+edition equals: trailer
+marker file: .comingsoon
+```
+
+This is intentionally not title based. A title like `Trailer Park Boys` is not ignored unless the file path, filename, edition, or marker file matches.
+
+## Route filter example
+
+Watcher route filters use the normal route `filters` object:
+
+```json
+{
+  "filters": {
+    "users": ["Pascal"],
+    "ignore_agregarr_trailers": true,
+    "ignored_path_prefixes": ["/data/media/placeholder"],
+    "ignored_filename_patterns": ["{edition-Trailer}"],
+    "ignored_editions": ["Trailer"]
+  }
+}
+```
+
+## Webhook filter example
+
+Webhook filters are stored per source profile, so the provider key matters:
+
+```json
+{
+  "filters_plex": {
+    "ignore_agregarr_trailers": true,
+    "ignored_filename_patterns": ["{edition-Trailer}"]
+  },
+  "filters_jellyfin": {
+    "ignored_path_prefixes": ["/data/media/placeholder"]
+  },
+  "filters_emby": {
+    "ignored_editions": ["Trailer"]
+  }
+}
+```
+
+Every destination attached to that webhook source profile uses the same provider filter.
+
+Use Watcher routes when each destination needs its own filter set.
+
+## Supported media keys
+
+CrossWatch looks for path-like values in incoming payloads, including:
+
+```text
+path
+file
+filename
+filepath
+file_path
+mediafile
+media_file
+```
+
+It also checks internally enriched Plex values:
+
+```text
+_cw_file_path
+_cw_file_paths
+_cw_edition_title
+```
+
+Edition-like values include:
+
+```text
+edition
+editionTitle
+edition_title
+version
+versionTitle
+version_title
+```
+
+Nested payloads are searched too, so Jellyfin and Emby `NowPlayingItem.Path` style data can be matched.
+
+## Common mistakes
+
+### Using a display name
+
+The display name can differ from the event username. Use the picker or inspect incoming event logs.
+
+### Adding a Plex account ID without a prefix
+
+Use:
+
+```text
+id:123
+```
+
+Do not use:
+
+```text
+123
+```
+
+The `id:` prefix is required for an ID match.
+
+### Expecting different webhook filters per destination
+
+Webhook filters are shared by source profile. Use Watcher routes for destination-specific filtering.
+
+### Adding one UUID to both lists
+
+The blocklist wins. CrossWatch rejects the event.
+
+### Expecting Scrob to always have file paths
+
+Scrob can only apply path, filename, or edition filters when the incoming payload includes those fields.
+
+If the payload only contains metadata IDs and title information, media-file filters cannot match.

--- a/providers/scrobble/emby/watch.py
+++ b/providers/scrobble/emby/watch.py
@@ -16,6 +16,7 @@ except Exception:
 from cw_platform.config_base import load_config
 from providers.scrobble.scrobble import Dispatcher, ScrobbleSink, ScrobbleEvent, MediaType, mask_account as _mask_account
 from providers.scrobble.currently_watching import update_from_event as _cw_update, update_from_payload as _cw_update_payload
+from providers.scrobble.media_filters import event_ignore_reason, log_media_filter_drop
 from providers.scrobble.sources import source_enabled
 
 TRAKT_API = "https://api.trakt.tv"
@@ -758,6 +759,14 @@ class EmbyWatchService:
 
     def _passes_filters(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> bool:
         sk = str(ev.session_key or "")
+        ignore_reason = event_ignore_reason(ev, cfg)
+        if ignore_reason:
+            log_media_filter_drop(ev, ignore_reason)
+            if sk:
+                self._allowed_sessions.discard(sk)
+                self._scrobble_whitelist_sessions.discard(sk)
+            return False
+
         libs = self._scrobble_whitelist(cfg)
 
         if libs:

--- a/providers/scrobble/jellyfin/watch.py
+++ b/providers/scrobble/jellyfin/watch.py
@@ -16,6 +16,7 @@ except Exception:
 from cw_platform.config_base import load_config
 from providers.scrobble.scrobble import Dispatcher, ScrobbleSink, ScrobbleEvent, MediaType, mask_account as _mask_account
 from providers.scrobble.currently_watching import update_from_event as _cw_update, update_from_payload as _cw_update_payload
+from providers.scrobble.media_filters import event_ignore_reason, log_media_filter_drop
 from providers.scrobble.sources import source_enabled
 
 TRAKT_API = "https://api.trakt.tv"
@@ -756,6 +757,14 @@ class JellyfinWatchService:
 
     def _passes_filters(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> bool:
         sk = str(ev.session_key or "")
+        ignore_reason = event_ignore_reason(ev, cfg)
+        if ignore_reason:
+            log_media_filter_drop(ev, ignore_reason)
+            if sk:
+                self._allowed_sessions.discard(sk)
+                self._scrobble_whitelist_sessions.discard(sk)
+            return False
+
         libs = self._scrobble_whitelist(cfg)
 
         if libs:

--- a/providers/scrobble/media_filters.py
+++ b/providers/scrobble/media_filters.py
@@ -1,0 +1,220 @@
+# providers/scrobble/media_filters.py
+# CrossWatch - Scrobble media-level filters
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+try:
+    from _logging import log as BASE_LOG
+except Exception:
+    BASE_LOG = None
+
+
+DEFAULT_AGREGARR_FILENAME_PATTERNS = ("{edition-trailer}",)
+DEFAULT_AGREGARR_EDITIONS = ("trailer",)
+DEFAULT_AGREGARR_MARKER_FILES = (".comingsoon",)
+
+_PATH_KEYS = {
+    "path",
+    "file",
+    "filename",
+    "filepath",
+    "file_path",
+    "mediafile",
+    "media_file",
+    "_cw_file_path",
+    "_cw_file_paths",
+}
+_EDITION_KEYS = {
+    "edition",
+    "editiontitle",
+    "edition_title",
+    "version",
+    "versiontitle",
+    "version_title",
+    "_cw_edition_title",
+}
+
+
+def _log(msg: str, lvl: str = "DEBUG") -> None:
+    if BASE_LOG:
+        try:
+            BASE_LOG(str(msg), level=lvl, module="SCROBBLE")
+            return
+        except Exception:
+            pass
+
+
+def _as_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    items = value if isinstance(value, (list, tuple, set)) else [value]
+    out: list[str] = []
+    for item in items:
+        text = str(item or "").strip()
+        if text:
+            out.append(text)
+    return out
+
+
+def _norm_path(value: Any) -> str:
+    text = str(value or "").strip().replace("\\", "/")
+    while "//" in text:
+        text = text.replace("//", "/")
+    return text.rstrip("/").lower()
+
+
+def _basename(value: str) -> str:
+    text = str(value or "").strip().replace("\\", "/").rstrip("/")
+    return text.rsplit("/", 1)[-1].lower()
+
+
+def _walk_media_values(raw: Any) -> tuple[list[str], list[str]]:
+    paths: list[str] = []
+    editions: list[str] = []
+
+    def add_path(value: Any) -> None:
+        text = str(value or "").strip()
+        if text:
+            paths.append(text)
+
+    def add_edition(value: Any) -> None:
+        text = str(value or "").strip()
+        if text:
+            editions.append(text)
+
+    def add_many(value: Any, add_fn: Any) -> None:
+        if isinstance(value, Mapping):
+            walk(value)
+        elif isinstance(value, (list, tuple, set)):
+            for item in value:
+                add_many(item, add_fn)
+        else:
+            add_fn(value)
+
+    def walk(value: Any) -> None:
+        if isinstance(value, Mapping):
+            for key, item in value.items():
+                key_lc = str(key or "").strip().lower()
+                if key_lc in _PATH_KEYS:
+                    add_many(item, add_path)
+                    continue
+                if key_lc in _EDITION_KEYS:
+                    add_many(item, add_edition)
+                    continue
+                walk(item)
+        elif isinstance(value, (list, tuple, set)):
+            for item in value:
+                walk(item)
+
+    walk(raw)
+    return paths, editions
+
+
+def _path_matches_prefix(paths: list[str], prefixes: list[str]) -> str | None:
+    norm_prefixes = [_norm_path(prefix) for prefix in prefixes if _norm_path(prefix)]
+    if not norm_prefixes:
+        return None
+    for path in paths:
+        got = _norm_path(path)
+        if not got:
+            continue
+        for prefix in norm_prefixes:
+            if got == prefix or got.startswith(prefix + "/"):
+                return f"path_prefix:{prefix}"
+    return None
+
+
+def _path_matches_pattern(paths: list[str], patterns: list[str]) -> str | None:
+    needles = [str(pattern or "").strip().lower() for pattern in patterns if str(pattern or "").strip()]
+    if not needles:
+        return None
+    for path in paths:
+        haystacks = [_norm_path(path), _basename(path)]
+        for needle in needles:
+            if any(needle in hay for hay in haystacks):
+                return f"filename_pattern:{needle}"
+    return None
+
+
+def _edition_matches(editions: list[str], blocked: list[str]) -> str | None:
+    blocked_lc = {str(item or "").strip().lower() for item in blocked if str(item or "").strip()}
+    if not blocked_lc:
+        return None
+    for edition in editions:
+        got = str(edition or "").strip().lower()
+        if got and got in blocked_lc:
+            return f"edition:{got}"
+    return None
+
+
+def _marker_file_exists(paths: list[str], markers: list[str]) -> str | None:
+    marker_names = [str(marker or "").strip() for marker in markers if str(marker or "").strip()]
+    if not marker_names:
+        return None
+    for raw_path in paths:
+        text = str(raw_path or "").strip()
+        if not text or "://" in text:
+            continue
+        try:
+            parent = Path(text).parent
+            if not str(parent) or str(parent) == ".":
+                continue
+            for marker in marker_names:
+                if (parent / marker).exists():
+                    return f"marker_file:{marker}"
+        except Exception:
+            continue
+    return None
+
+
+def media_filter_ignore_reason(
+    filters: Mapping[str, Any] | None,
+    raw: Mapping[str, Any] | None,
+    *,
+    title: Any = None,
+) -> str | None:
+    filt = filters if isinstance(filters, Mapping) else {}
+    raw_map = raw if isinstance(raw, Mapping) else {}
+    paths, editions = _walk_media_values(raw_map)
+
+    custom_prefixes = _as_list(filt.get("ignored_path_prefixes"))
+    custom_patterns = _as_list(filt.get("ignored_filename_patterns"))
+    custom_editions = _as_list(filt.get("ignored_editions"))
+    custom_markers = _as_list(filt.get("ignored_marker_files"))
+
+    agregarr_on = bool(filt.get("ignore_agregarr_trailers"))
+    if agregarr_on:
+        custom_patterns = [*DEFAULT_AGREGARR_FILENAME_PATTERNS, *custom_patterns]
+        custom_editions = [*DEFAULT_AGREGARR_EDITIONS, *custom_editions]
+        custom_markers = [*DEFAULT_AGREGARR_MARKER_FILES, *custom_markers]
+
+    reason = _path_matches_prefix(paths, custom_prefixes)
+    if reason:
+        return reason
+    reason = _path_matches_pattern(paths, custom_patterns)
+    if reason:
+        return reason
+    reason = _edition_matches(editions, custom_editions)
+    if reason:
+        return reason
+    reason = _marker_file_exists(paths, custom_markers)
+    if reason:
+        return reason
+
+    return None
+
+
+def event_ignore_reason(event: Any, cfg: Mapping[str, Any] | None) -> str | None:
+    cfg_map = cfg if isinstance(cfg, Mapping) else {}
+    filt = (((cfg_map.get("scrobble") or {}).get("watch") or {}).get("filters") or {})
+    if not isinstance(filt, Mapping):
+        return None
+    return media_filter_ignore_reason(filt, getattr(event, "raw", None), title=getattr(event, "title", None))
+
+
+def log_media_filter_drop(event: Any, reason: str) -> None:
+    title = str(getattr(event, "title", "") or "?")
+    session = str(getattr(event, "session_key", "") or "?")
+    _log(f"event filtered by media filter: reason={reason} title={title!r} sess={session}", "DEBUG")

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -30,6 +30,7 @@ from providers.scrobble.scrobble import (
     mask_account as _mask_account,
 )
 from providers.scrobble.currently_watching import update_from_event as _cw_update, update_from_payload as _cw_update_payload
+from providers.scrobble.media_filters import event_ignore_reason, log_media_filter_drop
 from providers.scrobble.sources import source_enabled
 
 
@@ -773,6 +774,13 @@ class WatchService:
 
         cfg = self._active_cfg()
 
+        ignore_reason = event_ignore_reason(ev, cfg)
+        if ignore_reason:
+            log_media_filter_drop(ev, ignore_reason)
+            if cache_key:
+                self._allowed_sessions.discard(cache_key)
+            return False
+
         # # A whitelist must be validated per event
         libs = _as_set_str((((cfg.get("plex") or {}).get("scrobble") or {}).get("libraries")))
         if libs:
@@ -933,6 +941,35 @@ class WatchService:
             ids_raw: dict[str, Any] = dict(ev.ids or {}, plex=int(rk))
             ids_raw.update(_ids_from_guids_any(getattr(it, "guids", [])))
             ids = _normalize_ids(ids_raw)
+            raw = dict(ev.raw or {})
+            paths: list[str] = []
+            try:
+                parts = it.iterParts() if callable(getattr(it, "iterParts", None)) else []
+                for part in parts:
+                    file_val = getattr(part, "file", None)
+                    if file_val:
+                        paths.append(str(file_val))
+            except Exception:
+                pass
+            if not paths:
+                try:
+                    for media in getattr(it, "media", []) or []:
+                        for part in getattr(media, "parts", []) or []:
+                            file_val = getattr(part, "file", None)
+                            if file_val:
+                                paths.append(str(file_val))
+                except Exception:
+                    pass
+            if paths:
+                raw["_cw_file_paths"] = paths
+            for attr in ("editionTitle", "edition", "versionTitle"):
+                try:
+                    val = getattr(it, attr, None)
+                    if val:
+                        raw["_cw_edition_title"] = str(val)
+                        break
+                except Exception:
+                    pass
             season, number = ev.season, ev.number
             if media_type == "episode":
                 try:
@@ -960,7 +997,7 @@ class WatchService:
                 account=account,
                 server_uuid=ev.server_uuid,
                 session_key=ev.session_key,
-                raw=ev.raw,
+                raw=raw,
             )
         except Exception:
             return ev
@@ -1158,6 +1195,15 @@ class WatchService:
                 return
             ev = enriched
             sk = str(ev.session_key) if ev.session_key else None
+            ignore_reason = event_ignore_reason(ev, cfg)
+            if ignore_reason:
+                log_media_filter_drop(ev, ignore_reason)
+                if sk:
+                    cache_key = f"{sk}|{_norm_user(ev.account or '')}|{str(ev.server_uuid or '').strip().lower()}"
+                    self._allowed_sessions.discard(cache_key)
+                self._throttled_filtered_log(ev)
+                self._clear_currently_watching(ev)
+                return
             vo = None
             dur = None
             if isinstance(best_psn, dict):

--- a/providers/scrobble/scrobble.py
+++ b/providers/scrobble/scrobble.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Iterable, Literal, Protocol
 
 from cw_platform.account_match import media_account_allowed, normalize_media_account_name
+from providers.scrobble.media_filters import event_ignore_reason, log_media_filter_drop
 
 try:
     from _logging import log as BASE_LOG
@@ -384,6 +385,13 @@ class Dispatcher:
         cache_key: str | None = None
         if ev.session_key:
             cache_key = f"{ev.session_key}|{_norm_user(ev.account or '')}|{str(ev.server_uuid or '').strip().lower()}"
+
+        ignore_reason = event_ignore_reason(ev, cfg)
+        if ignore_reason:
+            log_media_filter_drop(ev, ignore_reason)
+            return False
+
+        if cache_key:
             if cache_key in self._session_ok:
                 return True
 

--- a/providers/webhooks/dispatch.py
+++ b/providers/webhooks/dispatch.py
@@ -10,6 +10,7 @@ from typing import Any
 from cw_platform.provider_instances import normalize_instance_id
 from cw_platform.access_policy import webhook_effective_profile_id
 from cw_platform.user_profile_resources import webhook_assigned_profile_id, webhook_resource_id
+from providers.scrobble.media_filters import event_ignore_reason, log_media_filter_drop
 from providers.scrobble.scrobble import ScrobbleAction, ScrobbleEvent
 from providers.webhooks.config import sink_configured, webhook_settings, webhook_sink_instance, webhook_sinks
 
@@ -221,12 +222,18 @@ def dispatch_scrobble(
     dispatched: list[str] = []
     for sink in sinks:
         inst = webhook_sink_instance(wh, sink)
+        route_cfg = _route_cfg(cfg, provider_lc, provider_inst, sink, inst)
+        ignore_reason = event_ignore_reason(ev, route_cfg)
+        if ignore_reason:
+            log_media_filter_drop(ev, ignore_reason)
+            _emit(logger, f"webhook sink {sink}:{inst} skipped by media filter: {ignore_reason}", "DEBUG")
+            targets.append({"target": sink, "target_instance": inst, "ok": True, "skipped": True, "ignored": True, "reason": ignore_reason})
+            continue
         if not sink_configured(cfg, sink, inst):
             targets.append({"target": sink, "target_instance": inst, "ok": False, "skipped": True, "error": "not_configured"})
             _emit(logger, f"webhook sink {sink}:{inst} skipped: not configured in Connections", "WARNING")
             continue
         dispatched.append(sink)
-        route_cfg = _route_cfg(cfg, provider_lc, provider_inst, sink, inst)
 
         def _provider(route_cfg: dict[str, Any] = route_cfg) -> dict[str, Any]:
             return route_cfg
@@ -244,7 +251,7 @@ def dispatch_scrobble(
         "action": path,
         "status": 200 if ok else 502,
         "route_dispatch": True,
-        "activity_recorded": True,
+        "activity_recorded": any(not bool(t.get("skipped")) and bool(t.get("ok")) for t in targets),
         "targets": targets,
     }
     _emit(logger, f"webhook dispatch {path} -> {','.join(dispatched) or 'none'} status={payload['status']}", "DEBUG")

--- a/providers/webhooks/emby.py
+++ b/providers/webhooks/emby.py
@@ -1116,9 +1116,10 @@ def process_webhook(
             f"webhook {intended} -> {r.status_code}",
             "DEBUG",
         )
+        activity_recorded = bool(rj.get("activity_recorded")) if isinstance(rj, dict) else False
 
         if r.status_code < 400:
-            if intended == "/scrobble/stop" and prog >= watched_at and not st.get("wl_removed") is True:
+            if activity_recorded and intended == "/scrobble/stop" and prog >= watched_at and not st.get("wl_removed") is True:
                 try:
                     _call_remove_across(ids_all or {}, media_type, origin=f"emby:{provider_instance}")
                     st = {**st, "wl_removed": True}
@@ -1130,7 +1131,7 @@ def process_webhook(
                 "last_event": ev_lc,
                 "last_pause_ts": now if intended == "pause" else st.get("last_pause_ts", 0.0),
                 "prog": prog,
-                "finished": intended == "/scrobble/stop" and prog >= watched_at,
+                "finished": activity_recorded and intended == "/scrobble/stop" and prog >= watched_at,
                 **({"wl_removed": st.get("wl_removed")} if st.get("wl_removed") else {}),
                 "paused": intended == "pause",
                 **({"last_stop_ts": now} if intended == "/scrobble/stop" else {}),
@@ -1148,11 +1149,11 @@ def process_webhook(
             except Exception:
                 pass
 
-            if "trakt" in sinks_cfg and intended == "/scrobble/start":
+            if activity_recorded and "trakt" in sinks_cfg and intended == "/scrobble/start":
                 _archive("scrobble_started", media_type, md, payload, ids_all, acc_title, prog)
-            elif "trakt" in sinks_cfg and intended == "/scrobble/stop" and prog >= watched_at:
+            elif activity_recorded and "trakt" in sinks_cfg and intended == "/scrobble/stop" and prog >= watched_at:
                 _archive("scrobble_completed", media_type, md, payload, ids_all, acc_title, prog)
-            return {"ok": True, "status": 200, "action": intended, "trakt": rj}
+            return {"ok": True, "status": 200, "action": intended, "trakt": rj, "ignored": not activity_recorded}
 
         _emit(logger, f"{intended} {r.status_code} {(str(rj)[:180])}", "ERROR")
         if "trakt" in sinks_cfg and intended in ("/scrobble/start", "/scrobble/stop"):

--- a/providers/webhooks/jellyfin.py
+++ b/providers/webhooks/jellyfin.py
@@ -1496,11 +1496,12 @@ def process_webhook(
             f"webhook {intended} -> {r.status_code}",
             "DEBUG",
         )
+        activity_recorded = bool(rj.get("activity_recorded")) if isinstance(rj, dict) else False
 
         if r.status_code < 400:
-            if intended == "/scrobble/stop" and prog >= watched_at:
+            if activity_recorded and intended == "/scrobble/stop" and prog >= watched_at:
                 _LAST_FINISH_BY_ACC[acc_key] = {"ik": item_key, "ts": now}
-            if intended == "/scrobble/stop" and prog >= watched_at and not (st.get("wl_removed") is True):
+            if activity_recorded and intended == "/scrobble/stop" and prog >= watched_at and not (st.get("wl_removed") is True):
                 try:
                     _call_remove_across(ids_all or {}, media_type, origin=f"jellyfin:{provider_instance}")
                     st = {**st, "wl_removed": True}
@@ -1512,7 +1513,7 @@ def process_webhook(
                 "last_pause_ts": (now if intended == "pause" else st.get("last_pause_ts", 0)),
                 "prog": prog,
                 "sk": sk_current,
-                "finished": (intended == "/scrobble/stop" and prog >= watched_at),
+                "finished": (activity_recorded and intended == "/scrobble/stop" and prog >= watched_at),
                 **({"wl_removed": st.get("wl_removed")} if st.get("wl_removed") else {}),
                 "paused": (intended == "pause"),
                 **({"last_stop_ts": now} if intended == "/scrobble/stop" else {}),
@@ -1527,11 +1528,11 @@ def process_webhook(
             except Exception:
                 pass
 
-            if "trakt" in sinks_cfg and intended == "/scrobble/start":
+            if activity_recorded and "trakt" in sinks_cfg and intended == "/scrobble/start":
                 _archive("scrobble_started", media_type, md, payload, ids_all, acc_title, prog)
-            elif "trakt" in sinks_cfg and intended == "/scrobble/stop" and prog >= watched_at:
+            elif activity_recorded and "trakt" in sinks_cfg and intended == "/scrobble/stop" and prog >= watched_at:
                 _archive("scrobble_completed", media_type, md, payload, ids_all, acc_title, prog)
-            return {"ok": True, "status": 200, "action": intended, "trakt": rj}
+            return {"ok": True, "status": 200, "action": intended, "trakt": rj, "ignored": not activity_recorded}
 
         _emit(logger, f"{intended} {r.status_code} {(str(rj)[:180])}", "ERROR")
         if "trakt" in sinks_cfg and intended in ("/scrobble/start", "/scrobble/stop"):

--- a/providers/webhooks/plex.py
+++ b/providers/webhooks/plex.py
@@ -1625,9 +1625,10 @@ def process_webhook(
     except Exception:
         rj = {"raw": (r.text or "")[:200]}
     _emit(logger, f"webhook {intended} -> {r.status_code}", "DEBUG")
+    activity_recorded = bool(rj.get("activity_recorded")) if isinstance(rj, dict) else False
 
     if r.status_code < 400:
-        if intended == "/scrobble/stop" and prog >= watched_at and not (st.get("wl_removed") is True):
+        if activity_recorded and intended == "/scrobble/stop" and prog >= watched_at and not (st.get("wl_removed") is True):
             try:
                 _call_remove_across(ids_all2 or {}, media_type, origin=f"plex:{provider_instance}")
                 st = {**st, "wl_removed": True}
@@ -1637,21 +1638,21 @@ def process_webhook(
             "last_event": event,
             "last_pause_ts": (now if intended == "pause" else st.get("last_pause_ts", 0)),
             "prog": prog,
-            "finished": (intended == "/scrobble/stop" and prog >= watched_at),
+            "finished": (activity_recorded and intended == "/scrobble/stop" and prog >= watched_at),
             **({"wl_removed": st.get("wl_removed")} if st.get("wl_removed") else {}),
         }
-        if intended == "/scrobble/stop" and prog >= watched_at:
+        if activity_recorded and intended == "/scrobble/stop" and prog >= watched_at:
             _LAST_FINISH_BY_ACC[_account_key(payload)] = {"rk": str(rk or ""), "ts": now}
         try:
             action_name = intended.rsplit("/", 1)[-1]
             _emit(logger, f"user='{_mask_account(acc_title)}' {action_name} {prog:.1f}% • {media_name_dbg}", "INFO")
         except Exception:
             pass
-        if "trakt" in sinks_cfg and intended == "/scrobble/start":
+        if activity_recorded and "trakt" in sinks_cfg and intended == "/scrobble/start":
             _archive("scrobble_started", media_type, md, ids_all2, acc_title, prog)
-        elif "trakt" in sinks_cfg and intended == "/scrobble/stop" and prog >= watched_at:
+        elif activity_recorded and "trakt" in sinks_cfg and intended == "/scrobble/stop" and prog >= watched_at:
             _archive("scrobble_completed", media_type, md, ids_all2, acc_title, prog)
-        return {"ok": True, "status": 200, "action": intended, "trakt": rj}
+        return {"ok": True, "status": 200, "action": intended, "trakt": rj, "ignored": not activity_recorded}
 
     if event in ("media.stop", "media.scrobble") and prog >= force_stop_at:
         _LAST_FINISH_BY_ACC[_account_key(payload)] = {"rk": str(rk or ""), "ts": now}

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -2616,6 +2616,20 @@ def test_cards_tag_user_profile_class() -> None:
     assert '${r.user_profile_label ? "has-user-profile" : ""}' in routes
 
 
+def test_scrobbler_cards_summarize_media_ignore_filters() -> None:
+    js = Path("assets/js/scrobbler.js").read_text("utf-8")
+    webhooks = js.split("function renderWebhooks(", 1)[1].split("function renderRoutes(", 1)[0]
+    routes = js.split("function renderRoutes(", 1)[1]
+
+    assert "ignore_agregarr_trailers" in js
+    assert "ignored_path_prefixes" in js
+    assert "ignored_filename_patterns" in js
+    assert "ignored_editions" in js
+    assert "function webhookFilterSummary(row = {})" in js
+    assert "${esc(webhookFilterSummary(x))}" in webhooks
+    assert "${esc(routeFilterSummary(r.filters))}" in routes
+
+
 def test_pair_config_profile_selector_sits_before_mode_control() -> None:
     js = Path("assets/js/modals/pair-config/index.js").read_text("utf-8")
     css = Path("assets/js/modals/pair-config/styles.css").read_text("utf-8")

--- a/tests/test_scrobble_media_filters.py
+++ b/tests/test_scrobble_media_filters.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from typing import Any
+
+from api.scrobblerManagementAPI import _normalize_filters
+from providers.scrobble.media_filters import media_filter_ignore_reason
+from providers.scrobble.scrobble import Dispatcher, ScrobbleEvent
+
+
+def _event(raw: dict[str, Any], *, title: str = "Soldier's Bones") -> ScrobbleEvent:
+    return ScrobbleEvent(
+        action="start",
+        media_type="movie",
+        ids={"tmdb": "1638209"},
+        title=title,
+        year=2026,
+        season=None,
+        number=None,
+        progress=1,
+        account="user",
+        server_uuid="server",
+        session_key="sess",
+        raw=raw,
+    )
+
+
+def test_agregarr_edition_filename_is_ignored() -> None:
+    raw = {
+        "Metadata": {
+            "Media": [
+                {
+                    "Part": [
+                        {
+                            "file": "/data/media/placeholder/movies/Soldier's Bones (2026)/Soldier's Bones (2026) {tmdb-1638209} {edition-Trailer}.mp4"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+
+    reason = media_filter_ignore_reason({"ignore_agregarr_trailers": True}, raw)
+
+    assert reason == "filename_pattern:{edition-trailer}"
+
+
+def test_title_with_trailer_word_is_not_ignored_without_media_path_or_edition() -> None:
+    raw = {"Metadata": {"title": "Trailer Park Boys", "type": "movie"}}
+
+    assert media_filter_ignore_reason({"ignore_agregarr_trailers": True}, raw) is None
+
+
+def test_custom_path_prefix_is_ignored() -> None:
+    raw = {"NowPlayingItem": {"Path": r"Z:\data\media\placeholder\movies\Movie\file.mp4"}}
+
+    reason = media_filter_ignore_reason({"ignored_path_prefixes": [r"Z:\data\media\placeholder"]}, raw)
+
+    assert reason == "path_prefix:z:/data/media/placeholder"
+
+
+def test_jellyfin_emby_now_playing_path_is_ignored() -> None:
+    raw = {"NowPlayingItem": {"Path": "/data/media/placeholder/movies/The Odyssey (2026)/The Odyssey.mp4"}}
+
+    reason = media_filter_ignore_reason({"ignored_path_prefixes": ["/data/media/placeholder"]}, raw)
+
+    assert reason == "path_prefix:/data/media/placeholder"
+
+
+def test_kodi_item_file_is_ignored() -> None:
+    raw = {"provider": "kodi", "item": {"file": "/data/media/placeholder/movies/The Odyssey (2026)/The Odyssey {edition-Trailer}.mp4"}}
+
+    reason = media_filter_ignore_reason({"ignore_agregarr_trailers": True}, raw)
+
+    assert reason == "filename_pattern:{edition-trailer}"
+
+
+def test_enriched_plex_file_path_list_is_ignored() -> None:
+    raw = {"_cw_file_paths": ["/media/The Odyssey (2026)/The Odyssey (2026) {edition-Trailer}.mp4"]}
+
+    reason = media_filter_ignore_reason({"ignore_agregarr_trailers": True}, raw)
+
+    assert reason == "filename_pattern:{edition-trailer}"
+
+
+def test_enriched_plex_edition_title_is_ignored() -> None:
+    raw = {"_cw_edition_title": "Trailer"}
+
+    reason = media_filter_ignore_reason({"ignore_agregarr_trailers": True}, raw)
+
+    assert reason == "edition:trailer"
+
+
+def test_agregarr_marker_file_is_ignored(tmp_path) -> None:
+    movie_dir = tmp_path / "movies" / "Movie (2026)"
+    movie_dir.mkdir(parents=True)
+    (movie_dir / ".comingsoon").write_text("", encoding="utf-8")
+    raw = {"file": str(movie_dir / "Movie (2026).mp4")}
+
+    reason = media_filter_ignore_reason({"ignore_agregarr_trailers": True}, raw)
+
+    assert reason == "marker_file:.comingsoon"
+
+
+def test_dispatcher_filters_ignored_media() -> None:
+    calls: list[ScrobbleEvent] = []
+
+    class Sink:
+        def send(self, event: ScrobbleEvent) -> None:
+            calls.append(event)
+
+    cfg = {"scrobble": {"watch": {"filters": {"ignore_agregarr_trailers": True}}}}
+    dispatcher = Dispatcher([Sink()], cfg_provider=lambda: cfg)
+
+    assert dispatcher.dispatch(_event({"file": "/media/Movie (2026) {edition-Trailer}.mp4"})) is False
+    assert calls == []
+
+
+def test_webhook_dispatch_reports_ignored_without_sending(monkeypatch) -> None:
+    import providers.webhooks.dispatch as dispatch
+
+    calls: list[ScrobbleEvent] = []
+
+    class Sink:
+        def send(self, event: ScrobbleEvent, cfg: dict[str, Any] | None = None) -> None:
+            calls.append(event)
+
+    monkeypatch.setattr(dispatch, "webhook_sinks", lambda cfg, provider, instance: ["trakt"])
+    monkeypatch.setattr(dispatch, "webhook_sink_instance", lambda settings, sink: "default")
+    monkeypatch.setattr(dispatch, "sink_configured", lambda cfg, sink, instance: True)
+    monkeypatch.setattr(dispatch, "_make_sink", lambda sink, instance, cfg_provider: Sink())
+
+    cfg = {"scrobble": {"webhook": {"filters_plex": {"ignore_agregarr_trailers": True}}}}
+    res = dispatch.dispatch_scrobble(
+        "plex",
+        "/scrobble/start",
+        media_type="movie",
+        ids={"tmdb": "1638209"},
+        title="Soldier's Bones",
+        raw={"file": "/media/Soldier's Bones (2026) {edition-Trailer}.mp4"},
+        cfg=cfg,
+    )
+    payload = res.json()
+
+    assert res.status_code == 200
+    assert payload["activity_recorded"] is False
+    assert payload["targets"][0]["ignored"] is True
+    assert calls == []
+
+
+def test_jellyfin_webhook_dispatch_uses_jellyfin_filters(monkeypatch) -> None:
+    import providers.webhooks.dispatch as dispatch
+
+    calls: list[ScrobbleEvent] = []
+
+    class Sink:
+        def send(self, event: ScrobbleEvent, cfg: dict[str, Any] | None = None) -> None:
+            calls.append(event)
+
+    monkeypatch.setattr(dispatch, "webhook_sinks", lambda cfg, provider, instance: ["simkl"])
+    monkeypatch.setattr(dispatch, "webhook_sink_instance", lambda settings, sink: "default")
+    monkeypatch.setattr(dispatch, "sink_configured", lambda cfg, sink, instance: True)
+    monkeypatch.setattr(dispatch, "_make_sink", lambda sink, instance, cfg_provider: Sink())
+
+    cfg = {"scrobble": {"webhook": {"filters_jellyfin": {"ignored_path_prefixes": ["/data/media/placeholder"]}}}}
+    res = dispatch.dispatch_scrobble(
+        "jellyfin",
+        "/scrobble/start",
+        media_type="movie",
+        ids={"tmdb": "1368337"},
+        title="The Odyssey",
+        raw={"NowPlayingItem": {"Path": "/data/media/placeholder/movies/The Odyssey (2026)/The Odyssey.mp4"}},
+        cfg=cfg,
+    )
+    payload = res.json()
+
+    assert res.status_code == 200
+    assert payload["activity_recorded"] is False
+    assert payload["targets"][0]["ignored"] is True
+    assert calls == []
+
+
+def test_normalize_filters_accepts_media_ignore_fields() -> None:
+    filters = _normalize_filters(
+        {
+            "ignore_agregarr_trailers": True,
+            "ignored_path_prefixes": "/data/media/placeholder",
+            "ignored_filename_patterns": ["{edition-Trailer}"],
+            "ignored_editions": "Trailer",
+            "ignored_marker_files": ".comingsoon",
+        },
+        "jellyfin",
+    )
+
+    assert filters == {
+        "ignore_agregarr_trailers": True,
+        "ignored_path_prefixes": ["/data/media/placeholder"],
+        "ignored_filename_patterns": ["{edition-Trailer}"],
+        "ignored_editions": ["Trailer"],
+        "ignored_marker_files": [".comingsoon"],
+    }


### PR DESCRIPTION
# Pull request

## Change

Add media ignore filters for scrobbler routes and webhooks.

Includes path prefixes, filename patterns, editions, and an Agregarr placeholder trailer toggle.

## Why

Agregarr placeholder trailers can look like normal movie playback and get scrobbled.

These filters let users skip them cleanly.

## Testing

- tests\test_scrobble_media_filters.py

## Issue

Relates to #813