### PR TITLE
Fix: FLOPPY anime history coordinate sync

### DIFF
--- a/providers/sync/floppy/_history.py
+++ b/providers/sync/floppy/_history.py
@@ -12,7 +12,7 @@ from cw_platform.anime_mapping.coordinates import translate
 from cw_platform.anime_mapping.overrides import find_source_override
 from cw_platform.anime_mapping.service import PAIR_FEATURE_OPTIONS_KEY, mapping_enabled_for_feature, runtime_pair_feature_options
 from cw_platform.anime_mapping.storage import query_edges
-from cw_platform.history_events import history_sync_key, minimal_history_item
+from cw_platform.history_events import history_epoch_from_value, history_sync_key, minimal_history_item
 from cw_platform.id_map import minimal as id_minimal
 from providers.sync._mod_common import build_op_result, unresolved_keys
 
@@ -185,6 +185,8 @@ def _anime_coordinate_for_absolute(
         except Exception:
             rows = []
         for row in rows:
+            if namespace == "anidb" and str(row.get("source_scope") or "").strip().upper() != "R":
+                continue
             if str(row.get("target_provider") or "").strip().lower() != "tmdb":
                 continue
             if str(row.get("target_kind") or "").strip().lower() != "show":
@@ -230,7 +232,7 @@ def prepare_source_snapshot(items: Iterable[Mapping[str, Any]]) -> int:
         if not tmdb_id:
             continue
         season, episode = _episode_numbers(item)
-        if season is None or episode is None or season < 1 or episode < 1:
+        if season is None or episode is None or season < 0 or episode < 1:
             continue
         record = shows.setdefault(tmdb_id, {"coords": set(), "abs": {}})
         record["coords"].add((season, episode))
@@ -248,7 +250,8 @@ def _rekey_to_source_numbering(adapter: Any, out: dict[str, dict[str, Any]]) -> 
     shows: dict[str, dict[str, Any]] = _SRC_SNAPSHOT.get("shows") or {}
     if not shows or not out or _SRC_SNAPSHOT.get("scope") != _pair_scope():
         return out
-    owned_by_show: dict[str, dict[tuple[int, int], str]] = {}
+    event_mode = _rewatches_enabled(adapter)
+    owned_by_show: dict[str, dict[tuple[int, int], list[str]]] = {}
     for key, item in out.items():
         if str(item.get("type") or "").strip().lower() != "episode":
             continue
@@ -258,7 +261,7 @@ def _rekey_to_source_numbering(adapter: Any, out: dict[str, dict[str, Any]]) -> 
         season, episode = _episode_numbers(item)
         if not show or season is None or episode is None:
             continue
-        owned_by_show.setdefault(show, {})[(season, episode)] = key
+        owned_by_show.setdefault(show, {}).setdefault((season, episode), []).append(key)
 
     for show, record in shows.items():
         owned = owned_by_show.get(show)
@@ -268,9 +271,7 @@ def _rekey_to_source_numbering(adapter: Any, out: dict[str, dict[str, Any]]) -> 
         missing = [coord for coord in wanted if coord not in owned]
         if not missing:
             continue
-        layout = show_layout(adapter, show)
-        if not layout:
-            continue
+        layout: list[tuple[int, int]] | None = None
         for coord in sorted(missing):
             absolute = record["abs"].get(coord)
             if absolute is None:
@@ -282,10 +283,25 @@ def _rekey_to_source_numbering(adapter: Any, out: dict[str, dict[str, Any]]) -> 
                 else None
             )
             if real is None:
+                if layout is None:
+                    layout = show_layout(adapter, show)
+                if not layout:
+                    continue
                 real = absolute_to_coord(layout, absolute)
-            if real is None or real == coord or real in wanted:
+            if real is None or real == coord:
                 continue
-            key = owned.get(real)
+            keys = owned.get(real) or []
+            key = ""
+            if event_mode and isinstance(source_item, Mapping):
+                source_key = _history_key(adapter, source_item)
+                source_event = source_key.rsplit("@", 1)[-1] if "@" in source_key else ""
+                for candidate in keys:
+                    candidate_event = candidate.rsplit("@", 1)[-1] if "@" in candidate else ""
+                    if source_event and candidate_event == source_event:
+                        key = candidate
+                        break
+            if not key and real not in wanted:
+                key = keys[0] if keys else ""
             if not key:
                 continue
             item = out.get(key)
@@ -299,26 +315,38 @@ def _rekey_to_source_numbering(adapter: Any, out: dict[str, dict[str, Any]]) -> 
                 continue
             out.pop(key, None)
             out[new_key] = rekeyed
-            owned.pop(real, None)
-            owned[coord] = new_key
+            if key in keys:
+                keys.remove(key)
+            if keys:
+                owned[real] = keys
+            else:
+                owned.pop(real, None)
+            owned.setdefault(coord, []).append(new_key)
     return out
 
 
-def _write_coord(adapter: Any, tmdb_id: str, item: Mapping[str, Any], season: int, episode: int) -> tuple[int, int]:
+def _write_coord_result(adapter: Any, tmdb_id: str, item: Mapping[str, Any], season: int, episode: int) -> tuple[int, int, bool]:
     stored = _floppy_coord(item)
     if stored is not None:
-        return stored
+        return stored[0], stored[1], False
     absolute = _explicit_absolute(item)
     if absolute is None:
-        return season, episode
+        return season, episode, False
     mapped = _anime_coordinate_for_absolute(adapter, tmdb_id, item, absolute)
     if mapped is not None:
-        return mapped
+        return mapped[0], mapped[1], mapped != (season, episode)
     layout = show_layout(adapter, tmdb_id)
     if not layout or has_coord(layout, season, episode):
-        return season, episode
+        return season, episode, False
     real = absolute_to_coord(layout, absolute)
-    return real if real is not None else (season, episode)
+    if real is not None:
+        return real[0], real[1], real != (season, episode)
+    return season, episode, False
+
+
+def _write_coord(adapter: Any, tmdb_id: str, item: Mapping[str, Any], season: int, episode: int) -> tuple[int, int]:
+    real_season, real_episode, _verify = _write_coord_result(adapter, tmdb_id, item, season, episode)
+    return real_season, real_episode
 
 
 def _history_id(item: Mapping[str, Any]) -> str | None:
@@ -341,6 +369,22 @@ def _episode_history(adapter: Any, tmdb_id: str, season: int, episode: int) -> l
         return paged(adapter, f"media/tv/tmdb/{tmdb_id}/{season}/{episode}/history")
     except Exception:
         return []
+
+
+def _history_rows_include_write(adapter: Any, item: Mapping[str, Any], rows: Iterable[Mapping[str, Any]]) -> bool:
+    rows_list = [row for row in rows or [] if isinstance(row, Mapping)]
+    if not rows_list:
+        return False
+    if not _rewatches_enabled(adapter):
+        return True
+    target = history_epoch_from_value(_watched_at(item))
+    if target is None:
+        return True
+    for row in rows_list:
+        row_ts = history_epoch_from_value(row.get("end_date") or row.get("progressed_at") or row.get("created_at") or row.get("watched_at"))
+        if row_ts == target:
+            return True
+    return False
 
 
 def _put_latest(out: dict[str, dict[str, Any]], item: dict[str, Any]) -> None:
@@ -477,9 +521,15 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
                 results.append({"status": "dry_run", "item": _history_minimal(adapter, raw), "canonical_key": key})
                 continue
             try:
-                season, episode = _write_coord(adapter, tmdb_id, raw, season, episode)
-                if _rewatches_enabled(adapter) or not _episode_history(adapter, tmdb_id, season, episode):
+                season, episode, verify_after_write = _write_coord_result(adapter, tmdb_id, raw, season, episode)
+                existing_history = _episode_history(adapter, tmdb_id, season, episode)
+                if _rewatches_enabled(adapter) or not existing_history:
                     api_post(adapter, f"media/tv/tmdb/{tmdb_id}/{season}/episodes/{episode}/watch", json={"end_date": _watched_at(raw)})
+                if verify_after_write and not _history_rows_include_write(adapter, raw, _episode_history(adapter, tmdb_id, season, episode)):
+                    entry = unresolved(raw, "floppy_history_write_not_readable")
+                    unresolved_rows.append(entry)
+                    results.append(entry)
+                    continue
             except Exception as exc:
                 entry = unresolved(raw, failure_reason(exc))
                 unresolved_rows.append(entry)

--- a/tests/test_floppy_sync.py
+++ b/tests/test_floppy_sync.py
@@ -527,12 +527,15 @@ def _dbz_routes(watched: list[tuple[int, int]], layout: dict[int, int]) -> dict[
     return routes
 
 
-def _anime_history_cfg() -> dict[str, Any]:
-    return {
+def _anime_history_cfg(*, rewatches: bool = False) -> dict[str, Any]:
+    out = {
         "floppy": {"watchlist_name": "Watchlist"},
         "anime_mapping": {"enabled": True, "features": ["history"], "release_tag": "v3"},
         "_cw_pair_feature_options": {"feature": "history", "use_anime_mapping": True},
     }
+    if rewatches:
+        out["_cw_history_rewatches"] = True
+    return out
 
 
 def _anime_routes(tmdb_id: str, watched: list[tuple[int, int]], layout: dict[int, int]) -> dict[tuple[str, str], Any]:
@@ -549,6 +552,19 @@ def _anime_routes(tmdb_id: str, watched: list[tuple[int, int]], layout: dict[int
             "count": total,
         }
     return routes
+
+
+def _history_visible_after_post(consumption_id: int = 77) -> Any:
+    seen = 0
+
+    def route(_call: dict[str, Any]) -> dict[str, Any]:
+        nonlocal seen
+        seen += 1
+        if seen == 1:
+            return {"results": [], "count": 0}
+        return {"results": [{"consumption_id": consumption_id, "end_date": "2026-01-02T00:00:00Z"}], "count": 1}
+
+    return route
 
 
 def _overlord_iv_source(**extra: Any) -> dict[str, Any]:
@@ -591,7 +607,7 @@ def test_floppy_history_add_uses_anime_native_coordinate_before_layout_absolute(
     _history.prepare_source_snapshot([])
     _history.reset_layout_cache()
     routes = _anime_routes("64196", [], {1: 13, 2: 13, 3: 13, 4: 13})
-    routes[("GET", "media/tv/tmdb/64196/4/1/history")] = {"results": [], "count": 0}
+    routes[("GET", "media/tv/tmdb/64196/4/1/history")] = _history_visible_after_post()
     routes[("POST", "media/tv/tmdb/64196/4/episodes/1/watch")] = {"consumption_id": 77}
     adapter = AdapterStub(routes, _anime_history_cfg())
 
@@ -617,7 +633,7 @@ def test_floppy_history_add_prefers_user_anime_override(monkeypatch: Any) -> Non
     _history.prepare_source_snapshot([])
     _history.reset_layout_cache()
     routes = _anime_routes("64196", [], {1: 13, 2: 13, 3: 13, 4: 13, 9: 13})
-    routes[("GET", "media/tv/tmdb/64196/9/7/history")] = {"results": [], "count": 0}
+    routes[("GET", "media/tv/tmdb/64196/9/7/history")] = _history_visible_after_post()
     routes[("POST", "media/tv/tmdb/64196/9/episodes/7/watch")] = {"consumption_id": 77}
     adapter = AdapterStub(routes, _anime_history_cfg())
 
@@ -626,6 +642,61 @@ def test_floppy_history_add_prefers_user_anime_override(monkeypatch: Any) -> Non
     assert res["count"] == 1
     assert [c["path"] for c in adapter.client.session.calls if c["method"] == "POST"] == ["media/tv/tmdb/64196/9/episodes/7/watch"]
     assert not any(c["path"] == "media/tv/tmdb/64196/4/episodes/1/watch" for c in adapter.client.session.calls)
+
+
+def test_floppy_history_add_ignores_anidb_special_edges_for_regular_anime(monkeypatch: Any) -> None:
+    from providers.sync.floppy import _history
+
+    def fake_edges(tag: str, namespace: str, ident: str) -> list[dict[str, Any]]:
+        if tag == "v3" and namespace == "anidb" and ident == "18921":
+            return [
+                {
+                    "source_scope": "R",
+                    "target_provider": "tmdb",
+                    "target_kind": "show",
+                    "target_id": "65930",
+                    "target_scope": "s8",
+                    "source_range": "1-11",
+                    "target_range": "1-11",
+                },
+                {
+                    "source_scope": "S",
+                    "target_provider": "tmdb",
+                    "target_kind": "show",
+                    "target_id": "65930",
+                    "target_scope": "s0",
+                    "source_range": "1",
+                    "target_range": "18",
+                },
+            ]
+        return []
+
+    monkeypatch.setattr(_history, "query_edges", fake_edges)
+    _history.prepare_source_snapshot([])
+    _history.reset_layout_cache()
+    routes = _anime_routes("65930", [], {8: 11})
+    routes[("GET", "media/tv/tmdb/65930/8/1/history")] = _history_visible_after_post()
+    routes[("POST", "media/tv/tmdb/65930/8/episodes/1/watch")] = {"consumption_id": 77}
+    adapter = AdapterStub(routes, _anime_history_cfg())
+
+    res = _history.add(
+        adapter,
+        [
+            {
+                "type": "episode",
+                "series_title": "Boku no Hero Academia",
+                "season": 1,
+                "episode": 160,
+                "_simkl_episode_number": 1,
+                "watched_at": "2026-01-02T00:00:00Z",
+                "show_ids": {"tmdb": "65930", "anidb": "18921"},
+            }
+        ],
+    )
+
+    assert res["count"] == 1
+    assert [c["path"] for c in adapter.client.session.calls if c["method"] == "POST"] == ["media/tv/tmdb/65930/8/episodes/1/watch"]
+    assert not any(c["path"] == "media/tv/tmdb/65930/0/episodes/18/watch" for c in adapter.client.session.calls)
 
 
 def test_floppy_history_rekeys_anime_native_coordinate_without_false_missing(monkeypatch: Any) -> None:
@@ -644,6 +715,80 @@ def test_floppy_history_rekeys_anime_native_coordinate_without_false_missing(mon
     assert "tmdb:64196#s04e01" not in out
     assert out["tmdb:64196#s01e40"]["_floppy_season"] == 4
     assert out["tmdb:64196#s01e40"]["_floppy_episode"] == 1
+
+
+def test_floppy_history_rekeys_anime_event_coordinate_without_layout(monkeypatch: Any) -> None:
+    from providers.sync.floppy import _history
+
+    monkeypatch.setattr(_history, "query_edges", _fake_overlord_edges)
+    monkeypatch.setattr(_history, "show_layout", lambda *_args, **_kwargs: [])
+    _history.prepare_source_snapshot([])
+    _history.reset_layout_cache()
+    adapter = AdapterStub(_anime_routes("64196", [(4, 1)], {}), _anime_history_cfg(rewatches=True))
+
+    produced = _history.prepare_source_snapshot([_overlord_iv_source()])
+    out = _history.build_index(adapter)
+
+    assert produced == 1
+    assert "tmdb:64196#s01e40@1767312000" in out
+    assert "tmdb:64196#s04e01@1767312000" not in out
+    assert out["tmdb:64196#s01e40@1767312000"]["_floppy_season"] == 4
+    assert out["tmdb:64196#s01e40@1767312000"]["_floppy_episode"] == 1
+
+
+def test_floppy_history_rekeys_anime_special_event_without_stealing_regular(monkeypatch: Any) -> None:
+    from providers.sync.floppy import _history
+
+    def fake_edges(tag: str, namespace: str, ident: str) -> list[dict[str, Any]]:
+        if tag == "v3" and namespace == "mal" and ident == "11887":
+            return [
+                {
+                    "target_provider": "tmdb",
+                    "target_kind": "show",
+                    "target_id": "45807",
+                    "target_scope": "s1",
+                    "source_range": "1-4",
+                    "target_range": "1-4",
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(_history, "query_edges", fake_edges)
+    monkeypatch.setattr(_history, "show_layout", lambda *_args, **_kwargs: [])
+    _history.prepare_source_snapshot([])
+    _history.reset_layout_cache()
+    routes = _anime_routes("45807", [(1, 1), (1, 1)], {})
+    routes[("GET", "media/episode")]["results"][0]["end_date"] = "2012-07-07T12:00:00Z"
+    routes[("GET", "media/episode")]["results"][1]["end_date"] = "2012-11-18T15:30:00Z"
+    adapter = AdapterStub(routes, _anime_history_cfg(rewatches=True))
+    source = [
+        {
+            "type": "episode",
+            "series_title": "Kokoro Connect",
+            "season": 1,
+            "episode": 1,
+            "watched_at": "2012-07-07T12:00:00Z",
+            "show_ids": {"tmdb": "45807", "mal": "11887"},
+        },
+        {
+            "type": "episode",
+            "series_title": "Kokoro Connect",
+            "season": 0,
+            "episode": 1,
+            "_simkl_episode_number": 1,
+            "watched_at": "2012-11-18T15:30:00Z",
+            "show_ids": {"tmdb": "45807", "mal": "11887"},
+        },
+    ]
+
+    produced = _history.prepare_source_snapshot(source)
+    out = _history.build_index(adapter)
+
+    assert produced == 2
+    assert "tmdb:45807#s01e01@1341662400" in out
+    assert "tmdb:45807#s00e01@1353252600" in out
+    assert out["tmdb:45807#s00e01@1353252600"]["_floppy_season"] == 1
+    assert out["tmdb:45807#s00e01@1353252600"]["_floppy_episode"] == 1
 
 
 def test_floppy_history_rekeys_absolute_source_numbering_onto_aired_episodes() -> None:
@@ -717,7 +862,7 @@ def test_floppy_history_add_writes_absolute_episode_to_its_aired_coordinate() ->
     _history.prepare_source_snapshot([])
     _history.reset_layout_cache()
     routes = _dbz_routes([], {1: 39, 2: 35})
-    routes[("GET", "media/tv/tmdb/12971/2/5/history")] = {"results": [], "count": 0}
+    routes[("GET", "media/tv/tmdb/12971/2/5/history")] = _history_visible_after_post()
     routes[("POST", "media/tv/tmdb/12971/2/episodes/5/watch")] = {"consumption_id": 77}
     adapter = AdapterStub(routes)
 
@@ -729,6 +874,27 @@ def test_floppy_history_add_writes_absolute_episode_to_its_aired_coordinate() ->
     assert res["count"] == 1
     assert [c["path"] for c in adapter.client.session.calls if c["method"] == "POST"] == ["media/tv/tmdb/12971/2/episodes/5/watch"]
     assert res["confirmed_keys"] == ["tmdb:12971#s01e44"]
+
+
+def test_floppy_history_add_marks_translated_episode_unresolved_when_write_is_not_readable() -> None:
+    from providers.sync.floppy import _history
+
+    _history.prepare_source_snapshot([])
+    _history.reset_layout_cache()
+    routes = _dbz_routes([], {1: 39, 2: 35})
+    routes[("GET", "media/tv/tmdb/12971/2/5/history")] = {"results": [], "count": 0}
+    routes[("POST", "media/tv/tmdb/12971/2/episodes/5/watch")] = {"consumption_id": 77}
+    adapter = AdapterStub(routes)
+
+    res = _history.add(
+        adapter,
+        [{"type": "episode", "show_ids": {"tmdb": "12971"}, "season": 1, "episode": 44, "_simkl_episode_number": 44, "watched_at": "2026-01-02T00:00:00Z"}],
+    )
+
+    assert res["count"] == 0
+    assert res["unresolved_keys"] == ["tmdb:12971#s01e44"]
+    assert res["unresolved"][0]["reason"] == "floppy_history_write_not_readable"
+    assert [c["path"] for c in adapter.client.session.calls if c["method"] == "POST"] == ["media/tv/tmdb/12971/2/episodes/5/watch"]
 
 
 def test_floppy_history_add_uses_stored_coordinate_without_layout_lookup() -> None:


### PR DESCRIPTION
# Pull request

## Change

- Fix FLOPPY history sync for anime episode coordinates.
- Custom anime mappings are checked first, then AniBridge/native mappings, then the old absolute fallback.
- Translated anime writes are now verified against FLOPPY readback. 
- If FLOPPY does not expose the written history row, the item is marked unresolved instead of counted as added.

## Why

SIMKL anime history can use anime episode numbering.

FLOPPY writes need the provider season/episode coordinate. Some writes were accepted but later did not compare back, so CrossWatch kept trying to add them again.

## Testing

- tests/test_floppy_sync.py -q

## Issue

Relates to #809