### PR TITLE
Change: group playlist item events

### DIFF
--- a/cw_platform/event_archive/groups.py
+++ b/cw_platform/event_archive/groups.py
@@ -67,7 +67,7 @@ _PROBLEM_TYPES_SQL = "('write_failed','unresolved_recorded','blackbox_promoted',
 _UNRESOLVED_TYPES_SQL = "('write_failed','unresolved_recorded')"
 
 # DO NOT FORGET to update the version when the correlation key/status/summary logic
-CORRELATION_VERSION = 14
+CORRELATION_VERSION = 15
 
 
 def _with_reason_labels(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -121,6 +121,13 @@ def _g(r: Any, key: str) -> Any:
         return None
 
 
+def _is_playlist_batch_event(r: Any) -> bool:
+    if str(_g(r, "feature") or "").strip().lower() != "playlists":
+        return False
+    event_type = str(_g(r, "event_type") or "").strip().lower()
+    return event_type in {"playlist_add", "playlist_remove", "playlist_update"}
+
+
 def group_hash(r: Any) -> str:
     if str(_g(r, "domain") or "").strip().lower() == "audit":
         ident = str(_g(r, "event_hash") or _g(r, "id") or _g(r, "created_at") or "").strip()
@@ -141,6 +148,17 @@ def group_hash(r: Any) -> str:
             token,
         ]
         return hashlib.sha256("\x1f".join(parts).encode("utf-8", "replace")).hexdigest()
+    if _is_playlist_batch_event(r):
+        run_or_batch = str(_g(r, "run_id") or _g(r, "created_at") or "").strip()
+        parts = [
+            "\x00playlist_batch",
+            run_or_batch,
+            _norm_op(_g(r, "operation")),
+            str(_g(r, "pair_key") or "").strip(),
+            _route_anchor(r),
+        ]
+        return hashlib.sha256("\x1f".join(parts).encode("utf-8", "replace")).hexdigest()
+
     item_key = str(_g(r, "item_key") or "").strip()
     if item_key:
         parts = [
@@ -189,6 +207,9 @@ def _derive_status(events: list[dict[str, Any]], extra_problems: int = 0) -> str
             if ts >= best_ts:
                 best_ts, best = ts, st
         return best or "informational"
+
+    if any(_is_playlist_batch_event(e) for e in events):
+        return "completed"
 
     # status reflects the run's completion
     if "sync_run_finished" in types:
@@ -266,6 +287,17 @@ def _summarize(status: str, events: list[dict[str, Any]], feature: str, dst: str
 
     if types & set(_SCROBBLE_STATUS):
         return _summarize_scrobble(status, events, dst)
+
+    if str(feature or "").strip().lower() == "playlists" and any(_is_playlist_batch_event(e) for e in events):
+        src = _P(_pick(events, "source_provider"))
+        route = f"{src} -> {dst}" if (src and dst) else (dst or src or "")
+        op = _norm_op(_pick(events, "operation"))
+        noun = "item" if len(events) == 1 else "items"
+        action = {"add": "added", "remove": "removed", "update": "updated"}.get(op, "updated")
+        head = f"Playlist {action}"
+        if route:
+            head = f"{route} {head[:1].lower()}{head[1:]}"
+        return f"{head}, {len(events)} {noun}"
 
     # one sync run with its pair/feature jobs and health checks
     if types & {"sync_run_started", "sync_run_finished"}:
@@ -460,12 +492,24 @@ def _recompute(conn: sqlite3.Connection, group_id: int, now: int) -> None:
     reason = str((fail_evt or {}).get("reason") or _pick(events, "reason") or "")
     summary = _summarize(status, events, feature, dst, norm_op, reason_code, feat_issues)
     domain = str(_pick(events, "domain") or "sync")
+    is_playlist_batch = feature.strip().lower() == "playlists" and any(_is_playlist_batch_event(e) for e in events)
 
     if is_run:
         vals = (
             domain, now, min(ts), max(ts), len(events), status, severity,
             None, "run", None, None, None, None, None, None, None, None,
             None, None, None, None, None, None, None, None, summary, group_id,
+        )
+    elif is_playlist_batch:
+        vals = (
+            domain, now, min(ts), max(ts), len(events), status, severity,
+            feature or None, norm_op or None,
+            _pick(events, "source_provider"), _pick(events, "source_instance"),
+            _pick(events, "destination_provider"), _pick(events, "destination_instance"),
+            _pick(events, "origin_provider"), _pick(events, "origin_instance"),
+            _pick(events, "pair_key"), _pick(events, "direction"),
+            None, None, None, None, None, None,
+            reason_code or None, reason or None, summary, group_id,
         )
     else:
         vals = (
@@ -545,7 +589,7 @@ def correlate(*, conn: sqlite3.Connection | None = None, reset: bool = False) ->
             _LOG.warning("event correlation reset failed: %s", exc)
     try:
         rows = c.execute(
-            "SELECT id, event_hash, domain, feature, operation, item_key, title, season, episode, created_at, "
+            "SELECT id, event_hash, domain, event_type, feature, operation, item_key, title, season, episode, created_at, "
             "source_kind, session_key, source_provider, source_instance, destination_provider, destination_instance, "
             "pair_key, run_id FROM events WHERE group_id IS NULL"
         ).fetchall()

--- a/cw_platform/playlists_runner.py
+++ b/cw_platform/playlists_runner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1138,6 +1139,7 @@ def _event_rows(
     from .id_map import canonical_key
 
     now = int(time.time())
+    run_id = str(ctx.get("run_id") or os.environ.get("CW_RUN_ID") or "").strip() or None
     rows: list[dict[str, Any]] = []
     for it in items or []:
         mt = str(it.get("type") or "").lower()
@@ -1146,6 +1148,7 @@ def _event_rows(
             {
                 "domain": "sync",
                 "created_at": now,
+                "run_id": run_id,
                 "event_type": f"playlist_{operation}",
                 "severity": "info",
                 "feature": "playlists",

--- a/tests/test_event_archive_playlists.py
+++ b/tests/test_event_archive_playlists.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from cw_platform.event_archive.db import connect
+from cw_platform.event_archive.groups import group_events, list_groups
+from cw_platform.event_archive.recorder import record_events
+
+
+def test_playlist_item_events_group_by_mapping_batch() -> None:
+    conn = connect(":memory:")
+
+    record_events(
+        [
+            {
+                "domain": "sync",
+                "created_at": 1770000000,
+                "run_id": "run-1",
+                "event_type": "playlist_add",
+                "severity": "info",
+                "feature": "playlists",
+                "operation": "add",
+                "pair_key": "MAP-01",
+                "direction": "one_way",
+                "source_provider": "TRAKT",
+                "source_instance": "default",
+                "destination_provider": "PLEX",
+                "destination_instance": "default",
+                "item_key": key,
+                "title": title,
+                "media_type": "movie",
+            }
+            for key, title in (
+                ("tmdb:1", "Avengers: Infinity War"),
+                ("tmdb:2", "Guardians of the Galaxy"),
+                ("tmdb:3", "Captain Marvel"),
+            )
+        ],
+        conn=conn,
+    )
+
+    groups = list_groups(feature="playlists", operation="add", visibility="all", conn=conn)
+
+    assert groups["total"] == 1
+    thread = groups["items"][0]
+    assert thread["event_count"] == 3
+    assert thread["item_key"] is None
+    assert thread["title"] is None
+    assert thread["summary"] == "TRAKT -> PLEX playlist added, 3 items"
+
+    events = group_events(thread["id"], conn=conn)["items"]
+    assert [row["title"] for row in events] == [
+        "Avengers: Infinity War",
+        "Guardians of the Galaxy",
+        "Captain Marvel",
+    ]
+
+
+def test_playlist_item_events_without_run_group_by_timestamp_batch() -> None:
+    conn = connect(":memory:")
+
+    record_events(
+        [
+            {
+                "domain": "sync",
+                "created_at": 1770000000,
+                "event_type": "playlist_remove",
+                "severity": "info",
+                "feature": "playlists",
+                "operation": "remove",
+                "pair_key": "MAP-01",
+                "source_provider": "TRAKT",
+                "destination_provider": "PLEX",
+                "item_key": key,
+                "title": title,
+            }
+            for key, title in (("tmdb:1", "One"), ("tmdb:2", "Two"))
+        ],
+        conn=conn,
+    )
+
+    groups = list_groups(feature="playlists", operation="remove", visibility="all", conn=conn)
+
+    assert groups["total"] == 1
+    assert groups["items"][0]["summary"] == "TRAKT -> PLEX playlist removed, 2 items"


### PR DESCRIPTION
# Pull request

## Change

- Group playlist item add/remove events into one event thread per mapping batch.
- Keep individual playlist item events available inside the thread details.
- Attach the active sync run id to playlist item events when available.
- Rebuild existing event grouping with the new playlist correlation logic.

## Why

Playlist syncs can show many items at once, and the Events modal should show that as one useful thread.

## Testing

- tests/test_event_archive_playlists.py 
- tests/test_event_archive_blackbox.py 
- tests/test_event_context.py 
- tests/test_playlists_runner.py 

## Issue

Relates to #439