### PR TITLE
Change: scope pair runs

### DIFF
--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -893,23 +893,22 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
         except Exception:
             req_pair_ids = set()
 
-        original_pairs_for_scope = list(cfg.get("pairs") or []) if (req_pair_ids or req_pair_id) else None
+        pair_scope_ids: set[str] = set(req_pair_ids)
 
         if req_pair_ids:
             _summary_set("pair_scope_ids", sorted(req_pair_ids))
-            cfg = dict(cfg)
-            cfg["_cw_pair_scope_original_pairs"] = original_pairs_for_scope
-            cfg["pairs"] = [p for p in (cfg.get("pairs") or []) if str(p.get("id") or "") in req_pair_ids]
 
         if req_pair_id:
+            if req_pair_ids and req_pair_id not in req_pair_ids:
+                _sync_progress_ui(f"[!] Pair not found or disabled: {req_pair_id}")
+                _sync_progress_ui("[SYNC] exit code: 1")
+                return
             pair = next((p for p in (cfg.get("pairs") or []) if str(p.get("id") or "") == req_pair_id), None)
             if not pair or not coerce_bool(pair.get("enabled", True), True):
                 _sync_progress_ui(f"[!] Pair not found or disabled: {req_pair_id}")
                 _sync_progress_ui("[SYNC] exit code: 1")
                 return
-            cfg = dict(cfg)
-            cfg["_cw_pair_scope_original_pairs"] = original_pairs_for_scope
-            cfg["pairs"] = [pair]
+            pair_scope_ids = {req_pair_id}
             pair_scope = req_pair_id
             pair_src = str(pair.get("source") or pair_src)
             pair_dst = str(pair.get("target") or pair_dst)
@@ -935,7 +934,13 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
                         return True
                 return False
 
-            for pair in (cfg.get("pairs") or []):
+            pairs_for_run = [
+                p for p in (cfg.get("pairs") or [])
+                if isinstance(p, dict)
+                and (not pair_scope_ids or str(p.get("id") or "") in pair_scope_ids)
+            ]
+
+            for pair in pairs_for_run:
                 if not coerce_bool(pair.get("enabled", True), True):
                     continue
                 if "features" in pair and not _pair_has_enabled_features(pair):
@@ -957,6 +962,7 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
             result = mgr.run_pairs(
                 dry_run=dry,
                 progress=_sync_progress_ui,
+                pair_scope_ids=sorted(pair_scope_ids),
                 write_state_json=write_state_json,
                 use_snapshot=True,
             )

--- a/cw_platform/orchestrator/_pairs.py
+++ b/cw_platform/orchestrator/_pairs.py
@@ -116,16 +116,14 @@ except Exception:
             return
 
 
-def _collect_health_for_run(ctx) -> dict[str, Any]:
+def _collect_health_for_run(ctx, pairs: list[Mapping[str, Any]]) -> dict[str, Any]:
     emit = ctx.emit
     provs = ctx.providers or {}
 
     cfg: Mapping[str, Any] = ctx.config or {}
     needed: set[tuple[str, str]] = set()
 
-    for p in (cfg.get("pairs") or []):
-        if not p.get("enabled", True):
-            continue
+    for p in pairs:
         s = str(p.get("source") or "").upper().strip()
         t = str(p.get("target") or "").upper().strip()
         si = normalize_instance_id(p.get("source_instance"))
@@ -237,6 +235,27 @@ def _feature_list_for_pair(pair: Mapping[str, Any]) -> list[str]:
     return ["history", "watchlist", "ratings", "progress", "playlists"]
 
 
+def _pair_scope_ids(ctx) -> set[str]:
+    raw = getattr(ctx, "pair_scope_ids", None) or []
+    if isinstance(raw, (str, bytes)):
+        raw = [raw]
+    return {str(x).strip() for x in raw if str(x).strip()}
+
+
+def _pairs_for_run(ctx, cfg: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    scope = _pair_scope_ids(ctx)
+    out: list[Mapping[str, Any]] = []
+    for pair in cfg.get("pairs") or []:
+        if not isinstance(pair, Mapping):
+            continue
+        if not coerce_bool(pair.get("enabled", True), True):
+            continue
+        if scope and str(pair.get("id") or "").strip() not in scope:
+            continue
+        out.append(pair)
+    return out
+
+
 
 def _pair_scope_key(pair: Mapping[str, Any], *, i: int, src: str, dst: str, mode: str) -> str:
     mode_norm = str(mode or "one-way").strip().lower()
@@ -325,7 +344,8 @@ def run_pairs(ctx) -> dict[str, Any]:
     except Exception:
         pass
 
-    health_map = _collect_health_for_run(ctx)
+    pairs = _pairs_for_run(ctx, cfg)
+    health_map = _collect_health_for_run(ctx, pairs)
 
     emit(
         "run:start",
@@ -344,7 +364,6 @@ def run_pairs(ctx) -> dict[str, Any]:
     errors_total = 0
     attempted_add_duplicate_keys_total = 0
 
-    pairs = [p for p in (cfg.get("pairs") or []) if coerce_bool(p.get("enabled", True), True)]
     provs = ctx.providers or {}
 
     features_ran: set[str] = set()

--- a/cw_platform/orchestrator/facade.py
+++ b/cw_platform/orchestrator/facade.py
@@ -53,6 +53,7 @@ class Orchestrator:
 
     dry_run: bool = False
     only_feature: str | None = None
+    pair_scope_ids: Sequence[str] | None = None
     write_state_json: bool = True
     state_path: Path | None = None
 
@@ -141,6 +142,7 @@ class Orchestrator:
             emit_rate_warnings=self.emit_rate_warnings,
             tomb_prune=self.prune_tombstones,
             only_feature=self.only_feature,
+            pair_scope_ids=list(self.pair_scope_ids or []),
             write_state_json=self.write_state_json,
             state_path=self.state_path,
             snap_cache=self.snap_cache,
@@ -156,6 +158,7 @@ class Orchestrator:
         *,
         dry_run: bool = False,
         only_feature: str | None = None,
+        pair_scope_ids: Iterable[str] | None = None,
         write_state_json: bool = True,
         state_path: str | None = None,
         progress: Callable[[str], None] | bool | None = None,
@@ -183,6 +186,7 @@ class Orchestrator:
 
             self.dry_run = bool(dry_run)
             self.only_feature = only_feature
+            self.pair_scope_ids = tuple(str(x).strip() for x in (pair_scope_ids or []) if str(x).strip()) or None
             self.write_state_json = bool(write_state_json)
             self.state_path = Path(state_path) if state_path else None
 
@@ -237,6 +241,17 @@ class Orchestrator:
         state_path: str | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
+        pair_id = str((pair or {}).get("id") or (pair or {}).get("pair_id") or "").strip()
+        if pair_id:
+            only_feat = (pair or {}).get("feature")
+            return self.run(
+                dry_run=dry_run,
+                only_feature=only_feat,
+                pair_scope_ids=[pair_id],
+                write_state_json=write_state_json,
+                state_path=state_path,
+                **kwargs,
+            )
         saved = self.cfg
         try:
             cfg_copy = dict(saved)

--- a/services/playlists.py
+++ b/services/playlists.py
@@ -28,7 +28,6 @@ _MEMBERSHIP = {"add_only", "managed_only", "mirror"}
 _ORDER = {"ignore", "preserve"}
 _NAME_MAX = 10
 _PLAYLIST_NAME_MAX = 20
-_PAIR_SCOPE_ORIGINAL_PAIRS_KEY = "_cw_pair_scope_original_pairs"
 _SAFE_NAME_CHARS = " _.'-&()"
 
 
@@ -1254,9 +1253,4 @@ def cleanup_state(cfg: Mapping[str, Any]) -> dict[str, Any]:
 def _save(cfg: dict[str, Any]) -> None:
     from cw_platform.config_base import save_config
 
-    original_pairs = cfg.get(_PAIR_SCOPE_ORIGINAL_PAIRS_KEY)
-    if isinstance(original_pairs, list):
-        cfg = dict(cfg)
-        cfg["pairs"] = original_pairs
-        cfg.pop(_PAIR_SCOPE_ORIGINAL_PAIRS_KEY, None)
     save_config(cfg)

--- a/tests/test_access_audit_fixes.py
+++ b/tests/test_access_audit_fixes.py
@@ -154,15 +154,14 @@ def test_run_sync_allows_own_pair_and_pins_server_side_scope(monkeypatch) -> Non
     assert "pair_scope" not in overrides
 
 
-def test_run_pairs_thread_scope_filter_precedes_single_pair_selection() -> None:
+def test_run_pairs_thread_passes_pair_scope_without_narrowing_config() -> None:
     from api import syncAPI as sync_api
     import inspect
 
     src = inspect.getsource(sync_api._run_pairs_thread)
-    scope_at = src.find('cfg["pairs"] = [p for p in (cfg.get("pairs") or []) if str(p.get("id") or "") in req_pair_ids]')
-    single_at = src.find('if req_pair_id:\n            pair = next(')
-    assert scope_at > 0 and single_at > 0
-    assert scope_at < single_at
+    assert 'cfg["pairs"] = [p for p in (cfg.get("pairs") or []) if str(p.get("id") or "") in req_pair_ids]' not in src
+    assert 'cfg["pairs"] = [pair]' not in src
+    assert "pair_scope_ids=sorted(pair_scope_ids)" in src
 
 
 # H2 - the OIDC login callback must be bound to the browser that started the flow

--- a/tests/test_playlists_orchestration.py
+++ b/tests/test_playlists_orchestration.py
@@ -232,6 +232,38 @@ def test_playlist_pair_refreshes_mapping_endpoints_after_run(config_base, monkey
     assert calls == ["MAP-01"]
 
 
+def test_pair_scope_runs_playlist_pair_without_narrowing_config(config_base, monkeypatch):
+    seen: list[str] = []
+    cfg = _pair_cfg("one-way")
+    cfg["pairs"][0]["id"] = "pair_playlist_1"
+    cfg["pairs"].insert(0, {
+        "id": "regular_pair",
+        "source": "FAKESRC",
+        "target": "FAKEDST",
+        "source_instance": "default",
+        "target_instance": "default",
+        "enabled": True,
+        "mode": "one-way",
+        "features": {"watchlist": {"enable": True}},
+    })
+    ctx = _ctx(cfg)
+    ctx.pair_scope_ids = ["pair_playlist_1"]
+
+    def fake_playlist(ctx, src, dst, *, fcfg, health_map, full_cfg, pair):
+        seen.append(str(pair.get("id") or ""))
+        assert full_cfg is cfg
+        assert [p["id"] for p in full_cfg["pairs"]] == ["regular_pair", "pair_playlist_1"]
+        return {"added": 1, "removed": 0, "updated": 0, "unresolved": 0, "skipped": 0, "errors": 0}
+
+    monkeypatch.setattr(pairs, "run_playlist_mappings", fake_playlist)
+    monkeypatch.setattr(pairs, "run_one_way_feature", lambda *a, **k: (_ for _ in ()).throw(AssertionError("regular pair should not run")))
+
+    result = pairs.run_pairs(ctx)
+
+    assert seen == ["pair_playlist_1"]
+    assert result["added"] == 1
+
+
 def test_manual_and_scheduled_share_core_runner():
     from services import playlists as svc
 

--- a/tests/test_playlists_service.py
+++ b/tests/test_playlists_service.py
@@ -450,24 +450,6 @@ def test_clear_activity_resets_playlist_run_metadata(config_base, fake_providers
     assert svc.activity(cfg) == []
 
 
-def test_playlist_save_preserves_pairs_for_scoped_sync(monkeypatch):
-    from cw_platform import config_base
-
-    saved: list[dict[str, Any]] = []
-    full_pairs = [{"id": "pair_1"}, {"id": "pair_2"}, {"id": "pair_playlist_1"}]
-    scoped_cfg = {
-        "pairs": [{"id": "pair_playlist_1"}],
-        "playlists": {"endpoints": [], "mappings": []},
-        "_cw_pair_scope_original_pairs": full_pairs,
-    }
-    monkeypatch.setattr(config_base, "save_config", lambda cfg: saved.append(cfg))
-
-    svc._save(scoped_cfg)
-
-    assert saved[0]["pairs"] == full_pairs
-    assert "_cw_pair_scope_original_pairs" not in saved[0]
-
-
 def test_mappings_for_pair_compat_and_one_pair(config_base, fake_providers):
     cfg = _cfg()
     e1, e2 = _seed_endpoints(cfg)


### PR DESCRIPTION
# Pull request

## Change

- Add runtime pair scoping to the orchestrator.
- Pass `pair_scope_ids` from `/api/run` instead of rewriting `cfg["pairs"]`.
- Scope health checks and pair execution without mutating the saved config path.
- Remove the temporary scoped-config save workaround.

## Why

Single-pair runs should run only the requested pair, but the full config must stay intact so metadata saves cannot drop other sync pairs.

## Testing

- tests/test_playlists_orchestration.py 
- tests/test_access_audit_fixes.py::test_run_sync_allows_own_pair_and_pins_server_side_scope
- tests/test_access_audit_fixes.py::test_run_pairs_thread_passes_pair_scope_without_narrowing_config
- tests/test_sync_cancel.py::test_cancelled_run_marks_summary_and_reports_failure -q`

## Issue

NA