### PR TITLE
Fix: statistics week and month numbers

### DIFF
--- a/api/insightAPI.py
+++ b/api/insightAPI.py
@@ -1877,6 +1877,12 @@ def register_insights(app: FastAPI) -> None:
                         bucket = "remove"
                     elif anyin(action, ("update", "edit", "rename", "move", "reorder")):
                         bucket = "update"
+                elif feat == "collection" or ("collection" in feat) or ("collect" in action) or ("library" in feat):
+                    lane_name = "collection"
+                    if anyin(action, ("uncollect", "remove", "delete", "del", "rm", "clear")):
+                        bucket = "remove"
+                    elif anyin(action, ("update", "edit", "upgrade", "replace", "fix")):
+                        bucket = "update"
                 else:
                     is_history_feat = feat in ("history", "watch", "watched") or ("history" in action)
                     is_add_like = anyin(action, ("watch", "scrobble", "checkin", "mark_watched", "history_add", "add_history"))
@@ -2418,8 +2424,6 @@ def register_insights(app: FastAPI) -> None:
 
 
         now_ts = int(time.time())
-        week_floor = now_ts - 7 * 86400
-        month_floor = now_ts - 30 * 86400
 
         def _last_run_lane(feat: str) -> dict[str, Any]:
             for row in rows:
@@ -2470,6 +2474,7 @@ def register_insights(app: FastAPI) -> None:
             return out
 
         week_tot = _lane_totals(7)
+        month_tot = _lane_totals(30)
 
         ts_grid = [r["ts"] for r in series_by_feature.get("watchlist", [])]
         if len(ts_grid) < 2:
@@ -2502,22 +2507,12 @@ def register_insights(app: FastAPI) -> None:
                 out_series.append({"ts": ts_grid[i], "count": v})
             series_by_feature[f] = list(reversed(out_series))
 
-        def _val_at(series_list: list[dict[str, int]], floor_ts: int) -> int:
-            try:
-                arr = sorted(series_list or [], key=lambda r: int(r.get("ts") or 0))
-                if not arr:
-                    return 0
-                val = int(arr[0].get("count") or 0)
-                for r in arr:
-                    t = int(r.get("ts") or 0)
-                    if t <= floor_ts:
-                        val = int(r.get("count") or 0)
-                    else:
-                        break
-                return val
-            except Exception:
-                return 0
-            
+        def _window_totals(feat: str, totals: dict[str, tuple[int, int, int]]) -> tuple[int, int]:
+            lane = totals.get(feat)
+            if isinstance(lane, tuple) and len(lane) == 3:
+                return int(lane[0] or 0), int(lane[1] or 0)
+            return 0, 0
+
         history_counts = derived.get("history_counts") or {}
 
         feats_out: dict[str, dict[str, Any]] = {}
@@ -2526,17 +2521,19 @@ def register_insights(app: FastAPI) -> None:
             add_last = int(last_lane.get("added") or 0)
             rem_last = int(last_lane.get("removed") or 0)
             upd_last = int(last_lane.get("updated") or 0)
-            t = week_tot.get(feat)
-            if isinstance(t, tuple) and len(t) == 3:
-                wa, wr, wu = t
-            else:
-                wa, wr, wu = (0, 0, 0)
 
             s = series_by_feature.get(feat, [])
+            now_val = _union_now(feat)
+            week_added, week_removed = _window_totals(feat, week_tot)
+            month_added, month_removed = _window_totals(feat, month_tot)
+            week_added = min(week_added, now_val + week_removed)
+            month_added = min(month_added, now_val + month_removed)
             feats_out[feat] = {
-                "now": _union_now(feat),
-                "week": _val_at(s, week_floor),
-                "month": _val_at(s, month_floor),
+                "now": now_val,
+                "week": week_added,
+                "month": month_added,
+                "week_removed": week_removed,
+                "month_removed": month_removed,
                 "added": add_last,
                 "removed": rem_last,
                 "updated": upd_last,

--- a/assets/helpers/core.js
+++ b/assets/helpers/core.js
@@ -1784,13 +1784,13 @@
     if (!chart || !tip) return;
 
     [
-      [document.querySelector(".bar.week"), "Last Week"],
-      [document.querySelector(".bar.month"), "Last Month"],
-      [document.querySelector(".bar.now"), "Now"],
-    ].forEach(([el, label]) => {
+      [document.querySelector(".bar.week"), "Last Week", "added"],
+      [document.querySelector(".bar.month"), "Last Month", "added"],
+      [document.querySelector(".bar.now"), "Now", "items"],
+    ].forEach(([el, label, unit]) => {
       if (!el) return;
       const show = (x, y) => {
-        tip.textContent = `${label}: ${el.dataset.v || "0"} items`;
+        tip.textContent = `${label}: ${el.dataset.v || "0"} ${unit}`;
         tip.style.left = `${x}px`;
         tip.style.top = `${y}px`;
         tip.hidden = false;

--- a/assets/js/insights.js
+++ b/assets/js/insights.js
@@ -221,8 +221,8 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
     }, { A: 0, R: 0, S: 0 });
     const ms = Date.now();
     if (!Number.isFinite(+now)) now = rows.length ? totalsFor(feat, rows.at(-1).r).sum : 0;
-    if (!Number.isFinite(+week)) week = sumSince(ms - 7 * 86400000).S;
-    if (!Number.isFinite(+month)) month = sumSince(ms - 30 * 86400000).S;
+    if (!Number.isFinite(+week)) week = sumSince(ms - 7 * 86400000).A;
+    if (!Number.isFinite(+month)) month = sumSince(ms - 30 * 86400000).A;
     if (!Number.isFinite(+added) || !Number.isFinite(+removed)) {
       const m = sumSince(ms - 30 * 86400000);
       if (!Number.isFinite(+added)) added = m.A;
@@ -233,6 +233,7 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
       providers: raw.providers || {},
       active: raw.providers_active || data?.providers_active || {},
       now: asNum(now), week: asNum(week), month: asNum(month), added: asNum(added), removed: asNum(removed),
+      weekRemoved: asNum(raw.week_removed), monthRemoved: asNum(raw.month_removed),
       raw
     };
   }
@@ -591,7 +592,7 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
     }).join("");
   }
 
-  function renderTopStats({ now = 0, week = 0, month = 0, added = 0, removed = 0 }) {
+  function renderTopStats({ now = 0, week = 0, month = 0, added = 0, removed = 0, weekRemoved = 0 }) {
     [["#stat-now", now], ["#stat-week", week], ["#stat-month", month], ["#stat-added", added], ["#stat-removed", removed]].forEach(([sel, val]) => animateNumber($(sel), val | 0));
     const fill = $("#stat-fill"), max = Math.max(1, now, week, month);
     if (fill) fill.style.width = `${Math.round(now / max * 100)}%`;
@@ -600,12 +601,12 @@ const FEAT_ICON = { watchlist:"movie", ratings:"star", history:"play_arrow", pro
     if (lab) lab.textContent = featureLabel(_feature);
     const chip = $("#trend-week") || $("#stat-delta-chip");
     if (chip) {
-      const diff = (now | 0) - (week | 0);
-      chip.textContent = diff === 0 ? "no change" : `${diff > 0 ? "+" : ""}${diff} vs last week`;
+      const diff = (week | 0) - (weekRemoved | 0);
+      chip.textContent = diff === 0 ? "no change" : `${diff > 0 ? "+" : ""}${diff} this week`;
       chip.classList.remove("up", "down", "flat", "muted");
       chip.classList.add(diff > 0 ? "up" : diff < 0 ? "down" : "flat");
       chip.classList.toggle("muted", diff === 0);
-      chip.title = diff === 0 ? "No change versus last week" : `${Math.abs(diff)} ${diff > 0 ? "more" : "fewer"} than last week`;
+      chip.title = diff === 0 ? "No change in the last 7 days" : `${week | 0} added, ${weekRemoved | 0} removed in the last 7 days`;
     }
     $("#stat-breakdown")?.remove();
   }

--- a/services/dashboard_widgets.py
+++ b/services/dashboard_widgets.py
@@ -619,6 +619,18 @@ _ART_RESOLVE_WORKERS = 8
 _ROW_WINDOW = 400
 
 
+def _window_per_source(entries: list, window: int | None, *, rank, source_of) -> list:
+    if window is None or window <= 0 or len(entries) <= window:
+        return list(entries)
+    buckets: dict[Any, list] = {}
+    for entry in entries:
+        buckets.setdefault(source_of(entry), []).append(entry)
+    out: list = []
+    for bucket in buckets.values():
+        out.extend(heapq.nlargest(window, bucket, key=rank) if len(bucket) > window else bucket)
+    return out
+
+
 def _needs_metadata_lookup(row: Mapping[str, Any]) -> bool:
     if not (row.get("poster") or row.get("tmdb")):
         return True
@@ -986,10 +998,15 @@ def latest_ratings_widget(
             reverse=True,
         )
 
-    windowed = entries
-    if window is not None and window > 0 and len(entries) > window:
-        windowed = heapq.nlargest(window, entries, key=lambda entry: entry[0])
-        windowed.sort(key=lambda entry: entry[1])
+    windowed = _window_per_source(
+        entries,
+        window,
+        rank=lambda entry: entry[0],
+        source_of=lambda entry: tuple(
+            (ref.get("provider"), ref.get("instance")) for ref in (entry[4] or [])
+        ),
+    )
+    windowed.sort(key=lambda entry: entry[1])
 
     items = _build(windowed)
     if len(items) < cap and len(windowed) < len(entries):
@@ -1164,9 +1181,13 @@ def _latest_history_state_rows(
             key = str(raw_key)
             epoch = int(_history_sort_epoch(item) or _history_key_epoch(key) or 0)
             entries.append((epoch, len(entries), key, item, ref))
-    if window is not None and window > 0 and len(entries) > window:
-        entries = heapq.nlargest(window, entries, key=lambda entry: entry[0])
-        entries.sort(key=lambda entry: entry[1])
+    entries = _window_per_source(
+        entries,
+        window,
+        rank=lambda entry: entry[0],
+        source_of=lambda entry: (entry[4]["provider"], entry[4]["instance"]),
+    )
+    entries.sort(key=lambda entry: entry[1])
     for _epoch, _ordinal, raw_key, item, ref in entries:
         row = _history_state_row(raw_key, item, [ref])
         if not row:

--- a/tests/test_dashboard_widget_source_attribution.py
+++ b/tests/test_dashboard_widget_source_attribution.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from services import dashboard_widgets
+
+
+def _movie(idx: int) -> dict:
+    return {
+        "type": "movie",
+        "title": f"Movie {idx}",
+        "year": 2020,
+        "watched_at": "2026-09-01T00:00:00Z",
+        "ids": {"tmdb": str(5000 + idx)},
+    }
+
+
+def _state(count: int) -> dict:
+    items = {f"tmdb:{5000 + i}": _movie(i) for i in range(count)}
+    return {
+        "providers": {
+            "CROSSWATCH": {"history": {"baseline": {"items": dict(items)}}},
+            "TRAKT": {"history": {"baseline": {"items": dict(items)}}},
+        }
+    }
+
+
+def _providers_of(row) -> set[str]:
+    return {str(s.get("provider") or "").upper() for s in row.get("sources") or []}
+
+
+def test_history_rows_keep_every_provider_past_the_row_window(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_widgets, "_resolve_missing_art_rows", lambda rows, **_k: rows)
+    # more items per provider than the window, all sharing one watched_at
+    count = dashboard_widgets._ROW_WINDOW + 50
+    payload = dashboard_widgets.recent_history_widget(_state(count), limit=6)
+
+    rows = payload["items"]
+    assert rows
+    for row in rows:
+        assert _providers_of(row) == {"CROSSWATCH", "TRAKT"}, row.get("title")
+
+
+def test_ratings_rows_keep_every_provider_past_the_row_window(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_widgets, "_resolve_missing_art_rows", lambda rows, **_k: rows)
+    count = dashboard_widgets._ROW_WINDOW + 50
+    items = {
+        f"tmdb:{6000 + i}": {
+            "type": "movie",
+            "title": f"Rated {i}",
+            "year": 2020,
+            "rating": 8,
+            "rated_at": "2026-08-01T00:00:00Z",
+            "ids": {"tmdb": str(6000 + i)},
+        }
+        for i in range(count)
+    }
+    state = {
+        "providers": {
+            "CROSSWATCH": {"ratings": {"baseline": {"items": dict(items)}}},
+            "TRAKT": {"ratings": {"baseline": {"items": dict(items)}}},
+        }
+    }
+    payload = dashboard_widgets.latest_ratings_widget(state, limit=6)
+
+    rows = payload["items"]
+    assert rows
+    for row in rows:
+        assert _providers_of(row) == {"CROSSWATCH", "TRAKT"}, row.get("title")

--- a/tests/test_insights_week_month_windows.py
+++ b/tests/test_insights_week_month_windows.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api import insightAPI as insight_api
+
+NOW = int(time.time())
+DAY = 86400
+
+
+def _movie(idx: int, extra: dict) -> dict:
+    base = {"type": "movie", "title": f"Movie {idx}", "ids": {"tmdb": str(1000 + idx)}}
+    base.update(extra)
+    return base
+
+
+def _client(monkeypatch, state, events):
+    class Stats:
+        data = {"samples": [], "events": list(events)}
+
+    cw = SimpleNamespace(
+        STATS=Stats(),
+        REPORT_DIR=None,
+        CACHE_DIR=None,
+        _load_wall_snapshot=lambda: [],
+        _append_log=lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(insight_api, "_env", lambda: (cw, lambda: {}, lambda _cfg: None, lambda *a, **k: None))
+    monkeypatch.setattr(insight_api, "_load_state_features", lambda _features: state)
+
+    app = FastAPI()
+    insight_api.register_insights(app)
+    return TestClient(app).get("/api/insights?limit_samples=0&history=0&include_events=0").json()
+
+
+def test_week_and_month_count_what_was_added_in_each_window(monkeypatch) -> None:
+    state = {
+        "providers": {
+            "PLEX": {
+                "history": {"baseline": {"items": {
+                    f"tmdb:{1000 + i}": _movie(i, {"watched_at": "2026-09-01T00:00:00Z"}) for i in range(2)
+                }}},
+                "ratings": {"baseline": {"items": {
+                    f"tmdb:{2000 + i}": _movie(i, {"rating": 8, "rated_at": "2026-08-01T00:00:00Z"}) for i in range(2)
+                }}},
+            }
+        }
+    }
+    events = [
+        {"ts": NOW - DAY, "action": "add", "feature": "history", "key": f"h{i}"} for i in range(2)
+    ] + [
+        {"ts": NOW - 20 * DAY, "action": "rate", "feature": "ratings", "key": f"r{i}"} for i in range(2)
+    ]
+
+    feats = _client(monkeypatch, state, events)["features"]
+    hist, rate = feats["history"], feats["ratings"]
+
+    # history: 2 added a day ago -> inside both windows
+    assert hist["week"] == 2
+    assert hist["month"] == 2
+
+    # ratings: 2 added 20 days ago -> outside the week, inside the month
+    assert rate["week"] == 0
+    assert rate["month"] == 2
+
+
+def test_quiet_feature_reports_nothing_added(monkeypatch) -> None:
+    state = {
+        "providers": {
+            "PLEX": {
+                "watchlist": {"baseline": {"items": {
+                    f"tmdb:{3000 + i}": _movie(i, {}) for i in range(4)
+                }}}
+            }
+        }
+    }
+    wl = _client(monkeypatch, state, [])["features"]["watchlist"]
+    assert wl["now"] == 4
+    assert wl["week"] == 0
+    assert wl["month"] == 0
+    assert wl["week_removed"] == 0
+
+
+def test_removals_are_reported_separately_from_adds(monkeypatch) -> None:
+    state = {
+        "providers": {
+            "PLEX": {
+                "watchlist": {"baseline": {"items": {
+                    f"tmdb:{4000 + i}": _movie(i, {}) for i in range(3)
+                }}}
+            }
+        }
+    }
+    events = [
+        {"ts": NOW - 2 * DAY, "action": "watchlist_add", "feature": "watchlist", "key": f"a{i}"}
+        for i in range(2)
+    ] + [
+        {"ts": NOW - 2 * DAY, "action": "watchlist_remove", "feature": "watchlist", "key": f"w{i}"}
+        for i in range(5)
+    ]
+    wl = _client(monkeypatch, state, events)["features"]["watchlist"]
+    assert wl["now"] == 3
+    assert wl["week"] == 2
+    assert wl["week_removed"] == 5
+    assert wl["month"] == 2
+    assert wl["month_removed"] == 5
+
+
+def test_collection_events_feed_the_collection_lane(monkeypatch) -> None:
+    state = {
+        "providers": {
+            "PLEX": {
+                "collection": {"baseline": {"items": {
+                    f"tmdb:{7000 + i}": _movie(i, {}) for i in range(10)
+                }}}
+            }
+        }
+    }
+    events = (
+        [{"ts": NOW - DAY, "action": "add", "feature": "collection", "key": f"c{i}"} for i in range(4)]
+        + [{"ts": NOW - 20 * DAY, "action": "add", "feature": "collection", "key": f"c{40 + i}"} for i in range(6)]
+        + [{"ts": NOW - 2 * DAY, "action": "remove", "feature": "collection", "key": f"c{80 + i}"} for i in range(2)]
+    )
+
+    coll = _client(monkeypatch, state, events)["features"]["collection"]
+    assert coll["now"] == 10
+    assert coll["week"] == 4
+    assert coll["week_removed"] == 2
+    assert coll["month"] == 10
+    assert coll["month_removed"] == 2
+
+
+def test_collection_events_do_not_leak_into_other_lanes(monkeypatch) -> None:
+    state = {
+        "providers": {
+            "PLEX": {
+                "collection": {"baseline": {"items": {
+                    f"tmdb:{7000 + i}": _movie(i, {}) for i in range(3)
+                }}},
+                "watchlist": {"baseline": {"items": {"tmdb:8000": _movie(9, {})}}},
+            }
+        }
+    }
+    events = [{"ts": NOW - DAY, "action": "add", "feature": "collection", "key": f"c{i}"} for i in range(3)]
+    feats = _client(monkeypatch, state, events)["features"]
+    assert feats["collection"]["week"] == 3
+    assert feats["watchlist"]["week"] == 0
+    assert feats["history"]["week"] == 0
+    assert feats["playlists"]["week"] == 0
+
+
+def test_repeated_runs_do_not_inflate_the_window_adds(monkeypatch) -> None:
+    # 1561 rows on disk, but three successive runs each reported them as added
+    state = {
+        "providers": {
+            "CROSSWATCH": {
+                "history": {"baseline": {"items": {
+                    f"tmdb:{9000 + i}": _movie(i, {"watched_at": "2026-09-01T00:00:00Z"})
+                    for i in range(30)
+                }}}
+            }
+        }
+    }
+    events = [
+        {"ts": NOW - run * DAY, "action": "add", "feature": "history", "key": f"agg:history:add:{run}:{i}"}
+        for run in (1, 2, 3)
+        for i in range(30)
+    ]
+
+    hist = _client(monkeypatch, state, events)["features"]["history"]
+    assert hist["now"] == 30
+    # 90 raw add events, but only 30 items can possibly exist
+    assert hist["week"] == 30
+    assert hist["month"] == 30
+
+
+def test_churn_still_counts_adds_above_the_current_level(monkeypatch) -> None:
+    # 10 present now, 40 removed during the window -> up to 50 distinct adds are reachable
+    state = {
+        "providers": {
+            "PLEX": {
+                "watchlist": {"baseline": {"items": {
+                    f"tmdb:{9500 + i}": _movie(i, {}) for i in range(10)
+                }}}
+            }
+        }
+    }
+    events = (
+        [{"ts": NOW - DAY, "action": "watchlist_add", "feature": "watchlist", "key": f"a{i}"} for i in range(50)]
+        + [{"ts": NOW - DAY, "action": "watchlist_remove", "feature": "watchlist", "key": f"r{i}"} for i in range(40)]
+    )
+    wl = _client(monkeypatch, state, events)["features"]["watchlist"]
+    assert wl["now"] == 10
+    assert wl["week"] == 50
+    assert wl["week_removed"] == 40


### PR DESCRIPTION
# Pull request

## Change

- Last Week and Last Month now count what was added in that window, capped so repeated runs cannot inflate them. 
- Collection got its own lane. 
- Widget rows keep every provider icon. 

## Why

- Week and month always showed the same number

## Testing

- tests/test_insights_week_month_windows.py 
- tests/test_dashboard_widget_source_attribution.py

## Issue

NA