### PR TITLE
Fix: playlist API CodeQL errors

### DIFF
--- a/services/playlists.py
+++ b/services/playlists.py
@@ -12,7 +12,6 @@ from typing import Any, Iterator, Mapping
 from _logging import log as _cw_log
 from cw_platform.playlists import (
     BUILTIN_RULESETS,
-    PlaylistUserError,
     playlist_capabilities,
     supports_playlists,
     validate_ruleset,
@@ -32,7 +31,6 @@ _SAFE_NAME_CHARS = " _.'-&()"
 
 
 def _internal_playlist_error(action: str, exc: Exception, **extra: Any) -> dict[str, Any]:
-    reason = str(exc or "").strip() if isinstance(exc, PlaylistUserError) else ""
     try:
         _cw_log(
             f"playlist {action} failed",
@@ -41,13 +39,12 @@ def _internal_playlist_error(action: str, exc: Exception, **extra: Any) -> dict[
             extra={
                 "action": action,
                 "error_type": exc.__class__.__name__,
-                "reason": reason,
                 **{k: v for k, v in extra.items() if v not in (None, "", [], {})},
             },
         )
     except Exception:
         pass
-    return {"ok": False, "error": f"{action} failed: {reason}" if reason else f"{action} failed"}
+    return {"ok": False, "error": f"{action} failed"}
 
 
 def _safe_name_error(name: Any, label: str, max_len: int) -> str:

--- a/tests/test_playlists_service.py
+++ b/tests/test_playlists_service.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 from cw_platform.id_map import canonical_key
-from cw_platform.playlists import PlaylistItem, PlaylistResource, PlaylistSnapshot
+from cw_platform.playlists import PlaylistItem, PlaylistResource, PlaylistSnapshot, PlaylistUserError
 from cw_platform import playlists_runner as runner
 from services import playlists as svc
 
@@ -158,6 +158,19 @@ def test_playlist_resource_errors_do_not_expose_exception_text(config_base, fake
 def test_playlist_create_errors_do_not_expose_exception_text(config_base, fake_providers):
     def fail(*_args, **_kwargs):
         raise RuntimeError("password=secret-from-provider /srv/crosswatch/internal.py")
+
+    fake_providers["TRAKT"].create_playlist = fail
+    res = svc.upsert_endpoint(
+        _cfg(),
+        {"name": "NewList", "provider": "TRAKT", "instance": "default", "create": True, "create_name": "Weekend Movies"},
+    )
+
+    assert res == {"ok": False, "error": "create failed"}
+
+
+def test_playlist_user_errors_do_not_expose_exception_text(config_base, fake_providers):
+    def fail(*_args, **_kwargs):
+        raise PlaylistUserError("token=secret-from-provider /srv/crosswatch/internal.py")
 
     fake_providers["TRAKT"].create_playlist = fail
     res = svc.upsert_endpoint(


### PR DESCRIPTION
# Pull request

## Change

- Sanitize playlist internal error responses so exception text is not sent back to the client.

## Why

- CodeQL flagged playlist API responses for possible stack trace or exception detail exposure.

## Testing
- tests\test_playlists_service.py

## Issue
Relates to CodeQL code scanning alerts