### PR TITLE
Fix: harden Emby and Jellyfin item ID resolution

### DIFF
--- a/providers/sync/emby/_common.py
+++ b/providers/sync/emby/_common.py
@@ -495,6 +495,9 @@ def normalize(obj: Mapping[str, Any]) -> dict[str, Any]:
         base = dict(obj)
         res = id_minimal(base)
         raw = base.get("emby_item_id") or base.get("_emby_item_id") or (base.get("ids") or {}).get("emby")
+        res_ids = res.get("ids")
+        if isinstance(res_ids, dict):
+            res_ids.pop("emby", None)
         if raw:
             res["emby_item_id"] = str(raw)
         if "library_id" in base:
@@ -506,8 +509,7 @@ def normalize(obj: Mapping[str, Any]) -> dict[str, Any]:
     pids = obj.get("ProviderIds") if isinstance(pids := obj.get("ProviderIds"), Mapping) else obj.get("ids") or {}
     ids = {k: v for k, v in _ids_from_provider_ids(pids).items() if v}
     em_id = obj.get("Id") or (pids.get("emby") if isinstance(pids, Mapping) else None)
-    if em_id:
-        ids["emby"] = str(em_id)
+    ids.pop("emby", None)
     row: dict[str, Any] = {"type": t, "title": title, "year": year, "ids": ids}
     if em_id:
         row["emby_item_id"] = str(em_id)
@@ -1404,6 +1406,67 @@ def _pick_from_candidates(
     return str(iid) if iid and not looks_like_bad_id(iid) else None
 
 
+def _public_ids(ids: Mapping[str, Any]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for key in ("tmdb", "imdb", "tvdb"):
+        pair = format_provider_pair(key, ids.get(key))
+        if pair:
+            out[key] = pair.partition(".")[2]
+    return out
+
+
+def _row_matches_type(row: Mapping[str, Any], want_type: str | None) -> bool:
+    if not want_type:
+        return True
+    row_type = str(row.get("Type") or "").strip().lower()
+    if want_type == "movie":
+        return row_type in ("movie", "video")
+    if want_type in ("show", "series"):
+        return row_type == "series"
+    if want_type == "episode":
+        return row_type == "episode"
+    return True
+
+
+def _row_matches_title_year(row: Mapping[str, Any], title: str, year: Any) -> bool:
+    if not title:
+        return False
+    row_title = str(row.get("Name") or "").strip().lower()
+    if row_title != title.lower():
+        return False
+    if year is None:
+        return True
+    try:
+        return isinstance(row.get("ProductionYear"), int) and abs(int(row["ProductionYear"]) - int(year)) <= 1
+    except Exception:
+        return False
+
+
+def _native_row_matches_request(
+    row: Mapping[str, Any],
+    ids: Mapping[str, Any],
+    *,
+    want_type: str | None,
+    title: str,
+    year: Any,
+) -> bool:
+    if not row or not _row_matches_type(row, want_type):
+        return False
+
+    requested_public = _public_ids(ids)
+    if requested_public:
+        row_public = _ids_from_provider_ids(row.get("ProviderIds"))
+        if any(row_public.get(key) == value for key, value in requested_public.items()):
+            return True
+        if row_public:
+            return False
+        return _row_matches_title_year(row, title, year)
+
+    if title:
+        return _row_matches_title_year(row, title, year)
+    return True
+
+
 def _direct_query_by_pairs(
     http: Any,
     uid: str,
@@ -1488,33 +1551,36 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
         )
     if mk in memo and memo[mk]:
         return memo[mk]
-    em = ids.get("emby")
-    if em and not looks_like_bad_id(em):
-        if selected_libs:
-            try:
-                response = http.get(
-                    f"/Users/{uid}/Items/{em}",
-                    params={"Fields": "LibraryId,CollectionFolderId,AncestorIds,ParentId,Type"},
-                )
-                row = response.json() or {} if getattr(response, "status_code", 0) == 200 else {}
-            except Exception:
-                row = {}
-            if not emby_filter_library_candidates([row] if row else [], selected_libs):
-                setattr(adapter, "_emby_last_resolve_hint", "outside_library_scope")
-                cw_log("EMBY", "common", "debug", "target_candidate_outside_library_scope", item_id=str(em), allowed_library_ids=sorted(selected_libs), resolution_method="provider_id")
-            else:
-                memo[mk] = str(em)
-                return str(em)
-        else:
-            cw_log("EMBY", "common", "debug", "resolve_hit", kind="direct", method="provider_id", item_id=str(em))
-            memo[mk] = str(em)
-            return str(em)
     t = _lookup_type(it)
     title = (it.get("title") or "").strip()
     year = it.get("year")
     season = it.get("season")
     episode = it.get("episode")
     series_title = (it.get("series_title") or "").strip()
+    em = ids.get("emby")
+    if em and not looks_like_bad_id(em):
+        needs_validation = bool(selected_libs or _public_ids(ids) or title)
+        if needs_validation:
+            try:
+                response = http.get(
+                    f"/Users/{uid}/Items/{em}",
+                    params={"Fields": "ProviderIds,ProductionYear,LibraryId,CollectionFolderId,AncestorIds,ParentId,Type,Name"},
+                )
+                row = response.json() or {} if getattr(response, "status_code", 0) == 200 else {}
+            except Exception:
+                row = {}
+            if selected_libs and not emby_filter_library_candidates([row] if row else [], selected_libs):
+                setattr(adapter, "_emby_last_resolve_hint", "outside_library_scope")
+                cw_log("EMBY", "common", "debug", "target_candidate_outside_library_scope", item_id=str(em), allowed_library_ids=sorted(selected_libs), resolution_method="provider_id")
+            elif row and _native_row_matches_request(row, ids, want_type=t, title=title, year=year):
+                memo[mk] = str(em)
+                return str(em)
+            else:
+                cw_log("EMBY", "common", "debug", "native_id_rejected", item_id=str(em), kind=t, title=title, year=year)
+        else:
+            cw_log("EMBY", "common", "debug", "resolve_hit", kind="direct", method="provider_id", item_id=str(em))
+            memo[mk] = str(em)
+            return str(em)
 
     strict = bool(getattr(getattr(adapter, "cfg", None), "strict_id_matching", False))
     series_ids = dict(it.get("show_ids") or {})
@@ -1933,12 +1999,6 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "his
     uid = getattr(getattr(adapter, "cfg", None), "user_id", None)
     if not http or not uid:
         return []
-
-    raw_iid = it.get("emby_item_id") or it.get("_emby_item_id")
-    if raw_iid:
-        s = str(raw_iid).strip()
-        if s and not looks_like_bad_id(s):
-            return [s]
 
     one = resolve_item_id(adapter, it, feature=feature)
     selected_libs = emby_selected_library_ids(adapter.cfg, feature)

--- a/providers/sync/emby/_history.py
+++ b/providers/sync/emby/_history.py
@@ -386,6 +386,24 @@ def _pids_to_ids(pids: Any) -> dict[str, str]:
                 pass
     return out
 
+
+def _public_ids_only(ids: Mapping[str, Any] | None) -> dict[str, str]:
+    out: dict[str, str] = {}
+    src = ids if isinstance(ids, Mapping) else {}
+    for key in ("tmdb", "imdb", "tvdb"):
+        value = str(src.get(key) or "").strip()
+        if not value:
+            continue
+        if key == "imdb":
+            out["imdb"] = value if value.startswith("tt") else f"tt{value}"
+            continue
+        try:
+            out[key] = str(int(value))
+        except Exception:
+            pass
+    return out
+
+
 def _series_ids_for(http: Any, series_id: str | None) -> dict[str, str]:
     body = _item_meta(http, series_id)
     if not body:
@@ -838,7 +856,7 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
                 typ = (row.get("Type") or "").strip()
 
                 if _is_movieish(row):
-                    ids = dict(m.get("ids") or {})
+                    ids = _public_ids_only(m.get("ids"))
                     if not ids:
                         ids = _item_ids_for(http, row.get("Id"))
                     movie_title = (m.get("title") or row.get("Name") or "").strip()

--- a/providers/sync/emby/_progress.py
+++ b/providers/sync/emby/_progress.py
@@ -305,7 +305,7 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
             chosen_viewOffset=int(selected.get("progress_ms") or 0),
             duration_ms=selected.get("duration_ms"),
             ids=dict(selected.get("ids") or {}),
-            emby_item_id=str((selected.get("ids") or {}).get("emby") or ""),
+            emby_item_id=str(selected.get("emby_item_id") or ""),
             action=action,
         )
 

--- a/providers/sync/jellyfin/_common.py
+++ b/providers/sync/jellyfin/_common.py
@@ -521,6 +521,9 @@ def _ids_from_provider_ids(pids: Mapping[str, Any] | None) -> dict[str, str]:
 def normalize(obj: Mapping[str, Any]) -> dict[str, Any]:
     if isinstance(obj, Mapping) and "ids" in obj and "type" in obj:
         out = id_minimal(obj)
+        out_ids = out.get("ids")
+        if isinstance(out_ids, dict):
+            out_ids.pop("jellyfin", None)
         raw = obj.get("jellyfin_item_id") or obj.get("_jellyfin_item_id") or obj.get("Id")
         if raw:
             out["jellyfin_item_id"] = str(raw)
@@ -531,8 +534,7 @@ def normalize(obj: Mapping[str, Any]) -> dict[str, Any]:
     pids = obj.get("ProviderIds") if isinstance(obj.get("ProviderIds"), Mapping) else (obj.get("ids") or {})
     ids = {k: v for k, v in _ids_from_provider_ids(pids).items() if v}
     jf_id = obj.get("Id") or (pids.get("jellyfin") if isinstance(pids, Mapping) else None)
-    if jf_id:
-        ids["jellyfin"] = str(jf_id)
+    ids.pop("jellyfin", None)
     row: dict[str, Any] = {"type": t, "title": title, "year": year, "ids": ids}
     
     if jf_id:
@@ -1101,6 +1103,104 @@ def _pick_from_candidates(
     return str(iid) if iid and not looks_like_bad_id(iid) else None
 
 
+def _public_ids(ids: Mapping[str, Any]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for key in ("tmdb", "imdb", "tvdb"):
+        pair = format_provider_pair(key, ids.get(key))
+        if pair:
+            out[key] = pair.partition(".")[2]
+    return out
+
+
+def _row_matches_type(row: Mapping[str, Any], want_type: str | None) -> bool:
+    if not want_type:
+        return True
+    row_type = str(row.get("Type") or "").strip().lower()
+    if want_type == "movie":
+        return row_type in ("movie", "video")
+    if want_type in ("show", "series"):
+        return row_type == "series"
+    if want_type == "episode":
+        return row_type == "episode"
+    return True
+
+
+def _row_matches_title_year(row: Mapping[str, Any], title: str, year: Any) -> bool:
+    if not title:
+        return False
+    row_title = str(row.get("Name") or "").strip().lower()
+    if row_title != title.lower():
+        return False
+    if year is None:
+        return True
+    try:
+        return isinstance(row.get("ProductionYear"), int) and abs(int(row["ProductionYear"]) - int(year)) <= 1
+    except Exception:
+        return False
+
+
+def _native_row_matches_request(
+    row: Mapping[str, Any],
+    ids: Mapping[str, Any],
+    *,
+    want_type: str | None,
+    title: str,
+    year: Any,
+) -> bool:
+    if not row or not _row_matches_type(row, want_type):
+        return False
+
+    requested_public = _public_ids(ids)
+    if requested_public:
+        row_public = _ids_from_provider_ids(row.get("ProviderIds"))
+        if any(row_public.get(key) == value for key, value in requested_public.items()):
+            return True
+        if row_public:
+            return False
+        return _row_matches_title_year(row, title, year)
+
+    if title:
+        return _row_matches_title_year(row, title, year)
+    return True
+
+
+def _validate_native_item_id(
+    adapter: Any,
+    iid: Any,
+    ids: Mapping[str, Any],
+    *,
+    selected_libs: set[str],
+    want_type: str | None,
+    title: str,
+    year: Any,
+) -> str | None:
+    s = str(iid or "").strip()
+    if not s or looks_like_bad_id(s):
+        return None
+    needs_validation = bool(selected_libs or _public_ids(ids) or title)
+    if not needs_validation:
+        _dbg("resolve_hit", kind="direct", method="provider_id", item_id=s)
+        return s
+    http = adapter.client
+    uid = adapter.cfg.user_id
+    try:
+        response = http.get(
+            f"/Items/{s}",
+            params={"userId": uid, "Fields": "ProviderIds,ProductionYear,LibraryId,CollectionFolderId,AncestorIds,ParentId,Type,Name"},
+        )
+        row = response.json() or {} if getattr(response, "status_code", 0) == 200 else {}
+    except Exception:
+        row = {}
+    if selected_libs and not jf_filter_library_candidates([row] if row else [], selected_libs):
+        setattr(adapter, "_jellyfin_last_resolve_hint", "outside_library_scope")
+        _dbg("target_candidate_outside_library_scope", item_id=s, allowed_library_ids=sorted(selected_libs), resolution_method="provider_id")
+        return None
+    if row and _native_row_matches_request(row, ids, want_type=want_type, title=title, year=year):
+        return s
+    _dbg("native_id_rejected", item_id=s, kind=want_type, title=title, year=year)
+    return None
+
+
 def _direct_query_by_pairs(
     adapter: Any,
     http: Any,
@@ -1411,45 +1511,44 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
     selected_libs = jf_selected_library_ids(adapter.cfg, feature)
     setattr(adapter, "_jellyfin_last_resolve_hint", None)
     outside_scope_seen = False
-
-    # Prefer native Jellyfin item id when present.
-    raw_iid = it.get("jellyfin_item_id") or it.get("_jellyfin_item_id")
-    if raw_iid:
-        s = str(raw_iid).strip()
-        if s and not looks_like_bad_id(s):
-            _dbg('resolve_hit', kind='direct', method='item_field', item_id=s)
-            return s
-
     ids = dict(it.get("ids") or {})
     show_ids = it.get("show_ids") if isinstance(it.get("show_ids"), Mapping) else None
-
-    jf = ids.get("jellyfin")
-    if jf and not looks_like_bad_id(jf):
-        if selected_libs:
-            try:
-                response = http.get(
-                    f"/Items/{jf}",
-                    params={"userId": uid, "Fields": "LibraryId,CollectionFolderId,AncestorIds,ParentId,Type"},
-                )
-                row = response.json() or {} if getattr(response, "status_code", 0) == 200 else {}
-            except Exception:
-                row = {}
-            if not jf_filter_library_candidates([row] if row else [], selected_libs):
-                outside_scope_seen = True
-                setattr(adapter, "_jellyfin_last_resolve_hint", "outside_library_scope")
-                _dbg('target_candidate_outside_library_scope', item_id=str(jf), allowed_library_ids=sorted(selected_libs), resolution_method='provider_id')
-            else:
-                return str(jf)
-        else:
-            _dbg('resolve_hit', kind='direct', method='provider_id', item_id=str(jf))
-            return str(jf)
-
     t = _lookup_type(it)
     title = (it.get("title") or "").strip()
     year = it.get("year")
     season = it.get("season")
     episode = it.get("episode")
     series_title = (it.get("series_title") or "").strip()
+
+    raw_iid = it.get("jellyfin_item_id") or it.get("_jellyfin_item_id")
+    native_iid = _validate_native_item_id(
+        adapter,
+        raw_iid,
+        ids,
+        selected_libs=selected_libs,
+        want_type=t,
+        title=title,
+        year=year,
+    )
+    if native_iid:
+        _dbg("resolve_hit", kind="direct", method="item_field", item_id=native_iid)
+        return native_iid
+
+    jf = ids.get("jellyfin")
+    native_iid = _validate_native_item_id(
+        adapter,
+        jf,
+        ids,
+        selected_libs=selected_libs,
+        want_type=t,
+        title=title,
+        year=year,
+    )
+    if native_iid:
+        _dbg("resolve_hit", kind="direct", method="provider_id", item_id=native_iid)
+        return native_iid
+    if jf and selected_libs and getattr(adapter, "_jellyfin_last_resolve_hint", None) == "outside_library_scope":
+        outside_scope_seen = True
 
     strict = bool(getattr(getattr(adapter, "cfg", None), "strict_id_matching", False))
 
@@ -1719,13 +1818,6 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "his
     uid = getattr(getattr(adapter, "cfg", None), "user_id", None)
     if not http or not uid:
         return []
-
-    # Prefer native Jellyfin item id when present
-    raw_iid = it.get("jellyfin_item_id") or it.get("_jellyfin_item_id")
-    if raw_iid:
-        s = str(raw_iid).strip()
-        if s and not looks_like_bad_id(s):
-            return [s]
 
     one = resolve_item_id(adapter, it, feature=feature)
     selected_libs = jf_selected_library_ids(adapter.cfg, feature)

--- a/providers/sync/jellyfin/_history.py
+++ b/providers/sync/jellyfin/_history.py
@@ -797,7 +797,7 @@ def _prepare_want(
 
         ids = dict(nm.get("ids") or {})
         for k_id, v_id in base_ids.items():
-            if v_id not in (None, "", 0):
+            if str(k_id).strip().lower() != "jellyfin" and v_id not in (None, "", 0):
                 ids[k_id] = v_id
         if ids:
             m["ids"] = ids
@@ -854,7 +854,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         results.append(_result_row(str(u.get("key") or ""), _ST_RESOLVE_FAILED, action="resolve", reason=reason))
 
     for k, m in wants.items():
-        iid = m.get("jellyfin_item_id") or _try_resolve_iid(adapter, m)
+        iid = _try_resolve_iid(adapter, m)
         if iid:
             mids.append((k, str(iid)))
         else:
@@ -1013,10 +1013,13 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
 
     for k, m in wants.items():
         ent = shadow.get(k) or {}
-        iid = (m.get("jellyfin_item_id") or (ent.get("iid") if isinstance(ent, Mapping) else None))
-
+        iid = _try_resolve_iid(adapter, m)
         if not iid:
-            iid = _try_resolve_iid(adapter, m)
+            ent_iid = ent.get("iid") if isinstance(ent, Mapping) else None
+            if ent_iid:
+                hinted = dict(m)
+                hinted["jellyfin_item_id"] = str(ent_iid)
+                iid = _try_resolve_iid(adapter, hinted)
 
         if iid:
             mids.append((k, str(iid)))

--- a/providers/tests/test_emby_resolver.py
+++ b/providers/tests/test_emby_resolver.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+
+common = importlib.import_module("providers.sync.emby._common")
+history = importlib.import_module("providers.sync.emby._history")
+progress = importlib.import_module("providers.sync.emby._progress")
+watchlist = importlib.import_module("providers.sync.emby._watchlist")
+
+
+class FakeResp:
+    def __init__(self, status: int, payload: Any = None):
+        self.status_code = status
+        self._payload = payload
+        self.text = ""
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeHttp:
+    def __init__(self, items: list[dict[str, Any]]) -> None:
+        self.items = items
+        self.calls: list[dict[str, Any]] = []
+
+    def get(self, path: str, *, params: dict[str, Any] | None = None) -> FakeResp:
+        params = dict(params or {})
+        self.calls.append({"method": "GET", "path": path, "params": params})
+
+        prefix = "/Users/U1/Items/"
+        if path.startswith(prefix):
+            item_id = path.removeprefix(prefix)
+            for item in self.items:
+                if str(item.get("Id") or "") == item_id:
+                    return FakeResp(200, item)
+            return FakeResp(404, {})
+
+        if path == "/Users/U1/Views":
+            return FakeResp(200, {"Items": []})
+
+        if path == "/Users/U1/Items":
+            if params.get("Filters") in {"IsPlayed", "IsResumable", "IsFavorite"}:
+                include = {x.strip() for x in str(params.get("IncludeItemTypes") or "").split(",") if x.strip()}
+                rows = [item for item in self.items if str(item.get("Type") or "") in include]
+                return FakeResp(200, {"Items": rows, "TotalRecordCount": len(rows)})
+
+            provider_terms = {x.strip() for x in str(params.get("AnyProviderIdEquals") or "").split(",") if x.strip()}
+            include = {x.strip() for x in str(params.get("IncludeItemTypes") or "").split(",") if x.strip()}
+            rows: list[dict[str, Any]] = []
+            for item in self.items:
+                if include and str(item.get("Type") or "") not in include:
+                    continue
+                provider_ids = {str(k).lower(): str(v).strip() for k, v in (item.get("ProviderIds") or {}).items()}
+                pairs = {f"{key}.{int(value)}" if key in {"tmdb", "tvdb"} and value.isdigit() else f"{key}.{value}" for key, value in provider_ids.items()}
+                if provider_terms & pairs:
+                    rows.append(item)
+            return FakeResp(200, {"Items": rows, "TotalRecordCount": len(rows)})
+
+        return FakeResp(404, {})
+
+    def post(self, path: str, *, params: dict[str, Any] | None = None, json: Any = None) -> FakeResp:
+        self.calls.append({"method": "POST", "path": path, "params": dict(params or {}), "json": json})
+        return FakeResp(204, {})
+
+    def delete(self, path: str, *, params: dict[str, Any] | None = None) -> FakeResp:
+        self.calls.append({"method": "DELETE", "path": path, "params": dict(params or {})})
+        return FakeResp(204, {})
+
+
+class FakeCfg:
+    user_id = "U1"
+    strict_id_matching = False
+    history_guid_priority = None
+    watchlist_guid_priority = None
+    history_libraries = None
+    progress_libraries = None
+    watchlist_libraries = None
+    watchlist_mode = "favorites"
+    watchlist_query_limit = 25
+    history_query_limit = 25
+    history_write_delay_ms = 0
+
+
+class FakeAdapter:
+    def __init__(self, items: list[dict[str, Any]]) -> None:
+        self.client = FakeHttp(items)
+        self.cfg = FakeCfg()
+
+
+def emby_movie(iid: str, title: str, tmdb: str, *, played_at: str | None = None) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "Id": iid,
+        "Type": "Movie",
+        "Name": title,
+        "ProductionYear": 2021,
+        "ProviderIds": {"Tmdb": tmdb},
+    }
+    if played_at:
+        row["UserData"] = {"Played": True, "PlayCount": 1, "LastPlayedDate": played_at}
+    return row
+
+
+def assert_public_ids_without_native_emby(item: dict[str, Any], *, has_current_item_id: bool = True) -> None:
+    assert item["ids"] == {"tmdb": "568124"}
+    if has_current_item_id:
+        assert item["emby_item_id"]
+    assert "emby" not in item["ids"]
+
+
+def test_resolve_rejects_stale_native_emby_id_when_public_id_disagrees() -> None:
+    adapter = FakeAdapter(
+        [
+            emby_movie("10", "Wrong Movie", "1"),
+            emby_movie("20", "Encanto", "568124"),
+        ],
+    )
+
+    item = {"type": "movie", "title": "Encanto", "year": 2021, "ids": {"emby": "10", "tmdb": "568124"}}
+
+    assert common.resolve_item_id(adapter, item, feature="history") == "20"
+    assert any(call["path"] == "/Users/U1/Items/10" for call in adapter.client.calls)
+    assert any(call["params"].get("AnyProviderIdEquals") == "tmdb.568124" for call in adapter.client.calls)
+
+
+def test_resolve_accepts_native_emby_id_when_public_id_matches() -> None:
+    adapter = FakeAdapter([emby_movie("10", "Encanto", "568124")])
+
+    item = {"type": "movie", "title": "Encanto", "year": 2021, "ids": {"emby": "10", "tmdb": "568124"}}
+
+    assert common.resolve_item_id(adapter, item, feature="history") == "10"
+    assert not any(call["params"].get("AnyProviderIdEquals") for call in adapter.client.calls)
+
+
+def test_history_index_does_not_export_native_emby_ids_for_movies() -> None:
+    adapter = FakeAdapter([emby_movie("10", "Encanto", "568124", played_at="2026-08-01T00:00:00Z")])
+
+    index = history.build_index(adapter)
+
+    assert len(index) == 1
+    item = next(iter(index.values()))
+    assert_public_ids_without_native_emby(item, has_current_item_id=False)
+
+
+def test_progress_index_does_not_export_native_emby_ids_for_movies() -> None:
+    row = emby_movie("10", "Encanto", "568124")
+    row["RunTimeTicks"] = 6_000_000_000
+    row["UserData"] = {
+        "PlaybackPositionTicks": 1_200_000_000,
+        "LastPlayedDate": "2026-08-01T00:00:00Z",
+    }
+    adapter = FakeAdapter([row])
+
+    index = progress.build_index(adapter)
+
+    assert len(index) == 1
+    item = next(iter(index.values()))
+    assert_public_ids_without_native_emby(item)
+
+
+def test_progress_write_does_not_trust_stale_emby_item_id() -> None:
+    wrong = emby_movie("10", "Wrong Movie", "1")
+    current = emby_movie("20", "Encanto", "568124")
+    current["RunTimeTicks"] = 6_000_000_000
+    current["UserData"] = {"PlaybackPositionTicks": 0}
+    adapter = FakeAdapter([wrong, current])
+
+    item = {
+        "type": "movie",
+        "title": "Encanto",
+        "year": 2021,
+        "ids": {"tmdb": "568124"},
+        "emby_item_id": "10",
+        "progress_ms": 120_000,
+        "duration_ms": 600_000,
+        "progress_at": "2026-08-01T00:00:00Z",
+    }
+
+    applied, unresolved = progress.add(adapter, [item])
+
+    assert applied == 1
+    assert unresolved == []
+    assert not any(call["path"] == "/Users/U1/Items/10/UserData" for call in adapter.client.calls)
+    assert any(call["path"] == "/Users/U1/Items/20/UserData" for call in adapter.client.calls)
+
+
+def test_watchlist_index_does_not_export_native_emby_ids_for_movies() -> None:
+    row = emby_movie("10", "Encanto", "568124")
+    row["UserData"] = {"IsFavorite": True}
+    adapter = FakeAdapter([row])
+
+    index = watchlist.build_index(adapter)
+
+    assert len(index) == 1
+    item = next(iter(index.values()))
+    assert_public_ids_without_native_emby(item)

--- a/providers/tests/test_jellyfin_resolver.py
+++ b/providers/tests/test_jellyfin_resolver.py
@@ -11,6 +11,7 @@ if str(REPO_ROOT) not in sys.path:
 
 common = importlib.import_module("providers.sync.jellyfin._common")
 history = importlib.import_module("providers.sync.jellyfin._history")
+progress = importlib.import_module("providers.sync.jellyfin._progress")
 
 
 class FakeResp:
@@ -32,6 +33,14 @@ class FakeHttp:
         params = dict(params or {})
         self.calls.append({"method": "GET", "path": path, "params": params})
         assert "AnyProviderIdEquals" not in params
+        if path == "/Sessions":
+            return FakeResp(200, [])
+        if path.startswith("/Items/"):
+            item_id = path.removeprefix("/Items/")
+            for item in self.items:
+                if str(item.get("Id") or "") == item_id:
+                    return FakeResp(200, item)
+            return FakeResp(404, {})
         if path == "/Items":
             return FakeResp(200, {"Items": self.items, "TotalRecordCount": len(self.items)})
         if path.startswith("/Shows/") and path.endswith("/Episodes"):
@@ -52,6 +61,7 @@ class FakeCfg:
     watchlist_guid_priority = None
     history_guid_priority = None
     history_libraries = None
+    progress_libraries = None
 
 
 class FakeAdapter:
@@ -135,6 +145,66 @@ def test_jellyfin_long_numeric_item_ids_are_valid_backend_ids():
     item = {"type": "movie", "title": "Encanto", "year": 2021, "ids": {"tmdb": "568124"}}
 
     assert common.resolve_item_id(adapter, item, feature="history") == "7214430293560476068"
+
+
+def test_normalize_does_not_export_native_jellyfin_id():
+    row = jf_row("M1", "Movie", "Encanto", tmdb="568124")
+
+    item = common.normalize(row)
+
+    assert item["ids"] == {"tmdb": "568124"}
+    assert item["jellyfin_item_id"] == "M1"
+    assert "jellyfin" not in item["ids"]
+
+
+def test_resolve_rejects_stale_native_jellyfin_id_when_public_id_disagrees():
+    wrong = jf_row("M0", "Movie", "Wrong Movie", tmdb="1")
+    right = jf_row("M1", "Movie", "Encanto", tmdb="568124")
+    adapter = FakeAdapter(FakeHttp([wrong, right]))
+
+    item = {"type": "movie", "title": "Encanto", "year": 2021, "ids": {"jellyfin": "M0", "tmdb": "568124"}}
+
+    assert common.resolve_item_id(adapter, item, feature="history") == "M1"
+    assert any(call["path"] == "/Items/M0" for call in adapter.client.calls)
+    assert any(call["params"].get("SearchTerm") == "Encanto" for call in adapter.client.calls)
+
+
+def test_resolve_rejects_stale_jellyfin_item_id_when_public_id_disagrees():
+    wrong = jf_row("M0", "Movie", "Wrong Movie", tmdb="1")
+    right = jf_row("M1", "Movie", "Encanto", tmdb="568124")
+    adapter = FakeAdapter(FakeHttp([wrong, right]))
+
+    item = {"type": "movie", "title": "Encanto", "year": 2021, "ids": {"tmdb": "568124"}, "jellyfin_item_id": "M0"}
+
+    assert common.resolve_item_id(adapter, item, feature="history") == "M1"
+    assert any(call["path"] == "/Items/M0" for call in adapter.client.calls)
+    assert any(call["params"].get("SearchTerm") == "Encanto" for call in adapter.client.calls)
+
+
+def test_progress_write_does_not_trust_stale_jellyfin_item_id():
+    wrong = jf_row("M0", "Movie", "Wrong Movie", tmdb="1")
+    current = jf_row("M1", "Movie", "Encanto", tmdb="568124")
+    current["RunTimeTicks"] = 6_000_000_000
+    current["UserData"] = {"PlaybackPositionTicks": 0}
+    adapter = FakeAdapter(FakeHttp([wrong, current]))
+
+    item = {
+        "type": "movie",
+        "title": "Encanto",
+        "year": 2021,
+        "ids": {"tmdb": "568124"},
+        "jellyfin_item_id": "M0",
+        "progress_ms": 120_000,
+        "duration_ms": 600_000,
+        "progress_at": "2026-08-01T00:00:00Z",
+    }
+
+    applied, unresolved = progress.add(adapter, [item])
+
+    assert applied == 1
+    assert unresolved == []
+    assert not any(call["path"] == "/UserItems/M0/UserData" for call in adapter.client.calls)
+    assert any(call["path"] == "/UserItems/M1/UserData" for call in adapter.client.calls)
 
 
 def test_movie_targeted_lookup_resolves_without_full_provider_index():


### PR DESCRIPTION
# Pull request

## Change

- Hardened Emby and Jellyfin item resolution so stale native item IDs are not trusted as stable sync identity.
- Native server IDs are no longer exported as `ids.emby` / `ids.jellyfin` in shared snapshots. 
- They can still be kept separately as local item context, but writes now resolve against the current library before applying changes.

## Why

- Emby and Jellyfin can assign new internal item IDs when media is removed and later re-added. 
- Old native IDs can become stale, disappear, or theoretically point at a different item later.
- CrossWatch should match long-term on stable public IDs like TMDb, IMDb, and TVDb instead.

## Testing

- providers/tests/test_emby_resolver.py providers/tests/test_jellyfin_resolver.py

## Issue

Relates to #896