### PR TITLE
Fix: SIMKL treated TVDb show as anime

### DIFF
--- a/providers/sync/_mod_SIMKL.py
+++ b/providers/sync/_mod_SIMKL.py
@@ -79,7 +79,7 @@ def _confirmed_keys(key_of, items: Iterable[Mapping[str, Any]], unresolved: Any)
         seen.add(k)
     return out
 
-__VERSION__ = "1.7"
+__VERSION__ = "1.8"
 __all__ = ["get_manifest", "SIMKLModule", "OPS"]
 
 

--- a/providers/sync/simkl/_history.py
+++ b/providers/sync/simkl/_history.py
@@ -1833,6 +1833,16 @@ class _AnimeResolveState:
         self.failed = 0
 
 
+def _tvdb_known_non_anime(tvdb: Any, state: _AnimeResolveState | None) -> bool:
+    key = str(tvdb or "").strip()
+    if not key or state is None:
+        return False
+    miss_ts = state.misses.get(key)
+    if miss_ts is None:
+        return False
+    return _now_epoch() - int(miss_ts) < _ANIME_RESOLVE_MISS_TTL
+
+
 def _load_anime_resolve_cache() -> _AnimeResolveState:
     data = _load_json(_anime_resolve_path())
     resolved: dict[str, str] = {}
@@ -3232,7 +3242,10 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                                 retry_ids = dict(obj_retry_ids)
                                 if not retry_ids:
                                     retry_ids = _anime_retry_show_ids(_orig)
-                                if obj_confirms_anime or retry_ids.get("tvdb"):
+                                retry_tvdb = retry_ids.get("tvdb")
+                                if obj_confirms_anime or (
+                                    retry_tvdb and not _tvdb_known_non_anime(retry_tvdb, native_resolve_state)
+                                ):
                                     retry_confirmed_keys.add(retry_key)
                                     if retry_ids:
                                         retry_response_ids[retry_key] = retry_ids


### PR DESCRIPTION
# Pull request

## Change

- Not found retry gate no longer confirms a show as anime just because it has a TVDb id
- Skips TVDb ids the same run already resolved as non anime
- Adds `_tvdb_known_non_anime`

## Why

- Almost every show has a TVDb id, so nearly every failed episode got the anime reason
- Could not just drop the clause, it is the only fallback that gets real anime into the anime payload
- Nothing was written wrongly, retries returned accepted=0, only the label was off

## Testing

- providers/tests/test_simkl_history_anime_mapping.py
- tests/test_simkl_anime_retry_confirmation.py

## Issue

NA