### PR TITLE
Change: avoid SIMKL watchlist overwriting completed items

### DIFF
--- a/providers/sync/simkl/_watchlist.py
+++ b/providers/sync/simkl/_watchlist.py
@@ -43,7 +43,13 @@ def _shadow_path():
     return state_file("simkl.watchlist.shadow.json")
 
 
+def _history_cover_path():
+    return state_file("simkl.watchlist.history_cover.json")
+
+
 WATCHLIST_BUCKETS = ("movies", "shows", "anime")
+_HISTORY_COVERING_STATUSES = {"completed", "watching"}
+_STATUS_HISTORY_COVERED: dict[str, dict[str, Any]] = {}
 
 
 
@@ -155,6 +161,56 @@ def _shadow_ttl_seconds() -> float:
         return float(value)
     except Exception:
         return 300.0
+
+
+def _history_cover_load() -> dict[str, dict[str, Any]]:
+    if _is_capture_mode():
+        return {}
+    data = load_json_state(_history_cover_path())
+    if not isinstance(data, Mapping):
+        return {}
+    items = data.get("items")
+    if not isinstance(items, Mapping):
+        return {}
+    now = time.time()
+    ttl = _shadow_ttl_seconds()
+    out: dict[str, dict[str, Any]] = {}
+    for key, row in items.items():
+        if not isinstance(key, str) or not isinstance(row, Mapping):
+            continue
+        seen_at = row.get("_cw_seen_at") or data.get("updated_at")
+        if isinstance(seen_at, (int, float, str)):
+            try:
+                age = now - float(seen_at)
+            except ValueError:
+                age = ttl + 1.0
+        else:
+            age = ttl + 1.0
+        if age <= ttl:
+            out[key] = dict(row)
+    return out
+
+
+def _history_cover_save(items: Mapping[str, Mapping[str, Any]]) -> None:
+    if _is_capture_mode():
+        return
+    now = time.time()
+    payload: dict[str, dict[str, Any]] = {}
+    for key, row in items.items():
+        if not isinstance(key, str) or not isinstance(row, Mapping):
+            continue
+        mapped = dict(row)
+        seen_at = mapped.get("_cw_seen_at")
+        mapped["_cw_seen_at"] = float(seen_at) if isinstance(seen_at, (int, float, str)) else now
+        payload[key] = mapped
+    save_json_state(
+        _history_cover_path(),
+        {
+            "schema": 1,
+            "updated_at": now,
+            "items": payload,
+        },
+    )
 
 
 _ALLOWED_ID_KEYS = ("tmdb", "imdb", "tvdb", "trakt", "simkl", "mal", "anilist", "kitsu", "anidb")
@@ -436,6 +492,101 @@ def _sigs_from_write_resp(body: Any) -> set[str]:
     return sigs
 
 
+def _base_key_token(value: Any) -> str:
+    key = str(value or "").strip()
+    if not key:
+        return ""
+    return key.split("@", 1)[0]
+
+
+def _identity_tokens(item: Mapping[str, Any]) -> set[str]:
+    tokens: set[str] = set()
+    if not isinstance(item, Mapping):
+        return tokens
+    try:
+        key = _base_key_token(simkl_key_of(item))
+        if key:
+            tokens.add(key)
+    except Exception:
+        pass
+
+    for field in ("ids", "show_ids"):
+        raw = item.get(field)
+        if not isinstance(raw, Mapping):
+            continue
+        for ns in _ALLOWED_ID_KEYS:
+            value = raw.get(ns)
+            if value not in (None, ""):
+                tokens.add(f"{ns}:{str(value).strip().lower()}")
+    return tokens
+
+
+def _history_cache_items() -> dict[str, dict[str, Any]]:
+    data = load_json_state(state_file("simkl.history.cache.json"))
+    if not isinstance(data, Mapping) or int(data.get("schema") or 0) != 4:
+        return {}
+    items = data.get("items")
+    if not isinstance(items, Mapping):
+        return {}
+    return {str(k): dict(v) for k, v in items.items() if isinstance(v, Mapping)}
+
+
+def _history_covered_tokens() -> set[str]:
+    tokens: set[str] = set()
+    for key, row in _history_cache_items().items():
+        if not row.get("watched") and not row.get("watched_at"):
+            continue
+        base = _base_key_token(key)
+        if base:
+            tokens.add(base)
+        tokens.update(_identity_tokens(row))
+    for key, row in _history_cover_load().items():
+        base = _base_key_token(key)
+        if base:
+            tokens.add(base)
+        tokens.update(_identity_tokens(row))
+    for key, row in _STATUS_HISTORY_COVERED.items():
+        base = _base_key_token(key)
+        if base:
+            tokens.add(base)
+        tokens.update(_identity_tokens(row))
+    return tokens
+
+
+def _remember_status_history_rows(rows: Mapping[str, Mapping[str, Any]]) -> None:
+    if not rows:
+        return
+    remembered = {str(k): dict(v) for k, v in rows.items() if isinstance(v, Mapping)}
+    if not remembered:
+        return
+    _STATUS_HISTORY_COVERED.update(remembered)
+    persisted = _history_cover_load()
+    persisted.update(remembered)
+    _history_cover_save(persisted)
+
+
+def _split_history_covered(
+    items: Iterable[Mapping[str, Any]],
+) -> tuple[list[Mapping[str, Any]], list[str]]:
+    covered_tokens = _history_covered_tokens()
+    if not covered_tokens:
+        return list(items or []), []
+    pending: list[Mapping[str, Any]] = []
+    skipped: list[str] = []
+    for item in items or []:
+        if not isinstance(item, Mapping):
+            pending.append(item)
+            continue
+        tokens = _identity_tokens(item)
+        if tokens and not tokens.isdisjoint(covered_tokens):
+            key = simkl_key_of(id_minimal(item)) or simkl_key_of(item)
+            if key:
+                skipped.append(str(key))
+            continue
+        pending.append(item)
+    return pending, skipped
+
+
 def _mk_shadow_item(item: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
     ids = _ids_filter(dict(item.get("ids") or {}))
     bucket = str(item.get("simkl_bucket") or "").strip().lower()
@@ -600,12 +751,22 @@ def _pull_all_watchlist(
         raise SIMKLFetchError("watchlist aggregate request failed") from exc
 
     out: dict[str, dict[str, Any]] = {}
+    history_covered: dict[str, dict[str, Any]] = {}
     count = 0
     for bucket in WATCHLIST_BUCKETS:
         for row in _rows_from_data(data, bucket):
             if isinstance(row, Mapping):
                 status = str(row.get("status") or "").strip().lower()
                 if status and status != "plantowatch":
+                    if status in _HISTORY_COVERING_STATUSES:
+                        try:
+                            mapped_status = _normalize_row(bucket, row)
+                            if mapped_status.get("ids"):
+                                mapped_status["simkl_status"] = status
+                                mapped_status["_simkl_history_covers_watchlist"] = True
+                                history_covered[simkl_key_of(mapped_status)] = mapped_status
+                        except Exception:
+                            pass
                     continue
             try:
                 mapped = _normalize_row(bucket, row)
@@ -616,7 +777,9 @@ def _pull_all_watchlist(
             out[simkl_key_of(mapped)] = mapped
             count += 1
             if limit and count >= int(limit):
+                _remember_status_history_rows(history_covered)
                 return out
+    _remember_status_history_rows(history_covered)
     return out
 
 
@@ -646,10 +809,11 @@ def _build_index_live(adapter: Any, limit: int | None = None) -> dict[str, dict[
     comp_ts = _composite_ts(ts_map)
 
     if os.getenv("CW_SIMKL_WATCHLIST_CLEAR") == "1":
-        try:
-            _shadow_path().unlink(missing_ok=True)
-        except Exception:
-            pass
+        for path in (_shadow_path(), _history_cover_path()):
+            try:
+                path.unlink(missing_ok=True)
+            except Exception:
+                pass
 
     shadow = _shadow_load()
     buckets_seen: dict[str, Any] = dict(shadow.get("buckets_seen") or {})
@@ -1014,16 +1178,37 @@ def _chunk_items(seq: list[Mapping[str, Any]], n: int) -> Iterable[list[Mapping[
 def add(
     adapter: Any,
     items: Iterable[Mapping[str, Any]],
-) -> tuple[int, list[dict[str, Any]]]:
+) -> dict[str, Any]:
     session = adapter.client.session
     headers = _headers(adapter)
     items_list: list[Mapping[str, Any]] = list(items or [])
     if not items_list:
         _info("write_skipped", op="add", reason="empty_payload", unresolved=0)
-        return 0, []
+        return {
+            "ok": True,
+            "count": 0,
+            "unresolved": [],
+            "confirmed_keys": [],
+            "skipped_keys": [],
+            "presence_confirmed_keys": [],
+        }
+    items_list, skipped_keys = _split_history_covered(items_list)
+    if skipped_keys:
+        _unfreeze_if_present(skipped_keys)
+        _info("write_skipped", op="add", reason="history_covers_watchlist", skipped=len(skipped_keys))
+    if not items_list:
+        return {
+            "ok": True,
+            "count": 0,
+            "unresolved": [],
+            "confirmed_keys": [],
+            "skipped_keys": skipped_keys,
+            "presence_confirmed_keys": [],
+        }
     batch = max(1, int(getattr(adapter.cfg, "watchlist_batch_size", 100) or 100))
     ok = 0
     unresolved: list[dict[str, Any]] = []
+    confirmed_keys: list[str] = []
     for part in _chunk_items(items_list, batch):
         raw_payload, part_unresolved = _split_buckets(part)
         unresolved.extend(part_unresolved)
@@ -1079,10 +1264,17 @@ def add(
                             sig = _id_sig(_ids_filter(item.get("ids") or {}))
                             if sig and sig in sigs:
                                 to_add.append(item)
+                                confirmed_key = simkl_key_of(id_minimal(item)) or simkl_key_of(item)
+                                if confirmed_key:
+                                    confirmed_keys.append(str(confirmed_key))
                         if to_add:
                             _shadow_add_items(to_add)
                     elif processed == len(part):
                         _shadow_add_items(part)
+                        for item in part:
+                            confirmed_key = simkl_key_of(id_minimal(item)) or simkl_key_of(item)
+                            if confirmed_key:
+                                confirmed_keys.append(str(confirmed_key))
                     _unfreeze_if_present([simkl_key_of(id_minimal(it)) for it in part])
             else:
                 _warn("write_failed", op="add", status=resp.status_code, body=(resp.text or '')[:180])
@@ -1119,8 +1311,26 @@ def add(
                         reasons=["exception"],
                         ids_sent=body_ids,
                     )
-    _info("write_done", op="add", ok=bool(items_list) and len(unresolved) == 0 and ok == len(items_list), applied=ok, unresolved=len(unresolved))
-    return ok, unresolved
+    if ok and not confirmed_keys:
+        unresolved_keys = {
+            str(u.get("key") or simkl_key_of(u.get("item") or {}))
+            for u in unresolved
+            if isinstance(u, Mapping)
+        }
+        for item in items_list:
+            confirmed_key = simkl_key_of(id_minimal(item)) or simkl_key_of(item)
+            if confirmed_key and confirmed_key not in unresolved_keys:
+                confirmed_keys.append(str(confirmed_key))
+    confirmed_keys = list(dict.fromkeys(confirmed_keys))
+    _info("write_done", op="add", ok=bool(items_list) and len(unresolved) == 0 and ok == len(items_list), applied=ok, unresolved=len(unresolved), skipped=len(skipped_keys))
+    return {
+        "ok": len(unresolved) == 0 and ok == len(items_list),
+        "count": len(confirmed_keys),
+        "unresolved": unresolved,
+        "confirmed_keys": confirmed_keys,
+        "skipped_keys": skipped_keys,
+        "presence_confirmed_keys": confirmed_keys,
+    }
 
 
 def remove(

--- a/providers/sync/stremio/_watchlist.py
+++ b/providers/sync/stremio/_watchlist.py
@@ -53,14 +53,15 @@ def _is_listed(record: Mapping[str, Any]) -> bool:
 def _metadata_enriched(adapter: Any, item: Mapping[str, Any], typ: str) -> dict[str, Any]:
     out = dict(item)
     stremio_id = stremio_id_for_item(out)
+    ids = merge_ids(ids_from(out), imdb_ids_from_item(out))
     if stremio_id:
         if not str(out.get("poster") or out.get("poster_url") or "").strip():
             out["poster"] = poster_url_from_item(out, stremio_id)
-        return out
+        if str(ids.get("tmdb") or "").strip():
+            return out
     provider = tmdb_metadata_provider(adapter)
     if provider is None:
         return out
-    ids = merge_ids(ids_from(out), imdb_ids_from_item(out))
     lookup = {k: str(ids.get(k) or "").strip() for k in ("tmdb", "imdb", "tvdb") if str(ids.get(k) or "").strip()}
     title = str(out.get("series_title") or out.get("show_title") or out.get("title") or "").strip()
     if title:
@@ -77,17 +78,27 @@ def _metadata_enriched(adapter: Any, item: Mapping[str, Any], typ: str) -> dict[
         return out
     detail_ids = detail.get("ids")
     ids_map: Mapping[str, Any] = detail_ids if isinstance(detail_ids, Mapping) else {}
+    portable_ids: dict[str, Any] = {}
+    tmdb = str(ids_map.get("tmdb") or "").strip()
+    if tmdb:
+        portable_ids["tmdb"] = tmdb
     found = imdb_id(ids_map.get("imdb"))
     if found:
+        portable_ids["imdb"] = found
+    tvdb = str(ids_map.get("tvdb") or "").strip()
+    if tvdb:
+        portable_ids["tvdb"] = tvdb
+    if portable_ids:
         out_ids_raw = out.get("ids")
         out_ids: Mapping[str, Any] = out_ids_raw if isinstance(out_ids_raw, Mapping) else {}
         merged = dict(out_ids)
-        merged["imdb"] = found
+        for key, value in portable_ids.items():
+            merged.setdefault(key, value)
         out["ids"] = merged
     if not str(out.get("title") or out.get("series_title") or "").strip() and str(detail.get("title") or "").strip():
         out["title"] = str(detail.get("title") or "").strip()
     if not str(out.get("poster") or out.get("poster_url") or "").strip():
-        poster = poster_url_from_item(out, found) or _image_url(detail, "poster")
+        poster = poster_url_from_item(out, found or stremio_id) or _image_url(detail, "poster")
         if poster:
             out["poster"] = poster
     return out

--- a/providers/tests/test_simkl_watchlist.py
+++ b/providers/tests/test_simkl_watchlist.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+class _Resp:
+    def __init__(self, status: int = 200, payload: Any = None) -> None:
+        self.status_code = status
+        self._payload = payload if payload is not None else {}
+        self.text = json.dumps(self._payload)
+        self.headers = {"Content-Type": "application/json"}
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class _Session:
+    def __init__(self, get_payload: Any = None, post_payload: Any = None) -> None:
+        self.get_payload = get_payload if get_payload is not None else {}
+        self.post_payload = post_payload if post_payload is not None else {"added": {"movies": 1}}
+        self.posts: list[dict[str, Any]] = []
+
+    def get(self, url: str, **_kwargs: Any) -> _Resp:
+        return _Resp(200, self.get_payload)
+
+    def post(self, url: str, **kwargs: Any) -> _Resp:
+        self.posts.append({"url": url, "json": kwargs.get("json")})
+        return _Resp(201, self.post_payload)
+
+
+def _adapter(session: _Session) -> Any:
+    return SimpleNamespace(
+        client=SimpleNamespace(session=session),
+        cfg=SimpleNamespace(timeout=5, watchlist_batch_size=100),
+    )
+
+
+def _movie() -> dict[str, Any]:
+    return {
+        "type": "movie",
+        "title": "A Cure for Wellness",
+        "year": 2016,
+        "ids": {"imdb": "tt4731136", "tmdb": "340837"},
+    }
+
+
+def _movie_imdb_only() -> dict[str, Any]:
+    movie = _movie()
+    movie["ids"] = {"imdb": "tt4731136"}
+    return movie
+
+
+@pytest.fixture(autouse=True)
+def simkl_watchlist_state(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    from providers.sync.simkl import _watchlist as m
+
+    store: dict[str, str] = {}
+    monkeypatch.setattr(m, "state_file", lambda name: name)
+    monkeypatch.setattr(m, "load_json_state", lambda path: json.loads(store.get(str(path)) or "{}"))
+    monkeypatch.setattr(m, "save_json_state", lambda path, data: store.__setitem__(str(path), json.dumps(data)))
+    monkeypatch.setattr(m, "_headers", lambda *a, **k: {})
+    monkeypatch.setattr(m, "simkl_api_params_from_headers", lambda headers=None, **k: dict(k))
+    monkeypatch.setattr(m, "fetch_activities", lambda *a, **k: ({}, None))
+    monkeypatch.setattr(m, "get_watermark", lambda *a, **k: None)
+    monkeypatch.setattr(m, "save_watermark", lambda *a, **k: None)
+    monkeypatch.setattr(m, "normalize_flat_watermarks", lambda: None)
+    m._STATUS_HISTORY_COVERED = {}
+    return store
+
+
+def _history_cache_doc(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema": 4,
+        "generated_at": "2026-08-30T00:00:00Z",
+        "rewatches": False,
+        "items": {
+            "tmdb:340837@1788085800": {
+                "type": "movie",
+                "watched": True,
+                "watched_at": "2026-07-18T17:58:00Z",
+                "title": item["title"],
+                "year": item["year"],
+                "ids": dict(item["ids"]),
+                "simkl_bucket": "movies",
+            }
+        },
+    }
+
+
+def test_add_skips_movie_already_covered_by_simkl_history(simkl_watchlist_state: dict[str, str]) -> None:
+    from providers.sync.simkl import _watchlist as m
+
+    movie = _movie()
+    simkl_watchlist_state["simkl.history.cache.json"] = json.dumps(_history_cache_doc(movie))
+    session = _Session()
+
+    result = m.add(_adapter(session), [movie])
+
+    assert result["ok"] is True
+    assert result["count"] == 0
+    assert result["unresolved"] == []
+    assert result["skipped_keys"] == [m.simkl_key_of(m.id_minimal(movie))]
+    assert result["presence_confirmed_keys"] == []
+    assert session.posts == []
+
+
+def test_history_cache_does_not_make_simkl_watchlist_read_export_virtual_items(
+    simkl_watchlist_state: dict[str, str],
+) -> None:
+    from providers.sync.simkl import _watchlist as m
+
+    history_movie = _movie()
+    simkl_watchlist_state["simkl.history.cache.json"] = json.dumps(_history_cache_doc(history_movie))
+
+    index = m.build_index(_adapter(_Session(get_payload={})))
+
+    assert index == {}
+
+
+def test_completed_all_items_row_is_not_exported_as_simkl_watchlist() -> None:
+    from providers.sync.simkl import _watchlist as m
+
+    movie = _movie()
+    session = _Session(
+        get_payload={
+            "movies": [
+                {
+                    "status": "completed",
+                    "movie": {
+                        "title": movie["title"],
+                        "year": movie["year"],
+                        "ids": dict(movie["ids"]),
+                    },
+                }
+            ],
+            "shows": [],
+            "anime": [],
+        }
+    )
+
+    index = m.build_index(_adapter(session))
+
+    assert index == {}
+
+
+def test_completed_all_items_row_still_prevents_plantowatch_write() -> None:
+    from providers.sync.simkl import _watchlist as m
+
+    history_movie = _movie()
+    source_movie = _movie_imdb_only()
+    session = _Session(
+        get_payload={
+            "movies": [
+                {
+                    "status": "completed",
+                    "movie": {
+                        "title": history_movie["title"],
+                        "year": history_movie["year"],
+                        "ids": dict(history_movie["ids"]),
+                    },
+                }
+            ],
+            "shows": [],
+            "anime": [],
+        }
+    )
+    assert m.build_index(_adapter(session)) == {}
+
+    result = m.add(_adapter(session), [source_movie])
+
+    assert result["ok"] is True
+    assert result["skipped_keys"] == [m.simkl_key_of(m.id_minimal(source_movie))]
+    assert result["presence_confirmed_keys"] == []
+    assert session.posts == []
+
+
+def test_completed_status_cover_survives_restart_without_virtual_export(
+    simkl_watchlist_state: dict[str, str],
+) -> None:
+    from providers.sync.simkl import _watchlist as m
+
+    history_movie = _movie()
+    source_movie = _movie_imdb_only()
+    session = _Session(
+        get_payload={
+            "movies": [
+                {
+                    "status": "completed",
+                    "movie": {
+                        "title": history_movie["title"],
+                        "year": history_movie["year"],
+                        "ids": dict(history_movie["ids"]),
+                    },
+                }
+            ],
+            "shows": [],
+            "anime": [],
+        }
+    )
+
+    assert m.build_index(_adapter(session)) == {}
+    assert "simkl.watchlist.history_cover.json" in simkl_watchlist_state
+
+    m._STATUS_HISTORY_COVERED = {}
+    result = m.add(_adapter(session), [source_movie])
+
+    assert result["ok"] is True
+    assert result["skipped_keys"] == [m.simkl_key_of(m.id_minimal(source_movie))]
+    assert result["presence_confirmed_keys"] == []
+    assert session.posts == []
+
+
+def test_add_unwatched_movie_still_posts_to_plantowatch() -> None:
+    from providers.sync.simkl import _watchlist as m
+
+    movie = _movie()
+    session = _Session()
+
+    result = m.add(_adapter(session), [movie])
+
+    assert result["ok"] is True
+    assert result["confirmed_keys"] == [m.simkl_key_of(m.id_minimal(movie))]
+    assert result["skipped_keys"] == []
+    assert result["presence_confirmed_keys"] == [m.simkl_key_of(m.id_minimal(movie))]
+    assert len(session.posts) == 1
+    assert session.posts[0]["url"] == "https://api.simkl.com/sync/add-to-list"
+    assert session.posts[0]["json"] == {
+        "movies": [{"ids": {"tmdb": "340837", "imdb": "tt4731136"}, "to": "plantowatch"}]
+    }

--- a/providers/tests/test_stremio_sync.py
+++ b/providers/tests/test_stremio_sync.py
@@ -1212,6 +1212,24 @@ def test_watchlist_read_indexes_native_tmdb_id() -> None:
     assert adapter._stremio_read_drops["watchlist"] == []
 
 
+def test_watchlist_read_enriches_imdb_movie_id_with_tmdb(monkeypatch) -> None:
+    class Provider:
+        def fetch(self, **kwargs: Any) -> dict[str, Any]:
+            assert kwargs["entity"] == "movie"
+            assert kwargs["ids"]["imdb"] == "tt0137523"
+            return {"ids": {"tmdb": "550", "imdb": "tt0137523"}, "images": {}}
+
+    monkeypatch.setattr(_watchlist, "tmdb_metadata_provider", lambda _adapter: Provider())
+    movie = movie_record(removed=False, temp=False)
+    adapter = FakeAdapter([movie])
+
+    index = _watchlist.build_index(adapter)
+
+    assert set(index) == {"tmdb:550"}
+    assert index["tmdb:550"]["ids"] == {"imdb": "tt0137523", "tmdb": "550"}
+    assert adapter._stremio_read_drops["watchlist"] == []
+
+
 def test_watchlist_excludes_temporary_history_progress_records() -> None:
     movie = movie_record(removed=True, temp=True)
     adapter = FakeAdapter([movie])


### PR DESCRIPTION
# Pull request

## Change

- Keep SIMKL watchlist writes from fighting items already covered by SIMKL history/watching.
- Also keep Stremio watchlist rows enriched with TMDB ids when metadata is available.

## Why

- SIMKL can keep completed items outside plan-to-watch.
- Stremio expose IMDb-only watchlist rows, which made covers and sync state look off in this pair.

## Testing

- providers/tests/test_simkl_watchlist.py 
- providers/tests/test_stremio_sync.py

## Issue

Relates to #944