### PR TITLE
Change: isolate Analyzer results per sync pair

### DIFF
--- a/assets/js/analyzer/index.js
+++ b/assets/js/analyzer/index.js
@@ -15,7 +15,7 @@ const icon = name => `<span class="material-symbols-rounded" aria-hidden="true">
 const array = value => Array.isArray(value) ? value : [];
 const human = value => String(value || "").replace(/[_-]+/g, " ").replace(/^./, c => c.toUpperCase());
 const severity = row => row.severity === "error" ? "error" : ["warn", "warning"].includes(row.severity) ? "warn" : "info";
-const identity = row => `${row.provider || ""}::${row.feature || ""}::${row.key || ""}`;
+const identity = row => `${row.pair_id || ""}::${row.provider || ""}::${row.feature || ""}::${row.key || ""}`;
 const label = row => {
   const item = row.item || row;
   const title = row.title || row.item_title || item.title || row.series_title || item.series_title || row.message || row.key || array(row.keys)[0] || "Untitled item";
@@ -137,7 +137,7 @@ const Analyzer = {
     const $ = selector => root.querySelector(selector);
     const lifetime = new AbortController();
     let analysisController, systemController, pageController, detailController, searchTimer;
-    let pairs = [], problems = [], pending = [], system = [], exclusions = [];
+    let pairs = [], problems = [], pending = [], system = [], exclusions = [], snapshotGaps = [];
     let PROFILE_LABELS = {}, activity = {}, status = {};
     let view = "missing", analysisState = "loading", systemState = "loading";
     let analysisError = "", systemError = "", checked = "", pageError = "";
@@ -160,9 +160,9 @@ const Analyzer = {
       if (activeCleanup === cleanup) activeCleanup = null;
     };
     activeCleanup = cleanup;
-    const scoped = path => {
+    const scoped = (path, pairId = "") => {
       const url = new URL(path, location.origin);
-      const ids = $("#an-pair").value ? [$("#an-pair").value] : pairs.map(p => p.id);
+      const ids = pairId ? [pairId] : $("#an-pair").value ? [$("#an-pair").value] : pairs.map(p => p.id);
       if (ids.length) url.searchParams.set("pairs", ids.join(","));
       return url.pathname + url.search;
     };
@@ -218,6 +218,7 @@ const Analyzer = {
       }
       $('[data-view="system"]').classList.toggle("has-errors", errors > 0 || systemState === "error");
       const alerts = [];
+      if (analysisState === "ready" && snapshotGaps.length) alerts.push(`<div class="an-notice" role="status">${icon("info")}<div><strong>Some pair comparisons are unavailable</strong><p>Run the affected pair to read both providers. An unread snapshot is not treated as an empty library.</p>${snapshotGaps.slice(0, 5).map(row => `<p>${esc(providerName(row.source))} → ${esc(providerName(row.target))} · ${esc(human(row.feature))}: no saved snapshot for ${esc(array(row.missing).map(providerName).join(", "))}.</p>`).join("")}${snapshotGaps.length > 5 ? `<p>${snapshotGaps.length - 5} more comparisons need snapshot data.</p>` : ""}</div></div>`);
       if (analysisState === "error") alerts.push(`<div class="an-notice an-error" role="alert">${icon("error")}<div><strong>Item analysis could not finish</strong><p>${esc(analysisError)}</p></div><button type="button" class="an-button" data-retry="analysis">Retry</button></div>`);
       if (systemState === "error") alerts.push(`<div class="an-notice an-error" role="alert">${icon("error")}<div><strong>System health could not be checked</strong><p>${esc(systemError)} The result is unknown.</p></div><button type="button" class="an-button" data-retry="system">Retry</button></div>`);
       if (errors || warnings) alerts.push(`<div class="an-notice ${errors ? "an-error" : "an-warning"}">${icon(errors ? "error" : "warning")}<div><strong>${errors ? `${errors} system failure${errors === 1 ? "" : "s"}` : `${warnings} system warning${warnings === 1 ? "" : "s"}`} need${(errors || warnings) === 1 ? "s" : ""} attention</strong><p>${errors && warnings ? `${warnings} warning${warnings === 1 ? "" : "s"} also found. ` : ""}Review provider and saved-state diagnostics.</p></div><button type="button" class="an-button" data-open-system>View findings</button></div>`);
@@ -271,6 +272,11 @@ const Analyzer = {
           title = loading ? "Analysis in progress" : failed ? "Results unavailable" : ({ missing: "No missing items found", pending: "No pending retries", blocked: "No blocked items", system: "No system findings", all: "No saved items" })[view];
           message = loading ? "Results will appear here as the checks finish." : failed ? "Retry the failed check using the message above." : view === "system" && systemState === "restricted" ? "Global system diagnostics are available to administrators. Pair findings remain visible here." : view === "missing" ? "No presence differences were found in the saved snapshots for these pairs." : "There is nothing to review in this view for the current scope.";
           symbol = loading ? "progress_activity" : failed ? "error" : "check_circle";
+          if (!loading && !failed && view === "missing" && snapshotGaps.length) {
+            title = "Comparison incomplete";
+            message = "No missing items were found where both snapshots are available. Run the affected pairs to check the remaining comparisons.";
+            symbol = "info";
+          }
           if (!loading && !failed && view !== "system" && !pairs.length) {
             title = "No active sync pairs";
             message = "Create or enable a pair in Synchronization, then run it to create saved snapshots.";
@@ -396,7 +402,7 @@ const Analyzer = {
       if (!mismatch || detailCache.has(identity(row))) return;
       try {
         const params = new URLSearchParams({ provider: row.provider, feature: row.feature, key: row.key });
-        const detail = await requestJSON(scoped(`/api/analyzer/detail?${params}`), controller.signal);
+        const detail = await requestJSON(scoped(`/api/analyzer/detail?${params}`, row.pair_id), controller.signal);
         if (controller.signal.aborted || lifetime.signal.aborted) return;
         if (detailCache.size >= 500) detailCache.clear();
         detailCache.set(identity(row), detail);
@@ -416,6 +422,7 @@ const Analyzer = {
       problems = [];
       pending = [];
       exclusions = [];
+      snapshotGaps = [];
       missingIndex.clear();
       blockedIndex.clear();
       indexResultGroups();
@@ -444,6 +451,7 @@ const Analyzer = {
         problems = array(meta.problems);
         pending = array(meta.attention?.rows).filter(row => row.unresolved).map(row => ({ ...row.item, ...row, key: row.key || array(row.keys)[0] }));
         exclusions = array(meta.pair_exclusions);
+        snapshotGaps = array(meta.snapshot_gaps);
         missingIndex = new Map(problems.filter(p => p.type === "missing_peer").map(p => [identity(p), p]));
         blockedIndex = new Map(problems.filter(p => p.type === "blocked_manual").map(p => [identity(p), p]));
         indexResultGroups();

--- a/services/analyzer.py
+++ b/services/analyzer.py
@@ -20,6 +20,8 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from cw_platform.access_policy import filter_pairs_for_user, pair_ids_for_user, request_user
+from cw_platform.pair_scope import pair_feature_scope
+from cw_platform.orchestrator._state_store import StateStore
 from cw_platform.anime_mapping.history_coords import (
     HistoryCoordinateAliases,
     build_history_coordinate_aliases,
@@ -332,7 +334,7 @@ def _pair_id(pair: Mapping[str, Any]) -> str:
 def _config_for_pairs(cfg: dict[str, Any], pairs_raw: str | None) -> dict[str, Any]:
     """Return a shallow config view containing only explicitly selected pairs."""
     selected = set(_parse_pairs_raw(pairs_raw))
-    if not selected:
+    if not selected and not str(pairs_raw or "").startswith(_STRICT_PAIRS_PREFIX):
         return cfg
     out = dict(cfg or {})
     out["_analyzer_pairs_selected"] = True
@@ -458,23 +460,26 @@ def _load_state_at(path: Path) -> dict[str, Any]:
         raise HTTPException(500, f"Failed to parse {path.name}")
 
 
+def _analysis_pair_ids(pairs_raw: str | None) -> list[str]:
+    cfg = _config_for_pairs(_cfg(), pairs_raw)
+    return [_pair_id(pair) for pair in cfg.get("pairs") or [] if isinstance(pair, Mapping) and _pair_id(pair) and pair.get("enabled") is not False]
+
+
 def _load_state_handles(pairs_raw: str | None, features: Iterable[str] | None = None) -> list[dict[str, Any]]:
-    strict_pairs = str(pairs_raw or "").startswith(_STRICT_PAIRS_PREFIX)
-    pairs = _parse_pairs_raw(pairs_raw)
+    cfg = _cfg()
+    selected = set(_analysis_pair_ids(pairs_raw))
     handles: list[dict[str, Any]] = []
-    if pairs:
-        for pid in pairs:
-            safe = _safe_scope(pid)
-            cand = _state_candidates(safe)
-            legacy = _legacy_state_token(pid)
-            if legacy and legacy != safe:
-                cand += _state_candidates(legacy)
-            path = _pick_existing(cand)
-            if path is None:
-                continue
-            handles.append({"pair": pid, "safe": safe, "path": path, "state": _load_state_at(path)})
-        if handles:
-            return handles
+    wanted = _feature_set(features)
+    for index, pair in enumerate(cfg.get("pairs") or [], 1):
+        if not isinstance(pair, Mapping) or _pair_id(pair) not in selected:
+            continue
+        pid = _pair_id(pair)
+        for feature in wanted:
+            scope = pair_feature_scope(cfg, pair, feature, index)
+            state = StateStore(CONFIG_DIR).for_pair(scope).load_state_features({feature})
+            handles.append({"pair": pid, "safe": scope, "state": state})
+    if handles or cfg.get("pairs") or str(pairs_raw or "").startswith(_STRICT_PAIRS_PREFIX):
+        return handles
     state = _load_main_state(features)
     if state.get("providers") or _main_state_db_exists():
         return [{"pair": None, "safe": None, "main": True, "state": state}]
@@ -486,7 +491,7 @@ def _merge_states(handles: list[dict[str, Any]], features: Iterable[str] | None 
     wanted = _feature_set(features)
 
     def merge_feat(dst_blk: dict[str, Any], src_blk: dict[str, Any], feat: str) -> None:
-        items = (((src_blk.get(feat) or {}).get("baseline") or {}).get("items") or {})
+        items = ((src_blk.get(feat) or {}).get("baseline") or {}).get("items")
         if not isinstance(items, dict):
             return
         mb = dst_blk.setdefault(feat, {}).setdefault("baseline", {}).setdefault("items", {})
@@ -576,6 +581,12 @@ def _save_state_handle(
             _save_main_feature(state, provider, feature)
             return
         raise HTTPException(500, "Analyzer main DB writes require a provider and feature")
+    if handle.get("pair") and handle.get("safe"):
+        block = _feature_block(state, provider, feature) if provider and feature else None
+        if block is None:
+            raise HTTPException(400, "A pair feature is required")
+        base, instance, name, value = block
+        StateStore(CONFIG_DIR).for_pair(handle["safe"]).save_feature_blocks({(base, instance, name): value})
         return
     path = handle.get("path")
     if not isinstance(path, Path):
@@ -849,7 +860,7 @@ def _read_cw_state(allowed_scopes: set[str] | None = None) -> dict[str, Any]:
 
     scopes = set(allowed_scopes or [])
     for p in sorted(CWS_DIR.glob("*.json")):
-        if scopes:
+        if allowed_scopes is not None:
             if not any(p.name.endswith(f".{safe}.json") for safe in scopes):
                 continue
         try:
@@ -2263,21 +2274,9 @@ def _alias_destination_key(rec: Mapping[str, Any]) -> str:
     return event.split("@", 1)[0] if event else ""
 
 
-def _pair_alias_scope_key(pair: Mapping[str, Any], index: int, mode: str, src: str, dst: str, si: str, ti: str) -> str:
-    mode_norm = "two-way" if str(mode or "").strip().lower() in (
-        "two-way", "two_way", "two way", "bi", "both", "mirror", "two"
-    ) else "one-way"
-    a = f"{src}#{si}"
-    b = f"{dst}#{ti}"
-    base = "-".join(sorted([a, b])) if mode_norm == "two-way" else f"{a}-{b}"
-    raw_id = pair.get("id") or pair.get("pair_id") or pair.get("name") or pair.get("label") or ""
-    pid = str(raw_id).strip() or str(index)
-    return f"{mode_norm}:{base}:{pid}"
-
-
 def _expected_alias_scopes(cfg: Mapping[str, Any]) -> dict[str, tuple[str, str]]:
     out: dict[str, tuple[str, str]] = {}
-    for index, pair in enumerate(cfg.get("pairs") or []):
+    for index, pair in enumerate(cfg.get("pairs") or [], 1):
         if not isinstance(pair, Mapping) or pair.get("enabled") is False:
             continue
         src = str(pair.get("src") or pair.get("source") or "").upper().strip()
@@ -2287,11 +2286,11 @@ def _expected_alias_scopes(cfg: Mapping[str, Any]) -> dict[str, tuple[str, str]]
         si = normalize_instance_id(pair.get("src_instance") or pair.get("source_instance"))
         ti = normalize_instance_id(pair.get("dst_instance") or pair.get("target_instance"))
         mode = str(pair.get("mode") or "one-way")
-        key = _pair_alias_scope_key(pair, index, mode, src, dst, si, ti)
+        key = pair_feature_scope(cfg, pair, "history", index)
         src_tok = _prov_token(src, si)
         dst_tok = _prov_token(dst, ti)
         out[f"{key}|{src}>{dst}"] = (src_tok, dst_tok)
-        if key.startswith("two-way:"):
+        if mode.lower() in {"two-way", "two_way", "two way", "bi", "both", "mirror", "two"}:
             out[f"{key}|{dst}>{src}"] = (dst_tok, src_tok)
     return out
 
@@ -2605,7 +2604,8 @@ def _eligible_targets(ctx: _AnalysisContext, prov: str, feat: str, item: dict[st
     return [
         dst
         for dst in ctx.pairs.get((prov_key, feat_key), [])
-        if _passes_pair_lib_filter(ctx.pair_libs, prov_key, feat_key, dst, item)
+        if _bucket(ctx.state, dst, feat_key) is not None
+        and _passes_pair_lib_filter(ctx.pair_libs, prov_key, feat_key, dst, item)
         and _passes_pair_type_filter(ctx.pair_types, prov_key, feat_key, dst, item)
     ]
 
@@ -2673,6 +2673,8 @@ def _pair_stats(
     for (prov, feat), targets in analysis.pairs.items():
         src_items = _bucket(s, prov, feat) or {}
         for dst in targets:
+            if _bucket(s, prov, feat) is None or _bucket(s, dst, feat) is None:
+                continue
             total = 0
             synced = 0
             anime_synced = 0
@@ -2702,6 +2704,19 @@ def _pair_stats(
                 rec["anime_synced"] = anime_synced
             stats.append(rec)
     return stats
+
+
+def _snapshot_gaps(ctx: _AnalysisContext) -> list[dict[str, Any]]:
+    gaps = []
+    seen = set()
+    for (src, feature), targets in ctx.pairs.items():
+        for dst in targets:
+            route = (tuple(sorted((src, dst))), feature)
+            missing = [provider for provider in (src, dst) if _bucket(ctx.state, provider, feature) is None]
+            if missing and route not in seen:
+                seen.add(route)
+                gaps.append(dict(source=src, target=dst, feature=feature, missing=missing))
+    return gaps
 
 
 def _pair_exclusions(
@@ -2964,6 +2979,8 @@ def _history_normalization_issues(s: dict[str, Any], cfg: dict[str, Any] | None 
         for dst in targets:
             b = _norm_prov_token(dst)
             if not b or a == b:
+                continue
+            if _bucket(s, a, "history") is None or _bucket(s, b, "history") is None:
                 continue
 
             key = (a, b) if a <= b else (b, a)
@@ -4209,13 +4226,16 @@ def _path_stamp(path: Path) -> tuple[str, int, int]:
 
 def _state_signature(pairs_raw: str | None) -> tuple[Any, ...]:
     artifacts = sorted(CWS_DIR.glob("*.json")) if CWS_DIR.exists() else []
+    artifacts.extend(sorted(CONFIG_DIR.glob("state.*.json")))
     try:
         from cw_platform.local_db import crosswatch_db_path
 
-        db_stamp = _path_stamp(crosswatch_db_path(CONFIG_DIR))
+        db_path = crosswatch_db_path(CONFIG_DIR)
+        db_stamp = (_path_stamp(db_path), _path_stamp(Path(str(db_path) + "-wal")))
     except Exception:
         db_stamp = ("local-db", 0, 0)
     return (
+        str(pairs_raw or "").startswith(_STRICT_PAIRS_PREFIX),
         tuple(_parse_pairs_raw(pairs_raw)),
         _path_stamp(CONFIG_DIR / "config.json"),
         db_stamp,
@@ -4250,8 +4270,10 @@ def _load_analysis_state(pairs_raw: str | None) -> tuple[dict[str, Any], _Analys
     selected_cfg = _config_for_pairs(_cfg(), pairs_raw)
     context = _analysis_context(state, selected_cfg)
     t2 = time.perf_counter()
-    scopes = {h.get("safe") for h in handles if h.get("safe")}
-    allowed = set(x for x in scopes if isinstance(x, str) and x) or None
+    selected = _analysis_pair_ids(pairs_raw)
+    allowed = set() if selected or str(pairs_raw or "").startswith(_STRICT_PAIRS_PREFIX) else None
+    if allowed is not None:
+        allowed.update(str(handle["safe"]) for handle in handles if handle.get("safe"))
     entry = (state, context, allowed, selected_cfg)
     with _STATE_CACHE_LOCK:
         _STATE_CACHE.clear()
@@ -4265,8 +4287,14 @@ def _cached_scoped_rows(pairs_raw: str | None) -> tuple[list[dict[str, Any]], di
         cached = _SCOPED_ROWS_CACHE.get(signature)
         if cached is not None:
             return cached
-    state, _context, _allowed, selected_cfg, _timings = _load_analysis_state(pairs_raw)
-    rows = _scoped_item_rows(state, selected_cfg)
+    ids = _analysis_pair_ids(pairs_raw)
+    if len(ids) > 1:
+        rows = [row for pid in ids for row in _cached_scoped_rows(pid)[0]]
+    else:
+        state, _context, _allowed, selected_cfg, _timings = _load_analysis_state(pairs_raw)
+        rows = _scoped_item_rows(state, selected_cfg)
+        if ids:
+            rows = [{**row, "pair_id": ids[0]} for row in rows]
     result = (rows, _counts_from_rows(rows))
     with _SCOPED_ROWS_CACHE_LOCK:
         _SCOPED_ROWS_CACHE.clear()
@@ -4287,6 +4315,24 @@ def _cached_analysis(pairs_raw: str | None, *, include_system: bool = False, inc
             if cached is not None:
                 return _with_cache_hit(cached)
 
+        ids = _analysis_pair_ids(pairs_raw)
+        if len(ids) > 1:
+            results = [_cached_analysis(pid, include_hints=include_hints) for pid in ids]
+            problems = [row for result in results for row in result["problems"]]
+            if include_system:
+                problems.extend(_cached_system()["problems"])
+            attention_rows = [row for result in results for row in result["attention"]["rows"]]
+            counts = {key: sum(result["attention"]["counts"].get(key, 0) for result in results)
+                      for key in ("current_mismatch", "pending_retry", "blocked", "total")}
+            result = {"problems": problems, "summary": _diagnostic_summary(problems),
+                      "attention": {"rows": attention_rows, "counts": counts},
+                      "timings_ms": {"cache_hit": False}}
+            for key in ("pair_stats", "pair_exclusions", "snapshot_gaps"):
+                result[key] = [row for part in results for row in part[key]]
+            with _ANALYSIS_CACHE_LOCK:
+                _ANALYSIS_CACHE[signature] = result
+            return result
+
         started = time.perf_counter()
         state, context, allowed, selected_cfg, st_tim = _load_analysis_state(pairs_raw)
         inner: dict[str, Any] = {}
@@ -4299,6 +4345,9 @@ def _cached_analysis(pairs_raw: str | None, *, include_system: bool = False, inc
             attention = _attention_from_analysis(problems, allowed, context)
         except Exception:
             attention = {"rows": [], "counts": {"current_mismatch": 0, "pending_retry": 0, "blocked": 0, "total": 0}}
+        if ids:
+            problems = [{**row, "pair_id": ids[0]} for row in problems]
+            attention["rows"] = [{**row, "pair_id": ids[0]} for row in attention["rows"]]
         completed = time.perf_counter()
         timings = {
             "state_load": st_tim.get("state_load", 0.0),
@@ -4316,6 +4365,7 @@ def _cached_analysis(pairs_raw: str | None, *, include_system: bool = False, inc
             "summary": _diagnostic_summary(problems),
             "pair_stats": stats,
             "pair_exclusions": exclusions,
+            "snapshot_gaps": _snapshot_gaps(context),
             "attention": attention,
             "timings_ms": timings,
         }
@@ -4365,6 +4415,14 @@ def _cached_system(refresh: bool = False) -> dict[str, Any]:
 
 
 def _detail_for_item(pairs_raw: str | None, provider: str, feature: str, key: str) -> dict[str, Any]:
+    ids = _analysis_pair_ids(pairs_raw)
+    if len(ids) > 1:
+        parts = [(pid, _detail_for_item(pid, provider, feature, key)) for pid in ids]
+        return {
+            "targets": sorted({target for _, part in parts for target in part["targets"]}),
+            "hints": [{**hint, "pair_id": pid} for pid, part in parts for hint in part["hints"]],
+            "target_show_info": [{**hint, "pair_id": pid} for pid, part in parts for hint in part["target_show_info"]],
+        }
     state, context, allowed, _cfg_sel, _tim = _load_analysis_state(pairs_raw)
     prov_key = _norm_prov_token(provider)
     feat_key = str(feature or "").lower()
@@ -4470,13 +4528,8 @@ def api_pair_activity(request: Request = cast(Request, None)) -> dict[str, Any]:
         pid = str(pair.get("id") or "").strip()
         if not pid:
             continue
-        path = _pick_existing(_state_candidates(_safe_scope_for_pair(pair)))
-        mtime = 0
-        if path is not None:
-            try:
-                mtime = int(path.stat().st_mtime_ns)
-            except OSError:
-                mtime = 0
+        handles = _load_state_handles(pid, _ANALYZER_FEATURES)
+        mtime = max((int((handle["state"].get("last_sync_epoch") or 0) * 1_000_000_000) for handle in handles), default=0)
         out.append({"id": pid, "last_run_ns": mtime})
     return {"pairs": out}
 
@@ -4499,9 +4552,9 @@ def api_cw_state(pairs: str | None = None, request: Request = cast(Request, None
     try:
         handles = _load_state_handles(pairs)
         scopes = {h.get("safe") for h in handles if h.get("safe")}
-        allowed = set(x for x in scopes if isinstance(x, str) and x) or None
+        allowed = set(x for x in scopes if isinstance(x, str) and x)
     except HTTPException:
-        allowed = None
+        allowed = set()
     return _read_cw_state(allowed)
 
 @router.post("/analyzer/suggest", response_class=JSONResponse)

--- a/tests/test_analyzer_history_aliases.py
+++ b/tests/test_analyzer_history_aliases.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 import services.analyzer as A
+from cw_platform.pair_scope import pair_feature_scope
 
 
 WATCHED = "2024-01-01T00:00:00Z"
@@ -54,8 +55,11 @@ def _cfg(src="SIMKL", dst="TRAKT", src_inst="SIMKL-P01", dst_inst="TRAKT-P01", r
     return {"pairs": [pair]}
 
 
-def _write_alias(tmp_path: Path, items, *, scope="one-way:SIMKL#SIMKL-P01-TRAKT#TRAKT-P01:p1|SIMKL>TRAKT",
+def _write_alias(tmp_path: Path, items, *, scope=None,
                  name="trakt_history.pair_alias.one-way_SIMKL_SIMKL-P01-TRAKT_TRAKT-P01_p1.json"):
+    if scope is None:
+        cfg = _cfg()
+        scope = pair_feature_scope(cfg, cfg["pairs"][0], "history") + "|SIMKL>TRAKT"
     (tmp_path / name).write_text(json.dumps({"scope": scope, "items": items}), encoding="utf-8")
 
 

--- a/tests/test_analyzer_pair_scope.py
+++ b/tests/test_analyzer_pair_scope.py
@@ -1,0 +1,173 @@
+# tests/test_analyzer_pair_scope.py
+# CrossWatch - Analyzer Pair Scope Regression Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import services.analyzer as A
+from cw_platform.orchestrator._state_store import StateStore
+from cw_platform.pair_scope import pair_feature_scope
+
+
+@pytest.fixture
+def pair_state(config_base, monkeypatch):
+    monkeypatch.setattr(A, "CONFIG_DIR", config_base)
+    monkeypatch.setattr(A, "CWS_DIR", config_base / ".cw_state")
+    for cache in ("_STATE_CACHE", "_SCOPED_ROWS_CACHE", "_ANALYSIS_CACHE"):
+        monkeypatch.setattr(A, cache, {})
+    cfg = {"pairs": [dict(id=pid, source="PLEX", target=target, enabled=True, mode="two-way",
+                          features={feature: True for feature in A._ANALYZER_FEATURES})
+                     for pid, target in (("plex-simkl", "SIMKL"), ("plex-mdblist", "MDBLIST"))]}
+    monkeypatch.setattr(A, "_cfg", lambda: cfg)
+    return StateStore(config_base), cfg
+
+
+def save_pair(store, cfg, pid, blocks):
+    pair = next(pair for pair in cfg["pairs"] if pair["id"] == pid)
+    for feature in {key[2] for key in blocks}:
+        scope = pair_feature_scope(cfg, pair, feature)
+        store.for_pair(scope).save_feature_blocks({key: value for key, value in blocks.items() if key[2] == feature})
+
+
+@pytest.mark.parametrize("feature", A._ANALYZER_FEATURES)
+@pytest.mark.parametrize("destination", ["unread", "empty", "present"])
+def test_shared_source_does_not_make_unread_destination_missing(pair_state, feature, destination):
+    store, _cfg = pair_state
+    item = dict(type="movie", title="Example", ids={"tmdb": "1"})
+    block = {"baseline": {"items": {"tmdb:1": item}}}
+    blocks = {("PLEX", "default", feature): block, ("SIMKL", "default", feature): block}
+    if destination != "unread":
+        blocks[("MDBLIST", "default", feature)] = block if destination == "present" else {"baseline": {"items": {}}}
+    save_pair(store, _cfg, "plex-simkl", {key: value for key, value in blocks.items() if key[0] != "MDBLIST"})
+    save_pair(store, _cfg, "plex-mdblist", {key: value for key, value in blocks.items() if key[0] != "SIMKL"})
+    assert not A._cached_analysis("plex-simkl")["attention"]["counts"]["current_mismatch"]
+    result = A._cached_analysis("plex-mdblist")
+    missing = [row for row in result["problems"] if row["type"] == "missing_peer"]
+    assert len(missing) == (1 if destination == "empty" else 0)
+    assert all(row["targets"] == ["MDBLIST"] for row in missing)
+    gaps = [row for row in result["snapshot_gaps"] if row["feature"] == feature]
+    assert bool(gaps) == (destination == "unread")
+    if gaps:
+        assert gaps[0]["missing"] == ["MDBLIST"]
+        assert not [row for row in result["pair_stats"] if row["feature"] == feature]
+    detail = A._detail_for_item("plex-mdblist", "PLEX", feature, "tmdb:1")
+    assert detail["targets"] == (["MDBLIST"] if destination == "empty" else [])
+
+
+@pytest.mark.parametrize("feature", A._ANALYZER_FEATURES)
+@pytest.mark.parametrize("scope_format", ["legacy", "runtime", "isolated"])
+def test_retry_records_stay_with_their_pair_on_database_fallback(pair_state, feature, scope_format):
+    from cw_platform.orchestrator._pairs import _pair_scope_key
+
+    store, _cfg = pair_state
+    store.save_feature_blocks({("PLEX", "default", feature): {"baseline": {"items": {}}}})
+    scope = "plex-simkl" if scope_format == "legacy" else A._safe_scope(_pair_scope_key(_cfg["pairs"][0], i=0, src="PLEX", dst="SIMKL", mode="two-way"))
+    if scope_format == "isolated":
+        scope = pair_feature_scope(_cfg, _cfg["pairs"][0], feature)
+    store.cw_state_dir.joinpath(f"PLEX_{feature}.unresolved.{scope}.json").write_text(json.dumps({
+        "tmdb:1": {"item": {"type": "movie", "title": "Failed item", "ids": {"tmdb": "1"}}, "reason": "not_found"}
+    }), encoding="utf-8")
+    assert A._cached_analysis("plex-simkl")["attention"]["counts"]["pending_retry"] == int(scope_format == "isolated")
+    assert A._cached_analysis("plex-mdblist")["attention"]["counts"]["pending_retry"] == 0
+    assert A._cached_analysis("plex-simkl,plex-mdblist")["attention"]["counts"]["pending_retry"] == int(scope_format == "isolated")
+
+
+def test_unknown_instance_does_not_use_default_instance_snapshot(pair_state):
+    store, cfg = pair_state
+    cfg["pairs"][1]["target_instance"] = "other"
+    block = {"baseline": {"items": {"tmdb:1": {"type": "movie", "ids": {"tmdb": "1"}}}}}
+    save_pair(store, cfg, "plex-mdblist", {("PLEX", "default", "watchlist"): block, ("MDBLIST", "default", "watchlist"): {"baseline": {"items": {}}}})
+    result = A._cached_analysis("plex-mdblist")
+    assert result["attention"]["counts"]["current_mismatch"] == 0
+    assert any(row["missing"] == ["MDBLIST@other"] for row in result["snapshot_gaps"])
+
+
+def test_empty_managed_pair_scope_does_not_read_other_pair_artifacts(pair_state):
+    store, _cfg = pair_state
+    store.save_feature_blocks({("PLEX", "default", "watchlist"): {"baseline": {"items": {}}}})
+    store.cw_state_dir.joinpath("PLEX_watchlist.unresolved.plex-simkl.json").write_text(json.dumps({
+        "tmdb:1": {"item": {"ids": {"tmdb": "1"}}, "reason": "not_found"}
+    }), encoding="utf-8")
+    result = A._cached_analysis(A._STRICT_PAIRS_PREFIX)
+    assert result["attention"]["counts"]["pending_retry"] == 0
+    assert A._cached_scoped_rows(A._STRICT_PAIRS_PREFIX)[0] == []
+
+
+def test_history_normalization_does_not_compare_unread_destination(pair_state):
+    store, _cfg = pair_state
+    episodes = {f"tmdb:{n}#s01e01": dict(type="episode", title=f"Show {n}", series_title=f"Show {n}",
+                                        show_ids={"tmdb": str(n)}, season=1, episode=1)
+                for n in range(20)}
+    store.save_feature_blocks({("PLEX", "default", "history"): {"baseline": {"items": episodes}}})
+    result = A._cached_analysis("plex-mdblist")
+    assert not [row for row in result["problems"] if row["type"] in ("missing_peer", "history_show_normalization")]
+
+
+def test_legacy_snapshot_does_not_seed_a_new_pair_baseline(pair_state, config_base):
+    store, _cfg = pair_state
+    item = dict(type="movie", title="Shared provider item", ids={"tmdb": "1"})
+    block = {"baseline": {"items": {"tmdb:1": item}}}
+    store.save_feature_blocks({("PLEX", "default", "watchlist"): block})
+    config_base.joinpath("state.plex-mdblist.json").write_text(json.dumps({
+        "providers": {"PLEX": {"watchlist": {"baseline": {"items": {}}}},
+                      "MDBLIST": {"watchlist": {"baseline": {"items": {}}}}}
+    }), encoding="utf-8")
+    result = A._cached_analysis("plex-mdblist")
+    assert not result["attention"]["counts"]["current_mismatch"]
+    assert not A._cached_scoped_rows("plex-mdblist")[0]
+
+
+def test_new_destination_snapshot_invalidates_cached_pair_analysis(pair_state):
+    store, _cfg = pair_state
+    item = dict(type="movie", title="Example", ids={"tmdb": "1"})
+    block = {"baseline": {"items": {"tmdb:1": item}}}
+    save_pair(store, _cfg, "plex-mdblist", {("PLEX", "default", "watchlist"): block})
+    before = A._cached_analysis("plex-mdblist")
+    assert not before["attention"]["counts"]["current_mismatch"]
+    save_pair(store, _cfg, "plex-mdblist", {("MDBLIST", "default", "watchlist"): {"baseline": {"items": {}}}})
+    after = A._cached_analysis("plex-mdblist")
+    assert after["attention"]["counts"]["current_mismatch"] == 1
+    assert not [row for row in after["snapshot_gaps"] if row["feature"] == "watchlist"]
+
+
+@pytest.mark.parametrize("feature", A._ANALYZER_FEATURES)
+def test_all_pairs_are_compared_independently(pair_state, feature):
+    store, cfg = pair_state
+    first = {"baseline": {"items": {"tmdb:1": {"type": "movie", "title": "First library", "ids": {"tmdb": "1"}}}}}
+    second = {"baseline": {"items": {"tmdb:2": {"type": "movie", "title": "Second library", "ids": {"tmdb": "2"}}}}}
+    save_pair(store, cfg, "plex-simkl", {("PLEX", "default", feature): first, ("SIMKL", "default", feature): {"baseline": {"items": {}}}})
+    save_pair(store, cfg, "plex-mdblist", {("PLEX", "default", feature): second, ("MDBLIST", "default", feature): second})
+    assert not A._cached_analysis("plex-mdblist")["attention"]["counts"]["current_mismatch"]
+    for selection in ("plex-simkl", "plex-simkl,plex-mdblist", None):
+        result = A._cached_analysis(selection)
+        missing = [row for row in result["problems"] if row["type"] == "missing_peer"]
+        assert len(missing) == 1
+        assert missing[0]["pair_id"] == "plex-simkl"
+        assert missing[0]["key"] == "tmdb:1"
+        assert missing[0]["targets"] == ["SIMKL"]
+    rows, _ = A._cached_scoped_rows("plex-simkl,plex-mdblist")
+    assert {row["key"] for row in rows if row["pair_id"] == "plex-mdblist"} == {"tmdb:2"}
+
+
+def test_unsynced_pair_does_not_read_shared_inventory(pair_state):
+    store, cfg = pair_state
+    block = {"baseline": {"items": {"tmdb:1": {"type": "movie", "ids": {"tmdb": "1"}}}}}
+    save_pair(store, cfg, "plex-simkl", {("PLEX", "default", "watchlist"): block, ("SIMKL", "default", "watchlist"): block})
+    store.save_feature_blocks({("MDBLIST", "default", "watchlist"): {"baseline": {"items": {}}}})
+    assert not A._cached_scoped_rows("plex-mdblist")[0]
+    result = A._cached_analysis("plex-mdblist")
+    assert result["attention"]["counts"]["current_mismatch"] == 0
+    assert any(set(row["missing"]) == {"PLEX", "MDBLIST"} for row in result["snapshot_gaps"])
+
+
+def test_empty_profile_cannot_reuse_all_profiles_cache(pair_state):
+    store, cfg = pair_state
+    block = {"baseline": {"items": {"tmdb:1": {"type": "movie", "ids": {"tmdb": "1"}}}}}
+    save_pair(store, cfg, "plex-simkl", {("PLEX", "default", "watchlist"): block, ("SIMKL", "default", "watchlist"): {"baseline": {"items": {}}}})
+    assert A._cached_analysis(None)["attention"]["counts"]["current_mismatch"] == 1
+    assert A._cached_scoped_rows(None)[0]
+    assert not A._cached_analysis(A._STRICT_PAIRS_PREFIX)["attention"]["counts"]["current_mismatch"]
+    assert not A._cached_scoped_rows(A._STRICT_PAIRS_PREFIX)[0]


### PR DESCRIPTION
# Pull request

## Change

- Use pair-specific snapshots and retries in Analyzer. 
- Keep item details and findings tied to the correct pair.

## Why

- Syncing one pair should not create misleading findings for other pairs sharing a provider.

## Testing

- tests/test_analyzer_pair_scope.py

## Issue

Relates to #1022