### PR TITLE
Fix: blocked and unresolved totals in orchestration

### DIFF
--- a/cw_platform/orchestrator/_pairs.py
+++ b/cw_platform/orchestrator/_pairs.py
@@ -361,6 +361,7 @@ def run_pairs(ctx) -> dict[str, Any]:
     skipped_total = 0
     skipped_exact_total = 0
     skipped_inferred_total = 0
+    blocked_total = 0
     errors_total = 0
     attempted_add_duplicate_keys_total = 0
 
@@ -487,6 +488,7 @@ def run_pairs(ctx) -> dict[str, Any]:
                             updated_total += int(res.get("updated", 0))
                             unresolved_total += int(res.get("unresolved", 0))
                             skipped_total += int(res.get("skipped", 0))
+                            blocked_total += int(res.get("blocked", 0))
                             errors_total += int(res.get("errors", 0))
                         elif mode == "two-way":
                             res = run_two_way_feature(ctx, src, dst, feature=feature, fcfg=fcfg, health_map=health_map)
@@ -505,6 +507,7 @@ def run_pairs(ctx) -> dict[str, Any]:
                                 + int(res.get("skipped_to_A", 0))
                                 + int(res.get("skipped_to_B", 0))
                             )
+                            blocked_total += int(res.get("blocked", 0))
                             errors_total += (
                                 int(res.get("errors", 0))
                                 + int(res.get("errors_to_A", 0))
@@ -520,6 +523,7 @@ def run_pairs(ctx) -> dict[str, Any]:
                             skipped_total += int(res.get("skipped", 0))
                             skipped_exact_total += int(res.get("skipped_exact", 0))
                             skipped_inferred_total += int(res.get("skipped_inferred", 0))
+                            blocked_total += int(res.get("blocked", 0))
                             attempted_add_duplicate_keys_total += int(res.get("attempted_add_duplicate_keys", 0))
                             errors_total += int(res.get("errors", 0))
 
@@ -580,6 +584,7 @@ def run_pairs(ctx) -> dict[str, Any]:
                     "skipped_inferred": skipped_inferred_total,
                     "attempted_add_duplicate_keys": attempted_add_duplicate_keys_total,
                     "unresolved": unresolved_total,
+                    "blocked": blocked_total,
                     "errors": errors_total,
                 },
             }
@@ -634,6 +639,7 @@ def run_pairs(ctx) -> dict[str, Any]:
         skipped_inferred=skipped_inferred_total,
         attempted_add_duplicate_keys=attempted_add_duplicate_keys_total,
         unresolved=unresolved_total,
+        blocked=blocked_total,
         errors=errors_total,
         pairs=len(pairs),
         cancelled=cancelled,
@@ -653,6 +659,7 @@ def run_pairs(ctx) -> dict[str, Any]:
         "removed": removed_total,
         "skipped": skipped_total,
         "unresolved": unresolved_total,
+        "blocked": blocked_total,
         "errors": errors_total,
         "pairs": len(pairs),
         "cancelled": cancelled,

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -1632,8 +1632,10 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
         emit=emit, dbg=dbg, dst_name=dst, feature=feature,
     )
 
+    blocked_total = 0
     pair_key = "-".join(sorted([src, dst]))
     if feature != "watchlist":
+        before_blocklist = len(adds)
         adds = apply_blocklist(
             ctx.state_store,
             adds,
@@ -1644,6 +1646,7 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
             ignore_pair_tomb=(str(feature or "").lower() == "history"),
             emit=emit,
         )
+        blocked_total += max(0, before_blocklist - len(adds))
 
     manual_blocked = 0
     if manual_blocks:
@@ -1663,6 +1666,7 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
                 blocked_keys=int(len(manual_blocks)),
             )
             ctx.stats_manual_blocked = int(getattr(ctx, "stats_manual_blocked", 0) or 0) + int(manual_blocked)
+        blocked_total += int(manual_blocked)
 
     if unresolved_known:
         try:
@@ -1683,6 +1687,7 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
     guard = PhantomGuard(src, dst, feature, ttl_days=ttl_days, enabled=use_phantoms)
     if use_phantoms and adds:
         adds, _blocked = guard.filter_adds(adds, _sync_key, _sync_minimal, emit, ctx.state_store, pair_key)
+        blocked_total += int(_blocked or 0)
 
     attempted_keys: list[str] = []
     key2item: dict[str, Any] = {}
@@ -1921,7 +1926,6 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
                         record_unresolved(dst, feature, failed_items, hint="apply:add:failed")
                     if promoted_keys:
                         clear_unresolved(dst, feature, promoted_keys)
-                        unresolved_new_total = max(0, unresolved_new_total - len(promoted_keys & set(still_unresolved)))
                         
                     _emit_item_failures(emit, dst, feature, pair_key, failed_keys, key2item, _bb)
                             
@@ -2248,6 +2252,7 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
         "errors": int((res_update or {}).get("errors", 0)) + int((res_add or {}).get("errors", 0)) + int((res_remove or {}).get("errors", 0)),
         "skipped_exact": int((res_update or {}).get("skipped_exact", 0)) + int((res_add or {}).get("skipped_exact", 0)),
         "skipped_inferred": int((res_update or {}).get("skipped_inferred", 0)) + int((res_add or {}).get("skipped_inferred", 0)),
+        "blocked": int(blocked_total),
         "res_add": res_add,
         "res_update": res_update,
         "res_remove": res_remove,

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -1739,27 +1739,33 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
     except Exception:
         pass
 
+    blocked_total = 0
     if feature != "watchlist":
-            add_to_A = apply_blocklist(
-                ctx.state_store,
-                add_to_A,
-                dst=a,
-                feature=feature,
-                pair_key=pair_key,
-                cross_feature_unresolved=_cross_feature_unresolved(feature),
-                ignore_pair_tomb=(str(feature or "").lower() in ("history", "ratings")),
-                emit=emit,
-            )
-            add_to_B = apply_blocklist(
-                ctx.state_store,
-                add_to_B,
-                dst=b,
-                feature=feature,
-                pair_key=pair_key,
-                cross_feature_unresolved=_cross_feature_unresolved(feature),
-                ignore_pair_tomb=(str(feature or "").lower() in ("history", "ratings")),
-                emit=emit,
-            )
+        before_blocklist_A = len(add_to_A)
+        add_to_A = apply_blocklist(
+            ctx.state_store,
+            add_to_A,
+            dst=a,
+            feature=feature,
+            pair_key=pair_key,
+            cross_feature_unresolved=_cross_feature_unresolved(feature),
+            ignore_pair_tomb=(str(feature or "").lower() in ("history", "ratings")),
+            emit=emit,
+        )
+        blocked_total += max(0, before_blocklist_A - len(add_to_A))
+
+        before_blocklist_B = len(add_to_B)
+        add_to_B = apply_blocklist(
+            ctx.state_store,
+            add_to_B,
+            dst=b,
+            feature=feature,
+            pair_key=pair_key,
+            cross_feature_unresolved=_cross_feature_unresolved(feature),
+            ignore_pair_tomb=(str(feature or "").lower() in ("history", "ratings")),
+            emit=emit,
+        )
+        blocked_total += max(0, before_blocklist_B - len(add_to_B))
 
     manual_blocked = 0
     if manual_blocks_A:
@@ -1787,6 +1793,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
             ctx.stats_manual_blocked = int(getattr(ctx, "stats_manual_blocked", 0) or 0) + int(manual_blocked)
         except Exception:
             pass
+        blocked_total += int(manual_blocked)
 
     bb = ((cfg or {}).get("blackbox") if isinstance(cfg, dict) else getattr(cfg, "blackbox", {})) or {}
     use_phantoms = bool(bb.get("enabled") and bb.get("block_adds", True))
@@ -1796,9 +1803,11 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
     guardB = PhantomGuard(src=a, dst=b, feature=feature, ttl_days=bb_ttl_days, enabled=use_phantoms)
 
     if use_phantoms and add_to_A:
-        add_to_A, _ = guardA.filter_adds(add_to_A, _sync_key, _sync_minimal, emit, ctx.state_store, pair_key)
+        add_to_A, blocked_A = guardA.filter_adds(add_to_A, _sync_key, _sync_minimal, emit, ctx.state_store, pair_key)
+        blocked_total += int(blocked_A or 0)
     if use_phantoms and add_to_B:
-        add_to_B, _ = guardB.filter_adds(add_to_B, _sync_key, _sync_minimal, emit, ctx.state_store, pair_key)
+        add_to_B, blocked_B = guardB.filter_adds(add_to_B, _sync_key, _sync_minimal, emit, ctx.state_store, pair_key)
+        blocked_total += int(blocked_B or 0)
 
     if feature == "ratings":
         upd_to_A = [it for it in add_to_A if _present(A_eff, A_alias, it)]
@@ -2202,7 +2211,6 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                         record_unresolved(a, feature, failed_items_A, hint="apply:add:failed")
                     if promoted_A:
                         clear_unresolved(a, feature, promoted_A)
-                        unresolved_new_A_total = max(0, unresolved_new_A_total - len(promoted_A & set(still_unresolved_A)))
                         
                     _emit_item_failures(emit, a, feature, pair_key, failed_A, k2i_A, _bb_A)
                
@@ -2340,7 +2348,6 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                         record_unresolved(b, feature, failed_items_B, hint="apply:add:failed")
                     if promoted_B:
                         clear_unresolved(b, feature, promoted_B)
-                        unresolved_new_B_total = max(0, unresolved_new_B_total - len(promoted_B & set(still_unresolved_B)))
                         
                     _emit_item_failures(emit, b, feature, pair_key, failed_B, k2i_B, _bb_B)
                 
@@ -2591,6 +2598,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
         "unresolved_to_B": unresolved_B_total,
         "unresolved": unresolved_total,
         "skipped": skipped_total,
+        "blocked": int(blocked_total),
         "errors": errors_total,
     }
 


### PR DESCRIPTION
# Pull request

## Change

- Make orchestrator totals include blocked items returned by feature syncs.
- Keep current-run unresolved writes visible even if they are promoted to the blackbox during that same run.

## Why

- The final summary should make that visible instead of making the run look fully clean.

## Testing

- tests/test_history_baseline_native.py 
- tests/test_twoway_remove_accounting.py

## Issue

NA