### PR TITLE
Add: CLI and API token support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,8 @@ COPY --from=appsrc --chown=root:root /src /app
 # --- scripts ---
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY docker/run-sync.sh   /usr/local/bin/run-sync.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/run-sync.sh
+COPY docker/cw            /usr/local/bin/cw
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/run-sync.sh /usr/local/bin/cw /app/cli/cw.py
 
 # --- runtime env ---
 ARG APP_VERSION=v0.0.0

--- a/api/apiTokensAPI.py
+++ b/api/apiTokensAPI.py
@@ -19,14 +19,13 @@ from .appAuthAPI import (
     _audit,
     _cfg_auth,
     _cfg_users,
-    _digest_eq,
-    _is_sha256_hex,
     _normalize_app_user_id,
     _now,
     _origin_allowed,
     _origin_blocked_response,
+    _password_hash,
+    _password_matches,
     _public_user,
-    _sha256_hex,
     _update_config,
     auth_required,
     current_user,
@@ -51,9 +50,23 @@ def _cfg_api_tokens(a: dict[str, Any]) -> list[dict[str, Any]]:
     return [x for x in raw if isinstance(x, dict)]
 
 
+def _valid_token_hash(raw: Any) -> bool:
+    if not isinstance(raw, dict):
+        return False
+    if str(raw.get("scheme") or "") != "pbkdf2_sha256":
+        return False
+    if not str(raw.get("salt") or "").strip():
+        return False
+    if not str(raw.get("hash") or "").strip():
+        return False
+    try:
+        return int(raw.get("iterations") or 0) > 0
+    except Exception:
+        return False
+
+
 def _valid_entry(entry: dict[str, Any]) -> bool:
-    digest = str(entry.get("token_hash") or "").strip()
-    if not digest or not _is_sha256_hex(digest):
+    if not _valid_token_hash(entry.get("token_hash")):
         return False
     if not str(entry.get("id") or "").strip():
         return False
@@ -127,11 +140,11 @@ def resolve_api_token(cfg: dict[str, Any], raw: str) -> dict[str, Any] | None:
     tokens = _cfg_api_tokens(a)
     if not tokens:
         return None
-    digest = _sha256_hex(token)
     for entry in tokens:
         if not _valid_entry(entry):
             continue
-        if not _digest_eq(digest, str(entry.get("token_hash") or "")):
+        token_hash = entry.get("token_hash")
+        if not isinstance(token_hash, dict) or not _password_matches(token_hash, token):
             continue
         identity = _entry_identity(a, entry)
         if identity is None:
@@ -201,7 +214,7 @@ def issue_api_token(
         entry = {
             "id": entry_id,
             "name": label,
-            "token_hash": _sha256_hex(raw),
+            "token_hash": _password_hash(raw),
             "prefix": raw[: len(TOKEN_PREFIX) + 6],
             "user_id": target,
             "username": str(identity.get("username") or ""),

--- a/api/apiTokensAPI.py
+++ b/api/apiTokensAPI.py
@@ -1,0 +1,388 @@
+# /api/apiTokensAPI.py
+# CrossWatch - API tokens for headless and CLI access
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import secrets
+import time
+from typing import Any
+
+from fastapi import APIRouter, Body, Request
+from fastapi.responses import JSONResponse
+
+from cw_platform.config_base import load_config
+
+from .appAuthAPI import (
+    ADMIN_USER_ID,
+    COOKIE_NAME,
+    _admin_identity,
+    _audit,
+    _cfg_auth,
+    _cfg_users,
+    _digest_eq,
+    _is_sha256_hex,
+    _normalize_app_user_id,
+    _now,
+    _origin_allowed,
+    _origin_blocked_response,
+    _public_user,
+    _sha256_hex,
+    _update_config,
+    auth_required,
+    current_user,
+)
+
+TOKEN_PREFIX = "cwt_"
+TOKEN_HEADER = "x-cw-token"
+MAX_TOKENS_PER_USER = 20
+TOUCH_INTERVAL_SEC = 300
+
+_TOUCH_CACHE: dict[str, float] = {}
+
+
+def _nostore(payload: dict[str, Any], status: int = 200) -> JSONResponse:
+    return JSONResponse(payload, status_code=status, headers={"Cache-Control": "no-store"})
+
+
+def _cfg_api_tokens(a: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = a.get("api_tokens")
+    if not isinstance(raw, list):
+        return []
+    return [x for x in raw if isinstance(x, dict)]
+
+
+def _valid_entry(entry: dict[str, Any]) -> bool:
+    digest = str(entry.get("token_hash") or "").strip()
+    if not digest or not _is_sha256_hex(digest):
+        return False
+    if not str(entry.get("id") or "").strip():
+        return False
+    exp = int(entry.get("expires_at") or 0)
+    return exp <= 0 or exp > _now()
+
+
+def _prune_api_tokens(tokens: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    keep = [t for t in tokens if _valid_entry(t)]
+    buckets: dict[str, list[dict[str, Any]]] = {}
+    for entry in keep:
+        buckets.setdefault(_entry_user_id(entry), []).append(entry)
+    out: list[dict[str, Any]] = []
+    for entries in buckets.values():
+        entries.sort(key=lambda x: int(x.get("created_at") or 0))
+        out.extend(entries[-MAX_TOKENS_PER_USER:])
+    out.sort(key=lambda x: int(x.get("created_at") or 0))
+    return out
+
+
+def _entry_user_id(entry: dict[str, Any]) -> str:
+    raw = entry.get("user_id")
+    if raw is None or str(raw).strip() == "":
+        return ADMIN_USER_ID
+    return _normalize_app_user_id(raw) or ADMIN_USER_ID
+
+
+def _entry_identity(a: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any] | None:
+    user_id = _entry_user_id(entry)
+    if user_id == ADMIN_USER_ID:
+        return _admin_identity(a)
+    raw = _cfg_users(a).get(user_id)
+    if not isinstance(raw, dict):
+        return None
+    public = _public_user(user_id, raw)
+    return public if public["enabled"] else None
+
+
+def _public_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": str(entry.get("id") or ""),
+        "name": str(entry.get("name") or ""),
+        "prefix": str(entry.get("prefix") or ""),
+        "user_id": _entry_user_id(entry),
+        "username": str(entry.get("username") or ""),
+        "created_at": int(entry.get("created_at") or 0),
+        "expires_at": int(entry.get("expires_at") or 0),
+        "last_used_at": int(entry.get("last_used_at") or 0),
+    }
+
+
+def extract_api_token(request: Request) -> str:
+    try:
+        headers = request.headers
+    except Exception:
+        return ""
+    raw = str(headers.get(TOKEN_HEADER) or "").strip()
+    if raw:
+        return raw
+    auth = str(headers.get("authorization") or "").strip()
+    if len(auth) > 7 and auth[:7].lower() == "bearer ":
+        return auth[7:].strip()
+    return ""
+
+
+def resolve_api_token(cfg: dict[str, Any], raw: str) -> dict[str, Any] | None:
+    token = str(raw or "").strip()
+    if not token or not token.startswith(TOKEN_PREFIX):
+        return None
+    a = _cfg_auth(cfg)
+    tokens = _cfg_api_tokens(a)
+    if not tokens:
+        return None
+    digest = _sha256_hex(token)
+    for entry in tokens:
+        if not _valid_entry(entry):
+            continue
+        if not _digest_eq(digest, str(entry.get("token_hash") or "")):
+            continue
+        identity = _entry_identity(a, entry)
+        if identity is None:
+            return None
+        out = dict(identity)
+        out["auth_kind"] = "api_token"
+        out["api_token_id"] = str(entry.get("id") or "")
+        out["api_token_name"] = str(entry.get("name") or "")
+        return out
+    return None
+
+
+def touch_api_token(token_id: str) -> None:
+    tid = str(token_id or "").strip()
+    if not tid:
+        return
+    now = time.time()
+    last = _TOUCH_CACHE.get(tid) or 0.0
+    if (now - last) < TOUCH_INTERVAL_SEC:
+        return
+    _TOUCH_CACHE[tid] = now
+
+    def _mutate(latest: dict[str, Any]) -> None:
+        a = latest.get("app_auth")
+        if not isinstance(a, dict):
+            return
+        for entry in _cfg_api_tokens(a):
+            if str(entry.get("id") or "") == tid:
+                entry["last_used_at"] = _now()
+                return
+
+    try:
+        _update_config(_mutate)
+    except Exception:
+        pass
+
+
+def issue_api_token(
+    cfg: dict[str, Any],
+    *,
+    name: str,
+    user_id: str = "",
+    expires_days: int = 0,
+) -> tuple[str, dict[str, Any]]:
+    label = str(name or "").strip()[:64] or "CLI"
+    days = max(0, int(expires_days or 0))
+    raw = TOKEN_PREFIX + secrets.token_urlsafe(32)
+    entry_id = secrets.token_hex(8)
+    created = _now()
+    expires = created + days * 86400 if days else 0
+    target = _normalize_app_user_id(user_id) or ADMIN_USER_ID
+
+    def _mutate(latest: dict[str, Any]) -> dict[str, Any]:
+        a = latest.setdefault("app_auth", {})
+        if not isinstance(a, dict):
+            a = {}
+            latest["app_auth"] = a
+        identity = None
+        if target == ADMIN_USER_ID:
+            identity = _admin_identity(a)
+        else:
+            found = _cfg_users(a).get(target)
+            if isinstance(found, dict):
+                identity = _public_user(target, found)
+        if identity is None:
+            raise KeyError("not_found")
+        entry = {
+            "id": entry_id,
+            "name": label,
+            "token_hash": _sha256_hex(raw),
+            "prefix": raw[: len(TOKEN_PREFIX) + 6],
+            "user_id": target,
+            "username": str(identity.get("username") or ""),
+            "created_at": created,
+            "expires_at": expires,
+            "last_used_at": 0,
+        }
+        a["api_tokens"] = _prune_api_tokens([*_cfg_api_tokens(a), entry])
+        return entry
+
+    _cfg, entry = _update_config(_mutate)
+    return raw, _public_entry(entry)
+
+
+def list_api_tokens(cfg: dict[str, Any], *, user_id: str = "") -> list[dict[str, Any]]:
+    a = _cfg_auth(cfg)
+    entries = _prune_api_tokens(_cfg_api_tokens(a))
+    scope = _normalize_app_user_id(user_id)
+    if scope:
+        entries = [e for e in entries if _entry_user_id(e) == scope]
+    return [_public_entry(e) for e in entries]
+
+
+def revoke_api_token(token_id: str, *, user_id: str = "") -> bool:
+    tid = str(token_id or "").strip()
+    if not tid:
+        return False
+    scope = _normalize_app_user_id(user_id)
+
+    def _mutate(latest: dict[str, Any]) -> bool:
+        a = latest.get("app_auth")
+        if not isinstance(a, dict):
+            return False
+        tokens = _cfg_api_tokens(a)
+        keep = []
+        removed = False
+        for entry in tokens:
+            match = str(entry.get("id") or "") == tid
+            if match and scope and _entry_user_id(entry) != scope:
+                match = False
+            if match:
+                removed = True
+                continue
+            keep.append(entry)
+        if removed:
+            a["api_tokens"] = keep
+        return removed
+
+    _cfg, removed = _update_config(_mutate)
+    _TOUCH_CACHE.pop(tid, None)
+    return bool(removed)
+
+
+def revoke_all_api_tokens(*, user_id: str = "") -> int:
+    scope = _normalize_app_user_id(user_id)
+
+    def _mutate(latest: dict[str, Any]) -> int:
+        a = latest.get("app_auth")
+        if not isinstance(a, dict):
+            return 0
+        tokens = _cfg_api_tokens(a)
+        keep = [e for e in tokens if scope and _entry_user_id(e) != scope]
+        a["api_tokens"] = keep
+        return len(tokens) - len(keep)
+
+    _cfg, count = _update_config(_mutate)
+    _TOUCH_CACHE.clear()
+    return int(count or 0)
+
+
+router = APIRouter(prefix="/api/app-auth/tokens", tags=["app-auth"])
+
+
+def _actor(request: Request) -> tuple[dict[str, Any] | None, JSONResponse | None]:
+    cfg = load_config()
+    if not auth_required(cfg):
+        return _admin_identity(_cfg_auth(cfg)), None
+    token = request.cookies.get(COOKIE_NAME)
+    user = current_user(cfg, token)
+    if user is None:
+        api_user = resolve_api_token(cfg, extract_api_token(request))
+        if api_user is not None:
+            return api_user, None
+        return None, _nostore({"ok": False, "error": "Unauthorized"}, 401)
+    if not user.get("is_admin"):
+        return None, _nostore({"ok": False, "error": "Administrator access required"}, 403)
+    if token and not _origin_allowed(request):
+        return None, _origin_blocked_response()
+    return user, None
+
+
+@router.get("/whoami")
+def api_tokens_whoami(request: Request) -> JSONResponse:
+    cfg = load_config()
+    if not auth_required(cfg):
+        return _nostore({"ok": True, "auth_required": False, "user": None})
+    actor = current_user(cfg, request.cookies.get(COOKIE_NAME))
+    kind = "session"
+    if actor is None:
+        actor = resolve_api_token(cfg, extract_api_token(request))
+        kind = "api_token"
+    if actor is None:
+        return _nostore({"ok": False, "error": "Unauthorized"}, 401)
+    return _nostore(
+        {
+            "ok": True,
+            "auth_required": True,
+            "auth_kind": kind,
+            "token_id": str(actor.get("api_token_id") or ""),
+            "token_name": str(actor.get("api_token_name") or ""),
+            "user": {
+                "id": actor.get("id"),
+                "username": actor.get("username"),
+                "display_name": actor.get("display_name"),
+                "is_admin": bool(actor.get("is_admin")),
+                "profile_id": actor.get("profile_id"),
+            },
+        }
+    )
+
+
+@router.get("")
+def api_tokens_list(request: Request) -> JSONResponse:
+    actor, err = _actor(request)
+    if err is not None:
+        return err
+    cfg = load_config()
+    scope = "" if (actor or {}).get("is_admin") else str((actor or {}).get("id") or "")
+    return _nostore({"ok": True, "tokens": list_api_tokens(cfg, user_id=scope)})
+
+
+@router.post("")
+def api_tokens_create(request: Request, payload: dict[str, Any] | None = Body(default_factory=dict)) -> JSONResponse:
+    actor, err = _actor(request)
+    if err is not None:
+        return err
+    body = payload or {}
+    name = str(body.get("name") or "").strip()
+    try:
+        expires_days = int(body.get("expires_days") or 0)
+    except Exception:
+        expires_days = 0
+    target = str(body.get("user_id") or "").strip()
+    if not (actor or {}).get("is_admin"):
+        target = str((actor or {}).get("id") or "")
+    cfg = load_config()
+    try:
+        raw, entry = issue_api_token(cfg, name=name, user_id=target, expires_days=expires_days)
+    except KeyError:
+        return _nostore({"ok": False, "error": "Not found"}, 404)
+    _audit(
+        request,
+        "api_token_created",
+        actor=actor,
+        target_type="api_token",
+        target_id=entry.get("id"),
+        message=f"API token {entry.get('name') or entry.get('id')} was created",
+        fields={"expires_at": entry.get("expires_at")},
+    )
+    return _nostore({"ok": True, "token": raw, "entry": entry})
+
+
+@router.delete("/{token_id}")
+def api_tokens_revoke(request: Request, token_id: str) -> JSONResponse:
+    actor, err = _actor(request)
+    if err is not None:
+        return err
+    scope = "" if (actor or {}).get("is_admin") else str((actor or {}).get("id") or "")
+    removed = revoke_api_token(token_id, user_id=scope)
+    if not removed:
+        return _nostore({"ok": False, "error": "Not found"}, 404)
+    _audit(
+        request,
+        "api_token_revoked",
+        actor=actor,
+        target_type="api_token",
+        target_id=token_id,
+        message=f"API token {token_id} was revoked",
+    )
+    return _nostore({"ok": True, "revoked": token_id})
+
+
+def register_api_tokens(app) -> None:
+    app.include_router(router)

--- a/api/configAPI.py
+++ b/api/configAPI.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import json
 import os
+import re
 from datetime import datetime, timezone
 
 from packaging.version import InvalidVersion, Version
@@ -640,6 +641,103 @@ def api_config_save(request: Request, payload: dict[str, Any] = Body(...)) -> di
             result["watcher_reload_error"] = "watcher_reload_failed"
             WATCH_LOG.error(f"watcher runtime refresh failed: {type(e).__name__}: {e}")
     return result
+
+PROTECTED_CONFIG_ROOTS = {"app_auth"}
+_CONFIG_INDEX_RE = re.compile(r"^\[(\d+)\]$")
+
+
+def _split_config_path(raw: Any) -> list[str]:
+    text = str(raw or "").strip()
+    if not text:
+        return []
+    parts: list[str] = []
+    for chunk in text.replace("/", ".").split("."):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        match = re.fullmatch(r"([^\[\]]*)((?:\[\d+\])*)", chunk)
+        if match is None:
+            parts.append(chunk)
+            continue
+        head, indexes = match.group(1), match.group(2)
+        if head:
+            parts.append(head)
+        for pos in re.findall(r"\[(\d+)\]", indexes):
+            parts.append(f"[{pos}]")
+    return parts
+
+
+def _delete_config_path(cfg: dict[str, Any], parts: list[str]) -> bool:
+    node: Any = cfg
+    for part in parts[:-1]:
+        index = _CONFIG_INDEX_RE.match(part)
+        if index is not None:
+            if not isinstance(node, list):
+                return False
+            pos = int(index.group(1))
+            if pos >= len(node):
+                return False
+            node = node[pos]
+            continue
+        if not isinstance(node, dict) or part not in node:
+            return False
+        node = node[part]
+    last = parts[-1]
+    index = _CONFIG_INDEX_RE.match(last)
+    if index is not None:
+        if not isinstance(node, list):
+            return False
+        pos = int(index.group(1))
+        if pos >= len(node):
+            return False
+        node.pop(pos)
+        return True
+    if not isinstance(node, dict) or last not in node:
+        return False
+    node.pop(last, None)
+    return True
+
+
+@router.post("/config/unset")
+def api_config_unset(request: Request, payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
+    raw_paths = payload.get("paths")
+    if not isinstance(raw_paths, list):
+        raw_paths = [payload.get("path")] if payload.get("path") else []
+
+    requested = [str(p or "").strip() for p in raw_paths if str(p or "").strip()]
+    if not requested:
+        return {"ok": False, "error": "no_paths"}
+
+    env = _env()
+    cfg = dict(env["load"]() or {})
+    removed: list[str] = []
+    missing: list[str] = []
+
+    for raw in requested:
+        parts = _split_config_path(raw)
+        if not parts:
+            missing.append(raw)
+            continue
+        if parts[0] in PROTECTED_CONFIG_ROOTS:
+            return {"ok": False, "error": "protected_path", "path": raw}
+        if _delete_config_path(cfg, parts):
+            removed.append(raw)
+        else:
+            missing.append(raw)
+
+    if not removed:
+        return {"ok": False, "error": "not_found", "missing": missing}
+
+    try:
+        env["prune"](cfg)
+        env["ensure"](cfg)
+    except Exception:
+        pass
+
+    env["save"](cfg)
+    _after_config_save(env, cfg)
+    return {"ok": True, "removed": removed, "missing": missing}
+
 
 @router.post("/config/migrate")
 def api_config_migrate() -> dict[str, Any]:

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,455 @@
+# CrossWatch CLI
+
+`cw` does what the web UI does, from a terminal. Status, config, provider logins, syncs, watcher, scheduler, logs, plus the analyzer, events, captures, backups, playlists, the editor and the rest.
+
+It runs in the same container as CrossWatch and talks to the running service over the API. So a sync you start here shows up in the web UI, logs to the same place, and respects the sync already running guard. If the service is down, the read only stuff still works by reading the install directly.
+
+```
+docker exec -it crosswatch cw status
+docker exec -it crosswatch cw sync run --follow
+docker exec -it crosswatch cw shell
+```
+
+Inside the container, `cw` is installed on `PATH`, so the current directory does not matter:
+
+```
+cw status
+cw auth token create --local
+```
+
+Outside a container, run it from the install root:
+
+```
+python cli/cw.py status
+python -m cli status
+```
+
+## Tokens
+
+No auth enabled in CrossWatch? Nothing to do, it just works.
+
+With auth on you need a token. Use `--local` for the first one, that writes straight to the config so it works before you can authenticate at all:
+
+```
+cw --local auth token create --name cli
+```
+
+Shown once. Saved to `/config/.cw_cli/cli.json` in the container, `~/.crosswatch/cli.json` outside it. Every command after that is authenticated.
+
+Per command or from the env if you prefer:
+
+```
+cw --token cwt_... status
+CW_TOKEN=cwt_... cw status
+```
+
+```
+cw auth token whoami
+cw auth token list
+cw auth token revoke <id>
+```
+
+Tokens are hashed at rest, inherit the permissions of the user they belong to, and land in the audit log like any UI action. Add `--expires-days` if you want them to lapse.
+
+## Global options
+
+These work anywhere on the line, before or after the subcommand.
+
+```
+-U, --url            base URL, falls back to CW_URL then the local install
+-T, --token          API token, falls back to CW_TOKEN then the saved one
+-o, --output         auto, table, json, yaml, plain
+-L, --local          use this install, never the API
+-k, --insecure       skip TLS checks, for self signed certs
+    --http-timeout   seconds, default 30
+-q, --quiet
+    --no-color
+```
+
+`-o json` and `-o plain` are the script friendly ones. JSON on stdout, nothing decorative, errors on stderr.
+
+```
+cw pair list -o json | jq ".[] | select(.enabled) | .id"
+cw auth token list -o plain | cut -f1
+```
+
+## Status
+
+```
+cw status                    everything at a glance
+cw status --fresh            re-probe providers instead of the cached status
+cw status --no-providers     skip the provider table
+cw version                   version, plus every provider module version
+cw health                    is anything answering
+```
+
+## Pairs
+
+```
+cw pair create plex trakt --feature watchlist --feature ratings
+cw pair create simkl trakt --mode two-way
+cw pair list [--enabled]
+cw pair show <id>
+cw pair enable <id>
+cw pair disable <id>
+cw pair feature <id> <feature> on|off
+cw pair reorder <id> <id> ...
+cw pair delete <id> [--yes]
+```
+
+Any unique id prefix works, so `cw pair show pair_07c3` is enough. The route name works too, `cw pair show "PLEX -> TRAKT"`.
+
+## Sync
+
+```
+cw sync run                        every enabled pair
+cw sync run --pair pair_07c3       just the one
+cw sync run --follow               run it and stream the log until it finishes
+cw sync status                     current or last run, with counts
+cw sync follow                     attach to a run already going
+cw sync cancel                     stop after the current step
+cw sync unresolved                 what the last run could not match
+cw sync providers [--counts]
+```
+
+`--follow` passes through the exit code from the sync, handy in cron or a health check.
+
+## Config
+
+```
+cw config show [path]              all of it, or one subtree, secrets masked
+cw config get sync.anime.enabled
+cw config set sync.anime.enabled true
+cw config set some.list "[1,2,3]" --json
+cw config unset some.key
+cw config edit                     opens $EDITOR
+cw config meta                     the schema the UI uses
+cw config migrate                  bring an old config up to date
+cw config path                     where config, state and the db live
+```
+
+`set` is a merge patch, it only touches the key you name. Values get parsed, so `true`, `yes`, `on`, numbers and `null` all do the obvious thing, everything else stays a string. It will not let you clobber an object or a list with a scalar unless you pass `--json`.
+
+`unset` actually removes the key. A merge patch cannot delete, so that one goes through its own endpoint. Anything under `app_auth` is off limits.
+
+## Provider logins
+
+All 18 providers work from here. Look before you leap:
+
+```
+cw auth providers                  everything, its flow and what it wants
+cw auth show jellyfin              the fields for one provider
+cw auth list [--fresh]             what is connected right now
+```
+
+`cw auth login <provider>` sorts out the flow itself, so the command is the same whichever kind it is:
+
+```
+cw auth login trakt                prints a code, waits for you to approve it
+cw auth login plex --no-wait       same, without blocking
+cw auth login jellyfin             asks for server, username, password
+cw auth logout simkl
+```
+
+Plex, Trakt, SIMKL, MDBList, PunchPlay, BingeBase and Nuvio give you a code and a URL, then poll until they report connected or `--timeout` runs out.
+
+Jellyfin, Emby, Kodi, Stremio, Floppy, Scrob, Tautulli, PublicMetaDB and TMDb ask for fields. Trakt, SIMKL and AniList want a client id and secret first. Pass them instead of typing them if you are scripting:
+
+```
+cw auth login jellyfin \
+  --field jellyfin.server=http://192.168.2.100:8096 \
+  --field jellyfin.username=pascal \
+  --field jellyfin.password="$JF_PASSWORD" \
+  --non-interactive
+```
+
+Field names come from the provider manifest, so `cw auth show <provider>` is the list that counts. The prefix is optional, `--field username=bob` is fine. `--non-interactive` exits 2 instead of prompting.
+
+AniList is the odd one, it needs the client id and secret, then a browser to finish. The CLI prints the URL and waits for the callback.
+
+`--instance <id>` everywhere, for multi instance setups.
+
+## Analyzer
+
+Finds items that are stuck or disagree between providers.
+
+```
+cw analyzer problems               what it thinks is wrong
+cw analyzer attention              mismatches, pending retries, blocked
+cw analyzer ratings                where ratings disagree
+cw analyzer activity               per pair
+cw analyzer detail <provider> <feature> <key>
+cw analyzer suggest <provider> <feature> <key>
+cw analyzer fix <provider> <feature> <key>
+cw analyzer drop <provider> <feature> <key>
+cw analyzer tracker
+```
+
+Most of them take `--pairs id1,id2` to narrow the scope.
+
+## Events
+
+```
+cw events status
+cw events recent [--domain scrobble] [--view events]
+cw events search "dragon ball" --provider TRAKT
+cw events groups
+cw events show <group_id>
+cw events run <run_id>             everything one sync run recorded
+cw events item <item_key>          the history of one item
+cw events stats --range 7d
+cw events ack <group_id> [--undo]
+cw events clear
+```
+
+## Captures
+
+The rollback tool.
+
+```
+cw capture list
+cw capture create [--provider PLEX] [--feature watchlist]
+cw capture diff <older> <newer>
+cw capture read <path>
+cw capture restore <path> [--dry-run]
+cw capture delete <path>
+cw capture clear
+```
+
+`capture create` waits for the job and prints progress. `--no-wait` if you would rather not.
+
+## Backups
+
+```
+cw backup list
+cw backup create --note "before the big sync"
+cw backup validate <path>
+cw backup restore <path>
+cw backup delete <path>
+cw backup schedule [--enable] [--every-hours 24]
+cw backup retention 10
+```
+
+## Watchlist and playback
+
+```
+cw watchlist list [--type movie] [--search dune]
+cw watchlist remove <key> [<key> ...]
+
+cw progress list [--provider PLEX] [--min 10]
+cw progress providers
+cw progress settings
+cw progress watched <key>
+cw progress set <key> 45
+cw progress remove <key>
+```
+
+## Editor
+
+```
+cw editor list --kind watchlist [--provider PLEX]
+cw editor sources
+cw editor providers
+cw editor send <key> --provider TRAKT
+cw editor export
+```
+
+## Playlists
+
+```
+cw playlist overview
+cw playlist providers
+cw playlist resources PLEX
+cw playlist activity
+
+cw playlist endpoint list|add|sync|delete
+cw playlist mapping list|add|run|preview|result|delete
+cw playlist ruleset list|show|delete
+```
+
+`cw playlist mapping run <id> --dry-run` first, always.
+
+## Import and export
+
+```
+cw export options
+cw export preview --provider PLEX --feature watchlist
+cw export file out.csv --provider PLEX --feature watchlist
+
+cw import options
+cw import preview letterboxd.csv
+cw import commit <import_id> --features watchlist
+```
+
+## Metadata and manual entry
+
+```
+cw metadata search "blade runner" --year 1982
+cw metadata resolve imdb=tt0083658
+cw metadata providers
+
+cw manual providers
+cw manual watched --field imdb=tt0083658 --field type=movie --provider TRAKT
+```
+
+## Anime mapping
+
+```
+cw anime status
+cw anime update [--rebuild]
+cw anime overrides
+cw anime add-override \
+  --field match_provider=tvdb --field match_id=81472 \
+  --field target_namespace=anidb --field target_id=4563
+cw anime delete-override <rule_id>
+cw anime search "dragon ball z"
+cw anime export
+```
+
+## Instances and profiles
+
+```
+cw instance list [PLEX] [--configured]
+cw instance add plex --field server=http://...
+cw instance set plex PLEX-P01 --field label=Living room
+cw instance delete plex PLEX-P01
+
+cw user-profile list|show|create|set|delete
+```
+
+## Scrobbler
+
+```
+cw scrobbler overview
+cw scrobbler event-routes
+cw scrobbler route add|set|delete
+cw scrobbler webhook urls
+cw scrobbler webhook regenerate
+cw scrobbler webhook cleanup-legacy
+```
+
+## Reporting
+
+```
+cw insights
+cw stats [--raw]
+cw activity recent
+cw activity history [--type movie] [--search dune]
+cw activity clear
+```
+
+## Maintenance
+
+```
+cw maintenance database            runtime db health
+cw maintenance events              archive health, --optimize, --rebuild
+cw maintenance cache <what>        all, metadata, provider-sync, activity-log, scrobbles, state
+cw maintenance provider-cache
+cw maintenance state-file --prune|--compact
+cw maintenance tracker [--clear]
+cw maintenance reset-stats
+cw maintenance reset-watching
+cw maintenance support [--scopes]
+cw maintenance restart
+```
+
+## Watcher
+
+```
+cw watcher status
+cw watcher start
+cw watcher stop
+cw watcher restart                 reload config and restart the routes
+cw watcher now                     what is playing
+cw watcher logs [-n 200]
+```
+
+## Scheduler
+
+```
+cw scheduler status
+cw scheduler next
+cw scheduler enable
+cw scheduler disable
+cw scheduler run-now               fire it now
+cw scheduler replan                recompute the next run time
+cw scheduler stop                  stop the worker, keep the config
+cw scheduler show                  raw scheduling config
+```
+
+## Logs
+
+```
+cw logs tail                       last 200 lines of SYNC
+cw logs tail -t WATCH -n 500
+cw logs tail -f                    follow it live
+cw logs tail -f --grep "ERROR|WARN"
+cw logs channels
+```
+
+## Shell
+
+```
+cw shell
+```
+
+Groups nest, so you stop retyping the prefix:
+
+```
+cw> sync
+cw(sync)> ?
+cw(sync)> status
+cw(sync)> run --follow
+cw(sync)> !status          run something top level without leaving
+cw(sync)> exit
+cw> config
+cw(config)> get sync.anime.enabled
+cw(config)> exit
+cw> exit
+```
+
+`?` shows what you can run here, `help <command>` gives the full help, `exit` or `end` or `..` steps back out. History goes to `~/.crosswatch/history`. Tab completion works where readline does.
+
+## Exit codes
+
+```
+0   ok
+1   failed
+2   bad usage
+3   cannot reach CrossWatch
+4   not allowed
+5   not found
+6   busy, a sync is already running
+```
+
+`cw sync run --follow` passes through the exit code from the sync instead.
+
+## When the service is down
+
+Read only and repair commands keep going by reading the install. You get a note on stderr and the endpoint shows as `local (fallback)`:
+
+```
+! Cannot reach CrossWatch at http://127.0.0.1:8787 - answering from the local install instead
+```
+
+Works without the service: `status`, `health`, `version`, all of `config`, `pair list/show/enable/disable/delete`, `scheduler status/next/show`, and every `auth token` command.
+
+Anything that needs the engine running, so starting a sync, poking the watcher, streaming logs, fails with exit 3 instead of doing something the UI cannot see. `--local` forces that mode and turns those into an error straight away.
+
+## Layout
+
+```
+cli/
+  cw.py            entry point
+  _app.py          Typer app, argument hoisting, error handling
+  _context.py      per invocation state, API first with local fallback
+  _transport.py    HTTP client and SSE log streaming
+  _local.py        in-process transport for the offline subset
+  _settings.py     URL and token resolution, cli.json
+  _render.py       table, key value, JSON, YAML and plain output
+  _util.py         dotted paths, value parsing, formatting, pair lookup
+  _errors.py       error types and exit codes
+  commands/        one module per group
+```
+
+New command group means a `commands/<name>.py` with a `register(app)` function, listed in `_app._register_all`. Commands go through `Ctx` rather than a transport, that is what gets them the fallback for free.

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,12 @@
+# /cli/__init__.py
+# CrossWatch - Command line package
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+__all__ = ["main"]
+
+
+def main(argv: list[str] | None = None) -> int:
+    from ._app import main as _main
+
+    return _main(argv)

--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -1,0 +1,11 @@
+# /cli/__main__.py
+# CrossWatch - Entry point for python -m cli
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import sys
+
+from ._app import main
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/cli/_app.py
+++ b/cli/_app.py
@@ -1,0 +1,293 @@
+# /cli/_app.py
+# CrossWatch - CLI application, argument handling and error reporting
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import typer
+
+from ._context import Ctx
+from ._errors import EXIT_ERROR, EXIT_USAGE, CLIError
+from ._render import Output
+
+PROG = "cw"
+HELP = """CrossWatch command line.
+
+Talks to the running CrossWatch service over its API, and falls back to the
+local install for read-only and repair commands when the service is down.
+"""
+
+app = typer.Typer(
+    name=PROG,
+    help=HELP,
+    add_completion=True,
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+
+
+def get_ctx(ctx: typer.Context) -> Ctx:
+    state = ctx.obj
+    if not isinstance(state, Ctx):
+        state = Ctx.build()
+        ctx.obj = state
+    return state
+
+
+PARAM_TO_OPTION = {
+    "url": "url",
+    "token": "token",
+    "output": "output",
+    "local": "local",
+    "insecure": "insecure",
+    "http_timeout": "timeout",
+    "quiet": "quiet",
+}
+
+
+def _given_on_the_command_line(ctx: typer.Context, name: str) -> bool:
+    try:
+        source = ctx.get_parameter_source(name)
+    except Exception:
+        return False
+    return source is not None and getattr(source, "name", "DEFAULT") != "DEFAULT"
+
+
+@app.callback()
+def main_callback(
+    ctx: typer.Context,
+    url: str = typer.Option("", "--url", "-U", help="CrossWatch base URL. Defaults to CW_URL, then the local install.", envvar="CW_URL"),
+    token: str = typer.Option("", "--token", "-T", help="API token. Defaults to CW_TOKEN or the saved token.", envvar="CW_TOKEN"),
+    output: str = typer.Option("auto", "--output", "-o", help="Output format: auto, table, json, yaml, plain."),
+    local: bool = typer.Option(False, "--local", "-L", help="Work directly against this install, never the HTTP API."),
+    insecure: bool = typer.Option(False, "--insecure", "-k", help="Skip TLS verification (self-signed certificates)."),
+    http_timeout: float = typer.Option(30.0, "--http-timeout", help="HTTP timeout in seconds."),
+    no_color: bool = typer.Option(False, "--no-color", help="Disable colored output."),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Suppress non-essential output."),
+) -> None:
+    if output not in ("auto", "table", "json", "yaml", "plain"):
+        raise CLIError(f"Unknown output format '{output}'", hint="Use auto, table, json, yaml or plain.", exit_code=EXIT_USAGE)
+
+    given = {
+        "url": url,
+        "token": token,
+        "output": output,
+        "local": local,
+        "insecure": insecure,
+        "http_timeout": http_timeout,
+        "quiet": quiet,
+    }
+    explicit = {name for name in given if _given_on_the_command_line(ctx, name)}
+    if _given_on_the_command_line(ctx, "no_color"):
+        explicit.add("no_color")
+
+    inherited = ctx.obj if isinstance(ctx.obj, Ctx) else None
+    if inherited is not None and not explicit:
+        return
+
+    settings: dict[str, Any] = dict(inherited.options) if inherited is not None else {}
+    for name in explicit:
+        if name == "no_color":
+            settings["color"] = not no_color
+        else:
+            settings[PARAM_TO_OPTION[name]] = given[name]
+
+    ctx.obj = Ctx.build(**settings) if inherited is not None else Ctx.build(
+        url=url,
+        token=token,
+        timeout=http_timeout,
+        insecure=insecure,
+        local=local,
+        output=output,
+        color=not no_color,
+        quiet=quiet,
+    )
+
+
+def _register_all() -> None:
+    from .commands import (
+        analyzer,
+        anime,
+        auth,
+        backup,
+        capture,
+        config,
+        editor,
+        events,
+        insights,
+        instance,
+        logs,
+        maintenance,
+        metadata,
+        pair,
+        playlist,
+        progress,
+        scheduler,
+        scrobbler,
+        shell,
+        status,
+        sync,
+        transfer,
+        watcher,
+        watchlist,
+    )
+
+    for module in (
+        status,
+        pair,
+        sync,
+        config,
+        auth,
+        watcher,
+        scheduler,
+        logs,
+        analyzer,
+        events,
+        capture,
+        backup,
+        watchlist,
+        progress,
+        editor,
+        playlist,
+        transfer,
+        metadata,
+        anime,
+        instance,
+        scrobbler,
+        insights,
+        maintenance,
+        shell,
+    ):
+        module.register(app)
+
+
+_register_all()
+
+
+GLOBAL_VALUE_FLAGS = {"--url", "-U", "--token", "-T", "--output", "-o", "--http-timeout"}
+GLOBAL_BOOL_FLAGS = {"--local", "-L", "--insecure", "-k", "--no-color", "--quiet", "-q"}
+
+
+def hoist_globals(args: list[str]) -> list[str]:
+    leading: list[str] = []
+    rest: list[str] = []
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token == "--":
+            rest.extend(args[index:])
+            break
+        head = token.split("=", 1)[0]
+        if head in GLOBAL_VALUE_FLAGS:
+            leading.append(token)
+            if "=" not in token and index + 1 < len(args):
+                index += 1
+                leading.append(args[index])
+            index += 1
+            continue
+        if head in GLOBAL_BOOL_FLAGS:
+            leading.append(token)
+            index += 1
+            continue
+        rest.append(token)
+        index += 1
+    return leading + rest
+
+
+def click_exception_types() -> tuple[type[BaseException], ...]:
+    found: list[type[BaseException]] = []
+    modules: list[Any] = []
+    try:
+        from typer._click import exceptions as typer_exceptions
+
+        modules.append(typer_exceptions)
+    except Exception:
+        pass
+    try:
+        import click.exceptions as click_exceptions_module
+
+        modules.append(click_exceptions_module)
+    except Exception:
+        pass
+    for module in modules:
+        for name in ("ClickException", "Exit", "Abort", "UsageError"):
+            candidate = getattr(module, name, None)
+            if isinstance(candidate, type) and issubclass(candidate, BaseException):
+                found.append(candidate)
+    return tuple(found) or (SystemExit,)
+
+
+def _handle_click(err: BaseException, reporter: Output) -> int:
+    names = {klass.__name__ for klass in type(err).__mro__}
+    if "Exit" in names:
+        return int(getattr(err, "exit_code", 0) or 0)
+    if "Abort" in names:
+        reporter.warn("Aborted")
+        return 130
+    show = getattr(err, "show", None)
+    if callable(show):
+        try:
+            show()
+        except Exception:
+            reporter.error(str(err))
+    else:
+        reporter.error(str(err))
+    if "UsageError" in names:
+        return EXIT_USAGE
+    return int(getattr(err, "exit_code", EXIT_ERROR) or EXIT_ERROR)
+
+
+def _invoke(args: list[str], state: Ctx | None = None) -> int:
+    reporter = state.out if state is not None else Output()
+    try:
+        if state is None:
+            app(args=args, prog_name=PROG, standalone_mode=False)
+        else:
+            app(args=args, prog_name=PROG, standalone_mode=False, obj=state)
+    except CLIError as err:
+        reporter.error(err.message, err.hint)
+        return err.exit_code
+    except click_exception_types() as err:
+        return _handle_click(err, reporter)
+    except KeyboardInterrupt:
+        reporter.warn("Interrupted")
+        return 130
+    except BrokenPipeError:
+        return 0
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return _invoke(hoist_globals(list(sys.argv[1:] if argv is None else argv)))
+
+
+def run_isolated(ctx_state: Ctx, argv: list[str]) -> int:
+    return _invoke(hoist_globals(list(argv)), ctx_state)
+
+
+def _short_help(command: Any) -> str:
+    try:
+        return (command.get_short_help_str(limit=70) or "").strip()
+    except Exception:
+        return (getattr(command, "help", "") or "").strip().splitlines()[0] if getattr(command, "help", "") else ""
+
+
+def _subcommands(command: Any) -> dict[str, Any]:
+    commands = getattr(command, "commands", None)
+    return commands if isinstance(commands, dict) else {}
+
+
+def describe_commands() -> list[tuple[str, str]]:
+    root = typer.main.get_command(app)
+    return [(name, _short_help(command)) for name, command in sorted(_subcommands(root).items())]
+
+
+def describe_group(name: str) -> list[tuple[str, str]]:
+    root = typer.main.get_command(app)
+    group = _subcommands(root).get(name)
+    if group is None:
+        return []
+    return [(sub, _short_help(command)) for sub, command in sorted(_subcommands(group).items())]

--- a/cli/_context.py
+++ b/cli/_context.py
@@ -1,0 +1,130 @@
+# /cli/_context.py
+# CrossWatch - CLI invocation state, service first with local fallback
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterator
+
+from ._errors import CLIError, LocalUnsupported, TransportUnavailable
+from ._local import LocalTransport
+from ._render import Output
+from ._settings import resolve_token, resolve_url
+from ._transport import HttpTransport, Transport
+
+
+@dataclass
+class Ctx:
+    url: str = ""
+    token: str = ""
+    timeout: float = 30.0
+    insecure: bool = False
+    force_local: bool = False
+    out: Output = field(default_factory=Output)
+    options: dict[str, Any] = field(default_factory=dict, repr=False)
+    _http: HttpTransport | None = field(default=None, repr=False)
+    _local: LocalTransport | None = field(default=None, repr=False)
+    _fell_back: bool = field(default=False, repr=False)
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        url: str = "",
+        token: str = "",
+        timeout: float = 30.0,
+        insecure: bool = False,
+        local: bool = False,
+        output: str = "auto",
+        color: bool = True,
+        quiet: bool = False,
+    ) -> "Ctx":
+        return cls(
+            url=resolve_url(url),
+            token=resolve_token(token),
+            timeout=timeout,
+            insecure=insecure,
+            force_local=bool(local),
+            out=Output(output, color=color, quiet=quiet),
+            options={
+                "url": url,
+                "token": token,
+                "timeout": timeout,
+                "insecure": insecure,
+                "local": local,
+                "output": output,
+                "color": color,
+                "quiet": quiet,
+            },
+        )
+
+    @property
+    def http(self) -> HttpTransport:
+        if self._http is None:
+            self._http = HttpTransport(self.url, token=self.token, timeout=self.timeout, insecure=self.insecure)
+        return self._http
+
+    @property
+    def local(self) -> LocalTransport:
+        if self._local is None:
+            self._local = LocalTransport()
+        return self._local
+
+    @property
+    def transport(self) -> Transport:
+        return self.local if self.force_local else self.http
+
+    @property
+    def mode(self) -> str:
+        if self.force_local:
+            return "local"
+        return "local (fallback)" if self._fell_back else "service"
+
+    def _note_fallback(self, reason: str) -> None:
+        if self._fell_back:
+            return
+        self._fell_back = True
+        self.out.warn(f"{reason} - answering from the local install instead (read-only view may be stale).")
+
+    def request(self, method: str, path: str, *, params: dict[str, Any] | None = None, json_body: Any = None) -> Any:
+        if self.force_local:
+            return self.local.request(method, path, params=params, json_body=json_body)
+        try:
+            return self.http.request(method, path, params=params, json_body=json_body)
+        except TransportUnavailable as unreachable:
+            try:
+                result = self.local.request(method, path, params=params, json_body=json_body)
+            except LocalUnsupported:
+                raise unreachable from None
+            except CLIError:
+                raise unreachable from None
+            self._note_fallback(str(unreachable.message))
+            return result
+
+    def get(self, path: str, **kwargs: Any) -> Any:
+        return self.request("GET", path, **kwargs)
+
+    def post(self, path: str, **kwargs: Any) -> Any:
+        return self.request("POST", path, **kwargs)
+
+    def put(self, path: str, **kwargs: Any) -> Any:
+        return self.request("PUT", path, **kwargs)
+
+    def delete(self, path: str, **kwargs: Any) -> Any:
+        return self.request("DELETE", path, **kwargs)
+
+    def stream_sse(self, path: str, *, params: dict[str, Any] | None = None) -> Iterator[tuple[str, str]]:
+        if self.force_local:
+            raise LocalUnsupported("Log streaming")
+        return self.http.stream_sse(path, params=params)
+
+    def stream_client(self) -> HttpTransport:
+        return HttpTransport(self.url, token=self.token, timeout=self.timeout, insecure=self.insecure)
+
+    def require_service(self, what: str) -> None:
+        if self.force_local:
+            raise LocalUnsupported(what)
+
+    def close(self) -> None:
+        if self._http is not None:
+            self._http.close()

--- a/cli/_errors.py
+++ b/cli/_errors.py
@@ -1,0 +1,68 @@
+# /cli/_errors.py
+# CrossWatch - CLI error types and exit codes
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_USAGE = 2
+EXIT_UNREACHABLE = 3
+EXIT_UNAUTHORIZED = 4
+EXIT_NOT_FOUND = 5
+EXIT_BUSY = 6
+
+
+class CLIError(Exception):
+    def __init__(self, message: str, *, hint: str = "", exit_code: int = EXIT_ERROR) -> None:
+        super().__init__(message)
+        self.message = message
+        self.hint = hint
+        self.exit_code = exit_code
+
+
+class TransportUnavailable(CLIError):
+    def __init__(self, message: str, *, hint: str = "") -> None:
+        super().__init__(message, hint=hint, exit_code=EXIT_UNREACHABLE)
+
+
+class LocalUnsupported(CLIError):
+    def __init__(self, what: str) -> None:
+        super().__init__(
+            f"{what} needs the CrossWatch service",
+            hint="Start CrossWatch, or drop --local so the CLI can reach the running instance.",
+            exit_code=EXIT_UNREACHABLE,
+        )
+
+
+class ApiError(CLIError):
+    def __init__(self, status: int, payload: Any, *, method: str = "", path: str = "") -> None:
+        self.status = int(status)
+        self.payload = payload
+        detail = ""
+        if isinstance(payload, dict):
+            for field in ("message", "detail", "error"):
+                value = payload.get(field)
+                if isinstance(value, str) and value.strip():
+                    detail = value.strip()
+                    break
+        elif isinstance(payload, str):
+            detail = payload.strip()[:400]
+        where = f"{method} {path}".strip()
+        message = detail or f"Request failed with HTTP {self.status}"
+        if where:
+            message = f"{message} ({where})"
+        code = EXIT_ERROR
+        hint = ""
+        if self.status == 401:
+            code = EXIT_UNAUTHORIZED
+            hint = "Create a token with 'cw auth token create --local' and export CW_TOKEN, or run 'cw auth token use <token>'."
+        elif self.status == 403:
+            code = EXIT_UNAUTHORIZED
+            hint = "This token does not have permission for that action."
+        elif self.status == 404:
+            code = EXIT_NOT_FOUND
+        elif self.status == 409:
+            code = EXIT_BUSY
+        super().__init__(message, hint=hint, exit_code=code)

--- a/cli/_local.py
+++ b/cli/_local.py
@@ -1,0 +1,277 @@
+# /cli/_local.py
+# CrossWatch - In-process transport for CLI commands that run without the service
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+from ._util import as_dict
+from ._errors import CLIError, LocalUnsupported
+from ._transport import Transport
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _ensure_import_path() -> None:
+    root = str(REPO_ROOT)
+    if root not in sys.path:
+        sys.path.insert(0, root)
+
+
+class LocalTransport(Transport):
+    name = "local"
+
+    def __init__(self) -> None:
+        _ensure_import_path()
+        try:
+            from cw_platform import config_base
+        except Exception as exc:
+            raise CLIError(
+                "Cannot load the CrossWatch engine from this directory",
+                hint=f"Run the CLI from the CrossWatch install root. ({exc})",
+            ) from exc
+        self._cfg_base = config_base
+        self._routes: list[tuple[str, list[str], Callable[..., Any]]] = []
+        self._register()
+
+    def _add(self, method: str, pattern: str, handler: Callable[..., Any]) -> None:
+        self._routes.append((method.upper(), [p for p in pattern.strip("/").split("/")], handler))
+
+    def _register(self) -> None:
+        self._add("GET", "/api/health", self._health)
+        self._add("GET", "/api/version", self._version)
+        self._add("GET", "/api/status", self._status)
+        self._add("GET", "/api/config", self._config_get)
+        self._add("POST", "/api/config", self._config_post)
+        self._add("POST", "/api/config/unset", self._config_unset)
+        self._add("GET", "/api/pairs", self._pairs_get)
+        self._add("PUT", "/api/pairs/{pair_id}", self._pairs_put)
+        self._add("DELETE", "/api/pairs/{pair_id}", self._pairs_delete)
+        self._add("GET", "/api/scheduling", self._scheduling_get)
+        self._add("GET", "/api/scheduling/status", self._scheduling_status)
+        self._add("GET", "/api/scheduling/next", self._scheduling_next)
+        self._add("GET", "/api/app-auth/tokens", self._tokens_get)
+        self._add("POST", "/api/app-auth/tokens", self._tokens_post)
+        self._add("DELETE", "/api/app-auth/tokens/{token_id}", self._tokens_delete)
+
+    def _match(self, method: str, path: str) -> tuple[Callable[..., Any], dict[str, str]] | None:
+        parts = [p for p in path.split("?", 1)[0].strip("/").split("/")]
+        for route_method, pattern, handler in self._routes:
+            if route_method != method.upper() or len(pattern) != len(parts):
+                continue
+            captured: dict[str, str] = {}
+            ok = True
+            for expected, actual in zip(pattern, parts):
+                if expected.startswith("{") and expected.endswith("}"):
+                    captured[expected[1:-1]] = actual
+                elif expected != actual:
+                    ok = False
+                    break
+            if ok:
+                return handler, captured
+        return None
+
+    def request(self, method: str, path: str, *, params: dict[str, Any] | None = None, json_body: Any = None) -> Any:
+        found = self._match(method, path)
+        if found is None:
+            raise LocalUnsupported(f"'{method.upper()} {path}'")
+        handler, captured = found
+        return handler(params=params or {}, body=json_body, **captured)
+
+    def stream_sse(self, path: str, *, params: dict[str, Any] | None = None) -> Iterator[tuple[str, str]]:
+        raise LocalUnsupported("Log streaming")
+
+    def _load(self) -> dict[str, Any]:
+        return dict(self._cfg_base.load_config() or {})
+
+    def _health(self, **_: Any) -> dict[str, Any]:
+        out: dict[str, Any] = {"ok": True, "mode": "local", "config_dir": str(self._cfg_base.CONFIG)}
+        try:
+            from cw_platform.local_db.diagnostics import diagnostics
+
+            out["database"] = diagnostics(self._cfg_base.CONFIG)
+        except Exception as exc:
+            out["database"] = {"ok": False, "error": str(exc)}
+        return out
+
+    def _version(self, **_: Any) -> dict[str, Any]:
+        version = ""
+        for candidate in (REPO_ROOT / "VERSION", Path("/app/VERSION")):
+            try:
+                version = candidate.read_text(encoding="utf-8").strip()
+            except Exception:
+                continue
+            if version:
+                break
+        return {"ok": True, "current": version or os.getenv("APP_VERSION") or "unknown"}
+
+    def _status(self, **_: Any) -> dict[str, Any]:
+        cfg = self._load()
+        pairs = [p for p in (cfg.get("pairs") or []) if isinstance(p, dict)]
+        enabled = [p for p in pairs if p.get("enabled", True) is not False]
+        scheduling = as_dict(cfg.get("scheduling"))
+        return {
+            "ok": True,
+            "mode": "local",
+            "degraded": True,
+            "pairs_total": len(pairs),
+            "pairs_enabled": len(enabled),
+            "can_sync": bool(enabled),
+            "scheduling_enabled": bool(scheduling.get("enabled")),
+            "providers": sorted(
+                {
+                    str(p.get(side) or "").upper()
+                    for p in pairs
+                    for side in ("source", "target")
+                    if str(p.get(side) or "").strip()
+                }
+            ),
+        }
+
+    def _config_get(self, **_: Any) -> dict[str, Any]:
+        cfg = self._load()
+        try:
+            return self._cfg_base.redact_config(cfg)
+        except Exception:
+            return cfg
+
+    def _config_post(self, *, body: Any = None, **_: Any) -> dict[str, Any]:
+        incoming = as_dict(body)
+        current = self._load()
+        merge: Any = getattr(self._cfg_base, "_deep_merge", None)
+        merged: dict[str, Any] = {**current, **incoming} if merge is None else merge(current, incoming)
+        self._cfg_base.save_config(merged)
+        return {"ok": True}
+
+    def _config_unset(self, *, body: Any = None, **_: Any) -> dict[str, Any]:
+        from api.configAPI import PROTECTED_CONFIG_ROOTS, _delete_config_path, _split_config_path
+
+        payload = as_dict(body)
+        raw_paths = payload.get("paths")
+        if not isinstance(raw_paths, list):
+            raw_paths = [payload.get("path")] if payload.get("path") else []
+        requested = [str(p or "").strip() for p in raw_paths if str(p or "").strip()]
+        if not requested:
+            return {"ok": False, "error": "no_paths"}
+
+        cfg = self._load()
+        removed: list[str] = []
+        missing: list[str] = []
+        for raw in requested:
+            parts = _split_config_path(raw)
+            if not parts:
+                missing.append(raw)
+                continue
+            if parts[0] in PROTECTED_CONFIG_ROOTS:
+                return {"ok": False, "error": "protected_path", "path": raw}
+            if _delete_config_path(cfg, parts):
+                removed.append(raw)
+            else:
+                missing.append(raw)
+        if not removed:
+            return {"ok": False, "error": "not_found", "missing": missing}
+        self._cfg_base.save_config(cfg)
+        return {"ok": True, "removed": removed, "missing": missing}
+
+    def _pairs_get(self, **_: Any) -> list[dict[str, Any]]:
+        cfg = self._load()
+        return [p for p in (cfg.get("pairs") or []) if isinstance(p, dict)]
+
+    def _pairs_put(self, *, pair_id: str, body: Any = None, **_: Any) -> dict[str, Any]:
+        patch = as_dict(body)
+        cfg = self._load()
+        pairs = [p for p in (cfg.get("pairs") or []) if isinstance(p, dict)]
+        for pair in pairs:
+            if str(pair.get("id") or "") == str(pair_id):
+                pair.update(patch)
+                cfg["pairs"] = pairs
+                self._cfg_base.save_config(cfg)
+                return {"ok": True}
+        return {"ok": False, "error": "not_found"}
+
+    def _pairs_delete(self, *, pair_id: str, **_: Any) -> dict[str, Any]:
+        cfg = self._load()
+        pairs = [p for p in (cfg.get("pairs") or []) if isinstance(p, dict)]
+        keep = [p for p in pairs if str(p.get("id") or "") != str(pair_id)]
+        if len(keep) == len(pairs):
+            return {"ok": False, "error": "not_found"}
+        cfg["pairs"] = keep
+        self._cfg_base.save_config(cfg)
+        return {"ok": True}
+
+    def _scheduling_get(self, **_: Any) -> dict[str, Any]:
+        cfg = self._load()
+        return as_dict(cfg.get("scheduling"))
+
+    def _next_run_at(self, scfg: dict[str, Any]) -> int:
+        try:
+            from datetime import datetime, timezone
+
+            from services.scheduling import compute_next_run
+
+            nxt = compute_next_run(datetime.now(timezone.utc), scfg)
+            return int(nxt.timestamp())
+        except Exception:
+            return 0
+
+    def _scheduling_status(self, **_: Any) -> dict[str, Any]:
+        scfg = self._scheduling_get()
+        return {
+            "ok": True,
+            "mode": "local",
+            "running": False,
+            "degraded": True,
+            "config": scfg,
+            "next_run_at": self._next_run_at(scfg) if scfg.get("enabled") else 0,
+        }
+
+    def _scheduling_next(self, **_: Any) -> dict[str, Any]:
+        scfg = self._scheduling_get()
+        return {"ok": True, "next_run_at": self._next_run_at(scfg), "config": scfg}
+
+    def _tokens_api(self) -> Any:
+        try:
+            from api import apiTokensAPI
+
+            return apiTokensAPI
+        except Exception as exc:
+            raise CLIError(f"API token support unavailable: {exc}") from exc
+
+    def _tokens_get(self, **_: Any) -> dict[str, Any]:
+        mod = self._tokens_api()
+        return {"ok": True, "tokens": mod.list_api_tokens(self._load())}
+
+    def _tokens_post(self, *, body: Any = None, **_: Any) -> dict[str, Any]:
+        mod = self._tokens_api()
+        payload = as_dict(body)
+        try:
+            expires_days = int(payload.get("expires_days") or 0)
+        except Exception:
+            expires_days = 0
+        raw, entry = mod.issue_api_token(
+            self._load(),
+            name=str(payload.get("name") or ""),
+            user_id=str(payload.get("user_id") or ""),
+            expires_days=expires_days,
+        )
+        return {"ok": True, "token": raw, "entry": entry}
+
+    def _tokens_delete(self, *, token_id: str, **_: Any) -> dict[str, Any]:
+        mod = self._tokens_api()
+        if not mod.revoke_api_token(token_id):
+            return {"ok": False, "error": "not_found"}
+        return {"ok": True, "revoked": token_id}
+
+
+LOCAL_CAPABLE_HINT = (
+    "Locally the CLI can serve status, config, pairs, scheduling and token commands. "
+    "Everything else needs the running service."
+)
+
+
+def now_ts() -> int:
+    return int(time.time())

--- a/cli/_render.py
+++ b/cli/_render.py
@@ -1,0 +1,218 @@
+# /cli/_render.py
+# CrossWatch - CLI output rendering
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Iterable, Sequence
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+from rich.theme import Theme
+
+CW_THEME = Theme(
+    {
+        "cw.accent": "bold #b026ff",
+        "cw.key": "dim",
+        "cw.ok": "bold green",
+        "cw.warn": "bold yellow",
+        "cw.err": "bold red",
+        "cw.muted": "dim",
+        "cw.on": "green",
+        "cw.off": "red",
+    }
+)
+
+MODES = ("auto", "table", "json", "yaml", "plain")
+
+
+class Output:
+    def __init__(self, mode: str = "auto", *, color: bool = True, quiet: bool = False) -> None:
+        self.mode = mode if mode in MODES else "auto"
+        self.quiet = bool(quiet)
+        force = None if color else False
+        self.console = Console(theme=CW_THEME, no_color=not color, force_terminal=force, soft_wrap=False)
+        self.err_console = Console(theme=CW_THEME, no_color=not color, stderr=True)
+
+    @property
+    def json_mode(self) -> bool:
+        return self.mode in ("json", "yaml")
+
+    @property
+    def plain(self) -> bool:
+        return self.mode == "plain"
+
+    def data(self, payload: Any) -> None:
+        if self.mode == "yaml":
+            sys.stdout.write(_to_yaml(payload) + "\n")
+        else:
+            sys.stdout.write(json.dumps(payload, indent=2, default=str) + "\n")
+        sys.stdout.flush()
+
+    def print(self, *args: Any, **kwargs: Any) -> None:
+        if self.quiet or self.json_mode:
+            return
+        self.console.print(*args, **kwargs)
+
+    def rule(self, title: str) -> None:
+        if self.quiet or self.json_mode or self.plain:
+            return
+        self.console.rule(Text(title, style="cw.accent"))
+
+    def raw(self, text: str) -> None:
+        sys.stdout.write(str(text) + "\n")
+        sys.stdout.flush()
+
+    def success(self, message: str) -> None:
+        if self.quiet or self.json_mode:
+            return
+        self.console.print(f"[cw.ok]OK[/] {message}")
+
+    def info(self, message: str) -> None:
+        if self.quiet or self.json_mode:
+            return
+        self.console.print(f"[cw.muted]{message}[/]")
+
+    def warn(self, message: str) -> None:
+        if self.json_mode:
+            return
+        self.err_console.print(f"[cw.warn]![/] {message}")
+
+    def error(self, message: str, hint: str = "") -> None:
+        self.err_console.print(f"[cw.err]x[/] {message}")
+        if hint:
+            self.err_console.print(f"  [cw.muted]{hint}[/]")
+
+    def table(
+        self,
+        columns: Sequence[str],
+        rows: Iterable[Sequence[Any]],
+        *,
+        title: str = "",
+        empty: str = "Nothing to show",
+    ) -> None:
+        materialised = [list(r) for r in rows]
+        if self.plain:
+            for row in materialised:
+                self.raw("\t".join("" if c is None else str(c) for c in row))
+            return
+        if not materialised:
+            self.info(empty)
+            return
+        table = Table(
+            title=Text(title, style="cw.accent") if title else None,
+            title_justify="left",
+            header_style="cw.accent",
+            box=None,
+            pad_edge=False,
+            show_edge=False,
+            expand=False,
+        )
+        for name in columns:
+            table.add_column(str(name), overflow="fold")
+        for row in materialised:
+            table.add_row(*[_cell(c) for c in row])
+        self.console.print(table)
+
+    def records(
+        self,
+        items: Sequence[Any],
+        columns: Sequence[tuple[str, Any]],
+        *,
+        title: str = "",
+        empty: str = "Nothing to show",
+    ) -> None:
+        rows = []
+        for item in items:
+            source = item if isinstance(item, dict) else {}
+            row = []
+            for _, key in columns:
+                row.append(key(source) if callable(key) else source.get(key))
+            rows.append(row)
+        self.table([head for head, _ in columns], rows, title=title, empty=empty)
+
+    def kv(self, pairs: Sequence[tuple[str, Any]], *, title: str = "") -> None:
+        if self.plain:
+            for key, value in pairs:
+                self.raw(f"{key}\t{_plain(value)}")
+            return
+        table = Table(box=None, show_header=False, pad_edge=False, show_edge=False)
+        table.add_column(style="cw.key", no_wrap=True)
+        table.add_column(overflow="fold")
+        for key, value in pairs:
+            table.add_row(str(key), _cell(value))
+        if title:
+            self.console.print(Panel(table, title=Text(title, style="cw.accent"), title_align="left", border_style="cw.muted"))
+        else:
+            self.console.print(table)
+
+
+def _plain(value: Any) -> str:
+    if isinstance(value, Text):
+        return value.plain
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _cell(value: Any) -> Any:
+    if isinstance(value, Text):
+        return value
+    if isinstance(value, bool):
+        return Text("yes" if value else "no", style="cw.on" if value else "cw.off")
+    if value is None:
+        return Text("-", style="cw.muted")
+    if isinstance(value, (list, tuple)):
+        return ", ".join(str(v) for v in value) or Text("-", style="cw.muted")
+    text = str(value)
+    return text if text else Text("-", style="cw.muted")
+
+
+def state_text(value: Any, *, on: str = "on", off: str = "off") -> Text:
+    flag = bool(value)
+    return Text(on if flag else off, style="cw.on" if flag else "cw.off")
+
+
+def _to_yaml(payload: Any, indent: int = 0) -> str:
+    pad = "  " * indent
+    if isinstance(payload, dict):
+        if not payload:
+            return pad + "{}"
+        lines = []
+        for key, value in payload.items():
+            if isinstance(value, (dict, list)) and value:
+                lines.append(f"{pad}{key}:")
+                lines.append(_to_yaml(value, indent + 1))
+            else:
+                lines.append(f"{pad}{key}: {_yaml_scalar(value)}")
+        return "\n".join(lines)
+    if isinstance(payload, list):
+        if not payload:
+            return pad + "[]"
+        lines = []
+        for item in payload:
+            if isinstance(item, (dict, list)) and item:
+                rendered = _to_yaml(item, indent + 1).lstrip()
+                lines.append(f"{pad}- {rendered}")
+            else:
+                lines.append(f"{pad}- {_yaml_scalar(item)}")
+        return "\n".join(lines)
+    return pad + _yaml_scalar(payload)
+
+
+def _yaml_scalar(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    text = str(value)
+    if text == "" or any(ch in text for ch in ":#\n\"'") or text.strip() != text:
+        return json.dumps(text)
+    return text

--- a/cli/_settings.py
+++ b/cli/_settings.py
@@ -1,0 +1,124 @@
+# /cli/_settings.py
+# CrossWatch - CLI endpoint and token resolution
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+from ._util import as_dict
+
+DEFAULT_PORT = 8787
+DEFAULT_HOST = "127.0.0.1"
+
+
+def cli_home() -> Path:
+    raw = os.getenv("CW_CLI_HOME") or ""
+    if raw.strip():
+        return Path(raw.strip()).expanduser()
+    runtime = os.getenv("RUNTIME_DIR") or ""
+    if runtime.strip():
+        return Path(runtime.strip()).expanduser() / ".cw_cli"
+    config = Path("/config")
+    if config.is_dir():
+        return config / ".cw_cli"
+    return Path.home() / ".crosswatch"
+
+
+def settings_path() -> Path:
+    return cli_home() / "cli.json"
+
+
+def load_settings() -> dict[str, Any]:
+    path = settings_path()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return as_dict(raw)
+
+
+def save_settings(data: dict[str, Any]) -> Path:
+    path = settings_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    try:
+        path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    except Exception:
+        pass
+    return path
+
+
+def update_settings(**changes: Any) -> dict[str, Any]:
+    data = load_settings()
+    for key, value in changes.items():
+        if value is None:
+            data.pop(key, None)
+        else:
+            data[key] = value
+    save_settings(data)
+    return data
+
+
+def config_dir() -> Path:
+    raw = os.getenv("CONFIG_BASE") or os.getenv("RUNTIME_DIR") or ""
+    if raw.strip():
+        return Path(raw.strip()).expanduser()
+    docker = Path("/config")
+    if docker.is_dir():
+        return docker
+    return Path(__file__).resolve().parent.parent
+
+
+def _config_snapshot() -> dict[str, Any]:
+    try:
+        raw = json.loads((config_dir() / "config.json").read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return as_dict(raw)
+
+
+def discover_base_url() -> str:
+    cfg = _config_snapshot()
+    ui = as_dict(cfg.get("ui"))
+    protocol = str(ui.get("protocol") or "http").strip().lower()
+    if protocol not in ("http", "https"):
+        protocol = "http"
+    try:
+        port = int(os.getenv("WEB_PORT") or DEFAULT_PORT)
+    except Exception:
+        port = DEFAULT_PORT
+    return f"{protocol}://{DEFAULT_HOST}:{port}"
+
+
+def normalize_url(raw: str) -> str:
+    url = str(raw or "").strip().rstrip("/")
+    if not url:
+        return ""
+    if "://" not in url:
+        url = "http://" + url
+    return url
+
+
+def resolve_url(explicit: str = "") -> str:
+    if explicit.strip():
+        return normalize_url(explicit)
+    env = os.getenv("CW_URL") or os.getenv("CROSSWATCH_URL") or ""
+    if env.strip():
+        return normalize_url(env)
+    stored = str(load_settings().get("url") or "")
+    if stored.strip():
+        return normalize_url(stored)
+    return discover_base_url()
+
+
+def resolve_token(explicit: str = "") -> str:
+    if explicit.strip():
+        return explicit.strip()
+    env = os.getenv("CW_TOKEN") or os.getenv("CROSSWATCH_TOKEN") or ""
+    if env.strip():
+        return env.strip()
+    return str(load_settings().get("token") or "").strip()

--- a/cli/_transport.py
+++ b/cli/_transport.py
@@ -1,0 +1,178 @@
+# /cli/_transport.py
+# CrossWatch - CLI HTTP transport, including log streaming
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+from typing import Any, Iterator
+
+from ._errors import ApiError, CLIError, TransportUnavailable
+
+JSON_CT = "application/json"
+
+
+class Transport:
+    name = "transport"
+
+    def request(self, method: str, path: str, *, params: dict[str, Any] | None = None, json_body: Any = None) -> Any:
+        raise NotImplementedError
+
+    def get(self, path: str, **kwargs: Any) -> Any:
+        return self.request("GET", path, **kwargs)
+
+    def post(self, path: str, **kwargs: Any) -> Any:
+        return self.request("POST", path, **kwargs)
+
+    def put(self, path: str, **kwargs: Any) -> Any:
+        return self.request("PUT", path, **kwargs)
+
+    def delete(self, path: str, **kwargs: Any) -> Any:
+        return self.request("DELETE", path, **kwargs)
+
+    def stream_sse(self, path: str, *, params: dict[str, Any] | None = None) -> Iterator[tuple[str, str]]:
+        raise NotImplementedError
+
+    def close(self) -> None:
+        return None
+
+
+class HttpTransport(Transport):
+    name = "http"
+
+    def __init__(self, base_url: str, *, token: str = "", timeout: float = 30.0, insecure: bool = False) -> None:
+        try:
+            import requests
+        except ImportError as exc:
+            raise CLIError("The 'requests' package is required for the CrossWatch CLI") from exc
+        self._requests = requests
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.timeout = float(timeout)
+        self.insecure = bool(insecure)
+        self.session = requests.Session()
+        self.session.headers.update({"Accept": JSON_CT, "User-Agent": "crosswatch-cli"})
+        if token:
+            self.session.headers["X-CW-Token"] = token
+        if insecure:
+            try:
+                import urllib3
+
+                urllib3.disable_warnings()
+            except Exception:
+                pass
+
+    def _url(self, path: str) -> str:
+        return self.base_url + ("/" + path.lstrip("/"))
+
+    def _unreachable(self, exc: Exception) -> TransportUnavailable:
+        return TransportUnavailable(
+            f"Cannot reach CrossWatch at {self.base_url}",
+            hint=f"Is the service running? ({type(exc).__name__})",
+        )
+
+    def request(self, method: str, path: str, *, params: dict[str, Any] | None = None, json_body: Any = None) -> Any:
+        try:
+            resp = self.session.request(
+                method.upper(),
+                self._url(path),
+                params=params or None,
+                json=json_body,
+                timeout=self.timeout,
+                verify=not self.insecure,
+                allow_redirects=False,
+            )
+        except self._requests.exceptions.SSLError as exc:
+            raise TransportUnavailable(
+                f"TLS handshake failed for {self.base_url}",
+                hint="CrossWatch is probably using a self-signed certificate. Retry with --insecure.",
+            ) from exc
+        except self._requests.exceptions.Timeout as exc:
+            raise TransportUnavailable(f"Timed out after {self.timeout:g}s talking to {self.base_url}") from exc
+        except self._requests.exceptions.RequestException as exc:
+            raise self._unreachable(exc) from exc
+
+        if resp.status_code in (301, 302, 303, 307, 308):
+            location = str(resp.headers.get("location") or "")
+            if "/login" in location:
+                raise ApiError(401, {"error": "Authentication required"}, method=method.upper(), path=path)
+
+        payload: Any
+        text = resp.text or ""
+        ctype = str(resp.headers.get("content-type") or "")
+        if JSON_CT in ctype:
+            try:
+                payload = resp.json()
+            except Exception:
+                payload = text
+        else:
+            payload = text
+
+        if resp.status_code >= 400:
+            raise ApiError(resp.status_code, payload, method=method.upper(), path=path)
+        return payload
+
+    def stream_sse(self, path: str, *, params: dict[str, Any] | None = None) -> Iterator[tuple[str, str]]:
+        try:
+            resp = self.session.get(
+                self._url(path),
+                params=params or None,
+                stream=True,
+                timeout=(self.timeout, None),
+                verify=not self.insecure,
+                headers={"Accept": "text/event-stream"},
+            )
+        except self._requests.exceptions.RequestException as exc:
+            raise self._unreachable(exc) from exc
+
+        if resp.status_code >= 400:
+            body: Any
+            try:
+                body = resp.json()
+            except Exception:
+                body = resp.text
+            raise ApiError(resp.status_code, body, method="GET", path=path)
+
+        event = "message"
+        data: list[str] = []
+        try:
+            for raw in resp.iter_lines(decode_unicode=True):
+                if raw is None:
+                    continue
+                line = str(raw)
+                if line == "":
+                    if data:
+                        yield event, "\n".join(data)
+                    event = "message"
+                    data = []
+                    continue
+                if line.startswith(":"):
+                    continue
+                if line.startswith("event:"):
+                    event = line[6:].strip() or "message"
+                elif line.startswith("data:"):
+                    data.append(line[5:].lstrip())
+        finally:
+            try:
+                resp.close()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        try:
+            self.session.close()
+        except Exception:
+            pass
+
+
+def probe(transport: HttpTransport) -> bool:
+    try:
+        transport.request("GET", "/api/health")
+        return True
+    except TransportUnavailable:
+        return False
+    except ApiError:
+        return True
+
+
+def dumps(value: Any) -> str:
+    return json.dumps(value, indent=2, sort_keys=False, default=str)

--- a/cli/_util.py
+++ b/cli/_util.py
@@ -1,0 +1,249 @@
+# /cli/_util.py
+# CrossWatch - CLI helpers for config paths, values and formatting
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from ._errors import CLIError, EXIT_USAGE
+
+_INDEX_RE = re.compile(r"^\[(\d+)\]$")
+TRUE_WORDS = {"1", "true", "yes", "on", "enable", "enabled"}
+FALSE_WORDS = {"0", "false", "no", "off", "disable", "disabled"}
+
+
+def as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def error_text(payload: Any, default: str = "Rejected") -> str:
+    block = payload if isinstance(payload, dict) else {}
+    for key in ("message", "detail", "error", "status"):
+        value = block.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    if block.get("found") is False:
+        return "not found"
+    return default
+
+
+def split_path(path: str) -> list[str]:
+    raw = str(path or "").strip()
+    if not raw:
+        raise CLIError("A config path is required, for example sync.anime.enabled", exit_code=EXIT_USAGE)
+    parts: list[str] = []
+    for chunk in raw.replace("/", ".").split("."):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        match = re.fullmatch(r"([^\[\]]*)((?:\[\d+\])*)", chunk)
+        if match is None:
+            parts.append(chunk)
+            continue
+        head, indexes = match.group(1), match.group(2)
+        if head:
+            parts.append(head)
+        for pos in re.findall(r"\[(\d+)\]", indexes):
+            parts.append(f"[{pos}]")
+    if not parts:
+        raise CLIError(f"Cannot parse config path '{raw}'", exit_code=EXIT_USAGE)
+    return parts
+
+
+def dotted_get(data: Any, path: str, default: Any = None) -> Any:
+    node = data
+    for part in split_path(path):
+        index = _INDEX_RE.match(part)
+        if index is not None:
+            if not isinstance(node, list):
+                return default
+            pos = int(index.group(1))
+            if pos >= len(node):
+                return default
+            node = node[pos]
+            continue
+        if not isinstance(node, dict) or part not in node:
+            return default
+        node = node[part]
+    return node
+
+
+def dotted_payload(path: str, value: Any) -> dict[str, Any]:
+    parts = split_path(path)
+    if any(_INDEX_RE.match(p) for p in parts):
+        raise CLIError("List indexes cannot be set directly; set the whole list with --json", exit_code=EXIT_USAGE)
+    out: dict[str, Any] = {}
+    node = out
+    for part in parts[:-1]:
+        nxt: dict[str, Any] = {}
+        node[part] = nxt
+        node = nxt
+    node[parts[-1]] = value
+    return out
+
+
+def dotted_delete(data: dict[str, Any], path: str) -> bool:
+    parts = split_path(path)
+    node: Any = data
+    for part in parts[:-1]:
+        if not isinstance(node, dict) or part not in node:
+            return False
+        node = node[part]
+    if not isinstance(node, dict) or parts[-1] not in node:
+        return False
+    node.pop(parts[-1], None)
+    return True
+
+
+def parse_value(raw: str, *, as_json: bool = False) -> Any:
+    text = "" if raw is None else str(raw)
+    if as_json:
+        try:
+            return json.loads(text)
+        except Exception as exc:
+            raise CLIError(f"Not valid JSON: {text}", exit_code=EXIT_USAGE) from exc
+    low = text.strip().lower()
+    if low in TRUE_WORDS:
+        return True
+    if low in FALSE_WORDS:
+        return False
+    if low in ("null", "none", "~"):
+        return None
+    stripped = text.strip()
+    if re.fullmatch(r"[+-]?\d+", stripped):
+        try:
+            return int(stripped)
+        except Exception:
+            return stripped
+    if re.fullmatch(r"[+-]?\d*\.\d+", stripped):
+        try:
+            return float(stripped)
+        except Exception:
+            return stripped
+    return text
+
+
+def coerce_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    return str(value).strip().lower() in TRUE_WORDS
+
+
+def fmt_ts(value: Any, *, empty: str = "-") -> str:
+    try:
+        epoch = int(float(value or 0))
+    except Exception:
+        return empty
+    if epoch <= 0:
+        return empty
+    if epoch > 1_000_000_000_000:
+        epoch = epoch // 1000
+    try:
+        return datetime.fromtimestamp(epoch, tz=timezone.utc).astimezone().strftime("%Y-%m-%d %H:%M:%S")
+    except Exception:
+        return empty
+
+
+def fmt_rel(value: Any, *, empty: str = "-") -> str:
+    try:
+        epoch = int(float(value or 0))
+    except Exception:
+        return empty
+    if epoch <= 0:
+        return empty
+    if epoch > 1_000_000_000_000:
+        epoch = epoch // 1000
+    delta = int(epoch - datetime.now(tz=timezone.utc).timestamp())
+    ahead = delta >= 0
+    delta = abs(delta)
+    text = fmt_duration(delta)
+    return f"in {text}" if ahead else f"{text} ago"
+
+
+def fmt_duration(seconds: Any) -> str:
+    try:
+        total = int(float(seconds or 0))
+    except Exception:
+        return "-"
+    if total < 0:
+        total = 0
+    if total < 60:
+        return f"{total}s"
+    minutes, sec = divmod(total, 60)
+    if minutes < 60:
+        return f"{minutes}m {sec}s" if sec else f"{minutes}m"
+    hours, minutes = divmod(minutes, 60)
+    if hours < 24:
+        return f"{hours}h {minutes}m" if minutes else f"{hours}h"
+    days, hours = divmod(hours, 24)
+    return f"{days}d {hours}h" if hours else f"{days}d"
+
+
+def parse_iso(value: Any) -> int:
+    text = str(value or "").strip()
+    if not text:
+        return 0
+    try:
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        return int(datetime.fromisoformat(text).timestamp())
+    except Exception:
+        return 0
+
+
+def pair_label(pair: dict[str, Any]) -> str:
+    source = str(pair.get("source") or "?").upper()
+    target = str(pair.get("target") or "?").upper()
+    mode = str(pair.get("mode") or "one-way").strip().lower()
+    arrow = "<->" if mode in ("two-way", "both", "bidirectional") else "->"
+    return f"{source} {arrow} {target}"
+
+
+def pair_features(pair: dict[str, Any]) -> list[str]:
+    features = pair.get("features")
+    if not isinstance(features, dict):
+        return []
+    out: list[str] = []
+    for name, block in features.items():
+        if isinstance(block, dict):
+            if coerce_bool(block.get("enable", block.get("enabled")), False):
+                out.append(str(name))
+        elif coerce_bool(block, False):
+            out.append(str(name))
+    return sorted(out)
+
+
+def find_pair(pairs: list[dict[str, Any]], needle: str) -> dict[str, Any]:
+    want = str(needle or "").strip()
+    if not want:
+        raise CLIError("A pair id is required", exit_code=EXIT_USAGE)
+    for pair in pairs:
+        if str(pair.get("id") or "") == want:
+            return pair
+    lowered = want.lower()
+    partial = [p for p in pairs if str(p.get("id") or "").lower().startswith(lowered)]
+    if len(partial) == 1:
+        return partial[0]
+    if len(partial) > 1:
+        ids = ", ".join(str(p.get("id")) for p in partial[:6])
+        raise CLIError(f"Pair id '{want}' is ambiguous", hint=f"Matches: {ids}", exit_code=EXIT_USAGE)
+    labelled = [p for p in pairs if pair_label(p).lower().replace(" ", "") == lowered.replace(" ", "")]
+    if len(labelled) == 1:
+        return labelled[0]
+    raise CLIError(f"No pair matches '{want}'", hint="Run 'cw pair list' to see the configured pairs.", exit_code=5)
+
+
+LOG_CONTROL_LINES = {"::CLEAR::"}
+
+
+def is_log_control(line: str) -> bool:
+    return str(line or "").strip() in LOG_CONTROL_LINES
+
+
+def strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;?]*[ -/]*[@-~]", "", str(text or ""))

--- a/cli/commands/__init__.py
+++ b/cli/commands/__init__.py
@@ -1,0 +1,4 @@
+# /cli/commands/__init__.py
+# CrossWatch - CLI command groups
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations

--- a/cli/commands/analyzer.py
+++ b/cli/commands/analyzer.py
@@ -1,0 +1,298 @@
+# /cli/commands/analyzer.py
+# CrossWatch - CLI analyzer commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import CLIError
+from .._util import as_dict, error_text
+
+analyzer_app = typer.Typer(help="Find items that are stuck or inconsistent between providers.", no_args_is_help=True)
+
+
+def _scope(pairs: str) -> dict[str, Any] | None:
+    return {"pairs": pairs.strip()} if pairs.strip() else None
+
+
+def _items(payload: Any, *keys: str) -> list[dict[str, Any]]:
+    block = as_dict(payload)
+    for key in keys:
+        found = block.get(key)
+        if isinstance(found, list):
+            return [as_dict(i) for i in found]
+    if isinstance(payload, list):
+        return [as_dict(i) for i in payload]
+    return []
+
+
+@analyzer_app.command("problems")
+def analyzer_problems(
+    ctx: typer.Context,
+    pairs: str = typer.Option("", "--pairs", "-p", help="Limit to these pair ids, comma separated."),
+    system: bool = typer.Option(False, "--system", help="Include system level problems."),
+    hints: bool = typer.Option(False, "--hints", help="Include hints."),
+    limit: int = typer.Option(50, "--limit", "-n", help="Maximum rows."),
+) -> None:
+    """List what the analyzer thinks is wrong."""
+    state: Ctx = ctx.obj
+    params: dict[str, Any] = {"include_system": system, "include_hints": hints}
+    if pairs.strip():
+        params["pairs"] = pairs.strip()
+    payload = state.get("/api/analyzer/problems", params=params)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _items(payload, "problems", "items")
+    state.out.records(
+        rows[: max(1, limit)],
+        [
+            ("SEVERITY", lambda r: str(r.get("severity") or r.get("level") or "-")),
+            ("CODE", lambda r: str(r.get("code") or r.get("id") or "-")),
+            ("PROVIDER", lambda r: str(r.get("provider") or "-")),
+            ("FEATURE", lambda r: str(r.get("feature") or "-")),
+            ("WHAT", lambda r: str(r.get("message") or r.get("title") or r.get("text") or "-")[:60]),
+        ],
+        title=f"Problems ({len(rows)})",
+        empty="Nothing flagged.",
+    )
+
+
+@analyzer_app.command("state")
+def analyzer_state(
+    ctx: typer.Context,
+    pairs: str = typer.Option("", "--pairs", "-p", help="Limit to these pair ids, comma separated."),
+    limit: int = typer.Option(50, "--limit", "-n", help="Maximum rows."),
+    offset: int = typer.Option(0, "--offset", help="Skip this many rows."),
+) -> None:
+    """Show the analyzer view of stored state."""
+    state: Ctx = ctx.obj
+    params: dict[str, Any] = {"limit": limit, "offset": offset}
+    if pairs.strip():
+        params["pairs"] = pairs.strip()
+    payload = state.get("/api/analyzer/state", params=params)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _items(payload, "items", "rows", "state")
+    state.out.records(
+        rows,
+        [
+            ("KEY", lambda r: str(r.get("key") or r.get("item_key") or "-")[:34]),
+            ("TITLE", lambda r: str(r.get("title") or "-")[:40]),
+            ("TYPE", lambda r: str(r.get("type") or "-")),
+            ("PROVIDER", lambda r: str(r.get("provider") or "-")),
+            ("FEATURE", lambda r: str(r.get("feature") or "-")),
+        ],
+        title="Analyzer state",
+        empty="No state rows.",
+    )
+
+
+@analyzer_app.command("attention")
+def analyzer_attention(
+    ctx: typer.Context,
+    pairs: str = typer.Option("", "--pairs", "-p", help="Limit to these pair ids, comma separated."),
+) -> None:
+    """Show the system view: current mismatches, pending retries and blocked items."""
+    state: Ctx = ctx.obj
+    payload = as_dict(state.get("/api/analyzer/system", params=_scope(pairs)))
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    attention = as_dict(payload.get("attention"))
+    counts = attention or payload
+    state.out.kv(
+        [
+            ("Current mismatches", str(counts.get("current") or counts.get("mismatches") or 0)),
+            ("Pending retries", str(counts.get("pending") or counts.get("retries") or 0)),
+            ("Blocked", str(counts.get("blocked") or 0)),
+            ("Flagged total", str(counts.get("total") or counts.get("flagged") or 0)),
+        ],
+        title="Needs attention",
+    )
+    rows = _items(attention or payload, "items", "rows")
+    if rows:
+        state.out.print()
+        state.out.records(
+            rows[:50],
+            [
+                ("TITLE", lambda r: str(r.get("title") or r.get("key") or "-")[:44]),
+                ("PROVIDER", lambda r: str(r.get("provider") or "-")),
+                ("FEATURE", lambda r: str(r.get("feature") or "-")),
+                ("WHY", lambda r: str(r.get("reason") or r.get("state") or "-")[:36]),
+            ],
+            title="Flagged items",
+        )
+
+
+@analyzer_app.command("ratings")
+def analyzer_ratings(
+    ctx: typer.Context,
+    pairs: str = typer.Option("", "--pairs", "-p", help="Limit to these pair ids, comma separated."),
+    limit: int = typer.Option(50, "--limit", "-n", help="Maximum rows."),
+) -> None:
+    """Audit ratings for disagreement between providers."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/analyzer/ratings-audit", params=_scope(pairs))
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _items(payload, "items", "rows", "audit")
+    state.out.records(
+        rows[: max(1, limit)],
+        [
+            ("TITLE", lambda r: str(r.get("title") or r.get("key") or "-")[:44]),
+            ("TYPE", lambda r: str(r.get("type") or "-")),
+            ("RATINGS", lambda r: str(r.get("ratings") or r.get("values") or "-")[:40]),
+            ("WHY", lambda r: str(r.get("reason") or r.get("status") or "-")[:30]),
+        ],
+        title="Ratings audit",
+        empty="Ratings agree everywhere.",
+    )
+
+
+@analyzer_app.command("tracker")
+def analyzer_tracker(
+    ctx: typer.Context,
+    pairs: str = typer.Option("", "--pairs", "-p", help="Limit to these pair ids, comma separated."),
+) -> None:
+    """Show the CrossWatch tracker state the analyzer sees."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/analyzer/cw-state", params=_scope(pairs))
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    import json as _json
+
+    from rich.syntax import Syntax
+
+    state.out.console.print(
+        Syntax(_json.dumps(payload, indent=2, default=str), "json", theme="ansi_dark", background_color="default")
+    )
+
+
+@analyzer_app.command("activity")
+def analyzer_activity(ctx: typer.Context) -> None:
+    """Show per pair analyzer activity."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/analyzer/pair-activity")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _items(payload, "pairs", "items")
+    state.out.records(
+        rows,
+        [
+            ("PAIR", lambda r: str(r.get("pair") or r.get("id") or "-")),
+            ("LAST RUN", lambda r: str(r.get("last_run") or r.get("updated_at") or "-")),
+            ("FLAGGED", lambda r: str(r.get("flagged") or r.get("count") or 0)),
+        ],
+        title="Pair activity",
+        empty="No analyzer activity yet.",
+    )
+
+
+@analyzer_app.command("detail")
+def analyzer_detail(
+    ctx: typer.Context,
+    provider: str = typer.Argument(..., help="Provider name."),
+    feature: str = typer.Argument(..., help="Feature, for example watchlist."),
+    key: str = typer.Argument(..., help="Item key."),
+    pairs: str = typer.Option("", "--pairs", "-p", help="Limit to these pair ids, comma separated."),
+) -> None:
+    """Show everything the analyzer knows about one item."""
+    state: Ctx = ctx.obj
+    params: dict[str, Any] = {"provider": provider, "feature": feature, "key": key}
+    if pairs.strip():
+        params["pairs"] = pairs.strip()
+    payload = state.get("/api/analyzer/detail", params=params)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    import json as _json
+
+    from rich.syntax import Syntax
+
+    state.out.console.print(
+        Syntax(_json.dumps(payload, indent=2, default=str), "json", theme="ansi_dark", background_color="default")
+    )
+
+
+@analyzer_app.command("fix")
+def analyzer_fix(
+    ctx: typer.Context,
+    provider: str = typer.Argument(..., help="Provider name."),
+    feature: str = typer.Argument(..., help="Feature, for example watchlist."),
+    key: str = typer.Argument(..., help="Item key."),
+    pairs: str = typer.Option("", "--pairs", "-p", help="Limit to these pair ids, comma separated."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Apply the suggested fix for one item."""
+    state: Ctx = ctx.obj
+    state.require_service("Applying an analyzer fix")
+    if not yes and not typer.confirm(f"Apply the analyzer fix to {key}?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    body = {"provider": provider, "feature": feature, "key": key}
+    result = as_dict(state.post("/api/analyzer/fix", params=_scope(pairs), json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Fix rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success(f"Fix applied to {key}")
+
+
+@analyzer_app.command("suggest")
+def analyzer_suggest(
+    ctx: typer.Context,
+    provider: str = typer.Argument(..., help="Provider name."),
+    feature: str = typer.Argument(..., help="Feature, for example watchlist."),
+    key: str = typer.Argument(..., help="Item key."),
+    pairs: str = typer.Option("", "--pairs", "-p", help="Limit to these pair ids, comma separated."),
+) -> None:
+    """Ask what the analyzer would do, without doing it."""
+    state: Ctx = ctx.obj
+    body = {"provider": provider, "feature": feature, "key": key}
+    payload = state.post("/api/analyzer/suggest", params=_scope(pairs), json_body=body)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    import json as _json
+
+    from rich.syntax import Syntax
+
+    state.out.console.print(
+        Syntax(_json.dumps(payload, indent=2, default=str), "json", theme="ansi_dark", background_color="default")
+    )
+
+
+@analyzer_app.command("drop")
+def analyzer_drop(
+    ctx: typer.Context,
+    provider: str = typer.Argument(..., help="Provider name."),
+    feature: str = typer.Argument(..., help="Feature, for example watchlist."),
+    key: str = typer.Argument(..., help="Item key."),
+    pairs: str = typer.Option("", "--pairs", "-p", help="Limit to these pair ids, comma separated."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Remove an item from the analyzer state."""
+    state: Ctx = ctx.obj
+    state.require_service("Dropping an analyzer item")
+    if not yes and not typer.confirm(f"Drop {key} from the analyzer state?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    body = {"provider": provider, "feature": feature, "key": key}
+    result = as_dict(state.delete("/api/analyzer/item", params=_scope(pairs), json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Drop rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success(f"Dropped {key}")
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(analyzer_app, name="analyzer")

--- a/cli/commands/anime.py
+++ b/cli/commands/anime.py
@@ -1,0 +1,202 @@
+# /cli/commands/anime.py
+# CrossWatch - CLI anime mapping commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import EXIT_USAGE, CLIError
+from .._util import as_dict, error_text, fmt_ts
+
+anime_app = typer.Typer(help="Anime id mapping and custom overrides.", no_args_is_help=True)
+
+
+def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
+    block = as_dict(payload)
+    for key in keys:
+        found = block.get(key)
+        if isinstance(found, list):
+            return [as_dict(i) for i in found]
+    if isinstance(payload, list):
+        return [as_dict(i) for i in payload]
+    return []
+
+
+@anime_app.command("status")
+def anime_status(ctx: typer.Context) -> None:
+    """Show the mapping index state."""
+    state: Ctx = ctx.obj
+    payload = as_dict(state.get("/api/anime-mapping/status"))
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    state.out.kv(
+        [
+            ("Status", str(payload.get("status") or "-")),
+            ("Schema", str(payload.get("schema_version") or payload.get("expected_schema_version") or "-")),
+            ("Sources", f"{int(payload.get('source_count') or 0):,}"),
+            ("Edges", f"{int(payload.get('edge_count') or 0):,}"),
+            ("Updated", fmt_ts(payload.get("updated_at") or payload.get("built_at"))),
+            ("Enabled", str(payload.get("enabled"))),
+        ],
+        title="Anime mapping",
+    )
+    if payload.get("message"):
+        state.out.info(str(payload.get("message")))
+
+
+@anime_app.command("update")
+def anime_update(
+    ctx: typer.Context,
+    rebuild: bool = typer.Option(False, "--rebuild", help="Rebuild the index instead of fetching an update."),
+) -> None:
+    """Fetch new mapping data, or rebuild the index."""
+    state: Ctx = ctx.obj
+    state.require_service("Updating the anime mapping")
+    path = "/api/anime-mapping/rebuild-index" if rebuild else "/api/anime-mapping/update"
+    result = as_dict(state.post(path))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Update rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success("Index rebuilt." if rebuild else "Mapping updated.")
+    for key in ("source_count", "edge_count", "status"):
+        if key in result:
+            state.out.info(f"{key}: {result.get(key)}")
+
+
+@anime_app.command("overrides")
+def anime_overrides(
+    ctx: typer.Context,
+    limit: int = typer.Option(50, "--limit", "-n", help="Maximum rows."),
+) -> None:
+    """List custom mapping overrides."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/anime-mapping/overrides")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "overrides", "rules", "items")
+    state.out.records(
+        rows[: max(1, limit)],
+        [
+            ("ID", lambda r: str(r.get("id") or r.get("rule_id") or "-")),
+            (
+                "MATCH",
+                lambda r: f"{r.get('match_provider') or '-'}:{r.get('match_id') or '-'}",
+            ),
+            (
+                "TARGET",
+                lambda r: f"{r.get('target_namespace') or '-'}:{r.get('target_id') or '-'}",
+            ),
+            ("TITLE", lambda r: str(r.get("title") or "-")[:28]),
+            ("NOTE", lambda r: str(r.get("note") or r.get("comment") or "-")[:24]),
+        ],
+        title=f"Overrides ({len(rows)})",
+        empty="No custom overrides.",
+    )
+
+
+@anime_app.command("add-override")
+def anime_add_override(
+    ctx: typer.Context,
+    field: list[str] = typer.Option(
+        [],
+        "--field",
+        "-F",
+        help="Rule field as key=value. Needs match_provider, match_id, target_namespace and target_id.",
+    ),
+) -> None:
+    """Add a custom mapping override."""
+    state: Ctx = ctx.obj
+    state.require_service("Adding an override")
+    body: dict[str, Any] = {}
+    for item in field:
+        key, sep, value = str(item).partition("=")
+        if not sep or not key.strip():
+            raise CLIError(f"--field expects key=value, got '{item}'", exit_code=EXIT_USAGE)
+        body[key.strip()] = value
+    if not body:
+        raise CLIError(
+            "An override needs at least one field",
+            hint="For example --field match_provider=tvdb --field match_id=81472 --field target_namespace=anidb --field target_id=4563",
+            exit_code=EXIT_USAGE,
+        )
+    result = as_dict(state.post("/api/anime-mapping/overrides", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Override rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success(f"Override added{': ' + str(result.get('id')) if result.get('id') else '.'}")
+
+
+@anime_app.command("delete-override")
+def anime_delete_override(
+    ctx: typer.Context,
+    rule_id: str = typer.Argument(..., help="Rule id from 'cw anime overrides'."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Delete a custom mapping override."""
+    state: Ctx = ctx.obj
+    state.require_service("Deleting an override")
+    if not yes and not typer.confirm(f"Delete override {rule_id}?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(state.delete(f"/api/anime-mapping/overrides/{rule_id}"))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Delete rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Deleted {rule_id}")
+
+
+@anime_app.command("export")
+def anime_export(ctx: typer.Context) -> None:
+    """Print the overrides as JSON."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/anime-mapping/overrides/export")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    import json as _json
+
+    state.out.raw(_json.dumps(payload, indent=2, default=str))
+
+
+@anime_app.command("search")
+def anime_search(
+    ctx: typer.Context,
+    query: str = typer.Argument(..., help="Title to look up on SIMKL."),
+    limit: int = typer.Option(25, "--limit", "-n", help="Maximum rows."),
+    instance: str = typer.Option("", "--instance", "-i", help="Provider instance id."),
+) -> None:
+    """Search SIMKL for an anime, to build a mapping."""
+    state: Ctx = ctx.obj
+    params: dict[str, Any] = {"q": query, "limit": limit}
+    if instance.strip():
+        params["instance"] = instance.strip()
+    payload = state.get("/api/anime-mapping/simkl/search", params=params)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "results", "items")
+    state.out.records(
+        rows,
+        [
+            ("TITLE", lambda r: str(r.get("title") or "-")[:44]),
+            ("YEAR", lambda r: str(r.get("year") or "-")),
+            ("TYPE", lambda r: str(r.get("type") or "-")),
+            ("IDS", lambda r: ", ".join(f"{k}:{v}" for k, v in as_dict(r.get("ids")).items())[:44]),
+        ],
+        title=f"SIMKL results for {query}",
+        empty="Nothing found.",
+    )
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(anime_app, name="anime")

--- a/cli/commands/auth.py
+++ b/cli/commands/auth.py
@@ -1,0 +1,651 @@
+# /cli/commands/auth.py
+# CrossWatch - CLI provider logins and API token management
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import EXIT_NOT_FOUND, EXIT_USAGE, CLIError
+from .._render import state_text
+from .._settings import settings_path, update_settings
+from .._util import as_dict, coerce_bool, error_text, fmt_rel, fmt_ts
+
+auth_app = typer.Typer(help="Connect providers and manage CLI API tokens.", no_args_is_help=True)
+token_app = typer.Typer(help="Create and revoke API tokens for the CLI.", no_args_is_help=True)
+
+
+@dataclass(frozen=True)
+class Endpoints:
+    submit: str = ""
+    submit_starts: bool = False
+    start: str = ""
+    poll: str = ""
+    finish: str = ""
+    cancel: str = ""
+    disconnect: str = ""
+    needs_origin: bool = False
+
+
+ENDPOINTS: dict[str, Endpoints] = {
+    "PLEX": Endpoints(start="/api/plex/pin/new", disconnect="/api/plex/token/delete"),
+    "TRAKT": Endpoints(
+        submit="/api/trakt/pin/new",
+        submit_starts=True,
+        start="/api/trakt/pin/new",
+        disconnect="/api/trakt/token/delete",
+    ),
+    "SIMKL": Endpoints(
+        start="/api/simkl/pin/start",
+        poll="/api/simkl/pin/poll",
+        cancel="/api/simkl/pin/cancel",
+        disconnect="/api/simkl/token/delete",
+    ),
+    "ANILIST": Endpoints(
+        submit="/api/anilist/save",
+        start="/api/anilist/authorize",
+        needs_origin=True,
+        disconnect="/api/anilist/token/delete",
+    ),
+    "MDBLIST": Endpoints(
+        submit="/api/mdblist/save",
+        start="/api/mdblist/device/start",
+        poll="/api/mdblist/device/poll",
+        disconnect="/api/mdblist/disconnect",
+    ),
+    "PUNCHPLAY": Endpoints(
+        start="/api/punchplay/device/start",
+        poll="/api/punchplay/device/poll",
+        cancel="/api/punchplay/device/cancel",
+        disconnect="/api/punchplay/disconnect",
+    ),
+    "BINGEBASE": Endpoints(
+        start="/api/bingebase/device/start",
+        poll="/api/bingebase/device/poll",
+        cancel="/api/bingebase/device/cancel",
+        disconnect="/api/bingebase/disconnect",
+    ),
+    "NUVIO": Endpoints(
+        start="/api/nuvio/device/start",
+        poll="/api/nuvio/device/poll",
+        finish="/api/nuvio/device/finish",
+        disconnect="/api/nuvio/disconnect",
+    ),
+    "JELLYFIN": Endpoints(submit="/api/jellyfin/login", disconnect="/api/jellyfin/token/delete"),
+    "EMBY": Endpoints(submit="/api/emby/login", disconnect="/api/emby/token/delete"),
+    "KODI": Endpoints(submit="/api/kodi/connect", disconnect="/api/kodi/disconnect"),
+    "STREMIO": Endpoints(submit="/api/stremio/connect", disconnect="/api/stremio/disconnect"),
+    "FLOPPY": Endpoints(submit="/api/floppy/save", disconnect="/api/floppy/disconnect"),
+    "SCROB": Endpoints(submit="/api/scrob/save", disconnect="/api/scrob/disconnect"),
+    "TAUTULLI": Endpoints(submit="/api/tautulli/save", disconnect="/api/tautulli/disconnect"),
+    "PUBLICMETADB": Endpoints(submit="/api/publicmetadb/save", disconnect="/api/publicmetadb/disconnect"),
+    "TMDB": Endpoints(submit="/api/tmdb_sync/save", disconnect="/api/tmdb_sync/disconnect"),
+    "CROSSWATCH": Endpoints(submit="/api/crosswatch/connect", disconnect="/api/crosswatch/disconnect"),
+}
+
+AUTHORIZED = {"authorized", "ok", "connected", "success", "complete", "done"}
+PENDING = {"pending", "waiting", "authorization_pending", "slow_down", "", "polling"}
+
+
+@dataclass
+class Manifest:
+    name: str
+    label: str
+    flow: str
+    notes: str = ""
+    verify_url: str = ""
+    fields: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def endpoints(self) -> Endpoints:
+        return ENDPOINTS.get(self.name, Endpoints())
+
+    @property
+    def supported(self) -> bool:
+        endpoints = self.endpoints
+        return bool(endpoints.submit or endpoints.start)
+
+
+def _manifests(state: Ctx) -> list[Manifest]:
+    payload = state.get("/api/auth/providers")
+    if not isinstance(payload, list):
+        raise CLIError("The provider manifest endpoint returned an unexpected payload")
+    out: list[Manifest] = []
+    for raw in payload:
+        block = as_dict(raw)
+        name = str(block.get("name") or "").strip().upper()
+        if not name:
+            continue
+        fields = [as_dict(f) for f in (block.get("fields") or []) if isinstance(f, dict)]
+        out.append(
+            Manifest(
+                name=name,
+                label=str(block.get("label") or name),
+                flow=str(block.get("flow") or ""),
+                notes=str(block.get("notes") or ""),
+                verify_url=str(block.get("verify_url") or ""),
+                fields=fields,
+            )
+        )
+    return sorted(out, key=lambda m: m.name)
+
+
+def _manifest(state: Ctx, provider: str) -> Manifest:
+    want = str(provider or "").strip().upper()
+    if not want:
+        raise CLIError("A provider name is required", exit_code=EXIT_USAGE)
+    catalogue = _manifests(state)
+    for item in catalogue:
+        if item.name == want:
+            return item
+    known = ", ".join(m.name.lower() for m in catalogue)
+    raise CLIError(f"Unknown provider '{provider}'", hint=f"Known providers: {known}", exit_code=EXIT_USAGE)
+
+
+def _public(manifest: Manifest) -> dict[str, Any]:
+    return {
+        "name": manifest.name,
+        "label": manifest.label,
+        "flow": manifest.flow,
+        "supported": manifest.supported,
+        "fields": manifest.fields,
+        "verify_url": manifest.verify_url,
+        "notes": manifest.notes,
+    }
+
+
+def _nest(pairs: dict[str, Any], *, drop_prefix: bool) -> dict[str, Any]:
+    body: dict[str, Any] = {}
+    for key, value in pairs.items():
+        parts = [p for p in str(key).split(".") if p]
+        if drop_prefix:
+            parts = parts[1:]
+        if not parts:
+            continue
+        node = body
+        for part in parts[:-1]:
+            nxt = node.get(part)
+            if not isinstance(nxt, dict):
+                nxt = {}
+                node[part] = nxt
+            node = nxt
+        node[parts[-1]] = value
+    return body
+
+
+def _collect_fields(manifest: Manifest, supplied: dict[str, str], *, interactive: bool) -> dict[str, Any]:
+    known = {str(f.get("key") or "").strip() for f in manifest.fields if f.get("key")}
+    known |= {key.split(".", 1)[-1] for key in known}
+    unknown = sorted(k for k in supplied if k not in known)
+    if unknown:
+        raise CLIError(
+            f"{manifest.label} has no field named: {', '.join(unknown)}",
+            hint=f"Known fields: {', '.join(sorted(str(f.get('key')) for f in manifest.fields)) or 'none'}",
+            exit_code=EXIT_USAGE,
+        )
+
+    values: dict[str, Any] = {}
+    leftover = dict(supplied)
+
+    for spec in manifest.fields:
+        key = str(spec.get("key") or "").strip()
+        if not key:
+            continue
+        short = key.split(".", 1)[-1]
+        given = leftover.pop(key, None)
+        if given is None:
+            given = leftover.pop(short, None)
+        kind = str(spec.get("type") or "text").strip().lower()
+        required = coerce_bool(spec.get("required"), False)
+
+        if given is not None:
+            values[key] = coerce_bool(given, False) if kind == "bool" else given
+            continue
+        if not interactive:
+            if required:
+                raise CLIError(
+                    f"{manifest.label} needs '{key}' and prompting is disabled",
+                    hint=f"Pass it with --field {key}=VALUE",
+                    exit_code=EXIT_USAGE,
+                )
+            continue
+
+        label = str(spec.get("label") or short)
+        if kind == "bool":
+            values[key] = typer.confirm(label, default=True)
+            continue
+        answer = str(typer.prompt(label, hide_input=(kind == "password"), default="", show_default=False) or "").strip()
+        if answer:
+            values[key] = answer
+        elif required:
+            raise CLIError(f"{manifest.label} needs '{key}'", exit_code=EXIT_USAGE)
+
+    return values
+
+
+def _parse_field_args(raw: list[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for item in raw or []:
+        key, sep, value = str(item).partition("=")
+        key = key.strip()
+        if not sep or not key:
+            raise CLIError(f"--field expects key=value, got '{item}'", exit_code=EXIT_USAGE)
+        out[key] = value
+    return out
+
+
+def _connected(state: Ctx, provider: str) -> bool:
+    try:
+        status = as_dict(state.get("/api/status", params={"fresh": 1}))
+    except CLIError:
+        return False
+    if coerce_bool(status.get(f"{provider.lower()}_connected"), False):
+        return True
+    block = as_dict(as_dict(status.get("providers")).get(provider.upper()))
+    return coerce_bool(block.get("connected"), False)
+
+
+def _rejected(result: Any) -> str:
+    block = as_dict(result)
+    if block.get("ok") is False:
+        return str(block.get("error") or block.get("status") or "rejected")
+    return ""
+
+
+def _show_code(state: Ctx, manifest: Manifest, started: dict[str, Any]) -> bool:
+    code = str(started.get("user_code") or started.get("code") or started.get("pin") or "").strip()
+    url = str(
+        started.get("verification_url")
+        or started.get("verificationUrl")
+        or started.get("verification_uri")
+        or started.get("authorize_url")
+        or started.get("url")
+        or manifest.verify_url
+        or ""
+    ).strip()
+    expires = started.get("expiresIn") or started.get("expires_in") or 0
+    if not code and not url:
+        return False
+    rows: list[tuple[str, Any]] = []
+    if code:
+        rows.append(("Code", code))
+    if url:
+        rows.append(("Open", url))
+    if expires:
+        rows.append(("Expires", f"in {int(expires)}s"))
+    state.out.kv(rows, title=f"Authorize {manifest.label}")
+    return True
+
+
+def _wait(state: Ctx, manifest: Manifest, instance: str, timeout: float, interval: float) -> bool:
+    endpoints = manifest.endpoints
+    deadline = time.time() + max(30.0, timeout)
+    state.out.info("Waiting for authorization... (Ctrl-C to stop)")
+    while time.time() < deadline:
+        time.sleep(interval)
+        if endpoints.poll:
+            try:
+                result = as_dict(state.post(endpoints.poll, params={"instance": instance}))
+            except CLIError:
+                continue
+            status = str(result.get("status") or "").strip().lower()
+            if not status and result.get("ok") and result.get("access_token"):
+                status = "authorized"
+            if status in AUTHORIZED or coerce_bool(result.get("authorized"), False):
+                if endpoints.finish:
+                    state.post(endpoints.finish, params={"instance": instance})
+                return True
+            if status and status not in PENDING:
+                raise CLIError(f"{manifest.label} authorization failed: {status}")
+        if _connected(state, manifest.name):
+            return True
+    return False
+
+
+@auth_app.command("providers")
+def auth_providers(
+    ctx: typer.Context,
+    show_all: bool = typer.Option(False, "--all", "-a", help="Include providers the CLI cannot connect."),
+) -> None:
+    """List every provider, how it authenticates and what it needs."""
+    state: Ctx = ctx.obj
+    catalogue = _manifests(state)
+    if not show_all:
+        catalogue = [m for m in catalogue if m.supported]
+    if state.out.json_mode:
+        state.out.data([_public(m) for m in catalogue])
+        return
+    state.out.table(
+        ["PROVIDER", "FLOW", "NEEDS", "CLI LOGIN"],
+        [
+            [
+                m.name,
+                m.flow or "-",
+                ", ".join(str(f.get("key") or "").split(".", 1)[-1] for f in m.fields) or "nothing",
+                state_text(m.supported, on="yes", off="no"),
+            ]
+            for m in catalogue
+        ],
+        title="Authentication providers",
+    )
+    state.out.info("Run 'cw auth show <provider>' for details, then 'cw auth login <provider>'.")
+
+
+@auth_app.command("show")
+def auth_show(ctx: typer.Context, provider: str = typer.Argument(..., help="Provider name.")) -> None:
+    """Show how one provider authenticates and which fields it needs."""
+    state: Ctx = ctx.obj
+    manifest = _manifest(state, provider)
+    if state.out.json_mode:
+        state.out.data(_public(manifest))
+        return
+    state.out.kv(
+        [
+            ("Provider", manifest.name),
+            ("Label", manifest.label),
+            ("Flow", manifest.flow or "-"),
+            ("CLI login", state_text(manifest.supported, on="supported", off="use the web UI")),
+            ("Verify at", manifest.verify_url or "-"),
+            ("Connected", state_text(_connected(state, manifest.name), on="yes", off="no")),
+        ],
+        title=manifest.label,
+    )
+    if manifest.notes:
+        state.out.print()
+        state.out.info(manifest.notes)
+    if not manifest.fields:
+        return
+    state.out.print()
+    state.out.table(
+        ["FIELD", "LABEL", "TYPE", "REQUIRED"],
+        [
+            [
+                str(f.get("key") or ""),
+                str(f.get("label") or "-"),
+                str(f.get("type") or "text"),
+                state_text(coerce_bool(f.get("required"), False), on="yes", off="no"),
+            ]
+            for f in manifest.fields
+        ],
+        title="Fields",
+    )
+    example = " ".join(f"--field {f.get('key')}=..." for f in manifest.fields if coerce_bool(f.get("required"), False))
+    if example:
+        state.out.print()
+        state.out.info(f"cw auth login {manifest.name.lower()} {example}")
+
+
+@auth_app.command("list")
+def auth_list(
+    ctx: typer.Context,
+    fresh: bool = typer.Option(False, "--fresh", "-f", help="Re-probe every provider instead of using the cached status."),
+) -> None:
+    """Show which providers are connected."""
+    state: Ctx = ctx.obj
+    params = {"fresh": 1} if fresh else None
+    providers = as_dict(as_dict(state.get("/api/status", params=params)).get("providers"))
+    if state.out.json_mode:
+        state.out.data(providers)
+        return
+    rows: list[list[Any]] = []
+    for name in sorted(providers):
+        block = as_dict(providers.get(name))
+        summary = as_dict(block.get("instances_summary"))
+        rows.append(
+            [
+                name,
+                state_text(block.get("connected"), on="connected", off="not connected"),
+                f"{int(summary.get('ok') or 0)}/{int(summary.get('total') or 0)}" if summary.get("total") else "-",
+                str(block.get("reason") or "")[:44],
+            ]
+        )
+    state.out.table(
+        ["PROVIDER", "STATE", "INSTANCES", "REASON"],
+        rows,
+        title="Provider connections",
+        empty="No providers configured yet. Run 'cw auth providers' to see the options.",
+    )
+    if not fresh:
+        state.out.info("Status is cached; pass --fresh to re-probe.")
+
+
+@auth_app.command("login")
+def auth_login(
+    ctx: typer.Context,
+    provider: str = typer.Argument(..., help="Provider name. See 'cw auth providers'."),
+    fields: list[str] = typer.Option([], "--field", "-F", help="Supply a field as key=value. Repeatable."),
+    instance: str = typer.Option("default", "--instance", "-i", help="Provider instance id."),
+    interactive: bool = typer.Option(True, "--interactive/--non-interactive", help="Prompt for missing fields."),
+    wait: bool = typer.Option(True, "--wait/--no-wait", help="Wait for a device code to be authorized."),
+    timeout: float = typer.Option(300.0, "--timeout", help="How long to wait, in seconds."),
+    interval: float = typer.Option(3.0, "--interval", help="Seconds between authorization checks."),
+) -> None:
+    """Connect a provider, whichever way that provider authenticates."""
+    state: Ctx = ctx.obj
+    state.require_service("Provider login")
+    manifest = _manifest(state, provider)
+    endpoints = manifest.endpoints
+    if not manifest.supported:
+        raise CLIError(
+            f"{manifest.label} cannot be connected from the CLI",
+            hint=f"Its '{manifest.flow}' flow needs the web UI.",
+            exit_code=EXIT_USAGE,
+        )
+
+    values = _collect_fields(manifest, _parse_field_args(fields), interactive=interactive)
+    params = {"instance": instance}
+    started: dict[str, Any] | None = None
+
+    if values or (endpoints.submit and not endpoints.start):
+        if endpoints.submit:
+            result = state.post(endpoints.submit, params=params, json_body=_nest(values, drop_prefix=True))
+            rejected = _rejected(result)
+            if rejected:
+                raise CLIError(f"{manifest.label} rejected those details: {rejected}")
+            if endpoints.submit_starts:
+                started = as_dict(result)
+        else:
+            state.post("/api/config", json_body=_nest(values, drop_prefix=False))
+
+    if started is None and endpoints.start:
+        body: dict[str, Any] = {"origin": state.url} if endpoints.needs_origin else {}
+        result = state.post(endpoints.start, params=params, json_body=body)
+        rejected = _rejected(result)
+        if rejected:
+            raise CLIError(
+                f"{manifest.label} refused to start a login: {rejected}",
+                hint=f"Check its fields with 'cw auth show {manifest.name.lower()}'.",
+            )
+        started = as_dict(result)
+
+    if started is None or not _show_code(state, manifest, started):
+        connected = _connected(state, manifest.name)
+        if state.out.json_mode:
+            state.out.data({"ok": connected, "provider": manifest.name, "instance": instance})
+            return
+        if connected:
+            state.out.success(f"{manifest.label} connected.")
+            return
+        state.out.warn(f"{manifest.label} accepted the details but does not report as connected yet.")
+        raise typer.Exit(1)
+
+    if not wait:
+        state.out.info("Finish in your browser, then run 'cw auth list' to confirm.")
+        return
+
+    try:
+        ok = _wait(state, manifest, instance, timeout, interval)
+    except KeyboardInterrupt:
+        if endpoints.cancel:
+            try:
+                state.post(endpoints.cancel, params=params)
+            except CLIError:
+                pass
+        raise CLIError("Login cancelled", exit_code=0) from None
+
+    if state.out.json_mode:
+        state.out.data({"ok": ok, "provider": manifest.name, "instance": instance})
+        return
+    if ok:
+        state.out.success(f"{manifest.label} connected.")
+        return
+    state.out.warn(f"{manifest.label} was not authorized before the timeout.")
+    raise typer.Exit(1)
+
+
+@auth_app.command("logout")
+def auth_logout(
+    ctx: typer.Context,
+    provider: str = typer.Argument(..., help="Provider to disconnect."),
+    instance: str = typer.Option("default", "--instance", "-i", help="Provider instance id."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Disconnect a provider and drop its stored credentials."""
+    state: Ctx = ctx.obj
+    state.require_service("Provider logout")
+    manifest = _manifest(state, provider)
+    endpoint = manifest.endpoints.disconnect
+    if not endpoint:
+        raise CLIError(f"{manifest.label} has no disconnect endpoint", exit_code=EXIT_NOT_FOUND)
+    if not yes and not typer.confirm(f"Disconnect {manifest.label} ({instance})?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = state.post(endpoint, params={"instance": instance})
+    rejected = _rejected(result)
+    if rejected:
+        raise CLIError(f"{manifest.label} could not be disconnected: {rejected}")
+    if state.out.json_mode:
+        state.out.data(as_dict(result) or {"ok": True})
+        return
+    state.out.success(f"{manifest.label} disconnected.")
+
+
+@token_app.command("list")
+def token_list(ctx: typer.Context) -> None:
+    """List API tokens."""
+    state: Ctx = ctx.obj
+    payload = as_dict(state.get("/api/app-auth/tokens"))
+    tokens = [as_dict(t) for t in (payload.get("tokens") or []) if isinstance(t, dict)]
+    if state.out.json_mode:
+        state.out.data(tokens)
+        return
+    state.out.table(
+        ["ID", "NAME", "PREFIX", "USER", "CREATED", "EXPIRES", "LAST USED"],
+        [
+            [
+                str(t.get("id") or ""),
+                str(t.get("name") or "-"),
+                str(t.get("prefix") or "-") + "...",
+                str(t.get("username") or t.get("user_id") or "-"),
+                fmt_ts(t.get("created_at")),
+                fmt_ts(t.get("expires_at")) if t.get("expires_at") else "never",
+                fmt_rel(t.get("last_used_at")) if t.get("last_used_at") else "never",
+            ]
+            for t in tokens
+        ],
+        title="API tokens",
+        empty="No API tokens yet. Create one with 'cw auth token create --local'.",
+    )
+
+
+@token_app.command("create")
+def token_create(
+    ctx: typer.Context,
+    name: str = typer.Option("CLI", "--name", "-n", help="Label shown in the token list."),
+    expires_days: int = typer.Option(0, "--expires-days", help="Expire after N days. 0 means never."),
+    save: bool = typer.Option(True, "--save/--no-save", help="Store the token in the CLI settings file."),
+) -> None:
+    """Create an API token. Use --local to bootstrap when you have no token yet."""
+    state: Ctx = ctx.obj
+    payload = as_dict(state.post("/api/app-auth/tokens", json_body={"name": name, "expires_days": int(expires_days)}))
+    if not payload.get("token"):
+        raise CLIError(f"Token creation failed: {payload.get('error') or 'unknown error'}")
+    raw = str(payload.get("token"))
+    entry = as_dict(payload.get("entry"))
+    stored = ""
+    if save:
+        update_settings(token=raw, url=state.url)
+        stored = str(settings_path())
+    if state.out.json_mode:
+        state.out.data({"token": raw, "entry": entry, "saved_to": stored})
+        return
+    state.out.kv(
+        [
+            ("Token", raw),
+            ("Id", str(entry.get("id") or "-")),
+            ("Name", str(entry.get("name") or name)),
+            ("Expires", fmt_ts(entry.get("expires_at")) if entry.get("expires_at") else "never"),
+            ("Saved to", stored or "not saved"),
+        ],
+        title="New API token",
+    )
+    state.out.warn("This is the only time the token is shown. Store it somewhere safe.")
+
+
+@token_app.command("revoke")
+def token_revoke(
+    ctx: typer.Context,
+    token_id: str = typer.Argument(..., help="Token id from 'cw auth token list'."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Revoke an API token."""
+    state: Ctx = ctx.obj
+    if not yes and not typer.confirm(f"Revoke token {token_id}?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(state.delete(f"/api/app-auth/tokens/{token_id}"))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Token not found"), exit_code=EXIT_NOT_FOUND)
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Revoked {token_id}")
+
+
+@token_app.command("use")
+def token_use(
+    ctx: typer.Context,
+    token: str = typer.Argument(..., help="An existing API token to store for future commands."),
+    url: str = typer.Option("", "--url", help="Also store this base URL."),
+) -> None:
+    """Save a token (and optionally a URL) in the CLI settings file."""
+    state: Ctx = ctx.obj
+    if not token.strip().startswith("cwt_"):
+        raise CLIError("That does not look like a CrossWatch API token", hint="Tokens start with cwt_.", exit_code=EXIT_USAGE)
+    update_settings(token=token.strip(), url=(url.strip() or state.url))
+    if state.out.json_mode:
+        state.out.data({"ok": True, "saved_to": str(settings_path())})
+        return
+    state.out.success(f"Saved to {settings_path()}")
+
+
+@token_app.command("whoami")
+def token_whoami(ctx: typer.Context) -> None:
+    """Show which identity the current token maps to."""
+    state: Ctx = ctx.obj
+    payload = as_dict(state.get("/api/app-auth/tokens/whoami"))
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    if not payload.get("auth_required"):
+        state.out.kv([("Endpoint", state.url), ("Auth", "not enabled on this instance")], title="Identity")
+        return
+    user = as_dict(payload.get("user"))
+    state.out.kv(
+        [
+            ("Endpoint", state.url),
+            ("User", str(user.get("username") or user.get("display_name") or "-")),
+            ("Role", "admin" if user.get("is_admin") else "user"),
+            ("Profile", str(user.get("profile_id") or "-")),
+            ("Authenticated by", str(payload.get("auth_kind") or "-")),
+            ("Token", str(payload.get("token_name") or payload.get("token_id") or "-")),
+        ],
+        title="Identity",
+    )
+
+
+def register(app: typer.Typer) -> None:
+    auth_app.add_typer(token_app, name="token")
+    app.add_typer(auth_app, name="auth")

--- a/cli/commands/backup.py
+++ b/cli/commands/backup.py
@@ -1,0 +1,196 @@
+# /cli/commands/backup.py
+# CrossWatch - CLI backup commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import CLIError
+from .._util import as_dict, error_text, fmt_ts
+
+backup_app = typer.Typer(help="CrossWatch tracker backups.", no_args_is_help=True)
+
+
+def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
+    block = as_dict(payload)
+    for key in keys:
+        found = block.get(key)
+        if isinstance(found, list):
+            return [as_dict(i) for i in found]
+    if isinstance(payload, list):
+        return [as_dict(i) for i in payload]
+    return []
+
+
+def _size(value: Any) -> str:
+    try:
+        size = float(value or 0)
+    except Exception:
+        return "-"
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return "-"
+
+
+@backup_app.command("list")
+def backup_list(ctx: typer.Context) -> None:
+    """List backups."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/backups/list")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "backups", "items", "files")
+    state.out.records(
+        rows,
+        [
+            ("PATH", lambda r: str(r.get("path") or r.get("name") or "-")),
+            ("WHEN", lambda r: fmt_ts(r.get("created_at") or r.get("mtime") or r.get("ts"))),
+            ("SIZE", lambda r: _size(r.get("size") or r.get("size_bytes"))),
+            ("KIND", lambda r: str(r.get("kind") or r.get("type") or "-")),
+        ],
+        title=f"Backups ({len(rows)})",
+        empty="No backups yet.",
+    )
+
+
+@backup_app.command("create")
+def backup_create(
+    ctx: typer.Context,
+    note: str = typer.Option("", "--note", "-m", help="Label for this backup."),
+) -> None:
+    """Take a backup now."""
+    state: Ctx = ctx.obj
+    state.require_service("Taking a backup")
+    body: dict[str, Any] = {}
+    if note.strip():
+        body["note"] = note.strip()
+    result = as_dict(state.post("/api/backups/create", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Backup rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success(f"Backup created{': ' + str(result.get('path')) if result.get('path') else '.'}")
+
+
+@backup_app.command("validate")
+def backup_validate(
+    ctx: typer.Context,
+    path: str = typer.Argument(..., help="Backup path from 'cw backup list'."),
+) -> None:
+    """Check a backup can be restored."""
+    state: Ctx = ctx.obj
+    result = as_dict(state.post("/api/backups/validate", json_body={"path": path}))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Backup is not valid"))
+    state.out.success("Backup looks valid.")
+    for key, value in result.items():
+        if key != "ok" and not isinstance(value, (dict, list)):
+            state.out.info(f"{key}: {value}")
+
+
+@backup_app.command("restore")
+def backup_restore(
+    ctx: typer.Context,
+    path: str = typer.Argument(..., help="Backup path from 'cw backup list'."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Restore a backup."""
+    state: Ctx = ctx.obj
+    state.require_service("Restoring a backup")
+    if not yes:
+        state.out.warn("This overwrites current data.")
+        if not typer.confirm(f"Restore {path}?", default=False):
+            raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(state.post("/api/backups/restore", json_body={"path": path}))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Restore rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success("Backup restored.")
+
+
+@backup_app.command("delete")
+def backup_delete(
+    ctx: typer.Context,
+    path: str = typer.Argument(..., help="Backup path."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Delete a backup."""
+    state: Ctx = ctx.obj
+    state.require_service("Deleting a backup")
+    if not yes and not typer.confirm(f"Delete {path}?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(state.post("/api/backups/delete", json_body={"path": path}))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Delete rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Deleted {path}")
+
+
+@backup_app.command("schedule")
+def backup_schedule(
+    ctx: typer.Context,
+    enable: bool = typer.Option(None, "--enable/--disable", help="Turn scheduled backups on or off."),
+    every_hours: int = typer.Option(0, "--every-hours", help="Interval in hours."),
+) -> None:
+    """Show or change the backup schedule."""
+    state: Ctx = ctx.obj
+    if enable is None and not every_hours:
+        payload = state.get("/api/backups/schedule")
+        if state.out.json_mode:
+            state.out.data(payload)
+            return
+        block = as_dict(payload)
+        state.out.kv(
+            [(key, value) for key, value in block.items() if not isinstance(value, (dict, list))],
+            title="Backup schedule",
+        )
+        return
+
+    state.require_service("Changing the backup schedule")
+    body: dict[str, Any] = dict(as_dict(state.get("/api/backups/schedule")))
+    if enable is not None:
+        body["enabled"] = bool(enable)
+    if every_hours:
+        body["every_n_hours"] = int(every_hours)
+    result = as_dict(state.post("/api/backups/schedule", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Schedule rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success("Backup schedule updated.")
+
+
+@backup_app.command("retention")
+def backup_retention(
+    ctx: typer.Context,
+    keep: int = typer.Argument(..., help="How many backups to keep."),
+) -> None:
+    """Set how many backups to keep and prune the rest."""
+    state: Ctx = ctx.obj
+    state.require_service("Changing backup retention")
+    result = as_dict(state.post("/api/backups/retention", json_body={"keep": int(keep)}))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Retention rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Keeping {keep} backups.")
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(backup_app, name="backup")

--- a/cli/commands/capture.py
+++ b/cli/commands/capture.py
@@ -1,0 +1,265 @@
+# /cli/commands/capture.py
+# CrossWatch - CLI capture and snapshot commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import CLIError
+from .._util import as_dict, error_text, fmt_ts
+
+capture_app = typer.Typer(help="Captures, the rollback tool for watchlist, ratings and history.", no_args_is_help=True)
+
+
+def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
+    block = as_dict(payload)
+    for key in keys:
+        found = block.get(key)
+        if isinstance(found, list):
+            return [as_dict(i) for i in found]
+    if isinstance(payload, list):
+        return [as_dict(i) for i in payload]
+    return []
+
+
+def _size(value: Any) -> str:
+    try:
+        size = float(value or 0)
+    except Exception:
+        return "-"
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return "-"
+
+
+CAPTURE_COLUMNS = [
+    ("PATH", lambda r: str(r.get("path") or r.get("id") or r.get("name") or "-")),
+    ("PROVIDER", lambda r: str(r.get("provider") or "-")),
+    ("FEATURE", lambda r: str(r.get("feature") or "-")),
+    ("WHEN", lambda r: fmt_ts(r.get("created_at") or r.get("ts") or r.get("mtime"))),
+    ("ITEMS", lambda r: str(r.get("count") or r.get("items") or "-")),
+    ("SIZE", lambda r: _size(r.get("size") or r.get("size_bytes"))),
+]
+
+
+@capture_app.command("list")
+def capture_list(ctx: typer.Context) -> None:
+    """List captures."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/snapshots/list")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "snapshots", "items", "captures")
+    state.out.records(rows, CAPTURE_COLUMNS, title=f"Captures ({len(rows)})", empty="No captures yet.")
+
+
+@capture_app.command("manifest")
+def capture_manifest(ctx: typer.Context) -> None:
+    """Show the capture manifest."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/snapshots/manifest")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    import json as _json
+
+    from rich.syntax import Syntax
+
+    state.out.console.print(
+        Syntax(_json.dumps(payload, indent=2, default=str), "json", theme="ansi_dark", background_color="default")
+    )
+
+
+@capture_app.command("create")
+def capture_create(
+    ctx: typer.Context,
+    provider: str = typer.Option("", "--provider", "-p", help="Limit to one provider."),
+    feature: str = typer.Option("", "--feature", "-F", help="Limit to one feature."),
+    instance: str = typer.Option("", "--instance", "-i", help="Provider instance id."),
+    wait: bool = typer.Option(True, "--wait/--no-wait", help="Wait for the capture to finish."),
+    timeout: float = typer.Option(600.0, "--timeout", help="How long to wait, in seconds."),
+) -> None:
+    """Take a capture."""
+    state: Ctx = ctx.obj
+    state.require_service("Taking a capture")
+    body: dict[str, Any] = {}
+    if provider.strip():
+        body["provider"] = provider.strip().upper()
+    if feature.strip():
+        body["feature"] = feature.strip().lower()
+    if instance.strip():
+        body["instance"] = instance.strip()
+
+    result = as_dict(state.post("/api/snapshots/create", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Capture rejected"))
+
+    progress_id = str(result.get("progress_id") or result.get("id") or "")
+    if not wait or not progress_id:
+        if state.out.json_mode:
+            state.out.data(result)
+            return
+        state.out.success("Capture started." if progress_id else "Capture done.")
+        return
+
+    deadline = time.time() + max(10.0, timeout)
+    last = ""
+    while time.time() < deadline:
+        time.sleep(2.0)
+        progress = as_dict(state.get(f"/api/snapshots/capture-progress/{progress_id}"))
+        status = str(progress.get("status") or progress.get("state") or "").lower()
+        note = str(progress.get("message") or progress.get("step") or "")
+        if note and note != last:
+            state.out.info(note)
+            last = note
+        if status in ("done", "finished", "complete", "ok"):
+            if state.out.json_mode:
+                state.out.data(progress)
+                return
+            state.out.success("Capture finished.")
+            return
+        if status in ("error", "failed"):
+            raise CLIError(error_text(progress, "Capture failed"))
+    state.out.warn("Still running, stopped waiting.")
+
+
+@capture_app.command("delete")
+def capture_delete(
+    ctx: typer.Context,
+    path: str = typer.Argument(..., help="Capture path from 'cw capture list'."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Delete a capture."""
+    state: Ctx = ctx.obj
+    state.require_service("Deleting a capture")
+    if not yes and not typer.confirm(f"Delete capture {path}?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(state.post("/api/snapshots/delete", json_body={"path": path}))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Delete rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Deleted {path}")
+
+
+@capture_app.command("restore")
+def capture_restore(
+    ctx: typer.Context,
+    path: str = typer.Argument(..., help="Capture path from 'cw capture list'."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Report what would change, change nothing."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Restore a capture back to its provider."""
+    state: Ctx = ctx.obj
+    state.require_service("Restoring a capture")
+    if not dry_run and not yes:
+        state.out.warn("This writes to the provider.")
+        if not typer.confirm(f"Restore {path}?", default=False):
+            raise CLIError("Cancelled", exit_code=0)
+    body = {"path": path, "dry_run": bool(dry_run)}
+    result = as_dict(state.post("/api/snapshots/restore", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Restore rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success(("Dry run finished." if dry_run else "Restore finished."))
+    for key in ("added", "removed", "updated", "skipped", "errors"):
+        if key in result:
+            state.out.info(f"{key}: {result.get(key)}")
+
+
+@capture_app.command("read")
+def capture_read(
+    ctx: typer.Context,
+    path: str = typer.Argument(..., help="Capture path."),
+) -> None:
+    """Print the contents of a capture."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/snapshots/read", params={"path": path})
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    import json as _json
+
+    from rich.syntax import Syntax
+
+    state.out.console.print(
+        Syntax(_json.dumps(payload, indent=2, default=str), "json", theme="ansi_dark", background_color="default")
+    )
+
+
+@capture_app.command("diff")
+def capture_diff(
+    ctx: typer.Context,
+    first: str = typer.Argument(..., help="Older capture path."),
+    second: str = typer.Argument(..., help="Newer capture path."),
+    feature: str = typer.Option("", "--feature", "-F", help="Limit to one feature."),
+    kind: str = typer.Option("all", "--kind", help="all, added or removed."),
+    limit: int = typer.Option(100, "--limit", "-n", help="Maximum rows."),
+) -> None:
+    """Compare two captures."""
+    state: Ctx = ctx.obj
+    params: dict[str, Any] = {"a": first, "b": second, "limit": limit, "kind": kind}
+    path = "/api/snapshots/diff"
+    if feature.strip():
+        params["feature"] = feature.strip()
+        path = "/api/snapshots/diff/extended"
+    payload = state.get(path, params=params)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    block = as_dict(payload)
+    summary = as_dict(block.get("summary")) or block
+    state.out.kv(
+        [
+            ("Added", str(summary.get("added") or 0)),
+            ("Removed", str(summary.get("removed") or 0)),
+            ("Changed", str(summary.get("changed") or summary.get("updated") or 0)),
+        ],
+        title="Diff",
+    )
+    rows = _rows(payload, "items", "changes", "rows")
+    if rows:
+        state.out.print()
+        state.out.records(
+            rows[: max(1, limit)],
+            [
+                ("CHANGE", lambda r: str(r.get("kind") or r.get("change") or "-")),
+                ("TITLE", lambda r: str(r.get("title") or r.get("key") or "-")[:48]),
+                ("TYPE", lambda r: str(r.get("type") or "-")),
+                ("FEATURE", lambda r: str(r.get("feature") or "-")),
+            ],
+            title="Changes",
+        )
+
+
+@capture_app.command("clear")
+def capture_clear(
+    ctx: typer.Context,
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Delete every capture."""
+    state: Ctx = ctx.obj
+    state.require_service("Clearing captures")
+    if not yes and not typer.confirm("Delete every capture?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(state.post("/api/snapshots/clear"))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Clear rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success("Captures cleared.")
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(capture_app, name="capture")

--- a/cli/commands/config.py
+++ b/cli/commands/config.py
@@ -1,0 +1,239 @@
+# /cli/commands/config.py
+# CrossWatch - CLI configuration commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import EXIT_NOT_FOUND, EXIT_USAGE, CLIError
+from .._settings import config_dir
+from .._util import dotted_get, dotted_payload, error_text, parse_value, split_path
+
+config_app = typer.Typer(help="Read and change CrossWatch settings.", no_args_is_help=True)
+
+
+def _load(state: Ctx) -> dict[str, Any]:
+    payload = state.get("/api/config")
+    if not isinstance(payload, dict):
+        raise CLIError("Config endpoint returned an unexpected payload")
+    if payload.get("ok") is False:
+        raise CLIError(error_text(payload, "Cannot read config"))
+    return payload
+
+
+def _save(state: Ctx, body: dict[str, Any]) -> None:
+    result = state.post("/api/config", json_body=body)
+    if isinstance(result, dict) and result.get("ok") is False:
+        raise CLIError(error_text(result, "Config save rejected"))
+
+
+def _render_json(state: Ctx, value: Any) -> None:
+    if state.out.json_mode:
+        state.out.data(value)
+        return
+    if state.out.plain or not isinstance(value, (dict, list)):
+        state.out.raw(value if isinstance(value, str) else json.dumps(value, indent=2, default=str))
+        return
+    from rich.syntax import Syntax
+
+    state.out.console.print(Syntax(json.dumps(value, indent=2, default=str), "json", theme="ansi_dark", background_color="default"))
+
+
+@config_app.command("show")
+def config_show(
+    ctx: typer.Context,
+    path: str = typer.Argument("", help="Optional dotted path, for example sync or scrobble.watch."),
+) -> None:
+    """Print the configuration, or one subtree of it. Secrets stay masked."""
+    state: Ctx = ctx.obj
+    cfg = _load(state)
+    value = cfg if not path.strip() else dotted_get(cfg, path, _MISSING)
+    if value is _MISSING:
+        raise CLIError(f"No config at '{path}'", exit_code=EXIT_NOT_FOUND)
+    _render_json(state, value)
+
+
+@config_app.command("get")
+def config_get(ctx: typer.Context, path: str = typer.Argument(..., help="Dotted path, for example sync.anime.enabled.")) -> None:
+    """Print a single config value."""
+    state: Ctx = ctx.obj
+    value = dotted_get(_load(state), path, _MISSING)
+    if value is _MISSING:
+        raise CLIError(f"No config at '{path}'", exit_code=EXIT_NOT_FOUND)
+    if state.out.json_mode:
+        state.out.data({"path": path, "value": value})
+        return
+    if isinstance(value, (dict, list)):
+        _render_json(state, value)
+        return
+    state.out.raw("" if value is None else ("true" if value is True else "false" if value is False else str(value)))
+
+
+@config_app.command("set")
+def config_set(
+    ctx: typer.Context,
+    path: str = typer.Argument(..., help="Dotted path, for example sync.anime.enabled."),
+    value: str = typer.Argument(..., help="New value. Booleans, numbers and null are detected automatically."),
+    as_json: bool = typer.Option(False, "--json", "-j", help="Parse the value as JSON (use for lists and objects)."),
+) -> None:
+    """Change one config value."""
+    state: Ctx = ctx.obj
+    parsed = parse_value(value, as_json=as_json)
+    cfg = _load(state)
+    current = dotted_get(cfg, path, _MISSING)
+    if current is not _MISSING and isinstance(current, (dict, list)) and not as_json:
+        raise CLIError(
+            f"'{path}' holds a {type(current).__name__}; refusing to overwrite it with a scalar",
+            hint="Pass --json and a JSON value if that is really what you want.",
+            exit_code=EXIT_USAGE,
+        )
+    _save(state, dotted_payload(path, parsed))
+    if state.out.json_mode:
+        state.out.data({"ok": True, "path": path, "value": parsed, "previous": None if current is _MISSING else current})
+        return
+    before = "unset" if current is _MISSING else json.dumps(current, default=str)
+    state.out.success(f"{path}: {before} -> {json.dumps(parsed, default=str)}")
+
+
+@config_app.command("unset")
+def config_unset(
+    ctx: typer.Context,
+    path: str = typer.Argument(..., help="Dotted path to remove."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Remove a config key."""
+    state: Ctx = ctx.obj
+    cfg = _load(state)
+    if dotted_get(cfg, path, _MISSING) is _MISSING:
+        raise CLIError(f"No config at '{path}'", exit_code=EXIT_NOT_FOUND)
+    if len(split_path(path)) == 1 and not yes:
+        state.out.warn(f"'{path}' is a top level config section.")
+        if not typer.confirm(f"Remove the whole '{path}' section?", default=False):
+            raise CLIError("Cancelled", exit_code=0)
+
+    result = state.post("/api/config/unset", json_body={"paths": [path]})
+    if not isinstance(result, dict) or result.get("ok") is not True:
+        error = str((result or {}).get("error") or "unknown error")
+        if error == "protected_path":
+            raise CLIError(
+                f"'{path}' is protected and cannot be removed from the CLI",
+                hint="Authentication settings are managed in the UI or with 'cw auth token'.",
+            )
+        if error == "not_found":
+            raise CLIError(f"No config at '{path}'", exit_code=EXIT_NOT_FOUND)
+        raise CLIError(f"Could not remove '{path}': {error}")
+
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success(f"Removed {path}")
+
+
+@config_app.command("edit")
+def config_edit(
+    ctx: typer.Context,
+    editor: str = typer.Option("", "--editor", help="Editor command. Defaults to $VISUAL, then $EDITOR, then vi."),
+) -> None:
+    """Open the configuration in an editor and save what you write back."""
+    state: Ctx = ctx.obj
+    cfg = _load(state)
+    original = json.dumps(cfg, indent=2, default=str)
+    command = editor.strip() or os.getenv("VISUAL") or os.getenv("EDITOR") or ("notepad" if os.name == "nt" else "vi")
+
+    handle = tempfile.NamedTemporaryFile("w", suffix=".cw-config.json", delete=False, encoding="utf-8")
+    temp = Path(handle.name)
+    try:
+        handle.write(original)
+        handle.close()
+        try:
+            subprocess.call([*command.split(), str(temp)])
+        except FileNotFoundError as exc:
+            raise CLIError(f"Editor '{command}' not found", hint="Set $EDITOR or pass --editor.") from exc
+        edited = temp.read_text(encoding="utf-8")
+    finally:
+        try:
+            temp.unlink()
+        except Exception:
+            pass
+
+    if edited.strip() == original.strip():
+        state.out.info("No changes.")
+        return
+    try:
+        parsed = json.loads(edited)
+    except Exception as exc:
+        raise CLIError(f"That is not valid JSON: {exc}", hint="Nothing was saved.") from exc
+    if not isinstance(parsed, dict):
+        raise CLIError("The config must stay a JSON object", hint="Nothing was saved.")
+    _save(state, parsed)
+    state.out.success("Configuration saved.")
+
+
+@config_app.command("meta")
+def config_meta(ctx: typer.Context) -> None:
+    """Show the config schema metadata the UI uses."""
+    state: Ctx = ctx.obj
+    _render_json(state, state.get("/api/config/meta"))
+
+
+@config_app.command("migrate")
+def config_migrate(
+    ctx: typer.Context,
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Migrate the config to the current schema. Takes a backup first."""
+    state: Ctx = ctx.obj
+    if not yes and not typer.confirm("Migrate the configuration now?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = state.post("/api/config/migrate")
+    if isinstance(result, dict) and result.get("ok") is False:
+        raise CLIError(error_text(result, "Migration failed"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    block = result if isinstance(result, dict) else {}
+    state.out.success("Configuration migrated.")
+    if block.get("backup"):
+        state.out.info(f"Backup: {block.get('backup')}")
+    changed = block.get("changed") or block.get("forced") or []
+    if isinstance(changed, list) and changed:
+        state.out.info(f"{len(changed)} path(s) changed")
+
+
+@config_app.command("path")
+def config_path(ctx: typer.Context) -> None:
+    """Show where the configuration and runtime data live."""
+    state: Ctx = ctx.obj
+    base = config_dir()
+    data = {
+        "config_dir": str(base),
+        "config_file": str(base / "config.json"),
+        "state_dir": str(base / ".cw_state"),
+        "database": str(base / ".cw_databases" / "crosswatch.sqlite3"),
+        "cache_dir": str(base / "cache"),
+        "endpoint": state.url,
+    }
+    if state.out.json_mode:
+        state.out.data(data)
+        return
+    state.out.kv(list(data.items()), title="Paths")
+
+
+class _Missing:
+    def __repr__(self) -> str:
+        return "<missing>"
+
+
+_MISSING = _Missing()
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(config_app, name="config")

--- a/cli/commands/editor.py
+++ b/cli/commands/editor.py
@@ -1,0 +1,169 @@
+# /cli/commands/editor.py
+# CrossWatch - CLI editor commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import EXIT_USAGE, CLIError
+from .._util import as_dict, error_text
+
+editor_app = typer.Typer(help="Inspect and adjust stored items.", no_args_is_help=True)
+
+
+def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
+    block = as_dict(payload)
+    for key in keys:
+        found = block.get(key)
+        if isinstance(found, list):
+            return [as_dict(i) for i in found]
+    if isinstance(payload, list):
+        return [as_dict(i) for i in payload]
+    return []
+
+
+@editor_app.command("list")
+def editor_list(
+    ctx: typer.Context,
+    kind: str = typer.Option("watchlist", "--kind", "-k", help="watchlist, ratings, history or playlists."),
+    provider: str = typer.Option("", "--provider", "-p", help="Limit to one provider."),
+    instance: str = typer.Option("", "--instance", "-i", help="Provider instance id."),
+    source: str = typer.Option("state", "--source", help="state or snapshot."),
+    snapshot: str = typer.Option("", "--snapshot", help="Snapshot path when source is snapshot."),
+    limit: int = typer.Option(50, "--limit", "-n", help="Maximum rows."),
+) -> None:
+    """List what the editor sees."""
+    state: Ctx = ctx.obj
+    params: dict[str, Any] = {"kind": kind, "source": source}
+    if provider.strip():
+        params["provider"] = provider.strip().upper()
+    if instance.strip():
+        params["provider_instance"] = instance.strip()
+    if snapshot.strip():
+        params["snapshot"] = snapshot.strip()
+    payload = state.get("/api/editor", params=params)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "items", "rows")
+    state.out.records(
+        rows[: max(1, limit)],
+        [
+            ("KEY", lambda r: str(r.get("key") or r.get("id") or "-")[:28]),
+            ("TITLE", lambda r: str(r.get("title") or "-")[:40]),
+            ("TYPE", lambda r: str(r.get("type") or "-")),
+            ("YEAR", lambda r: str(r.get("year") or "-")),
+            ("PROVIDER", lambda r: str(r.get("provider") or "-")),
+        ],
+        title=f"Editor: {kind} ({len(rows)})",
+        empty="Nothing stored for that view.",
+    )
+
+
+@editor_app.command("providers")
+def editor_providers(
+    ctx: typer.Context,
+    kind: str = typer.Option("watchlist", "--kind", "-k", help="Which feature to ask about."),
+) -> None:
+    """Show which providers the editor can send to."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/editor/send/providers", params={"kind": kind})
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "providers", "items")
+    if rows:
+        state.out.records(
+            rows,
+            [
+                ("PROVIDER", lambda r: str(r.get("name") or r.get("provider") or "-")),
+                ("INSTANCE", lambda r: str(r.get("instance") or "-")),
+            ],
+            title="Send targets",
+        )
+        return
+    block = as_dict(payload)
+    names = block.get("providers")
+    if isinstance(names, list):
+        state.out.table(["PROVIDER"], [[str(n)] for n in names], title="Send targets")
+        return
+    state.out.kv([(k, v) for k, v in block.items() if not isinstance(v, (dict, list))], title="Send targets")
+
+
+@editor_app.command("send")
+def editor_send(
+    ctx: typer.Context,
+    keys: list[str] = typer.Argument(..., help="Item keys."),
+    provider: str = typer.Option(..., "--provider", "-p", help="Where to send them."),
+    kind: str = typer.Option("watchlist", "--kind", "-k", help="Which feature."),
+    instance: str = typer.Option("", "--instance", "-i", help="Provider instance id."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Send stored items to a provider."""
+    state: Ctx = ctx.obj
+    state.require_service("Sending items")
+    wanted = [k.strip() for k in keys if k.strip()]
+    if not wanted:
+        raise CLIError("Nothing to send", exit_code=EXIT_USAGE)
+    if not yes:
+        state.out.warn(f"This writes {len(wanted)} item(s) to {provider.upper()}.")
+        if not typer.confirm("Continue?", default=False):
+            raise CLIError("Cancelled", exit_code=0)
+    body: dict[str, Any] = {"keys": wanted, "provider": provider.strip().upper(), "kind": kind}
+    if instance.strip():
+        body["provider_instance"] = instance.strip()
+    result = as_dict(state.post("/api/editor/send", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Send rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success(f"Sent {len(wanted)} item(s) to {provider.upper()}.")
+
+
+@editor_app.command("export")
+def editor_export(ctx: typer.Context) -> None:
+    """Print the manual editor state as JSON."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/editor/state/manual/export")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    import json as _json
+
+    state.out.raw(_json.dumps(payload, indent=2, default=str))
+
+
+@editor_app.command("sources")
+def editor_sources(ctx: typer.Context) -> None:
+    """Show which providers the editor can read state from."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/editor/state/providers")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "providers", "items")
+    if rows:
+        state.out.records(
+            rows,
+            [
+                ("PROVIDER", lambda r: str(r.get("name") or r.get("provider") or "-")),
+                ("INSTANCE", lambda r: str(r.get("instance") or "-")),
+                ("ITEMS", lambda r: str(r.get("count") or "-")),
+            ],
+            title="State sources",
+        )
+        return
+    block = as_dict(payload)
+    names = block.get("providers")
+    if isinstance(names, list):
+        state.out.table(["PROVIDER"], [[str(n)] for n in names], title="State sources")
+        return
+    state.out.kv([(k, v) for k, v in block.items() if not isinstance(v, (dict, list))], title="State sources")
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(editor_app, name="editor")

--- a/cli/commands/events.py
+++ b/cli/commands/events.py
@@ -1,0 +1,296 @@
+# /cli/commands/events.py
+# CrossWatch - CLI events archive commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import EXIT_NOT_FOUND, CLIError
+from .._render import state_text
+from .._util import as_dict, coerce_bool, error_text, fmt_ts
+
+events_app = typer.Typer(help="Search and inspect the events archive.", no_args_is_help=True)
+
+
+def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
+    block = as_dict(payload)
+    for key in keys:
+        found = block.get(key)
+        if isinstance(found, list):
+            return [as_dict(i) for i in found]
+    if isinstance(payload, list):
+        return [as_dict(i) for i in payload]
+    return []
+
+
+def _when(row: dict[str, Any]) -> str:
+    for key in ("ts", "created_at", "timestamp", "at", "occurred_at"):
+        if row.get(key):
+            return fmt_ts(row.get(key))
+    return "-"
+
+
+EVENT_COLUMNS = [
+    ("WHEN", _when),
+    ("TYPE", lambda r: str(r.get("event_type") or r.get("type") or "-")),
+    ("PROVIDER", lambda r: str(r.get("provider") or r.get("destination_provider") or "-")),
+    ("FEATURE", lambda r: str(r.get("feature") or "-")),
+    ("TITLE", lambda r: str(r.get("title") or r.get("item_title") or r.get("message") or "-")[:44]),
+]
+
+GROUP_COLUMNS = [
+    ("ID", lambda r: str(r.get("id") or r.get("group_id") or "-")),
+    ("WHEN", _when),
+    ("TYPE", lambda r: str(r.get("event_type") or r.get("type") or "-")),
+    ("PROVIDER", lambda r: str(r.get("provider") or "-")),
+    ("COUNT", lambda r: str(r.get("count") or r.get("events") or 0)),
+    ("ACK", lambda r: state_text(coerce_bool(r.get("acknowledged"), False), on="yes", off="no")),
+    ("WHAT", lambda r: str(r.get("title") or r.get("message") or "-")[:38]),
+]
+
+
+def _filters(
+    query: str,
+    event_type: str,
+    provider: str,
+    feature: str,
+    domain: str,
+    limit: int,
+    offset: int,
+    visibility: str,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {"limit": limit, "offset": offset}
+    if query.strip():
+        params["q"] = query.strip()
+    if event_type.strip():
+        params["event_type"] = event_type.strip()
+    if provider.strip():
+        params["provider"] = provider.strip()
+    if feature.strip():
+        params["feature"] = feature.strip()
+    if domain.strip():
+        params["domain"] = domain.strip()
+    if visibility.strip():
+        params["visibility"] = visibility.strip()
+    return params
+
+
+@events_app.command("status")
+def events_status(ctx: typer.Context) -> None:
+    """Show the state of the events archive."""
+    state: Ctx = ctx.obj
+    payload = as_dict(state.get("/api/events/status"))
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    state.out.kv(
+        [(key, value) for key, value in payload.items() if not isinstance(value, (dict, list))],
+        title="Events archive",
+    )
+
+
+@events_app.command("recent")
+def events_recent(
+    ctx: typer.Context,
+    limit: int = typer.Option(50, "--limit", "-n", help="Maximum rows."),
+    offset: int = typer.Option(0, "--offset", help="Skip this many rows."),
+    domain: str = typer.Option("sync", "--domain", "-d", help="sync or scrobble."),
+    visibility: str = typer.Option("open", "--visibility", help="open, all or acknowledged."),
+    view: str = typer.Option("groups", "--view", help="groups or events."),
+) -> None:
+    """Show recent activity from the archive."""
+    state: Ctx = ctx.obj
+    params = {"limit": limit, "offset": offset, "domain": domain, "visibility": visibility, "view": view}
+    payload = state.get("/api/events/recent", params=params)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "groups", "items", "events")
+    columns = GROUP_COLUMNS if view == "groups" else EVENT_COLUMNS
+    state.out.records(rows, columns, title=f"Recent {view}", empty="Nothing recorded yet.")
+
+
+@events_app.command("search")
+def events_search(
+    ctx: typer.Context,
+    query: str = typer.Argument("", help="Free text to search for."),
+    event_type: str = typer.Option("", "--type", "-t", help="Event type filter."),
+    provider: str = typer.Option("", "--provider", "-p", help="Provider filter."),
+    feature: str = typer.Option("", "--feature", help="Feature filter."),
+    domain: str = typer.Option("", "--domain", "-d", help="sync or scrobble."),
+    visibility: str = typer.Option("", "--visibility", help="open, all or acknowledged."),
+    limit: int = typer.Option(50, "--limit", "-n", help="Maximum rows."),
+    offset: int = typer.Option(0, "--offset", help="Skip this many rows."),
+) -> None:
+    """Search events."""
+    state: Ctx = ctx.obj
+    params = _filters(query, event_type, provider, feature, domain, limit, offset, visibility)
+    payload = state.get("/api/events/search", params=params)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "events", "items", "results")
+    state.out.records(rows, EVENT_COLUMNS, title=f"Events ({len(rows)})", empty="Nothing matched.")
+
+
+@events_app.command("groups")
+def events_groups(
+    ctx: typer.Context,
+    query: str = typer.Argument("", help="Free text to search for."),
+    event_type: str = typer.Option("", "--type", "-t", help="Event type filter."),
+    provider: str = typer.Option("", "--provider", "-p", help="Provider filter."),
+    feature: str = typer.Option("", "--feature", help="Feature filter."),
+    domain: str = typer.Option("", "--domain", "-d", help="sync or scrobble."),
+    visibility: str = typer.Option("", "--visibility", help="open, all or acknowledged."),
+    limit: int = typer.Option(50, "--limit", "-n", help="Maximum rows."),
+    offset: int = typer.Option(0, "--offset", help="Skip this many rows."),
+) -> None:
+    """List event groups."""
+    state: Ctx = ctx.obj
+    params = _filters(query, event_type, provider, feature, domain, limit, offset, visibility)
+    payload = state.get("/api/events/groups", params=params)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "groups", "items")
+    state.out.records(rows, GROUP_COLUMNS, title=f"Groups ({len(rows)})", empty="No groups.")
+
+
+@events_app.command("show")
+def events_show(
+    ctx: typer.Context,
+    group_id: int = typer.Argument(..., help="Group id from 'cw events groups'."),
+    limit: int = typer.Option(100, "--limit", "-n", help="Maximum member events."),
+) -> None:
+    """Show one group and the events inside it."""
+    state: Ctx = ctx.obj
+    payload = as_dict(state.get(f"/api/events/groups/{group_id}"))
+    members = state.get(f"/api/events/groups/{group_id}/events", params={"limit": limit})
+    if state.out.json_mode:
+        state.out.data({"group": payload, "events": members})
+        return
+    group = as_dict(payload.get("group")) or payload
+    state.out.kv(
+        [
+            ("Id", str(group.get("id") or group_id)),
+            ("Type", str(group.get("event_type") or group.get("type") or "-")),
+            ("Provider", str(group.get("provider") or "-")),
+            ("Feature", str(group.get("feature") or "-")),
+            ("When", _when(group)),
+            ("Events", str(group.get("count") or group.get("events") or 0)),
+            ("Acknowledged", state_text(coerce_bool(group.get("acknowledged"), False), on="yes", off="no")),
+        ],
+        title=str(group.get("title") or f"Group {group_id}"),
+    )
+    rows = _rows(members, "events", "items")
+    if rows:
+        state.out.print()
+        state.out.records(rows, EVENT_COLUMNS, title="Events")
+
+
+@events_app.command("run")
+def events_run(
+    ctx: typer.Context,
+    run_id: str = typer.Argument(..., help="Run id, see 'cw sync status'."),
+    limit: int = typer.Option(200, "--limit", "-n", help="Maximum rows."),
+) -> None:
+    """Show every event recorded for one sync run."""
+    state: Ctx = ctx.obj
+    payload = state.get(f"/api/events/run/{run_id}", params={"limit": limit})
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "events", "items")
+    state.out.records(rows, EVENT_COLUMNS, title=f"Run {run_id}", empty="Nothing recorded for that run.")
+
+
+@events_app.command("item")
+def events_item(
+    ctx: typer.Context,
+    item_key: str = typer.Argument(..., help="Item key."),
+    limit: int = typer.Option(100, "--limit", "-n", help="Maximum rows."),
+) -> None:
+    """Show the history of one item."""
+    state: Ctx = ctx.obj
+    payload = state.get(f"/api/events/item/{item_key}", params={"limit": limit})
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "events", "items")
+    state.out.records(rows, EVENT_COLUMNS, title=item_key, empty="No history for that item.")
+
+
+@events_app.command("stats")
+def events_stats(
+    ctx: typer.Context,
+    window: str = typer.Option("30d", "--range", "-r", help="Time range, for example 7d or 30d."),
+) -> None:
+    """Show archive statistics."""
+    state: Ctx = ctx.obj
+    payload = as_dict(state.get("/api/events/statistics", params={"range": window}))
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    state.out.kv(
+        [(key, value) for key, value in payload.items() if not isinstance(value, (dict, list))],
+        title=f"Events over {window}",
+    )
+    buckets = payload.get("buckets") or payload.get("series")
+    if isinstance(buckets, list) and buckets:
+        state.out.print()
+        state.out.records(
+            [as_dict(b) for b in buckets][:30],
+            [
+                ("WHEN", lambda r: str(r.get("label") or r.get("bucket") or _when(r))),
+                ("COUNT", lambda r: str(r.get("count") or r.get("total") or 0)),
+            ],
+            title="Buckets",
+        )
+
+
+@events_app.command("ack")
+def events_ack(
+    ctx: typer.Context,
+    group_id: int = typer.Argument(..., help="Group id."),
+    undo: bool = typer.Option(False, "--undo", help="Unacknowledge instead."),
+) -> None:
+    """Acknowledge a group so it drops out of the open view."""
+    state: Ctx = ctx.obj
+    state.require_service("Acknowledging events")
+    action = "unacknowledge" if undo else "acknowledge"
+    result = as_dict(state.post(f"/api/events/groups/{group_id}/{action}"))
+    if result.get("ok") is False:
+        found = result.get("found")
+        if found is False:
+            raise CLIError(f"No event group {group_id}", exit_code=EXIT_NOT_FOUND)
+        raise CLIError(error_text(result, "Rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Group {group_id} {'unacknowledged' if undo else 'acknowledged'}.")
+
+
+@events_app.command("clear")
+def events_clear(
+    ctx: typer.Context,
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Clear the events archive."""
+    state: Ctx = ctx.obj
+    state.require_service("Clearing the events archive")
+    if not yes and not typer.confirm("Clear the whole events archive?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(state.post("/api/events/clear"))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Clear rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success("Events archive cleared.")
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(events_app, name="events")

--- a/cli/commands/insights.py
+++ b/cli/commands/insights.py
@@ -1,0 +1,136 @@
+# /cli/commands/insights.py
+# CrossWatch - CLI insights, statistics and activity commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import CLIError
+from .._util import as_dict, error_text, fmt_ts
+
+activity_app = typer.Typer(help="The recent activity log.", no_args_is_help=True)
+
+
+def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
+    block = as_dict(payload)
+    for key in keys:
+        found = block.get(key)
+        if isinstance(found, list):
+            return [as_dict(i) for i in found]
+    if isinstance(payload, list):
+        return [as_dict(i) for i in payload]
+    return []
+
+
+def _flat_kv(payload: dict[str, Any]) -> list[tuple[str, Any]]:
+    return [(key, value) for key, value in payload.items() if not isinstance(value, (dict, list))]
+
+
+ACTIVITY_COLUMNS = [
+    ("WHEN", lambda r: fmt_ts(r.get("ts") or r.get("watched_at") or r.get("created_at"))),
+    ("TITLE", lambda r: str(r.get("title") or "-")[:44]),
+    ("TYPE", lambda r: str(r.get("type") or r.get("media_type") or "-")),
+    ("PROVIDER", lambda r: str(r.get("provider") or "-")),
+    ("STATUS", lambda r: str(r.get("status") or r.get("action") or "-")),
+]
+
+
+@activity_app.command("recent")
+def activity_recent(
+    ctx: typer.Context,
+    limit: int = typer.Option(20, "--limit", "-n", help="Maximum rows."),
+) -> None:
+    """Show what happened recently."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/activity/recent", params={"limit": limit})
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "items", "activity", "recent")
+    state.out.records(rows, ACTIVITY_COLUMNS, title="Recent activity", empty="Nothing recorded.")
+
+
+@activity_app.command("history")
+def activity_history(
+    ctx: typer.Context,
+    limit: int = typer.Option(50, "--limit", "-n", help="Maximum rows."),
+    offset: int = typer.Option(0, "--offset", help="Skip this many rows."),
+    media_type: str = typer.Option("all", "--type", "-t", help="movie, episode or all."),
+    status: str = typer.Option("all", "--status", help="Status filter."),
+    query: str = typer.Option("", "--search", "-q", help="Free text filter."),
+) -> None:
+    """Show the activity history."""
+    state: Ctx = ctx.obj
+    params: dict[str, Any] = {"limit": limit, "offset": offset, "media_type": media_type, "status": status}
+    if query.strip():
+        params["q"] = query.strip()
+    payload = state.get("/api/activity/history", params=params)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "items", "history")
+    state.out.records(rows, ACTIVITY_COLUMNS, title=f"History ({len(rows)})", empty="Nothing recorded.")
+
+
+@activity_app.command("clear")
+def activity_clear(
+    ctx: typer.Context,
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Clear the activity history."""
+    state: Ctx = ctx.obj
+    state.require_service("Clearing activity history")
+    if not yes and not typer.confirm("Clear the activity history?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(state.delete("/api/activity/history"))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Clear rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success("Activity history cleared.")
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(activity_app, name="activity")
+
+    @app.command("insights")
+    def insights_cmd(
+        ctx: typer.Context,
+        history: int = typer.Option(3, "--history", help="How many past runs to include."),
+        events: bool = typer.Option(True, "--events/--no-events", help="Include event derived numbers."),
+    ) -> None:
+        """Show the insights the dashboard is built from."""
+        state: Ctx = ctx.obj
+        params = {"history": history, "include_events": 1 if events else 0}
+        payload = as_dict(state.get("/api/insights", params=params))
+        if state.out.json_mode:
+            state.out.data(payload)
+            return
+        state.out.kv(_flat_kv(payload), title="Insights")
+        for key, value in payload.items():
+            block = as_dict(value)
+            if block and all(not isinstance(v, (dict, list)) for v in block.values()):
+                state.out.print()
+                state.out.kv(_flat_kv(block), title=key)
+
+    @app.command("stats")
+    def stats_cmd(
+        ctx: typer.Context,
+        raw: bool = typer.Option(False, "--raw", help="Show the unrolled numbers."),
+    ) -> None:
+        """Show sync statistics."""
+        state: Ctx = ctx.obj
+        payload = as_dict(state.get("/api/stats/raw" if raw else "/api/stats"))
+        if state.out.json_mode:
+            state.out.data(payload)
+            return
+        state.out.kv(_flat_kv(payload), title="Statistics")
+        for key, value in payload.items():
+            block = as_dict(value)
+            if block and all(not isinstance(v, (dict, list)) for v in block.values()):
+                state.out.print()
+                state.out.kv(_flat_kv(block), title=key)

--- a/cli/commands/instance.py
+++ b/cli/commands/instance.py
@@ -1,0 +1,256 @@
+# /cli/commands/instance.py
+# CrossWatch - CLI provider instance and user profile commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import EXIT_NOT_FOUND, EXIT_USAGE, CLIError
+from .._render import state_text
+from .._util import as_dict, coerce_bool, error_text
+
+instance_app = typer.Typer(help="Provider instances, for multi server setups.", no_args_is_help=True)
+profile_app = typer.Typer(help="User profiles.", no_args_is_help=True)
+
+
+def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
+    block = as_dict(payload)
+    for key in keys:
+        found = block.get(key)
+        if isinstance(found, list):
+            return [as_dict(i) for i in found]
+    if isinstance(payload, list):
+        return [as_dict(i) for i in payload]
+    return []
+
+
+def _fields(raw: list[str]) -> dict[str, Any]:
+    body: dict[str, Any] = {}
+    for item in raw or []:
+        key, sep, value = str(item).partition("=")
+        key = key.strip()
+        if not sep or not key:
+            raise CLIError(f"--field expects key=value, got '{item}'", exit_code=EXIT_USAGE)
+        body[key] = value
+    return body
+
+
+@instance_app.command("list")
+def instance_list(
+    ctx: typer.Context,
+    provider: str = typer.Argument("", help="Optional provider to limit to."),
+    configured: bool = typer.Option(False, "--configured", help="Only instances that are configured."),
+) -> None:
+    """List provider instances."""
+    state: Ctx = ctx.obj
+    if provider.strip():
+        payload = state.get(f"/api/provider-instances/{provider.strip().upper()}")
+    else:
+        payload = state.get("/api/provider-instances", params={"configured_only": configured})
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+
+    block = as_dict(payload)
+    rows: list[list[Any]] = []
+    if provider.strip():
+        for item in _rows(payload, "instances", "items"):
+            rows.append(
+                [
+                    provider.strip().upper(),
+                    str(item.get("id") or item.get("instance_id") or "-"),
+                    str(item.get("label") or item.get("name") or "-"),
+                    state_text(coerce_bool(item.get("configured"), False), on="yes", off="no"),
+                ]
+            )
+    else:
+        source = as_dict(block.get("providers")) or block
+        for name in sorted(source):
+            entry = source.get(name)
+            items = entry if isinstance(entry, list) else as_dict(entry).get("instances") or []
+            for item in items:
+                item = as_dict(item)
+                rows.append(
+                    [
+                        str(name).upper(),
+                        str(item.get("id") or item.get("instance_id") or "-"),
+                        str(item.get("label") or item.get("name") or "-"),
+                        state_text(coerce_bool(item.get("configured"), False), on="yes", off="no"),
+                    ]
+                )
+    state.out.table(
+        ["PROVIDER", "INSTANCE", "LABEL", "CONFIGURED"],
+        rows,
+        title="Provider instances",
+        empty="No instances beyond the defaults.",
+    )
+
+
+@instance_app.command("add")
+def instance_add(
+    ctx: typer.Context,
+    provider: str = typer.Argument(..., help="Provider name."),
+    field: list[str] = typer.Option([], "--field", "-F", help="Instance setting as key=value. Repeatable."),
+) -> None:
+    """Add the next instance for a provider."""
+    state: Ctx = ctx.obj
+    state.require_service("Adding a provider instance")
+    result = as_dict(state.post(f"/api/provider-instances/{provider.strip().upper()}/next", json_body=_fields(field)))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success(f"Added {provider.upper()} instance {result.get('instance_id') or result.get('id') or ''}".strip())
+
+
+@instance_app.command("set")
+def instance_set(
+    ctx: typer.Context,
+    provider: str = typer.Argument(..., help="Provider name."),
+    instance_id: str = typer.Argument(..., help="Instance id."),
+    field: list[str] = typer.Option([], "--field", "-F", help="Instance setting as key=value. Repeatable."),
+) -> None:
+    """Update one provider instance."""
+    state: Ctx = ctx.obj
+    state.require_service("Updating a provider instance")
+    body = _fields(field)
+    if not body:
+        raise CLIError("Nothing to change", hint="Pass at least one --field key=value", exit_code=EXIT_USAGE)
+    path = f"/api/provider-instances/{provider.strip().upper()}/{instance_id.strip()}"
+    result = as_dict(state.request("PATCH", path, json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Updated {provider.upper()} instance {instance_id}")
+
+
+@instance_app.command("delete")
+def instance_delete(
+    ctx: typer.Context,
+    provider: str = typer.Argument(..., help="Provider name."),
+    instance_id: str = typer.Argument(..., help="Instance id."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Delete a provider instance."""
+    state: Ctx = ctx.obj
+    state.require_service("Deleting a provider instance")
+    if not yes and not typer.confirm(f"Delete {provider.upper()} instance {instance_id}?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    path = f"/api/provider-instances/{provider.strip().upper()}/{instance_id.strip()}"
+    result = as_dict(state.delete(path))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Delete rejected"), exit_code=EXIT_NOT_FOUND)
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Deleted {provider.upper()} instance {instance_id}")
+
+
+@profile_app.command("list")
+def profile_list(ctx: typer.Context) -> None:
+    """List user profiles."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/user-profiles")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "profiles", "items")
+    state.out.records(
+        rows,
+        [
+            ("ID", lambda r: str(r.get("id") or r.get("profile_id") or "-")),
+            ("NAME", lambda r: str(r.get("name") or r.get("label") or "-")),
+            ("PAIRS", lambda r: str(r.get("pair_count") or len(r.get("pairs") or []) or 0)),
+            ("READ ONLY", lambda r: state_text(coerce_bool(r.get("read_only"), False), on="yes", off="no")),
+        ],
+        title="User profiles",
+        empty="No profiles configured.",
+    )
+
+
+@profile_app.command("show")
+def profile_show(ctx: typer.Context, profile_id: str = typer.Argument(..., help="Profile id.")) -> None:
+    """Show one user profile."""
+    state: Ctx = ctx.obj
+    payload = state.get(f"/api/user-profiles/{profile_id}")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    import json as _json
+
+    from rich.syntax import Syntax
+
+    state.out.console.print(
+        Syntax(_json.dumps(payload, indent=2, default=str), "json", theme="ansi_dark", background_color="default")
+    )
+
+
+@profile_app.command("create")
+def profile_create(
+    ctx: typer.Context,
+    name: str = typer.Argument(..., help="Profile name."),
+    field: list[str] = typer.Option([], "--field", "-F", help="Extra setting as key=value. Repeatable."),
+) -> None:
+    """Create a user profile."""
+    state: Ctx = ctx.obj
+    state.require_service("Creating a user profile")
+    body = {"name": name, **_fields(field)}
+    result = as_dict(state.post("/api/user-profiles", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success(f"Created profile {result.get('id') or name}")
+
+
+@profile_app.command("set")
+def profile_set(
+    ctx: typer.Context,
+    profile_id: str = typer.Argument(..., help="Profile id."),
+    field: list[str] = typer.Option([], "--field", "-F", help="Setting as key=value. Repeatable."),
+) -> None:
+    """Update a user profile."""
+    state: Ctx = ctx.obj
+    state.require_service("Updating a user profile")
+    body = _fields(field)
+    if not body:
+        raise CLIError("Nothing to change", hint="Pass at least one --field key=value", exit_code=EXIT_USAGE)
+    result = as_dict(state.put(f"/api/user-profiles/{profile_id}", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Updated profile {profile_id}")
+
+
+@profile_app.command("delete")
+def profile_delete(
+    ctx: typer.Context,
+    profile_id: str = typer.Argument(..., help="Profile id."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Delete a user profile."""
+    state: Ctx = ctx.obj
+    state.require_service("Deleting a user profile")
+    if not yes and not typer.confirm(f"Delete profile {profile_id}?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(state.delete(f"/api/user-profiles/{profile_id}"))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Delete rejected"), exit_code=EXIT_NOT_FOUND)
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Deleted profile {profile_id}")
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(instance_app, name="instance")
+    app.add_typer(profile_app, name="user-profile")

--- a/cli/commands/logs.py
+++ b/cli/commands/logs.py
@@ -1,0 +1,83 @@
+# /cli/commands/logs.py
+# CrossWatch - CLI log commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import re
+import time
+
+import typer
+
+from .._context import Ctx
+from .._errors import CLIError
+from .._util import is_log_control, strip_ansi
+
+logs_app = typer.Typer(help="Read the CrossWatch log stream.", no_args_is_help=True)
+
+COMMON_TAGS = ("SYNC", "SCHED", "WATCH", "WATCHM", "SCROBBLE", "WEBHOOK", "TRAKT", "SIMKL", "PLEX", "JELLYFIN", "EMBY", "TRBL")
+
+
+@logs_app.command("tail")
+def logs_tail(
+    ctx: typer.Context,
+    tag: str = typer.Option("SYNC", "--tag", "-t", help=f"Log channel. Common ones: {', '.join(COMMON_TAGS)}."),
+    lines: int = typer.Option(200, "--lines", "-n", min=1, max=5000, help="How many past lines to show."),
+    follow: bool = typer.Option(False, "--follow", "-f", help="Keep printing new lines until interrupted."),
+    grep: str = typer.Option("", "--grep", "-g", help="Only print lines matching this regular expression."),
+    timeout: float = typer.Option(0.0, "--timeout", help="Stop following after this many seconds (0 = no limit)."),
+) -> None:
+    """Show recent log output, optionally following it live."""
+    state: Ctx = ctx.obj
+    channel = tag.strip().upper() or "SYNC"
+    pattern = re.compile(grep) if grep.strip() else None
+
+    if not follow:
+        payload = state.get("/api/logs/dump", params={"channel": channel, "n": lines})
+        if not isinstance(payload, dict):
+            raise CLIError("Log endpoint returned an unexpected payload")
+        if state.out.json_mode:
+            state.out.data(payload)
+            return
+        for line in payload.get("lines") or []:
+            text = strip_ansi(str(line))
+            if is_log_control(text):
+                continue
+            if pattern is None or pattern.search(text):
+                state.out.raw(text)
+        return
+
+    state.require_service("Following logs")
+    deadline = time.time() + timeout if timeout > 0 else 0.0
+    client = state.stream_client()
+    try:
+        for event, data in client.stream_sse(
+            "/api/logs/stream", params={"tag": channel, "plain": "true", "tail": lines}
+        ):
+            if event in ("ping", "scope"):
+                if deadline and time.time() > deadline:
+                    return
+                continue
+            text = strip_ansi(data)
+            if text.strip() and not is_log_control(text) and (pattern is None or pattern.search(text)):
+                state.out.raw(text)
+            if deadline and time.time() > deadline:
+                return
+    except KeyboardInterrupt:
+        return
+    finally:
+        client.close()
+
+
+@logs_app.command("channels")
+def logs_channels(ctx: typer.Context) -> None:
+    """List the log channels the CLI knows about."""
+    state: Ctx = ctx.obj
+    if state.out.json_mode:
+        state.out.data(list(COMMON_TAGS))
+        return
+    state.out.table(["CHANNEL"], [[t] for t in COMMON_TAGS], title="Log channels")
+    state.out.info("Any tag the engine emits works, these are just the usual ones.")
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(logs_app, name="logs")

--- a/cli/commands/maintenance.py
+++ b/cli/commands/maintenance.py
@@ -1,0 +1,249 @@
+# /cli/commands/maintenance.py
+# CrossWatch - CLI maintenance commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import EXIT_USAGE, CLIError
+from .._util import as_dict, error_text
+
+maintenance_app = typer.Typer(help="Database health, caches and housekeeping.", no_args_is_help=True)
+
+CACHES = {
+    "all": "/api/maintenance/clear-cache",
+    "metadata": "/api/maintenance/clear-metadata-cache",
+    "provider-sync": "/api/maintenance/clear-provider-sync-cache",
+    "activity-log": "/api/maintenance/clear-activity-log",
+    "scrobbles": "/api/maintenance/clear-recent-scrobbles",
+    "state": "/api/maintenance/clear-state",
+}
+
+
+def _flat(state: Ctx, payload: Any, title: str) -> None:
+    block = as_dict(payload)
+    if state.out.json_mode:
+        state.out.data(block)
+        return
+    state.out.kv(
+        [(key, value) for key, value in block.items() if not isinstance(value, (dict, list))],
+        title=title,
+    )
+    for key, value in block.items():
+        if isinstance(value, dict) and value:
+            state.out.print()
+            state.out.kv(
+                [(k, v) for k, v in value.items() if not isinstance(v, (dict, list))],
+                title=key,
+            )
+
+
+@maintenance_app.command("database")
+def maintenance_database(ctx: typer.Context) -> None:
+    """Check the runtime database."""
+    state: Ctx = ctx.obj
+    _flat(state, state.post("/api/maintenance/database-health"), "Database health")
+
+
+@maintenance_app.command("events")
+def maintenance_events(
+    ctx: typer.Context,
+    optimize: bool = typer.Option(False, "--optimize", help="Optimize the archive."),
+    rebuild: bool = typer.Option(False, "--rebuild", help="Rebuild the archive index."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Check, optimize or rebuild the events archive."""
+    state: Ctx = ctx.obj
+    if optimize and rebuild:
+        raise CLIError("Pick one of --optimize or --rebuild", exit_code=EXIT_USAGE)
+    if rebuild:
+        state.require_service("Rebuilding the events archive")
+        if not yes and not typer.confirm("Rebuild the events index?", default=False):
+            raise CLIError("Cancelled", exit_code=0)
+        _flat(state, state.post("/api/maintenance/events-rebuild"), "Events rebuild")
+        return
+    if optimize:
+        state.require_service("Optimizing the events archive")
+        _flat(state, state.post("/api/maintenance/events-optimize"), "Events optimize")
+        return
+    _flat(state, state.post("/api/maintenance/events-health"), "Events health")
+
+
+@maintenance_app.command("cache")
+def maintenance_cache(
+    ctx: typer.Context,
+    what: str = typer.Argument("all", help=f"One of: {', '.join(sorted(CACHES))}."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Clear a cache."""
+    state: Ctx = ctx.obj
+    state.require_service("Clearing a cache")
+    key = str(what).strip().lower()
+    endpoint = CACHES.get(key)
+    if endpoint is None:
+        raise CLIError(f"Unknown cache '{what}'", hint=f"Try: {', '.join(sorted(CACHES))}", exit_code=EXIT_USAGE)
+    if not yes and not typer.confirm(f"Clear the {key} cache?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(state.post(endpoint))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Clear rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Cleared the {key} cache.")
+
+
+@maintenance_app.command("provider-cache")
+def maintenance_provider_cache(ctx: typer.Context) -> None:
+    """Show what the provider cache holds."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/maintenance/provider-cache")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    block = as_dict(payload)
+    rows = block.get("providers") or block.get("items")
+    if isinstance(rows, list):
+        state.out.records(
+            [as_dict(r) for r in rows],
+            [
+                ("PROVIDER", lambda r: str(r.get("provider") or r.get("name") or "-")),
+                ("ENTRIES", lambda r: str(r.get("entries") or r.get("count") or "-")),
+                ("SIZE", lambda r: str(r.get("size") or r.get("size_bytes") or "-")),
+            ],
+            title="Provider cache",
+        )
+        return
+    _flat(state, payload, "Provider cache")
+
+
+@maintenance_app.command("state-file")
+def maintenance_state_file(
+    ctx: typer.Context,
+    prune: bool = typer.Option(False, "--prune", help="Drop stale entries."),
+    compact: bool = typer.Option(False, "--compact", help="Rewrite the file smaller."),
+) -> None:
+    """Prune or compact state.json."""
+    state: Ctx = ctx.obj
+    state.require_service("Working on the state file")
+    if not prune and not compact:
+        raise CLIError("Pick --prune or --compact", exit_code=EXIT_USAGE)
+    if prune:
+        _flat(state, state.post("/api/maintenance/state-file/prune"), "State file prune")
+    if compact:
+        _flat(state, state.post("/api/maintenance/state-file/compact"), "State file compact")
+
+
+@maintenance_app.command("tracker")
+def maintenance_tracker(
+    ctx: typer.Context,
+    instance: str = typer.Option("default", "--instance", "-i", help="Provider instance id."),
+    clear: bool = typer.Option(False, "--clear", help="Clear the tracker state."),
+    snapshots: bool = typer.Option(False, "--snapshots", help="With --clear, also drop its snapshots."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Show or clear the CrossWatch tracker."""
+    state: Ctx = ctx.obj
+    if not clear:
+        _flat(state, state.get("/api/maintenance/crosswatch-tracker", params={"provider_instance": instance}), "Tracker")
+        return
+    state.require_service("Clearing the tracker")
+    if not yes and not typer.confirm(f"Clear tracker state for {instance}?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    body = {"clear_state": True, "clear_snapshots": bool(snapshots), "provider_instance": instance}
+    result = as_dict(state.post("/api/maintenance/crosswatch-tracker/clear", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Clear rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success("Tracker cleared.")
+
+
+@maintenance_app.command("reset-stats")
+def maintenance_reset_stats(
+    ctx: typer.Context,
+    recalc: bool = typer.Option(False, "--recalc", help="Recalculate instead of only clearing."),
+    purge_reports: bool = typer.Option(False, "--purge-reports", help="Also delete sync reports."),
+    purge_insights: bool = typer.Option(False, "--purge-insights", help="Also delete insights."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Reset the statistics."""
+    state: Ctx = ctx.obj
+    state.require_service("Resetting statistics")
+    if not yes and not typer.confirm("Reset statistics?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    body = {
+        "recalc": bool(recalc),
+        "purge_reports": bool(purge_reports),
+        "purge_insights": bool(purge_insights),
+    }
+    _flat(state, state.post("/api/maintenance/reset-stats", json_body=body), "Statistics reset")
+
+
+@maintenance_app.command("reset-watching")
+def maintenance_reset_watching(ctx: typer.Context) -> None:
+    """Clear the currently watching card."""
+    state: Ctx = ctx.obj
+    state.require_service("Resetting currently watching")
+    result = as_dict(state.post("/api/maintenance/reset-currently-watching"))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Reset rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success("Currently watching cleared.")
+
+
+@maintenance_app.command("support")
+def maintenance_support(
+    ctx: typer.Context,
+    scopes: bool = typer.Option(False, "--scopes", help="List what a support bundle can include."),
+    pairs: str = typer.Option("", "--pairs", "-p", help="Limit to these pair ids, comma separated."),
+) -> None:
+    """Show support diagnostics."""
+    state: Ctx = ctx.obj
+    if scopes:
+        payload = state.get("/api/maintenance/support/scopes")
+        if state.out.json_mode:
+            state.out.data(payload)
+            return
+        block = as_dict(payload)
+        rows = block.get("scopes") or block.get("items")
+        if isinstance(rows, list):
+            state.out.table(["SCOPE"], [[str(r)] for r in rows], title="Support scopes")
+            return
+        _flat(state, payload, "Support scopes")
+        return
+    params = {"pairs": [p.strip() for p in pairs.split(",") if p.strip()]} if pairs.strip() else None
+    _flat(state, state.get("/api/maintenance/support/state", params=params), "Support state")
+
+
+@maintenance_app.command("restart")
+def maintenance_restart(
+    ctx: typer.Context,
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Restart the CrossWatch service."""
+    state: Ctx = ctx.obj
+    state.require_service("Restarting CrossWatch")
+    if not yes:
+        state.out.warn("This restarts the running service.")
+        if not typer.confirm("Restart now?", default=False):
+            raise CLIError("Cancelled", exit_code=0)
+    try:
+        state.post("/api/maintenance/restart")
+    except CLIError as err:
+        if int(getattr(err, "status", 0) or 0) or "Cannot reach" not in err.message:
+            raise
+    if state.out.json_mode:
+        state.out.data({"ok": True, "restarting": True})
+        return
+    state.out.success("Restart requested.")
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(maintenance_app, name="maintenance")

--- a/cli/commands/metadata.py
+++ b/cli/commands/metadata.py
@@ -1,0 +1,182 @@
+# /cli/commands/metadata.py
+# CrossWatch - CLI metadata and manual entry commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import EXIT_USAGE, CLIError
+from .._util import as_dict, error_text
+
+metadata_app = typer.Typer(help="Look up titles and ids.", no_args_is_help=True)
+manual_app = typer.Typer(help="Record a watch by hand.", no_args_is_help=True)
+
+
+def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
+    block = as_dict(payload)
+    for key in keys:
+        found = block.get(key)
+        if isinstance(found, list):
+            return [as_dict(i) for i in found]
+    if isinstance(payload, list):
+        return [as_dict(i) for i in payload]
+    return []
+
+
+def _ids(row: dict[str, Any]) -> str:
+    ids = as_dict(row.get("ids"))
+    if not ids:
+        ids = {k: v for k, v in row.items() if k in ("imdb", "tmdb", "tvdb", "trakt", "simkl", "anidb")}
+    return ", ".join(f"{k}:{v}" for k, v in ids.items() if v)[:50] or "-"
+
+
+@metadata_app.command("search")
+def metadata_search(
+    ctx: typer.Context,
+    query: str = typer.Argument(..., help="Title to search for."),
+    media_type: str = typer.Option("movie", "--type", "-t", help="movie or tv."),
+    year: int = typer.Option(0, "--year", "-y", help="Release year."),
+    limit: int = typer.Option(10, "--limit", "-n", help="Maximum rows."),
+) -> None:
+    """Search for a title."""
+    state: Ctx = ctx.obj
+    params: dict[str, Any] = {"q": query, "typ": media_type, "limit": limit}
+    if year:
+        params["year"] = year
+    payload = state.get("/api/metadata/search", params=params)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "results", "items")
+    state.out.records(
+        rows,
+        [
+            ("TITLE", lambda r: str(r.get("title") or r.get("name") or "-")[:40]),
+            ("YEAR", lambda r: str(r.get("year") or "-")),
+            ("TYPE", lambda r: str(r.get("type") or media_type)),
+            ("IDS", _ids),
+        ],
+        title=f"Results for {query}",
+        empty="Nothing found.",
+    )
+
+
+@metadata_app.command("resolve")
+def metadata_resolve(
+    ctx: typer.Context,
+    ids: list[str] = typer.Argument(..., help="Ids as key=value, for example imdb=tt0111161."),
+    media_type: str = typer.Option("movie", "--type", "-t", help="movie or tv."),
+) -> None:
+    """Resolve ids to a canonical item."""
+    state: Ctx = ctx.obj
+    parsed: dict[str, Any] = {}
+    for item in ids:
+        key, sep, value = str(item).partition("=")
+        if not sep or not key.strip():
+            raise CLIError(f"Ids are key=value, got '{item}'", exit_code=EXIT_USAGE)
+        parsed[key.strip()] = value
+    payload = state.post("/api/metadata/resolve", json_body={"ids": parsed, "type": media_type})
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    import json as _json
+
+    from rich.syntax import Syntax
+
+    state.out.console.print(
+        Syntax(_json.dumps(payload, indent=2, default=str), "json", theme="ansi_dark", background_color="default")
+    )
+
+
+@metadata_app.command("providers")
+def metadata_providers(ctx: typer.Context) -> None:
+    """Show which metadata providers are available."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/metadata/providers")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "providers", "items")
+    if rows:
+        state.out.records(
+            rows,
+            [
+                ("PROVIDER", lambda r: str(r.get("name") or r.get("provider") or "-")),
+                ("ENABLED", lambda r: str(r.get("enabled"))),
+                ("NOTE", lambda r: str(r.get("note") or r.get("label") or "-")[:44]),
+            ],
+            title="Metadata providers",
+        )
+        return
+    block = as_dict(payload)
+    state.out.kv([(k, v) for k, v in block.items() if not isinstance(v, (dict, list))], title="Metadata providers")
+
+
+@manual_app.command("providers")
+def manual_providers(ctx: typer.Context) -> None:
+    """Show which providers accept a manual watch."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/manual/providers")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "providers", "items")
+    if rows:
+        state.out.records(
+            rows,
+            [
+                ("PROVIDER", lambda r: str(r.get("name") or r.get("provider") or "-")),
+                ("INSTANCE", lambda r: str(r.get("instance") or "-")),
+            ],
+            title="Manual entry targets",
+        )
+        return
+    block = as_dict(payload)
+    names = block.get("providers")
+    if isinstance(names, list):
+        state.out.table(["PROVIDER"], [[str(n)] for n in names], title="Manual entry targets")
+        return
+    state.out.kv([(k, v) for k, v in block.items() if not isinstance(v, (dict, list))], title="Manual entry targets")
+
+
+@manual_app.command("watched")
+def manual_watched(
+    ctx: typer.Context,
+    field: list[str] = typer.Option([], "--field", "-F", help="Item detail as key=value. Repeatable."),
+    provider: str = typer.Option("", "--provider", "-p", help="Where to record it."),
+    watched_at: str = typer.Option("", "--at", help="ISO timestamp. Defaults to now."),
+) -> None:
+    """Record a watch by hand."""
+    state: Ctx = ctx.obj
+    state.require_service("Recording a manual watch")
+    body: dict[str, Any] = {}
+    for item in field:
+        key, sep, value = str(item).partition("=")
+        if not sep or not key.strip():
+            raise CLIError(f"--field expects key=value, got '{item}'", exit_code=EXIT_USAGE)
+        body[key.strip()] = value
+    if not body:
+        raise CLIError(
+            "Nothing to record",
+            hint="For example --field imdb=tt0111161 --field type=movie",
+            exit_code=EXIT_USAGE,
+        )
+    if provider.strip():
+        body["provider"] = provider.strip().upper()
+    if watched_at.strip():
+        body["watched_at"] = watched_at.strip()
+    result = as_dict(state.post("/api/manual/watched", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success("Recorded.")
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(metadata_app, name="metadata")
+    app.add_typer(manual_app, name="manual")

--- a/cli/commands/pair.py
+++ b/cli/commands/pair.py
@@ -1,0 +1,257 @@
+# /cli/commands/pair.py
+# CrossWatch - CLI sync pair commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import EXIT_USAGE, CLIError
+from .._render import state_text
+from .._util import as_dict, coerce_bool, error_text, find_pair, pair_features, pair_label
+
+pair_app = typer.Typer(help="Inspect and toggle sync pairs.", no_args_is_help=True)
+
+
+def _pairs(state: Ctx) -> list[dict[str, Any]]:
+    payload = state.get("/api/pairs")
+    if isinstance(payload, dict) and payload.get("ok") is False:
+        raise CLIError(error_text(payload, "Cannot read pairs"))
+    if not isinstance(payload, list):
+        return []
+    return [p for p in payload if isinstance(p, dict)]
+
+
+def _set_enabled(state: Ctx, target: str, enabled: bool) -> dict[str, Any]:
+    pair = find_pair(_pairs(state), target)
+    pair_id = str(pair.get("id") or "")
+    result = state.put(f"/api/pairs/{pair_id}", json_body={"enabled": bool(enabled)})
+    if isinstance(result, dict) and result.get("ok") is False:
+        raise CLIError(error_text(result, "Update rejected"))
+    return pair
+
+
+@pair_app.command("list")
+def pair_list(
+    ctx: typer.Context,
+    enabled_only: bool = typer.Option(False, "--enabled", help="Only show enabled pairs."),
+) -> None:
+    """List configured sync pairs."""
+    state: Ctx = ctx.obj
+    pairs = _pairs(state)
+    if enabled_only:
+        pairs = [p for p in pairs if p.get("enabled", True) is not False]
+    if state.out.json_mode:
+        state.out.data(pairs)
+        return
+    state.out.table(
+        ["ID", "PAIR", "MODE", "STATE", "FEATURES"],
+        [
+            [
+                str(p.get("id") or ""),
+                pair_label(p),
+                str(p.get("mode") or "one-way"),
+                state_text(p.get("enabled", True) is not False, on="enabled", off="disabled"),
+                ", ".join(pair_features(p)) or "-",
+            ]
+            for p in pairs
+        ],
+        title="Sync pairs",
+        empty="No pairs configured yet.",
+    )
+
+
+@pair_app.command("create")
+def pair_create(
+    ctx: typer.Context,
+    source: str = typer.Argument(..., help="Source provider, for example PLEX."),
+    target: str = typer.Argument(..., help="Target provider, for example TRAKT."),
+    mode: str = typer.Option("one-way", "--mode", "-m", help="one-way or two-way."),
+    feature: list[str] = typer.Option([], "--feature", "-F", help="Enable a feature. Repeatable."),
+    source_instance: str = typer.Option("", "--source-instance", help="Source instance id."),
+    target_instance: str = typer.Option("", "--target-instance", help="Target instance id."),
+    profile: str = typer.Option("", "--profile", help="User profile id."),
+    disabled: bool = typer.Option(False, "--disabled", help="Create it switched off."),
+) -> None:
+    """Create a sync pair."""
+    state: Ctx = ctx.obj
+    wanted = str(mode).strip().lower()
+    if wanted not in ("one-way", "two-way"):
+        raise CLIError(f"Unknown mode '{mode}'", hint="Use one-way or two-way.", exit_code=EXIT_USAGE)
+
+    body: dict[str, Any] = {
+        "source": str(source).strip().upper(),
+        "target": str(target).strip().upper(),
+        "mode": wanted,
+        "enabled": not disabled,
+    }
+    if feature:
+        body["features"] = {str(f).strip().lower(): {"enable": True} for f in feature if str(f).strip()}
+    if source_instance.strip():
+        body["source_instance"] = source_instance.strip()
+    if target_instance.strip():
+        body["target_instance"] = target_instance.strip()
+    if profile.strip():
+        body["profile_id"] = profile.strip()
+
+    result = as_dict(state.post("/api/pairs", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Pair was rejected"))
+    pair_id = str(result.get("id") or "")
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success(f"Created {body['source']} {'<->' if wanted == 'two-way' else '->'} {body['target']} ({pair_id})")
+    try:
+        created = find_pair(_pairs(state), pair_id)
+    except CLIError:
+        return
+    enabled = pair_features(created)
+    if enabled:
+        state.out.info(f"Features on: {', '.join(enabled)}")
+    else:
+        state.out.info(f"No features enabled. Turn one on with 'cw pair feature {pair_id} watchlist on'.")
+
+
+@pair_app.command("reorder")
+def pair_reorder(
+    ctx: typer.Context,
+    pair_ids: list[str] = typer.Argument(..., help="Pair ids in the order you want them."),
+) -> None:
+    """Set the order pairs run in."""
+    state: Ctx = ctx.obj
+    pairs = _pairs(state)
+    resolved = [str(find_pair(pairs, p).get("id") or "") for p in pair_ids]
+    known = {str(p.get("id") or "") for p in pairs}
+    missing = sorted(known - set(resolved))
+    if missing:
+        raise CLIError(
+            "Every pair must be listed when reordering",
+            hint=f"Missing: {', '.join(missing)}",
+            exit_code=EXIT_USAGE,
+        )
+    result = as_dict(state.post("/api/pairs/reorder", json_body=resolved))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Reorder rejected"))
+    if state.out.json_mode:
+        state.out.data({"ok": True, "order": resolved})
+        return
+    state.out.success("Order updated.")
+
+
+@pair_app.command("show")
+def pair_show(ctx: typer.Context, pair_id: str = typer.Argument(..., help="Pair id or prefix.")) -> None:
+    """Show one pair in full."""
+    state: Ctx = ctx.obj
+    pair = find_pair(_pairs(state), pair_id)
+    if state.out.json_mode:
+        state.out.data(pair)
+        return
+    state.out.kv(
+        [
+            ("Id", str(pair.get("id") or "")),
+            ("Route", pair_label(pair)),
+            ("Mode", str(pair.get("mode") or "one-way")),
+            ("Enabled", state_text(pair.get("enabled", True) is not False, on="yes", off="no")),
+            ("Source instance", str(pair.get("source_instance") or "default")),
+            ("Target instance", str(pair.get("target_instance") or "default")),
+            ("Profile", str(pair.get("profile_id") or "-")),
+        ],
+        title=pair_label(pair),
+    )
+    features = as_dict(pair.get("features"))
+    rows: list[list[Any]] = []
+    for name in sorted(features):
+        block = features.get(name)
+        if isinstance(block, dict):
+            enabled = coerce_bool(block.get("enable", block.get("enabled")), False)
+            extras = {k: v for k, v in block.items() if k not in ("enable", "enabled")}
+            rows.append([name, state_text(enabled, on="on", off="off"), json.dumps(extras, default=str) if extras else "-"])
+        else:
+            rows.append([name, state_text(coerce_bool(block, False), on="on", off="off"), "-"])
+    if rows:
+        state.out.print()
+        state.out.table(["FEATURE", "STATE", "OPTIONS"], rows, title="Features")
+
+
+@pair_app.command("enable")
+def pair_enable(ctx: typer.Context, pair_id: str = typer.Argument(..., help="Pair id or prefix.")) -> None:
+    """Enable a pair."""
+    state: Ctx = ctx.obj
+    pair = _set_enabled(state, pair_id, True)
+    if state.out.json_mode:
+        state.out.data({"ok": True, "id": pair.get("id"), "enabled": True})
+        return
+    state.out.success(f"Enabled {pair_label(pair)} ({pair.get('id')})")
+
+
+@pair_app.command("disable")
+def pair_disable(ctx: typer.Context, pair_id: str = typer.Argument(..., help="Pair id or prefix.")) -> None:
+    """Disable a pair."""
+    state: Ctx = ctx.obj
+    pair = _set_enabled(state, pair_id, False)
+    if state.out.json_mode:
+        state.out.data({"ok": True, "id": pair.get("id"), "enabled": False})
+        return
+    state.out.success(f"Disabled {pair_label(pair)} ({pair.get('id')})")
+
+
+@pair_app.command("feature")
+def pair_feature(
+    ctx: typer.Context,
+    pair_id: str = typer.Argument(..., help="Pair id or prefix."),
+    feature: str = typer.Argument(..., help="Feature name, for example watchlist, ratings, history, playlists."),
+    value: str = typer.Argument(..., help="on or off."),
+) -> None:
+    """Turn one feature of a pair on or off."""
+    state: Ctx = ctx.obj
+    pair = find_pair(_pairs(state), pair_id)
+    features = dict(pair.get("features") or {})
+    key = str(feature).strip().lower()
+    if key not in features:
+        known = ", ".join(sorted(features)) or "none"
+        raise CLIError(f"Pair has no feature '{key}'", hint=f"Known features: {known}", exit_code=EXIT_USAGE)
+    flag = coerce_bool(value, False)
+    block = features.get(key)
+    if isinstance(block, dict):
+        block = dict(block)
+        block["enable"] = flag
+        features[key] = block
+    else:
+        features[key] = flag
+    result = state.put(f"/api/pairs/{pair.get('id')}", json_body={"features": features})
+    if isinstance(result, dict) and result.get("ok") is False:
+        raise CLIError(error_text(result, "Update rejected"))
+    if state.out.json_mode:
+        state.out.data({"ok": True, "id": pair.get("id"), "feature": key, "enabled": flag})
+        return
+    state.out.success(f"{pair_label(pair)}: {key} is now {'on' if flag else 'off'}")
+
+
+@pair_app.command("delete")
+def pair_delete(
+    ctx: typer.Context,
+    pair_id: str = typer.Argument(..., help="Pair id or prefix."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Delete a pair."""
+    state: Ctx = ctx.obj
+    pair = find_pair(_pairs(state), pair_id)
+    if not yes:
+        state.out.print(f"About to delete [cw.accent]{pair_label(pair)}[/] ({pair.get('id')})")
+        if not typer.confirm("Delete this pair?", default=False):
+            raise CLIError("Cancelled", exit_code=0)
+    result = state.delete(f"/api/pairs/{pair.get('id')}")
+    if isinstance(result, dict) and result.get("ok") is False:
+        raise CLIError(error_text(result, "Delete rejected"))
+    if state.out.json_mode:
+        state.out.data({"ok": True, "deleted": pair.get("id")})
+        return
+    state.out.success(f"Deleted {pair_label(pair)} ({pair.get('id')})")
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(pair_app, name="pair")

--- a/cli/commands/playlist.py
+++ b/cli/commands/playlist.py
@@ -1,0 +1,405 @@
+# /cli/commands/playlist.py
+# CrossWatch - CLI playlist commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import EXIT_USAGE, CLIError
+from .._render import state_text
+from .._util import as_dict, coerce_bool, error_text, fmt_ts
+
+playlist_app = typer.Typer(help="Playlist endpoints, mappings and rulesets.", no_args_is_help=True)
+endpoint_app = typer.Typer(help="Playlist endpoints.", no_args_is_help=True)
+mapping_app = typer.Typer(help="Playlist mappings.", no_args_is_help=True)
+ruleset_app = typer.Typer(help="Playlist rulesets.", no_args_is_help=True)
+
+
+def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
+    block = as_dict(payload)
+    for key in keys:
+        found = block.get(key)
+        if isinstance(found, list):
+            return [as_dict(i) for i in found]
+    if isinstance(payload, list):
+        return [as_dict(i) for i in payload]
+    return []
+
+
+def _fields(raw: list[str]) -> dict[str, Any]:
+    body: dict[str, Any] = {}
+    for item in raw or []:
+        key, sep, value = str(item).partition("=")
+        key = key.strip()
+        if not sep or not key:
+            raise CLIError(f"--field expects key=value, got '{item}'", exit_code=EXIT_USAGE)
+        body[key] = value
+    return body
+
+
+@playlist_app.command("overview")
+def playlist_overview(ctx: typer.Context) -> None:
+    """Show the playlist setup."""
+    state: Ctx = ctx.obj
+    payload = as_dict(state.get("/api/playlists/overview"))
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    state.out.kv(
+        [(key, value) for key, value in payload.items() if not isinstance(value, (dict, list))],
+        title="Playlists",
+    )
+
+
+@playlist_app.command("providers")
+def playlist_providers(ctx: typer.Context) -> None:
+    """Show which providers can hold playlists."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/playlists/providers")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "providers", "items")
+    if rows:
+        state.out.records(
+            rows,
+            [
+                ("PROVIDER", lambda r: str(r.get("name") or r.get("provider") or "-")),
+                ("INSTANCE", lambda r: str(r.get("instance") or "-")),
+            ],
+            title="Playlist providers",
+        )
+        return
+    block = as_dict(payload)
+    names = block.get("providers")
+    if isinstance(names, list):
+        state.out.table(["PROVIDER"], [[str(n)] for n in names], title="Playlist providers")
+        return
+    state.out.kv([(k, v) for k, v in block.items() if not isinstance(v, (dict, list))], title="Playlist providers")
+
+
+@playlist_app.command("resources")
+def playlist_resources(
+    ctx: typer.Context,
+    provider: str = typer.Argument(..., help="Provider name."),
+    instance: str = typer.Option("", "--instance", "-i", help="Provider instance id."),
+) -> None:
+    """List the playlists a provider holds."""
+    state: Ctx = ctx.obj
+    params: dict[str, Any] = {"provider": provider.strip().upper()}
+    if instance.strip():
+        params["instance"] = instance.strip()
+    payload = state.get("/api/playlists/resources", params=params)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "resources", "items", "playlists")
+    state.out.records(
+        rows,
+        [
+            ("ID", lambda r: str(r.get("id") or r.get("key") or "-")[:24]),
+            ("NAME", lambda r: str(r.get("name") or r.get("title") or "-")[:40]),
+            ("ITEMS", lambda r: str(r.get("count") or r.get("items") or "-")),
+        ],
+        title=f"{provider.upper()} playlists",
+        empty="No playlists there.",
+    )
+
+
+@playlist_app.command("activity")
+def playlist_activity(ctx: typer.Context) -> None:
+    """Show recent playlist runs."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/playlists/activity")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "activity", "items", "runs")
+    state.out.records(
+        rows,
+        [
+            ("WHEN", lambda r: fmt_ts(r.get("ts") or r.get("created_at") or r.get("finished_at"))),
+            ("MAPPING", lambda r: str(r.get("mapping") or r.get("mapping_id") or "-")[:24]),
+            ("RESULT", lambda r: str(r.get("result") or r.get("status") or "-")),
+            ("CHANGES", lambda r: str(r.get("changes") or r.get("added") or "-")),
+        ],
+        title="Playlist activity",
+        empty="No playlist runs yet.",
+    )
+
+
+@endpoint_app.command("list")
+def endpoint_list(ctx: typer.Context) -> None:
+    """List playlist endpoints."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/playlists/endpoints")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "endpoints", "items")
+    state.out.records(
+        rows,
+        [
+            ("ID", lambda r: str(r.get("id") or "-")),
+            ("NAME", lambda r: str(r.get("name") or r.get("label") or "-")[:32]),
+            ("PROVIDER", lambda r: str(r.get("provider") or "-")),
+            ("ENABLED", lambda r: state_text(coerce_bool(r.get("enabled"), True), on="yes", off="no")),
+        ],
+        title="Playlist endpoints",
+        empty="No endpoints configured.",
+    )
+
+
+@endpoint_app.command("add")
+def endpoint_add(
+    ctx: typer.Context,
+    field: list[str] = typer.Option([], "--field", "-F", help="Endpoint setting as key=value. Repeatable."),
+) -> None:
+    """Add a playlist endpoint."""
+    state: Ctx = ctx.obj
+    state.require_service("Adding a playlist endpoint")
+    body = _fields(field)
+    if not body:
+        raise CLIError("An endpoint needs fields", hint="For example --field provider=PLEX --field name=Favourites", exit_code=EXIT_USAGE)
+    result = as_dict(state.post("/api/playlists/endpoints", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success(f"Endpoint added{': ' + str(result.get('id')) if result.get('id') else '.'}")
+
+
+@endpoint_app.command("sync")
+def endpoint_sync(
+    ctx: typer.Context,
+    endpoint_id: str = typer.Argument(..., help="Endpoint id."),
+) -> None:
+    """Refresh one endpoint from its provider."""
+    state: Ctx = ctx.obj
+    state.require_service("Syncing a playlist endpoint")
+    result = as_dict(state.post(f"/api/playlists/endpoints/{endpoint_id}/sync"))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Endpoint {endpoint_id} synced.")
+
+
+@endpoint_app.command("delete")
+def endpoint_delete(
+    ctx: typer.Context,
+    endpoint_id: str = typer.Argument(..., help="Endpoint id."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Delete a playlist endpoint."""
+    state: Ctx = ctx.obj
+    state.require_service("Deleting a playlist endpoint")
+    if not yes and not typer.confirm(f"Delete endpoint {endpoint_id}?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(state.delete(f"/api/playlists/endpoints/{endpoint_id}"))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Delete rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Deleted endpoint {endpoint_id}")
+
+
+@mapping_app.command("list")
+def mapping_list(
+    ctx: typer.Context,
+    pair: str = typer.Option("", "--pair", "-p", help="Only mappings for this pair id."),
+) -> None:
+    """List playlist mappings."""
+    state: Ctx = ctx.obj
+    path = f"/api/playlists/pairs/{pair.strip()}/mappings" if pair.strip() else "/api/playlists/mappings"
+    payload = state.get(path)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "mappings", "items")
+    state.out.records(
+        rows,
+        [
+            ("ID", lambda r: str(r.get("id") or "-")),
+            ("NAME", lambda r: str(r.get("name") or r.get("label") or "-")[:30]),
+            ("SOURCE", lambda r: str(r.get("source") or "-")),
+            ("TARGET", lambda r: str(r.get("target") or "-")),
+            ("ENABLED", lambda r: state_text(coerce_bool(r.get("enabled"), True), on="yes", off="no")),
+        ],
+        title="Playlist mappings",
+        empty="No mappings configured.",
+    )
+
+
+@mapping_app.command("add")
+def mapping_add(
+    ctx: typer.Context,
+    field: list[str] = typer.Option([], "--field", "-F", help="Mapping setting as key=value. Repeatable."),
+) -> None:
+    """Add a playlist mapping."""
+    state: Ctx = ctx.obj
+    state.require_service("Adding a playlist mapping")
+    body = _fields(field)
+    if not body:
+        raise CLIError("A mapping needs fields", hint="See 'cw playlist endpoint list' for ids", exit_code=EXIT_USAGE)
+    result = as_dict(state.post("/api/playlists/mappings", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success(f"Mapping added{': ' + str(result.get('id')) if result.get('id') else '.'}")
+
+
+@mapping_app.command("run")
+def mapping_run(
+    ctx: typer.Context,
+    mapping_id: str = typer.Argument(..., help="Mapping id."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Report what would change, change nothing."),
+) -> None:
+    """Run one playlist mapping."""
+    state: Ctx = ctx.obj
+    state.require_service("Running a playlist mapping")
+    result = as_dict(state.post(f"/api/playlists/mappings/{mapping_id}/run", params={"dry_run": dry_run}))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Run rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success("Dry run finished." if dry_run else "Mapping run finished.")
+    for key in ("added", "removed", "updated", "skipped", "errors"):
+        if key in result:
+            state.out.info(f"{key}: {result.get(key)}")
+
+
+@mapping_app.command("preview")
+def mapping_preview(
+    ctx: typer.Context,
+    mapping_id: str = typer.Argument(..., help="Mapping id."),
+) -> None:
+    """Preview what a mapping would produce."""
+    state: Ctx = ctx.obj
+    payload = state.post(f"/api/playlists/mappings/{mapping_id}/preview")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "items", "preview")
+    state.out.records(
+        rows[:50],
+        [
+            ("TITLE", lambda r: str(r.get("title") or r.get("key") or "-")[:44]),
+            ("TYPE", lambda r: str(r.get("type") or "-")),
+            ("ACTION", lambda r: str(r.get("action") or r.get("change") or "-")),
+        ],
+        title=f"Preview {mapping_id}",
+        empty="Nothing would change.",
+    )
+
+
+@mapping_app.command("result")
+def mapping_result(
+    ctx: typer.Context,
+    mapping_id: str = typer.Argument(..., help="Mapping id."),
+) -> None:
+    """Show the last result for a mapping."""
+    state: Ctx = ctx.obj
+    payload = state.get(f"/api/playlists/mappings/{mapping_id}/result")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    block = as_dict(payload)
+    state.out.kv(
+        [(key, value) for key, value in block.items() if not isinstance(value, (dict, list))],
+        title=f"Mapping {mapping_id}",
+    )
+
+
+@mapping_app.command("delete")
+def mapping_delete(
+    ctx: typer.Context,
+    mapping_id: str = typer.Argument(..., help="Mapping id."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Delete a playlist mapping."""
+    state: Ctx = ctx.obj
+    state.require_service("Deleting a playlist mapping")
+    if not yes and not typer.confirm(f"Delete mapping {mapping_id}?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(state.delete(f"/api/playlists/mappings/{mapping_id}"))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Delete rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Deleted mapping {mapping_id}")
+
+
+@ruleset_app.command("list")
+def ruleset_list(ctx: typer.Context) -> None:
+    """List playlist rulesets."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/playlists/rulesets")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "rulesets", "items")
+    state.out.records(
+        rows,
+        [
+            ("ID", lambda r: str(r.get("id") or "-")),
+            ("NAME", lambda r: str(r.get("name") or "-")[:34]),
+            ("RULES", lambda r: str(len(r.get("rules") or []) or r.get("rule_count") or 0)),
+        ],
+        title="Rulesets",
+        empty="No rulesets.",
+    )
+
+
+@ruleset_app.command("show")
+def ruleset_show(ctx: typer.Context, ruleset_id: str = typer.Argument(..., help="Ruleset id.")) -> None:
+    """Show one ruleset."""
+    state: Ctx = ctx.obj
+    payload = state.get(f"/api/playlists/rulesets/{ruleset_id}")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    import json as _json
+
+    from rich.syntax import Syntax
+
+    state.out.console.print(
+        Syntax(_json.dumps(payload, indent=2, default=str), "json", theme="ansi_dark", background_color="default")
+    )
+
+
+@ruleset_app.command("delete")
+def ruleset_delete(
+    ctx: typer.Context,
+    ruleset_id: str = typer.Argument(..., help="Ruleset id."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Delete a ruleset."""
+    state: Ctx = ctx.obj
+    state.require_service("Deleting a ruleset")
+    if not yes and not typer.confirm(f"Delete ruleset {ruleset_id}?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(state.delete(f"/api/playlists/rulesets/{ruleset_id}"))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Delete rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Deleted ruleset {ruleset_id}")
+
+
+def register(app: typer.Typer) -> None:
+    playlist_app.add_typer(endpoint_app, name="endpoint")
+    playlist_app.add_typer(mapping_app, name="mapping")
+    playlist_app.add_typer(ruleset_app, name="ruleset")
+    app.add_typer(playlist_app, name="playlist")

--- a/cli/commands/progress.py
+++ b/cli/commands/progress.py
@@ -1,0 +1,184 @@
+# /cli/commands/progress.py
+# CrossWatch - CLI playback progress commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import CLIError
+from .._util import as_dict, error_text, fmt_ts
+
+progress_app = typer.Typer(help="Unfinished playback across providers.", no_args_is_help=True)
+
+
+def _rows(payload: Any) -> list[dict[str, Any]]:
+    block = as_dict(payload)
+    for key in ("items", "rows", "results"):
+        found = block.get(key)
+        if isinstance(found, list):
+            return [as_dict(i) for i in found]
+    if isinstance(payload, list):
+        return [as_dict(i) for i in payload]
+    return []
+
+
+def _percent(row: dict[str, Any]) -> str:
+    value = row.get("progress")
+    if value is None:
+        value = row.get("percent")
+    if value is None:
+        return "-"
+    try:
+        return f"{float(value):.0f}%"
+    except Exception:
+        return "-"
+
+
+@progress_app.command("list")
+def progress_list(
+    ctx: typer.Context,
+    provider: str = typer.Option("", "--provider", "-p", help="Limit to one provider."),
+    instance: str = typer.Option("", "--instance", "-i", help="Provider instance id."),
+    media_type: str = typer.Option("", "--type", "-t", help="movie or episode."),
+    minimum: float = typer.Option(0.0, "--min", help="Only items at or above this percent."),
+    maximum: float = typer.Option(0.0, "--max", help="Only items at or below this percent."),
+    limit: int = typer.Option(50, "--limit", "-n", help="Maximum rows."),
+) -> None:
+    """List unfinished playback."""
+    state: Ctx = ctx.obj
+    params: dict[str, Any] = {}
+    if provider.strip():
+        params["provider"] = provider.strip().upper()
+    if instance.strip():
+        params["instance_id"] = instance.strip()
+    if media_type.strip():
+        params["media_type"] = media_type.strip().lower()
+    if minimum:
+        params["progress_min"] = minimum
+    if maximum:
+        params["progress_max"] = maximum
+    payload = state.get("/api/playback_progress/items", params=params or None)
+    rows = _rows(payload)
+    if state.out.json_mode:
+        state.out.data(rows)
+        return
+    state.out.records(
+        rows[: max(1, limit)],
+        [
+            ("KEY", lambda r: str(r.get("key") or r.get("id") or "-")[:26]),
+            ("TITLE", lambda r: str(r.get("title") or "-")[:40]),
+            ("TYPE", lambda r: str(r.get("media_type") or r.get("type") or "-")),
+            ("PROVIDER", lambda r: str(r.get("provider") or "-")),
+            ("PROGRESS", _percent),
+            ("WATCHED", lambda r: fmt_ts(r.get("updated_at") or r.get("last_played_at") or r.get("ts"))),
+        ],
+        title=f"In progress ({len(rows)})",
+        empty="Nothing part watched.",
+    )
+
+
+@progress_app.command("providers")
+def progress_providers(ctx: typer.Context) -> None:
+    """Show which providers report playback progress."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/playback_progress/providers", params={"user_profile": ""})
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload) or [as_dict(p) for p in (as_dict(payload).get("providers") or [])]
+    state.out.records(
+        rows,
+        [
+            ("PROVIDER", lambda r: str(r.get("provider") or r.get("name") or "-")),
+            ("INSTANCE", lambda r: str(r.get("instance") or r.get("instance_id") or "-")),
+            ("ITEMS", lambda r: str(r.get("count") or r.get("items") or "-")),
+        ],
+        title="Progress providers",
+        empty="No providers report progress.",
+    )
+
+
+@progress_app.command("settings")
+def progress_settings(ctx: typer.Context) -> None:
+    """Show the playback progress settings."""
+    state: Ctx = ctx.obj
+    payload = as_dict(state.get("/api/playback_progress/settings", params={"user_profile": ""}))
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    state.out.kv(
+        [(key, value) for key, value in payload.items() if not isinstance(value, (dict, list))],
+        title="Playback progress settings",
+    )
+
+
+def _act(state: Ctx, path: str, keys: list[str], extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    body: dict[str, Any] = {"keys": keys}
+    if len(keys) == 1:
+        body["key"] = keys[0]
+    body.update(extra or {})
+    result = as_dict(state.post(path, json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Rejected"))
+    return result
+
+
+@progress_app.command("watched")
+def progress_watched(
+    ctx: typer.Context,
+    keys: list[str] = typer.Argument(..., help="Item keys from 'cw progress list'."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Mark part watched items as fully watched."""
+    state: Ctx = ctx.obj
+    state.require_service("Marking playback watched")
+    wanted = [k.strip() for k in keys if k.strip()]
+    if not yes and not typer.confirm(f"Mark {len(wanted)} item(s) watched?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = _act(state, "/api/playback_progress/actions/mark_watched", wanted)
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Marked {len(wanted)} item(s) watched.")
+
+
+@progress_app.command("remove")
+def progress_remove(
+    ctx: typer.Context,
+    keys: list[str] = typer.Argument(..., help="Item keys from 'cw progress list'."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Drop playback progress for these items."""
+    state: Ctx = ctx.obj
+    state.require_service("Removing playback progress")
+    wanted = [k.strip() for k in keys if k.strip()]
+    if not yes and not typer.confirm(f"Remove progress for {len(wanted)} item(s)?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = _act(state, "/api/playback_progress/actions/remove", wanted)
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Removed progress for {len(wanted)} item(s).")
+
+
+@progress_app.command("set")
+def progress_set(
+    ctx: typer.Context,
+    key: str = typer.Argument(..., help="Item key."),
+    percent: float = typer.Argument(..., help="New progress percent."),
+) -> None:
+    """Set the progress percent for one item."""
+    state: Ctx = ctx.obj
+    state.require_service("Updating playback progress")
+    result = _act(state, "/api/playback_progress/actions/update_progress", [key], {"progress": float(percent)})
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"{key} is now at {percent:g}%")
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(progress_app, name="progress")

--- a/cli/commands/scheduler.py
+++ b/cli/commands/scheduler.py
@@ -1,0 +1,178 @@
+# /cli/commands/scheduler.py
+# CrossWatch - CLI scheduler commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import CLIError
+from .._render import state_text
+from .._util import as_dict, coerce_bool, error_text, fmt_rel, fmt_ts
+
+scheduler_app = typer.Typer(help="Inspect and drive the sync scheduler.", no_args_is_help=True)
+
+
+def _status(state: Ctx) -> dict[str, Any]:
+    payload = state.get("/api/scheduling/status")
+    return as_dict(payload)
+
+
+def _config(state: Ctx) -> dict[str, Any]:
+    payload = state.get("/api/scheduling")
+    return as_dict(payload)
+
+
+def _mode(scfg: dict[str, Any]) -> str:
+    advanced = as_dict(scfg.get("advanced"))
+    if coerce_bool(advanced.get("enabled"), False):
+        return "advanced"
+    mode = str(scfg.get("mode") or "").strip()
+    if mode:
+        return mode
+    every = scfg.get("every_n_hours") or scfg.get("interval_hours")
+    return f"every {every}h" if every else "simple"
+
+
+def _render(state: Ctx, status: dict[str, Any]) -> None:
+    if state.out.json_mode:
+        state.out.data(status)
+        return
+    scfg = as_dict(status.get("config"))
+    nxt = int(status.get("next_run_at") or 0)
+    warnings = status.get("scheduling_warnings") or []
+    state.out.kv(
+        [
+            ("Enabled", state_text(coerce_bool(scfg.get("enabled"), False), on="yes", off="no")),
+            ("Worker", state_text(coerce_bool(status.get("running"), False), on="running", off="stopped")),
+            ("Mode", _mode(scfg)),
+            ("Next run", f"{fmt_ts(nxt)}  ({fmt_rel(nxt)})" if nxt else "not scheduled"),
+            ("Last run", fmt_ts(status.get("last_run_at")) if status.get("last_run_at") else "-"),
+            ("Warnings", str(len(warnings)) if warnings else "none"),
+        ],
+        title="Scheduler",
+    )
+    if warnings:
+        state.out.print()
+        rows = []
+        for item in warnings:
+            if isinstance(item, dict):
+                rows.append([str(item.get("code") or item.get("id") or "-"), str(item.get("message") or item.get("text") or "-")])
+            else:
+                rows.append(["-", str(item)])
+        state.out.table(["CODE", "WARNING"], rows, title="Scheduling warnings")
+
+
+@scheduler_app.command("status")
+def scheduler_status(ctx: typer.Context) -> None:
+    """Show scheduler state and the next planned run."""
+    state: Ctx = ctx.obj
+    _render(state, _status(state))
+
+
+@scheduler_app.command("next")
+def scheduler_next(ctx: typer.Context) -> None:
+    """Show only the next planned run."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/scheduling/next")
+    nxt = int((payload or {}).get("next_run_at") or 0)
+    if state.out.json_mode:
+        state.out.data(as_dict(payload))
+        return
+    if not nxt:
+        state.out.info("No run is scheduled.")
+        return
+    state.out.raw(f"{fmt_ts(nxt)}  ({fmt_rel(nxt)})")
+
+
+@scheduler_app.command("run-now")
+def scheduler_run_now(ctx: typer.Context) -> None:
+    """Ask the scheduler to fire its job immediately."""
+    state: Ctx = ctx.obj
+    state.require_service("Triggering the scheduler")
+    payload = state.post("/api/scheduling/trigger_now")
+    if isinstance(payload, dict) and payload.get("ok") is False:
+        raise CLIError(error_text(payload, "Trigger failed"))
+    if state.out.json_mode:
+        state.out.data(payload if isinstance(payload, dict) else {"ok": True})
+        return
+    if isinstance(payload, dict) and payload.get("triggered") is False:
+        state.out.warn("Scheduler accepted the request but did not fire; is it enabled?")
+        return
+    state.out.success("Scheduler fired.")
+
+
+@scheduler_app.command("replan")
+def scheduler_replan(ctx: typer.Context) -> None:
+    """Recompute the next run time from the current configuration."""
+    state: Ctx = ctx.obj
+    state.require_service("Replanning the scheduler")
+    payload = state.post("/api/scheduling/replan_now")
+    if not state.out.json_mode:
+        state.out.success("Replanned.")
+        state.out.print()
+    _render(state, as_dict(payload))
+
+
+@scheduler_app.command("enable")
+def scheduler_enable(ctx: typer.Context) -> None:
+    """Turn the scheduler on."""
+    _set_enabled(ctx, True)
+
+
+@scheduler_app.command("disable")
+def scheduler_disable(ctx: typer.Context) -> None:
+    """Turn the scheduler off."""
+    _set_enabled(ctx, False)
+
+
+def _set_enabled(ctx: typer.Context, enabled: bool) -> None:
+    state: Ctx = ctx.obj
+    state.require_service("Changing the scheduler")
+    scfg = dict(_config(state))
+    scfg["enabled"] = bool(enabled)
+    payload = state.post("/api/scheduling", json_body=scfg)
+    if isinstance(payload, dict) and payload.get("ok") is False:
+        raise CLIError(error_text(payload, "Scheduler update rejected"))
+    nxt = int((payload or {}).get("next_run_at") or 0)
+    if state.out.json_mode:
+        state.out.data({"ok": True, "enabled": enabled, "next_run_at": nxt})
+        return
+    state.out.success(f"Scheduler {'enabled' if enabled else 'disabled'}.")
+    if enabled and nxt:
+        state.out.info(f"Next run {fmt_ts(nxt)} ({fmt_rel(nxt)})")
+
+
+@scheduler_app.command("stop")
+def scheduler_stop(ctx: typer.Context) -> None:
+    """Stop the scheduler worker without changing the saved configuration."""
+    state: Ctx = ctx.obj
+    state.require_service("Stopping the scheduler")
+    payload = state.post("/api/scheduling/stop")
+    if isinstance(payload, dict) and payload.get("ok") is False:
+        raise CLIError(error_text(payload, "Stop failed"))
+    if state.out.json_mode:
+        state.out.data(payload if isinstance(payload, dict) else {"ok": True})
+        return
+    state.out.success("Scheduler worker stopped.")
+
+
+@scheduler_app.command("show")
+def scheduler_show(ctx: typer.Context) -> None:
+    """Print the raw scheduling configuration."""
+    state: Ctx = ctx.obj
+    scfg = _config(state)
+    if state.out.json_mode:
+        state.out.data(scfg)
+        return
+    import json as _json
+
+    from rich.syntax import Syntax
+
+    state.out.console.print(Syntax(_json.dumps(scfg, indent=2, default=str), "json", theme="ansi_dark", background_color="default"))
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(scheduler_app, name="scheduler")

--- a/cli/commands/scrobbler.py
+++ b/cli/commands/scrobbler.py
@@ -1,0 +1,210 @@
+# /cli/commands/scrobbler.py
+# CrossWatch - CLI scrobbler management commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import EXIT_USAGE, CLIError
+from .._render import state_text
+from .._util import as_dict, coerce_bool, error_text
+
+scrobbler_app = typer.Typer(help="Scrobbler routes and webhooks.", no_args_is_help=True)
+route_app = typer.Typer(help="Scrobble routes.", no_args_is_help=True)
+webhook_app = typer.Typer(help="Scrobble webhooks.", no_args_is_help=True)
+
+
+def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
+    block = as_dict(payload)
+    for key in keys:
+        found = block.get(key)
+        if isinstance(found, list):
+            return [as_dict(i) for i in found]
+    if isinstance(payload, list):
+        return [as_dict(i) for i in payload]
+    return []
+
+
+def _fields(raw: list[str]) -> dict[str, Any]:
+    body: dict[str, Any] = {}
+    for item in raw or []:
+        key, sep, value = str(item).partition("=")
+        key = key.strip()
+        if not sep or not key:
+            raise CLIError(f"--field expects key=value, got '{item}'", exit_code=EXIT_USAGE)
+        body[key] = value
+    return body
+
+
+@scrobbler_app.command("overview")
+def scrobbler_overview(ctx: typer.Context) -> None:
+    """Show the scrobbler setup."""
+    state: Ctx = ctx.obj
+    payload = as_dict(state.get("/api/scrobbler/overview"))
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    state.out.kv(
+        [(key, value) for key, value in payload.items() if not isinstance(value, (dict, list))],
+        title="Scrobbler",
+    )
+    routes = _rows(payload, "routes")
+    if routes:
+        state.out.print()
+        state.out.records(
+            routes,
+            [
+                ("ID", lambda r: str(r.get("id") or r.get("route_id") or "-")),
+                ("SOURCE", lambda r: str(r.get("source") or r.get("provider") or "-")),
+                ("SINK", lambda r: str(r.get("sink") or "-")),
+                ("ENABLED", lambda r: state_text(coerce_bool(r.get("enabled"), False), on="yes", off="no")),
+            ],
+            title="Routes",
+        )
+
+
+@scrobbler_app.command("event-routes")
+def scrobbler_event_routes(ctx: typer.Context) -> None:
+    """Show where scrobble events are delivered."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/scrobble/event_routes")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = _rows(payload, "routes", "items")
+    state.out.records(
+        rows,
+        [
+            ("EVENT", lambda r: str(r.get("event") or r.get("type") or "-")),
+            ("SOURCE", lambda r: str(r.get("source") or r.get("provider") or "-")),
+            ("SINK", lambda r: str(r.get("sink") or r.get("target") or "-")),
+        ],
+        title="Event routes",
+        empty="No event routes.",
+    )
+
+
+@route_app.command("add")
+def route_add(
+    ctx: typer.Context,
+    field: list[str] = typer.Option([], "--field", "-F", help="Route setting as key=value. Repeatable."),
+) -> None:
+    """Add a scrobble route."""
+    state: Ctx = ctx.obj
+    state.require_service("Adding a scrobble route")
+    body = _fields(field)
+    if not body:
+        raise CLIError("A route needs fields", hint="For example --field source=PLEX --field sink=TRAKT", exit_code=EXIT_USAGE)
+    result = as_dict(state.post("/api/scrobbler/routes", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success(f"Route added{': ' + str(result.get('id')) if result.get('id') else '.'}")
+
+
+@route_app.command("set")
+def route_set(
+    ctx: typer.Context,
+    route_id: str = typer.Argument(..., help="Route id."),
+    field: list[str] = typer.Option([], "--field", "-F", help="Route setting as key=value. Repeatable."),
+) -> None:
+    """Update a scrobble route."""
+    state: Ctx = ctx.obj
+    state.require_service("Updating a scrobble route")
+    body = _fields(field)
+    if not body:
+        raise CLIError("Nothing to change", hint="Pass at least one --field key=value", exit_code=EXIT_USAGE)
+    result = as_dict(state.put(f"/api/scrobbler/routes/{route_id}", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Updated route {route_id}")
+
+
+@route_app.command("delete")
+def route_delete(
+    ctx: typer.Context,
+    route_id: str = typer.Argument(..., help="Route id."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Delete a scrobble route."""
+    state: Ctx = ctx.obj
+    state.require_service("Deleting a scrobble route")
+    if not yes and not typer.confirm(f"Delete route {route_id}?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(state.delete(f"/api/scrobbler/routes/{route_id}"))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Delete rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Deleted route {route_id}")
+
+
+@webhook_app.command("urls")
+def webhook_urls(ctx: typer.Context) -> None:
+    """Show the webhook URLs to paste into your media server."""
+    state: Ctx = ctx.obj
+    payload = as_dict(state.get("/api/webhooks/urls"))
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    rows = [[key, str(value)] for key, value in payload.items() if not isinstance(value, (dict, list))]
+    state.out.table(["NAME", "URL"], rows, title="Webhook URLs", empty="No webhook URLs yet.")
+
+
+@webhook_app.command("regenerate")
+def webhook_regenerate(
+    ctx: typer.Context,
+    profile: str = typer.Option("", "--profile", help="Regenerate one profile instead of all."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Roll the webhook tokens. Existing URLs stop working."""
+    state: Ctx = ctx.obj
+    state.require_service("Regenerating webhooks")
+    if not yes:
+        state.out.warn("Existing webhook URLs will stop working.")
+        if not typer.confirm("Regenerate?", default=False):
+            raise CLIError("Cancelled", exit_code=0)
+    if profile.strip():
+        result = as_dict(state.post("/api/scrobbler/webhooks/profile/regenerate", json_body={"profile": profile.strip()}))
+    else:
+        result = as_dict(state.post("/api/webhooks/regenerate"))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success("Webhook URLs regenerated.")
+
+
+@webhook_app.command("cleanup-legacy")
+def webhook_cleanup(
+    ctx: typer.Context,
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Strip legacy inherited webhook sinks."""
+    state: Ctx = ctx.obj
+    state.require_service("Cleaning legacy webhooks")
+    if not yes and not typer.confirm("Remove legacy webhook settings?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(state.post("/api/scrobbler/webhooks/cleanup-legacy"))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success("Legacy webhook settings removed.")
+
+
+def register(app: typer.Typer) -> None:
+    scrobbler_app.add_typer(route_app, name="route")
+    scrobbler_app.add_typer(webhook_app, name="webhook")
+    app.add_typer(scrobbler_app, name="scrobbler")

--- a/cli/commands/shell.py
+++ b/cli/commands/shell.py
@@ -1,0 +1,217 @@
+# /cli/commands/shell.py
+# CrossWatch - CLI interactive shell
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import CLIError
+from .._settings import cli_home
+
+GROUPS = (
+    "pair",
+    "sync",
+    "config",
+    "auth",
+    "watcher",
+    "scheduler",
+    "logs",
+    "analyzer",
+    "events",
+    "capture",
+    "backup",
+    "watchlist",
+    "progress",
+    "editor",
+    "playlist",
+    "export",
+    "import",
+    "metadata",
+    "manual",
+    "anime",
+    "instance",
+    "user-profile",
+    "scrobbler",
+    "activity",
+    "maintenance",
+)
+LEAVE = {"exit", "end", "quit", "up", "..", "back"}
+BANNER = """CrossWatch interactive shell.
+
+  ?              list what you can run here
+  <group>        step into a group, for example: sync
+  exit / end     leave the group, or quit at the top
+  !<command>     run a command at the top level from inside a group
+"""
+
+
+def _history_file() -> Path:
+    home = cli_home()
+    home.mkdir(parents=True, exist_ok=True)
+    return home / "history"
+
+
+def _setup_readline(completer: Any) -> Any:
+    try:
+        import readline as _readline
+    except Exception:
+        return None
+    readline: Any = _readline
+    try:
+        readline.read_history_file(str(_history_file()))
+    except Exception:
+        pass
+    try:
+        readline.set_completer(completer)
+        readline.set_completer_delims(" \t\n")
+        readline.parse_and_bind("tab: complete")
+    except Exception:
+        pass
+    return readline
+
+
+def _save_history(readline: Any) -> None:
+    if readline is None:
+        return
+    try:
+        readline.set_history_length(1000)
+        readline.write_history_file(str(_history_file()))
+    except Exception:
+        pass
+
+
+class Shell:
+    def __init__(self, state: Ctx) -> None:
+        self.state = state
+        self.group = ""
+        self._root_cache: list[tuple[str, str]] = []
+        self._group_cache: dict[str, list[tuple[str, str]]] = {}
+
+    def root_commands(self) -> list[tuple[str, str]]:
+        if not self._root_cache:
+            from .._app import describe_commands
+
+            self._root_cache = describe_commands()
+        return self._root_cache
+
+    def group_commands(self, name: str) -> list[tuple[str, str]]:
+        if name not in self._group_cache:
+            from .._app import describe_group
+
+            self._group_cache[name] = describe_group(name)
+        return self._group_cache[name]
+
+    def prompt(self) -> str:
+        return f"cw({self.group})> " if self.group else "cw> "
+
+    def complete(self, text: str, index: int) -> str | None:
+        pool = [name for name, _ in (self.group_commands(self.group) if self.group else self.root_commands())]
+        pool = pool + sorted(LEAVE) + ["?", "help"]
+        matches = [c for c in pool if c.startswith(text)]
+        return matches[index] if index < len(matches) else None
+
+    def show_help(self) -> None:
+        out = self.state.out
+        if self.group:
+            rows = [[name, doc] for name, doc in self.group_commands(self.group)]
+            out.table(["COMMAND", "WHAT IT DOES"], rows, title=f"cw {self.group}")
+            out.info("Type 'exit' to go back, or !<command> to run something at the top level.")
+            return
+        rows = [[name, doc] for name, doc in self.root_commands()]
+        out.table(["COMMAND", "WHAT IT DOES"], rows, title="cw")
+        out.info("Type a group name to step into it, for example: sync")
+
+    def dispatch(self, argv: list[str]) -> int:
+        from .._app import run_isolated
+
+        return run_isolated(self.state, argv)
+
+    def handle(self, raw: str) -> bool:
+        line = raw.strip()
+        if not line:
+            return True
+        if line in ("?", "help") or line.startswith("? "):
+            self.show_help()
+            return True
+        if line.lower() in LEAVE:
+            if self.group:
+                self.group = ""
+                return True
+            return False
+        if line.lower() in ("clear", "cls"):
+            self.state.out.console.clear()
+            return True
+
+        try:
+            argv = shlex.split(line)
+        except ValueError as exc:
+            self.state.out.error(f"Cannot parse that line: {exc}")
+            return True
+        if not argv:
+            return True
+
+        if argv[0].startswith("!"):
+            argv[0] = argv[0][1:]
+            argv = [a for a in argv if a]
+            if argv:
+                self.dispatch(argv)
+            return True
+
+        if argv[0] == "help" and len(argv) > 1:
+            target = ([self.group] if self.group else []) + argv[1:] + ["--help"]
+            self.dispatch(target)
+            return True
+
+        if not self.group and argv[0] in GROUPS and len(argv) == 1:
+            self.group = argv[0]
+            return True
+
+        if self.group:
+            known = {name for name, _ in self.group_commands(self.group)}
+            if argv[0] in known:
+                self.dispatch([self.group, *argv])
+                return True
+            if argv[0] in GROUPS and len(argv) == 1:
+                self.group = argv[0]
+                return True
+            self.dispatch(argv)
+            return True
+
+        self.dispatch(argv)
+        return True
+
+    def run(self) -> None:
+        out = self.state.out
+        out.print(f"[cw.accent]CrossWatch[/] {self.state.url}  ([cw.muted]{self.state.mode}[/])")
+        out.print(BANNER)
+        readline = _setup_readline(self.complete)
+        try:
+            while True:
+                try:
+                    line = input(self.prompt())
+                except EOFError:
+                    out.print()
+                    break
+                except KeyboardInterrupt:
+                    out.print()
+                    continue
+                if not self.handle(line):
+                    break
+        finally:
+            _save_history(readline)
+        out.info("Bye.")
+
+
+def register(app: typer.Typer) -> None:
+    @app.command("shell")
+    def shell_cmd(ctx: typer.Context) -> None:
+        """Start an interactive CrossWatch session with grouped contexts."""
+        state: Ctx = ctx.obj
+        if state.out.json_mode:
+            raise CLIError("The shell needs a human readable output format", hint="Drop -o json.")
+        Shell(state).run()

--- a/cli/commands/status.py
+++ b/cli/commands/status.py
@@ -1,0 +1,201 @@
+# /cli/commands/status.py
+# CrossWatch - CLI status, version and health commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import CLIError
+from .._render import state_text
+from .._util import as_dict, coerce_bool, fmt_rel, fmt_ts, pair_features, pair_label
+
+
+def _safe(ctx: Ctx, path: str, default: Any = None, *, params: dict[str, Any] | None = None) -> Any:
+    try:
+        return ctx.get(path, params=params)
+    except CLIError as err:
+        if int(getattr(err, "status", 0) or 0) in (401, 403):
+            raise
+        return default
+
+
+def _provider_rows(providers: dict[str, Any]) -> list[list[Any]]:
+    rows: list[list[Any]] = []
+    for name in sorted(providers):
+        block = providers.get(name)
+        if not isinstance(block, dict):
+            continue
+        summary = as_dict(block.get("instances_summary"))
+        total = int(summary.get("total") or 0)
+        ok = int(summary.get("ok") or 0)
+        instances = f"{ok}/{total}" if total else "-"
+        rows.append(
+            [
+                name,
+                state_text(block.get("connected"), on="connected", off="down"),
+                instances,
+                str(block.get("used_by") or "-"),
+                str(block.get("reason") or "")[:52],
+            ]
+        )
+    return rows
+
+
+def _collect(ctx: Ctx, *, fresh: bool = False) -> dict[str, Any]:
+    status = ctx.get("/api/status", params={"fresh": 1} if fresh else None)
+    status = as_dict(status)
+    pairs = _safe(ctx, "/api/pairs", []) or []
+    if not isinstance(pairs, list):
+        pairs = []
+    run = _safe(ctx, "/api/run/cancel", {}) or {}
+    sched = _safe(ctx, "/api/scheduling/status", {}) or {}
+    watch = _safe(ctx, "/api/watch/status", {}) or {}
+    version = _safe(ctx, "/api/version", {}) or {}
+    enabled = [p for p in pairs if isinstance(p, dict) and p.get("enabled", True) is not False]
+    return {
+        "mode": ctx.mode,
+        "url": ctx.url,
+        "version": str(version.get("current") or version.get("version") or "unknown"),
+        "can_run": coerce_bool(status.get("can_run"), False),
+        "sync_running": coerce_bool(run.get("running"), False),
+        "cancel_requested": coerce_bool(run.get("cancel_requested"), False),
+        "run_id": str(run.get("run_id") or ""),
+        "pairs_total": len(pairs),
+        "pairs_enabled": len(enabled),
+        "scheduler_enabled": coerce_bool((sched.get("config") or {}).get("enabled"), False),
+        "scheduler_running": coerce_bool(sched.get("running"), False),
+        "next_run_at": int(sched.get("next_run_at") or 0),
+        "watcher_alive": coerce_bool(watch.get("alive"), False),
+        "watcher_groups": len(watch.get("groups") or []),
+        "watcher_sinks": list(watch.get("sinks") or []),
+        "providers": as_dict(status.get("providers")),
+        "pairs": pairs,
+    }
+
+
+def register(app: typer.Typer) -> None:
+    @app.command("status")
+    def status_cmd(
+        ctx: typer.Context,
+        providers: bool = typer.Option(True, "--providers/--no-providers", help="Include the provider connection table."),
+        pairs: bool = typer.Option(True, "--pairs/--no-pairs", help="Include the sync pair table."),
+        fresh: bool = typer.Option(False, "--fresh", "-f", help="Re-probe providers instead of using the cached status."),
+    ) -> None:
+        """Show engine, provider, pair, scheduler and watcher state at a glance."""
+        state: Ctx = ctx.obj
+        data = _collect(state, fresh=fresh)
+        out = state.out
+        if out.json_mode:
+            out.data(data)
+            return
+
+        out.kv(
+            [
+                ("CrossWatch", data["version"]),
+                ("Endpoint", f"{data['url']}  ({data['mode']})"),
+                ("Sync", state_text(data["sync_running"], on="running", off="idle")),
+                ("Run id", data["run_id"] or "-"),
+                ("Pairs", f"{data['pairs_enabled']} enabled / {data['pairs_total']} total"),
+                ("Ready to sync", state_text(data["can_run"], on="yes", off="no")),
+                (
+                    "Scheduler",
+                    state_text(data["scheduler_enabled"], on="enabled", off="disabled").append(
+                        f"  next {fmt_ts(data['next_run_at'])} ({fmt_rel(data['next_run_at'])})"
+                        if data["next_run_at"]
+                        else ""
+                    ),
+                ),
+                (
+                    "Watcher",
+                    state_text(data["watcher_alive"], on="running", off="stopped").append(
+                        f"  {data['watcher_groups']} group(s) -> {', '.join(data['watcher_sinks']) or 'no sinks'}"
+                    ),
+                ),
+            ],
+            title="CrossWatch status",
+        )
+
+        if providers and data["providers"]:
+            out.print()
+            out.table(
+                ["PROVIDER", "STATE", "INSTANCES", "USED BY", "REASON"],
+                _provider_rows(data["providers"]),
+                title="Providers",
+            )
+
+        if pairs and data["pairs"]:
+            out.print()
+            out.table(
+                ["ID", "PAIR", "STATE", "FEATURES"],
+                [
+                    [
+                        str(p.get("id") or "")[:12],
+                        pair_label(p),
+                        state_text(p.get("enabled", True) is not False, on="enabled", off="disabled"),
+                        ", ".join(pair_features(p)) or "-",
+                    ]
+                    for p in data["pairs"]
+                    if isinstance(p, dict)
+                ],
+                title="Pairs",
+            )
+
+    @app.command("version")
+    def version_cmd(
+        ctx: typer.Context,
+        check: bool = typer.Option(False, "--check", "-c", help="Ask upstream whether a newer release exists."),
+    ) -> None:
+        """Show the CrossWatch version and provider module versions."""
+        state: Ctx = ctx.obj
+        version = _safe(state, "/api/version/check" if check else "/api/version", {}) or {}
+        modules = _safe(state, "/api/modules/versions", {}) or {}
+        if state.out.json_mode:
+            state.out.data({"version": version, "modules": modules})
+            return
+        state.out.kv(
+            [
+                ("Version", str(version.get("current") or "unknown")),
+                ("Latest", str(version.get("latest") or "-")),
+                ("Update available", state_text(coerce_bool(version.get("update_available"), False), on="yes", off="no")),
+                ("Endpoint", f"{state.url}  ({state.mode})"),
+            ],
+            title="CrossWatch",
+        )
+        rows: list[list[Any]] = []
+        groups = as_dict(modules.get("groups"))
+        if groups:
+            for group, members in sorted(groups.items()):
+                if isinstance(members, dict):
+                    for name, value in sorted(members.items()):
+                        rows.append([str(group), str(name), str(value)])
+            if rows:
+                state.out.print()
+                state.out.table(["GROUP", "MODULE", "VERSION"], rows, title="Modules")
+            return
+        flat = modules.get("flat") if isinstance(modules.get("flat"), dict) else modules
+        if isinstance(flat, dict):
+            for name, value in sorted(flat.items()):
+                if not isinstance(value, (dict, list)):
+                    rows.append([str(name), str(value)])
+        if rows:
+            state.out.print()
+            state.out.table(["MODULE", "VERSION"], rows, title="Modules")
+
+    @app.command("health")
+    def health_cmd(ctx: typer.Context) -> None:
+        """Check that the service (or local install) answers."""
+        state: Ctx = ctx.obj
+        payload = state.get("/api/health")
+        if state.out.json_mode:
+            state.out.data(payload if isinstance(payload, dict) else {"raw": payload})
+            return
+        if isinstance(payload, dict):
+            state.out.kv(
+                [("Endpoint", state.url), ("Mode", state.mode), *[(k, v) for k, v in payload.items() if not isinstance(v, (dict, list))]],
+                title="Health",
+            )
+        else:
+            state.out.success(str(payload))

--- a/cli/commands/sync.py
+++ b/cli/commands/sync.py
@@ -1,0 +1,308 @@
+# /cli/commands/sync.py
+# CrossWatch - CLI sync run commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import queue
+import re
+import threading
+import time
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import EXIT_BUSY, CLIError
+from .._render import state_text
+from .._util import as_dict, coerce_bool, error_text, find_pair, fmt_duration, fmt_ts, is_log_control, pair_label, parse_iso, strip_ansi
+
+sync_app = typer.Typer(help="Trigger, watch and inspect sync runs.", no_args_is_help=True)
+
+EXIT_LINE = re.compile(r"\[SYNC\]\s*exit code:\s*(-?\d+)")
+LOG_TAG = "SYNC"
+
+
+def _summary(state: Ctx) -> dict[str, Any]:
+    payload = state.get("/api/run/summary")
+    return as_dict(payload)
+
+
+def _run_state(state: Ctx) -> dict[str, Any]:
+    payload = state.get("/api/run/cancel")
+    return as_dict(payload)
+
+
+class _Follower:
+    def __init__(self, state: Ctx) -> None:
+        self.state = state
+        self.inbox: "queue.Queue[tuple[str, str]]" = queue.Queue()
+        self.stop = threading.Event()
+        self.failure: list[Exception] = []
+        self.client = state.stream_client()
+        self.worker = threading.Thread(target=self._pump, name="cw-log-follow", daemon=True)
+
+    def start(self, settle: float = 0.35) -> "_Follower":
+        self.worker.start()
+        time.sleep(settle)
+        return self
+
+    def _pump(self) -> None:
+        try:
+            for event, data in self.client.stream_sse(
+                "/api/logs/stream", params={"tag": LOG_TAG, "plain": "true", "tail": 1}
+            ):
+                if self.stop.is_set():
+                    break
+                self.inbox.put((event, data))
+        except Exception as exc:
+            self.failure.append(exc)
+        finally:
+            self.inbox.put(("__closed__", ""))
+
+    def close(self) -> None:
+        self.stop.set()
+        try:
+            self.client.close()
+        except Exception:
+            pass
+
+    def drain(self, *, timeout: float) -> int:
+        state = self.state
+        deadline = time.time() + timeout if timeout > 0 else 0.0
+        exit_code = 0
+        idle_checks = 0
+        try:
+            while True:
+                try:
+                    event, data = self.inbox.get(timeout=1.0)
+                except queue.Empty:
+                    if deadline and time.time() > deadline:
+                        state.out.warn(f"Stopped following after {fmt_duration(timeout)}; the run continues in the background.")
+                        return EXIT_BUSY
+                    idle_checks += 1
+                    if idle_checks % 5 == 0 and not coerce_bool(_run_state(state).get("running"), False):
+                        return exit_code
+                    continue
+                idle_checks = 0
+                if event == "__closed__":
+                    if self.failure:
+                        raise self.failure[0]
+                    return exit_code
+                if event in ("ping", "scope"):
+                    continue
+                line = strip_ansi(data)
+                if not line.strip() or is_log_control(line):
+                    continue
+                state.out.raw(line)
+                match = EXIT_LINE.search(line)
+                if match:
+                    return int(match.group(1))
+                if deadline and time.time() > deadline:
+                    state.out.warn(f"Stopped following after {fmt_duration(timeout)}; the run continues in the background.")
+                    return EXIT_BUSY
+        finally:
+            self.close()
+
+
+@sync_app.command("run")
+def sync_run(
+    ctx: typer.Context,
+    pair: str = typer.Option("", "--pair", "-p", help="Run one pair only (id or prefix). Default runs every enabled pair."),
+    follow: bool = typer.Option(False, "--follow", "-f", help="Stream the sync log until the run finishes."),
+    timeout: float = typer.Option(0.0, "--timeout", help="Give up following after this many seconds (0 = no limit)."),
+) -> None:
+    """Start a sync run."""
+    state: Ctx = ctx.obj
+    state.require_service("Starting a sync")
+    payload: dict[str, Any] = {"source": "cli"}
+    label = "all enabled pairs"
+    if pair.strip():
+        target = find_pair(
+            [p for p in (state.get("/api/pairs") or []) if isinstance(p, dict)],
+            pair,
+        )
+        payload["pair_id"] = str(target.get("id") or "")
+        label = f"{pair_label(target)} ({target.get('id')})"
+
+    if follow:
+        code = _start_and_follow(state, payload, label, timeout)
+        raise typer.Exit(code)
+
+    result = state.post("/api/run", json_body=payload)
+    if isinstance(result, dict) and result.get("ok") is False:
+        error = error_text(result, "Sync refused")
+        raise CLIError(error, exit_code=EXIT_BUSY if "already running" in error.lower() else 1)
+    if state.out.json_mode:
+        state.out.data(result if isinstance(result, dict) else {"ok": True})
+        return
+    if isinstance(result, dict) and result.get("skipped"):
+        state.out.warn(f"Nothing to do: {result.get('skipped')}")
+        return
+    run_id = str((result or {}).get("run_id") or "")
+    state.out.success(f"Sync started for {label}" + (f" (run {run_id})" if run_id else ""))
+    state.out.info("Follow it with 'cw logs tail -f' or 'cw sync status'.")
+
+
+def _start_and_follow(state: Ctx, payload: dict[str, Any], label: str, timeout: float) -> int:
+    follower = _Follower(state).start()
+    try:
+        result = state.post("/api/run", json_body=payload)
+    except Exception:
+        follower.close()
+        raise
+    if isinstance(result, dict) and result.get("ok") is False:
+        follower.close()
+        error = error_text(result, "Sync refused")
+        raise CLIError(error, exit_code=EXIT_BUSY if "already running" in error.lower() else 1)
+    if isinstance(result, dict) and result.get("skipped"):
+        follower.close()
+        state.out.warn(f"Nothing to do: {result.get('skipped')}")
+        return 0
+
+    state.out.info(f"Running {label} (run {(result or {}).get('run_id') or '?'})")
+    return follower.drain(timeout=timeout)
+
+
+@sync_app.command("status")
+def sync_status(ctx: typer.Context) -> None:
+    """Show the current or last sync run."""
+    state: Ctx = ctx.obj
+    run = _run_state(state)
+    summary = _summary(state)
+    running = coerce_bool(run.get("running"), False)
+    started = parse_iso(summary.get("started_at")) or int(float(summary.get("raw_started_ts") or 0) or 0)
+    if state.out.json_mode:
+        state.out.data({"running": running, "run": run, "summary": summary})
+        return
+    timeline = as_dict(summary.get("timeline"))
+    phases = [name for name in ("start", "pre", "post", "done") if timeline.get(name)]
+    state.out.kv(
+        [
+            ("State", state_text(running, on="running", off="idle")),
+            ("Run id", str(summary.get("run_id") or run.get("run_id") or "-")),
+            ("Started", fmt_ts(started)),
+            ("Finished", fmt_ts(parse_iso(summary.get("finished_at")))),
+            ("Duration", fmt_duration(summary.get("duration_sec")) if summary.get("duration_sec") else "-"),
+            ("Result", str(summary.get("result") or "-")),
+            ("Exit code", str(summary.get("exit_code")) if summary.get("exit_code") is not None else "-"),
+            ("Phases", " > ".join(phases) or "-"),
+            ("Cancel requested", state_text(coerce_bool(run.get("cancel_requested"), False), on="yes", off="no")),
+            ("Added", str(summary.get("added_last") or 0)),
+            ("Updated", str(summary.get("updated_last") or 0)),
+            ("Removed", str(summary.get("removed_last") or 0)),
+        ],
+        title="Sync run",
+    )
+
+    counts = summary.get("provider_counts")
+    if isinstance(counts, dict) and counts:
+        rows = []
+        for name, block in sorted(counts.items()):
+            if isinstance(block, dict):
+                rows.append([name, *[str(block.get(k, "-")) for k in ("watchlist", "ratings", "history", "playlists")]])
+        if rows:
+            state.out.print()
+            state.out.table(["PROVIDER", "WATCHLIST", "RATINGS", "HISTORY", "PLAYLISTS"], rows, title="Provider counts")
+
+
+@sync_app.command("follow")
+def sync_follow(
+    ctx: typer.Context,
+    timeout: float = typer.Option(0.0, "--timeout", help="Give up after this many seconds (0 = no limit)."),
+) -> None:
+    """Attach to the sync log of a run that is already going."""
+    state: Ctx = ctx.obj
+    state.require_service("Following a sync")
+    if not coerce_bool(_run_state(state).get("running"), False):
+        state.out.warn("No sync is running right now; showing new output as it appears.")
+    raise typer.Exit(_Follower(state).start(0.0).drain(timeout=timeout))
+
+
+@sync_app.command("cancel")
+def sync_cancel(ctx: typer.Context) -> None:
+    """Ask the running sync to stop after the current step."""
+    state: Ctx = ctx.obj
+    state.require_service("Cancelling a sync")
+    result = state.post("/api/run/cancel")
+    if state.out.json_mode:
+        state.out.data(result if isinstance(result, dict) else {"ok": True})
+        return
+    if isinstance(result, dict) and result.get("ok") is False:
+        state.out.warn(error_text(result, "Nothing to cancel"))
+        return
+    state.out.success("Cancel requested; the run stops after the current step.")
+
+
+@sync_app.command("unresolved")
+def sync_unresolved(
+    ctx: typer.Context,
+    limit: int = typer.Option(50, "--limit", "-n", help="Maximum rows to show."),
+) -> None:
+    """List items the last run could not match."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/run/unresolved")
+    items = payload.get("items") if isinstance(payload, dict) else []
+    items = [i for i in (items or []) if isinstance(i, dict)]
+    if state.out.json_mode:
+        state.out.data({"total": (payload or {}).get("total", len(items)), "items": items})
+        return
+    state.out.table(
+        ["TITLE", "TYPE", "YEAR", "REASON"],
+        [
+            [
+                str(i.get("title") or i.get("line") or "-")[:60],
+                str(i.get("type") or "-"),
+                str(i.get("year") or "-"),
+                str(i.get("reason") or "-")[:40],
+            ]
+            for i in items[: max(1, limit)]
+        ],
+        title=f"Unresolved items ({(payload or {}).get('total', len(items))})",
+        empty="Nothing unresolved.",
+    )
+
+
+@sync_app.command("providers")
+def sync_providers(
+    ctx: typer.Context,
+    counts: bool = typer.Option(False, "--counts", help="Show per-provider item counts instead of capabilities."),
+) -> None:
+    """Show providers the sync engine can use."""
+    state: Ctx = ctx.obj
+    path = "/api/sync/providers/counts" if counts else "/api/sync/providers"
+    payload = state.get(path)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    if counts:
+        source = payload.get("providers") if isinstance(payload, dict) else payload
+        rows = []
+        if isinstance(source, dict):
+            for name, block in sorted(source.items()):
+                if isinstance(block, dict):
+                    rows.append([name, *[str(block.get(k, "-")) for k in ("watchlist", "ratings", "history", "playlists")]])
+        state.out.table(["PROVIDER", "WATCHLIST", "RATINGS", "HISTORY", "PLAYLISTS"], rows, title="Provider counts")
+        return
+    source = payload.get("providers") if isinstance(payload, dict) else payload
+    rows = []
+    if isinstance(source, list):
+        for entry in source:
+            if isinstance(entry, dict):
+                features = as_dict(entry.get("features"))
+                rows.append(
+                    [
+                        str(entry.get("name") or entry.get("id") or "-"),
+                        str(entry.get("label") or "-"),
+                        ", ".join(sorted(k for k, v in features.items() if v)) or "-",
+                    ]
+                )
+            else:
+                rows.append([str(entry), "-", "-"])
+    elif isinstance(source, dict):
+        for name, entry in sorted(source.items()):
+            rows.append([name, str((entry or {}).get("label") or "-") if isinstance(entry, dict) else "-", "-"])
+    state.out.table(["PROVIDER", "LABEL", "FEATURES"], rows, title="Sync providers")
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(sync_app, name="sync")

--- a/cli/commands/transfer.py
+++ b/cli/commands/transfer.py
@@ -1,0 +1,223 @@
+# /cli/commands/transfer.py
+# CrossWatch - CLI import and export commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import EXIT_NOT_FOUND, EXIT_USAGE, CLIError
+from .._util import as_dict, error_text
+
+export_app = typer.Typer(help="Export your data out of CrossWatch.", no_args_is_help=True)
+import_app = typer.Typer(help="Import data into CrossWatch.", no_args_is_help=True)
+
+
+def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
+    block = as_dict(payload)
+    for key in keys:
+        found = block.get(key)
+        if isinstance(found, list):
+            return [as_dict(i) for i in found]
+    if isinstance(payload, list):
+        return [as_dict(i) for i in payload]
+    return []
+
+
+def _options(state: Ctx, path: str, title: str) -> None:
+    payload = as_dict(state.get(path))
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    for key, value in payload.items():
+        if isinstance(value, list) and value:
+            state.out.table([key.upper()], [[str(v)] for v in value], title=key)
+            state.out.print()
+        elif not isinstance(value, dict):
+            state.out.kv([(key, value)])
+    if not payload:
+        state.out.info(f"No {title} reported.")
+
+
+@export_app.command("options")
+def export_options(ctx: typer.Context) -> None:
+    """Show what can be exported and in which formats."""
+    state: Ctx = ctx.obj
+    _options(state, "/api/export/options", "export options")
+
+
+@export_app.command("preview")
+def export_preview(
+    ctx: typer.Context,
+    provider: str = typer.Option(..., "--provider", "-p", help="Provider to export from."),
+    feature: str = typer.Option("watchlist", "--feature", "-F", help="watchlist, ratings or history."),
+    export_format: str = typer.Option("letterboxd", "--format", help="Output format."),
+    media_types: str = typer.Option("movie", "--types", help="Comma separated media types."),
+    instance: str = typer.Option("all", "--instance", "-i", help="Provider instance id."),
+) -> None:
+    """Show a sample of what an export would contain."""
+    state: Ctx = ctx.obj
+    params = {
+        "provider": provider.strip().upper(),
+        "feature": feature,
+        "format": export_format,
+        "media_types": media_types,
+        "provider_instance": instance,
+    }
+    payload = state.get("/api/export/sample", params=params)
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    block = as_dict(payload)
+    sample = block.get("sample") or block.get("preview") or block.get("text")
+    if isinstance(sample, str):
+        state.out.raw(sample)
+        return
+    rows = _rows(payload, "items", "rows", "sample")
+    if rows:
+        keys = list(rows[0])[:5]
+        state.out.records(rows[:20], [(k.upper(), k) for k in keys], title="Export sample")
+        return
+    state.out.kv([(k, v) for k, v in block.items() if not isinstance(v, (dict, list))], title="Export sample")
+
+
+@export_app.command("file")
+def export_file(
+    ctx: typer.Context,
+    output: Path = typer.Argument(..., help="Where to write the export."),
+    provider: str = typer.Option(..., "--provider", "-p", help="Provider to export from."),
+    feature: str = typer.Option("watchlist", "--feature", "-F", help="watchlist, ratings or history."),
+    export_format: str = typer.Option("letterboxd", "--format", help="Output format."),
+    media_types: str = typer.Option("movie", "--types", help="Comma separated media types."),
+    instance: str = typer.Option("all", "--instance", "-i", help="Provider instance id."),
+) -> None:
+    """Write an export to a file."""
+    state: Ctx = ctx.obj
+    state.require_service("Exporting")
+    params = {
+        "provider": provider.strip().upper(),
+        "feature": feature,
+        "format": export_format,
+        "media_types": media_types,
+        "provider_instance": instance,
+    }
+    payload = state.get("/api/export/file", params=params)
+    if isinstance(payload, str):
+        text = payload
+    else:
+        import json as _json
+
+        text = _json.dumps(payload, indent=2, default=str)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(text, encoding="utf-8")
+    if state.out.json_mode:
+        state.out.data({"ok": True, "path": str(output), "bytes": len(text.encode("utf-8"))})
+        return
+    state.out.success(f"Wrote {len(text.encode('utf-8')):,} bytes to {output}")
+
+
+@import_app.command("options")
+def import_options(ctx: typer.Context) -> None:
+    """Show what can be imported."""
+    state: Ctx = ctx.obj
+    _options(state, "/api/import/options", "import options")
+
+
+@import_app.command("preview")
+def import_preview(
+    ctx: typer.Context,
+    file: Path = typer.Argument(..., help="File to import."),
+    source: str = typer.Option("auto", "--source", "-s", help="Source format, or auto."),
+    target: str = typer.Option("default", "--target", "-t", help="Target instance id."),
+    limit: int = typer.Option(20, "--limit", "-n", help="Maximum preview rows."),
+) -> None:
+    """Upload a file and show what would be imported."""
+    state: Ctx = ctx.obj
+    state.require_service("Previewing an import")
+    if not file.is_file():
+        raise CLIError(f"No such file: {file}", exit_code=EXIT_NOT_FOUND)
+    client = state.stream_client()
+    try:
+        with file.open("rb") as handle:
+            response = client.session.post(
+                client.base_url + "/api/import/preview",
+                files={"file": (file.name, handle)},
+                data={"source": source, "target_instance": target},
+                timeout=client.timeout,
+                verify=not client.insecure,
+            )
+    finally:
+        client.close()
+    if response.status_code >= 400:
+        raise CLIError(f"Import preview failed with HTTP {response.status_code}: {response.text[:200]}")
+    payload = as_dict(response.json())
+    import_id = str(payload.get("import_id") or payload.get("id") or "")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    state.out.kv(
+        [
+            ("Import id", import_id or "-"),
+            ("Source", str(payload.get("source") or source)),
+            ("Rows", str(payload.get("total") or payload.get("count") or "-")),
+        ],
+        title=f"Preview of {file.name}",
+    )
+    rows = _rows(payload, "items", "rows", "preview")
+    if not rows and import_id:
+        rows = _rows(state.get(f"/api/import/preview/{import_id}", params={"limit": limit}), "items", "rows")
+    if rows:
+        state.out.print()
+        state.out.records(
+            rows[: max(1, limit)],
+            [
+                ("TITLE", lambda r: str(r.get("title") or "-")[:40]),
+                ("YEAR", lambda r: str(r.get("year") or "-")),
+                ("TYPE", lambda r: str(r.get("type") or "-")),
+                ("STATUS", lambda r: str(r.get("status") or "-")),
+            ],
+            title="Rows",
+        )
+    if import_id:
+        state.out.print()
+        state.out.info(f"Commit it with 'cw import commit {import_id}'.")
+
+
+@import_app.command("commit")
+def import_commit(
+    ctx: typer.Context,
+    import_id: str = typer.Argument(..., help="Import id from 'cw import preview'."),
+    features: str = typer.Option("watchlist", "--features", "-F", help="Comma separated features."),
+    target: str = typer.Option("default", "--target", "-t", help="Target instance id."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Apply a previewed import."""
+    state: Ctx = ctx.obj
+    state.require_service("Committing an import")
+    if not yes:
+        state.out.warn("This writes to your providers.")
+        if not typer.confirm(f"Commit import {import_id}?", default=False):
+            raise CLIError("Cancelled", exit_code=0)
+    body = {
+        "import_id": import_id,
+        "features": [f.strip() for f in features.split(",") if f.strip()],
+        "target_instance": target,
+    }
+    result = as_dict(state.post("/api/import/commit", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Import rejected"), exit_code=EXIT_USAGE)
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success("Import committed.")
+    for key in ("added", "updated", "skipped", "duplicate", "exists", "errors"):
+        if key in result:
+            state.out.info(f"{key}: {result.get(key)}")
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(export_app, name="export")
+    app.add_typer(import_app, name="import")

--- a/cli/commands/watcher.py
+++ b/cli/commands/watcher.py
@@ -1,0 +1,153 @@
+# /cli/commands/watcher.py
+# CrossWatch - CLI scrobble watcher commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import CLIError
+from .._render import state_text
+from .._util import as_dict, coerce_bool, strip_ansi
+
+watcher_app = typer.Typer(help="Control the scrobble watcher.", no_args_is_help=True)
+
+
+def _status(state: Ctx) -> dict[str, Any]:
+    payload = state.get("/api/watch/status")
+    return as_dict(payload)
+
+
+def _render(state: Ctx, payload: dict[str, Any]) -> None:
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    groups = [g for g in (payload.get("groups") or []) if isinstance(g, dict)]
+    routes = [r for r in (payload.get("routes") or []) if isinstance(r, dict)]
+    state.out.kv(
+        [
+            ("State", state_text(coerce_bool(payload.get("alive"), False), on="running", off="stopped")),
+            ("Provider", str(payload.get("provider") or "-")),
+            ("Groups", str(len(groups))),
+            ("Routes", str(len(routes))),
+            ("Sinks", ", ".join(str(s) for s in (payload.get("sinks") or [])) or "-"),
+        ],
+        title="Watcher",
+    )
+    if routes:
+        state.out.print()
+        state.out.table(
+            ["ROUTE", "SOURCE", "SINK", "STATE", "DETAIL"],
+            [
+                [
+                    str(r.get("id") or r.get("route_id") or "-"),
+                    str(r.get("provider") or r.get("source") or "-"),
+                    str(r.get("sink") or "-"),
+                    state_text(coerce_bool(r.get("running"), False), on="running", off="stopped"),
+                    str(r.get("status") or r.get("detail") or r.get("error") or "")[:44],
+                ]
+                for r in routes
+            ],
+            title="Routes",
+        )
+
+
+@watcher_app.command("status")
+def watcher_status(ctx: typer.Context) -> None:
+    """Show whether the watcher is running and which routes it serves."""
+    state: Ctx = ctx.obj
+    _render(state, _status(state))
+
+
+@watcher_app.command("start")
+def watcher_start(ctx: typer.Context) -> None:
+    """Start the watcher from the saved configuration."""
+    state: Ctx = ctx.obj
+    state.require_service("Starting the watcher")
+    payload = state.post("/api/watch/start")
+    if not state.out.json_mode:
+        state.out.success("Watcher started.")
+        state.out.print()
+    _render(state, as_dict(payload))
+
+
+@watcher_app.command("stop")
+def watcher_stop(ctx: typer.Context) -> None:
+    """Stop the watcher."""
+    state: Ctx = ctx.obj
+    state.require_service("Stopping the watcher")
+    payload = state.post("/api/watch/stop")
+    if not state.out.json_mode:
+        state.out.success("Watcher stopped.")
+        state.out.print()
+    _render(state, as_dict(payload))
+
+
+@watcher_app.command("restart")
+def watcher_restart(ctx: typer.Context) -> None:
+    """Reload the watcher configuration and restart its routes."""
+    state: Ctx = ctx.obj
+    state.require_service("Restarting the watcher")
+    payload = state.post("/api/watch/refresh")
+    if not state.out.json_mode:
+        state.out.success("Watcher reloaded.")
+        state.out.print()
+    _render(state, as_dict(payload))
+
+
+@watcher_app.command("now")
+def watcher_now(ctx: typer.Context) -> None:
+    """Show what is playing right now."""
+    state: Ctx = ctx.obj
+    payload = state.get("/api/watch/currently_watching")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    items = payload if isinstance(payload, list) else (payload or {}).get("items") or []
+    items = [i for i in items if isinstance(i, dict)]
+    if not items and isinstance(payload, dict) and payload.get("title"):
+        items = [payload]
+    state.out.table(
+        ["TITLE", "TYPE", "PROVIDER", "USER", "PROGRESS", "STATE"],
+        [
+            [
+                str(i.get("title") or i.get("name") or "-")[:52],
+                str(i.get("type") or i.get("media_type") or "-"),
+                str(i.get("provider") or i.get("server") or "-"),
+                str(i.get("username") or i.get("user") or "-"),
+                f"{int(float(i.get('progress') or 0))}%" if i.get("progress") is not None else "-",
+                str(i.get("state") or i.get("status") or "-"),
+            ]
+            for i in items
+        ],
+        title="Currently watching",
+        empty="Nothing is playing.",
+    )
+
+
+@watcher_app.command("logs")
+def watcher_logs(
+    ctx: typer.Context,
+    lines: int = typer.Option(200, "--lines", "-n", min=1, max=3000, help="How many lines to show."),
+    tags: str = typer.Option("", "--tags", help="Comma separated watcher log tags."),
+) -> None:
+    """Show recent watcher log output."""
+    state: Ctx = ctx.obj
+    state.require_service("Reading watcher logs")
+    params: dict[str, Any] = {"tail": lines}
+    if tags.strip():
+        params["tags"] = tags.strip()
+    payload = state.get("/api/logs/watcher", params=params)
+    if not isinstance(payload, dict):
+        raise CLIError("Watcher log endpoint returned an unexpected payload")
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    for line in payload.get("lines") or []:
+        state.out.raw(strip_ansi(str(line)))
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(watcher_app, name="watcher")

--- a/cli/commands/watchlist.py
+++ b/cli/commands/watchlist.py
@@ -1,0 +1,106 @@
+# /cli/commands/watchlist.py
+# CrossWatch - CLI unified watchlist commands
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+from .._context import Ctx
+from .._errors import CLIError
+from .._util import as_dict, error_text
+
+watchlist_app = typer.Typer(help="The unified watchlist across providers.", no_args_is_help=True)
+
+
+def _rows(payload: Any) -> list[dict[str, Any]]:
+    block = as_dict(payload)
+    for key in ("items", "watchlist", "rows", "results"):
+        found = block.get(key)
+        if isinstance(found, list):
+            return [as_dict(i) for i in found]
+    if isinstance(payload, list):
+        return [as_dict(i) for i in payload]
+    return []
+
+
+def _providers(row: dict[str, Any]) -> str:
+    found = row.get("providers") or row.get("sources")
+    if isinstance(found, dict):
+        return ", ".join(sorted(str(k) for k, v in found.items() if v))
+    if isinstance(found, list):
+        return ", ".join(str(v) for v in found)
+    return str(found or "-")
+
+
+@watchlist_app.command("list")
+def watchlist_list(
+    ctx: typer.Context,
+    limit: int = typer.Option(50, "--limit", "-n", help="Maximum rows. 0 means everything."),
+    media_type: str = typer.Option("", "--type", "-t", help="movie or tv."),
+    query: str = typer.Option("", "--search", "-q", help="Filter titles locally."),
+    overview: bool = typer.Option(False, "--overview", help="Include the overview text."),
+) -> None:
+    """List everything on the watchlist."""
+    state: Ctx = ctx.obj
+    params: dict[str, Any] = {"limit": limit, "overview": "short" if overview else "none"}
+    payload = state.get("/api/watchlist", params=params)
+    rows = _rows(payload)
+    if media_type.strip():
+        want = media_type.strip().lower()
+        rows = [r for r in rows if str(r.get("type") or r.get("media_type") or "").lower() == want]
+    if query.strip():
+        needle = query.strip().lower()
+        rows = [r for r in rows if needle in str(r.get("title") or "").lower()]
+    if state.out.json_mode:
+        state.out.data(rows)
+        return
+    columns = [
+        ("KEY", lambda r: str(r.get("key") or r.get("id") or "-")[:28]),
+        ("TITLE", lambda r: str(r.get("title") or "-")[:44]),
+        ("TYPE", lambda r: str(r.get("type") or r.get("media_type") or "-")),
+        ("YEAR", lambda r: str(r.get("year") or "-")),
+        ("PROVIDERS", _providers),
+    ]
+    if overview:
+        columns.append(("OVERVIEW", lambda r: str(r.get("overview") or "-")[:60]))
+    state.out.records(rows, columns, title=f"Watchlist ({len(rows)})", empty="Watchlist is empty.")
+
+
+@watchlist_app.command("remove")
+def watchlist_remove(
+    ctx: typer.Context,
+    keys: list[str] = typer.Argument(..., help="Item keys from 'cw watchlist list'."),
+    provider: str = typer.Option("ALL", "--provider", "-p", help="Remove from one provider, or ALL."),
+    instance: str = typer.Option("", "--instance", "-i", help="Provider instance id."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Remove items from the watchlist."""
+    state: Ctx = ctx.obj
+    state.require_service("Removing from the watchlist")
+    wanted = [k.strip() for k in keys if k.strip()]
+    if not wanted:
+        raise CLIError("Nothing to remove")
+    if not yes:
+        state.out.warn(f"About to remove {len(wanted)} item(s) from {provider}.")
+        if not typer.confirm("Continue?", default=False):
+            raise CLIError("Cancelled", exit_code=0)
+
+    body: dict[str, Any] = {"keys": wanted, "provider": provider}
+    if instance.strip():
+        body["provider_instance"] = instance.strip()
+    path = "/api/watchlist/delete_batch" if len(wanted) > 1 else "/api/watchlist/delete"
+    if len(wanted) == 1:
+        body["key"] = wanted[0]
+    result = as_dict(state.post(path, json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Remove rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Removed {len(wanted)} item(s).")
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(watchlist_app, name="watchlist")

--- a/cli/cw.py
+++ b/cli/cw.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# /cli/cw.py
+# CrossWatch - Command line entry point
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from cli._app import app, main  # noqa: E402
+
+__all__ = ["app", "main"]
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -44,6 +44,12 @@ from api.appAuthAPI import (
     setup_lock_required as app_auth_setup_lock_required,
     register_app_auth,
 )
+from api.apiTokensAPI import (
+    extract_api_token as app_extract_api_token,
+    resolve_api_token as app_resolve_api_token,
+    touch_api_token as app_touch_api_token,
+    register_api_tokens,
+)
 from cw_platform.access_policy import clean_managed_permissions
 from cw_platform.event_archive.audit import record_audit
 
@@ -595,6 +601,25 @@ async def app_auth_gate(request: Request, call_next):
     if not app_auth_required(cfg):
         return await call_next(request)
 
+    api_token = app_extract_api_token(request)
+    if api_token:
+        api_user = app_resolve_api_token(cfg, api_token)
+        if api_user is None:
+            if path.startswith("/api/"):
+                return JSONResponse({"ok": False, "error": "Unauthorized"}, status_code=401, headers={"Cache-Control": "no-store"})
+            return PlainTextResponse("Unauthorized", status_code=401, headers={"Cache-Control": "no-store"})
+        try:
+            request.state.cw_user = api_user
+        except Exception:
+            pass
+        if not api_user.get("is_admin"):
+            if not app_non_admin_api_allowed(path, request.method) or not _non_admin_permission_allowed(api_user, path, request.method):
+                return JSONResponse({"ok": False, "error": "Administrator access required"}, status_code=403, headers={"Cache-Control": "no-store"})
+        app_touch_api_token(str(api_user.get("api_token_id") or ""))
+        response = await call_next(request)
+        _audit_api_action(request, response, api_user)
+        return response
+
     token = request.cookies.get(APP_AUTH_COOKIE)
     if app_is_authenticated(cfg, token):
         if _unsafe_api_origin_blocked(cfg, request, token):
@@ -628,6 +653,7 @@ async def app_auth_gate(request: Request, call_next):
 register_assets_and_favicons(app, ROOT)
 register_ui_root(app)
 register_app_auth(app)
+register_api_tokens(app)
 
 # Misc utilities
 def get_primary_ip() -> str:

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -850,6 +850,7 @@ DEFAULT_CFG: dict[str, Any] = {
             "expires_at": 0,
         },
         "sessions": [],
+        "api_tokens": [],
         "last_login_at": 0,
         "users": {},
     },
@@ -928,6 +929,12 @@ def redact_config(cfg: dict[str, Any]) -> dict[str, Any]:
             for s in sessions:
                 if isinstance(s, dict) and s.get("token_hash"):
                     s["token_hash"] = MASK
+
+        api_tokens = a.get("api_tokens")
+        if isinstance(api_tokens, list):
+            for t in api_tokens:
+                if isinstance(t, dict) and t.get("token_hash"):
+                    t["token_hash"] = MASK
 
         totp = a.get("totp")
         if isinstance(totp, dict):
@@ -2445,6 +2452,10 @@ def _normalize_app_auth(cfg: dict[str, Any]) -> None:
 
     sessions = a.get("sessions")
     a["sessions"] = sessions if isinstance(sessions, list) else []
+
+    api_tokens = a.get("api_tokens")
+    a["api_tokens"] = [x for x in api_tokens if isinstance(x, dict)] if isinstance(api_tokens, list) else []
+
     try:
         a["last_login_at"] = int(a.get("last_login_at", 0) or 0)
     except Exception:

--- a/docker/cw
+++ b/docker/cw
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# CrossWatch - CLI wrapper for the container
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+
+set -Eeuo pipefail
+
+APP_DIR="${APP_DIR:-/app}"
+export PYTHONPATH="${APP_DIR}:${PYTHONPATH:-}"
+export CW_CLI_HOME="${CW_CLI_HOME:-${RUNTIME_DIR:-/config}/.cw_cli}"
+
+exec python "${APP_DIR}/cli/cw.py" "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ packaging
 cryptography
 defusedxml
 qrcode
+typer
+rich

--- a/tests/test_api_tokens.py
+++ b/tests/test_api_tokens.py
@@ -1,0 +1,167 @@
+# tests/test_api_tokens.py
+# CrossWatch - API token tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from starlette.requests import Request
+
+
+def _request(path: str, *, method: str = "GET", headers: dict[str, str] | None = None) -> Request:
+    raw_headers = [(b"host", b"testserver")]
+    for key, value in (headers or {}).items():
+        raw_headers.append((str(key).lower().encode("latin-1"), str(value).encode("latin-1")))
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("latin-1"),
+        "query_string": b"",
+        "headers": raw_headers,
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+    }
+    return Request(scope)
+
+
+@pytest.fixture()
+def tokens_env(config_base: Path, monkeypatch: pytest.MonkeyPatch):
+    import importlib
+
+    from cw_platform import config_base as cfg_base
+
+    importlib.reload(cfg_base)
+    from api import apiTokensAPI
+
+    importlib.reload(apiTokensAPI)
+
+    from api import appAuthAPI as auth
+
+    salt = b"0123456789abcdef"
+    cfg = {
+        "app_auth": {
+            "enabled": True,
+            "username": "admin",
+            "password": {
+                "scheme": "pbkdf2_sha256",
+                "iterations": 260_000,
+                "salt": auth._b64e(salt),
+                "hash": auth._b64e(auth._pbkdf2_hash("secrett1", salt, iterations=260_000)),
+            },
+            "sessions": [],
+            "api_tokens": [],
+        }
+    }
+    (config_base / "config.json").write_text(json.dumps(cfg), encoding="utf-8")
+    apiTokensAPI._TOUCH_CACHE.clear()
+    return apiTokensAPI
+
+
+def test_issue_and_resolve_round_trip(tokens_env) -> None:
+    mod = tokens_env
+    from cw_platform.config_base import load_config
+
+    raw, entry = mod.issue_api_token(load_config(), name="cli", expires_days=0)
+
+    assert raw.startswith(mod.TOKEN_PREFIX)
+    assert entry["name"] == "cli"
+    assert entry["expires_at"] == 0
+    assert raw not in json.dumps(load_config())
+
+    identity = mod.resolve_api_token(load_config(), raw)
+    assert identity is not None
+    assert identity["is_admin"] is True
+    assert identity["auth_kind"] == "api_token"
+    assert identity["api_token_id"] == entry["id"]
+
+
+def test_unknown_and_malformed_tokens_are_rejected(tokens_env) -> None:
+    mod = tokens_env
+    from cw_platform.config_base import load_config
+
+    mod.issue_api_token(load_config(), name="cli")
+    cfg = load_config()
+
+    assert mod.resolve_api_token(cfg, "") is None
+    assert mod.resolve_api_token(cfg, "not-a-token") is None
+    assert mod.resolve_api_token(cfg, mod.TOKEN_PREFIX + "wrongwrongwrong") is None
+
+
+def test_expired_token_is_rejected(tokens_env) -> None:
+    mod = tokens_env
+    from cw_platform.config_base import load_config, update_config
+
+    raw, entry = mod.issue_api_token(load_config(), name="cli", expires_days=1)
+    assert mod.resolve_api_token(load_config(), raw) is not None
+
+    def _expire(cfg: dict) -> None:
+        for item in cfg["app_auth"]["api_tokens"]:
+            if item["id"] == entry["id"]:
+                item["expires_at"] = 1
+
+    update_config(_expire)
+
+    assert mod.resolve_api_token(load_config(), raw) is None
+    assert mod.list_api_tokens(load_config()) == []
+
+
+def test_plain_config_save_cannot_clobber_tokens(tokens_env) -> None:
+    mod = tokens_env
+    from cw_platform.config_base import load_config, save_config
+
+    raw, _entry = mod.issue_api_token(load_config(), name="cli")
+
+    cfg = load_config()
+    cfg["app_auth"]["api_tokens"] = []
+    cfg["scheduling"] = {"enabled": True}
+    save_config(cfg)
+
+    assert mod.resolve_api_token(load_config(), raw) is not None
+
+
+def test_revoke_removes_the_token(tokens_env) -> None:
+    mod = tokens_env
+    from cw_platform.config_base import load_config
+
+    raw, entry = mod.issue_api_token(load_config(), name="cli")
+    assert mod.revoke_api_token(entry["id"]) is True
+    assert mod.resolve_api_token(load_config(), raw) is None
+    assert mod.revoke_api_token(entry["id"]) is False
+
+
+def test_listing_never_exposes_the_secret(tokens_env) -> None:
+    mod = tokens_env
+    from cw_platform.config_base import load_config
+
+    raw, _entry = mod.issue_api_token(load_config(), name="cli")
+    listed = mod.list_api_tokens(load_config())
+
+    assert len(listed) == 1
+    blob = json.dumps(listed)
+    assert raw not in blob
+    assert "token_hash" not in blob
+
+
+def test_extract_reads_header_and_bearer() -> None:
+    from api import apiTokensAPI as mod
+
+    assert mod.extract_api_token(_request("/api/status", headers={"X-CW-Token": "cwt_abc"})) == "cwt_abc"
+    assert mod.extract_api_token(_request("/api/status", headers={"Authorization": "Bearer cwt_xyz"})) == "cwt_xyz"
+    assert mod.extract_api_token(_request("/api/status")) == ""
+
+
+def test_redaction_masks_token_hashes(tokens_env) -> None:
+    mod = tokens_env
+    from cw_platform.config_base import load_config, redact_config
+
+    mod.issue_api_token(load_config(), name="cli")
+    redacted = redact_config(load_config())
+
+    for entry in redacted["app_auth"]["api_tokens"]:
+        assert entry["token_hash"] == "•" * 8

--- a/tests/test_api_tokens.py
+++ b/tests/test_api_tokens.py
@@ -73,6 +73,9 @@ def test_issue_and_resolve_round_trip(tokens_env) -> None:
     assert entry["name"] == "cli"
     assert entry["expires_at"] == 0
     assert raw not in json.dumps(load_config())
+    stored = load_config()["app_auth"]["api_tokens"][0]["token_hash"]
+    assert isinstance(stored, dict)
+    assert stored["scheme"] == "pbkdf2_sha256"
 
     identity = mod.resolve_api_token(load_config(), raw)
     assert identity is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,618 @@
+# tests/test_cli.py
+# CrossWatch - CLI unit tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cli._app import hoist_globals
+from cli._context import Ctx
+from cli._errors import ApiError, CLIError, LocalUnsupported, TransportUnavailable
+from cli._render import Output, _to_yaml
+from cli._transport import Transport
+from cli._util import (
+    coerce_bool,
+    dotted_delete,
+    dotted_get,
+    dotted_payload,
+    find_pair,
+    fmt_duration,
+    pair_features,
+    pair_label,
+    parse_value,
+    split_path,
+    strip_ansi,
+)
+
+
+class FakeTransport(Transport):
+    name = "fake"
+
+    def __init__(self, routes: dict[tuple[str, str], Any] | None = None) -> None:
+        self.routes = routes or {}
+        self.calls: list[tuple[str, str, Any]] = []
+
+    def request(self, method: str, path: str, *, params: dict[str, Any] | None = None, json_body: Any = None) -> Any:
+        self.calls.append((method.upper(), path, json_body))
+        key = (method.upper(), path)
+        if key not in self.routes:
+            raise ApiError(404, {"error": "not found"}, method=method, path=path)
+        value = self.routes[key]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+def _ctx(http: Transport | None = None, local: Transport | None = None, *, force_local: bool = False) -> Ctx:
+    state = Ctx(url="http://cw.test", force_local=force_local, out=Output("json"))
+    state._http = http  # type: ignore[assignment]
+    state._local = local  # type: ignore[assignment]
+    return state
+
+
+def test_split_path_handles_dots_slashes_and_indexes() -> None:
+    assert split_path("sync.anime.enabled") == ["sync", "anime", "enabled"]
+    assert split_path("sync/anime/enabled") == ["sync", "anime", "enabled"]
+    assert split_path("pairs[0].features.history") == ["pairs", "[0]", "features", "history"]
+    with pytest.raises(CLIError):
+        split_path("   ")
+
+
+def test_dotted_get_walks_dicts_and_lists() -> None:
+    data = {"a": {"b": [{"c": 1}]}}
+    assert dotted_get(data, "a.b[0].c") == 1
+    assert dotted_get(data, "a.b[9].c", "fallback") == "fallback"
+    assert dotted_get(data, "a.missing", None) is None
+
+
+def test_dotted_payload_builds_a_merge_patch() -> None:
+    assert dotted_payload("sync.anime.enabled", True) == {"sync": {"anime": {"enabled": True}}}
+    with pytest.raises(CLIError):
+        dotted_payload("pairs[0].enabled", True)
+
+
+def test_dotted_delete_removes_only_what_exists() -> None:
+    data = {"a": {"b": 1, "c": 2}}
+    assert dotted_delete(data, "a.b") is True
+    assert data == {"a": {"c": 2}}
+    assert dotted_delete(data, "a.nope") is False
+    assert dotted_delete(data, "nope.deeper") is False
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("yes", True),
+        ("off", False),
+        ("42", 42),
+        ("-7", -7),
+        ("3.5", 3.5),
+        ("null", None),
+        ("plain text", "plain text"),
+        ("", ""),
+    ],
+)
+def test_parse_value_detects_scalars(raw: str, expected: Any) -> None:
+    assert parse_value(raw) == expected
+
+
+def test_parse_value_json_mode() -> None:
+    assert parse_value('["a","b"]', as_json=True) == ["a", "b"]
+    with pytest.raises(CLIError):
+        parse_value("{not json}", as_json=True)
+
+
+def test_coerce_bool_defaults() -> None:
+    assert coerce_bool(None, True) is True
+    assert coerce_bool("ON") is True
+    assert coerce_bool("nope") is False
+
+
+def test_fmt_duration_scales() -> None:
+    assert fmt_duration(45) == "45s"
+    assert fmt_duration(90) == "1m 30s"
+    assert fmt_duration(3600) == "1h"
+    assert fmt_duration(90000) == "1d 1h"
+
+
+def test_pair_helpers() -> None:
+    pair = {
+        "id": "abc123",
+        "source": "plex",
+        "target": "trakt",
+        "mode": "two-way",
+        "features": {"watchlist": {"enable": True}, "ratings": {"enable": False}, "history": True},
+    }
+    assert pair_label(pair) == "PLEX <-> TRAKT"
+    assert pair_features(pair) == ["history", "watchlist"]
+
+
+def test_find_pair_matches_exact_prefix_and_label() -> None:
+    pairs = [
+        {"id": "abc123", "source": "plex", "target": "trakt"},
+        {"id": "def456", "source": "simkl", "target": "trakt"},
+    ]
+    assert find_pair(pairs, "abc123")["id"] == "abc123"
+    assert find_pair(pairs, "def")["id"] == "def456"
+    assert find_pair(pairs, "PLEX -> TRAKT")["id"] == "abc123"
+    with pytest.raises(CLIError):
+        find_pair(pairs, "nothing")
+
+
+def test_find_pair_rejects_ambiguous_prefix() -> None:
+    pairs = [{"id": "abc1", "source": "a", "target": "b"}, {"id": "abc2", "source": "c", "target": "d"}]
+    with pytest.raises(CLIError) as err:
+        find_pair(pairs, "abc")
+    assert "ambiguous" in err.value.message
+
+
+def test_hoist_globals_moves_flags_in_front_of_the_command() -> None:
+    assert hoist_globals(["pair", "list", "-o", "json"]) == ["-o", "json", "pair", "list"]
+    assert hoist_globals(["sync", "run", "--local", "--pair", "x"]) == ["--local", "sync", "run", "--pair", "x"]
+    assert hoist_globals(["--output=json", "status"]) == ["--output=json", "status"]
+
+
+def test_hoist_globals_leaves_subcommand_timeout_alone() -> None:
+    assert hoist_globals(["sync", "run", "--timeout", "30"]) == ["sync", "run", "--timeout", "30"]
+    assert hoist_globals(["-U", "http://x", "sync", "run", "--timeout", "30"]) == [
+        "-U",
+        "http://x",
+        "sync",
+        "run",
+        "--timeout",
+        "30",
+    ]
+
+
+def test_hoist_globals_stops_at_double_dash() -> None:
+    assert hoist_globals(["logs", "tail", "--", "-o", "json"]) == ["logs", "tail", "--", "-o", "json"]
+
+
+def test_api_error_maps_status_to_exit_code() -> None:
+    assert ApiError(401, {}).exit_code == 4
+    assert ApiError(403, {}).exit_code == 4
+    assert ApiError(404, {}).exit_code == 5
+    assert ApiError(409, {}).exit_code == 6
+    assert ApiError(500, {}).exit_code == 1
+
+
+def test_api_error_uses_server_detail() -> None:
+    err = ApiError(400, {"error": "Sync already running"}, method="POST", path="/api/run")
+    assert "Sync already running" in err.message
+    assert "POST /api/run" in err.message
+
+
+def test_context_falls_back_to_local_when_service_is_down() -> None:
+    http = FakeTransport({("GET", "/api/status"): TransportUnavailable("down")})
+    local = FakeTransport({("GET", "/api/status"): {"ok": True, "mode": "local"}})
+    state = _ctx(http, local)
+
+    assert state.get("/api/status") == {"ok": True, "mode": "local"}
+    assert state.mode == "local (fallback)"
+
+
+def test_context_reports_unreachable_when_local_cannot_serve_it() -> None:
+    http = FakeTransport({("POST", "/api/run"): TransportUnavailable("Cannot reach CrossWatch at http://cw.test")})
+    local = FakeTransport({("POST", "/api/run"): LocalUnsupported("Starting a sync")})
+    state = _ctx(http, local)
+
+    with pytest.raises(TransportUnavailable) as err:
+        state.post("/api/run")
+    assert "Cannot reach CrossWatch" in err.value.message
+    assert err.value.exit_code == 3
+
+
+def test_context_does_not_fall_back_on_auth_errors() -> None:
+    http = FakeTransport({("GET", "/api/status"): ApiError(401, {"error": "Unauthorized"})})
+    local = FakeTransport({("GET", "/api/status"): {"ok": True}})
+    state = _ctx(http, local)
+
+    with pytest.raises(ApiError) as err:
+        state.get("/api/status")
+    assert err.value.status == 401
+
+
+def test_force_local_never_touches_http() -> None:
+    http = FakeTransport({("GET", "/api/status"): {"from": "http"}})
+    local = FakeTransport({("GET", "/api/status"): {"from": "local"}})
+    state = _ctx(http, local, force_local=True)
+
+    assert state.get("/api/status") == {"from": "local"}
+    assert http.calls == []
+    with pytest.raises(LocalUnsupported):
+        state.require_service("Starting a sync")
+
+
+def test_strip_ansi_removes_colour_codes() -> None:
+    assert strip_ansi("\x1b[92m[TRAKT]\x1b[0m done") == "[TRAKT] done"
+
+
+def test_yaml_rendering_round_trips_simple_structures() -> None:
+    rendered = _to_yaml({"enabled": True, "count": 3, "name": "sync", "empty": None, "items": ["a", "b"]})
+    assert "enabled: true" in rendered
+    assert "count: 3" in rendered
+    assert "empty: null" in rendered
+    assert "- a" in rendered
+
+
+def test_local_transport_serves_config_and_pairs(config_base: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib
+
+    from cw_platform import config_base as cfg_base
+
+    importlib.reload(cfg_base)
+    (config_base / "config.json").write_text(
+        json.dumps({"pairs": [{"id": "p1", "source": "plex", "target": "trakt", "enabled": True}]}),
+        encoding="utf-8",
+    )
+
+    from cli import _local
+
+    importlib.reload(_local)
+    transport = _local.LocalTransport()
+
+    pairs = transport.request("GET", "/api/pairs")
+    assert [p["id"] for p in pairs] == ["p1"]
+
+    assert transport.request("PUT", "/api/pairs/p1", json_body={"enabled": False})["ok"] is True
+    assert transport.request("GET", "/api/pairs")[0]["enabled"] is False
+
+    assert transport.request("PUT", "/api/pairs/nope", json_body={"enabled": False})["ok"] is False
+
+    with pytest.raises(LocalUnsupported):
+        transport.request("POST", "/api/run")
+
+
+def test_local_transport_config_set_deep_merges(config_base: Path) -> None:
+    import importlib
+
+    from cw_platform import config_base as cfg_base
+
+    importlib.reload(cfg_base)
+    (config_base / "config.json").write_text(json.dumps({"sync": {"keep": 1}}), encoding="utf-8")
+
+    from cli import _local
+
+    importlib.reload(_local)
+    transport = _local.LocalTransport()
+
+    transport.request("POST", "/api/config", json_body={"sync": {"anime": {"enabled": True}}})
+    cfg = transport.request("GET", "/api/config")
+
+    assert cfg["sync"]["keep"] == 1
+    assert cfg["sync"]["anime"]["enabled"] is True
+
+
+def test_local_transport_config_unset_removes_keys(config_base: Path) -> None:
+    import importlib
+
+    from cw_platform import config_base as cfg_base
+
+    importlib.reload(cfg_base)
+    (config_base / "config.json").write_text(
+        json.dumps({"sync": {"keep": 1, "drop": 2}, "pairs": [{"id": "a"}, {"id": "b"}]}),
+        encoding="utf-8",
+    )
+
+    from cli import _local
+
+    importlib.reload(_local)
+    transport = _local.LocalTransport()
+
+    assert transport.request("POST", "/api/config/unset", json_body={"paths": ["sync.drop"]})["ok"] is True
+    cfg = transport.request("GET", "/api/config")
+    assert cfg["sync"]["keep"] == 1
+    assert "drop" not in cfg["sync"]
+
+    missing = transport.request("POST", "/api/config/unset", json_body={"paths": ["sync.gone"]})
+    assert missing["ok"] is False
+    assert missing["error"] == "not_found"
+
+    protected = transport.request("POST", "/api/config/unset", json_body={"paths": ["app_auth.enabled"]})
+    assert protected["ok"] is False
+    assert protected["error"] == "protected_path"
+
+
+def test_config_path_helpers_match_the_cli_parser() -> None:
+    from api.configAPI import _delete_config_path, _split_config_path
+
+    assert _split_config_path("sync.anime.enabled") == split_path("sync.anime.enabled")
+    assert _split_config_path("pairs[0].features") == split_path("pairs[0].features")
+
+    data = {"pairs": [{"id": "a"}, {"id": "b"}], "sync": {"x": 1}}
+    assert _delete_config_path(data, _split_config_path("pairs[0]")) is True
+    assert [p["id"] for p in data["pairs"]] == ["b"]
+    assert _delete_config_path(data, _split_config_path("sync.missing")) is False
+    assert _delete_config_path(data, _split_config_path("pairs[9]")) is False
+
+
+def test_log_control_lines_are_filtered() -> None:
+    from cli._util import is_log_control
+
+    assert is_log_control("::CLEAR::") is True
+    assert is_log_control("  ::CLEAR::  ") is True
+    assert is_log_control("[SYNC] exit code: 0") is False
+
+
+def test_entry_point_is_lowercase_cw_py() -> None:
+    import os
+
+    cli_dir = Path(__file__).resolve().parents[1] / "cli"
+    names = os.listdir(cli_dir)
+
+    assert "cw.py" in names
+    assert "CW.py" not in names
+
+
+def test_entry_point_exposes_app_and_main() -> None:
+    from cli import cw
+
+    assert callable(cw.main)
+    assert cw.app is not None
+
+
+def test_cli_home_uses_runtime_dir_in_the_container(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cli._settings import cli_home
+
+    monkeypatch.delenv("CW_CLI_HOME", raising=False)
+    monkeypatch.setenv("RUNTIME_DIR", "/config")
+
+    assert cli_home() == Path("/config/.cw_cli")
+
+
+def test_cli_home_env_override_still_wins(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from cli._settings import cli_home
+
+    custom = tmp_path / "custom-cli"
+    monkeypatch.setenv("CW_CLI_HOME", str(custom))
+    monkeypatch.setenv("RUNTIME_DIR", "/config")
+
+    assert cli_home() == custom
+
+
+def test_entry_point_is_directly_executable_in_the_container() -> None:
+    entrypoint = (Path(__file__).resolve().parents[1] / "cli" / "cw.py").read_text(encoding="utf-8").splitlines()
+
+    assert entrypoint[0] == "#!/usr/bin/env python3"
+
+
+def test_container_wrapper_points_at_the_entry_point() -> None:
+    wrapper = (Path(__file__).resolve().parents[1] / "docker" / "cw").read_text(encoding="utf-8")
+
+    assert 'APP_DIR="${APP_DIR:-/app}"' in wrapper
+    assert 'CW_CLI_HOME="${CW_CLI_HOME:-${RUNTIME_DIR:-/config}/.cw_cli}"' in wrapper
+    assert "/cli/cw.py" in wrapper
+    assert "CW.py" not in wrapper
+
+
+def test_container_installs_cw_command_on_the_path() -> None:
+    dockerfile = (Path(__file__).resolve().parents[1] / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "COPY docker/cw            /usr/local/bin/cw" in dockerfile
+    assert "chmod +x" in dockerfile
+    assert "/usr/local/bin/cw" in dockerfile
+
+
+def test_new_modules_carry_the_project_header() -> None:
+    root = Path(__file__).resolve().parents[1]
+    modules = sorted((root / "cli").rglob("*.py")) + [root / "api" / "apiTokensAPI.py"]
+
+    assert modules
+    for module in modules:
+        lines = module.read_text(encoding="utf-8").splitlines()
+        if lines and lines[0].startswith("#!"):
+            lines = lines[1:]
+        lines = lines[:3]
+        relative = module.relative_to(root).as_posix()
+        assert lines[0] == f"# /{relative}", relative
+        assert lines[1].startswith("# CrossWatch - "), relative
+        assert lines[2].startswith("# Copyright (c) 2025-2026 CrossWatch / Cenodude"), relative
+
+
+@pytest.fixture()
+def clean_cli_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CW_CLI_HOME", str(tmp_path / "cli-home"))
+    for name in ("CW_URL", "CROSSWATCH_URL", "CW_TOKEN", "CROSSWATCH_TOKEN"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_build_records_the_options_it_was_given() -> None:
+    state = Ctx.build(url="http://cw.test", output="json", local=True, quiet=True)
+
+    assert state.options["url"] == "http://cw.test"
+    assert state.options["local"] is True
+    assert state.options["output"] == "json"
+    assert state.options["quiet"] is True
+
+
+def test_dispatch_inherits_session_globals(clean_cli_env, capsys: pytest.CaptureFixture[str]) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://inherited.test", output="json", local=True)
+    assert run_isolated(state, ["config", "path"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["endpoint"] == "http://inherited.test"
+
+
+def test_dispatch_lets_a_flag_override_just_that_command(clean_cli_env, capsys: pytest.CaptureFixture[str]) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://inherited.test", output="json", local=True)
+
+    assert run_isolated(state, ["-U", "http://override.test", "config", "path"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["endpoint"] == "http://override.test"
+
+    assert state.url == "http://inherited.test"
+    assert state.options["local"] is True
+
+    assert run_isolated(state, ["config", "path"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["endpoint"] == "http://inherited.test"
+
+
+def test_dispatch_without_flags_reuses_the_same_context(clean_cli_env) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://inherited.test", output="json", local=True)
+    state._fell_back = True
+
+    assert run_isolated(state, ["config", "path"]) == 0
+    assert state._fell_back is True
+
+
+def _manifest(name: str, flow: str, fields: list[dict[str, Any]] | None = None):
+    from cli.commands.auth import Manifest
+
+    return Manifest(name=name, label=name.title(), flow=flow, fields=fields or [])
+
+
+def test_every_manifest_provider_has_cli_endpoints() -> None:
+    from cli.commands.auth import ENDPOINTS
+    from providers.auth.registry import auth_providers_manifests
+
+    shipped = {str(m.get("name") or "").upper() for m in auth_providers_manifests()}
+
+    assert shipped, "no auth providers discovered"
+    missing = sorted(shipped - set(ENDPOINTS))
+    assert missing == [], f"providers with no CLI endpoints: {missing}"
+
+    stale = sorted(set(ENDPOINTS) - shipped)
+    assert stale == [], f"CLI endpoints for providers that no longer exist: {stale}"
+
+
+def test_every_provider_is_loginable() -> None:
+    from cli.commands.auth import ENDPOINTS
+
+    for name, endpoints in ENDPOINTS.items():
+        assert endpoints.submit or endpoints.start, f"{name} has no way to log in"
+        assert endpoints.disconnect, f"{name} has no way to log out"
+
+
+def test_field_body_strips_the_provider_prefix() -> None:
+    from cli.commands.auth import _nest
+
+    values = {"jellyfin.server": "http://jf", "jellyfin.username": "bob"}
+    assert _nest(values, drop_prefix=True) == {"server": "http://jf", "username": "bob"}
+
+
+def test_field_body_keeps_nested_keys() -> None:
+    from cli.commands.auth import _nest
+
+    values = {"tautulli.server_url": "http://t", "tautulli.history.user_id": "7"}
+    assert _nest(values, drop_prefix=True) == {"server_url": "http://t", "history": {"user_id": "7"}}
+
+
+def test_config_body_keeps_the_provider_prefix() -> None:
+    from cli.commands.auth import _nest
+
+    values = {"simkl.client_id": "abc", "simkl.client_secret": "xyz"}
+    assert _nest(values, drop_prefix=False) == {"simkl": {"client_id": "abc", "client_secret": "xyz"}}
+
+
+def test_parse_field_args_requires_key_equals_value() -> None:
+    from cli.commands.auth import _parse_field_args
+
+    assert _parse_field_args(["a=1", "b=with=equals"]) == {"a": "1", "b": "with=equals"}
+    assert _parse_field_args(["a="]) == {"a": ""}
+    with pytest.raises(CLIError):
+        _parse_field_args(["nope"])
+
+
+def test_collect_fields_accepts_long_and_short_keys() -> None:
+    from cli.commands.auth import _collect_fields
+
+    manifest = _manifest(
+        "JELLYFIN",
+        "token",
+        [
+            {"key": "jellyfin.server", "label": "Server", "type": "text", "required": True},
+            {"key": "jellyfin.username", "label": "User", "type": "text"},
+        ],
+    )
+    values = _collect_fields(manifest, {"jellyfin.server": "http://jf", "username": "bob"}, interactive=False)
+    assert values == {"jellyfin.server": "http://jf", "jellyfin.username": "bob"}
+
+
+def test_collect_fields_coerces_bools() -> None:
+    from cli.commands.auth import _collect_fields
+
+    manifest = _manifest("FLOPPY", "api_key", [{"key": "floppy.verify_ssl", "label": "Verify", "type": "bool"}])
+    assert _collect_fields(manifest, {"floppy.verify_ssl": "no"}, interactive=False) == {"floppy.verify_ssl": False}
+
+
+def test_collect_fields_rejects_unknown_fields_first() -> None:
+    from cli.commands.auth import _collect_fields
+
+    manifest = _manifest("JELLYFIN", "token", [{"key": "jellyfin.server", "label": "Server", "required": True}])
+    with pytest.raises(CLIError) as err:
+        _collect_fields(manifest, {"bogus": "x"}, interactive=False)
+    assert "no field named" in err.value.message
+
+
+def test_collect_fields_requires_required_fields_when_not_prompting() -> None:
+    from cli.commands.auth import _collect_fields
+
+    manifest = _manifest("TAUTULLI", "api_keys", [{"key": "tautulli.server_url", "label": "Server", "required": True}])
+    with pytest.raises(CLIError) as err:
+        _collect_fields(manifest, {}, interactive=False)
+    assert err.value.exit_code == 2
+    assert "--field tautulli.server_url=" in err.value.hint
+
+
+def test_collect_fields_skips_optional_fields_when_not_prompting() -> None:
+    from cli.commands.auth import _collect_fields
+
+    manifest = _manifest("MDBLIST", "device_code", [{"key": "mdblist.api_key", "label": "Key"}])
+    assert _collect_fields(manifest, {}, interactive=False) == {}
+
+
+def test_every_command_group_is_registered() -> None:
+    from cli._app import describe_commands
+
+    names = {name for name, _ in describe_commands()}
+    expected = {
+        "status", "version", "health", "shell", "insights", "stats",
+        "pair", "sync", "config", "auth", "watcher", "scheduler", "logs",
+        "analyzer", "events", "capture", "backup", "watchlist", "progress",
+        "editor", "playlist", "export", "import", "metadata", "manual",
+        "anime", "instance", "user-profile", "scrobbler", "activity", "maintenance",
+    }
+    assert expected <= names, f"missing groups: {sorted(expected - names)}"
+
+
+def test_shell_knows_every_group() -> None:
+    from cli._app import describe_commands, describe_group
+    from cli.commands.shell import GROUPS
+
+    groups = {name for name, _ in describe_commands() if describe_group(name)}
+    assert set(GROUPS) <= groups, f"shell lists unknown groups: {sorted(set(GROUPS) - groups)}"
+    assert groups <= set(GROUPS), f"shell is missing groups: {sorted(groups - set(GROUPS))}"
+
+
+def test_error_text_prefers_the_server_message() -> None:
+    from cli._util import error_text
+
+    assert error_text({"message": "real reason", "error": "code"}) == "real reason"
+    assert error_text({"error": "code"}) == "code"
+    assert error_text({"found": False}) == "not found"
+    assert error_text({}, "fallback") == "fallback"
+    assert error_text(None, "fallback") == "fallback"
+
+
+def test_api_error_prefers_the_server_message() -> None:
+    err = ApiError(400, {"error": "invalid_rule", "message": "match_provider must be one of: tvdb"})
+    assert "match_provider must be one of" in err.message
+
+
+def test_auth_field_nesting_round_trip() -> None:
+    from cli.commands.auth import _nest
+
+    assert _nest({"a.b.c": 1}, drop_prefix=True) == {"b": {"c": 1}}
+    assert _nest({"a.b.c": 1}, drop_prefix=False) == {"a": {"b": {"c": 1}}}
+    assert _nest({"solo": 1}, drop_prefix=True) == {}


### PR DESCRIPTION
# Pull request

## Change

- Add the CrossWatch CLI
- Add API token support for CLI and headless access
- Add local fallback for read only and repair commands
- Add `cw` as a container command from any directory
- Store CLI settings under `/config/.cw_cli` in containers
- Add CLI docs and tests

## Why

CW can be managed from the terminal, scripts, cron, and containers without using the web UI.

## Testing

- tests/test_cli.py 
- tests/test_api_tokens.py

## Issue

Relates to #839