### PR TITLE
Change: speed up dashboard startup

### DIFF
--- a/assets/js/dashboard-widgets.js
+++ b/assets/js/dashboard-widgets.js
@@ -25,7 +25,6 @@
   const WIDE_UNITS = 3;
   const WIDGET_REFRESH_TTL_MS = 60 * 1000;
   const WIDGET_FETCH_RETRY_DELAYS = [350, 900, 1800];
-  const IMAGE_PREWARM_MAX = 12;
   const visibleCounts = { history: GRID_PAGE_STEP, ratings: RATING_PAGE_STEP, scrobble: GRID_PAGE_STEP, progress: GRID_PAGE_STEP, playlists: GRID_PAGE_STEP };
   const latestItems = { history: [], ratings: [], scrobble: [], progress: [], playlists: [] };
   const EMPTY_META = {
@@ -966,49 +965,6 @@
     return `/art/tmdb/${kind}/${encodeURIComponent(String(tmdb))}?kind=backdrop&size=${encodeURIComponent(size)}&locale=${encodeURIComponent(window.__CW_LOCALE || navigator.language || "en-US")}${title}${year}`;
   }
 
-  function prewarmImageUrls(urls) {
-    const list = [...new Set((urls || []).filter(Boolean))].slice(0, IMAGE_PREWARM_MAX);
-    if (!list.length) return;
-    if (navigator.connection?.saveData) return;
-    const run = () => {
-      let index = 0;
-      const next = () => {
-        const url = list[index++];
-        if (!url) return;
-        let settled = false;
-        const img = new Image();
-        const done = () => {
-          if (settled) return;
-          settled = true;
-          window.setTimeout(next, 160);
-        };
-        img.onload = done;
-        img.onerror = done;
-        img.decoding = "async";
-        img.src = url;
-        window.setTimeout(done, 3500);
-      };
-      next();
-    };
-    const start = () => {
-      if ("requestIdleCallback" in window) window.requestIdleCallback(run, { timeout: 4000 });
-      else window.setTimeout(run, 800);
-    };
-    window.setTimeout(start, 900);
-  }
-
-  function prewarmWidgetImages(active) {
-    const urls = [];
-    for (const kind of ["history", "ratings", "scrobble", "progress"]) {
-      if (!active?.[kind]) continue;
-      const limit = Math.min(latestItems[kind]?.length || 0, visibleCounts[kind] || PAGE_STEP);
-      for (const item of (latestItems[kind] || []).slice(0, limit)) {
-        urls.push(poster(item), coverPoster(item, "w342"), backdropPoster(item, null, "w780"));
-      }
-    }
-    prewarmImageUrls(urls);
-  }
-
   function tmdbLink(item) {
     const tmdb = item?.tmdb;
     if (!tmdb) return "";
@@ -1630,7 +1586,6 @@
       for (const kind of ["history", "ratings", "scrobble", "progress", "playlists"]) {
         if (active[kind]) renderWidget(kind);
       }
-      prewarmWidgetImages(active);
     } catch (e) {
       if (authPendingError(e)) {
         scheduleAuthReadyRefresh();
@@ -1789,7 +1744,11 @@
     });
     window.addEventListener("resize", scheduleMasonry);
     if (authSetupPending()) scheduleAuthReadyRefresh();
-    window.addEventListener("load", () => setTimeout(() => refreshDashboardWidgets({ forceConfig: true }), 100), { once: true });
+    window.addEventListener("load", () => {
+      setTimeout(() => {
+        if (!hasLoaded) refreshDashboardWidgets({ forceConfig: true });
+      }, 100);
+    }, { once: true });
     refreshDashboardWidgets();
   }
 

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -312,19 +312,19 @@ def _asset_block(include_admin: bool = True, user: dict | None = None) -> str:
     full_user = not include_admin and bool(_managed_user_permissions(user).get("write"))
     helper_scripts = _HELPER_SCRIPTS if include_admin else (_FULL_USER_HELPER_SCRIPTS if full_user else _USER_HELPER_SCRIPTS)
     app_scripts = _APP_SCRIPTS if include_admin else (_FULL_USER_APP_SCRIPTS if full_user else _USER_APP_SCRIPTS)
-    helper_tags = "\n".join(f'<script src="/assets/helpers/{name}?v=__CW_VERSION__"></script>' for name in helper_scripts)
+    helper_tags = "\n".join(f'<script src="/assets/helpers/{name}?v=__CW_VERSION__" defer></script>' for name in helper_scripts)
     app_tags = "\n".join(f'<script src="/assets/js/{name}?v=__CW_VERSION__" defer></script>' for name in app_scripts)
     admin_only_tags = (
         '<script src="/assets/helpers/media_user_picker.js?v=__CW_VERSION__" defer></script>',
         '<script src="/assets/helpers/whitelist_table.js?v=__CW_VERSION__" defer></script>',
-        '<script src="/assets/auth/auth.shared.js?v=__CW_VERSION__"></script>',
+        '<script src="/assets/auth/auth.shared.js?v=__CW_VERSION__" defer></script>',
         '<script src="/assets/auth/auth_loader.js?v=__CW_VERSION__" defer></script>',
         '<script src="/assets/auth/auth.tmdb.js?v=__CW_VERSION__" defer></script>',
         '<script type="module" src="/assets/js/modals.js?v=__CW_VERSION__"></script>',
     ) if include_admin else (('<script type="module" src="/assets/js/modals.js?v=__CW_VERSION__"></script>',) if full_user else ())
     return "\n".join((
         helper_tags,
-        '<script src="/assets/crosswatch.js?v=__CW_VERSION__"></script>',
+        '<script src="/assets/crosswatch.js?v=__CW_VERSION__" defer></script>',
         app_tags,
         *admin_only_tags,
         '<script src="/assets/js/theme-flat-runtime.js?v=__CW_VERSION__" defer></script>',
@@ -2309,13 +2309,13 @@ def get_profile_html(user: dict | None = None) -> str:
 }})();
 </script>
 <script type="module" src="/assets/js/modals.js?v=__CW_VERSION__"></script>
-<script src="/assets/helpers/provider-meta.js?v=__CW_VERSION__"></script>
-<script src="/assets/helpers/icon-select.js?v=__CW_VERSION__"></script>
-<script src="/assets/helpers/api.js?v=__CW_VERSION__"></script>
-<script src="/assets/helpers/media-meta.js?v=__CW_VERSION__"></script>
-<script src="/assets/helpers/trailer.js?v=__CW_VERSION__"></script>
-<script src="/assets/helpers/playing-card.js?v=__CW_VERSION__"></script>
-<script src="/assets/helpers/watchlist-preview.js?v=__CW_VERSION__"></script>
+<script src="/assets/helpers/provider-meta.js?v=__CW_VERSION__" defer></script>
+<script src="/assets/helpers/icon-select.js?v=__CW_VERSION__" defer></script>
+<script src="/assets/helpers/api.js?v=__CW_VERSION__" defer></script>
+<script src="/assets/helpers/media-meta.js?v=__CW_VERSION__" defer></script>
+<script src="/assets/helpers/trailer.js?v=__CW_VERSION__" defer></script>
+<script src="/assets/helpers/playing-card.js?v=__CW_VERSION__" defer></script>
+<script src="/assets/helpers/watchlist-preview.js?v=__CW_VERSION__" defer></script>
 <script>window.cwIsAuthSetupPending = window.cwIsAuthSetupPending || (() => window.__cwAuthSetupPending === true);</script>
 <script src="/assets/js/dashboard-widgets.js?v=__CW_VERSION__" defer></script>
 <script src="/assets/js/activity.js?v=__CW_VERSION__" defer></script>


### PR DESCRIPTION
# Pull request

## Change

- Defer frontend helper scripts so page assets load quicker.
- Stop dashboard widgets from doing an extra boot refresh after they already loaded.
- Remove unused dashboard image prewarm code.

## Why

The dashboard was doing extra work during first load, especially around widget artwork. 

## Testing

NA

## Issue

NA