### PR TITLE
Change: update Emby and Jellyfin adapters version

### DIFF
--- a/providers/sync/_mod_EMBY.py
+++ b/providers/sync/_mod_EMBY.py
@@ -117,7 +117,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "2.4"
+__VERSION__ = "2.5"
 os.environ.setdefault("CW_EMBY_VERSION", __VERSION__)
 os.environ.setdefault("CW_EMBY_UA", f"CrossWatch/{__VERSION__} (Emby)")
 __all__ = ["get_manifest", "EMBYModule", "OPS"]

--- a/providers/sync/_mod_JELLYFIN.py
+++ b/providers/sync/_mod_JELLYFIN.py
@@ -113,7 +113,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "2.5"
+__VERSION__ = "2.6"
 _MIN_PROGRESS_WRITE_VERSION = (10, 9)
 _JF_VERSION_CACHE: dict[str, tuple[float, str | None]] = {}
 

--- a/providers/tests/test_simkl_history_anime_mapping.py
+++ b/providers/tests/test_simkl_history_anime_mapping.py
@@ -1305,3 +1305,75 @@ def test_source_episode_id_aliases_survive_when_episode_ids_are_absent(monkeypat
     assert ("tvdb", "355411") in out
     assert ("tvdb", "355412") in out
     assert ("tvdb", "81472") not in out
+
+
+class _MixedRedirectSession(_Session):
+    def __init__(self, *, anime_map=None, non_anime_map=None, post_handler=None, episodes_map=None):
+        super().__init__(post_handler=post_handler, redirect_map=anime_map, episodes_map=episodes_map)
+        self._non_anime_map = {str(k): str(v) for k, v in (non_anime_map or {}).items()}
+
+    def get(self, url, headers=None, params=None, timeout=None, allow_redirects=None):
+        import sync.simkl._history as m
+
+        if url == m.URL_REDIRECT:
+            tvdb = str((params or {}).get("tvdb") or "")
+            other = self._non_anime_map.get(tvdb)
+            if other:
+                self.gets.append({"url": url, "params": params})
+                return _Resp(302, {}, headers={"Location": f"https://simkl.com/tv/{other}/x"})
+        return super().get(url, headers=headers, params=params, timeout=timeout, allow_redirects=allow_redirects)
+
+
+def _not_found_once(tvdb, tmdb, season, episode):
+    state = {"sent": False}
+
+    def handler(url, body):
+        if not state["sent"] and isinstance(body, dict) and "shows" in body:
+            state["sent"] = True
+            return _Resp(200, _ok_add(not_found={
+                "movies": [],
+                "shows": [],
+                "episodes": [{
+                    "ids": {"tvdb": tvdb, "tmdb": tmdb},
+                    "seasons": [{"number": season, "episodes": [{"number": episode}]}],
+                }],
+            }))
+        return _Resp(200, _ok_add(episodes=1))
+
+    return handler
+
+
+def test_non_anime_tvdb_not_found_skips_anime_retry(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _MixedRedirectSession(
+        non_anime_map={"161511": "34307"},
+        post_handler=_not_found_once("161511", "34307", 1, 1),
+    )
+    adapter = _adapter(session)
+
+    _ok, unresolved = m.add(adapter, [_episode("161511", "34307", 1, 1, "Shameless (US)")])
+
+    assert list(_anime_of(session, m.URL_ADD)) == []
+    reasons = {u.get("reason") or u.get("hint") for u in unresolved}
+    assert "simkl_anime_retry_unmapped:episodes" not in reasons
+    assert "simkl_not_found:episodes" in reasons
+
+
+def test_real_anime_tvdb_not_found_still_reaches_anime_retry(monkeypatch):
+    import sync.simkl._history as m
+
+    _patch_fs(monkeypatch, m)
+    session = _MixedRedirectSession(
+        anime_map={"267440": "39687"},
+        episodes_map={},
+        post_handler=_not_found_once("267440", "1429", 4, 17),
+    )
+    adapter = _adapter(session)
+
+    _ok, unresolved = m.add(adapter, [_episode("267440", "1429", 4, 17, "Attack on Titan")])
+
+    reasons = {u.get("reason") or u.get("hint") for u in unresolved}
+    assert "simkl_anime_retry_unmapped:episodes" in reasons
+    assert "simkl_not_found:episodes" not in reasons

--- a/tests/test_simkl_anime_retry_confirmation.py
+++ b/tests/test_simkl_anime_retry_confirmation.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from providers.sync.simkl import _history
+
+
+def _state(misses: dict[str, int] | None = None, resolved: dict[str, str] | None = None) -> Any:
+    return _history._AnimeResolveState(resolved=dict(resolved or {}), misses=dict(misses or {}))
+
+
+def _not_found_echo(tvdb: str) -> dict[str, Any]:
+    return {
+        "ids": {"tvdb": tvdb, "tmdb": "34307", "imdb": "tt1586680"},
+        "title": "Shameless (US)",
+        "seasons": [{"number": 1, "episodes": [{"number": 1}]}],
+    }
+
+
+def _confirms(tvdb: str, state: Any) -> bool:
+    obj = _not_found_echo(tvdb)
+    retry_ids = _history._response_show_retry_ids(obj)
+    retry_tvdb = retry_ids.get("tvdb")
+    return bool(
+        _history._not_found_confirms_anime(obj)
+        or (retry_tvdb and not _history._tvdb_known_non_anime(retry_tvdb, state))
+    )
+
+
+def test_known_non_anime_tvdb_is_not_confirmed_as_anime() -> None:
+    state = _state(misses={"161511": int(time.time())})
+    assert _history._tvdb_known_non_anime("161511", state) is True
+    assert _confirms("161511", state) is False
+
+
+def test_resolved_anime_tvdb_stays_confirmed() -> None:
+    state = _state(resolved={"81797": "12345"})
+    assert _history._tvdb_known_non_anime("81797", state) is False
+    assert _confirms("81797", state) is True
+
+
+def test_unprobed_tvdb_stays_confirmed() -> None:
+    state = _state()
+    assert _history._tvdb_known_non_anime("999999", state) is False
+    assert _confirms("999999", state) is True
+
+
+def test_expired_miss_stays_confirmed() -> None:
+    stale = int(time.time()) - _history._ANIME_RESOLVE_MISS_TTL - 1
+    state = _state(misses={"161511": stale})
+    assert _history._tvdb_known_non_anime("161511", state) is False
+    assert _confirms("161511", state) is True
+
+
+def test_response_confirming_anime_wins_over_negative_cache() -> None:
+    state = _state(misses={"161511": int(time.time())})
+    obj = _not_found_echo("161511")
+    obj["ids"]["anidb"] = "4563"
+    assert _history._not_found_confirms_anime(obj) is True
+    retry_ids = _history._response_show_retry_ids(obj)
+    retry_tvdb = retry_ids.get("tvdb")
+    assert bool(
+        _history._not_found_confirms_anime(obj)
+        or (retry_tvdb and not _history._tvdb_known_non_anime(retry_tvdb, state))
+    ) is True
+
+
+def test_missing_tvdb_and_missing_state_are_safe() -> None:
+    assert _history._tvdb_known_non_anime("", _state(misses={"161511": int(time.time())})) is False
+    assert _history._tvdb_known_non_anime(None, _state()) is False
+    assert _history._tvdb_known_non_anime("161511", None) is False


### PR DESCRIPTION
# Pull request

## Change

- Emby adapter to 2.5, Jellyfin adapter to 2.6

## Why

- Both adapters changed this release.

## Testing

- providers/tests/test_manifests.py

## Issue

NA
