### PR TITLE
Add: interactive Sync backend

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -29,6 +29,7 @@ from .authenticationAPI import register_auth
 from .wallAPI import register_wall
 from .versionAPI import router as version_router
 from .editorAPI import router as editor_router
+from .interactiveSyncAPI import router as interactive_sync_router
 from .eventsAPI import router as events_router
 from .providerInstancesAPI import router as provider_instances_router
 from .playbackProgressAPI import router as playback_progress_router
@@ -111,6 +112,7 @@ def register(
     app.include_router(export_router)
     app.include_router(importer_router)
     app.include_router(editor_router)
+    app.include_router(interactive_sync_router)
     app.include_router(events_router)
     app.include_router(provider_instances_router)
     app.include_router(playback_progress_router)

--- a/api/appAuthAPI.py
+++ b/api/appAuthAPI.py
@@ -723,6 +723,7 @@ def non_admin_api_allowed(path: Any, method: Any) -> bool:
         "/api/export",
         "/api/import",
         "/api/editor",
+        "/api/interactive-sync",
         "/api/playlists",
         "/api/snapshots",
         "/api/manual",

--- a/api/interactiveSyncAPI.py
+++ b/api/interactiveSyncAPI.py
@@ -1,0 +1,245 @@
+# api/interactiveSyncAPI.py
+# CrossWatch - Interactive Sync API
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from copy import deepcopy
+import threading
+import time
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
+from cw_platform.access_policy import request_user, user_can_access_pair
+from cw_platform.config_base import load_config
+from cw_platform.id_map import canonical_key, coalesce_ids, keys_for_item, ID_KEYS
+from cw_platform.value_coercion import coerce_bool
+from services import interactive_sync as svc
+
+router = APIRouter(prefix="/api/interactive-sync", tags=["synchronization"])
+
+
+class Start(BaseModel):
+    pair_id: str = Field(min_length=1, max_length=256)
+
+
+class Revision(BaseModel):
+    revision: int = Field(ge=0)
+
+
+class Refresh(Revision):
+    choices: dict[str, str] = Field(default_factory=dict)
+
+
+class Apply(Revision):
+    model_config = {"extra": "forbid"}
+    selection_version: int = Field(ge=0)
+
+
+class Selection(Revision):
+    selection_version: int = Field(ge=0)
+    selected: bool
+    ids: list[str] | None = Field(default=None, min_length=1, max_length=200)
+    feature: str = Field(default="", max_length=32)
+    result: str = Field(default="", max_length=32)
+    q: str = Field(default="", max_length=256)
+
+
+class MappingEdit(Revision):
+    row_id: str
+    item: dict[str, Any]
+
+
+def owner(request):
+    user = request_user(request)
+    if user and not user.get("is_admin") and not (user.get("permissions") or {}).get("write"):
+        raise HTTPException(403, "Write permission required")
+    return str((user or {}).get("id") or (user or {}).get("username") or "local")
+
+
+def pair_for(cfg, request, pair_id):
+    pair = next((p for p in cfg.get("pairs", []) if str(p.get("id")) == pair_id), None)
+    if not pair or not user_can_access_pair(cfg, request_user(request), pair):
+        raise HTTPException(404, "Sync pair not found")
+    if not coerce_bool(pair.get("enabled", True), True):
+        raise HTTPException(409, "Enable this sync pair before running it")
+    return pair
+
+
+def get_session(sid, request, cfg):
+    svc.prune()
+    session = svc.SESSIONS.get(sid)
+    if session is None or session.owner != owner(request):
+        raise HTTPException(404, "Review expired or not found. Run the pair again.")
+    pair_for(cfg, request, session.pair_id)
+    session.touched = time.monotonic()
+    return session
+
+
+def check_revision(session, revision):
+    if session.status in ("reading", "applying"):
+        raise HTTPException(409, "This review is busy")
+    if session.status == "complete":
+        raise HTTPException(409, "This operation has finished. Run the pair again for a new review.")
+    if session.revision != revision:
+        raise HTTPException(409, "The plan changed. Reload this review.")
+
+
+def check_selection(session, version):
+    if session.selection_version != version:
+        raise HTTPException(409, "The selection changed. Reload this review.")
+
+
+def launch(session, task, *args, applying=False, prepare=None):
+    from . import syncAPI
+
+    rt = syncAPI._rt()
+    with rt[2]:
+        if syncAPI._is_sync_running():
+            raise HTTPException(409, "Another sync is running. Try again when it finishes.")
+        if prepare is not None:
+            prepare()
+        session.status = "applying" if applying else "reading"
+        session.message = "Checking provider data before applying selections…" if applying else "Reading providers and building the sync plan…"
+        thread = threading.Thread(target=svc.worker, args=(session, task, *args), daemon=True)
+        rt[1]["SYNC"] = thread
+        thread.start()
+
+
+@router.post("")
+def start(payload: Start, request: Request):
+    cfg = load_config()
+    user_id = owner(request)
+    pair = pair_for(cfg, request, payload.pair_id)
+    with svc.LOCK:
+        svc.prune()
+        if len(svc.SESSIONS) >= svc.MAX_SESSIONS:
+            raise HTTPException(429, "Close an existing review before starting another")
+        session = svc.Session(pair_id=payload.pair_id, owner=user_id)
+        session.pair = {k: pair.get(k) for k in ("source", "target", "source_instance", "target_instance", "mode", "name")}
+        launch(session, svc.refresh, cfg, {})
+        svc.SESSIONS[session.id] = session
+        return session.public()
+
+
+@router.get("/{sid}")
+def get(sid: str, request: Request):
+    with svc.LOCK:
+        return get_session(sid, request, load_config()).public()
+
+
+@router.post("/{sid}/refresh")
+def refresh(sid: str, payload: Refresh, request: Request):
+    cfg = load_config()
+    with svc.LOCK:
+        session = get_session(sid, request, cfg)
+        check_revision(session, payload.revision)
+        choices = dict(session.plan.choices)
+        for cid, winner in payload.choices.items():
+            conflict = session.plan.conflicts.get(cid)
+            if not conflict or winner not in (conflict["source"], conflict["target"]):
+                raise HTTPException(400, "Invalid conflict choice")
+            choices[cid] = winner
+        launch(session, svc.refresh, cfg, choices)
+        return session.public()
+
+
+@router.get("/{sid}/rows")
+def rows(sid: str, request: Request, revision: int = Query(ge=0), offset: int = Query(default=0, ge=0),
+         limit: int = Query(default=75, ge=1, le=200), feature: str = Query(default="", max_length=32),
+         result: str = Query(default="", max_length=32), q: str = Query(default="", max_length=256)):
+    with svc.LOCK:
+        session = get_session(sid, request, load_config())
+        if revision != session.revision:
+            raise HTTPException(409, "The plan changed. Reload this review.")
+        if session.store is None:
+            raise HTTPException(409, "Wait for the plan to finish")
+        return dict(ok=True, revision=session.revision, selection_version=session.selection_version,
+                    counts=dict(session.store.counts), **session.store.page(offset=offset, limit=limit, feature=feature, result=result, q=q))
+
+
+@router.post("/{sid}/selection")
+def selection(sid: str, payload: Selection, request: Request):
+    with svc.LOCK:
+        session = get_session(sid, request, load_config())
+        check_revision(session, payload.revision)
+        check_selection(session, payload.selection_version)
+        if session.status != "review" or session.store is None:
+            raise HTTPException(409, "Build a complete plan before selecting changes")
+        try:
+            session.store.select(payload.selected, ids=payload.ids, feature=payload.feature, result=payload.result, q=payload.q)
+        except ValueError as error:
+            raise HTTPException(400, str(error)) from error
+        session.selection_version += 1
+        return session.public()
+
+
+@router.post("/{sid}/apply")
+def apply(sid: str, payload: Apply, request: Request):
+    cfg = load_config()
+    with svc.LOCK:
+        session = get_session(sid, request, cfg)
+        check_revision(session, payload.revision)
+        check_selection(session, payload.selection_version)
+        if session.status != "review":
+            raise HTTPException(409, "Build a complete plan before applying")
+        if coerce_bool((cfg.get("sync") or {}).get("dry_run", False)):
+            raise HTTPException(409, "Disable global dry run before applying changes")
+        selected = session.store.selected_ids() if session.store else set()
+        if not selected:
+            raise HTTPException(400, "Select valid changes from this review")
+        launch(session, svc.apply, cfg, selected, applying=True)
+        return session.public()
+
+
+@router.post("/{sid}/mapping")
+def mapping(sid: str, payload: MappingEdit, request: Request):
+    from .editorAPI import _require_instance_scope, _save_policy_manual
+
+    cfg = load_config()
+    with svc.LOCK:
+        session = get_session(sid, request, cfg)
+        check_revision(session, payload.revision)
+        row = session.plan.rows.get(payload.row_id)
+        if not row or row["operation"] not in ("add", "update") or row["feature"] == "playlists":
+            raise HTTPException(400, "This change cannot be remapped")
+        _require_instance_scope(cfg, request, row["source"], row["source_instance"])
+        item = deepcopy(row["item"])
+        for key in (*ID_KEYS, "_trakt_history_id", "history_id", "_simkl_history_id", "_plex_history_id", "watched_id", "play_id"):
+            item.pop(key, None)
+        for key in ("type", "title", "year", "season", "episode", "series_title", "series_year", "show_ids"):
+            item.pop(key, None)
+            if key in payload.item:
+                item[key] = payload.item[key]
+        ids = payload.item.get("ids")
+        if not isinstance(ids, dict) or any(k not in ID_KEYS for k in ids):
+            raise HTTPException(400, "Supply supported media identifiers")
+        item["ids"] = coalesce_ids(ids)
+        if "show_ids" in item:
+            if not isinstance(item["show_ids"], dict) or any(k not in ID_KEYS for k in item["show_ids"]):
+                raise HTTPException(400, "Supply supported show identifiers")
+            item["show_ids"] = coalesce_ids(item["show_ids"])
+        if item.get("type") not in ("movie", "show", "anime", "season", "episode"):
+            raise HTTPException(400, "Invalid media type")
+        key = canonical_key(item)
+        if key == "unknown:" or not (item["ids"] or item.get("show_ids")):
+            raise HTTPException(400, "A media identifier is required")
+        original = row["key"]
+        def save():
+            _save_policy_manual(row["feature"], row["source"], {key: item},
+                                [original] if original and key != original and original not in keys_for_item(item) else [],
+                                row["source_instance"], merge=True)
+        launch(session, svc.refresh, cfg, session.plan.choices, prepare=save)
+        return session.public()
+
+
+@router.delete("/{sid}")
+def discard(sid: str, request: Request):
+    with svc.LOCK:
+        session = get_session(sid, request, load_config())
+        if session.status in ("reading", "applying"):
+            raise HTTPException(409, "Wait for the current operation to finish")
+        session.close()
+        del svc.SESSIONS[sid]
+        return {"ok": True}

--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -771,7 +771,7 @@ def _emit_unresolved_details(total_unresolved: int | None = None) -> None:
         for line in shown:
             _sync_progress_ui(f"[i] {line}")
 
-def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
+def _run_pairs_thread(run_id: str, overrides: dict | None = None, *, interactive: Any = None) -> None:
     rt = _rt()
     LOG_BUFFERS, RUNNING_PROCS, _append_log, strip_ansi = rt[0], rt[1], rt[8], rt[7]
     overrides = overrides or {}
@@ -880,6 +880,11 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
     try:
         load_config, _save = _env()
         cfg = load_config()
+        if interactive is not None:
+            from cw_platform.orchestrator._interactive import fingerprint
+
+            if fingerprint(cfg) != interactive.config_hash:
+                return
         scheduler_webhook_cfg = cfg if isinstance(cfg, dict) else {}
 
         try:
@@ -965,6 +970,8 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
                     )
 
             mgr = OrchestratorClass(config=cfg)
+            if interactive is not None:
+                mgr.interactive = interactive
             dry = coerce_bool((cfg.get("sync") or {}).get("dry_run", False)) or coerce_bool((overrides or {}).get("dry_run"))
             runtime_cfg = cfg.get("runtime") or {}
             sync_cfg = cfg.get("sync") or {}
@@ -972,13 +979,20 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None) -> None:
                 sync_cfg.get("write_state_json", runtime_cfg.get("write_state_json", True)),
                 True,
             )
+            def report_progress(line):
+                _sync_progress_ui(line)
+                if interactive is not None and interactive.on_progress is not None:
+                    interactive.on_progress(line)
+
             result = mgr.run_pairs(
                 dry_run=dry,
-                progress=_sync_progress_ui,
+                progress=report_progress,
                 pair_scope_ids=sorted(pair_scope_ids),
                 write_state_json=write_state_json,
                 use_snapshot=True,
             )
+            if interactive is not None:
+                interactive.result = result
 
         if coerce_bool(result.get("cancelled")) or cancel_requested(run_id):
             was_cancelled = True

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -468,6 +468,7 @@ def _non_admin_permission_allowed(user: dict, path: str, method: str = "GET") ->
         "/api/export",
         "/api/import",
         "/api/editor",
+        "/api/interactive-sync",
         "/api/playlists",
         "/api/snapshots",
         "/api/manual",

--- a/cw_platform/orchestrator/_interactive.py
+++ b/cw_platform/orchestrator/_interactive.py
@@ -1,0 +1,109 @@
+# cw_platform/orchestrator/_interactive.py
+# CrossWatch - Interactive Sync Plan Review
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+import hashlib
+import json
+import time
+from typing import Any
+from collections.abc import Callable, MutableMapping
+
+from ..id_map import canonical_key
+
+
+def fingerprint(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, default=str, separators=(",", ":")).encode()).hexdigest()
+
+
+@dataclass
+class InteractivePlan:
+    preview: bool = True
+    selected: set[str] = field(default_factory=set)
+    choices: dict[str, str] = field(default_factory=dict)
+    rows: MutableMapping[str, dict[str, Any]] = field(default_factory=dict)
+    conflicts: MutableMapping[str, dict[str, Any]] = field(default_factory=dict)
+    record_rows: bool = True
+    copy_rows: bool = True
+    notices: list[dict[str, Any]] = field(default_factory=list)
+    seen: set[str] = field(default_factory=set)
+    deferred_removes: list[dict[str, Any]] = field(default_factory=list)
+    result: dict[str, Any] | None = None
+    valid: Callable[[], bool] | None = None
+    config_hash: str = ""
+    planned_at: int = field(default_factory=lambda: int(time.time()))
+    on_progress: Callable[[Any], None] | None = None
+    on_result: Callable[..., None] | None = None
+
+    def conflict(self, feature, key, a, b, left, right, default):
+        cid = fingerprint([feature, key, a, b, left, right])
+        winner = self.choices.get(cid, default)
+        if winner not in (a, b):
+            winner = default
+        if self.record_rows:
+            self.conflicts[cid] = dict(id=cid, feature=feature, key=key, source=a, target=b,
+                                       left=deepcopy(left) if self.copy_rows else left,
+                                       right=deepcopy(right) if self.copy_rows else right, winner=winner)
+        return winner
+
+    def filter(self, feature, provider, instance, operation, items, *, source="", source_instance="default", before=None, scope="", down=False, destination_label=""):
+        from ._unresolved import load_unresolved_map
+
+        unresolved = load_unresolved_map(provider, feature, cross_features=False) if self.record_rows and self.preview and items else {}
+        valid = self.valid is None or self.valid()
+        kept = []
+        total = len(items) if hasattr(items, "__len__") else None
+        done = 0
+        def report():
+            if self.on_progress is not None:
+                self.on_progress(dict(event="review:plan", feature=feature, provider=provider, done=done, total=total))
+        if items:
+            report()
+        for item in items:
+            key = canonical_key(item)
+            current = (before or {}).get(key)
+            payload = dict(feature=feature, provider=provider, instance=instance, operation=operation,
+                           item=item, before=current, scope=scope,
+                           source=source, source_instance=source_instance, destination_label=destination_label)
+            rid = fingerprint(payload)
+            reason = "Provider unavailable" if down else ""
+            if key == "unknown:":
+                reason = "Missing media identifier"
+            known = (unresolved or {}).get(key)
+            hint = str((known or {}).get("hint") or (known or {}).get("reason") or "") if isinstance(known, dict) else ""
+            if "|title:" in key and not hint:
+                hint = "No media ID; provider title resolution is required"
+            result = "blocked" if reason else ("unresolved" if hint else operation)
+            if self.record_rows:
+                self.rows[rid] = dict(deepcopy(payload) if self.copy_rows else payload,
+                                      id=rid, key=key, result=result, reason=reason or hint, selectable=not reason)
+            if valid and not reason and rid in self.selected:
+                self.seen.add(rid)
+            if not self.preview and rid in self.selected and not reason and valid:
+                kept.append(item)
+            elif not self.preview and operation == "remove":
+                self.deferred_removes.append(payload)
+            done += 1
+            if done % 250 == 0:
+                report()
+        if done:
+            report()
+        return kept
+
+    def retain_deferred(self, feature, provider, instance, current, previous, key_fn=canonical_key):
+        retained = False
+        for row in self.deferred_removes:
+            if (row["feature"], row["source"], row["source_instance"]) != (feature, provider, instance):
+                continue
+            key = key_fn(row["item"])
+            if key in previous and key not in current:
+                current[key] = deepcopy(previous[key])
+                retained = True
+        return retained
+
+
+def choose_conflict(ctx, feature, key, a, b, left, right, default):
+    review = getattr(ctx, "interactive", None)
+    return review.conflict(feature, key, a, b, left, right, default) if review is not None else default

--- a/cw_platform/orchestrator/_pairs.py
+++ b/cw_platform/orchestrator/_pairs.py
@@ -344,6 +344,8 @@ def _pair_env(pair: Mapping[str, Any], *, i: int, src: str, dst: str, mode: str,
                 os.environ[k] = v
 
 def run_pairs(ctx) -> dict[str, Any]:
+    review = getattr(ctx, "interactive", None)
+    preview = review is not None and review.preview
     for k in ("CW_PAIR_KEY", "CW_PAIR_SCOPE", "CW_SYNC_PAIR", "CW_PAIR"):
         if str(os.environ.get(k, "")).strip().lower() == "unscoped":
             os.environ.pop(k, None)
@@ -358,19 +360,21 @@ def run_pairs(ctx) -> dict[str, Any]:
     emit = ctx.emit
 
     _event_rec = None
-    try:
-        from ..event_archive import RunRecorder as _RunRecorder
-        import time as _t
-        _rid = str(os.environ.get("CW_RUN_ID") or int(_t.time()))
-        _event_rec = _RunRecorder(ctx.emit, run_id=_rid)
-        ctx.emit = _event_rec.emit
-        emit = ctx.emit
-    except Exception:
-        _event_rec = None
+    if not preview:
+        try:
+            from ..event_archive import RunRecorder as _RunRecorder
+            import time as _t
+            _rid = str(os.environ.get("CW_RUN_ID") or int(_t.time()))
+            _event_rec = _RunRecorder(ctx.emit, run_id=_rid)
+            ctx.emit = _event_rec.emit
+            emit = ctx.emit
+        except Exception:
+            _event_rec = None
 
     try:
         ttl_days = int(sync_cfg.get("tombstone_ttl_days", 30))
-        ctx.tomb_prune(max(1, ttl_days) * 24 * 3600)
+        if not preview:
+            ctx.tomb_prune(max(1, ttl_days) * 24 * 3600)
     except Exception:
         pass
 
@@ -557,6 +561,9 @@ def run_pairs(ctx) -> dict[str, Any]:
                             attempted_add_duplicate_keys_total += int(res.get("attempted_add_duplicate_keys", 0))
                             errors_total += int(res.get("errors", 0))
 
+                        if review is not None and not preview and review.on_result is not None:
+                            review.on_result(feature, src, dst, src_inst, dst_inst, mode, res)
+
                         if isinstance(res, Mapping) and coerce_bool(res.get("cancelled"), False):
                             emit("feature:cancelled", src=src, dst=dst, feature=feature)
                             cancelled = True
@@ -574,6 +581,11 @@ def run_pairs(ctx) -> dict[str, Any]:
                     ctx.config = prev_cfg
     if not cancelled and cancel_requested():
         cancelled = True
+
+    if preview:
+        ctx.emit = metrics._orig_emit
+        return {"ok": not errors_total and not cancelled, "errors": errors_total,
+                "blocked": blocked_total, "cancelled": cancelled, "pairs": len(pairs)}
 
     if "watchlist" in features_ran:
         try:

--- a/cw_platform/orchestrator/_pairs_blocklist.py
+++ b/cw_platform/orchestrator/_pairs_blocklist.py
@@ -184,13 +184,18 @@ def apply_blocklist(
     pair_key: str | None = None,
     cross_feature_unresolved: bool = True,
     ignore_pair_tomb: bool = False,
+    tomb_ttl_seconds: int | None = None,
+    now: int | None = None,
+    observed_tombstones: Mapping[str, int] | None = None,
     emit=None,
 ) -> list[dict[str, Any]]:
     global_tomb: set[str] = set()
 
     try:
-        pmap_raw = keys_for_feature(state_store, feature, pair=pair_key) or {}
+        pmap_raw = keys_for_feature(state_store, feature, pair=pair_key, ttl_seconds=tomb_ttl_seconds, now=now) or {}
         pmap: dict[str, int] = {str(k): int(v) for k, v in (pmap_raw or {}).items()} if isinstance(pmap_raw, Mapping) else {}
+        for key, timestamp in (observed_tombstones or {}).items():
+            pmap.setdefault(key, timestamp)
         pair_tomb: set[str] = set(pmap.keys())
     except Exception:
         pmap = {}

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -1118,7 +1118,7 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
     cancelled = bool(cancel_requested())
 
     prev_state = load_feature_state(ctx.state_store, feature)
-    manual_adds, manual_blocks = _manual_policy(prev_state, src, feature)
+    manual_adds, manual_blocks = _manual_policy(prev_state, src, feature, src_inst)
     prev_provs = (prev_state.get("providers") or {})
 
     def _prev_items(pmap: Mapping[str, Any], prov: str, inst: str, feat: str) -> dict[str, Any]:
@@ -1646,6 +1646,8 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
             pair_key=pair_key,
             cross_feature_unresolved=_cross_feature_unresolved(feature),
             ignore_pair_tomb=(str(feature or "").lower() == "history"),
+            tomb_ttl_seconds=max(1, int(sync_cfg.get("tombstone_ttl_days", 30))) * 86400,
+            now=getattr(getattr(ctx, "interactive", None), "planned_at", None),
             emit=emit,
         )
         blocked_total += max(0, before_blocklist - len(adds))
@@ -1690,6 +1692,15 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
     if use_phantoms and adds:
         adds, _blocked = guard.filter_adds(adds, _sync_key, _sync_minimal, emit, ctx.state_store, pair_key)
         blocked_total += int(_blocked or 0)
+
+    review = getattr(ctx, "interactive", None)
+    if review is not None:
+        review_args = dict(source=src, source_instance=src_inst, before=dst_full, down=dst_down)
+        adds = review.filter(feature, dst, dst_inst, "add", adds, **review_args)
+        updates = review.filter(feature, dst, dst_inst, "update", updates, **review_args)
+        removes = review.filter(feature, dst, dst_inst, "remove", removes, **review_args)
+        if review.preview:
+            return {"blocked": blocked_total, "cancelled": cancelled}
 
     attempted_keys: list[str] = []
     key2item: dict[str, Any] = {}
@@ -2226,6 +2237,8 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
                 dbg("baseline.provider_native", feature=feature, dst=dst,
                     canonical=len(dst_commit), comparison=len(dst_full))
 
+            if review is not None and review.retain_deferred(feature, src, src_inst, src_idx, prev_src, _sync_key):
+                now_cp_src = prev_cp_src
             _commit_baseline(provs_block, src, src_inst, feature, src_idx)
             _commit_baseline(provs_block, dst, dst_inst, feature, dst_commit)
             _commit_checkpoint(provs_block, src, src_inst, feature, now_cp_src)

--- a/cw_platform/orchestrator/_pairs_playlists.py
+++ b/cw_platform/orchestrator/_pairs_playlists.py
@@ -74,12 +74,15 @@ def run_playlist_mappings(
     for mapping in resolved:
         mapping_id = str(mapping.get("id") or "")
         try:
+            review = getattr(ctx, "interactive", None)
+            review_kwargs = {"interactive": review} if review is not None else {}
             res = run_mapping(
                 full_cfg,
                 mapping,
                 dry_run=dry_run,
                 providers=providers,
                 emit=ctx.emit,
+                **review_kwargs,
             )
             if not dry_run and isinstance(full_cfg, dict):
                 try:

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -69,6 +69,7 @@ except Exception:  # pragma: no cover
 
 from ..provider_instances import normalize_instance_id
 from ._planner import diff_ratings, diff_progress, _pick_rating
+from ._interactive import choose_conflict
 from ._progress_completion import fcfg_for_progress_target
 try:
     from ._pairs_oneway import _media_type_filter_index as _media_filter
@@ -496,8 +497,8 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
         except Exception:
             pass
 
-    manual_adds_A, manual_blocks_A = _manual_policy(prev_state, a, feature)
-    manual_adds_B, manual_blocks_B = _manual_policy(prev_state, b, feature)
+    manual_adds_A, manual_blocks_A = _manual_policy(prev_state, a, feature, src_inst)
+    manual_adds_B, manual_blocks_B = _manual_policy(prev_state, b, feature, dst_inst)
 
     prev_provs = (prev_state.get("providers") or {})
 
@@ -664,20 +665,18 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
             A_eff = collapse_history_latest(A_eff)
             B_eff = collapse_history_latest(B_eff)
 
-    now = int(_t.time())
+    review = getattr(ctx, "interactive", None)
+    now = review.planned_at if review is not None else int(_t.time())
     tomb_ttl_days = int((cfg.get("sync") or {}).get("tombstone_ttl_days", 30))
     tomb_ttl_secs = max(1, tomb_ttl_days) * 24 * 3600
     pair_key = "-".join(sorted([a, b]))
-    tomb_map = dict(
-        keys_for_feature(
-            ctx.state_store, feature, pair=pair_key
-        ) or {}
-    )
-    tomb = {k for k, ts in tomb_map.items() if not isinstance(ts, int) or (now - int(ts)) <= tomb_ttl_secs}
+    tomb_map = keys_for_feature(ctx.state_store, feature, pair=pair_key, ttl_seconds=tomb_ttl_secs, now=now) or {}
+    tomb = set(tomb_map)
 
     bootstrap = (not prevA) and (not prevB) and not tomb
     obsA: set[str] = set()
     obsB: set[str] = set()
+    observed_tombstones: dict[str, int] = {}
     if not bootstrap:
         if include_obs_A and not A_suspect:
             obsA = {k for k in prevA.keys() if k not in (A_cur or {})}
@@ -686,9 +685,6 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
         newly = (obsA | obsB) - tomb
 
         if newly:
-            t = ctx.state_store.load_tomb() or {}
-            ks = t.setdefault("keys", {})
-
             def _tokens_for_ck(ck: str) -> set[str]:
                 toks = {ck}
                 if feature == "history" and history_event_mode:
@@ -708,10 +704,13 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
             for ck in set(newly):
                 write_tokens |= _tokens_for_ck(ck)
 
-            for tok in write_tokens:
-                ks.setdefault(f"{feature}:{pair_key}|{tok}", now)
-
-            ctx.state_store.save_tomb(t)
+            observed_tombstones = dict.fromkeys(write_tokens, now)
+            if review is None:
+                t = ctx.state_store.load_tomb() or {}
+                ks = t.setdefault("keys", {})
+                for tok in write_tokens:
+                    ks.setdefault(f"{feature}:{pair_key}|{tok}", now)
+                ctx.state_store.save_tomb(t)
 
         emit("debug", msg="observed.deletions", a=len(obsA), b=len(obsB), tomb=len(tomb),
              suppressed_on_A=bool(A_suspect), suppressed_on_B=bool(B_suspect))
@@ -1111,6 +1110,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                     win = a if ta > tb else b
                 else:
                     win = prefer
+                win = choose_conflict(ctx, feature, ak, a, b, av, bv, win)
                 if win == a:
                     addB.append(_minimal_keep_rating(av))
                 else:
@@ -1470,6 +1470,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                         else:
                             win = prefer
 
+                win = choose_conflict(ctx, feature, k, a, b, a_it, b_it, win)
                 if win == a:
                     addB.append(_minimal_keep_progress(upB[k]))
                 else:
@@ -1485,6 +1486,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                     win = a if ta > tb else b
                 else:
                     win = prefer
+                win = choose_conflict(ctx, feature, k, a, b, clB[k], b_it, win)
                 if win == a:
                     if allow_removals:
                         remB.append(_minimal(clB[k]))
@@ -1499,6 +1501,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                     win = a if ta > tb else b
                 else:
                     win = prefer
+                win = choose_conflict(ctx, feature, k, a, b, a_it, clA[k], win)
                 if win == b:
                     if allow_removals:
                         remA.append(_minimal(clA[k]))
@@ -1752,6 +1755,9 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
             pair_key=pair_key,
             cross_feature_unresolved=_cross_feature_unresolved(feature),
             ignore_pair_tomb=(str(feature or "").lower() in ("history", "ratings")),
+            tomb_ttl_seconds=tomb_ttl_secs,
+            now=now,
+            observed_tombstones=observed_tombstones,
             emit=emit,
         )
         blocked_total += max(0, before_blocklist_A - len(add_to_A))
@@ -1765,25 +1771,29 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
             pair_key=pair_key,
             cross_feature_unresolved=_cross_feature_unresolved(feature),
             ignore_pair_tomb=(str(feature or "").lower() in ("history", "ratings")),
+            tomb_ttl_seconds=tomb_ttl_secs,
+            now=now,
+            observed_tombstones=observed_tombstones,
             emit=emit,
         )
         blocked_total += max(0, before_blocklist_B - len(add_to_B))
 
     manual_blocked = 0
-    if manual_blocks_A:
+    manual_blocks = manual_blocks_A | manual_blocks_B
+    if manual_blocks:
         pre_add, pre_rem = len(add_to_A), len(rem_from_A)
-        add_to_A = _filter_manual_block(add_to_A, manual_blocks_A)
-        rem_from_A = _filter_manual_block(rem_from_A, manual_blocks_A)
+        add_to_A = _filter_manual_block(add_to_A, manual_blocks)
+        rem_from_A = _filter_manual_block(rem_from_A, manual_blocks)
         blk = (pre_add - len(add_to_A)) + (pre_rem - len(rem_from_A))
         if blk:
             emit("debug", msg="blocked.counts", feature=feature, dst=a, pair=f"{a}-{b}",
                  blocked_manual=int(blk), blocked_total=int(blk))
         manual_blocked += blk
 
-    if manual_blocks_B:
+    if manual_blocks:
         pre_add, pre_rem = len(add_to_B), len(rem_from_B)
-        add_to_B = _filter_manual_block(add_to_B, manual_blocks_B)
-        rem_from_B = _filter_manual_block(rem_from_B, manual_blocks_B)
+        add_to_B = _filter_manual_block(add_to_B, manual_blocks)
+        rem_from_B = _filter_manual_block(rem_from_B, manual_blocks)
         blk = (pre_add - len(add_to_B)) + (pre_rem - len(rem_from_B))
         if blk:
             emit("debug", msg="blocked.counts", feature=feature, dst=b, pair=f"{a}-{b}",
@@ -1890,6 +1900,19 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
          upd_to_A=len(upd_to_A), upd_to_B=len(upd_to_B),
          rem_from_A=len(rem_from_A), rem_from_B=len(rem_from_B))
     cancelled = cancelled or bool(cancel_requested())
+
+    review = getattr(ctx, "interactive", None)
+    if review is not None:
+        args_A = dict(source=b, source_instance=dst_inst, before=A_eff, down=a_down)
+        args_B = dict(source=a, source_instance=src_inst, before=B_eff, down=b_down)
+        add_to_A = review.filter(feature, a, src_inst, "add", add_to_A, **args_A)
+        add_to_B = review.filter(feature, b, dst_inst, "add", add_to_B, **args_B)
+        upd_to_A = review.filter(feature, a, src_inst, "update", upd_to_A, **args_A)
+        upd_to_B = review.filter(feature, b, dst_inst, "update", upd_to_B, **args_B)
+        rem_from_A = review.filter(feature, a, src_inst, "remove", rem_from_A, **args_A)
+        rem_from_B = review.filter(feature, b, dst_inst, "remove", rem_from_B, **args_B)
+        if review.preview:
+            return {"cancelled": cancelled}
 
     resA_rem: dict[str, Any] = {"ok": True, "count": 0}
     resB_rem: dict[str, Any] = {"ok": True, "count": 0}
@@ -2567,6 +2590,11 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                 return out
 
             B_eff = _rekey_to_other(B_eff, A_eff)
+        if review is not None:
+            if review.retain_deferred(feature, a, src_inst, A_eff, prevA, _sync_key):
+                now_cp_A = prev_cp_A
+            if review.retain_deferred(feature, b, dst_inst, B_eff, prevB, _sync_key):
+                now_cp_B = prev_cp_B
         _commit_baseline(provs_block, a, src_inst, feature, A_eff)
         _commit_baseline(provs_block, b, dst_inst, feature, B_eff)
         _commit_checkpoint(provs_block, a, src_inst, feature, now_cp_A)

--- a/cw_platform/orchestrator/_snapshots.py
+++ b/cw_platform/orchestrator/_snapshots.py
@@ -726,6 +726,7 @@ def build_snapshots_for_feature(
         if not provider_configured(config, name):
             continue
 
+        emit_info(json.dumps(dict(event="snapshot:start", provider=name, feature=feature)))
         scope = pair_scope() or "unscoped"
         mode = "events" if bool((config or {}).get("_cw_history_rewatches")) and str(feature).lower() == "history" else "state"
         memo_key = (scope, name, feature, mode)
@@ -736,6 +737,7 @@ def build_snapshots_for_feature(
                 if (now - ts) < snap_ttl_sec:
                     snaps[name] = cached_idx
                     dbg("snapshot.memo", provider=name, feature=feature, count=_eventish_count(feature, cached_idx), raw_count=len(cached_idx))
+                    emit_info(json.dumps(dict(event="snapshot:done", provider=name, feature=feature, count=_eventish_count(feature, cached_idx))))
                     if on_snapshot is not None:
                         on_snapshot(name, cached_idx)
                     continue
@@ -764,6 +766,7 @@ def build_snapshots_for_feature(
                 snap_cache[memo_key] = (now, canon)
 
         dbg("snapshot", provider=name, feature=feature, count=_eventish_count(feature, canon), raw_count=len(canon))
+        emit_info(json.dumps(dict(event="snapshot:done", provider=name, feature=feature, count=_eventish_count(feature, canon))))
         if on_snapshot is not None:
             on_snapshot(name, canon)
 

--- a/cw_platform/orchestrator/_tombstones.py
+++ b/cw_platform/orchestrator/_tombstones.py
@@ -63,6 +63,8 @@ def keys_for_feature(
     *,
     pair: str | None = None,
     include_global: bool = True,
+    ttl_seconds: int | None = None,
+    now: int | None = None,
 ) -> dict[str, int]:
     tomb = store.load_tomb()
     raw = tomb.get("keys") or {}
@@ -72,6 +74,10 @@ def keys_for_feature(
         }
     else:
         ks_all = {}
+
+    if ttl_seconds is not None:
+        current = int(time.time()) if now is None else now
+        ks_all = {k: ts for k, ts in ks_all.items() if current - ts < ttl_seconds}
 
     out: dict[str, int] = {}
 

--- a/cw_platform/orchestrator/facade.py
+++ b/cw_platform/orchestrator/facade.py
@@ -56,6 +56,7 @@ class Orchestrator:
     pair_scope_ids: Sequence[str] | None = None
     write_state_json: bool = True
     state_path: Path | None = None
+    interactive: Any = None
 
     files: StateStore | None = field(init=False, default=None)
     providers: dict[str, InventoryOps] = field(init=False, default_factory=dict)
@@ -129,7 +130,7 @@ class Orchestrator:
         from types import SimpleNamespace
 
         return SimpleNamespace(
-            config=self.cfg,
+            config={**self.cfg, "_cw_interactive_planned_at": self.interactive.planned_at} if self.interactive is not None else self.cfg,
             providers=self.providers,
             emit=self.emitter.emit,
             emit_info=self.emitter.info,
@@ -145,6 +146,7 @@ class Orchestrator:
             pair_scope_ids=list(self.pair_scope_ids or []),
             write_state_json=self.write_state_json,
             state_path=self.state_path,
+            interactive=self.interactive,
             snap_cache=self.snap_cache,
             snap_ttl_sec=self.snap_ttl_sec,
             apply_chunk_size=self.apply_chunk_size,
@@ -191,6 +193,9 @@ class Orchestrator:
             self.state_path = Path(state_path) if state_path else None
 
             summary = _run_pairs(self.context)
+
+            if self.interactive is not None and self.interactive.preview:
+                return summary
 
 
             if self.write_state_json:

--- a/cw_platform/playlists_runner.py
+++ b/cw_platform/playlists_runner.py
@@ -467,8 +467,12 @@ def _ops_cfg(providers: Mapping[str, Any], cfg: Mapping[str, Any], endpoint: Map
     return ops, build_provider_config_view(cfg, provider, inst), inst, provider, playlist_id
 
 
-def _snapshot_endpoint(providers: Mapping[str, Any], cfg: Mapping[str, Any], endpoint: Mapping[str, Any]) -> tuple[PlaylistSnapshot, Any, Mapping[str, Any], str]:
+def _snapshot_endpoint(providers: Mapping[str, Any], cfg: Mapping[str, Any], endpoint: Mapping[str, Any], *, review_pending: bool = False) -> tuple[PlaylistSnapshot, Any, Mapping[str, Any], str]:
     ops, view, inst, provider, playlist_id = _ops_cfg(providers, cfg, endpoint)
+    if not playlist_id and review_pending and isinstance(endpoint.get("pending_create"), Mapping):
+        resource = PlaylistResource(provider=provider, id="pending", instance=inst,
+                                    name=str(endpoint["pending_create"].get("name") or "New playlist"), can_add=True)
+        return PlaylistSnapshot(resource=resource), ops, view, inst
     if not playlist_id:
         raise PlaylistRunError("playlist id missing")
     snap = ops.get_playlist_snapshot(view, playlist_id, instance=inst)
@@ -602,6 +606,8 @@ def _aggregate_targets(
     providers: Mapping[str, Any],
     cfg: Mapping[str, Any],
     targets: Sequence[Mapping[str, Any]],
+    *,
+    review_pending: bool = False,
 ) -> dict[str, Any]:
     logical: dict[str, PlaylistItem] = {}
     physical: dict[str, list[dict[str, Any]]] = {}
@@ -611,7 +617,7 @@ def _aggregate_targets(
     warnings: list[str] = []
     for pos, target in enumerate(targets):
         endpoint_id = str(target.get("endpoint_id") or "").strip()
-        snap, ops, view, inst = _snapshot_endpoint(providers, cfg, target)
+        snap, ops, view, inst = _snapshot_endpoint(providers, cfg, target, review_pending=review_pending)
         resource = snap.resource
         _merge_warnings(warnings, resource)
         if resource.is_smart:
@@ -666,6 +672,7 @@ def _plan_ruleset(
     *,
     providers: Mapping[str, Any] | None = None,
     materialize: bool = False,
+    review_pending: bool = False,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     providers = providers or _providers()
     ruleset = _ruleset_for_mapping(cfg, mapping)
@@ -689,9 +696,9 @@ def _plan_ruleset(
     source_keys = [it.key for it in source_items]
     source_set = set(source_by_key)
     for tgt in targets:
-        if isinstance(tgt, Mapping) and tgt.get("pending_create"):
+        if isinstance(tgt, Mapping) and tgt.get("pending_create") and not review_pending:
             _materialize_pending(providers, cfg, mapping, tgt, source_items, materialize=materialize)
-    agg = _aggregate_targets(providers, cfg, targets)
+    agg = _aggregate_targets(providers, cfg, targets, review_pending=review_pending)
     warnings: list[str] = list(agg.get("warnings") or [])
     if ruleset["direction"] == "bidirectional":
         _merge_warnings(warnings, source_snap.resource)
@@ -832,6 +839,7 @@ def build_plan(
     *,
     providers: Mapping[str, Any] | None = None,
     materialize: bool = False,
+    review_pending: bool = False,
 ) -> tuple[PlaylistPlan, dict[str, Any]]:
     providers = providers or _providers()
     source = mapping.get("source") or {}
@@ -862,15 +870,16 @@ def build_plan(
     src_snap: PlaylistSnapshot = src_ops.get_playlist_snapshot(src_cfg, src_pl, instance=src_inst)
 
     seeded_keys: set[str] = set()
-    if not dst_pl:
+    pending_review = review_pending and not dst_pl and isinstance(target.get("pending_create"), Mapping)
+    if not dst_pl and not pending_review:
         dst_pl, seeded_keys = _materialize_pending(
             providers, cfg, mapping, target, src_snap.items, materialize=materialize
         )
         dst_cfg = build_provider_config_view(cfg, dst, dst_inst)
-    if not dst_pl:
+    if not dst_pl and not pending_review:
         raise PlaylistRunError("mapping target playlist id missing")
 
-    dst_resource = _find_resource(dst_ops, dst_cfg, dst_inst, dst_pl)
+    dst_resource = PlaylistResource(provider=dst, id="pending", name=str((target.get("pending_create") or {}).get("name") or "New playlist"), instance=dst_inst, can_add=True) if pending_review else _find_resource(dst_ops, dst_cfg, dst_inst, dst_pl)
     if dst_resource is None:
         raise PlaylistRunError(f"target playlist not found: {dst_pl}")
     if dst_resource.is_smart:
@@ -879,7 +888,7 @@ def build_plan(
         raise PlaylistRunError("target playlist is read only")
     _merge_warnings(plan.warnings, dst_resource)
 
-    dst_snap: PlaylistSnapshot = dst_ops.get_playlist_snapshot(dst_cfg, dst_pl, instance=dst_inst)
+    dst_snap: PlaylistSnapshot = PlaylistSnapshot(resource=dst_resource) if pending_review else dst_ops.get_playlist_snapshot(dst_cfg, dst_pl, instance=dst_inst)
 
     src_by_key = src_snap.by_key()
     dst_by_key = dst_snap.by_key()
@@ -935,7 +944,9 @@ def build_plan(
         "dst_set": dst_set,
         "src_set": src_set,
         "src_keys": src_keys,
+        "dst_keys": dst_snap.ordered_keys(),
         "seeded_keys": {k for k in seeded_keys if k in dst_set},
+        "pending_review": pending_review,
     }
     return plan, ctx
 
@@ -970,8 +981,9 @@ def _apply_ruleset_mapping(
     dry_run: bool = False,
     providers: Mapping[str, Any] | None = None,
     emit: Callable[..., None] | None = None,
+    interactive: Any = None,
 ) -> dict[str, Any]:
-    plan, ctx = _plan_ruleset(cfg, mapping, providers=providers, materialize=not dry_run)
+    plan, ctx = _plan_ruleset(cfg, mapping, providers=providers, materialize=not dry_run and interactive is None, review_pending=interactive is not None)
     mapping_id = str(mapping.get("id") or "")
     result: dict[str, Any] = {
         "ok": not bool(plan.get("blocked")),
@@ -1000,9 +1012,34 @@ def _apply_ruleset_mapping(
         result["error"] = "capacity exceeded"
         result["unresolved_count"] = 0
         result["finished_at"] = int(time.time())
-        store_result(mapping, result)
+        if not dry_run:
+            store_result(mapping, result)
         _emit(emit, "playlist:capacity", mapping=mapping_id, ruleset=plan.get("ruleset_id"), overflow=result["overflow_count"])
         return result
+    if interactive is not None:
+        source = mapping.get("source") or {}
+        target_meta = {str(t["endpoint_id"]): t for t in plan.get("per_target", [])}
+        for field_name, operation in (("target_additions", "add"), ("target_removals", "remove")):
+            for eid, keys in ctx[field_name].items():
+                meta = target_meta[eid]
+                batch = [_item_dict_from_sources(k, ctx["source_by_key"], ctx["target_by_key"], ctx["assignments"]) for k in keys]
+                kept = interactive.filter("playlists", str(meta["provider"]).upper(), normalize_instance_id(meta.get("instance")), operation, batch,
+                                          source=str(source.get("provider") or "").upper(), source_instance=ctx["source_inst"], scope=f"{mapping_id}:{eid}",
+                                          destination_label=str(meta.get("playlist_name") or eid) + (" (create playlist)" if not meta.get("playlist_id") else ""))
+                ctx[field_name][eid] = [canonical_key(it) for it in kept]
+        for field_name, operation in (("add_to_source", "add"), ("remove_from_source", "remove")):
+            batch = [_item_dict_from_sources(k, ctx["source_by_key"], ctx["target_by_key"], ctx["assignments"]) for k in sorted(ctx[field_name])]
+            kept = interactive.filter("playlists", str(source.get("provider") or "").upper(), ctx["source_inst"], operation, batch, scope=f"{mapping_id}:source")
+            ctx[field_name] = {canonical_key(it) for it in kept}
+        if not interactive.preview:
+            target_keys = set(ctx["target_keys"])
+            selected_additions = {k for keys in ctx["target_additions"].values() for k in keys}
+            selected_removals = {k for keys in ctx["target_removals"].values() for k in keys}
+            ctx["final_source"] = (set(ctx["source_keys"]) | ctx["add_to_source"]) - ctx["remove_from_source"]
+            ctx["final_managed"] = (set(ctx["assignments"]) | selected_additions) & ((target_keys - selected_removals) | selected_additions)
+            ctx["assignment_target"] = {k: v.get("endpoint_id") for k, v in ctx["assignments"].items()}
+            for eid, keys in ctx["target_additions"].items():
+                ctx["assignment_target"].update({k: eid for k in keys})
     if dry_run:
         result["added"] = int(plan.get("planned_additions") or 0)
         result["removed"] = int(plan.get("planned_removals") or 0)
@@ -1011,6 +1048,20 @@ def _apply_ruleset_mapping(
     source_by_key = ctx["source_by_key"]
     target_by_key = ctx["target_by_key"]
     assignments = ctx["assignments"]
+    if interactive is not None:
+        for target in _mapping_targets(mapping):
+            eid = str(target.get("endpoint_id") or "")
+            keys = ctx["target_additions"].get(eid) or []
+            if not keys or target.get("playlist_id") or not target.get("pending_create"):
+                continue
+            items = [_item_dict_from_sources(k, source_by_key, target_by_key, assignments) for k in keys]
+            playlist_id, seeded = _materialize_pending(providers or _providers(), cfg, mapping, target,
+                                                       [PlaylistItem.from_media(it) for it in items], materialize=True)
+            ctx["target_ctx"][eid]["playlist_id"] = playlist_id
+            ctx["target_additions"][eid] = [k for k in keys if k not in seeded]
+            ctx["target_keys"] = list(set(ctx["target_keys"]) | seeded)
+            result["added"] += len(seeded)
+            _record_events(_event_rows(mapping_id=mapping_id, ctx={"src": ctx["ruleset"]["id"], "dst": eid, "dst_inst": ""}, operation="add", items=[it for it in items if canonical_key(it) in seeded]))
     applied_ok = True
     for eid, keys in ctx["target_removals"].items():
         if not keys:
@@ -1196,10 +1247,11 @@ def run_mapping(
     dry_run: bool = False,
     providers: Mapping[str, Any] | None = None,
     emit: Callable[..., None] | None = None,
+    interactive: Any = None,
 ) -> dict[str, Any]:
     if mapping.get("ruleset_id"):
-        return _apply_ruleset_mapping(cfg, mapping, dry_run=dry_run, providers=providers, emit=emit)
-    plan, ctx = build_plan(cfg, mapping, providers=providers, materialize=not dry_run)
+        return _apply_ruleset_mapping(cfg, mapping, dry_run=dry_run, providers=providers, emit=emit, interactive=interactive)
+    plan, ctx = build_plan(cfg, mapping, providers=providers, materialize=not dry_run and interactive is None, review_pending=interactive is not None)
 
     dst_ops = ctx["dst_ops"]
     dst_cfg = ctx["dst_cfg"]
@@ -1253,6 +1305,18 @@ def run_mapping(
             result["warnings"].append("mass_delete_blocked")
         remove_items = guarded
 
+    if interactive is not None:
+        review_args = dict(source=ctx["src"], source_instance=ctx["src_inst"], scope=mapping_id,
+                           destination_label=ctx["dst_resource"].name + (" (create playlist)" if ctx["pending_review"] else ""))
+        plan.add_items = interactive.filter("playlists", ctx["dst"], dst_inst, "add", plan.add_items, **review_args)
+        remove_items = interactive.filter("playlists", ctx["dst"], dst_inst, "remove", remove_items, **review_args)
+        if plan.reorder_count:
+            reorder = {"type": "playlist", "title": "Reorder playlist", "ids": {"slug": dst_pl}, "target_order": plan.target_order,
+                       "current_order": ctx["dst_keys"]}
+            kept = interactive.filter("playlists", ctx["dst"], dst_inst, "update", [reorder], **review_args)
+            if not kept:
+                plan.reorder_count = 0
+
     applied_add_keys: set[str] = set(ctx.get("seeded_keys") or ())
     applied_remove_keys: set[str] = set()
     if applied_add_keys:
@@ -1269,9 +1333,22 @@ def run_mapping(
 
     from .id_map import canonical_key
 
+    if ctx.get("pending_review"):
+        if not plan.add_items:
+            return result
+        dst_pl, seeded = _materialize_pending(providers or _providers(), cfg, mapping, mapping.get("target") or {},
+                                              [PlaylistItem.from_media(it) for it in plan.add_items], materialize=True)
+        dst_cfg = build_provider_config_view(cfg, ctx["dst"], dst_inst)
+        applied_add_keys |= seeded
+        result["created"] = True
+        result["added"] = len(seeded)
+        ctx["dst_pl"] = dst_pl
+        _record_events(_event_rows(mapping_id=mapping_id, ctx=ctx, operation="add", items=[it for it in plan.add_items if canonical_key(it) in seeded]))
+        plan.add_items = [it for it in plan.add_items if canonical_key(it) not in seeded]
+
     if plan.add_items:
         add_res = dst_ops.add_playlist_items(dst_cfg, dst_pl, plan.add_items, instance=dst_inst) or {}
-        result["added"] = int(add_res.get("count") or 0)
+        result["added"] += int(add_res.get("count") or 0)
         result["unresolved"].extend(add_res.get("unresolved") or [])
         _merge_warnings(result, add_res)
         confirmed = set(add_res.get("confirmed_keys") or [])
@@ -1322,6 +1399,11 @@ def run_mapping(
         except Exception:
             present = set()
         target_order = [k for k in plan.target_order if not present or k in present]
+        if interactive is not None:
+            target_order = [k for k in plan.target_order if k in present]
+            ordered = set(target_order)
+            if present:
+                target_order.extend(k for k in dst_snap2.ordered_keys() if k not in ordered)
         if ctx["dst_resource"].can_reorder and target_order:
             ro = dst_ops.reorder_playlist_items(dst_cfg, dst_pl, target_order, instance=dst_inst) or {}
             result["reordered"] = int(ro.get("reordered") or ro.get("count") or 0)

--- a/providers/sync/_mod_common.py
+++ b/providers/sync/_mod_common.py
@@ -18,6 +18,16 @@ from cw_platform.run_control import raise_if_cancelled
 __VERSION__ = "0.2.1"
 MAX_RETRY_AFTER_SLEEP_S = 60.0
 CANCEL_SLEEP_SLICE_S = 0.25
+
+
+def observation_time(adapter: Any, fallback: Callable[[], str] | None = None) -> str:
+    config = getattr(adapter, "config", None) or getattr(adapter, "raw_cfg", None)
+    planned_at = config.get("_cw_interactive_planned_at") if isinstance(config, Mapping) else None
+    if isinstance(planned_at, (int, float)) and planned_at > 0:
+        return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(planned_at))
+    return fallback() if fallback is not None else ""
+
+
 __all__ = [
     "HitSession",
     "make_emitter",
@@ -481,6 +491,7 @@ class HitSession(requests.Session):
         self._emit = emit
         self._label = feature_label or (lambda m, u, kw: default_feature_label(provider, m, u, kw))
         self._emit_hits = bool(os.getenv("CW_API_HITS")) if emit_hits is None else bool(emit_hits)
+        self._on_request: Callable[[Mapping[str, Any]], object] | None = None
         self._rate_limiter = None
         self._rate_limiter_meta = None
         try:
@@ -553,6 +564,11 @@ class HitSession(requests.Session):
                     self._emit("api:hit", {"provider": self._provider, "feature": feature})
                 except Exception:
                     pass
+            if self._on_request is not None:
+                try:
+                    self._on_request({"event": "api:request", "provider": self._provider, "feature": feature})
+                except Exception:
+                    pass
 
 
 def build_session(
@@ -562,7 +578,11 @@ def build_session(
     feature_label: FeatureLabelFn | None = None,
     emit_hits: bool | None = None,
 ) -> HitSession:
-    return HitSession(provider, make_emitter(ctx), feature_label, emit_hits)
+    session = HitSession(provider, make_emitter(ctx), feature_label, emit_hits)
+    callback = getattr(getattr(ctx, "interactive", None), "on_progress", None)
+    if callable(callback):
+        session._on_request = callback
+    return session
 
 
 def parse_rate_limit(h: Mapping[str, Any]) -> dict[str, int | None]:

--- a/providers/sync/crosswatch/_ratings.py
+++ b/providers/sync/crosswatch/_ratings.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable, Mapping
 from typing import Any
 
 from cw_platform.id_map import canonical_key
+from providers.sync._mod_common import observation_time
 
 from ._common import (
     _atomic_write,
@@ -39,7 +40,7 @@ def _now_iso_z() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
 
-def _accepted(obj: Mapping[str, Any]) -> dict[str, Any]:
+def _accepted(obj: Mapping[str, Any], *, observed_at: str | None = None) -> dict[str, Any]:
     base = tracker_minimal(obj)
     out: dict[str, Any] = dict(base)
 
@@ -78,7 +79,7 @@ def _accepted(obj: Mapping[str, Any]) -> dict[str, Any]:
     if ra:
         out["rated_at"] = str(ra)
     elif obj.get("rating") is not None or obj.get("liked") is not None:
-        out["rated_at"] = _now_iso_z()
+        out["rated_at"] = observed_at or _now_iso_z()
     return out
 
 
@@ -90,6 +91,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
     if _pair_scope() is None:
         return {"ts": 0, "items": {}}
     root = _root(adapter)
+    observed_at = observation_time(adapter)
     path = _ratings_path(adapter)
     raw: Any | None
 
@@ -122,7 +124,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
             key = canonical_key(obj)
             if not key:
                 continue
-            items[key] = _accepted(obj)
+            items[key] = _accepted(obj, observed_at=observed_at)
         state = {"ts": 0, "items": items}
         if items and may_persist(adapter, path):
             _atomic_write(path, {"ts": int(time.time()), "items": items})
@@ -139,7 +141,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
                 ck = str(key) or canonical_key(value)
                 if not ck:
                     continue
-                items2[ck] = _accepted(value)
+                items2[ck] = _accepted(value, observed_at=observed_at)
             state = {"ts": ts, "items": items2}
             if items2 and may_persist(adapter, path):
                 _atomic_write(path, {"ts": ts or int(time.time()), "items": items2})
@@ -152,7 +154,7 @@ def _load_state(adapter: Any) -> dict[str, Any]:
             ck = str(key) or canonical_key(value)
             if not ck:
                 continue
-            items3[ck] = _accepted(value)
+            items3[ck] = _accepted(value, observed_at=observed_at)
         state = {"ts": 0, "items": items3}
         if items3 and may_persist(adapter, path):
             _atomic_write(path, {"ts": int(time.time()), "items": items3})

--- a/providers/sync/kodi/_common.py
+++ b/providers/sync/kodi/_common.py
@@ -773,11 +773,13 @@ def library_index(adapter: Any, feature: str = "") -> LibraryIndex:
 
 
 def feature_index(adapter: Any, feature: str) -> dict[str, dict[str, Any]]:
+    from providers.sync._mod_common import observation_time
+
     idx = library_index(adapter, feature)
     out: dict[str, dict[str, Any]] = {}
     prior_ratings = _load_kodi_ratings_baseline(adapter) if feature == "ratings" else {}
     prior_progress = _load_kodi_progress_baseline(adapter) if feature == "progress" else {}
-    now_iso = _utc_now_iso() if feature in {"ratings", "progress"} else ""
+    now_iso = observation_time(adapter, _utc_now_iso) if feature in {"ratings", "progress"} else ""
     for base in idx.items:
         item = dict(base)
         raw_obj = item.get("_kodi_raw")

--- a/providers/sync/plex/_history.py
+++ b/providers/sync/plex/_history.py
@@ -12,6 +12,7 @@ from typing import Any, Iterable, Mapping
 from pathlib import Path
 
 from cw_platform.id_map import canonical_key, minimal as id_minimal, ids_from, ids_from_guid
+from providers.sync._mod_common import observation_time
 
 from ._common import (
     _as_base_url,
@@ -1396,6 +1397,7 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
         max_seen = 0
         workers = plex_worker_count(adapter, "history_workers", "CW_PLEX_HISTORY_WORKERS", 12)
         include_marked = bool(_history_cfg_get(adapter, "include_marked_watched", True))
+        interactive_read = bool(observation_time(adapter))
 
         # Optional cursor debugging: show the rows that are considered "new" for this run.
         if eff_since is not None and str(os.environ.get("CW_PLEX_HISTORY_DEBUG_CURSOR", "")).strip().lower() in ("1", "true", "yes"):
@@ -1450,7 +1452,12 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
             if not explicit_user and cli_acct_id and aid is not None and int(aid) != int(cli_acct_id):
                 return None
 
-            meta = minimal_from_history_row(raw, token=None, allow_discover=False)
+            rk = str(getattr(raw, "ratingKey", None) or "").strip()
+            catalog_entry = cat.by_rk.get(rk) if interactive_read and scope_ok else None
+            if catalog_entry and (has_external_ids(catalog_entry.get("ids") or {}) or has_external_ids(catalog_entry.get("show_ids") or {})):
+                meta = _catalog_entry_to_minimal(catalog_entry)
+            else:
+                meta = minimal_from_history_row(raw, token=None, allow_discover=False)
             if not meta and fallback_guid:
                 meta = minimal_from_history_row(raw, token=None, allow_discover=True)
             if not meta:

--- a/providers/sync/simkl/_ratings.py
+++ b/providers/sync/simkl/_ratings.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping, cast
 
 from cw_platform.id_map import minimal as id_minimal
+from providers.sync._mod_common import observation_time
 
 from .._log import log as cw_log
 from ._common import (
@@ -550,7 +551,9 @@ def build_index(adapter: Any, *, since_iso: str | None = None) -> dict[str, dict
 
     out: dict[str, dict[str, Any]] = {}
     thaw: set[str] = set()
-    shadow_has_data = bool((_rshadow_load().get("items") or {}))
+    shadow_items = _rshadow_load().get("items") or {}
+    shadow_has_data = bool(shadow_items)
+    observed_at = observation_time(adapter)
 
     act_latest: str | None = None
 
@@ -702,10 +705,15 @@ def build_index(adapter: Any, *, since_iso: str | None = None) -> dict[str, dict
                         pass
                 continue
 
+            ts = _as_epoch(m.get("rated_at"))
+            if observed_at and not m.get("rated_at"):
+                previous_raw = shadow_items.get(k)
+                previous = previous_raw if isinstance(previous_raw, Mapping) else {}
+                previous_date = previous.get("rated_at") if _norm_rating(previous.get("rating")) == rt else None
+                m["rated_at"] = previous_date or observed_at
             out[k] = m
             thaw.add(k)
 
-            ts = _as_epoch(m.get("rated_at"))
             if ts is not None:
                 latest = max(latest or 0, ts)
 

--- a/services/interactive_sync.py
+++ b/services/interactive_sync.py
@@ -1,0 +1,225 @@
+# services/interactive_sync.py
+# CrossWatch - Interactive Sync Sessions
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+import json
+import logging
+import threading
+import time
+from typing import Any
+import uuid
+
+from cw_platform.orchestrator import Orchestrator
+from cw_platform.orchestrator._interactive import InteractivePlan, fingerprint
+from .interactive_sync_store import ReviewStore
+from .interactive_sync_progress import SyncProgress
+from .interactive_sync_report import SyncReport
+
+SESSION_TTL = 3600
+MAX_SESSIONS = 24
+LOCK = threading.RLock()
+SESSIONS: dict[str, Session] = {}
+LOG = logging.getLogger(__name__)
+
+
+@dataclass
+class Session:
+    pair_id: str
+    owner: str
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    status: str = "reading"
+    revision: int = 0
+    touched: float = field(default_factory=time.monotonic)
+    plan: InteractivePlan = field(default_factory=InteractivePlan)
+    config_hash: str = ""
+    mapping_version: str = ""
+    pair: dict[str, Any] = field(default_factory=dict)
+    message: str = "Reading providers and building the sync plan…"
+    summary: dict[str, Any] = field(default_factory=dict)
+    progress: SyncProgress = field(default_factory=SyncProgress)
+    planned_at: int = field(default_factory=lambda: int(time.time()))
+    store: ReviewStore | None = None
+    selection_version: int = 0
+    apply_review: dict[str, Any] | None = None
+    report: dict[str, Any] | None = None
+
+    def public(self):
+        return dict(ok=True, id=self.id, pair_id=self.pair_id, pair=self.pair, status=self.status,
+                    revision=self.revision, message=self.message, progress=self.progress.public(),
+                    counts=dict(self.store.counts) if self.store else dict(changes=0, conflicts=0, attention=0, selected=0),
+                    features=list(self.store.features) if self.store else [], selection_version=self.selection_version,
+                    notices=self.plan.notices[:100], summary=self.summary, apply_review=self.apply_review, report=self.report)
+
+    def close(self):
+        if self.store is not None:
+            self.store.close()
+            self.store = None
+
+
+def prune():
+    now = time.monotonic()
+    for sid, session in list(SESSIONS.items()):
+        if session.status not in ("reading", "applying") and now - session.touched > SESSION_TTL:
+            session.close()
+            del SESSIONS[sid]
+
+
+def mapping_version(cfg=None):
+    from cw_platform.config_base import CONFIG_BASE
+    from cw_platform.local_db.manual_policy import load_policy
+    from cw_platform.anime_mapping.overrides import load_overrides
+    from cw_platform.anime_mapping.storage import paths
+
+    dataset = paths(((cfg or {}).get("anime_mapping") or {}).get("release_tag", "v3"))["db"]
+    stamp = dataset.stat().st_mtime_ns if dataset.exists() else 0
+    return fingerprint([load_policy(CONFIG_BASE()), load_overrides(), stamp])
+
+
+def build(session: Session, cfg: dict[str, Any], choices: dict[str, str], *, store=None, selected=None) -> tuple[InteractivePlan, dict[str, Any]]:
+    plan = InteractivePlan(choices=dict(choices), planned_at=session.planned_at,
+                           record_rows=store is not None or selected is None, selected=selected or set(), copy_rows=store is None)
+    plan.on_progress = session.progress.event
+    if store is not None:
+        plan.rows = store.rows
+        plan.conflicts = store.conflicts
+    preview_cfg = deepcopy(cfg)
+    preview_cfg["_cw_readonly"] = True
+
+    def progress(line):
+        session.progress.event(line)
+        try:
+            event = json.loads(line)
+        except (ValueError, TypeError):
+            return
+        name = str(event.get("event") or "")
+        feature = str(event.get("feature") or "")
+        if name in {"feature:error", "feature:unsupported", "pair:skip", "run:pair:skip", "playlist:mapping:error", "writes:skipped"} or "mass_delete" in name or "massdelete" in name:
+            if len(plan.notices) < 100:
+                plan.notices.append(dict(event=name, feature=feature, reason=str(event.get("reason") or name),
+                                         provider=str(event.get("dst") or "")))
+
+    mgr = Orchestrator(preview_cfg, on_progress=progress, interactive=plan)
+    summary = mgr.run(dry_run=True, pair_scope_ids=[session.pair_id], write_state_json=False)
+    return plan, summary
+
+
+def refresh(session: Session, cfg: dict[str, Any], choices: dict[str, str], *, restart_progress=True):
+    if restart_progress:
+        session.progress.begin("preview")
+    version = mapping_version(cfg)
+    store = ReviewStore()
+    try:
+        plan, summary = build(session, cfg, choices, store=store)
+        _finish_review(session, cfg, version, plan, summary, store)
+    except Exception:
+        if session.store is not store:
+            store.close()
+        raise
+
+
+def _finish_review(session, cfg, version, plan, summary, store):
+    session.progress.set_stage("finalizing", "Preparing pages and preserving selections")
+    store.finish(session.store)
+    with LOCK:
+        session.close()
+        session.store = store
+        session.plan = plan
+        session.summary = summary
+        session.config_hash = fingerprint(cfg)
+        session.mapping_version = version
+        session.revision += 1
+        session.selection_version += 1
+        session.apply_review = None
+        session.report = None
+        session.status = "review" if summary.get("ok") else "error"
+        session.message = "Review the proposed changes. Nothing has been applied." if summary.get("ok") else "The plan could not be completed. Check provider status and refresh."
+        if summary.get("cancelled"):
+            session.message = "Reading cancelled. Refresh to build a new plan."
+        session.touched = time.monotonic()
+        session.progress.finish("cancelled" if summary.get("cancelled") else session.status, session.message)
+
+
+def _apply_needs_review(session, selected, reason):
+    with LOCK:
+        retained = len(selected & session.store.selected_ids()) if session.store else 0
+        session.apply_review = dict(requested=len(selected), retained=retained, needs_review=len(selected) - retained,
+                                    applied=0, reason=reason)
+        session.message = "Nothing was applied. " + reason + " Review the refreshed plan before applying again."
+        session.progress.finish(session.status, session.message)
+    LOG.info("interactive_sync_recheck session=%s requested=%s retained=%s needs_review=%s reason=%s",
+             session.id, len(selected), retained, len(selected) - retained, reason)
+
+
+def apply(session: Session, cfg: dict[str, Any], selected: set[str]):
+    from api import syncAPI
+
+    session.progress.begin("apply")
+    session.apply_review = None
+    session.report = None
+    report = SyncReport()
+    if fingerprint(cfg) != session.config_hash or mapping_version(cfg) != session.mapping_version:
+        refresh(session, cfg, session.plan.choices, restart_progress=False)
+        _apply_needs_review(session, selected, "Settings or mappings changed.")
+        return
+    version = mapping_version(cfg)
+    store = ReviewStore()
+    try:
+        plan, summary = build(session, cfg, session.plan.choices, selected=selected, store=store)
+        if not summary.get("ok") or not selected <= plan.seen:
+            if session.store is not None:
+                for detail in store.recheck_details(session.store, selected - plan.seen):
+                    LOG.info("interactive_sync_proposal_changed session=%s detail=%s", session.id, json.dumps(detail, sort_keys=True))
+            _finish_review(session, cfg, version, plan, summary, store)
+            reason = "The provider recheck could not be completed." if not summary.get("ok") else "Some selected proposals changed or are no longer available."
+            _apply_needs_review(session, selected, reason)
+            return
+    finally:
+        if session.store is not store:
+            store.close()
+    execution = InteractivePlan(preview=False, selected=selected, choices=dict(plan.choices), planned_at=session.planned_at, record_rows=False)
+    def progress(event):
+        session.progress.event(event)
+        report.event(event)
+
+    execution.on_progress = progress
+    execution.on_result = report.record
+    execution.valid = lambda: mapping_version(cfg) == session.mapping_version
+    execution.config_hash = fingerprint(cfg)
+    try:
+        syncAPI._run_pairs_thread("interactive-" + session.id, {"pair_id": session.pair_id}, interactive=execution)
+    finally:
+        with LOCK:
+            session.report = report.finish(session, execution, execution.result)
+    with LOCK:
+        result = execution.result
+        session.summary = dict(result or {})
+        session.summary["not_applied"] = len(selected - execution.seen)
+        session.status = "complete" if result is not None else "error"
+        session.message = "Selected changes processed. Review the results below." if result is not None else "Sync failed. Check Events before running again."
+        if session.summary.get("cancelled"):
+            session.message = "Sync cancelled. Changes already applied were kept."
+        session.touched = time.monotonic()
+        session.progress.finish("cancelled" if session.summary.get("cancelled") else session.status, session.message)
+
+
+def worker(session: Session, task, *args):
+    from api import syncAPI
+    from cw_platform.run_control import clear_cancel
+
+    try:
+        clear_cancel()
+        task(session, *args)
+    except Exception:
+        LOG.exception("interactive_sync_failed session=%s", session.id)
+        with LOCK:
+            session.status = "error"
+            session.message = "Interactive Sync failed. Check the server logs and refresh the plan."
+            session.progress.finish("error", session.message)
+    finally:
+        rt = syncAPI._rt()
+        with rt[2]:
+            if rt[1].get("SYNC") is threading.current_thread():
+                rt[1].pop("SYNC", None)

--- a/services/interactive_sync_progress.py
+++ b/services/interactive_sync_progress.py
@@ -1,0 +1,121 @@
+# services/interactive_sync_progress.py
+# CrossWatch - Interactive Sync Progress Tracking
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections import deque
+import json
+import threading
+import time
+from typing import Any, overload
+
+
+class SyncProgress:
+    def __init__(self):
+        self.lock = threading.RLock()
+        self.begin("preview")
+
+    def begin(self, operation):
+        with self.lock:
+            self.operation = operation
+            self.started = self.changed = self.activity = time.monotonic()
+            self.finished = None
+            self.stage = "connecting" if operation == "preview" else "verifying"
+            self.label = "Checking provider connections" if operation == "preview" else "Rechecking providers before applying"
+            self.provider = self.feature = ""
+            self.done, self.total, self.unit = 0, None, "items"
+            self.requests = 0
+            self.reads = {}
+            self.recent = deque(maxlen=6)
+            self.recent.append(dict(at=time.time(), text=self.label))
+
+    def set_stage(self, stage, label, *, provider="", feature="", done=0, total=None, unit="items"):
+        with self.lock:
+            identity = (stage, label, provider, feature)
+            if identity != (self.stage, self.label, self.provider, self.feature):
+                self.changed = time.monotonic()
+                self.recent.append(dict(at=time.time(), text=label))
+            self.stage, self.label, self.provider, self.feature = identity
+            self.done, self.total, self.unit = done, total, unit
+            self.activity = time.monotonic()
+
+    def finish(self, status, message):
+        with self.lock:
+            self.set_stage(status, message)
+            self.finished = time.monotonic()
+
+    @staticmethod
+    @overload
+    def number(value: Any, default: int = 0) -> int: ...
+
+    @staticmethod
+    @overload
+    def number(value: Any, default: None) -> int | None: ...
+
+    @staticmethod
+    def number(value: Any, default: int | None = 0) -> int | None:
+        try:
+            return max(0, int(value))
+        except (ValueError, TypeError, OverflowError):
+            return default
+
+    def event(self, event):
+        if isinstance(event, str):
+            try:
+                event = json.loads(event)
+            except (ValueError, TypeError):
+                return
+        if not isinstance(event, dict):
+            return
+        name = str(event.get("event") or "")
+        feature = str(event.get("feature") or "")[:32]
+        provider = str(event.get("provider") or event.get("dst") or "")[:80]
+        done = self.number(event.get("done"))
+        total = self.number(event.get("total"), None)
+        subject = " ".join(x for x in (provider, feature) if x) or "provider data"
+        with self.lock:
+            if self.finished is not None:
+                return
+            if name == "api:request":
+                self.requests += 1
+                self.activity = time.monotonic()
+                return
+            if name == "health":
+                self.set_stage("connecting" if self.operation == "preview" else "verifying", f"Checked {provider} connection", provider=provider)
+            elif name in ("snapshot:start", "snapshot:progress"):
+                stage = "reading" if self.operation == "preview" else "verifying"
+                self.set_stage(stage, f"{'Reading' if self.operation == 'preview' else 'Rechecking'} {subject}", provider=provider, feature=feature, done=done, total=total, unit="items read")
+                self.reads[(provider, feature)] = max(self.reads.get((provider, feature), 0), done)
+            elif name == "snapshot:done":
+                self.reads[(provider, feature)] = self.number(event.get("count"))
+                self.set_stage("planning" if self.operation == "preview" else "verifying", f"Calculating {feature or 'sync'} changes", feature=feature)
+            elif name == "review:plan":
+                stage = "planning" if self.operation == "preview" else "verifying"
+                self.set_stage(stage, f"{'Building' if self.operation == 'preview' else 'Verifying'} {feature} changes for {provider}", provider=provider, feature=feature, done=done, total=total, unit="changes checked")
+            elif name in ("apply:add:start", "apply:update:start", "apply:remove:start"):
+                operation = name.split(":")[1]
+                self.set_stage("applying", f"{'Removing from' if operation == 'remove' else 'Updating' if operation == 'update' else 'Adding to'} {subject}", provider=provider, feature=feature, total=self.number(event.get("count")), unit="changes processed")
+            elif name in ("apply:add:progress", "apply:update:progress", "apply:remove:progress", "apply:add:done", "apply:update:done", "apply:remove:done"):
+                if name.endswith(":done"):
+                    done = self.number(event.get("attempted"), self.total or self.number(event.get("count")))
+                    total = self.total
+                self.set_stage("applying", self.label if self.stage == "applying" else f"Processing {subject}", provider=provider, feature=feature, done=done, total=total, unit="changes processed")
+            elif name in ("rate:slow", "rate:low", "rate_limit_retry", "http_retry"):
+                self.recent.append(dict(at=time.time(), text=f"{provider or 'Provider'} is rate limiting or retrying requests"))
+                self.activity = time.monotonic()
+            elif name in ("feature:error", "feature:unsupported", "writes:skipped", "mass_delete:blocked", "snapshot:suspect", "playlist:mapping:error"):
+                messages = {"feature:error": "Provider reported an error", "feature:unsupported": "Feature unavailable", "writes:skipped": "Provider writes skipped", "mass_delete:blocked": "Mass delete protection activated", "snapshot:suspect": "Provider data needs verification", "playlist:mapping:error": "Playlist mapping reported an error"}
+                self.recent.append(dict(at=time.time(), text=f"{subject}: {messages[name]}"))
+                self.activity = time.monotonic()
+            elif name == "run:done":
+                self.set_stage("finalizing", "Saving sync results")
+
+    def public(self):
+        with self.lock:
+            now = self.finished or time.monotonic()
+            percent = min(100, round(100 * self.done / self.total, 1)) if self.total else None
+            return dict(operation=self.operation, stage=self.stage, label=self.label, provider=self.provider,
+                        feature=self.feature, done=self.done, total=self.total, unit=self.unit, percent=percent,
+                        elapsed_seconds=int(now - self.started), stage_seconds=int(now - self.changed),
+                        quiet_seconds=int(now - self.activity), running=self.finished is None,
+                        items_read=sum(self.reads.values()), requests=self.requests, recent=list(self.recent))

--- a/services/interactive_sync_report.py
+++ b/services/interactive_sync_report.py
@@ -1,0 +1,108 @@
+# services/interactive_sync_report.py
+# CrossWatch - Interactive Sync Completion Reports
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import time
+
+
+COUNTERS = ("added", "updated", "removed", "skipped", "unresolved", "blocked", "errors")
+
+
+def count(value):
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def timestamp(value):
+    return datetime.fromtimestamp(value, timezone.utc).isoformat(timespec="seconds")
+
+
+class SyncReport:
+    def __init__(self):
+        self.started = time.time()
+        self.features = []
+        self.notices = {}
+        self.notice_overflow = 0
+        self.cancelled = False
+
+    def event(self, value):
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except (ValueError, TypeError):
+                return
+        if not isinstance(value, dict):
+            return
+        name = str(value.get("event") or "")
+        if name in ("feature:cancelled", "run:cancelled"):
+            self.cancelled = True
+        reasons = {
+            "feature:error": "A feature could not finish. Check Events for the provider error.",
+            "feature:unsupported": "A provider does not support this feature or is unavailable.",
+            "playlist:mapping:error": "A playlist mapping could not finish. Check Events for details.",
+            "writes:skipped": "Writes were skipped by the sync engine.",
+            "pair:skip": "The pair was skipped by the sync engine.",
+            "run:pair:skip": "The pair was skipped by the sync engine.",
+        }
+        reason = reasons.get(name)
+        if "mass_delete" in name or "massdelete" in name:
+            reason = "Mass delete protection was triggered. Check Events for details."
+        if not reason:
+            return
+        feature = str(value.get("feature") or "")[:32]
+        provider = str(value.get("dst") or value.get("provider") or "")[:80]
+        key = (name, feature, provider)
+        if key in self.notices:
+            self.notices[key]["occurrences"] += 1
+        elif len(self.notices) < 100:
+            self.notices[key] = dict(event=name, feature=feature, provider=provider, reason=reason, occurrences=1)
+        else:
+            self.notice_overflow += 1
+
+    def record(self, feature, src, dst, src_instance, dst_instance, mode, result):
+        totals = {key: count(result.get(key)) for key in COUNTERS}
+        destinations = []
+        if mode == "two-way" and feature != "playlists":
+            for side, provider, instance in (("A", src, src_instance), ("B", dst, dst_instance)):
+                row = dict(provider=provider, instance=instance,
+                           added=count(result.get(f"adds_to_{side}")),
+                           updated=count(result.get(f"upd_to_{side}")),
+                           removed=count(result.get(f"rem_from_{side}")),
+                           unresolved=count(result.get(f"unresolved_to_{side}")))
+                for key in ("skipped", "errors"):
+                    row[key] = sum(count((result.get(f"res{side}_{op}") or {}).get(key)) for op in ("add", "update", "remove"))
+                destinations.append(row)
+            for key in ("added", "updated", "removed"):
+                totals[key] = sum(row[key] for row in destinations)
+            totals["unresolved"] = count(result.get("unresolved", sum(row["unresolved"] for row in destinations)))
+            for key in ("skipped", "errors"):
+                totals[key] += count(result.get(f"{key}_to_A")) + count(result.get(f"{key}_to_B"))
+        elif feature != "playlists":
+            destinations.append(dict(provider=dst, instance=dst_instance, **totals))
+        self.features.append(dict(feature=feature, **totals, destinations=destinations))
+
+    def finish(self, session, execution, result):
+        totals = {key: count(result.get(key)) if result is not None else sum(row[key] for row in self.features) for key in COUNTERS}
+        requested = len(execution.selected)
+        not_reached = len(execution.selected - execution.seen)
+        cancelled = self.cancelled or bool((result or {}).get("cancelled"))
+        outcome = "cancelled" if cancelled else "incomplete" if result is None or not result.get("ok", True) else "attention" if not_reached or any(totals[k] for k in ("errors", "unresolved", "blocked")) or self.notices else "success"
+        counts = session.store.counts if session.store else {}
+        return dict(version=1, run_id="interactive-" + session.id, pair=dict(session.pair),
+                    started_at=timestamp(self.started), finished_at=timestamp(time.time()),
+                    duration_seconds=session.progress.public().get("elapsed_seconds", 0),
+                    outcome=outcome, totals=totals, requested=requested,
+                    proposed=count(counts.get("changes")),
+                    not_selected=max(0, count(counts.get("changes")) - requested),
+                    reached_execution=requested - not_reached, not_reached=not_reached,
+                    conflicts_reviewed=count(counts.get("conflicts")),
+                    features=self.features, notices=list(self.notices.values()), notice_overflow=self.notice_overflow,
+                    review_notices=session.plan.notices[:100],
+                    requests=session.progress.public().get("requests", 0),
+                    accounting_note="Totals use the existing sync engine's provider results. Skips can include items already present. Errors and protection counts can overlap or describe a whole batch; they are not an item-by-item receipt. Playlist totals count playlist contents and ordering operations.",
+                    incomplete_note="Some writes may have completed before the interruption without final counts. Check Events before starting another sync." if outcome in ("cancelled", "incomplete") else "")

--- a/services/interactive_sync_store.py
+++ b/services/interactive_sync_store.py
@@ -1,0 +1,206 @@
+# services/interactive_sync_store.py
+# CrossWatch - Paged Interactive Sync Review Storage
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+import json
+import os
+from pathlib import Path
+import sqlite3
+import tempfile
+import threading
+import weakref
+
+
+class ReviewRows(MutableMapping):
+    def __init__(self, store, kind):
+        self.store = weakref.proxy(store)
+        self.kind = kind
+
+    def __getitem__(self, key):
+        with self.store.lock:
+            row = self.store.db.execute("SELECT payload FROM review WHERE id=? AND kind=?", (key, self.kind)).fetchone()
+        if row is None:
+            raise KeyError(key)
+        return json.loads(row[0])
+
+    def __setitem__(self, key, value):
+        self.store.put(key, value, self.kind)
+
+    def __delitem__(self, key):
+        with self.store.lock:
+            if not self.store.db.execute("DELETE FROM review WHERE id=? AND kind=?", (key, self.kind)).rowcount:
+                raise KeyError(key)
+
+    def __iter__(self):
+        with self.store.lock:
+            cursor = self.store.db.execute("SELECT id FROM review WHERE kind=? ORDER BY seq", (self.kind,))
+            while batch := cursor.fetchmany(256):
+                yield from (row[0] for row in batch)
+
+    def __len__(self):
+        with self.store.lock:
+            return self.store.db.execute("SELECT COUNT(*) FROM review WHERE kind=?", (self.kind,)).fetchone()[0]
+
+
+class ReviewStore:
+    def __init__(self):
+        descriptor, path = tempfile.mkstemp(prefix="cw-sync-review-", suffix=".sqlite")
+        os.close(descriptor)
+        self.path = Path(path)
+        self.lock = threading.RLock()
+        self.db = sqlite3.connect(self.path, check_same_thread=False)
+        self.cleanup = weakref.finalize(self, self._cleanup, self.db, self.path)
+        self.db.execute("PRAGMA journal_mode=OFF")
+        self.db.execute("PRAGMA synchronous=OFF")
+        self.db.execute("PRAGMA cache_size=-2048")
+        self.db.execute("PRAGMA temp_store=FILE")
+        self.db.execute("CREATE TABLE review (seq INTEGER PRIMARY KEY, id TEXT UNIQUE NOT NULL, kind TEXT NOT NULL, feature TEXT NOT NULL, result TEXT NOT NULL, selectable INTEGER NOT NULL, selected INTEGER NOT NULL, search TEXT NOT NULL, payload TEXT NOT NULL)")
+        self.rows = ReviewRows(self, "change")
+        self.conflicts = ReviewRows(self, "conflict")
+        self.counts = dict(changes=0, conflicts=0, attention=0, selected=0)
+        self.features = []
+        self.selectable_count = 0
+
+    def put(self, key, value, kind):
+        result = "conflict" if kind == "conflict" else value["result"]
+        item = value.get("item") or value.get("left") or {}
+        search = " ".join(str(item.get(k) or "") for k in ("title", "series_title", "year", "season", "episode"))
+        search += " " + str(value.get("key") or "") + " " + json.dumps(item.get("ids") or {}, ensure_ascii=False)
+        selectable = bool(value.get("selectable")) and kind == "change"
+        payload = json.dumps(value, ensure_ascii=False, separators=(",", ":"), default=str)
+        with self.lock:
+            self.db.execute("INSERT INTO review(id,kind,feature,result,selectable,selected,search,payload) VALUES(?,?,?,?,?,?,?,?) ON CONFLICT(id) DO UPDATE SET payload=excluded.payload,search=excluded.search",
+                            (key, kind, value["feature"], result, selectable, selectable, search.casefold(), payload))
+
+    def finish(self, previous=None):
+        with self.lock:
+            self.db.commit()
+            if previous is not None:
+                with previous.lock:
+                    previous.db.commit()
+                self.db.execute("ATTACH DATABASE ? AS previous", (str(previous.path),))
+                try:
+                    self.db.execute("UPDATE review SET selected=selectable AND EXISTS(SELECT 1 FROM previous.review old WHERE old.id=review.id AND old.selected=1)")
+                    self.db.commit()
+                finally:
+                    self.db.execute("DETACH DATABASE previous")
+            self.db.execute("CREATE INDEX IF NOT EXISTS review_filter ON review(feature,result,seq)")
+            self.db.execute("CREATE INDEX IF NOT EXISTS review_result ON review(result,seq)")
+            self.db.execute("CREATE INDEX IF NOT EXISTS review_selection ON review(selected,id)")
+            self.db.commit()
+            groups = self.db.execute("SELECT kind,result,COUNT(*),SUM(selected),SUM(selectable) FROM review GROUP BY kind,result").fetchall()
+            self.counts = dict(changes=0, conflicts=0, attention=0, selected=0)
+            self.selectable_count = 0
+            for kind, result, count, selected, selectable in groups:
+                self.counts["conflicts" if kind == "conflict" else "changes"] += count
+                self.counts["selected"] += selected
+                self.selectable_count += selectable
+                if result in ("unresolved", "blocked"):
+                    self.counts["attention"] += count
+            self.features = [r[0] for r in self.db.execute("SELECT DISTINCT feature FROM review ORDER BY feature")]
+
+    @staticmethod
+    def where(feature="", result="", q=""):
+        clauses, args = ["1=1"], []
+        for name, value in (("feature", feature), ("result", result)):
+            if value:
+                clauses.append(f"{name}=?")
+                args.append(value)
+        if q:
+            clauses.append("instr(search,?)>0")
+            args.append(q.casefold())
+        return " AND ".join(clauses), args
+
+    def page(self, *, offset=0, limit=75, feature="", result="", q=""):
+        where, args = self.where(feature, result, q)
+        with self.lock:
+            if not args:
+                total = self.counts["changes"] + self.counts["conflicts"]
+                selectable, selected = self.selectable_count, self.counts["selected"]
+            else:
+                total, selectable, selected = self.db.execute(f"SELECT COUNT(*),COALESCE(SUM(selectable),0),COALESCE(SUM(selected),0) FROM review WHERE {where}", args).fetchone()
+            offset = min(offset, max(0, ((total - 1) // limit) * limit))
+            rows = self.db.execute(f"SELECT payload,kind,selected FROM review WHERE {where} ORDER BY seq LIMIT ? OFFSET ?", (*args, limit, offset)).fetchall()
+        items = []
+        for payload, kind, chosen in rows:
+            row = json.loads(payload)
+            row["selected"] = bool(chosen)
+            if kind == "conflict":
+                row.update(result="conflict", item=row["left"], selectable=False)
+            if row["feature"] == "playlists":
+                for field in ("item", "before", "left", "right"):
+                    if isinstance(row.get(field), dict):
+                        for order in ("target_order", "current_order"):
+                            values = row[field].pop(order, None)
+                            if values is not None:
+                                row[field][order + "_count"] = len(values)
+            items.append(row)
+        return dict(items=items, total=total, selectable=selectable, selected=selected, offset=offset, limit=limit)
+
+    def select(self, selected, *, ids=None, feature="", result="", q=""):
+        where, args = self.where(feature, result, q)
+        with self.lock:
+            if ids is not None:
+                placeholders = ",".join("?" for _ in ids)
+                found = self.db.execute(f"SELECT COUNT(*) FROM review WHERE selectable=1 AND id IN ({placeholders})", ids).fetchone()[0]
+                if found != len(set(ids)):
+                    raise ValueError("Select valid changes from this review")
+                where += f" AND id IN ({placeholders})"
+                args.extend(ids)
+            changed = self.db.execute(f"UPDATE review SET selected=? WHERE selectable=1 AND selected!=? AND {where}", (selected, selected, *args)).rowcount
+            self.db.commit()
+            self.counts["selected"] += changed if selected else -changed
+
+    def selected_ids(self):
+        with self.lock:
+            return {r[0] for r in self.db.execute("SELECT id FROM review WHERE selected=1")}
+
+    def recheck_details(self, previous, missing, *, limit=5):
+        from itertools import islice
+
+        details = []
+        identity = ("key", "source", "source_instance", "provider", "instance", "scope", "operation")
+        with self.lock:
+            for rid in islice(iter(missing), limit):
+                old = previous.rows.get(rid)
+                if old is None:
+                    continue
+                where = " AND ".join(f"json_extract(payload,'$.{field}') IS ?" for field in identity)
+                rows = self.db.execute(f"SELECT payload FROM review WHERE kind='change' AND feature=? AND {where} LIMIT 2",
+                                       (old["feature"], *(old.get(field) for field in identity))).fetchall()
+                entry = dict(key=old["key"], feature=old["feature"], provider=old["provider"], instance=old["instance"],
+                             operation=old["operation"], reason="unavailable" if not rows else "ambiguous", fields=[])
+                if len(rows) == 1:
+                    current = json.loads(rows[0][0])
+                    changed = []
+
+                    def compare(left, right, path):
+                        if len(changed) >= 20:
+                            return
+                        if isinstance(left, dict) and isinstance(right, dict):
+                            for field in sorted(left.keys() | right.keys()):
+                                child = f"{path}.{field}" if path else field
+                                if field not in left or field not in right:
+                                    if len(changed) < 20:
+                                        changed.append(child)
+                                else:
+                                    compare(left[field], right[field], child)
+                        elif json.dumps(left, sort_keys=True) != json.dumps(right, sort_keys=True):
+                            changed.append(path)
+
+                    for field in ("item", "before", "destination_label", "selectable", "reason"):
+                        compare(old.get(field), current.get(field), field)
+                    entry.update(reason="changed", fields=changed)
+                details.append(entry)
+        return details
+
+    def close(self):
+        with self.lock:
+            self.cleanup()
+
+    @staticmethod
+    def _cleanup(db, path):
+        db.close()
+        path.unlink(missing_ok=True)

--- a/tests/test_history_baseline_native.py
+++ b/tests/test_history_baseline_native.py
@@ -398,7 +398,7 @@ def test_manual_history_date_change_updates_upsert_destination(
     dst_event = {**_simkl_event(), "watched_at": old_watched}
     key = _event_key(src_event)
 
-    def manual_policy(_state, provider, _feature):
+    def manual_policy(_state, provider, _feature, _instance="default"):
         if provider == "SRC":
             return {key: manual_event}, set()
         return {}, set()

--- a/tests/test_interactive_sync.py
+++ b/tests/test_interactive_sync.py
@@ -1,0 +1,606 @@
+# tests/test_interactive_sync.py
+# CrossWatch - Interactive Sync Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from cw_platform.orchestrator import Orchestrator
+from cw_platform.orchestrator._interactive import InteractivePlan
+from test_orchestrator_dry_run_no_side_effects import FakeOps, _cfg, _install
+from test_playlists_pending_create import world
+
+
+def item(number, **extra):
+    return dict(type="movie", title=f"Movie {number}", ids={"imdb": f"tt{number:07}"}, **extra)
+
+
+def setup_ops(config_base, monkeypatch, source=None, target=None):
+    from cw_platform.id_map import canonical_key
+
+    src = FakeOps("SRC", {canonical_key(x): x for x in (source or [])})
+    dst = FakeOps("DST", {canonical_key(x): x for x in (target or [])})
+    _install(monkeypatch, src, dst, config_base / ".cw_state")
+    return src, dst
+
+
+def run(cfg, plan):
+    return Orchestrator(cfg, interactive=plan).run(dry_run=plan.preview, pair_scope_ids=["p1"], write_state_json=not plan.preview)
+
+
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_preview_never_calls_provider_writes(config_base, monkeypatch, mode):
+    src, dst = setup_ops(config_base, monkeypatch, [item(1), item(2)])
+    cfg = _cfg(False)
+    cfg["pairs"][0]["mode"] = mode
+    plan = InteractivePlan()
+    result = run(cfg, plan)
+    assert result["ok"]
+    assert len(plan.rows) == 2
+    assert not src.add_calls and not dst.add_calls
+    assert not dst.index
+
+
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_only_selected_items_reach_provider(config_base, monkeypatch, mode):
+    src, dst = setup_ops(config_base, monkeypatch, [item(1), item(2)])
+    cfg = _cfg(False)
+    cfg["pairs"][0]["mode"] = mode
+    plan = InteractivePlan()
+    run(cfg, plan)
+    rid = next(rid for rid, row in plan.rows.items() if row["item"]["title"] == "Movie 2")
+    run(cfg, InteractivePlan(preview=False, selected={rid}))
+    assert len(dst.add_calls) == 1
+    assert [x["title"] for x in dst.add_calls[0]] == ["Movie 2"]
+
+
+def test_changed_payload_is_not_applied(config_base, monkeypatch):
+    src, dst = setup_ops(config_base, monkeypatch, [item(1)])
+    plan = InteractivePlan()
+    run(_cfg(False), plan)
+    next(iter(src.index.values()))["title"] = "Changed"
+    run(_cfg(False), InteractivePlan(preview=False, selected=set(plan.rows)))
+    assert not dst.add_calls
+
+
+def test_selection_does_not_bypass_disabled_adds(config_base, monkeypatch):
+    src, dst = setup_ops(config_base, monkeypatch, [item(1)])
+    cfg = _cfg(False)
+    plan = InteractivePlan()
+    run(cfg, plan)
+    cfg["pairs"][0]["features"]["watchlist"]["add"] = False
+    run(cfg, InteractivePlan(preview=False, selected=set(plan.rows)))
+    assert not dst.add_calls
+
+
+def test_mass_delete_protection_precedes_review(config_base, monkeypatch):
+    setup_ops(config_base, monkeypatch, [item(1)], [item(1), item(2), item(3)])
+    cfg = _cfg(False)
+    cfg["sync"].update(enable_remove=True, allow_mass_delete=False)
+    cfg["pairs"][0]["features"]["watchlist"].update(remove=True, remove_mode="mirror")
+    plan = InteractivePlan()
+    run(cfg, plan)
+    assert not any(row["operation"] == "remove" for row in plan.rows.values())
+
+
+def test_editor_mapping_recalculates_plan(config_base, monkeypatch):
+    from api import editorAPI
+
+    setup_ops(config_base, monkeypatch, [item(1)])
+    monkeypatch.setattr(editorAPI, "_STATE_BASE", config_base)
+    cfg = _cfg(False)
+    original = InteractivePlan()
+    run(cfg, original)
+    old_key = next(iter(original.rows.values()))["key"]
+    corrected = item(2)
+    editorAPI._save_policy_manual("watchlist", "SRC", {"imdb:tt0000002": corrected}, [old_key], merge=True)
+    refreshed = InteractivePlan()
+    run(cfg, refreshed)
+    assert {row["key"] for row in refreshed.rows.values()} == {"imdb:tt0000002"}
+    assert not set(original.rows) & set(refreshed.rows)
+
+
+def test_fingerprint_includes_destination_state():
+    plan = InteractivePlan()
+    plan.filter("ratings", "DST", "default", "update", [item(1, rating=8)], before={"imdb:tt0000001": item(1, rating=3)})
+    execution = InteractivePlan(preview=False, selected=set(plan.rows))
+    assert not execution.filter("ratings", "DST", "default", "update", [item(1, rating=8)], before={"imdb:tt0000001": item(1, rating=6)})
+
+
+def test_conflict_choice_is_bound_to_values():
+    plan = InteractivePlan()
+    assert plan.conflict("ratings", "key", "A", "B", item(1, rating=4), item(1, rating=9), "A") == "A"
+    cid = next(iter(plan.conflicts))
+    changed = InteractivePlan(choices={cid: "B"})
+    assert changed.conflict("ratings", "key", "A", "B", item(1, rating=4), item(1, rating=9), "A") == "B"
+    assert changed.conflict("ratings", "key", "A", "B", item(1, rating=5), item(1, rating=9), "A") == "A"
+
+
+def test_instance_mapping_is_loaded_only_for_its_account(config_base, monkeypatch):
+    from api import editorAPI
+    from cw_platform.orchestrator._state_store import StateStore
+    from cw_platform.orchestrator._pairs_utils import manual_policy
+
+    monkeypatch.setattr(editorAPI, "_STATE_BASE", config_base)
+    editorAPI._save_policy_manual("watchlist", "SRC", {"imdb:tt0000002": item(2)}, ["imdb:tt0000001"], "second", merge=True)
+    state = StateStore(config_base).load_state_features({"watchlist"})
+    assert manual_policy(state, "SRC", "watchlist", "default") == ({}, set())
+    adds, blocks = manual_policy(state, "SRC", "watchlist", "second")
+    assert set(adds) == {"imdb:tt0000002"}
+    assert blocks == {"imdb:tt0000001"}
+    editorAPI._save_policy_manual("watchlist", "SRC", {"imdb:tt0000003": item(3)}, [], "second", merge=True)
+    state = StateStore(config_base).load_state_features({"watchlist"})
+    assert set(manual_policy(state, "SRC", "watchlist", "second")[0]) == {"imdb:tt0000002", "imdb:tt0000003"}
+
+
+def test_preview_does_not_record_observed_deletions(config_base, monkeypatch):
+    from cw_platform.orchestrator._state_store import StateStore
+
+    src, dst = setup_ops(config_base, monkeypatch, [item(1), item(2)], [item(1), item(2)])
+    cfg = _cfg(False)
+    cfg["pairs"][0]["mode"] = "two-way"
+    cfg["sync"].update(enable_remove=True, include_observed_deletes=True)
+    cfg["pairs"][0]["features"]["watchlist"]["remove"] = True
+    run(cfg, InteractivePlan(preview=False))
+    src.index.pop("imdb:tt0000002")
+    store = StateStore(config_base)
+    before = deepcopy(store.load_tomb())
+    before_state = deepcopy(store.load_state())
+    run(cfg, InteractivePlan())
+    assert store.load_tomb() == before
+    assert store.load_state() == before_state
+
+
+@pytest.mark.parametrize("age_days,expected_operation", [(31, "add"), (30, "add"), (1, "remove")])
+def test_two_way_preview_matches_normal_plan_for_tombstone_expiry(config_base, monkeypatch, age_days, expected_operation):
+    import json
+    import time
+    from cw_platform.orchestrator._state_store import StateStore
+
+    setup_ops(config_base, monkeypatch, [item(1), item(2)], [item(1)])
+    cfg = _cfg(False)
+    cfg["pairs"][0]["mode"] = "two-way"
+    cfg["sync"].update(enable_remove=True, tombstone_ttl_days=30)
+    cfg["pairs"][0]["features"]["watchlist"]["remove"] = True
+    run(cfg, InteractivePlan(preview=False))
+    store = StateStore(config_base)
+    tomb = {"keys": {"watchlist:DST-SRC|imdb:tt0000002": int(time.time()) - age_days * 86400}}
+    store.save_tomb(tomb)
+    before_tomb = deepcopy(store.load_tomb())
+    plan = InteractivePlan()
+    run(cfg, plan)
+    assert store.load_tomb() == before_tomb
+    events = []
+    Orchestrator(cfg, on_progress=lambda line: events.append(json.loads(line)) if line.startswith("{") else None).run(dry_run=True, pair_scope_ids=["p1"], write_state_json=False)
+    normal = next(event for event in events if event.get("event") == "two:plan")
+    assert normal["add_to_B"] == int(expected_operation == "add")
+    assert normal["rem_from_A"] == int(expected_operation == "remove")
+    assert [(row["operation"], row["provider"]) for row in plan.rows.values()] == [(expected_operation, "DST" if expected_operation == "add" else "SRC")]
+
+
+@pytest.mark.parametrize("new_on", ["SRC", "DST"])
+def test_two_way_shared_watchlist_with_one_new_item_only_proposes_one_add(config_base, monkeypatch, new_on):
+    import json
+    from cw_platform.id_map import canonical_key
+
+    common = [{**item(n), "ids": {"tmdb": str(1000 + n), "imdb": f"tt{n:07}"}} for n in range(1, 7)]
+    target = [{**item(n), "ids": {"tmdb": str(1000 + n)}} for n in range(1, 7)]
+    src, dst = setup_ops(config_base, monkeypatch, common, target)
+    cfg = _cfg(False)
+    cfg["pairs"][0]["mode"] = "two-way"
+    cfg["pairs"][0]["features"]["watchlist"]["remove"] = True
+    cfg["sync"].update(enable_remove=True, include_observed_deletes=True)
+    run(cfg, InteractivePlan(preview=False))
+    added = {**item(7), "ids": {"tmdb": "1007"}}
+    (src if new_on == "SRC" else dst).index[canonical_key(added)] = added
+    plan = InteractivePlan()
+    run(cfg, plan)
+    expected_target = "DST" if new_on == "SRC" else "SRC"
+    assert [(row["operation"], row["provider"], row["key"]) for row in plan.rows.values()] == [("add", expected_target, "tmdb:1007")]
+    events = []
+    Orchestrator(cfg, on_progress=lambda line: events.append(json.loads(line)) if line.startswith("{") else None).run(dry_run=True, pair_scope_ids=["p1"], write_state_json=False)
+    normal = next(event for event in events if event.get("event") == "two:plan")
+    assert normal["rem_from_A"] == normal["rem_from_B"] == 0
+    assert normal["add_to_A"] + normal["add_to_B"] == 1
+
+
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_deselected_observed_remove_can_be_reviewed_again(config_base, monkeypatch, mode):
+    src, dst = setup_ops(config_base, monkeypatch, [item(1), item(2)], [item(1), item(2)])
+    cfg = _cfg(False)
+    cfg["pairs"][0]["mode"] = mode
+    cfg["sync"].update(enable_remove=True, include_observed_deletes=True)
+    cfg["pairs"][0]["features"]["watchlist"]["remove"] = True
+    run(cfg, InteractivePlan(preview=False))
+    src.index.pop("imdb:tt0000002")
+    plan = InteractivePlan()
+    run(cfg, plan)
+    assert any(r["operation"] == "remove" for r in plan.rows.values())
+    run(cfg, InteractivePlan(preview=False))
+    again = InteractivePlan()
+    run(cfg, again)
+    assert any(r["operation"] == "remove" for r in again.rows.values())
+
+
+def test_playlists_only_apply_selected_membership(config_base):
+    from cw_platform import playlists_runner as runner
+    from test_playlists_runner import _providers, _mapping, _cfg as playlist_cfg, _movie
+
+    providers = _providers({"L1": {"items": [_movie(1), _movie(2)]}}, {"T1": {"items": [_movie(3)]}})
+    mapping = _mapping(membership="mirror", order="preserve")
+    plan = InteractivePlan()
+    runner.run_mapping(playlist_cfg(), mapping, dry_run=True, providers=providers, interactive=plan)
+    assert not providers["PLEX"].calls
+    selected = {rid for rid, row in plan.rows.items() if row["operation"] == "add" and row["key"] == "tmdb:2"}
+    assert selected
+    runner.run_mapping(playlist_cfg(), mapping, providers=providers, interactive=InteractivePlan(preview=False, selected=selected))
+    assert providers["PLEX"].calls == [("add", "T1", ["tmdb:2"])]
+
+
+def test_ruleset_selection_preserves_assignment_bookkeeping(config_base):
+    from cw_platform import playlists_runner as runner
+    from test_playlists_rulesets import providers, cfg, mapping, movie
+
+    ops = providers([movie(1), movie(2), movie(3)])
+    plan = InteractivePlan()
+    runner.run_mapping(cfg(), mapping(), providers=ops, dry_run=True, interactive=plan)
+    selected = {rid for rid, row in plan.rows.items() if row["key"] == "tmdb:2"}
+    assert selected
+    runner.run_mapping(cfg(), mapping(), providers=ops, interactive=InteractivePlan(preview=False, selected=selected))
+    assert ops["TRAKT"].calls == [("add", "T1", ["tmdb:2"])]
+    entry = runner._state_entry(mapping())
+    assert set(entry["assignments"]) == {"tmdb:2"}
+    again = InteractivePlan()
+    runner.run_mapping(cfg(), mapping(), providers=ops, dry_run=True, interactive=again)
+    assert {row["key"] for row in again.rows.values()} == {"tmdb:1", "tmdb:3"}
+
+
+def test_mapping_change_at_execution_boundary_excludes_writes():
+    plan = InteractivePlan()
+    plan.filter("watchlist", "DST", "default", "add", [item(1)])
+    execution = InteractivePlan(preview=False, selected=set(plan.rows), valid=lambda: False)
+    assert not execution.filter("watchlist", "DST", "default", "add", [item(1)])
+    assert not execution.seen
+
+
+def test_session_preflight_drift_returns_to_review(config_base, monkeypatch):
+    from services import interactive_sync as svc
+    from api import syncAPI
+
+    src, dst = setup_ops(config_base, monkeypatch, [item(1)])
+    session = svc.Session(pair_id="p1", owner="local")
+    cfg = _cfg(False)
+    svc.refresh(session, cfg, {})
+    chosen = set(session.plan.rows)
+    next(iter(src.index.values()))["title"] = "Changed"
+    monkeypatch.setattr(syncAPI, "_run_pairs_thread", lambda *a, **k: pytest.fail("stale plan reached execution"))
+    svc.apply(session, cfg, chosen)
+    assert session.status == "review"
+    assert session.revision == 2
+    assert not dst.add_calls
+
+
+def test_preflight_explains_selection_loss_without_a_third_provider_read(config_base, monkeypatch, caplog):
+    from api import syncAPI
+    from services import interactive_sync as svc
+    from services import interactive_sync_progress as progress
+
+    src, dst = setup_ops(config_base, monkeypatch, [item(n) for n in range(1431)])
+    session = svc.Session(pair_id="p1", owner="local")
+    cfg = _cfg(False)
+    reads = []
+    original_read = src.build_index
+    now = [1000.0]
+    monkeypatch.setattr(progress.time, "monotonic", lambda: now[0])
+    caplog.set_level("INFO", logger="services.interactive_sync")
+
+    def read(*args, **kwargs):
+        reads.append(True)
+        now[0] += 3000
+        return original_read(*args, **kwargs)
+
+    monkeypatch.setattr(src, "build_index", read)
+    monkeypatch.setattr(syncAPI, "_run_pairs_thread", lambda *a, **k: pytest.fail("stale plan reached execution"))
+    try:
+        svc.refresh(session, cfg, {})
+        selected = session.store.selected_ids()
+        for row in list(src.index.values())[:1151]:
+            row["title"] += " changed"
+        svc.apply(session, cfg, selected)
+        assert len(reads) == 2
+        assert session.status == "review"
+        assert session.public()["counts"]["changes"] == 1431
+        assert session.public()["counts"]["selected"] == 280
+        result = session.public()["apply_review"]
+        assert {k: result[k] for k in ("requested", "retained", "needs_review", "applied")} == dict(requested=1431, retained=280, needs_review=1151, applied=0)
+        assert session.message.startswith("Nothing was applied.")
+        assert session.public()["progress"]["elapsed_seconds"] == 3000
+        assert not dst.add_calls
+        diagnostics = [record.message for record in caplog.records if "interactive_sync_proposal_changed" in record.message]
+        assert len(diagnostics) == 5
+        assert all('"item.title"' in message for message in diagnostics)
+    finally:
+        session.close()
+
+
+def test_failed_preflight_does_not_report_provider_changes(config_base, monkeypatch):
+    from api import syncAPI
+    from services import interactive_sync as svc
+
+    setup_ops(config_base, monkeypatch, [item(1)])
+    session = svc.Session(pair_id="p1", owner="local")
+    cfg = _cfg(False)
+    try:
+        svc.refresh(session, cfg, {})
+        original_build = svc.build
+
+        def failed_build(*args, **kwargs):
+            plan, summary = original_build(*args, **kwargs)
+            return plan, dict(summary, ok=False)
+
+        monkeypatch.setattr(svc, "build", failed_build)
+        monkeypatch.setattr(syncAPI, "_run_pairs_thread", lambda *a, **k: pytest.fail("failed preflight reached execution"))
+        svc.apply(session, cfg, session.store.selected_ids())
+        assert session.status == "error"
+        assert "recheck could not be completed" in session.message
+        assert session.public()["apply_review"]["applied"] == 0
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def api_client(config_base, monkeypatch):
+    from fastapi import FastAPI, Request
+    from fastapi.testclient import TestClient
+    from api import interactiveSyncAPI as api
+    from services import interactive_sync as svc
+
+    cfg = _cfg(False)
+    monkeypatch.setattr(api, "load_config", lambda: cfg)
+    monkeypatch.setattr(svc, "SESSIONS", {})
+    session = svc.Session(pair_id="p1", owner="alice", status="review", revision=1)
+    session.store = svc.ReviewStore()
+    session.plan.rows = session.store.rows
+    session.plan.conflicts = session.store.conflicts
+    session.plan.filter("watchlist", "DST", "default", "add", [item(1)], source="SRC")
+    session.store.finish()
+    svc.SESSIONS[session.id] = session
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def user(request: Request, call_next):
+        request.state.user = dict(id=request.headers.get("x-test-user", "alice"), is_admin=True)
+        return await call_next(request)
+
+    app.include_router(api.router)
+    with TestClient(app) as client:
+        yield client, session, api
+    session.close()
+
+
+def test_api_rejects_cross_user_session(api_client):
+    client, session, api = api_client
+    assert client.get(f"/api/interactive-sync/{session.id}", headers={"x-test-user": "bob"}).status_code == 404
+
+
+@pytest.mark.parametrize("payload, status", [({"revision": 0, "selection_version": 0}, 409), ({"revision": 1, "selection_version": 9}, 409), ({"revision": 1, "selection_version": 0, "selected": ["forged"]}, 422)])
+def test_api_rejects_stale_or_invalid_selection(api_client, payload, status):
+    client, session, api = api_client
+    assert client.post(f"/api/interactive-sync/{session.id}/apply", json=payload).status_code == status
+
+
+def test_api_cannot_apply_twice(api_client, monkeypatch):
+    client, session, api = api_client
+
+    def launch(session, *a, **k):
+        session.status = "applying"
+
+    monkeypatch.setattr(api, "launch", launch)
+    payload = dict(revision=1, selection_version=0)
+    assert client.post(f"/api/interactive-sync/{session.id}/apply", json=payload).status_code == 200
+    assert client.post(f"/api/interactive-sync/{session.id}/apply", json=payload).status_code == 409
+
+
+def test_api_expires_reviews(api_client, monkeypatch):
+    from services import interactive_sync as svc
+
+    client, session, api = api_client
+    session.touched = -svc.SESSION_TTL
+    assert client.get(f"/api/interactive-sync/{session.id}").status_code == 404
+
+
+@pytest.mark.parametrize("ruleset", [False, True])
+def test_pending_playlist_creates_only_selected_items(world, ruleset):
+    from cw_platform import playlists_runner as runner
+
+    cfg, src, dst, providers = world
+    mapping = runner.resolve_mapping_by_id(cfg, "MAP-01")
+    if ruleset:
+        from test_playlists_rulesets import custom_rule
+
+        rule = custom_rule(250)
+        cfg["playlists"]["rulesets"] = [rule]
+        mapping["ruleset_id"] = rule["id"]
+    plan = InteractivePlan()
+    runner.run_mapping(cfg, mapping, providers=providers, dry_run=True, interactive=plan)
+    assert not providers["PLEX"].created
+    selected = {rid for rid, row in plan.rows.items() if row["key"] == "tmdb:2"}
+    assert selected
+    result = runner.run_mapping(cfg, mapping, providers=providers, interactive=InteractivePlan(preview=False, selected=selected))
+    if not ruleset:
+        assert result["created"]
+    assert result["added"] == 1
+    assert providers["PLEX"].created[0]["seed"] == ["tmdb:2"]
+
+
+def test_no_selection_does_not_create_pending_playlist(world):
+    from cw_platform import playlists_runner as runner
+
+    cfg, src, dst, providers = world
+    runner.run_mapping(cfg, runner.resolve_mapping_by_id(cfg, "MAP-01"), providers=providers, interactive=InteractivePlan(preview=False))
+    assert not providers["PLEX"].created
+
+
+def test_rating_conflict_choice_replans_existing_engine(config_base, monkeypatch):
+    src, dst = setup_ops(config_base, monkeypatch, [item(1, rating=3)], [item(1, rating=8)])
+    for ops in (src, dst):
+        ops.features = lambda: {"ratings": True}
+        ops.health = lambda *_a, **_k: {"ok": True, "status": "ok", "features": {"ratings": True}}
+    cfg = _cfg(False)
+    cfg["pairs"][0].update(mode="two-way", feature="ratings", features={"ratings": {"enable": True, "add": True, "mode": "all"}})
+    first = InteractivePlan()
+    run(cfg, first)
+    assert len(first.conflicts) == 1
+    assert {row["provider"] for row in first.rows.values()} == {"DST"}
+    chosen = InteractivePlan(choices={next(iter(first.conflicts)): "DST"})
+    run(cfg, chosen)
+    assert {row["provider"] for row in chosen.rows.values()} == {"SRC"}
+    run(cfg, InteractivePlan(preview=False, selected=set(chosen.rows), choices=chosen.choices))
+    assert src.add_calls[0][0]["rating"] == 8
+    assert not dst.add_calls
+
+
+def test_provider_capability_checks_are_preserved(config_base, monkeypatch):
+    src, dst = setup_ops(config_base, monkeypatch, [item(1)])
+    dst.features = lambda: {"watchlist": False}
+    dst.capabilities = lambda: {"features": {"watchlist": False}}
+    plan = InteractivePlan()
+    run(_cfg(False), plan)
+    assert not plan.rows
+    assert not dst.add_calls
+
+
+def test_anime_coordinates_participate_in_preview(config_base, monkeypatch):
+    import json
+    from cw_platform.anime_mapping import storage
+    from test_anime_history_coords_orchestrator import FakeOps as HistoryOps, _episode, _cfg as anime_cfg, MAPPINGS, SRC_SHOW_IDS, DST_SHOW_IDS
+
+    paths = storage.paths("v3")
+    paths["root"].mkdir(parents=True, exist_ok=True)
+    paths["mappings"].write_text(json.dumps(MAPPINGS), encoding="utf-8")
+    storage.rebuild_sqlite_from_mappings(release_tag="v3")
+    src = HistoryOps("CROSSWATCH", {"tmdb:12609#s02e01": _episode(SRC_SHOW_IDS, 2, 1, absolute=14)})
+    dst = HistoryOps("MDBLIST", {"tmdb:12609#s01e14": _episode(DST_SHOW_IDS, 1, 14)})
+    monkeypatch.setattr("cw_platform.orchestrator.facade.load_sync_providers", lambda: {"CROSSWATCH": src, "MDBLIST": dst})
+    monkeypatch.setattr("cw_platform.orchestrator._snapshots.provider_configured", lambda *_: True)
+    plan = InteractivePlan()
+    run(anime_cfg(True), plan)
+    assert not plan.rows
+    assert not dst.add_calls
+
+
+def test_session_apply_uses_normal_run_path(config_base, monkeypatch):
+    from api import syncAPI
+    from services import interactive_sync as svc
+
+    src, dst = setup_ops(config_base, monkeypatch, [item(1), item(2)])
+    cfg = _cfg(False)
+    monkeypatch.setattr(syncAPI, "_env", lambda: (lambda: deepcopy(cfg), lambda *_: None))
+    session = svc.Session(pair_id="p1", owner="local")
+    svc.refresh(session, cfg, {})
+    chosen = {rid for rid, row in session.plan.rows.items() if row["key"] == "imdb:tt0000002"}
+    assert session.mapping_version == svc.mapping_version(cfg)
+    assert chosen
+    progress_events = []
+    original_progress = session.progress.event
+
+    def progress(event):
+        progress_events.append(event)
+        original_progress(event)
+
+    monkeypatch.setattr(session.progress, "event", progress)
+    svc.apply(session, cfg, chosen)
+    assert session.status == "complete", session.message
+    assert session.summary["added"] == 1
+    assert len(dst.add_calls) == 1
+    assert dst.add_calls[0][0]["title"] == "Movie 2"
+    assert any('"event":"apply:add:start"' in event for event in progress_events if isinstance(event, str))
+    assert session.public()["progress"]["stage"] == "complete"
+
+
+def test_unidentified_rows_offer_mapping_without_disabling_title_resolution():
+    plan = InteractivePlan()
+    plan.filter("watchlist", "DST", "default", "add", [{"type": "movie", "title": "Unknown movie"}, {}])
+    rows = list(plan.rows.values())
+    assert rows[0]["result"] == "unresolved" and rows[0]["selectable"]
+    assert rows[1]["result"] == "blocked" and not rows[1]["selectable"]
+
+
+@pytest.mark.parametrize("enrichment", [False, True])
+def test_mapping_api_persists_and_recalculates(api_client, config_base, monkeypatch, enrichment):
+    from api import editorAPI
+    from services import interactive_sync as svc
+
+    client, session, api = api_client
+    setup_ops(config_base, monkeypatch, [item(1, _trakt_history_id=9876)])
+    monkeypatch.setattr(editorAPI, "_STATE_BASE", config_base)
+    svc.refresh(session, _cfg(False), {})
+    corrected = item(2)
+    if enrichment:
+        corrected = item(1)
+        corrected["ids"]["tmdb"] = "2"
+
+    def launch(current, task, *args, prepare=None, **kwargs):
+        if prepare is not None:
+            prepare()
+        task(current, *args)
+
+    monkeypatch.setattr(api, "launch", launch)
+    response = client.post(f"/api/interactive-sync/{session.id}/mapping", json={
+        "revision": session.revision, "row_id": next(iter(session.plan.rows)), "item": corrected,
+    })
+    assert response.status_code == 200, response.text
+    assert len(session.plan.rows) == 1
+    row = next(iter(session.plan.rows.values()))
+    assert row["key"] == ("tmdb:2" if enrichment else "imdb:tt0000002")
+    adds, blocks = editorAPI._load_policy_manual("watchlist", "SRC")
+    assert "_trakt_history_id" not in next(iter(adds.values()))
+    assert blocks == ([] if enrichment else ["imdb:tt0000001"])
+
+
+def test_mapping_api_rejects_unusable_ids(api_client):
+    client, session, api = api_client
+    corrected = item(1)
+    corrected["ids"] = {"tmdb": "not-an-id"}
+    response = client.post(f"/api/interactive-sync/{session.id}/mapping", json={
+        "revision": session.revision, "row_id": next(iter(session.plan.rows)), "item": corrected,
+    })
+    assert response.status_code == 400
+
+
+def test_playlist_reorder_keeps_deselected_membership(config_base):
+    from cw_platform import playlists_runner as runner
+    from test_playlists_runner import _providers, _mapping, _cfg as playlist_cfg, _movie
+
+    providers = _providers({"L1": {"items": [_movie(1), _movie(2)]}}, {"T1": {"items": [_movie(3), _movie(1)]}})
+    mapping = _mapping(membership="mirror", order="preserve")
+    plan = InteractivePlan()
+    runner.run_mapping(playlist_cfg(), mapping, dry_run=True, providers=providers, interactive=plan)
+    selected = {rid for rid, row in plan.rows.items() if row["operation"] == "update"}
+    assert selected
+    runner.run_mapping(playlist_cfg(), mapping, providers=providers, interactive=InteractivePlan(preview=False, selected=selected))
+    assert providers["PLEX"].calls == [("reorder", "T1", ["tmdb:1", "tmdb:3"])]
+
+
+def test_cancel_during_selected_execution_prevents_writes(config_base, monkeypatch):
+    from cw_platform import run_control
+
+    src, dst = setup_ops(config_base, monkeypatch, [item(1)])
+    plan = InteractivePlan()
+    run(_cfg(False), plan)
+    original = dst.build_index
+
+    def cancel(*args, **kwargs):
+        result = original(*args, **kwargs)
+        run_control.request_cancel()
+        return result
+
+    monkeypatch.setattr(dst, "build_index", cancel)
+    try:
+        result = run(_cfg(False), InteractivePlan(preview=False, selected=set(plan.rows)))
+        assert result["cancelled"]
+        assert not dst.add_calls
+    finally:
+        run_control.clear_cancel()

--- a/tests/test_interactive_sync_features.py
+++ b/tests/test_interactive_sync_features.py
@@ -1,0 +1,178 @@
+# tests/test_interactive_sync_features.py
+# CrossWatch - Interactive Sync Feature Parity Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+import time
+
+import pytest
+
+from cw_platform.id_map import canonical_key
+from cw_platform.orchestrator import Orchestrator
+from cw_platform.orchestrator._interactive import InteractivePlan
+from cw_platform.orchestrator._state_store import StateStore
+from test_interactive_sync import item, run, setup_ops
+from test_orchestrator_dry_run_no_side_effects import _cfg
+
+
+FEATURES = ["watchlist", "history", "ratings", "progress", "collection"]
+
+
+def feature_item(feature, number):
+    return item(number, **{
+        "watchlist": {},
+        "history": {"watched_at": "2024-01-01T12:00:00Z"},
+        "ratings": {"rating": 8, "rated_at": "2024-01-01T12:00:00Z"},
+        "progress": {"progress_percent": 30, "progress_ms": 180000, "duration_ms": 600000, "progress_at": "2024-01-01T12:00:00Z"},
+        "collection": {"collected_at": "2024-01-01T12:00:00Z"},
+    }[feature])
+
+
+def feature_setup(config_base, monkeypatch, feature, source, target, mode="two-way"):
+    src, dst = setup_ops(config_base, monkeypatch, source, target)
+    for ops in (src, dst):
+        ops.features = lambda: {feature: True}
+        ops.capabilities = lambda: {"features": {feature: True}, "index_semantics": "present"}
+        ops.health = lambda *_a, **_k: {"ok": True, "status": "ok", "features": {feature: True}}
+    cfg = _cfg(False)
+    cfg["sync"].update(enable_remove=True, include_observed_deletes=True, tombstone_ttl_days=30)
+    cfg["pairs"][0].update(mode=mode, feature=feature, features={feature: {"enable": True, "add": True, "remove": True, "mode": "all"}})
+    return cfg, src, dst
+
+
+@pytest.mark.parametrize("feature", FEATURES)
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_expired_deletion_does_not_change_preview_from_normal_plan(config_base, monkeypatch, feature, mode):
+    common, extra = feature_item(feature, 1), feature_item(feature, 2)
+    cfg, src, dst = feature_setup(config_base, monkeypatch, feature, [common, extra], [common], mode)
+    run(cfg, InteractivePlan(preview=False))
+    store = StateStore(config_base)
+    store.save_tomb({"keys": {f"{feature}:DST-SRC|{canonical_key(extra)}": int(time.time()) - 31 * 86400}})
+    before = deepcopy(store.load_tomb())
+    plan = InteractivePlan()
+    run(cfg, plan)
+    assert store.load_tomb() == before
+    events = []
+    Orchestrator(cfg, on_progress=lambda line: events.append(json.loads(line)) if line.startswith("{") else None).run(dry_run=True, pair_scope_ids=["p1"], write_state_json=False)
+    assert dst.add_calls and len(dst.add_calls[-1]) == 1
+    assert canonical_key(dst.add_calls[-1][0]) == canonical_key(extra)
+    assert [(row["operation"], row["provider"], row["key"]) for row in plan.rows.values()] == [("add", "DST", canonical_key(extra))]
+    assert not any(event.get("event") == "apply:remove:start" and event.get("count") for event in events)
+
+
+@pytest.mark.parametrize("feature", FEATURES)
+@pytest.mark.parametrize("source", ["SRC", "DST"])
+def test_two_way_feature_only_applies_selected_addition(config_base, monkeypatch, feature, source):
+    common = feature_item(feature, 1)
+    cfg, src, dst = feature_setup(config_base, monkeypatch, feature, [common], [common])
+    run(cfg, InteractivePlan(preview=False))
+    origin, destination = (src, dst) if source == "SRC" else (dst, src)
+    for n in (2, 3):
+        row = feature_item(feature, n)
+        origin.index[canonical_key(row)] = row
+    plan = InteractivePlan()
+    run(cfg, plan)
+    assert len(plan.rows) == 2
+    assert {row["operation"] for row in plan.rows.values()} == {"add"}
+    selected = {rid for rid, row in plan.rows.items() if row["key"] == canonical_key(feature_item(feature, 3))}
+    assert len(selected) == 1
+    run(cfg, InteractivePlan(preview=False, selected=selected))
+    assert len(destination.add_calls) == 1
+    assert [canonical_key(row) for row in destination.add_calls[0]] == [canonical_key(feature_item(feature, 3))]
+    assert not origin.add_calls
+
+
+@pytest.mark.parametrize("feature", FEATURES)
+@pytest.mark.parametrize("scenario", ["active_tomb", "observed_delete", "removals_disabled"])
+def test_two_way_deletion_safety_matches_normal_plan(config_base, monkeypatch, feature, scenario):
+    common, extra = feature_item(feature, 1), feature_item(feature, 2)
+    target = [common] if scenario == "active_tomb" else [common, extra]
+    cfg, src, dst = feature_setup(config_base, monkeypatch, feature, [common, extra], target)
+    run(cfg, InteractivePlan(preview=False))
+    store = StateStore(config_base)
+    if scenario == "active_tomb":
+        store.save_tomb({"keys": {f"{feature}:DST-SRC|{canonical_key(extra)}": int(time.time()) - 86400}})
+    else:
+        dst.index.pop(canonical_key(extra))
+    if scenario == "removals_disabled":
+        cfg["pairs"][0]["features"][feature]["remove"] = False
+    before_tomb = deepcopy(store.load_tomb())
+    before_state = deepcopy(store.load_state())
+    plan = InteractivePlan()
+    assert run(cfg, plan)["ok"]
+    assert store.load_tomb() == before_tomb
+    assert store.load_state() == before_state
+    assert not src.add_calls and not dst.add_calls
+    events = []
+    Orchestrator(cfg, on_progress=lambda line: events.append(json.loads(line)) if line.startswith("{") else None).run(dry_run=True, pair_scope_ids=["p1"], write_state_json=False)
+    normal = next(event for event in events if event.get("event") == "two:plan")
+    for operation, field in (("add", "add_to"), ("update", "upd_to"), ("remove", "rem_from")):
+        for provider, side in (("SRC", "A"), ("DST", "B")):
+            assert sum(row["operation"] == operation and row["provider"] == provider for row in plan.rows.values()) == normal[f"{field}_{side}"]
+    if scenario == "removals_disabled":
+        assert not any(row["operation"] == "remove" for row in plan.rows.values())
+
+
+def test_progress_conflict_choice_is_replanned_and_applied(config_base, monkeypatch):
+    left = {**feature_item("progress", 1), "progress_percent": 0, "progress_ms": 0}
+    right = {**left, "progress_percent": 60, "progress_ms": 360000}
+    cfg, src, dst = feature_setup(config_base, monkeypatch, "progress", [left], [right])
+    plan = InteractivePlan()
+    run(cfg, plan)
+    assert len(plan.conflicts) == 1
+    choices = {next(iter(plan.conflicts)): "DST"}
+    refreshed = InteractivePlan(choices=choices)
+    run(cfg, refreshed)
+    assert len(refreshed.rows) == 1
+    assert {row["provider"] for row in refreshed.rows.values()} == {"SRC"}
+    run(cfg, InteractivePlan(preview=False, selected=set(refreshed.rows), choices=choices))
+    assert src.add_calls[0][0]["progress_ms"] == 360000
+    assert not dst.add_calls
+
+
+@pytest.mark.parametrize("feature", FEATURES)
+def test_mapping_recalculation_preserves_feature_values(config_base, monkeypatch, feature):
+    from api import editorAPI
+
+    original = feature_item(feature, 1)
+    cfg, src, dst = feature_setup(config_base, monkeypatch, feature, [original], [])
+    first = InteractivePlan()
+    run(cfg, first)
+    assert len(first.rows) == 1
+    corrected = feature_item(feature, 2)
+    monkeypatch.setattr(editorAPI, "_STATE_BASE", config_base)
+    editorAPI._save_policy_manual(feature, "SRC", {canonical_key(corrected): corrected}, [canonical_key(original)], merge=True)
+    refreshed = InteractivePlan()
+    run(cfg, refreshed)
+    assert len(refreshed.rows) == 1
+    row = next(iter(refreshed.rows.values()))
+    assert row["key"] == canonical_key(corrected)
+    assert not set(first.rows) & set(refreshed.rows)
+    first_payload = next(iter(first.rows.values()))["item"]
+    for key in ("watched_at", "rating", "progress_ms", "collected_at"):
+        if key in first_payload:
+            assert row["item"][key] == first_payload[key]
+    assert not src.add_calls and not dst.add_calls
+
+
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_history_rewatches_apply_only_selected_play(config_base, monkeypatch, mode):
+    from cw_platform.history_events import history_sync_key
+
+    cfg, src, dst = feature_setup(config_base, monkeypatch, "history", [], [], mode)
+    cfg["pairs"][0]["features"]["history"]["rewatches"] = True
+    for ops in (src, dst):
+        ops.capabilities = lambda: {"features": {"history": True}, "index_semantics": "present", "history": {"rewatches": {"read": True, "write": True}}}
+    first = feature_item("history", 1)
+    second = {**first, "watched_at": "2024-02-01T12:00:00Z"}
+    src.index = {history_sync_key(row, event_mode=True): row for row in (first, second)}
+    plan = InteractivePlan()
+    run(cfg, plan)
+    assert len(plan.rows) == 2
+    selected = {rid for rid, row in plan.rows.items() if row["item"].get("watched_at") == second["watched_at"]}
+    assert len(selected) == 1
+    run(cfg, InteractivePlan(preview=False, selected=selected))
+    assert len(dst.add_calls) == 1 and len(dst.add_calls[0]) == 1
+    assert dst.add_calls[0][0]["watched_at"] == second["watched_at"]

--- a/tests/test_interactive_sync_paging.py
+++ b/tests/test_interactive_sync_paging.py
@@ -1,0 +1,187 @@
+# tests/test_interactive_sync_paging.py
+# CrossWatch - Interactive Sync Paging and Large Review Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from cw_platform.orchestrator._interactive import InteractivePlan
+from services.interactive_sync_store import ReviewStore
+from test_interactive_sync import api_client, item
+
+
+def test_fifty_thousand_rows_have_bounded_responses_and_server_selection(api_client, monkeypatch):
+    client, session, api = api_client
+    session.close()
+    session.store = ReviewStore()
+    session.plan = InteractivePlan(rows=session.store.rows, conflicts=session.store.conflicts, copy_rows=False)
+    started = time.perf_counter()
+    session.plan.filter("history", "DST", "default", "add", (item(i, watched_at="2026-09-01T12:00:00Z") for i in range(50000)), source="SRC")
+    session.store.finish()
+    build_seconds = time.perf_counter() - started
+    status = client.get(f"/api/interactive-sync/{session.id}")
+    assert status.json()["counts"]["changes"] == 50000
+    assert "rows" not in status.json() and "conflicts" not in status.json()
+    assert len(status.content) < 2000
+    started = time.perf_counter()
+    first = client.get(f"/api/interactive-sync/{session.id}/rows", params=dict(revision=1)).json()
+    last_response = client.get(f"/api/interactive-sync/{session.id}/rows", params=dict(revision=1, offset=49950))
+    last = last_response.json()
+    page_seconds = time.perf_counter() - started
+    assert len(first["items"]) == 75 and len(last["items"]) == 50
+    assert first["total"] == last["total"] == 50000
+    assert not {row["id"] for row in first["items"]} & {row["id"] for row in last["items"]}
+    assert len(last_response.content) < 100000
+    filtered = client.get(f"/api/interactive-sync/{session.id}/rows", params=dict(revision=1, feature="history", result="add", q="Movie 4999")).json()
+    assert filtered["total"] == 11
+    response = client.post(f"/api/interactive-sync/{session.id}/selection", json=dict(revision=1, selection_version=0, selected=False, q="Movie 4999"))
+    assert response.json()["counts"]["selected"] == 49989
+    assert len(response.content) < 2000
+    captured = []
+
+    def launch(current, task, cfg, chosen, **kwargs):
+        captured.append(chosen)
+
+    monkeypatch.setattr(api, "launch", launch)
+    applied = client.post(f"/api/interactive-sync/{session.id}/apply", json=dict(revision=1, selection_version=1))
+    assert applied.status_code == 200
+    assert len(captured[0]) == 49989
+    assert not captured[0] & {row["id"] for row in filtered["items"]}
+    print(json.dumps(dict(rows=50000, build_seconds=round(build_seconds, 3), two_pages_seconds=round(page_seconds, 3),
+                         status_bytes=len(status.content), last_page_bytes=len(last_response.content), sqlite_bytes=session.store.path.stat().st_size)))
+
+
+def test_conflicts_share_bounded_paging(api_client):
+    client, session, api = api_client
+    for i in range(1200):
+        session.plan.conflict("ratings", str(i), "SRC", "DST", item(i, rating=4), item(i, rating=9), "SRC")
+    session.store.finish()
+    page = client.get(f"/api/interactive-sync/{session.id}/rows", params=dict(revision=1, result="conflict", offset=75)).json()
+    assert page["total"] == 1200 and len(page["items"]) == 75
+    assert all(row["result"] == "conflict" and not row["selectable"] for row in page["items"])
+    assert len(client.get(f"/api/interactive-sync/{session.id}").content) < 2000
+
+
+@pytest.mark.parametrize("params", [dict(limit=201), dict(limit=0), dict(offset=-1), dict(q="a" * 257)])
+def test_page_limits_are_validated(api_client, params):
+    client, session, api = api_client
+    assert client.get(f"/api/interactive-sync/{session.id}/rows", params=dict(revision=1, **params)).status_code == 422
+
+
+def test_stale_pages_and_selections_are_rejected(api_client):
+    client, session, api = api_client
+    assert client.get(f"/api/interactive-sync/{session.id}/rows", params=dict(revision=0)).status_code == 409
+    payload = dict(revision=1, selection_version=0, selected=False)
+    assert client.post(f"/api/interactive-sync/{session.id}/selection", json=payload).status_code == 200
+    assert client.post(f"/api/interactive-sync/{session.id}/selection", json=payload).status_code == 409
+    assert client.post(f"/api/interactive-sync/{session.id}/apply", json=dict(revision=1, selection_version=1)).status_code == 400
+
+
+def test_invalid_selection_is_atomic_and_scoped(api_client):
+    client, session, api = api_client
+    payload = dict(revision=1, selection_version=0, selected=False, ids=[next(iter(session.plan.rows)), "forged"])
+    assert client.post(f"/api/interactive-sync/{session.id}/selection", json=payload).status_code == 400
+    assert session.store.counts["selected"] == 1
+    assert client.post(f"/api/interactive-sync/{session.id}/selection", json=payload, headers={"x-test-user": "bob"}).status_code == 404
+    assert client.get(f"/api/interactive-sync/{session.id}/rows", params=dict(revision=1), headers={"x-test-user": "bob"}).status_code == 404
+
+
+def test_refreshed_store_preserves_only_unchanged_selections():
+    old, new = ReviewStore(), ReviewStore()
+    try:
+        before = InteractivePlan(rows=old.rows, copy_rows=False)
+        before.filter("history", "DST", "default", "add", [item(1), item(2)])
+        old.finish()
+        old.select(False, q="Movie 2")
+        after = InteractivePlan(rows=new.rows, copy_rows=False)
+        after.filter("history", "DST", "default", "add", [item(1), item(2), item(3)])
+        new.finish(old)
+        assert new.counts["selected"] == 1
+        assert new.selected_ids() == old.selected_ids()
+        assert len(new.rows) == 3
+    finally:
+        old.close()
+        new.close()
+
+
+def test_recheck_diagnostics_identify_changed_fields_without_item_payloads():
+    old, new = ReviewStore(), ReviewStore()
+    try:
+        before = InteractivePlan(rows=old.rows, copy_rows=False)
+        before.filter("history", "SIMKL", "SIMKL-P01", "add", [item(1, watched_at="2026-09-01T12:00:00Z", year=2026)])
+        old.finish()
+        after = InteractivePlan(rows=new.rows, copy_rows=False)
+        after.filter("history", "SIMKL", "default", "add", [item(1)])
+        after.filter("history", "SIMKL", "SIMKL-P01", "add", [item(1, watched_at="2026-09-01T12:00:00Z", year="2026")])
+        details = new.recheck_details(old, old.selected_ids())
+        assert len(details) == 1
+        assert details[0]["reason"] == "changed"
+        assert details[0]["fields"] == ["item.year"]
+        assert details[0]["instance"] == "SIMKL-P01"
+        assert "Movie 1" not in json.dumps(details)
+        assert "watched_at" not in json.dumps(details)
+        assert old.selected_ids()
+    finally:
+        old.close()
+        new.close()
+
+
+def test_recheck_diagnostics_bound_missing_and_ambiguous_results():
+    old, new = ReviewStore(), ReviewStore()
+    try:
+        before = InteractivePlan(rows=old.rows, copy_rows=False)
+        before.filter("history", "SIMKL", "default", "add", [item(i) for i in range(100)])
+        old.finish()
+        after = InteractivePlan(rows=new.rows, copy_rows=False)
+        after.filter("history", "SIMKL", "default", "add", [item(i, watched_at=date) for i in range(100) for date in ("2026-09-01T12:00:00Z", "2026-09-02T12:00:00Z")])
+        details = new.recheck_details(old, old.selected_ids())
+        assert len(details) == 5
+        assert all(row["reason"] == "ambiguous" and row["fields"] == [] for row in details)
+        new.db.execute("DELETE FROM review")
+        details = new.recheck_details(old, old.selected_ids())
+        assert len(details) == 5
+        assert all(row["reason"] == "unavailable" for row in details)
+    finally:
+        old.close()
+        new.close()
+
+
+def test_preflight_and_execution_do_not_accumulate_row_payloads():
+    original = InteractivePlan()
+    original.filter("history", "DST", "default", "add", [item(5)])
+    selected = set(original.rows)
+    for preview in (True, False):
+        plan = InteractivePlan(preview=preview, selected=selected, record_rows=False)
+        kept = plan.filter("history", "DST", "default", "add", (item(i) for i in range(5000)))
+        assert not plan.rows and not plan.conflicts
+        assert plan.seen == selected
+        assert len(kept) == (0 if preview else 1)
+
+
+@pytest.mark.parametrize("expire", [False, True])
+def test_closed_and_expired_reviews_remove_sqlite_files(api_client, expire):
+    client, session, api = api_client
+    path = session.store.path
+    assert path.exists()
+    if expire:
+        session.touched = -100000
+        assert client.get(f"/api/interactive-sync/{session.id}").status_code == 404
+    else:
+        assert client.delete(f"/api/interactive-sync/{session.id}").status_code == 200
+    assert not path.exists()
+
+
+def test_playlist_order_arrays_are_not_sent_in_page_responses(api_client):
+    client, session, api = api_client
+    reorder = dict(type="playlist", ids={"slug": "list"}, target_order=[str(i) for i in range(50000)])
+    session.plan.filter("playlists", "DST", "default", "update", [reorder])
+    session.store.finish()
+    response = client.get(f"/api/interactive-sync/{session.id}/rows", params=dict(revision=1, feature="playlists"))
+    row = response.json()["items"][0]
+    assert row["item"]["target_order_count"] == 50000
+    assert "target_order" not in row["item"]
+    assert len(response.content) < 2000
+    assert len(session.plan.rows[row["id"]]["item"]["target_order"]) == 50000

--- a/tests/test_interactive_sync_plex_history.py
+++ b/tests/test_interactive_sync_plex_history.py
@@ -1,0 +1,88 @@
+# tests/test_interactive_sync_plex_history.py
+# CrossWatch - Interactive Sync Plex History Read Stability Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from cw_platform.orchestrator._interactive import InteractivePlan
+from cw_platform.id_map import minimal
+from providers.sync.plex import _history as history
+
+
+@pytest.mark.parametrize("kind", ["movie", "episode"])
+@pytest.mark.parametrize("interactive", [False, True])
+@pytest.mark.parametrize("include_marked", [False, True])
+def test_history_selection_survives_full_to_incremental_read(config_base, monkeypatch, kind, interactive, include_marked):
+    watched_at = 1787093918
+    raw = SimpleNamespace(type=kind, ratingKey="42", title="History title", guid="tmdb://123",
+                          viewedAt=watched_at, grandparentTitle="Example series", grandparentGuid="tvdb://99", parentIndex=1, index=2)
+    server = SimpleNamespace(history=lambda **kwargs: [] if kwargs.get("mindate") else [raw])
+    adapter = SimpleNamespace(client=SimpleNamespace(server=server), cfg=SimpleNamespace(), config={"_cw_interactive_planned_at": 1788650000} if interactive else {})
+    catalog = history.HistoryCatalog()
+    catalog.add(dict(rk="42", type=kind, title="Catalog title", year=2026, ids={"tmdb": "123", "plex": "42"},
+                     series_title="Example series", season=1, episode=2, show_ids={"tvdb": "99"},
+                     watched=True, view_count=1, last_viewed_at=watched_at))
+    watermark = {}
+    monkeypatch.setattr(history, "home_scope_enter", lambda _: (False, False, None, None))
+    monkeypatch.setattr(history, "home_scope_exit", lambda *_: None)
+    monkeypatch.setattr(history, "plex_cfg_get", lambda _, key, default=None: default)
+    monkeypatch.setattr(history, "_history_cfg_get", lambda _, key, default=None: include_marked if key == "include_marked_watched" else default)
+    monkeypatch.setattr(history, "plex_feature_library_ids", lambda *_: set())
+    monkeypatch.setattr(history, "_history_force_full", lambda _: False)
+    monkeypatch.setattr(history, "_build_history_catalog", lambda *a, **k: catalog)
+    monkeypatch.setattr(history, "_store_history_catalog", lambda *_: None)
+    monkeypatch.setattr(history, "_load_watermark", lambda key: watermark.get(key))
+    monkeypatch.setattr(history, "_save_watermark", lambda key, value: watermark.update({key: value}))
+    monkeypatch.setattr(history, "_keep_in_snapshot", lambda *_: True)
+    monkeypatch.setattr(history, "_pms_fetch_metadata_row", lambda *_: dict(viewCount=1, lastViewedAt=watched_at))
+    monkeypatch.setattr(history, "_load_marked_state", lambda: {})
+    monkeypatch.setattr(history, "_iter_marked_watched_from_library", lambda *a, **k: [])
+    monkeypatch.setattr(history, "_fb_cache_flush", lambda: None)
+    monkeypatch.setattr(history, "plex_worker_count", lambda *a: 1)
+    first = history.build_index(adapter)
+    second = history.build_index(adapter)
+    assert len(first) == len(second) == 1
+    if not interactive:
+        expected = history.minimal_from_history_row(raw, token=None, allow_discover=False)
+        row = next(iter(first.values()))
+        assert row["ids"] == expected["ids"]
+        assert row["year"] == expected["year"]
+        if kind == "movie":
+            assert row["title"] == "History title"
+        return
+    initial = InteractivePlan()
+    initial.filter("history", "SIMKL", "SIMKL-P01", "add", [minimal(row) for row in first.values()], source="PLEX")
+    recheck = InteractivePlan(preview=False, selected=set(initial.rows))
+    kept = recheck.filter("history", "SIMKL", "SIMKL-P01", "add", [minimal(row) for row in second.values()], source="PLEX")
+    assert len(kept) == 1
+    assert kept[0]["watched_at"] == history._iso(watched_at)
+    third = history.build_index(adapter)
+    assert len(recheck.filter("history", "SIMKL", "SIMKL-P01", "add", [minimal(row) for row in third.values()], source="PLEX")) == 1
+    catalog.by_rk["42"]["last_viewed_at"] = watched_at + 3600
+    changed = history.build_index(adapter)
+    assert not recheck.filter("history", "SIMKL", "SIMKL-P01", "add", [minimal(row) for row in changed.values()], source="PLEX")
+
+    from api import syncAPI
+    from services import interactive_sync as svc
+    from test_interactive_sync_features import feature_setup
+
+    cfg, src, dst = feature_setup(config_base, monkeypatch, "history", [], [], "one-way")
+    snapshots = iter((first, second, third))
+    monkeypatch.setattr(src, "build_index", lambda *args, **kwargs: deepcopy(next(snapshots)))
+    monkeypatch.setattr(syncAPI, "_env", lambda: (lambda: deepcopy(cfg), lambda *_: None))
+    session = svc.Session(pair_id="p1", owner="local")
+    try:
+        svc.refresh(session, cfg, {})
+        assert session.store.counts["selected"] == 1
+        svc.apply(session, cfg, session.store.selected_ids())
+        assert session.status == "complete", session.message
+        assert session.apply_review is None
+        assert session.summary["not_applied"] == 0
+        assert len(dst.add_calls) == 1
+        assert dst.add_calls[0][0]["watched_at"] == history._iso(watched_at)
+    finally:
+        session.close()

--- a/tests/test_interactive_sync_progress.py
+++ b/tests/test_interactive_sync_progress.py
@@ -1,0 +1,202 @@
+# tests/test_interactive_sync_progress.py
+# CrossWatch - Interactive Sync Progress Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from services.interactive_sync_progress import SyncProgress
+from test_interactive_sync import api_client, setup_ops, item
+from test_orchestrator_dry_run_no_side_effects import _cfg
+
+
+def test_provider_counts_are_scoped_and_unknown_totals_stay_indeterminate():
+    progress = SyncProgress()
+    progress.event(dict(event="snapshot:start", provider="TRAKT", feature="history"))
+    assert progress.public()["percent"] is None
+    progress.event(dict(event="snapshot:progress", dst="TRAKT", feature="history", done=12500, total=50000))
+    state = progress.public()
+    assert state["percent"] == 25
+    assert state["items_read"] == 12500
+    progress.event(dict(event="snapshot:done", provider="TRAKT", feature="history", count=50000))
+    progress.event(dict(event="snapshot:start", provider="PLEX", feature="history"))
+    state = progress.public()
+    assert state["done"] == 0 and state["percent"] is None
+    assert state["items_read"] == 50000
+    assert state["provider"] == "PLEX"
+
+
+def test_elapsed_and_quiet_times_work_beyond_an_hour(monkeypatch):
+    from services import interactive_sync_progress as module
+
+    now = [100.0]
+    monkeypatch.setattr(module, "time", SimpleNamespace(monotonic=lambda: now[0], time=lambda: now[0] + 1000000))
+    progress = SyncProgress()
+    progress.event(dict(event="snapshot:start", provider="PLEX", feature="history"))
+    now[0] += 3900
+    state = progress.public()
+    assert state["elapsed_seconds"] == state["quiet_seconds"] == 3900
+    assert state["running"] and state["percent"] is None
+    progress.event(dict(event="api:request", provider="PLEX"))
+    assert progress.public()["quiet_seconds"] == 0
+    assert progress.public()["requests"] == 1
+    progress.finish("review", "Ready")
+    now[0] += 3600
+    assert progress.public()["elapsed_seconds"] == 3900
+    assert not progress.public()["running"]
+
+
+def test_apply_progress_counts_processed_items_and_ignores_duplicate_outer_events():
+    progress = SyncProgress()
+    progress.begin("apply")
+    progress.event(dict(event="apply:add:start", dst="TRAKT", feature="history", count=50000))
+    progress.event(dict(event="apply:add:progress", dst="TRAKT", feature="history", done=10000, total=50000))
+    progress.event(dict(event="two:apply:add:A:done", dst="TRAKT", feature="history", count=10000))
+    assert progress.public()["percent"] == 20
+    assert progress.public()["unit"] == "changes processed"
+    progress.event(dict(event="apply:add:done", dst="TRAKT", feature="history", attempted=50000, count=49900))
+    assert progress.public()["done"] == 50000
+    progress.finish("cancelled", "Cancelled")
+    progress.event(dict(event="api:request"))
+    assert progress.public()["stage"] == "cancelled"
+    assert not progress.public()["running"]
+
+
+def test_recent_activity_is_bounded_and_does_not_include_raw_provider_errors():
+    progress = SyncProgress()
+    for _ in range(1000):
+        progress.event(dict(event="feature:error", provider="PLEX", feature="history", error="secret-token", traceback="private-data"))
+    state = progress.public()
+    assert len(state["recent"]) == 6
+    assert "secret-token" not in str(state) and "private-data" not in str(state)
+
+
+def test_preview_exposes_provider_progress_while_index_is_being_read(config_base, monkeypatch):
+    from services import interactive_sync as svc
+
+    src, dst = setup_ops(config_base, monkeypatch, [item(1)])
+    session = svc.Session(pair_id="p1", owner="local")
+    observed = []
+    original = src.build_index
+
+    def build_index(*args, **kwargs):
+        src.ctx.emit("snapshot:progress", dst="SRC", feature="watchlist", done=12500, total=50000)
+        observed.append(session.public()["progress"])
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(src, "build_index", build_index)
+    try:
+        svc.refresh(session, _cfg(False), {})
+        assert observed[0]["percent"] == 25
+        assert observed[0]["provider"] == "SRC"
+        assert session.public()["progress"]["stage"] == "review"
+        assert not dst.add_calls
+    finally:
+        session.close()
+
+
+def test_active_review_does_not_expire_after_an_hour(api_client):
+    client, session, api = api_client
+    session.status = "reading"
+    session.touched -= 7200
+    result = client.get(f"/api/interactive-sync/{session.id}")
+    assert result.status_code == 200
+    assert result.json()["status"] == "reading"
+
+
+@pytest.mark.parametrize("verbose", [False, True])
+def test_http_attempts_count_without_verbose_logs_or_health_double_counting(monkeypatch, verbose):
+    import requests
+    from providers.sync._mod_common import build_session
+
+    progress = SyncProgress()
+    events = []
+    ctx = SimpleNamespace(interactive=SimpleNamespace(on_progress=progress.event), emit=lambda event, **data: (events.append(event), progress.event(dict(event=event, **data))))
+    progress.event(dict(event="api:hit", provider="PLEX", endpoint="health:status"))
+    assert progress.public()["requests"] == 0
+    outcomes = iter([requests.Response(), requests.Timeout("Test timeout"), requests.Response()])
+
+    def transport(*args, **kwargs):
+        outcome = next(outcomes)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(requests.Session, "request", transport)
+    with build_session("PLEX", ctx, emit_hits=verbose) as http:
+        http.get("https://example.invalid/history")
+        assert progress.public()["requests"] == 1
+        with pytest.raises(requests.Timeout):
+            http.get("https://example.invalid/history")
+        assert progress.public()["requests"] == 2
+        http.get("https://example.invalid/history")
+        assert progress.public()["requests"] == 3
+    assert len(events) == (3 if verbose else 0)
+
+
+@pytest.mark.parametrize("verbose", [False, True])
+def test_normal_http_session_has_no_interactive_observer(monkeypatch, verbose):
+    import requests
+    from providers.sync._mod_common import build_session
+
+    calls, events = [], []
+    response = requests.Response()
+    response.status_code = 200
+
+    def transport(session, method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        return response
+
+    monkeypatch.setattr(requests.Session, "request", transport)
+    ctx = SimpleNamespace(interactive=None, emit=lambda event, **data: events.append(event))
+    with build_session("PLEX", ctx, emit_hits=verbose) as http:
+        assert http._on_request is None
+        assert http.get("https://example.invalid/history", params={"page": 2}, timeout=5) is response
+    assert len(calls) == 1
+    assert calls[0][2]["params"] == {"page": 2}
+    assert calls[0][2]["timeout"] == 5
+    assert events == (["api:hit"] if verbose else [])
+
+
+def test_request_counter_advances_during_preview_and_apply(config_base, monkeypatch):
+    from copy import deepcopy
+    import requests
+    from api import syncAPI
+    from providers.sync._mod_common import build_session
+    from services import interactive_sync as svc
+
+    monkeypatch.delenv("CW_API_HITS", raising=False)
+    monkeypatch.setattr(requests.Session, "request", lambda *_a, **_k: requests.Response())
+    src, dst = setup_ops(config_base, monkeypatch, [item(1)])
+    original_read, original_add = src.build_index, dst.add
+    seen = []
+    session = svc.Session(pair_id="p1", owner="local")
+
+    def read(*args, **kwargs):
+        with build_session("SRC", src.ctx) as http:
+            for _ in range(5):
+                http.get("https://example.invalid/watchlist")
+                seen.append(session.public()["progress"]["requests"])
+        return original_read(*args, **kwargs)
+
+    def add(*args, **kwargs):
+        with build_session("DST", dst.ctx) as http:
+            http.post("https://example.invalid/watchlist")
+        return original_add(*args, **kwargs)
+
+    monkeypatch.setattr(src, "build_index", read)
+    monkeypatch.setattr(dst, "add", add)
+    cfg = _cfg(False)
+    monkeypatch.setattr(syncAPI, "_env", lambda: (lambda: deepcopy(cfg), lambda *_: None))
+    try:
+        svc.refresh(session, cfg, {})
+        assert seen == [1, 2, 3, 4, 5]
+        assert session.public()["progress"]["requests"] == 5
+        svc.apply(session, cfg, set(session.plan.rows))
+        assert session.status == "complete"
+        assert session.public()["progress"]["requests"] == 11
+        assert len(dst.add_calls) == 1
+    finally:
+        session.close()

--- a/tests/test_interactive_sync_provider_stability.py
+++ b/tests/test_interactive_sync_provider_stability.py
@@ -1,0 +1,254 @@
+# tests/test_interactive_sync_provider_stability.py
+# CrossWatch - Interactive Sync Provider Read Stability Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from copy import deepcopy
+import importlib
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from cw_platform.id_map import canonical_key, minimal
+from cw_platform.orchestrator._interactive import InteractivePlan
+
+
+def assert_stable(feature, provider, first, second):
+    from cw_platform.orchestrator._snapshots import canonicalize_index
+
+    first = canonicalize_index(first, feature=feature)
+    second = canonicalize_index(second, feature=feature)
+    assert first and second
+    conflict = InteractivePlan()
+    conflict.conflict(feature, "item", "SRC", provider, next(iter(first.values())), {}, provider)
+    repeated = InteractivePlan(choices=conflict.choices)
+    repeated.conflict(feature, "item", "SRC", provider, next(iter(second.values())), {}, provider)
+    assert set(conflict.conflicts) == set(repeated.conflicts)
+    for operation in ("add", "update", "remove"):
+        plan = InteractivePlan()
+        plan.filter(feature, provider, "default", operation, [minimal(v) for v in first.values()], before=first)
+        selected = InteractivePlan(preview=False, selected=set(plan.rows))
+        kept = selected.filter(feature, provider, "default", operation, [minimal(v) for v in second.values()], before=second)
+        assert len(kept) == len(first), (provider, feature, operation, first, second)
+
+
+@pytest.mark.parametrize("kind", ["movies", "shows", "anime"])
+@pytest.mark.parametrize("rated_at", ["", "2026-08-01T12:00:00Z"])
+@pytest.mark.parametrize("interactive", [False, True])
+def test_simkl_ratings_live_and_cached_reads_match(config_base, monkeypatch, kind, rated_at, interactive):
+    from providers.sync.simkl import _ratings as ratings
+
+    now = [1788650000]
+    monkeypatch.setenv("CW_PAIR_KEY", "stability")
+    watermark = {}
+    monkeypatch.setattr(ratings, "_shadow_path", lambda: str(config_base / "ratings-shadow.json"))
+    monkeypatch.setattr(ratings, "_headers", lambda *a, **k: {})
+    monkeypatch.setattr(ratings, "normalize_flat_watermarks", lambda: None)
+    monkeypatch.setattr(ratings, "_now", lambda: now[0])
+    monkeypatch.setattr(ratings, "get_watermark", lambda feature: watermark.get(feature))
+    monkeypatch.setattr(ratings, "update_watermark_if_new", lambda feature, value: watermark.update({feature: max(watermark.get(feature, ""), value)}) if value else None)
+    monkeypatch.setattr(ratings, "fetch_activities", lambda *a, **k: ({"movies": {"rated_at": "2026-09-01T12:00:00Z"}}, {}))
+    media = "movie" if kind == "movies" else "show" if kind == "shows" else "anime"
+    row = {media: dict(title="Example", year=2026, ids={"simkl": 123, "tmdb": 456}), "user_rating": 8, "user_rated_at": rated_at}
+    rows = {bucket: [row] if bucket == kind else [] for bucket in ("movies", "shows", "anime")}
+    fetches = []
+
+    def fetch(*args, **kwargs):
+        fetches.append(True)
+        return deepcopy(rows), True
+
+    monkeypatch.setattr(ratings, "_fetch_current", fetch)
+    adapter = SimpleNamespace(client=SimpleNamespace(session=None), cfg=SimpleNamespace(timeout=5), config={"_cw_interactive_planned_at": now[0]} if interactive else {})
+    first = ratings.build_index(adapter)
+    now[0] += 3600
+    second = ratings.build_index(adapter)
+    if interactive or rated_at:
+        assert_stable("ratings", "SIMKL", first, second)
+    else:
+        assert next(iter(first.values()))["rated_at"] == ""
+        assert next(iter(second.values()))["rated_at"] == ratings._as_iso(1788650000)
+    now[0] += 3600
+    assert_stable("ratings", "SIMKL", second, ratings.build_index(adapter))
+    assert len(fetches) == 1
+    assert watermark["ratings"] == "2026-09-01T12:00:00Z"
+    if interactive:
+        watermark.clear()
+        assert_stable("ratings", "SIMKL", second, ratings.build_index(adapter))
+
+
+@pytest.mark.parametrize("provider,feature", [("trakt", "history"), ("trakt", "ratings"), ("trakt", "watchlist"), ("trakt", "collection"), ("mdblist", "history"), ("mdblist", "ratings"), ("mdblist", "watchlist"), ("mdblist", "collection"), ("simkl", "history"), ("simkl", "watchlist")])
+@pytest.mark.parametrize("kind", ["movie", "episode"])
+def test_provider_cache_roundtrip_keeps_review_identity(config_base, monkeypatch, provider, feature, kind):
+    from cw_platform.history_events import history_event_key
+
+    monkeypatch.setenv("CW_PAIR_KEY", "stability")
+    monkeypatch.delenv("CW_CAPTURE_MODE", raising=False)
+    mod = importlib.import_module(f"providers.sync.{provider}._{feature}")
+    if feature == "watchlist" and kind == "episode":
+        kind = "show"
+    item = dict(type=kind, title="Example" if kind == "movie" else "S01E02", year=2026, ids={"tmdb": "456", "imdb": "tt1234567"})
+    if kind == "episode":
+        item.update(series_title="Example series", season=1, episode=2, show_ids={"tvdb": "99"})
+    item.update({"history": dict(watched=True, watched_at="2026-08-01T12:00:00Z", provider_event_id="123"), "ratings": dict(rating=8, rated_at="2026-08-01T12:00:00Z"), "collection": dict(collected_at="2026-08-01T12:00:00Z"), "watchlist": {}}[feature])
+    key = history_event_key(item) if feature == "history" else canonical_key(item)
+    first = {key: item}
+    is_cache = feature in ("history", "ratings")
+    path_name = "_cache_path" if is_cache else "_shadow_path"
+    monkeypatch.setattr(mod, path_name, lambda: config_base / "cache.json")
+    if provider == "trakt" and is_cache:
+        mod._save_cache_doc(first, "2026-08-01T12:00:00Z" if feature == "history" else {"movies": "2026-08-01T12:00:00Z"})
+        second = mod._load_cache_doc()["items"]
+    elif provider == "mdblist" and is_cache:
+        mod._save_cache(first)
+        second = mod._load_cache()
+    elif provider == "simkl" and feature == "history":
+        mod._cache_save(first, rewatches=True)
+        second = mod._cache_load()
+    else:
+        if provider == "trakt" and feature == "collection":
+            mod._shadow_save({"movies": "etag"}, first, {"movies": first})
+        elif provider in ("trakt", "simkl"):
+            mod._shadow_save("etag", first)
+        else:
+            mod._shadow_save(first)
+        second = mod._shadow_load()["items"]
+    assert_stable(feature, provider.upper(), first, second)
+
+
+@pytest.mark.parametrize("feature", ["watchlist", "history", "ratings", "progress", "collection"])
+def test_crosswatch_readonly_feature_reread_is_stable(config_base, monkeypatch, feature):
+    from providers.sync._mod_CROSSWATCH import CROSSWATCHModule
+    from providers.tests.test_crosswatch_collection import _cfg
+    from test_interactive_sync_features import feature_item
+
+    monkeypatch.setenv("CW_CROSSWATCH_PAIR_SCOPED", "1")
+    monkeypatch.setenv("CW_PAIR_KEY", "stability")
+    current = feature_item(feature, 1)
+    path = config_base / f"{feature}.stability.json"
+    path.write_text(json.dumps({"items": {canonical_key(current): current}}), encoding="utf-8")
+    cfg = dict(_cfg(config_base), _cw_readonly=True, _cw_interactive_planned_at=1788650000)
+    before = path.read_bytes()
+    first = CROSSWATCHModule(cfg).build_index(feature)
+    second = CROSSWATCHModule(cfg).build_index(feature)
+    assert_stable(feature, "CROSSWATCH", first, second)
+    assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize("feature", ["ratings", "progress"])
+@pytest.mark.parametrize("interactive", [False, True])
+def test_kodi_uncommitted_observation_times_are_stable(config_base, monkeypatch, feature, interactive):
+    from providers.sync.kodi import _common as common
+    from providers.tests.test_kodi_sync import FakeKodiClient, adapter, movie
+
+    monkeypatch.setattr(common, "_load_kodi_feature_baseline", lambda *a: {})
+    now = ["2026-09-01T12:00:00Z"]
+    monkeypatch.setattr(common, "_utc_now_iso", lambda: now[0])
+
+    def read():
+        current = adapter(FakeKodiClient(movies=[movie()]))
+        current.config = {"_cw_interactive_planned_at": 1788650000} if interactive else {}
+        return common.feature_index(current, feature)
+
+    first = read()
+    now[0] = "2026-09-01T13:00:00Z"
+    second = read()
+    if interactive:
+        assert_stable(feature, "KODI", first, second)
+    else:
+        field = "rated_at" if feature == "ratings" else "progress_at"
+        assert next(iter(first.values()))[field] == "2026-09-01T12:00:00Z"
+        assert next(iter(second.values()))[field] == "2026-09-01T13:00:00Z"
+
+
+@pytest.mark.parametrize("feature", ["ratings", "progress"])
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_kodi_observation_time_survives_session_preflight_and_execution(config_base, monkeypatch, feature, mode):
+    from api import syncAPI
+    from providers.sync.kodi import _common as common
+    from providers.tests.test_kodi_sync import FakeKodiClient, adapter, movie
+    from services import interactive_sync as svc
+    from test_interactive_sync_features import feature_setup
+
+    cfg, src, dst = feature_setup(config_base, monkeypatch, feature, [], [], mode)
+    monkeypatch.setattr(common, "_load_kodi_feature_baseline", lambda *a: {})
+    times = iter(["2026-09-01T12:00:00Z", "2026-09-01T13:00:00Z", "2026-09-01T14:00:00Z"])
+
+    def read(config, *, feature, **kwargs):
+        current = adapter(FakeKodiClient(movies=[movie()]))
+        current.config = config
+        monkeypatch.setattr(common, "_utc_now_iso", lambda: next(times))
+        return common.feature_index(current, feature)
+
+    monkeypatch.setattr(src, "build_index", read)
+    monkeypatch.setattr(syncAPI, "_env", lambda: (lambda: deepcopy(cfg), lambda *_: None))
+    session = svc.Session(pair_id="p1", owner="local")
+    try:
+        svc.refresh(session, cfg, {})
+        assert session.store.counts["changes"] == 1
+        svc.apply(session, cfg, session.store.selected_ids())
+        assert session.status == "complete", session.message
+        assert len(dst.add_calls) == 1
+        assert session.summary["not_applied"] == 0
+    finally:
+        session.close()
+
+
+@pytest.mark.parametrize("interactive", [False, True])
+def test_crosswatch_readonly_ratings_without_dates_are_stable(config_base, monkeypatch, interactive):
+    from providers.sync.crosswatch import _ratings as ratings
+    from providers.sync._mod_CROSSWATCH import CROSSWATCHModule
+    from providers.tests.test_crosswatch_collection import _cfg
+
+    monkeypatch.setenv("CW_CROSSWATCH_PAIR_SCOPED", "1")
+    monkeypatch.setenv("CW_PAIR_KEY", "stability")
+    cfg = dict(_cfg(config_base), _cw_readonly=True)
+    if interactive:
+        cfg["_cw_interactive_planned_at"] = 1788650000
+    adapter = CROSSWATCHModule(cfg)
+    path = ratings._ratings_path(adapter)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"items": {"tmdb:123": dict(type="movie", ids={"tmdb": "123"}, rating=8)}}), encoding="utf-8")
+    before = path.read_bytes()
+    monkeypatch.setattr(ratings, "_now_iso_z", lambda: "2026-09-01T12:00:00Z")
+    first = ratings.build_index(adapter)
+    monkeypatch.setattr(ratings, "_now_iso_z", lambda: "2026-09-01T13:00:00Z")
+    second = ratings.build_index(adapter)
+    if interactive:
+        assert_stable("ratings", "CROSSWATCH", first, second)
+    else:
+        assert next(iter(first.values()))["rated_at"] == "2026-09-01T12:00:00Z"
+        assert next(iter(second.values()))["rated_at"] == "2026-09-01T13:00:00Z"
+    assert path.read_bytes() == before
+
+
+def test_interactive_clock_does_not_leak_to_other_orchestrators(config_base, monkeypatch):
+    from cw_platform.orchestrator import Orchestrator
+    from test_interactive_sync import setup_ops
+    from test_orchestrator_dry_run_no_side_effects import _cfg
+
+    setup_ops(config_base, monkeypatch)
+    cfg = _cfg(False)
+    before = deepcopy(cfg)
+    interactive = Orchestrator(cfg, interactive=InteractivePlan(planned_at=1788650000))
+    assert interactive.context.config["_cw_interactive_planned_at"] == 1788650000
+    assert "_cw_interactive_planned_at" not in interactive.cfg
+    assert "_cw_interactive_planned_at" not in Orchestrator(cfg).context.config
+    assert cfg == before
+
+
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+@pytest.mark.parametrize("feature,field,value", [("watchlist", "title", "Corrected title"), ("history", "watched_at", "2026-09-01T12:00:00Z"), ("ratings", "rating", 4), ("progress", "progress_ms", 60000), ("collection", "collected_at", "2026-09-01T12:00:00Z")])
+def test_real_feature_changes_still_invalidate_selection(config_base, monkeypatch, mode, feature, field, value):
+    from test_interactive_sync import run
+    from test_interactive_sync_features import feature_item, feature_setup
+
+    cfg, src, dst = feature_setup(config_base, monkeypatch, feature, [feature_item(feature, 1)], [], mode)
+    initial = InteractivePlan()
+    run(cfg, initial)
+    assert initial.rows
+    next(iter(src.index.values()))[field] = value
+    execution = InteractivePlan(preview=False, selected=set(initial.rows), planned_at=initial.planned_at)
+    run(cfg, execution)
+    assert not execution.seen
+    assert not dst.add_calls

--- a/tests/test_interactive_sync_report.py
+++ b/tests/test_interactive_sync_report.py
@@ -1,0 +1,129 @@
+# tests/test_interactive_sync_report.py
+# CrossWatch - Interactive Sync Completion Report Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+
+import pytest
+
+from cw_platform.orchestrator._interactive import InteractivePlan
+from services.interactive_sync import Session
+from services.interactive_sync_report import COUNTERS, SyncReport
+from test_interactive_sync import run
+from test_interactive_sync_features import FEATURES, feature_item, feature_setup
+
+
+@pytest.mark.parametrize("feature", FEATURES)
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_report_uses_actual_selected_execution_results(config_base, monkeypatch, feature, mode):
+    cfg, src, dst = feature_setup(config_base, monkeypatch, feature,
+                                  [feature_item(feature, 1), feature_item(feature, 2)], [], mode)
+    preview = InteractivePlan()
+    collector = SyncReport()
+    preview.on_result = collector.record
+    run(cfg, preview)
+    assert collector.features == []
+    selected = {next(iter(preview.rows))}
+    execution = InteractivePlan(preview=False, selected=selected, on_result=collector.record)
+    result = run(cfg, execution)
+    report = collector.finish(Session(pair_id="p1", owner="local"), execution, result)
+    assert report["outcome"] == "success"
+    assert report["requested"] == report["reached_execution"] == 1
+    assert report["not_reached"] == 0
+    assert report["totals"]["added"] == 1
+    assert len(collector.features) == 1
+    assert {k: collector.features[0][k] for k in COUNTERS} == report["totals"]
+    assert sum(row["added"] for row in collector.features[0]["destinations"]) == 1
+    assert len(dst.add_calls[0]) == 1
+
+
+def test_two_way_results_preserve_direction_and_instances():
+    collector = SyncReport()
+    collector.record("ratings", "PLEX", "TRAKT", "home", "other", "two-way", dict(
+        adds_to_A=3, adds_to_B=7, upd_to_A=2, upd_to_B=4, rem_from_A=1, rem_from_B=5,
+        skipped=6, errors=2, unresolved=3, unresolved_to_A=1, unresolved_to_B=2,
+        resA_add={"skipped": 2, "errors": 1}, resB_update={"skipped": 4, "errors": 1}))
+    row = collector.features[0]
+    assert (row["added"], row["updated"], row["removed"], row["skipped"], row["errors"]) == (10, 6, 6, 6, 2)
+    assert row["destinations"][0] == dict(provider="PLEX", instance="home", added=3, updated=2, removed=1, skipped=2, errors=1, unresolved=1)
+    assert row["destinations"][1] == dict(provider="TRAKT", instance="other", added=7, updated=4, removed=5, skipped=4, errors=1, unresolved=2)
+
+
+def test_playlist_results_do_not_invent_destination_or_item_receipts():
+    collector = SyncReport()
+    collector.record("playlists", "PLEX", "TRAKT", "default", "other", "two-way",
+                     dict(added=240, updated=2, removed=8, errors=1, unresolved=4))
+    row = collector.features[0]
+    assert row["added"] == 240
+    assert row["updated"] == 2
+    assert row["destinations"] == []
+
+
+@pytest.mark.parametrize("result,outcome", [(None, "incomplete"), ({"ok": True, "cancelled": True}, "cancelled"),
+                                            ({"ok": True, "errors": 2}, "attention"), ({"ok": False}, "incomplete")])
+def test_interrupted_and_failed_runs_never_claim_success(result, outcome):
+    collector = SyncReport()
+    collector.record("history", "PLEX", "SIMKL", "default", "default", "one-way", {"added": 8})
+    execution = InteractivePlan(preview=False, selected={"a", "b"}, seen={"a"})
+    report = collector.finish(Session(pair_id="p1", owner="local"), execution, result)
+    assert report["outcome"] == outcome
+    assert report["not_reached"] == 1
+    assert report["requested"] == 2
+    if result is None:
+        assert report["totals"]["added"] == 8
+        assert report["incomplete_note"]
+
+
+def test_notices_are_bounded_and_do_not_export_raw_provider_errors():
+    collector = SyncReport()
+    for n in range(500):
+        collector.event(json.dumps(dict(event="feature:error", feature="history", dst=f"provider{n}",
+                                        error="secret-token", traceback="secret-token")))
+    collector.event(dict(event="mass_delete:blocked", feature="watchlist"))
+    assert len(collector.notices) == 100
+    assert collector.notice_overflow == 401
+    assert "secret-token" not in json.dumps(list(collector.notices.values()))
+
+
+def test_report_is_session_scoped_and_survives_other_runs(config_base, monkeypatch):
+    from api import syncAPI
+    from services import interactive_sync as svc
+
+    cfg, src, dst = feature_setup(config_base, monkeypatch, "watchlist", [feature_item("watchlist", 1)], [], "one-way")
+    monkeypatch.setattr(syncAPI, "_env", lambda: (lambda: deepcopy(cfg), lambda *_: None))
+    session = Session(pair_id="p1", owner="local")
+    session.pair = dict(source="SRC", target="DST", mode="one-way")
+    try:
+        svc.refresh(session, cfg, {})
+        assert session.public()["report"] is None
+        svc.apply(session, cfg, session.store.selected_ids())
+        report = deepcopy(session.public()["report"])
+        assert report["outcome"] == "success"
+        assert report["proposed"] == report["requested"] == report["totals"]["added"] == 1
+        assert report["not_selected"] == 0
+        run(cfg, InteractivePlan(preview=False))
+        assert session.public()["report"] == report
+    finally:
+        session.close()
+
+
+def test_fatal_execution_still_keeps_a_report(config_base, monkeypatch):
+    from api import syncAPI
+    from services import interactive_sync as svc
+
+    cfg, src, dst = feature_setup(config_base, monkeypatch, "watchlist", [feature_item("watchlist", 1)], [], "one-way")
+    session = Session(pair_id="p1", owner="local")
+    def crash(*args, **kwargs):
+        raise RuntimeError("interrupted")
+    monkeypatch.setattr(syncAPI, "_run_pairs_thread", crash)
+    try:
+        svc.refresh(session, cfg, {})
+        with pytest.raises(RuntimeError, match="interrupted"):
+            svc.apply(session, cfg, session.store.selected_ids())
+        assert session.report["outcome"] == "incomplete"
+        assert session.report["totals"]["added"] == 0
+        assert session.report["not_reached"] == 1
+    finally:
+        session.close()

--- a/tests/test_twoway_anime_comparison_view.py
+++ b/tests/test_twoway_anime_comparison_view.py
@@ -60,7 +60,7 @@ def test_view_is_used_for_comparison_features(feature: str) -> None:
 def test_source_only_reads_the_hook_when_anime_mapping_is_on() -> None:
     source = twoway.__loader__.get_source(twoway.__name__)
     anchor = source.index("if bool(anime_pair_opts.get(\"use_anime_mapping\", False)):")
-    gate = source[anchor : source.index("\n    now = int(_t.time())", anchor)]
+    gate = source[anchor : source.index("\n    tomb_ttl_days =", anchor)]
     assert "_comparison_view(aops" in gate
     assert "_comparison_view(bops" in gate
     assert source.count("_comparison_view(aops") == 1

--- a/tests/test_twoway_history_specials.py
+++ b/tests/test_twoway_history_specials.py
@@ -208,7 +208,7 @@ def test_manual_history_date_correction_updates_upsert_peer(monkeypatch) -> None
     trakt_key = f"tmdb:1402#s00e48@{WATCHED_EPOCH}"
     simkl_key = f"tvdb:153021#s00e48@{WATCHED_EPOCH}"
 
-    def manual_policy(_state, provider, _feature):
+    def manual_policy(_state, provider, _feature, _instance="default"):
         if provider == "TRAKT":
             return {canonical_key(trakt_manual): trakt_manual}, set()
         return {}, set()


### PR DESCRIPTION
# Pull request

## Change

- Reuse the sync planner to preview and apply selected changes.
- Add paged reviews, mapping refresh, progress and reports.
- Fix provider read consistency and keep existing protections active.

## Why

Let users review sync changes before anything is written.

## Testing

- tests/test_interactive_sync.py

## Issue

Relates to #1018