### PR TITLE
Add: simple collections page

### DIFF
--- a/api/profileAPI.py
+++ b/api/profileAPI.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude
 from __future__ import annotations
 
+from collections import OrderedDict
 from typing import Any
 
 import base64
@@ -11,9 +12,10 @@ import secrets
 import time
 import urllib.parse
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 
-from fastapi import APIRouter, Body, Request
+from fastapi import APIRouter, Body, Query, Request
 from fastapi.responses import FileResponse, JSONResponse, Response
 
 from api.appAuthAPI import (
@@ -45,9 +47,12 @@ from api.appAuthAPI import (
     _totp_verify,
     clean_user_preferences,
     current_user,
+    effective_user_profile_id,
 )
 from cw_platform.config_base import CONFIG as CONFIG_DIR, load_config, update_config
-from cw_platform.provider_instances import list_user_profiles
+from cw_platform.id_map import canonical_key
+from cw_platform.orchestrator._state_store import StateStore
+from cw_platform.provider_instances import instances_for_user_profile, list_user_profiles, normalize_instance_id, provider_display_key
 
 router = APIRouter(prefix="/api/profile", tags=["profile"])
 
@@ -265,6 +270,401 @@ def _generate_recovery_codes(raw: dict[str, Any]) -> list[str]:
     codes = [f"{secrets.token_hex(5).upper()}-{secrets.token_hex(5).upper()}" for _ in range(10)]
     raw["recovery_codes"] = [_password_hash(code) for code in codes]
     return codes
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _collection_state() -> dict[str, Any]:
+    try:
+        state = StateStore(CONFIG_DIR).load_state_features({"collection"}) or {}
+        return state if isinstance(state, dict) else {}
+    except Exception:
+        return {}
+
+
+def _collection_baseline_items(node: Any) -> dict[str, Any]:
+    baseline = _as_dict(_as_dict(_as_dict(node).get("collection")).get("baseline"))
+    items = baseline.get("items")
+    return items if isinstance(items, dict) else {}
+
+
+def _iter_collection_baselines(state: dict[str, Any]):
+    providers = _as_dict(state.get("providers"))
+    for provider, pnode in providers.items():
+        prov = provider_display_key(provider)
+        items = _collection_baseline_items(pnode)
+        if items:
+            yield prov, "default", items
+        for instance, inode in _as_dict(_as_dict(pnode).get("instances")).items():
+            items = _collection_baseline_items(inode)
+            if items:
+                yield prov, normalize_instance_id(instance), items
+
+
+def _collection_user_filter(cfg: dict[str, Any], profile_id: str) -> dict[str, set[str]]:
+    raw = instances_for_user_profile(cfg, profile_id) if profile_id else {}
+    return {
+        provider_display_key(provider): {normalize_instance_id(inst) for inst in (instances or [])}
+        for provider, instances in raw.items()
+    }
+
+
+def _collection_source_allowed(user_filter: dict[str, set[str]], provider: str, instance: str) -> bool:
+    if not user_filter:
+        return True
+    return normalize_instance_id(instance) in user_filter.get(provider_display_key(provider), set())
+
+
+def _collection_media_type(item: dict[str, Any]) -> str:
+    raw = str(item.get("type") or item.get("media_type") or item.get("art_type") or "").strip().lower()
+    if raw in {"movie", "movies"}:
+        return "movie"
+    if raw in {"season", "seasons"}:
+        return "season"
+    if raw in {"episode", "episodes", "anime_episode"}:
+        return "episode"
+    if raw in {"show", "shows", "tv", "series", "anime"}:
+        return "show"
+    if item.get("episode") is not None or item.get("episode_number") is not None:
+        return "episode"
+    if item.get("season") is not None or item.get("season_number") is not None:
+        return "season"
+    return raw or "movie"
+
+
+def _collection_date_sort(value: Any) -> float:
+    if value is None:
+        return 0.0
+    try:
+        ts = float(value)
+        if ts > 100000000000:
+            ts = ts / 1000
+        if ts > 0:
+            return ts
+    except Exception:
+        pass
+    raw = str(value or "").strip()
+    if not raw:
+        return 0.0
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except Exception:
+        return 0.0
+
+
+def _collection_first_text(item: dict[str, Any], keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = item.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def _collection_ids(item: dict[str, Any]) -> dict[str, Any]:
+    ids = item.get("ids")
+    out = dict(ids) if isinstance(ids, dict) else {}
+    for key in ("tmdb", "imdb", "tvdb", "trakt", "simkl", "mdblist"):
+        for raw_key in (key, f"{key}_id"):
+            if raw_key in item and item.get(raw_key) not in (None, ""):
+                out.setdefault(key, item.get(raw_key))
+    return out
+
+
+def _collection_item_key(raw_key: Any, item: dict[str, Any]) -> str:
+    try:
+        key = canonical_key(item)
+    except Exception:
+        key = ""
+    key = str(key or "").strip().lower()
+    if key and key != "unknown:":
+        return key
+    return str(raw_key or "").strip().lower() or "unknown:"
+
+
+def _collection_add_unique(target: list[Any], value: Any) -> None:
+    if value in (None, ""):
+        return
+    if value not in target:
+        target.append(value)
+
+
+def _collection_merge_group(group: dict[str, Any], item: dict[str, Any], *, raw_key: str, provider: str, instance: str) -> None:
+    ids = _collection_ids(item)
+    base = group.setdefault("ids", {})
+    if isinstance(base, dict):
+        for key, value in ids.items():
+            if value not in (None, ""):
+                base.setdefault(key, value)
+    for key in ("title", "series_title", "show_title", "name", "year", "release_year", "season", "season_number", "episode", "episode_number", "overview"):
+        if group.get(key) in (None, "") and item.get(key) not in (None, ""):
+            group[key] = item.get(key)
+    raw_show_ids = item.get("show_ids")
+    if isinstance(raw_show_ids, dict) and raw_show_ids:
+        show_ids = group.setdefault("show_ids", {})
+        if isinstance(show_ids, dict):
+            for key, value in raw_show_ids.items():
+                if value not in (None, ""):
+                    show_ids.setdefault(str(key), value)
+    for key in ("poster", "poster_url", "cover", "poster_cover", "backdrop_url", "background_url", "fanart"):
+        if group.get(key) in (None, "") and item.get(key):
+            group[key] = item.get(key)
+    media_type = _collection_media_type(item)
+    if group.get("type") in (None, ""):
+        group["type"] = media_type
+    collected_at = _collection_first_text(item, ("collected_at", "added_at", "date_added", "created_at", "datecreated", "date"))
+    library = _collection_first_text(item, ("library_title", "library_name", "section_title", "section_name", "collection_name"))
+    source = {
+        "provider": provider,
+        "instance": normalize_instance_id(instance),
+        "key": raw_key,
+        "collected_at": collected_at,
+    }
+    if library:
+        source["library"] = library
+    sources = group.setdefault("collection_sources", [])
+    if isinstance(sources, list):
+        sources.append(source)
+    by_provider = group.setdefault("sources_by_provider", {})
+    if isinstance(by_provider, dict):
+        insts = by_provider.setdefault(provider.lower(), [])
+        if isinstance(insts, list):
+            _collection_add_unique(insts, normalize_instance_id(instance))
+    libraries = group.setdefault("libraries", [])
+    if isinstance(libraries, list):
+        _collection_add_unique(libraries, library)
+    dates = group.setdefault("_collection_dates", [])
+    if isinstance(dates, list):
+        _collection_add_unique(dates, collected_at)
+
+
+def _collection_finalize_group(key: str, group: dict[str, Any]) -> dict[str, Any]:
+    dates = [d for d in group.pop("_collection_dates", []) if d]
+    dates_sorted = sorted(dates, key=_collection_date_sort)
+    sources = group.get("collection_sources") if isinstance(group.get("collection_sources"), list) else []
+    providers = sorted({str(src.get("provider") or "").lower() for src in sources if isinstance(src, dict) and src.get("provider")})
+    instances = sorted({
+        f"{str(src.get('provider') or '').lower()}:{normalize_instance_id(src.get('instance'))}"
+        for src in sources if isinstance(src, dict) and src.get("provider")
+    })
+    out = dict(group)
+    out["key"] = key
+    out["collection_key"] = key
+    out["type"] = _collection_media_type(out)
+    out["title"] = _collection_first_text(out, ("title", "series_title", "show_title", "name")) or "Untitled"
+    out["providers"] = providers
+    out["owned_provider_count"] = len(providers)
+    out["owned_instance_count"] = len(instances)
+    out["owned_count"] = len(sources)
+    show_ids = out.get("show_ids")
+    if isinstance(show_ids, dict) and show_ids and out["type"] in {"episode", "season"}:
+        ids = out.get("ids")
+        if not isinstance(ids, dict):
+            ids = {}
+        else:
+            ids = dict(ids)
+        for src, dst in (("tmdb", "tmdb_show"), ("imdb", "imdb_show"), ("tvdb", "tvdb_show")):
+            value = show_ids.get(src)
+            if value not in (None, "") and not ids.get(dst):
+                ids[dst] = value
+        out["ids"] = ids
+    out["first_collected_at"] = dates_sorted[0] if dates_sorted else ""
+    out["last_collected_at"] = dates_sorted[-1] if dates_sorted else ""
+    out["collected_at"] = out["last_collected_at"]
+    out["sources"] = providers
+    return out
+
+
+_COLLECTION_INDEX_CACHE: "OrderedDict[tuple, tuple[list[dict[str, Any]], dict[str, int], dict[str, int]]]" = OrderedDict()
+_COLLECTION_INDEX_CACHE_MAX = 8
+
+
+def _build_collection_index(
+    state: dict[str, Any],
+    cfg: dict[str, Any],
+    profile_id: str,
+) -> tuple[list[dict[str, Any]], dict[str, int], dict[str, int]]:
+    user_filter = _collection_user_filter(cfg, profile_id)
+    if profile_id and not user_filter:
+        user_filter = {"__NONE__": {"__NONE__"}}
+    groups: dict[str, dict[str, Any]] = {}
+    for prov, inst, items in _iter_collection_baselines(state):
+        if not _collection_source_allowed(user_filter, prov, inst):
+            continue
+        for raw_key, raw_item in items.items():
+            if not isinstance(raw_item, dict):
+                continue
+            item = dict(raw_item)
+            key = _collection_item_key(raw_key, item)
+            _collection_merge_group(groups.setdefault(key, {}), item, raw_key=str(raw_key), provider=prov, instance=inst)
+    items = [_collection_finalize_group(key, group) for key, group in groups.items()]
+    counts: dict[str, int] = {"all": len(items), "movie": 0, "show": 0, "season": 0, "episode": 0}
+    provider_counts: dict[str, int] = {}
+    for item in items:
+        typ = _collection_media_type(item)
+        counts[typ] = counts.get(typ, 0) + 1
+        for prov in item.get("providers") or []:
+            provider_counts[str(prov).lower()] = provider_counts.get(str(prov).lower(), 0) + 1
+    return items, counts, provider_counts
+
+
+def _collection_index(
+    state: dict[str, Any] | Any,
+    cfg: dict[str, Any],
+    profile_id: str,
+    cache_key: tuple | None,
+) -> tuple[list[dict[str, Any]], dict[str, int], dict[str, int]]:
+    if cache_key is None:
+        return _build_collection_index(state() if callable(state) else state, cfg, profile_id)
+    key = (profile_id, *cache_key)
+    hit = _COLLECTION_INDEX_CACHE.get(key)
+    if hit is None:
+        hit = _build_collection_index(state() if callable(state) else state, cfg, profile_id)
+        _COLLECTION_INDEX_CACHE[key] = hit
+        while len(_COLLECTION_INDEX_CACHE) > _COLLECTION_INDEX_CACHE_MAX:
+            _COLLECTION_INDEX_CACHE.popitem(last=False)
+    else:
+        _COLLECTION_INDEX_CACHE.move_to_end(key)
+    items, counts, provider_counts = hit
+    return list(items), dict(counts), dict(provider_counts)
+
+
+def collection_cache_fingerprint() -> tuple:
+    """Cheap signature of the collection inputs: sync epoch, db writes, config."""
+    epoch = None
+    try:
+        epoch = StateStore(CONFIG_DIR).last_sync_epoch()
+    except Exception:
+        epoch = None
+    stamp = 0.0
+    try:
+        from cw_platform.local_db.db import crosswatch_db_path
+
+        db = Path(str(crosswatch_db_path(CONFIG_DIR)))
+        for candidate in (db, db.with_name(db.name + "-wal")):
+            try:
+                stamp = max(stamp, candidate.stat().st_mtime)
+            except OSError:
+                continue
+    except Exception:
+        stamp = 0.0
+    cfg_stamp = 0.0
+    try:
+        cfg_stamp = (Path(CONFIG_DIR) / "config.json").stat().st_mtime
+    except OSError:
+        cfg_stamp = 0.0
+    return (epoch, round(stamp, 3), round(cfg_stamp, 3))
+
+
+def build_profile_collection_payload(
+    state: dict[str, Any] | Any,
+    cfg: dict[str, Any],
+    *,
+    profile_id: str = "",
+    media_type: str = "all",
+    provider: str = "",
+    search: str = "",
+    sort: str = "collected_at",
+    page: int = 1,
+    page_size: int = 48,
+    cache_key: tuple | None = None,
+) -> dict[str, Any]:
+    items, counts, provider_counts = _collection_index(state, cfg, profile_id, cache_key)
+    wanted_type = str(media_type or "all").strip().lower()
+    if wanted_type not in {"", "all"}:
+        items = [item for item in items if _collection_media_type(item) == wanted_type]
+    wanted_provider = str(provider or "").strip().lower()
+    if wanted_provider:
+        items = [item for item in items if wanted_provider in {str(prov).lower() for prov in item.get("providers") or []}]
+    needle = str(search or "").strip().lower()
+    if needle:
+        def _match(item: dict[str, Any]) -> bool:
+            hay = " ".join(
+                str(value or "")
+                for value in (
+                    item.get("title"),
+                    item.get("series_title"),
+                    item.get("show_title"),
+                    item.get("year"),
+                    item.get("key"),
+                    " ".join(str(p) for p in item.get("providers") or []),
+                    " ".join(str(lib) for lib in item.get("libraries") or []),
+                )
+            ).lower()
+            return needle in hay
+        items = [item for item in items if _match(item)]
+    def _title_key(item: dict[str, Any]) -> str:
+        return str(item.get("title") or "").lower()
+
+    def _year_key(item: dict[str, Any]) -> int:
+        try:
+            return int(str(item.get("year") or 0)[:4])
+        except (TypeError, ValueError):
+            return 0
+
+    wanted_sort = str(sort or "collected_at").strip().lower()
+    if wanted_sort == "title":
+        items.sort(key=lambda item: (_title_key(item), _year_key(item)))
+    elif wanted_sort == "title_desc":
+        items.sort(key=lambda item: (_title_key(item), _year_key(item)), reverse=True)
+    elif wanted_sort == "collected_at_asc":
+        items.sort(key=lambda item: (_collection_date_sort(item.get("last_collected_at")), _title_key(item)))
+    elif wanted_sort == "year_desc":
+        items.sort(key=lambda item: (_year_key(item), _collection_date_sort(item.get("last_collected_at"))), reverse=True)
+    elif wanted_sort == "year_asc":
+        items.sort(key=lambda item: (_year_key(item) or 9999, _title_key(item)))
+    else:
+        items.sort(key=lambda item: (_collection_date_sort(item.get("last_collected_at")), _title_key(item)), reverse=True)
+    page = max(1, int(page or 1))
+    page_size = min(120, max(1, int(page_size or 48)))
+    total = len(items)
+    start = (page - 1) * page_size
+    end = start + page_size
+    return {
+        "ok": True,
+        "items": items[start:end],
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "has_more": end < total,
+        "counts": counts,
+        "providers": [{"provider": key, "count": count} for key, count in sorted(provider_counts.items())],
+    }
+
+
+@router.get("/collection")
+def api_profile_collection(
+    request: Request,
+    media_type: str = Query("all", alias="type"),
+    provider: str = Query(""),
+    search: str = Query(""),
+    sort: str = Query("collected_at"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(48, ge=1, le=120),
+    user_profile: str = Query(""),
+) -> JSONResponse:
+    ctx = _profile_context(request)
+    if isinstance(ctx, JSONResponse):
+        return ctx
+    cfg, _a, _uid, _raw, _user, token = ctx
+    profile_id = effective_user_profile_id(cfg, token, user_profile)
+    payload = build_profile_collection_payload(
+        _collection_state,
+        cfg,
+        profile_id=profile_id,
+        media_type=media_type,
+        provider=provider,
+        search=search,
+        sort=sort,
+        page=page,
+        page_size=page_size,
+        cache_key=collection_cache_fingerprint(),
+    )
+    return JSONResponse(payload, headers={"Cache-Control": "no-store"})
 
 
 @router.get("")

--- a/assets/css/profile-page.css
+++ b/assets/css/profile-page.css
@@ -5,9 +5,7 @@
 html.cw-theme-light{--profile-bg:#f5f7fb;--profile-panel:rgba(255,255,255,.9);--profile-panel-2:rgba(244,247,252,.88);--profile-line:rgba(30,41,59,.16);--profile-text:#172033;--profile-muted:#617086;--profile-accent:#5266d6;--profile-good:#148a60;--profile-danger:#c83d55}
 html[data-cw-theme="flat-dark"] body.cw-profile-page{--profile-bg:#090A0D;--profile-panel:#101217;--profile-panel-2:#15181E;--profile-panel-3:#191C23;--profile-line:#292D36;--profile-line-strong:#3A3F4A;--profile-hover:#20242C;--profile-text:#F1F3F5;--profile-muted:#9299A6}
 body.cw-profile-page{margin:0;background:var(--profile-bg);color:var(--profile-text);min-height:100vh}
-.cw-profile-topbar{position:sticky;top:0;z-index:20;display:flex;align-items:center;gap:18px;min-height:0;padding:10px 16px;border-bottom:1px solid var(--profile-line);background:rgba(5,8,13,.86);backdrop-filter:blur(16px) saturate(120%)}
-html.cw-theme-light .cw-profile-topbar{background:rgba(255,255,255,.86)}
-.cw-profile-topbar .brand{display:flex;align-items:center;gap:10px;color:inherit;text-decoration:none}.cw-profile-topbar .logo{width:32px;height:32px}.cw-profile-topbar .brand-text{display:flex;align-items:baseline;gap:8px}.cw-profile-topbar .name{font-weight:950;font-size:19px}.cw-profile-topbar .version{font-size:11px;color:var(--profile-muted);font-weight:800}.cw-profile-topbar .tabs{margin-left:auto;display:flex;align-items:center;gap:4px}.cw-profile-topbar .tabs a,.cw-profile-topbar .tabs button{border:0;background:transparent;color:var(--profile-muted);text-decoration:none;font-weight:850;font-size:14px;padding:0 12px;border-radius:0;cursor:pointer}.cw-profile-topbar .tabs a:hover,.cw-profile-topbar .tabs button:hover{background:rgba(139,124,255,.12);color:var(--profile-text)}.cw-profile-topbar .tabs .cw-tabmenu{position:relative;display:flex;align-items:center}.cw-profile-topbar .tabs .cw-tabmenu>.tab{display:flex;align-items:center;gap:3px}.cw-profile-topbar .tabs .cw-menu{top:calc(100% + 8px);right:0}.cw-profile-topbar .tabs .cw-menu .cw-menu-item{width:100%;justify-content:flex-start;text-align:left}.cw-profile-topbar .tabs .cw-nav-profile-link{width:32px!important;height:32px!important;min-width:32px!important;min-height:32px!important;max-width:32px!important;max-height:32px!important;flex:0 0 32px!important;padding:0!important;border-radius:50%}.cw-profile-topbar .tabs .cw-nav-profile-link:hover{background:linear-gradient(180deg,rgba(255,255,255,.09),rgba(255,255,255,.03));color:#a9bcff}
+body.cw-profile-page header .brand{color:inherit;text-decoration:none}
 .cw-profile-shell{width:calc(100vw - 40px);max-width:none;margin:0 auto 40px}.cw-profile-hero{position:relative;min-height:270px;border:1px solid rgba(139,124,255,.26);border-radius:22px;overflow:hidden;background:radial-gradient(900px 360px at 70% 0,rgba(139,124,255,.18),transparent 62%),var(--profile-panel-2);box-shadow:0 22px 52px rgba(0,0,0,.28)}
 .cw-profile-hero-art{position:absolute;inset:0;background-size:cover;background-position:center;opacity:0;filter:saturate(1.08);transition:opacity .2s ease}.cw-profile-hero.has-last .cw-profile-hero-art{opacity:.78}.cw-profile-hero-art:after{content:"";position:absolute;inset:0;background:linear-gradient(90deg,rgba(8,12,19,1),rgba(8,12,19,.72) 24%,rgba(8,12,19,.18) 58%,rgba(8,12,19,.52)),linear-gradient(0deg,rgba(8,12,19,.76),transparent 46%)}.cw-profile-hero-shade{position:absolute;inset:0;background:linear-gradient(90deg,rgba(8,12,19,.96),rgba(8,12,19,.72) 46%,rgba(8,12,19,.08))}html.cw-theme-light .cw-profile-hero-shade{background:linear-gradient(90deg,rgba(246,248,252,.96),rgba(246,248,252,.74) 46%,rgba(246,248,252,.16))}html.cw-theme-light .cw-profile-hero-art:after{background:linear-gradient(90deg,rgba(246,248,252,1),rgba(246,248,252,.7) 24%,rgba(246,248,252,.18) 58%,rgba(246,248,252,.48)),linear-gradient(0deg,rgba(246,248,252,.64),transparent 46%)}
 .cw-profile-identity{position:relative;z-index:2;display:flex;align-items:center;gap:24px;padding:52px 46px}.cw-profile-avatar-wrap{position:relative;display:inline-grid;place-items:center}.cw-profile-avatar{width:138px;height:138px;border-radius:50%;border:4px solid var(--profile-accent);background:linear-gradient(180deg,rgba(255,255,255,.08),rgba(255,255,255,.02)),#151b27;display:grid;place-items:center;overflow:hidden;color:#b8c5ff;box-shadow:0 18px 42px rgba(0,0,0,.38);cursor:pointer}.cw-profile-avatar img{width:100%;height:100%;object-fit:cover}.cw-profile-avatar .material-symbols-rounded{display:grid;place-items:center;width:100%;height:100%;font-size:82px!important;line-height:1}.cw-profile-avatar-badge{position:absolute;right:4px;bottom:7px;z-index:2;display:grid!important;place-items:center;width:38px;height:38px;border-radius:50%;border:2px solid rgba(255,255,255,.86);background:linear-gradient(135deg,#a16cff,var(--profile-accent));color:#fff;font-size:20px!important;line-height:1!important;box-shadow:0 12px 24px rgba(0,0,0,.34),0 0 0 4px rgba(8,12,19,.2);pointer-events:none;font-variation-settings:"FILL" 1,"wght" 600,"GRAD" 0,"opsz" 24}.cw-profile-avatar:hover+.cw-profile-avatar-badge,.cw-profile-avatar:focus-visible+.cw-profile-avatar-badge{transform:translateY(-1px);box-shadow:0 14px 28px rgba(0,0,0,.38),0 0 0 4px rgba(139,124,255,.18)}html[data-cw-theme="flat-light"] body.cw-profile-page .cw-profile-avatar-badge{border-color:#fff;box-shadow:0 10px 22px rgba(30,41,59,.2),0 0 0 4px rgba(255,255,255,.78)}html[data-cw-theme="flat-dark"] body.cw-profile-page .cw-profile-avatar-badge{background:#7d86c9;box-shadow:0 12px 24px rgba(0,0,0,.28),0 0 0 4px rgba(13,15,20,.78)}html.cw-theme-original body.cw-profile-page .cw-profile-avatar-badge{background:linear-gradient(135deg,#ad7cff,#725cff);box-shadow:0 12px 26px rgba(0,0,0,.34),0 0 18px rgba(139,124,255,.28)}.cw-profile-role{display:inline-flex;align-items:center;height:24px;padding:0 10px;border-radius:999px;background:rgba(139,124,255,.72);color:#fff;font-size:11px;font-weight:950;letter-spacing:.08em;text-transform:uppercase}.cw-profile-nameblock h1{margin:12px 0 6px;font-size:clamp(34px,4vw,58px);line-height:1;letter-spacing:0}.cw-profile-username{color:var(--profile-muted);font-size:16px;font-weight:750}
@@ -21,8 +19,7 @@ html.cw-theme-light .cw-profile-topbar{background:rgba(255,255,255,.86)}
 .cw-profile-upload{display:grid;gap:8px;margin-top:12px;padding:10px;border:1px solid var(--profile-line);border-radius:12px;background:rgba(255,255,255,.035)}.cw-profile-upload.hidden{display:none}.cw-profile-upload-head{display:flex;align-items:center;justify-content:space-between;gap:12px;color:var(--profile-muted);font-size:12px;font-weight:850}.cw-profile-upload-head strong{color:var(--profile-text)}.cw-profile-upload-bar{height:7px;overflow:hidden;border-radius:999px;background:rgba(255,255,255,.08)}.cw-profile-upload-bar span{display:block;width:0;height:100%;border-radius:inherit;background:linear-gradient(90deg,var(--profile-accent),#a78bfa,#8b5cf6);transition:width .18s ease}
 .cw-profile-toast{position:fixed;right:22px;bottom:22px;z-index:50;max-width:340px;padding:12px 14px;border:1px solid var(--profile-line);border-radius:14px;background:var(--profile-panel);box-shadow:0 18px 42px rgba(0,0,0,.32);font-weight:850}.cw-profile-toast.error{border-color:rgba(239,95,115,.55);color:#ffd6dd}.cw-profile-toast.hidden{display:none}
 @media(max-width:1100px){.cw-profile-widget-grid,.cw-profile-security-grid{grid-template-columns:1fr 1fr}.cw-profile-widget--wide{grid-column:1/-1}.cw-profile-quick-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.cw-profile-hero-art{width:100%}.cw-profile-last{position:relative;right:auto;bottom:auto;width:auto;margin:0 24px 24px}.cw-profile-identity{padding-bottom:28px}.cw-profile-hero-shade{background:linear-gradient(0deg,rgba(8,12,19,.9),rgba(8,12,19,.5))}}
-@media(max-width:720px){.cw-profile-shell{width:calc(100vw - 22px);margin-top:0}.cw-profile-topbar{padding:9px 12px}.cw-profile-topbar .brand-text .version{display:none}.cw-profile-topbar .tabs{gap:2px}.cw-profile-topbar .tabs a,.cw-profile-topbar .tabs button{font-size:12px;padding:0 8px}.cw-profile-identity{padding:28px 22px;align-items:flex-start;flex-direction:column}.cw-profile-avatar{width:104px;height:104px}.cw-profile-avatar .material-symbols-rounded{font-size:64px!important}.cw-profile-avatar-badge{right:0;bottom:5px;width:32px;height:32px;font-size:17px!important}.cw-profile-widget-grid,.cw-profile-security-grid,.cw-profile-quick-grid{grid-template-columns:1fr}.cw-profile-poster-row,.cw-profile-poster-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.cw-profile-tabs button{flex:1;padding:0 12px}.cw-profile-qr{grid-template-columns:1fr;justify-items:start}.cw-profile-qr-code{width:160px;height:160px}.cw-profile-qr-verify{grid-template-columns:1fr}}
-.cw-profile-topbar .tabs .cw-nav-profile-link{display:inline-grid!important;place-items:center!important;width:32px!important;height:32px!important;min-width:32px!important;min-height:32px!important;max-width:32px!important;max-height:32px!important;flex:0 0 32px!important;padding:0!important;border-radius:50%!important;border:1px solid rgba(255,255,255,.12);background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.02));box-shadow:inset 0 1px 0 rgba(255,255,255,.035);color:#a9bcff;text-decoration:none;overflow:hidden!important}.cw-profile-topbar .tabs .cw-nav-profile-avatar{display:grid!important;place-items:center!important;width:100%!important;height:100%!important;min-width:0!important;min-height:0!important;max-width:100%!important;max-height:100%!important;font-size:21px!important;line-height:1!important;text-align:center;overflow:hidden!important}.cw-profile-topbar .tabs .cw-nav-profile-avatar img{display:block!important;width:100%!important;height:100%!important;min-width:0!important;min-height:0!important;max-width:100%!important;max-height:100%!important;object-fit:cover!important;border-radius:50%!important}
+@media(max-width:720px){.cw-profile-shell{width:calc(100vw - 22px);margin-top:0}.cw-profile-identity{padding:28px 22px;align-items:flex-start;flex-direction:column}.cw-profile-avatar{width:104px;height:104px}.cw-profile-avatar .material-symbols-rounded{font-size:64px!important}.cw-profile-avatar-badge{right:0;bottom:5px;width:32px;height:32px;font-size:17px!important}.cw-profile-widget-grid,.cw-profile-security-grid,.cw-profile-quick-grid{grid-template-columns:1fr}.cw-profile-poster-row,.cw-profile-poster-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.cw-profile-tabs button{flex:1;padding:0 12px}.cw-profile-qr{grid-template-columns:1fr;justify-items:start}.cw-profile-qr-code{width:160px;height:160px}.cw-profile-qr-verify{grid-template-columns:1fr}}
 /* Hero: live scrobble layer crossfading into the last-watched artwork */
 .cw-profile-hero-now{position:absolute;inset:0;background-size:cover;background-position:center;opacity:0;filter:saturate(1.06);transition:opacity .28s ease}
 .cw-profile-hero.is-playing .cw-profile-hero-now{opacity:.74}
@@ -75,6 +72,7 @@ html.cw-theme-light .cw-profile-now{background:rgba(255,255,255,.5)}
 .cw-profile-widget .cw-profile-stat--tv{--profile-stat-rgb:58,143,255}
 .cw-profile-widget .cw-profile-stat--anime{--profile-stat-rgb:45,206,209}
 .cw-profile-widget .cw-profile-stat--episodes{--profile-stat-rgb:56,203,123}
+.cw-profile-stat--collections{--profile-stat-rgb:56,203,123}
 .cw-profile-widget .cw-profile-stat--watchlist{--profile-stat-rgb:255,157,42}
 .cw-profile-widget .cw-profile-stat--hours{--profile-stat-rgb:238,76,137}
 html[data-cw-theme="flat-dark"] body.cw-profile-page .cw-profile-widget .cw-profile-stat{background:#20242d;border-color:rgba(var(--profile-stat-rgb),.3);box-shadow:none}
@@ -83,8 +81,6 @@ html[data-cw-theme="flat-light"] body.cw-profile-page .cw-profile-widget .cw-pro
 html[data-cw-theme="flat-light"] body.cw-profile-page .cw-profile-widget .cw-profile-stat>.material-symbols-rounded{background:rgba(var(--profile-stat-rgb),.12);box-shadow:none}
 html[data-cw-theme="flat-light"] body.cw-profile-page .cw-profile-widget .cw-profile-stat::after{color:rgba(var(--profile-stat-rgb),.1)}
 html.cw-theme-original body.cw-profile-page .cw-profile-widget .cw-profile-stat{background:linear-gradient(135deg,rgba(12,18,31,.96),rgba(17,22,34,.88));border-color:rgba(var(--profile-stat-rgb),.34);box-shadow:0 16px 34px rgba(0,0,0,.22)}
-html[data-cw-theme="flat-dark"] body.cw-profile-page .cw-profile-topbar{background:#090A0D;border-color:var(--profile-line);box-shadow:none;backdrop-filter:none;-webkit-backdrop-filter:none}
-html[data-cw-theme="flat-dark"] body.cw-profile-page .cw-profile-topbar .tabs :is(a,button):hover{background:var(--profile-hover);color:var(--profile-text)}
 html[data-cw-theme="flat-dark"] body.cw-profile-page .cw-profile-hero{border-color:var(--profile-line);background:var(--profile-panel);background-image:none;box-shadow:none}
 html[data-cw-theme="flat-dark"] body.cw-profile-page .cw-profile-hero.has-last .cw-profile-hero-art,
 html[data-cw-theme="flat-dark"] body.cw-profile-page .cw-profile-hero.has-now .cw-profile-hero-now{opacity:.5;filter:saturate(.95) contrast(1.02)}
@@ -152,6 +148,144 @@ html[data-cw-theme="flat-light"] body.cw-profile-page #profile-progress .cw-cw-e
 .cw-cw-pct{flex:0 0 auto;color:var(--profile-muted);font-size:12px;font-weight:850;font-variant-numeric:tabular-nums}
 @media(prefers-reduced-motion:reduce){.cw-cw-card{transition:none}}
 @media(max-width:720px){.cw-cw-art{aspect-ratio:16/10}}
+#profile-panel-collection{--cch-u:clamp(.92px,.05vw,1.1px);--cch-line:rgba(255,255,255,.07);--cch-line-soft:rgba(255,255,255,.045);--cch-surface:rgba(255,255,255,.026);--cch-surface-hi:rgba(255,255,255,.055);--cch-accent:#a78bfa;--cch-accent-rgb:167,139,250}
+html.cw-theme-light body.cw-profile-page #profile-panel-collection{--cch-line:rgba(23,32,51,.12);--cch-line-soft:rgba(23,32,51,.08);--cch-surface:rgba(23,32,51,.035);--cch-surface-hi:rgba(23,32,51,.07);--cch-accent:#6d4df6;--cch-accent-rgb:109,77,246}
+.cw-collection-head{display:flex;align-items:center;justify-content:space-between;gap:calc(34 * var(--cch-u));margin:calc(18 * var(--cch-u)) 0 calc(32 * var(--cch-u))}
+.cw-collection-headline{min-width:0}
+.cw-collection-kicker{display:block;color:var(--cch-accent);font-size:calc(11 * var(--cch-u));font-weight:900;letter-spacing:.14em;text-transform:uppercase}
+.cw-collection-headline h2{margin:calc(8 * var(--cch-u)) 0 0;font-size:calc(34 * var(--cch-u));line-height:1.04;letter-spacing:-.02em;font-weight:900}
+.cw-collection-headline p{margin:calc(8 * var(--cch-u)) 0 0;color:var(--profile-muted);font-size:calc(14 * var(--cch-u));font-weight:600;line-height:1.35}
+.cw-collection-tiles{display:grid;grid-template-columns:repeat(4,minmax(calc(150 * var(--cch-u)),1fr));gap:calc(14 * var(--cch-u));min-width:min(calc(700 * var(--cch-u)),56vw)}
+.cw-collection-tile{display:grid;grid-template-columns:calc(42 * var(--cch-u)) minmax(0,1fr);align-items:center;column-gap:calc(13 * var(--cch-u));padding:calc(15 * var(--cch-u)) calc(17 * var(--cch-u));border:1px solid rgba(var(--tone-rgb),.26);border-radius:calc(15 * var(--cch-u));background:linear-gradient(150deg,rgba(var(--tone-rgb),.13),rgba(var(--tone-rgb),.03) 62%)}
+.cw-collection-tile[data-tone="violet"]{--tone-rgb:167,139,250}
+.cw-collection-tile[data-tone="blue"]{--tone-rgb:96,165,250}
+.cw-collection-tile[data-tone="green"]{--tone-rgb:74,222,128}
+.cw-collection-tile[data-tone="amber"]{--tone-rgb:251,191,36}
+.cw-collection-tile .material-symbols-rounded{display:inline-flex;align-items:center;justify-content:center;width:calc(42 * var(--cch-u));height:calc(42 * var(--cch-u));border-radius:calc(12 * var(--cch-u));background:rgba(var(--tone-rgb),.16);color:rgb(var(--tone-rgb));font-size:calc(21 * var(--cch-u));line-height:1}
+.cw-collection-tile-body{display:grid;min-width:0}
+.cw-collection-tile strong{font-size:calc(23 * var(--cch-u));line-height:1.1;font-weight:900;font-variant-numeric:tabular-nums;color:var(--profile-text)}
+.cw-collection-tile span{font-size:calc(13 * var(--cch-u));font-weight:800;color:var(--profile-text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.cw-collection-tile small{margin-top:calc(1 * var(--cch-u));font-size:calc(11 * var(--cch-u));font-weight:700;color:var(--profile-muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+
+.cw-collection-toolbar{display:flex;align-items:center;flex-wrap:wrap;gap:calc(10 * var(--cch-u));margin-bottom:calc(26 * var(--cch-u))}
+.cw-collection-search{position:relative;flex:0 1 calc(320 * var(--cch-u));min-width:calc(210 * var(--cch-u))}
+.cw-collection-search .material-symbols-rounded{position:absolute;left:calc(14 * var(--cch-u));top:50%;transform:translateY(-50%);color:var(--profile-muted);font-size:calc(19 * var(--cch-u));pointer-events:none}
+.cw-collection-search input{box-sizing:border-box;width:100%;height:calc(44 * var(--cch-u));padding:0 calc(14 * var(--cch-u)) 0 calc(42 * var(--cch-u));border:1px solid var(--cch-line);border-radius:calc(12 * var(--cch-u));background:var(--cch-surface);color:var(--profile-text);font:inherit;font-size:calc(13 * var(--cch-u));font-weight:700}
+.cw-collection-search input::placeholder{color:var(--profile-muted);font-weight:600}
+.cw-collection-search input:focus{outline:none;border-color:rgba(var(--cch-accent-rgb),.55);background:var(--cch-surface-hi)}
+.cw-collection-search input::-webkit-search-cancel-button{filter:invert(.6)}
+.cw-collection-chips{display:flex;align-items:center;gap:calc(8 * var(--cch-u));min-width:0;flex:1 1 auto}
+.cw-collection-chips button{display:inline-flex;align-items:center;gap:calc(8 * var(--cch-u));height:calc(44 * var(--cch-u));padding:0 calc(14 * var(--cch-u));border:1px solid var(--cch-line);border-radius:calc(12 * var(--cch-u));background:transparent;color:var(--profile-muted);font:inherit;font-size:calc(13 * var(--cch-u));font-weight:800;white-space:nowrap;cursor:pointer;transition:border-color .14s ease,background .14s ease,color .14s ease}
+.cw-collection-chips button:hover{border-color:var(--cch-line);background:var(--cch-surface);color:var(--profile-text)}
+.cw-collection-chips button.active{border-color:rgba(var(--cch-accent-rgb),.6);background:rgba(var(--cch-accent-rgb),.14);color:var(--profile-text)}
+.cw-collection-chips button:focus-visible{outline:2px solid rgba(var(--cch-accent-rgb),.7);outline-offset:2px}
+.cw-collection-chips .material-symbols-rounded{font-size:calc(17 * var(--cch-u));line-height:1}
+.cw-collection-chips button.active .material-symbols-rounded{color:var(--cch-accent)}
+.cw-collection-chips strong{padding:calc(2 * var(--cch-u)) calc(7 * var(--cch-u));border-radius:calc(7 * var(--cch-u));background:var(--cch-surface-hi);color:inherit;font-size:calc(11 * var(--cch-u));font-weight:900;font-variant-numeric:tabular-nums}
+.cw-collection-chips button.active strong{background:rgba(var(--cch-accent-rgb),.22);color:var(--profile-text)}
+.cw-collection-controls{display:flex;align-items:center;gap:calc(10 * var(--cch-u));margin-left:auto}
+.cw-collection-controls select{height:calc(44 * var(--cch-u));padding:0 calc(12 * var(--cch-u));border:1px solid var(--cch-line);border-radius:calc(12 * var(--cch-u));background:var(--cch-surface);color:var(--profile-text);font:inherit;font-size:calc(13 * var(--cch-u));font-weight:800;cursor:pointer}
+.cw-collection-controls .cw-icon-select{width:calc(178 * var(--cch-u));min-width:0}
+.cw-collection-controls #profile-collection-sort+.cw-icon-select{width:calc(212 * var(--cch-u))}
+.cw-collection-controls .cw-icon-select-label{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.cw-collection-controls .cw-icon-select-btn{min-height:calc(44 * var(--cch-u));padding:0 calc(13 * var(--cch-u));border-radius:calc(12 * var(--cch-u));border-color:var(--cch-line);background:var(--cch-surface);color:var(--profile-text);box-shadow:none}
+.cw-collection-controls .cw-icon-select-btn:hover{border-color:rgba(var(--cch-accent-rgb),.4);background:var(--cch-surface-hi)}
+.cw-collection-controls .cw-icon-select-label{font-size:calc(13 * var(--cch-u));font-weight:800}
+.cw-collection-controls .cw-icon-select-icon{width:calc(17 * var(--cch-u));height:calc(17 * var(--cch-u));flex-basis:calc(17 * var(--cch-u))}
+.cw-collection-controls .cw-icon-select-icon.material-symbols-rounded{font-size:calc(17 * var(--cch-u));background:transparent;color:var(--profile-muted)}
+.cw-collection-views{display:inline-flex;align-items:center;gap:calc(4 * var(--cch-u));padding:calc(4 * var(--cch-u));border:1px solid var(--cch-line);border-radius:calc(12 * var(--cch-u));background:var(--cch-surface)}
+.cw-collection-views button{display:inline-flex;align-items:center;justify-content:center;width:calc(36 * var(--cch-u));height:calc(34 * var(--cch-u));padding:0;border:0;border-radius:calc(9 * var(--cch-u));background:transparent;color:var(--profile-muted);cursor:pointer;transition:background .14s ease,color .14s ease}
+.cw-collection-views button:hover{color:var(--profile-text)}
+.cw-collection-views button.active{background:rgba(var(--cch-accent-rgb),.2);color:var(--cch-accent)}
+.cw-collection-views button:focus-visible{outline:2px solid rgba(var(--cch-accent-rgb),.7);outline-offset:1px}
+.cw-collection-views .material-symbols-rounded{font-size:calc(19 * var(--cch-u))}
+
+.cw-collection-grid{display:grid;align-items:start;grid-template-columns:repeat(auto-fill,minmax(190px,1fr));gap:20px 18px}
+.cw-collection-grid[data-view="grid"]{grid-template-columns:repeat(auto-fill,minmax(190px,1fr));gap:20px 18px}
+.cw-collection-grid[data-view="list"]{grid-template-columns:minmax(0,1fr);gap:0;border:1px solid var(--cch-line);border-radius:calc(16 * var(--cch-u));overflow:hidden;background:var(--cch-surface)}
+.cw-collection-card{display:flex;flex-direction:column;min-width:0;padding:0;border:0;background:transparent;color:inherit;font:inherit;text-align:left;cursor:pointer}
+.cw-collection-poster{position:relative;display:block;width:100%;aspect-ratio:2/3;overflow:hidden;border-radius:calc(12 * var(--cch-u));background:var(--cch-surface);box-shadow:0 0 0 1px var(--cch-line-soft)}
+.cw-collection-poster img{display:block;width:100%;height:100%;object-fit:cover;transition:transform .22s ease}
+.cw-collection-card:hover .cw-collection-poster{box-shadow:0 0 0 1px rgba(var(--cch-accent-rgb),.5),0 14px 30px rgba(0,0,0,.34)}
+.cw-collection-card:hover .cw-collection-poster img{transform:scale(1.03)}
+.cw-collection-card:focus-visible{outline:none}
+.cw-collection-card:focus-visible .cw-collection-poster{box-shadow:0 0 0 2px var(--cch-accent)}
+.cw-collection-badge{position:absolute;left:calc(8 * var(--cch-u));top:calc(8 * var(--cch-u));z-index:2;display:inline-flex;align-items:center;gap:calc(4 * var(--cch-u));height:calc(22 * var(--cch-u));padding:0 calc(8 * var(--cch-u));border-radius:calc(7 * var(--cch-u));background:rgba(8,10,15,.72);color:#fff;font-size:calc(10 * var(--cch-u));font-weight:800;line-height:1;letter-spacing:.01em;backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px)}
+.cw-collection-badge .material-symbols-rounded{font-size:calc(13 * var(--cch-u))}
+.cw-collection-info{display:grid;gap:calc(5 * var(--cch-u));padding:calc(11 * var(--cch-u)) calc(2 * var(--cch-u)) 0}
+.cw-collection-name{display:-webkit-box;-webkit-line-clamp:2;line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;color:var(--profile-text);font-size:calc(13.5 * var(--cch-u));font-weight:850;line-height:1.28;letter-spacing:-.01em}
+.cw-collection-meta{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--profile-muted);font-size:calc(11.5 * var(--cch-u));font-weight:650}
+.cw-collection-sources{display:flex;flex-wrap:wrap;gap:calc(5 * var(--cch-u));margin-top:calc(2 * var(--cch-u))}
+.cw-collection-sources .cw-profile-provider-badge{width:calc(21 * var(--cch-u));min-width:calc(21 * var(--cch-u));min-height:calc(21 * var(--cch-u));height:calc(21 * var(--cch-u));padding:0;justify-content:center;border-color:var(--cch-line);background:var(--cch-surface);box-shadow:none}
+.cw-collection-sources .cw-profile-provider-logo{width:calc(13 * var(--cch-u));height:calc(13 * var(--cch-u));flex:0 0 calc(13 * var(--cch-u))}
+.cw-collection-sources .cw-profile-provider-fallback{width:calc(13 * var(--cch-u));height:calc(13 * var(--cch-u));font-size:calc(7 * var(--cch-u))}
+
+.cw-collection-grid[data-view="list"] .cw-collection-card{display:none}
+.cw-collection-grid[data-view="list"]{--cch-cols:78px minmax(300px,1.7fr) 130px minmax(180px,1fr) 140px 112px 130px}
+.cw-collection-row{display:grid;grid-template-columns:var(--cch-cols);align-items:center;gap:calc(12 * var(--cch-u));width:100%;padding:calc(10 * var(--cch-u)) calc(16 * var(--cch-u));border:0;border-bottom:1px solid var(--cch-line-soft);background:transparent;color:inherit;font:inherit;text-align:left;cursor:pointer;transition:background .14s ease}
+.cw-collection-row:hover{background:var(--cch-surface-hi)}
+.cw-collection-row:focus-visible{outline:2px solid rgba(var(--cch-accent-rgb),.7);outline-offset:-2px}
+.cw-collection-row:last-child{border-bottom:0}
+.cw-collection-row--head{padding-top:calc(12 * var(--cch-u));padding-bottom:calc(12 * var(--cch-u));border-bottom:1px solid var(--cch-line);background:var(--cch-surface-hi);color:var(--profile-muted);font-size:calc(11 * var(--cch-u));font-weight:900;letter-spacing:.04em;text-transform:uppercase;cursor:default}
+.cw-collection-row--head:hover{background:var(--cch-surface-hi)}
+.cw-collection-row--head .cw-collection-cell{position:relative;padding-right:calc(8 * var(--cch-u))}
+.cw-collection-resize{position:absolute;right:calc(-6 * var(--cch-u));top:calc(-12 * var(--cch-u));bottom:calc(-12 * var(--cch-u));z-index:3;width:calc(12 * var(--cch-u));cursor:col-resize;touch-action:none}
+.cw-collection-resize::after{content:"";position:absolute;top:calc(6 * var(--cch-u));bottom:calc(6 * var(--cch-u));left:50%;width:2px;border-radius:999px;background:var(--cch-line);transition:background .12s ease}
+.cw-collection-resize:hover::after{background:var(--cch-accent)}
+body.cw-column-resizing{cursor:col-resize;user-select:none}
+.cw-collection-cell{min-width:0;font-size:calc(13.5 * var(--cch-u));color:var(--profile-muted);font-weight:700;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.cw-collection-cell--poster{display:block;width:calc(48 * var(--cch-u));aspect-ratio:2/3;overflow:hidden;border-radius:calc(7 * var(--cch-u));background:var(--cch-surface)}
+.cw-collection-row--head .cw-collection-cell--poster{display:block;width:auto;aspect-ratio:auto;background:transparent;border-radius:0}
+.cw-collection-cell--poster img{display:block;width:100%;height:100%;object-fit:cover}
+.cw-collection-cell--title{display:flex;align-items:center;gap:calc(9 * var(--cch-u));white-space:normal}
+.cw-collection-row--head .cw-collection-cell--title{display:block}
+.cw-collection-cell--title strong{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--profile-text);font-size:calc(15 * var(--cch-u));font-weight:850;letter-spacing:-.01em}
+.cw-collection-cell--genre{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.cw-collection-cell--added{display:grid;gap:calc(2 * var(--cch-u));line-height:1.2}
+.cw-collection-row--head .cw-collection-cell--added{display:block}
+.cw-collection-cell--added strong{color:var(--profile-text);font-size:calc(13.5 * var(--cch-u));font-weight:800;font-variant-numeric:tabular-nums}
+.cw-collection-cell--added small{color:var(--profile-muted);font-size:calc(11.5 * var(--cch-u));font-weight:700}
+.cw-collection-cell--rel{font-variant-numeric:tabular-nums}
+.cw-collection-cell--providers{display:flex;align-items:center;gap:calc(5 * var(--cch-u));white-space:nowrap}
+.cw-collection-row--head .cw-collection-cell--providers{display:block}
+.cw-collection-cell--providers .cw-profile-provider-badge{width:calc(23 * var(--cch-u));min-width:calc(23 * var(--cch-u));height:calc(23 * var(--cch-u));min-height:calc(23 * var(--cch-u));padding:0;justify-content:center;border-color:var(--cch-line);background:var(--cch-surface);box-shadow:none}
+.cw-collection-cell--providers .cw-profile-provider-logo{width:calc(14 * var(--cch-u));height:calc(14 * var(--cch-u));flex:0 0 calc(14 * var(--cch-u))}
+.cw-collection-cell--providers .cw-profile-provider-fallback{width:calc(14 * var(--cch-u));height:calc(14 * var(--cch-u));font-size:calc(7 * var(--cch-u))}
+.cw-collection-pill{display:inline-flex;align-items:center;gap:calc(4 * var(--cch-u));flex:0 0 auto;height:calc(22 * var(--cch-u));padding:0 calc(9 * var(--cch-u));border:1px solid var(--cch-line);border-radius:999px;background:var(--cch-surface);color:var(--profile-text);font-size:calc(11.5 * var(--cch-u));font-weight:850;font-variant-numeric:tabular-nums;line-height:1}
+.cw-collection-pill--type{border-color:rgba(var(--cch-accent-rgb),.32);background:rgba(var(--cch-accent-rgb),.12)}
+.cw-collection-pill .material-symbols-rounded{font-size:calc(14 * var(--cch-u))}
+.cw-collection-grid .cw-profile-empty{grid-column:1/-1}
+.cw-collection-grid .cw-dash-skeleton{grid-column:auto}
+.cw-collection-skel{display:grid;gap:calc(11 * var(--cch-u))}
+.cw-collection-skel .cw-collection-skel-art{display:block;width:100%;height:auto;aspect-ratio:2/3;border-radius:calc(12 * var(--cch-u))}
+.cw-collection-skel .cw-profile-skel-lines{gap:calc(8 * var(--cch-u))}
+.cw-collection-skel--row{grid-template-columns:calc(42 * var(--cch-u)) minmax(0,1fr);align-items:center;gap:calc(14 * var(--cch-u));padding:calc(8 * var(--cch-u)) calc(12 * var(--cch-u));border:1px solid var(--cch-line-soft);border-radius:calc(12 * var(--cch-u))}
+.cw-collection-skel--row .cw-collection-skel-art{width:calc(42 * var(--cch-u));border-radius:calc(8 * var(--cch-u))}
+
+.cw-collection-footer{display:grid;grid-template-columns:1fr auto 1fr;align-items:center;gap:calc(14 * var(--cch-u));margin-top:calc(26 * var(--cch-u))}
+.cw-collection-footer[hidden]{display:none}
+.cw-collection-pages{grid-column:2;display:flex;align-items:center;justify-content:center;gap:calc(6 * var(--cch-u))}
+.cw-collection-pages button{display:inline-flex;align-items:center;justify-content:center;min-width:calc(36 * var(--cch-u));height:calc(36 * var(--cch-u));padding:0 calc(9 * var(--cch-u));border:1px solid var(--cch-line);border-radius:calc(10 * var(--cch-u));background:transparent;color:var(--profile-muted);font:inherit;font-size:calc(13 * var(--cch-u));font-weight:800;font-variant-numeric:tabular-nums;cursor:pointer;transition:border-color .14s ease,background .14s ease,color .14s ease}
+.cw-collection-pages button:hover:not(:disabled):not(.active){background:var(--cch-surface);color:var(--profile-text)}
+.cw-collection-pages button.active{border-color:rgba(var(--cch-accent-rgb),.7);background:rgba(var(--cch-accent-rgb),.2);color:var(--profile-text)}
+.cw-collection-pages button:disabled{opacity:.35;cursor:default}
+.cw-collection-pages button:focus-visible{outline:2px solid rgba(var(--cch-accent-rgb),.7);outline-offset:2px}
+.cw-collection-pages .material-symbols-rounded{font-size:calc(18 * var(--cch-u))}
+.cw-collection-pages .cw-collection-gap{display:inline-flex;align-items:center;justify-content:center;min-width:calc(24 * var(--cch-u));color:var(--profile-muted);font-size:calc(13 * var(--cch-u));font-weight:800}
+.cw-collection-summary{grid-column:3;display:flex;align-items:center;justify-content:flex-end;gap:calc(10 * var(--cch-u));color:var(--profile-muted);font-size:calc(12 * var(--cch-u));font-weight:700;font-variant-numeric:tabular-nums}
+.cw-collection-summary select{height:calc(36 * var(--cch-u));padding:0 calc(9 * var(--cch-u));border:1px solid var(--cch-line);border-radius:calc(10 * var(--cch-u));background:var(--cch-surface);color:var(--profile-text);font:inherit;font-size:calc(12 * var(--cch-u));font-weight:800;cursor:pointer}
+.cw-collection-summary select:focus-visible{outline:2px solid rgba(var(--cch-accent-rgb),.7);outline-offset:1px}
+
+.cw-profile-collection-menu{min-width:220px;border-color:rgba(167,139,250,.28);background:linear-gradient(180deg,rgba(27,31,45,.98),rgba(15,18,28,.99));box-shadow:0 20px 42px rgba(0,0,0,.5)}
+.cw-profile-collection-menu .cw-icon-select-item[aria-selected="true"]{border-color:rgba(167,139,250,.36);background:rgba(117,76,220,.28)}
+.cw-profile-collection-menu .cw-icon-select-icon.material-symbols-rounded{background:rgba(136,89,255,.16);color:#b48cff}
+html[data-cw-theme="flat-dark"] body.cw-profile-page #profile-panel-collection{--cch-line:var(--profile-line);--cch-line-soft:var(--profile-line);--cch-surface:var(--profile-panel);--cch-surface-hi:var(--profile-panel-2)}
+html[data-cw-theme="flat-dark"] body.cw-profile-page .cw-collection-poster{background:var(--profile-panel)}
+html[data-cw-theme="flat-dark"] body.cw-profile-page .cw-collection-row:not(.cw-collection-row--head):hover{background:var(--profile-panel-2)}
+
+@media(max-width:1450px){.cw-collection-head{align-items:flex-start;gap:calc(24 * var(--cch-u))}.cw-collection-tiles{min-width:0;grid-template-columns:repeat(2,minmax(0,1fr))}.cw-collection-search{flex:1 1 calc(240 * var(--cch-u))}.cw-collection-chips{order:3;flex-basis:100%;overflow-x:auto;padding-bottom:calc(2 * var(--cch-u))}}
+@media(max-width:980px){.cw-collection-head{display:grid}.cw-collection-tiles{width:100%}.cw-collection-controls{margin-left:0;flex:1 1 auto;justify-content:space-between}.cw-collection-controls .cw-icon-select{width:100%}}
+@media(max-width:720px){.cw-collection-headline h2{font-size:calc(26 * var(--cch-u))}.cw-collection-tiles{grid-template-columns:repeat(2,minmax(0,1fr));gap:calc(10 * var(--cch-u))}.cw-collection-search{flex-basis:100%}.cw-collection-grid,.cw-collection-grid[data-view="grid"]{grid-template-columns:repeat(auto-fill,minmax(132px,1fr));gap:14px 11px}.cw-collection-grid[data-view="list"]{--cch-cols:52px minmax(0,1fr) auto!important}.cw-collection-cell--rel,.cw-collection-cell--genre,.cw-collection-cell--added,.cw-collection-cell--type{display:none}.cw-collection-resize{display:none}.cw-collection-footer{grid-template-columns:1fr}.cw-collection-pages,.cw-collection-summary{grid-column:1;justify-content:center}}
 
 /* Profile-only widget skin. Scoped to body.cw-profile-page so Main is untouched. */
 body.cw-profile-page #dashboard-widgets-card{--cw-widget-cols:3;column-gap:16px;margin-top:0}

--- a/assets/js/profile-page.js
+++ b/assets/js/profile-page.js
@@ -69,6 +69,7 @@
   const providerLabel = (provider) => window.CW?.ProviderMeta?.label?.(provider) || String(provider || "").toUpperCase();
   const providerKey = (provider) => window.CW?.ProviderMeta?.keyOf?.(provider) || String(provider || "").trim().toUpperCase();
   const providerLogo = (provider) => window.CW?.ProviderMeta?.logoPath?.(provider) || "";
+  const providerLogLogo = (provider) => window.CW?.ProviderMeta?.logLogoPath?.(provider) || providerLogo(provider);
   const visibleProviderLabel = (provider) => {
     const raw = String(provider || "").trim();
     if (!raw || raw === "?" || /^unknown$/i.test(raw) || /^none$/i.test(raw)) return "";
@@ -128,6 +129,18 @@
     if (mediaValue(item) === "movie") return item?.tmdb || item?.tmdb_id || ids.tmdb || ids.id || "";
     return showIds.tmdb || nestedShowIds.tmdb || show.tmdb || show.tmdb_id || ids.tmdb_show || item?.tmdb_show || ids.show_tmdb || item?.show_tmdb || item?.tmdb || item?.tmdb_id || ids.tmdb || "";
   };
+  const showTmdbId = (item) => {
+    const ids = objectOf(item?.ids);
+    const meta = objectOf(item?.provider_metadata);
+    const show = objectOf(item?.show || item?.series || item?.anime);
+    const showIds = objectOf(meta.show_ids);
+    const nestedShowIds = objectOf(show.ids);
+    const directShowIds = objectOf(item?.show_ids);
+    return String(
+      showIds.tmdb || nestedShowIds.tmdb || directShowIds.tmdb || show.tmdb || show.tmdb_id
+      || ids.tmdb_show || item?.tmdb_show || ids.show_tmdb || item?.show_tmdb || ""
+    ).trim();
+  };
   const titleOf = (item) => String(item?.series_title || item?.title || item?.name || item?.show_title || item?.label || "Untitled");
   const yearOf = (item) => String(item?.year || item?.release_year || item?.aired_year || "").trim();
   const episodeOf = (item) => {
@@ -143,7 +156,8 @@
       ? (item?.show_cover_url || item?.show_cover || item?.show_poster_url || item?.show_poster || item?.series_poster || item?.series_cover || item?.grandparentThumb || show.poster_url || show.poster || show.cover || show.poster_cover || item?.poster_cover || "")
       : (item?.poster_url || item?.poster || item?.cover || item?.poster_cover || ""));
     if (src) return src;
-    const id = tmdbId(item);
+    const episode = isEpisodeItem(item);
+    const id = episode ? showTmdbId(item) : tmdbId(item);
     if (!id) return "/assets/img/placeholder_poster.svg";
     const kind = mediaType(item) ? "tv" : "movie";
     const title = !isEpisodeItem(item) && (item?.series_title || item?.title) ? `&title=${encodeURIComponent(String(item?.series_title || item?.title))}` : "";
@@ -208,6 +222,8 @@
     progress: `<div class="cw-cw-card cw-dash-skeleton cw-dash-skeleton-row cw-profile-skel" aria-hidden="true"><span class="cw-cw-art cw-skel-block"></span>${skelLines}</div>`,
     watchlist: `<div class="cw-profile-row cw-dash-skeleton cw-dash-skeleton-row cw-profile-skel" aria-hidden="true"><span class="cw-skel-block"></span>${skelLines}<span class="cw-profile-skel-pill cw-skel-dot"></span></div>`,
     stats: `<div class="cw-profile-stat cw-dash-skeleton cw-dash-skeleton-row cw-profile-skel" aria-hidden="true"><span class="cw-profile-skel-icon cw-skel-block"></span>${skelLines}</div>`,
+    collection: `<div class="cw-collection-skel cw-dash-skeleton cw-profile-skel" aria-hidden="true"><span class="cw-collection-skel-art cw-skel-block"></span>${skelLines}</div>`,
+    collectionRow: `<div class="cw-collection-skel cw-collection-skel--row cw-dash-skeleton cw-profile-skel" aria-hidden="true"><span class="cw-collection-skel-art cw-skel-block"></span>${skelLines}</div>`,
   };
   const skeleton = (kind, count) => Array.from({ length: count }, () => skelShapes[kind]).join("");
 
@@ -426,6 +442,18 @@
     const key = `profile-${++posterSeq}`;
     posterItems.set(key, overlayItem(item || {}));
     return key;
+  }
+
+  function prunePosterItems() {
+    if (posterItems.size <= 600) return;
+    const live = new Set();
+    document.querySelectorAll("[data-profile-poster-key]").forEach((node) => {
+      const key = node.dataset.profilePosterKey;
+      if (key) live.add(key);
+    });
+    for (const key of [...posterItems.keys()]) {
+      if (!live.has(key)) posterItems.delete(key);
+    }
   }
 
   function progressPct(item) {
@@ -700,7 +728,7 @@
     return raw;
   }
 
-  function renderQuickStats({ wall, widgets, progressItems, insights }) {
+  function renderQuickStats({ wall, widgets, progressItems, insights, collection }) {
     const history = widgets?.recent_history?.items || [];
     const ratings = widgets?.latest_ratings?.items || [];
     const scrobble = widgets?.recent_scrobble?.items || [];
@@ -711,7 +739,8 @@
     const movies = Number(breakdown.movies ?? watchtime.movies ?? sampleStats.movies) || 0;
     const shows = Number(breakdown.shows ?? watchtime.shows ?? sampleStats.shows) || 0;
     const anime = Number(breakdown.anime) || 0;
-    const episodes = Number(breakdown.episodes ?? sampleStats.episodes) || 0;
+    const collectionCounts = collection?.counts || {};
+    const owned = (Number(collectionCounts.movie) || 0) + (Number(collectionCounts.show) || 0);
     const watchlist = Number(wall?.total ?? (wall?.items || []).length) || 0;
     const fallbackHours = scrobble.reduce((sum, item) => sum + durationMinutes(item), 0) / 60;
     const hours = Number(widgets?.recent_scrobble?.scrobble_hours ?? fallbackHours) || 0;
@@ -719,7 +748,7 @@
       ["movies", "movie", "theaters", "Movies", numberFmt.format(movies), "Total movies in your syncs"],
       ["tv", "tv", "live_tv", "TV Shows", numberFmt.format(shows), "Total TV shows in your syncs"],
       ["anime", "animation", "auto_awesome", "Anime", numberFmt.format(anime), "Total anime in your syncs"],
-      ["episodes", "subscriptions", "stacked_bar_chart", "Episodes", numberFmt.format(episodes), "Total episodes in your syncs"],
+      ["collections", "inventory_2", "video_library", "Collections", numberFmt.format(owned), "Movies and shows you own"],
       ["watchlist", "bookmark", "format_list_bulleted", "Watchlist Items", numberFmt.format(watchlist), "Items on your watchlist"],
       ["hours", "schedule", "show_chart", "Hours Watched", hours ? `${numberFmt.format(Math.round(hours * 10) / 10)} h` : "0 h", "Total time spent watching"],
     ];
@@ -735,13 +764,13 @@
   }
 
   function renderOverview(payload = {}) {
-    posterSeq = 0;
-    posterItems.clear();
+    prunePosterItems();
     const widgets = payload.widgets || {};
     const wall = payload.wall || { items: [] };
     const progress = payload.progress || { items: [] };
     const insights = payload.insights || null;
     const status = payload.status || null;
+    const collection = payload.collection || null;
     const history = widgets?.recent_history?.items || [];
     const ratings = widgets?.latest_ratings?.items || [];
     const scrobble = widgets?.recent_scrobble?.items || [];
@@ -749,7 +778,7 @@
     const progressItems = progress?.items?.length ? progress.items : widgetProgress;
     const scrobbleTotal = Number(widgets?.recent_scrobble?.scrobble_total ?? widgets?.recent_scrobble?.total ?? scrobble.length) || 0;
     renderHero(scrobble, history);
-    renderQuickStats({ wall, widgets, progressItems, insights });
+    renderQuickStats({ wall, widgets, progressItems, insights, collection });
     const watchlistItems = Array.isArray(wall?.items) ? wall.items : [];
     renderHeroChips({
       itemsWatched: scrobbleTotal,
@@ -765,11 +794,12 @@
     if (cached) renderOverview(cached);
     else paintOverviewSkeletons();
 
-    const [widgetsRes, wallRes, insightsRes, statusRes] = await Promise.allSettled([
+    const [widgetsRes, wallRes, insightsRes, statusRes, collectionRes] = await Promise.allSettled([
       api("/api/dashboard/widgets?include=history,ratings,scrobble,progress&history_limit=8&ratings_limit=9&scrobble_limit=8&progress_limit=8"),
       api("/api/state/wall?limit=8"),
       api("/api/insights?limit_samples=0&history=0&runtime=0&include_events=0"),
       api("/api/status"),
+      api("/api/profile/collection?page=1&page_size=1"),
     ]);
     const next = {
       widgets: widgetsRes.status === "fulfilled" ? widgetsRes.value : (cached?.widgets || {}),
@@ -777,6 +807,9 @@
       progress: cached?.progress || { items: [] },
       insights: insightsRes.status === "fulfilled" ? insightsRes.value : (cached?.insights || null),
       status: statusRes.status === "fulfilled" ? statusRes.value : (cached?.status || null),
+      collection: collectionRes.status === "fulfilled"
+        ? { counts: collectionRes.value?.counts || {}, total: Number(collectionRes.value?.total) || 0 }
+        : (cached?.collection || null),
     };
     if (!next.progress?.items?.length && next.widgets?.recent_progress?.items?.length) {
       next.progress = { items: next.widgets.recent_progress.items };
@@ -788,10 +821,607 @@
       const fresh = { ...next, progress: progress || { items: [] } };
       const progressItems = fresh.progress?.items?.length ? fresh.progress.items : (fresh.widgets?.recent_progress?.items || []);
       renderProgressItems(progressItems);
-      renderQuickStats({ wall: fresh.wall, widgets: fresh.widgets, progressItems, insights: fresh.insights });
+      renderQuickStats({ wall: fresh.wall, widgets: fresh.widgets, progressItems, insights: fresh.insights, collection: fresh.collection });
       writeCache(cacheKey, fresh);
     }).catch(() => {});
     refreshNowPlaying();
+  }
+
+  const COLLECTION_PREFS_KEY = "cw.profile.collection";
+  const COLLECTION_PAGE_SIZES = [24, 48, 72, 96];
+
+  function readCollectionPrefs() {
+    try {
+      const raw = JSON.parse(window.localStorage?.getItem(COLLECTION_PREFS_KEY) || "{}");
+      return raw && typeof raw === "object" ? raw : {};
+    } catch {
+      return {};
+    }
+  }
+
+  const collectionPrefs = readCollectionPrefs();
+
+  const collectionState = {
+    loaded: false,
+    loading: false,
+    page: 1,
+    pageSize: COLLECTION_PAGE_SIZES.includes(Number(collectionPrefs.pageSize)) ? Number(collectionPrefs.pageSize) : 24,
+    view: collectionPrefs.view === "list" ? "list" : "grid",
+    type: "all",
+    provider: "",
+    search: "",
+    sort: "collected_at",
+    items: [],
+    total: 0,
+    pageCount: 1,
+    cols: (collectionPrefs.cols && typeof collectionPrefs.cols === "object") ? { ...collectionPrefs.cols } : {},
+  };
+
+  function saveCollectionPrefs() {
+    try {
+      window.localStorage?.setItem(COLLECTION_PREFS_KEY, JSON.stringify({ view: collectionState.view, pageSize: collectionState.pageSize, cols: collectionState.cols }));
+    } catch {}
+  }
+
+  function lockCollectionPager() {
+    $("#profile-collection-pages")?.querySelectorAll("button").forEach((btn) => { btn.disabled = true; });
+  }
+
+  function epochOf(value) {
+    const numeric = Number(value || 0);
+    if (Number.isFinite(numeric) && numeric > 0) return numeric > 1e12 ? Math.floor(numeric / 1000) : numeric;
+    const parsed = Date.parse(String(value || "").trim());
+    return Number.isFinite(parsed) ? Math.floor(parsed / 1000) : 0;
+  }
+
+  function collectionKind(item) {
+    const raw = String(item?.type || item?.media_type || "").toLowerCase();
+    if (raw === "season") return ["stacks", "Season"];
+    if (/episode/.test(raw) || item?.episode || item?.episode_number) return ["play_circle", "Episode"];
+    if (/show|tv|series|anime/.test(raw)) return ["tv", "Show"];
+    return ["movie", "Movie"];
+  }
+
+  function collectionSourceProviders(item) {
+    const out = [];
+    const push = (value) => {
+      const name = providerName(value);
+      if (name && !out.some((existing) => String(existing).toLowerCase() === name.toLowerCase())) out.push(name);
+    };
+    for (const row of Array.isArray(item?.providers) ? item.providers : []) push(row);
+    for (const row of Array.isArray(item?.sources) ? item.sources : []) push(row);
+    const byProvider = item?.sources_by_provider || item?.sourcesByProvider;
+    if (byProvider && typeof byProvider === "object") Object.keys(byProvider).forEach(push);
+    return out;
+  }
+
+  function collectionLibrarySummary(item) {
+    const libraries = Array.isArray(item?.libraries) ? item.libraries.filter(Boolean) : [];
+    if (!libraries.length) return "";
+    if (libraries.length === 1) return libraries[0];
+    return `${libraries[0]} +${libraries.length - 1}`;
+  }
+
+  function collectionCard(item) {
+    const key = storePosterItem(item);
+    const [icon, kind] = collectionKind(item);
+    const title = titleOf(item);
+    const year = yearOf(item);
+    const episode = episodeOf(item);
+    const added = epochOf(item?.last_collected_at || item?.collected_at || item?.first_collected_at);
+    const when = added ? relTime(added) : "";
+    const art = poster(item, "w342");
+    const providerStrip = collectionSourceProviders(item).map(providerIconHtml).filter(Boolean).join("");
+    const meta = [kind, episode || year, when, collectionLibrarySummary(item)].filter(Boolean).join(" · ");
+    return `<button class="cw-collection-card" type="button" data-profile-poster-key="${esc(key)}" aria-label="Show details for ${esc(title)}">
+      <span class="cw-collection-poster">
+        <img src="${esc(art)}" alt="" loading="lazy" onerror="this.onerror=null;this.src='/assets/img/placeholder_poster.svg'">
+        <span class="cw-collection-badge"><span class="material-symbols-rounded" aria-hidden="true">${esc(icon)}</span>${esc(kind)}</span>
+      </span>
+      <span class="cw-collection-info">
+        <strong class="cw-collection-name">${esc(title)}</strong>
+        <span class="cw-collection-meta">${esc(meta)}</span>
+        ${providerStrip ? `<span class="cw-collection-sources">${providerStrip}</span>` : ""}
+      </span>
+    </button>`;
+  }
+
+  const collectionDateFmt = (epoch) => {
+    if (!epoch) return "";
+    try {
+      return new Intl.DateTimeFormat(window.__CW_LOCALE || navigator.language || undefined, { day: "2-digit", month: "2-digit", year: "numeric" }).format(new Date(epoch * 1000));
+    } catch {
+      return "";
+    }
+  };
+
+  const collectionIsoFmt = (iso) => {
+    const raw = String(iso || "").trim();
+    if (!raw) return "";
+    const parsed = Date.parse(raw.length <= 10 ? raw + "T00:00:00Z" : raw);
+    if (!Number.isFinite(parsed)) return "";
+    try {
+      return new Intl.DateTimeFormat(window.__CW_LOCALE || navigator.language || undefined, { day: "2-digit", month: "2-digit", year: "numeric", timeZone: "UTC" }).format(new Date(parsed));
+    } catch {
+      return "";
+    }
+  };
+
+  const COLLECTION_COLUMNS = [
+    { key: "poster", label: "Poster", width: 78, min: 62, max: 130 },
+    { key: "title", label: "Title", width: 300, min: 170, max: 900, flex: 1.7 },
+    { key: "rel", label: "Release", width: 130, min: 96, max: 240 },
+    { key: "genre", label: "Genre", width: 180, min: 110, max: 420, flex: 1 },
+    { key: "added", label: "Added", width: 140, min: 108, max: 260 },
+    { key: "type", label: "Type", width: 112, min: 84, max: 200 },
+    { key: "providers", label: "Providers", width: 130, min: 84, max: 280 },
+  ];
+
+  const collectionColumnWidth = (col) => {
+    const stored = Number(collectionState.cols?.[col.key]);
+    const value = Number.isFinite(stored) && stored > 0 ? stored : col.width;
+    return Math.max(col.min, Math.min(col.max, Math.round(value)));
+  };
+
+  function applyCollectionColumns() {
+    const grid = $("#profile-collection-grid");
+    if (!grid) return;
+    grid.style.setProperty("--cch-cols", COLLECTION_COLUMNS.map((col) => {
+      const width = collectionColumnWidth(col);
+      return col.flex ? `minmax(${width}px,${col.flex}fr)` : `${width}px`;
+    }).join(" "));
+  }
+
+  function collectionListHead() {
+    const cells = COLLECTION_COLUMNS.map((col, index) => {
+      const handle = index < COLLECTION_COLUMNS.length - 1
+        ? `<span class="cw-collection-resize" role="separator" aria-orientation="vertical" title="Drag to resize, double-click to reset" data-collection-resize="${esc(col.key)}"></span>`
+        : "";
+      return `<span class="cw-collection-cell cw-collection-cell--${esc(col.key)}">${esc(col.label)}${handle}</span>`;
+    }).join("");
+    return `<div class="cw-collection-row cw-collection-row--head" role="presentation">${cells}</div>`;
+  }
+
+  const collectionReleaseIso = (item, meta) => {
+    const movie = /^movie$/i.test(String(item?.type || item?.media_type || ""));
+    const fromMeta = meta ? (movie ? (meta.detail?.release_date || meta.release?.date || "") : (meta.detail?.first_air_date || meta.release?.date || "")) : "";
+    return String(fromMeta || item?.release_date || item?.first_air_date || item?.released || item?.premiered || "").trim();
+  };
+
+  const collectionGenreText = (item, meta) => {
+    const raw = (meta && (meta.genres || meta.detail?.genres)) || item?.genres || item?.genre || [];
+    const list = Array.isArray(raw) ? raw : String(raw || "").split(",");
+    return list.map((g) => (typeof g === "string" ? g : (g?.name || g?.title || ""))).map((g) => String(g).trim()).filter(Boolean).slice(0, 3).join(", ");
+  };
+
+  function collectionListRow(item, index) {
+    const key = storePosterItem(item);
+    const [icon, kind] = collectionKind(item);
+    const title = titleOf(item);
+    const year = yearOf(item);
+    const episode = episodeOf(item);
+    const added = epochOf(item?.last_collected_at || item?.collected_at || item?.first_collected_at);
+    const art = poster(item, "w342");
+    const providerStrip = collectionSourceProviders(item).map(providerIconHtml).filter(Boolean).join("");
+    const stamp = episode || year;
+    const stored = recallCollectionMeta(item);
+    const release = collectionIsoFmt(collectionReleaseIso(item, null)) || stored?.r || "";
+    const genres = collectionGenreText(item, null) || stored?.g || "";
+    return `<button class="cw-collection-row" type="button" data-collection-index="${index}" data-profile-poster-key="${esc(key)}" aria-label="Show details for ${esc(title)}">
+      <span class="cw-collection-cell cw-collection-cell--poster"><img src="${esc(art)}" alt="" loading="lazy" onerror="this.onerror=null;this.src='/assets/img/placeholder_poster.svg'"></span>
+      <span class="cw-collection-cell cw-collection-cell--title">
+        <strong>${esc(title)}</strong>
+        ${stamp ? `<span class="cw-collection-pill">${esc(stamp)}</span>` : ""}
+      </span>
+      <span class="cw-collection-cell cw-collection-cell--rel">${esc(release || "—")}</span>
+      <span class="cw-collection-cell cw-collection-cell--genre">${esc(genres || "—")}</span>
+      <span class="cw-collection-cell cw-collection-cell--added">
+        <strong>${esc(collectionDateFmt(added) || "—")}</strong>
+        ${added ? `<small>${esc(relTime(added))}</small>` : ""}
+      </span>
+      <span class="cw-collection-cell cw-collection-cell--type"><span class="cw-collection-pill cw-collection-pill--type"><span class="material-symbols-rounded" aria-hidden="true">${esc(icon)}</span>${esc(kind)}</span></span>
+      <span class="cw-collection-cell cw-collection-cell--providers">${providerStrip}</span>
+    </button>`;
+  }
+
+  function applyCollectionMeta() {
+    const grid = $("#profile-collection-grid");
+    if (!grid || collectionState.view !== "list") return;
+    grid.querySelectorAll("[data-collection-index]").forEach((row) => {
+      const item = collectionState.items[Number(row.dataset.collectionIndex)];
+      if (!item) return;
+      const meta = window.CW?.Meta?.peek?.(item) || null;
+      const relCell = row.querySelector(".cw-collection-cell--rel");
+      const genreCell = row.querySelector(".cw-collection-cell--genre");
+      const stored = meta ? null : recallCollectionMeta(item);
+      const release = meta ? collectionIsoFmt(collectionReleaseIso(item, meta)) : (stored?.r || "");
+      const genres = meta ? collectionGenreText(item, meta) : (stored?.g || "");
+      if (meta) rememberCollectionMeta(item, release, genres);
+      if (relCell) relCell.textContent = release || "—";
+      if (genreCell) {
+        genreCell.textContent = genres || "—";
+        genreCell.title = genres;
+      }
+    });
+    saveCollectionMetaCache();
+  }
+
+  let collectionMetaSeq = 0;
+  const COLLECTION_META_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+  const COLLECTION_META_MAX = 4000;
+  let collectionMetaStore = null;
+  let collectionMetaDirty = false;
+
+  const collectionMetaKey = (item) => {
+    try {
+      return String(window.CW?.Meta?.key?.(item) || "");
+    } catch {
+      return "";
+    }
+  };
+
+  function collectionMetaCache() {
+    if (collectionMetaStore) return collectionMetaStore;
+    const stored = readCache(profileCacheKey("collection_meta"), COLLECTION_META_TTL_MS);
+    collectionMetaStore = new Map(Object.entries(stored && typeof stored === "object" ? stored : {}));
+    return collectionMetaStore;
+  }
+
+  function saveCollectionMetaCache() {
+    if (!collectionMetaDirty || !collectionMetaStore) return;
+    collectionMetaDirty = false;
+    let entries = [...collectionMetaStore.entries()];
+    if (entries.length > COLLECTION_META_MAX) entries = entries.slice(-COLLECTION_META_MAX);
+    writeCache(profileCacheKey("collection_meta"), Object.fromEntries(entries));
+  }
+
+  function rememberCollectionMeta(item, release, genres) {
+    const key = collectionMetaKey(item);
+    if (!key || (!release && !genres)) return;
+    const cache = collectionMetaCache();
+    const prev = cache.get(key);
+    if (prev && prev.r === release && prev.g === genres) return;
+    cache.delete(key);
+    cache.set(key, { r: release, g: genres });
+    collectionMetaDirty = true;
+  }
+
+  function recallCollectionMeta(item) {
+    const key = collectionMetaKey(item);
+    return key ? collectionMetaCache().get(key) || null : null;
+  }
+
+  async function hydrateCollectionMeta() {
+    if (collectionState.view !== "list" || !collectionState.items.length) return;
+    const meta = window.CW?.Meta;
+    if (typeof meta?.batch !== "function") return;
+    const token = ++collectionMetaSeq;
+    try {
+      await meta.batch(collectionState.items, "row");
+    } catch {
+      return;
+    }
+    if (token === collectionMetaSeq) applyCollectionMeta();
+  }
+
+  function startCollectionResize(event, key) {
+    const col = COLLECTION_COLUMNS.find((entry) => entry.key === key);
+    if (!col || (event.button != null && event.button !== 0)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const startX = event.clientX;
+    const startWidth = collectionColumnWidth(col);
+    document.body.classList.add("cw-column-resizing");
+    const onMove = (moveEvent) => {
+      collectionState.cols[col.key] = Math.max(col.min, Math.min(col.max, startWidth + moveEvent.clientX - startX));
+      applyCollectionColumns();
+    };
+    const finish = () => {
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", finish);
+      document.removeEventListener("pointercancel", finish);
+      document.body.classList.remove("cw-column-resizing");
+      saveCollectionPrefs();
+    };
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", finish);
+    document.addEventListener("pointercancel", finish);
+  }
+
+  function renderCollectionTypeChips(counts = {}) {
+    const host = $("#profile-collection-types");
+    if (!host) return;
+    const rows = [
+      ["all", "apps", "All"],
+      ["movie", "movie", "Movies"],
+      ["show", "tv", "Shows"],
+      ["season", "stacks", "Seasons"],
+      ["episode", "play_circle", "Episodes"],
+    ];
+    host.innerHTML = rows.map(([key, icon, label]) => {
+      const count = Number(counts[key] || 0);
+      return `<button class="${collectionState.type === key ? "active" : ""}" type="button" data-collection-type="${esc(key)}" aria-pressed="${collectionState.type === key}">
+        <span class="material-symbols-rounded" aria-hidden="true">${esc(icon)}</span>
+        <span>${esc(label)}</span>
+        <strong>${esc(numberFmt.format(count))}</strong>
+      </button>`;
+    }).join("");
+  }
+
+  function renderCollectionProviders(providers = []) {
+    const select = $("#profile-collection-provider");
+    if (!select) return;
+    const current = collectionState.provider;
+    const options = [`<option value="">All providers</option>`].concat((providers || []).map((row) => {
+      const key = String(row?.provider || "").toLowerCase();
+      const label = visibleProviderLabel(key) || key.toUpperCase();
+      const count = Number(row?.count || 0);
+      return `<option value="${esc(key)}" data-provider="${esc(key)}" data-label="${esc(label)}">${esc(label)} (${esc(numberFmt.format(count))})</option>`;
+    }));
+    select.innerHTML = options.join("");
+    select.value = current;
+    enhanceCollectionProviderSelect(select);
+  }
+
+  function enhanceCollectionProviderSelect(select = $("#profile-collection-provider")) {
+    if (!select || typeof window.CW?.IconSelect?.enhance !== "function") return;
+    window.CW.IconSelect.enhance(select, {
+      className: "cw-profile-collection-select",
+      menuClassName: "cw-profile-collection-menu",
+      menuMinWidth: 260,
+      getOptionData: (value, option) => {
+        if (!value) return { label: "All providers", icons: [{ symbol: "hub" }] };
+        const provider = option?.dataset?.provider || value;
+        const label = option?.dataset?.label || visibleProviderLabel(provider) || String(provider || "").toUpperCase();
+        const logo = providerLogLogo(provider);
+        return {
+          label: option?.textContent?.trim() || label,
+          icons: logo ? [{ src: logo, alt: label }] : [{ text: label.slice(0, 2) || "?" }],
+        };
+      },
+    });
+  }
+
+  function enhanceCollectionSortSelect(select = $("#profile-collection-sort")) {
+    if (!select || typeof window.CW?.IconSelect?.enhance !== "function") return;
+    const sortIcons = {
+      collected_at: "schedule",
+      collected_at_asc: "history",
+      title: "sort_by_alpha",
+      title_desc: "sort_by_alpha",
+      year_desc: "calendar_month",
+      year_asc: "calendar_month",
+    };
+    window.CW.IconSelect.enhance(select, {
+      className: "cw-profile-collection-select",
+      menuClassName: "cw-profile-collection-menu",
+      menuMinWidth: 230,
+      getOptionData: (value, option) => ({
+        label: option?.textContent?.trim() || "Sort",
+        icons: [{ symbol: sortIcons[value] || "sort" }],
+      }),
+    });
+  }
+
+  function renderCollectionMetrics(data = {}) {
+    const host = $("#profile-collection-metrics");
+    if (!host) return;
+    const counts = data.counts || {};
+    const providers = Array.isArray(data.providers) ? data.providers.length : 0;
+    const values = [
+      ["violet", "movie", "Movies", "Owned", counts.movie || 0],
+      ["blue", "tv", "Shows", "Owned", counts.show || 0],
+      ["green", "hub", "Providers", "Connected", providers],
+      ["amber", "inventory_2", "Items", "Total", counts.all ?? data.total ?? 0],
+    ];
+    host.innerHTML = values.map(([tone, icon, label, note, value]) => `<span class="cw-collection-tile" data-tone="${esc(tone)}">
+      <span class="material-symbols-rounded" aria-hidden="true">${esc(icon)}</span>
+      <span class="cw-collection-tile-body">
+        <strong>${esc(numberFmt.format(Number(value) || 0))}</strong>
+        <span>${esc(label)}</span>
+        <small>${esc(note)}</small>
+      </span>
+    </span>`).join("");
+  }
+
+  function paintCollectionItems() {
+    const grid = $("#profile-collection-grid");
+    if (!grid) return;
+    const list = collectionState.view === "list";
+    grid.dataset.view = list ? "list" : "grid";
+    if (!collectionState.items.length) {
+      grid.innerHTML = empty("No collection items match this view.");
+      return;
+    }
+    if (list) {
+      grid.innerHTML = collectionListHead() + collectionState.items.map(collectionListRow).join("");
+      applyCollectionColumns();
+      applyCollectionMeta();
+      void hydrateCollectionMeta();
+      return;
+    }
+    grid.innerHTML = collectionState.items.map(collectionCard).join("");
+  }
+
+  function setCollectionView(view) {
+    const next = view === "list" ? "list" : "grid";
+    if (next === collectionState.view) return;
+    collectionState.view = next;
+    saveCollectionPrefs();
+    syncCollectionViewButtons();
+    paintCollectionItems();
+  }
+
+  function syncCollectionViewButtons() {
+    document.querySelectorAll("[data-collection-view]").forEach((btn) => {
+      const active = btn.dataset.collectionView === collectionState.view;
+      btn.classList.toggle("active", active);
+      btn.setAttribute("aria-pressed", String(active));
+    });
+  }
+
+  function renderCollection(data = {}) {
+    const grid = $("#profile-collection-grid");
+    if (!grid) return;
+    collectionState.total = Number(data.total || 0);
+    renderCollectionMetrics(data);
+    renderCollectionTypeChips(data.counts || {});
+    renderCollectionProviders(data.providers || []);
+    paintCollectionItems();
+    renderCollectionPager(data);
+  }
+
+  function collectionPageNumbers(page, pageCount) {
+    if (pageCount <= 7) return Array.from({ length: pageCount }, (_, i) => i + 1);
+    let from = Math.max(2, page - 1);
+    let to = Math.min(pageCount - 1, page + 1);
+    if (page <= 3) { from = 2; to = 3; }
+    else if (page >= pageCount - 2) { from = pageCount - 2; to = pageCount - 1; }
+    const out = [1];
+    if (from > 2) out.push("gap");
+    for (let i = from; i <= to; i += 1) out.push(i);
+    if (to < pageCount - 1) out.push("gap");
+    out.push(pageCount);
+    return out;
+  }
+
+  function renderCollectionPager(data = {}) {
+    const footer = $("#profile-collection-footer");
+    if (!footer) return;
+    const total = Number(data.total || 0);
+    const pageSize = Number(data.page_size || collectionState.pageSize) || collectionState.pageSize;
+    const pageCount = total ? Math.ceil(total / pageSize) : 1;
+    const page = Math.min(Math.max(1, Number(data.page || collectionState.page) || 1), pageCount);
+    collectionState.page = page;
+    collectionState.pageCount = pageCount;
+    footer.hidden = !total;
+    const start = total ? (page - 1) * pageSize : 0;
+    const end = total ? Math.min(start + pageSize, total) : 0;
+    const label = $("#profile-collection-page-label");
+    if (label) label.textContent = total ? `Showing ${numberFmt.format(start + 1)}–${numberFmt.format(end)} of ${numberFmt.format(total)}` : "";
+    const pages = $("#profile-collection-pages");
+    if (pages) {
+      const step = (target, icon, title, disabled) => `<button type="button" data-collection-page="${target}" title="${title}" aria-label="${title}"${disabled ? " disabled" : ""}><span class="material-symbols-rounded" aria-hidden="true">${icon}</span></button>`;
+      const numbers = collectionPageNumbers(page, pageCount).map((entry) => {
+        if (entry === "gap") return `<span class="cw-collection-gap" aria-hidden="true">…</span>`;
+        const active = entry === page;
+        return `<button type="button" class="${active ? "active" : ""}" data-collection-page="${entry}"${active ? ' aria-current="page" disabled' : ""}>${numberFmt.format(entry)}</button>`;
+      }).join("");
+      pages.innerHTML = step(page - 1, "chevron_left", "Previous page", page <= 1) + numbers + step(page + 1, "chevron_right", "Next page", page >= pageCount);
+    }
+  }
+
+  function goToCollectionPage(page) {
+    const target = Math.max(1, Number(page) || 1);
+    if (collectionState.loading || target === collectionState.page) return;
+    if (collectionState.pageCount && target > collectionState.pageCount) return;
+    collectionState.page = target;
+    void loadCollection();
+    $("#profile-panel-collection")?.scrollIntoView({ block: "start", behavior: "smooth" });
+  }
+
+  async function loadCollection({ reset = false } = {}) {
+    if (collectionState.loading) return;
+    if (reset) collectionState.page = 1;
+    collectionState.items = [];
+    const skeletonGrid = $("#profile-collection-grid");
+    if (skeletonGrid) {
+      skeletonGrid.dataset.view = collectionState.view === "list" ? "list" : "grid";
+      skeletonGrid.innerHTML = collectionState.view === "list" ? skeleton("collectionRow", 6) : skeleton("collection", 7);
+    }
+    collectionState.loading = true;
+    lockCollectionPager();
+    const params = new URLSearchParams({
+      type: collectionState.type,
+      provider: collectionState.provider,
+      search: collectionState.search,
+      sort: collectionState.sort,
+      page: String(collectionState.page),
+      page_size: String(collectionState.pageSize),
+    });
+    try {
+      const data = await api(`/api/profile/collection?${params.toString()}`);
+      collectionState.items = Array.isArray(data.items) ? data.items : [];
+      collectionState.loaded = true;
+      renderCollection(data);
+    } catch (e) {
+      const grid = $("#profile-collection-grid");
+      if (grid) grid.innerHTML = empty("Collections could not be loaded.");
+      renderCollectionPager({ total: collectionState.total, page: collectionState.page, page_size: collectionState.pageSize });
+      toast(e.message || "Collections could not be loaded", true);
+    } finally {
+      collectionState.loading = false;
+    }
+  }
+
+  function wireCollection() {
+    let searchTimer = null;
+    document.addEventListener("click", (event) => {
+      const btn = event.target?.closest?.("[data-collection-view]");
+      if (!btn) return;
+      setCollectionView(btn.dataset.collectionView);
+    });
+    syncCollectionViewButtons();
+    document.addEventListener("pointerdown", (event) => {
+      const handle = event.target?.closest?.("[data-collection-resize]");
+      if (!handle) return;
+      startCollectionResize(event, handle.dataset.collectionResize);
+    });
+    document.addEventListener("dblclick", (event) => {
+      const handle = event.target?.closest?.("[data-collection-resize]");
+      if (!handle) return;
+      event.preventDefault();
+      delete collectionState.cols[handle.dataset.collectionResize];
+      applyCollectionColumns();
+      saveCollectionPrefs();
+    });
+    enhanceCollectionProviderSelect();
+    enhanceCollectionSortSelect();
+    $("#profile-collection-types")?.addEventListener("click", (event) => {
+      const btn = event.target?.closest?.("[data-collection-type]");
+      if (!btn) return;
+      collectionState.type = btn.dataset.collectionType || "all";
+      void loadCollection({ reset: true });
+    });
+    $("#profile-collection-provider")?.addEventListener("change", (event) => {
+      collectionState.provider = event.target?.value || "";
+      void loadCollection({ reset: true });
+    });
+    $("#profile-collection-sort")?.addEventListener("change", (event) => {
+      collectionState.sort = event.target?.value || "collected_at";
+      void loadCollection({ reset: true });
+    });
+    $("#profile-collection-search")?.addEventListener("input", (event) => {
+      collectionState.search = event.target?.value || "";
+      clearTimeout(searchTimer);
+      searchTimer = setTimeout(() => loadCollection({ reset: true }), 220);
+    });
+    document.addEventListener("keydown", (event) => {
+      if (!(event.ctrlKey || event.metaKey) || String(event.key || "").toLowerCase() !== "k") return;
+      if (!$("#profile-panel-collection")?.classList?.contains("active")) return;
+      const input = $("#profile-collection-search");
+      if (!input) return;
+      event.preventDefault();
+      input.focus();
+      input.select?.();
+    });
+    $("#profile-collection-pages")?.addEventListener("click", (event) => {
+      const btn = event.target?.closest?.("[data-collection-page]");
+      if (!btn || btn.disabled) return;
+      goToCollectionPage(Number(btn.dataset.collectionPage));
+    });
+    const pageSizeSelect = $("#profile-collection-page-size");
+    if (pageSizeSelect) {
+      pageSizeSelect.value = String(collectionState.pageSize);
+      pageSizeSelect.addEventListener("change", (event) => {
+        const next = Number(event.target?.value) || 24;
+        if (next === collectionState.pageSize) return;
+        collectionState.pageSize = next;
+        saveCollectionPrefs();
+        void loadCollection({ reset: true });
+      });
+    }
+    syncCollectionViewButtons();
   }
 
   function connectedServices(status) {
@@ -822,6 +1452,7 @@
         const key = btn.dataset.profileTab;
         document.querySelectorAll("[data-profile-tab]").forEach((tab) => tab.classList.toggle("active", tab === btn));
         document.querySelectorAll(".cw-profile-panel").forEach((panel) => panel.classList.toggle("active", panel.id === `profile-panel-${key}`));
+        if (key === "collection" && !collectionState.loaded) void loadCollection({ reset: true });
       });
     });
   }
@@ -1152,6 +1783,7 @@
 
   function wirePosterOverlay() {
     const openFromTarget = (target, event) => {
+      if (target?.closest?.("[data-collection-resize]")) return false;
       const btn = target?.closest?.("[data-profile-poster-key]");
       if (!btn) return false;
       const item = posterItems.get(btn.dataset.profilePosterKey || "");
@@ -1202,6 +1834,7 @@
 
   async function init() {
     wireTabs();
+    wireCollection();
     wirePreferences();
     wireAvatar();
     wireForms();

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -1707,14 +1707,14 @@ def test_profile_nav_keeps_read_only_managed_links() -> None:
         user={"is_admin": False, "profile_id": ALICE_PROFILE_ID, "username": "pascal", "permissions": {"dashboard": True, "watchlist": True, "playback": True, "write": False}},
     )
 
-    assert 'class="tab active" href="/profile">Main</a>' in html
-    assert 'class="tab" href="/?view=watchlist#watchlist">Watchlist</a>' in html
-    assert 'class="tab" href="/?view=playback_progress#playback_progress">Playback</a>' in html
+    assert """<button class="tab active" type="button" onclick="location.href='/profile'">Main</button>""" in html
+    assert """<button class="tab" type="button" onclick="location.href='/?view=watchlist#watchlist'">Watchlist</button>""" in html
+    assert """<button class="tab" type="button" onclick="location.href='/?view=playback_progress#playback_progress'">Playback</button>""" in html
     assert 'href="/?view=watchlist#watchlist">View all</a>' in html
     assert 'href="/?view=playback_progress#playback_progress">View all</a>' in html
     assert 'id="cw-profile-logout"' in html
-    assert 'href="/?main=1#main">Main</a>' not in html
-    assert 'href="/?main=1#snapshots">Captures</a>' not in html
+    assert "location.href='/?main=1#main'" not in html
+    assert "location.href='/?main=1#snapshots'" not in html
 
 
 def test_profile_nav_uses_full_user_links_for_write_managed_user() -> None:
@@ -1724,12 +1724,12 @@ def test_profile_nav_uses_full_user_links_for_write_managed_user() -> None:
         user={"is_admin": False, "profile_id": ALICE_PROFILE_ID, "username": "pascal", "permissions": {"dashboard": True, "watchlist": True, "playback": True, "write": True}},
     )
 
-    assert 'class="tab active" href="/?main=1#main">Main</a>' in html
-    assert 'href="/?main=1#watchlist">Watchlist</a>' in html
-    assert 'href="/?main=1#playback_progress">Playback</a>' in html
-    assert 'href="/?main=1#snapshots">Captures</a>' in html
-    assert 'href="/?main=1#playlists">Playlists</a>' in html
-    assert 'href="/?main=1#editor">Editor</a>' in html
+    assert """<button class="tab active" type="button" onclick="location.href='/?main=1#main'">Main</button>""" in html
+    assert """<button class="tab" type="button" onclick="location.href='/?main=1#watchlist'">Watchlist</button>""" in html
+    assert """<button class="tab" type="button" onclick="location.href='/?main=1#playback_progress'">Playback</button>""" in html
+    assert """<button class="tab" type="button" onclick="location.href='/?main=1#snapshots'">Captures</button>""" in html
+    assert """<button class="tab" type="button" onclick="location.href='/?main=1#playlists'">Playlists</button>""" in html
+    assert """<button class="tab" type="button" onclick="location.href='/?main=1#editor'">Editor</button>""" in html
     assert 'href="/?main=1#watchlist">View all</a>' in html
     assert 'href="/?main=1#playback_progress">View all</a>' in html
     assert 'href="/?main=1#settings">Settings</a>' not in html
@@ -1755,12 +1755,12 @@ def test_profile_page_supports_admin_account() -> None:
     assert 'data-cw-role="admin"' in html
     assert 'data-cw-profile-id=""' in html
     assert 'id="profile-role" class="cw-profile-role">Administrator</span>' in html
-    assert 'class="tab active" href="/">Main</a>' in html
-    assert 'href="/#watchlist">Watchlist</a>' in html
-    assert 'href="/#playback_progress">Playback</a>' in html
-    assert 'href="/#snapshots">Captures</a>' in html
-    assert 'href="/#playlists">Playlists</a>' in html
-    assert 'href="/#editor">Editor</a>' in html
+    assert """<button class="tab active" type="button" onclick="location.href='/'">Main</button>""" in html
+    assert """<button class="tab" type="button" onclick="location.href='/#watchlist'">Watchlist</button>""" in html
+    assert """<button class="tab" type="button" onclick="location.href='/#playback_progress'">Playback</button>""" in html
+    assert """<button class="tab" type="button" onclick="location.href='/#snapshots'">Captures</button>""" in html
+    assert """<button class="tab" type="button" onclick="location.href='/#playlists'">Playlists</button>""" in html
+    assert """<button class="tab" type="button" onclick="location.href='/#editor'">Editor</button>""" in html
     assert 'id="tab-settings" class="tab"' in html
     assert '<span>Settings</span><span class="tab-caret"' in html
     assert 'id="tab-about" class="tab"' in html
@@ -1917,7 +1917,8 @@ def test_quick_stats_counts_movies_and_shows_from_history_breakdown() -> None:
     assert "const movies = Number(breakdown.movies ?? watchtime.movies ?? sampleStats.movies) || 0;" in stats
     assert "const shows = Number(breakdown.shows ?? watchtime.shows ?? sampleStats.shows) || 0;" in stats
     assert "const anime = Number(breakdown.anime) || 0;" in stats
-    assert "const episodes = Number(breakdown.episodes ?? sampleStats.episodes) || 0;" in stats
+    assert "const owned = (Number(collectionCounts.movie) || 0) + (Number(collectionCounts.show) || 0);" in stats
+    assert '["collections", "inventory_2", "video_library", "Collections", numberFmt.format(owned), "Movies and shows you own"],' in stats
     assert 'const breakdown = insights?.features?.history?.breakdown || {};' in stats
     assert '["anime", "animation", "auto_awesome", "Anime", numberFmt.format(anime), "Total anime in your syncs"],' in stats
     assert "cw-profile-stat--anime" in Path("assets/css/profile-page.css").read_text("utf-8")
@@ -1928,7 +1929,7 @@ def test_profile_overview_paints_shimmer_skeletons_before_data_lands() -> None:
     css = Path("assets/css/profile-page.css").read_text("utf-8")
 
     assert "async function init() {\n    paintOverviewSkeletons();" in js
-    assert "posterItems.clear();\n    paintOverviewSkeletons();" in js
+    assert "prunePosterItems();" in js
     for host in ("#profile-progress", "#profile-watchlist", "#profile-quick-stats"):
         assert host in js[js.index("function paintOverviewSkeletons()"):js.index("function setAvatar(url)")]
     for primitive in ("cw-dash-skeleton", "cw-dash-skeleton-row", "cw-skel-block", "cw-skel-line--title", "cw-skel-line--meta", "cw-skel-dot"):

--- a/tests/test_profile_collection.py
+++ b/tests/test_profile_collection.py
@@ -1,0 +1,181 @@
+from pathlib import Path
+
+from api import profileAPI
+
+
+def _baseline(items: dict) -> dict:
+    return {"collection": {"baseline": {"items": items}}}
+
+
+def test_profile_collection_merges_owned_sources_for_user_profile() -> None:
+    state = {
+        "providers": {
+            "PLEX": {
+                "instances": {
+                    "PLEX-P01": _baseline({
+                        "tmdb:10": {
+                            "type": "movie",
+                            "title": "Owned Movie",
+                            "year": 2026,
+                            "ids": {"tmdb": "10"},
+                            "collected_at": "2026-01-01T00:00:00Z",
+                            "library_title": "Movies",
+                        }
+                    })
+                }
+            },
+            "MDBLIST": _baseline({
+                "tmdb:10": {
+                    "type": "movie",
+                    "title": "Owned Movie",
+                    "year": 2026,
+                    "ids": {"tmdb": "10"},
+                    "collected_at": "2026-02-01T00:00:00Z",
+                }
+            }),
+            "TRAKT": _baseline({
+                "tmdb:99": {
+                    "type": "movie",
+                    "title": "Other Profile",
+                    "ids": {"tmdb": "99"},
+                }
+            }),
+        }
+    }
+    cfg = {
+        "plex": {"instances": {"PLEX-P01": {"label": "Plex"}}},
+        "mdblist": {},
+        "user_profiles": {
+            "alice": {"label": "Alice", "instances": {"PLEX": ["PLEX-P01"], "MDBLIST": ["default"]}},
+        }
+    }
+
+    payload = profileAPI.build_profile_collection_payload(state, cfg, profile_id="alice")
+
+    assert payload["total"] == 1
+    item = payload["items"][0]
+    assert item["title"] == "Owned Movie"
+    assert item["owned_instance_count"] == 2
+    assert item["providers"] == ["mdblist", "plex"]
+    assert item["sources_by_provider"] == {"plex": ["PLEX-P01"], "mdblist": ["default"]}
+    assert item["first_collected_at"] == "2026-01-01T00:00:00Z"
+    assert item["last_collected_at"] == "2026-02-01T00:00:00Z"
+    assert item["libraries"] == ["Movies"]
+    assert payload["counts"]["movie"] == 1
+
+
+def test_profile_collection_ui_assets_are_registered() -> None:
+    root = Path(__file__).resolve().parents[1]
+    html = (root / "ui_frontend.py").read_text(encoding="utf-8")
+    js = (root / "assets/js/profile-page.js").read_text(encoding="utf-8")
+    css = (root / "assets/css/profile-page.css").read_text(encoding="utf-8")
+
+    assert 'data-profile-tab="collection"' in html
+    assert 'id="profile-panel-collection"' in html
+    assert "Your unified library across all providers" in html
+    assert 'data-collection-view="grid"' in html
+    assert 'data-collection-view="list"' in html
+    assert 'id="profile-collection-page-size"' in html
+    assert "/assets/helpers/icon-select.js" in html
+    assert "/api/profile/collection" in js
+    assert "IconSelect.enhance" in js
+    assert "last_collected_at" in js
+    assert "cw-profile-collection-own" not in js
+    assert ".cw-collection-grid" in css
+
+
+def test_profile_collection_index_is_cached_per_fingerprint() -> None:
+    state = {
+        "providers": {
+            "PLEX": _baseline({
+                "tmdb:1": {"type": "movie", "title": "One", "ids": {"tmdb": "1"}},
+                "tmdb:2": {"type": "show", "title": "Two", "ids": {"tmdb": "2"}},
+            })
+        }
+    }
+    loads = []
+
+    def loader():
+        loads.append(1)
+        return state
+
+    first = profileAPI.build_profile_collection_payload(loader, {}, cache_key=("unit", 1))
+    second = profileAPI.build_profile_collection_payload(loader, {}, cache_key=("unit", 1), sort="title")
+
+    assert first["total"] == 2
+    assert second["total"] == 2
+    assert len(loads) == 1
+
+    profileAPI.build_profile_collection_payload(loader, {}, cache_key=("unit", 2))
+    assert len(loads) == 2
+
+    uncached = profileAPI.build_profile_collection_payload(state, {})
+    assert uncached["total"] == 2
+
+
+def test_profile_collection_cache_does_not_leak_sorts_between_requests() -> None:
+    state = {
+        "providers": {
+            "PLEX": _baseline({
+                "tmdb:1": {"type": "movie", "title": "Bravo", "ids": {"tmdb": "1"}, "collected_at": "2026-01-01T00:00:00Z"},
+                "tmdb:2": {"type": "movie", "title": "Alpha", "ids": {"tmdb": "2"}, "collected_at": "2026-02-01T00:00:00Z"},
+            })
+        }
+    }
+    key = ("unit-sort", 1)
+
+    by_title = profileAPI.build_profile_collection_payload(state, {}, cache_key=key, sort="title")
+    by_date = profileAPI.build_profile_collection_payload(state, {}, cache_key=key, sort="collected_at")
+
+    assert [item["title"] for item in by_title["items"]] == ["Alpha", "Bravo"]
+    assert [item["title"] for item in by_date["items"]] == ["Alpha", "Bravo"]
+    assert by_date["counts"]["all"] == 2
+
+    filtered = profileAPI.build_profile_collection_payload(state, {}, cache_key=key, search="alpha")
+    assert filtered["total"] == 1
+    assert profileAPI.build_profile_collection_payload(state, {}, cache_key=key)["total"] == 2
+
+
+def test_profile_collection_keeps_show_ids_for_episodes() -> None:
+    state = {
+        "providers": {
+            "TRAKT": _baseline({
+                "tmdb:7461052": {
+                    "type": "episode",
+                    "title": "Pilot",
+                    "series_title": "Lioness",
+                    "season": 3,
+                    "episode": 4,
+                    "show_ids": {"tmdb": "125988", "tvdb": "404126", "imdb": "tt13111078"},
+                    "ids": {"tmdb": "7461052", "trakt": "999"},
+                    "collected_at": "2026-08-23T00:00:00Z",
+                }
+            })
+        }
+    }
+
+    item = profileAPI.build_profile_collection_payload(state, {})["items"][0]
+
+    assert item["show_ids"]["tmdb"] == "125988"
+    assert item["ids"]["tmdb_show"] == "125988"
+    assert item["ids"]["imdb_show"] == "tt13111078"
+    assert item["ids"]["tvdb_show"] == "404126"
+    assert item["ids"]["tmdb"] == "7461052"
+
+
+def test_profile_collection_movies_keep_plain_ids() -> None:
+    state = {"providers": {"TRAKT": _baseline({
+        "tmdb:550": {"type": "movie", "title": "Fight Club", "year": 1999, "ids": {"tmdb": "550"}},
+    })}}
+
+    item = profileAPI.build_profile_collection_payload(state, {})["items"][0]
+
+    assert item["ids"] == {"tmdb": "550"}
+    assert "tmdb_show" not in item["ids"]
+
+
+def test_profile_page_uses_show_ids_for_episode_art() -> None:
+    js = Path(__file__).resolve().parents[1].joinpath("assets/js/profile-page.js").read_text(encoding="utf-8")
+
+    assert "const showTmdbId = (item)" in js
+    assert "const id = episode ? showTmdbId(item) : tmdbId(item);" in js

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -223,6 +223,11 @@ def _assert_admin_shell_stripped(html: str) -> None:
     raise RuntimeError("managed_user_shell_strip_failed:" + ",".join(sorted(leaked)))
 
 
+def _profile_nav_tab(label: str, href: str, active: bool = False) -> str:
+    cls = "tab active" if active else "tab"
+    return f"<button class=\"{cls}\" type=\"button\" onclick=\"location.href='{href}'\">{label}</button>"
+
+
 def _nav_profile_link() -> str:
     return '    <a id="cw-nav-profile-link" class="cw-nav-profile-link" href="/profile" title="Open profile" aria-label="Open profile"><span id="cw-nav-profile-avatar" class="cw-nav-profile-avatar material-symbols-rounded" aria-hidden="true">person</span></a>'
 
@@ -1866,31 +1871,31 @@ def get_profile_html(user: dict | None = None) -> str:
     nav_items: list[str] = []
     if is_admin:
         nav_items.extend([
-            '<a class="tab active" href="/">Main</a>',
-            '<a class="tab" href="/#watchlist">Watchlist</a>',
-            '<a class="tab" href="/#playback_progress">Playback</a>',
-            '<a class="tab" href="/#snapshots">Captures</a>',
-            '<a class="tab" href="/#playlists">Playlists</a>',
-            '<a class="tab" href="/#editor">Editor</a>',
+            _profile_nav_tab("Main", "/", active=True),
+            _profile_nav_tab("Watchlist", "/#watchlist"),
+            _profile_nav_tab("Playback", "/#playback_progress"),
+            _profile_nav_tab("Captures", "/#snapshots"),
+            _profile_nav_tab("Playlists", "/#playlists"),
+            _profile_nav_tab("Editor", "/#editor"),
             settings_nav,
             about_nav,
         ])
     elif write_nav:
         nav_items.extend([
-            '<a class="tab active" href="/?main=1#main">Main</a>',
-            '<a class="tab" href="/?main=1#watchlist">Watchlist</a>',
-            '<a class="tab" href="/?main=1#playback_progress">Playback</a>',
-            '<a class="tab" href="/?main=1#snapshots">Captures</a>',
-            '<a class="tab" href="/?main=1#playlists">Playlists</a>',
-            '<a class="tab" href="/?main=1#editor">Editor</a>',
+            _profile_nav_tab("Main", "/?main=1#main", active=True),
+            _profile_nav_tab("Watchlist", "/?main=1#watchlist"),
+            _profile_nav_tab("Playback", "/?main=1#playback_progress"),
+            _profile_nav_tab("Captures", "/?main=1#snapshots"),
+            _profile_nav_tab("Playlists", "/?main=1#playlists"),
+            _profile_nav_tab("Editor", "/?main=1#editor"),
             '<button id="cw-profile-logout" class="tab" type="button">Logout</button>',
         ])
     else:
-        nav_items.append('<a class="tab active" href="/profile">Main</a>')
+        nav_items.append(_profile_nav_tab("Main", "/profile", active=True))
         if perms.get("watchlist"):
-            nav_items.append(f'<a class="tab" href="{watchlist_href}">Watchlist</a>')
+            nav_items.append(_profile_nav_tab("Watchlist", watchlist_href))
         if perms.get("playback"):
-            nav_items.append(f'<a class="tab" href="{playback_href}">Playback</a>')
+            nav_items.append(_profile_nav_tab("Playback", playback_href))
         nav_items.append('<button id="cw-profile-logout" class="tab" type="button">Logout</button>')
     nav_items.append(_nav_profile_link().strip())
     profile_nav = "\n    ".join(nav_items)
@@ -1943,11 +1948,14 @@ def get_profile_html(user: dict | None = None) -> str:
 </script>
 </head>
 <body class="cw-profile-page">
-<header class="cw-profile-topbar">
-  <a class="brand" href="/profile" title="Go to profile">
+<header>
+  <div class="brand" role="button" tabindex="0" title="Go to Profile" onclick="location.href='/profile'" onkeypress="if(event.key==='Enter'||event.key===' ')location.href='/profile'">
     <img class="logo" src="/assets/pwa/favicon-64.png?v=__CW_VERSION__" alt="CrossWatch">
-    <span class="brand-text"><span class="name">CrossWatch</span><span class="version">__CW_CURRENT_VERSION__</span></span>
-  </a>
+    <span class="brand-text">
+      <span class="name">CrossWatch</span>
+      <span class="version">__CW_CURRENT_VERSION__</span>
+    </span>
+  </div>
   <nav class="tabs" aria-label="Primary navigation">
     {profile_nav}
   </nav>
@@ -1999,6 +2007,7 @@ def get_profile_html(user: dict | None = None) -> str:
   </section>
   <div class="cw-profile-tabs" role="tablist" aria-label="Profile tabs">
     <button id="profile-tab-overview" class="active" type="button" data-profile-tab="overview">Overview</button>
+    <button id="profile-tab-collection" type="button" data-profile-tab="collection">Collections</button>
     <button id="profile-tab-security" type="button" data-profile-tab="security">Security</button>
 {preferences_tab}
   </div>
@@ -2096,6 +2105,51 @@ def get_profile_html(user: dict | None = None) -> str:
       <div id="recent-playlists-list" class="cw-history-widget-list cw-widget-scrollbar" aria-live="polite"></div>
     </article>
   </section>
+  </section>
+  <section id="profile-panel-collection" class="cw-profile-panel">
+    <header class="cw-collection-head">
+      <div class="cw-collection-headline">
+        <span class="cw-collection-kicker">Owned Media</span>
+        <h2>Collections</h2>
+        <p>Your unified library across all providers</p>
+      </div>
+      <div class="cw-collection-tiles" id="profile-collection-metrics"></div>
+    </header>
+    <div class="cw-collection-toolbar">
+      <label class="cw-collection-search">
+        <span class="material-symbols-rounded" aria-hidden="true">search</span>
+        <input id="profile-collection-search" type="search" placeholder="Search collections...">
+      </label>
+      <div class="cw-collection-chips" id="profile-collection-types" aria-label="Collection type filters"></div>
+      <div class="cw-collection-controls">
+        <select id="profile-collection-provider" aria-label="Provider filter"><option value="">All providers</option></select>
+        <select id="profile-collection-sort" aria-label="Collection sort">
+          <option value="collected_at">Recently added</option>
+          <option value="collected_at_asc">Oldest added</option>
+          <option value="title">Title A-Z</option>
+          <option value="title_desc">Title Z-A</option>
+          <option value="year_desc">Year: newest</option>
+          <option value="year_asc">Year: oldest</option>
+        </select>
+        <div class="cw-collection-views" role="group" aria-label="View mode">
+          <button class="active" type="button" data-collection-view="grid" title="Grid view" aria-label="Grid view" aria-pressed="true"><span class="material-symbols-rounded" aria-hidden="true">grid_view</span></button>
+          <button type="button" data-collection-view="list" title="List view" aria-label="List view" aria-pressed="false"><span class="material-symbols-rounded" aria-hidden="true">view_list</span></button>
+        </div>
+      </div>
+    </div>
+    <div id="profile-collection-grid" class="cw-collection-grid" data-view="grid" aria-live="polite"></div>
+    <div id="profile-collection-footer" class="cw-collection-footer" hidden>
+      <nav id="profile-collection-pages" class="cw-collection-pages" aria-label="Collection pages"></nav>
+      <div class="cw-collection-summary">
+        <span id="profile-collection-page-label"></span>
+        <select id="profile-collection-page-size" aria-label="Items per page">
+          <option value="24">24</option>
+          <option value="48">48</option>
+          <option value="72">72</option>
+          <option value="96">96</option>
+        </select>
+      </div>
+    </div>
   </section>
   <section id="profile-panel-security" class="cw-profile-panel">
     <div class="cw-profile-security-grid">
@@ -2255,6 +2309,7 @@ def get_profile_html(user: dict | None = None) -> str:
 </script>
 <script type="module" src="/assets/js/modals.js?v=__CW_VERSION__"></script>
 <script src="/assets/helpers/provider-meta.js?v=__CW_VERSION__"></script>
+<script src="/assets/helpers/icon-select.js?v=__CW_VERSION__"></script>
 <script src="/assets/helpers/api.js?v=__CW_VERSION__"></script>
 <script src="/assets/helpers/media-meta.js?v=__CW_VERSION__"></script>
 <script src="/assets/helpers/trailer.js?v=__CW_VERSION__"></script>


### PR DESCRIPTION
# Pull request

## Change

- Add a simple collections page to user profiles.
- Shows owned media from collection state with filters, provider counts, and collection cards.

## Why

- Collections are now a sync feature, so users need a basic place to view what CrossWatch has stored across providers.

## Testing

- tests/test_profile_collection.py tests/test_crosswatch_profiles.py

## Issue

Relates to #866