### PR TITLE
Change: speed up playing card art loading

### DIFF
--- a/api/metaAPI.py
+++ b/api/metaAPI.py
@@ -1165,7 +1165,7 @@ def api_tmdb_art(
             str(local_path),
             media_type=mime,
             headers={
-                "Cache-Control": "public, max-age=86400, stale-while-revalidate=86400"
+                "Cache-Control": "public, max-age=31536000, immutable"
             },
         )
     except Exception as e:

--- a/assets/helpers/playing-card.js
+++ b/assets/helpers/playing-card.js
@@ -2,10 +2,11 @@
 /* Shared Playing Card renderer: one card, per-variant regions */
 /* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
 (function () {
+  const PLACEHOLDER_POSTER = "/assets/img/placeholder_poster.svg";
   const TEMPLATE = `
     <div class="pc-inner">
       <a class="pc-poster-link" target="_blank" rel="noopener noreferrer">
-        <img class="pc-poster" src="/assets/img/placeholder_poster.svg" alt="">
+        <img class="pc-poster" src="${PLACEHOLDER_POSTER}" alt="">
       </a>
       <div class="pc-body">
         <div class="pc-title-row">
@@ -201,9 +202,30 @@
       links: q(".pc-links"),
     };
 
-    els.poster.onerror = () => {
-      els.poster.onerror = null;
-      els.poster.src = "/assets/img/placeholder_poster.svg";
+    const failedPosterSrcs = new Set();
+    let currentPosterSrc = PLACEHOLDER_POSTER;
+    let currentBackdropValue = "";
+
+    const setPosterSrc = (value) => {
+      const raw = String(value || PLACEHOLDER_POSTER).trim() || PLACEHOLDER_POSTER;
+      const next = failedPosterSrcs.has(raw) ? PLACEHOLDER_POSTER : raw;
+      if (currentPosterSrc === next) return;
+      currentPosterSrc = next;
+      els.poster.onerror = () => {
+        if (currentPosterSrc !== PLACEHOLDER_POSTER) failedPosterSrcs.add(currentPosterSrc);
+        currentPosterSrc = PLACEHOLDER_POSTER;
+        els.poster.onerror = null;
+        els.poster.src = PLACEHOLDER_POSTER;
+      };
+      els.poster.src = next;
+    };
+
+    const setBackdrop = (value) => {
+      const raw = String(value || "").trim();
+      const next = raw ? `url("${raw}")` : "none";
+      if (currentBackdropValue === next) return;
+      currentBackdropValue = next;
+      el.style.setProperty("--pc-backdrop", next);
     };
 
     let overviewFrame = 0;
@@ -351,10 +373,10 @@
       els.title.textContent = model.year ? `${model.title} ${model.year}` : (model.title || "");
       setChips(model.chips);
       setOverview(model.overview || "");
-      els.poster.src = model.poster || "/assets/img/placeholder_poster.svg";
+      setPosterSrc(model.poster || PLACEHOLDER_POSTER);
       els.poster.alt = model.title || "Poster";
       setPosterLink(model.posterHref || "", model.title);
-      el.style.setProperty("--pc-backdrop", model.backdrop ? `url("${model.backdrop}")` : "none");
+      setBackdrop(model.backdrop);
       setInformation(model.information, model.isMovie);
       setRating(model.rating?.value, model.rating?.votes);
       setProgress(model.progress);

--- a/assets/js/playingcard.js
+++ b/assets/js/playingcard.js
@@ -73,9 +73,8 @@
   };
 
   const buildArtUrl = (p) => {
-    if (p?.cover) return p.cover;
     const id = tmdbIdOf(p);
-    if (!id) return "/assets/img/placeholder_poster.svg";
+    if (!id) return p?.cover || "/assets/img/placeholder_poster.svg";
     return `/art/tmdb/${artTypeOf(p)}/${encodeURIComponent(String(id))}?size=w342${artEvidenceOf(p)}`;
   };
 
@@ -157,11 +156,12 @@
     return hr < 24 ? `${hr}h ago` : `${Math.floor(hr / 24)}d ago`;
   };
 
-  const backdropFromMeta = (meta) => {
-    const id = meta?.ids?.tmdb;
+  const buildBackdropUrl = (p, meta = null) => {
+    const id = meta?.ids?.tmdb || meta?.ids?.id || tmdbIdOf(p);
     if (!id) return "";
-    const type = String(meta?.resolved_type || meta?.type || "").toLowerCase() === "movie" ? "movie" : "tv";
-    return `/art/tmdb/${type}/${encodeURIComponent(String(id))}?kind=backdrop&size=w1280`;
+    const resolved = meta?.resolved_type || meta?.type || window.CW?.Meta?.peek(p)?.resolved_type;
+    const type = String(resolved || p?.media_type || p?.type || "").toLowerCase() === "movie" ? "movie" : "tv";
+    return `/art/tmdb/${type}/${encodeURIComponent(String(id))}?kind=backdrop&size=w1280${artEvidenceOf(p)}`;
   };
 
   const SHARED_WATCH_KEY = "__CW_CURRENT_WATCHING_SHARED__";
@@ -422,7 +422,7 @@
       overview,
       poster: buildArtUrl(p),
       posterHref: tmdbUrl,
-      backdrop: meta ? backdropFromMeta(meta) : "",
+      backdrop: buildBackdropUrl(p, meta),
       information: meta ? FMT.informationFor(meta, isMovie) : "loading",
       rating,
       progress: progressModel(p),

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -2258,6 +2258,16 @@ def test_playing_card_uses_overview_profile_scope() -> None:
     assert "CARD.cacheScope !== scope" in js
 
 
+def test_playing_card_art_starts_early_and_skips_redundant_image_updates() -> None:
+    driver = Path("assets/js/playingcard.js").read_text("utf-8")
+    renderer = Path("assets/helpers/playing-card.js").read_text("utf-8")
+
+    assert "const buildBackdropUrl = (p, meta = null)" in driver
+    assert "backdrop: buildBackdropUrl(p, meta)" in driver
+    assert "if (currentPosterSrc === next) return;" in renderer
+    assert "if (currentBackdropValue === next) return;" in renderer
+
+
 def test_insights_snapshot_selector_saves_crosswatch_profile_choice(monkeypatch) -> None:
     from fastapi import FastAPI
     from fastapi.testclient import TestClient

--- a/tests/test_meta_api_tmdb_retry.py
+++ b/tests/test_meta_api_tmdb_retry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 import requests
@@ -84,3 +85,17 @@ def test_posters_survive_a_rate_limited_first_attempt(monkeypatch) -> None:
 def test_posters_return_empty_when_retries_exhausted(monkeypatch) -> None:
     _patch(monkeypatch, [FakeResponse(429, headers={"Retry-After": "1"}) for _ in range(4)])
     assert metaAPI._tmdb_fetch_posters("key", "movie", "8392", "en-US") == []
+
+
+def test_tmdb_art_route_uses_long_lived_cache_headers(monkeypatch, tmp_path) -> None:
+    img = tmp_path / "poster.jpg"
+    img.write_bytes(b"fake jpg")
+
+    monkeypatch.setattr(metaAPI, "load_config", lambda: {"tmdb": {"api_key": "key"}})
+    monkeypatch.setattr(metaAPI, "_env", lambda: (None, tmp_path, lambda: {}))
+    monkeypatch.setattr(metaAPI, "get_art_file", lambda *a, **k: (str(img), "image/jpeg"))
+
+    request = SimpleNamespace(headers={}, url=SimpleNamespace(path="/art/tmdb/movie/1"))
+    response = metaAPI.api_tmdb_art(request, typ="movie", tmdb_id=1, size="w342", kind="poster")
+
+    assert response.headers["cache-control"] == "public, max-age=31536000, immutable"


### PR DESCRIPTION
# Pull request

## Change

- Cache TMDb art longer and avoid resetting the same poster/backdrop on every playing card render.

## Why

- The scrobble playing card felt slow, especially when the backdrop had to load again.

## Testing
- tests/test_meta_api_tmdb_retry.py::test_tmdb_art_route_uses_long_lived_cache_headers
- tests/test_crosswatch_profiles.py::test_playing_card_uses_overview_profile_scope
- tests/test_crosswatch_profiles.py::test_playing_card_art_starts_early_and_skips_redundant_image_updates

## Issue

NA