### PR TITLE
Add: collection sync backend

### DIFF
--- a/api/editorAPI.py
+++ b/api/editorAPI.py
@@ -1,5 +1,5 @@
 # /api/editorAPI.py
-# CrossWatch - Tracker editor API for history / ratings / watchlist / progress
+# CrossWatch - Tracker editor API for history / ratings / watchlist / progress / collection
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
@@ -373,7 +373,7 @@ def _merge_policy(into: dict[str, Any], src: dict[str, Any], mode: str) -> dict[
         return out
 
     def _merge_feature_block(tgt: dict[str, Any], node: dict[str, Any]) -> None:
-        for kind in ("watchlist", "history", "ratings", "progress"):
+        for kind in ("watchlist", "history", "ratings", "progress", "collection"):
             f = node.get(kind)
             if not isinstance(f, dict):
                 continue
@@ -461,7 +461,7 @@ def _policy_stats(pol: dict[str, Any]) -> dict[str, int]:
         if not isinstance(node, dict):
             continue
         pcount += 1
-        for kind in ("watchlist", "history", "ratings", "progress"):
+        for kind in ("watchlist", "history", "ratings", "progress", "collection"):
             f = node.get(kind)
             if not isinstance(f, dict):
                 continue
@@ -648,7 +648,7 @@ def _save_state_manual(
 
 def _normalize_kind(val: str | None) -> Kind:
     k = (val or "watchlist").strip().lower()
-    if k not in ("watchlist", "history", "ratings", "progress"):
+    if k not in ("watchlist", "history", "ratings", "progress", "collection"):
         raise HTTPException(status_code=400, detail=f"Unsupported kind: {k}")
     return k  # type: ignore[return-value]
 
@@ -1164,11 +1164,13 @@ def _editor_send_targets(cfg: dict[str, Any], feature: str) -> list[dict[str, An
     feat = str(feature or "").strip().lower()
     if feat == "rating":
         feat = "ratings"
-    if feat not in {"watchlist", "history", "ratings", "progress"}:
+    if feat not in {"watchlist", "history", "ratings", "progress", "collection"}:
         return []
 
     targets: list[dict[str, Any]] = []
     for provider in sync_provider_names(upper=True):
+        if feat == "collection" and str(provider or "").strip().upper() in {"PLEX", "EMBY", "JELLYFIN", "KODI"}:
+            continue
         ops = load_sync_ops(provider)
         if not ops:
             continue
@@ -1213,6 +1215,7 @@ def _editor_send_targets(cfg: dict[str, Any], feature: str) -> list[dict[str, An
                     "ratings_enabled": bool(supported.get("ratings")),
                     "watchlist_enabled": bool(supported.get("watchlist")),
                     "progress_enabled": bool(supported.get("progress")),
+                    "collection_enabled": bool(supported.get("collection")),
                 }
             )
 
@@ -1544,6 +1547,7 @@ def api_editor_state_import_providers(request: Request = cast(Request, None)) ->
                     "history": bool(feats.get("history")),
                     "ratings": bool(feats.get("ratings")),
                     "progress": bool(feats.get("progress")),
+                    "collection": bool(feats.get("collection")),
                 },
             }
         )
@@ -1575,9 +1579,9 @@ def api_editor_state_import(payload: dict[str, Any] = Body(...), request: Reques
     if isinstance(feats_in, list):
         features = [str(x).strip().lower() for x in feats_in if str(x).strip()]
     else:
-        features = ["watchlist", "history", "ratings", "progress"]
+        features = ["watchlist", "history", "ratings", "progress", "collection"]
 
-    allowed = {"watchlist", "history", "ratings", "progress"}
+    allowed = {"watchlist", "history", "ratings", "progress", "collection"}
     features = [f for f in features if f in allowed]
     if not features:
         raise HTTPException(status_code=400, detail="No features selected")

--- a/api/insightAPI.py
+++ b/api/insightAPI.py
@@ -420,7 +420,7 @@ def register_insights(app: FastAPI) -> None:
 
     @app.post("/api/crosswatch/select-snapshot", tags=["insight"])
     def api_select_snapshot(
-        feature: str = Query(..., pattern="^(watchlist|history|ratings|progress)$"),
+        feature: str = Query(..., pattern="^(watchlist|history|ratings|progress|collection)$"),
         snapshot: str = Query(...),
         provider_instance: str = Query("default"),
     ) -> dict[str, Any]:
@@ -580,8 +580,10 @@ def register_insights(app: FastAPI) -> None:
                     return 1
                 if f == "ratings":
                     return 2
-                if f == "playlists":
+                if f == "collection":
                     return 3
+                if f == "playlists":
+                    return 4
                 return 9
 
             def _rank_source(v: Any) -> int:
@@ -654,7 +656,7 @@ def register_insights(app: FastAPI) -> None:
                 if not isinstance(pdata, dict):
                     continue
 
-                for feat in ("history", "ratings", "watchlist", "playlists"):
+                for feat in ("history", "ratings", "watchlist", "playlists", "collection"):
                     for node in _iter_nodes(pdata, feat):
                         baseline = node.get("baseline")
                         base: dict[str, Any] = baseline if isinstance(baseline, dict) else node
@@ -736,7 +738,7 @@ def register_insights(app: FastAPI) -> None:
             for _, pdata in provs.items():
                 if not isinstance(pdata, dict):
                     continue
-                for feat in ("history", "ratings", "watchlist", "playlists"):
+                for feat in ("history", "ratings", "watchlist", "playlists", "collection"):
                     for node in _iter_nodes(pdata, feat):
                         baseline = node.get("baseline")
                         base: dict[str, Any] = baseline if isinstance(baseline, dict) else node
@@ -1135,7 +1137,7 @@ def register_insights(app: FastAPI) -> None:
 
             return out
 
-        base_feats: tuple[str, ...] = ("watchlist", "ratings", "history", "progress", "playlists")
+        base_feats: tuple[str, ...] = ("watchlist", "ratings", "history", "progress", "playlists", "collection")
 
         def _features_from(obj: Any) -> list[str]:
             keys: list[str] = []
@@ -1449,6 +1451,7 @@ def register_insights(app: FastAPI) -> None:
         ) -> dict[str, int]:
             movies: set[str] = set()
             shows: set[str] = set()
+            seasons: set[str] = set()
             anime: set[str] = set()
             episodes: set[str] = set()
 
@@ -1601,14 +1604,138 @@ def register_insights(app: FastAPI) -> None:
             return {
                 "movies": len(movies),
                 "shows": len(shows),
+                "seasons": len(seasons),
                 "anime": len(anime),
                 "episodes": len(episodes),
             }
 
-        def _identity_item_count(recs: list[dict[str, Any]]) -> int:
+        def _compute_collection_breakdown(state_obj: dict[str, Any] | None) -> dict[str, int]:
+            movies: set[str] = set()
+            shows: set[str] = set()
+            seasons: set[str] = set()
+            anime: set[str] = set()
+            episodes: set[str] = set()
+
+            try:
+                prov_block = (state_obj or {}).get("providers") or {}
+                for _prov_name, prov_data in prov_block.items():
+                    if not isinstance(prov_data, dict):
+                        continue
+
+                    for _inst_id, feat_block in _iter_provider_feature_nodes(prov_data, "collection"):
+                        node = feat_block.get("baseline") or feat_block
+                        items = (node.get("items") if isinstance(node, dict) else None) or {}
+
+                        if isinstance(items, dict):
+                            it = items.values()
+                        elif isinstance(items, list):
+                            it = items
+                        else:
+                            continue
+
+                        for rec in it:
+                            if not isinstance(rec, dict) or _is_presence_stub(rec):
+                                continue
+                            sig = _collection_identity(rec)
+                            if not sig:
+                                continue
+                            typ = str(rec.get("type") or "").strip().lower()
+                            ids = _id_map(rec, "ids")
+                            show_ids_field = _id_map(rec, "show_ids")
+                            is_anime = bool(
+                                typ == "anime"
+                                or ids.get("anilist") or ids.get("mal")
+                                or show_ids_field.get("anilist") or show_ids_field.get("mal")
+                            )
+                            if typ == "episode":
+                                episodes.add(sig)
+                            elif typ == "season":
+                                seasons.add(sig)
+                            elif is_anime:
+                                anime.add(sig)
+                            elif typ == "movie" and not (show_ids_field or rec.get("series_title") or rec.get("show_title")):
+                                movies.add(sig)
+                            else:
+                                shows.add(sig)
+            except Exception as exc:
+                _append_log("INSIGHTS", f"[!] collection breakdown failed: {exc}")
+
+            return {
+                "movies": len(movies),
+                "shows": len(shows),
+                "seasons": len(seasons),
+                "anime": len(anime),
+                "episodes": len(episodes),
+            }
+
+        def _collection_identity(rec: dict[str, Any]) -> str | None:
+            typ = str(rec.get("type") or "").strip().lower()
+            ids = _id_map(rec, "ids")
+            show_ids_field = _id_map(rec, "show_ids")
+            has_show_meta = bool(
+                show_ids_field
+                or rec.get("series_title")
+                or rec.get("show_title")
+            )
+            is_anime = bool(
+                typ == "anime"
+                or ids.get("anilist") or ids.get("mal")
+                or show_ids_field.get("anilist") or show_ids_field.get("mal")
+            )
+            if typ == "episode":
+                s = int(rec.get("season") or 0)
+                ep = int(rec.get("episode") or 0)
+                return _pick_identity(
+                    title=rec.get("series_title") or rec.get("show_title") or rec.get("title") or rec.get("name"),
+                    year=rec.get("series_year") or rec.get("year"),
+                    ids=show_ids_field or ids,
+                    id_keys=("tmdb", "imdb", "tvdb", "anilist", "mal", "slug"),
+                    prefix="episode",
+                    suffix=f"|s{s}e{ep}",
+                )
+            if typ == "season":
+                s = int(rec.get("season") or rec.get("number") or 0)
+                return _pick_identity(
+                    title=rec.get("series_title") or rec.get("show_title") or rec.get("title") or rec.get("name"),
+                    year=rec.get("series_year") or rec.get("year"),
+                    ids=show_ids_field or ids,
+                    id_keys=("tmdb", "imdb", "tvdb", "anilist", "mal", "slug"),
+                    prefix="season",
+                    suffix=f"|s{s}",
+                )
+            if is_anime:
+                ids_anime = show_ids_field if (show_ids_field.get("anilist") or show_ids_field.get("mal")) else ids
+                return _pick_identity(
+                    title=rec.get("title") or rec.get("name"),
+                    year=rec.get("year"),
+                    ids=ids_anime,
+                    id_keys=("anilist", "mal", "slug", "tmdb", "imdb", "tvdb"),
+                    prefix="anime",
+                )
+            if typ == "movie" and not has_show_meta:
+                return _pick_identity(
+                    title=rec.get("title") or rec.get("name"),
+                    year=rec.get("year"),
+                    ids=ids,
+                    id_keys=("tmdb", "imdb", "tvdb", "slug"),
+                    prefix="movie",
+                )
+            return _pick_identity(
+                title=rec.get("series_title") or rec.get("show_title") or rec.get("title") or rec.get("name"),
+                year=rec.get("series_year") or rec.get("year"),
+                ids=show_ids_field or ids,
+                id_keys=("tmdb", "imdb", "tvdb", "slug"),
+                prefix="show",
+            )
+
+        def _identity_item_count(recs: list[dict[str, Any]], feature: str | None = None) -> int:
             identities: set[str] = set()
             for idx, rec in enumerate(recs):
                 if not isinstance(rec, dict):
+                    continue
+                if feature == "collection":
+                    sig = _collection_identity(rec)
+                    identities.add(sig or f"raw:{idx}")
                     continue
                 typ = str(rec.get("type") or "").strip().lower()
                 ids = _id_map(rec, "ids")
@@ -1872,14 +1999,14 @@ def register_insights(app: FastAPI) -> None:
                     snap_dir = Path(root_dir).joinpath("snapshots")
                     selected: dict[str, str] = {
                         feat: str((block or {}).get(f"restore_{feat}") or "latest").strip() or "latest"
-                        for feat in ("watchlist", "history", "ratings", "progress")
+                        for feat in ("watchlist", "history", "ratings", "progress", "collection")
                     }
 
                     files: list[Path] = []
                     if snap_dir.is_dir():
                         files = list(snap_dir.glob("*.json"))
 
-                    by_feat: dict[str, list[str]] = {"watchlist": [], "history": [], "ratings": [], "progress": [], "playlists": []}
+                    by_feat: dict[str, list[str]] = {"watchlist": [], "history": [], "ratings": [], "progress": [], "playlists": [], "collection": []}
                     for p in files:
                         name = p.name
                         for feat in by_feat.keys():
@@ -2061,7 +2188,7 @@ def register_insights(app: FastAPI) -> None:
 
         def _count_items(node: Any, feature: str | None = None) -> int:
             try:
-                if feature in ("watchlist", "history", "ratings", "progress") and isinstance(node, dict):
+                if feature in ("watchlist", "history", "ratings", "progress", "collection") and isinstance(node, dict):
                     recs = _iter_feature_items(node)
                     if feature == "history":
                         recs = [
@@ -2085,7 +2212,7 @@ def register_insights(app: FastAPI) -> None:
                     else:
                         recs = [r for r in recs if not _is_presence_stub(r)]
 
-                    return _identity_item_count(recs)
+                    return _identity_item_count(recs, feature)
 
                 if isinstance(node, dict):
                     base = node.get("baseline") or {}
@@ -2141,12 +2268,13 @@ def register_insights(app: FastAPI) -> None:
             return out
 
         def _sum_mse(parts: list[dict[str, int]]) -> dict[str, int]:
-            out = {"movies": 0, "shows": 0, "anime": 0, "episodes": 0}
+            out = {"movies": 0, "shows": 0, "seasons": 0, "anime": 0, "episodes": 0}
             for p in parts:
                 if not isinstance(p, dict):
                     continue
                 out["movies"] += int(p.get("movies") or 0)
                 out["shows"] += int(p.get("shows") or 0)
+                out["seasons"] += int(p.get("seasons") or 0)
                 out["anime"] += int(p.get("anime") or 0)
                 out["episodes"] += int(p.get("episodes") or 0)
             return out
@@ -2185,15 +2313,19 @@ def register_insights(app: FastAPI) -> None:
                         for inst_id, node in _iter_provider_feature_nodes(pdata, feat):
                             inst_counts[inst_id] = _count_items(node, feat)
                             try:
-                                per_counts = _compute_history_breakdown(
-                                    {"providers": {prov_upper: {feat: node}}},
-                                    feat,
-                                ) or {}
+                                if feat == "collection":
+                                    per_counts = _compute_collection_breakdown({"providers": {prov_upper: {feat: node}}}) or {}
+                                else:
+                                    per_counts = _compute_history_breakdown(
+                                        {"providers": {prov_upper: {feat: node}}},
+                                        feat,
+                                    ) or {}
                             except Exception:
                                 per_counts = {}
                             inst_mse[inst_id] = {
                                 "movies": int(per_counts.get("movies") or 0),
                                 "shows": int(per_counts.get("shows") or 0),
+                                "seasons": int(per_counts.get("seasons") or 0),
                                 "anime": int(per_counts.get("anime") or 0),
                                 "episodes": int(per_counts.get("episodes") or 0),
                             }
@@ -2243,11 +2375,11 @@ def register_insights(app: FastAPI) -> None:
                         existing[inst] = max(int(existing.get(inst) or 0), int(inst_count or 0))
 
         providers_instances_mse_by_feature: dict[str, dict[str, dict[str, dict[str, int]]]] = {
-            feat: {k: {"default": {"movies": 0, "shows": 0, "anime": 0, "episodes": 0}} for k in providers_set}
+            feat: {k: {"default": {"movies": 0, "shows": 0, "seasons": 0, "anime": 0, "episodes": 0}} for k in providers_set}
             for feat in feature_keys
         }
         providers_mse_by_feature: dict[str, dict[str, dict[str, int]]] = {
-            feat: {k: {"movies": 0, "shows": 0, "anime": 0, "episodes": 0} for k in providers_set}
+            feat: {k: {"movies": 0, "shows": 0, "seasons": 0, "anime": 0, "episodes": 0} for k in providers_set}
             for feat in feature_keys
         }
 
@@ -2258,7 +2390,7 @@ def register_insights(app: FastAPI) -> None:
                 for key, stored in provs.items():
                     inst_mse = {inst: dict(vals) for inst, vals in stored.items()}
                     if "default" not in inst_mse and not wanted_instances:
-                        inst_mse["default"] = {"movies": 0, "shows": 0, "anime": 0, "episodes": 0}
+                        inst_mse["default"] = {"movies": 0, "shows": 0, "seasons": 0, "anime": 0, "episodes": 0}
                     providers_instances_mse_by_feature[feat][key] = inst_mse
                     providers_mse_by_feature[feat][key] = _sum_mse(list(inst_mse.values()))
         except Exception:

--- a/api/maintenanceAPI.py
+++ b/api/maintenanceAPI.py
@@ -93,7 +93,7 @@ def _cw() -> tuple[Any, Any, Any, Any, Any, Any]:
 
     def _load_statistics_state() -> dict[str, Any]:
         try:
-            return StateStore(CONFIG_DIR).load_state_features({"watchlist", "history", "ratings", "playlists"}) or {}
+            return StateStore(CONFIG_DIR).load_state_features({"watchlist", "history", "ratings", "playlists", "collection"}) or {}
         except Exception:
             return {}
 
@@ -353,7 +353,7 @@ def _sync_state_inventory(config_dir: Path) -> tuple[int, int]:
         return 0, 0
 
     baseline_count = 0
-    feature_names = {"history", "ratings", "watchlist", "playlists", "progress"}
+    feature_names = {"history", "ratings", "watchlist", "playlists", "progress", "collection"}
     for provider in providers.values():
         if not isinstance(provider, dict):
             continue
@@ -371,7 +371,7 @@ def _sync_state_baseline_inventory(config_dir: Path) -> dict[str, Any]:
     if not isinstance(providers, dict):
         return {"providers": 0, "baselines": 0, "items": 0, "largest": None}
 
-    feature_names = {"history", "ratings", "watchlist", "playlists", "progress"}
+    feature_names = {"history", "ratings", "watchlist", "playlists", "progress", "collection"}
     baselines = 0
     items_total = 0
     largest: dict[str, Any] | None = None
@@ -415,7 +415,7 @@ def _sync_state_baseline_inventory(config_dir: Path) -> dict[str, Any]:
     }
 
 
-FEATURE_NAMES = {"history", "ratings", "watchlist", "playlists", "progress"}
+FEATURE_NAMES = {"history", "ratings", "watchlist", "playlists", "progress", "collection"}
 
 
 def _feature_item_count(block: Any) -> int:
@@ -1001,7 +1001,7 @@ def _scan_cw_tracker(root: Path) -> dict[str, Any]:
 
     state_files.sort(key=lambda x: x.get("name") or "")
     snapshots.sort(key=lambda x: x.get("mtime") or "")
-    core_names = {"history.json", "ratings.json", "watchlist.json", "progress.json"}
+    core_names = {"history.json", "ratings.json", "watchlist.json", "progress.json", "collection.json"}
     state_count = sum(
         1 for f in state_files
         if (f.get("name") or "") in core_names

--- a/api/snapshotsAPI.py
+++ b/api/snapshotsAPI.py
@@ -33,7 +33,7 @@ router = APIRouter(prefix="/api/snapshots", tags=["snapshots"])
 _LOG = logging.getLogger("crosswatch.api.snapshots")
 
 RestoreMode = Literal["merge", "clear_restore"]
-Feature = Literal["watchlist", "ratings", "history", "progress", "all"]
+Feature = Literal["watchlist", "ratings", "history", "progress", "collection", "all"]
 _SAFE_ERROR_PREFIXES = (
     "Snapshot path is required",
     "Invalid snapshot path",

--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -62,9 +62,10 @@ def _rt():
     )
 
 
-FEATURE_KEYS = ["watchlist", "ratings", "history", "playlists", "progress"]
+FEATURE_KEYS = ["watchlist", "ratings", "history", "playlists", "progress", "collection"]
 _ALLOWED_RATING_TYPES: tuple[str, ...] = ("movies", "shows", "seasons", "episodes")
 _ALLOWED_RATING_MODES: tuple[str, ...] = ("only_new", "from_date", "all")
+_ALLOWED_COLLECTION_TYPES: tuple[str, ...] = ("movies", "shows", "seasons", "episodes")
 
 def _normalize_progress_block(v: dict | bool | None) -> dict:
     if isinstance(v, bool):
@@ -159,12 +160,38 @@ def _normalize_ratings_block(v: dict | bool | None) -> dict:
 
     return d
 
+def _normalize_collection_block(v: dict | bool | None) -> dict:
+    if isinstance(v, bool):
+        return {
+            "enable": coerce_bool(v), "add": coerce_bool(v), "remove": False,
+            "types": ["movies"],
+        }
+
+    d = dict(v or {})
+    d["enable"] = coerce_bool(d.get("enable", d.get("enabled", False)))
+    d["add"] = coerce_bool(d.get("add", True), True)
+    d["remove"] = coerce_bool(d.get("remove", False))
+
+    t = d.get("types", [])
+    if isinstance(t, str):
+        t = [t]
+    t_norm = [str(x).strip().lower() for x in t if isinstance(x, str)]
+    if "all" in t_norm:
+        d["types"] = list(_ALLOWED_COLLECTION_TYPES)
+    else:
+        keep = [x for x in _ALLOWED_COLLECTION_TYPES if x in t_norm]
+        d["types"] = keep or ["movies"]
+
+    return d
+
 def _normalize_features(f: dict | None) -> dict:
     f = dict(f or {})
     for k in FEATURE_KEYS:
         v = f.get(k)
         if k == "ratings":
             f[k] = _normalize_ratings_block(v)
+        elif k == "collection":
+            f[k] = _normalize_collection_block(v)
         elif k == "progress":
             if isinstance(v, (bool, dict)):
                 f[k] = _normalize_progress_block(v)
@@ -194,6 +221,11 @@ def _enforce_pair_feature_constraints(pair: dict[str, Any]) -> None:
         feats.pop("progress", None)
     if not sync_provider_supports_feature(src, "ratings") or not sync_provider_supports_feature(dst, "ratings"):
         feats.pop("ratings", None)
+    if "collection" in feats:
+        collection_sources = {"PLEX", "EMBY", "JELLYFIN", "KODI", "TRAKT", "MDBLIST", "CROSSWATCH", "PUNCHPLAY", "FLOPPY", "SCROB"}
+        collection_targets = {"TRAKT", "MDBLIST", "CROSSWATCH", "PUNCHPLAY", "FLOPPY", "SCROB"}
+        if src not in collection_sources or dst not in collection_targets or str(pair.get("mode") or "").strip().lower().startswith("two"):
+            feats.pop("collection", None)
 
 def _normalize_pair_providers(p: Any) -> dict[str, Any]:
     if not isinstance(p, dict):
@@ -893,7 +925,7 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
         RUNNING_PROCS.pop("SYNC", None)
 
 def _lanes_enabled_defaults() -> dict[str, bool]:
-    return {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": True}
+    return {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": True, "collection": True}
 
 def _parse_sync_line(line: str) -> None:
     s = _rt()[7](line).strip()
@@ -942,7 +974,7 @@ def _parse_sync_line(line: str) -> None:
                 return
 
             feat = str(o.get("feature") or "").lower()
-            if feat in ("watchlist", "history", "ratings", "progress", "playlists"):
+            if feat in ("watchlist", "history", "ratings", "progress", "playlists", "collection"):
                 F = SUMMARY.setdefault("features", {})
                 if feat not in F:
                     F[feat] = {
@@ -1276,7 +1308,7 @@ def _show_title_maps_from_state(state: dict[str, Any]) -> tuple[dict[str, str], 
         if not isinstance(pdata, dict):
             continue
 
-        for feat in ("history", "ratings", "watchlist", "playlists"):
+        for feat in ("history", "ratings", "watchlist", "playlists", "collection"):
             for node in _iter_nodes(pdata, feat):
                 baseline = node.get("baseline")
                 base: dict[str, Any] = baseline if isinstance(baseline, dict) else node
@@ -1379,7 +1411,7 @@ def _episode_code_map_from_state(state: dict[str, Any]) -> dict[str, tuple[int, 
     for _, pdata in provs.items():
         if not isinstance(pdata, dict):
             continue
-        for feat in ("history", "ratings", "watchlist", "playlists"):
+        for feat in ("history", "ratings", "watchlist", "playlists", "collection"):
             for node in _iter_nodes(pdata, feat):
                 baseline = node.get("baseline")
                 base: dict[str, Any] = baseline if isinstance(baseline, dict) else node
@@ -1417,7 +1449,7 @@ def _get_episode_code_map() -> dict[str, tuple[int, int]]:
             cm = _EP_META_CACHE.get("code_map")
             if isinstance(cm, dict):
                 return cast(dict[str, tuple[int, int]], cm)
-    state = _load_state_features({"history", "ratings", "watchlist", "playlists"})
+    state = _load_state_features({"history", "ratings", "watchlist", "playlists", "collection"})
     cm2 = _episode_code_map_from_state(state or {})
     with _EP_META_CACHE_LOCK:
         _EP_META_CACHE["key"] = skey
@@ -1432,7 +1464,7 @@ def _get_title_maps() -> tuple[dict[str, str], dict[str, str]]:
             im = _TITLE_MAP_CACHE.get("id_map")
             if isinstance(km, dict) and isinstance(im, dict):
                 return cast(dict[str, str], km), cast(dict[str, str], im)
-    state = _load_state_features({"history", "ratings", "watchlist", "playlists"})
+    state = _load_state_features({"history", "ratings", "watchlist", "playlists", "collection"})
     km2, im2 = _show_title_maps_from_state(state or {})
     with _TITLE_MAP_CACHE_LOCK:
         _TITLE_MAP_CACHE["key"] = skey
@@ -1603,7 +1635,7 @@ def _hydrate_summary_spotlights_from_log(summary_obj: dict[str, Any], *, max_lin
         if ev not in ("apply:add:done", "apply:remove:done", "apply:update:done"):
             continue
         feat = str(obj.get("feature") or "").lower()
-        if feat not in ("watchlist", "history", "ratings", "progress", "playlists"):
+        if feat not in ("watchlist", "history", "ratings", "progress", "playlists", "collection"):
             continue
 
         lane = feats.get(feat)
@@ -1791,7 +1823,7 @@ def _is_sync_running() -> bool:
 @router.get("/sync/providers")
 def api_sync_providers(request: Request = cast(Request, None)) -> JSONResponse:
     HIDDEN = {"BASE"}
-    FEATURE_KEYS = ("watchlist", "ratings", "history", "playlists", "progress")
+    FEATURE_KEYS = ("watchlist", "ratings", "history", "playlists", "progress", "collection")
     try:
         from cw_platform.config_base import load_config
         from cw_platform.provider_instances import build_provider_config_view, list_instance_ids

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -1341,6 +1341,7 @@ def apply_migration_overrides(cfg: dict[str, Any]) -> tuple[dict[str, Any], list
 # Feature normalization
 _ALLOWED_RATING_TYPES: list[str] = ["movies", "shows", "seasons", "episodes"]
 _ALLOWED_RATING_MODES: list[str] = ["only_new", "from_date", "all"]
+_ALLOWED_COLLECTION_TYPES: list[str] = ["movies", "shows", "seasons", "episodes"]
 _ALLOWED_UI_PROTOCOLS: list[str] = ["http", "https"]
 
 
@@ -1384,6 +1385,25 @@ def _normalize_ratings_feature(val: dict[str, Any]) -> dict[str, Any]:
     return v
 
 
+def _normalize_collection_feature(val: dict[str, Any]) -> dict[str, Any]:
+    v: dict[str, Any] = dict(val or {})
+    v["enable"] = bool(v.get("enable", False))
+    v["add"] = bool(v.get("add", False))
+    v["remove"] = bool(v.get("remove", False))
+
+    raw_types = _as_list(v.get("types"))
+    types = [str(t).strip().lower() for t in raw_types]
+    if "all" in types:
+        types = list(_ALLOWED_COLLECTION_TYPES)
+    else:
+        types = [t for t in _ALLOWED_COLLECTION_TYPES if t in types]
+        if not types:
+            types = ["movies"]
+    v["types"] = types
+
+    return v
+
+
 def _normalize_features_map(features: dict[str, Any] | None) -> dict[str, Any]:
     f: dict[str, Any] = dict(features or {})
     for name, val in list(f.items()):
@@ -1396,6 +1416,8 @@ def _normalize_features_map(features: dict[str, Any] | None) -> dict[str, Any]:
             # Ratings has extra fields
             if name == "ratings":
                 v = _normalize_ratings_feature(v)
+            elif name == "collection":
+                v = _normalize_collection_feature(v)
             f[name] = v
             continue
 

--- a/cw_platform/event_archive/context.py
+++ b/cw_platform/event_archive/context.py
@@ -15,6 +15,7 @@ from . import query as _query
 from ..local_db.legacy_files import STATE_MANUAL_JSON
 
 _RELATED_LIMIT = 50
+_CONTEXT_FEATURES = ("history", "watchlist", "ratings", "progress", "collection")
 
 
 def _safe(fn: Callable[[], Any]) -> Any:
@@ -502,7 +503,7 @@ def _baseline_states() -> list[Mapping[str, Any]]:
     if not out:
         try:
             from services.analyzer import _load_state
-            gs = _load_state(None, {"history", "watchlist", "ratings", "progress"})
+            gs = _load_state(None, set(_CONTEXT_FEATURES))
             if isinstance(gs, Mapping):
                 out.append(gs)
         except Exception:
@@ -554,7 +555,7 @@ def _title_index() -> dict[str, dict[str, Any]]:
     def _ingest_provblk(blk: Any) -> None:
         if not isinstance(blk, Mapping):
             return
-        for feat in ("history", "watchlist", "ratings", "progress"):
+        for feat in _CONTEXT_FEATURES:
             fblk = blk.get(feat)
             items = ((fblk or {}).get("baseline") or {}).get("items") if isinstance(fblk, Mapping) else None
             _ingest_items(items)

--- a/cw_platform/local_db/manual_policy.py
+++ b/cw_platform/local_db/manual_policy.py
@@ -13,7 +13,7 @@ from .db import crosswatch_db_path, get_conn
 from .schema import ID_KEYS
 
 _LOCK = threading.RLock()
-_FEATURES = ("watchlist", "history", "ratings", "progress", "playlists")
+_FEATURES = ("watchlist", "history", "ratings", "progress", "playlists", "collection")
 
 
 def _now() -> int:

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -611,7 +611,7 @@ def _effective_library_whitelist(
     feature: str,
     fcfg: Mapping[str, Any],
 ) -> list[str]:
-    if feature not in ("history", "ratings", "progress"):
+    if feature not in ("history", "ratings", "progress", "collection"):
         return []
 
     libs: list[str] = []
@@ -715,6 +715,48 @@ def _ratings_filter_index(idx: dict[str, Any], fcfg: Mapping[str, Any]) -> dict[
         return True
 
     return {k: v for k, v in idx.items() if _keep(v)}
+
+
+def _media_type_filter_index(idx: dict[str, Any], fcfg: Mapping[str, Any]) -> dict[str, Any]:
+    alias = {
+        "movies": "movie",
+        "movie": "movie",
+        "shows": "show",
+        "show": "show",
+        "series": "show",
+        "tv": "show",
+        "anime": "show",
+        "animes": "show",
+        "seasons": "season",
+        "season": "season",
+        "episodes": "episode",
+        "episode": "episode",
+        "ep": "episode",
+        "eps": "episode",
+    }
+    raw = fcfg.get("types")
+    if isinstance(raw, (str, bytes)):
+        raw_values = [raw]
+    elif isinstance(raw, (list, tuple, set)):
+        raw_values = list(raw)
+    else:
+        raw_values = ["movies"]
+    types_raw = [str(t).strip().lower() for t in raw_values if isinstance(t, (str, bytes))]
+    if "all" in types_raw:
+        types = {"movie", "show", "season", "episode"}
+    else:
+        types = {alias.get(t, t.rstrip("s")) for t in types_raw if t}
+    if not types:
+        types = {"movie"}
+
+    def _keep(v: Any) -> bool:
+        if not isinstance(v, Mapping):
+            return False
+        raw = str(v.get("type", "")).strip().lower()
+        vt = alias.get(raw, raw.rstrip("s"))
+        return vt in types
+
+    return {k: v for k, v in (idx or {}).items() if _keep(v)}
 
 # One-way sync core
 def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
@@ -1074,14 +1116,31 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
 
     def _prev_items(pmap: Mapping[str, Any], prov: str, inst: str, feat: str) -> dict[str, Any]:
         try:
-            pblk = pmap.get(prov) or {}
+            pkey = str(prov or "").upper()
+            pblk = pmap.get(pkey) or pmap.get(str(prov or "")) or {}
+            if not isinstance(pblk, Mapping):
+                for pk, pv in (pmap or {}).items():
+                    if str(pk or "").upper() == pkey and isinstance(pv, Mapping):
+                        pblk = pv
+                        break
             if not isinstance(pblk, Mapping):
                 return {}
             if inst != "default":
                 insts = pblk.get("instances") or {}
-                if not isinstance(insts, Mapping):
+                if isinstance(insts, Mapping):
+                    pblk2 = insts.get(inst) or {}
+                    if not isinstance(pblk2, Mapping):
+                        want_inst = normalize_instance_id(inst)
+                        for ik, iv in insts.items():
+                            if normalize_instance_id(ik) == want_inst and isinstance(iv, Mapping):
+                                pblk2 = iv
+                                break
+                    if isinstance(pblk2, Mapping) and pblk2:
+                        pblk = pblk2
+                    elif feat not in pblk:
+                        return {}
+                elif feat not in pblk:
                     return {}
-                pblk = insts.get(inst) or {}
                 if not isinstance(pblk, Mapping):
                     return {}
             fblk = pblk.get(feat) or {}
@@ -1141,16 +1200,28 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
 
     allow_unknown_src = (str(src).upper() == "PLEX" and feature == "history") or str(src).upper() == "KODI"
     allow_unknown_dst = (str(dst).upper() == "PLEX" and feature == "history") or str(dst).upper() == "KODI"
+    allow_unknown_prev_src = allow_unknown_src or feature == "collection"
+    allow_unknown_prev_dst = allow_unknown_dst or feature == "collection"
+    allow_unknown_eff_src = allow_unknown_src or feature == "collection"
+    allow_unknown_eff_dst = allow_unknown_dst or feature == "collection"
 
     if libs_src:
-        prev_src = _filter_index_by_libraries(prev_src, libs_src, allow_unknown=allow_unknown_src)
+        prev_src = _filter_index_by_libraries(prev_src, libs_src, allow_unknown=allow_unknown_prev_src)
         src_cur  = _filter_index_by_libraries(src_cur,  libs_src, allow_unknown=allow_unknown_src)
-        eff_src  = _filter_index_by_libraries(eff_src,  libs_src, allow_unknown=allow_unknown_src)
+        eff_src  = _filter_index_by_libraries(eff_src,  libs_src, allow_unknown=allow_unknown_eff_src)
 
     if libs_dst:
-        prev_dst = _filter_index_by_libraries(prev_dst, libs_dst, allow_unknown=allow_unknown_dst)
+        prev_dst = _filter_index_by_libraries(prev_dst, libs_dst, allow_unknown=allow_unknown_prev_dst)
         dst_cur  = _filter_index_by_libraries(dst_cur,  libs_dst, allow_unknown=allow_unknown_dst)
-        eff_dst  = _filter_index_by_libraries(eff_dst,  libs_dst, allow_unknown=allow_unknown_dst)
+        eff_dst  = _filter_index_by_libraries(eff_dst,  libs_dst, allow_unknown=allow_unknown_eff_dst)
+
+    if feature == "collection":
+        prev_src = _media_type_filter_index(prev_src, fcfg)
+        src_cur = _media_type_filter_index(src_cur, fcfg)
+        eff_src = _media_type_filter_index(eff_src, fcfg)
+        prev_dst = _media_type_filter_index(prev_dst, fcfg)
+        dst_cur = _media_type_filter_index(dst_cur, fcfg)
+        eff_dst = _media_type_filter_index(eff_dst, fcfg)
 
     src_dropped_tokens: set[str] = set()
     dst_dropped_tokens: set[str] = set()

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -70,8 +70,12 @@ from ..provider_instances import normalize_instance_id
 from ._planner import diff_ratings, diff_progress, _pick_rating
 from ._progress_completion import fcfg_for_progress_target
 try:
+    from ._pairs_oneway import _media_type_filter_index as _media_filter
     from ._pairs_oneway import _ratings_filter_index as _rate_filter
 except Exception:
+    def _media_filter(idx: dict[str, Any], fcfg: Mapping[str, Any]) -> dict[str, Any]:
+        return idx
+
     def _rate_filter(idx: dict[str, Any], fcfg: Mapping[str, Any]) -> dict[str, Any]:
         return idx
 
@@ -235,7 +239,7 @@ def _effective_library_whitelist(
     feature: str,
     fcfg: Mapping[str, Any],
 ) -> list[str]:
-    if feature not in ("history", "ratings", "progress"):
+    if feature not in ("history", "ratings", "progress", "collection"):
         return []
 
     libs: list[str] = []
@@ -497,14 +501,31 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
 
     def _prev_items(pmap: Mapping[str, Any], prov: str, inst: str, feat: str) -> dict[str, Any]:
         try:
-            pblk = pmap.get(prov) or {}
+            pkey = str(prov or "").upper()
+            pblk = pmap.get(pkey) or pmap.get(str(prov or "")) or {}
+            if not isinstance(pblk, Mapping):
+                for pk, pv in (pmap or {}).items():
+                    if str(pk or "").upper() == pkey and isinstance(pv, Mapping):
+                        pblk = pv
+                        break
             if not isinstance(pblk, Mapping):
                 return {}
             if inst != "default":
                 insts = pblk.get("instances") or {}
-                if not isinstance(insts, Mapping):
+                if isinstance(insts, Mapping):
+                    pblk2 = insts.get(inst) or {}
+                    if not isinstance(pblk2, Mapping):
+                        want_inst = normalize_instance_id(inst)
+                        for ik, iv in insts.items():
+                            if normalize_instance_id(ik) == want_inst and isinstance(iv, Mapping):
+                                pblk2 = iv
+                                break
+                    if isinstance(pblk2, Mapping) and pblk2:
+                        pblk = pblk2
+                    elif feat not in pblk:
+                        return {}
+                elif feat not in pblk:
                     return {}
-                pblk = insts.get(inst) or {}
                 if not isinstance(pblk, Mapping):
                     return {}
             fblk = pblk.get(feat) or {}
@@ -563,16 +584,28 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
 
     allow_unknown_A = (str(a).upper() == "PLEX" and feature == "history") or str(a).upper() == "KODI"
     allow_unknown_B = (str(b).upper() == "PLEX" and feature == "history") or str(b).upper() == "KODI"
+    allow_unknown_prev_A = allow_unknown_A or feature == "collection"
+    allow_unknown_prev_B = allow_unknown_B or feature == "collection"
+    allow_unknown_eff_A = allow_unknown_A or feature == "collection"
+    allow_unknown_eff_B = allow_unknown_B or feature == "collection"
 
     if libs_A:
-        prevA = _filter_index_by_libraries(prevA, libs_A, allow_unknown=allow_unknown_A)
+        prevA = _filter_index_by_libraries(prevA, libs_A, allow_unknown=allow_unknown_prev_A)
         A_cur = _filter_index_by_libraries(A_cur, libs_A, allow_unknown=allow_unknown_A)
-        A_eff = _filter_index_by_libraries(A_eff, libs_A, allow_unknown=allow_unknown_A)
+        A_eff = _filter_index_by_libraries(A_eff, libs_A, allow_unknown=allow_unknown_eff_A)
 
     if libs_B:
-        prevB = _filter_index_by_libraries(prevB, libs_B, allow_unknown=allow_unknown_B)
+        prevB = _filter_index_by_libraries(prevB, libs_B, allow_unknown=allow_unknown_prev_B)
         B_cur = _filter_index_by_libraries(B_cur, libs_B, allow_unknown=allow_unknown_B)
-        B_eff = _filter_index_by_libraries(B_eff, libs_B, allow_unknown=allow_unknown_B)
+        B_eff = _filter_index_by_libraries(B_eff, libs_B, allow_unknown=allow_unknown_eff_B)
+
+    if feature == "collection":
+        prevA = _media_filter(prevA, fcfg)
+        A_cur = _media_filter(A_cur, fcfg)
+        A_eff = _media_filter(A_eff, fcfg)
+        prevB = _media_filter(prevB, fcfg)
+        B_cur = _media_filter(B_cur, fcfg)
+        B_eff = _media_filter(B_eff, fcfg)
 
     dropped_A: set[str] = set()
     dropped_B: set[str] = set()

--- a/cw_platform/orchestrator/_pairs_utils.py
+++ b/cw_platform/orchestrator/_pairs_utils.py
@@ -8,7 +8,7 @@ import importlib
 from collections.abc import Mapping as _Mapping
 from ..id_map import canonical_key as _ck, ID_KEYS
 
-LIBRARY_SCOPED_FEATURES = frozenset({"history", "ratings", "progress"})
+LIBRARY_SCOPED_FEATURES = frozenset({"history", "ratings", "progress", "collection"})
 
 LIBRARY_PROVIDER_KEYS = {
     "PLEX": "plex",

--- a/cw_platform/orchestrator/_snapshots.py
+++ b/cw_platform/orchestrator/_snapshots.py
@@ -159,7 +159,7 @@ def _pick_key(provider_key: str, computed_key: str) -> str:
 _ID_COALESCE_KEYS = ("tmdb", "imdb", "tvdb", "trakt", "simkl", "mal", "anilist", "kitsu", "anidb")
 
 def _coalesce_by_shared_ids(idx: SnapIndex, *, feature: str) -> SnapIndex:
-    if str(feature or "").lower() != "watchlist" or not idx:
+    if str(feature or "").lower() not in {"watchlist", "collection"} or not idx:
         return dict(idx)
 
     parent: dict[str, str] = {}

--- a/cw_platform/orchestrator/_state_store.py
+++ b/cw_platform/orchestrator/_state_store.py
@@ -118,7 +118,7 @@ class StateStore:
                 for feature, f_node in manual.items():
                     _merge_feature(p_node, str(feature).lower(), f_node)
 
-            for feature in ("watchlist", "history", "ratings", "progress", "playlists"):
+            for feature in ("watchlist", "history", "ratings", "progress", "playlists", "collection"):
                 if feature in p_node and isinstance(p_node.get(feature), dict):
                     _merge_feature(p_node, feature, p_node.get(feature))
 

--- a/cw_platform/orchestrator/facade.py
+++ b/cw_platform/orchestrator/facade.py
@@ -373,7 +373,7 @@ class Orchestrator:
                 continue
             fmap = p.get("features") or {}
             
-            for name in ("watchlist", "ratings", "history", "progress", "playlists"):
+            for name in ("watchlist", "ratings", "history", "progress", "playlists", "collection"):
                 v = fmap.get(name)
                 if isinstance(v, bool):
                     if v:

--- a/services/analyzer.py
+++ b/services/analyzer.py
@@ -36,7 +36,7 @@ from cw_platform.reason_labels import TRACKER_TO_MEDIA_SERVER_MESSAGE, reason_me
 router = APIRouter(prefix="/api", tags=["analyzer"])
 CWS_DIR = CONFIG_DIR / ".cw_state"
 _MANUAL_POLICY_REF = "manual policy"
-_ANALYZER_FEATURES = ("history", "watchlist", "ratings", "progress")
+_ANALYZER_FEATURES = ("history", "watchlist", "ratings", "progress", "collection")
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PROVIDERS_SYNC_DIR = REPO_ROOT / "providers" / "sync"
 ORCH_ROOT_DIR = REPO_ROOT / "cw_platform"
@@ -646,7 +646,7 @@ def _iter_items(s: dict[str, Any]) -> Iterable[tuple[str, str, str, dict[str, An
         if not isinstance(pv, dict):
             continue
 
-        for feat in ("history", "watchlist", "ratings", "progress"):
+        for feat in _ANALYZER_FEATURES:
             items = (((pv.get(feat) or {}).get("baseline") or {}).get("items") or {})
             if isinstance(items, dict):
                 for k, it in items.items():
@@ -659,7 +659,7 @@ def _iter_items(s: dict[str, Any]) -> Iterable[tuple[str, str, str, dict[str, An
             if not isinstance(blk, dict):
                 continue
             tok = _prov_token(str(prov), inst_id)
-            for feat in ("history", "watchlist", "ratings", "progress"):
+            for feat in _ANALYZER_FEATURES:
                 items = (((blk.get(feat) or {}).get("baseline") or {}).get("items") or {})
                 if not isinstance(items, dict):
                     continue
@@ -759,8 +759,8 @@ def _find_item(
 def _counts(s: dict[str, Any]) -> dict[str, dict[str, int]]:
     out: dict[str, dict[str, int]] = {}
     for prov, feat, _, _ in _iter_items(s):
-        cur = out.setdefault(prov, {"history": 0, "watchlist": 0, "ratings": 0, "progress": 0, "total": 0})
-        if feat in ("history", "watchlist", "ratings", "progress"):
+        cur = out.setdefault(prov, {**{name: 0 for name in _ANALYZER_FEATURES}, "total": 0})
+        if feat in _ANALYZER_FEATURES:
             cur[feat] = int(cur.get(feat, 0)) + 1
             cur["total"] = int(cur.get("total", 0)) + 1
     return out
@@ -823,8 +823,8 @@ def _counts_from_rows(rows: Iterable[Mapping[str, Any]]) -> dict[str, dict[str, 
     for row in rows:
         prov = str(row.get("provider") or "")
         feat = str(row.get("feature") or "").lower()
-        cur = out.setdefault(prov, {"history": 0, "watchlist": 0, "ratings": 0, "progress": 0, "total": 0})
-        if feat in ("history", "watchlist", "ratings", "progress"):
+        cur = out.setdefault(prov, {**{name: 0 for name in _ANALYZER_FEATURES}, "total": 0})
+        if feat in _ANALYZER_FEATURES:
             cur[feat] += 1
             cur["total"] += 1
     return out
@@ -1829,7 +1829,7 @@ def _pair_map(cfg: dict[str, Any], _state: dict[str, Any]) -> dict[tuple[str, st
         if isinstance(feats, (list, tuple)):
             feats_list = [str(f).lower() for f in feats]
         elif isinstance(feats, dict):
-            for name in ("history", "watchlist", "ratings", "progress"):
+            for name in _ANALYZER_FEATURES:
                 f = feats.get(name)
                 if isinstance(f, bool):
                     if f:
@@ -1952,7 +1952,7 @@ def _pair_type_filters(cfg: dict[str, Any]) -> dict[tuple[str, str, str], set[st
         if not isinstance(feats, dict):
             continue
 
-        for feat in ("history", "watchlist", "ratings", "progress"):
+        for feat in _ANALYZER_FEATURES:
             fcfg = feats.get(feat)
             if not is_on(fcfg):
                 continue
@@ -2066,7 +2066,7 @@ def _pair_lib_filters(cfg: dict[str, Any]) -> dict[tuple[str, str, str], set[str
         if not isinstance(feats, dict):
             continue
 
-        for feat in ("history", "watchlist", "ratings", "progress"):
+        for feat in _ANALYZER_FEATURES:
             fcfg = feats.get(feat) or {}
             if not (isinstance(fcfg, dict) and (fcfg.get("enable") or fcfg.get("enabled"))):
                 continue
@@ -2585,7 +2585,7 @@ def _has_peer_by_pairs(
     pair_types: dict[tuple[str, str, str], set[str]] | None = None,
     cfg: dict[str, Any] | None = None,
 ) -> bool:
-    if feat not in ("history", "watchlist", "ratings", "progress"):
+    if feat not in _ANALYZER_FEATURES:
         return True
 
     prov_key = _norm_prov_token(prov)

--- a/services/editor.py
+++ b/services/editor.py
@@ -1,5 +1,5 @@
 # services/editor.py
-# CrossWatch - Tracker state helpers for history / ratings / watchlist
+# CrossWatch - Tracker state helpers for history / ratings / watchlist / progress / collection
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
@@ -18,7 +18,7 @@ import zipfile
 from cw_platform.config_base import CONFIG, load_config
 from cw_platform.provider_instances import get_provider_block, normalize_instance_id
 
-Kind = Literal["watchlist", "history", "ratings", "progress"]
+Kind = Literal["watchlist", "history", "ratings", "progress", "collection"]
 
 _JSON_FILE_SUFFIX = ".json"
 
@@ -254,7 +254,7 @@ def _enforce_snapshot_retention(kind: Kind, provider_instance: Any = None) -> No
 def load_state(kind: Kind | None = None, snapshot: str | None = None, provider_instance: Any = None) -> dict[str, Any]:
     if kind is None:
         kind_val: Kind = "watchlist"
-    elif kind in ("watchlist", "history", "ratings", "progress"):
+    elif kind in ("watchlist", "history", "ratings", "progress", "collection"):
         kind_val = kind
     else:
         raise ValueError(f"Unsupported kind: {kind!r}")
@@ -278,7 +278,7 @@ def load_state(kind: Kind | None = None, snapshot: str | None = None, provider_i
 def save_state(kind: Kind | None, items: dict[str, Any], provider_instance: Any = None) -> dict[str, Any]:
     if kind is None:
         kind_val: Kind = "watchlist"
-    elif kind in ("watchlist", "history", "ratings", "progress"):
+    elif kind in ("watchlist", "history", "ratings", "progress", "collection"):
         kind_val = kind
     else:
         raise ValueError(f"Unsupported kind: {kind!r}")
@@ -400,13 +400,13 @@ def import_tracker_json(payload: bytes, filename: str, provider_instance: Any = 
     target: str
     kind: Kind | None = None
 
-    if lower in ("watchlist.json", "history.json", "ratings.json", "progress.json"):
+    if lower in ("watchlist.json", "history.json", "ratings.json", "progress.json", "collection.json"):
         base = lower.split(".")[0]  # "watchlist" / "history" / "ratings"
         kind = cast(Kind, base)
         dest = _state_path(kind, provider_instance)
         target = "state"
     else:
-        for candidate in ("watchlist", "history", "ratings", "progress"):
+        for candidate in ("watchlist", "history", "ratings", "progress", "collection"):
             if lower.endswith(f"-{candidate}.json"):
                 kind = cast(Kind, candidate)
                 break
@@ -468,7 +468,7 @@ def import_tracker_upload(
 
 _PAIR_SCOPE_RE = re.compile(r"^(?P<mode>[^_]+)_(?P<link>[^_]+)_pair_(?P<pid>.+)$")
 _PAIR_DATASET_RE = re.compile(
-    r"^(?P<prefix>.+)[._-](?P<kind>watchlist|history|ratings|progress)\.(?P<variant>index|shadow)\.(?P<scope>.+)\.json$",
+    r"^(?P<prefix>.+)[._-](?P<kind>watchlist|history|ratings|progress|collection)\.(?P<variant>index|shadow)\.(?P<scope>.+)\.json$",
     re.IGNORECASE,
 )
 

--- a/services/scheduling.py
+++ b/services/scheduling.py
@@ -364,7 +364,7 @@ def _normalize_capture_job(j: dict[str, Any]) -> dict[str, Any]:
             continue
     days2.sort()
     feature = str(j.get("feature") or "").strip().lower()
-    if feature not in {"watchlist", "ratings", "history", "progress", "all"}:
+    if feature not in {"watchlist", "ratings", "history", "progress", "collection", "all"}:
         feature = ""
     instance = str(j.get("instance") or j.get("instance_id") or j.get("profile") or "default").strip() or "default"
     return {

--- a/services/snapshots.py
+++ b/services/snapshots.py
@@ -1,5 +1,5 @@
 # services/snapshots.py
-# CrossWatch - Provider captures (watchlist/ratings/history/progress)
+# CrossWatch - Provider captures (watchlist/ratings/history/progress/collection)
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
@@ -20,13 +20,13 @@ from cw_platform.config_base import CONFIG, load_config
 from cw_platform.modules_registry import load_sync_ops, state_read_features, sync_provider_names
 from cw_platform.provider_instances import build_provider_config_view, list_instance_ids, normalize_instance_id
 
-Feature = Literal["watchlist", "ratings", "history", "progress"]
-CreateFeature = Literal["watchlist", "ratings", "history", "progress", "all"]
+Feature = Literal["watchlist", "ratings", "history", "progress", "collection"]
+CreateFeature = Literal["watchlist", "ratings", "history", "progress", "collection", "all"]
 RestoreMode = Literal["merge", "clear_restore"]
 
 SNAPSHOT_KIND = "snapshot"
 SNAPSHOT_BUNDLE_KIND = "snapshot_bundle"
-SNAPSHOT_FEATURES: tuple[Feature, ...] = ("watchlist", "ratings", "history", "progress")
+SNAPSHOT_FEATURES: tuple[Feature, ...] = ("watchlist", "ratings", "history", "progress", "collection")
 _CAPTURE_PROGRESS: dict[str, dict[str, Any]] = {}
 _CAPTURE_PROGRESS_LOCK = Lock()
 _CAPTURE_PROGRESS_TTL_SECONDS = 6 * 60 * 60
@@ -481,7 +481,7 @@ def _resolve_snapshot_file(path: str, *, must_exist: bool = True) -> tuple[str, 
 
 def _norm_feature(x: str) -> Feature:
     v = str(x or "").strip().lower()
-    if v not in ("watchlist", "ratings", "history", "progress"):
+    if v not in ("watchlist", "ratings", "history", "progress", "collection"):
         raise ValueError(f"Unsupported feature: {x}")
     return cast(Feature, v)
 
@@ -1641,8 +1641,9 @@ def clear_provider_features(
             unresolved: list[Any] = []
             errors: list[str] = []
             passes = 0
-            max_passes = 6 if feat == "history" else 1
+            max_passes = 6 if feat in {"history", "collection"} else 1
             prev_count: int | None = None
+            seen_count = initial_count
 
             while cur and passes < max_passes:
                 passes += 1
@@ -1699,22 +1700,23 @@ def clear_provider_features(
                 if remaining_count <= 0:
                     cur = []
                     break
-                if feat != "history":
+                if feat not in {"history", "collection"}:
                     cur = remaining
                     break
                 if prev_count is not None and remaining_count >= prev_count:
                     cur = remaining
                     break
                 prev_count = remaining_count
+                seen_count += remaining_count
                 cur = remaining
 
             total_removed += removed
-            ok = len(errors) == 0
+            ok = len(errors) == 0 and len(cur) == 0
             done["ok"] = done["ok"] and ok
             done["results"][feat] = {
                 "ok": ok,
                 "removed": removed,
-                "count": initial_count,
+                "count": max(seen_count, removed),
                 "remaining": len(cur),
                 "passes": passes,
                 "unresolved": unresolved,
@@ -2006,7 +2008,7 @@ def _bundle_compare_setup(a: Mapping[str, Any], b: Mapping[str, Any], feature: s
                 out[feat] = path
         return out
 
-    order = ("watchlist", "history", "ratings", "progress")
+    order = ("watchlist", "collection", "history", "ratings", "progress")
     a_children = _child_paths(a)
     b_children = _child_paths(b)
     features = [feat for feat in order if feat in a_children and feat in b_children]

--- a/services/statistics.py
+++ b/services/statistics.py
@@ -41,7 +41,7 @@ def _canon_feature(name: Any) -> str:
         return "progress"
     if s in ("wl", "watchlist"):
         return "watchlist"
-    return s if s in ("watchlist", "ratings", "history", "progress", "playlists") else "watchlist"
+    return s if s in ("watchlist", "ratings", "history", "progress", "playlists", "collection") else "watchlist"
 
 
 class Stats:

--- a/services/support.py
+++ b/services/support.py
@@ -24,7 +24,7 @@ from cw_platform.local_db.sync_reports import list_reports
 from cw_platform.orchestrator._state_store import StateStore
 from cw_platform.provider_instances import normalize_instance_id, sanitize_instance_label
 
-FEATURE_NAMES = ("watchlist", "ratings", "history", "playlists", "progress")
+FEATURE_NAMES = ("watchlist", "ratings", "history", "playlists", "progress", "collection")
 BUNDLE_SECTIONS = ("config", "diagnostics", "reports", "logs")
 DEFAULT_SECTIONS = frozenset(BUNDLE_SECTIONS)
 

--- a/tests/test_analyzer_attention_model.py
+++ b/tests/test_analyzer_attention_model.py
@@ -44,6 +44,43 @@ def test_unresolved_only_one_pending_row():
     assert row["unresolved"] and not row["current_mismatch"]
 
 
+def test_collection_pair_is_analyzed_like_other_features():
+    item = {
+        "type": "movie",
+        "title": "Owned Movie",
+        "ids": {"tmdb": "10"},
+    }
+    state = {
+        "providers": {
+            "PLEX": {"collection": {"baseline": {"items": {"tmdb:10": item}}}},
+            "TRAKT": {"collection": {"baseline": {"items": {}}}},
+        }
+    }
+    cfg = {
+        "pairs": [
+            {
+                "id": "p1",
+                "enabled": True,
+                "source": "PLEX",
+                "target": "TRAKT",
+                "mode": "one-way",
+                "features": {"collection": {"enable": True}},
+            }
+        ]
+    }
+    ctx = A._analysis_context(state, cfg)
+
+    assert A._pair_map(cfg, state) == {("PLEX", "collection"): ["TRAKT"]}
+    assert A._counts(state)["PLEX"]["collection"] == 1
+
+    problems = A._problems(state, None, cfg=cfg, ctx=ctx, include_system=False, include_hints=False)
+    missing = [p for p in problems if p.get("type") == "missing_peer"]
+
+    assert len(missing) == 1
+    assert missing[0]["feature"] == "collection"
+    assert missing[0]["targets"] == ["TRAKT"]
+
+
 def test_same_item_in_both_is_one_row_with_both_states():
     mismatch = [_mismatch("TRAKT", "history", "tmdb:1", ["SIMKL"], ["tmdb:1", "imdb:tt1"])]
     records = [_record("SIMKL", "history", "tmdb:1", ["tmdb:1"])]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -161,6 +161,16 @@ def test_find_pair_matches_exact_prefix_and_label() -> None:
         find_pair(pairs, "nothing")
 
 
+def test_find_pair_matches_one_based_index_after_exact_ids() -> None:
+    pairs = [
+        {"id": "1", "source": "plex", "target": "trakt"},
+        {"id": "def456", "source": "simkl", "target": "trakt"},
+    ]
+
+    assert find_pair(pairs, "1")["id"] == "1"
+    assert find_pair(pairs, "2")["id"] == "def456"
+
+
 def test_find_pair_rejects_ambiguous_prefix() -> None:
     pairs = [{"id": "abc1", "source": "a", "target": "b"}, {"id": "abc2", "source": "c", "target": "d"}]
     with pytest.raises(CLIError) as err:
@@ -522,6 +532,113 @@ def test_dispatch_without_flags_reuses_the_same_context(clean_cli_env) -> None:
 
     assert run_isolated(state, ["config", "path"]) == 0
     assert state._fell_back is True
+
+
+def test_sync_list_prints_pair_order_source_target_and_features(
+    clean_cli_env,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://cw.test", output="plain")
+    state._http = FakeTransport(
+        {
+            (
+                "GET",
+                "/api/pairs",
+            ): [
+                {
+                    "id": "plex-trakt",
+                    "source": "plex",
+                    "target": "trakt",
+                    "source_instance": "kids",
+                    "mode": "one-way",
+                    "enabled": True,
+                    "features": {"watchlist": {"enable": True}, "ratings": {"enable": False}, "history": True},
+                },
+                {
+                    "id": "simkl-trakt",
+                    "source": "simkl",
+                    "target": "trakt",
+                    "mode": "two-way",
+                    "enabled": False,
+                    "features": {"progress": {"enable": True}},
+                },
+            ],
+        }
+    )
+
+    assert run_isolated(state, ["sync", "list"]) == 0
+    out = capsys.readouterr().out
+
+    assert "1\tplex-trakt\tPLEX:kids\tTRAKT\tone-way" in out
+    assert "history, watchlist" in out
+    assert "2\tsimkl-trakt\tSIMKL\tTRAKT\ttwo-way" in out
+    assert "progress" in out
+
+
+def test_sync_run_without_selector_posts_all_pairs(clean_cli_env) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://cw.test", output="plain")
+    state._http = FakeTransport({("POST", "/api/run"): {"ok": True, "run_id": "run-1"}})
+
+    assert run_isolated(state, ["sync", "run"]) == 0
+    assert state._http.calls == [("POST", "/api/run", {"source": "cli"})]
+
+
+def test_sync_run_positional_pair_index_posts_pair_id(clean_cli_env) -> None:
+    from cli._app import run_isolated
+
+    state = Ctx.build(url="http://cw.test", output="plain")
+    state._http = FakeTransport(
+        {
+            (
+                "GET",
+                "/api/pairs",
+            ): [
+                {"id": "plex-trakt", "source": "plex", "target": "trakt"},
+                {"id": "simkl-trakt", "source": "simkl", "target": "trakt"},
+            ],
+            ("POST", "/api/run"): {"ok": True, "run_id": "run-2"},
+        }
+    )
+
+    assert run_isolated(state, ["sync", "run", "2"]) == 0
+    assert state._http.calls == [
+        ("GET", "/api/pairs", None),
+        ("POST", "/api/run", {"source": "cli", "pair_id": "simkl-trakt"}),
+    ]
+
+
+def test_shell_sync_group_uses_new_list_and_run_selector(clean_cli_env) -> None:
+    from cli.commands.shell import Shell
+
+    state = Ctx.build(url="http://cw.test", output="plain")
+    state._http = FakeTransport(
+        {
+            (
+                "GET",
+                "/api/pairs",
+            ): [
+                {"id": "plex-trakt", "source": "plex", "target": "trakt", "features": {"watchlist": True}},
+                {"id": "simkl-trakt", "source": "simkl", "target": "trakt", "features": {"history": True}},
+            ],
+            ("POST", "/api/run"): {"ok": True, "run_id": "run-shell"},
+        }
+    )
+    shell = Shell(state)
+
+    assert shell.handle("sync") is True
+    assert shell.group == "sync"
+    assert shell.handle("list") is True
+    assert shell.handle("run 2") is True
+
+    assert state._http.calls == [
+        ("GET", "/api/pairs", None),
+        ("GET", "/api/pairs", None),
+        ("POST", "/api/run", {"source": "cli", "pair_id": "simkl-trakt"}),
+    ]
 
 
 def test_analyzer_problems_prints_titles_for_missing_items(
@@ -967,7 +1084,7 @@ def test_maintenance_cleanup_features_accepts_repeated_and_csv_values() -> None:
     from cli.commands.maintenance import _split_cleanup_features
 
     assert _split_cleanup_features(["watchlist,ratings", "history"]) == ["watchlist", "ratings", "history"]
-    assert _split_cleanup_features([], all_features=True) == ["watchlist", "ratings", "history", "progress"]
+    assert _split_cleanup_features([], all_features=True) == ["watchlist", "ratings", "history", "progress", "collection"]
     with pytest.raises(CLIError):
         _split_cleanup_features(["bogus"])
 

--- a/tests/test_collection_scope_safety.py
+++ b/tests/test_collection_scope_safety.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from cw_platform.orchestrator import _pairs_oneway as oneway
+
+
+def _mixed_index() -> dict[str, dict]:
+    return {
+        "tmdb:1": {"type": "movie", "title": "Movie"},
+        "tmdb:2": {"type": "show", "title": "Show"},
+        "tmdb:2#season:1": {"type": "season", "title": "Show", "season": 1},
+        "tmdb:2#s01e01": {"type": "episode", "title": "Show", "season": 1, "episode": 1},
+    }
+
+
+def test_collection_media_filter_defaults_to_movies() -> None:
+    assert set(oneway._media_type_filter_index(_mixed_index(), {})) == {"tmdb:1"}
+
+
+def test_collection_media_filter_accepts_explicit_all() -> None:
+    assert set(oneway._media_type_filter_index(_mixed_index(), {"types": ["all"]})) == set(_mixed_index())
+
+
+def test_collection_media_filter_accepts_string_type() -> None:
+    assert set(oneway._media_type_filter_index(_mixed_index(), {"types": "episodes"})) == {"tmdb:2#s01e01"}
+
+
+def test_one_way_collection_is_library_scoped() -> None:
+    cfg = {"plex": {"collection": {"libraries": ["1", "2"]}}}
+
+    assert oneway._effective_library_whitelist(cfg, "PLEX", "collection", {}) == ["1", "2"]
+
+
+def test_previous_collection_baseline_without_library_id_survives_pair_scope() -> None:
+    prev = {"tmdb:1": {"type": "movie", "ids": {"tmdb": "1"}}}
+
+    kept = oneway._filter_index_by_libraries(prev, ["19"], allow_unknown=True)
+
+    assert kept == prev
+
+
+def test_collection_state_store_round_trips_non_default_instance(tmp_path) -> None:
+    from cw_platform.orchestrator._state_store import StateStore
+
+    store = StateStore(tmp_path)
+    store.save_feature_blocks(
+        {
+            ("PLEX", "PLEX-P01", "collection"): {
+                "baseline": {"items": {"tmdb:1": {"type": "movie", "ids": {"tmdb": "1"}}}},
+                "checkpoint": None,
+            }
+        }
+    )
+
+    state = store.load_state_features({"collection"})
+
+    items = state["providers"]["PLEX"]["instances"]["PLEX-P01"]["collection"]["baseline"]["items"]
+    assert set(items) == {"tmdb:1"}
+
+
+def test_api_normalizes_collection_types_to_movies_by_default() -> None:
+    from api.syncAPI import _normalize_features
+
+    out = _normalize_features({"collection": {"enable": True, "add": True, "remove": True}})
+
+    assert out["collection"]["types"] == ["movies"]
+
+
+def test_config_loader_normalizes_collection_types_to_movies_by_default() -> None:
+    from cw_platform.config_base import _normalize_features_map
+
+    out = _normalize_features_map({"collection": {"enable": True, "add": True, "remove": True}})
+
+    assert out["collection"]["types"] == ["movies"]

--- a/tests/test_event_context.py
+++ b/tests/test_event_context.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+
+from cw_platform.event_archive import context
+
+
+def test_event_context_title_enrichment_reads_collection_state(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(context, "_config_base", lambda: tmp_path)
+    context._TITLE_CACHE["index"] = None
+    context._TITLE_CACHE["ts"] = 0.0
+
+    state = {
+        "providers": {
+            "PLEX": {
+                "collection": {
+                    "baseline": {
+                        "items": {
+                            "tmdb:10": {
+                                "type": "movie",
+                                "title": "Owned Movie",
+                                "year": 2026,
+                                "ids": {"tmdb": "10"},
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    (tmp_path / "state.test.json").write_text(json.dumps(state), encoding="utf-8")
+
+    title = context.resolve_title("tmdb:10")
+
+    assert title == {
+        "series_title": None,
+        "title": "Owned Movie",
+        "year": 2026,
+        "media_type": "movie",
+        "season": None,
+        "episode": None,
+    }

--- a/tests/test_insights_statistics.py
+++ b/tests/test_insights_statistics.py
@@ -153,6 +153,84 @@ def test_insights_history_provider_counts_collapse_native_namespace_duplicates(m
     assert history["providers_mse"]["simkl"] == {
         "movies": 1,
         "shows": 1,
+        "seasons": 0,
+        "anime": 0,
+        "episodes": 2,
+    }
+
+
+def test_insights_collection_counts_actual_collection_types(monkeypatch) -> None:
+    state = {
+        "providers": {
+            "PLEX": {
+                "instances": {
+                    "PLEX-P01": {
+                        "collection": {
+                            "baseline": {
+                                "items": {
+                                    "tmdb:100#s01e01": {
+                                        "type": "episode",
+                                        "series_title": "Show",
+                                        "season": 1,
+                                        "episode": 1,
+                                        "show_ids": {"tmdb": "100"},
+                                    },
+                                    "tmdb:100#s01e02": {
+                                        "type": "episode",
+                                        "series_title": "Show",
+                                        "season": 1,
+                                        "episode": 2,
+                                        "show_ids": {"tmdb": "100"},
+                                    },
+                                    "tmdb:100#s01": {
+                                        "type": "season",
+                                        "series_title": "Show",
+                                        "season": 1,
+                                        "show_ids": {"tmdb": "100"},
+                                    },
+                                    "tmdb:200": {
+                                        "type": "show",
+                                        "title": "Other Show",
+                                        "ids": {"tmdb": "200"},
+                                    },
+                                    "tmdb:603": {
+                                        "type": "movie",
+                                        "title": "The Matrix",
+                                        "year": 1999,
+                                        "ids": {"tmdb": "603"},
+                                    },
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    class Stats:
+        data = {"samples": [], "events": []}
+
+    cw = SimpleNamespace(
+        STATS=Stats(),
+        REPORT_DIR=None,
+        CACHE_DIR=None,
+        _load_wall_snapshot=lambda: [],
+        _append_log=lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(insight_api, "_env", lambda: (cw, lambda: {}, lambda _cfg: None, lambda *a, **k: None))
+    monkeypatch.setattr(insight_api, "_load_state_features", lambda _features: state)
+
+    app = FastAPI()
+    insight_api.register_insights(app)
+    data = TestClient(app).get("/api/insights?limit_samples=0&history=0&include_events=0").json()
+
+    collection = data["features"]["collection"]
+    assert collection["providers"]["plex"] == 5
+    assert collection["providers_mse"]["plex"] == {
+        "movies": 1,
+        "shows": 1,
+        "seasons": 1,
         "anime": 0,
         "episodes": 2,
     }


### PR DESCRIPTION
# Pull request

## Change

- Adds collection as a real sync feature in the backend sync platform.
- Includes: 
  - config normalization
  - pair feature gating
  - one-way collection planning
  - media type filtering
  - library scope handling
  - snapshots/captures support
  - editor/analyzer/insight backend support,
  - CLI-facing coverage.

## Why

Collections need to behave like the existing sync features instead of being a special push-only path.

## Testing

- tests\test_collection_scope_safety.py 
- tests\test_event_context.py 
- tests\test_cli.py 
- tests\test_analyzer_attention_model.py 
- tests\test_insights_statistics.py

## Issue

Relates to #866