### PR TITLE
FIx: resolve Plex watcher users before username filtering

### DIFF
--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -690,6 +690,20 @@ def _validate_route(cfg: Mapping[str, Any], route: dict[str, Any]) -> dict[str, 
     return normalized
 
 
+def _set_plex_unresolved_user_fallback_default(route: dict[str, Any], value: bool) -> None:
+    if str((route or {}).get("provider") or "").strip().lower() != "plex":
+        return
+    options = route.setdefault("options", {})
+    if not isinstance(options, dict):
+        options = {}
+        route["options"] = options
+    watch = options.setdefault("watch", {})
+    if not isinstance(watch, dict):
+        watch = {}
+        options["watch"] = watch
+    watch.setdefault("unresolved_user_fallback", bool(value))
+
+
 def _validate_routes_unique(routes: list[dict[str, Any]]) -> None:
     ids: set[str] = set()
     keys: set[tuple[str, str, str, str]] = set()
@@ -842,6 +856,7 @@ def api_route_create(request: Request, payload: dict[str, Any] = Body(...)) -> J
         routes = _routes_node(after)
         route_body = dict(payload or {})
         route_body["id"] = str(route_body.get("id") or _next_route_id(routes)).strip()
+        _set_plex_unresolved_user_fallback_default(route_body, False)
         route = _validate_route(after, route_body)
         next_routes = [normalize_route(r, f"R{i + 1}") for i, r in enumerate(routes) if isinstance(r, dict)]
         next_routes.append(route)

--- a/assets/js/modals/scrobbler-route/index.js
+++ b/assets/js/modals/scrobbler-route/index.js
@@ -445,6 +445,9 @@ function filtersPanel(r, f) {
 }
 
 function optionsPanel(r) {
+  const unresolvedFallback = r.provider === "plex"
+    ? `<label class="scrm-toggle-row"><span class="scrm-toggle-copy"><span class="material-symbols-rounded">person_alert</span><span><strong>Unresolved user fallback</strong><small>Use the configured Plex username when Plex omits the playback user and the session cannot be resolved.</small></span></span><span class="scrm-switch"><input type="checkbox" id="scr-unresolved-user-fallback" ${r.options.watch?.unresolved_user_fallback ? "checked" : ""}><span class="scrm-switch-track"></span></span></label>`
+    : "";
   return `
     <section class="scrm-panel ${activeTab === "options" ? "active" : ""}" data-panel="options">
       <div class="scrm-journey scrm-journey-compact">
@@ -459,6 +462,7 @@ function optionsPanel(r) {
         ${field("Pause debounce (s)", `<input class="input" id="scr-watch-pause" type="number" min="0" max="3600" value="${esc(r.options.watch?.pause_debounce_seconds ?? "")}" placeholder="Global">`, "", "Seconds to ignore tiny pause/start flaps just after playback starts for this route.")}
         ${field("Suppress start (%)", `<input class="input" id="scr-watch-suppress" type="number" min="0" max="100" value="${esc(r.options.watch?.suppress_start_at ?? "")}" placeholder="Global">`, "", "Ignore new start events at or above this progress for this route.")}
       </div>
+      ${unresolvedFallback}
     </section>
   `;
 }
@@ -622,6 +626,7 @@ function collect() {
   const suppress = root.querySelector("#scr-watch-suppress")?.value;
   if (pause !== "") watch.pause_debounce_seconds = Number(pause);
   if (suppress !== "") watch.suppress_start_at = Number(suppress);
+  if (provider === "plex") watch.unresolved_user_fallback = !!root.querySelector("#scr-unresolved-user-fallback")?.checked;
   const ratingsMode = root.querySelector("#scr-ratings-mode")?.value || "off";
   return {
     id: draft.id,

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -898,7 +898,6 @@ class WatchService:
                 return stale_hit
             return None
         except Exception as e:
-            # allow falling back to configured username later.
             try:
                 msg = str(e).lower()
                 if any(k in msg for k in ("401", "403", "unauthorized", "forbidden")):
@@ -915,6 +914,37 @@ class WatchService:
             return None
         name = str(ident.get("name") or "").strip()
         return name or None
+
+    def _event_with_session_identity(self, ev: ScrobbleEvent, ident: dict[str, Any] | None) -> ScrobbleEvent:
+        if not isinstance(ident, dict):
+            return ev
+        clean_ident = {
+            "name": str(ident.get("name") or "").strip(),
+            "user_name": str(ident.get("user_name") or "").strip(),
+            "user_id": str(ident.get("user_id") or "").strip(),
+            "account_name": str(ident.get("account_name") or "").strip(),
+            "account_id": str(ident.get("account_id") or "").strip(),
+            "account_uuid": str(ident.get("account_uuid") or "").strip().lower(),
+        }
+        if not any(clean_ident.values()):
+            return ev
+        raw = dict(ev.raw or {})
+        raw["_cw_session_identity"] = clean_ident
+        account = clean_ident["name"] or ev.account
+        if account == ev.account and raw == (ev.raw or {}):
+            return ev
+        return ScrobbleEvent(**{**ev.__dict__, "account": account, "raw": raw})
+
+    def _event_with_unresolved_user_fallback(self, ev: ScrobbleEvent, account: str) -> ScrobbleEvent:
+        fallback_account = str(account or "").strip()
+        if str(ev.account or "").strip() or not fallback_account:
+            return ev
+        raw = dict(ev.raw or {})
+        raw["_cw_unresolved_user_fallback"] = {
+            "account": fallback_account,
+            "source": "configured_plex_username",
+        }
+        return ScrobbleEvent(**{**ev.__dict__, "raw": raw})
 
     def _enrich_event_with_plex(self, ev: ScrobbleEvent) -> ScrobbleEvent | None:
         try:
@@ -1128,17 +1158,7 @@ class WatchService:
                     inst = ((px.get("instances") or {}).get(str(self._instance_id)) or {})
                 except Exception:
                     inst = {}
-            # For non-default Plex instances (e.g. Home users), Plex alert payloads may not
-            # include an account name. Use the configured instance username as a fallback so
-            # events are not dropped as unresolved user alerts.
-            fallback_username = ""
-            try:
-                if str(self._instance_id) != "default":
-                    fallback_username = str(inst.get("username") or "").strip()
-            except Exception:
-                fallback_username = ""
             defaults = {
-                "username": fallback_username,
                 "server_uuid": str((
                     server_uuid or
                     inst.get("server_uuid") or inst.get("machine_id") or
@@ -1172,22 +1192,11 @@ class WatchService:
                 if prev_acc:
                     ev = ScrobbleEvent(**{**ev.__dict__, "account": prev_acc})
 
-            acc = self._resolve_account_from_session(ev.session_key)
-            if acc and _norm_user(acc) != _norm_user(ev.account or ""):
-                ev = ScrobbleEvent(**{**ev.__dict__, "account": acc})
-
-            # Fall back to configured username.
-            if not str(ev.account or "").strip() and getattr(self, "_no_sessions_access", False):
-                cfg_user = (str(inst.get("username") or "").strip() if str(self._instance_id) != "default" else str(px.get("username") or "").strip())
-                if cfg_user:
-                    self._dbg(
-                        f"no sessions access; assume token user '{_mask_account(cfg_user)}' inst={self._instance_id} sess={ev.session_key}"
-                    )
-                    ev = ScrobbleEvent(**{**ev.__dict__, "account": cfg_user})
-
-            # Drop unresolved/no-user alerts before filter logging
+            ident = self._resolve_session_identity(ev.session_key)
+            ev = self._event_with_session_identity(ev, ident)
             if not str(ev.account or "").strip():
-                return
+                cfg_user = (str(inst.get("username") or "").strip() if str(self._instance_id) != "default" else str(px.get("username") or "").strip())
+                ev = self._event_with_unresolved_user_fallback(ev, cfg_user)
 
             if not self._passes_filters(ev):
                 self._throttled_filtered_log(ev)

--- a/providers/scrobble/routes.py
+++ b/providers/scrobble/routes.py
@@ -23,6 +23,7 @@ ROUTE_WATCH_POLICY_RANGES = {
     "pause_debounce_seconds": (0, 3600),
     "suppress_start_at": (0, 100),
 }
+ROUTE_WATCH_BOOLEAN_KEYS = {"unresolved_user_fallback"}
 
 
 def _deep_clone(v: Any) -> Any:
@@ -99,7 +100,7 @@ def normalize_route_options(options: Any) -> dict[str, Any]:
 
     watch_raw = raw.get("watch")
     watch_src: dict[str, Any] = watch_raw if isinstance(watch_raw, dict) else {}
-    watch: dict[str, int] = {}
+    watch: dict[str, Any] = {}
     for key, (min_val, max_val) in ROUTE_WATCH_POLICY_RANGES.items():
         if key not in watch_src:
             continue
@@ -112,6 +113,9 @@ def normalize_route_options(options: Any) -> dict[str, Any]:
             continue
         if min_val <= val <= max_val:
             watch[key] = val
+    for key in ROUTE_WATCH_BOOLEAN_KEYS:
+        if key in watch_src:
+            watch[key] = bool(watch_src.get(key))
 
     return {
         "auto_remove_watchlist": auto_remove,
@@ -124,6 +128,13 @@ def normalize_route_options(options: Any) -> dict[str, Any]:
         "scrobble": scrobble,
         "watch": watch,
     }
+
+
+def route_options_has_watch_key(options: Any, key: str) -> bool:
+    if not isinstance(options, dict):
+        return False
+    watch = options.get("watch")
+    return isinstance(watch, dict) and key in watch
 
 
 def normalize_route(route: dict[str, Any], fallback_id: str) -> dict[str, Any]:
@@ -146,7 +157,10 @@ def normalize_route(route: dict[str, Any], fallback_id: str) -> dict[str, Any]:
     filters = r.get("filters")
     if not isinstance(filters, dict):
         filters = {}
-    options = normalize_route_options(r.get("options"))
+    raw_options = r.get("options")
+    options = normalize_route_options(raw_options)
+    if prov == "plex" and not route_options_has_watch_key(raw_options, "unresolved_user_fallback"):
+        options["watch"]["unresolved_user_fallback"] = True
     profile_id = normalize_user_profile_id(r.get("profile_id") or r.get("profileId"))
 
     out = {

--- a/providers/scrobble/scrobble.py
+++ b/providers/scrobble/scrobble.py
@@ -255,7 +255,7 @@ def from_plex_pssn(payload: dict[str, Any], defaults: dict[str, Any] | None = No
         "type": n.get("type") or "",
         "state": n.get("state") or "",
         "sessionKey": n.get("sessionKey"),
-        "account": n.get("account") or n.get("accountID") or defaults.get("username"),
+        "account": n.get("account"),
         "machineIdentifier": n.get("machineIdentifier") or defaults.get("server_uuid"),
     }
     return _event_from_meta(meta, payload)
@@ -345,7 +345,7 @@ def from_plex_flat_playing(payload: dict[str, Any], defaults: dict[str, Any] | N
         "type": first.get("type") or prog_src.get("type") or "",
         "state": prog_src.get("state") or first.get("state") or "",
         "sessionKey": first.get("sessionKey") or prog_src.get("sessionKey"),
-        "account": first.get("account") or prog_src.get("account") or defaults.get("username"),
+        "account": first.get("account") or prog_src.get("account"),
         "machineIdentifier": first.get("machineIdentifier") or prog_src.get("machineIdentifier") or defaults.get("server_uuid"),
     }
     return _event_from_meta(meta, payload)
@@ -380,6 +380,30 @@ class Dispatcher:
             sink.send(ev, cfg=cfg)
         except TypeError:
             sink.send(ev, cfg)
+
+    def _route_event(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> ScrobbleEvent:
+        if str(ev.account or "").strip():
+            return ev
+        try:
+            watch_cfg = ((cfg.get("scrobble") or {}).get("watch") or {})
+            route_options = watch_cfg.get("route_options") or {}
+            watch_options = route_options.get("watch") if isinstance(route_options, dict) else {}
+            if not (isinstance(watch_options, dict) and bool(watch_options.get("unresolved_user_fallback"))):
+                return ev
+        except Exception:
+            return ev
+        raw = ev.raw if isinstance(ev.raw, dict) else {}
+        fallback = raw.get("_cw_unresolved_user_fallback") if isinstance(raw, dict) else None
+        fallback_account = ""
+        if isinstance(fallback, dict):
+            fallback_account = str(fallback.get("account") or "").strip()
+        else:
+            fallback_account = str(fallback or "").strip()
+        if not fallback_account:
+            return ev
+        raw2 = dict(raw)
+        raw2["_cw_unresolved_user_fallback_used"] = True
+        return ScrobbleEvent(**{**ev.__dict__, "account": fallback_account, "raw": raw2})
 
     def _passes_filters(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> bool:
         cache_key: str | None = None
@@ -436,10 +460,24 @@ class Dispatcher:
                         return r
             return None
 
-        n = (find_psn(ev.raw or {}) or [None])[0] or {}
-        acc_id = str(n.get("accountID") or "")
-        acc_uuid = str(n.get("accountUUID") or "").lower()
-        user_id = find_user_id(ev.raw or {})
+        raw = ev.raw or {}
+        ident = raw.get("_cw_session_identity") if isinstance(raw, dict) else None
+        if not isinstance(ident, dict):
+            ident = {}
+
+        n = (find_psn(raw) or [None])[0] or {}
+        acc_id = str(ident.get("account_id") or n.get("accountID") or "")
+        acc_uuid = str(ident.get("account_uuid") or n.get("accountUUID") or "").lower()
+        user_id = str(ident.get("user_id") or "").strip().lower() or find_user_id(raw)
+        account = (
+            str(
+                ev.account
+                or ident.get("name")
+                or ident.get("user_name")
+                or ident.get("account_name")
+                or ""
+            ).strip()
+        )
 
         def _allow() -> bool:
             if cache_key:
@@ -455,10 +493,10 @@ class Dispatcher:
         scoped = bool(str(((cfg.get("scrobble") or {}).get("watch") or {}).get("route_profile_id") or "").strip())
         if not wl and scoped:
             rid = str(((cfg.get("scrobble") or {}).get("watch") or {}).get("route_id") or "?")
-            _log(f"route {rid}: blocked account '{ev.account or '?'}' - profile-scoped route has no username whitelist", "WARNING")
+            _log(f"route {rid}: blocked account '{account or '?'}' - profile-scoped route has no username whitelist", "WARNING")
             return False
 
-        if not media_account_allowed(wl, ev.account or "", account_id=acc_id, account_uuid=acc_uuid, user_id=user_id, default_allow=not scoped):
+        if not media_account_allowed(wl, account, account_id=acc_id, account_uuid=acc_uuid, user_id=user_id, default_allow=not scoped):
             return False
         return _allow()
 
@@ -492,10 +530,12 @@ class Dispatcher:
 
     def accepts(self, ev: ScrobbleEvent) -> bool:
         cfg = self._cfg_provider() or {}
+        ev = self._route_event(ev, cfg)
         return self._passes_filters(ev, cfg)
 
     def dispatch(self, ev: ScrobbleEvent) -> bool:
         cfg = self._cfg_provider() or {}
+        ev = self._route_event(ev, cfg)
         if not self._passes_filters(ev, cfg):
             return False
         if not self._should_send(ev, cfg):

--- a/tests/test_plex_watcher_session_identity.py
+++ b/tests/test_plex_watcher_session_identity.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import Any
+
+import pytest
+
+
+class CaptureSink:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    def send(self, event: Any, *args: Any, **kwargs: Any) -> None:
+        self.events.append(event)
+
+
+class FakePlex:
+    machineIdentifier = "server-1"
+
+    def __init__(self, sessions: list[str]) -> None:
+        self._sessions = list(sessions)
+        self.queries: list[str] = []
+
+    def query(self, path: str) -> ET.Element:
+        self.queries.append(path)
+        xml = self._sessions.pop(0) if self._sessions else "<MediaContainer />"
+        return ET.fromstring(xml)
+
+    def sessions(self) -> list[Any]:
+        return []
+
+
+def _session_xml(
+    session_key: str,
+    *,
+    user_name: str = "",
+    user_id: str = "",
+    account_name: str = "",
+    account_id: str = "",
+    account_uuid: str = "",
+) -> str:
+    user_attrs = []
+    if user_name:
+        user_attrs.append(f'title="{user_name}"')
+    if user_id:
+        user_attrs.append(f'id="{user_id}"')
+    account_attrs = []
+    if account_name:
+        account_attrs.append(f'title="{account_name}"')
+    if account_id:
+        account_attrs.append(f'id="{account_id}"')
+    if account_uuid:
+        account_attrs.append(f'uuid="{account_uuid}"')
+    user = f"<User {' '.join(user_attrs)} />" if user_attrs else ""
+    account = f"<Account {' '.join(account_attrs)} />" if account_attrs else ""
+    return f'<MediaContainer><Video sessionKey="{session_key}">{user}{account}</Video></MediaContainer>'
+
+
+def _cfg(username_whitelist: list[str] | None, *, unresolved_user_fallback: bool = False) -> dict[str, Any]:
+    filters: dict[str, Any] = {}
+    if username_whitelist is not None:
+        filters["username_whitelist"] = username_whitelist
+    watch: dict[str, Any] = {"filters": filters}
+    if unresolved_user_fallback:
+        watch["route_options"] = {"watch": {"unresolved_user_fallback": True}}
+    return {
+        "plex": {
+            "server_url": "http://plex.test",
+            "account_token": "token",
+            "username": "owner",
+        },
+        "scrobble": {
+            "enabled": True,
+            "sources": {"watcher": True},
+            "watch": watch,
+        },
+    }
+
+
+def _alert(session_key: str, *, media_type: str = "movie", state: str = "playing") -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "state": state,
+        "sessionKey": session_key,
+        "title": "Movie" if media_type == "movie" else "Episode",
+        "type": media_type,
+        "guid": "imdb://tt0000001",
+        "duration": 1_000_000,
+        "viewOffset": 50_000,
+        "machineIdentifier": "server-1",
+    }
+    if media_type == "episode":
+        entry.update(
+            {
+                "grandparentTitle": "Show",
+                "grandparentGuid": "tvdb://123",
+                "grandparentIndex": 1,
+                "index": 2,
+            }
+        )
+    return {"type": "playing", "PlaySessionStateNotification": [entry]}
+
+
+def _service(monkeypatch: pytest.MonkeyPatch, cfg: dict[str, Any], plex: FakePlex) -> tuple[Any, CaptureSink]:
+    from providers.scrobble.plex import watch
+    from providers.scrobble.scrobble import Dispatcher
+
+    monkeypatch.setattr(watch, "_cw_update", lambda *args, **kwargs: None)
+    monkeypatch.setattr(watch, "_cw_update_payload", lambda *args, **kwargs: None)
+
+    sink = CaptureSink()
+    dispatcher = Dispatcher([sink], cfg_provider=lambda: cfg)
+    service = watch.WatchService(dispatcher=dispatcher, cfg_provider=lambda: cfg, quiet_startup=True)
+    service._plex = plex
+    return service, sink
+
+
+def test_owner_playback_with_whitelist_is_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["owner"])
+    plex = FakePlex([_session_xml("s-owner", user_name="owner", user_id="u1", account_id="a1", account_uuid="uuid-owner")])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("s-owner"))
+
+    assert len(sink.events) == 1
+    assert sink.events[0].account == "owner"
+
+
+def test_shared_user_playback_with_whitelist_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["owner"])
+    plex = FakePlex([_session_xml("s-shared", user_name="shared", user_id="u2", account_id="a2", account_uuid="uuid-shared")])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("s-shared"))
+
+    assert sink.events == []
+
+
+def test_unknown_user_with_whitelist_is_rejected_despite_configured_username(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.scrobble import from_plex_pssn
+
+    parser_alert = _alert("s-unknown")
+    parser_alert["PlaySessionStateNotification"][0]["accountID"] = "a1"
+    parsed = from_plex_pssn(parser_alert, defaults={"username": "owner"})
+    assert parsed is not None
+    assert parsed.account is None
+
+    cfg = _cfg(["owner"])
+    plex = FakePlex(["<MediaContainer />"])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("s-unknown"))
+
+    assert sink.events == []
+
+
+def test_unknown_user_without_whitelist_is_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(None)
+    plex = FakePlex(["<MediaContainer />"])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("s-open"))
+
+    assert len(sink.events) == 1
+    assert sink.events[0].account is None
+
+
+def test_unresolved_user_fallback_restores_legacy_configured_username(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["owner"], unresolved_user_fallback=True)
+    plex = FakePlex(["<MediaContainer />"])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("s-fallback"))
+
+    assert len(sink.events) == 1
+    assert sink.events[0].account == "owner"
+    assert sink.events[0].raw["_cw_unresolved_user_fallback_used"] is True
+
+
+def test_cached_session_identity_is_used_on_stopped_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["owner"])
+    plex = FakePlex([_session_xml("s-stop", user_name="owner", user_id="u1", account_id="a1", account_uuid="uuid-owner")])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("s-stop"))
+    service._last_event.clear()
+    service._handle_alert(_alert("s-stop", state="stopped"))
+
+    assert [event.action for event in sink.events] == ["start", "stop"]
+    assert [event.account for event in sink.events] == ["owner", "owner"]
+    assert plex.queries == ["/status/sessions"]
+
+
+@pytest.mark.parametrize("media_type", ["movie", "episode"])
+def test_movie_and_episode_use_resolved_session_identity(monkeypatch: pytest.MonkeyPatch, media_type: str) -> None:
+    cfg = _cfg(["owner"])
+    plex = FakePlex([_session_xml(f"s-{media_type}", user_name="owner", user_id="u1", account_id="a1", account_uuid="uuid-owner")])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert(f"s-{media_type}", media_type=media_type))
+
+    assert len(sink.events) == 1
+    assert sink.events[0].account == "owner"
+    assert sink.events[0].media_type == media_type

--- a/tests/test_scrobble_account_scope.py
+++ b/tests/test_scrobble_account_scope.py
@@ -132,12 +132,56 @@ def test_route_needs_account_filter_flag() -> None:
     assert route_needs_account_filter(plain, plain["scrobble"]["watch"]["routes"][0]) is False
 
 
+def test_route_options_keep_unresolved_user_fallback() -> None:
+    from providers.scrobble.routes import normalize_route_options
+
+    options = normalize_route_options({"watch": {"unresolved_user_fallback": True}})
+
+    assert options["watch"]["unresolved_user_fallback"] is True
+
+
+def test_existing_plex_route_without_unresolved_fallback_option_defaults_on() -> None:
+    from providers.scrobble.routes import build_route_cfg, normalize_route
+
+    cfg = _cfg(profile=False, whitelist=None)
+    route = cfg["scrobble"]["watch"]["routes"][0]
+
+    normalized = normalize_route(route, "R1")
+    built = build_route_cfg(cfg, route)
+
+    assert normalized["options"]["watch"]["unresolved_user_fallback"] is True
+    assert built["scrobble"]["watch"]["route_options"]["watch"]["unresolved_user_fallback"] is True
+
+
+def test_explicit_unresolved_fallback_false_stays_off() -> None:
+    from providers.scrobble.routes import normalize_route
+
+    cfg = _cfg(profile=False, whitelist=None)
+    route = cfg["scrobble"]["watch"]["routes"][0]
+    route["options"] = {"watch": {"unresolved_user_fallback": False}}
+
+    normalized = normalize_route(route, "R1")
+
+    assert normalized["options"]["watch"]["unresolved_user_fallback"] is False
+
+
+def test_new_plex_route_default_sets_unresolved_fallback_off() -> None:
+    from api.scrobblerManagementAPI import _set_plex_unresolved_user_fallback_default
+
+    route = {"provider": "plex", "options": {"watch": {}}}
+
+    _set_plex_unresolved_user_fallback_default(route, False)
+
+    assert route["options"]["watch"]["unresolved_user_fallback"] is False
+
+
 def test_overview_route_row_exposes_flag() -> None:
     from api.scrobblerManagementAPI import _normalized_routes
 
     cfg = _cfg(profile=True, whitelist=None)
     rows = _normalized_routes(cfg, None)
     assert rows and rows[0]["needs_account_filter"] is True
+    assert rows[0]["options"]["watch"]["unresolved_user_fallback"] is True
 
 
 def _webhook_cfg(*, profile: bool, whitelist: list[str] | None) -> dict[str, Any]:


### PR DESCRIPTION
# Pull request

## Change

- Resolve Plex watcher users from sessionKey and cache the result for late stop events.
- Stop using the configured Plex username as the default playback user. 
- Add a route option called Unresolved user fallback to restore that behavior when needed.

## Why

- Missing Plex users could pass username filters as the configured Plex account.
- This keeps strict filtering by default, while still supporting Plex Home and shared-server setups that need the old fallback.

## Testing

- tests/test_plex_watcher_session_identity.py 
- tests/test_scrobble_account_scope.py 
- tests/test_plex_webhook_ratings.py 
- tests/test_scrobble_media_filters.py

## Issue

Relates to #958