### PR TITLE
Change: playlist endpoint management foundation

### DIFF
--- a/api/appAuthAPI.py
+++ b/api/appAuthAPI.py
@@ -711,6 +711,8 @@ def non_admin_api_allowed(path: Any, method: Any) -> bool:
         return m == "GET"
     if p.startswith("/api/playback_progress/actions/"):
         return m == "POST"
+    if p == "/api/playlists/activity" and m == "DELETE":
+        return False
     for prefix in (
         "/api/analyzer",
         "/api/events",

--- a/api/playlistsAPI.py
+++ b/api/playlistsAPI.py
@@ -85,6 +85,59 @@ def api_playlist_resources(
     return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
 
 
+@router.post("/resources")
+def api_playlist_resource_create(payload: dict[str, Any] = Body(...), request: Request = cast(Request, None)) -> JSONResponse:
+    cfg = load_config() or {}
+    provider = payload.get("provider")
+    instance = payload.get("instance") or "default"
+    if not user_can_access_instance(cfg, request_user(request), provider, instance):
+        return _scope_denied()
+    res = svc.create_provider_playlist(
+        cfg,
+        str(provider or ""),
+        str(instance or "default"),
+        payload.get("name") or payload.get("create_name"),
+        payload.get("media_type"),
+    )
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
+@router.patch("/resources/{playlist_id}")
+def api_playlist_resource_rename(
+    playlist_id: str,
+    payload: dict[str, Any] = Body(...),
+    request: Request = cast(Request, None),
+) -> JSONResponse:
+    cfg = load_config() or {}
+    provider = payload.get("provider")
+    instance = payload.get("instance") or "default"
+    if not user_can_access_instance(cfg, request_user(request), provider, instance):
+        return _scope_denied()
+    res = svc.rename_provider_playlist(
+        cfg,
+        str(provider or ""),
+        str(instance or "default"),
+        playlist_id,
+        payload.get("name"),
+    )
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
+@router.delete("/resources/{playlist_id}")
+def api_playlist_resource_delete(
+    playlist_id: str,
+    provider: str = Query(...),
+    instance: str | None = Query(None),
+    request: Request = cast(Request, None),
+) -> JSONResponse:
+    cfg = load_config() or {}
+    inst = instance or "default"
+    if not user_can_access_instance(cfg, request_user(request), provider, inst):
+        return _scope_denied()
+    res = svc.delete_provider_playlist(cfg, provider, inst, playlist_id)
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400))
+
+
 @router.get("/overview")
 def api_playlist_overview(request: Request = cast(Request, None)) -> JSONResponse:
     cfg = load_config() or {}
@@ -168,6 +221,15 @@ def api_playlist_activity(request: Request = cast(Request, None)) -> JSONRespons
         ]
         return JSONResponse({"ok": True, "activity": activity})
     return JSONResponse({"ok": True, "activity": svc.activity(cfg)})
+
+
+@router.delete("/activity")
+def api_playlist_activity_clear(request: Request = cast(Request, None)) -> JSONResponse:
+    if not _is_admin_request(request):
+        return _scope_denied()
+    cfg = load_config() or {}
+    res = svc.clear_activity(cfg)
+    return JSONResponse(res, status_code=(200 if res.get("ok") else 400), headers={"Cache-Control": "no-store"})
 
 
 @router.get("/rulesets")

--- a/cw_platform/playlists.py
+++ b/cw_platform/playlists.py
@@ -10,6 +10,7 @@ from .id_map import canonical_key, minimal
 
 PLAYLIST_KIND_REGULAR = "regular"
 PLAYLIST_KIND_SMART = "smart"
+PLAYLIST_SOURCE_KIND_DISCOVERY = "discovery"
 RULESET_SCHEMA_VERSION = 1
 BUILTIN_TRAKT_FREE_ACCOUNT_RULESET_ID = "trakt_free_account"
 
@@ -214,6 +215,14 @@ class PlaylistResource:
     def writable(self) -> bool:
         return not self.is_smart and (self.can_add or self.can_remove)
 
+    @property
+    def source_kind(self) -> str:
+        return _clean_str(self.extra.get("source_kind") or self.extra.get("endpoint_type")).lower()
+
+    @property
+    def is_discovery(self) -> bool:
+        return self.source_kind == PLAYLIST_SOURCE_KIND_DISCOVERY or bool(self.extra.get("discovery"))
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "provider": self.provider,
@@ -227,6 +236,10 @@ class PlaylistResource:
             "can_remove": self.can_remove,
             "can_reorder": self.can_reorder,
             "writable": self.writable,
+            "source_kind": self.source_kind,
+            "discovery": self.is_discovery,
+            "virtual": bool(self.extra.get("virtual")),
+            "endpoint_type": _clean_str(self.extra.get("endpoint_type") or self.kind).lower(),
             "media_types": list(self.media_types),
             "extra": dict(self.extra),
         }
@@ -385,6 +398,25 @@ class PlaylistOps(Protocol):
         cfg: Mapping[str, Any],
         playlist_id: str,
         ordered_keys: Sequence[str],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]: ...
+
+    def rename_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        name: str,
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> PlaylistResource: ...
+
+    def delete_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
         *,
         instance: str | None = None,
         dry_run: bool = False,

--- a/cw_platform/playlists_runner.py
+++ b/cw_platform/playlists_runner.py
@@ -343,6 +343,18 @@ def load_result(mapping: Mapping[str, Any]) -> dict[str, Any] | None:
     return dict(res) if isinstance(res, Mapping) else None
 
 
+def clear_result(mapping: Mapping[str, Any]) -> bool:
+    data = _load_all_state()
+    key = scope_key(mapping)
+    entry = data.get(key)
+    if isinstance(entry, dict) and "last_result" in entry:
+        entry.pop("last_result", None)
+        data[key] = entry
+        _save_all_state(data)
+        return True
+    return False
+
+
 def prune_baselines(valid_keys: set[str]) -> int:
     data = _load_all_state()
     removed = 0

--- a/services/playlists.py
+++ b/services/playlists.py
@@ -12,6 +12,7 @@ from typing import Any, Iterator, Mapping
 from _logging import log as _cw_log
 from cw_platform.playlists import (
     BUILTIN_RULESETS,
+    PlaylistResource,
     playlist_capabilities,
     supports_playlists,
     validate_ruleset,
@@ -153,7 +154,155 @@ def list_resources(cfg: Mapping[str, Any], provider: str, instance: str | None =
         res = _internal_playlist_error("resource listing", e, provider=name, instance=inst)
         res["resources"] = []
         return res
-    return {"ok": True, "provider": name, "instance": inst, "resources": [r.to_dict() for r in resources]}
+    return {"ok": True, "provider": name, "instance": inst, "resources": [_resource_with_manage_flags(r, ops) for r in resources]}
+
+
+def create_provider_playlist(
+    cfg: Mapping[str, Any],
+    provider: str,
+    instance: str | None,
+    playlist_name: Any,
+    media_type: Any = None,
+) -> dict[str, Any]:
+    name = str(provider or "").strip().upper()
+    inst = normalize_instance_id(instance)
+    ops = _providers().get(name)
+    if not ops or not supports_playlists(ops):
+        return {"ok": False, "error": "provider not playlist-capable"}
+    create_name = str(playlist_name or "").strip()
+    create_err = _playlist_name_error(create_name)
+    if create_err:
+        return {"ok": False, "error": create_err}
+    allowed_types = creatable_endpoint_types(ops)
+    endpoint_type = str(media_type or allowed_types[0]).strip().lower()
+    if endpoint_type not in allowed_types:
+        label = " or ".join(allowed_types)
+        return {"ok": False, "error": f"{name} can only create a {label}"}
+    try:
+        view = build_provider_config_view(cfg, name, inst)
+        resource = ops.create_playlist(view, create_name, media_type=endpoint_type, instance=inst)
+    except Exception as e:
+        return _internal_playlist_error("create", e, provider=name, instance=inst, media_type=endpoint_type)
+    if isinstance(resource, PlaylistResource):
+        resource_data = resource.to_dict()
+    elif isinstance(resource, Mapping):
+        resource_data = dict(resource)
+    else:
+        resource_data = {"id": str(getattr(resource, "id", "") or ""), "name": str(getattr(resource, "name", create_name) or create_name)}
+    resource_data.setdefault("provider", name)
+    resource_data.setdefault("instance", inst)
+    if isinstance(resource, (PlaylistResource, Mapping)):
+        try:
+            resource_data = _resource_with_manage_flags(PlaylistResource.from_dict(resource_data), ops)
+        except Exception:
+            resource_data = dict(resource_data)
+    return {"ok": True, "provider": name, "instance": inst, "resource": resource_data}
+
+
+def rename_provider_playlist(
+    cfg: Mapping[str, Any],
+    provider: str,
+    instance: str | None,
+    playlist_id: Any,
+    playlist_name: Any,
+) -> dict[str, Any]:
+    name = str(provider or "").strip().upper()
+    inst = normalize_instance_id(instance)
+    ops = _providers().get(name)
+    rename = getattr(ops, "rename_playlist", None) if ops else None
+    if not ops or not supports_playlists(ops) or not callable(rename):
+        return {"ok": False, "error": "provider playlist rename is not supported"}
+    pid = str(playlist_id or "").strip()
+    if not pid:
+        return {"ok": False, "error": "playlist id required"}
+    rename_name = str(playlist_name or "").strip()
+    rename_err = _playlist_name_error(rename_name)
+    if rename_err:
+        return {"ok": False, "error": rename_err}
+    try:
+        view = build_provider_config_view(cfg, name, inst)
+        current = _find_resource_data(ops, view, inst, pid)
+        if not current:
+            return {"ok": False, "error": "playlist not found"}
+        if not current.get("can_rename"):
+            return {"ok": False, "error": "selected playlist cannot be renamed"}
+        resource = rename(view, pid, rename_name, instance=inst)
+        if isinstance(resource, PlaylistResource):
+            resource_data = _resource_with_manage_flags(resource, ops)
+        elif isinstance(resource, Mapping):
+            resource_data = _resource_with_manage_flags(PlaylistResource.from_dict(resource), ops)
+        else:
+            resource_data = _find_resource_data(ops, view, inst, pid) or dict(current)
+            resource_data["name"] = rename_name
+    except Exception as e:
+        return _internal_playlist_error("rename", e, provider=name, instance=inst)
+    return {"ok": True, "provider": name, "instance": inst, "resource": resource_data}
+
+
+def delete_provider_playlist(
+    cfg: Mapping[str, Any],
+    provider: str,
+    instance: str | None,
+    playlist_id: Any,
+) -> dict[str, Any]:
+    name = str(provider or "").strip().upper()
+    inst = normalize_instance_id(instance)
+    ops = _providers().get(name)
+    delete = getattr(ops, "delete_playlist", None) if ops else None
+    if not ops or not supports_playlists(ops) or not callable(delete):
+        return {"ok": False, "error": "provider playlist delete is not supported"}
+    pid = str(playlist_id or "").strip()
+    if not pid:
+        return {"ok": False, "error": "playlist id required"}
+    try:
+        view = build_provider_config_view(cfg, name, inst)
+        current = _find_resource_data(ops, view, inst, pid)
+        if not current:
+            return {"ok": False, "error": "playlist not found"}
+        if not current.get("can_delete"):
+            return {"ok": False, "error": "selected playlist cannot be deleted"}
+        res = delete(view, pid, instance=inst)
+    except Exception as e:
+        return _internal_playlist_error("delete", e, provider=name, instance=inst)
+    if isinstance(res, Mapping) and res.get("ok") is False:
+        return {"ok": False, "error": str(res.get("error") or "delete failed")}
+    return {"ok": True, "provider": name, "instance": inst, "playlist_id": pid}
+
+
+def _resource_with_manage_flags(resource: PlaylistResource, ops: Any) -> dict[str, Any]:
+    data = resource.to_dict()
+    caps = playlist_capabilities(ops)
+    can_manage = _resource_can_be_managed(data)
+    raw_extra = data.get("extra")
+    extra: Mapping[str, Any] = raw_extra if isinstance(raw_extra, Mapping) else {}
+    endpoint_type = str(data.get("endpoint_type") or extra.get("endpoint_type") or "").strip().lower()
+    delete_default = endpoint_type != "collection"
+    data["can_rename"] = bool(can_manage and bool(extra.get("can_rename", True)) and callable(getattr(ops, "rename_playlist", None)) and caps.get("rename", True))
+    data["can_delete"] = bool(can_manage and bool(extra.get("can_delete", delete_default)) and callable(getattr(ops, "delete_playlist", None)) and caps.get("delete", True))
+    return data
+
+
+def _resource_can_be_managed(resource: Mapping[str, Any]) -> bool:
+    raw_extra = resource.get("extra")
+    extra: Mapping[str, Any] = raw_extra if isinstance(raw_extra, Mapping) else {}
+    kind = str(resource.get("kind") or "").strip().lower()
+    endpoint_type = str(resource.get("endpoint_type") or extra.get("endpoint_type") or "").strip().lower()
+    source_kind = str(resource.get("source_kind") or extra.get("source_kind") or endpoint_type).strip().lower()
+    if not str(resource.get("id") or "").strip():
+        return False
+    if bool(resource.get("smart")) or bool(resource.get("discovery")) or bool(resource.get("virtual")):
+        return False
+    if bool(extra.get("builtin")) or bool(extra.get("virtual")) or bool(extra.get("discovery")):
+        return False
+    return kind != "smart" and endpoint_type not in {"discovery", "watchlist"} and source_kind not in {"discovery", "watchlist"}
+
+
+def _find_resource_data(ops: Any, view: Mapping[str, Any], instance: str, playlist_id: str) -> dict[str, Any] | None:
+    for res in ops.list_playlist_resources(view, instance=instance) or []:
+        raw_id = str((res.extra or {}).get("raw_id") or "").strip()
+        if res.id == playlist_id or raw_id == playlist_id:
+            return _resource_with_manage_flags(res, ops)
+    return None
 
 
 # Endpoints
@@ -309,6 +458,13 @@ def _resource_meta(cfg: Mapping[str, Any], provider: str, instance: str, playlis
                 out: dict[str, Any] = {
                     "playlist_type": str(extra.get("endpoint_type") or res.kind or "").strip().lower(),
                     "media_types": list(res.media_types or []),
+                    "source_kind": str(extra.get("source_kind") or extra.get("endpoint_type") or res.kind or "").strip().lower(),
+                    "smart": bool(res.is_smart),
+                    "discovery": bool(getattr(res, "is_discovery", False)),
+                    "virtual": bool(extra.get("virtual")),
+                    "can_read": bool(res.can_read),
+                    "can_add": bool(res.can_add),
+                    "can_remove": bool(res.can_remove),
                     "can_reorder": bool(res.can_reorder),
                     "destructive_remove": bool(extra.get("destructive_remove")),
                     "remove_warning": str(extra.get("remove_warning") or "").strip(),
@@ -359,13 +515,43 @@ def activity(cfg: Mapping[str, Any], *, limit: int = 25) -> list[dict[str, Any]]
         if isinstance(r, Mapping) and r.get("finished_at"):
             finished_at = int(r.get("finished_at") or 0)
             src = (m.get("source") or {}).get("label"); dst = (m.get("target") or {}).get("label")
+            ruleset_name = (m.get("ruleset") or {}).get("name") or r.get("ruleset_id") or "direct"
+            target_count = len(m.get("targets") or [])
             rows.append({
                 "ts": finished_at, "type": "Run", "status": "completed" if r.get("ok", True) else "error",
+                "ruleset": ruleset_name,
+                "target_count": target_count,
+                "added": int(r.get("added", 0)),
+                "updated": int(r.get("updated", 0)),
+                "removed": int(r.get("removed", 0)),
+                "skipped": int(r.get("skipped", 0)),
                 "label": f"{m.get('id')} · {src} → {dst}",
                 "details": f"{(m.get('ruleset') or {}).get('name') or r.get('ruleset_id') or 'direct'}, {len(m.get('targets') or [])} target(s), +{int(r.get('added', 0))}/-{int(r.get('removed', 0))}" + (", capacity error" if r.get("capacity_error") else ""),
             })
     rows.sort(key=lambda x: x["ts"], reverse=True)
     return rows[: max(1, int(limit))]
+
+
+def clear_activity(cfg: dict[str, Any]) -> dict[str, Any]:
+    root = runner.pl_root(cfg, create=True)
+    removed = 0
+    for ep in root.get("endpoints", []):
+        if isinstance(ep, dict) and "last_synced" in ep:
+            ep.pop("last_synced", None)
+            removed += 1
+    for mapping in root.get("mappings", []):
+        if isinstance(mapping, dict):
+            had_result = "last_result" in mapping
+            if had_result:
+                mapping.pop("last_result", None)
+            resolved = runner.resolve_mapping(cfg, mapping)
+            if resolved:
+                had_result = runner.clear_result(resolved) or had_result
+            if had_result:
+                removed += 1
+    if removed:
+        _save(cfg)
+    return {"ok": True, "removed": removed}
 
 
 def upsert_endpoint(cfg: dict[str, Any], payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -385,30 +571,25 @@ def upsert_endpoint(cfg: dict[str, Any], payload: Mapping[str, Any]) -> dict[str
         create_err = _playlist_name_error(create_name)
         if create_err:
             return {"ok": False, "error": create_err}
-        caps = playlist_capabilities(ops)
         allowed_types = creatable_endpoint_types(ops)
         media_type = str(payload.get("media_type") or allowed_types[0]).strip().lower()
         if media_type not in allowed_types:
             label = " or ".join(allowed_types)
             return {"ok": False, "error": f"{clean['provider']} can only create a {label}"}
         clean["playlist_type"] = media_type
-        if caps.get("create_empty", True) is False:
-            clean["playlist_name"] = clean["playlist_name"] or create_name
-            clean["pending_create"] = {"name": create_name, "media_type": media_type}
-        else:
-            try:
-                view = build_provider_config_view(cfg, clean["provider"], clean["instance"])
-                res = ops.create_playlist(view, create_name, media_type=media_type, instance=clean["instance"])
-                clean["playlist_id"] = res.id
-                clean["playlist_name"] = clean["playlist_name"] or res.name
-            except Exception as e:
-                return _internal_playlist_error(
-                    "create",
-                    e,
-                    provider=clean["provider"],
-                    instance=clean["instance"],
-                    media_type=media_type,
-                )
+        try:
+            view = build_provider_config_view(cfg, clean["provider"], clean["instance"])
+            res = ops.create_playlist(view, create_name, media_type=media_type, instance=clean["instance"])
+            clean["playlist_id"] = res.id
+            clean["playlist_name"] = clean["playlist_name"] or res.name
+        except Exception as e:
+            return _internal_playlist_error(
+                "create",
+                e,
+                provider=clean["provider"],
+                instance=clean["instance"],
+                media_type=media_type,
+            )
 
     if not (clean["playlist_id"] or clean.get("pending_create")):
         return {"ok": False, "error": "playlist required"}
@@ -488,6 +669,41 @@ def _endpoint_reorderable(cfg: Mapping[str, Any], endpoint_id: str) -> bool:
     return bool(playlist_capabilities(ops).get("reorder", True))
 
 
+def _endpoint_resource_flags(cfg: Mapping[str, Any], endpoint_id: str) -> dict[str, Any]:
+    ep = runner.get_endpoint(cfg, endpoint_id) or {}
+    out = dict(ep)
+    if "can_add" in out or "can_remove" in out or "smart" in out or "discovery" in out:
+        return out
+    meta = _resource_meta(
+        cfg,
+        str(ep.get("provider") or "").strip().upper(),
+        normalize_instance_id(ep.get("instance")),
+        str(ep.get("playlist_id") or "").strip(),
+    )
+    out.update(meta)
+    return out
+
+
+def _endpoint_is_discovery(cfg: Mapping[str, Any], endpoint_id: str) -> bool:
+    ep = _endpoint_resource_flags(cfg, endpoint_id)
+    typ = str(ep.get("playlist_type") or ep.get("source_kind") or "").strip().lower()
+    return bool(ep.get("discovery")) or typ == "discovery"
+
+
+def _endpoint_writable(cfg: Mapping[str, Any], endpoint_id: str) -> bool:
+    ep = _endpoint_resource_flags(cfg, endpoint_id)
+    typ = str(ep.get("playlist_type") or ep.get("source_kind") or "").strip().lower()
+    if bool(ep.get("smart")) or bool(ep.get("discovery")) or typ == "discovery":
+        return False
+    if "can_add" in ep or "can_remove" in ep:
+        return bool(ep.get("can_add") or ep.get("can_remove"))
+    ops = _providers().get(str(ep.get("provider") or "").upper())
+    if not ops:
+        return False
+    caps = playlist_capabilities(ops)
+    return bool(caps.get("add", True) or caps.get("remove", True))
+
+
 def validate_mapping(cfg: Mapping[str, Any], payload: Mapping[str, Any]) -> tuple[bool, str]:
     clean = _clean_mapping(payload)
     name_err = _name_error(clean["name"], "mapping name")
@@ -504,6 +720,8 @@ def validate_mapping(cfg: Mapping[str, Any], payload: Mapping[str, Any]) -> tupl
     for tid in clean["target_endpoints"]:
         if not runner.get_endpoint(cfg, tid):
             return False, "target endpoint not found"
+        if not _endpoint_writable(cfg, tid):
+            return False, "destination endpoint is read only"
     target_pairs: set[tuple[str, str]] = set()
     for tid in clean["target_endpoints"]:
         ep = runner.get_endpoint(cfg, tid) or {}
@@ -516,8 +734,14 @@ def validate_mapping(cfg: Mapping[str, Any], payload: Mapping[str, Any]) -> tupl
             return False, "ruleset not found"
         if len(clean["target_endpoints"]) > int(rs.get("maximum_targets") or 1):
             return False, "too many target endpoints for ruleset"
+        if _endpoint_is_discovery(cfg, clean["source_endpoint"]):
+            return False, "discovery sources use direct mirror mappings"
+        if str(rs.get("direction") or "") == "bidirectional" and not _endpoint_writable(cfg, clean["source_endpoint"]):
+            return False, "bidirectional mappings require a writable source endpoint"
     elif len(clean["target_endpoints"]) != 1:
         return False, "direct mappings require exactly one target endpoint"
+    if _endpoint_is_discovery(cfg, clean["source_endpoint"]) and clean["membership"] != "mirror":
+        return False, "discovery sources must use mirror sync mode"
     first_target = clean["target_endpoints"][0]
     if clean["order"] == "preserve" and not _endpoint_reorderable(cfg, first_target):
         return False, "target provider does not support ordering; use order 'ignore'"

--- a/tests/test_action_route_scope.py
+++ b/tests/test_action_route_scope.py
@@ -132,6 +132,8 @@ def test_activity_history_delete_not_in_non_admin_allowlist() -> None:
 
     assert non_admin_api_allowed("/api/activity/history", "GET") is True
     assert non_admin_api_allowed("/api/activity/history", "DELETE") is False
+    assert non_admin_api_allowed("/api/playlists/activity", "GET") is True
+    assert non_admin_api_allowed("/api/playlists/activity", "DELETE") is False
 
 
 def test_write_permission_no_longer_bypasses_feature_permissions() -> None:

--- a/tests/test_playlists_pending_create.py
+++ b/tests/test_playlists_pending_create.py
@@ -202,9 +202,18 @@ def test_an_empty_source_cannot_create_the_target(world) -> None:
     assert provs["PLEX"].created == []
 
 
-def test_service_parks_the_endpoint_when_the_provider_cannot_create_an_empty_list(world, monkeypatch) -> None:
+def test_service_attempts_create_even_when_the_provider_reports_no_empty_create(world, monkeypatch) -> None:
     cfg, _src, _dst, provs = world
     monkeypatch.setattr(svc, "_providers", lambda: provs)
+
+    def create_without_seed(cfg, name, *, media_type=None, items=None, instance=None, dry_run=False):
+        provs["PLEX"]._next_id += 1
+        pid = str(provs["PLEX"]._next_id)
+        provs["PLEX"].pl[pid] = {"name": name, "items": []}
+        provs["PLEX"].created.append({"id": pid, "name": name, "seed": []})
+        return provs["PLEX"]._resource(pid)
+
+    provs["PLEX"].create_playlist = create_without_seed
 
     res = svc.upsert_endpoint(
         cfg,
@@ -212,8 +221,8 @@ def test_service_parks_the_endpoint_when_the_provider_cannot_create_an_empty_lis
     )
 
     assert res["ok"] is True
-    assert provs["PLEX"].created == [], "creation must be deferred, not attempted with no items"
-    assert res["endpoint"]["pending_create"] == {"name": "Later", "media_type": "playlist"}
+    assert provs["PLEX"].created == [{"id": res["endpoint"]["playlist_id"], "name": "Later", "seed": []}]
+    assert "pending_create" not in res["endpoint"]
 
 
 def test_service_still_creates_immediately_when_the_provider_supports_it(world, monkeypatch) -> None:

--- a/tests/test_playlists_runner.py
+++ b/tests/test_playlists_runner.py
@@ -26,6 +26,7 @@ class FakeOps:
             can_add=not smart,
             can_remove=not smart,
             can_reorder=bool(d.get("can_reorder", True)) and not smart,
+            extra=dict(d.get("extra") or {}),
         )
 
     def list_playlist_resources(self, cfg, *, instance=None):
@@ -132,6 +133,24 @@ def test_mirror_removes_extras(config_base):
     assert res["added"] == 1 and res["removed"] == 1
     assert res["manual_affected"] is True
     assert {canonical_key(m) for m in dst["T1"]["items"]} == {"tmdb:1", "tmdb:2"}
+
+
+def test_discovery_source_can_mirror_to_writable_target(config_base):
+    src = {
+        "D1": {
+            "name": "Trending",
+            "items": [_movie(2), _movie(1)],
+            "smart": True,
+            "extra": {"endpoint_type": "discovery", "source_kind": "discovery", "discovery": True, "virtual": True},
+        }
+    }
+    dst = {"T1": {"name": "dst", "items": [_movie(1), _movie(3)]}}
+    provs = _providers(src, dst)
+
+    res = R.run_mapping(_cfg(), _mapping(src_pl="D1", membership="mirror", order="preserve"), providers=provs)
+
+    assert res["added"] == 1 and res["removed"] == 1
+    assert [canonical_key(m) for m in dst["T1"]["items"]] == ["tmdb:2", "tmdb:1"]
 
 
 def test_multiple_mappings_isolated(config_base):

--- a/tests/test_playlists_service.py
+++ b/tests/test_playlists_service.py
@@ -11,10 +11,12 @@ from services import playlists as svc
 
 
 class FakeOps:
-    def __init__(self, name: str, playlists: dict[str, dict[str, Any]], reorder: bool = True):
+    def __init__(self, name: str, playlists: dict[str, dict[str, Any]], reorder: bool = True, rename: bool = True, delete: bool = True):
         self._name = name
         self.pl = playlists
         self.reorder = reorder
+        self.rename = rename
+        self.delete = delete
         self.calls: list[Any] = []
 
     def name(self) -> str:
@@ -24,14 +26,23 @@ class FakeOps:
         return self._name.title()
 
     def capabilities(self) -> dict[str, Any]:
-        return {"playlists": {"reorder": self.reorder}}
+        return {"playlists": {"reorder": self.reorder, "rename": self.rename, "delete": self.delete}}
 
     def is_configured(self, cfg) -> bool:
         return True
 
     def _res(self, pid: str) -> PlaylistResource:
-        return PlaylistResource(provider=self._name, id=pid, name=self.pl[pid].get("name") or pid,
-                                can_add=True, can_remove=True, can_reorder=self.reorder)
+        data = self.pl[pid]
+        return PlaylistResource(
+            provider=self._name,
+            id=pid,
+            name=data.get("name") or pid,
+            kind=data.get("kind") or ("smart" if data.get("smart") else "regular"),
+            can_add=bool(data.get("can_add", True)),
+            can_remove=bool(data.get("can_remove", True)),
+            can_reorder=bool(data.get("can_reorder", self.reorder)),
+            extra=dict(data.get("extra") or {}),
+        )
 
     def list_playlist_resources(self, cfg, *, instance=None):
         return [self._res(p) for p in self.pl]
@@ -43,6 +54,16 @@ class FakeOps:
 
     def create_playlist(self, cfg, name, *, media_type=None, items=None, instance=None, dry_run=False):
         return PlaylistResource(provider=self._name, id="new", name=name)
+
+    def rename_playlist(self, cfg, playlist_id, name, *, instance=None, dry_run=False):
+        self.calls.append(("rename", playlist_id, name))
+        self.pl[playlist_id]["name"] = name
+        return self._res(playlist_id)
+
+    def delete_playlist(self, cfg, playlist_id, *, instance=None, dry_run=False):
+        self.calls.append(("delete", playlist_id))
+        self.pl.pop(playlist_id, None)
+        return {"ok": True, "count": 1}
 
     def add_playlist_items(self, cfg, playlist_id, items, *, instance=None, dry_run=False):
         self.calls.append(("add", playlist_id))
@@ -145,6 +166,58 @@ def test_created_playlist_name_is_limited_and_safe(config_base, fake_providers):
     assert ok["ok"] is True
 
 
+def test_provider_playlist_create_is_separate_from_endpoint_create(config_base, fake_providers):
+    res = svc.create_provider_playlist(_cfg(), "TRAKT", "default", "Weekend Movies", "playlist")
+    assert res["ok"] is True
+    assert res["resource"]["id"] == "new"
+    assert res["resource"]["name"] == "Weekend Movies"
+
+    bad = svc.create_provider_playlist(_cfg(), "TRAKT", "default", "Bad/List", "playlist")
+    assert bad["ok"] is False and "unsupported" in bad["error"]
+
+
+def test_provider_playlist_manage_flags_and_actions(config_base, fake_providers):
+    cfg = _cfg()
+    fake_providers["TRAKT"].pl["D1"] = {
+        "name": "Trending",
+        "items": [],
+        "kind": "smart",
+        "can_add": False,
+        "can_remove": False,
+        "extra": {"endpoint_type": "discovery", "source_kind": "discovery", "discovery": True, "virtual": True},
+    }
+    fake_providers["TRAKT"].pl["W1"] = {
+        "name": "Watchlist",
+        "items": [],
+        "extra": {"builtin": "watchlist"},
+    }
+    fake_providers["TRAKT"].pl["C1"] = {
+        "name": "Collection",
+        "items": [],
+        "extra": {"endpoint_type": "collection"},
+    }
+
+    resources = svc.list_resources(cfg, "TRAKT", "default")["resources"]
+    by_id = {r["id"]: r for r in resources}
+    assert by_id["L1"]["can_rename"] is True
+    assert by_id["L1"]["can_delete"] is True
+    assert by_id["D1"]["can_rename"] is False
+    assert by_id["W1"]["can_delete"] is False
+    assert by_id["C1"]["can_rename"] is True
+    assert by_id["C1"]["can_delete"] is False
+
+    renamed = svc.rename_provider_playlist(cfg, "TRAKT", "default", "L1", "Renamed")
+    assert renamed["ok"] is True
+    assert renamed["resource"]["name"] == "Renamed"
+
+    deleted = svc.delete_provider_playlist(cfg, "TRAKT", "default", "L2")
+    assert deleted["ok"] is True
+    assert "L2" not in fake_providers["TRAKT"].pl
+
+    blocked = svc.delete_provider_playlist(cfg, "TRAKT", "default", "D1")
+    assert blocked["ok"] is False and "cannot be deleted" in blocked["error"]
+
+
 def test_playlist_resource_errors_do_not_expose_exception_text(config_base, fake_providers):
     def fail(*_args, **_kwargs):
         raise RuntimeError("token=secret-from-provider /srv/crosswatch/internal.py")
@@ -196,6 +269,41 @@ def test_mapping_validation(config_base, fake_providers):
     assert not bad4 and "10 characters" in why4
     bad5, why5 = svc.validate_mapping(cfg, {"name": "Bad/Map", "source_endpoint": e1, "target_endpoints": [e2]})
     assert not bad5 and "unsupported" in why5
+
+
+def test_discovery_source_requires_direct_mirror_and_writable_target(config_base, fake_providers):
+    cfg = _cfg()
+    fake_providers["TRAKT"].pl["D1"] = {
+        "name": "Trending Movies",
+        "items": [_movie(1)],
+        "kind": "smart",
+        "can_add": False,
+        "can_remove": False,
+        "can_reorder": False,
+        "extra": {"endpoint_type": "discovery", "source_kind": "discovery", "discovery": True, "virtual": True},
+    }
+    fake_providers["PLEX"].pl["R1"] = {
+        "name": "ReadOnly",
+        "items": [],
+        "kind": "smart",
+        "can_add": False,
+        "can_remove": False,
+        "can_reorder": False,
+    }
+    src = svc.upsert_endpoint(cfg, {"name": "Trend", "provider": "TRAKT", "instance": "default", "playlist_id": "D1"})
+    dst = svc.upsert_endpoint(cfg, {"name": "PlexDst", "provider": "PLEX", "instance": "default", "playlist_id": "T1"})
+    ro = svc.upsert_endpoint(cfg, {"name": "ReadOnly", "provider": "PLEX", "instance": "default", "playlist_id": "R1"})
+
+    assert src["endpoint"]["playlist_type"] == "discovery"
+    assert src["endpoint"]["discovery"] is True
+    bad = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": src["endpoint"]["id"], "target_endpoints": [dst["endpoint"]["id"]]})
+    assert bad["ok"] is False and "mirror" in bad["error"]
+    bad_target = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": dst["endpoint"]["id"], "target_endpoints": [src["endpoint"]["id"]]})
+    assert bad_target["ok"] is False and "read only" in bad_target["error"]
+    bad_ro = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": src["endpoint"]["id"], "target_endpoints": [ro["endpoint"]["id"]], "membership": "mirror"})
+    assert bad_ro["ok"] is False and "read only" in bad_ro["error"]
+    ok = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": src["endpoint"]["id"], "target_endpoints": [dst["endpoint"]["id"]], "membership": "mirror"})
+    assert ok["ok"] is True
 
 
 def test_preserve_order_rejected_when_target_not_reorderable(config_base, monkeypatch):
@@ -289,6 +397,30 @@ def test_provider_count_summary_merges_endpoint_and_mapping_counts(config_base, 
     assert after["providers"]["trakt"] == 2
     assert after["providers"]["plex"] == 2
     assert after["providers_instances"]["plex"]["default"] == 2
+
+
+def test_clear_activity_resets_playlist_run_metadata(config_base, fake_providers):
+    cfg = _cfg()
+    e1, e2 = _seed_endpoints(cfg)
+    mid = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": [e2]})["mapping"]["id"]
+    cfg["playlists"]["endpoints"][0]["last_synced"] = 123
+    mapping = next(m for m in cfg["playlists"]["mappings"] if m["id"] == mid)
+    mapping["last_result"] = {"ok": True, "finished_at": 456, "added": 2, "removed": 1}
+    resolved = runner.resolve_mapping_by_id(cfg, mid)
+    assert resolved is not None
+    runner.save_baseline(resolved, {"tmdb:1"})
+    runner.store_result(resolved, {"ok": True, "finished_at": 456, "added": 2, "removed": 1})
+
+    assert len(svc.activity(cfg)) == 3
+
+    cleared = svc.clear_activity(cfg)
+
+    assert cleared == {"ok": True, "removed": 3}
+    assert "last_synced" not in cfg["playlists"]["endpoints"][0]
+    assert "last_result" not in mapping
+    assert runner.load_result(resolved) is None
+    assert runner.load_baseline(resolved) == {"tmdb:1"}
+    assert svc.activity(cfg) == []
 
 
 def test_mappings_for_pair_compat_and_one_pair(config_base, fake_providers):


### PR DESCRIPTION
# Pull request

## Change
Add the backend foundation for playlist endpoint management.

- provider playlist create, rename, delete API routes
- discovery/resource metadata on playlist resources
- discovery mapping validation
- playlist activity clearing
- admin-only guard for clearing playlist activity

## Why
Needed for #439 so playlist endpoints can be managed through the shared playlist service before wiring up each provider and the UI.

## Testing
- tests/test_playlists_service.py 
- tests/test_playlists_runner.py 
- tests/test_playlists_pending_create.py 
- tests/test_action_route_scope.py -q

## Issue
Relates to #439