### PR TITLE
Change: isolate pair sync state

### DIFF
--- a/cw_platform/local_db/diagnostics.py
+++ b/cw_platform/local_db/diagnostics.py
@@ -11,6 +11,10 @@ from .db import crosswatch_db_path, get_conn
 from .schema import SCHEMA_VERSION
 
 _ORPHAN_QUERIES = {
+    "pair_baseline_items_missing_feature": (
+        "SELECT COUNT(*) FROM pair_baseline_items b "
+        "LEFT JOIN pair_feature_state p ON p.id=b.provider_state_id WHERE p.id IS NULL"
+    ),
     "baseline_items_missing_feature": (
         "SELECT COUNT(*) FROM baseline_items b "
         "LEFT JOIN provider_feature_state p ON p.id=b.provider_state_id WHERE p.id IS NULL"

--- a/cw_platform/local_db/schema.py
+++ b/cw_platform/local_db/schema.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import sqlite3
 import time
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 ID_KEYS = (
     "tmdb",
@@ -613,6 +613,13 @@ def apply_schema(conn: sqlite3.Connection) -> int:
         conn.execute(_CREATE_LOCAL_META)
         conn.execute(_CREATE_PROVIDER_FEATURE_STATE)
         conn.execute(_CREATE_BASELINE_ITEMS)
+        conn.execute(_CREATE_PROVIDER_FEATURE_STATE.replace("provider_feature_state", "pair_feature_state").replace(
+            "provider          TEXT", "pair_scope        TEXT NOT NULL,\n    provider          TEXT"
+        ).replace("UNIQUE(provider, instance, feature)", "UNIQUE(pair_scope, provider, instance, feature)"))
+        conn.execute(_CREATE_BASELINE_ITEMS.replace("baseline_items", "pair_baseline_items").replace(
+            "REFERENCES provider_feature_state", "REFERENCES pair_feature_state"
+        ))
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_pair_items_state_key ON pair_baseline_items(provider_state_id, item_key)")
         _ensure_column(conn, "baseline_items", "collected_at", "TEXT")
         conn.execute(_CREATE_LAST_SYNC_SUMMARY)
         conn.execute(_CREATE_LAST_SYNC_FIELDS)

--- a/cw_platform/local_db/state.py
+++ b/cw_platform/local_db/state.py
@@ -8,7 +8,7 @@ import re
 import sqlite3
 import threading
 import time
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -335,10 +335,10 @@ def _feature_mode(items: Mapping[str, Any]) -> str:
     return "event" if any(_event_parts(str(k))[1] for k in items.keys()) else "collapsed"
 
 
-def _stored_item_compare_map(conn: sqlite3.Connection, provider_state_id: int) -> dict[str, tuple[Any, ...]]:
+def _stored_item_compare_map(conn: sqlite3.Connection, provider_state_id: int, *, pair: bool = False) -> dict[str, tuple[Any, ...]]:
     columns = ",".join(_BASELINE_ITEM_COMPARE_COLUMNS)
     rows = conn.execute(
-        f"SELECT {columns} FROM baseline_items WHERE provider_state_id=?",
+        f"SELECT {columns} FROM {'pair_baseline_items' if pair else 'baseline_items'} WHERE provider_state_id=?",
         (provider_state_id,),
     ).fetchall()
     return {str(row["item_key"]): tuple(row) for row in rows}
@@ -360,7 +360,14 @@ def _replace_feature(
     feature: str,
     block: Mapping[str, Any],
     ts: int,
+    *,
+    pair_scope: str | None = None,
 ) -> bool:
+    def sql(statement: str) -> str:
+        if pair_scope is None:
+            return statement
+        return statement.replace("provider_feature_state", "pair_feature_state").replace("baseline_items", "pair_baseline_items")
+
     provider, instance, feature = _feature_key(provider, instance, feature)
     if not provider or not feature:
         return False
@@ -373,19 +380,24 @@ def _replace_feature(
     mode = _feature_mode(items)
     checkpoint = _scalar_parts(block.get("checkpoint"))
     pfs = conn.execute(
-        "SELECT * FROM provider_feature_state WHERE provider=? AND instance=? AND feature=?",
-        (provider, instance, feature),
+        sql("SELECT * FROM provider_feature_state WHERE provider=? AND instance=? AND feature=?") + (" AND pair_scope=?" if pair_scope is not None else ""),
+        (provider, instance, feature, pair_scope) if pair_scope is not None else (provider, instance, feature),
     ).fetchone()
     cp_text, cp_int, cp_real, cp_type = checkpoint
     if pfs is None:
-        cur = conn.execute(_PFS_INSERT_SQL, (provider, instance, feature, mode, cp_text, cp_int, cp_real, cp_type, ts))
+        statement = sql(_PFS_INSERT_SQL)
+        values: tuple[Any, ...] = (provider, instance, feature, mode, cp_text, cp_int, cp_real, cp_type, ts)
+        if pair_scope is not None:
+            statement = statement.replace("(provider,", "(pair_scope,provider,").replace("VALUES(", "VALUES(?,")
+            values = (pair_scope, *values)
+        cur = conn.execute(statement, values)
         pfs_id_raw = cur.lastrowid
         if pfs_id_raw is None:
             return False
         pfs_id = int(pfs_id_raw)
         if rows:
             conn.executemany(
-                _BASELINE_ITEM_INSERT_SQL,
+                sql(_BASELINE_ITEM_INSERT_SQL),
                 [(pfs_id, *row[1:-1], ts) for row in rows],
             )
         return True
@@ -398,7 +410,7 @@ def _replace_feature(
         pfs["checkpoint_type"],
     )
     metadata_changed = str(pfs["mode"] or "") != mode or current_checkpoint != checkpoint
-    existing = _stored_item_compare_map(conn, pfs_id)
+    existing = _stored_item_compare_map(conn, pfs_id, pair=pair_scope is not None)
     incoming_rows = _incoming_item_row_map(rows)
     incoming_compare = {key: tuple(row[1:-1]) for key, row in incoming_rows.items()}
     existing_keys = set(existing)
@@ -414,24 +426,25 @@ def _replace_feature(
         return False
 
     conn.execute(
-        "UPDATE provider_feature_state SET mode=?,checkpoint_text=?,checkpoint_int=?,"
-        "checkpoint_real=?,checkpoint_type=?,updated_at=? WHERE id=?",
+        sql("UPDATE provider_feature_state SET mode=?,checkpoint_text=?,checkpoint_int=?,"
+        "checkpoint_real=?,checkpoint_type=?,updated_at=? WHERE id=?"),
         (mode, cp_text, cp_int, cp_real, cp_type, ts, pfs_id),
     )
-    if delete_keys:
-        placeholders = ",".join("?" for _ in delete_keys)
+    for offset in range(0, len(delete_keys), 500):
+        chunk = delete_keys[offset:offset + 500]
+        placeholders = ",".join("?" for _ in chunk)
         conn.execute(
-            f"DELETE FROM baseline_items WHERE provider_state_id=? AND item_key IN ({placeholders})",
-            (pfs_id, *delete_keys),
+            sql(f"DELETE FROM baseline_items WHERE provider_state_id=? AND item_key IN ({placeholders})"),
+            (pfs_id, *chunk),
         )
     if insert_rows:
         conn.executemany(
-            _BASELINE_ITEM_INSERT_SQL,
+            sql(_BASELINE_ITEM_INSERT_SQL),
             [(pfs_id, *row[1:-1], ts) for row in insert_rows],
         )
     if update_rows:
         conn.executemany(
-            _BASELINE_ITEM_UPDATE_SQL,
+            sql(_BASELINE_ITEM_UPDATE_SQL),
             [(*row[2:-1], ts, pfs_id, str(row[1])) for row in update_rows],
         )
     return True
@@ -492,7 +505,9 @@ def _build_state_from_feature_rows(
     rows: list[sqlite3.Row],
     *,
     recent_limit: int | None = None,
+    pair: bool = False,
 ) -> dict[str, Any]:
+    table = "pair_baseline_items" if pair else "baseline_items"
     providers: dict[str, Any] = {}
     wall: list[dict[str, Any]] = []
     for pfs in rows:
@@ -508,14 +523,14 @@ def _build_state_from_feature_rows(
         if checkpoint is not None:
             feat_node["checkpoint"] = checkpoint
         order_column = _RECENT_ORDER_COLUMNS.get(feature) if recent_limit else None
-        if order_column:
+        if order_column and recent_limit is not None:
             items = conn.execute(
-                f"SELECT * FROM baseline_items WHERE provider_state_id=? ORDER BY {order_column} DESC LIMIT ?",
+                f"SELECT * FROM {table} WHERE provider_state_id=? ORDER BY {order_column} DESC LIMIT ?",
                 (int(pfs["id"]), int(recent_limit)),
             ).fetchall()
         else:
             items = conn.execute(
-                "SELECT * FROM baseline_items WHERE provider_state_id=? ORDER BY item_key",
+                f"SELECT * FROM {table} WHERE provider_state_id=? ORDER BY item_key",
                 (int(pfs["id"]),),
             ).fetchall()
         for row in items:
@@ -719,6 +734,52 @@ def save_feature_blocks(
         _invalidate()
 
 
+def load_pair_state(base_path: str | Path, pair_scope: str, features: Iterable[str] | None = None) -> dict[str, Any]:
+    with _LOCK:
+        conn = get_conn(base_path)
+        if conn is None:
+            raise RuntimeError("Pair state database is unavailable")
+        params: list[Any] = [pair_scope]
+        query = "SELECT * FROM pair_feature_state WHERE pair_scope=?"
+        if features is not None:
+            wanted = sorted(set(features))
+            if not wanted:
+                return {"providers": {}, "wall": [], "last_sync_epoch": None}
+            query += " AND feature IN (" + ",".join("?" for _ in wanted) + ")"
+            params.extend(wanted)
+        rows = conn.execute(query + " ORDER BY provider,instance,feature", params).fetchall()
+        state = _build_state_from_feature_rows(conn, rows, pair=True)
+        state["last_sync_epoch"] = max((int(row["updated_at"]) for row in rows), default=0) / 1_000_000_000 or None
+        return state
+
+
+def save_pair_blocks(base_path: str | Path, pair_scope: str, blocks: Mapping[tuple[str, str, str], Mapping[str, Any]], *, last_sync_epoch: Any = None) -> None:
+    if not pair_scope:
+        raise ValueError("Pair scope is required")
+    with _LOCK:
+        conn = get_conn(base_path)
+        if conn is None:
+            raise RuntimeError("Pair state database is unavailable")
+        ts = _now()
+        with conn:
+            for (provider, instance, feature), block in blocks.items():
+                _replace_feature(conn, provider, instance, feature, block, ts, pair_scope=pair_scope)
+                _replace_feature(conn, provider, instance, feature, block, ts)
+            if last_sync_epoch is not None:
+                _set_meta(conn, "last_sync_epoch", last_sync_epoch, ts)
+        _invalidate()
+
+
+def clear_pair_state(base_path: str | Path, pair_scope: str) -> None:
+    with _LOCK:
+        conn = get_conn(base_path)
+        if conn is None:
+            raise RuntimeError("Pair state database is unavailable")
+        with conn:
+            conn.execute("DELETE FROM pair_feature_state WHERE pair_scope=?", (pair_scope,))
+        _invalidate()
+
+
 def set_last_sync_epoch(base_path: str | Path, value: Any) -> None:
     with _LOCK:
         conn = get_conn(base_path)
@@ -735,6 +796,8 @@ def clear_state(base_path: str | Path) -> None:
         if conn is None:
             return
         with conn:
+            conn.execute("DELETE FROM pair_baseline_items")
+            conn.execute("DELETE FROM pair_feature_state")
             conn.execute("DELETE FROM baseline_items")
             conn.execute("DELETE FROM provider_feature_state")
             conn.execute("DELETE FROM state_meta")

--- a/cw_platform/orchestrator/_pairs.py
+++ b/cw_platform/orchestrator/_pairs.py
@@ -21,6 +21,7 @@ from ._pairs_twoway import run_two_way_feature
 from ._pairs_playlists import run_playlist_mappings
 from ..run_control import SyncCancelled, cancel_requested
 from ..value_coercion import coerce_bool
+from ..pair_scope import pair_feature_scope
 
 def _deep_merge_provider_overrides(dst: dict[str, Any], src: Mapping[str, Any]) -> None:
     for k, v in (src or {}).items():
@@ -311,8 +312,8 @@ def _pair_scope_key(pair: Mapping[str, Any], *, i: int, src: str, dst: str, mode
 
 
 @contextmanager
-def _pair_env(pair: Mapping[str, Any], *, i: int, src: str, dst: str, mode: str, feature: str):
-    key = _pair_scope_key(pair, i=i, src=src, dst=dst, mode=mode)
+def _pair_env(pair: Mapping[str, Any], *, i: int, src: str, dst: str, mode: str, feature: str, scope: str | None = None):
+    key = scope or _pair_scope_key(pair, i=i, src=src, dst=dst, mode=mode)
     src_inst = normalize_instance_id(pair.get("source_instance"))
     dst_inst = normalize_instance_id(pair.get("target_instance"))
     new = {
@@ -482,9 +483,12 @@ def run_pairs(ctx) -> dict[str, Any]:
             if isinstance(fcfg, dict) and not coerce_bool(fcfg.get("enable", True), True):
                 continue
 
-            with _pair_env(pair, i=i, src=src, dst=dst, mode=mode, feature=feature):
+            scope = pair_feature_scope(cfg, pair, feature, i)
+            with _pair_env(pair, i=i, src=src, dst=dst, mode=mode, feature=feature, scope=scope):
                 prev_cfg = ctx.config
-                ctx.config = _config_with_pair_feature_options(pair_cfg_view, fcfg, (src, dst), feature)
+                prev_store = ctx.state_store
+                ctx.state_store = prev_store.for_pair(scope)
+                ctx.config = {**_config_with_pair_feature_options(pair_cfg_view, fcfg, (src, dst), feature), "_cw_pair_scope": scope}
                 try:
                     if not injected:
                         inject_ctx_into_provider(sops, ctx)
@@ -579,6 +583,7 @@ def run_pairs(ctx) -> dict[str, Any]:
                         continue
                 finally:
                     ctx.config = prev_cfg
+                    ctx.state_store = prev_store
     if not cancelled and cancel_requested():
         cancelled = True
 

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -1144,9 +1144,9 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
                                 break
                     if isinstance(pblk2, Mapping) and pblk2:
                         pblk = pblk2
-                    elif feat not in pblk:
+                    else:
                         return {}
-                elif feat not in pblk:
+                else:
                     return {}
                 if not isinstance(pblk, Mapping):
                     return {}
@@ -1635,7 +1635,7 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
     )
 
     blocked_total = 0
-    pair_key = "-".join(sorted([src, dst]))
+    pair_key = str(getattr(ctx.state_store, "pair_scope", None) or "-".join(sorted([src, dst]))).upper()
     if feature != "watchlist":
         before_blocklist = len(adds)
         adds = apply_blocklist(
@@ -2252,7 +2252,8 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
             }
             ctx.state_store.save_feature_blocks(blocks, last_sync_epoch=last_sync_epoch)
         except Exception:
-            pass
+            if getattr(ctx.state_store, "pair_scope", None):
+                raise
 
     emit("feature:done", src=src, dst=dst, feature=feature)
 

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -489,11 +489,12 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
             setattr(ctx, "_stable_prev_state_by_feature", prev_state_cache)
         except Exception:
             pass
-    prev_state = prev_state_cache.get(feature)
+    state_key = (getattr(ctx.state_store, "pair_scope", None), feature)
+    prev_state = prev_state_cache.get(state_key)
     if not prev_state:
         prev_state = load_feature_state(ctx.state_store, feature)
         try:
-            prev_state_cache[feature] = prev_state
+            prev_state_cache[state_key] = prev_state
         except Exception:
             pass
 
@@ -525,9 +526,9 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
                                 break
                     if isinstance(pblk2, Mapping) and pblk2:
                         pblk = pblk2
-                    elif feat not in pblk:
+                    else:
                         return {}
-                elif feat not in pblk:
+                else:
                     return {}
                 if not isinstance(pblk, Mapping):
                     return {}
@@ -669,7 +670,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
     now = review.planned_at if review is not None else int(_t.time())
     tomb_ttl_days = int((cfg.get("sync") or {}).get("tombstone_ttl_days", 30))
     tomb_ttl_secs = max(1, tomb_ttl_days) * 24 * 3600
-    pair_key = "-".join(sorted([a, b]))
+    pair_key = str(getattr(ctx.state_store, "pair_scope", None) or "-".join(sorted([a, b]))).upper()
     tomb_map = keys_for_feature(ctx.state_store, feature, pair=pair_key, ttl_seconds=tomb_ttl_secs, now=now) or {}
     tomb = set(tomb_map)
 
@@ -2607,7 +2608,8 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
         }
         ctx.state_store.save_feature_blocks(blocks, last_sync_epoch=last_sync_epoch)
     except Exception:
-        pass
+        if getattr(ctx.state_store, "pair_scope", None):
+            raise
 
     emit("two:done", a=a, b=b, feature=feature,
          upd_to_A=eff_upd_A, upd_to_B=eff_upd_B,

--- a/cw_platform/orchestrator/_scope.py
+++ b/cw_platform/orchestrator/_scope.py
@@ -34,7 +34,7 @@ def scoped_file(root: Path, name: str, *, migrate: bool = True) -> Path:
         scoped = root / f"{p.stem}.{scope}{p.suffix}"
     else:
         scoped = root / f"{name}.{scope}"
-    if migrate:
+    if migrate and not scope.startswith("cw2_"):
         legacy = root / name
         if not scoped.exists() and legacy.exists():
             try:

--- a/cw_platform/orchestrator/_state_store.py
+++ b/cw_platform/orchestrator/_state_store.py
@@ -17,6 +17,12 @@ from ..local_db import watchlist_hide as sqlite_watchlist_hide
 @dataclass
 class StateStore:
     base_path: Path
+    pair_scope: str | None = None
+
+    def for_pair(self, scope: str) -> StateStore:
+        if not scope:
+            raise ValueError("Pair scope is required")
+        return StateStore(self.base_path, pair_scope=scope)
 
     @property
     def cw_state_dir(self) -> Path:
@@ -135,7 +141,7 @@ class StateStore:
         return state
 
     def load_state(self) -> dict[str, Any]:
-        state = sqlite_state.load_state(self.base_path)
+        state = sqlite_state.load_pair_state(self.base_path, self.pair_scope) if self.pair_scope else sqlite_state.load_state(self.base_path)
         policy = sqlite_manual_policy.load_policy(self.base_path)
         return self._merge_policy(state, policy)
 
@@ -174,7 +180,7 @@ class StateStore:
         recent_limit: int | None = None,
     ) -> dict[str, Any]:
         wanted = {str(feature or "").strip().lower() for feature in features or [] if str(feature or "").strip()}
-        state = sqlite_state.load_state_features(self.base_path, features, recent_limit=recent_limit)
+        state = sqlite_state.load_pair_state(self.base_path, self.pair_scope, wanted) if self.pair_scope else sqlite_state.load_state_features(self.base_path, features, recent_limit=recent_limit)
         policy = self._filter_policy_features(sqlite_manual_policy.load_policy(self.base_path), wanted)
         return self._merge_policy(state, policy)
 
@@ -191,6 +197,8 @@ class StateStore:
         return sqlite_state.last_sync_epoch(self.base_path)
 
     def save_state(self, data: Mapping[str, Any]) -> None:
+        if self.pair_scope:
+            raise ValueError("Pair state must be saved by feature")
         sqlite_state.save_state(self.base_path, data or {})
 
     def save_feature_baseline(
@@ -203,6 +211,9 @@ class StateStore:
         checkpoint: Any = None,
         last_sync_epoch: Any = None,
     ) -> None:
+        if self.pair_scope:
+            self.save_feature_blocks({(provider, instance, feature): {"baseline": {"items": items}, "checkpoint": checkpoint}}, last_sync_epoch=last_sync_epoch)
+            return
         sqlite_state.save_feature_baseline(
             self.base_path,
             provider=provider,
@@ -219,13 +230,19 @@ class StateStore:
         *,
         last_sync_epoch: Any = None,
     ) -> None:
-        sqlite_state.save_feature_blocks(self.base_path, blocks, last_sync_epoch=last_sync_epoch)
+        if self.pair_scope:
+            sqlite_state.save_pair_blocks(self.base_path, self.pair_scope, blocks, last_sync_epoch=last_sync_epoch)
+        else:
+            sqlite_state.save_feature_blocks(self.base_path, blocks, last_sync_epoch=last_sync_epoch)
 
     def set_last_sync_epoch(self, value: Any) -> None:
         sqlite_state.set_last_sync_epoch(self.base_path, value)
 
     def clear_state(self) -> None:
-        sqlite_state.clear_state(self.base_path)
+        if self.pair_scope:
+            sqlite_state.clear_pair_state(self.base_path, self.pair_scope)
+        else:
+            sqlite_state.clear_state(self.base_path)
 
     def load_tomb(self) -> dict[str, Any]:
         t = self._read(self.tomb, {"keys": {}, "pruned_at": None})

--- a/cw_platform/pair_scope.py
+++ b/cw_platform/pair_scope.py
@@ -1,0 +1,44 @@
+# cw_platform/pair_scope.py
+# CrossWatch - Sync Pair State Identity
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from .provider_instances import build_provider_config_view, normalize_instance_id
+
+
+def pair_feature_scope(config: Mapping[str, Any], pair: Mapping[str, Any], feature: str, index: int = 0) -> str:
+    def settings(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {str(k): settings(v) for k, v in value.items()
+                    if not str(k).startswith("_cw_") and not any(word in str(k).lower() for word in ("token", "password", "secret", "api_key"))
+                    and str(k) not in {"auth", "oauth", "label"}}
+        if isinstance(value, (list, tuple)):
+            return [settings(v) for v in value]
+        return value
+
+    endpoints = []
+    for side in ("source", "target"):
+        provider = str(pair.get(side) or "").upper().strip()
+        instance = normalize_instance_id(pair.get(f"{side}_instance"))
+        view = build_provider_config_view(dict(config), provider, instance)
+        block = dict(view.get(provider.lower()) or {})
+        for other in ("watchlist", "history", "ratings", "progress", "collection", "playlists"):
+            if other != feature:
+                block.pop(other, None)
+        endpoints.append([provider, instance, settings(block)])
+    payload = {
+        "pair": str(pair.get("id") or pair.get("pair_id") or index),
+        "profile": pair.get("profile_id"),
+        "mode": pair.get("mode", "one-way"),
+        "endpoints": endpoints,
+        "feature": feature,
+        "rules": settings((pair.get("features") or {}).get(feature)),
+        "overrides": settings(pair.get("providers") or {}),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return "cw2_" + hashlib.sha256(encoded).hexdigest()

--- a/tests/test_interactive_sync.py
+++ b/tests/test_interactive_sync.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 import pytest
 
 from cw_platform.orchestrator import Orchestrator
+from cw_platform.pair_scope import pair_feature_scope
 from cw_platform.orchestrator._interactive import InteractivePlan
 from test_orchestrator_dry_run_no_side_effects import FakeOps, _cfg, _install
 from test_playlists_pending_create import world
@@ -166,7 +167,7 @@ def test_two_way_preview_matches_normal_plan_for_tombstone_expiry(config_base, m
     cfg["pairs"][0]["features"]["watchlist"]["remove"] = True
     run(cfg, InteractivePlan(preview=False))
     store = StateStore(config_base)
-    tomb = {"keys": {"watchlist:DST-SRC|imdb:tt0000002": int(time.time()) - age_days * 86400}}
+    tomb = {"keys": {f"watchlist:{pair_feature_scope(cfg, cfg['pairs'][0], 'watchlist').upper()}|imdb:tt0000002": int(time.time()) - age_days * 86400}}
     store.save_tomb(tomb)
     before_tomb = deepcopy(store.load_tomb())
     plan = InteractivePlan()

--- a/tests/test_interactive_sync_features.py
+++ b/tests/test_interactive_sync_features.py
@@ -11,6 +11,7 @@ import pytest
 
 from cw_platform.id_map import canonical_key
 from cw_platform.orchestrator import Orchestrator
+from cw_platform.pair_scope import pair_feature_scope
 from cw_platform.orchestrator._interactive import InteractivePlan
 from cw_platform.orchestrator._state_store import StateStore
 from test_interactive_sync import item, run, setup_ops
@@ -49,7 +50,7 @@ def test_expired_deletion_does_not_change_preview_from_normal_plan(config_base, 
     cfg, src, dst = feature_setup(config_base, monkeypatch, feature, [common, extra], [common], mode)
     run(cfg, InteractivePlan(preview=False))
     store = StateStore(config_base)
-    store.save_tomb({"keys": {f"{feature}:DST-SRC|{canonical_key(extra)}": int(time.time()) - 31 * 86400}})
+    store.save_tomb({"keys": {f"{feature}:{pair_feature_scope(cfg, cfg['pairs'][0], feature).upper()}|{canonical_key(extra)}": int(time.time()) - 31 * 86400}})
     before = deepcopy(store.load_tomb())
     plan = InteractivePlan()
     run(cfg, plan)
@@ -93,7 +94,7 @@ def test_two_way_deletion_safety_matches_normal_plan(config_base, monkeypatch, f
     run(cfg, InteractivePlan(preview=False))
     store = StateStore(config_base)
     if scenario == "active_tomb":
-        store.save_tomb({"keys": {f"{feature}:DST-SRC|{canonical_key(extra)}": int(time.time()) - 86400}})
+        store.save_tomb({"keys": {f"{feature}:{pair_feature_scope(cfg, cfg['pairs'][0], feature).upper()}|{canonical_key(extra)}": int(time.time()) - 86400}})
     else:
         dst.index.pop(canonical_key(extra))
     if scenario == "removals_disabled":


### PR DESCRIPTION
# Pull request

## Change

- Isolate database baselines, checkpoints and orchestrator state per sync pair. 
- Existing pairs build fresh baselines on their next sync.

## Why

- Pairs sharing a provider instance should not affect each other’s sync decisions.

## Testing

- tests/test_interactive_sync_features.py

## Issue

Relates to #1022