### PR TITLE
Add: targeted Jellyfin lookup

### DIFF
--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -211,6 +211,8 @@ def _normalize_pair_providers(p: Any) -> dict[str, Any]:
         blk: dict[str, Any] = {}
         if "strict_id_matching" in v:
             blk["strict_id_matching"] = coerce_bool(v.get("strict_id_matching"))
+        if key == "jellyfin" and "targeted_lookup" in v:
+            blk["targeted_lookup"] = coerce_bool(v.get("targeted_lookup"), True)
         if key == "trakt":
             if "history_ignore_dropped_shows" in v:
                 blk["history_ignore_dropped_shows"] = coerce_bool(v.get("history_ignore_dropped_shows"))
@@ -222,6 +224,8 @@ def _normalize_pair_providers(p: Any) -> dict[str, Any]:
                 blk["history_ignore_dropped_shows"] = coerce_bool(v.get("history_ignore_dropped_shows"))
         for kk, vv in v.items():
             if kk in {"strict_id_matching", "history_ignore_dropped_shows"}:
+                continue
+            if key == "jellyfin" and kk == "targeted_lookup":
                 continue
             blk[str(kk)] = vv
         if blk:

--- a/assets/js/modals/pair-config/help.js
+++ b/assets/js/modals/pair-config/help.js
@@ -53,6 +53,7 @@ export const HELP_TEXT = {
   "plx-marked-watched": "Plex: Marked watched\nInclude items you manually marked as watched in Plex when syncing history.\nDisable if you only want actual play history.",
   "plx-strict-ids": "Plex: Strict ID matching\nWhen enabled, CrossWatch only matches by IDs (Plex IDs + external IDs). Title/year searches are disabled.",
   "jf-strict-ids": "Jellyfin: Strict ID matching\nWhen enabled, CrossWatch only matches by IDs (Jellyfin IDs + external IDs). Title/year searches are disabled.",
+  "jf-targeted-lookup": "Jellyfin: Targeted library lookup\nWhen writing to Jellyfin, search Jellyfin by title first and verify the result before falling back to the full library scan. Disable to use the slower all-items scan behavior.",
   "em-strict-ids": "Emby: Strict ID matching\nWhen enabled, CrossWatch only matches by IDs (Emby IDs + external IDs). Title/year searches are disabled.",
 };
 

--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -266,6 +266,7 @@ function normalizePairProviders(p){
     if(v&&typeof v==="object"){
       const blk=Object.assign({},v);
       if("strict_id_matching" in blk) blk.strict_id_matching=!!blk.strict_id_matching;
+      if(key==="jellyfin" && "targeted_lookup" in blk) blk.targeted_lookup=!!blk.targeted_lookup;
       if(key==="trakt"){
         if("history_collection" in blk) blk.history_collection=!!blk.history_collection;
         if("history_ignore_dropped_shows" in blk) blk.history_ignore_dropped_shows=!!blk.history_ignore_dropped_shows;
@@ -300,6 +301,14 @@ function getPairProviderStrictValue(state, providerKey){
   const blk=state?.pairProviders?.[key];
   if(blk && typeof blk==="object" && "strict_id_matching" in blk) return !!blk.strict_id_matching;
   return defaultStrictIdForProvider(key);
+}
+
+function getPairProviderTargetedLookupValue(state){
+  const blk=state?.pairProviders?.jellyfin;
+  if(blk && typeof blk==="object" && "targeted_lookup" in blk) return !!blk.targeted_lookup;
+  const jf=state?.cfgRaw?.jellyfin;
+  if(jf && typeof jf==="object" && "targeted_lookup" in jf) return jf.targeted_lookup !== false;
+  return true;
 }
 
 // Data
@@ -907,6 +916,7 @@ function getProviderOverrideCount(state, providerKey){
     if (num("jf-timeout", Number.isFinite(jf.timeout) ? jf.timeout : 15, 1) !== 15) count++;
     if (num("jf-retries", Number.isFinite(jf.max_retries) ? jf.max_retries : 3, 0) !== 3) count++;
     if (checked("jf-strict-ids", getPairProviderStrictValue(state, "jellyfin")) !== strictDefault) count++;
+    if (checked("jf-targeted-lookup", getPairProviderTargetedLookupValue(state)) !== true) count++;
     return count + countProviderLibraries(state, "JELLYFIN");
   }
   if (providerKey === "emby") {
@@ -1027,6 +1037,7 @@ function renderFeaturePanel(state){
             <div class="opt-row"><label for="jf-timeout">Timeout (s)</label><input id="jf-timeout" class="input small" type="number" min="1" max="120" step="1" value="${Number.isFinite(jf.timeout)?jf.timeout:15}"></div>
             <div class="opt-row"><label for="jf-retries">Max retries</label><input id="jf-retries" class="input small" type="number" min="0" max="10" step="1" value="${Number.isFinite(jf.max_retries)?jf.max_retries:3}"></div>
             <div class="opt-row"><label for="jf-strict-ids">Strict ID matching</label><label class="switch"><input id="jf-strict-ids" type="checkbox" ${getPairProviderStrictValue(state, "jellyfin")?"checked":""}><span class="slider"></span></label></div>
+            <div class="opt-row"><label for="jf-targeted-lookup">Targeted library lookup</label><label class="switch"><input id="jf-targeted-lookup" type="checkbox" ${getPairProviderTargetedLookupValue(state)?"checked":""}><span class="slider"></span></label></div>
           </div>
           <div class="prov-box" id="jf-pair-libs">
             <div class="panel-title small">Pair library whitelist</div>
@@ -1962,10 +1973,11 @@ function bindChangeHandlers(state,root){
   root.addEventListener("change",(e)=>{
     const id=e.target.id, el=e.target;
 
-    if(id==="plx-strict-ids"||id==="jf-strict-ids"||id==="em-strict-ids"){
+    if(id==="plx-strict-ids"||id==="jf-strict-ids"||id==="em-strict-ids"||id==="jf-targeted-lookup"){
       state.pairProviders=state.pairProviders||{};
       if(id==="plx-strict-ids") state.pairProviders.plex=Object.assign({},state.pairProviders.plex||{}, {strict_id_matching:!!el.checked});
       if(id==="jf-strict-ids") state.pairProviders.jellyfin=Object.assign({},state.pairProviders.jellyfin||{}, {strict_id_matching:!!el.checked});
+      if(id==="jf-targeted-lookup") state.pairProviders.jellyfin=Object.assign({},state.pairProviders.jellyfin||{}, {targeted_lookup:!!el.checked});
       if(id==="em-strict-ids") state.pairProviders.emby=Object.assign({},state.pairProviders.emby||{}, {strict_id_matching:!!el.checked});
       return;
     }
@@ -2611,7 +2623,7 @@ function buildPayload(state,wrap){
   const useFloppy=(String(src).toUpperCase()==="FLOPPY"||String(dst).toUpperCase()==="FLOPPY");
   const useScrob=(String(src).toUpperCase()==="SCROB"||String(dst).toUpperCase()==="SCROB");
   if(usePlex) prov.plex={strict_id_matching:getPairProviderStrictValue(state, "plex")};
-  if(useJf) prov.jellyfin={strict_id_matching:getPairProviderStrictValue(state, "jellyfin")};
+  if(useJf) prov.jellyfin={strict_id_matching:getPairProviderStrictValue(state, "jellyfin"),targeted_lookup:getPairProviderTargetedLookupValue(state)};
   if(useEm) prov.emby={strict_id_matching:getPairProviderStrictValue(state, "emby")};
   if(usePmdb){
     const pmSrc=pp.publicmetadb||{};

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -542,6 +542,7 @@ DEFAULT_CFG: dict[str, Any] = {
         "verify_ssl": False,                            # Verify TLS certificates
         "timeout": 15.0,                                # HTTP timeout (seconds)
         "max_retries": 3,                               # Retry budget for API calls
+        "targeted_lookup": True,                        # Use targeted title search before full library scans when resolving writes
 
         "scrobble": {
             "libraries": []                             # whitelist of library GUIDs; empty = all

--- a/cw_platform/orchestrator/_pairs.py
+++ b/cw_platform/orchestrator/_pairs.py
@@ -28,6 +28,9 @@ def _deep_merge_provider_overrides(dst: dict[str, Any], src: Mapping[str, Any]) 
         if kk == "strict_id_matching":
             dst["strict_id_matching"] = coerce_bool(v)
             continue
+        if kk == "targeted_lookup":
+            dst["targeted_lookup"] = coerce_bool(v, True)
+            continue
         cur = dst.get(kk)
         if isinstance(cur, dict) and isinstance(v, Mapping):
             _deep_merge_provider_overrides(cur, v)

--- a/providers/sync/_mod_JELLYFIN.py
+++ b/providers/sync/_mod_JELLYFIN.py
@@ -107,7 +107,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "2.2"
+__VERSION__ = "2.3"
 _MIN_PROGRESS_WRITE_VERSION = (10, 9)
 _JF_VERSION_CACHE: dict[str, tuple[float, str | None]] = {}
 
@@ -279,6 +279,7 @@ class JFConfig:
     timeout: float = 15.0
     max_retries: int = 3
     strict_id_matching: bool = False
+    targeted_lookup: bool = True
     watchlist_mode: str = "favorites"
     watchlist_playlist_name: str = "Watchlist"
     watchlist_query_limit: int = 25
@@ -440,6 +441,7 @@ class JELLYFINModule:
             timeout=float((cfg or {}).get("timeout", jf.get("timeout", 15.0))),
             max_retries=int((cfg or {}).get("max_retries", jf.get("max_retries", 3))),
             strict_id_matching=coerce_bool(jf.get("strict_id_matching", False)),
+            targeted_lookup=coerce_bool(jf.get("targeted_lookup", True), True),
             watchlist_mode=wl_mode,
             watchlist_playlist_name=wl_pname,
             watchlist_query_limit=wl_qlim,

--- a/providers/sync/jellyfin/_common.py
+++ b/providers/sync/jellyfin/_common.py
@@ -1180,6 +1180,174 @@ def _episode_number_matches(row: Mapping[str, Any], season: Any, episode: Any) -
         return False
 
 
+def _valid_item_id(value: Any) -> str | None:
+    s = str(value or "").strip()
+    return s if s and not looks_like_bad_id(s) else None
+
+
+def _targeted_search(
+    adapter: Any,
+    feature: str,
+    selected_libs: set[str],
+    include_types: str,
+    term: str,
+) -> list[Mapping[str, Any]]:
+    if not str(term or "").strip():
+        return []
+    try:
+        rows = jf_get_scoped_items(
+            adapter.client,
+            adapter.cfg.user_id,
+            {
+                "recursive": True,
+                "includeItemTypes": include_types,
+                "SearchTerm": term,
+                "Fields": (
+                    "ProviderIds,ProductionYear,Type,IndexNumber,ParentIndexNumber,"
+                    "SeriesId,ParentId,CollectionFolderId,AncestorIds,LibraryId,Name"
+                ),
+                "Limit": 50,
+                "EnableUserData": False,
+            },
+            adapter.cfg,
+            feature,
+        )
+        return jf_filter_library_candidates(rows, selected_libs, trust_query_scope=True)
+    except Exception:
+        return []
+
+
+def _row_matches_pair(row: Mapping[str, Any], pairs: Iterable[str]) -> bool:
+    row_ids = _ids_from_provider_ids(row.get("ProviderIds"))
+    if not row_ids:
+        return False
+    for pair in pairs or []:
+        namespace, _, value = str(pair or "").partition(".")
+        namespace = namespace.strip().lower()
+        value = value.strip().lower()
+        have = str(row_ids.get(namespace) or "").strip().lower()
+        if not namespace or not value or not have:
+            continue
+        if have == value:
+            return True
+        if have.isdigit() and value.isdigit() and int(have) == int(value):
+            return True
+    return False
+
+
+def _targeted_year_ok(row: Mapping[str, Any], year: Any, *, missing_ok: bool) -> bool:
+    if year is None:
+        return True
+    row_year = row.get("ProductionYear")
+    if row_year is None:
+        return missing_ok
+    try:
+        return abs(int(row_year) - int(year)) <= 1
+    except (TypeError, ValueError):
+        return False
+
+
+def _pick_targeted_match(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    jf_type: str,
+    title: str,
+    year: Any,
+    pairs: Iterable[str],
+    strict: bool,
+) -> Mapping[str, Any] | None:
+    pair_list = list(pairs or [])
+    cands = [
+        row for row in rows
+        if (row.get("Type") or "") == jf_type
+        and (row.get("Name") or "").strip().lower() == title.strip().lower()
+        and _valid_item_id(row.get("Id"))
+    ]
+    pair_cands = [
+        row for row in cands
+        if _row_matches_pair(row, pair_list) and _targeted_year_ok(row, year, missing_ok=True)
+    ]
+    if len(pair_cands) == 1:
+        return pair_cands[0]
+    if strict or pair_list:
+        return None
+    plain = [row for row in cands if _targeted_year_ok(row, year, missing_ok=False)]
+    return plain[0] if len(plain) == 1 else None
+
+
+def _targeted_lookup_item_id(
+    adapter: Any,
+    it: Mapping[str, Any],
+    *,
+    feature: str,
+    pairs: list[str],
+    episode_pairs: list[str],
+    series_pairs: list[str],
+    selected_libs: set[str],
+) -> str | None:
+    enabled = getattr(getattr(adapter, "cfg", None), "targeted_lookup", True)
+    if str(enabled).strip().lower() in ("0", "false", "no", "off"):
+        return None
+
+    item_type = _lookup_type(it)
+    title = (it.get("title") or "").strip()
+    year = it.get("year")
+    season = it.get("season")
+    episode = it.get("episode")
+    series_title = (it.get("series_title") or "").strip()
+    strict = bool(getattr(getattr(adapter, "cfg", None), "strict_id_matching", False))
+
+    if item_type in ("movie", "show", "series") and title:
+        jf_type = "Movie" if item_type == "movie" else "Series"
+        row = _pick_targeted_match(
+            _targeted_search(adapter, feature, selected_libs, jf_type, title),
+            jf_type=jf_type,
+            title=title,
+            year=year,
+            pairs=pairs,
+            strict=strict,
+        )
+        iid = _valid_item_id(row.get("Id")) if row else None
+        if iid:
+            kind = "movie" if jf_type == "Movie" else "series"
+            _dbg("resolve_hit", kind=kind, method="targeted_search", title=title, year=year, item_id=iid)
+            return iid
+        return None
+
+    if item_type == "episode" and series_title and season is not None and episode is not None:
+        series_row = _pick_targeted_match(
+            _targeted_search(adapter, feature, selected_libs, "Series", series_title),
+            jf_type="Series",
+            title=series_title,
+            year=None,
+            pairs=series_pairs,
+            strict=strict,
+        )
+        sid = _valid_item_id(series_row.get("Id")) if series_row else None
+        if not sid:
+            return None
+        body = get_series_episodes(adapter.client, adapter.cfg.user_id, sid, start=0, limit=10000)
+        if body is None:
+            return None
+        rows = [
+            row for row in (body.get("Items") or [])
+            if isinstance(row, Mapping)
+            and (row.get("Type") or "") == "Episode"
+            and _episode_number_matches(row, season, episode)
+        ]
+        pair_rows = [row for row in rows if _row_matches_pair(row, episode_pairs)]
+        chosen: Mapping[str, Any] | None = None
+        if len(pair_rows) == 1:
+            chosen = pair_rows[0]
+        elif len(rows) == 1:
+            chosen = rows[0]
+        iid = _valid_item_id(chosen.get("Id")) if chosen else None
+        if iid:
+            _dbg("resolve_hit", kind="episode", method="targeted_series_search", series_title=series_title, season=season, episode=episode, item_id=iid)
+            return iid
+    return None
+
+
 def _path_match_item_id(
     adapter: Any,
     it: Mapping[str, Any],
@@ -1307,6 +1475,18 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
         for p in series_pairs:
             if p not in pairs:
                 pairs.append(p)
+
+    targeted_iid = _targeted_lookup_item_id(
+        adapter,
+        it,
+        feature=feature,
+        pairs=pairs,
+        episode_pairs=episode_pairs,
+        series_pairs=series_pairs,
+        selected_libs=selected_libs,
+    )
+    if targeted_iid:
+        return targeted_iid
 
     # Movies
     if t == "movie":

--- a/providers/tests/test_jellyfin_resolver.py
+++ b/providers/tests/test_jellyfin_resolver.py
@@ -48,6 +48,7 @@ class FakeHttp:
 class FakeCfg:
     user_id = "U1"
     strict_id_matching = False
+    targeted_lookup = True
     watchlist_guid_priority = None
     history_guid_priority = None
     history_libraries = None
@@ -134,6 +135,63 @@ def test_jellyfin_long_numeric_item_ids_are_valid_backend_ids():
     item = {"type": "movie", "title": "Encanto", "year": 2021, "ids": {"tmdb": "568124"}}
 
     assert common.resolve_item_id(adapter, item, feature="history") == "7214430293560476068"
+
+
+def test_movie_targeted_lookup_resolves_without_full_provider_index():
+    row = jf_row("M1", "Movie", "Encanto", tmdb="568124")
+    adapter = FakeAdapter(FakeHttp([row]))
+
+    item = {"type": "movie", "title": "Encanto", "year": 2021, "ids": {"tmdb": "568124"}}
+
+    assert common.resolve_item_id(adapter, item, feature="history") == "M1"
+    assert any(call["params"].get("SearchTerm") == "Encanto" for call in adapter.client.calls)
+    assert not any("StartIndex" in call["params"] for call in adapter.client.calls)
+
+
+def test_movie_targeted_lookup_disabled_falls_back_to_provider_index():
+    row = jf_row("M1", "Movie", "Encanto", tmdb="568124")
+    adapter = FakeAdapter(FakeHttp([row]))
+    adapter.cfg.targeted_lookup = False
+
+    item = {"type": "movie", "title": "Encanto", "year": 2021, "ids": {"tmdb": "568124"}}
+
+    assert common.resolve_item_id(adapter, item, feature="history") == "M1"
+    assert not any(call["params"].get("SearchTerm") == "Encanto" for call in adapter.client.calls)
+    assert any("StartIndex" in call["params"] for call in adapter.client.calls)
+
+
+def test_strict_targeted_lookup_requires_provider_id_match():
+    wrong = jf_row("M0", "Movie", "Encanto", tmdb="1")
+    right = jf_row("M1", "Movie", "Encanto", tmdb="568124")
+    adapter = FakeAdapter(FakeHttp([wrong, right]))
+    adapter.cfg.strict_id_matching = True
+
+    item = {"type": "movie", "title": "Encanto", "year": 2021, "ids": {"tmdb": "568124"}}
+
+    assert common.resolve_item_id(adapter, item, feature="history") == "M1"
+    assert any(call["params"].get("SearchTerm") == "Encanto" for call in adapter.client.calls)
+    assert not any("StartIndex" in call["params"] for call in adapter.client.calls)
+
+
+def test_episode_targeted_lookup_uses_series_search_and_episode_numbers():
+    series = jf_row("S1", "Series", "Example Show", tmdb="999")
+    episode = jf_row("E2", "Episode", "Second", series_id="S1", season=1, episode=2)
+    adapter = FakeAdapter(FakeHttp([series], episodes={"S1": [episode]}))
+
+    item = {
+        "type": "episode",
+        "title": "Second",
+        "series_title": "Example Show",
+        "season": 1,
+        "episode": 2,
+        "ids": {},
+        "show_ids": {"tmdb": "999"},
+    }
+
+    assert common.resolve_item_id(adapter, item, feature="history") == "E2"
+    assert any(call["path"] == "/Items" and call["params"].get("SearchTerm") == "Example Show" for call in adapter.client.calls)
+    assert any(call["path"] == "/Shows/S1/Episodes" for call in adapter.client.calls)
+    assert not any("StartIndex" in call["params"] for call in adapter.client.calls if call["path"] == "/Items")
 
 
 def test_jellyfin_scoped_provider_index_trusts_rows_without_library_metadata():


### PR DESCRIPTION
# Pull request

## Change

- Added an optional targeted Jellyfin lookup before the slower all-items scan.
- The setting is enabled by default and can be turned off per pair under Jellyfin provider tuning.
- It only works for source to Jellyfin (not the other way around)

## Why

- Large Jellyfin libraries can hang or take a very long time when CW has to scan all items just to resolve one target item.

## Testing

- providers/tests/test_jellyfin_resolver.py 
- tests/test_scrob_integration.py::test_pair_config_keeps_unknown_provider_keys
- providers/tests/test_manifests.py::test_get_manifest_shape

## Issue

Relates to #857