### PR TITLE
Fix: Emby and Jellyfin episode keys need show_ids

### DIFF
--- a/providers/sync/emby/_history.py
+++ b/providers/sync/emby/_history.py
@@ -45,7 +45,55 @@ def sleep_ms(ms: int) -> None:
         pass
 
 
+def _scope_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except Exception:
+        return None
+
+
+def _scope_fragment(event: Mapping[str, Any]) -> str:
+    typ = str(event.get("type") or "").strip().lower()
+    season = _scope_int(event.get("season"))
+    if season is None:
+        return ""
+    if typ == "season":
+        return f"#season:{season}"
+    episode = _scope_int(event.get("episode"))
+    if episode is None:
+        return ""
+    return f"#s{season:02d}e{episode:02d}"
+
+
+def _series_scope_key(event: Mapping[str, Any]) -> str:
+    title = str(event.get("series_title") or "").strip().lower()
+    if not title:
+        return ""
+    year = event.get("series_year")
+    year_part = "" if year in (None, "") else str(year)
+    return f"show|title:{title}|year:{year_part}{_scope_fragment(event)}"
+
+
 def _event_base_key(event: Mapping[str, Any], fallback: Mapping[str, Any]) -> str:
+    typ = str(event.get("type") or "").strip().lower()
+    if typ in ("episode", "season"):
+        show_ids = event.get("show_ids") if isinstance(event.get("show_ids"), Mapping) else None
+        if show_ids:
+            try:
+                key = canonical_key(event)
+            except Exception:
+                key = ""
+            if key and any(key.startswith(f"{prefix}:") for prefix in KEY_PRIORITY):
+                return key
+        scoped = _series_scope_key(event)
+        if scoped:
+            return scoped
+        try:
+            return canonical_key(fallback)
+        except Exception:
+            return "unknown:"
     try:
         key = canonical_key(event)
     except Exception:
@@ -368,7 +416,7 @@ def _item_meta(http: Any, item_id: str | None) -> Mapping[str, Any] | None:
     if iid in _item_meta_cache:
         return _item_meta_cache[iid]
     try:
-        r = http.get(f"/Items/{iid}", params={"Fields": "ProviderIds,ProductionYear"})
+        r = http.get(f"/Items/{iid}", params={"Fields": "ProviderIds,ProductionYear,Type"})
         if getattr(r, 'status_code', 0) != 200:
             _item_meta_cache[iid] = None
             return None
@@ -444,6 +492,13 @@ def _item_ids_for(http: Any, item_id: str | None) -> dict[str, str]:
     _item_ids_cache[iid] = ids
     return ids
 
+
+def _series_ids_via_item(http: Any, item_id: str | None) -> dict[str, str]:
+    body = _item_meta(http, item_id)
+    if not isinstance(body, Mapping) or str(body.get('Type') or '').strip() != 'Series':
+        return {}
+    return _item_ids_for(http, item_id)
+
 def _resp_snip(r: Any) -> str:
     try:
         j = r.json()
@@ -457,8 +512,36 @@ def _resp_snip(r: Any) -> str:
         except Exception:
             return "<no-body>"
 
+_SERIES_SCOPE_RX = re.compile(
+    r"^show\|title:(?P<title>[^|]*)\|year:(?P<year>\d*)(?:#s(?P<s>\d+)e(?P<e>\d+))?$"
+)
+
+
 def _minimal_from_ckey(key: str) -> dict[str, Any]:
     k = str(key or "").strip().lower()
+    sm = _SERIES_SCOPE_RX.match(k)
+    if sm:
+        out: dict[str, Any] = {"watched": True}
+        title = (sm.group("title") or "").strip()
+        if not title:
+            return out
+        out["series_title"] = title
+        year = sm.group("year")
+        if year:
+            try:
+                out["series_year"] = int(year)
+            except Exception:
+                pass
+        s = sm.group("s")
+        e = sm.group("e")
+        if s and e:
+            try:
+                out["type"] = "episode"
+                out["season"] = int(s)
+                out["episode"] = int(e)
+            except Exception:
+                pass
+        return out
     m = re.match(r"^(?P<idkey>[a-z0-9_]+):(?P<idval>[^#]+)(?:#s(?P<s>\d+)e(?P<e>\d+))?$", k)
     if not m:
         return {"watched": True}
@@ -851,7 +934,7 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
                                     except Exception:
                                         pass
                                 if not show_ids and sid:
-                                    show_ids = _item_ids_for(http, str(sid))
+                                    show_ids = _series_ids_via_item(http, str(sid))
                                 if show_ids:
                                     mm["show_ids"] = dict(show_ids)
 
@@ -899,7 +982,7 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
                             pass
                     if not show_ids and sid:
                         # Fallback to direct item lookup (cached) if the series item couldn't be resolved.
-                        show_ids = _item_ids_for(http, sid)
+                        show_ids = _series_ids_via_item(http, sid)
                     season = m.get("season")
                     episode = m.get("episode")
                     if season is None:

--- a/providers/sync/jellyfin/_history.py
+++ b/providers/sync/jellyfin/_history.py
@@ -46,7 +46,55 @@ _UNRES_CACHE: dict[str, dict[str, Any]] = {}
 _UNRES_DIRTY: set[str] = set()
 
 
+def _scope_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except Exception:
+        return None
+
+
+def _scope_fragment(event: Mapping[str, Any]) -> str:
+    typ = str(event.get("type") or "").strip().lower()
+    season = _scope_int(event.get("season"))
+    if season is None:
+        return ""
+    if typ == "season":
+        return f"#season:{season}"
+    episode = _scope_int(event.get("episode"))
+    if episode is None:
+        return ""
+    return f"#s{season:02d}e{episode:02d}"
+
+
+def _series_scope_key(event: Mapping[str, Any]) -> str:
+    title = str(event.get("series_title") or "").strip().lower()
+    if not title:
+        return ""
+    year = event.get("series_year")
+    year_part = "" if year in (None, "") else str(year)
+    return f"show|title:{title}|year:{year_part}{_scope_fragment(event)}"
+
+
 def _event_base_key(event: Mapping[str, Any], fallback: Mapping[str, Any]) -> str:
+    typ = str(event.get("type") or "").strip().lower()
+    if typ in ("episode", "season"):
+        show_ids = event.get("show_ids") if isinstance(event.get("show_ids"), Mapping) else None
+        if show_ids:
+            try:
+                key = canonical_key(event)
+            except Exception:
+                key = ""
+            if key and any(key.startswith(f"{prefix}:") for prefix in KEY_PRIORITY):
+                return key
+        scoped = _series_scope_key(event)
+        if scoped:
+            return scoped
+        try:
+            return canonical_key(fallback)
+        except Exception:
+            return "unknown:"
     try:
         key = canonical_key(event)
     except Exception:
@@ -374,6 +422,38 @@ def _series_ids_for(http: Any, uid: str, series_id: str | None) -> dict[str, str
     return out
 
 
+def _series_meta_type(series_id: str | None) -> str:
+    body = _SERIES_META_CACHE.get(str(series_id or '').strip()) or {}
+    return str(body.get('Type') or '').strip() if isinstance(body, Mapping) else ''
+
+
+def _series_year_for(http: Any, uid: str, series_id: str | None) -> int | None:
+    sid = (str(series_id or '').strip()) or ''
+    if not sid:
+        return None
+    if sid not in _SERIES_META_CACHE:
+        _prefetch_series_meta(http, uid, [sid])
+    body = _SERIES_META_CACHE.get(sid) or {}
+    year = body.get('ProductionYear') if isinstance(body, Mapping) else None
+    try:
+        return int(year) if year is not None else None
+    except Exception:
+        return None
+
+
+def _episode_show_ids(http: Any, uid: str, row: Mapping[str, Any]) -> tuple[str, dict[str, str]]:
+    sid = str(row.get('SeriesId') or '').strip()
+    ids = _series_ids_for(http, uid, sid) if sid else {}
+    if ids:
+        return sid, ids
+    parent = str(row.get('ParentId') or '').strip()
+    if parent and parent != sid:
+        parent_ids = _series_ids_for(http, uid, parent)
+        if parent_ids and _series_meta_type(parent) == 'Series':
+            return parent, parent_ids
+    return sid, ids
+
+
 # low-level Jellyfin writes
 def _mark_played(http: Any, uid: str, item_id: str, *, date_played_iso: str | None) -> bool:
     try:
@@ -617,7 +697,7 @@ def build_index(
                     "watched": True,
                 }
             elif typ == "Episode":
-                show_ids = _series_ids_for(http, uid, row.get("SeriesId"))
+                series_id, show_ids = _episode_show_ids(http, uid, row)
                 s = m.get("season")
                 e = m.get("episode")
                 try:
@@ -638,6 +718,9 @@ def build_index(
                     "watched_at": watched_at,
                     "watched": True,
                 }
+                series_year = _series_year_for(http, uid, series_id)
+                if series_year is not None:
+                    event["series_year"] = series_year
             else:
                 continue
 

--- a/tests/test_media_server_history_keys.py
+++ b/tests/test_media_server_history_keys.py
@@ -141,14 +141,19 @@ def test_emby_history_no_id_episode_title_fallback_uses_original_row(monkeypatch
 
     monkeypatch.setattr(_history, "_emby_library_roots", lambda _adapter: {})
     monkeypatch.setattr(_history, "prefetch_series_minimals", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(_history, "_series_minimal_from_episode", lambda *_args, **_kwargs: {"ids": {}})
+    monkeypatch.setattr(
+        _history,
+        "_series_minimal_from_episode",
+        lambda _http, _uid, ep, _cache: {"ids": {}, "year": 2019 if ep.get("SeriesId") == "series-a" else 2018},
+    )
+    monkeypatch.setattr(_history, "_series_ids_via_item", lambda *_args, **_kwargs: {})
     monkeypatch.setattr(_history, "_shadow_load", lambda: {})
     monkeypatch.setattr(_history, "_bb_load", lambda: {})
 
     out = _history.build_index(adapter)
 
-    assert "episode|title:ep one|year:2020@1767312000" in out
-    assert "episode|title:ep two|year:2021@1767312000" in out
+    assert "show|title:show a|year:2019#s06e03@1767312000" in out
+    assert "show|title:show b|year:2018#s06e03@1767312000" in out
     assert "episode|title:s06e03|year:@1767312000" not in out
 
 
@@ -186,11 +191,109 @@ def test_jellyfin_history_no_id_episode_title_fallback_uses_original_row(monkeyp
     monkeypatch.setattr(_history, "jf_get_library_roots", lambda _adapter: {})
     monkeypatch.setattr(_history, "_prefetch_series_meta", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(_history, "_series_ids_for", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(
+        _history,
+        "_series_year_for",
+        lambda _http, _uid, sid: 2019 if sid == "series-a" else 2018,
+    )
     monkeypatch.setattr(_history, "_shadow_load", lambda: {})
     monkeypatch.setattr(_history, "_bb_load", lambda: {})
 
     out = _history.build_index(adapter)
 
-    assert "episode|title:ep one|year:2020@1767312000" in out
-    assert "episode|title:ep two|year:2021@1767312000" in out
+    assert "show|title:show a|year:2019#s06e03@1767312000" in out
+    assert "show|title:show b|year:2018#s06e03@1767312000" in out
     assert "episode|title:s06e03|year:@1767312000" not in out
+
+
+def test_emby_history_never_keys_episode_on_its_own_imdb_id(monkeypatch: Any) -> None:
+    from providers.sync.emby import _history
+
+    row = {
+        "Id": "episode-3",
+        "Type": "Episode",
+        "Name": "Sleep Hypnosis",
+        "SeriesName": "What We Do in the Shadows",
+        "SeriesId": "series-wwdits",
+        "ParentIndexNumber": 6,
+        "IndexNumber": 3,
+        "ProviderIds": {"Imdb": "tt33029958"},
+        "UserData": {"Played": True, "LastPlayedDate": "2026-01-02T00:00:00Z"},
+    }
+    adapter = SimpleNamespace(client=_Http([row]), cfg=SimpleNamespace(user_id="user-1"))
+
+    monkeypatch.setattr(_history, "_emby_library_roots", lambda _adapter: {})
+    monkeypatch.setattr(_history, "prefetch_series_minimals", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_history, "_series_minimal_from_episode", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_history, "_series_ids_via_item", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(_history, "_shadow_load", lambda: {})
+    monkeypatch.setattr(_history, "_bb_load", lambda: {})
+
+    out = _history.build_index(adapter)
+
+    assert "imdb:tt33029958#s06e03@1767312000" not in out
+    assert "show|title:what we do in the shadows|year:#s06e03@1767312000" in out
+
+
+def test_jellyfin_history_never_keys_episode_on_its_own_imdb_id(monkeypatch: Any) -> None:
+    from providers.sync.jellyfin import _history
+
+    row = {
+        "Id": "episode-3",
+        "Type": "Episode",
+        "Name": "Sleep Hypnosis",
+        "SeriesName": "What We Do in the Shadows",
+        "SeriesId": "series-wwdits",
+        "ParentIndexNumber": 6,
+        "IndexNumber": 3,
+        "ProviderIds": {"Imdb": "tt33029958"},
+        "UserData": {"Played": True, "LastPlayedDate": "2026-01-02T00:00:00Z"},
+    }
+    adapter = SimpleNamespace(client=_Http([row]), cfg=SimpleNamespace(user_id="user-1"))
+
+    monkeypatch.setattr(_history, "jf_get_library_roots", lambda _adapter: {})
+    monkeypatch.setattr(_history, "_prefetch_series_meta", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_history, "_series_ids_for", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(_history, "_series_year_for", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_history, "_shadow_load", lambda: {})
+    monkeypatch.setattr(_history, "_bb_load", lambda: {})
+
+    out = _history.build_index(adapter)
+
+    assert "imdb:tt33029958#s06e03@1767312000" not in out
+    assert "show|title:what we do in the shadows|year:#s06e03@1767312000" in out
+
+
+def test_jellyfin_history_falls_back_to_parent_series_ids(monkeypatch: Any) -> None:
+    from providers.sync.jellyfin import _history
+
+    row = {
+        "Id": "episode-3",
+        "Type": "Episode",
+        "Name": "Sleep Hypnosis",
+        "SeriesName": "What We Do in the Shadows",
+        "SeriesId": "",
+        "ParentId": "series-wwdits",
+        "ParentIndexNumber": 6,
+        "IndexNumber": 3,
+        "ProviderIds": {"Imdb": "tt33029958"},
+        "UserData": {"Played": True, "LastPlayedDate": "2026-01-02T00:00:00Z"},
+    }
+    adapter = SimpleNamespace(client=_Http([row]), cfg=SimpleNamespace(user_id="user-1"))
+
+    monkeypatch.setattr(_history, "jf_get_library_roots", lambda _adapter: {})
+    monkeypatch.setattr(_history, "_prefetch_series_meta", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        _history,
+        "_series_ids_for",
+        lambda _http, _uid, sid: {"tmdb": "83631", "imdb": "tt7908628"} if sid == "series-wwdits" else {},
+    )
+    monkeypatch.setattr(_history, "_series_meta_type", lambda sid: "Series" if sid == "series-wwdits" else "")
+    monkeypatch.setattr(_history, "_series_year_for", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_history, "_shadow_load", lambda: {})
+    monkeypatch.setattr(_history, "_bb_load", lambda: {})
+
+    out = _history.build_index(adapter)
+
+    assert "tmdb:83631#s06e03@1767312000" in out
+    assert out["tmdb:83631#s06e03@1767312000"]["show_ids"] == {"tmdb": "83631", "imdb": "tt7908628"}


### PR DESCRIPTION
# Pull request

## Change

- Episodes and seasons only take a canonical key when show_ids is there
- Without show_ids they fall back to a series title key with season and episode
- Emby only accepts the ParentId lookup when the item is a Series
- Jellyfin got the ParentId fallback and series_year it was missing

## Why

- keep consistancy

## Testing

- tests/test_media_server_history_keys.py

## Issue

NA
