### PR TITLE
Change: make one-way remove mode pair-specific

### DIFF
--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -185,6 +185,12 @@ def _normalize_collection_block(v: dict | bool | None) -> dict:
 
     return d
 
+def _normalize_remove_mode(raw: Any) -> str | None:
+    mode = str(raw or "").strip().lower()
+    if not mode:
+        return None
+    return "mirror" if mode == "mirror" else "source_deletes"
+
 def _normalize_features(f: dict | None) -> dict:
     f = dict(f or {})
     for k in FEATURE_KEYS:
@@ -204,6 +210,12 @@ def _normalize_features(f: dict | None) -> dict:
             v["remove"] = coerce_bool(v.get("remove", False))
         if k == "history" and isinstance(f.get(k), dict):
             f[k]["rewatches"] = coerce_bool(f[k].get("rewatches", False))
+        if isinstance(f.get(k), dict) and "remove_mode" in f[k]:
+            mode = _normalize_remove_mode(f[k].get("remove_mode"))
+            if mode is None:
+                f[k].pop("remove_mode", None)
+            else:
+                f[k]["remove_mode"] = mode
         if isinstance(f.get(k), dict) and ("use_anime_mapping" in f[k] or "anime_only_sync" in f[k]):
             use_map = coerce_bool(f[k].get("use_anime_mapping", False))
             f[k]["use_anime_mapping"] = use_map

--- a/assets/js/modals/pair-config/help.js
+++ b/assets/js/modals/pair-config/help.js
@@ -7,7 +7,7 @@ export const HELP_TEXT = {
   "gl-verify": "Verify after write\nRe-check the destination after writes (when supported).",
   "gl-drop": "Drop guard\nProtects against sudden inventory drops by pausing delete plans.",
   "gl-mass": "Allow mass delete\nIf off, blocks large delete plans (roughly >10%). Enable for first runs.\n It's either mass-delete or drop-guard or none; not both.",
-  "gl-oneway-remove": "Deletions based on Source\nWhen enabled there should always be a match between source and destination before deletion.\nWhen disabled it acts in mirror mode, meaning it will always follow source (destructive; use with care)",
+  "gl-oneway-remove": "Deletions based on Source\nWhen enabled, this pair only removes items after CrossWatch observed them disappear from the source.\nWhen disabled, this pair runs mirror mode and removes target items missing from the source (destructive; use with care).",
   "gl-observed": "Include observed deletes\nIf off, observed deletes are ignored and delta-delete providers are disabled (safer).",
   "gl-bb-enable": "Blackbox: Enabled\nAutomatic flapper protection and failure quarantine.",
   "gl-bb-pair": "Blackbox: Pair scoped\nKeep blackbox decisions per pair instead of global.",

--- a/assets/js/modals/pair-config/index.js
+++ b/assets/js/modals/pair-config/index.js
@@ -65,6 +65,25 @@ function pairInstanceForKind(state, kind){
 const isAniList=(v)=>same(v,"anilist");
 function hasAniList(state){return isAniList(state?.src)||isAniList(state?.dst)}
 function hasOwn(obj,key){return !!obj&&Object.prototype.hasOwnProperty.call(obj,key)}
+function normalizeRemoveMode(value){return String(value||"source_deletes").trim().toLowerCase()==="mirror"?"mirror":"source_deletes"}
+function pairRemoveModeFromFeatures(features, fallback="source_deletes"){
+  const mode=normalizeRemoveMode(fallback);
+  if(!features||typeof features!=="object") return mode;
+  for(const key of ["watchlist","ratings","history","progress","collection"]){
+    const block=features[key];
+    if(block&&typeof block==="object"&&hasOwn(block,"remove_mode")) return normalizeRemoveMode(block.remove_mode);
+  }
+  return mode;
+}
+function applyPairRemoveMode(features, mode){
+  const clean=normalizeRemoveMode(mode);
+  if(!features||typeof features!=="object") return features;
+  for(const key of ["watchlist","ratings","history","progress","collection"]){
+    const block=features[key];
+    if(block&&typeof block==="object"&&block.enable!==false) block.remove_mode=clean;
+  }
+  return features;
+}
 function isTwoWayMode(state){return !!ID("cx-mode-two")?.checked||String(state?.mode||"").toLowerCase().startsWith("two")}
 function anilistCanReceive(state){return isAniList(state?.dst)||(hasAniList(state)&&isTwoWayMode(state))}
 function globalAnimeMappingEnabled(state){return !!state?.cfgRaw?.anime_mapping?.enabled}
@@ -339,6 +358,8 @@ function defaultState(){
       collection:{enable:false,add:false,remove:false,types:["movies"]}
     },
     pairProviders:{},
+    pair_remove_mode:"source_deletes",
+    pair_remove_mode_touched:false,
     jellyfin:{watchlist:{mode:"favorites",playlist_name:"Watchlist"}},
     emby:{watchlist:{mode:"favorites",playlist_name:"Watchlist"}},
     globals:{
@@ -474,7 +495,7 @@ async function loadConfigBits(state){
     verify_after_write:!!s.verify_after_write,
     drop_guard:dropOn,
     allow_mass_delete:massOn,
-    one_way_remove_mode:(String(s.one_way_remove_mode||"source_deletes").trim().toLowerCase()==="mirror"?"mirror":"source_deletes"),
+    one_way_remove_mode:normalizeRemoveMode(s.one_way_remove_mode),
     tombstone_ttl_days:Number.isFinite(s.tombstone_ttl_days)?s.tombstone_ttl_days:30,
     include_observed_deletes:!!s.include_observed_deletes,
     blackbox:Object.assign(
@@ -1286,6 +1307,11 @@ function renderFeaturePanel(state){
 
   if(state.feature==="globals"){
     const g=state.globals||{},bb=g.blackbox||{},rt=g.runtime||{suspect_min_prev:20,suspect_shrink_ratio:0.1};
+    const removeModeDisabled=isTwoWayMode(state);
+    const removeModeLabel=normalizeRemoveMode(state.pair_remove_mode)==="mirror"?"Stored: Mirror-mode":"Stored: Source";
+    const removeModeRow=removeModeDisabled
+      ? `<div class="opt-row muted"><label data-tip-id="gl-oneway-remove">One-Way Remove mode Source | Mirror-mode</label><span class="provider-card-badge" title="Kept for one-way mode">${removeModeLabel}</span></div>`
+      : `<div class="opt-row"><label for="gl-oneway-remove">One-Way Remove mode Source | Mirror-mode</label><label class="switch"><input id="gl-oneway-remove" type="checkbox" ${normalizeRemoveMode(state.pair_remove_mode)==="source_deletes"?"checked":""}><span class="slider"></span></label></div>`;
     const pct = Math.round((Number.isFinite(rt.suspect_shrink_ratio)?rt.suspect_shrink_ratio:0.1)*100);
     const minPrevVal = Number.isFinite(rt.suspect_min_prev)?rt.suspect_min_prev:20;
 
@@ -1314,9 +1340,10 @@ function renderFeaturePanel(state){
       </div>
       <div class="grid2 compact">
         <div class="opt-row"><label for="gl-mass">Allow mass delete</label><label class="switch"><input id="gl-mass" type="checkbox" ${g.allow_mass_delete?"checked":""}><span class="slider"></span></label></div>
-        <div class="opt-row"><label for="gl-oneway-remove">One-Way Remove mode Source</label><label class="switch"><input id="gl-oneway-remove" type="checkbox" ${((String(g.one_way_remove_mode||"source_deletes").trim().toLowerCase()==="mirror")?"":"checked")}><span class="slider"></span></label></div>
       </div>`;
-    right.innerHTML=`<div class="panel-title">Advanced <button type="button" class="cx-help material-symbols-rounded" data-tip-id="gl-section-advanced">help</button></div>
+    right.innerHTML=`<div class="panel-title small">Pair safety</div>
+      ${removeModeRow}
+      <div class="panel-title" style="margin-top:10px">Advanced <button type="button" class="cx-help material-symbols-rounded" data-tip-id="gl-section-advanced">help</button></div>
       <div class="opt-row"><label for="gl-ttl">Tombstone TTL (days)</label><input id="gl-ttl" class="input" type="number" min="0" step="1" value="${g.tombstone_ttl_days??30}"></div><div class="muted">Keep delete markers to avoid re-adding.</div>
       <div class="opt-row"><label for="gl-observed">Include observed deletes</label><label class="switch"><input id="gl-observed" type="checkbox" ${g.include_observed_deletes?"checked":""}><span class="slider"></span></label></div>
       <div class="panel-title small" style="margin-top:10px">Blackbox <button type="button" class="cx-help material-symbols-rounded" data-tip-id="gl-bb-section">help</button></div>
@@ -2440,11 +2467,16 @@ function bindChangeHandlers(state,root){
         verify_after_write:!!Q("#gl-verify")?.checked,
         drop_guard:dropOn,
         allow_mass_delete:!!Q("#gl-mass")?.checked && !dropOn,
+        one_way_remove_mode:normalizeRemoveMode(state.globals?.one_way_remove_mode),
         tombstone_ttl_days:parseInt(Q("#gl-ttl")?.value||"0",10)||0,
         include_observed_deletes:!!Q("#gl-observed")?.checked,
         runtime:{suspect_min_prev:minPrev,suspect_shrink_ratio:pct/100},
         blackbox:bb
       };
+      if(id==="gl-oneway-remove"){
+        state.pair_remove_mode=!!Q("#gl-oneway-remove")?.checked ? "source_deletes" : "mirror";
+        state.pair_remove_mode_touched=true;
+      }
     }
 
     if(id==="cx-jf-wl-mode-fav"||id==="cx-jf-wl-mode-pl"||id==="cx-jf-wl-mode-col"||id==="cx-jf-wl-pl-name"||id==="cx-wl-q"||id==="cx-wl-delay"||id==="cx-wl-guid"){
@@ -2511,7 +2543,6 @@ async function saveConfigBits(state){
         verify_after_write:!!ID("gl-verify")?.checked,
         drop_guard:dropOn,
         allow_mass_delete:massOn,
-        one_way_remove_mode:!!ID("gl-oneway-remove")?.checked ? "source_deletes" : "mirror",
         tombstone_ttl_days:Math.max(0,parseInt(ID("gl-ttl")?.value||"0",10)||0),
         include_observed_deletes:!!ID("gl-observed")?.checked
       };
@@ -2791,6 +2822,7 @@ function buildPayload(state,wrap){
     collection.types=keep.length?keep:(allowedCollectionTypes.includes("movies")?["movies"]:allowedCollectionTypes.slice(0,1));
   }
   const features=sanitizeFeaturesForPair({src,dst,twoWay:modeTwo},{watchlist,ratings,history,progress,playlists:get("playlists"),collection});
+  if(state.pair_remove_mode_touched) applyPairRemoveMode(features,state.pair_remove_mode);
   const payload={source:src,target:dst,source_instance:String(srcInst||"default"),target_instance:String(dstInst||"default"),enabled,mode:modeTwo?"two-way":"one-way",features};
   const eid=wrap.dataset&&wrap.dataset.editingId?String(wrap.dataset.editingId||""):"";
   const selectedProfileId=String(state.selected_user_profile_id||"").trim();
@@ -2916,6 +2948,7 @@ export default{
     }
 
     await loadConfigBits(state);
+    state.pair_remove_mode=pairRemoveModeFromFeatures(pair?.features,state.globals.one_way_remove_mode);
     await loadProviders(state);
     await loadProviderInstances(state);
     await loadUserProfiles(state);

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -1409,6 +1409,13 @@ def _normalize_collection_feature(val: dict[str, Any]) -> dict[str, Any]:
     return v
 
 
+def _normalize_remove_mode(raw: Any) -> str | None:
+    mode = str(raw or "").strip().lower()
+    if not mode:
+        return None
+    return "mirror" if mode == "mirror" else "source_deletes"
+
+
 def _normalize_features_map(features: dict[str, Any] | None) -> dict[str, Any]:
     f: dict[str, Any] = dict(features or {})
     for name, val in list(f.items()):
@@ -1417,6 +1424,12 @@ def _normalize_features_map(features: dict[str, Any] | None) -> dict[str, Any]:
             v.setdefault("enable", True)
             v.setdefault("add", True)
             v.setdefault("remove", False)
+            if "remove_mode" in v:
+                remove_mode = _normalize_remove_mode(v.get("remove_mode"))
+                if remove_mode is None:
+                    v.pop("remove_mode", None)
+                else:
+                    v["remove_mode"] = remove_mode
 
             # Ratings has extra fields
             if name == "ratings":

--- a/tests/test_collection_scope_safety.py
+++ b/tests/test_collection_scope_safety.py
@@ -68,12 +68,44 @@ def test_api_normalizes_collection_types_to_movies_by_default() -> None:
     assert out["collection"]["types"] == ["movies"]
 
 
+def test_api_normalizes_feature_remove_mode_and_drops_empty_fallback() -> None:
+    from api.syncAPI import _normalize_features
+
+    out = _normalize_features(
+        {
+            "watchlist": {"enable": True, "remove_mode": "mirror"},
+            "history": {"enable": True, "remove_mode": "nonsense"},
+            "progress": {"enable": True, "remove_mode": ""},
+        }
+    )
+
+    assert out["watchlist"]["remove_mode"] == "mirror"
+    assert out["history"]["remove_mode"] == "source_deletes"
+    assert "remove_mode" not in out["progress"]
+
+
 def test_config_loader_normalizes_collection_types_to_movies_by_default() -> None:
     from cw_platform.config_base import _normalize_features_map
 
     out = _normalize_features_map({"collection": {"enable": True, "add": True, "remove": True}})
 
     assert out["collection"]["types"] == ["movies"]
+
+
+def test_config_loader_normalizes_feature_remove_mode_and_drops_empty_fallback() -> None:
+    from cw_platform.config_base import _normalize_features_map
+
+    out = _normalize_features_map(
+        {
+            "watchlist": {"enable": True, "remove_mode": "mirror"},
+            "history": {"enable": True, "remove_mode": "nonsense"},
+            "progress": {"enable": True, "remove_mode": ""},
+        }
+    )
+
+    assert out["watchlist"]["remove_mode"] == "mirror"
+    assert out["history"]["remove_mode"] == "source_deletes"
+    assert "remove_mode" not in out["progress"]
 
 
 def test_pair_config_allows_server_collection_show_and_season_scope() -> None:

--- a/tests/test_orchestrator_oneway_watchlist.py
+++ b/tests/test_orchestrator_oneway_watchlist.py
@@ -140,7 +140,75 @@ def test_orchestrator_oneway_watchlist_add_then_observed_remove(
     assert [it.get("ids", {}).get("imdb") for it in dst.add_calls[0]] == ["tt03"]
     assert dst.remove_calls == []
 
-    # Run 2: now DST has a baseline that includes B,  removal is allowed.
+    src.index.pop("imdb:tt03")
+
+    # Run 2: C was present on the source baseline and is now gone, so it can be
+    # treated as an observed source delete.
     orch.run()
     assert len(dst.remove_calls) == 1
-    assert [it.get("ids", {}).get("imdb") for it in dst.remove_calls[0]] == ["tt02"]
+    assert [it.get("ids", {}).get("imdb") for it in dst.remove_calls[0]] == ["tt03"]
+
+
+def test_oneway_pair_remove_mode_overrides_global_mirror(
+    config_base: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    src_items = {
+        "imdb:tt01": {"type": "movie", "title": "A", "year": 2000, "ids": {"imdb": "tt01"}},
+    }
+    dst_items = {
+        "imdb:tt01": {"type": "movie", "title": "A", "year": 2000, "ids": {"imdb": "tt01"}},
+        "imdb:tt02": {"type": "movie", "title": "B", "year": 2001, "ids": {"imdb": "tt02"}},
+    }
+
+    src = FakeOps("SRC", src_items)
+    dst = FakeOps("DST", dst_items)
+
+    monkeypatch.setattr(
+        "cw_platform.orchestrator.facade.load_sync_providers",
+        lambda: {"SRC": src, "DST": dst},
+    )
+    monkeypatch.setattr(
+        "cw_platform.orchestrator._snapshots.provider_configured",
+        lambda _cfg, _name: True,
+    )
+
+    cfg = {
+        "runtime": {
+            "debug": False,
+            "snapshot_ttl_sec": 0,
+            "apply_chunk_size": 0,
+            "apply_chunk_pause_ms": 0,
+        },
+        "sync": {
+            "dry_run": False,
+            "enable_add": True,
+            "enable_remove": True,
+            "include_observed_deletes": True,
+            "allow_mass_delete": True,
+            "one_way_remove_mode": "mirror",
+        },
+        "pairs": [
+            {
+                "id": "p1",
+                "enabled": True,
+                "source": "SRC",
+                "target": "DST",
+                "mode": "one-way",
+                "feature": "watchlist",
+                "features": {
+                    "watchlist": {
+                        "enable": True,
+                        "add": True,
+                        "remove": True,
+                        "remove_mode": "source_deletes",
+                    }
+                },
+            }
+        ],
+    }
+
+    orch = Orchestrator(cfg)
+    orch.run()
+    orch.run()
+
+    assert dst.remove_calls == []


### PR DESCRIPTION
# Pull request

## Change

- Make one-way remove mode pair-specific.

## Why

Different pairs may need different delete behavior. 
Source-delete mode stays the safe default, while mirror mode can be enabled only where needed.

## Testing

- tests/test_orchestrator_oneway_watchlist.py 
- tests/test_config_api.py tests/test_collection_scope_safety.py

## Issue

NA