### PR TITLE
Change: improve main page loading performance

### DIFF
--- a/api/insightAPI.py
+++ b/api/insightAPI.py
@@ -1958,14 +1958,17 @@ def register_insights(app: FastAPI) -> None:
         rows: list[dict[str, Any]] = []
         try:
             history_limit = max(0, int(history))
-            if history_limit > 0 and not wanted_instances:
-                from cw_platform.local_db.sync_reports import base_path_from_report_dir, list_reports
+            if not wanted_instances:
+                def _history_rows() -> list[dict[str, Any]]:
+                    from cw_platform.local_db.sync_reports import base_path_from_report_dir, list_reports
 
-                rows = list_reports(
-                    base_path_from_report_dir(REPORT_DIR),
-                    limit=history_limit,
-                    feature_keys=feature_keys,
-                )
+                    return list_reports(
+                        base_path_from_report_dir(REPORT_DIR),
+                        limit=history_limit,
+                        feature_keys=feature_keys,
+                    )
+
+                rows = _history_rows() if history_limit > 0 else []
         except Exception as e:
             _append_log("INSIGHTS", f"[!] report load failed: {e}")
 

--- a/assets/helpers/maintenance.js
+++ b/assets/helpers/maintenance.js
@@ -31,10 +31,37 @@
     }
   }
 
+  function removeLocalStorageKeys({ exact = [], prefixes = [] } = {}){
+    try {
+      const keys = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i) || "";
+        if (exact.includes(key) || prefixes.some((prefix) => key.startsWith(prefix))) keys.push(key);
+      }
+      for (const key of keys) localStorage.removeItem(key);
+    } catch {}
+  }
+
+  function applySyncStateReset(result = {}){
+    removeLocalStorageKeys({
+      exact: ["insights.tiles.v1", "cw.dashboardWidgets.data.v1", "cw.profileWidgets.data.v1"],
+      prefixes: ["cw.wall.preview.v2."],
+    });
+    try {
+      window.dispatchEvent(new CustomEvent("cw:sync-state-cleared", {
+        detail: { source: "maintenance", result },
+      }));
+    } catch {}
+    try { window.Insights?.refreshInsightsFastThenFull?.(true); } catch {}
+    try { window.refreshStats?.(true); } catch {}
+    try { window.CW?.DashboardWidgets?.refresh?.({ force: true, forceConfig: true, preserve: false }); } catch {}
+  }
+
   async function clearState(){
     return runAction({
       url: "/api/maintenance/reset-state",
       body: { mode: "clear_both" },
+      onSuccess: applySyncStateReset,
       successText: "Clear State – started ✓",
       failText: "Clear State – failed"
     });
@@ -75,5 +102,5 @@
 
   Object.assign(window, { clearState, clearCache, resetStats, resetCurrentlyPlaying, restartCrossWatch });
   (window.CW ||= {});
-  window.CW.Maintenance = { runAction, clearState, clearCache, resetStats, resetCurrentlyPlaying, restartCrossWatch };
+  window.CW.Maintenance = { runAction, clearState, clearCache, resetStats, resetCurrentlyPlaying, restartCrossWatch, applySyncStateReset };
 })();

--- a/assets/helpers/watchlist-preview.js
+++ b/assets/helpers/watchlist-preview.js
@@ -123,6 +123,18 @@
   const clearWallCache = () => {
     try { localStorage.removeItem(wallCacheKey()); } catch {}
   };
+  const clearAllWallCaches = () => {
+    try {
+      const keys = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i) || "";
+        if (key.startsWith(`${WALL_PREVIEW_CACHE_KEY}.`)) keys.push(key);
+      }
+      for (const key of keys) localStorage.removeItem(key);
+    } catch {
+      clearWallCache();
+    }
+  };
 
   const hasRenderedWall = (row = document.getElementById("poster-row")) => !!(row?.childElementCount && !row.classList.contains("hidden"));
   const previewNeedsRefresh = () => window.__cwWallPreviewDirty
@@ -518,6 +530,21 @@
     window.dispatchEvent(new CustomEvent("cw:watchlist-widget-state", { detail: { empty: true, count: 0 } }));
   };
 
+  function renderCachedPreview({ preserveIfSame = true } = {}) {
+    const card = document.getElementById("placeholder-card");
+    const msg = document.getElementById("wall-msg");
+    const row = document.getElementById("poster-row");
+    if (!card || !msg || !row) return false;
+    if (!isOnMain() || profileWatchlistWidgetHidden()) return false;
+    const cached = readWallCache();
+    if (!cached?.items?.length) return false;
+    card.classList.remove("hidden");
+    return renderWall(row, msg, cached.items, cached.last_sync_epoch || 0, {
+      preserveIfSame,
+      total: cached.total ?? null,
+    });
+  }
+
   function pillFor(status) {
     const raw = String(status || "").toLowerCase().trim();
     if (raw === "deleted") return { text: "DELETED", cls: "p-del" };
@@ -767,19 +794,23 @@
     const myReq = ++wallReqSeq;
     const refreshVersion = window.__cwWallPreviewDirtyVersion;
     const renderedWall = hasRenderedWall(row);
+    const cached = readWallCache();
     if (!renderedWall) {
-      msg.textContent = "Loading...";
-      msg.classList.remove("is-empty");
-      msg.classList.remove("hidden");
-      row.closest(".wall-wrap")?.classList.remove("is-empty");
-      row.classList.add("hidden");
+      if (cached?.items?.length) {
+        renderCachedPreview({ preserveIfSame: true });
+      } else {
+        msg.textContent = "Loading...";
+        msg.classList.remove("is-empty");
+        msg.classList.remove("hidden");
+        row.closest(".wall-wrap")?.classList.remove("is-empty");
+        row.classList.add("hidden");
+      }
     }
 
     const limit = Number.isFinite(window.MAX_WALL_POSTERS) ? Math.max(1, Number(window.MAX_WALL_POSTERS)) : 20;
     const params = new URLSearchParams({ both_only: "0", active_only: "1", limit: String(limit) });
     const userProfile = overviewProfileId();
     if (userProfile) params.set("user_profile", userProfile);
-    const cached = readWallCache();
     if (cached?.version) params.set("known_version", cached.version);
     const wallDataPromise = json(`/api/state/wall?${params.toString()}`)
       .then((data) => ({ data }), (error) => ({ error }));
@@ -938,8 +969,10 @@
       card.classList.remove("hidden");
       const rendered = hasRenderedWall(row);
       if (msg && !window.wallLoaded && !rendered) {
-        msg.textContent = "Loading...";
-        msg.classList.remove("hidden");
+        if (!renderCachedPreview({ preserveIfSame: true })) {
+          msg.textContent = "Loading...";
+          msg.classList.remove("hidden");
+        }
       }
 
       if ((!window.wallLoaded || previewNeedsRefresh()) && !window.__wallLoading) {
@@ -961,6 +994,29 @@
     return true;
   }
 
+  function clearWatchlistPreview() {
+    clearAllWallCaches();
+    wallReqSeq += 1;
+    previewBusy = false;
+    window.__wallLoading = false;
+    window.wallLoaded = false;
+    window.__cwWallPreviewDirty = true;
+    window.__cwWallPreviewDirtyVersion += 1;
+    window.__cwWallPreviewLoadedAt = 0;
+    window._lastSyncEpoch = null;
+    window.__wallRenderSignature = "";
+    const card = document.getElementById("placeholder-card");
+    const row = document.getElementById("poster-row");
+    const msg = document.getElementById("wall-msg");
+    if (card && row && msg && isOnMain() && !profileWatchlistWidgetHidden()) {
+      card.classList.remove("hidden");
+      setWallEmpty(row, msg, "No items to show yet.");
+      return true;
+    }
+    try { window.dispatchEvent(new CustomEvent("cw:watchlist-widget-state", { detail: { empty: true, count: 0 } })); } catch {}
+    return false;
+  }
+
   window.addEventListener("storage", (event) => {
     if (event.key !== "wl_hidden") return;
     updatePreviewVisibility();
@@ -969,6 +1025,7 @@
   window.addEventListener("sync-complete", markWatchlistPreviewDirty);
   window.addEventListener("watchlist:refresh", markWatchlistPreviewDirty);
   window.addEventListener("cw:overview-profile-changed", markWatchlistPreviewDirty);
+  window.addEventListener("cw:sync-state-cleared", clearWatchlistPreview);
 
   const WatchlistPreview = {
     updateEdges,
@@ -980,6 +1037,7 @@
     gridArtUrl,
     applyWidgetView,
     prewarmWallImages,
+    renderCachedPreview,
     loadWall,
     updateWatchlistPreview,
     hasTmdbKey,
@@ -987,6 +1045,7 @@
     isWatchlistPreviewAllowed,
     updatePreviewVisibility,
     markWatchlistPreviewDirty,
+    clearWatchlistPreview,
   };
 
   (window.CW ||= {}).WatchlistPreview = WatchlistPreview;

--- a/assets/js/dashboard-widgets.js
+++ b/assets/js/dashboard-widgets.js
@@ -185,6 +185,10 @@
     } catch {}
   }
 
+  function clearCachedWidgetData() {
+    try { localStorage.removeItem(DATA_CACHE_KEY); } catch {}
+  }
+
   function hasOwn(obj, key) {
     return Object.prototype.hasOwnProperty.call(obj || {}, key);
   }
@@ -420,8 +424,12 @@
     if (hasLoaded || !isOnMain() || authSetupPending()) return;
     const settings = readCachedSettings();
     if (!settings) return;
+    lastSettings = settings;
     applyVisibility(settings);
     const active = activeWidgetSettings(settings);
+    if (active.watchlist) {
+      window.CW?.WatchlistPreview?.renderCachedPreview?.({ preserveIfSame: true });
+    }
     const cached = readCachedWidgetData();
     if (cached) {
       applyWidgetPayload(cached, active);
@@ -1584,6 +1592,28 @@
     );
   }
 
+  function clearDashboardWidgetState() {
+    clearCachedWidgetData();
+    loadSeq += 1;
+    widgetsDirty = true;
+    dirtyVersion += 1;
+    lastLoadedAt = 0;
+    loadedWidgetKinds.clear();
+    const settings = lastSettings || readCachedSettings() || widgetSettings(currentConfig?.ui || currentConfig?.user_interface || {});
+    lastSettings = settings;
+    for (const kind of REFRESHABLE_WIDGETS) {
+      latestItems[kind] = [];
+      resetVisibleCount(kind);
+      const [chipId, chipLabel] = WIDGET_COUNT_CHIPS[kind];
+      setCountChip(chipId, 0, chipLabel);
+      renderWidget(kind);
+      loadedWidgetKinds.add(kind);
+    }
+    hasLoaded = true;
+    applyVisibility(settings);
+    scheduleMasonry();
+  }
+
   function applyVisibility(settings) {
     const card = $("#dashboard-widgets-card");
     if (!card) return;
@@ -1861,6 +1891,7 @@
     window.addEventListener("cw-user-profiles-changed", () => markWidgetsDirty(150, { forceConfig: true, preserve: hasLoaded }));
     window.addEventListener("cw:overview-profile-changed", () => markWidgetsDirty(0, { preserve: hasLoaded }));
     window.addEventListener("activity-log-cleared", () => markWidgetsDirty(100));
+    window.addEventListener("cw:sync-state-cleared", clearDashboardWidgetState);
     window.addEventListener("sync-complete", refreshForSyncComplete);
     window.addEventListener("cw:scrobble-stopped", refreshForScrobbleStopped);
     window.addEventListener("cw:manual-watched-saved", () => markWidgetsDirty(250));
@@ -1880,7 +1911,7 @@
   }
 
   window.CW = window.CW || {};
-  window.CW.DashboardWidgets = { refresh: refreshDashboardWidgets, showAll: showAllWidgets, hiddenCount: hiddenWidgetCount };
+  window.CW.DashboardWidgets = { refresh: refreshDashboardWidgets, clear: clearDashboardWidgetState, showAll: showAllWidgets, hiddenCount: hiddenWidgetCount };
 
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", initDashboardWidgets, { once: true });

--- a/assets/js/insights.js
+++ b/assets/js/insights.js
@@ -111,7 +111,7 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
   let _prefs = loadPrefs(), _visibleFeats = visibleFeatures(_prefs);
   const clampFeature = name => _visibleFeats.includes(String(name)) ? name : (_visibleFeats[0] || "watchlist");
   let _feature = clampFeature(localStorage.getItem("insights.feature"));
-  let _lastStatsFetch = 0, _cwSnapModal = null, _lastInsightsData = null, _fullInsightsTimer = 0, _configuredProvidersCache = null, _tilesFeature = null, _bootScheduled = false, _bootRefreshFired = false, _tilesPainted = false;
+  let _lastStatsFetch = 0, _cwSnapModal = null, _lastInsightsData = null, _fullInsightsTimer = 0, _configuredProvidersCache = null, _tilesFeature = null, _tileShellFeature = null, _bootScheduled = false, _bootRefreshFired = false, _tilesPainted = false;
 
   function syncPrefs(instancesByProvider = {}) {
     const next = normalizePrefs(_prefs, instancesByProvider), changed = JSON.stringify(next) !== JSON.stringify(_prefs);
@@ -371,7 +371,7 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
     const featCount = Math.max(1, _visibleFeats.length);
     host.style.setProperty("--ins-feat-count", String(featCount));
     host.dataset.labels = featCount >= 4 ? "icon" : "text";
-    if (seg) seg.dataset.count = String(featCount);
+    if (seg) seg.dataset.count = String(Math.max(1, _visibleFeats.length));
     host.querySelector(":scope > .ins-gear")?.remove();
     const needsGear = seg && !seg.querySelector(".ins-gear");
     if (host.dataset.feats !== sig || host.dataset.cur !== _feature || needsGear) {
@@ -495,15 +495,39 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
   }
 
   function paintCachedTiles() {
-    if (_tilesPainted) return;
-    if (!$("#stats-card")) return;
+    if (_tilesPainted) return false;
+    if (!$("#stats-card")) return false;
+    if (authSetupPending()) return false;
     const cached = readJSON(TILES_KEY, {})[_feature];
-    if (!cached || !Array.isArray(cached.keys) || !cached.keys.length) return;
+    if (!cached || !Array.isArray(cached.keys) || !cached.keys.length) return false;
     _tilesPainted = true;
     _tilesFeature = _feature;
     footWrap();
     ensureSwitch();
     renderProviderStats(cached.totals, cached.active, new Set(cached.keys), cached.mse, {}, false);
+    return true;
+  }
+
+  function visibleStatusProviderKeys() {
+    return [...new Set($$("#conn-badges [data-provider-key], #conn-badges [data-prov]")
+      .map(node => String(node.dataset.providerKey || node.dataset.prov || "").trim())
+      .filter(Boolean))];
+  }
+
+  function paintTileShell() {
+    if (_tilesPainted || _tileShellFeature === _feature || authSetupPending() || !$("#stats-card")) return false;
+    footWrap();
+    ensureSwitch();
+    let keys = visibleStatusProviderKeys();
+    if (!keys.length) keys = [...configuredProvidersSnapshot({})];
+    keys = keys.filter(k => providerOnSyncSurface(k));
+    if (!keys.length) return false;
+    _tileShellFeature = _feature;
+    _tilesFeature = _feature;
+    const totals = Object.fromEntries(keys.map(k => [k, 0]));
+    const active = Object.fromEntries(keys.map(k => [k, false]));
+    renderProviderStats(totals, active, new Set(keys), {}, {}, false);
+    return true;
   }
 
   function crosswatchSnapshotProfiles(cwSnapshots) {
@@ -622,10 +646,7 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
     if (authSetupPending()) return;
     try {
       const profileParam = overviewProfileId() ? `&user_profile=${encodeURIComponent(overviewProfileId())}` : "";
-      const [data] = await Promise.all([
-        fetchJSON(`/api/insights?limit_samples=60&history=60${profileParam}${force ? `&t=${Date.now()}` : ""}`),
-        getConfiguredProviders(force).catch(() => null),
-      ]);
+      const data = await fetchJSON(`/api/insights?limit_samples=60&history=60${profileParam}${force ? `&t=${Date.now()}` : ""}`);
       await renderFromData(data, false, force);
     }
     catch (e) {
@@ -641,10 +662,7 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
     _lastStatsFetch = now;
     try {
       const profileParam = overviewProfileId() ? `&user_profile=${encodeURIComponent(overviewProfileId())}` : "";
-      const [data] = await Promise.all([
-        fetchJSON(`/api/insights?limit_samples=0&history=0&include_events=0${profileParam}${force ? `&t=${Date.now()}` : ""}`),
-        getConfiguredProviders(force).catch(() => null),
-      ]);
+      const data = await fetchJSON(`/api/insights?limit_samples=0&history=0&include_events=0${profileParam}${force ? `&t=${Date.now()}` : ""}`);
       await renderFromData(data, true, force);
     }
     catch (e) {
@@ -663,12 +681,30 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
     }, 180);
   }
 
+  function clearInsightsState() {
+    try { localStorage.removeItem(TILES_KEY); } catch {}
+    clearTimeout(_fullInsightsTimer);
+    _fullInsightsTimer = 0;
+    _lastInsightsData = {};
+    _tilesPainted = false;
+    _tilesFeature = "";
+    _tileShellFeature = null;
+    renderTopStats({});
+    renderHistoryTabs([]);
+    const providers = $("#stat-providers");
+    if (providers) {
+      providers.replaceChildren();
+      providers.hidden = true;
+    }
+  }
+
   w.addEventListener("insights:settings-changed", () => { _prefs = loadPrefs(); _visibleFeats = visibleFeatures(_prefs); _feature = clampFeature(_feature); localStorage.setItem("insights.feature", _feature); refreshInsightsFastThenFull(true); });
   w.addEventListener("cw:overview-profile-changed", () => refreshInsightsFastThenFull(true));
+  w.addEventListener("cw:sync-state-cleared", clearInsightsState);
 
   w.Insights = Object.assign(w.Insights || {}, {
     renderSparkline, refreshInsights, refreshStats, fetchJSON, animateNumber, animateChart, titleOf, subtitleOf,
-    switchFeature, refreshInsightsFastThenFull, get feature() { return _feature; },
+    switchFeature, refreshInsightsFastThenFull, clearState: clearInsightsState, get feature() { return _feature; },
     get bootRefreshFired() { return _bootRefreshFired; }
   });
   w.renderSparkline = renderSparkline;
@@ -685,13 +721,28 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
     let tries = 0, limit = max || 20;
     (function tick() {
       if (authSetupPending()) return void (_bootScheduled = false);
-      if ($("#sync-history") || $("#stat-now") || $("#sparkline")) { _bootRefreshFired = true; paintCachedTiles(); return refreshInsightsFastThenFull(); }
+      if ($("#sync-history") || $("#stat-now") || $("#sparkline")) { _bootRefreshFired = true; if (!paintCachedTiles()) paintTileShell(); return refreshInsightsFastThenFull(); }
       if (++tries < limit) setTimeout(tick, 250);
       else _bootScheduled = false;
     })();
   };
 
-  d.addEventListener("DOMContentLoaded", () => { if (!authSetupPending()) w.scheduleInsights(); });
+  d.addEventListener("DOMContentLoaded", () => {
+    const badges = $("#conn-badges");
+    if (badges && !badges.dataset.insightsShellWatch) {
+      badges.dataset.insightsShellWatch = "1";
+      new MutationObserver(() => { if (!paintCachedTiles()) paintTileShell(); }).observe(badges, { childList: true, subtree: true });
+    }
+    if (!authSetupPending()) {
+      if (!paintCachedTiles()) paintTileShell();
+      w.scheduleInsights();
+    }
+  });
+  w.addEventListener("cw-auth-setup-pending", (ev) => {
+    if (ev?.detail?.pending !== false) return;
+    if (!paintCachedTiles()) paintTileShell();
+    w.scheduleInsights();
+  });
   d.addEventListener("tab-changed", ev => {
     if (authSetupPending()) return;
     const tab = String(ev?.detail?.id || ev?.detail?.tab || "").toLowerCase();

--- a/assets/js/modals/maintenance/index.js
+++ b/assets/js/modals/maintenance/index.js
@@ -944,6 +944,10 @@ export default {
         if (kind === "scrobbles") {
           try { window.dispatchEvent(new CustomEvent("activity-log-cleared")); } catch {}
         }
+        if (kind === "state") {
+          try { window.CW?.Maintenance?.applySyncStateReset?.(res || { ok: true }); } catch {}
+          await refreshSummary();
+        }
         if (kind === "cache" || kind === "tracker") await refreshSummary();
 
         if (kind === "defaults") {
@@ -1077,16 +1081,20 @@ export default {
       });
     }
 
-    showOverviewStatus();
-    await loadTrackerProfiles();
-    await refreshSummary();
-    setStatus("");
     const initialGroup = String(props?.group || props?.target || "").trim().toLowerCase();
     if (initialGroup) {
       [...root.querySelectorAll(".side-nav-btn[data-target]")]
         .find((btn) => btn.dataset.target === `cxm-group-${initialGroup}`)
         ?.click();
     }
+    showOverviewStatus();
+    const loadMaintenanceBootStatus = async () => {
+      await loadTrackerProfiles();
+      await refreshSummary();
+      if (root.isConnected && !operationBusy) setStatus("");
+    };
+    setStatus("Loading maintenance status...", "busy");
+    void loadMaintenanceBootStatus();
   },
   unmount() {},
 };

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -1463,6 +1463,24 @@ def test_maintenance_tracker_archive_uses_profile_selector_toolbar() -> None:
     assert "{ ...cfg, className:" in profile_select_js
 
 
+def test_maintenance_rebuild_state_refreshes_main_page_caches() -> None:
+    root = Path(__file__).resolve().parents[1]
+    modal_js = (root / "assets" / "js" / "modals" / "maintenance" / "index.js").read_text("utf-8")
+    helper_js = (root / "assets" / "helpers" / "maintenance.js").read_text("utf-8")
+
+    assert "function applySyncStateReset(result = {})" in helper_js
+    assert '"insights.tiles.v1", "cw.dashboardWidgets.data.v1", "cw.profileWidgets.data.v1"' in helper_js
+    assert 'prefixes: ["cw.wall.preview.v2."]' in helper_js
+    assert 'window.dispatchEvent(new CustomEvent("cw:sync-state-cleared"' in helper_js
+    assert "window.CW?.DashboardWidgets?.refresh?.({ force: true, forceConfig: true, preserve: false })" in helper_js
+    assert 'if (kind === "state")' in modal_js
+    assert "window.CW?.Maintenance?.applySyncStateReset?.(res || { ok: true })" in modal_js
+    assert "await injectCSS();" in modal_js
+    assert "const loadMaintenanceBootStatus = async () =>" in modal_js
+    assert "void loadMaintenanceBootStatus();" in modal_js
+    assert "await loadTrackerProfiles();\n      await refreshSummary();" in modal_js
+
+
 def test_maintenance_tracker_archive_exports_and_imports_profile_storage(tmp_path: Path, monkeypatch) -> None:
     from fastapi import FastAPI
     from fastapi.testclient import TestClient

--- a/tests/test_dashboard_widgets.py
+++ b/tests/test_dashboard_widgets.py
@@ -1487,6 +1487,9 @@ def test_dashboard_widget_frontend_uses_cached_payload_version() -> None:
     assert "const DATA_CACHE_KEY" in js
     assert "function readCachedWidgetData()" in js
     assert "function writeCachedWidgetData(payload)" in js
+    assert "function clearDashboardWidgetState()" in js
+    assert 'window.addEventListener("cw:sync-state-cleared", clearDashboardWidgetState);' in js
+    assert "clear: clearDashboardWidgetState" in js
     assert "const WIDGET_LOADING_DELAY_MS = 700;" in js
     assert 'const REFRESHABLE_WIDGETS = ["history", "ratings", "scrobble", "progress", "playlists"];' in js
     assert "async function refreshDashboardWidgets({ forceConfig = false, force = false, preserve = true, kinds = null } = {})" in js
@@ -1498,7 +1501,7 @@ def test_dashboard_widget_frontend_uses_cached_payload_version() -> None:
     assert "const preserve = opts.preserve === false ? hasLoaded : true;" in js
     assert "try { await window.CW?.OverviewProfile?.ready; } catch {}\n    if (seq !== loadSeq || !isOnMain()) return;\n    if (!hasLoaded) revealFromCache();" in js
     assert "function scheduleSlowWidgetLoading(hosts, requestedKinds)" in js
-    assert "if (!latestItems[kind]?.length) setLoading(hosts[kind], kind);" in js
+    assert "if (!loadedWidgetKinds.has(kind)) setLoading(hosts[kind], kind);" in js
     assert "const requestedKinds = REFRESHABLE_WIDGETS.filter((key) => active[key] && (!wantedKinds || wantedKinds.has(key)));" in js
     assert "mergeWidgetPayload" not in js
     assert "loadedKinds" not in js

--- a/tests/test_playlists_ui.py
+++ b/tests/test_playlists_ui.py
@@ -411,6 +411,11 @@ def test_insights_main_load_uses_lightweight_stats_first():
     assert "return refreshInsightsFastThenFull()" in insights
     assert "optimisticConfigured" in insights
     assert "configuredProvidersSnapshot(blk.active)" in insights
+    assert "function paintTileShell()" in insights
+    assert "function clearInsightsState()" in insights
+    assert 'w.addEventListener("cw:sync-state-cleared", clearInsightsState);' in insights
+    assert "visibleStatusProviderKeys()" in insights
+    assert 'new MutationObserver(() => { if (!paintCachedTiles()) paintTileShell(); })' in insights
     assert "_configuredProvidersCache" in insights
     assert "new Set(Object.entries(active || {}).filter" in insights
     assert "new Set([...Object.keys(blk.providers || {}), ...Object.keys(blk.active || {})])" not in insights

--- a/tests/test_wall_api.py
+++ b/tests/test_wall_api.py
@@ -92,6 +92,9 @@ def test_watchlist_preview_uses_cached_wall_version() -> None:
     assert 'params.set("known_version", cached.version)' in js
     assert "if (data?.not_modified && cached?.items?.length)" in js
     assert "preserveIfSame: true" in js
+    assert "function clearWatchlistPreview()" in js
+    assert 'window.addEventListener("cw:sync-state-cleared", clearWatchlistPreview);' in js
+    assert "key.startsWith(`${WALL_PREVIEW_CACHE_KEY}.`)" in js
 
 
 def test_watchlist_preview_uses_shared_provider_branding() -> None:

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -641,7 +641,19 @@ html[data-cw-initial-tab="settings"] #page-settings{display:block!important}
     </div>
 
     <div class="sync-status" style="display:none"><div id="sync-icon"></div><div id="sync-status-text"></div><span id="sched-inline" style="display:none"></span></div>
-    <div id="ux-progress"></div><div id="ux-lanes"></div><div id="ux-spotlight"></div>
+    <div id="ux-progress">
+      <div class="sb-head">
+        <div class="sb-head-main">
+          <div>
+            <div class="sb-label">Sync status</div>
+            <div class="sb-phase"><div class="sb-phase-text">Waiting for the next sync run</div></div>
+          </div>
+        </div>
+        <div class="sb-head-side"><div class="sb-note hide"></div><div class="sb-badge">Idle</div></div>
+      </div>
+      <div class="sb-rail"><div class="sb-fill"></div><div class="sb-fly hide"></div></div>
+      <div class="sb-steps"><span data-step="start">Start</span><span data-step="discovering">Discovering</span><span data-step="syncing">Syncing</span><span data-step="done">Done</span></div>
+    </div><div id="ux-lanes"></div><div id="ux-spotlight"></div>
 
     <div class="action-row">
       <div class="action-buttons">


### PR DESCRIPTION
# Pull request

## Change

- Speed up the main page first with cached preview/widget data and an idle sync shell.
- Refresh main page stats, widgets, and previews in place after rebuilding sync state from maintenance.

## Why

- The main page felt slow to fill in, and rebuild sync state still showed stale numbers until a manual refresh.

## Testing

- tests\test_crosswatch_profiles.py 
- tests\test_dashboard_widgets.py 
- tests\test_playlists_ui.py tests\test_wall_api.py

## Issue

NA