### PR TITLE
Change: CLI setup for scheduler, sync, and playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,29 @@ volumes:
 
 > Want no web UI? Add `-e CW_CLI_ONLY=1` or `CW_CLI_ONLY: "1"` in Compose. The API, CLI, webhooks and auth callbacks keep working.
 
+### Run Once and Exit
+
+For cron, Kubernetes CronJobs or other external schedulers, run the container as a one-shot sync job:
+
+```bash
+docker run --rm \
+  -v crosswatch_config:/config \
+  -e TZ=Europe/Amsterdam \
+  ghcr.io/cenodude/crosswatch:latest \
+  run-once
+```
+
+Run selected pairs by id, number or unique prefix:
+
+```bash
+docker run --rm \
+  -v crosswatch_config:/config \
+  ghcr.io/cenodude/crosswatch:latest \
+  run-once --pair pair_07c3 --pair pair_91ab
+```
+
+The one-shot command exits `0` on success and `1` when the sync reports errors or cancellation. Add `--fail-on-unresolved` if unmatched items should fail the job.
+
 ## Sponsors
 
 <div align="center">

--- a/cli/README.md
+++ b/cli/README.md
@@ -122,6 +122,10 @@ cw sync run 1                      just pair #1 from cw sync list
 cw sync run pair_07c3              just the one by id or unique prefix
 cw sync run --pair pair_07c3       same selector, option form
 cw sync run --follow               run it and stream the log until it finishes
+cw sync once                       local run, wait, return exit code
+cw sync once --pair pair_07c3      local one-shot pair run
+cw sync once --pair a --pair b     local one-shot selected pair run
+cw sync once --feature watchlist   local one-shot feature-only run
 cw sync status                     current or last run, with counts
 cw sync follow                     attach to a run already going
 cw sync cancel                     stop after the current step
@@ -129,7 +133,7 @@ cw sync unresolved                 what the last run could not match
 cw sync providers [--counts]
 ```
 
-`--follow` passes through the exit code from the sync, handy in cron or a health check.
+`cw sync run` starts work through the running service. `cw sync once` runs in the current process, waits for completion, and exits with the sync result code, which is useful for `docker run --rm`, cron, Kubernetes CronJobs and other external schedulers. By default unresolved items do not fail the command; add `--fail-on-unresolved` for a stricter run.
 
 ## Config
 
@@ -278,10 +282,35 @@ cw playlist overview
 cw playlist providers
 cw playlist resources PLEX
 cw playlist activity
+cw playlist setup --source-provider TRAKT --source-playlist LIST_ID --target-provider PLEX --create-target "Weekend"
 
-cw playlist endpoint list|add|sync|delete
-cw playlist mapping list|add|run|preview|result|delete
-cw playlist ruleset list|show|delete
+cw playlist resource list PLEX
+cw playlist resource create PLEX --name Weekend
+cw playlist resource rename PLEX LIST_ID --name NewName
+cw playlist resource delete PLEX LIST_ID
+
+cw playlist endpoint list
+cw playlist endpoint add PLEX LIST_ID --name PlexFavs
+cw playlist endpoint edit EP-01 --playlist LIST_ID
+cw playlist endpoint sync EP-01
+cw playlist endpoint delete EP-01
+
+cw playlist mapping list
+cw playlist mapping add --source EP-01 --target EP-02 --name Movies
+cw playlist mapping edit MAP-01 --membership mirror --order preserve
+cw playlist mapping enable MAP-01
+cw playlist mapping disable MAP-01
+cw playlist mapping run MAP-01
+cw playlist mapping preview MAP-01
+cw playlist mapping result MAP-01
+cw playlist mapping delete MAP-01
+
+cw playlist ruleset list
+cw playlist ruleset show trakt_free_account
+cw playlist ruleset clone trakt_free_account --name MyRules
+cw playlist ruleset add ruleset.json
+cw playlist ruleset validate ruleset.json
+cw playlist ruleset delete RULESET_ID
 ```
 
 `cw playlist mapping run <id> --dry-run` first, always.
@@ -391,6 +420,17 @@ cw scheduler status
 cw scheduler next
 cw scheduler enable
 cw scheduler disable
+cw scheduler list                  advanced jobs
+cw scheduler set hourly
+cw scheduler set every 6h
+cw scheduler set daily 03:30
+cw scheduler set interval 45m
+cw scheduler add PAIR_ID --at 00:00 --at 12:00
+cw scheduler edit JOB_ID --at 03:30
+cw scheduler pause JOB_ID
+cw scheduler resume JOB_ID
+cw scheduler delete JOB_ID
+cw scheduler setup                 guided setup
 cw scheduler run-now               fire it now
 cw scheduler replan                recompute the next run time
 cw scheduler stop                  stop the worker, keep the config

--- a/cli/_context.py
+++ b/cli/_context.py
@@ -110,6 +110,9 @@ class Ctx:
     def put(self, path: str, **kwargs: Any) -> Any:
         return self.request("PUT", path, **kwargs)
 
+    def patch(self, path: str, **kwargs: Any) -> Any:
+        return self.request("PATCH", path, **kwargs)
+
     def delete(self, path: str, **kwargs: Any) -> Any:
         return self.request("DELETE", path, **kwargs)
 

--- a/cli/_transport.py
+++ b/cli/_transport.py
@@ -26,6 +26,9 @@ class Transport:
     def put(self, path: str, **kwargs: Any) -> Any:
         return self.request("PUT", path, **kwargs)
 
+    def patch(self, path: str, **kwargs: Any) -> Any:
+        return self.request("PATCH", path, **kwargs)
+
     def delete(self, path: str, **kwargs: Any) -> Any:
         return self.request("DELETE", path, **kwargs)
 

--- a/cli/commands/playlist.py
+++ b/cli/commands/playlist.py
@@ -3,16 +3,19 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 import typer
 
 from .._context import Ctx
-from .._errors import EXIT_USAGE, CLIError
+from .._errors import EXIT_NOT_FOUND, EXIT_USAGE, CLIError
 from .._render import state_text
-from .._util import as_dict, coerce_bool, error_text, fmt_ts, rows_from_payload
+from .._util import as_dict, coerce_bool, error_text, fmt_ts, parse_value, rows_from_payload
 
 playlist_app = typer.Typer(help="Playlist endpoints, mappings and rulesets.", no_args_is_help=True)
+resource_app = typer.Typer(help="Provider playlist resources.", no_args_is_help=True)
 endpoint_app = typer.Typer(help="Playlist endpoints.", no_args_is_help=True)
 mapping_app = typer.Typer(help="Playlist mappings.", no_args_is_help=True)
 ruleset_app = typer.Typer(help="Playlist rulesets.", no_args_is_help=True)
@@ -29,8 +32,153 @@ def _fields(raw: list[str]) -> dict[str, Any]:
         key = key.strip()
         if not sep or not key:
             raise CLIError(f"--field expects key=value, got '{item}'", exit_code=EXIT_USAGE)
-        body[key] = value
+        body[key] = parse_value(value)
     return body
+
+
+def _put_if(text: str, body: dict[str, Any], key: str, value: Any) -> None:
+    if str(text or "").strip():
+        body[key] = value
+
+
+def _find_id(items: list[dict[str, Any]], needle: str, label: str) -> dict[str, Any]:
+    wanted = str(needle or "").strip()
+    if not wanted:
+        raise CLIError(f"A {label} id is required", exit_code=EXIT_USAGE)
+    exact = [item for item in items if str(item.get("id") or "") == wanted]
+    if exact:
+        return exact[0]
+    partial = [item for item in items if str(item.get("id") or "").lower().startswith(wanted.lower())]
+    if len(partial) == 1:
+        return partial[0]
+    if len(partial) > 1:
+        ids = ", ".join(str(item.get("id") or "") for item in partial[:6])
+        raise CLIError(f"{label.title()} id '{wanted}' is ambiguous", hint=f"Matches: {ids}", exit_code=EXIT_USAGE)
+    raise CLIError(f"No {label} matches '{wanted}'", exit_code=EXIT_NOT_FOUND)
+
+
+def _endpoint_items(state: Ctx) -> list[dict[str, Any]]:
+    return _rows(state.get("/api/playlists/endpoints"), "endpoints", "items")
+
+
+def _mapping_items(state: Ctx) -> list[dict[str, Any]]:
+    return _rows(state.get("/api/playlists/mappings"), "mappings", "items")
+
+
+def _endpoint_label(endpoint: Any) -> str:
+    ep = endpoint if isinstance(endpoint, dict) else {}
+    provider = str(ep.get("provider") or "").upper()
+    inst = str(ep.get("instance") or "default")
+    name = str(ep.get("playlist_name") or ep.get("name") or ep.get("playlist_id") or "-")
+    return f"{provider}:{inst} {name}" if provider else name
+
+
+def _mapping_source(mapping: dict[str, Any]) -> str:
+    src = mapping.get("source")
+    if isinstance(src, dict):
+        return _endpoint_label(src)
+    return str(mapping.get("source_endpoint") or mapping.get("source") or "-")
+
+
+def _mapping_targets(mapping: dict[str, Any]) -> str:
+    targets = mapping.get("targets")
+    if isinstance(targets, list) and targets:
+        return ", ".join(_endpoint_label(t) for t in targets if isinstance(t, dict))
+    target = mapping.get("target")
+    if isinstance(target, dict):
+        return _endpoint_label(target)
+    raw = mapping.get("target_endpoints")
+    if isinstance(raw, list):
+        return ", ".join(str(x) for x in raw)
+    return str(raw or mapping.get("target") or "-")
+
+
+def _mapping_payload(mapping: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": str(mapping.get("id") or ""),
+        "name": str(mapping.get("name") or ""),
+        "source_endpoint": str(mapping.get("source_endpoint") or ""),
+        "target_endpoints": list(mapping.get("target_endpoints") or []),
+        "ruleset_id": str(mapping.get("ruleset_id") or ""),
+        "membership": str(mapping.get("membership") or "managed_only"),
+        "order": str(mapping.get("order") or "ignore"),
+        "enabled": coerce_bool(mapping.get("enabled"), True),
+        "allow_mass_delete": coerce_bool(mapping.get("allow_mass_delete"), False),
+    }
+
+
+def _run_result(payload: dict[str, Any]) -> dict[str, Any]:
+    result = payload.get("result")
+    return dict(result) if isinstance(result, dict) else payload
+
+
+def _print_playlist_counts(state: Ctx, result: dict[str, Any]) -> None:
+    for key in ("planned_additions", "planned_removals", "added", "removed", "reordered", "skipped", "unresolved_count", "errors"):
+        if key in result:
+            state.out.info(f"{key}: {result.get(key)}")
+
+
+def _load_json_file(path: str) -> dict[str, Any]:
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise CLIError(f"Cannot read JSON from {path}: {exc}", exit_code=EXIT_USAGE) from exc
+    if not isinstance(data, dict):
+        raise CLIError("JSON file must contain an object", exit_code=EXIT_USAGE)
+    return data
+
+
+def _short_name(value: str, fallback: str) -> str:
+    text = str(value or fallback).strip()
+    cleaned = "".join(ch for ch in text if ch.isalnum() or ch in " _.'-&()").strip()
+    if not cleaned or not cleaned[0].isalnum():
+        cleaned = fallback
+    return cleaned[:10] or fallback[:10]
+
+
+def _resource_rows(state: Ctx, provider: str, instance: str) -> list[dict[str, Any]]:
+    params = {"provider": provider.strip().upper()}
+    if instance.strip():
+        params["instance"] = instance.strip()
+    return _rows(state.get("/api/playlists/resources", params=params), "resources", "items", "playlists")
+
+
+def _choose_resource(state: Ctx, provider: str, instance: str, prompt: str) -> str:
+    rows = _resource_rows(state, provider, instance)
+    state.out.table(
+        ["#", "ID", "NAME", "WRITE"],
+        [
+            [
+                str(idx),
+                str(row.get("id") or "-")[:24],
+                str(row.get("name") or row.get("title") or "-")[:40],
+                state_text(coerce_bool(row.get("writable") or row.get("can_add") or row.get("can_remove"), False), on="yes", off="no"),
+            ]
+            for idx, row in enumerate(rows, start=1)
+        ],
+        title=f"{provider.upper()} playlists",
+        empty="No playlists found.",
+    )
+    answer = str(typer.prompt(prompt) or "").strip()
+    if answer.isdigit():
+        pos = int(answer)
+        if 1 <= pos <= len(rows):
+            return str(rows[pos - 1].get("id") or "")
+    return answer
+
+
+def _post_endpoint(state: Ctx, body: dict[str, Any]) -> dict[str, Any]:
+    result = as_dict(state.post("/api/playlists/endpoints", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Endpoint rejected"))
+    return as_dict(result.get("endpoint"))
+
+
+def _post_mapping(state: Ctx, body: dict[str, Any]) -> dict[str, Any]:
+    result = as_dict(state.post("/api/playlists/mappings", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Mapping rejected"))
+    return result
 
 
 @playlist_app.command("overview")
@@ -95,11 +243,102 @@ def playlist_resources(
         [
             ("ID", lambda r: str(r.get("id") or r.get("key") or "-")[:24]),
             ("NAME", lambda r: str(r.get("name") or r.get("title") or "-")[:40]),
-            ("ITEMS", lambda r: str(r.get("count") or r.get("items") or "-")),
+            ("KIND", lambda r: str(r.get("kind") or r.get("playlist_type") or "-")),
+            ("WRITE", lambda r: state_text(coerce_bool(r.get("writable") or r.get("can_add") or r.get("can_remove"), False), on="yes", off="no")),
+            ("ITEMS", lambda r: str(r.get("count") or r.get("item_count") or r.get("items") or "-")),
         ],
         title=f"{provider.upper()} playlists",
         empty="No playlists there.",
     )
+
+
+@resource_app.command("list")
+def resource_list(
+    ctx: typer.Context,
+    provider: str = typer.Argument(..., help="Provider name."),
+    instance: str = typer.Option("", "--instance", "-i", help="Provider instance id."),
+) -> None:
+    """List provider playlist resources."""
+    playlist_resources(ctx, provider=provider, instance=instance)
+
+
+@resource_app.command("create")
+def resource_create(
+    ctx: typer.Context,
+    provider: str = typer.Argument(..., help="Provider name."),
+    name: str = typer.Option(..., "--name", "-n", help="Playlist name."),
+    media_type: str = typer.Option("playlist", "--type", help="Playlist media type."),
+    instance: str = typer.Option("default", "--instance", "-i", help="Provider instance id."),
+) -> None:
+    """Create a playlist at a provider."""
+    state: Ctx = ctx.obj
+    state.require_service("Creating a provider playlist")
+    result = as_dict(
+        state.post(
+            "/api/playlists/resources",
+            json_body={"provider": provider.strip().upper(), "instance": instance.strip() or "default", "name": name, "media_type": media_type},
+        )
+    )
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Create rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    resource = as_dict(result.get("resource"))
+    state.out.success(f"Created {_endpoint_label(resource)} ({resource.get('id') or result.get('playlist_id') or '-'})")
+
+
+@resource_app.command("rename")
+def resource_rename(
+    ctx: typer.Context,
+    provider: str = typer.Argument(..., help="Provider name."),
+    playlist_id: str = typer.Argument(..., help="Provider playlist id."),
+    name: str = typer.Option(..., "--name", "-n", help="New playlist name."),
+    instance: str = typer.Option("default", "--instance", "-i", help="Provider instance id."),
+) -> None:
+    """Rename a provider playlist."""
+    state: Ctx = ctx.obj
+    state.require_service("Renaming a provider playlist")
+    result = as_dict(
+        state.patch(
+            f"/api/playlists/resources/{playlist_id}",
+            json_body={"provider": provider.strip().upper(), "instance": instance.strip() or "default", "name": name},
+        )
+    )
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Rename rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    resource = as_dict(result.get("resource"))
+    state.out.success(f"Renamed playlist {playlist_id} to {resource.get('name') or name}.")
+
+
+@resource_app.command("delete")
+def resource_delete(
+    ctx: typer.Context,
+    provider: str = typer.Argument(..., help="Provider name."),
+    playlist_id: str = typer.Argument(..., help="Provider playlist id."),
+    instance: str = typer.Option("default", "--instance", "-i", help="Provider instance id."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Delete a provider playlist."""
+    state: Ctx = ctx.obj
+    state.require_service("Deleting a provider playlist")
+    if not yes and not typer.confirm(f"Delete {provider.upper()} playlist {playlist_id}?", default=False):
+        raise CLIError("Cancelled", exit_code=0)
+    result = as_dict(
+        state.delete(
+            f"/api/playlists/resources/{playlist_id}",
+            params={"provider": provider.strip().upper(), "instance": instance.strip() or "default"},
+        )
+    )
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Delete rejected"))
+    if state.out.json_mode:
+        state.out.data(result or {"ok": True})
+        return
+    state.out.success(f"Deleted {provider.upper()} playlist {playlist_id}.")
 
 
 @playlist_app.command("activity")
@@ -122,6 +361,124 @@ def playlist_activity(ctx: typer.Context) -> None:
         title="Playlist activity",
         empty="No playlist runs yet.",
     )
+
+
+@playlist_app.command("setup")
+def playlist_setup(
+    ctx: typer.Context,
+    source_provider: str = typer.Option("", "--source-provider", help="Source provider."),
+    source_instance: str = typer.Option("default", "--source-instance", help="Source provider instance."),
+    source_playlist: str = typer.Option("", "--source-playlist", help="Source provider playlist id."),
+    target_provider: str = typer.Option("", "--target-provider", help="Target provider."),
+    target_instance: str = typer.Option("default", "--target-instance", help="Target provider instance."),
+    target_playlist: list[str] = typer.Option([], "--target-playlist", help="Target provider playlist id. Repeatable."),
+    create_target: str = typer.Option("", "--create-target", help="Create this target playlist on first run."),
+    name: str = typer.Option("", "--name", "-n", help="Mapping name."),
+    ruleset: str = typer.Option("", "--ruleset", "-r", help="Ruleset id, for example trakt_free_account."),
+    membership: str = typer.Option("managed_only", "--membership", help="managed_only or mirror."),
+    order: str = typer.Option("ignore", "--order", help="ignore or preserve."),
+    run_now: bool = typer.Option(False, "--run-now", help="Run the mapping after setup."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview the mapping after setup instead of running."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+) -> None:
+    """Guided setup for a playlist mapping."""
+    state: Ctx = ctx.obj
+    state.require_service("Setting up playlists")
+
+    src_provider = source_provider.strip().upper() or str(typer.prompt("Source provider", default="TRAKT") or "TRAKT").strip().upper()
+    src_instance = source_instance.strip() or "default"
+    src_playlist = source_playlist.strip() or _choose_resource(state, src_provider, src_instance, "Source playlist id or number")
+
+    dst_provider = target_provider.strip().upper() or str(typer.prompt("Target provider", default="PLEX") or "PLEX").strip().upper()
+    dst_instance = target_instance.strip() or "default"
+    targets = [str(t).strip() for t in target_playlist if str(t).strip()]
+    pending_name = create_target.strip()
+    if not targets and not pending_name:
+        state.out.print("Choose an existing target playlist, or enter +Name to create it on first run.")
+        answer = _choose_resource(state, dst_provider, dst_instance, "Target playlist id, number, or +Name")
+        if answer.startswith("+"):
+            pending_name = answer[1:].strip()
+        else:
+            targets = [answer]
+    if targets and pending_name:
+        raise CLIError("Use either --target-playlist or --create-target, not both.", exit_code=EXIT_USAGE)
+    if not targets and not pending_name:
+        raise CLIError("A target playlist or --create-target name is required", exit_code=EXIT_USAGE)
+
+    map_name = _short_name(name or pending_name or src_playlist, "Playlist")
+    src_endpoint_body = {
+        "name": _short_name(f"{map_name}Src", "Src"),
+        "provider": src_provider,
+        "instance": src_instance,
+        "playlist_id": src_playlist,
+    }
+    target_endpoint_bodies: list[dict[str, Any]] = []
+    if pending_name:
+        target_endpoint_bodies.append(
+            {
+                "name": _short_name(f"{map_name}Dst", "Dst"),
+                "provider": dst_provider,
+                "instance": dst_instance,
+                "playlist_id": "",
+                "playlist_name": pending_name,
+                "pending_create": {"name": pending_name, "media_type": "playlist"},
+            }
+        )
+    else:
+        for idx, playlist_id in enumerate(targets, start=1):
+            target_endpoint_bodies.append(
+                {
+                    "name": _short_name(f"{map_name}{idx}", "Target"),
+                    "provider": dst_provider,
+                    "instance": dst_instance,
+                    "playlist_id": playlist_id,
+                }
+            )
+
+    mapping_body = {
+        "name": map_name,
+        "source_endpoint": "<created>",
+        "target_endpoints": ["<created>"],
+        "ruleset_id": ruleset.strip(),
+        "membership": membership.strip().lower() or "managed_only",
+        "order": order.strip().lower() or "ignore",
+        "enabled": True,
+    }
+    if not yes:
+        state.out.kv(
+            [
+                ("Source", f"{src_provider}:{src_instance} {src_playlist}"),
+                ("Target", f"{dst_provider}:{dst_instance} {pending_name or ', '.join(targets)}"),
+                ("Mapping", map_name),
+                ("Ruleset", ruleset.strip() or "direct"),
+                ("Membership", mapping_body["membership"]),
+                ("Order", mapping_body["order"]),
+            ],
+            title="Playlist setup",
+        )
+        if not typer.confirm("Create endpoint(s) and mapping?", default=True):
+            raise CLIError("Cancelled", exit_code=0)
+
+    src_endpoint = _post_endpoint(state, src_endpoint_body)
+    target_endpoints = [_post_endpoint(state, body) for body in target_endpoint_bodies]
+    mapping_body["source_endpoint"] = str(src_endpoint.get("id") or "")
+    mapping_body["target_endpoints"] = [str(ep.get("id") or "") for ep in target_endpoints if ep.get("id")]
+    result = _post_mapping(state, mapping_body)
+    mapping = as_dict(result.get("mapping"))
+    mapping_id = str(mapping.get("id") or "")
+
+    if state.out.json_mode:
+        state.out.data({"ok": True, "source_endpoint": src_endpoint, "target_endpoints": target_endpoints, **result})
+        return
+
+    state.out.success(f"Playlist mapping created: {mapping_id or '-'}")
+    if result.get("pair_id"):
+        state.out.info(f"Managed pair: {result.get('pair_id')}")
+
+    if dry_run and mapping_id:
+        mapping_preview(ctx, mapping_id)
+    if run_now and mapping_id:
+        mapping_run(ctx, mapping_id, dry_run=False)
 
 
 @endpoint_app.command("list")
@@ -149,12 +506,27 @@ def endpoint_list(ctx: typer.Context) -> None:
 @endpoint_app.command("add")
 def endpoint_add(
     ctx: typer.Context,
+    provider: str = typer.Argument("", help="Provider name, for example PLEX."),
+    playlist_id: str = typer.Argument("", help="Provider playlist id. Omit with --create."),
+    name: str = typer.Option("", "--name", "-n", help="Short endpoint name."),
+    instance: str = typer.Option("default", "--instance", "-i", help="Provider instance id."),
+    create: str = typer.Option("", "--create", help="Create this provider playlist and bind it."),
+    media_type: str = typer.Option("", "--type", help="Created playlist media type."),
     field: list[str] = typer.Option([], "--field", "-F", help="Endpoint setting as key=value. Repeatable."),
 ) -> None:
     """Add a playlist endpoint."""
     state: Ctx = ctx.obj
     state.require_service("Adding a playlist endpoint")
     body = _fields(field)
+    _put_if(provider, body, "provider", provider.strip().upper())
+    _put_if(playlist_id, body, "playlist_id", playlist_id.strip())
+    _put_if(name, body, "name", name.strip())
+    _put_if(instance, body, "instance", instance.strip() or "default")
+    if create.strip():
+        body["create"] = True
+        body["create_name"] = create.strip()
+        body.setdefault("name", create.strip()[:10])
+    _put_if(media_type, body, "media_type", media_type.strip().lower())
     if not body:
         raise CLIError("An endpoint needs fields", hint="For example --field provider=PLEX --field name=Favourites", exit_code=EXIT_USAGE)
     result = as_dict(state.post("/api/playlists/endpoints", json_body=body))
@@ -163,7 +535,42 @@ def endpoint_add(
     if state.out.json_mode:
         state.out.data(result)
         return
-    state.out.success(f"Endpoint added{': ' + str(result.get('id')) if result.get('id') else '.'}")
+    endpoint = as_dict(result.get("endpoint"))
+    state.out.success(f"Endpoint {'created' if result.get('created') else 'saved'}: {endpoint.get('id') or '-'}")
+
+
+@endpoint_app.command("edit")
+def endpoint_edit(
+    ctx: typer.Context,
+    endpoint_id: str = typer.Argument(..., help="Endpoint id or unique prefix."),
+    name: str = typer.Option("", "--name", "-n", help="Endpoint name."),
+    provider: str = typer.Option("", "--provider", help="Provider name."),
+    playlist_id: str = typer.Option("", "--playlist", help="Provider playlist id."),
+    playlist_name: str = typer.Option("", "--playlist-name", help="Provider playlist display name."),
+    instance: str = typer.Option("", "--instance", "-i", help="Provider instance id."),
+    media_type: str = typer.Option("", "--type", help="Playlist media type."),
+    field: list[str] = typer.Option([], "--field", "-F", help="Endpoint setting as key=value. Repeatable."),
+) -> None:
+    """Edit a playlist endpoint."""
+    state: Ctx = ctx.obj
+    state.require_service("Editing a playlist endpoint")
+    endpoint = _find_id(_endpoint_items(state), endpoint_id, "endpoint")
+    body = {**endpoint, **_fields(field)}
+    body["id"] = str(endpoint.get("id") or "")
+    _put_if(name, body, "name", name.strip())
+    _put_if(provider, body, "provider", provider.strip().upper())
+    _put_if(playlist_id, body, "playlist_id", playlist_id.strip())
+    _put_if(playlist_name, body, "playlist_name", playlist_name.strip())
+    _put_if(instance, body, "instance", instance.strip() or "default")
+    _put_if(media_type, body, "media_type", media_type.strip().lower())
+    result = as_dict(state.post("/api/playlists/endpoints", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Update rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    saved = as_dict(result.get("endpoint"))
+    state.out.success(f"Endpoint saved: {saved.get('id') or endpoint.get('id')}")
 
 
 @endpoint_app.command("sync")
@@ -221,8 +628,9 @@ def mapping_list(
         [
             ("ID", lambda r: str(r.get("id") or "-")),
             ("NAME", lambda r: str(r.get("name") or r.get("label") or "-")[:30]),
-            ("SOURCE", lambda r: str(r.get("source") or "-")),
-            ("TARGET", lambda r: str(r.get("target") or "-")),
+            ("SOURCE", _mapping_source),
+            ("TARGET", _mapping_targets),
+            ("PAIR", lambda r: str(r.get("assigned_pair") or "-")),
             ("ENABLED", lambda r: state_text(coerce_bool(r.get("enabled"), True), on="yes", off="no")),
         ],
         title="Playlist mappings",
@@ -233,12 +641,31 @@ def mapping_list(
 @mapping_app.command("add")
 def mapping_add(
     ctx: typer.Context,
+    source: str = typer.Option("", "--source", "-s", help="Source endpoint id."),
+    target: list[str] = typer.Option([], "--target", "-t", help="Target endpoint id. Repeatable."),
+    name: str = typer.Option("", "--name", "-n", help="Mapping name."),
+    ruleset: str = typer.Option("", "--ruleset", "-r", help="Ruleset id for partitioned or bidirectional mappings."),
+    membership: str = typer.Option("", "--membership", help="managed_only or mirror."),
+    order: str = typer.Option("", "--order", help="ignore or preserve."),
+    disabled: bool = typer.Option(False, "--disabled", help="Create disabled."),
+    allow_mass_delete: bool = typer.Option(False, "--allow-mass-delete", help="Allow mirror-style removals at larger scale."),
     field: list[str] = typer.Option([], "--field", "-F", help="Mapping setting as key=value. Repeatable."),
 ) -> None:
     """Add a playlist mapping."""
     state: Ctx = ctx.obj
     state.require_service("Adding a playlist mapping")
     body = _fields(field)
+    _put_if(source, body, "source_endpoint", source.strip())
+    if target:
+        body["target_endpoints"] = [str(t).strip() for t in target if str(t).strip()]
+    _put_if(name, body, "name", name.strip())
+    _put_if(ruleset, body, "ruleset_id", ruleset.strip())
+    _put_if(membership, body, "membership", membership.strip().lower())
+    _put_if(order, body, "order", order.strip().lower())
+    if disabled:
+        body["enabled"] = False
+    if allow_mass_delete:
+        body["allow_mass_delete"] = True
     if not body:
         raise CLIError("A mapping needs fields", hint="See 'cw playlist endpoint list' for ids", exit_code=EXIT_USAGE)
     result = as_dict(state.post("/api/playlists/mappings", json_body=body))
@@ -247,7 +674,77 @@ def mapping_add(
     if state.out.json_mode:
         state.out.data(result)
         return
-    state.out.success(f"Mapping added{': ' + str(result.get('id')) if result.get('id') else '.'}")
+    mapping = as_dict(result.get("mapping"))
+    state.out.success(f"Mapping {'created' if result.get('created') else 'saved'}: {mapping.get('id') or '-'}")
+    if result.get("pair_id"):
+        state.out.info(f"Managed pair: {result.get('pair_id')}")
+
+
+@mapping_app.command("edit")
+def mapping_edit(
+    ctx: typer.Context,
+    mapping_id: str = typer.Argument(..., help="Mapping id or unique prefix."),
+    source: str = typer.Option("", "--source", "-s", help="Source endpoint id."),
+    target: list[str] = typer.Option([], "--target", "-t", help="Replace target endpoint list. Repeatable."),
+    name: str = typer.Option("", "--name", "-n", help="Mapping name."),
+    ruleset: str | None = typer.Option(None, "--ruleset", "-r", help="Ruleset id. Pass empty to clear."),
+    membership: str = typer.Option("", "--membership", help="managed_only or mirror."),
+    order: str = typer.Option("", "--order", help="ignore or preserve."),
+    allow_mass_delete: bool | None = typer.Option(None, "--allow-mass-delete/--no-allow-mass-delete", help="Allow or block larger removals."),
+    field: list[str] = typer.Option([], "--field", "-F", help="Mapping setting as key=value. Repeatable."),
+) -> None:
+    """Edit a playlist mapping."""
+    state: Ctx = ctx.obj
+    state.require_service("Editing a playlist mapping")
+    mapping = _find_id(_mapping_items(state), mapping_id, "mapping")
+    body = {**_mapping_payload(mapping), **_fields(field)}
+    _put_if(source, body, "source_endpoint", source.strip())
+    if target:
+        body["target_endpoints"] = [str(t).strip() for t in target if str(t).strip()]
+    _put_if(name, body, "name", name.strip())
+    if ruleset is not None:
+        body["ruleset_id"] = str(ruleset or "").strip()
+    _put_if(membership, body, "membership", membership.strip().lower())
+    _put_if(order, body, "order", order.strip().lower())
+    if allow_mass_delete is not None:
+        body["allow_mass_delete"] = bool(allow_mass_delete)
+    result = as_dict(state.post("/api/playlists/mappings", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Update rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    saved = as_dict(result.get("mapping"))
+    state.out.success(f"Mapping saved: {saved.get('id') or mapping.get('id')}")
+    if result.get("pair_id"):
+        state.out.info(f"Managed pair: {result.get('pair_id')}")
+
+
+@mapping_app.command("enable")
+def mapping_enable(ctx: typer.Context, mapping_id: str = typer.Argument(..., help="Mapping id or unique prefix.")) -> None:
+    """Enable a playlist mapping."""
+    _set_mapping_enabled(ctx, mapping_id, True)
+
+
+@mapping_app.command("disable")
+def mapping_disable(ctx: typer.Context, mapping_id: str = typer.Argument(..., help="Mapping id or unique prefix.")) -> None:
+    """Disable a playlist mapping."""
+    _set_mapping_enabled(ctx, mapping_id, False)
+
+
+def _set_mapping_enabled(ctx: typer.Context, mapping_id: str, enabled: bool) -> None:
+    state: Ctx = ctx.obj
+    state.require_service("Changing a playlist mapping")
+    mapping = _find_id(_mapping_items(state), mapping_id, "mapping")
+    body = _mapping_payload(mapping)
+    body["enabled"] = bool(enabled)
+    result = as_dict(state.post("/api/playlists/mappings", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Update rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    state.out.success(f"{'Enabled' if enabled else 'Disabled'} mapping {body['id']}.")
 
 
 @mapping_app.command("run")
@@ -266,9 +763,7 @@ def mapping_run(
         state.out.data(result)
         return
     state.out.success("Dry run finished." if dry_run else "Mapping run finished.")
-    for key in ("added", "removed", "updated", "skipped", "errors"):
-        if key in result:
-            state.out.info(f"{key}: {result.get(key)}")
+    _print_playlist_counts(state, _run_result(result))
 
 
 @mapping_app.command("preview")
@@ -282,16 +777,10 @@ def mapping_preview(
     if state.out.json_mode:
         state.out.data(payload)
         return
-    rows = _rows(payload, "items", "preview")
-    state.out.records(
-        rows[:50],
-        [
-            ("TITLE", lambda r: str(r.get("title") or r.get("key") or "-")[:44]),
-            ("TYPE", lambda r: str(r.get("type") or "-")),
-            ("ACTION", lambda r: str(r.get("action") or r.get("change") or "-")),
-        ],
+    preview = as_dict(as_dict(payload).get("preview"))
+    state.out.kv(
+        [(key, value) for key, value in preview.items() if not isinstance(value, (dict, list))],
         title=f"Preview {mapping_id}",
-        empty="Nothing would change.",
     )
 
 
@@ -306,7 +795,7 @@ def mapping_result(
     if state.out.json_mode:
         state.out.data(payload)
         return
-    block = as_dict(payload)
+    block = _run_result(as_dict(payload))
     state.out.kv(
         [(key, value) for key, value in block.items() if not isinstance(value, (dict, list))],
         title=f"Mapping {mapping_id}",
@@ -371,6 +860,61 @@ def ruleset_show(ctx: typer.Context, ruleset_id: str = typer.Argument(..., help=
     )
 
 
+@ruleset_app.command("add")
+def ruleset_add(
+    ctx: typer.Context,
+    file: str = typer.Argument(..., help="JSON file containing a ruleset object."),
+) -> None:
+    """Add or update a ruleset from JSON."""
+    state: Ctx = ctx.obj
+    state.require_service("Saving a ruleset")
+    result = as_dict(state.post("/api/playlists/rulesets", json_body=_load_json_file(file)))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Ruleset rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    ruleset = as_dict(result.get("ruleset"))
+    state.out.success(f"Ruleset {'created' if result.get('created') else 'saved'}: {ruleset.get('id') or '-'}")
+
+
+@ruleset_app.command("validate")
+def ruleset_validate(
+    ctx: typer.Context,
+    file: str = typer.Argument(..., help="JSON file containing a ruleset object."),
+) -> None:
+    """Validate a ruleset JSON file."""
+    state: Ctx = ctx.obj
+    result = as_dict(state.post("/api/playlists/rulesets/validate", json_body=_load_json_file(file)))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Ruleset is invalid"), exit_code=EXIT_USAGE)
+    ruleset = as_dict(result.get("ruleset"))
+    state.out.success(f"Ruleset is valid: {ruleset.get('id') or ruleset.get('name') or file}")
+
+
+@ruleset_app.command("clone")
+def ruleset_clone(
+    ctx: typer.Context,
+    ruleset_id: str = typer.Argument(..., help="Ruleset id."),
+    name: str = typer.Option("", "--name", "-n", help="Name for the cloned ruleset."),
+) -> None:
+    """Clone a ruleset."""
+    state: Ctx = ctx.obj
+    state.require_service("Cloning a ruleset")
+    body = {"name": name} if name.strip() else {}
+    result = as_dict(state.post(f"/api/playlists/rulesets/{ruleset_id}/clone", json_body=body))
+    if result.get("ok") is False:
+        raise CLIError(error_text(result, "Clone rejected"))
+    if state.out.json_mode:
+        state.out.data(result)
+        return
+    ruleset = as_dict(result.get("ruleset"))
+    state.out.success(f"Ruleset cloned: {ruleset.get('id') or '-'}")
+
+
 @ruleset_app.command("delete")
 def ruleset_delete(
     ctx: typer.Context,
@@ -392,6 +936,7 @@ def ruleset_delete(
 
 
 def register(app: typer.Typer) -> None:
+    playlist_app.add_typer(resource_app, name="resource")
     playlist_app.add_typer(endpoint_app, name="endpoint")
     playlist_app.add_typer(mapping_app, name="mapping")
     playlist_app.add_typer(ruleset_app, name="ruleset")

--- a/cli/commands/scheduler.py
+++ b/cli/commands/scheduler.py
@@ -3,16 +3,40 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import copy
+import re
 from typing import Any
 
 import typer
 
 from .._context import Ctx
-from .._errors import CLIError
+from .._errors import EXIT_NOT_FOUND, EXIT_USAGE, CLIError
 from .._render import state_text
-from .._util import as_dict, coerce_bool, error_text, fmt_rel, fmt_ts
+from .._util import as_dict, coerce_bool, error_text, find_pair, fmt_rel, fmt_ts, pair_label
 
 scheduler_app = typer.Typer(help="Inspect and drive the sync scheduler.", no_args_is_help=True)
+
+_HHMM_RE = re.compile(r"^(?:[01]\d|2[0-3]):[0-5]\d$")
+_DAY_ALIASES = {
+    "mon": 1,
+    "monday": 1,
+    "tue": 2,
+    "tues": 2,
+    "tuesday": 2,
+    "wed": 3,
+    "wednesday": 3,
+    "thu": 4,
+    "thur": 4,
+    "thurs": 4,
+    "thursday": 4,
+    "fri": 5,
+    "friday": 5,
+    "sat": 6,
+    "saturday": 6,
+    "sun": 7,
+    "sunday": 7,
+}
+_DAY_NAMES = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
 
 
 def _status(state: Ctx) -> dict[str, Any]:
@@ -23,6 +47,197 @@ def _status(state: Ctx) -> dict[str, Any]:
 def _config(state: Ctx) -> dict[str, Any]:
     payload = state.get("/api/scheduling")
     return as_dict(payload)
+
+
+def _pairs(state: Ctx) -> list[dict[str, Any]]:
+    payload = state.get("/api/pairs")
+    if isinstance(payload, dict) and payload.get("ok") is False:
+        raise CLIError(error_text(payload, "Cannot read pairs"))
+    if not isinstance(payload, list):
+        return []
+    return [p for p in payload if isinstance(p, dict)]
+
+
+def _save_config(state: Ctx, scfg: dict[str, Any]) -> dict[str, Any]:
+    state.require_service("Changing the scheduler")
+    payload = state.post("/api/scheduling", json_body=scfg)
+    if isinstance(payload, dict) and payload.get("ok") is False:
+        raise CLIError(error_text(payload, "Scheduler update rejected"))
+    return as_dict(payload)
+
+
+def _advanced(scfg: dict[str, Any]) -> dict[str, Any]:
+    adv = scfg.get("advanced")
+    if not isinstance(adv, dict):
+        adv = {}
+        scfg["advanced"] = adv
+    jobs = adv.get("jobs")
+    if not isinstance(jobs, list):
+        adv["jobs"] = []
+    return adv
+
+
+def _adv_jobs(scfg: dict[str, Any]) -> list[dict[str, Any]]:
+    adv = _advanced(scfg)
+    return [j for j in adv.get("jobs", []) if isinstance(j, dict)]
+
+
+def _replace_adv_jobs(scfg: dict[str, Any], jobs: list[dict[str, Any]]) -> None:
+    _advanced(scfg)["jobs"] = jobs
+
+
+def _validate_time(value: str) -> str:
+    text = str(value or "").strip()
+    if not _HHMM_RE.fullmatch(text):
+        raise CLIError(f"Invalid time '{value}'", hint="Use 24-hour HH:MM, for example 03:30.", exit_code=EXIT_USAGE)
+    return text
+
+
+def _parse_hours(value: str) -> int:
+    text = str(value or "").strip().lower()
+    match = re.fullmatch(r"(\d+)\s*h(?:ours?)?", text)
+    if not match:
+        match = re.fullmatch(r"(\d+)", text)
+    if not match:
+        raise CLIError(f"Invalid hour interval '{value}'", hint="Use a value like 6h or 6.", exit_code=EXIT_USAGE)
+    hours = int(match.group(1))
+    if hours < 1:
+        raise CLIError("Hour interval must be at least 1.", exit_code=EXIT_USAGE)
+    return hours
+
+
+def _parse_minutes(value: str) -> int:
+    text = str(value or "").strip().lower()
+    match = re.fullmatch(r"(\d+)\s*m(?:in(?:utes?)?)?", text)
+    if not match:
+        match = re.fullmatch(r"(\d+)", text)
+    if not match:
+        raise CLIError(f"Invalid minute interval '{value}'", hint="Use a value like 45m or 45.", exit_code=EXIT_USAGE)
+    minutes = int(match.group(1))
+    if minutes < 15:
+        raise CLIError("Custom interval must be at least 15 minutes.", exit_code=EXIT_USAGE)
+    return minutes
+
+
+def _parse_days(value: str) -> list[int]:
+    text = str(value or "").strip().lower()
+    if not text or text in {"all", "daily", "everyday", "every-day", "every day"}:
+        return []
+    if text in {"weekday", "weekdays"}:
+        return [1, 2, 3, 4, 5]
+    if text in {"weekend", "weekends"}:
+        return [6, 7]
+    out: list[int] = []
+    for chunk in re.split(r"[, ]+", text):
+        if not chunk:
+            continue
+        if re.fullmatch(r"[1-7]", chunk):
+            day = int(chunk)
+        elif chunk in _DAY_ALIASES:
+            day = _DAY_ALIASES[chunk]
+        else:
+            raise CLIError(
+                f"Unknown day '{chunk}'",
+                hint="Use all, weekdays, weekends, or comma-separated names like mon,wed,fri.",
+                exit_code=EXIT_USAGE,
+            )
+        if day not in out:
+            out.append(day)
+    return out
+
+
+def _days_text(days: Any) -> str:
+    if not isinstance(days, list) or not days:
+        return "every day"
+    labels = []
+    for day in days:
+        try:
+            idx = int(day) - 1
+        except Exception:
+            continue
+        if 0 <= idx < len(_DAY_NAMES):
+            labels.append(_DAY_NAMES[idx])
+    return ", ".join(labels) if labels else "every day"
+
+
+def _slug(value: str) -> str:
+    text = re.sub(r"[^a-z0-9]+", "_", str(value or "").strip().lower())
+    return re.sub(r"_+", "_", text).strip("_") or "job"
+
+
+def _unique_job_id(existing: list[dict[str, Any]], base: str) -> str:
+    known = {str(j.get("id") or "") for j in existing}
+    if base not in known:
+        return base
+    i = 2
+    while f"{base}_{i}" in known:
+        i += 1
+    return f"{base}_{i}"
+
+
+def _find_job(jobs: list[dict[str, Any]], needle: str) -> dict[str, Any]:
+    wanted = str(needle or "").strip()
+    if not wanted:
+        raise CLIError("A job id is required", exit_code=EXIT_USAGE)
+    exact = [j for j in jobs if str(j.get("id") or "") == wanted]
+    if exact:
+        return exact[0]
+    lowered = wanted.lower()
+    partial = [j for j in jobs if str(j.get("id") or "").lower().startswith(lowered)]
+    if len(partial) == 1:
+        return partial[0]
+    if len(partial) > 1:
+        ids = ", ".join(str(j.get("id") or "") for j in partial[:6])
+        raise CLIError(f"Job id '{wanted}' is ambiguous", hint=f"Matches: {ids}", exit_code=EXIT_USAGE)
+    raise CLIError(f"No scheduler job matches '{wanted}'", hint="Run 'cw scheduler list' to see jobs.", exit_code=EXIT_NOT_FOUND)
+
+
+def _job_table_rows(scfg: dict[str, Any], pairs: list[dict[str, Any]]) -> list[list[Any]]:
+    pair_by_id = {str(p.get("id") or ""): p for p in pairs}
+    rows: list[list[Any]] = []
+    for job in _adv_jobs(scfg):
+        pair_id = str(job.get("pair_id") or "")
+        pair = pair_by_id.get(pair_id)
+        rows.append(
+            [
+                str(job.get("id") or ""),
+                pair_label(pair) if pair else pair_id or "-",
+                str(job.get("at") or "-"),
+                _days_text(job.get("days")),
+                state_text(job.get("active", True) is not False, on="active", off="paused"),
+                str(job.get("after") or "-"),
+            ]
+        )
+    return rows
+
+
+def _print_preview(state: Ctx, scfg: dict[str, Any], *, title: str = "Scheduler change") -> None:
+    if state.out.json_mode:
+        state.out.data({"dry_run": True, "scheduling": scfg})
+        return
+    state.out.kv(
+        [
+            ("Standard enabled", state_text(coerce_bool(scfg.get("enabled"), False), on="yes", off="no")),
+            ("Mode", _mode(scfg)),
+            ("Advanced enabled", state_text(coerce_bool(as_dict(scfg.get("advanced")).get("enabled"), False), on="yes", off="no")),
+            ("Advanced jobs", str(len(_adv_jobs(scfg)))),
+        ],
+        title=title,
+    )
+
+
+def _finish_save(state: Ctx, scfg: dict[str, Any], *, dry_run: bool, message: str) -> None:
+    if dry_run:
+        _print_preview(state, scfg)
+        return
+    payload = _save_config(state, scfg)
+    nxt = int(payload.get("next_run_at") or 0)
+    if state.out.json_mode:
+        state.out.data({"ok": True, "next_run_at": nxt, "scheduling": scfg})
+        return
+    state.out.success(message)
+    if nxt:
+        state.out.info(f"Next run {fmt_ts(nxt)} ({fmt_rel(nxt)})")
 
 
 def _mode(scfg: dict[str, Any]) -> str:
@@ -41,11 +256,16 @@ def _render(state: Ctx, status: dict[str, Any]) -> None:
         state.out.data(status)
         return
     scfg = as_dict(status.get("config"))
+    advanced = as_dict(scfg.get("advanced"))
+    standard_enabled = coerce_bool(scfg.get("enabled"), False)
+    advanced_enabled = coerce_bool(advanced.get("enabled"), False)
     nxt = int(status.get("next_run_at") or 0)
     warnings = status.get("scheduling_warnings") or []
     state.out.kv(
         [
-            ("Enabled", state_text(coerce_bool(scfg.get("enabled"), False), on="yes", off="no")),
+            ("Enabled", state_text(standard_enabled or advanced_enabled, on="yes", off="no")),
+            ("Standard", state_text(standard_enabled, on="on", off="off")),
+            ("Advanced", state_text(advanced_enabled, on="on", off="off")),
             ("Worker", state_text(coerce_bool(status.get("running"), False), on="running", off="stopped")),
             ("Mode", _mode(scfg)),
             ("Next run", f"{fmt_ts(nxt)}  ({fmt_rel(nxt)})" if nxt else "not scheduled"),
@@ -85,6 +305,58 @@ def scheduler_next(ctx: typer.Context) -> None:
         state.out.info("No run is scheduled.")
         return
     state.out.raw(f"{fmt_ts(nxt)}  ({fmt_rel(nxt)})")
+
+
+@scheduler_app.command("list")
+def scheduler_list(ctx: typer.Context) -> None:
+    """List advanced scheduler jobs."""
+    state: Ctx = ctx.obj
+    scfg = _config(state)
+    pairs = _pairs(state)
+    if state.out.json_mode:
+        state.out.data({"advanced_enabled": coerce_bool(as_dict(scfg.get("advanced")).get("enabled"), False), "jobs": _adv_jobs(scfg)})
+        return
+    state.out.table(
+        ["ID", "PAIR", "TIME", "DAYS", "STATE", "AFTER"],
+        _job_table_rows(scfg, pairs),
+        title="Advanced scheduler jobs",
+        empty="No advanced scheduler jobs configured.",
+    )
+
+
+@scheduler_app.command("set")
+def scheduler_set(
+    ctx: typer.Context,
+    mode: str = typer.Argument(..., help="hourly, every, daily, or interval."),
+    value: str = typer.Argument("", help="Interval or time, for example 6h, 03:30, or 45m."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview the change without saving."),
+) -> None:
+    """Configure the standard scheduler without editing JSON."""
+    state: Ctx = ctx.obj
+    scfg = copy.deepcopy(_config(state))
+    wanted = str(mode or "").strip().lower().replace("-", "_")
+    if wanted in {"hourly", "hour"}:
+        scfg["enabled"] = True
+        scfg["mode"] = "hourly"
+        scfg["every_n_hours"] = 1
+    elif wanted in {"every", "every_n_hours"}:
+        hours = _parse_hours(value)
+        scfg["enabled"] = True
+        scfg["mode"] = "hourly" if hours == 1 else "every_n_hours"
+        scfg["every_n_hours"] = hours
+    elif wanted in {"daily", "daily_time", "at"}:
+        scfg["enabled"] = True
+        scfg["mode"] = "daily_time"
+        scfg["daily_time"] = _validate_time(value)
+    elif wanted in {"interval", "custom", "custom_interval"}:
+        scfg["enabled"] = True
+        scfg["mode"] = "custom_interval"
+        scfg["custom_interval_minutes"] = _parse_minutes(value)
+    else:
+        raise CLIError(f"Unknown scheduler mode '{mode}'", hint="Use hourly, every, daily, or interval.", exit_code=EXIT_USAGE)
+
+    _advanced(scfg)["enabled"] = False
+    _finish_save(state, scfg, dry_run=dry_run, message="Standard scheduler configured.")
 
 
 @scheduler_app.command("run-now")
@@ -143,6 +415,228 @@ def _set_enabled(ctx: typer.Context, enabled: bool) -> None:
     state.out.success(f"Scheduler {'enabled' if enabled else 'disabled'}.")
     if enabled and nxt:
         state.out.info(f"Next run {fmt_ts(nxt)} ({fmt_rel(nxt)})")
+
+
+@scheduler_app.command("add")
+def scheduler_add(
+    ctx: typer.Context,
+    pair_id: str = typer.Argument(..., help="Sync pair id, prefix, label, or list number."),
+    at: list[str] = typer.Option([], "--at", "-t", help="Run time in HH:MM. Repeat for multiple daily runs."),
+    days: str = typer.Option("all", "--days", help="all, weekdays, weekends, or names like mon,wed,fri."),
+    job_id: str = typer.Option("", "--id", help="Job id. Only allowed with one --at."),
+    after: str = typer.Option("", "--after", help="Run after another due job id."),
+    paused: bool = typer.Option(False, "--paused", help="Create the job paused."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview the change without saving."),
+) -> None:
+    """Add one or more advanced pair jobs."""
+    state: Ctx = ctx.obj
+    if not at:
+        raise CLIError("At least one --at time is required", hint="Example: cw scheduler add PAIR_ID --at 00:00 --at 12:00", exit_code=EXIT_USAGE)
+    times = [_validate_time(item) for item in at]
+    if len(times) > 1 and job_id.strip():
+        raise CLIError("--id can only be used when adding one job", exit_code=EXIT_USAGE)
+
+    pair = find_pair(_pairs(state), pair_id)
+    resolved_pair_id = str(pair.get("id") or "")
+    scfg = copy.deepcopy(_config(state))
+    adv = _advanced(scfg)
+    adv["enabled"] = True
+    jobs = _adv_jobs(scfg)
+    parsed_days = _parse_days(days)
+    created: list[dict[str, Any]] = []
+    for time_text in times:
+        base_id = job_id.strip() or f"{_slug(resolved_pair_id)}_{time_text.replace(':', '')}"
+        jid = _unique_job_id(jobs, base_id)
+        job = {
+            "id": jid,
+            "pair_id": resolved_pair_id,
+            "at": time_text,
+            "days": parsed_days,
+            "after": after.strip() or None,
+            "active": not paused,
+        }
+        jobs.append(job)
+        created.append(job)
+    _replace_adv_jobs(scfg, jobs)
+
+    if dry_run:
+        _print_preview(state, scfg, title="Scheduler add preview")
+        return
+    payload = _save_config(state, scfg)
+    if state.out.json_mode:
+        state.out.data({"ok": True, "created": created, "next_run_at": int(payload.get("next_run_at") or 0)})
+        return
+    state.out.success(f"Added {len(created)} advanced scheduler job(s) for {pair_label(pair)}.")
+    nxt = int(payload.get("next_run_at") or 0)
+    if nxt:
+        state.out.info(f"Next run {fmt_ts(nxt)} ({fmt_rel(nxt)})")
+
+
+@scheduler_app.command("edit")
+def scheduler_edit(
+    ctx: typer.Context,
+    job_id: str = typer.Argument(..., help="Job id or prefix."),
+    pair_id: str = typer.Option("", "--pair", help="Change the sync pair."),
+    at: str = typer.Option("", "--at", "-t", help="Change run time in HH:MM."),
+    days: str | None = typer.Option(None, "--days", help="Change days: all, weekdays, weekends, or mon,wed,fri."),
+    after: str | None = typer.Option(None, "--after", help="Change dependency. Pass an empty value to clear."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview the change without saving."),
+) -> None:
+    """Edit an advanced pair job."""
+    state: Ctx = ctx.obj
+    scfg = copy.deepcopy(_config(state))
+    jobs = _adv_jobs(scfg)
+    job = _find_job(jobs, job_id)
+    changed = False
+
+    if pair_id.strip():
+        pair = find_pair(_pairs(state), pair_id)
+        job["pair_id"] = str(pair.get("id") or "")
+        changed = True
+    if at.strip():
+        job["at"] = _validate_time(at)
+        changed = True
+    if days is not None:
+        job["days"] = _parse_days(days)
+        changed = True
+    if after is not None:
+        job["after"] = str(after or "").strip() or None
+        changed = True
+    if not changed:
+        raise CLIError("Nothing to edit", hint="Pass --pair, --at, --days, or --after.", exit_code=EXIT_USAGE)
+
+    _advanced(scfg)["enabled"] = True
+    _replace_adv_jobs(scfg, jobs)
+    _finish_save(state, scfg, dry_run=dry_run, message=f"Updated scheduler job {job['id']}.")
+
+
+@scheduler_app.command("pause")
+def scheduler_pause(
+    ctx: typer.Context,
+    job_id: str = typer.Argument(..., help="Job id or prefix."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview the change without saving."),
+) -> None:
+    """Pause an advanced scheduler job."""
+    _set_job_active(ctx, job_id, False, dry_run=dry_run)
+
+
+@scheduler_app.command("resume")
+def scheduler_resume(
+    ctx: typer.Context,
+    job_id: str = typer.Argument(..., help="Job id or prefix."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview the change without saving."),
+) -> None:
+    """Resume an advanced scheduler job."""
+    _set_job_active(ctx, job_id, True, dry_run=dry_run)
+
+
+def _set_job_active(ctx: typer.Context, job_id: str, active: bool, *, dry_run: bool) -> None:
+    state: Ctx = ctx.obj
+    scfg = copy.deepcopy(_config(state))
+    jobs = _adv_jobs(scfg)
+    job = _find_job(jobs, job_id)
+    job["active"] = bool(active)
+    _replace_adv_jobs(scfg, jobs)
+    _finish_save(state, scfg, dry_run=dry_run, message=f"{'Resumed' if active else 'Paused'} scheduler job {job['id']}.")
+
+
+@scheduler_app.command("delete")
+def scheduler_delete(
+    ctx: typer.Context,
+    job_id: str = typer.Argument(..., help="Job id or prefix."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Do not ask for confirmation."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview the change without saving."),
+) -> None:
+    """Delete an advanced scheduler job."""
+    state: Ctx = ctx.obj
+    scfg = copy.deepcopy(_config(state))
+    jobs = _adv_jobs(scfg)
+    job = _find_job(jobs, job_id)
+    if not yes and not dry_run:
+        state.out.print(f"About to delete scheduler job [cw.accent]{job.get('id')}[/]")
+        if not typer.confirm("Delete this job?", default=False):
+            raise CLIError("Cancelled", exit_code=0)
+    remaining = [j for j in jobs if j is not job]
+    _replace_adv_jobs(scfg, remaining)
+    _finish_save(state, scfg, dry_run=dry_run, message=f"Deleted scheduler job {job['id']}.")
+
+
+@scheduler_app.command("setup")
+def scheduler_setup(
+    ctx: typer.Context,
+    kind: str = typer.Option("", "--kind", help="standard or pair."),
+    pair_id: str = typer.Option("", "--pair", help="Pair id/prefix/number for pair scheduling."),
+    cadence: str = typer.Option("", "--cadence", help="hourly, every, daily, or interval."),
+    value: str = typer.Option("", "--value", help="Interval or daily time, for example 6h, 03:30, or 45m."),
+    at: list[str] = typer.Option([], "--at", "-t", help="Run time in HH:MM. Repeat for multiple daily runs."),
+    days: str = typer.Option("all", "--days", help="all, weekdays, weekends, or names like mon,wed,fri."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Save without confirmation."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview the change without saving."),
+) -> None:
+    """Guided scheduler setup that chooses standard or advanced config."""
+    state: Ctx = ctx.obj
+    chosen_kind = str(kind or "").strip().lower()
+    if not chosen_kind:
+        state.out.print("What do you want to schedule?")
+        state.out.print("  1. All enabled sync pairs on one cadence")
+        state.out.print("  2. One sync pair at specific time(s)")
+        chosen_kind = str(typer.prompt("Choose", default="1") or "1").strip().lower()
+    if chosen_kind in {"1", "all", "standard", "all-pairs", "all_pairs"}:
+        _setup_standard(ctx, cadence=cadence, value=value, yes=yes, dry_run=dry_run)
+        return
+    if chosen_kind not in {"2", "pair", "advanced", "one-pair", "one_pair", "multi-time", "multi_time"}:
+        raise CLIError("This setup path is not implemented yet", hint="Use --kind standard or --kind pair.", exit_code=EXIT_USAGE)
+
+    pairs = _pairs(state)
+    selected_pair = pair_id.strip()
+    if not selected_pair:
+        state.out.table(
+            ["#", "ID", "PAIR"],
+            [[idx, str(p.get("id") or ""), pair_label(p)] for idx, p in enumerate(pairs, start=1)],
+            title="Sync pairs",
+            empty="No sync pairs configured yet.",
+        )
+        selected_pair = str(typer.prompt("Pair id or number") or "").strip()
+    chosen_at = list(at)
+    if not chosen_at:
+        raw = str(typer.prompt("Run time(s), comma-separated HH:MM", default="03:30") or "").strip()
+        chosen_at = [part.strip() for part in raw.split(",") if part.strip()]
+    if not yes and not dry_run:
+        state.out.info(f"Will create {len(chosen_at)} advanced job(s).")
+        if not typer.confirm("Save and enable advanced scheduler?", default=True):
+            raise CLIError("Cancelled", exit_code=0)
+    scheduler_add(ctx, selected_pair, at=chosen_at, days=days, job_id="", after="", paused=False, dry_run=dry_run)
+
+
+def _setup_standard(ctx: typer.Context, *, cadence: str, value: str, yes: bool, dry_run: bool) -> None:
+    state: Ctx = ctx.obj
+    chosen = str(cadence or "").strip().lower()
+    if not chosen:
+        state.out.print("How often should all enabled pairs run?")
+        state.out.print("  1. Hourly")
+        state.out.print("  2. Every N hours")
+        state.out.print("  3. Daily at a time")
+        state.out.print("  4. Custom interval in minutes")
+        chosen = str(typer.prompt("Choose", default="2") or "2").strip().lower()
+    if chosen in {"1", "hourly"}:
+        mode, val = "hourly", ""
+    elif chosen in {"2", "every", "every_n_hours"}:
+        mode = "every"
+        val = value.strip() or str(typer.prompt("Every how many hours?", default="12") or "12")
+    elif chosen in {"3", "daily", "daily_time"}:
+        mode = "daily"
+        val = value.strip() or str(typer.prompt("Daily time", default="03:30") or "03:30")
+    elif chosen in {"4", "interval", "custom", "custom_interval"}:
+        mode = "interval"
+        val = value.strip() or str(typer.prompt("Interval minutes", default="60") or "60")
+    else:
+        raise CLIError(f"Unknown cadence '{chosen}'", exit_code=EXIT_USAGE)
+
+    if not yes and not dry_run:
+        state.out.info(f"Will configure the standard scheduler: {mode} {val}".strip())
+        if not typer.confirm("Save and enable scheduler?", default=True):
+            raise CLIError("Cancelled", exit_code=0)
+    scheduler_set(ctx, mode, val, dry_run=dry_run)
 
 
 @scheduler_app.command("stop")

--- a/cli/commands/sync.py
+++ b/cli/commands/sync.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import copy
 import queue
 import re
 import threading
@@ -12,7 +13,7 @@ from typing import Any
 import typer
 
 from .._context import Ctx
-from .._errors import EXIT_BUSY, CLIError
+from .._errors import EXIT_BUSY, EXIT_USAGE, CLIError
 from .._render import state_text
 from .._util import as_dict, coerce_bool, error_text, find_pair, fmt_duration, fmt_ts, is_log_control, pair_features, pair_label, parse_iso, strip_ansi
 
@@ -53,6 +54,45 @@ def _provider_ref(pair: dict[str, Any], side: str) -> str:
 
 def _feature_summary(pair: dict[str, Any]) -> str:
     return ", ".join(pair_features(pair)) or "-"
+
+
+def _once_exit_code(result: dict[str, Any], *, fail_on_unresolved: bool = False, fail_on_skipped: bool = False) -> int:
+    if not isinstance(result, dict):
+        return 1
+    try:
+        if int(result.get("errors") or 0) > 0:
+            return 1
+        if int(result.get("cancelled") or 0) > 0:
+            return 1
+        if fail_on_unresolved and int(result.get("unresolved") or 0) > 0:
+            return 1
+        if fail_on_skipped and int(result.get("skipped") or 0) > 0:
+            return 1
+    except Exception:
+        return 1
+    return 0
+
+
+def _copy_with_selected_pairs(cfg: dict[str, Any], selectors: list[str], features: list[str]) -> dict[str, Any]:
+    out = copy.deepcopy(cfg)
+    pairs = [p for p in (out.get("pairs") or []) if isinstance(p, dict)]
+    if selectors:
+        selected = [find_pair(pairs, selector) for selector in selectors]
+    else:
+        selected = [p for p in pairs if p.get("enabled", True) is not False]
+
+    wanted_features = [str(f or "").strip().lower() for f in features if str(f or "").strip()]
+    if wanted_features:
+        for pair in selected:
+            fmap = pair.get("features")
+            if isinstance(fmap, dict) and fmap:
+                pair["features"] = {name: value for name, value in fmap.items() if str(name).strip().lower() in wanted_features}
+            else:
+                pair["features"] = {name: {"enable": True} for name in wanted_features}
+            pair["feature"] = "multi"
+
+    out["pairs"] = selected
+    return out
 
 
 class _Follower:
@@ -288,6 +328,74 @@ def sync_cancel(ctx: typer.Context) -> None:
         state.out.warn(error_text(result, "Nothing to cancel"))
         return
     state.out.success("Cancel requested; the run stops after the current step.")
+
+
+@sync_app.command("once")
+def sync_once(
+    ctx: typer.Context,
+    target: str = typer.Argument("", help="Optional pair number, id, prefix or label. Default runs every enabled pair."),
+    pair: list[str] = typer.Option([], "--pair", "-p", help="Run a selected pair. Repeat for multiple pairs."),
+    feature: list[str] = typer.Option([], "--feature", "-F", help="Run only this feature. Repeat for multiple features."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Plan the run without writing provider changes."),
+    no_state_json: bool = typer.Option(False, "--no-state-json", help="Do not update the last-sync state marker."),
+    fail_on_unresolved: bool = typer.Option(False, "--fail-on-unresolved", help="Exit 1 when unresolved items are found."),
+    fail_on_skipped: bool = typer.Option(False, "--fail-on-skipped", help="Exit 1 when skipped items are reported."),
+    json_output: bool = typer.Option(False, "--json", help="Print the final summary as JSON."),
+) -> None:
+    """Run sync locally, wait for completion, and exit with the sync result code."""
+    state: Ctx = ctx.obj
+    selectors = [s for s in [target.strip(), *[str(p or "").strip() for p in pair]] if s]
+    if target.strip() and pair:
+        raise CLIError("Use either the positional pair selector or --pair, not both.", exit_code=EXIT_USAGE)
+
+    from cw_platform.config_base import load_config
+    from cw_platform.orchestrator import Orchestrator
+
+    cfg = _copy_with_selected_pairs(dict(load_config() or {}), selectors, feature)
+    selected_pairs = [p for p in (cfg.get("pairs") or []) if isinstance(p, dict)]
+    if not selected_pairs:
+        result = {"ok": True, "pairs": 0, "updated": 0, "added": 0, "removed": 0, "skipped": 0, "unresolved": 0, "errors": 0, "cancelled": False}
+        if json_output or state.out.json_mode:
+            state.out.data({**result, "exit_code": 0})
+        else:
+            state.out.warn("No enabled sync pairs matched; nothing to run.")
+        raise typer.Exit(0)
+
+    runtime_raw = cfg.get("runtime")
+    sync_raw = cfg.get("sync")
+    runtime_cfg: dict[str, Any] = runtime_raw if isinstance(runtime_raw, dict) else {}
+    sync_cfg: dict[str, Any] = sync_raw if isinstance(sync_raw, dict) else {}
+    write_state_json = not no_state_json and coerce_bool(
+        sync_cfg.get("write_state_json", runtime_cfg.get("write_state_json", True)),
+        True,
+    )
+
+    label = "all enabled pairs" if not selectors else ", ".join(str(p.get("id") or pair_label(p)) for p in selected_pairs)
+    if not (json_output or state.out.json_mode):
+        state.out.info(f"Running {label} locally; the process will exit when sync finishes.")
+
+    try:
+        result = Orchestrator(cfg).run(
+            dry_run=dry_run,
+            write_state_json=write_state_json,
+            progress=(None if (json_output or state.out.json_mode) else True),
+        )
+    except Exception as exc:
+        if json_output or state.out.json_mode:
+            state.out.data({"ok": False, "error": str(exc), "exit_code": 1})
+        else:
+            state.out.error(f"Sync failed: {exc}")
+        raise typer.Exit(1) from exc
+
+    code = _once_exit_code(result, fail_on_unresolved=fail_on_unresolved, fail_on_skipped=fail_on_skipped)
+    result = {**result, "exit_code": code}
+    if json_output or state.out.json_mode:
+        state.out.data(result)
+    elif code == 0:
+        state.out.success("Sync completed.")
+    else:
+        state.out.warn(f"Sync completed with exit code {code}.")
+    raise typer.Exit(code)
 
 
 @sync_app.command("unresolved")

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -184,6 +184,10 @@ main() {
   echo "[ENTRYPOINT] CrossWatch on ${WEB_HOST}:${WEB_PORT} (reload=${RELOAD:-no}) as $(run_identity)"
 
   if [[ "$#" -gt 0 ]]; then
+    if [[ "$1" == "run-once" ]]; then
+      shift
+      run_as /usr/local/bin/cw sync once "$@"
+    fi
     # Run a custom command
     run_as "$@"
   else

--- a/docker/run-sync.sh
+++ b/docker/run-sync.sh
@@ -1,37 +1,11 @@
 #!/usr/bin/env bash
-# Run all configured sync pairs using the Orchestrator
-# Exits non-zero on failure and prints full output
+# Compatibility wrapper for one-shot container syncs.
 
 set -Eeuo pipefail
-export PYTHONUNBUFFERED=1
-export PYTHONPATH="${PYTHONPATH:-/app}"
 
-python - <<'PY'
-import sys, json, traceback
-from cw_platform.config_base import load_config
-from cw_platform.orchestrator import Orchestrator
+export PYTHONUNBUFFERED="${PYTHONUNBUFFERED:-1}"
+export APP_DIR="${APP_DIR:-/app}"
+export PYTHONPATH="${APP_DIR}:${PYTHONPATH:-}"
+export CW_CLI_HOME="${CW_CLI_HOME:-${RUNTIME_DIR:-/config}/.cw_cli}"
 
-def coerce_bool(value, default=False):
-    if isinstance(value, bool):
-        return value
-    if value is None:
-        return default
-    return str(value).strip().lower() in {"1", "true", "yes", "on"}
-
-try:
-    cfg = load_config() or {}
-    runtime_cfg = cfg.get("runtime") or {}
-    sync_cfg = cfg.get("sync") or {}
-    write_state_json = coerce_bool(
-        sync_cfg.get("write_state_json", runtime_cfg.get("write_state_json", True)),
-        True,
-    )
-    orc = Orchestrator(cfg)
-    result = orc.run_pairs(write_state_json=write_state_json)
-    print(json.dumps(result, indent=2, ensure_ascii=False))
-    sys.exit(int(result.get("exit_code", 0)) if isinstance(result, dict) else 0)
-except Exception as e:
-    print(f"[RUN] Sync failed: {e}", file=sys.stderr)
-    traceback.print_exc()
-    sys.exit(1)
-PY
+exec /usr/local/bin/cw sync once "$@"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,6 +47,8 @@ class FakeTransport(Transport):
         value = self.routes[key]
         if isinstance(value, Exception):
             raise value
+        if callable(value):
+            return value(method.upper(), path, params, json_body)
         return value
 
 
@@ -1238,6 +1240,415 @@ def test_collect_fields_skips_optional_fields_when_not_prompting() -> None:
 
     manifest = _manifest("MDBLIST", "device_code", [{"key": "mdblist.api_key", "label": "Key"}])
     assert _collect_fields(manifest, {}, interactive=False) == {}
+
+
+def test_scheduler_set_every_configures_standard_scheduler() -> None:
+    from cli.commands.scheduler import scheduler_set
+
+    http = FakeTransport(
+        {
+            ("GET", "/api/scheduling"): {"enabled": False, "advanced": {"enabled": True, "jobs": []}},
+            ("POST", "/api/scheduling"): {"ok": True, "next_run_at": 123},
+        }
+    )
+    state = _ctx(http=http)
+
+    scheduler_set(SimpleNamespace(obj=state), "every", "6h", dry_run=False)
+
+    assert http.calls[-1] == (
+        "POST",
+        "/api/scheduling",
+        {
+            "enabled": True,
+            "advanced": {"enabled": False, "jobs": []},
+            "mode": "every_n_hours",
+            "every_n_hours": 6,
+        },
+    )
+
+
+def test_scheduler_add_repeated_times_creates_multiple_advanced_jobs() -> None:
+    from cli.commands.scheduler import scheduler_add
+
+    http = FakeTransport(
+        {
+            ("GET", "/api/pairs"): [{"id": "simkl-plex", "source": "SIMKL", "target": "PLEX"}],
+            ("GET", "/api/scheduling"): {"enabled": False, "advanced": {"enabled": False, "jobs": []}},
+            ("POST", "/api/scheduling"): {"ok": True, "next_run_at": 123},
+        }
+    )
+    state = _ctx(http=http)
+
+    scheduler_add(SimpleNamespace(obj=state), "simkl", at=["00:00", "06:00"], days="weekdays", job_id="", after="", paused=False, dry_run=False)
+
+    posted = http.calls[-1][2]
+    jobs = posted["advanced"]["jobs"]
+    assert posted["advanced"]["enabled"] is True
+    assert [j["id"] for j in jobs] == ["simkl_plex_0000", "simkl_plex_0600"]
+    assert [j["at"] for j in jobs] == ["00:00", "06:00"]
+    assert jobs[0]["days"] == [1, 2, 3, 4, 5]
+    assert jobs[0]["pair_id"] == "simkl-plex"
+
+
+def test_scheduler_edit_updates_existing_job() -> None:
+    from cli.commands.scheduler import scheduler_edit
+
+    http = FakeTransport(
+        {
+            ("GET", "/api/scheduling"): {
+                "enabled": False,
+                "advanced": {
+                    "enabled": True,
+                    "jobs": [{"id": "night", "pair_id": "a", "at": "00:00", "days": [], "after": None, "active": True}],
+                },
+            },
+            ("POST", "/api/scheduling"): {"ok": True, "next_run_at": 123},
+        }
+    )
+    state = _ctx(http=http)
+
+    scheduler_edit(SimpleNamespace(obj=state), "night", pair_id="", at="03:30", days="weekends", after="", dry_run=False)
+
+    job = http.calls[-1][2]["advanced"]["jobs"][0]
+    assert job["at"] == "03:30"
+    assert job["days"] == [6, 7]
+    assert job["after"] is None
+
+
+def test_scheduler_pause_resume_and_delete_mutate_jobs() -> None:
+    from cli.commands.scheduler import scheduler_delete, scheduler_pause, scheduler_resume
+
+    base = {
+        "enabled": False,
+        "advanced": {
+            "enabled": True,
+            "jobs": [
+                {"id": "first", "pair_id": "a", "at": "00:00", "days": [], "active": True},
+                {"id": "second", "pair_id": "b", "at": "06:00", "days": [], "active": True},
+            ],
+        },
+    }
+    http = FakeTransport({("GET", "/api/scheduling"): base, ("POST", "/api/scheduling"): {"ok": True}})
+    state = _ctx(http=http)
+
+    scheduler_pause(SimpleNamespace(obj=state), "first", dry_run=False)
+    assert http.calls[-1][2]["advanced"]["jobs"][0]["active"] is False
+
+    http.routes[("GET", "/api/scheduling")] = http.calls[-1][2]
+    scheduler_resume(SimpleNamespace(obj=state), "first", dry_run=False)
+    assert http.calls[-1][2]["advanced"]["jobs"][0]["active"] is True
+
+    http.routes[("GET", "/api/scheduling")] = http.calls[-1][2]
+    scheduler_delete(SimpleNamespace(obj=state), "second", yes=True, dry_run=False)
+    assert [j["id"] for j in http.calls[-1][2]["advanced"]["jobs"]] == ["first"]
+
+
+def test_sync_once_filters_selected_pairs_and_returns_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    import typer
+    import cw_platform.config_base as config_base
+    import cw_platform.orchestrator as orchestrator
+    from cli.commands.sync import sync_once
+
+    seen: dict[str, Any] = {}
+
+    class FakeOrchestrator:
+        def __init__(self, cfg: dict[str, Any]) -> None:
+            seen["pairs"] = cfg.get("pairs")
+
+        def run(self, **kwargs: Any) -> dict[str, Any]:
+            seen["kwargs"] = kwargs
+            return {"ok": True, "pairs": 2, "updated": 0, "added": 0, "removed": 0, "skipped": 0, "unresolved": 0, "errors": 0}
+
+    monkeypatch.setattr(config_base, "load_config", lambda: {
+        "pairs": [
+            {"id": "a", "source": "PLEX", "target": "TRAKT", "enabled": True},
+            {"id": "b", "source": "SIMKL", "target": "PLEX", "enabled": True},
+            {"id": "c", "source": "MDBLIST", "target": "TRAKT", "enabled": True},
+        ],
+    })
+    monkeypatch.setattr(orchestrator, "Orchestrator", FakeOrchestrator)
+    state = _ctx(http=FakeTransport())
+
+    with pytest.raises(typer.Exit) as err:
+        sync_once(
+            SimpleNamespace(obj=state),
+            target="",
+            pair=["a", "b"],
+            feature=[],
+            dry_run=False,
+            no_state_json=False,
+            fail_on_unresolved=False,
+            fail_on_skipped=False,
+            json_output=True,
+        )
+
+    assert err.value.exit_code == 0
+    assert [p["id"] for p in seen["pairs"]] == ["a", "b"]
+    assert seen["kwargs"]["write_state_json"] is True
+
+
+def test_sync_once_feature_filter_and_strict_unresolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    import typer
+    import cw_platform.config_base as config_base
+    import cw_platform.orchestrator as orchestrator
+    from cli.commands.sync import sync_once
+
+    seen: dict[str, Any] = {}
+
+    class FakeOrchestrator:
+        def __init__(self, cfg: dict[str, Any]) -> None:
+            seen["pairs"] = cfg.get("pairs")
+
+        def run(self, **_: Any) -> dict[str, Any]:
+            return {"ok": True, "pairs": 1, "updated": 0, "added": 0, "removed": 0, "skipped": 0, "unresolved": 1, "errors": 0}
+
+    monkeypatch.setattr(config_base, "load_config", lambda: {
+        "pairs": [
+            {
+                "id": "a",
+                "source": "PLEX",
+                "target": "TRAKT",
+                "enabled": True,
+                "features": {"watchlist": {"enable": True}, "ratings": {"enable": True}},
+            },
+        ],
+    })
+    monkeypatch.setattr(orchestrator, "Orchestrator", FakeOrchestrator)
+    state = _ctx(http=FakeTransport())
+
+    with pytest.raises(typer.Exit) as err:
+        sync_once(
+            SimpleNamespace(obj=state),
+            target="a",
+            pair=[],
+            feature=["watchlist"],
+            dry_run=False,
+            no_state_json=True,
+            fail_on_unresolved=True,
+            fail_on_skipped=False,
+            json_output=True,
+        )
+
+    assert err.value.exit_code == 1
+    assert seen["pairs"][0]["features"] == {"watchlist": {"enable": True}}
+
+
+def test_sync_once_no_enabled_pairs_exits_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    import typer
+    import cw_platform.config_base as config_base
+    from cli.commands.sync import sync_once
+
+    monkeypatch.setattr(config_base, "load_config", lambda: {"pairs": [{"id": "a", "enabled": False}]})
+    state = _ctx(http=FakeTransport())
+
+    with pytest.raises(typer.Exit) as err:
+        sync_once(
+            SimpleNamespace(obj=state),
+            target="",
+            pair=[],
+            feature=[],
+            dry_run=False,
+            no_state_json=False,
+            fail_on_unresolved=False,
+            fail_on_skipped=False,
+            json_output=True,
+        )
+
+    assert err.value.exit_code == 0
+
+
+def test_playlist_resource_commands_use_provider_resource_api() -> None:
+    from cli.commands.playlist import resource_create, resource_delete, resource_rename
+
+    http = FakeTransport(
+        {
+            ("POST", "/api/playlists/resources"): {"ok": True, "resource": {"id": "new", "provider": "PLEX", "instance": "default", "name": "Weekend"}},
+            ("PATCH", "/api/playlists/resources/pl1"): {"ok": True, "resource": {"id": "pl1", "name": "Renamed"}},
+            ("DELETE", "/api/playlists/resources/pl1"): {"ok": True},
+        }
+    )
+    state = _ctx(http=http)
+
+    resource_create(SimpleNamespace(obj=state), "PLEX", name="Weekend", media_type="playlist", instance="default")
+    resource_rename(SimpleNamespace(obj=state), "PLEX", "pl1", name="Renamed", instance="default")
+    resource_delete(SimpleNamespace(obj=state), "PLEX", "pl1", instance="default", yes=True)
+
+    assert http.calls[0] == ("POST", "/api/playlists/resources", {"provider": "PLEX", "instance": "default", "name": "Weekend", "media_type": "playlist"})
+    assert http.calls[1] == ("PATCH", "/api/playlists/resources/pl1", {"provider": "PLEX", "instance": "default", "name": "Renamed"})
+    assert http.param_calls[2] == ("DELETE", "/api/playlists/resources/pl1", {"provider": "PLEX", "instance": "default"}, None)
+
+
+def test_playlist_endpoint_add_and_edit_have_friendly_arguments() -> None:
+    from cli.commands.playlist import endpoint_add, endpoint_edit
+
+    http = FakeTransport(
+        {
+            ("POST", "/api/playlists/endpoints"): {"ok": True, "created": True, "endpoint": {"id": "EP-01"}},
+            ("GET", "/api/playlists/endpoints"): {
+                "ok": True,
+                "endpoints": [{"id": "EP-01", "name": "Old", "provider": "PLEX", "instance": "default", "playlist_id": "pl1"}],
+            },
+        }
+    )
+    state = _ctx(http=http)
+
+    endpoint_add(SimpleNamespace(obj=state), "PLEX", "pl1", name="PlexFavs", instance="default", create="", media_type="", field=[])
+    endpoint_edit(SimpleNamespace(obj=state), "EP", name="New", provider="", playlist_id="pl2", playlist_name="", instance="", media_type="", field=[])
+
+    assert http.calls[0] == ("POST", "/api/playlists/endpoints", {"provider": "PLEX", "playlist_id": "pl1", "name": "PlexFavs", "instance": "default"})
+    assert http.calls[-1] == (
+        "POST",
+        "/api/playlists/endpoints",
+        {"id": "EP-01", "name": "New", "provider": "PLEX", "instance": "default", "playlist_id": "pl2"},
+    )
+
+
+def test_playlist_mapping_add_edit_enable_disable_are_friendly() -> None:
+    from cli.commands.playlist import mapping_add, mapping_disable, mapping_edit, mapping_enable
+
+    mapping = {
+        "id": "MAP-01",
+        "name": "Movies",
+        "source_endpoint": "EP-01",
+        "target_endpoints": ["EP-02"],
+        "ruleset_id": "",
+        "membership": "managed_only",
+        "order": "ignore",
+        "enabled": True,
+    }
+    http = FakeTransport(
+        {
+            ("POST", "/api/playlists/mappings"): {"ok": True, "created": True, "pair_id": "pair_playlist_1", "mapping": mapping},
+            ("GET", "/api/playlists/mappings"): {"ok": True, "mappings": [mapping]},
+        }
+    )
+    state = _ctx(http=http)
+
+    mapping_add(
+        SimpleNamespace(obj=state),
+        source="EP-01",
+        target=["EP-02", "EP-03"],
+        name="Movies",
+        ruleset="trakt_free_account",
+        membership="managed_only",
+        order="ignore",
+        disabled=False,
+        allow_mass_delete=False,
+        field=[],
+    )
+    mapping_edit(
+        SimpleNamespace(obj=state),
+        "MAP",
+        source="",
+        target=["EP-04"],
+        name="NewName",
+        ruleset="",
+        membership="mirror",
+        order="preserve",
+        allow_mass_delete=True,
+        field=[],
+    )
+    mapping_disable(SimpleNamespace(obj=state), "MAP")
+    mapping_enable(SimpleNamespace(obj=state), "MAP")
+
+    assert http.calls[0][2]["target_endpoints"] == ["EP-02", "EP-03"]
+    assert http.calls[0][2]["ruleset_id"] == "trakt_free_account"
+    assert http.calls[2][2]["target_endpoints"] == ["EP-04"]
+    assert http.calls[2][2]["membership"] == "mirror"
+    assert http.calls[4][2]["enabled"] is False
+    assert http.calls[6][2]["enabled"] is True
+
+
+def test_playlist_mapping_run_accepts_wrapped_result() -> None:
+    from cli.commands.playlist import mapping_run
+
+    http = FakeTransport({("POST", "/api/playlists/mappings/MAP-01/run"): {"ok": True, "result": {"added": 2, "removed": 1, "errors": 0}}})
+    state = _ctx(http=http)
+
+    mapping_run(SimpleNamespace(obj=state), "MAP-01", dry_run=False)
+
+    assert http.param_calls[-1] == ("POST", "/api/playlists/mappings/MAP-01/run", {"dry_run": False}, None)
+
+
+def test_playlist_ruleset_add_validate_and_clone() -> None:
+    from cli.commands.playlist import ruleset_add, ruleset_clone, ruleset_validate
+
+    http = FakeTransport(
+        {
+            ("POST", "/api/playlists/rulesets"): {"ok": True, "created": True, "ruleset": {"id": "RS-01"}},
+            ("POST", "/api/playlists/rulesets/validate"): {"ok": True, "ruleset": {"id": "RS-01"}},
+            ("POST", "/api/playlists/rulesets/trakt_free_account/clone"): {"ok": True, "ruleset": {"id": "RS-02"}},
+        }
+    )
+    state = _ctx(http=http)
+    path = Path("ruleset-test.json")
+    path.write_text('{"id":"RS-01","name":"Rules"}', encoding="utf-8")
+    try:
+        ruleset_add(SimpleNamespace(obj=state), str(path))
+        ruleset_validate(SimpleNamespace(obj=state), str(path))
+        ruleset_clone(SimpleNamespace(obj=state), "trakt_free_account", name="Custom")
+    finally:
+        path.unlink(missing_ok=True)
+
+    assert http.calls[0] == ("POST", "/api/playlists/rulesets", {"id": "RS-01", "name": "Rules"})
+    assert http.calls[1] == ("POST", "/api/playlists/rulesets/validate", {"id": "RS-01", "name": "Rules"})
+    assert http.calls[2] == ("POST", "/api/playlists/rulesets/trakt_free_account/clone", {"name": "Custom"})
+
+
+def test_playlist_setup_creates_endpoints_and_mapping_non_interactively() -> None:
+    from cli.commands.playlist import playlist_setup
+
+    endpoint_ids = iter(["EP-01", "EP-02"])
+
+    def post_endpoint(_method: str, _path: str, _params: Any, body: Any) -> dict[str, Any]:
+        return {"ok": True, "created": True, "endpoint": {**body, "id": next(endpoint_ids)}}
+
+    def post_mapping(_method: str, _path: str, _params: Any, body: Any) -> dict[str, Any]:
+        return {"ok": True, "created": True, "pair_id": "pair_playlist_1", "mapping": {**body, "id": "MAP-01"}}
+
+    http = FakeTransport(
+        {
+            ("POST", "/api/playlists/endpoints"): post_endpoint,
+            ("POST", "/api/playlists/mappings"): post_mapping,
+        }
+    )
+    state = _ctx(http=http)
+
+    playlist_setup(
+        SimpleNamespace(obj=state),
+        source_provider="TRAKT",
+        source_instance="default",
+        source_playlist="src1",
+        target_provider="PLEX",
+        target_instance="default",
+        target_playlist=[],
+        create_target="Weekend Movies",
+        name="Weekend",
+        ruleset="",
+        membership="managed_only",
+        order="ignore",
+        run_now=False,
+        dry_run=False,
+        yes=True,
+    )
+
+    assert http.calls[0][2]["playlist_id"] == "src1"
+    assert http.calls[1][2]["pending_create"] == {"name": "Weekend Movies", "media_type": "playlist"}
+    assert http.calls[2][2]["source_endpoint"] == "EP-01"
+    assert http.calls[2][2]["target_endpoints"] == ["EP-02"]
+
+
+def test_run_sync_wrapper_delegates_to_sync_once() -> None:
+    wrapper = (Path(__file__).resolve().parents[1] / "docker" / "run-sync.sh").read_text(encoding="utf-8")
+
+    assert "cw sync once" in wrapper
+
+
+def test_entrypoint_supports_run_once_alias() -> None:
+    entrypoint = (Path(__file__).resolve().parents[1] / "docker" / "entrypoint.sh").read_text(encoding="utf-8")
+
+    assert '"$1" == "run-once"' in entrypoint
+    assert "/usr/local/bin/cw sync once" in entrypoint
 
 
 def test_every_command_group_is_registered() -> None:


### PR DESCRIPTION
# Pull request

## Change

Adds CLI flows for scheduler, one-shot sync, and playlist setup.

- add `cw scheduler setup`
- add scheduler add/edit/delete/pause/resume/list/set
- add `cw sync once` for container runs that exit after sync
- add `run-once` container alias
- add playlist resource, endpoint, mapping, and ruleset CLI helpers
- add `cw playlist setup`

## Why

- Makes common config tasks easier without editing raw JSON.
- Also gives container users a clean way to run sync, get an exit code, and shut down.

## Testing

- tests\test_cli.py

## Issue

Relates to #856