### PR TITLE
Fix: connection modal click and delete

### DIFF
--- a/api/authenticationAPI.py
+++ b/api/authenticationAPI.py
@@ -1861,10 +1861,13 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
             return {"ok": False, "connected": False, "pending": False, "error": "verify_failed", "instance": inst}
 
     @app.post("/api/tmdb_sync/disconnect", tags=["auth"])
-    def api_tmdb_sync_disconnect(instance: str | None = Query(None)) -> dict[str, Any]:
+    def api_tmdb_sync_disconnect(instance: str | None = Query(None)) -> Any:
         inst = normalize_instance_id(instance)
         try:
             cfg = load_config()
+            conflict = usage_conflict_response(cfg, "tmdb", inst)
+            if conflict is not None:
+                return conflict
             tm = ensure_instance_block(cfg, "tmdb_sync", inst)
             tm["api_key"] = ""
             tm["session_id"] = ""
@@ -2299,9 +2302,12 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         return {"connected": bool(ok), "instance": normalize_instance_id(instance), **({} if ok else {"reason": reason})}
 
     @app.post("/api/publicmetadb/disconnect", tags=["auth"])
-    def api_publicmetadb_disconnect(instance: str | None = Query(None)) -> dict[str, Any]:
+    def api_publicmetadb_disconnect(instance: str | None = Query(None)) -> Any:
         try:
             cfg = load_config()
+            conflict = usage_conflict_response(cfg, "publicmetadb", normalize_instance_id(instance))
+            if conflict is not None:
+                return conflict
             p = ensure_instance_block(cfg, "publicmetadb", instance)
             p["api_key"] = ""
             save_config(cfg)
@@ -2533,10 +2539,13 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         return {"connected": bool(ok), "instance": inst, **({} if ok else {"reason": reason})}
 
     @app.post("/api/tautulli/disconnect", tags=["auth"])
-    def api_tautulli_disconnect(instance: str | None = Query(None)) -> dict[str, Any]:
+    def api_tautulli_disconnect(instance: str | None = Query(None)) -> Any:
         inst = normalize_instance_id(instance)
         try:
             cfg = load_config()
+            conflict = usage_conflict_response(cfg, "tautulli", inst)
+            if conflict is not None:
+                return conflict
             t = ensure_instance_block(cfg, "tautulli", inst)
             t["server_url"] = ""
             t["api_key"] = ""
@@ -2613,10 +2622,13 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         return {"connected": bool(ok), "server_url": server, "has_token": True, "verify_ssl": coerce_bool(f.get("verify_ssl", False), False), "instance": inst, **({} if ok else {"reason": reason})}
 
     @app.post("/api/floppy/disconnect", tags=["auth"])
-    def api_floppy_disconnect(instance: str | None = Query(None)) -> dict[str, Any]:
+    def api_floppy_disconnect(instance: str | None = Query(None)) -> Any:
         inst = normalize_instance_id(instance)
         try:
             cfg = load_config()
+            conflict = usage_conflict_response(cfg, "floppy", inst)
+            if conflict is not None:
+                return conflict
             f = ensure_instance_block(cfg, "floppy", inst)
             f["server_url"] = ""
             f["api_token"] = ""
@@ -2761,10 +2773,13 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
         return {**base, "connected": bool(ok), **({} if ok else {"reason": reason})}
 
     @app.post("/api/scrob/disconnect", tags=["auth"])
-    def api_scrob_disconnect(instance: str | None = Query(None)) -> dict[str, Any]:
+    def api_scrob_disconnect(instance: str | None = Query(None)) -> Any:
         inst = normalize_instance_id(instance)
         try:
             cfg = load_config()
+            conflict = usage_conflict_response(cfg, "scrob", inst)
+            if conflict is not None:
+                return conflict
             s = ensure_instance_block(cfg, "scrob", inst)
             s["server_url"] = ""
             s["api_key"] = ""
@@ -3092,9 +3107,12 @@ def register_auth(app, *, log_fn: Optional[Callable[[str, str], None]] = None, p
             return PlainTextResponse("Error", 500)
 
     @app.post("/api/anilist/token/delete", tags=["auth"])
-    def api_anilist_token_delete(instance: str = Query("default")) -> dict[str, Any]:
+    def api_anilist_token_delete(instance: str = Query("default")) -> Any:
         cfg = load_config()
         inst = normalize_instance_id(instance)
+        conflict = usage_conflict_response(cfg, "anilist", inst)
+        if conflict is not None:
+            return conflict
         a = ensure_instance_block(cfg, "anilist", inst)
         a["access_token"] = ""
         a.pop("user", None)

--- a/assets/auth/auth.anilist.js
+++ b/assets/auth/auth.anilist.js
@@ -372,6 +372,7 @@
         cache: "no-store",
       });
       const j = await r.json().catch(() => ({}));
+      if (Shared.reportProviderUsage({ status: r.status, data: j })) return;
 
       if (r.ok && j.ok !== false) {
         if (msg) {

--- a/assets/auth/auth.emby.js
+++ b/assets/auth/auth.emby.js
@@ -344,8 +344,6 @@
   }
 
   async function embyDeleteToken() {
-    const inst = getEmbyInstance();
-    if (!confirm(`Delete Emby token for "${inst}"?`)) return;
     const msg = Q("#emby_msg");
     setMsgBanner(msg, "warn", "Deleting…");
     try {

--- a/assets/auth/auth.floppy.js
+++ b/assets/auth/auth.floppy.js
@@ -110,6 +110,7 @@
   async function onDisconnect() {
     try {
       const r = await Shared.fetchJSON(api("/api/floppy/disconnect"), { method: "POST", cache: "no-store" });
+      if (Shared.reportProviderUsage(r)) return;
       if (!r.ok || (r.data && r.data.ok === false)) throw new Error(r.data?.error || "disconnect_failed");
       if (el("floppy_server")) el("floppy_server").value = "";
       Shared.maskSecret(el("floppy_token"), false);

--- a/assets/auth/auth.publicmetadb.js
+++ b/assets/auth/auth.publicmetadb.js
@@ -231,6 +231,7 @@
   async function onDisc() {
     try {
       const r = await fetchJSON(api("/api/publicmetadb/disconnect"), { method: "POST" });
+      if (Shared.reportProviderUsage(r)) return;
       if (!r.ok || (r.data && r.data.ok === false)) throw new Error("disconnect_failed");
       maskInput(el("publicmetadb_key"), false);
       el("publicmetadb_hint")?.classList.remove("hidden");

--- a/assets/auth/auth.scrob.js
+++ b/assets/auth/auth.scrob.js
@@ -182,6 +182,7 @@
   async function onDisconnect() {
     try {
       const r = await Shared.fetchJSON(api("/api/scrob/disconnect"), { method: "POST", cache: "no-store" });
+      if (Shared.reportProviderUsage(r)) return;
       if (!r.ok || (r.data && r.data.ok === false)) throw new Error(r.data?.error || "disconnect_failed");
       if (el("scrob_server")) el("scrob_server").value = "";
       if (el("scrob_username")) el("scrob_username").value = "";

--- a/assets/auth/auth.tautulli.js
+++ b/assets/auth/auth.tautulli.js
@@ -152,6 +152,7 @@
   async function onDisc() {
     try {
       const r = await fetchJSON(tautApi("/api/tautulli/disconnect"), { method: "POST" });
+      if (Shared.reportProviderUsage(r)) return;
       if (!r.ok || (r.data && r.data.ok === false)) throw new Error(r.data?.error || "disconnect_failed");
 
       maskKey(el("tautulli_key"), false);

--- a/assets/auth/auth.tmdb.js
+++ b/assets/auth/auth.tmdb.js
@@ -219,6 +219,7 @@
     stopPoll();
     try {
       const r = await fetchJSON(tmdbApi(API.disconnect), { method: "POST" });
+      if (Shared.reportProviderUsage(r)) return;
       if (!r.ok || (r.data && r.data.ok === false)) throw new Error("disconnect_failed");
       const keyEl = el("tmdb_sync_api_key");
       const sessEl = el("tmdb_sync_session_id");

--- a/assets/helpers/providers-ui.js
+++ b/assets/helpers/providers-ui.js
@@ -386,6 +386,12 @@
     overlay?.querySelector("#cw-auth-provider-picker")?.classList.remove("hidden");
   }
 
+  function setPickerHtml(picker, html) {
+    if (picker.__cwPickerHtml === html) return;
+    picker.__cwPickerHtml = html;
+    picker.innerHTML = html;
+  }
+
   function renderAuthPicker(overlay, cfg = getCachedConfig(), mode = "provider") {
     const picker = overlay?.querySelector("#cw-auth-provider-picker");
     if (!picker) return;
@@ -399,7 +405,7 @@
           <span class="cw-auth-card-status ${status.ok ? "ok" : ""}"><span></span></span>
         </button>`;
       }).join("");
-      picker.innerHTML = `<div class="cw-auth-picker-group"><h4>${META_GROUP.title}</h4><div class="cw-auth-picker-grid">${items}</div></div>`;
+      setPickerHtml(picker, `<div class="cw-auth-picker-group"><h4>${META_GROUP.title}</h4><div class="cw-auth-picker-grid">${items}</div></div>`);
       return;
     }
     const configured = configuredProviderKeys(cfg);
@@ -417,7 +423,7 @@
         }).join("");
       return items ? `<div class="cw-auth-picker-group"><h4>${group.title}</h4><div class="cw-auth-picker-grid">${items}</div></div>` : "";
     }).join("");
-    picker.innerHTML = rows || '<div class="cw-auth-empty">No supported providers found.</div>';
+    setPickerHtml(picker, rows || '<div class="cw-auth-empty">No supported providers found.</div>');
   }
 
   function renderAuthCards(slot, cfg = getCachedConfig()) {
@@ -518,13 +524,17 @@
         <div class="cw-auth-service-grid">${cards}</div>
       </section>`;
     }).join("");
-    shell.innerHTML = `
+    const dashboardHtml = `
       <div class="cw-auth-dashboard">
         <div class="cw-auth-summary-row">
           ${summaryCards}
         </div>
         <div class="cw-auth-service-list">${userProfileSection}${serviceSections}</div>
       </div>`;
+    if (shell.__cwAuthCardsHtml !== dashboardHtml) {
+      shell.__cwAuthCardsHtml = dashboardHtml;
+      shell.innerHTML = dashboardHtml;
+    }
     try { window.cwUserProfilesManager?.init?.(true); } catch {}
     const overlay = document.getElementById("cw-auth-connection-overlay");
     renderAuthPicker(overlay, cfg, overlay?.dataset?.cwPickerMode || "provider");
@@ -1627,13 +1637,64 @@
     btn.__cwConnectionDeleteTimer = setTimeout(() => resetConnectionDeleteConfirm(btn), 4200);
   }
 
+  function connectionDeleteWarningVisible(panel) {
+    const warn = panel?.querySelector(".cw-connection-footer-warn");
+    return !!(warn && !warn.classList.contains("hidden"));
+  }
+
+  function connectionConnectedPill(panel) {
+    if (!panel) return null;
+    const nodes = Array.from(panel.querySelectorAll("#plex_msg, #jfy_msg, #emby_msg, .cw-connection-status-pill"));
+    return nodes.find((node) => {
+      const text = String(node?.textContent || "").trim().toLowerCase();
+      return /\bconnected\b/.test(text) && !/\bnot\s+connected\b/.test(text) && !node.classList?.contains("hidden") && node.getAttribute?.("aria-hidden") !== "true";
+    }) || null;
+  }
+
+  async function awaitConnectionDeleteSettled(panel, hadPill) {
+    const start = Date.now();
+    const deadline = start + 2500;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      if (connectionDeleteWarningVisible(panel)) return false;
+      if (hadPill) {
+        if (!connectionConnectedPill(panel)) return true;
+      } else if (Date.now() - start >= 900) {
+        return true;
+      }
+    }
+    return !hadPill;
+  }
+
+  async function runConnectionSave(panel, info, footer) {
+    const btn = footer?.querySelector(".cw-connection-footer-save");
+    if (btn?.__cwSaving) return false;
+    if (btn) {
+      btn.__cwSaving = true;
+      setConnectionSaveBusy(btn, true);
+    }
+    try {
+      await window.CW?.AuthShared?.saveVisibleProfileLabels?.(panel);
+      if (info.key === "NUVIO") await window.cwAuth?.nuvio?.saveSelectedProfile?.({ silent: true });
+      const ret = window.saveSettings?.();
+      if (ret && typeof ret.then === "function") await ret;
+      if (btn) flashConnectionResult(btn, true);
+      return true;
+    } catch {
+      if (btn) flashConnectionResult(btn, false);
+      return false;
+    } finally {
+      if (btn) btn.__cwSaving = false;
+    }
+  }
+
   function ensureConnectionModalFooter(panel, info) {
     if (!panel.querySelector(":scope > .cw-connection-modal-footer")) {
       const footer = document.createElement("div");
       footer.className = "cw-connection-modal-footer";
       footer.innerHTML = `<button type="button" class="btn danger cw-connection-footer-delete"><span class="material-symbols-rounded" aria-hidden="true">delete</span><span>Delete connection</span></button><span class="cw-connection-footer-warn hidden" role="alert" aria-live="polite"></span><button type="button" class="btn cw-connection-footer-cancel">Cancel</button><button type="button" class="btn primary cw-connection-footer-save">Save changes</button>`;
       panel.appendChild(footer);
-      footer.querySelector(".cw-connection-footer-delete")?.addEventListener("click", (ev) => {
+      footer.querySelector(".cw-connection-footer-delete")?.addEventListener("click", async (ev) => {
         const trigger = ev.currentTarget;
         if (connectionDeleteBlockedByProfiles(panel, info)) {
           resetConnectionDeleteConfirm(trigger);
@@ -1645,38 +1706,32 @@
           return;
         }
         resetConnectionDeleteConfirm(trigger);
-        const btn = info.deleteSelector ? panel.querySelector(info.deleteSelector) || document.querySelector(info.deleteSelector) : null;
-        btn?.click?.();
-        [700, 1600].forEach((delay) => setTimeout(() => {
-          const warn = panel.querySelector(".cw-connection-footer-warn");
-          if (warn && !warn.classList.contains("hidden")) return;
+        if (trigger.__cwDeleting) return;
+        trigger.__cwDeleting = true;
+        try { window.CW.AuthShared.clearConnectionWarnings(); } catch {}
+        try {
+          const btn = info.deleteSelector ? panel.querySelector(info.deleteSelector) || document.querySelector(info.deleteSelector) : null;
+          if (!btn) return;
+          const hadPill = !!connectionConnectedPill(panel);
+          btn.click();
+          if (!await awaitConnectionDeleteSettled(panel, hadPill)) return;
           showConnectionDisconnected(panel);
-        }, delay));
+          if (!await runConnectionSave(panel, info, footer)) return;
+          setTimeout(closeAuthProviderOverlay, 600);
+        } finally {
+          trigger.__cwDeleting = false;
+        }
       });
       footer.querySelector(".cw-connection-footer-cancel")?.addEventListener("click", () => {
         resetConnectionDeleteConfirm(footer.querySelector(".cw-connection-footer-delete"));
         closeAuthProviderOverlay();
       });
-      footer.querySelector(".cw-connection-footer-save")?.addEventListener("click", async (ev) => {
+      footer.querySelector(".cw-connection-footer-save")?.addEventListener("click", async () => {
         resetConnectionDeleteConfirm(footer.querySelector(".cw-connection-footer-delete"));
-        const btn = ev.currentTarget;
-        if (btn.__cwSaving) return;
         const keepOpen = ["PLEX", "JELLYFIN", "EMBY"].includes(info.key);
-        btn.__cwSaving = true;
-        setConnectionSaveBusy(btn, true);
-        try {
-          await window.CW?.AuthShared?.saveVisibleProfileLabels?.(panel);
-          if (info.key === "NUVIO") await window.cwAuth?.nuvio?.saveSelectedProfile?.({ silent: true });
-          const ret = window.saveSettings?.();
-          if (ret && typeof ret.then === "function") await ret;
-          flashConnectionResult(btn, true);
-          loadConfig(true).then((cfg) => syncConnectionSuccessState(panel, info, cfg)).catch(() => {});
-          if (!keepOpen) setTimeout(closeAuthProviderOverlay, 1100);
-        } catch {
-          flashConnectionResult(btn, false);
-        } finally {
-          btn.__cwSaving = false;
-        }
+        if (!await runConnectionSave(panel, info, footer)) return;
+        loadConfig(true).then((cfg) => syncConnectionSuccessState(panel, info, cfg)).catch(() => {});
+        if (!keepOpen) setTimeout(closeAuthProviderOverlay, 1100);
       });
     }
     const deleteBtn = panel.querySelector(".cw-connection-footer-delete");
@@ -1909,8 +1964,30 @@
     });
   }
 
+  let pointerHeld = false;
+  let deferredCardRender = false;
+  function flushDeferredCardRender() {
+    if (!deferredCardRender) return;
+    deferredCardRender = false;
+    const slot = document.getElementById("auth-providers");
+    if (slot) renderAuthCards(slot, getCachedConfig());
+  }
+  function releasePointerHold() {
+    if (!pointerHeld) return;
+    pointerHeld = false;
+    setTimeout(flushDeferredCardRender, 0);
+  }
+  document.addEventListener("pointerdown", () => { pointerHeld = true; }, true);
+  document.addEventListener("pointerup", releasePointerHold, true);
+  document.addEventListener("pointercancel", releasePointerHold, true);
+  window.addEventListener("blur", releasePointerHold);
+
   async function refreshAuthPresentation(slot, force = false) {
     const cfg = await loadConfig(!!force);
+    if (pointerHeld) {
+      deferredCardRender = true;
+      return;
+    }
     renderAuthCards(slot, cfg);
   }
 

--- a/assets/js/user-profiles.js
+++ b/assets/js/user-profiles.js
@@ -362,20 +362,32 @@
       </div>`;
   }
 
+  function setHostHtml(host, html) {
+    if (host.__cwUpmHtml === html) return;
+    host.__cwUpmHtml = html;
+    host.innerHTML = html;
+  }
+
+  function invalidateHostHtml() {
+    [$(HOST_ID), $("cw-upm-floating-host")].forEach((node) => {
+      if (node) node.__cwUpmHtml = null;
+    });
+  }
+
   function render() {
     const host = (floatingModal ? $("cw-upm-floating-host") : null) || $(HOST_ID);
     if (!host) return;
     if (floatingModal) {
-      host.innerHTML = renderModal();
+      setHostHtml(host, renderModal());
       return;
     }
-    host.innerHTML = `
+    setHostHtml(host, `
       <div class="cw-auth-service-grid cw-upm-service-grid">
         ${userProfiles.map(renderProfileCard).join("")}
         ${renderAddCard()}
       </div>
       <div class="cw-upm-status" id="cw-upm-status"></div>
-      ${renderModal()}`;
+      ${renderModal()}`);
   }
 
   async function load(force = false) {
@@ -407,7 +419,10 @@
       loadedOnce = true;
     } catch (e) {
       const status = $("cw-upm-status");
-      if (status) status.textContent = String(e?.message || e || "Failed to load user profiles");
+      if (status) {
+        status.textContent = String(e?.message || e || "Failed to load user profiles");
+        invalidateHostHtml();
+      }
       toast("Could not load user profiles: " + String(e?.message || e), false);
     } finally {
       loading = false;
@@ -561,6 +576,7 @@
     target.dataset.cwConfirmDelete = "";
     target.classList.remove("is-confirming");
     target.innerHTML = `<span class="material-symbols-rounded" aria-hidden="true">delete</span><span>Delete profile</span>`;
+    invalidateHostHtml();
   }
 
   function armDeleteConfirm(btn) {
@@ -568,6 +584,7 @@
     btn.dataset.cwConfirmDelete = "1";
     btn.classList.add("is-confirming");
     btn.innerHTML = `<span class="material-symbols-rounded" aria-hidden="true">warning</span><span>Confirm delete</span>`;
+    invalidateHostHtml();
     if (deleteConfirmTimer) clearTimeout(deleteConfirmTimer);
     deleteConfirmTimer = setTimeout(() => resetDeleteConfirm(btn), 4200);
   }
@@ -582,6 +599,7 @@
     node.classList.add("hidden");
     node.classList.remove("is-fading");
     node.textContent = "";
+    invalidateHostHtml();
   }
 
   function showDeleteWarning(message) {
@@ -595,6 +613,7 @@
     node.innerHTML = `<span class="material-symbols-rounded" aria-hidden="true">warning</span><span class="cw-connection-footer-warn-text"></span>`;
     node.lastElementChild.textContent = text;
     node.classList.remove("hidden", "is-fading");
+    invalidateHostHtml();
   }
 
   async function deleteProfile(btn) {


### PR DESCRIPTION
# Pull request

## Change

- Provider cards no longer rebuild on every render, so clicks stop getting swallowed.
- Delete connection now saves and closes the modal by itself.
- Dropped the extra confirm dialog on Emby.
- Added the in-use guard to AniList, TMDb, PublicMetaDB, Floppy, Tautulli and Scrob. The other providers already had it.

## Why

The cards were wiped and rebuilt on every status or config refresh.

## Testing

NA

## Issue

NA