### PR TITLE
Change: enrich Stremio progress IDs before sync

### DIFF
--- a/providers/sync/stremio/_progress.py
+++ b/providers/sync/stremio/_progress.py
@@ -103,7 +103,9 @@ def _metadata_enriched(adapter: Any, item: Mapping[str, Any], typ: str) -> dict[
     if stremio_id:
         if not str(out.get("poster") or out.get("poster_url") or "").strip():
             out["poster"] = poster_url_from_item(out, stremio_id)
-        if _duration_ms(out):
+        ids_source = out.get("show_ids") if typ in {"episode", "episodes"} else out.get("ids")
+        ids_map = ids_source if isinstance(ids_source, Mapping) else {}
+        if _duration_ms(out) and str(ids_map.get("tmdb") or "").strip():
             return out
     provider = tmdb_metadata_provider(adapter)
     if provider is None:
@@ -127,17 +129,28 @@ def _metadata_enriched(adapter: Any, item: Mapping[str, Any], typ: str) -> dict[
         return out
     ids_raw = detail.get("ids")
     ids: Mapping[str, Any] = ids_raw if isinstance(ids_raw, Mapping) else {}
+    portable_ids: dict[str, Any] = {}
+    tmdb = str(ids.get("tmdb") or "").strip()
+    if tmdb:
+        portable_ids["tmdb"] = tmdb
     imdb = imdb_id(ids.get("imdb"))
     if imdb:
+        portable_ids["imdb"] = imdb
+    tvdb = str(ids.get("tvdb") or "").strip()
+    if tvdb:
+        portable_ids["tvdb"] = tvdb
+    if portable_ids:
         if typ in {"episode", "episodes"}:
             merged: dict[str, Any] = dict(show_ids)
-            merged["imdb"] = imdb
+            for key, value in portable_ids.items():
+                merged.setdefault(key, value)
             out["show_ids"] = merged
         else:
             out_ids_raw = out.get("ids")
             out_ids: Mapping[str, Any] = out_ids_raw if isinstance(out_ids_raw, Mapping) else {}
             merged = dict(out_ids)
-            merged["imdb"] = imdb
+            for key, value in portable_ids.items():
+                merged.setdefault(key, value)
             out["ids"] = merged
     duration = positive_int(detail.get("runtime_minutes"))
     if duration is None and typ in {"episode", "episodes"}:

--- a/providers/tests/test_stremio_sync.py
+++ b/providers/tests/test_stremio_sync.py
@@ -751,6 +751,26 @@ def test_progress_read_indexes_native_tmdb_movie_id() -> None:
     assert adapter._stremio_read_drops["progress"] == []
 
 
+def test_progress_read_enriches_imdb_movie_id_with_tmdb_when_duration_exists(monkeypatch) -> None:
+    class Provider:
+        def fetch(self, **kwargs: Any) -> dict[str, Any]:
+            assert kwargs["entity"] == "movie"
+            assert kwargs["ids"]["imdb"] == "tt0137523"
+            return {"ids": {"tmdb": "550", "imdb": "tt0137523"}, "images": {}}
+
+    monkeypatch.setattr(_progress, "tmdb_metadata_provider", lambda _adapter: Provider())
+    record = movie_record(state={"timeOffset": 120_000, "duration": 600_000, "lastWatched": 1_785_441_100_000})
+    adapter = FakeAdapter([record])
+
+    index = _progress.build_index(adapter)
+
+    assert set(index) == {"tmdb:550"}
+    assert index["tmdb:550"]["ids"] == {"tmdb": "550", "imdb": "tt0137523"}
+    assert index["tmdb:550"]["progress_ms"] == 120_000
+    assert index["tmdb:550"]["duration_ms"] == 600_000
+    assert index["tmdb:550"]["progress_percent"] == 20.0
+
+
 def test_parse_episode_progress_uses_video_id() -> None:
     record = series_record()
     record["state"].update({"video_id": "tt0903747:1:2", "season": 1, "episode": 2, "timeOffset": 60_000, "duration": 600_000})
@@ -775,6 +795,40 @@ def test_progress_read_indexes_native_tmdb_episode_id() -> None:
     assert index["tmdb:1396#s01e02"]["show_ids"] == {"tmdb": "1396"}
     assert index["tmdb:1396#s01e02"]["progress_at"] == "2026-07-30T19:51:40Z"
     assert adapter._stremio_read_drops["progress"] == []
+
+
+def test_progress_read_enriches_imdb_episode_show_id_with_tmdb_when_duration_exists(monkeypatch) -> None:
+    class Provider:
+        def fetch(self, **kwargs: Any) -> dict[str, Any]:
+            assert kwargs["entity"] == "tv"
+            assert kwargs["ids"]["imdb"] == "tt13111078"
+            assert kwargs["ids"]["title"] == "Lioness"
+            return {"ids": {"tmdb": "113962", "imdb": "tt13111078"}, "runtime_minutes": 42, "images": {}}
+
+    monkeypatch.setattr(_progress, "tmdb_metadata_provider", lambda _adapter: Provider())
+    record = series_record() | {"_id": "tt13111078", "name": "Lioness"}
+    record["state"].update(
+        {
+            "video_id": "tt13111078:1:1",
+            "season": 1,
+            "episode": 1,
+            "timeOffset": 756_000,
+            "duration": 2_520_000,
+            "lastWatched": 1_788_013_866_000,
+        }
+    )
+    adapter = FakeAdapter([record])
+
+    index = _progress.build_index(adapter)
+
+    assert set(index) == {"tmdb:113962#s01e01"}
+    item = index["tmdb:113962#s01e01"]
+    assert item["show_ids"] == {"imdb": "tt13111078", "tmdb": "113962"}
+    assert item["ids"] == {"imdb": "tt13111078"}
+    assert item["progress_ms"] == 756_000
+    assert item["duration_ms"] == 2_520_000
+    assert item["progress_percent"] == 30.0
+    assert item["_stremio_video_id"] == "tt13111078:1:1"
 
 
 def test_progress_write_preserves_history_bitfield_and_unknown_fields() -> None:


### PR DESCRIPTION
# Pull request

## Change

- Stremio progress reads now enrich missing portable IDs from TMDB before exporting progress items.
- This covers movie IDs and episode show IDs while keeping the original Stremio identity intact.

## Why

- Stremio progress could export IMDb-only items, while targets like MDBList return the same item as TMDB after writing.
- That made successful writes look unresolved.

## Testing

- providers/tests/test_stremio_sync.py providers/tests/test_mdblist_progress.py 
- providers/tests/test_simkl_progress.py providers/tests/test_nuvio_progress.py

## Issue

Relates to #905, #906, #908