### PR TITLE
Fix: rewatch support flags

### DIFF
--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -931,6 +931,22 @@ function applySubDisable(feature){
     only.closest?.(".opt-row")?.classList.toggle("muted",only.disabled);
   }
 }
+function applyHistoryRewatchGuard(state){
+  const rw=ID("cx-hs-rewatches");
+  if(!rw) return;
+  const row=rw.closest?.(".opt-row");
+  const supported=pairSupportsHistoryRewatches(state);
+  const enabled=!!ID("cx-hs-enable")?.checked;
+  if(!supported){
+    rw.checked=false;
+    rw.disabled=true;
+    row?.classList.add("disabled","muted");
+    return;
+  }
+  rw.disabled=!enabled;
+  row?.classList.remove("disabled");
+  row?.classList.toggle("muted",!enabled);
+}
 
 function countProviderLibraries(state, providerName){
   const historyLibs = state.options?.history?.libraries?.[providerName];
@@ -1896,12 +1912,7 @@ left.innerHTML = `
 
     right.innerHTML = parts.join("");
     applySubDisable("history");
-    const rw = ID("cx-hs-rewatches");
-    if(rw && !rwSupported){
-      rw.checked = false;
-      rw.disabled = true;
-      rw.closest(".opt-row")?.classList.add("disabled");
-    }
+    applyHistoryRewatchGuard(state);
     return;
   }
 
@@ -2208,6 +2219,7 @@ function bindChangeHandlers(state,root){
         if (add) add.checked = true;
       }
       applySubDisable("history");
+      applyHistoryRewatchGuard(state);
     }
 
     if (id === "cx-pl-enable") {

--- a/providers/sync/_mod_EMBY.py
+++ b/providers/sync/_mod_EMBY.py
@@ -185,6 +185,14 @@ _FEATURES: dict[str, Any] = {
     "collection": feat_collection,
 }
 
+_HISTORY_CAPABILITIES: dict[str, Any] = {
+    "index_semantics": "present",
+    "observed_deletes": True,
+    "aggregated": True,
+    "event_history": False,
+    "rewatches": {"read": False, "write": False, "account_gate": False},
+}
+
 _PLAYLIST_CAPABILITIES: dict[str, Any] = {
     "read": True,
     "create": True,
@@ -266,6 +274,7 @@ def get_manifest() -> Mapping[str, Any]:
             "bidirectional": True,
             "provides_ids": False,
             "index_semantics": "present",
+            "history": _HISTORY_CAPABILITIES,
             "ratings": {
                 "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
                 "upsert": True,
@@ -733,6 +742,7 @@ class _EmbyOPS:
             "bidirectional": True,
             "provides_ids": False,
             "index_semantics": "present",
+            "history": _HISTORY_CAPABILITIES,
             "ratings": {
                 "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
                 "upsert": True,

--- a/providers/sync/_mod_FLICKLIST.py
+++ b/providers/sync/_mod_FLICKLIST.py
@@ -105,6 +105,8 @@ def get_manifest() -> Mapping[str, Any]:
                 "accepted_ids": list(_ACCEPTED_IDS),
                 "provides_ids": ["fldb", "tmdb", "imdb", "tvdb", "anilist"],
                 "rewatch": True,
+                "event_history": True,
+                "rewatches": {"read": True, "write": True, "account_gate": False},
                 "requires_watched_at": False,
                 "batch_size": 1000,
             },

--- a/providers/sync/_mod_JELLYFIN.py
+++ b/providers/sync/_mod_JELLYFIN.py
@@ -178,6 +178,14 @@ _FEATURES: dict[str, Any] = {
     "collection": feat_collection,
 }
 
+_HISTORY_CAPABILITIES: dict[str, Any] = {
+    "index_semantics": "present",
+    "observed_deletes": True,
+    "aggregated": True,
+    "event_history": False,
+    "rewatches": {"read": False, "write": False, "account_gate": False},
+}
+
 _PLAYLIST_CAPABILITIES: dict[str, Any] = {
     "read": True,
     "create": True,
@@ -276,6 +284,7 @@ def get_manifest() -> Mapping[str, Any]:
             "bidirectional": True,
             "provides_ids": False,
             "index_semantics": "present",
+            "history": _HISTORY_CAPABILITIES,
             "ratings": {
                 "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
                 "upsert": True,
@@ -761,6 +770,7 @@ class _JellyfinOPS:
             "bidirectional": True,
             "provides_ids": False,
             "index_semantics": "present",
+            "history": _HISTORY_CAPABILITIES,
             "ratings": {
                 "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
                 "upsert": True,

--- a/providers/sync/_mod_KODI.py
+++ b/providers/sync/_mod_KODI.py
@@ -39,6 +39,8 @@ def get_manifest() -> Mapping[str, Any]:
             "remove": True,
             "observed_deletes": True,
             "aggregated": True,
+            "event_history": False,
+            "rewatches": {"read": False, "write": False},
         },
         "ratings": {
             "read": True,

--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -532,7 +532,12 @@ def get_manifest() -> Mapping[str, Any]:
             "bidirectional": True,
             "provides_ids": True,
             "index_semantics": "present",
-            "history": {"index_semantics": "present", "observed_deletes": True},
+            "history": {
+                "index_semantics": "present",
+                "observed_deletes": True,
+                "event_history": True,
+                "rewatches": {"read": True, "write": False, "account_gate": False},
+            },
             "watchlist": {"writes": "discover_first", "pms_fallback": True, "upsert": True, "remove": True},
             "ratings": {
                 "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
@@ -1535,7 +1540,12 @@ class _PlexOPS:
             "bidirectional": True,
             "provides_ids": True,
             "index_semantics": "present",
-            "history": {"index_semantics": "present", "observed_deletes": True},
+            "history": {
+                "index_semantics": "present",
+                "observed_deletes": True,
+                "event_history": True,
+                "rewatches": {"read": True, "write": False, "account_gate": False},
+            },
             "watchlist": {"writes": "discover_first", "pms_fallback": True, "upsert": True, "remove": True},
             "ratings": {
                 "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},

--- a/providers/sync/_mod_PUNCHPLAY.py
+++ b/providers/sync/_mod_PUNCHPLAY.py
@@ -110,6 +110,8 @@ def get_manifest() -> Mapping[str, Any]:
                 "accepted_ids": list(_ACCEPTED_IDS),
                 "provides_ids": ["tmdb"],
                 "rewatch": True,
+                "event_history": True,
+                "rewatches": {"read": True, "write": True, "account_gate": False},
                 "requires_watched_at": True,
                 "batch_size": 100,
             },

--- a/providers/sync/_mod_TAUTULLI.py
+++ b/providers/sync/_mod_TAUTULLI.py
@@ -22,6 +22,16 @@ os.environ.setdefault("CW_TAUTULLI_VERSION", __VERSION__)
 os.environ.setdefault("CW_TAUTULLI_UA", f"CrossWatch/{__VERSION__} (Tautulli)")
 __all__ = ["get_manifest", "OPS"]
 
+_HISTORY_CAPABILITIES: dict[str, Any] = {
+    "read": True,
+    "write": False,
+    "types": {"movies": True, "shows": False, "seasons": False, "episodes": True},
+    "index_semantics": "event",
+    "observed_deletes": False,
+    "event_history": True,
+    "rewatches": {"read": True, "write": False, "account_gate": False},
+}
+
 def _health(status: str, ok: bool, latency_ms: int) -> None:
     cw_log("TAUTULLI", "health", "info", "health", latency_ms=latency_ms, ok=ok, status=status)
 
@@ -63,6 +73,7 @@ def get_manifest() -> Mapping[str, Any]:
             "can_source": True,
             "can_target": False,
             "read_only": True,
+            "history": _HISTORY_CAPABILITIES,
         },
         "description": "Plex monitoring (history only).",
     }
@@ -238,6 +249,7 @@ class _TAUTULLIOPS:
             "can_source": True,
             "can_target": False,
             "read_only": True,
+            "history": _HISTORY_CAPABILITIES,
         }
 
     def is_configured(self, cfg: Mapping[str, Any]) -> bool:

--- a/providers/sync/punchplay/_history.py
+++ b/providers/sync/punchplay/_history.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Iterable, Mapping
 
+from cw_platform.history_events import history_sync_key, minimal_history_item
 from cw_platform.id_map import canonical_key, minimal as id_minimal
 
 from ._common import (
@@ -42,6 +43,17 @@ def _key_of(obj: Mapping[str, Any]) -> str:
         return str(canonical_key(id_minimal(obj)) or "").strip()
     except Exception:
         return ""
+
+
+def _rewatches_enabled(adapter: Any) -> bool:
+    cfg = getattr(adapter, "config", None)
+    return bool(isinstance(cfg, Mapping) and cfg.get("_cw_history_rewatches"))
+
+
+def _history_key(adapter: Any, item: Mapping[str, Any]) -> str:
+    if _rewatches_enabled(adapter):
+        return history_sync_key(item, event_mode=True)
+    return _key_of(item)
 
 
 def _as_int(value: Any) -> int | None:
@@ -129,14 +141,21 @@ def _row_to_minimal(row: Mapping[str, Any]) -> dict[str, Any] | None:
     return out
 
 
-def _collect_history_rows(rows: Any, collected: dict[str, dict[str, Any]]) -> int:
+def _collect_history_rows(adapter: Any, rows: Any, collected: dict[str, dict[str, Any]]) -> int:
     row_list = [r for r in rows if isinstance(r, Mapping)] if isinstance(rows, list) else []
+    event_mode = _rewatches_enabled(adapter)
     for row in row_list:
         minimal = _row_to_minimal(row)
         if not minimal:
             continue
-        key = _key_of(minimal)
+        key = _history_key(adapter, minimal)
         if not key:
+            continue
+        if event_mode:
+            if key in collected:
+                suffix = str(minimal.get(HISTORY_EVENT_ID_FIELD) or len(collected))
+                key = f"{key}~pp{suffix}"
+            collected[key] = minimal_history_item(minimal, key, event_mode=True)
             continue
         existing = collected.get(key)
         if existing is None:
@@ -160,7 +179,7 @@ def _index_from_snapshot(adapter: Any, *, per_page: int) -> dict[str, dict[str, 
     rows = 0
     for page in snapshot_pages(adapter, "history", feature=FEATURE, limit=per_page):
         pages += 1
-        rows += _collect_history_rows(page, collected)
+        rows += _collect_history_rows(adapter, page, collected)
     _dbg(FEATURE, "snapshot_scanned", rows=rows, indexed=len(collected), pages=pages)
     return collected
 
@@ -186,7 +205,7 @@ def _index_from_history_endpoint(adapter: Any, *, per_page: int, max_pages: int)
         if not isinstance(data, Mapping):
             break
         rows = data.get("items")
-        row_count = _collect_history_rows(rows, collected)
+        row_count = _collect_history_rows(adapter, rows, collected)
 
         cursor = data.get("nextCursor") or None
         if not cursor or row_count <= 0:
@@ -211,8 +230,8 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
     return collected
 
 
-def _payload_for(item: Mapping[str, Any]) -> tuple[dict[str, Any], str] | None:
-    key = _key_of(item)
+def _payload_for(adapter: Any, item: Mapping[str, Any]) -> tuple[dict[str, Any], str] | None:
+    key = _history_key(adapter, item)
     if not key:
         return None
 
@@ -268,9 +287,9 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
     unresolved_keys: list[str] = []
 
     for item in items or []:
-        built = _payload_for(item)
+        built = _payload_for(adapter, item)
         if built is None:
-            key = _key_of(item)
+            key = _history_key(adapter, item)
             if key:
                 unresolved_keys.append(key)
                 unresolved.append({"key": key, "status": "missing_supported_id_or_watched_at"})
@@ -310,7 +329,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
     ok = True
 
     for item in items or []:
-        key = _key_of(item)
+        key = _history_key(adapter, item)
         if not key:
             continue
 
@@ -339,6 +358,11 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
             unresolved_keys.append(key)
             unresolved.append({"key": key, "status": "missing_history_entry_id"})
             _dbg(FEATURE, "item_unresolved_before_write", key=key, reason="episode_delete_needs_entry_id")
+            continue
+        if _rewatches_enabled(adapter):
+            unresolved_keys.append(key)
+            unresolved.append({"key": key, "status": "missing_history_entry_id"})
+            _dbg(FEATURE, "item_unresolved_before_write", key=key, reason="event_delete_needs_entry_id")
             continue
 
         payload = ids_for_punchplay(item)

--- a/providers/sync/tautulli/_history.py
+++ b/providers/sync/tautulli/_history.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 import re
 from typing import Any
 
+from cw_platform.history_events import history_sync_key, minimal_history_item
 from cw_platform.id_map import canonical_key, ids_from_guid
 
 from ._common import make_logger
@@ -25,6 +26,11 @@ def _cfg_get(adapter: Any, key: str, default: Any = None) -> Any:
         if cur is None:
             return default
     return cur
+
+
+def _rewatches_enabled(adapter: Any) -> bool:
+    cfg = getattr(adapter, "cfg", None)
+    return bool(isinstance(cfg, Mapping) and cfg.get("_cw_history_rewatches"))
 
 
 def _to_int(v: Any) -> int | None:
@@ -244,6 +250,7 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 5000) -> 
     skipped_type = 0
     skipped_no_time = 0
     skipped_no_ids = 0
+    event_mode = _rewatches_enabled(adapter)
 
     def _page_sig(rows: list[dict[str, Any]]) -> str:
         if not rows:
@@ -375,6 +382,16 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 5000) -> 
                     item["series_title"] = st
                 if _has_ext_ids(show_ids):
                     item["show_ids"] = show_ids
+
+            if event_mode:
+                key = history_sync_key(item, event_mode=True)
+                if key and key in out:
+                    event_id = str(row.get("row_id") or row.get("reference_id") or row.get("id") or rows_seen).strip()
+                    key = f"{key}~tt{event_id or rows_seen}"
+                if key:
+                    out[key] = minimal_history_item(item, key, event_mode=True)
+                    rows_kept += 1
+                continue
 
             ck = canonical_key(item)
             if ck and ck not in out:

--- a/providers/tests/test_kodi_sync.py
+++ b/providers/tests/test_kodi_sync.py
@@ -83,6 +83,9 @@ def test_kodi_manifest_capabilities_are_scoped():
 
     assert manifest["features"] == {"watchlist": False, "ratings": True, "history": True, "progress": True, "playlists": False, "collection": True}
     assert manifest["capabilities"]["history"]["read"] is True
+    assert manifest["capabilities"]["history"]["aggregated"] is True
+    assert manifest["capabilities"]["history"]["event_history"] is False
+    assert manifest["capabilities"]["history"]["rewatches"] == {"read": False, "write": False}
     assert manifest["capabilities"]["ratings"]["write"] is True
     assert manifest["capabilities"]["progress"]["types"]["episodes"] is True
     assert manifest["capabilities"]["collection"]["read"] is True

--- a/tests/test_flicklist_provider.py
+++ b/tests/test_flicklist_provider.py
@@ -56,6 +56,8 @@ def test_sync_manifest_declares_full_provider_features() -> None:
     assert caps["watchlist"]["write"] is True
     assert caps["ratings"]["remove"] is True
     assert caps["history"]["write"] is True
+    assert caps["history"]["event_history"] is True
+    assert caps["history"]["rewatches"] == {"read": True, "write": True, "account_gate": False}
     assert caps["progress"]["read"] is True
     assert caps["playlists"]["create"] is True
     assert caps["playlists"]["reorder"] is False

--- a/tests/test_history_rewatches.py
+++ b/tests/test_history_rewatches.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, Mapping
 
 from cw_platform.history_events import history_sync_key, minimal_history_item
@@ -42,6 +43,82 @@ class _Ops:
 
     def capabilities(self) -> dict[str, Any]:
         return {"history": {"rewatches": {"read": self._read, "write": self._write}}}
+
+
+def test_plex_can_source_rewatches_but_not_bidirectional() -> None:
+    from providers.sync import _mod_PLEX
+
+    plex = _mod_PLEX.OPS
+    target = _Ops(True, True)
+
+    assert history_rewatch_pair_enabled("history", {"rewatches": True}, "PLEX", plex, "TARGET", target)
+    assert not history_rewatch_pair_enabled("history", {"rewatches": True}, "PLEX", plex, "TARGET", target, bidirectional=True)
+
+
+def test_emby_and_jellyfin_do_not_source_rewatches() -> None:
+    from providers.sync import _mod_EMBY, _mod_JELLYFIN
+
+    target = _Ops(True, True)
+
+    assert not history_rewatch_pair_enabled("history", {"rewatches": True}, "EMBY", _mod_EMBY.OPS, "TARGET", target)
+    assert not history_rewatch_pair_enabled("history", {"rewatches": True}, "JELLYFIN", _mod_JELLYFIN.OPS, "TARGET", target)
+
+
+def test_event_history_providers_can_source_rewatches() -> None:
+    from providers.sync import _mod_FLICKLIST, _mod_PUNCHPLAY, _mod_TAUTULLI
+
+    target = _Ops(True, True)
+
+    for name, ops in (
+        ("FLICKLIST", _mod_FLICKLIST.OPS),
+        ("PUNCHPLAY", _mod_PUNCHPLAY.OPS),
+        ("TAUTULLI", _mod_TAUTULLI.OPS),
+    ):
+        assert history_rewatch_pair_enabled("history", {"rewatches": True}, name, ops, "TARGET", target)
+
+    assert not history_rewatch_pair_enabled(
+        "history",
+        {"rewatches": True},
+        "TAUTULLI",
+        _mod_TAUTULLI.OPS,
+        "TARGET",
+        target,
+        bidirectional=True,
+    )
+
+
+def test_tautulli_rewatch_mode_keeps_each_play_row() -> None:
+    from providers.sync.tautulli import _history
+
+    class Client:
+        def call(self, cmd: str, **_params: Any) -> Mapping[str, Any]:
+            assert cmd == "get_history"
+            return {
+                "data": [
+                    {
+                        "row_id": 7,
+                        "media_type": "movie",
+                        "date": 1704153600,
+                        "title": "Fight Club",
+                        "year": 1999,
+                        "guid": "com.plexapp.agents.themoviedb://550",
+                    },
+                    {
+                        "row_id": 9,
+                        "media_type": "movie",
+                        "date": 1704067200,
+                        "title": "Fight Club",
+                        "year": 1999,
+                        "guid": "com.plexapp.agents.themoviedb://550",
+                    },
+                ],
+                "recordsTotal": 2,
+            }
+
+    idx = _history.build_index(SimpleNamespace(cfg={"_cw_history_rewatches": True}, client=Client()))
+
+    assert sorted(idx) == ["tmdb:550@1704067200", "tmdb:550@1704153600"]
+    assert all(item.get("_cw_rewatch_sync") is True for item in idx.values())
 
 
 def test_history_event_keys_keep_rewatches_separate() -> None:

--- a/tests/test_punchplay_sync.py
+++ b/tests/test_punchplay_sync.py
@@ -83,6 +83,8 @@ def test_manifest_matches_validated_contract() -> None:
 
     assert caps["ratings"]["scale"] == "1-10"
     assert caps["history"]["rewatch"] is True
+    assert caps["history"]["event_history"] is True
+    assert caps["history"]["rewatches"] == {"read": True, "write": True, "account_gate": False}
     assert caps["history"]["requires_watched_at"] is True
     for feature in ("watchlist", "ratings", "history"):
         assert caps[feature]["batch_size"] == 100
@@ -603,6 +605,24 @@ def test_history_index_collects_entry_ids_for_rewatches(monkeypatch: pytest.Monk
     entry = idx["tmdb:550"]
     assert sorted(entry["_punchplay_history_ids"]) == ["7", "9"]
     assert entry["watched_at"] == "2026-06-01T20:00:00.000Z"
+
+
+def test_history_rewatch_mode_indexes_each_play_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.sync.punchplay import _history as hi
+
+    http = FakeHTTP([_Resp(200, {"items": [
+        {"id": 7, "kind": "movie", "tmdb_id": 550, "title": "Fight Club", "year": 1999, "watched_at": "2026-01-01T20:00:00.000Z"},
+        {"id": 9, "kind": "movie", "tmdb_id": 550, "title": "Fight Club", "year": 1999, "watched_at": "2026-06-01T20:00:00.000Z"},
+    ], "hasMore": False, "nextAfter": None})])
+    _patch(monkeypatch, hi, http)
+    adapter = Adapter()
+    adapter.config["_cw_history_rewatches"] = True
+
+    idx = hi.build_index(adapter)
+
+    assert len(idx) == 2
+    assert all(key.startswith("tmdb:550@") for key in idx)
+    assert all(entry["_cw_rewatch_sync"] is True for entry in idx.values())
 
 
 def test_history_remove_deletes_each_entry_id(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
# Pull request

## Change
- Update rewatch capability flags for sync providers
- Keep unsupported rewatch pairs disabled
- Preserve per-play history for PunchPlay and Tautulli in rewatch mode

## Why
Some providers only expose latest watched state, while others can read or write real play events.

## Testing
- tests\test_history_rewatches.py 
- tests\test_punchplay_sync.py 
- tests\test_flicklist_provider.py 
- providers\tests\test_kodi_sync.py 
- tests\test_simkl_rewatch_account_gate.py

## Issue
Relates to #888