### PR TITLE
Add: cache dashboard widgets across refreshes

### DIFF
--- a/api/dashboardAPI.py
+++ b/api/dashboardAPI.py
@@ -3,7 +3,10 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude
 from __future__ import annotations
 
-from typing import cast
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, cast
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
@@ -11,6 +14,64 @@ from fastapi.responses import JSONResponse
 from services.dashboard_widgets import dashboard_widgets_payload
 
 router = APIRouter(prefix="/api/dashboard", tags=["dashboard"])
+
+
+def _dashboard_db_stamp(base_path: Any) -> tuple[float, float]:
+    try:
+        from cw_platform.local_db.db import crosswatch_db_path
+
+        db = Path(str(crosswatch_db_path(base_path)))
+        stamp = 0.0
+        wal_stamp = 0.0
+        try:
+            stamp = db.stat().st_mtime
+        except OSError:
+            pass
+        try:
+            wal_stamp = db.with_name(db.name + "-wal").stat().st_mtime
+        except OSError:
+            pass
+        return round(stamp, 3), round(wal_stamp, 3)
+    except Exception:
+        return 0.0, 0.0
+
+
+def _dashboard_config_stamp(base_path: Any) -> float:
+    try:
+        return round((Path(base_path) / "config.json").stat().st_mtime, 3)
+    except OSError:
+        return 0.0
+
+
+def _dashboard_widgets_version(
+    base_path: Any,
+    *,
+    requested: set[str],
+    state_features: set[str],
+    profile: str,
+    limits: dict[str, int],
+) -> str:
+    try:
+        from cw_platform.local_db import state as sqlite_state
+        from cw_platform.local_db import manual_policy as sqlite_manual_policy
+
+        state_fp = sqlite_state.fingerprint(base_path, state_features) if state_features else None
+        policy_fp = sqlite_manual_policy.fingerprint(base_path, state_features) if state_features else None
+    except Exception:
+        state_fp = None
+        policy_fp = None
+    source = {
+        "requested": sorted(requested),
+        "state_features": sorted(state_features),
+        "profile": str(profile or ""),
+        "limits": limits,
+        "state": state_fp,
+        "policy": policy_fp,
+        "db": _dashboard_db_stamp(base_path),
+        "config": _dashboard_config_stamp(base_path),
+    }
+    blob = json.dumps(source, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
 
 
 @router.get("/widgets")
@@ -23,6 +84,7 @@ def dashboard_widgets(
     playlists_limit: int = Query(8, ge=1, le=24),
     include: str = Query("history,ratings,scrobble,progress,playlists"),
     user_profile: str = Query("", alias="user_profile"),
+    known_version: str = Query("", alias="known_version"),
 ) -> JSONResponse:
     try:
         from cw_platform.config_base import CONFIG, load_config
@@ -32,10 +94,26 @@ def dashboard_widgets(
 
         requested = {part.strip() for part in include.split(",") if part.strip()}
         state_features = requested & {"history", "ratings", "progress"}
-        state = StateStore(CONFIG).load_state_features(state_features) if state_features else {}
         cfg = load_config() or {}
         token = request.cookies.get(COOKIE_NAME) if request is not None else None
         profile = effective_user_profile_id(cfg, token, user_profile)
+        limits = {
+            "history": history_limit,
+            "ratings": ratings_limit,
+            "scrobble": scrobble_limit,
+            "progress": progress_limit,
+            "playlists": playlists_limit,
+        }
+        version = _dashboard_widgets_version(
+            CONFIG,
+            requested=requested,
+            state_features=state_features,
+            profile=str(profile or "").strip(),
+            limits=limits,
+        )
+        if known_version and str(known_version).strip() == version:
+            return JSONResponse({"ok": True, "not_modified": True, "version": version}, headers={"Cache-Control": "no-store"})
+        state = StateStore(CONFIG).load_state_features(state_features) if state_features else {}
         scoped = bool(str(profile or "").strip())
         user_filter = instances_for_user_profile(cfg, profile) if scoped else {}
         if scoped and not user_filter:
@@ -50,6 +128,7 @@ def dashboard_widgets(
             include=requested,
             user_filter=user_filter,
         )
+        payload["version"] = version
         if scoped:
             payload["user_profile"] = str(profile or "").strip()
         return JSONResponse(payload, headers={"Cache-Control": "no-store"})

--- a/assets/js/dashboard-widgets.js
+++ b/assets/js/dashboard-widgets.js
@@ -25,6 +25,22 @@
   const WIDE_UNITS = 3;
   const WIDGET_REFRESH_TTL_MS = 60 * 1000;
   const WIDGET_FETCH_RETRY_DELAYS = [350, 900, 1800];
+  const WIDGET_LOADING_DELAY_MS = 700;
+  const REFRESHABLE_WIDGETS = ["history", "ratings", "scrobble", "progress", "playlists"];
+  const WIDGET_PAYLOAD_KEYS = {
+    history: "recent_history",
+    ratings: "latest_ratings",
+    scrobble: "recent_scrobble",
+    progress: "recent_progress",
+    playlists: "recent_playlists",
+  };
+  const WIDGET_COUNT_CHIPS = {
+    history: ["recent-history-count-chip", "item"],
+    ratings: ["latest-ratings-count-chip", "rating"],
+    scrobble: ["recent-scrobble-count-chip", "scrobble"],
+    progress: ["recent-progress-count-chip", "progress sync"],
+    playlists: ["recent-playlists-count-chip", "playlist sync"],
+  };
   const visibleCounts = { history: GRID_PAGE_STEP, ratings: RATING_PAGE_STEP, scrobble: GRID_PAGE_STEP, progress: GRID_PAGE_STEP, playlists: GRID_PAGE_STEP };
   const latestItems = { history: [], ratings: [], scrobble: [], progress: [], playlists: [] };
   const EMPTY_META = {
@@ -39,6 +55,7 @@
   const ON_PROFILE_PAGE = !!document.getElementById("profile-hero");
   const LAYOUT_KEY = ON_PROFILE_PAGE ? "cw.profileWidgets.layout.v3" : "cw.dashboardWidgets.layout.v3";
   const SETTINGS_KEY = "cw.dashboardWidgets.settings.v1";
+  const DATA_CACHE_KEY = ON_PROFILE_PAGE ? "cw.profileWidgets.data.v1" : "cw.dashboardWidgets.data.v1";
   const ALL_WIDGETS = [
     { key: "watchlist", id: "placeholder-card", label: "Watchlist" },
     { key: "history", id: "recent-history-widget", label: "Recent History" },
@@ -139,6 +156,65 @@
       raw.wallEmpty = !!empty;
       localStorage.setItem(SETTINGS_KEY, JSON.stringify(raw));
     } catch {}
+  }
+
+  function widgetDataCacheScope() {
+    return `${ON_PROFILE_PAGE ? "profile" : "main"}:${overviewProfileId() || "all"}`;
+  }
+
+  function readCachedWidgetData() {
+    try {
+      const raw = JSON.parse(localStorage.getItem(DATA_CACHE_KEY) || "null");
+      if (!raw || typeof raw !== "object" || raw.scope !== widgetDataCacheScope()) return null;
+      const payload = raw.payload && typeof raw.payload === "object" ? raw.payload : null;
+      return payload?.ok ? payload : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function writeCachedWidgetData(payload) {
+    try {
+      if (!payload?.ok || payload.not_modified) return;
+      localStorage.setItem(DATA_CACHE_KEY, JSON.stringify({
+        t: Date.now(),
+        scope: widgetDataCacheScope(),
+        payload,
+      }));
+    } catch {}
+  }
+
+  function hasOwn(obj, key) {
+    return Object.prototype.hasOwnProperty.call(obj || {}, key);
+  }
+
+  function normalizeRefreshKinds(kinds) {
+    if (!kinds) return null;
+    const list = Array.isArray(kinds) ? kinds : String(kinds).split(",");
+    const out = list.map((kind) => String(kind || "").trim()).filter((kind) => REFRESHABLE_WIDGETS.includes(kind));
+    return out.length ? new Set(out) : new Set();
+  }
+
+  function applyWidgetPayload(data, active, kinds = null) {
+    const wanted = normalizeRefreshKinds(kinds);
+    let applied = 0;
+    for (const kind of REFRESHABLE_WIDGETS) {
+      if (!active[kind]) continue;
+      if (wanted && !wanted.has(kind)) continue;
+      const payloadKey = WIDGET_PAYLOAD_KEYS[kind];
+      if (!hasOwn(data, payloadKey)) continue;
+      const block = data?.[payloadKey] || {};
+      const items = Array.isArray(block.items) ? block.items : [];
+      const [chipId, chipLabel] = WIDGET_COUNT_CHIPS[kind];
+      setCountChip(chipId, block.total ?? items.length, chipLabel);
+      latestItems[kind] = items;
+      renderWidget(kind);
+      applied += 1;
+    }
+    if (applied) {
+      lastLoadedAt = Date.now();
+      hasLoaded = true;
+    }
   }
 
   function resetLayout() {
@@ -326,7 +402,7 @@
       .finally(() => {
         authRetryQueued = false;
         if (authSetupPending()) return;
-        window.setTimeout(() => refreshDashboardWidgets({ forceConfig: true }), 25);
+        window.setTimeout(() => refreshDashboardWidgets({ forceConfig: true, preserve: true }), 25);
       });
   }
 
@@ -344,26 +420,74 @@
     if (!settings) return;
     applyVisibility(settings);
     const active = activeWidgetSettings(settings);
-    if (active.history) setLoading($("#recent-history-list"));
-    if (active.ratings) setLoading($("#latest-ratings-grid"), "ratings");
-    if (active.scrobble) setLoading($("#recent-scrobble-list"));
-    if (active.progress) setLoading($("#recent-progress-list"));
-    if (active.playlists) setLoading($("#recent-playlists-list"));
+    const cached = readCachedWidgetData();
+    if (cached) {
+      applyWidgetPayload(cached, active);
+      return;
+    }
   }
 
   function markWidgetsDirty(delay = 150, opts = {}) {
     widgetsDirty = true;
     dirtyVersion += 1;
     if (!isOnMain()) return;
-    scheduleWidgetRefresh(delay, { ...opts, force: true, preserve: hasLoaded });
+    const preserve = opts.preserve === false ? hasLoaded : true;
+    scheduleWidgetRefresh(delay, { ...opts, force: true, preserve });
+  }
+
+  function syncLaneHasUpdates(lane) {
+    if (!lane || typeof lane !== "object") return false;
+    for (const key of ["added", "removed", "updated", "created", "deleted", "applied", "failed", "skipped", "blocked"]) {
+      if (Number(lane[key] || 0) > 0) return true;
+    }
+    for (const key of ["spotlight_add", "spotlight_remove", "spotlight_update", "items"]) {
+      if (Array.isArray(lane[key]) && lane[key].length) return true;
+    }
+    return false;
+  }
+
+  function syncFeatureWidgetKind(feature) {
+    const key = String(feature || "").trim().toLowerCase();
+    if (["watch", "watched", "history"].includes(key)) return "history";
+    if (["rating", "ratings"].includes(key)) return "ratings";
+    if (key === "progress") return "progress";
+    if (["playlist", "playlists"].includes(key)) return "playlists";
+    return "";
+  }
+
+  function widgetKindsFromSyncEvent(event) {
+    const features = event?.detail?.summary?.features;
+    if (!features || typeof features !== "object") return null;
+    const kinds = new Set();
+    for (const [feature, lane] of Object.entries(features)) {
+      const kind = syncFeatureWidgetKind(feature);
+      if (kind && syncLaneHasUpdates(lane)) kinds.add(kind);
+    }
+    return Array.from(kinds);
+  }
+
+  function refreshForSyncComplete(event) {
+    const kinds = widgetKindsFromSyncEvent(event);
+    if (kinds === null) {
+      markWidgetsDirty(250);
+    } else if (kinds.length) {
+      markWidgetsDirty(250, { kinds });
+    }
   }
 
   function scheduleScrobbleStopRefresh() {
     window.clearTimeout(scrobbleStopRefreshTimer);
     scrobbleStopRefreshTimer = window.setTimeout(() => {
       scrobbleStopRefreshTimer = null;
-      markWidgetsDirty(0);
+      markWidgetsDirty(0, { kinds: ["scrobble", "history", "progress"] });
     }, 1000);
+  }
+
+  function refreshForScrobbleStopped() {
+    scheduleScrobbleStopRefresh();
+    try {
+      window.dispatchEvent(new CustomEvent("watchlist:refresh", { detail: { source: "scrobble-stop" } }));
+    } catch {}
   }
 
   async function fetchJSON(url) {
@@ -1334,9 +1458,9 @@
       </div>`;
   }
 
-  function setLoading(host, kind = "list") {
+  function setLoading(host, kind) {
     if (!host) return;
-    const widgetKey = kind === "list" ? (host.closest(".cw-dash-widget")?.dataset?.widgetKey || kind) : kind;
+    const widgetKey = WIDGET_KEYS.includes(kind) ? kind : (host.closest(".cw-dash-widget")?.dataset?.widgetKey || kind);
     const view = widgetView(widgetKey);
     setWidgetEmpty(widgetKey, false);
     host.classList.toggle("cw-widget-view-icon", view === "icon");
@@ -1376,6 +1500,16 @@
           <span class="cw-dash-source cw-skel-dot"></span>
         </span>
       </div>`).join("");
+  }
+
+  function scheduleSlowWidgetLoading(hosts, requestedKinds) {
+    if (!requestedKinds.length) return () => {};
+    const timer = window.setTimeout(() => {
+      for (const kind of requestedKinds) {
+        if (!latestItems[kind]?.length) setLoading(hosts[kind], kind);
+      }
+    }, WIDGET_LOADING_DELAY_MS);
+    return () => window.clearTimeout(timer);
   }
 
   function renderCarousel(host, items, count, cardFn, kind) {
@@ -1482,7 +1616,7 @@
     scheduleMasonry();
   }
 
-  async function refreshDashboardWidgets({ forceConfig = false, force = false, preserve = false } = {}) {
+  async function refreshDashboardWidgets({ forceConfig = false, force = false, preserve = true, kinds = null } = {}) {
     if (!isOnMain()) {
       hideDashboardWidgets();
       return;
@@ -1498,6 +1632,8 @@
     const seq = ++loadSeq;
     const refreshVersion = dirtyVersion;
     try { await window.CW?.OverviewProfile?.ready; } catch {}
+    if (seq !== loadSeq || !isOnMain()) return;
+    if (!hasLoaded) revealFromCache();
     let cfg;
     try {
       cfg = await getConfig(forceConfig);
@@ -1517,9 +1653,6 @@
     currentConfig = cfg;
     lastSettings = settings;
     if (seq !== loadSeq || !isOnMain()) return;
-    if (!preserve || !hasLoaded) {
-      ["history", "ratings", "scrobble", "progress", "playlists"].forEach(resetVisibleCount);
-    }
     applyVisibility(settings);
     writeCachedSettings(settings, hasTmdbKeyInConfig(cfg));
     const active = activeWidgetSettings(settings);
@@ -1530,23 +1663,26 @@
     if (!hasTmdbKeyInConfig(cfg)) {
       $("#placeholder-card")?.classList.add("hidden");
     }
+    const cachedPayload = readCachedWidgetData();
+    if (!hasLoaded && cachedPayload) {
+      applyWidgetPayload(cachedPayload, active);
+    }
 
     const historyHost = $("#recent-history-list");
     const ratingsHost = $("#latest-ratings-grid");
     const scrobbleHost = $("#recent-scrobble-list");
     const progressHost = $("#recent-progress-list");
     const playlistsHost = $("#recent-playlists-list");
-    if (!preserve || !hasLoaded) {
-      if (active.history) setLoading(historyHost);
-      if (active.ratings) setLoading(ratingsHost, "ratings");
-      if (active.scrobble) setLoading(scrobbleHost);
-      if (active.progress) setLoading(progressHost);
-      if (active.playlists) setLoading(playlistsHost);
-    }
+    const hosts = { history: historyHost, ratings: ratingsHost, scrobble: scrobbleHost, progress: progressHost, playlists: playlistsHost };
+    const wantedKinds = normalizeRefreshKinds(kinds);
+    const requestedKinds = REFRESHABLE_WIDGETS.filter((key) => active[key] && (!wantedKinds || wantedKinds.has(key)));
+    if (!preserve) requestedKinds.forEach(resetVisibleCount);
+    const partialRefresh = !!wantedKinds;
+    const stopSlowLoading = scheduleSlowWidgetLoading(hosts, requestedKinds);
 
     try {
-      const requestedKinds = ["history", "ratings", "scrobble", "progress", "playlists"].filter((key) => active[key]);
       if (!requestedKinds.length) {
+        stopSlowLoading();
         hasLoaded = true;
         lastLoadedAt = Date.now();
         widgetsDirty = dirtyVersion !== refreshVersion;
@@ -1562,31 +1698,21 @@
       });
       const userProfile = overviewProfileId();
       if (userProfile) params.set("user_profile", userProfile);
+      if (!force && !partialRefresh && cachedPayload?.version) params.set("known_version", cachedPayload.version);
       const data = await fetchWidgetPayload(`/api/dashboard/widgets?${params.toString()}`);
+      stopSlowLoading();
       if (seq !== loadSeq || !isOnMain()) return;
-
-      const historyItems = Array.isArray(data?.recent_history?.items) ? data.recent_history.items : [];
-      const scrobbleItems = Array.isArray(data?.recent_scrobble?.items) ? data.recent_scrobble.items : [];
-      const ratingItems = Array.isArray(data?.latest_ratings?.items) ? data.latest_ratings.items : [];
-      const progressItems = Array.isArray(data?.recent_progress?.items) ? data.recent_progress.items : [];
-      const playlistItems = Array.isArray(data?.recent_playlists?.items) ? data.recent_playlists.items : [];
-      setCountChip("recent-history-count-chip", data?.recent_history?.total ?? historyItems.length, "item");
-      setCountChip("latest-ratings-count-chip", data?.latest_ratings?.total ?? ratingItems.length, "rating");
-      setCountChip("recent-scrobble-count-chip", data?.recent_scrobble?.total ?? scrobbleItems.length, "scrobble");
-      setCountChip("recent-progress-count-chip", data?.recent_progress?.total ?? progressItems.length, "progress sync");
-      setCountChip("recent-playlists-count-chip", data?.recent_playlists?.total ?? playlistItems.length, "playlist sync");
-      latestItems.history = historyItems;
-      latestItems.ratings = ratingItems;
-      latestItems.scrobble = scrobbleItems;
-      latestItems.progress = progressItems;
-      latestItems.playlists = playlistItems;
-      hasLoaded = true;
-      lastLoadedAt = Date.now();
-      widgetsDirty = dirtyVersion !== refreshVersion;
-      for (const kind of ["history", "ratings", "scrobble", "progress", "playlists"]) {
-        if (active[kind]) renderWidget(kind);
+      if (data?.not_modified && cachedPayload) {
+        hasLoaded = true;
+        lastLoadedAt = Date.now();
+        widgetsDirty = dirtyVersion !== refreshVersion;
+        return;
       }
+      applyWidgetPayload(data, active, partialRefresh ? requestedKinds : null);
+      if (!partialRefresh) writeCachedWidgetData(data);
+      widgetsDirty = dirtyVersion !== refreshVersion;
     } catch (e) {
+      stopSlowLoading();
       if (authPendingError(e)) {
         scheduleAuthReadyRefresh();
         return;
@@ -1733,10 +1859,9 @@
     window.addEventListener("cw-user-profiles-changed", () => markWidgetsDirty(150, { forceConfig: true, preserve: hasLoaded }));
     window.addEventListener("cw:overview-profile-changed", () => markWidgetsDirty(0, { preserve: hasLoaded }));
     window.addEventListener("activity-log-cleared", () => markWidgetsDirty(100));
-    window.addEventListener("sync-complete", () => markWidgetsDirty(250));
-    window.addEventListener("cw:scrobble-stopped", scheduleScrobbleStopRefresh);
+    window.addEventListener("sync-complete", refreshForSyncComplete);
+    window.addEventListener("cw:scrobble-stopped", refreshForScrobbleStopped);
     window.addEventListener("cw:manual-watched-saved", () => markWidgetsDirty(250));
-    window.addEventListener("watchlist:refresh", () => markWidgetsDirty(250));
     window.addEventListener("cw:watchlist-widget-state", (event) => {
       setWidgetEmpty("watchlist", !!event?.detail?.empty);
       cacheWatchlistEmpty(!!event?.detail?.empty);
@@ -1746,10 +1871,10 @@
     if (authSetupPending()) scheduleAuthReadyRefresh();
     window.addEventListener("load", () => {
       setTimeout(() => {
-        if (!hasLoaded) refreshDashboardWidgets({ forceConfig: true });
+        if (!hasLoaded) refreshDashboardWidgets({ forceConfig: true, preserve: true });
       }, 100);
     }, { once: true });
-    refreshDashboardWidgets();
+    refreshDashboardWidgets({ preserve: true });
   }
 
   window.CW = window.CW || {};

--- a/assets/js/profile-page.js
+++ b/assets/js/profile-page.js
@@ -28,6 +28,14 @@
   const writeCache = (key, payload) => {
     try { localStorage.setItem(key, JSON.stringify({ t: Date.now(), payload })); } catch {}
   };
+  const readAnyCache = (key) => {
+    try {
+      const entry = JSON.parse(localStorage.getItem(key) || "null");
+      return entry && entry.payload ? entry.payload : null;
+    } catch {
+      return null;
+    }
+  };
   const profileRouteSegment = (value) => {
     try {
       value = decodeURIComponent(String(value || ""));
@@ -86,17 +94,6 @@
       : "";
     const fallbackHidden = logo ? " hidden" : "";
     return `<span class="cw-profile-provider-badge cw-profile-provider-badge--icon" data-provider="${esc(key)}" title="${esc(label)}" aria-label="${esc(label)}">${icon}<span class="cw-profile-provider-fallback"${fallbackHidden}>${esc(label.slice(0, 2))}</span></span>`;
-  };
-  const providerBadgeHtml = (provider) => {
-    const label = visibleProviderLabel(provider);
-    if (!label) return "";
-    const key = providerKey(provider).toLowerCase().replace(/[^a-z0-9-]+/g, "");
-    const logo = providerLogo(provider);
-    const icon = logo
-      ? `<img class="cw-profile-provider-logo" src="${esc(logo)}" alt="" loading="lazy" onerror="this.hidden=true;this.nextElementSibling.hidden=false">`
-      : "";
-    const fallbackHidden = logo ? " hidden" : "";
-    return `<span class="cw-profile-provider-badge" data-provider="${esc(key)}">${icon}<span class="cw-profile-provider-fallback"${fallbackHidden}>${esc(label)}</span><span>${esc(label)}</span></span>`;
   };
   const providerName = (value) => {
     if (!value) return "";
@@ -561,19 +558,6 @@
     </button>`;
   }
 
-  function posterCard(item) {
-    const meta = [episodeOf(item) || yearOf(item), String(item?.type || item?.media_type || "").replace("_", " ")].filter(Boolean).join(" - ");
-    const key = storePosterItem(item);
-    return `<button class="cw-profile-poster" type="button" data-profile-poster-key="${esc(key)}" aria-label="Show details for ${esc(titleOf(item))}"><img src="${esc(poster(item))}" alt="" loading="lazy" onerror="this.onerror=null;this.src='/assets/img/placeholder_poster.svg'"><span>${esc(titleOf(item))}<small>${esc(meta)}</small></span></button>`;
-  }
-
-  function listRow(item, fallbackIcon = "movie") {
-    const source = providerOf(item);
-    const meta = [visibleProviderLabel(source), episodeOf(item) || yearOf(item), relTime(item?.ts || item?.last_watched_at || item?.watched_at || item?.updated_at)].filter(Boolean).join(" - ");
-    const key = storePosterItem(item);
-    return `<button class="cw-profile-row cw-profile-click-row" type="button" data-profile-poster-key="${esc(key)}" aria-label="Show details for ${esc(titleOf(item))}"><img src="${esc(poster(item, "w185"))}" alt="" loading="lazy" onerror="this.onerror=null;this.replaceWith(Object.assign(document.createElement('span'),{className:'material-symbols-rounded',textContent:'${fallbackIcon}'}))"><div><strong>${esc(titleOf(item))}</strong><span>${esc(meta)}</span></div><span></span></button>`;
-  }
-
   const watchedEpoch = (item) => {
     const raw = Number(item?.ts || item?.sort_epoch || item?.last_watched_at || item?.watched_at || 0);
     if (!Number.isFinite(raw) || raw <= 0) return 0;
@@ -797,19 +781,31 @@
 
   async function loadOverview() {
     const cacheKey = profileCacheKey("overview");
-    const cached = readCache(cacheKey);
+    const cached = readCache(cacheKey) || readAnyCache(cacheKey);
     if (cached) renderOverview(cached);
     else paintOverviewSkeletons();
+    const widgetParams = new URLSearchParams({
+      include: "history,ratings,scrobble,progress",
+      history_limit: "8",
+      ratings_limit: "9",
+      scrobble_limit: "8",
+      progress_limit: "8",
+    });
+    if (cached?.widgets?.version) widgetParams.set("known_version", cached.widgets.version);
 
     const [widgetsRes, wallRes, insightsRes, statusRes, collectionRes] = await Promise.allSettled([
-      api("/api/dashboard/widgets?include=history,ratings,scrobble,progress&history_limit=8&ratings_limit=9&scrobble_limit=8&progress_limit=8"),
+      api(`/api/dashboard/widgets?${widgetParams.toString()}`),
       api("/api/state/wall?limit=8"),
       api("/api/insights?limit_samples=0&history=0&runtime=0&include_events=0"),
       api("/api/status"),
       api("/api/profile/collection?page=1&page_size=1"),
     ]);
+    const widgetsNotModified = widgetsRes.status === "fulfilled" && widgetsRes.value?.not_modified && cached?.widgets;
+    const widgets = widgetsRes.status === "fulfilled"
+      ? (widgetsNotModified ? (cached?.widgets || {}) : widgetsRes.value)
+      : (cached?.widgets || {});
     const next = {
-      widgets: widgetsRes.status === "fulfilled" ? widgetsRes.value : (cached?.widgets || {}),
+      widgets,
       wall: wallRes.status === "fulfilled" ? wallRes.value : (cached?.wall || { items: [] }),
       progress: cached?.progress || { items: [] },
       insights: insightsRes.status === "fulfilled" ? insightsRes.value : (cached?.insights || null),
@@ -823,6 +819,10 @@
     }
     renderOverview(next);
     writeCache(cacheKey, next);
+    if (widgetsNotModified) {
+      refreshNowPlaying();
+      return;
+    }
 
     api("/api/playback_progress/items?page=1&page_size=8").then((progress) => {
       const fresh = { ...next, progress: progress || { items: [] } };

--- a/tests/test_dashboard_widgets.py
+++ b/tests/test_dashboard_widgets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -1441,6 +1442,76 @@ def test_dashboard_widgets_api_reads_state_widgets_from_db(monkeypatch, tmp_path
     assert payload["recent_history"]["items"][0]["tmdb"] == "949"
     assert payload["latest_ratings"]["items"][0]["tmdb"] == "550"
     assert payload["recent_progress"]["items"][0]["tmdb"] == "40"
+
+
+def test_dashboard_widgets_api_returns_not_modified_for_known_version(monkeypatch, tmp_path) -> None:
+    import cw_platform.config_base as config_base
+    from api import dashboardAPI
+
+    monkeypatch.setattr(config_base, "CONFIG", tmp_path)
+    monkeypatch.setattr(dashboard_widgets, "_tracker_feature_items", lambda _kind: {})
+
+    first = dashboardAPI.dashboard_widgets(
+        history_limit=8,
+        ratings_limit=12,
+        scrobble_limit=8,
+        progress_limit=8,
+        playlists_limit=8,
+        include="history",
+    )
+    version = _loads_body(first.body)["version"]
+    monkeypatch.setattr(
+        dashboardAPI,
+        "dashboard_widgets_payload",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("payload should not rebuild")),
+    )
+
+    second = dashboardAPI.dashboard_widgets(
+        history_limit=8,
+        ratings_limit=12,
+        scrobble_limit=8,
+        progress_limit=8,
+        playlists_limit=8,
+        include="history",
+        known_version=version,
+    )
+    payload = _loads_body(second.body)
+
+    assert payload == {"ok": True, "not_modified": True, "version": version}
+
+
+def test_dashboard_widget_frontend_uses_cached_payload_version() -> None:
+    js = Path("assets/js/dashboard-widgets.js").read_text("utf-8")
+    profile_js = Path("assets/js/profile-page.js").read_text("utf-8")
+
+    assert "const DATA_CACHE_KEY" in js
+    assert "function readCachedWidgetData()" in js
+    assert "function writeCachedWidgetData(payload)" in js
+    assert "const WIDGET_LOADING_DELAY_MS = 700;" in js
+    assert 'const REFRESHABLE_WIDGETS = ["history", "ratings", "scrobble", "progress", "playlists"];' in js
+    assert "async function refreshDashboardWidgets({ forceConfig = false, force = false, preserve = true, kinds = null } = {})" in js
+    assert 'params.set("known_version", cachedPayload.version)' in js
+    assert "if (data?.not_modified && cachedPayload)" in js
+    assert "applyWidgetPayload(cached, active)" in js
+    assert "if (!hasLoaded && cachedPayload)" in js
+    assert "applyWidgetPayload(cachedPayload, active)" in js
+    assert "const preserve = opts.preserve === false ? hasLoaded : true;" in js
+    assert "try { await window.CW?.OverviewProfile?.ready; } catch {}\n    if (seq !== loadSeq || !isOnMain()) return;\n    if (!hasLoaded) revealFromCache();" in js
+    assert "function scheduleSlowWidgetLoading(hosts, requestedKinds)" in js
+    assert "if (!latestItems[kind]?.length) setLoading(hosts[kind], kind);" in js
+    assert "const requestedKinds = REFRESHABLE_WIDGETS.filter((key) => active[key] && (!wantedKinds || wantedKinds.has(key)));" in js
+    assert "mergeWidgetPayload" not in js
+    assert "loadedKinds" not in js
+    assert "if (!partialRefresh) writeCachedWidgetData(data);" in js
+    assert "refreshDashboardWidgets({ preserve: true });" in js
+    assert "refreshDashboardWidgets({ forceConfig: true, preserve: true })" in js
+    assert 'window.addEventListener("sync-complete", refreshForSyncComplete);' in js
+    assert 'window.addEventListener("cw:scrobble-stopped", refreshForScrobbleStopped);' in js
+    assert 'markWidgetsDirty(0, { kinds: ["scrobble", "history", "progress"] });' in js
+    assert 'window.addEventListener("watchlist:refresh", () => markWidgetsDirty(250));' not in js
+    assert "const readAnyCache = (key) =>" in profile_js
+    assert 'widgetParams.set("known_version", cached.widgets.version)' in profile_js
+    assert "if (widgetsNotModified)" in profile_js
 
 
 def test_dashboard_widgets_api_reads_scrobble_from_activity_db(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
# Pull request

## Change

- Adds cached dashboard widget payloads for Main and Profile.
- Adds a widget version check so unchanged data can skip rebuilding.
- Refreshes only connected widgets after sync and scrobble stops.

## Why

Refreshing the page kept showing loading states and rebuilding widgets even when nothing changed.

## Testing

- tests/test_dashboard_widgets.py::test_dashboard_widgets_api_returns_not_modified_for_known_version
- tests/test_dashboard_widgets.py::test_dashboard_widget_frontend_uses_cached_payload_versio

## Issue

NA