### PR TITLE
Change: secure first setup and API tokens

### DIFF
--- a/api/apiTokensAPI.py
+++ b/api/apiTokensAPI.py
@@ -12,7 +12,7 @@ from typing import Any
 from fastapi import APIRouter, Body, Request
 from fastapi.responses import JSONResponse
 
-from cw_platform.config_base import _load_config_key, load_config
+from cw_platform.config_base import load_config
 
 from .appAuthAPI import (
     ADMIN_USER_ID,
@@ -40,7 +40,6 @@ TOKEN_MAX_LENGTH = 256
 TOKEN_V2_SECRET_BYTES = 32
 
 _TOKEN_V2_RE = re.compile(r"^cwt_([a-f0-9]{16})\.([A-Za-z0-9_-]{32,})$")
-_SHA256_HEX_RE = re.compile(r"^[a-f0-9]{64}$")
 _TRUSTED_LOCAL_TOKEN_ORIGINS = {"local_cli", "local_bootstrap"}
 
 _TOUCH_CACHE: dict[str, float] = {}
@@ -72,13 +71,6 @@ def _valid_token_hash(raw: Any) -> bool:
         return False
 
 
-def _token_digest(raw: str, *, create_key: bool = False) -> str:
-    key = _load_config_key(create=create_key)
-    if not key:
-        return ""
-    return hmac.new(key, str(raw or "").encode("utf-8"), "sha256").hexdigest()
-
-
 def _valid_v1_entry(entry: dict[str, Any]) -> bool:
     if not _valid_token_hash(entry.get("token_hash")):
         return False
@@ -97,8 +89,7 @@ def _valid_v2_entry(entry: dict[str, Any]) -> bool:
         return False
     if not re.fullmatch(r"[a-f0-9]{16}", str(entry.get("id") or "")):
         return False
-    digest = str(entry.get("token_digest") or "")
-    if str(entry.get("digest_scheme") or "") != "hmac_sha256" or not _SHA256_HEX_RE.fullmatch(digest):
+    if not str(entry.get("secret") or "").strip():
         return False
     exp = int(entry.get("expires_at") or 0)
     return exp <= 0 or exp > _now()
@@ -179,13 +170,11 @@ def resolve_api_token(cfg: dict[str, Any], raw: str) -> dict[str, Any] | None:
     v2_match = _TOKEN_V2_RE.fullmatch(token)
     if v2_match:
         token_id = v2_match.group(1)
-        digest = _token_digest(token)
-        if not digest:
-            return None
+        secret = v2_match.group(2)
         for entry in tokens:
             if str(entry.get("id") or "") != token_id or not _valid_v2_entry(entry):
                 continue
-            if not hmac.compare_digest(digest, str(entry.get("token_digest") or "")):
+            if not hmac.compare_digest(secret, str(entry.get("secret") or "")):
                 return None
             identity = _entry_identity(a, entry)
             if identity is None:
@@ -280,8 +269,7 @@ def issue_api_token(
             "id": entry_id,
             "version": 2,
             "name": label,
-            "token_digest": _token_digest(raw, create_key=True),
-            "digest_scheme": "hmac_sha256",
+            "secret": secret,
             "prefix": f"{TOKEN_PREFIX}{entry_id}.{secret[:6]}",
             "user_id": target,
             "username": str(identity.get("username") or ""),

--- a/api/apiTokensAPI.py
+++ b/api/apiTokensAPI.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
-import hashlib
 import hmac
 import re
 import secrets
@@ -13,7 +12,7 @@ from typing import Any
 from fastapi import APIRouter, Body, Request
 from fastapi.responses import JSONResponse
 
-from cw_platform.config_base import load_config
+from cw_platform.config_base import _load_config_key, load_config
 
 from .appAuthAPI import (
     ADMIN_USER_ID,
@@ -73,8 +72,11 @@ def _valid_token_hash(raw: Any) -> bool:
         return False
 
 
-def _token_digest(raw: str) -> str:
-    return hashlib.sha256(str(raw or "").encode("utf-8")).hexdigest()
+def _token_digest(raw: str, *, create_key: bool = False) -> str:
+    key = _load_config_key(create=create_key)
+    if not key:
+        return ""
+    return hmac.new(key, str(raw or "").encode("utf-8"), "sha256").hexdigest()
 
 
 def _valid_v1_entry(entry: dict[str, Any]) -> bool:
@@ -96,7 +98,7 @@ def _valid_v2_entry(entry: dict[str, Any]) -> bool:
     if not re.fullmatch(r"[a-f0-9]{16}", str(entry.get("id") or "")):
         return False
     digest = str(entry.get("token_digest") or "")
-    if str(entry.get("digest_scheme") or "") != "sha256" or not _SHA256_HEX_RE.fullmatch(digest):
+    if str(entry.get("digest_scheme") or "") != "hmac_sha256" or not _SHA256_HEX_RE.fullmatch(digest):
         return False
     exp = int(entry.get("expires_at") or 0)
     return exp <= 0 or exp > _now()
@@ -178,6 +180,8 @@ def resolve_api_token(cfg: dict[str, Any], raw: str) -> dict[str, Any] | None:
     if v2_match:
         token_id = v2_match.group(1)
         digest = _token_digest(token)
+        if not digest:
+            return None
         for entry in tokens:
             if str(entry.get("id") or "") != token_id or not _valid_v2_entry(entry):
                 continue
@@ -276,8 +280,8 @@ def issue_api_token(
             "id": entry_id,
             "version": 2,
             "name": label,
-            "token_digest": _token_digest(raw),
-            "digest_scheme": "sha256",
+            "token_digest": _token_digest(raw, create_key=True),
+            "digest_scheme": "hmac_sha256",
             "prefix": f"{TOKEN_PREFIX}{entry_id}.{secret[:6]}",
             "user_id": target,
             "username": str(identity.get("username") or ""),

--- a/api/apiTokensAPI.py
+++ b/api/apiTokensAPI.py
@@ -3,6 +3,9 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import hashlib
+import hmac
+import re
 import secrets
 import time
 from typing import Any
@@ -23,7 +26,6 @@ from .appAuthAPI import (
     _now,
     _origin_allowed,
     _origin_blocked_response,
-    _password_hash,
     _password_matches,
     _public_user,
     _update_config,
@@ -35,6 +37,12 @@ TOKEN_PREFIX = "cwt_"
 TOKEN_HEADER = "x-cw-token"
 MAX_TOKENS_PER_USER = 20
 TOUCH_INTERVAL_SEC = 300
+TOKEN_MAX_LENGTH = 256
+TOKEN_V2_SECRET_BYTES = 32
+
+_TOKEN_V2_RE = re.compile(r"^cwt_([a-f0-9]{16})\.([A-Za-z0-9_-]{32,})$")
+_SHA256_HEX_RE = re.compile(r"^[a-f0-9]{64}$")
+_TRUSTED_LOCAL_TOKEN_ORIGINS = {"local_cli", "local_bootstrap"}
 
 _TOUCH_CACHE: dict[str, float] = {}
 
@@ -65,13 +73,37 @@ def _valid_token_hash(raw: Any) -> bool:
         return False
 
 
-def _valid_entry(entry: dict[str, Any]) -> bool:
+def _token_digest(raw: str) -> str:
+    return hashlib.sha256(str(raw or "").encode("utf-8")).hexdigest()
+
+
+def _valid_v1_entry(entry: dict[str, Any]) -> bool:
     if not _valid_token_hash(entry.get("token_hash")):
         return False
     if not str(entry.get("id") or "").strip():
         return False
     exp = int(entry.get("expires_at") or 0)
     return exp <= 0 or exp > _now()
+
+
+def _valid_v2_entry(entry: dict[str, Any]) -> bool:
+    try:
+        version = int(entry.get("version") or 0)
+    except Exception:
+        return False
+    if version != 2:
+        return False
+    if not re.fullmatch(r"[a-f0-9]{16}", str(entry.get("id") or "")):
+        return False
+    digest = str(entry.get("token_digest") or "")
+    if str(entry.get("digest_scheme") or "") != "sha256" or not _SHA256_HEX_RE.fullmatch(digest):
+        return False
+    exp = int(entry.get("expires_at") or 0)
+    return exp <= 0 or exp > _now()
+
+
+def _valid_entry(entry: dict[str, Any]) -> bool:
+    return _valid_v2_entry(entry) or _valid_v1_entry(entry)
 
 
 def _prune_api_tokens(tokens: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -108,6 +140,7 @@ def _entry_identity(a: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any] 
 def _public_entry(entry: dict[str, Any]) -> dict[str, Any]:
     return {
         "id": str(entry.get("id") or ""),
+        "version": 2 if _valid_v2_entry(entry) else 1,
         "name": str(entry.get("name") or ""),
         "prefix": str(entry.get("prefix") or ""),
         "user_id": _entry_user_id(entry),
@@ -134,14 +167,37 @@ def extract_api_token(request: Request) -> str:
 
 def resolve_api_token(cfg: dict[str, Any], raw: str) -> dict[str, Any] | None:
     token = str(raw or "").strip()
-    if not token or not token.startswith(TOKEN_PREFIX):
+    if not token or len(token) > TOKEN_MAX_LENGTH or not token.startswith(TOKEN_PREFIX):
         return None
     a = _cfg_auth(cfg)
     tokens = _cfg_api_tokens(a)
     if not tokens:
         return None
+
+    v2_match = _TOKEN_V2_RE.fullmatch(token)
+    if v2_match:
+        token_id = v2_match.group(1)
+        digest = _token_digest(token)
+        for entry in tokens:
+            if str(entry.get("id") or "") != token_id or not _valid_v2_entry(entry):
+                continue
+            if not hmac.compare_digest(digest, str(entry.get("token_digest") or "")):
+                return None
+            identity = _entry_identity(a, entry)
+            if identity is None:
+                return None
+            out = dict(identity)
+            out["auth_kind"] = "api_token"
+            out["api_token_id"] = str(entry.get("id") or "")
+            out["api_token_name"] = str(entry.get("name") or "")
+            return out
+        return None
+
+    if "." in token:
+        return None
+
     for entry in tokens:
-        if not _valid_entry(entry):
+        if not _valid_v1_entry(entry):
             continue
         token_hash = entry.get("token_hash")
         if not isinstance(token_hash, dict) or not _password_matches(token_hash, token):
@@ -188,14 +244,19 @@ def issue_api_token(
     name: str,
     user_id: str = "",
     expires_days: int = 0,
+    created_via: str = "api",
 ) -> tuple[str, dict[str, Any]]:
     label = str(name or "").strip()[:64] or "CLI"
     days = max(0, int(expires_days or 0))
-    raw = TOKEN_PREFIX + secrets.token_urlsafe(32)
     entry_id = secrets.token_hex(8)
+    secret = secrets.token_urlsafe(TOKEN_V2_SECRET_BYTES)
+    raw = f"{TOKEN_PREFIX}{entry_id}.{secret}"
     created = _now()
     expires = created + days * 86400 if days else 0
     target = _normalize_app_user_id(user_id) or ADMIN_USER_ID
+    origin = str(created_via or "api").strip()
+    if origin not in {*_TRUSTED_LOCAL_TOKEN_ORIGINS, "api"}:
+        origin = "api"
 
     def _mutate(latest: dict[str, Any]) -> dict[str, Any]:
         a = latest.setdefault("app_auth", {})
@@ -213,11 +274,14 @@ def issue_api_token(
             raise KeyError("not_found")
         entry = {
             "id": entry_id,
+            "version": 2,
             "name": label,
-            "token_hash": _password_hash(raw),
-            "prefix": raw[: len(TOKEN_PREFIX) + 6],
+            "token_digest": _token_digest(raw),
+            "digest_scheme": "sha256",
+            "prefix": f"{TOKEN_PREFIX}{entry_id}.{secret[:6]}",
             "user_id": target,
             "username": str(identity.get("username") or ""),
+            "created_via": origin,
             "created_at": created,
             "expires_at": expires,
             "last_used_at": 0,
@@ -291,7 +355,7 @@ router = APIRouter(prefix="/api/app-auth/tokens", tags=["app-auth"])
 def _actor(request: Request) -> tuple[dict[str, Any] | None, JSONResponse | None]:
     cfg = load_config()
     if not auth_required(cfg):
-        return _admin_identity(_cfg_auth(cfg)), None
+        return None, _nostore({"ok": False, "error": "Authentication is not configured"}, 403)
     token = request.cookies.get(COOKIE_NAME)
     user = current_user(cfg, token)
     if user is None:

--- a/api/appAuthAPI.py
+++ b/api/appAuthAPI.py
@@ -830,6 +830,23 @@ def auth_required(cfg: dict[str, Any]) -> bool:
     return bool(a.get("enabled")) and credentials_configured(cfg)
 
 
+def _trusted_pre_auth_api_tokens(a: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = a.get("api_tokens")
+    if not isinstance(raw, list):
+        return []
+    keep: list[dict[str, Any]] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            version = int(entry.get("version") or 0)
+        except Exception:
+            continue
+        if version == 2 and str(entry.get("created_via") or "") in {"local_cli", "local_bootstrap"}:
+            keep.append(entry)
+    return keep
+
+
 def reset_pending(cfg: dict[str, Any]) -> bool:
     a = _cfg_auth(cfg)
     return bool(a.get("reset_required"))
@@ -871,7 +888,7 @@ def _config_needs_upgrade(cfg: dict[str, Any]) -> bool:
 def setup_lock_required(cfg: dict[str, Any]) -> bool:
     if reset_pending(cfg):
         return True
-    return (not auth_required(cfg)) and _config_needs_upgrade(cfg)
+    return not auth_required(cfg)
 
 
 def _find_session(a: dict[str, Any], token: str | None) -> dict[str, Any] | None:
@@ -2027,6 +2044,7 @@ def api_set_credentials(request: Request, payload: dict[str, Any] = Body(...)) -
             latest_a["enabled"] = False
             latest_a["reset_required"] = False
             latest_a["username"] = username or str(latest_a.get("username") or "")
+            latest_a["api_tokens"] = []
             _clear_sessions(latest)
             return latest_a
 
@@ -2079,6 +2097,8 @@ def api_set_credentials(request: Request, payload: dict[str, Any] = Body(...)) -
         latest_a["enabled"] = True
         latest_a["username"] = username
         latest_a["reset_required"] = False
+        if (not configured0) or recovery_mode:
+            latest_a["api_tokens"] = _trusted_pre_auth_api_tokens(latest_a)
         _clear_sessions(latest)
         _clear_setup_autogen_flag(latest)
         _mark_upgrade_pending_if_needed(latest)

--- a/cli/README.md
+++ b/cli/README.md
@@ -28,11 +28,21 @@ python cli/cw.py status
 python -m cli status
 ```
 
+## First Setup
+
+Fresh install or deleted config? Set the CrossWatch admin password before using the API commands:
+
+```
+cw --local auth setup --username admin
+```
+
+By default this also creates and saves a CLI API token. Use `--no-token` if you only want to set the password.
+
 ## Tokens
 
-No auth enabled in CrossWatch? Nothing to do, it just works.
+Without app authentication configured, CrossWatch only exposes health/status/setup endpoints remotely. Use `cw --local auth setup` from the CrossWatch host or container for CLI-only installs.
 
-With auth on you need a token. Use `--local` for the first one, that writes straight to the config so it works before you can authenticate at all:
+With auth on you need a token. You can create another one locally from the CrossWatch host or container:
 
 ```
 cw --local auth token create --name cli

--- a/cli/_app.py
+++ b/cli/_app.py
@@ -13,11 +13,7 @@ from ._errors import EXIT_ERROR, EXIT_USAGE, CLIError
 from ._render import Output
 
 PROG = "cw"
-HELP = """CrossWatch command line.
-
-Talks to the running CrossWatch service over its API, and falls back to the
-local install for read-only and repair commands when the service is down.
-"""
+HELP = "CrossWatch command line."
 
 app = typer.Typer(
     name=PROG,

--- a/cli/_errors.py
+++ b/cli/_errors.py
@@ -55,9 +55,13 @@ class ApiError(CLIError):
             message = f"{message} ({where})"
         code = EXIT_ERROR
         hint = ""
-        if self.status == 401:
+        setup_required = detail.lower() == "authentication setup required"
+        if setup_required:
             code = EXIT_UNAUTHORIZED
-            hint = "Create a token with 'cw auth token create --local' and export CW_TOKEN, or run 'cw auth token use <token>'."
+            hint = "Run 'cw --local auth setup --username admin' from the CrossWatch host or container to set the admin password and create a CLI token."
+        elif self.status == 401:
+            code = EXIT_UNAUTHORIZED
+            hint = "Run 'cw --local auth token create' on the CrossWatch host/container; it saves the token by default. For a token from another machine, use CW_TOKEN or 'cw auth token use <token>'."
         elif self.status == 403:
             code = EXIT_UNAUTHORIZED
             hint = "This token does not have permission for that action."

--- a/cli/_local.py
+++ b/cli/_local.py
@@ -54,6 +54,7 @@ class LocalTransport(Transport):
         self._add("GET", "/api/scheduling", self._scheduling_get)
         self._add("GET", "/api/scheduling/status", self._scheduling_status)
         self._add("GET", "/api/scheduling/next", self._scheduling_next)
+        self._add("POST", "/api/app-auth/credentials", self._credentials_post)
         self._add("GET", "/api/app-auth/tokens", self._tokens_get)
         self._add("POST", "/api/app-auth/tokens", self._tokens_post)
         self._add("DELETE", "/api/app-auth/tokens/{token_id}", self._tokens_delete)
@@ -233,6 +234,43 @@ class LocalTransport(Transport):
         scfg = self._scheduling_get()
         return {"ok": True, "next_run_at": self._next_run_at(scfg), "config": scfg}
 
+    def _credentials_post(self, *, body: Any = None, **_: Any) -> dict[str, Any]:
+        try:
+            from api import appAuthAPI as auth
+        except Exception as exc:
+            raise CLIError(f"App authentication support unavailable: {exc}") from exc
+
+        payload = as_dict(body)
+        if not bool(payload.get("enabled", True)):
+            return {"ok": False, "error": "Local setup only enables authentication"}
+        username = str(payload.get("username") or "").strip()
+        password = str(payload.get("password") or "")
+        if not username:
+            return {"ok": False, "error": "Username is required"}
+        if len(password) < auth.MIN_PASSWORD_LENGTH:
+            return {"ok": False, "error": f"Password must be at least {auth.MIN_PASSWORD_LENGTH} characters"}
+
+        def _mutate(cfg: dict[str, Any]) -> dict[str, Any]:
+            was_configured = auth.auth_required(cfg)
+            was_reset = auth.reset_pending(cfg)
+            a = cfg.setdefault("app_auth", {})
+            if not isinstance(a, dict):
+                a = {}
+                cfg["app_auth"] = a
+            keep_tokens = auth._trusted_pre_auth_api_tokens(a) if ((not was_configured) or was_reset) else [t for t in a.get("api_tokens", []) if isinstance(t, dict)]
+            a["enabled"] = True
+            a["username"] = username
+            a["password"] = auth._password_hash(password)
+            a["reset_required"] = False
+            a["session"] = {"token_hash": "", "expires_at": 0}
+            a["sessions"] = []
+            a["api_tokens"] = keep_tokens
+            a["last_login_at"] = 0
+            return {"ok": True, "enabled": True}
+
+        _cfg, result = self._cfg_base.update_config(_mutate)
+        return result
+
     def _tokens_api(self) -> Any:
         try:
             from api import apiTokensAPI
@@ -257,6 +295,7 @@ class LocalTransport(Transport):
             name=str(payload.get("name") or ""),
             user_id=str(payload.get("user_id") or ""),
             expires_days=expires_days,
+            created_via="local_cli",
         )
         return {"ok": True, "token": raw, "entry": entry}
 

--- a/cli/_settings.py
+++ b/cli/_settings.py
@@ -32,6 +32,51 @@ def settings_path() -> Path:
     return cli_home() / "cli.json"
 
 
+def _ownership_reference(path: Path) -> os.stat_result | None:
+    path_stat: os.stat_result | None = None
+    parent_stat: os.stat_result | None = None
+    config_stat: os.stat_result | None = None
+    try:
+        if path.exists():
+            path_stat = path.stat()
+    except Exception:
+        path_stat = None
+    try:
+        if path.parent.exists():
+            parent_stat = path.parent.stat()
+    except Exception:
+        parent_stat = None
+    try:
+        cfg = config_dir()
+        if cfg.exists():
+            config_stat = cfg.stat()
+    except Exception:
+        config_stat = None
+    if os.name != "nt":
+        try:
+            if os.geteuid() == 0:
+                for candidate in (config_stat, parent_stat):
+                    if candidate is not None and candidate.st_uid != 0:
+                        return candidate
+        except Exception:
+            pass
+    return path_stat or parent_stat or config_stat
+
+
+def _apply_owner_mode(path: Path, ref: os.stat_result | None, *, mode: int) -> None:
+    if ref is None:
+        return
+    if os.name != "nt":
+        try:
+            os.chown(path, ref.st_uid, ref.st_gid)
+        except Exception:
+            pass
+    try:
+        path.chmod(mode)
+    except Exception:
+        pass
+
+
 def load_settings() -> dict[str, Any]:
     path = settings_path()
     try:
@@ -44,11 +89,10 @@ def load_settings() -> dict[str, Any]:
 def save_settings(data: dict[str, Any]) -> Path:
     path = settings_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+    ref = _ownership_reference(path)
+    _apply_owner_mode(path.parent, ref, mode=stat.S_IRWXU)
     path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    try:
-        path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-    except Exception:
-        pass
+    _apply_owner_mode(path, ref, mode=stat.S_IRUSR | stat.S_IWUSR)
     return path
 
 

--- a/cli/commands/auth.py
+++ b/cli/commands/auth.py
@@ -158,6 +158,54 @@ def _public(manifest: Manifest) -> dict[str, Any]:
     }
 
 
+@auth_app.command("setup")
+def app_setup(
+    ctx: typer.Context,
+    username: str = typer.Option("admin", "--username", "-u", help="CrossWatch admin username."),
+    password: str = typer.Option("", "--password", "-p", help="CrossWatch admin password. Prompts when omitted."),
+    create_token: bool = typer.Option(True, "--token/--no-token", help="Create and save a CLI API token after setup."),
+    token_name: str = typer.Option("CLI", "--token-name", help="Label for the generated CLI token."),
+    save: bool = typer.Option(True, "--save/--no-save", help="Store the generated token in the CLI settings file."),
+) -> None:
+    """Set up CrossWatch app authentication."""
+    state: Ctx = ctx.obj
+    pwd = password
+    if not pwd:
+        pwd = str(typer.prompt("Password", hide_input=True, confirmation_prompt=True) or "")
+    payload = as_dict(state.post("/api/app-auth/credentials", json_body={"enabled": True, "username": username, "password": pwd}))
+    if payload.get("ok") is False:
+        raise CLIError(error_text(payload, "Authentication setup failed"))
+
+    raw = ""
+    entry: dict[str, Any] = {}
+    stored = ""
+    if create_token:
+        token_payload = as_dict(state.post("/api/app-auth/tokens", json_body={"name": token_name, "expires_days": 0}))
+        if not token_payload.get("token"):
+            raise CLIError(error_text(token_payload, "Token creation failed"))
+        raw = str(token_payload.get("token") or "")
+        entry = as_dict(token_payload.get("entry"))
+        if save:
+            update_settings(token=raw, url=state.url)
+            stored = str(settings_path())
+
+    if state.out.json_mode:
+        state.out.data({"ok": True, "enabled": True, "token": raw, "entry": entry, "saved_to": stored})
+        return
+    rows: list[tuple[str, Any]] = [("Auth", "enabled"), ("Username", username)]
+    if create_token:
+        rows.extend(
+            [
+                ("Token", raw),
+                ("Token id", str(entry.get("id") or "-")),
+                ("Saved to", stored or "not saved"),
+            ]
+        )
+    state.out.kv(rows, title="CrossWatch auth setup")
+    if raw:
+        state.out.warn("This is the only time the token is shown. Store it somewhere safe.")
+
+
 def _nest(pairs: dict[str, Any], *, drop_prefix: bool) -> dict[str, Any]:
     body: dict[str, Any] = {}
     for key, value in pairs.items():
@@ -558,7 +606,7 @@ def token_create(
     expires_days: int = typer.Option(0, "--expires-days", help="Expire after N days. 0 means never."),
     save: bool = typer.Option(True, "--save/--no-save", help="Store the token in the CLI settings file."),
 ) -> None:
-    """Create an API token. Use --local to bootstrap when you have no token yet."""
+    """Create an API token. Use --local from the CrossWatch host or container for CLI-only setup."""
     state: Ctx = ctx.obj
     payload = as_dict(state.post("/api/app-auth/tokens", json_body={"name": name, "expires_days": int(expires_days)}))
     if not payload.get("token"):

--- a/cli/commands/status.py
+++ b/cli/commands/status.py
@@ -84,7 +84,7 @@ def register(app: typer.Typer) -> None:
         pairs: bool = typer.Option(True, "--pairs/--no-pairs", help="Include the sync pair table."),
         fresh: bool = typer.Option(False, "--fresh", "-f", help="Re-probe providers instead of using the cached status."),
     ) -> None:
-        """Show engine, provider, pair, scheduler and watcher state at a glance."""
+        """Show engine, provider, pair, scheduler and watcher state."""
         state: Ctx = ctx.obj
         data = _collect(state, fresh=fresh)
         out = state.out

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -246,6 +246,7 @@ def _apply_auth_reset_env_once() -> None:
         sess["token_hash"] = ""
         sess["expires_at"] = 0
         a["sessions"] = []
+        a["api_tokens"] = []
         a["last_login_at"] = 0
         save_config(cfg)
         print("[BOOT] CW_RESET_AUTH_ONCE detected: app authentication was reset. Remove the env var and set a new username/password in the UI.")
@@ -282,9 +283,12 @@ _APP_AUTH_SETUP_ALLOWED_PATHS = {
     "/login",
     "/logout",
     "/api/health",
+    "/api/status",
+    "/api/version",
     "/api/config/meta",
     "/api/app-auth/status",
     "/api/app-auth/credentials",
+    "/api/app-auth/tokens/whoami",
 }
 
 _PUBLIC_HEALTH_PATHS = {
@@ -312,7 +316,7 @@ def _redact_query_string(query: str) -> str:
         return ""
 
 _SECRET_KV_RE = re.compile(
-    r"(?i)(\b(?:api_key|apikey|access_token|refresh_token|client_secret|session_id|token|x-plex-token|password)\b\s*[=:]\s*)([^\s,;&]+)"
+    r"(?i)(\b(?:api_key|apikey|access_token|refresh_token|client_secret|session_id|token|token_digest|x-plex-token|password)\b\s*[=:]\s*)([^\s,;&]+)"
 )
 _URL_QS_RE = re.compile(
     r"(?i)([?&](?:api_key|apikey|access_token|refresh_token|client_secret|session_id|token|x-plex-token)=)([^&\s]+)"
@@ -320,10 +324,10 @@ _URL_QS_RE = re.compile(
 _AUTH_BEARER_RE = re.compile(r"(?i)(authorization\s*[:=]\s*bearer\s+)([^\s,;]+)")
 _BEARER_RE = re.compile(r"(?i)\bBearer\s+([^\s,;]+)")
 _JSON_DQ_RE = re.compile(
-    r'(?i)("(?:api_key|apikey|access_token|refresh_token|client_secret|session_id|token|x-plex-token|password|hash|salt)"\s*:\s*")([^"]*)(")'
+    r'(?i)("(?:api_key|apikey|access_token|refresh_token|client_secret|session_id|token|token_digest|x-plex-token|password|hash|salt)"\s*:\s*")([^"]*)(")'
 )
 _JSON_SQ_RE = re.compile(
-    r"(?i)('(?:api_key|apikey|access_token|refresh_token|client_secret|session_id|token|x-plex-token|password|hash|salt)'\s*:\s*')([^']*)(')"
+    r"(?i)('(?:api_key|apikey|access_token|refresh_token|client_secret|session_id|token|token_digest|x-plex-token|password|hash|salt)'\s*:\s*')([^']*)(')"
 )
 
 def _redact_secrets_in_text(s: str) -> str:

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -937,6 +937,8 @@ def redact_config(cfg: dict[str, Any]) -> dict[str, Any]:
                     t["token_hash"] = MASK
                 if isinstance(t, dict) and t.get("token_digest"):
                     t["token_digest"] = MASK
+                if isinstance(t, dict) and t.get("secret"):
+                    t["secret"] = MASK
 
         totp = a.get("totp")
         if isinstance(totp, dict):

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import secrets
+import stat
 import base64
 import hashlib
 import threading
@@ -86,7 +87,9 @@ def _load_config_key(*, create: bool) -> bytes | None:
 
     key_path = _config_key_file()
     if key_path.exists():
-        return _normalize_fernet_key(key_path.read_text(encoding="utf-8"))
+        raw = key_path.read_text(encoding="utf-8")
+        _apply_owner_mode(key_path, _ownership_reference(_cfg_file()), mode=0o600)
+        return _normalize_fernet_key(raw)
 
     if not create:
         return None
@@ -99,10 +102,7 @@ def _load_config_key(*, create: bool) -> bytes | None:
     key = Fernet.generate_key()
     key_path.parent.mkdir(parents=True, exist_ok=True)
     key_path.write_text(key.decode("ascii"), encoding="utf-8")
-    try:
-        os.chmod(key_path, 0o600)
-    except Exception:
-        pass
+    _apply_owner_mode(key_path, _ownership_reference(_cfg_file()), mode=0o600)
     return key
 
 
@@ -174,7 +174,7 @@ def _is_sensitive_path(path: tuple[str, ...]) -> bool:
         "client_secret",
         "account_token", "pms_token", "home_pin",
         "session_id",
-        "token_hash", "salt", "hash",
+        "token_hash", "token_digest", "salt", "hash",
         "device_code",
         "pending_secret",
         "_pending_request_token",
@@ -935,6 +935,8 @@ def redact_config(cfg: dict[str, Any]) -> dict[str, Any]:
             for t in api_tokens:
                 if isinstance(t, dict) and t.get("token_hash"):
                     t["token_hash"] = MASK
+                if isinstance(t, dict) and t.get("token_digest"):
+                    t["token_digest"] = MASK
 
         totp = a.get("totp")
         if isinstance(totp, dict):
@@ -1035,6 +1037,42 @@ def _cfg_file() -> Path:
     return CONFIG / "config.json"
 
 
+def _ownership_reference(path: Path) -> os.stat_result | None:
+    path_stat: os.stat_result | None = None
+    parent_stat: os.stat_result | None = None
+    try:
+        if path.exists():
+            path_stat = path.stat()
+    except Exception:
+        path_stat = None
+    try:
+        if path.parent.exists():
+            parent_stat = path.parent.stat()
+    except Exception:
+        parent_stat = None
+    if os.name != "nt" and path_stat is not None and parent_stat is not None:
+        try:
+            if os.geteuid() == 0 and path_stat.st_uid == 0 and parent_stat.st_uid != 0:
+                return parent_stat
+        except Exception:
+            pass
+    return path_stat or parent_stat
+
+
+def _apply_owner_mode(path: Path, ref: os.stat_result | None, *, mode: int | None = None) -> None:
+    if ref is None:
+        return
+    if os.name != "nt":
+        try:
+            os.chown(path, ref.st_uid, ref.st_gid)
+        except Exception:
+            pass
+    try:
+        os.chmod(path, mode if mode is not None else stat.S_IMODE(ref.st_mode))
+    except Exception:
+        pass
+
+
 @contextmanager
 def _config_file_lock() -> Iterator[None]:
     depth = int(getattr(_CONFIG_FILE_LOCK_STATE, "depth", 0) or 0)
@@ -1046,8 +1084,18 @@ def _config_file_lock() -> Iterator[None]:
             _CONFIG_FILE_LOCK_STATE.depth = depth
         return
     lock_path = CONFIG / "config.json.lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("a+b") as f:
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        f = lock_path.open("a+b")
+    except PermissionError:
+        _CONFIG_FILE_LOCK_STATE.depth = 1
+        try:
+            yield
+        finally:
+            _CONFIG_FILE_LOCK_STATE.depth = 0
+        return
+    _apply_owner_mode(lock_path, _ownership_reference(_cfg_file()), mode=0o660)
+    with f:
         _CONFIG_FILE_LOCK_STATE.depth = 1
         try:
             try:
@@ -1121,11 +1169,15 @@ def _write_json_atomic(p: Path, data: dict[str, Any]) -> None:
 
         suffix = f".{_time.time_ns()}.{_os.getpid()}.{threading.get_ident()}.{secrets.token_hex(4)}.tmp"
         tmp = p.with_suffix(suffix)
+        ref = _ownership_reference(p)
+        mode = stat.S_IMODE(ref.st_mode) if ref is not None and p.exists() else 0o600
 
         with tmp.open("w", encoding="utf-8", newline="\n") as f:
             json.dump(data, f, indent=2, ensure_ascii=False)
             f.write("\n")
+        _apply_owner_mode(tmp, ref, mode=mode)
         tmp.replace(p)
+        _apply_owner_mode(p, ref, mode=mode)
 
 
 def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_api_tokens.py
+++ b/tests/test_api_tokens.py
@@ -65,7 +65,7 @@ def tokens_env(config_base: Path, monkeypatch: pytest.MonkeyPatch):
 
 def test_issue_and_resolve_round_trip(tokens_env) -> None:
     mod = tokens_env
-    from cw_platform.config_base import load_config
+    from cw_platform.config_base import config_path, load_config
 
     raw, entry = mod.issue_api_token(load_config(), name="cli", expires_days=0)
 
@@ -77,10 +77,11 @@ def test_issue_and_resolve_round_trip(tokens_env) -> None:
     assert raw not in json.dumps(load_config())
     stored = load_config()["app_auth"]["api_tokens"][0]
     assert stored["version"] == 2
-    assert stored["digest_scheme"] == "hmac_sha256"
-    assert isinstance(stored["token_digest"], str)
-    assert len(stored["token_digest"]) == 64
+    assert isinstance(stored["secret"], str)
+    assert stored["secret"] in raw
+    assert stored["secret"] not in config_path().read_text(encoding="utf-8")
     assert "token_hash" not in stored
+    assert "token_digest" not in stored
 
     identity = mod.resolve_api_token(load_config(), raw)
     assert identity is not None
@@ -234,6 +235,7 @@ def test_listing_never_exposes_the_secret(tokens_env) -> None:
     assert raw not in blob
     assert "token_hash" not in blob
     assert "token_digest" not in blob
+    assert "secret" not in blob
 
 
 def test_extract_reads_header_and_bearer() -> None:
@@ -244,7 +246,7 @@ def test_extract_reads_header_and_bearer() -> None:
     assert mod.extract_api_token(_request("/api/status")) == ""
 
 
-def test_redaction_masks_token_digests(tokens_env) -> None:
+def test_redaction_masks_token_secrets(tokens_env) -> None:
     mod = tokens_env
     from cw_platform.config_base import load_config, redact_config
 
@@ -252,4 +254,4 @@ def test_redaction_masks_token_digests(tokens_env) -> None:
     redacted = redact_config(load_config())
 
     for entry in redacted["app_auth"]["api_tokens"]:
-        assert entry["token_digest"] == "•" * 8
+        assert entry["secret"] == "•" * 8

--- a/tests/test_api_tokens.py
+++ b/tests/test_api_tokens.py
@@ -70,18 +70,53 @@ def test_issue_and_resolve_round_trip(tokens_env) -> None:
     raw, entry = mod.issue_api_token(load_config(), name="cli", expires_days=0)
 
     assert raw.startswith(mod.TOKEN_PREFIX)
+    assert "." in raw
     assert entry["name"] == "cli"
+    assert entry["version"] == 2
     assert entry["expires_at"] == 0
     assert raw not in json.dumps(load_config())
-    stored = load_config()["app_auth"]["api_tokens"][0]["token_hash"]
-    assert isinstance(stored, dict)
-    assert stored["scheme"] == "pbkdf2_sha256"
+    stored = load_config()["app_auth"]["api_tokens"][0]
+    assert stored["version"] == 2
+    assert stored["digest_scheme"] == "sha256"
+    assert isinstance(stored["token_digest"], str)
+    assert len(stored["token_digest"]) == 64
+    assert "token_hash" not in stored
 
     identity = mod.resolve_api_token(load_config(), raw)
     assert identity is not None
     assert identity["is_admin"] is True
     assert identity["auth_kind"] == "api_token"
     assert identity["api_token_id"] == entry["id"]
+
+
+def test_legacy_v1_tokens_still_resolve(tokens_env) -> None:
+    mod = tokens_env
+    from api import appAuthAPI as auth
+    from cw_platform.config_base import load_config, update_config
+
+    raw = mod.TOKEN_PREFIX + "legacysecret"
+
+    def _add_legacy(cfg: dict) -> None:
+        cfg["app_auth"]["api_tokens"].append(
+            {
+                "id": "legacy1",
+                "name": "old cli",
+                "token_hash": auth._password_hash(raw),
+                "prefix": raw[: len(mod.TOKEN_PREFIX) + 6],
+                "user_id": auth.ADMIN_USER_ID,
+                "username": "admin",
+                "created_at": auth._now(),
+                "expires_at": 0,
+                "last_used_at": 0,
+            }
+        )
+
+    update_config(_add_legacy)
+
+    identity = mod.resolve_api_token(load_config(), raw)
+    assert identity is not None
+    assert identity["is_admin"] is True
+    assert identity["api_token_id"] == "legacy1"
 
 
 def test_unknown_and_malformed_tokens_are_rejected(tokens_env) -> None:
@@ -94,6 +129,55 @@ def test_unknown_and_malformed_tokens_are_rejected(tokens_env) -> None:
     assert mod.resolve_api_token(cfg, "") is None
     assert mod.resolve_api_token(cfg, "not-a-token") is None
     assert mod.resolve_api_token(cfg, mod.TOKEN_PREFIX + "wrongwrongwrong") is None
+
+
+def test_malformed_v2_tokens_do_not_trigger_legacy_hash_scan(tokens_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = tokens_env
+    from api import appAuthAPI as auth
+    from cw_platform.config_base import load_config, update_config
+
+    def _add_legacy(cfg: dict) -> None:
+        cfg["app_auth"]["api_tokens"].append(
+            {
+                "id": "legacy1",
+                "name": "old cli",
+                "token_hash": auth._password_hash(mod.TOKEN_PREFIX + "legacysecret"),
+                "prefix": mod.TOKEN_PREFIX + "legacy",
+                "user_id": auth.ADMIN_USER_ID,
+                "username": "admin",
+                "created_at": auth._now(),
+                "expires_at": 0,
+                "last_used_at": 0,
+            }
+        )
+
+    update_config(_add_legacy)
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("legacy PBKDF2 scan should not run for malformed v2 tokens")
+
+    monkeypatch.setattr(mod, "_password_matches", _boom)
+
+    assert mod.resolve_api_token(load_config(), mod.TOKEN_PREFIX + "abcdefabcdefabcd.bad") is None
+
+
+def test_remote_token_management_requires_configured_auth(tokens_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = tokens_env
+
+    cfg = {
+        "app_auth": {
+            "enabled": False,
+            "username": "",
+            "password": {"scheme": "pbkdf2_sha256", "iterations": 260_000, "salt": "", "hash": ""},
+            "sessions": [],
+            "api_tokens": [],
+        }
+    }
+    monkeypatch.setattr(mod, "load_config", lambda: cfg)
+
+    resp = mod.api_tokens_create(_request("/api/app-auth/tokens", method="POST"), {"name": "remote"})
+    assert resp.status_code == 403
+    assert json.loads(resp.body.decode("utf-8"))["error"] == "Authentication is not configured"
 
 
 def test_expired_token_is_rejected(tokens_env) -> None:
@@ -149,6 +233,7 @@ def test_listing_never_exposes_the_secret(tokens_env) -> None:
     blob = json.dumps(listed)
     assert raw not in blob
     assert "token_hash" not in blob
+    assert "token_digest" not in blob
 
 
 def test_extract_reads_header_and_bearer() -> None:
@@ -159,7 +244,7 @@ def test_extract_reads_header_and_bearer() -> None:
     assert mod.extract_api_token(_request("/api/status")) == ""
 
 
-def test_redaction_masks_token_hashes(tokens_env) -> None:
+def test_redaction_masks_token_digests(tokens_env) -> None:
     mod = tokens_env
     from cw_platform.config_base import load_config, redact_config
 
@@ -167,4 +252,4 @@ def test_redaction_masks_token_hashes(tokens_env) -> None:
     redacted = redact_config(load_config())
 
     for entry in redacted["app_auth"]["api_tokens"]:
-        assert entry["token_hash"] == "•" * 8
+        assert entry["token_digest"] == "•" * 8

--- a/tests/test_api_tokens.py
+++ b/tests/test_api_tokens.py
@@ -77,7 +77,7 @@ def test_issue_and_resolve_round_trip(tokens_env) -> None:
     assert raw not in json.dumps(load_config())
     stored = load_config()["app_auth"]["api_tokens"][0]
     assert stored["version"] == 2
-    assert stored["digest_scheme"] == "sha256"
+    assert stored["digest_scheme"] == "hmac_sha256"
     assert isinstance(stored["token_digest"], str)
     assert len(stored["token_digest"]) == 64
     assert "token_hash" not in stored

--- a/tests/test_app_auth_api.py
+++ b/tests/test_app_auth_api.py
@@ -285,6 +285,89 @@ def test_bootstrap_credentials_still_work_without_origin(monkeypatch) -> None:
     assert cfg["app_auth"]["sessions"]
 
 
+def test_bootstrap_credentials_clear_untrusted_pre_auth_tokens(monkeypatch) -> None:
+    from api import appAuthAPI as auth
+
+    cfg = _auth_cfg(enabled=False)
+    cfg["app_auth"]["username"] = ""
+    cfg["app_auth"]["password"] = {"scheme": "pbkdf2_sha256", "iterations": 260_000, "salt": "", "hash": ""}
+    cfg["app_auth"]["api_tokens"] = [
+        {"id": "legacy1", "token_hash": {"scheme": "pbkdf2_sha256", "iterations": 1, "salt": "a", "hash": "b"}},
+        {"id": "abcdefabcdefabcd", "version": 2, "token_digest": "a" * 64, "digest_scheme": "sha256"},
+    ]
+    monkeypatch.setattr(auth, "load_config", lambda: cfg)
+    monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
+
+    req = _request("/api/app-auth/credentials")
+    resp = auth.api_set_credentials(req, {"enabled": True, "username": "admin", "password": "secrett1"})
+
+    assert resp.status_code == 200
+    assert cfg["app_auth"]["api_tokens"] == []
+
+
+def test_bootstrap_credentials_preserve_local_cli_pre_auth_tokens(monkeypatch) -> None:
+    from api import appAuthAPI as auth
+
+    local_token = {
+        "id": "abcdefabcdefabcd",
+        "version": 2,
+        "token_digest": "a" * 64,
+        "digest_scheme": "sha256",
+        "created_via": "local_cli",
+    }
+    cfg = _auth_cfg(enabled=False)
+    cfg["app_auth"]["username"] = ""
+    cfg["app_auth"]["password"] = {"scheme": "pbkdf2_sha256", "iterations": 260_000, "salt": "", "hash": ""}
+    cfg["app_auth"]["api_tokens"] = [local_token]
+    monkeypatch.setattr(auth, "load_config", lambda: cfg)
+    monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
+
+    req = _request("/api/app-auth/credentials")
+    resp = auth.api_set_credentials(req, {"enabled": True, "username": "admin", "password": "secrett1"})
+
+    assert resp.status_code == 200
+    assert cfg["app_auth"]["api_tokens"] == [local_token]
+
+
+def test_credentials_update_preserves_existing_tokens(monkeypatch) -> None:
+    from api import appAuthAPI as auth
+
+    existing_token = {
+        "id": "abcdefabcdefabcd",
+        "version": 2,
+        "token_digest": "a" * 64,
+        "digest_scheme": "sha256",
+        "created_via": "api",
+    }
+    cfg = _auth_cfg()
+    cfg["app_auth"]["api_tokens"] = [existing_token]
+    monkeypatch.setattr(auth, "load_config", lambda: cfg)
+    monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
+
+    session, _exp = auth._issue_session(cfg, _request("/api/app-auth/login"))
+    req = _request("/api/app-auth/credentials", headers={"cookie": f"{auth.COOKIE_NAME}={session}"})
+    resp = auth.api_set_credentials(req, {"enabled": True, "username": "admin", "password": "newpass1"})
+
+    assert resp.status_code == 200
+    assert cfg["app_auth"]["api_tokens"] == [existing_token]
+
+
+def test_disabling_credentials_clears_tokens(monkeypatch) -> None:
+    from api import appAuthAPI as auth
+
+    cfg = _auth_cfg()
+    cfg["app_auth"]["api_tokens"] = [{"id": "abcdefabcdefabcd", "version": 2, "token_digest": "a" * 64}]
+    monkeypatch.setattr(auth, "load_config", lambda: cfg)
+    monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
+
+    session, _exp = auth._issue_session(cfg, _request("/api/app-auth/login"))
+    req = _request("/api/app-auth/credentials", headers={"cookie": f"{auth.COOKIE_NAME}={session}"})
+    resp = auth.api_set_credentials(req, {"enabled": False, "username": "admin"})
+
+    assert resp.status_code == 200
+    assert cfg["app_auth"]["api_tokens"] == []
+
+
 def test_login_sets_session_cookie_when_remember_disabled(monkeypatch) -> None:
     from api import appAuthAPI as auth
 
@@ -412,14 +495,34 @@ def test_setup_lock_required_for_upgrade_without_auth(monkeypatch) -> None:
     assert auth.setup_lock_required(cfg) is True
 
 
-def test_setup_lock_not_required_when_up_to_date_without_auth(monkeypatch) -> None:
+def test_setup_lock_required_when_up_to_date_without_auth(monkeypatch) -> None:
     from api import appAuthAPI as auth
 
     cfg = _auth_cfg(enabled=False)
     cfg["version"] = "0.9.14"
     monkeypatch.setattr(auth, "_current_version_text", lambda: "0.9.14")
 
-    assert auth.setup_lock_required(cfg) is False
+    assert auth.setup_lock_required(cfg) is True
+
+
+def test_setup_lock_blocks_regular_api_until_credentials_exist(monkeypatch) -> None:
+    from fastapi.testclient import TestClient
+
+    import crosswatch
+
+    cfg = _auth_cfg(enabled=False)
+    cfg["app_auth"]["username"] = ""
+    cfg["app_auth"]["password"] = {"scheme": "pbkdf2_sha256", "iterations": 260_000, "salt": "", "hash": ""}
+    monkeypatch.setattr(crosswatch, "load_config", lambda: cfg)
+
+    client = TestClient(crosswatch.app)
+
+    blocked = client.get("/api/editor")
+    assert blocked.status_code == 403
+    assert blocked.json()["error"] == "Authentication setup required"
+
+    assert client.get("/api/app-auth/status").status_code == 200
+    assert client.get("/api/version").status_code == 200
 
 
 def test_credentials_reject_too_short_password(monkeypatch) -> None:

--- a/tests/test_app_auth_api.py
+++ b/tests/test_app_auth_api.py
@@ -293,7 +293,7 @@ def test_bootstrap_credentials_clear_untrusted_pre_auth_tokens(monkeypatch) -> N
     cfg["app_auth"]["password"] = {"scheme": "pbkdf2_sha256", "iterations": 260_000, "salt": "", "hash": ""}
     cfg["app_auth"]["api_tokens"] = [
         {"id": "legacy1", "token_hash": {"scheme": "pbkdf2_sha256", "iterations": 1, "salt": "a", "hash": "b"}},
-        {"id": "abcdefabcdefabcd", "version": 2, "token_digest": "a" * 64, "digest_scheme": "sha256"},
+        {"id": "abcdefabcdefabcd", "version": 2, "token_digest": "a" * 64, "digest_scheme": "hmac_sha256"},
     ]
     monkeypatch.setattr(auth, "load_config", lambda: cfg)
     monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
@@ -312,7 +312,7 @@ def test_bootstrap_credentials_preserve_local_cli_pre_auth_tokens(monkeypatch) -
         "id": "abcdefabcdefabcd",
         "version": 2,
         "token_digest": "a" * 64,
-        "digest_scheme": "sha256",
+        "digest_scheme": "hmac_sha256",
         "created_via": "local_cli",
     }
     cfg = _auth_cfg(enabled=False)
@@ -336,7 +336,7 @@ def test_credentials_update_preserves_existing_tokens(monkeypatch) -> None:
         "id": "abcdefabcdefabcd",
         "version": 2,
         "token_digest": "a" * 64,
-        "digest_scheme": "sha256",
+        "digest_scheme": "hmac_sha256",
         "created_via": "api",
     }
     cfg = _auth_cfg()

--- a/tests/test_app_auth_api.py
+++ b/tests/test_app_auth_api.py
@@ -293,7 +293,7 @@ def test_bootstrap_credentials_clear_untrusted_pre_auth_tokens(monkeypatch) -> N
     cfg["app_auth"]["password"] = {"scheme": "pbkdf2_sha256", "iterations": 260_000, "salt": "", "hash": ""}
     cfg["app_auth"]["api_tokens"] = [
         {"id": "legacy1", "token_hash": {"scheme": "pbkdf2_sha256", "iterations": 1, "salt": "a", "hash": "b"}},
-        {"id": "abcdefabcdefabcd", "version": 2, "token_digest": "a" * 64, "digest_scheme": "hmac_sha256"},
+        {"id": "abcdefabcdefabcd", "version": 2, "secret": "secret"},
     ]
     monkeypatch.setattr(auth, "load_config", lambda: cfg)
     monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
@@ -311,8 +311,7 @@ def test_bootstrap_credentials_preserve_local_cli_pre_auth_tokens(monkeypatch) -
     local_token = {
         "id": "abcdefabcdefabcd",
         "version": 2,
-        "token_digest": "a" * 64,
-        "digest_scheme": "hmac_sha256",
+        "secret": "secret",
         "created_via": "local_cli",
     }
     cfg = _auth_cfg(enabled=False)
@@ -335,8 +334,7 @@ def test_credentials_update_preserves_existing_tokens(monkeypatch) -> None:
     existing_token = {
         "id": "abcdefabcdefabcd",
         "version": 2,
-        "token_digest": "a" * 64,
-        "digest_scheme": "hmac_sha256",
+        "secret": "secret",
         "created_via": "api",
     }
     cfg = _auth_cfg()
@@ -356,7 +354,7 @@ def test_disabling_credentials_clears_tokens(monkeypatch) -> None:
     from api import appAuthAPI as auth
 
     cfg = _auth_cfg()
-    cfg["app_auth"]["api_tokens"] = [{"id": "abcdefabcdefabcd", "version": 2, "token_digest": "a" * 64}]
+    cfg["app_auth"]["api_tokens"] = [{"id": "abcdefabcdefabcd", "version": 2, "secret": "secret"}]
     monkeypatch.setattr(auth, "load_config", lambda: cfg)
     monkeypatch.setattr(auth, "save_config", lambda *_args, **_kwargs: None)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,21 @@ def test_split_path_handles_dots_slashes_and_indexes() -> None:
         split_path("   ")
 
 
+def test_setup_required_error_points_to_local_auth_setup() -> None:
+    err = ApiError(403, {"error": "Authentication setup required"}, method="GET", path="/api/editor")
+
+    assert "Authentication setup required" in err.message
+    assert "cw --local auth setup --username admin" in err.hint
+
+
+def test_unauthorized_error_explains_local_token_create_saves_by_default() -> None:
+    err = ApiError(401, {"error": "Unauthorized"}, method="GET", path="/api/editor")
+
+    assert "cw --local auth token create" in err.hint
+    assert "saves the token by default" in err.hint
+    assert "CW_TOKEN" in err.hint
+
+
 def test_dotted_get_walks_dicts_and_lists() -> None:
     data = {"a": {"b": [{"c": 1}]}}
     assert dotted_get(data, "a.b[0].c") == 1
@@ -319,6 +334,45 @@ def test_local_transport_config_unset_removes_keys(config_base: Path) -> None:
     protected = transport.request("POST", "/api/config/unset", json_body={"paths": ["app_auth.enabled"]})
     assert protected["ok"] is False
     assert protected["error"] == "protected_path"
+
+
+def test_local_transport_can_setup_app_auth(config_base: Path) -> None:
+    import importlib
+
+    from cw_platform import config_base as cfg_base
+
+    importlib.reload(cfg_base)
+    (config_base / "config.json").write_text(
+        json.dumps(
+            {
+                "app_auth": {
+                    "enabled": False,
+                    "username": "",
+                    "password": {"scheme": "pbkdf2_sha256", "iterations": 260_000, "salt": "", "hash": ""},
+                    "api_tokens": [{"id": "legacy1", "token_hash": {"scheme": "pbkdf2_sha256", "iterations": 1, "salt": "a", "hash": "b"}}],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    from cli import _local
+
+    importlib.reload(_local)
+    transport = _local.LocalTransport()
+
+    result = transport.request(
+        "POST",
+        "/api/app-auth/credentials",
+        json_body={"enabled": True, "username": "admin", "password": "secrett1"},
+    )
+    cfg = cfg_base.load_config()
+
+    assert result["ok"] is True
+    assert cfg["app_auth"]["enabled"] is True
+    assert cfg["app_auth"]["username"] == "admin"
+    assert cfg["app_auth"]["password"]["hash"]
+    assert cfg["app_auth"]["api_tokens"] == []
 
 
 def test_config_path_helpers_match_the_cli_parser() -> None:


### PR DESCRIPTION
# Pull request

## Change

- Lock regular API routes until app auth is set up
- Add v2 API tokens and keep v1 tokens working
- Add `cw --local auth setup` for CLI-only setup
- Keep config/key file ownership sane when local CLI runs as root
- Improve CLI auth/setup hints

## Why

Fresh installs should not behave like an open API, and CLI-only users need a clear first setup path.

## Testing

- tests/test_cli.py 
- tests/test_api_tokens.py 
- tests/test_app_auth_api.py

## Issue

NA (internal security scan)