### PR TITLE
Fix: FLOPPY anime history write verification

### DIFF
--- a/providers/sync/floppy/_history.py
+++ b/providers/sync/floppy/_history.py
@@ -328,20 +328,39 @@ def _rekey_to_source_numbering(adapter: Any, out: dict[str, dict[str, Any]]) -> 
 def _write_coord_result(adapter: Any, tmdb_id: str, item: Mapping[str, Any], season: int, episode: int) -> tuple[int, int, bool]:
     stored = _floppy_coord(item)
     if stored is not None:
-        return stored[0], stored[1], False
+        return stored[0], stored[1], _anime_write_needs_readback(adapter, item, season, episode, stored[0], stored[1])
     absolute = _explicit_absolute(item)
     if absolute is None:
-        return season, episode, False
+        return season, episode, _anime_write_needs_readback(adapter, item, season, episode, season, episode)
     mapped = _anime_coordinate_for_absolute(adapter, tmdb_id, item, absolute)
     if mapped is not None:
-        return mapped[0], mapped[1], mapped != (season, episode)
+        return mapped[0], mapped[1], _anime_write_needs_readback(adapter, item, season, episode, mapped[0], mapped[1])
     layout = show_layout(adapter, tmdb_id)
     if not layout or has_coord(layout, season, episode):
-        return season, episode, False
+        return season, episode, _anime_write_needs_readback(adapter, item, season, episode, season, episode)
     real = absolute_to_coord(layout, absolute)
     if real is not None:
-        return real[0], real[1], real != (season, episode)
-    return season, episode, False
+        return real[0], real[1], _anime_write_needs_readback(adapter, item, season, episode, real[0], real[1])
+    return season, episode, _anime_write_needs_readback(adapter, item, season, episode, season, episode)
+
+
+def _anime_write_needs_readback(
+    adapter: Any,
+    item: Mapping[str, Any],
+    source_season: int,
+    source_episode: int,
+    write_season: int,
+    write_episode: int,
+) -> bool:
+    if _floppy_coord(item) is not None and _explicit_absolute(item) is None and not _anime_native_ids(item):
+        return False
+    if not _anime_mapping_enabled(adapter):
+        return (write_season, write_episode) != (source_season, source_episode)
+    if _explicit_absolute(item) is not None:
+        return True
+    if _anime_native_ids(item):
+        return True
+    return (write_season, write_episode) != (source_season, source_episode)
 
 
 def _write_coord(adapter: Any, tmdb_id: str, item: Mapping[str, Any], season: int, episode: int) -> tuple[int, int]:
@@ -371,11 +390,11 @@ def _episode_history(adapter: Any, tmdb_id: str, season: int, episode: int) -> l
         return []
 
 
-def _history_rows_include_write(adapter: Any, item: Mapping[str, Any], rows: Iterable[Mapping[str, Any]]) -> bool:
+def _history_rows_include_write(adapter: Any, item: Mapping[str, Any], rows: Iterable[Mapping[str, Any]], *, exact_time: bool = False) -> bool:
     rows_list = [row for row in rows or [] if isinstance(row, Mapping)]
     if not rows_list:
         return False
-    if not _rewatches_enabled(adapter):
+    if not exact_time and not _rewatches_enabled(adapter):
         return True
     target = history_epoch_from_value(_watched_at(item))
     if target is None:
@@ -525,7 +544,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
                 existing_history = _episode_history(adapter, tmdb_id, season, episode)
                 if _rewatches_enabled(adapter) or not existing_history:
                     api_post(adapter, f"media/tv/tmdb/{tmdb_id}/{season}/episodes/{episode}/watch", json={"end_date": _watched_at(raw)})
-                if verify_after_write and not _history_rows_include_write(adapter, raw, _episode_history(adapter, tmdb_id, season, episode)):
+                if verify_after_write and not _history_rows_include_write(adapter, raw, _episode_history(adapter, tmdb_id, season, episode), exact_time=True):
                     entry = unresolved(raw, "floppy_history_write_not_readable")
                     unresolved_rows.append(entry)
                     results.append(entry)

--- a/tests/test_floppy_sync.py
+++ b/tests/test_floppy_sync.py
@@ -897,6 +897,145 @@ def test_floppy_history_add_marks_translated_episode_unresolved_when_write_is_no
     assert [c["path"] for c in adapter.client.session.calls if c["method"] == "POST"] == ["media/tv/tmdb/12971/2/episodes/5/watch"]
 
 
+def test_floppy_history_add_marks_stored_anime_coord_unresolved_when_write_is_not_readable() -> None:
+    from providers.sync.floppy import _history
+
+    _history.prepare_source_snapshot([])
+    _history.reset_layout_cache()
+    adapter = AdapterStub(
+        {
+            ("GET", "media/tv/tmdb/64196/4/1/history"): {"results": [], "count": 0},
+            ("POST", "media/tv/tmdb/64196/4/episodes/1/watch"): {"consumption_id": 77},
+        },
+        _anime_history_cfg(),
+    )
+
+    res = _history.add(adapter, [_overlord_iv_source(_floppy_season=4, _floppy_episode=1)])
+
+    assert res["count"] == 0
+    assert res["unresolved_keys"] == ["tmdb:64196#s01e40"]
+    assert res["unresolved"][0]["reason"] == "floppy_history_write_not_readable"
+    assert [c["path"] for c in adapter.client.session.calls if c["method"] == "POST"] == ["media/tv/tmdb/64196/4/episodes/1/watch"]
+
+
+def test_floppy_history_add_marks_stored_anime_coord_unresolved_when_only_old_history_exists() -> None:
+    from providers.sync.floppy import _history
+
+    _history.prepare_source_snapshot([])
+    _history.reset_layout_cache()
+    adapter = AdapterStub(
+        {
+            ("GET", "media/tv/tmdb/64196/4/1/history"): {
+                "results": [{"consumption_id": 77, "end_date": "2025-01-02T00:00:00Z"}],
+                "count": 1,
+            },
+        },
+        _anime_history_cfg(),
+    )
+
+    res = _history.add(adapter, [_overlord_iv_source(_floppy_season=4, _floppy_episode=1)])
+
+    assert res["count"] == 0
+    assert res["unresolved_keys"] == ["tmdb:64196#s01e40"]
+    assert res["unresolved"][0]["reason"] == "floppy_history_write_not_readable"
+    assert not any(c["method"] == "POST" for c in adapter.client.session.calls)
+
+
+def test_floppy_history_add_marks_native_anime_coord_unresolved_when_write_is_not_readable() -> None:
+    from providers.sync.floppy import _history
+
+    _history.prepare_source_snapshot([])
+    _history.reset_layout_cache()
+    adapter = AdapterStub(
+        {
+            ("GET", "media/tv/tmdb/64196/1/40/history"): {"results": [], "count": 0},
+            ("POST", "media/tv/tmdb/64196/1/episodes/40/watch"): {"consumption_id": 77},
+        },
+        _anime_history_cfg(),
+    )
+
+    res = _history.add(adapter, [_overlord_iv_source(_simkl_episode_number=None)])
+
+    assert res["count"] == 0
+    assert res["unresolved_keys"] == ["tmdb:64196#s01e40"]
+    assert res["unresolved"][0]["reason"] == "floppy_history_write_not_readable"
+    assert [c["path"] for c in adapter.client.session.calls if c["method"] == "POST"] == ["media/tv/tmdb/64196/1/episodes/40/watch"]
+
+
+def test_floppy_history_unreadable_write_retries_until_blackbox(monkeypatch: Any, tmp_path: Any) -> None:
+    from cw_platform.orchestrator import _blackbox
+    from cw_platform.orchestrator._applier import apply_add
+    from cw_platform.orchestrator._blackbox import record_attempts
+    from cw_platform.orchestrator._pairs_blocklist import apply_blocklist
+
+    monkeypatch.setattr(_blackbox, "STATE_DIR", tmp_path)
+    event_key = "tmdb:12971#s01e44@1767312000"
+    item = {
+        "type": "episode",
+        "show_ids": {"tmdb": "12971"},
+        "season": 1,
+        "episode": 44,
+        "watched_at": "2026-01-02T00:00:00Z",
+        "_cw_event_key": event_key,
+        "_cw_rewatch_sync": True,
+    }
+
+    class OpsStub:
+        def add(self, _cfg: dict[str, Any], _items: list[dict[str, Any]], *, feature: str, dry_run: bool = False) -> dict[str, Any]:
+            assert feature == "history"
+            assert dry_run is False
+            return {
+                "ok": False,
+                "count": 0,
+                "confirmed_keys": [],
+                "unresolved_keys": [event_key],
+                "unresolved": [{"reason": "floppy_history_write_not_readable", "item": item}],
+            }
+
+    res = apply_add(
+        dst_ops=OpsStub(),
+        cfg={},
+        dst_name="FLOPPY",
+        feature="history",
+        items=[item],
+        dry_run=False,
+        emit=lambda *_args, **_kwargs: None,
+        dbg=lambda *_args, **_kwargs: None,
+        chunk_size=100,
+        chunk_pause_ms=0,
+    )
+
+    assert res["unresolved_keys"] == [event_key]
+
+    pair_key = "FLOPPY-SIMKL"
+    assert apply_blocklist(
+        None,
+        [item],
+        dst="FLOPPY",
+        feature="history",
+        pair_key=pair_key,
+        cross_feature_unresolved=True,
+    ) == [item]
+
+    record_attempts(
+        "FLOPPY",
+        "history",
+        [event_key],
+        reason="apply:add:failed",
+        op="add",
+        pair=pair_key,
+        cfg={"sync": {"blackbox": {"enabled": True, "promote_after": 1, "pair_scoped": True}}},
+    )
+    assert apply_blocklist(
+        None,
+        [item],
+        dst="FLOPPY",
+        feature="history",
+        pair_key=pair_key,
+        cross_feature_unresolved=True,
+    ) == []
+
+
 def test_floppy_history_add_uses_stored_coordinate_without_layout_lookup() -> None:
     from providers.sync.floppy import _history
 


### PR DESCRIPTION
# Pull request

## Change

Improve FLOPPY anime history writes.

Anime-mapped history writes now need to show up in FLOPPY history with the same watched time before they count as added.

## Why

- Some SIMKL anime episodes kept getting planned again every run.
- FLOPPY accepted the write, but the expected history item did not show up in the next snapshot. 
  - Those should be unresolved instead of added.

## Testing

- tests/test_floppy_sync.py

## Issue

Relates to #809