### PR TITLE
Change: secure webhook replay and malformed payload logging

### DIFF
--- a/api/scrobbleAPI.py
+++ b/api/scrobbleAPI.py
@@ -309,6 +309,15 @@ def _webhook_ignore_log(prefix: str, target_error: dict[str, Any] | None) -> tup
     return f"{prefix}: ignored ({text})", level
 
 
+def _webhook_parse_failure_log(prefix: str, provider: str, content_type: str, raw: bytes | bytearray | None, exc: BaseException) -> str:
+    body_len = len(raw or b"")
+    err_cls = exc.__class__.__name__
+    return (
+        f"{prefix}: failed to parse payload | provider={provider} "
+        f"content-type='{content_type or ''}' bytes={body_len} error_class={err_cls}"
+    )
+
+
 def _resolve_plexwatcher_target(request: Request) -> tuple[str, dict[str, Any], dict[str, Any] | None]:
     cfg = load_config() or {}
     ids = _ensure_webhook_ids(cfg)
@@ -1409,13 +1418,7 @@ async def webhook_jellyfintrakt(request: Request) -> JSONResponse:
             payload = json.loads(raw.decode("utf-8", errors="replace")) if raw else {}
             log("jf-webhook: parsed json payload", "DEBUG")
     except Exception as e:
-        snippet = (
-            raw[:200].decode("utf-8", errors="replace") if raw else "<no body>"
-        )
-        log(
-            f"jf-webhook: failed to parse payload: {e} | body[:200]={snippet}",
-            "ERROR",
-        )
+        log(_webhook_parse_failure_log("jf-webhook", "jellyfin", ct, raw, e), "ERROR")
         return JSONResponse({"ok": True}, status_code=200)
 
     md = (
@@ -1568,13 +1571,7 @@ async def webhook_embytrakt(request: Request) -> JSONResponse:
             payload = json.loads(raw.decode("utf-8", errors="replace")) if raw else {}
             log("emby-webhook: parsed json payload", "DEBUG")
     except Exception as e:
-        snippet = (
-            raw[:200].decode("utf-8", errors="replace") if raw else "<no body>"
-        )
-        log(
-            f"emby-webhook: failed to parse payload: {e} | body[:200]={snippet}",
-            "ERROR",
-        )
+        log(_webhook_parse_failure_log("emby-webhook", "emby", ct, raw, e), "ERROR")
         return JSONResponse({"ok": True}, status_code=200)
 
     md = (
@@ -1732,13 +1729,7 @@ async def webhook_trakt(request: Request) -> JSONResponse:
             payload = json.loads(raw.decode("utf-8", errors="replace")) if raw else {}
             log("plex-webhook: parsed json payload", "DEBUG")
     except Exception as e:
-        snippet = (
-            raw[:200].decode("utf-8", errors="replace") if raw else "<no body>"
-        )
-        log(
-            f"plex-webhook: failed to parse payload: {e} | body[:200]={snippet}",
-            "ERROR",
-        )
+        log(_webhook_parse_failure_log("plex-webhook", "plex", ct, raw, e), "ERROR")
         return JSONResponse({"ok": True}, status_code=200)
 
     payload = payload or {}
@@ -1848,7 +1839,7 @@ async def webhook_plexwatcher(request: Request) -> JSONResponse:
         else:
             payload = json.loads(raw.decode("utf-8", errors="replace")) if raw else {}
     except Exception as e:
-        log(f"plexwatcher-webhook: failed to parse payload: {e}", "ERROR")
+        log(_webhook_parse_failure_log("plexwatcher-webhook", "plexwatcher", ct, raw, e), "ERROR")
         payload = {}
 
     if not isinstance(payload, dict):

--- a/providers/webhooks/emby.py
+++ b/providers/webhooks/emby.py
@@ -526,6 +526,28 @@ def _make_session_id(payload: Mapping[str, Any], md: Mapping[str, Any], ids_all:
     return base + "|" + _session_media_key(md, ids_all, root=payload)
 
 
+def _completion_session_token(payload: Mapping[str, Any]) -> str:
+    for key in ("PlaySessionId", "SessionId", "SessionID"):
+        val = str(payload.get(key) or "").strip()
+        if val:
+            return val
+    return ""
+
+
+def _completion_replay_key(
+    provider_instance: str,
+    account: Any,
+    session_token: str,
+    media_key: str,
+) -> str:
+    session_token = str(session_token or "").strip()
+    media_key = str(media_key or "").strip()
+    if not (session_token and media_key):
+        return ""
+    acc_key = str(account or "").strip().lower() or "unknown"
+    return f"emby:{provider_instance}|u:{acc_key}|s:{session_token}|m:{media_key}"
+
+
 def _guid_search_episode(epi_hint: dict[str, Any], cfg: dict[str, Any], logger: Any | None = None) -> dict[str, Any]:
     try:
         q = {k: epi_hint.get(k) for k in ("tmdb", "imdb", "tvdb") if epi_hint.get(k)}
@@ -964,6 +986,12 @@ def process_webhook(
         now = time.time()
         st = _SCROBBLE_STATE.get(ses) or {}
         ev_lc = event
+        completion_key = _completion_replay_key(
+            provider_instance,
+            acc_title,
+            _completion_session_token(payload),
+            _session_media_key(md, ids_all, root=payload),
+        )
 
         intended: str | None
         if ev_lc in ("playbackstart", "playbackunpause", "play", "playing", "resume", "unpause"):
@@ -1025,6 +1053,25 @@ def process_webhook(
         if intended != "/scrobble/start" and st_prog and (st_prog - prog) > regress_tol:
             _emit(logger, f"regress {st_prog}->{prog} within tol {regress_tol}", "DEBUG")
             prog = st_prog
+
+        if (
+            intended == "/scrobble/stop"
+            and prog >= watched_at
+            and completion_key
+            and st.get("completion_key") == completion_key
+            and st.get("completion_done") is True
+        ):
+            _emit(logger, "suppress duplicate completion replay", "DEBUG")
+            _SCROBBLE_STATE[ses] = {
+                **st,
+                "ts": now,
+                "last_event": ev_lc,
+                "prog": prog,
+                "finished": True,
+                **({"last_stop_ts": now} if intended == "/scrobble/stop" else {}),
+                "retry_completion": False,
+            }
+            return {"ok": True, "suppressed": True, "dedup": True}
 
         cw_ids = dict(ids_all)
         title = (md.get("SeriesName") or md.get("Name") or "").strip()
@@ -1119,6 +1166,7 @@ def process_webhook(
         activity_recorded = bool(rj.get("activity_recorded")) if isinstance(rj, dict) else False
 
         if r.status_code < 400:
+            completed_success = activity_recorded and intended == "/scrobble/stop" and prog >= watched_at
             if activity_recorded and intended == "/scrobble/stop" and prog >= watched_at and not st.get("wl_removed") is True:
                 try:
                     _call_remove_across(ids_all or {}, media_type, origin=f"emby:{provider_instance}")
@@ -1136,6 +1184,8 @@ def process_webhook(
                 "paused": intended == "pause",
                 **({"last_stop_ts": now} if intended == "/scrobble/stop" else {}),
                 **({"last_play_ts": now} if intended == "/scrobble/start" else {}),
+                **({"completion_key": completion_key, "completion_done": True} if completed_success and completion_key else {}),
+                "retry_completion": False,
             }
 
             try:
@@ -1166,6 +1216,7 @@ def process_webhook(
             "finished": prog >= complete_at,
             **({"wl_removed": st.get("wl_removed")} if st.get("wl_removed") else {}),
             "paused": st.get("paused") if paused_flag is None else paused_flag,
+            "retry_completion": bool(intended == "/scrobble/stop" and prog >= watched_at),
         }
         return {"ok": False, "status": r.status_code, "trakt": rj}
     except Exception as e:

--- a/providers/webhooks/jellyfin.py
+++ b/providers/webhooks/jellyfin.py
@@ -1012,6 +1012,28 @@ def _make_session_id(payload: Mapping[str, Any], md: Mapping[str, Any], ids_all:
     return base + "|" + _session_media_key(md, ids_all, root=payload)
 
 
+def _completion_session_token(payload: Mapping[str, Any]) -> str:
+    for key in ("PlaySessionId", "SessionId"):
+        val = str(payload.get(key) or "").strip()
+        if val:
+            return val
+    return ""
+
+
+def _completion_replay_key(
+    provider_instance: str,
+    account: Any,
+    session_token: str,
+    media_key: str,
+) -> str:
+    session_token = str(session_token or "").strip()
+    media_key = str(media_key or "").strip()
+    if not (session_token and media_key):
+        return ""
+    acc_key = str(account or "").strip().lower() or "unknown"
+    return f"jellyfin:{provider_instance}|u:{acc_key}|s:{session_token}|m:{media_key}"
+
+
 def _archive(event_type: str, media_type: str, md: dict[str, Any], payload: dict[str, Any], ids: dict[str, Any], account: Any, prog: Any, reason: str | None = None) -> None:
     try:
         from cw_platform.event_archive import record_webhook
@@ -1145,6 +1167,12 @@ def process_webhook(
         st = _SCROBBLE_STATE.get(sess) or {}
         first_seen = float(st.get("first_seen") or now)
         st = {**st, "first_seen": first_seen}
+        completion_key = _completion_replay_key(
+            provider_instance,
+            acc_title,
+            _completion_session_token(payload),
+            item_key,
+        )
 
         ev_lc = (event or "").lower()
         paused_flag = _extract_paused(payload)
@@ -1153,6 +1181,7 @@ def process_webhook(
         if (
             st.get("last_event") == ev_lc
             and (now - float(st.get("ts", 0))) < 1.0
+            and not st.get("retry_completion")
             and not (paused_flag is not None and paused_flag != st.get("paused"))
         ):
             return {"ok": True, "dedup": True}
@@ -1368,7 +1397,7 @@ def process_webhook(
 
         if intended == "/scrobble/stop" and prog >= complete_at:
             fin = _LAST_FINISH_BY_ACC.get(acc_key) or {}
-            if fin.get("ik") == item_key and (now - float(fin.get("ts") or 0)) <= _DUP_FINISH_WINDOW_S:
+            if fin.get("ik") == item_key and fin.get("sess") == sess and (now - float(fin.get("ts") or 0)) <= _DUP_FINISH_WINDOW_S:
                 _emit(logger, "suppress duplicate finish (stop<->scrobble)", "DEBUG")
                 _SCROBBLE_STATE[sess] = {
                     **st,
@@ -1383,6 +1412,28 @@ def process_webhook(
                     "last_stop_ts": now,
                 }
                 return {"ok": True, "suppressed": True}
+        if (
+            intended == "/scrobble/stop"
+            and prog >= watched_at
+            and completion_key
+            and st.get("completion_key") == completion_key
+            and st.get("completion_done") is True
+        ):
+            _emit(logger, "suppress duplicate completion replay", "DEBUG")
+            _SCROBBLE_STATE[sess] = {
+                **st,
+                "ts": now,
+                "last_event": ev_lc,
+                "last_pause_ts": st.get("last_pause_ts", 0),
+                "prog": prog,
+                "sk": sk_current,
+                "finished": True,
+                **({"wl_removed": st.get("wl_removed")} if st.get("wl_removed") else {}),
+                "paused": False,
+                "last_stop_ts": now,
+                "retry_completion": False,
+            }
+            return {"ok": True, "suppressed": True, "dedup": True}
         if (
             ev_lc in ("playbackstop", "playbackstopped")
             and st.get("last_event") in ("playbackstop", "playbackstopped")
@@ -1499,8 +1550,9 @@ def process_webhook(
         activity_recorded = bool(rj.get("activity_recorded")) if isinstance(rj, dict) else False
 
         if r.status_code < 400:
+            completed_success = activity_recorded and intended == "/scrobble/stop" and prog >= watched_at
             if activity_recorded and intended == "/scrobble/stop" and prog >= watched_at:
-                _LAST_FINISH_BY_ACC[acc_key] = {"ik": item_key, "ts": now}
+                _LAST_FINISH_BY_ACC[acc_key] = {"ik": item_key, "sess": sess, "ts": now}
             if activity_recorded and intended == "/scrobble/stop" and prog >= watched_at and not (st.get("wl_removed") is True):
                 try:
                     _call_remove_across(ids_all or {}, media_type, origin=f"jellyfin:{provider_instance}")
@@ -1517,6 +1569,9 @@ def process_webhook(
                 **({"wl_removed": st.get("wl_removed")} if st.get("wl_removed") else {}),
                 "paused": (intended == "pause"),
                 **({"last_stop_ts": now} if intended == "/scrobble/stop" else {}),
+                "completion_key": completion_key if completed_success and completion_key else "",
+                "completion_done": bool(completed_success and completion_key),
+                "retry_completion": False,
             }
 
             try:
@@ -1545,6 +1600,7 @@ def process_webhook(
             "finished": (prog >= complete_at),
             **({"wl_removed": st.get("wl_removed")} if st.get("wl_removed") else {}),
             "paused": st.get("paused") if paused_flag is None else paused_flag,
+            "retry_completion": bool(intended == "/scrobble/stop" and prog >= watched_at),
         }
         return {"ok": False, "status": r.status_code, "trakt": rj}
     except Exception as e:

--- a/providers/webhooks/plex.py
+++ b/providers/webhooks/plex.py
@@ -1028,6 +1028,29 @@ def _map_event(event: str) -> str | None:
     return None
 
 
+def _completion_session_token(payload: Mapping[str, Any], md: Mapping[str, Any]) -> str:
+    for source in (payload, md):
+        for key in ("PlaySessionId", "playSessionId", "SessionId", "sessionId", "SessionKey", "sessionKey"):
+            val = str(source.get(key) or "").strip()
+            if val:
+                return val
+    return ""
+
+
+def _completion_replay_key(
+    provider_instance: str,
+    account_key: str,
+    session_token: str,
+    rating_key: str,
+) -> str:
+    session_token = str(session_token or "").strip()
+    rating_key = str(rating_key or "").strip()
+    if not (session_token and rating_key):
+        return ""
+    account_key = str(account_key or "").strip().lower() or "unknown"
+    return f"plex:{provider_instance}|u:{account_key}|s:{session_token}|m:{rating_key}"
+
+
 def _verify_signature(raw: bytes | None, headers: Mapping[str, str], secret: str) -> bool:
     if not secret:
         return True
@@ -1352,15 +1375,18 @@ def process_webhook(
     prog_raw = _progress(md)
     acc_key = _account_key(payload)
     rk = str(md.get("ratingKey") or md.get("ratingkey") or "")
+    completion_session = _completion_session_token(payload, md)
+    completion_key = _completion_replay_key(provider_instance, acc_key, completion_session, rk)
     player_uuid = str((payload.get("Player") or {}).get("uuid") or "")
-    sess = f"rk:{rk}|p:{player_uuid or 'na'}|u:{acc_key}"
+    sess_token = completion_session or player_uuid or "na"
+    sess = f"rk:{rk}|s:{sess_token}|p:{player_uuid or 'na'}|u:{acc_key}"
 
     now = time.time()
     st = _SCROBBLE_STATE.get(sess) or {}
     first_seen = float(st.get("first_seen") or now)
     st = {**st, "first_seen": first_seen}
 
-    if st.get("last_event") == event and (now - float(st.get("ts", 0))) < 1.0:
+    if st.get("last_event") == event and (now - float(st.get("ts", 0))) < 1.0 and not st.get("retry_completion"):
         return {"ok": True, "dedup": True}
     if event == "media.pause" and (now - float(st.get("last_pause_ts", 0))) < pause_debounce:
         _emit(logger, f"debounce pause ({pause_debounce}s)", "DEBUG")
@@ -1571,7 +1597,7 @@ def process_webhook(
 
     if event in ("media.stop", "media.scrobble") and prog >= force_stop_at:
         fin = _LAST_FINISH_BY_ACC.get(acc_key)
-        if fin and str(fin.get("rk") or "") == str(rk or "") and (now - float(fin.get("ts", 0))) <= 180:
+        if fin and str(fin.get("rk") or "") == str(rk or "") and fin.get("sess") == sess and (now - float(fin.get("ts", 0))) <= 180:
             _emit(logger, "suppress duplicate finish (stop<->scrobble)", "DEBUG")
             _SCROBBLE_STATE[sess] = {**st,                "ts": now,
                 "last_event": event,
@@ -1583,8 +1609,24 @@ def process_webhook(
             _update_playback_state()
             return {"ok": True, "suppressed": True}
 
-    if event in ("media.stop", "media.scrobble") and prog >= force_stop_at:
-        _LAST_FINISH_BY_ACC[_account_key(payload)] = {"rk": str(rk or ""), "ts": now}
+    if (
+        intended == "/scrobble/stop"
+        and prog >= watched_at
+        and completion_key
+        and st.get("completion_key") == completion_key
+        and st.get("completion_done") is True
+    ):
+        _emit(logger, "suppress duplicate completion replay", "DEBUG")
+        _SCROBBLE_STATE[sess] = {**st,            "ts": now,
+            "last_event": event,
+            "last_pause_ts": st.get("last_pause_ts", 0),
+            "prog": prog,
+            "finished": True,
+            **({"wl_removed": st.get("wl_removed")} if st.get("wl_removed") else {}),
+            "retry_completion": False,
+        }
+        _update_playback_state()
+        return {"ok": True, "suppressed": True, "dedup": True}
 
     _update_playback_state()
 
@@ -1636,6 +1678,7 @@ def process_webhook(
     activity_recorded = bool(rj.get("activity_recorded")) if isinstance(rj, dict) else False
 
     if r.status_code < 400:
+        completed_success = activity_recorded and intended == "/scrobble/stop" and prog >= watched_at
         if activity_recorded and intended == "/scrobble/stop" and prog >= watched_at and not (st.get("wl_removed") is True):
             try:
                 _call_remove_across(ids_all2 or {}, media_type, origin=f"plex:{provider_instance}")
@@ -1648,9 +1691,12 @@ def process_webhook(
             "prog": prog,
             "finished": (activity_recorded and intended == "/scrobble/stop" and prog >= watched_at),
             **({"wl_removed": st.get("wl_removed")} if st.get("wl_removed") else {}),
+            "completion_key": completion_key if completed_success and completion_key else "",
+            "completion_done": bool(completed_success and completion_key),
+            "retry_completion": False,
         }
         if activity_recorded and intended == "/scrobble/stop" and prog >= watched_at:
-            _LAST_FINISH_BY_ACC[_account_key(payload)] = {"rk": str(rk or ""), "ts": now}
+            _LAST_FINISH_BY_ACC[_account_key(payload)] = {"rk": str(rk or ""), "sess": sess, "ts": now}
         try:
             action_name = intended.rsplit("/", 1)[-1]
             _emit(logger, f"user='{_mask_account(acc_title)}' {action_name} {prog:.1f}% • {media_name_dbg}", "INFO")
@@ -1662,9 +1708,6 @@ def process_webhook(
             _archive("scrobble_completed", media_type, md, ids_all2, acc_title, prog)
         return {"ok": True, "status": 200, "action": intended, "trakt": rj, "ignored": not activity_recorded}
 
-    if event in ("media.stop", "media.scrobble") and prog >= force_stop_at:
-        _LAST_FINISH_BY_ACC[_account_key(payload)] = {"rk": str(rk or ""), "ts": now}
-
     _emit(logger, f"{intended} {r.status_code} {(str(rj)[:180])}", "ERROR")
     if "trakt" in sinks_cfg and intended in ("/scrobble/start", "/scrobble/stop"):
         _archive("scrobble_failed", media_type, md, ids_all2, acc_title, prog, reason=str(r.status_code))
@@ -1674,5 +1717,6 @@ def process_webhook(
         "prog": prog,
         "finished": (prog >= force_stop_at),
         **({"wl_removed": st.get("wl_removed")} if st.get("wl_removed") else {}),
+        "retry_completion": bool(intended == "/scrobble/stop" and prog >= watched_at),
     }
     return {"ok": False, "status": r.status_code, "trakt": rj}

--- a/tests/test_webhook_completion_replay.py
+++ b/tests/test_webhook_completion_replay.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+class _Resp:
+    def __init__(self, status_code: int = 200, *, activity_recorded: bool = True) -> None:
+        self.status_code = status_code
+        self.text = ""
+        self._body = {"activity_recorded": activity_recorded}
+
+    def json(self) -> dict[str, Any]:
+        return dict(self._body)
+
+
+def _cfg() -> dict[str, Any]:
+    return {
+        "scrobble": {
+            "enabled": True,
+            "sources": {"webhook": True},
+            "webhook": {"sinks": ["trakt"], "pause_debounce_seconds": 0},
+            "trakt": {"complete_at": 95, "force_stop_at": 95, "watched_at": 90},
+        }
+    }
+
+
+def _emby_payload(session_id: str = "session-1") -> dict[str, Any]:
+    return {
+        "NotificationType": "PlaybackStop",
+        "SessionId": session_id,
+        "UserName": "pasca",
+        "Progress": 95,
+        "Item": {
+            "Id": "movie-1",
+            "Type": "Movie",
+            "Name": "Replay Movie",
+            "ProductionYear": 2026,
+            "ProviderIds": {"Tmdb": "550"},
+        },
+    }
+
+
+def _jellyfin_payload(session_id: str = "session-1") -> dict[str, Any]:
+    return {
+        "NotificationType": "scrobble",
+        "SessionId": session_id,
+        "UserName": "pasca",
+        "Progress": 95,
+        "Item": {
+            "Id": "movie-1",
+            "Type": "Movie",
+            "Name": "Replay Movie",
+            "ProductionYear": 2026,
+            "ProviderIds": {"Tmdb": "550"},
+        },
+    }
+
+
+def _plex_payload(session_id: str = "session-1") -> dict[str, Any]:
+    return {
+        "event": "media.scrobble",
+        "sessionKey": session_id,
+        "Account": {"title": "pasca", "uuid": "account-1"},
+        "Player": {"uuid": "player-1"},
+        "Metadata": {
+            "type": "movie",
+            "title": "Replay Movie",
+            "year": 2026,
+            "ratingKey": "movie-1",
+            "duration": 100_000,
+            "viewOffset": 95_000,
+            "Guid": [{"id": "tmdb://550"}],
+        },
+    }
+
+
+def _patch_common(monkeypatch: Any, module: Any, responses: list[_Resp] | None = None) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+    queued = list(responses or [_Resp()])
+
+    def fake_dispatch(provider: str, action: str, **kwargs: Any) -> _Resp:
+        calls.append({"provider": provider, "action": action, **kwargs})
+        if queued:
+            return queued.pop(0)
+        return _Resp()
+
+    if hasattr(module, "_SCROBBLE_STATE"):
+        module._SCROBBLE_STATE.clear()
+    if hasattr(module, "_LAST_FINISH_BY_ACC"):
+        module._LAST_FINISH_BY_ACC.clear()
+    if hasattr(module, "_TRAKT_ID_CACHE"):
+        module._TRAKT_ID_CACHE.clear()
+
+    monkeypatch.setattr(module, "_dispatch_scrobble", fake_dispatch)
+    monkeypatch.setattr(module, "_cw_update", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "_call_remove_across", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "_archive", lambda *args, **kwargs: None)
+    if hasattr(module, "_resolve_trakt_movie_id"):
+        monkeypatch.setattr(module, "_resolve_trakt_movie_id", lambda *args, **kwargs: None)
+    return calls
+
+
+def test_emby_normal_completion_still_writes_once(monkeypatch: Any) -> None:
+    from providers.webhooks import emby
+
+    calls = _patch_common(monkeypatch, emby)
+
+    result = emby.process_webhook(deepcopy(_emby_payload()), {}, cfg=_cfg())
+
+    assert result["ok"] is True
+    assert result["action"] == "/scrobble/stop"
+    assert len(calls) == 1
+    assert calls[0]["action"] == "/scrobble/stop"
+
+
+def test_emby_exact_successful_completion_replay_does_not_write_again(monkeypatch: Any) -> None:
+    from providers.webhooks import emby
+
+    calls = _patch_common(monkeypatch, emby)
+
+    first = emby.process_webhook(deepcopy(_emby_payload()), {}, cfg=_cfg())
+    replay = emby.process_webhook(deepcopy(_emby_payload()), {}, cfg=_cfg())
+
+    assert first["ok"] is True
+    assert replay["ok"] is True
+    assert replay["dedup"] is True
+    assert len(calls) == 1
+
+
+def test_emby_failed_outbound_completion_can_be_retried(monkeypatch: Any) -> None:
+    from providers.webhooks import emby
+
+    calls = _patch_common(
+        monkeypatch,
+        emby,
+        [_Resp(502, activity_recorded=False), _Resp(200, activity_recorded=True)],
+    )
+
+    failed = emby.process_webhook(deepcopy(_emby_payload()), {}, cfg=_cfg())
+    retried = emby.process_webhook(deepcopy(_emby_payload()), {}, cfg=_cfg())
+
+    assert failed["ok"] is False
+    assert retried["ok"] is True
+    assert len(calls) == 2
+
+
+def test_jellyfin_failed_outbound_completion_can_be_retried_immediately(monkeypatch: Any) -> None:
+    from providers.webhooks import jellyfin
+
+    calls = _patch_common(
+        monkeypatch,
+        jellyfin,
+        [_Resp(502, activity_recorded=False), _Resp(200, activity_recorded=True)],
+    )
+    monkeypatch.setattr(jellyfin.time, "time", lambda: 1_000.0)
+
+    failed = jellyfin.process_webhook(deepcopy(_jellyfin_payload("session-1")), {}, cfg=_cfg())
+    retried = jellyfin.process_webhook(deepcopy(_jellyfin_payload("session-1")), {}, cfg=_cfg())
+
+    assert failed["ok"] is False
+    assert retried["ok"] is True
+    assert len(calls) == 2
+
+
+def test_plex_failed_outbound_completion_can_be_retried_immediately(monkeypatch: Any) -> None:
+    from providers.webhooks import plex
+
+    calls = _patch_common(
+        monkeypatch,
+        plex,
+        [_Resp(502, activity_recorded=False), _Resp(200, activity_recorded=True)],
+    )
+    monkeypatch.setattr(plex.time, "time", lambda: 1_000.0)
+
+    failed = plex.process_webhook(deepcopy(_plex_payload("session-1")), {}, cfg=_cfg())
+    retried = plex.process_webhook(deepcopy(_plex_payload("session-1")), {}, cfg=_cfg())
+
+    assert failed["ok"] is False
+    assert retried["ok"] is True
+    assert len(calls) == 2
+
+
+def test_jellyfin_later_legitimate_rewatch_same_media_writes(monkeypatch: Any) -> None:
+    from providers.webhooks import jellyfin
+
+    calls = _patch_common(monkeypatch, jellyfin)
+    now = [1_000.0]
+    monkeypatch.setattr(jellyfin.time, "time", lambda: now[0])
+
+    first = jellyfin.process_webhook(deepcopy(_jellyfin_payload("session-1")), {}, cfg=_cfg())
+    now[0] += 30.0
+    rewatch = jellyfin.process_webhook(deepcopy(_jellyfin_payload("session-2")), {}, cfg=_cfg())
+
+    assert first["ok"] is True
+    assert rewatch["ok"] is True
+    assert len(calls) == 2
+    assert [call["session_key"] for call in calls] == ["session-1|movie-1", "session-2|movie-1"]
+
+
+def test_jellyfin_exact_successful_completion_replay_after_window_is_suppressed(monkeypatch: Any) -> None:
+    from providers.webhooks import jellyfin
+
+    calls = _patch_common(monkeypatch, jellyfin)
+    now = [1_000.0]
+    monkeypatch.setattr(jellyfin.time, "time", lambda: now[0])
+
+    first = jellyfin.process_webhook(deepcopy(_jellyfin_payload("session-1")), {}, cfg=_cfg())
+    now[0] += 181.0
+    replay = jellyfin.process_webhook(deepcopy(_jellyfin_payload("session-1")), {}, cfg=_cfg())
+
+    assert first["ok"] is True
+    assert replay["ok"] is True
+    assert replay["dedup"] is True
+    assert len(calls) == 1
+
+
+def test_plex_safe_session_completion_replay_after_window_is_suppressed(monkeypatch: Any) -> None:
+    from providers.webhooks import plex
+
+    calls = _patch_common(monkeypatch, plex)
+    now = [1_000.0]
+    monkeypatch.setattr(plex.time, "time", lambda: now[0])
+
+    first = plex.process_webhook(deepcopy(_plex_payload("session-1")), {}, cfg=_cfg())
+    now[0] += 181.0
+    replay = plex.process_webhook(deepcopy(_plex_payload("session-1")), {}, cfg=_cfg())
+
+    assert first["ok"] is True
+    assert replay["ok"] is True
+    assert replay["dedup"] is True
+    assert len(calls) == 1
+
+
+def test_plex_separate_playback_sessions_same_media_are_not_deduplicated(monkeypatch: Any) -> None:
+    from providers.webhooks import plex
+
+    calls = _patch_common(monkeypatch, plex)
+    now = [1_000.0]
+    monkeypatch.setattr(plex.time, "time", lambda: now[0])
+
+    first = plex.process_webhook(deepcopy(_plex_payload("session-1")), {}, cfg=_cfg())
+    now[0] += 30.0
+    second = plex.process_webhook(deepcopy(_plex_payload("session-2")), {}, cfg=_cfg())
+
+    assert first["ok"] is True
+    assert second["ok"] is True
+    assert len(calls) == 2
+    assert [call["session_key"] for call in calls] == [
+        "rk:movie-1|s:session-1|p:player-1|u:account-1",
+        "rk:movie-1|s:session-2|p:player-1|u:account-1",
+    ]

--- a/tests/test_webhook_parse_logging.py
+++ b/tests/test_webhook_parse_logging.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_webhook_parse_failure_log_omits_raw_body_snippet() -> None:
+    from api import scrobbleAPI
+
+    raw = b'{"Account":{"title":"secret-user"},"Metadata":{"title":"Private Movie"}}'
+    msg = scrobbleAPI._webhook_parse_failure_log(
+        "plex-webhook",
+        "plex",
+        "application/json",
+        raw,
+        ValueError("parser exploded near Private Movie"),
+    )
+
+    assert "body[:200]" not in msg
+    assert "secret-user" not in msg
+    assert "Private Movie" not in msg
+    assert "parser exploded" not in msg
+    assert "provider=plex" in msg
+    assert "content-type='application/json'" in msg
+    assert f"bytes={len(raw)}" in msg
+    assert "error_class=ValueError" in msg
+
+
+def test_webhook_parse_failure_handlers_do_not_log_body_prefix() -> None:
+    source = (ROOT / "api" / "scrobbleAPI.py").read_text(encoding="utf-8")
+
+    assert "body[:200]" not in source
+    assert "raw[:200]" not in source


### PR DESCRIPTION
# Pull request

## Change

- secure/harden webhook completion replay handling and malformed payload logging.

## Why

- Avoid duplicate completion writes while keeping retries, rewatches, and separate sessions working. 
- Keep raw webhook payload data out of parse failure logs.

## Testing

- tests/test_webhook_completion_replay.py 
- tests/test_webhook_parse_logging.py

## Issue

Relates to own internal vulnerability scan findings
