### PR TITLE
Fix: Plex ratings webhook rating sink

### DIFF
--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -68,6 +68,7 @@ WEBHOOK_SETTING_KEYS = {
     "plex_floppy_ratings",
     "plex_punchplay_ratings",
     "plex_flicklist_ratings",
+    "plex_scrob_ratings",
     "pause_debounce_seconds",
     "suppress_start_at",
 }
@@ -294,7 +295,7 @@ def _normalize_webhook_settings(cfg: Mapping[str, Any], provider: str, body: Map
         if key in body:
             out[key] = _normalize_filters(body.get(key), provider, key)
     if provider == "plex":
-        for key in ("plex_trakt_ratings", "plex_simkl_ratings", "plex_mdblist_ratings", "plex_crosswatch_ratings", "plex_floppy_ratings", "plex_punchplay_ratings", "plex_flicklist_ratings"):
+        for key in ("plex_trakt_ratings", "plex_simkl_ratings", "plex_mdblist_ratings", "plex_crosswatch_ratings", "plex_floppy_ratings", "plex_punchplay_ratings", "plex_flicklist_ratings", "plex_scrob_ratings"):
             if key in body:
                 out[key] = bool(body.get(key))
     for key in ("pause_debounce_seconds", "suppress_start_at"):
@@ -565,6 +566,7 @@ def build_overview(cfg: dict[str, Any], request: Request) -> dict[str, Any]:
             "floppy": bool(watch.get("plex_floppy_ratings")),
             "punchplay": bool(watch.get("plex_punchplay_ratings")),
             "flicklist": bool(watch.get("plex_flicklist_ratings")),
+            "scrob": bool(watch.get("plex_scrob_ratings")),
             "endpoint_url": _global_plex_ratings_url(request, cfg),
         },
     }
@@ -933,7 +935,7 @@ def api_scrobbler_settings(request: Request, payload: dict[str, Any] = Body(...)
             watch["autostart"] = bool(payload.get("watch_autostart"))
         ratings_raw = payload.get("global_plex_ratings")
         if isinstance(ratings_raw, Mapping):
-            for sink in ("trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "flicklist"):
+            for sink in ("trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "flicklist", "scrob"):
                 watch[f"plex_{sink}_ratings"] = bool(ratings_raw.get(sink))
         if bool(payload.get("regenerate_global_plex_ratings_webhook")):
             sec = after.setdefault("security", {})

--- a/assets/js/scrobbler.js
+++ b/assets/js/scrobbler.js
@@ -6,7 +6,7 @@
   const providerMeta = () => w.CW?.ProviderMeta || {};
   const label = (v) => providerMeta().label?.(v) || String(v || "").toUpperCase();
   const logo = (v) => providerMeta().logoPath?.(v) || "";
-  const plexRatingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay"];
+  const plexRatingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "flicklist", "scrob"];
   const state = { root: null, overview: null, busy: false, panels: { watcherDefaults: false, ratings: false, webhookDefaults: false }, delBtn: null, delTimer: 0, regenBtn: null, regenTimer: 0, legacyConfirm: false, legacyTimer: 0, hybridDismissed: false };
 
   async function j(url, options = {}) {

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -782,6 +782,7 @@ DEFAULT_CFG: dict[str, Any] = {
             "plex_trakt_ratings": False,                # Watch mode: forward Plex ratings to Trakt
             "plex_mdblist_ratings": False,              # Watch mode: forward Plex ratings to MDblist
             "plex_flicklist_ratings": False,            # Watch mode: forward Plex ratings to FlickList
+            "plex_scrob_ratings": False,                # Watch mode: forward Plex ratings to Scrob
             "pause_debounce_seconds": 5,                # Ignore micro-pauses just after start
             "suppress_start_at": 99,                    # Kill near-end "start" flaps (credits)
             "filters": {
@@ -800,6 +801,7 @@ DEFAULT_CFG: dict[str, Any] = {
             "probe_session_progress": True,             # Call GET /status/sessions on your Plex server and match the item by ratingKey/sessionKey
             "plex_trakt_ratings": False,                # Watch mode: forward Plex ratings to Trakt
             "plex_flicklist_ratings": False,            # Watch mode: forward Plex ratings to FlickList
+            "plex_scrob_ratings": False,                # Watch mode: forward Plex ratings to Scrob
             # Plex-only filters
             "filters_plex": {
                 "username_whitelist": [],               # Restrict accepted Account.title values (empty = allow all)

--- a/providers/scrobble/plex/ratings_sync.py
+++ b/providers/scrobble/plex/ratings_sync.py
@@ -105,10 +105,14 @@ def _ops(provider: str) -> Any | None:
         from providers.sync._mod_FLICKLIST import OPS
 
         return OPS
+    if provider == "scrob":
+        from providers.sync._mod_SCROB import OPS
+
+        return OPS
     return None
 
 
-OPS_RATING_SINKS: tuple[str, ...] = ("crosswatch", "floppy", "punchplay", "flicklist")
+OPS_RATING_SINKS: tuple[str, ...] = ("crosswatch", "floppy", "punchplay", "flicklist", "scrob")
 RATING_SINKS: tuple[str, ...] = ("trakt", "simkl", "mdblist", *OPS_RATING_SINKS)
 
 

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -1776,6 +1776,7 @@ def process_rating_webhook(
         enable_floppy = "floppy" in custom_targets
         enable_punchplay = "punchplay" in custom_targets
         enable_flicklist = "flicklist" in custom_targets
+        enable_scrob = "scrob" in custom_targets
     else:
         enable_trakt = bool(watch_cfg.get("plex_trakt_ratings"))
         enable_simkl = bool(watch_cfg.get("plex_simkl_ratings"))
@@ -1784,8 +1785,9 @@ def process_rating_webhook(
         enable_floppy = bool(watch_cfg.get("plex_floppy_ratings"))
         enable_punchplay = bool(watch_cfg.get("plex_punchplay_ratings"))
         enable_flicklist = bool(watch_cfg.get("plex_flicklist_ratings"))
+        enable_scrob = bool(watch_cfg.get("plex_scrob_ratings"))
 
-    if not (enable_trakt or enable_simkl or enable_mdblist or enable_crosswatch or enable_floppy or enable_punchplay or enable_flicklist):
+    if not (enable_trakt or enable_simkl or enable_mdblist or enable_crosswatch or enable_floppy or enable_punchplay or enable_flicklist or enable_scrob):
         return {"ok": True, "ignored": True}
 
     if not payload:
@@ -1827,7 +1829,7 @@ def process_rating_webhook(
         rating_val = 0
 
 
-    if media_type == "episode" and not (enable_trakt or enable_crosswatch or enable_punchplay or enable_flicklist):
+    if media_type == "episode" and not (enable_trakt or enable_crosswatch or enable_punchplay or enable_flicklist or enable_scrob):
         return {"ok": True, "ignored": True}
 
     acc_key = _account_key(payload)
@@ -1871,7 +1873,7 @@ def process_rating_webhook(
         results["mdblist"] = _mdblist_send_rating(media_type, ids, rating_val, cfg, logger)
     ops_enabled = [
         name
-        for name, on in (("crosswatch", enable_crosswatch), ("floppy", enable_floppy), ("punchplay", enable_punchplay), ("flicklist", enable_flicklist))
+        for name, on in (("crosswatch", enable_crosswatch), ("floppy", enable_floppy), ("punchplay", enable_punchplay), ("flicklist", enable_flicklist), ("scrob", enable_scrob))
         if on
     ]
     if ops_enabled:

--- a/providers/webhooks/plex.py
+++ b/providers/webhooks/plex.py
@@ -62,6 +62,7 @@ _DEF_WEBHOOK: dict[str, Any] = {
     "plex_floppy_ratings": False,
     "plex_punchplay_ratings": False,
     "plex_flicklist_ratings": False,
+    "plex_scrob_ratings": False,
 }
 
 _DEF_TRAKT: dict[str, Any] = {
@@ -216,6 +217,7 @@ def _ensure_scrobble(cfg: dict[str, Any]) -> dict[str, Any]:
         "plex_floppy_ratings",
         "plex_punchplay_ratings",
         "plex_flicklist_ratings",
+        "plex_scrob_ratings",
     ):
         if key not in wh:
             wh[key] = _DEF_WEBHOOK.get(key, False)
@@ -1147,6 +1149,7 @@ def process_webhook(
     enable_floppy_ratings = bool(wh.get("plex_floppy_ratings", False)) and "floppy" in selected_rating_sinks
     enable_punchplay_ratings = bool(wh.get("plex_punchplay_ratings", False)) and "punchplay" in selected_rating_sinks
     enable_flicklist_ratings = bool(wh.get("plex_flicklist_ratings", False)) and "flicklist" in selected_rating_sinks
+    enable_scrob_ratings = bool(wh.get("plex_scrob_ratings", False)) and "scrob" in selected_rating_sinks
     flt = (wh.get("filters_plex") or {})
     allow_users = {str(x).strip() for x in (flt.get("username_whitelist") or []) if str(x).strip()}
     srv_uuid_allow = _as_filter_set(flt.get("server_uuid_whitelist"))
@@ -1228,7 +1231,7 @@ def process_webhook(
     _emit(logger, f"ids resolved: {media_name_dbg} -> {_describe_ids((show_ids or epi_ids) or all_ids)}", "DEBUG")
 
     if event == "media.rate":
-        if not (enable_trakt_ratings or enable_simkl_ratings or enable_mdblist_ratings or enable_crosswatch_ratings or enable_floppy_ratings or enable_punchplay_ratings or enable_flicklist_ratings):
+        if not (enable_trakt_ratings or enable_simkl_ratings or enable_mdblist_ratings or enable_crosswatch_ratings or enable_floppy_ratings or enable_punchplay_ratings or enable_flicklist_ratings or enable_scrob_ratings):
             _emit(logger, "rating forwarding disabled", "DEBUG")
             return {"ok": True, "ignored": True}
 
@@ -1300,6 +1303,7 @@ def process_webhook(
                 ("floppy", enable_floppy_ratings),
                 ("punchplay", enable_punchplay_ratings),
                 ("flicklist", enable_flicklist_ratings),
+                ("scrob", enable_scrob_ratings),
             )
             if on
         ]

--- a/tests/test_plex_webhook_ratings.py
+++ b/tests/test_plex_webhook_ratings.py
@@ -1,7 +1,37 @@
 # CrossWatch test scripts
 from __future__ import annotations
 
+import json
+import re
+from pathlib import Path
 from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _js_const_array(relative_path: str, const_name: str) -> list[str]:
+    text = (ROOT / relative_path).read_text(encoding="utf-8")
+    match = re.search(rf"\bconst\s+{re.escape(const_name)}\s*=\s*(\[[^\]]*\])", text)
+    assert match, f"{const_name} not found in {relative_path}"
+    return list(json.loads(match.group(1)))
+
+
+def _request(path: str = "/api/scrobbler/overview"):
+    from starlette.requests import Request
+
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "headers": [],
+            "server": ("testserver", 80),
+            "scheme": "http",
+            "client": ("testclient", 50000),
+            "app": object(),
+        }
+    )
 
 
 def test_plex_webhook_ratings_forward_to_crosswatch_and_floppy(monkeypatch) -> None:
@@ -56,3 +86,159 @@ def test_plex_webhook_ratings_forward_to_crosswatch_and_floppy(monkeypatch) -> N
     assert {call["instance"] for call in sent} == {"CW-P01", "F1"}
     assert all(call["item"]["ids"]["tmdb"] == 550 for call in sent)
     assert all(call["rating"] == 8 for call in sent)
+
+
+def test_global_plex_rating_surfaces_cover_dispatcher_sinks(monkeypatch) -> None:
+    from api import scrobblerManagementAPI as management
+    from providers.scrobble.plex import ratings_sync
+    from providers.scrobble.plex.ratings_sync import RATING_SINKS
+    from providers.sync._mod_SCROB import OPS as SCROB_OPS
+
+    rating_sinks = set(RATING_SINKS)
+
+    assert ratings_sync._ops("scrob") is SCROB_OPS
+    assert SCROB_OPS.features()["ratings"] is True
+    assert set(_js_const_array("assets/js/scrobbler.js", "plexRatingSinks")) == rating_sinks
+    assert rating_sinks <= set(_js_const_array("assets/js/modals/scrobbler-webhook/index.js", "ratingSinks"))
+    assert rating_sinks <= set(_js_const_array("assets/js/modals/scrobbler-route/index.js", "ratingSinks"))
+
+    cfg = {
+        "scrobble": {
+            "enabled": True,
+            "sources": {"watcher": True, "webhook": False},
+            "watch": {f"plex_{sink}_ratings": True for sink in RATING_SINKS},
+        },
+        "security": {"webhook_ids": {"plexwatcher": "ratings-token"}},
+    }
+    monkeypatch.setattr(management, "_runtime_status", lambda _request, _cfg: {})
+    monkeypatch.setattr(management, "request_user", lambda _request: None)
+
+    overview = management.build_overview(cfg, _request())
+    global_ratings = overview["source_state"]["global_plex_ratings"]
+
+    assert set(global_ratings) - {"endpoint_url"} == rating_sinks
+    assert all(global_ratings[sink] is True for sink in RATING_SINKS)
+    assert global_ratings["endpoint_url"] == "http://testserver/webhook/plexwatcher?token=ratings-token"
+
+    saved: dict[str, Any] = {}
+    monkeypatch.setattr(management, "load_config", lambda: {"scrobble": {"watch": {}}})
+    monkeypatch.setattr(management, "save_config", lambda cfg: saved.update(cfg))
+    monkeypatch.setattr(management, "_after_config_save", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(management, "_watch_runtime_changed", lambda _before, _after: False)
+
+    response = management.api_scrobbler_settings(
+        _request("/api/scrobbler/settings"),
+        {"global_plex_ratings": {sink: True for sink in RATING_SINKS}},
+    )
+    body = json.loads(response.body)
+
+    assert body["ok"] is True
+    assert all(saved["scrobble"]["watch"][f"plex_{sink}_ratings"] is True for sink in RATING_SINKS)
+
+
+def test_send_rating_supports_scrob_ops_sink(monkeypatch) -> None:
+    from providers.scrobble.plex.ratings_sync import send_rating
+    from providers.sync.scrob import _ratings as scrob_ratings
+
+    class Resp:
+        status_code = 200
+        text = "{}"
+
+        def json(self) -> dict[str, Any]:
+            return {"ok": True}
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(scrob_ratings, "scrob_request", lambda adapter, method, path, **kwargs: calls.append({"method": method, "path": path, **kwargs}) or Resp())
+
+    cfg = {"scrob": {"server_url": "http://scrob.test", "api_key": "scrob-token", "username": "pasca", "password": "secret"}}
+    item = {"type": "movie", "ids": {"tmdb": "550"}, "title": "Fight Club", "rating": 8}
+
+    result = send_rating("scrob", cfg, "default", item, 8)
+
+    assert result["ok"] is True
+    assert calls == [{"method": "POST", "path": scrob_ratings.PATH_RATINGS, "json": {"tmdb_id": 550, "media_type": "movie", "rating": 8.0}}]
+
+
+def test_plex_webhook_ratings_forward_to_every_dispatcher_sink(monkeypatch) -> None:
+    from providers.scrobble.plex import ratings_sync
+    from providers.scrobble.plex import watch as plex_watch
+    from providers.webhooks import plex
+
+    class Resp:
+        status_code = 200
+        text = "{}"
+
+        def json(self) -> dict[str, Any]:
+            return {"ok": True}
+
+    trakt_calls: list[dict[str, Any]] = []
+    ops_calls: list[dict[str, Any]] = []
+
+    def fake_send_rating(provider: str, cfg: dict[str, Any], instance: str, item: dict[str, Any], rating: int) -> dict[str, Any]:
+        ops_calls.append({"provider": provider, "instance": instance, "item": item, "rating": rating})
+        return {"ok": True, "resp": {"confirmed_keys": ["tmdb:550"]}}
+
+    monkeypatch.setattr(plex, "_save_config", lambda _cfg: None)
+    monkeypatch.setattr(plex, "_post_trakt", lambda path, body, cfg: trakt_calls.append({"path": path, "body": body}) or Resp())
+    monkeypatch.setattr(plex_watch, "_simkl_send_rating", lambda media_type, ids, rating, cfg, logger: {"ok": True, "provider": "simkl"})
+    monkeypatch.setattr(plex_watch, "_mdblist_send_rating", lambda media_type, ids, rating, cfg, logger: {"ok": True, "provider": "mdblist"})
+    monkeypatch.setattr(ratings_sync, "send_rating", fake_send_rating)
+    plex._LAST_RATING_BY_ACC.clear()
+
+    flags = {f"plex_{sink}_ratings": True for sink in ratings_sync.RATING_SINKS}
+    cfg = {
+        "scrobble": {
+            "enabled": True,
+            "sources": {"webhook": True},
+            "webhook": {
+                "sinks": list(ratings_sync.RATING_SINKS),
+                "sink_instances": {sink: f"{sink}-profile" for sink in ratings_sync.RATING_SINKS},
+                "pause_debounce_seconds": 5,
+                "suppress_start_at": 99,
+                "probe_session_progress": True,
+                **flags,
+            },
+            "trakt": {"stop_pause_threshold": 80, "force_stop_at": 95, "regress_tolerance_percent": 5},
+        },
+        "trakt": {"access_token": "trakt-token", "instances": {"trakt-profile": {"access_token": "trakt-token"}}},
+        "simkl": {"access_token": "simkl-token", "instances": {"simkl-profile": {"access_token": "simkl-token"}}},
+        "mdblist": {"api_key": "mdblist-token", "instances": {"mdblist-profile": {"api_key": "mdblist-token"}}},
+        "crosswatch": {"enabled": True, "instances": {"crosswatch-profile": {"enabled": True}}},
+        "floppy": {"instances": {"floppy-profile": {"server_url": "http://floppy.test", "api_token": "floppy-token"}}},
+        "punchplay": {"access_token": "punchplay-token", "instances": {"punchplay-profile": {"access_token": "punchplay-token"}}},
+        "flicklist": {"api_key": "flicklist-token", "instances": {"flicklist-profile": {"api_key": "flicklist-token"}}},
+        "scrob": {
+            "server_url": "http://scrob.test",
+            "api_key": "scrob-token",
+            "username": "pasca",
+            "password": "secret",
+            "instances": {
+                "scrob-profile": {
+                    "server_url": "http://scrob.test",
+                    "api_key": "scrob-token",
+                    "username": "pasca",
+                    "password": "secret",
+                }
+            },
+        },
+    }
+    payload = {
+        "event": "media.rate",
+        "Account": {"title": "pasca"},
+        "Metadata": {
+            "type": "movie",
+            "title": "Fight Club",
+            "year": 1999,
+            "ratingKey": "rk-550-all",
+            "userRating": 8,
+            "Guid": [{"id": "tmdb://550"}],
+        },
+    }
+
+    result = plex.process_webhook(payload, {}, cfg=cfg)
+
+    assert result["ok"] is True
+    assert set(result) >= {"trakt", "simkl", "mdblist", *ratings_sync.OPS_RATING_SINKS}
+    assert trakt_calls and trakt_calls[0]["path"] == "/sync/ratings"
+    assert {call["provider"] for call in ops_calls} == set(ratings_sync.OPS_RATING_SINKS)
+    assert {call["instance"] for call in ops_calls} == {f"{sink}-profile" for sink in ratings_sync.OPS_RATING_SINKS}


### PR DESCRIPTION
# Pull request

## Change

- Adds FlickList and Scrob to the global Plex ratings webhook flow.

## Why

- FlickList was missing from the global Plex ratings destinations.
- Scrob supports ratings and was already shown in rating sink lists, but was not wired into Plex ratings webhook dispatch.

## Testing

- tests/test_plex_webhook_ratings.py

## Issue

Relates to #887