### PR TITLE
Fix: stop attributing shared user playback to the Plex owner

### DIFF
--- a/cw_platform/account_match.py
+++ b/cw_platform/account_match.py
@@ -26,6 +26,7 @@ def media_account_allowed(allow: Any, account: Any = "", *, account_id: Any = ""
     title = str((acc.get("title") if isinstance(acc, Mapping) else "") or flat).strip()
     acc_id = str((acc.get("id") if isinstance(acc, Mapping) else "") or account_id or "").strip()
     acc_uuid = str((acc.get("uuid") if isinstance(acc, Mapping) else "") or account_uuid or "").strip().lower()
+    uid = str(user_id or "").strip().lower()
     values = allow if isinstance(allow, list) else [allow]
     for entry in values:
         raw = str(entry or "").strip()
@@ -34,7 +35,7 @@ def media_account_allowed(allow: Any, account: Any = "", *, account_id: Any = ""
         lowered = raw.lower()
         if lowered.startswith("id:"):
             wanted = lowered.split(":", 1)[1].strip()
-            if wanted and wanted == acc_id.lower():
+            if wanted and wanted in (acc_id.lower(), uid):
                 return True
             continue
         if lowered.startswith("uuid:"):

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -388,13 +388,14 @@ class WatchService:
         self._last_pause_ts: dict[str, float] = {}
         self._filtered_ts: dict[str, float] = {}
         self._route_filtered_ts: dict[str, float] = {}
+        self._identity_log_ts: dict[str, float] = {}
+        self._identity_miss: dict[str, int] = {}
         self._last_probe: dict[str, float] = {}
         self._best_offset: dict[str, tuple[int, int, float]] = {}
         self._dur_cache: dict[int, tuple[int, float]] = {}
         self._last_event: dict[str, ScrobbleEvent] = {}
         self._tl_last: dict[str, tuple[int, int, int, float]] = {}
         self._last_seek_emit: dict[str, float] = {}
-        self._sess_user_cache: dict[str, tuple[str, float]] = {}
         self._sess_identity_cache: dict[str, dict[str, Any]] = {}
         self._offline = False
         self._offline_failures = 0
@@ -820,7 +821,30 @@ class WatchService:
                 return _safe_int(v.get("ratingKey") or v.get("ratingkey"))
         return None
 
+    def _accepts_user(self, ev: ScrobbleEvent) -> bool:
+        try:
+            fn = getattr(self._dispatch, "accepts_user", None)
+            return bool(fn(ev)) if callable(fn) else True
+        except Exception:
+            return True
+
+    def _needs_user_resolution(self) -> bool:
+        try:
+            fn = getattr(self._dispatch, "needs_user_resolution", None)
+            return bool(fn()) if callable(fn) else True
+        except Exception:
+            return True
+
+    def _log_identity(self, msg: str, throttle_key: str | None = None) -> None:
+        if throttle_key is not None:
+            now = time.time()
+            if now - self._identity_log_ts.get(throttle_key, 0.0) < 30.0:
+                return
+            self._identity_log_ts[throttle_key] = now
+        self._dbg(msg)
+
     def _resolve_session_identity(self, session_key: str | None) -> dict[str, Any] | None:
+        self._no_sessions_access = False
         if not (self._plex and session_key):
             return None
         sk = str(session_key).strip()
@@ -840,9 +864,20 @@ class WatchService:
                 stale_hit = hit
                 if stale_age is not None and stale_age < 15.0:
                     return hit
+        t0 = time.time()
+
+        def _ms() -> int:
+            return int((time.time() - t0) * 1000)
+
+        now = time.time()
         try:
             el: Any = self._plex.query("/status/sessions")
             if el is None or not hasattr(el, "iter"):
+                self._log_identity(
+                    f"identity unresolved sess={sk} reason=bad_response "
+                    f"in={_ms()}ms",
+                    f"bad|{sk}",
+                )
                 return None
             ident: dict[str, Any] | None = None
             for v in el.iter("Video"):
@@ -884,36 +919,58 @@ class WatchService:
                 }
                 break
 
-            if ident and isinstance(cache, dict):
+            has_identity = bool(
+                ident
+                and any(str(ident.get(k) or "").strip() for k in ("name", "user_name", "user_id", "account_name", "account_id", "account_uuid"))
+            )
+            if has_identity and isinstance(cache, dict):
                 cache[sk] = ident
-                uc = getattr(self, "_sess_user_cache", None)
-                if isinstance(uc, dict):
-                    nm = str(ident.get("name") or "").strip()
-                    if nm:
-                        uc[sk] = (nm, now)
-            if ident:
+            if has_identity:
+                self._identity_miss.pop(sk, None)
+                self._log_identity(
+                    f"identity resolved sess={sk} user={_mask_account(ident.get('name'))} "
+                    f"user_id={ident.get('user_id') or '-'} account_id={ident.get('account_id') or '-'} "
+                    f"in={_ms()}ms"
+                )
                 return ident
-            
             if isinstance(stale_hit, dict) and stale_age is not None and stale_age < 6 * 3600:
+                self._identity_miss.pop(sk, None)
+                self._log_identity(
+                    f"identity stale sess={sk} user={_mask_account(stale_hit.get('name'))} "
+                    f"age={int(stale_age)}s reason=session_not_listed in={_ms()}ms",
+                    f"stale|{sk}",
+                )
                 return stale_hit
+            misses = self._identity_miss.get(sk, 0) + 1
+            self._identity_miss[sk] = misses
+            if misses > 1:
+                self._log_identity(
+                    f"identity unresolved sess={sk} reason=session_not_listed "
+                    f"misses={misses} in={_ms()}ms",
+                    f"miss|{sk}",
+                )
             return None
         except Exception as e:
+            reason = "sessions_error"
             try:
                 msg = str(e).lower()
                 if any(k in msg for k in ("401", "403", "unauthorized", "forbidden")):
                     self._no_sessions_access = True
+                    reason = "sessions_forbidden"
             except Exception:
                 pass
             if isinstance(stale_hit, dict) and stale_age is not None and stale_age < 6 * 3600:
+                self._log_identity(
+                    f"identity stale sess={sk} user={_mask_account(stale_hit.get('name'))} "
+                    f"age={int(stale_age)}s reason={reason} in={_ms()}ms",
+                    f"stale|{sk}",
+                )
                 return stale_hit
+            self._log_identity(
+                f"identity unresolved sess={sk} reason={reason} err={e} in={_ms()}ms",
+                f"err|{sk}",
+            )
             return None
-
-    def _resolve_account_from_session(self, session_key: str | None) -> str | None:
-        ident = self._resolve_session_identity(session_key)
-        if not isinstance(ident, dict):
-            return None
-        name = str(ident.get("name") or "").strip()
-        return name or None
 
     def _event_with_session_identity(self, ev: ScrobbleEvent, ident: dict[str, Any] | None) -> ScrobbleEvent:
         if not isinstance(ident, dict):
@@ -935,30 +992,19 @@ class WatchService:
             return ev
         return ScrobbleEvent(**{**ev.__dict__, "account": account, "raw": raw})
 
-    def _event_with_unresolved_user_fallback(self, ev: ScrobbleEvent, account: str) -> ScrobbleEvent:
-        fallback_account = str(account or "").strip()
-        if str(ev.account or "").strip() or not fallback_account:
+    def _event_with_unresolved_user_fallback(self, ev: ScrobbleEvent) -> ScrobbleEvent:
+        if str(ev.account or "").strip():
             return ev
         raw = dict(ev.raw or {})
-        raw["_cw_unresolved_user_fallback"] = {
-            "account": fallback_account,
-            "source": "configured_plex_username",
-        }
+        raw["_cw_sessions_access_unavailable"] = True
         return ScrobbleEvent(**{**ev.__dict__, "raw": raw})
 
     def _enrich_event_with_plex(self, ev: ScrobbleEvent) -> ScrobbleEvent | None:
         try:
             if not self._plex:
                 return ev
-            acc = self._resolve_account_from_session(ev.session_key)
-            if acc and _norm_user(acc) != _norm_user(ev.account or ""):
-                ev = ScrobbleEvent(**{**ev.__dict__, "account": acc})
             rk = self._find_rating_key(ev.raw or {})
             if not rk:
-                if not ev.account:
-                    acc = self._resolve_account_from_session(ev.session_key)
-                    if acc:
-                        return ScrobbleEvent(**{**ev.__dict__, "account": acc})
                 return ev
 
             it = self._plex.fetchItem(int(rk))
@@ -1017,7 +1063,6 @@ class WatchService:
                     for k, v in show_ids_raw.items():
                         ids.setdefault(f"{k}_show", str(v))
 
-            account = ev.account or self._resolve_account_from_session(ev.session_key)
             return ScrobbleEvent(
                 action=ev.action,
                 media_type=("episode" if media_type == "episode" else "movie"),
@@ -1027,7 +1072,7 @@ class WatchService:
                 season=season,
                 number=number,
                 progress=ev.progress,
-                account=account,
+                account=ev.account,
                 server_uuid=ev.server_uuid,
                 session_key=ev.session_key,
                 raw=raw,
@@ -1094,6 +1139,8 @@ class WatchService:
             self._filtered_ts[key] = now
 
     def _throttled_route_filtered_log(self, ev: ScrobbleEvent, kind: str = "event") -> None:
+        if not str(ev.account or "").strip():
+            return
         key = f"{kind}|{ev.account}|{ev.server_uuid}|{ev.session_key or self._find_rating_key(ev.raw or {}) or '?'}"
         now = time.time()
         last = self._route_filtered_ts.get(key, 0.0)
@@ -1192,14 +1239,18 @@ class WatchService:
                 if prev_acc:
                     ev = ScrobbleEvent(**{**ev.__dict__, "account": prev_acc})
 
-            ident = self._resolve_session_identity(ev.session_key)
-            ev = self._event_with_session_identity(ev, ident)
-            if not str(ev.account or "").strip():
-                cfg_user = (str(inst.get("username") or "").strip() if str(self._instance_id) != "default" else str(px.get("username") or "").strip())
-                ev = self._event_with_unresolved_user_fallback(ev, cfg_user)
+            if not str(ev.account or "").strip() and self._needs_user_resolution():
+                ident = self._resolve_session_identity(ev.session_key)
+                ev = self._event_with_session_identity(ev, ident)
+                if not str(ev.account or "").strip() and getattr(self, "_no_sessions_access", False):
+                    ev = self._event_with_unresolved_user_fallback(ev)
 
             if not self._passes_filters(ev):
                 self._throttled_filtered_log(ev)
+                return
+
+            if not self._accepts_user(ev):
+                self._throttled_route_filtered_log(ev)
                 return
 
             enriched = self._enrich_event_with_plex(ev)

--- a/providers/scrobble/scrobble.py
+++ b/providers/scrobble/scrobble.py
@@ -360,6 +360,7 @@ class Dispatcher:
         self._last_action: dict[str, str] = {}
         self._last_progress: dict[str, float] = {}
         self._sink_accepts_cfg: dict[int, bool] = {}
+        self._route_log_ts: dict[str, float] = {}
 
     def _send_sink(self, sink: Any, ev: ScrobbleEvent, cfg: dict[str, Any]) -> None:
         sid = id(sink)
@@ -381,29 +382,78 @@ class Dispatcher:
         except TypeError:
             sink.send(ev, cfg)
 
-    def _route_event(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> ScrobbleEvent:
+    def _route_label(self, cfg: dict[str, Any]) -> str:
+        try:
+            w = ((cfg.get("scrobble") or {}).get("watch") or {})
+            rid = str(w.get("route_id") or "").strip()
+            prov = str(w.get("route_provider") or "").strip()
+            sink = str(w.get("route_sink") or "").strip()
+            pair = f"{prov}->{sink}" if prov and sink else (prov or sink)
+            if rid and pair:
+                return f"{rid} {pair}"
+            return rid or pair or "?"
+        except Exception:
+            return "?"
+
+    def _throttled_route_log(self, key: str, msg: str, lvl: str = "DEBUG") -> None:
+        now = time.time()
+        if now - self._route_log_ts.get(key, 0.0) >= 30.0:
+            self._route_log_ts[key] = now
+            _log(msg, lvl)
+
+    def _fallback_account(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> str:
         if str(ev.account or "").strip():
-            return ev
+            return ""
         try:
             watch_cfg = ((cfg.get("scrobble") or {}).get("watch") or {})
             route_options = watch_cfg.get("route_options") or {}
             watch_options = route_options.get("watch") if isinstance(route_options, dict) else {}
             if not (isinstance(watch_options, dict) and bool(watch_options.get("unresolved_user_fallback"))):
-                return ev
+                return ""
         except Exception:
-            return ev
+            return ""
         raw = ev.raw if isinstance(ev.raw, dict) else {}
-        fallback = raw.get("_cw_unresolved_user_fallback") if isinstance(raw, dict) else None
-        fallback_account = ""
+        if not raw.get("_cw_sessions_access_unavailable"):
+            return ""
+        fallback = raw.get("_cw_unresolved_user_fallback")
         if isinstance(fallback, dict):
             fallback_account = str(fallback.get("account") or "").strip()
         else:
             fallback_account = str(fallback or "").strip()
         if not fallback_account:
+            plex_cfg = cfg.get("plex") if isinstance(cfg, dict) else {}
+            if isinstance(plex_cfg, dict):
+                fallback_account = str(plex_cfg.get("username") or "").strip()
+        return fallback_account
+
+    def _route_event(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> ScrobbleEvent:
+        fallback_account = self._fallback_account(ev, cfg)
+        if not fallback_account:
             return ev
-        raw2 = dict(raw)
+        raw2 = dict(ev.raw if isinstance(ev.raw, dict) else {})
         raw2["_cw_unresolved_user_fallback_used"] = True
+        self._throttled_route_log(
+            f"fallback|{fallback_account}|{ev.session_key}",
+            f"route {self._route_label(cfg)}: unresolved user fallback used "
+            f"user={mask_account(fallback_account)} sess={ev.session_key}",
+        )
         return ScrobbleEvent(**{**ev.__dict__, "account": fallback_account, "raw": raw2})
+
+    def needs_user_resolution(self) -> bool:
+        try:
+            cfg = self._cfg_provider() or {}
+            watch_cfg = ((cfg.get("scrobble") or {}).get("watch") or {})
+            filt = watch_cfg.get("filters") or {}
+            if not isinstance(filt, dict):
+                filt = {}
+            scoped = bool(str(watch_cfg.get("route_profile_id") or "").strip())
+            if filt.get("username_whitelist") or str(filt.get("user_id") or "").strip() or scoped:
+                return True
+            route_options = watch_cfg.get("route_options") or {}
+            watch_options = route_options.get("watch") if isinstance(route_options, dict) else {}
+            return bool(isinstance(watch_options, dict) and watch_options.get("unresolved_user_fallback"))
+        except Exception:
+            return False
 
     def _passes_filters(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> bool:
         cache_key: str | None = None
@@ -419,6 +469,23 @@ class Dispatcher:
             if cache_key in self._session_ok:
                 return True
 
+        if not self._identity_allowed(ev, cfg):
+            return False
+        if cache_key:
+            self._session_ok.add(cache_key)
+        return True
+
+    def accepts_user(self, ev: ScrobbleEvent) -> bool:
+        try:
+            cfg = self._cfg_provider() or {}
+            acct = self._fallback_account(ev, cfg)
+            if acct:
+                ev = ScrobbleEvent(**{**ev.__dict__, "account": acct})
+            return self._identity_allowed(ev, cfg)
+        except Exception:
+            return True
+
+    def _identity_allowed(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> bool:
         filt = (((cfg.get("scrobble") or {}).get("watch") or {}).get("filters") or {})
         if not isinstance(filt, dict):
             filt = {}
@@ -479,26 +546,35 @@ class Dispatcher:
             ).strip()
         )
 
-        def _allow() -> bool:
-            if cache_key:
-                self._session_ok.add(cache_key)
-            return True
+        resolved = bool(str(account or "").strip() or str(user_id or "").strip())
 
-        if want_user:
-            if not user_id:
-                return False
-            if want_user != user_id:
-                return False
+        if want_user and want_user != user_id:
+            if resolved:
+                self._throttled_route_log(
+                    f"user_id|{user_id}|{ev.session_key}",
+                    f"route {self._route_label(cfg)}: filtered user={mask_account(account)} "
+                    f"sess={ev.session_key} reason=user_id",
+                )
+            return False
 
         scoped = bool(str(((cfg.get("scrobble") or {}).get("watch") or {}).get("route_profile_id") or "").strip())
         if not wl and scoped:
-            rid = str(((cfg.get("scrobble") or {}).get("watch") or {}).get("route_id") or "?")
-            _log(f"route {rid}: blocked account '{account or '?'}' - profile-scoped route has no username whitelist", "WARNING")
+            _log(
+                f"route {self._route_label(cfg)}: filtered user={mask_account(account)} "
+                f"sess={ev.session_key} reason=profile_scoped_without_whitelist",
+                "WARNING",
+            )
             return False
 
         if not media_account_allowed(wl, account, account_id=acc_id, account_uuid=acc_uuid, user_id=user_id, default_allow=not scoped):
+            if resolved:
+                self._throttled_route_log(
+                    f"username|{account}|{ev.session_key}",
+                    f"route {self._route_label(cfg)}: filtered user={mask_account(account)} "
+                    f"sess={ev.session_key} reason=username_whitelist",
+                )
             return False
-        return _allow()
+        return True
 
     def _should_send(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> bool:
         sk = ev.session_key or "?"
@@ -547,6 +623,12 @@ class Dispatcher:
                 sent = True
             except Exception as e:
                 _log(f"Sink error: {e}", "ERROR")
+        if sent:
+            self._throttled_route_log(
+                f"sent|{ev.action}|{ev.account}|{ev.session_key}",
+                f"route {self._route_label(cfg)}: sent {ev.action} "
+                f"user={mask_account(ev.account)} sess={ev.session_key}",
+            )
         return sent or not self._sinks
 
 

--- a/providers/scrobble/watch_manager.py
+++ b/providers/scrobble/watch_manager.py
@@ -93,6 +93,29 @@ class MultiDispatcher:
                 _log(f"Route dispatcher error: {e}", "ERROR")
         return accepted
 
+    def accepts_user(self, event: ScrobbleEvent) -> bool:
+        if not self._dispatchers:
+            return True
+        for d in self._dispatchers:
+            try:
+                fn = getattr(d, "accepts_user", None)
+                if fn is None or bool(fn(event)):
+                    return True
+            except Exception as e:
+                _log(f"Route user gate error: {e}", "ERROR")
+                return True
+        return False
+
+    def needs_user_resolution(self) -> bool:
+        for d in self._dispatchers:
+            try:
+                fn = getattr(d, "needs_user_resolution", None)
+                if callable(fn) and bool(fn()):
+                    return True
+            except Exception as e:
+                _log(f"Route user resolution check error: {e}", "ERROR")
+        return False
+
 
 class _SchedulerEventSink:
     def __init__(self, route_id: str, route_provider: str, route_provider_instance: str) -> None:

--- a/tests/test_plex_watcher_session_identity.py
+++ b/tests/test_plex_watcher_session_identity.py
@@ -17,13 +17,15 @@ class CaptureSink:
 class FakePlex:
     machineIdentifier = "server-1"
 
-    def __init__(self, sessions: list[str]) -> None:
+    def __init__(self, sessions: list[str | Exception]) -> None:
         self._sessions = list(sessions)
         self.queries: list[str] = []
 
     def query(self, path: str) -> ET.Element:
         self.queries.append(path)
         xml = self._sessions.pop(0) if self._sessions else "<MediaContainer />"
+        if isinstance(xml, Exception):
+            raise xml
         return ET.fromstring(xml)
 
     def sessions(self) -> list[Any]:
@@ -106,6 +108,7 @@ def _service(monkeypatch: pytest.MonkeyPatch, cfg: dict[str, Any], plex: FakePle
 
     monkeypatch.setattr(watch, "_cw_update", lambda *args, **kwargs: None)
     monkeypatch.setattr(watch, "_cw_update_payload", lambda *args, **kwargs: None)
+    monkeypatch.setattr(watch.time, "sleep", lambda *args, **kwargs: None)
 
     sink = CaptureSink()
     dispatcher = Dispatcher([sink], cfg_provider=lambda: cfg)
@@ -162,11 +165,26 @@ def test_unknown_user_without_whitelist_is_allowed(monkeypatch: pytest.MonkeyPat
 
     assert len(sink.events) == 1
     assert sink.events[0].account is None
+    assert plex.queries == []
+
+
+def test_event_user_is_used_without_session_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["Carmen"])
+    plex = FakePlex(["<MediaContainer />"])
+    service, sink = _service(monkeypatch, cfg, plex)
+    alert = _alert("s-event-user")
+    alert["PlaySessionStateNotification"][0]["account"] = "Carmen"
+
+    service._handle_alert(alert)
+
+    assert len(sink.events) == 1
+    assert sink.events[0].account == "Carmen"
+    assert plex.queries == []
 
 
 def test_unresolved_user_fallback_restores_legacy_configured_username(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = _cfg(["owner"], unresolved_user_fallback=True)
-    plex = FakePlex(["<MediaContainer />"])
+    plex = FakePlex([RuntimeError("403 forbidden")])
     service, sink = _service(monkeypatch, cfg, plex)
 
     service._handle_alert(_alert("s-fallback"))
@@ -174,6 +192,74 @@ def test_unresolved_user_fallback_restores_legacy_configured_username(monkeypatc
     assert len(sink.events) == 1
     assert sink.events[0].account == "owner"
     assert sink.events[0].raw["_cw_unresolved_user_fallback_used"] is True
+    assert service._last_event["s-fallback"].raw["_cw_sessions_access_unavailable"] is True
+
+
+def test_unresolved_user_fallback_disabled_rejects_when_sessions_inaccessible(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["owner"], unresolved_user_fallback=False)
+    plex = FakePlex([RuntimeError("403 forbidden")])
+    service, sink = _service(monkeypatch, cfg, plex)
+    messages: list[str] = []
+    monkeypatch.setattr(service, "_dbg", lambda msg: messages.append(msg))
+
+    service._handle_alert(_alert("s-disabled"))
+
+    assert sink.events == []
+    assert [m for m in messages if m.startswith("event filtered by route dispatcher")] == []
+
+
+def test_unresolved_user_fallback_waits_when_sessions_are_accessible(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["owner"], unresolved_user_fallback=True)
+    plex = FakePlex(["<MediaContainer />"])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("s-temporary-miss"))
+
+    assert sink.events == []
+    assert service._no_sessions_access is False
+
+
+def test_session_identity_uses_one_fetch_and_resolves_on_the_next_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["Carmen"])
+    plex = FakePlex(["<MediaContainer />", _session_xml("s-race", user_name="Carmen", user_id="176467484")])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("s-race"))
+    assert sink.events == []
+    assert plex.queries == ["/status/sessions"]
+
+    service._handle_alert(_alert("s-race"))
+    assert len(sink.events) == 1
+    assert sink.events[0].account == "Carmen"
+    assert plex.queries == ["/status/sessions", "/status/sessions"]
+
+
+def test_route_filtered_log_does_not_show_unresolved_fallback_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.plex import watch
+    from providers.scrobble.scrobble import ScrobbleEvent
+
+    cfg = _cfg(["owner"], unresolved_user_fallback=False)
+    service = watch.WatchService(dispatcher=None, cfg_provider=lambda: cfg, quiet_startup=True)
+    messages: list[str] = []
+    monkeypatch.setattr(service, "_dbg", lambda msg: messages.append(msg))
+    ev = ScrobbleEvent(
+        action="start",
+        media_type="movie",
+        ids={"imdb": "tt1"},
+        title="Movie",
+        year=2020,
+        season=None,
+        number=None,
+        progress=5.0,
+        account=None,
+        server_uuid="server-1",
+        session_key="s-log",
+        raw={"_cw_sessions_access_unavailable": True, "_cw_unresolved_user_fallback": {"account": "owner"}},
+    )
+
+    service._throttled_route_filtered_log(ev)
+
+    assert messages == []
 
 
 def test_cached_session_identity_is_used_on_stopped_event(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -201,3 +287,317 @@ def test_movie_and_episode_use_resolved_session_identity(monkeypatch: pytest.Mon
     assert len(sink.events) == 1
     assert sink.events[0].account == "owner"
     assert sink.events[0].media_type == media_type
+
+
+def _route_dispatcher_cfg(route_id: str, sink_name: str, whitelist: list[str] | None, fallback: bool) -> dict[str, Any]:
+    cfg = _cfg(whitelist, unresolved_user_fallback=fallback)
+    watch_cfg = cfg["scrobble"]["watch"]
+    watch_cfg["route_id"] = route_id
+    watch_cfg["route_provider"] = "plex"
+    watch_cfg["route_sink"] = sink_name
+    return cfg
+
+
+def _dispatch_and_capture(monkeypatch: pytest.MonkeyPatch, cfg: dict[str, Any], raw: dict[str, Any], account: str | None = None) -> list[str]:
+    import providers.scrobble.scrobble as scrobble_mod
+    from providers.scrobble.scrobble import Dispatcher, ScrobbleEvent
+
+    messages: list[str] = []
+    monkeypatch.setattr(scrobble_mod, "_log", lambda msg, lvl="INFO": messages.append(str(msg)))
+    dispatcher = Dispatcher([CaptureSink()], cfg_provider=lambda: cfg)
+    ev = ScrobbleEvent(
+        action="start",
+        media_type="movie",
+        ids={"imdb": "tt1"},
+        title="Movie",
+        year=2020,
+        season=None,
+        number=None,
+        progress=5.0,
+        account=account,
+        server_uuid="server-1",
+        session_key="30",
+        raw=raw,
+    )
+    dispatcher.dispatch(ev)
+    return messages
+
+
+def test_route_filter_log_names_the_route_and_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _route_dispatcher_cfg("R1", "simkl", ["Carmen"], False)
+
+    messages = _dispatch_and_capture(monkeypatch, cfg, {}, account="Pascal")
+
+    assert messages == ["route R1 plex->simkl: filtered user=Pa*** sess=30 reason=username_whitelist"]
+
+
+def test_route_filter_stays_quiet_while_identity_is_unresolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _route_dispatcher_cfg("R1", "simkl", ["Carmen"], False)
+
+    messages = _dispatch_and_capture(monkeypatch, cfg, {})
+
+    assert messages == []
+
+
+def test_route_fallback_and_send_logs_name_the_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _route_dispatcher_cfg("R2", "mdblist", None, True)
+
+    messages = _dispatch_and_capture(monkeypatch, cfg, {"_cw_sessions_access_unavailable": True})
+
+    assert messages == [
+        "route R2 plex->mdblist: unresolved user fallback used user=ow*** sess=30",
+        "route R2 plex->mdblist: sent start user=ow*** sess=30",
+    ]
+
+
+def _identity_logs(monkeypatch: pytest.MonkeyPatch, service: Any) -> list[str]:
+    lines: list[str] = []
+    monkeypatch.setattr(service, "_dbg", lambda msg: lines.append(str(msg)))
+    return lines
+
+
+def test_identity_log_reports_resolution_details(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["Carmen"])
+    plex = FakePlex([_session_xml("31", user_name="Carmen", user_id="176467484")])
+    service, sink = _service(monkeypatch, cfg, plex)
+    lines = _identity_logs(monkeypatch, service)
+
+    service._handle_alert(_alert("31"))
+
+    resolved = [ln for ln in lines if ln.startswith("identity resolved")]
+    assert len(resolved) == 1
+    assert "sess=31" in resolved[0]
+    assert "user=Ca***" in resolved[0]
+    assert "user_id=176467484" in resolved[0]
+    assert sink.events[0].account == "Carmen"
+
+
+def test_first_session_not_listed_miss_stays_silent(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["Carmen"])
+    plex = FakePlex(["<MediaContainer />"])
+    service, _sink = _service(monkeypatch, cfg, plex)
+    lines = _identity_logs(monkeypatch, service)
+
+    service._handle_alert(_alert("31"))
+
+    assert [ln for ln in lines if ln.startswith("identity unresolved")] == []
+    assert plex.queries == ["/status/sessions"]
+
+
+def test_identity_log_reports_forbidden_without_retrying(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["Carmen"])
+    plex = FakePlex([RuntimeError("403 forbidden")])
+    service, _sink = _service(monkeypatch, cfg, plex)
+    lines = _identity_logs(monkeypatch, service)
+
+    service._handle_alert(_alert("31"))
+
+    unresolved = [ln for ln in lines if ln.startswith("identity unresolved")]
+    assert len(unresolved) == 1
+    assert "reason=sessions_forbidden" in unresolved[0]
+    assert plex.queries == ["/status/sessions"]
+
+
+def test_identity_miss_log_is_throttled_per_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["Carmen"])
+    plex = FakePlex(["<MediaContainer />"] * 12)
+    service, _sink = _service(monkeypatch, cfg, plex)
+    lines = _identity_logs(monkeypatch, service)
+
+    service._handle_alert(_alert("31"))
+    service._handle_alert(_alert("31"))
+
+    assert len([ln for ln in lines if ln.startswith("identity unresolved")]) == 1
+
+
+def test_username_whitelist_matches_plex_user_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["id:176467484"])
+    plex = FakePlex([_session_xml("31", user_name="Carmen", user_id="176467484")])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("31"))
+
+    assert len(sink.events) == 1
+    assert sink.events[0].account == "Carmen"
+
+
+def test_username_whitelist_user_id_does_not_match_other_users(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["id:176467484"])
+    plex = FakePlex([_session_xml("31", user_name="Pascal", user_id="1")])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("31"))
+
+    assert sink.events == []
+
+
+class CountingPlex(FakePlex):
+    def __init__(self, sessions: list[str | Exception]) -> None:
+        super().__init__(sessions)
+        self.fetches: list[int] = []
+
+    def fetchItem(self, rating_key: int) -> None:
+        self.fetches.append(int(rating_key))
+        return None
+
+
+def _alert_with_rating_key(session_key: str, rating_key: int = 1234) -> dict[str, Any]:
+    alert = _alert(session_key)
+    alert["PlaySessionStateNotification"][0]["ratingKey"] = rating_key
+    return alert
+
+
+def test_user_gate_skips_enrichment_for_filtered_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["Carmen"])
+    plex = CountingPlex([_session_xml("31", user_name="Pascal", user_id="1")])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert_with_rating_key("31"))
+
+    assert plex.fetches == []
+    assert sink.events == []
+
+
+def test_user_gate_still_enriches_allowed_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["Carmen"])
+    plex = CountingPlex([_session_xml("31", user_name="Carmen", user_id="176467484")])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert_with_rating_key("31"))
+
+    assert plex.fetches == [1234]
+    assert len(sink.events) == 1
+
+
+def test_user_gate_is_a_noop_without_a_whitelist(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(None)
+    plex = CountingPlex(["<MediaContainer />"])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert_with_rating_key("31"))
+
+    assert plex.queries == []
+    assert plex.fetches == [1234]
+    assert len(sink.events) == 1
+
+
+def test_fallback_route_without_whitelist_resolves_the_real_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(None, unresolved_user_fallback=True)
+    plex = FakePlex([_session_xml("31", user_name="Carmen", user_id="176467484")])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("31"))
+
+    assert plex.queries == ["/status/sessions"]
+    assert len(sink.events) == 1
+    assert sink.events[0].account == "Carmen"
+
+
+def test_fallback_route_without_whitelist_falls_back_when_forbidden(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(None, unresolved_user_fallback=True)
+    plex = FakePlex([RuntimeError("403 forbidden")])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("31"))
+
+    assert len(sink.events) == 1
+    assert sink.events[0].account == "owner"
+    assert sink.events[0].raw["_cw_unresolved_user_fallback_used"] is True
+
+
+def test_route_without_whitelist_or_fallback_never_looks_up_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(None, unresolved_user_fallback=False)
+    plex = FakePlex(["<MediaContainer />"])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("31"))
+
+    assert plex.queries == []
+    assert len(sink.events) == 1
+
+
+def test_forbidden_verdict_does_not_leak_into_a_later_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(None, unresolved_user_fallback=True)
+    plex = FakePlex([RuntimeError("403 forbidden"), RuntimeError("connection reset by peer")])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("31"))
+    assert sink.events[0].account == "owner"
+    assert service._no_sessions_access is True
+
+    service._handle_alert(_alert("32"))
+    assert service._no_sessions_access is False
+    assert sink.events[1].account is None
+    assert "_cw_unresolved_user_fallback_used" not in (sink.events[1].raw or {})
+
+
+class NullResponsePlex(FakePlex):
+    def query(self, path: str) -> Any:
+        self.queries.append(path)
+        nxt = self._sessions.pop(0) if self._sessions else None
+        if isinstance(nxt, Exception):
+            raise nxt
+        return None
+
+
+def test_forbidden_verdict_does_not_leak_into_a_later_bad_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(None, unresolved_user_fallback=True)
+    plex = NullResponsePlex([RuntimeError("403 forbidden"), None])
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("31"))
+    assert sink.events[0].account == "owner"
+    assert service._no_sessions_access is True
+
+    service._handle_alert(_alert("32"))
+    assert service._no_sessions_access is False
+    assert sink.events[1].account is None
+
+
+def test_repeated_session_not_listed_miss_is_logged(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["Carmen"])
+    plex = FakePlex(["<MediaContainer />"] * 3)
+    service, _sink = _service(monkeypatch, cfg, plex)
+    lines = _identity_logs(monkeypatch, service)
+
+    service._handle_alert(_alert("31"))
+    assert [ln for ln in lines if ln.startswith("identity unresolved")] == []
+
+    service._handle_alert(_alert("31"))
+    unresolved = [ln for ln in lines if ln.startswith("identity unresolved")]
+    assert len(unresolved) == 1
+    assert "reason=session_not_listed" in unresolved[0]
+    assert "misses=2" in unresolved[0]
+
+
+def test_miss_counter_resets_once_the_session_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["Carmen"])
+    plex = FakePlex([
+        "<MediaContainer />",
+        _session_xml("31", user_name="Carmen", user_id="176467484"),
+        "<MediaContainer />",
+    ])
+    service, _sink = _service(monkeypatch, cfg, plex)
+    lines = _identity_logs(monkeypatch, service)
+
+    service._handle_alert(_alert("31"))
+    service._handle_alert(_alert("31"))
+    assert service._identity_miss.get("31") is None
+
+    service._sess_identity_cache.clear()
+    service._last_event.clear()
+    service._handle_alert(_alert("31"))
+    assert [ln for ln in lines if ln.startswith("identity unresolved")] == []
+
+
+def test_forbidden_is_logged_on_the_very_first_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["Carmen"])
+    plex = FakePlex([RuntimeError("403 forbidden")])
+    service, _sink = _service(monkeypatch, cfg, plex)
+    lines = _identity_logs(monkeypatch, service)
+
+    service._handle_alert(_alert("31"))
+
+    unresolved = [ln for ln in lines if ln.startswith("identity unresolved")]
+    assert len(unresolved) == 1
+    assert "reason=sessions_forbidden" in unresolved[0]


### PR DESCRIPTION
# Pull request

## Change

Plex watcher no longer guesses a username when a session is missing from /status/sessions.

- Fallback to the configured Plex user now only runs on a 401 or 403, not when sessions
- The sessions verdict is reset at the start of every lookup.
- Dropped the 3x retry loop, one fetch per event, the next Plex alert resolves it anyway
- Session lookup now also runs for routes that have Unresolved user fallback enabled.
- Skip metadata enrichment when no route accepts the user.
- id: whitelist entries now match the Plex User id, sessions.

## Why

Based on previous change.

## Testing

- tests/test_plex_watcher_session_identity.py 
- tests/test_scrobble_account_scope.py

## Issue

Relates to #958