### PR TITLE
Change: block unsafe scheduler webhook targets

### DIFF
--- a/services/scheduler_webhooks.py
+++ b/services/scheduler_webhooks.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+import ipaddress
+import socket
 from typing import Any, Callable
 from urllib.parse import urlsplit, urlunsplit
 
@@ -10,6 +12,7 @@ import requests
 
 SCHEDULED_SYNC_MODES = {"standard", "advanced", "advanced_workflow"}
 EVENTS = {"start", "success", "failure"}
+BLOCKED_HOSTNAMES = {"localhost", "localhost.localdomain"}
 
 DEFAULT_WEBHOOKS: dict[str, Any] = {
     "enabled": False,
@@ -151,6 +154,9 @@ def notify_scheduler_webhook(
     url = callback_url(webhooks, event)
     if not url:
         return False
+    if not scheduler_webhook_url_allowed(url):
+        _log(log_fn, f"[!] Scheduler webhook {event}: blocked unsafe URL")
+        return False
 
     payload = build_payload(event, context, summary, str(webhooks.get("payload_format") or "crosswatch"))
     if webhooks.get("payload_format") == "notifiarr":
@@ -164,6 +170,7 @@ def notify_scheduler_webhook(
             json=payload,
             timeout=timeout,
             headers={"User-Agent": "CrossWatch scheduler webhook"},
+            allow_redirects=False,
         )
         resp.raise_for_status()
         _log(log_fn, f"[i] Scheduler webhook {event}: delivered")
@@ -290,6 +297,64 @@ def _http_url_or_blank(value: Any) -> str:
     if parts.scheme.lower() not in {"http", "https"} or not parts.netloc:
         return ""
     return url
+
+
+def scheduler_webhook_url_allowed(value: Any) -> bool:
+    url = str(value or "").strip()
+    if not url:
+        return False
+    try:
+        parts = urlsplit(url)
+        port = parts.port
+    except Exception:
+        return False
+
+    if parts.scheme.lower() not in {"http", "https"} or not parts.netloc:
+        return False
+    if parts.username or parts.password:
+        return False
+
+    host = str(parts.hostname or "").strip()
+    if not host:
+        return False
+    if _blocked_hostname(host):
+        return False
+
+    port = int(port or (443 if parts.scheme.lower() == "https" else 80))
+    try:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except Exception:
+        return False
+
+    addresses: set[ipaddress.IPv4Address | ipaddress.IPv6Address] = set()
+    for info in infos:
+        try:
+            sockaddr = info[4]
+            ip = ipaddress.ip_address(str(sockaddr[0]))
+        except Exception:
+            return False
+        if not _public_ip_allowed(ip):
+            return False
+        addresses.add(ip)
+
+    return bool(addresses)
+
+
+def _blocked_hostname(host: str) -> bool:
+    clean = host.strip().rstrip(".").lower()
+    if clean in BLOCKED_HOSTNAMES:
+        return True
+    try:
+        return not _public_ip_allowed(ipaddress.ip_address(clean))
+    except ValueError:
+        return False
+
+
+def _public_ip_allowed(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        return _public_ip_allowed(mapped)
+    return bool(ip.is_global)
 
 
 def _payload_format(value: Any) -> str:

--- a/tests/test_scheduler_webhooks.py
+++ b/tests/test_scheduler_webhooks.py
@@ -7,6 +7,15 @@ from typing import Any
 import pytest
 
 
+def _mock_scheduler_webhook_dns(monkeypatch: pytest.MonkeyPatch, webhooks: Any, *addresses: str) -> None:
+    resolved = addresses or ("93.184.216.34",)
+
+    def fake_getaddrinfo(_host: str, port: int, *_args: Any, **_kwargs: Any) -> list[tuple[int, int, int, str, tuple[str, int]]]:
+        return [(0, 0, 0, "", (address, int(port or 443))) for address in resolved]
+
+    monkeypatch.setattr(webhooks.socket, "getaddrinfo", fake_getaddrinfo)
+
+
 def test_resolve_completion_event_keeps_unresolved_runs_successful() -> None:
     from services.scheduler_webhooks import resolve_completion_event
 
@@ -102,6 +111,40 @@ def test_scheduler_webhook_urls_must_be_http_or_https() -> None:
     assert callback_url(webhooks, "failure") == "https://monitor.example/failure"
 
 
+def test_scheduler_webhook_url_allows_public_destinations(monkeypatch) -> None:
+    import services.scheduler_webhooks as webhooks
+
+    _mock_scheduler_webhook_dns(monkeypatch, webhooks, "93.184.216.34")
+
+    assert webhooks.scheduler_webhook_url_allowed("https://hooks.example.com/crosswatch") is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:8080/hook",
+        "http://localhost.:8080/hook",
+        "http://127.0.0.1:8080/hook",
+        "http://[::1]:8080/hook",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://10.0.0.5/hook",
+        "http://192.168.1.20/hook",
+    ],
+)
+def test_scheduler_webhook_url_blocks_local_and_private_literals(url: str) -> None:
+    import services.scheduler_webhooks as webhooks
+
+    assert webhooks.scheduler_webhook_url_allowed(url) is False
+
+
+def test_scheduler_webhook_url_blocks_private_dns_results(monkeypatch) -> None:
+    import services.scheduler_webhooks as webhooks
+
+    _mock_scheduler_webhook_dns(monkeypatch, webhooks, "10.0.0.5")
+
+    assert webhooks.scheduler_webhook_url_allowed("https://hooks.example.com/crosswatch") is False
+
+
 def test_scheduler_webhook_payload_includes_context_and_summary_counts() -> None:
     from services.scheduler_webhooks import build_payload
 
@@ -165,6 +208,7 @@ def test_scheduler_webhook_notifiarr_notify_adds_channel(monkeypatch) -> None:
     import services.scheduler_webhooks as webhooks
 
     posted: dict[str, Any] = {}
+    _mock_scheduler_webhook_dns(monkeypatch, webhooks)
 
     class FakeResponse:
         def raise_for_status(self) -> None:
@@ -173,6 +217,7 @@ def test_scheduler_webhook_notifiarr_notify_adds_channel(monkeypatch) -> None:
     def fake_post(url: str, **kwargs: Any) -> FakeResponse:
         posted["url"] = url
         posted["json"] = kwargs.get("json")
+        posted["allow_redirects"] = kwargs.get("allow_redirects")
         return FakeResponse()
 
     monkeypatch.setattr(webhooks.requests, "post", fake_post)
@@ -196,10 +241,43 @@ def test_scheduler_webhook_notifiarr_notify_adds_channel(monkeypatch) -> None:
     assert ok is True
     assert posted["url"] == "https://notifiarr.com/api/v1/notification/passthrough/key"
     assert posted["json"]["discord"]["ids"]["channel"] == 123456789012345678
+    assert posted["allow_redirects"] is False
+
+
+def test_scheduler_webhook_notify_blocks_unsafe_destination(monkeypatch) -> None:
+    import services.scheduler_webhooks as webhooks
+
+    _mock_scheduler_webhook_dns(monkeypatch, webhooks, "10.0.0.5")
+
+    def fail_post(*_args: Any, **_kwargs: Any) -> None:
+        pytest.fail("unsafe scheduler webhook should not be delivered")
+
+    logs: list[str] = []
+    monkeypatch.setattr(webhooks.requests, "post", fail_post)
+
+    ok = webhooks.notify_scheduler_webhook(
+        {
+            "scheduling": {
+                "webhooks": {
+                    "enabled": True,
+                    "failure_url": "https://hooks.example.com/fail",
+                }
+            }
+        },
+        "failure",
+        {"source": "scheduler", "scheduler_mode": "standard", "run_id": "run-unsafe"},
+        {"exit_code": 1},
+        log_fn=logs.append,
+    )
+
+    assert ok is False
+    assert logs and "blocked unsafe URL" in logs[0]
 
 
 def test_scheduler_webhook_notify_is_best_effort(monkeypatch) -> None:
     import services.scheduler_webhooks as webhooks
+
+    _mock_scheduler_webhook_dns(monkeypatch, webhooks)
 
     def fail_post(*_args: Any, **_kwargs: Any) -> None:
         raise RuntimeError("offline")


### PR DESCRIPTION
# Pull request

## Change

- Adds SSRF protection for scheduler webhooks.
- Blocks unsafe local, private, link-local, and non-global webhook targets before delivery

## Why

- Scheduler webhooks should not be able to call internal services from the CW host.

## Testing

- tests/test_scheduler_webhooks.py

## Issue

Relates to GHSA-h9xr-4m67-48f7