### PR TITLE
Change: drop auth from the About modal

### DIFF
--- a/api/versionAPI.py
+++ b/api/versionAPI.py
@@ -170,6 +170,7 @@ def get_module_versions() -> dict[str, Any]:
     groups = {
         g: {name: _get_module_version(path) for name, path in mods.items()}
         for g, mods in _env_modules().items()
+        if g != "AUTH"
     }
     flat: dict[str, str] = {
         name: ver for mods in groups.values() for name, ver in mods.items()

--- a/assets/js/modals/about.js
+++ b/assets/js/modals/about.js
@@ -258,7 +258,6 @@ function view(info, mods, logo) {
                 </div>
                 <span class="material-symbols-rounded lede-mark" aria-hidden="true">language</span>
               </section>
-              ${_fold("Authentication Providers", _providerRows(mods.groups?.AUTH), "lock")}
               ${_fold("Synchronization Providers", _providerRows(mods.groups?.SYNC), "sync")}
               <section class="about-card disclaimer">
                 <div class="about-section-title"><span class="material-symbols-rounded warn" aria-hidden="true">warning</span><span>Disclaimer</span></div>


### PR DESCRIPTION
# Pull request

## Change

- About modal no longer shows the Authentication Providers section
- `get_module_versions` skips the AUTH group

## Why

- Auth adapter versions are not useful to users.

## Testing

NA

## Issue

NA