### PR TITLE
Change: improve speed and clean up Scrobbler settings

### DIFF
--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -469,9 +469,9 @@ def _runtime_status(request: Request, cfg: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
-def _normalized_routes(cfg: dict[str, Any], request: Request) -> list[dict[str, Any]]:
+def _normalized_routes(cfg: dict[str, Any], request: Request, runtime: Mapping[str, Any] | None = None) -> list[dict[str, Any]]:
     _ensure_route_ratings_webhook_ids(cfg)
-    runtime = _runtime_status(request, cfg)
+    runtime = runtime if isinstance(runtime, Mapping) else _runtime_status(request, cfg)
     running_by_id = {
         str((r or {}).get("id") or ""): bool((r or {}).get("running"))
         for r in runtime.get("routes", [])
@@ -525,13 +525,13 @@ def build_overview(cfg: dict[str, Any], request: Request) -> dict[str, Any]:
         _sync_derived_sources(cfg)
     sources = scrobble_sources(cfg)
     webhooks = _webhook_cards(cfg, request)
-    routes = _normalized_routes(cfg, request)
+    runtime = _runtime_status(request, cfg)
+    routes = _normalized_routes(cfg, request, runtime)
     user = request_user(request)
     if isinstance(user, Mapping) and not bool(user.get("is_admin")):
         pid = managed_profile_id(user)
         webhooks = [row for row in webhooks if pid and webhook_effective_profile_id(cfg, row) == pid]
         routes = [row for row in routes if _user_can_access_route(cfg, user, row)]
-    runtime = _runtime_status(request, cfg)
     sc = _dict(cfg.get("scrobble"))
     watch = _dict(sc.get("watch"))
     wh = _dict(sc.get("webhook"))

--- a/assets/helpers/core.js
+++ b/assets/helpers/core.js
@@ -1289,9 +1289,11 @@
 
     const start = () => {
       if (scrobblerInit) return;
-      if (window.Scrobbler?.init) window.Scrobbler.init({ mountId: mount.id });
-      else if (window.Scrobbler?.mount) window.Scrobbler.mount(mount, window._cfgCache || {});
+      let boot;
+      if (window.Scrobbler?.init) boot = window.Scrobbler.init({ mountId: mount.id });
+      else if (window.Scrobbler?.mount) boot = window.Scrobbler.mount(mount, window._cfgCache || {});
       else return;
+      Promise.resolve(boot).catch((err) => console.warn("[scrobbler] init failed", err));
       scrobblerInit = true;
     };
 
@@ -1319,7 +1321,7 @@
     if (String(e?.detail?.pane || "").toLowerCase() !== "scrobbler") return;
     try { window.loadConfig?.(); } catch {}
     if (scrobblerInit) {
-      try { window.Scrobbler?.refresh?.(); } catch {}
+      try { Promise.resolve(window.Scrobbler?.refresh?.()).catch((err) => console.warn("[scrobbler] refresh failed", err)); } catch {}
       return;
     }
     try { ensureScrobbler(); setTimeout(ensureScrobbler, 200); } catch {}

--- a/assets/js/modals/scrobbler-route/index.js
+++ b/assets/js/modals/scrobbler-route/index.js
@@ -502,6 +502,15 @@ function ratingsPanel(r, ratings, ratingTargets) {
   `;
 }
 
+function enableSelectedUnavailableRatingTargets() {
+  root?.querySelectorAll(".scrm-target.is-disabled input[data-rating-target]:checked").forEach((input) => {
+    input.disabled = false;
+    const target = input.closest(".scrm-target");
+    target?.classList.remove("is-disabled");
+    target?.classList.add("is-unconfigured");
+  });
+}
+
 function normalizeActiveTab(tab = activeTab) {
   const next = String(tab || "route");
   return ["route", "filters", "options", "ratings"].includes(next) ? next : "route";
@@ -580,6 +589,7 @@ function render(errors = []) {
     </div>
   `;
   ensureVisiblePanel();
+  enableSelectedUnavailableRatingTargets();
 }
 
 function collect() {

--- a/assets/js/modals/scrobbler-webhook/index.js
+++ b/assets/js/modals/scrobbler-webhook/index.js
@@ -350,6 +350,13 @@ function availableRatingSinks() {
   return ratingSinks.filter((s) => s !== self && sinkProfiles(s).length > 0);
 }
 
+function visibleRatingSinks(selected = []) {
+  const self = sourceProviderKey();
+  const available = availableRatingSinks();
+  const selectedList = selected.map((x) => String(x || "").toLowerCase()).filter((x) => ratingSinks.includes(x) && x !== self);
+  return [...selectedList.filter((x) => !available.includes(x)), ...available];
+}
+
 function selectedSinkKey() {
   const cur = selectedWebhook();
   const current = String(cur.sink || "").toLowerCase();
@@ -495,7 +502,7 @@ function globalRatingTargets() {
 
 function ratingsPanel(provider, ratingsTargets) {
   if (provider !== "plex") return "";
-  const targets = availableRatingSinks();
+  const targets = visibleRatingSinks(ratingsTargets);
   const globalTargets = globalRatingTargets();
   const globalWarn = globalTargets.length
     ? `<div class="scrm-note is-warn"><span class="material-symbols-rounded">warning</span><span>Global Plex ratings is on and already forwarding to <strong>${esc(globalTargets.map(label).join(", "))}</strong>. This webhook sends ratings <em>in addition</em> to the global one — only enable trackers here if this profile needs different destinations.</span></div>`
@@ -507,7 +514,10 @@ function ratingsPanel(provider, ratingsTargets) {
         <div><strong>Plex ratings</strong><p>Forward Plex ratings received on this webhook to the selected trackers.</p></div>
       </div>
       ${globalWarn}
-      <div class="scrm-targets">${targets.length ? targets.map((sink) => `<label class="scrm-target"><input type="checkbox" data-rating="${esc(sink)}" ${ratingsTargets.includes(sink) ? "checked" : ""}><span class="scrm-target-mark">${providerIcon(sink)}</span><span>${esc(label(sink))}</span></label>`).join("") : `<span class="scrm-muted">No configured rating destinations</span>`}</div>
+      <div class="scrm-targets">${targets.length ? targets.map((sink) => {
+        const configured = sinkProfiles(sink).length > 0;
+        return `<label class="scrm-target${configured ? "" : " is-unconfigured"}"><input type="checkbox" data-rating="${esc(sink)}" ${ratingsTargets.includes(sink) ? "checked" : ""}><span class="scrm-target-mark">${providerIcon(sink)}</span><span>${esc(label(sink))}${configured ? "" : " - not configured"}</span></label>`;
+      }).join("") : `<span class="scrm-muted">No configured rating destinations</span>`}</div>
     </section>
   `;
 }

--- a/assets/js/scrobbler.js
+++ b/assets/js/scrobbler.js
@@ -9,8 +9,29 @@
   const plexRatingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "flicklist", "scrob"];
   const state = { root: null, overview: null, busy: false, panels: { watcherDefaults: false, ratings: false, webhookDefaults: false }, delBtn: null, delTimer: 0, regenBtn: null, regenTimer: 0, legacyConfirm: false, legacyTimer: 0, hybridDismissed: false };
 
+  async function authSetupBlocked() {
+    const boot = w.__cwAuthBootstrapState;
+    if (boot && typeof boot.blocked === "boolean") return boot.blocked;
+    const pending = w.__cwAuthBootstrapPromise;
+    if (pending && typeof pending.then === "function") {
+      const resolved = await pending.catch(() => null);
+      if (resolved && typeof resolved.blocked === "boolean") return resolved.blocked;
+    }
+    return w.cwIsAuthSetupPending?.() === true;
+  }
+
+  function authPendingError() {
+    const err = new Error("auth setup pending");
+    err.code = "auth_setup_pending";
+    return err;
+  }
+
+  function isAuthPendingError(err) {
+    return err?.code === "auth_setup_pending" || String(err?.message || "").includes("auth setup pending");
+  }
+
   async function j(url, options = {}) {
-    if (w.cwIsAuthSetupPending?.() === true) throw new Error("auth setup pending");
+    if (await authSetupBlocked()) throw authPendingError();
     const res = await fetch(url, { cache: "no-store", credentials: "same-origin", ...options });
     const data = await res.json().catch(() => ({}));
     if (!res.ok || data?.ok === false) {
@@ -272,7 +293,12 @@
     const r = st.global_plex_ratings || {};
     const open = state.panels.ratings;
     const url = r.endpoint_url || "";
-    const on = plexRatingSinks.filter((k) => r[k]);
+    const configured = new Set((o.destination_availability || [])
+      .filter((g) => plexRatingSinks.includes(String(g?.provider || "").toLowerCase()))
+      .filter((g) => (g?.profiles || []).some((p) => p?.configured))
+      .map((g) => String(g.provider || "").toLowerCase()));
+    const visibleSinks = plexRatingSinks.filter((k) => configured.has(k) || r[k]);
+    const on = visibleSinks.filter((k) => r[k]);
     const summary = on.length ? `→ ${on.map(label).join(", ")}` : "No destinations selected";
     return `
       <section class="sc2-section sc2-collapse ${open ? "is-open" : ""}" id="sc-sec-ratings">
@@ -283,7 +309,7 @@
         </button>
         <div class="sc2-collapse-body">
           <div class="sc2-rating-targets">
-            ${plexRatingSinks.map((k) => `<button type="button" class="sc2-rating-pill provider-${k} ${r[k] ? "is-on" : ""}" data-rating-target="${k}"><span class="material-symbols-rounded">${r[k] ? "check_circle" : "radio_button_unchecked"}</span>${esc(label(k))}</button>`).join("")}
+            ${visibleSinks.map((k) => `<button type="button" class="sc2-rating-pill provider-${k} ${r[k] ? "is-on" : ""}" data-rating-target="${k}"><span class="material-symbols-rounded">${r[k] ? "check_circle" : "radio_button_unchecked"}</span>${esc(label(k))}</button>`).join("") || '<div class="sc2-muted">Configure a ratings destination first.</div>'}
           </div>
           <div class="sc2-endpoint">
             <code title="${esc(url)}">${esc(url || "Global Plex ratings URL is unavailable until a token exists")}</code>
@@ -347,9 +373,22 @@
     state.root.innerHTML = `<div class="sc2-page">${renderHeader(o)}${gate}${renderSummary(o)}${hybrid}${legacy}${renderRoutes(o)}${collapseRow}${renderRuntime(o)}${renderWebhooks(o)}${webhookDefaults}</div>`;
   }
 
+  function renderAuthPending() {
+    if (!state.root) return;
+    state.root.innerHTML = `<div class="sc2-page">${renderHeader(state.overview || {})}<div class="sc2-empty">Finish authentication setup to load Scrobbler.</div></div>`;
+  }
+
   async function loadOverview() {
-    state.overview = await j("/api/scrobbler/overview");
-    render();
+    try {
+      state.overview = await j("/api/scrobbler/overview");
+      render();
+    } catch (err) {
+      if (isAuthPendingError(err)) {
+        renderAuthPending();
+        return;
+      }
+      throw err;
+    }
   }
 
   function applyMutation(data) {

--- a/tests/test_plex_webhook_ratings.py
+++ b/tests/test_plex_webhook_ratings.py
@@ -136,6 +136,102 @@ def test_global_plex_rating_surfaces_cover_dispatcher_sinks(monkeypatch) -> None
     assert all(saved["scrobble"]["watch"][f"plex_{sink}_ratings"] is True for sink in RATING_SINKS)
 
 
+def test_scrobbler_overview_reuses_runtime_status(monkeypatch) -> None:
+    from api import scrobblerManagementAPI as management
+
+    calls = 0
+
+    def fake_runtime(_request, _cfg):
+        nonlocal calls
+        calls += 1
+        return {
+            "running": True,
+            "alive": True,
+            "groups": [],
+            "routes": [{"id": "R1", "running": True, "sink": "trakt"}],
+        }
+
+    cfg = {
+        "trakt": {"access_token": "token"},
+        "plex": {"token": "token", "baseurl": "http://plex"},
+        "scrobble": {
+            "enabled": True,
+            "sources": {"watcher": True},
+            "watch": {
+                "routes": [
+                    {
+                        "id": "R1",
+                        "enabled": True,
+                        "provider": "plex",
+                        "provider_instance": "default",
+                        "sink": "trakt",
+                        "sink_instance": "default",
+                    }
+                ]
+            },
+        },
+    }
+    monkeypatch.setattr(management, "_runtime_status", fake_runtime)
+    monkeypatch.setattr(management, "_webhook_cards", lambda _cfg, _request: [])
+    monkeypatch.setattr(management, "_eligible_sources", lambda _cfg: [])
+    monkeypatch.setattr(management, "_destination_availability", lambda _cfg: [])
+    monkeypatch.setattr(management, "request_user", lambda _request: None)
+
+    overview = management.build_overview(cfg, _request())
+
+    assert calls == 1
+    assert overview["watcher_runtime"]["running"] is True
+    assert overview["routes"][0]["runtime"]["running"] is True
+
+
+def test_global_plex_rating_targets_only_show_configured_or_enabled_sinks() -> None:
+    js = (ROOT / "assets" / "js" / "scrobbler.js").read_text(encoding="utf-8")
+    block = js.split("function renderRatingsWebhook(o)", 1)[1].split("function renderWebhookDefaults(o)", 1)[0]
+
+    assert "const configured = new Set((o.destination_availability || [])" in block
+    assert ".filter((g) => (g?.profiles || []).some((p) => p?.configured))" in block
+    assert "const visibleSinks = plexRatingSinks.filter((k) => configured.has(k) || r[k]);" in block
+    assert "visibleSinks.map((k)" in block
+    assert "plexRatingSinks.map((k)" not in block
+    assert "Configure a ratings destination first." in block
+
+
+def test_scrobbler_rating_modals_keep_enabled_unconfigured_sinks_visible() -> None:
+    webhook = (ROOT / "assets" / "js" / "modals" / "scrobbler-webhook" / "index.js").read_text(encoding="utf-8")
+    route = (ROOT / "assets" / "js" / "modals" / "scrobbler-route" / "index.js").read_text(encoding="utf-8")
+
+    webhook_block = webhook.split("function visibleRatingSinks(selected = [])", 1)[1].split("function selectedSinkKey()", 1)[0]
+    assert "const available = availableRatingSinks();" in webhook_block
+    assert "ratingSinks.includes(x) && x !== self" in webhook_block
+    assert "return [...selectedList.filter((x) => !available.includes(x)), ...available];" in webhook_block
+
+    webhook_panel = webhook.split("function ratingsPanel(provider, ratingsTargets)", 1)[1].split("function optionsPanel()", 1)[0]
+    assert "const targets = visibleRatingSinks(ratingsTargets);" in webhook_panel
+    assert 'class="scrm-target${configured ? "" : " is-unconfigured"}"' in webhook_panel
+    assert " - not configured" in webhook_panel
+
+    route_render = route.split("function enableSelectedUnavailableRatingTargets()", 1)[1].split("function normalizeActiveTab", 1)[0]
+    assert '.scrm-target.is-disabled input[data-rating-target]:checked' in route_render
+    assert "input.disabled = false;" in route_render
+    assert 'target?.classList.add("is-unconfigured");' in route_render
+
+
+def test_scrobbler_loader_waits_for_auth_bootstrap_before_blocking() -> None:
+    scrobbler = (ROOT / "assets" / "js" / "scrobbler.js").read_text(encoding="utf-8")
+    core = (ROOT / "assets" / "helpers" / "core.js").read_text(encoding="utf-8")
+
+    auth_block = scrobbler.split("async function authSetupBlocked()", 1)[1].split("async function j", 1)[0]
+    assert "w.__cwAuthBootstrapState" in auth_block
+    assert "w.__cwAuthBootstrapPromise" in auth_block
+    assert "await pending.catch(() => null)" in auth_block
+    assert "return resolved.blocked;" in auth_block
+    assert "if (await authSetupBlocked()) throw authPendingError();" in scrobbler
+    assert 'err.code = "auth_setup_pending";' in scrobbler
+    assert "renderAuthPending();" in scrobbler
+    assert 'Promise.resolve(boot).catch((err) => console.warn("[scrobbler] init failed", err));' in core
+    assert 'Promise.resolve(window.Scrobbler?.refresh?.()).catch((err) => console.warn("[scrobbler] refresh failed", err));' in core
+
+
 def test_send_rating_supports_scrob_ops_sink(monkeypatch) -> None:
     from providers.scrobble.plex.ratings_sync import send_rating
     from providers.sync.scrob import _ratings as scrob_ratings


### PR DESCRIPTION
# Pull request

## Change

- Speeds up the Scrobbler overview load by reusing watcher runtime status.
- Shows Plex ratings destinations only when that provider is configured.
- Keeps route and webhook rating modals aligned with the same destination rules.

## Why

- Scrobbler page was doing extra backend work and could show destinations that were not usable.

## Testing

- tests/test_plex_webhook_ratings.py::test_scrobbler_loader_waits_for_auth_bootstrap_before_blocking
- tests/test_plex_webhook_ratings.py::test_scrobbler_overview_reuses_runtime_status
- tests/test_plex_webhook_ratings.py::test_global_plex_rating_targets_only_show_configured_or_enabled_sinks
- tests/test_plex_webhook_ratings.py::test_scrobbler_rating_modals_keep_enabled_unconfigured_sinks_visible 

## Issue

NA