### PR TITLE
Change: optimize CLI API

### DIFF
--- a/cli/_util.py
+++ b/cli/_util.py
@@ -20,6 +20,36 @@ def as_dict(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+def rows_from_payload(payload: Any, *keys: str) -> list[dict[str, Any]]:
+    def _coerce_rows(value: Any) -> list[dict[str, Any]]:
+        if isinstance(value, dict):
+            rows: list[dict[str, Any]] = []
+            for key, item in value.items():
+                row = dict(item) if isinstance(item, dict) else {"value": item}
+                row.setdefault("key", str(key))
+                rows.append(row)
+            return rows
+        if isinstance(value, list):
+            rows = []
+            for item in value:
+                if isinstance(item, dict):
+                    rows.append(dict(item))
+                    continue
+                text = str(item or "").strip()
+                if text:
+                    rows.append({"value": text, "name": text, "provider": text})
+            return rows
+        return []
+
+    block = as_dict(payload)
+    for key in keys:
+        if key in block:
+            return _coerce_rows(block.get(key))
+    if keys:
+        return _coerce_rows(payload) if isinstance(payload, list) else []
+    return _coerce_rows(payload)
+
+
 def error_text(payload: Any, default: str = "Rejected") -> str:
     block = payload if isinstance(payload, dict) else {}
     for key in ("message", "detail", "error", "status"):

--- a/cli/commands/analyzer.py
+++ b/cli/commands/analyzer.py
@@ -9,7 +9,7 @@ import typer
 
 from .._context import Ctx
 from .._errors import CLIError
-from .._util import as_dict, error_text
+from .._util import as_dict, error_text, rows_from_payload
 
 analyzer_app = typer.Typer(help="Find items that are stuck or inconsistent between providers.", no_args_is_help=True)
 
@@ -19,14 +19,7 @@ def _scope(pairs: str) -> dict[str, Any] | None:
 
 
 def _items(payload: Any, *keys: str) -> list[dict[str, Any]]:
-    block = as_dict(payload)
-    for key in keys:
-        found = block.get(key)
-        if isinstance(found, list):
-            return [as_dict(i) for i in found]
-    if isinstance(payload, list):
-        return [as_dict(i) for i in payload]
-    return []
+    return rows_from_payload(payload, *keys)
 
 
 def _item_title(row: dict[str, Any]) -> str:

--- a/cli/commands/anime.py
+++ b/cli/commands/anime.py
@@ -9,20 +9,13 @@ import typer
 
 from .._context import Ctx
 from .._errors import EXIT_USAGE, CLIError
-from .._util import as_dict, error_text, fmt_ts
+from .._util import as_dict, error_text, fmt_ts, rows_from_payload
 
 anime_app = typer.Typer(help="Anime id mapping and custom overrides.", no_args_is_help=True)
 
 
 def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
-    block = as_dict(payload)
-    for key in keys:
-        found = block.get(key)
-        if isinstance(found, list):
-            return [as_dict(i) for i in found]
-    if isinstance(payload, list):
-        return [as_dict(i) for i in payload]
-    return []
+    return rows_from_payload(payload, *keys)
 
 
 @anime_app.command("status")

--- a/cli/commands/backup.py
+++ b/cli/commands/backup.py
@@ -9,20 +9,13 @@ import typer
 
 from .._context import Ctx
 from .._errors import CLIError
-from .._util import as_dict, error_text, fmt_ts
+from .._util import as_dict, error_text, fmt_ts, rows_from_payload
 
 backup_app = typer.Typer(help="CrossWatch tracker backups.", no_args_is_help=True)
 
 
 def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
-    block = as_dict(payload)
-    for key in keys:
-        found = block.get(key)
-        if isinstance(found, list):
-            return [as_dict(i) for i in found]
-    if isinstance(payload, list):
-        return [as_dict(i) for i in payload]
-    return []
+    return rows_from_payload(payload, *keys)
 
 
 def _size(value: Any) -> str:
@@ -69,14 +62,16 @@ def backup_create(
     state.require_service("Taking a backup")
     body: dict[str, Any] = {}
     if note.strip():
-        body["note"] = note.strip()
+        body["label"] = note.strip()
     result = as_dict(state.post("/api/backups/create", json_body=body))
     if result.get("ok") is False:
         raise CLIError(error_text(result, "Backup rejected"))
     if state.out.json_mode:
         state.out.data(result)
         return
-    state.out.success(f"Backup created{': ' + str(result.get('path')) if result.get('path') else '.'}")
+    backup = as_dict(result.get("backup"))
+    path = str(backup.get("path") or result.get("path") or "")
+    state.out.success(f"Backup created{': ' + path if path else '.'}")
 
 
 @backup_app.command("validate")
@@ -153,7 +148,7 @@ def backup_schedule(
         if state.out.json_mode:
             state.out.data(payload)
             return
-        block = as_dict(payload)
+        block = as_dict(as_dict(payload).get("schedule")) or as_dict(payload)
         state.out.kv(
             [(key, value) for key, value in block.items() if not isinstance(value, (dict, list))],
             title="Backup schedule",
@@ -161,9 +156,11 @@ def backup_schedule(
         return
 
     state.require_service("Changing the backup schedule")
-    body: dict[str, Any] = dict(as_dict(state.get("/api/backups/schedule")))
+    body: dict[str, Any] = dict(as_dict(as_dict(state.get("/api/backups/schedule")).get("schedule")))
+    body["enabled"] = bool(body.get("enabled", body.get("active", False)))
     if enable is not None:
         body["enabled"] = bool(enable)
+        body["active"] = bool(enable)
     if every_hours:
         body["every_n_hours"] = int(every_hours)
     result = as_dict(state.post("/api/backups/schedule", json_body=body))
@@ -183,7 +180,7 @@ def backup_retention(
     """Set how many backups to keep and prune the rest."""
     state: Ctx = ctx.obj
     state.require_service("Changing backup retention")
-    result = as_dict(state.post("/api/backups/retention", json_body={"keep": int(keep)}))
+    result = as_dict(state.post("/api/backups/retention", json_body={"max_backups": int(keep)}))
     if result.get("ok") is False:
         raise CLIError(error_text(result, "Retention rejected"))
     if state.out.json_mode:

--- a/cli/commands/capture.py
+++ b/cli/commands/capture.py
@@ -10,20 +10,13 @@ import typer
 
 from .._context import Ctx
 from .._errors import CLIError
-from .._util import as_dict, error_text, fmt_ts
+from .._util import as_dict, error_text, fmt_ts, rows_from_payload
 
 capture_app = typer.Typer(help="Captures, the rollback tool for watchlist, ratings and history.", no_args_is_help=True)
 
 
 def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
-    block = as_dict(payload)
-    for key in keys:
-        found = block.get(key)
-        if isinstance(found, list):
-            return [as_dict(i) for i in found]
-    if isinstance(payload, list):
-        return [as_dict(i) for i in payload]
-    return []
+    return rows_from_payload(payload, *keys)
 
 
 def _size(value: Any) -> str:
@@ -114,8 +107,11 @@ def capture_create(
     while time.time() < deadline:
         time.sleep(2.0)
         progress = as_dict(state.get(f"/api/snapshots/capture-progress/{progress_id}"))
-        status = str(progress.get("status") or progress.get("state") or "").lower()
-        note = str(progress.get("message") or progress.get("step") or "")
+        current = as_dict(progress.get("progress")) or progress
+        status = str(current.get("status") or current.get("state") or "").lower()
+        if not status and current.get("done") is True:
+            status = "done"
+        note = str(current.get("message") or current.get("step") or current.get("stage") or "")
         if note and note != last:
             state.out.info(note)
             last = note
@@ -218,7 +214,8 @@ def capture_diff(
         state.out.data(payload)
         return
     block = as_dict(payload)
-    summary = as_dict(block.get("summary")) or block
+    diff = as_dict(block.get("diff"))
+    summary = as_dict(block.get("summary")) or as_dict(diff.get("summary")) or diff or block
     state.out.kv(
         [
             ("Added", str(summary.get("added") or 0)),
@@ -227,7 +224,7 @@ def capture_diff(
         ],
         title="Diff",
     )
-    rows = _rows(payload, "items", "changes", "rows")
+    rows = _rows(diff or payload, "items", "changes", "rows")
     if rows:
         state.out.print()
         state.out.records(

--- a/cli/commands/editor.py
+++ b/cli/commands/editor.py
@@ -9,20 +9,29 @@ import typer
 
 from .._context import Ctx
 from .._errors import EXIT_USAGE, CLIError
-from .._util import as_dict, error_text
+from .._util import as_dict, error_text, rows_from_payload
 
 editor_app = typer.Typer(help="Inspect and adjust stored items.", no_args_is_help=True)
 
 
+def _row_key(row: dict[str, Any]) -> str:
+    return str(row.get("key") or row.get("id") or "").strip()
+
+
+def _id_value(row: dict[str, Any], name: str) -> str:
+    value = row.get(name)
+    if value not in (None, ""):
+        return str(value)
+    ids = row.get("ids")
+    if isinstance(ids, dict):
+        value = ids.get(name)
+        if value not in (None, ""):
+            return str(value)
+    return "-"
+
+
 def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
-    block = as_dict(payload)
-    for key in keys:
-        found = block.get(key)
-        if isinstance(found, list):
-            return [as_dict(i) for i in found]
-    if isinstance(payload, list):
-        return [as_dict(i) for i in payload]
-    return []
+    return rows_from_payload(payload, *keys)
 
 
 @editor_app.command("list")
@@ -30,9 +39,9 @@ def editor_list(
     ctx: typer.Context,
     kind: str = typer.Option("watchlist", "--kind", "-k", help="watchlist, ratings, history or playlists."),
     provider: str = typer.Option("", "--provider", "-p", help="Limit to one provider."),
-    instance: str = typer.Option("", "--instance", "-i", help="Provider instance id."),
-    source: str = typer.Option("state", "--source", help="state or snapshot."),
-    snapshot: str = typer.Option("", "--snapshot", help="Snapshot path when source is snapshot."),
+    instance: str = typer.Option("", "--instance", "-i", "--profile", help="Provider instance/profile id."),
+    source: str = typer.Option("state", "--source", help="state/current, manual or playlist."),
+    snapshot: str = typer.Option("", "--snapshot", "--endpoint", help="Playlist endpoint id when source is playlist."),
     limit: int = typer.Option(50, "--limit", "-n", help="Maximum rows."),
 ) -> None:
     """List what the editor sees."""
@@ -49,16 +58,36 @@ def editor_list(
         state.out.data(payload)
         return
     rows = _rows(payload, "items", "rows")
+    workspace = as_dict(payload)
+    chosen_provider = str(workspace.get("provider") or provider or "-")
+    chosen_instance = str(workspace.get("provider_instance") or instance or "-")
+    if chosen_provider != "-":
+        for row in rows:
+            row.setdefault("provider", chosen_provider)
+            row.setdefault("provider_instance", chosen_instance)
+    state.out.kv(
+        [
+            ("Source", str(workspace.get("source") or source)),
+            ("Kind", str(workspace.get("kind") or kind)),
+            ("Provider", chosen_provider),
+            ("Profile", chosen_instance),
+            ("Rows", str(len(rows))),
+        ],
+        title="Editor workspace",
+    )
+    if rows:
+        state.out.print()
     state.out.records(
         rows[: max(1, limit)],
         [
-            ("KEY", lambda r: str(r.get("key") or r.get("id") or "-")[:28]),
-            ("TITLE", lambda r: str(r.get("title") or "-")[:40]),
+            ("KEY", lambda r: (_row_key(r) or "-")[:28]),
             ("TYPE", lambda r: str(r.get("type") or "-")),
+            ("TITLE", lambda r: str(r.get("title") or r.get("name") or "-")[:40]),
+            ("TMDB", lambda r: _id_value(r, "tmdb")),
             ("YEAR", lambda r: str(r.get("year") or "-")),
             ("PROVIDER", lambda r: str(r.get("provider") or "-")),
         ],
-        title=f"Editor: {kind} ({len(rows)})",
+        title=f"Editor: {source}/{kind} ({len(rows)})",
         empty="Nothing stored for that view.",
     )
 
@@ -80,7 +109,8 @@ def editor_providers(
             rows,
             [
                 ("PROVIDER", lambda r: str(r.get("name") or r.get("provider") or "-")),
-                ("INSTANCE", lambda r: str(r.get("instance") or "-")),
+                ("PROFILE", lambda r: str(r.get("instance") or r.get("provider_instance") or "-")),
+                ("DISPLAY", lambda r: str(r.get("display") or r.get("label") or "-")),
             ],
             title="Send targets",
         )
@@ -99,7 +129,12 @@ def editor_send(
     keys: list[str] = typer.Argument(..., help="Item keys."),
     provider: str = typer.Option(..., "--provider", "-p", help="Where to send them."),
     kind: str = typer.Option("watchlist", "--kind", "-k", help="Which feature."),
-    instance: str = typer.Option("", "--instance", "-i", help="Provider instance id."),
+    instance: str = typer.Option("", "--instance", "-i", "--profile", help="Target provider instance/profile id."),
+    source: str = typer.Option("state", "--source", help="state/current, manual or playlist."),
+    source_provider: str = typer.Option("", "--source-provider", help="Provider to read stored items from."),
+    source_instance: str = typer.Option("", "--source-instance", "--source-profile", help="Source provider instance/profile id."),
+    snapshot: str = typer.Option("", "--snapshot", "--endpoint", help="Playlist endpoint id when source is playlist."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without writing."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
 ) -> None:
     """Send stored items to a provider."""
@@ -108,20 +143,43 @@ def editor_send(
     wanted = [k.strip() for k in keys if k.strip()]
     if not wanted:
         raise CLIError("Nothing to send", exit_code=EXIT_USAGE)
+    params: dict[str, Any] = {"kind": kind, "source": source}
+    if source_provider.strip():
+        params["provider"] = source_provider.strip().upper()
+    if source_instance.strip():
+        params["provider_instance"] = source_instance.strip()
+    if snapshot.strip():
+        params["snapshot"] = snapshot.strip()
+    current = state.get("/api/editor", params=params)
+    rows = _rows(current, "items", "rows")
+    by_key = {_row_key(row): row for row in rows if _row_key(row)}
+    selected = [by_key[key] for key in wanted if key in by_key]
+    missing = [key for key in wanted if key not in by_key]
+    if missing:
+        raise CLIError(
+            f"{len(missing)} item(s) were not found in that editor view",
+            hint=f"Missing: {', '.join(missing[:6])}",
+            exit_code=EXIT_USAGE,
+        )
     if not yes:
         state.out.warn(f"This writes {len(wanted)} item(s) to {provider.upper()}.")
         if not typer.confirm("Continue?", default=False):
             raise CLIError("Cancelled", exit_code=0)
-    body: dict[str, Any] = {"keys": wanted, "provider": provider.strip().upper(), "kind": kind}
-    if instance.strip():
-        body["provider_instance"] = instance.strip()
+    body: dict[str, Any] = {
+        "items": selected,
+        "providers": [{"provider": provider.strip().upper(), "instance": instance.strip() or "default"}],
+        "kind": kind,
+        "dry_run": dry_run,
+    }
     result = as_dict(state.post("/api/editor/send", json_body=body))
     if result.get("ok") is False:
         raise CLIError(error_text(result, "Send rejected"))
     if state.out.json_mode:
         state.out.data(result)
         return
-    state.out.success(f"Sent {len(wanted)} item(s) to {provider.upper()}.")
+    verb = "Would send" if dry_run else "Sent"
+    sent = int(result.get("sent") or len(selected))
+    state.out.success(f"{verb} {sent} item(s) to {provider.upper()}.")
 
 
 @editor_app.command("export")
@@ -138,7 +196,10 @@ def editor_export(ctx: typer.Context) -> None:
 
 
 @editor_app.command("sources")
-def editor_sources(ctx: typer.Context) -> None:
+def editor_sources(
+    ctx: typer.Context,
+    kind: str = typer.Option("watchlist", "--kind", "-k", help="Which feature to count."),
+) -> None:
     """Show which providers the editor can read state from."""
     state: Ctx = ctx.obj
     payload = state.get("/api/editor/state/providers")
@@ -147,14 +208,26 @@ def editor_sources(ctx: typer.Context) -> None:
         return
     rows = _rows(payload, "providers", "items")
     if rows:
+        for row in rows:
+            provider_name = str(row.get("name") or row.get("provider") or "").strip()
+            if not provider_name:
+                continue
+            try:
+                detail = as_dict(state.get("/api/editor", params={"kind": kind, "source": "state", "provider": provider_name.upper()}))
+            except CLIError:
+                continue
+            if row.get("count") in (None, ""):
+                row["count"] = detail.get("count")
+            if row.get("provider_instance") in (None, "") and row.get("instance") in (None, ""):
+                row["provider_instance"] = detail.get("provider_instance")
         state.out.records(
             rows,
             [
                 ("PROVIDER", lambda r: str(r.get("name") or r.get("provider") or "-")),
-                ("INSTANCE", lambda r: str(r.get("instance") or "-")),
+                ("PROFILE", lambda r: str(r.get("instance") or r.get("provider_instance") or "-")),
                 ("ITEMS", lambda r: str(r.get("count") or "-")),
             ],
-            title="State sources",
+            title=f"State sources: {kind}",
         )
         return
     block = as_dict(payload)

--- a/cli/commands/events.py
+++ b/cli/commands/events.py
@@ -10,20 +10,13 @@ import typer
 from .._context import Ctx
 from .._errors import EXIT_NOT_FOUND, CLIError
 from .._render import state_text
-from .._util import as_dict, coerce_bool, error_text, fmt_ts
+from .._util import as_dict, coerce_bool, error_text, fmt_ts, rows_from_payload
 
 events_app = typer.Typer(help="Search and inspect the events archive.", no_args_is_help=True)
 
 
 def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
-    block = as_dict(payload)
-    for key in keys:
-        found = block.get(key)
-        if isinstance(found, list):
-            return [as_dict(i) for i in found]
-    if isinstance(payload, list):
-        return [as_dict(i) for i in payload]
-    return []
+    return rows_from_payload(payload, *keys)
 
 
 def _when(row: dict[str, Any]) -> str:

--- a/cli/commands/insights.py
+++ b/cli/commands/insights.py
@@ -9,20 +9,13 @@ import typer
 
 from .._context import Ctx
 from .._errors import CLIError
-from .._util import as_dict, error_text, fmt_ts
+from .._util import as_dict, error_text, fmt_ts, rows_from_payload
 
 activity_app = typer.Typer(help="The recent activity log.", no_args_is_help=True)
 
 
 def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
-    block = as_dict(payload)
-    for key in keys:
-        found = block.get(key)
-        if isinstance(found, list):
-            return [as_dict(i) for i in found]
-    if isinstance(payload, list):
-        return [as_dict(i) for i in payload]
-    return []
+    return rows_from_payload(payload, *keys)
 
 
 def _flat_kv(payload: dict[str, Any]) -> list[tuple[str, Any]]:

--- a/cli/commands/instance.py
+++ b/cli/commands/instance.py
@@ -10,21 +10,14 @@ import typer
 from .._context import Ctx
 from .._errors import EXIT_NOT_FOUND, EXIT_USAGE, CLIError
 from .._render import state_text
-from .._util import as_dict, coerce_bool, error_text
+from .._util import as_dict, coerce_bool, error_text, rows_from_payload
 
 instance_app = typer.Typer(help="Provider instances, for multi server setups.", no_args_is_help=True)
 profile_app = typer.Typer(help="User profiles.", no_args_is_help=True)
 
 
 def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
-    block = as_dict(payload)
-    for key in keys:
-        found = block.get(key)
-        if isinstance(found, list):
-            return [as_dict(i) for i in found]
-    if isinstance(payload, list):
-        return [as_dict(i) for i in payload]
-    return []
+    return rows_from_payload(payload, *keys)
 
 
 def _fields(raw: list[str]) -> dict[str, Any]:

--- a/cli/commands/metadata.py
+++ b/cli/commands/metadata.py
@@ -9,21 +9,14 @@ import typer
 
 from .._context import Ctx
 from .._errors import EXIT_USAGE, CLIError
-from .._util import as_dict, error_text
+from .._util import as_dict, error_text, rows_from_payload
 
 metadata_app = typer.Typer(help="Look up titles and ids.", no_args_is_help=True)
 manual_app = typer.Typer(help="Record a watch by hand.", no_args_is_help=True)
 
 
 def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
-    block = as_dict(payload)
-    for key in keys:
-        found = block.get(key)
-        if isinstance(found, list):
-            return [as_dict(i) for i in found]
-    if isinstance(payload, list):
-        return [as_dict(i) for i in payload]
-    return []
+    return rows_from_payload(payload, *keys)
 
 
 def _ids(row: dict[str, Any]) -> str:
@@ -78,7 +71,7 @@ def metadata_resolve(
         if not sep or not key.strip():
             raise CLIError(f"Ids are key=value, got '{item}'", exit_code=EXIT_USAGE)
         parsed[key.strip()] = value
-    payload = state.post("/api/metadata/resolve", json_body={"ids": parsed, "type": media_type})
+    payload = state.post("/api/metadata/resolve", json_body={"ids": parsed, "entity": media_type})
     if state.out.json_mode:
         state.out.data(payload)
         return
@@ -146,28 +139,77 @@ def manual_providers(ctx: typer.Context) -> None:
 def manual_watched(
     ctx: typer.Context,
     field: list[str] = typer.Option([], "--field", "-F", help="Item detail as key=value. Repeatable."),
-    provider: str = typer.Option("", "--provider", "-p", help="Where to record it."),
-    watched_at: str = typer.Option("", "--at", help="ISO timestamp. Defaults to now."),
+    provider: list[str] = typer.Option([], "--provider", "-p", help="Where to record it. Repeatable."),
+    instance: str = typer.Option("default", "--instance", "-i", help="Target provider instance/profile id."),
+    watched_at: str = typer.Option("", "--at", "--date", help="YYYY-MM-DD. Defaults to today."),
+    date_mode: str = typer.Option("today", "--date-mode", help="today, custom or release."),
+    history: bool = typer.Option(True, "--history/--no-history", help="Record history."),
+    watchlist: bool = typer.Option(False, "--watchlist", help="Also add to watchlist."),
+    rating_action: bool = typer.Option(False, "--rating", help="Also record the rating from --field rating=1..10."),
 ) -> None:
     """Record a watch by hand."""
     state: Ctx = ctx.obj
     state.require_service("Recording a manual watch")
-    body: dict[str, Any] = {}
+    raw_fields: dict[str, Any] = {}
     for item in field:
         key, sep, value = str(item).partition("=")
         if not sep or not key.strip():
             raise CLIError(f"--field expects key=value, got '{item}'", exit_code=EXIT_USAGE)
-        body[key.strip()] = value
-    if not body:
+        raw_fields[key.strip()] = value
+    if not raw_fields:
         raise CLIError(
             "Nothing to record",
-            hint="For example --field imdb=tt0111161 --field type=movie",
+            hint="For example --field tmdb=603 --field type=movie --provider trakt",
             exit_code=EXIT_USAGE,
         )
-    if provider.strip():
-        body["provider"] = provider.strip().upper()
-    if watched_at.strip():
-        body["watched_at"] = watched_at.strip()
+    providers = [p.strip().upper() for p in provider if p.strip()]
+    if not providers:
+        raise CLIError(
+            "Pick at least one provider",
+            hint="Run 'cw manual providers', then pass --provider TRAKT or another target.",
+            exit_code=EXIT_USAGE,
+        )
+    if not history and not watchlist and not rating_action:
+        raise CLIError("Pick at least one action", hint="Use --history, --watchlist, or --rating.", exit_code=EXIT_USAGE)
+
+    item_payload: dict[str, Any] = {}
+    ids: dict[str, Any] = {}
+    rating_value = raw_fields.pop("rating", None)
+    field_date = raw_fields.pop("watched_at", raw_fields.pop("watched_on", None))
+    for key, value in raw_fields.items():
+        low = key.lower().strip()
+        if low in {"tmdb", "tmdb_id"}:
+            item_payload["tmdb"] = value
+            ids["tmdb"] = value
+        elif low in {"imdb", "tvdb", "trakt", "simkl", "mal", "anilist", "kitsu"}:
+            ids[low] = value
+        elif low in {"type", "media_type", "title", "name", "year"}:
+            item_payload[low] = value
+        else:
+            item_payload[low] = value
+    if ids:
+        item_payload["ids"] = ids
+    if not (item_payload.get("tmdb") or ids.get("tmdb")):
+        raise CLIError("Manual watches need a TMDb id", hint="Pass --field tmdb=12345.", exit_code=EXIT_USAGE)
+
+    watched_on = (watched_at or str(field_date or "")).strip()
+    mode = str(date_mode or "today").strip().lower()
+    if watched_on:
+        mode = "custom"
+        watched_on = watched_on[:10]
+
+    body: dict[str, Any] = {
+        "item": item_payload,
+        "providers": [{"provider": p, "instance": instance.strip() or "default"} for p in providers],
+        "actions": {"history": bool(history), "watchlist": bool(watchlist), "rating": bool(rating_action)},
+        "date_mode": mode,
+    }
+    if watched_on:
+        body["watched_on"] = watched_on
+    if rating_value not in (None, ""):
+        body["rating"] = rating_value
+        if rating_action is False:
+            body["actions"]["rating"] = True
     result = as_dict(state.post("/api/manual/watched", json_body=body))
     if result.get("ok") is False:
         raise CLIError(error_text(result, "Rejected"))

--- a/cli/commands/playlist.py
+++ b/cli/commands/playlist.py
@@ -10,7 +10,7 @@ import typer
 from .._context import Ctx
 from .._errors import EXIT_USAGE, CLIError
 from .._render import state_text
-from .._util import as_dict, coerce_bool, error_text, fmt_ts
+from .._util import as_dict, coerce_bool, error_text, fmt_ts, rows_from_payload
 
 playlist_app = typer.Typer(help="Playlist endpoints, mappings and rulesets.", no_args_is_help=True)
 endpoint_app = typer.Typer(help="Playlist endpoints.", no_args_is_help=True)
@@ -19,14 +19,7 @@ ruleset_app = typer.Typer(help="Playlist rulesets.", no_args_is_help=True)
 
 
 def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
-    block = as_dict(payload)
-    for key in keys:
-        found = block.get(key)
-        if isinstance(found, list):
-            return [as_dict(i) for i in found]
-    if isinstance(payload, list):
-        return [as_dict(i) for i in payload]
-    return []
+    return rows_from_payload(payload, *keys)
 
 
 def _fields(raw: list[str]) -> dict[str, Any]:

--- a/cli/commands/progress.py
+++ b/cli/commands/progress.py
@@ -8,21 +8,14 @@ from typing import Any
 import typer
 
 from .._context import Ctx
-from .._errors import CLIError
-from .._util import as_dict, error_text, fmt_ts
+from .._errors import EXIT_USAGE, CLIError
+from .._util import as_dict, error_text, fmt_ts, rows_from_payload
 
 progress_app = typer.Typer(help="Unfinished playback across providers.", no_args_is_help=True)
 
 
 def _rows(payload: Any) -> list[dict[str, Any]]:
-    block = as_dict(payload)
-    for key in ("items", "rows", "results"):
-        found = block.get(key)
-        if isinstance(found, list):
-            return [as_dict(i) for i in found]
-    if isinstance(payload, list):
-        return [as_dict(i) for i in payload]
-    return []
+    return rows_from_payload(payload, "items", "rows", "results")
 
 
 def _percent(row: dict[str, Any]) -> str:
@@ -35,6 +28,33 @@ def _percent(row: dict[str, Any]) -> str:
         return f"{float(value):.0f}%"
     except Exception:
         return "-"
+
+
+def _selected_rows(state: Ctx, keys: list[str]) -> list[dict[str, Any]]:
+    wanted = [str(k or "").strip() for k in keys if str(k or "").strip()]
+    if not wanted:
+        raise CLIError("No progress item keys given", exit_code=EXIT_USAGE)
+    payload = state.get("/api/playback_progress/items", params={"page_size": 250, "user_profile": ""})
+    rows = _rows(payload)
+    by_key: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        for candidate in {
+            str(row.get("key") or "").strip(),
+            str(row.get("canonical_key") or "").strip(),
+            str(row.get("id") or "").strip(),
+            str(row.get("remote_id") or "").strip(),
+        }:
+            if candidate:
+                by_key[candidate] = row
+    selected = [by_key[key] for key in wanted if key in by_key]
+    missing = [key for key in wanted if key not in by_key]
+    if missing:
+        raise CLIError(
+            f"{len(missing)} progress item(s) were not found",
+            hint=f"Missing: {', '.join(missing[:6])}",
+            exit_code=EXIT_USAGE,
+        )
+    return selected
 
 
 @progress_app.command("list")
@@ -60,6 +80,7 @@ def progress_list(
         params["progress_min"] = minimum
     if maximum:
         params["progress_max"] = maximum
+    params["page_size"] = max(1, min(int(limit or 50), 250))
     payload = state.get("/api/playback_progress/items", params=params or None)
     rows = _rows(payload)
     if state.out.json_mode:
@@ -68,7 +89,7 @@ def progress_list(
     state.out.records(
         rows[: max(1, limit)],
         [
-            ("KEY", lambda r: str(r.get("key") or r.get("id") or "-")[:26]),
+            ("KEY", lambda r: str(r.get("key") or r.get("canonical_key") or r.get("id") or r.get("remote_id") or "-")[:26]),
             ("TITLE", lambda r: str(r.get("title") or "-")[:40]),
             ("TYPE", lambda r: str(r.get("media_type") or r.get("type") or "-")),
             ("PROVIDER", lambda r: str(r.get("provider") or "-")),
@@ -115,10 +136,17 @@ def progress_settings(ctx: typer.Context) -> None:
     )
 
 
-def _act(state: Ctx, path: str, keys: list[str], extra: dict[str, Any] | None = None) -> dict[str, Any]:
-    body: dict[str, Any] = {"keys": keys}
-    if len(keys) == 1:
-        body["key"] = keys[0]
+def _bulk_act(state: Ctx, action: str, keys: list[str]) -> dict[str, Any]:
+    selected = _selected_rows(state, keys)
+    result = as_dict(state.post("/api/playback_progress/actions/bulk", json_body={"action": action, "items": selected}))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Rejected"))
+    return result
+
+
+def _single_act(state: Ctx, path: str, key: str, extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    selected = _selected_rows(state, [key])
+    body: dict[str, Any] = dict(selected[0])
     body.update(extra or {})
     result = as_dict(state.post(path, json_body=body))
     if result.get("ok") is False:
@@ -138,7 +166,7 @@ def progress_watched(
     wanted = [k.strip() for k in keys if k.strip()]
     if not yes and not typer.confirm(f"Mark {len(wanted)} item(s) watched?", default=False):
         raise CLIError("Cancelled", exit_code=0)
-    result = _act(state, "/api/playback_progress/actions/mark_watched", wanted)
+    result = _bulk_act(state, "mark_watched", wanted)
     if state.out.json_mode:
         state.out.data(result or {"ok": True})
         return
@@ -157,7 +185,7 @@ def progress_remove(
     wanted = [k.strip() for k in keys if k.strip()]
     if not yes and not typer.confirm(f"Remove progress for {len(wanted)} item(s)?", default=False):
         raise CLIError("Cancelled", exit_code=0)
-    result = _act(state, "/api/playback_progress/actions/remove", wanted)
+    result = _bulk_act(state, "remove_progress", wanted)
     if state.out.json_mode:
         state.out.data(result or {"ok": True})
         return
@@ -173,7 +201,7 @@ def progress_set(
     """Set the progress percent for one item."""
     state: Ctx = ctx.obj
     state.require_service("Updating playback progress")
-    result = _act(state, "/api/playback_progress/actions/update_progress", [key], {"progress": float(percent)})
+    result = _single_act(state, "/api/playback_progress/actions/update_progress", key, {"progress_percent": float(percent)})
     if state.out.json_mode:
         state.out.data(result or {"ok": True})
         return

--- a/cli/commands/scrobbler.py
+++ b/cli/commands/scrobbler.py
@@ -10,7 +10,7 @@ import typer
 from .._context import Ctx
 from .._errors import EXIT_USAGE, CLIError
 from .._render import state_text
-from .._util import as_dict, coerce_bool, error_text
+from .._util import as_dict, coerce_bool, error_text, rows_from_payload
 
 scrobbler_app = typer.Typer(help="Scrobbler routes and webhooks.", no_args_is_help=True)
 route_app = typer.Typer(help="Scrobble routes.", no_args_is_help=True)
@@ -18,14 +18,7 @@ webhook_app = typer.Typer(help="Scrobble webhooks.", no_args_is_help=True)
 
 
 def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
-    block = as_dict(payload)
-    for key in keys:
-        found = block.get(key)
-        if isinstance(found, list):
-            return [as_dict(i) for i in found]
-    if isinstance(payload, list):
-        return [as_dict(i) for i in payload]
-    return []
+    return rows_from_payload(payload, *keys)
 
 
 def _fields(raw: list[str]) -> dict[str, Any]:
@@ -74,13 +67,17 @@ def scrobbler_event_routes(ctx: typer.Context) -> None:
     if state.out.json_mode:
         state.out.data(payload)
         return
+    block = as_dict(payload)
     rows = _rows(payload, "routes", "items")
+    if not rows:
+        rows = _rows(block.get("watcher_routes"), "items") + _rows(block.get("webhook_routes"), "items")
     state.out.records(
         rows,
         [
-            ("EVENT", lambda r: str(r.get("event") or r.get("type") or "-")),
-            ("SOURCE", lambda r: str(r.get("source") or r.get("provider") or "-")),
+            ("KIND", lambda r: str(r.get("source") or "-")),
+            ("PROVIDER", lambda r: str(r.get("provider") or "-")),
             ("SINK", lambda r: str(r.get("sink") or r.get("target") or "-")),
+            ("LABEL", lambda r: str(r.get("label") or "-")[:44]),
         ],
         title="Event routes",
         empty="No event routes.",
@@ -156,14 +153,35 @@ def webhook_urls(ctx: typer.Context) -> None:
     if state.out.json_mode:
         state.out.data(payload)
         return
-    rows = [[key, str(value)] for key, value in payload.items() if not isinstance(value, (dict, list))]
-    state.out.table(["NAME", "URL"], rows, title="Webhook URLs", empty="No webhook URLs yet.")
+    rows: list[list[str]] = []
+    ids = as_dict(payload.get("ids"))
+    for key, value in sorted(ids.items()):
+        if value:
+            rows.append([str(key), str(value)])
+    for hook in _rows(payload.get("profile_hooks")):
+        rows.append(
+            [
+                f"{hook.get('provider') or '-'}:{hook.get('instance') or 'default'}",
+                str(hook.get("webhook_token") or "-"),
+            ]
+        )
+    for hook in _rows(payload.get("route_hooks")):
+        rows.append(
+            [
+                f"route:{hook.get('route_id') or hook.get('id') or '-'}",
+                str(hook.get("webhook_token") or "-"),
+            ]
+        )
+    state.out.table(["NAME", "TOKEN"], rows, title="Webhook tokens", empty="No webhook tokens yet.")
 
 
 @webhook_app.command("regenerate")
 def webhook_regenerate(
     ctx: typer.Context,
     profile: str = typer.Option("", "--profile", help="Regenerate one profile instead of all."),
+    provider: str = typer.Option("", "--provider", "-p", help="Source provider profile to regenerate."),
+    instance: str = typer.Option("default", "--instance", "-i", help="Source provider instance/profile id."),
+    route: str = typer.Option("", "--route", help="Route id for ratings webhook tokens."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
 ) -> None:
     """Roll the webhook tokens. Existing URLs stop working."""
@@ -173,8 +191,23 @@ def webhook_regenerate(
         state.out.warn("Existing webhook URLs will stop working.")
         if not typer.confirm("Regenerate?", default=False):
             raise CLIError("Cancelled", exit_code=0)
-    if profile.strip():
-        result = as_dict(state.post("/api/scrobbler/webhooks/profile/regenerate", json_body={"profile": profile.strip()}))
+    raw_profile = profile.strip()
+    target_provider = provider.strip().lower()
+    target_instance = instance.strip() or "default"
+    if raw_profile and not target_provider:
+        target_provider, _, parsed_instance = raw_profile.partition(":")
+        target_provider = target_provider.strip().lower()
+        if parsed_instance.strip():
+            target_instance = parsed_instance.strip()
+    if route.strip():
+        result = as_dict(state.post("/api/webhooks/regenerate", json_body={"route_id": route.strip()}))
+    elif target_provider:
+        result = as_dict(
+            state.post(
+                "/api/scrobbler/webhooks/profile/regenerate",
+                json_body={"provider": target_provider, "provider_instance": target_instance},
+            )
+        )
     else:
         result = as_dict(state.post("/api/webhooks/regenerate"))
     if result.get("ok") is False:

--- a/cli/commands/transfer.py
+++ b/cli/commands/transfer.py
@@ -10,21 +10,14 @@ import typer
 
 from .._context import Ctx
 from .._errors import EXIT_NOT_FOUND, EXIT_USAGE, CLIError
-from .._util import as_dict, error_text
+from .._util import as_dict, error_text, rows_from_payload
 
 export_app = typer.Typer(help="Export your data out of CrossWatch.", no_args_is_help=True)
 import_app = typer.Typer(help="Import data into CrossWatch.", no_args_is_help=True)
 
 
 def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
-    block = as_dict(payload)
-    for key in keys:
-        found = block.get(key)
-        if isinstance(found, list):
-            return [as_dict(i) for i in found]
-    if isinstance(payload, list):
-        return [as_dict(i) for i in payload]
-    return []
+    return rows_from_payload(payload, *keys)
 
 
 def _options(state: Ctx, path: str, title: str) -> None:

--- a/cli/commands/watchlist.py
+++ b/cli/commands/watchlist.py
@@ -9,20 +9,13 @@ import typer
 
 from .._context import Ctx
 from .._errors import CLIError
-from .._util import as_dict, error_text
+from .._util import as_dict, error_text, rows_from_payload
 
 watchlist_app = typer.Typer(help="The unified watchlist across providers.", no_args_is_help=True)
 
 
 def _rows(payload: Any) -> list[dict[str, Any]]:
-    block = as_dict(payload)
-    for key in ("items", "watchlist", "rows", "results"):
-        found = block.get(key)
-        if isinstance(found, list):
-            return [as_dict(i) for i in found]
-    if isinstance(payload, list):
-        return [as_dict(i) for i in payload]
-    return []
+    return rows_from_payload(payload, "items", "watchlist", "rows", "results")
 
 
 def _providers(row: dict[str, Any]) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -570,6 +570,295 @@ def test_watcher_logs_uses_finite_watch_log_endpoint(
     ]
 
 
+def test_editor_list_reads_items_dict_payload(
+    clean_cli_env,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://cw.test", output="plain")
+    state._http = FakeTransport(
+        {
+            ("GET", "/api/editor"): {
+                "kind": "watchlist",
+                "source": "state",
+                "provider": "PLEX",
+                "provider_instance": "default",
+                "count": 1,
+                "items": {
+                    "tmdb:454639": {
+                        "type": "movie",
+                        "title": "Masters of the Universe",
+                        "ids": {"tmdb": 454639},
+                    }
+                },
+            },
+        }
+    )
+
+    assert run_isolated(state, ["editor", "list", "--provider", "plex", "--profile", "default"]) == 0
+    out = capsys.readouterr().out
+
+    assert "PLEX" in out
+    assert "tmdb:454639" in out
+    assert "Masters of the Universe" in out
+    assert "454639" in out
+    assert state._http.param_calls == [
+        (
+            "GET",
+            "/api/editor",
+            {"kind": "watchlist", "source": "state", "provider": "PLEX", "provider_instance": "default"},
+            None,
+        )
+    ]
+
+
+def test_editor_sources_prints_provider_names_from_string_payload(
+    clean_cli_env,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://cw.test", output="plain")
+    state._http = FakeTransport(
+        {
+            ("GET", "/api/editor/state/providers"): {"providers": ["PLEX", "TRAKT"]},
+            ("GET", "/api/editor"): {
+                "kind": "watchlist",
+                "source": "state",
+                "provider_instance": "default",
+                "count": 3,
+                "items": {},
+            },
+        }
+    )
+
+    assert run_isolated(state, ["editor", "sources"]) == 0
+    out = capsys.readouterr().out
+
+    assert "PLEX" in out
+    assert "TRAKT" in out
+    assert "3" in out
+    assert "-         -         -" not in out
+
+
+def test_editor_send_loads_selected_items_before_posting(
+    clean_cli_env,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://cw.test", output="plain")
+    state._http = FakeTransport(
+        {
+            ("GET", "/api/editor"): {
+                "items": {
+                    "tmdb:454639": {
+                        "type": "movie",
+                        "title": "Masters of the Universe",
+                        "ids": {"tmdb": 454639},
+                    }
+                },
+            },
+            ("POST", "/api/editor/send"): {"ok": True, "sent": 1},
+        }
+    )
+
+    assert run_isolated(
+        state,
+        ["editor", "send", "tmdb:454639", "--provider", "trakt", "--source-provider", "plex", "--yes"],
+    ) == 0
+    out = capsys.readouterr().out
+
+    assert "Sent 1 item(s) to TRAKT." in out
+    assert state._http.param_calls[0] == (
+        "GET",
+        "/api/editor",
+        {"kind": "watchlist", "source": "state", "provider": "PLEX"},
+        None,
+    )
+    body = state._http.calls[-1][2]
+    assert body["providers"] == [{"provider": "TRAKT", "instance": "default"}]
+    assert body["items"][0]["key"] == "tmdb:454639"
+    assert body["items"][0]["ids"]["tmdb"] == 454639
+
+
+def test_rows_from_payload_handles_dicts_and_strings() -> None:
+    from cli._util import rows_from_payload
+
+    assert rows_from_payload({"items": {"tmdb:1": {"title": "Heat"}}}, "items") == [
+        {"title": "Heat", "key": "tmdb:1"}
+    ]
+    assert rows_from_payload({"providers": ["PLEX"]}, "providers") == [
+        {"value": "PLEX", "name": "PLEX", "provider": "PLEX"}
+    ]
+
+
+def test_metadata_resolve_uses_api_entity_field(
+    clean_cli_env,
+) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://cw.test", output="json")
+    state._http = FakeTransport({("POST", "/api/metadata/resolve"): {"ok": True, "result": {}}})
+
+    assert run_isolated(state, ["metadata", "resolve", "tmdb=1399", "--type", "tv"]) == 0
+
+    assert state._http.calls == [
+        ("POST", "/api/metadata/resolve", {"ids": {"tmdb": "1399"}, "entity": "tv"})
+    ]
+
+
+def test_manual_watched_sends_editor_style_payload(
+    clean_cli_env,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://cw.test", output="plain")
+    state._http = FakeTransport({("POST", "/api/manual/watched"): {"ok": True, "results": []}})
+
+    assert run_isolated(
+        state,
+        [
+            "manual",
+            "watched",
+            "--field",
+            "tmdb=603",
+            "--field",
+            "type=movie",
+            "--field",
+            "rating=9",
+            "--provider",
+            "trakt",
+            "--at",
+            "2026-08-22",
+        ],
+    ) == 0
+
+    body = state._http.calls[-1][2]
+    assert body["item"]["tmdb"] == "603"
+    assert body["providers"] == [{"provider": "TRAKT", "instance": "default"}]
+    assert body["actions"] == {"history": True, "watchlist": False, "rating": True}
+    assert body["date_mode"] == "custom"
+    assert body["watched_on"] == "2026-08-22"
+    assert body["rating"] == "9"
+    assert "Recorded." in capsys.readouterr().out
+
+
+def test_backup_retention_uses_max_backups(
+    clean_cli_env,
+) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://cw.test", output="json")
+    state._http = FakeTransport({("POST", "/api/backups/retention"): {"ok": True, "result": {}}})
+
+    assert run_isolated(state, ["backup", "retention", "7"]) == 0
+
+    assert state._http.calls == [("POST", "/api/backups/retention", {"max_backups": 7})]
+
+
+def test_capture_diff_reads_nested_diff_rows(
+    clean_cli_env,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://cw.test", output="plain")
+    state._http = FakeTransport(
+        {
+            ("GET", "/api/snapshots/diff"): {
+                "ok": True,
+                "diff": {
+                    "summary": {"added": 1, "removed": 0, "changed": 0},
+                    "items": [{"kind": "added", "title": "Heat", "type": "movie"}],
+                },
+            },
+        }
+    )
+
+    assert run_isolated(state, ["capture", "diff", "old.json", "new.json"]) == 0
+
+    out = capsys.readouterr().out
+    assert "Heat" in out
+    assert "added" in out
+
+
+def test_scrobbler_event_routes_reads_watcher_and_webhook_routes(
+    clean_cli_env,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://cw.test", output="plain")
+    state._http = FakeTransport(
+        {
+            ("GET", "/api/scrobble/event_routes"): {
+                "ok": True,
+                "watcher_routes": [{"source": "watcher", "provider": "plex", "sink": "trakt", "label": "Plex -> Trakt"}],
+                "webhook_routes": [{"source": "webhook", "provider": "jellyfin", "label": "Jellyfin webhook"}],
+            },
+        }
+    )
+
+    assert run_isolated(state, ["scrobbler", "event-routes"]) == 0
+
+    out = capsys.readouterr().out
+    assert "Plex -> Trakt" in out
+    assert "Jellyfin webhook" in out
+
+
+def test_scrobbler_profile_webhook_regenerate_uses_provider_payload(
+    clean_cli_env,
+) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://cw.test", output="json")
+    state._http = FakeTransport({("POST", "/api/scrobbler/webhooks/profile/regenerate"): {"ok": True}})
+
+    assert run_isolated(state, ["scrobbler", "webhook", "regenerate", "--profile", "plex:P2", "--yes"]) == 0
+
+    assert state._http.calls == [
+        ("POST", "/api/scrobbler/webhooks/profile/regenerate", {"provider": "plex", "provider_instance": "P2"})
+    ]
+
+
+def test_progress_watched_loads_selected_records_before_bulk_action(
+    clean_cli_env,
+) -> None:
+    from cli._app import run_isolated
+
+    record = {
+        "key": "tmdb:603",
+        "provider": "trakt",
+        "instance_id": "default",
+        "remote_id": "abc",
+        "can_mark_watched": True,
+    }
+    state = Ctx.build(url="http://cw.test", output="json")
+    state._http = FakeTransport(
+        {
+            ("GET", "/api/playback_progress/items"): {"items": [record]},
+            ("POST", "/api/playback_progress/actions/bulk"): {"successful": 1, "failed": 0},
+        }
+    )
+
+    assert run_isolated(state, ["progress", "watched", "tmdb:603", "--yes"]) == 0
+
+    assert state._http.param_calls[0] == (
+        "GET",
+        "/api/playback_progress/items",
+        {"page_size": 250, "user_profile": ""},
+        None,
+    )
+    assert state._http.calls[-1] == (
+        "POST",
+        "/api/playback_progress/actions/bulk",
+        {"action": "mark_watched", "items": [record]},
+    )
+
+
 def _manifest(name: str, flow: str, fields: list[dict[str, Any]] | None = None):
     from cli.commands.auth import Manifest
 


### PR DESCRIPTION
# Pull request

## Change

- Fixes a bunch of CLI commands so they match the backend API payloads and response shapes better.
- Adds shared CLI row parsing, fixes editor/manual/progress/scrobbler/backup/capture handling.

## Why

- Some commands looked fine in help hecks but failed or showed empty data with real API responses.

## Testing

- tests/test_cli.py

## Issue

Relates to #839