### PR TITLE
Change: resolve IMDb-only Floppy writes through TMDB

### DIFF
--- a/providers/sync/_mod_FLOPPY.py
+++ b/providers/sync/_mod_FLOPPY.py
@@ -17,7 +17,7 @@ from providers.sync.floppy import _ratings as feat_ratings
 from providers.sync.floppy import _watchlist as feat_watchlist
 from providers.sync.floppy._common import api_delete, api_get, configured_block, is_configured, media_parts_from_item_id, paged
 
-__VERSION__ = "0.2"
+__VERSION__ = "0.3"
 __all__ = ["get_manifest", "FLOPPYModule", "OPS"]
 
 if "ctx" not in globals():
@@ -29,7 +29,13 @@ if "ctx" not in globals():
 
 
 _FEATURES = {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False}
-_FEATURE_MODULES = {"watchlist": feat_watchlist, "ratings": feat_ratings, "history": feat_history, "progress": feat_progress}
+_FEATURE_MODULES: dict[str, Any] = {"watchlist": feat_watchlist, "ratings": feat_ratings, "history": feat_history, "progress": feat_progress}
+
+
+def _index_dict(value: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(k): dict(v) for k, v in value.items() if isinstance(v, Mapping)}
 
 
 def _rate_limit_settings(block: Mapping[str, Any]) -> dict[str, float]:
@@ -134,12 +140,12 @@ class FLOPPYModule:
 
     def build_index(self, feature: str, **kwargs: Any) -> Mapping[str, dict[str, Any]]:
         mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
-        return mod.build_index(self, **kwargs) if mod else {}
+        return _index_dict(mod.build_index(self, **kwargs)) if mod else {}
 
     def destination_comparison_view(self, feature: str, index: Mapping[str, Mapping[str, Any]]) -> Mapping[str, dict[str, Any]]:
         mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
         hook = getattr(mod, "destination_comparison_view", None)
-        return hook(self, index) if callable(hook) else dict(index or {})
+        return _index_dict(hook(self, index)) if callable(hook) else _index_dict(index)
 
     def prepare_source_snapshot(self, feature: str, items: Any) -> int:
         mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())

--- a/providers/sync/floppy/_common.py
+++ b/providers/sync/floppy/_common.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from cw_platform.id_map import canonical_key, ids_from, minimal as id_minimal
+from cw_platform.id_map import canonical_key, ids_from, merge_ids, minimal as id_minimal
 from providers.auth._auth_FLOPPY import FloppyAuthError, is_configured as auth_is_configured, provider_block
 from providers.sync._mod_common import safe_json
 
@@ -233,6 +233,89 @@ def tmdb_id_for_item(item: Mapping[str, Any], *, episode_show: bool = False) -> 
     ids = ids_from(src if isinstance(src, Mapping) else item)
     val = str(ids.get("tmdb") or "").strip()
     return val or None
+
+
+def _tmdb_metadata_provider(adapter: Any) -> Any | None:
+    cached = getattr(adapter, "_floppy_tmdb_provider", None)
+    if cached is not None:
+        return cached
+    cfg = getattr(adapter, "config", None) or getattr(adapter, "raw_cfg", None) or {}
+    if not isinstance(cfg, Mapping):
+        return None
+    tmdb_raw = cfg.get("tmdb")
+    metadata_raw = cfg.get("metadata")
+    tmdb: Mapping[str, Any] = tmdb_raw if isinstance(tmdb_raw, Mapping) else {}
+    metadata: Mapping[str, Any] = metadata_raw if isinstance(metadata_raw, Mapping) else {}
+    if not str(tmdb.get("api_key") or metadata.get("tmdb_api_key") or "").strip():
+        return None
+    try:
+        from providers.metadata._meta_TMDB import TmdbProvider
+
+        provider = TmdbProvider(lambda: dict(cfg), lambda _cfg: None)
+        setattr(adapter, "_floppy_tmdb_provider", provider)
+        return provider
+    except Exception:
+        return None
+
+
+def _metadata_lookup_ids(item: Mapping[str, Any], *, episode_show: bool = False) -> dict[str, str]:
+    show_ids = item.get("show_ids")
+    if episode_show and isinstance(show_ids, Mapping):
+        source = merge_ids({str(k): v for k, v in show_ids.items()}, {})
+    else:
+        source = merge_ids(ids_from(item), ids_from(id_minimal(item)))
+        if isinstance(show_ids, Mapping):
+            source = merge_ids(source, {str(k): v for k, v in show_ids.items()})
+    return {key: str(source.get(key) or "").strip() for key in ("tmdb", "imdb", "tvdb") if str(source.get(key) or "").strip()}
+
+
+def resolved_tmdb_id_for_item(adapter: Any, item: Mapping[str, Any], *, episode_show: bool = False) -> str | None:
+    direct = tmdb_id_for_item(item, episode_show=episode_show)
+    if direct:
+        return direct
+    lookup_ids = _metadata_lookup_ids(item, episode_show=episode_show)
+    if not lookup_ids:
+        return None
+    provider = _tmdb_metadata_provider(adapter)
+    if provider is None:
+        return None
+    typ = str(item.get("type") or id_minimal(item).get("type") or "").strip().lower()
+    entity = "tv" if episode_show or typ in {"episode", "episodes", "season", "seasons", "show", "series", "tv"} else "movie"
+    try:
+        detail = provider.fetch(entity=entity, ids=lookup_ids, need={"poster": False, "backdrop": False, "ids": True})
+    except Exception:
+        return None
+    if not isinstance(detail, Mapping):
+        return None
+    detail_ids = detail.get("ids")
+    if not isinstance(detail_ids, Mapping):
+        return None
+    tmdb = str(detail_ids.get("tmdb") or "").strip()
+    return tmdb if tmdb.isdigit() else None
+
+
+def tmdb_enriched_item(adapter: Any, item: Mapping[str, Any], *, episode_show: bool = False) -> dict[str, Any]:
+    out = dict(item)
+    tmdb_id = resolved_tmdb_id_for_item(adapter, out, episode_show=episode_show)
+    if not tmdb_id:
+        return out
+    if episode_show:
+        show_ids_raw = out.get("show_ids")
+        show_ids: Mapping[str, Any] = show_ids_raw if isinstance(show_ids_raw, Mapping) else {}
+        merged = dict(show_ids)
+        merged["tmdb"] = tmdb_id
+        out["show_ids"] = merged
+        return out
+    ids_raw = out.get("ids")
+    ids: Mapping[str, Any] = ids_raw if isinstance(ids_raw, Mapping) else {}
+    merged = dict(ids)
+    merged["tmdb"] = tmdb_id
+    out["ids"] = merged
+    return out
+
+
+def confirmed_destination(item: Mapping[str, Any]) -> dict[str, Any]:
+    return {"key": canonical_item_key(item), "item": id_minimal(item)}
 
 
 def canonical_item_key(item: Mapping[str, Any]) -> str:

--- a/providers/sync/floppy/_history.py
+++ b/providers/sync/floppy/_history.py
@@ -17,7 +17,7 @@ from cw_platform.history_events import history_epoch_from_value, history_sync_ke
 from cw_platform.id_map import minimal as id_minimal
 from providers.sync._mod_common import build_op_result, unresolved_keys
 
-from ._common import COMPLETED, absolute_to_coord, api_delete, api_patch, api_post, canonical_item_key, failure_reason, has_coord, int_or_none, item_from_row, paged, reset_layout_cache, show_layout, tmdb_id_for_item, track_media, unresolved
+from ._common import COMPLETED, absolute_to_coord, api_delete, api_patch, api_post, canonical_item_key, confirmed_destination, failure_reason, has_coord, int_or_none, item_from_row, paged, reset_layout_cache, show_layout, tmdb_enriched_item, tmdb_id_for_item, track_media, unresolved
 
 _SRC_SNAPSHOT: dict[str, Any] = {"scope": None, "shows": {}}
 
@@ -551,66 +551,72 @@ def destination_comparison_view(adapter: Any, index: Mapping[str, Mapping[str, A
 
 def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
     confirmed: list[str] = []
+    confirmed_destinations: dict[str, dict[str, Any]] = {}
     unresolved_rows: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
     for raw in [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]:
         key = _history_key(adapter, raw)
         typ = str(id_minimal(raw).get("type") or "").lower()
+        item = tmdb_enriched_item(adapter, raw, episode_show=typ == "episode")
         if typ == "movie":
-            tmdb_id = tmdb_id_for_item(raw)
+            tmdb_id = tmdb_id_for_item(item)
             if not tmdb_id:
-                entry = unresolved(raw, "floppy_tmdb_id_missing")
+                entry = unresolved(item, "floppy_tmdb_id_missing")
                 unresolved_rows.append(entry)
                 results.append(entry)
                 continue
             if dry_run:
                 confirmed.append(key)
-                results.append({"status": "dry_run", "item": _history_minimal(adapter, raw), "canonical_key": key})
+                confirmed_destinations[key] = confirmed_destination(item)
+                results.append({"status": "dry_run", "item": _history_minimal(adapter, item), "canonical_key": key})
                 continue
             try:
-                _write_movie_history(adapter, tmdb_id, _watched_at(raw), raw, key)
+                _write_movie_history(adapter, tmdb_id, _watched_at(item), item, key)
             except Exception as exc:
-                entry = unresolved(raw, failure_reason(exc))
+                entry = unresolved(item, failure_reason(exc))
                 unresolved_rows.append(entry)
                 results.append(entry)
                 continue
             confirmed.append(key)
-            results.append({"status": "applied", "item": _history_minimal(adapter, raw), "canonical_key": key})
+            confirmed_destinations[key] = confirmed_destination(item)
+            results.append({"status": "applied", "item": _history_minimal(adapter, item), "canonical_key": key})
             continue
         if typ == "episode":
-            tmdb_id = tmdb_id_for_item(raw, episode_show=True)
-            season, episode = _episode_numbers(raw)
+            tmdb_id = tmdb_id_for_item(item, episode_show=True)
+            season, episode = _episode_numbers(item)
             if not tmdb_id or season is None or episode is None:
-                entry = unresolved(raw, "floppy_episode_id_missing")
+                entry = unresolved(item, "floppy_episode_id_missing")
                 unresolved_rows.append(entry)
                 results.append(entry)
                 continue
             if dry_run:
                 confirmed.append(key)
-                results.append({"status": "dry_run", "item": _history_minimal(adapter, raw), "canonical_key": key})
+                confirmed_destinations[key] = confirmed_destination(item)
+                results.append({"status": "dry_run", "item": _history_minimal(adapter, item), "canonical_key": key})
                 continue
             try:
-                tmdb_id, season, episode, verify_after_write = _write_target_result(adapter, tmdb_id, raw, season, episode)
+                tmdb_id, season, episode, verify_after_write = _write_target_result(adapter, tmdb_id, item, season, episode)
                 existing_history = _episode_history(adapter, tmdb_id, season, episode)
                 if _rewatches_enabled(adapter) or not existing_history:
-                    api_post(adapter, f"media/tv/tmdb/{tmdb_id}/{season}/episodes/{episode}/watch", json={"end_date": _watched_at(raw)})
-                if verify_after_write and not _history_rows_include_write(adapter, raw, _episode_history(adapter, tmdb_id, season, episode), exact_time=True):
-                    entry = unresolved(raw, "floppy_history_write_not_readable")
+                    api_post(adapter, f"media/tv/tmdb/{tmdb_id}/{season}/episodes/{episode}/watch", json={"end_date": _watched_at(item)})
+                if verify_after_write and not _history_rows_include_write(adapter, item, _episode_history(adapter, tmdb_id, season, episode), exact_time=True):
+                    entry = unresolved(item, "floppy_history_write_not_readable")
                     unresolved_rows.append(entry)
                     results.append(entry)
                     continue
             except Exception as exc:
-                entry = unresolved(raw, failure_reason(exc))
+                entry = unresolved(item, failure_reason(exc))
                 unresolved_rows.append(entry)
                 results.append(entry)
                 continue
             confirmed.append(key)
-            results.append({"status": "applied", "item": _history_minimal(adapter, raw), "canonical_key": key})
+            confirmed_destinations[key] = confirmed_destination(item)
+            results.append({"status": "applied", "item": _history_minimal(adapter, item), "canonical_key": key})
             continue
-        entry = unresolved(raw, "floppy_history_type_unsupported")
+        entry = unresolved(item, "floppy_history_type_unsupported")
         unresolved_rows.append(entry)
         results.append(entry)
-    return build_op_result(ok=not unresolved_rows, count=len(confirmed), confirmed_keys=confirmed, unresolved_keys=unresolved_keys(unresolved_rows, lambda it: _history_key(adapter, it)), unresolved=unresolved_rows, results=results, attempted=len(confirmed) + len(unresolved_rows))
+    return build_op_result(ok=not unresolved_rows, count=len(confirmed), confirmed_keys=confirmed, confirmed_destinations=confirmed_destinations, unresolved_keys=unresolved_keys(unresolved_rows, lambda it: _history_key(adapter, it)), unresolved=unresolved_rows, results=results, attempted=len(confirmed) + len(unresolved_rows))
 
 
 def _write_movie_history(adapter: Any, tmdb_id: str, watched_at: str, item: Mapping[str, Any], key: str) -> None:
@@ -626,21 +632,24 @@ def _write_movie_history(adapter: Any, tmdb_id: str, watched_at: str, item: Mapp
 
 def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
     confirmed: list[str] = []
+    confirmed_destinations: dict[str, dict[str, Any]] = {}
     unresolved_rows: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
     for raw in [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]:
         key = _history_key(adapter, raw)
         typ = str(id_minimal(raw).get("type") or "").lower()
+        item = tmdb_enriched_item(adapter, raw, episode_show=typ == "episode")
         if dry_run:
             confirmed.append(key)
-            results.append({"status": "dry_run", "item": _history_minimal(adapter, raw), "canonical_key": key})
+            confirmed_destinations[key] = confirmed_destination(item)
+            results.append({"status": "dry_run", "item": _history_minimal(adapter, item), "canonical_key": key})
             continue
         try:
             if typ == "movie":
-                tmdb_id = tmdb_id_for_item(raw)
+                tmdb_id = tmdb_id_for_item(item)
                 if not tmdb_id:
                     raise ValueError("missing tmdb")
-                history_id = _history_id(raw)
+                history_id = _history_id(item)
                 if not history_id and _rewatches_enabled(adapter):
                     raise ValueError("missing history id")
                 if not history_id:
@@ -651,12 +660,12 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
                 else:
                     api_patch(adapter, f"media/movie/tmdb/{tmdb_id}", json={"status": 0, "end_date": None})
             elif typ == "episode":
-                tmdb_id = tmdb_id_for_item(raw, episode_show=True)
-                season, episode = _episode_numbers(raw)
+                tmdb_id = tmdb_id_for_item(item, episode_show=True)
+                season, episode = _episode_numbers(item)
                 if not tmdb_id or season is None or episode is None:
                     raise ValueError("missing episode ids")
-                tmdb_id, season, episode = _write_target(adapter, tmdb_id, raw, season, episode)
-                history_id = _history_id(raw)
+                tmdb_id, season, episode = _write_target(adapter, tmdb_id, item, season, episode)
+                history_id = _history_id(item)
                 if not history_id and _rewatches_enabled(adapter):
                     raise ValueError("missing history id")
                 if not history_id:
@@ -669,10 +678,11 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
             else:
                 raise ValueError("unsupported")
         except Exception:
-            entry = unresolved(raw, "floppy_history_remove_failed")
+            entry = unresolved(item, "floppy_history_remove_failed")
             unresolved_rows.append(entry)
             results.append(entry)
             continue
         confirmed.append(key)
-        results.append({"status": "applied", "item": _history_minimal(adapter, raw), "canonical_key": key})
-    return build_op_result(ok=not unresolved_rows, count=len(confirmed), confirmed_keys=confirmed, unresolved_keys=unresolved_keys(unresolved_rows, lambda it: _history_key(adapter, it)), unresolved=unresolved_rows, results=results, attempted=len(confirmed) + len(unresolved_rows))
+        confirmed_destinations[key] = confirmed_destination(item)
+        results.append({"status": "applied", "item": _history_minimal(adapter, item), "canonical_key": key})
+    return build_op_result(ok=not unresolved_rows, count=len(confirmed), confirmed_keys=confirmed, confirmed_destinations=confirmed_destinations, unresolved_keys=unresolved_keys(unresolved_rows, lambda it: _history_key(adapter, it)), unresolved=unresolved_rows, results=results, attempted=len(confirmed) + len(unresolved_rows))

--- a/providers/sync/floppy/_progress.py
+++ b/providers/sync/floppy/_progress.py
@@ -10,7 +10,7 @@ from cw_platform.id_map import minimal as id_minimal
 from providers.sync._mod_common import build_op_result, unresolved_keys
 from providers.sync._progress_policy import select_progress_record
 
-from ._common import api_put, canonical_item_key, failure_reason, paged, tmdb_id_for_item, unresolved
+from ._common import api_put, canonical_item_key, confirmed_destination, failure_reason, paged, tmdb_enriched_item, tmdb_id_for_item, unresolved
 
 
 def _int(value: Any) -> int | None:
@@ -162,19 +162,23 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
 
 def _write(adapter: Any, items: Iterable[Mapping[str, Any]], *, clear: bool, dry_run: bool = False) -> dict[str, Any]:
     confirmed: list[str] = []
+    confirmed_destinations: dict[str, dict[str, Any]] = {}
     unresolved_rows: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
     for raw in [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]:
         key = canonical_item_key(raw)
-        body, reason = _payload(raw, clear=clear)
+        typ = str(id_minimal(raw).get("type") or "").strip().lower()
+        item = tmdb_enriched_item(adapter, raw, episode_show=typ == "episode")
+        body, reason = _payload(item, clear=clear)
         if body is None:
-            entry = unresolved(raw, reason or "floppy_progress_unresolved")
+            entry = unresolved(item, reason or "floppy_progress_unresolved")
             unresolved_rows.append(entry)
             results.append(entry)
             continue
         if dry_run:
             confirmed.append(key)
-            results.append({"status": "dry_run", "item": id_minimal(raw), "canonical_key": key})
+            confirmed_destinations[key] = confirmed_destination(item)
+            results.append({"status": "dry_run", "item": id_minimal(item), "canonical_key": key})
             continue
         try:
             if clear:
@@ -182,10 +186,11 @@ def _write(adapter: Any, items: Iterable[Mapping[str, Any]], *, clear: bool, dry
             else:
                 api_put(adapter, "playback/progress", json=body)
         except Exception as exc:
-            entry = unresolved(raw, failure_reason(exc))
+            entry = unresolved(item, failure_reason(exc))
             unresolved_rows.append(entry)
             results.append(entry)
             continue
         confirmed.append(key)
-        results.append({"status": "applied", "item": id_minimal(raw), "canonical_key": key})
-    return build_op_result(ok=not unresolved_rows, count=len(confirmed), confirmed_keys=confirmed, unresolved_keys=unresolved_keys(unresolved_rows, canonical_item_key), unresolved=unresolved_rows, results=results, attempted=len(confirmed) + len(unresolved_rows))
+        confirmed_destinations[key] = confirmed_destination(item)
+        results.append({"status": "applied", "item": id_minimal(item), "canonical_key": key})
+    return build_op_result(ok=not unresolved_rows, count=len(confirmed), confirmed_keys=confirmed, confirmed_destinations=confirmed_destinations, unresolved_keys=unresolved_keys(unresolved_rows, canonical_item_key), unresolved=unresolved_rows, results=results, attempted=len(confirmed) + len(unresolved_rows))

--- a/providers/sync/floppy/_ratings.py
+++ b/providers/sync/floppy/_ratings.py
@@ -11,7 +11,7 @@ from typing import Any
 from cw_platform.id_map import minimal as id_minimal
 from providers.sync._mod_common import build_op_result, unresolved_keys
 
-from ._common import PLANNING, api_patch, canonical_item_key, failure_reason, floppy_type_for_item, item_from_row, paged, rating_number, track_media, tmdb_id_for_item, unresolved
+from ._common import PLANNING, api_patch, canonical_item_key, confirmed_destination, failure_reason, floppy_type_for_item, item_from_row, paged, rating_number, tmdb_enriched_item, track_media, tmdb_id_for_item, unresolved
 
 _SHADOW_TTL = 180.0
 _WRITE_SHADOW: dict[tuple[str, str], dict[str, Any]] = {}
@@ -83,35 +83,38 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
 
 def _write(adapter: Any, items: Iterable[Mapping[str, Any]], *, clear: bool, dry_run: bool = False) -> dict[str, Any]:
     confirmed: list[str] = []
+    confirmed_destinations: dict[str, dict[str, Any]] = {}
     skipped: list[str] = []
     unresolved_rows: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
     for raw in [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]:
         key = canonical_item_key(raw)
-        typ = floppy_type_for_item(raw)
-        tmdb_id = tmdb_id_for_item(raw)
-        rating = None if clear else rating_number(raw.get("rating"))
+        item = tmdb_enriched_item(adapter, raw)
+        typ = floppy_type_for_item(item)
+        tmdb_id = tmdb_id_for_item(item)
+        rating = None if clear else rating_number(item.get("rating"))
         if typ not in {"movie", "tv"}:
             skipped.append(key)
-            results.append({"status": "skipped", "reason": "floppy_rating_type_unsupported", "item": id_minimal(raw), "canonical_key": key})
+            results.append({"status": "skipped", "reason": "floppy_rating_type_unsupported", "item": id_minimal(item), "canonical_key": key})
             continue
         if not tmdb_id:
-            entry = unresolved(raw, "floppy_tmdb_id_missing")
+            entry = unresolved(item, "floppy_tmdb_id_missing")
             unresolved_rows.append(entry)
             results.append(entry)
             continue
         if rating is None and not clear:
-            entry = unresolved(raw, "floppy_rating_missing")
+            entry = unresolved(item, "floppy_rating_missing")
             unresolved_rows.append(entry)
             results.append(entry)
             continue
         if rating is not None and rating <= 0 and not clear:
             skipped.append(key)
-            results.append({"status": "skipped", "reason": "floppy_rating_zero_is_clear", "item": id_minimal(raw), "canonical_key": key})
+            results.append({"status": "skipped", "reason": "floppy_rating_zero_is_clear", "item": id_minimal(item), "canonical_key": key})
             continue
         if dry_run:
             confirmed.append(key)
-            results.append({"status": "dry_run", "item": id_minimal(raw), "canonical_key": key})
+            confirmed_destinations[key] = confirmed_destination(item)
+            results.append({"status": "dry_run", "item": id_minimal(item), "canonical_key": key})
             continue
         try:
             if clear:
@@ -119,18 +122,19 @@ def _write(adapter: Any, items: Iterable[Mapping[str, Any]], *, clear: bool, dry
             else:
                 track_media(adapter, typ, tmdb_id, payload={"status": PLANNING, "score": rating}, patch_payload={"score": rating})
         except Exception as exc:
-            entry = unresolved(raw, failure_reason(exc))
+            entry = unresolved(item, failure_reason(exc))
             unresolved_rows.append(entry)
             results.append(entry)
             continue
         confirmed.append(key)
+        confirmed_destinations[key] = confirmed_destination(item)
         if clear:
             _remember(adapter, key, None)
         else:
-            cached = id_minimal(raw)
+            cached = id_minimal(item)
             cached["rating"] = rating
-            if raw.get("rated_at"):
-                cached["rated_at"] = raw.get("rated_at")
+            if item.get("rated_at"):
+                cached["rated_at"] = item.get("rated_at")
             _remember(adapter, key, cached)
-        results.append({"status": "applied", "item": id_minimal(raw), "canonical_key": key})
-    return build_op_result(ok=not unresolved_rows, count=len(confirmed), confirmed_keys=confirmed, unresolved_keys=unresolved_keys(unresolved_rows, canonical_item_key), unresolved=unresolved_rows, results=results, attempted=len(confirmed) + len(skipped) + len(unresolved_rows), skipped=len(skipped), skipped_keys=skipped)
+        results.append({"status": "applied", "item": id_minimal(item), "canonical_key": key})
+    return build_op_result(ok=not unresolved_rows, count=len(confirmed), confirmed_keys=confirmed, confirmed_destinations=confirmed_destinations, unresolved_keys=unresolved_keys(unresolved_rows, canonical_item_key), unresolved=unresolved_rows, results=results, attempted=len(confirmed) + len(skipped) + len(unresolved_rows), skipped=len(skipped), skipped_keys=skipped)

--- a/providers/sync/floppy/_watchlist.py
+++ b/providers/sync/floppy/_watchlist.py
@@ -10,7 +10,7 @@ from cw_platform.id_map import minimal as id_minimal
 from providers.auth._auth_FLOPPY import FloppyAuthError
 from providers.sync._mod_common import build_op_result, unresolved_keys
 
-from ._common import api_delete, api_get, api_post, api_put, canonical_item_key, ensure_media, floppy_type_for_item, item_from_row, paged, tmdb_id_for_item, unresolved, watchlist_name
+from ._common import api_delete, api_get, api_post, api_put, canonical_item_key, confirmed_destination, ensure_media, floppy_type_for_item, item_from_row, paged, tmdb_enriched_item, tmdb_id_for_item, unresolved, watchlist_name
 
 
 def _list_id(adapter: Any, *, create: bool = False) -> str | None:
@@ -50,24 +50,27 @@ def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
 
 def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
     confirmed: list[str] = []
+    confirmed_destinations: dict[str, dict[str, Any]] = {}
     unresolved_rows: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
     lid = None if dry_run else _list_id(adapter, create=True)
     for raw in [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]:
         key = canonical_item_key(raw)
-        typ = floppy_type_for_item(raw)
-        tmdb_id = tmdb_id_for_item(raw)
+        item = tmdb_enriched_item(adapter, raw)
+        typ = floppy_type_for_item(item)
+        tmdb_id = tmdb_id_for_item(item)
         if typ not in {"movie", "tv"} or not tmdb_id:
-            entry = unresolved(raw, "floppy_tmdb_id_missing")
+            entry = unresolved(item, "floppy_tmdb_id_missing")
             unresolved_rows.append(entry)
             results.append(entry)
             continue
         if dry_run:
             confirmed.append(key)
-            results.append({"status": "dry_run", "item": id_minimal(raw), "canonical_key": key})
+            confirmed_destinations[key] = confirmed_destination(item)
+            results.append({"status": "dry_run", "item": id_minimal(item), "canonical_key": key})
             continue
         if not lid:
-            entry = unresolved(raw, "floppy_watchlist_missing")
+            entry = unresolved(item, "floppy_watchlist_missing")
             unresolved_rows.append(entry)
             results.append(entry)
             continue
@@ -80,54 +83,60 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
                     api_put(adapter, f"media/{typ}/tmdb/{tmdb_id}/lists/{lid}")
                 except FloppyAuthError as inner:
                     if getattr(inner, "status_code", None) != 409:
-                        entry = unresolved(raw, str(getattr(inner, "reason", "") or "floppy_watchlist_write_failed"))
+                        entry = unresolved(item, str(getattr(inner, "reason", "") or "floppy_watchlist_write_failed"))
                         unresolved_rows.append(entry)
                         results.append(entry)
                         continue
             elif getattr(exc, "status_code", None) != 409:
-                entry = unresolved(raw, str(getattr(exc, "reason", "") or "floppy_watchlist_write_failed"))
+                entry = unresolved(item, str(getattr(exc, "reason", "") or "floppy_watchlist_write_failed"))
                 unresolved_rows.append(entry)
                 results.append(entry)
                 continue
         confirmed.append(key)
-        results.append({"status": "applied", "item": id_minimal(raw), "canonical_key": key})
-    return build_op_result(ok=not unresolved_rows, count=len(confirmed), confirmed_keys=confirmed, unresolved_keys=unresolved_keys(unresolved_rows, canonical_item_key), unresolved=unresolved_rows, results=results, attempted=len(confirmed) + len(unresolved_rows))
+        confirmed_destinations[key] = confirmed_destination(item)
+        results.append({"status": "applied", "item": id_minimal(item), "canonical_key": key})
+    return build_op_result(ok=not unresolved_rows, count=len(confirmed), confirmed_keys=confirmed, confirmed_destinations=confirmed_destinations, unresolved_keys=unresolved_keys(unresolved_rows, canonical_item_key), unresolved=unresolved_rows, results=results, attempted=len(confirmed) + len(unresolved_rows))
 
 
 def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
     confirmed: list[str] = []
+    confirmed_destinations: dict[str, dict[str, Any]] = {}
     unresolved_rows: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
     lid = None if dry_run else _list_id(adapter)
     current = {} if dry_run or not lid else _list_items(adapter, lid)
     for raw in [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]:
         key = canonical_item_key(raw)
-        typ = floppy_type_for_item(raw)
-        tmdb_id = tmdb_id_for_item(raw)
+        item = tmdb_enriched_item(adapter, raw)
+        typ = floppy_type_for_item(item)
+        tmdb_id = tmdb_id_for_item(item)
         if typ not in {"movie", "tv"} or not tmdb_id:
-            entry = unresolved(raw, "floppy_tmdb_id_missing")
+            entry = unresolved(item, "floppy_tmdb_id_missing")
             unresolved_rows.append(entry)
             results.append(entry)
             continue
         if dry_run:
             confirmed.append(key)
-            results.append({"status": "dry_run", "item": id_minimal(raw), "canonical_key": key})
+            confirmed_destinations[key] = confirmed_destination(item)
+            results.append({"status": "dry_run", "item": id_minimal(item), "canonical_key": key})
             continue
         if not lid:
             confirmed.append(key)
-            results.append({"status": "skipped", "reason": "already_absent", "item": id_minimal(raw), "canonical_key": key})
+            confirmed_destinations[key] = confirmed_destination(item)
+            results.append({"status": "skipped", "reason": "already_absent", "item": id_minimal(item), "canonical_key": key})
             continue
         try:
-            list_item_id = raw.get("_floppy_list_item_id") or current.get(key, {}).get("_floppy_list_item_id")
+            list_item_id = item.get("_floppy_list_item_id") or current.get(key, {}).get("_floppy_list_item_id")
             if list_item_id:
                 api_delete(adapter, f"lists/{lid}/items/{list_item_id}")
             else:
                 api_delete(adapter, f"media/{typ}/tmdb/{tmdb_id}/lists/{lid}")
         except Exception:
-            entry = unresolved(raw, "floppy_watchlist_remove_failed")
+            entry = unresolved(item, "floppy_watchlist_remove_failed")
             unresolved_rows.append(entry)
             results.append(entry)
             continue
         confirmed.append(key)
-        results.append({"status": "applied", "item": id_minimal(raw), "canonical_key": key})
-    return build_op_result(ok=not unresolved_rows, count=len(confirmed), confirmed_keys=confirmed, unresolved_keys=unresolved_keys(unresolved_rows, canonical_item_key), unresolved=unresolved_rows, results=results, attempted=len(confirmed) + len(unresolved_rows))
+        confirmed_destinations[key] = confirmed_destination(item)
+        results.append({"status": "applied", "item": id_minimal(item), "canonical_key": key})
+    return build_op_result(ok=not unresolved_rows, count=len(confirmed), confirmed_keys=confirmed, confirmed_destinations=confirmed_destinations, unresolved_keys=unresolved_keys(unresolved_rows, canonical_item_key), unresolved=unresolved_rows, results=results, attempted=len(confirmed) + len(unresolved_rows))

--- a/tests/test_floppy_sync.py
+++ b/tests/test_floppy_sync.py
@@ -61,6 +61,23 @@ class AdapterStub:
         self.client = ClientStub(SessionStub(routes))
 
 
+def _install_tmdb_resolver(monkeypatch: Any, tmdb_id: str) -> list[dict[str, Any]]:
+    from providers.metadata import _meta_TMDB
+
+    calls: list[dict[str, Any]] = []
+
+    class FakeTmdb:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def fetch(self, *, entity: str, ids: dict[str, str], need: dict[str, bool] | None = None, **_kwargs: Any) -> dict[str, Any]:
+            calls.append({"entity": entity, "ids": dict(ids), "need": dict(need or {})})
+            return {"ids": {"tmdb": tmdb_id}}
+
+    monkeypatch.setattr(_meta_TMDB, "TmdbProvider", FakeTmdb)
+    return calls
+
+
 def test_floppy_capabilities_expose_only_requested_features() -> None:
     from providers.sync._mod_FLOPPY import OPS
 
@@ -186,6 +203,28 @@ def test_floppy_watchlist_tracks_missing_item_before_add() -> None:
 
     assert res["count"] == 1
     assert [c["method"] for c in adapter.client.session.calls] == ["GET", "PUT", "POST", "PUT"]
+
+
+def test_floppy_watchlist_resolves_imdb_to_tmdb_when_metadata_configured(monkeypatch: Any) -> None:
+    from providers.sync.floppy import _watchlist
+
+    calls = _install_tmdb_resolver(monkeypatch, "550")
+    adapter = AdapterStub(
+        {
+            ("GET", "lists"): {"results": [{"id": 7, "name": "Watchlist"}], "count": 1},
+            ("PUT", "media/movie/tmdb/550/lists/7"): [],
+        },
+        {"floppy": {"watchlist_name": "Watchlist"}, "tmdb": {"api_key": "tmdb-key"}},
+    )
+
+    res = _watchlist.add(adapter, [{"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club"}])
+
+    assert res["count"] == 1
+    assert res["confirmed_keys"] == ["imdb:tt0137523"]
+    assert res["confirmed_destinations"]["imdb:tt0137523"]["key"] == "tmdb:550"
+    assert res["confirmed_destinations"]["imdb:tt0137523"]["item"]["ids"] == {"tmdb": "550", "imdb": "tt0137523"}
+    assert calls == [{"entity": "movie", "ids": {"imdb": "tt0137523"}, "need": {"poster": False, "backdrop": False, "ids": True}}]
+    assert adapter.client.session.calls[1]["path"] == "media/movie/tmdb/550/lists/7"
 
 
 def test_floppy_ratings_read_and_write_native_scale() -> None:
@@ -356,6 +395,32 @@ def test_floppy_progress_write_and_clear_use_playback_progress_api() -> None:
     assert adapter.client.session.calls[1]["json"] == {"media_type": "episode", "ids": {"tmdb": "22"}, "season_number": 1, "episode_number": 2, "position_seconds": None}
 
 
+def test_floppy_progress_resolves_show_imdb_to_tmdb_when_metadata_configured(monkeypatch: Any) -> None:
+    from providers.sync.floppy import _progress
+
+    calls = _install_tmdb_resolver(monkeypatch, "1399")
+    adapter = AdapterStub(
+        {("PUT", "playback/progress"): ResponseStub(204, {})},
+        {"floppy": {}, "tmdb": {"api_key": "tmdb-key"}},
+    )
+    item = {
+        "type": "episode",
+        "show_ids": {"imdb": "tt0944947"},
+        "season": 1,
+        "episode": 1,
+        "progress_ms": 600000,
+        "duration_ms": 3600000,
+    }
+
+    res = _progress.add(adapter, [item])
+
+    assert res["count"] == 1
+    assert res["confirmed_destinations"]["imdb:tt0944947#s01e01"]["key"] == "tmdb:1399#s01e01"
+    assert res["confirmed_destinations"]["imdb:tt0944947#s01e01"]["item"]["show_ids"] == {"tmdb": "1399", "imdb": "tt0944947"}
+    assert calls == [{"entity": "tv", "ids": {"imdb": "tt0944947"}, "need": {"poster": False, "backdrop": False, "ids": True}}]
+    assert adapter.client.session.calls[0]["json"]["ids"] == {"tmdb": "1399"}
+
+
 def test_floppy_history_reads_movies_and_episodes() -> None:
     from providers.sync.floppy import _history
 
@@ -377,6 +442,29 @@ def test_floppy_history_reads_movies_and_episodes() -> None:
     assert out["tmdb:11"]["watched_at"] == "2026-01-03T00:00:00Z"
     assert out["tmdb:11"]["_floppy_consumption_id"] == 43
     assert out["tmdb:22#s01e02"]["_floppy_consumption_id"] == 42
+
+
+def test_floppy_history_resolves_imdb_to_tmdb_when_metadata_configured(monkeypatch: Any) -> None:
+    from providers.sync.floppy import _history
+
+    _install_tmdb_resolver(monkeypatch, "550")
+    adapter = AdapterStub(
+        {("POST", "media/movie"): {"item_id": "movie/tmdb/550"}},
+        {"floppy": {}, "tmdb": {"api_key": "tmdb-key"}},
+    )
+
+    res = _history.add(adapter, [{"type": "movie", "ids": {"imdb": "tt0137523"}, "watched_at": "2026-01-01T00:00:00Z"}])
+
+    assert res["count"] == 1
+    assert res["confirmed_keys"] == ["imdb:tt0137523"]
+    assert res["confirmed_destinations"]["imdb:tt0137523"]["key"] == "tmdb:550"
+    assert res["confirmed_destinations"]["imdb:tt0137523"]["item"]["ids"] == {"tmdb": "550", "imdb": "tt0137523"}
+    assert adapter.client.session.calls[0]["json"] == {
+        "source": "tmdb",
+        "media_id": "550",
+        "status": 3,
+        "end_date": "2026-01-01T00:00:00Z",
+    }
 
 
 def test_floppy_movie_history_create_does_not_patch_after_create() -> None:


### PR DESCRIPTION
# Pull request

## Change

- Resolve IMDb/TVDB-only items to TMDB before Floppy writes.
- Also report the Floppy destination key so state can keep the source key linked to the resolved TMDB item.

## Why

Nuvio can provide IMDb-only items, but Floppy needs TMDB IDs. 
Those items were getting marked unresolved even with TMDB configured.

## Testing

- tests/test_floppy_sync.py

## Issue

Relates to #836