### PR TITLE
Fix: keep title index cache alive after slow builds

### DIFF
--- a/cw_platform/event_archive/context.py
+++ b/cw_platform/event_archive/context.py
@@ -579,7 +579,7 @@ def _title_index() -> dict[str, dict[str, Any]]:
             _ingest_items(d.get("items"))
 
     _TITLE_CACHE["index"] = idx
-    _TITLE_CACHE["ts"] = now
+    _TITLE_CACHE["ts"] = time.monotonic()
     return idx
 
 

--- a/tests/test_event_context.py
+++ b/tests/test_event_context.py
@@ -40,3 +40,43 @@ def test_event_context_title_enrichment_reads_collection_state(tmp_path, monkeyp
         "season": None,
         "episode": None,
     }
+
+
+def test_title_index_cache_timestamp_is_set_after_slow_build(monkeypatch) -> None:
+    context._TITLE_CACHE["index"] = None
+    context._TITLE_CACHE["ts"] = 0.0
+    calls = {"baseline": 0}
+    ticks = iter([100.0, 113.5, 114.0])
+
+    def slow_baseline_states():
+        calls["baseline"] += 1
+        return [
+            {
+                "providers": {
+                    "TRAKT": {
+                        "history": {
+                            "baseline": {
+                                "items": {
+                                    "tmdb:10": {
+                                        "type": "movie",
+                                        "title": "Slow Movie",
+                                        "year": 2026,
+                                        "ids": {"tmdb": "10"},
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+
+    monkeypatch.setattr(context.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(context, "_baseline_states", slow_baseline_states)
+    monkeypatch.setattr(context, "_iter_state_files", lambda *args, **kwargs: iter(()))
+
+    first = context._title_index()
+    second = context._title_index()
+
+    assert first is second
+    assert calls["baseline"] == 1


### PR DESCRIPTION
# Pull request

## Change

- Update the event title index cache timestamp after the index build finishes.

## Why

- Large state loads can take longer than the 8s cache TTL. 
  - That made the cache expire immediately and caused event correlation to rebuild the title index over-andover again.

## Testing

- tests/test_event_context.py

## Issue

Relates to #932
