### PR TITLE
Fix: Nuvio unresolved sync accounting

### DIFF
--- a/providers/sync/_mod_NUVIO.py
+++ b/providers/sync/_mod_NUVIO.py
@@ -27,7 +27,7 @@ from .nuvio import _watchlist as feat_watchlist
 from .nuvio._common import pull_library_rows, pull_watch_progress_rows, pull_watched_rows
 from cw_platform.provider_instances import normalize_instance_id
 
-__VERSION__ = "0.4"
+__VERSION__ = "0.5"
 __all__ = ["get_manifest", "NUVIOModule", "OPS"]
 
 if "ctx" not in globals():

--- a/providers/sync/_mod_STREMIO.py
+++ b/providers/sync/_mod_STREMIO.py
@@ -17,7 +17,7 @@ from providers.sync.stremio import _ratings as feat_ratings
 from providers.sync.stremio import _watchlist as feat_watchlist
 from providers.sync.stremio._common import DEFAULT_STREMIO_PROFILE_ID, datastore_meta, is_capture_mode, is_configured, read_drop_unresolved_items
 
-__VERSION__ = "0.2"
+__VERSION__ = "0.3"
 __all__ = ["get_manifest", "STREMIOModule", "OPS", "feat_history", "feat_progress", "feat_ratings", "feat_watchlist"]
 
 if "ctx" not in globals():

--- a/providers/sync/nuvio/_common.py
+++ b/providers/sync/nuvio/_common.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import threading
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -38,6 +38,7 @@ __all__ = [
     "content_id_key",
     "epoch_ms",
     "ids_for_content_id",
+    "enrich_external_ids",
     "is_configured",
     "iso_from_epoch_ms",
     "library_lock",
@@ -53,6 +54,7 @@ __all__ = [
     "resolve_episode",
     "rpc",
     "selected_profile_id",
+    "unresolved_result_keys",
     "to_int",
 ]
 
@@ -148,6 +150,61 @@ def ids_for_content_id(content_id: Any) -> dict[str, str] | None:
         if value.isdigit():
             return {"tmdb": value}
     return None
+
+
+def enrich_external_ids(adapter: Any, item: Mapping[str, Any], *, entity: str) -> dict[str, Any]:
+    out = dict(item or {})
+    content_ids = ids_for_content_id(out.get("_nuvio_content_id") or out.get("content_id"))
+    tmdb = str((content_ids or {}).get("tmdb") or "").strip()
+    if not tmdb:
+        ids_raw = out.get("show_ids") if str(entity or "").lower() == "tv" and isinstance(out.get("show_ids"), Mapping) else out.get("ids")
+        ids = ids_raw if isinstance(ids_raw, Mapping) else {}
+        tmdb = str(ids.get("tmdb") or "").strip()
+    if not tmdb.isdigit():
+        return out
+
+    cache = getattr(adapter, "_nuvio_external_ids_cache", None)
+    if not isinstance(cache, dict):
+        cache = {}
+        try:
+            setattr(adapter, "_nuvio_external_ids_cache", cache)
+        except Exception:
+            pass
+
+    ent = "tv" if str(entity or "").strip().lower() in {"tv", "show", "series"} else "movie"
+    cache_key = (ent, tmdb)
+    ids_extra = cache.get(cache_key)
+    if ids_extra is None:
+        provider = _tmdb_metadata_provider(adapter)
+        if provider is None:
+            cache[cache_key] = {}
+            return out
+        try:
+            detail = provider.fetch(entity=ent, ids={"tmdb": tmdb}, need={"poster": False, "backdrop": False, "ids": True})
+        except Exception:
+            cache[cache_key] = {}
+            return out
+        raw = detail.get("ids") if isinstance(detail, Mapping) else None
+        ids_extra = merge_ids({"tmdb": tmdb}, raw if isinstance(raw, Mapping) else {})
+        cache[cache_key] = ids_extra
+
+    if not isinstance(ids_extra, Mapping) or not ids_extra:
+        return out
+
+    ids_cur = out.get("ids") if isinstance(out.get("ids"), Mapping) else {}
+    merged_ids = merge_ids(ids_cur, ids_extra)
+    if merged_ids:
+        out["ids"] = merged_ids
+
+    if str(out.get("type") or "").strip().lower() in {"episode", "season", "show"} or ent == "tv":
+        show_ids_cur = out.get("show_ids") if isinstance(out.get("show_ids"), Mapping) else {}
+        merged_show_ids = merge_ids(show_ids_cur, ids_extra)
+        if merged_show_ids:
+            out["show_ids"] = merged_show_ids
+            if str(out.get("type") or "").strip().lower() in {"episode", "season"}:
+                out["ids"] = merge_ids(out.get("ids") if isinstance(out.get("ids"), Mapping) else {}, merged_show_ids)
+
+    return out
 
 
 def content_id_for_item(item: Mapping[str, Any]) -> str | None:
@@ -302,6 +359,29 @@ def make_item(
 
 def canonical_item_key(item: Mapping[str, Any]) -> str:
     return canonical_key(id_minimal(item))
+
+
+def unresolved_result_keys(unresolved: Iterable[Mapping[str, Any]]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for row in unresolved or []:
+        if not isinstance(row, Mapping):
+            continue
+        key = ""
+        for field in ("key", "_cw_key", "canonical_key"):
+            raw = str(row.get(field) or "").strip()
+            if raw:
+                key = raw
+                break
+        if not key:
+            item = row.get("item")
+            if isinstance(item, Mapping):
+                key = canonical_item_key(item)
+        if not key or key == "unknown:" or key in seen:
+            continue
+        seen.add(key)
+        out.append(key)
+    return out
 
 
 def payload_item_key(payload: Mapping[str, Any]) -> str:

--- a/providers/sync/nuvio/_history.py
+++ b/providers/sync/nuvio/_history.py
@@ -7,12 +7,13 @@ import re
 from collections.abc import Iterable, Mapping
 from typing import Any
 
-from cw_platform.id_map import canonical_key, minimal as id_minimal
+from cw_platform.id_map import minimal as id_minimal
 
 from providers.sync._log import log as cw_log
 
 from ._common import (
     canonical_item_key,
+    enrich_external_ids,
     epoch_ms,
     iso_from_epoch_ms,
     make_item,
@@ -24,6 +25,7 @@ from ._common import (
     resolve_episode,
     rpc,
     selected_profile_id,
+    unresolved_result_keys,
 )
 
 
@@ -73,6 +75,7 @@ def _item_from_row(adapter: Any, row: Mapping[str, Any]) -> tuple[str | None, di
     item["watched_at"] = watched_at
     item["_nuvio_content_id"] = str(row.get("content_id") or "").strip()
     item["_nuvio_profile_id"] = row.get("profile_id")
+    item = enrich_external_ids(adapter, item, entity="tv" if ctype in {"series", "show"} else "movie")
     key = canonical_item_key(item)
     if not key or key == "unknown:":
         return None, None, "nuvio_id_missing"
@@ -141,8 +144,12 @@ def _delete_key_for_item(adapter: Any, item: Mapping[str, Any]) -> dict[str, Any
     return key
 
 
-def _unresolved(item: Mapping[str, Any], reason: str) -> dict[str, Any]:
-    return {"status": "unresolved", "reason": reason, "item": id_minimal(item)}
+def _unresolved(item: Mapping[str, Any], reason: str, key: str | None = None) -> dict[str, Any]:
+    out = {"status": "unresolved", "reason": reason, "item": id_minimal(item)}
+    if key:
+        out["key"] = key
+        out["canonical_key"] = key
+    return out
 
 
 def _result(ok: bool, count: int, attempted: int, confirmed: list[str], unresolved: list[dict[str, Any]], results: list[dict[str, Any]], skipped: int, **extra: Any) -> dict[str, Any]:
@@ -152,7 +159,7 @@ def _result(ok: bool, count: int, attempted: int, confirmed: list[str], unresolv
         "attempted": int(attempted),
         "confirmed_keys": list(dict.fromkeys(k for k in confirmed if k)),
         "unresolved": unresolved,
-        "unresolved_keys": list(dict.fromkeys(canonical_key((u.get("item") or {}) if isinstance(u, Mapping) else {}) for u in unresolved)),
+        "unresolved_keys": unresolved_result_keys(unresolved),
         "results": results,
         "skipped": int(skipped),
         "errors": sum(1 for u in unresolved if str(u.get("status") or "") == "failed"),
@@ -171,20 +178,27 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
     keys: list[str] = []
     verify_keys: list[str] = []
     pending_items: list[dict[str, Any]] = []
+    skipped_keys: list[str] = []
+    presence_confirmed_keys: list[str] = []
+    confirmed_destinations: dict[str, dict[str, Any]] = {}
     skipped = 0
 
     for item in src:
         key = canonical_item_key(item)
         payload, reason = _payload_for_item(adapter, item, current_rows=rows)
         if payload is None:
-            entry = _unresolved(item, reason or "nuvio_history_write_failed")
+            entry = _unresolved(item, reason or "nuvio_history_write_failed", key)
             unresolved.append(entry)
             results.append(entry)
             continue
         verify_key = payload_item_key(payload) or key
         target = current.get(verify_key) or current.get(key)
         if target and (epoch_ms(target.get("watched_at")) or 0) >= int(payload.get("watched_at") or 0):
+            dest_key = verify_key if verify_key in current else key
             skipped += 1
+            skipped_keys.append(key)
+            presence_confirmed_keys.append(key)
+            confirmed_destinations[key] = {"key": dest_key, "item": dict(target), "status": "existing"}
             results.append({"status": "skipped", "reason": "history_unchanged", "item": id_minimal(item), "canonical_key": key})
             continue
         payloads.append(payload)
@@ -194,7 +208,19 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
         results.append({"status": "pending" if not dry_run else "dry_run", "item": id_minimal(item), "canonical_key": key})
 
     if dry_run:
-        return _result(len(unresolved) == 0, len(payloads), len(payloads), [], unresolved, results, skipped, dry_run=True)
+        return _result(
+            len(unresolved) == 0,
+            len(payloads),
+            len(payloads),
+            [],
+            unresolved,
+            results,
+            skipped,
+            skipped_keys=skipped_keys,
+            presence_confirmed_keys=presence_confirmed_keys,
+            confirmed_destinations=confirmed_destinations,
+            dry_run=True,
+        )
 
     failed = False
     if payloads:
@@ -203,19 +229,31 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
         except Exception:
             failed = True
             for item, key in zip(pending_items, keys):
-                unresolved.append({"status": "failed", "reason": "nuvio_history_write_failed", "item": id_minimal(item), "canonical_key": key})
+                unresolved.append({"status": "failed", "reason": "nuvio_history_write_failed", "item": id_minimal(item), "key": key, "canonical_key": key})
 
     after = build_index(adapter) if payloads and not failed else current
     confirmed: list[str] = []
-    for key, verify_key in ([] if failed else zip(keys, verify_keys)):
+    for item, key, verify_key in ([] if failed else zip(pending_items, keys, verify_keys)):
         if verify_key in after:
             confirmed.append(key)
+            confirmed_destinations[key] = {"key": verify_key, "item": dict(after.get(verify_key) or {}), "status": "added"}
         else:
-            unresolved.append({"status": "failed", "reason": "nuvio_history_verification_failed", "canonical_key": key})
+            unresolved.append({"status": "failed", "reason": "nuvio_history_verification_failed", "item": id_minimal(item), "key": key, "canonical_key": key})
 
     ok = len(unresolved) == 0
     _info("write_done", op="add", ok=ok, attempted=len(payloads), confirmed=len(confirmed), skipped=skipped, unresolved=len(unresolved))
-    return _result(ok, len(confirmed), len(payloads), confirmed, unresolved, results, skipped)
+    return _result(
+        ok,
+        len(confirmed),
+        len(payloads),
+        confirmed,
+        unresolved,
+        results,
+        skipped,
+        skipped_keys=skipped_keys,
+        presence_confirmed_keys=presence_confirmed_keys,
+        confirmed_destinations=confirmed_destinations,
+    )
 
 
 def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
@@ -233,7 +271,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
         item_key = canonical_item_key(item)
         payload = _delete_key_for_item(adapter, current.get(item_key) or item)
         if not payload:
-            entry = _unresolved(item, "nuvio_id_missing")
+            entry = _unresolved(item, "nuvio_id_missing", item_key)
             unresolved.append(entry)
             results.append(entry)
             continue
@@ -258,15 +296,15 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
         except Exception:
             failed = True
             for item, key in zip(pending_items, item_keys):
-                unresolved.append({"status": "failed", "reason": "nuvio_history_write_failed", "item": id_minimal(item), "canonical_key": key})
+                unresolved.append({"status": "failed", "reason": "nuvio_history_write_failed", "item": id_minimal(item), "key": key, "canonical_key": key})
 
     after = build_index(adapter) if keys_payload and not failed else current
     confirmed: list[str] = []
-    for key, verify_key in ([] if failed else zip(item_keys, verify_keys)):
+    for item, key, verify_key in ([] if failed else zip(pending_items, item_keys, verify_keys)):
         if key and verify_key not in after:
             confirmed.append(key)
         elif key:
-            unresolved.append({"status": "failed", "reason": "nuvio_history_verification_failed", "canonical_key": key})
+            unresolved.append({"status": "failed", "reason": "nuvio_history_verification_failed", "item": id_minimal(item), "key": key, "canonical_key": key})
 
     ok = len(unresolved) == 0
     _info("write_done", op="remove", ok=ok, attempted=len(keys_payload), confirmed=len(confirmed), skipped=skipped, unresolved=len(unresolved))

--- a/providers/sync/nuvio/_progress.py
+++ b/providers/sync/nuvio/_progress.py
@@ -7,7 +7,7 @@ import re
 from collections.abc import Iterable, Mapping
 from typing import Any
 
-from cw_platform.id_map import canonical_key, minimal as id_minimal
+from cw_platform.id_map import minimal as id_minimal
 
 from providers.sync._log import log as cw_log
 from providers.sync._progress_policy import decide_progress_write, progress_materially_equal, select_progress_record
@@ -17,6 +17,7 @@ from ._common import (
     NuvioProfileUnavailable,
     NuvioTokenRefreshError,
     canonical_item_key,
+    enrich_external_ids,
     epoch_ms,
     iso_from_epoch_ms,
     make_item,
@@ -30,6 +31,7 @@ from ._common import (
     rpc,
     selected_profile_id,
     to_int,
+    unresolved_result_keys,
 )
 
 MAX_SIGNED_64_BIT_INT = (2**63) - 1
@@ -138,6 +140,7 @@ def _item_from_row(adapter: Any, row: Mapping[str, Any]) -> tuple[str | None, di
             "_nuvio_last_watched": int(last_watched),
         }
     )
+    item = enrich_external_ids(adapter, item, entity="tv" if ctype in {"series", "show"} else "movie")
     key = canonical_item_key(item)
     if not key or key == "unknown:":
         return None, None, "nuvio_id_missing"
@@ -218,8 +221,12 @@ def _payload_for_item(adapter: Any, item: Mapping[str, Any], current_rows: Any =
     }, None
 
 
-def _unresolved(item: Mapping[str, Any], reason: str) -> dict[str, Any]:
-    return {"status": "unresolved", "reason": reason, "item": id_minimal(item)}
+def _unresolved(item: Mapping[str, Any], reason: str, key: str | None = None) -> dict[str, Any]:
+    out = {"status": "unresolved", "reason": reason, "item": id_minimal(item)}
+    if key:
+        out["key"] = key
+        out["canonical_key"] = key
+    return out
 
 
 def _confirmed_after_write(after: Mapping[str, Mapping[str, Any]], key: str, payload: Mapping[str, Any]) -> bool:
@@ -238,7 +245,7 @@ def _result(ok: bool, count: int, attempted: int, confirmed: list[str], unresolv
         "attempted": int(attempted),
         "confirmed_keys": list(dict.fromkeys(k for k in confirmed if k)),
         "unresolved": unresolved,
-        "unresolved_keys": list(dict.fromkeys(canonical_key((u.get("item") or {}) if isinstance(u, Mapping) else {}) for u in unresolved)),
+        "unresolved_keys": unresolved_result_keys(unresolved),
         "results": results,
         "skipped": int(skipped),
         "errors": sum(1 for u in unresolved if str(u.get("status") or "") == "failed"),
@@ -249,7 +256,7 @@ def _result(ok: bool, count: int, attempted: int, confirmed: list[str], unresolv
 
 def _write_failed_items(pending_items: list[dict[str, Any]], keys: list[str]) -> list[dict[str, Any]]:
     return [
-        {"status": "failed", "reason": "nuvio_progress_write_failed", "item": id_minimal(item), "canonical_key": key}
+        {"status": "failed", "reason": "nuvio_progress_write_failed", "item": id_minimal(item), "key": key, "canonical_key": key}
         for item, key in zip(pending_items, keys)
     ]
 
@@ -293,13 +300,16 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
     keys: list[str] = []
     verify_keys: list[str] = []
     pending_items: list[dict[str, Any]] = []
+    skipped_keys: list[str] = []
+    presence_confirmed_keys: list[str] = []
+    confirmed_destinations: dict[str, dict[str, Any]] = {}
     skipped = 0
 
     for item in src:
         key = canonical_item_key(item)
         payload, reason = _payload_for_item(adapter, item, current_rows=rows)
         if payload is None:
-            entry = _unresolved(item, reason or "nuvio_progress_invalid")
+            entry = _unresolved(item, reason or "nuvio_progress_invalid", key)
             unresolved.append(entry)
             results.append(entry)
             continue
@@ -318,7 +328,12 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
             replay_enabled=True,
         )
         if not decision.apply:
+            dest_key = verify_key if verify_key in current else key
             skipped += 1
+            skipped_keys.append(key)
+            if isinstance(target, Mapping):
+                presence_confirmed_keys.append(key)
+                confirmed_destinations[key] = {"key": dest_key, "item": dict(target), "status": "existing"}
             results.append({"status": "skipped", "reason": decision.reason, "item": id_minimal(item), "canonical_key": key})
             continue
         entries.append(payload)
@@ -328,27 +343,51 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
         results.append({"status": "pending" if not dry_run else "dry_run", "item": id_minimal(item), "canonical_key": key})
 
     if dry_run:
-        return _result(len(unresolved) == 0, len(entries), len(entries), [], unresolved, results, skipped, dry_run=True)
+        return _result(
+            len(unresolved) == 0,
+            len(entries),
+            len(entries),
+            [],
+            unresolved,
+            results,
+            skipped,
+            skipped_keys=skipped_keys,
+            presence_confirmed_keys=presence_confirmed_keys,
+            confirmed_destinations=confirmed_destinations,
+            dry_run=True,
+        )
 
     write_failures: list[dict[str, Any]] = []
     if entries:
         write_failures = _push_progress_entries(adapter, entries, keys, pending_items, profile_id=selected_profile_id(adapter))
         unresolved.extend(write_failures)
 
-    failed_keys = {str(row.get("canonical_key") or "") for row in write_failures if isinstance(row, Mapping)}
+    failed_keys = {str(row.get("key") or row.get("canonical_key") or "") for row in write_failures if isinstance(row, Mapping)}
     after = build_index(adapter) if entries and len(write_failures) < len(entries) else current
     confirmed: list[str] = []
-    for key, verify_key, payload in zip(keys, verify_keys, entries):
+    for item, key, verify_key, payload in zip(pending_items, keys, verify_keys, entries):
         if key in failed_keys:
             continue
         if _confirmed_after_write(after, verify_key, payload):
             confirmed.append(key)
+            confirmed_destinations[key] = {"key": verify_key, "item": dict(after.get(verify_key) or {}), "status": "added"}
         else:
-            unresolved.append({"status": "failed", "reason": "nuvio_progress_verification_failed", "canonical_key": key, "item": dict(after.get(verify_key) or {})})
+            unresolved.append({"status": "failed", "reason": "nuvio_progress_verification_failed", "key": key, "canonical_key": key, "item": dict(after.get(verify_key) or id_minimal(item))})
 
     ok = len(unresolved) == 0
     _info("write_done", op="add", ok=ok, attempted=len(entries), confirmed=len(confirmed), skipped=skipped, unresolved=len(unresolved))
-    return _result(ok, len(confirmed), len(entries), confirmed, unresolved, results, skipped)
+    return _result(
+        ok,
+        len(confirmed),
+        len(entries),
+        confirmed,
+        unresolved,
+        results,
+        skipped,
+        skipped_keys=skipped_keys,
+        presence_confirmed_keys=presence_confirmed_keys,
+        confirmed_destinations=confirmed_destinations,
+    )
 
 
 def _remote_key_for_item(adapter: Any, current: Mapping[str, Mapping[str, Any]], item: Mapping[str, Any]) -> tuple[str | None, str | None, str | None]:
@@ -384,7 +423,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
     for item in src:
         remote_key, item_key, verify_key = _remote_key_for_item(adapter, current, item)
         if not remote_key:
-            entry = _unresolved(item, "nuvio_video_id_missing")
+            entry = _unresolved(item, "nuvio_video_id_missing", item_key)
             unresolved.append(entry)
             results.append(entry)
             continue
@@ -408,15 +447,15 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
         except Exception:
             delete_failed = True
             for item, key in zip(pending_items, item_keys):
-                unresolved.append({"status": "failed", "reason": "nuvio_progress_delete_failed", "item": id_minimal(item), "canonical_key": key})
+                unresolved.append({"status": "failed", "reason": "nuvio_progress_delete_failed", "item": id_minimal(item), "key": key, "canonical_key": key})
 
     after = build_index(adapter) if remote_keys and not delete_failed else current
     confirmed: list[str] = []
-    for item_key, verify_key in ([] if delete_failed else zip(item_keys, verify_keys)):
+    for item, item_key, verify_key in ([] if delete_failed else zip(pending_items, item_keys, verify_keys)):
         if item_key and verify_key not in after:
             confirmed.append(item_key)
         elif item_key:
-            unresolved.append({"status": "failed", "reason": "nuvio_progress_verification_failed", "canonical_key": item_key, "item": dict(after.get(verify_key) or {})})
+            unresolved.append({"status": "failed", "reason": "nuvio_progress_verification_failed", "key": item_key, "canonical_key": item_key, "item": dict(after.get(verify_key) or id_minimal(item))})
 
     ok = len(unresolved) == 0
     _info("write_done", op="remove", ok=ok, attempted=len(remote_keys), confirmed=len(confirmed), skipped=skipped, unresolved=len(unresolved))

--- a/providers/sync/nuvio/_watchlist.py
+++ b/providers/sync/nuvio/_watchlist.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import Any
 
-from cw_platform.id_map import canonical_key, ids_from, minimal as id_minimal
+from cw_platform.id_map import ids_from, minimal as id_minimal
 
 from providers.sync._log import log as cw_log
 
-from ._common import canonical_item_key, epoch_ms, library_lock, make_item, payload_item_key, pull_library_rows, resolve_content_id_for_item, rpc, selected_profile_id
+from ._common import canonical_item_key, enrich_external_ids, epoch_ms, library_lock, make_item, payload_item_key, pull_library_rows, resolve_content_id_for_item, rpc, selected_profile_id, unresolved_result_keys
 
 _METADATA_FIELDS = (
     "name",
@@ -34,7 +34,7 @@ def _warn(event: str, **fields: Any) -> None:
     cw_log("NUVIO", "watchlist", "warn", event, **fields)
 
 
-def _item_from_row(row: Mapping[str, Any]) -> tuple[str | None, dict[str, Any] | None, str | None]:
+def _item_from_row(adapter: Any, row: Mapping[str, Any]) -> tuple[str | None, dict[str, Any] | None, str | None]:
     ctype = str(row.get("content_type") or "").strip().lower()
     if ctype not in {"movie", "series", "show"}:
         return None, None, "nuvio_id_missing"
@@ -52,6 +52,7 @@ def _item_from_row(row: Mapping[str, Any]) -> tuple[str | None, dict[str, Any] |
     for field in _METADATA_FIELDS:
         if field in row:
             item[f"_nuvio_{field}"] = row.get(field)
+    item = enrich_external_ids(adapter, item, entity="tv" if item.get("type") == "show" else "movie")
     key = canonical_item_key(item)
     if not key or key == "unknown:":
         return None, None, "nuvio_id_missing"
@@ -216,7 +217,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
     out: dict[str, dict[str, Any]] = {}
     skipped = 0
     for row in rows:
-        key, item, reason = _item_from_row(row)
+        key, item, reason = _item_from_row(adapter, row)
         if not key or not item:
             if reason:
                 skipped += 1
@@ -232,7 +233,7 @@ def _pull_remote_by_key(adapter: Any) -> tuple[dict[str, dict[str, Any]], dict[s
     items: dict[str, dict[str, Any]] = {}
     remote: dict[str, dict[str, Any]] = {}
     for row in rows:
-        key, item, _reason = _item_from_row(row)
+        key, item, _reason = _item_from_row(adapter, row)
         if key and item:
             items[key] = item
             remote[key] = _remote_for_row(row)
@@ -263,7 +264,7 @@ def _result(ok: bool, count: int, attempted: int, confirmed: list[str], unresolv
         "attempted": int(attempted),
         "confirmed_keys": list(dict.fromkeys(k for k in confirmed if k)),
         "unresolved": unresolved,
-        "unresolved_keys": list(dict.fromkeys(canonical_key((u.get("item") or {}) if isinstance(u, Mapping) else {}) for u in unresolved)),
+        "unresolved_keys": unresolved_result_keys(unresolved),
         "results": results,
         "skipped": int(skipped),
         "errors": sum(1 for u in unresolved if str(u.get("status") or "") == "failed"),
@@ -283,12 +284,13 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
         pending_keys: list[str] = []
         verify_keys: list[str] = []
         pending_items: list[dict[str, Any]] = []
+        confirmed_destinations: dict[str, dict[str, Any]] = {}
 
         for item in src:
             key = canonical_item_key(item)
             payload, reason = _remote_for_item(adapter, item)
             if payload is None:
-                entry = {"status": "unresolved", "reason": reason or "nuvio_id_missing", "item": id_minimal(item)}
+                entry = {"status": "unresolved", "reason": reason or "nuvio_id_missing", "item": id_minimal(item), "key": key, "canonical_key": key}
                 unresolved.append(entry)
                 results.append(entry)
                 continue
@@ -311,14 +313,26 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = Fal
             try:
                 rpc(adapter, "sync_push_library", {"p_profile_id": selected_profile_id(adapter), "p_items": list(remote.values())})
             except Exception:
-                return _result(False, 0, attempted, [], [{"status": "failed", "reason": "nuvio_library_replace_failed"}], results, 0)
+                failed = [
+                    {"status": "failed", "reason": "nuvio_library_replace_failed", "item": id_minimal(item), "key": key, "canonical_key": key}
+                    for item, key in zip(pending_items, pending_keys)
+                ]
+                return _result(False, 0, attempted, [], failed or [{"status": "failed", "reason": "nuvio_library_replace_failed"}], results, 0)
 
         after = build_index(adapter)
-        confirmed = [key for key, verify_key in zip(pending_keys, verify_keys) if verify_key in after]
-        unresolved.extend({"status": "failed", "reason": "nuvio_library_verification_failed", "item": id_minimal(item), "canonical_key": key} for item, key, verify_key in zip(pending_items, pending_keys, verify_keys) if verify_key not in after)
+        confirmed = []
+        for key, verify_key in zip(pending_keys, verify_keys):
+            if verify_key in after:
+                confirmed.append(key)
+                confirmed_destinations[key] = {
+                    "key": verify_key,
+                    "item": dict(after.get(verify_key) or {}),
+                    "status": "added" if changed else "existing",
+                }
+        unresolved.extend({"status": "failed", "reason": "nuvio_library_verification_failed", "item": id_minimal(item), "key": key, "canonical_key": key} for item, key, verify_key in zip(pending_items, pending_keys, verify_keys) if verify_key not in after)
         ok = len(unresolved) == 0
         _info("write_done", op="add", ok=ok, attempted=attempted, confirmed=len(confirmed), unresolved=len(unresolved))
-        return _result(ok, len(confirmed), attempted, confirmed, unresolved, results, 0)
+        return _result(ok, len(confirmed), attempted, confirmed, unresolved, results, 0, confirmed_destinations=confirmed_destinations)
 
 
 def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
@@ -337,7 +351,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
             key = canonical_item_key(item)
             verify_key = _verify_key_for_item(adapter, item)
             if not key or key == "unknown:":
-                entry = {"status": "unresolved", "reason": "nuvio_id_missing", "item": id_minimal(item)}
+                entry = {"status": "unresolved", "reason": "nuvio_id_missing", "item": id_minimal(item), "key": key, "canonical_key": key}
                 unresolved.append(entry)
                 results.append(entry)
                 continue
@@ -358,7 +372,11 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
             try:
                 rpc(adapter, "sync_push_library", {"p_profile_id": selected_profile_id(adapter), "p_items": list(remote.values())})
             except Exception:
-                return _result(False, 0, attempted, [], [{"status": "failed", "reason": "nuvio_library_replace_failed"}], results, skipped)
+                failed = [
+                    {"status": "failed", "reason": "nuvio_library_replace_failed", "item": id_minimal(item), "key": key, "canonical_key": key}
+                    for item, key in zip(pending_items, pending_keys)
+                ]
+                return _result(False, 0, attempted, [], failed or [{"status": "failed", "reason": "nuvio_library_replace_failed"}], results, skipped)
 
         after = build_index(adapter)
         confirmed: list[str] = []
@@ -366,7 +384,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]], *, dry_run: bool = 
             if key and verify_key not in after:
                 confirmed.append(key)
             elif verify_key in current:
-                unresolved.append({"status": "failed", "reason": "nuvio_library_verification_failed", "item": id_minimal(item), "canonical_key": key})
+                unresolved.append({"status": "failed", "reason": "nuvio_library_verification_failed", "item": id_minimal(item), "key": key, "canonical_key": key})
         ok = len(unresolved) == 0
         _info("write_done", op="remove", ok=ok, attempted=attempted, confirmed=len(confirmed), skipped=skipped, unresolved=len(unresolved))
         return _result(ok, len(confirmed), attempted, confirmed, unresolved, results, skipped)

--- a/providers/sync/stremio/_history.py
+++ b/providers/sync/stremio/_history.py
@@ -606,12 +606,16 @@ def _latest_history_ts(items: Iterable[Mapping[str, Any]]) -> str | None:
     return latest[1] if latest else None
 
 
-def _unresolved(item: Mapping[str, Any], reason: str) -> dict[str, Any]:
-    return {"status": "unresolved", "reason": reason, "item": id_minimal(item)}
+def _unresolved(item: Mapping[str, Any], reason: str, key: str | None = None) -> dict[str, Any]:
+    out = {"status": "unresolved", "reason": reason, "item": id_minimal(item)}
+    if key:
+        out["key"] = key
+        out["canonical_key"] = key
+    return out
 
 
 def _api_failure(item: Mapping[str, Any], key: str, exc: StremioAuthError, fallback: str) -> dict[str, Any]:
-    entry = {"status": "failed", "reason": str(getattr(exc, "reason", "") or fallback), "item": id_minimal(item), "canonical_key": key}
+    entry = {"status": "failed", "reason": str(getattr(exc, "reason", "") or fallback), "item": id_minimal(item), "key": key, "canonical_key": key}
     detail = str(getattr(exc, "detail", "") or "").replace("\n", " ").replace("\r", " ").strip()
     if detail:
         for token in ("authKey", "auth_key", "password"):
@@ -708,7 +712,7 @@ def _write(adapter: Any, items: Iterable[Mapping[str, Any]], watched: bool, *, d
         item = _metadata_enriched(adapter, item, typ)
         stremio_id = stremio_write_id_for_item(item)
         if not stremio_id or typ not in {"movie", "episode", "episodes"}:
-            entry = _unresolved(item, "stremio_id_missing")
+            entry = _unresolved(item, "stremio_id_missing", key)
             unresolved.append(entry)
             results.append(entry)
             continue
@@ -743,12 +747,12 @@ def _write(adapter: Any, items: Iterable[Mapping[str, Any]], watched: bool, *, d
                     if reason:
                         raise ValueError(reason)
                 except ValueError as exc:
-                    entry = _unresolved(item, str(exc) or "stremio_history_write_failed")
+                    entry = _unresolved(item, str(exc) or "stremio_history_write_failed", key)
                     unresolved.append(entry)
                     results.append(entry)
                     continue
                 except Exception:
-                    entry = {"status": "failed", "reason": "stremio_history_write_failed", "item": id_minimal(item), "canonical_key": key}
+                    entry = {"status": "failed", "reason": "stremio_history_write_failed", "item": id_minimal(item), "key": key, "canonical_key": key}
                     unresolved.append(entry)
                     results.append(entry)
                     continue
@@ -774,7 +778,7 @@ def _write(adapter: Any, items: Iterable[Mapping[str, Any]], watched: bool, *, d
                         continue
                     except Exception:
                         for key, item in ops:
-                            entry = {"status": "failed", "reason": "stremio_history_write_failed", "item": id_minimal(item), "canonical_key": key}
+                            entry = {"status": "failed", "reason": "stremio_history_write_failed", "item": id_minimal(item), "key": key, "canonical_key": key}
                             unresolved.append(entry)
                             results.append(entry)
                         continue

--- a/providers/sync/stremio/_progress.py
+++ b/providers/sync/stremio/_progress.py
@@ -293,12 +293,16 @@ def build_index(adapter: Any, **kwargs: Any) -> dict[str, dict[str, Any]]:
     return out
 
 
-def _unresolved(item: Mapping[str, Any], reason: str) -> dict[str, Any]:
-    return {"status": "unresolved", "reason": reason, "item": id_minimal(item)}
+def _unresolved(item: Mapping[str, Any], reason: str, key: str | None = None) -> dict[str, Any]:
+    out = {"status": "unresolved", "reason": reason, "item": id_minimal(item)}
+    if key:
+        out["key"] = key
+        out["canonical_key"] = key
+    return out
 
 
 def _api_failure(item: Mapping[str, Any], key: str, exc: StremioAuthError, fallback: str) -> dict[str, Any]:
-    entry = {"status": "failed", "reason": str(getattr(exc, "reason", "") or fallback), "item": id_minimal(item), "canonical_key": key}
+    entry = {"status": "failed", "reason": str(getattr(exc, "reason", "") or fallback), "item": id_minimal(item), "key": key, "canonical_key": key}
     detail = str(getattr(exc, "detail", "") or "").replace("\n", " ").replace("\r", " ").strip()
     if detail:
         for token in ("authKey", "auth_key", "password"):
@@ -359,7 +363,7 @@ def _write(adapter: Any, items: Iterable[Mapping[str, Any]], clear: bool, *, dry
         item = _metadata_enriched(adapter, item, typ)
         stremio_id = stremio_write_id_for_item(item)
         if not stremio_id or typ not in {"movie", "episode", "episodes"}:
-            entry = _unresolved(item, "stremio_id_missing")
+            entry = _unresolved(item, "stremio_id_missing", key)
             unresolved.append(entry)
             results.append(entry)
             continue
@@ -376,7 +380,7 @@ def _write(adapter: Any, items: Iterable[Mapping[str, Any]], clear: bool, *, dry
 
             read_merge_write(adapter, stremio_id, "movie" if typ == "movie" else "series", item, mutate)
         except ValueError as exc:
-            entry = _unresolved(item, str(exc) or "stremio_progress_write_failed")
+            entry = _unresolved(item, str(exc) or "stremio_progress_write_failed", key)
             unresolved.append(entry)
             results.append(entry)
             continue
@@ -386,7 +390,7 @@ def _write(adapter: Any, items: Iterable[Mapping[str, Any]], clear: bool, *, dry
             results.append(entry)
             continue
         except Exception:
-            entry = {"status": "failed", "reason": "stremio_progress_write_failed", "item": id_minimal(item), "canonical_key": key}
+            entry = {"status": "failed", "reason": "stremio_progress_write_failed", "item": id_minimal(item), "key": key, "canonical_key": key}
             unresolved.append(entry)
             results.append(entry)
             continue

--- a/providers/sync/stremio/_ratings.py
+++ b/providers/sync/stremio/_ratings.py
@@ -212,7 +212,7 @@ def _write(adapter: Any, items: Iterable[Mapping[str, Any]], *, clear_missing: b
         media_id = _media_id(item)
         status = None if clear_missing else _status_for_rating(adapter, item.get("rating"))
         if not media_type or not media_id:
-            entry = {"status": "unresolved", "reason": "stremio_rating_id_missing", "item": id_minimal(item), "canonical_key": key}
+            entry = {"status": "unresolved", "reason": "stremio_rating_id_missing", "item": id_minimal(item), "key": key, "canonical_key": key}
             unresolved.append(entry)
             results.append(entry)
             continue
@@ -258,7 +258,7 @@ def _write(adapter: Any, items: Iterable[Mapping[str, Any]], *, clear_missing: b
                 raise StremioAuthError("Stremio rating write failed", reason="request_failed", detail=_response_detail(resp), status_code=resp.status_code, endpoint="likes/send")
         except StremioAuthError as exc:
             reason = str(getattr(exc, "reason", "") or "stremio_rating_write_failed")
-            entry = {"status": "failed", "reason": reason, "item": id_minimal(item), "canonical_key": key}
+            entry = {"status": "failed", "reason": reason, "item": id_minimal(item), "key": key, "canonical_key": key}
             detail = str(getattr(exc, "detail", "") or "").strip()
             if detail:
                 entry["hint"] = detail
@@ -266,7 +266,7 @@ def _write(adapter: Any, items: Iterable[Mapping[str, Any]], *, clear_missing: b
             results.append(entry)
             continue
         except Exception:
-            entry = {"status": "failed", "reason": "stremio_rating_write_failed", "item": id_minimal(item), "canonical_key": key}
+            entry = {"status": "failed", "reason": "stremio_rating_write_failed", "item": id_minimal(item), "key": key, "canonical_key": key}
             unresolved.append(entry)
             results.append(entry)
             continue

--- a/providers/sync/stremio/_watchlist.py
+++ b/providers/sync/stremio/_watchlist.py
@@ -116,8 +116,12 @@ def build_index(adapter: Any, **kwargs: Any) -> dict[str, dict[str, Any]]:
     return out
 
 
-def _unresolved(item: Mapping[str, Any], reason: str) -> dict[str, Any]:
-    return {"status": "unresolved", "reason": reason, "item": id_minimal(item)}
+def _unresolved(item: Mapping[str, Any], reason: str, key: str | None = None) -> dict[str, Any]:
+    out = {"status": "unresolved", "reason": reason, "item": id_minimal(item)}
+    if key:
+        out["key"] = key
+        out["canonical_key"] = key
+    return out
 
 
 def _apply_membership(record: dict[str, Any], item: Mapping[str, Any], listed: bool) -> None:
@@ -144,8 +148,9 @@ def _write(adapter: Any, items: Iterable[Mapping[str, Any]], listed: bool, *, dr
     attempted = 0
     for raw in [dict(x or {}) for x in items or [] if isinstance(x, Mapping)]:
         typ = str(id_minimal(raw).get("type") or raw.get("type") or "").strip().lower()
+        raw_key = canonical_item_key(raw)
         if typ in {"episode", "episodes", "season", "seasons"}:
-            entry = _unresolved(raw, "stremio_watchlist_type_unsupported")
+            entry = _unresolved(raw, "stremio_watchlist_type_unsupported", raw_key)
             unresolved.append(entry)
             results.append(entry)
             continue
@@ -153,7 +158,7 @@ def _write(adapter: Any, items: Iterable[Mapping[str, Any]], listed: bool, *, dr
         key = canonical_item_key(item)
         stremio_id = stremio_write_id_for_item(item)
         if not stremio_id or typ not in {"movie", "show", "series", "tv"}:
-            entry = _unresolved(item, "stremio_id_missing")
+            entry = _unresolved(item, "stremio_id_missing", key)
             unresolved.append(entry)
             results.append(entry)
             continue
@@ -173,7 +178,7 @@ def _write(adapter: Any, items: Iterable[Mapping[str, Any]], listed: bool, *, dr
             _apply_membership(record, item, listed)
             datastore_put(adapter, [record])
         except Exception:
-            entry = {"status": "failed", "reason": "stremio_watchlist_write_failed", "item": id_minimal(item), "canonical_key": key}
+            entry = {"status": "failed", "reason": "stremio_watchlist_write_failed", "item": id_minimal(item), "key": key, "canonical_key": key}
             unresolved.append(entry)
             results.append(entry)
             continue


### PR DESCRIPTION
# Pull request

## Change

- Fix unresolved reporting for Nuvio writes and Stremio source keys.

## Why

- Nuvio history items could not be written, but the final totals did not clearly show the unresolved/blocked state.
- Nuvio now keeps the attempted key in failed write results and readback rows are enriched so Stremio imdb/tvdb items can match Nuvio tmdb rows.
- Stremio failed write results also keep the attempted key after enrichment.

## Testing

- tests/test_history_baseline_native.py 
- tests/test_twoway_remove_accounting.py
- providers/tests/test_stremio_sync.py 
- providers/tests/test_nuvio_history.py 
- providers/tests/test_nuvio_progress.py 
- providers/tests/test_nuvio_watchlist.py

## Issue

Relates to #942

## Important

Based on this change both adapters Stremio and Nuvio needs TMDB metadata to function correctly.