### PR TITLE
Fix: keep Stremio episode timestamps stable

### DIFF
--- a/providers/sync/_mod_STREMIO.py
+++ b/providers/sync/_mod_STREMIO.py
@@ -214,12 +214,62 @@ class _STREMIOOPS:
 
     def _adapter(self, cfg: Mapping[str, Any]) -> STREMIOModule:
         return STREMIOModule(cfg)
+    # Fix #930 - keep a baseline of history items to avoid re-reading them as unresolved in future syncs
+    def _inject_history_baseline(self, adapter: STREMIOModule) -> None:
+        if isinstance(getattr(adapter, "_stremio_history_baseline", None), Mapping):
+            return
+        try:
+            store = getattr(ctx, "state_store", None)
+            load = getattr(store, "load_state_features", None)
+            if not callable(load):
+                return
+            state = load({"history"}) or {}
+            providers = state.get("providers") if isinstance(state, Mapping) else None
+            providers = providers if isinstance(providers, Mapping) else {}
+            stremio = providers.get("STREMIO") or providers.get("stremio")
+            if not isinstance(stremio, Mapping):
+                return
+
+            def _baseline_items(node: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+                history = node.get("history") if isinstance(node, Mapping) else None
+                history = history if isinstance(history, Mapping) else {}
+                baseline = history.get("baseline") if isinstance(history, Mapping) else None
+                baseline = baseline if isinstance(baseline, Mapping) else {}
+                items = baseline.get("items") if isinstance(baseline, Mapping) else None
+                if not isinstance(items, Mapping):
+                    return {}
+                return {str(k): dict(v) for k, v in items.items() if isinstance(v, Mapping)}
+
+            instance_id = normalize_instance_id(getattr(adapter, "instance_id", "default"))
+            nodes: list[Mapping[str, Any]] = []
+            instances = stremio.get("instances")
+            if isinstance(instances, Mapping):
+                node = instances.get(instance_id) or instances.get(str(instance_id))
+                if not isinstance(node, Mapping):
+                    for raw_inst, raw_node in instances.items():
+                        if normalize_instance_id(raw_inst) == instance_id and isinstance(raw_node, Mapping):
+                            node = raw_node
+                            break
+                if isinstance(node, Mapping):
+                    nodes.append(node)
+            nodes.append(stremio)
+
+            for node in nodes:
+                items = _baseline_items(node)
+                if items:
+                    setattr(adapter, "_stremio_history_baseline", items)
+                    return
+        except Exception:
+            return
+        #end of _inject_history_baseline
 
     def health(self, cfg: Mapping[str, Any]) -> Mapping[str, Any]:
         return self._adapter(cfg).health()
 
     def build_index(self, cfg: Mapping[str, Any], *, feature: str) -> Mapping[str, dict[str, Any]]:
         adapter = self._adapter(cfg)
+        if str(feature or "").strip().lower() == "history":
+            self._inject_history_baseline(adapter)
         index = adapter.build_index(feature)
         self._record_read_unresolved(feature, adapter)
         return index

--- a/providers/tests/test_stremio_sync.py
+++ b/providers/tests/test_stremio_sync.py
@@ -538,6 +538,51 @@ def test_stremio_ops_clears_read_drops_once_the_records_resolve(tmp_path, monkey
     assert _unresolved.load_unresolved_pending("STREMIO", "history") == []
 
 
+def test_stremio_ops_injects_orchestrator_history_baseline(monkeypatch) -> None:
+    class Store:
+        def load_state_features(self, _features: set[str]) -> dict[str, Any]:
+            return {
+                "providers": {
+                    "STREMIO": {
+                        "history": {
+                            "baseline": {
+                                "items": {
+                                    "imdb:tt0903747#s01e01": {
+                                        "type": "episode",
+                                        "show_ids": {"imdb": "tt0903747"},
+                                        "ids": {"imdb": "tt0903747"},
+                                        "season": 1,
+                                        "episode": 1,
+                                        "watched": True,
+                                        "watched_at": "2026-01-01T00:00:00Z",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+    class Ctx:
+        state_store = Store()
+
+    class FakeStremioModule(FakeAdapter):
+        def build_index(self, feature: str, **_kwargs: Any) -> dict[str, dict[str, Any]]:
+            assert feature == "history"
+            return _history.build_index(self)
+
+    monkeypatch.setattr(mod, "ctx", Ctx())
+    monkeypatch.setattr(_history, "cinemeta_videos", lambda _adapter, _imdb: bb_videos())
+    adapter = FakeStremioModule([series_record("tt0903747:1:1:6:eJxTYIACAAEpACE=")])
+    monkeypatch.setattr(mod.OPS, "_adapter", lambda _cfg: adapter)
+
+    index = mod.OPS.build_index({}, feature="history")
+
+    item = index["imdb:tt0903747#s01e01"]
+    assert item["watched_at"] == "2026-01-01T00:00:00Z"
+    assert item["_stremio_watched_at_source"] == "stored_episode_estimate"
+
+
 def test_history_write_resolves_imdb_with_tmdb_and_uses_metahub_poster(monkeypatch) -> None:
     class Provider:
         def fetch(self, **_kwargs: Any) -> dict[str, Any]:
@@ -1055,6 +1100,50 @@ def test_progress_percent_without_duration_reports_duration_missing() -> None:
 
     assert result["count"] == 0
     assert result["unresolved"][0]["reason"] == "stremio_duration_missing"
+
+
+def test_history_unresolved_preserves_attempted_key_after_enrichment(monkeypatch) -> None:
+    class Provider:
+        def fetch(self, **_kwargs: Any) -> dict[str, Any]:
+            return {"ids": {"imdb": "tt0903747", "tvdb": "81189"}, "images": {}}
+
+    monkeypatch.setattr(_history, "tmdb_metadata_provider", lambda _adapter: Provider())
+    monkeypatch.setattr(_history, "video_orders_for_series_record", lambda *_a, **_k: ([{"id": "tt0903747:1:2", "season": 1, "episode": 2}], False))
+    monkeypatch.setattr(_history, "datastore_put", lambda *_a, **_k: (_ for _ in ()).throw(Exception("write failed")))
+    adapter = FakeAdapter([])
+    item = {"type": "episode", "show_ids": {"tvdb": "81189"}, "series_title": "Breaking Bad", "season": 1, "episode": 2}
+
+    result = _history.add(adapter, [item])
+
+    assert result["count"] == 0
+    assert result["unresolved_keys"] == ["tvdb:81189#s01e02"]
+    assert result["unresolved"][0]["key"] == "tvdb:81189#s01e02"
+    assert result["unresolved"][0]["canonical_key"] == "tvdb:81189#s01e02"
+
+
+def test_progress_unresolved_preserves_attempted_key_after_enrichment(monkeypatch) -> None:
+    class Provider:
+        def fetch(self, **_kwargs: Any) -> dict[str, Any]:
+            return {"ids": {"imdb": "tt0903747", "tvdb": "81189"}, "images": {}, "runtime_minutes": 45}
+
+    monkeypatch.setattr(_progress, "tmdb_metadata_provider", lambda _adapter: Provider())
+    monkeypatch.setattr(_progress, "read_merge_write", lambda *_a, **_k: (_ for _ in ()).throw(Exception("write failed")))
+    adapter = FakeAdapter([])
+    item = {
+        "type": "episode",
+        "show_ids": {"tvdb": "81189"},
+        "series_title": "Breaking Bad",
+        "season": 1,
+        "episode": 2,
+        "progress_percent": 10.0,
+    }
+
+    result = _progress.add(adapter, [item])
+
+    assert result["count"] == 0
+    assert result["unresolved_keys"] == ["tvdb:81189#s01e02"]
+    assert result["unresolved"][0]["key"] == "tvdb:81189#s01e02"
+    assert result["unresolved"][0]["canonical_key"] == "tvdb:81189#s01e02"
 
 
 def test_created_record_uses_stremio_library_shape() -> None:


### PR DESCRIPTION
# Pull request

## Change

Pass the previous Stremio history baseline into normal Stremio history reads.

## Why

- The direct Stremio test preserved stored episode timestamps, but normal pair runs created a fresh adapter without that baseline.
- That make old episode estimates drift to the newer show-level `lastWatched`.

## Testing

- providers/tests/test_stremio_sync.py

## Issue

Relates to #930