### PR TITLE
Change: improve dashboard widget refreshes

### DIFF
--- a/api/dashboardAPI.py
+++ b/api/dashboardAPI.py
@@ -3,8 +3,12 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
+import threading
+import traceback
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Mapping, cast
 
@@ -22,25 +26,66 @@ except Exception:  # pragma: no cover
 
 router = APIRouter(prefix="/api/dashboard", tags=["dashboard"])
 
+_PAYLOAD_CACHE: "OrderedDict[str, dict[str, Any]]" = OrderedDict()
+_PAYLOAD_CACHE_LOCK = threading.Lock()
+_PAYLOAD_CACHE_MAX = 8
 
-def _dashboard_db_stamp(base_path: Any) -> tuple[float, float]:
+
+def _cached_widgets_payload(version: str) -> dict[str, Any] | None:
+    if not version:
+        return None
+    with _PAYLOAD_CACHE_LOCK:
+        payload = _PAYLOAD_CACHE.get(version)
+        if payload is None:
+            return None
+        _PAYLOAD_CACHE.move_to_end(version)
+        return copy.deepcopy(payload)
+
+
+def _store_widgets_payload(version: str, payload: Mapping[str, Any]) -> None:
+    if not version:
+        return
+    with _PAYLOAD_CACHE_LOCK:
+        _PAYLOAD_CACHE[version] = copy.deepcopy(dict(payload))
+        _PAYLOAD_CACHE.move_to_end(version)
+        while len(_PAYLOAD_CACHE) > _PAYLOAD_CACHE_MAX:
+            _PAYLOAD_CACHE.popitem(last=False)
+
+
+def clear_dashboard_payload_cache() -> None:
+    with _PAYLOAD_CACHE_LOCK:
+        _PAYLOAD_CACHE.clear()
+
+
+def _dashboard_alias_stamp(requested: set[str]) -> list[tuple[str, int, int]]:
+    if "history" not in requested:
+        return []
     try:
-        from cw_platform.local_db.db import crosswatch_db_path
+        from services.analyzer import CWS_DIR
 
-        db = Path(str(crosswatch_db_path(base_path)))
-        stamp = 0.0
-        wal_stamp = 0.0
-        try:
-            stamp = db.stat().st_mtime
-        except OSError:
-            pass
-        try:
-            wal_stamp = db.with_name(db.name + "-wal").stat().st_mtime
-        except OSError:
-            pass
-        return round(stamp, 3), round(wal_stamp, 3)
+        if not CWS_DIR.is_dir():
+            return []
+        stamp: list[tuple[str, int, int]] = []
+        for path in sorted(CWS_DIR.glob("*history.pair_alias*.json")):
+            try:
+                st = path.stat()
+                stamp.append((path.name, int(st.st_mtime_ns), int(st.st_size)))
+            except OSError:
+                stamp.append((path.name, 0, 0))
+        return stamp
     except Exception:
-        return 0.0, 0.0
+        return []
+
+
+def _dashboard_activity_stamp(base_path: Any, requested: set[str]) -> tuple[Any, ...] | None:
+    if "scrobble" not in requested:
+        return None
+    try:
+        from cw_platform.local_db import activity as sqlite_activity
+
+        return sqlite_activity.fingerprint(base_path)
+    except Exception:
+        return None
 
 
 def _dashboard_config_stamp(base_path: Any) -> float:
@@ -112,9 +157,10 @@ def _dashboard_widgets_version(
         "limits": limits,
         "state": state_fp,
         "policy": policy_fp,
-        "db": _dashboard_db_stamp(base_path),
+        "activity": _dashboard_activity_stamp(base_path, requested),
         "config": _dashboard_config_stamp(base_path),
         "tracker": _dashboard_tracker_stamp(base_path, cfg, requested),
+        "alias": _dashboard_alias_stamp(requested),
     }
     blob = json.dumps(source, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
@@ -160,21 +206,24 @@ def dashboard_widgets(
         )
         if known_version and str(known_version).strip() == version:
             return JSONResponse({"ok": True, "not_modified": True, "version": version}, headers={"Cache-Control": "no-store"})
-        state = StateStore(CONFIG).load_state_features(state_features) if state_features else {}
         scoped = bool(str(profile or "").strip())
-        user_filter = instances_for_user_profile(cfg, profile) if scoped else {}
-        if scoped and not user_filter:
-            user_filter = {"__NONE__": ["__NONE__"]}
-        payload = dashboard_widgets_payload(
-            state,
-            history_limit=history_limit,
-            ratings_limit=ratings_limit,
-            scrobble_limit=scrobble_limit,
-            progress_limit=progress_limit,
-            playlists_limit=playlists_limit,
-            include=requested,
-            user_filter=user_filter,
-        )
+        payload = _cached_widgets_payload(version)
+        if payload is None:
+            state = StateStore(CONFIG).load_state_features(state_features) if state_features else {}
+            user_filter = instances_for_user_profile(cfg, profile) if scoped else {}
+            if scoped and not user_filter:
+                user_filter = {"__NONE__": ["__NONE__"]}
+            payload = dashboard_widgets_payload(
+                state,
+                history_limit=history_limit,
+                ratings_limit=ratings_limit,
+                scrobble_limit=scrobble_limit,
+                progress_limit=progress_limit,
+                playlists_limit=playlists_limit,
+                include=requested,
+                user_filter=user_filter,
+            )
+            _store_widgets_payload(version, payload)
         payload["version"] = version
         if scoped:
             payload["user_profile"] = str(profile or "").strip()
@@ -182,7 +231,10 @@ def dashboard_widgets(
     except Exception as exc:
         try:
             if LOG is not None:
-                LOG.error("dashboard widgets payload failed", extra={"error": f"{type(exc).__name__}: {exc}"})
+                LOG.error(
+                    "dashboard widgets payload failed",
+                    extra={"error": f"{type(exc).__name__}: {exc}", "traceback": traceback.format_exc()},
+                )
         except Exception:
             pass
         return JSONResponse(

--- a/api/wallAPI.py
+++ b/api/wallAPI.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import json
 import threading
+from collections import OrderedDict
 from typing import Any, cast
 from fastapi import FastAPI, Query, Request
 
@@ -19,7 +20,30 @@ from services.watchlist import build_watchlist, detect_available_watchlist_provi
 
 
 _WALL_CACHE_LOCK = threading.Lock()
-_WALL_CACHE: dict[str, Any] = {"key": None, "data": None}
+_WALL_CACHE: "OrderedDict[tuple[Any, ...], dict[str, Any]]" = OrderedDict()
+_WALL_CACHE_MAX = 8
+
+
+def _wall_cache_get(key: tuple[Any, ...]) -> dict[str, Any] | None:
+    with _WALL_CACHE_LOCK:
+        data = _WALL_CACHE.get(key)
+        if data is None:
+            return None
+        _WALL_CACHE.move_to_end(key)
+        return dict(data)
+
+
+def _wall_cache_put(key: tuple[Any, ...], data: dict[str, Any]) -> None:
+    with _WALL_CACHE_LOCK:
+        _WALL_CACHE[key] = dict(data)
+        _WALL_CACHE.move_to_end(key)
+        while len(_WALL_CACHE) > _WALL_CACHE_MAX:
+            _WALL_CACHE.popitem(last=False)
+
+
+def clear_wall_cache() -> None:
+    with _WALL_CACHE_LOCK:
+        _WALL_CACHE.clear()
 
 
 def _path_key(path: Any) -> tuple[str, int, int]:
@@ -184,9 +208,9 @@ def register_wall(app: FastAPI) -> None:
         version = _cache_version(key)
         if known_version and str(known_version).strip() == version:
             return {"ok": True, "not_modified": True, "version": version}
-        with _WALL_CACHE_LOCK:
-            if _WALL_CACHE.get("key") == key and isinstance(_WALL_CACHE.get("data"), dict):
-                return dict(_WALL_CACHE["data"])
+        cached = _wall_cache_get(key)
+        if cached is not None:
+            return cached
 
         st = _load_state()
         api_key = _tmdb_api_key(cfg)
@@ -229,7 +253,5 @@ def register_wall(app: FastAPI) -> None:
             "last_sync_epoch": st.get("last_sync_epoch") if isinstance(st, dict) else None,
             "version": version,
         }
-        with _WALL_CACHE_LOCK:
-            _WALL_CACHE["key"] = key
-            _WALL_CACHE["data"] = data
+        _wall_cache_put(key, data)
         return data

--- a/assets/helpers/watchlist-preview.js
+++ b/assets/helpers/watchlist-preview.js
@@ -17,6 +17,7 @@
   const WALL_PREVIEW_CACHE_KEY = "cw.wall.preview.v2";
   const WALL_PREVIEW_MIGRATION_KEY = "cw.wallPreviewMigrated.v1";
   const WALL_PREVIEW_REFRESH_TTL_MS = 60 * 1000;
+  const WALL_PREVIEW_FETCH_TIMEOUT_MS = 30 * 1000;
   const DEFAULT_INSTANCE = "default";
 
   const migrateWallPreviewCache = () => {
@@ -35,8 +36,15 @@
 
   const json = async (url, opt) => {
     if (authSetupPending()) throw new Error("auth setup pending");
-    if (window.CW?.API?.j && !opt) return window.CW.API.j(url);
-    const res = await fetch(url, { cache: "no-store", ...(opt || {}) });
+    if (window.CW?.API?.j && !opt) return window.CW.API.j(url, {}, WALL_PREVIEW_FETCH_TIMEOUT_MS);
+    const controller = !opt?.signal && typeof AbortController === "function" ? new AbortController() : null;
+    const timer = controller ? window.setTimeout(() => controller.abort("timeout"), WALL_PREVIEW_FETCH_TIMEOUT_MS) : 0;
+    let res;
+    try {
+      res = await fetch(url, { cache: "no-store", ...(opt || {}), signal: opt?.signal || controller?.signal });
+    } finally {
+      if (timer) window.clearTimeout(timer);
+    }
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return res.json();
   };

--- a/assets/js/dashboard-widgets.js
+++ b/assets/js/dashboard-widgets.js
@@ -213,10 +213,16 @@
       const block = data?.[payloadKey] || {};
       const items = Array.isArray(block.items) ? block.items : [];
       const total = Number(block.total ?? items.length);
-      const chipTotal = Number(kind === "scrobble" && block.scrobble_total !== undefined ? block.scrobble_total : (block.total ?? items.length));
+      const rawChipTotal = kind === "scrobble"
+        ? block.scrobble_total
+        : (block.library_total !== undefined ? block.library_total : block.total);
+      const chipTotal = Number(rawChipTotal ?? items.length);
       const [chipId, chipLabel] = WIDGET_COUNT_CHIPS[kind];
       latestTotals[kind] = Math.max(items.length, Number.isFinite(total) ? total : 0);
-      setCountChip(chipId, Math.max(items.length, Number.isFinite(chipTotal) ? chipTotal : latestTotals[kind]), chipLabel);
+      const chipCount = kind === "scrobble"
+        ? Math.max(0, Number.isFinite(chipTotal) ? chipTotal : latestTotals[kind])
+        : Math.max(items.length, Number.isFinite(chipTotal) ? chipTotal : latestTotals[kind]);
+      setCountChip(chipId, chipCount, chipLabel);
       latestItems[kind] = items;
       loadedWidgetKinds.add(kind);
       renderWidget(kind);
@@ -541,8 +547,7 @@
   }
 
   function isTimeoutError(e) {
-    const text = `${e?.name || ""} ${e?.message || ""} ${e || ""}`.toLowerCase();
-    return text.includes("abort") || text.includes("timeout");
+    return e === "timeout" || e?.name === "AbortError";
   }
 
   async function fetchWidgetPayload(url) {
@@ -1506,7 +1511,7 @@
       </div>`;
   }
 
-  function hasWidgetContent(host) {
+  function hasPreservableContent(host) {
     if (!host || !host.children.length) return false;
     if (host.querySelector(".cw-dash-skeleton")) return false;
     const empty = host.querySelector(".cw-dash-empty");
@@ -1515,7 +1520,7 @@
   }
 
   function setWidgetLoadError(host, message, preserve) {
-    if (preserve && hasWidgetContent(host)) return;
+    if (preserve && hasPreservableContent(host)) return;
     setEmpty(host, "error", message);
   }
 
@@ -1539,7 +1544,8 @@
       el.textContent = String(message || "");
       el.classList.remove("hide", "error", "ok");
       el.classList.add(ok ? "ok" : "error");
-      window.setTimeout(() => el.classList.add("hide"), 2200);
+      window.clearTimeout(showWidgetToast._timer);
+      showWidgetToast._timer = window.setTimeout(() => el.classList.add("hide"), 2200);
     } catch {}
   }
 
@@ -1749,7 +1755,8 @@
     const seq = ++loadSeq;
     const refreshVersion = dirtyVersion;
     try { await window.CW?.OverviewProfile?.ready; } catch {}
-    if (seq !== loadSeq || !isOnMain()) return false;
+    if (seq !== loadSeq) return null;
+    if (!isOnMain()) return false;
     if (!hasLoaded) revealFromCache();
     let cfg;
     let widgetUrl = "";
@@ -1771,7 +1778,8 @@
     const settings = widgetSettings(cfg?.ui || cfg?.user_interface || {});
     currentConfig = cfg;
     lastSettings = settings;
-    if (seq !== loadSeq || !isOnMain()) return false;
+    if (seq !== loadSeq) return null;
+    if (!isOnMain()) return false;
     applyVisibility(settings);
     writeCachedSettings(settings, hasTmdbKeyInConfig(cfg));
     const active = activeWidgetSettings(settings);
@@ -1802,9 +1810,11 @@
     try {
       if (!requestedKinds.length) {
         stopSlowLoading();
-        hasLoaded = true;
-        lastLoadedAt = Date.now();
-        widgetsDirty = dirtyVersion !== refreshVersion;
+        if (!partialRefresh) {
+          hasLoaded = true;
+          lastLoadedAt = Date.now();
+          widgetsDirty = dirtyVersion !== refreshVersion;
+        }
         return true;
       }
       const params = new URLSearchParams({
@@ -1817,21 +1827,27 @@
       });
       const userProfile = overviewProfileId();
       if (userProfile) params.set("user_profile", userProfile);
-      if (!force && !partialRefresh && cachedPayload?.version) params.set("known_version", cachedPayload.version);
+      if (!forceConfig && !partialRefresh && cachedPayload?.version) params.set("known_version", cachedPayload.version);
       widgetUrl = `/api/dashboard/widgets?${params.toString()}`;
       widgetStartedAt = Date.now();
       const data = await fetchWidgetPayload(widgetUrl);
       stopSlowLoading();
-      if (seq !== loadSeq || !isOnMain()) return false;
+      if (seq !== loadSeq) return null;
+      if (!isOnMain()) return false;
       if (data?.not_modified && cachedPayload) {
         hasLoaded = true;
         lastLoadedAt = Date.now();
         widgetsDirty = dirtyVersion !== refreshVersion;
+        if (requestedKinds.some((kind) => !hasPreservableContent(hosts[kind]))) {
+          applyWidgetPayload(cachedPayload, active, partialRefresh ? requestedKinds : null);
+        }
         return true;
       }
       const applied = applyWidgetPayload(data, active, partialRefresh ? requestedKinds : null);
-      if (!partialRefresh) writeCachedWidgetData(data);
-      widgetsDirty = dirtyVersion !== refreshVersion;
+      if (!partialRefresh) {
+        writeCachedWidgetData(data);
+        widgetsDirty = dirtyVersion !== refreshVersion;
+      }
       return applied > 0;
     } catch (e) {
       stopSlowLoading();
@@ -1881,6 +1897,7 @@
       setExpandBusy(opts.button, true);
       void refreshDashboardWidgets({ force: true, preserve: true, kinds: [kind] }).then((ok) => {
         setExpandBusy(opts.button, false);
+        if (ok === null) return;
         const loadedEnough = (latestItems[kind]?.length || 0) >= next || widgetTotal(kind) <= current;
         if (!ok && !loadedEnough) {
           visibleCounts[kind] = current;

--- a/cw_platform/local_db/activity.py
+++ b/cw_platform/local_db/activity.py
@@ -203,6 +203,18 @@ def clear_events(base_path: str | Path | None, *, kind: str | None = None) -> di
     return {"existed": before > 0, "removed": removed, "remaining": remaining}
 
 
+def fingerprint(base_path: str | Path | None) -> tuple[Any, ...] | None:
+    conn = get_conn(base_path)
+    if conn is None:
+        return None
+    row = conn.execute(
+        "SELECT COUNT(*), COALESCE(MAX(updated_at),0), COALESCE(MAX(captured_at),0) FROM activity_events"
+    ).fetchone()
+    if row is None:
+        return None
+    return (int(row[0] or 0), int(row[1] or 0), int(row[2] or 0))
+
+
 def event_count(base_path: str | Path | None, *, kind: str | None = None) -> int:
     conn = get_conn(base_path)
     if conn is None:

--- a/services/dashboard_widgets.py
+++ b/services/dashboard_widgets.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
+import heapq
 import re
 from typing import Any, Iterable, Mapping
 
@@ -615,6 +616,7 @@ def _ensure_art_urls(
 
 
 _ART_RESOLVE_WORKERS = 8
+_ROW_WINDOW = 400
 
 
 def _needs_metadata_lookup(row: Mapping[str, Any]) -> bool:
@@ -914,7 +916,9 @@ def latest_ratings_widget(
     limit: int = 12,
     tracker_items: Mapping[str, Any] | None = None,
     user_filter: Mapping[str, Any] | None = None,
+    window: int | None = None,
 ) -> dict[str, Any]:
+    window = window if window is not None else max(_ROW_WINDOW, min(int(limit or 12), 24) * 8)
     rows: dict[str, dict[str, Any]] = {}
     aliases: dict[str, str] = {}
 
@@ -933,14 +937,19 @@ def latest_ratings_widget(
         for alias in _rating_aliases(rows[match_key]):
             aliases[alias] = match_key
 
+    entries: list[tuple[tuple[int, int, str], int, str, dict[str, Any], list[dict[str, str]], bool]] = []
+
+    def _rank(item: Mapping[str, Any]) -> tuple[int, int, str]:
+        return (int(_rating_epoch(item) or 0), int(_update_epoch(item) or 0), str(_title(item) or ""))
+
     for raw_key, raw_item in (tracker_items or {}).items():
         item = _unwrap_rating_item(raw_item)
-        row = _rating_row(str(raw_key), item, _sources_from_item(item))
-        if row:
-            if not _sources_match_user(row.get("sources"), user_filter):
-                continue
-            row[_RATING_TRACKER_FLAG] = True
-            put(row)
+        if _rating_value(item) is None:
+            continue
+        sources = _sources_from_item(item)
+        if not _sources_match_user(sources, user_filter):
+            continue
+        entries.append((_rank(item), len(entries), str(raw_key), item, sources, True))
 
     providers = state.get("providers") if isinstance(state.get("providers"), Mapping) else {}
     provider_keys = sorted({str(p).upper() for p in providers.keys()}) if isinstance(providers, Mapping) else []
@@ -948,29 +957,50 @@ def latest_ratings_widget(
         for instance, block in _provider_blocks(state, provider):
             if not _endpoint_matches_user(provider, instance, user_filter):
                 continue
+            ref = _provider_ref(provider, instance)
             for raw_key, raw_item in _feature_items(block, "ratings").items():
                 item = _unwrap_rating_item(raw_item)
-                row = _rating_row(str(raw_key), item, [_provider_ref(provider, instance)])
-                if not row:
+                if _rating_value(item) is None:
                     continue
-                put(row)
+                entries.append((_rank(item), len(entries), str(raw_key), item, [ref], False))
 
-    items = sorted(
-        rows.values(),
-        key=lambda x: (
-            int(x.get("sort_epoch") or 0),
-            int(x.get("updated_epoch") or 0),
-            str(x.get("title") or ""),
-        ),
-        reverse=True,
-    )
+    library_total = len(entries)
     cap = max(1, min(int(limit or 12), 24))
+
+    def _build(selected: list) -> list[dict[str, Any]]:
+        rows.clear()
+        aliases.clear()
+        for _rank_key, _ordinal, raw_key, item, sources, from_tracker in selected:
+            row = _rating_row(raw_key, item, sources)
+            if not row:
+                continue
+            if from_tracker:
+                row[_RATING_TRACKER_FLAG] = True
+            put(row)
+        return sorted(
+            rows.values(),
+            key=lambda x: (
+                int(x.get("sort_epoch") or 0),
+                int(x.get("updated_epoch") or 0),
+                str(x.get("title") or ""),
+            ),
+            reverse=True,
+        )
+
+    windowed = entries
+    if window is not None and window > 0 and len(entries) > window:
+        windowed = heapq.nlargest(window, entries, key=lambda entry: entry[0])
+        windowed.sort(key=lambda entry: entry[1])
+
+    items = _build(windowed)
+    if len(items) < cap and len(windowed) < len(entries):
+        items = _build(entries)
     selected = _resolve_missing_art_rows(
         items[:cap], size="w300", episode_still=True, backdrop_fallback=True, resolve_art_type=True
     )
     for row in selected:
         row.pop(_RATING_TRACKER_FLAG, None)
-    return {"ok": True, "items": selected, "total": len(items)}
+    return {"ok": True, "items": selected, "total": len(items), "library_total": library_total}
 
 
 def _activity_row(event: Mapping[str, Any]) -> dict[str, Any]:
@@ -1120,42 +1150,92 @@ def _history_aliases(row: Mapping[str, Any], alias_map: Mapping[str, str] | None
     return aliases
 
 
-def _latest_history_state_rows(state: Mapping[str, Any], *, user_filter: Mapping[str, Any] | None = None) -> list[dict[str, Any]]:
+def _latest_history_state_rows(
+    state: Mapping[str, Any],
+    *,
+    user_filter: Mapping[str, Any] | None = None,
+    window: int | None = None,
+) -> list[dict[str, Any]]:
     rows: dict[str, dict[str, Any]] = {}
+    entries: list[tuple[int, int, str, dict[str, Any], dict[str, str]]] = []
+    for provider, instance, block in _history_provider_blocks(state, user_filter):
+        ref = _provider_ref(provider, instance)
+        for raw_key, raw_item in _feature_items(block, "history").items():
+            item = _unwrap_history_item(raw_item)
+            key = str(raw_key)
+            epoch = int(_history_sort_epoch(item) or _history_key_epoch(key) or 0)
+            entries.append((epoch, len(entries), key, item, ref))
+    if window is not None and window > 0 and len(entries) > window:
+        entries = heapq.nlargest(window, entries, key=lambda entry: entry[0])
+        entries.sort(key=lambda entry: entry[1])
+    for _epoch, _ordinal, raw_key, item, ref in entries:
+        row = _history_state_row(raw_key, item, [ref])
+        if not row:
+            continue
+        key = str(row["key"])
+        prev = rows.get(key)
+        if not prev:
+            rows[key] = row
+            continue
+        prev_sources = prev.setdefault("sources", [])
+        for src in row.get("sources") or []:
+            if src not in prev_sources:
+                prev_sources.append(src)
+        if int(row.get("sort_epoch") or 0) >= int(prev.get("sort_epoch") or 0):
+            row["sources"] = prev_sources
+            rows[key] = row
+    return sorted(rows.values(), key=lambda x: int(x.get("sort_epoch") or 0), reverse=True)
+
+
+def _history_provider_blocks(state: Mapping[str, Any], user_filter: Mapping[str, Any] | None):
     providers = state.get("providers") if isinstance(state.get("providers"), Mapping) else {}
     provider_keys = sorted({str(p).upper() for p in providers.keys()}) if isinstance(providers, Mapping) else []
     for provider in provider_keys:
         for instance, block in _provider_blocks(state, provider):
             if not _endpoint_matches_user(provider, instance, user_filter):
                 continue
-            for raw_key, raw_item in _feature_items(block, "history").items():
-                item = _unwrap_history_item(raw_item)
-                row = _history_state_row(str(raw_key), item, [_provider_ref(provider, instance)])
-                if not row:
-                    continue
-                key = str(row["key"])
-                prev = rows.get(key)
-                if not prev:
-                    rows[key] = row
-                    continue
-                prev_sources = prev.setdefault("sources", [])
-                for src in row.get("sources") or []:
-                    if src not in prev_sources:
-                        prev_sources.append(src)
-                if int(row.get("sort_epoch") or 0) >= int(prev.get("sort_epoch") or 0):
-                    row["sources"] = prev_sources
-                    rows[key] = row
-    return sorted(rows.values(), key=lambda x: int(x.get("sort_epoch") or 0), reverse=True)
+            yield provider, instance, block
 
 
-def _latest_history_tracker_rows(items: Mapping[str, Any], *, user_filter: Mapping[str, Any] | None = None) -> list[dict[str, Any]]:
-    rows: dict[str, dict[str, Any]] = {}
-    for raw_key, raw_item in (items or {}).items():
-        item = _unwrap_history_item(raw_item)
-        row = _history_state_row(str(raw_key), item, _sources_from_item(item))
-        if not row:
+def _history_library_total(
+    state: Mapping[str, Any],
+    tracker_items: Mapping[str, Any] | None,
+    *,
+    user_filter: Mapping[str, Any] | None = None,
+) -> int:
+    scoped = bool(_normalize_user_filter(user_filter))
+    seen: set[str] = set()
+    for raw_key, raw_item in (tracker_items or {}).items():
+        if scoped and not _sources_match_user(_sources_from_item(_unwrap_history_item(raw_item)), user_filter):
             continue
-        if not _sources_match_user(row.get("sources"), user_filter):
+        seen.add(str(raw_key))
+    for _provider, _instance, block in _history_provider_blocks(state or {}, user_filter):
+        seen.update(str(raw_key) for raw_key in _feature_items(block, "history").keys())
+    return len(seen)
+
+
+def _latest_history_tracker_rows(
+    items: Mapping[str, Any],
+    *,
+    user_filter: Mapping[str, Any] | None = None,
+    window: int | None = None,
+) -> list[dict[str, Any]]:
+    entries: list[tuple[int, int, str, dict[str, Any], list[dict[str, str]]]] = []
+    for ordinal, (raw_key, raw_item) in enumerate((items or {}).items()):
+        item = _unwrap_history_item(raw_item)
+        sources = _sources_from_item(item)
+        if not _sources_match_user(sources, user_filter):
+            continue
+        key = str(raw_key)
+        epoch = int(_history_sort_epoch(item) or _history_key_epoch(key) or 0)
+        entries.append((epoch, ordinal, key, item, sources))
+    if window is not None and window > 0 and len(entries) > window:
+        entries = heapq.nlargest(window, entries, key=lambda entry: entry[0])
+        entries.sort(key=lambda entry: entry[1])
+    rows: dict[str, dict[str, Any]] = {}
+    for _epoch, _ordinal, raw_key, item, sources in entries:
+        row = _history_state_row(raw_key, item, sources)
+        if not row:
             continue
         rows[str(row["key"])] = row
     return sorted(rows.values(), key=lambda x: int(x.get("sort_epoch") or 0), reverse=True)
@@ -1199,11 +1279,22 @@ def recent_history_widget(
     user_filter: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     cap = max(1, min(int(limit or 8), 24))
-    state_rows = _latest_history_state_rows(state or {}, user_filter=user_filter)
-    tracker_rows = _latest_history_tracker_rows(tracker_items or {}, user_filter=user_filter)
-    rows = _merge_history_rows(state_rows, tracker_rows, alias_map=_history_alias_representatives())
+    window = max(_ROW_WINDOW, cap * 8)
+    alias_map = _history_alias_representatives()
+    state_rows = _latest_history_state_rows(state or {}, user_filter=user_filter, window=window)
+    tracker_rows = _latest_history_tracker_rows(tracker_items or {}, user_filter=user_filter, window=window)
+    rows = _merge_history_rows(state_rows, tracker_rows, alias_map=alias_map)
+    if len(rows) < cap and (len(state_rows) >= window or len(tracker_rows) >= window):
+        state_rows = _latest_history_state_rows(state or {}, user_filter=user_filter, window=None)
+        tracker_rows = _latest_history_tracker_rows(tracker_items or {}, user_filter=user_filter, window=None)
+        rows = _merge_history_rows(state_rows, tracker_rows, alias_map=alias_map)
     selected = _resolve_missing_art_rows(rows[:cap], size="w300", episode_still=True)
-    return {"ok": True, "items": selected, "total": len(rows)}
+    return {
+        "ok": True,
+        "items": selected,
+        "total": len(rows),
+        "library_total": _history_library_total(state or {}, tracker_items, user_filter=user_filter),
+    }
 
 
 def recent_scrobble_widget(*, limit: int = 8, user_filter: Mapping[str, Any] | None = None) -> dict[str, Any]:

--- a/tests/test_dashboard_widgets.py
+++ b/tests/test_dashboard_widgets.py
@@ -1165,6 +1165,127 @@ def test_recent_scrobble_widget_reports_scrobble_total_separately(monkeypatch) -
     assert payload["scrobble_hours"] == 0.0
 
 
+def _history_tracker_items(count: int) -> dict:
+    return {
+        f"movie:tmdb:{idx}": {
+            "type": "movie",
+            "title": f"Movie {idx}",
+            "year": 2000 + (idx % 20),
+            "ids": {"tmdb": 900000 + idx},
+            "watched_at": f"2026-01-01T00:00:{idx % 60:02d}Z",
+            "watched": True,
+            "_epoch": 1767225600 + idx,
+        }
+        for idx in range(count)
+    }
+
+
+def test_recent_history_widget_windowing_keeps_newest_items(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_widgets, "_resolve_missing_art_rows", lambda rows, **_kwargs: rows)
+    monkeypatch.setattr(dashboard_widgets, "_history_alias_representatives", lambda: {})
+
+    count = dashboard_widgets._ROW_WINDOW * 3
+    items = _history_tracker_items(count)
+    for idx, key in enumerate(items):
+        items[key]["watched_at"] = 1767225600 + idx
+
+    payload = dashboard_widgets.recent_history_widget({}, limit=6, tracker_items=items)
+    titles = [row["title"] for row in payload["items"]]
+
+    assert titles == [f"Movie {idx}" for idx in range(count - 1, count - 7, -1)]
+    assert payload["library_total"] == count
+
+
+def test_recent_history_widget_window_matches_unwindowed_top_rows(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_widgets, "_resolve_missing_art_rows", lambda rows, **_kwargs: rows)
+    monkeypatch.setattr(dashboard_widgets, "_history_alias_representatives", lambda: {})
+
+    items = _history_tracker_items(dashboard_widgets._ROW_WINDOW * 2)
+    for idx, key in enumerate(items):
+        items[key]["watched_at"] = 1767225600 + idx
+
+    windowed = dashboard_widgets._latest_history_tracker_rows(items, window=dashboard_widgets._ROW_WINDOW)
+    full = dashboard_widgets._latest_history_tracker_rows(items, window=None)
+
+    assert [row["key"] for row in windowed[:24]] == [row["key"] for row in full[:24]]
+    assert len(windowed) <= dashboard_widgets._ROW_WINDOW
+    assert len(full) == len(items)
+
+
+def _rating_tracker_items(count: int, *, same_epoch: bool) -> dict:
+    return {
+        f"movie:tmdb:{idx}": {
+            "type": "movie",
+            "title": f"Rating {idx:05d}",
+            "year": 2000 + (idx % 20),
+            "ids": {"tmdb": 800000 + idx},
+            "rating": (idx % 10) + 1,
+            "rated_at": "2026-01-01T00:00:00Z" if same_epoch else f"2026-01-01T00:00:{idx % 60:02d}Z",
+        }
+        for idx in range(count)
+    }
+
+
+def test_latest_ratings_widget_window_respects_full_sort_tiebreak(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_widgets, "_resolve_missing_art_rows", lambda rows, **_kwargs: rows)
+
+    items = _rating_tracker_items(dashboard_widgets._ROW_WINDOW * 2, same_epoch=True)
+
+    windowed = dashboard_widgets.latest_ratings_widget(
+        {}, limit=24, tracker_items=items, window=dashboard_widgets._ROW_WINDOW
+    )
+    full = dashboard_widgets.latest_ratings_widget({}, limit=24, tracker_items=items, window=0)
+
+    assert [row["title"] for row in windowed["items"]] == [row["title"] for row in full["items"]]
+    assert windowed["library_total"] == full["library_total"] == len(items)
+
+
+def test_latest_ratings_widget_widens_window_when_merge_underfills(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_widgets, "_resolve_missing_art_rows", lambda rows, **_kwargs: rows)
+
+    items = _rating_tracker_items(100, same_epoch=False)
+    payload = dashboard_widgets.latest_ratings_widget({}, limit=24, tracker_items=items, window=5)
+
+    assert len(payload["items"]) == 24
+
+
+def test_recent_history_widget_widens_window_when_merge_underfills(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_widgets, "_resolve_missing_art_rows", lambda rows, **_kwargs: rows)
+    monkeypatch.setattr(dashboard_widgets, "_history_alias_representatives", lambda: {})
+    monkeypatch.setattr(dashboard_widgets, "_ROW_WINDOW", 2)
+
+    items = _history_tracker_items(100)
+    for idx, key in enumerate(items):
+        items[key]["watched_at"] = 1767225600 + idx
+
+    payload = dashboard_widgets.recent_history_widget({}, limit=24, tracker_items=items)
+
+    assert len(payload["items"]) == 24
+
+
+def test_dashboard_widgets_api_version_tracks_history_alias_files(monkeypatch, tmp_path) -> None:
+    import cw_platform.config_base as config_base
+    from api import dashboardAPI
+    from services import analyzer
+
+    alias_dir = tmp_path / ".cw_state"
+    alias_dir.mkdir()
+    alias_file = alias_dir / "PLEX-TRAKT.history.pair_alias.json"
+    alias_file.write_text('{"a": 1}', encoding="utf-8")
+
+    monkeypatch.setattr(config_base, "CONFIG", tmp_path)
+    monkeypatch.setattr(analyzer, "CWS_DIR", alias_dir)
+    monkeypatch.setattr(dashboard_widgets, "_tracker_feature_items", lambda _kind: {})
+    dashboardAPI.clear_dashboard_payload_cache()
+
+    first = dashboardAPI.dashboard_widgets(include="history", history_limit=8)
+    alias_file.write_text('{"a": 2, "b": 3}', encoding="utf-8")
+    second = dashboardAPI.dashboard_widgets(include="history", history_limit=8)
+
+    assert _loads_body(first.body)["version"] != _loads_body(second.body)["version"]
+    dashboardAPI.clear_dashboard_payload_cache()
+
+
 def test_recent_scrobble_widget_total_is_not_page_limited(monkeypatch) -> None:
     rows = [
         {
@@ -1540,6 +1661,58 @@ def test_dashboard_widgets_api_returns_not_modified_for_known_version(monkeypatc
     assert payload == {"ok": True, "not_modified": True, "version": version}
 
 
+def test_dashboard_widgets_api_reuses_payload_for_same_version(monkeypatch, tmp_path) -> None:
+    import cw_platform.config_base as config_base
+    from api import dashboardAPI
+
+    monkeypatch.setattr(config_base, "CONFIG", tmp_path)
+    monkeypatch.setattr(dashboard_widgets, "_tracker_feature_items", lambda _kind: {})
+    dashboardAPI.clear_dashboard_payload_cache()
+
+    first = dashboardAPI.dashboard_widgets(
+        history_limit=8,
+        ratings_limit=12,
+        scrobble_limit=8,
+        progress_limit=8,
+        playlists_limit=8,
+        include="history",
+    )
+    first_payload = _loads_body(first.body)
+
+    monkeypatch.setattr(
+        dashboardAPI,
+        "dashboard_widgets_payload",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("payload should not rebuild")),
+    )
+
+    second = dashboardAPI.dashboard_widgets(
+        history_limit=8,
+        ratings_limit=12,
+        scrobble_limit=8,
+        progress_limit=8,
+        playlists_limit=8,
+        include="history",
+    )
+
+    assert _loads_body(second.body) == first_payload
+    dashboardAPI.clear_dashboard_payload_cache()
+
+
+def test_dashboard_widgets_api_rebuilds_when_version_changes(monkeypatch, tmp_path) -> None:
+    import cw_platform.config_base as config_base
+    from api import dashboardAPI
+
+    monkeypatch.setattr(config_base, "CONFIG", tmp_path)
+    monkeypatch.setattr(dashboard_widgets, "_tracker_feature_items", lambda _kind: {})
+    dashboardAPI.clear_dashboard_payload_cache()
+
+    first = dashboardAPI.dashboard_widgets(include="history", history_limit=8)
+    second = dashboardAPI.dashboard_widgets(include="history", history_limit=12)
+
+    assert _loads_body(first.body)["version"] != _loads_body(second.body)["version"]
+    dashboardAPI.clear_dashboard_payload_cache()
+
+
 def test_dashboard_widgets_api_version_tracks_crosswatch_tracker_files(monkeypatch, tmp_path) -> None:
     import cw_platform.config_base as config_base
     from api import dashboardAPI
@@ -1602,7 +1775,7 @@ def test_dashboard_widget_frontend_uses_cached_payload_version() -> None:
     assert "window.CW.API.j(url, {}, WIDGET_FETCH_TIMEOUT_MS)" in js
     assert 'controller.abort("timeout")' in js
     assert "function isTimeoutError(e)" in js
-    assert '${e?.name || \"\"} ${e?.message || \"\"} ${e || \"\"}' in js
+    assert 'return e === "timeout" || e?.name === "AbortError";' in js
     assert "if (isTimeoutError(e)) break;" in js
     assert "const WIDGET_LOADING_DELAY_MS = 700;" in js
     assert 'const REFRESHABLE_WIDGETS = ["history", "ratings", "scrobble", "progress", "playlists"];' in js
@@ -1611,14 +1784,15 @@ def test_dashboard_widget_frontend_uses_cached_payload_version() -> None:
     assert "async function refreshDashboardWidgets({ forceConfig = false, force = false, preserve = true, kinds = null } = {})" in js
     assert 'params.set("known_version", cachedPayload.version)' in js
     assert "if (data?.not_modified && cachedPayload)" in js
+    assert "if (requestedKinds.some((kind) => !hasPreservableContent(hosts[kind]))) {" in js
     assert "applyWidgetPayload(cached, active)" in js
     assert "if (!hasLoaded && cachedPayload)" in js
     assert "applyWidgetPayload(cachedPayload, active)" in js
     assert "const preserve = opts.preserve === false ? hasLoaded : true;" in js
-    assert "try { await window.CW?.OverviewProfile?.ready; } catch {}\n    if (seq !== loadSeq || !isOnMain()) return false;\n    if (!hasLoaded) revealFromCache();" in js
+    assert "try { await window.CW?.OverviewProfile?.ready; } catch {}\n    if (seq !== loadSeq) return null;\n    if (!isOnMain()) return false;\n    if (!hasLoaded) revealFromCache();" in js
     assert "function scheduleSlowWidgetLoading(hosts, requestedKinds)" in js
     assert "if (!loadedWidgetKinds.has(kind)) setLoading(hosts[kind], kind);" in js
-    assert "function hasWidgetContent(host)" in js
+    assert "function hasPreservableContent(host)" in js
     assert "function setWidgetLoadError(host, message, preserve)" in js
     assert "function showWidgetToast(message, ok = false)" in js
     assert "function setExpandBusy(btn, busy)" in js
@@ -1629,15 +1803,16 @@ def test_dashboard_widget_frontend_uses_cached_payload_version() -> None:
     assert "function expandWidget(kind, opts = {})" in js
     assert "if (!REFRESHABLE_WIDGETS.includes(kind)) return false;" in js
     assert 'refreshDashboardWidgets({ force: true, preserve: true, kinds: [kind] })' in js
+    assert "if (ok === null) return;" in js
     assert "visibleCounts[kind] = current;" in js
     assert 'showWidgetToast("Could not load more items.");' in js
     assert "if (!wanted) lastLoadedAt = Date.now();" in js
     assert "window.console.warn(\"[CrossWatch] dashboard widgets refresh failed\"" in js
     assert 'const shouldShowWidgetError = (kind) => active[kind] && (!partialRefresh || requestedKinds.includes(kind));' in js
+    assert "if (!partialRefresh) {\n        writeCachedWidgetData(data);\n        widgetsDirty = dirtyVersion !== refreshVersion;\n      }" in js
     assert "const requestedKinds = REFRESHABLE_WIDGETS.filter((key) => active[key] && (!wantedKinds || wantedKinds.has(key)));" in js
     assert "mergeWidgetPayload" not in js
     assert "loadedKinds" not in js
-    assert "if (!partialRefresh) writeCachedWidgetData(data);" in js
     assert "refreshDashboardWidgets({ preserve: true });" in js
     assert "refreshDashboardWidgets({ forceConfig: true, preserve: true })" in js
     assert 'window.addEventListener("sync-complete", refreshForSyncComplete);' in js

--- a/tests/test_wall_api.py
+++ b/tests/test_wall_api.py
@@ -89,6 +89,10 @@ def test_watchlist_preview_uses_cached_wall_version() -> None:
     js = Path("assets/helpers/watchlist-preview.js").read_text("utf-8")
 
     assert "version" in js
+    assert "const WALL_PREVIEW_FETCH_TIMEOUT_MS = 30 * 1000;" in js
+    assert "window.CW.API.j(url, {}, WALL_PREVIEW_FETCH_TIMEOUT_MS)" in js
+    assert 'const controller = !opt?.signal && typeof AbortController === "function" ? new AbortController() : null;' in js
+    assert 'controller.abort("timeout")' in js
     assert 'params.set("known_version", cached.version)' in js
     assert "if (data?.not_modified && cached?.items?.length)" in js
     assert "preserveIfSame: true" in js


### PR DESCRIPTION
# Pull request

## Change

- Speed up dashboard widget refreshes by only building the rows needed for the first page
- Improving cache reuse
- Adding longer timeouts for dashboard/watchlist widget requests.

## Why

- Some users with large libraries could hit widget load errors during automatic refreshes, especially on slower NAS/Docker setups.

## Testing

- tests/test_dashboard_widgets.py 
- tests/test_wall_api.py

## Issue

Relates to #985