### PR TITLE
Change: hide unsupported provider cleanup

### DIFF
--- a/assets/js/modals/provider-cleanup/index.js
+++ b/assets/js/modals/provider-cleanup/index.js
@@ -69,7 +69,7 @@ function configuredProviders(providers) {
 }
 
 function providerFeatures(provider) {
-  const features = provider?.features || {};
+  const features = provider?.cleanup_features || provider?.features || {};
   return FEATURES.filter((feature) => !!features[feature.key]);
 }
 
@@ -187,6 +187,9 @@ export default {
                   </span>
                 </button>
               `).join("")}
+            </div>
+            <div class="cc-feature-empty hidden" id="ccc-features-empty">
+              No clearable data types are available for this provider profile.
             </div>
           </section>
 
@@ -400,11 +403,13 @@ export default {
         const key = String(row.dataset.feature || "");
         const enabled = !!provider && instanceOk && available.has(key);
         row.classList.toggle("disabled", !enabled);
+        row.hidden = !enabled;
         row.disabled = busy || !enabled;
         row.dataset.disabledByFeature = enabled ? "" : "1";
         if (!enabled) row.classList.remove("selected");
         row.setAttribute("aria-pressed", row.classList.contains("selected") ? "true" : "false");
       });
+      $("#ccc-features-empty", root)?.classList.toggle("hidden", !provider || !instanceOk || available.size > 0);
       const anySelected = selectedFeatures().length > 0;
       const clearBtn = $("#ccc-clear-selected", root);
       if (clearBtn) clearBtn.disabled = busy || !provider || !instanceOk || !anySelected;

--- a/assets/js/modals/provider-cleanup/styles.css
+++ b/assets/js/modals/provider-cleanup/styles.css
@@ -34,6 +34,8 @@
 .cw-provider-cleanup .cc-feature.selected{border-color:color-mix(in srgb,var(--cc-accent) 58%,var(--cc-border));background:color-mix(in srgb,var(--cc-accent) 10%,var(--cc-panel));box-shadow:0 0 0 1px color-mix(in srgb,var(--cc-accent) 18%,transparent)}
 .cw-provider-cleanup .cc-feature.selected .cc-feature-icon{border:1px solid color-mix(in srgb,var(--cc-accent) 44%,var(--cc-border));background:color-mix(in srgb,var(--cc-accent) 22%,var(--cc-card))}
 .cw-provider-cleanup .cc-feature.disabled{opacity:.45;cursor:not-allowed}
+.cw-provider-cleanup .cc-feature-empty{padding:14px;border:1px solid var(--cc-border);border-radius:12px;background:color-mix(in srgb,var(--cc-panel) 88%,#091321);color:var(--cc-muted);font-size:13px;line-height:1.35}
+.cw-provider-cleanup .cc-feature-empty.hidden{display:none}
 .cw-provider-cleanup .cc-run-card{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:10px;align-items:center;border-color:color-mix(in srgb,#ffbd4a 28%,var(--cc-border))}
 .cw-provider-cleanup .cc-warning{min-width:0;display:flex;align-items:center;gap:10px;color:var(--cc-muted);font-size:13px;line-height:1.35}
 .cw-provider-cleanup .cc-warning .material-symbols-rounded{color:#ffbd4a;font-size:24px}

--- a/cli/commands/maintenance.py
+++ b/cli/commands/maintenance.py
@@ -92,7 +92,7 @@ def _provider_targets(payload: Any) -> list[dict[str, str]]:
             continue
         pid = str(provider.get("id") or "").strip().upper()
         label = str(provider.get("label") or pid or "-")
-        raw_features = provider.get("features")
+        raw_features = provider.get("cleanup_features") or provider.get("features")
         features: dict[str, Any] = raw_features if isinstance(raw_features, dict) else {}
         cleanup_features = [feature for feature in PROVIDER_CLEANUP_FEATURES if features.get(feature)]
         instances = provider.get("instances") if isinstance(provider.get("instances"), list) else []

--- a/services/snapshots.py
+++ b/services/snapshots.py
@@ -613,6 +613,68 @@ def _state_read_feature_enabled(ops: Any, feature: Feature) -> bool:
     return bool(state_read_features(ops).get(feature))
 
 
+def _provider_capabilities(ops: Any) -> Mapping[str, Any]:
+    fn = getattr(ops, "capabilities", None)
+    if not callable(fn):
+        return {}
+    try:
+        caps = fn() or {}
+    except Exception:
+        return {}
+    return caps if isinstance(caps, Mapping) else {}
+
+
+def _first_cap_bool(cap: Mapping[str, Any], names: Sequence[str]) -> bool | None:
+    for name in names:
+        if name not in cap:
+            continue
+        value = cap.get(name)
+        if isinstance(value, bool):
+            return value
+        if value is not None and name in {"writes"}:
+            return bool(value)
+    return None
+
+
+def _cleanup_feature_enabled(ops: Any, feature: Feature) -> bool:
+    if not _state_read_feature_enabled(ops, feature):
+        return False
+
+    caps = _provider_capabilities(ops)
+    cap_raw = caps.get(feature)
+    if not isinstance(cap_raw, Mapping):
+        return not bool(caps.get("read_only"))
+
+    cap: Mapping[str, Any] = cap_raw
+    if bool(cap.get("source_only")):
+        return False
+
+    cleanup_raw = cap.get("cleanup") if "cleanup" in cap else cap.get("clear")
+    if isinstance(cleanup_raw, bool):
+        return cleanup_raw
+    if isinstance(cleanup_raw, Mapping):
+        cleanup: Mapping[str, Any] = cleanup_raw
+        enabled = cleanup.get("enabled")
+        if isinstance(enabled, bool):
+            return enabled
+        remove = _first_cap_bool(cleanup, ("remove", "delete", "write", "writes", "unrate", "upsert"))
+        if remove is not None:
+            return remove
+
+    names: tuple[str, ...]
+    if feature == "ratings":
+        names = ("remove", "unrate", "write", "upsert")
+    else:
+        names = ("remove", "delete", "write", "writes", "upsert")
+
+    remove = _first_cap_bool(cap, names)
+    if remove is not None:
+        return remove
+    if bool(cap.get("read_only")) or bool(caps.get("read_only")):
+        return False
+    return True
+
+
 def _configured(ops: Any, cfg: Mapping[str, Any]) -> bool:
     fn = getattr(ops, "is_configured", None)
     if not callable(fn):
@@ -659,6 +721,7 @@ def snapshot_manifest(cfg: Mapping[str, Any] | None = None) -> list[dict[str, An
             continue
         raw = state_read_features(ops)
         feats = {k: bool(raw.get(k)) for k in SNAPSHOT_FEATURES}
+        cleanup_feats = {k: _cleanup_feature_enabled(ops, k) for k in SNAPSHOT_FEATURES}
 
         insts = list_instance_ids(cfg, pid)
         inst_meta: list[dict[str, Any]] = []
@@ -675,6 +738,7 @@ def snapshot_manifest(cfg: Mapping[str, Any] | None = None) -> list[dict[str, An
                 "label": getattr(ops, "label", lambda: pid)() if callable(getattr(ops, "label", None)) else pid,
                 "configured": configured_any,
                 "features": feats,
+                "cleanup_features": cleanup_feats,
                 "instances": inst_meta,
             }
         )
@@ -1624,8 +1688,9 @@ def clear_provider_features(
                 feature_items=0,
                 percent=_progress_percent(index, len(feature_list) or 1, 0.12),
             )
-            if not _state_read_feature_enabled(ops, feat):
-                done["results"][feat] = {"ok": True, "skipped": True, "reason": "feature_disabled"}
+            if not _cleanup_feature_enabled(ops, feat):
+                reason = "feature_disabled" if not _state_read_feature_enabled(ops, feat) else "cleanup_not_supported"
+                done["results"][feat] = {"ok": True, "skipped": True, "reason": reason}
                 continue
             cur = _load_current_items(feat)
             initial_count = len(cur)

--- a/tests/test_capture_restore_compare_tools.py
+++ b/tests/test_capture_restore_compare_tools.py
@@ -68,6 +68,17 @@ class RevealingCollectionCleanupOps(MutableSyncOps):
         return result
 
 
+class CleanupCapabilityOps(MutableSyncOps):
+    def capabilities(self) -> dict[str, dict]:
+        return {
+            "watchlist": {"read": True, "remove": True},
+            "ratings": {"read": True, "unrate": False},
+            "history": {"read": True, "write": False},
+            "progress": {"read": True, "remove": True},
+            "collection": {"read": True, "remove": False, "source_only": True},
+        }
+
+
 def _snapshot_path(tmp_path: Path, stamp: str, feature: str, payload: dict) -> str:
     day = stamp[:8]
     rel = f"{day[:4]}-{day[4:6]}-{day[6:8]}/{stamp}__PLEX__default__{feature}__capture.json"
@@ -569,6 +580,49 @@ def test_provider_cleanup_background_job_tracks_progress(tmp_path: Path, monkeyp
     assert progress["done"] is True
     assert progress["total_items"] == 2
     assert progress["cleanup_results"]["watchlist"]["removed"] == 2
+    assert ops.current_by_feature["watchlist"] == {}
+
+
+def test_snapshot_manifest_reports_cleanup_features_separately(tmp_path: Path, monkeypatch) -> None:
+    import services.snapshots as snapshots
+
+    ops = CleanupCapabilityOps({})
+    _patch_ops(monkeypatch, snapshots, tmp_path, ops)
+    monkeypatch.setattr(snapshots, "_registry_sync_providers", lambda: ["PLEX"])
+    monkeypatch.setattr(snapshots, "list_instance_ids", lambda _cfg, _pid: ["default"])
+
+    row = snapshots.snapshot_manifest({})[0]
+
+    assert row["features"]["collection"] is True
+    assert row["cleanup_features"] == {
+        "watchlist": True,
+        "ratings": False,
+        "history": False,
+        "progress": True,
+        "collection": False,
+    }
+
+
+def test_provider_cleanup_skips_source_only_features(tmp_path: Path, monkeypatch) -> None:
+    import services.snapshots as snapshots
+
+    ops = CleanupCapabilityOps(
+        {
+            "collection": {"one": {"id": "one", "type": "movie", "title": "Heat"}},
+            "watchlist": {"two": {"id": "two", "type": "movie", "title": "Alien"}},
+        }
+    )
+    _patch_ops(monkeypatch, snapshots, tmp_path, ops)
+
+    result = snapshots.clear_provider_features("PLEX", ["collection", "watchlist"], cfg={})
+
+    assert result["ok"] is True
+    assert result["results"]["collection"] == {
+        "ok": True,
+        "skipped": True,
+        "reason": "cleanup_not_supported",
+    }
+    assert ops.current_by_feature["collection"] == {"one": {"id": "one", "type": "movie", "title": "Heat"}}
     assert ops.current_by_feature["watchlist"] == {}
 
 


### PR DESCRIPTION
# Pull request

## Change

- Provider cleanup now uses a separate cleanup feature map and hides data types that a provider cannot safely clear.

## Why

- Some providers can read collections for captures but cannot remove them. 
- Plex, Jellyfin, Emby, and Kodi no longer show Collections in provider cleanup.

## Testing
- tests\test_capture_restore_compare_tools.py::test_snapshot_manifest_reports_cleanup_features_separately
- tests\test_capture_restore_compare_tools.py::test_provider_cleanup_skips_source_only_features
- tests\test_cli.py::test_maintenance_provider_cleanup_lists_manifest_targets -q

## Issue

N/A