### PR TITLE
Change: refresh dashboard after tracker cleanup

### DIFF
--- a/api/dashboardAPI.py
+++ b/api/dashboardAPI.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Mapping, cast
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
@@ -43,9 +43,47 @@ def _dashboard_config_stamp(base_path: Any) -> float:
         return 0.0
 
 
+def _dashboard_tracker_stamp(
+    base_path: Any,
+    cfg: Mapping[str, Any],
+    requested: set[str],
+) -> list[tuple[str, int, int]]:
+    tracker_features = requested & {"history", "ratings", "progress"}
+    if not tracker_features:
+        return []
+    try:
+        from cw_platform.provider_instances import normalize_instance_id
+
+        node = cfg.get("crosswatch") if isinstance(cfg, Mapping) else {}
+        raw_root = str(node.get("root_dir") or "").strip() if isinstance(node, Mapping) else ""
+        root = Path(raw_root or ".cw_provider")
+        if not root.is_absolute():
+            root = Path(base_path) / root
+        roots: list[tuple[str, Path]] = [("default", root)]
+        instances = node.get("instances") if isinstance(node, Mapping) else {}
+        if isinstance(instances, Mapping):
+            for raw_id in instances.keys():
+                inst = normalize_instance_id(raw_id)
+                if inst != "default":
+                    roots.append((inst, root / "profiles" / inst))
+        stamp: list[tuple[str, int, int]] = []
+        for inst, base in roots:
+            for feature in sorted(tracker_features):
+                path = base / f"{feature}.json"
+                try:
+                    st = path.stat()
+                    stamp.append((f"{inst}:{feature}", int(st.st_mtime_ns), int(st.st_size)))
+                except OSError:
+                    stamp.append((f"{inst}:{feature}", 0, 0))
+        return stamp
+    except Exception:
+        return []
+
+
 def _dashboard_widgets_version(
     base_path: Any,
     *,
+    cfg: Mapping[str, Any],
     requested: set[str],
     state_features: set[str],
     profile: str,
@@ -69,6 +107,7 @@ def _dashboard_widgets_version(
         "policy": policy_fp,
         "db": _dashboard_db_stamp(base_path),
         "config": _dashboard_config_stamp(base_path),
+        "tracker": _dashboard_tracker_stamp(base_path, cfg, requested),
     }
     blob = json.dumps(source, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
@@ -106,6 +145,7 @@ def dashboard_widgets(
         }
         version = _dashboard_widgets_version(
             CONFIG,
+            cfg=cfg,
             requested=requested,
             state_features=state_features,
             profile=str(profile or "").strip(),

--- a/assets/js/modals/maintenance/index.js
+++ b/assets/js/modals/maintenance/index.js
@@ -45,6 +45,24 @@ const post = (url, body) =>
     body: JSON.stringify(body),
   });
 const listParts = (data, defs) => defs.flatMap(([k, label]) => data && data[k] != null ? [`${data[k]} ${label}${data[k] === 1 ? "" : "s"}`] : []);
+const notifyTrackerStateChanged = (result = {}) => {
+  try {
+    if (window.CW?.Maintenance?.applySyncStateReset) {
+      window.CW.Maintenance.applySyncStateReset({ ...(result || {}), source: "tracker" });
+      return;
+    }
+  } catch {}
+  try {
+    localStorage.removeItem("cw.dashboardWidgets.data.v1");
+    localStorage.removeItem("cw.profileWidgets.data.v1");
+  } catch {}
+  try {
+    window.dispatchEvent(new CustomEvent("cw:sync-state-cleared", {
+      detail: { source: "tracker", result },
+    }));
+  } catch {}
+  try { window.CW?.DashboardWidgets?.refresh?.({ force: true, forceConfig: true, preserve: false }); } catch {}
+};
 const SIMPLE_OPS = {
   state: "/api/maintenance/clear-state",
   cache: "/api/maintenance/clear-cache",
@@ -534,6 +552,7 @@ export default {
         if (data?.ok === false) throw new Error(data.error || "Import failed");
         const parts = listParts(data, [["files", "file"], ["states", "state file"], ["snapshots", "snapshot"]]);
         setStatus("Imported " + (parts.length ? parts.join(", ") : "tracker archive") + ".", "ok");
+        if (Number(data?.states || 0) > 0) notifyTrackerStateChanged(data);
         await refreshSummary();
         if (selectedInsightKind === "tracker") await loadActionInsight("tracker");
       } catch (e) {
@@ -880,6 +899,7 @@ export default {
 
       try {
         let res = null;
+        let trackerStateChanged = false;
         if (SIMPLE_OPS[kind]) {
           const body = kind === "stats" ? {
             recalc: false,
@@ -906,6 +926,7 @@ export default {
             clear_snapshots: clearSnaps,
             provider_instance: trackerProfile(),
           });
+          trackerStateChanged = clearState;
         } else if (kind === "defaults") {
           const warn = [
             "WARNING Reset all to default",
@@ -947,6 +968,9 @@ export default {
         if (kind === "state") {
           try { window.CW?.Maintenance?.applySyncStateReset?.(res || { ok: true }); } catch {}
           await refreshSummary();
+        }
+        if (kind === "tracker" && trackerStateChanged) {
+          notifyTrackerStateChanged(res || { ok: true });
         }
         if (kind === "cache" || kind === "tracker") await refreshSummary();
 

--- a/tests/test_crosswatch_profiles.py
+++ b/tests/test_crosswatch_profiles.py
@@ -1475,6 +1475,13 @@ def test_maintenance_rebuild_state_refreshes_main_page_caches() -> None:
     assert "window.CW?.DashboardWidgets?.refresh?.({ force: true, forceConfig: true, preserve: false })" in helper_js
     assert 'if (kind === "state")' in modal_js
     assert "window.CW?.Maintenance?.applySyncStateReset?.(res || { ok: true })" in modal_js
+    assert "const notifyTrackerStateChanged = (result = {}) =>" in modal_js
+    assert 'window.CW.Maintenance.applySyncStateReset({ ...(result || {}), source: "tracker" })' in modal_js
+    assert 'localStorage.removeItem("cw.dashboardWidgets.data.v1")' in modal_js
+    assert 'window.dispatchEvent(new CustomEvent("cw:sync-state-cleared"' in modal_js
+    assert 'trackerStateChanged = clearState;' in modal_js
+    assert 'if (kind === "tracker" && trackerStateChanged)' in modal_js
+    assert "if (Number(data?.states || 0) > 0) notifyTrackerStateChanged(data);" in modal_js
     assert "await injectCSS();" in modal_js
     assert "const loadMaintenanceBootStatus = async () =>" in modal_js
     assert "void loadMaintenanceBootStatus();" in modal_js

--- a/tests/test_dashboard_widgets.py
+++ b/tests/test_dashboard_widgets.py
@@ -1480,6 +1480,54 @@ def test_dashboard_widgets_api_returns_not_modified_for_known_version(monkeypatc
     assert payload == {"ok": True, "not_modified": True, "version": version}
 
 
+def test_dashboard_widgets_api_version_tracks_crosswatch_tracker_files(monkeypatch, tmp_path) -> None:
+    import cw_platform.config_base as config_base
+    from api import dashboardAPI
+
+    root = tmp_path / ".cw_provider"
+    root.mkdir()
+    (tmp_path / "config.json").write_text(
+        json.dumps({"crosswatch": {"root_dir": str(root)}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config_base, "CONFIG", tmp_path)
+    monkeypatch.setattr(dashboard_widgets, "_tracker_feature_items", lambda _kind: {})
+
+    first = dashboardAPI.dashboard_widgets(
+        history_limit=8,
+        ratings_limit=12,
+        scrobble_limit=8,
+        progress_limit=8,
+        playlists_limit=8,
+        include="history",
+    )
+    version = _loads_body(first.body)["version"]
+    (root / "history.json").write_text(
+        json.dumps({"items": {"movie:tmdb:949": {"type": "movie", "title": "Heat", "ids": {"tmdb": 949}}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        dashboardAPI,
+        "dashboard_widgets_payload",
+        lambda *_args, **_kwargs: {"ok": True, "recent_history": {"ok": True, "items": [], "total": 0}},
+    )
+
+    second = dashboardAPI.dashboard_widgets(
+        history_limit=8,
+        ratings_limit=12,
+        scrobble_limit=8,
+        progress_limit=8,
+        playlists_limit=8,
+        include="history",
+        known_version=version,
+    )
+    payload = _loads_body(second.body)
+
+    assert payload["ok"] is True
+    assert payload.get("not_modified") is not True
+    assert payload["version"] != version
+
+
 def test_dashboard_widget_frontend_uses_cached_payload_version() -> None:
     js = Path("assets/js/dashboard-widgets.js").read_text("utf-8")
     profile_js = Path("assets/js/profile-page.js").read_text("utf-8")


### PR DESCRIPTION
# Pull request

## Change

- Refresh dashboard widget state after CW tracker cleanup or tracker state import.
- Also include tracker state files in the dashboard widget cache version.

## Why

- After cleaning CW tracker state, the dashboard could still show cached CrossWatch records until a later refresh.

## Testing

- tests/test_dashboard_widgets.py::test_dashboard_widgets_api_version_tracks_crosswatch_tracker_files
- tests/test_crosswatch_profiles.py::test_maintenance_rebuild_state_refreshes_main_page_caches 

## Issue

NA