### PR TITLE
Change: resolve Plex watcher identity in one lookup

### DIFF
--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -391,6 +391,7 @@ class WatchService:
         self._route_filtered_ts: dict[str, float] = {}
         self._identity_log_ts: dict[str, float] = {}
         self._identity_miss: dict[str, int] = {}
+        self._identity_logged: dict[str, str] = {}
         self._account_ctx: dict[str, Any] | None = None
         self._instance_label: str | None = None
         self._last_probe: dict[str, float] = {}
@@ -1000,9 +1001,20 @@ class WatchService:
                     f"bad|{sk}",
                 )
                 return None
+
+            def _has_identity(d: dict[str, Any] | None) -> bool:
+                return bool(
+                    d
+                    and any(
+                        str(d.get(k) or "").strip()
+                        for k in ("name", "user_name", "user_id", "account_name", "account_id", "account_uuid")
+                    )
+                )
+
             ident: dict[str, Any] | None = None
             for v in el.iter("Video"):
-                if v.get("sessionKey") != sk:
+                vk = str(v.get("sessionKey") or "").strip()
+                if not vk:
                     continue
                 user_name = ""
                 user_id = ""
@@ -1029,7 +1041,7 @@ class WatchService:
                             acc_name = str(val).strip()
                             break
 
-                ident = {
+                row: dict[str, Any] = {
                     "name": user_name or acc_name,
                     "user_name": user_name,
                     "user_id": user_id,
@@ -1038,21 +1050,25 @@ class WatchService:
                     "account_uuid": acc_uuid,
                     "ts": now,
                 }
-                break
+                if vk == sk:
+                    ident = row
+                if _has_identity(row) and isinstance(cache, dict):
+                    cache[vk] = row
 
-            has_identity = bool(
-                ident
-                and any(str(ident.get(k) or "").strip() for k in ("name", "user_name", "user_id", "account_name", "account_id", "account_uuid"))
-            )
-            if ident and has_identity and isinstance(cache, dict):
-                cache[sk] = ident
+            has_identity = _has_identity(ident)
             if ident and has_identity:
                 self._identity_miss.pop(sk, None)
-                self._log_identity(
-                    f"identity resolved sess={sk} user={_mask_account(ident.get('name'))} "
-                    f"user_id={ident.get('user_id') or '-'} account_id={ident.get('account_id') or '-'} "
-                    f"in={_ms()}ms"
+                sig = "|".join(
+                    str(ident.get(k) or "")
+                    for k in ("name", "user_name", "user_id", "account_id", "account_uuid")
                 )
+                if self._identity_logged.get(sk) != sig:
+                    self._identity_logged[sk] = sig
+                    self._log_identity(
+                        f"identity resolved sess={sk} user={_mask_account(ident.get('name'))} "
+                        f"user_id={ident.get('user_id') or '-'} account_id={ident.get('account_id') or '-'} "
+                        f"in={_ms()}ms"
+                    )
                 return ident
             if isinstance(stale_hit, dict) and stale_age is not None and stale_age < 6 * 3600:
                 self._identity_miss.pop(sk, None)
@@ -1263,11 +1279,10 @@ class WatchService:
         if not str(ev.account or "").strip():
             return
         key = f"{kind}|{ev.account}|{ev.server_uuid}|{ev.session_key or self._find_rating_key(ev.raw or {}) or '?'}"
-        now = time.time()
-        last = self._route_filtered_ts.get(key, 0.0)
-        if now - last >= 30.0:
-            self._dbg(f"{kind} filtered by route dispatcher: user={_mask_account(ev.account)} server={ev.server_uuid} sess={ev.session_key}")
-            self._route_filtered_ts[key] = now
+        if key in self._route_filtered_ts:
+            return
+        self._route_filtered_ts[key] = time.time()
+        self._dbg(f"{kind} filtered by route dispatcher: user={_mask_account(ev.account)} server={ev.server_uuid} sess={ev.session_key}")
 
     def _clear_currently_watching(self, ev: ScrobbleEvent) -> None:
         try:

--- a/tests/test_plex_watcher_session_identity.py
+++ b/tests/test_plex_watcher_session_identity.py
@@ -32,7 +32,7 @@ class FakePlex:
         return []
 
 
-def _session_xml(
+def _video_xml(
     session_key: str,
     *,
     user_name: str = "",
@@ -55,7 +55,15 @@ def _session_xml(
         account_attrs.append(f'uuid="{account_uuid}"')
     user = f"<User {' '.join(user_attrs)} />" if user_attrs else ""
     account = f"<Account {' '.join(account_attrs)} />" if account_attrs else ""
-    return f'<MediaContainer><Video sessionKey="{session_key}">{user}{account}</Video></MediaContainer>'
+    return f'<Video sessionKey="{session_key}">{user}{account}</Video>'
+
+
+def _sessions_xml(*videos: str) -> str:
+    return f"<MediaContainer>{''.join(videos)}</MediaContainer>"
+
+
+def _session_xml(session_key: str, **kwargs: Any) -> str:
+    return _sessions_xml(_video_xml(session_key, **kwargs))
 
 
 def _cfg(username_whitelist: list[str] | None, *, unresolved_user_fallback: bool = False) -> dict[str, Any]:
@@ -786,3 +794,77 @@ def test_watcher_log_prefixes_use_friendly_instance_names(monkeypatch: pytest.Mo
         "[PLEX-P02] hello",
         "Watcher connected; inst=Ceno",
     ]
+
+
+def test_one_sessions_fetch_resolves_every_active_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["owner"])
+    plex = FakePlex(
+        [
+            _sessions_xml(
+                _video_xml("s-shared", user_name="shared", user_id="u2", account_id="a2"),
+                _video_xml("s-owner", user_name="owner", user_id="u1", account_id="a1"),
+            )
+        ]
+    )
+    service, sink = _service(monkeypatch, cfg, plex)
+
+    service._handle_alert(_alert("s-shared"))
+    service._handle_alert(_alert("s-owner"))
+
+    assert plex.queries == ["/status/sessions"]
+    assert [e.account for e in sink.events] == ["owner"]
+
+
+def test_identity_resolved_is_logged_once_per_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["Carmen"])
+    row = _session_xml("31", user_name="Carmen", user_id="176467484")
+    plex = FakePlex([row, row, row])
+    service, _sink = _service(monkeypatch, cfg, plex)
+    lines = _identity_logs(monkeypatch, service)
+
+    for _ in range(3):
+        service._sess_identity_cache.clear()
+        service._last_event.clear()
+        service._handle_alert(_alert("31"))
+
+    assert plex.queries == ["/status/sessions"] * 3
+    assert len([ln for ln in lines if ln.startswith("identity resolved")]) == 1
+
+
+def test_identity_is_logged_again_when_the_session_key_changes_hands(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["Carmen", "Pascal"])
+    plex = FakePlex([
+        _session_xml("31", user_name="Carmen", user_id="176467484"),
+        _session_xml("31", user_name="Pascal", user_id="114349713"),
+    ])
+    service, _sink = _service(monkeypatch, cfg, plex)
+    lines = _identity_logs(monkeypatch, service)
+
+    service._handle_alert(_alert("31"))
+    service._sess_identity_cache.clear()
+    service._last_event.clear()
+    service._handle_alert(_alert("31"))
+
+    resolved = [ln for ln in lines if ln.startswith("identity resolved")]
+    assert len(resolved) == 2
+    assert "user=Ca***" in resolved[0]
+    assert "user=Pa***" in resolved[1]
+
+
+def test_route_filtered_log_is_emitted_once_per_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(["owner"])
+    row = _session_xml("s-shared", user_name="shared", user_id="u2", account_id="a2")
+    plex = FakePlex([row, row, row])
+    service, sink = _service(monkeypatch, cfg, plex)
+    messages: list[str] = []
+    monkeypatch.setattr(service, "_dbg", lambda msg: messages.append(str(msg)))
+
+    for _ in range(3):
+        service._sess_identity_cache.clear()
+        service._handle_alert(_alert("s-shared"))
+        for key in list(service._route_filtered_ts):
+            service._route_filtered_ts[key] -= 60.0
+
+    assert sink.events == []
+    assert len([m for m in messages if m.startswith("event filtered by route dispatcher")]) == 1
+


### PR DESCRIPTION
# Pull request

## Change

- Plex watcher now fills session identity for every active session from a single /status/sessions call instead of one call per session.
- Also logs identity and route filtering once per session instead of repeating them every 30 seconds.

## Why

The identity lookup already downloaded every active session but kept only the one it asked for.
The log lines repeated forever for the same session even though the answer never changes. 

## Testing

- tests/test_plex_watcher_session_identity.py

## Issue

NA
