### PR TITLE
Fix: always rebuild blank dashboard

### DIFF
--- a/assets/js/dashboard-widgets.js
+++ b/assets/js/dashboard-widgets.js
@@ -1827,7 +1827,8 @@
       });
       const userProfile = overviewProfileId();
       if (userProfile) params.set("user_profile", userProfile);
-      if (!forceConfig && !partialRefresh && cachedPayload?.version) params.set("known_version", cachedPayload.version);
+      const anyWidgetBlank = requestedKinds.some((kind) => !(latestItems[kind]?.length));
+      if (!forceConfig && !anyWidgetBlank && !partialRefresh && cachedPayload?.version) params.set("known_version", cachedPayload.version);
       widgetUrl = `/api/dashboard/widgets?${params.toString()}`;
       widgetStartedAt = Date.now();
       const data = await fetchWidgetPayload(widgetUrl);

--- a/tests/test_dashboard_widgets.py
+++ b/tests/test_dashboard_widgets.py
@@ -1783,6 +1783,8 @@ def test_dashboard_widget_frontend_uses_cached_payload_version() -> None:
     assert "block.scrobble_total" in js
     assert "async function refreshDashboardWidgets({ forceConfig = false, force = false, preserve = true, kinds = null } = {})" in js
     assert 'params.set("known_version", cachedPayload.version)' in js
+    assert "const anyWidgetBlank = requestedKinds.some((kind) => !(latestItems[kind]?.length));" in js
+    assert "if (!forceConfig && !anyWidgetBlank && !partialRefresh && cachedPayload?.version)" in js
     assert "if (data?.not_modified && cachedPayload)" in js
     assert "if (requestedKinds.some((kind) => !hasPreservableContent(hosts[kind]))) {" in js
     assert "applyWidgetPayload(cached, active)" in js


### PR DESCRIPTION
# Pull request

## Change

- Blank dashboard widgets no longer send known_version, so they always get a real build.

## Why

- A widget with no items could get not_modified back and just stay empty. 

## Testing

- tests/test_dashboard_widgets.py

## Issue

NA
