### PR TITLE
Fix: PunchPlay episode ids no longer carry the show id

### DIFF
--- a/providers/sync/_mod_PUNCHPLAY.py
+++ b/providers/sync/_mod_PUNCHPLAY.py
@@ -24,7 +24,7 @@ from providers.sync.punchplay._common import (
     request_id_of,
 )
 
-__VERSION__ = "0.2"
+__VERSION__ = "0.3"
 __all__ = ["get_manifest", "PUNCHPLAYModule", "OPS", "feat_history", "feat_progress", "feat_ratings", "feat_watchlist"]
 
 if "ctx" not in globals():

--- a/providers/sync/punchplay/_history.py
+++ b/providers/sync/punchplay/_history.py
@@ -103,11 +103,6 @@ def _row_to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
             "season": season,
             "episode": episode,
         }
-        ep_tmdb = _as_int(_pick(data, "episode_tmdb_id", "episodeTmdbId"))
-        if not ep_tmdb and _pick(data, "show_tmdb_id", "showTmdbId", "showTmdbID") is not None:
-            ep_tmdb = _as_int(_pick(data, "tmdbId"))
-        if ep_tmdb:
-            out["ids"] = {"tmdb": str(ep_tmdb)}
         series_title = str(_pick(data, "series_title", "show_title", "showTitle", "title") or "").strip()
         if series_title:
             out["series_title"] = series_title

--- a/providers/sync/punchplay/_progress.py
+++ b/providers/sync/punchplay/_progress.py
@@ -177,9 +177,6 @@ def _row_to_minimal(row: Mapping[str, Any], adapter: Any | None = None) -> dict[
             "season": season,
             "episode": episode,
         }
-        ep_tmdb = _as_int(row.get("tmdbId"))
-        if ep_tmdb:
-            out["ids"] = {"tmdb": str(ep_tmdb)}
         show_title = str(row.get("showTitle") or "").strip()
         if show_title:
             out["series_title"] = show_title

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -1429,3 +1429,20 @@ def test_settings_modal_shows_profile_names_without_the_provider() -> None:
     assert "return profileLabel(p);" in block
     assert "String(p.instance_label || id)" not in block
     assert 'if (id === "default") return "Default";' in block
+
+
+def test_provider_menu_is_wide_enough_for_qualified_labels() -> None:
+    js = Path("assets/js/playback_progress.js").read_text("utf-8")
+    block = js.split("function providerOptions(", 1)[1].split("function loadingCard(", 1)[0]
+
+    assert "menuMinWidth:" in block
+
+
+def test_late_shown_filters_are_enhanced_like_the_rest() -> None:
+    js = Path("assets/js/playback_progress.js").read_text("utf-8")
+    profile = js.split("function userProfileOptions(", 1)[1].split("function providerOptions(", 1)[0]
+    rating = js.split("function renderItems(", 1)[1].split("const markup =", 1)[0]
+
+    assert "ProfileSelect?.enhanceProfile?.(select" in profile
+    assert "IconSelect?.enhance?.(ratingFilter" in rating
+    assert "if (showRating)" in rating


### PR DESCRIPTION
# Pull request

## Change

- Stop writing the show tmdb id into the episode ids map
- Applies to both history and progress
- Episode identity now comes from show_ids plus season and episode

## Why

- PunchPlay has no episode level id, the spec only has showTmdbId with season and episode
- The old fallback read episodeTmdbId, which does not exist anywhere in the API
- Show id in the episode slot made anime enrichment stamp the full series identity on every episode
- SIMKL got the series tvdb and anidb sent as the episode id, Trakt was hit the same way
- Does not fix the One Piece episode, that one drops further down in the SIMKL anime path

## Testing

- tests/test_punchplay_sync.py 
- tests/test_punchplay_playback.py

## Issue

Relates to #812
