### PR TITLE
Change: gate BingeBase scrobbles on completion

### DIFF
--- a/providers/scrobble/bingebase/sink.py
+++ b/providers/scrobble/bingebase/sink.py
@@ -11,6 +11,7 @@ import requests
 
 from cw_platform.config_base import load_config
 from cw_platform.provider_instances import normalize_instance_id, resolve_provider_block
+from providers.scrobble._watched_gate import resolve_stop_action
 from services.activity import record_scrobble_event
 
 try:
@@ -32,6 +33,7 @@ except ImportError:
 
 
 APP_AGENT = "CrossWatch/BingeBaseWebhook/1.0"
+DEFAULT_WATCHED_AT = 90.0
 ACTION_EVENT = {
     "start": "playback.start",
     "pause": "playback.pause",
@@ -162,6 +164,17 @@ def _progress(value: Any) -> float:
         return 0.0
 
 
+def _watched_at(cfg: Mapping[str, Any]) -> float:
+    try:
+        sc = cfg.get("scrobble") if isinstance(cfg, Mapping) else {}
+        value = ((sc or {}).get("bingebase") or {}).get("watched_at")
+        if value is None:
+            value = ((sc or {}).get("trakt") or {}).get("watched_at", DEFAULT_WATCHED_AT)
+        return max(0.0, min(100.0, float(value)))
+    except Exception:
+        return DEFAULT_WATCHED_AT
+
+
 def _ms_to_seconds(value: Any) -> int | None:
     num = _as_int(value)
     if num is None or num <= 0:
@@ -183,6 +196,7 @@ class BingeBaseSink(ScrobbleSink):
         self._cfg_provider = cfg_provider
         self.instance_id = normalize_instance_id(instance_id)
         self.session = requests.Session()
+        self._completed: dict[str, float] = {}
         try:
             self.session.headers.setdefault("Accept", "application/json")
             self.session.headers.setdefault("User-Agent", APP_AGENT)
@@ -206,6 +220,26 @@ class BingeBaseSink(ScrobbleSink):
         except Exception:
             block = cfg.get("bingebase") if isinstance(cfg, Mapping) else None
             return dict(block) if isinstance(block, Mapping) else {}
+
+    def _completion_key(self, event: Any) -> str:
+        ids = getattr(event, "ids", None) or {}
+        if not isinstance(ids, Mapping):
+            ids = {}
+        parts = [
+            str(getattr(event, "server_uuid", "") or "?"),
+            str(getattr(event, "session_key", "") or "?"),
+            str(getattr(event, "media_type", "") or "movie"),
+        ]
+        for key, value in sorted(ids.items()):
+            if value not in (None, ""):
+                parts.append(f"{key}:{value}")
+        if str(getattr(event, "media_type", "") or "").lower() == "episode":
+            parts.append(f"s{_as_int(getattr(event, 'season', None)) or 0}")
+            parts.append(f"e{_as_int(getattr(event, 'number', None)) or 0}")
+        elif len(parts) == 3:
+            parts.append(str(getattr(event, "title", "") or ""))
+            parts.append(str(getattr(event, "year", "") or ""))
+        return "|".join(parts)
 
     def _jellyfin_payload(self, event: Any, action: str, media_type: str, ids: Mapping[str, Any], title: str) -> dict[str, Any] | None:
         provider_ids = _provider_ids(ids, media_type)
@@ -278,8 +312,8 @@ class BingeBaseSink(ScrobbleSink):
 
         return payload
 
-    def _payload(self, event: Any, webhook_url: Any = None) -> dict[str, Any] | None:
-        action = str(getattr(event, "action", "") or "").strip().lower()
+    def _payload(self, event: Any, webhook_url: Any = None, action_override: str | None = None) -> dict[str, Any] | None:
+        action = str(action_override or getattr(event, "action", "") or "").strip().lower()
         if action not in ACTION_EVENT:
             return None
 
@@ -304,10 +338,6 @@ class BingeBaseSink(ScrobbleSink):
             _log("BINGEBASE: skip scrobble, webhook URL not configured", "DEBUG")
             return
 
-        payload = self._payload(event, webhook_url)
-        if payload is None:
-            return
-
         try:
             timeout = float(block.get("timeout") or 20.0)
         except Exception:
@@ -318,7 +348,22 @@ class BingeBaseSink(ScrobbleSink):
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
 
-        action = str(getattr(event, "action", "") or "").strip().lower()
+        raw_action = str(getattr(event, "action", "") or "").strip().lower()
+        progress = _progress(getattr(event, "progress", 0.0))
+        watched_at = _watched_at(cfgd)
+        action = resolve_stop_action(progress, watched_at) if raw_action == "stop" else raw_action
+        if raw_action == "stop" and action == "pause":
+            _log(f"BINGEBASE: hold stop below watched_at ({progress:.0f}% < {watched_at:.0f}%)", "DEBUG")
+
+        complete = raw_action == "stop" and action == "stop" and progress >= watched_at
+        done_key = self._completion_key(event) if complete else ""
+        if complete and self._completed.get(done_key, -1.0) >= watched_at:
+            return
+
+        payload = self._payload(event, webhook_url, action_override=action)
+        if payload is None:
+            return
+
         src, src_inst = _route_source(cfgd)
         try:
             resp = self.session.post(
@@ -338,10 +383,10 @@ class BingeBaseSink(ScrobbleSink):
 
         _log(
             f"BINGEBASE: scrobble {action} user='{mask_account(getattr(event, 'account', None))}' "
-            f"p={_progress(getattr(event, 'progress', 0.0)):.1f}% source={src}:{src_inst}",
+            f"p={progress:.1f}% source={src}:{src_inst}",
             "INFO",
         )
-        if action == "stop":
+        if complete:
             try:
                 record_scrobble_event(
                     event,
@@ -349,10 +394,11 @@ class BingeBaseSink(ScrobbleSink):
                     source_instance=src_inst,
                     target="bingebase",
                     target_instance=self.instance_id,
-                    progress=_progress(getattr(event, "progress", 0.0)),
+                    progress=progress,
                 )
             except Exception:
                 pass
+            self._completed[done_key] = progress
 
 
 __all__ = ["BingeBaseSink", "_redact_url"]

--- a/tests/test_bingebase_scrobble.py
+++ b/tests/test_bingebase_scrobble.py
@@ -172,12 +172,27 @@ def test_kodi_webhook_episode_payload_includes_show_identity(monkeypatch: pytest
 def test_start_pause_stop_mapping(sink) -> None:
     s, calls = sink
 
-    for action in ("start", "pause", "stop"):
-        s.send(Event(action=action))
+    s.send(Event(action="start"))
+    s.send(Event(action="pause"))
+    s.send(Event(action="stop", progress=95))
 
     payloads = [call["json"] for call in calls]
     assert [p["Event"] for p in payloads] == ["playback.start", "playback.pause", "playback.stop"]
     assert [p["NotificationType"] for p in payloads] == ["PlaybackStart", "PlaybackStart", "PlaybackStop"]
+
+
+def test_stop_below_watched_threshold_is_sent_as_pause_and_not_recorded(sink, monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.bingebase import sink as sink_mod
+
+    s, calls = sink
+    activity: list[dict[str, Any]] = []
+    monkeypatch.setattr(sink_mod, "record_scrobble_event", lambda ev, **kwargs: activity.append(kwargs))
+
+    for progress in (67, 68, 69):
+        s.send(Event(action="stop", progress=progress))
+
+    assert [call["json"]["Event"] for call in calls] == ["playback.pause", "playback.pause", "playback.pause"]
+    assert activity == []
 
 
 def test_webhook_dispatch_reaches_bingebase(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -240,6 +255,45 @@ def test_successful_stop_records_recent_scrobble_activity(sink, monkeypatch: pyt
     assert activity[0]["target"] == "bingebase"
     assert activity[0]["target_instance"] == "default"
     assert activity[0]["progress"] == 97.0
+
+
+def test_repeated_completed_stop_records_once(sink, monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.bingebase import sink as sink_mod
+
+    s, calls = sink
+    activity: list[dict[str, Any]] = []
+    monkeypatch.setattr(sink_mod, "record_scrobble_event", lambda ev, **kwargs: activity.append(kwargs))
+
+    s.send(Event(action="stop", progress=97))
+    s.send(Event(action="stop", progress=98))
+
+    assert len(calls) == 1
+    assert len(activity) == 1
+    assert activity[0]["progress"] == 97.0
+
+
+def test_watched_threshold_reads_bingebase_then_trakt_then_default() -> None:
+    from providers.scrobble.bingebase import sink as s
+
+    assert s._watched_at({"scrobble": {"bingebase": {"watched_at": 75}}}) == 75.0
+    assert s._watched_at({"scrobble": {"trakt": {"watched_at": 85}}}) == 85.0
+    assert s._watched_at({}) == s.DEFAULT_WATCHED_AT
+
+
+def test_repeated_completed_stop_is_deduped_even_if_activity_recording_fails(sink, monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.bingebase import sink as sink_mod
+
+    s, calls = sink
+
+    def fail_record(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("activity unavailable")
+
+    monkeypatch.setattr(sink_mod, "record_scrobble_event", fail_record)
+
+    s.send(Event(action="stop", progress=97))
+    s.send(Event(action="stop", progress=98))
+
+    assert len(calls) == 1
 
 
 def test_failed_stop_does_not_record_recent_scrobble_activity(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
# Pull request

## Change

- BingeBase watcher stops now use the same watched threshold as the other scrobble sinks.
- Incomplete stops are sent as pause updates and repeated completed stops are deduped.

## Why

- Recent Scrobble was showing multiple BingeBase watcher entries before playback was finished.

## Testing
- tests\test_bingebase_scrobble.py

## Issue
Relates to #784