### PR TITLE
Change: provider playlist adapters

### DIFF
--- a/providers/sync/_mod_CROSSWATCH.py
+++ b/providers/sync/_mod_CROSSWATCH.py
@@ -104,11 +104,17 @@ except Exception as e:
     cw_log("CROSSWATCH", "module", "warn", "feature_import_failed", import_feature="collection", error=str(e))
 
 try:
+    from .crosswatch import _playlists as feat_playlists
+except Exception as e:
+    feat_playlists = None
+    cw_log("CROSSWATCH", "module", "warn", "feature_import_failed", import_feature="playlists", error=str(e))
+
+try:
     from ._mod_common import make_snapshot_progress
 except Exception:
     make_snapshot_progress = None  # type: ignore[assignment]
 
-__VERSION__ = "1.1"
+__VERSION__ = "1.2"
 __all__ = ["get_manifest", "CROSSWATCHModule", "OPS"]
 
 _FEATURES: dict[str, Any] = {}
@@ -122,6 +128,8 @@ if feat_progress:
     _FEATURES["progress"] = feat_progress
 if feat_collection:
     _FEATURES["collection"] = feat_collection
+if feat_playlists:
+    _FEATURES["playlists"] = feat_playlists
 
 
 def _dbg(feature: str, msg: str, **fields: Any) -> None:
@@ -147,7 +155,7 @@ def _features_flags() -> dict[str, bool]:
         "ratings": "ratings" in _FEATURES,
         "progress": "progress" in _FEATURES,
         "collection": "collection" in _FEATURES,
-        "playlists": False,
+        "playlists": "playlists" in _FEATURES,
     }
 
 
@@ -194,6 +202,22 @@ def get_manifest() -> Mapping[str, Any]:
                 "upsert": True,
                 "remove": True,
             },
+            "playlists": {
+                "read": True,
+                "create": True,
+                "add": True,
+                "remove": True,
+                "reorder": True,
+                "rename": True,
+                "delete": True,
+                "smart": False,
+                "smart_writable": False,
+                "media_types": ["movie", "show", "season", "episode"],
+                "requires_ids": [],
+                "endpoint_types": ["playlist"],
+                "ordered_endpoint_types": ["playlist"],
+                "unordered_endpoint_types": [],
+            },
             "snapshots": {
                 "root_dir_default": "/config/.cw_provider",
                 "managed_by": "CrossWatch",
@@ -223,6 +247,7 @@ class CROSSWATCHConfig:
 class CROSSWATCHModule:
     def __init__(self, cfg: Mapping[str, Any]):
         self.raw_cfg = cfg
+        self.instance_id: str = "default"
         cw_cfg = dict((cfg.get("CrossWatch") or cfg.get("crosswatch") or {}) or {})
 
         def _bool(key: str, default: bool) -> bool:
@@ -295,7 +320,7 @@ class CROSSWATCHModule:
             "ratings": True,
             "progress": True,
             "collection": True,
-            "playlists": False,
+            "playlists": True,
         }
         present = _features_flags()
         return {k: bool(toggles.get(k, False) and present.get(k, False)) for k in toggles.keys()}
@@ -435,41 +460,7 @@ class _CrossWatchOPS:
         return CROSSWATCHModule.supported_features()
 
     def capabilities(self) -> Mapping[str, Any]:
-        return {
-            "bidirectional": True,
-            "provides_ids": True,
-            "index_semantics": "present",
-            "observed_deletes": True,
-            "ratings": {
-                "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
-                "upsert": True,
-                "unrate": True,
-                "from_date": False,
-            },
-            "history": {
-                "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
-                "upsert": True,
-                "remove": True,
-                "timestamp": True,
-                "event_history": True,
-                "rewatches": {"read": True, "write": True, "account_gate": False},
-            },
-            "progress": {
-                "upsert": True,
-                "remove": True,
-                "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
-                "position": "milliseconds",
-                "timestamp": True,
-            },
-            "collection": {
-                "index_semantics": "present",
-                "observed_deletes": True,
-                "types": {"movies": True, "shows": True, "seasons": True, "episodes": True},
-                "read": True,
-                "upsert": True,
-                "remove": True,
-            },
-        }
+        return get_manifest()["capabilities"]
 
     def is_configured(self, cfg: Mapping[str, Any]) -> bool:
         root = (cfg or {}).get("CrossWatch") or (cfg or {}).get("crosswatch") or {}
@@ -487,6 +478,16 @@ class _CrossWatchOPS:
 
     def _adapter(self, cfg: Mapping[str, Any]) -> CROSSWATCHModule:
         return CROSSWATCHModule(cfg)
+
+    def _playlist_adapter(self, cfg: Mapping[str, Any], instance: str | None) -> CROSSWATCHModule:
+        from cw_platform.provider_instances import normalize_instance_id
+
+        adapter = self._adapter(cfg)
+        try:
+            adapter.instance_id = normalize_instance_id(instance)
+        except Exception:
+            adapter.instance_id = "default"
+        return adapter
 
     def build_index(
         self,
@@ -518,5 +519,110 @@ class _CrossWatchOPS:
 
     def health(self, cfg: Mapping[str, Any]) -> Mapping[str, Any]:
         return self._adapter(cfg).health()
+
+    def list_playlist_resources(self, cfg: Mapping[str, Any], *, instance: str | None = None):
+        return list(feat_playlists.list_resources(self._playlist_adapter(cfg, instance))) if feat_playlists else []
+
+    def get_playlist_snapshot(self, cfg: Mapping[str, Any], playlist_id: str, *, instance: str | None = None):
+        if not feat_playlists:
+            raise RuntimeError("CrossWatch playlists are unavailable")
+        return feat_playlists.get_snapshot(self._playlist_adapter(cfg, instance), playlist_id)
+
+    def create_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        name: str,
+        *,
+        media_type: str | None = None,
+        items: Iterable[Mapping[str, Any]] | None = None,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ):
+        if not feat_playlists:
+            raise RuntimeError("CrossWatch playlists are unavailable")
+        return feat_playlists.create(
+            self._playlist_adapter(cfg, instance),
+            name,
+            media_type=media_type,
+            items=list(items or []),
+            dry_run=dry_run,
+        )
+
+    def add_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Iterable[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        lst = list(items or [])
+        if dry_run:
+            return {"ok": True, "count": len(lst), "dry_run": True, "unresolved": [], "confirmed_keys": []}
+        if not feat_playlists:
+            return {"ok": False, "error": "CrossWatch playlists are unavailable"}
+        return feat_playlists.add(self._playlist_adapter(cfg, instance), playlist_id, lst)
+
+    def remove_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        items: Iterable[Mapping[str, Any]],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        lst = list(items or [])
+        if dry_run:
+            return {"ok": True, "count": len(lst), "dry_run": True, "unresolved": [], "confirmed_keys": []}
+        if not feat_playlists:
+            return {"ok": False, "error": "CrossWatch playlists are unavailable"}
+        return feat_playlists.remove(self._playlist_adapter(cfg, instance), playlist_id, lst)
+
+    def reorder_playlist_items(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        ordered_keys: Iterable[str],
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        keys = list(ordered_keys or [])
+        if dry_run:
+            return {"ok": True, "count": len(keys), "dry_run": True}
+        if not feat_playlists:
+            return {"ok": False, "error": "CrossWatch playlists are unavailable"}
+        return feat_playlists.reorder(self._playlist_adapter(cfg, instance), playlist_id, keys)
+
+    def rename_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        name: str,
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ):
+        if not feat_playlists:
+            raise RuntimeError("CrossWatch playlists are unavailable")
+        if dry_run:
+            return feat_playlists.create(self._playlist_adapter(cfg, instance), name, dry_run=True)
+        return feat_playlists.rename(self._playlist_adapter(cfg, instance), playlist_id, name)
+
+    def delete_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        if dry_run:
+            return {"ok": True, "dry_run": True, "playlist_id": playlist_id}
+        if not feat_playlists:
+            return {"ok": False, "error": "CrossWatch playlists are unavailable"}
+        return feat_playlists.delete(self._playlist_adapter(cfg, instance), playlist_id)
 
 OPS = _CrossWatchOPS()

--- a/providers/sync/_mod_EMBY.py
+++ b/providers/sync/_mod_EMBY.py
@@ -117,7 +117,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "2.3"
+__VERSION__ = "2.4"
 os.environ.setdefault("CW_EMBY_VERSION", __VERSION__)
 os.environ.setdefault("CW_EMBY_UA", f"CrossWatch/{__VERSION__} (Emby)")
 __all__ = ["get_manifest", "EMBYModule", "OPS"]
@@ -197,6 +197,8 @@ _PLAYLIST_CAPABILITIES: dict[str, Any] = {
     "read": True,
     "create": True,
     "create_endpoint_types": ["playlist", "collection"],
+    "rename": True,
+    "delete": True,
     "add": True,
     "remove": True,
     "reorder": True,
@@ -835,6 +837,27 @@ class _EmbyOPS:
             items=list(items or []),
             dry_run=dry_run,
         )
+
+    def rename_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        name: str,
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ):
+        return self._pl().rename(self._playlist_adapter(cfg, instance), playlist_id, name, dry_run=dry_run)
+
+    def delete_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        return self._pl().delete(self._playlist_adapter(cfg, instance), playlist_id, dry_run=dry_run)
 
     def add_playlist_items(
         self,

--- a/providers/sync/_mod_JELLYFIN.py
+++ b/providers/sync/_mod_JELLYFIN.py
@@ -113,7 +113,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "2.4"
+__VERSION__ = "2.5"
 _MIN_PROGRESS_WRITE_VERSION = (10, 9)
 _JF_VERSION_CACHE: dict[str, tuple[float, str | None]] = {}
 
@@ -190,6 +190,8 @@ _PLAYLIST_CAPABILITIES: dict[str, Any] = {
     "read": True,
     "create": True,
     "create_endpoint_types": ["playlist", "collection"],
+    "rename": True,
+    "delete": True,
     "add": True,
     "remove": True,
     "reorder": False,
@@ -872,6 +874,27 @@ class _JellyfinOPS:
             items=list(items or []),
             dry_run=dry_run,
         )
+
+    def rename_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        name: str,
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ):
+        return self._pl().rename(self._playlist_adapter(cfg, instance), playlist_id, name, dry_run=dry_run)
+
+    def delete_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        return self._pl().delete(self._playlist_adapter(cfg, instance), playlist_id, dry_run=dry_run)
 
     def add_playlist_items(
         self,

--- a/providers/sync/_mod_MDBLIST.py
+++ b/providers/sync/_mod_MDBLIST.py
@@ -142,7 +142,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.7"
+__VERSION__ = "1.8"
 __all__ = ["get_manifest", "MDBLISTModule", "OPS"]
 
 def _health(status: str, ok: bool, latency_ms: int) -> None:
@@ -212,11 +212,14 @@ except Exception as e:
 _PLAYLIST_CAPABILITIES: dict[str, Any] = {
     "read": True,
     "create": True,
+    "rename": True,
+    "delete": True,
     "add": True,
     "remove": True,
     "reorder": False,
     "smart": True,
     "smart_writable": False,
+    "discovery": True,
     "media_types": ["movies", "shows"],
 }
 
@@ -1080,6 +1083,27 @@ class _MDBLISTOPS:
             items=list(items or []),
             dry_run=dry_run,
         )
+
+    def rename_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        name: str,
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ):
+        return self._pl().rename(self._playlist_adapter(cfg, instance), playlist_id, name, dry_run=dry_run)
+
+    def delete_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        return self._pl().delete(self._playlist_adapter(cfg, instance), playlist_id, dry_run=dry_run)
 
     def add_playlist_items(
         self,

--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -40,7 +40,7 @@ def _error(event: str, **fields: Any) -> None:
 def _log(msg: str) -> None:
     _dbg(msg)
 
-__VERSION__ = "2.4"
+__VERSION__ = "2.5"
 os.environ.setdefault("CW_PLEX_VERSION", __VERSION__)
 os.environ.setdefault("CW_PLEX_UA", f"CrossWatch/{__VERSION__} (Plex)")
 __all__ = ["get_manifest", "PLEXModule", "PLEXClient", "PLEXError", "PLEXAuthError", "PLEXNotFound", "OPS"]
@@ -125,8 +125,10 @@ except Exception as e:
 _PLAYLIST_CAPABILITIES: dict[str, Any] = {
     "read": True,
     "create": True,
-    "create_empty": False,
+    "create_empty": True,
     "create_endpoint_types": ["playlist"],
+    "rename": True,
+    "delete": True,
     "add": True,
     "remove": True,
     "reorder": True,
@@ -1682,6 +1684,27 @@ class _PlexOPS:
             items=list(items or []),
             dry_run=dry_run,
         )
+
+    def rename_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        name: str,
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ):
+        return self._pl().rename(self._playlist_adapter(cfg, instance), playlist_id, name, dry_run=dry_run)
+
+    def delete_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        return self._pl().delete(self._playlist_adapter(cfg, instance), playlist_id, dry_run=dry_run)
 
     def add_playlist_items(
         self,

--- a/providers/sync/_mod_PUBLICMETADB.py
+++ b/providers/sync/_mod_PUBLICMETADB.py
@@ -25,7 +25,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.1"
+__VERSION__ = "1.2"
 __all__ = ["get_manifest", "PUBLICMETADBModule", "OPS"]
 
 
@@ -67,6 +67,7 @@ _PLAYLIST_CAPABILITIES: dict[str, Any] = {
     "create": True,
     "add": True,
     "remove": True,
+    "delete": True,
     "reorder": False,
     "smart": False,
     "smart_writable": False,
@@ -508,6 +509,18 @@ class _PUBLICMETADBOPS:
         if dry_run:
             return {"ok": True, "count": len(lst), "dry_run": True, "unresolved": [], "confirmed_keys": []}
         return self._pl().remove(self._playlist_adapter(cfg, instance), playlist_id, lst)
+
+    def delete_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        if dry_run:
+            return {"ok": True, "dry_run": True, "playlist_id": playlist_id}
+        return self._pl().delete(self._playlist_adapter(cfg, instance), playlist_id)
 
     def reorder_playlist_items(
         self,

--- a/providers/sync/_mod_TRAKT.py
+++ b/providers/sync/_mod_TRAKT.py
@@ -103,7 +103,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.6"
+__VERSION__ = "1.7"
 __all__ = ["get_manifest", "TRAKTModule", "OPS"]
 
 os.environ.setdefault("CW_TRAKT_UA", f"CrossWatch TRAKT/{__VERSION__}")
@@ -122,10 +122,13 @@ _PROVIDER = "TRAKT"
 _PLAYLIST_CAPABILITIES: dict[str, Any] = {
     "read": True,
     "create": True,
+    "rename": True,
+    "delete": True,
     "add": True,
     "remove": True,
     "reorder": True,
     "smart": False,
+    "discovery": True,
     "media_types": ["movies", "shows", "seasons", "episodes"],
 }
 
@@ -915,6 +918,27 @@ class _TraktOPS:
         dry_run: bool = False,
     ):
         return self._pl().create(self._playlist_adapter(cfg, instance), name, media_type=media_type, dry_run=dry_run)
+
+    def rename_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        name: str,
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ):
+        return self._pl().rename(self._playlist_adapter(cfg, instance), playlist_id, name, dry_run=dry_run)
+
+    def delete_playlist(
+        self,
+        cfg: Mapping[str, Any],
+        playlist_id: str,
+        *,
+        instance: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        return self._pl().delete(self._playlist_adapter(cfg, instance), playlist_id, dry_run=dry_run)
 
     def add_playlist_items(
         self,

--- a/providers/sync/crosswatch/_playlists.py
+++ b/providers/sync/crosswatch/_playlists.py
@@ -1,0 +1,378 @@
+# /providers/sync/crosswatch/_playlists.py
+# CrossWatch playlists module
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from cw_platform.id_map import canonical_key, merge_ids, minimal as id_minimal
+from cw_platform.playlists import PLAYLIST_KIND_REGULAR, PlaylistItem, PlaylistResource, PlaylistSnapshot
+
+from ._common import _atomic_write, _capture_mode, _root, make_logger, readonly
+
+_dbg, _info, _warn, _error = make_logger("playlists")
+
+_PROVIDER = "CROSSWATCH"
+_MEDIA_TYPES = ("movie", "show", "season", "episode")
+_VERSION = 1
+
+
+class CrossWatchPlaylistError(RuntimeError):
+    pass
+
+
+class CrossWatchPlaylistNotFound(CrossWatchPlaylistError):
+    pass
+
+
+def _instance_id(adapter: Any) -> str:
+    return str(getattr(adapter, "instance_id", None) or "default").strip() or "default"
+
+
+def _path(adapter: Any) -> Path:
+    return _root(adapter) / "playlists.json"
+
+
+def _empty_state() -> dict[str, Any]:
+    return {"version": _VERSION, "ts": 0, "lists": {}}
+
+
+def _read_state(adapter: Any) -> dict[str, Any]:
+    try:
+        raw = json.loads(_path(adapter).read_text("utf-8"))
+    except Exception:
+        return _empty_state()
+    if not isinstance(raw, Mapping):
+        return _empty_state()
+    lists = raw.get("lists")
+    if not isinstance(lists, Mapping):
+        return _migrate_legacy(raw)
+    out = _empty_state()
+    out["version"] = int(raw.get("version") or _VERSION)
+    out["ts"] = int(raw.get("ts") or 0)
+    out["lists"] = {
+        str(k): _clean_list_row(str(k), v)
+        for k, v in lists.items()
+        if isinstance(v, Mapping) and str(k).strip()
+    }
+    return out
+
+
+def _migrate_legacy(raw: Mapping[str, Any]) -> dict[str, Any]:
+    out = _empty_state()
+    if isinstance(raw.get("items"), Mapping):
+        out["lists"]["watchlist"] = {
+            "id": "watchlist",
+            "name": "Watchlist",
+            "type": "playlist",
+            "items": {str(k): id_minimal(v) for k, v in raw.get("items", {}).items() if isinstance(v, Mapping)},
+            "order": [str(k) for k in raw.get("items", {}).keys()],
+            "created_at": int(raw.get("ts") or 0),
+            "updated_at": int(raw.get("ts") or 0),
+        }
+    return out
+
+
+def _write_state(adapter: Any, state: Mapping[str, Any]) -> None:
+    if _capture_mode() or readonly(adapter):
+        return
+    payload = {
+        "version": _VERSION,
+        "ts": int(time.time()),
+        "lists": dict(state.get("lists") or {}),
+    }
+    _atomic_write(_path(adapter), payload)
+
+
+def _clean_list_row(list_id: str, row: Mapping[str, Any]) -> dict[str, Any]:
+    lid = str(row.get("id") or list_id).strip() or list_id
+    name = str(row.get("name") or row.get("title") or lid).strip() or lid
+    items_raw = row.get("items")
+    order_raw = row.get("order")
+    items: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    if isinstance(items_raw, Mapping):
+        for raw_key, raw_value in items_raw.items():
+            if not isinstance(raw_value, Mapping):
+                continue
+            item = id_minimal(raw_value)
+            key = canonical_key(item) or str(raw_key)
+            if not key:
+                continue
+            items[key] = item
+    elif isinstance(items_raw, list):
+        for raw_value in items_raw:
+            if not isinstance(raw_value, Mapping):
+                continue
+            item = id_minimal(raw_value)
+            key = canonical_key(item)
+            if not key:
+                continue
+            items[key] = item
+            order.append(key)
+    if isinstance(order_raw, list):
+        order = [str(k).strip() for k in order_raw if str(k).strip()]
+    order = _normalized_order(order, items)
+    return {
+        "id": lid,
+        "name": name,
+        "type": "playlist",
+        "items": items,
+        "order": order,
+        "created_at": int(row.get("created_at") or 0),
+        "updated_at": int(row.get("updated_at") or 0),
+    }
+
+
+def _normalized_order(order: Sequence[str], items: Mapping[str, Any]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw_key in order or []:
+        key = str(raw_key or "").strip()
+        if key and key in items and key not in seen:
+            out.append(key)
+            seen.add(key)
+    for key in items.keys():
+        if key not in seen:
+            out.append(key)
+            seen.add(key)
+    return out
+
+
+def _items_map(row: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    raw = row.get("items")
+    if not isinstance(raw, Mapping):
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    for key, value in raw.items():
+        if isinstance(value, Mapping):
+            out[str(key)] = dict(value)
+    return out
+
+
+def _order_list(row: Mapping[str, Any]) -> list[str]:
+    raw = row.get("order")
+    return [str(k) for k in raw] if isinstance(raw, list) else []
+
+
+def _resource(adapter: Any, row: Mapping[str, Any]) -> PlaylistResource:
+    items = _items_map(row)
+    return PlaylistResource(
+        provider=_PROVIDER,
+        id=str(row.get("id") or ""),
+        name=str(row.get("name") or row.get("id") or ""),
+        instance=_instance_id(adapter),
+        kind=PLAYLIST_KIND_REGULAR,
+        can_read=True,
+        can_add=True,
+        can_remove=True,
+        can_reorder=True,
+        media_types=_MEDIA_TYPES,
+        extra={
+            "endpoint_type": "playlist",
+            "raw_id": str(row.get("id") or ""),
+            "item_count": len(items),
+            "can_rename": True,
+            "can_delete": True,
+            "local": True,
+        },
+    )
+
+
+def list_resources(adapter: Any) -> list[PlaylistResource]:
+    state = _read_state(adapter)
+    rows = [row for row in (state.get("lists") or {}).values() if isinstance(row, Mapping)]
+    out = [_resource(adapter, row) for row in sorted(rows, key=lambda r: str(r.get("name") or "").lower())]
+    _info("list_resources_done", count=len(out))
+    return out
+
+
+def _get_row(adapter: Any, playlist_id: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    lid = str(playlist_id or "").strip()
+    if not lid:
+        raise CrossWatchPlaylistNotFound("missing crosswatch playlist id")
+    state = _read_state(adapter)
+    row = (state.get("lists") or {}).get(lid)
+    if not isinstance(row, Mapping):
+        raise CrossWatchPlaylistNotFound("crosswatch playlist not found")
+    return state, dict(row)
+
+
+def get_snapshot(adapter: Any, playlist_id: Any) -> PlaylistSnapshot:
+    _state, row = _get_row(adapter, playlist_id)
+    items_raw = _items_map(row)
+    order = _normalized_order(_order_list(row), items_raw)
+    items: list[PlaylistItem] = []
+    for pos, key in enumerate(order):
+        raw = items_raw.get(key)
+        if not isinstance(raw, Mapping):
+            continue
+        item = PlaylistItem.from_media(raw, playlist_item_id=key, position=pos, provider_media_id=key)
+        items.append(item)
+    _info("snapshot_done", list_id=str(row.get("id") or ""), count=len(items))
+    return PlaylistSnapshot(resource=_resource(adapter, row), items=items, checkpoint=str(row.get("updated_at") or ""))
+
+
+def _new_id(existing: Mapping[str, Any]) -> str:
+    while True:
+        lid = f"cwpl_{uuid.uuid4().hex[:12]}"
+        if lid not in existing:
+            return lid
+
+
+def create(
+    adapter: Any,
+    name: str,
+    *,
+    media_type: str | None = None,
+    items: Sequence[Mapping[str, Any]] | None = None,
+    dry_run: bool = False,
+) -> PlaylistResource:
+    nm = str(name or "").strip()
+    if not nm:
+        raise ValueError("playlist name required")
+    if dry_run:
+        return PlaylistResource(provider=_PROVIDER, id="", name=nm, instance=_instance_id(adapter), can_add=True, can_remove=True, can_reorder=True, media_types=_MEDIA_TYPES)
+    state = _read_state(adapter)
+    lists = dict(state.get("lists") or {})
+    lid = _new_id(lists)
+    now = int(time.time())
+    row = {"id": lid, "name": nm, "type": "playlist", "items": {}, "order": [], "created_at": now, "updated_at": now}
+    lists[lid] = row
+    state["lists"] = lists
+    _write_state(adapter, state)
+    if items:
+        add(adapter, lid, items)
+        state, row = _get_row(adapter, lid)
+    _info("create_done", list_id=lid, name=nm)
+    return _resource(adapter, row)
+
+
+def _accepted(items: Sequence[Mapping[str, Any]]) -> tuple[list[tuple[str, dict[str, Any]]], list[dict[str, Any]]]:
+    accepted: list[tuple[str, dict[str, Any]]] = []
+    unresolved: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in items or []:
+        if not isinstance(raw, Mapping):
+            continue
+        try:
+            item = id_minimal(raw)
+        except Exception:
+            unresolved.append({"item": dict(raw), "hint": "invalid_item"})
+            continue
+        key = canonical_key(item)
+        if not key:
+            unresolved.append({"item": item, "hint": "missing_supported_id"})
+            continue
+        if key in seen:
+            continue
+        seen.add(key)
+        accepted.append((key, item))
+    return accepted, unresolved
+
+
+def add(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    state, row = _get_row(adapter, playlist_id)
+    accepted, unresolved = _accepted(list(items or []))
+    cur = _items_map(row)
+    order = _normalized_order(_order_list(row), cur)
+    changed = 0
+    confirmed: list[str] = []
+    for key, item in accepted:
+        existing = cur.get(key)
+        if isinstance(existing, Mapping):
+            old_ids = existing.get("ids") if isinstance(existing.get("ids"), Mapping) else {}
+            new_ids = item.get("ids") if isinstance(item.get("ids"), Mapping) else {}
+            merged = merge_ids(old_ids, new_ids)
+            if merged:
+                item["ids"] = merged
+        if existing != item:
+            cur[key] = item
+            changed += 1
+        if key not in order:
+            order.append(key)
+        confirmed.append(key)
+    if changed:
+        row["items"] = cur
+        row["order"] = _normalized_order(order, cur)
+        row["updated_at"] = int(time.time())
+        lists = dict(state.get("lists") or {})
+        lists[str(row.get("id"))] = row
+        state["lists"] = lists
+        _write_state(adapter, state)
+    _info("write_done", op="add", list_id=str(row.get("id") or ""), applied=changed, unresolved=len(unresolved))
+    return {"ok": True, "count": changed, "unresolved": unresolved, "confirmed_keys": confirmed}
+
+
+def remove(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    state, row = _get_row(adapter, playlist_id)
+    accepted, unresolved = _accepted(list(items or []))
+    cur = _items_map(row)
+    want = {key for key, _item in accepted}
+    confirmed = [key for key in want if key in cur]
+    changed = 0
+    for key in confirmed:
+        cur.pop(key, None)
+        changed += 1
+    if changed:
+        row["items"] = cur
+        row["order"] = _normalized_order(_order_list(row), cur)
+        row["updated_at"] = int(time.time())
+        lists = dict(state.get("lists") or {})
+        lists[str(row.get("id"))] = row
+        state["lists"] = lists
+        _write_state(adapter, state)
+    _info("write_done", op="remove", list_id=str(row.get("id") or ""), applied=changed, unresolved=len(unresolved))
+    return {"ok": True, "count": changed, "unresolved": unresolved, "confirmed_keys": confirmed}
+
+
+def reorder(adapter: Any, playlist_id: Any, ordered_keys: Sequence[str]) -> dict[str, Any]:
+    state, row = _get_row(adapter, playlist_id)
+    cur = _items_map(row)
+    before = _normalized_order(_order_list(row), cur)
+    after = _normalized_order([str(k) for k in ordered_keys or []], cur)
+    if after != before:
+        row["order"] = after
+        row["updated_at"] = int(time.time())
+        lists = dict(state.get("lists") or {})
+        lists[str(row.get("id"))] = row
+        state["lists"] = lists
+        _write_state(adapter, state)
+    _info("reorder_done", list_id=str(row.get("id") or ""), changed=after != before)
+    return {"ok": True, "count": len(after), "reordered": len(after) if after != before else 0}
+
+
+def rename(adapter: Any, playlist_id: Any, name: str) -> PlaylistResource:
+    nm = str(name or "").strip()
+    if not nm:
+        raise ValueError("playlist name required")
+    state, row = _get_row(adapter, playlist_id)
+    if row.get("name") != nm:
+        row["name"] = nm
+        row["updated_at"] = int(time.time())
+        lists = dict(state.get("lists") or {})
+        lists[str(row.get("id"))] = row
+        state["lists"] = lists
+        _write_state(adapter, state)
+    _info("rename_done", list_id=str(row.get("id") or ""), name=nm)
+    return _resource(adapter, row)
+
+
+def delete(adapter: Any, playlist_id: Any) -> dict[str, Any]:
+    lid = str(playlist_id or "").strip()
+    if not lid:
+        raise CrossWatchPlaylistNotFound("missing crosswatch playlist id")
+    state = _read_state(adapter)
+    lists = dict(state.get("lists") or {})
+    if lid not in lists:
+        raise CrossWatchPlaylistNotFound("crosswatch playlist not found")
+    lists.pop(lid, None)
+    state["lists"] = lists
+    _write_state(adapter, state)
+    _info("delete_done", list_id=lid)
+    return {"ok": True, "playlist_id": lid}

--- a/providers/sync/emby/_common.py
+++ b/providers/sync/emby/_common.py
@@ -1139,6 +1139,34 @@ def playlist_move_item(http: Any, playlist_id: str, item_id: str, new_index: int
     return getattr(r, "status_code", 0) in (200, 204)
 
 
+def update_item_name(http: Any, item_id: str, name: str) -> bool:
+    iid = str(item_id or "").strip()
+    nm = str(name or "").strip()
+    if not iid or not nm:
+        return False
+    r = http.get(f"/Items/{iid}")
+    body: dict[str, Any] = {}
+    if getattr(r, "status_code", 0) == 200:
+        try:
+            data = r.json() or {}
+        except Exception:
+            data = {}
+        if isinstance(data, Mapping):
+            body.update(data)
+    body["Id"] = iid
+    body["Name"] = nm
+    r2 = http.post(f"/Items/{iid}", json=body)
+    return getattr(r2, "status_code", 0) in (200, 204)
+
+
+def delete_item(http: Any, item_id: str) -> bool:
+    iid = str(item_id or "").strip()
+    if not iid:
+        return False
+    r = http.delete(f"/Items/{iid}")
+    return getattr(r, "status_code", 0) in (200, 204)
+
+
 # collections (BoxSets)
 def find_seed_item_id(http: Any, user_id: str) -> str | None:
     for t in ("Movie", "Series"):

--- a/providers/sync/emby/_playlists.py
+++ b/providers/sync/emby/_playlists.py
@@ -13,6 +13,7 @@ from ._common import (
     collection_remove_items,
     create_collection,
     create_playlist,
+    delete_item,
     key_of as emby_key_of,
     make_logger,
     normalize as emby_normalize,
@@ -21,6 +22,7 @@ from ._common import (
     playlist_remove_entries,
     resolve_item_id,
     sleep_ms,
+    update_item_name,
 )
 
 _PROVIDER = "EMBY"
@@ -35,6 +37,10 @@ class EmbyPlaylistError(RuntimeError):
 
 
 class EmbyPlaylistNotFound(EmbyPlaylistError):
+    pass
+
+
+class EmbyPlaylistUnsupported(EmbyPlaylistError):
     pass
 
 
@@ -247,6 +253,46 @@ def create(
         raise EmbyPlaylistError(f"emby create {endpoint_type} returned no id")
     _info("create_done", list_id=res.id, endpoint_type=endpoint_type, name=res.name)
     return res
+
+
+def rename(adapter: Any, playlist_id: Any, name: str, *, dry_run: bool = False) -> PlaylistResource:
+    nm = str(name or "").strip()
+    if not nm:
+        raise ValueError("playlist name required")
+    endpoint_type, raw_id, resource = _resolved_resource(adapter, playlist_id)
+    if dry_run:
+        return PlaylistResource(
+            provider=_PROVIDER,
+            id=resource.id,
+            name=nm,
+            instance=resource.instance,
+            kind=resource.kind,
+            can_read=resource.can_read,
+            can_add=resource.can_add,
+            can_remove=resource.can_remove,
+            can_reorder=resource.can_reorder,
+            media_types=resource.media_types,
+            extra=dict(resource.extra or {}),
+        )
+    if not update_item_name(adapter.client, raw_id, nm):
+        raise EmbyPlaylistError(f"emby rename {endpoint_type} failed")
+    res = _resource_from_row(adapter, {"Id": raw_id, "Name": nm, "Type": "BoxSet" if endpoint_type == "collection" else "Playlist"}, endpoint_type)
+    if res is None:
+        raise EmbyPlaylistError(f"emby rename {endpoint_type} returned no id")
+    _info("rename_done", list_id=res.id, endpoint_type=endpoint_type, name=res.name)
+    return res
+
+
+def delete(adapter: Any, playlist_id: Any, *, dry_run: bool = False) -> dict[str, Any]:
+    endpoint_type, raw_id, resource = _resolved_resource(adapter, playlist_id)
+    if endpoint_type != "playlist":
+        raise EmbyPlaylistUnsupported("emby collections must be deleted in emby")
+    if dry_run:
+        return {"ok": True, "dry_run": True}
+    if not delete_item(adapter.client, raw_id):
+        raise EmbyPlaylistError("emby delete playlist failed")
+    _info("delete_done", list_id=resource.id)
+    return {"ok": True, "count": 1}
 
 
 def _accepted_items(adapter: Any, endpoint_type: str, items: Sequence[Mapping[str, Any]]) -> tuple[list[tuple[str, str]], list[dict[str, Any]]]:

--- a/providers/sync/jellyfin/_common.py
+++ b/providers/sync/jellyfin/_common.py
@@ -906,6 +906,34 @@ def playlist_remove_entries(http: Any, playlist_id: str, entry_ids: Iterable[str
     return getattr(r, "status_code", 0) in (200, 204)
 
 
+def update_item_name(http: Any, item_id: str, name: str) -> bool:
+    iid = str(item_id or "").strip()
+    nm = str(name or "").strip()
+    if not iid or not nm:
+        return False
+    r = http.get(f"/Items/{iid}")
+    body: dict[str, Any] = {}
+    if getattr(r, "status_code", 0) == 200:
+        try:
+            data = r.json() or {}
+        except Exception:
+            data = {}
+        if isinstance(data, Mapping):
+            body.update(data)
+    body["Id"] = iid
+    body["Name"] = nm
+    r2 = http.post(f"/Items/{iid}", json=body)
+    return getattr(r2, "status_code", 0) in (200, 204)
+
+
+def delete_item(http: Any, item_id: str) -> bool:
+    iid = str(item_id or "").strip()
+    if not iid:
+        return False
+    r = http.delete(f"/Items/{iid}")
+    return getattr(r, "status_code", 0) in (200, 204)
+
+
 def find_collection_id_by_name(http: Any, user_id: str, name: str) -> str | None:
     try:
         r = http.get(

--- a/providers/sync/jellyfin/_playlists.py
+++ b/providers/sync/jellyfin/_playlists.py
@@ -1,3 +1,7 @@
+# /providers/sync/jellyfin/_playlists.py
+# Jellyfin Module for playlist sync functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+
 from __future__ import annotations
 
 from typing import Any, Iterable, Mapping, Sequence
@@ -12,6 +16,7 @@ from ._common import (
     collection_remove_items,
     create_collection,
     create_playlist,
+    delete_item,
     key_of as jelly_key_of,
     make_logger,
     normalize as jelly_normalize,
@@ -20,6 +25,7 @@ from ._common import (
     playlist_remove_entries,
     resolve_item_id,
     sleep_ms,
+    update_item_name,
 )
 
 _PROVIDER = "JELLYFIN"
@@ -33,6 +39,10 @@ class JellyfinPlaylistError(RuntimeError):
 
 
 class JellyfinPlaylistNotFound(JellyfinPlaylistError):
+    pass
+
+
+class JellyfinPlaylistUnsupported(JellyfinPlaylistError):
     pass
 
 
@@ -239,6 +249,46 @@ def create(
         raise JellyfinPlaylistError(f"jellyfin create {endpoint_type} returned no id")
     _info("create_done", list_id=res.id, endpoint_type=endpoint_type, name=res.name)
     return res
+
+
+def rename(adapter: Any, playlist_id: Any, name: str, *, dry_run: bool = False) -> PlaylistResource:
+    nm = str(name or "").strip()
+    if not nm:
+        raise ValueError("playlist name required")
+    endpoint_type, raw_id, resource = _resolved_resource(adapter, playlist_id)
+    if dry_run:
+        return PlaylistResource(
+            provider=_PROVIDER,
+            id=resource.id,
+            name=nm,
+            instance=resource.instance,
+            kind=resource.kind,
+            can_read=resource.can_read,
+            can_add=resource.can_add,
+            can_remove=resource.can_remove,
+            can_reorder=resource.can_reorder,
+            media_types=resource.media_types,
+            extra=dict(resource.extra or {}),
+        )
+    if not update_item_name(adapter.client, raw_id, nm):
+        raise JellyfinPlaylistError(f"jellyfin rename {endpoint_type} failed")
+    res = _resource_from_row(adapter, {"Id": raw_id, "Name": nm, "Type": "BoxSet" if endpoint_type == "collection" else "Playlist"}, endpoint_type)
+    if res is None:
+        raise JellyfinPlaylistError(f"jellyfin rename {endpoint_type} returned no id")
+    _info("rename_done", list_id=res.id, endpoint_type=endpoint_type, name=res.name)
+    return res
+
+
+def delete(adapter: Any, playlist_id: Any, *, dry_run: bool = False) -> dict[str, Any]:
+    endpoint_type, raw_id, resource = _resolved_resource(adapter, playlist_id)
+    if endpoint_type != "playlist":
+        raise JellyfinPlaylistUnsupported("jellyfin collections must be deleted in jellyfin")
+    if dry_run:
+        return {"ok": True, "dry_run": True}
+    if not delete_item(adapter.client, raw_id):
+        raise JellyfinPlaylistError("jellyfin delete playlist failed")
+    _info("delete_done", list_id=resource.id)
+    return {"ok": True, "count": 1}
 
 
 def _accepted_items(adapter: Any, items: Sequence[Mapping[str, Any]]) -> tuple[list[tuple[str, str]], list[dict[str, Any]]]:

--- a/providers/sync/mdblist/_playlists.py
+++ b/providers/sync/mdblist/_playlists.py
@@ -25,6 +25,7 @@ URL_LIST_ITEMS = f"{BASE}/lists/{{id}}/items"
 URL_LIST_ADD = f"{BASE}/lists/{{id}}/items/add"
 URL_LIST_REMOVE = f"{BASE}/lists/{{id}}/items/remove"
 URL_CREATE_LIST = f"{BASE}/lists/user/add"
+URL_DELETE_LIST = f"{BASE}/lists/{{id}}"
 URL_UPDATE_LIST = f"{BASE}/lists/{{id}}/update"
 URL_USER = f"{BASE}/user"
 
@@ -159,6 +160,10 @@ def _resource_from_list(adapter: Any, row: Mapping[str, Any]) -> PlaylistResourc
         can_reorder=False,
         media_types=media_types,
         extra={
+            "endpoint_type": "discovery" if dynamic else "playlist",
+            "source_kind": "discovery" if dynamic else "playlist",
+            "discovery": dynamic,
+            "virtual": dynamic,
             "dynamic": dynamic,
             "static": not dynamic,
             "mediatype": mediatype,
@@ -350,6 +355,55 @@ def update_metadata(adapter: Any, playlist_id: Any, *, name: str | None = None, 
         _warn("update_failed", status=r.status_code, list_id=resource.id)
         raise MDBListPlaylistError(f"mdblist update list failed: http {r.status_code}")
     return {"ok": True, "updated": True}
+
+
+def rename(adapter: Any, playlist_id: Any, name: str, *, dry_run: bool = False) -> PlaylistResource:
+    nm = str(name or "").strip()
+    if not nm:
+        raise ValueError("playlist name required")
+    resource = _find_owned_resource(adapter, playlist_id)
+    if resource is None:
+        raise MDBListNotOwnedError("mdblist list is not owned by the authenticated user")
+    if resource.is_smart:
+        raise MDBListDynamicListError("cannot rename a dynamic mdblist list")
+    if not dry_run:
+        update_metadata(adapter, resource.id, name=nm)
+    return PlaylistResource(
+        provider=_PROVIDER,
+        id=resource.id,
+        name=nm,
+        instance=resource.instance,
+        kind=resource.kind,
+        can_read=resource.can_read,
+        can_add=resource.can_add,
+        can_remove=resource.can_remove,
+        can_reorder=resource.can_reorder,
+        media_types=resource.media_types,
+        extra=dict(resource.extra or {}),
+    )
+
+
+def delete(adapter: Any, playlist_id: Any, *, dry_run: bool = False) -> dict[str, Any]:
+    resource = _find_owned_resource(adapter, playlist_id)
+    if resource is None:
+        raise MDBListNotOwnedError("mdblist list is not owned by the authenticated user")
+    if resource.is_smart:
+        raise MDBListDynamicListError("cannot delete a dynamic mdblist list")
+    if dry_run:
+        return {"ok": True, "dry_run": True}
+    r = mdblist_request(
+        adapter,
+        "DELETE",
+        URL_DELETE_LIST.format(id=resource.id),
+        params={"apikey": _apikey(adapter)},
+    )
+    if r.status_code in (401, 403):
+        raise MDBListPlaylistError("mdblist delete list unauthorized")
+    if not (200 <= r.status_code < 300):
+        _warn("delete_failed", status=r.status_code, list_id=resource.id)
+        raise MDBListPlaylistError(f"mdblist delete list failed: http {r.status_code}")
+    _info("delete_done", list_id=resource.id)
+    return {"ok": True, "count": 1}
 
 
 def _guard_writable(resource: PlaylistResource | None) -> PlaylistResource:

--- a/providers/sync/plex/_playlists.py
+++ b/providers/sync/plex/_playlists.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+from collections.abc import Iterable as IterableABC, Mapping as MappingABC
 from typing import Any, Iterable, Mapping, Sequence
 
 from cw_platform.id_map import canonical_key, minimal as id_minimal
@@ -249,6 +250,54 @@ def _iter_collections(srv: Any) -> list[tuple[Any, Any]]:
             if _collection_subtype(sec, coll) in _COLLECTION_TYPES:
                 out.append((sec, coll))
     return out
+
+
+def _first_from_call(obj: Any, name: str, **kwargs: Any) -> Any | None:
+    fn = getattr(obj, name, None)
+    if not callable(fn):
+        return None
+    def _first_value(value: Any) -> Any | None:
+        if value is None:
+            return None
+        if isinstance(value, IterableABC) and not isinstance(value, (str, bytes, MappingABC)):
+            values = list(value)
+            return values[0] if values else None
+        return value
+
+    try:
+        value = fn(**kwargs)
+    except TypeError:
+        try:
+            value = fn()
+        except Exception:
+            return None
+    except Exception:
+        return None
+    return _first_value(value)
+
+
+def _first_empty_playlist_seed(adapter: Any) -> Any | None:
+    try:
+        sections = list(adapter.libraries(types=("movie",)) or [])
+    except Exception:
+        sections = []
+    for section in sections:
+        item = _first_from_call(section, "search", maxresults=1)
+        if item is None:
+            item = _first_from_call(section, "all")
+        if item is not None:
+            return item
+
+    try:
+        sections = list(adapter.libraries(types=("show",)) or [])
+    except Exception:
+        sections = []
+    for section in sections:
+        item = _first_from_call(section, "searchEpisodes", maxresults=1)
+        if item is not None:
+            return item
+
+    return None
 
 
 def list_resources(adapter: Any) -> list[PlaylistResource]:
@@ -538,7 +587,29 @@ def create(
         )
     lst = list(items or [])
     if not lst:
-        raise PlaylistItemsRequired("plex cannot create an empty playlist")
+        srv = _server(adapter)
+        seed = _first_empty_playlist_seed(adapter)
+        if seed is None:
+            raise PlaylistItemsRequired("plex cannot create an empty playlist without at least one library item")
+        try:
+            pl = srv.createPlaylist(nm, items=[seed])
+            try:
+                pl.removeItems([seed])
+            except Exception:
+                try:
+                    pl = pl.reload()
+                    pl.removeItems([seed])
+                except Exception as e:
+                    _warn("create_seed_remove_failed", name=nm, error=str(e))
+                    raise PlaylistError(f"plex created playlist '{nm}' but could not remove the seed item: {e}") from e
+        except PlaylistError:
+            raise
+        except Exception as e:
+            _warn("create_empty_failed", name=nm, error=str(e))
+            raise PlaylistError(f"plex create empty playlist failed: {e}") from e
+        _info("create_empty_done", name=nm)
+        return _resource_from_playlist(adapter, pl)
+
     srv = _server(adapter)
     resolved, _confirmed, unresolved = _resolve_items(adapter, lst)
     if not resolved:
@@ -551,6 +622,74 @@ def create(
         raise PlaylistError(f"plex create playlist failed: {e}") from e
     _info("create_done", name=nm, seeded=len(resolved))
     return _resource_from_playlist(adapter, pl)
+
+
+def rename(adapter: Any, playlist_id: Any, name: str, *, dry_run: bool = False) -> PlaylistResource:
+    if _is_watchlist_id(playlist_id):
+        raise PlaylistUnsupported("plex watchlist cannot be renamed as a playlist")
+    if _is_collection_id(playlist_id):
+        raise PlaylistUnsupported("plex collections must be renamed in plex")
+    nm = str(name or "").strip()
+    if not nm:
+        raise ValueError("playlist name required")
+    srv = _server(adapter)
+    pl = _find_playlist(srv, playlist_id)
+    _guard_writable(pl)
+    if dry_run:
+        return PlaylistResource(
+            provider=_PROVIDER,
+            id=str(getattr(pl, "ratingKey", None) or playlist_id),
+            name=nm,
+            instance=_instance_id(adapter),
+            can_add=True,
+            can_remove=True,
+            can_reorder=True,
+            media_types=("movie", "episode"),
+        )
+    try:
+        edit_title = getattr(pl, "editTitle", None)
+        if callable(edit_title):
+            edit_title(nm)
+        else:
+            edit = getattr(pl, "edit", None)
+            if not callable(edit):
+                raise PlaylistUnsupported("plex playlist rename is not supported by this plexapi version")
+            edit(title=nm)
+        try:
+            pl = pl.reload()
+        except Exception:
+            setattr(pl, "title", nm)
+    except PlaylistError:
+        raise
+    except Exception as e:
+        _warn("rename_failed", list_id=str(playlist_id), error=str(e))
+        raise PlaylistError(f"plex rename playlist failed: {e}") from e
+    _info("rename_done", list_id=str(playlist_id), name=nm)
+    return _resource_from_playlist(adapter, pl)
+
+
+def delete(adapter: Any, playlist_id: Any, *, dry_run: bool = False) -> dict[str, Any]:
+    if _is_watchlist_id(playlist_id):
+        raise PlaylistUnsupported("plex watchlist cannot be deleted as a playlist")
+    if _is_collection_id(playlist_id):
+        raise PlaylistUnsupported("plex collections must be deleted in plex")
+    srv = _server(adapter)
+    pl = _find_playlist(srv, playlist_id)
+    _guard_writable(pl)
+    if dry_run:
+        return {"ok": True, "dry_run": True}
+    try:
+        delete_playlist = getattr(pl, "delete", None)
+        if not callable(delete_playlist):
+            raise PlaylistUnsupported("plex playlist delete is not supported by this plexapi version")
+        delete_playlist()
+    except PlaylistError:
+        raise
+    except Exception as e:
+        _warn("delete_failed", list_id=str(playlist_id), error=str(e))
+        raise PlaylistError(f"plex delete playlist failed: {e}") from e
+    _info("delete_done", list_id=str(playlist_id))
+    return {"ok": True, "count": 1}
 
 
 def _confirmed_keys(items: Sequence[Mapping[str, Any]], unresolved: Sequence[Mapping[str, Any]]) -> list[str]:

--- a/providers/sync/publicmetadb/_playlists.py
+++ b/providers/sync/publicmetadb/_playlists.py
@@ -1,3 +1,6 @@
+# /providers/sync/publicmetadb/_playlists.py
+# PublicMetaDB Module for playlist sync functions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
 from typing import Any, Mapping, Sequence
@@ -87,6 +90,8 @@ def _resource_from_row(adapter: Any, row: Mapping[str, Any]) -> PlaylistResource
     public_raw = row.get("is_public")
     if public_raw is None:
         public_raw = row.get("public")
+    list_type = str(row.get("type") or "").strip().lower()
+    is_watchlist = list_type == "watchlist"
     return PlaylistResource(
         provider=_PROVIDER,
         id=raw_id,
@@ -103,8 +108,11 @@ def _resource_from_row(adapter: Any, row: Mapping[str, Any]) -> PlaylistResource
             "raw_id": raw_id,
             "item_count": count,
             "private": not bool(public_raw),
-            "type": str(row.get("type") or "").strip().lower(),
+            "type": list_type,
             "description": str(row.get("description") or "").strip(),
+            "builtin": is_watchlist,
+            "can_rename": False,
+            "can_delete": not is_watchlist,
         },
     )
 
@@ -337,6 +345,22 @@ def remove(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -
             unresolved.append({"item": media, "hint": f"http:{r.status_code}"})
     _info("write_done", op="remove", list_id=lid, applied=ok, unresolved=len(unresolved))
     return {"ok": True, "count": ok, "unresolved": unresolved, "confirmed_keys": confirmed}
+
+
+def delete(adapter: Any, playlist_id: Any) -> dict[str, Any]:
+    lid = str(playlist_id or "").strip()
+    if not lid:
+        raise PublicMetaDBPlaylistNotFound("missing publicmetadb list id")
+    resource = _find_resource(adapter, lid)
+    if resource is None:
+        raise PublicMetaDBPlaylistNotFound("publicmetadb list not found")
+    if (resource.extra or {}).get("type") == "watchlist":
+        raise PublicMetaDBPlaylistError("publicmetadb watchlist cannot be deleted")
+    r = adapter.client.delete(f"/api/external/lists/{lid}")
+    if not (200 <= r.status_code < 300):
+        raise PublicMetaDBPlaylistError(f"publicmetadb delete failed: HTTP {r.status_code}")
+    _info("delete_done", list_id=lid)
+    return {"ok": True, "playlist_id": lid}
 
 
 def reorder(adapter: Any, playlist_id: Any, ordered_keys: Sequence[str]) -> dict[str, Any]:

--- a/providers/sync/trakt/_playlists.py
+++ b/providers/sync/trakt/_playlists.py
@@ -8,6 +8,7 @@ from typing import Any, Iterable, Mapping, Sequence
 
 from cw_platform.playlists import (
     PLAYLIST_KIND_REGULAR,
+    PLAYLIST_KIND_SMART,
     PlaylistItem,
     PlaylistResource,
     PlaylistSnapshot,
@@ -31,6 +32,19 @@ _PROVIDER = "TRAKT"
 _FEATURE = "playlists"
 _SUPPORTED_TYPES = ("movie", "show", "season", "episode")
 WATCHLIST_ID = "__watchlist__"
+DISCOVERY_PREFIX = "discovery:trakt:"
+_DISCOVERY_LIMIT = 100
+
+_DISCOVERY_FEEDS: tuple[dict[str, Any], ...] = (
+    {"id": "discovery:trakt:movies:trending", "name": "Trending Movies", "media_type": "movie", "path": "/movies/trending", "feed": "trending"},
+    {"id": "discovery:trakt:movies:popular", "name": "Popular Movies", "media_type": "movie", "path": "/movies/popular", "feed": "popular"},
+    {"id": "discovery:trakt:movies:anticipated", "name": "Anticipated Movies", "media_type": "movie", "path": "/movies/anticipated", "feed": "anticipated"},
+    {"id": "discovery:trakt:movies:recommendations", "name": "Recommended Movies", "media_type": "movie", "path": "/recommendations/movies", "feed": "recommendations"},
+    {"id": "discovery:trakt:shows:trending", "name": "Trending Shows", "media_type": "show", "path": "/shows/trending", "feed": "trending"},
+    {"id": "discovery:trakt:shows:popular", "name": "Popular Shows", "media_type": "show", "path": "/shows/popular", "feed": "popular"},
+    {"id": "discovery:trakt:shows:anticipated", "name": "Anticipated Shows", "media_type": "show", "path": "/shows/anticipated", "feed": "anticipated"},
+    {"id": "discovery:trakt:shows:recommendations", "name": "Recommended Shows", "media_type": "show", "path": "/recommendations/shows", "feed": "recommendations"},
+)
 
 _SETTINGS_MEMO: tuple[float, dict[str, Any] | None] = (0.0, None)
 
@@ -70,6 +84,16 @@ def _is_watchlist_id(resource_or_id: Any) -> bool:
     return lid in {WATCHLIST_ID, "watchlist", "trakt:watchlist"}
 
 
+def _discovery_feed(resource_or_id: Any) -> dict[str, Any] | None:
+    lid = _list_id(resource_or_id).strip().lower()
+    if not lid.startswith(DISCOVERY_PREFIX):
+        return None
+    for feed in _DISCOVERY_FEEDS:
+        if str(feed["id"]).lower() == lid:
+            return feed
+    return None
+
+
 def _watchlist_resource(adapter: Any) -> PlaylistResource:
     return PlaylistResource(
         provider=_PROVIDER,
@@ -84,6 +108,34 @@ def _watchlist_resource(adapter: Any) -> PlaylistResource:
         media_types=("movies", "shows", "seasons", "episodes"),
         extra={"builtin": "watchlist"},
     )
+
+
+def _discovery_resource(adapter: Any, feed: Mapping[str, Any]) -> PlaylistResource:
+    media_type = str(feed.get("media_type") or "").strip().lower()
+    return PlaylistResource(
+        provider=_PROVIDER,
+        id=str(feed.get("id") or ""),
+        name=str(feed.get("name") or feed.get("id") or "").strip(),
+        instance=_instance_id(adapter),
+        kind=PLAYLIST_KIND_SMART,
+        can_read=True,
+        can_add=False,
+        can_remove=False,
+        can_reorder=False,
+        media_types=(media_type,) if media_type else (),
+        extra={
+            "endpoint_type": "discovery",
+            "source_kind": "discovery",
+            "discovery": True,
+            "virtual": True,
+            "provider_feed": str(feed.get("feed") or ""),
+            "default_limit": _DISCOVERY_LIMIT,
+        },
+    )
+
+
+def _discovery_resources(adapter: Any) -> list[PlaylistResource]:
+    return [_discovery_resource(adapter, feed) for feed in _DISCOVERY_FEEDS]
 
 
 def _settings_limits(adapter: Any) -> dict[str, Any]:
@@ -154,7 +206,7 @@ def _resource_from_list(adapter: Any, row: Mapping[str, Any]) -> PlaylistResourc
 def list_resources(adapter: Any) -> list[PlaylistResource]:
     sess = adapter.client.session
     headers = headers_for_adapter(adapter)
-    out: list[PlaylistResource] = [_watchlist_resource(adapter)]
+    out: list[PlaylistResource] = [_watchlist_resource(adapter), *_discovery_resources(adapter)]
     r = request_with_retries(
         sess,
         "GET",
@@ -177,6 +229,75 @@ def list_resources(adapter: Any) -> list[PlaylistResource]:
     return out
 
 
+def _discovery_row(row: Mapping[str, Any], media_type: str) -> dict[str, Any] | None:
+    kind = "show" if media_type == "show" else "movie"
+    if kind in row:
+        wrapped = dict(row)
+        wrapped.setdefault("type", kind)
+    else:
+        wrapped = {"type": kind, kind: row}
+    media = normalize_watchlist_row(wrapped)
+    ids = media.get("ids") if isinstance(media, Mapping) else None
+    if not isinstance(ids, Mapping) or not any(str(v or "").strip() for v in ids.values()):
+        return None
+    return media
+
+
+def _discovery_snapshot(adapter: Any, feed: Mapping[str, Any]) -> PlaylistSnapshot:
+    sess = adapter.client.session
+    headers = headers_for_adapter(adapter)
+    resource = _discovery_resource(adapter, feed)
+    media_type = str(feed.get("media_type") or "").strip().lower()
+    path = str(feed.get("path") or "").strip()
+    items: list[PlaylistItem] = []
+    page = 1
+    per_page = _DISCOVERY_LIMIT
+    while len(items) < _DISCOVERY_LIMIT and page <= 10:
+        r = request_with_retries(
+            sess,
+            "GET",
+            f"{BASE}{path}",
+            headers=headers,
+            params={"page": page, "limit": min(per_page, _DISCOVERY_LIMIT - len(items)), "extended": "full"},
+            timeout=adapter.cfg.timeout,
+            max_retries=adapter.cfg.max_retries,
+        )
+        if r.status_code != 200:
+            _warn("http_failed", op="discovery_snapshot", status=r.status_code, feed=feed.get("id"))
+            break
+        rows = r.json() if (r.text or "").strip() else []
+        if not isinstance(rows, list) or not rows:
+            break
+        for row in rows:
+            if not isinstance(row, Mapping):
+                continue
+            media = _discovery_row(row, media_type)
+            if not media:
+                continue
+            pos = row.get("rank") or len(items)
+            items.append(
+                PlaylistItem.from_media(
+                    media,
+                    playlist_item_id=None,
+                    position=pos,
+                    provider_media_id=(dict(media.get("ids") or {}).get("trakt")),
+                )
+            )
+            if len(items) >= _DISCOVERY_LIMIT:
+                break
+        try:
+            page_count = int(r.headers.get("X-Pagination-Page-Count") or 0)
+        except Exception:
+            page_count = 0
+        if page_count and page >= page_count:
+            break
+        if len(rows) < per_page:
+            break
+        page += 1
+    _info("snapshot_done", list_id=resource.id, count=len(items))
+    return PlaylistSnapshot(resource=resource, items=items, checkpoint=None)
+
+
 def get_snapshot(adapter: Any, playlist_id: Any) -> PlaylistSnapshot:
     if _is_watchlist_id(playlist_id):
         resource = _watchlist_resource(adapter)
@@ -184,6 +305,10 @@ def get_snapshot(adapter: Any, playlist_id: Any) -> PlaylistSnapshot:
         items = [PlaylistItem.from_media(m, position=i) for i, m in enumerate(idx.values()) if isinstance(m, Mapping)]
         _info("snapshot_done", list_id=WATCHLIST_ID, count=len(items))
         return PlaylistSnapshot(resource=resource, items=items, checkpoint=None)
+
+    discovery = _discovery_feed(playlist_id)
+    if discovery is not None:
+        return _discovery_snapshot(adapter, discovery)
 
     lid = _list_id(playlist_id)
     sess = adapter.client.session
@@ -308,6 +433,78 @@ def create(adapter: Any, name: str, *, media_type: str | None = None, dry_run: b
     return res
 
 
+def rename(adapter: Any, playlist_id: Any, name: str, *, dry_run: bool = False) -> PlaylistResource:
+    if _discovery_feed(playlist_id) is not None or _is_watchlist_id(playlist_id):
+        raise RuntimeError("trakt built-in and discovery feeds cannot be renamed")
+    nm = str(name or "").strip()
+    if not nm:
+        raise ValueError("playlist name required")
+    lid = _list_id(playlist_id)
+    if dry_run:
+        return PlaylistResource(
+            provider=_PROVIDER,
+            id=lid,
+            name=nm,
+            instance=_instance_id(adapter),
+            can_add=True,
+            can_remove=True,
+            can_reorder=True,
+            media_types=("movies", "shows", "seasons", "episodes"),
+        )
+    sess = adapter.client.session
+    headers = headers_for_adapter(adapter)
+    r = request_with_retries(
+        sess,
+        "PUT",
+        f"{BASE}/users/me/lists/{lid}",
+        headers=headers,
+        json={"name": nm},
+        timeout=adapter.cfg.timeout,
+        max_retries=adapter.cfg.max_retries,
+    )
+    if r.status_code not in (200, 201):
+        _warn("write_failed", op="rename", status=r.status_code, body=((r.text or "")[:180]))
+        raise RuntimeError(f"trakt rename list failed: http {r.status_code}")
+    data = r.json() if (r.text or "").strip() else {}
+    res = _resource_from_list(adapter, data if isinstance(data, Mapping) else {})
+    if res is None:
+        res = PlaylistResource(
+            provider=_PROVIDER,
+            id=lid,
+            name=nm,
+            instance=_instance_id(adapter),
+            can_add=True,
+            can_remove=True,
+            can_reorder=True,
+            media_types=("movies", "shows", "seasons", "episodes"),
+        )
+    _info("rename_done", list_id=res.id, name=res.name)
+    return res
+
+
+def delete(adapter: Any, playlist_id: Any, *, dry_run: bool = False) -> dict[str, Any]:
+    if _discovery_feed(playlist_id) is not None or _is_watchlist_id(playlist_id):
+        raise RuntimeError("trakt built-in and discovery feeds cannot be deleted")
+    lid = _list_id(playlist_id)
+    if dry_run:
+        return {"ok": True, "dry_run": True}
+    sess = adapter.client.session
+    headers = headers_for_adapter(adapter)
+    r = request_with_retries(
+        sess,
+        "DELETE",
+        f"{BASE}/users/me/lists/{lid}",
+        headers=headers,
+        timeout=adapter.cfg.timeout,
+        max_retries=adapter.cfg.max_retries,
+    )
+    if r.status_code not in (200, 204):
+        _warn("write_failed", op="delete", status=r.status_code, body=((r.text or "")[:180]))
+        raise RuntimeError(f"trakt delete list failed: http {r.status_code}")
+    _info("delete_done", list_id=lid)
+    return {"ok": True, "count": 1}
+
+
 def _confirmed_keys(items: Iterable[Mapping[str, Any]], unresolved: list[dict[str, Any]]) -> list[str]:
     ukeys: set[str] = set()
     for u in unresolved or []:
@@ -332,6 +529,8 @@ def _confirmed_keys(items: Iterable[Mapping[str, Any]], unresolved: list[dict[st
 
 
 def _write(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]], *, op: str) -> dict[str, Any]:
+    if _discovery_feed(playlist_id) is not None:
+        raise RuntimeError("trakt discovery feeds are read only")
     if _is_watchlist_id(playlist_id):
         lst = list(items or [])
         count, unresolved = (feat_watchlist.add(adapter, lst) if op == "add" else feat_watchlist.remove(adapter, lst))
@@ -427,6 +626,8 @@ def remove(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -
 
 
 def reorder(adapter: Any, playlist_id: Any, ordered_keys: Sequence[str]) -> dict[str, Any]:
+    if _discovery_feed(playlist_id) is not None:
+        return {"ok": False, "count": 0, "reordered": 0, "unsupported": True, "error": "read_only"}
     if _is_watchlist_id(playlist_id):
         return {"ok": True, "count": 0, "reordered": 0, "unsupported": True}
 

--- a/providers/tests/test_crosswatch_playlists.py
+++ b/providers/tests/test_crosswatch_playlists.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from cw_platform.playlists import supports_playlists
+from providers.sync import _mod_CROSSWATCH as mod
+from providers.sync._mod_CROSSWATCH import CROSSWATCHModule
+
+
+def _cfg(root: Any) -> dict[str, Any]:
+    return {
+        "CrossWatch": {
+            "connected": True,
+            "enabled": True,
+            "root_dir": str(root),
+            "auto_snapshot": True,
+            "max_snapshots": 64,
+        }
+    }
+
+
+def _movie(tmdb: int, title: str = "Movie") -> dict[str, Any]:
+    return {"type": "movie", "title": title, "ids": {"tmdb": str(tmdb)}}
+
+
+def _episode() -> dict[str, Any]:
+    return {
+        "type": "episode",
+        "series_title": "Severance",
+        "show_ids": {"tmdb": "95396"},
+        "season": 1,
+        "episode": 2,
+        "ids": {},
+    }
+
+
+def test_crosswatch_playlist_local_crud_and_order(tmp_path: Any) -> None:
+    adapter = CROSSWATCHModule(_cfg(tmp_path))
+    res = mod.feat_playlists.create(adapter, "Local", items=[_movie(1, "One"), _episode()])
+
+    assert res.provider == "CROSSWATCH"
+    assert res.can_add is True
+    assert res.can_remove is True
+    assert res.can_reorder is True
+
+    snap = mod.feat_playlists.get_snapshot(adapter, res.id)
+    assert snap.ordered_keys() == ["tmdb:1", "tmdb:95396#s01e02"]
+
+    add = mod.feat_playlists.add(adapter, res.id, [_movie(2, "Two"), _movie(1, "One")])
+    assert add["count"] == 1
+    assert add["confirmed_keys"] == ["tmdb:2", "tmdb:1"]
+
+    reorder = mod.feat_playlists.reorder(adapter, res.id, ["tmdb:2", "tmdb:1", "tmdb:95396#s01e02"])
+    assert reorder["reordered"] == 3
+    assert mod.feat_playlists.get_snapshot(adapter, res.id).ordered_keys() == ["tmdb:2", "tmdb:1", "tmdb:95396#s01e02"]
+
+    renamed = mod.feat_playlists.rename(adapter, res.id, "Renamed")
+    assert renamed.name == "Renamed"
+
+    remove = mod.feat_playlists.remove(adapter, res.id, [_movie(1, "One")])
+    assert remove["count"] == 1
+    assert mod.feat_playlists.get_snapshot(adapter, res.id).ordered_keys() == ["tmdb:2", "tmdb:95396#s01e02"]
+
+    deleted = mod.feat_playlists.delete(adapter, res.id)
+    assert deleted["ok"] is True
+    payload = json.loads((tmp_path / "playlists.json").read_text("utf-8"))
+    assert payload["lists"] == {}
+
+
+def test_crosswatch_ops_exposes_playlist_contract(tmp_path: Any) -> None:
+    assert mod.get_manifest()["features"]["playlists"] is True
+    assert mod.CROSSWATCHModule.supported_features()["playlists"] is True
+    assert supports_playlists(mod.OPS)
+
+    cfg = _cfg(tmp_path)
+    created = mod.OPS.create_playlist(cfg, "Sink")
+    resources = mod.OPS.list_playlist_resources(cfg)
+    assert [r.id for r in resources] == [created.id]
+    assert resources[0].name == "Sink"
+    assert mod.OPS.add_playlist_items(cfg, created.id, [_movie(99)])["count"] == 1
+    assert mod.OPS.get_playlist_snapshot(cfg, created.id).ordered_keys() == ["tmdb:99"]

--- a/providers/tests/test_emby_playlists.py
+++ b/providers/tests/test_emby_playlists.py
@@ -33,6 +33,10 @@ class FakeHttp:
             return FakeResp(200, {"Items": [{"Id": "P1", "Name": "Weekend", "Type": "Playlist", "ChildCount": 2}], "TotalRecordCount": 1})
         if path == "/Users/U1/Items" and params.get("IncludeItemTypes") == "BoxSet":
             return FakeResp(200, {"Items": [{"Id": "C1", "Name": "Favorites", "Type": "BoxSet", "ChildCount": 1}], "TotalRecordCount": 1})
+        if path == "/Items/P1":
+            return FakeResp(200, {"Id": "P1", "Name": "Weekend", "Type": "Playlist"})
+        if path == "/Items/C1":
+            return FakeResp(200, {"Id": "C1", "Name": "Favorites", "Type": "BoxSet"})
         if path == "/Playlists/P1/Items":
             return FakeResp(200, {"Items": [
                 row("I1", "Movie", "Dune", tmdb="438631", playlist_item_id="E1"),
@@ -43,6 +47,8 @@ class FakeHttp:
     def post(self, path: str, *, params: dict[str, Any] | None = None, json: Any = None) -> FakeResp:
         self.calls.append({"method": "POST", "path": path, "params": dict(params or {}), "json": json})
         if path in ("/Playlists/P1/Items", "/Collections/C1/Items"):
+            return FakeResp(204, {})
+        if path in ("/Items/P1", "/Items/C1"):
             return FakeResp(204, {})
         if path.startswith("/Playlists/P1/Items/") and "/Move/" in path:
             return FakeResp(204, {})
@@ -55,6 +61,8 @@ class FakeHttp:
     def delete(self, path: str, *, params: dict[str, Any] | None = None) -> FakeResp:
         self.calls.append({"method": "DELETE", "path": path, "params": dict(params or {})})
         if path in ("/Playlists/P1/Items", "/Collections/C1/Items"):
+            return FakeResp(204, {})
+        if path == "/Items/P1":
             return FakeResp(204, {})
         return FakeResp(404, {})
 
@@ -186,3 +194,29 @@ def test_create_can_make_playlist_or_collection():
     assert collection.id == "collection:C2"
     assert any(c["path"] == "/Playlists" and c["params"]["Name"] == "NewList" for c in ad.client.calls)
     assert any(c["path"] == "/Collections" and c["params"]["Name"] == "NewBox" for c in ad.client.calls)
+
+
+def test_rename_and_delete_playlist_resources():
+    ad = FakeAdapter()
+    renamed_playlist = pl.rename(ad, "playlist:P1", "Renamed")
+    renamed_collection = pl.rename(ad, "collection:C1", "BoxRenamed")
+    deleted = pl.delete(ad, "playlist:P1")
+
+    assert renamed_playlist.id == "playlist:P1"
+    assert renamed_playlist.name == "Renamed"
+    assert renamed_collection.id == "collection:C1"
+    assert renamed_collection.name == "BoxRenamed"
+    assert deleted["ok"] is True
+    assert any(c["method"] == "POST" and c["path"] == "/Items/P1" and c["json"]["Name"] == "Renamed" for c in ad.client.calls)
+    assert any(c["method"] == "POST" and c["path"] == "/Items/C1" and c["json"]["Name"] == "BoxRenamed" for c in ad.client.calls)
+    assert any(c["method"] == "DELETE" and c["path"] == "/Items/P1" for c in ad.client.calls)
+
+
+def test_delete_collection_is_blocked():
+    ad = FakeAdapter()
+    try:
+        pl.delete(ad, "collection:C1")
+    except pl.EmbyPlaylistUnsupported:
+        pass
+    else:
+        raise AssertionError("collection delete should be blocked")

--- a/providers/tests/test_jellyfin_playlists.py
+++ b/providers/tests/test_jellyfin_playlists.py
@@ -33,6 +33,10 @@ class FakeHttp:
             return FakeResp(200, {"Items": [{"Id": "P1", "Name": "Weekend", "Type": "Playlist", "ChildCount": 1}], "TotalRecordCount": 1})
         if path == "/Items" and params.get("IncludeItemTypes") == "BoxSet":
             return FakeResp(200, {"Items": [{"Id": "C1", "Name": "Favorites", "Type": "BoxSet", "ChildCount": 1}], "TotalRecordCount": 1})
+        if path == "/Items/P1":
+            return FakeResp(200, {"Id": "P1", "Name": "Weekend", "Type": "Playlist"})
+        if path == "/Items/C1":
+            return FakeResp(200, {"Id": "C1", "Name": "Favorites", "Type": "BoxSet"})
         if path == "/Playlists/P1/Items":
             return FakeResp(200, {"Items": [row("I1", "Movie", "Dune", tmdb="438631", playlist_item_id="E1")], "TotalRecordCount": 1})
         return FakeResp(404, {})
@@ -40,6 +44,8 @@ class FakeHttp:
     def post(self, path: str, *, params: dict[str, Any] | None = None, json: Any = None) -> FakeResp:
         self.calls.append({"method": "POST", "path": path, "params": dict(params or {}), "json": json})
         if path in ("/Playlists/P1/Items", "/Collections/C1/Items"):
+            return FakeResp(204, {})
+        if path in ("/Items/P1", "/Items/C1"):
             return FakeResp(204, {})
         if path == "/Playlists":
             return FakeResp(200, {"Id": "P2"})
@@ -50,6 +56,8 @@ class FakeHttp:
     def delete(self, path: str, *, params: dict[str, Any] | None = None) -> FakeResp:
         self.calls.append({"method": "DELETE", "path": path, "params": dict(params or {})})
         if path in ("/Playlists/P1/Items", "/Collections/C1/Items"):
+            return FakeResp(204, {})
+        if path == "/Items/P1":
             return FakeResp(204, {})
         return FakeResp(404, {})
 
@@ -161,3 +169,29 @@ def test_create_can_make_playlist_or_collection():
     assert collection.id == "collection:C2"
     assert any(c["path"] == "/Playlists" and c["json"]["Name"] == "NewList" for c in ad.client.calls)
     assert any(c["path"] == "/Collections" and c["params"]["Name"] == "NewBox" for c in ad.client.calls)
+
+
+def test_rename_and_delete_playlist_resources():
+    ad = FakeAdapter()
+    renamed_playlist = pl.rename(ad, "playlist:P1", "Renamed")
+    renamed_collection = pl.rename(ad, "collection:C1", "BoxRenamed")
+    deleted = pl.delete(ad, "playlist:P1")
+
+    assert renamed_playlist.id == "playlist:P1"
+    assert renamed_playlist.name == "Renamed"
+    assert renamed_collection.id == "collection:C1"
+    assert renamed_collection.name == "BoxRenamed"
+    assert deleted["ok"] is True
+    assert any(c["method"] == "POST" and c["path"] == "/Items/P1" and c["json"]["Name"] == "Renamed" for c in ad.client.calls)
+    assert any(c["method"] == "POST" and c["path"] == "/Items/C1" and c["json"]["Name"] == "BoxRenamed" for c in ad.client.calls)
+    assert any(c["method"] == "DELETE" and c["path"] == "/Items/P1" for c in ad.client.calls)
+
+
+def test_delete_collection_is_blocked():
+    ad = FakeAdapter()
+    try:
+        pl.delete(ad, "collection:C1")
+    except pl.JellyfinPlaylistUnsupported:
+        pass
+    else:
+        raise AssertionError("collection delete should be blocked")

--- a/providers/tests/test_mdblist_playlists.py
+++ b/providers/tests/test_mdblist_playlists.py
@@ -91,6 +91,9 @@ def test_dynamic_list_is_read_only_static_is_writable(monkeypatch):
     assert dynamic.media_types == ("show",)
     assert static.extra["item_count"] == 2 and static.extra["private"] is True
     assert dynamic.extra["dynamic"] is True
+    assert dynamic.extra["endpoint_type"] == "discovery"
+    assert dynamic.extra["source_kind"] == "discovery"
+    assert dynamic.is_discovery is True
 
 
 def test_watchlist_snapshot_and_writes_delegate(monkeypatch):
@@ -208,6 +211,52 @@ def test_create_static_list_uses_current_user_add_route(monkeypatch):
     assert res.id == "303"
     call = next(c for c in captured if c["url"].endswith("/lists/user/add"))
     assert call["json"] == {"name": "Short"}
+
+
+def test_rename_static_list_uses_update_route(monkeypatch):
+    captured = _router(
+        monkeypatch,
+        {
+            ("GET", "/lists/user"): FakeResp(200, USER_LISTS),
+            ("POST", "/lists/101/update"): FakeResp(200, {"ok": True}),
+        },
+    )
+
+    renamed = pl.rename(FakeAdapter(), "101", "Renamed")
+
+    assert renamed.id == "101"
+    assert renamed.name == "Renamed"
+    update_call = next(c for c in captured if c["url"].endswith("/lists/101/update"))
+    assert update_call["json"] == {"name": "Renamed"}
+
+
+def test_delete_static_list_uses_delete_route(monkeypatch):
+    captured = _router(
+        monkeypatch,
+        {
+            ("GET", "/lists/user"): FakeResp(200, USER_LISTS),
+            ("DELETE", "/lists/101"): FakeResp(204, None),
+        },
+    )
+
+    deleted = pl.delete(FakeAdapter(), "101")
+
+    assert deleted["ok"] is True
+    delete_call = next(c for c in captured if c["url"].endswith("/lists/101"))
+    assert delete_call["method"] == "DELETE"
+    assert delete_call["params"] == {"apikey": "k"}
+
+
+def test_dynamic_list_cannot_be_renamed(monkeypatch):
+    _router(monkeypatch, {("GET", "/lists/user"): FakeResp(200, USER_LISTS)})
+    with pytest.raises(pl.MDBListDynamicListError):
+        pl.rename(FakeAdapter(), "202", "Nope")
+
+
+def test_dynamic_list_cannot_be_deleted(monkeypatch):
+    _router(monkeypatch, {("GET", "/lists/user"): FakeResp(200, USER_LISTS)})
+    with pytest.raises(pl.MDBListDynamicListError):
+        pl.delete(FakeAdapter(), "202")
 
 
 def test_seasons_and_episodes_use_tmdb_buckets(monkeypatch):

--- a/providers/tests/test_plex_playlists.py
+++ b/providers/tests/test_plex_playlists.py
@@ -60,6 +60,17 @@ class FakePlaylist:
             idx = self._items.index(after)
             self._items.insert(idx + 1, obj)
 
+    def editTitle(self, title: str) -> None:
+        self.calls.append(("rename", title))
+        self.title = title
+
+    def delete(self) -> None:
+        self.calls.append(("delete",))
+
+    def reload(self) -> "FakePlaylist":
+        self.calls.append(("reload",))
+        return self
+
 
 class FakeCollection:
     def __init__(
@@ -126,6 +137,15 @@ class FakeServer:
     def playlists(self) -> list[FakePlaylist]:
         return list(self._playlists)
 
+    def fetchItem(self, rating_key: int) -> Any:
+        for obj in self.items_library:
+            if int(getattr(obj, "ratingKey", -1)) == int(rating_key):
+                return obj
+        for playlist in self._playlists:
+            if int(getattr(playlist, "ratingKey", -1)) == int(rating_key):
+                return playlist
+        raise KeyError(rating_key)
+
     def createPlaylist(self, name: str, items: Any = None) -> FakePlaylist:
         pl = FakePlaylist(name, 999, items or [])
         self.created.append(pl)
@@ -155,9 +175,21 @@ def _fake_resolve(srv: FakeServer, guids: list[str], allow: set, accept: set) ->
     return None
 
 
+def _fake_find_rating_key_by_guid(srv: FakeServer, guids: list[str]) -> str | None:
+    wanted = {str(g) for g in guids}
+    for obj in srv.items_library:
+        candidates = {str(getattr(obj, "guid", "") or "")}
+        candidates.update(str(getattr(g, "id", "") or getattr(g, "guid", "") or g) for g in (getattr(obj, "guids", []) or []))
+        if candidates & wanted:
+            return str(getattr(obj, "ratingKey", "") or "")
+    return None
+
+
 @pytest.fixture(autouse=True)
 def _patch_resolve(monkeypatch):
-    monkeypatch.setattr(plpl, "resolve_obj_by_guids", _fake_resolve)
+    monkeypatch.setattr(plpl, "resolve_obj_by_guids", _fake_resolve, raising=False)
+    monkeypatch.setattr(plpl, "server_find_rating_key_by_guid", _fake_find_rating_key_by_guid)
+    monkeypatch.setattr(plpl, "plex_feature_library_ids", lambda *_a, **_k: set())
 
 
 def _media(tmdb: int, title: str) -> dict[str, Any]:
@@ -234,7 +266,7 @@ def test_collection_snapshot_and_writes_use_scoped_ids():
     other = FObj(2, "B Other", section_id=2)
     coll = FakeCollection("Movies", 30, [a], subtype="movie", section_id=1)
     sections = [FakeSection("Movies", 1, "movie", [coll])]
-    ad = FakeAdapter(FakeServer([], [a, other, b], sections))
+    ad = FakeAdapter(FakeServer([], [a, b, other], sections))
     collection_id = f"{plpl.COLLECTION_PREFIX}1:30"
 
     snap = plpl.get_snapshot(ad, collection_id)
@@ -289,7 +321,7 @@ def test_missing_library_media_is_unresolved():
     res = plpl.add(ad, "10", [_media(999, "Ghost")])
     assert res["count"] == 0
     assert res["confirmed_keys"] == []
-    assert res["unresolved"] and res["unresolved"][0]["hint"] == "not_found"
+    assert res["unresolved"] and res["unresolved"][0]["hint"] == "not_in_library"
 
 
 def test_smart_playlist_writes_rejected():
@@ -318,6 +350,36 @@ def test_add_remove_basic():
     rm_res = plpl.remove(ad, "10", [_media(1, "A")])
     assert rm_res["count"] == 1
     assert rm_res["confirmed_keys"] == ["tmdb:1"]
+
+
+def test_rename_and_delete_regular_playlist():
+    a = FObj(1, "A", plid=101)
+    regular = FakePlaylist("Weekend", 10, [a], smart=False)
+    ad = FakeAdapter(FakeServer([regular], [a]))
+
+    renamed = plpl.rename(ad, "10", "Renamed")
+    deleted = plpl.delete(ad, "10")
+
+    assert renamed.id == "10"
+    assert renamed.name == "Renamed"
+    assert ("rename", "Renamed") in regular.calls
+    assert ("delete",) in regular.calls
+    assert deleted["ok"] is True
+
+
+def test_rename_delete_blocked_for_smart_watchlist_and_collections():
+    a = FObj(1, "A", plid=101, section_id=1)
+    smart = FakePlaylist("Smart", 20, [a], smart=True)
+    coll = FakeCollection("Movies", 30, [a], subtype="movie", section_id=1)
+    sections = [FakeSection("Movies", 1, "movie", [coll])]
+    ad = FakeAdapter(FakeServer([smart], [a], sections))
+
+    with pytest.raises(plpl.SmartPlaylistError):
+        plpl.rename(ad, "20", "Nope")
+    with pytest.raises(plpl.PlaylistUnsupported):
+        plpl.rename(ad, plpl.WATCHLIST_ID, "Nope")
+    with pytest.raises(plpl.PlaylistUnsupported):
+        plpl.delete(ad, f"{plpl.COLLECTION_PREFIX}1:30")
 
 
 def test_snapshot_ordered():

--- a/providers/tests/test_publicmetadb_playlists.py
+++ b/providers/tests/test_publicmetadb_playlists.py
@@ -160,12 +160,37 @@ def test_remove_fetches_selected_list_item_ids():
     assert "/api/external/lists/list-b/items/b-item" in deletes
 
 
+def test_delete_custom_list_and_protect_watchlist():
+    client = FakeClient(
+        {
+            ("GET", "/api/external/lists", 1): {
+                "items": [
+                    {"id": "list-a", "name": "Weekend", "type": "custom"},
+                    {"id": "watch-1", "name": "Watchlist", "type": "watchlist"},
+                ],
+            },
+        }
+    )
+    ad = FakeAdapter(client)
+
+    assert pl.delete(ad, "list-a") == {"ok": True, "playlist_id": "list-a"}
+    delete_calls = [c for c in client.calls if c["method"] == "DELETE"]
+    assert delete_calls[-1]["path"] == "/api/external/lists/list-a"
+
+    try:
+        pl.delete(ad, "watch-1")
+    except pl.PublicMetaDBPlaylistError as exc:
+        assert "watchlist" in str(exc)
+    else:
+        raise AssertionError("expected PublicMetaDBPlaylistError")
+
+
 def test_reorder_is_unsupported():
     assert pl.reorder(FakeAdapter(FakeClient()), "list-a", ["tmdb:1"])["unsupported"] is True
 
 
 def test_publicmetadb_manifest_and_auth_capabilities_cover_supported_features():
-    assert pmdb.__VERSION__ == "1.1"
+    assert pmdb.__VERSION__ == "1.2"
     assert pmdb_auth.__VERSION__ == "1.0"
 
     features = pmdb.get_manifest()["features"]

--- a/providers/tests/test_trakt_playlists.py
+++ b/providers/tests/test_trakt_playlists.py
@@ -85,6 +85,39 @@ def test_list_resources_and_normalization(monkeypatch):
     assert r.name == "Weekend"
     assert r.can_add and r.can_remove and r.can_reorder
     assert r.is_smart is False
+    discovery = by_id["discovery:trakt:movies:trending"]
+    assert discovery.name == "Trending Movies"
+    assert discovery.is_smart is True
+    assert discovery.is_discovery is True
+    assert discovery.can_read is True
+    assert discovery.can_add is False and discovery.can_remove is False
+    assert discovery.media_types == ("movie",)
+
+
+def test_discovery_snapshot_reads_wrapped_and_direct_rows(monkeypatch):
+    rows = [
+        {"watchers": 12, "movie": {"title": "Dune", "year": 2021, "ids": {"trakt": 1, "tmdb": 438631}}},
+        {"title": "Arrival", "year": 2016, "ids": {"trakt": 2, "tmdb": 329865}},
+    ]
+    captured = _router(
+        monkeypatch,
+        {("GET", "/movies/trending"): FakeResp(200, rows, headers={"X-Pagination-Page-Count": "1"})},
+    )
+    snap = pl.get_snapshot(FakeAdapter(), "discovery:trakt:movies:trending")
+
+    assert snap.resource.is_discovery is True
+    assert snap.resource.writable is False
+    assert snap.ordered_keys() == ["tmdb:438631", "tmdb:329865"]
+    call = captured[0]
+    assert call["params"]["extended"] == "full"
+    assert call["params"]["limit"] == 100
+
+
+def test_discovery_feeds_are_read_only(monkeypatch):
+    _router(monkeypatch, {})
+    with pytest.raises(RuntimeError):
+        pl.add(FakeAdapter(), "discovery:trakt:movies:popular", [{"type": "movie", "ids": {"tmdb": "1"}}])
+    assert pl.reorder(FakeAdapter(), "discovery:trakt:movies:popular", ["tmdb:1"])["unsupported"] is True
 
 
 def test_watchlist_snapshot_and_writes_delegate(monkeypatch):
@@ -185,3 +218,31 @@ def test_create_respects_list_count_limit(monkeypatch):
     ad = FakeAdapter(settings={"limits": {"list": {"count": 1, "item_count": 100}}})
     with pytest.raises(pl.TraktCapacityError):
         pl.create(ad, "New List")
+
+
+def test_rename_and_delete_user_list(monkeypatch):
+    captured = _router(
+        monkeypatch,
+        {
+            ("PUT", "/users/me/lists/123"): FakeResp(200, {"name": "Renamed", "ids": {"trakt": 123}}),
+            ("DELETE", "/users/me/lists/123"): FakeResp(204),
+        },
+    )
+    ad = FakeAdapter()
+
+    renamed = pl.rename(ad, "123", "Renamed")
+    deleted = pl.delete(ad, "123")
+
+    assert renamed.id == "123"
+    assert renamed.name == "Renamed"
+    assert deleted["ok"] is True
+    assert any(c["method"] == "PUT" and c["json"] == {"name": "Renamed"} for c in captured)
+    assert any(c["method"] == "DELETE" and c["url"].endswith("/users/me/lists/123") for c in captured)
+
+
+def test_built_in_lists_cannot_be_renamed_or_deleted(monkeypatch):
+    _router(monkeypatch, {})
+    with pytest.raises(RuntimeError):
+        pl.rename(FakeAdapter(), pl.WATCHLIST_ID, "Nope")
+    with pytest.raises(RuntimeError):
+        pl.delete(FakeAdapter(), "discovery:trakt:movies:popular")

--- a/tests/test_plex_playlists_resolve.py
+++ b/tests/test_plex_playlists_resolve.py
@@ -46,6 +46,7 @@ class _Obj:
     def __init__(self, rating_key: str, type_: str, section_id: str, title: str) -> None:
         self.ratingKey = rating_key
         self.type = type_
+        self.listType = "video"
         self.librarySectionID = section_id
         self.title = title
         self.year = 1974
@@ -59,6 +60,7 @@ class _Playlist:
         self.playlistType = "video"
         self.smart = False
         self.added: list[Any] = []
+        self.removed: list[Any] = []
 
     def items(self):
         return []
@@ -66,11 +68,25 @@ class _Playlist:
     def addItems(self, objs):
         self.added.extend(objs)
 
+    def removeItems(self, objs):
+        self.removed.extend(objs)
+        return self
+
 
 class _Section:
     def __init__(self, key: str, type_: str) -> None:
         self.key = key
         self.type = type_
+
+    def search(self, **_kwargs):
+        if self.type == "movie":
+            return [_Obj("11", "movie", self.key, "The Godfather Part II")]
+        return []
+
+    def searchEpisodes(self, **_kwargs):
+        if self.type == "show":
+            return [_Obj("22", "episode", self.key, "Winter Is Coming")]
+        return []
 
 
 class _Server:
@@ -158,8 +174,30 @@ def test_item_that_is_not_in_the_library_is_reported_as_such(plex) -> None:
     assert [u["hint"] for u in res["unresolved"]] == ["not_in_library"]
 
 
-def test_create_without_items_is_refused_with_a_typed_error(plex) -> None:
+def test_create_without_items_creates_then_removes_a_seed_item(plex, monkeypatch) -> None:
     pl, adapter, _playlist = plex
+    created: dict[str, Any] = {}
+
+    def _create(title, items=None):
+        playlist = _Playlist()
+        created["title"] = title
+        created["items"] = list(items or [])
+        created["playlist"] = playlist
+        return playlist
+
+    monkeypatch.setattr(adapter.client.server, "createPlaylist", _create, raising=False)
+
+    res = pl.create(adapter, "Weekend", items=[])
+
+    assert created["title"] == "Weekend"
+    assert [o.ratingKey for o in created["items"]] == ["11"]
+    assert [o.ratingKey for o in created["playlist"].removed] == ["11"]
+    assert res.id == "10234"
+
+
+def test_create_without_items_is_refused_when_no_seed_item_exists(plex) -> None:
+    pl, adapter, _playlist = plex
+    adapter.libraries = lambda types=(): []
 
     with pytest.raises(pl.PlaylistItemsRequired):
         pl.create(adapter, "Weekend", items=[])


### PR DESCRIPTION
# Pull request

## Change
Add playlist adapters for Plex, Trakt, MDBList, PublicMetaDB, Jellyfin, Emby, and CrossWatch.

- create, rename, delete, and reorder where supported
- discovery feeds exposed as playlist resources
- provider capability updates
- module version bumps

## Why
Needed for #439 so playlist endpoints can work with real provider lists.

## Testing
- providers/tests/test_plex_playlists.py 
- providers/tests/test_trakt_playlists.py 
- providers/tests/test_mdblist_playlists.py 
- providers/tests/test_publicmetadb_playlists.py 
- providers/tests/test_jellyfin_playlists.py 
- providers/tests/test_emby_playlists.py 
- providers/tests/test_crosswatch_playlists.py 
- tests/test_plex_playlists_resolve.py

## Issue
Relates to #439