### PR TITLE
Add: BingeBase realtime scrobbling

### DIFF
--- a/assets/js/modals/scrobbler-route/index.js
+++ b/assets/js/modals/scrobbler-route/index.js
@@ -1,8 +1,8 @@
 /* CrossWatch - Scrobbler Route Modal */
 const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
-const label = (v) => ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", kodi: "Kodi", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy", punchplay: "PunchPlay", scrob: "Scrob" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
+const label = (v) => ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", kodi: "Kodi", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy", punchplay: "PunchPlay", bingebase: "BingeBase", scrob: "Scrob" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
 const sources = ["plex", "jellyfin", "emby", "kodi", "scrob"];
-const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "scrob"];
+const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "bingebase", "scrob"];
 const ratingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "scrob"];
 
 function flashCopied(btn) {

--- a/assets/js/modals/scrobbler-webhook/index.js
+++ b/assets/js/modals/scrobbler-webhook/index.js
@@ -1,7 +1,7 @@
 /* CrossWatch - Scrobbler Webhook Modal */
 const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
-const label = (v) => window.CW?.ProviderMeta?.label?.(v) || ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy", punchplay: "PunchPlay", scrob: "Scrob" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
-const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "scrob"];
+const label = (v) => window.CW?.ProviderMeta?.label?.(v) || ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy", punchplay: "PunchPlay", bingebase: "BingeBase", scrob: "Scrob" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
+const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "bingebase", "scrob"];
 const ratingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "scrob"];
 const webhookSources = new Set(["plex", "jellyfin", "emby"]);
 

--- a/providers/scrobble/bingebase/__init__.py
+++ b/providers/scrobble/bingebase/__init__.py
@@ -1,0 +1,3 @@
+# providers/scrobble/bingebase/__init__.py
+
+__all__: list[str] = []

--- a/providers/scrobble/bingebase/sink.py
+++ b/providers/scrobble/bingebase/sink.py
@@ -45,6 +45,11 @@ ACTION_NOTIFICATION = {
 KODI_WEBHOOK_PATH = "/webhooks/kodi/"
 
 
+def _is_bingebase_host(host: Any) -> bool:
+    text = str(host or "").strip().lower().rstrip(".")
+    return text == "bingebase.com" or text.endswith(".bingebase.com")
+
+
 def _cfg() -> dict[str, Any]:
     try:
         return load_config() or {}
@@ -81,7 +86,7 @@ def _redact_url(url: Any) -> str:
         if not parts.scheme or not parts.netloc:
             return "<redacted>"
         path = parts.path
-        if parts.netloc.lower().endswith("bingebase.com") and path.startswith(KODI_WEBHOOK_PATH):
+        if path.startswith(KODI_WEBHOOK_PATH):
             path = KODI_WEBHOOK_PATH.rstrip("/")
         return urlunsplit((parts.scheme, parts.netloc, path, "", ""))
     except Exception:
@@ -91,7 +96,7 @@ def _redact_url(url: Any) -> str:
 def _is_kodi_webhook(url: Any) -> bool:
     try:
         parts = urlsplit(str(url or "").strip())
-        return parts.netloc.lower().endswith("bingebase.com") and parts.path.startswith(KODI_WEBHOOK_PATH)
+        return _is_bingebase_host(parts.hostname) and parts.path.startswith(KODI_WEBHOOK_PATH)
     except Exception:
         return False
 

--- a/providers/scrobble/bingebase/sink.py
+++ b/providers/scrobble/bingebase/sink.py
@@ -1,0 +1,353 @@
+# providers/scrobble/bingebase/sink.py
+# CrossWatch - BingeBase realtime scrobble sink
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+import requests
+
+from cw_platform.config_base import load_config
+from cw_platform.provider_instances import normalize_instance_id, resolve_provider_block
+from services.activity import record_scrobble_event
+
+try:
+    from _logging import log as BASE_LOG
+except Exception:
+    BASE_LOG = None
+
+try:
+    from providers.scrobble.scrobble import ScrobbleSink, mask_account  # type: ignore
+except ImportError:
+    class ScrobbleSink:  # pragma: no cover
+        def send(self, event: Any) -> None: ...
+
+    def mask_account(value: Any) -> str:  # pragma: no cover
+        s = str(value or "").strip()
+        if not s:
+            return "unknown"
+        return s[0] + "*" if len(s) <= 2 else s[:2] + "***"
+
+
+APP_AGENT = "CrossWatch/BingeBaseWebhook/1.0"
+ACTION_EVENT = {
+    "start": "playback.start",
+    "pause": "playback.pause",
+    "stop": "playback.stop",
+}
+ACTION_NOTIFICATION = {
+    "start": "PlaybackStart",
+    "pause": "PlaybackStart",
+    "stop": "PlaybackStop",
+}
+KODI_WEBHOOK_PATH = "/webhooks/kodi/"
+
+
+def _cfg() -> dict[str, Any]:
+    try:
+        return load_config() or {}
+    except Exception:
+        return {}
+
+
+def _is_debug() -> bool:
+    try:
+        return bool((_cfg().get("runtime") or {}).get("debug"))
+    except Exception:
+        return False
+
+
+def _log(msg: str, lvl: str = "INFO") -> None:
+    level = (str(lvl) or "INFO").upper()
+    if level == "DEBUG" and not _is_debug():
+        return
+    if BASE_LOG is not None:
+        try:
+            BASE_LOG(msg, level=level, module="SCROBBLE")
+            return
+        except Exception:
+            pass
+    print(f"[SCROBBLE] {level}: {msg}")
+
+
+def _redact_url(url: Any) -> str:
+    text = str(url or "").strip()
+    if not text:
+        return ""
+    try:
+        parts = urlsplit(text)
+        if not parts.scheme or not parts.netloc:
+            return "<redacted>"
+        path = parts.path
+        if parts.netloc.lower().endswith("bingebase.com") and path.startswith(KODI_WEBHOOK_PATH):
+            path = KODI_WEBHOOK_PATH.rstrip("/")
+        return urlunsplit((parts.scheme, parts.netloc, path, "", ""))
+    except Exception:
+        return "<redacted>"
+
+
+def _is_kodi_webhook(url: Any) -> bool:
+    try:
+        parts = urlsplit(str(url or "").strip())
+        return parts.netloc.lower().endswith("bingebase.com") and parts.path.startswith(KODI_WEBHOOK_PATH)
+    except Exception:
+        return False
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(str(value).strip())
+    except Exception:
+        return None
+
+
+def _imdb(value: Any) -> str | None:
+    text = str(value or "").strip().lower()
+    if not text:
+        return None
+    if not text.startswith("tt"):
+        text = f"tt{text.lstrip('t')}"
+    rest = text[2:]
+    return text if rest.isdigit() and rest else None
+
+
+def _provider_ids(ids: Mapping[str, Any], media_type: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    tmdb = _as_int(ids.get("tmdb"))
+    imdb = _imdb(ids.get("imdb"))
+    if tmdb and tmdb > 0:
+        out["Tmdb"] = str(tmdb)
+    if imdb:
+        out["Imdb"] = imdb
+    if media_type == "episode":
+        show_tmdb = _as_int(ids.get("tmdb_show"))
+        if show_tmdb and show_tmdb > 0:
+            out["ShowTmdb"] = str(show_tmdb)
+    return out
+
+
+def _kodi_unique_ids(ids: Mapping[str, Any], media_type: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name in ("tmdb", "tvdb", "imdb"):
+        value = ids.get(f"{name}_episode") if media_type == "episode" else ids.get(name)
+        value = value or ids.get(name)
+        text = str(value or "").strip()
+        if text:
+            out[name] = text
+    return out
+
+
+def _kodi_show_unique_ids(ids: Mapping[str, Any]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name in ("tmdb", "tvdb", "imdb"):
+        text = str(ids.get(f"{name}_show") or "").strip()
+        if text:
+            out[name] = text
+    return out
+
+
+def _progress(value: Any) -> float:
+    try:
+        return max(0.0, min(100.0, float(value or 0.0)))
+    except Exception:
+        return 0.0
+
+
+def _ms_to_seconds(value: Any) -> int | None:
+    num = _as_int(value)
+    if num is None or num <= 0:
+        return None
+    return max(1, int(round(num / 1000.0)))
+
+
+def _route_source(cfg: Mapping[str, Any]) -> tuple[str, str]:
+    watch = ((cfg.get("scrobble") or {}).get("watch") or {}) if isinstance(cfg, Mapping) else {}
+    source = str(watch.get("route_provider") or "watcher").strip().lower() or "watcher"
+    source_instance = str(watch.get("route_provider_instance") or "default").strip() or "default"
+    return source, source_instance
+
+
+class BingeBaseSink(ScrobbleSink):
+    name = "bingebase"
+
+    def __init__(self, cfg_provider: Callable[[], dict[str, Any]] | None = None, instance_id: Any = None) -> None:
+        self._cfg_provider = cfg_provider
+        self.instance_id = normalize_instance_id(instance_id)
+        self.session = requests.Session()
+        try:
+            self.session.headers.setdefault("Accept", "application/json")
+            self.session.headers.setdefault("User-Agent", APP_AGENT)
+        except Exception:
+            pass
+
+    @property
+    def config(self) -> dict[str, Any]:
+        if self._cfg_provider is not None:
+            try:
+                cfg = self._cfg_provider()
+                if isinstance(cfg, Mapping):
+                    return dict(cfg)
+            except Exception:
+                pass
+        return _cfg()
+
+    def _block(self, cfg: Mapping[str, Any]) -> dict[str, Any]:
+        try:
+            return resolve_provider_block(cfg, "bingebase", self.instance_id) or {}
+        except Exception:
+            block = cfg.get("bingebase") if isinstance(cfg, Mapping) else None
+            return dict(block) if isinstance(block, Mapping) else {}
+
+    def _jellyfin_payload(self, event: Any, action: str, media_type: str, ids: Mapping[str, Any], title: str) -> dict[str, Any] | None:
+        provider_ids = _provider_ids(ids, media_type)
+        if not provider_ids:
+            _log("BINGEBASE: skip scrobble, no supported ids", "DEBUG")
+            return None
+
+        item: dict[str, Any] = {
+            "Name": title,
+            "Type": "Episode" if media_type == "episode" else "Movie",
+            "ProviderIds": provider_ids,
+        }
+        year = _as_int(getattr(event, "year", None))
+        if year and media_type == "movie":
+            item["ProductionYear"] = year
+
+        if media_type == "episode":
+            season = _as_int(getattr(event, "season", None))
+            episode = _as_int(getattr(event, "number", None))
+            if season is None or episode is None:
+                _log("BINGEBASE: skip scrobble, episode missing season/episode", "DEBUG")
+                return None
+            item["ParentIndexNumber"] = season
+            item["IndexNumber"] = episode
+            item["SeriesName"] = title
+
+        return {
+            "Event": ACTION_EVENT[action],
+            "NotificationType": ACTION_NOTIFICATION[action],
+            "Item": item,
+            "Percentage": round(_progress(getattr(event, "progress", 0.0)), 1),
+        }
+
+    def _kodi_payload(self, event: Any, action: str, media_type: str, ids: Mapping[str, Any], title: str) -> dict[str, Any] | None:
+        unique_ids = _kodi_unique_ids(ids, media_type)
+        show_unique_ids = _kodi_show_unique_ids(ids) if media_type == "episode" else {}
+        if not unique_ids and not show_unique_ids:
+            _log("BINGEBASE: skip scrobble, no supported ids", "DEBUG")
+            return None
+
+        payload: dict[str, Any] = {
+            "mediaType": media_type,
+            "title": title,
+            "uniqueIds": unique_ids,
+            "event": action,
+            "progress": {"percent": round(_progress(getattr(event, "progress", 0.0)), 1)},
+        }
+        year = _as_int(getattr(event, "year", None))
+        if year:
+            payload["year"] = year
+
+        duration = _ms_to_seconds(getattr(event, "duration_ms", None))
+        if duration:
+            payload["duration"] = duration
+            position = _ms_to_seconds(getattr(event, "position_ms", None))
+            if position is None:
+                position = int(round(duration * (_progress(getattr(event, "progress", 0.0)) / 100.0)))
+            payload["progress"]["time"] = max(0, min(position, duration))
+
+        if media_type == "episode":
+            season = _as_int(getattr(event, "season", None))
+            episode = _as_int(getattr(event, "number", None))
+            if season is None or episode is None:
+                _log("BINGEBASE: skip scrobble, episode missing season/episode", "DEBUG")
+                return None
+            payload["tvShowTitle"] = title
+            payload["season"] = season
+            payload["episode"] = episode
+            payload["showUniqueIds"] = show_unique_ids
+
+        return payload
+
+    def _payload(self, event: Any, webhook_url: Any = None) -> dict[str, Any] | None:
+        action = str(getattr(event, "action", "") or "").strip().lower()
+        if action not in ACTION_EVENT:
+            return None
+
+        media_type = "episode" if str(getattr(event, "media_type", "") or "").lower() == "episode" else "movie"
+        ids = getattr(event, "ids", None) or {}
+        ids = ids if isinstance(ids, Mapping) else {}
+
+        title = str(getattr(event, "title", "") or "").strip()
+        if not title:
+            _log("BINGEBASE: skip scrobble, missing title", "DEBUG")
+            return None
+
+        if _is_kodi_webhook(webhook_url):
+            return self._kodi_payload(event, action, media_type, ids, title)
+        return self._jellyfin_payload(event, action, media_type, ids, title)
+
+    def send(self, event: Any, cfg: Mapping[str, Any] | None = None) -> None:
+        cfgd = dict(cfg) if isinstance(cfg, Mapping) else self.config
+        block = self._block(cfgd)
+        webhook_url = str(block.get("webhook_url") or "").strip()
+        if not webhook_url:
+            _log("BINGEBASE: skip scrobble, webhook URL not configured", "DEBUG")
+            return
+
+        payload = self._payload(event, webhook_url)
+        if payload is None:
+            return
+
+        try:
+            timeout = float(block.get("timeout") or 20.0)
+        except Exception:
+            timeout = 20.0
+
+        headers = {"Accept": "application/json", "Content-Type": "application/json", "User-Agent": APP_AGENT}
+        api_key = str(block.get("api_key") or "").strip()
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        action = str(getattr(event, "action", "") or "").strip().lower()
+        src, src_inst = _route_source(cfgd)
+        try:
+            resp = self.session.post(
+                webhook_url,
+                json=payload,
+                headers=headers,
+                timeout=max(1.0, timeout),
+            )
+        except Exception as exc:
+            _log(f"BINGEBASE: scrobble {action} failed ({exc.__class__.__name__}) target={_redact_url(webhook_url)}", "WARN")
+            return
+
+        code = int(getattr(resp, "status_code", 0) or 0)
+        if not (200 <= code < 300):
+            _log(f"BINGEBASE: scrobble {action} rejected status={code} target={_redact_url(webhook_url)}", "WARN")
+            return
+
+        _log(
+            f"BINGEBASE: scrobble {action} user='{mask_account(getattr(event, 'account', None))}' "
+            f"p={_progress(getattr(event, 'progress', 0.0)):.1f}% source={src}:{src_inst}",
+            "INFO",
+        )
+        if action == "stop":
+            try:
+                record_scrobble_event(
+                    event,
+                    source=src,
+                    source_instance=src_inst,
+                    target="bingebase",
+                    target_instance=self.instance_id,
+                    progress=_progress(getattr(event, "progress", 0.0)),
+                )
+            except Exception:
+                pass
+
+
+__all__ = ["BingeBaseSink", "_redact_url"]

--- a/providers/scrobble/routes.py
+++ b/providers/scrobble/routes.py
@@ -9,7 +9,7 @@ from cw_platform.provider_instances import get_provider_block, normalize_instanc
 
 DEFAULT_INSTANCE_ID = "default"
 ROUTE_PROVIDERS = {"plex", "emby", "jellyfin", "kodi", "scrob"}
-ROUTE_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "scrob"}
+ROUTE_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "bingebase", "scrob"}
 ROUTE_RATING_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "scrob"}
 ROUTE_OPTION_STATES = {"inherit", "on", "off"}
 ROUTE_RATINGS_MODES = {"off", "custom"}

--- a/providers/scrobble/watch_manager.py
+++ b/providers/scrobble/watch_manager.py
@@ -170,6 +170,10 @@ def _make_sink(name: str, cfg_provider: Callable[[], dict[str, Any]], instance_i
         from providers.scrobble.punchplay.sink import PunchPlaySink
 
         cls = PunchPlaySink
+    elif sink == "bingebase":
+        from providers.scrobble.bingebase.sink import BingeBaseSink
+
+        cls = BingeBaseSink
     elif sink == "scrob":
         from providers.scrobble.scrob.sink import ScrobSink
 

--- a/providers/webhooks/config.py
+++ b/providers/webhooks/config.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from cw_platform.provider_instances import get_provider_block, normalize_instance_id
 
-_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "scrob"}
+_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "bingebase", "scrob"}
 
 _SINK_CREDENTIALS: dict[str, tuple[str, ...]] = {
     "trakt": ("access_token",),
@@ -17,6 +17,7 @@ _SINK_CREDENTIALS: dict[str, tuple[str, ...]] = {
     "mdblist": ("api_key", "access_token"),
     "floppy": ("server_url", "api_token"),
     "punchplay": ("access_token",),
+    "bingebase": ("webhook_url",),
     "scrob": ("api_key",),
 }
 

--- a/providers/webhooks/dispatch.py
+++ b/providers/webhooks/dispatch.py
@@ -88,6 +88,10 @@ def _make_sink(name: str, instance_id: str, cfg_provider: Callable[[], dict[str,
         from providers.scrobble.punchplay.sink import PunchPlaySink
 
         cls = PunchPlaySink
+    elif sink == "bingebase":
+        from providers.scrobble.bingebase.sink import BingeBaseSink
+
+        cls = BingeBaseSink
     elif sink == "scrob":
         from providers.scrobble.scrob.sink import ScrobSink
 

--- a/tests/test_bingebase_scrobble.py
+++ b/tests/test_bingebase_scrobble.py
@@ -259,7 +259,7 @@ def test_failed_stop_does_not_record_recent_scrobble_activity(monkeypatch: pytes
 def test_secret_url_redaction(monkeypatch: pytest.MonkeyPatch) -> None:
     from cw_platform.config_base import redact_config
     from providers.scrobble.bingebase import sink as sink_mod
-    from providers.scrobble.bingebase.sink import BingeBaseSink, _redact_url
+    from providers.scrobble.bingebase.sink import BingeBaseSink, _is_kodi_webhook, _redact_url
 
     logs: list[str] = []
     sink = BingeBaseSink(cfg_provider=lambda: dict(CFG))
@@ -270,6 +270,9 @@ def test_secret_url_redaction(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert _redact_url(WEBHOOK_URL) == "https://bingebase.com/api/webhooks/jellyfin"
     assert _redact_url(KODI_WEBHOOK_URL) == "https://bingebase.com/webhooks/kodi"
+    assert _redact_url("https://evilbingebase.com/webhooks/kodi/device-access") == "https://evilbingebase.com/webhooks/kodi"
+    assert _is_kodi_webhook(KODI_WEBHOOK_URL) is True
+    assert _is_kodi_webhook("https://evilbingebase.com/webhooks/kodi/device-access") is False
     assert "secret-token" not in "\n".join(logs)
     assert "device-access" not in _redact_url(KODI_WEBHOOK_URL)
     assert "token=" not in "\n".join(logs)

--- a/tests/test_bingebase_scrobble.py
+++ b/tests/test_bingebase_scrobble.py
@@ -1,0 +1,278 @@
+# CrossWatch BingeBase scrobble tests
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+
+class _Resp:
+    def __init__(self, status_code: int = 200, payload: Any = None) -> None:
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = json.dumps(self._payload)
+        self.headers: dict[str, str] = {}
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class Event:
+    def __init__(self, **kw: Any) -> None:
+        self.action = kw.get("action", "start")
+        self.media_type = kw.get("media_type", "movie")
+        self.ids = kw.get("ids", {"tmdb": "550", "imdb": "tt0137523"})
+        self.title = kw.get("title", "Fight Club")
+        self.year = kw.get("year", 1999)
+        self.season = kw.get("season")
+        self.number = kw.get("number")
+        self.progress = kw.get("progress", 10.0)
+        self.account = kw.get("account", "user@example.com")
+        self.server_uuid = kw.get("server_uuid", "srv-1")
+        self.session_key = kw.get("session_key", "sess-1")
+        self.raw = kw.get("raw", {})
+        self.position_ms = kw.get("position_ms")
+        self.duration_ms = kw.get("duration_ms")
+
+
+WEBHOOK_URL = "https://bingebase.com/api/webhooks/jellyfin?token=secret-token"
+KODI_WEBHOOK_URL = "https://bingebase.com/webhooks/kodi/device-access"
+CFG = {
+    "bingebase": {"webhook_url": WEBHOOK_URL, "access_token": "device-access", "api_key": "bearer-secret"},
+    "scrobble": {"watch": {"watched_at": 90}},
+}
+
+
+@pytest.fixture()
+def sink(monkeypatch: pytest.MonkeyPatch):
+    from providers.scrobble.bingebase.sink import BingeBaseSink
+
+    calls: list[dict[str, Any]] = []
+    s = BingeBaseSink(cfg_provider=lambda: dict(CFG))
+
+    def fake_post(url: str, **kwargs: Any) -> _Resp:
+        calls.append({"url": url, **kwargs})
+        return _Resp(200, {})
+
+    monkeypatch.setattr(s.session, "post", fake_post)
+    return s, calls
+
+
+def test_sink_is_registered_for_webhook_and_watcher_destinations() -> None:
+    from providers.scrobble.bingebase.sink import BingeBaseSink
+    from providers.scrobble.routes import ROUTE_RATING_SINKS, ROUTE_SINKS, build_route_cfg, normalize_route
+    from providers.scrobble.watch_manager import _make_sink
+    from providers.webhooks.config import sink_configured, webhook_sinks
+    from providers.webhooks.dispatch import _make_sink as make_webhook_sink
+
+    route = normalize_route({"id": "R1", "provider": "plex", "sink": "bingebase"}, "R1")
+    view = build_route_cfg(CFG, route)
+
+    assert "bingebase" in ROUTE_SINKS
+    assert "bingebase" not in ROUTE_RATING_SINKS
+    assert route["sink"] == "bingebase"
+    assert view["bingebase"]["webhook_url"] == WEBHOOK_URL
+    assert sink_configured(CFG, "bingebase", "default") is True
+    assert isinstance(_make_sink("bingebase", lambda: dict(CFG), "default"), BingeBaseSink)
+    assert isinstance(make_webhook_sink("bingebase", "default", lambda: dict(CFG)), BingeBaseSink)
+
+    cfg = {**CFG, "scrobble": {"webhook": {"sinks": ["bingebase"]}}}
+    assert "bingebase" in webhook_sinks(cfg, "plex", "default")
+
+
+def test_movie_payload_shape(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(action="start", progress=12.3456))
+    payload = calls[0]["json"]
+
+    assert calls[0]["url"] == WEBHOOK_URL
+    assert calls[0]["headers"]["Authorization"] == "Bearer bearer-secret"
+    assert payload["Event"] == "playback.start"
+    assert payload["NotificationType"] == "PlaybackStart"
+    assert payload["Percentage"] == 12.3
+    assert payload["Item"]["Name"] == "Fight Club"
+    assert payload["Item"]["Type"] == "Movie"
+    assert payload["Item"]["ProductionYear"] == 1999
+    assert payload["Item"]["ProviderIds"] == {"Tmdb": "550", "Imdb": "tt0137523"}
+
+
+def test_episode_payload_shape(sink) -> None:
+    s, calls = sink
+
+    s.send(Event(
+        action="pause",
+        media_type="episode",
+        title="Severance",
+        season=1,
+        number=2,
+        ids={"tmdb": "5978363", "imdb": "tt11280740", "tmdb_show": "95396"},
+        progress=45,
+    ))
+    item = calls[0]["json"]["Item"]
+
+    assert calls[0]["json"]["Event"] == "playback.pause"
+    assert item["Type"] == "Episode"
+    assert item["SeriesName"] == "Severance"
+    assert item["ParentIndexNumber"] == 1
+    assert item["IndexNumber"] == 2
+    assert item["ProviderIds"] == {"Tmdb": "5978363", "Imdb": "tt11280740", "ShowTmdb": "95396"}
+
+
+def test_kodi_webhook_uses_kodi_payload_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.bingebase.sink import BingeBaseSink
+
+    calls: list[dict[str, Any]] = []
+    cfg = {"bingebase": {"webhook_url": KODI_WEBHOOK_URL, "access_token": "device-access"}}
+    s = BingeBaseSink(cfg_provider=lambda: cfg)
+    monkeypatch.setattr(s.session, "post", lambda url, **kwargs: calls.append({"url": url, **kwargs}) or _Resp(200, {}))
+
+    s.send(Event(action="start", progress=25, duration_ms=400000, position_ms=100000))
+
+    payload = calls[0]["json"]
+    assert calls[0]["url"] == KODI_WEBHOOK_URL
+    assert "Authorization" not in calls[0]["headers"]
+    assert payload["event"] == "start"
+    assert payload["mediaType"] == "movie"
+    assert payload["title"] == "Fight Club"
+    assert payload["uniqueIds"] == {"tmdb": "550", "imdb": "tt0137523"}
+    assert payload["duration"] == 400
+    assert payload["progress"] == {"percent": 25.0, "time": 100}
+
+
+def test_kodi_webhook_episode_payload_includes_show_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.bingebase.sink import BingeBaseSink
+
+    calls: list[dict[str, Any]] = []
+    cfg = {"bingebase": {"webhook_url": KODI_WEBHOOK_URL, "access_token": "device-access"}}
+    s = BingeBaseSink(cfg_provider=lambda: cfg)
+    monkeypatch.setattr(s.session, "post", lambda url, **kwargs: calls.append({"url": url, **kwargs}) or _Resp(200, {}))
+
+    s.send(Event(
+        action="pause",
+        media_type="episode",
+        title="Severance",
+        season=1,
+        number=2,
+        ids={"tmdb_episode": "5978363", "imdb_episode": "tt11280740", "tmdb_show": "95396"},
+        progress=45,
+    ))
+
+    payload = calls[0]["json"]
+    assert payload["event"] == "pause"
+    assert payload["mediaType"] == "episode"
+    assert payload["tvShowTitle"] == "Severance"
+    assert payload["season"] == 1
+    assert payload["episode"] == 2
+    assert payload["uniqueIds"] == {"tmdb": "5978363", "imdb": "tt11280740"}
+    assert payload["showUniqueIds"] == {"tmdb": "95396"}
+
+
+def test_start_pause_stop_mapping(sink) -> None:
+    s, calls = sink
+
+    for action in ("start", "pause", "stop"):
+        s.send(Event(action=action))
+
+    payloads = [call["json"] for call in calls]
+    assert [p["Event"] for p in payloads] == ["playback.start", "playback.pause", "playback.stop"]
+    assert [p["NotificationType"] for p in payloads] == ["PlaybackStart", "PlaybackStart", "PlaybackStop"]
+
+
+def test_webhook_dispatch_reaches_bingebase(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.bingebase import sink as sink_mod
+    from providers.webhooks.dispatch import dispatch_scrobble
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_post(self: Any, url: str, **kwargs: Any) -> _Resp:
+        calls.append({"url": url, **kwargs})
+        return _Resp(200, {})
+
+    monkeypatch.setattr(sink_mod.requests.Session, "post", fake_post)
+    cfg = {
+        "plex": {"account_token": "source-token"},
+        "bingebase": {"webhook_url": WEBHOOK_URL, "api_key": "bearer-secret"},
+        "scrobble": {"webhook": {"sinks": ["bingebase"]}},
+    }
+
+    res = dispatch_scrobble("plex", "/start", media_type="movie", ids={"tmdb": "550"}, title="Fight Club", progress=10, cfg=cfg)
+
+    assert res.status_code == 200
+    assert res.json()["targets"][0]["target"] == "bingebase"
+    assert calls and calls[0]["json"]["Item"]["ProviderIds"]["Tmdb"] == "550"
+    assert calls[0]["headers"]["Authorization"] == "Bearer bearer-secret"
+
+
+def test_watcher_dispatch_reaches_bingebase(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.bingebase import sink as sink_mod
+    from providers.scrobble.scrobble import Dispatcher
+    from providers.scrobble.watch_manager import _make_sink
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_post(self: Any, url: str, **kwargs: Any) -> _Resp:
+        calls.append({"url": url, **kwargs})
+        return _Resp(200, {})
+
+    monkeypatch.setattr(sink_mod.requests.Session, "post", fake_post)
+    sink = _make_sink("bingebase", lambda: dict(CFG), "default")
+    dispatcher = Dispatcher([sink], cfg_provider=lambda: dict(CFG))
+
+    assert dispatcher.dispatch(Event(action="start")) is True
+    assert calls and calls[0]["url"] == WEBHOOK_URL
+
+
+def test_successful_stop_records_recent_scrobble_activity(sink, monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.bingebase import sink as sink_mod
+
+    s, _calls = sink
+    activity: list[dict[str, Any]] = []
+    monkeypatch.setattr(sink_mod, "record_scrobble_event", lambda ev, **kwargs: activity.append(kwargs))
+
+    s.send(Event(action="start", progress=86))
+    s.send(Event(action="stop", progress=97))
+
+    assert len(activity) == 1
+    assert activity[0]["source"] == "watcher"
+    assert activity[0]["source_instance"] == "default"
+    assert activity[0]["target"] == "bingebase"
+    assert activity[0]["target_instance"] == "default"
+    assert activity[0]["progress"] == 97.0
+
+
+def test_failed_stop_does_not_record_recent_scrobble_activity(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.bingebase import sink as sink_mod
+    from providers.scrobble.bingebase.sink import BingeBaseSink
+
+    activity: list[dict[str, Any]] = []
+    s = BingeBaseSink(cfg_provider=lambda: dict(CFG))
+    monkeypatch.setattr(s.session, "post", lambda url, **kwargs: _Resp(500, {}))
+    monkeypatch.setattr(sink_mod, "record_scrobble_event", lambda ev, **kwargs: activity.append(kwargs))
+
+    s.send(Event(action="stop", progress=97))
+
+    assert activity == []
+
+
+def test_secret_url_redaction(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cw_platform.config_base import redact_config
+    from providers.scrobble.bingebase import sink as sink_mod
+    from providers.scrobble.bingebase.sink import BingeBaseSink, _redact_url
+
+    logs: list[str] = []
+    sink = BingeBaseSink(cfg_provider=lambda: dict(CFG))
+    monkeypatch.setattr(sink_mod, "BASE_LOG", lambda msg, **kw: logs.append(str(msg)))
+    monkeypatch.setattr(sink.session, "post", lambda url, **kw: _Resp(500, {"error": "nope"}))
+
+    sink.send(Event(action="stop"))
+
+    assert _redact_url(WEBHOOK_URL) == "https://bingebase.com/api/webhooks/jellyfin"
+    assert _redact_url(KODI_WEBHOOK_URL) == "https://bingebase.com/webhooks/kodi"
+    assert "secret-token" not in "\n".join(logs)
+    assert "device-access" not in _redact_url(KODI_WEBHOOK_URL)
+    assert "token=" not in "\n".join(logs)
+    redacted = json.dumps(redact_config({"bingebase": {"webhook_url": WEBHOOK_URL, "api_key": "bearer-secret"}}))
+    assert "secret-token" not in redacted
+    assert "bearer-secret" not in redacted


### PR DESCRIPTION
# Pull request

## Change

Adds BingeBase as a realtime scrobble destination for watcher and webhook routes.

## Why

BingeBase only needs realtime scrobbling in CW, as BingeBase has no normal sync features.

## Testing

-  tests/test_bingebase_scrobble.py

## Issue

Relates to #784