### PR TITLE
Change: enable CW tracker by default

### DIFF
--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -668,7 +668,7 @@ DEFAULT_CFG: dict[str, Any] = {
     },
 
     "crosswatch": {
-        "connected":        False,                      # True after local tracker connection is created
+        "connected":        True,                       # Fresh installs enable the local tracker by default
         "root_dir":         "/config/.cw_provider",     # Root folder for local provider state
         "enabled":          True,                       # Enable/disable CrossWatch as sync provider
         "retention_days":   30,                         # Snapshot retention in days; 0 = keep forever
@@ -2804,10 +2804,10 @@ def load_config() -> dict[str, Any]:
         user_cw = user_cfg.get("crosswatch") if isinstance(user_cfg.get("crosswatch"), dict) else user_cfg.get("CrossWatch")
         cw = cfg.get("crosswatch")
         if isinstance(cw, dict):
-            if isinstance(user_cw, dict) and "connected" not in user_cw and user_cw.get("enabled") is not False:
-                cw["connected"] = True
+            if isinstance(user_cw, dict) and "connected" not in user_cw:
+                cw["connected"] = user_cw.get("enabled") is not False
             elif not isinstance(user_cw, dict):
-                cw["connected"] = False
+                cw["connected"] = bool(first_run)
             user_insts = user_cw.get("instances") if isinstance(user_cw, dict) else None
             insts = cw.get("instances")
             if isinstance(user_insts, dict) and isinstance(insts, dict):

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -1699,7 +1699,7 @@ def test_crosswatch_connect_creates_connection_config(monkeypatch) -> None:
     assert store["crosswatch"]["max_snapshots"] == 64
 
 
-def test_crosswatch_default_config_is_not_connected() -> None:
+def test_crosswatch_explicitly_disconnected_config_stays_disconnected() -> None:
     from providers.auth._auth_CROSSWATCH import PROVIDER
     from providers.sync._mod_CROSSWATCH import OPS
 
@@ -1709,18 +1709,29 @@ def test_crosswatch_default_config_is_not_connected() -> None:
     assert OPS.is_configured(cfg) is False
 
 
-def test_crosswatch_config_default_does_not_auto_connect(tmp_path: Path, monkeypatch) -> None:
+def test_crosswatch_config_default_connects_new_install_but_respects_opt_out(tmp_path: Path, monkeypatch) -> None:
     import cw_platform.config_base as config_base
 
     monkeypatch.setattr(config_base, "CONFIG", tmp_path)
     cfg = config_base.load_config()
 
-    assert cfg["crosswatch"]["connected"] is False
+    assert cfg["crosswatch"]["connected"] is True
 
     (tmp_path / "config.json").write_text(json.dumps({"crosswatch": {"root_dir": "/tmp/cw"}}), "utf-8")
     migrated = config_base.load_config()
 
     assert migrated["crosswatch"]["connected"] is True
+
+    (tmp_path / "config.json").write_text(json.dumps({}), "utf-8")
+    removed = config_base.load_config()
+
+    assert removed["crosswatch"]["connected"] is False
+
+    (tmp_path / "config.json").write_text(json.dumps({"crosswatch": {"enabled": False}}), "utf-8")
+    disabled = config_base.load_config()
+
+    assert disabled["crosswatch"]["connected"] is False
+    assert disabled["crosswatch"]["enabled"] is False
 
 
 def test_analyzer_treats_crosswatch_as_tracker_provider() -> None:


### PR DESCRIPTION
# Pull request

## Change

- Enable CW Tracker by default on fresh installs.

## Why

- CW tracker is built in and useful out of the box, but users can still disconnect it or disable it when they do not want it.

## Testing

NA

## Issue

NA