### PR TITLE
Fix: provider cards prefer live status

### DIFF
--- a/assets/helpers/core.js
+++ b/assets/helpers/core.js
@@ -663,12 +663,18 @@
 
   function saveStatusCache(providers) {
     try {
-      localStorage.setItem(statusCacheKey(), JSON.stringify({ providers: normalizeProviders(providers), updatedAt: Date.now(), v: 1 }));
+      const payload = { providers: normalizeProviders(providers), updatedAt: Date.now(), v: 1 };
+      window._statusCache = payload;
+      localStorage.setItem(statusCacheKey(), JSON.stringify(payload));
     } catch {}
   }
 
   function loadStatusCache(maxAgeMs = 10 * 60 * 1000) {
     try {
+      const memory = window._statusCache;
+      if (memory?.providers && (Date.now() - (memory.updatedAt || 0)) <= maxAgeMs) {
+        return { providers: normalizeProviders(memory.providers), updatedAt: memory.updatedAt };
+      }
       const cached = JSON.parse(localStorage.getItem(statusCacheKey()) || "null");
       if (!cached?.providers) return null;
       if ((Date.now() - (cached.updatedAt || 0)) > maxAgeMs) return null;

--- a/assets/helpers/providers-ui.js
+++ b/assets/helpers/providers-ui.js
@@ -106,7 +106,7 @@
   }
 
   function statusProviderData(key) {
-    const providers = window.loadStatusCache?.()?.providers || window._statusCache?.providers || {};
+    const providers = window.__CW_PROVIDER_STATUS__?.providers || window._statusCache?.providers || window.loadStatusCache?.()?.providers || {};
     if (!providers || typeof providers !== "object") return null;
     const upper = String(key || "").toUpperCase();
     const lower = upper.toLowerCase();

--- a/tests/test_status_force_refresh.py
+++ b/tests/test_status_force_refresh.py
@@ -130,3 +130,11 @@ def test_client_sends_the_fresh_flag_only_on_a_forced_status_refresh() -> None:
 
     core_js = pathlib.Path("assets/helpers/core.js").read_text(encoding="utf-8")
     assert 'requestJSON(force ? "/api/status?fresh=1" : "/api/status", {}, 15000)' in core_js
+
+
+def test_provider_cards_prefer_live_status_over_persisted_status() -> None:
+    providers_ui = pathlib.Path("assets/helpers/providers-ui.js").read_text(encoding="utf-8")
+    assert "window.__CW_PROVIDER_STATUS__?.providers || window._statusCache?.providers || window.loadStatusCache?.()?.providers" in providers_ui
+
+    core_js = pathlib.Path("assets/helpers/core.js").read_text(encoding="utf-8")
+    assert "window._statusCache = payload;" in core_js


### PR DESCRIPTION
# Pull request

## Change

- Keep the latest provider status in memory when saving the status cache
- Make the settings provider cards prefer the live `cw-status-updated` payload before falling back to cached status
- Add coverage to guard against provider cards reading stale persisted status first

## Why

A user could still see the Scrob provider card stuck on `Check connection` in a normal Chrome profile, while Incognito showed `Connected`. That points to stale browser-side persisted status, likely `localStorage`, surviving cache clearing. 

## Testing

- tests/test_status_force_refresh.py

## Issue

Relates to #728