### PR TITLE
Change: improve progress sync Stremio/Nuvio

### DIFF
--- a/providers/sync/nuvio/_progress.py
+++ b/providers/sync/nuvio/_progress.py
@@ -13,6 +13,9 @@ from providers.sync._log import log as cw_log
 from providers.sync._progress_policy import decide_progress_write, progress_materially_equal, select_progress_record
 
 from ._common import (
+    NuvioAuthError,
+    NuvioProfileUnavailable,
+    NuvioTokenRefreshError,
     canonical_item_key,
     epoch_ms,
     iso_from_epoch_ms,
@@ -28,6 +31,8 @@ from ._common import (
     selected_profile_id,
     to_int,
 )
+
+MAX_SIGNED_64_BIT_INT = (2**63) - 1
 
 
 def _info(event: str, **fields: Any) -> None:
@@ -58,6 +63,15 @@ def _duration_ms(item: Mapping[str, Any]) -> int | None:
         if number is not None:
             return number
     return None
+
+
+def _duration_ms_for_write(item: Mapping[str, Any]) -> tuple[int | None, str | None]:
+    duration = _duration_ms(item)
+    if duration is None:
+        return None, "nuvio_duration_missing"
+    if duration > MAX_SIGNED_64_BIT_INT:
+        return None, "nuvio_duration_invalid"
+    return duration, None
 
 
 def _progress_percent_value(item: Mapping[str, Any]) -> float | None:
@@ -155,11 +169,11 @@ def _payload_for_item(adapter: Any, item: Mapping[str, Any], current_rows: Any =
     if not content_id:
         return None, "nuvio_id_missing"
 
-    duration = _duration_ms(mini) if isinstance(mini, Mapping) else None
+    duration, reason = _duration_ms_for_write(mini) if isinstance(mini, Mapping) else (None, None)
+    if duration is None and reason != "nuvio_duration_invalid":
+        duration, reason = _duration_ms_for_write(it)
     if duration is None:
-        duration = _duration_ms(it)
-    if duration is None:
-        return None, "nuvio_duration_missing"
+        return None, reason or "nuvio_duration_missing"
 
     position = _progress_ms_for_write(mini, duration) if isinstance(mini, Mapping) else None
     if position is None:
@@ -233,6 +247,37 @@ def _result(ok: bool, count: int, attempted: int, confirmed: list[str], unresolv
     return out
 
 
+def _write_failed_items(pending_items: list[dict[str, Any]], keys: list[str]) -> list[dict[str, Any]]:
+    return [
+        {"status": "failed", "reason": "nuvio_progress_write_failed", "item": id_minimal(item), "canonical_key": key}
+        for item, key in zip(pending_items, keys)
+    ]
+
+
+def _push_progress_entries(
+    adapter: Any,
+    entries: list[dict[str, Any]],
+    keys: list[str],
+    pending_items: list[dict[str, Any]],
+    *,
+    profile_id: int,
+) -> list[dict[str, Any]]:
+    if not entries:
+        return []
+    try:
+        rpc(adapter, "sync_push_watch_progress", {"p_profile_id": profile_id, "p_entries": entries})
+        return []
+    except (NuvioAuthError, NuvioProfileUnavailable, NuvioTokenRefreshError):
+        return _write_failed_items(pending_items, keys)
+    except Exception:
+        if len(entries) == 1:
+            return _write_failed_items(pending_items, keys)
+        mid = len(entries) // 2
+        left = _push_progress_entries(adapter, entries[:mid], keys[:mid], pending_items[:mid], profile_id=profile_id)
+        right = _push_progress_entries(adapter, entries[mid:], keys[mid:], pending_items[mid:], profile_id=profile_id)
+        return left + right
+
+
 def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
     src = [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]
     rows = pull_watch_progress_rows(adapter)
@@ -285,18 +330,17 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
     if dry_run:
         return _result(len(unresolved) == 0, len(entries), len(entries), [], unresolved, results, skipped, dry_run=True)
 
-    write_failed = False
+    write_failures: list[dict[str, Any]] = []
     if entries:
-        try:
-            rpc(adapter, "sync_push_watch_progress", {"p_profile_id": selected_profile_id(adapter), "p_entries": entries})
-        except Exception:
-            write_failed = True
-            for item, key in zip(pending_items, keys):
-                unresolved.append({"status": "failed", "reason": "nuvio_progress_write_failed", "item": id_minimal(item), "canonical_key": key})
+        write_failures = _push_progress_entries(adapter, entries, keys, pending_items, profile_id=selected_profile_id(adapter))
+        unresolved.extend(write_failures)
 
-    after = build_index(adapter) if entries and not write_failed else current
+    failed_keys = {str(row.get("canonical_key") or "") for row in write_failures if isinstance(row, Mapping)}
+    after = build_index(adapter) if entries and len(write_failures) < len(entries) else current
     confirmed: list[str] = []
-    for key, verify_key, payload in ([] if write_failed else zip(keys, verify_keys, entries)):
+    for key, verify_key, payload in zip(keys, verify_keys, entries):
+        if key in failed_keys:
+            continue
         if _confirmed_after_write(after, verify_key, payload):
             confirmed.append(key)
         else:

--- a/providers/sync/stremio/_progress.py
+++ b/providers/sync/stremio/_progress.py
@@ -37,24 +37,44 @@ from ._common import (
 )
 from providers.sync._log import log as cw_log
 
+MAX_STREMIO_PROGRESS_DURATION_MS = 24 * 60 * 60 * 1000
+
 
 def _progress_percent(position: int, duration: int) -> float | None:
     return round((position / duration) * 100.0, 3) if duration > 0 and position >= 0 else None
 
 
+def _bounded_duration_ms(value: Any, scale: int = 1) -> int | None:
+    number = positive_int(value)
+    if number is None:
+        return None
+    duration = number * scale
+    return duration if duration <= MAX_STREMIO_PROGRESS_DURATION_MS else None
+
+
+def _state_duration_ms(state: Mapping[str, Any]) -> tuple[int | None, int | None]:
+    raw = positive_int(state.get("duration"))
+    if raw is None:
+        return None, None
+    duration = _bounded_duration_ms(raw)
+    if duration is not None:
+        return duration, None
+    return None, raw
+
+
 def _duration_ms(item: Mapping[str, Any]) -> int | None:
     for key in ("duration_ms", "durationMs", "duration", "runtime_ms", "runtimeMs"):
-        number = positive_int(item.get(key))
-        if number is not None:
-            return number
+        duration = _bounded_duration_ms(item.get(key))
+        if duration is not None:
+            return duration
     for key in ("duration_seconds", "durationSeconds", "runtime_seconds", "runtimeSeconds"):
-        number = positive_int(item.get(key))
-        if number is not None:
-            return number * 1000
+        duration = _bounded_duration_ms(item.get(key), 1000)
+        if duration is not None:
+            return duration
     for key in ("runtime_minutes", "runtimeMinutes", "duration_minutes", "durationMinutes", "runtime"):
-        number = positive_int(item.get(key))
-        if number is not None:
-            return number * 60_000
+        duration = _bounded_duration_ms(item.get(key), 60_000)
+        if duration is not None:
+            return duration
     return None
 
 
@@ -165,8 +185,15 @@ def _metadata_enriched(adapter: Any, item: Mapping[str, Any], typ: str) -> dict[
                 ep = {}
             if isinstance(ep, Mapping):
                 duration = positive_int(ep.get("runtime"))
-    if duration:
-        out.setdefault("duration_ms", duration * 60_000)
+    duration_ms = _bounded_duration_ms(duration, 60_000) if duration else None
+    if duration_ms is not None:
+        if out.get("_stremio_duration_invalid") or _duration_ms(out) is None:
+            out["duration_ms"] = duration_ms
+            position = _progress_ms(out, duration_ms)
+            if position is not None:
+                out["progress_ms"] = position
+                out["progress_percent"] = _progress_percent(position, duration_ms)
+            out.pop("_stremio_duration_invalid", None)
     if not str(out.get("poster") or out.get("poster_url") or "").strip():
         poster = poster_url_from_item(out, imdb) or _image_url(detail, "poster")
         if poster:
@@ -177,15 +204,18 @@ def _metadata_enriched(adapter: Any, item: Mapping[str, Any], typ: str) -> dict[
 def parse_movie_progress_record(record: Mapping[str, Any]) -> dict[str, Any] | None:
     state = state_of(record)
     position = to_int(state.get("timeOffset"))
-    duration = positive_int(state.get("duration"))
-    if position is None or position <= 0 or not duration:
+    duration, invalid_duration = _state_duration_ms(state)
+    if position is None or position <= 0 or (duration is None and invalid_duration is None):
         return None
     item = item_from_movie_record(record)
     if not item:
         return None
     item["progress_ms"] = position
-    item["duration_ms"] = duration
-    item["progress_percent"] = _progress_percent(position, duration)
+    if duration:
+        item["duration_ms"] = duration
+        item["progress_percent"] = _progress_percent(position, duration)
+    elif invalid_duration is not None:
+        item["_stremio_duration_invalid"] = invalid_duration
     ts = iso_from_epoch_ms(state.get("lastWatched")) or iso_from_epoch_ms(record.get("_mtime"))
     if ts:
         item["progress_at"] = ts
@@ -195,8 +225,8 @@ def parse_movie_progress_record(record: Mapping[str, Any]) -> dict[str, Any] | N
 def parse_episode_progress_record(record: Mapping[str, Any]) -> dict[str, Any] | None:
     state = state_of(record)
     position = to_int(state.get("timeOffset"))
-    duration = positive_int(state.get("duration"))
-    if position is None or position <= 0 or not duration:
+    duration, invalid_duration = _state_duration_ms(state)
+    if position is None or position <= 0 or (duration is None and invalid_duration is None):
         return None
     show_id = str(record.get("_id") or "").strip()
     video_id = str(state.get("video_id") or state.get("videoId") or "").strip()
@@ -218,8 +248,11 @@ def parse_episode_progress_record(record: Mapping[str, Any]) -> dict[str, Any] |
     if not item:
         return None
     item["progress_ms"] = position
-    item["duration_ms"] = duration
-    item["progress_percent"] = _progress_percent(position, duration)
+    if duration:
+        item["duration_ms"] = duration
+        item["progress_percent"] = _progress_percent(position, duration)
+    elif invalid_duration is not None:
+        item["_stremio_duration_invalid"] = invalid_duration
     ts = iso_from_epoch_ms(state.get("lastWatched")) or iso_from_epoch_ms(record.get("_mtime"))
     if ts:
         item["progress_at"] = ts
@@ -246,6 +279,11 @@ def build_index(adapter: Any, **kwargs: Any) -> dict[str, dict[str, Any]]:
         if not item:
             continue
         item = _metadata_enriched(adapter, item, "episode" if str(item.get("type") or "").lower() == "episode" else "movie")
+        if _duration_ms(item) is None:
+            invalid_duration = item.get("_stremio_duration_invalid")
+            if invalid_duration is not None:
+                record_read_drop(adapter, "progress", record, "stremio_duration_invalid", duration_ms=invalid_duration)
+            continue
         key = canonical_item_key(item)
         selected, _reason = select_progress_record(out.get(key), item)
         out[key] = selected

--- a/providers/tests/test_nuvio_progress.py
+++ b/providers/tests/test_nuvio_progress.py
@@ -5,9 +5,10 @@ from collections.abc import Mapping
 from typing import Any
 
 class FakeClient:
-    def __init__(self, rows: list[dict[str, Any]] | None = None):
+    def __init__(self, rows: list[dict[str, Any]] | None = None, fail_push_content_ids: set[str] | None = None):
         self.rows = list(rows or [])
         self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.fail_push_content_ids = set(fail_push_content_ids or set())
 
     def request_json(self, method: str, path: str, *, payload: Mapping[str, Any] | None = None, **_: Any) -> Any:
         body = dict(payload or {})
@@ -19,6 +20,8 @@ class FakeClient:
             rows = [row for row in self.rows if int(row.get("last_watched") or 0) > since]
             return rows[:limit]
         if name == "sync_push_watch_progress":
+            if any(str(entry.get("content_id") or "") in self.fail_push_content_ids for entry in body.get("p_entries") or []):
+                raise RuntimeError("push failed")
             for entry in body.get("p_entries") or []:
                 row = dict(entry)
                 row["id"] = row.get("content_id")
@@ -38,7 +41,7 @@ class FakeClient:
 
 
 class FakeAdapter:
-    def __init__(self, rows: list[dict[str, Any]] | None = None, profile_id: int = 1):
+    def __init__(self, rows: list[dict[str, Any]] | None = None, profile_id: int = 1, fail_push_content_ids: set[str] | None = None):
         self.config = {
             "nuvio": {
                 "base_url": "https://api.nuvio.tv",
@@ -48,7 +51,7 @@ class FakeAdapter:
             }
         }
         self.instance_id = "default"
-        self.client = FakeClient(rows)
+        self.client = FakeClient(rows, fail_push_content_ids=fail_push_content_ids)
 
 
 def _row(content_id: str, position: int = 120_000, duration: int = 600_000, last_watched: int = 1_785_000_000_000) -> dict[str, Any]:
@@ -217,6 +220,57 @@ def test_add_returns_unresolved_for_unsupported_id_and_missing_duration() -> Non
     assert result["attempted"] == 0
     assert {row["reason"] for row in result["unresolved"]} == {"nuvio_id_missing", "nuvio_duration_missing"}
     assert not any(name == "sync_push_watch_progress" for name, _body in adapter.client.calls)
+
+
+def test_add_rejects_duration_outside_nuvio_integer_range() -> None:
+    from providers.sync.nuvio import _progress
+
+    adapter = FakeAdapter([])
+    item = {
+        "type": "movie",
+        "ids": {"tmdb": "550"},
+        "progress_ms": 100_000,
+        "duration_ms": 2**63,
+        "progress_at": 1_785_000_000_000,
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["ok"] is False
+    assert result["attempted"] == 0
+    assert result["unresolved"][0]["reason"] == "nuvio_duration_invalid"
+    assert not any(name == "sync_push_watch_progress" for name, _body in adapter.client.calls)
+
+
+def test_add_isolates_failed_progress_entry_after_bulk_push_failure() -> None:
+    from providers.sync.nuvio import _progress
+
+    adapter = FakeAdapter([], fail_push_content_ids={"tmdb:551"})
+    good = {
+        "type": "movie",
+        "ids": {"tmdb": "550"},
+        "progress_ms": 100_000,
+        "duration_ms": 500_000,
+        "progress_at": 1_785_000_000_000,
+    }
+    bad = {
+        "type": "movie",
+        "ids": {"tmdb": "551"},
+        "progress_ms": 100_000,
+        "duration_ms": 500_000,
+        "progress_at": 1_785_000_000_000,
+    }
+
+    result = _progress.add(adapter, [good, bad])
+
+    assert result["ok"] is False
+    assert result["attempted"] == 2
+    assert result["count"] == 1
+    assert result["confirmed_keys"] == ["tmdb:550"]
+    assert result["unresolved"][0]["canonical_key"] == "tmdb:551"
+    assert result["unresolved"][0]["reason"] == "nuvio_progress_write_failed"
+    pushes = [body["p_entries"] for name, body in adapter.client.calls if name == "sync_push_watch_progress"]
+    assert [[entry["content_id"] for entry in entries] for entries in pushes] == [["tmdb:550", "tmdb:551"], ["tmdb:550"], ["tmdb:551"]]
 
 
 def test_add_does_not_write_title_only_unresolved_item() -> None:

--- a/providers/tests/test_stremio_sync.py
+++ b/providers/tests/test_stremio_sync.py
@@ -838,6 +838,38 @@ def test_progress_read_enriches_imdb_movie_id_with_tmdb_when_duration_exists(mon
     assert index["tmdb:550"]["progress_percent"] == 20.0
 
 
+def test_progress_read_replaces_invalid_movie_duration_from_tmdb(monkeypatch) -> None:
+    class Provider:
+        def fetch(self, **kwargs: Any) -> dict[str, Any]:
+            assert kwargs["entity"] == "movie"
+            assert kwargs["ids"]["imdb"] == "tt0137523"
+            return {"ids": {"tmdb": "550", "imdb": "tt0137523"}, "runtime_minutes": 95, "images": {}}
+
+    monkeypatch.setattr(_progress, "tmdb_metadata_provider", lambda _adapter: Provider())
+    record = movie_record(state={"timeOffset": 3_531_671, "duration": 2**63, "lastWatched": 1_785_441_100_000})
+    adapter = FakeAdapter([record])
+
+    index = _progress.build_index(adapter)
+
+    assert set(index) == {"tmdb:550"}
+    item = index["tmdb:550"]
+    assert item["progress_ms"] == 3_531_671
+    assert item["duration_ms"] == 5_700_000
+    assert item["progress_percent"] == 61.959
+    assert "_stremio_duration_invalid" not in item
+
+
+def test_progress_read_drops_invalid_duration_when_tmdb_cannot_recover() -> None:
+    record = movie_record(state={"timeOffset": 3_531_671, "duration": 2**63, "lastWatched": 1_785_441_100_000})
+    adapter = FakeAdapter([record])
+
+    index = _progress.build_index(adapter)
+
+    assert index == {}
+    assert adapter._stremio_read_drops["progress"][0]["reason"] == "stremio_duration_invalid"
+    assert adapter._stremio_read_drops["progress"][0]["duration_ms"] == 2**63
+
+
 def test_parse_episode_progress_uses_video_id() -> None:
     record = series_record()
     record["state"].update({"video_id": "tt0903747:1:2", "season": 1, "episode": 2, "timeOffset": 60_000, "duration": 600_000})
@@ -896,6 +928,39 @@ def test_progress_read_enriches_imdb_episode_show_id_with_tmdb_when_duration_exi
     assert item["duration_ms"] == 2_520_000
     assert item["progress_percent"] == 30.0
     assert item["_stremio_video_id"] == "tt13111078:1:1"
+
+
+def test_progress_read_replaces_invalid_episode_duration_from_tmdb(monkeypatch) -> None:
+    class Provider:
+        def fetch(self, **kwargs: Any) -> dict[str, Any]:
+            assert kwargs["entity"] == "tv"
+            assert kwargs["ids"]["imdb"] == "tt13111078"
+            assert kwargs["ids"]["title"] == "Lioness"
+            return {"ids": {"tmdb": "113962", "imdb": "tt13111078"}, "runtime_minutes": 42, "images": {}}
+
+    monkeypatch.setattr(_progress, "tmdb_metadata_provider", lambda _adapter: Provider())
+    record = series_record() | {"_id": "tt13111078", "name": "Lioness"}
+    record["state"].update(
+        {
+            "video_id": "tt13111078:1:1",
+            "season": 1,
+            "episode": 1,
+            "timeOffset": 756_000,
+            "duration": 2**63,
+            "lastWatched": 1_788_013_866_000,
+        }
+    )
+    adapter = FakeAdapter([record])
+
+    index = _progress.build_index(adapter)
+
+    assert set(index) == {"tmdb:113962#s01e01"}
+    item = index["tmdb:113962#s01e01"]
+    assert item["show_ids"] == {"imdb": "tt13111078", "tmdb": "113962"}
+    assert item["progress_ms"] == 756_000
+    assert item["duration_ms"] == 2_520_000
+    assert item["progress_percent"] == 30.0
+    assert "_stremio_duration_invalid" not in item
 
 
 def test_progress_write_preserves_history_bitfield_and_unknown_fields() -> None:


### PR DESCRIPTION
# Pull request

## Change

- Stremio progress now ignores impossible runtime values and keeps the real watch position.
- Nuvio progress validate and skips bad durations before sending, and retries failed batches in smaller parts.

## Why

- Stremio can store invalid duration when the real runtime is unknown (at least, thats what i think ?!?) 
- CW was passing that through, which could make Nuvio reject the whole progress batch.

## Testing

- providers/tests/test_stremio_sync.py 
- providers/tests/test_mdblist_progress.py 
- providers/tests/test_simkl_progress.py 
- providers/tests/test_nuvio_progress.py

## Issue
  
Relates to #906  