### PR TITLE
Change: retry TMDb metadata after temporary failures

### DIFF
--- a/api/metaAPI.py
+++ b/api/metaAPI.py
@@ -558,6 +558,10 @@ def _entity_from_kind(kind: Any) -> str:
 _RESOLVED_ENTITY_MEMO: dict[str, str] = {}
 
 
+class _NoMetadataResult(RuntimeError):
+    pass
+
+
 def _resolve_entity(
     entity: str,
     tmdb_id: str | int,
@@ -663,20 +667,20 @@ def _resolve_tmdb_cached(
 ) -> dict[str, Any]:
     _METADATA, _, _ = _env()
     if _METADATA is None:
-        return {}
+        raise _NoMetadataResult("MetadataManager not available")
     need = {k: True for k in need_key} if need_key else None
-    try:
-        return (
-            _METADATA.resolve(
-                entity=entity,
-                ids={"tmdb": tmdb_id},
-                locale=locale,
-                need=need,
-            )
-            or {}
+    result = (
+        _METADATA.resolve(
+            entity=entity,
+            ids={"tmdb": tmdb_id},
+            locale=locale,
+            need=need,
         )
-    except Exception:
-        return {}
+        or {}
+    )
+    if not isinstance(result, dict) or not result:
+        raise _NoMetadataResult("empty metadata result")
+    return result
 
 
 def get_meta(
@@ -725,9 +729,21 @@ def get_meta(
         )
 
     ttl_key = _ttl_bucket(_cfg_meta_ttl_secs())
-    res = _resolve_tmdb_cached(
-        ttl_key, entity, str(tmdb_id), eff_locale, need_key
-    ) or {}
+    try:
+        res = _resolve_tmdb_cached(
+            ttl_key, entity, str(tmdb_id), eff_locale, need_key
+        ) or {}
+    except _NoMetadataResult:
+        res = {}
+    except Exception as e:
+        _meta_debug(
+            "metadata_resolve_failed",
+            type=entity,
+            tmdb_id=tmdb_id,
+            locale=eff_locale or "en-US",
+            error=e.__class__.__name__,
+        )
+        res = {}
 
     if res and _meta_cache_enabled():
         try:

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -70,3 +70,27 @@ def test_meta_api_reuses_shared_disk_cache_after_memory_cache_reset(tmp_path, mo
     assert first["title"] == "Cached title"
     assert second["title"] == "Cached title"
     assert calls == [("movie", "321")]
+
+
+def test_empty_tmdb_result_is_not_cached_after_transient_failure(tmp_path, monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    class Metadata:
+        def resolve(self, *, entity, ids, locale=None, need=None):
+            calls.append((entity, ids["tmdb"]))
+            if len(calls) == 1:
+                return {}
+            return {"type": entity, "title": "Recovered title", "ids": dict(ids)}
+
+    monkeypatch.setattr(metaAPI, "_env", lambda: (Metadata(), tmp_path.parent, lambda: {}))
+    monkeypatch.setattr(metaAPI, "_meta_cache_dir", lambda: tmp_path)
+    monkeypatch.setattr(metaAPI, "_meta_cache_enabled", lambda: False)
+    monkeypatch.setattr(metaAPI, "_cfg_meta_ttl_secs", lambda: 720 * 3600)
+    metaAPI._resolve_tmdb_cached.cache_clear()
+
+    first = metaAPI.get_meta("unused", "movie", "654", tmp_path, need={"title": True}, locale="en-US")
+    second = metaAPI.get_meta("unused", "movie", "654", tmp_path, need={"title": True}, locale="en-US")
+
+    assert first == {}
+    assert second["title"] == "Recovered title"
+    assert calls == [("movie", "654"), ("movie", "654")]


### PR DESCRIPTION
# Pull request

## Change

- Do not cache empty TMDb metadata results in memory.

## Why

- based on issue #875 

## Testing

- tests\test_metadata_cache.py tests\test_metadata_namespace_resolution.py 
- tests\test_meta_api_tmdb_retry.py 
- tests\test_meta_api_episode_stills.py

## Issue

Relates to #875