### PR TITLE
Fix: show failed connection profile only

### DIFF
--- a/assets/helpers/providers-ui.js
+++ b/assets/helpers/providers-ui.js
@@ -155,7 +155,13 @@
     const entryConnected = profileStatusEntryConnected(entry);
     if (entryConnected === true) return "ok";
     if (entryConnected === false) return "fail";
-    if (entry && typeof entry === "object" && entry.probed === true) return "fail";
+    if (entry && typeof entry === "object") {
+      if (entry.probed === true) return "fail";
+      if (entry.configured === true) return "ok";
+    }
+    if (data?.instances && typeof data.instances === "object") {
+      return configuredProfileIds(cfg, provider, connected).some((pid) => String(pid) === String(id)) ? "ok" : "fail";
+    }
     if (data && typeof data.connected === "boolean") return data.connected ? "ok" : "fail";
     return configuredProfileIds(cfg, provider, connected).some((pid) => String(pid) === String(id)) ? "ok" : "fail";
   }

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -2411,6 +2411,8 @@ def test_connection_cards_name_failed_profiles_and_dot_each_profile() -> None:
     assert "function failedProfileIds(" in ui
     assert "function authProfileState(" in ui
     assert "Check connection: ${shown}${overflow}" in ui
+    assert "if (entry.configured === true) return \"ok\";" in ui
+    assert "data?.instances && typeof data.instances === \"object\"" in ui
     assert "cw-auth-profile-dot" in ui
     assert "cw-auth-profile-name" in ui
     assert "is-connected" in ui


### PR DESCRIPTION
# Pull request

## Change

Connection cards now show the profile that failed its connection check.

Profile pills also get green or red dots, without marking unprobed profiles as failed.

## Why

A failed provider check could make every profile look broken, even when only one profile was actually checked and failed.

## Testing

- tests\test_crosswatch_profiles.py 

## Issue

Relates to #821