### PR TITLE
Add: FlickList scrobble sink and cross provider merge

### DIFF
--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -67,6 +67,7 @@ WEBHOOK_SETTING_KEYS = {
     "plex_crosswatch_ratings",
     "plex_floppy_ratings",
     "plex_punchplay_ratings",
+    "plex_flicklist_ratings",
     "pause_debounce_seconds",
     "suppress_start_at",
 }
@@ -293,7 +294,7 @@ def _normalize_webhook_settings(cfg: Mapping[str, Any], provider: str, body: Map
         if key in body:
             out[key] = _normalize_filters(body.get(key), provider, key)
     if provider == "plex":
-        for key in ("plex_trakt_ratings", "plex_simkl_ratings", "plex_mdblist_ratings", "plex_crosswatch_ratings", "plex_floppy_ratings", "plex_punchplay_ratings"):
+        for key in ("plex_trakt_ratings", "plex_simkl_ratings", "plex_mdblist_ratings", "plex_crosswatch_ratings", "plex_floppy_ratings", "plex_punchplay_ratings", "plex_flicklist_ratings"):
             if key in body:
                 out[key] = bool(body.get(key))
     for key in ("pause_debounce_seconds", "suppress_start_at"):
@@ -563,6 +564,7 @@ def build_overview(cfg: dict[str, Any], request: Request) -> dict[str, Any]:
             "crosswatch": bool(watch.get("plex_crosswatch_ratings")),
             "floppy": bool(watch.get("plex_floppy_ratings")),
             "punchplay": bool(watch.get("plex_punchplay_ratings")),
+            "flicklist": bool(watch.get("plex_flicklist_ratings")),
             "endpoint_url": _global_plex_ratings_url(request, cfg),
         },
     }
@@ -931,7 +933,7 @@ def api_scrobbler_settings(request: Request, payload: dict[str, Any] = Body(...)
             watch["autostart"] = bool(payload.get("watch_autostart"))
         ratings_raw = payload.get("global_plex_ratings")
         if isinstance(ratings_raw, Mapping):
-            for sink in ("trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay"):
+            for sink in ("trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "flicklist"):
                 watch[f"plex_{sink}_ratings"] = bool(ratings_raw.get(sink))
         if bool(payload.get("regenerate_global_plex_ratings_webhook")):
             sec = after.setdefault("security", {})

--- a/assets/js/modals/scrobbler-route/index.js
+++ b/assets/js/modals/scrobbler-route/index.js
@@ -1,9 +1,9 @@
 /* CrossWatch - Scrobbler Route Modal */
 const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
-const label = (v) => ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", kodi: "Kodi", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy", punchplay: "PunchPlay", bingebase: "BingeBase", scrob: "Scrob" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
+const label = (v) => ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", kodi: "Kodi", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy", punchplay: "PunchPlay", bingebase: "BingeBase", flicklist: "FlickList", scrob: "Scrob" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
 const sources = ["plex", "jellyfin", "emby", "kodi", "scrob"];
-const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "bingebase", "scrob"];
-const ratingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "scrob"];
+const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "bingebase", "flicklist", "scrob"];
+const ratingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "flicklist", "scrob"];
 
 function flashCopied(btn) {
   if (!btn) return;

--- a/assets/js/modals/scrobbler-webhook/index.js
+++ b/assets/js/modals/scrobbler-webhook/index.js
@@ -1,8 +1,8 @@
 /* CrossWatch - Scrobbler Webhook Modal */
 const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
-const label = (v) => window.CW?.ProviderMeta?.label?.(v) || ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy", punchplay: "PunchPlay", bingebase: "BingeBase", scrob: "Scrob" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
-const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "bingebase", "scrob"];
-const ratingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "scrob"];
+const label = (v) => window.CW?.ProviderMeta?.label?.(v) || ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy", punchplay: "PunchPlay", bingebase: "BingeBase", flicklist: "FlickList", scrob: "Scrob" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
+const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "bingebase", "flicklist", "scrob"];
+const ratingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "flicklist", "scrob"];
 const webhookSources = new Set(["plex", "jellyfin", "emby"]);
 
 function flashCopied(btn) {

--- a/providers/scrobble/flicklist/__init__.py
+++ b/providers/scrobble/flicklist/__init__.py
@@ -1,0 +1,1 @@
+# CrossWatch - FlickList scrobble sink package

--- a/providers/scrobble/flicklist/sink.py
+++ b/providers/scrobble/flicklist/sink.py
@@ -1,0 +1,315 @@
+# CrossWatch - FlickList scrobble sink
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import requests
+
+from cw_platform.config_base import load_config
+from cw_platform.event_archive import record_watch
+from cw_platform.local_db.ttl_dedupe import once_per_ttl
+from cw_platform.provider_instances import normalize_instance_id, resolve_provider_block
+from providers.scrobble._auto_remove_watchlist import remove_across_providers_by_ids as _rm_across
+from providers.scrobble._watched_gate import resolve_stop_action
+from providers.sync.flicklist._common import URL_SCROBBLE, error_of, flicklist_request
+from services.activity import record_scrobble_event
+
+try:
+    from _logging import log as BASE_LOG
+except Exception:
+    BASE_LOG = None
+
+try:
+    from providers.scrobble.scrobble import ScrobbleEvent, ScrobbleSink, mask_account  # type: ignore
+except ImportError:
+    class ScrobbleSink:  # pragma: no cover
+        def send(self, event: Any) -> None: ...
+
+    class ScrobbleEvent:  # pragma: no cover
+        ...
+
+    def mask_account(value: Any) -> str:  # pragma: no cover
+        s = str(value or "").strip()
+        return s[:2] + "***" if len(s) > 2 else "unknown"
+
+APP_AGENT = "CrossWatch/FlickListWatcher/1.0"
+DEFAULT_WATCHED_AT = 90.0
+_AR_TTL = 60
+
+
+def _cfg() -> dict[str, Any]:
+    try:
+        return load_config() or {}
+    except Exception:
+        return {}
+
+
+def _is_debug() -> bool:
+    try:
+        return bool((_cfg().get("runtime") or {}).get("debug"))
+    except Exception:
+        return False
+
+
+def _log(msg: str, lvl: str = "INFO") -> None:
+    level = (str(lvl) or "INFO").upper()
+    if level == "DEBUG" and not _is_debug():
+        return
+    if BASE_LOG is not None:
+        try:
+            BASE_LOG(msg, level=level, module="SCROBBLE")
+            return
+        except Exception:
+            pass
+    print(f"[SCROBBLE] {level}: {msg}")
+
+
+def _route_source(cfg: Mapping[str, Any]) -> tuple[str, str]:
+    watch = ((cfg.get("scrobble") or {}).get("watch") or {}) if isinstance(cfg, Mapping) else {}
+    source = str(watch.get("route_provider") or "watcher").strip().lower() or "watcher"
+    source_instance = str(watch.get("route_provider_instance") or "default").strip() or "default"
+    return source, source_instance
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(str(value).strip())
+    except Exception:
+        return None
+
+
+def _imdb(value: Any) -> str | None:
+    text = str(value or "").strip().lower()
+    if not text:
+        return None
+    if not text.startswith("tt"):
+        text = f"tt{text.lstrip('t')}"
+    return text if text[2:].isdigit() else None
+
+
+def _norm_media_type(value: str) -> str:
+    text = (value or "").strip().lower()
+    if text.endswith("s"):
+        text = text[:-1]
+    return "show" if text in {"serie", "series", "tv"} else text
+
+
+def _ar_seen(key: str) -> bool:
+    try:
+        return not once_per_ttl(None, "auto_remove_seen", key, ttl_seconds=_AR_TTL)
+    except Exception:
+        return False
+
+
+def _auto_remove_enabled(cfg: Mapping[str, Any], media_type: str) -> bool:
+    scrobble = (cfg.get("scrobble") or {}) if isinstance(cfg, Mapping) else {}
+    watch = scrobble.get("watch") or {}
+    route_opts = watch.get("route_options") if isinstance(watch.get("route_options"), Mapping) else {}
+    mode = str((route_opts or {}).get("auto_remove_watchlist") or "inherit").strip().lower()
+    if mode == "off":
+        return False
+    if not scrobble.get("delete_plex") and mode != "on":
+        return False
+    types = scrobble.get("delete_plex_types") or []
+    mt = _norm_media_type(media_type)
+    if isinstance(types, str):
+        return _norm_media_type(types) == mt
+    try:
+        return mt in {_norm_media_type(str(x)) for x in types if str(x).strip()}
+    except Exception:
+        return False
+
+
+def _auto_remove_across(event: Any, cfg: Mapping[str, Any], scope: str = "") -> None:
+    media_type = "episode" if str(getattr(event, "media_type", "") or "").lower() == "episode" else "movie"
+    if not _auto_remove_enabled(cfg, media_type):
+        return
+    ids = {k: str(v) for k, v in (getattr(event, "ids", None) or {}).items() if v}
+    if not ids:
+        return
+    key = f"{scope}|{media_type}|" + ",".join(f"{k}={v}" for k, v in sorted(ids.items()))
+    if _ar_seen(key):
+        return
+    try:
+        _rm_across(ids, media_type, scope=scope)
+    except Exception:
+        pass
+
+
+class FlickListSink(ScrobbleSink):
+    name = "flicklist"
+
+    def __init__(self, cfg_provider: Callable[[], dict[str, Any]] | None = None, instance_id: Any = None) -> None:
+        self._cfg_provider = cfg_provider
+        self.instance_id = normalize_instance_id(instance_id)
+        self.session = requests.Session()
+        try:
+            self.session.headers.setdefault("Accept", "application/json")
+            self.session.headers.setdefault("User-Agent", APP_AGENT)
+        except Exception:
+            pass
+
+    @property
+    def config(self) -> dict[str, Any]:
+        if self._cfg_provider is not None:
+            try:
+                cfg = self._cfg_provider()
+                if isinstance(cfg, Mapping):
+                    return dict(cfg)
+            except Exception:
+                pass
+        return _cfg()
+
+    def _block(self, cfg: Mapping[str, Any]) -> dict[str, Any]:
+        try:
+            return resolve_provider_block(cfg, "flicklist", self.instance_id) or {}
+        except Exception:
+            block = cfg.get("flicklist") if isinstance(cfg, Mapping) else None
+            return dict(block) if isinstance(block, Mapping) else {}
+
+    def _watched_at(self, cfg: Mapping[str, Any]) -> float:
+        try:
+            sc = cfg.get("scrobble") if isinstance(cfg, Mapping) else {}
+            value = ((sc or {}).get("flicklist") or {}).get("watched_at")
+            if value is None:
+                value = ((sc or {}).get("trakt") or {}).get("watched_at", DEFAULT_WATCHED_AT)
+            return max(0.0, min(100.0, float(value)))
+        except Exception:
+            return DEFAULT_WATCHED_AT
+
+    def _ids_payload(self, event: Any, media_type: str) -> dict[str, Any]:
+        ids = getattr(event, "ids", None) or {}
+        if media_type == "episode":
+            show_ids = {k[: -len("_show")]: v for k, v in ids.items() if k.endswith("_show") and v}
+            if not show_ids:
+                return {}
+            ids = show_ids
+        out: dict[str, Any] = {}
+        fldb = str(ids.get("fldb") or "").strip()
+        if fldb:
+            out["fldb"] = fldb
+            return out
+        tmdb = _as_int(ids.get("tmdb"))
+        if tmdb and tmdb > 0:
+            out["tmdb"] = tmdb
+        imdb = _imdb(ids.get("imdb"))
+        if imdb:
+            out["imdb"] = imdb
+        tvdb = _as_int(ids.get("tvdb"))
+        if tvdb and tvdb > 0:
+            out["tvdb"] = tvdb
+        return out
+
+    def _payload(self, event: Any) -> tuple[str, dict[str, Any]] | None:
+        media_type = "episode" if str(getattr(event, "media_type", "") or "").lower() == "episode" else "movie"
+        ids = self._ids_payload(event, media_type)
+        if not ids:
+            return None
+        payload: dict[str, Any] = {"ids": ids, "media_type": "show" if media_type == "episode" else "movie"}
+        if media_type == "episode":
+            season = _as_int(getattr(event, "season", None))
+            episode = _as_int(getattr(event, "number", None))
+            if season is None or episode is None:
+                return None
+            payload["season"] = season
+            payload["episode"] = episode
+        try:
+            payload["progress"] = max(0.0, min(100.0, float(getattr(event, "progress", 0.0) or 0.0)))
+        except Exception:
+            payload["progress"] = 0.0
+        return media_type, payload
+
+    def send(self, event: Any, cfg: Mapping[str, Any] | None = None) -> None:
+        cfg = dict(cfg) if isinstance(cfg, Mapping) else self.config
+        block = self._block(cfg)
+        if not str(block.get("api_key") or block.get("access_token") or block.get("token") or "").strip():
+            _log("FLICKLIST: skip scrobble, not connected", "DEBUG")
+            return
+        action = str(getattr(event, "action", "") or "").strip().lower()
+        if action not in {"start", "pause", "stop"}:
+            return
+        built = self._payload(event)
+        if not built:
+            _log("FLICKLIST: skip scrobble, no supported ids", "DEBUG")
+            return
+        media_type, payload = built
+        progress_pct = float(payload.get("progress") or 0.0)
+        watched_at = self._watched_at(cfg)
+        watched = action == "stop" and resolve_stop_action(progress_pct, watched_at) == "stop"
+        self._post(cfg, event, action, payload, progress_pct, watched=watched, media_type=media_type)
+
+    def _post(self, cfg: Mapping[str, Any], event: Any, action: str, payload: Mapping[str, Any], progress_pct: float, *, watched: bool, media_type: str) -> None:
+        adapter = _Adapter(dict(cfg), self.instance_id, self.session)
+        src, src_inst = _route_source(cfg)
+        archived = action in ("start", "stop")
+        try:
+            resp = flicklist_request(adapter, "POST", URL_SCROBBLE.format(action=action), json=dict(payload))
+        except Exception as exc:
+            reason = exc.__class__.__name__
+            _log(f"FLICKLIST: scrobble {action} failed ({reason})", "WARN")
+            if archived:
+                self._archive(event, action, src, src_inst, progress_pct, status="fail", reason=reason)
+            return
+
+        code = int(getattr(resp, "status_code", 0) or 0)
+        if not (200 <= code < 300):
+            reason = error_of(resp) or f"http:{code}"
+            _log(f"FLICKLIST: scrobble {action} rejected status={code} error={reason}", "WARN")
+            if archived:
+                self._archive(event, action, src, src_inst, progress_pct, status="fail", reason=reason)
+            return
+
+        if archived:
+            self._archive(event, action, src, src_inst, progress_pct)
+
+        if action == "stop" and watched:
+            try:
+                record_scrobble_event(
+                    event,
+                    source=src,
+                    source_instance=src_inst,
+                    target="flicklist",
+                    target_instance=self.instance_id,
+                    progress=progress_pct,
+                )
+            except Exception:
+                pass
+            _auto_remove_across(event, cfg, scope=f"flicklist:{self.instance_id}")
+
+        _log(
+            f"FLICKLIST: scrobble {action} user='{mask_account(getattr(event, 'account', None))}' p={progress_pct:.1f}% media={media_type}",
+            "DEBUG" if action == "pause" else "INFO",
+        )
+
+    def _archive(self, event: Any, action: str, src: str, src_inst: str, progress_pct: float, *, status: str = "", reason: str = "") -> None:
+        try:
+            extra: dict[str, Any] = {}
+            if status:
+                extra["status"] = status
+            if reason:
+                extra["reason"] = reason
+            record_watch(
+                event,
+                action=action,
+                source_provider=src,
+                source_instance=src_inst,
+                destination_provider="flicklist",
+                destination_instance=self.instance_id,
+                progress=progress_pct,
+                **extra,
+            )
+        except Exception:
+            pass
+
+
+class _Adapter:
+    def __init__(self, cfg: dict[str, Any], instance_id: str, session: requests.Session) -> None:
+        self.config = cfg
+        self.instance_id = instance_id
+        self.session = session
+
+
+__all__ = ["FlickListSink"]

--- a/providers/scrobble/plex/ratings_sync.py
+++ b/providers/scrobble/plex/ratings_sync.py
@@ -20,7 +20,7 @@ def _as_int(value: Any) -> int | None:
 
 def _clean_ids(ids: Mapping[str, Any] | None) -> dict[str, Any]:
     out: dict[str, Any] = {}
-    for key in ("tmdb", "imdb", "tvdb", "trakt", "simkl", "mdblist", "plex"):
+    for key in ("tmdb", "imdb", "tvdb", "trakt", "simkl", "mdblist", "fldb", "plex"):
         value = (ids or {}).get(key)
         if value in (None, ""):
             continue
@@ -101,10 +101,14 @@ def _ops(provider: str) -> Any | None:
         from providers.sync._mod_PUNCHPLAY import OPS
 
         return OPS
+    if provider == "flicklist":
+        from providers.sync._mod_FLICKLIST import OPS
+
+        return OPS
     return None
 
 
-OPS_RATING_SINKS: tuple[str, ...] = ("crosswatch", "floppy", "punchplay")
+OPS_RATING_SINKS: tuple[str, ...] = ("crosswatch", "floppy", "punchplay", "flicklist")
 RATING_SINKS: tuple[str, ...] = ("trakt", "simkl", "mdblist", *OPS_RATING_SINKS)
 
 

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -1775,6 +1775,7 @@ def process_rating_webhook(
         enable_crosswatch = "crosswatch" in custom_targets
         enable_floppy = "floppy" in custom_targets
         enable_punchplay = "punchplay" in custom_targets
+        enable_flicklist = "flicklist" in custom_targets
     else:
         enable_trakt = bool(watch_cfg.get("plex_trakt_ratings"))
         enable_simkl = bool(watch_cfg.get("plex_simkl_ratings"))
@@ -1782,8 +1783,9 @@ def process_rating_webhook(
         enable_crosswatch = bool(watch_cfg.get("plex_crosswatch_ratings"))
         enable_floppy = bool(watch_cfg.get("plex_floppy_ratings"))
         enable_punchplay = bool(watch_cfg.get("plex_punchplay_ratings"))
+        enable_flicklist = bool(watch_cfg.get("plex_flicklist_ratings"))
 
-    if not (enable_trakt or enable_simkl or enable_mdblist or enable_crosswatch or enable_floppy or enable_punchplay):
+    if not (enable_trakt or enable_simkl or enable_mdblist or enable_crosswatch or enable_floppy or enable_punchplay or enable_flicklist):
         return {"ok": True, "ignored": True}
 
     if not payload:
@@ -1825,7 +1827,7 @@ def process_rating_webhook(
         rating_val = 0
 
 
-    if media_type == "episode" and not (enable_trakt or enable_crosswatch or enable_punchplay):
+    if media_type == "episode" and not (enable_trakt or enable_crosswatch or enable_punchplay or enable_flicklist):
         return {"ok": True, "ignored": True}
 
     acc_key = _account_key(payload)
@@ -1869,7 +1871,7 @@ def process_rating_webhook(
         results["mdblist"] = _mdblist_send_rating(media_type, ids, rating_val, cfg, logger)
     ops_enabled = [
         name
-        for name, on in (("crosswatch", enable_crosswatch), ("floppy", enable_floppy), ("punchplay", enable_punchplay))
+        for name, on in (("crosswatch", enable_crosswatch), ("floppy", enable_floppy), ("punchplay", enable_punchplay), ("flicklist", enable_flicklist))
         if on
     ]
     if ops_enabled:

--- a/providers/scrobble/routes.py
+++ b/providers/scrobble/routes.py
@@ -9,8 +9,8 @@ from cw_platform.provider_instances import get_provider_block, normalize_instanc
 
 DEFAULT_INSTANCE_ID = "default"
 ROUTE_PROVIDERS = {"plex", "emby", "jellyfin", "kodi", "scrob"}
-ROUTE_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "bingebase", "scrob"}
-ROUTE_RATING_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "scrob"}
+ROUTE_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "bingebase", "flicklist", "scrob"}
+ROUTE_RATING_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "flicklist", "scrob"}
 ROUTE_OPTION_STATES = {"inherit", "on", "off"}
 ROUTE_RATINGS_MODES = {"off", "custom"}
 ROUTE_SCROBBLE_POLICY_RANGES = {

--- a/providers/scrobble/watch_manager.py
+++ b/providers/scrobble/watch_manager.py
@@ -174,6 +174,10 @@ def _make_sink(name: str, cfg_provider: Callable[[], dict[str, Any]], instance_i
         from providers.scrobble.bingebase.sink import BingeBaseSink
 
         cls = BingeBaseSink
+    elif sink == "flicklist":
+        from providers.scrobble.flicklist.sink import FlickListSink
+
+        cls = FlickListSink
     elif sink == "scrob":
         from providers.scrobble.scrob.sink import ScrobSink
 

--- a/providers/webhooks/config.py
+++ b/providers/webhooks/config.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from cw_platform.provider_instances import get_provider_block, normalize_instance_id
 
-_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "bingebase", "scrob"}
+_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "bingebase", "flicklist", "scrob"}
 
 _SINK_CREDENTIALS: dict[str, tuple[str, ...]] = {
     "trakt": ("access_token",),
@@ -18,6 +18,7 @@ _SINK_CREDENTIALS: dict[str, tuple[str, ...]] = {
     "floppy": ("server_url", "api_token"),
     "punchplay": ("access_token",),
     "bingebase": ("webhook_url",),
+    "flicklist": ("api_key", "access_token", "token"),
     "scrob": ("api_key",),
 }
 

--- a/providers/webhooks/dispatch.py
+++ b/providers/webhooks/dispatch.py
@@ -92,6 +92,10 @@ def _make_sink(name: str, instance_id: str, cfg_provider: Callable[[], dict[str,
         from providers.scrobble.bingebase.sink import BingeBaseSink
 
         cls = BingeBaseSink
+    elif sink == "flicklist":
+        from providers.scrobble.flicklist.sink import FlickListSink
+
+        cls = FlickListSink
     elif sink == "scrob":
         from providers.scrobble.scrob.sink import ScrobSink
 

--- a/providers/webhooks/plex.py
+++ b/providers/webhooks/plex.py
@@ -61,6 +61,7 @@ _DEF_WEBHOOK: dict[str, Any] = {
     "plex_crosswatch_ratings": False,
     "plex_floppy_ratings": False,
     "plex_punchplay_ratings": False,
+    "plex_flicklist_ratings": False,
 }
 
 _DEF_TRAKT: dict[str, Any] = {
@@ -214,6 +215,7 @@ def _ensure_scrobble(cfg: dict[str, Any]) -> dict[str, Any]:
         "plex_crosswatch_ratings",
         "plex_floppy_ratings",
         "plex_punchplay_ratings",
+        "plex_flicklist_ratings",
     ):
         if key not in wh:
             wh[key] = _DEF_WEBHOOK.get(key, False)
@@ -1144,6 +1146,7 @@ def process_webhook(
     enable_crosswatch_ratings = bool(wh.get("plex_crosswatch_ratings", False)) and "crosswatch" in selected_rating_sinks
     enable_floppy_ratings = bool(wh.get("plex_floppy_ratings", False)) and "floppy" in selected_rating_sinks
     enable_punchplay_ratings = bool(wh.get("plex_punchplay_ratings", False)) and "punchplay" in selected_rating_sinks
+    enable_flicklist_ratings = bool(wh.get("plex_flicklist_ratings", False)) and "flicklist" in selected_rating_sinks
     flt = (wh.get("filters_plex") or {})
     allow_users = {str(x).strip() for x in (flt.get("username_whitelist") or []) if str(x).strip()}
     srv_uuid_allow = _as_filter_set(flt.get("server_uuid_whitelist"))
@@ -1225,7 +1228,7 @@ def process_webhook(
     _emit(logger, f"ids resolved: {media_name_dbg} -> {_describe_ids((show_ids or epi_ids) or all_ids)}", "DEBUG")
 
     if event == "media.rate":
-        if not (enable_trakt_ratings or enable_simkl_ratings or enable_mdblist_ratings or enable_crosswatch_ratings or enable_floppy_ratings):
+        if not (enable_trakt_ratings or enable_simkl_ratings or enable_mdblist_ratings or enable_crosswatch_ratings or enable_floppy_ratings or enable_punchplay_ratings or enable_flicklist_ratings):
             _emit(logger, "rating forwarding disabled", "DEBUG")
             return {"ok": True, "ignored": True}
 
@@ -1296,6 +1299,7 @@ def process_webhook(
                 ("crosswatch", enable_crosswatch_ratings),
                 ("floppy", enable_floppy_ratings),
                 ("punchplay", enable_punchplay_ratings),
+                ("flicklist", enable_flicklist_ratings),
             )
             if on
         ]

--- a/services/playback_progress/adapters/flicklist.py
+++ b/services/playback_progress/adapters/flicklist.py
@@ -1,0 +1,241 @@
+# /services/playback_progress/adapters/flicklist.py
+# CrossWatch - FlickList Playback Progress Adapter
+from __future__ import annotations
+
+from typing import Any, Mapping, cast
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+from providers.sync._mod_FLICKLIST import OPS as FLICKLIST_OPS
+from providers.sync.flicklist._common import write_ident
+
+from ..models import PlaybackActionResult, PlaybackCapabilities, PlaybackListResult, PlaybackRecord, clean_mapping, utc_now_iso
+from .base import PlaybackProgressAdapter, enrich_parallel, public_failure, tmdb_metadata_provider
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _num(value: Any) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(float(str(value).strip()))
+    except Exception:
+        return None
+
+
+def _float(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(str(value).strip())
+    except Exception:
+        return None
+
+
+def _image_url(meta: Mapping[str, Any], kind: str) -> str:
+    rows = _mapping(meta.get("images")).get(kind)
+    if not isinstance(rows, list):
+        return ""
+    for row in rows:
+        if isinstance(row, Mapping) and str(row.get("url") or "").strip():
+            return str(row.get("url") or "").strip()
+    return ""
+
+
+def _metadata_detail(provider: Any, *, media_type: str, ids: Mapping[str, Any], show_ids: Mapping[str, Any]) -> dict[str, Any]:
+    lookup_ids = show_ids if media_type == "episode" and show_ids else ids
+    fetch_ids = {key: str(lookup_ids.get(key) or "").strip() for key in ("tmdb", "imdb", "tvdb") if str(lookup_ids.get(key) or "").strip()}
+    if provider is None or not fetch_ids:
+        return {}
+    try:
+        detail = provider.fetch(entity="tv" if media_type == "episode" else "movie", ids=fetch_ids, need={"poster": True, "backdrop": True, "ids": False})
+    except Exception:
+        return {}
+    if not isinstance(detail, Mapping):
+        return {}
+    out: dict[str, Any] = {}
+    title = str(detail.get("title") or "").strip()
+    if title:
+        out["title"] = title
+    year = _num(detail.get("year"))
+    if year is not None:
+        out["year"] = year
+    poster = _image_url(detail, "poster")
+    if poster:
+        out["poster_url"] = poster
+    backdrop = _image_url(detail, "backdrop")
+    if backdrop:
+        out["backdrop_url"] = backdrop
+    return out
+
+
+def _progress_item(record: Mapping[str, Any]) -> dict[str, Any]:
+    meta = _mapping(record.get("provider_metadata"))
+    stored = meta.get("progress_item")
+    if isinstance(stored, Mapping):
+        item = clean_mapping(stored)
+    else:
+        media_type = str(record.get("media_type") or "").strip().lower()
+        ids = clean_mapping(_mapping(record.get("ids")))
+        item = {
+            "type": "episode" if media_type in {"episode", "anime_episode"} else "movie",
+            "ids": ids,
+            "title": record.get("episode_title") or record.get("title") or record.get("series_title"),
+            "year": record.get("year"),
+        }
+        if item["type"] == "episode":
+            item["show_ids"] = clean_mapping(_mapping(meta.get("show_ids"))) or ids
+            item["series_title"] = record.get("series_title")
+            item["season"] = record.get("season")
+            item["episode"] = record.get("episode")
+        item = clean_mapping(item)
+    remote_id = str(record.get("remote_id") or "").strip()
+    if remote_id:
+        item["_flicklist_playback_id"] = remote_id
+    return item
+
+
+def _progress_item_with_percent(record: Mapping[str, Any], progress_percent: float) -> dict[str, Any]:
+    item = _progress_item(record)
+    item["progress_percent"] = round(max(0.0, min(100.0, float(progress_percent))), 3)
+    item["progress_at"] = utc_now_iso()
+    return clean_mapping(item)
+
+
+class FlickListPlaybackAdapter(PlaybackProgressAdapter):
+    provider = "flicklist"
+    provider_label = "FlickList"
+    ops = FLICKLIST_OPS
+
+    def capabilities(self, config_view: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackCapabilities:
+        try:
+            configured = bool(self.ops.is_configured(config_view))
+        except Exception:
+            configured = False
+        caps = _mapping(self.ops.capabilities())
+        progress = _mapping(caps.get("progress"))
+        history = _mapping(caps.get("history"))
+        types = _mapping(progress.get("types"))
+        reason = "" if configured else "FlickList is not connected for this instance."
+        return PlaybackCapabilities(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            configured=configured,
+            read=bool(configured and progress.get("read")),
+            remove_progress=bool(configured and progress.get("remove")),
+            mark_watched=bool(configured and history.get("write")),
+            update_progress=bool(configured and progress.get("upsert")),
+            bulk_remove_progress=bool(configured and progress.get("remove")),
+            bulk_mark_watched=bool(configured and history.get("write")),
+            bulk_update_progress=bool(configured and progress.get("upsert")),
+            supports_movies=bool(configured and types.get("movies")),
+            supports_episodes=bool(configured and types.get("episodes")),
+            supports_anime=False,
+            reason=reason,
+        )
+
+    def list_progress(
+        self,
+        config_view: Mapping[str, Any],
+        *,
+        instance_id: str,
+        instance_label: str,
+        force_refresh: bool = False,
+    ) -> PlaybackListResult:
+        caps = self.capabilities(config_view, instance_id=instance_id, instance_label=instance_label)
+        if not caps.read:
+            return PlaybackListResult(False, self.provider, instance_id, error_code="unsupported" if caps.configured else "not_configured", message=caps.reason or "FlickList does not support playback listing.")
+        try:
+            index = self.ops.build_index(config_view, feature="progress") or {}
+        except Exception:
+            return PlaybackListResult(False, self.provider, instance_id, error_code="provider_error", message="FlickList progress request failed.", retryable=True)
+        metadata = tmdb_metadata_provider(config_view)
+        pending = [(key, item) for key, item in dict(index).items() if isinstance(item, Mapping)]
+        items = enrich_parallel(pending, lambda entry: self._record(entry[0], entry[1], instance_id, instance_label, caps, metadata))
+        return PlaybackListResult(True, self.provider, instance_id, items=[item for item in items if item], refreshed_at=utc_now_iso())
+
+    def _record(self, key: Any, item: Mapping[str, Any], instance_id: str, instance_label: str, caps: PlaybackCapabilities, metadata: Any = None) -> PlaybackRecord | None:
+        mini = id_minimal(item)
+        typ = str(mini.get("type") or item.get("type") or "").strip().lower()
+        media_type = "episode" if typ == "episode" else "movie"
+        ids = clean_mapping(_mapping(mini.get("ids") or item.get("ids")))
+        show_ids = clean_mapping(_mapping(mini.get("show_ids") or item.get("show_ids")))
+        title = str(mini.get("title") or item.get("title") or item.get("series_title") or "").strip()
+        series_title = str(mini.get("series_title") or item.get("series_title") or "").strip()
+        needs_metadata = not title or (media_type == "episode" and not series_title) or not str(item.get("poster") or item.get("poster_url") or "").strip()
+        resolved = _metadata_detail(metadata, media_type=media_type, ids=ids, show_ids=show_ids) if needs_metadata else {}
+        if resolved.get("title"):
+            if media_type == "episode" and not series_title:
+                series_title = str(resolved["title"])
+            if not title:
+                title = str(resolved["title"])
+        year = _num(mini.get("year") or item.get("year") or resolved.get("year"))
+        progress = _float(item.get("progress_percent") or item.get("progress"))
+        if progress is not None:
+            progress = round(max(0.0, min(100.0, progress)), 3)
+        canonical = canonical_key(mini) or str(key or "")
+        progress_item = clean_mapping(item)
+        can_update = bool(caps.update_progress and progress_item and write_ident(progress_item))
+        if not canonical or progress is None:
+            return None
+        episode_title = title if media_type == "episode" and title != series_title else ""
+        return PlaybackRecord(
+            provider=self.provider,
+            provider_label=self.provider_label,
+            instance_id=instance_id,
+            instance_label=instance_label,
+            remote_id=str(item.get("_flicklist_playback_id") or key or ""),
+            canonical_key=canonical,
+            media_type=media_type,
+            title=series_title or title,
+            episode_title=episode_title,
+            series_title=series_title,
+            season=_num(mini.get("season") or item.get("season")),
+            episode=_num(mini.get("episode") or item.get("episode")),
+            year=year,
+            ids=ids,
+            progress_percent=progress,
+            progress_at=str(item.get("progress_at") or item.get("updated_at") or "").strip() or None,
+            updated_at=str(item.get("updated_at") or item.get("progress_at") or "").strip() or None,
+            source_app="FlickList",
+            can_remove_progress=caps.remove_progress,
+            can_mark_watched=caps.mark_watched,
+            can_update_progress=can_update,
+            capability_messages=[] if caps.configured else [caps.reason],
+            poster_url=str(item.get("poster") or item.get("poster_url") or resolved.get("poster_url") or "").strip(),
+            backdrop_url=str(item.get("backdrop") or item.get("backdrop_url") or resolved.get("backdrop_url") or "").strip(),
+            provider_metadata={"progress_item": progress_item, "show_ids": show_ids},
+        )
+
+    def remove_progress(self, config_view: Mapping[str, Any], record: Mapping[str, Any], *, instance_id: str, instance_label: str) -> PlaybackActionResult:
+        try:
+            result = self.ops.remove(config_view, [_progress_item(record)], feature="progress", dry_run=False) or {}
+            ok = bool(result.get("ok"))
+            return PlaybackActionResult(ok, self.provider, instance_id, "remove_progress", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), message="Playback record removed." if ok else "FlickList remove progress failed.", error_code="" if ok else "progress_failed", decision_context=clean_mapping(result))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="remove_progress", message="FlickList remove progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+
+    def mark_watched(self, config_view: Mapping[str, Any], record: Mapping[str, Any], *, instance_id: str, instance_label: str, watched_at: str | None = None) -> PlaybackActionResult:
+        item = _progress_item(record)
+        item["watched_at"] = watched_at or utc_now_iso()
+        try:
+            result = self.ops.add(config_view, [item], feature="history", dry_run=False) or {}
+            ok = bool(result.get("ok"))
+            return PlaybackActionResult(ok, self.provider, instance_id, "mark_watched", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), message="Marked watched on FlickList." if ok else "FlickList mark watched failed.", error_code="" if ok else "history_failed", history_result=clean_mapping(result))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="mark_watched", message="FlickList mark watched failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+
+    def update_progress(self, config_view: Mapping[str, Any], record: Mapping[str, Any], progress_percent: float, *, instance_id: str, instance_label: str) -> PlaybackActionResult:
+        try:
+            result = self.ops.add(config_view, [_progress_item_with_percent(record, progress_percent)], feature="progress", dry_run=False) or {}
+            ok = bool(result.get("ok"))
+            return PlaybackActionResult(ok, self.provider, instance_id, "update_progress", remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""), message=f"Progress updated on FlickList to {progress_percent:g}%." if ok else "FlickList update progress failed.", error_code="" if ok else "progress_failed", decision_context=clean_mapping(result))
+        except Exception:
+            return public_failure(provider=self.provider, instance_id=instance_id, operation="update_progress", message="FlickList update progress failed.", retryable=True, remote_id=str(record.get("remote_id") or ""), canonical_key=str(record.get("canonical_key") or ""))
+
+
+__all__ = ["FlickListPlaybackAdapter"]

--- a/services/playback_progress/service.py
+++ b/services/playback_progress/service.py
@@ -45,6 +45,7 @@ LIVE_MAX_AGE_SECONDS = 10 * 60
 CANONICAL_TMDB_RE = re.compile(r"^tmdb:(\d+)(?:#|$)", re.I)
 EDITABLE_PROGRESS_MIN_PERCENT = 2.0
 EDITABLE_PROGRESS_DEFAULT_MAX_EXCLUSIVE = 100.0
+GROUP_ID_KEYS = ("tmdb", "imdb", "tvdb", "trakt", "simkl", "mdblist")
 
 
 def _parse_iso(value: Any) -> datetime | None:
@@ -77,6 +78,58 @@ def _group_number(value: Any) -> str:
         return str(int(value))
     except Exception:
         return str(value).strip().lower()
+
+
+def _group_id_value(provider: str, value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if provider == "imdb" and text.isdigit():
+        text = f"tt{text}"
+    return text.lower()
+
+
+def _canonical_id_pair(value: Any) -> tuple[str, str] | None:
+    text = str(value or "").strip()
+    if not text or text.lower().startswith("unknown:"):
+        return None
+    base = text.split("#", 1)[0].strip()
+    if ":" not in base:
+        return None
+    provider, ident = base.split(":", 1)
+    provider = provider.strip().lower()
+    ident = _group_id_value(provider, ident)
+    if provider not in GROUP_ID_KEYS or not ident:
+        return None
+    return provider, ident
+
+
+def _record_movie_id_aliases(item: Mapping[str, Any]) -> list[str]:
+    ids = _as_mapping(item.get("ids"))
+    aliases: list[str] = []
+    canonical = _canonical_id_pair(item.get("canonical_key"))
+    if canonical:
+        aliases.append(f"{canonical[0]}:{canonical[1]}")
+    for provider in GROUP_ID_KEYS:
+        value = ids.get(provider) or item.get(provider)
+        ident = _group_id_value(provider, value)
+        if ident:
+            aliases.append(f"{provider}:{ident}")
+    return list(dict.fromkeys(aliases))
+
+
+def _record_show_id_aliases(item: Mapping[str, Any]) -> list[str]:
+    aliases: list[str] = []
+    canonical = _canonical_id_pair(item.get("canonical_key"))
+    if canonical:
+        aliases.append(f"{canonical[0]}:{canonical[1]}")
+    show_ids = _show_ids_for_artwork(item)
+    for provider in GROUP_ID_KEYS:
+        value = show_ids.get(provider)
+        ident = _group_id_value(provider, value)
+        if ident:
+            aliases.append(f"{provider}:{ident}")
+    return list(dict.fromkeys(aliases))
 
 
 def _live_source_provider(value: Any) -> str:
@@ -278,6 +331,14 @@ def _record_group_keys(item: Mapping[str, Any]) -> list[str]:
     if key and not key.startswith("unknown:"):
         keys.append(f"key:{key}:profile:{profile}")
     media_type = _group_text(item.get("media_type"))
+    if media_type == "movie":
+        for alias in _record_movie_id_aliases(item):
+            keys.append(f"id:movie:{alias}:profile:{profile}")
+    elif media_type in {"episode", "anime_episode"}:
+        season = _group_number(item.get("season"))
+        episode = _group_number(item.get("episode"))
+        for alias in _record_show_id_aliases(item):
+            keys.append(f"id:episode:{alias}:{season}:{episode}:profile:{profile}")
     title = _group_text(item.get("title"))
     series = _group_text(item.get("series_title"))
     season = _group_number(item.get("season"))

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -9,6 +9,7 @@ from providers.metadata._meta_TMDB import TmdbProvider
 
 from services.playback_progress.service import (
     _combine_records,
+    _group_records,
     _overlay_live_streams,
     _progress_edit_max_exclusive,
     _profile_has_explicit_identity,
@@ -83,8 +84,9 @@ def test_playback_progress_frontend_includes_kodi_provider_key():
     js = (ROOT / "assets" / "js" / "playback_progress.js").read_text(encoding="utf-8")
 
     keys = js.split("PLAYBACK_PROVIDER_KEYS")[1].split("]")[0]
-    for provider in ("crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy"):
+    for provider in ("crosswatch", "trakt", "simkl", "mdblist", "publicmetadb", "punchplay", "plex", "emby", "jellyfin", "nuvio", "kodi", "stremio", "floppy"):
         assert f'"{provider}"' in keys, provider
+    assert '"flicklist"' not in keys
 
 
 def test_playback_progress_frontend_is_readonly_for_managed_users():
@@ -275,6 +277,36 @@ def test_combined_record_uses_stable_artwork_source_instead_of_newest_record():
 
     assert forward["poster_url"] == older["poster_url"]
     assert reverse["poster_url"] == older["poster_url"]
+
+
+def test_playback_progress_groups_cross_provider_id_aliases():
+    trakt = _record(
+        provider="trakt",
+        provider_label="Trakt",
+        remote_id="trakt-1",
+        canonical_key="tmdb:1662317",
+        title="The Crash",
+        year=2026,
+        ids={"tmdb": "1662317", "imdb": "tt40792117"},
+        progress_percent=21.0,
+    )
+    stremio = _record(
+        provider="stremio",
+        provider_label="Stremio",
+        remote_id="stremio-1",
+        canonical_key="imdb:tt40792117",
+        title="The Crash",
+        year=None,
+        ids={"imdb": "tt40792117"},
+        progress_percent=21.5,
+    )
+
+    rows = _group_records([trakt, stremio])
+
+    assert len(rows) == 1
+    assert rows[0]["provider"] == "combined"
+    assert rows[0]["provider_count"] == 2
+    assert rows[0]["ids"] == {"tmdb": "1662317", "imdb": "tt40792117"}
 
 
 def test_same_title_with_different_profile_progress_does_not_group():
@@ -1443,6 +1475,6 @@ def test_late_shown_filters_are_enhanced_like_the_rest() -> None:
     profile = js.split("function userProfileOptions(", 1)[1].split("function providerOptions(", 1)[0]
     rating = js.split("function renderItems(", 1)[1].split("const markup =", 1)[0]
 
-    assert "ProfileSelect?.enhanceProfile?.(select" in profile
+    assert "ProfileSelect?.enhanceUserProfile?.(select" in profile
     assert "IconSelect?.enhance?.(ratingFilter" in rating
     assert "if (showRating)" in rating

--- a/tests/test_wall_api.py
+++ b/tests/test_wall_api.py
@@ -126,3 +126,49 @@ def test_wall_endpoint_reads_db_watchlist(monkeypatch, tmp_path):
     assert data["total"] == 1
     assert data["items"][0]["tmdb"] == 550
     assert data["last_sync_epoch"] == 123
+
+
+def test_wall_endpoint_uses_watchlist_id_alias_merge(monkeypatch, tmp_path):
+    app = FastAPI()
+    wallAPI.register_wall(app)
+    wallAPI._WALL_CACHE.clear()
+    wallAPI._WALL_CACHE.update({"key": None, "data": None})
+
+    monkeypatch.setattr(wallAPI, "CONFIG", tmp_path)
+    monkeypatch.setattr(watchlist_service, "CONFIG", tmp_path)
+    monkeypatch.setattr(wallAPI, "load_config", lambda: {"tmdb": {"api_key": "tmdb-key"}})
+    monkeypatch.setattr(wallAPI, "config_path", lambda: tmp_path / "config.json")
+    monkeypatch.setattr(watchlist_service, "_registry_sync_providers", lambda: ["TRAKT", "STREMIO"])
+    StateStore(tmp_path).save_feature_baseline(
+        provider="TRAKT",
+        feature="watchlist",
+        items={
+            "tmdb:1662317": {
+                "type": "movie",
+                "title": "The Crash",
+                "year": 2026,
+                "ids": {"tmdb": "1662317", "imdb": "tt40792117"},
+            }
+        },
+        last_sync_epoch=123,
+    )
+    StateStore(tmp_path).save_feature_baseline(
+        provider="STREMIO",
+        feature="watchlist",
+        items={
+            "imdb:tt40792117": {
+                "type": "movie",
+                "title": "The Crash",
+                "ids": {"imdb": "tt40792117"},
+            }
+        },
+        last_sync_epoch=123,
+    )
+
+    endpoint = next(cast(APIRoute, route).endpoint for route in app.routes if getattr(route, "path", "") == "/api/state/wall")
+    data = endpoint(both_only=False, active_only=False, limit=20)
+
+    assert data["total"] == 1
+    assert data["items"][0]["key"] == "tmdb:1662317"
+    assert data["items"][0]["tmdb"] == 1662317
+    assert data["items"][0]["sources"] == ["stremio", "trakt"]

--- a/tests/test_watchlist_delete_scope.py
+++ b/tests/test_watchlist_delete_scope.py
@@ -236,3 +236,49 @@ def test_watchlist_aliases_include_simkl_and_mdblist_native_ids(monkeypatch) -> 
     assert "simkl:42" in by_key["simkl:42"]["aliases"]
     assert "mdblist:99" in by_key
     assert "mdblist:99" in by_key["mdblist:99"]["aliases"]
+
+
+def test_build_watchlist_merges_cross_provider_id_aliases(monkeypatch) -> None:
+    import services.watchlist as wl
+
+    monkeypatch.setattr(wl, "_registry_sync_providers", lambda: ["TRAKT", "STREMIO"])
+    monkeypatch.setattr(wl, "_load_hide_set", lambda: set())
+
+    state = {
+        "providers": {
+            "TRAKT": {
+                "watchlist": {
+                    "baseline": {
+                        "items": {
+                            "tmdb:1662317": {
+                                "type": "movie",
+                                "title": "The Crash",
+                                "year": 2026,
+                                "ids": {"tmdb": "1662317", "imdb": "tt40792117"},
+                            }
+                        }
+                    }
+                }
+            },
+            "STREMIO": {
+                "watchlist": {
+                    "baseline": {
+                        "items": {
+                            "imdb:tt40792117": {
+                                "type": "movie",
+                                "title": "The Crash",
+                                "ids": {"imdb": "tt40792117"},
+                            }
+                        }
+                    }
+                }
+            },
+        }
+    }
+
+    rows = wl.build_watchlist(state, tmdb_ok=False)
+
+    assert len(rows) == 1
+    assert rows[0]["key"] == "tmdb:1662317"
+    assert rows[0]["sources"] == ["stremio", "trakt"]
+    assert rows[0]["ids"] == {"tmdb": "1662317", "imdb": "tt40792117"}


### PR DESCRIPTION
# Pull request

## Change

- New FlickList scrobble sink, wired into the watcher, webhook dispatch and routes
- FlickList added to the sink and rating sink lists, plus plex_flicklist_ratings in the scrobbler API and both scrobbler modals
- FlickList playback progress adapter, backend only.
- Playback progress now groups records by shared tmdb, imdb, tvdb, trakt, simkl and mdblist ids

## Why

Last batch to add for new provider FlickList

## Testing

- tests/test_playback_progress.py
- tests/test_wall_api.py
- tests/test_watchlist_delete_scope.py

## Issue

Relates to #229
Playback progress is disabled due to API issues at FlickList