### PR TITLE
Change: protect playlist-managed pairs

### DIFF
--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -209,6 +209,11 @@ def _normalize_features(f: dict | None) -> dict:
             f[k]["anime_only_sync"] = coerce_bool(f[k].get("anime_only_sync", False)) if use_map else False
     return f
 
+def _playlist_managed_pair(pair: Mapping[str, Any] | None) -> bool:
+    feats = pair.get("features") if isinstance(pair, Mapping) else None
+    pl = feats.get("playlists") if isinstance(feats, Mapping) else None
+    return str(pl.get("managed_by") if isinstance(pl, Mapping) else "").strip().lower() == "playlists"
+
 def _enforce_pair_feature_constraints(pair: dict[str, Any]) -> None:
     src = str(pair.get("source") or "").strip().upper()
     dst = str(pair.get("target") or "").strip().upper()
@@ -2354,6 +2359,8 @@ def api_pairs_update(pair_id: str, payload: PairPatch = Body(...), request: Requ
             if str(it.get("id")) == str(pair_id):
                 if _managed_pair_blocked(cfg, request, it):
                     return {"ok": False, "error": "profile_scope_denied"}
+                if _playlist_managed_pair(it):
+                    return {"ok": False, "error": "playlist_managed_pair"}
                 if "features" in upd:
                     it["features"] = _normalize_features(upd.pop("features"))
                 if "providers" in upd:
@@ -2438,6 +2445,8 @@ def api_pairs_delete(pair_id: str, purge_state: bool = True, request: Request = 
         pair = next((it for it in arr if str(it.get("id")) == str(pair_id)), None)
         if pair is not None and _managed_pair_blocked(cfg, request, pair):
             return {"ok": False, "error": "profile_scope_denied"}
+        if pair is not None and _playlist_managed_pair(pair):
+            return {"ok": False, "error": "playlist_managed_pair"}
         before = len(arr)
         arr[:] = [it for it in arr if str(it.get("id")) != str(pair_id)]
         deleted = before - len(arr)

--- a/services/playlists.py
+++ b/services/playlists.py
@@ -517,16 +517,20 @@ def activity(cfg: Mapping[str, Any], *, limit: int = 25) -> list[dict[str, Any]]
             src = (m.get("source") or {}).get("label"); dst = (m.get("target") or {}).get("label")
             ruleset_name = (m.get("ruleset") or {}).get("name") or r.get("ruleset_id") or "direct"
             target_count = len(m.get("targets") or [])
+            unresolved = int(r.get("unresolved_count") or 0)
+            has_warning = unresolved > 0 or bool(r.get("warnings"))
+            has_error = bool(r.get("capacity_error")) or bool(r.get("errors")) or (r.get("ok") is False and not has_warning)
             rows.append({
-                "ts": finished_at, "type": "Run", "status": "completed" if r.get("ok", True) else "error",
+                "ts": finished_at, "type": "Run", "status": "error" if has_error else "warning" if has_warning else "completed",
                 "ruleset": ruleset_name,
                 "target_count": target_count,
                 "added": int(r.get("added", 0)),
                 "updated": int(r.get("updated", 0)),
                 "removed": int(r.get("removed", 0)),
                 "skipped": int(r.get("skipped", 0)),
+                "unresolved": unresolved,
                 "label": f"{m.get('id')} · {src} → {dst}",
-                "details": f"{(m.get('ruleset') or {}).get('name') or r.get('ruleset_id') or 'direct'}, {len(m.get('targets') or [])} target(s), +{int(r.get('added', 0))}/-{int(r.get('removed', 0))}" + (", capacity error" if r.get("capacity_error") else ""),
+                "details": f"{(m.get('ruleset') or {}).get('name') or r.get('ruleset_id') or 'direct'}, {len(m.get('targets') or [])} target(s), +{int(r.get('added', 0))}/-{int(r.get('removed', 0))}" + (f", {unresolved} unresolved" if unresolved else "") + (", capacity error" if r.get("capacity_error") else ""),
             })
     rows.sort(key=lambda x: x["ts"], reverse=True)
     return rows[: max(1, int(limit))]

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -2034,6 +2034,41 @@ def test_managed_pair_endpoints_are_profile_scoped(monkeypatch) -> None:
     assert denied_delete == {"ok": False, "error": "profile_scope_denied"}
 
 
+def test_playlist_managed_pairs_use_playlist_api(monkeypatch) -> None:
+    import api.syncAPI as sync_api
+
+    cfg = {
+        "pairs": [
+            {
+                "id": "pair_playlist_abc123",
+                "source": "TRAKT",
+                "source_instance": "default",
+                "target": "PLEX",
+                "target_instance": "default",
+                "enabled": True,
+                "features": {
+                    "playlists": {
+                        "enable": True,
+                        "mappings": ["MAP-01"],
+                        "managed_by": "playlists",
+                        "mapping_id": "MAP-01",
+                    }
+                },
+            }
+        ],
+    }
+    saves: list[dict[str, Any]] = []
+    monkeypatch.setattr(sync_api, "_env", lambda: (lambda: cfg, lambda next_cfg: saves.append(next_cfg)))
+
+    blocked_update = sync_api.api_pairs_update("pair_playlist_abc123", sync_api.PairPatch(enabled=False), request=cast(Any, None))
+    blocked_delete = sync_api.api_pairs_delete("pair_playlist_abc123", request=cast(Any, None))
+
+    assert blocked_update == {"ok": False, "error": "playlist_managed_pair"}
+    assert blocked_delete == {"ok": False, "error": "playlist_managed_pair"}
+    assert cfg["pairs"][0]["enabled"] is True
+    assert saves == []
+
+
 def test_managed_events_are_profile_scoped_to_assigned_pairs() -> None:
     cfg = {
         "user_profiles": {

--- a/tests/test_playlists_service.py
+++ b/tests/test_playlists_service.py
@@ -405,13 +405,18 @@ def test_clear_activity_resets_playlist_run_metadata(config_base, fake_providers
     mid = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": [e2]})["mapping"]["id"]
     cfg["playlists"]["endpoints"][0]["last_synced"] = 123
     mapping = next(m for m in cfg["playlists"]["mappings"] if m["id"] == mid)
-    mapping["last_result"] = {"ok": True, "finished_at": 456, "added": 2, "removed": 1}
+    mapping["last_result"] = {"ok": False, "finished_at": 456, "added": 2, "removed": 1, "unresolved_count": 7}
     resolved = runner.resolve_mapping_by_id(cfg, mid)
     assert resolved is not None
     runner.save_baseline(resolved, {"tmdb:1"})
-    runner.store_result(resolved, {"ok": True, "finished_at": 456, "added": 2, "removed": 1})
+    runner.store_result(resolved, {"ok": False, "finished_at": 456, "added": 2, "removed": 1, "unresolved_count": 7})
 
-    assert len(svc.activity(cfg)) == 3
+    rows = svc.activity(cfg)
+    run_row = next(row for row in rows if row["type"] == "Run")
+    assert run_row["status"] == "warning"
+    assert run_row["unresolved"] == 7
+    assert "7 unresolved" in run_row["details"]
+    assert len(rows) == 3
 
     cleared = svc.clear_activity(cfg)
 


### PR DESCRIPTION
# Pull request

## Change

- Block direct update/delete calls for playlist-managed sync pairs.
- Show playlist runs with unresolved items as warnings in playlist activity.
- Include unresolved counts in playlist activity rows.

## Why

- Playlist-created pairs should be managed from the Playlists page, not edited like normal sync pairs.
- Unresolved playlist items should be visible as warnings instead of looking like a clean success.

## Testing

- tests/test_crosswatch_profiles.py::test_playlist_managed_pairs_use_playlist_api
- tests/test_playlists_service.py::test_clear_activity_resets_playlist_run_metadata 

## Issue

Relates to #439
