### PR TITLE
Change: prevent provider state leaking between sync pairs

### DIFF
--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -288,6 +288,9 @@ def _adapter_identity(cfg: Mapping[str, Any]) -> str:
             return str(v or "")
 
     behavior = {
+        "pair_scope": cfg.get("_cw_pair_scope"),
+        "readonly": cfg.get("_cw_readonly"),
+        "planned_at": cfg.get("_cw_interactive_planned_at"),
         "fallback_GUID": pl.get("fallback_GUID") if "fallback_GUID" in pl else pl.get("fallback_guid"),
         "history": pl.get("history") if isinstance(pl.get("history"), Mapping) else {},
         "progress": pl.get("progress") if isinstance(pl.get("progress"), Mapping) else {},
@@ -1238,7 +1241,7 @@ class PLEXModule:
             strict_id_matching=coerce_bool(plex_cfg.get("strict_id_matching", False)),
         )
 
-        configure_plex_context(baseurl=self.cfg.baseurl or "", token=(self.cfg.pms_token or self.cfg.token or ""))
+        configure_plex_context(baseurl=self.cfg.baseurl or "", token=(self.cfg.pms_token or self.cfg.token or ""), account_token=self.cfg.token or "")
 
         if self.cfg.client_id:
             cid = str(self.cfg.client_id)
@@ -1602,7 +1605,10 @@ class _PlexOPS:
         with _ADAPTER_LOCK:
             ent = _ADAPTER_CACHE.get(key)
             if ent is not None and (now - ent[1]) < _ADAPTER_TTL:
-                return ent[0]
+                mod = ent[0]
+                server = getattr(getattr(mod, "client", None), "server", None)
+                configure_plex_context(baseurl=mod.cfg.baseurl or "", token=getattr(server, "_token", None) or mod.cfg.pms_token or mod.cfg.token or "", account_token=mod.cfg.token or "")
+                return mod
         mod = PLEXModule(cfg)
         try:
             setattr(mod, "_cw_home_scope_sticky", True)

--- a/providers/sync/_mod_STREMIO.py
+++ b/providers/sync/_mod_STREMIO.py
@@ -252,7 +252,8 @@ class _STREMIOOPS:
                             break
                 if isinstance(node, Mapping):
                     nodes.append(node)
-            nodes.append(stremio)
+            if instance_id == "default":
+                nodes.append(stremio)
 
             for node in nodes:
                 items = _baseline_items(node)

--- a/providers/sync/emby/_common.py
+++ b/providers/sync/emby/_common.py
@@ -52,7 +52,7 @@ def state_file(name: str) -> str:
         legacy = _STATE_DIR / name
 
     # Auto-migrate legacy unscoped state to scoped file
-    if (not _is_capture_mode()) and (not scoped.exists()) and legacy.exists():
+    if not str(_pair_scope() or "").startswith("cw2_") and (not _is_capture_mode()) and (not scoped.exists()) and legacy.exists():
         try:
             _STATE_DIR.mkdir(parents=True, exist_ok=True)
             shutil.copy2(legacy, scoped)
@@ -68,7 +68,7 @@ _BAD_NUM = re.compile(r"^\d{13,}$")
 CfgLike = Mapping[str, Any] | object
 
 # Adapter-scoped provider-index cache
-_PROVIDER_INDEX_CACHE: dict[tuple[int, tuple[str, ...]], tuple[float, dict[str, list[dict[str, Any]]]]] = {}
+_PROVIDER_INDEX_CACHE: dict[tuple[Any, ...], tuple[float, dict[str, list[dict[str, Any]]]]] = {}
 
 
 def _debug_level() -> str:
@@ -736,7 +736,7 @@ def build_provider_index(adapter: Any, *, feature: str | None = None) -> dict[st
 
 
 def provider_index(adapter: Any, *, ttl_sec: int = 300, force_refresh: bool = False, feature: str = "history") -> dict[str, list[dict[str, Any]]]:
-    key = (id(adapter), tuple(sorted(emby_selected_library_ids(adapter.cfg, feature))))
+    key = (id(adapter), scope_safe(), feature, tuple(sorted(emby_selected_library_ids(adapter.cfg, feature))))
     now = time.time()
     if not force_refresh:
         hit = _PROVIDER_INDEX_CACHE.get(key)
@@ -748,7 +748,7 @@ def provider_index(adapter: Any, *, ttl_sec: int = 300, force_refresh: bool = Fa
 
 
 def _cached_provider_index(adapter: Any, feature: str, *, ttl_sec: int = 300) -> dict[str, list[dict[str, Any]]] | None:
-    key = (id(adapter), tuple(sorted(emby_selected_library_ids(adapter.cfg, feature))))
+    key = (id(adapter), scope_safe(), feature, tuple(sorted(emby_selected_library_ids(adapter.cfg, feature))))
     hit = _PROVIDER_INDEX_CACHE.get(key)
     if hit and (time.time() - hit[0]) < max(1, int(ttl_sec)):
         return hit[1]

--- a/providers/sync/jellyfin/_common.py
+++ b/providers/sync/jellyfin/_common.py
@@ -63,7 +63,7 @@ def state_file(name: str) -> Path:
     else:
         scoped = STATE_DIR / f"{name}.{safe}"
         legacy = STATE_DIR / name
-    if (not _is_capture_mode()) and scoped != legacy and not scoped.exists() and legacy.exists():
+    if not str(_pair_scope() or "").startswith("cw2_") and (not _is_capture_mode()) and scoped != legacy and not scoped.exists() and legacy.exists():
         try:
             STATE_DIR.mkdir(parents=True, exist_ok=True)
             shutil.copy2(legacy, scoped)

--- a/providers/sync/kodi/_common.py
+++ b/providers/sync/kodi/_common.py
@@ -480,7 +480,9 @@ def _load_kodi_feature_baseline(adapter: Any, feature: str) -> Mapping[str, Mapp
         from cw_platform.config_base import CONFIG_BASE
         from cw_platform.orchestrator._state_store import StateStore
 
-        state = StateStore(Path(CONFIG_BASE())).load_state()
+        config = getattr(adapter, "config", None) or {}
+        scope = config.get("_cw_pair_scope") if isinstance(config, Mapping) else None
+        state = StateStore(Path(CONFIG_BASE()), pair_scope=scope).load_state_features({name})
         providers = state.get("providers") if isinstance(state, Mapping) else None
         providers = providers if isinstance(providers, Mapping) else {}
         kodi = providers.get("KODI") or providers.get("kodi")
@@ -493,7 +495,8 @@ def _load_kodi_feature_baseline(adapter: Any, feature: str) -> Mapping[str, Mapp
             inst_node = instances.get(instance_id) or instances.get(str(instance_id))
             if isinstance(inst_node, Mapping):
                 nodes.append(inst_node)
-        nodes.append(kodi)
+        if instance_id == "default":
+            nodes.append(kodi)
         for node in nodes:
             block = node.get(name)
             block = block if isinstance(block, Mapping) else {}

--- a/providers/sync/mdblist/_common.py
+++ b/providers/sync/mdblist/_common.py
@@ -150,6 +150,8 @@ def _legacy_path(path: Path) -> Path | None:
 
 
 def _migrate_legacy_json(path: Path) -> None:
+    if str(_pair_scope() or "").startswith("cw2_"):
+        return
     if path.exists():
         return
     if _is_capture_mode() or _pair_scope() is None:

--- a/providers/sync/plex/_common.py
+++ b/providers/sync/plex/_common.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 import re
 import shutil
@@ -58,7 +59,7 @@ def state_file(name: str) -> Path:
     p = Path(name)
     scoped = STATE_DIR / (f"{p.stem}.{safe}{p.suffix}" if p.suffix else f"{name}.{safe}")
     legacy = STATE_DIR / (f"{p.stem}{p.suffix}" if p.suffix else name)
-    if (not _is_capture_mode()) and (not scoped.exists()) and legacy.exists():
+    if not str(_pair_scope() or "").startswith("cw2_") and (not _is_capture_mode()) and (not scoped.exists()) and legacy.exists():
         try:
             STATE_DIR.mkdir(parents=True, exist_ok=True)
             shutil.copy2(legacy, scoped)
@@ -120,8 +121,8 @@ def configure_plex_context(
 ) -> None:
     _PLEX_CTX["baseurl"] = baseurl.rstrip("/") if isinstance(baseurl, str) else None
     _PLEX_CTX["token"] = token or None
-    if account_token:
-        _PLEX_CTX["account_token"] = account_token
+    if account_token is not None:
+        _PLEX_CTX["account_token"] = account_token or None
 
 
 DISCOVER = "https://discover.provider.plex.tv"
@@ -657,6 +658,7 @@ def server_find_rating_key_by_guid(srv: Any, guids: Iterable[str]) -> str | None
 
 
 _FBGUID_MEMO: dict[str, Any] = {}
+_FBGUID_MEMO_PATH: Path | None = None
 _FBGUID_NOHIT = "__NOHIT__"
 def _fbguid_cache_path() -> Path:
     return state_file("plex_fallback_memo.json")
@@ -714,10 +716,18 @@ def _fb_key_from_row(row: Any) -> str:
 
 
 def _fb_cache_load() -> dict[str, Any]:
+    global _FBGUID_MEMO_PATH, _FBGUID_MEMO_DIRTY
+    path = _fbguid_cache_path()
+    if path != _FBGUID_MEMO_PATH:
+        if _FBGUID_MEMO_DIRTY and _FBGUID_MEMO_PATH is not None:
+            _fb_cache_save()
+        _FBGUID_MEMO.clear()
+        _FBGUID_MEMO_DIRTY = False
+        _FBGUID_MEMO_PATH = path
     if _FBGUID_MEMO:
         return _FBGUID_MEMO
     try:
-        data = read_json(_fbguid_cache_path())
+        data = read_json(path)
         if isinstance(data, dict):
             _FBGUID_MEMO.update(data)
     except Exception:
@@ -727,7 +737,7 @@ def _fb_cache_load() -> dict[str, Any]:
 
 def _fb_cache_save() -> None:
     try:
-        write_json(_fbguid_cache_path(), _FBGUID_MEMO, indent=0, sort_keys=False, separators=(",", ":"))
+        write_json(_FBGUID_MEMO_PATH or _fbguid_cache_path(), _FBGUID_MEMO, indent=0, sort_keys=False, separators=(",", ":"))
     except Exception:
         pass
 
@@ -743,15 +753,22 @@ def _fb_cache_flush() -> None:
 _SHOW_PMS_GUID_CACHE: dict[str, dict[str, str]] = {}
 _EP_SHOW_IDS_CACHE: dict[str, dict[str, str]] = {}
 
+def _metadata_cache_key(rating_key: str, token: str | None = None, base: str | None = None) -> str:
+    identity = [scope_safe(), base or _PLEX_CTX.get("baseurl"), token or _PLEX_CTX.get("token"), _PLEX_CTX.get("account_token")]
+    digest = hashlib.sha256(json.dumps(identity, separators=(",", ":")).encode()).hexdigest()
+    return f"{digest}:{rating_key}"
+
+
 def _hydrate_show_ids_from_episode_rk(token: str | None, episode_rk: str | None) -> dict[str, str]:
     if not token or not episode_rk:
         return {}
     rk = str(episode_rk).strip()
     if not rk:
         return {}
+    key = _metadata_cache_key(rk, token)
 
-    if rk in _EP_SHOW_IDS_CACHE:
-        return dict(_EP_SHOW_IDS_CACHE[rk])
+    if key in _EP_SHOW_IDS_CACHE:
+        return dict(_EP_SHOW_IDS_CACHE[key])
 
     headers = plex_headers(token)
     headers["Accept"] = "application/json, application/xml;q=0.9,*/*;q=0.5"
@@ -791,12 +808,12 @@ def _hydrate_show_ids_from_episode_rk(token: str | None, episode_rk: str | None)
             if not r.ok:
                 continue
             ids = _parse(r)
-            _EP_SHOW_IDS_CACHE[rk] = dict(ids)
+            _EP_SHOW_IDS_CACHE[key] = dict(ids)
             return dict(ids)
         except Exception:
             continue
 
-    _EP_SHOW_IDS_CACHE[rk] = {}
+    _EP_SHOW_IDS_CACHE[key] = {}
     return {}
 
 
@@ -805,13 +822,14 @@ def _hydrate_show_ids_from_pms(obj: Any) -> dict[str, str]:
     if not rk:
         return {}
     rk = str(rk)
-    if rk in _SHOW_PMS_GUID_CACHE:
-        return _SHOW_PMS_GUID_CACHE[rk]
     srv = getattr(obj, "_server", None)
+    key = _metadata_cache_key(rk, getattr(srv, "token", None) or getattr(srv, "_token", None), _as_base_url(srv))
+    if key in _SHOW_PMS_GUID_CACHE:
+        return _SHOW_PMS_GUID_CACHE[key]
     base = _as_base_url(srv) or _PLEX_CTX["baseurl"]
     token = getattr(srv, "token", None) or getattr(srv, "_token", None) or _PLEX_CTX["token"]
     if not base or not token:
-        _SHOW_PMS_GUID_CACHE[rk] = {}
+        _SHOW_PMS_GUID_CACHE[key] = {}
         return {}
     url = f"{base}/library/metadata/{rk}?includeGuids=1"
     try:
@@ -845,11 +863,11 @@ def _hydrate_show_ids_from_pms(obj: Any) -> dict[str, str]:
                         if gid:
                             ids.update(ids_from_guid(str(gid)))
         ids = {k: v for k, v in ids.items() if v}
-        _SHOW_PMS_GUID_CACHE[rk] = ids
+        _SHOW_PMS_GUID_CACHE[key] = ids
         return ids
     except Exception as e:
         _warn("hydrate_show_pms_failed", rk=rk, error=str(e))
-        _SHOW_PMS_GUID_CACHE[rk] = {}
+        _SHOW_PMS_GUID_CACHE[key] = {}
         return {}
 
 
@@ -941,10 +959,11 @@ def hydrate_external_ids(token: str | None, rating_key: str | None) -> dict[str,
     rk = str(rating_key).strip()
     if not rk:
         return {}
+    key = _metadata_cache_key(rk, token)
     with _HYDRATE_LOCK:
-        if rk in _GUID_CACHE:
-            return _GUID_CACHE[rk]
-        if rk in _HYDRATE_404:
+        if key in _GUID_CACHE:
+            return _GUID_CACHE[key]
+        if key in _HYDRATE_404:
             return {}
 
     headers = plex_headers(token)
@@ -1002,7 +1021,7 @@ def hydrate_external_ids(token: str | None, rating_key: str | None) -> dict[str,
                 continue
             ids = _parse_response(r)
             with _HYDRATE_LOCK:
-                _GUID_CACHE[rk] = ids
+                _GUID_CACHE[key] = ids
             return ids
         except Exception as e:
             last_err = str(e)
@@ -1010,12 +1029,12 @@ def hydrate_external_ids(token: str | None, rating_key: str | None) -> dict[str,
 
     if meta_status == 404:
         with _HYDRATE_LOCK:
-            _HYDRATE_404.add(rk)
-            _GUID_CACHE[rk] = {}
+            _HYDRATE_404.add(key)
+            _GUID_CACHE[key] = {}
         return {}
 
     with _HYDRATE_LOCK:
-        _GUID_CACHE[rk] = {}
+        _GUID_CACHE[key] = {}
     if last_err:
         _warn("hydrate_failed", rk=rk, error=last_err, meta_status=meta_status)
     return {}
@@ -1345,7 +1364,7 @@ def _show_episode_cache_entry(show_obj: Any) -> dict[str, Any]:
     if rk:
         srv = getattr(show_obj, "_server", None) or getattr(show_obj, "server", None)
         sid = getattr(srv, "machineIdentifier", None) or _as_base_url(srv) or ""
-        key = f"{sid}:{rk}"
+        key = _metadata_cache_key(f"{sid}:{rk}", getattr(srv, "_token", None), _as_base_url(srv))
     now = time.monotonic()
     if key:
         entry = _SHOW_EPISODE_CACHE.get(key)
@@ -1864,7 +1883,7 @@ def minimal_from_history_row(
     allow_discover: bool = False,
 ) -> dict[str, Any] | None:
     global _FBGUID_MEMO_DIRTY
-    key = _fb_key_from_row(row)
+    key = _metadata_cache_key(_fb_key_from_row(row), token)
     memo = _fb_cache_load()
     hit = memo.get(key, None)
     if hit == _FBGUID_NOHIT and not allow_discover:

--- a/providers/sync/simkl/_common.py
+++ b/providers/sync/simkl/_common.py
@@ -116,6 +116,8 @@ def _legacy_path(path: Path) -> Path | None:
 
 
 def _migrate_legacy_json(path: Path) -> None:
+    if str(_pair_scope() or "").startswith("cw2_"):
+        return
     if path.exists():
         return
     if _is_capture_mode() or _pair_scope() is None:

--- a/providers/sync/stremio/_history.py
+++ b/providers/sync/stremio/_history.py
@@ -409,7 +409,7 @@ def _load_stremio_history_baseline(adapter: Any) -> dict[str, dict[str, Any]]:
         from cw_platform.orchestrator._state_store import StateStore
         from cw_platform.provider_instances import normalize_instance_id
 
-        state = StateStore(Path(CONFIG_BASE())).load_state_features({"history"}) or {}
+        state = StateStore(Path(CONFIG_BASE()), pair_scope=adapter.config.get("_cw_pair_scope")).load_state_features({"history"}) or {}
         providers = state.get("providers") if isinstance(state, Mapping) else None
         providers = providers if isinstance(providers, Mapping) else {}
         stremio = providers.get("STREMIO") or providers.get("stremio")
@@ -429,7 +429,8 @@ def _load_stremio_history_baseline(adapter: Any) -> dict[str, dict[str, Any]]:
                             break
                 if isinstance(node, Mapping):
                     nodes.append(node)
-        nodes.append(stremio)
+        if instance_id == "default":
+            nodes.append(stremio)
 
         for node in nodes:
             history = node.get("history") if isinstance(node, Mapping) else None

--- a/providers/sync/tautulli/_common.py
+++ b/providers/sync/tautulli/_common.py
@@ -49,7 +49,7 @@ def state_file(name: str) -> Path:
         legacy = STATE_DIR / name
 
     # Auto-migrate legacy state to scoped file
-    if (not _is_capture_mode()) and (not scoped.exists()) and legacy.exists():
+    if not str(_pair_scope() or "").startswith("cw2_") and (not _is_capture_mode()) and (not scoped.exists()) and legacy.exists():
         try:
             STATE_DIR.mkdir(parents=True, exist_ok=True)
             shutil.copy2(legacy, scoped)

--- a/providers/sync/tmdb/_common.py
+++ b/providers/sync/tmdb/_common.py
@@ -59,6 +59,8 @@ def _legacy_path(path: Path) -> Path | None:
 
 
 def _migrate_legacy_json(path: Path) -> None:
+    if str(_pair_scope() or "").startswith("cw2_"):
+        return
     if path.exists() or _pair_scope() is None:
         return
     legacy = _legacy_path(path)

--- a/tests/test_pair_state_isolation.py
+++ b/tests/test_pair_state_isolation.py
@@ -1,0 +1,265 @@
+# tests/test_pair_state_isolation.py
+# CrossWatch - Pair State Isolation Regression Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from copy import deepcopy
+import importlib
+import json
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+from cw_platform.orchestrator import Orchestrator
+from cw_platform.orchestrator._interactive import InteractivePlan
+from cw_platform.orchestrator._state_store import StateStore
+from cw_platform.pair_scope import pair_feature_scope
+from test_interactive_sync_features import FEATURES, feature_item, feature_setup
+
+
+def block(number, feature="watchlist", checkpoint=None):
+    return {"baseline": {"items": {f"imdb:tt{number:07}": feature_item(feature, number)}}, "checkpoint": checkpoint}
+
+
+@pytest.mark.parametrize("feature", [*FEATURES, "playlists"])
+def test_pair_database_roundtrip_does_not_inherit_or_replace_other_pairs(config_base, feature):
+    store = StateStore(config_base)
+    key = ("PLEX", "default", feature)
+    a, b = store.for_pair("pair-a"), store.for_pair("pair-b")
+    first, second = block(1), block(2)
+    first["checkpoint"], second["checkpoint"] = "a-cursor", "b-cursor"
+    store.save_feature_blocks({key: second})
+    assert not a.load_state()["providers"]
+    a.save_feature_blocks({key: first})
+    assert not b.load_state()["providers"]
+    b.save_feature_blocks({key: second})
+    for scoped, expected in ((a, first), (b, second)):
+        found = scoped.load_state_features({feature})["providers"]["PLEX"][feature]
+        assert found["checkpoint"] == expected["checkpoint"]
+        assert set(found["baseline"]["items"]) == set(expected["baseline"]["items"])
+    a.save_feature_blocks({key: {"baseline": {"items": {}}}})
+    assert not a.load_state()["providers"]["PLEX"][feature]["baseline"]["items"]
+    assert b.load_state()["providers"]["PLEX"][feature]["baseline"]["items"]
+
+
+@pytest.mark.parametrize("field", ["id", "profile_id", "source_instance", "target_instance", "mode"])
+def test_pair_scope_distinguishes_identity(config_base, field):
+    pair = dict(id="pair-a", source="PLEX", target="SIMKL", mode="one-way", profile_id="alice")
+    changed = {**pair, field: "different"}
+    assert pair_feature_scope({}, pair, "history") != pair_feature_scope({}, changed, "history")
+
+
+def test_whitelist_change_invalidates_only_affected_feature():
+    pair = dict(id="pair-a", source="PLEX", target="SIMKL", features={"history": {"libraries": {"PLEX": ["1"]}}})
+    other = deepcopy(pair)
+    other["features"]["history"]["libraries"]["PLEX"] = ["2"]
+    assert pair_feature_scope({}, pair, "history") != pair_feature_scope({}, other, "history")
+    assert pair_feature_scope({}, pair, "ratings") == pair_feature_scope({}, other, "ratings")
+    assert pair_feature_scope({"plex": {"token": "old"}}, pair, "history") == pair_feature_scope({"plex": {"token": "new"}}, pair, "history")
+
+
+@pytest.mark.parametrize("feature", FEATURES)
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_normal_and_interactive_execution_keep_pair_baselines_separate(config_base, monkeypatch, feature, mode):
+    common, extra = feature_item(feature, 1), feature_item(feature, 2)
+    cfg, src, dst = feature_setup(config_base, monkeypatch, feature, [common], [common], mode)
+    cfg["pairs"].append({**deepcopy(cfg["pairs"][0]), "id": "p2"})
+    store = StateStore(config_base)
+    first_scope = pair_feature_scope(cfg, cfg["pairs"][0], feature, 1)
+    second_scope = pair_feature_scope(cfg, cfg["pairs"][1], feature, 2)
+    first = store.for_pair(first_scope)
+    second = store.for_pair(second_scope)
+    first.save_feature_blocks({("SRC", "default", feature): block(1, feature), ("DST", "default", feature): block(1, feature)})
+    second.save_feature_blocks({("SRC", "default", feature): block(2, feature), ("DST", "default", feature): block(2, feature)})
+    before = second.load_state_features({feature})
+    src.index["imdb:tt0000002"] = extra
+    review = InteractivePlan()
+    Orchestrator(cfg, interactive=review).run(dry_run=True, pair_scope_ids=["p1"], write_state_json=False)
+    assert not src.add_calls and not dst.add_calls
+    assert any(row["operation"] == "add" and row["provider"] == "DST" for row in review.rows.values())
+    assert not any(row["operation"] == "remove" for row in review.rows.values())
+    result = Orchestrator(cfg).run(pair_scope_ids=["p1"])
+    assert not result["errors"]
+    assert dst.add_calls
+    assert second.load_state_features({feature})["providers"] == before["providers"]
+    assert "imdb:tt0000002" in first.load_state_features({feature})["providers"]["DST"][feature]["baseline"]["items"]
+
+
+@pytest.mark.parametrize("provider,feature", [("KODI", "ratings"), ("KODI", "progress"), ("STREMIO", "history")])
+def test_provider_baseline_reads_use_pair_and_exact_instance(config_base, provider, feature):
+    from providers.sync.kodi._common import _load_kodi_feature_baseline
+    from providers.sync.stremio._history import _load_stremio_history_baseline
+
+    store = StateStore(config_base)
+    store.save_feature_blocks({(provider, "default", feature): block(9, feature)})
+    store.for_pair("a").save_feature_blocks({(provider, "default", feature): block(1, feature)})
+    store.for_pair("b").save_feature_blocks({(provider, "default", feature): block(2, feature)})
+    def load(scope, instance):
+        adapter = SimpleNamespace(config={"_cw_pair_scope": scope}, instance_id=instance)
+        return _load_kodi_feature_baseline(adapter, feature) if provider == "KODI" else _load_stremio_history_baseline(adapter)
+    assert set(load("a", "default")) == {"imdb:tt0000001"}
+    assert set(load("b", "default")) == {"imdb:tt0000002"}
+    assert not load("new", "default")
+    assert not load("a", "unknown")
+
+
+def test_pair_storage_handles_50000_items_and_large_removal(config_base):
+    store = StateStore(config_base).for_pair("large")
+    items = {f"imdb:tt{number:07}": feature_item("history", number) for number in range(50000)}
+    key = ("PLEX", "default", "history")
+    store.save_feature_blocks({key: {"baseline": {"items": items}}})
+    assert len(store.load_state_features({"history"})["providers"]["PLEX"]["history"]["baseline"]["items"]) == 50000
+    store.save_feature_blocks({key: block(1, "history")})
+    assert set(store.load_state_features({"history"})["providers"]["PLEX"]["history"]["baseline"]["items"]) == {"imdb:tt0000001"}
+
+
+def test_two_way_pairs_in_one_run_do_not_share_previous_state(config_base, monkeypatch):
+    common, extra = feature_item("watchlist", 1), feature_item("watchlist", 2)
+    cfg, src, dst = feature_setup(config_base, monkeypatch, "watchlist", [common, extra], [common])
+    cfg["sync"]["allow_mass_delete"] = True
+    cfg["pairs"].append({**deepcopy(cfg["pairs"][0]), "id": "p2"})
+    one = block(1)
+    both = {"baseline": {"items": {**one["baseline"]["items"], **block(2)["baseline"]["items"]}}}
+    for pair, baseline in zip(cfg["pairs"], (one, both)):
+        store = StateStore(config_base).for_pair(pair_feature_scope(cfg, pair, "watchlist"))
+        store.save_feature_blocks({("SRC", "default", "watchlist"): baseline, ("DST", "default", "watchlist"): baseline})
+    events = []
+    result = Orchestrator(cfg, on_progress=lambda line: events.append(json.loads(line)) if line.startswith("{") else None).run(dry_run=True)
+    assert not result["errors"]
+    plans = [event for event in events if event.get("event") == "two:plan"]
+    assert len(plans) == 2
+    assert plans[0]["add_to_B"] == 1 and plans[0]["rem_from_A"] == 0
+    assert plans[1]["add_to_B"] == 0 and plans[1]["rem_from_A"] == 1
+
+
+def test_tombstones_and_retries_are_pair_scoped(config_base, monkeypatch):
+    from cw_platform.orchestrator._pairs import _pair_env
+    from cw_platform.orchestrator._tombstones import add_keys_for_feature, keys_for_feature
+    from cw_platform.orchestrator import _unresolved as unresolved
+
+    store = StateStore(config_base)
+    monkeypatch.setattr(unresolved, "STATE_DIR", config_base / ".cw_state")
+    a, b = "cw2_pair_a", "cw2_pair_b"
+    add_keys_for_feature(store, lambda *a, **k: None, "watchlist", ["imdb:tt0000001"], pair=a)
+    assert keys_for_feature(store, "watchlist", pair=a)
+    assert not keys_for_feature(store, "watchlist", pair=b)
+    with _pair_env({}, i=1, src="PLEX", dst="SIMKL", mode="two-way", feature="watchlist", scope=a):
+        unresolved.record_unresolved("SIMKL", "watchlist", [feature_item("watchlist", 1)], hint="test")
+        assert unresolved.load_unresolved_pending("SIMKL", "watchlist")
+    with _pair_env({}, i=2, src="PLEX", dst="SIMKL", mode="two-way", feature="watchlist", scope=b):
+        assert not unresolved.load_unresolved_pending("SIMKL", "watchlist")
+
+
+@pytest.mark.parametrize("provider", ["plex", "simkl", "trakt", "mdblist", "emby", "jellyfin", "tmdb", "tautulli", "anilist", "publicmetadb", "punchplay"])
+def test_new_pair_provider_cache_does_not_inherit_legacy_state(config_base, monkeypatch, provider):
+    module = importlib.import_module(f"providers.sync.{provider}._common")
+    root = config_base / "cache"
+    root.mkdir()
+    monkeypatch.setattr(module, "STATE_DIR" if hasattr(module, "STATE_DIR") else "_STATE_DIR", root)
+    (root / "audit.json").write_text('{"from_other_scope": true}', encoding="utf-8")
+    for key in ("CW_PAIR_KEY", "CW_PAIR_SCOPE", "CW_SYNC_PAIR", "CW_PAIR"):
+        monkeypatch.setenv(key, "cw2_new_pair")
+    path = module.state_file("audit.json")
+    reader = getattr(module, "read_json", None) or getattr(module, "_read_json", None)
+    if reader:
+        assert not reader(path)
+    assert not Path(path).exists()
+
+
+def test_plex_local_ids_do_not_collide_between_servers(monkeypatch):
+    from providers.sync.plex import _common as common
+
+    monkeypatch.setattr(common, "_SHOW_PMS_GUID_CACHE", {})
+    calls = []
+    def get(url, **kwargs):
+        calls.append(url)
+        number = "101" if "server-a" in url else "202"
+        return SimpleNamespace(ok=True, headers={"content-type": "application/json"}, json=lambda: {"MediaContainer": {"Metadata": [{"Guid": [{"id": f"tmdb://{number}"}]}]}})
+    monkeypatch.setattr(common.requests, "get", get)
+    for server, expected in (("a", "101"), ("b", "202"), ("a", "101")):
+        obj = SimpleNamespace(grandparentRatingKey="42", _server=SimpleNamespace(_baseurl=f"http://server-{server}", _token=f"fake-{server}"))
+        assert common._hydrate_show_ids_from_pms(obj)["tmdb"] == expected
+    assert len(calls) == 2
+
+
+def test_plex_fallback_cache_is_saved_to_its_own_pair(config_base, monkeypatch):
+    from cw_platform.orchestrator._pairs import _pair_env
+    from providers.sync.plex import _common as common
+
+    monkeypatch.setattr(common, "STATE_DIR", config_base)
+    monkeypatch.setattr(common, "_FBGUID_MEMO", {})
+    monkeypatch.setattr(common, "_FBGUID_MEMO_PATH", None)
+    monkeypatch.setattr(common, "_FBGUID_MEMO_DIRTY", False)
+    with _pair_env({}, i=1, src="PLEX", dst="SIMKL", mode="one-way", feature="history", scope="cw2_a"):
+        common._fb_cache_load()["only-a"] = {"title": "A"}
+        common._FBGUID_MEMO_DIRTY = True
+        path_a = common._fbguid_cache_path()
+    with _pair_env({}, i=2, src="PLEX", dst="SIMKL", mode="one-way", feature="history", scope="cw2_b"):
+        assert not common._fb_cache_load()
+        common._fb_cache_load()["only-b"] = {"title": "B"}
+        common._FBGUID_MEMO_DIRTY = True
+        common._fb_cache_flush()
+        assert set(json.loads(common._fbguid_cache_path().read_text("utf-8"))) == {"only-b"}
+    assert set(json.loads(path_a.read_text("utf-8"))) == {"only-a"}
+
+
+def test_clearing_one_pair_keeps_other_pairs_and_inventory(config_base):
+    store = StateStore(config_base)
+    for scope in ("a", "b"):
+        store.for_pair(scope).save_feature_blocks({("PLEX", "default", "watchlist"): block(1)})
+    store.for_pair("a").clear_state()
+    assert not store.for_pair("a").load_state()["providers"]
+    assert store.for_pair("b").load_state()["providers"]
+    assert store.load_state()["providers"]
+
+
+def test_schema_upgrade_preserves_inventory_without_assigning_it_to_a_pair(config_base):
+    from cw_platform.local_db import get_conn
+    from cw_platform.local_db.schema import apply_schema
+
+    store = StateStore(config_base)
+    store.save_feature_blocks({("PLEX", "default", "watchlist"): block(1)})
+    conn = get_conn(config_base)
+    with conn:
+        conn.execute("DROP TABLE pair_baseline_items")
+        conn.execute("DROP TABLE pair_feature_state")
+        conn.execute("DELETE FROM schema_migrations WHERE version=2")
+    apply_schema(conn)
+    apply_schema(conn)
+    assert store.load_state()["providers"]["PLEX"]["watchlist"]["baseline"]["items"]
+    assert not store.for_pair("new-pair").load_state()["providers"]
+    assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_same_plex_instance_with_different_libraries(config_base, monkeypatch, mode):
+    cfg, src, dst = feature_setup(config_base, monkeypatch, "history", [], [], mode)
+    src.provider, dst.provider = "PLEX", "SIMKL"
+    cfg["plex"] = {"history": {"libraries": ["1", "2"]}}
+    cfg["pairs"][0].update(source="PLEX", target="SIMKL")
+    cfg["pairs"][0]["features"]["history"]["libraries"] = {"PLEX": ["1"]}
+    cfg["pairs"].append({**deepcopy(cfg["pairs"][0]), "id": "p2"})
+    cfg["pairs"][1]["features"]["history"]["libraries"] = {"PLEX": ["2"]}
+    cfg["pairs"][1]["target"] = "TRAKT"
+    other_dst = deepcopy(dst)
+    other_dst.provider = "TRAKT"
+    monkeypatch.setattr("cw_platform.orchestrator.facade.load_sync_providers", lambda: {"PLEX": src, "SIMKL": dst, "TRAKT": other_dst})
+    def read(config, *, feature):
+        number = int(config["plex"][feature]["libraries"][0])
+        return {f"imdb:tt{number:07}": {**feature_item(feature, number), "library_id": str(number)}}
+    src.build_index = read
+    for pid in ("p1", "p2", "p1"):
+        assert not Orchestrator(cfg).run(pair_scope_ids=[pid])["errors"]
+    for pair, expected in zip(cfg["pairs"], (1, 2)):
+        state = StateStore(config_base).for_pair(pair_feature_scope(cfg, pair, "history")).load_state()
+        assert set(state["providers"]["PLEX"]["history"]["baseline"]["items"]) == {f"imdb:tt{expected:07}"}
+
+
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_pair_persistence_failure_is_reported(config_base, monkeypatch, mode):
+    cfg, _, _ = feature_setup(config_base, monkeypatch, "watchlist", [feature_item("watchlist", 1)], [], mode)
+    def fail(*args, **kwargs):
+        raise RuntimeError("Cannot persist pair baseline")
+    monkeypatch.setattr("cw_platform.local_db.state.save_pair_blocks", fail)
+    assert Orchestrator(cfg).run()["errors"] == 1


### PR DESCRIPTION
# Pull request

## Change

- Use pair-specific provider state and caches. 
- Prevent shared legacy state and Plex metadata from leaking between pairs or instances.

## Why

- Pairs with different accounts or library filters need separate sync state.

## Testing

- tests/test_pair_state_isolation.py

## Issue

Relates to #1022