### PR TITLE
Change: improve sync cancel within pair batches

### DIFF
--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -21,6 +21,7 @@ from cw_platform.provider_instances import list_user_profiles, normalize_user_pr
 from cw_platform.local_db.legacy_files import LAST_SYNC_JSON
 from cw_platform.reason_labels import friendly_reason
 from cw_platform.run_control import (
+    SyncCancelled,
     cancel_requested,
     cancel_state,
     clear_cancel,
@@ -1037,6 +1038,11 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
                 _emit_unresolved_details(unresolved)
             except Exception:
                 pass
+        _sync_progress_ui("[SYNC] exit code: 0")
+    except SyncCancelled:
+        was_cancelled = True
+        _summary_set("cancelled", True)
+        _sync_progress_ui("[!] Sync cancelled - already applied changes were kept.")
         _sync_progress_ui("[SYNC] exit code: 0")
     except Exception as e:
         _sync_progress_ui(f"[!] Sync error: {e}")
@@ -2791,7 +2797,7 @@ def api_cancel_sync(request: Request = cast(Request, None)) -> Any:
     run_id = str(_summary_snapshot().get("run_id") or "")
     state = request_cancel(run_id, reason="user")
     _summary_set("cancel_requested", True)
-    _rt()[8]("SYNC", "[!] Cancel requested; finishing the current step and stopping.")
+    _rt()[8]("SYNC", "[!] Cancel requested; stopping after the current batch.")
     return {"ok": True, "running": True, "run_id": state.get("run_id"), "requested_at": state.get("requested_at")}
 
 

--- a/assets/helpers/core.js
+++ b/assets/helpers/core.js
@@ -1692,7 +1692,7 @@
         state.cancelPending = false;
         setSyncHeader("sync-warn", payload?.error ? `Cancel failed – ${payload.error}` : "Cancel failed");
       } else {
-        setSyncHeader("sync-warn", "Cancelling — finishing the current step…");
+        setSyncHeader("sync-warn", "Cancelling — stopping after the current batch…");
       }
     } catch {
       state.cancelPending = false;

--- a/cli/README.md
+++ b/cli/README.md
@@ -128,7 +128,7 @@ cw sync once --pair a --pair b     local one-shot selected pair run
 cw sync once --feature watchlist   local one-shot feature-only run
 cw sync status                     current or last run, with counts
 cw sync follow                     attach to a run already going
-cw sync cancel                     stop after the current step
+cw sync cancel                     stop after the current batch
 cw sync unresolved                 what the last run could not match
 cw sync providers [--counts]
 ```

--- a/cli/commands/sync.py
+++ b/cli/commands/sync.py
@@ -317,7 +317,7 @@ def sync_follow(
 
 @sync_app.command("cancel")
 def sync_cancel(ctx: typer.Context) -> None:
-    """Ask the running sync to stop after the current step."""
+    """Ask the running sync to stop after the current batch."""
     state: Ctx = ctx.obj
     state.require_service("Cancelling a sync")
     result = state.post("/api/run/cancel")
@@ -327,7 +327,7 @@ def sync_cancel(ctx: typer.Context) -> None:
     if isinstance(result, dict) and result.get("ok") is False:
         state.out.warn(error_text(result, "Nothing to cancel"))
         return
-    state.out.success("Cancel requested; the run stops after the current step.")
+    state.out.success("Cancel requested; the run stops after the current batch.")
 
 
 @sync_app.command("once")

--- a/cw_platform/orchestrator/_applier.py
+++ b/cw_platform/orchestrator/_applier.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence, Mapping
 from typing import Any, Callable, cast
 from . import _unresolved as _unresolved_mod
-from ..run_control import cancel_requested
+from ..run_control import SyncCancelled, cancel_requested
 record_unresolved = cast(Callable[..., dict[str, Any]], getattr(_unresolved_mod, "record_unresolved"))
 
 _UNRESOLVED_EXAMPLE_CAP = 25
@@ -26,6 +26,8 @@ def _retry(fn: Callable[[], Any], *, attempts: int = 3, base_sleep: float = 0.5)
     last = None
     for i in range(attempts):
         try: return fn()
+        except SyncCancelled:
+            raise
         except Exception as e:
             last = e
             __import__("time").sleep(base_sleep * (2 ** i))
@@ -442,7 +444,11 @@ def _apply_chunked(
         return {"ok": True, "attempted": 0, "confirmed": 0, "skipped": 0, "unresolved": 0, "errors": 0, "count": 0, "cancelled": True}
     csize = int(chunk_size or 0)
     if csize <= 0 or total <= csize:
-        raw = _retry(lambda: call(items))
+        try:
+            raw = _retry(lambda: call(items))
+        except SyncCancelled:
+            emit(f"{tag}:cancelled", dst=dst, feature=feature, done=0, total=total)
+            return {"ok": True, "attempted": 0, "confirmed": 0, "skipped": 0, "unresolved": 0, "errors": 0, "count": 0, "cancelled": True}
         return _normalize(raw, items, tag, dst=dst, feature=feature, emit=emit)
 
     done = 0
@@ -467,7 +473,12 @@ def _apply_chunked(
             emit(f"{tag}:cancelled", dst=dst, feature=feature, done=done, total=total)
             break
         chunk = items[i : i + csize]
-        raw = _retry(lambda: call(chunk))
+        try:
+            raw = _retry(lambda: call(chunk))
+        except SyncCancelled:
+            agg["cancelled"] = True
+            emit(f"{tag}:cancelled", dst=dst, feature=feature, done=done, total=total)
+            break
         res = _normalize(raw, chunk, tag, dst=dst, feature=feature, emit=emit)
         agg["ok"] = agg["ok"] and res["ok"]
         agg["attempted"] += res["attempted"]
@@ -503,7 +514,7 @@ def _apply_chunked(
         done += len(chunk)
         emit(f"{tag}:progress", dst=dst, feature=feature, done=done, total=total, ok=res["ok"])
         pause = int(chunk_pause_ms or 0)
-        if pause:
+        if pause and not cancel_requested():
             try:
                 __import__("time").sleep(pause / 1000.0)
             except Exception:

--- a/cw_platform/orchestrator/_pairs.py
+++ b/cw_platform/orchestrator/_pairs.py
@@ -174,9 +174,39 @@ def _collect_health_for_run(ctx, pairs: list[Mapping[str, Any]]) -> dict[str, An
             inject_ctx_into_provider(ops, ctx)
             try:
                 h = ops.health(cfg_view, emit=emit) or {}
+            except SyncCancelled:
+                h = {"ok": False, "status": "cancelled", "details": "health cancelled"}
+                health_map[f"{str(name).upper()}#{normalize_instance_id(inst)}"] = h
+                emit(
+                    "health",
+                    provider=name,
+                    instance=normalize_instance_id(inst),
+                    status="cancelled",
+                    ok=False,
+                    latency_ms=None,
+                    details=h.get("details"),
+                    features={},
+                    api={},
+                )
+                break
             except TypeError:
                 try:
                     h = ops.health(cfg_view) or {}
+                except SyncCancelled:
+                    h = {"ok": False, "status": "cancelled", "details": "health cancelled"}
+                    health_map[f"{str(name).upper()}#{normalize_instance_id(inst)}"] = h
+                    emit(
+                        "health",
+                        provider=name,
+                        instance=normalize_instance_id(inst),
+                        status="cancelled",
+                        ok=False,
+                        latency_ms=None,
+                        details=h.get("details"),
+                        features={},
+                        api={},
+                    )
+                    break
                 except Exception as e:
                     h = {"ok": False, "status": "down", "details": f"health exception: {e}"}
             except Exception as e:
@@ -526,6 +556,11 @@ def run_pairs(ctx) -> dict[str, Any]:
                             blocked_total += int(res.get("blocked", 0))
                             attempted_add_duplicate_keys_total += int(res.get("attempted_add_duplicate_keys", 0))
                             errors_total += int(res.get("errors", 0))
+
+                        if isinstance(res, Mapping) and coerce_bool(res.get("cancelled"), False):
+                            emit("feature:cancelled", src=src, dst=dst, feature=feature)
+                            cancelled = True
+                            break
 
                     except SyncCancelled:
                         emit("feature:cancelled", src=src, dst=dst, feature=feature)

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -10,6 +10,7 @@ import re
 import datetime as _dt
 
 from ._progress_completion import fcfg_for_progress_target
+from ..run_control import cancel_requested
 
 
 def load_feature_state(state_store: Any, feature: str) -> dict[str, Any]:
@@ -1114,6 +1115,7 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
 
     src_cur = snaps.get(src) or {}
     dst_cur = snaps.get(dst) or {}
+    cancelled = bool(cancel_requested())
 
     prev_state = load_feature_state(ctx.state_store, feature)
     manual_adds, manual_blocks = _manual_policy(prev_state, src, feature)
@@ -1744,8 +1746,9 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
     dry_run_flag = bool(ctx.dry_run or sync_cfg.get("dry_run", False))
     verify_after_write = bool(sync_cfg.get("verify_after_write", False))
     post_apply_add_res: dict[str, Any] | None = None
+    cancelled = cancelled or bool(cancel_requested())
 
-    if updates:
+    if updates and not cancelled:
         if dst_down:
             record_unresolved(dst, feature, updates, hint="provider_down:update")
             emit("writes:skipped", dst=dst, feature=feature, reason="provider_down", op="update", count=len(updates))
@@ -1794,8 +1797,9 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
                         dst_full[k] = v
                 if keys_to_write:
                     _bust_snapshot(dst)
+            cancelled = bool((upd_res or {}).get("cancelled")) or bool(cancel_requested())
 
-    if adds:
+    if adds and not cancelled:
         if dst_down:
             record_unresolved(dst, feature, adds, hint="provider_down:add")
             emit("writes:skipped", dst=dst, feature=feature, reason="provider_down", op="add", count=len(adds))
@@ -1956,12 +1960,13 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
                         dst_canonical[dk] = item
                 _bust_snapshot(dst)
             post_apply_add_res = add_res
+            cancelled = bool((add_res or {}).get("cancelled")) or bool(cancel_requested())
 
     removed_count = 0
     rem_keys_attempted: list[str] = []
     res_remove: dict[str, Any] = {"attempted": 0, "confirmed": 0, "skipped": 0, "unresolved": 0, "errors": 0}
     rem_key2item: dict[str, dict[str, Any]] = {}
-    if removes:
+    if removes and not cancelled:
         try:
             for it in removes:
                 k = _sync_key(_sync_minimal(it))
@@ -2048,6 +2053,7 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
                          added=len(removed_tokens), scope="pair")
                 except Exception:
                     pass
+            cancelled = bool((rem_res or {}).get("cancelled")) or bool(cancel_requested())
             if not dry_run_flag and removed_count:
                 for k in rem_success_keys:
                     if k in dst_full:
@@ -2097,7 +2103,7 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
                     out[fld] = merged
         return out
 
-    if (not dry_run_flag) and (not dst_down) and needs_post_apply_refresh(post_apply_add_res):
+    if (not cancelled) and (not dry_run_flag) and (not dst_down) and needs_post_apply_refresh(post_apply_add_res):
         _r = post_apply_add_res or {}
         emit("post_apply_refresh:start", provider=dst, instance=dst_inst, feature=feature,
              reason="accepted_not_live_confirmed",
@@ -2127,7 +2133,7 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
              refreshed_count=len(refreshed or {}), first_keys=list(refreshed or {})[:10],
              contains_trace_key=contains_trace, baseline_update_count=base_update)
 
-    if getattr(ctx, "write_state_json", True):
+    if (not cancelled) and getattr(ctx, "write_state_json", True):
         try:
             provs_block: dict[str, Any] = {}
 
@@ -2256,4 +2262,5 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
         "res_add": res_add,
         "res_update": res_update,
         "res_remove": res_remove,
+        "cancelled": bool(cancelled or cancel_requested()),
     }

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -10,6 +10,7 @@ import re
 import datetime as _dt
 
 from ._pairs_oneway import _emit_item_failures, _emit_item_resolutions, compute_effective_add, compute_effective_remove, current_attempt_unresolved_keys, is_remove_retry_reason, load_feature_state, resolve_baseline_writes, select_baseline_keys
+from ..run_control import cancel_requested
 
 try:
     from ._pairs_oneway import (
@@ -477,6 +478,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
     )
     A_cur = snaps.get(a) or {}
     B_cur = snaps.get(b) or {}
+    cancelled = bool(cancel_requested())
 
 
     prev_state_cache = getattr(ctx, "_stable_prev_state_by_feature", None)
@@ -1887,6 +1889,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
          add_to_A=len(add_to_A), add_to_B=len(add_to_B),
          upd_to_A=len(upd_to_A), upd_to_B=len(upd_to_B),
          rem_from_A=len(rem_from_A), rem_from_B=len(rem_from_B))
+    cancelled = cancelled or bool(cancel_requested())
 
     resA_rem: dict[str, Any] = {"ok": True, "count": 0}
     resB_rem: dict[str, Any] = {"ok": True, "count": 0}
@@ -1927,7 +1930,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
         except Exception:
             pass
 
-    if rem_from_A:
+    if rem_from_A and not cancelled:
         if a_down:
             record_unresolved(a, feature, rem_from_A, hint="provider_down:remove")
             remove_unresolved_A = len(set(remA_keys))
@@ -1972,8 +1975,9 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                  unresolved=remove_unresolved_A,
                  errors=int(resA_rem.get("errors", 0)),
                  result=resA_rem)
+            cancelled = bool((resA_rem or {}).get("cancelled")) or bool(cancel_requested())
 
-    if rem_from_B:
+    if rem_from_B and not cancelled:
         if b_down:
             record_unresolved(b, feature, rem_from_B, hint="provider_down:remove")
             remove_unresolved_B = len(set(remB_keys))
@@ -2018,6 +2022,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                  unresolved=remove_unresolved_B,
                  errors=int(resB_rem.get("errors", 0)),
                  result=resB_rem)
+            cancelled = bool((resB_rem or {}).get("cancelled")) or bool(cancel_requested())
 
     resA_add: dict[str, Any] = {"ok": True, "count": 0}
     resB_add: dict[str, Any] = {"ok": True, "count": 0}
@@ -2032,7 +2037,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
     unresolved_new_A_total = 0
     unresolved_new_B_total = 0
 
-    if upd_to_A:
+    if upd_to_A and not cancelled:
         if a_down:
             record_unresolved(a, feature, upd_to_A, hint="provider_down:update")
             emit("writes:skipped", dst=a, feature=feature, reason="provider_down", op="update", count=len(upd_to_A))
@@ -2071,8 +2076,9 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                  unresolved=int(resA_upd.get("unresolved", 0)),
                  errors=int(resA_upd.get("errors", 0)),
                  result=resA_upd)
+            cancelled = bool((resA_upd or {}).get("cancelled")) or bool(cancel_requested())
 
-    if upd_to_B:
+    if upd_to_B and not cancelled:
         if b_down:
             record_unresolved(b, feature, upd_to_B, hint="provider_down:update")
             emit("writes:skipped", dst=b, feature=feature, reason="provider_down", op="update", count=len(upd_to_B))
@@ -2111,8 +2117,9 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                  unresolved=int(resB_upd.get("unresolved", 0)),
                  errors=int(resB_upd.get("errors", 0)),
                  result=resB_upd)
+            cancelled = bool((resB_upd or {}).get("cancelled")) or bool(cancel_requested())
 
-    if add_to_A:
+    if add_to_A and not cancelled:
         if a_down:
             record_unresolved(a, feature, add_to_A, hint="provider_down:add")
             emit("writes:skipped", dst=a, feature=feature, reason="provider_down", op="add", count=len(add_to_A))
@@ -2248,8 +2255,9 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                  unresolved=int(resA_add.get("unresolved", 0)),
                  errors=int(resA_add.get("errors", 0)),
                  result=resA_add)
+            cancelled = bool((resA_add or {}).get("cancelled")) or bool(cancel_requested())
 
-    if add_to_B:
+    if add_to_B and not cancelled:
         if b_down:
             record_unresolved(b, feature, add_to_B, hint="provider_down:add")
             emit("writes:skipped", dst=b, feature=feature, reason="provider_down", op="add", count=len(add_to_B))
@@ -2385,6 +2393,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                  unresolved=int(resB_add.get("unresolved", 0)),
                  errors=int(resB_add.get("errors", 0)),
                  result=resB_add)
+            cancelled = bool((resB_add or {}).get("cancelled")) or bool(cancel_requested())
 
     def _post_apply_refresh(prov: str, inst: str, res: dict[str, Any] | None, ops: Any, eff: dict[str, Any], down: bool) -> None:
         if dry_run_flag or down or not needs_post_apply_refresh(res):
@@ -2426,10 +2435,13 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
              refreshed_count=len(refreshed or {}), first_keys=list(refreshed or {})[:10],
              contains_trace_key=contains_trace, baseline_update_count=base_update)
 
-    _post_apply_refresh(a, src_inst, post_apply_A_res, aops, A_eff, a_down)
-    _post_apply_refresh(b, dst_inst, post_apply_B_res, bops, B_eff, b_down)
+    if not cancelled:
+        _post_apply_refresh(a, src_inst, post_apply_A_res, aops, A_eff, a_down)
+        _post_apply_refresh(b, dst_inst, post_apply_B_res, bops, B_eff, b_down)
 
     try:
+        if cancelled:
+            raise RuntimeError("sync cancelled before checkpoint persistence")
         if not getattr(ctx, "write_state_json", True):
             raise RuntimeError("legacy state persistence disabled")
 
@@ -2600,6 +2612,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
         "skipped": skipped_total,
         "blocked": int(blocked_total),
         "errors": errors_total,
+        "cancelled": bool(cancelled or cancel_requested()),
     }
 
 def run_two_way_feature(

--- a/cw_platform/run_control.py
+++ b/cw_platform/run_control.py
@@ -14,7 +14,7 @@ _LOCK = threading.RLock()
 _STATE: dict[str, Any] = {"run_id": None, "requested_at": None, "reason": "", "queue_stopped": False}
 
 
-class SyncCancelled(RuntimeError):
+class SyncCancelled(BaseException):
     pass
 
 

--- a/providers/sync/_mod_common.py
+++ b/providers/sync/_mod_common.py
@@ -13,8 +13,11 @@ from urllib.parse import parse_qs, urlparse
 import requests
 
 from ._log import log as cw_log
+from cw_platform.run_control import raise_if_cancelled
 
 __VERSION__ = "0.2.1"
+MAX_RETRY_AFTER_SLEEP_S = 60.0
+CANCEL_SLEEP_SLICE_S = 0.25
 __all__ = [
     "HitSession",
     "make_emitter",
@@ -588,6 +591,16 @@ def safe_json(resp: requests.Response) -> Any:
         return {}
 
 
+def _sleep_cancellable(seconds: float) -> None:
+    remaining = max(0.0, float(seconds or 0.0))
+    while remaining > 0:
+        raise_if_cancelled()
+        step = min(CANCEL_SLEEP_SLICE_S, remaining)
+        time.sleep(step)
+        remaining -= step
+    raise_if_cancelled()
+
+
 def request_with_retries(
     session: requests.Session,
     method: str,
@@ -609,6 +622,7 @@ def request_with_retries(
 
     last: Any = None
     for i in range(max(1, int(max_retries))):
+        raise_if_cancelled()
         try:
             t0 = time.monotonic()
             resp = session.request(method, url, timeout=timeout, **kwargs)
@@ -620,7 +634,7 @@ def request_with_retries(
                     if resp.status_code == 429:
                         ra = resp.headers.get("Retry-After")
                         if ra:
-                            retry_after = float(ra)
+                            retry_after = min(float(ra), MAX_RETRY_AFTER_SLEEP_S)
                             wait = max(wait, retry_after)
                 except Exception:
                     pass
@@ -659,7 +673,7 @@ def request_with_retries(
                         dur_ms=dur_ms,
                     )
 
-                time.sleep(wait)
+                _sleep_cancellable(wait)
                 last = resp
                 continue
             return resp
@@ -685,7 +699,7 @@ def request_with_retries(
                     dur_ms=dur_ms,
                     error=f"{type(e).__name__}: {e}",
                 )
-                time.sleep(wait)
+                _sleep_cancellable(wait)
             else:
                 _http_log(
                     session,

--- a/tests/test_sync_cancel.py
+++ b/tests/test_sync_cancel.py
@@ -4,6 +4,7 @@ import sys
 import threading
 import types
 import json
+import time
 from typing import Any
 
 import pytest
@@ -68,6 +69,98 @@ def test_apply_chunked_stops_after_current_chunk() -> None:
     assert seen == [2, 2]
     assert res["cancelled"] is True
     assert res["attempted"] == 4
+
+
+def test_apply_chunked_preserves_counts_when_cancel_raises_mid_batch() -> None:
+    calls = 0
+    events: list[str] = []
+
+    def call(chunk):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            run_control.request_cancel()
+            raise run_control.SyncCancelled("stop")
+        return {"ok": True, "count": len(chunk)}
+
+    res = _applier._apply_chunked(
+        "add",
+        dst="TRAKT",
+        feature="watchlist",
+        items=[{"n": i} for i in range(5)],
+        call=call,
+        emit=lambda event, **_k: events.append(event),
+        dbg=lambda *a, **k: None,
+        chunk_size=2,
+        chunk_pause_ms=0,
+    )
+
+    assert calls == 2
+    assert res["cancelled"] is True
+    assert res["attempted"] == 2
+    assert res["confirmed"] == 2
+    assert "add:cancelled" in events
+
+
+def test_apply_chunked_single_shot_returns_cancelled_when_call_raises() -> None:
+    def call(_items):
+        run_control.request_cancel()
+        raise run_control.SyncCancelled("stop")
+
+    res = _applier._apply_chunked(
+        "add",
+        dst="TRAKT",
+        feature="watchlist",
+        items=[{"n": 1}],
+        call=call,
+        emit=lambda *a, **k: None,
+        dbg=lambda *a, **k: None,
+        chunk_size=0,
+        chunk_pause_ms=0,
+    )
+
+    assert res["cancelled"] is True
+    assert res["attempted"] == 0
+
+
+def test_retry_does_not_retry_sync_cancelled() -> None:
+    calls = 0
+
+    def call():
+        nonlocal calls
+        calls += 1
+        raise run_control.SyncCancelled("stop")
+
+    with pytest.raises(run_control.SyncCancelled):
+        _applier._retry(call, attempts=3, base_sleep=0)
+
+    assert calls == 1
+
+
+def test_apply_chunked_skips_pause_after_cancel(monkeypatch) -> None:
+    slept: list[float] = []
+
+    monkeypatch.setattr(time, "sleep", lambda seconds: slept.append(float(seconds)))
+
+    def call(chunk):
+        run_control.request_cancel()
+        return {"ok": True, "count": len(chunk)}
+
+    res = _applier._apply_chunked(
+        "add",
+        dst="TRAKT",
+        feature="watchlist",
+        items=[{"n": 1}, {"n": 2}],
+        call=call,
+        emit=lambda *a, **k: None,
+        dbg=lambda *a, **k: None,
+        chunk_size=1,
+        chunk_pause_ms=100,
+    )
+
+    assert slept == []
+    assert res["cancelled"] is True
+    assert res["attempted"] == 1
 
 
 def test_apply_chunked_completes_when_not_cancelled() -> None:
@@ -318,3 +411,29 @@ def test_manual_run_clears_a_stale_queue_stop(monkeypatch, tmp_path) -> None:
     sync.clear_queue_stop()
 
     assert run_control.queue_stopped() is False
+
+
+def test_request_with_retries_exits_during_retry_sleep(monkeypatch) -> None:
+    from providers.sync import _mod_common
+
+    class Session:
+        calls = 0
+
+        def request(self, *_args, **_kwargs):
+            self.calls += 1
+            return types.SimpleNamespace(status_code=503, headers={}, text="")
+
+    session = Session()
+    slept: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        slept.append(float(seconds))
+        run_control.request_cancel()
+
+    monkeypatch.setattr(_mod_common.time, "sleep", fake_sleep)
+
+    with pytest.raises(run_control.SyncCancelled):
+        _mod_common.request_with_retries(session, "GET", "https://example.test", max_retries=3)
+
+    assert session.calls == 1
+    assert slept == [0.25]

--- a/tests/test_sync_cancel_orchestrator.py
+++ b/tests/test_sync_cancel_orchestrator.py
@@ -42,6 +42,9 @@ class FakeOps:
         return True
 
     def health(self, cfg: Mapping[str, Any], **_: Any) -> dict[str, Any]:
+        hook = self.hooks.get("health")
+        if hook:
+            hook(self)
         return {"ok": True, "status": "ok", "features": {"watchlist": True}, "api": {}}
 
     def build_index(self, cfg: Mapping[str, Any], *, feature: str) -> Mapping[str, dict[str, Any]]:
@@ -54,6 +57,9 @@ class FakeOps:
     def add(self, cfg, items: Iterable[Mapping[str, Any]], *, feature: str, dry_run: bool = False):
         batch = [dict(x) for x in items]
         self.add_calls.append(batch)
+        hook = self.hooks.get("add")
+        if hook:
+            hook(self)
         if not dry_run:
             for it in batch:
                 k = canonical_key(it)
@@ -64,6 +70,9 @@ class FakeOps:
     def remove(self, cfg, items: Iterable[Mapping[str, Any]], *, feature: str, dry_run: bool = False):
         batch = [dict(x) for x in items]
         self.remove_calls.append(batch)
+        hook = self.hooks.get("remove")
+        if hook:
+            hook(self)
         return {"ok": True, "removed": len(batch), "count": len(batch)}
 
 
@@ -146,6 +155,41 @@ def test_uncancelled_run_still_writes(config_base, monkeypatch) -> None:
     assert result["added"] == 1
 
 
+def test_cancel_during_health_returns_cancelled_summary(config_base, monkeypatch) -> None:
+    src = FakeOps("SRC", {"imdb:tt01": _movie("01")})
+    dst = FakeOps("DST", {})
+
+    def hook(_ops: FakeOps) -> None:
+        run_control.request_cancel()
+        raise run_control.SyncCancelled("stop")
+
+    src.hooks["health"] = hook
+    _wire(monkeypatch, {"SRC": src, "DST": dst})
+
+    result = Orchestrator(_cfg([_pair("p1", "SRC", "DST")])).run()
+
+    assert result["cancelled"] is True
+    assert src.index_calls == []
+    assert dst.add_calls == []
+
+
+def test_cancelled_one_way_apply_skips_feature_checkpoint_persistence(config_base, monkeypatch) -> None:
+    src = FakeOps("SRC", {"imdb:tt01": _movie("01")})
+    dst = FakeOps("DST", {})
+    dst.hooks["add"] = lambda _ops: run_control.request_cancel()
+    _wire(monkeypatch, {"SRC": src, "DST": dst})
+
+    orch = Orchestrator(_cfg([_pair("p1", "SRC", "DST")]))
+    saved: list[object] = []
+    monkeypatch.setattr(orch.state_store, "save_feature_blocks", lambda *a, **k: saved.append((a, k)))
+
+    result = orch.run()
+
+    assert dst.add_calls
+    assert result["cancelled"] is True
+    assert saved == []
+
+
 def _twoway(pid: str, src: str, dst: str) -> dict[str, Any]:
     return {
         "id": pid, "enabled": True, "source": src, "target": dst, "mode": "two-way",
@@ -171,6 +215,21 @@ def test_one_cancel_stops_every_remaining_pair(config_base, monkeypatch) -> None
         assert ops[f"S{i}"].index_calls == [], f"pair {i} source was read"
         assert ops[f"D{i}"].index_calls == [], f"pair {i} target was read"
         assert ops[f"D{i}"].add_calls == [], f"pair {i} was written"
+
+
+def test_two_way_cancel_after_side_a_write_skips_side_b(config_base, monkeypatch) -> None:
+    a = FakeOps("A", {"imdb:tt01": _movie("01")})
+    b = FakeOps("B", {"imdb:tt02": _movie("02")})
+    a.hooks["add"] = lambda _ops: run_control.request_cancel()
+    _wire(monkeypatch, {"A": a, "B": b})
+
+    cfg = _cfg([_twoway("p1", "A", "B")])
+    cfg["sync"]["enable_remove"] = False
+    result = Orchestrator(cfg).run()
+
+    assert a.add_calls, "side A should receive B's missing item"
+    assert b.add_calls == [], "side B should not start after side A requested cancel"
+    assert result["cancelled"] is True
 
 
 def test_cancel_marks_queue_stopped_until_consumed() -> None:


### PR DESCRIPTION
# Pull request

## Change

- Improve sync cancel so it can stop inside a pair at batch boundaries.
- Keeps completed batch counts
- Skips checkpoint persistence on cancelled runs
- Updates the cancel copy from current step to current batch.

## Why

Cancel was limited before and only really stopped between pairs.

## Testing

- tests/test_sync_cancel.py 
- tests/test_sync_cancel_orchestrator.py

## Issue

NA