### PR TITLE
Change: harden FLOPPY anime episode history

### DIFF
--- a/providers/sync/floppy/_history.py
+++ b/providers/sync/floppy/_history.py
@@ -17,9 +17,16 @@ from cw_platform.history_events import history_epoch_from_value, history_sync_ke
 from cw_platform.id_map import minimal as id_minimal
 from providers.sync._mod_common import build_op_result, unresolved_keys
 
-from ._common import COMPLETED, absolute_to_coord, api_delete, api_patch, api_post, canonical_item_key, confirmed_destination, failure_reason, has_coord, int_or_none, item_from_row, paged, reset_layout_cache, show_layout, tmdb_enriched_item, tmdb_id_for_item, track_media, unresolved
+from ._common import COMPLETED, absolute_to_coord, api_delete, api_patch, api_post, canonical_item_key, confirmed_destination, failure_reason, has_coord, int_or_none, item_from_row, media_parts_from_item_id, paged, reset_layout_cache, show_layout, tmdb_enriched_item, tmdb_id_for_item, track_media, unresolved
 
 _SRC_SNAPSHOT: dict[str, Any] = {"scope": None, "shows": {}}
+_SEASON_EPISODE_CACHE: dict[tuple[str, int], set[int] | None] = {}
+
+
+class FloppyCoordinateError(RuntimeError):
+    def __init__(self, message: str, *, reason: str = "floppy_episode_coord_missing") -> None:
+        super().__init__(message)
+        self.reason = reason
 
 
 def _rewatches_enabled(adapter: Any) -> bool:
@@ -74,6 +81,60 @@ def _floppy_coord(item: Mapping[str, Any]) -> tuple[int, int] | None:
     if season is None or episode is None or season < 0 or episode <= 0:
         return None
     return season, episode
+
+
+def _row_episode_number(row: Mapping[str, Any]) -> int | None:
+    for key in ("episode_number", "number", "episode"):
+        number = int_or_none(row.get(key))
+        if number is not None and number > 0:
+            return number
+    _, _, _, _, episode = media_parts_from_item_id(row.get("item_id"))
+    return episode if isinstance(episode, int) and episode > 0 else None
+
+
+def _season_episode_numbers(adapter: Any, tmdb_id: str, season: int) -> set[int] | None:
+    key = (str(tmdb_id or "").strip(), int(season))
+    if not key[0] or key[1] < 0:
+        return None
+    if key in _SEASON_EPISODE_CACHE:
+        return _SEASON_EPISODE_CACHE[key]
+    try:
+        rows = paged(adapter, f"media/tv/tmdb/{key[0]}/{key[1]}/episodes")
+    except Exception:
+        _SEASON_EPISODE_CACHE[key] = None
+        return None
+    numbers = {number for number in (_row_episode_number(row) for row in rows) if number}
+    _SEASON_EPISODE_CACHE[key] = numbers
+    return numbers
+
+
+def _floppy_coord_status(adapter: Any, tmdb_id: str, season: int, episode: int) -> bool | None:
+    if not tmdb_id or season < 0 or episode <= 0:
+        return None
+    numbers = _season_episode_numbers(adapter, tmdb_id, season)
+    if numbers is None:
+        return None
+    return episode in numbers
+
+
+def _detached_floppy_coord(adapter: Any, item: Mapping[str, Any]) -> bool:
+    if not _anime_mapping_enabled(adapter) or _SRC_SNAPSHOT.get("scope") != _pair_scope():
+        return False
+    if str(item.get("type") or "").strip().lower() != "episode":
+        return False
+    tmdb_id = tmdb_id_for_item(item, episode_show=True)
+    season, episode = _episode_numbers(item)
+    if not tmdb_id or season is None or episode is None:
+        return False
+    record = (_SRC_SNAPSHOT.get("shows") or {}).get(tmdb_id)
+    if not isinstance(record, Mapping):
+        return False
+    source_item = (record.get("items") or {}).get((season, episode))
+    if not isinstance(source_item, Mapping):
+        return False
+    if _explicit_absolute(source_item) is None or not _anime_native_ids(source_item):
+        return False
+    return _floppy_coord_status(adapter, tmdb_id, season, episode) is False
 
 
 def _anime_mapping_enabled(adapter: Any) -> bool:
@@ -256,6 +317,7 @@ def _pair_scope() -> str:
 def prepare_source_snapshot(items: Iterable[Mapping[str, Any]]) -> int:
     shows: dict[str, dict[str, Any]] = {}
     reset_layout_cache()
+    _SEASON_EPISODE_CACHE.clear()
     count = 0
     for item in items or []:
         if not isinstance(item, Mapping) or str(item.get("type") or "").strip().lower() != "episode":
@@ -375,14 +437,22 @@ def _write_target_result(adapter: Any, tmdb_id: str, item: Mapping[str, Any], se
     mapped = _anime_target_for_absolute(adapter, tmdb_id, item, absolute)
     if mapped is not None:
         target_id, mapped_season, mapped_episode = mapped
-        return target_id, mapped_season, mapped_episode, _anime_write_needs_readback(adapter, item, season, episode, mapped_season, mapped_episode)
+        if _floppy_coord_status(adapter, target_id, mapped_season, mapped_episode) is not False:
+            return target_id, mapped_season, mapped_episode, _anime_write_needs_readback(adapter, item, season, episode, mapped_season, mapped_episode)
+        layout = show_layout(adapter, target_id)
+        real = absolute_to_coord(layout, absolute)
+        if real is not None:
+            return target_id, real[0], real[1], _anime_write_needs_readback(adapter, item, season, episode, real[0], real[1])
+        raise FloppyCoordinateError(f"FLOPPY episode coordinate not found: tmdb:{target_id} S{mapped_season}E{mapped_episode}")
     layout = show_layout(adapter, tmdb_id)
-    if not layout or has_coord(layout, season, episode):
+    if not layout:
+        return tmdb_id, season, episode, _anime_write_needs_readback(adapter, item, season, episode, season, episode)
+    if has_coord(layout, season, episode):
         return tmdb_id, season, episode, _anime_write_needs_readback(adapter, item, season, episode, season, episode)
     real = absolute_to_coord(layout, absolute)
     if real is not None:
         return tmdb_id, real[0], real[1], _anime_write_needs_readback(adapter, item, season, episode, real[0], real[1])
-    return tmdb_id, season, episode, _anime_write_needs_readback(adapter, item, season, episode, season, episode)
+    raise FloppyCoordinateError(f"FLOPPY episode coordinate not found: tmdb:{tmdb_id} S{season}E{episode}")
 
 
 def _anime_write_needs_readback(
@@ -532,6 +602,8 @@ def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
             continue
         item = item_from_row(row, force_type="episode")
         if not item:
+            continue
+        if _detached_floppy_coord(adapter, item):
             continue
         item["watched"] = True
         item["watched_at"] = row.get("end_date") or row.get("progressed_at") or row.get("created_at")

--- a/tests/test_floppy_sync.py
+++ b/tests/test_floppy_sync.py
@@ -725,6 +725,28 @@ def _fake_mha_final_edges(tag: str, namespace: str, ident: str) -> list[dict[str
     return []
 
 
+def _one_piece_s23_source(**extra: Any) -> dict[str, Any]:
+    return {
+        "type": "episode",
+        "series_title": "One Piece",
+        "season": 23,
+        "episode": 1,
+        "_simkl_episode_number": 1156,
+        "watched_at": "2026-01-02T00:00:00Z",
+        "show_ids": {
+            "tmdb": "37854",
+            "imdb": "tt0388629",
+            "tvdb": "81797",
+            "simkl": "38636",
+            "mal": "21",
+            "anilist": "21",
+            "kitsu": "12",
+            "anidb": "69",
+        },
+        **extra,
+    }
+
+
 def test_floppy_history_add_uses_anime_native_coordinate_before_layout_absolute(monkeypatch: Any) -> None:
     from providers.sync.floppy import _history
 
@@ -859,6 +881,64 @@ def test_floppy_history_add_uses_anime_target_tmdb_when_source_tmdb_conflicts(mo
     assert res["confirmed_keys"] == ["tmdb:308405#s08e01"]
     assert [c["path"] for c in adapter.client.session.calls if c["method"] == "POST"] == ["media/tv/tmdb/65930/8/episodes/1/watch"]
     assert not any("media/tv/tmdb/308405" in c["path"] for c in adapter.client.session.calls)
+
+
+def test_floppy_history_add_falls_back_when_anime_target_coord_is_not_in_floppy_layout(monkeypatch: Any) -> None:
+    from providers.sync.floppy import _history
+
+    monkeypatch.setattr(
+        _history,
+        "resolve_source_coordinate",
+        lambda *_args, **_kwargs: SimpleNamespace(provider="tmdb", ident="37854", season=23, episode=1),
+    )
+    monkeypatch.setattr(
+        _history,
+        "show_layout",
+        lambda *_args, **_kwargs: [(1, n) for n in range(1, 1156)] + [(23, n) for n in range(1156, 1182)],
+    )
+    _history.prepare_source_snapshot([])
+    _history.reset_layout_cache()
+    routes = {
+        ("GET", "media/tv/tmdb/37854/23/episodes"): {
+            "results": [{"item_id": f"tv/tmdb/37854/23/{n}", "episode_number": n} for n in range(1156, 1182)],
+            "count": 26,
+        },
+        ("GET", "media/tv/tmdb/37854/23/1156/history"): _history_visible_after_post(),
+        ("POST", "media/tv/tmdb/37854/23/episodes/1156/watch"): {"consumption_id": 77},
+    }
+    adapter = AdapterStub(routes, _anime_history_cfg())
+
+    res = _history.add(adapter, [_one_piece_s23_source()])
+
+    assert res["count"] == 1
+    assert res["confirmed_keys"] == ["tmdb:37854#s23e01"]
+    assert [c["path"] for c in adapter.client.session.calls if c["method"] == "POST"] == ["media/tv/tmdb/37854/23/episodes/1156/watch"]
+    assert not any(c["path"] == "media/tv/tmdb/37854/23/episodes/1/watch" for c in adapter.client.session.calls)
+
+
+def test_floppy_history_ignores_detached_episode_rows_from_readback(monkeypatch: Any) -> None:
+    from providers.sync.floppy import _history
+
+    monkeypatch.setattr(_history, "show_layout", lambda *_args, **_kwargs: [(23, n) for n in range(1156, 1182)])
+    _history.prepare_source_snapshot([_one_piece_s23_source()])
+    adapter = AdapterStub(
+        {
+            ("GET", "media/movie"): {"results": [], "count": 0},
+            ("GET", "media/episode"): {
+                "results": [{"item_id": "tv/tmdb/37854/23/1", "end_date": "2026-01-02T00:00:00Z", "consumption_id": 77}],
+                "count": 1,
+            },
+            ("GET", "media/tv/tmdb/37854/23/episodes"): {
+                "results": [{"item_id": f"tv/tmdb/37854/23/{n}", "episode_number": n} for n in range(1156, 1182)],
+                "count": 26,
+            },
+        },
+        _anime_history_cfg(),
+    )
+
+    out = _history.build_index(adapter)
+
+    assert out == {}
 
 
 def test_floppy_history_uses_anidb_when_native_targets_disagree(monkeypatch: Any) -> None:


### PR DESCRIPTION
# Pull request

## Change

- Harden FLOPPY history writes for anime episode mappings.
- CrossWatch now checks mapped FLOPPY episode coordinates against FLOPPY season episodes first. 
  - If the mapped coordinate is detached, it falls back to the real FLOPPY layout coordinate.
- It also ignores detached FLOPPY readback rows so they do not make sync look successful.

## Why

Anime mappings could write to FLOPPY coordinates that FLOPPY accepted, but did not show as watched on the real season page.

## Testing

- tests\test_floppy_sync.py

## Issue

Relates to #809

note: pending bug issue at Floppy