### PR TITLE
Add: collection sync provider adapters

### DIFF
--- a/providers/auth/_auth_CROSSWATCH.py
+++ b/providers/auth/_auth_CROSSWATCH.py
@@ -24,7 +24,7 @@ class CrossWatchAuth(AuthProvider):
         )
 
     def capabilities(self) -> dict[str, Any]:
-        return {"watchlist": True, "ratings": True, "history": True, "progress": True}
+        return {"watchlist": True, "ratings": True, "history": True, "progress": True, "collection": True}
 
     def get_status(self, cfg: Mapping[str, Any], *, instance_id: Any = None) -> AuthStatus:
         inst = normalize_instance_id(instance_id)
@@ -76,7 +76,7 @@ def html() -> str:
         <div class="cw-panel-head">
           <div>
             <div class="cw-panel-title">CrossWatch Local Tracker</div>
-            <div class="muted">Local watchlist, ratings, history and progress storage.</div>
+            <div class="muted">Local watchlist, ratings, history, progress and collection storage.</div>
           </div>
         </div>
 
@@ -137,7 +137,7 @@ def html() -> str:
                   <div>
                     <div class="cw-field-label-row">
                       <label for="cw_tracker_max_snapshots">Max snapshots per feature</label>
-                      <button type="button" class="cw-field-help material-symbols-rounded" title="Max snapshots per feature: Maximum snapshots kept for watchlist, history, ratings and progress. Use 0 for unlimited." aria-label="Local tracker max snapshots setting help">help</button>
+                      <button type="button" class="cw-field-help material-symbols-rounded" title="Max snapshots per feature: Maximum snapshots kept for watchlist, history, ratings, progress and collection. Use 0 for unlimited." aria-label="Local tracker max snapshots setting help">help</button>
                     </div>
                     <input id="cw_tracker_max_snapshots" name="cw_tracker_max_snapshots" type="number" min="0" step="1" placeholder="64" autocomplete="off" />
                   </div>
@@ -180,6 +180,13 @@ def html() -> str:
                       <button type="button" class="cw-field-help material-symbols-rounded" title="Progress snapshot: Snapshot used when restoring or reading this local tracker profile's playback progress. Latest follows the newest snapshot." aria-label="Local tracker progress restore help">help</button>
                     </div>
                     <select id="cw_tracker_restore_progress" name="cw_tracker_restore_progress" autocomplete="off"></select>
+                  </div>
+                  <div>
+                    <div class="cw-field-label-row">
+                      <label for="cw_tracker_restore_collection">Collection snapshot</label>
+                      <button type="button" class="cw-field-help material-symbols-rounded" title="Collection snapshot: Snapshot used when restoring or reading this local tracker profile's collection. Latest follows the newest snapshot." aria-label="Local tracker collection restore help">help</button>
+                    </div>
+                    <select id="cw_tracker_restore_collection" name="cw_tracker_restore_collection" autocomplete="off"></select>
                   </div>
                 </div>
               </section>

--- a/providers/auth/_auth_EMBY.py
+++ b/providers/auth/_auth_EMBY.py
@@ -328,11 +328,12 @@ def html() -> str:
           </div>
 
           <div class="cw-subpanel" data-sub="whitelist">
-            <div style="max-width:980px">
+            <div style="width:100%;max-width:none">
               <div id="emby_lib_matrix"></div>
               <select id="emby_lib_history" class="lm-hidden" multiple></select>
               <select id="emby_lib_ratings" class="lm-hidden" multiple></select>
               <select id="emby_lib_progress" class="lm-hidden" multiple></select>
+              <select id="emby_lib_collection" class="lm-hidden" multiple></select>
               <select id="emby_lib_scrobble" class="lm-hidden" multiple></select>
             </div>
           </div>

--- a/providers/auth/_auth_JELLYFIN.py
+++ b/providers/auth/_auth_JELLYFIN.py
@@ -491,11 +491,12 @@ def html() -> str:
           </div>
 
           <div class="cw-subpanel" data-sub="whitelist">
-            <div style="max-width:980px">
+            <div style="width:100%;max-width:none">
               <div id="jfy_lib_matrix"></div>
               <select id="jfy_lib_history" name="jfy_lib_history" class="lm-hidden" multiple></select>
               <select id="jfy_lib_ratings" name="jfy_lib_ratings" class="lm-hidden" multiple></select>
               <select id="jfy_lib_progress" name="jfy_lib_progress" class="lm-hidden" multiple></select>
+              <select id="jfy_lib_collection" name="jfy_lib_collection" class="lm-hidden" multiple></select>
               <select id="jfy_lib_scrobble" name="jfy_lib_scrobble" class="lm-hidden" multiple></select>
             </div>
           </div>

--- a/providers/auth/_auth_KODI.py
+++ b/providers/auth/_auth_KODI.py
@@ -407,6 +407,7 @@ def html() -> str:
             <select id="kodi_lib_history" class="lm-hidden" multiple></select>
             <select id="kodi_lib_ratings" class="lm-hidden" multiple></select>
             <select id="kodi_lib_progress" class="lm-hidden" multiple></select>
+            <select id="kodi_lib_collection" class="lm-hidden" multiple></select>
             <select id="kodi_lib_scrobble" class="lm-hidden" multiple></select>
           </div>
         </div>

--- a/providers/auth/_auth_PLEX.py
+++ b/providers/auth/_auth_PLEX.py
@@ -375,11 +375,12 @@ def html() -> str:
           </div>
 
           <div class="cw-subpanel" data-sub="whitelist">
-            <div style="max-width:980px">
+            <div style="width:100%;max-width:none">
               <div id="plex_lib_matrix"></div>
               <select id="plex_lib_history" class="lm-hidden" multiple></select>
               <select id="plex_lib_ratings" class="lm-hidden" multiple></select>
               <select id="plex_lib_progress" class="lm-hidden" multiple></select>
+              <select id="plex_lib_collection" class="lm-hidden" multiple></select>
               <select id="plex_lib_scrobble" class="lm-hidden" multiple></select>
             </div>
           </div>

--- a/providers/sync/_mod_CROSSWATCH.py
+++ b/providers/sync/_mod_CROSSWATCH.py
@@ -98,11 +98,17 @@ except Exception as e:
     cw_log("CROSSWATCH", "module", "warn", "feature_import_failed", import_feature="progress", error=str(e))
 
 try:
+    from .crosswatch import _collection as feat_collection
+except Exception as e:
+    feat_collection = None
+    cw_log("CROSSWATCH", "module", "warn", "feature_import_failed", import_feature="collection", error=str(e))
+
+try:
     from ._mod_common import make_snapshot_progress
 except Exception:
     make_snapshot_progress = None  # type: ignore[assignment]
 
-__VERSION__ = "1.0"
+__VERSION__ = "1.1"
 __all__ = ["get_manifest", "CROSSWATCHModule", "OPS"]
 
 _FEATURES: dict[str, Any] = {}
@@ -114,6 +120,8 @@ if feat_ratings:
     _FEATURES["ratings"] = feat_ratings
 if feat_progress:
     _FEATURES["progress"] = feat_progress
+if feat_collection:
+    _FEATURES["collection"] = feat_collection
 
 
 def _dbg(feature: str, msg: str, **fields: Any) -> None:
@@ -138,6 +146,7 @@ def _features_flags() -> dict[str, bool]:
         "history": "history" in _FEATURES,
         "ratings": "ratings" in _FEATURES,
         "progress": "progress" in _FEATURES,
+        "collection": "collection" in _FEATURES,
         "playlists": False,
     }
 
@@ -177,6 +186,14 @@ def get_manifest() -> Mapping[str, Any]:
                 "position": "milliseconds",
                 "timestamp": True,
             },
+            "collection": {
+                "index_semantics": "present",
+                "observed_deletes": True,
+                "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
+                "read": True,
+                "upsert": True,
+                "remove": True,
+            },
             "snapshots": {
                 "root_dir_default": "/config/.cw_provider",
                 "managed_by": "CrossWatch",
@@ -196,6 +213,7 @@ class CROSSWATCHConfig:
     restore_history: str | None = None
     restore_ratings: str | None = None
     restore_progress: str | None = None
+    restore_collection: str | None = None
 
     @property
     def base_path(self) -> Path:
@@ -243,6 +261,7 @@ class CROSSWATCHModule:
             restore_history=_restore_id("restore_history"),
             restore_ratings=_restore_id("restore_ratings"),
             restore_progress=_restore_id("restore_progress"),
+            restore_collection=_restore_id("restore_collection"),
         )
 
         try:
@@ -275,6 +294,7 @@ class CROSSWATCHModule:
             "history": True,
             "ratings": True,
             "progress": True,
+            "collection": True,
             "playlists": False,
         }
         present = _features_flags()
@@ -440,6 +460,14 @@ class _CrossWatchOPS:
                 "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
                 "position": "milliseconds",
                 "timestamp": True,
+            },
+            "collection": {
+                "index_semantics": "present",
+                "observed_deletes": True,
+                "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
+                "read": True,
+                "upsert": True,
+                "remove": True,
             },
         }
 

--- a/providers/sync/_mod_EMBY.py
+++ b/providers/sync/_mod_EMBY.py
@@ -23,6 +23,12 @@ from .emby import _history as feat_history
 from .emby import _ratings as feat_ratings
 from .emby import _progress as feat_progress
 try:
+    from .emby import _collection as feat_collection
+except Exception as e:
+    feat_collection = None
+    if os.environ.get("CW_DEBUG") or os.environ.get("CW_EMBY_DEBUG"):
+        cw_log("EMBY", "collection", "warn", "feature_import_failed", error=str(e))
+try:
     from .emby import _playlists as feat_playlists
 except Exception as e:
     feat_playlists = None
@@ -111,7 +117,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "2.2"
+__VERSION__ = "2.3"
 os.environ.setdefault("CW_EMBY_VERSION", __VERSION__)
 os.environ.setdefault("CW_EMBY_UA", f"CrossWatch/{__VERSION__} (Emby)")
 __all__ = ["get_manifest", "EMBYModule", "OPS"]
@@ -176,6 +182,7 @@ _FEATURES: dict[str, Any] = {
     "history": feat_history,
     "ratings": feat_ratings,
     "progress": feat_progress,
+    "collection": feat_collection,
 }
 
 _PLAYLIST_CAPABILITIES: dict[str, Any] = {
@@ -206,6 +213,16 @@ _PROGRESS_CAPABILITIES: dict[str, Any] = {
             "setting": "LibraryOptions.MaxResumePct",
         },
     },
+}
+
+_COLLECTION_CAPABILITIES: dict[str, Any] = {
+    "index_semantics": "present",
+    "observed_deletes": True,
+    "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+    "read": True,
+    "add": False,
+    "remove": False,
+    "source_only": True,
 }
 
 _HEALTH_SHADOW_NAME = "emby.health.shadow.json"
@@ -242,6 +259,7 @@ def get_manifest() -> Mapping[str, Any]:
             "ratings": False,
             "playlists": feat_playlists is not None,
             "progress": True,
+            "collection": feat_collection is not None,
         },
         "requires": ["requests"],
         "capabilities": {
@@ -255,6 +273,7 @@ def get_manifest() -> Mapping[str, Any]:
                 "from_date": False,
             },
             "progress": _PROGRESS_CAPABILITIES,
+            "collection": _COLLECTION_CAPABILITIES,
             "playlists": _PLAYLIST_CAPABILITIES,
         },
     }
@@ -284,6 +303,7 @@ class EMBYConfig:
     history_libraries: list[str] | None = None
     progress_libraries: list[str] | None = None
     ratings_libraries: list[str] | None = None
+    collection_libraries: list[str] | None = None
     progress_replay_enabled: bool = False
     progress_timestamp_tolerance_seconds: int = 30
 
@@ -391,6 +411,7 @@ class EMBYModule:
         hi_gprio = hi.get("history_guid_priority") or wl_gprio
         pr = dict(em.get("progress") or {})
         ra = dict(em.get("ratings") or {})
+        co = dict(em.get("collection") or {})
 
         def _list_str(v: Any) -> list[str] | None:
             if not v:
@@ -440,6 +461,7 @@ class EMBYModule:
             history_libraries=_list_str(hi.get("libraries")),
             progress_libraries=_list_str(pr.get("libraries")),
             ratings_libraries=_list_str(ra.get("libraries")),
+            collection_libraries=_list_str(co.get("libraries")),
             progress_replay_enabled=coerce_bool(pr.get("replay_enabled", em.get("progress_replay_enabled", False))),
             progress_timestamp_tolerance_seconds=_i(pr.get("timestamp_tolerance_seconds", em.get("progress_clock_drift_seconds", 30)), 30),
             history_force_overwrite=force_overwrite,
@@ -476,7 +498,7 @@ class EMBYModule:
 
     @staticmethod
     def supported_features() -> dict[str, bool]:
-        toggles = {"watchlist": True, "history": True, "ratings": False, "playlists": feat_playlists is not None, "progress": True}
+        toggles = {"watchlist": True, "history": True, "ratings": False, "playlists": feat_playlists is not None, "progress": True, "collection": feat_collection is not None}
         present = _present_flags()
         out = {k: bool(toggles.get(k, False) and present.get(k, False)) for k in toggles.keys()}
         out["playlists"] = bool(feat_playlists is not None)
@@ -498,7 +520,7 @@ class EMBYModule:
                 "server": {"product": None, "version": None},
                 "disabled": [k for k, v in enabled.items() if not v],
             }
-            features = {k: False for k in ("watchlist", "history", "ratings", "playlists", "progress")}
+            features = {k: False for k in ("watchlist", "history", "ratings", "playlists", "progress", "collection")}
             api = {
                 "ping": {"status": None},
                 "info": {"status": None},
@@ -546,6 +568,7 @@ class EMBYModule:
             "ratings": base_ready if enabled.get("ratings") else False,
             "playlists": base_ready if enabled.get("playlists") else False,
             "progress": base_ready if enabled.get("progress") else False,
+            "collection": base_ready if enabled.get("collection") else False,
         }
 
         checks: list[bool] = [features[k] for k, on in enabled.items() if on]
@@ -717,6 +740,7 @@ class _EmbyOPS:
                 "from_date": False,
             },
             "progress": _PROGRESS_CAPABILITIES,
+            "collection": _COLLECTION_CAPABILITIES,
             "playlists": _PLAYLIST_CAPABILITIES,
         }
 

--- a/providers/sync/_mod_FLOPPY.py
+++ b/providers/sync/_mod_FLOPPY.py
@@ -11,13 +11,14 @@ from typing import Any
 from cw_platform.provider_instances import normalize_instance_id
 from providers.auth._auth_FLOPPY import FloppyAuthError, FloppyClient
 from providers.sync._mod_common import SimpleRateLimiter, build_op_result, build_session
+from providers.sync.floppy import _collection as feat_collection
 from providers.sync.floppy import _history as feat_history
 from providers.sync.floppy import _progress as feat_progress
 from providers.sync.floppy import _ratings as feat_ratings
 from providers.sync.floppy import _watchlist as feat_watchlist
 from providers.sync.floppy._common import api_delete, api_get, configured_block, is_configured, media_parts_from_item_id, paged
 
-__VERSION__ = "0.3"
+__VERSION__ = "0.4"
 __all__ = ["get_manifest", "FLOPPYModule", "OPS"]
 
 if "ctx" not in globals():
@@ -28,8 +29,8 @@ if "ctx" not in globals():
     ctx = _NullCtx()  # type: ignore[assignment]
 
 
-_FEATURES = {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False}
-_FEATURE_MODULES: dict[str, Any] = {"watchlist": feat_watchlist, "ratings": feat_ratings, "history": feat_history, "progress": feat_progress}
+_FEATURES = {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False, "collection": True}
+_FEATURE_MODULES: dict[str, Any] = {"watchlist": feat_watchlist, "ratings": feat_ratings, "history": feat_history, "progress": feat_progress, "collection": feat_collection}
 
 
 def _index_dict(value: Any) -> dict[str, dict[str, Any]]:
@@ -83,6 +84,7 @@ def get_manifest() -> Mapping[str, Any]:
             "history": {"read": True, "write": True, "types": {"movies": True, "shows": False, "seasons": False, "episodes": True}, "upsert": True, "remove": True, "observed_deletes": True, "requires_ids": ["tmdb"], "event_history": True, "rewatches": {"read": True, "write": True, "account_gate": False}},
             "progress": {"read": True, "write": True, "types": {"movies": True, "shows": False, "seasons": False, "episodes": True}, "upsert": True, "remove": True, "observed_deletes": False, "requires_ids": ["tmdb"], "units": "seconds", "completion_policy": {"progress_write": {"mode": "none"}}},
             "playlists": {"read": False, "write": False},
+            "collection": {"read": True, "write": True, "types": {"movies": True, "shows": True, "seasons": True, "episodes": True}, "upsert": True, "remove": True, "observed_deletes": True, "requires_ids": ["tmdb"], "provides_ids": ["tmdb", "imdb", "tvdb"], "default_format": "digital"},
         },
     }
 

--- a/providers/sync/_mod_JELLYFIN.py
+++ b/providers/sync/_mod_JELLYFIN.py
@@ -22,6 +22,12 @@ from .jellyfin import _history as feat_history
 from .jellyfin import _ratings as feat_ratings
 from .jellyfin import _progress as feat_progress
 try:
+    from .jellyfin import _collection as feat_collection
+except Exception as e:
+    feat_collection = None
+    if os.environ.get("CW_DEBUG") or os.environ.get("CW_JELLYFIN_DEBUG"):
+        cw_log("JELLYFIN", "collection", "warn", "feature_import_failed", error=str(e))
+try:
     from .jellyfin import _playlists as feat_playlists
 except Exception as e:
     feat_playlists = None
@@ -107,7 +113,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "2.3"
+__VERSION__ = "2.4"
 _MIN_PROGRESS_WRITE_VERSION = (10, 9)
 _JF_VERSION_CACHE: dict[str, tuple[float, str | None]] = {}
 
@@ -169,6 +175,7 @@ _FEATURES: dict[str, Any] = {
     "history": feat_history,
     "ratings": feat_ratings,
     "progress": feat_progress,
+    "collection": feat_collection,
 }
 
 _PLAYLIST_CAPABILITIES: dict[str, Any] = {
@@ -199,6 +206,16 @@ _PROGRESS_CAPABILITIES: dict[str, Any] = {
             "setting": "MaxResumePct",
         },
     },
+}
+
+_COLLECTION_CAPABILITIES: dict[str, Any] = {
+    "index_semantics": "present",
+    "observed_deletes": True,
+    "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+    "read": True,
+    "add": False,
+    "remove": False,
+    "source_only": True,
 }
 
 _HEALTH_SHADOW_NAME = "jellyfin.health.shadow.json"
@@ -252,6 +269,7 @@ def get_manifest() -> Mapping[str, Any]:
             "ratings": False,
             "playlists": feat_playlists is not None,
             "progress": True,
+            "collection": feat_collection is not None,
         },
         "requires": ["requests"],
         "capabilities": {
@@ -265,6 +283,7 @@ def get_manifest() -> Mapping[str, Any]:
                 "from_date": False,
             },
             "progress": _PROGRESS_CAPABILITIES,
+            "collection": _COLLECTION_CAPABILITIES,
             "playlists": _PLAYLIST_CAPABILITIES,
         },
     }
@@ -292,6 +311,7 @@ class JFConfig:
     history_libraries: list[str] | None = None
     progress_libraries: list[str] | None = None
     ratings_libraries: list[str] | None = None
+    collection_libraries: list[str] | None = None
     progress_replay_enabled: bool = False
     progress_timestamp_tolerance_seconds: int = 30
 
@@ -420,6 +440,7 @@ class JELLYFINModule:
         hi_gprio = hi.get("history_guid_priority") or wl_gprio
         pr = dict(jf.get("progress") or {})
         ra = dict(jf.get("ratings") or {})
+        co = dict(jf.get("collection") or {})
 
         def _list_str(v: Any) -> list[str] | None:
             if not v:
@@ -454,6 +475,7 @@ class JELLYFINModule:
             history_libraries=_list_str(hi.get("libraries")),
             progress_libraries=_list_str(pr.get("libraries")),
             ratings_libraries=_list_str(ra.get("libraries")),
+            collection_libraries=_list_str(co.get("libraries")),
             progress_replay_enabled=coerce_bool(pr.get("replay_enabled", jf.get("progress_replay_enabled", False))),
             progress_timestamp_tolerance_seconds=_int_value(pr.get("timestamp_tolerance_seconds", jf.get("progress_clock_drift_seconds", 30)), 30),
         )
@@ -487,7 +509,7 @@ class JELLYFINModule:
 
     @staticmethod
     def supported_features() -> dict[str, bool]:
-        toggles = {"watchlist": True, "history": True, "ratings": False, "playlists": feat_playlists is not None, "progress": True}
+        toggles = {"watchlist": True, "history": True, "ratings": False, "playlists": feat_playlists is not None, "progress": True, "collection": feat_collection is not None}
         present = _present_flags()
         out = {k: bool(toggles.get(k, False) and present.get(k, False)) for k in toggles.keys()}
         out["playlists"] = bool(feat_playlists is not None)
@@ -509,7 +531,7 @@ class JELLYFINModule:
                 "server": {"product": None, "version": None},
                 "disabled": [k for k, v in enabled.items() if not v],
             }
-            features = {k: False for k in ("watchlist", "history", "ratings", "playlists", "progress")}
+            features = {k: False for k in ("watchlist", "history", "ratings", "playlists", "progress", "collection")}
             api = {
                 "ping": {"status": None},
                 "info": {"status": None},
@@ -563,6 +585,7 @@ class JELLYFINModule:
             "ratings": base_ready if enabled.get("ratings") else False,
             "playlists": base_ready if enabled.get("playlists") else False,
             "progress": bool(base_ready and progress_supported) if enabled.get("progress") else False,
+            "collection": base_ready if enabled.get("collection") else False,
         }
 
         checks: list[bool] = [features[k] for k, on in enabled.items() if on]
@@ -745,6 +768,7 @@ class _JellyfinOPS:
                 "from_date": False,
             },
             "progress": _PROGRESS_CAPABILITIES,
+            "collection": _COLLECTION_CAPABILITIES,
             "playlists": _PLAYLIST_CAPABILITIES,
         }
 

--- a/providers/sync/_mod_KODI.py
+++ b/providers/sync/_mod_KODI.py
@@ -7,16 +7,17 @@ from collections.abc import Iterable, Mapping
 from typing import Any
 
 from providers.sync._mod_common import build_op_result
+from providers.sync.kodi import _collection as feat_collection
 from providers.sync.kodi import _history as feat_history
 from providers.sync.kodi import _progress as feat_progress
 from providers.sync.kodi import _ratings as feat_ratings
 from providers.sync.kodi._common import KodiClient, health_payload, is_configured, item_key, make_config, pick_instance_id
 
-__VERSION__ = "0.2"
+__VERSION__ = "0.3"
 __all__ = ["get_manifest", "KODIModule", "OPS"]
 
-_FEATURES = {"watchlist": False, "ratings": True, "history": True, "progress": True, "playlists": False}
-_FEATURE_MODULES = {"history": feat_history, "ratings": feat_ratings, "progress": feat_progress}
+_FEATURES = {"watchlist": False, "ratings": True, "history": True, "progress": True, "playlists": False, "collection": True}
+_FEATURE_MODULES = {"history": feat_history, "ratings": feat_ratings, "progress": feat_progress, "collection": feat_collection}
 
 
 def get_manifest() -> Mapping[str, Any]:
@@ -62,6 +63,15 @@ def get_manifest() -> Mapping[str, Any]:
                     "setting": "playcountminimumpercent",
                 },
             },
+        },
+        "collection": {
+            "read": True,
+            "write": False,
+            "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+            "upsert": False,
+            "remove": False,
+            "observed_deletes": True,
+            "notes": "Kodi collection is the local video library inventory. CrossWatch can read movies and episodes but cannot add or remove files from Kodi.",
         },
     }
     return {

--- a/providers/sync/_mod_MDBLIST.py
+++ b/providers/sync/_mod_MDBLIST.py
@@ -142,7 +142,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.6"
+__VERSION__ = "1.7"
 __all__ = ["get_manifest", "MDBLISTModule", "OPS"]
 
 def _health(status: str, ok: bool, latency_ms: int) -> None:
@@ -197,6 +197,12 @@ except Exception as e:
     feat_progress = None
 
 try:
+    from .mdblist import _collection as feat_collection
+except Exception as e:
+    _warn("feature_import_failed", import_feature="collection", error=f"{type(e).__name__}: {e}")
+    feat_collection = None
+
+try:
     from .mdblist import _playlists as feat_playlists
 except Exception as e:
     _warn("feature_import_failed", import_feature="playlists", error=f"{type(e).__name__}: {e}")
@@ -224,6 +230,8 @@ if feat_history:
     _FEATURES["history"] = feat_history
 if feat_progress:
     _FEATURES["progress"] = feat_progress
+if feat_collection:
+    _FEATURES["collection"] = feat_collection
 
 
 def _features_flags() -> dict[str, bool]:
@@ -232,6 +240,7 @@ def _features_flags() -> dict[str, bool]:
         "ratings": "ratings" in _FEATURES,
         "history": "history" in _FEATURES,
         "progress": "progress" in _FEATURES,
+        "collection": "collection" in _FEATURES,
         "playlists": feat_playlists is not None,
     }
 
@@ -281,6 +290,12 @@ def get_manifest() -> Mapping[str, Any]:
                     "progress_write": {"mode": "none"},
                     "stop_scrobble": {"marks_watched_percent": 80, "comparison": "gte"},
                 },
+            },
+            "collection": {
+                "observed_deletes": True,
+                "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
+                "upsert": True,
+                "remove": True,
             },
             "playlists": _PLAYLIST_CAPABILITIES,
         },
@@ -463,7 +478,7 @@ class MDBLISTModule:
 
     @staticmethod
     def supported_features() -> dict[str, bool]:
-        toggles = {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": True}
+        toggles = {"watchlist": True, "ratings": True, "history": True, "progress": True, "collection": True, "playlists": True}
         present = _features_flags()
         return {k: bool(toggles.get(k, False) and present.get(k, False)) for k in toggles.keys()}
 
@@ -482,7 +497,7 @@ class MDBLISTModule:
                 "status": "ok",
                 "latency_ms": 0,
                 "features": {},
-                "details": {"disabled": ["watchlist", "ratings", "history", "progress"]},
+                "details": {"disabled": ["watchlist", "ratings", "history", "progress", "collection"]},
                 "api": {},
             }
 
@@ -534,6 +549,7 @@ class MDBLISTModule:
             "ratings": bool(enabled.get("ratings") and user_ok),
             "history": bool(enabled.get("history") and user_ok),
             "progress": bool(enabled.get("progress") and user_ok),
+            "collection": bool(enabled.get("collection") and user_ok),
             "playlists": bool(enabled.get("playlists") and user_ok),
         }
 
@@ -851,6 +867,12 @@ class _MDBLISTOPS:
                     "progress_write": {"mode": "none"},
                     "stop_scrobble": {"marks_watched_percent": 80, "comparison": "gte"},
                 },
+            },
+            "collection": {
+                "observed_deletes": True,
+                "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
+                "upsert": True,
+                "remove": True,
             },
             "playlists": _PLAYLIST_CAPABILITIES,
         }

--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -40,7 +40,7 @@ def _error(event: str, **fields: Any) -> None:
 def _log(msg: str) -> None:
     _dbg(msg)
 
-__VERSION__ = "2.3"
+__VERSION__ = "2.4"
 os.environ.setdefault("CW_PLEX_VERSION", __VERSION__)
 os.environ.setdefault("CW_PLEX_UA", f"CrossWatch/{__VERSION__} (Plex)")
 __all__ = ["get_manifest", "PLEXModule", "PLEXClient", "PLEXError", "PLEXAuthError", "PLEXNotFound", "OPS"]
@@ -107,6 +107,13 @@ except Exception as e:
     feat_progress = None
     if os.environ.get("CW_DEBUG") or os.environ.get("CW_PLEX_DEBUG"):
         _warn("feature_import_failed", feature="progress", error=str(e))
+
+try:
+    from .plex import _collection as feat_collection
+except Exception as e:
+    feat_collection = None
+    if os.environ.get("CW_DEBUG") or os.environ.get("CW_PLEX_DEBUG"):
+        _warn("feature_import_failed", feature="collection", error=str(e))
 
 try:
     from .plex import _playlists as feat_playlists
@@ -519,7 +526,7 @@ def get_manifest() -> Mapping[str, Any]:
         "version": __VERSION__,
         "type": "sync",
         "bidirectional": True,
-        "features": {"watchlist": True, "history": True, "ratings": True, "playlists": True, "progress": True},
+        "features": {"watchlist": True, "history": True, "ratings": True, "playlists": True, "progress": True, "collection": True},
         "requires": ["plexapi"],
         "capabilities": {
             "bidirectional": True,
@@ -534,6 +541,14 @@ def get_manifest() -> Mapping[str, Any]:
                 "from_date": False,
             },
             "progress": _PROGRESS_CAPABILITIES,
+            "collection": {
+                "index_semantics": "present",
+                "observed_deletes": True,
+                "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+                "read": True,
+                "upsert": False,
+                "remove": False,
+            },
             "playlists": _PLAYLIST_CAPABILITIES,
         },
     }
@@ -1174,6 +1189,7 @@ _FEATURES: dict[str, Any] = {
     "history": feat_history,
     "ratings": feat_ratings,
     "progress": feat_progress,
+    "collection": feat_collection,
 }
 
 
@@ -1183,6 +1199,7 @@ def _features_flags() -> dict[str, bool]:
         "history": "history" in _FEATURES and _FEATURES["history"] is not None,
         "ratings": "ratings" in _FEATURES and _FEATURES["ratings"] is not None,
         "progress": "progress" in _FEATURES and _FEATURES["progress"] is not None,
+        "collection": "collection" in _FEATURES and _FEATURES["collection"] is not None,
         "playlists": feat_playlists is not None,
     }
 
@@ -1239,7 +1256,7 @@ class PLEXModule:
 
     @staticmethod
     def supported_features() -> dict[str, bool]:
-        toggles = {"watchlist": True, "ratings": True, "history": True, "playlists": True, "progress": True}
+        toggles = {"watchlist": True, "ratings": True, "history": True, "playlists": True, "progress": True, "collection": True}
         present = _features_flags()
         return {k: bool(toggles.get(k, False) and present.get(k, False)) for k in toggles.keys()}
 
@@ -1274,7 +1291,7 @@ class PLEXModule:
         started = _t.perf_counter()
 
         wl_needed = bool(enabled.get("watchlist"))
-        lib_needed = any(enabled.get(k) for k in ("history", "ratings", "playlists"))
+        lib_needed = any(enabled.get(k) for k in ("history", "ratings", "playlists", "collection"))
 
         discover_ok = False
         discover_reason: str | None = None
@@ -1349,6 +1366,7 @@ class PLEXModule:
             "ratings": pms_ok if enabled.get("ratings") else False,
             "playlists": pms_ok if enabled.get("playlists") else False,
             "progress": pms_ok if enabled.get("progress") else False,
+            "collection": pms_ok if enabled.get("collection") else False,
         }
 
         checks: list[bool] = []
@@ -1385,7 +1403,7 @@ class PLEXModule:
         if wl_needed and not discover_ok:
             reasons.append(f"watchlist:{discover_reason or 'down'}")
         if lib_needed and not pms_ok:
-            missing = [f for f in ("history", "ratings", "playlists") if enabled.get(f)]
+            missing = [f for f in ("history", "ratings", "playlists", "collection") if enabled.get(f)]
             if missing:
                 reasons.append(f"{'+'.join(missing)}:{pms_reason or 'down'}")
         if reasons:
@@ -1526,6 +1544,14 @@ class _PlexOPS:
                 "from_date": False,
             },
             "progress": _PROGRESS_CAPABILITIES,
+            "collection": {
+                "index_semantics": "present",
+                "observed_deletes": True,
+                "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+                "read": True,
+                "upsert": False,
+                "remove": False,
+            },
             "playlists": _PLAYLIST_CAPABILITIES,
         }
 

--- a/providers/sync/_mod_PUNCHPLAY.py
+++ b/providers/sync/_mod_PUNCHPLAY.py
@@ -11,6 +11,7 @@ from typing import Any
 from cw_platform.provider_instances import normalize_instance_id
 from providers.auth._auth_PUNCHPLAY import ME_URL, is_configured as auth_is_configured
 from providers.sync._mod_common import SimpleRateLimiter, build_op_result, build_session, dedup_keys
+from providers.sync.punchplay import _collection as feat_collection
 from providers.sync.punchplay import _history as feat_history
 from providers.sync.punchplay import _progress as feat_progress
 from providers.sync.punchplay import _ratings as feat_ratings
@@ -24,8 +25,8 @@ from providers.sync.punchplay._common import (
     request_id_of,
 )
 
-__VERSION__ = "0.3"
-__all__ = ["get_manifest", "PUNCHPLAYModule", "OPS", "feat_history", "feat_progress", "feat_ratings", "feat_watchlist"]
+__VERSION__ = "0.4"
+__all__ = ["get_manifest", "PUNCHPLAYModule", "OPS", "feat_collection", "feat_history", "feat_progress", "feat_ratings", "feat_watchlist"]
 
 if "ctx" not in globals():
     class _NullCtx:
@@ -35,12 +36,13 @@ if "ctx" not in globals():
     ctx = _NullCtx()  # type: ignore[assignment]
 
 
-_FEATURES = {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False}
+_FEATURES = {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False, "collection": True}
 _FEATURE_MODULES = {
     "watchlist": feat_watchlist,
     "ratings": feat_ratings,
     "history": feat_history,
     "progress": feat_progress,
+    "collection": feat_collection,
 }
 
 _ACCEPTED_IDS = ["tmdb", "imdb", "tvdb", "mal"]
@@ -122,6 +124,17 @@ def get_manifest() -> Mapping[str, Any]:
                 "accepted_ids": ["tmdb", "imdb", "tvdb"],
                 "provides_ids": ["tmdb"],
                 "requires_duration": False,
+            },
+            "collection": {
+                "read": True,
+                "write": True,
+                "types": {"movies": True, "shows": True, "seasons": True, "episodes": False},
+                "upsert": True,
+                "remove": True,
+                "observed_deletes": True,
+                "accepted_ids": ["tmdb"],
+                "provides_ids": ["tmdb"],
+                "default_format": "digital",
             },
         },
     }

--- a/providers/sync/_mod_SCROB.py
+++ b/providers/sync/_mod_SCROB.py
@@ -20,12 +20,12 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "0.1"
+__VERSION__ = "0.2"
 os.environ.setdefault("CW_SCROB_VERSION", __VERSION__)
 os.environ.setdefault("CW_SCROB_UA", f"CrossWatch/{__VERSION__} (Scrob)")
 __all__ = ["get_manifest", "SCROBModule", "OPS"]
 
-FEATURES = {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False}
+FEATURES = {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False, "collection": True}
 
 CAPABILITIES: dict[str, Any] = {
     "bidirectional": True,
@@ -69,6 +69,14 @@ CAPABILITIES: dict[str, Any] = {
         "write_window_percent": {"min": 5, "max": 90},
         "notes": "Scrob only keeps continue-watching state between 5% and 90%.",
     },
+    "collection": {
+        "types": ["movie", "show", "season", "episode"],
+        "upsert": True,
+        "remove": True,
+        "observed_deletes": True,
+        "required_ids": ["tmdb"],
+        "notes": "Scrob collection source uses the personal export; show and season writes expand server-side.",
+    },
 }
 
 
@@ -91,7 +99,7 @@ def get_manifest() -> Mapping[str, Any]:
         "features": dict(FEATURES),
         "requires": [],
         "capabilities": dict(CAPABILITIES),
-        "description": "Self hosted Scrob tracker (watchlist, ratings, history, progress).",
+        "description": "Self hosted Scrob tracker (watchlist, ratings, history, progress, collection).",
     }
 
 
@@ -160,6 +168,10 @@ class SCROBModule:
             from .scrob import _progress
 
             return _progress
+        if key == "collection":
+            from .scrob import _collection
+
+            return _collection
         return None
 
     def build_index(self, feature: str, **kwargs: Any) -> dict[str, dict[str, Any]]:

--- a/providers/sync/_mod_TRAKT.py
+++ b/providers/sync/_mod_TRAKT.py
@@ -80,6 +80,10 @@ try:
 except Exception:
     feat_progress = None
 try:
+    from .trakt import _collection as feat_collection
+except Exception:
+    feat_collection = None
+try:
     from .trakt import _playlists as feat_playlists
 except Exception:
     feat_playlists = None
@@ -99,7 +103,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.5"
+__VERSION__ = "1.6"
 __all__ = ["get_manifest", "TRAKTModule", "OPS"]
 
 os.environ.setdefault("CW_TRAKT_UA", f"CrossWatch TRAKT/{__VERSION__}")
@@ -149,6 +153,8 @@ if feat_ratings:
     _FEATURES["ratings"] = feat_ratings
 if feat_progress:
     _FEATURES["progress"] = feat_progress
+if feat_collection:
+    _FEATURES["collection"] = feat_collection
 
 
 def _features_flags() -> dict[str, bool]:
@@ -157,6 +163,7 @@ def _features_flags() -> dict[str, bool]:
         "ratings": "ratings" in _FEATURES,
         "history": "history" in _FEATURES,
         "progress": "progress" in _FEATURES,
+        "collection": "collection" in _FEATURES,
         "playlists": feat_playlists is not None,
     }
 
@@ -197,6 +204,11 @@ def get_manifest() -> Mapping[str, Any]:
                     "stop_scrobble": {"marks_watched_percent": 80, "comparison": "above"},
                 },
             },
+            "collection": {
+                "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
+                "upsert": True,
+                "remove": True,
+            },
             "playlists": _PLAYLIST_CAPABILITIES,
         },
     }
@@ -220,6 +232,9 @@ class TRAKTConfig:
     history_number_fallback: bool = False
     history_collection: bool = False
     history_collection_types: list[str] | None = None
+    collection_batch_size: int = 100
+    collection_use_etag: bool = True
+    collection_shadow_ttl_hours: int = 168
 
 
 class TRAKTClient:
@@ -406,6 +421,9 @@ class TRAKTModule:
             history_number_fallback=bool(t.get("history_number_fallback")),
             history_collection=bool(t.get("history_collection")),
             history_collection_types=types or None,
+            collection_batch_size=int(t.get("collection_batch_size", t.get("watchlist_batch_size", 100)) or 100),
+            collection_use_etag=bool(t.get("collection_use_etag", True)),
+            collection_shadow_ttl_hours=int(t.get("collection_shadow_ttl_hours", 168) or 168),
         )
         if not self.cfg.client_id or not self.cfg.access_token:
             raise TRAKTAuthError("Missing Trakt client_id/access_token")
@@ -436,6 +454,7 @@ class TRAKTModule:
             "ratings": True,
             "history": True,
             "progress": True,
+            "collection": True,
             "playlists": True,
         }
         present = _features_flags()
@@ -536,6 +555,7 @@ class TRAKTModule:
             "ratings": (core_ok if (enabled.get("ratings") and "ratings" in _FEATURES) else False),
             "history": (core_ok if (enabled.get("history") and "history" in _FEATURES) else False),
             "progress": (core_ok if (enabled.get("progress") and "progress" in _FEATURES) else False),
+            "collection": (core_ok if (enabled.get("collection") and "collection" in _FEATURES) else False),
             "playlists": (core_ok if enabled.get("playlists") else False),
         }
 
@@ -766,6 +786,11 @@ class _TraktOPS:
                     "progress_write": {"mode": "none"},
                     "stop_scrobble": {"marks_watched_percent": 80, "comparison": "above"},
                 },
+            },
+            "collection": {
+                "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
+                "upsert": True,
+                "remove": True,
             },
             "playlists": _PLAYLIST_CAPABILITIES,
         }

--- a/providers/sync/crosswatch/_collection.py
+++ b/providers/sync/crosswatch/_collection.py
@@ -1,0 +1,239 @@
+# /providers/sync/crosswatch/_collection.py
+# CrossWatch tracker Module for collection management
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+from cw_platform.id_map import canonical_key, merge_ids, minimal as id_minimal
+
+from ._common import (
+    _atomic_write,
+    _capture_mode,
+    _maybe_restore,
+    _pair_scope,
+    _record_unresolved,
+    _root,
+    _snapshot_state,
+    current_state_only,
+    latest_snapshot_file,
+    latest_state_file,
+    make_logger,
+    may_persist,
+    readonly,
+    scoped_file,
+    state_file_for_read,
+)
+
+_dbg, _info, _warn, _error = make_logger("collection")
+
+
+def _collection_path(adapter: Any) -> Path:
+    return scoped_file(_root(adapter), "collection.json")
+
+
+def _accepted(obj: Mapping[str, Any]) -> dict[str, Any]:
+    item = id_minimal(obj)
+    for key in ("collected_at", "listed_at", "added_at"):
+        value = obj.get(key)
+        if isinstance(value, str) and value.strip():
+            item["collected_at"] = value.strip()
+            break
+    return item
+
+
+def _load_state(adapter: Any) -> dict[str, Any]:
+    if _pair_scope() is None:
+        return {"ts": 0, "items": {}}
+
+    root = _root(adapter)
+    path = _collection_path(adapter)
+
+    def _read_json(p: Path) -> Any | None:
+        try:
+            return json.loads(p.read_text("utf-8"))
+        except Exception:
+            return None
+
+    read_path = state_file_for_read(root, "collection", path)
+    raw = _read_json(read_path)
+    if raw is None:
+        alt = latest_state_file(root, "collection")
+        if alt and alt != path:
+            raw = _read_json(alt)
+    if raw is None and current_state_only(adapter):
+        return {"ts": 0, "items": {}}
+    if raw is None:
+        snap = latest_snapshot_file(root, "collection")
+        if snap:
+            raw = _read_json(snap)
+    if raw is None:
+        return {"ts": 0, "items": {}}
+
+    if isinstance(raw, list):
+        items: dict[str, dict[str, Any]] = {}
+        for obj in raw:
+            if not isinstance(obj, Mapping):
+                continue
+            try:
+                accepted = _accepted(obj)
+            except Exception:
+                continue
+            key = canonical_key(accepted)
+            if key:
+                items[key] = accepted
+        state = {"ts": 0, "items": items}
+        if items and may_persist(adapter, path):
+            _atomic_write(path, {"ts": int(time.time()), "items": items})
+        return state
+
+    if isinstance(raw, Mapping):
+        if "items" in raw and isinstance(raw.get("items"), Mapping):
+            ts = int(raw.get("ts", 0) or 0)
+            items_raw = raw.get("items") or {}
+            items2: dict[str, dict[str, Any]] = {}
+            for key, value in items_raw.items():
+                if not isinstance(value, Mapping):
+                    continue
+                try:
+                    accepted = _accepted(value)
+                except Exception:
+                    continue
+                ck = str(key) or canonical_key(accepted)
+                if ck:
+                    items2[ck] = accepted
+            state = {"ts": ts, "items": items2}
+            if items2 and may_persist(adapter, path):
+                _atomic_write(path, {"ts": ts or int(time.time()), "items": items2})
+            return state
+
+        items3: dict[str, dict[str, Any]] = {}
+        for key, value in raw.items():
+            if not isinstance(value, Mapping):
+                continue
+            try:
+                accepted = _accepted(value)
+            except Exception:
+                continue
+            ck = str(key) or canonical_key(accepted)
+            if ck:
+                items3[ck] = accepted
+        state = {"ts": 0, "items": items3}
+        if items3 and may_persist(adapter, path):
+            _atomic_write(path, {"ts": int(time.time()), "items": items3})
+        return state
+
+    return {"ts": 0, "items": {}}
+
+
+def _save_state(adapter: Any, items: Mapping[str, Mapping[str, Any]]) -> None:
+    if _capture_mode() or readonly(adapter) or _pair_scope() is None:
+        return
+    _atomic_write(_collection_path(adapter), {"ts": int(time.time()), "items": dict(items or {})})
+
+
+def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
+    if _pair_scope() is None:
+        return {}
+    _maybe_restore(adapter, "collection", _save_state)
+    prog_factory = getattr(adapter, "progress_factory", None)
+    prog: Any = prog_factory("collection") if callable(prog_factory) else None
+    state = _load_state(adapter)
+    out: dict[str, dict[str, Any]] = {}
+    for key, value in dict(state.get("items") or {}).items():
+        if not isinstance(value, Mapping):
+            continue
+        try:
+            accepted = _accepted(value)
+        except Exception:
+            continue
+        ck = canonical_key(accepted) or str(key)
+        if ck:
+            out[ck] = accepted
+    total = len(out)
+    if prog:
+        try:
+            prog.tick(total, total=total, force=True)
+            prog.done()
+        except Exception:
+            pass
+    return out
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    if _pair_scope() is None:
+        return 0, []
+    src = list(items or [])
+    if not src:
+        return 0, []
+    _maybe_restore(adapter, "collection", _save_state)
+    state = _load_state(adapter)
+    cur: dict[str, dict[str, Any]] = dict(state.get("items") or {})
+    unresolved_src: list[Mapping[str, Any]] = []
+    changed = 0
+    for obj in src:
+        if not isinstance(obj, Mapping):
+            continue
+        try:
+            accepted = _accepted(obj)
+        except Exception:
+            unresolved_src.append(obj)
+            continue
+        key = canonical_key(accepted)
+        if not key:
+            unresolved_src.append(obj)
+            continue
+        existing = cur.get(key)
+        if isinstance(existing, dict):
+            ex_ids = existing.get("ids") if isinstance(existing.get("ids"), dict) else {}
+            in_ids = accepted.get("ids") if isinstance(accepted.get("ids"), dict) else {}
+            merged = merge_ids(ex_ids, in_ids)
+            if merged:
+                accepted["ids"] = merged
+            if existing.get("collected_at") and not accepted.get("collected_at"):
+                accepted["collected_at"] = existing.get("collected_at")
+        if existing != accepted:
+            cur[key] = accepted
+            changed += 1
+    if changed:
+        _snapshot_state(adapter, cur, "collection", reuse_window=60)
+        _save_state(adapter, cur)
+    unresolved = _record_unresolved(adapter, unresolved_src, "collection") if unresolved_src else []
+    return changed, unresolved
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    if _pair_scope() is None:
+        return 0, []
+    src = list(items or [])
+    if not src:
+        return 0, []
+    _maybe_restore(adapter, "collection", _save_state)
+    state = _load_state(adapter)
+    cur: dict[str, dict[str, Any]] = dict(state.get("items") or {})
+    unresolved_src: list[Mapping[str, Any]] = []
+    changed = 0
+    for obj in src:
+        if not isinstance(obj, Mapping):
+            continue
+        try:
+            accepted = _accepted(obj)
+        except Exception:
+            unresolved_src.append(obj)
+            continue
+        key = canonical_key(accepted)
+        if not key:
+            unresolved_src.append(obj)
+            continue
+        if key in cur:
+            del cur[key]
+            changed += 1
+    if changed:
+        _snapshot_state(adapter, cur, "collection", reuse_window=60)
+        _save_state(adapter, cur)
+    unresolved = _record_unresolved(adapter, unresolved_src, "collection") if unresolved_src else []
+    return changed, unresolved

--- a/providers/sync/emby/_collection.py
+++ b/providers/sync/emby/_collection.py
@@ -1,0 +1,212 @@
+# /providers/sync/emby/_collection.py
+# EMBY Module for collection inventory synchronization
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from cw_platform.id_map import canonical_key
+
+from ._common import (
+    _ids_from_provider_ids,
+    chunked,
+    emby_get_library_roots,
+    emby_item_library_ids,
+    emby_resolve_library_id,
+    emby_selected_library_ids,
+    make_logger,
+    normalize as emby_normalize,
+)
+
+_dbg, _info, _warn, _error = make_logger("collection")
+
+_ITEM_FIELDS = (
+    "ProviderIds,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesId,"
+    "SeriesName,ParentId,CollectionFolderId,AncestorIds,LibraryId,Name"
+)
+
+
+def _progress(adapter: Any) -> Any:
+    factory = getattr(adapter, "progress_factory", None)
+    if callable(factory):
+        try:
+            return factory("collection")
+        except Exception:
+            pass
+
+    class _Noop:
+        def tick(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def done(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    return _Noop()
+
+
+def _series_ids_by_item_id(
+    http: Any,
+    uid: str,
+    rows: Iterable[tuple[Mapping[str, Any], str | None]],
+) -> dict[str, dict[str, str]]:
+    series_ids = sorted(
+        {
+            str(raw.get("SeriesId") or "").strip()
+            for raw, _source_library_id in rows
+            if str(raw.get("SeriesId") or "").strip()
+        }
+    )
+    out: dict[str, dict[str, str]] = {}
+    for batch in chunked(series_ids, 100):
+        try:
+            response = http.get(
+                f"/Users/{uid}/Items",
+                params={
+                    "Ids": ",".join(batch),
+                    "Fields": "ProviderIds,ProductionYear,Type,Name",
+                },
+            )
+            if getattr(response, "status_code", 0) != 200:
+                continue
+            body = response.json() or {}
+            for row in body.get("Items") or []:
+                if not isinstance(row, Mapping):
+                    continue
+                series_id = str(row.get("Id") or "").strip()
+                provider_ids = row.get("ProviderIds")
+                if series_id and isinstance(provider_ids, Mapping):
+                    out[series_id] = _ids_from_provider_ids(provider_ids)
+        except Exception as exc:
+            _warn("series_metadata_query_failed", series_ids=batch, error=str(exc))
+    return out
+
+
+def _fetch_rows(adapter: Any) -> tuple[list[tuple[Mapping[str, Any], str | None]], set[str]]:
+    http = getattr(adapter, "client", None)
+    uid = getattr(getattr(adapter, "cfg", None), "user_id", None)
+    if not http or not uid:
+        return [], set()
+
+    allowed = emby_selected_library_ids(adapter.cfg, "collection")
+    if not allowed:
+        _dbg("library_scope_not_configured")
+    parents: list[str | None] = list(sorted(allowed)) or [None]
+    rows: list[tuple[Mapping[str, Any], str | None]] = []
+    seen_item_ids: set[str] = set()
+    page_size = 500
+    base_params: dict[str, Any] = {
+        "Recursive": True,
+        "IncludeItemTypes": "Movie,Episode",
+        "Fields": _ITEM_FIELDS,
+        "EnableUserData": False,
+    }
+    for parent_id in parents:
+        start = 0
+        seen_pages: set[tuple[str, ...]] = set()
+        while True:
+            params = dict(base_params)
+            params.update({"StartIndex": start, "Limit": page_size, "EnableTotalRecordCount": True})
+            if parent_id:
+                params["ParentId"] = parent_id
+            try:
+                response = http.get(f"/Users/{uid}/Items", params=params)
+                if getattr(response, "status_code", 0) != 200:
+                    _warn("library_scope_query_failed", source_library_id=parent_id, allowed_library_ids=sorted(allowed), status=getattr(response, "status_code", None))
+                    break
+                body = response.json() or {}
+                page = body.get("Items") or []
+                if not isinstance(page, list):
+                    break
+            except Exception as exc:
+                _warn("library_scope_query_failed", source_library_id=parent_id, allowed_library_ids=sorted(allowed), error=str(exc))
+                break
+            signature = tuple(str(raw.get("Id") or "") for raw in page if isinstance(raw, Mapping))
+            if page and signature in seen_pages:
+                _warn("pagination_repeated_page", source_library_id=parent_id, start_index=start)
+                break
+            seen_pages.add(signature)
+            for raw in page:
+                if not isinstance(raw, Mapping):
+                    continue
+                item_id = str(raw.get("Id") or "").strip()
+                if item_id and item_id in seen_item_ids:
+                    _dbg("duplicate_collection_item", provider_item_id=item_id, source_library_id=parent_id, item_title=str(raw.get("Name") or ""), media_type=str(raw.get("Type") or ""))
+                    continue
+                if item_id:
+                    seen_item_ids.add(item_id)
+                rows.append((raw, parent_id))
+            start += len(page)
+            total = int(body.get("TotalRecordCount") or 0)
+            if not page or (total and start >= total) or len(page) < page_size:
+                break
+    return rows, allowed
+
+
+def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
+    http = getattr(adapter, "client", None)
+    uid = getattr(getattr(adapter, "cfg", None), "user_id", None)
+    if not http or not uid:
+        return {}
+
+    prog = _progress(adapter)
+    rows, allowed = _fetch_rows(adapter)
+    roots = emby_get_library_roots(adapter)
+    scope_libs = sorted(allowed)
+    series_ids_by_item_id = _series_ids_by_item_id(http, str(uid), rows)
+    out: dict[str, dict[str, Any]] = {}
+    total = max(1, len(rows))
+    dup_keys = 0
+
+    for idx, (raw, source_library_id) in enumerate(rows, start=1):
+        raw_type = str(raw.get("Type") or "").strip()
+        if raw_type not in {"Movie", "Episode"}:
+            _warn("unsupported_collection_row_type", provider_item_id=str(raw.get("Id") or ""), media_type=raw_type)
+            continue
+        if allowed:
+            memberships = emby_item_library_ids(raw)
+            if memberships and not (memberships & allowed):
+                _dbg("outside_library_scope", provider_item_id=str(raw.get("Id") or ""), source_library_id=source_library_id, allowed_library_ids=sorted(allowed), item_title=str(raw.get("Name") or ""), media_type=raw_type, provider_ids=dict(raw.get("ProviderIds") or {}))
+                continue
+        try:
+            item = emby_normalize(raw)
+            lib_id = emby_resolve_library_id(
+                raw,
+                roots,
+                scope_libs,
+                http,
+                str(uid),
+                allow_deep_lookup=False,
+            ) or source_library_id
+            if lib_id:
+                item["library_id"] = lib_id
+            series_id = str(raw.get("SeriesId") or "").strip()
+            show_ids = series_ids_by_item_id.get(series_id)
+            if raw_type == "Episode" and show_ids:
+                item["show_ids"] = show_ids
+            key = canonical_key(item)
+            if not key:
+                _warn("collection_item_without_key", provider_item_id=str(raw.get("Id") or ""), item_title=str(raw.get("Name") or ""), media_type=raw_type, provider_ids=dict(raw.get("ProviderIds") or {}))
+                continue
+            if key in out:
+                dup_keys += 1
+                _dbg("duplicate_collection_key", key=key, provider_item_id=str(raw.get("Id") or ""), item_title=str(raw.get("Name") or ""), media_type=raw_type)
+            out[key] = item
+        finally:
+            prog.tick(idx, total=total)
+
+    try:
+        prog.done(total=len(out))
+    except Exception:
+        pass
+    _info("collection_index_built", rows=len(rows), indexed=len(out), duplicate_keys=dup_keys, library_ids=sorted(allowed), resolved_roots=len(roots))
+    return out
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    unresolved = [{"item": dict(item), "hint": "emby_collection_write_unsupported"} for item in items or []]
+    return 0, unresolved
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    unresolved = [{"item": dict(item), "hint": "emby_collection_write_unsupported"} for item in items or []]
+    return 0, unresolved

--- a/providers/sync/emby/_common.py
+++ b/providers/sync/emby/_common.py
@@ -309,6 +309,120 @@ def emby_scope_any(cfg: CfgLike) -> dict[str, Any]:
     return _emby_scope_from_list(libs)
 
 
+def emby_build_library_roots(http: Any, user_id: str | None = None) -> dict[str, dict[str, Any]]:
+    roots: dict[str, dict[str, Any]] = {}
+    try:
+        r = http.get(f"/Users/{user_id}/Views") if user_id else http.get("/Library/MediaFolders")
+    except Exception:
+        r = None
+    try:
+        if r is not None and getattr(r, "status_code", 0) == 200:
+            data = r.json() or {}
+            for item in data.get("Items") or data.get("ItemsList") or []:
+                if not isinstance(item, Mapping):
+                    continue
+                lid = str(item.get("Id") or item.get("Key") or "").strip()
+                if not lid:
+                    continue
+                ctyp = str(item.get("CollectionType") or item.get("Type") or "").strip().lower()
+                if "movie" in ctyp:
+                    typ = "movie"
+                elif "series" in ctyp or "tv" in ctyp:
+                    typ = "show"
+                else:
+                    typ = ctyp or "lib"
+                roots[lid] = {"id": lid, "type": typ, "raw": item}
+    except Exception:
+        pass
+    if (os.environ.get("CW_DEBUG") or os.environ.get("CW_EMBY_DEBUG")) and roots:
+        cw_log("EMBY", "common", "debug", "index_fetch_counts", source="library_roots", roots=sorted(roots.keys()))
+    return roots
+
+
+def emby_get_library_roots(adapter: Any) -> dict[str, dict[str, Any]]:
+    roots = getattr(adapter, "_emby_library_roots", None)
+    if isinstance(roots, dict) and roots:
+        return roots
+    http = getattr(adapter, "client", None)
+    cfg = getattr(adapter, "cfg", None)
+    user_id = getattr(cfg, "user_id", None) if cfg is not None else None
+    if not http:
+        return {}
+    roots = emby_build_library_roots(http, str(user_id or "") or None)
+    setattr(adapter, "_emby_library_roots", roots)
+    return roots
+
+
+_emby_lib_anc_cache: dict[str, str | None] = {}
+
+
+def _emby_lib_id_via_ancestors(http: Any, user_id: str | None, item_id: str, roots: Mapping[str, Any]) -> str | None:
+    if not item_id:
+        return None
+    if item_id in _emby_lib_anc_cache:
+        return _emby_lib_anc_cache[item_id]
+    try:
+        params = {"Fields": "Id"}
+        if user_id:
+            params["UserId"] = str(user_id)
+        response = http.get(f"/Items/{item_id}/Ancestors", params=params)
+        if getattr(response, "status_code", 0) == 200:
+            root_keys = {str(k) for k in (roots or {}).keys()}
+            for ancestor in response.json() or []:
+                aid = str((ancestor or {}).get("Id") or "").strip()
+                if aid in root_keys:
+                    _emby_lib_anc_cache[item_id] = aid
+                    return aid
+    except Exception:
+        pass
+    _emby_lib_anc_cache[item_id] = None
+    return None
+
+
+def emby_resolve_library_id(
+    row: Mapping[str, Any],
+    roots: Mapping[str, Mapping[str, Any]],
+    scope_libs: list[str] | None = None,
+    http: Any | None = None,
+    user_id: str | None = None,
+    *,
+    allow_deep_lookup: bool = False,
+) -> str | None:
+    if scope_libs and len(scope_libs) == 1:
+        return str(scope_libs[0])
+
+    candidates: list[str] = []
+    for key in ("library_id", "LibraryId", "CollectionFolderId", "ParentId"):
+        value = row.get(key)
+        if value is not None:
+            candidates.append(str(value))
+    ancestors = row.get("AncestorIds") or []
+    if isinstance(ancestors, (list, tuple)):
+        candidates.extend(str(value) for value in ancestors if value is not None)
+
+    root_keys = {str(key) for key in (roots or {}).keys()}
+    for candidate in candidates:
+        if candidate in root_keys:
+            return candidate
+
+    if allow_deep_lookup and http and row.get("Id"):
+        found = _emby_lib_id_via_ancestors(http, user_id, str(row["Id"]), roots)
+        if found:
+            return found
+
+    want: str | None = None
+    typ = str(row.get("Type") or row.get("type") or "").strip().lower()
+    if typ in ("movie", "video"):
+        want = "movie"
+    elif typ in ("episode", "series", "season", "show"):
+        want = "show"
+    if want:
+        for lib_id, meta in roots.items():
+            if str((meta or {}).get("type") or "").lower() == want:
+                return str(lib_id)
+    return None
+
+
 # type & id helpers
 def _norm_type(t: Any) -> str:
     x = str(t or "").strip().lower()

--- a/providers/sync/emby/_utils.py
+++ b/providers/sync/emby/_utils.py
@@ -67,6 +67,10 @@ def ensure_whitelist_defaults(cfg: dict[str, Any] | None = None, instance_id: An
         em.setdefault("ratings", {}).setdefault("libraries", [])
         changed = True
 
+    if "collection" not in em or "libraries" not in (em.get("collection") or {}):
+        em.setdefault("collection", {}).setdefault("libraries", [])
+        changed = True
+
     if "scrobble" not in em or "libraries" not in (em.get("scrobble") or {}):
         em.setdefault("scrobble", {}).setdefault("libraries", [])
         changed = True

--- a/providers/sync/floppy/_collection.py
+++ b/providers/sync/floppy/_collection.py
@@ -1,0 +1,271 @@
+# providers/sync/floppy/_collection.py
+# CrossWatch - Floppy collection sync
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from cw_platform.id_map import minimal as id_minimal
+from providers.auth._auth_FLOPPY import FloppyAuthError
+from providers.sync._mod_common import build_op_result, unresolved_keys
+
+from ._common import PLANNING, api_delete, api_get, api_post, canonical_item_key, confirmed_destination, failure_reason, int_or_none, paged, tmdb_enriched_item, tmdb_id_for_item, unresolved
+
+
+def _media_numbers(item: Mapping[str, Any]) -> tuple[int | None, int | None]:
+    season = int_or_none(item.get("season") if item.get("season") is not None else item.get("season_number"))
+    episode = int_or_none(item.get("episode") if item.get("episode") is not None else item.get("episode_number"))
+    return season, episode
+
+
+def _ids_from_floppy_item(row: Mapping[str, Any]) -> dict[str, str]:
+    ids_raw = row.get("ids")
+    ids = {str(k).strip().lower(): str(v).strip() for k, v in ids_raw.items() if str(v or "").strip()} if isinstance(ids_raw, Mapping) else {}
+    if str(row.get("source") or "").strip().lower() == "tmdb":
+        media_id = str(row.get("media_id") or "").strip()
+        if media_id:
+            ids.setdefault("tmdb", media_id)
+    return {k: v for k, v in ids.items() if k in {"tmdb", "imdb", "tvdb", "trakt", "simkl", "mal", "anilist", "kitsu", "anidb"}}
+
+
+def _to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    item_raw = row.get("item")
+    item: Mapping[str, Any] = item_raw if isinstance(item_raw, Mapping) else row
+    ids = _ids_from_floppy_item(item)
+    if not ids:
+        return None
+    raw_type = str(item.get("media_type") or "").strip().lower()
+    season = int_or_none(item.get("season_number") if item.get("season_number") is not None else item.get("season"))
+    episode = int_or_none(item.get("episode_number") if item.get("episode_number") is not None else item.get("episode"))
+    if raw_type == "episode" or (season is not None and episode is not None):
+        if season is None or episode is None:
+            return None
+        out: dict[str, Any] = {"type": "episode", "show_ids": dict(ids), "season": season, "episode": episode}
+    elif raw_type == "season" or season is not None:
+        if season is None:
+            return None
+        out = {"type": "season", "ids": dict(ids), "show_ids": dict(ids), "season": season}
+    elif raw_type in {"tv", "show", "series"}:
+        out = {"type": "show", "ids": dict(ids)}
+    elif raw_type == "movie":
+        out = {"type": "movie", "ids": dict(ids)}
+    else:
+        return None
+
+    title = str(item.get("title") or "").strip()
+    if title:
+        out["title"] = title
+    year = int_or_none(item.get("year"))
+    if year:
+        out["year"] = year
+    poster = str(item.get("image") or item.get("poster") or "").strip()
+    if poster:
+        out["poster"] = poster
+    entry_id = row.get("id")
+    if entry_id is not None:
+        out["_floppy_collection_id"] = str(entry_id)
+        out["_floppy_collection_ids"] = [str(entry_id)]
+    fmt = str(row.get("media_type") or "").strip()
+    if fmt:
+        out["format"] = fmt
+    collected_at = str(row.get("collected_at") or "").strip()
+    if collected_at:
+        out["collected_at"] = collected_at
+    return id_minimal(out) | {k: v for k, v in out.items() if k.startswith("_floppy_") or k in {"format", "collected_at", "poster"}}
+
+
+def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for row in paged(adapter, "collection"):
+        item = _to_minimal(row)
+        if not item:
+            continue
+        key = canonical_item_key(item)
+        if key in out:
+            ids = out[key].setdefault("_floppy_collection_ids", [])
+            if isinstance(ids, list) and item.get("_floppy_collection_id"):
+                ids.append(str(item["_floppy_collection_id"]))
+            continue
+        out[key] = item
+    return out
+
+
+def _floppy_media_type(item: Mapping[str, Any]) -> str | None:
+    typ = str(id_minimal(item).get("type") or "").strip().lower()
+    if typ == "movie":
+        return "movie"
+    if typ in {"show", "series", "tv"}:
+        return "tv"
+    if typ == "season":
+        return "season"
+    if typ == "episode":
+        return "episode"
+    return None
+
+
+def _detail_path(media_type: str, tmdb_id: str, season: int | None = None, episode: int | None = None) -> str:
+    if media_type == "episode" and season is not None and episode is not None:
+        return f"media/episode/tmdb/{tmdb_id}/{season}/{episode}"
+    if media_type == "season" and season is not None:
+        return f"media/season/tmdb/{tmdb_id}/{season}"
+    return f"media/{media_type}/tmdb/{tmdb_id}"
+
+
+def _item_id_from_response(data: Any) -> str | None:
+    if not isinstance(data, Mapping):
+        return None
+    for key in ("id", "item_pk", "item_db_id"):
+        value = str(data.get(key) or "").strip()
+        if value.isdigit():
+            return value
+    return None
+
+
+def _ensure_item_id(adapter: Any, item: Mapping[str, Any]) -> tuple[str | None, str]:
+    media_type = _floppy_media_type(item)
+    if not media_type:
+        return None, "floppy_collection_type_unsupported"
+    episode_show = media_type in {"season", "episode"}
+    tmdb_id = tmdb_id_for_item(item, episode_show=episode_show)
+    if not tmdb_id:
+        return None, "floppy_tmdb_id_missing"
+    season, episode = _media_numbers(item)
+    if media_type in {"season", "episode"} and season is None:
+        return None, "floppy_season_id_missing"
+    if media_type == "episode" and episode is None:
+        return None, "floppy_episode_id_missing"
+
+    body: dict[str, Any] = {"source": "tmdb", "media_id": str(tmdb_id), "status": PLANNING}
+    if season is not None:
+        body["season_number"] = season
+    if episode is not None:
+        body["episode_number"] = episode
+    title = str(item.get("title") or item.get("series_title") or "").strip()
+    if title:
+        body["title"] = title
+    poster = str(item.get("poster") or item.get("image") or "").strip()
+    if poster:
+        body["image"] = poster
+
+    try:
+        item_id = _item_id_from_response(api_post(adapter, f"media/{media_type}", json=body))
+        if item_id:
+            return item_id, ""
+    except FloppyAuthError as exc:
+        if getattr(exc, "status_code", None) not in {400, 409}:
+            return None, failure_reason(exc)
+
+    try:
+        item_id = _item_id_from_response(api_get(adapter, _detail_path(media_type, str(tmdb_id), season, episode)))
+        if item_id:
+            return item_id, ""
+    except Exception as exc:
+        return None, failure_reason(exc)
+    return None, "floppy_item_id_missing"
+
+
+def _collection_body(adapter: Any, item: Mapping[str, Any]) -> tuple[dict[str, Any] | None, str]:
+    item_id, reason = _ensure_item_id(adapter, item)
+    if not item_id:
+        return None, reason
+    body: dict[str, Any] = {"item_id": item_id}
+    fmt = str(item.get("format") or item.get("edition_format") or "digital").strip().lower()
+    if fmt:
+        body["media_type"] = fmt[:20]
+    collected_at = str(item.get("collected_at") or "").strip()
+    if collected_at:
+        body["collected_at"] = collected_at
+    return body, ""
+
+
+def _collection_ids_for_remove(adapter: Any, item: Mapping[str, Any]) -> list[str]:
+    direct = item.get("_floppy_collection_ids")
+    ids = [str(x).strip() for x in direct if str(x or "").strip()] if isinstance(direct, list) else []
+    single = str(item.get("_floppy_collection_id") or item.get("collection_id") or "").strip()
+    if single:
+        ids.append(single)
+    if ids:
+        return list(dict.fromkeys(ids))
+    key = canonical_item_key(item)
+    if not key:
+        return []
+    try:
+        match = build_index(adapter).get(key)
+    except Exception:
+        match = None
+    if not isinstance(match, Mapping):
+        return []
+    found = match.get("_floppy_collection_ids")
+    ids = [str(x).strip() for x in found if str(x or "").strip()] if isinstance(found, list) else []
+    single = str(match.get("_floppy_collection_id") or "").strip()
+    if single:
+        ids.append(single)
+    return list(dict.fromkeys(ids))
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    confirmed: list[str] = []
+    confirmed_destinations: dict[str, dict[str, Any]] = {}
+    unresolved_rows: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    for raw in [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]:
+        key = canonical_item_key(raw)
+        item = tmdb_enriched_item(adapter, raw, episode_show=str(id_minimal(raw).get("type") or "").strip().lower() in {"season", "episode"})
+        if dry_run:
+            confirmed.append(key)
+            confirmed_destinations[key] = confirmed_destination(item)
+            results.append({"status": "dry_run", "item": id_minimal(item), "canonical_key": key})
+            continue
+        body, reason = _collection_body(adapter, item)
+        if body is None:
+            entry = unresolved(item, reason or "floppy_collection_unresolved")
+            unresolved_rows.append(entry)
+            results.append(entry)
+            continue
+        try:
+            api_post(adapter, "collection", json=body)
+        except Exception as exc:
+            entry = unresolved(item, failure_reason(exc))
+            unresolved_rows.append(entry)
+            results.append(entry)
+            continue
+        confirmed.append(key)
+        confirmed_destinations[key] = confirmed_destination(item)
+        results.append({"status": "applied", "item": id_minimal(item), "canonical_key": key})
+    return build_op_result(ok=not unresolved_rows, count=len(confirmed), confirmed_keys=confirmed, confirmed_destinations=confirmed_destinations, unresolved_keys=unresolved_keys(unresolved_rows, canonical_item_key), unresolved=unresolved_rows, results=results, attempted=len(confirmed) + len(unresolved_rows))
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    confirmed: list[str] = []
+    confirmed_destinations: dict[str, dict[str, Any]] = {}
+    unresolved_rows: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    for raw in [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]:
+        key = canonical_item_key(raw)
+        if dry_run:
+            confirmed.append(key)
+            confirmed_destinations[key] = confirmed_destination(raw)
+            results.append({"status": "dry_run", "item": id_minimal(raw), "canonical_key": key})
+            continue
+        entry_ids = _collection_ids_for_remove(adapter, raw)
+        if not entry_ids:
+            entry = unresolved(raw, "floppy_collection_id_missing")
+            unresolved_rows.append(entry)
+            results.append(entry)
+            continue
+        failed = False
+        for entry_id in entry_ids:
+            try:
+                api_delete(adapter, f"collection/{entry_id}")
+            except Exception:
+                failed = True
+        if failed:
+            entry = unresolved(raw, "floppy_collection_remove_failed")
+            unresolved_rows.append(entry)
+            results.append(entry)
+            continue
+        confirmed.append(key)
+        confirmed_destinations[key] = confirmed_destination(raw)
+        results.append({"status": "applied", "item": id_minimal(raw), "canonical_key": key})
+    return build_op_result(ok=not unresolved_rows, count=len(confirmed), confirmed_keys=confirmed, confirmed_destinations=confirmed_destinations, unresolved_keys=unresolved_keys(unresolved_rows, canonical_item_key), unresolved=unresolved_rows, results=results, attempted=len(confirmed) + len(unresolved_rows))

--- a/providers/sync/jellyfin/_collection.py
+++ b/providers/sync/jellyfin/_collection.py
@@ -1,0 +1,212 @@
+# /providers/sync/jellyfin/_collection.py
+# JELLYFIN Module for collection inventory synchronization
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from cw_platform.id_map import canonical_key
+
+from ._common import (
+    _ids_from_provider_ids,
+    chunked,
+    jf_get_library_roots,
+    jf_item_library_ids,
+    jf_resolve_library_id,
+    jf_selected_library_ids,
+    make_logger,
+    normalize as jelly_normalize,
+)
+from ._routes import items as items_route, user_params
+
+_dbg, _info, _warn = make_logger("collection")
+
+_ITEM_FIELDS = (
+    "ProviderIds,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesId,"
+    "SeriesName,ParentId,CollectionFolderId,AncestorIds,LibraryId,Name"
+)
+
+
+def _progress(adapter: Any) -> Any:
+    factory = getattr(adapter, "progress_factory", None)
+    if callable(factory):
+        try:
+            return factory("collection")
+        except Exception:
+            pass
+
+    class _Noop:
+        def tick(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def done(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    return _Noop()
+
+
+def _series_ids_by_item_id(
+    http: Any,
+    uid: str,
+    rows: Iterable[tuple[Mapping[str, Any], str | None]],
+) -> dict[str, dict[str, str]]:
+    series_ids = sorted(
+        {
+            str(raw.get("SeriesId") or "").strip()
+            for raw, _source_library_id in rows
+            if str(raw.get("SeriesId") or "").strip()
+        }
+    )
+    out: dict[str, dict[str, str]] = {}
+    for batch in chunked(series_ids, 100):
+        try:
+            response = http.get(
+                items_route(),
+                params=user_params(uid, {
+                    "Ids": ",".join(batch),
+                    "Fields": "ProviderIds,ProductionYear,Type,Name",
+                }),
+            )
+            if getattr(response, "status_code", 0) != 200:
+                continue
+            body = response.json() or {}
+            for row in body.get("Items") or []:
+                if not isinstance(row, Mapping):
+                    continue
+                series_id = str(row.get("Id") or "").strip()
+                provider_ids = row.get("ProviderIds")
+                if series_id and isinstance(provider_ids, Mapping):
+                    out[series_id] = _ids_from_provider_ids(provider_ids)
+        except Exception as exc:
+            _warn("series_metadata_query_failed", series_ids=batch, error=str(exc))
+    return out
+
+
+def _fetch_rows(adapter: Any) -> tuple[list[tuple[Mapping[str, Any], str | None]], set[str]]:
+    http = getattr(adapter, "client", None)
+    uid = getattr(getattr(adapter, "cfg", None), "user_id", None)
+    if not http or not uid:
+        return [], set()
+
+    allowed = jf_selected_library_ids(adapter.cfg, "collection")
+    if not allowed:
+        _dbg("library_scope_not_configured")
+    parents: list[str | None] = list(sorted(allowed)) or [None]
+    rows: list[tuple[Mapping[str, Any], str | None]] = []
+    seen_item_ids: set[str] = set()
+    page_size = 500
+    base_params: dict[str, Any] = {
+        "Recursive": True,
+        "IncludeItemTypes": "Movie,Episode",
+        "Fields": _ITEM_FIELDS,
+        "EnableUserData": False,
+    }
+    for parent_id in parents:
+        start = 0
+        seen_pages: set[tuple[str, ...]] = set()
+        while True:
+            params = dict(base_params)
+            params.update({"StartIndex": start, "Limit": page_size, "EnableTotalRecordCount": True})
+            if parent_id:
+                params["ParentId"] = parent_id
+            try:
+                response = http.get(items_route(), params=user_params(str(uid), params))
+                if getattr(response, "status_code", 0) != 200:
+                    _warn("library_scope_query_failed", source_library_id=parent_id, allowed_library_ids=sorted(allowed), status=getattr(response, "status_code", None))
+                    break
+                body = response.json() or {}
+                page = body.get("Items") or []
+                if not isinstance(page, list):
+                    break
+            except Exception as exc:
+                _warn("library_scope_query_failed", source_library_id=parent_id, allowed_library_ids=sorted(allowed), error=str(exc))
+                break
+            signature = tuple(str(raw.get("Id") or "") for raw in page if isinstance(raw, Mapping))
+            if page and signature in seen_pages:
+                _warn("pagination_repeated_page", source_library_id=parent_id, start_index=start)
+                break
+            seen_pages.add(signature)
+            for raw in page:
+                if not isinstance(raw, Mapping):
+                    continue
+                item_id = str(raw.get("Id") or "").strip()
+                if item_id and item_id in seen_item_ids:
+                    _dbg("duplicate_collection_item", provider_item_id=item_id, source_library_id=parent_id, item_title=str(raw.get("Name") or ""), media_type=str(raw.get("Type") or ""))
+                    continue
+                if item_id:
+                    seen_item_ids.add(item_id)
+                rows.append((raw, parent_id))
+            start += len(page)
+            total = int(body.get("TotalRecordCount") or 0)
+            if not page or (total and start >= total) or len(page) < page_size:
+                break
+    return rows, allowed
+
+
+def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
+    http = getattr(adapter, "client", None)
+    uid = getattr(getattr(adapter, "cfg", None), "user_id", None)
+    if not http or not uid:
+        return {}
+
+    prog = _progress(adapter)
+    rows, allowed = _fetch_rows(adapter)
+    roots = jf_get_library_roots(adapter)
+    scope_libs = sorted(allowed)
+    series_ids_by_item_id = _series_ids_by_item_id(http, str(uid), rows)
+    out: dict[str, dict[str, Any]] = {}
+    total = max(1, len(rows))
+    dup_keys = 0
+
+    for idx, (raw, source_library_id) in enumerate(rows, start=1):
+        raw_type = str(raw.get("Type") or "").strip()
+        if raw_type not in {"Movie", "Episode"}:
+            _warn("unsupported_collection_row_type", provider_item_id=str(raw.get("Id") or ""), media_type=raw_type)
+            continue
+        if allowed:
+            memberships = jf_item_library_ids(raw)
+            if memberships and not (memberships & allowed):
+                _dbg("outside_library_scope", provider_item_id=str(raw.get("Id") or ""), source_library_id=source_library_id, allowed_library_ids=sorted(allowed), item_title=str(raw.get("Name") or ""), media_type=raw_type, provider_ids=dict(raw.get("ProviderIds") or {}))
+                continue
+        try:
+            item = jelly_normalize(raw)
+            lib_id = jf_resolve_library_id(
+                raw,
+                roots,
+                scope_libs,
+                http,
+                allow_deep_lookup=False,
+            ) or source_library_id
+            if lib_id:
+                item["library_id"] = lib_id
+            series_id = str(raw.get("SeriesId") or "").strip()
+            show_ids = series_ids_by_item_id.get(series_id)
+            if raw_type == "Episode" and show_ids:
+                item["show_ids"] = show_ids
+            key = canonical_key(item)
+            if not key:
+                _warn("collection_item_without_key", provider_item_id=str(raw.get("Id") or ""), item_title=str(raw.get("Name") or ""), media_type=raw_type, provider_ids=dict(raw.get("ProviderIds") or {}))
+                continue
+            if key in out:
+                dup_keys += 1
+                _dbg("duplicate_collection_key", key=key, provider_item_id=str(raw.get("Id") or ""), item_title=str(raw.get("Name") or ""), media_type=raw_type)
+            out[key] = item
+        finally:
+            prog.tick(idx, total=total)
+
+    try:
+        prog.done(total=len(out))
+    except Exception:
+        pass
+    _info("collection_index_built", rows=len(rows), indexed=len(out), duplicate_keys=dup_keys, library_ids=sorted(allowed), resolved_roots=len(roots))
+    return out
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    unresolved = [{"item": dict(item), "hint": "jellyfin_collection_write_unsupported"} for item in items or []]
+    return 0, unresolved
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    unresolved = [{"item": dict(item), "hint": "jellyfin_collection_write_unsupported"} for item in items or []]
+    return 0, unresolved

--- a/providers/sync/jellyfin/_utils.py
+++ b/providers/sync/jellyfin/_utils.py
@@ -25,7 +25,7 @@ def ensure_whitelist_defaults(cfg: dict[str, Any] | None = None, instance_id: An
     jf = _jellyfin(cfg2, instance_id)
     changed = False
 
-    for sec in ("history", "progress", "ratings", "scrobble"):
+    for sec in ("history", "progress", "ratings", "collection", "scrobble"):
         if sec not in jf or not isinstance(jf.get(sec), dict):
             jf[sec] = {}
             changed = True

--- a/providers/sync/kodi/_collection.py
+++ b/providers/sync/kodi/_collection.py
@@ -1,0 +1,37 @@
+# providers/sync/kodi/_collection.py
+# CrossWatch Kodi collection source
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from providers.sync._mod_common import build_op_result
+
+from ._common import item_key, library_index, log
+
+
+def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
+    idx = library_index(adapter, "collection")
+    out: dict[str, dict[str, Any]] = {}
+    for base in idx.items:
+        item = dict(base)
+        key = item_key(item)
+        if key and key != "unknown:":
+            out[key] = item
+    log("collection", "info", "index_done", count=len(out))
+    return out
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    rows = [dict(item) for item in items or []]
+    unresolved = [{"item": item, "reason": "kodi_collection_write_unsupported"} for item in rows]
+    log("collection", "info", "write_skipped", op="add", reason="unsupported", unresolved=len(unresolved), dry_run=bool(dry_run))
+    return build_op_result(ok=True, count=0, unresolved=unresolved, reason="unsupported")
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    rows = [dict(item) for item in items or []]
+    unresolved = [{"item": item, "reason": "kodi_collection_write_unsupported"} for item in rows]
+    log("collection", "info", "write_skipped", op="remove", reason="unsupported", unresolved=len(unresolved), dry_run=bool(dry_run))
+    return build_op_result(ok=True, count=0, unresolved=unresolved, reason="unsupported")

--- a/providers/sync/kodi/_common.py
+++ b/providers/sync/kodi/_common.py
@@ -23,7 +23,7 @@ EPISODE_BASE_PROPERTIES = ["uniqueid", "title", "showtitle", "season", "episode"
 MOVIE_PROPERTIES = [*MOVIE_BASE_PROPERTIES, "playcount", "lastplayed", "userrating", "resume"]
 EPISODE_PROPERTIES = [*EPISODE_BASE_PROPERTIES, "playcount", "lastplayed", "userrating", "resume"]
 SHOW_PROPERTIES = ["uniqueid", "title", "year"]
-WHITELIST_FEATURES = ("history", "ratings", "progress", "scrobble")
+WHITELIST_FEATURES = ("history", "ratings", "progress", "collection", "scrobble")
 
 
 def properties_for_feature(feature: str) -> tuple[list[str], list[str], list[str]]:

--- a/providers/sync/mdblist/_collection.py
+++ b/providers/sync/mdblist/_collection.py
@@ -1,0 +1,813 @@
+# /providers/sync/mdblist/_collection.py
+# MDBList collection sync module
+# Copyright (c) 2025-2026 CrossWatch / Cenodude
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from cw_platform.anime_mapping.service import mapped_or_default_media_type
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+
+from .._log import log as cw_log
+from ._common import (
+    _is_capture_mode,
+    _pair_scope,
+    as_epoch,
+    cfg_bool,
+    cfg_int,
+    cfg_section,
+    get_watermark,
+    has_auth,
+    iso_ok,
+    iso_z,
+    mdblist_request,
+    now_iso,
+    read_json,
+    save_watermark,
+    state_file,
+    write_json,
+)
+
+BASE = "https://api.mdblist.com"
+URL_LIST = f"{BASE}/sync/collection"
+URL_REMOVE = f"{BASE}/sync/collection/remove"
+
+_cfg = cfg_section
+_cfg_int = cfg_int
+_cfg_bool = cfg_bool
+_as_epoch = as_epoch
+_iso_ok = iso_ok
+_iso_z = iso_z
+_now_iso = now_iso
+
+
+def _dbg(msg: str, **fields: Any) -> None:
+    cw_log("MDBLIST", "collection", "debug", msg, **fields)
+
+
+def _info(msg: str, **fields: Any) -> None:
+    cw_log("MDBLIST", "collection", "info", msg, **fields)
+
+
+def _warn(msg: str, **fields: Any) -> None:
+    cw_log("MDBLIST", "collection", "warn", msg, **fields)
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        s = str(value).strip()
+        if not s:
+            return None
+        return int(s)
+    except Exception:
+        return None
+
+
+def _as_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s or None
+
+
+def _key_of(item: Mapping[str, Any]) -> str:
+    try:
+        key = canonical_key(item)
+        if key:
+            return str(key)
+    except Exception:
+        pass
+    return f"obj:{hash(json.dumps(dict(item), sort_keys=True, default=str)) & 0xffffffff}"
+
+
+def _unresolved_entry(item: Mapping[str, Any], hint: str, *, key: str | None = None) -> dict[str, Any]:
+    minimal_item = id_minimal(item)
+    entry: dict[str, Any] = {"item": minimal_item, "hint": hint}
+    resolved_key = _as_str(key)
+    if not resolved_key:
+        try:
+            resolved_key = _as_str(canonical_key(minimal_item))
+        except Exception:
+            resolved_key = None
+    if resolved_key:
+        entry["key"] = resolved_key
+    return entry
+
+
+def _collection_write_result(
+    *,
+    confirmed_keys: Iterable[str],
+    unresolved: list[dict[str, Any]],
+    attempted: int,
+    accepted_keys: Iterable[str] | None = None,
+    presence_confirmed_keys: Iterable[str] | None = None,
+    accepted_not_seen_live_keys: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    unresolved_keys = [
+        str(u.get("key") or "").strip()
+        for u in unresolved
+        if isinstance(u, Mapping) and str(u.get("key") or "").strip()
+    ]
+    unresolved_set = set(unresolved_keys)
+    confirmed = [
+        str(k)
+        for k in dict.fromkeys(str(k) for k in confirmed_keys if k)
+        if str(k) not in unresolved_set
+    ]
+    out: dict[str, Any] = {
+        "ok": not unresolved,
+        "count": len(confirmed),
+        "confirmed_keys": confirmed,
+        "unresolved": unresolved,
+        "unresolved_keys": list(dict.fromkeys(unresolved_keys)),
+        "attempted": int(attempted or 0),
+    }
+    if accepted_keys is not None:
+        out["accepted_keys"] = [str(k) for k in dict.fromkeys(str(k) for k in accepted_keys if k)]
+    if presence_confirmed_keys is not None:
+        out["presence_confirmed_keys"] = [
+            str(k) for k in dict.fromkeys(str(k) for k in presence_confirmed_keys if k)
+        ]
+    if accepted_not_seen_live_keys is not None:
+        out["accepted_not_seen_live_keys"] = [
+            str(k) for k in dict.fromkeys(str(k) for k in accepted_not_seen_live_keys if k)
+        ]
+    return out
+
+
+def _shadow_path() -> Path:
+    return state_file("mdblist_collection.shadow.json")
+
+
+def _shadow_load() -> dict[str, Any]:
+    doc = read_json(_shadow_path())
+    if not isinstance(doc, dict):
+        return {"ts": 0, "items": {}}
+    doc.setdefault("ts", 0)
+    if not isinstance(doc.get("items"), dict):
+        doc["items"] = {}
+    return doc
+
+
+def _shadow_save(items: Mapping[str, Any]) -> None:
+    if _is_capture_mode() or _pair_scope() is None:
+        return
+    write_json(_shadow_path(), {"ts": int(time.time()), "items": dict(items)}, indent=None, sort_keys=False)
+
+
+def _shadow_bust() -> None:
+    if _is_capture_mode() or _pair_scope() is None:
+        return
+    try:
+        p = _shadow_path()
+        if p.exists():
+            p.unlink()
+            _dbg("cache_invalidated", cache="shadow", reason="write_applied")
+    except Exception:
+        pass
+
+
+def _ids_clean(ids: Mapping[str, Any] | None) -> dict[str, str]:
+    out: dict[str, str] = {}
+    aliases = {
+        "imdbid": "imdb",
+        "imdb_id": "imdb",
+        "tmdbid": "tmdb",
+        "tmdb_id": "tmdb",
+        "tvdbid": "tvdb",
+        "tvdb_id": "tvdb",
+        "traktid": "trakt",
+        "trakt_id": "trakt",
+        "mdblistid": "mdblist",
+        "mdblist_id": "mdblist",
+        "kitsuid": "kitsu",
+        "kitsu_id": "kitsu",
+    }
+    for k, v in dict(ids or {}).items():
+        if v is None:
+            continue
+        key = aliases.get(str(k).strip().lower(), str(k).strip().lower())
+        s = str(v).strip()
+        if s:
+            out[key] = s
+    return out
+
+
+def _ids_pick(*nodes: Any) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for node in nodes:
+        if not isinstance(node, Mapping):
+            continue
+        out.update(_ids_clean(node.get("ids") if isinstance(node.get("ids"), Mapping) else None))
+        out.update(
+            _ids_clean(
+                {
+                    "imdb": node.get("imdb") or node.get("imdb_id") or node.get("imdbid"),
+                    "tmdb": node.get("tmdb") or node.get("tmdb_id") or node.get("tmdbid"),
+                    "tvdb": node.get("tvdb") or node.get("tvdb_id") or node.get("tvdbid"),
+                    "trakt": node.get("trakt") or node.get("trakt_id") or node.get("traktid"),
+                    "mdblist": node.get("mdblist") or node.get("mdblist_id") or node.get("mdblistid"),
+                    "kitsu": node.get("kitsu") or node.get("kitsu_id") or node.get("kitsuid"),
+                }
+            )
+        )
+    return out
+
+
+def _title(node: Any) -> Any:
+    if not isinstance(node, Mapping):
+        return None
+    return node.get("title") or node.get("name") or node.get("episode_title")
+
+
+def _year(node: Any) -> int | None:
+    if not isinstance(node, Mapping):
+        return None
+    year = _as_int(node.get("year") or node.get("release_year") or node.get("first_air_year"))
+    if year is not None:
+        return year
+    first_air = _as_str(node.get("first_air_date") or node.get("first_aired"))
+    return _as_int(first_air[:4]) if first_air and len(first_air) >= 4 else None
+
+
+def _number_from(node: Any, *keys: str) -> int | None:
+    if not isinstance(node, Mapping):
+        return None
+    for key in keys:
+        value = node.get(key)
+        if isinstance(value, Mapping):
+            value = value.get("number")
+        num = _as_int(value)
+        if num is not None:
+            return num
+    return None
+
+
+def _show_node(row: Mapping[str, Any], child: Any = None) -> Mapping[str, Any] | None:
+    if isinstance(child, Mapping) and isinstance(child.get("show"), Mapping):
+        return child["show"]
+    if isinstance(row.get("show"), Mapping):
+        return row["show"]
+    return None
+
+
+def _ids_for_mdblist(item: Mapping[str, Any], *, show_scope: bool = False) -> dict[str, Any]:
+    source = item.get("show_ids") if show_scope and isinstance(item.get("show_ids"), Mapping) else item.get("ids")
+    ids_raw = dict(source or {})
+    if not ids_raw and not show_scope:
+        ids_raw = {
+            "imdb": item.get("imdb") or item.get("imdb_id"),
+            "tmdb": item.get("tmdb") or item.get("tmdb_id"),
+            "tvdb": item.get("tvdb") or item.get("tvdb_id"),
+            "trakt": item.get("trakt") or item.get("trakt_id"),
+            "mdblist": item.get("mdblist") or item.get("mdblist_id"),
+            "kitsu": item.get("kitsu") or item.get("kitsu_id"),
+        }
+
+    out: dict[str, Any] = {}
+    imdb = _as_str(ids_raw.get("imdb"))
+    if imdb:
+        out["imdb"] = imdb
+    mdblist = _as_str(ids_raw.get("mdblist") or ids_raw.get("mdblist_id"))
+    if mdblist:
+        out["mdblist"] = mdblist
+    for key in ("tmdb", "tvdb", "trakt", "kitsu"):
+        ident = _as_int(ids_raw.get(key) or ids_raw.get(f"{key}_id"))
+        if ident is not None:
+            out[key] = ident
+    return out
+
+
+def _item_media_type(item: Mapping[str, Any]) -> str:
+    t = str(item.get("type") or item.get("media_type") or "").strip().lower()
+    if t in ("episode", "season"):
+        return t
+    if mapped_or_default_media_type(item) == "show" or t in ("show", "shows", "series", "tv"):
+        return "show"
+    return "movie"
+
+
+def _movie_from_row(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    movie = row.get("movie") if isinstance(row.get("movie"), Mapping) else row
+    if not isinstance(movie, Mapping):
+        return None
+    item = id_minimal({"type": "movie", "title": _title(movie), "year": _year(movie), "ids": _ids_pick(movie, row)})
+    collected_at = row.get("collected_at")
+    if collected_at:
+        item["collected_at"] = str(collected_at)
+    return item
+
+
+def _show_base(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    show = row.get("show") if isinstance(row.get("show"), Mapping) else row
+    if not isinstance(show, Mapping):
+        return None
+    item = id_minimal({"type": "show", "title": _title(show), "year": _year(show), "ids": _ids_pick(show, row)})
+    collected_at = row.get("collected_at")
+    if collected_at:
+        item["collected_at"] = str(collected_at)
+    return item
+
+
+def _season_from_row(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    season = row.get("season") if isinstance(row.get("season"), Mapping) else row
+    if not isinstance(season, Mapping):
+        return None
+    show = _show_node(row, season)
+    row_show_ids = row.get("show_ids") if isinstance(row.get("show_ids"), Mapping) else None
+    show_ids = _ids_pick(show) or _ids_pick(row_show_ids) or _ids_pick(row)
+    season_no = _number_from(season, "number", "season", "season_number") or _number_from(
+        row, "number", "season", "season_number"
+    )
+    if season_no is None or not show_ids:
+        return None
+    item = id_minimal(
+        {
+            "type": "season",
+            "title": _title(show) or _title(row),
+            "series_title": _title(show) or _title(row),
+            "year": _year(show) or _year(row),
+            "show_ids": show_ids,
+            "ids": _ids_pick(season) or show_ids,
+            "season": season_no,
+        }
+    )
+    collected_at = season.get("collected_at") or row.get("collected_at")
+    if collected_at:
+        item["collected_at"] = str(collected_at)
+    return item
+
+
+def _episode_from_row(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    episode = row.get("episode") if isinstance(row.get("episode"), Mapping) else row
+    if not isinstance(episode, Mapping):
+        return None
+    show = _show_node(row, episode)
+    show_ids = _ids_pick(show)
+    if not show_ids:
+        row_show_ids = row.get("show_ids") if isinstance(row.get("show_ids"), Mapping) else None
+        show_ids = _ids_pick(row_show_ids) or _ids_pick(row)
+    season_no = _number_from(episode, "season", "season_number") or _number_from(row, "season", "season_number")
+    episode_no = _number_from(episode, "number", "episode", "episode_number") or _number_from(row, "number", "episode", "episode_number")
+    ids = _ids_pick(episode)
+    if episode is row:
+        ids = {}
+    if season_no is None or episode_no is None or not (show_ids or ids):
+        return None
+    scope_ids = show_ids or ids
+    item = id_minimal(
+        {
+            "type": "episode",
+            "title": _title(episode),
+            "series_title": _title(show) or _title(row),
+            "year": _year(show) or _year(row),
+            "show_ids": scope_ids,
+            "ids": ids or scope_ids,
+            "season": season_no,
+            "episode": episode_no,
+        }
+    )
+    collected_at = episode.get("collected_at") or row.get("collected_at")
+    if collected_at:
+        item["collected_at"] = str(collected_at)
+    return item
+
+
+def _items_from_row(row: Mapping[str, Any], bucket: str) -> list[dict[str, Any]]:
+    typ = str(row.get("type") or "").strip().lower()
+    if typ.endswith("s") and typ in ("movies", "shows", "seasons", "episodes"):
+        typ = typ[:-1]
+    if bucket == "episodes" or typ == "episode":
+        item = _episode_from_row(row)
+        return [item] if item else []
+    if bucket == "seasons" or typ == "season":
+        item = _season_from_row(row)
+        return [item] if item else []
+    if bucket == "movies" or isinstance(row.get("movie"), Mapping):
+        item = _movie_from_row(row)
+        return [item] if item else []
+
+    show_item = _show_base(row)
+    show = row.get("show") if isinstance(row.get("show"), Mapping) else row
+    seasons = row.get("seasons")
+    if not isinstance(seasons, list) and isinstance(show, Mapping):
+        seasons = show.get("seasons")
+    if not isinstance(seasons, list) or not seasons:
+        return [show_item] if show_item else []
+
+    show_ids = dict((show_item or {}).get("ids") or {})
+    title = (show_item or {}).get("title")
+    year = (show_item or {}).get("year")
+    out: list[dict[str, Any]] = []
+    for season in seasons:
+        if not isinstance(season, Mapping):
+            continue
+        season_no = season.get("number")
+        episodes = season.get("episodes")
+        collected_at = season.get("collected_at") or row.get("collected_at")
+        if isinstance(episodes, list) and episodes:
+            for ep in episodes:
+                if not isinstance(ep, Mapping):
+                    continue
+                ep_no = ep.get("number")
+                if season_no is None or ep_no is None:
+                    continue
+                item = id_minimal({"type": "episode", "title": ep.get("title"), "series_title": title, "year": year, "show_ids": show_ids, "ids": _ids_clean(ep.get("ids")), "season": season_no, "episode": ep_no})
+                if ep.get("collected_at") or collected_at:
+                    item["collected_at"] = str(ep.get("collected_at") or collected_at)
+                out.append(item)
+        elif season_no is not None:
+            item = id_minimal({"type": "season", "title": title, "series_title": title, "year": year, "show_ids": show_ids, "ids": _ids_clean(season.get("ids")), "season": season_no})
+            if collected_at:
+                item["collected_at"] = str(collected_at)
+            out.append(item)
+    return out or ([show_item] if show_item else [])
+
+
+def _fetch_last_activities(adapter: Any, *, apikey: str, timeout: float, retries: int) -> dict[str, Any] | None:
+    client = getattr(adapter, "client", None)
+    if client and hasattr(client, "last_activities"):
+        try:
+            data = client.last_activities()
+            if isinstance(data, Mapping) and "error" not in data and "status" not in data:
+                return dict(data)
+        except Exception:
+            pass
+    try:
+        r = mdblist_request(adapter, "GET", f"{BASE}/sync/last_activities", params={"apikey": apikey}, timeout=timeout, max_retries=retries)
+        if 200 <= r.status_code < 300:
+            data = r.json() if (r.text or "").strip() else {}
+            return dict(data) if isinstance(data, Mapping) else None
+    except Exception:
+        pass
+    return None
+
+
+def _activity_collected_at(acts: Mapping[str, Any]) -> str | None:
+    values = [acts.get("collected_at"), acts.get("collection_at"), acts.get("updated_at")]
+    for nested_name in ("movies", "shows"):
+        nested = acts.get(nested_name)
+        if isinstance(nested, Mapping):
+            values.extend([nested.get("collected_at"), nested.get("collection_at")])
+    latest: str | None = None
+    for value in values:
+        if _iso_ok(value):
+            latest = str(value) if latest is None else max(latest, str(value))
+    return _iso_z(latest) if _iso_ok(latest) else None
+
+
+def build_index(adapter: Any, *, per_page: int = 1000, max_pages: int = 250) -> dict[str, dict[str, Any]]:
+    cfg = _cfg(adapter)
+    apikey = _as_str(cfg.get("api_key")) or ""
+    shadow = _shadow_load()
+    cached: dict[str, dict[str, Any]] = dict(shadow.get("items") or {})
+    if not has_auth(cfg):
+        source = "shadow" if cached else "empty"
+        _info("index_done", count=len(cached), source=source)
+        return cached
+
+    timeout = adapter.cfg.timeout
+    retries = adapter.cfg.max_retries
+    acts = _fetch_last_activities(adapter, apikey=apikey, timeout=timeout, retries=retries) or {}
+    acts_ts = _activity_collected_at(acts)
+    wm = get_watermark("collection")
+    if acts_ts and wm and (_as_epoch(acts_ts) or 0) <= (_as_epoch(wm) or 0) and cached:
+        _dbg("index_cache_hit", source="shadow", reason="activities_unchanged", collected_at=acts_ts, watermark=wm, count=len(cached))
+        _info("index_done", count=len(cached), source="shadow")
+        return cached
+    if acts_ts and (not wm) and cached:
+        save_watermark("collection", acts_ts)
+        _dbg("index_cache_hit", source="shadow", reason="baseline_watermark_set", watermark=acts_ts, count=len(cached))
+        _info("index_done", count=len(cached), source="shadow")
+        return cached
+
+    limit = max(1, min(_cfg_int(cfg, "collection_per_page", per_page), 5000))
+    max_pages = max(1, min(_cfg_int(cfg, "collection_max_pages", max_pages), 2000))
+    prog_factory = getattr(adapter, "progress_factory", None)
+    prog: Any = prog_factory("collection") if callable(prog_factory) else None
+    out: dict[str, dict[str, Any]] = {}
+    offset = 0
+    pages = 0
+    total_tick = 0
+
+    while pages < max_pages:
+        r = mdblist_request(adapter, "GET", URL_LIST, params={"apikey": apikey, "offset": offset, "limit": limit}, timeout=timeout, max_retries=retries)
+        if r.status_code != 200:
+            _warn("http_failed", op="index", status=r.status_code, offset=offset)
+            break
+        data = r.json() if (r.text or "").strip() else {}
+        if not isinstance(data, Mapping):
+            break
+        rows_seen = 0
+        for bucket in ("movies", "shows", "seasons", "episodes"):
+            raw = data.get(bucket)
+            if not isinstance(raw, list):
+                continue
+            for row in raw:
+                if not isinstance(row, Mapping):
+                    continue
+                rows_seen += 1
+                for item in _items_from_row(row, bucket):
+                    key = _key_of(item)
+                    if key:
+                        out[key] = item
+        total_tick += rows_seen
+        if prog:
+            prog.tick(total_tick, total=max(total_tick, offset + rows_seen))
+        pag = data.get("pagination") if isinstance(data.get("pagination"), Mapping) else {}
+        has_more = bool(pag.get("has_more")) if isinstance(pag, Mapping) else rows_seen >= limit
+        if not rows_seen or not has_more:
+            break
+        offset += int(pag.get("limit") or limit) if isinstance(pag, Mapping) else limit
+        pages += 1
+
+    if out:
+        _shadow_save(out)
+    if acts_ts:
+        save_watermark("collection", acts_ts)
+    _info("index_done", count=len(out), source="current")
+    return out
+
+
+def _chunk(seq: list[Any], n: int) -> Iterable[list[Any]]:
+    size = max(1, int(n or 1))
+    for i in range(0, len(seq), size):
+        yield seq[i : i + size]
+
+
+def _batch_payload(items: Iterable[Mapping[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    accepted: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+    for item in items or []:
+        m = id_minimal(item)
+        typ = _item_media_type(m)
+        ids = _ids_for_mdblist(m, show_scope=typ in ("season", "episode"))
+        if typ in ("season", "episode") and not ids:
+            ids = _ids_for_mdblist(m)
+        if not ids:
+            rejected.append({"item": m, "hint": "missing_ids"})
+            continue
+        entry = {"type": typ, "ids": ids, "collected_at": m.get("collected_at")}
+        if typ in ("season", "episode"):
+            entry["season"] = m.get("season") if m.get("season") is not None else m.get("number")
+        if typ == "episode":
+            entry["episode"] = m.get("episode") if m.get("episode") is not None else m.get("episode_number")
+        if typ == "season" and entry.get("season") is None:
+            rejected.append({"item": m, "hint": "missing_season"})
+            continue
+        if typ == "episode" and (entry.get("season") is None or entry.get("episode") is None):
+            rejected.append({"item": m, "hint": "missing_episode_scope"})
+            continue
+        accepted.append(entry)
+    return accepted, rejected
+
+
+def _attempted_items_by_key(items: Iterable[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for item in items or []:
+        m = id_minimal(item)
+        key = _key_of(m)
+        if key:
+            out.setdefault(key, m)
+    return out
+
+
+def _unresolved_key_set(unresolved: Iterable[Mapping[str, Any]]) -> set[str]:
+    out: set[str] = set()
+    for row in unresolved or []:
+        if not isinstance(row, Mapping):
+            continue
+        explicit = _as_str(row.get("key") or row.get("unresolved_key"))
+        if explicit:
+            out.add(explicit)
+            continue
+        item = row.get("item") if isinstance(row.get("item"), Mapping) else row
+        if isinstance(item, Mapping):
+            key = _key_of(id_minimal(item))
+            if key:
+                out.add(key)
+    return out
+
+
+def _with_unresolved_keys(rows: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for row in rows or []:
+        if not isinstance(row, Mapping):
+            continue
+        item = row.get("item") if isinstance(row.get("item"), Mapping) else row
+        hint = _as_str(row.get("hint") or row.get("reason") or row.get("error")) or "unknown"
+        key = _as_str(row.get("key") or row.get("unresolved_key"))
+        if isinstance(item, Mapping):
+            out.append(_unresolved_entry(item, hint, key=key))
+    return out
+
+
+def _payload_from_accepted(items: list[dict[str, Any]], *, include_dates: bool) -> dict[str, Any]:
+    body: dict[str, Any] = {}
+    shows_by_key: dict[str, dict[str, Any]] = {}
+
+    def show_key(ids: Mapping[str, Any]) -> str:
+        return json.dumps({k: ids.get(k) for k in ("imdb", "tmdb", "tvdb", "trakt", "mdblist", "kitsu") if ids.get(k) is not None}, sort_keys=True)
+
+    for item in items:
+        typ = str(item.get("type") or "").lower()
+        ids = dict(item.get("ids") or {})
+        collected_at = item.get("collected_at")
+        if typ == "movie":
+            entry: dict[str, Any] = {"ids": ids}
+            if include_dates and collected_at:
+                entry["collected_at"] = str(collected_at)
+            body.setdefault("movies", []).append(entry)
+            continue
+        if typ == "show":
+            entry: dict[str, Any] = {"ids": ids}
+            if include_dates and collected_at:
+                entry["collected_at"] = str(collected_at)
+            body.setdefault("shows", []).append(entry)
+            continue
+
+        skey = show_key(ids)
+        show_entry = shows_by_key.setdefault(skey, {"ids": ids, "seasons": {}})
+        season_raw = item.get("season")
+        if season_raw is None:
+            continue
+        try:
+            season_i = int(season_raw)
+        except Exception:
+            continue
+        season_entry = show_entry["seasons"].setdefault(season_i, {"number": season_i})
+        if include_dates and collected_at:
+            season_entry.setdefault("collected_at", str(collected_at))
+        if typ == "episode":
+            episode_raw = item.get("episode")
+            if episode_raw is None:
+                continue
+            try:
+                episode_i = int(episode_raw)
+            except Exception:
+                continue
+            ep_entry: dict[str, Any] = {"number": episode_i}
+            if include_dates and collected_at:
+                ep_entry["collected_at"] = str(collected_at)
+            season_entry.setdefault("episodes", []).append(ep_entry)
+
+    if shows_by_key:
+        body.setdefault("shows", []).extend(
+            {"ids": v["ids"], "seasons": list(v["seasons"].values())}
+            for v in shows_by_key.values()
+            if v.get("ids")
+        )
+    return body
+
+
+def _count_result(value: Any) -> int:
+    if not isinstance(value, Mapping):
+        return 0
+    return sum(int(_as_int(value.get(k)) or 0) for k in ("movies", "shows", "seasons", "episodes"))
+
+
+def _write(adapter: Any, op: str, items: Iterable[Mapping[str, Any]]) -> dict[str, Any] | tuple[int, list[dict[str, Any]]]:
+    cfg = _cfg(adapter)
+    apikey = _as_str(cfg.get("api_key")) or ""
+    item_list = list(items or [])
+    if not has_auth(cfg):
+        return 0, _with_unresolved_keys({"item": id_minimal(it), "hint": "missing_auth"} for it in item_list)
+    accepted, unresolved = _batch_payload(item_list)
+    unresolved = _with_unresolved_keys(unresolved)
+    attempted_by_key = _attempted_items_by_key(item_list)
+    if not accepted:
+        _info("write_skipped", op=op, reason="empty_payload", unresolved=len(unresolved))
+        return 0, unresolved
+
+    chunk_size = _cfg_int(cfg, "collection_batch_size", 25)
+    delay_ms = _cfg_int(cfg, "collection_write_delay_ms", 600)
+    max_backoff_ms = _cfg_int(cfg, "collection_max_backoff_ms", 8000)
+    url = URL_LIST if op == "add" else URL_REMOVE
+    ok = 0
+    body = _payload_from_accepted(accepted, include_dates=(op == "add"))
+    if not body:
+        _info("write_skipped", op=op, reason="empty_payload", unresolved=len(unresolved))
+        return 0, unresolved
+
+    _dbg(
+        "write_start",
+        op=op,
+        movies=len(body.get("movies") or []),
+        shows=len(body.get("shows") or []),
+        chunk_size=chunk_size,
+    )
+
+    for bucket in ("movies", "shows"):
+        rows = body.get(bucket) or []
+        if not rows:
+            continue
+        for part in _chunk(rows, chunk_size):
+            payload = {bucket: part}
+            attempt = 0
+            backoff = delay_ms
+
+            while True:
+                r = mdblist_request(
+                    adapter,
+                    "POST",
+                    url,
+                    params={"apikey": apikey},
+                    json=payload,
+                    timeout=adapter.cfg.timeout,
+                    max_retries=adapter.cfg.max_retries,
+                )
+                if r.status_code in (200, 201, 204):
+                    chunk_ok = 0
+                    if r.status_code == 204 or not (r.text or "").strip():
+                        body_any: Any = {}
+                    else:
+                        try:
+                            body_any = r.json()
+                        except Exception:
+                            body_any = {}
+                    if isinstance(body_any, Mapping):
+                        chunk_ok = _count_result(
+                            body_any.get("updated")
+                            or body_any.get("added")
+                            or body_any.get("existing")
+                            or body_any.get("deleted")
+                            or body_any.get("removed")
+                        )
+                    ok += chunk_ok or len(part)
+                    time.sleep(max(0.0, delay_ms / 1000.0))
+                    break
+
+                if r.status_code in (429, 503):
+                    _warn(
+                        "rate_limit",
+                        op=op,
+                        bucket=bucket,
+                        status=r.status_code,
+                        attempt=attempt,
+                        backoff_ms=backoff,
+                        body=(r.text or "")[:180],
+                    )
+                    time.sleep(min(max_backoff_ms, backoff) / 1000.0)
+                    attempt += 1
+                    backoff = min(max_backoff_ms, int(backoff * 1.6) + 200)
+                    if attempt <= 4:
+                        continue
+
+                _warn("write_failed", op=op, bucket=bucket, status=r.status_code, body=(r.text or "")[:200])
+                item_type = "show" if bucket == "shows" else "movie"
+                for x in part:
+                    unresolved.extend(
+                        _with_unresolved_keys(
+                            [{"item": id_minimal({"type": item_type, "ids": x.get("ids") or {}}), "hint": f"http:{r.status_code}"}]
+                        )
+                    )
+                break
+    if ok:
+        _shadow_bust()
+    if op == "add" and _cfg_bool(cfg, "collection_verify_after_write", True):
+        rejected = _unresolved_key_set(unresolved)
+        accepted_keys = [key for key in attempted_by_key if key not in rejected]
+        live_keys: set[str] = set()
+        verified_live = False
+        if accepted_keys:
+            try:
+                live_keys = set(build_index(adapter).keys())
+                verified_live = True
+            except Exception as exc:
+                _warn("verify_failed", error=f"{type(exc).__name__}: {exc}")
+        if accepted_keys and not verified_live:
+            _info("write_done", op=op, ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved), verified=False)
+            return ok, unresolved
+        presence = [key for key in accepted_keys if key in live_keys]
+        not_seen = [key for key in accepted_keys if key not in live_keys]
+        for key in not_seen:
+            item = attempted_by_key.get(key)
+            if item:
+                unresolved.append(_unresolved_entry(item, "not_seen_live", key=key))
+        if not_seen:
+            _warn("write_unverified", op=op, accepted=len(accepted_keys), confirmed=len(presence), not_seen=len(not_seen))
+        _info("write_done", op=op, ok=len(unresolved) == 0, applied=len(presence), unresolved=len(unresolved))
+        return _collection_write_result(
+            confirmed_keys=presence,
+            unresolved=unresolved,
+            attempted=len(item_list),
+            accepted_keys=accepted_keys,
+            presence_confirmed_keys=presence,
+            accepted_not_seen_live_keys=not_seen,
+        )
+    _info("write_done", op=op, ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
+    return ok, unresolved
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, Any] | tuple[int, list[dict[str, Any]]]:
+    return _write(adapter, "add", items)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, Any] | tuple[int, list[dict[str, Any]]]:
+    return _write(adapter, "remove", items)

--- a/providers/sync/plex/_collection.py
+++ b/providers/sync/plex/_collection.py
@@ -1,0 +1,105 @@
+# /providers/sync/plex/_collection.py
+# Plex library collection source
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from cw_platform.id_map import canonical_key
+
+from ._common import (
+    active_pms_token,
+    make_logger,
+    minimal_from_history_row,
+    plex_feature_library_ids,
+)
+from ._history import _fetch_section_guid_rows
+
+_dbg, _info, _warn, _error, _log = make_logger("collection")
+
+
+def _row_type(row: Mapping[str, Any], fallback: str) -> str:
+    typ = str(row.get("type") or "").strip().lower()
+    if typ:
+        return typ
+    return fallback
+
+
+def _normalize_row(row: Mapping[str, Any], *, library_id: str, fallback_type: str, token: str | None) -> dict[str, Any] | None:
+    raw = dict(row)
+    raw["librarySectionID"] = str(library_id)
+    raw.setdefault("type", fallback_type)
+    item = minimal_from_history_row(raw, token=token, allow_discover=False)
+    if not item:
+        return None
+    item = dict(item)
+    item["type"] = "episode" if _row_type(raw, fallback_type) == "episode" else "movie"
+    item["library_id"] = str(library_id)
+    return item
+
+
+def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
+    srv = getattr(getattr(adapter, "client", None), "server", None)
+    if not srv:
+        _info("index_skipped", reason="no_pms")
+        return {}
+
+    allowed = plex_feature_library_ids(adapter, "collection")
+    token = active_pms_token(adapter)
+    prog_mk = getattr(adapter, "progress_factory", None)
+    prog: Any = prog_mk("collection") if callable(prog_mk) else None
+
+    sections: list[tuple[str, str, int]] = []
+    found: set[str] = set()
+    for sec in adapter.libraries(types=("movie", "show")) or []:
+        sid = str(getattr(sec, "key", "") or "").strip()
+        typ = str(getattr(sec, "type", "") or "").strip().lower()
+        if not sid or typ not in {"movie", "show"}:
+            continue
+        found.add(sid)
+        if allowed and sid not in allowed:
+            continue
+        sections.append((sid, typ, 1 if typ == "movie" else 4))
+
+    missing = sorted(allowed - found)
+    if missing:
+        _warn("libraries_not_found", libraries=",".join(missing))
+
+    out: dict[str, dict[str, Any]] = {}
+    scanned = 0
+    total_sections = max(1, len(sections))
+
+    for index, (sid, lib_type, plex_type) in enumerate(sections, start=1):
+        rows, requests_made = _fetch_section_guid_rows(srv, sid, plex_type)
+        scanned += len(rows)
+        fallback_type = "movie" if lib_type == "movie" else "episode"
+        for row in rows:
+            if not isinstance(row, Mapping):
+                continue
+            item = _normalize_row(row, library_id=sid, fallback_type=fallback_type, token=token)
+            if not item:
+                continue
+            key = canonical_key(item)
+            if key:
+                out[key] = item
+        if prog:
+            try:
+                prog.tick(index, total=total_sections)
+            except Exception:
+                pass
+        _dbg("section_scanned", library_id=sid, library_type=lib_type, rows=len(rows), requests=requests_made)
+
+    _info("index_done", count=len(out), scanned=scanned, libraries=len(sections))
+    return out
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    unresolved = [{"item": dict(item), "hint": "plex_collection_write_unsupported"} for item in items or []]
+    _info("write_skipped", op="add", reason="unsupported", unresolved=len(unresolved))
+    return 0, unresolved
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    unresolved = [{"item": dict(item), "hint": "plex_collection_write_unsupported"} for item in items or []]
+    _info("write_skipped", op="remove", reason="unsupported", unresolved=len(unresolved))
+    return 0, unresolved

--- a/providers/sync/plex/_utils.py
+++ b/providers/sync/plex/_utils.py
@@ -1088,7 +1088,7 @@ def ensure_whitelist_defaults(
     cfg = load_config() if cfg is None else cfg
     plex = _plex(cfg, instance_id)
     changed = False
-    for sec in ("history", "progress", "ratings", "scrobble"):
+    for sec in ("history", "progress", "ratings", "collection", "scrobble"):
         if not isinstance(plex.get(sec), dict):
             plex[sec] = {}
             changed = True

--- a/providers/sync/punchplay/_collection.py
+++ b/providers/sync/punchplay/_collection.py
@@ -1,0 +1,266 @@
+# /providers/sync/punchplay/_collection.py
+# PunchPlay collection sync module
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+
+from ._common import (
+    URL_COLLECTION,
+    URL_COLLECTION_ITEM,
+    URL_COLLECTION_WRITE,
+    cfg_section,
+    error_of,
+    ids_for_punchplay,
+    punchplay_request,
+    request_id_of,
+    safe_json,
+    _as_int,
+    _dbg,
+    _info,
+    _warn,
+)
+
+FEATURE = "collection"
+VALID_FORMATS = {"4k_bluray", "bluray", "hd_dvd", "dvd", "digital"}
+
+
+def _key_of(obj: Mapping[str, Any]) -> str:
+    try:
+        return str(canonical_key(id_minimal(obj)) or "").strip()
+    except Exception:
+        return ""
+
+
+def _pick(row: Mapping[str, Any], *names: str) -> Any:
+    for name in names:
+        if name in row and row.get(name) is not None:
+            return row.get(name)
+    return None
+
+
+def _nested(row: Mapping[str, Any], *names: str) -> Mapping[str, Any]:
+    for name in names:
+        value = row.get(name)
+        if isinstance(value, Mapping):
+            return value
+    return {}
+
+
+def _kind_of(item: Mapping[str, Any]) -> str:
+    raw = str(item.get("type") or item.get("kind") or "").strip().lower()
+    if raw in ("movie", "movies", "film"):
+        return "movie"
+    return "show"
+
+
+def _format_value(adapter: Any, item: Mapping[str, Any]) -> str:
+    raw = str(item.get("format") or item.get("edition_format") or "").strip().lower()
+    if raw in VALID_FORMATS:
+        return raw
+    cfg = cfg_section(adapter)
+    raw_cfg = str(cfg.get("collection_default_format") or "digital").strip().lower()
+    return raw_cfg if raw_cfg in VALID_FORMATS else "digital"
+
+
+def _row_ids(row: Mapping[str, Any], title: Mapping[str, Any]) -> dict[str, str]:
+    ids: dict[str, str] = {}
+    source_id = _pick(row, "sourceId", "source_id", "tmdbId", "tmdb_id", "titleTmdbId", "title_tmdb_id") or _pick(title, "sourceId", "source_id", "tmdbId", "tmdb_id")
+    tmdb = _as_int(source_id)
+    if tmdb:
+        ids["tmdb"] = str(tmdb)
+    imdb = _pick(row, "imdbId", "imdb_id") or _pick(title, "imdbId", "imdb_id")
+    if imdb:
+        text = str(imdb).strip()
+        if text:
+            ids["imdb"] = text if text.startswith("tt") else f"tt{text.lstrip('t')}"
+    tvdb = _as_int(_pick(row, "tvdbId", "tvdb_id") or _pick(title, "tvdbId", "tvdb_id"))
+    if tvdb:
+        ids["tvdb"] = str(tvdb)
+    mal = _as_int(_pick(row, "malId", "mal_id") or _pick(title, "malId", "mal_id"))
+    if mal:
+        ids["mal"] = str(mal)
+    return ids
+
+
+def _to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    title_obj = _nested(row, "title", "item")
+    ids = _row_ids(row, title_obj)
+    if not ids:
+        return None
+
+    raw_kind = str(_pick(row, "kind", "type", "mediaType", "media_type") or _pick(title_obj, "kind", "type", "mediaType", "media_type") or "").strip().lower()
+    season = _as_int(_pick(row, "season", "seasonNumber", "season_number"))
+    typ = "movie" if raw_kind in ("movie", "movies", "film") else ("season" if season is not None else "show")
+
+    if typ == "season":
+        out: dict[str, Any] = {"type": "season", "ids": dict(ids), "show_ids": dict(ids), "season": season}
+    else:
+        out = {"type": typ, "ids": dict(ids)}
+
+    title = _pick(row, "title", "name")
+    if isinstance(title, Mapping):
+        title = _pick(title, "title", "name")
+    if not title:
+        title = _pick(title_obj, "title", "name")
+    if title:
+        out["title"] = str(title).strip()
+
+    year = _pick(row, "year") or _pick(title_obj, "year")
+    try:
+        if year is not None:
+            out["year"] = int(year)
+    except Exception:
+        pass
+
+    entry_id = _pick(row, "id", "collectionId", "collection_id")
+    if entry_id is not None:
+        out["_punchplay_collection_id"] = str(entry_id)
+    fmt = str(_pick(row, "format") or "").strip().lower()
+    if fmt:
+        out["format"] = fmt
+    notes = str(_pick(row, "notes") or "").strip()
+    if notes:
+        out["notes"] = notes
+    added = _pick(row, "addedAt", "added_at", "createdAt", "created_at", "collectedAt", "collected_at")
+    if added:
+        out["collected_at"] = str(added)
+    return id_minimal(out) | {k: v for k, v in out.items() if str(k).startswith("_punchplay_") or k in {"format", "notes", "collected_at"}}
+
+
+def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
+    collected: dict[str, dict[str, Any]] = {}
+    cursor: str | None = None
+    guard = 0
+    while True:
+        guard += 1
+        if guard > 2000:
+            _warn(FEATURE, "collection_page_guard_tripped")
+            break
+        params: dict[str, Any] = {"limit": 200}
+        if cursor:
+            params["cursor"] = cursor
+        resp = punchplay_request(adapter, "GET", URL_COLLECTION, params=params)
+        if resp.status_code != 200:
+            _warn(FEATURE, "collection_fetch_failed", status=resp.status_code, error=error_of(resp), request_id=request_id_of(resp))
+            break
+        data = safe_json(resp) or {}
+        if not isinstance(data, Mapping):
+            break
+        rows = data.get("items")
+        rows = [row for row in rows if isinstance(row, Mapping)] if isinstance(rows, list) else []
+        for row in rows:
+            item = _to_minimal(row)
+            if not item:
+                continue
+            key = _key_of(item)
+            if key:
+                collected[key] = item
+        cursor = str(data.get("nextCursor") or "").strip() or None
+        if not cursor:
+            break
+    _info(FEATURE, "index_done", count=len(collected))
+    return collected
+
+
+def _payload_for(adapter: Any, item: Mapping[str, Any]) -> tuple[dict[str, Any], str] | None:
+    m = id_minimal(item)
+    key = _key_of(m)
+    if not key:
+        return None
+    typ = str(m.get("type") or "").strip().lower()
+    if typ == "episode":
+        return None
+    source: Mapping[str, Any] = m
+    if typ == "season" and isinstance(m.get("show_ids"), Mapping):
+        source = {"ids": m.get("show_ids")}
+    ids = ids_for_punchplay(source)
+    source_id = ids.get("tmdb_id")
+    if not source_id:
+        return None
+    payload: dict[str, Any] = {
+        "kind": _kind_of(m),
+        "sourceId": int(source_id),
+        "format": _format_value(adapter, item),
+    }
+    if typ == "season":
+        season = _as_int(m.get("season") if m.get("season") is not None else m.get("season_number"))
+        if season is None:
+            return None
+        payload["season"] = season
+    title = str((m.get("series_title") or m.get("title") or "") if typ == "season" else (m.get("title") or "")).strip()
+    if title:
+        payload["title"] = title[:500]
+    year = _as_int(m.get("year"))
+    if year:
+        payload["year"] = year
+    notes = str(item.get("notes") or "").strip()
+    if notes:
+        payload["notes"] = notes[:1000]
+    return payload, key
+
+
+def _collection_id_for_remove(adapter: Any, item: Mapping[str, Any]) -> str | None:
+    direct = str(item.get("_punchplay_collection_id") or item.get("collection_id") or "").strip()
+    if direct:
+        return direct
+    key = _key_of(item)
+    if not key:
+        return None
+    try:
+        idx = build_index(adapter)
+    except Exception:
+        idx = {}
+    match = idx.get(key)
+    if isinstance(match, Mapping):
+        found = str(match.get("_punchplay_collection_id") or "").strip()
+        if found:
+            return found
+    return None
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    confirmed: list[str] = []
+    unresolved_keys: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    for item in items or []:
+        built = _payload_for(adapter, item)
+        if built is None:
+            key = _key_of(item)
+            if key:
+                unresolved_keys.append(key)
+            unresolved.append({"item": id_minimal(item), "status": "missing_tmdb_id_or_unsupported_type"})
+            continue
+        payload, key = built
+        resp = punchplay_request(adapter, "POST", URL_COLLECTION_WRITE, json=payload)
+        if 200 <= int(resp.status_code) < 300:
+            confirmed.append(key)
+        else:
+            unresolved_keys.append(key)
+            unresolved.append({"key": key, "status": f"http:{resp.status_code}", "error": error_of(resp), "request_id": request_id_of(resp)})
+    _info(FEATURE, "write_done", action="add", confirmed=len(confirmed), unresolved=len(unresolved_keys))
+    return {"ok": not unresolved_keys, "confirmed_keys": confirmed, "unresolved_keys": unresolved_keys, "unresolved": unresolved}
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    confirmed: list[str] = []
+    unresolved_keys: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    for item in items or []:
+        key = _key_of(item)
+        entry_id = _collection_id_for_remove(adapter, item)
+        if not key or not entry_id:
+            if key:
+                unresolved_keys.append(key)
+            unresolved.append({"item": id_minimal(item), "status": "missing_collection_id"})
+            continue
+        resp = punchplay_request(adapter, "DELETE", URL_COLLECTION_ITEM.format(entry_id=entry_id))
+        if 200 <= int(resp.status_code) < 300 or int(resp.status_code) == 404:
+            confirmed.append(key)
+        else:
+            unresolved_keys.append(key)
+            unresolved.append({"key": key, "status": f"http:{resp.status_code}", "error": error_of(resp), "request_id": request_id_of(resp)})
+    _info(FEATURE, "write_done", action="remove", confirmed=len(confirmed), unresolved=len(unresolved_keys))
+    return {"ok": not unresolved_keys, "confirmed_keys": confirmed, "unresolved_keys": unresolved_keys, "unresolved": unresolved}

--- a/providers/sync/punchplay/_common.py
+++ b/providers/sync/punchplay/_common.py
@@ -40,6 +40,9 @@ URL_TITLE_HISTORY = f"{PLATFORM_BASE}/title/{{kind}}/{{title_id}}/history"
 URL_RATINGS = f"{PLATFORM_BASE}/me/ratings"
 URL_FAVOURITES = f"{PLATFORM_BASE}/me/favourites"
 URL_WATCH_STATUS = f"{PLATFORM_BASE}/me/watch-status"
+URL_COLLECTION = f"{PLATFORM_BASE}/me/collection"
+URL_COLLECTION_ITEM = f"{PLATFORM_BASE}/collection/{{entry_id}}"
+URL_COLLECTION_WRITE = f"{PLATFORM_BASE}/collection"
 URL_IN_PROGRESS = f"{PLATFORM_BASE}/playback/in-progress"
 URL_IN_PROGRESS_ITEM = f"{PLATFORM_BASE}/playback/in-progress/{{entry_id}}"
 URL_CONTINUE_WATCHING = f"{PLATFORM_BASE}/me/continue-watching"
@@ -90,6 +93,8 @@ def _endpoint_bucket(method: str, url: str) -> str | None:
         return "history_read"
     if "/me/lists" in u or "/lists/" in u:
         return "lists_read"
+    if "/me/collection" in u or "/collection" in u:
+        return "sync_read"
     if "/calendar" in u:
         return "calendar"
     return None

--- a/providers/sync/scrob/_collection.py
+++ b/providers/sync/scrob/_collection.py
@@ -1,0 +1,397 @@
+# /providers/sync/scrob/_collection.py
+# Scrob collection sync module
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from pathlib import PurePosixPath
+from typing import Any, Iterable, Mapping
+
+from cw_platform.id_map import canonical_key, ids_from, minimal as id_minimal
+
+from ._common import (
+    MEDIA_TYPE_EPISODE,
+    MEDIA_TYPE_MOVIE,
+    MEDIA_TYPE_SERIES,
+    as_int,
+    error_of,
+    ids_for_scrob,
+    iso_z,
+    ok_status,
+    positive_int,
+    safe_json,
+    scrob_request,
+    show_ids_for_scrob,
+    year_of,
+    _dbg,
+    _info,
+    _warn,
+)
+
+FEATURE = "collection"
+
+PATH_EXPORT = "export/data"
+PATH_COLLECT = "media/collect"
+PATH_COLLECT_SHOW = "media/collect-show"
+PATH_COLLECT_SEASON = "media/collect-season"
+
+COLLECTION_ID_FIELD = "_scrob_collection_id"
+
+
+def _key_of(obj: Mapping[str, Any]) -> str:
+    try:
+        return str(canonical_key(id_minimal(obj)) or "").strip()
+    except Exception:
+        return ""
+
+
+def _ids_clean(*sources: Mapping[str, Any] | None) -> dict[str, str]:
+    merged: dict[str, Any] = {}
+    for source in sources:
+        if isinstance(source, Mapping):
+            merged.update(source)
+    ids = ids_from({"ids": merged})
+    out = {key: str(value) for key, value in ids.items() if str(value or "").strip()}
+    for src_key, dst_key in (("tmdb_id", "tmdb"), ("imdb_id", "imdb"), ("tvdb_id", "tvdb")):
+        if dst_key in out:
+            continue
+        value = merged.get(src_key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            out[dst_key] = text
+    return out
+
+
+def _nested(row: Mapping[str, Any], *names: str) -> Mapping[str, Any]:
+    for name in names:
+        value = row.get(name)
+        if isinstance(value, Mapping):
+            return value
+    return {}
+
+
+def _item_with_meta(item: dict[str, Any], *rows: Mapping[str, Any]) -> dict[str, Any]:
+    for row in rows:
+        collected = iso_z(row.get("collected_at") or row.get("listed_at") or row.get("added_at"))
+        if collected:
+            item["collected_at"] = collected
+            break
+    for row in rows:
+        cid = positive_int(row.get("id") or row.get("collection_id"))
+        if cid:
+            item[COLLECTION_ID_FIELD] = str(cid)
+            break
+    return id_minimal(item) | {k: v for k, v in item.items() if k.startswith("_scrob_") or k == "collected_at"}
+
+
+def _movie_from_row(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    movie = _nested(row, "movie", "media") or row
+    ids = _ids_clean(movie.get("ids") if isinstance(movie.get("ids"), Mapping) else {}, movie)
+    if not ids:
+        return None
+    item: dict[str, Any] = {"type": "movie", "ids": ids}
+    title = str(movie.get("title") or row.get("title") or "").strip()
+    if title:
+        item["title"] = title
+    year = as_int(movie.get("year") or row.get("year")) or year_of(movie)
+    if year:
+        item["year"] = year
+    return _item_with_meta(item, row, movie)
+
+
+def _show_from_row(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    show = _nested(row, "show", "series", "media") or row
+    ids = _ids_clean(show.get("ids") if isinstance(show.get("ids"), Mapping) else {}, show)
+    if not ids:
+        return None
+    item: dict[str, Any] = {"type": "show", "ids": ids}
+    title = str(show.get("title") or show.get("name") or row.get("title") or "").strip()
+    if title:
+        item["title"] = title
+    year = as_int(show.get("year") or row.get("year")) or year_of(show)
+    if year:
+        item["year"] = year
+    return _item_with_meta(item, row, show)
+
+
+def _items_from_row(row: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw_type = str(row.get("type") or row.get("media_type") or _nested(row, "media").get("type") or "").strip().lower()
+    if raw_type == MEDIA_TYPE_MOVIE or isinstance(row.get("movie"), Mapping):
+        movie = _movie_from_row(row)
+        return [movie] if movie else []
+
+    show_item = _show_from_row(row)
+    show = _nested(row, "show", "series", "media") or row
+    show_ids = dict((show_item or {}).get("ids") or {})
+    title = (show_item or {}).get("title")
+    year = (show_item or {}).get("year")
+
+    season_number = as_int(row.get("season") if row.get("season") is not None else row.get("season_number"))
+    episode_number = as_int(row.get("episode") if row.get("episode") is not None else row.get("episode_number"))
+    if raw_type == MEDIA_TYPE_EPISODE or episode_number is not None:
+        if not show_ids or season_number is None or episode_number is None:
+            return []
+        ep_ids = _ids_clean(row.get("ids") if isinstance(row.get("ids"), Mapping) else {}, row)
+        item = {
+            "type": "episode",
+            "ids": ep_ids,
+            "show_ids": show_ids,
+            "season": season_number,
+            "episode": episode_number,
+            "series_title": title,
+            "year": year,
+        }
+        ep_title = str(row.get("title") or "").strip()
+        if ep_title:
+            item["title"] = ep_title
+        return [_item_with_meta(item, row)]
+
+    seasons = row.get("seasons")
+    if not isinstance(seasons, list):
+        seasons = show.get("seasons") if isinstance(show, Mapping) else None
+    if not isinstance(seasons, list) or not seasons:
+        if raw_type in {"series", "show", "tv"} or isinstance(row.get("show"), Mapping):
+            return [show_item] if show_item else []
+        return []
+
+    out: list[dict[str, Any]] = []
+    for season in seasons:
+        if not isinstance(season, Mapping):
+            continue
+        season_no = as_int(season.get("number") if season.get("number") is not None else season.get("season_number"))
+        episodes = season.get("episodes")
+        if isinstance(episodes, list) and episodes:
+            for ep in episodes:
+                if not isinstance(ep, Mapping):
+                    continue
+                ep_no = as_int(ep.get("number") if ep.get("number") is not None else ep.get("episode_number"))
+                if season_no is None or ep_no is None:
+                    continue
+                item = {
+                    "type": "episode",
+                    "ids": _ids_clean(ep.get("ids") if isinstance(ep.get("ids"), Mapping) else {}, ep),
+                    "show_ids": show_ids,
+                    "season": season_no,
+                    "episode": ep_no,
+                    "series_title": title,
+                    "year": year,
+                }
+                ep_title = str(ep.get("title") or "").strip()
+                if ep_title:
+                    item["title"] = ep_title
+                out.append(_item_with_meta(item, row, season, ep))
+        elif season_no is not None and show_ids:
+            item = {"type": "season", "ids": dict(show_ids), "show_ids": show_ids, "season": season_no, "series_title": title, "title": title, "year": year}
+            out.append(_item_with_meta(item, row, season))
+    return out or ([show_item] if show_item else [])
+
+
+def _json_rows(data: Any) -> list[Mapping[str, Any]]:
+    if isinstance(data, list):
+        return [row for row in data if isinstance(row, Mapping)]
+    if not isinstance(data, Mapping):
+        return []
+    for key in ("collection", "items", "results", "data"):
+        value = data.get(key)
+        if isinstance(value, list):
+            return [row for row in value if isinstance(row, Mapping)]
+    rows: list[Mapping[str, Any]] = []
+    for key in ("movies", "shows", "seasons", "episodes"):
+        value = data.get(key)
+        if isinstance(value, list):
+            rows.extend(row for row in value if isinstance(row, Mapping))
+    return rows
+
+
+def _loads_json(data: bytes) -> Any:
+    try:
+        return json.loads(data.decode("utf-8", "replace"))
+    except Exception:
+        return None
+
+
+def _export_payload(resp: Any) -> list[Mapping[str, Any]]:
+    content = getattr(resp, "content", b"") or b""
+    if isinstance(content, str):
+        content = content.encode("utf-8")
+    if not content:
+        text = getattr(resp, "text", "") or ""
+        content = text.encode("utf-8") if text else b""
+
+    rows: list[Mapping[str, Any]] = []
+    if content and zipfile.is_zipfile(io.BytesIO(content)):
+        with zipfile.ZipFile(io.BytesIO(content)) as archive:
+            for info in archive.infolist():
+                if info.is_dir():
+                    continue
+                base = PurePosixPath(info.filename).name.lower()
+                if not base.startswith("collection-") and "collection" not in PurePosixPath(info.filename).parts:
+                    continue
+                if not base.endswith((".json", ".txt")):
+                    continue
+                loaded = _loads_json(archive.read(info))
+                rows.extend(_json_rows(loaded))
+        return rows
+
+    loaded = safe_json(resp)
+    if loaded is None and content:
+        loaded = _loads_json(content)
+    return _json_rows(loaded)
+
+
+def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
+    resp = scrob_request(
+        adapter,
+        "GET",
+        PATH_EXPORT,
+        params={
+            "watched": False,
+            "ratings": False,
+            "collection": True,
+            "lists": False,
+            "comments": False,
+            "api_keys": False,
+            "media_connections": False,
+            "scrobble_connections": False,
+            "connections": False,
+        },
+    )
+    if not ok_status(resp):
+        _warn(FEATURE, "fetch_failed", status=int(resp.status_code), error=error_of(resp))
+        return {}
+
+    rows = _export_payload(resp)
+    out: dict[str, dict[str, Any]] = {}
+    skipped = 0
+    for row in rows:
+        produced = _items_from_row(row)
+        if not produced:
+            skipped += 1
+            continue
+        for item in produced:
+            key = _key_of(item)
+            if key:
+                out[key] = item
+            else:
+                skipped += 1
+    _info(FEATURE, "index_done", count=len(out), rows=len(rows), skipped=skipped)
+    return out
+
+
+def _scope(item: Mapping[str, Any]) -> str:
+    typ = str(item.get("type") or "").strip().lower()
+    if typ == "episode" or (item.get("season") is not None and item.get("episode") is not None):
+        return "episode"
+    if typ == "season":
+        return "season"
+    if typ in ("show", "series", "tv"):
+        return "show"
+    return "movie"
+
+
+def _payload_for(item: Mapping[str, Any]) -> tuple[str, dict[str, Any]] | None:
+    scope = _scope(item)
+    if scope == "show":
+        tmdb = positive_int(ids_for_scrob(item).get("tmdb_id")) or positive_int(show_ids_for_scrob(item).get("tmdb_id"))
+        return (PATH_COLLECT_SHOW, {"tmdb_id": tmdb, "media_type": MEDIA_TYPE_SERIES}) if tmdb else None
+    if scope == "season":
+        tmdb = positive_int(show_ids_for_scrob(item).get("tmdb_id")) or positive_int(ids_for_scrob(item).get("tmdb_id"))
+        season = as_int(item.get("season"))
+        return (PATH_COLLECT_SEASON, {"series_tmdb_id": tmdb, "season_number": season}) if tmdb and season is not None else None
+    if scope == "episode":
+        tmdb = positive_int(ids_for_scrob(item).get("tmdb_id"))
+        show_tmdb = positive_int(show_ids_for_scrob(item).get("tmdb_id"))
+        season = as_int(item.get("season"))
+        episode = as_int(item.get("episode"))
+        if not tmdb or not show_tmdb or season is None or episode is None:
+            return None
+        return (PATH_COLLECT, {"tmdb_id": tmdb, "media_type": MEDIA_TYPE_EPISODE, "series_tmdb_id": show_tmdb, "season_number": season, "episode_number": episode})
+    tmdb = positive_int(ids_for_scrob(item).get("tmdb_id"))
+    return (PATH_COLLECT, {"tmdb_id": tmdb, "media_type": MEDIA_TYPE_MOVIE}) if tmdb else None
+
+
+def _remove_params(item: Mapping[str, Any]) -> tuple[str, dict[str, Any]] | None:
+    scope = _scope(item)
+    if scope == "show":
+        tmdb = positive_int(ids_for_scrob(item).get("tmdb_id")) or positive_int(show_ids_for_scrob(item).get("tmdb_id"))
+        return (PATH_COLLECT_SHOW, {"tmdb_id": tmdb}) if tmdb else None
+    if scope == "season":
+        tmdb = positive_int(show_ids_for_scrob(item).get("tmdb_id")) or positive_int(ids_for_scrob(item).get("tmdb_id"))
+        season = as_int(item.get("season"))
+        return (PATH_COLLECT_SEASON, {"series_tmdb_id": tmdb, "season_number": season}) if tmdb and season is not None else None
+    media_type = MEDIA_TYPE_EPISODE if scope == "episode" else MEDIA_TYPE_MOVIE
+    params: dict[str, Any] = {"media_type": media_type}
+    cid = positive_int(item.get(COLLECTION_ID_FIELD) or item.get("collection_id"))
+    if cid:
+        params["id"] = cid
+        return PATH_COLLECT, params
+    tmdb = positive_int(ids_for_scrob(item).get("tmdb_id"))
+    if tmdb:
+        params["tmdb_id"] = tmdb
+        return PATH_COLLECT, params
+    return None
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    confirmed: list[str] = []
+    unresolved_keys: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    ok = True
+    for item in items or []:
+        key = _key_of(item)
+        if not key:
+            continue
+        payload = _payload_for(item)
+        if payload is None:
+            unresolved_keys.append(key)
+            unresolved.append({"key": key, "status": "missing_supported_id_or_type"})
+            _dbg(FEATURE, "item_unresolved_before_write", key=key)
+            continue
+        path, body = payload
+        if dry_run:
+            confirmed.append(key)
+            continue
+        resp = scrob_request(adapter, "POST", path, json=body)
+        if ok_status(resp) or int(resp.status_code) == 409:
+            confirmed.append(key)
+            continue
+        ok = False
+        unresolved_keys.append(key)
+        unresolved.append({"key": key, "status": f"http:{int(resp.status_code)}", "error": error_of(resp)})
+        _warn(FEATURE, "collection_add_failed", key=key, status=int(resp.status_code), error=error_of(resp))
+    _info(FEATURE, "write_done", action="add", confirmed=len(confirmed), unresolved=len(unresolved_keys), dry_run=bool(dry_run))
+    return {"ok": ok, "count": len(confirmed), "confirmed_keys": confirmed, "unresolved_keys": unresolved_keys, "deferred_keys": [], "unresolved": unresolved}
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+    confirmed: list[str] = []
+    unresolved_keys: list[str] = []
+    unresolved: list[dict[str, Any]] = []
+    ok = True
+    for item in items or []:
+        key = _key_of(item)
+        if not key:
+            continue
+        payload = _remove_params(item)
+        if payload is None:
+            unresolved_keys.append(key)
+            unresolved.append({"key": key, "status": "missing_supported_id_or_type"})
+            continue
+        path, params = payload
+        if dry_run:
+            confirmed.append(key)
+            continue
+        resp = scrob_request(adapter, "DELETE", path, params=params)
+        if ok_status(resp) or int(resp.status_code) == 404:
+            confirmed.append(key)
+            continue
+        ok = False
+        unresolved_keys.append(key)
+        unresolved.append({"key": key, "status": f"http:{int(resp.status_code)}", "error": error_of(resp)})
+        _warn(FEATURE, "collection_remove_failed", key=key, status=int(resp.status_code), error=error_of(resp))
+    _info(FEATURE, "write_done", action="remove", confirmed=len(confirmed), unresolved=len(unresolved_keys), dry_run=bool(dry_run))
+    return {"ok": ok, "count": len(confirmed), "confirmed_keys": confirmed, "unresolved_keys": unresolved_keys, "deferred_keys": [], "unresolved": unresolved}

--- a/providers/sync/trakt/_collection.py
+++ b/providers/sync/trakt/_collection.py
@@ -1,0 +1,371 @@
+# /providers/sync/trakt/_collection.py
+# TRAKT collection sync functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from cw_platform.id_map import canonical_key, minimal as id_minimal
+
+from ._common import (
+    _chunk,
+    _is_capture_mode,
+    _pair_scope,
+    build_watchlist_body,
+    fetch_last_activities,
+    headers_for_adapter,
+    ids_for_trakt,
+    key_of,
+    normalize_watchlist_row,
+    pick_trakt_kind,
+    state_file,
+    update_watermarks_from_last_activities,
+)
+from .._log import log as cw_log
+from .._mod_common import request_with_retries
+
+BASE = "https://api.trakt.tv"
+URL_ADD = f"{BASE}/sync/collection"
+URL_MOVIES = f"{BASE}/sync/collection/movies"
+URL_SHOWS = f"{BASE}/sync/collection/shows"
+URL_REMOVE = f"{BASE}/sync/collection/remove"
+
+_PROVIDER = "TRAKT"
+_FEATURE = "collection"
+
+
+def _dbg(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "debug", event, **fields)
+
+
+def _info(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "info", event, **fields)
+
+
+def _warn(event: str, **fields: Any) -> None:
+    cw_log(_PROVIDER, _FEATURE, "warn", event, **fields)
+
+
+def _shadow_path() -> Path:
+    return state_file("trakt_collection.shadow.json")
+
+
+def _cfg(adapter: Any) -> Mapping[str, Any]:
+    c = getattr(adapter, "config", {}) or {}
+    if isinstance(c, dict) and isinstance(c.get("trakt"), dict):
+        return c["trakt"]
+    return {}
+
+
+def _cfg_int(d: Mapping[str, Any], key: str, default: int) -> int:
+    try:
+        return int(d.get(key, default))
+    except Exception:
+        return default
+
+
+def _cfg_bool(d: Mapping[str, Any], key: str, default: bool) -> bool:
+    v = d.get(key, default)
+    if isinstance(v, bool):
+        return v
+    s = str(v).strip().lower()
+    if s in ("1", "true", "yes", "on"):
+        return True
+    if s in ("0", "false", "no", "off"):
+        return False
+    return default
+
+
+def _shadow_load() -> dict[str, Any]:
+    if _is_capture_mode() or _pair_scope() is None:
+        return {"etag": None, "ts": 0, "items": {}}
+    try:
+        return json.loads(_shadow_path().read_text("utf-8"))
+    except Exception:
+        return {"etag": None, "ts": 0, "items": {}}
+
+
+def _shadow_save(etags: Mapping[str, str | None], items: Mapping[str, Any], bucket_items: Mapping[str, Mapping[str, Any]]) -> None:
+    if _is_capture_mode() or _pair_scope() is None:
+        return
+    try:
+        path = _shadow_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(
+            json.dumps(
+                {
+                    "etag": None,
+                    "etags": dict(etags or {}),
+                    "ts": int(time.time()),
+                    "items": dict(items),
+                    "bucket_items": {str(k): dict(v or {}) for k, v in dict(bucket_items or {}).items()},
+                },
+                ensure_ascii=False,
+            ),
+            "utf-8",
+        )
+        os.replace(tmp, path)
+    except Exception:
+        pass
+
+
+def _shadow_bust() -> None:
+    if _is_capture_mode() or _pair_scope() is None:
+        return
+    try:
+        path = _shadow_path()
+        if path.exists():
+            path.unlink()
+            _dbg("cache_invalidated", cache="shadow", reason="write_applied")
+    except Exception:
+        pass
+
+
+def _ids_clean(ids: Mapping[str, Any] | None) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for k, v in dict(ids or {}).items():
+        if v is None:
+            continue
+        s = str(v).strip()
+        if s:
+            out[str(k)] = s
+    return out
+
+
+def _item_key(item: Mapping[str, Any]) -> str:
+    return canonical_key(item) or key_of(item) or ""
+
+
+def _movie_from_row(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    movie = row.get("movie") if isinstance(row.get("movie"), Mapping) else row
+    if not isinstance(movie, Mapping):
+        return None
+    item = id_minimal({"type": "movie", "title": movie.get("title"), "year": movie.get("year"), "ids": _ids_clean(movie.get("ids"))})
+    collected_at = row.get("collected_at") or row.get("listed_at")
+    if collected_at:
+        item["collected_at"] = str(collected_at)
+    return item
+
+
+def _show_base(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    show = row.get("show") if isinstance(row.get("show"), Mapping) else row
+    if not isinstance(show, Mapping):
+        return None
+    item = id_minimal({"type": "show", "title": show.get("title"), "year": show.get("year"), "ids": _ids_clean(show.get("ids"))})
+    collected_at = row.get("collected_at") or row.get("listed_at")
+    if collected_at:
+        item["collected_at"] = str(collected_at)
+    return item
+
+
+def _items_from_collection_row(row: Mapping[str, Any]) -> list[dict[str, Any]]:
+    typ = str(row.get("type") or "").strip().lower()
+    seasons = row.get("seasons")
+    if not isinstance(seasons, list):
+        show = row.get("show") if isinstance(row.get("show"), Mapping) else row
+        seasons = show.get("seasons") if isinstance(show, Mapping) else None
+    if typ and not (typ == "show" and isinstance(seasons, list) and seasons):
+        return [normalize_watchlist_row(row)]
+    if isinstance(row.get("movie"), Mapping):
+        movie = _movie_from_row(row)
+        return [movie] if movie else []
+    show_item = _show_base(row)
+    show = row.get("show") if isinstance(row.get("show"), Mapping) else row
+    if not isinstance(seasons, list) or not seasons:
+        return [show_item] if show_item else []
+    show_ids = dict((show_item or {}).get("ids") or {})
+    title = (show_item or {}).get("title")
+    year = (show_item or {}).get("year")
+    out: list[dict[str, Any]] = []
+    for season in seasons:
+        if not isinstance(season, Mapping):
+            continue
+        season_no = season.get("number")
+        episodes = season.get("episodes")
+        collected_at = season.get("collected_at") or row.get("collected_at")
+        if isinstance(episodes, list) and episodes:
+            for ep in episodes:
+                if not isinstance(ep, Mapping):
+                    continue
+                ep_no = ep.get("number")
+                if season_no is None or ep_no is None:
+                    continue
+                item = id_minimal(
+                    {
+                        "type": "episode",
+                        "title": ep.get("title"),
+                        "series_title": title,
+                        "year": year,
+                        "show_ids": show_ids,
+                        "season": season_no,
+                        "episode": ep_no,
+                        "ids": _ids_clean(ep.get("ids")),
+                    }
+                )
+                if collected_at or ep.get("collected_at"):
+                    item["collected_at"] = str(ep.get("collected_at") or collected_at)
+                out.append(item)
+        elif season_no is not None:
+            item = id_minimal({"type": "season", "title": title, "series_title": title, "year": year, "show_ids": show_ids, "season": season_no, "ids": _ids_clean(season.get("ids"))})
+            if collected_at:
+                item["collected_at"] = str(collected_at)
+            out.append(item)
+    return out or ([show_item] if show_item else [])
+
+
+def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
+    cfg = _cfg(adapter)
+    use_etag = _cfg_bool(cfg, "collection_use_etag", True)
+    ttl_h = _cfg_int(cfg, "collection_shadow_ttl_hours", 168)
+    prog_mk = getattr(adapter, "progress_factory", None)
+    prog: Any = prog_mk("collection") if callable(prog_mk) else None
+
+    sess = adapter.client.session
+    headers = headers_for_adapter(adapter)
+    try:
+        acts = fetch_last_activities(sess, headers, timeout=adapter.cfg.timeout, max_retries=adapter.cfg.max_retries)
+        update_watermarks_from_last_activities(acts)
+    except Exception:
+        pass
+
+    shadow = _shadow_load()
+    bucket_cache = shadow.get("bucket_items") if isinstance(shadow.get("bucket_items"), Mapping) else {}
+    shadow_etags = shadow.get("etags") if isinstance(shadow.get("etags"), Mapping) else {}
+    fresh = True
+    if ttl_h > 0 and shadow.get("ts"):
+        fresh = (int(time.time()) - int(shadow.get("ts") or 0)) <= ttl_h * 3600
+
+    def _fetch_bucket(name: str, url: str) -> tuple[dict[str, dict[str, Any]], str | None, bool]:
+        req_headers = dict(headers)
+        cached = bucket_cache.get(name) if isinstance(bucket_cache, Mapping) else None
+        etag = shadow_etags.get(name) if isinstance(shadow_etags, Mapping) else None
+        if use_etag and fresh and etag and isinstance(cached, Mapping):
+            req_headers["If-None-Match"] = str(etag)
+
+        r = request_with_retries(
+            sess,
+            "GET",
+            url,
+            headers=req_headers,
+            timeout=adapter.cfg.timeout,
+            max_retries=adapter.cfg.max_retries,
+        )
+        if r.status_code == 304 and use_etag and isinstance(cached, Mapping):
+            return dict(cached), str(etag), True
+        if r.status_code != 200:
+            _warn("http_failed", op="index", bucket=name, status=r.status_code)
+            return (dict(cached) if isinstance(cached, Mapping) else {}), (str(etag) if etag else None), True
+
+        data = r.json() if (r.text or "").strip() else []
+        rows: list[Mapping[str, Any]] = []
+        if isinstance(data, list):
+            rows = [x for x in data if isinstance(x, Mapping)]
+        elif isinstance(data, Mapping):
+            raw = data.get(name)
+            if isinstance(raw, list):
+                rows = [x for x in raw if isinstance(x, Mapping)]
+
+        idx: dict[str, dict[str, Any]] = {}
+        total = max(1, len(rows))
+        for i, row in enumerate(rows, start=1):
+            for item in _items_from_collection_row(row):
+                key = _item_key(item)
+                if key:
+                    idx[key] = item
+            if prog:
+                prog.tick(i, total=total)
+        return idx, r.headers.get("ETag"), False
+
+    movie_idx, movie_etag, movie_cached = _fetch_bucket("movies", URL_MOVIES)
+    show_idx, show_etag, show_cached = _fetch_bucket("shows", URL_SHOWS)
+
+    idx: dict[str, dict[str, Any]] = {}
+    idx.update(movie_idx)
+    idx.update(show_idx)
+
+    if use_etag:
+        _shadow_save({"movies": movie_etag, "shows": show_etag}, idx, {"movies": movie_idx, "shows": show_idx})
+    source = "shadow" if movie_cached and show_cached else ("mixed" if movie_cached or show_cached else "live")
+    _info("index_done", count=len(idx), source=source)
+    return idx
+
+
+def _batch_payload(items: Iterable[Mapping[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    accepted: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+    for it in items or []:
+        m = id_minimal(it)
+        kind = pick_trakt_kind(m)
+        ids = ids_for_trakt(m)
+        show_ids = dict(m.get("show_ids") or {})
+        season_no = m.get("season") if m.get("season") is not None else m.get("number")
+        episode_no = m.get("episode") if m.get("episode") is not None else m.get("episode_number")
+        if kind in ("movies", "shows") and ids:
+            accepted.append(m)
+        elif kind == "seasons" and (ids or (show_ids and season_no is not None)):
+            accepted.append(m)
+        elif kind == "episodes" and (ids or (show_ids and season_no is not None and episode_no is not None)):
+            accepted.append(m)
+        else:
+            rejected.append({"item": m, "hint": "missing ids" if not show_ids else "missing scope"})
+    return accepted, rejected
+
+
+def _record_not_found(not_found: Mapping[str, Any], unresolved: list[dict[str, Any]]) -> None:
+    if not isinstance(not_found, Mapping):
+        return
+    for bucket in ("movies", "shows", "seasons", "episodes"):
+        raw = not_found.get(bucket)
+        if not isinstance(raw, list):
+            continue
+        for obj in raw:
+            if isinstance(obj, Mapping):
+                typ = bucket[:-1] if bucket.endswith("s") else bucket
+                unresolved.append({"item": id_minimal({"type": typ, "ids": dict(obj.get("ids") or obj)}), "hint": "not_found"})
+
+
+def _write(adapter: Any, op: str, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    cfg = _cfg(adapter)
+    batch = _cfg_int(cfg, "collection_batch_size", _cfg_int(cfg, "watchlist_batch_size", 100))
+    accepted, unresolved = _batch_payload(items)
+    if not accepted:
+        _info("write_skipped", op=op, reason="empty_payload", unresolved=len(unresolved))
+        return 0, unresolved
+
+    url = URL_ADD if op == "add" else URL_REMOVE
+    ok = 0
+    for sl in _chunk(accepted, batch):
+        payload = build_watchlist_body(sl)
+        if not payload:
+            continue
+        r = request_with_retries(adapter.client.session, "POST", url, headers=headers_for_adapter(adapter), json=payload, timeout=adapter.cfg.timeout, max_retries=adapter.cfg.max_retries)
+        if r.status_code in (200, 201):
+            body = r.json() if (r.text or "").strip() else {}
+            result = body.get("added") if op == "add" else body.get("deleted") or body.get("removed")
+            existing = body.get("existing") if op == "add" else {}
+            result = result if isinstance(result, Mapping) else {}
+            existing = existing if isinstance(existing, Mapping) else {}
+            ok += sum(int(result.get(k) or 0) for k in ("movies", "shows", "seasons", "episodes"))
+            ok += sum(int(existing.get(k) or 0) for k in ("movies", "shows", "seasons", "episodes"))
+            _record_not_found(body.get("not_found") or {}, unresolved)
+        else:
+            _warn("write_failed", op=op, status=r.status_code, body=(r.text or "")[:180])
+            for x in sl:
+                unresolved.append({"item": x, "hint": f"http:{r.status_code}"})
+    if ok:
+        _shadow_bust()
+    _info("write_done", op=op, ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
+    return ok, unresolved
+
+
+def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    return _write(adapter, "add", items)
+
+
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    return _write(adapter, "remove", items)

--- a/providers/tests/test_crosswatch_collection.py
+++ b/providers/tests/test_crosswatch_collection.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+from providers.sync._mod_CROSSWATCH import CROSSWATCHModule
+
+
+def _cfg(root: Any) -> dict[str, Any]:
+    return {
+        "CrossWatch": {
+            "connected": True,
+            "enabled": True,
+            "root_dir": str(root),
+            "auto_snapshot": True,
+            "max_snapshots": 64,
+        }
+    }
+
+
+def test_crosswatch_collection_is_pair_scoped_and_read_write(monkeypatch: Any, tmp_path: Any) -> None:
+    monkeypatch.setenv("CW_CROSSWATCH_PAIR_SCOPED", "1")
+    monkeypatch.setenv("CW_PAIR_KEY", "plex-mdblist")
+
+    adapter = CROSSWATCHModule(_cfg(tmp_path))
+    episode = {
+        "type": "episode",
+        "series_title": "Severance",
+        "show_ids": {"tmdb": "95396"},
+        "season": 1,
+        "episode": 2,
+        "ids": {},
+        "collected_at": "2026-08-24T20:00:00Z",
+    }
+
+    added = adapter.add("collection", [episode])
+
+    assert added["ok"] is True
+    assert added["count"] == 1
+    assert added["confirmed_keys"] == ["tmdb:95396#s01e02"]
+
+    state_path = tmp_path / "collection.plex-mdblist.json"
+    payload = json.loads(state_path.read_text("utf-8"))
+    assert payload["items"]["tmdb:95396#s01e02"]["show_ids"] == {"tmdb": "95396"}
+
+    index = adapter.build_index("collection")
+    assert index["tmdb:95396#s01e02"]["type"] == "episode"
+
+    removed = adapter.remove("collection", [episode])
+    assert removed["ok"] is True
+    assert removed["count"] == 1
+    assert removed["confirmed_keys"] == ["tmdb:95396#s01e02"]
+    assert adapter.build_index("collection") == {}
+
+
+def test_crosswatch_collection_reuses_history_style_snapshot_window(monkeypatch: Any, tmp_path: Any) -> None:
+    monkeypatch.setenv("CW_CROSSWATCH_PAIR_SCOPED", "1")
+    monkeypatch.setenv("CW_PAIR_KEY", "plex-trakt")
+
+    adapter = CROSSWATCHModule(_cfg(tmp_path))
+    first = {"type": "movie", "title": "Dune", "year": 2021, "ids": {"tmdb": "438631"}}
+    second = {"type": "movie", "title": "Arrival", "year": 2016, "ids": {"tmdb": "329865"}}
+
+    assert adapter.add("collection", [first])["count"] == 1
+    assert adapter.add("collection", [second])["count"] == 1
+
+    snaps = sorted((tmp_path / "snapshots" / "plex-trakt").glob("*-collection.json"))
+    assert len(snaps) == 1

--- a/providers/tests/test_emby_collection.py
+++ b/providers/tests/test_emby_collection.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from providers.sync.emby import _collection as collection
+
+
+class Resp:
+    def __init__(self, status: int, payload: Any) -> None:
+        self.status_code = status
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeEmbyClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get(self, path: str, params: dict[str, Any] | None = None) -> Resp:
+        params = dict(params or {})
+        self.calls.append((path, params))
+        if path == "/Users/user-1/Views":
+            return Resp(
+                200,
+                {
+                    "Items": [
+                        {"Id": "lib-tv", "Name": "TV", "CollectionType": "tvshows"},
+                        {"Id": "lib-movies", "Name": "Movies", "CollectionType": "movies"},
+                    ]
+                },
+            )
+        if path == "/Users/user-1/Items" and params.get("Ids") == "show-1":
+            return Resp(
+                200,
+                {
+                    "Items": [
+                        {
+                            "Id": "show-1",
+                            "Name": "The Show",
+                            "Type": "Series",
+                            "ProviderIds": {"Tmdb": "12345", "Tvdb": "67890"},
+                        }
+                    ]
+                },
+            )
+        if path == "/Users/user-1/Items":
+            return Resp(
+                200,
+                {
+                    "Items": [
+                        {
+                            "Id": "ep-1",
+                            "Type": "Episode",
+                            "Name": "Pilot",
+                            "SeriesName": "The Show",
+                            "SeriesId": "show-1",
+                            "ParentIndexNumber": 1,
+                            "IndexNumber": 1,
+                            "AncestorIds": ["lib-tv", "show-1"],
+                            "ProviderIds": {"Tvdb": "111"},
+                        }
+                    ],
+                    "TotalRecordCount": 1,
+                },
+            )
+        return Resp(404, {})
+
+
+def test_collection_resolves_library_id_like_history() -> None:
+    adapter = SimpleNamespace(
+        client=FakeEmbyClient(),
+        cfg=SimpleNamespace(user_id="user-1"),
+    )
+
+    index = collection.build_index(adapter)
+
+    assert sorted(index) == ["tmdb:12345#s01e01"]
+    item = index["tmdb:12345#s01e01"]
+    assert item["type"] == "episode"
+    assert item["library_id"] == "lib-tv"
+    assert item["show_ids"] == {"tmdb": "12345", "tvdb": "67890"}
+    assert item["season"] == 1
+    assert item["episode"] == 1

--- a/providers/tests/test_jellyfin_collection.py
+++ b/providers/tests/test_jellyfin_collection.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from providers.sync.jellyfin import _collection as collection
+
+
+class Resp:
+    def __init__(self, status: int, payload: Any) -> None:
+        self.status_code = status
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeJellyfinClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get(self, path: str, params: dict[str, Any] | None = None) -> Resp:
+        params = dict(params or {})
+        self.calls.append((path, params))
+        if path == "/UserViews":
+            return Resp(
+                200,
+                {
+                    "Items": [
+                        {"Id": "lib-tv", "Name": "TV", "CollectionType": "tvshows"},
+                        {"Id": "lib-movies", "Name": "Movies", "CollectionType": "movies"},
+                    ]
+                },
+            )
+        if path == "/Items" and params.get("Ids") == "show-1":
+            return Resp(
+                200,
+                {
+                    "Items": [
+                        {
+                            "Id": "show-1",
+                            "Name": "The Show",
+                            "Type": "Series",
+                            "ProviderIds": {"Tmdb": "12345", "Tvdb": "67890"},
+                        }
+                    ]
+                },
+            )
+        if path == "/Items":
+            return Resp(
+                200,
+                {
+                    "Items": [
+                        {
+                            "Id": "ep-1",
+                            "Type": "Episode",
+                            "Name": "Pilot",
+                            "SeriesName": "The Show",
+                            "SeriesId": "show-1",
+                            "ParentIndexNumber": 1,
+                            "IndexNumber": 1,
+                            "AncestorIds": ["lib-tv", "show-1"],
+                            "ProviderIds": {"Tvdb": "111"},
+                        }
+                    ],
+                    "TotalRecordCount": 1,
+                },
+            )
+        return Resp(404, {})
+
+
+def test_collection_resolves_library_id_like_history() -> None:
+    adapter = SimpleNamespace(
+        client=FakeJellyfinClient(),
+        cfg=SimpleNamespace(user_id="user-1"),
+    )
+
+    index = collection.build_index(adapter)
+
+    assert sorted(index) == ["tmdb:12345#s01e01"]
+    item = index["tmdb:12345#s01e01"]
+    assert item["type"] == "episode"
+    assert item["library_id"] == "lib-tv"
+    assert item["show_ids"] == {"tmdb": "12345", "tvdb": "67890"}
+    assert item["season"] == 1
+    assert item["episode"] == 1

--- a/providers/tests/test_kodi_sync.py
+++ b/providers/tests/test_kodi_sync.py
@@ -81,10 +81,13 @@ def tvshow(**extra):
 def test_kodi_manifest_capabilities_are_scoped():
     manifest = mod.get_manifest()
 
-    assert manifest["features"] == {"watchlist": False, "ratings": True, "history": True, "progress": True, "playlists": False}
+    assert manifest["features"] == {"watchlist": False, "ratings": True, "history": True, "progress": True, "playlists": False, "collection": True}
     assert manifest["capabilities"]["history"]["read"] is True
     assert manifest["capabilities"]["ratings"]["write"] is True
     assert manifest["capabilities"]["progress"]["types"]["episodes"] is True
+    assert manifest["capabilities"]["collection"]["read"] is True
+    assert manifest["capabilities"]["collection"]["write"] is False
+    assert manifest["capabilities"]["collection"]["types"] == {"movies": True, "shows": False, "seasons": False, "episodes": True}
 
 
 def test_kodi_sync_properties_match_jsonrpc_v13_5_contract():
@@ -92,7 +95,7 @@ def test_kodi_sync_properties_match_jsonrpc_v13_5_contract():
     episode_allowed = {"title", "showtitle", "season", "episode", "tvshowid", "uniqueid", "playcount", "lastplayed", "userrating", "resume"}
     show_allowed = {"title", "year", "uniqueid"}
 
-    for feature in ("history", "ratings", "progress", ""):
+    for feature in ("history", "ratings", "progress", "collection", ""):
         movie_props, episode_props, show_props = common.properties_for_feature(feature)
         assert set(movie_props) <= movie_allowed
         assert set(episode_props) <= episode_allowed
@@ -107,7 +110,7 @@ def test_history_index_reads_movies_and_episodes():
 
     assert "tmdb:329865" in index
     assert index["tmdb:329865"]["watched"] is True
-    assert index["tmdb:329865"]["watched_at"] == "2026-01-02T03:04:05Z"
+    assert index["tmdb:329865"]["watched_at"] == common.kodi_lastplayed_to_iso("2026-01-02 03:04:05")
     ep = index["tmdb:63639#s01e01"]
     assert ep["type"] == "episode"
     assert ep["title"] == "The Target"
@@ -199,6 +202,35 @@ def test_kodi_library_rows_uses_v13_5_path_filters_without_extra_properties(monk
         assert "path" not in params["properties"]
 
 
+def test_collection_index_reads_library_inventory():
+    ad = adapter(FakeKodiClient([movie()], [episode()], [tvshow()]))
+
+    index = mod.feat_collection.build_index(ad)
+
+    assert sorted(index) == ["tmdb:329865", "tmdb:63639#s01e01"]
+    assert index["tmdb:329865"]["type"] == "movie"
+    ep = index["tmdb:63639#s01e01"]
+    assert ep["type"] == "episode"
+    assert ep["show_ids"] == {"tmdb": "63639", "tvdb": "280619"}
+    assert ep["season"] == 1 and ep["episode"] == 1
+
+
+def test_collection_writes_are_source_only():
+    client = FakeKodiClient([movie()], [episode()], [tvshow()])
+    module = mod.KODIModule({"kodi": {"server": "http://localhost:8080", "connection_verified": True}})
+    module.client = client
+
+    result = module.add("collection", [{"type": "movie", "ids": {"tmdb": "329865"}}])
+    removed = module.remove("collection", [{"type": "movie", "ids": {"tmdb": "329865"}}])
+
+    assert result["ok"] is True and result["count"] == 0
+    assert result["reason"] == "unsupported"
+    assert result["unresolved"][0]["reason"] == "kodi_collection_write_unsupported"
+    assert removed["reason"] == "unsupported"
+    assert client.movie_writes == []
+    assert client.episode_writes == []
+
+
 def test_kodi_sync_logs_library_scope_filter_when_configured(monkeypatch):
     logs: list[tuple[str, str, str, dict[str, Any]]] = []
     monkeypatch.setattr(common, "log", lambda feature, level, event, **fields: logs.append((feature, level, event, fields)))
@@ -285,7 +317,7 @@ def test_writes_history_ratings_and_progress_to_resolved_library_items():
     assert module.add("ratings", [source_ep])["count"] == 1
     assert module.add("progress", [source_movie])["count"] == 1
 
-    assert client.movie_writes[0] == (10, {"playcount": 1, "lastplayed": "2026-06-01 12:00:00"})
+    assert client.movie_writes[0] == (10, {"playcount": 1, "lastplayed": common.watched_at_to_kodi("2026-06-01T12:00:00Z")})
     assert client.episode_writes[0] == (20, {"userrating": 10})
     assert client.movie_writes[1] == (10, {"resume": {"position": 90.0, "total": 6000.0}})
 

--- a/providers/tests/test_mdblist_collection.py
+++ b/providers/tests/test_mdblist_collection.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+from providers.sync.mdblist import _collection as collection
+
+
+class Resp:
+    def __init__(self, status: int, payload: Any) -> None:
+        self.status_code = status
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self) -> Any:
+        return self._payload
+
+
+def _adapter() -> SimpleNamespace:
+    return SimpleNamespace(
+        cfg=SimpleNamespace(timeout=1.0, max_retries=0),
+        config={"mdblist": {"auth_method": "api_key", "api_key": "k"}},
+        client=SimpleNamespace(session=object()),
+    )
+
+
+def test_collection_index_keeps_flat_episode_bucket_scope(monkeypatch) -> None:
+    payload = {
+        "episodes": [
+            {
+                "ids": {"tmdb": 73679, "tvdb": 337501},
+                "title": "Japanology Plus",
+                "year": 2014,
+                "season": 1,
+                "number": 1,
+                "collected_at": "2026-01-01T00:00:00Z",
+            },
+            {
+                "ids": {"tmdb": 73679, "tvdb": 337501},
+                "title": "Japanology Plus",
+                "year": 2014,
+                "season": 1,
+                "number": 2,
+                "collected_at": "2026-01-01T00:00:00Z",
+            },
+        ],
+        "pagination": {"has_more": False},
+    }
+
+    def fake_request(_adapter, _method, url, **_kwargs):
+        if "last_activities" in url:
+            return Resp(200, {})
+        return Resp(200, payload)
+
+    monkeypatch.setattr(collection, "mdblist_request", fake_request)
+    monkeypatch.setattr(collection, "has_auth", lambda _cfg: True)
+    monkeypatch.setattr(collection, "_shadow_load", lambda: {"ts": 0, "items": {}})
+    monkeypatch.setattr(collection, "_shadow_save", lambda _items: None)
+    monkeypatch.setattr(collection, "save_watermark", lambda *_args, **_kwargs: None)
+
+    idx = collection.build_index(_adapter(), per_page=100, max_pages=1)
+
+    assert sorted(idx) == ["tmdb:73679#s01e01", "tmdb:73679#s01e02"]
+    assert idx["tmdb:73679#s01e01"]["type"] == "episode"
+    assert idx["tmdb:73679#s01e01"]["show_ids"] == {"tmdb": "73679", "tvdb": "337501"}
+
+
+def test_collection_index_reads_nested_episode_rows(monkeypatch) -> None:
+    payload = {
+        "episodes": [
+            {
+                "episode": {"season": 6, "number": 2, "title": "Exile", "ids": {"tmdbid": 5978363}},
+                "show": {"title": "The Handmaid's Tale", "year": 2017, "ids": {"tmdbid": 69478}},
+                "collected_at": "2026-01-01T00:00:00Z",
+            }
+        ],
+        "pagination": {"has_more": False},
+    }
+
+    def fake_request(_adapter, _method, url, **_kwargs):
+        if "last_activities" in url:
+            return Resp(200, {})
+        return Resp(200, payload)
+
+    monkeypatch.setattr(collection, "mdblist_request", fake_request)
+    monkeypatch.setattr(collection, "has_auth", lambda _cfg: True)
+    monkeypatch.setattr(collection, "_shadow_load", lambda: {"ts": 0, "items": {}})
+    monkeypatch.setattr(collection, "_shadow_save", lambda _items: None)
+    monkeypatch.setattr(collection, "save_watermark", lambda *_args, **_kwargs: None)
+
+    idx = collection.build_index(_adapter(), per_page=100, max_pages=1)
+
+    item = idx["tmdb:69478#s06e02"]
+    assert item["type"] == "episode"
+    assert item["title"] == "Exile"
+    assert item["ids"] == {"tmdb": "5978363"}
+    assert item["show_ids"] == {"tmdb": "69478"}
+
+
+def test_collection_add_confirms_only_items_seen_live(monkeypatch) -> None:
+    def fake_request(_adapter, method, url, **kwargs):
+        if method == "POST":
+            return Resp(200, {"added": {"shows": 1}})
+        if "last_activities" in url:
+            return Resp(200, {})
+        return Resp(
+            200,
+            {
+                "shows": [
+                    {
+                        "title": "Show",
+                        "year": 2026,
+                        "ids": {"tmdb": 100},
+                        "seasons": [{"number": 1, "episodes": [{"number": 1, "title": "One"}]}],
+                    }
+                ],
+                "pagination": {"has_more": False},
+            },
+        )
+
+    monkeypatch.setattr(collection, "mdblist_request", fake_request)
+    monkeypatch.setattr(collection, "has_auth", lambda _cfg: True)
+    monkeypatch.setattr(collection, "_shadow_load", lambda: {"ts": 0, "items": {}})
+    monkeypatch.setattr(collection, "_shadow_save", lambda _items: None)
+    monkeypatch.setattr(collection, "_shadow_bust", lambda: None)
+    monkeypatch.setattr(collection, "get_watermark", lambda _feature: None)
+    monkeypatch.setattr(collection, "save_watermark", lambda *_args, **_kwargs: None)
+
+    result = collection.add(
+        _adapter(),
+        [
+            {"type": "episode", "title": "One", "show_ids": {"tmdb": "100"}, "season": 1, "episode": 1},
+            {"type": "episode", "title": "Two", "show_ids": {"tmdb": "100"}, "season": 1, "episode": 2},
+        ],
+    )
+
+    assert isinstance(result, dict)
+    assert result["confirmed_keys"] == ["tmdb:100#s01e01"]
+    assert result["presence_confirmed_keys"] == ["tmdb:100#s01e01"]
+    assert result["accepted_not_seen_live_keys"] == ["tmdb:100#s01e02"]
+    assert result["unresolved"][-1]["hint"] == "not_seen_live"
+
+
+def test_collection_remove_uses_history_style_bucket_chunks(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_request(_adapter, method, url, **kwargs):
+        payload = kwargs.get("json") or {}
+        calls.append(payload)
+        show_count = len(payload.get("shows") or [])
+        if show_count > 200:
+            return Resp(400, {"error": "Too many shows in one request (max 200)"})
+        return Resp(200, {"deleted": {"shows": show_count}})
+
+    monkeypatch.setattr(collection, "mdblist_request", fake_request)
+    monkeypatch.setattr(collection, "has_auth", lambda _cfg: True)
+    monkeypatch.setattr(collection, "_shadow_bust", lambda: None)
+
+    items = [{"type": "show", "ids": {"tmdb": i}} for i in range(1, 202)]
+
+    removed, unresolved = collection.remove(_adapter(), items)
+
+    assert removed == 201
+    assert unresolved == []
+    assert len(calls) == 9
+    assert [len(call.get("shows") or []) for call in calls] == [25, 25, 25, 25, 25, 25, 25, 25, 1]

--- a/providers/tests/test_plex_collection.py
+++ b/providers/tests/test_plex_collection.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any, Mapping
+
+
+collection = importlib.import_module("providers.sync.plex._collection")
+
+
+def test_collection_normalize_never_enables_guid_discovery(monkeypatch):
+    seen: dict[str, Any] = {}
+
+    def fake_minimal_from_history_row(
+        row: Mapping[str, Any],
+        *,
+        token: str | None = None,
+        allow_discover: bool = False,
+    ) -> dict[str, Any]:
+        seen["row"] = dict(row)
+        seen["token"] = token
+        seen["allow_discover"] = allow_discover
+        return {"type": row.get("type"), "title": "Attack on Titan", "ids": {"tmdb": "1429"}}
+
+    monkeypatch.setattr(collection, "minimal_from_history_row", fake_minimal_from_history_row)
+
+    item = collection._normalize_row(
+        {"ratingKey": "45573", "type": "episode"},
+        library_id="12",
+        fallback_type="episode",
+        token="plex-token",
+    )
+
+    assert seen["allow_discover"] is False
+    assert seen["token"] == "plex-token"
+    assert seen["row"]["librarySectionID"] == "12"
+    assert item["type"] == "episode"
+    assert item["library_id"] == "12"

--- a/providers/tests/test_trakt_collection.py
+++ b/providers/tests/test_trakt_collection.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from providers.sync.trakt import _collection as collection
+
+
+class FakeResp:
+    def __init__(self, status: int, payload: Any = None, headers: dict[str, str] | None = None) -> None:
+        self.status_code = status
+        self._payload = payload
+        self.headers = headers or {}
+        self.text = "x" if payload is not None else ""
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeSession:
+    pass
+
+
+def _adapter() -> SimpleNamespace:
+    return SimpleNamespace(
+        cfg=SimpleNamespace(timeout=5, max_retries=1, client_id="cid", access_token="tok"),
+        client=SimpleNamespace(session=FakeSession()),
+        config={"trakt": {"collection_use_etag": False, "collection_batch_size": 100}},
+    )
+
+
+def test_collection_index_reads_trakt_movie_and_show_endpoints(monkeypatch: Any) -> None:
+    calls: list[str] = []
+
+    def fake_request(_sess: Any, method: str, url: str, **_kwargs: Any) -> FakeResp:
+        calls.append(f"{method} {url}")
+        if url.endswith("/sync/collection/movies"):
+            return FakeResp(
+                200,
+                [
+                    {
+                        "collected_at": "2026-08-24T20:00:00.000Z",
+                        "movie": {"title": "Dune", "year": 2021, "ids": {"tmdb": 438631, "trakt": 1}},
+                    }
+                ],
+                {"ETag": "m1"},
+            )
+        if url.endswith("/sync/collection/shows"):
+            return FakeResp(
+                200,
+                [
+                    {
+                        "type": "show",
+                        "show": {"title": "Severance", "year": 2022, "ids": {"tmdb": 95396, "trakt": 2}},
+                        "seasons": [
+                            {
+                                "number": 1,
+                                "episodes": [
+                                    {"number": 1, "ids": {"tmdb": 1001, "trakt": 11}},
+                                    {"number": 2},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+                {"ETag": "s1"},
+            )
+        return FakeResp(404, {})
+
+    monkeypatch.setattr(collection, "request_with_retries", fake_request)
+    monkeypatch.setattr(collection, "fetch_last_activities", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(collection, "update_watermarks_from_last_activities", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(collection, "_shadow_load", lambda: {"ts": 0, "items": {}})
+    monkeypatch.setattr(collection, "_shadow_save", lambda *_args, **_kwargs: None)
+
+    idx = collection.build_index(_adapter())
+
+    assert "GET https://api.trakt.tv/sync/collection" not in calls
+    assert "GET https://api.trakt.tv/sync/collection/movies" in calls
+    assert "GET https://api.trakt.tv/sync/collection/shows" in calls
+    assert idx["tmdb:438631"]["type"] == "movie"
+    assert idx["tmdb:95396#s01e01"]["type"] == "episode"
+    assert idx["tmdb:95396#s01e02"]["type"] == "episode"
+
+
+def test_collection_write_uses_collection_endpoint_and_shared_nested_body(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_request(_sess: Any, method: str, url: str, **kwargs: Any) -> FakeResp:
+        calls.append({"method": method, "url": url, "json": kwargs.get("json")})
+        return FakeResp(201, {"added": {"movies": 0, "shows": 0, "seasons": 0, "episodes": 1}})
+
+    monkeypatch.setattr(collection, "request_with_retries", fake_request)
+    monkeypatch.setattr(collection, "_shadow_bust", lambda: None)
+
+    added, unresolved = collection.add(
+        _adapter(),
+        [
+            {
+                "type": "episode",
+                "series_title": "Severance",
+                "show_ids": {"tmdb": "95396"},
+                "season": 1,
+                "episode": 2,
+                "ids": {},
+            }
+        ],
+    )
+
+    assert added == 1
+    assert unresolved == []
+    assert calls[0]["url"] == "https://api.trakt.tv/sync/collection"
+    assert calls[0]["json"] == {"shows": [{"ids": {"tmdb": "95396"}, "seasons": [{"number": 1, "episodes": [{"number": 2}]}]}]}

--- a/tests/test_floppy_sync.py
+++ b/tests/test_floppy_sync.py
@@ -84,11 +84,14 @@ def test_floppy_capabilities_expose_only_requested_features() -> None:
     features = OPS.features()
     caps = OPS.capabilities()
 
-    assert features == {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False}
+    assert features == {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False, "collection": True}
     assert caps["watchlist"]["custom_lists"] is True
     assert caps["ratings"]["scale"] == "0-10"
     assert caps["progress"]["read"] is True
     assert caps["progress"]["write"] is True
+    assert caps["collection"]["read"] is True
+    assert caps["collection"]["write"] is True
+    assert caps["collection"]["types"] == {"movies": True, "shows": True, "seasons": True, "episodes": True}
 
 
 def test_floppy_module_uses_shared_rate_limiter() -> None:
@@ -225,6 +228,87 @@ def test_floppy_watchlist_resolves_imdb_to_tmdb_when_metadata_configured(monkeyp
     assert res["confirmed_destinations"]["imdb:tt0137523"]["item"]["ids"] == {"tmdb": "550", "imdb": "tt0137523"}
     assert calls == [{"entity": "movie", "ids": {"imdb": "tt0137523"}, "need": {"poster": False, "backdrop": False, "ids": True}}]
     assert adapter.client.session.calls[1]["path"] == "media/movie/tmdb/550/lists/7"
+
+
+def test_floppy_collection_reads_owned_movies_and_episodes() -> None:
+    from providers.sync.floppy import _collection
+
+    adapter = AdapterStub(
+        {
+            ("GET", "collection"): {
+                "results": [
+                    {
+                        "id": 91,
+                        "media_type": "digital",
+                        "collected_at": "2026-08-01T12:00:00Z",
+                        "item": {"media_type": "movie", "source": "tmdb", "media_id": "11", "title": "Movie", "ids": {"tmdb": "11", "imdb": "tt0000011"}},
+                    },
+                    {
+                        "id": 92,
+                        "item": {"media_type": "episode", "source": "tmdb", "media_id": "22", "season_number": 1, "episode_number": 2, "title": "Episode", "ids": {"tmdb": "22"}},
+                    },
+                ],
+                "count": 2,
+            }
+        }
+    )
+
+    out = _collection.build_index(adapter)
+
+    assert out["tmdb:11"]["format"] == "digital"
+    assert out["tmdb:11"]["_floppy_collection_id"] == "91"
+    assert out["tmdb:22#s01e02"]["_floppy_collection_id"] == "92"
+
+
+def test_floppy_collection_adds_movie_via_item_id() -> None:
+    from providers.sync.floppy import _collection
+
+    adapter = AdapterStub(
+        {
+            ("POST", "media/movie"): {"id": 41, "item_id": "movie/tmdb/11"},
+            ("POST", "collection"): {"id": 91},
+        }
+    )
+
+    res = _collection.add(adapter, [{"type": "movie", "ids": {"tmdb": "11"}}])
+
+    assert res["count"] == 1
+    assert [c["path"] for c in adapter.client.session.calls] == ["media/movie", "collection"]
+    assert adapter.client.session.calls[0]["json"] == {"source": "tmdb", "media_id": "11", "status": 0}
+    assert adapter.client.session.calls[1]["json"] == {"item_id": "41", "media_type": "digital"}
+
+
+def test_floppy_collection_adds_episode_scope() -> None:
+    from providers.sync.floppy import _collection
+
+    adapter = AdapterStub(
+        {
+            ("POST", "media/episode"): {"id": 42, "item_id": "tv/tmdb/22/1/2"},
+            ("POST", "collection"): {"id": 92},
+        }
+    )
+
+    res = _collection.add(adapter, [{"type": "episode", "show_ids": {"tmdb": "22"}, "season": 1, "episode": 2}])
+
+    assert res["count"] == 1
+    assert adapter.client.session.calls[0]["json"] == {"source": "tmdb", "media_id": "22", "status": 0, "season_number": 1, "episode_number": 2}
+    assert adapter.client.session.calls[1]["json"] == {"item_id": "42", "media_type": "digital"}
+
+
+def test_floppy_collection_remove_deletes_all_matching_entries() -> None:
+    from providers.sync.floppy import _collection
+
+    adapter = AdapterStub(
+        {
+            ("DELETE", "collection/91"): ResponseStub(204, {}),
+            ("DELETE", "collection/92"): ResponseStub(204, {}),
+        }
+    )
+
+    res = _collection.remove(adapter, [{"type": "movie", "ids": {"tmdb": "11"}, "_floppy_collection_ids": ["91", "92"]}])
+
+    assert res["count"] == 1
+    assert [c["path"] for c in adapter.client.session.calls] == ["collection/91", "collection/92"]
 
 
 def test_floppy_ratings_read_and_write_native_scale() -> None:

--- a/tests/test_pair_library_scope.py
+++ b/tests/test_pair_library_scope.py
@@ -74,7 +74,7 @@ def test_features_without_library_scope_are_untouched(feature) -> None:
     assert out["plex"]["history"]["libraries"] == ["2", "3", "4", "5", "8", "9"]
 
 
-@pytest.mark.parametrize("feature", ["history", "ratings", "progress"])
+@pytest.mark.parametrize("feature", ["history", "ratings", "progress", "collection"])
 def test_all_library_scoped_features_are_handled(feature) -> None:
     cfg = {"plex": {feature: {"libraries": ["1", "2"]}}}
     fcfg = {"libraries": {"PLEX": ["2"]}}

--- a/tests/test_punchplay_sync.py
+++ b/tests/test_punchplay_sync.py
@@ -59,7 +59,7 @@ def test_module_is_registered_and_discoverable() -> None:
     assert ops.name() == "PUNCHPLAY"
     assert ops.label() == "PunchPlay"
     assert dict(ops.features()) == {
-        "watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False,
+        "watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False, "collection": True,
     }
     assert sync_provider_supports_feature("PUNCHPLAY", "history") is True
     assert sync_provider_supports_feature("PUNCHPLAY", "playlists") is False
@@ -78,7 +78,7 @@ def test_manifest_matches_validated_contract() -> None:
     assert man["experimental"] is True
     assert man["bidirectional"] is True
 
-    for feature in ("watchlist", "ratings", "history", "progress"):
+    for feature in ("watchlist", "ratings", "history", "progress", "collection"):
         assert caps[feature]["observed_deletes"] is True, feature
 
     assert caps["ratings"]["scale"] == "1-10"
@@ -87,6 +87,8 @@ def test_manifest_matches_validated_contract() -> None:
     for feature in ("watchlist", "ratings", "history"):
         assert caps[feature]["batch_size"] == 100
         assert caps[feature]["accepted_ids"] == ["tmdb", "imdb", "tvdb", "mal"]
+    assert caps["collection"]["types"] == {"movies": True, "shows": True, "seasons": True, "episodes": False}
+    assert caps["collection"]["default_format"] == "digital"
 
 
 def test_ui_feature_flags_match_the_sync_manifest() -> None:
@@ -352,6 +354,78 @@ def test_watchlist_index_merges_sync_snapshot_list_items(monkeypatch: pytest.Mon
     assert http.calls[2]["method"] == "GET"
     assert http.calls[2]["url"].endswith("/me/sync/snapshot")
     assert http.calls[2]["params"]["resource"] == "list_item"
+
+
+# --- collection ---------------------------------------------------------------
+
+def test_collection_index_reads_paged_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _collection as co
+
+    http = FakeHTTP([
+        _Resp(200, {"items": [
+            {"id": 11, "kind": "movie", "sourceId": 550, "title": "Fight Club", "year": 1999, "format": "bluray"},
+            {"id": 12, "kind": "show", "sourceId": 1399, "title": "Game of Thrones", "year": 2011, "season": 1, "format": "digital"},
+        ], "nextCursor": "next"}),
+        _Resp(200, {"items": [
+            {"id": 13, "kind": "show", "sourceId": 1402, "title": "The Walking Dead", "year": 2010},
+        ], "nextCursor": None}),
+    ])
+    _patch(monkeypatch, co, http)
+
+    idx = co.build_index(Adapter())
+
+    assert idx["tmdb:550"]["_punchplay_collection_id"] == "11"
+    assert idx["tmdb:550"]["format"] == "bluray"
+    assert idx["tmdb:1399#season:1"]["type"] == "season"
+    assert idx["tmdb:1399#season:1"]["show_ids"] == {"tmdb": "1399"}
+    assert idx["tmdb:1402"]["type"] == "show"
+    assert http.calls[0]["params"] == {"limit": 200}
+    assert http.calls[1]["params"] == {"limit": 200, "cursor": "next"}
+
+
+def test_collection_add_defaults_to_digital(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _collection as co
+
+    http = FakeHTTP([_Resp(200, {"id": 99})])
+    _patch(monkeypatch, co, http)
+
+    res = co.add(Adapter(), [{"type": "movie", "title": "Fight Club", "year": 1999, "ids": {"tmdb": "550"}}])
+
+    assert res["confirmed_keys"] == ["tmdb:550"]
+    assert http.calls[0]["method"] == "POST"
+    assert http.calls[0]["url"].endswith("/collection")
+    assert http.calls[0]["json"] == {"kind": "movie", "sourceId": 550, "format": "digital", "title": "Fight Club", "year": 1999}
+
+
+def test_collection_add_supports_season_and_rejects_episode(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _collection as co
+
+    http = FakeHTTP([_Resp(200, {"id": 99})])
+    _patch(monkeypatch, co, http)
+
+    res = co.add(Adapter(), [
+        {"type": "season", "series_title": "Example", "show_ids": {"tmdb": "100"}, "season": 2},
+        {"type": "episode", "show_ids": {"tmdb": "100"}, "season": 2, "episode": 4},
+    ])
+
+    assert res["confirmed_keys"] == ["tmdb:100#season:2"]
+    assert res["unresolved_keys"] == ["tmdb:100#s02e04"]
+    assert http.calls[0]["json"]["kind"] == "show"
+    assert http.calls[0]["json"]["sourceId"] == 100
+    assert http.calls[0]["json"]["season"] == 2
+
+
+def test_collection_remove_uses_existing_collection_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _collection as co
+
+    http = FakeHTTP([_Resp(204)])
+    _patch(monkeypatch, co, http)
+
+    res = co.remove(Adapter(), [{"type": "movie", "ids": {"tmdb": "550"}, "_punchplay_collection_id": "77"}])
+
+    assert res["confirmed_keys"] == ["tmdb:550"]
+    assert http.calls[0]["method"] == "DELETE"
+    assert http.calls[0]["url"].endswith("/collection/77")
 
 
 # --- ratings ------------------------------------------------------------------

--- a/tests/test_scrob_sync.py
+++ b/tests/test_scrob_sync.py
@@ -9,7 +9,7 @@ from typing import Any
 import pytest
 
 from providers.sync import _mod_SCROB as mod
-from providers.sync.scrob import _history, _progress, _ratings, _watchlist
+from providers.sync.scrob import _collection, _history, _progress, _ratings, _watchlist
 
 
 @dataclass
@@ -66,7 +66,7 @@ def _patch_transport(monkeypatch: pytest.MonkeyPatch):
     def fake_webhook(adapter: Any, path: str, payload: Any) -> ResponseStub:
         return adapter.respond("POST", path, json=payload)
 
-    for module in (_common, _history, _ratings, _progress, _watchlist):
+    for module in (_common, _history, _ratings, _progress, _watchlist, _collection):
         if hasattr(module, "scrob_request"):
             monkeypatch.setattr(module, "scrob_request", fake_request)
         if hasattr(module, "webhook_post"):
@@ -115,7 +115,7 @@ def test_manifest_declares_supported_features_only():
     assert manifest["name"] == "SCROB"
     assert manifest["version"] == "0.1"
     assert manifest["bidirectional"] is True
-    assert manifest["features"] == {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False}
+    assert manifest["features"] == {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": False, "collection": True}
 
 
 def test_capabilities_declare_event_history_and_rewatches():
@@ -131,6 +131,7 @@ def test_registry_discovers_scrob():
     assert "SCROB" in sync_provider_names()
     assert load_sync_ops("SCROB") is mod.OPS
     assert sync_provider_supports_feature("scrob", "history") is True
+    assert sync_provider_supports_feature("scrob", "collection") is True
     assert sync_provider_supports_feature("scrob", "playlists") is False
 
 
@@ -424,6 +425,76 @@ def test_progress_remove_without_media_id_is_unresolved():
     result = _progress.remove(adapter, [{"type": "movie", "ids": {"tmdb": "550"}}])
     assert result["unresolved"][0]["status"] == "missing_scrob_media_id"
     assert not adapter.calls
+
+
+def test_collection_index_reads_export_collection_rows():
+    payload = {
+        "collection": [
+            {
+                "id": 71,
+                "movie": {"tmdb_id": 550, "type": "movie", "title": "Fight Club", "release_date": "1999-10-15"},
+                "collected_at": "2026-08-01T10:00:00",
+            },
+            {
+                "show": {"tmdb_id": 1399, "type": "series", "title": "Game of Thrones"},
+                "seasons": [{"number": 1, "episodes": [{"number": 1, "tmdb_id": 63056, "title": "Winter Is Coming"}]}],
+            },
+        ]
+    }
+    adapter = FakeAdapter({("GET", "export/data"): ResponseStub(200, payload)})
+
+    index = _collection.build_index(adapter)
+
+    assert sorted(index) == ["tmdb:1399#s01e01", "tmdb:550"]
+    assert index["tmdb:550"]["_scrob_collection_id"] == "71"
+    assert index["tmdb:550"]["collected_at"] == "2026-08-01T10:00:00.000Z"
+    assert index["tmdb:1399#s01e01"]["show_ids"] == {"tmdb": "1399"}
+
+
+def test_collection_add_maps_each_scope():
+    adapter = FakeAdapter({
+        ("POST", "media/collect"): ResponseStub(200, {"status": "ok"}),
+        ("POST", "media/collect-show"): ResponseStub(200, {"status": "ok"}),
+        ("POST", "media/collect-season"): ResponseStub(200, {"status": "ok"}),
+    })
+    items = [
+        {"type": "movie", "ids": {"tmdb": "550"}},
+        {"type": "show", "ids": {"tmdb": "1399"}},
+        {"type": "season", "show_ids": {"tmdb": "1399"}, "season": 2},
+        {"type": "episode", "ids": {"tmdb": "63056"}, "show_ids": {"tmdb": "1399"}, "season": 1, "episode": 1},
+    ]
+
+    result = _collection.add(adapter, items)
+
+    assert result["ok"] and len(result["confirmed_keys"]) == 4
+    bodies = [call["json"] for call in adapter.calls]
+    assert bodies[0] == {"tmdb_id": 550, "media_type": "movie"}
+    assert bodies[1] == {"tmdb_id": 1399, "media_type": "series"}
+    assert bodies[2] == {"series_tmdb_id": 1399, "season_number": 2}
+    assert bodies[3] == {"tmdb_id": 63056, "media_type": "episode", "series_tmdb_id": 1399, "season_number": 1, "episode_number": 1}
+
+
+def test_collection_remove_maps_each_scope():
+    adapter = FakeAdapter({
+        ("DELETE", "media/collect"): ResponseStub(200, {"status": "ok"}),
+        ("DELETE", "media/collect-show"): ResponseStub(200, {"status": "ok"}),
+        ("DELETE", "media/collect-season"): ResponseStub(200, {"status": "ok"}),
+    })
+    items = [
+        {"type": "movie", "ids": {"tmdb": "550"}, "_scrob_collection_id": "71"},
+        {"type": "show", "ids": {"tmdb": "1399"}},
+        {"type": "season", "show_ids": {"tmdb": "1399"}, "season": 2},
+        {"type": "episode", "ids": {"tmdb": "63056"}, "show_ids": {"tmdb": "1399"}, "season": 1, "episode": 1},
+    ]
+
+    result = _collection.remove(adapter, items)
+
+    assert result["ok"] and len(result["confirmed_keys"]) == 4
+    params = [call["params"] for call in adapter.calls]
+    assert params[0] == {"media_type": "movie", "id": 71}
+    assert params[1] == {"tmdb_id": 1399}
+    assert params[2] == {"series_tmdb_id": 1399, "season_number": 2}
+    assert params[3] == {"media_type": "episode", "tmdb_id": 63056}
 
 
 def test_watchlist_index_reads_the_named_list():


### PR DESCRIPTION
# Pull request

## Change

- Adds collection support to the provider adapters.
- Includes Plex, MDBList, Trakt, CrossWatch, Emby, Jellyfin, Kodi, PunchPlay, Floppy and Scrob collection handling.

## Why

Collections need provider-level read/write support before the UI can expose the feature properly.

## Testing

- providers\tests\test_crosswatch_collection.py 
- providers\tests\test_emby_collection.py 
- providers\tests\test_jellyfin_collection.py 
- providers\tests\test_mdblist_collection.py 
- providers\tests\test_plex_collection.py 
- providers\tests\test_trakt_collection.py
- providers\tests\test_kodi_sync.py 
- tests\test_floppy_sync.py 
- tests\test_pair_library_scope.py 
- tests\test_punchplay_sync.py 
- tests\test_scrob_sync.py 

## Issue

Relates to #866