### PR TITLE
Change: preserve CW  tracker identity during syncs

### DIFF
--- a/providers/sync/_mod_CROSSWATCH.py
+++ b/providers/sync/_mod_CROSSWATCH.py
@@ -114,7 +114,7 @@ try:
 except Exception:
     make_snapshot_progress = None  # type: ignore[assignment]
 
-__VERSION__ = "1.2"
+__VERSION__ = "1.3"
 __all__ = ["get_manifest", "CROSSWATCHModule", "OPS"]
 
 _FEATURES: dict[str, Any] = {}

--- a/providers/sync/crosswatch/_collection.py
+++ b/providers/sync/crosswatch/_collection.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
-from cw_platform.id_map import canonical_key, merge_ids, minimal as id_minimal
+from cw_platform.id_map import canonical_key, merge_ids
 
 from ._common import (
     _atomic_write,
@@ -24,9 +24,11 @@ from ._common import (
     latest_state_file,
     make_logger,
     may_persist,
+    merge_tracker_identity,
     readonly,
     scoped_file,
     state_file_for_read,
+    tracker_minimal,
 )
 
 _dbg, _info, _warn, _error = make_logger("collection")
@@ -37,7 +39,7 @@ def _collection_path(adapter: Any) -> Path:
 
 
 def _accepted(obj: Mapping[str, Any]) -> dict[str, Any]:
-    item = id_minimal(obj)
+    item = tracker_minimal(obj)
     for key in ("collected_at", "listed_at", "added_at"):
         value = obj.get(key)
         if isinstance(value, str) and value.strip():
@@ -194,6 +196,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             merged = merge_ids(ex_ids, in_ids)
             if merged:
                 accepted["ids"] = merged
+            accepted = merge_tracker_identity(existing, accepted)
             if existing.get("collected_at") and not accepted.get("collected_at"):
                 accepted["collected_at"] = existing.get("collected_at")
         if existing != accepted:

--- a/providers/sync/crosswatch/_common.py
+++ b/providers/sync/crosswatch/_common.py
@@ -171,6 +171,71 @@ def make_logger(feature: str):  # type: ignore[return]
     return _dbg, _info, _warn, _error
 
 
+_IDENTITY_MAP_FIELDS: tuple[str, ...] = ("ids", "show_ids")
+_PASSTHROUGH_FIELDS: tuple[str, ...] = (
+    "_anime_absolute",
+    "_cw_anime_map",
+    "_simkl_episode_number",
+    "_trakt_number_abs",
+    "anime_type",
+    "simkl_bucket",
+)
+
+
+def _clean_identity_map(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    out: dict[str, Any] = {}
+    for key, item in value.items():
+        name = str(key or "").strip().lower()
+        if not name or item in (None, "") or isinstance(item, bool):
+            continue
+        if isinstance(item, (Mapping, list, tuple, set)):
+            continue
+        text = str(item).strip()
+        if text:
+            out[name] = text
+    return out
+
+
+def preserve_tracker_identity(base: Mapping[str, Any], source: Mapping[str, Any]) -> dict[str, Any]:
+    """Keep CrossWatch useful as a chained provider by preserving source identity maps."""
+    out = dict(base or {})
+    for field in _IDENTITY_MAP_FIELDS:
+        raw = _clean_identity_map(source.get(field))
+        current = _clean_identity_map(out.get(field))
+        merged = dict(raw)
+        merged.update(current)
+        if merged:
+            out[field] = merged
+        else:
+            out.pop(field, None)
+    for field in _PASSTHROUGH_FIELDS:
+        value = source.get(field)
+        if value not in (None, ""):
+            out[field] = value
+    return out
+
+
+def tracker_minimal(item: Mapping[str, Any]) -> dict[str, Any]:
+    return preserve_tracker_identity(id_minimal(item), item)
+
+
+def merge_tracker_identity(existing: Mapping[str, Any] | None, incoming: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(existing, Mapping):
+        return dict(incoming or {})
+    out = dict(incoming or {})
+    for field in _IDENTITY_MAP_FIELDS:
+        merged = _clean_identity_map(existing.get(field))
+        merged.update(_clean_identity_map(out.get(field)))
+        if merged:
+            out[field] = merged
+    for field in _PASSTHROUGH_FIELDS:
+        if out.get(field) in (None, "") and existing.get(field) not in (None, ""):
+            out[field] = existing.get(field)
+    return out
+
+
 # Path helpers
 
 def _root(adapter: Any) -> Path:

--- a/providers/sync/crosswatch/_history.py
+++ b/providers/sync/crosswatch/_history.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 from cw_platform.history_events import history_sync_key, minimal_history_item
-from cw_platform.id_map import canonical_key, minimal as id_minimal
+from cw_platform.id_map import canonical_key
 
 from ._common import (
     _atomic_write,
@@ -24,10 +24,13 @@ from ._common import (
     latest_state_file,
     make_logger,
     may_persist,
+    merge_tracker_identity,
+    preserve_tracker_identity,
     pair_scoped,
     readonly,
     scoped_file,
     state_file_for_read,
+    tracker_minimal,
 )
 
 _dbg, _info, _warn, _error = make_logger("history")
@@ -47,11 +50,11 @@ def _history_key(adapter: Any, item: Mapping[str, Any], fallback_key: Any = None
 
 
 def _history_minimal(adapter: Any, item: Mapping[str, Any], fallback_key: Any = None) -> dict[str, Any]:
-    return minimal_history_item(item, fallback_key, event_mode=_rewatches_enabled(adapter))
+    return preserve_tracker_identity(minimal_history_item(item, fallback_key, event_mode=_rewatches_enabled(adapter)), item)
 
 
 def _accepted(obj: Mapping[str, Any]) -> dict[str, Any]:
-    base = id_minimal(obj)
+    base = tracker_minimal(obj)
     out: dict[str, Any] = dict(base)
     if obj.get("watched") is not None:
         out["watched"] = bool(obj.get("watched"))
@@ -237,6 +240,8 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             unresolved_src.append(obj)
             continue
         if existing is None or (str(existing.get("watched_at") or "") <= str(accepted.get("watched_at") or "")):
+            if isinstance(existing, Mapping):
+                accepted = merge_tracker_identity(existing, accepted)
             cur[key] = _history_minimal(adapter, accepted, key)
             changed += 1
 

--- a/providers/sync/crosswatch/_playlists.py
+++ b/providers/sync/crosswatch/_playlists.py
@@ -10,10 +10,10 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
-from cw_platform.id_map import canonical_key, merge_ids, minimal as id_minimal
+from cw_platform.id_map import canonical_key, merge_ids
 from cw_platform.playlists import PLAYLIST_KIND_REGULAR, PlaylistItem, PlaylistResource, PlaylistSnapshot
 
-from ._common import _atomic_write, _capture_mode, _root, make_logger, readonly
+from ._common import _atomic_write, _capture_mode, _root, make_logger, merge_tracker_identity, readonly, tracker_minimal
 
 _dbg, _info, _warn, _error = make_logger("playlists")
 
@@ -70,7 +70,7 @@ def _migrate_legacy(raw: Mapping[str, Any]) -> dict[str, Any]:
             "id": "watchlist",
             "name": "Watchlist",
             "type": "playlist",
-            "items": {str(k): id_minimal(v) for k, v in raw.get("items", {}).items() if isinstance(v, Mapping)},
+            "items": {str(k): tracker_minimal(v) for k, v in raw.get("items", {}).items() if isinstance(v, Mapping)},
             "order": [str(k) for k in raw.get("items", {}).keys()],
             "created_at": int(raw.get("ts") or 0),
             "updated_at": int(raw.get("ts") or 0),
@@ -100,7 +100,7 @@ def _clean_list_row(list_id: str, row: Mapping[str, Any]) -> dict[str, Any]:
         for raw_key, raw_value in items_raw.items():
             if not isinstance(raw_value, Mapping):
                 continue
-            item = id_minimal(raw_value)
+            item = tracker_minimal(raw_value)
             key = canonical_key(item) or str(raw_key)
             if not key:
                 continue
@@ -109,7 +109,7 @@ def _clean_list_row(list_id: str, row: Mapping[str, Any]) -> dict[str, Any]:
         for raw_value in items_raw:
             if not isinstance(raw_value, Mapping):
                 continue
-            item = id_minimal(raw_value)
+            item = tracker_minimal(raw_value)
             key = canonical_key(item)
             if not key:
                 continue
@@ -261,7 +261,7 @@ def _accepted(items: Sequence[Mapping[str, Any]]) -> tuple[list[tuple[str, dict[
         if not isinstance(raw, Mapping):
             continue
         try:
-            item = id_minimal(raw)
+            item = tracker_minimal(raw)
         except Exception:
             unresolved.append({"item": dict(raw), "hint": "invalid_item"})
             continue
@@ -291,6 +291,7 @@ def add(adapter: Any, playlist_id: Any, items: Sequence[Mapping[str, Any]]) -> d
             merged = merge_ids(old_ids, new_ids)
             if merged:
                 item["ids"] = merged
+            item = merge_tracker_identity(existing, item)
         if existing != item:
             cur[key] = item
             changed += 1

--- a/providers/sync/crosswatch/_progress.py
+++ b/providers/sync/crosswatch/_progress.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
-from cw_platform.id_map import canonical_key, minimal as id_minimal
+from cw_platform.id_map import canonical_key
 
 from ._common import (
     _atomic_write,
@@ -23,10 +23,12 @@ from ._common import (
     latest_state_file,
     make_logger,
     may_persist,
+    merge_tracker_identity,
     pair_scoped,
     readonly,
     scoped_file,
     state_file_for_read,
+    tracker_minimal,
 )
 
 _dbg, _info, _warn, _error = make_logger("progress")
@@ -108,7 +110,7 @@ def _metadata_show_detail(adapter: Any, show_ids: Mapping[str, Any]) -> dict[str
 
 
 def _accepted(obj: Mapping[str, Any], adapter: Any | None = None) -> dict[str, Any]:
-    base = id_minimal(obj)
+    base = tracker_minimal(obj)
     out: dict[str, Any] = dict(base)
 
     typ = str(obj.get("type") or base.get("type") or "").strip().lower()
@@ -356,6 +358,8 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             or (new_ms is None and new_percent is not None and (old_percent is None or new_percent > old_percent or (abs(new_percent - old_percent) <= 0.001 and new_ts and old_ts <= new_ts)))
         )
         if should_write:
+            if isinstance(existing, Mapping):
+                accepted = merge_tracker_identity(existing, accepted)
             cur[key] = accepted
             changed += 1
 
@@ -384,7 +388,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
     for obj in src:
         if not isinstance(obj, Mapping):
             continue
-        base = id_minimal(obj)
+        base = tracker_minimal(obj)
         key = canonical_key(base)
         if not key:
             unresolved_src.append(obj)

--- a/providers/sync/crosswatch/_ratings.py
+++ b/providers/sync/crosswatch/_ratings.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from collections.abc import Iterable, Mapping
 from typing import Any
 
-from cw_platform.id_map import canonical_key, minimal as id_minimal
+from cw_platform.id_map import canonical_key
 
 from ._common import (
     _atomic_write,
@@ -24,10 +24,12 @@ from ._common import (
     latest_state_file,
     make_logger,
     may_persist,
+    merge_tracker_identity,
     pair_scoped,
     readonly,
     scoped_file,
     state_file_for_read,
+    tracker_minimal,
 )
 
 _dbg, _info, _warn, _error = make_logger("ratings")
@@ -38,7 +40,7 @@ def _now_iso_z() -> str:
 
 
 def _accepted(obj: Mapping[str, Any]) -> dict[str, Any]:
-    base = id_minimal(obj)
+    base = tracker_minimal(obj)
     out: dict[str, Any] = dict(base)
 
     typ = str(obj.get("type") or base.get("type") or "")
@@ -227,6 +229,8 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         new_ts = str(accepted.get("rated_at") or "")
         old_ts = str((existing or {}).get("rated_at") or "")
         if existing is None or old_ts <= new_ts:
+            if isinstance(existing, Mapping):
+                accepted = merge_tracker_identity(existing, accepted)
             cur[key] = accepted
             changed += 1
 

--- a/providers/sync/crosswatch/_watchlist.py
+++ b/providers/sync/crosswatch/_watchlist.py
@@ -10,7 +10,7 @@ from typing import Any, Iterable, Mapping
 
 from cw_platform.anime_mapping.service import mapped_or_default_media_type
 from cw_platform.config_base import load_config, save_config
-from cw_platform.id_map import canonical_key, merge_ids, minimal as id_minimal
+from cw_platform.id_map import canonical_key, merge_ids
 from cw_platform.metadata import MetadataManager
 
 from ._common import (
@@ -26,10 +26,12 @@ from ._common import (
     latest_state_file,
     make_logger,
     may_persist,
+    merge_tracker_identity,
     pair_scoped,
     readonly,
     scoped_file,
     state_file_for_read,
+    tracker_minimal,
 )
 
 _dbg, _info, _warn, _error = make_logger("watchlist")
@@ -71,8 +73,9 @@ def _ensure_tmdb_for_item(item: dict[str, Any]) -> bool:
     ids = dict(item.get("ids") or {}) if isinstance(item.get("ids"), dict) else {}
     if ids.get("tmdb") or item.get("tmdb"):
         if item.get("tmdb") and not ids.get("tmdb"):
-            ids = merge_ids(ids, {"tmdb": item.get("tmdb")})
-            item["ids"] = ids
+            merged = dict(ids)
+            merged.update(merge_ids(ids, {"tmdb": item.get("tmdb")}))
+            item["ids"] = merged
             return True
         return False
 
@@ -93,8 +96,9 @@ def _ensure_tmdb_for_item(item: dict[str, Any]) -> bool:
         tmdb = ((res or {}).get("ids") or {}).get("tmdb")
         if not tmdb:
             return False
-        ids = merge_ids(ids, {"tmdb": tmdb, "imdb": imdb})
-        item["ids"] = ids
+        merged = dict(ids)
+        merged.update(merge_ids(ids, {"tmdb": tmdb, "imdb": imdb}))
+        item["ids"] = merged
         return True
     except Exception:
         return False
@@ -141,7 +145,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
             key = canonical_key(obj)
             if not key:
                 continue
-            items[key] = id_minimal(obj)
+            items[key] = tracker_minimal(obj)
         state = {"ts": 0, "items": items}
         if items and may_persist(adapter, path):
             _atomic_write(path, {"ts": int(time.time()), "items": items})
@@ -157,7 +161,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
                 ck = str(key) or canonical_key(value)
                 if not ck:
                     continue
-                items2[ck] = id_minimal(value)
+                items2[ck] = tracker_minimal(value)
             state = {"ts": ts, "items": items2}
             if items2 and may_persist(adapter, path):
                 _atomic_write(path, {"ts": ts or int(time.time()), "items": items2})
@@ -169,7 +173,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
             ck = str(key) or canonical_key(value)
             if not ck:
                 continue
-            items3[ck] = id_minimal(value)
+            items3[ck] = tracker_minimal(value)
         state = {"ts": 0, "items": items3}
         if items3 and may_persist(adapter, path):
             _atomic_write(path, {"ts": int(time.time()), "items": items3})
@@ -211,7 +215,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
         ck = canonical_key(value) or str(key)
         if not ck:
             continue
-        out[ck] = id_minimal(value)
+        out[ck] = tracker_minimal(value)
     total = len(out)
     if prog:
         try:
@@ -237,7 +241,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         if not isinstance(obj, Mapping):
             continue
         try:
-            minimal = id_minimal(obj)
+            minimal = tracker_minimal(obj)
         except Exception:
             unresolved_src.append(obj)
             continue
@@ -252,6 +256,7 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             merged = merge_ids(ex_ids, in_ids)
             if merged:
                 minimal["ids"] = merged
+            minimal = merge_tracker_identity(existing, minimal)
 
         if not _capture_mode():
             _ensure_tmdb_for_item(minimal)
@@ -281,7 +286,7 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
         if not isinstance(obj, Mapping):
             continue
         try:
-            minimal = id_minimal(obj)
+            minimal = tracker_minimal(obj)
         except Exception:
             unresolved_src.append(obj)
             continue

--- a/tests/test_crosswatch_chain_state.py
+++ b/tests/test_crosswatch_chain_state.py
@@ -74,3 +74,104 @@ def test_crosswatch_progress_enriches_episode_series_title(monkeypatch) -> None:
     assert item["series_year"] == 2022
     assert item["title"] == "S02E07"
     assert item["show_ids"] == {"tmdb": "94997"}
+
+
+def test_crosswatch_history_preserves_rich_source_identity(tmp_path: Path) -> None:
+    from providers.sync.crosswatch import _history
+
+    rich = {
+        "type": "episode",
+        "title": "Mission: Forgetter IV",
+        "series_title": "Spy Kyoushitsu",
+        "year": 2023,
+        "season": 2,
+        "episode": 5,
+        "watched": True,
+        "watched_at": "2026-09-01T14:27:40Z",
+        "ids": {"tvdb": "9896573", "anidb": "269769", "source_episode": "kodi-14372"},
+        "show_ids": {
+            "tmdb": "194986",
+            "tvdb": "415821",
+            "anidb": "17979",
+            "mal": "54947",
+            "anilist": "163542",
+            "source_show": "kodi-show-12",
+        },
+        "_cw_anime_map": {"absolute": 5, "namespace": "anidb", "target_id": "17979", "release_tag": "v3"},
+        "_anime_absolute": 5,
+        "simkl_bucket": "anime",
+        "_simkl_episode_number": 5,
+    }
+
+    added, unresolved = _history.add(_adapter(tmp_path), [rich])
+    index = _history.build_index(_adapter(tmp_path))
+    item = next(iter(index.values()))
+
+    assert added == 1
+    assert unresolved == []
+    assert item["ids"]["anidb"] == "269769"
+    assert item["ids"]["source_episode"] == "kodi-14372"
+    assert item["show_ids"]["anidb"] == "17979"
+    assert item["show_ids"]["mal"] == "54947"
+    assert item["show_ids"]["source_show"] == "kodi-show-12"
+    assert item["_cw_anime_map"]["target_id"] == "17979"
+    assert item["_anime_absolute"] == 5
+    assert item["_simkl_episode_number"] == 5
+    assert item["simkl_bucket"] == "anime"
+
+
+def test_crosswatch_history_sparse_update_keeps_existing_identity(tmp_path: Path) -> None:
+    from providers.sync.crosswatch import _history
+
+    adapter = _adapter(tmp_path)
+    first = {
+        "type": "episode",
+        "series_title": "Spy Kyoushitsu",
+        "season": 1,
+        "episode": 5,
+        "watched_at": "2026-09-01T14:27:40Z",
+        "ids": {"tvdb": "9896573", "anidb": "269769"},
+        "show_ids": {"tvdb": "415821", "anidb": "17979", "mal": "54947"},
+        "_cw_anime_map": {"absolute": 5, "namespace": "anidb", "target_id": "17979", "release_tag": "v3"},
+    }
+    sparse = {
+        "type": "episode",
+        "series_title": "Spy Kyoushitsu",
+        "season": 1,
+        "episode": 5,
+        "watched_at": "2026-09-01T14:29:00Z",
+        "ids": {"tvdb": "9896573"},
+        "show_ids": {"tvdb": "415821"},
+    }
+
+    _history.add(adapter, [first])
+    _history.add(adapter, [sparse])
+    item = next(iter(_history.build_index(adapter).values()))
+
+    assert item["watched_at"] == "2026-09-01T14:29:00Z"
+    assert item["ids"] == {"tvdb": "9896573", "anidb": "269769"}
+    assert item["show_ids"] == {"tvdb": "415821", "anidb": "17979", "mal": "54947"}
+    assert item["_cw_anime_map"]["absolute"] == 5
+
+
+def test_crosswatch_watchlist_tmdb_enrichment_keeps_source_identity(monkeypatch) -> None:
+    from providers.sync.crosswatch import _watchlist
+
+    class Meta:
+        def resolve(self, **_kwargs):
+            return {"ids": {"tmdb": "194986"}}
+
+    item = {
+        "type": "show",
+        "title": "Spy Kyoushitsu",
+        "ids": {"imdb": "tt20259190", "anidb": "17979", "source_show": "kodi-show-12"},
+    }
+    monkeypatch.setattr(_watchlist, "_meta", lambda: Meta())
+
+    changed = _watchlist._ensure_tmdb_for_item(item)
+
+    assert changed is True
+    assert item["ids"]["tmdb"] == "194986"
+    assert item["ids"]["imdb"] == "tt20259190"
+    assert item["ids"]["anidb"] == "17979"
+    assert item["ids"]["source_show"] == "kodi-show-12"

--- a/tests/test_plex_watcher_session_identity.py
+++ b/tests/test_plex_watcher_session_identity.py
@@ -601,3 +601,188 @@ def test_forbidden_is_logged_on_the_very_first_failure(monkeypatch: pytest.Monke
     unresolved = [ln for ln in lines if ln.startswith("identity unresolved")]
     assert len(unresolved) == 1
     assert "reason=sessions_forbidden" in unresolved[0]
+
+
+def _service_with_account_ctx(
+    monkeypatch: pytest.MonkeyPatch, cfg: dict[str, Any], plex: FakePlex, ctx: dict[str, Any] | None
+) -> tuple[Any, CaptureSink]:
+    service, sink = _service(monkeypatch, cfg, plex)
+    service._account_ctx = ctx
+    return service, sink
+
+
+def test_shared_instance_uses_plex_tv_identity_instead_of_the_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["ceno88"], unresolved_user_fallback=True)
+    plex = FakePlex([RuntimeError("403 forbidden")])
+    ctx = {"owned": False, "name": "ceno88", "user_id": "716210920"}
+    service, sink = _service_with_account_ctx(monkeypatch, cfg, plex, ctx)
+
+    service._handle_alert(_alert("40"))
+
+    assert len(sink.events) == 1
+    assert sink.events[0].account == "ceno88"
+    assert "_cw_unresolved_user_fallback_used" not in (sink.events[0].raw or {})
+    assert sink.events[0].raw["_cw_session_identity"]["user_id"] == "716210920"
+    assert sink.events[0].raw["_cw_session_identity"]["account_uuid"] == ""
+    assert plex.queries == []
+
+
+def test_owned_instance_never_probes_plex_tv(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["Carmen"])
+    plex = FakePlex([_session_xml("41", user_name="Carmen", user_id="176467484")])
+    service, sink = _service_with_account_ctx(monkeypatch, cfg, plex, {"owned": True, "name": "owner"})
+
+    service._handle_alert(_alert("41"))
+
+    assert sink.events[0].account == "Carmen"
+    assert plex.queries == ["/status/sessions"]
+
+
+def test_shared_identity_falls_back_when_plex_tv_is_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["owner"], unresolved_user_fallback=True)
+    plex = FakePlex([RuntimeError("403 forbidden")])
+    service, sink = _service_with_account_ctx(monkeypatch, cfg, plex, None)
+
+    service._handle_alert(_alert("42"))
+
+    assert len(sink.events) == 1
+    assert sink.events[0].account == "owner"
+    assert sink.events[0].raw["_cw_unresolved_user_fallback_used"] is True
+
+
+class _Resp:
+    def __init__(self, text: str = "", payload: Any = None, ok: bool = True) -> None:
+        self.text = text
+        self._payload = payload
+        self._ok = ok
+
+    def raise_for_status(self) -> None:
+        if not self._ok:
+            raise RuntimeError("http error")
+
+    def json(self) -> Any:
+        return self._payload
+
+
+def _fake_plex_tv(monkeypatch: pytest.MonkeyPatch, *, owned: str, identity: Any) -> list[str]:
+    from providers.scrobble.plex import watch
+
+    calls: list[str] = []
+
+    def _get(url: str, **kwargs: Any) -> _Resp:
+        calls.append(url)
+        if "resources" in url:
+            return _Resp(text=f'<MediaContainer><Device clientIdentifier="server-1" owned="{owned}" /></MediaContainer>')
+        if identity is None:
+            return _Resp(ok=False)
+        return _Resp(payload=identity)
+
+    monkeypatch.setattr(watch.requests, "get", _get)
+    return calls
+
+
+def _service_for_refresh(monkeypatch: pytest.MonkeyPatch) -> Any:
+    cfg = _cfg(["ceno88"])
+    service, _sink = _service(monkeypatch, cfg, FakePlex([]))
+    return service
+
+
+def test_refresh_account_context_detects_shared_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _service_for_refresh(monkeypatch)
+    calls = _fake_plex_tv(monkeypatch, owned="0", identity={"username": "ceno88", "id": 716210920})
+
+    service._refresh_account_context()
+
+    assert service._account_ctx == {"owned": False, "name": "ceno88", "user_id": "716210920"}
+    assert len(calls) == 2
+
+
+def test_refresh_account_context_skips_identity_for_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _service_for_refresh(monkeypatch)
+    calls = _fake_plex_tv(monkeypatch, owned="1", identity={"username": "owner", "id": 1})
+
+    service._refresh_account_context()
+
+    assert service._account_ctx is None
+    assert len(calls) == 1
+
+
+def test_refresh_account_context_falls_back_when_identity_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _service_for_refresh(monkeypatch)
+    _fake_plex_tv(monkeypatch, owned="0", identity=None)
+
+    service._refresh_account_context()
+
+    assert service._account_ctx is None
+
+
+def test_refresh_account_context_clears_stale_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _service_for_refresh(monkeypatch)
+    service._account_ctx = {"owned": False, "name": "old-user", "user_id": "1"}
+    _fake_plex_tv(monkeypatch, owned="1", identity={"username": "owner", "id": 1})
+
+    service._refresh_account_context()
+
+    assert service._account_ctx is None
+
+
+def test_route_label_names_non_default_instances(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _route_dispatcher_cfg("R4", "crosswatch", ["zzz-no-one"], False)
+    watch_cfg = cfg["scrobble"]["watch"]
+    watch_cfg["route_provider_instance"] = "PLEX-P01"
+    watch_cfg["route_sink_instance"] = "default"
+    cfg["plex"]["label"] = "Ceno"
+
+    messages = _dispatch_and_capture(monkeypatch, cfg, {}, account="ceno88")
+
+    assert messages == [
+        "route R4 plex[Ceno]->crosswatch: filtered user=ce*** sess=30 reason=username_whitelist"
+    ]
+
+
+def test_route_label_falls_back_to_instance_id_without_a_label(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _route_dispatcher_cfg("R4", "crosswatch", ["zzz-no-one"], False)
+    cfg["scrobble"]["watch"]["route_provider_instance"] = "PLEX-P02"
+
+    messages = _dispatch_and_capture(monkeypatch, cfg, {}, account="ceno88")
+
+    assert messages == [
+        "route R4 plex[PLEX-P02]->crosswatch: filtered user=ce*** sess=30 reason=username_whitelist"
+    ]
+
+
+def test_route_label_omits_default_instances(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _route_dispatcher_cfg("R1", "simkl", ["Carmen"], False)
+    cfg["scrobble"]["watch"]["route_provider_instance"] = "default"
+
+    messages = _dispatch_and_capture(monkeypatch, cfg, {}, account="Pascal")
+
+    assert messages == ["route R1 plex->simkl: filtered user=Pa*** sess=30 reason=username_whitelist"]
+
+
+def test_watcher_log_prefixes_use_friendly_instance_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.plex import watch
+
+    lines: list[str] = []
+    monkeypatch.setattr(watch, "BASE_LOG", lambda msg, level="INFO", module="": lines.append(str(msg)))
+
+    def _svc(instance_id: str, plex_cfg: dict[str, Any]) -> Any:
+        cfg = _cfg(None)
+        cfg["plex"].update(plex_cfg)
+        return watch.WatchService(
+            dispatcher=None, cfg_provider=lambda: cfg, quiet_startup=True, instance_id=instance_id
+        )
+
+    _svc("default", {})._log("hello")
+    _svc("default", {"label": "Main"})._log("hello")
+    _svc("PLEX-P01", {"instances": {"PLEX-P01": {"label": "Ceno"}}})._log("hello")
+    _svc("PLEX-P02", {"instances": {"PLEX-P02": {}}})._log("hello")
+    _svc("PLEX-P01", {"instances": {"PLEX-P01": {"label": "Ceno"}}})._log("Watcher connected; inst=Ceno")
+
+    assert lines == [
+        "hello",
+        "[Main] hello",
+        "[Ceno] hello",
+        "[PLEX-P02] hello",
+        "Watcher connected; inst=Ceno",
+    ]


### PR DESCRIPTION
# Pull request

## Change

- preserve source identity on CW tracker entries during syncs.
- This preserves `ids`, `show_ids`, and anime-related metadata when CW is used between providers.

## Why

- CW tracker can sit in the middle of sync chains, so it should not drop IDs that later providers may need for correct matching.

## Testing

- tests/test_crosswatch_chain_state.py 

## Issue

NA