### PR TITLE
Change: show sync failure details in i-sync

### DIFF
--- a/api/interactiveSyncAPI.py
+++ b/api/interactiveSyncAPI.py
@@ -145,6 +145,17 @@ def refresh(sid: str, payload: Refresh, request: Request):
         return session.public()
 
 
+@router.get("/{sid}/report-issues")
+def report_issues(sid: str, request: Request, offset: int = Query(default=0, ge=0),
+                  limit: int = Query(default=75, ge=1, le=200), feature: str = Query(default="", max_length=32),
+                  result: str = Query(default="", max_length=32), q: str = Query(default="", max_length=256)):
+    with svc.LOCK:
+        session = get_session(sid, request, load_config())
+        if session.report is None or session.store is None:
+            raise HTTPException(409, "The sync report is not available yet")
+        return dict(ok=True, **session.store.report_page(offset=offset, limit=limit, feature=feature, result=result, q=q))
+
+
 @router.get("/{sid}/rows")
 def rows(sid: str, request: Request, revision: int = Query(ge=0), offset: int = Query(default=0, ge=0),
          limit: int = Query(default=75, ge=1, le=200), feature: str = Query(default="", max_length=32),

--- a/assets/css/interactive-sync.css
+++ b/assets/css/interactive-sync.css
@@ -152,6 +152,14 @@
 .is-report-table th:first-child { width: 30%; }
 .is-report-table tbody th { text-align: left; padding: 15px 20px; border-bottom: 1px solid var(--is-line); font-weight: 600; }
 .is-report-feature { background: color-mix(in srgb, var(--is-accent) 5%, var(--is-surface)); }
+.is-report-items { table-layout: fixed; min-width: 650px; }
+.is-table-wrap:has(> .is-report-items) { max-height: min(65vh, 620px); }
+.is-report-items thead th { position: sticky; top: 0; z-index: 1; background: var(--is-surface); }
+.is-report-items td { overflow-wrap: anywhere; }
+.is-report-items th:first-child { width: 30%; }
+.is-report-items th:nth-child(2) { width: 24%; }
+.is-report-items th:nth-child(3) { width: 16%; }
+.is-report-items .is-report-reason { white-space: pre-wrap; }
 .is-report-table .is-report-destination { padding-left: 34px; color: var(--is-muted); font-size: 12px; font-weight: 400; }
 .is-report-checks { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; margin: 16px 0; }
 .is-report-checks > div { border: 1px solid var(--is-line); border-radius: 10px; padding: 17px; display: flex; flex-direction: column; gap: 12px; }

--- a/assets/js/interactive-sync.js
+++ b/assets/js/interactive-sync.js
@@ -80,6 +80,9 @@
   }
   function accept(data, forcePage = false) {
     const changed = !session || session.id !== data.id || session.revision !== data.revision || session.selection_version !== data.selection_version || session.status !== data.status;
+    if (data.report && (!session?.report || session.id !== data.id)) {
+      page = 0; feature = ""; result = ""; query = ""; pageData = {items: [], total: 0};
+    }
     session = data;
     progressReceived = Date.now();
     pollFailures = 0;
@@ -96,7 +99,8 @@
     clearTimeout(searchTimer);
   }
   async function loadPage() {
-    if (!session?.revision || session.report || pending() || !active()) return;
+    if (!session?.revision || pending() || !active()) return;
+    if (session.report && !session.report.issue_count) return;
     invalidatePage();
     const request = pageRequest, current = generation, sid = session.id;
     pageController = new AbortController();
@@ -104,12 +108,14 @@
     render();
     const params = new URLSearchParams({ revision: session.revision, offset: page * PAGE_SIZE, limit: PAGE_SIZE, feature, result, q: query });
     try {
-      const data = await json(`${API}/${sid}/rows?${params}`, { signal: pageController.signal });
+      const data = await json(`${API}/${sid}/${session.report ? "report-issues" : "rows"}?${params}`, { signal: pageController.signal });
       if (request !== pageRequest || current !== generation) return;
       pageData = data;
       page = Math.floor(data.offset / PAGE_SIZE);
-      session.counts = data.counts;
-      session.selection_version = data.selection_version;
+      if (!session.report) {
+        session.counts = data.counts;
+        session.selection_version = data.selection_version;
+      }
       pageLoading = false;
       render();
     } catch (error) {
@@ -151,6 +157,16 @@
     const box = host.querySelector(".is-error");
     if (box) { box.textContent = error.message || String(error); box.hidden = false; }
   }
+  function reportIssuesHTML() {
+    const report = session.report;
+    if (!report.issue_count && !report.issue_details_omitted) return "";
+    const pages = Math.max(1, Math.ceil(pageData.total / PAGE_SIZE));
+    return `<section class="is-report-section"><h2>Items that need attention (${number(report.issue_count)})</h2><p>Item details and reasons recorded by the sync engine during this run.</p>
+      ${report.issue_details_omitted ? `<p class="is-report-warning">${number(report.issue_details_omitted)} additional items were omitted from the engine's detailed events. The totals above include them.</p>` : ""}
+      <div class="is-toolbar"><label class="is-search"><span class="material-symbols-rounded" aria-hidden="true">search</span><input data-filter="query" type="search" maxlength="256" placeholder="Search titles, IDs or reasons" aria-label="Search report items" value="${esc(query)}"></label><label>Feature<select data-filter="feature"><option value="">All features</option>${session.report.features.map(row => `<option value="${esc(row.feature)}" ${feature === row.feature ? "selected" : ""}>${esc(row.feature)}</option>`).join("")}</select></label><label>Result<select data-filter="result"><option value="">All results</option>${Object.entries({failed:"Not confirmed",unresolved:"Unresolved",blocked:"Blocked"}).map(([key,label]) => `<option value="${key}" ${result === key ? "selected" : ""}>${label}</option>`).join("")}</select></label></div>
+      <p class="is-report-item-range" role="status">${pageLoading ? "Loading..." : `${number(pageData.total ? page * PAGE_SIZE + 1 : 0)}&ndash;${number(Math.min((page + 1) * PAGE_SIZE, pageData.total))} of ${number(pageData.total)} matching items`}</p><div class="is-table-wrap"><table class="is-table is-report-items"><thead><tr><th>Item</th><th>Feature / destination</th><th>Result</th><th>Reason</th></tr></thead><tbody>${pageLoading ? `<tr><td colspan="4">Loading item details…</td></tr>` : pageData.items.map(row => `<tr><td><strong>${esc(title(row.item))}</strong><small>${esc(row.key || Object.entries(row.item?.ids || {}).map(([key,value]) => `${key}:${value}`).join(" · "))}</small></td><td>${esc(row.feature)}<small>${esc(endpoint(row.provider,row.instance))} · ${esc(labels[row.operation] || row.operation)}</small></td><td><span class="is-badge ${row.result === "blocked" ? "blocked" : "unresolved"}">${row.result === "blocked" ? "Blocked" : row.result === "unresolved" ? "Unresolved" : "Not confirmed"}</span></td><td class="is-report-reason">${esc(row.explanation || row.reason)}${row.explanation ? `<small>${esc(row.reason)}</small>` : ""}</td></tr>`).join("") || `<tr><td colspan="4">No matching items.</td></tr>`}</tbody></table></div>
+      <nav class="is-pagination" aria-label="Report item pages"><button class="is-btn is-small" data-action="first" ${pageLoading || !page ? "disabled" : ""}>First</button><button class="is-btn is-small" data-action="prev" ${pageLoading || !page ? "disabled" : ""}>Previous</button><label>Page <input type="number" data-page min="1" max="${pages}" value="${page + 1}" ${pageLoading ? "disabled" : ""}> of ${number(pages)}</label><button class="is-btn is-small" data-action="next" ${pageLoading || page + 1 >= pages ? "disabled" : ""}>Next</button><button class="is-btn is-small" data-action="last" ${pageLoading || page + 1 >= pages ? "disabled" : ""}>Last</button></nav></section>`;
+  }
   function reportHTML() {
     const report = session.report, totals = report.totals;
     const outcomes = {
@@ -170,9 +186,10 @@
       ${changes ? `<div class="is-report-distribution" role="img" aria-label="${number(totals.added)} added, ${number(totals.updated)} updated, ${number(totals.removed)} removed">${["added", "updated", "removed"].map(key => `<span class="${key}" style="width:${totals[key] / changes * 100}%"></span>`).join("")}</div><div class="is-report-legend">${columns.slice(0, 3).map(([key, label]) => `<span><i class="${key}"></i>${label}</span>`).join("")}</div>` : ""}
       <dl class="is-report-facts"><div><dt>Selected for this run</dt><dd>${number(report.requested)} of ${number(report.proposed)} proposals</dd></div><div><dt>Not selected</dt><dd>${number(report.not_selected)}</dd></div><div><dt>Started</dt><dd>${date(report.started_at)}</dd></div><div><dt>Finished</dt><dd>${date(report.finished_at)}</dd></div><div><dt>API requests</dt><dd>${number(report.requests)}</dd></div><div><dt>Conflict decisions</dt><dd>${number(report.conflicts_reviewed)}</dd></div></dl>
       <section class="is-report-section"><h2>Results by feature and destination</h2><p>Counts reported by the sync engine for this operation.</p><div class="is-table-wrap"><table class="is-table is-report-table"><thead><tr><th scope="col">Feature / destination</th>${columns.map(([, label]) => `<th scope="col">${label}</th>`).join("")}</tr></thead><tbody>${report.features.map(row => `<tr class="is-report-feature"><th scope="row">${esc(row.feature.charAt(0).toUpperCase() + row.feature.slice(1))}</th>${cells(row)}</tr>${row.destinations.map(dst => `<tr><th scope="row" class="is-report-destination">${esc(endpoint(dst.provider, dst.instance))}</th>${cells(dst)}</tr>`).join("")}`).join("") || `<tr><td colspan="8">No completed feature results were reported.</td></tr>`}</tbody></table></div></section>
-      <section class="is-report-section is-report-attention"><h2>Attention and follow-up</h2><div class="is-report-checks">${[["Unresolved mappings", totals.unresolved], ["Provider errors", totals.errors], ["Blocked by sync rules", totals.blocked], ["Selected proposals not reached", report.not_reached]].map(([label, n]) => `<div class="${n ? "needs-attention" : ""}"><span>${label}</span><strong>${number(n)}</strong></div>`).join("")}</div>${report.not_reached ? `<p>These selected proposals did not reach execution. Data may have changed, a protection may have stopped them, or the run may have ended early.</p>` : ""}${report.incomplete_note ? `<p class="is-report-warning">${esc(report.incomplete_note)}</p>` : ""}${report.outcome !== "success" ? `<p>Check Events for details. Start a new review to see what still needs syncing before retrying.</p>` : ""}</section>
+      <section class="is-report-section is-report-attention"><h2>Attention and follow-up</h2><div class="is-report-checks">${[["Unresolved items", totals.unresolved], ["Provider errors", totals.errors], ["Blocked by sync rules", totals.blocked], ["Selected proposals not reached", report.not_reached]].map(([label, n]) => `<div class="${n ? "needs-attention" : ""}"><span>${label}</span><strong>${number(n)}</strong></div>`).join("")}</div>${report.not_reached ? `<p>These selected proposals did not reach execution. Data may have changed, a protection may have stopped them, or the run may have ended early.</p>` : ""}${report.incomplete_note ? `<p class="is-report-warning">${esc(report.incomplete_note)}</p>` : ""}${report.outcome !== "success" ? `<p>${report.issue_count ? "Review the affected items below." : "The engine did not include item-level details. Check Events for the available diagnostics."} Start a new review to see what still needs syncing before retrying.</p>` : ""}</section>
       ${(report.notices || []).length ? `<details class="is-notices" open><summary>Execution notices (${number(report.notices.length)})</summary>${report.notices.map(n => `<p><strong>${esc([n.feature, n.provider].filter(Boolean).join(" · "))}</strong> ${esc(n.reason)}${n.occurrences > 1 ? ` (${number(n.occurrences)} occurrences)` : ""}</p>`).join("")}${report.notice_overflow ? `<p>Additional notices are available in Events.</p>` : ""}</details>` : ""}
       ${(report.review_notices || []).length ? `<details class="is-notices"><summary>Protections and notices from the preview (${number(report.review_notices.length)})</summary>${report.review_notices.map(n => `<p>${esc(n.feature)} ${esc(n.provider)} · ${esc(n.reason)}</p>`).join("")}</details>` : ""}
+      ${reportIssuesHTML()}
       <p class="is-report-accounting">${esc(report.accounting_note)}</p>
       <footer class="is-report-footer"><div><strong>Keep a copy of this report</strong><small>Available while this review session is retained. Download it for your records.</small></div><div class="is-header-actions"><button class="is-btn" data-action="download-report"><span class="material-symbols-rounded" aria-hidden="true">download</span>Download JSON</button><a class="is-btn is-primary" href="#settings/sync">Back to Synchronization</a></div></footer>
     </section>`;
@@ -304,12 +321,22 @@
     if (button.dataset.map) return mapping(pageData.items.find(row => row.id === button.dataset.map));
     const name = button.dataset.action;
     if (name === "download-report" && session.report) {
-      const url = URL.createObjectURL(new Blob([JSON.stringify(session.report, null, 2)], { type: "application/json" }));
+      const report = session.report, sid = session.id, issues = [];
+      button.disabled = true;
+      try {
+        while (issues.length < (report.issue_count || 0)) {
+          const data = await json(`${API}/${sid}/report-issues?offset=${issues.length}&limit=200`);
+          if (!data.items.length) throw new Error("Could not read all report items. Try downloading again.");
+          issues.push(...data.items);
+        }
+      } catch (error) { button.disabled = false; showError(error); return; }
+      const url = URL.createObjectURL(new Blob([JSON.stringify({...report, issues}, null, 2)], { type: "application/json" }));
       const link = document.createElement("a");
       link.href = url;
-      link.download = `crosswatch-sync-${session.id}.json`;
+      link.download = `crosswatch-sync-${sid}.json`;
       document.body.append(link); link.click(); link.remove();
       setTimeout(() => URL.revokeObjectURL(url), 1000);
+      button.disabled = false;
       return;
     }
     if (name === "refresh") return action("refresh");

--- a/services/interactive_sync.py
+++ b/services/interactive_sync.py
@@ -159,7 +159,7 @@ def apply(session: Session, cfg: dict[str, Any], selected: set[str]):
     session.progress.begin("apply")
     session.apply_review = None
     session.report = None
-    report = SyncReport()
+    report = SyncReport(session.store, session.pair)
     if fingerprint(cfg) != session.config_hash or mapping_version(cfg) != session.mapping_version:
         refresh(session, cfg, session.plan.choices, restart_progress=False)
         _apply_needs_review(session, selected, "Settings or mappings changed.")

--- a/services/interactive_sync_report.py
+++ b/services/interactive_sync_report.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import json
 import time
+from cw_platform.orchestrator._interactive import fingerprint
 
 
 COUNTERS = ("added", "updated", "removed", "skipped", "unresolved", "blocked", "errors")
@@ -23,12 +24,67 @@ def timestamp(value):
 
 
 class SyncReport:
-    def __init__(self):
+    def __init__(self, store=None, pair=None):
         self.started = time.time()
         self.features = []
         self.notices = {}
         self.notice_overflow = 0
         self.cancelled = False
+        self.store = store
+        self.pair = pair or {}
+        self.operations = {}
+        self.authoritative = set()
+        self.detail_omitted = {}
+        if store is not None:
+            store.clear_report_issues()
+
+    def item_event(self, value):
+        if self.store is None:
+            return
+        name = value.get("event")
+        provider = str(value.get("provider") or value.get("dst") or "")[:160]
+        feature = str(value.get("feature") or "")[:32]
+        if name in ("apply:add:start", "apply:update:start", "apply:remove:start"):
+            self.operations[(provider, feature)] = name.split(":")[1]
+            return
+        if name not in ("apply:unresolved", "archive:item_failures"):
+            return
+        operation = str(value.get("op") or self.operations.get((provider, feature), "add"))
+        scope = (provider, feature, operation)
+        provisional = name == "apply:unresolved"
+        if provisional and scope in self.authoritative:
+            return
+        if not provisional:
+            self.authoritative.add(scope)
+            self.store.clear_report_issues(*scope)
+            self.detail_omitted.pop(scope, None)
+        else:
+            self.detail_omitted[scope] = self.detail_omitted.get(scope, 0) + count(value.get("omitted"))
+        instances = {self.pair.get(side + "_instance") or "default" for side in ("source", "target") if self.pair.get(side) == provider}
+        instance = next(iter(instances)) if len(instances) == 1 else ""
+        for raw in value.get("items") or []:
+            if not isinstance(raw, dict):
+                continue
+            item = raw.get("item")
+            if not isinstance(item, dict):
+                item = raw
+            safe_item: dict[str, object] = {key: str(item[key])[:500] for key in ("title", "name", "type", "year", "season", "episode", "series_title", "show_title") if item.get(key) is not None}
+            ids = item.get("ids") or {}
+            safe_item["ids"] = {key: str(ids[key])[:128] for key in ("imdb", "tmdb", "tvdb", "trakt", "simkl", "mal", "anilist") if isinstance(ids, dict) and ids.get(key)}
+            reason = str(raw.get("reason") or raw.get("hint") or "The provider did not confirm this change.")[:2000]
+            explanation = {
+                "not_found": "The destination provider could not find this item.",
+                "missing_write_ids": "The item is missing IDs required by the destination provider.",
+                "missing_auth": "The destination provider requires authentication.",
+                "rate_limited": "The provider's request limit was reached.",
+                "apply:add:failed": "The provider did not confirm that this item was added.",
+                "apply:add:unaccounted": "The provider response did not account for this item.",
+            }.get(reason, "")
+            key = str(raw.get("key") or "")[:500]
+            row = dict(provider=provider, instance=instance, feature=feature, operation=operation,
+                       result="blocked" if raw.get("promoted") else "unresolved" if provisional else "failed",
+                       key=key, item=safe_item, reason=reason, explanation=explanation)
+            self.store.put_report_issue(fingerprint([scope, key or safe_item]), row, provisional)
 
     def event(self, value):
         if isinstance(value, str):
@@ -39,6 +95,7 @@ class SyncReport:
         if not isinstance(value, dict):
             return
         name = str(value.get("event") or "")
+        self.item_event(value)
         if name in ("feature:cancelled", "run:cancelled"):
             self.cancelled = True
         reasons = {
@@ -93,7 +150,7 @@ class SyncReport:
         cancelled = self.cancelled or bool((result or {}).get("cancelled"))
         outcome = "cancelled" if cancelled else "incomplete" if result is None or not result.get("ok", True) else "attention" if not_reached or any(totals[k] for k in ("errors", "unresolved", "blocked")) or self.notices else "success"
         counts = session.store.counts if session.store else {}
-        return dict(version=1, run_id="interactive-" + session.id, pair=dict(session.pair),
+        return dict(version=2, run_id="interactive-" + session.id, pair=dict(session.pair),
                     started_at=timestamp(self.started), finished_at=timestamp(time.time()),
                     duration_seconds=session.progress.public().get("elapsed_seconds", 0),
                     outcome=outcome, totals=totals, requested=requested,
@@ -102,6 +159,8 @@ class SyncReport:
                     reached_execution=requested - not_reached, not_reached=not_reached,
                     conflicts_reviewed=count(counts.get("conflicts")),
                     features=self.features, notices=list(self.notices.values()), notice_overflow=self.notice_overflow,
+                    issue_count=self.store.report_page(limit=1)["total"] if self.store is not None else 0,
+                    issue_details_omitted=sum(self.detail_omitted.values()),
                     review_notices=session.plan.notices[:100],
                     requests=session.progress.public().get("requests", 0),
                     accounting_note="Totals use the existing sync engine's provider results. Skips can include items already present. Errors and protection counts can overlap or describe a whole batch; they are not an item-by-item receipt. Playlist totals count playlist contents and ordering operations.",

--- a/services/interactive_sync_store.py
+++ b/services/interactive_sync_store.py
@@ -62,6 +62,29 @@ class ReviewStore:
         self.counts = dict(changes=0, conflicts=0, attention=0, selected=0)
         self.features = []
         self.selectable_count = 0
+        self.db.execute("CREATE TABLE report_issues (id TEXT PRIMARY KEY, provider TEXT NOT NULL, feature TEXT NOT NULL, result TEXT NOT NULL, operation TEXT NOT NULL, provisional INTEGER NOT NULL, search TEXT NOT NULL, payload TEXT NOT NULL)")
+
+    def clear_report_issues(self, provider=None, feature=None, operation=None):
+        with self.lock:
+            if provider is None:
+                self.db.execute("DELETE FROM report_issues")
+            else:
+                self.db.execute("DELETE FROM report_issues WHERE provider=? AND feature=? AND operation=? AND provisional=1", (provider, feature, operation))
+
+    def put_report_issue(self, key, row, provisional=False):
+        payload = json.dumps(row, ensure_ascii=False, default=str)
+        with self.lock:
+            self.db.execute("INSERT OR REPLACE INTO report_issues VALUES(?,?,?,?,?,?,?,?)",
+                            (key, row["provider"], row["feature"], row["result"], row["operation"], int(provisional), payload.casefold(), payload))
+
+    def report_page(self, *, offset=0, limit=75, feature="", result="", q=""):
+        where, args = self.where(feature, result, q)
+        with self.lock:
+            total = self.db.execute(f"SELECT COUNT(*) FROM report_issues WHERE {where}", args).fetchone()[0]
+            limit = max(1, min(200, int(limit)))
+            offset = max(0, min(int(offset), ((total - 1) // limit) * limit)) if total else 0
+            rows = self.db.execute(f"SELECT payload FROM report_issues WHERE {where} ORDER BY rowid LIMIT ? OFFSET ?", [*args, limit, offset]).fetchall()
+        return dict(items=[json.loads(row[0]) for row in rows], total=total, offset=offset, limit=limit)
 
     def put(self, key, value, kind):
         result = "conflict" if kind == "conflict" else value["result"]

--- a/tests/test_interactive_sync_report.py
+++ b/tests/test_interactive_sync_report.py
@@ -11,7 +11,7 @@ import pytest
 from cw_platform.orchestrator._interactive import InteractivePlan
 from services.interactive_sync import Session
 from services.interactive_sync_report import COUNTERS, SyncReport
-from test_interactive_sync import run
+from test_interactive_sync import api_client, run
 from test_interactive_sync_features import FEATURES, feature_item, feature_setup
 
 
@@ -127,3 +127,94 @@ def test_fatal_execution_still_keeps_a_report(config_base, monkeypatch):
         assert session.report["not_reached"] == 1
     finally:
         session.close()
+
+
+@pytest.mark.parametrize("feature", FEATURES)
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_report_keeps_engine_item_failure_details(config_base, monkeypatch, feature, mode):
+    from api import syncAPI
+    from services import interactive_sync as svc
+
+    cfg, src, dst = feature_setup(config_base, monkeypatch, feature,
+                                  [feature_item(feature, 1), feature_item(feature, 2)], [], mode)
+    monkeypatch.setattr(syncAPI, "_env", lambda: (lambda: deepcopy(cfg), lambda *_: None))
+    def unresolved(cfg, items, **kwargs):
+        return dict(ok=True, count=0, unresolved=[dict(item=dict(item), hint="not_found") for item in items])
+    monkeypatch.setattr(dst, "add", unresolved)
+    session = Session(pair_id="p1", owner="local")
+    session.pair = dict(source="SRC", target="DST", target_instance="other", mode=mode)
+    try:
+        svc.refresh(session, cfg, {})
+        svc.apply(session, cfg, session.store.selected_ids())
+        details = session.store.report_page()
+        assert session.report["outcome"] == "attention"
+        assert session.report["issue_count"] == details["total"] == 2
+        assert all(row["feature"] == feature and row["provider"] == "DST" for row in details["items"])
+        assert all(row["instance"] == "other" and row["reason"] == "not_found" for row in details["items"])
+        assert all(row["item"]["title"] for row in details["items"])
+        assert "issues" not in session.public()["report"]
+    finally:
+        session.close()
+
+
+def test_report_pages_all_failures_and_replaces_log_samples():
+    from services.interactive_sync_store import ReviewStore
+
+    store = ReviewStore()
+    collector = SyncReport(store)
+    try:
+        collector.event(dict(event="apply:unresolved", provider="PLEX", feature="history",
+                             items=[dict(title="Sample", reason="not_found")], omitted=4999))
+        collector.event(dict(event="archive:item_failures", provider="PLEX", feature="history", op="add",
+                             items=[dict(key=f"tmdb:{n}", item=dict(title=f"Movie {n}", ids={"tmdb":n}, token="private"),
+                                         reason="not_found", promoted=n == 4999) for n in range(5000)]))
+        assert not collector.detail_omitted
+        page = store.report_page(offset=4990, limit=10)
+        assert page["total"] == 5000 and len(page["items"]) == 10
+        assert page["items"][-1]["item"]["title"] == "Movie 4999"
+        assert page["items"][-1]["result"] == "blocked"
+        assert "private" not in json.dumps(page)
+        assert store.report_page(q="Movie 4999")["total"] == 1
+        assert store.report_page(result="blocked")["total"] == 1
+        assert store.report_page(feature="ratings")["total"] == 0
+        assert len(store.report_page(limit=5000)["items"]) == 200
+    finally:
+        store.close()
+
+
+def test_update_and_remove_keep_available_reasons_and_omitted_counts():
+    from services.interactive_sync_store import ReviewStore
+
+    store = ReviewStore()
+    collector = SyncReport(store)
+    try:
+        for operation in ("update", "remove"):
+            collector.event(dict(event=f"apply:{operation}:start", dst="TRAKT", feature="ratings"))
+            collector.event(dict(event="apply:unresolved", provider="TRAKT", feature="ratings",
+                                 items=[dict(title="Movie", reason="http:429")], omitted=30))
+        assert store.report_page()["total"] == 2
+        assert {row["operation"] for row in store.report_page()["items"]} == {"update", "remove"}
+        report = collector.finish(Session(pair_id="p1", owner="local"), InteractivePlan(preview=False), {"ok":True,"unresolved":62})
+        assert report["issue_details_omitted"] == 60
+    finally:
+        store.close()
+
+
+def test_report_issue_api_is_paged_and_session_scoped(api_client):
+    client, session, api = api_client
+    url = f"/api/interactive-sync/{session.id}/report-issues"
+    assert client.get(url).status_code == 409
+    collector = SyncReport(session.store)
+    collector.event(dict(event="archive:item_failures", provider="DST", feature="history", op="add",
+                         items=[dict(key=str(n), item=dict(title=f"Episode {n}"), reason="not_found") for n in range(5000)]))
+    session.report = collector.finish(session, InteractivePlan(preview=False), {"ok":True,"unresolved":5000})
+    session.status = "complete"
+    response = client.get(url, params=dict(offset=4995,limit=5,feature="history",result="failed"))
+    assert response.status_code == 200
+    assert response.json()["total"] == 5000
+    assert [row["item"]["title"] for row in response.json()["items"]] == [f"Episode {n}" for n in range(4995,5000)]
+    assert len(response.content) < 4000
+    assert client.get(url, params=dict(q="Episode 4999")).json()["total"] == 1
+    assert client.get(url, params=dict(limit=201)).status_code == 422
+    assert client.get(url, headers={"x-test-user":"bob"}).status_code == 404
+    assert client.get(url.replace(session.id,"missing")).status_code == 404


### PR DESCRIPTION
# Pull request

## Change

- Show affected items and reasons in the sync report.
- Add search, filters and paging.
- Include item details in downloaded reports.

## Why

- Totals alone do not explain which items failed or why.

## Testing

- tests/test_interactive_sync_report.py 

## Issue

Relates to #1018