### PR TITLE
Change: enable Anime ID Mapping for CW pairs

### DIFF
--- a/api/animeMappingAPI.py
+++ b/api/animeMappingAPI.py
@@ -120,6 +120,13 @@ def api_anime_mapping_settings(payload: dict[str, Any] | None = Body(default=Non
 
         cfg["anime_mapping"] = block
         save_config(cfg)
+        normalized_cfg = load_config() or cfg
+        normalized_block = (
+            normalized_cfg.get("anime_mapping")
+            if isinstance(normalized_cfg.get("anime_mapping"), dict)
+            else block
+        )
+        block = dict(normalized_block or {})
         log(
             "settings_saved",
             level="debug",
@@ -131,7 +138,7 @@ def api_anime_mapping_settings(payload: dict[str, Any] | None = Body(default=Non
                 "use_for_pairs": ",".join(_provider_list(block.get("use_for_pairs")) or ANIME_MAPPING_PAIRS_DEFAULT),
             },
         )
-        st = mapping_status(cfg=cfg)
+        st = mapping_status(cfg=normalized_cfg)
         bootstrap = None
         bootstrap_error = ""
         if bool(block.get("enabled", False)) and not bool(st.get("installed") and st.get("index_ready")):

--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -68,7 +68,7 @@ function hasOwn(obj,key){return !!obj&&Object.prototype.hasOwnProperty.call(obj,
 function isTwoWayMode(state){return !!ID("cx-mode-two")?.checked||String(state?.mode||"").toLowerCase().startsWith("two")}
 function anilistCanReceive(state){return isAniList(state?.dst)||(hasAniList(state)&&isTwoWayMode(state))}
 function globalAnimeMappingEnabled(state){return !!state?.cfgRaw?.anime_mapping?.enabled}
-function hasAnimeProvider(state){return hasAniList(state)||isSimkl(state?.src)||isSimkl(state?.dst)}
+function hasAnimeProvider(state){return hasAniList(state)||isSimkl(state?.src)||isSimkl(state?.dst)||isCrossWatch(state?.src)||isCrossWatch(state?.dst)}
 function tmdbMetadataReady(state){return !!String(state?.cfgRaw?.tmdb?.api_key||state?.cfgRaw?.metadata?.tmdb_api_key||"").trim()}
 function collectionRouteSupported(state){
   const sourceOk=isPlex(state?.src)||isEmby(state?.src)||isJelly(state?.src)||isTrakt(state?.src)||isMDBList(state?.src)||isCrossWatch(state?.src)||isPunchPlay(state?.src);

--- a/cw_platform/anime_mapping/service.py
+++ b/cw_platform/anime_mapping/service.py
@@ -10,9 +10,9 @@ from cw_platform.id_map import canonical_key, ids_from, merge_ids, minimal
 
 from .descriptors import descriptor_candidates_for_id, parse_descriptor
 from .overrides import find_identity_overrides
-from .storage import index_ready, query_edges, query_identity_natives
+from .storage import index_ready, query_edges, query_identity_natives, query_native_identity
 
-ANIME_NATIVE_PROVIDERS = {"anilist", "simkl"}
+ANIME_NATIVE_PROVIDERS = {"anilist", "simkl", "crosswatch"}
 DEFAULT_FEATURES = {"watchlist", "ratings"}
 OPT_IN_FEATURES = {"history"}
 ANY_PAIR = "*"
@@ -215,6 +215,32 @@ class AnimeMappingService:
                 return natives
         return {}
 
+    def _identity_target_ids(self, ids: Mapping[str, Any], media_type: str | None = None) -> dict[str, str]:
+        if str(media_type or "").strip().lower() in IDENTITY_SEED_EXCLUDED_TYPES:
+            return {}
+        found: dict[str, str] = {}
+        conflicts: set[str] = set()
+        for key in ("anidb", "mal", "anilist"):
+            value = str(ids.get(key) or "").strip()
+            if not value:
+                continue
+            try:
+                targets = query_native_identity(self.release_tag, key, value)
+            except Exception:
+                continue
+            for target_key in IDENTITY_SEED_KEYS:
+                target_value = str(targets.get(target_key) or "").strip()
+                if not target_value:
+                    continue
+                current = found.get(target_key)
+                if current is None:
+                    found[target_key] = target_value
+                elif current != target_value:
+                    conflicts.add(target_key)
+        for key in conflicts:
+            found.pop(key, None)
+        return found
+
     def enrich_ids(self, ids: Mapping[str, Any] | None, *, media_type: str | None = None) -> dict[str, Any]:
         ids0 = {str(k).lower(): v for k, v in dict(ids or {}).items() if v not in (None, "")}
         if not ids0:
@@ -236,7 +262,8 @@ class AnimeMappingService:
             }
 
         identity_seeds = self._identity_seed_ids(ids0, media_type)
-        seed_ids: dict[str, Any] = {**identity_seeds, **ids0, **ruled}
+        identity_targets = self._identity_target_ids(ids0, media_type)
+        seed_ids: dict[str, Any] = {**identity_seeds, **identity_targets, **ids0, **ruled}
 
         seen_sources: set[tuple[str, str]] = set()
         rows: list[dict[str, Any]] = []
@@ -334,10 +361,11 @@ class AnimeMappingService:
                 "source_descriptors": sorted(set(source_descriptors)),
                 **({"overrides": dict(ruled)} if ruled else {}),
                 **({"identity_seeds": dict(identity_seeds)} if identity_seeds else {}),
+                **({"identity_targets": dict(identity_targets)} if identity_targets else {}),
                 **({"ambiguous": sorted(ambiguous)} if ambiguous else {}),
                 **details,
             }
-        } if (details or ruled or identity_seeds) else {}
+        } if (details or ruled or identity_seeds or identity_targets) else {}
         return {"ids": merged or dict(ids0), "detail": detail, "changed": bool(changed)}
 
     def enrich_item(self, item: Mapping[str, Any]) -> dict[str, Any]:

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -763,7 +763,7 @@ DEFAULT_CFG: dict[str, Any] = {
         "release_tag": "v3",                            # AniBridge release tag
         "refresh_hours": 24,                            # Minimum age before an automatic refresh is considered
         "stale_after_days": 14,                         # UI/status warning threshold
-        "use_for_pairs": ["anilist", "simkl"],          # Providers that activate anime mapping when present in a pair ("*" = any pair)
+        "use_for_pairs": ["anilist", "simkl", "crosswatch"],  # Providers that activate anime mapping when present in a pair ("*" = any pair)
         "features": ["watchlist", "ratings", "history"],  # Sync features where anime mapping may apply; history is opt-in per pair
     },
 
@@ -2047,7 +2047,7 @@ def _normalize_scheduling(cfg: dict[str, Any]) -> None:
     adv["workflows"] = wf_out
 
 
-ANIME_MAPPING_PAIRS_DEFAULT: list[str] = ["anilist", "simkl"]
+ANIME_MAPPING_PAIRS_DEFAULT: list[str] = ["anilist", "simkl", "crosswatch"]
 ANIME_MAPPING_FEATURES_DEFAULT: list[str] = ["watchlist", "ratings", "history"]
 
 

--- a/tests/test_anime_episodes.py
+++ b/tests/test_anime_episodes.py
@@ -161,12 +161,13 @@ def test_resolution_matches_ids_guards_wrong_entry(index: Path) -> None:
     assert resolution_matches_ids(None, {"anilist": "813"}) is False
 
 
-def test_existing_config_is_migrated_to_include_simkl_and_history() -> None:
+def test_existing_config_is_migrated_to_include_default_pairs_and_history() -> None:
     from cw_platform.config_base import _normalize_anime_mapping
 
     cfg = {"anime_mapping": {"enabled": True, "use_for_pairs": ["anilist"], "features": ["watchlist", "ratings"]}}
     _normalize_anime_mapping(cfg)
     assert "simkl" in cfg["anime_mapping"]["use_for_pairs"]
+    assert "crosswatch" in cfg["anime_mapping"]["use_for_pairs"]
     assert "history" in cfg["anime_mapping"]["features"]
 
 

--- a/tests/test_anime_mapping_pair_directions.py
+++ b/tests/test_anime_mapping_pair_directions.py
@@ -116,6 +116,33 @@ def test_plex_to_simkl_resolves_native_ids(index: Path) -> None:
     assert _kind_group(out) == "shows"
 
 
+# --- CrossWatch as an intermediate anime identity cache -----------------------
+
+
+def test_kodi_to_crosswatch_resolves_native_ids(index: Path) -> None:
+    out = _enrich({"type": "show", "title": "Frieren", "ids": {"anidb": ANIDB}}, "KODI", "CROSSWATCH")
+    ids = out["ids"]
+    assert ids["simkl"] == SIMKL
+    assert ids["mal"] == MAL
+    assert ids["tmdb"] == TMDB
+
+
+def test_crosswatch_to_simkl_can_use_preserved_kodi_native_ids(index: Path) -> None:
+    from providers.sync.simkl._watchlist import _split_buckets
+
+    crosswatch_item = _enrich(
+        {"type": "show", "title": "Frieren", "ids": {"anidb": ANIDB}},
+        "KODI",
+        "CROSSWATCH",
+    )
+    second_hop = _enrich(crosswatch_item, "CROSSWATCH", "SIMKL")
+    payload, unresolved = _split_buckets([second_hop])
+
+    assert unresolved == []
+    assert payload["shows"][0]["ids"]["simkl"] == SIMKL
+    assert payload["shows"][0]["ids"]["anidb"] == ANIDB
+
+
 # --- 3. SIMKL -> MDBList ------------------------------------------------------
 
 

--- a/tests/test_anime_overrides_api.py
+++ b/tests/test_anime_overrides_api.py
@@ -44,6 +44,18 @@ def test_list_is_empty_and_exposes_the_schema(client: TestClient) -> None:
     assert body["schema"]["media_types"] == ["show", "movie"]
 
 
+def test_settings_response_returns_normalized_default_pairs(client: TestClient) -> None:
+    r = client.post(
+        "/api/anime-mapping/settings",
+        json={"enabled": False, "auto_update": True, "use_for_pairs": ["anilist"]},
+    )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert set(body["anime_mapping"]["use_for_pairs"]) >= {"anilist", "simkl", "crosswatch"}
+
+
 def test_create_then_list(client: TestClient) -> None:
     r = client.post("/api/anime-mapping/overrides", json=_RULE)
     assert r.status_code == 200


### PR DESCRIPTION
# Pull request

## Change

- Allow CW pairs to use Anime ID Mapping and preserve enriched anime IDs through CW sync hops.

## Why

- CW act as an internal ID cache, so anime synced from Kodi to CrossWatch can later sync correctly from CW to Simkl.

## Testing

- tests/test_anime_episodes.py 
- tests/test_anime_mapping_pair_directions.py 
- tests/test_anime_overrides_api.py

## Issue

Relates to #953