### PR TITLE
Change: integrate playlists into editor

### DIFF
--- a/assets/js/connections.pairs.overlay.js
+++ b/assets/js/connections.pairs.overlay.js
@@ -21,7 +21,11 @@
     return v === true || v === 1 || v === "1" || v === "true" || v === "on" || v === "yes";
   };
   const playlistMappingIds = (v) => Array.isArray(v?.mappings) ? v.mappings.map((x) => String(x || "").trim()).filter(Boolean) : [];
-  const hasPlaylistMappings = (v) => truthy(v) && playlistMappingIds(v).length > 0;
+  const playlistBlock = (pair) => {
+    const block = pair?.features?.playlists;
+    return block && typeof block === "object" ? block : {};
+  };
+  const isPlaylistManagedPair = (pair) => String(playlistBlock(pair).managed_by || "").trim().toLowerCase() === "playlists";
 
 
   function scheduleViewportLimit(delay = 0) {
@@ -130,9 +134,10 @@
   window.cxPairsEditClick = function (btn) {
     try {
       const id = btn.closest(".pair-card")?.dataset?.id; if (!id) return;
-      if (typeof window.cxEditPair === "function") return window.cxEditPair(id);
       const pairs = Array.isArray(window.cx?.pairs) ? window.cx.pairs : [];
       const pair = pairs.find((p) => String(p.id) === String(id));
+      if (isPlaylistManagedPair(pair)) return openPlaylistMappingsForPair(id, btn);
+      if (typeof window.cxEditPair === "function") return window.cxEditPair(id);
       if (pair) {
         if (typeof window.openPairModal === "function") return window.openPairModal(pair);
         if (typeof window.cxOpenModalFor === "function") return window.cxOpenModalFor(pair);
@@ -143,23 +148,108 @@
 
   if (typeof window.cxToggleEnable !== "function") {
     window.cxToggleEnable = async function (id, on, inputEl) {
+      const card = (inputEl && inputEl.closest(".pair-card")) || document.querySelector(`#pairs_list .pair-card[data-id="${id}"]`);
+      const btn = card?.querySelector(".icon-btn.power");
+      const list = Array.isArray(window.cx?.pairs) ? window.cx.pairs : [];
+      const it = list.find((p) => String(p.id) === String(id));
+      const prev = it ? it.enabled !== false : !on;
       try {
-        const card = (inputEl && inputEl.closest(".pair-card")) || document.querySelector(`#pairs_list .pair-card[data-id="${id}"]`);
-        const btn = card?.querySelector(".icon-btn.power");
         if (btn) btn.classList.toggle("off", !on);
+        if (btn) btn.setAttribute("aria-checked", on ? "true" : "false");
         if (card) card.classList.toggle("pair-disabled", !on);
-        const list = Array.isArray(window.cx?.pairs) ? window.cx.pairs : [];
-        const it = list.find((p) => String(p.id) === String(id)); if (it) it.enabled = !!on;
-        await fetch(`/api/pairs/${id}`, {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ enabled: !!on })
-        }).then(() => { try { document.dispatchEvent(new Event("cx-state-change")); } catch {} });
-      } catch (e) { console.warn("[cxToggleEnable] failed", e); }
+        if (inputEl) inputEl.disabled = true;
+        if (isPlaylistManagedPair(it)) {
+          await setPlaylistManagedPairEnabled(id, on, it);
+        } else {
+          await fetch(`/api/pairs/${id}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ enabled: !!on })
+          }).then((r) => r.ok ? r.json() : Promise.reject(new Error("pair update failed")));
+        }
+        if (it) it.enabled = !!on;
+        try { document.dispatchEvent(new Event("cx-state-change")); } catch {}
+      } catch (e) {
+        if (btn) btn.classList.toggle("off", !prev);
+        if (btn) btn.setAttribute("aria-checked", prev ? "true" : "false");
+        if (card) card.classList.toggle("pair-disabled", !prev);
+        if (inputEl) inputEl.checked = !!prev;
+        console.warn("[cxToggleEnable] failed", e);
+      } finally {
+        if (inputEl) inputEl.disabled = false;
+      }
     };
   }
 
+  async function playlistMappingsForPair(pairId, pair) {
+    const id = String(pairId || "").trim();
+    if (!id) return [];
+    try {
+      const data = await fetch(`/api/playlists/pairs/${encodeURIComponent(id)}/mappings`, { cache: "no-store" }).then((r) => r.ok ? r.json() : null);
+      if (Array.isArray(data?.mappings) && data.mappings.length) return data.mappings;
+    } catch {}
+    const ids = new Set(playlistMappingIds(playlistBlock(pair)));
+    if (!ids.size) return [];
+    try {
+      const data = await fetch("/api/playlists/mappings", { cache: "no-store" }).then((r) => r.ok ? r.json() : null);
+      const mappings = Array.isArray(data?.mappings) ? data.mappings : [];
+      return mappings.filter((m) => ids.has(String(m.id || "")));
+    } catch {
+      return [];
+    }
+  }
+
+  function playlistMappingPayload(mapping, enabled) {
+    return {
+      id: mapping.id,
+      name: mapping.name,
+      source_endpoint: mapping.source_endpoint,
+      target_endpoints: mapping.target_endpoints || [],
+      ruleset_id: mapping.ruleset_id || "",
+      membership: mapping.membership || "managed_only",
+      order: mapping.order || "ignore",
+      enabled: !!enabled,
+    };
+  }
+
+  async function setPlaylistManagedPairEnabled(pairId, enabled, pair) {
+    const mappings = await playlistMappingsForPair(pairId, pair);
+    if (!mappings.length) throw new Error("playlist mapping not found");
+    await Promise.all(mappings.map((mapping) => fetch("/api/playlists/mappings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(playlistMappingPayload(mapping, enabled)),
+    }).then((r) => r.ok ? r.json() : Promise.reject(new Error("playlist mapping update failed")))));
+  }
+
+  async function deletePlaylistManagedPair(pairId, pair) {
+    const mappings = await playlistMappingsForPair(pairId, pair);
+    if (!mappings.length) {
+      await openPlaylistMappingsForPair(pairId, null);
+      return false;
+    }
+    await Promise.all(mappings.map((mapping) => fetch(`/api/playlists/mappings/${encodeURIComponent(mapping.id)}`, {
+      method: "DELETE",
+    }).then((r) => r.ok ? r.json() : Promise.reject(new Error("playlist mapping delete failed")))));
+    return true;
+  }
+
   async function deletePairCard(id) {
+    const pairs = Array.isArray(window.cx?.pairs) ? window.cx.pairs : [];
+    const pair = pairs.find((p) => String(p.id) === String(id));
+    if (isPlaylistManagedPair(pair)) {
+      try {
+        const deleted = await deletePlaylistManagedPair(id, pair);
+        if (!deleted) return;
+      } catch (e) {
+        console.warn("delete playlist mapping failed", e);
+        await openPlaylistMappingsForPair(id, null);
+        return;
+      }
+      if (Array.isArray(window.cx?.pairs)) window.cx.pairs = window.cx.pairs.filter((p) => String(p.id) !== String(id));
+      try { window.dispatchEvent(new CustomEvent("cx:pairs:changed", { detail: { action: "delete", id } })); } catch {}
+      return;
+    }
     const board = document.querySelector("#pairs_list .pairs-board");
     const el = board?.querySelector(`.pair-card[data-id="${id}"]`); if (!el) return;
     el.classList.add("removing"); setTimeout(() => el.remove(), 200);
@@ -198,14 +288,12 @@
 
     const bead = (cls, tip, val) => `<span class="bead ${cls} ${truthy(val) ? "on" : ""}" data-tip="${tip}"></span>`;
     const inst = (v) => (String(v || "default").trim() || "default");
-    // TEMP Disabled due to playlists validation
-    const showPlaylistMappingButton = false;
     const pill = (provider, instance, role) => {
       const name = providerLabel(provider), full = String(instance || "default").toLowerCase() !== "default" ? `${name}:${instance}` : name, logo = providerLogo(provider), tip = `${role === "src" ? "Source" : "Target"}: ${full}`;
       return `<span class="pair-pill ${role}" data-tip="${esc(tip)}"><span class="pair-pill-text">${esc(full)}</span><span class="prov-watermark" aria-hidden="true" style="--wm:url('${esc(logo)}')"></span></span>`;
     };
 
-    const html = pairs.map((pr, i) => {
+    const renderPairCard = (pr, displayIndex) => {
       const src = key(pr.source);
       const dst = key(pr.target);
       const srcInst = inst(pr.source_instance);
@@ -223,7 +311,7 @@
         <div class="pair-card brand-${brandKey(src)} dst-${brandKey(dst)} ${enabled ? "" : "pair-disabled"}" data-id="${pr.id || ""}" data-source="${src}" data-target="${dst}" data-mode="${modeLabel}" style="--src-solid:${srcTone.solid};--src-rgb:${srcTone.rgb};--dst-solid:${dstTone.solid};--dst-rgb:${dstTone.rgb};--accent:${srcTone.solid};--accent-rgb:${srcTone.rgb}">
           <div class="pair-row">
             <div class="pair-left">
-              <span class="ord-badge" data-tip="Order position">${i + 1}</span>
+              <span class="ord-badge" data-tip="Sync order">${displayIndex}</span>
               ${pill(src, srcInst, "src")}
               <span class="arrow" data-tip="${modeLabel}">${arrow}</span>
               ${pill(dst, dstInst, "dst")}
@@ -239,10 +327,6 @@
                 ${bead("pl", "Playlists", f.playlists)}
                 ${bead("co", "Collections", f.collection)}
               </div>
-
-              ${showPlaylistMappingButton && hasPlaylistMappings(f.playlists) ? `<button type="button" class="icon-btn" data-tip="Manage playlist mappings" onclick="window.cxOpenPlaylistMappingsForPair && window.cxOpenPlaylistMappingsForPair(this.closest('.pair-card')?.dataset?.id, this)" aria-label="Manage playlist mappings">
-                <svg viewBox="0 0 24 24" class="ico" aria-hidden="true"><path d="M4 6h11"></path><path d="M4 12h11"></path><path d="M4 18h7"></path><path d="M17 15l4 3-4 3"></path></svg>
-              </button>` : ""}
 
               <label class="icon-btn power ${enabled ? "" : "off"}" data-tip="Enable / disable" role="switch" aria-checked="${enabled}">
                 <input class="sr-only" type="checkbox" name="pair-enabled" ${enabled ? "checked" : ""}
@@ -265,9 +349,9 @@
             </div>
           </div>
         </div>`;
-    }).join("");
+    };
 
-    board.innerHTML = html;
+    board.innerHTML = pairs.map((pair, index) => renderPairCard(pair, index + 1)).join("");
     scheduleViewportLimit(0);
     installTooltip(host);
     refreshBadges(board);

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -406,6 +406,54 @@
     if (nextWrap) nextWrap.style.display = "";
   }
 
+  function playlistEndpointType(ep, playlist) {
+    const raw = String(ep?.playlist_type || ep?.endpoint_type || ep?.resource_kind || ep?.source_kind || ep?.kind || "").toLowerCase();
+    if (raw.includes("discover")) return "Discovery";
+    if (raw.includes("watchlist") || String(playlist || "").toLowerCase() === "watchlist") return "Watchlist";
+    if (!raw || raw === "regular" || raw === "playlist") return "";
+    return raw.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+  }
+
+  function syncPlaylistEndpointIconSelect(selectEl, show) {
+    if (!selectEl) return;
+    const helper = window.CW?.IconSelect?.enhance;
+    const wrap = selectEl.nextElementSibling && selectEl.nextElementSibling.classList?.contains("cw-icon-select")
+      ? selectEl.nextElementSibling
+      : null;
+    if (!show || typeof helper !== "function") {
+      selectEl.classList.remove("cw-icon-select-native");
+      if (wrap) wrap.style.display = "none";
+      return;
+    }
+    helper(selectEl, {
+      className: "cw-editor-icon-select cw-editor-endpoint-select",
+      menuClassName: "pl-endpoint-select-menu cw-editor-endpoint-select-menu",
+      getOptionData: (value, option) => {
+        const ep = (state.playlistEndpoints || []).find(x => String(x?.id || "") === String(value || "")) || {};
+        const provider = ep.provider || option?.dataset?.provider || "";
+        const providerText = providerLabel(provider, provider || "");
+        const playlist = ep.playlist_name || ep.playlist_id || "";
+        const label = ep.name || ep.id || option?.textContent || value || "Endpoint";
+        const note = [providerText, playlist && playlist !== label ? playlist : ""].filter(Boolean).join(" - ");
+        const type = playlistEndpointType(ep, playlist);
+        const icon = providerMeta.logLogoPath?.(provider) || providerMeta.logoPath?.(provider) || "";
+        return {
+          label,
+          note,
+          selectedLabel: label,
+          selectedShowNote: true,
+          icons: [icon ? { src: icon, alt: providerText } : { text: String(provider || "?").slice(0, 2) }],
+          badges: [type].filter(Boolean),
+          disabled: !!option?.disabled,
+        };
+      },
+    });
+    const nextWrap = selectEl.nextElementSibling && selectEl.nextElementSibling.classList?.contains("cw-icon-select")
+      ? selectEl.nextElementSibling
+      : null;
+    if (nextWrap) nextWrap.style.display = "";
+  }
+
   function syncSnapshotControlVisibility() {
     return editorSources.syncSnapshotControlVisibility(sourceContext());
   }
@@ -432,6 +480,7 @@
       fetchJSON,
       syncProviderIconSelect,
       syncProfileIconSelect,
+      syncPlaylistEndpointIconSelect,
       renderInstanceOptions,
       loadInstanceOptions,
       persistUIState,
@@ -1927,6 +1976,7 @@ function bindFileImport(btn, input, url, done) {
     snapSel.addEventListener("change", async () => {
       state.snapshot = snapSel.value || "";
       if (isProviderPickerSource()) syncProviderIconSelect(snapSel, true);
+      else if (state.source === "playlist") syncPlaylistEndpointIconSelect(snapSel, true);
       if (isProviderPickerSource()) {
         state.instance = await loadInstanceOptions(state.snapshot, instanceSel, state.instance);
         persistUIState();

--- a/assets/js/editor/sources.js
+++ b/assets/js/editor/sources.js
@@ -123,6 +123,7 @@
     if (ctx.instanceLabel) ctx.instanceLabel.style.display = providerPicker ? "" : "none";
     if (ctx.instanceSel) ctx.instanceSel.style.display = providerPicker ? "" : "none";
     ctx.syncProfileIconSelect?.(ctx.instanceSel, providerPicker);
+    ctx.syncPlaylistEndpointIconSelect?.(snapSel, isPlaylist);
 
     if (isPlaylist) {
       const list = Array.isArray(state.playlistEndpoints) ? state.playlistEndpoints : [];
@@ -134,7 +135,7 @@
       const next = opts.includes(state.snapshot) ? state.snapshot : opts[0] || "";
       if (next !== state.snapshot) state.snapshot = next;
       snapSel.value = state.snapshot || "";
-      ctx.syncProviderIconSelect?.(snapSel, false);
+      ctx.syncPlaylistEndpointIconSelect?.(snapSel, true);
       syncSnapshotControlVisibility(ctx);
       return;
     }

--- a/assets/js/modals/pair-config/custom-rules.js
+++ b/assets/js/modals/pair-config/custom-rules.js
@@ -93,7 +93,7 @@ export function commonFeaturesForPair(state, providerFeatures, isProgressPair) {
   if (!state?.src || !state?.dst) return [];
   const a = providerFeatures(state.src);
   const b = providerFeatures(state.dst);
-  const keys = ["watchlist", "ratings", "history", "progress", "playlists", "collection"];
+  const keys = ["watchlist", "ratings", "history", "progress", "collection"];
   return keys.filter(k => {
     if (!featureAllowedForPair(state, k)) return false;
     if (k === "progress") return isProgressPair(state) && !!a.progress && !!b.progress;

--- a/assets/js/modals/pair-config/flow.js
+++ b/assets/js/modals/pair-config/flow.js
@@ -11,10 +11,12 @@ import {
 } from "./meta.js";
 
 export function createFlowController({ ID, Q, byName, renderWarnings }) {
+  const editableFeatureOrder = () => sharedFeatureOrder().filter((key) => String(key || "").toLowerCase() !== "playlists");
+
   function renderFlowRailDots(state) {
     const arrow = ID("cx-flow-rail")?.querySelector(".arrow");
     if (!arrow) return;
-    const enabled = sharedFeatureOrder().filter((key) => !!state?.options?.[key]?.enable);
+    const enabled = editableFeatureOrder().filter((key) => !!state?.options?.[key]?.enable);
     const keys = enabled.length ? enabled : [getFlowFeatureKey(state)];
     arrow.innerHTML = keys
       .map((key, index) => {
@@ -66,7 +68,7 @@ export function createFlowController({ ID, Q, byName, renderWarnings }) {
     ) {
       return current;
     }
-    const order = sharedFeatureOrder();
+    const order = editableFeatureOrder();
     return order.find((key) => !!state?.options?.[key]?.enable) || "watchlist";
   }
 
@@ -84,7 +86,6 @@ export function createFlowController({ ID, Q, byName, renderWarnings }) {
       ["ratings", "rt"],
       ["history", "hi"],
       ["progress", "pr"],
-      ["playlists", "pl"],
       ["collection", "co"],
     ];
     host.innerHTML = items

--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -21,6 +21,9 @@ const G=typeof window!=="undefined"?window:globalThis;
 const jclone=(o)=>JSON.parse(JSON.stringify(o||{}));
 const escHTML=(s)=>String(s==null?"":s).replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
 const PROGRESS_LEGACY_MAX_PERCENT = 95;
+const playlistBlockOf=(pair)=>{const block=pair?.features?.playlists;return block&&typeof block==="object"?block:{}};
+const playlistMappingIds=(pair)=>{const ids=playlistBlockOf(pair).mappings;return Array.isArray(ids)?ids.map(x=>String(x||"").trim()).filter(Boolean):[]};
+const isManagedPlaylistPair=(pair)=>String(playlistBlockOf(pair).managed_by||"").trim().toLowerCase()==="playlists";
 
 const isEmby = v => same(v, "emby");
 function hasEmby(state){ return isEmby(state?.src) || isEmby(state?.dst) }
@@ -189,6 +192,40 @@ function applyCollectionTypeRules(state){
 
 // Inline footer
 function closePairConfigModal(modal){try{G.cxCloseModal?.()}catch{}if(modal?.isConnected)modal.dispatchEvent(new CustomEvent("cw-modal-close",{bubbles:true}))}
+function renderManagedPlaylistPairModal(hostEl,pair){
+  hostEl.__doSave=null;
+  const pairId=String(pair?.id||"").trim();
+  const ids=playlistMappingIds(pair);
+  const label=ids.length?ids.join(", "):"playlist mapping";
+  hostEl.innerHTML=`
+    <div id="cx-modal" class="cx-card">
+      <div class="cx-head">
+        <div class="title-wrap">
+          <span class="material-symbols-rounded app-logo" aria-hidden="true">queue_music</span>
+          <div><div class="app-name">Managed by Playlists</div><div class="app-sub">Edit this pair from the Playlists page.</div></div>
+        </div>
+      </div>
+      <div class="cx-body">
+        <div class="panel">
+          <div class="panel-title">Playlist mapping</div>
+          <div class="muted">This sync pair is owned by ${escHTML(label)}. Normal pair editing is disabled so the playlist mapping stays connected.</div>
+        </div>
+      </div>
+      <div class="cx-actions">
+        <button type="button" class="cx-btn" id="cx-managed-close">Cancel</button>
+        <button type="button" class="cx-btn primary" id="cx-managed-open"><span class="material-symbols-rounded" aria-hidden="true">queue_music</span> Open playlist mapping</button>
+      </div>
+    </div>`;
+  ID("cx-managed-close",hostEl)?.addEventListener("click",(e)=>{e.preventDefault();closePairConfigModal(hostEl)});
+  ID("cx-managed-open",hostEl)?.addEventListener("click",async(e)=>{
+    e.preventDefault();
+    closePairConfigModal(hostEl);
+    try{
+      if(typeof G.showTab==="function") await G.showTab("playlists");
+      await G.Playlists?.openMappingForPair?.(pairId,e.currentTarget,{returnToSyncPairs:true});
+    }catch(err){console.warn("[pair-config] playlist mapping open failed",err)}
+  });
+}
 function ensureInlineFoot(modal){if(!modal)return;const card=Q(".cx-card",modal)||modal;let bar=card.querySelector(":scope > .cx-actions");if(!bar){bar=document.createElement("div");bar.className="cx-actions";const cancel=document.createElement("button");cancel.type="button";cancel.className="cx-btn";cancel.textContent="Cancel";cancel.addEventListener("click",(e)=>{e.preventDefault();closePairConfigModal(modal)});const save=document.createElement("button");save.type="button";save.className="cx-btn primary";save.id="cx-inline-save";save.textContent="Save";save.addEventListener("click",async(e)=>{e.preventDefault();const run=modal.__doSave;if(typeof run!=="function")return;const b=ID("cx-inline-save");if(!b)return;const old=b.textContent;b.disabled=true;b.textContent="Saving...";try{await run()}finally{b.disabled=false;b.textContent=old}});bar.append(cancel,save);card.appendChild(bar)}}
 
 // Ratings summary
@@ -2868,6 +2905,11 @@ export default{
     let pair=null;
     if(props?.pairOrId && typeof props.pairOrId==="object") pair=props.pairOrId;
     else if(props?.pairOrId) pair=await loadPairById(String(props.pairOrId));
+
+    if(isManagedPlaylistPair(pair)){
+      renderManagedPlaylistPairModal(hostEl,pair);
+      return;
+    }
 
     if(pair && typeof pair==="object"){
       const up=x=>String(x||"").toUpperCase();

--- a/tests/test_editor_playlists.py
+++ b/tests/test_editor_playlists.py
@@ -157,6 +157,22 @@ def test_editor_ui_exposes_playlist_source() -> None:
     assert "state.source = ctx.normalizeSource(state.source);" in load_js
 
 
+def test_editor_playlist_endpoint_picker_uses_styled_single_select() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "assets" / "js" / "editor.js").read_text(encoding="utf-8")
+    sources_js = (root / "assets" / "js" / "editor" / "sources.js").read_text(encoding="utf-8")
+    css = (root / "assets" / "css" / "pages.css").read_text(encoding="utf-8")
+    assert "function syncPlaylistEndpointIconSelect(selectEl, show)" in js
+    assert 'className: "cw-editor-icon-select cw-editor-endpoint-select"' in js
+    assert 'menuClassName: "pl-endpoint-select-menu cw-editor-endpoint-select-menu"' in js
+    assert "ctx.syncPlaylistEndpointIconSelect?.(snapSel, true);" in sources_js
+    assert "ctx.syncProviderIconSelect?.(snapSel, false);" not in sources_js
+    assert "#page-editor .cw-editor-endpoint-select .cw-icon-select-btn" in css
+    assert ".cw-editor-endpoint-select-menu .cw-icon-select-text" in css
+
+
 def test_editor_ui_allows_extra_policy_corrections() -> None:
     from pathlib import Path
 


### PR DESCRIPTION
# Pull request

## Change

- Hide playlist feature editing from the normal pair config flow.
- Route playlist-managed pair edits back to the Playlists page.
- Keep playlist-managed pairs visible in the normal pair list with normal controls.
- Add playlist endpoint loading to the editor workspace picker.

## Why

Playlist mappings now own playlist sync configuration, so the normal pair config should not duplicate that setup.

## Testing

- tests/test_editor_playlists.py 
- tests/test_playlists_ui.py::test_pair_config_hides_playlist_feature_tab
- tests/test_playlists_ui.py::test_pair_overlay_playlist_managed_pairs_open_playlist_mapping

## Issue

Relates to #439