### PR TITLE
Fix: Plex playlist writes and Jellyfin/Emby

### DIFF
--- a/assets/js/playlists.js
+++ b/assets/js/playlists.js
@@ -175,6 +175,13 @@
     return state.rulesets.find((rs) => rs.id === id) || null;
   }
 
+  function creatableEndpointTypes(provider) {
+    const key = String(provider || "").toUpperCase();
+    const found = state.providers.find((p) => String(p.provider || "").toUpperCase() === key);
+    const types = (found && found.create_endpoint_types) || [];
+    return types.length ? types : ["playlist"];
+  }
+
   function configuredProviders() {
     const seen = new Set();
     return state.providers.filter((p) => {
@@ -657,6 +664,11 @@
           <input id="pl-ep-create-name" maxlength="${PLAYLIST_NAME_MAX}" value="${esc(seed.playlist_name || seed.name || "")}" placeholder="New playlist name" aria-describedby="pl-ep-create-name-error">
           <div class="pl-field-error" id="pl-ep-create-name-error"></div>
         </div>
+        <div class="pl-field full" id="pl-ep-create-type-wrap" style="display:none">
+          <label for="pl-ep-create-type">New list type</label>
+          <select id="pl-ep-create-type"></select>
+          <div class="pl-help" id="pl-ep-create-type-help">Collections group titles in the library, playlists keep their own order.</div>
+        </div>
       </div>
     `;
     openModal({
@@ -690,15 +702,27 @@
       instanceSelect.innerHTML = selectOptions(list.map((x) => ({ value: x, label: x })), list.includes(instanceSelect.value) ? instanceSelect.value : (list[0] || "default"));
     };
     const toggleCreate = () => {
+      const typeWrap = $("#pl-ep-create-type-wrap", root);
       $("#pl-ep-existing-wrap", root).style.display = createCheck.checked ? "none" : "";
       $("#pl-ep-create-wrap", root).style.display = createCheck.checked ? "" : "none";
+      if (typeWrap) typeWrap.style.display = createCheck.checked && typeWrap.dataset.multi ? "" : "none";
       syncModalPrimary(ctx);
+    };
+    const updateCreateTypes = () => {
+      const wrap = $("#pl-ep-create-type-wrap", root);
+      const select = $("#pl-ep-create-type", root);
+      if (!wrap || !select) return;
+      const types = creatableEndpointTypes(providerSelect.value);
+      const current = select.value;
+      select.innerHTML = selectOptions(types.map((t) => ({ value: t, label: titleize(t) })), types.includes(current) ? current : types[0]);
+      wrap.dataset.multi = types.length > 1 ? "1" : "";
     };
     const updateProviderRestrictions = () => {
       const isSimkl = String(providerSelect.value || "").toUpperCase() === "SIMKL";
       if (simklWarning) simklWarning.classList.toggle("hidden", !isSimkl);
       createCheck.disabled = isSimkl;
       if (isSimkl) createCheck.checked = false;
+      updateCreateTypes();
       toggleCreate();
     };
     providerSelect.addEventListener("change", () => {
@@ -755,7 +779,8 @@
       const createName = val("#pl-ep-create-name", root);
       const createNameErr = playlistNameError(createName);
       if (createNameErr) throw new Error(createNameErr);
-      await API.epUpsert({ id: isEdit ? seed.id : "", name: name || createName, provider, instance, create: true, create_name: createName });
+      const createType = val("#pl-ep-create-type", root) || creatableEndpointTypes(provider)[0];
+      await API.epUpsert({ id: isEdit ? seed.id : "", name: name || createName, provider, instance, create: true, create_name: createName, media_type: createType });
     } else {
       const ids = selectedValues("#pl-ep-playlist", root);
       if (!ids.length) throw new Error("Select at least one playlist.");

--- a/cw_platform/playlists.py
+++ b/cw_platform/playlists.py
@@ -69,6 +69,10 @@ _PLAYLIST_METHODS = (
 )
 
 
+class PlaylistUserError(RuntimeError):
+    pass
+
+
 def _clean_str(v: Any) -> str:
     return str(v).strip() if v is not None else ""
 

--- a/cw_platform/playlists_runner.py
+++ b/cw_platform/playlists_runner.py
@@ -157,13 +157,17 @@ def get_mapping_profile(cfg: Mapping[str, Any], mapping_id: Any) -> dict[str, An
 
 
 def _endpoint_view(ep: Mapping[str, Any]) -> dict[str, Any]:
-    return {
+    out = {
         "provider": str(ep.get("provider") or "").strip().upper(),
         "instance": normalize_instance_id(ep.get("instance")),
         "playlist_id": str(ep.get("playlist_id") or "").strip(),
         "playlist_name": ep.get("playlist_name") or ep.get("name"),
         "endpoint_id": str(ep.get("id") or "").strip(),
     }
+    pending = ep.get("pending_create")
+    if not out["playlist_id"] and isinstance(pending, Mapping) and str(pending.get("name") or "").strip():
+        out["pending_create"] = dict(pending)
+    return out
 
 
 def _target_ids(profile: Mapping[str, Any]) -> list[str]:
@@ -460,6 +464,95 @@ def _snapshot_endpoint(providers: Mapping[str, Any], cfg: Mapping[str, Any], end
     return snap, ops, view, inst
 
 
+_CREATE_SEED_LIMIT = 25
+
+
+def _persist_endpoint_playlist_id(cfg: Mapping[str, Any], endpoint_id: str, playlist_id: str, playlist_name: str) -> bool:
+    eid = str(endpoint_id or "").strip()
+    if not eid:
+        return False
+
+    def _apply(root_cfg: Any) -> bool:
+        found = False
+        for ep in pl_root(root_cfg, create=True).get("endpoints", []):
+            if isinstance(ep, dict) and str(ep.get("id") or "") == eid:
+                ep["playlist_id"] = playlist_id
+                if playlist_name and not str(ep.get("playlist_name") or "").strip():
+                    ep["playlist_name"] = playlist_name
+                ep.pop("pending_create", None)
+                found = True
+        return found
+
+    stored = False
+    try:
+        from .config_base import update_config
+
+        _unused, stored = update_config(_apply)
+    except Exception:
+        stored = False
+    if isinstance(cfg, dict):
+        try:
+            stored = _apply(cfg) or stored
+        except Exception:
+            pass
+    return bool(stored)
+
+
+def _apply_new_playlist_id(mapping: Mapping[str, Any], endpoint_id: str, playlist_id: str, playlist_name: str) -> None:
+    views: list[Any] = [mapping.get("source"), mapping.get("target")]
+    views.extend(_mapping_targets(mapping))
+    for view in views:
+        if not isinstance(view, dict):
+            continue
+        if str(view.get("endpoint_id") or "") != str(endpoint_id):
+            continue
+        view["playlist_id"] = playlist_id
+        if playlist_name and not str(view.get("playlist_name") or "").strip():
+            view["playlist_name"] = playlist_name
+        view.pop("pending_create", None)
+
+
+def _materialize_pending(
+    providers: Mapping[str, Any],
+    cfg: Mapping[str, Any],
+    mapping: Mapping[str, Any],
+    endpoint: Mapping[str, Any],
+    source_items: Sequence[PlaylistItem],
+    *,
+    materialize: bool,
+) -> tuple[str, set[str]]:
+    pending = endpoint.get("pending_create") if isinstance(endpoint, Mapping) else None
+    if not isinstance(pending, Mapping):
+        return "", set()
+    name = str(pending.get("name") or endpoint.get("playlist_name") or "").strip()
+    if not name:
+        raise PlaylistRunError("pending target playlist has no name")
+    if not materialize:
+        raise PlaylistRunError(f"target playlist '{name}' is created on the first run")
+
+    ops, view, inst, provider, _unused = _ops_cfg(providers, cfg, endpoint)
+    seed_items = [it for it in (source_items or []) if it.key][:_CREATE_SEED_LIMIT]
+    if not seed_items:
+        raise PlaylistRunError(f"{provider} cannot create '{name}' from an empty source playlist")
+
+    res = ops.create_playlist(
+        view,
+        name,
+        media_type=pending.get("media_type"),
+        items=[dict(it.item or {}) for it in seed_items],
+        instance=inst,
+    )
+    new_id = str(getattr(res, "id", "") or "").strip()
+    if not new_id:
+        raise PlaylistRunError(f"{provider} did not return an id for the new playlist '{name}'")
+    new_name = str(getattr(res, "name", "") or name)
+    endpoint_id = str(endpoint.get("endpoint_id") or "")
+    _apply_new_playlist_id(mapping, endpoint_id, new_id, new_name)
+    if not _persist_endpoint_playlist_id(cfg, endpoint_id, new_id, new_name):
+        raise PlaylistRunError(f"created '{name}' but could not store its id on endpoint {endpoint_id or '?'}")
+    return new_id, {it.key for it in seed_items}
+
+
 def _unique_snapshot_items(snapshot: PlaylistSnapshot) -> tuple[list[PlaylistItem], dict[str, PlaylistItem]]:
     ordered: list[PlaylistItem] = []
     by_key: dict[str, PlaylistItem] = {}
@@ -559,6 +652,7 @@ def _plan_ruleset(
     mapping: Mapping[str, Any],
     *,
     providers: Mapping[str, Any] | None = None,
+    materialize: bool = False,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     providers = providers or _providers()
     ruleset = _ruleset_for_mapping(cfg, mapping)
@@ -581,6 +675,9 @@ def _plan_ruleset(
     source_items, source_by_key = _unique_snapshot_items(source_snap)
     source_keys = [it.key for it in source_items]
     source_set = set(source_by_key)
+    for tgt in targets:
+        if isinstance(tgt, Mapping) and tgt.get("pending_create"):
+            _materialize_pending(providers, cfg, mapping, tgt, source_items, materialize=materialize)
     agg = _aggregate_targets(providers, cfg, targets)
     warnings: list[str] = list(agg.get("warnings") or [])
     if ruleset["direction"] == "bidirectional":
@@ -721,6 +818,7 @@ def build_plan(
     mapping: Mapping[str, Any],
     *,
     providers: Mapping[str, Any] | None = None,
+    materialize: bool = False,
 ) -> tuple[PlaylistPlan, dict[str, Any]]:
     providers = providers or _providers()
     source = mapping.get("source") or {}
@@ -744,11 +842,20 @@ def build_plan(
         raise PlaylistRunError(f"target provider {dst or '?'} does not support playlists")
     if not src_pl:
         raise PlaylistRunError("mapping source playlist id missing")
-    if not dst_pl:
-        raise PlaylistRunError("mapping target playlist id missing")
 
     src_cfg = build_provider_config_view(cfg, src, src_inst)
     dst_cfg = build_provider_config_view(cfg, dst, dst_inst)
+
+    src_snap: PlaylistSnapshot = src_ops.get_playlist_snapshot(src_cfg, src_pl, instance=src_inst)
+
+    seeded_keys: set[str] = set()
+    if not dst_pl:
+        dst_pl, seeded_keys = _materialize_pending(
+            providers, cfg, mapping, target, src_snap.items, materialize=materialize
+        )
+        dst_cfg = build_provider_config_view(cfg, dst, dst_inst)
+    if not dst_pl:
+        raise PlaylistRunError("mapping target playlist id missing")
 
     dst_resource = _find_resource(dst_ops, dst_cfg, dst_inst, dst_pl)
     if dst_resource is None:
@@ -759,7 +866,6 @@ def build_plan(
         raise PlaylistRunError("target playlist is read only")
     _merge_warnings(plan.warnings, dst_resource)
 
-    src_snap: PlaylistSnapshot = src_ops.get_playlist_snapshot(src_cfg, src_pl, instance=src_inst)
     dst_snap: PlaylistSnapshot = dst_ops.get_playlist_snapshot(dst_cfg, dst_pl, instance=dst_inst)
 
     src_by_key = src_snap.by_key()
@@ -816,6 +922,7 @@ def build_plan(
         "dst_set": dst_set,
         "src_set": src_set,
         "src_keys": src_keys,
+        "seeded_keys": {k for k in seeded_keys if k in dst_set},
     }
     return plan, ctx
 
@@ -851,7 +958,7 @@ def _apply_ruleset_mapping(
     providers: Mapping[str, Any] | None = None,
     emit: Callable[..., None] | None = None,
 ) -> dict[str, Any]:
-    plan, ctx = _plan_ruleset(cfg, mapping, providers=providers)
+    plan, ctx = _plan_ruleset(cfg, mapping, providers=providers, materialize=not dry_run)
     mapping_id = str(mapping.get("id") or "")
     result: dict[str, Any] = {
         "ok": not bool(plan.get("blocked")),
@@ -1077,7 +1184,7 @@ def run_mapping(
 ) -> dict[str, Any]:
     if mapping.get("ruleset_id"):
         return _apply_ruleset_mapping(cfg, mapping, dry_run=dry_run, providers=providers, emit=emit)
-    plan, ctx = build_plan(cfg, mapping, providers=providers)
+    plan, ctx = build_plan(cfg, mapping, providers=providers, materialize=not dry_run)
 
     dst_ops = ctx["dst_ops"]
     dst_cfg = ctx["dst_cfg"]
@@ -1131,8 +1238,12 @@ def run_mapping(
             result["warnings"].append("mass_delete_blocked")
         remove_items = guarded
 
-    applied_add_keys: set[str] = set()
+    applied_add_keys: set[str] = set(ctx.get("seeded_keys") or ())
     applied_remove_keys: set[str] = set()
+    if applied_add_keys:
+        result["created"] = True
+        result["seeded"] = len(applied_add_keys)
+        result["warnings"].append(f"created target playlist with {len(applied_add_keys)} seed item(s)")
 
     if dry_run:
         result["added"] = len(plan.add_items)
@@ -1151,7 +1262,7 @@ def run_mapping(
         confirmed = set(add_res.get("confirmed_keys") or [])
         if not confirmed and result["added"]:
             confirmed = {canonical_key(it) for it in plan.add_items}
-        applied_add_keys = confirmed
+        applied_add_keys |= confirmed
         if add_res.get("capacity"):
             result["warnings"].append(f"capacity:{add_res.get('capacity')}")
         added_items = [it for it in plan.add_items if canonical_key(it) in confirmed]

--- a/providers/sync/_mod_EMBY.py
+++ b/providers/sync/_mod_EMBY.py
@@ -181,6 +181,7 @@ _FEATURES: dict[str, Any] = {
 _PLAYLIST_CAPABILITIES: dict[str, Any] = {
     "read": True,
     "create": True,
+    "create_endpoint_types": ["playlist", "collection"],
     "add": True,
     "remove": True,
     "reorder": True,

--- a/providers/sync/_mod_JELLYFIN.py
+++ b/providers/sync/_mod_JELLYFIN.py
@@ -174,6 +174,7 @@ _FEATURES: dict[str, Any] = {
 _PLAYLIST_CAPABILITIES: dict[str, Any] = {
     "read": True,
     "create": True,
+    "create_endpoint_types": ["playlist", "collection"],
     "add": True,
     "remove": True,
     "reorder": False,

--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -118,6 +118,8 @@ except Exception as e:
 _PLAYLIST_CAPABILITIES: dict[str, Any] = {
     "read": True,
     "create": True,
+    "create_empty": False,
+    "create_endpoint_types": ["playlist"],
     "add": True,
     "remove": True,
     "reorder": True,

--- a/providers/sync/plex/_playlists.py
+++ b/providers/sync/plex/_playlists.py
@@ -12,13 +12,22 @@ from cw_platform.playlists import (
     PlaylistItem,
     PlaylistResource,
     PlaylistSnapshot,
+    PlaylistUserError,
 )
 
 from ._common import (
+    extract_show_ids,
     item_guid_candidates,
     key_of as plex_key_of,
     normalize as plex_normalize,
-    resolve_obj_by_guids,
+    object_type,
+    plex_feature_library_ids,
+    section_allowed,
+    server_find_rating_key_by_guid,
+)
+from ._history import (
+    _build_guid_index as _hist_build_guid_index,
+    _pms_find_in_guid_index as _hist_find_in_guid_index,
 )
 from . import _watchlist as feat_watchlist
 from .._log import log as cw_log
@@ -29,6 +38,20 @@ _VIDEO_TYPES = {"movie", "episode"}
 _COLLECTION_TYPES = {"movie", "show"}
 WATCHLIST_ID = "__watchlist__"
 COLLECTION_PREFIX = "collection:"
+_COLLECTION_MEDIA_TYPES = {"collection", "boxset"}
+_SHOW_LIKE_TYPES = frozenset({"show", "season", "episode", "anime"})
+
+HINT_NO_IDS = "no_ids"
+HINT_NOT_IN_LIBRARY = "not_in_library"
+HINT_TYPE_UNSUPPORTED = "unsupported_type"
+HINT_SECTION_EXCLUDED = "section_excluded"
+
+_HINT_RANK = {
+    HINT_NO_IDS: 0,
+    HINT_NOT_IN_LIBRARY: 1,
+    HINT_SECTION_EXCLUDED: 2,
+    HINT_TYPE_UNSUPPORTED: 3,
+}
 
 
 def _info(event: str, **fields: Any) -> None:
@@ -48,6 +71,14 @@ class SmartPlaylistError(PlaylistError):
 
 
 class PlaylistNotFound(PlaylistError):
+    pass
+
+
+class PlaylistItemsRequired(PlaylistError, PlaylistUserError):
+    pass
+
+
+class PlaylistUnsupported(PlaylistError, PlaylistUserError):
     pass
 
 
@@ -331,14 +362,88 @@ def get_snapshot(adapter: Any, playlist_id: Any) -> PlaylistSnapshot:
     return PlaylistSnapshot(resource=resource, items=items, checkpoint=None)
 
 
-def _resolve_object(srv: Any, item: Mapping[str, Any], *, accept: set[str] | None = None, allow: set[str] | None = None) -> Any | None:
-    guids = item_guid_candidates(item.get("ids") or {}, item.get("show_ids") or {}, item)
-    if not guids:
+def _library_type_for(item: Mapping[str, Any]) -> str:
+    return "show" if str(item.get("type") or "").strip().lower() in _SHOW_LIKE_TYPES else "movie"
+
+
+def _fetch(srv: Any, rating_key: Any) -> Any | None:
+    try:
+        return srv.fetchItem(int(rating_key))
+    except Exception:
         return None
-    return resolve_obj_by_guids(srv, guids, set(allow or set()), set(accept or _VIDEO_TYPES))
 
 
-def _resolve_items(srv: Any, items: Sequence[Mapping[str, Any]], *, accept: set[str] | None = None, allow: set[str] | None = None, missing_hint: str = "not_found") -> tuple[list[Any], list[str], list[dict[str, Any]]]:
+def _resolve_object(
+    adapter: Any,
+    item: Mapping[str, Any],
+    *,
+    accept: set[str],
+    allow: set[str],
+) -> tuple[Any | None, str, str]:
+    srv = getattr(getattr(adapter, "client", None), "server", None)
+    if srv is None:
+        return None, "", HINT_NOT_IN_LIBRARY
+
+    raw_ids = item.get("ids")
+    ids = dict(raw_ids) if isinstance(raw_ids, Mapping) else {}
+    guids = item_guid_candidates(ids, extract_show_ids(item) or {}, item)
+
+    candidates: list[Any] = []
+    plex_rk = ids.get("plex")
+    if plex_rk:
+        obj = _fetch(srv, plex_rk)
+        if obj is not None:
+            candidates.append(obj)
+
+    rk = None
+    if guids:
+        try:
+            rk = server_find_rating_key_by_guid(srv, guids)
+        except Exception:
+            rk = None
+        if rk:
+            obj = _fetch(srv, rk)
+            if obj is not None:
+                candidates.append(obj)
+        rk_idx = None
+        try:
+            _hist_build_guid_index(adapter, allow)
+            rk_idx = _hist_find_in_guid_index(_library_type_for(item), guids)
+        except Exception:
+            rk_idx = None
+        if rk_idx and str(rk_idx) != str(rk or ""):
+            obj = _fetch(srv, rk_idx)
+            if obj is not None:
+                candidates.append(obj)
+
+    if not candidates:
+        return None, "", (HINT_NO_IDS if not (guids or plex_rk) else HINT_NOT_IN_LIBRARY)
+
+    miss = ""
+    for obj in candidates:
+        otype = object_type(obj)
+        if not section_allowed(obj, allow):
+            if _HINT_RANK[HINT_SECTION_EXCLUDED] > _HINT_RANK.get(miss, -1):
+                miss = HINT_SECTION_EXCLUDED
+            continue
+        if accept and otype not in accept:
+            if _HINT_RANK[HINT_TYPE_UNSUPPORTED] > _HINT_RANK.get(miss, -1):
+                miss = HINT_TYPE_UNSUPPORTED
+            continue
+        return obj, otype, ""
+    return None, object_type(candidates[0]), (miss or HINT_NOT_IN_LIBRARY)
+
+
+def _resolve_items(
+    adapter: Any,
+    items: Sequence[Mapping[str, Any]],
+    *,
+    accept: set[str] | None = None,
+    allow: set[str] | None = None,
+) -> tuple[list[Any], list[str], list[dict[str, Any]]]:
+    accepted = set(accept or _VIDEO_TYPES)
+    allowed = set(allow) if allow is not None else plex_feature_library_ids(adapter, _FEATURE)
+    allowed = {str(x).strip() for x in (allowed or set()) if str(x).strip()}
     resolved: list[Any] = []
     confirmed: list[str] = []
     unresolved: list[dict[str, Any]] = []
@@ -351,13 +456,60 @@ def _resolve_items(srv: Any, items: Sequence[Mapping[str, Any]], *, accept: set[
         if key in seen:
             continue
         seen.add(key)
-        obj = _resolve_object(srv, m, accept=accept, allow=allow)
+        obj, matched_type, hint = _resolve_object(adapter, m, accept=accepted, allow=allowed)
         if obj is None:
-            unresolved.append({"item": m, "hint": missing_hint})
+            miss: dict[str, Any] = {"item": m, "hint": hint or HINT_NOT_IN_LIBRARY}
+            if matched_type:
+                miss["matched_type"] = matched_type
+            unresolved.append(miss)
             continue
         resolved.append(obj)
         confirmed.append(key)
     return resolved, confirmed, unresolved
+
+
+def _hint_counts(unresolved: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for u in unresolved or []:
+        hint = str((u or {}).get("hint") or "unknown")
+        out[hint] = out.get(hint, 0) + 1
+    return out
+
+
+def _unresolved_sample(unresolved: Sequence[Mapping[str, Any]], limit: int = 3) -> list[str]:
+    out: list[str] = []
+    for u in unresolved or []:
+        item = u.get("item") if isinstance(u, Mapping) else None
+        if not isinstance(item, Mapping):
+            continue
+        title = str(item.get("series_title") or item.get("title") or "").strip()
+        if title:
+            out.append(title)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _write_done(op: str, list_id: Any, applied: int, unresolved: Sequence[Mapping[str, Any]]) -> None:
+    fields: dict[str, Any] = {"op": op, "list_id": str(list_id), "applied": int(applied), "unresolved": len(unresolved)}
+    if unresolved:
+        fields["hints"] = _hint_counts(unresolved)
+        sample = _unresolved_sample(unresolved)
+        if sample:
+            fields["sample"] = sample
+    _info("write_done", **fields)
+
+
+def _resolve_warnings(unresolved: Sequence[Mapping[str, Any]], *, target: str) -> list[str]:
+    hints = _hint_counts(unresolved)
+    out: list[str] = []
+    n = hints.get(HINT_TYPE_UNSUPPORTED) or 0
+    if n:
+        out.append(f"{n} item(s) matched in plex but are the wrong type for this {target}")
+    n = hints.get(HINT_NOT_IN_LIBRARY) or 0
+    if n:
+        out.append(f"{n} item(s) are not in this plex library")
+    return out
 
 
 def create(
@@ -371,6 +523,8 @@ def create(
     nm = str(name or "").strip()
     if not nm:
         raise ValueError("playlist name required")
+    if str(media_type or "").strip().lower() in _COLLECTION_MEDIA_TYPES:
+        raise PlaylistUnsupported("plex collections must be created in plex, they cannot be created from crosswatch")
     if dry_run:
         return PlaylistResource(
             provider=_PROVIDER,
@@ -382,16 +536,20 @@ def create(
             can_reorder=True,
             media_types=("movie", "episode"),
         )
+    lst = list(items or [])
+    if not lst:
+        raise PlaylistItemsRequired("plex cannot create an empty playlist")
     srv = _server(adapter)
-    resolved, _confirmed, _unresolved = _resolve_items(srv, list(items or []))
+    resolved, _confirmed, unresolved = _resolve_items(adapter, lst)
     if not resolved:
-        raise PlaylistError("plex requires at least one resolvable item to create a playlist")
+        _warn("create_unresolved", name=nm, count=len(lst), hints=_hint_counts(unresolved))
+        raise PlaylistItemsRequired("none of the source items exist in this plex library")
     try:
         pl = srv.createPlaylist(nm, items=resolved)
     except Exception as e:
         _warn("create_failed", name=nm, error=str(e))
         raise PlaylistError(f"plex create playlist failed: {e}") from e
-    _info("create_done", name=nm)
+    _info("create_done", name=nm, seeded=len(resolved))
     return _resource_from_playlist(adapter, pl)
 
 
@@ -443,11 +601,10 @@ def add(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> d
         section_id = str(resource.extra.get("section_id") or "").strip()
         allow = {section_id} if section_id else None
         resolved, confirmed, unresolved = _resolve_items(
-            srv,
+            adapter,
             list(items or []),
             accept={subtype},
             allow=allow,
-            missing_hint="not_in_library",
         )
         added = 0
         if resolved:
@@ -460,13 +617,19 @@ def add(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> d
                     unresolved.append({"item": plex_normalize(obj), "hint": "add_failed"})
                 confirmed = []
                 added = 0
-        _info("write_done", op="add", list_id=resource.id, applied=added, unresolved=len(unresolved))
-        return {"ok": True, "count": added, "unresolved": unresolved, "confirmed_keys": confirmed}
+        _write_done("add", resource.id, added, unresolved)
+        return {
+            "ok": True,
+            "count": added,
+            "unresolved": unresolved,
+            "confirmed_keys": confirmed,
+            "warnings": _resolve_warnings(unresolved, target="collection"),
+        }
 
     pl = _find_playlist(srv, playlist_id)
     _guard_writable(pl)
 
-    resolved, confirmed, unresolved = _resolve_items(srv, list(items or []))
+    resolved, confirmed, unresolved = _resolve_items(adapter, list(items or []))
     added = 0
     if resolved:
         try:
@@ -478,8 +641,14 @@ def add(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> d
                 unresolved.append({"item": plex_normalize(obj), "hint": "add_failed"})
             confirmed = []
             added = 0
-    _info("write_done", op="add", list_id=str(playlist_id), applied=added, unresolved=len(unresolved))
-    return {"ok": True, "count": added, "unresolved": unresolved, "confirmed_keys": confirmed}
+    _write_done("add", playlist_id, added, unresolved)
+    return {
+        "ok": True,
+        "count": added,
+        "unresolved": unresolved,
+        "confirmed_keys": confirmed,
+        "warnings": _resolve_warnings(unresolved, target="playlist"),
+    }
 
 
 def remove(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
@@ -527,7 +696,7 @@ def remove(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -
             except Exception as e:
                 _warn("collection_remove_item_failed", list_id=resource.id, error=str(e))
                 unresolved.append({"item": {"key": key}, "hint": "remove_failed"})
-        _info("write_done", op="remove", list_id=resource.id, applied=removed, unresolved=len(unresolved))
+        _write_done("remove", resource.id, removed, unresolved)
         return {"ok": True, "count": removed, "unresolved": unresolved, "confirmed_keys": confirmed}
 
     pl = _find_playlist(srv, playlist_id)
@@ -568,7 +737,7 @@ def remove(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -
             _warn("remove_item_failed", list_id=str(playlist_id), error=str(e))
             unresolved.append({"item": {"key": key}, "hint": "remove_failed"})
 
-    _info("write_done", op="remove", list_id=str(playlist_id), applied=removed, unresolved=len(unresolved))
+    _write_done("remove", playlist_id, removed, unresolved)
     return {"ok": True, "count": removed, "unresolved": unresolved, "confirmed_keys": confirmed}
 
 

--- a/services/playlists.py
+++ b/services/playlists.py
@@ -10,7 +10,13 @@ from contextlib import contextmanager
 from typing import Any, Iterator, Mapping
 
 from _logging import log as _cw_log
-from cw_platform.playlists import BUILTIN_RULESETS, playlist_capabilities, supports_playlists, validate_ruleset
+from cw_platform.playlists import (
+    BUILTIN_RULESETS,
+    PlaylistUserError,
+    playlist_capabilities,
+    supports_playlists,
+    validate_ruleset,
+)
 from cw_platform.provider_instances import (
     build_provider_config_view,
     list_instance_ids,
@@ -26,6 +32,7 @@ _SAFE_NAME_CHARS = " _.'-&()"
 
 
 def _internal_playlist_error(action: str, exc: Exception, **extra: Any) -> dict[str, Any]:
+    reason = str(exc or "").strip() if isinstance(exc, PlaylistUserError) else ""
     try:
         _cw_log(
             f"playlist {action} failed",
@@ -34,12 +41,13 @@ def _internal_playlist_error(action: str, exc: Exception, **extra: Any) -> dict[
             extra={
                 "action": action,
                 "error_type": exc.__class__.__name__,
+                "reason": reason,
                 **{k: v for k, v in extra.items() if v not in (None, "", [], {})},
             },
         )
     except Exception:
         pass
-    return {"ok": False, "error": f"{action} failed"}
+    return {"ok": False, "error": f"{action} failed: {reason}" if reason else f"{action} failed"}
 
 
 def _safe_name_error(name: Any, label: str, max_len: int) -> str:
@@ -129,6 +137,7 @@ def list_playlist_providers(cfg: Mapping[str, Any]) -> list[dict[str, Any]]:
                     "label": label,
                     "configured": configured,
                     "capabilities": caps,
+                    "create_endpoint_types": creatable_endpoint_types(ops),
                 }
             )
     return out
@@ -167,7 +176,30 @@ def _clean_endpoint(payload: Mapping[str, Any]) -> dict[str, Any]:
     media_types = payload.get("media_types")
     if isinstance(media_types, list):
         out["media_types"] = [str(x).strip().lower() for x in media_types if str(x).strip()]
+    pending = _clean_pending_create(payload.get("pending_create"))
+    if pending:
+        out["pending_create"] = pending
     return out
+
+
+def _clean_pending_create(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    name = str(value.get("name") or "").strip()
+    if not name:
+        return None
+    return {"name": name, "media_type": str(value.get("media_type") or "playlist").strip().lower()}
+
+
+def creatable_endpoint_types(ops: Any) -> list[str]:
+    caps = playlist_capabilities(ops)
+    raw = caps.get("create_endpoint_types") or caps.get("endpoint_types") or ["playlist"]
+    out: list[str] = []
+    for x in raw if isinstance(raw, (list, tuple)) else [raw]:
+        v = str(x or "").strip().lower()
+        if v and v not in out:
+            out.append(v)
+    return out or ["playlist"]
 
 
 def list_endpoints(cfg: Mapping[str, Any]) -> list[dict[str, Any]]:
@@ -356,28 +388,42 @@ def upsert_endpoint(cfg: dict[str, Any], payload: Mapping[str, Any]) -> dict[str
         create_err = _playlist_name_error(create_name)
         if create_err:
             return {"ok": False, "error": create_err}
-        media_type = str(payload.get("media_type") or "movie").strip().lower()
-        try:
-            view = build_provider_config_view(cfg, clean["provider"], clean["instance"])
-            res = ops.create_playlist(view, create_name, media_type=media_type, instance=clean["instance"])
-            clean["playlist_id"] = res.id
-            clean["playlist_name"] = clean["playlist_name"] or res.name
-        except Exception as e:
-            return _internal_playlist_error(
-                "create",
-                e,
-                provider=clean["provider"],
-                instance=clean["instance"],
-                media_type=media_type,
-            )
+        caps = playlist_capabilities(ops)
+        allowed_types = creatable_endpoint_types(ops)
+        media_type = str(payload.get("media_type") or allowed_types[0]).strip().lower()
+        if media_type not in allowed_types:
+            label = " or ".join(allowed_types)
+            return {"ok": False, "error": f"{clean['provider']} can only create a {label}"}
+        clean["playlist_type"] = media_type
+        if caps.get("create_empty", True) is False:
+            clean["playlist_name"] = clean["playlist_name"] or create_name
+            clean["pending_create"] = {"name": create_name, "media_type": media_type}
+        else:
+            try:
+                view = build_provider_config_view(cfg, clean["provider"], clean["instance"])
+                res = ops.create_playlist(view, create_name, media_type=media_type, instance=clean["instance"])
+                clean["playlist_id"] = res.id
+                clean["playlist_name"] = clean["playlist_name"] or res.name
+            except Exception as e:
+                return _internal_playlist_error(
+                    "create",
+                    e,
+                    provider=clean["provider"],
+                    instance=clean["instance"],
+                    media_type=media_type,
+                )
 
-    if not clean["playlist_id"]:
+    if not (clean["playlist_id"] or clean.get("pending_create")):
         return {"ok": False, "error": "playlist required"}
     root = runner.pl_root(cfg, create=True)
     endpoints = root["endpoints"]
     if clean["id"]:
         for i, ep in enumerate(endpoints):
             if isinstance(ep, Mapping) and str(ep.get("id") or "") == clean["id"]:
+                if not clean["playlist_id"] and not clean.get("pending_create"):
+                    carried = _clean_pending_create(ep.get("pending_create"))
+                    if carried:
+                        clean["pending_create"] = carried
                 endpoints[i] = clean
                 out = _refresh_endpoint_meta(cfg, clean["id"]) or clean
                 _refresh_mapping_pairs_for_endpoint(cfg, clean["id"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,4 +14,7 @@ if str(REPO_ROOT) not in sys.path:
 @pytest.fixture()
 def config_base(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("CONFIG_BASE", str(tmp_path))
+    from cw_platform import config_base as _cb
+
+    monkeypatch.setattr(_cb, "CONFIG", tmp_path, raising=False)
     return tmp_path

--- a/tests/test_playlists_pending_create.py
+++ b/tests/test_playlists_pending_create.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cw_platform.id_map import canonical_key
+from cw_platform.playlists import PlaylistItem, PlaylistResource, PlaylistSnapshot
+from cw_platform import playlists_runner as R
+import services.playlists as svc
+
+
+def _movie(n: int) -> dict[str, Any]:
+    return {"type": "movie", "title": f"M{n}", "year": 2020, "ids": {"tmdb": str(n)}}
+
+
+class FakeOps:
+    can_create_empty = False
+
+    def __init__(self, name: str, playlists: dict[str, dict[str, Any]]):
+        self._name = name
+        self.pl = playlists
+        self.created: list[dict[str, Any]] = []
+        self.calls: list[Any] = []
+        self._next_id = 500
+
+    def capabilities(self) -> dict[str, Any]:
+        return {"playlists": {"create": True, "create_empty": bool(self.can_create_empty)}}
+
+    def _resource(self, pid: str) -> PlaylistResource:
+        d = self.pl[pid]
+        return PlaylistResource(
+            provider=self._name,
+            id=pid,
+            name=d.get("name") or pid,
+            can_add=True,
+            can_remove=True,
+            can_reorder=True,
+        )
+
+    def list_playlist_resources(self, cfg, *, instance=None):
+        return [self._resource(pid) for pid in self.pl]
+
+    def get_playlist_snapshot(self, cfg, playlist_id, *, instance=None):
+        d = self.pl[playlist_id]
+        items = [PlaylistItem.from_media(m, position=i) for i, m in enumerate(d["items"])]
+        return PlaylistSnapshot(resource=self._resource(playlist_id), items=items)
+
+    def create_playlist(self, cfg, name, *, media_type=None, items=None, instance=None, dry_run=False):
+        seed = [dict(x) for x in (items or [])]
+        if not self.can_create_empty and not seed:
+            raise RuntimeError("cannot create an empty playlist")
+        self._next_id += 1
+        pid = str(self._next_id)
+        self.pl[pid] = {"name": name, "items": seed}
+        self.created.append({"id": pid, "name": name, "seed": [canonical_key(x) for x in seed]})
+        return self._resource(pid)
+
+    def add_playlist_items(self, cfg, playlist_id, items, *, instance=None, dry_run=False):
+        self.calls.append(("add", playlist_id, [canonical_key(x) for x in items]))
+        d = self.pl[playlist_id]
+        existing = {canonical_key(m) for m in d["items"]}
+        conf = []
+        for it in items:
+            k = canonical_key(it)
+            if k not in existing:
+                d["items"].append(dict(it))
+                existing.add(k)
+                conf.append(k)
+        return {"ok": True, "count": len(conf), "unresolved": [], "confirmed_keys": conf}
+
+    def remove_playlist_items(self, cfg, playlist_id, items, *, instance=None, dry_run=False):
+        self.calls.append(("remove", playlist_id, [canonical_key(x) for x in items]))
+        d = self.pl[playlist_id]
+        want = {canonical_key(x) for x in items}
+        conf = [canonical_key(m) for m in d["items"] if canonical_key(m) in want]
+        d["items"] = [m for m in d["items"] if canonical_key(m) not in want]
+        return {"ok": True, "count": len(conf), "unresolved": [], "confirmed_keys": conf}
+
+    def reorder_playlist_items(self, cfg, playlist_id, ordered_keys, *, instance=None, dry_run=False):
+        return {"ok": True, "reordered": 0, "count": 0}
+
+    def is_configured(self, cfg) -> bool:
+        return True
+
+
+def _cfg(src: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "trakt": {},
+        "plex": {},
+        "runtime": {},
+        "playlists": {
+            "endpoints": [
+                {"id": "EP-01", "name": "Src", "provider": "TRAKT", "instance": "default", "playlist_id": "L1"},
+                {
+                    "id": "EP-02",
+                    "name": "Dst",
+                    "provider": "PLEX",
+                    "instance": "default",
+                    "playlist_id": "",
+                    "playlist_name": "Weekend",
+                    "pending_create": {"name": "Weekend", "media_type": "playlist"},
+                },
+            ],
+            "mappings": [
+                {
+                    "id": "MAP-01",
+                    "name": "Map1",
+                    "source_endpoint": "EP-01",
+                    "target_endpoints": ["EP-02"],
+                    "membership": "managed_only",
+                    "order": "ignore",
+                    "enabled": True,
+                }
+            ],
+            "rulesets": [],
+        },
+    }
+
+
+@pytest.fixture
+def world(config_base, monkeypatch):
+    from cw_platform import config_base as cb
+
+    def _update_config(mutator):
+        cfg = getattr(_update_config, "cfg", None)
+        return cfg, (mutator(cfg) if isinstance(cfg, dict) else None)
+
+    monkeypatch.setattr(cb, "update_config", _update_config)
+    monkeypatch.setattr(svc, "_save", lambda _cfg: None)
+
+    src = {"L1": {"name": "src", "items": [_movie(1), _movie(2), _movie(3)]}}
+    dst: dict[str, dict[str, Any]] = {}
+    provs = {"TRAKT": FakeOps("TRAKT", src), "PLEX": FakeOps("PLEX", dst)}
+    cfg = _cfg(src)
+    _update_config.cfg = cfg
+    return cfg, src, dst, provs
+
+
+def test_pending_target_is_created_on_the_first_run(world) -> None:
+    cfg, src, dst, provs = world
+    mapping = R.resolve_mapping_by_id(cfg, "MAP-01")
+
+    res = R.run_mapping(cfg, mapping, providers=provs)
+
+    assert res["ok"] and res.get("created") is True
+    created = provs["PLEX"].created
+    assert len(created) == 1 and created[0]["name"] == "Weekend"
+    assert {canonical_key(m) for m in dst[created[0]["id"]]["items"]} == {"tmdb:1", "tmdb:2", "tmdb:3"}
+
+
+def test_the_new_playlist_id_is_written_back_to_the_endpoint(world) -> None:
+    cfg, src, dst, provs = world
+    mapping = R.resolve_mapping_by_id(cfg, "MAP-01")
+
+    R.run_mapping(cfg, mapping, providers=provs)
+
+    ep = R.get_endpoint(cfg, "EP-02")
+    assert ep["playlist_id"] == provs["PLEX"].created[0]["id"]
+    assert "pending_create" not in ep, "a materialized endpoint must not stay pending"
+
+
+def test_the_second_run_reuses_the_playlist_instead_of_creating_another(world) -> None:
+    cfg, src, dst, provs = world
+
+    R.run_mapping(cfg, R.resolve_mapping_by_id(cfg, "MAP-01"), providers=provs)
+    R.run_mapping(cfg, R.resolve_mapping_by_id(cfg, "MAP-01"), providers=provs)
+
+    assert len(provs["PLEX"].created) == 1
+
+
+def test_seeded_items_are_managed_so_a_later_source_removal_propagates(world) -> None:
+    cfg, src, dst, provs = world
+
+    R.run_mapping(cfg, R.resolve_mapping_by_id(cfg, "MAP-01"), providers=provs)
+    pid = provs["PLEX"].created[0]["id"]
+
+    src["L1"]["items"] = [_movie(1)]
+    res = R.run_mapping(cfg, R.resolve_mapping_by_id(cfg, "MAP-01"), providers=provs)
+
+    assert res["removed"] == 2, "items created as the seed must land in the managed baseline"
+    assert {canonical_key(m) for m in dst[pid]["items"]} == {"tmdb:1"}
+
+
+def test_a_dry_run_never_creates_the_playlist(world) -> None:
+    cfg, src, dst, provs = world
+    mapping = R.resolve_mapping_by_id(cfg, "MAP-01")
+
+    with pytest.raises(R.PlaylistRunError, match="first run"):
+        R.run_mapping(cfg, mapping, dry_run=True, providers=provs)
+
+    assert provs["PLEX"].created == []
+
+
+def test_an_empty_source_cannot_create_the_target(world) -> None:
+    cfg, src, dst, provs = world
+    src["L1"]["items"] = []
+
+    with pytest.raises(R.PlaylistRunError, match="empty source"):
+        R.run_mapping(cfg, R.resolve_mapping_by_id(cfg, "MAP-01"), providers=provs)
+
+    assert provs["PLEX"].created == []
+
+
+def test_service_parks_the_endpoint_when_the_provider_cannot_create_an_empty_list(world, monkeypatch) -> None:
+    cfg, _src, _dst, provs = world
+    monkeypatch.setattr(svc, "_providers", lambda: provs)
+
+    res = svc.upsert_endpoint(
+        cfg,
+        {"name": "Later", "provider": "PLEX", "instance": "default", "create": True, "create_name": "Later"},
+    )
+
+    assert res["ok"] is True
+    assert provs["PLEX"].created == [], "creation must be deferred, not attempted with no items"
+    assert res["endpoint"]["pending_create"] == {"name": "Later", "media_type": "playlist"}
+
+
+def test_service_still_creates_immediately_when_the_provider_supports_it(world, monkeypatch) -> None:
+    cfg, _src, _dst, provs = world
+    provs["PLEX"].can_create_empty = True
+    monkeypatch.setattr(svc, "_providers", lambda: provs)
+
+    res = svc.upsert_endpoint(
+        cfg,
+        {"name": "Now", "provider": "PLEX", "instance": "default", "create": True, "create_name": "Now"},
+    )
+
+    assert res["ok"] is True
+    assert len(provs["PLEX"].created) == 1
+    assert res["endpoint"]["playlist_id"] == provs["PLEX"].created[0]["id"]
+    assert "pending_create" not in res["endpoint"]
+
+
+class CollectionOps(FakeOps):
+    can_create_empty = True
+
+    def __init__(self, name: str, playlists: dict[str, Any], endpoint_types: list[str]):
+        super().__init__(name, playlists)
+        self._endpoint_types = endpoint_types
+
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "playlists": {
+                "create": True,
+                "create_empty": True,
+                "endpoint_types": ["playlist", "collection"],
+                "create_endpoint_types": self._endpoint_types,
+            }
+        }
+
+    def _resource(self, pid: str) -> PlaylistResource:
+        res = super()._resource(pid)
+        res.extra = {"endpoint_type": self.pl[pid].get("endpoint_type") or "playlist"}
+        return res
+
+    def create_playlist(self, cfg, name, *, media_type=None, items=None, instance=None, dry_run=False):
+        res = super().create_playlist(cfg, name, media_type=media_type, items=items, instance=instance, dry_run=dry_run)
+        pid = self.created[-1]["id"]
+        self.pl[pid]["endpoint_type"] = "collection" if media_type == "collection" else "playlist"
+        self.created[-1]["media_type"] = media_type
+        return self._resource(pid)
+
+
+def _collection_world(monkeypatch, endpoint_types):
+    provs = {"JELLYFIN": CollectionOps("JELLYFIN", {}, endpoint_types)}
+    monkeypatch.setattr(svc, "_providers", lambda: provs)
+    monkeypatch.setattr(svc, "_save", lambda _cfg: None)
+    return provs
+
+
+def test_a_requested_collection_reaches_the_provider_as_a_collection(config_base, monkeypatch) -> None:
+    provs = _collection_world(monkeypatch, ["playlist", "collection"])
+
+    res = svc.upsert_endpoint(
+        {},
+        {
+            "name": "Marvel",
+            "provider": "JELLYFIN",
+            "instance": "default",
+            "create": True,
+            "create_name": "Marvel",
+            "media_type": "collection",
+        },
+    )
+
+    assert res["ok"] is True
+    assert provs["JELLYFIN"].created[0]["media_type"] == "collection"
+    assert res["endpoint"]["playlist_type"] == "collection"
+
+
+def test_the_default_create_type_is_a_playlist_not_a_media_type(config_base, monkeypatch) -> None:
+    provs = _collection_world(monkeypatch, ["playlist", "collection"])
+
+    svc.upsert_endpoint(
+        {},
+        {"name": "Weekend", "provider": "JELLYFIN", "instance": "default", "create": True, "create_name": "Weekend"},
+    )
+
+    assert provs["JELLYFIN"].created[0]["media_type"] == "playlist"
+
+
+def test_a_type_the_provider_cannot_create_is_refused(config_base, monkeypatch) -> None:
+    provs = _collection_world(monkeypatch, ["playlist"])
+
+    res = svc.upsert_endpoint(
+        {},
+        {
+            "name": "Marvel",
+            "provider": "JELLYFIN",
+            "instance": "default",
+            "create": True,
+            "create_name": "Marvel",
+            "media_type": "collection",
+        },
+    )
+
+    assert res["ok"] is False and "can only create a playlist" in res["error"]
+    assert provs["JELLYFIN"].created == []

--- a/tests/test_plex_playlists_resolve.py
+++ b/tests/test_plex_playlists_resolve.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+MOVIE_ROWS = [
+    {
+        "ratingKey": "11",
+        "guid": "plex://movie/5d776b59ad5437001f79c6f8",
+        "Guid": [{"id": "imdb://tt0071562"}, {"id": "tmdb://240"}],
+    },
+]
+SHOW_ROWS = [
+    {"ratingKey": "21", "guid": "plex://show/5d9c08254eefaa001f5d6f1c", "Guid": [{"id": "tmdb://1399"}]},
+]
+
+
+class _Resp:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.ok = True
+        self.status_code = 200
+        self.headers = {"content-type": "application/json"}
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+    @property
+    def text(self) -> str:
+        return json.dumps(self._payload)
+
+
+class _Session:
+    headers: dict[str, str] = {}
+
+    def get(self, url, params=None, headers=None, timeout=None):
+        sid = url.rsplit("/all", 1)[0].rsplit("/", 1)[-1]
+        rows = MOVIE_ROWS if sid == "1" else SHOW_ROWS
+        start = int((params or {}).get("X-Plex-Container-Start") or 0)
+        return _Resp({"MediaContainer": {"Metadata": rows[start:], "totalSize": len(rows)}})
+
+
+class _Obj:
+    def __init__(self, rating_key: str, type_: str, section_id: str, title: str) -> None:
+        self.ratingKey = rating_key
+        self.type = type_
+        self.librarySectionID = section_id
+        self.title = title
+        self.year = 1974
+        self.guid = f"plex://{type_}/{rating_key}"
+
+
+class _Playlist:
+    def __init__(self) -> None:
+        self.ratingKey = "10234"
+        self.title = "Weekend"
+        self.playlistType = "video"
+        self.smart = False
+        self.added: list[Any] = []
+
+    def items(self):
+        return []
+
+    def addItems(self, objs):
+        self.added.extend(objs)
+
+
+class _Section:
+    def __init__(self, key: str, type_: str) -> None:
+        self.key = key
+        self.type = type_
+
+
+class _Server:
+    _token = "TOK"
+    machineIdentifier = "MID"
+
+    def __init__(self, playlist: _Playlist) -> None:
+        self._session = _Session()
+        self._playlist = playlist
+
+    def url(self, path):
+        return f"http://pms{path}"
+
+    def playlists(self):
+        return [self._playlist]
+
+    def query(self, *_a, **_k):
+        return None
+
+    def fetchItem(self, rating_key):
+        table = {
+            11: _Obj("11", "movie", "1", "The Godfather Part II"),
+            21: _Obj("21", "show", "2", "Game of Thrones"),
+        }
+        obj = table.get(int(rating_key))
+        if obj is None:
+            raise LookupError(rating_key)
+        return obj
+
+
+class _Adapter:
+    def __init__(self, srv: _Server) -> None:
+        self.client = type("C", (), {"server": srv})()
+        self.instance_id = "default"
+
+    def libraries(self, types=()):
+        return [_Section("1", "movie"), _Section("2", "show")]
+
+
+@pytest.fixture
+def plex(monkeypatch, tmp_path):
+    from providers.sync.plex import _history as h
+    from providers.sync.plex import _playlists as pl
+
+    monkeypatch.setattr(h, "_as_base_url", lambda _s: "http://pms")
+    monkeypatch.setattr(h, "_load_guid_index", lambda *a, **k: False)
+    monkeypatch.setattr(h, "_save_guid_index", lambda *a, **k: None)
+    monkeypatch.setattr(pl, "server_find_rating_key_by_guid", lambda *a, **k: None)
+    monkeypatch.setattr(pl, "plex_feature_library_ids", lambda *a, **k: set())
+    h._clear_guid_index()
+    h._GUID_INDEX_KEY = None
+
+    playlist = _Playlist()
+    return pl, _Adapter(_Server(playlist)), playlist
+
+
+def test_movie_is_added_when_only_the_guid_children_carry_the_external_id(plex) -> None:
+    pl, adapter, playlist = plex
+
+    res = pl.add(adapter, "10234", [{"type": "movie", "title": "The Godfather Part II", "ids": {"tmdb": "240"}}])
+
+    assert res["count"] == 1, "the guid index must resolve what the guid query misses"
+    assert res["unresolved"] == []
+    assert [o.ratingKey for o in playlist.added] == ["11"]
+
+
+def test_show_against_a_video_playlist_reports_the_type_not_a_missing_item(plex) -> None:
+    pl, adapter, playlist = plex
+
+    res = pl.add(adapter, "10234", [{"type": "show", "title": "Game of Thrones", "ids": {"tmdb": "1399"}}])
+
+    assert res["count"] == 0
+    assert [u["hint"] for u in res["unresolved"]] == ["unsupported_type"]
+    assert res["unresolved"][0]["matched_type"] == "show"
+    assert any("wrong type" in w for w in res["warnings"])
+    assert playlist.added == []
+
+
+def test_item_that_is_not_in_the_library_is_reported_as_such(plex) -> None:
+    pl, adapter, _playlist = plex
+
+    res = pl.add(adapter, "10234", [{"type": "movie", "title": "Nope", "ids": {"tmdb": "999999"}}])
+
+    assert res["count"] == 0
+    assert [u["hint"] for u in res["unresolved"]] == ["not_in_library"]
+
+
+def test_create_without_items_is_refused_with_a_typed_error(plex) -> None:
+    pl, adapter, _playlist = plex
+
+    with pytest.raises(pl.PlaylistItemsRequired):
+        pl.create(adapter, "Weekend", items=[])
+
+
+def test_create_seeds_the_playlist_with_the_resolved_items(plex, monkeypatch) -> None:
+    pl, adapter, _playlist = plex
+    created: dict[str, Any] = {}
+
+    def _create(title, items=None):
+        created["title"] = title
+        created["items"] = list(items or [])
+        return _Playlist()
+
+    monkeypatch.setattr(adapter.client.server, "createPlaylist", _create, raising=False)
+
+    res = pl.create(adapter, "Weekend", items=[{"type": "movie", "title": "x", "ids": {"tmdb": "240"}}])
+
+    assert created["title"] == "Weekend"
+    assert [o.ratingKey for o in created["items"]] == ["11"]
+    assert res.id == "10234"
+
+
+def test_collections_cannot_be_created_from_crosswatch(plex) -> None:
+    pl, adapter, _playlist = plex
+
+    with pytest.raises(pl.PlaylistUnsupported):
+        pl.create(adapter, "Marvel", media_type="collection", items=[{"ids": {"tmdb": "240"}}])


### PR DESCRIPTION
# Pull request

## Change

- Plex playlist writes now fall back to the history GUID index, same as ratings and progress
- Unresolved items get a real hint (not_in_library, unsupported_type) and the write log shows a hint count plus sample titles
- Plex cannot create an empty playlist, so the endpoint is parked as pending_create and the runner creates it on the first run, seeded from the source
- Create now sends an endpoint type instead of a media type, so Jellyfin and Emby collections can be created
- New list type selector in the create modal, driven by create_endpoint_types

## Why

- Plex uses the modern agents, so /library/all?guid= only matches the primary GUID and every external id missed. That is the applied=0 unresolved=30
- Endpoint create called the provider with zero items, which Plex always rejects
- The UI never sent media_type, so Jellyfin and Emby always got a playlist and never a collection

## Testing

- tests/test_plex_playlists_resolve.py
- tests/test_playlists_pending_create.py

## Issue

Relates to #439
Relates to #819
