### PR TITLE
Fix: Emby episodes could lose their parent show ID

### DIFF
--- a/providers/sync/emby/_common.py
+++ b/providers/sync/emby/_common.py
@@ -841,28 +841,77 @@ def _is_future_episode(it: Any) -> bool:
     return False
 
 
+_SERIES_FIELDS = "ProviderIds,ProductionYear,Type,Name,SeriesId,ParentId"
+
+
+def _items_by_ids(http: Any, uid: str, ids: list[str]) -> tuple[bool, dict[str, Mapping[str, Any]]]:
+    if not ids:
+        return True, {}
+    try:
+        r = http.get(
+            f"/Users/{uid}/Items",
+            params={"Ids": ",".join(ids), "Fields": _SERIES_FIELDS},
+        )
+    except Exception:
+        return False, {}
+    if getattr(r, "status_code", 0) != 200:
+        return False, {}
+    try:
+        arr = (r.json() or {}).get("Items") or []
+    except Exception:
+        return True, {}
+    out: dict[str, Mapping[str, Any]] = {}
+    for raw in arr if isinstance(arr, list) else []:
+        if not isinstance(raw, Mapping):
+            continue
+        rid = str(raw.get("Id") or "").strip()
+        if rid:
+            out[rid] = raw
+    return True, out
+
+
+def _series_id_for_episode(http: Any, uid: str, ep: Mapping[str, Any]) -> str:
+    sid = str(ep.get("SeriesId") or ep.get("seriesid") or "").strip()
+    if sid:
+        return sid
+    parent = str(ep.get("ParentId") or "").strip()
+    if not parent:
+        return ""
+    ok, rows = _items_by_ids(http, uid, [parent])
+    row = rows.get(parent)
+    if not ok or not isinstance(row, Mapping):
+        return ""
+    kind = str(row.get("Type") or "").strip()
+    if kind == "Series":
+        return parent
+    if kind == "Season":
+        return str(row.get("SeriesId") or row.get("ParentId") or "").strip()
+    return ""
+
+
 def _series_minimal_from_episode(
     http: Any,
     uid: str,
     ep: Mapping[str, Any],
     _cache: dict[str, dict[str, Any] | None],
 ) -> dict[str, Any] | None:
-    sid = ep.get("SeriesId") or ep.get("seriesid")
-    if not sid:
-        return None
-    if sid in _cache:
+    sid = str(ep.get("SeriesId") or ep.get("seriesid") or "").strip()
+    if sid and sid in _cache:
         return _cache[sid]
-    r = http.get(
-        f"/Users/{uid}/Items",
-        params={"Ids": sid, "Fields": "ProviderIds,ProductionYear,Type,Name"},
-    )
-    if getattr(r, "status_code", 0) == 200:
-        arr = (r.json() or {}).get("Items") or []
-        if arr:
-            m = normalize(arr[0])
-            _cache[sid] = m
-            return m
-    _cache[sid] = None
+    if not sid:
+        sid = _series_id_for_episode(http, uid, ep)
+        if not sid:
+            return None
+        if sid in _cache:
+            return _cache[sid]
+    ok, rows = _items_by_ids(http, uid, [sid])
+    row = rows.get(sid)
+    if isinstance(row, Mapping) and str(row.get("Type") or "").strip() == "Series":
+        m = normalize(row)
+        _cache[sid] = m
+        return m
+    if ok:
+        _cache[sid] = None
     return None
 
 
@@ -889,13 +938,11 @@ def prefetch_series_minimals(
         try:
             r = http.get(
                 f"/Users/{uid}/Items",
-                params={"Ids": ','.join(batch), "Fields": "ProviderIds,ProductionYear,Type,Name"},
+                params={"Ids": ','.join(batch), "Fields": _SERIES_FIELDS},
             )
         except Exception:
             r = None
         if r is None or getattr(r, 'status_code', 0) != 200:
-            for sid in batch:
-                _cache.setdefault(sid, None)
             continue
         try:
             arr = (r.json() or {}).get('Items') or []
@@ -904,12 +951,10 @@ def prefetch_series_minimals(
         for raw in arr:
             try:
                 sid = str((raw or {}).get('Id') or '').strip()
-                if sid:
+                if sid and str((raw or {}).get('Type') or '').strip() == 'Series':
                     _cache[sid] = normalize(raw)
             except Exception:
                 pass
-        for sid in batch:
-            _cache.setdefault(sid, None)
 
 def _fetch_all_playlist_items(
     http: Any,

--- a/providers/sync/emby/_history.py
+++ b/providers/sync/emby/_history.py
@@ -21,6 +21,7 @@ from ._common import (
     _pair_scope,
     _is_capture_mode,
     _series_minimal_from_episode,
+    _items_by_ids,
     prefetch_series_minimals,
 )
 from cw_platform.id_map import KEY_PRIORITY, canonical_key, minimal as id_minimal
@@ -493,11 +494,42 @@ def _item_ids_for(http: Any, item_id: str | None) -> dict[str, str]:
     return ids
 
 
-def _series_ids_via_item(http: Any, item_id: str | None) -> dict[str, str]:
-    body = _item_meta(http, item_id)
-    if not isinstance(body, Mapping) or str(body.get('Type') or '').strip() != 'Series':
+_series_fallback_cache: dict[str, dict[str, str]] = {}
+
+
+def _series_ids_via_item(http: Any, uid: str, item_id: str | None) -> dict[str, str]:
+    iid = str(item_id or '').strip()
+    if not iid:
         return {}
-    return _item_ids_for(http, item_id)
+    if iid in _series_fallback_cache:
+        return dict(_series_fallback_cache[iid])
+    found = _series_ids_via_item_uncached(http, uid, iid)
+    _series_fallback_cache[iid] = dict(found)
+    return dict(found)
+
+
+def _series_ids_via_item_uncached(http: Any, uid: str, item_id: str) -> dict[str, str]:
+    iid = str(item_id or '').strip()
+    if not iid:
+        return {}
+    _ok, rows = _items_by_ids(http, uid, [iid])
+    row = rows.get(iid)
+    if isinstance(row, Mapping):
+        kind = str(row.get('Type') or '').strip()
+        if kind == 'Series':
+            return _pids_to_ids(row.get('ProviderIds'))
+        if kind == 'Season':
+            parent = str(row.get('SeriesId') or row.get('ParentId') or '').strip()
+            if parent:
+                _ok2, prows = _items_by_ids(http, uid, [parent])
+                prow = prows.get(parent)
+                if isinstance(prow, Mapping) and str(prow.get('Type') or '').strip() == 'Series':
+                    return _pids_to_ids(prow.get('ProviderIds'))
+        return {}
+    body = _item_meta(http, iid)
+    if isinstance(body, Mapping) and str(body.get('Type') or '').strip() == 'Series':
+        return _item_ids_for(http, iid)
+    return {}
 
 def _resp_snip(r: Any) -> str:
     try:
@@ -742,6 +774,7 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
     _item_meta_cache.clear()
     _item_ids_cache.clear()
     _lib_anc_cache.clear()
+    _series_fallback_cache.clear()
     series_cache: dict[str, dict[str, Any] | None] = {}
     played_ts_cache: dict[str, int] = {}
     page_size = _history_page_size(adapter)
@@ -785,6 +818,7 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
                     scope_libs = [str(x) for x in anc if x]
 
     events: list[tuple[int, dict[str, Any], dict[str, Any]]] = []
+    ep_show_ids_stats = {"resolved": 0, "missing": 0}
     presence_items: dict[str, dict[str, Any]] = {}
 
     def _is_movieish(row: Mapping[str, Any]) -> bool:
@@ -933,12 +967,21 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
                                         show_ids[k] = str(int(vv))
                                     except Exception:
                                         pass
-                                if not show_ids and sid:
-                                    show_ids = _series_ids_via_item(http, str(sid))
+                                if not show_ids and smeta is None and sid:
+                                    show_ids = _series_ids_via_item(http, uid, str(sid))
                                 if show_ids:
                                     mm["show_ids"] = dict(show_ids)
+                                    ep_show_ids_stats["resolved"] += 1
+                                else:
+                                    ep_show_ids_stats["missing"] += 1
+                                sy = smeta.get("year") if isinstance(smeta, Mapping) else None
+                                if sy is not None:
+                                    try:
+                                        mm["series_year"] = int(sy)
+                                    except Exception:
+                                        pass
 
-                            pk = canonical_key(mm)
+                            pk = _event_base_key(mm, m0)
                             if pk and pk not in presence_items:
                                 presence_items[pk] = mm
                             skipped_untimed += 1
@@ -980,9 +1023,9 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
                             show_ids[k] = str(int(vv))
                         except Exception:
                             pass
-                    if not show_ids and sid:
+                    if not show_ids and smeta is None and sid:
                         # Fallback to direct item lookup (cached) if the series item couldn't be resolved.
-                        show_ids = _series_ids_via_item(http, sid)
+                        show_ids = _series_ids_via_item(http, uid, sid)
                     season = m.get("season")
                     episode = m.get("episode")
                     if season is None:
@@ -1014,6 +1057,9 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
                     }
                     if show_ids:
                         event["show_ids"] = dict(show_ids)
+                        ep_show_ids_stats["resolved"] += 1
+                    else:
+                        ep_show_ids_stats["missing"] += 1
                     sy = smeta.get("year") if isinstance(smeta, Mapping) else None
                     if sy is not None:
                         try:
@@ -1166,6 +1212,12 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
             lib_counts[s] = lib_counts.get(s, 0) + 1
         _dbg("index_fetch_counts", source="library_distribution", cfg_libs=cfg_libs, distribution=lib_counts)
 
+    if ep_show_ids_stats["missing"]:
+        _warn(
+            "episode_show_ids_missing",
+            missing=ep_show_ids_stats["missing"],
+            resolved=ep_show_ids_stats["resolved"],
+        )
     _info("index_done", count=len(out), mode="events+presence")
     return out
 

--- a/tests/test_media_server_history_keys.py
+++ b/tests/test_media_server_history_keys.py
@@ -297,3 +297,192 @@ def test_jellyfin_history_falls_back_to_parent_series_ids(monkeypatch: Any) -> N
 
     assert "tmdb:83631#s06e03@1767312000" in out
     assert out["tmdb:83631#s06e03@1767312000"]["show_ids"] == {"tmdb": "83631", "imdb": "tt7908628"}
+
+
+def test_emby_presence_episode_never_keys_on_its_own_imdb_id(monkeypatch: Any) -> None:
+    from providers.sync.emby import _history
+
+    row = {
+        "Id": "episode-3",
+        "Type": "Episode",
+        "Name": "Sleep Hypnosis",
+        "SeriesName": "What We Do in the Shadows",
+        "SeriesId": "series-wwdits",
+        "ParentIndexNumber": 6,
+        "IndexNumber": 3,
+        "ProviderIds": {"Imdb": "tt33029958"},
+        "UserData": {"Played": True, "PlayCount": 1},
+    }
+    adapter = SimpleNamespace(client=_Http([row]), cfg=SimpleNamespace(user_id="user-1"))
+
+    monkeypatch.setattr(_history, "_emby_library_roots", lambda _adapter: {})
+    monkeypatch.setattr(_history, "prefetch_series_minimals", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_history, "_series_minimal_from_episode", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_history, "_series_ids_via_item", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(_history, "_prefetch_played_ts", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_history, "_shadow_load", lambda: {})
+    monkeypatch.setattr(_history, "_bb_load", lambda: {})
+
+    out = _history.build_index(adapter)
+
+    assert "imdb:tt33029958#s06e03" not in out
+    assert "show|title:what we do in the shadows|year:#s06e03" in out
+
+
+def test_emby_presence_and_timed_paths_agree_on_the_fallback_key(monkeypatch: Any) -> None:
+    from providers.sync.emby import _history
+
+    def _row(iid: str, played_date: str | None) -> dict[str, Any]:
+        ud: dict[str, Any] = {"Played": True, "PlayCount": 1}
+        if played_date:
+            ud["LastPlayedDate"] = played_date
+        return {
+            "Id": iid,
+            "Type": "Episode",
+            "Name": "Ep",
+            "SeriesName": "Show A",
+            "SeriesId": "series-a",
+            "ParentIndexNumber": 6,
+            "IndexNumber": 3,
+            "ProviderIds": {"Imdb": "tt33029958"},
+            "UserData": ud,
+        }
+
+    adapter = SimpleNamespace(
+        client=_Http([_row("timed", "2026-01-02T00:00:00Z"), _row("untimed", None)]),
+        cfg=SimpleNamespace(user_id="user-1"),
+    )
+
+    monkeypatch.setattr(_history, "_emby_library_roots", lambda _adapter: {})
+    monkeypatch.setattr(_history, "prefetch_series_minimals", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_history, "_series_minimal_from_episode", lambda *_args, **_kwargs: {"ids": {}, "year": 2019})
+    monkeypatch.setattr(_history, "_series_ids_via_item", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(_history, "_prefetch_played_ts", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_history, "_shadow_load", lambda: {})
+    monkeypatch.setattr(_history, "_bb_load", lambda: {})
+
+    out = _history.build_index(adapter)
+
+    bases = {k.split("@", 1)[0] for k in out}
+    assert bases == {"show|title:show a|year:2019#s06e03"}
+
+
+class _SeriesHttp:
+    # Emby-shaped server: /Users/{uid}/Items?Ids= is the user scoped lookup,
+    # /Items/{id} is the admin only one that non owner accounts cannot use.
+    def __init__(self, rows: list[dict[str, Any]], pool: dict[str, dict[str, Any]], mode: str = "ok") -> None:
+        self.rows = rows
+        self.pool = pool
+        self.mode = mode
+        self.id_calls: list[str] = []
+        self.admin_calls: list[str] = []
+
+    def get(self, path: str, params: dict[str, Any] | None = None) -> _Response:
+        params = params or {}
+        if path.startswith("/Items/"):
+            self.admin_calls.append(path)
+            return _Response(None)
+        if path.endswith("/Items") and "Ids" in params:
+            ids = [i for i in str(params["Ids"]).split(",") if i]
+            self.id_calls.append(str(params["Ids"]))
+            if self.mode == "batch_fails" and len(ids) > 1:
+                return _Response(None)
+            if self.mode == "batch_omits" and len(ids) > 1:
+                return _Response({"Items": []})
+            return _Response({"Items": [self.pool[i] for i in ids if i in self.pool]})
+        if path.endswith("/Items"):
+            start = int(params.get("StartIndex") or 0)
+            return _Response({"Items": self.rows if start == 0 else []})
+        return _Response({"Items": []})
+
+
+_SERIES_ROW = {
+    "Id": "S1", "Type": "Series", "Name": "What We Do in the Shadows",
+    "ProductionYear": 2019, "ProviderIds": {"Tmdb": "83631", "Imdb": "tt7908628"},
+}
+_SEASON_ROW = {
+    "Id": "SE1", "Type": "Season", "Name": "Season 6",
+    "SeriesId": "S1", "ParentId": "S1", "ProviderIds": {"Tvdb": "999999"},
+}
+
+
+def _episode_row(iid: str, number: int, **extra: Any) -> dict[str, Any]:
+    row = {
+        "Id": iid, "Type": "Episode", "Name": "Ep",
+        "SeriesName": "What We Do in the Shadows",
+        "ParentIndexNumber": 6, "IndexNumber": number,
+        "ProviderIds": {"Imdb": f"tt3302995{number}", "Tvdb": f"1052128{number}"},
+        "UserData": {"Played": True, "LastPlayedDate": "2026-01-02T00:00:00Z"},
+    }
+    row.update(extra)
+    return row
+
+
+def _quiet_index(monkeypatch: Any, http: Any) -> dict[str, Any]:
+    from providers.sync.emby import _history
+
+    monkeypatch.setattr(_history, "_emby_library_roots", lambda _adapter: {})
+    monkeypatch.setattr(_history, "_prefetch_played_ts", lambda *_a, **_k: None)
+    monkeypatch.setattr(_history, "_shadow_load", lambda: {})
+    monkeypatch.setattr(_history, "_bb_load", lambda: {})
+    adapter = SimpleNamespace(client=http, cfg=SimpleNamespace(user_id="user-1"))
+    return _history.build_index(adapter)
+
+
+def test_emby_resolves_show_ids_when_episode_row_has_no_series_id(monkeypatch: Any) -> None:
+    # SeriesId absent, ParentId points at the Season: hop Season -> Series.
+    http = _SeriesHttp([_episode_row("e1", 3, ParentId="SE1")], {"S1": _SERIES_ROW, "SE1": _SEASON_ROW})
+    out = _quiet_index(monkeypatch, http)
+
+    assert "tmdb:83631#s06e03@1767312000" in out
+    assert out["tmdb:83631#s06e03@1767312000"]["show_ids"] == {"tmdb": "83631", "imdb": "tt7908628"}
+
+
+def test_emby_never_takes_show_ids_from_a_season_row(monkeypatch: Any) -> None:
+    # The Season carries its own TVDb id, which must never become the show id.
+    orphan_season = {"Id": "SE9", "Type": "Season", "Name": "S6", "ProviderIds": {"Tvdb": "999999"}}
+    http = _SeriesHttp([_episode_row("e1", 3, ParentId="SE9")], {"SE9": orphan_season})
+    out = _quiet_index(monkeypatch, http)
+
+    assert not any(k.startswith("tvdb:999999") for k in out)
+    assert "show|title:what we do in the shadows|year:#s06e03@1767312000" in out
+
+
+_SERIES_ROW_2 = {
+    "Id": "S2", "Type": "Series", "Name": "Reacher",
+    "ProductionYear": 2022, "ProviderIds": {"Tmdb": "108978", "Imdb": "tt9288030"},
+}
+
+
+def _two_show_rows() -> list[dict[str, Any]]:
+    # Two distinct shows so the prefetch really sends a multi ID batch.
+    a = _episode_row("e1", 3, SeriesId="S1")
+    b = _episode_row("e2", 4, SeriesId="S2")
+    b["SeriesName"] = "Reacher"
+    return [a, b]
+
+
+def test_emby_recovers_when_the_series_batch_call_fails(monkeypatch: Any) -> None:
+    http = _SeriesHttp(_two_show_rows(), {"S1": _SERIES_ROW, "S2": _SERIES_ROW_2}, mode="batch_fails")
+    out = _quiet_index(monkeypatch, http)
+
+    assert {"tmdb:83631#s06e03@1767312000", "tmdb:108978#s06e04@1767312000"} <= set(out)
+
+
+def test_emby_recovers_when_the_series_batch_omits_the_show(monkeypatch: Any) -> None:
+    http = _SeriesHttp(_two_show_rows(), {"S1": _SERIES_ROW, "S2": _SERIES_ROW_2}, mode="batch_omits")
+    out = _quiet_index(monkeypatch, http)
+
+    assert {"tmdb:83631#s06e03@1767312000", "tmdb:108978#s06e04@1767312000"} <= set(out)
+
+
+def test_emby_does_not_retry_an_unresolvable_show_per_episode(monkeypatch: Any) -> None:
+    # A show with no provider IDs must cost one lookup, not one per episode.
+    ghost = {"Id": "G1", "Type": "Series", "Name": "Ghost Show", "ProviderIds": {}}
+    rows = [_episode_row(f"e{i}", i, SeriesId="G1") for i in range(1, 41)]
+    http = _SeriesHttp(rows, {"G1": ghost})
+    out = _quiet_index(monkeypatch, http)
+
+    assert len(out) == 40
+    assert len(http.id_calls) <= 2, http.id_calls
+    assert all(k.startswith("show|title:") for k in out)


### PR DESCRIPTION
# Pull request

## Change

- The presence path now uses the same show_ids guard as the timed path
- Episodes with no SeriesId resolve the parent by hopping Season to Series
- A failed series batch no longer caches a permanent miss for the whole run
- The fallback lookup is user scoped, the admin endpoint stays as a backup
- New warning when episodes end up without parent show IDs

## Why

- #998 only guarded the timed path, so played items with no play date still fell through
- Missing show_ids is the real cause, the episode ID key is only the symptom
- One short batch response marked up to 100 shows unresolvable with no retry

## Testing

- tests/test_media_server_history_keys.py

## Issue

NA
