### PR TITLE
Add: FlickList sync provider

### DIFF
--- a/providers/sync/_mod_FLICKLIST.py
+++ b/providers/sync/_mod_FLICKLIST.py
@@ -1,0 +1,366 @@
+# CrossWatch FlickList sync module
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+from cw_platform.provider_instances import normalize_instance_id, resolve_provider_block
+from providers.auth._auth_FLICKLIST import ME_URL, is_configured as auth_is_configured
+from providers.sync._mod_common import SimpleRateLimiter, build_op_result, build_session, dedup_keys
+from providers.sync.flicklist import _history as feat_history
+from providers.sync.flicklist import _playlists as feat_playlists
+from providers.sync.flicklist import _progress as feat_progress
+from providers.sync.flicklist import _ratings as feat_ratings
+from providers.sync.flicklist import _watchlist as feat_watchlist
+from providers.sync.flicklist._common import (
+    DEFAULT_GET_PER_SEC,
+    DEFAULT_POST_PER_SEC,
+    cfg_float,
+    error_of,
+    flicklist_request,
+)
+
+__VERSION__ = "0.1"
+__all__ = ["get_manifest", "FLICKLISTModule", "OPS", "feat_history", "feat_playlists", "feat_progress", "feat_ratings", "feat_watchlist"]
+
+if "ctx" not in globals():
+    class _NullCtx:
+        def emit(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    ctx = _NullCtx()  # type: ignore[assignment]
+
+
+_SYNC_DISABLED_REASON = "FlickList sync API writes are disabled until the remote bulk sync API is reliable; scrobble support remains enabled."
+_FEATURES = {"watchlist": False, "ratings": False, "history": False, "progress": False, "playlists": False}
+_FEATURE_MODULES = {
+    "watchlist": feat_watchlist,
+    "ratings": feat_ratings,
+    "history": feat_history,
+    "progress": feat_progress,
+}
+_ACCEPTED_IDS = ["fldb", "tmdb", "imdb", "tvdb"]
+
+
+def _current_instance_id() -> str:
+    if str(os.getenv("CW_PROBE_PROVIDER") or "").upper().strip() == "FLICKLIST":
+        return normalize_instance_id(os.getenv("CW_PROBE_INSTANCE"))
+    if str(os.getenv("CW_PAIR_SRC") or "").upper().strip() == "FLICKLIST":
+        return normalize_instance_id(os.getenv("CW_PAIR_SRC_INSTANCE"))
+    if str(os.getenv("CW_PAIR_DST") or "").upper().strip() == "FLICKLIST":
+        return normalize_instance_id(os.getenv("CW_PAIR_DST_INSTANCE"))
+    return "default"
+
+
+def get_manifest() -> Mapping[str, Any]:
+    return {
+        "name": "FLICKLIST",
+        "label": "FlickList",
+        "version": __VERSION__,
+        "type": "sync",
+        "bidirectional": False,
+        "experimental": True,
+        "disabled": True,
+        "disabled_reason": _SYNC_DISABLED_REASON,
+        "features": dict(_FEATURES),
+        "requires": ["requests"],
+        "capabilities": {
+            "bidirectional": False,
+            "experimental": True,
+            "disabled": True,
+            "disabled_reason": _SYNC_DISABLED_REASON,
+            "provides_ids": True,
+            "index_semantics": "present",
+            "multi_profile": True,
+            "features": dict(_FEATURES),
+            "watchlist": {
+                "read": False,
+                "write": False,
+                "types": {"movies": True, "shows": True, "seasons": False, "episodes": False},
+                "upsert": False,
+                "remove": False,
+                "observed_deletes": False,
+                "accepted_ids": list(_ACCEPTED_IDS),
+                "provides_ids": ["fldb", "tmdb", "imdb", "tvdb", "anilist"],
+                "custom_lists": False,
+                "batch_size": 1000,
+            },
+            "ratings": {
+                "read": False,
+                "write": False,
+                "types": {"movies": True, "shows": True, "seasons": False, "episodes": True},
+                "upsert": False,
+                "remove": False,
+                "observed_deletes": False,
+                "accepted_ids": list(_ACCEPTED_IDS),
+                "provides_ids": ["fldb", "tmdb", "imdb", "tvdb", "anilist"],
+                "scale": "0.5-10",
+                "rounds_to_half": True,
+                "batch_size": 1000,
+            },
+            "history": {
+                "read": False,
+                "write": False,
+                "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+                "upsert": False,
+                "remove": False,
+                "observed_deletes": False,
+                "accepted_ids": list(_ACCEPTED_IDS),
+                "provides_ids": ["fldb", "tmdb", "imdb", "tvdb", "anilist"],
+                "rewatch": True,
+                "requires_watched_at": False,
+                "batch_size": 1000,
+            },
+            "progress": {
+                "read": False,
+                "write": False,
+                "index_semantics": "present",
+                "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+                "upsert": False,
+                "remove": False,
+                "observed_deletes": False,
+                "accepted_ids": list(_ACCEPTED_IDS),
+                "provides_ids": ["fldb", "tmdb", "imdb", "tvdb", "anilist"],
+                "requires_duration": False,
+            },
+            "playlists": {
+                "read": False,
+                "write": False,
+                "create": False,
+                "remove": False,
+                "reorder": False,
+                "smart_lists_read_only": True,
+                "types": {"movies": True, "shows": True, "seasons": False, "episodes": True},
+                "accepted_ids": list(_ACCEPTED_IDS),
+                "batch_size": 1000,
+            },
+            "scrobble": {"read": False, "write": True, "actions": ["start", "pause", "stop"], "accepted_ids": list(_ACCEPTED_IDS)},
+        },
+    }
+
+
+def _result_from(raw: Mapping[str, Any] | None) -> dict[str, Any]:
+    data = dict(raw or {})
+    confirmed = [str(k) for k in (data.get("confirmed_keys") or []) if k]
+    unresolved_keys = [str(k) for k in (data.get("unresolved_keys") or []) if k]
+    skipped = [str(k) for k in (data.get("skipped_keys") or []) if k]
+    deferred = [str(k) for k in (data.get("deferred_keys") or []) if k]
+    skipped_all = dedup_keys(list(skipped) + list(deferred))
+    accepted_raw = [str(k) for k in (data.get("accepted_keys") or []) if k]
+    accepted = dedup_keys(accepted_raw or (list(confirmed) + list(skipped_all)))
+    extra: dict[str, Any] = {}
+    if skipped_all:
+        extra["skipped_keys"] = skipped_all
+        extra["skipped"] = len(skipped_all)
+    if deferred:
+        extra["deferred_keys"] = deferred
+        extra["deferred"] = len(deferred)
+    if accepted:
+        extra["accepted_keys"] = accepted
+    return build_op_result(
+        ok=bool(data.get("ok", True)),
+        count=len(confirmed),
+        confirmed_keys=confirmed,
+        unresolved_keys=unresolved_keys,
+        unresolved=data.get("unresolved") or [],
+        **extra,
+    )
+
+
+class FLICKLISTModule:
+    def __init__(self, cfg: Mapping[str, Any], instance_id: str | None = None):
+        self.config = cfg or {}
+        self.instance_id = normalize_instance_id(instance_id) if instance_id is not None else _current_instance_id()
+        section = (self.config.get("flicklist") or {}) if isinstance(self.config, Mapping) else {}
+        get_rps = cfg_float(section, "get_per_sec", DEFAULT_GET_PER_SEC)
+        post_rps = cfg_float(section, "post_per_sec", DEFAULT_POST_PER_SEC)
+        rl = section.get("rate_limit") if isinstance(section.get("rate_limit"), Mapping) else {}
+        if rl:
+            get_rps = cfg_float(rl, "get_per_sec", get_rps)
+            post_rps = cfg_float(rl, "post_per_sec", post_rps)
+        session = build_session("FLICKLIST", ctx)
+        try:
+            session._rate_limiter = SimpleRateLimiter(rates_per_sec={"GET": get_rps, "POST": post_rps, "DELETE": post_rps})
+            session._rate_limiter_meta = {"get_per_sec": get_rps, "post_per_sec": post_rps}
+        except Exception:
+            pass
+        try:
+            session.headers.setdefault("Accept", "application/json")
+            session.headers.setdefault("User-Agent", f"CrossWatch FLICKLIST/{__VERSION__}")
+        except Exception:
+            pass
+        self.session = session
+
+    @staticmethod
+    def supported_features() -> dict[str, bool]:
+        return dict(_FEATURES)
+
+    def manifest(self) -> Mapping[str, Any]:
+        return get_manifest()
+
+    def _section(self) -> Mapping[str, Any]:
+        try:
+            return resolve_provider_block(self.config, "flicklist", self.instance_id) or {}
+        except Exception:
+            block = self.config.get("flicklist") if isinstance(self.config, Mapping) else None
+            return block if isinstance(block, Mapping) else {}
+
+    def health(self) -> Mapping[str, Any]:
+        start = time.perf_counter()
+        ok = False
+        status = "not_configured"
+        reason: str | None = None
+        api: dict[str, Any] = {}
+        if not auth_is_configured(self._section()):
+            reason = "missing_authentication"
+        else:
+            try:
+                resp = flicklist_request(self, "GET", ME_URL, timeout=10.0, max_retries=1)
+                code = int(resp.status_code)
+                api["me"] = {"status": code}
+                if 200 <= code < 300:
+                    ok = True
+                    status = "ok"
+                elif code in (401, 403):
+                    status = "auth_failed"
+                    reason = "unauthorized"
+                elif code == 429:
+                    status = "rate_limited"
+                    reason = "rate_limited"
+                else:
+                    status = f"http:{code}"
+                    reason = error_of(resp) or status
+            except Exception as exc:
+                status = "service_unavailable"
+                reason = f"exception:{exc.__class__.__name__}"
+                api["me"] = {"status": status}
+        if not ok:
+            try:
+                ctx.emit("debug", msg="flicklist.health.failed", status=status, reason=reason, api=api)
+            except Exception:
+                pass
+        return {
+            "ok": ok,
+            "status": status,
+            "latency_ms": int((time.perf_counter() - start) * 1000),
+            "features": {name: bool(ok and enabled) for name, enabled in _FEATURES.items()},
+            "details": {"reason": reason} if reason else None,
+            "api": api,
+        }
+
+    def build_index(self, feature: str, **kwargs: Any) -> Mapping[str, dict[str, Any]]:
+        mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
+        if not mod:
+            return {}
+        return mod.build_index(self, **kwargs)
+
+    def add(self, feature: str, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+        mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
+        if not mod:
+            return build_op_result(ok=True, count=0, unsupported=True)
+        lst = list(items or [])
+        if dry_run:
+            return build_op_result(ok=True, count=len(lst), dry_run=True)
+        return _result_from(mod.add(self, lst))
+
+    def remove(self, feature: str, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+        mod = _FEATURE_MODULES.get(str(feature or "").strip().lower())
+        if not mod:
+            return build_op_result(ok=True, count=0, unsupported=True)
+        lst = list(items or [])
+        if dry_run:
+            return build_op_result(ok=True, count=len(lst), dry_run=True)
+        return _result_from(mod.remove(self, lst))
+
+    def list_playlist_resources(self) -> Sequence[Any]:
+        return feat_playlists.list_resources(self)
+
+    def get_playlist_snapshot(self, playlist_id: str) -> Any:
+        return feat_playlists.get_snapshot(self, playlist_id)
+
+    def create_playlist(self, name: str, *, media_type: str | None = None, items: Sequence[Mapping[str, Any]] | None = None, dry_run: bool = False) -> Any:
+        return feat_playlists.create(self, name, media_type=media_type, items=items, dry_run=dry_run)
+
+    def add_playlist_items(self, playlist_id: str, items: Sequence[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+        if dry_run:
+            return {"ok": True, "count": len(list(items or [])), "dry_run": True}
+        return feat_playlists.add(self, playlist_id, items)
+
+    def remove_playlist_items(self, playlist_id: str, items: Sequence[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+        if dry_run:
+            return {"ok": True, "count": len(list(items or [])), "dry_run": True}
+        return feat_playlists.remove(self, playlist_id, items)
+
+    def reorder_playlist_items(self, playlist_id: str, ordered_keys: Sequence[str], *, dry_run: bool = False) -> dict[str, Any]:
+        return feat_playlists.reorder(self, playlist_id, ordered_keys)
+
+
+class _FLICKLISTOPS:
+    def name(self) -> str:
+        return "FLICKLIST"
+
+    def label(self) -> str:
+        return "FlickList"
+
+    def features(self) -> Mapping[str, bool]:
+        return dict(_FEATURES)
+
+    def state_read_features(self) -> Mapping[str, bool]:
+        return dict(_FEATURES)
+
+    def capabilities(self) -> Mapping[str, Any]:
+        return get_manifest()["capabilities"]
+
+    def is_configured(self, cfg: Mapping[str, Any]) -> bool:
+        try:
+            block = resolve_provider_block(cfg or {}, "flicklist", _current_instance_id())
+        except Exception:
+            block = (cfg or {}).get("flicklist") if isinstance(cfg, Mapping) else None
+        return auth_is_configured(block if isinstance(block, Mapping) else {})
+
+    def _adapter(self, cfg: Mapping[str, Any], instance: str | None = None) -> FLICKLISTModule:
+        return FLICKLISTModule(cfg, instance_id=instance)
+
+    def health(self, cfg: Mapping[str, Any]) -> Mapping[str, Any]:
+        return self._adapter(cfg).health()
+
+    def build_index(self, cfg: Mapping[str, Any], *, feature: str) -> Mapping[str, dict[str, Any]]:
+        return self._adapter(cfg).build_index(feature)
+
+    def add(self, cfg: Mapping[str, Any], items: Iterable[Mapping[str, Any]], *, feature: str, dry_run: bool = False) -> dict[str, Any]:
+        return self._adapter(cfg).add(feature, items, dry_run=dry_run)
+
+    def remove(self, cfg: Mapping[str, Any], items: Iterable[Mapping[str, Any]], *, feature: str, dry_run: bool = False) -> dict[str, Any]:
+        return self._adapter(cfg).remove(feature, items, dry_run=dry_run)
+
+    def list_playlist_resources(self, cfg: Mapping[str, Any], *, instance: str | None = None) -> Sequence[Any]:
+        old = os.environ.get("CW_PROBE_INSTANCE")
+        if instance is not None:
+            os.environ["CW_PROBE_INSTANCE"] = str(instance)
+        try:
+            return self._adapter(cfg, instance).list_playlist_resources()
+        finally:
+            if old is None:
+                os.environ.pop("CW_PROBE_INSTANCE", None)
+            else:
+                os.environ["CW_PROBE_INSTANCE"] = old
+
+    def get_playlist_snapshot(self, cfg: Mapping[str, Any], playlist_id: str, *, instance: str | None = None) -> Any:
+        return self._adapter(cfg, instance).get_playlist_snapshot(playlist_id)
+
+    def create_playlist(self, cfg: Mapping[str, Any], name: str, *, media_type: str | None = None, instance: str | None = None, dry_run: bool = False) -> Any:
+        return self._adapter(cfg, instance).create_playlist(name, media_type=media_type, dry_run=dry_run)
+
+    def add_playlist_items(self, cfg: Mapping[str, Any], playlist_id: str, items: Sequence[Mapping[str, Any]], *, instance: str | None = None, dry_run: bool = False) -> dict[str, Any]:
+        return self._adapter(cfg, instance).add_playlist_items(playlist_id, items, dry_run=dry_run)
+
+    def remove_playlist_items(self, cfg: Mapping[str, Any], playlist_id: str, items: Sequence[Mapping[str, Any]], *, instance: str | None = None, dry_run: bool = False) -> dict[str, Any]:
+        return self._adapter(cfg, instance).remove_playlist_items(playlist_id, items, dry_run=dry_run)
+
+    def reorder_playlist_items(self, cfg: Mapping[str, Any], playlist_id: str, ordered_keys: Sequence[str], *, instance: str | None = None, dry_run: bool = False) -> dict[str, Any]:
+        return self._adapter(cfg, instance).reorder_playlist_items(playlist_id, ordered_keys, dry_run=dry_run)
+
+
+OPS = _FLICKLISTOPS()

--- a/providers/sync/flicklist/__init__.py
+++ b/providers/sync/flicklist/__init__.py
@@ -1,0 +1,6 @@
+# providers/sync/flicklist/__init__.py
+# CrossWatch - FlickList sync package
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+__all__ = []

--- a/providers/sync/flicklist/_common.py
+++ b/providers/sync/flicklist/_common.py
@@ -1,0 +1,584 @@
+# providers/sync/flicklist/_common.py
+# CrossWatch - FlickList sync helpers
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import math
+import time
+from datetime import datetime, timezone
+from typing import Any, Iterator, Mapping, Sequence
+
+import requests
+
+from cw_platform.id_map import canonical_key, ids_from, minimal as id_minimal
+from providers.auth._auth_FLICKLIST import API_V3_BASE, is_configured as auth_configured, request_with_auth
+from providers.sync._log import log as cw_log
+
+URL_ME = f"{API_V3_BASE}/me"
+URL_WATCHLIST = f"{API_V3_BASE}/sync/watchlist"
+URL_RATINGS = f"{API_V3_BASE}/sync/ratings"
+URL_HISTORY = f"{API_V3_BASE}/sync/history"
+URL_WATCHED_MOVIES = f"{API_V3_BASE}/sync/watched/movies"
+URL_WATCHED_SHOWS = f"{API_V3_BASE}/sync/watched/shows"
+URL_PLAYBACK = f"{API_V3_BASE}/sync/playback"
+URL_PLAYBACK_ITEM = f"{API_V3_BASE}/sync/playback/{{id}}"
+URL_LISTS = f"{API_V3_BASE}/sync/lists"
+URL_LIST = f"{API_V3_BASE}/sync/lists/{{id}}"
+URL_LIST_ITEMS = f"{API_V3_BASE}/sync/lists/{{id}}/items"
+URL_SCROBBLE = f"{API_V3_BASE}/scrobble/{{action}}"
+
+BULK_MAX = 1000
+HISTORY_PAGE_MAX = 500
+HISTORY_PAGE_DEFAULT = 100
+DEFAULT_TIMEOUT = 20.0
+DEFAULT_GET_PER_SEC = 0.2
+DEFAULT_POST_PER_SEC = 0.2
+
+
+class FlickListError(RuntimeError):
+    pass
+
+
+def _log(feature: str, level: str, event: str, **fields: Any) -> None:
+    cw_log("FLICKLIST", feature, level, event, **fields)
+
+
+def _dbg(feature: str, event: str, **fields: Any) -> None:
+    _log(feature, "debug", event, **fields)
+
+
+def _info(feature: str, event: str, **fields: Any) -> None:
+    _log(feature, "info", event, **fields)
+
+
+def _warn(feature: str, event: str, **fields: Any) -> None:
+    _log(feature, "warn", event, **fields)
+
+
+def cfg_section(adapter: Any) -> Mapping[str, Any]:
+    cfg = getattr(adapter, "config", None) or {}
+    block = cfg.get("flicklist") if isinstance(cfg, Mapping) else None
+    return block if isinstance(block, Mapping) else {}
+
+
+def instance_id(adapter: Any) -> str:
+    return str(getattr(adapter, "instance_id", None) or "default")
+
+
+def cfg_float(data: Mapping[str, Any], key: str, default: float) -> float:
+    try:
+        return float(data.get(key, default))
+    except Exception:
+        return default
+
+
+def cfg_int(data: Mapping[str, Any], key: str, default: int) -> int:
+    try:
+        return int(data.get(key, default))
+    except Exception:
+        return default
+
+
+def has_auth(block: Mapping[str, Any] | None) -> bool:
+    return auth_configured(block)
+
+
+def flicklist_request(adapter: Any, method: str, url: str, **kwargs: Any) -> requests.Response:
+    cfg = getattr(adapter, "config", None) or {}
+    section = cfg_section(adapter)
+    timeout = kwargs.pop("timeout", cfg_float(section, "timeout", DEFAULT_TIMEOUT))
+    session = getattr(adapter, "session", None) or requests.Session()
+    return request_with_auth(
+        session,
+        method,
+        url,
+        cfg=cfg,
+        instance_id=instance_id(adapter),
+        timeout=timeout,
+        **kwargs,
+    )
+
+
+def ok_status(resp: requests.Response) -> bool:
+    return 200 <= int(getattr(resp, "status_code", 0) or 0) < 300
+
+
+def safe_json(resp: requests.Response) -> Any:
+    try:
+        if not (getattr(resp, "text", "") or "").strip():
+            return None
+        return resp.json()
+    except Exception:
+        return None
+
+
+def error_of(resp: requests.Response) -> str:
+    data = safe_json(resp)
+    if not isinstance(data, Mapping):
+        return ""
+    detail = data.get("detail")
+    if isinstance(detail, list):
+        return "; ".join(str((x or {}).get("msg") if isinstance(x, Mapping) else x) for x in detail)[:200]
+    return str(data.get("error") or data.get("message") or detail or "").strip()[:200]
+
+
+def as_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(str(value).strip())
+    except Exception:
+        return None
+
+
+def header_int(resp: requests.Response, name: str) -> int | None:
+    try:
+        headers = getattr(resp, "headers", {}) or {}
+        value = headers.get(name) or headers.get(name.lower()) or headers.get(name.upper())
+    except Exception:
+        return None
+    return as_int(value)
+
+
+def positive_int(value: Any) -> int | None:
+    out = as_int(value)
+    return out if out is not None and out > 0 else None
+
+
+def as_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def imdb_id(value: Any) -> str | None:
+    text = str(value or "").strip().lower()
+    if not text:
+        return None
+    if not text.startswith("tt"):
+        text = f"tt{text.lstrip('t')}"
+    return text if text[2:].isdigit() else None
+
+
+def iso_z(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            secs = float(value) / 1000.0 if float(value) > 1e11 else float(value)
+            return datetime.fromtimestamp(secs, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        except Exception:
+            return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        dt = datetime.fromisoformat(text.replace("Z", "+00:00").replace(" ", "T"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    except Exception:
+        return None
+
+
+def not_future(value: str | None) -> str | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except Exception:
+        return value
+    now = datetime.now(timezone.utc)
+    return now.strftime("%Y-%m-%dT%H:%M:%S.000Z") if dt > now else value
+
+
+def epoch_of(value: Any) -> int | None:
+    text = iso_z(value)
+    if not text:
+        return None
+    try:
+        return int(datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp())
+    except Exception:
+        return None
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def norm_read_type(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    if text in {"tv", "show", "shows", "series"}:
+        return "show"
+    if text in {"episode", "episodes"}:
+        return "episode"
+    if text in {"season", "seasons"}:
+        return "season"
+    return "movie"
+
+
+def norm_write_type(value: Any) -> str:
+    text = norm_read_type(value)
+    return "show" if text in {"show", "season", "episode"} else "movie"
+
+
+def ids_from_flicklist(raw: Mapping[str, Any] | None) -> dict[str, str]:
+    src = raw if isinstance(raw, Mapping) else {}
+    out: dict[str, str] = {}
+    fldb = str(src.get("fldb") or "").strip()
+    if fldb:
+        out["fldb"] = fldb
+    slug = str(src.get("slug") or "").strip()
+    if slug:
+        out["slug"] = slug
+    tmdb = positive_int(src.get("tmdb"))
+    if tmdb:
+        out["tmdb"] = str(tmdb)
+    imdb = imdb_id(src.get("imdb"))
+    if imdb:
+        out["imdb"] = imdb
+    tvdb = positive_int(src.get("tvdb"))
+    if tvdb:
+        out["tvdb"] = str(tvdb)
+    anilist = positive_int(src.get("anilist"))
+    if anilist:
+        out["anilist"] = str(anilist)
+    return out
+
+
+def _show_ids_for_write(src: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    show_ids = src.get("show_ids") if isinstance(src.get("show_ids"), Mapping) else None
+    if show_ids:
+        return show_ids
+
+    ids = src.get("ids") if isinstance(src.get("ids"), Mapping) else {}
+    prefixed: dict[str, Any] = {}
+    for source in (ids, src):
+        if not isinstance(source, Mapping):
+            continue
+        for key in ("fldb", "tmdb", "imdb", "tvdb"):
+            value = source.get(f"{key}_show")
+            if value:
+                prefixed[key] = value
+    return prefixed or None
+
+
+def _write_ids_from(src: Mapping[str, Any], *, prefer_show: bool = False) -> dict[str, Any]:
+    if prefer_show:
+        ids = _show_ids_for_write(src) or {}
+    else:
+        ids = src.get("ids") if isinstance(src.get("ids"), Mapping) else src
+    out: dict[str, Any] = {}
+    fldb = str((ids or {}).get("fldb") or src.get("_flicklist_fldb") or "").strip()
+    if fldb:
+        out["fldb"] = fldb
+        return out
+    tmdb = positive_int((ids or {}).get("tmdb"))
+    if tmdb:
+        out["tmdb"] = tmdb
+    imdb = imdb_id((ids or {}).get("imdb"))
+    if imdb:
+        out["imdb"] = imdb
+    tvdb = positive_int((ids or {}).get("tvdb"))
+    if tvdb:
+        out["tvdb"] = tvdb
+    return out
+
+
+def write_ident(item: Mapping[str, Any]) -> dict[str, Any] | None:
+    typ = norm_write_type(item.get("type"))
+    is_episode = norm_read_type(item.get("type")) == "episode" or item.get("season") is not None or item.get("episode") is not None
+    ids = _write_ids_from(item, prefer_show=is_episode)
+    if not ids:
+        return None
+    payload: dict[str, Any] = {"ids": ids, "media_type": typ}
+    if is_episode:
+        season = as_int(item.get("season") if item.get("season") is not None else item.get("season_number"))
+        episode = as_int(item.get("episode") if item.get("episode") is not None else item.get("episode_number"))
+        if season is None or episode is None:
+            return None
+        payload["media_type"] = "show"
+        payload["season"] = season
+        payload["episode"] = episode
+    return payload
+
+
+def read_minimal(row: Mapping[str, Any], *, default_type: str = "movie") -> dict[str, Any] | None:
+    ids = ids_from_flicklist(row.get("ids") if isinstance(row.get("ids"), Mapping) else {})
+    if not ids:
+        return None
+    typ = norm_read_type(row.get("type") or row.get("media_type") or default_type)
+    out: dict[str, Any] = {"type": typ, "ids": {k: v for k, v in ids.items() if k != "fldb"}}
+    if "fldb" in ids:
+        out["_flicklist_fldb"] = ids["fldb"]
+    title = str(row.get("title") or "").strip()
+    if title:
+        out["title"] = title
+    year = as_int(row.get("year"))
+    if year:
+        out["year"] = year
+    season = as_int(row.get("season_number") if row.get("season_number") is not None else row.get("season"))
+    episode = as_int(row.get("episode_number") if row.get("episode_number") is not None else row.get("episode"))
+    if typ == "episode" or (season is not None and episode is not None):
+        out["type"] = "episode"
+        if season is not None:
+            out["season"] = season
+        if episode is not None:
+            out["episode"] = episode
+        # FlickList read rows carry show-level ids for episodes.
+        out["show_ids"] = {k: v for k, v in ids.items() if k in {"tmdb", "imdb", "tvdb", "anilist", "slug"}}
+        ep_name = str(row.get("episode_name") or "").strip()
+        if ep_name:
+            out["title"] = ep_name
+        if title:
+            out["series_title"] = title
+    return id_minimal(out)
+
+
+def key_of(item: Mapping[str, Any]) -> str:
+    try:
+        return str(canonical_key(id_minimal(item)) or "").strip()
+    except Exception:
+        return ""
+
+
+def event_key(item: Mapping[str, Any]) -> str:
+    base = key_of(item)
+    if not base:
+        return ""
+    ts = epoch_of(item.get("watched_at"))
+    if ts is not None:
+        return f"{base}@{ts}"
+    rid = str(item.get("_flicklist_history_id") or "").strip()
+    return f"{base}@id:{rid}" if rid else base
+
+
+def read_shape(resp: Any, data: Any) -> dict[str, Any]:
+    out: dict[str, Any] = {"status": int(getattr(resp, "status_code", 0) or 0)}
+    try:
+        headers = getattr(resp, "headers", {}) or {}
+        out["content_type"] = str(headers.get("Content-Type") or "").split(";", 1)[0]
+        for name, label in (
+            ("X-FlickList-Item-Count", "item_count"),
+            ("X-FlickList-Page-Count", "page_count"),
+            ("X-FlickList-Limit", "limit"),
+            ("X-FlickList-Page", "page"),
+        ):
+            value = header_int(resp, name)
+            if value is not None:
+                out[label] = value
+    except Exception:
+        pass
+    if isinstance(data, list):
+        out["body"] = f"list[{len(data)}]"
+    elif isinstance(data, Mapping):
+        out["body"] = "object"
+        out["body_keys"] = ",".join(sorted(str(k) for k in data.keys())[:12])
+    elif data is None:
+        out["body"] = "empty"
+    else:
+        out["body"] = type(data).__name__
+    try:
+        text = str(getattr(resp, "text", "") or "")
+        out["preview"] = text[:200]
+        out["length"] = len(text)
+    except Exception:
+        pass
+    return out
+
+
+def chunk(items: Sequence[Mapping[str, Any]], size: int = BULK_MAX) -> Iterator[list[Mapping[str, Any]]]:
+    n = max(1, min(int(size or BULK_MAX), BULK_MAX))
+    for idx in range(0, len(items), n):
+        yield [dict(x) for x in items[idx : idx + n]]
+
+
+def write_batch_size(adapter: Any, feature: str | None = None) -> int:
+    section = cfg_section(adapter) or {}
+    keys = []
+    feat = str(feature or "").strip().lower()
+    if feat:
+        keys.append(f"{feat}_write_batch_size")
+    keys.append("write_batch_size")
+    for key in keys:
+        raw = section.get(key)
+        if raw is None:
+            continue
+        n = cfg_int(section, key, BULK_MAX)
+        return max(1, min(n, BULK_MAX))
+    return BULK_MAX
+
+
+def half_point(value: Any) -> float | None:
+    num = as_float(value)
+    if num is None or num <= 0:
+        return None
+    return max(0.5, min(10.0, math.floor(num * 2.0 + 0.5) / 2.0))
+
+
+def percent_of(item: Mapping[str, Any]) -> float | None:
+    pct = as_float(item.get("progress_percent") if item.get("progress_percent") is not None else item.get("percent"))
+    if pct is not None:
+        return max(0.0, min(100.0, pct))
+    pos = as_float(item.get("progress_ms") if item.get("progress_ms") is not None else item.get("viewOffset"))
+    dur = as_float(item.get("duration_ms"))
+    if pos is not None and dur and dur > 0:
+        return max(0.0, min(100.0, (pos / dur) * 100.0))
+    return None
+
+
+_WRITE_ID_ORDER = ("fldb", "tmdb", "imdb", "tvdb")
+_ADD_COUNTERS = ("added", "existing")
+_REMOVE_COUNTERS = ("removed",)
+
+
+def _norm_write_ids(raw: Any) -> dict[str, str]:
+    src = raw if isinstance(raw, Mapping) else {}
+    out: dict[str, str] = {}
+    for key in _WRITE_ID_ORDER:
+        value = src.get(key)
+        if value in (None, "", False):
+            continue
+        text = str(value).strip().lower()
+        if text and text != "null":
+            out[key] = text
+    return out
+
+
+def _ident_tokens(row: Mapping[str, Any]) -> set[str]:
+    ids = _norm_write_ids(row.get("ids"))
+    season = as_int(row.get("season"))
+    episode = as_int(row.get("episode"))
+    frag = f"#s{season}e{episode}" if season is not None and episode is not None else ""
+    return {f"{key}:{value}{frag}" for key, value in ids.items()}
+
+
+def write_counters(body: Any, method: str) -> dict[str, Any]:
+    data = body if isinstance(body, Mapping) else {}
+    names = _REMOVE_COUNTERS if str(method).upper() == "DELETE" else _ADD_COUNTERS
+    out: dict[str, Any] = {}
+    for name in names:
+        value = as_int(data.get(name))
+        if value is not None:
+            out[name] = value
+    misses = data.get("not_found")
+    out["not_found"] = len(misses) if isinstance(misses, list) else 0
+    return out
+
+
+def has_write_counters(body: Any, method: str) -> bool:
+    if not isinstance(body, Mapping):
+        return False
+    names = _REMOVE_COUNTERS if str(method).upper() == "DELETE" else _ADD_COUNTERS
+    return any(name in body for name in names) or "not_found" in body
+
+
+def classify_write(
+    sent: Sequence[tuple[str, Mapping[str, Any]]],
+    body: Any,
+    *,
+    method: str = "POST",
+) -> tuple[list[str], list[str], list[dict[str, Any]], dict[str, Any]]:
+    counters = write_counters(body, method)
+    data = body if isinstance(body, Mapping) else {}
+    misses = data.get("not_found")
+    misses = misses if isinstance(misses, list) else []
+
+    tokens = [(key, _ident_tokens(payload)) for key, payload in sent]
+    unresolved_keys: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    unmatched = 0
+    claimed: set[str] = set()
+
+    for row in misses:
+        if not isinstance(row, Mapping):
+            unmatched += 1
+            continue
+        want = _ident_tokens(row)
+        found = ""
+        for key, have in tokens:
+            if key in claimed or not want or not have:
+                continue
+            if want & have:
+                found = key
+                break
+        if not found:
+            unmatched += 1
+            continue
+        claimed.add(found)
+        unresolved_keys.append(found)
+        unresolved.append({"key": found, "status": "not_found", "reason": str(row.get("reason") or "") or None})
+
+    applied = sum(int(counters.get(name) or 0) for name in (_REMOVE_COUNTERS if str(method).upper() == "DELETE" else _ADD_COUNTERS) if name in counters)
+    has_applied = any(name in counters for name in (_REMOVE_COUNTERS if str(method).upper() == "DELETE" else _ADD_COUNTERS))
+    expected = len(sent) - len(misses)
+    shortfall = has_applied and applied < expected
+
+    if unmatched or shortfall:
+        status = "not_found_unmatched" if unmatched else "write_not_applied"
+        unresolved_keys = [key for key, _ in sent if key]
+        unresolved = [{"key": key, "status": status, "applied": applied, "not_found": len(misses), "sent": len(sent)} for key in unresolved_keys]
+        return [], unresolved_keys, unresolved, counters
+
+    blocked = set(unresolved_keys)
+    confirmed = [key for key, _ in sent if key and key not in blocked]
+    return confirmed, unresolved_keys, unresolved, counters
+
+
+__all__ = [
+    "HISTORY_PAGE_DEFAULT",
+    "BULK_MAX",
+    "DEFAULT_GET_PER_SEC",
+    "DEFAULT_POST_PER_SEC",
+    "DEFAULT_TIMEOUT",
+    "FlickListError",
+    "URL_HISTORY",
+    "URL_LIST",
+    "URL_LISTS",
+    "URL_LIST_ITEMS",
+    "URL_ME",
+    "URL_PLAYBACK",
+    "URL_PLAYBACK_ITEM",
+    "URL_RATINGS",
+    "URL_SCROBBLE",
+    "URL_WATCHED_MOVIES",
+    "URL_WATCHED_SHOWS",
+    "URL_WATCHLIST",
+    "as_float",
+    "as_int",
+    "cfg_float",
+    "cfg_int",
+    "cfg_section",
+    "chunk",
+    "classify_write",
+    "has_write_counters",
+    "write_counters",
+    "error_of",
+    "event_key",
+    "flicklist_request",
+    "half_point",
+    "has_auth",
+    "ids_from",
+    "ids_from_flicklist",
+    "instance_id",
+    "iso_z",
+    "key_of",
+    "norm_read_type",
+    "norm_write_type",
+    "not_future",
+    "now_iso",
+    "ok_status",
+    "percent_of",
+    "positive_int",
+    "read_minimal",
+    "read_shape",
+    "safe_json",
+    "write_ident",
+    "write_batch_size",
+    "_dbg",
+    "_info",
+    "_warn",
+]

--- a/providers/sync/flicklist/_history.py
+++ b/providers/sync/flicklist/_history.py
@@ -1,0 +1,351 @@
+# CrossWatch - FlickList history sync
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from ._common import (
+    HISTORY_PAGE_DEFAULT,
+    HISTORY_PAGE_MAX,
+    URL_HISTORY,
+    URL_WATCHED_MOVIES,
+    URL_WATCHED_SHOWS,
+    as_int,
+    cfg_int,
+    cfg_section,
+    chunk,
+    classify_write,
+    error_of,
+    event_key,
+    flicklist_request,
+    iso_z,
+    has_write_counters,
+    header_int,
+    key_of,
+    not_future,
+    now_iso,
+    ok_status,
+    read_minimal,
+    read_shape,
+    safe_json,
+    write_ident,
+    write_batch_size,
+    _dbg,
+    _info,
+    _warn,
+)
+
+FEATURE = "history"
+
+
+def _sum_counters(rows: list[dict[str, Any]]) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for row in rows:
+        for key, value in (row or {}).items():
+            out[key] = out.get(key, 0) + int(value or 0)
+    return out
+
+
+def _rows(data: Any) -> list[Any]:
+    if isinstance(data, list):
+        return data
+    if isinstance(data, Mapping):
+        for key in ("items", "data", "results", "history", "events"):
+            value = data.get(key)
+            if isinstance(value, list):
+                return value
+    return []
+
+
+def _page_count(data: Any, current: int) -> int:
+    if not isinstance(data, Mapping):
+        return current
+    for key in ("page_count", "pageCount", "pages", "total_pages", "totalPages"):
+        value = as_int(data.get(key))
+        if value is not None:
+            return max(current, value)
+    meta = data.get("pagination")
+    if isinstance(meta, Mapping):
+        return _page_count(meta, current)
+    return current
+
+
+def _response_page_count(resp: Any, data: Any, current: int) -> int:
+    header_count = header_int(resp, "X-FlickList-Page-Count")
+    if header_count is not None:
+        return max(current, header_count)
+    return _page_count(data, current)
+
+
+def _row_to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    item = read_minimal(row, default_type=row.get("type") or row.get("media_type") or "movie")
+    if not item:
+        return None
+    watched_at = row.get("watched_at")
+    if watched_at:
+        item["watched_at"] = watched_at
+    event_id = str(row.get("id") or "").strip()
+    if event_id:
+        item["_flicklist_history_id"] = event_id
+    return item
+
+
+def _movie_row_to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    item = read_minimal(row, default_type="movie")
+    if not item:
+        return None
+    watched_at = row.get("last_watched_at") or row.get("watched_at")
+    if watched_at:
+        item["watched_at"] = watched_at
+    plays = as_int(row.get("plays"))
+    if plays is not None:
+        item["plays"] = plays
+    item["_flicklist_watched_movie"] = True
+    return item
+
+
+def _supplement_watched_movies(adapter: Any, out: dict[str, dict[str, Any]]) -> tuple[int, int]:
+    resp = flicklist_request(adapter, "GET", URL_WATCHED_MOVIES)
+    if not ok_status(resp):
+        _warn(FEATURE, "watched_movies_failed", status=int(resp.status_code), error=error_of(resp))
+        return 0, 0
+    data = safe_json(resp)
+    rows = _rows(data)
+    if not rows:
+        _dbg(FEATURE, "watched_movies_empty_response", **read_shape(resp, data))
+    added = 0
+    skipped = 0
+    existing_bases = {str(key).split("@", 1)[0].lower() for key in out}
+    for row in rows:
+        if not isinstance(row, Mapping):
+            skipped += 1
+            continue
+        item = _movie_row_to_minimal(row)
+        if not item:
+            skipped += 1
+            continue
+        key = key_of(item)
+        if not key:
+            skipped += 1
+            continue
+        base = key.split("@", 1)[0].lower()
+        if base in existing_bases or key in out:
+            skipped += 1
+            continue
+        out[key] = item
+        existing_bases.add(base)
+        added += 1
+    _info(FEATURE, "watched_movies_supplement_done", added=added, skipped=skipped)
+    return added, skipped
+
+
+def _supplement_watched_shows(adapter: Any, out: dict[str, dict[str, Any]]) -> tuple[int, int]:
+    resp = flicklist_request(adapter, "GET", URL_WATCHED_SHOWS)
+    if not ok_status(resp):
+        _warn(FEATURE, "watched_shows_failed", status=int(resp.status_code), error=error_of(resp))
+        return 0, 0
+    data = safe_json(resp)
+    rows = _rows(data)
+    if not rows:
+        _dbg(FEATURE, "watched_shows_empty_response", **read_shape(resp, data))
+    added = 0
+    skipped = 0
+    existing_bases = {str(key).split("@", 1)[0].lower() for key in out}
+    for row in rows:
+        if not isinstance(row, Mapping):
+            skipped += 1
+            continue
+        raw_show = row.get("show")
+        show: Mapping[str, Any] = raw_show if isinstance(raw_show, Mapping) else row
+        raw_ids = show.get("ids")
+        ids: Mapping[str, Any] = raw_ids if isinstance(raw_ids, Mapping) else {}
+        if not ids:
+            skipped += 1
+            continue
+        title = str(show.get("title") or row.get("title") or "").strip()
+        year = show.get("year") or row.get("year")
+        seasons = row.get("seasons")
+        if not isinstance(seasons, list):
+            skipped += 1
+            continue
+        for season_row in seasons:
+            if not isinstance(season_row, Mapping):
+                skipped += 1
+                continue
+            season = as_int(season_row.get("number") if season_row.get("number") is not None else season_row.get("season"))
+            episodes = season_row.get("episodes")
+            if season is None or not isinstance(episodes, list):
+                skipped += 1
+                continue
+            for ep_row in episodes:
+                if not isinstance(ep_row, Mapping):
+                    skipped += 1
+                    continue
+                episode = as_int(ep_row.get("number") if ep_row.get("number") is not None else ep_row.get("episode"))
+                if episode is None:
+                    skipped += 1
+                    continue
+                payload: dict[str, Any] = {
+                    "type": "episode",
+                    "title": title,
+                    "season_number": season,
+                    "episode_number": episode,
+                    "ids": ids,
+                }
+                if year is not None:
+                    payload["year"] = year
+                ep_title = str(ep_row.get("title") or ep_row.get("name") or ep_row.get("episode_name") or "").strip()
+                if ep_title:
+                    payload["episode_name"] = ep_title
+                item = read_minimal(payload, default_type="episode")
+                if not item:
+                    skipped += 1
+                    continue
+                watched_at = ep_row.get("last_watched_at") or ep_row.get("watched_at") or row.get("last_watched_at")
+                if watched_at:
+                    item["watched_at"] = watched_at
+                plays = as_int(ep_row.get("plays"))
+                if plays is not None:
+                    item["plays"] = plays
+                item["_flicklist_watched_show"] = True
+                key = key_of(item)
+                if not key:
+                    skipped += 1
+                    continue
+                base = key.split("@", 1)[0].lower()
+                if base in existing_bases or key in out:
+                    skipped += 1
+                    continue
+                out[key] = item
+                existing_bases.add(base)
+                added += 1
+    _info(FEATURE, "watched_shows_supplement_done", added=added, skipped=skipped)
+    return added, skipped
+
+
+def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
+    section = cfg_section(adapter) or {}
+    per_page = max(1, min(cfg_int(section, "history_per_page", HISTORY_PAGE_DEFAULT), HISTORY_PAGE_MAX))
+    max_pages = max(1, cfg_int(section, "history_max_pages", 500))
+    out: dict[str, dict[str, Any]] = {}
+    skipped = 0
+    page = 1
+    while page <= max_pages:
+        resp = flicklist_request(adapter, "GET", URL_HISTORY, params={"page": page, "limit": per_page})
+        if not ok_status(resp):
+            _warn(FEATURE, "index_failed", page=page, status=int(resp.status_code), error=error_of(resp))
+            break
+        data = safe_json(resp)
+        rows = _rows(data)
+        if not rows:
+            if page == 1:
+                _dbg(FEATURE, "index_empty_response", **read_shape(resp, data))
+            break
+        for row in rows:
+            if not isinstance(row, Mapping):
+                skipped += 1
+                continue
+            item = _row_to_minimal(row)
+            if not item:
+                skipped += 1
+                continue
+            key = event_key(item)
+            if not key:
+                skipped += 1
+                continue
+            if key in out:
+                suffix = str(item.get("_flicklist_history_id") or len(out))
+                key = f"{key}~fl{suffix}"
+            out[key] = item
+        if page >= _response_page_count(resp, data, page):
+            break
+        page += 1
+    if not any((item.get("type") == "movie") for item in out.values()):
+        added, extra_skipped = _supplement_watched_movies(adapter, out)
+        skipped += extra_skipped
+        if added:
+            _info(FEATURE, "index_movie_snapshot_supplemented", count=added)
+    if not any((item.get("type") == "episode") for item in out.values()):
+        added, extra_skipped = _supplement_watched_shows(adapter, out)
+        skipped += extra_skipped
+        if added:
+            _info(FEATURE, "index_show_snapshot_supplemented", count=added)
+    _info(FEATURE, "index_done", count=len(out), skipped=skipped, pages=page)
+    return out
+
+
+def _accepted(items: Iterable[Mapping[str, Any]], *, include_watched_at: bool) -> tuple[list[tuple[str, dict[str, Any]]], list[str], list[dict[str, Any]]]:
+    accepted: list[tuple[str, dict[str, Any]]] = []
+    unresolved_keys: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in items or []:
+        key = str(raw.get("_cw_event_key") or "").strip() or event_key(raw) or key_of(raw)
+        payload = write_ident(raw)
+        if not key or payload is None:
+            if key:
+                unresolved_keys.append(key)
+                unresolved.append({"key": key, "status": "missing_supported_id"})
+            continue
+        if payload.get("media_type") == "show" and payload.get("season") is None:
+            unresolved_keys.append(key)
+            unresolved.append({"key": key, "status": "unsupported_media_type"})
+            continue
+        if include_watched_at:
+            payload["watched_at"] = not_future(iso_z(raw.get("watched_at"))) or now_iso()
+        if key in seen:
+            continue
+        seen.add(key)
+        accepted.append((key, payload))
+    return accepted, unresolved_keys, unresolved
+
+
+def _write(adapter: Any, method: str, items: Iterable[Mapping[str, Any]], *, include_watched_at: bool, dry_run: bool = False) -> dict[str, Any]:
+    accepted, unresolved_keys, unresolved = _accepted(items, include_watched_at=include_watched_at)
+    confirmed: list[str] = []
+    ok = True
+    if dry_run:
+        return {"ok": True, "count": len(accepted), "confirmed_keys": [k for k, _ in accepted], "unresolved_keys": unresolved_keys, "unresolved": unresolved}
+    totals: list[dict[str, Any]] = []
+    sampled = False
+    batch_size = write_batch_size(adapter, FEATURE)
+    for batch in chunk([{"key": k, "payload": p} for k, p in accepted], batch_size):
+        sent = [(str(row["key"]), row["payload"]) for row in batch]
+        if not sampled:
+            sampled = True
+            _dbg(FEATURE, "write_payload_sample", method=method, batch=len(sent), sample=json.dumps([p for _k, p in sent[:3]], sort_keys=True))
+        resp = flicklist_request(adapter, method, URL_HISTORY, json={"items": [p for _k, p in sent]})
+        if ok_status(resp):
+            body = safe_json(resp)
+            if not has_write_counters(body, method):
+                ok = False
+                for key, _payload in sent:
+                    unresolved_keys.append(key)
+                    unresolved.append({"key": key, "status": "invalid_response", "error": "missing FlickList write counters"})
+                _warn(FEATURE, "write_invalid_response", method=method, status=int(resp.status_code), count=len(sent))
+                continue
+            yes, misses, miss_rows, counters = classify_write(sent, body, method=method)
+            totals.append(counters)
+            if misses:
+                ok = False
+                _warn(FEATURE, "write_partial", method=method, sent=len(sent), confirmed=len(yes), unresolved=len(misses), **counters)
+            confirmed.extend(yes)
+            unresolved_keys.extend(misses)
+            unresolved.extend(miss_rows)
+            continue
+        ok = False
+        for key, _payload in sent:
+            unresolved_keys.append(key)
+            unresolved.append({"key": key, "status": f"http:{int(resp.status_code)}", "error": error_of(resp)})
+        _warn(FEATURE, "write_failed", method=method, status=int(resp.status_code), error=error_of(resp))
+    _info(FEATURE, "write_done", action=method.lower(), sent=len(accepted), confirmed=len(confirmed), unresolved=len(unresolved_keys), dry_run=bool(dry_run), **_sum_counters(totals))
+    return {"ok": ok, "count": len(confirmed), "confirmed_keys": confirmed, "unresolved_keys": unresolved_keys, "unresolved": unresolved}
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, "POST", items, include_watched_at=True, dry_run=dry_run)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, "DELETE", items, include_watched_at=False, dry_run=dry_run)

--- a/providers/sync/flicklist/_playlists.py
+++ b/providers/sync/flicklist/_playlists.py
@@ -1,0 +1,243 @@
+# CrossWatch - FlickList playlist sync
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from cw_platform.playlists import PLAYLIST_KIND_REGULAR, PLAYLIST_KIND_SMART, PlaylistItem, PlaylistResource, PlaylistSnapshot
+
+from ._common import (
+    URL_LIST,
+    URL_LISTS,
+    URL_LIST_ITEMS,
+    chunk,
+    classify_write,
+    error_of,
+    flicklist_request,
+    header_int,
+    key_of,
+    ok_status,
+    read_minimal,
+    safe_json,
+    write_ident,
+    write_batch_size,
+    _info,
+    _warn,
+)
+
+FEATURE = "playlists"
+MEDIA_TYPES = ("movie", "show", "episode")
+
+
+class FlickListPlaylistError(RuntimeError):
+    pass
+
+
+class FlickListPlaylistNotFound(FlickListPlaylistError):
+    pass
+
+
+def _instance_id(adapter: Any) -> str:
+    return str(getattr(adapter, "instance_id", None) or "default")
+
+
+def _rows(data: Any) -> list[Any]:
+    if isinstance(data, list):
+        return data
+    if isinstance(data, Mapping):
+        for key in ("items", "data", "results", "lists"):
+            value = data.get(key)
+            if isinstance(value, list):
+                return value
+    return []
+
+
+def _header_page_count(resp: Any, current: int) -> int:
+    page_count = header_int(resp, "X-FlickList-Page-Count")
+    return max(current, page_count) if page_count is not None else current
+
+
+def _resource_from_row(adapter: Any, row: Mapping[str, Any]) -> PlaylistResource | None:
+    raw_id = str(row.get("id") or row.get("list_id") or "").strip()
+    if not raw_id:
+        return None
+    is_smart = bool(row.get("is_smart") or row.get("smart") or str(row.get("type") or "").lower() == "smart")
+    name = str(row.get("name") or row.get("title") or raw_id).strip()
+    return PlaylistResource(
+        provider="FLICKLIST",
+        id=raw_id,
+        name=name,
+        instance=_instance_id(adapter),
+        kind=PLAYLIST_KIND_SMART if is_smart else PLAYLIST_KIND_REGULAR,
+        can_read=True,
+        can_add=not is_smart,
+        can_remove=not is_smart,
+        can_reorder=False,
+        media_types=MEDIA_TYPES,
+        extra={
+            "raw_id": raw_id,
+            "description": str(row.get("description") or "").strip(),
+            "item_count": row.get("item_count") or row.get("items_count") or row.get("count"),
+            "type": str(row.get("type") or "").strip().lower(),
+        },
+    )
+
+
+def list_resources(adapter: Any) -> list[PlaylistResource]:
+    resp = flicklist_request(adapter, "GET", URL_LISTS)
+    if not ok_status(resp):
+        _warn(FEATURE, "list_resources_failed", status=int(resp.status_code), error=error_of(resp))
+        return []
+    out = [_resource_from_row(adapter, row) for row in _rows(safe_json(resp)) if isinstance(row, Mapping)]
+    resources = [res for res in out if res is not None]
+    _info(FEATURE, "list_resources_done", count=len(resources))
+    return resources
+
+
+def _find_resource(adapter: Any, playlist_id: Any) -> PlaylistResource | None:
+    lid = str(playlist_id or "").strip()
+    if not lid:
+        return None
+    for resource in list_resources(adapter):
+        if resource.id == lid:
+            return resource
+    return None
+
+
+def _item_from_row(row: Mapping[str, Any]) -> PlaylistItem | None:
+    media = read_minimal(row, default_type=row.get("media_type") or row.get("type") or "movie")
+    if not media:
+        return None
+    key = canonical_key(media)
+    if not key:
+        return None
+    item_id = str(row.get("id") or row.get("item_id") or row.get("list_item_id") or "").strip() or None
+    return PlaylistItem.from_media(media, playlist_item_id=item_id, provider_media_id=str(row.get("fldb") or media.get("_flicklist_fldb") or ""))
+
+
+def get_snapshot(adapter: Any, playlist_id: Any) -> PlaylistSnapshot:
+    lid = str(playlist_id or "").strip()
+    if not lid:
+        raise FlickListPlaylistNotFound("missing flicklist list id")
+    resource = _find_resource(adapter, lid) or PlaylistResource(
+        provider="FLICKLIST",
+        id=lid,
+        name=lid,
+        instance=_instance_id(adapter),
+        kind=PLAYLIST_KIND_REGULAR,
+        can_read=True,
+        can_add=True,
+        can_remove=True,
+        can_reorder=False,
+        media_types=MEDIA_TYPES,
+        extra={"raw_id": lid},
+    )
+    items: list[PlaylistItem] = []
+    page = 1
+    while True:
+        resp = flicklist_request(adapter, "GET", URL_LIST_ITEMS.format(id=lid), params={"page": page, "limit": 100})
+        if not ok_status(resp):
+            raise FlickListPlaylistError(error_of(resp) or f"http:{int(resp.status_code)}")
+        items.extend(item for item in (_item_from_row(row) for row in _rows(safe_json(resp)) if isinstance(row, Mapping)) if item is not None)
+        if page >= _header_page_count(resp, page):
+            break
+        page += 1
+    _info(FEATURE, "snapshot_done", list_id=lid, count=len(items))
+    return PlaylistSnapshot(resource=resource, items=items, checkpoint=None)
+
+
+def create(
+    adapter: Any,
+    name: str,
+    *,
+    media_type: str | None = None,
+    items: Sequence[Mapping[str, Any]] | None = None,
+    dry_run: bool = False,
+) -> PlaylistResource:
+    nm = str(name or "").strip()
+    if not nm:
+        raise ValueError("playlist name required")
+    if dry_run:
+        return PlaylistResource(provider="FLICKLIST", id="", name=nm, instance=_instance_id(adapter), can_add=True, can_remove=True, media_types=MEDIA_TYPES)
+    resp = flicklist_request(adapter, "POST", URL_LISTS, json={"name": nm})
+    if not ok_status(resp):
+        raise FlickListPlaylistError(error_of(resp) or f"http:{int(resp.status_code)}")
+    data = safe_json(resp)
+    row = data.get("list") if isinstance(data, Mapping) and isinstance(data.get("list"), Mapping) else data
+    resource = _resource_from_row(adapter, row if isinstance(row, Mapping) else {})
+    if resource is None:
+        raise FlickListPlaylistError("flicklist create list returned no id")
+    if items:
+        add(adapter, resource.id, items)
+    _info(FEATURE, "create_done", list_id=resource.id, name=resource.name)
+    return resource
+
+
+def _accepted(items: Sequence[Mapping[str, Any]]) -> tuple[list[tuple[str, dict[str, Any]]], list[dict[str, Any]]]:
+    accepted: list[tuple[str, dict[str, Any]]] = []
+    unresolved: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in items or []:
+        media = id_minimal(raw)
+        key = key_of(media)
+        payload = write_ident(media)
+        if not key or payload is None:
+            unresolved.append({"item": media, "hint": "missing_supported_id"})
+            continue
+        if key in seen:
+            continue
+        seen.add(key)
+        accepted.append((key, payload))
+    return accepted, unresolved
+
+
+def _write_items(adapter: Any, method: str, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    lid = str(playlist_id or "").strip()
+    if not lid:
+        raise FlickListPlaylistNotFound("missing flicklist list id")
+    accepted, unresolved = _accepted(items)
+    confirmed: list[str] = []
+    unresolved_keys: list[str] = []
+    ok = True
+    if not accepted:
+        return {"ok": True, "count": 0, "confirmed_keys": confirmed, "unresolved_keys": unresolved_keys, "unresolved": unresolved}
+    for batch in chunk([{"key": k, "payload": p} for k, p in accepted], write_batch_size(adapter, FEATURE)):
+        sent = [(str(row["key"]), row["payload"]) for row in batch]
+        resp = flicklist_request(adapter, method, URL_LIST_ITEMS.format(id=lid), json={"items": [payload for _key, payload in sent]})
+        if ok_status(resp):
+            yes, misses, miss_rows, counters = classify_write(sent, safe_json(resp), method=method)
+            if misses:
+                ok = False
+                _warn(FEATURE, "write_items_partial", method=method, list_id=lid, sent=len(sent), confirmed=len(yes), unresolved=len(misses), **counters)
+            confirmed.extend(yes)
+            unresolved_keys.extend(misses)
+            unresolved.extend({"item": {"key": row.get("key")}, "hint": row.get("status")} for row in miss_rows)
+        else:
+            ok = False
+            for key, _payload in sent:
+                unresolved_keys.append(key)
+                unresolved.append({"item": {"key": key}, "hint": f"http:{int(resp.status_code)}", "error": error_of(resp)})
+            _warn(FEATURE, "write_items_failed", method=method, list_id=lid, status=int(resp.status_code), error=error_of(resp))
+    _info(FEATURE, "write_items_done", method=method.lower(), list_id=lid, confirmed=len(confirmed), unresolved=len(unresolved_keys))
+    return {"ok": ok, "count": len(confirmed), "confirmed_keys": confirmed, "unresolved_keys": unresolved_keys, "unresolved": unresolved}
+
+
+def add(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    return _write_items(adapter, "POST", playlist_id, items)
+
+
+def remove(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    return _write_items(adapter, "DELETE", playlist_id, items)
+
+
+def delete(adapter: Any, playlist_id: Any) -> dict[str, Any]:
+    lid = str(playlist_id or "").strip()
+    if not lid:
+        raise FlickListPlaylistNotFound("missing flicklist list id")
+    resp = flicklist_request(adapter, "DELETE", URL_LIST.format(id=lid))
+    return {"ok": ok_status(resp) or int(resp.status_code) == 404, "status": int(resp.status_code)}
+
+
+def reorder(adapter: Any, playlist_id: Any, ordered_keys: Sequence[str]) -> dict[str, Any]:
+    return {"ok": True, "count": 0, "reordered": 0, "unsupported": True}

--- a/providers/sync/flicklist/_progress.py
+++ b/providers/sync/flicklist/_progress.py
@@ -1,0 +1,131 @@
+# CrossWatch - FlickList playback progress sync
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from ._common import (
+    URL_PLAYBACK,
+    URL_PLAYBACK_ITEM,
+    error_of,
+    flicklist_request,
+    key_of,
+    ok_status,
+    percent_of,
+    read_minimal,
+    safe_json,
+    write_ident,
+    _info,
+    _warn,
+)
+
+FEATURE = "progress"
+
+
+def _rows(data: Any) -> list[Any]:
+    if isinstance(data, list):
+        return data
+    if isinstance(data, Mapping):
+        for key in ("items", "data", "results", "playback"):
+            value = data.get(key)
+            if isinstance(value, list):
+                return value
+    return []
+
+
+def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
+    resp = flicklist_request(adapter, "GET", URL_PLAYBACK)
+    if not ok_status(resp):
+        _warn(FEATURE, "index_failed", status=int(resp.status_code), error=error_of(resp))
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    skipped = 0
+    for row in _rows(safe_json(resp)):
+        if not isinstance(row, Mapping):
+            skipped += 1
+            continue
+        item = read_minimal(row, default_type=row.get("media_type") or "movie")
+        if not item:
+            skipped += 1
+            continue
+        pct = percent_of({"progress_percent": row.get("progress")})
+        if pct is not None:
+            item["progress_percent"] = pct
+        updated = row.get("updated_at")
+        if updated:
+            item["progress_at"] = updated
+            item["progress_at_source"] = "flicklist"
+        rid = str(row.get("id") or "").strip()
+        if rid:
+            item["_flicklist_playback_id"] = rid
+        key = key_of(item)
+        if key:
+            out[key] = item
+        else:
+            skipped += 1
+    _info(FEATURE, "index_done", count=len(out), skipped=skipped)
+    return out
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    confirmed: list[str] = []
+    unresolved_keys: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    ok = True
+    for raw in items or []:
+        key = key_of(raw)
+        payload = write_ident(raw)
+        pct = percent_of(raw)
+        if not key or payload is None or pct is None:
+            if key:
+                unresolved_keys.append(key)
+                unresolved.append({"key": key, "status": "missing_progress_or_supported_id"})
+            continue
+        payload["progress"] = pct
+        if raw.get("paused") is not None:
+            payload["paused"] = bool(raw.get("paused"))
+        if dry_run:
+            confirmed.append(key)
+            continue
+        resp = flicklist_request(adapter, "POST", URL_PLAYBACK, json=payload)
+        if ok_status(resp):
+            confirmed.append(key)
+            continue
+        ok = False
+        unresolved_keys.append(key)
+        unresolved.append({"key": key, "status": f"http:{int(resp.status_code)}", "error": error_of(resp)})
+        _warn(FEATURE, "write_failed", action="add", key=key, status=int(resp.status_code), error=error_of(resp))
+    _info(FEATURE, "write_done", action="add", confirmed=len(confirmed), unresolved=len(unresolved_keys), dry_run=bool(dry_run))
+    return {"ok": ok, "count": len(confirmed), "confirmed_keys": confirmed, "unresolved_keys": unresolved_keys, "unresolved": unresolved}
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    current = None if dry_run else build_index(adapter)
+    confirmed: list[str] = []
+    unresolved_keys: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    ok = True
+    for raw in items or []:
+        key = key_of(raw)
+        playback_id = str(raw.get("_flicklist_playback_id") or "").strip()
+        if not playback_id and current is not None and key:
+            playback_id = str((current.get(key) or {}).get("_flicklist_playback_id") or "").strip()
+        if not key:
+            continue
+        if dry_run:
+            confirmed.append(key)
+            continue
+        if not playback_id:
+            unresolved_keys.append(key)
+            unresolved.append({"key": key, "status": "missing_remote_playback_id"})
+            continue
+        resp = flicklist_request(adapter, "DELETE", URL_PLAYBACK_ITEM.format(id=playback_id))
+        if ok_status(resp) or int(resp.status_code) == 404:
+            confirmed.append(key)
+            continue
+        ok = False
+        unresolved_keys.append(key)
+        unresolved.append({"key": key, "status": f"http:{int(resp.status_code)}", "error": error_of(resp)})
+        _warn(FEATURE, "write_failed", action="remove", key=key, status=int(resp.status_code), error=error_of(resp))
+    _info(FEATURE, "write_done", action="remove", confirmed=len(confirmed), unresolved=len(unresolved_keys), dry_run=bool(dry_run))
+    return {"ok": ok, "count": len(confirmed), "confirmed_keys": confirmed, "unresolved_keys": unresolved_keys, "unresolved": unresolved}

--- a/providers/sync/flicklist/_ratings.py
+++ b/providers/sync/flicklist/_ratings.py
@@ -1,0 +1,143 @@
+# CrossWatch - FlickList ratings sync
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from ._common import (
+    URL_RATINGS,
+    chunk,
+    classify_write,
+    error_of,
+    flicklist_request,
+    has_write_counters,
+    half_point,
+    key_of,
+    not_future,
+    ok_status,
+    read_minimal,
+    safe_json,
+    write_ident,
+    write_batch_size,
+    _info,
+    _warn,
+)
+
+FEATURE = "ratings"
+
+
+def _rows(data: Any) -> list[Any]:
+    if isinstance(data, list):
+        return data
+    if isinstance(data, Mapping):
+        for key in ("items", "data", "results", "ratings"):
+            value = data.get(key)
+            if isinstance(value, list):
+                return value
+    return []
+
+
+def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
+    resp = flicklist_request(adapter, "GET", URL_RATINGS)
+    if not ok_status(resp):
+        _warn(FEATURE, "index_failed", status=int(resp.status_code), error=error_of(resp))
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    skipped = 0
+    for row in _rows(safe_json(resp)):
+        if not isinstance(row, Mapping):
+            skipped += 1
+            continue
+        item = read_minimal(row, default_type=row.get("media_type") or "movie")
+        if not item:
+            skipped += 1
+            continue
+        rating = half_point(row.get("rating"))
+        if rating is None:
+            skipped += 1
+            continue
+        item["rating"] = rating
+        rated_at = row.get("rated_at")
+        if rated_at:
+            item["rated_at"] = rated_at
+        key = key_of(item)
+        if key:
+            out[key] = item
+        else:
+            skipped += 1
+    _info(FEATURE, "index_done", count=len(out), skipped=skipped)
+    return out
+
+
+def _accepted(items: Iterable[Mapping[str, Any]], *, include_rating: bool) -> tuple[list[tuple[str, dict[str, Any]]], list[str], list[dict[str, Any]]]:
+    accepted: list[tuple[str, dict[str, Any]]] = []
+    unresolved_keys: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in items or []:
+        key = key_of(raw)
+        payload = write_ident(raw)
+        if not key or payload is None:
+            if key:
+                unresolved_keys.append(key)
+                unresolved.append({"key": key, "status": "missing_supported_id"})
+            continue
+        if include_rating:
+            rating = half_point(raw.get("rating"))
+            if rating is None:
+                unresolved_keys.append(key)
+                unresolved.append({"key": key, "status": "invalid_rating"})
+                continue
+            payload["rating"] = rating
+            rated_at = not_future(str(raw.get("rated_at") or "").strip() or None)
+            if rated_at:
+                payload["rated_at"] = rated_at
+        if key in seen:
+            continue
+        seen.add(key)
+        accepted.append((key, payload))
+    return accepted, unresolved_keys, unresolved
+
+
+def _write(adapter: Any, method: str, items: Iterable[Mapping[str, Any]], *, include_rating: bool, dry_run: bool = False) -> dict[str, Any]:
+    accepted, unresolved_keys, unresolved = _accepted(items, include_rating=include_rating)
+    confirmed: list[str] = []
+    ok = True
+    if dry_run:
+        return {"ok": True, "count": len(accepted), "confirmed_keys": [k for k, _ in accepted], "unresolved_keys": unresolved_keys, "unresolved": unresolved}
+    batch_size = write_batch_size(adapter, FEATURE)
+    for batch in chunk([{"key": k, "payload": p} for k, p in accepted], batch_size):
+        sent = [(str(row["key"]), row["payload"]) for row in batch]
+        resp = flicklist_request(adapter, method, URL_RATINGS, json={"items": [p for _k, p in sent]})
+        if ok_status(resp):
+            body = safe_json(resp)
+            if not has_write_counters(body, method):
+                ok = False
+                for key, _payload in sent:
+                    unresolved_keys.append(key)
+                    unresolved.append({"key": key, "status": "invalid_response", "error": "missing FlickList write counters"})
+                _warn(FEATURE, "write_invalid_response", method=method, status=int(resp.status_code), count=len(sent))
+                continue
+            yes, misses, miss_rows, counters = classify_write(sent, body, method=method)
+            if misses:
+                ok = False
+                _warn(FEATURE, "write_partial", method=method, sent=len(sent), confirmed=len(yes), unresolved=len(misses), **counters)
+            confirmed.extend(yes)
+            unresolved_keys.extend(misses)
+            unresolved.extend(miss_rows)
+            continue
+        ok = False
+        for key, _payload in sent:
+            unresolved_keys.append(key)
+            unresolved.append({"key": key, "status": f"http:{int(resp.status_code)}", "error": error_of(resp)})
+        _warn(FEATURE, "write_failed", method=method, status=int(resp.status_code), error=error_of(resp))
+    _info(FEATURE, "write_done", action=method.lower(), sent=len(accepted), confirmed=len(confirmed), unresolved=len(unresolved_keys), dry_run=bool(dry_run))
+    return {"ok": ok, "count": len(confirmed), "confirmed_keys": confirmed, "unresolved_keys": unresolved_keys, "unresolved": unresolved}
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, "POST", items, include_rating=True, dry_run=dry_run)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, "DELETE", items, include_rating=False, dry_run=dry_run)

--- a/providers/sync/flicklist/_watchlist.py
+++ b/providers/sync/flicklist/_watchlist.py
@@ -1,0 +1,141 @@
+# CrossWatch - FlickList watchlist sync
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from ._common import (
+    URL_WATCHLIST,
+    chunk,
+    classify_write,
+    error_of,
+    flicklist_request,
+    has_write_counters,
+    key_of,
+    ok_status,
+    read_minimal,
+    safe_json,
+    write_ident,
+    write_batch_size,
+    _info,
+    _warn,
+)
+
+FEATURE = "watchlist"
+
+
+def _rows(data: Any) -> list[Any]:
+    if isinstance(data, list):
+        return data
+    if isinstance(data, Mapping):
+        for key in ("items", "data", "results", "watchlist"):
+            value = data.get(key)
+            if isinstance(value, list):
+                return value
+    return []
+
+
+def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
+    resp = flicklist_request(adapter, "GET", URL_WATCHLIST)
+    if not ok_status(resp):
+        _warn(FEATURE, "index_failed", status=int(resp.status_code), error=error_of(resp))
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    skipped = 0
+    for row in _rows(safe_json(resp)):
+        if not isinstance(row, Mapping):
+            skipped += 1
+            continue
+        item = read_minimal(row, default_type=row.get("media_type") or "movie")
+        if not item:
+            skipped += 1
+            continue
+        added_at = row.get("added_at")
+        if added_at:
+            item["added_at"] = added_at
+        status = str(row.get("status") or "").strip()
+        if status:
+            item["watchlist_status"] = status
+        raw_progress = row.get("progress")
+        if raw_progress is not None:
+            try:
+                progress = float(raw_progress)
+                if 0.0 <= progress <= 1.0:
+                    item["progress_percent"] = progress * 100.0
+            except Exception:
+                pass
+        key = key_of(item)
+        if key:
+            out[key] = item
+        else:
+            skipped += 1
+    _info(FEATURE, "index_done", count=len(out), skipped=skipped)
+    return out
+
+
+def _accepted(items: Iterable[Mapping[str, Any]]) -> tuple[list[tuple[str, dict[str, Any]]], list[str], list[dict[str, Any]]]:
+    accepted: list[tuple[str, dict[str, Any]]] = []
+    unresolved_keys: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in items or []:
+        key = key_of(raw)
+        payload = write_ident(raw)
+        if not key or payload is None:
+            if key:
+                unresolved_keys.append(key)
+                unresolved.append({"key": key, "status": "missing_supported_id"})
+            continue
+        if payload.get("season") is not None or payload.get("episode") is not None:
+            unresolved_keys.append(key)
+            unresolved.append({"key": key, "status": "unsupported_media_type"})
+            continue
+        if key in seen:
+            continue
+        seen.add(key)
+        accepted.append((key, payload))
+    return accepted, unresolved_keys, unresolved
+
+
+def _write(adapter: Any, method: str, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    accepted, unresolved_keys, unresolved = _accepted(items)
+    confirmed: list[str] = []
+    ok = True
+    if dry_run:
+        return {"ok": True, "count": len(accepted), "confirmed_keys": [k for k, _ in accepted], "unresolved_keys": unresolved_keys, "unresolved": unresolved}
+    batch_size = write_batch_size(adapter, FEATURE)
+    for batch in chunk([{"key": k, "payload": p} for k, p in accepted], batch_size):
+        sent = [(str(row["key"]), row["payload"]) for row in batch]
+        resp = flicklist_request(adapter, method, URL_WATCHLIST, json={"items": [p for _k, p in sent]})
+        if ok_status(resp):
+            body = safe_json(resp)
+            if not has_write_counters(body, method):
+                ok = False
+                for key, _payload in sent:
+                    unresolved_keys.append(key)
+                    unresolved.append({"key": key, "status": "invalid_response", "error": "missing FlickList write counters"})
+                _warn(FEATURE, "write_invalid_response", method=method, status=int(resp.status_code), count=len(sent))
+                continue
+            yes, misses, miss_rows, counters = classify_write(sent, body, method=method)
+            if misses:
+                ok = False
+                _warn(FEATURE, "write_partial", method=method, sent=len(sent), confirmed=len(yes), unresolved=len(misses), **counters)
+            confirmed.extend(yes)
+            unresolved_keys.extend(misses)
+            unresolved.extend(miss_rows)
+            continue
+        ok = False
+        for key, _payload in sent:
+            unresolved_keys.append(key)
+            unresolved.append({"key": key, "status": f"http:{int(resp.status_code)}", "error": error_of(resp)})
+        _warn(FEATURE, "write_failed", method=method, status=int(resp.status_code), error=error_of(resp))
+    _info(FEATURE, "write_done", action=method.lower(), sent=len(accepted), confirmed=len(confirmed), unresolved=len(unresolved_keys), dry_run=bool(dry_run))
+    return {"ok": ok, "count": len(confirmed), "confirmed_keys": confirmed, "unresolved_keys": unresolved_keys, "unresolved": unresolved}
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, "POST", items, dry_run=dry_run)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    return _write(adapter, "DELETE", items, dry_run=dry_run)

--- a/tests/test_flicklist_provider.py
+++ b/tests/test_flicklist_provider.py
@@ -1,0 +1,716 @@
+# CrossWatch FlickList provider tests
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+
+class _Resp:
+    def __init__(self, status_code: int = 200, payload: Any = None, headers: dict[str, str] | None = None) -> None:
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = json.dumps(self._payload)
+        self.headers: dict[str, str] = dict(headers or {})
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class Event:
+    def __init__(self, **kw: Any) -> None:
+        self.action = kw.get("action", "start")
+        self.media_type = kw.get("media_type", "movie")
+        self.ids = kw.get("ids", {"tmdb": "550", "imdb": "tt0137523"})
+        self.title = kw.get("title", "Fight Club")
+        self.year = kw.get("year", 1999)
+        self.season = kw.get("season")
+        self.number = kw.get("number")
+        self.progress = kw.get("progress", 10.0)
+        self.account = kw.get("account", "user@example.com")
+        self.server_uuid = kw.get("server_uuid", "srv-1")
+        self.session_key = kw.get("session_key", "sess-1")
+        self.raw = kw.get("raw", {})
+        self.position_ms = kw.get("position_ms")
+        self.duration_ms = kw.get("duration_ms")
+
+
+CFG = {
+    "flicklist": {"api_key": "fs_live_test"},
+    "scrobble": {"watch": {"watched_at": 90}},
+}
+
+
+def test_sync_manifest_is_dormant_while_scrobble_remains_available() -> None:
+    from providers.sync._mod_FLICKLIST import OPS, get_manifest
+
+    manifest = dict(get_manifest())
+    features = dict(manifest["features"])
+    caps = dict(manifest["capabilities"])
+
+    assert manifest["name"] == "FLICKLIST"
+    assert manifest["version"] == "0.1"
+    assert manifest["disabled"] is True
+    assert features == {"watchlist": False, "ratings": False, "history": False, "progress": False, "playlists": False}
+    assert OPS.features() == features
+    assert caps["watchlist"]["write"] is False
+    assert caps["ratings"]["write"] is False
+    assert caps["ratings"]["remove"] is False
+    assert caps["history"]["write"] is False
+    assert caps["history"]["remove"] is False
+    assert caps["progress"]["read"] is False
+    assert caps["progress"]["upsert"] is False
+    assert caps["playlists"]["create"] is False
+    assert caps["scrobble"]["write"] is True
+
+
+def test_flicklist_is_not_registered_as_sync_provider() -> None:
+    from cw_platform.modules_registry import MODULES
+
+    assert "_mod_FLICKLIST" not in MODULES["SYNC"]
+
+
+def test_device_code_uses_built_in_public_client_id() -> None:
+    from providers.auth import _auth_FLICKLIST as auth
+
+    assert auth.app_client_id({}) == "crosswatch_923f4294"
+
+
+def test_common_helpers_preserve_flicklist_ids() -> None:
+    from providers.sync.flicklist._common import half_point, read_minimal, write_ident
+
+    item = read_minimal({"media_type": "movie", "title": "Fight Club", "ids": {"fldb": "fl_123", "tmdb": 550}})
+
+    assert item["_flicklist_fldb"] == "fl_123"
+    assert item["ids"]["tmdb"] == "550"
+    assert write_ident(item) == {"ids": {"fldb": "fl_123"}, "media_type": "movie"}
+    assert half_point(7.26) == 7.5
+
+
+def test_episode_write_ident_uses_show_ids() -> None:
+    from providers.sync.flicklist._common import write_ident
+
+    item = {
+        "type": "episode",
+        "title": "Episode",
+        "series_title": "Ted Lasso",
+        "season": 2,
+        "episode": 4,
+        "ids": {"tmdb": "3089818", "imdb": "tt14968638", "tvdb": "8554003"},
+        "show_ids": {"tmdb": "97546", "imdb": "tt10986410", "tvdb": "383203"},
+    }
+
+    assert write_ident(item) == {
+        "ids": {"tmdb": 97546, "imdb": "tt10986410", "tvdb": 383203},
+        "media_type": "show",
+        "season": 2,
+        "episode": 4,
+    }
+
+
+def test_episode_write_ident_without_show_ids_is_unresolved() -> None:
+    from providers.sync.flicklist._common import write_ident
+
+    item = {
+        "type": "episode",
+        "season": 1,
+        "episode": 1,
+        "ids": {"tmdb": "2181581", "imdb": "tt11957006", "tvdb": "8444132"},
+    }
+
+    assert write_ident(item) is None
+
+
+def test_history_add_sends_episode_payload_with_show_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.flicklist import _history as history
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(history, "flicklist_request", lambda adapter, method, url, **kwargs: calls.append({"method": method, "url": url, **kwargs}) or _Resp(200, {"added": 1}))
+
+    item = {
+        "type": "episode",
+        "season": 1,
+        "episode": 1,
+        "watched_at": "2026-08-21T20:00:00.000Z",
+        "ids": {"tmdb": "2181581", "imdb": "tt11957006", "tvdb": "8444132"},
+        "show_ids": {"tmdb": "100088", "imdb": "tt3581920", "tvdb": "392256"},
+    }
+
+    res = history.add(object(), [item])
+
+    assert res["count"] == 1
+    assert calls[0]["json"]["items"] == [{
+        "ids": {"tmdb": 100088, "imdb": "tt3581920", "tvdb": 392256},
+        "media_type": "show",
+        "season": 1,
+        "episode": 1,
+        "watched_at": "2026-08-21T20:00:00.000Z",
+    }]
+
+
+def test_history_add_rejects_success_status_without_write_counters(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.flicklist import _history as history
+
+    monkeypatch.setattr(history, "flicklist_request", lambda adapter, method, url, **kwargs: _Resp(200, {"ok": True}))
+
+    res = history.add(object(), [{
+        "type": "movie",
+        "title": "Fight Club",
+        "watched_at": "2026-08-21T20:00:00.000Z",
+        "ids": {"tmdb": "550"},
+    }])
+
+    assert res["ok"] is False
+    assert res["count"] == 0
+    assert res["unresolved"][0]["status"] == "invalid_response"
+
+
+def test_history_add_uses_configured_flicklist_write_batch_size(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.flicklist import _history as history
+
+    class Adapter:
+        config = {"flicklist": {"write_batch_size": 100}}
+
+    sizes: list[int] = []
+
+    def fake_request(adapter: Any, method: str, url: str, **kwargs: Any) -> _Resp:
+        items = list((kwargs.get("json") or {}).get("items") or [])
+        sizes.append(len(items))
+        return _Resp(200, {"added": len(items), "not_found": []})
+
+    monkeypatch.setattr(history, "flicklist_request", fake_request)
+
+    items = [
+        {
+            "type": "movie",
+            "title": f"Movie {idx}",
+            "watched_at": "2026-08-21T20:00:00.000Z",
+            "ids": {"tmdb": str(100000 + idx)},
+        }
+        for idx in range(205)
+    ]
+
+    res = history.add(Adapter(), items)
+
+    assert sizes == [100, 100, 5]
+    assert res["count"] == 205
+
+
+def test_ratings_and_progress_episode_payloads_use_show_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.flicklist import _progress as progress
+    from providers.sync.flicklist import _ratings as ratings
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_request(adapter: Any, method: str, url: str, **kwargs: Any) -> _Resp:
+        calls.append({"method": method, "url": url, **kwargs})
+        return _Resp(200, {"added": 1})
+
+    monkeypatch.setattr(ratings, "flicklist_request", fake_request)
+    monkeypatch.setattr(progress, "flicklist_request", fake_request)
+
+    item = {
+        "type": "episode",
+        "season": 2,
+        "episode": 4,
+        "rating": 8,
+        "progress_percent": 42.5,
+        "ids": {"tmdb": "3089818", "imdb": "tt14968638", "tvdb": "8554003"},
+        "show_ids": {"tmdb": "97546", "imdb": "tt10986410", "tvdb": "383203"},
+    }
+
+    assert ratings.add(object(), [item])["count"] == 1
+    assert progress.add(object(), [item])["count"] == 1
+    assert calls[0]["json"]["items"] == [{
+        "ids": {"tmdb": 97546, "imdb": "tt10986410", "tvdb": 383203},
+        "media_type": "show",
+        "season": 2,
+        "episode": 4,
+        "rating": 8.0,
+    }]
+    assert calls[1]["json"] == {
+        "ids": {"tmdb": 97546, "imdb": "tt10986410", "tvdb": 383203},
+        "media_type": "show",
+        "season": 2,
+        "episode": 4,
+        "progress": 42.5,
+    }
+
+
+def test_watchlist_rejects_episode_items_before_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.flicklist import _watchlist as watchlist
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(watchlist, "flicklist_request", lambda adapter, method, url, **kwargs: calls.append(kwargs) or _Resp(200, {}))
+
+    item = {
+        "type": "episode",
+        "season": 1,
+        "episode": 1,
+        "ids": {"tmdb": "2181581"},
+        "show_ids": {"tmdb": "100088"},
+    }
+
+    res = watchlist.add(object(), [item])
+
+    assert calls == []
+    assert res["count"] == 0
+    assert res["unresolved"][0]["status"] == "unsupported_media_type"
+
+
+def test_playlist_episode_payload_uses_show_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.flicklist import _playlists as playlists
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(playlists, "flicklist_request", lambda adapter, method, url, **kwargs: calls.append({"method": method, "url": url, **kwargs}) or _Resp(200, {"added": 1}))
+
+    item = {
+        "type": "episode",
+        "season": 1,
+        "episode": 3,
+        "ids": {"tmdb": "4071040"},
+        "show_ids": {"tmdb": "100088", "imdb": "tt3581920"},
+    }
+
+    res = playlists.add(object(), "42", [item])
+
+    assert res["count"] == 1
+    assert calls[0]["url"].endswith("/sync/lists/42/items")
+    assert calls[0]["json"]["items"] == [{
+        "ids": {"tmdb": 100088, "imdb": "tt3581920"},
+        "media_type": "show",
+        "season": 1,
+        "episode": 3,
+    }]
+
+
+def test_sink_is_registered_for_webhook_and_watcher_destinations() -> None:
+    from providers.scrobble.flicklist.sink import FlickListSink
+    from providers.scrobble.routes import ROUTE_RATING_SINKS, ROUTE_SINKS, build_route_cfg, normalize_route
+    from providers.scrobble.watch_manager import _make_sink
+    from providers.webhooks.config import sink_configured, webhook_sinks
+    from providers.webhooks.dispatch import _make_sink as make_webhook_sink
+
+    route = normalize_route({"id": "R1", "provider": "plex", "sink": "flicklist"}, "R1")
+    view = build_route_cfg(CFG, route)
+
+    assert "flicklist" in ROUTE_SINKS
+    assert "flicklist" in ROUTE_RATING_SINKS
+    assert route["sink"] == "flicklist"
+    assert view["flicklist"]["api_key"] == "fs_live_test"
+    assert sink_configured(CFG, "flicklist", "default") is True
+    assert sink_configured({"flicklist": {"token": "session-token"}}, "flicklist", "default") is True
+    assert isinstance(_make_sink("flicklist", lambda: dict(CFG), "default"), FlickListSink)
+    assert isinstance(make_webhook_sink("flicklist", "default", lambda: dict(CFG)), FlickListSink)
+
+    cfg = {**CFG, "scrobble": {"webhook": {"sinks": ["flicklist"]}}}
+    assert "flicklist" in webhook_sinks(cfg, "plex", "default")
+
+
+def test_movie_scrobble_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.flicklist import sink as sink_mod
+    from providers.scrobble.flicklist.sink import FlickListSink
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_request(adapter: Any, method: str, url: str, **kwargs: Any) -> _Resp:
+        calls.append({"method": method, "url": url, **kwargs})
+        return _Resp(204, {})
+
+    monkeypatch.setattr(sink_mod, "flicklist_request", fake_request)
+    monkeypatch.setattr(sink_mod, "record_watch", lambda *args, **kwargs: None)
+
+    FlickListSink(cfg_provider=lambda: dict(CFG)).send(Event(action="start", progress=12.4))
+
+    assert calls[0]["method"] == "POST"
+    assert calls[0]["url"].endswith("/scrobble/start")
+    assert calls[0]["json"] == {"ids": {"tmdb": 550, "imdb": "tt0137523"}, "media_type": "movie", "progress": 12.4}
+
+
+def test_episode_scrobble_uses_show_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.flicklist import sink as sink_mod
+    from providers.scrobble.flicklist.sink import FlickListSink
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(sink_mod, "flicklist_request", lambda adapter, method, url, **kwargs: calls.append({"method": method, "url": url, **kwargs}) or _Resp(204, {}))
+    monkeypatch.setattr(sink_mod, "record_watch", lambda *args, **kwargs: None)
+
+    FlickListSink(cfg_provider=lambda: dict(CFG)).send(Event(
+        action="pause",
+        media_type="episode",
+        title="Severance",
+        season=1,
+        number=2,
+        ids={"tmdb": "5978363", "imdb": "tt11280740", "tmdb_show": "95396", "imdb_show": "tt11280740"},
+        progress=45,
+    ))
+
+    assert calls[0]["url"].endswith("/scrobble/pause")
+    assert calls[0]["json"] == {
+        "ids": {"tmdb": 95396, "imdb": "tt11280740"},
+        "media_type": "show",
+        "season": 1,
+        "episode": 2,
+        "progress": 45.0,
+    }
+
+
+def test_episode_scrobble_without_show_identity_is_not_sent(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.flicklist import sink as sink_mod
+    from providers.scrobble.flicklist.sink import FlickListSink
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(sink_mod, "flicklist_request", lambda adapter, method, url, **kwargs: calls.append({"method": method, "url": url, **kwargs}) or _Resp(200, {}))
+
+    FlickListSink(cfg_provider=lambda: dict(CFG)).send(Event(
+        action="start",
+        media_type="episode",
+        title="Severance",
+        season=1,
+        number=2,
+        ids={"tmdb": "5978363", "imdb": "tt11280740"},
+    ))
+
+    assert calls == []
+
+
+def test_scrobble_sink_accepts_route_cfg_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.flicklist import sink as sink_mod
+    from providers.scrobble.flicklist.sink import FlickListSink
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(sink_mod, "flicklist_request", lambda adapter, method, url, **kwargs: calls.append({"method": method, "url": url, "cfg": adapter.config, **kwargs}) or _Resp(200, {}))
+    monkeypatch.setattr(sink_mod, "record_watch", lambda *args, **kwargs: None)
+
+    route_cfg = {
+        "flicklist": {"api_key": "fs_live_route"},
+        "scrobble": {"watch": {"route_provider": "plex", "route_provider_instance": "P1"}},
+    }
+
+    FlickListSink(cfg_provider=lambda: {}).send(Event(action="start"), cfg=route_cfg)
+
+    assert calls
+    assert calls[0]["cfg"]["flicklist"]["api_key"] == "fs_live_route"
+
+
+def test_global_and_route_rating_surfaces_include_flicklist() -> None:
+    from pathlib import Path
+
+    import providers.webhooks.plex as wh
+    from providers.scrobble.plex.ratings_sync import OPS_RATING_SINKS, RATING_SINKS
+
+    root = Path(__file__).resolve().parents[1]
+    watch = (root / "providers" / "scrobble" / "plex" / "watch.py").read_text(encoding="utf-8")
+    api = (root / "api" / "scrobblerManagementAPI.py").read_text(encoding="utf-8")
+    webhook_modal = (root / "assets" / "js" / "modals" / "scrobbler-webhook" / "index.js").read_text(encoding="utf-8")
+
+    assert 'enable_flicklist = "flicklist" in custom_targets' in watch
+    assert 'enable_flicklist = bool(watch_cfg.get("plex_flicklist_ratings"))' in watch
+    assert '"flicklist": bool(watch.get("plex_flicklist_ratings"))' in api
+    assert '"flicklist"' in webhook_modal.split("ratingSinks")[1].split("]")[0]
+    assert "plex_flicklist_ratings" in wh._DEF_WEBHOOK
+    assert "flicklist" in OPS_RATING_SINKS
+    assert "flicklist" in RATING_SINKS
+    assert "flicklist" in wh.RATING_SINKS
+
+
+def test_history_index_uses_flicklist_header_pagination(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.flicklist import _history as history
+
+    class Adapter:
+        config = {"flicklist": {"history_per_page": 100, "history_max_pages": 10}}
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_request(adapter: Any, method: str, url: str, **kwargs: Any) -> _Resp:
+        calls.append(kwargs)
+        page = int((kwargs.get("params") or {}).get("page") or 1)
+        payload = [
+            {
+                "media_type": "movie",
+                "title": f"Movie {page}",
+                "year": 2026,
+                "watched_at": f"2026-08-2{page}T20:00:00.000Z",
+                "ids": {"tmdb": 1000 + page},
+            }
+        ]
+        return _Resp(200, payload, headers={"X-FlickList-Page-Count": "2"})
+
+    monkeypatch.setattr(history, "flicklist_request", fake_request)
+
+    out = history.build_index(Adapter())
+
+    assert len(calls) == 3
+    assert [call["params"]["page"] for call in calls[:2]] == [1, 2]
+    assert sorted(out) == ["tmdb:1001@1787342400", "tmdb:1002@1787428800"]
+
+
+def test_history_index_supplements_missing_movies_from_watched_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.flicklist import _history as history
+    from providers.sync.flicklist._common import URL_HISTORY, URL_WATCHED_MOVIES
+
+    class Adapter:
+        config = {"flicklist": {"history_per_page": 100, "history_max_pages": 10}}
+
+    calls: list[str] = []
+
+    def fake_request(adapter: Any, method: str, url: str, **kwargs: Any) -> _Resp:
+        calls.append(url)
+        if url == URL_HISTORY:
+            return _Resp(200, [
+                {
+                    "id": 42,
+                    "type": "episode",
+                    "title": "Severance",
+                    "episode_name": "Goodbye, Mrs. Selvig",
+                    "season_number": 1,
+                    "episode_number": 2,
+                    "watched_at": "2026-08-21T20:00:00.000Z",
+                    "ids": {"tmdb": 95396, "imdb": "tt11280740"},
+                }
+            ], headers={"X-FlickList-Page-Count": "1"})
+        if url == URL_WATCHED_MOVIES:
+            return _Resp(200, [
+                {
+                    "title": "Fight Club",
+                    "year": 1999,
+                    "plays": 1,
+                    "last_watched_at": "2026-08-20T20:00:00.000Z",
+                    "ids": {"tmdb": 550, "imdb": "tt0137523"},
+                }
+            ])
+        return _Resp(404, {})
+
+    monkeypatch.setattr(history, "flicklist_request", fake_request)
+
+    out = history.build_index(Adapter())
+
+    assert calls == [URL_HISTORY, URL_WATCHED_MOVIES]
+    assert "tmdb:95396#s01e02@1787342400" in out
+    assert out["tmdb:550"]["type"] == "movie"
+    assert out["tmdb:550"]["watched_at"] == "2026-08-20T20:00:00.000Z"
+
+
+def test_history_index_supplements_movie_only_accounts(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.flicklist import _history as history
+    from providers.sync.flicklist._common import URL_HISTORY, URL_WATCHED_MOVIES, URL_WATCHED_SHOWS
+
+    calls: list[str] = []
+
+    def fake_request(adapter: Any, method: str, url: str, **kwargs: Any) -> _Resp:
+        calls.append(url)
+        if url == URL_HISTORY:
+            return _Resp(200, [], headers={"X-FlickList-Page-Count": "1"})
+        if url == URL_WATCHED_MOVIES:
+            return _Resp(200, [{"title": "Heat", "year": 1995, "ids": {"tmdb": 949}}])
+        if url == URL_WATCHED_SHOWS:
+            return _Resp(200, [])
+        return _Resp(404, {})
+
+    monkeypatch.setattr(history, "flicklist_request", fake_request)
+
+    out = history.build_index(object())
+
+    assert calls == [URL_HISTORY, URL_WATCHED_MOVIES, URL_WATCHED_SHOWS]
+    assert sorted(out) == ["tmdb:949"]
+
+
+def test_history_index_supplements_empty_history_from_watched_show_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.flicklist import _history as history
+    from providers.sync.flicklist._common import URL_HISTORY, URL_WATCHED_MOVIES, URL_WATCHED_SHOWS
+
+    calls: list[str] = []
+
+    def fake_request(adapter: Any, method: str, url: str, **kwargs: Any) -> _Resp:
+        calls.append(url)
+        if url == URL_HISTORY:
+            return _Resp(200, [], headers={"X-FlickList-Page-Count": "1"})
+        if url == URL_WATCHED_MOVIES:
+            return _Resp(200, [])
+        if url == URL_WATCHED_SHOWS:
+            return _Resp(200, [
+                {
+                    "show": {
+                        "title": "Severance",
+                        "year": 2022,
+                        "ids": {"tmdb": 95396, "imdb": "tt11280740", "tvdb": 371980},
+                    },
+                    "last_watched_at": "2026-08-21T20:00:00.000Z",
+                    "seasons": [
+                        {
+                            "number": 1,
+                            "episodes": [
+                                {"number": 1, "plays": 1, "last_watched_at": "2026-08-20T20:00:00.000Z"},
+                                {"number": 2, "plays": 1, "last_watched_at": "2026-08-21T20:00:00.000Z"},
+                            ],
+                        }
+                    ],
+                }
+            ])
+        return _Resp(404, {})
+
+    monkeypatch.setattr(history, "flicklist_request", fake_request)
+
+    out = history.build_index(object())
+
+    assert calls == [URL_HISTORY, URL_WATCHED_MOVIES, URL_WATCHED_SHOWS]
+    assert sorted(out) == ["tmdb:95396#s01e01", "tmdb:95396#s01e02"]
+    assert out["tmdb:95396#s01e02"]["watched_at"] == "2026-08-21T20:00:00.000Z"
+    assert out["tmdb:95396#s01e02"]["show_ids"]["tmdb"] == "95396"
+
+
+def test_playback_progress_service_does_not_register_flicklist() -> None:
+    from services.playback_progress.service import PHASE1_PROVIDERS, PlaybackProgressService
+
+    cfg = {
+        "flicklist": {
+            "instances": {
+                "kid": {"access_token": "session-token", "username": "kid"},
+            }
+        }
+    }
+
+    service = PlaybackProgressService()
+    specs = [spec for spec in service.provider_instances(cfg) if spec["provider"] == "flicklist"]
+
+    assert "flicklist" not in PHASE1_PROVIDERS
+    assert service._adapter("flicklist") is None
+    assert specs == []
+
+
+class _FakeFlickListOps:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def is_configured(self, cfg: dict[str, Any]) -> bool:
+        return bool((cfg.get("flicklist") or {}).get("access_token") or (cfg.get("flicklist") or {}).get("api_key"))
+
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "progress": {
+                "read": True,
+                "remove": True,
+                "upsert": True,
+                "types": {"movies": True, "episodes": True},
+            },
+            "history": {"write": True},
+        }
+
+    def build_index(self, cfg: dict[str, Any], *, feature: str) -> dict[str, dict[str, Any]]:
+        assert feature == "progress"
+        return {
+            "tmdb:95396:s1e2": {
+                "type": "episode",
+                "title": "Goodbye, Mrs. Selvig",
+                "series_title": "Severance",
+                "season": 1,
+                "episode": 2,
+                "ids": {"tmdb": "95396", "imdb": "tt11280740"},
+                "show_ids": {"tmdb": "95396", "imdb": "tt11280740"},
+                "progress_percent": 45,
+                "progress_at": "2026-08-22T20:00:00Z",
+                "updated_at": "2026-08-22T20:00:00Z",
+                "_flicklist_playback_id": "4471",
+            }
+        }
+
+    def add(self, cfg: dict[str, Any], items: list[dict[str, Any]], *, feature: str, dry_run: bool = False) -> dict[str, Any]:
+        self.calls.append({"op": "add", "feature": feature, "items": items, "dry_run": dry_run})
+        return {"ok": True, "confirmed_keys": ["tmdb:95396:s1e2"]}
+
+    def remove(self, cfg: dict[str, Any], items: list[dict[str, Any]], *, feature: str, dry_run: bool = False) -> dict[str, Any]:
+        self.calls.append({"op": "remove", "feature": feature, "items": items, "dry_run": dry_run})
+        return {"ok": True, "confirmed_keys": ["tmdb:95396:s1e2"]}
+
+
+def test_flicklist_playback_adapter_lists_and_routes_actions() -> None:
+    from services.playback_progress.adapters.flicklist import FlickListPlaybackAdapter
+
+    fake = _FakeFlickListOps()
+    adapter = FlickListPlaybackAdapter()
+    adapter.ops = fake
+    cfg = {"flicklist": {"access_token": "session-token"}}
+
+    listed = adapter.list_progress(cfg, instance_id="default", instance_label="Default")
+    assert listed.ok is True
+    record = listed.items[0].to_dict()
+
+    assert record["provider"] == "flicklist"
+    assert record["remote_id"] == "4471"
+    assert record["media_type"] == "episode"
+    assert record["can_remove_progress"] is True
+    assert record["can_mark_watched"] is True
+    assert record["can_update_progress"] is True
+    assert record["provider_metadata"]["show_ids"] == {"tmdb": "95396", "imdb": "tt11280740"}
+
+    assert adapter.update_progress(cfg, record, 25, instance_id="default", instance_label="Default").ok is True
+    assert adapter.mark_watched(cfg, record, instance_id="default", instance_label="Default").ok is True
+    assert adapter.remove_progress(cfg, record, instance_id="default", instance_label="Default").ok is True
+
+    assert fake.calls[0]["op"] == "add"
+    assert fake.calls[0]["feature"] == "progress"
+    assert fake.calls[0]["items"][0]["progress_percent"] == 25
+    assert fake.calls[1]["op"] == "add"
+    assert fake.calls[1]["feature"] == "history"
+    assert fake.calls[2]["op"] == "remove"
+    assert fake.calls[2]["feature"] == "progress"
+    assert fake.calls[2]["items"][0]["_flicklist_playback_id"] == "4471"
+
+
+def test_history_add_does_not_confirm_items_echoed_in_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.flicklist import _history as history
+
+    body = {
+        "added": 0,
+        "existing": 0,
+        "not_found": [
+            {"ids": {"fldb": None, "tmdb": 550, "imdb": "tt0137523", "tvdb": None}, "reason": "no_catalog_match"},
+        ],
+    }
+    monkeypatch.setattr(history, "flicklist_request", lambda adapter, method, url, **kwargs: _Resp(200, body))
+
+    res = history.add(object(), [{
+        "type": "movie",
+        "title": "Fight Club",
+        "watched_at": "2026-08-21T20:00:00.000Z",
+        "ids": {"tmdb": "550", "imdb": "tt0137523"},
+    }])
+
+    assert res["ok"] is False
+    assert res["count"] == 0
+    assert res["confirmed_keys"] == []
+    assert res["unresolved"][0]["status"] == "not_found"
+
+
+def test_history_add_does_not_confirm_when_nothing_was_applied(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.flicklist import _history as history
+
+    monkeypatch.setattr(history, "flicklist_request", lambda adapter, method, url, **kwargs: _Resp(200, {"added": 0, "existing": 0, "not_found": []}))
+
+    res = history.add(object(), [{
+        "type": "movie",
+        "title": "Fight Club",
+        "watched_at": "2026-08-21T20:00:00.000Z",
+        "ids": {"tmdb": "550"},
+    }])
+
+    assert res["ok"] is False
+    assert res["count"] == 0
+    assert res["unresolved"][0]["status"] == "write_not_applied"
+
+
+def test_history_add_counts_existing_plays_as_confirmed(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.flicklist import _history as history
+
+    monkeypatch.setattr(history, "flicklist_request", lambda adapter, method, url, **kwargs: _Resp(200, {"added": 0, "existing": 1, "not_found": []}))
+
+    res = history.add(object(), [{
+        "type": "movie",
+        "title": "Fight Club",
+        "watched_at": "2026-08-21T20:00:00.000Z",
+        "ids": {"tmdb": "550"},
+    }])
+
+    assert res["ok"] is True
+    assert res["count"] == 1


### PR DESCRIPTION
# Pull request

## Change

- Adds the FlickList sync provider files for watchlist, ratings, history, progress, and playlists.
- The provider stays disabled and is not registered as a sync target.

## Why

- Sync work is kept in the tree while FlickList API writes stay disabled for now.

## Testing

- tests/test_flicklist_provider.py

## Issue

Relates to #229
There are issues with their API and therefore the sync part stays disabled