### PR TITLE
Change: keep Plex client ID consistent

### DIFF
--- a/api/authenticationAPI.py
+++ b/api/authenticationAPI.py
@@ -46,6 +46,7 @@ from providers.sync.plex._utils import (
     fetch_libraries_from_cfg,
     inspect_and_persist,
 )
+from providers.sync.plex._common import stable_client_id as plex_stable_client_id
 import providers.sync.plex._utils as plex_utils
 
 __all__ = ["register_auth"]
@@ -451,8 +452,8 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
 
         cid = str((base.get("client_id") or plex.get("client_id") or "")).strip()
         if not cid:
-            cid = secrets.token_hex(12)
-            base["client_id"] = cid
+            cid = plex_stable_client_id()
+        base["client_id"] = cid
         plex["client_id"] = cid
         save_config(cfg)
 

--- a/api/probesAPI.py
+++ b/api/probesAPI.py
@@ -24,6 +24,7 @@ from cw_platform.config_base import load_config as _load_config
 from cw_platform.provider_instances import get_provider_block, list_instance_ids, normalize_instance_id, provider_key
 from providers.auth._auth_KODI import KodiAuthError, verify_connection as verify_kodi_connection
 from providers.sync.simkl._common import simkl_api_params, simkl_user_agent
+from providers.sync.plex._common import stable_client_id as plex_stable_client_id
 
 
 def _provider_auth():
@@ -82,6 +83,20 @@ _USERINFO_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
 _SECRET_CACHE_TAGS: dict[str, str] = {}
 
 _CACHE_LOCK = threading.Lock()
+
+
+def _plex_client_identifier(cfg: Mapping[str, Any] | dict[str, Any]) -> str:
+    plex = cfg.get("plex") if isinstance(cfg, Mapping) else None
+    app_auth = cfg.get("app_auth") if isinstance(cfg, Mapping) else None
+    plex_sso = app_auth.get("plex_sso") if isinstance(app_auth, Mapping) else None
+    for block in (plex, plex_sso):
+        if isinstance(block, Mapping):
+            client_id = str(block.get("client_id") or "").strip()
+            if client_id:
+                return client_id
+    return plex_stable_client_id()
+
+
 _BUST_SEEN: set[str] = set()
 
 _HTTP_TL = threading.local()
@@ -571,7 +586,7 @@ def probe_plex(cfg: dict[str, Any], max_age_sec: int = PROBE_TTL) -> bool:
 
     headers = {
         "X-Plex-Token": token,
-        "X-Plex-Client-Identifier": "crosswatch",
+        "X-Plex-Client-Identifier": _plex_client_identifier(cfg),
         "X-Plex-Product": "CrossWatch",
         "X-Plex-Version": "1.0",
         "Accept": "application/xml",
@@ -738,7 +753,7 @@ def _probe_plex_detail(cfg: dict[str, Any], max_age_sec: int = PROBE_TTL) -> tup
     headers = {
         **UA,
         "X-Plex-Token": token,
-        "X-Plex-Client-Identifier": "crosswatch",
+        "X-Plex-Client-Identifier": _plex_client_identifier(cfg),
         "X-Plex-Product": "CrossWatch",
         "X-Plex-Version": "1.0",
     }
@@ -1564,7 +1579,7 @@ def plex_user_info(cfg: dict[str, Any], max_age_sec: int = USERINFO_TTL) -> dict
         headers = {
             **UA,
             "X-Plex-Token": token,
-            "X-Plex-Client-Identifier": "crosswatch",
+            "X-Plex-Client-Identifier": _plex_client_identifier(cfg),
             "X-Plex-Product": "CrossWatch",
             "X-Plex-Version": "1.0",
         }

--- a/providers/auth/_auth_PLEX.py
+++ b/providers/auth/_auth_PLEX.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import copy
-import secrets
 import time
 from collections.abc import Mapping, MutableMapping
 from typing import Any
@@ -14,6 +13,7 @@ import requests
 from ._auth_base import AuthManifest, AuthProvider, AuthStatus
 from cw_platform.config_base import DEFAULT_CFG, save_config
 from cw_platform.provider_instances import ensure_provider_block, ensure_instance_block, normalize_instance_id
+from providers.sync.plex._common import stable_client_id
 
 try:
     from _logging import log as _real_log
@@ -85,8 +85,8 @@ class PlexAuth(AuthProvider):
 
         cid = str((base.get("client_id") or plex.get("client_id") or "")).strip()
         if not cid:
-            cid = secrets.token_hex(12)
-            base["client_id"] = cid
+            cid = stable_client_id()
+        base["client_id"] = cid
         plex["client_id"] = cid
 
         headers = {

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -32,6 +32,7 @@ from providers.scrobble.scrobble import (
 from providers.scrobble.currently_watching import update_from_event as _cw_update, update_from_payload as _cw_update_payload
 from providers.scrobble.media_filters import event_ignore_reason, log_media_filter_drop
 from providers.scrobble.sources import source_enabled
+from providers.sync.plex._common import stable_client_id
 
 
 _CFG_CACHE: dict[str, Any] = {"ts": 0.0, "cfg": {}}
@@ -107,7 +108,9 @@ def _try_discover_pms_token(cfg: dict[str, Any], baseurl: str, cloud_token: str,
         return None, None
 
     px = cfg.get("plex") or {}
-    client_id = str(px.get("client_id") or "crosswatch").strip() or "crosswatch"
+    client_id = str(px.get("client_id") or "").strip()
+    if not client_id:
+        client_id = stable_client_id()
     want_mid = str(px.get("machine_id") or "").strip().lower() or None
 
     try:

--- a/services/authPlex.py
+++ b/services/authPlex.py
@@ -12,6 +12,8 @@ from urllib.parse import urlencode
 
 import requests
 
+from providers.sync.plex._common import stable_client_id
+
 PLEX_PIN_URL = "https://plex.tv/api/v2/pins"
 PLEX_USER_URL = "https://plex.tv/api/v2/user"
 PLEX_AUTH_URL = "https://app.plex.tv/auth#?"
@@ -45,6 +47,17 @@ def _plex_sso(cfg: dict[str, Any], *, create: bool = False) -> dict[str, Any]:
     return plex_sso
 
 
+def _plex_provider(cfg: dict[str, Any], *, create: bool = False) -> dict[str, Any]:
+    plex = cfg.get("plex")
+    if isinstance(plex, dict):
+        return plex
+    if not create:
+        return {}
+    plex = {}
+    cfg["plex"] = plex
+    return plex
+
+
 def _headers(client_id: str, token: str | None = None) -> dict[str, str]:
     out = {
         "Accept": "application/json",
@@ -60,11 +73,12 @@ def _headers(client_id: str, token: str | None = None) -> dict[str, str]:
 
 def _ensure_client_id(cfg: dict[str, Any]) -> str:
     plex_sso = _plex_sso(cfg, create=True)
-    client_id = str(plex_sso.get("client_id") or "").strip()
-    if client_id:
-        return client_id
-    client_id = f"crosswatch-{secrets.token_hex(10)}"
+    plex = _plex_provider(cfg, create=True)
+    client_id = str(plex.get("client_id") or plex_sso.get("client_id") or "").strip()
+    if not client_id:
+        client_id = stable_client_id()
     plex_sso["client_id"] = client_id
+    plex["client_id"] = client_id
     return client_id
 
 

--- a/tests/test_auth_plex_api.py
+++ b/tests/test_auth_plex_api.py
@@ -301,6 +301,39 @@ def test_plex_start_sets_flow_cookie(monkeypatch) -> None:
     assert f"{plex_api.FLOW_COOKIE_NAME}=" in _all_set_cookie_headers(resp)
 
 
+def test_plex_sso_start_reuses_provider_client_id(monkeypatch) -> None:
+    from services import authPlex
+
+    cfg = _auth_cfg()
+    cfg["plex"] = {"client_id": "main-plex-client"}
+    cfg["app_auth"]["plex_sso"]["client_id"] = "old-sso-client"
+    sent: dict[str, str] = {}
+
+    class Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {"id": "pin-1", "code": "ABCD"}
+
+    def fake_post(_url, *, headers, **_kwargs):
+        sent.update(headers)
+        return Response()
+
+    monkeypatch.setattr(authPlex.requests, "post", fake_post)
+
+    res = authPlex.start_flow(
+        cfg,
+        intent="login",
+        callback_url="https://crosswatch.example/callback",
+        flow_nonce_hash="nonce-hash",
+    )
+
+    assert sent["X-Plex-Client-Identifier"] == "main-plex-client"
+    assert "clientID=main-plex-client" in res["auth_url"]
+    assert cfg["app_auth"]["plex_sso"]["client_id"] == "main-plex-client"
+
+
 def test_plex_login_check_requires_matching_flow_cookie(monkeypatch) -> None:
     from api import authPlexAPI as plex_api
 


### PR DESCRIPTION
# Pull request

## Change

- Reuse the same Plex client identifier across auth, SSO, probes, and Plex watcher calls.

## Why

- Plex can show CW as a new authorized device when different requests use different client IDs.

## Testing

- tests/test_auth_plex_api.py

## Issue

NA