### PR TITLE
Change: expand collection sync scope

### DIFF
--- a/assets/js/modals/pair-config/custom-rules.js
+++ b/assets/js/modals/pair-config/custom-rules.js
@@ -14,9 +14,9 @@ const RATINGS_TYPE_RULES = {
 };
 
 const COLLECTION_TYPES = {
-  PLEX: ["movies", "episodes"],
-  EMBY: ["movies", "episodes"],
-  JELLYFIN: ["movies", "episodes"],
+  PLEX: ["movies", "shows", "seasons", "episodes"],
+  EMBY: ["movies", "shows", "seasons", "episodes"],
+  JELLYFIN: ["movies", "shows", "seasons", "episodes"],
   KODI: ["movies", "episodes"],
   TRAKT: ["movies", "shows", "seasons", "episodes"],
   MDBLIST: ["movies", "shows", "seasons", "episodes"],

--- a/providers/sync/_mod_EMBY.py
+++ b/providers/sync/_mod_EMBY.py
@@ -218,7 +218,7 @@ _PROGRESS_CAPABILITIES: dict[str, Any] = {
 _COLLECTION_CAPABILITIES: dict[str, Any] = {
     "index_semantics": "present",
     "observed_deletes": True,
-    "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+    "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
     "read": True,
     "add": False,
     "remove": False,

--- a/providers/sync/_mod_JELLYFIN.py
+++ b/providers/sync/_mod_JELLYFIN.py
@@ -211,7 +211,7 @@ _PROGRESS_CAPABILITIES: dict[str, Any] = {
 _COLLECTION_CAPABILITIES: dict[str, Any] = {
     "index_semantics": "present",
     "observed_deletes": True,
-    "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+    "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
     "read": True,
     "add": False,
     "remove": False,

--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -544,7 +544,7 @@ def get_manifest() -> Mapping[str, Any]:
             "collection": {
                 "index_semantics": "present",
                 "observed_deletes": True,
-                "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+                "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
                 "read": True,
                 "upsert": False,
                 "remove": False,
@@ -1547,7 +1547,7 @@ class _PlexOPS:
             "collection": {
                 "index_semantics": "present",
                 "observed_deletes": True,
-                "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+                "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
                 "read": True,
                 "upsert": False,
                 "remove": False,

--- a/providers/sync/emby/_collection.py
+++ b/providers/sync/emby/_collection.py
@@ -102,7 +102,7 @@ def _fetch_rows(adapter: Any) -> tuple[list[tuple[Mapping[str, Any], str | None]
     page_size = 500
     base_params: dict[str, Any] = {
         "Recursive": True,
-        "IncludeItemTypes": "Movie,Episode",
+        "IncludeItemTypes": "Movie,Series,Season,Episode",
         "Fields": _ITEM_FIELDS,
         "EnableUserData": False,
     }
@@ -165,7 +165,7 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
 
     for idx, (raw, source_library_id) in enumerate(rows, start=1):
         raw_type = str(raw.get("Type") or "").strip()
-        if raw_type not in {"Movie", "Episode"}:
+        if raw_type not in {"Movie", "Series", "Season", "Episode"}:
             _warn("unsupported_collection_row_type", provider_item_id=str(raw.get("Id") or ""), media_type=raw_type)
             continue
         if allowed:
@@ -175,6 +175,14 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
                 continue
         try:
             item = emby_normalize(raw)
+            if raw_type == "Series":
+                item["type"] = "show"
+            elif raw_type == "Season":
+                item["type"] = "season"
+            elif raw_type == "Episode":
+                item["type"] = "episode"
+            elif raw_type == "Movie":
+                item["type"] = "movie"
             collected_at = _collected_at_from_raw(raw)
             if collected_at:
                 item["collected_at"] = collected_at
@@ -190,8 +198,15 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
                 item["library_id"] = lib_id
             series_id = str(raw.get("SeriesId") or "").strip()
             show_ids = series_ids_by_item_id.get(series_id)
-            if raw_type == "Episode" and show_ids:
+            if raw_type in {"Season", "Episode"} and show_ids:
                 item["show_ids"] = show_ids
+            if raw_type == "Season" and item.get("season") is None:
+                season_no = raw.get("IndexNumber")
+                try:
+                    if season_no is not None:
+                        item["season"] = int(season_no)
+                except Exception:
+                    pass
             key = canonical_key(item)
             if not key:
                 _warn("collection_item_without_key", provider_item_id=str(raw.get("Id") or ""), item_title=str(raw.get("Name") or ""), media_type=raw_type, provider_ids=dict(raw.get("ProviderIds") or {}))

--- a/providers/sync/jellyfin/_collection.py
+++ b/providers/sync/jellyfin/_collection.py
@@ -103,7 +103,7 @@ def _fetch_rows(adapter: Any) -> tuple[list[tuple[Mapping[str, Any], str | None]
     page_size = 500
     base_params: dict[str, Any] = {
         "Recursive": True,
-        "IncludeItemTypes": "Movie,Episode",
+        "IncludeItemTypes": "Movie,Series,Season,Episode",
         "Fields": _ITEM_FIELDS,
         "EnableUserData": False,
     }
@@ -166,7 +166,7 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
 
     for idx, (raw, source_library_id) in enumerate(rows, start=1):
         raw_type = str(raw.get("Type") or "").strip()
-        if raw_type not in {"Movie", "Episode"}:
+        if raw_type not in {"Movie", "Series", "Season", "Episode"}:
             _warn("unsupported_collection_row_type", provider_item_id=str(raw.get("Id") or ""), media_type=raw_type)
             continue
         if allowed:
@@ -176,6 +176,14 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
                 continue
         try:
             item = jelly_normalize(raw)
+            if raw_type == "Series":
+                item["type"] = "show"
+            elif raw_type == "Season":
+                item["type"] = "season"
+            elif raw_type == "Episode":
+                item["type"] = "episode"
+            elif raw_type == "Movie":
+                item["type"] = "movie"
             collected_at = _collected_at_from_raw(raw)
             if collected_at:
                 item["collected_at"] = collected_at
@@ -190,8 +198,15 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
                 item["library_id"] = lib_id
             series_id = str(raw.get("SeriesId") or "").strip()
             show_ids = series_ids_by_item_id.get(series_id)
-            if raw_type == "Episode" and show_ids:
+            if raw_type in {"Season", "Episode"} and show_ids:
                 item["show_ids"] = show_ids
+            if raw_type == "Season" and item.get("season") is None:
+                season_no = raw.get("IndexNumber")
+                try:
+                    if season_no is not None:
+                        item["season"] = int(season_no)
+                except Exception:
+                    pass
             key = canonical_key(item)
             if not key:
                 _warn("collection_item_without_key", provider_item_id=str(raw.get("Id") or ""), item_title=str(raw.get("Name") or ""), media_type=raw_type, provider_ids=dict(raw.get("ProviderIds") or {}))

--- a/providers/sync/plex/_collection.py
+++ b/providers/sync/plex/_collection.py
@@ -40,7 +40,26 @@ def _normalize_row(row: Mapping[str, Any], *, library_id: str, fallback_type: st
     if not item:
         return None
     item = dict(item)
-    item["type"] = "episode" if _row_type(raw, fallback_type) == "episode" else "movie"
+    raw_type = _row_type(raw, fallback_type)
+    item["type"] = "episode" if raw_type == "episode" else ("season" if raw_type == "season" else ("show" if raw_type == "show" else "movie"))
+    if item["type"] == "season" and item.get("season") is None:
+        _dbg(
+            "season_row_without_scope",
+            library_id=str(library_id),
+            provider_item_id=str(raw.get("ratingKey") or raw.get("key") or ""),
+            item_title=str(raw.get("title") or ""),
+            series_title=str(raw.get("parentTitle") or raw.get("grandparentTitle") or item.get("series_title") or ""),
+        )
+        return None
+    if item["type"] == "episode" and (item.get("season") is None or item.get("episode") is None):
+        _dbg(
+            "episode_row_without_scope",
+            library_id=str(library_id),
+            provider_item_id=str(raw.get("ratingKey") or raw.get("key") or ""),
+            item_title=str(raw.get("title") or ""),
+            series_title=str(raw.get("grandparentTitle") or item.get("series_title") or ""),
+        )
+        return None
     item["library_id"] = str(library_id)
     collected_at = _collected_at_from_row(raw)
     if collected_at:
@@ -69,7 +88,12 @@ def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
         found.add(sid)
         if allowed and sid not in allowed:
             continue
-        sections.append((sid, typ, 1 if typ == "movie" else 4))
+        if typ == "movie":
+            sections.append((sid, "movie", 1))
+        else:
+            sections.append((sid, "show", 2))
+            sections.append((sid, "season", 3))
+            sections.append((sid, "episode", 4))
 
     missing = sorted(allowed - found)
     if missing:
@@ -82,7 +106,7 @@ def build_index(adapter: Any, **_kwargs: Any) -> dict[str, dict[str, Any]]:
     for index, (sid, lib_type, plex_type) in enumerate(sections, start=1):
         rows, requests_made = _fetch_section_guid_rows(srv, sid, plex_type)
         scanned += len(rows)
-        fallback_type = "movie" if lib_type == "movie" else "episode"
+        fallback_type = lib_type
         for row in rows:
             if not isinstance(row, Mapping):
                 continue

--- a/providers/sync/trakt/_collection.py
+++ b/providers/sync/trakt/_collection.py
@@ -30,12 +30,14 @@ from .._mod_common import request_with_retries
 
 BASE = "https://api.trakt.tv"
 URL_ADD = f"{BASE}/sync/collection"
+URL_MEDIA = f"{BASE}/sync/collection/media"
 URL_MOVIES = f"{BASE}/sync/collection/movies"
 URL_SHOWS = f"{BASE}/sync/collection/shows"
 URL_REMOVE = f"{BASE}/sync/collection/remove"
 
 _PROVIDER = "TRAKT"
 _FEATURE = "collection"
+_SHADOW_SCHEMA = 3
 
 
 def _dbg(event: str, **fields: Any) -> None:
@@ -84,7 +86,10 @@ def _shadow_load() -> dict[str, Any]:
     if _is_capture_mode() or _pair_scope() is None:
         return {"etag": None, "ts": 0, "items": {}}
     try:
-        return json.loads(_shadow_path().read_text("utf-8"))
+        raw = json.loads(_shadow_path().read_text("utf-8"))
+        if not isinstance(raw, Mapping) or int(raw.get("schema") or 0) != _SHADOW_SCHEMA:
+            return {"etag": None, "ts": 0, "items": {}}
+        return dict(raw)
     except Exception:
         return {"etag": None, "ts": 0, "items": {}}
 
@@ -99,6 +104,7 @@ def _shadow_save(etags: Mapping[str, str | None], items: Mapping[str, Any], buck
         tmp.write_text(
             json.dumps(
                 {
+                    "schema": _SHADOW_SCHEMA,
                     "etag": None,
                     "etags": dict(etags or {}),
                     "ts": int(time.time()),
@@ -141,6 +147,16 @@ def _item_key(item: Mapping[str, Any]) -> str:
     return canonical_key(item) or key_of(item) or ""
 
 
+def _hdr_int(headers: Mapping[str, Any], name: str) -> int | None:
+    try:
+        for k, v in (headers or {}).items():
+            if str(k).lower() == name.lower():
+                return int(str(v).strip())
+    except Exception:
+        return None
+    return None
+
+
 def _movie_from_row(row: Mapping[str, Any]) -> dict[str, Any] | None:
     movie = row.get("movie") if isinstance(row.get("movie"), Mapping) else row
     if not isinstance(movie, Mapping):
@@ -165,9 +181,33 @@ def _show_base(row: Mapping[str, Any]) -> dict[str, Any] | None:
 
 def _items_from_collection_row(row: Mapping[str, Any]) -> list[dict[str, Any]]:
     typ = str(row.get("type") or "").strip().lower()
+    if typ == "movie":
+        movie = _movie_from_row(row)
+        return [movie] if movie else []
+    if typ == "episode" and isinstance(row.get("episode"), Mapping):
+        ep = row["episode"]
+        show_raw = row.get("show")
+        show: Mapping[str, Any] = show_raw if isinstance(show_raw, Mapping) else {}
+        item = id_minimal(
+            {
+                "type": "episode",
+                "title": ep.get("title"),
+                "series_title": show.get("title"),
+                "year": show.get("year"),
+                "show_ids": _ids_clean(show.get("ids")),
+                "season": ep.get("season"),
+                "episode": ep.get("number"),
+                "ids": _ids_clean(ep.get("ids")),
+            }
+        )
+        collected_at = row.get("collected_at") or ep.get("collected_at")
+        if collected_at:
+            item["collected_at"] = str(collected_at)
+        return [item]
     seasons = row.get("seasons")
     if not isinstance(seasons, list):
-        show = row.get("show") if isinstance(row.get("show"), Mapping) else row
+        show_raw = row.get("show")
+        show: Mapping[str, Any] = show_raw if isinstance(show_raw, Mapping) else row
         seasons = show.get("seasons") if isinstance(show, Mapping) else None
     if typ and not (typ == "show" and isinstance(seasons, list) and seasons):
         return [normalize_watchlist_row(row)]
@@ -175,7 +215,8 @@ def _items_from_collection_row(row: Mapping[str, Any]) -> list[dict[str, Any]]:
         movie = _movie_from_row(row)
         return [movie] if movie else []
     show_item = _show_base(row)
-    show = row.get("show") if isinstance(row.get("show"), Mapping) else row
+    show_raw = row.get("show")
+    show = show_raw if isinstance(show_raw, Mapping) else row
     if not isinstance(seasons, list) or not seasons:
         return [show_item] if show_item else []
     show_ids = dict((show_item or {}).get("ids") or {})
@@ -222,6 +263,10 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
     cfg = _cfg(adapter)
     use_etag = _cfg_bool(cfg, "collection_use_etag", True)
     ttl_h = _cfg_int(cfg, "collection_shadow_ttl_hours", 168)
+    per_page = max(1, min(100, _cfg_int(cfg, "collection_per_page", _cfg_int(cfg, "history_per_page", 100))))
+    max_pages = _cfg_int(cfg, "collection_max_pages", _cfg_int(cfg, "history_max_pages", 10000))
+    if max_pages <= 0:
+        max_pages = 10000
     prog_mk = getattr(adapter, "progress_factory", None)
     prog: Any = prog_mk("collection") if callable(prog_mk) else None
 
@@ -247,11 +292,19 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
         if use_etag and fresh and etag and isinstance(cached, Mapping):
             req_headers["If-None-Match"] = str(etag)
 
+        idx: dict[str, dict[str, Any]] = {}
+        page = 1
+        total_pages: int | None = None
+        etag_out: str | None = None
+        total_hint: int | None = None
+        rows_seen = 0
+
         r = request_with_retries(
             sess,
             "GET",
             url,
             headers=req_headers,
+            params={"page": page, "limit": per_page},
             timeout=adapter.cfg.timeout,
             max_retries=adapter.cfg.max_retries,
         )
@@ -261,25 +314,65 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
             _warn("http_failed", op="index", bucket=name, status=r.status_code)
             return (dict(cached) if isinstance(cached, Mapping) else {}), (str(etag) if etag else None), True
 
-        data = r.json() if (r.text or "").strip() else []
-        rows: list[Mapping[str, Any]] = []
-        if isinstance(data, list):
-            rows = [x for x in data if isinstance(x, Mapping)]
-        elif isinstance(data, Mapping):
-            raw = data.get(name)
-            if isinstance(raw, list):
-                rows = [x for x in raw if isinstance(x, Mapping)]
+        while True:
+            if page > 1:
+                r = request_with_retries(
+                    sess,
+                    "GET",
+                    url,
+                    headers=headers,
+                    params={"page": page, "limit": per_page},
+                    timeout=adapter.cfg.timeout,
+                    max_retries=adapter.cfg.max_retries,
+                )
+                if r.status_code != 200:
+                    _warn("http_failed", op="index", bucket=name, page=page, status=r.status_code)
+                    break
 
-        idx: dict[str, dict[str, Any]] = {}
-        total = max(1, len(rows))
-        for i, row in enumerate(rows, start=1):
-            for item in _items_from_collection_row(row):
-                key = _item_key(item)
-                if key:
-                    idx[key] = item
+            if page == 1:
+                etag_out = r.headers.get("ETag")
+                total_pages = _hdr_int(r.headers, "X-Pagination-Page-Count")
+                total_hint = _hdr_int(r.headers, "X-Pagination-Item-Count")
+
+            data = r.json() if (r.text or "").strip() else []
+            rows: list[Mapping[str, Any]] = []
+            if isinstance(data, list):
+                rows = [x for x in data if isinstance(x, Mapping)]
+            elif isinstance(data, Mapping):
+                raw = data.get(name)
+                if isinstance(raw, list):
+                    rows = [x for x in raw if isinstance(x, Mapping)]
+            if not rows:
+                break
+
+            for row in rows:
+                for item in _items_from_collection_row(row):
+                    key = _item_key(item)
+                    if key:
+                        idx[key] = item
+            rows_seen += len(rows)
             if prog:
-                prog.tick(i, total=total)
-        return idx, r.headers.get("ETag"), False
+                prog.tick(rows_seen, total=total_hint or max(rows_seen, len(rows)))
+
+            page += 1
+            if total_pages is not None and page > total_pages:
+                break
+            if total_pages is None and len(rows) < per_page:
+                break
+            if max_pages and page > max_pages:
+                _warn("index_reconcile", reason="safety_cap_hit", strategy="paged_fetch", bucket=name, max_pages=max_pages)
+                break
+
+        _dbg("index_fetch_bucket", bucket=name, rows=rows_seen, items=len(idx), per_page=per_page, max_pages=max_pages, pages=(page - 1))
+        return idx, etag_out, False
+
+    media_idx, media_etag, media_cached = _fetch_bucket("media", URL_MEDIA)
+    if media_idx or not media_cached:
+        if use_etag:
+            _shadow_save({"media": media_etag}, media_idx, {"media": media_idx})
+        source = "shadow" if media_cached else "live"
+        _info("index_done", count=len(media_idx), source=source, endpoint="media", per_page=per_page, max_pages=max_pages)
+        return media_idx
 
     movie_idx, movie_etag, movie_cached = _fetch_bucket("movies", URL_MOVIES)
     show_idx, show_etag, show_cached = _fetch_bucket("shows", URL_SHOWS)
@@ -291,7 +384,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
     if use_etag:
         _shadow_save({"movies": movie_etag, "shows": show_etag}, idx, {"movies": movie_idx, "shows": show_idx})
     source = "shadow" if movie_cached and show_cached else ("mixed" if movie_cached or show_cached else "live")
-    _info("index_done", count=len(idx), source=source)
+    _info("index_done", count=len(idx), source=source, per_page=per_page, max_pages=max_pages)
     return idx
 
 
@@ -303,6 +396,7 @@ def _batch_payload(items: Iterable[Mapping[str, Any]]) -> tuple[list[dict[str, A
         collected_at = it.get("collected_at")
         if collected_at:
             m["collected_at"] = str(collected_at)
+            m["watched_at"] = str(collected_at)
         kind = pick_trakt_kind(m)
         ids = ids_for_trakt(m)
         show_ids = dict(m.get("show_ids") or {})
@@ -319,9 +413,10 @@ def _batch_payload(items: Iterable[Mapping[str, Any]]) -> tuple[list[dict[str, A
     return accepted, rejected
 
 
-def _record_not_found(not_found: Mapping[str, Any], unresolved: list[dict[str, Any]]) -> None:
+def _record_not_found(not_found: Mapping[str, Any], unresolved: list[dict[str, Any]]) -> list[str]:
+    keys: list[str] = []
     if not isinstance(not_found, Mapping):
-        return
+        return keys
     for bucket in ("movies", "shows", "seasons", "episodes"):
         raw = not_found.get(bucket)
         if not isinstance(raw, list):
@@ -329,21 +424,34 @@ def _record_not_found(not_found: Mapping[str, Any], unresolved: list[dict[str, A
         for obj in raw:
             if isinstance(obj, Mapping):
                 typ = bucket[:-1] if bucket.endswith("s") else bucket
-                unresolved.append({"item": id_minimal({"type": typ, "ids": dict(obj.get("ids") or obj)}), "hint": "not_found"})
+                item = id_minimal({"type": typ, "ids": dict(obj.get("ids") or obj)})
+                key = _item_key(item)
+                if key:
+                    keys.append(key)
+                unresolved.append({"item": item, "hint": "not_found", "key": key})
+    return keys
 
 
-def _write(adapter: Any, op: str, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+def _write(adapter: Any, op: str, items: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
     cfg = _cfg(adapter)
     batch = _cfg_int(cfg, "collection_batch_size", _cfg_int(cfg, "watchlist_batch_size", 100))
     accepted, unresolved = _batch_payload(items)
     if not accepted:
         _info("write_skipped", op=op, reason="empty_payload", unresolved=len(unresolved))
-        return 0, unresolved
+        return {"ok": len(unresolved) == 0, "count": 0, "confirmed": 0, "unresolved": unresolved, "confirmed_keys": [], "skipped_keys": []}
 
     url = URL_ADD if op == "add" else URL_REMOVE
     ok = 0
-    for sl in _chunk(accepted, batch):
-        payload = build_watchlist_body(sl, date_field="collected_at" if op == "add" else None)
+    skipped = 0
+    confirmed_keys: list[str] = []
+    skipped_keys: list[str] = []
+    chunks: Iterable[list[dict[str, Any]]]
+    if op == "add" and len(accepted) <= max(1, batch):
+        chunks = ([x] for x in accepted)
+    else:
+        chunks = _chunk(accepted, batch)
+    for sl in chunks:
+        payload = build_watchlist_body(sl, date_field="watched_at" if op == "add" else None)
         if not payload:
             continue
         r = request_with_retries(adapter.client.session, "POST", url, headers=headers_for_adapter(adapter), json=payload, timeout=adapter.cfg.timeout, max_retries=adapter.cfg.max_retries)
@@ -353,22 +461,38 @@ def _write(adapter: Any, op: str, items: Iterable[Mapping[str, Any]]) -> tuple[i
             existing = body.get("existing") if op == "add" else {}
             result = result if isinstance(result, Mapping) else {}
             existing = existing if isinstance(existing, Mapping) else {}
-            ok += sum(int(result.get(k) or 0) for k in ("movies", "shows", "seasons", "episodes"))
-            ok += sum(int(existing.get(k) or 0) for k in ("movies", "shows", "seasons", "episodes"))
-            _record_not_found(body.get("not_found") or {}, unresolved)
+            added_count = sum(int(result.get(k) or 0) for k in ("movies", "shows", "seasons", "episodes"))
+            existing_count = sum(int(existing.get(k) or 0) for k in ("movies", "shows", "seasons", "episodes"))
+            ok += added_count
+            skipped += existing_count
+            not_found_keys = set(_record_not_found(body.get("not_found") or {}, unresolved))
+            slice_keys = [_item_key(x) for x in sl]
+            slice_keys = [k for k in slice_keys if k and k not in not_found_keys]
+            if added_count and not existing_count:
+                confirmed_keys.extend(slice_keys)
+            elif existing_count and not added_count:
+                skipped_keys.extend(slice_keys)
         else:
             _warn("write_failed", op=op, status=r.status_code, body=(r.text or "")[:180])
             for x in sl:
                 unresolved.append({"item": x, "hint": f"http:{r.status_code}"})
     if ok:
         _shadow_bust()
-    _info("write_done", op=op, ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
-    return ok, unresolved
+    _info("write_done", op=op, ok=len(unresolved) == 0, applied=ok, existing=skipped, unresolved=len(unresolved))
+    return {
+        "ok": len(unresolved) == 0,
+        "count": ok,
+        "confirmed": ok,
+        "confirmed_keys": list(dict.fromkeys(confirmed_keys)),
+        "skipped": skipped,
+        "skipped_keys": list(dict.fromkeys(skipped_keys)),
+        "unresolved": unresolved,
+    }
 
 
-def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
     return _write(adapter, "add", items)
 
 
-def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
     return _write(adapter, "remove", items)

--- a/providers/sync/trakt/_history.py
+++ b/providers/sync/trakt/_history.py
@@ -2470,7 +2470,7 @@ def _history_body_to_collection(body: Mapping[str, Any], types: set[str]) -> dic
             out.setdefault("movies", []).append(
                 {
                     "ids": ids,
-                    "collected_at": m.get("watched_at") or _now_iso(),
+                    "watched_at": m.get("watched_at") or _now_iso(),
                 }
             )
 
@@ -2487,7 +2487,7 @@ def _history_body_to_collection(body: Mapping[str, Any], types: set[str]) -> dic
             out.setdefault("episodes", []).append(
                 {
                     "ids": ids,
-                    "collected_at": e.get("watched_at") or _now_iso(),
+                    "watched_at": e.get("watched_at") or _now_iso(),
                 }
             )
 
@@ -2513,7 +2513,7 @@ def _history_body_to_collection(body: Mapping[str, Any], types: set[str]) -> dic
                         eps_out.append(
                             {
                                 "number": int(n),
-                                "collected_at": ep.get("watched_at") or _now_iso(),
+                                "watched_at": ep.get("watched_at") or _now_iso(),
                             }
                         )
                     if eps_out:

--- a/providers/tests/test_emby_collection.py
+++ b/providers/tests/test_emby_collection.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from typing import Any
 
 from providers.sync.emby import _collection as collection
+from providers.sync._mod_EMBY import OPS
 
 
 class Resp:
@@ -52,6 +53,25 @@ class FakeEmbyClient:
                 {
                     "Items": [
                         {
+                            "Id": "show-1",
+                            "Type": "Series",
+                            "Name": "The Show",
+                            "AncestorIds": ["lib-tv"],
+                            "ProviderIds": {"Tmdb": "12345", "Tvdb": "67890"},
+                            "DateCreated": "2026-01-01T03:04:05Z",
+                        },
+                        {
+                            "Id": "season-1",
+                            "Type": "Season",
+                            "Name": "Season 1",
+                            "SeriesName": "The Show",
+                            "SeriesId": "show-1",
+                            "IndexNumber": 1,
+                            "AncestorIds": ["lib-tv", "show-1"],
+                            "ProviderIds": {},
+                            "DateCreated": "2026-01-01T04:04:05Z",
+                        },
+                        {
                             "Id": "ep-1",
                             "Type": "Episode",
                             "Name": "Pilot",
@@ -78,7 +98,18 @@ def test_collection_resolves_library_id_like_history() -> None:
 
     index = collection.build_index(adapter)
 
-    assert sorted(index) == ["tmdb:12345#s01e01"]
+    item_query = next(params for path, params in adapter.client.calls if path == "/Users/user-1/Items" and params.get("Recursive"))
+    assert item_query["IncludeItemTypes"] == "Movie,Series,Season,Episode"
+    assert sorted(index) == ["tmdb:12345", "tmdb:12345#s01e01", "tmdb:12345#season:1"]
+    show = index["tmdb:12345"]
+    assert show["type"] == "show"
+    assert show["library_id"] == "lib-tv"
+    season = index["tmdb:12345#season:1"]
+    assert season["type"] == "season"
+    assert season["library_id"] == "lib-tv"
+    assert season["show_ids"] == {"tmdb": "12345", "tvdb": "67890"}
+    assert season["season"] == 1
+    assert season["collected_at"] == "2026-01-01T04:04:05Z"
     item = index["tmdb:12345#s01e01"]
     assert item["type"] == "episode"
     assert item["library_id"] == "lib-tv"
@@ -86,3 +117,12 @@ def test_collection_resolves_library_id_like_history() -> None:
     assert item["season"] == 1
     assert item["episode"] == 1
     assert item["collected_at"] == "2026-01-02T03:04:05Z"
+
+
+def test_collection_capabilities_cover_show_season_episode_scope() -> None:
+    assert OPS.capabilities()["collection"]["types"] == {
+        "movies": True,
+        "shows": True,
+        "seasons": True,
+        "episodes": True,
+    }

--- a/providers/tests/test_jellyfin_collection.py
+++ b/providers/tests/test_jellyfin_collection.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from typing import Any
 
 from providers.sync.jellyfin import _collection as collection
+from providers.sync._mod_JELLYFIN import OPS
 
 
 class Resp:
@@ -52,6 +53,25 @@ class FakeJellyfinClient:
                 {
                     "Items": [
                         {
+                            "Id": "show-1",
+                            "Type": "Series",
+                            "Name": "The Show",
+                            "AncestorIds": ["lib-tv"],
+                            "ProviderIds": {"Tmdb": "12345", "Tvdb": "67890"},
+                            "DateCreated": "2026-01-01T03:04:05Z",
+                        },
+                        {
+                            "Id": "season-1",
+                            "Type": "Season",
+                            "Name": "Season 1",
+                            "SeriesName": "The Show",
+                            "SeriesId": "show-1",
+                            "IndexNumber": 1,
+                            "AncestorIds": ["lib-tv", "show-1"],
+                            "ProviderIds": {},
+                            "DateCreated": "2026-01-01T04:04:05Z",
+                        },
+                        {
                             "Id": "ep-1",
                             "Type": "Episode",
                             "Name": "Pilot",
@@ -78,7 +98,18 @@ def test_collection_resolves_library_id_like_history() -> None:
 
     index = collection.build_index(adapter)
 
-    assert sorted(index) == ["tmdb:12345#s01e01"]
+    item_query = next(params for path, params in adapter.client.calls if path == "/Items" and params.get("Recursive"))
+    assert item_query["IncludeItemTypes"] == "Movie,Series,Season,Episode"
+    assert sorted(index) == ["tmdb:12345", "tmdb:12345#s01e01", "tmdb:12345#season:1"]
+    show = index["tmdb:12345"]
+    assert show["type"] == "show"
+    assert show["library_id"] == "lib-tv"
+    season = index["tmdb:12345#season:1"]
+    assert season["type"] == "season"
+    assert season["library_id"] == "lib-tv"
+    assert season["show_ids"] == {"tmdb": "12345", "tvdb": "67890"}
+    assert season["season"] == 1
+    assert season["collected_at"] == "2026-01-01T04:04:05Z"
     item = index["tmdb:12345#s01e01"]
     assert item["type"] == "episode"
     assert item["library_id"] == "lib-tv"
@@ -86,3 +117,12 @@ def test_collection_resolves_library_id_like_history() -> None:
     assert item["season"] == 1
     assert item["episode"] == 1
     assert item["collected_at"] == "2026-01-02T03:04:05Z"
+
+
+def test_collection_capabilities_cover_show_season_episode_scope() -> None:
+    assert OPS.capabilities()["collection"]["types"] == {
+        "movies": True,
+        "shows": True,
+        "seasons": True,
+        "episodes": True,
+    }

--- a/providers/tests/test_plex_collection.py
+++ b/providers/tests/test_plex_collection.py
@@ -8,6 +8,17 @@ collection = importlib.import_module("providers.sync.plex._collection")
 common = importlib.import_module("providers.sync.plex._common")
 
 
+def test_plex_collection_manifest_declares_show_scope():
+    from providers.sync._mod_PLEX import get_manifest
+
+    assert get_manifest()["capabilities"]["collection"]["types"] == {
+        "movies": True,
+        "shows": True,
+        "seasons": True,
+        "episodes": True,
+    }
+
+
 def test_collection_normalize_never_enables_guid_discovery(monkeypatch):
     seen: dict[str, Any] = {}
 
@@ -20,7 +31,14 @@ def test_collection_normalize_never_enables_guid_discovery(monkeypatch):
         seen["row"] = dict(row)
         seen["token"] = token
         seen["allow_discover"] = allow_discover
-        return {"type": row.get("type"), "title": "Attack on Titan", "ids": {"tmdb": "1429"}}
+        return {
+            "type": row.get("type"),
+            "title": "Attack on Titan",
+            "ids": {"tmdb": "1429"},
+            "show_ids": {"tmdb": "1429"},
+            "season": 1,
+            "episode": 1,
+        }
 
     monkeypatch.setattr(collection, "minimal_from_history_row", fake_minimal_from_history_row)
 
@@ -85,3 +103,153 @@ def test_collection_xml_rows_keep_plex_added_at(monkeypatch):
 
     assert row["addedAt"] == 1778748605
     assert item["collected_at"] == "2026-05-14T08:50:05Z"
+
+
+def test_collection_normalize_preserves_show_rows(monkeypatch):
+    def fake_minimal_from_history_row(
+        row: Mapping[str, Any],
+        *,
+        token: str | None = None,
+        allow_discover: bool = False,
+    ) -> dict[str, Any]:
+        return {"type": row.get("type"), "title": "The Expanse", "ids": {"tmdb": "63639"}}
+
+    monkeypatch.setattr(collection, "minimal_from_history_row", fake_minimal_from_history_row)
+
+    item = collection._normalize_row(
+        {"ratingKey": "2", "type": "show", "addedAt": 1787600000},
+        library_id="3",
+        fallback_type="show",
+        token="plex-token",
+    )
+
+    assert item["type"] == "show"
+    assert item["ids"] == {"tmdb": "63639"}
+    assert item["library_id"] == "3"
+
+
+def test_collection_normalize_preserves_season_rows(monkeypatch):
+    def fake_minimal_from_history_row(
+        row: Mapping[str, Any],
+        *,
+        token: str | None = None,
+        allow_discover: bool = False,
+    ) -> dict[str, Any]:
+        return {
+            "type": row.get("type"),
+            "series_title": "The Expanse",
+            "show_ids": {"tmdb": "63639"},
+            "season": 1,
+        }
+
+    monkeypatch.setattr(collection, "minimal_from_history_row", fake_minimal_from_history_row)
+
+    item = collection._normalize_row(
+        {"ratingKey": "3", "type": "season", "title": "Season 1", "addedAt": 1787600000},
+        library_id="3",
+        fallback_type="season",
+        token="plex-token",
+    )
+
+    assert item["type"] == "season"
+    assert item["show_ids"] == {"tmdb": "63639"}
+    assert item["season"] == 1
+    assert item["library_id"] == "3"
+
+
+def test_collection_normalize_skips_season_rows_without_scope(monkeypatch):
+    def fake_minimal_from_history_row(
+        row: Mapping[str, Any],
+        *,
+        token: str | None = None,
+        allow_discover: bool = False,
+    ) -> dict[str, Any]:
+        return {"type": row.get("type"), "title": "Season 1", "ids": {"tmdb": "123"}}
+
+    monkeypatch.setattr(collection, "minimal_from_history_row", fake_minimal_from_history_row)
+
+    item = collection._normalize_row(
+        {"ratingKey": "3", "type": "season", "title": "Season 1"},
+        library_id="3",
+        fallback_type="season",
+        token="plex-token",
+    )
+
+    assert item is None
+
+
+def test_collection_normalize_skips_episode_rows_without_scope(monkeypatch):
+    def fake_minimal_from_history_row(
+        row: Mapping[str, Any],
+        *,
+        token: str | None = None,
+        allow_discover: bool = False,
+    ) -> dict[str, Any]:
+        return {"type": row.get("type"), "title": "Kaamelott", "ids": {"tmdb": "123"}}
+
+    monkeypatch.setattr(collection, "minimal_from_history_row", fake_minimal_from_history_row)
+
+    item = collection._normalize_row(
+        {"ratingKey": "9952", "type": "episode", "title": "Kaamelott"},
+        library_id="3",
+        fallback_type="episode",
+        token="plex-token",
+    )
+
+    assert item is None
+
+
+def test_collection_index_scans_show_libraries_as_shows_seasons_and_episodes(monkeypatch):
+    calls: list[tuple[str, int]] = []
+
+    class Section:
+        key = "3"
+        type = "show"
+
+    class Client:
+        server = object()
+
+    class Adapter:
+        client = Client()
+
+        def libraries(self, types=()):
+            return [Section()]
+
+    def fake_fetch_section_guid_rows(srv: Any, section_id: str, plex_type: int):
+        calls.append((section_id, plex_type))
+        if plex_type == 2:
+            return [{"ratingKey": "2", "type": "show", "title": "The Expanse"}], 1
+        if plex_type == 3:
+            return [{"ratingKey": "3", "type": "season", "title": "Season 1"}], 1
+        if plex_type == 4:
+            return [{"ratingKey": "4", "type": "episode", "title": "Dulcinea"}], 1
+        return [], 0
+
+    def fake_minimal_from_history_row(
+        row: Mapping[str, Any],
+        *,
+        token: str | None = None,
+        allow_discover: bool = False,
+    ) -> dict[str, Any]:
+        if row.get("type") == "show":
+            return {"type": "show", "title": "The Expanse", "ids": {"tmdb": "63639"}}
+        if row.get("type") == "season":
+            return {"type": "season", "series_title": "The Expanse", "show_ids": {"tmdb": "63639"}, "season": 1}
+        return {
+            "type": "episode",
+            "series_title": "The Expanse",
+            "show_ids": {"tmdb": "63639"},
+            "season": 1,
+            "episode": 1,
+            "ids": {"tmdb": "999001"},
+        }
+
+    monkeypatch.setattr(collection, "_fetch_section_guid_rows", fake_fetch_section_guid_rows)
+    monkeypatch.setattr(collection, "minimal_from_history_row", fake_minimal_from_history_row)
+
+    idx = collection.build_index(Adapter())
+
+    assert calls == [("3", 2), ("3", 3), ("3", 4)]
+    assert idx["tmdb:63639"]["type"] == "show"
+    assert idx["tmdb:63639#season:1"]["type"] == "season"
+    assert idx["tmdb:63639#s01e01"]["type"] == "episode"

--- a/providers/tests/test_trakt_collection.py
+++ b/providers/tests/test_trakt_collection.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from typing import Any
 
 from providers.sync.trakt import _collection as collection
+from providers.sync.trakt import _history as history
 
 
 class FakeResp:
@@ -29,23 +30,25 @@ def _adapter() -> SimpleNamespace:
     )
 
 
-def test_collection_index_reads_trakt_movie_and_show_endpoints(monkeypatch: Any) -> None:
+def test_collection_index_reads_trakt_media_endpoint(monkeypatch: Any) -> None:
     calls: list[str] = []
 
-    def fake_request(_sess: Any, method: str, url: str, **_kwargs: Any) -> FakeResp:
+    def fake_request(_sess: Any, method: str, url: str, **kwargs: Any) -> FakeResp:
         calls.append(f"{method} {url}")
-        if url.endswith("/sync/collection/movies"):
+        page = int((kwargs.get("params") or {}).get("page") or 1)
+        if url.endswith("/sync/collection/media") and page == 1:
             return FakeResp(
                 200,
                 [
                     {
+                        "type": "movie",
                         "collected_at": "2026-08-24T20:00:00.000Z",
                         "movie": {"title": "Dune", "year": 2021, "ids": {"tmdb": 438631, "trakt": 1}},
                     }
                 ],
-                {"ETag": "m1"},
+                {"ETag": "m1", "X-Pagination-Page-Count": "2", "X-Pagination-Item-Count": "2"},
             )
-        if url.endswith("/sync/collection/shows"):
+        if url.endswith("/sync/collection/media") and page == 2:
             return FakeResp(
                 200,
                 [
@@ -63,7 +66,7 @@ def test_collection_index_reads_trakt_movie_and_show_endpoints(monkeypatch: Any)
                         ],
                     }
                 ],
-                {"ETag": "s1"},
+                {"ETag": "m1", "X-Pagination-Page-Count": "2", "X-Pagination-Item-Count": "2"},
             )
         return FakeResp(404, {})
 
@@ -75,9 +78,10 @@ def test_collection_index_reads_trakt_movie_and_show_endpoints(monkeypatch: Any)
 
     idx = collection.build_index(_adapter())
 
-    assert "GET https://api.trakt.tv/sync/collection" not in calls
-    assert "GET https://api.trakt.tv/sync/collection/movies" in calls
-    assert "GET https://api.trakt.tv/sync/collection/shows" in calls
+    assert calls == [
+        "GET https://api.trakt.tv/sync/collection/media",
+        "GET https://api.trakt.tv/sync/collection/media",
+    ]
     assert idx["tmdb:438631"]["type"] == "movie"
     assert idx["tmdb:438631"]["collected_at"] == "2026-08-24T20:00:00.000Z"
     assert idx["tmdb:95396#s01e01"]["type"] == "episode"
@@ -94,7 +98,7 @@ def test_collection_write_uses_collection_endpoint_and_shared_nested_body(monkey
     monkeypatch.setattr(collection, "request_with_retries", fake_request)
     monkeypatch.setattr(collection, "_shadow_bust", lambda: None)
 
-    added, unresolved = collection.add(
+    res = collection.add(
         _adapter(),
         [
             {
@@ -109,8 +113,9 @@ def test_collection_write_uses_collection_endpoint_and_shared_nested_body(monkey
         ],
     )
 
-    assert added == 1
-    assert unresolved == []
+    assert res["count"] == 1
+    assert res["confirmed"] == 1
+    assert res["unresolved"] == []
     assert calls[0]["url"] == "https://api.trakt.tv/sync/collection"
     assert calls[0]["json"] == {
         "shows": [
@@ -119,9 +124,95 @@ def test_collection_write_uses_collection_endpoint_and_shared_nested_body(monkey
                 "seasons": [
                     {
                         "number": 1,
-                        "episodes": [{"number": 2, "collected_at": "2026-01-02T03:04:05Z"}],
+                        "episodes": [{"number": 2, "watched_at": "2026-01-02T03:04:05Z"}],
                     }
                 ],
             }
         ]
     }
+
+
+def test_collection_write_reports_existing_as_skipped_not_added(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_request(_sess: Any, method: str, url: str, **kwargs: Any) -> FakeResp:
+        calls.append({"method": method, "url": url, "json": kwargs.get("json")})
+        return FakeResp(201, {"added": {}, "existing": {"movies": 1}, "not_found": {}})
+
+    monkeypatch.setattr(collection, "request_with_retries", fake_request)
+    monkeypatch.setattr(collection, "_shadow_bust", lambda: None)
+
+    res = collection.add(
+        _adapter(),
+        [
+            {
+                "type": "movie",
+                "title": "Dune",
+                "ids": {"tmdb": "438631"},
+                "collected_at": "2026-01-02T03:04:05Z",
+            }
+        ],
+    )
+
+    assert res["count"] == 0
+    assert res["confirmed"] == 0
+    assert res["skipped"] == 1
+    assert res["skipped_keys"] == ["tmdb:438631"]
+    assert res["unresolved"] == []
+
+
+def test_collection_write_small_delta_maps_existing_and_not_found_exactly(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_request(_sess: Any, method: str, url: str, **kwargs: Any) -> FakeResp:
+        payload = kwargs.get("json") or {}
+        calls.append({"method": method, "url": url, "json": payload})
+        movies = payload.get("movies") or []
+        tmdb = str((((movies[0] if movies else {}).get("ids") or {}).get("tmdb") or ""))
+        if tmdb == "438631":
+            return FakeResp(201, {"added": {}, "existing": {"movies": 1}, "not_found": {}})
+        return FakeResp(201, {"added": {}, "existing": {}, "not_found": {"movies": [{"tmdb": int(tmdb)}]}})
+
+    monkeypatch.setattr(collection, "request_with_retries", fake_request)
+    monkeypatch.setattr(collection, "_shadow_bust", lambda: None)
+
+    res = collection.add(
+        _adapter(),
+        [
+            {"type": "movie", "title": "Dune", "ids": {"tmdb": "438631"}},
+            {"type": "movie", "title": "Missing", "ids": {"tmdb": "999999"}},
+        ],
+    )
+
+    assert len(calls) == 2
+    assert res["count"] == 0
+    assert res["confirmed"] == 0
+    assert res["skipped"] == 1
+    assert res["skipped_keys"] == ["tmdb:438631"]
+    assert res["unresolved"][0]["key"] == "tmdb:999999"
+
+
+def test_history_add_to_library_uses_trakt_collection_write_date_field() -> None:
+    body = {
+        "movies": [
+            {"ids": {"tmdb": "438631"}, "watched_at": "2026-01-02T03:04:05Z"},
+        ],
+        "shows": [
+            {
+                "ids": {"tmdb": "95396"},
+                "seasons": [
+                    {
+                        "number": 1,
+                        "episodes": [{"number": 2, "watched_at": "2026-01-03T03:04:05Z"}],
+                    }
+                ],
+            }
+        ],
+    }
+
+    out = history._history_body_to_collection(body, {"movies", "shows"})
+
+    assert out["movies"][0]["watched_at"] == "2026-01-02T03:04:05Z"
+    assert "collected_at" not in out["movies"][0]
+    assert out["shows"][0]["seasons"][0]["episodes"][0]["watched_at"] == "2026-01-03T03:04:05Z"
+    assert "collected_at" not in out["shows"][0]["seasons"][0]["episodes"][0]

--- a/tests/test_collection_scope_safety.py
+++ b/tests/test_collection_scope_safety.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from cw_platform.orchestrator import _pairs_oneway as oneway
 
 
@@ -72,3 +74,12 @@ def test_config_loader_normalizes_collection_types_to_movies_by_default() -> Non
     out = _normalize_features_map({"collection": {"enable": True, "add": True, "remove": True}})
 
     assert out["collection"]["types"] == ["movies"]
+
+
+def test_pair_config_allows_server_collection_show_and_season_scope() -> None:
+    js = (Path(__file__).resolve().parents[1] / "assets" / "js" / "modals" / "pair-config" / "custom-rules.js").read_text(encoding="utf-8")
+
+    assert 'PLEX: ["movies", "shows", "seasons", "episodes"]' in js
+    assert 'EMBY: ["movies", "shows", "seasons", "episodes"]' in js
+    assert 'JELLYFIN: ["movies", "shows", "seasons", "episodes"]' in js
+    assert 'PUNCHPLAY: ["movies", "shows", "seasons"]' in js


### PR DESCRIPTION
# Pull request

## Change

- Expand collection sync support for Plex, Emby, Jellyfin, and Trakt.
- Adds show and season collection indexing for media-server sources, updates pair-config scope rules, and improves Trakt collection reads/writes.

## Why

- Collections should support the same media scopes users can actually own and sync: movies, shows, seasons, and episodes where supported.

## Testing

- providers/tests/test_emby_collection.py 
- providers/tests/test_jellyfin_collection.py 
- providers/tests/test_plex_collection.py 
- providers/tests/test_trakt_collection.py 
- tests/test_collection_scope_safety.py

## Issue

Relates to #866