### PR TITLE
Fix: anime history coordinate writes

### DIFF
--- a/cw_platform/id_map.py
+++ b/cw_platform/id_map.py
@@ -365,6 +365,7 @@ def minimal(item: Mapping[str, Any]) -> dict[str, Any]:
         "_scrob_list_item_id",
         "_floppy_season",
         "_floppy_episode",
+        "_floppy_tmdb_id",
         "_cw_event_key",
         "_cw_rewatch_sync",
         "_cw_anime_map",

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -1384,6 +1384,11 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
     src_alias = _alias_index(src_idx)
     dst_alias = _alias_index(dst_full)
 
+    try:
+        unresolved_known = set(load_unresolved_keys(dst, feature, cross_features=_cross_feature_unresolved(feature)) or [])
+    except Exception:
+        unresolved_known = set()
+
     if adds:
         # Progress uses upsert semantics (update resume position)
         if feature not in ("ratings", "history", "progress"):
@@ -1395,6 +1400,9 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
                 ck = _ck(it) or ""
                 if ck and _history_ts_from_key(ck) is None and _present(dst_full, dst_alias, it):
                     if _coord_only_present(dst_full, dst_alias, it):
+                        if _sync_key(it) in unresolved_known:
+                            pruned.append(it)
+                            continue
                         coord_pruned += 1
                     continue
                 pruned.append(it)
@@ -1561,11 +1569,6 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
                 blocked_keys=int(len(manual_blocks)),
             )
             ctx.stats_manual_blocked = int(getattr(ctx, "stats_manual_blocked", 0) or 0) + int(manual_blocked)
-
-    try:
-        unresolved_known = set(load_unresolved_keys(dst, feature, cross_features=_cross_feature_unresolved(feature)) or [])
-    except Exception:
-        unresolved_known = set()
 
     if unresolved_known:
         try:

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -1007,6 +1007,8 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
     upd_to_B: list[dict[str, Any]] = []
     rem_from_A: list[dict[str, Any]] = []
     rem_from_B: list[dict[str, Any]] = []
+    unresolved_A: set[str] = set()
+    unresolved_B: set[str] = set()
 
     if feature == "ratings":
         A_f = _rate_filter(A_eff, fcfg)
@@ -1620,11 +1622,20 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                 else:
                     add_to_A.append(_minimal(v))
         elif not (feature == "history" and history_event_mode):
+            try:
+                unresolved_A = set(load_unresolved_keys(a, feature, cross_features=_cross_feature_unresolved(feature)) or [])
+                unresolved_B = set(load_unresolved_keys(b, feature, cross_features=_cross_feature_unresolved(feature)) or [])
+            except Exception:
+                unresolved_A = set()
+                unresolved_B = set()
             coord_pruned_to_B = 0
             coord_pruned_to_A = 0
             for _k, v in A_eff.items():
                 if _present(B_eff, B_alias, v):
                     if _coord_only_present(B_eff, B_alias, v):
+                        if _sync_key(v, str(_k)) in unresolved_B:
+                            add_to_B.append(_minimal(v))
+                            continue
                         coord_pruned_to_B += 1
                     continue
                 tomb_blocks = _tomb_blocks_remove(v, prev_self=prevA, prev_self_alias=prevA_alias)
@@ -1635,6 +1646,9 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
             for _k, v in B_eff.items():
                 if _present(A_eff, A_alias, v):
                     if _coord_only_present(A_eff, A_alias, v):
+                        if _sync_key(v, str(_k)) in unresolved_A:
+                            add_to_A.append(_minimal(v))
+                            continue
                         coord_pruned_to_A += 1
                     continue
                 tomb_blocks = _tomb_blocks_remove(v, prev_self=prevB, prev_self_alias=prevB_alias)
@@ -1669,9 +1683,15 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
         rem_from_B.clear()
         dbg("bootstrap.no-delete", a=a, b=b)
 
+    if not unresolved_A and not unresolved_B:
+        try:
+            unresolved_A = set(load_unresolved_keys(a, feature, cross_features=_cross_feature_unresolved(feature)) or [])
+            unresolved_B = set(load_unresolved_keys(b, feature, cross_features=_cross_feature_unresolved(feature)) or [])
+        except Exception:
+            unresolved_A = set()
+            unresolved_B = set()
+
     try:
-        unresolved_A = set(load_unresolved_keys(a, feature, cross_features=_cross_feature_unresolved(feature)) or [])
-        unresolved_B = set(load_unresolved_keys(b, feature, cross_features=_cross_feature_unresolved(feature)) or [])
         retryA = sum(1 for it in add_to_A if _sync_key(it) in unresolved_A)
         retryB = sum(1 for it in add_to_B if _sync_key(it) in unresolved_B)
         if retryA:

--- a/providers/sync/_mod_FLOPPY.py
+++ b/providers/sync/_mod_FLOPPY.py
@@ -136,6 +136,11 @@ class FLOPPYModule:
         mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
         return mod.build_index(self, **kwargs) if mod else {}
 
+    def destination_comparison_view(self, feature: str, index: Mapping[str, Mapping[str, Any]]) -> Mapping[str, dict[str, Any]]:
+        mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
+        hook = getattr(mod, "destination_comparison_view", None)
+        return hook(self, index) if callable(hook) else dict(index or {})
+
     def prepare_source_snapshot(self, feature: str, items: Any) -> int:
         mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
         hook = getattr(mod, "prepare_source_snapshot", None)
@@ -211,6 +216,9 @@ class _FLOPPYOPS:
 
     def build_index(self, cfg: Mapping[str, Any], *, feature: str) -> Mapping[str, dict[str, Any]]:
         return self._adapter(cfg).build_index(feature)
+
+    def destination_comparison_view(self, cfg: Mapping[str, Any], *, feature: str, index: Mapping[str, Mapping[str, Any]]) -> Mapping[str, dict[str, Any]]:
+        return self._adapter(cfg).destination_comparison_view(feature, index)
 
     def prepare_source_snapshot(self, cfg: Mapping[str, Any], *, feature: str, items: Any) -> int:
         return self._adapter(cfg).prepare_source_snapshot(feature, items)

--- a/providers/sync/floppy/_history.py
+++ b/providers/sync/floppy/_history.py
@@ -124,12 +124,12 @@ def _show_ids(item: Mapping[str, Any]) -> dict[str, str]:
     return out
 
 
-def _override_coordinate_for_absolute(
+def _override_target_for_absolute(
     item: Mapping[str, Any],
     tmdb_id: str,
     native_ids: Mapping[str, str],
     absolute: int,
-) -> tuple[int, int] | None:
+) -> tuple[str, int, int] | None:
     known_ids = _show_ids(item)
     if tmdb_id:
         known_ids.setdefault("tmdb", str(tmdb_id))
@@ -144,24 +144,31 @@ def _override_coordinate_for_absolute(
         if ruled is None:
             continue
         provider = str(ruled.provider or "").strip().lower()
-        expected = known_ids.get(provider)
-        if expected and str(ruled.ident or "").strip() != expected:
+        target_id = str(ruled.ident or "").strip()
+        if provider == "tmdb" and target_id:
+            expected = target_id
+        else:
+            expected = known_ids.get(provider)
+            if expected and target_id != expected:
+                continue
+            expected = tmdb_id
+        if provider != "tmdb":
             continue
-        if provider == "tmdb" and tmdb_id and str(ruled.ident or "").strip() != str(tmdb_id):
+        if not expected:
             continue
         season = int_or_none(ruled.season)
         episode = int_or_none(ruled.episode)
         if season is not None and season >= 0 and episode is not None and episode > 0:
-            return season, episode
+            return str(expected), season, episode
     return None
 
 
-def _anime_coordinate_for_absolute(
+def _anime_target_for_absolute(
     adapter: Any,
     tmdb_id: str,
     item: Mapping[str, Any],
     absolute: int,
-) -> tuple[int, int] | None:
+) -> tuple[str, int, int] | None:
     if not _anime_mapping_enabled(adapter):
         return None
     if str(item.get("type") or "").strip().lower() != "episode":
@@ -171,11 +178,11 @@ def _anime_coordinate_for_absolute(
         return None
 
     release_tag = _anime_release_tag(adapter)
-    override_coord = _override_coordinate_for_absolute(item, tmdb_id, native_ids, absolute)
-    if override_coord is not None:
-        return override_coord
+    override_target = _override_target_for_absolute(item, tmdb_id, native_ids, absolute)
+    if override_target is not None:
+        return override_target
 
-    found: set[tuple[int, int]] = set()
+    found: set[tuple[str, int, int]] = set()
     for namespace in ("anidb", "mal", "anilist", "kitsu"):
         ident = native_ids.get(namespace)
         if not ident:
@@ -192,7 +199,7 @@ def _anime_coordinate_for_absolute(
             if str(row.get("target_kind") or "").strip().lower() != "show":
                 continue
             target_id = str(row.get("target_id") or "").strip()
-            if target_id and str(target_id) != str(tmdb_id):
+            if not target_id:
                 continue
             season = _season_from_scope(row.get("target_scope"))
             if season is None or season < 0:
@@ -200,10 +207,22 @@ def _anime_coordinate_for_absolute(
             episode = translate(row.get("source_range"), row.get("target_range"), absolute)
             if episode is None or int(episode) <= 0:
                 continue
-            found.add((int(season), int(episode)))
+            found.add((target_id, int(season), int(episode)))
     if len(found) == 1:
         return next(iter(found))
     return None
+
+
+def _anime_coordinate_for_absolute(
+    adapter: Any,
+    tmdb_id: str,
+    item: Mapping[str, Any],
+    absolute: int,
+) -> tuple[int, int] | None:
+    target = _anime_target_for_absolute(adapter, tmdb_id, item, absolute)
+    if target is None:
+        return None
+    return target[1], target[2]
 
 
 def _season_from_scope(value: Any) -> int | None:
@@ -264,11 +283,9 @@ def _rekey_to_source_numbering(adapter: Any, out: dict[str, dict[str, Any]]) -> 
         owned_by_show.setdefault(show, {}).setdefault((season, episode), []).append(key)
 
     for show, record in shows.items():
-        owned = owned_by_show.get(show)
-        if not owned:
-            continue
         wanted: set[tuple[int, int]] = record["coords"]
-        missing = [coord for coord in wanted if coord not in owned]
+        source_owned = owned_by_show.get(show) or {}
+        missing = [coord for coord in wanted if coord not in source_owned]
         if not missing:
             continue
         layout: list[tuple[int, int]] | None = None
@@ -277,18 +294,22 @@ def _rekey_to_source_numbering(adapter: Any, out: dict[str, dict[str, Any]]) -> 
             if absolute is None:
                 continue
             source_item = (record.get("items") or {}).get(coord)
-            real = (
-                _anime_coordinate_for_absolute(adapter, show, source_item, absolute)
-                if isinstance(source_item, Mapping)
-                else None
-            )
+            real_show = show
+            real = None
+            if isinstance(source_item, Mapping):
+                target = _anime_target_for_absolute(adapter, show, source_item, absolute)
+                if target is not None:
+                    real_show, real = target[0], (target[1], target[2])
             if real is None:
                 if layout is None:
                     layout = show_layout(adapter, show)
                 if not layout:
                     continue
                 real = absolute_to_coord(layout, absolute)
-            if real is None or real == coord:
+            if real is None or (real == coord and real_show == show):
+                continue
+            owned = owned_by_show.get(real_show) or {}
+            if not owned:
                 continue
             keys = owned.get(real) or []
             key = ""
@@ -300,7 +321,7 @@ def _rekey_to_source_numbering(adapter: Any, out: dict[str, dict[str, Any]]) -> 
                     if source_event and candidate_event == source_event:
                         key = candidate
                         break
-            if not key and real not in wanted:
+            if not key and (real_show != show or real not in wanted):
                 key = keys[0] if keys else ""
             if not key:
                 continue
@@ -309,6 +330,11 @@ def _rekey_to_source_numbering(adapter: Any, out: dict[str, dict[str, Any]]) -> 
                 continue
             rekeyed = dict(item)
             rekeyed["_floppy_season"], rekeyed["_floppy_episode"] = real
+            if real_show != show:
+                rekeyed["_floppy_tmdb_id"] = real_show
+                show_ids = dict(rekeyed.get("show_ids") or {})
+                show_ids["tmdb"] = show
+                rekeyed["show_ids"] = show_ids
             rekeyed["season"], rekeyed["episode"] = coord
             new_key = _history_key(adapter, rekeyed) if _rewatches_enabled(adapter) else canonical_item_key(rekeyed)
             if new_key in out:
@@ -325,23 +351,25 @@ def _rekey_to_source_numbering(adapter: Any, out: dict[str, dict[str, Any]]) -> 
     return out
 
 
-def _write_coord_result(adapter: Any, tmdb_id: str, item: Mapping[str, Any], season: int, episode: int) -> tuple[int, int, bool]:
+def _write_target_result(adapter: Any, tmdb_id: str, item: Mapping[str, Any], season: int, episode: int) -> tuple[str, int, int, bool]:
     stored = _floppy_coord(item)
     if stored is not None:
-        return stored[0], stored[1], _anime_write_needs_readback(adapter, item, season, episode, stored[0], stored[1])
+        target_id = str(item.get("_floppy_tmdb_id") or tmdb_id or "").strip()
+        return target_id, stored[0], stored[1], _anime_write_needs_readback(adapter, item, season, episode, stored[0], stored[1])
     absolute = _explicit_absolute(item)
     if absolute is None:
-        return season, episode, _anime_write_needs_readback(adapter, item, season, episode, season, episode)
-    mapped = _anime_coordinate_for_absolute(adapter, tmdb_id, item, absolute)
+        return tmdb_id, season, episode, _anime_write_needs_readback(adapter, item, season, episode, season, episode)
+    mapped = _anime_target_for_absolute(adapter, tmdb_id, item, absolute)
     if mapped is not None:
-        return mapped[0], mapped[1], _anime_write_needs_readback(adapter, item, season, episode, mapped[0], mapped[1])
+        target_id, mapped_season, mapped_episode = mapped
+        return target_id, mapped_season, mapped_episode, _anime_write_needs_readback(adapter, item, season, episode, mapped_season, mapped_episode)
     layout = show_layout(adapter, tmdb_id)
     if not layout or has_coord(layout, season, episode):
-        return season, episode, _anime_write_needs_readback(adapter, item, season, episode, season, episode)
+        return tmdb_id, season, episode, _anime_write_needs_readback(adapter, item, season, episode, season, episode)
     real = absolute_to_coord(layout, absolute)
     if real is not None:
-        return real[0], real[1], _anime_write_needs_readback(adapter, item, season, episode, real[0], real[1])
-    return season, episode, _anime_write_needs_readback(adapter, item, season, episode, season, episode)
+        return tmdb_id, real[0], real[1], _anime_write_needs_readback(adapter, item, season, episode, real[0], real[1])
+    return tmdb_id, season, episode, _anime_write_needs_readback(adapter, item, season, episode, season, episode)
 
 
 def _anime_write_needs_readback(
@@ -364,8 +392,13 @@ def _anime_write_needs_readback(
 
 
 def _write_coord(adapter: Any, tmdb_id: str, item: Mapping[str, Any], season: int, episode: int) -> tuple[int, int]:
-    real_season, real_episode, _verify = _write_coord_result(adapter, tmdb_id, item, season, episode)
+    _target_id, real_season, real_episode, _verify = _write_target_result(adapter, tmdb_id, item, season, episode)
     return real_season, real_episode
+
+
+def _write_target(adapter: Any, tmdb_id: str, item: Mapping[str, Any], season: int, episode: int) -> tuple[str, int, int]:
+    target_id, real_season, real_episode, _verify = _write_target_result(adapter, tmdb_id, item, season, episode)
+    return target_id, real_season, real_episode
 
 
 def _history_id(item: Mapping[str, Any]) -> str | None:
@@ -499,6 +532,10 @@ def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
     return _rekey_to_source_numbering(adapter, out)
 
 
+def destination_comparison_view(adapter: Any, index: Mapping[str, Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    return _rekey_to_source_numbering(adapter, {str(k): dict(v) for k, v in (index or {}).items() if isinstance(v, Mapping)})
+
+
 def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
     confirmed: list[str] = []
     unresolved_rows: list[dict[str, Any]] = []
@@ -540,7 +577,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
                 results.append({"status": "dry_run", "item": _history_minimal(adapter, raw), "canonical_key": key})
                 continue
             try:
-                season, episode, verify_after_write = _write_coord_result(adapter, tmdb_id, raw, season, episode)
+                tmdb_id, season, episode, verify_after_write = _write_target_result(adapter, tmdb_id, raw, season, episode)
                 existing_history = _episode_history(adapter, tmdb_id, season, episode)
                 if _rewatches_enabled(adapter) or not existing_history:
                     api_post(adapter, f"media/tv/tmdb/{tmdb_id}/{season}/episodes/{episode}/watch", json={"end_date": _watched_at(raw)})
@@ -605,7 +642,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
                 season, episode = _episode_numbers(raw)
                 if not tmdb_id or season is None or episode is None:
                     raise ValueError("missing episode ids")
-                season, episode = _write_coord(adapter, tmdb_id, raw, season, episode)
+                tmdb_id, season, episode = _write_target(adapter, tmdb_id, raw, season, episode)
                 history_id = _history_id(raw)
                 if not history_id and _rewatches_enabled(adapter):
                     raise ValueError("missing history id")

--- a/tests/test_anime_history_coords_orchestrator.py
+++ b/tests/test_anime_history_coords_orchestrator.py
@@ -8,6 +8,7 @@ from typing import Any, Iterable, Mapping
 
 import pytest
 
+from cw_platform.id_map import canonical_key
 from cw_platform.anime_mapping import storage
 from cw_platform.orchestrator.facade import Orchestrator
 
@@ -19,6 +20,16 @@ MAPPINGS: dict[str, Any] = {
 
 SRC_SHOW_IDS = {"tmdb": "12609", "imdb": "tt0088509", "tvdb": "76666", "mal": "223", "anilist": "223"}
 DST_SHOW_IDS = {"tmdb": "12609", "imdb": "tt0088509", "trakt": "12553"}
+
+
+class _CoordAliases:
+    enabled = True
+
+    def tokens(self, item: Mapping[str, Any]) -> set[str]:
+        return {f"anime:absolute:{item.get('_anime_absolute')}"}
+
+    def stats(self) -> dict[str, int]:
+        return {"absolute_shows": 1, "coord_cache": 1}
 
 
 @dataclass
@@ -116,7 +127,7 @@ def _cfg(anime_enabled: bool) -> dict[str, Any]:
     }
 
 
-def _run(monkeypatch: pytest.MonkeyPatch, anime_enabled: bool) -> FakeOps:
+def _run(monkeypatch: pytest.MonkeyPatch, anime_enabled: bool, *, unresolved_keys: set[str] | None = None) -> FakeOps:
     src = FakeOps("CROSSWATCH", {"tmdb:12609#s02e01": _episode(SRC_SHOW_IDS, 2, 1, absolute=14)})
     dst = FakeOps("MDBLIST", {"tmdb:12609#s01e14": _episode(DST_SHOW_IDS, 1, 14)})
     monkeypatch.setattr(
@@ -124,6 +135,10 @@ def _run(monkeypatch: pytest.MonkeyPatch, anime_enabled: bool) -> FakeOps:
         lambda: {"CROSSWATCH": src, "MDBLIST": dst},
     )
     monkeypatch.setattr("cw_platform.orchestrator._snapshots.provider_configured", lambda _cfg, _name: True)
+    monkeypatch.setattr(
+        "cw_platform.orchestrator._pairs_oneway.load_unresolved_keys",
+        lambda *_a, **_k: set(unresolved_keys or set()),
+    )
     Orchestrator(_cfg(anime_enabled)).run()
     return dst
 
@@ -145,3 +160,50 @@ def test_orchestrator_plans_no_add_with_the_anime_toggle_on(
 
     planned = [it for batch in dst.add_calls for it in batch]
     assert planned == []
+
+
+def test_orchestrator_retries_unresolved_coord_match_with_the_anime_toggle_on(
+    config_base: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_item = {
+        "type": "episode",
+        "title": "Anime source",
+        "season": 2,
+        "episode": 1,
+        "watched_at": "2024-01-01T00:00:00Z",
+        "ids": {},
+        "show_ids": {"tmdb": "111"},
+        "_anime_absolute": 14,
+    }
+    destination_item = {
+        "type": "episode",
+        "title": "Anime destination",
+        "season": 1,
+        "episode": 14,
+        "watched_at": "2024-01-01T00:00:00Z",
+        "ids": {},
+        "show_ids": {"tvdb": "222"},
+        "_anime_absolute": 14,
+    }
+    source_key = canonical_key(source_item)
+    destination_key = canonical_key(destination_item)
+    src = FakeOps("CROSSWATCH", {source_key: source_item})
+    dst = FakeOps("MDBLIST", {destination_key: destination_item})
+    monkeypatch.setattr(
+        "cw_platform.orchestrator.facade.load_sync_providers",
+        lambda: {"CROSSWATCH": src, "MDBLIST": dst},
+    )
+    monkeypatch.setattr("cw_platform.orchestrator._snapshots.provider_configured", lambda _cfg, _name: True)
+    monkeypatch.setattr(
+        "cw_platform.orchestrator._pairs_oneway._build_history_coordinate_aliases",
+        lambda *_a, **_k: _CoordAliases(),
+    )
+    monkeypatch.setattr(
+        "cw_platform.orchestrator._pairs_oneway.load_unresolved_keys",
+        lambda *_a, **_k: {source_key},
+    )
+    Orchestrator(_cfg(False)).run()
+
+    planned = [it for batch in dst.add_calls for it in batch]
+    assert len(planned) == 1
+    assert (planned[0].get("season"), planned[0].get("episode")) == (2, 1)

--- a/tests/test_floppy_sync.py
+++ b/tests/test_floppy_sync.py
@@ -600,6 +600,43 @@ def _fake_overlord_edges(tag: str, namespace: str, ident: str) -> list[dict[str,
     return []
 
 
+def _mha_final_source(**extra: Any) -> dict[str, Any]:
+    return {
+        "type": "episode",
+        "series_title": "Boku no Hero Academia",
+        "season": 8,
+        "episode": 1,
+        "_simkl_episode_number": 1,
+        "watched_at": "2026-01-02T00:00:00Z",
+        "show_ids": {
+            "tmdb": "308405",
+            "imdb": "tt5626028",
+            "tvdb": "305074",
+            "simkl": "2607190",
+            "mal": "60098",
+            "anilist": "182896",
+            "kitsu": "49279",
+            "anidb": "18921",
+        },
+        **extra,
+    }
+
+
+def _fake_mha_final_edges(tag: str, namespace: str, ident: str) -> list[dict[str, Any]]:
+    if tag == "v3" and namespace == "mal" and ident == "60098":
+        return [
+            {
+                "target_provider": "tmdb",
+                "target_kind": "show",
+                "target_id": "65930",
+                "target_scope": "s8",
+                "source_range": "1-11",
+                "target_range": "1-11",
+            }
+        ]
+    return []
+
+
 def test_floppy_history_add_uses_anime_native_coordinate_before_layout_absolute(monkeypatch: Any) -> None:
     from providers.sync.floppy import _history
 
@@ -709,6 +746,87 @@ def test_floppy_history_rekeys_anime_native_coordinate_without_false_missing(mon
 
     produced = _history.prepare_source_snapshot([_overlord_iv_source()])
     out = _history.build_index(adapter)
+
+    assert produced == 1
+    assert "tmdb:64196#s01e40" in out
+    assert "tmdb:64196#s04e01" not in out
+    assert out["tmdb:64196#s01e40"]["_floppy_season"] == 4
+    assert out["tmdb:64196#s01e40"]["_floppy_episode"] == 1
+
+
+def test_floppy_history_add_uses_anime_target_tmdb_when_source_tmdb_conflicts(monkeypatch: Any) -> None:
+    from providers.sync.floppy import _history
+
+    monkeypatch.setattr(_history, "query_edges", _fake_mha_final_edges)
+    _history.prepare_source_snapshot([])
+    _history.reset_layout_cache()
+    routes = _anime_routes("65930", [], {8: 11})
+    routes[("GET", "media/tv/tmdb/65930/8/1/history")] = _history_visible_after_post()
+    routes[("POST", "media/tv/tmdb/65930/8/episodes/1/watch")] = {"consumption_id": 77}
+    adapter = AdapterStub(routes, _anime_history_cfg())
+
+    res = _history.add(adapter, [_mha_final_source()])
+
+    assert res["count"] == 1
+    assert res["confirmed_keys"] == ["tmdb:308405#s08e01"]
+    assert [c["path"] for c in adapter.client.session.calls if c["method"] == "POST"] == ["media/tv/tmdb/65930/8/episodes/1/watch"]
+    assert not any("media/tv/tmdb/308405" in c["path"] for c in adapter.client.session.calls)
+
+
+def test_floppy_history_destination_view_uses_anime_target_tmdb_when_source_tmdb_conflicts(monkeypatch: Any) -> None:
+    from providers.sync._mod_FLOPPY import OPS
+    from providers.sync.floppy import _history
+
+    monkeypatch.setattr(_history, "query_edges", _fake_mha_final_edges)
+    _history.prepare_source_snapshot([])
+    cfg = _anime_history_cfg()
+
+    produced = OPS.prepare_source_snapshot(cfg, feature="history", items={"tmdb:308405#s08e01": _mha_final_source()})
+    out = OPS.destination_comparison_view(
+        cfg,
+        feature="history",
+        index={
+            "tmdb:65930#s08e01": {
+                "type": "episode",
+                "show_ids": {"tmdb": "65930"},
+                "season": 8,
+                "episode": 1,
+                "watched_at": "2026-01-02T00:00:00Z",
+            }
+        },
+    )
+
+    assert produced == 1
+    assert "tmdb:308405#s08e01" in out
+    assert "tmdb:65930#s08e01" not in out
+    assert out["tmdb:308405#s08e01"]["_floppy_tmdb_id"] == "65930"
+    assert out["tmdb:308405#s08e01"]["_floppy_season"] == 8
+    assert out["tmdb:308405#s08e01"]["_floppy_episode"] == 1
+
+
+def test_floppy_history_destination_comparison_view_rekeys_collapsed_anime_coord(monkeypatch: Any) -> None:
+    from providers.sync._mod_FLOPPY import OPS
+    from providers.sync.floppy import _history
+
+    monkeypatch.setattr(_history, "query_edges", _fake_overlord_edges)
+    _history.prepare_source_snapshot([])
+    cfg = _anime_history_cfg()
+    source = _overlord_iv_source()
+
+    produced = OPS.prepare_source_snapshot(cfg, feature="history", items={"tmdb:64196#s01e40": source})
+    out = OPS.destination_comparison_view(
+        cfg,
+        feature="history",
+        index={
+            "tmdb:64196#s04e01": {
+                "type": "episode",
+                "show_ids": {"tmdb": "64196"},
+                "season": 4,
+                "episode": 1,
+                "watched_at": "2026-01-02T00:00:00Z",
+            }
+        },
+    )
 
     assert produced == 1
     assert "tmdb:64196#s01e40" in out

--- a/tests/test_twoway_history_specials.py
+++ b/tests/test_twoway_history_specials.py
@@ -66,19 +66,31 @@ class _Ops:
         return {"history": {"observed_deletes": False, "upsert": self.history_upsert}}
 
 
+class _CoordAliases:
+    enabled = True
+
+    def tokens(self, item: dict[str, Any]) -> set[str]:
+        return {f"anime:absolute:{item.get('_anime_absolute')}"}
+
+    def stats(self) -> dict[str, int]:
+        return {"absolute_shows": 1, "coord_cache": 1}
+
+
 def _run_two_way(
     monkeypatch,
     snapshots: dict[str, dict[str, dict[str, Any]]],
     *,
     trakt_upsert: bool = False,
     simkl_upsert: bool = False,
+    a: str = "TRAKT",
+    b: str = "SIMKL",
 ):
     trakt = _Ops(history_upsert=trakt_upsert)
     simkl = _Ops(history_upsert=simkl_upsert)
     monkeypatch.setattr(twoway, "build_snapshots_for_feature", lambda **_kwargs: snapshots)
     ctx = SimpleNamespace(
         config={"sync": {"include_observed_deletes": False, "blackbox": {"enabled": False}}, "runtime": {}},
-        providers={"TRAKT": trakt, "SIMKL": simkl},
+        providers={a: trakt, b: simkl},
         emit=lambda *_args, **_kwargs: None,
         emit_info=lambda *_args, **_kwargs: None,
         dbg=lambda *_args, **_kwargs: None,
@@ -89,7 +101,7 @@ def _run_two_way(
         stats_manual_blocked=0,
         apply_chunk_pause_ms=0,
     )
-    result = twoway._two_way_sync(ctx, "TRAKT", "SIMKL", feature="history", fcfg={}, health_map={})
+    result = twoway._two_way_sync(ctx, a, b, feature="history", fcfg={}, health_map={})
     return result, trakt, simkl
 
 
@@ -137,6 +149,53 @@ def test_trakt_simkl_two_way_routes_and_converges_special(monkeypatch) -> None:
     assert converged_result["adds_to_B"] == 0
     assert trakt.added == []
     assert simkl.added == []
+
+
+def test_two_way_retries_unresolved_coord_match(monkeypatch) -> None:
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(twoway, "_build_history_coordinate_aliases", lambda *_args, **_kwargs: _CoordAliases())
+
+    source_item = {
+        "type": "episode",
+        "title": "Anime source",
+        "season": 2,
+        "episode": 1,
+        "watched_at": WATCHED_AT,
+        "ids": {},
+        "show_ids": {"tmdb": "111"},
+        "_anime_absolute": 14,
+    }
+    destination_item = {
+        "type": "episode",
+        "title": "Anime destination",
+        "season": 1,
+        "episode": 14,
+        "watched_at": WATCHED_AT,
+        "ids": {},
+        "show_ids": {"tvdb": "222"},
+        "_anime_absolute": 14,
+    }
+    source_key = canonical_key(source_item)
+    destination_key = canonical_key(destination_item)
+    monkeypatch.setattr(
+        twoway,
+        "load_unresolved_keys",
+        lambda dst, *_args, **_kwargs: {source_key} if dst == "DST" else set(),
+    )
+
+    result, trakt, simkl = _run_two_way(
+        monkeypatch,
+        {"SRC": {source_key: source_item}, "DST": {destination_key: destination_item}},
+        a="SRC",
+        b="DST",
+    )
+
+    assert result["adds_to_A"] == 0
+    assert result["resB_add"]["attempted"] == 1
+    assert trakt.added == []
+    assert len(simkl.added) == 1
+    assert simkl.added[0]["season"] == 2
+    assert simkl.added[0]["episode"] == 1
 
 
 def test_manual_history_date_correction_updates_upsert_peer(monkeypatch) -> None:


### PR DESCRIPTION
# Pull request

## Change

- Fixes FLOPPY anime history writes when the source TMDB id differs from the anime target.
- Also keeps unresolved anime coordinate matches retryable instead of pruning them before apply.

## Why

- Some anime history entries looked synced, but were written to the wrong provider coordinate or stopped retrying too early.
- Unresolved items should keep retrying until the blackbox limit handles them.

## Testing

- tests/test_floppy_sync.py 
- tests/test_anime_history_coords.py 
- tests/test_anime_history_coords_orchestrator.py 
- tests/test_twoway_history_specials.py 
- tests/test_twoway_anime_comparison_view.py 
- providers/tests/test_mdblist_history_anime_mapping.py 
- providers/tests/test_simkl_history_tmdb_only_anime.py 
- tests/test_history_specials.py

## Issue

Relates to #809