### PR TITLE
Fix: currently watching profile scoping

### DIFF
--- a/api/scrobbleAPI.py
+++ b/api/scrobbleAPI.py
@@ -9,6 +9,7 @@ import secrets
 import hmac
 import urllib.parse
 import xml.etree.ElementTree as ET
+from collections.abc import Mapping
 from typing import Any, cast
 
 from fastapi import APIRouter, Query, Request, HTTPException, Body
@@ -16,7 +17,7 @@ from fastapi.responses import JSONResponse
 from urllib.parse import parse_qs
 
 from cw_platform.account_match import media_account_allowed
-from cw_platform.access_policy import media_account_allowlist_for_profile
+from cw_platform.access_policy import managed_profile_id, media_account_allowlist_for_profile, request_user
 from cw_platform.config_base import load_config, save_config
 from cw_platform.provider_instances import build_provider_config_view, instances_for_user_profile, list_instance_ids, normalize_instance_id
 from cw_platform.provider_usage import webhook_source_enabled
@@ -1103,12 +1104,16 @@ def api_plex_pms(instance: str | None = Query(None)) -> JSONResponse:
 
 
 def _currently_watching_user_filter(cfg: dict[str, Any], request: Request | None, requested_profile: Any) -> dict[str, Any]:
-    try:
-        from api.appAuthAPI import COOKIE_NAME, effective_user_profile_id
-        token = request.cookies.get(COOKIE_NAME) if request is not None else None
-        profile = effective_user_profile_id(cfg, token, requested_profile)
-    except Exception:
-        profile = "__none__"
+    user = request_user(request)
+    if isinstance(user, Mapping) and not bool(user.get("is_admin")):
+        profile = managed_profile_id(user) or "__none__"
+    else:
+        try:
+            from api.appAuthAPI import COOKIE_NAME, effective_user_profile_id
+            token = request.cookies.get(COOKIE_NAME) if request is not None else None
+            profile = effective_user_profile_id(cfg, token, requested_profile)
+        except Exception:
+            profile = "__none__"
     if not str(profile or "").strip():
         return {}
     user_filter = instances_for_user_profile(cfg, profile)

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -668,6 +668,94 @@ def test_currently_watching_managed_user_forces_own_profile(monkeypatch) -> None
     assert data["currently_watching"]["provider_instance"] == "PLEX-P02"
 
 
+def test_currently_watching_managed_api_token_user_forces_own_profile(monkeypatch) -> None:
+    from api import appAuthAPI as auth
+    from tests.test_app_auth_api import _auth_cfg
+
+    store: dict[str, Any] = _auth_cfg()
+    store["user_profiles"] = {
+        ALICE_PROFILE_ID: {"label": "Alice", "instances": {"PLEX": ["PLEX-P01"]}},
+        BOB_PROFILE_ID: {"label": "Bob", "instances": {"PLEX": ["PLEX-P02"]}},
+    }
+    _configured_refs(store, [("PLEX", "PLEX-P01"), ("PLEX", "PLEX-P02")])
+    store["app_auth"]["users"] = {
+        "aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa": {
+            "username": "bob",
+            "enabled": True,
+            "role": "user",
+            "profile_id": BOB_PROFILE_ID,
+            "permissions": {"dashboard": True},
+            "password": auth._password_hash("secrett2"),
+        }
+    }
+    user = auth._public_user("aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa", store["app_auth"]["users"]["aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa"])
+    request = SimpleNamespace(cookies={}, state=SimpleNamespace(cw_user=user))
+
+    monkeypatch.setattr(scrobble_api, "load_config", lambda: json.loads(json.dumps(store)))
+    monkeypatch.setattr(scrobble_api, "_cw_load_state", _currently_watching_state)
+
+    data = _loads_body(scrobble_api.api_currently_watching(cast(Any, request), user_profile="").body)
+
+    assert data["streams_count"] == 1
+    assert [row["title"] for row in data["streams"]] == ["Bob Movie"]
+    assert data["currently_watching"]["provider_instance"] == "PLEX-P02"
+
+
+def test_currently_watching_managed_api_token_cannot_request_another_profile(monkeypatch) -> None:
+    from api import appAuthAPI as auth
+    from tests.test_app_auth_api import _auth_cfg
+
+    store: dict[str, Any] = _auth_cfg()
+    store["user_profiles"] = {
+        ALICE_PROFILE_ID: {"label": "Alice", "instances": {"PLEX": ["PLEX-P01"]}},
+        BOB_PROFILE_ID: {"label": "Bob", "instances": {"PLEX": ["PLEX-P02"]}},
+    }
+    _configured_refs(store, [("PLEX", "PLEX-P01"), ("PLEX", "PLEX-P02")])
+    store["app_auth"]["users"] = {
+        "aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa": {
+            "username": "bob",
+            "enabled": True,
+            "role": "user",
+            "profile_id": BOB_PROFILE_ID,
+            "permissions": {"dashboard": True},
+            "password": auth._password_hash("secrett2"),
+        }
+    }
+    user = auth._public_user("aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa", store["app_auth"]["users"]["aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa"])
+    request = SimpleNamespace(cookies={}, state=SimpleNamespace(cw_user=user))
+
+    monkeypatch.setattr(scrobble_api, "load_config", lambda: json.loads(json.dumps(store)))
+    monkeypatch.setattr(scrobble_api, "_cw_load_state", _currently_watching_state)
+
+    data = _loads_body(scrobble_api.api_currently_watching(cast(Any, request), user_profile=ALICE_PROFILE_ID).body)
+
+    assert data["streams_count"] == 1
+    assert [row["title"] for row in data["streams"]] == ["Bob Movie"]
+    assert data["currently_watching"]["provider_instance"] == "PLEX-P02"
+
+
+def test_currently_watching_admin_can_read_all_or_requested_profile(monkeypatch) -> None:
+    store: dict[str, Any] = {
+        "user_profiles": {
+            ALICE_PROFILE_ID: {"label": "Alice", "instances": {"PLEX": ["PLEX-P01"]}},
+            BOB_PROFILE_ID: {"label": "Bob", "instances": {"PLEX": ["PLEX-P02"]}},
+        }
+    }
+    _configured_refs(store, [("PLEX", "PLEX-P01"), ("PLEX", "PLEX-P02")])
+    request = SimpleNamespace(cookies={}, state=SimpleNamespace(cw_user={"id": "administrator", "is_admin": True}))
+
+    monkeypatch.setattr(scrobble_api, "load_config", lambda: json.loads(json.dumps(store)))
+    monkeypatch.setattr(scrobble_api, "_cw_load_state", _currently_watching_state)
+
+    all_data = _loads_body(scrobble_api.api_currently_watching(cast(Any, request), user_profile="").body)
+    alice = _loads_body(scrobble_api.api_currently_watching(cast(Any, request), user_profile=ALICE_PROFILE_ID).body)
+
+    assert all_data["streams_count"] == 2
+    assert [row["title"] for row in all_data["streams"]] == ["Bob Movie", "Alice Movie"]
+    assert alice["streams_count"] == 1
+    assert [row["title"] for row in alice["streams"]] == ["Alice Movie"]
+
+
 def test_playback_progress_filter_for_managed_user_forces_own_profile(monkeypatch) -> None:
     from api import appAuthAPI as auth
     from tests.test_app_auth_api import _auth_cfg, _request


### PR DESCRIPTION
# Pull request

## Change

- Fix managed API token scoping for currently watching data.
- Keep admins able to view all or selected profiles.

## Why

- API token users should be scoped the same way as session users.

## Testing

- tests/test_crosswatch_profiles.py

## Issue

Relates to own internal vulnerability scan findings