### PR TITLE
Add: preserve collection added dates

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -1399,7 +1399,7 @@
   }
 
   function isExtraKindEditable() {
-    return state.kind === "ratings" || state.kind === "history" || state.kind === "progress";
+    return state.kind === "ratings" || state.kind === "history" || state.kind === "progress" || state.kind === "collection";
   }
 
   function manualCorrectionKindLabel(kind = state.kind) {
@@ -1407,6 +1407,7 @@
     if (k === "history") return "history date";
     if (k === "ratings") return "rating";
     if (k === "progress") return "progress";
+    if (k === "collection") return "collection date";
     return "extra field";
   }
 
@@ -1632,6 +1633,7 @@
       openRawFieldsModal,
       openRatingEditor,
       openHistoryEditor,
+      openCollectionEditor,
       openProgressEditor,
       setStatus,
       setRowsStatus,
@@ -1646,6 +1648,9 @@
     return editorExtraEditors.openHistoryEditor(row, anchor, displayEl, extraEditorContext());
   }
 
+  function openCollectionEditor(row, anchor, displayEl) {
+    return editorExtraEditors.openCollectionEditor(row, anchor, displayEl, extraEditorContext());
+  }
 
   function openProgressEditor(row, anchor, displayEl) {
     return editorExtraEditors.openProgressEditor(row, anchor, displayEl, extraEditorContext());

--- a/assets/js/editor/extra-editors.js
+++ b/assets/js/editor/extra-editors.js
@@ -26,6 +26,11 @@
       const w = row.raw && row.raw.watched_at;
       if (!w) placeholder = "Set time";
       else label = dt.formatHistoryLabel ? dt.formatHistoryLabel(w) : String(w || "");
+    } else if (state.kind === "collection") {
+      icon = "inventory_2";
+      const c = row.raw && row.raw.collected_at;
+      if (!c) placeholder = "Set date";
+      else label = dt.formatHistoryLabel ? dt.formatHistoryLabel(c) : String(c || "");
     } else if (state.kind === "progress") {
       icon = "play_circle";
       const p = row.raw && row.raw.progress_ms;
@@ -95,6 +100,40 @@
         { label: "Clear", kind: "ghost", onClick: () => { row.raw.watched_at = null; ctx.finishExtraChange(row, displayEl, close); } },
         { label: "Close", kind: "ghost", onClick: close },
         { label: "Save", kind: "primary", onClick: () => { row.raw.watched_at = dt.dateTimeInputsToIso?.(dateInput.value, timeInput.value) || null; ctx.finishExtraChange(row, displayEl, close); } },
+      ]);
+
+      dateInput.focus();
+    });
+  }
+
+  function openCollectionEditor(row, anchor, displayEl, ctx = {}) {
+    const dt = DT();
+    ctx.openPopup(anchor, (pop, close) => {
+      ctx.appendPopupTitle(pop, "Collected at");
+      const grid = document.createElement("div");
+      grid.className = "cw-datetime-grid";
+
+      const dateInput = document.createElement("input");
+      dateInput.type = "date";
+      dateInput.id = "cw_collection_date";
+      dateInput.name = dateInput.id;
+      const timeInput = document.createElement("input");
+      timeInput.type = "time";
+      timeInput.id = "cw_collection_time";
+      timeInput.name = timeInput.id;
+      timeInput.step = 60;
+
+      dt.fillDateTimeInputs?.(row.raw && row.raw.collected_at, dateInput, timeInput);
+
+      grid.appendChild(dateInput);
+      grid.appendChild(timeInput);
+      pop.appendChild(grid);
+      dt.appendUtcHint?.(pop);
+
+      ctx.appendPopupActions(pop, [
+        { label: "Clear", kind: "ghost", onClick: () => { row.raw.collected_at = null; ctx.finishExtraChange(row, displayEl, close); } },
+        { label: "Close", kind: "ghost", onClick: close },
+        { label: "Save", kind: "primary", onClick: () => { row.raw.collected_at = dt.dateTimeInputsToIso?.(dateInput.value, timeInput.value) || null; ctx.finishExtraChange(row, displayEl, close); } },
       ]);
 
       dateInput.focus();
@@ -219,6 +258,7 @@
   Editor.ExtraEditors = {
     updateExtraDisplay,
     openHistoryEditor,
+    openCollectionEditor,
     openProgressEditor,
     openRatingEditor,
   };

--- a/assets/js/editor/table-controller.js
+++ b/assets/js/editor/table-controller.js
@@ -91,6 +91,11 @@
           const bw = b.raw && b.raw.watched_at;
           av = aw ? Date.parse(aw) || 0 : 0;
           bv = bw ? Date.parse(bw) || 0 : 0;
+        } else if (state.kind === "collection") {
+          const ac = a.raw && a.raw.collected_at;
+          const bc = b.raw && b.raw.collected_at;
+          av = ac ? Date.parse(ac) || 0 : 0;
+          bv = bc ? Date.parse(bc) || 0 : 0;
         } else {
           av = "";
           bv = "";
@@ -138,6 +143,7 @@
       openRawFieldsModal: ctx.openRawFieldsModal,
       openRatingEditor: ctx.openRatingEditor,
       openHistoryEditor: ctx.openHistoryEditor,
+      openCollectionEditor: ctx.openCollectionEditor,
       openProgressEditor: ctx.openProgressEditor,
     };
   }

--- a/assets/js/editor/table.js
+++ b/assets/js/editor/table.js
@@ -263,6 +263,8 @@
       extraBtn.onclick = () => call(ctx, "openRatingEditor", row, extraBtn, extraBtn);
     } else if (state.kind === "history") {
       extraBtn.onclick = () => call(ctx, "openHistoryEditor", row, extraBtn, extraBtn);
+    } else if (state.kind === "collection") {
+      extraBtn.onclick = () => call(ctx, "openCollectionEditor", row, extraBtn, extraBtn);
     } else if (state.kind === "progress") {
       extraBtn.onclick = () => call(ctx, "openProgressEditor", row, extraBtn, extraBtn);
     }

--- a/cw_platform/id_map.py
+++ b/cw_platform/id_map.py
@@ -336,6 +336,7 @@ def minimal(item: Mapping[str, Any]) -> dict[str, Any]:
         "duration_ms",
         "progress_at",
         "progress_at_source",
+        "collected_at",
     ):
         if opt in item:
             out[opt] = item.get(opt)

--- a/tests/test_editor_playlists.py
+++ b/tests/test_editor_playlists.py
@@ -348,6 +348,57 @@ def test_editor_send_failure_does_not_expose_exception_detail(monkeypatch) -> No
     assert "super-secret" not in str(res)
 
 
+def test_editor_send_collection_preserves_collected_at(monkeypatch) -> None:
+    class Ops:
+        pass
+
+    sent: dict[str, Any] = {}
+    merged: dict[str, Any] = {}
+
+    monkeypatch.setattr(api, "load_config", lambda: {})
+    monkeypatch.setattr(
+        api,
+        "_editor_send_targets",
+        lambda cfg, feature: [
+            {
+                "provider": "MDBLIST",
+                "instance": "default",
+                "collection_enabled": True,
+            }
+        ],
+    )
+    monkeypatch.setattr(api, "load_sync_ops", lambda provider: Ops())
+    monkeypatch.setattr(api, "build_provider_config_view", lambda cfg, provider, instance: {})
+
+    def fake_apply_add(**kwargs):
+        sent.update(kwargs)
+        return {"ok": True, "confirmed": 1, "confirmed_keys": ["tmdb:949"]}
+
+    def fake_merge(provider, instance, feature, items):
+        merged.update(provider=provider, instance=instance, feature=feature, items=items)
+
+    monkeypatch.setattr(api, "apply_add", fake_apply_add)
+    monkeypatch.setattr(api, "_merge_sent_items_into_state", fake_merge)
+
+    item = {
+        "type": "movie",
+        "title": "Heat",
+        "ids": {"tmdb": "949"},
+        "collected_at": "2026-01-01T00:00:00Z",
+    }
+    res = api.api_editor_send(
+        {
+            "kind": "collection",
+            "providers": [{"provider": "MDBLIST", "instance": "default"}],
+            "items": [item],
+        }
+    )
+
+    assert res["ok"] is True
+    assert sent["items"][0]["collected_at"] == "2026-01-01T00:00:00Z"
+    assert merged["items"][0]["collected_at"] == "2026-01-01T00:00:00Z"
+
+
 def test_editor_bulk_action_buttons_use_playback_action_colors() -> None:
     from pathlib import Path
 


### PR DESCRIPTION
# Pull request

## Change

- Keep collection added dates when providers expose them.
- Adds date support through collection sync/state handling,

## Why

Preserve dates

## Testing

-  tests/test_editor_playlists.py::test_editor_send_collection_preserves_collected_at 
- tests/test_editor_playlists.py::test_editor_send_failure_does_not_expose_exception_detail

## Issue

Relates to #866