### PR TITLE
Change: harden Plex SSO flow

### DIFF
--- a/api/authPlexAPI.py
+++ b/api/authPlexAPI.py
@@ -152,6 +152,14 @@ def _unauthorized() -> JSONResponse:
     return JSONResponse({"ok": False, "error": "Unauthorized"}, status_code=401, headers={"Cache-Control": "no-store"})
 
 
+def _temporary_json_error(message: str, status_code: int, retry_after: int) -> JSONResponse:
+    return JSONResponse(
+        {"ok": False, "error": message, "retry_after": max(1, int(retry_after or 1))},
+        status_code=status_code,
+        headers={"Cache-Control": "no-store", "Retry-After": str(max(1, int(retry_after or 1)))},
+    )
+
+
 def _plex_link_conflict_error() -> str:
     return "This Plex account is already linked to another CrossWatch account"
 
@@ -257,18 +265,42 @@ def api_plex_start(request: Request, payload: dict[str, Any] | None = Body(None)
         return JSONResponse({"ok": False, "error": "Plex sign-in is not linked yet"}, status_code=400, headers={"Cache-Control": "no-store"})
 
     remember_me = bool((payload or {}).get("remember_me"))
+    flow_nonce = secrets.token_urlsafe(24)
     try:
-        flow_nonce = secrets.token_urlsafe(24)
-        cfg, data = app_auth._update_config(lambda latest: authPlex.start_flow(
-            latest,
+        def _prepare_login(latest: dict[str, Any]) -> str:
+            if not app_auth.auth_required(latest):
+                raise PermissionError("Authentication setup required")
+            if not authPlex.login_available(latest):
+                raise ValueError("Plex sign-in is not linked yet")
+            return authPlex.ensure_client_id(latest)
+
+        cfg, client_id = app_auth._update_config(_prepare_login)
+    except PermissionError:
+        return JSONResponse(
+            {"ok": False, "error": "Authentication setup required"},
+            status_code=403,
+            headers={"Cache-Control": "no-store"},
+        )
+    except ValueError:
+        return JSONResponse({"ok": False, "error": "Plex sign-in is not linked yet"}, status_code=400, headers={"Cache-Control": "no-store"})
+
+    try:
+        data = authPlex.start_flow(
+            cfg,
             intent="login",
             callback_url=_callback_url(request),
             flow_nonce_hash=authPlex._sha256_hex(flow_nonce),
             remember_me=remember_me,
-        ))
+            client_id=client_id,
+            client_key=app_auth._effective_client_ip(request),
+        )
         resp = JSONResponse(data, headers={"Cache-Control": "no-store"})
         _set_flow_cookie(resp, flow_nonce, request)
         return resp
+    except authPlex.PlexStartRateLimited as exc:
+        return _temporary_json_error("Too many Plex sign-in starts. Try again shortly.", 429, exc.retry_after)
+    except authPlex.PlexPendingCapacityError as exc:
+        return _temporary_json_error("Too many Plex sign-in flows are pending. Try again shortly.", 503, exc.retry_after)
     except Exception as exc:
         _log(f"Plex sign-in could not start: {exc}", level="ERROR")
         return JSONResponse({"ok": False, "error": "Plex sign-in could not start. Please try again."}, status_code=502, headers={"Cache-Control": "no-store"})
@@ -361,17 +393,31 @@ def api_plex_link_start(request: Request, payload: dict[str, Any] | None = Body(
 
     try:
         flow_nonce = secrets.token_urlsafe(24)
-        cfg, data = app_auth._update_config(lambda latest: authPlex.start_flow(
-            latest,
+        def _prepare_link(latest: dict[str, Any]) -> tuple[str, str]:
+            latest_actor = app_auth.current_user(latest, token)
+            latest_target_id, _latest_target_user, _latest_target_raw = _target_user_for_link(app_auth._cfg_auth(latest), latest_actor, (payload or {}).get("user_id"))
+            if not latest_target_id:
+                raise PermissionError("Unauthorized")
+            return latest_target_id, authPlex.ensure_client_id(latest)
+
+        cfg, prepared = app_auth._update_config(_prepare_link)
+        prepared_target_id, client_id = prepared
+        data = authPlex.start_flow(
+            cfg,
             intent="link",
             callback_url=_callback_url(request),
             flow_nonce_hash=authPlex._sha256_hex(flow_nonce),
             remember_me=False,
-            target_user_id=target_id,
-        ))
+            target_user_id=prepared_target_id,
+            client_id=client_id,
+        )
         resp = JSONResponse(data, headers={"Cache-Control": "no-store"})
         _set_flow_cookie(resp, flow_nonce, request)
         return resp
+    except PermissionError:
+        return _unauthorized()
+    except authPlex.PlexPendingCapacityError as exc:
+        return _temporary_json_error("Too many Plex sign-in flows are pending. Try again shortly.", 503, exc.retry_after)
     except Exception as exc:
         _log(f"Plex link could not start: {exc}", level="ERROR")
         return JSONResponse({"ok": False, "error": "Plex link could not start. Please try again."}, status_code=502, headers={"Cache-Control": "no-store"})

--- a/services/authPlex.py
+++ b/services/authPlex.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import hashlib
 import secrets
+import threading
 import time
 from urllib.parse import urlencode
 
@@ -18,8 +19,26 @@ PLEX_PIN_URL = "https://plex.tv/api/v2/pins"
 PLEX_USER_URL = "https://plex.tv/api/v2/user"
 PLEX_AUTH_URL = "https://app.plex.tv/auth#?"
 PENDING_TTL_SEC = 10 * 60
+START_RATE_WINDOW_SEC = 60
+START_RATE_LIMIT = 8
+MAX_PENDING_FLOWS = 64
 
 _PENDING_FLOWS: dict[str, dict[str, Any]] = {}
+_START_EVENTS: dict[str, list[int]] = {}
+_PENDING_STARTS_IN_FLIGHT = 0
+_PENDING_LOCK = threading.RLock()
+
+
+class PlexStartRateLimited(RuntimeError):
+    def __init__(self, retry_after: int) -> None:
+        super().__init__("Plex sign-in start rate limited")
+        self.retry_after = max(1, int(retry_after or 1))
+
+
+class PlexPendingCapacityError(RuntimeError):
+    def __init__(self, retry_after: int = 30) -> None:
+        super().__init__("Too many pending Plex sign-in flows")
+        self.retry_after = max(1, int(retry_after or 1))
 
 
 def _now() -> int:
@@ -82,11 +101,120 @@ def _ensure_client_id(cfg: dict[str, Any]) -> str:
     return client_id
 
 
-def _prune_pending() -> None:
-    now = _now()
-    dead = [k for k, v in _PENDING_FLOWS.items() if int(v.get("expires_at") or 0) <= now]
+def ensure_client_id(cfg: dict[str, Any]) -> str:
+    return _ensure_client_id(cfg)
+
+
+def _prune_pending_locked(now: int | None = None) -> None:
+    ts = _now() if now is None else int(now)
+    dead = [k for k, v in _PENDING_FLOWS.items() if int(v.get("expires_at") or 0) <= ts]
     for key in dead:
         _PENDING_FLOWS.pop(key, None)
+
+
+def _prune_pending() -> None:
+    with _PENDING_LOCK:
+        _prune_pending_locked()
+
+
+def _prune_start_events_locked(now: int) -> None:
+    cutoff = int(now) - START_RATE_WINDOW_SEC
+    for key in list(_START_EVENTS.keys()):
+        kept = [ts for ts in _START_EVENTS.get(key, []) if int(ts) > cutoff]
+        if kept:
+            _START_EVENTS[key] = kept
+        else:
+            _START_EVENTS.pop(key, None)
+
+
+def _capacity_retry_after_locked(now: int) -> int:
+    expiries = [int(v.get("expires_at") or 0) for v in _PENDING_FLOWS.values() if int(v.get("expires_at") or 0) > now]
+    if expiries:
+        return max(1, min(60, min(expiries) - now))
+    return 30
+
+
+def _reserve_start_slot(client_key: str | None = None) -> None:
+    global _PENDING_STARTS_IN_FLIGHT
+    now = _now()
+    key = str(client_key or "").strip()
+    with _PENDING_LOCK:
+        _prune_pending_locked(now)
+        _prune_start_events_locked(now)
+        if key:
+            events = list(_START_EVENTS.get(key) or [])
+            if len(events) >= START_RATE_LIMIT:
+                retry_after = START_RATE_WINDOW_SEC - max(0, now - min(events))
+                raise PlexStartRateLimited(retry_after)
+        if len(_PENDING_FLOWS) + _PENDING_STARTS_IN_FLIGHT >= MAX_PENDING_FLOWS:
+            raise PlexPendingCapacityError(_capacity_retry_after_locked(now))
+        if key:
+            _START_EVENTS[key] = [*events, now]
+        _PENDING_STARTS_IN_FLIGHT += 1
+
+
+def _release_start_slot() -> None:
+    global _PENDING_STARTS_IN_FLIGHT
+    with _PENDING_LOCK:
+        _PENDING_STARTS_IN_FLIGHT = max(0, _PENDING_STARTS_IN_FLIGHT - 1)
+
+
+def _issue_pin(client_id: str) -> tuple[str, str]:
+    resp = requests.post(
+        PLEX_PIN_URL,
+        headers={**_headers(client_id), "Content-Type": "application/x-www-form-urlencoded"},
+        data={"strong": "true"},
+        timeout=20,
+    )
+    resp.raise_for_status()
+    data = resp.json() or {}
+
+    pin_id = str(data.get("id") or "").strip()
+    code = str(data.get("code") or "").strip()
+    if not pin_id or not code:
+        raise RuntimeError("Plex PIN could not be issued")
+    return pin_id, code
+
+
+def _store_pending_flow(
+    *,
+    intent: str,
+    client_id: str,
+    pin_id: str,
+    code: str,
+    callback_url: str,
+    flow_nonce_hash: str,
+    remember_me: bool,
+    target_user_id: str,
+) -> dict[str, Any]:
+    global _PENDING_STARTS_IN_FLIGHT
+    expires_at = _now() + PENDING_TTL_SEC
+    params = {
+        "clientID": client_id,
+        "code": code,
+        "context[device][product]": "CrossWatch",
+        "forwardUrl": str(callback_url or "").strip(),
+    }
+    with _PENDING_LOCK:
+        _PENDING_STARTS_IN_FLIGHT = max(0, _PENDING_STARTS_IN_FLIGHT - 1)
+        state = secrets.token_urlsafe(18)
+        _PENDING_FLOWS[state] = {
+            "intent": str(intent or "").strip(),
+            "client_id": client_id,
+            "pin_id": pin_id,
+            "flow_nonce_hash": str(flow_nonce_hash or "").strip(),
+            "remember_me": bool(remember_me),
+            "target_user_id": str(target_user_id or "").strip(),
+            "expires_at": expires_at,
+        }
+
+    return {
+        "ok": True,
+        "state": state,
+        "pin_id": pin_id,
+        "auth_url": f"{PLEX_AUTH_URL}{urlencode(params)}",
+        "expires_at": expires_at,
+    }
 
 
 def _admin_link(cfg: dict[str, Any], *, create: bool = False) -> dict[str, Any]:
@@ -199,55 +327,38 @@ def start_flow(
     flow_nonce_hash: str,
     remember_me: bool = False,
     target_user_id: str = "",
+    client_id: str = "",
+    client_key: str | None = None,
 ) -> dict[str, Any]:
-    _prune_pending()
+    client_id = str(client_id or "").strip() or _ensure_client_id(cfg)
+    _reserve_start_slot(client_key)
+    reserved = True
 
-    client_id = _ensure_client_id(cfg)
-    resp = requests.post(
-        PLEX_PIN_URL,
-        headers={**_headers(client_id), "Content-Type": "application/x-www-form-urlencoded"},
-        data={"strong": "true"},
-        timeout=20,
-    )
-    resp.raise_for_status()
-    data = resp.json() or {}
-
-    pin_id = str(data.get("id") or "").strip()
-    code = str(data.get("code") or "").strip()
-    if not pin_id or not code:
-        raise RuntimeError("Plex PIN could not be issued")
-
-    expires_at = _now() + PENDING_TTL_SEC
-    state = secrets.token_urlsafe(18)
-    _PENDING_FLOWS[state] = {
-        "intent": str(intent or "").strip(),
-        "client_id": client_id,
-        "pin_id": pin_id,
-        "flow_nonce_hash": str(flow_nonce_hash or "").strip(),
-        "remember_me": bool(remember_me),
-        "target_user_id": str(target_user_id or "").strip(),
-        "expires_at": expires_at,
-    }
-
-    params = {
-        "clientID": client_id,
-        "code": code,
-        "context[device][product]": "CrossWatch",
-        "forwardUrl": str(callback_url or "").strip(),
-    }
-
-    return {
-        "ok": True,
-        "state": state,
-        "pin_id": pin_id,
-        "auth_url": f"{PLEX_AUTH_URL}{urlencode(params)}",
-        "expires_at": expires_at,
-    }
+    try:
+        pin_id, code = _issue_pin(client_id)
+        out = _store_pending_flow(
+            intent=intent,
+            client_id=client_id,
+            pin_id=pin_id,
+            code=code,
+            callback_url=callback_url,
+            flow_nonce_hash=flow_nonce_hash,
+            remember_me=remember_me,
+            target_user_id=target_user_id,
+        )
+        reserved = False
+        return out
+    finally:
+        if reserved:
+            _release_start_slot()
 
 
 def check_flow(cfg: dict[str, Any], *, state: str, intent: str) -> dict[str, Any]:
-    _prune_pending()
-    rec = _PENDING_FLOWS.get(str(state or "").strip())
+    state_key = str(state or "").strip()
+    with _PENDING_LOCK:
+        _prune_pending_locked()
+        rec = _PENDING_FLOWS.get(state_key)
+        rec = dict(rec) if isinstance(rec, dict) else None
     if not isinstance(rec, dict):
         return {"ok": False, "error": "Plex sign-in expired. Start again.", "status_code": 400}
 
@@ -257,7 +368,8 @@ def check_flow(cfg: dict[str, Any], *, state: str, intent: str) -> dict[str, Any
     client_id = str(rec.get("client_id") or _ensure_client_id(cfg)).strip()
     pin_id = str(rec.get("pin_id") or "").strip()
     if not pin_id:
-        _PENDING_FLOWS.pop(str(state or "").strip(), None)
+        with _PENDING_LOCK:
+            _PENDING_FLOWS.pop(state_key, None)
         return {"ok": False, "error": "Plex sign-in expired. Start again.", "status_code": 400}
 
     pin_resp = requests.get(f"{PLEX_PIN_URL}/{pin_id}", headers=_headers(client_id), timeout=20)
@@ -271,7 +383,8 @@ def check_flow(cfg: dict[str, Any], *, state: str, intent: str) -> dict[str, Any
     user_resp.raise_for_status()
     user = user_resp.json() or {}
 
-    _PENDING_FLOWS.pop(str(state or "").strip(), None)
+    with _PENDING_LOCK:
+        _PENDING_FLOWS.pop(state_key, None)
     return {
         "ok": True,
         "pending": False,

--- a/tests/test_auth_plex_api.py
+++ b/tests/test_auth_plex_api.py
@@ -2,7 +2,21 @@ from __future__ import annotations
 
 import json
 
+import pytest
 from starlette.requests import Request
+
+
+@pytest.fixture(autouse=True)
+def _reset_plex_flow_state():
+    from services import authPlex
+
+    authPlex._PENDING_FLOWS.clear()
+    authPlex._START_EVENTS.clear()
+    authPlex._PENDING_STARTS_IN_FLIGHT = 0
+    yield
+    authPlex._PENDING_FLOWS.clear()
+    authPlex._START_EVENTS.clear()
+    authPlex._PENDING_STARTS_IN_FLIGHT = 0
 
 
 def _auth_cfg() -> dict:
@@ -76,6 +90,22 @@ def _bind_config(monkeypatch, plex_api, cfg: dict) -> None:
 
 def _json_body(resp) -> dict:
     return json.loads(resp.body.decode("utf-8"))
+
+
+def _enable_plex_sso(cfg: dict) -> None:
+    cfg["app_auth"]["plex_sso"].update({"enabled": True, "linked_plex_account_id": "plex-123", "linked_username": "plexadmin"})
+
+
+class _PlexPinResponse:
+    def __init__(self, pin_id: str = "pin-1", code: str = "ABCD") -> None:
+        self.pin_id = pin_id
+        self.code = code
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return {"id": self.pin_id, "code": self.code}
 
 
 def _all_set_cookie_headers(resp) -> str:
@@ -299,6 +329,221 @@ def test_plex_start_sets_flow_cookie(monkeypatch) -> None:
 
     assert resp.status_code == 200
     assert f"{plex_api.FLOW_COOKIE_NAME}=" in _all_set_cookie_headers(resp)
+
+
+def test_plex_start_allows_reasonable_unauthenticated_starts(monkeypatch) -> None:
+    from api import authPlexAPI as plex_api
+
+    cfg = _auth_cfg()
+    _enable_plex_sso(cfg)
+    _bind_config(monkeypatch, plex_api, cfg)
+    calls: list[str] = []
+
+    def fake_post(_url, **_kwargs):
+        calls.append(_url)
+        return _PlexPinResponse(f"pin-{len(calls)}", f"CODE{len(calls)}")
+
+    monkeypatch.setattr(plex_api.authPlex.requests, "post", fake_post)
+
+    responses = [
+        plex_api.api_plex_start(_request("/api/app-auth/plex/start", client=("198.51.100.10", 4000 + i)), {})
+        for i in range(6)
+    ]
+
+    assert [resp.status_code for resp in responses] == [200] * 6
+    assert len(calls) == 6
+    assert len(plex_api.authPlex._PENDING_FLOWS) == 6
+
+
+def test_plex_start_throttles_excessive_starts_from_one_client(monkeypatch) -> None:
+    from api import authPlexAPI as plex_api
+
+    cfg = _auth_cfg()
+    _enable_plex_sso(cfg)
+    _bind_config(monkeypatch, plex_api, cfg)
+    calls: list[str] = []
+
+    def fake_post(_url, **_kwargs):
+        calls.append(_url)
+        return _PlexPinResponse(f"pin-{len(calls)}", f"CODE{len(calls)}")
+
+    monkeypatch.setattr(plex_api.authPlex, "START_RATE_LIMIT", 2)
+    monkeypatch.setattr(plex_api.authPlex.requests, "post", fake_post)
+    req = _request("/api/app-auth/plex/start", client=("198.51.100.20", 5000))
+
+    first = plex_api.api_plex_start(req, {})
+    second = plex_api.api_plex_start(req, {})
+    third = plex_api.api_plex_start(req, {})
+
+    assert [first.status_code, second.status_code, third.status_code] == [200, 200, 429]
+    assert _json_body(third)["retry_after"] >= 1
+    assert len(calls) == 2
+    assert len(plex_api.authPlex._PENDING_FLOWS) == 2
+
+
+def test_plex_start_pending_flow_global_cap_is_enforced(monkeypatch) -> None:
+    from api import authPlexAPI as plex_api
+
+    cfg = _auth_cfg()
+    _enable_plex_sso(cfg)
+    _bind_config(monkeypatch, plex_api, cfg)
+    plex_api.authPlex._PENDING_FLOWS.update(
+        {
+            "a": {"expires_at": 1 << 40},
+            "b": {"expires_at": 1 << 40},
+        }
+    )
+    calls: list[str] = []
+
+    monkeypatch.setattr(plex_api.authPlex, "MAX_PENDING_FLOWS", 2)
+    monkeypatch.setattr(plex_api.authPlex.requests, "post", lambda *_args, **_kwargs: calls.append("post") or _PlexPinResponse())
+
+    resp = plex_api.api_plex_start(_request("/api/app-auth/plex/start", client=("198.51.100.30", 5000)), {})
+
+    assert resp.status_code == 503
+    assert _json_body(resp)["retry_after"] >= 1
+    assert calls == []
+    assert len(plex_api.authPlex._PENDING_FLOWS) == 2
+
+
+def test_plex_start_prunes_expired_flows_before_capacity_check(monkeypatch) -> None:
+    from api import authPlexAPI as plex_api
+
+    cfg = _auth_cfg()
+    _enable_plex_sso(cfg)
+    _bind_config(monkeypatch, plex_api, cfg)
+    plex_api.authPlex._PENDING_FLOWS["old"] = {"expires_at": 99}
+
+    monkeypatch.setattr(plex_api.authPlex, "MAX_PENDING_FLOWS", 1)
+    monkeypatch.setattr(plex_api.authPlex, "_now", lambda: 100)
+    monkeypatch.setattr(plex_api.authPlex.requests, "post", lambda *_args, **_kwargs: _PlexPinResponse())
+
+    resp = plex_api.api_plex_start(_request("/api/app-auth/plex/start", client=("198.51.100.40", 5000)), {})
+
+    assert resp.status_code == 200
+    assert "old" not in plex_api.authPlex._PENDING_FLOWS
+    assert len(plex_api.authPlex._PENDING_FLOWS) == 1
+
+
+def test_plex_start_rate_limit_is_per_client(monkeypatch) -> None:
+    from api import authPlexAPI as plex_api
+
+    cfg = _auth_cfg()
+    _enable_plex_sso(cfg)
+    _bind_config(monkeypatch, plex_api, cfg)
+    calls: list[str] = []
+
+    def fake_post(_url, **_kwargs):
+        calls.append(_url)
+        return _PlexPinResponse(f"pin-{len(calls)}", f"CODE{len(calls)}")
+
+    monkeypatch.setattr(plex_api.authPlex, "START_RATE_LIMIT", 1)
+    monkeypatch.setattr(plex_api.authPlex.requests, "post", fake_post)
+
+    client_a_1 = plex_api.api_plex_start(_request("/api/app-auth/plex/start", client=("198.51.100.50", 5000)), {})
+    client_a_2 = plex_api.api_plex_start(_request("/api/app-auth/plex/start", client=("198.51.100.50", 5001)), {})
+    client_b_1 = plex_api.api_plex_start(_request("/api/app-auth/plex/start", client=("198.51.100.51", 5000)), {})
+
+    assert [client_a_1.status_code, client_a_2.status_code, client_b_1.status_code] == [200, 429, 200]
+    assert len(calls) == 2
+    assert len(plex_api.authPlex._PENDING_FLOWS) == 2
+
+
+def test_plex_start_issues_pin_after_config_update_lock(monkeypatch) -> None:
+    from api import authPlexAPI as plex_api
+
+    cfg = _auth_cfg()
+    _enable_plex_sso(cfg)
+    monkeypatch.setattr(plex_api, "load_config", lambda: cfg)
+    in_update = {"active": False}
+    observed = {"post_inside_update": None}
+
+    def fake_update(mutator):
+        in_update["active"] = True
+        try:
+            result = mutator(cfg)
+        finally:
+            in_update["active"] = False
+        return cfg, result
+
+    def fake_post(_url, **_kwargs):
+        observed["post_inside_update"] = in_update["active"]
+        return _PlexPinResponse()
+
+    monkeypatch.setattr(plex_api.app_auth, "_update_config", fake_update)
+    monkeypatch.setattr(plex_api.authPlex.requests, "post", fake_post)
+
+    resp = plex_api.api_plex_start(_request("/api/app-auth/plex/start"), {})
+
+    assert resp.status_code == 200
+    assert observed["post_inside_update"] is False
+
+
+def test_plex_start_failed_outbound_does_not_consume_pending_capacity(monkeypatch) -> None:
+    from api import authPlexAPI as plex_api
+
+    cfg = _auth_cfg()
+    _enable_plex_sso(cfg)
+    _bind_config(monkeypatch, plex_api, cfg)
+    calls = {"n": 0}
+
+    def fake_post(_url, **_kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("plex unavailable")
+        return _PlexPinResponse("pin-ok", "OKOK")
+
+    monkeypatch.setattr(plex_api.authPlex, "MAX_PENDING_FLOWS", 1)
+    monkeypatch.setattr(plex_api.authPlex.requests, "post", fake_post)
+
+    first = plex_api.api_plex_start(_request("/api/app-auth/plex/start", client=("198.51.100.60", 5000)), {})
+    second = plex_api.api_plex_start(_request("/api/app-auth/plex/start", client=("198.51.100.60", 5001)), {})
+
+    assert first.status_code == 502
+    assert second.status_code == 200
+    assert len(plex_api.authPlex._PENDING_FLOWS) == 1
+    assert plex_api.authPlex._PENDING_STARTS_IN_FLIGHT == 0
+
+
+def test_plex_start_then_callback_login_behavior_still_issues_session(monkeypatch) -> None:
+    from api import authPlexAPI as plex_api
+
+    cfg = _auth_cfg()
+    _enable_plex_sso(cfg)
+    _bind_config(monkeypatch, plex_api, cfg)
+
+    class Response:
+        def __init__(self, data: dict) -> None:
+            self._data = data
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return self._data
+
+    monkeypatch.setattr(plex_api.authPlex.requests, "post", lambda *_args, **_kwargs: Response({"id": "pin-1", "code": "ABCD"}))
+
+    def fake_get(url, **_kwargs):
+        if str(url).endswith("/pin-1"):
+            return Response({"authToken": "plex-token"})
+        return Response({"id": "plex-123", "username": "plexadmin", "email": "plex@example.com", "thumb": ""})
+
+    monkeypatch.setattr(plex_api.authPlex.requests, "get", fake_get)
+
+    start = plex_api.api_plex_start(_request("/api/app-auth/plex/start"), {})
+    start_body = _json_body(start)
+    flow_cookie = _all_set_cookie_headers(start).split(f"{plex_api.FLOW_COOKIE_NAME}=", 1)[1].split(";", 1)[0]
+    check = plex_api.api_plex_check(
+        _request("/api/app-auth/plex/check", headers={"cookie": f"{plex_api.FLOW_COOKIE_NAME}={flow_cookie}"}),
+        {"state": start_body["state"]},
+    )
+
+    assert start.status_code == 200
+    assert check.status_code == 200
+    assert _json_body(check)["ok"] is True
+    assert len(cfg["app_auth"]["sessions"]) == 1
+    assert plex_api.authPlex._PENDING_FLOWS == {}
 
 
 def test_plex_sso_start_reuses_provider_client_id(monkeypatch) -> None:


### PR DESCRIPTION
# Pull request

## Change

- Add per-client throttling for Plex SSO start requests.
- Add a global cap for pending Plex SSO flows.
- Move Plex PIN creation outside the config update lock.

## Why

- Prevent unauthenticated start spam from creating unbounded Plex requests and pending login state.
- Keep normal Plex login, retries, and callback behavior working.

## Testing

- tests/test_auth_plex_api.py

## Issue

Relates to own internal vulnerability scan findings