### PR TITLE
Add: sync activity calendar

### DIFF
--- a/api/eventsAPI.py
+++ b/api/eventsAPI.py
@@ -37,6 +37,13 @@ from cw_platform.event_archive import (
     acknowledge_group as _acknowledge_group,
     unacknowledge_group as _unacknowledge_group,
     events_db_path,
+    calendar as _calendar,
+    day_runs as _day_runs,
+    CalendarScope,
+    CALENDAR_ALL,
+    scope_key as _scope_key,
+    invalidate_calendar as _invalidate_calendar,
+    purge as _purge_events,
 )
 from cw_platform.event_archive.groups import run_problem_items as _run_problem_items
 from cw_platform.access_policy import filter_pairs_for_user, pair_refs, request_user, user_can_access_instance
@@ -619,6 +626,57 @@ def events_statistics(
     return _ok(_statistics(since=s, until=u, bucket=bs))
 
 
+_CALENDAR_MIN_DAYS = 7
+_CALENDAR_MAX_DAYS = 400
+
+
+def _calendar_scope(cfg: dict[str, Any], request: Request | None) -> CalendarScope:
+    user = request_user(request)
+    if not user or bool(user.get("is_admin")):
+        return CALENDAR_ALL
+    pair_ids: set[str] = set()
+    scope_keys: set[str] = set()
+    for pair in filter_pairs_for_user(cfg, user, _configured_pairs(cfg)):
+        pid = str(pair.get("id") or "").strip()
+        if pid:
+            pair_ids.add(pid)
+        (src, src_inst), (dst, dst_inst) = pair_refs(pair)
+        key = _scope_key(src, src_inst, dst, dst_inst)
+        if key:
+            scope_keys.add(key)
+    return CalendarScope(unrestricted=False, pair_ids=pair_ids, scope_keys=scope_keys)
+
+
+@router.get("/calendar")
+def events_calendar(
+    days: int = Query(371, ge=_CALENDAR_MIN_DAYS, le=_CALENDAR_MAX_DAYS),
+    tz: int = Query(0),
+    request: Request = cast(Request, None),
+) -> JSONResponse:
+    scope = _calendar_scope(load_config() or {}, request)
+    now = int(_time.time())
+    until = now + 86400
+    since = until - int(days) * 86400
+    payload = _calendar(since=since, until=until, tz_offset=tz, scope=scope)
+    payload["scoped"] = not scope.unrestricted
+    return _ok(payload)
+
+
+@router.get("/calendar/day")
+def events_calendar_day(
+    since: int = Query(..., ge=0),
+    until: int = Query(..., ge=0),
+    limit: int = Query(200, ge=1, le=500),
+    request: Request = cast(Request, None),
+) -> JSONResponse:
+    if until <= since or until - since > 7 * 86400:
+        return _ok({"ok": False, "error": "invalid_range"}, status_code=400)
+    scope = _calendar_scope(load_config() or {}, request)
+    payload = _day_runs(since=since, until=until, scope=scope, limit=limit)
+    payload["scoped"] = not scope.unrestricted
+    return _ok(payload)
+
+
 @router.get("/recent")
 def events_recent(
     limit: int = Query(50, ge=1, le=500),
@@ -944,24 +1002,11 @@ def events_clear(payload: dict[str, Any] | None = Body(None), request: Request =
         return _scope_denied()
     if not bool((payload or {}).get("confirm")):
         return _ok({"ok": False, "error": "confirmation_required", "confirm": False}, status_code=400)
-    conn = get_conn()
-    if conn is None:
-        return _ok({"ok": False, "available": False, "path": str(events_db_path())})
     domain = str((payload or {}).get("domain") or "").strip().lower()
-    try:
-        with conn:
-            if domain in ("", "all"):
-                conn.execute("DELETE FROM events")
-                conn.execute("DELETE FROM event_groups")
-                conn.execute("DELETE FROM sync_runs")
-                conn.execute("DELETE FROM event_imports")
-            else:
-                conn.execute("DELETE FROM events WHERE domain=?", (domain,))
-                conn.execute("DELETE FROM event_groups WHERE domain=?", (domain,))
-                if domain == "sync":
-                    conn.execute("DELETE FROM sync_runs")
-                    conn.execute("DELETE FROM event_imports")
-        return _ok({"ok": True, "cleared": True, "domain": domain or "all"})
-    except Exception:
-        _LOG.exception("events clear failed")
+    result = _purge_events(domain)
+    if not result.get("ok"):
+        if result.get("available") is False:
+            return _ok(result)
+        _LOG.error("events clear failed: %s", result.get("error"))
         return _ok({"ok": False, "error": "internal_error"}, status_code=500)
+    return _ok(result)

--- a/api/maintenanceAPI.py
+++ b/api/maintenanceAPI.py
@@ -848,7 +848,7 @@ def maintenance_action_status(action: str) -> dict[str, Any]:
                 _metric("Capture storage kept", captures["bytes"], "bytes"),
             ],
         )
-    elif action in ("events-health", "events-optimize", "events-rebuild"):
+    elif action in ("events-health", "events-optimize", "events-rebuild", "events-purge"):
         from cw_platform import event_archive as _ea
         st = _ea.status()
         db_path = Path(_ea.events_db_path())
@@ -876,6 +876,16 @@ def maintenance_action_status(action: str) -> dict[str, Any]:
                     _metric("Events", events),
                     _metric("Archive size", size, "bytes"),
                     _metric("Last updated", usage.get("modified"), "datetime"),
+                ],
+            )
+        elif action == "events-purge":
+            response.update(
+                title="Clear event data",
+                note="Empties every event category plus the sync activity calendar. Leaves the rest of the local database untouched. This cannot be undone.",
+                metrics=[
+                    _metric("Events removed", events),
+                    _metric("Sync runs removed", runs),
+                    _metric("Acknowledged", acknowledged),
                 ],
             )
         else:
@@ -1486,6 +1496,19 @@ def maintenance_events_rebuild(payload: dict[str, Any] | None = Body(None)) -> d
         return rebuild(reimport=False)
     except Exception:
         _LOG.exception("events-rebuild failed")
+        return {"ok": False, "error": "internal_error"}
+
+
+@router.post("/events-purge")
+def maintenance_events_purge(payload: dict[str, Any] | None = Body(None)) -> dict[str, Any]:
+    if not bool((payload or {}).get("confirm")):
+        return {"ok": False, "error": "confirmation_required", "confirm": False}
+    try:
+        from cw_platform.event_archive.maintenance import purge
+
+        return purge(None)
+    except Exception:
+        _LOG.exception("events-purge failed")
         return {"ok": False, "error": "internal_error"}
 
 

--- a/assets/js/modals.js
+++ b/assets/js/modals.js
@@ -36,6 +36,7 @@ ModalRegistry.register('scrobbler-route', () => import(_cwVer('./modals/scrobble
 ModalRegistry.register('editor-raw', () => import(_cwVer('./modals/editor-raw/index.js')));
 ModalRegistry.register('anime-overrides', () => import(_cwVer('./modals/anime-overrides/index.js')));
 ModalRegistry.register('support',      () => import(_cwVer('./modals/support/index.js')));
+ModalRegistry.register('statistics',   () => import(_cwVer('./modals/statistics/index.js')));
 
 export const openModal = ModalRegistry.open;
 export const closeModal = ModalRegistry.close;
@@ -56,6 +57,7 @@ window.closeAbout = async () => {
 
 window.openAnalyzer = (props = {}) => ModalRegistry.open('analyzer', props);
 window.openEvents = (props = {}) => ModalRegistry.open('events', props);
+window.openStatisticsModal = (props = {}) => ModalRegistry.open('statistics', props);
 window.openExporter = (props = {}) => ModalRegistry.open('exporter', props);
 
 window.openMaintenanceModal = (props = {}) => ModalRegistry.open('maintenance', props);

--- a/assets/js/modals/events/index.js
+++ b/assets/js/modals/events/index.js
@@ -460,7 +460,9 @@ export default {
     const initialDomain = String(props?.domain || "").trim().toLowerCase();
     const initialVisibility = String(props?.visibility || "").trim().toLowerCase();
     const initialMode = String(props?.mode || "").trim().toLowerCase();
+    let runFilter = String(props?.runId || props?.run_id || "").trim();
     let visibility = ["open", "acknowledged", "all"].includes(initialVisibility) ? initialVisibility : ls("cw.events.visibility", "open");
+    if (runFilter) visibility = ["open", "acknowledged", "all"].includes(initialVisibility) ? initialVisibility : "all";
     let order = "newest";
     let mode = ["grouped", "raw"].includes(initialMode) ? initialMode : ls("cw.events.mode", "grouped");
     if (initialGroupId) mode = "grouped";
@@ -588,7 +590,7 @@ export default {
       ev.preventDefault();
     });
 
-    let dateRange = ls("cw.events.range", "all");
+    let dateRange = runFilter ? "all" : ls("cw.events.range", "all");
     const ddRange = createDropdown({
       label: "All time", value: dateRange,
       items: [
@@ -786,7 +788,7 @@ export default {
       return "Custom range";
     };
 
-    const hiddenActive = () => !!(ddType.value || ddProvider.value || ddOrigin.value || ddFeature.value || ddPair.value || (dateRange && dateRange !== "all"));
+    const hiddenActive = () => !!(runFilter || ddType.value || ddProvider.value || ddOrigin.value || ddFeature.value || ddPair.value || (dateRange && dateRange !== "all"));
     const filtersActive = () => !!(qEl.value.trim() || (grouped() && ddCategory.value) || hiddenActive());
 
     const clearHidden = (k) => {
@@ -797,6 +799,7 @@ export default {
       if (all || k === "origin") ddOrigin.reset();
       if (all || k === "feature") ddFeature.reset();
       if (all || k === "pair") ddPair.reset();
+      if (all || k === "run") runFilter = "";
       if (isAdmin && (all || k === "profile")) { eventScope = ""; ddProfile.value = ""; }
       if (view === "statistics") loadStats();
       else load(0);
@@ -804,6 +807,7 @@ export default {
 
     const updateHidden = () => {
       const chips = [];
+      if (runFilter) chips.push({ k: "run", label: `Run: ${runFilter}` });
       if (dateRange && dateRange !== "all") chips.push({ k: "range", label: dateRange === "custom" ? customRangeLabel() : RANGE_LABEL[dateRange] });
       if (ddType.value) chips.push({ k: "type", label: ddType.labelOf(ddType.value) });
       if (ddProvider.value) chips.push({ k: "provider", label: ddProvider.labelOf(ddProvider.value) });
@@ -831,6 +835,7 @@ export default {
       if (ddOrigin.value) p.set("origin_provider", ddOrigin.value);
       if (ddFeature.value) p.set("feature", ddFeature.value);
       if (ddPair.value) p.set("pair_key", ddPair.value);
+      if (runFilter) p.set("run_id", runFilter);
       if (grouped() && ddCategory.value) p.set((domain === "scrobble" || domain === "audit") ? "status" : "category", ddCategory.value);
       p.set("domain", domain);
       const { since, until } = rangeEpoch();
@@ -1889,6 +1894,12 @@ export default {
       btn.setAttribute("aria-expanded", String(open));
       btn.classList.toggle("on", open);
     });
+    if (runFilter) {
+      moreWrap.removeAttribute("hidden");
+      moreBtn.setAttribute("aria-expanded", "true");
+      moreBtn.classList.add("on");
+    }
+
     Q("#ev-refresh", root).addEventListener("click", () => doRefresh());
     Q("#ev-clear", root)?.addEventListener("click", async () => {
       const label = domain === "audit" ? "audit" : (domain === "scrobble" ? "scrobble" : "sync");

--- a/assets/js/modals/maintenance/index.js
+++ b/assets/js/modals/maintenance/index.js
@@ -75,6 +75,7 @@ const SIMPLE_OPS = {
   "events-health": "/api/maintenance/events-health",
   "events-optimize": "/api/maintenance/events-optimize",
   "events-rebuild": "/api/maintenance/events-rebuild",
+  "events-purge": "/api/maintenance/events-purge",
   "state-file": "/api/maintenance/state-file/compact",
   "state-file-prune": "/api/maintenance/state-file/prune",
 };
@@ -197,6 +198,14 @@ const OPS = [
     desc: "Compacts and re-indexes the event archive to reclaim space.",
   },
   {
+    key: "events-purge",
+    kind: "events-purge",
+    icon: "delete_sweep",
+    title: "Clear event data",
+    tag: "event history",
+    desc: "Empties every event category and the sync activity calendar. Leaves the rest of the local database alone.",
+  },
+  {
     key: "events-rebuild",
     kind: "events-rebuild",
     icon: "database",
@@ -248,7 +257,7 @@ const GROUPS = [
     icon: "history",
     title: "Events",
     desc: "Check, optimize and rebuild the event history archive.",
-    keys: ["events-health", "events-optimize", "events-rebuild"],
+    keys: ["events-health", "events-optimize", "events-purge", "events-rebuild"],
   },
   {
     id: "state-file",
@@ -281,7 +290,7 @@ const GROUPS = [
 ];
 
 const OPS_BY_KEY = Object.fromEntries(OPS.map((op) => [op.key, op]));
-const OVERVIEW_EXCLUDED_KEYS = new Set(["tracker", "captures", "defaults", "events-health", "events-optimize", "events-rebuild", "database-health", "state-file", "state-file-prune"]);
+const OVERVIEW_EXCLUDED_KEYS = new Set(["tracker", "captures", "defaults", "events-health", "events-optimize", "events-purge", "events-rebuild", "database-health", "state-file", "state-file-prune"]);
 const OVERVIEW_KEYS = GROUPS
   .flatMap((group) => group.keys)
   .filter((key) => !OVERVIEW_EXCLUDED_KEYS.has(key));
@@ -877,6 +886,11 @@ export default {
         return false;
       }
 
+      if (!skipConfirm && kind === "events-purge" && !confirm("Clear all event data?\n\nThis empties every event category (sync, scrobble, audits) and the sync activity calendar.\n\nNothing else in the local database is touched. This cannot be undone.")) {
+        setStatus("Cancelled.", "");
+        return false;
+      }
+
       if (!skipConfirm && kind === "events-rebuild" && !confirm("This removes the current event archive and rebuilds it from current runtime state.\n\nHistorical events that only exist in the event database may be lost.\n\nThis does not change CrossWatch configuration or provider runtime state.")) {
         setStatus("Cancelled.", "");
         return false;
@@ -907,7 +921,7 @@ export default {
             purge_state: false,
             purge_reports: true,
             purge_insights: true,
-          } : kind === "events-rebuild" ? { confirm: true } : undefined;
+          } : (kind === "events-rebuild" || kind === "events-purge") ? { confirm: true } : undefined;
           res = await post(SIMPLE_OPS[kind], body);
         } else if (kind === "tracker") {
           const chkState = $("#cxm-cw-state", root);

--- a/assets/js/modals/statistics/index.js
+++ b/assets/js/modals/statistics/index.js
@@ -1,0 +1,505 @@
+/* assets/js/modals/statistics/index.js */
+/* CrossWatch - Sync activity modal */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+
+const esc = (s) => String(s ?? "").replace(/[&<>"']/g, (c) => (
+  { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]
+));
+
+const Q = (s, r = document) => r.querySelector(s);
+const nf = new Intl.NumberFormat();
+const fmt = (n) => nf.format(Math.round(Number(n || 0)));
+
+const TZ = -new Date().getTimezoneOffset() * 60;
+const DAY = 86400;
+const dayIndexOf = (ms) => Math.floor((ms / 1000 + TZ) / DAY);
+const dateOfIndex = (d) => new Date((d * DAY - TZ) * 1000);
+
+const RANGES = [
+  { value: "3m", label: "3M", days: 98, weeks: 14 },
+  { value: "6m", label: "6M", days: 189, weeks: 27 },
+  { value: "12m", label: "1Y", days: 371, weeks: 53 },
+];
+const METRICS = [
+  { value: "changes", label: "Changes", icon: "swap_horiz" },
+  { value: "runs", label: "Runs", icon: "sync" },
+  { value: "failed", label: "Failures", icon: "error" },
+];
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+const CELL = 11;
+const STEP = 14;
+const PAD_L = 32;
+const PAD_T = 20;
+
+const ls = (k, d) => { try { return localStorage.getItem(k) || d; } catch { return d; } };
+const lset = (k, v) => { try { localStorage.setItem(k, v); } catch {} };
+
+const fmtDur = (s) => {
+  const n = Number(s || 0);
+  if (!Number.isFinite(n) || n <= 0) return "";
+  if (n < 60) return `${n}s`;
+  if (n < 3600) return `${Math.floor(n / 60)}m ${n % 60}s`;
+  return `${(n / 3600).toFixed(1)}h`;
+};
+
+const fmtTime = (epoch) => {
+  const n = Number(epoch || 0);
+  if (!n) return "--:--";
+  return new Date(n * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+};
+
+const fmtDate = (d) => dateOfIndex(d).toLocaleDateString([], { weekday: "long", day: "numeric", month: "long", year: "numeric" });
+
+const brand = (name) => {
+  try { return window.CW?.ProviderMeta?.brandInfo?.(name) || null; } catch { return null; }
+};
+
+function providerChip(name) {
+  const key = String(name || "").trim().toUpperCase();
+  if (!key) return "";
+  const info = brand(key);
+  const label = info?.label || key;
+  const rgb = info?.tone?.rgb || "255,255,255";
+  const src = info?.icon || "";
+  const square = /\.png(?:[?#]|$)/i.test(src);
+  const media = src
+    ? `<img class="sc-prov-img${square ? " sq" : ""}" src="${esc(src)}" alt="" loading="lazy">`
+    : `<span class="sc-prov-abbr">${esc((info?.shortLabel || key).slice(0, 2))}</span>`;
+  return `<span class="sc-prov" style="--sc-prov-rgb:${esc(rgb)}">${media}<span class="sc-prov-name">${esc(label)}</span></span>`;
+}
+
+async function fjson(url, ms = 20000) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort("timeout"), ms);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal, cache: "no-store", credentials: "same-origin" });
+    if (!res.ok) throw new Error(String(res.status));
+    return await res.json();
+  } finally { clearTimeout(timer); }
+}
+
+function injectCss() {
+  const existing = document.getElementById("cw-statistics-css");
+  if (existing?.tagName === "LINK") return Promise.resolve();
+  existing?.remove();
+  const link = document.createElement("link");
+  const cssUrl = new URL("./styles.css", import.meta.url);
+  const version = new URL(import.meta.url).searchParams.get("v") || window.__CW_VERSION__;
+  if (version) cssUrl.searchParams.set("v", version);
+  link.id = "cw-statistics-css";
+  link.rel = "stylesheet";
+  link.href = cssUrl.href;
+  return new Promise((resolve) => {
+    link.addEventListener("load", resolve, { once: true });
+    link.addEventListener("error", resolve, { once: true });
+    document.head.appendChild(link);
+  });
+}
+
+function levels(values) {
+  const nonZero = values.filter((v) => v > 0).sort((a, b) => a - b);
+  if (!nonZero.length) return [1, 2, 3, 4];
+  const at = (p) => nonZero[Math.min(nonZero.length - 1, Math.floor(p * (nonZero.length - 1)))];
+  const raw = [at(0.25), at(0.5), at(0.75), at(0.92)];
+  const out = [];
+  let prev = 0;
+  for (const v of raw) {
+    const next = Math.max(prev + 1, Math.round(v));
+    out.push(next);
+    prev = next;
+  }
+  return out;
+}
+
+function levelOf(value, steps) {
+  if (value <= 0) return 0;
+  for (let i = 0; i < steps.length; i += 1) if (value <= steps[i]) return i + 1;
+  return 4;
+}
+
+function streaks(byIndex, firstIndex, lastIndex) {
+  let best = 0;
+  let current = 0;
+  let running = 0;
+  for (let d = firstIndex; d <= lastIndex; d += 1) {
+    if ((byIndex.get(d)?.runs || 0) > 0) {
+      running += 1;
+      if (running > best) best = running;
+    } else running = 0;
+  }
+  for (let d = lastIndex; d >= firstIndex; d -= 1) {
+    if ((byIndex.get(d)?.runs || 0) > 0) current += 1;
+    else break;
+  }
+  return { best, current };
+}
+
+export default {
+  async mount(root, props = {}) {
+    await injectCss();
+
+    const shell = root.closest(".cx-modal-shell");
+    if (shell) {
+      shell.classList.add("cw-statistics-shell");
+      shell.style.setProperty("--cxModalW", "980px");
+      shell.style.setProperty("--cxModalMaxW", "980px");
+      shell.style.setProperty("--cxModalMaxH", "88vh");
+    }
+
+    let alive = true;
+    let range = RANGES.some((r) => r.value === ls("cw.stats.range", "")) ? ls("cw.stats.range", "12m") : "12m";
+    let metric = METRICS.some((m) => m.value === ls("cw.stats.metric", "")) ? ls("cw.stats.metric", "changes") : "changes";
+    let payload = null;
+    let byIndex = new Map();
+    let selected = Number(props?.day) || null;
+    let pendingDay = selected;
+    let dayState = { index: null, runs: [], loading: false, error: "", filter: "", expanded: new Set() };
+
+    root.innerHTML = `
+      <div class="cw-sc">
+        <div class="cx-head">
+          <div class="sc-head-left">
+            <div class="sc-head-icon"><span class="material-symbols-rounded" aria-hidden="true">calendar_month</span></div>
+            <div>
+              <div class="sc-title">Sync activity</div>
+              <div class="sc-sub" id="sc-sub">Every sync run, day by day.</div>
+            </div>
+          </div>
+          <div class="sc-head-right">
+            <div class="sc-seg" id="sc-metric" role="tablist" aria-label="Metric"></div>
+            <div class="sc-seg" id="sc-range" role="tablist" aria-label="Range"></div>
+            <button type="button" class="sc-icon-btn" id="sc-refresh" title="Refresh" aria-label="Refresh"><span class="material-symbols-rounded" aria-hidden="true">refresh</span></button>
+            <button type="button" class="sc-icon-btn" id="sc-close" title="Close" aria-label="Close"><span class="material-symbols-rounded" aria-hidden="true">close</span></button>
+          </div>
+        </div>
+        <div class="sc-body">
+          <section class="sc-tiles" id="sc-tiles"></section>
+          <section class="sc-cal-card">
+            <div class="sc-cal-scroll"><div id="sc-cal" class="sc-cal"></div></div>
+            <div class="sc-cal-foot">
+              <span class="sc-cal-hint" id="sc-cal-hint">Click any day to see its runs.</span>
+              <span class="sc-legend"><span>Less</span><i class="lv0"></i><i class="lv1"></i><i class="lv2"></i><i class="lv3"></i><i class="lv4"></i><span>More</span></span>
+            </div>
+          </section>
+          <section class="sc-day-card" id="sc-day"></section>
+        </div>
+      </div>`;
+
+    const tip = document.createElement("div");
+    tip.className = "sc-tip";
+    tip.hidden = true;
+    document.body.appendChild(tip);
+
+    const showTip = (html, x, y) => {
+      tip.innerHTML = html;
+      tip.hidden = false;
+      const r = tip.getBoundingClientRect();
+      tip.style.left = `${Math.max(8, Math.min(x - r.width / 2, window.innerWidth - r.width - 8))}px`;
+      tip.style.top = `${Math.max(8, y - r.height - 12)}px`;
+    };
+    const hideTip = () => { tip.hidden = true; };
+
+    const renderSegs = () => {
+      Q("#sc-metric", root).innerHTML = METRICS.map((m) => `<button type="button" role="tab" class="sc-seg-btn${m.value === metric ? " on" : ""}" data-m="${m.value}" aria-selected="${m.value === metric}"><span class="material-symbols-rounded" aria-hidden="true">${m.icon}</span>${esc(m.label)}</button>`).join("");
+      Q("#sc-range", root).innerHTML = RANGES.map((r) => `<button type="button" role="tab" class="sc-seg-btn${r.value === range ? " on" : ""}" data-r="${r.value}" aria-selected="${r.value === range}">${esc(r.label)}</button>`).join("");
+      Q("#sc-metric", root).querySelectorAll(".sc-seg-btn").forEach((b) => b.addEventListener("click", () => {
+        if (b.dataset.m === metric) return;
+        metric = b.dataset.m; lset("cw.stats.metric", metric); renderSegs(); renderCalendar(); renderTiles();
+      }));
+      Q("#sc-range", root).querySelectorAll(".sc-seg-btn").forEach((b) => b.addEventListener("click", () => {
+        if (b.dataset.r === range) return;
+        range = b.dataset.r; lset("cw.stats.range", range); renderSegs(); load();
+      }));
+    };
+
+    const metricValue = (entry) => {
+      if (!entry) return 0;
+      if (metric === "runs") return entry.runs || 0;
+      if (metric === "failed") return entry.failed || 0;
+      return entry.changes || 0;
+    };
+
+    const renderTiles = () => {
+      const host = Q("#sc-tiles", root);
+      const totals = payload?.totals || {};
+      const cfg = RANGES.find((r) => r.value === range) || RANGES[2];
+      const todayIdx = dayIndexOf(Date.now());
+      const firstIdx = todayIdx - cfg.days + 1;
+      const st = streaks(byIndex, firstIdx, todayIdx);
+      const tiles = [
+        { k: "Sync runs", v: fmt(totals.runs), s: `${fmt(totals.failed || 0)} with errors` },
+        { k: "Changes", v: fmt(totals.changes), s: `+${fmt(totals.added)} / -${fmt(totals.removed)} / ~${fmt(totals.updated)}` },
+        { k: "Active days", v: `${fmt(totals.active_days)}`, s: `of ${fmt(cfg.days)} days` },
+        { k: "Current streak", v: `${fmt(st.current)}`, s: st.current === 1 ? "day" : "days" },
+        { k: "Longest streak", v: `${fmt(st.best)}`, s: st.best === 1 ? "day" : "days" },
+      ];
+      host.innerHTML = tiles.map((t) => `<div class="sc-tile"><div class="sc-tile-k">${esc(t.k)}</div><div class="sc-tile-v">${t.v}</div><div class="sc-tile-s">${esc(t.s)}</div></div>`).join("");
+    };
+
+    const renderCalendar = () => {
+      const host = Q("#sc-cal", root);
+      const cfg = RANGES.find((r) => r.value === range) || RANGES[2];
+      const todayIdx = dayIndexOf(Date.now());
+      const todayDow = (dateOfIndex(todayIdx).getDay() + 6) % 7;
+      const lastCol = todayIdx - todayDow;
+      const firstCol = lastCol - (cfg.weeks - 1) * 7;
+
+      const steps = levels([...byIndex.values()].map(metricValue));
+      const width = PAD_L + cfg.weeks * STEP + 6;
+      const height = PAD_T + 7 * STEP + 4;
+
+      const cells = [];
+      const monthLabels = [];
+      let lastMonth = -1;
+      for (let w = 0; w < cfg.weeks; w += 1) {
+        const colStart = firstCol + w * 7;
+        const colDate = dateOfIndex(colStart);
+        if (colDate.getMonth() !== lastMonth) {
+          lastMonth = colDate.getMonth();
+          monthLabels.push(`<text class="sc-ax" x="${PAD_L + w * STEP}" y="12">${MONTHS[lastMonth]}</text>`);
+        }
+        for (let d = 0; d < 7; d += 1) {
+          const index = colStart + d;
+          if (index > todayIdx) continue;
+          const entry = byIndex.get(index);
+          const value = metricValue(entry);
+          const lv = levelOf(value, steps);
+          const bad = (entry?.failed || 0) > 0;
+          const cls = `sc-cell lv${lv}${bad ? " bad" : ""}${index === selected ? " on" : ""}`;
+          cells.push(`<rect class="${cls}" x="${PAD_L + w * STEP}" y="${PAD_T + d * STEP}" width="${CELL}" height="${CELL}" rx="2" data-d="${index}"></rect>`);
+        }
+      }
+      const dayAxis = [0, 2, 4].map((d) => `<text class="sc-ax" x="0" y="${PAD_T + d * STEP + 9}">${WEEKDAYS[d]}</text>`).join("");
+
+      host.innerHTML = `<svg class="sc-svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}" role="img" aria-label="Sync activity calendar">${monthLabels.join("")}${dayAxis}${cells.join("")}</svg>`;
+
+      host.querySelectorAll(".sc-cell").forEach((cell) => {
+        const index = Number(cell.dataset.d);
+        cell.addEventListener("mousemove", (ev) => {
+          const entry = byIndex.get(index);
+          const runs = entry?.runs || 0;
+          const parts = [];
+          if (entry?.added) parts.push(`+${fmt(entry.added)} added`);
+          if (entry?.removed) parts.push(`-${fmt(entry.removed)} removed`);
+          if (entry?.updated) parts.push(`~${fmt(entry.updated)} updated`);
+          if (entry?.failed) parts.push(`${fmt(entry.failed)} failed`);
+          const body = runs
+            ? `<b>${fmt(runs)}</b> ${runs === 1 ? "run" : "runs"} &middot; <b>${fmt(entry.changes)}</b> ${entry.changes === 1 ? "change" : "changes"}${parts.length ? `<br><span class="sc-tip-sub">${parts.join(" &middot; ")}</span>` : ""}`
+            : `<span class="sc-tip-sub">No sync runs</span>`;
+          showTip(`<div class="sc-tip-d">${esc(fmtDate(index))}</div>${body}`, ev.clientX, cell.getBoundingClientRect().top);
+        });
+        cell.addEventListener("mouseleave", hideTip);
+        cell.addEventListener("click", () => { hideTip(); selectDay(index); });
+      });
+    };
+
+    const runMatches = (run, needle) => {
+      if (!needle) return true;
+      const bits = [
+        fmtTime(run.started_at), run.status, run.dry_run ? "dry run" : "",
+        ...(run.pair_rows || []).flatMap((p) => [p.pair_key, p.feature, p.src_provider, p.dst_provider, p.src_instance, p.dst_instance]),
+      ];
+      return bits.join(" ").toLowerCase().includes(needle);
+    };
+
+    const pairChips = (run) => {
+      const seen = new Map();
+      for (const row of run.pair_rows || []) {
+        const key = `${row.src_provider}>${row.dst_provider}`;
+        const entry = seen.get(key) || { src: row.src_provider, dst: row.dst_provider, features: new Set() };
+        if (row.feature) entry.features.add(row.feature);
+        seen.set(key, entry);
+      }
+      if (!seen.size) return `<span class="sc-run-nopair">no changes</span>`;
+      return [...seen.values()].map((e) => `<span class="sc-pair" title="${esc([...e.features].join(", "))}">${providerChip(e.src)}<span class="material-symbols-rounded sc-pair-arrow" aria-hidden="true">arrow_forward</span>${providerChip(e.dst)}</span>`).join("");
+    };
+
+    const featureChips = (run) => {
+      const feats = [...new Set((run.pair_rows || []).map((p) => String(p.feature || "").trim()).filter(Boolean))];
+      return feats.map((f) => `<span class="sc-chip">${esc(f)}</span>`).join("");
+    };
+
+    const counters = (row) => {
+      const bits = [];
+      if (row.added) bits.push(`<span class="sc-n add">+${fmt(row.added)}</span>`);
+      if (row.removed) bits.push(`<span class="sc-n del">-${fmt(row.removed)}</span>`);
+      if (row.updated) bits.push(`<span class="sc-n upd">~${fmt(row.updated)}</span>`);
+      if (row.errors) bits.push(`<span class="sc-n err">${fmt(row.errors)} err</span>`);
+      return bits.join("") || `<span class="sc-n zero">0</span>`;
+    };
+
+    const renderRuns = () => {
+      const host = Q("#sc-run-host", root);
+      if (!host) return;
+      if (dayState.loading) { host.innerHTML = `<div class="sc-day-msg">Loading runs...</div>`; return; }
+      if (dayState.error) { host.innerHTML = `<div class="sc-day-msg sc-day-msg--err">${esc(dayState.error)}</div>`; return; }
+
+      const needle = dayState.filter.trim().toLowerCase();
+      const rows = dayState.runs.filter((run) => runMatches(run, needle));
+      if (!rows.length) {
+        host.innerHTML = `<div class="sc-day-msg">${dayState.runs.length ? "No runs match that filter." : "No sync runs on this day."}</div>`;
+        return;
+      }
+
+      host.innerHTML = `<div class="sc-runs">${rows.map((run) => {
+        const open = dayState.expanded.has(run.run_id);
+        const status = run.errors ? "err" : (run.status === "running" ? "run" : "ok");
+        const detail = open
+          ? `<div class="sc-run-detail">${(run.pair_rows || []).length
+              ? `<table class="sc-tbl"><thead><tr><th>Route</th><th>Feature</th><th>Added</th><th>Removed</th><th>Updated</th><th>Errors</th></tr></thead><tbody>${run.pair_rows.map((p) => `<tr><td>${esc(p.src_provider)} &rarr; ${esc(p.dst_provider)}${p.src_instance !== "default" || p.dst_instance !== "default" ? `<span class="sc-inst">${esc(p.src_instance)} / ${esc(p.dst_instance)}</span>` : ""}</td><td>${esc(p.feature || "-")}</td><td>${fmt(p.added)}</td><td>${fmt(p.removed)}</td><td>${fmt(p.updated)}</td><td>${fmt(p.errors)}</td></tr>`).join("")}</tbody></table>`
+              : `<div class="sc-day-msg">No recorded changes for this run.</div>`}</div>`
+          : "";
+        return `
+          <div class="sc-run${open ? " open" : ""}" data-run="${esc(run.run_id)}">
+            <div class="sc-run-bar">
+            <button type="button" class="sc-run-head" aria-expanded="${open}">
+              <span class="sc-run-time">${esc(fmtTime(run.started_at))}</span>
+              <span class="sc-dot ${status}" aria-hidden="true"></span>
+              <span class="sc-run-pairs">${pairChips(run)}</span>
+              <span class="sc-run-chips">${featureChips(run)}${run.dry_run ? `<span class="sc-chip dry">dry run</span>` : ""}</span>
+              <span class="sc-run-counts">${counters(run)}</span>
+              <span class="sc-run-dur">${esc(fmtDur(run.duration))}</span>
+              <span class="material-symbols-rounded sc-run-caret" aria-hidden="true">expand_more</span>
+            </button>
+            <button type="button" class="sc-run-events" title="Open events for this run" aria-label="Open events for run ${esc(run.run_id)}">
+              <span class="material-symbols-rounded" aria-hidden="true">manage_search</span>
+            </button>
+            </div>
+            ${detail}
+          </div>`;
+      }).join("")}</div>`;
+
+      host.querySelectorAll(".sc-run-head").forEach((btn) => btn.addEventListener("click", () => {
+        const id = btn.closest(".sc-run")?.dataset?.run;
+        if (!id) return;
+        if (dayState.expanded.has(id)) dayState.expanded.delete(id);
+        else dayState.expanded.add(id);
+        renderRuns();
+      }));
+      host.querySelectorAll(".sc-run-events").forEach((btn) => btn.addEventListener("click", (ev) => {
+        ev.stopPropagation();
+        const id = btn.closest(".sc-run")?.dataset?.run;
+        const openEvents = window.openEvents;
+        if (!id || typeof openEvents !== "function") return;
+        window.cxCloseModal?.();
+        openEvents({ runId: id, domain: "sync", visibility: "all", mode: "grouped" });
+      }));
+    };
+
+    const renderDay = () => {
+      const host = Q("#sc-day", root);
+      if (dayState.index == null) {
+        host.innerHTML = `<div class="sc-day-empty"><span class="material-symbols-rounded" aria-hidden="true">touch_app</span><div><strong>No day selected</strong><span>Click a square above to list that day's sync runs.</span></div></div>`;
+        return;
+      }
+      const entry = byIndex.get(dayState.index);
+      const live = !dayState.loading && !dayState.error;
+      const runCount = live ? dayState.runs.length : (entry?.runs || 0);
+      const changeCount = live ? dayState.runs.reduce((n, r) => n + (r.changes || 0), 0) : (entry?.changes || 0);
+      const failCount = live ? dayState.runs.filter((r) => r.errors).length : (entry?.failed || 0);
+      host.innerHTML = `
+        <div class="sc-day-head">
+          <div>
+            <div class="sc-day-title">${esc(fmtDate(dayState.index))}</div>
+            <div class="sc-day-sub">${fmt(runCount)} runs &middot; ${fmt(changeCount)} changes${failCount ? ` &middot; ${fmt(failCount)} with errors` : ""}</div>
+          </div>
+          <div class="sc-day-tools">
+            <label class="sc-search"><span class="material-symbols-rounded" aria-hidden="true">search</span><input type="search" id="sc-filter" placeholder="Filter runs" value="${esc(dayState.filter)}" autocomplete="off"></label>
+          </div>
+        </div>
+        <div id="sc-run-host"></div>`;
+
+      Q("#sc-filter", host)?.addEventListener("input", (ev) => {
+        dayState.filter = ev.target.value;
+        renderRuns();
+      });
+      renderRuns();
+    };
+
+    const selectDay = async (index) => {
+      selected = index;
+      dayState = { index, runs: [], loading: true, error: "", filter: "", expanded: new Set() };
+      renderCalendar();
+      renderDay();
+      const since = index * DAY - TZ;
+      try {
+        const data = await fjson(`/api/events/calendar/day?since=${since}&until=${since + DAY}&limit=300`);
+        if (!alive || dayState.index !== index) return;
+        if (!data?.ok) throw new Error(data?.error || "failed");
+        dayState.runs = Array.isArray(data.runs) ? data.runs : [];
+      } catch (err) {
+        if (!alive || dayState.index !== index) return;
+        dayState.error = `Could not load runs (${err.message}).`;
+      } finally {
+        if (alive && dayState.index === index) {
+          dayState.loading = false;
+          renderDay();
+        }
+      }
+    };
+
+    const load = async () => {
+      const cfg = RANGES.find((r) => r.value === range) || RANGES[2];
+      const btn = Q("#sc-refresh", root);
+      btn?.classList.add("busy");
+      try {
+        const data = await fjson(`/api/events/calendar?days=${cfg.days}&tz=${TZ}`);
+        if (!alive) return;
+        if (!data?.ok) throw new Error(data?.error || "unavailable");
+        payload = data;
+        byIndex = new Map((data.days || []).map((row) => [Number(row.d), row]));
+        Q("#sc-sub", root).textContent = data.scoped ? "Runs visible to the selected profile." : "Every sync run, day by day.";
+      } catch (err) {
+        if (!alive) return;
+        payload = { totals: {} };
+        byIndex = new Map();
+        Q("#sc-sub", root).textContent = `Could not load activity (${err.message}).`;
+      } finally {
+        btn?.classList.remove("busy");
+      }
+      if (!alive) return;
+      renderTiles();
+      renderCalendar();
+
+      if (pendingDay != null) {
+        const want = pendingDay;
+        pendingDay = null;
+        await selectDay(want);
+        return;
+      }
+      const cal = RANGES.find((r) => r.value === range) || RANGES[2];
+      const todayIdx = dayIndexOf(Date.now());
+      const firstIdx = todayIdx - cal.days + 1;
+      const inRange = dayState.index != null && dayState.index >= firstIdx && dayState.index <= todayIdx;
+      const days = payload?.days || [];
+      const latest = days.length ? Number(days[days.length - 1].d) : null;
+      if (!inRange && latest != null) {
+        await selectDay(latest);
+        return;
+      }
+      renderDay();
+    };
+
+    const onProfileChange = () => { selected = null; pendingDay = null; dayState = { index: null, runs: [], loading: false, error: "", filter: "", expanded: new Set() }; void load(); };
+    window.addEventListener("cw:overview-profile-changed", onProfileChange);
+
+    Q("#sc-close", root).addEventListener("click", () => window.cxCloseModal?.());
+    Q("#sc-refresh", root).addEventListener("click", () => load());
+
+    renderSegs();
+    renderDay();
+    await load();
+
+    this._cleanup = () => {
+      alive = false;
+      window.removeEventListener("cw:overview-profile-changed", onProfileChange);
+      tip.remove();
+    };
+  },
+  unmount() {
+    try { this._cleanup?.(); } catch {}
+    this._cleanup = null;
+  },
+};

--- a/assets/js/modals/statistics/styles.css
+++ b/assets/js/modals/statistics/styles.css
@@ -1,0 +1,144 @@
+/* assets/js/modals/statistics/styles.css */
+/* CrossWatch - Sync activity modal styling */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude */
+
+.cx-modal-shell.cw-statistics-shell{
+  --sc-bg:var(--bg,#0c0f15);--sc-panel:var(--panel,#151922);--sc-card:var(--panel2,#1b202b);
+  --sc-text:var(--fg,#e7ecf5);--sc-muted:var(--muted,#a6afbf);--sc-accent:var(--accent,#7d86c9);
+  --sc-ok:var(--accent2,#5fd08a);--sc-warn:var(--cw-theme-warning,#e6b150);--sc-err:var(--danger,#e2564a);
+  --sc-border:var(--border,rgba(255,255,255,.12));
+  --sc-border-soft:color-mix(in srgb,var(--sc-border) 55%,transparent);
+  --sc-hover:color-mix(in srgb,var(--sc-card) 84%,var(--sc-text));
+  --sc-lv0:color-mix(in srgb,var(--sc-text) 13%,transparent);
+  --sc-lv1:color-mix(in srgb,var(--sc-ok) 30%,transparent);
+  --sc-lv2:color-mix(in srgb,var(--sc-ok) 52%,transparent);
+  --sc-lv3:color-mix(in srgb,var(--sc-ok) 76%,transparent);
+  --sc-lv4:var(--sc-ok);
+  width:min(var(--cxModalMaxW,980px),calc(100vw - 48px))!important;
+  max-width:min(var(--cxModalMaxW,980px),calc(100vw - 48px))!important;
+  height:min(var(--cxModalMaxH,88vh),calc(100vh - 48px))!important;
+  background:var(--sc-bg)!important;border:1px solid var(--sc-border)!important;
+}
+
+.cw-sc,.cw-sc *{box-sizing:border-box}
+.cw-sc{display:flex;flex-direction:column;height:100%;min-height:0;color:var(--sc-text);background:var(--sc-bg)}
+
+.cw-sc .cx-head{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:12px 16px;border-bottom:1px solid var(--sc-border);background:var(--sc-panel)}
+.sc-head-left{display:flex;align-items:center;gap:12px;min-width:0}
+.sc-head-icon{display:grid;place-items:center;width:36px;height:36px;flex:0 0 36px;border-radius:11px;border:1px solid var(--sc-border);background:var(--sc-card);color:var(--sc-accent);line-height:0}
+.sc-head-icon .material-symbols-rounded{display:block;font-size:20px;line-height:1}
+.sc-title{font-size:15px;font-weight:800;line-height:1.2}
+.sc-sub{font-size:12px;color:var(--sc-muted);line-height:1.3;margin-top:2px}
+.sc-head-right{display:flex;align-items:center;gap:8px;flex:0 0 auto}
+
+.sc-seg{display:inline-flex;padding:2px;gap:2px;border-radius:10px;border:1px solid var(--sc-border);background:var(--sc-card)}
+.sc-seg-btn{display:inline-flex;align-items:center;gap:5px;height:26px;padding:0 9px;border:0;border-radius:8px;background:transparent;color:var(--sc-muted);font:inherit;font-size:12px;font-weight:700;cursor:pointer;white-space:nowrap}
+.sc-seg-btn .material-symbols-rounded{font-size:16px;line-height:1}
+.sc-seg-btn:hover{color:var(--sc-text);background:var(--sc-hover)}
+.sc-seg-btn.on{color:var(--sc-text);background:color-mix(in srgb,var(--sc-accent) 26%,transparent)}
+.sc-icon-btn{display:inline-grid;place-items:center;width:30px;height:30px;padding:0;border-radius:9px;border:1px solid var(--sc-border);background:var(--sc-card);color:var(--sc-muted);cursor:pointer;line-height:0}
+.sc-icon-btn .material-symbols-rounded{display:block;font-size:18px;line-height:1}
+.sc-icon-btn:hover{color:var(--sc-text);background:var(--sc-hover)}
+.sc-icon-btn.busy .material-symbols-rounded{animation:sc-spin .8s linear infinite}
+@keyframes sc-spin{to{transform:rotate(360deg)}}
+
+.sc-body{flex:1;min-height:0;overflow:auto;padding:14px 16px 18px;display:flex;flex-direction:column;gap:14px}
+.sc-body,.sc-cal-scroll{scrollbar-width:thin;scrollbar-color:color-mix(in srgb,var(--sc-text) 22%,transparent) transparent}
+.sc-body::-webkit-scrollbar,.sc-cal-scroll::-webkit-scrollbar{width:10px;height:10px}
+.sc-body::-webkit-scrollbar-track,.sc-cal-scroll::-webkit-scrollbar-track{background:0 0}
+.sc-body::-webkit-scrollbar-thumb,.sc-cal-scroll::-webkit-scrollbar-thumb{border-radius:999px;border:3px solid transparent;background-clip:content-box;background-color:color-mix(in srgb,var(--sc-text) 22%,transparent)}
+
+.sc-tiles{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:10px}
+.sc-tile{padding:10px 12px;border-radius:12px;border:1px solid var(--sc-border-soft);background:var(--sc-card);min-width:0}
+.sc-tile-k{font-size:11px;font-weight:700;letter-spacing:.02em;text-transform:uppercase;color:var(--sc-muted)}
+.sc-tile-v{font-size:22px;font-weight:850;line-height:1.15;margin-top:3px}
+.sc-tile-s{font-size:11px;color:var(--sc-muted);margin-top:2px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+
+.sc-cal-card{border-radius:12px;border:1px solid var(--sc-border-soft);background:var(--sc-card);padding:12px 12px 8px}
+.sc-cal-scroll{overflow-x:auto;overflow-y:hidden}
+.sc-svg{display:block}
+.sc-svg .sc-ax{fill:var(--sc-muted);font-size:9px;font-weight:700}
+.sc-cell{fill:var(--sc-lv0);cursor:pointer;transition:stroke .1s ease}
+.sc-cell.lv1{fill:var(--sc-lv1)}
+.sc-cell.lv2{fill:var(--sc-lv2)}
+.sc-cell.lv3{fill:var(--sc-lv3)}
+.sc-cell.lv4{fill:var(--sc-lv4)}
+.sc-cell.bad{fill:color-mix(in srgb,var(--sc-err) 62%,transparent)}
+.sc-cell.bad.lv4{fill:var(--sc-err)}
+.sc-cell:hover{stroke:var(--sc-text);stroke-width:1}
+.sc-cell.on{stroke:var(--sc-accent);stroke-width:1.8}
+.sc-cal-foot{display:flex;align-items:center;justify-content:space-between;gap:12px;padding-top:6px;font-size:11px;color:var(--sc-muted)}
+.sc-legend{display:inline-flex;align-items:center;gap:4px}
+.sc-legend i{width:11px;height:11px;border-radius:2px;display:inline-block}
+.sc-legend .lv0{background:var(--sc-lv0)}
+.sc-legend .lv1{background:var(--sc-lv1)}
+.sc-legend .lv2{background:var(--sc-lv2)}
+.sc-legend .lv3{background:var(--sc-lv3)}
+.sc-legend .lv4{background:var(--sc-lv4)}
+
+.sc-tip{position:fixed;z-index:31000;max-width:280px;padding:7px 10px;border-radius:9px;border:1px solid var(--border,rgba(255,255,255,.14));background:var(--panel2,#1b202b);color:var(--fg,#e7ecf5);font-size:12px;line-height:1.35;pointer-events:none;box-shadow:0 12px 30px rgba(0,0,0,.45)}
+.sc-tip[hidden]{display:none}
+.sc-tip-d{font-weight:800;margin-bottom:2px}
+.sc-tip-sub{color:var(--muted,#a6afbf)}
+
+.sc-day-card{border-radius:12px;border:1px solid var(--sc-border-soft);background:var(--sc-card);padding:12px}
+.sc-day-empty{display:flex;align-items:center;gap:12px;color:var(--sc-muted);font-size:12px;padding:8px 2px}
+.sc-day-empty .material-symbols-rounded{font-size:24px}
+.sc-day-empty strong{display:block;color:var(--sc-text);font-size:13px}
+.sc-day-head{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;margin-bottom:10px}
+.sc-day-title{font-size:14px;font-weight:800}
+.sc-day-sub{font-size:12px;color:var(--sc-muted);margin-top:2px}
+.sc-search{display:inline-flex;align-items:center;gap:6px;height:30px;padding:0 10px;border-radius:9px;border:1px solid var(--sc-border);background:var(--sc-bg);color:var(--sc-muted)}
+.sc-search .material-symbols-rounded{font-size:17px}
+.sc-search input{border:0;background:transparent;color:var(--sc-text);font:inherit;font-size:12px;outline:0;width:170px}
+.sc-day-msg{font-size:12px;color:var(--sc-muted);padding:10px 2px}
+.sc-day-msg--err{color:var(--sc-err)}
+
+.sc-runs{display:flex;flex-direction:column;gap:6px}
+.sc-run{border-radius:10px;border:1px solid var(--sc-border-soft);background:var(--sc-bg);overflow:hidden}
+.sc-run.open{border-color:var(--sc-border)}
+.sc-run-bar{display:flex;align-items:stretch}
+.sc-run-events{flex:0 0 auto;display:grid;place-items:center;width:34px;padding:0;border:0;border-left:1px solid var(--sc-border-soft);background:transparent;color:var(--sc-muted);cursor:pointer;line-height:0}
+.sc-run-events .material-symbols-rounded{display:block;font-size:17px;line-height:1}
+.sc-run-events:hover{color:var(--sc-text);background:var(--sc-hover)}
+.sc-run-head{flex:1;min-width:0;display:grid;grid-template-columns:46px 10px minmax(0,1fr) auto auto 52px 20px;align-items:center;gap:10px;width:100%;padding:8px 10px;border:0;background:transparent;color:inherit;font:inherit;text-align:left;cursor:pointer}
+.sc-run-head:hover{background:var(--sc-hover)}
+.sc-run-time{font-size:12px;font-weight:750;font-variant-numeric:tabular-nums;color:var(--sc-muted)}
+.sc-dot{width:8px;height:8px;border-radius:50%;background:var(--sc-ok)}
+.sc-dot.err{background:var(--sc-err)}
+.sc-dot.run{background:var(--sc-warn)}
+.sc-run-pairs{display:flex;align-items:center;gap:8px;flex-wrap:wrap;min-width:0}
+.sc-pair{display:inline-flex;align-items:center;gap:3px}
+.sc-pair-arrow{font-size:13px;color:var(--sc-muted)}
+.sc-run-nopair{font-size:11px;color:var(--sc-muted)}
+.sc-prov{display:inline-flex;align-items:center;gap:5px;height:22px;padding:0 9px 0 5px;border-radius:999px;border:1px solid rgba(var(--sc-prov-rgb,255,255,255),.3);background:rgba(var(--sc-prov-rgb,255,255,255),.12);color:var(--sc-text);font-size:11px;font-weight:750;line-height:1;white-space:nowrap}
+.sc-prov-img{display:block;width:auto;height:13px;max-width:18px;object-fit:contain}
+.sc-prov-img.sq{height:15px;max-width:15px;border-radius:3px}
+.sc-prov-abbr{display:inline-grid;place-items:center;width:15px;height:15px;font-size:8px;font-weight:900}
+.sc-run-chips{display:flex;align-items:center;gap:4px}
+.sc-chip{display:inline-flex;align-items:center;height:19px;padding:0 7px;border-radius:999px;border:1px solid var(--sc-border-soft);font-size:10px;font-weight:750;color:var(--sc-muted);white-space:nowrap}
+.sc-chip.dry{color:var(--sc-warn);border-color:color-mix(in srgb,var(--sc-warn) 40%,transparent)}
+.sc-run-counts{display:flex;align-items:center;gap:6px;font-size:11px;font-weight:800;font-variant-numeric:tabular-nums}
+.sc-n.add{color:var(--sc-ok)}
+.sc-n.del{color:var(--sc-err)}
+.sc-n.upd{color:var(--sc-accent)}
+.sc-n.err{color:var(--sc-err)}
+.sc-n.zero{color:var(--sc-muted)}
+.sc-run-dur{font-size:11px;color:var(--sc-muted);font-variant-numeric:tabular-nums;text-align:right}
+.sc-run-caret{font-size:18px;color:var(--sc-muted);transition:transform .14s ease}
+.sc-run.open .sc-run-caret{transform:rotate(180deg)}
+.sc-run-detail{padding:2px 10px 10px;border-top:1px solid var(--sc-border-soft)}
+.sc-tbl{width:100%;border-collapse:collapse;font-size:11.5px}
+.sc-tbl th{text-align:left;padding:6px 8px;color:var(--sc-muted);font-weight:750;border-bottom:1px solid var(--sc-border-soft)}
+.sc-tbl td{padding:5px 8px;border-bottom:1px solid var(--sc-border-soft)}
+.sc-tbl tbody tr:last-child td{border-bottom:0}
+.sc-tbl td:not(:first-child),.sc-tbl th:not(:first-child){text-align:right;font-variant-numeric:tabular-nums}
+.sc-tbl th:nth-child(2),.sc-tbl td:nth-child(2){text-align:left}
+.sc-inst{display:block;font-size:10px;color:var(--sc-muted)}
+
+@media(max-width:820px){
+  .sc-tiles{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .sc-head-right{flex-wrap:wrap;justify-content:flex-end}
+  .sc-run-head{grid-template-columns:44px 10px minmax(0,1fr) auto 20px}
+  .sc-run-chips,.sc-run-dur{display:none}
+}

--- a/cw_platform/event_archive/__init__.py
+++ b/cw_platform/event_archive/__init__.py
@@ -28,8 +28,10 @@ from .groups import (
     unacknowledge_group,
 )
 from .context import build_context, build_group_context
-from .maintenance import health, optimize, rebuild, boot_check
+from .maintenance import health, optimize, rebuild, boot_check, purge
 from .stats import statistics
+from .activity import Scope as CalendarScope, UNRESTRICTED as CALENDAR_ALL, calendar, day_runs, invalidate as invalidate_calendar
+from .run_scope import backfill_run_pairs, record_run_pairs, scope_key
 
 __all__ = [
     "events_db_path",
@@ -70,5 +72,14 @@ __all__ = [
     "optimize",
     "rebuild",
     "boot_check",
+    "purge",
     "statistics",
+    "CalendarScope",
+    "CALENDAR_ALL",
+    "calendar",
+    "day_runs",
+    "invalidate_calendar",
+    "backfill_run_pairs",
+    "record_run_pairs",
+    "scope_key",
 ]

--- a/cw_platform/event_archive/activity.py
+++ b/cw_platform/event_archive/activity.py
@@ -1,0 +1,233 @@
+# cw_platform/event_archive/activity.py
+# CrossWatch - Sync activity calendar aggregation
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import hashlib
+import threading
+import time
+from collections.abc import Iterable
+from typing import Any
+
+from .db import get_conn
+
+_DAY = 86400
+_TZ_LIMIT = 14 * 3600
+_MAX_SCOPE_TERMS = 400
+_MAX_RUNS = 500
+
+_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
+_CACHE_TTL = 60.0
+_CACHE_CAP = 32
+_LOCK = threading.RLock()
+
+
+def clamp_tz(value: Any) -> int:
+    try:
+        tz = int(value or 0)
+    except Exception:
+        return 0
+    return max(-_TZ_LIMIT, min(_TZ_LIMIT, tz))
+
+
+class Scope:
+    """Resolved profile scope. `unrestricted` reads sync_runs without a join."""
+
+    __slots__ = ("unrestricted", "pair_ids", "scope_keys")
+
+    def __init__(self, *, unrestricted: bool, pair_ids: Iterable[str] = (), scope_keys: Iterable[str] = ()) -> None:
+        self.unrestricted = bool(unrestricted)
+        self.pair_ids = sorted({str(v) for v in pair_ids if str(v or "").strip()})[:_MAX_SCOPE_TERMS]
+        self.scope_keys = sorted({str(v) for v in scope_keys if str(v or "").strip()})[:_MAX_SCOPE_TERMS]
+
+    @property
+    def empty(self) -> bool:
+        return not self.unrestricted and not self.pair_ids and not self.scope_keys
+
+    def clause(self) -> tuple[str, list[Any]]:
+        terms: list[str] = []
+        params: list[Any] = []
+        if self.pair_ids:
+            terms.append(f"p.pair_id IN ({','.join('?' for _ in self.pair_ids)})")
+            params.extend(self.pair_ids)
+        if self.scope_keys:
+            terms.append(f"p.scope_key IN ({','.join('?' for _ in self.scope_keys)})")
+            params.extend(self.scope_keys)
+        return (f"({' OR '.join(terms)})" if terms else "0"), params
+
+    def token(self) -> str:
+        if self.unrestricted:
+            return "all"
+        raw = "\x1f".join(("i", *self.pair_ids, "s", *self.scope_keys))
+        return hashlib.sha1(raw.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+UNRESTRICTED = Scope(unrestricted=True)
+
+
+def _empty_payload(since: int, until: int, tz: int) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "range": {"since": since, "until": until, "tz_offset": tz},
+        "days": [],
+        "totals": {"runs": 0, "failed": 0, "added": 0, "removed": 0, "updated": 0, "changes": 0, "active_days": 0},
+    }
+
+
+def _day_rows(conn: Any, since: int, until: int, tz: int, scope: Scope) -> list[dict[str, Any]]:
+    if scope.unrestricted:
+        sql = (
+            "SELECT (started_at + ?)/86400 AS d, COUNT(*) runs, "
+            "SUM(CASE WHEN COALESCE(errors,0)>0 THEN 1 ELSE 0 END) failed, "
+            "SUM(COALESCE(added,0)) added, SUM(COALESCE(removed,0)) removed, SUM(COALESCE(updated,0)) updated "
+            "FROM sync_runs WHERE started_at>=? AND started_at<? GROUP BY d"
+        )
+        params: list[Any] = [tz, since, until]
+    else:
+        where, scope_params = scope.clause()
+        sql = (
+            "SELECT (r.started_at + ?)/86400 AS d, COUNT(DISTINCT r.run_id) runs, "
+            "COUNT(DISTINCT CASE WHEN p.errors>0 THEN r.run_id END) failed, "
+            "SUM(p.added) added, SUM(p.removed) removed, SUM(p.updated) updated "
+            "FROM sync_runs r JOIN run_pairs p ON p.run_id=r.run_id "
+            f"WHERE r.started_at>=? AND r.started_at<? AND {where} GROUP BY d"
+        )
+        params = [tz, since, until, *scope_params]
+    return [dict(row) for row in conn.execute(sql, params).fetchall()]
+
+
+def _compute(conn: Any, since: int, until: int, tz: int, scope: Scope) -> dict[str, Any]:
+    days: list[dict[str, Any]] = []
+    totals = {"runs": 0, "failed": 0, "added": 0, "removed": 0, "updated": 0}
+    for row in _day_rows(conn, since, until, tz, scope):
+        index = int(row["d"])
+        entry = {
+            "d": index,
+            "ts": index * _DAY - tz,
+            "runs": int(row["runs"] or 0),
+            "failed": int(row["failed"] or 0),
+            "added": int(row["added"] or 0),
+            "removed": int(row["removed"] or 0),
+            "updated": int(row["updated"] or 0),
+        }
+        entry["changes"] = entry["added"] + entry["removed"] + entry["updated"]
+        for key in totals:
+            totals[key] += entry[key]
+        days.append(entry)
+    days.sort(key=lambda item: item["d"])
+    totals["changes"] = totals["added"] + totals["removed"] + totals["updated"]
+    totals["active_days"] = len(days)
+    return {
+        "ok": True,
+        "range": {"since": since, "until": until, "tz_offset": tz},
+        "days": days,
+        "totals": totals,
+    }
+
+
+def calendar(*, since: int, until: int, tz_offset: int = 0, scope: Scope | None = None, conn: Any = None) -> dict[str, Any]:
+    until = int(until)
+    since = int(min(since, until))
+    tz = clamp_tz(tz_offset)
+    sc = scope or UNRESTRICTED
+    if sc.empty:
+        return _empty_payload(since, until, tz)
+
+    key = f"{since // _DAY}:{until // _DAY}:{tz}:{sc.token()}"
+    now = time.monotonic()
+    with _LOCK:
+        hit = _CACHE.get(key)
+        if hit and hit[0] > now:
+            return hit[1]
+
+    c = conn or get_conn()
+    if c is None:
+        return {"ok": False, "available": False, "range": {"since": since, "until": until, "tz_offset": tz}}
+    try:
+        payload = _compute(c, since, until, tz, sc)
+    except Exception:
+        return {"ok": False, "error": "internal_error", "range": {"since": since, "until": until, "tz_offset": tz}}
+
+    with _LOCK:
+        if len(_CACHE) >= _CACHE_CAP:
+            for stale in sorted(_CACHE, key=lambda k: _CACHE[k][0])[: _CACHE_CAP // 2]:
+                _CACHE.pop(stale, None)
+        _CACHE[key] = (now + _CACHE_TTL, payload)
+    return payload
+
+
+def invalidate() -> None:
+    with _LOCK:
+        _CACHE.clear()
+
+
+def _run_pair_rows(conn: Any, run_ids: list[str], scope: Scope) -> dict[str, list[dict[str, Any]]]:
+    out: dict[str, list[dict[str, Any]]] = {}
+    if not run_ids:
+        return out
+    placeholders = ",".join("?" for _ in run_ids)
+    where, scope_params = ("1", []) if scope.unrestricted else scope.clause()
+    rows = conn.execute(
+        f"SELECT p.run_id, p.pair_id, p.pair_key, p.feature, p.src_provider, p.src_instance, "
+        f"p.dst_provider, p.dst_instance, p.added, p.removed, p.updated, p.errors "
+        f"FROM run_pairs p WHERE p.run_id IN ({placeholders}) AND {where}",
+        [*run_ids, *scope_params],
+    ).fetchall()
+    for row in rows:
+        item = dict(row)
+        item["changes"] = int(item["added"] or 0) + int(item["removed"] or 0) + int(item["updated"] or 0)
+        out.setdefault(str(item.pop("run_id")), []).append(item)
+    for entries in out.values():
+        entries.sort(key=lambda e: (-int(e["changes"]), str(e["feature"])))
+    return out
+
+
+def day_runs(*, since: int, until: int, scope: Scope | None = None, limit: int = _MAX_RUNS, conn: Any = None) -> dict[str, Any]:
+    until = int(until)
+    since = int(min(since, until))
+    cap = max(1, min(int(limit or _MAX_RUNS), _MAX_RUNS))
+    sc = scope or UNRESTRICTED
+    if sc.empty:
+        return {"ok": True, "range": {"since": since, "until": until}, "runs": [], "total": 0}
+
+    c = conn or get_conn()
+    if c is None:
+        return {"ok": False, "available": False, "range": {"since": since, "until": until}}
+
+    try:
+        if sc.unrestricted:
+            rows = c.execute(
+                "SELECT run_id, started_at, finished_at, mode, dry_run, status, pairs, "
+                "added, removed, updated, unresolved, blocked, errors FROM sync_runs "
+                "WHERE started_at>=? AND started_at<? ORDER BY started_at DESC LIMIT ?",
+                (since, until, cap),
+            ).fetchall()
+        else:
+            where, scope_params = sc.clause()
+            rows = c.execute(
+                "SELECT r.run_id, r.started_at, r.finished_at, r.mode, r.dry_run, r.status, "
+                "COUNT(DISTINCT p.pair_id || '\x1f' || p.scope_key) pairs, "
+                "SUM(p.added) added, SUM(p.removed) removed, SUM(p.updated) updated, "
+                "0 unresolved, 0 blocked, SUM(p.errors) errors "
+                "FROM sync_runs r JOIN run_pairs p ON p.run_id=r.run_id "
+                f"WHERE r.started_at>=? AND r.started_at<? AND {where} "
+                "GROUP BY r.run_id ORDER BY r.started_at DESC LIMIT ?",
+                (since, until, *scope_params, cap),
+            ).fetchall()
+
+        runs = [dict(row) for row in rows]
+        pair_map = _run_pair_rows(c, [str(r["run_id"]) for r in runs], sc)
+    except Exception:
+        return {"ok": False, "error": "internal_error", "range": {"since": since, "until": until}}
+
+    for run in runs:
+        started = int(run.get("started_at") or 0)
+        finished = int(run.get("finished_at") or 0)
+        run["duration"] = finished - started if finished and finished >= started else None
+        run["dry_run"] = bool(run.get("dry_run"))
+        for key in ("added", "removed", "updated", "errors", "unresolved", "blocked", "pairs"):
+            run[key] = int(run.get(key) or 0)
+        run["changes"] = run["added"] + run["removed"] + run["updated"]
+        run["pair_rows"] = pair_map.get(str(run.get("run_id")), [])
+
+    return {"ok": True, "range": {"since": since, "until": until}, "runs": runs, "total": len(runs)}

--- a/cw_platform/event_archive/maintenance.py
+++ b/cw_platform/event_archive/maintenance.py
@@ -17,6 +17,16 @@ from .importer import import_all
 from .query import status
 
 
+_PURGE_TABLES = ("events", "event_groups", "sync_runs", "run_pairs", "event_imports")
+
+
+def _table_count(conn: sqlite3.Connection, table: str) -> int:
+    try:
+        return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] or 0)
+    except Exception:
+        return 0
+
+
 def _file_size(p: Path) -> int:
     try:
         return p.stat().st_size if p.exists() else 0
@@ -199,3 +209,49 @@ def rebuild(
         except Exception:
             imported = 0
     return {"ok": True, "path": str(path), "removed": removed, "imported": imported, "events": int(status(conn=c).get("events") or 0)}
+
+
+def purge(domain: str | None = None) -> dict[str, Any]:
+    """Delete archived events without touching the rest of the local database.
+
+    `domain` limits the wipe to one event domain; None or "all" clears every
+    domain plus the run tables the sync activity calendar reads.
+    """
+    c = get_conn()
+    path = events_db_path()
+    if c is None:
+        return {"ok": False, "available": False, "path": str(path)}
+
+    scope = str(domain or "").strip().lower()
+    before = {t: _table_count(c, t) for t in _PURGE_TABLES}
+    try:
+        with c:
+            if scope in ("", "all"):
+                for table in _PURGE_TABLES:
+                    c.execute(f"DELETE FROM {table}")
+            else:
+                c.execute("DELETE FROM events WHERE domain=?", (scope,))
+                c.execute("DELETE FROM event_groups WHERE domain=?", (scope,))
+                if scope == "sync":
+                    for table in ("sync_runs", "run_pairs", "event_imports"):
+                        c.execute(f"DELETE FROM {table}")
+    except Exception:
+        _LOG.exception("events purge failed")
+        return {"ok": False, "path": str(path), "error": "purge_failed", "domain": scope or "all"}
+
+    try:
+        from .activity import invalidate
+
+        invalidate()
+    except Exception:
+        pass
+
+    after = {t: _table_count(c, t) for t in _PURGE_TABLES}
+    return {
+        "ok": True,
+        "cleared": True,
+        "path": str(path),
+        "domain": scope or "all",
+        "removed": {t: max(0, before[t] - after[t]) for t in _PURGE_TABLES},
+        "remaining": after,
+    }

--- a/cw_platform/event_archive/recorder.py
+++ b/cw_platform/event_archive/recorder.py
@@ -13,6 +13,7 @@ from collections.abc import Iterable, Mapping
 from typing import Any
 
 from .db import get_conn
+from .run_scope import pair_id_from_scope, record_run_pairs, scope_key as _scope_key
 
 _LOG = logging.getLogger("crosswatch.event_archive")
 
@@ -196,6 +197,9 @@ class RunRecorder:
         self._b = ""
         self._two = False
         self._started = False
+        self._pair_id = ""
+        self._scope = ""
+        self._pair_stats: dict[tuple[str, str, str], dict[str, Any]] = {}
 
     def emit(self, event: str, **fields: Any):
         try:
@@ -225,6 +229,34 @@ class RunRecorder:
         kw.setdefault("pair_key", self._pair or None)
         kw.setdefault("source_kind", "runtime")
         self._buf.append(make_event(hash_extra=len(self._buf), **kw))
+
+    def _capture_pair_scope(self) -> None:
+        self._pair_id = pair_id_from_scope(os.environ.get("CW_PAIR_KEY"))
+        src, dst = self._ctx_providers()
+        self._scope = _scope_key(src, self._si or "default", dst, self._di or "default")
+
+    def _bump_pair_stats(self, *, src: str, dst: str, added: int = 0, removed: int = 0, updated: int = 0, errors: int = 0) -> None:
+        if not (added or removed or updated or errors):
+            return
+        scope = self._scope or _scope_key(src, self._si or "default", dst, self._di or "default")
+        key = (self._pair_id, scope, self._feature or "")
+        entry = self._pair_stats.get(key)
+        if entry is None:
+            entry = self._pair_stats[key] = {
+                "pair_id": self._pair_id,
+                "scope_key": scope,
+                "feature": self._feature or "",
+                "pair_key": self._pair or "",
+                "src_provider": src or "",
+                "src_instance": (self._si or "default").lower(),
+                "dst_provider": dst or "",
+                "dst_instance": (self._di or "default").lower(),
+                "added": 0, "removed": 0, "updated": 0, "errors": 0,
+            }
+        entry["added"] += int(added)
+        entry["removed"] += int(removed)
+        entry["updated"] += int(updated)
+        entry["errors"] += int(errors)
 
     def _seen_blackbox_item(self, *, feature: Any, pair_key: Any, dst: Any, src_instance: Any, dst_instance: Any, item_key: Any) -> bool:
         key = tuple(str(v or "") for v in (feature, pair_key, dst, src_instance, dst_instance, item_key))
@@ -265,6 +297,9 @@ class RunRecorder:
         if event == "run:done":
             self._add(event_type="sync_run_finished", operation="run", detail=dict(f))
             self._flush(force=True)
+            if self._pair_stats:
+                record_run_pairs(self._run_id, list(self._pair_stats.values()), conn=self._conn)
+                self._pair_stats = {}
             record_run_finished(
                 self._run_id,
                 status="done",
@@ -294,6 +329,7 @@ class RunRecorder:
             self._di = os.environ.get("CW_PAIR_DST_INSTANCE") or ""
             self._feature = str(f.get("feature") or "")
             self._pair = _pair_key(self._src, self._dst)
+            self._capture_pair_scope()
             return
 
         if event == "two:start":
@@ -304,6 +340,7 @@ class RunRecorder:
             self._di = os.environ.get("CW_PAIR_DST_INSTANCE") or ""
             self._feature = str(f.get("feature") or "")
             self._pair = _pair_key(self._a, self._b)
+            self._capture_pair_scope()
             return
 
         if event in ("one:plan", "two:plan"):
@@ -353,6 +390,14 @@ class RunRecorder:
             src_eff = src if src and src != dst else (self._b if dst == self._a else self._a)
             attempted = int(f.get("attempted") or 0)
             errors = int(f.get("errors") or 0)
+            self._bump_pair_stats(
+                src=src_eff or "",
+                dst=dst or "",
+                added=int(f.get("added") or 0),
+                removed=int(f.get("removed") or 0),
+                updated=int(f.get("updated") or 0),
+                errors=errors,
+            )
             self._add(
                 event_type="write_attempted",
                 operation=op,

--- a/cw_platform/event_archive/run_scope.py
+++ b/cw_platform/event_archive/run_scope.py
@@ -1,0 +1,178 @@
+# cw_platform/event_archive/run_scope.py
+# CrossWatch - Per-run pair scope and change counters
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import time
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from .db import get_conn
+
+_LOG = logging.getLogger("crosswatch.event_archive")
+
+_COLUMNS = (
+    "run_id", "pair_id", "scope_key", "feature", "pair_key",
+    "src_provider", "src_instance", "dst_provider", "dst_instance",
+    "added", "removed", "updated", "errors",
+)
+
+_BACKFILL_DAYS = 400
+_BACKFILL_CHUNK = 200
+
+
+def normalize_endpoint(provider: Any, instance: Any) -> str:
+    prov = str(provider or "").strip().upper()
+    inst = str(instance or "").strip().lower() or "default"
+    return f"{prov}:{inst}" if prov else ""
+
+
+def scope_key(src_provider: Any, src_instance: Any, dst_provider: Any, dst_instance: Any) -> str:
+    ends = [e for e in (normalize_endpoint(src_provider, src_instance), normalize_endpoint(dst_provider, dst_instance)) if e]
+    return "|".join(sorted(ends))
+
+
+def pair_id_from_scope(raw: Any) -> str:
+    parts = str(raw or "").split(":")
+    return parts[2].strip() if len(parts) >= 3 else ""
+
+
+def record_run_pairs(
+    run_id: str,
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    conn: sqlite3.Connection | None = None,
+) -> int:
+    prepared: list[tuple[Any, ...]] = []
+    for row in rows or ():
+        if not isinstance(row, Mapping):
+            continue
+        prepared.append((
+            str(run_id),
+            str(row.get("pair_id") or ""),
+            str(row.get("scope_key") or ""),
+            str(row.get("feature") or ""),
+            str(row.get("pair_key") or ""),
+            str(row.get("src_provider") or ""),
+            str(row.get("src_instance") or ""),
+            str(row.get("dst_provider") or ""),
+            str(row.get("dst_instance") or ""),
+            int(row.get("added") or 0),
+            int(row.get("removed") or 0),
+            int(row.get("updated") or 0),
+            int(row.get("errors") or 0),
+        ))
+    if not prepared:
+        return 0
+    c = conn or get_conn()
+    if c is None:
+        return 0
+    sql = f"INSERT OR REPLACE INTO run_pairs ({','.join(_COLUMNS)}) VALUES ({','.join('?' for _ in _COLUMNS)})"
+    try:
+        with c:
+            c.executemany(sql, prepared)
+        return len(prepared)
+    except Exception as exc:
+        _LOG.warning("run scope write failed: %s", exc)
+        return 0
+
+
+def _detail_counts(raw: Any) -> tuple[int, int, int, int]:
+    if isinstance(raw, Mapping):
+        data: Mapping[str, Any] = raw
+    else:
+        try:
+            parsed = json.loads(raw) if raw else {}
+        except Exception:
+            return (0, 0, 0, 0)
+        data = parsed if isinstance(parsed, Mapping) else {}
+
+    def _n(key: str) -> int:
+        try:
+            return max(0, int(data.get(key) or 0))
+        except Exception:
+            return 0
+
+    return (_n("added"), _n("removed"), _n("updated"), _n("errors"))
+
+
+def _backfill_batch(conn: sqlite3.Connection, run_ids: list[str]) -> int:
+    if not run_ids:
+        return 0
+    placeholders = ",".join("?" for _ in run_ids)
+    rows = conn.execute(
+        f"SELECT run_id, pair_key, feature, source_provider, source_instance, "
+        f"destination_provider, destination_instance, detail FROM events "
+        f"WHERE run_id IN ({placeholders}) AND event_type='write_attempted'",
+        run_ids,
+    ).fetchall()
+
+    agg: dict[tuple[str, ...], dict[str, Any]] = {}
+    for row in rows:
+        added, removed, updated, errors = _detail_counts(row["detail"])
+        if not (added or removed or updated or errors):
+            continue
+        src = str(row["source_provider"] or "").strip().upper()
+        dst = str(row["destination_provider"] or "").strip().upper()
+        si = str(row["source_instance"] or "").strip().lower() or "default"
+        di = str(row["destination_instance"] or "").strip().lower() or "default"
+        feature = str(row["feature"] or "")
+        key = (str(row["run_id"]), "", scope_key(src, si, dst, di), feature)
+        entry = agg.get(key)
+        if entry is None:
+            entry = agg[key] = {
+                "pair_key": str(row["pair_key"] or ""),
+                "src_provider": src, "src_instance": si,
+                "dst_provider": dst, "dst_instance": di,
+                "added": 0, "removed": 0, "updated": 0, "errors": 0,
+            }
+        entry["added"] += added
+        entry["removed"] += removed
+        entry["updated"] += updated
+        entry["errors"] += errors
+
+    if not agg:
+        return 0
+    prepared = [
+        (key[0], key[1], key[2], key[3], e["pair_key"],
+         e["src_provider"], e["src_instance"], e["dst_provider"], e["dst_instance"],
+         e["added"], e["removed"], e["updated"], e["errors"])
+        for key, e in agg.items()
+    ]
+    sql = f"INSERT OR REPLACE INTO run_pairs ({','.join(_COLUMNS)}) VALUES ({','.join('?' for _ in _COLUMNS)})"
+    with conn:
+        conn.executemany(sql, prepared)
+    return len(prepared)
+
+
+def backfill_run_pairs(conn: sqlite3.Connection | None = None, *, days: int = _BACKFILL_DAYS) -> int:
+    c = conn or get_conn()
+    if c is None:
+        return 0
+    since = int(time.time()) - int(days) * 86400
+    try:
+        pending = [
+            str(row[0]) for row in c.execute(
+                "SELECT run_id FROM sync_runs WHERE started_at>=? AND run_id IS NOT NULL AND run_id<>'' "
+                "AND NOT EXISTS (SELECT 1 FROM run_pairs p WHERE p.run_id=sync_runs.run_id) "
+                "ORDER BY started_at DESC",
+                (since,),
+            ).fetchall()
+        ]
+    except Exception as exc:
+        _LOG.warning("run scope backfill scan failed: %s", exc)
+        return 0
+
+    written = 0
+    for i in range(0, len(pending), _BACKFILL_CHUNK):
+        try:
+            written += _backfill_batch(c, pending[i:i + _BACKFILL_CHUNK])
+        except Exception as exc:
+            _LOG.warning("run scope backfill batch failed: %s", exc)
+            break
+    if written:
+        _LOG.info("run scope backfill wrote %d rows for %d runs", written, len(pending))
+    return written

--- a/cw_platform/event_archive/schema.py
+++ b/cw_platform/event_archive/schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import sqlite3
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 _CREATE_SYNC_RUNS = """
 CREATE TABLE IF NOT EXISTS sync_runs (
@@ -105,6 +105,25 @@ CREATE TABLE IF NOT EXISTS event_groups (
 )
 """
 
+_CREATE_RUN_PAIRS = """
+CREATE TABLE IF NOT EXISTS run_pairs (
+    run_id        TEXT NOT NULL,
+    pair_id       TEXT NOT NULL DEFAULT '',
+    scope_key     TEXT NOT NULL DEFAULT '',
+    feature       TEXT NOT NULL DEFAULT '',
+    pair_key      TEXT NOT NULL DEFAULT '',
+    src_provider  TEXT NOT NULL DEFAULT '',
+    src_instance  TEXT NOT NULL DEFAULT '',
+    dst_provider  TEXT NOT NULL DEFAULT '',
+    dst_instance  TEXT NOT NULL DEFAULT '',
+    added         INTEGER NOT NULL DEFAULT 0,
+    removed       INTEGER NOT NULL DEFAULT 0,
+    updated       INTEGER NOT NULL DEFAULT 0,
+    errors        INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (run_id, pair_id, scope_key, feature)
+) WITHOUT ROWID
+"""
+
 _CREATE_EVENT_IMPORTS = """
 CREATE TABLE IF NOT EXISTS event_imports (
     source_file        TEXT PRIMARY KEY,
@@ -165,7 +184,7 @@ _EXTRA_INDEXES = (
 
 
 def _create_tables(conn: sqlite3.Connection) -> None:
-    for stmt in (_CREATE_SYNC_RUNS, _CREATE_EVENTS, _CREATE_EVENT_GROUPS, _CREATE_EVENT_IMPORTS):
+    for stmt in (_CREATE_SYNC_RUNS, _CREATE_EVENTS, _CREATE_EVENT_GROUPS, _CREATE_EVENT_IMPORTS, _CREATE_RUN_PAIRS):
         conn.execute(stmt)
 
 
@@ -193,4 +212,12 @@ def apply_schema(conn: sqlite3.Connection) -> int:
         _create_indexes(conn)
         if ver < SCHEMA_VERSION:
             conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
+
+    if ver < 7:
+        try:
+            from .run_scope import backfill_run_pairs
+
+            backfill_run_pairs(conn)
+        except Exception:
+            pass
     return max(ver, SCHEMA_VERSION)

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -729,8 +729,11 @@ html[data-cw-initial-tab="settings"] #page-settings{display:block!important}
       <div class="cw-main-card-head-copy">
         <div class="cw-main-card-kicker">Statistics</div>
       </div>
-      <div id="cw-view-as" class="cw-view-as hidden">
-        <select id="cw-view-as-select" aria-label="View data as profile"></select>
+      <div class="cw-stats-head-side">
+        <button id="stats-calendar-open" class="cw-stats-calendar-btn" type="button" onclick="window.openStatisticsModal?.()" title="Sync activity calendar" aria-label="Open sync activity calendar"><span class="material-symbols-rounded" aria-hidden="true">calendar_month</span></button>
+        <div id="cw-view-as" class="cw-view-as hidden">
+          <select id="cw-view-as-select" aria-label="View data as profile"></select>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
# Pull request

## Change

- New Sync activity modal, opened from the calendar button on the Statistics card. 
- Year heatmap of syncs per day, click a day to get the runs on it with route, features and counts. 
- Metric toggle for changes, runs or failures.
- Adds a run_pairs table (schema v7) that records which pairs a run touched and what each one changed. 
- Events modal now takes a runId, so a run row can link straight into its events.
- Maintenance gets a Clear event data action that empties every event category and the calendar. 

## Why

- No easy way to see sync history over time

## Testing

- following full test suite

## Issue

NA