### PR TITLE
Change: refresh playlist activity in place

### DIFF
--- a/assets/js/playlists.js
+++ b/assets/js/playlists.js
@@ -337,7 +337,7 @@
       reconcileSyncSummary();
       const root = $("#page-playlists");
       if (root && root.querySelector(".pl-page")) {
-        if (wasBusy && !sharedSyncBusy()) await refreshOverview(["mappings", "activity"]);
+        if (wasBusy && !sharedSyncBusy()) await refreshOverview(["endpoints", "mappings", "activity"]);
         else {
           updateMappingActions(root);
           refreshSection(root, "mappings");
@@ -2307,7 +2307,9 @@
       primaryText: "Clear activity",
       savingText: "Clearing...",
       onPrimary: async () => {
-        await API.activityClear();
+        const cleared = await API.activityClear();
+        state.activity = Array.isArray(cleared.activity) ? cleared.activity : [];
+        if (cleared.overview) state.overview = cleared.overview;
         closeModal(true);
         await refreshOverview(["endpoints", "mappings", "activity"]);
       },

--- a/services/playlists.py
+++ b/services/playlists.py
@@ -570,7 +570,7 @@ def clear_activity(cfg: dict[str, Any]) -> dict[str, Any]:
                 removed += 1
     if removed:
         _save(cfg)
-    return {"ok": True, "removed": removed}
+    return {"ok": True, "removed": removed, "activity": activity(cfg), "overview": overview(cfg)}
 
 
 def upsert_endpoint(cfg: dict[str, Any], payload: Mapping[str, Any]) -> dict[str, Any]:

--- a/tests/test_playlists_service.py
+++ b/tests/test_playlists_service.py
@@ -439,7 +439,10 @@ def test_clear_activity_resets_playlist_run_metadata(config_base, fake_providers
 
     cleared = svc.clear_activity(cfg)
 
-    assert cleared == {"ok": True, "removed": 3}
+    assert cleared["ok"] is True
+    assert cleared["removed"] == 3
+    assert cleared["activity"] == []
+    assert cleared["overview"]["last_sync_epoch"] is None
     assert "last_synced" not in cfg["playlists"]["endpoints"][0]
     assert "last_result" not in mapping
     assert runner.load_result(resolved) is None

--- a/tests/test_playlists_ui.py
+++ b/tests/test_playlists_ui.py
@@ -215,6 +215,7 @@ def test_endpoint_and_mapping_tables_use_compact_icon_actions():
     assert "function mappingIsRunning" in js
     assert "API.runSummary()" in js
     assert "Synchronization is already running" in js
+    assert 'if (wasBusy && !sharedSyncBusy()) await refreshOverview(["endpoints", "mappings", "activity"]);' in js
     assert 'state.syncSummary = { ...(state.syncSummary || {}), running: true, pair_scope_ids: [String(mapping.assigned_pair || "")] };' in js
     assert "async function syncEndpoint" in js
     assert '"endpoint-sync"' in js
@@ -265,6 +266,8 @@ def test_playlists_overview_uses_dashboard_table_body():
     assert 'warningBits.push(`${unresolved} unresolved`)' in js
     assert "function openActivityClear" in js
     assert "activityClear: ()" in js
+    assert "state.activity = Array.isArray(cleared.activity) ? cleared.activity : [];" in js
+    assert "if (cleared.overview) state.overview = cleared.overview;" in js
     assert 'data-action="activity-clear"' in js
     assert '<table class="pl-activity-table">' in js
     assert '<th>Time</th><th>Mapping</th><th>Result</th><th>Changes</th><th>Status</th>' in js


### PR DESCRIPTION
# Pull request

## Change

- Refresh playlist endpoint rows after a playlist mapping sync finishes.
- Make clearing playlist activity update the page immediately.
- Return fresh playlist activity and overview state after clear.

## Why

- Playlist sync and clear actions were updating the backend, but the page could still show stale activity or endpoint refresh data until a browser refresh.

## Testing

- tests/test_playlists_service.py::test_clear_activity_resets_playlist_run_metadata
- tests/test_playlists_ui.py::test_playlists_overview_uses_dashboard_table_body
- tests/test_playlists_ui.py::test_endpoint_and_mapping_tables_use_compact_icon_actions 

## Issue

Relates to #439