### PR TITLE
Change: drop the box around recent activity

### DIFF
--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -2092,9 +2092,7 @@ def get_profile_html(user: dict | None = None) -> str:
     <div class="cw-profile-pair-grid">
       <article class="cw-profile-widget">
         <div class="cw-profile-widget-head"><h2>Recent Activity</h2><button id="profile-activity-view-all" class="ghost refresh-insights" type="button">View all</button></div>
-        <div class="stat-block" id="profile-activity-block">
-          <div id="profile-activity" class="cw-profile-activity-list"></div>
-        </div>
+        <div id="profile-activity" class="cw-profile-activity-list"></div>
       </article>
       <article class="cw-profile-widget">
         <div class="cw-profile-widget-head"><h2>Quick Stats</h2></div>


### PR DESCRIPTION
# Pull request

## Change

- Removed the stat-block wrapper around the recent activity list on the profile page.

## Why

NA

## Testing

Checked /profile in the browser.

## Issue

NA