### PR TITLE
Add: CLI watcher and CLI-only container mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 # --- minimal OS deps ---
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates tzdata bash curl util-linux \
+ && apt-get install -y --no-install-recommends ca-certificates tzdata bash curl util-linux nano \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -63,8 +63,10 @@ RUN printf '%s' "${APP_VERSION}" > /app/VERSION && chmod 0444 /app/VERSION
 ENV RUNTIME_DIR=/config \
     WEB_HOST=0.0.0.0 \
     WEB_PORT=8787 \
-    WEBINTERFACE=yes \
-    DEV_SHELL_ON_FAIL=yes
+    CW_CLI_ONLY=0 \
+    DEV_SHELL_ON_FAIL=yes \
+    EDITOR=nano \
+    VISUAL=nano
 
 # --- healthcheck ---
 HEALTHCHECK --interval=30s --timeout=5s --retries=5 \

--- a/cli/_util.py
+++ b/cli/_util.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import re
 from datetime import datetime, timezone
+from html import unescape
 from typing import Any
 
 from ._errors import CLIError, EXIT_USAGE
@@ -239,6 +240,8 @@ def find_pair(pairs: list[dict[str, Any]], needle: str) -> dict[str, Any]:
 
 
 LOG_CONTROL_LINES = {"::CLEAR::"}
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+_SPAN_RE = re.compile(r"</?span\b[^>]*>", re.IGNORECASE)
 
 
 def is_log_control(line: str) -> bool:
@@ -246,4 +249,6 @@ def is_log_control(line: str) -> bool:
 
 
 def strip_ansi(text: str) -> str:
-    return re.sub(r"\x1b\[[0-9;?]*[ -/]*[@-~]", "", str(text or ""))
+    cleaned = _ANSI_RE.sub("", str(text or ""))
+    cleaned = _SPAN_RE.sub("", cleaned)
+    return unescape(cleaned)

--- a/cli/commands/analyzer.py
+++ b/cli/commands/analyzer.py
@@ -29,6 +29,48 @@ def _items(payload: Any, *keys: str) -> list[dict[str, Any]]:
     return []
 
 
+def _item_title(row: dict[str, Any]) -> str:
+    item_type = str(row.get("item_type") or row.get("type") or row.get("type_name") or "").lower()
+    series = str(row.get("series_title") or "").strip()
+    title = str(row.get("title") or row.get("item_title") or "").strip()
+    season = row.get("season")
+    episode = row.get("episode")
+    if item_type == "episode" and series and season is not None and episode is not None:
+        try:
+            return f"{series} - S{int(season):02d}E{int(episode):02d}"
+        except Exception:
+            return f"{series} - S{season}E{episode}"
+    if item_type == "season" and series and season is not None:
+        try:
+            return f"{series} - S{int(season):02d}"
+        except Exception:
+            return f"{series} - S{season}"
+    return title or str(row.get("key") or "-")
+
+
+def _problem_detail(row: dict[str, Any]) -> str:
+    message = str(row.get("message") or row.get("text") or "").strip()
+    if message:
+        return message
+    targets = [str(t or "").upper() for t in row.get("targets") or [] if str(t or "").strip()]
+    if targets:
+        return "Missing at " + " & ".join(targets)
+    for detail in row.get("target_show_info") or []:
+        if isinstance(detail, dict) and str(detail.get("message") or "").strip():
+            return str(detail.get("message")).strip()
+    for hint in row.get("hints") or []:
+        if not isinstance(hint, dict):
+            continue
+        if str(hint.get("message") or "").strip():
+            return str(hint.get("message")).strip()
+        reasons = hint.get("reasons")
+        if isinstance(reasons, list) and reasons:
+            return ", ".join(str(r) for r in reasons if str(r).strip())
+        if str(hint.get("reason") or "").strip():
+            return str(hint.get("reason")).strip()
+    return str(row.get("code") or row.get("id") or row.get("type") or "-")
+
+
 @analyzer_app.command("problems")
 def analyzer_problems(
     ctx: typer.Context,
@@ -51,10 +93,11 @@ def analyzer_problems(
         rows[: max(1, limit)],
         [
             ("SEVERITY", lambda r: str(r.get("severity") or r.get("level") or "-")),
-            ("CODE", lambda r: str(r.get("code") or r.get("id") or "-")),
             ("PROVIDER", lambda r: str(r.get("provider") or "-")),
             ("FEATURE", lambda r: str(r.get("feature") or "-")),
-            ("WHAT", lambda r: str(r.get("message") or r.get("title") or r.get("text") or "-")[:60]),
+            ("TITLE", lambda r: _item_title(r)[:56]),
+            ("TYPE", lambda r: str(r.get("item_type") or r.get("type_name") or r.get("type") or "-")),
+            ("DETAIL", lambda r: _problem_detail(r)[:72]),
         ],
         title=f"Problems ({len(rows)})",
         empty="Nothing flagged.",

--- a/cli/commands/watcher.py
+++ b/cli/commands/watcher.py
@@ -13,6 +13,7 @@ from .._render import state_text
 from .._util import as_dict, coerce_bool, strip_ansi
 
 watcher_app = typer.Typer(help="Control the scrobble watcher.", no_args_is_help=True)
+DEFAULT_WATCHER_LOG_TAGS = "WATCH,WATCHM"
 
 
 def _status(state: Ctx) -> dict[str, Any]:
@@ -52,6 +53,47 @@ def _render(state: Ctx, payload: dict[str, Any]) -> None:
             ],
             title="Routes",
         )
+
+
+def _currently_watching_items(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [i for i in payload if isinstance(i, dict)]
+    if not isinstance(payload, dict):
+        return []
+
+    streams = payload.get("streams")
+    if isinstance(streams, list):
+        items = [i for i in streams if isinstance(i, dict)]
+        if items:
+            return items
+
+    items = payload.get("items")
+    if isinstance(items, list):
+        out = [i for i in items if isinstance(i, dict)]
+        if out:
+            return out
+
+    current = payload.get("currently_watching")
+    if isinstance(current, list):
+        return [i for i in current if isinstance(i, dict)]
+    if isinstance(current, dict) and (current.get("title") or current.get("name")):
+        return [current]
+
+    if payload.get("title") or payload.get("name"):
+        return [payload]
+    return []
+
+
+def _progress(item: dict[str, Any]) -> str:
+    value = item.get("progress")
+    if value is None:
+        value = item.get("progress_percent")
+    if value is None:
+        value = item.get("percent")
+    try:
+        return f"{int(float(value))}%"
+    except Exception:
+        return "-"
 
 
 @watcher_app.command("status")
@@ -105,19 +147,16 @@ def watcher_now(ctx: typer.Context) -> None:
     if state.out.json_mode:
         state.out.data(payload)
         return
-    items = payload if isinstance(payload, list) else (payload or {}).get("items") or []
-    items = [i for i in items if isinstance(i, dict)]
-    if not items and isinstance(payload, dict) and payload.get("title"):
-        items = [payload]
+    items = _currently_watching_items(payload)
     state.out.table(
         ["TITLE", "TYPE", "PROVIDER", "USER", "PROGRESS", "STATE"],
         [
             [
                 str(i.get("title") or i.get("name") or "-")[:52],
                 str(i.get("type") or i.get("media_type") or "-"),
-                str(i.get("provider") or i.get("server") or "-"),
-                str(i.get("username") or i.get("user") or "-"),
-                f"{int(float(i.get('progress') or 0))}%" if i.get("progress") is not None else "-",
+                str(i.get("provider") or i.get("source") or i.get("server") or "-"),
+                str(i.get("username") or i.get("user") or i.get("account") or "-"),
+                _progress(i),
                 str(i.get("state") or i.get("status") or "-"),
             ]
             for i in items
@@ -131,15 +170,13 @@ def watcher_now(ctx: typer.Context) -> None:
 def watcher_logs(
     ctx: typer.Context,
     lines: int = typer.Option(200, "--lines", "-n", min=1, max=3000, help="How many lines to show."),
-    tags: str = typer.Option("", "--tags", help="Comma separated watcher log tags."),
+    tags: str = typer.Option(DEFAULT_WATCHER_LOG_TAGS, "--tags", help="Comma separated watcher log tags."),
 ) -> None:
     """Show recent watcher log output."""
     state: Ctx = ctx.obj
     state.require_service("Reading watcher logs")
-    params: dict[str, Any] = {"tail": lines}
-    if tags.strip():
-        params["tags"] = tags.strip()
-    payload = state.get("/api/logs/watcher", params=params)
+    params: dict[str, Any] = {"tail": lines, "tags": tags.strip() or DEFAULT_WATCHER_LOG_TAGS}
+    payload = state.get("/api/watch/logs", params=params)
     if not isinstance(payload, dict):
         raise CLIError("Watcher log endpoint returned an unexpected payload")
     if state.out.json_mode:

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -173,6 +173,40 @@ def _env_truthy(name: str) -> bool:
     return str(os.getenv(name) or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+_WEBUI_PATHS = {
+    "/",
+    "/profile",
+    "/login",
+    "/logout",
+    "/favicon.ico",
+    "/favicon.svg",
+    "/favicon.png",
+    "/manifest.webmanifest",
+    "/sw.js",
+}
+
+
+def _cli_only_mode() -> bool:
+    return _env_truthy("CW_CLI_ONLY")
+
+
+def _webui_disabled_path(path: str) -> bool:
+    path = str(path or "/")
+    if path.startswith("/api/") or path.startswith("/webhook/"):
+        return False
+    if path == "/callback" or path.startswith("/callback/"):
+        return False
+    return path in _WEBUI_PATHS or path.startswith("/assets/")
+
+
+def _webui_disabled_response() -> PlainTextResponse:
+    return PlainTextResponse(
+        "CrossWatch web UI is disabled. Use the cw CLI or /api endpoints.",
+        status_code=404,
+        headers={"Cache-Control": "no-store"},
+    )
+
+
 def _apply_auth_reset_env_once() -> None:
     global _AUTH_RESET_ENV_APPLIED
     if _AUTH_RESET_ENV_APPLIED:
@@ -564,6 +598,9 @@ async def app_auth_gate(request: Request, call_next):
         return PlainTextResponse("Service unavailable", status_code=503, headers={"Cache-Control": "no-store"})
 
     path = request.url.path or "/"
+    if _cli_only_mode() and _webui_disabled_path(path):
+        return _webui_disabled_response()
+
     if path.startswith("/assets/"):
         return await call_next(request)
     
@@ -650,8 +687,9 @@ async def app_auth_gate(request: Request, call_next):
     return RedirectResponse(url="/login?next=" + quote(next_url), status_code=302)
 
 # Static files
-register_assets_and_favicons(app, ROOT)
-register_ui_root(app)
+if not _cli_only_mode():
+    register_assets_and_favicons(app, ROOT)
+    register_ui_root(app)
 register_app_auth(app)
 register_api_tokens(app)
 
@@ -1449,6 +1487,7 @@ def main(host: str = "0.0.0.0", port: int = 8787) -> None:
     boot.info(f"  {_c('Local:', DIM)}   {_c(f'{protocol}://127.0.0.1:{port}', GREEN)}")
     boot.info(f"  {_c('Docker:', DIM)}  {_c(f'{protocol}://{ip}:{port}', GREEN)}")
     boot.info(f"  {_c('Bind:', DIM)}    {_c(f'{host}:{port}', GREEN)}")
+    boot.info(f"  {_c('Mode:', DIM)}    {'CLI/API only' if _cli_only_mode() else 'Web UI + CLI/API'}")
     boot.info("")
     boot.info(f"  {_c('Cache:', DIM)}      {CACHE_DIR}")
     boot.info(f"  {_c('CW_STATE:', DIM)}   {CW_STATE_DIR}")

--- a/tests/test_app_auth_api.py
+++ b/tests/test_app_auth_api.py
@@ -842,6 +842,34 @@ def test_fastapi_docs_are_disabled() -> None:
     assert crosswatch.app.openapi_url is None
 
 
+def test_cli_only_env_disables_webui_but_not_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    import crosswatch
+
+    monkeypatch.setenv("CW_CLI_ONLY", "1")
+
+    assert crosswatch._cli_only_mode() is True
+    assert crosswatch._webui_disabled_path("/") is True
+    assert crosswatch._webui_disabled_path("/login") is True
+    assert crosswatch._webui_disabled_path("/assets/crosswatch.js") is True
+    assert crosswatch._webui_disabled_path("/api/status") is False
+    assert crosswatch._webui_disabled_path("/webhook/plex") is False
+    assert crosswatch._webui_disabled_path("/callback/trakt") is False
+
+
+def test_cli_only_mode_blocks_ui_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fastapi.testclient import TestClient
+
+    import crosswatch
+
+    monkeypatch.setenv("CW_CLI_ONLY", "1")
+    monkeypatch.setattr(crosswatch, "load_config", lambda: {"app_auth": {"enabled": False}})
+
+    res = TestClient(crosswatch.app).get("/", follow_redirects=False)
+
+    assert res.status_code == 404
+    assert "web UI is disabled" in res.text
+
+
 def test_non_admin_permissions_gate_feature_reads() -> None:
     import crosswatch
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,9 +35,11 @@ class FakeTransport(Transport):
     def __init__(self, routes: dict[tuple[str, str], Any] | None = None) -> None:
         self.routes = routes or {}
         self.calls: list[tuple[str, str, Any]] = []
+        self.param_calls: list[tuple[str, str, dict[str, Any] | None, Any]] = []
 
     def request(self, method: str, path: str, *, params: dict[str, Any] | None = None, json_body: Any = None) -> Any:
         self.calls.append((method.upper(), path, json_body))
+        self.param_calls.append((method.upper(), path, params, json_body))
         key = (method.upper(), path)
         if key not in self.routes:
             raise ApiError(404, {"error": "not found"}, method=method, path=path)
@@ -229,6 +231,7 @@ def test_force_local_never_touches_http() -> None:
 
 def test_strip_ansi_removes_colour_codes() -> None:
     assert strip_ansi("\x1b[92m[TRAKT]\x1b[0m done") == "[TRAKT] done"
+    assert strip_ansi('[WATCH] <span class="c94">INFO</span> route started') == "[WATCH] INFO route started"
 
 
 def test_yaml_rendering_round_trips_simple_structures() -> None:
@@ -464,6 +467,107 @@ def test_dispatch_without_flags_reuses_the_same_context(clean_cli_env) -> None:
 
     assert run_isolated(state, ["config", "path"]) == 0
     assert state._fell_back is True
+
+
+def test_analyzer_problems_prints_titles_for_missing_items(
+    clean_cli_env,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://cw.test", output="plain")
+    state._http = FakeTransport(
+        {
+            (
+                "GET",
+                "/api/analyzer/problems",
+            ): {
+                "problems": [
+                    {
+                        "severity": "warn",
+                        "type": "missing_peer",
+                        "provider": "NUVIO",
+                        "feature": "history",
+                        "key": "tmdb:329491",
+                        "title": "Episode 1",
+                        "series_title": "DAHMER - Monster: The Jeffrey Dahmer Story",
+                        "item_type": "episode",
+                        "season": 1,
+                        "episode": 1,
+                        "targets": ["FLOPPY"],
+                    }
+                ]
+            },
+        }
+    )
+
+    assert run_isolated(state, ["analyzer", "problems"]) == 0
+    out = capsys.readouterr().out
+
+    assert "DAHMER - Monster: The Jeffrey Dahmer Story - S01E01" in out
+    assert "Missing at FLOPPY" in out
+
+
+def test_watcher_now_reads_currently_watching_payload(
+    clean_cli_env,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://cw.test", output="plain")
+    state._http = FakeTransport(
+        {
+            (
+                "GET",
+                "/api/watch/currently_watching",
+            ): {
+                "ok": True,
+                "currently_watching": {
+                    "title": "Heat",
+                    "media_type": "movie",
+                    "source": "PLEX",
+                    "account": "Pascal",
+                    "progress_percent": 42,
+                    "state": "playing",
+                },
+                "streams_count": 1,
+            },
+        }
+    )
+
+    assert run_isolated(state, ["watcher", "now"]) == 0
+    out = capsys.readouterr().out
+
+    assert "Heat" in out
+    assert "PLEX" in out
+    assert "42%" in out
+
+
+def test_watcher_logs_uses_finite_watch_log_endpoint(
+    clean_cli_env,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://cw.test", output="plain")
+    state._http = FakeTransport(
+        {
+            ("GET", "/api/watch/logs"): {
+                "tags": ["WATCH"],
+                "tail": 20,
+                "lines": ['[WATCH] <span class="c94">INFO</span> route started'],
+            },
+        }
+    )
+
+    assert run_isolated(state, ["watcher", "logs", "--lines", "20"]) == 0
+    out = capsys.readouterr().out
+    assert "[WATCH] INFO route started" in out
+    assert "<span" not in out
+    assert state._http.calls == [("GET", "/api/watch/logs", None)]
+    assert state._http.param_calls == [
+        ("GET", "/api/watch/logs", {"tail": 20, "tags": "WATCH,WATCHM"}, None)
+    ]
 
 
 def _manifest(name: str, flow: str, fields: list[dict[str, Any]] | None = None):


### PR DESCRIPTION
# Pull request

## Change

- Add `CW_CLI_ONLY=1` for API/CLI-only container mode.
- Disable Web UI routes/assets when CLI-only mode is on.
- Show the active mode in startup logs.
- Improve `cw analyzer problems` with titles, item types, and clearer details.
- Improve `cw watcher now` payload handling.
- Make `cw watcher logs` use the finite watch log endpoint.
- Limit watcher logs to `WATCH,WATCHM` by default.
- Strip log color spans from CLI output.
- Add `nano` to the container and set it as default editor.
- Add tests for the CLI and CLI-only mode.

## Why

Makes the CLI nicer to use and lets users run CrossWatch without the Web UI when they want a CLI-only setup.

## Testing

- tests/test_cli.py 
- tests/test_app_auth_api.py

## Issue

Relates to #839