### PR TITLE
Change: scope provider instances

### DIFF
--- a/api/providerInstancesAPI.py
+++ b/api/providerInstancesAPI.py
@@ -3,10 +3,11 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
-from typing import Any, cast
 import copy
 import re
+from collections.abc import Mapping
 from functools import lru_cache
+from typing import Any, cast
 
 from fastapi import APIRouter, Body, Request
 from fastapi.responses import JSONResponse
@@ -218,16 +219,38 @@ def _profile_scope_provider_key(provider: Any) -> str:
     return "TMDB" if key == "tmdb" else key.upper()
 
 
-def _managed_user_instance_scope(cfg: dict[str, Any], request: Request | None) -> dict[str, set[str]] | None:
+def _authenticated_request_user(cfg: dict[str, Any], request: Request | None) -> Mapping[str, Any] | None:
     if request is None:
         return None
+    try:
+        state = getattr(request, "state", None)
+        user = getattr(state, "cw_user", None) or getattr(state, "user", None)
+        if isinstance(user, Mapping):
+            return user
+    except Exception:
+        pass
+    try:
+        from api.apiTokensAPI import extract_api_token, resolve_api_token
+
+        user = resolve_api_token(cfg, extract_api_token(request))
+        if isinstance(user, Mapping):
+            return user
+    except Exception:
+        pass
     try:
         from api.appAuthAPI import COOKIE_NAME, current_user
 
         user = current_user(cfg, request.cookies.get(COOKIE_NAME))
+        if isinstance(user, Mapping):
+            return user
     except Exception:
-        return None
-    if not isinstance(user, dict) or user.get("is_admin"):
+        pass
+    return None
+
+
+def _managed_user_instance_scope(cfg: dict[str, Any], request: Request | None) -> dict[str, set[str]] | None:
+    user = _authenticated_request_user(cfg, request)
+    if not isinstance(user, Mapping) or user.get("is_admin"):
         return None
     pid = normalize_user_profile_id(user.get("profile_id"))
     if not pid:

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -483,6 +483,56 @@ def test_provider_instances_are_scoped_for_managed_user(monkeypatch) -> None:
     assert [row["id"] for row in all_rows["PLEX"]] == ["PLEX-P01"]
 
 
+def test_provider_instances_are_scoped_for_managed_user_api_token(monkeypatch) -> None:
+    from api import appAuthAPI as auth
+    from api import apiTokensAPI as api_tokens
+    from tests.test_app_auth_api import _auth_cfg, _request
+
+    user_id = "aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa"
+    secret = "A" * 32
+    raw_token = f"{api_tokens.TOKEN_PREFIX}abcdefabcdefabcd.{secret}"
+    store: dict[str, Any] = _auth_cfg()
+    store["user_profiles"] = {
+        ALICE_PROFILE_ID: {"label": "Alice", "instances": {"CROSSWATCH": ["CW-P01"], "PLEX": ["PLEX-P01"]}},
+        BOB_PROFILE_ID: {"label": "Bob", "instances": {"CROSSWATCH": ["CW-P02"], "PLEX": ["PLEX-P02"]}},
+    }
+    _configured_refs(store, [("CROSSWATCH", "CW-P01"), ("CROSSWATCH", "CW-P02"), ("PLEX", "PLEX-P01"), ("PLEX", "PLEX-P02")])
+    store["app_auth"]["users"] = {
+        user_id: {
+            "username": "alice",
+            "enabled": True,
+            "role": "user",
+            "profile_id": ALICE_PROFILE_ID,
+            "permissions": {"dashboard": True},
+            "password": auth._password_hash("secrett2"),
+        }
+    }
+    store["app_auth"]["api_tokens"] = [
+        {
+            "id": "abcdefabcdefabcd",
+            "version": 2,
+            "name": "alice cli",
+            "secret": secret,
+            "prefix": raw_token[: len(api_tokens.TOKEN_PREFIX) + 16 + 1 + 6],
+            "user_id": user_id,
+            "username": "alice",
+            "created_at": auth._now(),
+            "expires_at": 0,
+            "last_used_at": 0,
+        }
+    ]
+    request = _request("/api/provider-instances", method="GET", headers={"Authorization": f"Bearer {raw_token}"})
+
+    monkeypatch.setattr(provider_api, "load_config", lambda: json.loads(json.dumps(store)))
+
+    all_rows = _loads_body(provider_api.api_provider_instances_all(request).body)
+    plex_rows = _loads_body(provider_api.api_provider_instances_provider("PLEX", request).body)
+
+    assert [row["id"] for row in all_rows["CROSSWATCH"]] == ["CW-P01"]
+    assert [row["id"] for row in all_rows["PLEX"]] == ["PLEX-P01"]
+    assert [row["id"] for row in plex_rows] == ["PLEX-P01"]
+
+
 def test_user_profile_detail_is_scoped_for_managed_user(monkeypatch) -> None:
     from api import appAuthAPI as auth
     from tests.test_app_auth_api import _auth_cfg, _request


### PR DESCRIPTION
# Pull request

## Change

- Scope provider instance API results for managed users authenticated with API tokens.

## Why

- Prevent managed users from seeing provider instances outside their assigned profile.

## Testing

- tests/test_crosswatch_profiles.py

## Issue

Relates to own internal vulnerability scan findings