### PR TITLE
Fix: anime history mapping conflicts

### DIFF
--- a/cw_platform/anime_mapping/episodes.py
+++ b/cw_platform/anime_mapping/episodes.py
@@ -168,6 +168,15 @@ def resolve_absolute(
             native = _native_passthrough(tag, ids, season, episode)
             if native is not None:
                 return native
+        anidb_hit = found.get("anidb")
+        if anidb_hit and anidb_hit[0] > 0:
+            return Resolution(
+                absolute=anidb_hit[0],
+                namespace="anidb",
+                target_id=anidb_hit[1],
+                basis="anibridge_absolute",
+                entry=basis,
+            )
         if len(agreed) != 1:
             return None
         absolute = agreed.pop()
@@ -249,8 +258,16 @@ def _override_source_coordinate(ids: Mapping[str, str], absolute: int) -> Source
     return None
 
 
-def _bridge_source_coordinate(tag: str, ids: Mapping[str, str], absolute: int) -> SourceCoordinate | None:
+def _bridge_source_coordinate(
+    tag: str,
+    ids: Mapping[str, str],
+    absolute: int,
+    *,
+    preferred_provider: str | None = None,
+) -> SourceCoordinate | None:
+    hits: list[tuple[str, str, str, int, int]] = []
     found: dict[tuple[str, str], tuple[int, int]] = {}
+    namespace_conflicts: set[str] = set()
     for namespace in NATIVE_ORDER:
         ident = ids.get(namespace, "")
         if not ident:
@@ -260,8 +277,6 @@ def _bridge_source_coordinate(tag: str, ids: Mapping[str, str], absolute: int) -
         except Exception:
             continue
         for row in rows:
-            if not int(row.get("reverse") or 0):
-                continue
             if namespace == "anidb" and str(row.get("source_scope") or "").strip().upper() != _ANIDB_REGULAR:
                 continue
             provider = str(row.get("target_provider") or "").strip().lower()
@@ -281,8 +296,32 @@ def _bridge_source_coordinate(tag: str, ids: Mapping[str, str], absolute: int) -
             key = (provider, target_id)
             prior = found.get(key)
             if prior is not None and prior != (season, episode):
-                return None
+                namespace_conflicts.add(namespace)
+                continue
             found[key] = (season, episode)
+            hits.append((namespace, provider, target_id, season, episode))
+
+    if not hits:
+        return None
+    preferred = str(preferred_provider or "").strip().lower()
+    anidb_hits = [hit for hit in hits if hit[0] == "anidb" and hit[0] not in namespace_conflicts]
+    anidb_coords = {(season, episode) for _namespace, _provider, _target_id, season, episode in anidb_hits}
+    if len(anidb_coords) == 1:
+        season, episode = next(iter(anidb_coords))
+        provider_order = ((preferred,) if preferred else ()) + tuple(p for p in AIRED_ORDER if p != preferred)
+        for provider in provider_order:
+            if not provider:
+                continue
+            for _namespace, row_provider, target_id, row_season, row_episode in anidb_hits:
+                if row_provider == provider and (row_season, row_episode) == (season, episode):
+                    return SourceCoordinate(
+                        provider=row_provider,
+                        ident=target_id,
+                        season=season,
+                        episode=episode,
+                        basis="anibridge_reverse",
+                        entry=f"{row_provider}_reverse",
+                    )
 
     if not found:
         return None
@@ -290,7 +329,10 @@ def _bridge_source_coordinate(tag: str, ids: Mapping[str, str], absolute: int) -
     if len(coords) != 1:
         return None
     season, episode = coords.pop()
-    for provider in AIRED_ORDER:
+    provider_order = ((preferred,) if preferred else ()) + tuple(p for p in AIRED_ORDER if p != preferred)
+    for provider in provider_order:
+        if not provider:
+            continue
         for (row_provider, target_id), _coord in found.items():
             if row_provider != provider:
                 continue
@@ -307,6 +349,7 @@ def _bridge_source_coordinate(tag: str, ids: Mapping[str, str], absolute: int) -
 
 def _axis_coordinates(tag: str, ids: Mapping[str, str], absolute: int) -> dict[tuple[str, str], tuple[int, int]]:
     found: dict[tuple[str, str], tuple[int, int] | None] = {}
+    by_namespace: dict[str, dict[tuple[str, str], tuple[int, int] | None]] = {}
     for namespace in NATIVE_ORDER:
         ident = ids.get(namespace, "")
         if not ident:
@@ -316,8 +359,6 @@ def _axis_coordinates(tag: str, ids: Mapping[str, str], absolute: int) -> dict[t
         except Exception:
             continue
         for row in rows:
-            if not int(row.get("reverse") or 0):
-                continue
             if namespace == "anidb" and str(row.get("source_scope") or "").strip().upper() != _ANIDB_REGULAR:
                 continue
             provider = str(row.get("target_provider") or "").strip().lower()
@@ -336,10 +377,18 @@ def _axis_coordinates(tag: str, ids: Mapping[str, str], absolute: int) -> dict[t
                 continue
             key = (provider, target_id)
             coord = (season, episode)
+            ns_found = by_namespace.setdefault(namespace, {})
+            if key in ns_found and ns_found[key] != coord:
+                ns_found[key] = None
+            elif key not in ns_found:
+                ns_found[key] = coord
             if key in found and found[key] != coord:
                 found[key] = None
             elif key not in found:
                 found[key] = coord
+    anidb = {k: v for k, v in by_namespace.get("anidb", {}).items() if v is not None}
+    if len(set(anidb.values())) == 1:
+        return anidb
     return {k: v for k, v in found.items() if v is not None}
 
 
@@ -370,6 +419,7 @@ def resolve_source_coordinate(
     absolute: Any,
     *,
     release_tag: str = "v3",
+    preferred_provider: str | None = None,
 ) -> SourceCoordinate | None:
     abs_num = _as_int(absolute)
     if abs_num is None or abs_num <= 0:
@@ -384,7 +434,12 @@ def resolve_source_coordinate(
     ruled = _override_source_coordinate(clean, abs_num)
     if ruled is not None:
         return ruled
-    return _bridge_source_coordinate(normalize_release_tag(release_tag), clean, abs_num)
+    return _bridge_source_coordinate(
+        normalize_release_tag(release_tag),
+        clean,
+        abs_num,
+        preferred_provider=preferred_provider,
+    )
 
 
 def resolution_matches_ids(resolution: Resolution | None, ids: Mapping[str, Any] | None) -> bool:

--- a/cw_platform/anime_mapping/history_coords.py
+++ b/cw_platform/anime_mapping/history_coords.py
@@ -10,6 +10,7 @@ from .episodes import resolve_axis_coordinates
 from .storage import index_ready, normalize_release_tag
 
 NATIVE_ANIME_ID_KEYS = ("mal", "anilist", "anidb", "kitsu")
+ABSOLUTE_ID_KEYS = ("tmdb", "imdb", "mal", "anilist", "anidb", "kitsu", "simkl")
 ABSOLUTE_FRAGMENT = "#abs:"
 _MIN_ABSOLUTE_RUN = 2
 _MAX_DUPLICATE_RATIO = 0.98
@@ -41,6 +42,10 @@ def show_tokens(item: Mapping[str, Any]) -> set[str]:
     return {f"{k}:{v.lower()}" for k, v in show_ids_of(item).items()}
 
 
+def absolute_show_tokens(item: Mapping[str, Any]) -> set[str]:
+    return {f"{k}:{v.lower()}" for k, v in show_ids_of(item).items() if k in ABSOLUTE_ID_KEYS}
+
+
 def native_anime_absolute(item: Mapping[str, Any]) -> int | None:
     if not _is_episode(item):
         return None
@@ -69,7 +74,7 @@ def _absolute_runs_in(index: Mapping[str, Any] | None) -> dict[str, tuple[set[in
         coord = _episode_coordinate(item)
         if coord is None or coord[0] <= 0:
             continue
-        for token in show_tokens(item):
+        for token in absolute_show_tokens(item):
             per_show.setdefault(token, []).append(coord)
 
     out: dict[str, tuple[set[int], set[int]]] = {}
@@ -159,7 +164,7 @@ class HistoryCoordinateAliases:
 
         absolute = native_anime_absolute(item)
         if absolute is not None:
-            tokens.update(f"{p}{ABSOLUTE_FRAGMENT}{absolute}" for p in prefixes)
+            tokens.update(f"{p}{ABSOLUTE_FRAGMENT}{absolute}" for p in absolute_show_tokens(item))
             if self._mapping_ready():
                 for season, episode in self._axis_coordinates(show_ids_of(item), absolute):
                     frag = f"#s{season:02d}e{episode:02d}"

--- a/providers/sync/floppy/_history.py
+++ b/providers/sync/floppy/_history.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from cw_platform.anime_mapping.coordinates import translate
+from cw_platform.anime_mapping.episodes import resolve_source_coordinate
 from cw_platform.anime_mapping.overrides import find_source_override
 from cw_platform.anime_mapping.service import PAIR_FEATURE_OPTIONS_KEY, mapping_enabled_for_feature, runtime_pair_feature_options
 from cw_platform.anime_mapping.storage import query_edges
@@ -181,6 +182,18 @@ def _anime_target_for_absolute(
     override_target = _override_target_for_absolute(item, tmdb_id, native_ids, absolute)
     if override_target is not None:
         return override_target
+
+    try:
+        source_coord = resolve_source_coordinate(
+            _show_ids(item),
+            absolute,
+            release_tag=release_tag,
+            preferred_provider="tmdb",
+        )
+    except Exception:
+        source_coord = None
+    if source_coord is not None and source_coord.provider == "tmdb":
+        return source_coord.ident, source_coord.season, source_coord.episode
 
     found: set[tuple[str, int, int]] = set()
     for namespace in ("anidb", "mal", "anilist", "kitsu"):

--- a/tests/test_anime_episodes.py
+++ b/tests/test_anime_episodes.py
@@ -78,8 +78,10 @@ def test_prefers_anidb_when_available(index: Path) -> None:
     assert (got.absolute, got.namespace, got.target_id) == (5, "anidb", "1530")
 
 
-def test_disagreeing_namespaces_are_refused(index: Path) -> None:
-    assert resolve_absolute(_episode({"tvdb": "700"}, 1, 3)) is None
+def test_anidb_breaks_disagreements_between_native_namespaces(index: Path) -> None:
+    got = resolve_absolute(_episode({"tvdb": "700"}, 1, 3))
+    assert got is not None
+    assert (got.absolute, got.namespace, got.target_id) == (4, "anidb", "700")
 
 
 def test_agreeing_namespaces_are_accepted(index: Path) -> None:

--- a/tests/test_anime_history_coords.py
+++ b/tests/test_anime_history_coords.py
@@ -29,6 +29,22 @@ MAPPINGS: dict[str, Any] = {
 DRAGON_BALL_IDS = {"tmdb": "12609", "imdb": "tt0088509", "tvdb": "76666", "mal": "223", "anilist": "223"}
 DBZ_IDS = {"tmdb": "12971", "imdb": "tt0121220", "tvdb": "81472", "mal": "813", "anilist": "813"}
 ONE_PIECE_IDS = {"tmdb": "37854", "imdb": "tt0388629", "tvdb": "81797", "mal": "21", "anilist": "21"}
+CLANNAD_IDS = {
+    "tmdb": "24835",
+    "imdb": "tt1118804",
+    "tvdb": "80644",
+    "simkl": "40750",
+    "mal": "2167",
+    "anilist": "2167",
+}
+CLANNAD_AFTER_STORY_IDS = {
+    "tmdb": "248058",
+    "imdb": "tt1298820",
+    "tvdb": "80644",
+    "simkl": "38483",
+    "mal": "4181",
+    "anilist": "4181",
+}
 
 MDBLIST_DRAGON_BALL_IDS = {"tmdb": "12609", "imdb": "tt0088509", "trakt": "12553"}
 MDBLIST_DBZ_IDS = {"tmdb": "12971", "imdb": "tt0121220", "trakt": "12915"}
@@ -158,6 +174,16 @@ def test_a_row_with_its_own_absolute_never_claims_its_episode_number_is_one(conf
     assert "tmdb:37854#abs:21" in tokens
     assert "tmdb:37854#abs:11" not in tokens
     assert not _matched(aliases, source, dst_index["tmdb:37854#s01e11"])
+
+
+def test_shared_tvdb_absolute_token_does_not_merge_separate_anime_entries(config_base: Path) -> None:
+    source = _episode(CLANNAD_AFTER_STORY_IDS, 2, 1, absolute=1)
+    destination = _episode(CLANNAD_IDS, 1, 1, absolute=1)
+    aliases = build_history_coordinate_aliases(CFG, "history", ({"a": source}, {"b": destination}))
+
+    assert "tvdb:80644#abs:1" not in aliases.tokens(source)
+    assert "tvdb:80644#abs:1" not in aliases.tokens(destination)
+    assert not _matched(aliases, source, destination)
 
 
 def test_per_season_restart_numbering_is_not_treated_as_absolute(config_base: Path) -> None:

--- a/tests/test_anime_history_coords_orchestrator.py
+++ b/tests/test_anime_history_coords_orchestrator.py
@@ -20,6 +20,22 @@ MAPPINGS: dict[str, Any] = {
 
 SRC_SHOW_IDS = {"tmdb": "12609", "imdb": "tt0088509", "tvdb": "76666", "mal": "223", "anilist": "223"}
 DST_SHOW_IDS = {"tmdb": "12609", "imdb": "tt0088509", "trakt": "12553"}
+CLANNAD_IDS = {
+    "tmdb": "24835",
+    "imdb": "tt1118804",
+    "tvdb": "80644",
+    "simkl": "40750",
+    "mal": "2167",
+    "anilist": "2167",
+}
+CLANNAD_AFTER_STORY_IDS = {
+    "tmdb": "248058",
+    "imdb": "tt1298820",
+    "tvdb": "80644",
+    "simkl": "38483",
+    "mal": "4181",
+    "anilist": "4181",
+}
 
 
 class _CoordAliases:
@@ -102,7 +118,7 @@ def _episode(show_ids: dict[str, str], season: int, episode: int, absolute: int 
     return out
 
 
-def _cfg(anime_enabled: bool) -> dict[str, Any]:
+def _cfg(anime_enabled: bool, *, source: str = "CROSSWATCH", target: str = "MDBLIST") -> dict[str, Any]:
     return {
         "runtime": {"debug": False, "snapshot_ttl_sec": 0, "apply_chunk_size": 0, "apply_chunk_pause_ms": 0},
         "anime_mapping": {"enabled": anime_enabled, "release_tag": "v3", "use_for_pairs": ["anilist", "simkl"]},
@@ -117,8 +133,8 @@ def _cfg(anime_enabled: bool) -> dict[str, Any]:
             {
                 "id": "p1",
                 "enabled": True,
-                "source": "CROSSWATCH",
-                "target": "MDBLIST",
+                "source": source,
+                "target": target,
                 "mode": "one-way",
                 "feature": "history",
                 "features": {"history": {"enable": True, "add": True, "remove": False}},
@@ -180,18 +196,18 @@ def test_orchestrator_retries_unresolved_coord_match_with_the_anime_toggle_on(
         "title": "Anime destination",
         "season": 1,
         "episode": 14,
-        "watched_at": "2024-01-01T00:00:00Z",
+        "watched_at": "2024-01-02T00:00:00Z",
         "ids": {},
         "show_ids": {"tvdb": "222"},
         "_anime_absolute": 14,
     }
     source_key = canonical_key(source_item)
     destination_key = canonical_key(destination_item)
-    src = FakeOps("CROSSWATCH", {source_key: source_item})
+    src = FakeOps("TRAKT", {source_key: source_item})
     dst = FakeOps("MDBLIST", {destination_key: destination_item})
     monkeypatch.setattr(
         "cw_platform.orchestrator.facade.load_sync_providers",
-        lambda: {"CROSSWATCH": src, "MDBLIST": dst},
+        lambda: {"TRAKT": src, "MDBLIST": dst},
     )
     monkeypatch.setattr("cw_platform.orchestrator._snapshots.provider_configured", lambda _cfg, _name: True)
     monkeypatch.setattr(
@@ -202,7 +218,37 @@ def test_orchestrator_retries_unresolved_coord_match_with_the_anime_toggle_on(
         "cw_platform.orchestrator._pairs_oneway.load_unresolved_keys",
         lambda *_a, **_k: {source_key},
     )
-    Orchestrator(_cfg(False)).run()
+    monkeypatch.setattr("cw_platform.orchestrator._pairs_oneway.load_blackbox_keys", lambda *_a, **_k: set())
+    monkeypatch.setattr("cw_platform.orchestrator._pairs_blocklist.load_blackbox_keys", lambda *_a, **_k: set())
+    Orchestrator(_cfg(False, source="TRAKT", target="MDBLIST")).run()
+
+    planned = [it for batch in dst.add_calls for it in batch]
+    assert len(planned) == 1
+    assert (planned[0].get("season"), planned[0].get("episode")) == (2, 1)
+
+
+def test_orchestrator_does_not_prune_separate_anime_entries_that_share_tvdb(
+    config_base: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_item = _episode(CLANNAD_AFTER_STORY_IDS, 2, 1, absolute=1)
+    destination_item = _episode(CLANNAD_IDS, 1, 1, absolute=1)
+    source_key = "tmdb:248058#s02e01"
+    destination_key = "tmdb:24835#s01e01"
+    src = FakeOps("SIMKL", {source_key: source_item})
+    dst = FakeOps("FLOPPY", {destination_key: destination_item})
+    monkeypatch.setattr(
+        "cw_platform.orchestrator.facade.load_sync_providers",
+        lambda: {"SIMKL": src, "FLOPPY": dst},
+    )
+    monkeypatch.setattr("cw_platform.orchestrator._snapshots.provider_configured", lambda _cfg, _name: True)
+    monkeypatch.setattr(
+        "cw_platform.orchestrator._pairs_oneway.load_unresolved_keys",
+        lambda *_a, **_k: set(),
+    )
+    monkeypatch.setattr("cw_platform.orchestrator._pairs_oneway.load_blackbox_keys", lambda *_a, **_k: set())
+    monkeypatch.setattr("cw_platform.orchestrator._pairs_blocklist.load_blackbox_keys", lambda *_a, **_k: set())
+
+    Orchestrator(_cfg(True, source="SIMKL", target="FLOPPY")).run()
 
     planned = [it for batch in dst.add_calls for it in batch]
     assert len(planned) == 1

--- a/tests/test_anime_reverse_mapping.py
+++ b/tests/test_anime_reverse_mapping.py
@@ -19,12 +19,30 @@ DBZ_MAPPINGS: dict[str, Any] = {
     "tvdb_show:81472:s3": {"mal:813": {"1-33": "75-107"}},
 }
 
+CLANNAD_MAPPINGS: dict[str, Any] = {
+    "anidb:5841:R": {"tmdb_show:24835:s2": {"1-22": "1-22"}, "tvdb_show:80644:s2": {"1-22": "1-22"}},
+    "anilist:4181": {
+        "tmdb_show:24835:s0": {"1-2": "3-4"},
+        "tmdb_show:24835:s2": {"3-24": "1-22"},
+        "tvdb_show:80644:s2": {"1-24": "1-24"},
+    },
+}
+
 
 @pytest.fixture()
 def dbz_index(config_base: Path) -> Path:
     paths = storage.paths("v3")
     paths["root"].mkdir(parents=True, exist_ok=True)
     paths["mappings"].write_text(json.dumps(DBZ_MAPPINGS), encoding="utf-8")
+    storage.rebuild_sqlite_from_mappings(release_tag="v3")
+    return paths["db"]
+
+
+@pytest.fixture()
+def clannad_index(config_base: Path) -> Path:
+    paths = storage.paths("v3")
+    paths["root"].mkdir(parents=True, exist_ok=True)
+    paths["mappings"].write_text(json.dumps(CLANNAD_MAPPINGS), encoding="utf-8")
     storage.rebuild_sqlite_from_mappings(release_tag="v3")
     return paths["db"]
 
@@ -119,6 +137,17 @@ def test_anibridge_reverse_maps_absolute_back_to_aired(dbz_index: Path) -> None:
     assert coord.basis == "anibridge_reverse"
     assert (coord.provider, coord.ident) == ("tvdb", "81472")
     assert (coord.season, coord.episode) == (2, 1)
+
+
+def test_anidb_breaks_reverse_mapping_conflicts(clannad_index: Path) -> None:
+    coord = resolve_source_coordinate(
+        {"anidb": "5841", "anilist": "4181", "tmdb": "248058", "tvdb": "80644"},
+        1,
+        preferred_provider="tmdb",
+    )
+
+    assert coord is not None
+    assert (coord.provider, coord.ident, coord.season, coord.episode) == ("tmdb", "24835", 2, 1)
 
 
 def test_anibridge_reverse_round_trips_every_dbz_season(dbz_index: Path) -> None:

--- a/tests/test_floppy_sync.py
+++ b/tests/test_floppy_sync.py
@@ -773,6 +773,96 @@ def test_floppy_history_add_uses_anime_target_tmdb_when_source_tmdb_conflicts(mo
     assert not any("media/tv/tmdb/308405" in c["path"] for c in adapter.client.session.calls)
 
 
+def test_floppy_history_uses_anidb_when_native_targets_disagree(monkeypatch: Any) -> None:
+    from cw_platform.anime_mapping import episodes
+    from providers.sync.floppy import _history
+
+    def fake_edges(tag: str, namespace: str, ident: str, **_kwargs: Any) -> list[dict[str, Any]]:
+        if tag != "v3":
+            return []
+        if namespace == "anidb" and ident == "5841":
+            return [
+                {
+                    "reverse": 1,
+                    "source_scope": "R",
+                    "target_provider": "tmdb",
+                    "target_kind": "show",
+                    "target_id": "24835",
+                    "target_scope": "s2",
+                    "source_range": "1-22",
+                    "target_range": "1-22",
+                },
+                {
+                    "reverse": 1,
+                    "source_scope": "R",
+                    "target_provider": "tvdb",
+                    "target_kind": "show",
+                    "target_id": "80644",
+                    "target_scope": "s2",
+                    "source_range": "1-22",
+                    "target_range": "1-22",
+                },
+            ]
+        if namespace == "anilist" and ident == "4181":
+            return [
+                {
+                    "reverse": 1,
+                    "target_provider": "tmdb",
+                    "target_kind": "show",
+                    "target_id": "24835",
+                    "target_scope": "s0",
+                    "source_range": "1-2",
+                    "target_range": "3-4",
+                },
+                {
+                    "reverse": 1,
+                    "target_provider": "tmdb",
+                    "target_kind": "show",
+                    "target_id": "24835",
+                    "target_scope": "s2",
+                    "source_range": "3-24",
+                    "target_range": "1-22",
+                },
+            ]
+        return []
+
+    monkeypatch.setattr(episodes, "query_edges", fake_edges)
+    monkeypatch.setattr(_history, "query_edges", fake_edges)
+    _history.prepare_source_snapshot([])
+    _history.reset_layout_cache()
+    routes = _anime_routes("24835", [], {2: 22})
+    routes[("GET", "media/tv/tmdb/24835/2/1/history")] = _history_visible_after_post()
+    routes[("POST", "media/tv/tmdb/24835/2/episodes/1/watch")] = {"consumption_id": 77}
+    adapter = AdapterStub(routes, _anime_history_cfg())
+
+    res = _history.add(
+        adapter,
+        [
+            {
+                "type": "episode",
+                "series_title": "Clannad: After Story",
+                "season": 2,
+                "episode": 1,
+                "_simkl_episode_number": 1,
+                "watched_at": "2026-01-02T00:00:00Z",
+                "show_ids": {
+                    "tmdb": "248058",
+                    "tvdb": "80644",
+                    "simkl": "38483",
+                    "mal": "4181",
+                    "anilist": "4181",
+                    "anidb": "5841",
+                },
+            }
+        ],
+    )
+
+    assert res["count"] == 1
+    assert res["confirmed_keys"] == ["tmdb:248058#s02e01"]
+    assert [c["path"] for c in adapter.client.session.calls if c["method"] == "POST"] == ["media/tv/tmdb/24835/2/episodes/1/watch"]
+    assert not any("media/tv/tmdb/248058" in c["path"] for c in adapter.client.session.calls)
+
+
 def test_floppy_history_destination_view_uses_anime_target_tmdb_when_source_tmdb_conflicts(monkeypatch: Any) -> None:
     from providers.sync._mod_FLOPPY import OPS
     from providers.sync.floppy import _history


### PR DESCRIPTION
# Pull request

## Change

- Better anime history coordinate matching.
- AniDB now wins when anime episode mappings disagree.

## Why

- Some anime entries could be matched too broadly through shared TVDB ids.
- Other entries could fail when AniDB and AniList mapped the same anime differently.

## Testing

- tests\test_anime_episodes.py 
- tests\test_anime_reverse_mapping.py 
- tests\test_floppy_sync.py 
- tests\test_anime_history_coords.py 
- tests\test_anime_history_coords_orchestrator.py 

## Issue

Relates to #809