### PR TITLE
Change: cache watchlist API responses

### DIFF
--- a/api/wallAPI.py
+++ b/api/wallAPI.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import hashlib
+import json
 import threading
 from typing import Any, cast
 from fastapi import FastAPI, Query, Request
@@ -41,6 +43,11 @@ def _cache_key(*, both_only: bool, active_only: bool, limit: int, user_profile: 
         int(limit or 0),
         str(user_profile or "").strip(),
     )
+
+
+def _cache_version(key: tuple[Any, ...]) -> str:
+    blob = json.dumps(key, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
 
 
 def _tmdb_api_key(cfg: dict[str, Any]) -> str:
@@ -166,6 +173,7 @@ def register_wall(app: FastAPI) -> None:
         active_only: bool = Query(False, description="Keep only items from configured providers"),
         limit: int = Query(0, ge=0, le=100, description="Optional item limit"),
         user_profile: str = Query("", description="Optional user profile id to scope provider instances"),
+        known_version: str = Query("", description="Client cache version to avoid rebuilding unchanged wall data"),
     ) -> dict[str, Any]:
         from api.appAuthAPI import COOKIE_NAME, effective_user_profile_id
 
@@ -173,6 +181,9 @@ def register_wall(app: FastAPI) -> None:
         token = request.cookies.get(COOKIE_NAME) if request is not None else None
         profile = effective_user_profile_id(cfg, token, user_profile)
         key = _cache_key(both_only=both_only, active_only=active_only, limit=limit, user_profile=profile)
+        version = _cache_version(key)
+        if known_version and str(known_version).strip() == version:
+            return {"ok": True, "not_modified": True, "version": version}
         with _WALL_CACHE_LOCK:
             if _WALL_CACHE.get("key") == key and isinstance(_WALL_CACHE.get("data"), dict):
                 return dict(_WALL_CACHE["data"])
@@ -216,6 +227,7 @@ def register_wall(app: FastAPI) -> None:
             "total": total,
             "missing_tmdb_key": not bool(api_key),
             "last_sync_epoch": st.get("last_sync_epoch") if isinstance(st, dict) else None,
+            "version": version,
         }
         with _WALL_CACHE_LOCK:
             _WALL_CACHE["key"] = key

--- a/api/watchlistAPI.py
+++ b/api/watchlistAPI.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import hashlib
+import json
 import urllib.parse
 from typing import Any, Literal, cast
 
@@ -21,6 +23,52 @@ from services.watchlist import (
 )
 
 router = APIRouter(prefix="/api/watchlist", tags=["watchlist"])
+_WATCHLIST_PAYLOAD_SCHEMA = "row-meta-v1"
+
+
+def _watchlist_version(
+    *,
+    requested_profile: str = "",
+    overview: str = "none",
+    locale: str | None = None,
+    limit: int = 0,
+    max_meta: int = 250,
+) -> str:
+    try:
+        from cw_platform.config_base import CONFIG, config_path
+        from cw_platform.local_db import manual_policy as sqlite_manual_policy
+        from cw_platform.local_db import state as sqlite_state
+        from cw_platform.local_db import watchlist_hide as sqlite_watchlist_hide
+    except Exception:
+        source = {
+            "schema": _WATCHLIST_PAYLOAD_SCHEMA,
+            "profile": requested_profile,
+            "overview": overview,
+            "locale": locale,
+            "limit": limit,
+            "max_meta": max_meta,
+        }
+    else:
+        try:
+            cfg_path = config_path()
+            cfg_stat = cfg_path.stat()
+            cfg_stamp = (str(cfg_path), int(getattr(cfg_stat, "st_mtime_ns", int(cfg_stat.st_mtime * 1e9))), int(cfg_stat.st_size))
+        except Exception:
+            cfg_stamp = ("", 0, 0)
+        source = {
+            "schema": _WATCHLIST_PAYLOAD_SCHEMA,
+            "state": sqlite_state.fingerprint(CONFIG, {"watchlist"}),
+            "policy": sqlite_manual_policy.fingerprint(CONFIG, {"watchlist"}),
+            "hidden": sqlite_watchlist_hide.fingerprint(CONFIG),
+            "config": cfg_stamp,
+            "profile": requested_profile,
+            "overview": overview,
+            "locale": locale,
+            "limit": int(limit or 0),
+            "max_meta": int(max_meta or 0),
+        }
+    blob = json.dumps(source, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
 
 
 def _load_watchlist_state() -> dict[str, Any]:
@@ -32,6 +80,17 @@ def _load_watchlist_state() -> dict[str, Any]:
         return state if isinstance(state, dict) else {}
     except Exception:
         return {}
+
+
+def _int_param(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _str_param(value: Any, default: str = "") -> str:
+    return value if isinstance(value, str) else default
 
 
 def _public_error(message: str = "operation_failed") -> str:
@@ -579,6 +638,7 @@ def api_watchlist(
         description="Cap enriched items",
     ),
     user_profile: str = Query("", description="Optional user profile id to scope provider instances"),
+    known_version: str = Query("", description="Client cache version to avoid rebuilding unchanged watchlist data"),
 ) -> JSONResponse:
 
     try:
@@ -589,25 +649,54 @@ def api_watchlist(
         return JSONResponse({"ok": False, "error": "server import failed"}, status_code=200)
 
     cfg = load_config()
-    st = _load_watchlist_state()
+    overview_value = _str_param(overview, "none")
+    if overview_value not in {"none", "short", "full"}:
+        overview_value = "none"
+    locale_value = _str_param(locale, "") or None
+    limit_value = _int_param(limit, 0)
+    max_meta_value = _int_param(max_meta, 250)
+    known_version_value = _str_param(known_version, "")
     api_key = _tmdb_api_key(cfg)
     has_key = bool(api_key)
+    profile, user_filter = _effective_user_filter(cfg, request, user_profile)
+    version = _watchlist_version(
+        requested_profile=profile,
+        overview=overview_value,
+        locale=locale_value,
+        limit=limit_value,
+        max_meta=max_meta_value,
+    )
+    if known_version_value and known_version_value.strip() == version:
+        return JSONResponse(
+            {"ok": True, "not_modified": True, "version": version},
+            status_code=200,
+            headers={"Cache-Control": "no-store"},
+        )
+    st = _load_watchlist_state()
 
     if not st:
         return JSONResponse(
-            {"ok": False, "error": "No snapshot found or empty.", "missing_tmdb_key": not has_key},
+            {
+                "ok": True,
+                "items": [],
+                "error": "",
+                "missing_tmdb_key": not has_key,
+                "last_sync_epoch": None,
+                "meta_enriched": 0,
+                "version": version,
+            },
             status_code=200,
+            headers={"Cache-Control": "no-store"},
         )
 
     try:
         items = build_watchlist(st, tmdb_ok=has_key) or []
     except Exception:
         return JSONResponse(
-            {"ok": False, "error": "watchlist build failed", "missing_tmdb_key": not has_key},
+            {"ok": False, "error": "watchlist build failed", "missing_tmdb_key": not has_key, "version": version},
             status_code=200,
         )
 
-    profile, user_filter = _effective_user_filter(cfg, request, user_profile)
     if user_filter:
         items = [
             scoped
@@ -626,19 +715,20 @@ def api_watchlist(
                 "missing_tmdb_key": not has_key,
                 "last_sync_epoch": st.get("last_sync_epoch"),
                 "meta_enriched": 0,
+                "version": version,
             },
             status_code=200,
         )
 
-    if limit:
-        items = items[:limit]
+    if limit_value:
+        items = items[:limit_value]
 
     enriched = 0
-    eff_overview = overview if (overview != "none" and has_key) else "none"
+    eff_overview = overview_value if (overview_value != "none" and has_key) else "none"
 
-    if eff_overview != "none":
+    if has_key and max_meta_value:
         eff_locale = (
-            locale
+            locale_value
             or (cfg.get("metadata") or {}).get("locale")
             or (cfg.get("ui") or {}).get("locale")
             or None
@@ -646,29 +736,58 @@ def api_watchlist(
 
         def _norm_type(x: str | None) -> str:
             t = (x or "").strip().lower()
-            if t in {"tv", "show", "shows", "series", "season", "episode"}:
+            if t in {"anime", "tv", "show", "shows", "series", "season", "episode"}:
                 return "tv"
             if t in {"movie", "movies", "film", "films"}:
                 return "movie"
             return "movie"
 
+        def _genre_names(value: Any) -> list[str]:
+            raw = value if isinstance(value, list) else []
+            out: list[str] = []
+            for row in raw:
+                if isinstance(row, str):
+                    name = row
+                elif isinstance(row, dict):
+                    name = str(row.get("name") or row.get("title") or "").strip()
+                else:
+                    name = ""
+                if name and name not in out:
+                    out.append(name)
+            return out
+
+        def _release_date(meta: dict[str, Any], typ: str) -> str:
+            raw_detail = meta.get("detail")
+            raw_release = meta.get("release")
+            detail: dict[str, Any] = raw_detail if isinstance(raw_detail, dict) else {}
+            release: dict[str, Any] = raw_release if isinstance(raw_release, dict) else {}
+            if typ == "movie":
+                raw = detail.get("release_date") or release.get("date")
+            else:
+                raw = detail.get("first_air_date") or release.get("date")
+            return str(raw or "").strip()
+
         for it in items:
-            if enriched >= int(max_meta):
+            if enriched >= max_meta_value:
                 break
             tmdb_id = it.get("tmdb")
             if not tmdb_id:
                 continue
 
-            it["type"] = _norm_type(it.get("type") or it.get("entity") or it.get("media_type"))
+            meta_type = _norm_type(it.get("type") or it.get("entity") or it.get("media_type"))
             raw_item_ids = it.get("ids")
             item_ids: dict[str, Any] = raw_item_ids if isinstance(raw_item_ids, dict) else {}
+            need: dict[str, bool] = {"genres": True, "release": True, "title": True, "year": True}
+            if eff_overview != "none":
+                need["overview"] = True
+                need["tagline"] = True
             try:
                 meta = get_meta(
                     api_key,
-                    it["type"],
+                    meta_type,
                     tmdb_id,
                     CACHE_DIR,
-                    need={"overview": True, "tagline": True, "title": True, "year": True},
+                    need=need,
                     locale=eff_locale,
                     title=it.get("title"),
                     year=it.get("year"),
@@ -677,14 +796,28 @@ def api_watchlist(
                 ) or {}
                 if meta.get("resolved_type"):
                     it["resolved_type"] = meta["resolved_type"]
-                desc = meta.get("overview") or ""
-                if not desc:
-                    continue
-                if eff_overview == "short":
-                    desc = _shorten(desc, 280)
-                it["overview"] = desc
-                if eff_overview == "short" and meta.get("tagline"):
-                    it["tagline"] = meta["tagline"]
+                genres = _genre_names(meta.get("genres") or (meta.get("detail") or {}).get("genres"))
+                if genres:
+                    it["genres"] = genres
+                release_date = _release_date(meta, meta_type)
+                if release_date:
+                    if meta_type == "movie":
+                        it["release_date"] = release_date
+                    else:
+                        it["first_air_date"] = release_date
+                    if not it.get("year"):
+                        try:
+                            it["year"] = int(release_date[:4])
+                        except Exception:
+                            pass
+                if eff_overview != "none":
+                    desc = meta.get("overview") or ""
+                    if desc:
+                        if eff_overview == "short":
+                            desc = _shorten(desc, 280)
+                        it["overview"] = desc
+                    if eff_overview == "short" and meta.get("tagline"):
+                        it["tagline"] = meta["tagline"]
                 enriched += 1
             except Exception:
                 continue
@@ -696,8 +829,10 @@ def api_watchlist(
             "missing_tmdb_key": not has_key,
             "last_sync_epoch": st.get("last_sync_epoch"),
             "meta_enriched": enriched,
+            "version": version,
         },
         status_code=200,
+        headers={"Cache-Control": "no-store"},
     )
 
 @router.delete("/{key}")

--- a/tests/test_wall_api.py
+++ b/tests/test_wall_api.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
+from pathlib import Path
 from typing import cast
 
 from api import wallAPI
@@ -55,6 +56,56 @@ def test_wall_cache_key_tracks_db_watchlist(monkeypatch, tmp_path):
     after = wallAPI._cache_key(both_only=False, active_only=False, limit=20)
 
     assert after != before
+
+
+def test_wall_endpoint_returns_not_modified_for_known_version(monkeypatch):
+    app = FastAPI()
+    wallAPI.register_wall(app)
+    wallAPI._WALL_CACHE.clear()
+    wallAPI._WALL_CACHE.update({"key": None, "data": None})
+
+    monkeypatch.setattr(wallAPI, "load_config", lambda: {"tmdb": {"api_key": "tmdb-key"}})
+    monkeypatch.setattr(wallAPI, "_load_state", lambda: {"last_sync_epoch": 123})
+    monkeypatch.setattr(wallAPI.sqlite_state, "fingerprint", lambda *_args, **_kwargs: ("state", 1))
+    monkeypatch.setattr(wallAPI.sqlite_manual_policy, "fingerprint", lambda *_args, **_kwargs: ("manual", 1))
+    monkeypatch.setattr(wallAPI.sqlite_watchlist_hide, "fingerprint", lambda *_args, **_kwargs: ("hidden", 1))
+    monkeypatch.setattr(wallAPI, "config_path", lambda: "config.json")
+    monkeypatch.setattr(wallAPI, "build_watchlist", lambda _state, tmdb_ok: [{"key": "one", "status": "both"}])
+
+    endpoint = next(cast(APIRoute, route).endpoint for route in app.routes if getattr(route, "path", "") == "/api/state/wall")
+    first = endpoint(both_only=False, active_only=False, limit=20)
+    monkeypatch.setattr(
+        wallAPI,
+        "build_watchlist",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("wall should not rebuild")),
+    )
+
+    second = endpoint(both_only=False, active_only=False, limit=20, known_version=first["version"])
+
+    assert second == {"ok": True, "not_modified": True, "version": first["version"]}
+
+
+def test_watchlist_preview_uses_cached_wall_version() -> None:
+    js = Path("assets/helpers/watchlist-preview.js").read_text("utf-8")
+
+    assert "version" in js
+    assert 'params.set("known_version", cached.version)' in js
+    assert "if (data?.not_modified && cached?.items?.length)" in js
+    assert "preserveIfSame: true" in js
+
+
+def test_watchlist_preview_uses_shared_provider_branding() -> None:
+    js = Path("assets/helpers/watchlist-preview.js").read_text("utf-8")
+    css = Path("assets/crosswatch.css").read_text("utf-8")
+
+    assert "const providerBrandInfo = (value) =>" in js
+    assert "const info = meta.brandInfo?.(key);" in js
+    assert "const providerLogoPath = (name) => providerBrandInfo(name).icon || \"\";" in js
+    assert "PILL_CLASS_BY_PROVIDER" not in js
+    assert 'cls: "p-provider"' in js
+    assert "rgb: brand.tone?.rgb || \"\"" in js
+    assert "border:1px solid rgba(${rgb},.22)" in js
+    assert ".p-provider{color:rgb(var(--pill-rgb,208,217,255));" in css
 
 
 def test_wall_endpoint_filters_by_user_profile(monkeypatch):

--- a/tests/test_watchlist_api.py
+++ b/tests/test_watchlist_api.py
@@ -33,6 +33,83 @@ def _json_body(resp) -> dict:
     return json.loads(resp.body.decode("utf-8"))
 
 
+def test_watchlist_api_returns_not_modified_for_known_version(monkeypatch) -> None:
+    from api import watchlistAPI
+    import cw_platform.config_base as config_base
+
+    monkeypatch.setattr(config_base, "load_config", lambda: {})
+    monkeypatch.setattr(watchlistAPI, "_tmdb_api_key", lambda _cfg: "")
+    monkeypatch.setattr(watchlistAPI, "_effective_user_filter", lambda *_args: ("", {}))
+    monkeypatch.setattr(watchlistAPI, "_watchlist_version", lambda **_kwargs: "v1")
+    monkeypatch.setattr(
+        watchlistAPI,
+        "_load_watchlist_state",
+        lambda: (_ for _ in ()).throw(AssertionError("state should not load")),
+    )
+
+    data = _json_body(watchlistAPI.api_watchlist(request=_request("/api/watchlist"), known_version="v1"))
+
+    assert data == {"ok": True, "not_modified": True, "version": "v1"}
+
+
+def test_watchlist_api_returns_empty_items_when_state_is_missing(monkeypatch) -> None:
+    from api import watchlistAPI
+    import cw_platform.config_base as config_base
+
+    monkeypatch.setattr(config_base, "load_config", lambda: {})
+    monkeypatch.setattr(watchlistAPI, "_tmdb_api_key", lambda _cfg: "")
+    monkeypatch.setattr(watchlistAPI, "_effective_user_filter", lambda *_args: ("", {}))
+    monkeypatch.setattr(watchlistAPI, "_watchlist_version", lambda **_kwargs: "empty-v1")
+    monkeypatch.setattr(watchlistAPI, "_load_watchlist_state", lambda: {})
+
+    data = _json_body(watchlistAPI.api_watchlist(request=_request("/api/watchlist")))
+
+    assert data["ok"] is True
+    assert data["items"] == []
+    assert data["version"] == "empty-v1"
+
+
+def test_watchlist_api_includes_row_metadata(monkeypatch) -> None:
+    from api import metaAPI
+    from api import watchlistAPI
+    import cw_platform.config_base as config_base
+
+    monkeypatch.setattr(config_base, "load_config", lambda: {"metadata": {"locale": "en-US"}})
+    monkeypatch.setattr(watchlistAPI, "_tmdb_api_key", lambda _cfg: "tmdb-key")
+    monkeypatch.setattr(watchlistAPI, "_effective_user_filter", lambda *_args: ("", {}))
+    monkeypatch.setattr(watchlistAPI, "_load_watchlist_state", lambda: {"last_sync_epoch": 123})
+    monkeypatch.setattr(
+        watchlistAPI,
+        "build_watchlist",
+        lambda _state, tmdb_ok: [
+            {
+                "key": "tmdb:movie:123",
+                "title": "Masters of the Universe",
+                "type": "movie",
+                "tmdb": 123,
+                "year": 2026,
+                "sources": ["plex"],
+                "sources_by_provider": {"plex": ["default"]},
+                "ids": {"tmdb": 123},
+            }
+        ],
+    )
+
+    def fake_get_meta(*_args, **kwargs):
+        assert kwargs["need"]["genres"] is True
+        assert kwargs["need"]["release"] is True
+        return {"genres": ["Action", "Fantasy"], "detail": {"release_date": "2026-06-03"}}
+
+    monkeypatch.setattr(metaAPI, "get_meta", fake_get_meta)
+
+    data = _json_body(watchlistAPI.api_watchlist(request=_request("/api/watchlist"), max_meta=10))
+
+    assert data["ok"] is True
+    assert data["meta_enriched"] == 1
+    assert data["items"][0]["release_date"] == "2026-06-03"
+    assert data["items"][0]["genres"] == ["Action", "Fantasy"]
+
+
 def test_watchlist_api_filters_non_admin_to_assigned_profile(monkeypatch) -> None:
     from api import appAuthAPI as auth
     from api import watchlistAPI


### PR DESCRIPTION
# Pull request

## Change

- Adds version checks for watchlist and wall API responses.
- Returns empty watchlist data cleanly when state is gone.
- Adds API coverage for not modified and empty-state responses.

## Why

The frontend needs a way to know when watchlist data changed without rebuilding every refresh.

## Testing

- tests/test_wall_api.py 
- tests/test_watchlist_api.py -q

## Issue

NA