### PR TITLE
Add: sync pair listing CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -116,8 +116,11 @@ Any unique id prefix works, so `cw pair show pair_07c3` is enough. The route nam
 ## Sync
 
 ```
+cw sync list [--enabled]           run order, endpoints and enabled features
 cw sync run                        every enabled pair
-cw sync run --pair pair_07c3       just the one
+cw sync run 1                      just pair #1 from cw sync list
+cw sync run pair_07c3              just the one by id or unique prefix
+cw sync run --pair pair_07c3       same selector, option form
 cw sync run --follow               run it and stream the log until it finishes
 cw sync status                     current or last run, with counts
 cw sync follow                     attach to a run already going
@@ -360,7 +363,7 @@ cw maintenance database            runtime db health
 cw maintenance events              archive health, --optimize, --rebuild
 cw maintenance cache <what>        all, metadata, provider-sync, activity-log, scrobbles, state
 cw maintenance provider-cache
-cw maintenance provider-cleanup    clear provider watchlist, ratings, history or progress
+cw maintenance provider-cleanup    clear provider watchlist, ratings, history, progress or collection
 cw maintenance state-file --prune|--compact
 cw maintenance tracker [--clear]
 cw maintenance reset-stats
@@ -449,7 +452,7 @@ Read only and repair commands keep going by reading the install. You get a note 
 ! Cannot reach CrossWatch at http://127.0.0.1:8787 - answering from the local install instead
 ```
 
-Works without the service: `status`, `health`, `version`, all of `config`, `pair list/show/enable/disable/delete`, `scheduler status/next/show`, and every `auth token` command.
+Works without the service: `status`, `health`, `version`, all of `config`, `pair list/show/enable/disable/delete`, `sync list`, `scheduler status/next/show`, and every `auth token` command.
 
 Anything that needs the engine running, so starting a sync, poking the watcher, streaming logs, fails with exit 3 instead of doing something the UI cannot see. `--local` forces that mode and turns those into an error straight away.
 

--- a/cli/_util.py
+++ b/cli/_util.py
@@ -256,6 +256,10 @@ def find_pair(pairs: list[dict[str, Any]], needle: str) -> dict[str, Any]:
     for pair in pairs:
         if str(pair.get("id") or "") == want:
             return pair
+    if re.fullmatch(r"\d+", want):
+        index = int(want)
+        if 1 <= index <= len(pairs):
+            return pairs[index - 1]
     lowered = want.lower()
     partial = [p for p in pairs if str(p.get("id") or "").lower().startswith(lowered)]
     if len(partial) == 1:
@@ -266,7 +270,7 @@ def find_pair(pairs: list[dict[str, Any]], needle: str) -> dict[str, Any]:
     labelled = [p for p in pairs if pair_label(p).lower().replace(" ", "") == lowered.replace(" ", "")]
     if len(labelled) == 1:
         return labelled[0]
-    raise CLIError(f"No pair matches '{want}'", hint="Run 'cw pair list' to see the configured pairs.", exit_code=5)
+    raise CLIError(f"No pair matches '{want}'", hint="Run 'cw sync list' to see the configured pairs.", exit_code=5)
 
 
 LOG_CONTROL_LINES = {"::CLEAR::"}

--- a/cli/commands/auth.py
+++ b/cli/commands/auth.py
@@ -69,6 +69,13 @@ ENDPOINTS: dict[str, Endpoints] = {
         cancel="/api/bingebase/device/cancel",
         disconnect="/api/bingebase/disconnect",
     ),
+    "FLICKLIST": Endpoints(
+        submit="/api/flicklist/save",
+        start="/api/flicklist/device/start",
+        poll="/api/flicklist/device/poll",
+        cancel="/api/flicklist/device/cancel",
+        disconnect="/api/flicklist/disconnect",
+    ),
     "NUVIO": Endpoints(
         start="/api/nuvio/device/start",
         poll="/api/nuvio/device/poll",

--- a/cli/commands/capture.py
+++ b/cli/commands/capture.py
@@ -12,7 +12,7 @@ from .._context import Ctx
 from .._errors import CLIError
 from .._util import as_dict, error_text, fmt_ts, rows_from_payload
 
-capture_app = typer.Typer(help="Captures, the rollback tool for watchlist, ratings and history.", no_args_is_help=True)
+capture_app = typer.Typer(help="Captures, the rollback tool for watchlist, ratings, history, progress and collections.", no_args_is_help=True)
 
 
 def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:

--- a/cli/commands/editor.py
+++ b/cli/commands/editor.py
@@ -37,7 +37,7 @@ def _rows(payload: Any, *keys: str) -> list[dict[str, Any]]:
 @editor_app.command("list")
 def editor_list(
     ctx: typer.Context,
-    kind: str = typer.Option("watchlist", "--kind", "-k", help="watchlist, ratings, history or playlists."),
+    kind: str = typer.Option("watchlist", "--kind", "-k", help="watchlist, ratings, history, progress, playlists or collection."),
     provider: str = typer.Option("", "--provider", "-p", help="Limit to one provider."),
     instance: str = typer.Option("", "--instance", "-i", "--profile", help="Provider instance/profile id."),
     source: str = typer.Option("state", "--source", help="state/current, manual or playlist."),

--- a/cli/commands/maintenance.py
+++ b/cli/commands/maintenance.py
@@ -24,7 +24,7 @@ CACHES = {
     "state": "/api/maintenance/clear-state",
 }
 
-PROVIDER_CLEANUP_FEATURES = ("watchlist", "ratings", "history", "progress")
+PROVIDER_CLEANUP_FEATURES = ("watchlist", "ratings", "history", "progress", "collection")
 
 MAINTENANCE_TOOLS = [
     ("Sync", "Rebuild sync state", "cw maintenance cache state --yes"),
@@ -269,13 +269,13 @@ def maintenance_provider_cleanup(
     provider: str = typer.Option("", "--provider", "-p", help="Provider to clear, for example PLEX."),
     instance: str = typer.Option("default", "--instance", "-i", help="Provider profile/instance id."),
     feature: list[str] = typer.Option([], "--feature", "-F", help="Data to clear. Repeat or comma-separate."),
-    all_features: bool = typer.Option(False, "--all", help="Clear watchlist, ratings, history and progress."),
+    all_features: bool = typer.Option(False, "--all", help="Clear watchlist, ratings, history, progress and collection."),
     targets: bool = typer.Option(False, "--targets", help="Show provider cleanup targets."),
     wait: bool = typer.Option(True, "--wait/--no-wait", help="Wait for cleanup to finish."),
     timeout: float = typer.Option(900.0, "--timeout", help="How long to wait, in seconds."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
 ) -> None:
-    """Clear provider watchlist, ratings, history or progress by profile."""
+    """Clear provider watchlist, ratings, history, progress or collection by profile."""
     state: Ctx = ctx.obj
     if targets or not provider.strip():
         payload = state.get("/api/snapshots/manifest")
@@ -301,7 +301,7 @@ def maintenance_provider_cleanup(
     if not features:
         raise CLIError(
             "Pick at least one cleanup feature",
-            hint="Use --feature watchlist, --feature ratings, --feature history, --feature progress or --all.",
+            hint="Use --feature watchlist, --feature ratings, --feature history, --feature progress, --feature collection or --all.",
             exit_code=EXIT_USAGE,
         )
     pid = provider.strip().upper()

--- a/cli/commands/pair.py
+++ b/cli/commands/pair.py
@@ -203,7 +203,7 @@ def pair_disable(ctx: typer.Context, pair_id: str = typer.Argument(..., help="Pa
 def pair_feature(
     ctx: typer.Context,
     pair_id: str = typer.Argument(..., help="Pair id or prefix."),
-    feature: str = typer.Argument(..., help="Feature name, for example watchlist, ratings, history, playlists."),
+    feature: str = typer.Argument(..., help="Feature name, for example watchlist, ratings, history, playlists, collection."),
     value: str = typer.Argument(..., help="on or off."),
 ) -> None:
     """Turn one feature of a pair on or off."""

--- a/cli/commands/sync.py
+++ b/cli/commands/sync.py
@@ -14,12 +14,14 @@ import typer
 from .._context import Ctx
 from .._errors import EXIT_BUSY, CLIError
 from .._render import state_text
-from .._util import as_dict, coerce_bool, error_text, find_pair, fmt_duration, fmt_ts, is_log_control, pair_label, parse_iso, strip_ansi
+from .._util import as_dict, coerce_bool, error_text, find_pair, fmt_duration, fmt_ts, is_log_control, pair_features, pair_label, parse_iso, strip_ansi
 
 sync_app = typer.Typer(help="Trigger, watch and inspect sync runs.", no_args_is_help=True)
 
 EXIT_LINE = re.compile(r"\[SYNC\]\s*exit code:\s*(-?\d+)")
 LOG_TAG = "SYNC"
+COUNT_FEATURES = ("watchlist", "ratings", "history", "progress", "playlists", "collection")
+COUNT_HEADERS = ("WATCHLIST", "RATINGS", "HISTORY", "PROGRESS", "PLAYLISTS", "COLLECTION")
 
 
 def _summary(state: Ctx) -> dict[str, Any]:
@@ -30,6 +32,27 @@ def _summary(state: Ctx) -> dict[str, Any]:
 def _run_state(state: Ctx) -> dict[str, Any]:
     payload = state.get("/api/run/cancel")
     return as_dict(payload)
+
+
+def _pairs(state: Ctx) -> list[dict[str, Any]]:
+    payload = state.get("/api/pairs")
+    if isinstance(payload, dict) and payload.get("ok") is False:
+        raise CLIError(error_text(payload, "Cannot read pairs"))
+    if not isinstance(payload, list):
+        return []
+    return [p for p in payload if isinstance(p, dict)]
+
+
+def _provider_ref(pair: dict[str, Any], side: str) -> str:
+    provider = str(pair.get(side) or "?").strip().upper()
+    instance = str(pair.get(f"{side}_instance") or "default").strip()
+    if not instance or instance.lower() == "default":
+        return provider
+    return f"{provider}:{instance}"
+
+
+def _feature_summary(pair: dict[str, Any]) -> str:
+    return ", ".join(pair_features(pair)) or "-"
 
 
 class _Follower:
@@ -107,7 +130,8 @@ class _Follower:
 @sync_app.command("run")
 def sync_run(
     ctx: typer.Context,
-    pair: str = typer.Option("", "--pair", "-p", help="Run one pair only (id or prefix). Default runs every enabled pair."),
+    target: str = typer.Argument("", help="Optional pair number, id, prefix or label. Default runs every enabled pair."),
+    pair: str = typer.Option("", "--pair", "-p", help="Run one pair only (number, id, prefix or label)."),
     follow: bool = typer.Option(False, "--follow", "-f", help="Stream the sync log until the run finishes."),
     timeout: float = typer.Option(0.0, "--timeout", help="Give up following after this many seconds (0 = no limit)."),
 ) -> None:
@@ -116,13 +140,14 @@ def sync_run(
     state.require_service("Starting a sync")
     payload: dict[str, Any] = {"source": "cli"}
     label = "all enabled pairs"
-    if pair.strip():
-        target = find_pair(
-            [p for p in (state.get("/api/pairs") or []) if isinstance(p, dict)],
-            pair,
+    selector = (target or "").strip() or (pair or "").strip()
+    if selector:
+        selected_pair = find_pair(
+            _pairs(state),
+            selector,
         )
-        payload["pair_id"] = str(target.get("id") or "")
-        label = f"{pair_label(target)} ({target.get('id')})"
+        payload["pair_id"] = str(selected_pair.get("id") or "")
+        label = f"{pair_label(selected_pair)} ({selected_pair.get('id')})"
 
     if follow:
         code = _start_and_follow(state, payload, label, timeout)
@@ -141,6 +166,38 @@ def sync_run(
     run_id = str((result or {}).get("run_id") or "")
     state.out.success(f"Sync started for {label}" + (f" (run {run_id})" if run_id else ""))
     state.out.info("Follow it with 'cw logs tail -f' or 'cw sync status'.")
+
+
+@sync_app.command("list")
+def sync_list(
+    ctx: typer.Context,
+    enabled_only: bool = typer.Option(False, "--enabled", help="Only show enabled pairs."),
+) -> None:
+    """List configured sync pairs."""
+    state: Ctx = ctx.obj
+    pairs = _pairs(state)
+    if enabled_only:
+        pairs = [p for p in pairs if p.get("enabled", True) is not False]
+    if state.out.json_mode:
+        state.out.data(pairs)
+        return
+    state.out.table(
+        ["#", "ID", "SOURCE", "TARGET", "MODE", "STATE", "FEATURES"],
+        [
+            [
+                str(index),
+                str(p.get("id") or ""),
+                _provider_ref(p, "source"),
+                _provider_ref(p, "target"),
+                str(p.get("mode") or "one-way"),
+                state_text(p.get("enabled", True) is not False, on="enabled", off="disabled"),
+                _feature_summary(p),
+            ]
+            for index, p in enumerate(pairs, start=1)
+        ],
+        title="Sync pairs",
+        empty="No pairs configured yet.",
+    )
 
 
 def _start_and_follow(state: Ctx, payload: dict[str, Any], label: str, timeout: float) -> int:
@@ -199,10 +256,10 @@ def sync_status(ctx: typer.Context) -> None:
         rows = []
         for name, block in sorted(counts.items()):
             if isinstance(block, dict):
-                rows.append([name, *[str(block.get(k, "-")) for k in ("watchlist", "ratings", "history", "playlists")]])
+                rows.append([name, *[str(block.get(k, "-")) for k in COUNT_FEATURES]])
         if rows:
             state.out.print()
-            state.out.table(["PROVIDER", "WATCHLIST", "RATINGS", "HISTORY", "PLAYLISTS"], rows, title="Provider counts")
+            state.out.table(["PROVIDER", *COUNT_HEADERS], rows, title="Provider counts")
 
 
 @sync_app.command("follow")
@@ -280,8 +337,8 @@ def sync_providers(
         if isinstance(source, dict):
             for name, block in sorted(source.items()):
                 if isinstance(block, dict):
-                    rows.append([name, *[str(block.get(k, "-")) for k in ("watchlist", "ratings", "history", "playlists")]])
-        state.out.table(["PROVIDER", "WATCHLIST", "RATINGS", "HISTORY", "PLAYLISTS"], rows, title="Provider counts")
+                    rows.append([name, *[str(block.get(k, "-")) for k in COUNT_FEATURES]])
+        state.out.table(["PROVIDER", *COUNT_HEADERS], rows, title="Provider counts")
         return
     source = payload.get("providers") if isinstance(payload, dict) else payload
     rows = []

--- a/cli/commands/transfer.py
+++ b/cli/commands/transfer.py
@@ -46,7 +46,7 @@ def export_options(ctx: typer.Context) -> None:
 def export_preview(
     ctx: typer.Context,
     provider: str = typer.Option(..., "--provider", "-p", help="Provider to export from."),
-    feature: str = typer.Option("watchlist", "--feature", "-F", help="watchlist, ratings or history."),
+    feature: str = typer.Option("watchlist", "--feature", "-F", help="watchlist, ratings, history or collection."),
     export_format: str = typer.Option("letterboxd", "--format", help="Output format."),
     media_types: str = typer.Option("movie", "--types", help="Comma separated media types."),
     instance: str = typer.Option("all", "--instance", "-i", help="Provider instance id."),
@@ -82,7 +82,7 @@ def export_file(
     ctx: typer.Context,
     output: Path = typer.Argument(..., help="Where to write the export."),
     provider: str = typer.Option(..., "--provider", "-p", help="Provider to export from."),
-    feature: str = typer.Option("watchlist", "--feature", "-F", help="watchlist, ratings or history."),
+    feature: str = typer.Option("watchlist", "--feature", "-F", help="watchlist, ratings, history or collection."),
     export_format: str = typer.Option("letterboxd", "--format", help="Output format."),
     media_types: str = typer.Option("movie", "--types", help="Comma separated media types."),
     instance: str = typer.Option("all", "--instance", "-i", help="Provider instance id."),


### PR DESCRIPTION
# Pull request

## Change

- Adds `cw sync list` and lets `cw sync run` take a pair number, id, prefix, or label.

## Why

- Makes it easier to see configured sync pairs and run just one pair from the CLI or shell.

## Testing

- tests\test_cli.py

## Issue

NA