### PR TITLE
Add: sync accounting test stuff

### DIFF
--- a/providers/tests/test_nuvio_history.py
+++ b/providers/tests/test_nuvio_history.py
@@ -127,7 +127,26 @@ def test_history_skips_unchanged_when_index_is_iso_and_source_is_epoch_ms() -> N
     result = _history.add(adapter, [{"type": "movie", "ids": {"tmdb": "550"}, "title": "Fight Club", "watched_at": 1_785_000_000_000}])
 
     assert result["skipped"] == 1
+    assert result["skipped_keys"] == ["tmdb:550"]
+    assert result["presence_confirmed_keys"] == ["tmdb:550"]
+    assert result["confirmed_destinations"]["tmdb:550"]["key"] == "tmdb:550"
     assert [name for name, _ in adapter.client.calls if name == "sync_push_watched_items"] == []
+
+
+def test_history_unresolved_rows_carry_attempted_key() -> None:
+    from providers.sync.nuvio import _history
+
+    adapter = FakeAdapter([])
+    result = _history.add(
+        adapter,
+        [{"type": "movie", "ids": {"tvdb": "99"}, "title": "Unknown", "watched_at": 1_785_000_000_000}],
+    )
+
+    assert result["ok"] is False
+    assert result["attempted"] == 0
+    assert result["unresolved_keys"] == ["tvdb:99"]
+    assert result["unresolved"][0]["key"] == "tvdb:99"
+    assert result["unresolved"][0]["canonical_key"] == "tvdb:99"
 
 
 def test_history_read_enriches_episode_code_title_from_tmdb(monkeypatch: Any) -> None:
@@ -209,8 +228,8 @@ def test_history_adds_movie_resolves_imdb_to_tmdb_content_id_when_tmdb_configure
 
         def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
             assert entity == "movie"
-            assert ids == {"imdb": "tt0137523"}
-            return {"ids": {"tmdb": "550"}}
+            assert ids in ({"imdb": "tt0137523"}, {"tmdb": "550"})
+            return {"ids": {"tmdb": "550", "imdb": "tt0137523"}}
 
     adapter = FakeAdapter([])
     adapter.config["tmdb"] = {"api_key": "tmdb-key"}
@@ -220,8 +239,76 @@ def test_history_adds_movie_resolves_imdb_to_tmdb_content_id_when_tmdb_configure
 
     assert result["ok"] is True
     assert result["confirmed_keys"] == ["imdb:tt0137523"]
+    assert result["confirmed_destinations"]["imdb:tt0137523"]["key"] == "tmdb:550"
     push = [body for name, body in adapter.client.calls if name == "sync_push_watched_items"][0]
     assert push["p_items"][0]["content_id"] == "tmdb:550"
+
+
+def test_history_read_enriches_tmdb_rows_with_external_ids(monkeypatch: Any) -> None:
+    from providers.metadata import _meta_TMDB
+    from providers.sync.nuvio import _history
+
+    class FakeTmdb:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
+            assert entity == "movie"
+            assert ids == {"tmdb": "550"}
+            return {"ids": {"tmdb": "550", "imdb": "tt0137523"}}
+
+    adapter = FakeAdapter(
+        [
+            {
+                "content_id": "tmdb:550",
+                "content_type": "movie",
+                "title": "Fight Club",
+                "watched_at": 1_785_000_000_000,
+            }
+        ]
+    )
+    adapter.config["tmdb"] = {"api_key": "tmdb-key"}
+    monkeypatch.setattr(_meta_TMDB, "TmdbProvider", FakeTmdb)
+
+    item = _history.build_index(adapter)["tmdb:550"]
+
+    assert item["ids"] == {"tmdb": "550", "imdb": "tt0137523"}
+
+
+def test_history_skip_maps_source_key_to_existing_tmdb_destination(monkeypatch: Any) -> None:
+    from providers.metadata import _meta_TMDB
+    from providers.sync.nuvio import _history
+
+    class FakeTmdb:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
+            assert entity == "movie"
+            assert ids in ({"imdb": "tt0137523"}, {"tmdb": "550"})
+            return {"ids": {"tmdb": "550", "imdb": "tt0137523"}}
+
+    adapter = FakeAdapter(
+        [
+            {
+                "content_id": "tmdb:550",
+                "content_type": "movie",
+                "title": "Fight Club",
+                "watched_at": 1_785_000_000_000,
+            }
+        ]
+    )
+    adapter.config["tmdb"] = {"api_key": "tmdb-key"}
+    monkeypatch.setattr(_meta_TMDB, "TmdbProvider", FakeTmdb)
+
+    result = _history.add(adapter, [{"type": "movie", "ids": {"imdb": "tt0137523"}, "title": "Fight Club", "watched_at": 1_785_000_000_000}])
+
+    assert result["attempted"] == 0
+    assert result["skipped"] == 1
+    assert result["skipped_keys"] == ["imdb:tt0137523"]
+    assert result["presence_confirmed_keys"] == ["imdb:tt0137523"]
+    assert result["confirmed_destinations"]["imdb:tt0137523"]["key"] == "tmdb:550"
+    assert [name for name, _ in adapter.client.calls if name == "sync_push_watched_items"] == []
 
 
 def test_history_adds_episode_with_show_tmdb_id_not_episode_tmdb_id() -> None:
@@ -262,8 +349,8 @@ def test_history_adds_episode_resolves_tvdb_to_tmdb_content_id_when_tmdb_configu
 
         def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
             assert entity == "tv"
-            assert ids == {"tvdb": "355567"}
-            return {"ids": {"tmdb": "69478"}}
+            assert ids in ({"tvdb": "355567"}, {"tmdb": "69478"})
+            return {"ids": {"tmdb": "69478", "tvdb": "355567"}}
 
     adapter = FakeAdapter([])
     adapter.config["tmdb"] = {"api_key": "tmdb-key"}

--- a/providers/tests/test_nuvio_progress.py
+++ b/providers/tests/test_nuvio_progress.py
@@ -185,8 +185,8 @@ def test_add_movie_progress_resolves_imdb_to_tmdb_content_id_when_tmdb_configure
 
         def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
             assert entity == "movie"
-            assert ids == {"imdb": "tt0137523"}
-            return {"ids": {"tmdb": "550"}}
+            assert ids in ({"imdb": "tt0137523"}, {"tmdb": "550"})
+            return {"ids": {"tmdb": "550", "imdb": "tt0137523"}}
 
     adapter = FakeAdapter([])
     adapter.config["tmdb"] = {"api_key": "tmdb-key"}
@@ -197,6 +197,7 @@ def test_add_movie_progress_resolves_imdb_to_tmdb_content_id_when_tmdb_configure
 
     assert result["ok"] is True
     assert result["confirmed_keys"] == ["imdb:tt0137523"]
+    assert result["confirmed_destinations"]["imdb:tt0137523"]["key"] == "tmdb:550"
     push = [body for name, body in adapter.client.calls if name == "sync_push_watch_progress"][0]
     assert push["p_entries"][0]["content_id"] == "tmdb:550"
 
@@ -219,6 +220,8 @@ def test_add_returns_unresolved_for_unsupported_id_and_missing_duration() -> Non
     assert result["ok"] is False
     assert result["attempted"] == 0
     assert {row["reason"] for row in result["unresolved"]} == {"nuvio_id_missing", "nuvio_duration_missing"}
+    assert set(result["unresolved_keys"]) == {"tvdb:99", "imdb:tt0137523", "trakt:12", "tmdb:550"}
+    assert {row["key"] for row in result["unresolved"]} == {"tvdb:99", "imdb:tt0137523", "trakt:12", "tmdb:550"}
     assert not any(name == "sync_push_watch_progress" for name, _body in adapter.client.calls)
 
 
@@ -334,6 +337,59 @@ def test_progress_skips_unchanged_when_index_is_iso_and_source_is_epoch_ms() -> 
 
     assert result["attempted"] == 0
     assert result["skipped"] == 1
+    assert result["skipped_keys"] == ["tmdb:550"]
+    assert result["presence_confirmed_keys"] == ["tmdb:550"]
+    assert result["confirmed_destinations"]["tmdb:550"]["key"] == "tmdb:550"
+    assert not any(name == "sync_push_watch_progress" for name, _body in adapter.client.calls)
+
+
+def test_progress_read_enriches_tmdb_rows_with_external_ids(monkeypatch: Any) -> None:
+    from providers.metadata import _meta_TMDB
+    from providers.sync.nuvio import _progress
+
+    class FakeTmdb:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
+            assert entity == "movie"
+            assert ids == {"tmdb": "550"}
+            return {"ids": {"tmdb": "550", "imdb": "tt0137523"}}
+
+    adapter = FakeAdapter([_row("tmdb:550")])
+    adapter.config["tmdb"] = {"api_key": "tmdb-key"}
+    monkeypatch.setattr(_meta_TMDB, "TmdbProvider", FakeTmdb)
+
+    item = _progress.build_index(adapter)["tmdb:550"]
+
+    assert item["ids"] == {"tmdb": "550", "imdb": "tt0137523"}
+
+
+def test_progress_skip_maps_source_key_to_existing_tmdb_destination(monkeypatch: Any) -> None:
+    from providers.metadata import _meta_TMDB
+    from providers.sync.nuvio import _progress
+
+    class FakeTmdb:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
+            assert entity == "movie"
+            assert ids in ({"imdb": "tt0137523"}, {"tmdb": "550"})
+            return {"ids": {"tmdb": "550", "imdb": "tt0137523"}}
+
+    adapter = FakeAdapter([_row("tmdb:550")])
+    adapter.config["tmdb"] = {"api_key": "tmdb-key"}
+    monkeypatch.setattr(_meta_TMDB, "TmdbProvider", FakeTmdb)
+    item = {"type": "movie", "ids": {"imdb": "tt0137523"}, "progress_ms": 120_000, "duration_ms": 600_000, "progress_at": 1_785_000_000_000}
+
+    result = _progress.add(adapter, [item])
+
+    assert result["attempted"] == 0
+    assert result["skipped"] == 1
+    assert result["skipped_keys"] == ["imdb:tt0137523"]
+    assert result["presence_confirmed_keys"] == ["imdb:tt0137523"]
+    assert result["confirmed_destinations"]["imdb:tt0137523"]["key"] == "tmdb:550"
     assert not any(name == "sync_push_watch_progress" for name, _body in adapter.client.calls)
 
 
@@ -416,8 +472,8 @@ def test_add_episode_progress_resolves_tvdb_to_tmdb_content_id_when_tmdb_configu
 
         def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
             assert entity == "tv"
-            assert ids == {"tvdb": "355567"}
-            return {"ids": {"tmdb": "69478"}}
+            assert ids in ({"tvdb": "355567"}, {"tmdb": "69478"})
+            return {"ids": {"tmdb": "69478", "tvdb": "355567"}}
 
     adapter = FakeAdapter([])
     adapter.config["tmdb"] = {"api_key": "tmdb-key"}

--- a/providers/tests/test_nuvio_watchlist.py
+++ b/providers/tests/test_nuvio_watchlist.py
@@ -95,8 +95,8 @@ def test_watchlist_add_resolves_imdb_to_tmdb_content_id_when_tmdb_configured(mon
 
         def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
             assert entity == "movie"
-            assert ids == {"imdb": "tt0137523"}
-            return {"ids": {"tmdb": "550"}}
+            assert ids in ({"imdb": "tt0137523"}, {"tmdb": "550"})
+            return {"ids": {"tmdb": "550", "imdb": "tt0137523"}}
 
     adapter = FakeAdapter([])
     adapter.config["tmdb"] = {"api_key": "tmdb-key"}
@@ -107,6 +107,7 @@ def test_watchlist_add_resolves_imdb_to_tmdb_content_id_when_tmdb_configured(mon
 
     assert result["ok"] is True
     assert result["confirmed_keys"] == ["imdb:tt0137523"]
+    assert result["confirmed_destinations"]["imdb:tt0137523"]["key"] == "tmdb:550"
     push = [body for name, body in adapter.client.calls if name == "sync_push_library"][0]
     assert push["p_items"][0]["content_id"] == "tmdb:550"
 
@@ -121,6 +122,19 @@ def test_watchlist_add_skips_tmdb_enrichment_without_metadata_config() -> None:
     assert result["ok"] is True
     push = [body for name, body in adapter.client.calls if name == "sync_push_library"][0]
     assert "poster" not in push["p_items"][0]
+
+
+def test_watchlist_unresolved_rows_carry_attempted_key() -> None:
+    from providers.sync.nuvio import _watchlist
+
+    adapter = FakeAdapter([])
+    result = _watchlist.add(adapter, [{"type": "movie", "ids": {"trakt": "12"}, "title": "Unknown"}])
+
+    assert result["ok"] is False
+    assert result["attempted"] == 0
+    assert result["unresolved_keys"] == ["trakt:12"]
+    assert result["unresolved"][0]["key"] == "trakt:12"
+    assert result["unresolved"][0]["canonical_key"] == "trakt:12"
 
 
 def test_watchlist_add_enriches_nuvio_payload_from_configured_tmdb(monkeypatch: Any) -> None:
@@ -165,8 +179,8 @@ def test_watchlist_add_resolves_tvdb_to_tmdb_content_id_when_tmdb_configured(mon
 
         def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
             assert entity == "tv"
-            assert ids == {"tvdb": "355567"}
-            return {"ids": {"tmdb": "69478"}}
+            assert ids in ({"tvdb": "355567"}, {"tmdb": "69478"})
+            return {"ids": {"tmdb": "69478", "tvdb": "355567"}}
 
     adapter = FakeAdapter([])
     adapter.config["tmdb"] = {"api_key": "tmdb-key"}
@@ -180,6 +194,28 @@ def test_watchlist_add_resolves_tvdb_to_tmdb_content_id_when_tmdb_configured(mon
     push = [body for name, body in adapter.client.calls if name == "sync_push_library"][0]
     assert push["p_items"][0]["content_id"] == "tmdb:69478"
     assert push["p_items"][0]["content_type"] == "series"
+
+
+def test_watchlist_read_enriches_tmdb_rows_with_external_ids(monkeypatch: Any) -> None:
+    from providers.metadata import _meta_TMDB
+    from providers.sync.nuvio import _watchlist
+
+    class FakeTmdb:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def fetch(self, *, entity: str, ids: dict[str, str], locale: str | None = None, need: dict[str, bool] | None = None) -> dict[str, Any]:
+            assert entity == "movie"
+            assert ids == {"tmdb": "550"}
+            return {"ids": {"tmdb": "550", "imdb": "tt0137523"}}
+
+    adapter = FakeAdapter([{"content_id": "tmdb:550", "content_type": "movie", "name": "Fight Club"}])
+    adapter.config["tmdb"] = {"api_key": "tmdb-key"}
+    monkeypatch.setattr(_meta_TMDB, "TmdbProvider", FakeTmdb)
+
+    item = _watchlist.build_index(adapter)["tmdb:550"]
+
+    assert item["ids"] == {"tmdb": "550", "imdb": "tt0137523"}
 
 
 def test_watchlist_remove_full_replaces_library_without_removed_item() -> None:

--- a/tests/test_history_baseline_native.py
+++ b/tests/test_history_baseline_native.py
@@ -219,6 +219,64 @@ def test_same_key_history_pair_converges_and_stays_native(
     assert len(dst.add_calls) == 1
 
 
+def test_promoted_failed_add_still_counts_as_run_unresolved(
+    config_base: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ok_item = {"type": "movie", "title": "OK", "ids": {"tmdb": "1"}, "watched_at": WATCHED}
+    bad_item = {"type": "movie", "title": "Bad", "ids": {"tmdb": "2"}, "watched_at": WATCHED}
+    ok_key = canonical_key(ok_item)
+    bad_key = canonical_key(bad_item)
+
+    class MixedOps(HistoryOps):
+        def add(
+            self,
+            cfg: Mapping[str, Any],
+            items: Iterable[Mapping[str, Any]],
+            *,
+            feature: str,
+            dry_run: bool = False,
+        ) -> dict[str, Any]:
+            batch = [dict(x) for x in items]
+            self.add_calls.append(batch)
+            self.index[ok_key] = dict(ok_item)
+            return {
+                "ok": False,
+                "count": 1,
+                "confirmed_keys": [ok_key],
+                "unresolved_keys": [bad_key],
+                "unresolved": [{"status": "failed", "reason": "write_failed", "item": bad_item, "key": bad_key}],
+            }
+
+    src = HistoryOps("SRC", {ok_key: ok_item, bad_key: bad_item})
+    dst = MixedOps("DST", {})
+    monkeypatch.setattr(
+        "cw_platform.orchestrator.facade.load_sync_providers",
+        lambda: {"SRC": src, "DST": dst},
+    )
+    monkeypatch.setattr(
+        "cw_platform.orchestrator._snapshots.provider_configured",
+        lambda _cfg, _name: True,
+    )
+    monkeypatch.setattr("cw_platform.orchestrator._pairs_blocklist.load_blackbox_keys", lambda *_a, **_k: set())
+    monkeypatch.setattr("cw_platform.orchestrator._pairs_blocklist.load_unresolved_keys", lambda *_a, **_k: {bad_key})
+    monkeypatch.setattr("cw_platform.orchestrator._pairs_oneway.load_unresolved_keys", lambda *_a, **_k: {bad_key})
+    monkeypatch.setattr(
+        "cw_platform.orchestrator._pairs_oneway.record_attempts",
+        lambda *_a, **_k: {"ok": True, "count": 1, "promoted": 1, "promoted_keys": [bad_key]},
+    )
+    cleared: list[list[str]] = []
+    monkeypatch.setattr(
+        "cw_platform.orchestrator._pairs_oneway.clear_unresolved",
+        lambda _dst, _feature, keys: cleared.append(list(keys)) or {"ok": True},
+    )
+
+    summary = Orchestrator(_cfg("history")).run()
+
+    assert summary["added"] == 1
+    assert summary["unresolved"] == 1
+    assert [bad_key] in cleared
+
+
 def test_collection_baselines_preserve_collected_at(
     config_base: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_playlists_orchestration.py
+++ b/tests/test_playlists_orchestration.py
@@ -69,7 +69,11 @@ class FakeStats:
 
 
 class FakeStateStore:
+    def __init__(self):
+        self.last = None
+
     def save_last(self, d):
+        self.last = d
         pass
 
     def load_state(self):
@@ -123,6 +127,84 @@ def _pair_cfg(mode="one-way"):
             }
         ],
     }
+
+
+def _history_pair_cfg(mode="one-way"):
+    return {
+        "runtime": {},
+        "sync": {},
+        "pairs": [
+            {
+                "id": "p1",
+                "source": "FAKESRC",
+                "target": "FAKEDST",
+                "source_instance": "default",
+                "target_instance": "default",
+                "enabled": True,
+                "mode": mode,
+                "features": {"history": {"enable": True}},
+            }
+        ],
+    }
+
+
+def test_run_pairs_includes_blocked_from_one_way_feature(monkeypatch):
+    events: list[tuple[str, dict[str, Any]]] = []
+    ctx = _ctx(_history_pair_cfg("one-way"))
+    ctx.emit = lambda event, **fields: events.append((event, dict(fields)))
+    monkeypatch.setattr(pairs, "supports_feature", lambda *_a, **_k: True)
+    monkeypatch.setattr(pairs, "health_feature_ok", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        pairs,
+        "run_one_way_feature",
+        lambda *_a, **_k: {
+            "updated": 0,
+            "added": 0,
+            "removed": 0,
+            "skipped": 0,
+            "unresolved": 0,
+            "blocked": 7,
+            "errors": 0,
+        },
+    )
+    monkeypatch.setattr(pairs, "run_two_way_feature", lambda *a, **k: (_ for _ in ()).throw(AssertionError("no two-way")))
+
+    result = pairs.run_pairs(ctx)
+
+    assert result["blocked"] == 7
+    assert ctx.state_store.last["result"]["blocked"] == 7
+    assert [fields["blocked"] for event, fields in events if event == "run:done"] == [7]
+
+
+def test_run_pairs_includes_blocked_from_two_way_feature(monkeypatch):
+    events: list[tuple[str, dict[str, Any]]] = []
+    ctx = _ctx(_history_pair_cfg("two-way"))
+    ctx.emit = lambda event, **fields: events.append((event, dict(fields)))
+    monkeypatch.setattr(pairs, "supports_feature", lambda *_a, **_k: True)
+    monkeypatch.setattr(pairs, "health_feature_ok", lambda *_a, **_k: True)
+    monkeypatch.setattr(pairs, "run_one_way_feature", lambda *a, **k: (_ for _ in ()).throw(AssertionError("no one-way")))
+    monkeypatch.setattr(
+        pairs,
+        "run_two_way_feature",
+        lambda *_a, **_k: {
+            "upd_to_A": 0,
+            "upd_to_B": 0,
+            "adds_to_A": 0,
+            "adds_to_B": 0,
+            "rem_from_A": 0,
+            "rem_from_B": 0,
+            "skipped": 0,
+            "unresolved": 0,
+            "blocked": 4,
+            "errors": 0,
+        },
+    )
+
+    result = pairs.run_pairs(ctx)
+
+    assert result["blocked"] == 4
+    assert ctx.state_store.last["result"]["blocked"] == 4
+    assert [fields["blocked"] for event, fields in events if event == "run:done"] == [4]
 
 
 def test_pairs_routes_playlists_to_dedicated_runner(config_base, monkeypatch):

--- a/tests/test_twoway_remove_accounting.py
+++ b/tests/test_twoway_remove_accounting.py
@@ -48,10 +48,13 @@ class _StateStore:
 class _Ops:
     def __init__(self, remove_result):
         self.removed: list[dict[str, Any]] = []
+        self.added: list[dict[str, Any]] = []
         self._remove_result = remove_result
 
     def add(self, _cfg, items, *, feature, dry_run=False):
-        return {"ok": True, "count": len(items), "confirmed_keys": [], "unresolved": []}
+        rows = [dict(i) for i in items]
+        self.added.extend(rows)
+        return {"ok": True, "count": len(rows), "confirmed_keys": [canonical_key(i) for i in rows], "unresolved": []}
 
     def remove(self, _cfg, items, *, feature, dry_run=False):
         lst = [dict(i) for i in items]
@@ -160,6 +163,72 @@ def test_twoway_ambiguous_partial_tombstones_nothing(monkeypatch):
     assert cleared == []
     assert len(recorded) == 1
     assert len(recorded[0]["items"]) == 10
+
+
+def test_twoway_promoted_failed_add_still_counts_as_run_unresolved(monkeypatch):
+    for name, val in (
+        ("_supports_feature", lambda _o, _f: True),
+        ("_health_feature_ok", lambda _h, _f: True),
+        ("_health_status", lambda _h: "up"),
+        ("_resolve_flags", lambda _f, _s: {"allow_adds": True, "allow_removals": False}),
+        ("_anime_pair_feature_options", lambda *_a, **_k: {"use_anime_mapping": False}),
+        ("_anime_config_with_pair_feature_options", lambda cfg, _o: cfg),
+        ("_index_semantics", lambda *_a, **_k: "full"),
+        ("prev_checkpoint", lambda *_a, **_k: None),
+        ("module_checkpoint", lambda *_a, **_k: None),
+        ("keys_for_feature", lambda *_a, **_k: {}),
+        ("_manual_policy", lambda *_a, **_k: ([], set())),
+        ("_provider_ignore_dropped_enabled", lambda *_a, **_k: False),
+        ("apply_blocklist", lambda _s, items, **_k: list(items)),
+        ("_maybe_block_massdelete", lambda items, **_k: list(items)),
+        ("effective_chunk_size", lambda *_a, **_k: 100),
+        ("load_blackbox_keys", lambda *_a, **_k: set()),
+        ("record_success", lambda *_a, **_k: {"ok": True, "count": 0}),
+    ):
+        monkeypatch.setattr(twoway, name, val)
+
+    ok_item = {"type": "movie", "title": "OK", "ids": {"tmdb": "1"}, "watched_at": WATCHED_AT}
+    bad_item = {"type": "movie", "title": "Bad", "ids": {"tmdb": "2"}, "watched_at": WATCHED_AT}
+    ok_key = canonical_key(ok_item)
+    bad_key = canonical_key(bad_item)
+    monkeypatch.setattr(twoway, "build_snapshots_for_feature", lambda **_k: {"TRAKT": {ok_key: ok_item, bad_key: bad_item}, "SIMKL": {}})
+    monkeypatch.setattr(twoway, "load_unresolved_keys", lambda *_a, **_k: {bad_key})
+    monkeypatch.setattr(twoway, "record_attempts", lambda *_a, **_k: {"ok": True, "count": 1, "promoted": 1, "promoted_keys": [bad_key]})
+    cleared: list[list[str]] = []
+    monkeypatch.setattr(twoway, "clear_unresolved", lambda _dst, _feature, keys: cleared.append(list(keys)) or {"ok": True})
+
+    class _MixedAddOps(_Ops):
+        def add(self, _cfg, items, *, feature, dry_run=False):
+            rows = [dict(i) for i in items]
+            self.added.extend(rows)
+            return {
+                "ok": False,
+                "count": 1,
+                "confirmed_keys": [ok_key],
+                "unresolved_keys": [bad_key],
+                "unresolved": [{"status": "failed", "reason": "write_failed", "item": bad_item, "key": bad_key}],
+            }
+
+    simkl = _MixedAddOps(lambda _l: {"ok": True, "count": 0})
+    ctx = SimpleNamespace(
+        config={"sync": {"include_observed_deletes": False, "blackbox": {"enabled": True}}, "runtime": {}},
+        providers={"TRAKT": _Ops(lambda _l: {"ok": True, "count": 0}), "SIMKL": simkl},
+        emit=lambda *_a, **_k: None,
+        emit_info=lambda *_a, **_k: None,
+        dbg=lambda *_a, **_k: None,
+        dry_run=False,
+        snap_cache={},
+        snap_ttl_sec=0,
+        state_store=_StateStore({}),
+        stats_manual_blocked=0,
+        apply_chunk_pause_ms=0,
+    )
+
+    result = twoway._two_way_sync(ctx, "TRAKT", "SIMKL", feature="history", fcfg={}, health_map={})
+
+    assert result["adds_to_B"] == 1
+    assert result["unresolved"] == 1
+    assert [bad_key] in cleared
 
 
 def test_twoway_clean_full_count_without_exact_keys_is_accepted(monkeypatch):


### PR DESCRIPTION
# Pull request

## Change

- Adds tests for Nuvio id mapping, unresolved keys, blocked counts, and promoted failed adds.

## Why

- Keeps sync summaries and retry accounting covered

## Testing

NA

## Issue

NA