### PR TITLE
Add: mapping edits to Analyzer

### DIFF
--- a/assets/js/analyzer/index.js
+++ b/assets/js/analyzer/index.js
@@ -113,6 +113,7 @@ const Analyzer = {
       </header>
       <div id="an-progress" class="an-progress" role="status" aria-live="polite" hidden></div>
       <div id="an-alerts"></div>
+      <p id="an-mapping-notice" class="an-mapping-notice" role="status" hidden></p>
       <section class="an-scope-bar" aria-label="Analysis scope">
         <label for="an-pair">Sync pair<select id="an-pair" disabled><option>Loading pairs…</option></select></label>
         <div class="an-snapshot">${icon("schedule")}<div><strong>Saved snapshots</strong><span id="an-snapshot-time">Run a sync to update provider data.</span></div></div>
@@ -143,6 +144,7 @@ const Analyzer = {
     let analysisError = "", systemError = "", checked = "", pageError = "";
     let analysisStarted = Date.now(), systemStarted = Date.now();
     let allTotal = null, selected = null;
+    let mappingWorkspace = null, mappingController = null;
     let total = 0, offset = 0, pageSize = 50;
     let currentRows = [], filteredRows = [];
     let pageLoading = false;
@@ -150,6 +152,8 @@ const Analyzer = {
     const detailCache = new Map();
     const cleanup = () => {
       lifetime.abort();
+      mappingController?.abort();
+      mappingWorkspace?.destroy?.();
       analysisController?.abort();
       systemController?.abort();
       pageController?.abort();
@@ -290,10 +294,11 @@ const Analyzer = {
         $("#an-list").innerHTML = `<div class="an-findings">${currentRows.map((row, index) => renderFinding(row, index)).join("")}</div>`;
         return;
       }
-      $("#an-list").innerHTML = `<div class="an-table-scroll"><table class="an-table"><thead><tr><th scope="col">Item</th><th scope="col">Provider</th><th scope="col">Feature</th><th scope="col">Finding</th></tr></thead><tbody>${currentRows.map((row, index) => {
+      const editable = view === "pending" && window.CW?.AuthState?.read?.().permissions?.write !== false;
+      $("#an-list").innerHTML = `<div class="an-table-scroll"><table class="an-table"><thead><tr><th scope="col">Item</th><th scope="col">Provider</th><th scope="col">Feature</th><th scope="col">Finding</th>${editable ? '<th scope="col" class="an-mapping-column" aria-label="Edit mapping"></th>' : ''}</tr></thead><tbody>${currentRows.map((row, index) => {
         const mismatch = missingIndex.get(identity(row));
         const finding = view === "pending" ? "Pending retry" : row.type === "missing_peer" || mismatch ? `Missing at ${array((mismatch || row).targets).map(providerName).join(", ") || "destination"}` : blockedIndex.has(identity(row)) ? "Blocked" : "No presence issue";
-        return `<tr data-row="${index}" class="${selected === row ? "is-selected" : ""}"><td><button type="button" class="an-item-button" data-row="${index}" aria-pressed="${selected === row}"><strong>${esc(label(row))}</strong><span>${esc([human(row.item_type || row.item?.type || (row.type === "missing_peer" ? "" : row.type)), row.year || row.item?.year].filter(Boolean).join(" · "))}</span></button></td><td>${esc(providerName(row.provider))}</td><td><span class="an-feature-badge">${esc(human(row.feature))}</span></td><td><span class="an-result-badge ${mismatch || row.type === "missing_peer" ? "an-warn-text" : ""}">${esc(finding)}</span></td></tr>`;
+        return `<tr data-row="${index}" class="${selected === row ? "is-selected" : ""}"><td><button type="button" class="an-item-button" data-row="${index}" aria-pressed="${selected === row}"><strong>${esc(label(row))}</strong><span>${esc([human(row.item_type || row.item?.type || (row.type === "missing_peer" ? "" : row.type)), row.year || row.item?.year].filter(Boolean).join(" · "))}</span></button></td><td>${esc(providerName(row.provider))}</td><td><span class="an-feature-badge">${esc(human(row.feature))}</span></td><td><span class="an-result-badge ${mismatch || row.type === "missing_peer" ? "an-warn-text" : ""}">${esc(finding)}</span></td>${editable ? `<td class="an-mapping-column">${row.key && FEATURES.includes(row.feature) ? `<button type="button" class="an-icon-button" data-edit-mapping="${index}" title="Edit mapping" aria-label="Edit mapping for ${esc(label(row))}">${icon("edit")}</button>` : ''}</td>` : ''}</tr>`;
       }).join("")}</tbody></table></div>`;
     }
     function renderFinding(row, index) {
@@ -396,7 +401,7 @@ const Analyzer = {
           const limit = ["watchlist", "collection"].includes(row.feature) ? provider?.limits?.[key] : null;
           return limit && limit.item_count > 0 && limit.used >= limit.item_count ? `${providerName(target)} ${human(key)} limit reached (${limit.used}/${limit.item_count}). Free up space or review the provider account limit.` : "";
         }).filter(Boolean);
-        $("#an-detail").innerHTML = `<div class="an-detail-heading"><span class="an-eyebrow">ITEM DETAILS</span><button type="button" class="an-icon-button" id="an-close-detail" aria-label="Close item details">${icon("close")}</button></div><h3>${esc(label(row))}</h3><p class="an-detail-meta">${esc([provider, human(row.feature), row.year || row.item?.year].filter(Boolean).join(" · "))}</p><div class="an-detail-status">${icon(mismatch || view === "pending" ? "info" : "check_circle")}<strong>${esc(presence)}</strong></div>${reasons.length || limitNotes.length ? `<div class="an-detail-reasons"><h4>What happened</h4>${[...limitNotes, ...reasons].map(reason => `<p>${esc(reason)}</p>`).join("")}</div>` : mismatch ? '<p class="an-muted">CrossWatch found this item in the source snapshot but could not confirm it at the destination.</p>' : ""}${error ? `<p class="an-detail-error" role="alert">${esc(error)}</p><button type="button" class="an-button" id="an-retry-detail">Retry details</button>` : ""}${mismatch || view === "pending" ? '<div class="an-next-step"><h4>Next step</h4><p>Check the pair’s sync rules and the provider. If an item needs a mapping correction, use Editor or Anime ID mappings, then run the pair again.</p></div>' : ""}${ids.length ? `<details class="an-identifiers"><summary>Item IDs (${ids.length})</summary><dl>${ids.map(([key, value]) => `<div><dt>${esc(key)}</dt><dd>${esc(value)}</dd></div>`).join("")}</dl></details>` : ""}${row.key ? `<p class="an-item-key">${esc(row.key)}</p>` : ""}`;
+        $("#an-detail").innerHTML = `<div class="an-detail-heading"><span class="an-eyebrow">ITEM DETAILS</span><button type="button" class="an-icon-button" id="an-close-detail" aria-label="Close item details">${icon("close")}</button></div><h3>${esc(label(row))}</h3><p class="an-detail-meta">${esc([provider, human(row.feature), row.year || row.item?.year].filter(Boolean).join(" · "))}</p><div class="an-detail-status">${icon(mismatch || view === "pending" ? "info" : "check_circle")}<strong>${esc(presence)}</strong></div>${reasons.length || limitNotes.length ? `<div class="an-detail-reasons"><h4>What happened</h4>${[...limitNotes, ...reasons].map(reason => `<p>${esc(reason)}</p>`).join("")}</div>` : mismatch ? '<p class="an-muted">CrossWatch found this item in the source snapshot but could not confirm it at the destination.</p>' : ""}${error ? `<p class="an-detail-error" role="alert">${esc(error)}</p><button type="button" class="an-button" id="an-retry-detail">Retry details</button>` : ""}${mismatch || view === "pending" ? '<div class="an-next-step"><h4>Next step</h4><p>Check the pair’s sync rules and the provider. Use the pencil beside a pending item to correct its mapping, then run the pair again.</p></div>' : ""}${ids.length ? `<details class="an-identifiers"><summary>Item IDs (${ids.length})</summary><dl>${ids.map(([key, value]) => `<div><dt>${esc(key)}</dt><dd>${esc(value)}</dd></div>`).join("")}</dl></details>` : ""}${row.key ? `<p class="an-item-key">${esc(row.key)}</p>` : ""}`;
       };
       render(detailCache.get(identity(row)));
       if (!mismatch || detailCache.has(identity(row))) return;
@@ -493,6 +498,42 @@ const Analyzer = {
       renderStatus();
       if (view === "system") refreshResults();
     }
+    async function editMapping(row, button) {
+      if (!row || mappingWorkspace || mappingController) return;
+      const pairId = row.pair_id || $("#an-pair").value;
+      const notice = $("#an-mapping-notice");
+      notice.hidden = false;
+      if (!pairId) { notice.textContent = "Select a sync pair before editing this mapping."; return; }
+      notice.textContent = "Opening mapping…";
+      const controller = mappingController = new AbortController();
+      button.disabled = true;
+      const finish = () => {
+        mappingWorkspace = null;
+        mappingController = null;
+        controller.abort();
+        if (button.isConnected) { button.disabled = false; button.focus(); }
+      };
+      try {
+        const {openAnalyzerMapping} = await import(`./mapping.js?v=${encodeURIComponent(window.APP_VERSION || '1')}`);
+        if (controller.signal.aborted) return;
+        mappingWorkspace = await openAnalyzerMapping({
+          reference:{pair_id:pairId, provider:row.provider, feature:row.feature, key:row.key},
+          signal:controller.signal,
+          onClose: () => { notice.hidden = true; finish(); },
+          onSaved: () => {
+            finish();
+            if (!lifetime.signal.aborted) {
+              notice.hidden = false;
+              notice.textContent = "Mapping saved. Run the pair again to retry this item, then analyze to update the results.";
+            }
+          },
+        });
+        if (!controller.signal.aborted) notice.hidden = true;
+      } catch (error) {
+        if (!controller.signal.aborted) notice.textContent = error.message || "Could not open mapping. Try again.";
+        finish();
+      }
+    }
     async function loadScope() {
       try {
         const [rawPairs, instances, runs] = await Promise.all([
@@ -529,7 +570,8 @@ const Analyzer = {
     root.addEventListener("click", event => {
       const button = event.target.closest("button, tr[data-row]");
       if (!button) return;
-      if (button.dataset.view) changeView(button.dataset.view);
+      if (button.hasAttribute("data-edit-mapping")) editMapping(currentRows[Number(button.dataset.editMapping)], button);
+      else if (button.dataset.view) changeView(button.dataset.view);
       else if (button.hasAttribute("data-open-system")) changeView("system");
       else if (button.dataset.row != null) {
         selected = currentRows[Number(button.dataset.row)];

--- a/assets/js/analyzer/mapping.js
+++ b/assets/js/analyzer/mapping.js
@@ -1,0 +1,42 @@
+/* CrossWatch - Analyzer entry point to the shared mapping workspace */
+async function loadStyles() {
+  if (document.querySelector('link[href*="/assets/css/interactive-sync.css"]')) return;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = `/assets/css/interactive-sync.css?v=${encodeURIComponent(window.APP_VERSION || '1')}`;
+  await new Promise(resolve => {
+    link.onload = link.onerror = resolve;
+    document.head.append(link);
+  });
+}
+
+export async function openAnalyzerMapping({reference, signal, onSaved, onClose}) {
+  let version = '';
+  const request = async (action, extra = {}, options = {}) => {
+    const response = await fetch('/api/analyzer/mapping', {
+      method:'POST', credentials:'same-origin', cache:'no-store',
+      headers:{'Content-Type':'application/json'},
+      signal:options.signal ? AbortSignal.any([signal, options.signal]) : signal,
+      body:JSON.stringify({...reference, version, action, ...extra}),
+    });
+    const data = await response.json();
+    if (!response.ok || data.ok === false) throw new Error(data.detail || data.error || 'Could not load mapping.');
+    return data;
+  };
+  const [data, module] = await Promise.all([
+    request('context'),
+    import(`/assets/js/interactive-sync-mapping.js?v=${encodeURIComponent(window.APP_VERSION || '1')}`),
+    loadStyles(),
+  ]);
+  if (signal.aborted) return null;
+  version = data.version;
+  return module.openMappingWorkspace({
+    rows:[data.row], total:1, standalone:true, onSaved, onClose,
+    mappingApi:{
+      catalogs: () => request('catalogs'),
+      search: (_row, q, catalog, options) => request('search', {q, catalog}, options),
+      episodes: (edits, options) => request('episodes', {item:edits[0].item}, options),
+      save: edits => request('save', {item:edits[0].item}),
+    },
+  });
+}

--- a/assets/js/analyzer/styles.css
+++ b/assets/js/analyzer/styles.css
@@ -143,3 +143,7 @@
 
 .an-page .an-tabs,.an-page .an-table-scroll,.an-page .an-detail{scrollbar-width:thin;scrollbar-color:var(--an-border) transparent}
 @media(max-width:720px){.an-page .an-header{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:6px 12px}.an-page .an-header>div{display:contents}.an-page .an-header .an-eyebrow{grid-column:1/-1}.an-page .an-header h1{grid-column:1;grid-row:2;font-size:26px;white-space:nowrap}.an-page .an-header p{grid-column:1/-1;grid-row:3}.an-page #an-run{grid-column:2;grid-row:2;min-height:38px;padding:8px 10px;font-size:12px}.an-page .an-tabs{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));overflow:visible;gap:6px}.an-page .an-tab{justify-content:flex-start;min-width:0}.an-page .an-tab:last-child{grid-column:1/-1}.an-page .an-notice{display:grid;grid-template-columns:24px minmax(0,1fr);align-items:start}.an-page .an-notice>.an-button{grid-column:2;justify-self:start;margin-left:0}.an-page .an-scope-bar>label{display:grid;gap:8px}}
+/* Mapping actions share the Analyzer's compact icon controls. */
+.an-page .an-mapping-column{width:56px;text-align:right;white-space:nowrap}
+.an-page .an-mapping-column .an-icon-button:hover{color:var(--accent,#8057ff);border-color:var(--accent,#8057ff)}
+.an-page .an-mapping-notice{padding:12px 16px;border:1px solid var(--border,#2a2e38);border-radius:12px;background:var(--panel,#101318);color:var(--muted,#959eab)}

--- a/services/analyzer.py
+++ b/services/analyzer.py
@@ -18,6 +18,7 @@ import threading
 import requests
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
+from services.analyzer_mapping import MappingRequest, handle_mapping
 
 from cw_platform.access_policy import filter_pairs_for_user, pair_ids_for_user, request_user
 from cw_platform.pair_scope import pair_feature_scope
@@ -4498,6 +4499,11 @@ def api_state(
         "limit": page_size,
         "has_more": start + len(page) < len(items),
     }
+
+
+@router.post("/analyzer/mapping", response_class=JSONResponse)
+def api_mapping(payload: MappingRequest, request: Request):
+    return handle_mapping(payload, request)
 
 
 @router.get("/analyzer/problems", response_class=JSONResponse)

--- a/services/analyzer_mapping.py
+++ b/services/analyzer_mapping.py
@@ -1,0 +1,106 @@
+# CrossWatch - Mapping corrections from Analyzer pending retries
+from __future__ import annotations
+
+from copy import deepcopy
+import hashlib
+import json
+import time
+from typing import Any, Literal
+
+from fastapi import HTTPException
+from pydantic import BaseModel, Field
+
+from cw_platform.access_policy import request_user, user_can_access_pair
+
+
+class MappingRequest(BaseModel):
+    pair_id: str = Field(min_length=1, max_length=256)
+    provider: str = Field(min_length=1, max_length=128)
+    feature: Literal["history", "watchlist", "ratings", "progress", "collection"]
+    key: str = Field(min_length=1, max_length=1024)
+    action: Literal["context", "catalogs", "search", "episodes", "save"] = "context"
+    version: str = Field(default="", max_length=64)
+    q: str = Field(default="", max_length=200)
+    catalog: Literal["destination", "tmdb"] = "destination"
+    item: dict[str, Any] = Field(default_factory=dict)
+
+
+def mapping_row(payload, request):
+    from services import analyzer as an
+
+    cfg, user = an._cfg(), request_user(request)
+    if user and not user.get("is_admin") and not (user.get("permissions") or {}).get("write"):
+        raise HTTPException(403, "Write permission required")
+    pair = next((p for p in cfg.get("pairs", []) if an._pair_id(p) == payload.pair_id), None)
+    if not pair or not user_can_access_pair(cfg, user, pair):
+        raise HTTPException(404, "Sync pair not found")
+    analysis = an._cached_analysis(payload.pair_id)
+    entries = [entry for entry in analysis.get("attention", {}).get("rows", [])
+               if entry.get("unresolved") and entry.get("feature") == payload.feature
+               and str(entry.get("provider", "")).casefold() == payload.provider.casefold()
+               and payload.key in [entry.get("key"), *(entry.get("keys") or [])]]
+    if len(entries) != 1:
+        raise HTTPException(409, "This pending item changed. Analyze again before editing its mapping.")
+    entry = entries[0]
+    aliases = {str(key) for key in [entry.get("key"), *(entry.get("keys") or [])] if key}
+    destination = entry.get("target") or payload.provider
+    dest_base, dest_instance, explicit_instance = an._split_prov_token_ex(destination)
+    directions = an._pair_map({**cfg, "pairs": [pair]}, {})
+    candidates = []
+    for handle in an._load_state_handles(payload.pair_id, {payload.feature}):
+        for source, feature, key, item in an._iter_items(handle["state"]):
+            if feature != payload.feature:
+                continue
+            matches = set(an._alias_keys({**item, "_key": key})) & aliases
+            if not matches:
+                continue
+            for target in directions.get((source, feature), []):
+                provider, instance = an._split_prov_token(target)
+                if provider != dest_base or (explicit_instance and instance != dest_instance):
+                    continue
+                src, src_instance = an._split_prov_token(source)
+                candidates.append(dict(id="analyzer-item", key=key, item=deepcopy(item), feature=feature,
+                                       source=src, source_instance=src_instance, provider=provider,
+                                       instance=instance, operation="add"))
+    exact = [row for row in candidates if row["key"] == entry.get("key")]
+    if exact:
+        candidates = exact
+    if len(candidates) != 1:
+        raise HTTPException(409, "The original source item could not be identified uniquely. Refresh the pair’s snapshots and analyze again.")
+    row = candidates[0]
+    if row["item"].get("type") not in {"movie", "show", "anime", "season", "episode"}:
+        raise HTTPException(400, "This item cannot be mapped")
+    version = hashlib.sha256(json.dumps(row, sort_keys=True, default=str).encode()).hexdigest()
+    if payload.action != "context" and payload.version != version:
+        raise HTTPException(409, "The source item changed. Reopen mapping before continuing.")
+    return cfg, row, version
+
+
+def handle_mapping(payload: MappingRequest, request):
+    cfg, row, version = mapping_row(payload, request)
+    if payload.action == "context":
+        return dict(ok=True, row=row, version=version)
+    if payload.action == "catalogs":
+        from services.interactive_sync_catalogs import search_catalogs
+        from services.interactive_sync_episodes import metadata_key
+        return {**search_catalogs(cfg, row), "episode_matching": bool(metadata_key(cfg, row))}
+    if payload.action == "search":
+        from services.interactive_sync_mapping import search_candidates
+        if len(payload.q.strip()) < 2:
+            raise HTTPException(400, "Enter at least two characters")
+        return search_candidates(cfg, row, payload.q, catalog=payload.catalog)
+    if payload.action == "episodes":
+        from services.interactive_sync_episodes import suggest_episodes
+        return suggest_episodes(cfg, [(row, payload.item)])
+
+    from api.interactiveSyncAPI import prepare_mapping
+    from api.editorAPI import _require_instance_scope, _save_policy_manual_batch
+    from services.saved_mappings import mapping_details
+
+    _require_instance_scope(cfg, request, row["source"], row["source_instance"])
+    key, item, blocks = prepare_mapping(row, payload.item)
+    scope = (row["feature"], row["source"], row["source_instance"])
+    records = {scope: {key: dict(original_key=row["key"], original=mapping_details(row["item"]),
+                               saved_at=int(time.time()), origin="analyzer")}}
+    _save_policy_manual_batch([(row["feature"], row["source"], {key: item}, blocks, row["source_instance"])], mappings=records)
+    return dict(ok=True, key=key)

--- a/tests/test_analyzer_mapping.py
+++ b/tests/test_analyzer_mapping.py
@@ -1,0 +1,130 @@
+import pytest
+from fastapi import HTTPException
+
+from services import analyzer as an
+from services import analyzer_mapping as mapping
+
+
+@pytest.fixture
+def mapping_case(monkeypatch):
+    key = "tmdb:123#s01e02"
+    item = dict(type="episode", title="Original", series_title="Original", season=1, episode=2,
+                ids={"tmdb": "123"}, watched_at="2026-09-07T12:00:00Z", rating=8)
+    pair = dict(id="p1", source="SIMKL", source_instance="alice", target="MDBLIST",
+                target_instance="destination", mode="one-way", features={"history": True})
+    state = {"providers": {"SIMKL": {"instances": {"alice": {"history": {"baseline": {"items": {key: item}}}}}}}}
+    entry = dict(provider="MDBLIST", feature="history", key=key, keys=[key], unresolved=True,
+                 target="MDBLIST@destination")
+    cfg = {"pairs": [pair]}
+    monkeypatch.setattr(an, "_cfg", lambda: cfg)
+    monkeypatch.setattr(an, "_cached_analysis", lambda pid: {"attention": {"rows": [entry]}})
+    monkeypatch.setattr(an, "_load_state_handles", lambda pid, features: [{"state": state}])
+    monkeypatch.setattr(mapping, "request_user", lambda request: None)
+    payload = mapping.MappingRequest(pair_id="p1", provider="MDBLIST", feature="history", key=key)
+    return payload, pair, state, entry, item
+
+
+def test_saves_source_profile_preserving_watched_date_and_rating(mapping_case, monkeypatch):
+    from api import editorAPI
+    payload, pair, state, entry, original = mapping_case
+    saved = []
+    monkeypatch.setattr(editorAPI, "_require_instance_scope", lambda *args: None)
+    monkeypatch.setattr(editorAPI, "_save_policy_manual_batch", lambda edits, **kwargs: saved.append((edits, kwargs)))
+    context = mapping.handle_mapping(payload, None)
+    assert context["row"]["source"] == "SIMKL"
+    assert context["row"]["source_instance"] == "alice"
+    assert context["row"]["instance"] == "destination"
+    corrected = {**original, "ids": {"tmdb": "456"}, "show_ids": {"tmdb": "456"}, "episode": 3,
+                 "watched_at": "do not overwrite", "rating": 1}
+    result = mapping.handle_mapping(payload.model_copy(update=dict(action="save", version=context["version"], item=corrected)), None)
+    assert result["key"] == "tmdb:456#s01e03"
+    edits, metadata = saved[0]
+    feature, provider, items, blocks, instance = edits[0]
+    assert (feature, provider, instance) == ("history", "SIMKL", "alice")
+    assert items[result["key"]]["watched_at"] == original["watched_at"]
+    assert items[result["key"]]["rating"] == 8
+    assert blocks == [payload.key]
+    record = metadata["mappings"][(feature, provider, instance)][result["key"]]
+    assert record["origin"] == "analyzer" and record["original_key"] == payload.key
+    assert original["episode"] == 2
+
+
+def test_reverse_direction_uses_actual_source(mapping_case):
+    payload, pair, state, entry, item = mapping_case
+    pair["mode"] = "two-way"
+    state["providers"] = {"MDBLIST": {"instances": {"destination": {"history": {"baseline": {"items": {payload.key: item}}}}}}}
+    entry.update(provider="SIMKL", target="SIMKL@alice")
+    context = mapping.handle_mapping(payload.model_copy(update={"provider": "SIMKL"}), None)
+    assert context["row"]["source"] == "MDBLIST"
+    assert context["row"]["source_instance"] == "destination"
+    assert context["row"]["provider"] == "SIMKL"
+
+
+def test_same_provider_instances_keep_direction(mapping_case):
+    payload, pair, state, entry, item = mapping_case
+    pair["target"] = "SIMKL"
+    entry.update(provider="SIMKL", target="SIMKL@destination")
+    context = mapping.handle_mapping(payload.model_copy(update={"provider": "SIMKL"}), None)
+    assert context["row"]["source_instance"] == "alice"
+    assert context["row"]["instance"] == "destination"
+
+
+@pytest.mark.parametrize("change", ["pair", "item", "pending", "profile"])
+def test_changed_or_unavailable_entry_is_not_saved(mapping_case, change):
+    payload, pair, state, entry, item = mapping_case
+    context = mapping.handle_mapping(payload, None)
+    if change == "pair": pair["id"] = "different"
+    if change == "item": item["watched_at"] = "later"
+    if change == "pending": entry["unresolved"] = False
+    if change == "profile": pair["source_instance"] = "bob"
+    with pytest.raises(HTTPException) as error:
+        mapping.handle_mapping(payload.model_copy(update=dict(action="save", version=context["version"], item=item)), None)
+    assert error.value.status_code in {404, 409}
+
+
+@pytest.mark.parametrize("write,access,status", [(False, True, 403), (True, False, 404)])
+def test_permissions_checked_before_reading_item(mapping_case, monkeypatch, write, access, status):
+    monkeypatch.setattr(mapping, "request_user", lambda request: {"is_admin": False, "permissions": {"write": write}})
+    monkeypatch.setattr(mapping, "user_can_access_pair", lambda *args: access)
+    with pytest.raises(HTTPException) as error:
+        mapping.handle_mapping(mapping_case[0], None)
+    assert error.value.status_code == status
+
+
+def test_search_and_episodes_use_shared_mapping_services(mapping_case, monkeypatch):
+    from services import interactive_sync_mapping, interactive_sync_episodes
+    payload = mapping_case[0]
+    context = mapping.handle_mapping(payload, None)
+    calls = []
+    monkeypatch.setattr(interactive_sync_mapping, "search_candidates", lambda cfg, row, q, **kw: calls.append((row, q)) or {"items": []})
+    monkeypatch.setattr(interactive_sync_episodes, "suggest_episodes", lambda cfg, edits: calls.append(edits) or {"results": []})
+    mapping.handle_mapping(payload.model_copy(update=dict(action="search", version=context["version"], q="Title")), None)
+    mapping.handle_mapping(payload.model_copy(update=dict(action="episodes", version=context["version"], item=context["row"]["item"])), None)
+    assert calls[0][0]["source_instance"] == "alice"
+    assert calls[1][0][0]["id"] == "analyzer-item"
+
+
+def test_api_save_persists_in_editor_saved_mappings(mapping_case, config_base, monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from api import editorAPI
+
+    monkeypatch.setattr(editorAPI, "_STATE_BASE", config_base)
+    monkeypatch.setattr(editorAPI, "load_config", lambda: {})
+    app = FastAPI()
+    app.include_router(an.router)
+    app.include_router(editorAPI.router)
+    payload = mapping_case[0].model_dump()
+    with TestClient(app) as client:
+        response = client.post("/api/analyzer/mapping", json=payload)
+        assert response.status_code == 200
+        context = response.json()
+        corrected = {**context["row"]["item"], "ids": {"tmdb": "456"}, "show_ids": {"tmdb": "456"}}
+        response = client.post("/api/analyzer/mapping", json={**payload, "action": "save", "version": context["version"], "item": corrected})
+        assert response.status_code == 200
+        records = client.get("/api/editor/mappings").json()["items"]
+    assert len(records) == 1
+    assert records[0]["origin"] == "analyzer"
+    assert (records[0]["provider"], records[0]["instance"]) == ("SIMKL", "alice")
+    assert records[0]["original"]["ids"] == {"tmdb": "123"}
+    assert records[0]["corrected"]["ids"] == {"tmdb": "456"}

--- a/tests/test_analyzer_page.py
+++ b/tests/test_analyzer_page.py
@@ -9,10 +9,11 @@ from ui_frontend import get_index_html
 
 
 @pytest.mark.parametrize("admin,write,visible", [(True, False, True), (False, True, True), (False, False, False)])
-def test_analyzer_page_respects_existing_write_access(admin, write, visible):
+@pytest.mark.parametrize("page,label", [("analyzer", "Analyzer"), ("events", "Events"), ("logs", "Logs")])
+def test_analyzer_page_respects_existing_write_access(admin, write, visible, page, label):
     html = get_index_html(include_admin=admin, user={"permissions": {"write": write, "dashboard": True}})
-    assert ('id="page-analyzer"' in html) is visible
-    assert 'id="tab-analyzer"' not in html
+    assert (f'id="page-{page}"' in html) is visible
+    assert f'id="tab-{page}"' not in html
     if visible:
-        assert 'html[data-cw-initial-tab="analyzer"] #page-analyzer' in html
-        assert 'analyzer: "Analyzer"' in html
+        assert f'html[data-cw-initial-tab="{page}"] #page-{page}' in html
+        assert f'{page}: "{label}"' in html


### PR DESCRIPTION
# Pull request

## Change

- Added a pencil icon to Analyzer’s Pending retries tab that opens the shared Interactive Sync mapping dialog. 
- Corrections are saved to the source profile and appear in Editor’s Saved mappings.

## Why

- Users can correct unresolved items directly from Analyzer, then rerun the pair to retry them with the saved mapping.

## Testing

- tests/test_analyzer_page.py

## Issue

Relates to #1016