### PR TITLE
Change: refresh playlist endpoints after sync

### DIFF
--- a/cw_platform/orchestrator/_pairs_playlists.py
+++ b/cw_platform/orchestrator/_pairs_playlists.py
@@ -81,6 +81,13 @@ def run_playlist_mappings(
                 providers=providers,
                 emit=ctx.emit,
             )
+            if not dry_run and isinstance(full_cfg, dict):
+                try:
+                    from services import playlists as playlists_svc
+
+                    playlists_svc.refresh_mapping_endpoints(full_cfg, mapping)
+                except Exception:
+                    pass
         except PlaylistRunError as e:
             totals["errors"] += 1
             _emit(ctx, "playlist:mapping:error", src=src, dst=dst, mapping=mapping_id, error=str(e))

--- a/services/playlists.py
+++ b/services/playlists.py
@@ -500,6 +500,21 @@ def sync_endpoint(cfg: dict[str, Any], endpoint_id: str) -> dict[str, Any]:
     return {"ok": True, "endpoint": ep}
 
 
+def refresh_mapping_endpoints(cfg: dict[str, Any], mapping: Mapping[str, Any], *, save: bool = True) -> dict[str, Any]:
+    ids: list[str] = []
+    source_id = str(mapping.get("source_endpoint") or "").strip()
+    if source_id:
+        ids.append(source_id)
+    for target_id in _clean_target_ids(mapping):
+        if target_id and target_id not in ids:
+            ids.append(target_id)
+    refreshed = [_refresh_endpoint_meta(cfg, endpoint_id) for endpoint_id in ids]
+    endpoints = [ep for ep in refreshed if ep]
+    if save and endpoints:
+        _save(cfg)
+    return {"ok": True, "endpoints": endpoints}
+
+
 def activity(cfg: Mapping[str, Any], *, limit: int = 25) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for ep in list_endpoints(cfg):
@@ -1180,6 +1195,8 @@ def run_mapping(cfg: Mapping[str, Any], mapping_id: str, *, dry_run: bool = Fals
     try:
         with _mapping_env(resolved):
             result = runner.run_mapping(cfg, resolved, dry_run=dry_run)
+        if not dry_run and isinstance(cfg, dict):
+            refresh_mapping_endpoints(cfg, resolved)
     except runner.PlaylistRunError as e:
         return _internal_playlist_error("run", e, mapping_id=mapping_id, dry_run=dry_run)
     except Exception as e:

--- a/tests/test_playlists_orchestration.py
+++ b/tests/test_playlists_orchestration.py
@@ -208,6 +208,30 @@ def test_playlist_pair_records_feature_totals(config_base, monkeypatch):
     ]
 
 
+def test_playlist_pair_refreshes_mapping_endpoints_after_run(config_base, monkeypatch):
+    from services import playlists as svc
+
+    calls: list[str] = []
+    cfg = _pair_cfg("one-way")
+    ctx = _ctx(cfg)
+    monkeypatch.setattr(glue, "resolve_pair_mappings", lambda _cfg, _pair: [playlists_runner.resolve_mapping(cfg, cfg["playlists"]["mappings"][0])])
+    monkeypatch.setattr(glue, "run_mapping", lambda *a, **k: {"ok": True, "added": 1, "removed": 0, "reordered": 0, "unresolved_count": 0})
+    monkeypatch.setattr(svc, "refresh_mapping_endpoints", lambda _cfg, mapping: calls.append(str(mapping.get("id") or "")) or {"ok": True, "endpoints": []})
+
+    result = glue.run_playlist_mappings(
+        ctx,
+        "FAKESRC",
+        "FAKEDST",
+        fcfg={"mappings": ["MAP-01"]},
+        health_map={},
+        full_cfg=cfg,
+        pair=cfg["pairs"][0],
+    )
+
+    assert result["added"] == 1
+    assert calls == ["MAP-01"]
+
+
 def test_manual_and_scheduled_share_core_runner():
     from services import playlists as svc
 

--- a/tests/test_playlists_service.py
+++ b/tests/test_playlists_service.py
@@ -383,6 +383,25 @@ def test_run_only_selected_mapping(config_base, fake_providers):
     assert ("add", "T2") not in fake_providers["PLEX"].calls
 
 
+def test_mapping_run_refreshes_source_and_destination_endpoints(config_base, fake_providers, monkeypatch):
+    cfg = _cfg()
+    e1, e2 = _seed_endpoints(cfg)
+    mid = svc.upsert_mapping(cfg, {"name": "Map1", "source_endpoint": e1, "target_endpoints": [e2]})["mapping"]["id"]
+    for endpoint in cfg["playlists"]["endpoints"]:
+        endpoint.pop("last_synced", None)
+        endpoint["item_count"] = 999
+    monkeypatch.setattr(svc.time, "time", lambda: 1234)
+
+    out = svc.run_mapping(cfg, mid)
+
+    assert out["ok"] and out["result"]["added"] == 2
+    endpoints = {ep["id"]: ep for ep in cfg["playlists"]["endpoints"]}
+    assert endpoints[e1]["last_synced"] == 1234
+    assert endpoints[e1]["item_count"] == 2
+    assert endpoints[e2]["last_synced"] == 1234
+    assert endpoints[e2]["item_count"] == 2
+
+
 def test_provider_count_summary_merges_endpoint_and_mapping_counts(config_base, fake_providers):
     cfg = _cfg()
     e1, e2 = _seed_endpoints(cfg)


### PR DESCRIPTION
# Pull request

## Change

- Refresh source and destination playlist endpoints after a mapping sync.
- Apply the refresh for both manual playlist runs and scheduled pair runs.
- Update endpoint item counts and last refresh timestamps after sync.

## Why

- After a playlist sync, the endpoint rows should show fresh counts and timestamps without needing a manual refresh.

## Testing

- tests/test_playlists_service.py 
- tests/test_playlists_orchestration.py 

## Issue

Relates to #439