### PR TITLE
Fix: preserve pairs during playlist sync

### DIFF
--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -893,9 +893,12 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
         except Exception:
             req_pair_ids = set()
 
+        original_pairs_for_scope = list(cfg.get("pairs") or []) if (req_pair_ids or req_pair_id) else None
+
         if req_pair_ids:
             _summary_set("pair_scope_ids", sorted(req_pair_ids))
             cfg = dict(cfg)
+            cfg["_cw_pair_scope_original_pairs"] = original_pairs_for_scope
             cfg["pairs"] = [p for p in (cfg.get("pairs") or []) if str(p.get("id") or "") in req_pair_ids]
 
         if req_pair_id:
@@ -905,6 +908,7 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
                 _sync_progress_ui("[SYNC] exit code: 1")
                 return
             cfg = dict(cfg)
+            cfg["_cw_pair_scope_original_pairs"] = original_pairs_for_scope
             cfg["pairs"] = [pair]
             pair_scope = req_pair_id
             pair_src = str(pair.get("source") or pair_src)

--- a/assets/js/connections.pairs.overlay.js
+++ b/assets/js/connections.pairs.overlay.js
@@ -253,7 +253,16 @@
     const board = document.querySelector("#pairs_list .pairs-board");
     const el = board?.querySelector(`.pair-card[data-id="${id}"]`); if (!el) return;
     el.classList.add("removing"); setTimeout(() => el.remove(), 200);
-    try { await fetch(`/api/pairs/${id}`, { method: "DELETE" }); } catch (e) { console.warn("delete api failed", e); }
+    try {
+      const res = await fetch(`/api/pairs/${id}`, { method: "DELETE" });
+      let data = null;
+      try { data = await res.json(); } catch {}
+      if (!res.ok || data?.ok === false || Number(data?.deleted || 0) < 1) throw new Error(data?.error || "pair delete failed");
+    } catch (e) {
+      console.warn("delete api failed", e);
+      el.classList.remove("removing");
+      return;
+    }
     if (Array.isArray(window.cx?.pairs)) window.cx.pairs = window.cx.pairs.filter((p) => String(p.id) !== String(id));
     try { window.dispatchEvent(new CustomEvent("cx:pairs:changed", { detail: { action: "delete", id } })); } catch {}
     setTimeout(() => refreshBadges(board), 220);

--- a/services/playlists.py
+++ b/services/playlists.py
@@ -28,6 +28,7 @@ _MEMBERSHIP = {"add_only", "managed_only", "mirror"}
 _ORDER = {"ignore", "preserve"}
 _NAME_MAX = 10
 _PLAYLIST_NAME_MAX = 20
+_PAIR_SCOPE_ORIGINAL_PAIRS_KEY = "_cw_pair_scope_original_pairs"
 _SAFE_NAME_CHARS = " _.'-&()"
 
 
@@ -1253,4 +1254,9 @@ def cleanup_state(cfg: Mapping[str, Any]) -> dict[str, Any]:
 def _save(cfg: dict[str, Any]) -> None:
     from cw_platform.config_base import save_config
 
+    original_pairs = cfg.get(_PAIR_SCOPE_ORIGINAL_PAIRS_KEY)
+    if isinstance(original_pairs, list):
+        cfg = dict(cfg)
+        cfg["pairs"] = original_pairs
+        cfg.pop(_PAIR_SCOPE_ORIGINAL_PAIRS_KEY, None)
     save_config(cfg)

--- a/tests/test_playlists_service.py
+++ b/tests/test_playlists_service.py
@@ -450,6 +450,24 @@ def test_clear_activity_resets_playlist_run_metadata(config_base, fake_providers
     assert svc.activity(cfg) == []
 
 
+def test_playlist_save_preserves_pairs_for_scoped_sync(monkeypatch):
+    from cw_platform import config_base
+
+    saved: list[dict[str, Any]] = []
+    full_pairs = [{"id": "pair_1"}, {"id": "pair_2"}, {"id": "pair_playlist_1"}]
+    scoped_cfg = {
+        "pairs": [{"id": "pair_playlist_1"}],
+        "playlists": {"endpoints": [], "mappings": []},
+        "_cw_pair_scope_original_pairs": full_pairs,
+    }
+    monkeypatch.setattr(config_base, "save_config", lambda cfg: saved.append(cfg))
+
+    svc._save(scoped_cfg)
+
+    assert saved[0]["pairs"] == full_pairs
+    assert "_cw_pair_scope_original_pairs" not in saved[0]
+
+
 def test_mappings_for_pair_compat_and_one_pair(config_base, fake_providers):
     cfg = _cfg()
     e1, e2 = _seed_endpoints(cfg)

--- a/tests/test_playlists_ui.py
+++ b/tests/test_playlists_ui.py
@@ -328,6 +328,7 @@ def test_pair_overlay_playlist_managed_pairs_open_playlist_mapping():
     assert 'fetch("/api/playlists/mappings", {' in js
     assert "async function deletePlaylistManagedPair" in js
     assert 'fetch(`/api/playlists/mappings/${encodeURIComponent(mapping.id)}`' in js
+    assert 'if (!res.ok || data?.ok === false || Number(data?.deleted || 0) < 1) throw new Error(data?.error || "pair delete failed");' in js
     assert "isPlaylistManagedPair(pair)) return openPlaylistMappingsForPair(id, btn)" in js
     assert 'pair-pill mode playlist-managed' not in js
     assert 'data-tip="Managed by Playlists"' not in js


### PR DESCRIPTION
# Pull request

## Change

- Preserve the full sync pair list when running a single playlist mapping sync.
- Prevent playlist endpoint refresh saves from persisting scoped pair-only config.
- Only remove pair cards in the UI after the delete API confirms success.

## Why

Running a playlist mapping sync could save the temporary single-pair config and remove regular sync pairs from the saved config.

## Testing

- tests/test_playlists_service.py::test_playlist_save_preserves_pairs_for_scoped_sync
- tests/test_playlists_ui.py::test_pair_overlay_playlist_managed_pairs_open_playlist_mapping
- tests/test_access_audit_fixes.py::test_run_pairs_thread_scope_filter_precedes_single_pair_selection

## Issue

Relates to #439