### PR TITLE
Change: cheaper dashboard widget loading on large libraries

### DIFF
--- a/api/dashboardAPI.py
+++ b/api/dashboardAPI.py
@@ -52,9 +52,65 @@ def _store_widgets_payload(version: str, payload: Mapping[str, Any]) -> None:
             _PAYLOAD_CACHE.popitem(last=False)
 
 
+_PAYLOAD_INFLIGHT: dict[str, threading.Event] = {}
+_PAYLOAD_BUILD_WAIT_SECONDS = 55.0
+_STATE_RECENT_LIMIT = 400
+_COUNT_FEATURES = {
+    "history": "recent_history",
+    "ratings": "latest_ratings",
+    "progress": "recent_progress",
+}
+
+
+def _feature_library_totals(base_path: Any, requested: set[str], user_filter: Mapping[str, Any]) -> dict[str, int]:
+    wanted = requested & set(_COUNT_FEATURES)
+    if not wanted:
+        return {}
+    scoped = {str(provider or "").strip().upper() for provider in (user_filter or {})}
+    try:
+        from cw_platform.orchestrator._state_store import StateStore
+
+        store = StateStore(base_path)
+    except Exception:
+        return {}
+    totals: dict[str, int] = {}
+    for feature in sorted(wanted):
+        try:
+            counts = store.provider_feature_counts(feature) or {}
+        except Exception:
+            continue
+        values = [
+            int(value or 0)
+            for provider, value in counts.items()
+            if not scoped or str(provider or "").strip().upper() in scoped
+        ]
+        totals[feature] = max(values) if values else 0
+    return totals
+
+
+def _begin_widgets_build(version: str) -> tuple[threading.Event, bool]:
+    with _PAYLOAD_CACHE_LOCK:
+        event = _PAYLOAD_INFLIGHT.get(version)
+        if event is not None:
+            return event, False
+        event = threading.Event()
+        _PAYLOAD_INFLIGHT[version] = event
+        return event, True
+
+
+def _finish_widgets_build(version: str) -> None:
+    with _PAYLOAD_CACHE_LOCK:
+        event = _PAYLOAD_INFLIGHT.pop(version, None)
+    if event is not None:
+        event.set()
+
+
 def clear_dashboard_payload_cache() -> None:
     with _PAYLOAD_CACHE_LOCK:
         _PAYLOAD_CACHE.clear()
+        for event in _PAYLOAD_INFLIGHT.values():
+            event.set()
+        _PAYLOAD_INFLIGHT.clear()
 
 
 def _dashboard_alias_stamp(requested: set[str]) -> list[tuple[str, int, int]]:
@@ -209,21 +265,38 @@ def dashboard_widgets(
         scoped = bool(str(profile or "").strip())
         payload = _cached_widgets_payload(version)
         if payload is None:
-            state = StateStore(CONFIG).load_state_features(state_features) if state_features else {}
-            user_filter = instances_for_user_profile(cfg, profile) if scoped else {}
-            if scoped and not user_filter:
-                user_filter = {"__NONE__": ["__NONE__"]}
-            payload = dashboard_widgets_payload(
-                state,
-                history_limit=history_limit,
-                ratings_limit=ratings_limit,
-                scrobble_limit=scrobble_limit,
-                progress_limit=progress_limit,
-                playlists_limit=playlists_limit,
-                include=requested,
-                user_filter=user_filter,
-            )
-            _store_widgets_payload(version, payload)
+            build_event, build_owner = _begin_widgets_build(version)
+            try:
+                if not build_owner:
+                    build_event.wait(timeout=_PAYLOAD_BUILD_WAIT_SECONDS)
+                    payload = _cached_widgets_payload(version)
+                if payload is None:
+                    state = (
+                        StateStore(CONFIG).load_state_features(state_features, recent_limit=_STATE_RECENT_LIMIT)
+                        if state_features
+                        else {}
+                    )
+                    user_filter = instances_for_user_profile(cfg, profile) if scoped else {}
+                    if scoped and not user_filter:
+                        user_filter = {"__NONE__": ["__NONE__"]}
+                    payload = dashboard_widgets_payload(
+                        state,
+                        history_limit=history_limit,
+                        ratings_limit=ratings_limit,
+                        scrobble_limit=scrobble_limit,
+                        progress_limit=progress_limit,
+                        playlists_limit=playlists_limit,
+                        include=requested,
+                        user_filter=user_filter,
+                    )
+                    for feature, total in _feature_library_totals(CONFIG, requested, user_filter).items():
+                        block = payload.get(_COUNT_FEATURES[feature])
+                        if isinstance(block, dict):
+                            block["library_total"] = total
+                    _store_widgets_payload(version, payload)
+            finally:
+                if build_owner:
+                    _finish_widgets_build(version)
         payload["version"] = version
         if scoped:
             payload["user_profile"] = str(profile or "").strip()

--- a/assets/js/dashboard-widgets.js
+++ b/assets/js/dashboard-widgets.js
@@ -24,7 +24,7 @@
   const UNITS = 2;
   const WIDE_UNITS = 3;
   const WIDGET_REFRESH_TTL_MS = 60 * 1000;
-  const WIDGET_FETCH_TIMEOUT_MS = 30 * 1000;
+  const WIDGET_FETCH_TIMEOUT_MS = 60 * 1000;
   const WIDGET_FETCH_RETRY_DELAYS = [350, 900, 1800];
   const WIDGET_LOADING_DELAY_MS = 700;
   const REFRESHABLE_WIDGETS = ["history", "ratings", "scrobble", "progress", "playlists"];
@@ -509,11 +509,8 @@
 
   function refreshForSyncComplete(event) {
     const kinds = widgetKindsFromSyncEvent(event);
-    if (kinds === null) {
-      markWidgetsDirty(250);
-    } else if (kinds.length) {
-      markWidgetsDirty(250, { kinds });
-    }
+    if (kinds && kinds.length) markWidgetsDirty(250, { kinds });
+    else markWidgetsDirty(250);
   }
 
   function scheduleScrobbleStopRefresh() {

--- a/cw_platform/local_db/state.py
+++ b/cw_platform/local_db/state.py
@@ -481,7 +481,18 @@ def has_state(base_path: str | Path) -> bool:
     return bool(row and int(row[0] or 0) > 0)
 
 
-def _build_state_from_feature_rows(conn: sqlite3.Connection, rows: list[sqlite3.Row]) -> dict[str, Any]:
+_RECENT_ORDER_COLUMNS = {
+    "history": "watched_at",
+    "ratings": "rated_at",
+}
+
+
+def _build_state_from_feature_rows(
+    conn: sqlite3.Connection,
+    rows: list[sqlite3.Row],
+    *,
+    recent_limit: int | None = None,
+) -> dict[str, Any]:
     providers: dict[str, Any] = {}
     wall: list[dict[str, Any]] = []
     for pfs in rows:
@@ -496,10 +507,17 @@ def _build_state_from_feature_rows(conn: sqlite3.Connection, rows: list[sqlite3.
         checkpoint = _scalar_from_row(pfs, "checkpoint")
         if checkpoint is not None:
             feat_node["checkpoint"] = checkpoint
-        items = conn.execute(
-            "SELECT * FROM baseline_items WHERE provider_state_id=? ORDER BY item_key",
-            (int(pfs["id"]),),
-        ).fetchall()
+        order_column = _RECENT_ORDER_COLUMNS.get(feature) if recent_limit else None
+        if order_column:
+            items = conn.execute(
+                f"SELECT * FROM baseline_items WHERE provider_state_id=? ORDER BY {order_column} DESC LIMIT ?",
+                (int(pfs["id"]), int(recent_limit)),
+            ).fetchall()
+        else:
+            items = conn.execute(
+                "SELECT * FROM baseline_items WHERE provider_state_id=? ORDER BY item_key",
+                (int(pfs["id"]),),
+            ).fetchall()
         for row in items:
             item = _row_to_item(row)
             feat_node["baseline"]["items"][str(row["item_key"])] = item
@@ -532,7 +550,12 @@ def load_state(base_path: str | Path) -> dict[str, Any]:
         return state
 
 
-def load_state_features(base_path: str | Path, features: set[str] | list[str] | tuple[str, ...]) -> dict[str, Any]:
+def load_state_features(
+    base_path: str | Path,
+    features: set[str] | list[str] | tuple[str, ...],
+    *,
+    recent_limit: int | None = None,
+) -> dict[str, Any]:
     wanted = sorted({str(feature or "").strip().lower() for feature in features or [] if str(feature or "").strip()})
     if not wanted:
         return {"providers": {}, "wall": [], "last_sync_epoch": None}
@@ -545,7 +568,7 @@ def load_state_features(base_path: str | Path, features: set[str] | list[str] | 
             f"SELECT * FROM provider_feature_state WHERE feature IN ({placeholders}) ORDER BY provider, instance, feature",
             wanted,
         ).fetchall()
-        return _build_state_from_feature_rows(conn, rows)
+        return _build_state_from_feature_rows(conn, rows, recent_limit=recent_limit)
 
 
 def provider_feature_counts(base_path: str | Path, feature: str = "watchlist") -> dict[str, int]:

--- a/cw_platform/orchestrator/_state_store.py
+++ b/cw_platform/orchestrator/_state_store.py
@@ -157,9 +157,14 @@ class StateStore:
                 out["providers"][str(provider)] = dst
         return out
 
-    def load_state_features(self, features: set[str] | list[str] | tuple[str, ...]) -> dict[str, Any]:
+    def load_state_features(
+        self,
+        features: set[str] | list[str] | tuple[str, ...],
+        *,
+        recent_limit: int | None = None,
+    ) -> dict[str, Any]:
         wanted = {str(feature or "").strip().lower() for feature in features or [] if str(feature or "").strip()}
-        state = sqlite_state.load_state_features(self.base_path, features)
+        state = sqlite_state.load_state_features(self.base_path, features, recent_limit=recent_limit)
         policy = self._filter_policy_features(sqlite_manual_policy.load_policy(self.base_path), wanted)
         return self._merge_policy(state, policy)
 

--- a/services/dashboard_widgets.py
+++ b/services/dashboard_widgets.py
@@ -964,7 +964,6 @@ def latest_ratings_widget(
                     continue
                 entries.append((_rank(item), len(entries), str(raw_key), item, [ref], False))
 
-    library_total = len(entries)
     cap = max(1, min(int(limit or 12), 24))
 
     def _build(selected: list) -> list[dict[str, Any]]:
@@ -1000,7 +999,7 @@ def latest_ratings_widget(
     )
     for row in selected:
         row.pop(_RATING_TRACKER_FLAG, None)
-    return {"ok": True, "items": selected, "total": len(items), "library_total": library_total}
+    return {"ok": True, "items": selected, "total": len(items)}
 
 
 def _activity_row(event: Mapping[str, Any]) -> dict[str, Any]:
@@ -1197,23 +1196,6 @@ def _history_provider_blocks(state: Mapping[str, Any], user_filter: Mapping[str,
             yield provider, instance, block
 
 
-def _history_library_total(
-    state: Mapping[str, Any],
-    tracker_items: Mapping[str, Any] | None,
-    *,
-    user_filter: Mapping[str, Any] | None = None,
-) -> int:
-    scoped = bool(_normalize_user_filter(user_filter))
-    seen: set[str] = set()
-    for raw_key, raw_item in (tracker_items or {}).items():
-        if scoped and not _sources_match_user(_sources_from_item(_unwrap_history_item(raw_item)), user_filter):
-            continue
-        seen.add(str(raw_key))
-    for _provider, _instance, block in _history_provider_blocks(state or {}, user_filter):
-        seen.update(str(raw_key) for raw_key in _feature_items(block, "history").keys())
-    return len(seen)
-
-
 def _latest_history_tracker_rows(
     items: Mapping[str, Any],
     *,
@@ -1289,12 +1271,7 @@ def recent_history_widget(
         tracker_rows = _latest_history_tracker_rows(tracker_items or {}, user_filter=user_filter, window=None)
         rows = _merge_history_rows(state_rows, tracker_rows, alias_map=alias_map)
     selected = _resolve_missing_art_rows(rows[:cap], size="w300", episode_still=True)
-    return {
-        "ok": True,
-        "items": selected,
-        "total": len(rows),
-        "library_total": _history_library_total(state or {}, tracker_items, user_filter=user_filter),
-    }
+    return {"ok": True, "items": selected, "total": len(rows)}
 
 
 def recent_scrobble_widget(*, limit: int = 8, user_filter: Mapping[str, Any] | None = None) -> dict[str, Any]:

--- a/tests/test_dashboard_widgets.py
+++ b/tests/test_dashboard_widgets.py
@@ -1193,7 +1193,6 @@ def test_recent_history_widget_windowing_keeps_newest_items(monkeypatch) -> None
     titles = [row["title"] for row in payload["items"]]
 
     assert titles == [f"Movie {idx}" for idx in range(count - 1, count - 7, -1)]
-    assert payload["library_total"] == count
 
 
 def test_recent_history_widget_window_matches_unwindowed_top_rows(monkeypatch) -> None:
@@ -1237,7 +1236,6 @@ def test_latest_ratings_widget_window_respects_full_sort_tiebreak(monkeypatch) -
     full = dashboard_widgets.latest_ratings_widget({}, limit=24, tracker_items=items, window=0)
 
     assert [row["title"] for row in windowed["items"]] == [row["title"] for row in full["items"]]
-    assert windowed["library_total"] == full["library_total"] == len(items)
 
 
 def test_latest_ratings_widget_widens_window_when_merge_underfills(monkeypatch) -> None:
@@ -1284,6 +1282,46 @@ def test_dashboard_widgets_api_version_tracks_history_alias_files(monkeypatch, t
 
     assert _loads_body(first.body)["version"] != _loads_body(second.body)["version"]
     dashboardAPI.clear_dashboard_payload_cache()
+
+
+def test_bounded_state_load_matches_full_load(monkeypatch, tmp_path) -> None:
+    import time as _time
+
+    from cw_platform.local_db import state as sqlite_state
+    from cw_platform.orchestrator._state_store import StateStore
+
+    monkeypatch.setattr(dashboard_widgets, "_resolve_missing_art_rows", lambda rows, **_kwargs: rows)
+    monkeypatch.setattr(dashboard_widgets, "_history_alias_representatives", lambda: {})
+
+    count = 1200
+    items = {
+        f"ep:{idx}": {
+            "type": "episode",
+            "title": f"Show {idx}",
+            "season": 1,
+            "episode": (idx % 24) + 1,
+            "watched_at": _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime(1700000000 + idx * 600)),
+            "ids": {"tmdb": 900000 + idx},
+            "show_ids": {"tmdb": 5000 + idx},
+        }
+        for idx in range(count)
+    }
+    StateStore(tmp_path).save_state({"providers": {"EMBY": {"history": {"baseline": {"items": items}}}}})
+
+    full = sqlite_state.load_state_features(tmp_path, {"history"})
+    bounded = sqlite_state.load_state_features(tmp_path, {"history"}, recent_limit=400)
+
+    full_payload = dashboard_widgets.recent_history_widget(full, limit=24, tracker_items={})
+    bounded_payload = dashboard_widgets.recent_history_widget(bounded, limit=24, tracker_items={})
+
+    assert [r["key"] for r in bounded_payload["items"]] == [r["key"] for r in full_payload["items"]]
+
+    # the unbounded load must keep its original shape for the orchestrator
+    full_node = full["providers"]["EMBY"]["history"]["baseline"]
+    bounded_node = bounded["providers"]["EMBY"]["history"]["baseline"]
+    assert "item_keys" not in full_node
+    assert len(full_node["items"]) == count
+    assert len(bounded_node["items"]) == 400
 
 
 def test_recent_scrobble_widget_total_is_not_page_limited(monkeypatch) -> None:
@@ -1713,6 +1751,91 @@ def test_dashboard_widgets_api_rebuilds_when_version_changes(monkeypatch, tmp_pa
     dashboardAPI.clear_dashboard_payload_cache()
 
 
+def test_dashboard_widgets_api_collapses_concurrent_builds(monkeypatch, tmp_path) -> None:
+    import threading
+    import time
+
+    import cw_platform.config_base as config_base
+    from api import dashboardAPI
+
+    monkeypatch.setattr(config_base, "CONFIG", tmp_path)
+    monkeypatch.setattr(dashboard_widgets, "_tracker_feature_items", lambda _kind: {})
+    dashboardAPI.clear_dashboard_payload_cache()
+
+    builds = []
+    builds_lock = threading.Lock()
+    real_payload = dashboardAPI.dashboard_widgets_payload
+
+    def slow_payload(*args, **kwargs):
+        with builds_lock:
+            builds.append(1)
+        time.sleep(0.4)
+        return real_payload(*args, **kwargs)
+
+    monkeypatch.setattr(dashboardAPI, "dashboard_widgets_payload", slow_payload)
+
+    results = []
+    results_lock = threading.Lock()
+
+    def hit():
+        r = dashboardAPI.dashboard_widgets(include="history", history_limit=8)
+        with results_lock:
+            results.append(_loads_body(r.body))
+
+    threads = [threading.Thread(target=hit) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(builds) == 1, f"expected a single build, got {len(builds)}"
+    assert len(results) == 4
+    assert len({r["version"] for r in results}) == 1
+    dashboardAPI.clear_dashboard_payload_cache()
+
+
+def test_dashboard_widgets_api_library_total_uses_highest_provider_count(monkeypatch, tmp_path) -> None:
+    import time as _time
+
+    import cw_platform.config_base as config_base
+    from api import dashboardAPI
+    from cw_platform.orchestrator._state_store import StateStore
+
+    def items(prefix: str, count: int, stamp: str) -> dict:
+        return {
+            f"{prefix}:{idx}": {
+                "type": "movie",
+                "title": f"Item {idx}",
+                "year": 2000,
+                "rating": (idx % 10) + 1,
+                stamp: _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime(1700000000 + idx * 600)),
+                "ids": {"tmdb": 900000 + idx},
+            }
+            for idx in range(count)
+        }
+
+    StateStore(tmp_path).save_state(
+        {
+            "providers": {
+                "EMBY": {"history": {"baseline": {"items": items("ep", 432, "watched_at")}}},
+                "SIMKL": {"history": {"baseline": {"items": items("ep", 400, "watched_at")}}},
+            }
+        }
+    )
+
+    monkeypatch.setattr(config_base, "CONFIG", tmp_path)
+    monkeypatch.setattr(dashboard_widgets, "_tracker_feature_items", lambda _kind: {})
+    monkeypatch.setattr(dashboard_widgets, "_resolve_missing_art_rows", lambda rows, **_kwargs: rows)
+    monkeypatch.setattr(dashboard_widgets, "_history_alias_representatives", lambda: {})
+    dashboardAPI.clear_dashboard_payload_cache()
+
+    payload = _loads_body(dashboardAPI.dashboard_widgets(include="history", history_limit=6).body)
+
+    # highest provider count wins, never the sum
+    assert payload["recent_history"]["library_total"] == 432
+    dashboardAPI.clear_dashboard_payload_cache()
+
+
 def test_dashboard_widgets_api_version_tracks_crosswatch_tracker_files(monkeypatch, tmp_path) -> None:
     import cw_platform.config_base as config_base
     from api import dashboardAPI
@@ -1771,7 +1894,7 @@ def test_dashboard_widget_frontend_uses_cached_payload_version() -> None:
     assert "function clearDashboardWidgetState()" in js
     assert 'window.addEventListener("cw:sync-state-cleared", clearDashboardWidgetState);' in js
     assert "clear: clearDashboardWidgetState" in js
-    assert "const WIDGET_FETCH_TIMEOUT_MS = 30 * 1000;" in js
+    assert "const WIDGET_FETCH_TIMEOUT_MS = 60 * 1000;" in js
     assert "window.CW.API.j(url, {}, WIDGET_FETCH_TIMEOUT_MS)" in js
     assert 'controller.abort("timeout")' in js
     assert "function isTimeoutError(e)" in js
@@ -1781,6 +1904,7 @@ def test_dashboard_widget_frontend_uses_cached_payload_version() -> None:
     assert 'const REFRESHABLE_WIDGETS = ["history", "ratings", "scrobble", "progress", "playlists"];' in js
     assert "const latestTotals = { history: 0, ratings: 0, scrobble: 0, progress: 0, playlists: 0 };" in js
     assert "block.scrobble_total" in js
+    assert "block.library_total" in js
     assert "async function refreshDashboardWidgets({ forceConfig = false, force = false, preserve = true, kinds = null } = {})" in js
     assert 'params.set("known_version", cachedPayload.version)' in js
     assert "const anyWidgetBlank = requestedKinds.some((kind) => !(latestItems[kind]?.length));" in js
@@ -1818,6 +1942,8 @@ def test_dashboard_widget_frontend_uses_cached_payload_version() -> None:
     assert "refreshDashboardWidgets({ preserve: true });" in js
     assert "refreshDashboardWidgets({ forceConfig: true, preserve: true })" in js
     assert 'window.addEventListener("sync-complete", refreshForSyncComplete);' in js
+    assert "if (kinds && kinds.length) markWidgetsDirty(250, { kinds });" in js
+    assert "else markWidgetsDirty(250);" in js
     assert 'window.addEventListener("cw:scrobble-stopped", refreshForScrobbleStopped);' in js
     assert 'markWidgetsDirty(0, { kinds: ["scrobble", "history", "progress"] });' in js
     assert 'window.addEventListener("watchlist:refresh", () => markWidgetsDirty(250));' not in js


### PR DESCRIPTION
# Pull request

## Change

- History and ratings load only recent rows from sqlite instead of the whole feature
- Widget counts come from provider_feature_counts, per feature, highest provider value
- Widgets endpoint builds once per version, extra requests wait for that build
- Sync complete always asks for a refresh, the server decides with known_version
- Widget fetch timeout raised from 30s to 60s

## Why

- A 15k history library did work across the whole library on every request to show a handful of rows. 
- Refreshing during a build stacked more builds on top and pushed it past the abort.

## Testing

pytest tests/test_dashboard_widgets.py

## Issue

Relates to #985 