### PR TITLE
Add: maintenance CLI cleanup commands

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -345,15 +345,18 @@ cw activity clear
 ## Maintenance
 
 ```
+cw maintenance tools               show modal-style maintenance actions
 cw maintenance database            runtime db health
 cw maintenance events              archive health, --optimize, --rebuild
 cw maintenance cache <what>        all, metadata, provider-sync, activity-log, scrobbles, state
 cw maintenance provider-cache
+cw maintenance provider-cleanup    clear provider watchlist, ratings, history or progress
 cw maintenance state-file --prune|--compact
 cw maintenance tracker [--clear]
 cw maintenance reset-stats
 cw maintenance reset-watching
 cw maintenance support [--scopes]
+cw maintenance factory-reset       requires --confirm RESET
 cw maintenance restart
 ```
 

--- a/cli/commands/maintenance.py
+++ b/cli/commands/maintenance.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import time
+import uuid
 from typing import Any
 
 import typer
@@ -22,6 +24,28 @@ CACHES = {
     "state": "/api/maintenance/clear-state",
 }
 
+PROVIDER_CLEANUP_FEATURES = ("watchlist", "ratings", "history", "progress")
+
+MAINTENANCE_TOOLS = [
+    ("Sync", "Rebuild sync state", "cw maintenance cache state --yes"),
+    ("Sync", "Retry provider items", "cw maintenance cache all --yes"),
+    ("Playback", "Clear currently playing", "cw maintenance reset-watching"),
+    ("Playback", "Clear Recent Scrobbles", "cw maintenance cache scrobbles --yes"),
+    ("Reports & Metadata", "Rebuild statistics", "cw maintenance reset-stats --purge-reports --purge-insights --yes"),
+    ("Reports & Metadata", "Refresh artwork & metadata", "cw maintenance cache metadata --yes"),
+    ("Events", "Health check", "cw maintenance events"),
+    ("Events", "Optimize archive", "cw maintenance events --optimize"),
+    ("Events", "Clear archive", "cw maintenance events --rebuild --yes"),
+    ("Sync State", "Database health", "cw maintenance database"),
+    ("Sync State", "Compact sync state", "cw maintenance state-file --compact"),
+    ("Sync State", "Prune stale state", "cw maintenance state-file --prune"),
+    ("Archive & Recovery", "CW tracker archive", "cw maintenance tracker --clear --snapshots --yes"),
+    ("Captures", "Clear all captures", "cw capture clear --yes"),
+    ("Provider Cleanup", "Clear provider data", "cw maintenance provider-cleanup --provider PLEX --feature watchlist --yes"),
+    ("Support", "Support diagnostics", "cw maintenance support"),
+    ("Danger zone", "Factory reset", "cw maintenance factory-reset --confirm RESET"),
+]
+
 
 def _flat(state: Ctx, payload: Any, title: str) -> None:
     block = as_dict(payload)
@@ -39,6 +63,100 @@ def _flat(state: Ctx, payload: Any, title: str) -> None:
                 [(k, v) for k, v in value.items() if not isinstance(v, (dict, list))],
                 title=key,
             )
+
+
+def _split_cleanup_features(values: list[str], *, all_features: bool = False) -> list[str]:
+    if all_features:
+        return list(PROVIDER_CLEANUP_FEATURES)
+    out: list[str] = []
+    for value in values:
+        for chunk in str(value or "").split(","):
+            feature = chunk.strip().lower()
+            if not feature:
+                continue
+            if feature not in PROVIDER_CLEANUP_FEATURES:
+                raise CLIError(
+                    f"Unknown cleanup feature '{feature}'",
+                    hint=f"Try: {', '.join(PROVIDER_CLEANUP_FEATURES)}",
+                    exit_code=EXIT_USAGE,
+                )
+            if feature not in out:
+                out.append(feature)
+    return out
+
+
+def _provider_targets(payload: Any) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for provider in as_dict(payload).get("providers") or []:
+        if not isinstance(provider, dict) or provider.get("configured") is False:
+            continue
+        pid = str(provider.get("id") or "").strip().upper()
+        label = str(provider.get("label") or pid or "-")
+        raw_features = provider.get("features")
+        features: dict[str, Any] = raw_features if isinstance(raw_features, dict) else {}
+        cleanup_features = [feature for feature in PROVIDER_CLEANUP_FEATURES if features.get(feature)]
+        instances = provider.get("instances") if isinstance(provider.get("instances"), list) else []
+        if not instances:
+            instances = [{"id": "default", "label": "Default", "configured": True}]
+        for instance in instances:
+            if not isinstance(instance, dict) or instance.get("configured") is False:
+                continue
+            rows.append(
+                {
+                    "provider": pid or label,
+                    "profile": str(instance.get("id") or "default"),
+                    "label": str(instance.get("label") or instance.get("id") or "Default"),
+                    "features": ", ".join(cleanup_features) if cleanup_features else "-",
+                }
+            )
+    return rows
+
+
+def _cleanup_result_rows(payload: Any) -> list[dict[str, Any]]:
+    block = as_dict(payload)
+    result = as_dict(block.get("result"))
+    progress = as_dict(block.get("progress"))
+    results = (
+        as_dict(result.get("results"))
+        or as_dict(progress.get("cleanup_results"))
+        or as_dict(progress.get("results"))
+        or as_dict(block.get("results"))
+    )
+    rows = []
+    for feature, item in results.items():
+        row = as_dict(item)
+        row.setdefault("feature", str(feature))
+        rows.append(row)
+    return rows
+
+
+def _print_cleanup_result(state: Ctx, payload: Any) -> None:
+    if state.out.json_mode:
+        state.out.data(payload)
+        return
+    block = as_dict(payload)
+    progress = as_dict(block.get("progress"))
+    result = as_dict(block.get("result"))
+    message = (
+        str(progress.get("message") or "")
+        or str(result.get("message") or "")
+        or "Provider cleanup complete."
+    )
+    rows = _cleanup_result_rows(payload)
+    state.out.success(message)
+    if rows:
+        state.out.print()
+        state.out.records(
+            rows,
+            [
+                ("FEATURE", lambda r: str(r.get("feature") or "-")),
+                ("REMOVED", lambda r: str(r.get("removed") or 0)),
+                ("FOUND", lambda r: str(r.get("count") or 0)),
+                ("LEFT", lambda r: str(r.get("remaining") or 0)),
+                ("STATUS", lambda r: "skipped" if r.get("skipped") else ("ok" if r.get("ok", True) else "failed")),
+            ],
+            title="Provider cleanup",
+        )
 
 
 @maintenance_app.command("database")
@@ -118,6 +236,150 @@ def maintenance_provider_cache(ctx: typer.Context) -> None:
         )
         return
     _flat(state, payload, "Provider cache")
+
+
+@maintenance_app.command("tools")
+def maintenance_tools(ctx: typer.Context) -> None:
+    """Show Maintenance modal actions and their CLI commands."""
+    state: Ctx = ctx.obj
+    if state.out.json_mode:
+        state.out.data(
+            {
+                "tools": [
+                    {"category": category, "action": action, "command": command}
+                    for category, action, command in MAINTENANCE_TOOLS
+                ]
+            }
+        )
+        return
+    state.out.records(
+        [{"category": category, "action": action, "command": command} for category, action, command in MAINTENANCE_TOOLS],
+        [
+            ("CATEGORY", lambda r: str(r.get("category") or "-")),
+            ("ACTION", lambda r: str(r.get("action") or "-")),
+            ("COMMAND", lambda r: str(r.get("command") or "-")),
+        ],
+        title="Maintenance tools",
+    )
+
+
+@maintenance_app.command("provider-cleanup")
+def maintenance_provider_cleanup(
+    ctx: typer.Context,
+    provider: str = typer.Option("", "--provider", "-p", help="Provider to clear, for example PLEX."),
+    instance: str = typer.Option("default", "--instance", "-i", help="Provider profile/instance id."),
+    feature: list[str] = typer.Option([], "--feature", "-F", help="Data to clear. Repeat or comma-separate."),
+    all_features: bool = typer.Option(False, "--all", help="Clear watchlist, ratings, history and progress."),
+    targets: bool = typer.Option(False, "--targets", help="Show provider cleanup targets."),
+    wait: bool = typer.Option(True, "--wait/--no-wait", help="Wait for cleanup to finish."),
+    timeout: float = typer.Option(900.0, "--timeout", help="How long to wait, in seconds."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Clear provider watchlist, ratings, history or progress by profile."""
+    state: Ctx = ctx.obj
+    if targets or not provider.strip():
+        payload = state.get("/api/snapshots/manifest")
+        if state.out.json_mode:
+            state.out.data(payload)
+            return
+        rows = _provider_targets(payload)
+        state.out.records(
+            rows,
+            [
+                ("PROVIDER", lambda r: str(r.get("provider") or "-")),
+                ("PROFILE", lambda r: str(r.get("profile") or "-")),
+                ("NAME", lambda r: str(r.get("label") or "-")),
+                ("CAN CLEAR", lambda r: str(r.get("features") or "-")),
+            ],
+            title="Provider cleanup targets",
+            empty="No configured provider cleanup targets.",
+        )
+        return
+
+    state.require_service("Clearing provider data")
+    features = _split_cleanup_features(feature, all_features=all_features)
+    if not features:
+        raise CLIError(
+            "Pick at least one cleanup feature",
+            hint="Use --feature watchlist, --feature ratings, --feature history, --feature progress or --all.",
+            exit_code=EXIT_USAGE,
+        )
+    pid = provider.strip().upper()
+    inst = instance.strip() or "default"
+    if not yes and not typer.confirm(f"Clear {', '.join(features)} from {pid}#{inst}?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+
+    progress_id = f"provider-cleanup-{uuid.uuid4()}"
+    result = as_dict(
+        state.post(
+            "/api/snapshots/tools/clear",
+            json_body={
+                "provider": pid,
+                "instance": inst,
+                "features": features,
+                "progress_id": progress_id,
+                "background": True,
+            },
+        )
+    )
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Provider cleanup rejected"))
+    if not wait:
+        if state.out.json_mode:
+            state.out.data(result)
+            return
+        state.out.success(f"Provider cleanup started ({progress_id}).")
+        return
+
+    deadline = time.time() + max(10.0, timeout)
+    last = ""
+    while time.time() < deadline:
+        time.sleep(1.0)
+        progress_payload = as_dict(state.get(f"/api/snapshots/capture-progress/{progress_id}"))
+        progress = as_dict(progress_payload.get("progress")) or progress_payload
+        if progress.get("ok") is False and progress.get("done"):
+            raise CLIError(error_text(progress, "Provider cleanup failed"))
+        note = str(progress.get("message") or progress.get("stage") or "")
+        if note and note != last:
+            state.out.info(note)
+            last = note
+        if progress.get("done"):
+            _print_cleanup_result(state, {"progress": progress, "start": result})
+            return
+    state.out.warn("Still running, stopped waiting.")
+
+
+@maintenance_app.command("factory-reset")
+def maintenance_factory_reset(
+    ctx: typer.Context,
+    confirm: str = typer.Option("", "--confirm", help="Type RESET to confirm."),
+    restart: bool = typer.Option(False, "--restart", help="Restart the service after reset."),
+) -> None:
+    """Return CrossWatch to a clean local install."""
+    state: Ctx = ctx.obj
+    state.require_service("Factory reset")
+    if str(confirm or "").strip().upper() != "RESET":
+        raise CLIError(
+            "Factory reset requires confirmation",
+            hint="Run with --confirm RESET. This deletes local state and backs up config.json.",
+            exit_code=EXIT_USAGE,
+        )
+    result = as_dict(state.post("/api/maintenance/reset-all-default", json_body={"restart": bool(restart)}))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Factory reset rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success("Factory reset complete.")
+    state.out.kv(
+        [
+            ("Config backup", result.get("backup") or "-"),
+            ("Removed files", len(result.get("removed_files") or [])),
+            ("Removed dirs", len(result.get("removed_dirs") or [])),
+            ("Restart", "scheduled" if result.get("restart_scheduled") else "no"),
+        ],
+        title="Factory reset",
+    )
 
 
 @maintenance_app.command("state-file")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -906,6 +907,109 @@ def test_config_body_keeps_the_provider_prefix() -> None:
 
     values = {"simkl.client_id": "abc", "simkl.client_secret": "xyz"}
     assert _nest(values, drop_prefix=False) == {"simkl": {"client_id": "abc", "client_secret": "xyz"}}
+
+
+def test_maintenance_cleanup_features_accepts_repeated_and_csv_values() -> None:
+    from cli.commands.maintenance import _split_cleanup_features
+
+    assert _split_cleanup_features(["watchlist,ratings", "history"]) == ["watchlist", "ratings", "history"]
+    assert _split_cleanup_features([], all_features=True) == ["watchlist", "ratings", "history", "progress"]
+    with pytest.raises(CLIError):
+        _split_cleanup_features(["bogus"])
+
+
+def test_maintenance_provider_cleanup_posts_snapshot_tool_clear() -> None:
+    from cli.commands.maintenance import maintenance_provider_cleanup
+
+    http = FakeTransport({("POST", "/api/snapshots/tools/clear"): {"ok": True, "progress_id": "job-1"}})
+    state = _ctx(http)
+
+    maintenance_provider_cleanup(
+        SimpleNamespace(obj=state),
+        provider="plex",
+        instance="kids",
+        feature=["watchlist,history"],
+        all_features=False,
+        targets=False,
+        wait=False,
+        timeout=10,
+        yes=True,
+    )
+
+    assert http.calls == [
+        (
+            "POST",
+            "/api/snapshots/tools/clear",
+            {
+                "provider": "PLEX",
+                "instance": "kids",
+                "features": ["watchlist", "history"],
+                "progress_id": http.calls[0][2]["progress_id"],
+                "background": True,
+            },
+        )
+    ]
+
+
+def test_maintenance_provider_cleanup_lists_manifest_targets() -> None:
+    from cli.commands.maintenance import maintenance_provider_cleanup
+
+    http = FakeTransport(
+        {
+            (
+                "GET",
+                "/api/snapshots/manifest",
+            ): {
+                "providers": [
+                    {
+                        "id": "PLEX",
+                        "label": "Plex",
+                        "configured": True,
+                        "features": {"watchlist": True, "ratings": False, "history": True, "progress": True},
+                        "instances": [{"id": "default", "label": "Default", "configured": True}],
+                    }
+                ]
+            }
+        }
+    )
+    state = _ctx(http)
+
+    maintenance_provider_cleanup(
+        SimpleNamespace(obj=state),
+        provider="",
+        instance="default",
+        feature=[],
+        all_features=False,
+        targets=False,
+        wait=True,
+        timeout=10,
+        yes=False,
+    )
+
+    assert http.param_calls[0][:3] == ("GET", "/api/snapshots/manifest", None)
+
+
+def test_maintenance_factory_reset_requires_typed_confirmation() -> None:
+    from cli.commands.maintenance import maintenance_factory_reset
+
+    http = FakeTransport({("POST", "/api/maintenance/reset-all-default"): {"ok": True}})
+    state = _ctx(http)
+
+    with pytest.raises(CLIError):
+        maintenance_factory_reset(SimpleNamespace(obj=state), confirm="", restart=False)
+
+    assert http.calls == []
+
+
+def test_maintenance_factory_reset_posts_reset_endpoint() -> None:
+    from cli.commands.maintenance import maintenance_factory_reset
+
+    http = FakeTransport({("POST", "/api/maintenance/reset-all-default"): {"ok": True, "backup": "/config/config.json.bak"}})
+    state = _ctx(http)
+
+    maintenance_factory_reset(SimpleNamespace(obj=state), confirm="RESET", restart=True)
+
+    assert http.calls == [("POST", "/api/maintenance/reset-all-default", {"restart": True})]
 
 
 def test_parse_field_args_requires_key_equals_value() -> None:


### PR DESCRIPTION
# Pull request

## Change

Add maintenance CLI commands for modal parity:
- `cw maintenance tools`
- `cw maintenance provider-cleanup`
- `cw maintenance factory-reset`

Also update the CLI README and add tests for the new maintenance commands.

## Why

CLI users should be able to run the same maintenance and provider cleanup actions without opening the web UI.

## Testing

- tests/test_cli.py

## Issue

Relates to #839