### PR TITLE
Add: live and saved Logs page

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -31,6 +31,7 @@ from .versionAPI import router as version_router
 from .editorAPI import router as editor_router
 from .interactiveSyncAPI import router as interactive_sync_router
 from .eventsAPI import router as events_router
+from .logsAPI import router as logs_router
 from .providerInstancesAPI import router as provider_instances_router
 from .playbackProgressAPI import router as playback_progress_router
 from .profileAPI import router as profile_router
@@ -114,6 +115,7 @@ def register(
     app.include_router(editor_router)
     app.include_router(interactive_sync_router)
     app.include_router(events_router)
+    app.include_router(logs_router)
     app.include_router(provider_instances_router)
     app.include_router(playback_progress_router)
     app.include_router(profile_router)

--- a/api/appAuthAPI.py
+++ b/api/appAuthAPI.py
@@ -701,6 +701,8 @@ def non_admin_api_allowed(path: Any, method: Any) -> bool:
         return m == "GET"
     if p == "/api/logs/stream":
         return m == "GET"
+    if p == "/api/logs/archive" or p.startswith("/api/logs/archive/"):
+        return m in {"GET", "PATCH", "DELETE"}
     if p == "/api/logs/watcher":
         return False
     if p == "/api/playlists/rulesets/validate":

--- a/api/logsAPI.py
+++ b/api/logsAPI.py
@@ -1,0 +1,129 @@
+# api/logsAPI.py
+# CrossWatch - Log archive API
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+
+from __future__ import annotations
+
+import json
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from cw_platform.access_policy import request_user, pair_refs, user_can_access_instance, requested_view_as_profile, profile_instances_map, profile_allows_instance
+from cw_platform.config_base import load_config
+from services.log_archive import archive, MAX_BYTES, RETENTION_DAYS
+
+router = APIRouter(prefix='/api/logs/archive', tags=['logging'])
+
+
+def allowed(request: Request, session: dict) -> bool:
+    user = request_user(request)
+    profile = requested_view_as_profile(request)
+    if (not user or user.get('is_admin')) and not profile:
+        return True
+    if session['channel'] != 'sync':
+        return False
+    pairs = json.loads(session['pairs'])
+    if not pairs:
+        return False
+    cfg = load_config() or {}
+    scope = profile_instances_map(cfg, profile) if profile else None
+    refs = [ref for pair in pairs for ref in pair_refs(pair)]
+    return bool(refs) and all(user_can_access_instance(cfg, user, provider, instance)
+                              and (scope is None or profile_allows_instance(scope, provider, instance))
+                              for provider, instance in refs)
+
+
+def get_session(request: Request, sid: str) -> dict:
+    item = archive().session(sid)
+    if not item or not allowed(request, item):
+        raise HTTPException(404, 'Log not found for this profile.')
+    return item
+
+
+@router.get('')
+def sessions(request: Request, channel: Literal['sync', 'watcher', 'debug'] = 'sync', run_id: str = Query('', max_length=160), pair_id: str = Query('', max_length=160)):
+    store = archive()
+    items = [item for item in store.sessions(channel, run_id, pair_id) if allowed(request, item)]
+    sync_logs = [item for item in store.sessions('sync') if allowed(request, item)]
+    choices = {}
+    # Include configured pairs with no logs yet, and retained logs for removed pairs.
+    configured = (load_config() or {}).get('pairs') or []
+    for pair in configured:
+        if isinstance(pair, dict) and allowed(request, dict(channel='sync', pairs=json.dumps([pair]))):
+            choices[str(pair.get('id') or '')] = pair
+    for item in sync_logs:
+        for pair in json.loads(item['pairs']):
+            choices.setdefault(str(pair.get('id') or ''), pair)
+    choices.pop('', None)
+    pairs = []
+    for index, (key, pair) in enumerate(choices.items(), 1):
+        (src, src_inst), (dst, dst_inst) = pair_refs(pair)
+        arrow = '↔' if 'two' in str(pair.get('mode') or '') else '→'
+        label = f"{pair.get('name') or f'Pair {index}'} · {src} · {src_inst} {arrow} {dst} · {dst_inst}"
+        pairs.append(dict(id=key, label=label))
+    latest = next((item['run_id'] for item in store.sessions('sync', pair_id=pair_id) if item['run_id'] and allowed(request, item)), '')
+    if pair_id or run_id:
+        items = [dict(item, **store.counts(item['id'], pair_id, run_id)) for item in items]
+    user = request_user(request)
+    admin = (not user or bool(user.get('is_admin'))) and not requested_view_as_profile(request)
+    return dict(items=items, pairs=pairs, latest_run_id=latest, channels=['sync', 'watcher', 'debug'] if admin else ['sync'], retention_days=RETENTION_DAYS,
+                max_bytes=MAX_BYTES, used_bytes=archive().used if admin else sum(item['bytes'] for item in items))
+
+
+@router.get('/{sid}/lines')
+def lines(request: Request, sid: str, q: str = Query('', max_length=200), level: str = Query('', pattern='^(|ERROR|WARN|INFO|DEBUG)$'),
+          provider: str = Query('', max_length=80), after: int = Query(0, ge=0), offset: int = Query(0, ge=0), limit: int = Query(500, ge=1, le=1000),
+          pair_id: str = Query('', max_length=160), run_id: str = Query('', max_length=160)):
+    item = get_session(request, sid)
+    if pair_id or run_id:
+        item = dict(item, **archive().counts(sid, pair_id, run_id))
+    result = archive().page(sid, q=q, level=level, provider=provider, after=after, offset=offset, limit=limit, pair_id=pair_id, run_id=run_id)
+    return dict(session=item, **result)
+
+
+@router.get('/{sid}/context/{line_id}')
+def context(request: Request, sid: str, line_id: int, pair_id: str = Query('', max_length=160), run_id: str = Query('', max_length=160)):
+    get_session(request, sid)
+    return dict(items=archive().context(sid, line_id, pair_id, run_id))
+
+
+class Pin(BaseModel):
+    pinned: bool
+
+
+@router.patch('/{sid}')
+def pin(request: Request, sid: str, body: Pin):
+    get_session(request, sid)
+    archive().pin(sid, body.pinned)
+    return dict(ok=True)
+
+
+@router.delete('/{sid}')
+def delete(request: Request, sid: str):
+    get_session(request, sid)
+    try:
+        archive().delete(sid)
+    except ValueError as error:
+        raise HTTPException(409, str(error)) from error
+    return dict(ok=True)
+
+
+@router.delete('')
+def clear_older(request: Request, channel: Literal['sync', 'watcher', 'debug'] = 'sync'):
+    count = 0
+    for item in archive().sessions(channel):
+        if item['ended'] is not None and not item['pinned'] and allowed(request, item):
+            archive().delete(item['id'])
+            count += 1
+    return dict(ok=True, deleted=count)
+
+
+@router.get('/{sid}/download', response_class=StreamingResponse)
+def download(request: Request, sid: str, q: str = Query('', max_length=200), level: str = Query('', pattern='^(|ERROR|WARN|INFO|DEBUG)$'), provider: str = Query('', max_length=80),
+             pair_id: str = Query('', max_length=160), run_id: str = Query('', max_length=160)):
+    get_session(request, sid)
+    return StreamingResponse(archive().export(sid, q=q, level=level, provider=provider, pair_id=pair_id, run_id=run_id), media_type='text/plain',
+                             headers={'Content-Disposition': f'attachment; filename="crosswatch-{sid}.log"', 'Cache-Control': 'no-store'})

--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -780,6 +780,22 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None, *, interactive
     scheduler_webhook_cfg: dict[str, Any] | None = None
     scheduler_start_sent = False
     was_cancelled = False
+    from cw_platform.log_context import log_run_id
+    log_token = log_run_id.set(str(run_id))
+    archived_run = None
+    try:
+        from services.log_archive import archive
+        log_cfg = _env()[0]()
+        requested = str(overrides.get("pair_id") or overrides.get("pair_scope") or "").strip()
+        raw_log_scope = overrides.get("pair_scope_ids")
+        scope = {str(value or '').strip() for value in raw_log_scope if str(value or '').strip()} if isinstance(raw_log_scope, list) else set()
+        log_pairs = [{key: p.get(key) for key in ("id", "source", "source_instance", "src_instance", "target", "target_instance", "dst_instance", "mode")}
+                     for p in log_cfg.get("pairs", []) if isinstance(p, dict) and coerce_bool(p.get("enabled", True), True)
+                     and (not requested or str(p.get("id")) == requested)
+                     and (not scope or str(p.get("id") or '').strip() in scope)]
+        archived_run = archive().start(str(run_id), log_pairs)
+    except Exception:
+        pass
     clear_cancel()
     _summary_reset()
     _summary_set("run_id", str(run_id))
@@ -1108,7 +1124,15 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None, *, interactive
         except Exception:
             pass
         clear_cancel()
+        if archived_run:
+            try:
+                snap = _summary_snapshot()
+                outcome = "cancelled" if was_cancelled else "failed" if snap.get("exit_code") not in (0, "0") or snap.get("errors") else "issues" if snap.get("unresolved") or snap.get("blocked") else "completed"
+                archive().finish(archived_run, outcome)
+            except Exception:
+                pass
         RUNNING_PROCS.pop("SYNC", None)
+        log_run_id.reset(log_token)
 
 def _lanes_enabled_defaults() -> dict[str, bool]:
     return {"watchlist": True, "ratings": True, "history": True, "progress": True, "playlists": True, "collection": True}

--- a/assets/css/logs.css
+++ b/assets/css/logs.css
@@ -1,0 +1,61 @@
+/* assets/css/logs.css */
+/* CrossWatch - Diagnostic log page styles */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+
+html[data-tab="logs"] { overflow: hidden; }
+#page-logs { padding: 0; background: transparent; border: 0; box-shadow: none; }
+.logs-page { display: flex; flex-direction: column; min-height: 0; padding: 12px 8px 0; color: var(--fg, #edf0f8); --log-line: var(--border, #ffffff16); --log-surface: var(--panel, #101217); --log-muted: var(--muted, #9296aa); }
+.logs-page [hidden] { display: none!important; }
+.logs-back { display: inline-flex; align-items: center; align-self: flex-start; gap: 8px; color: var(--log-muted); text-decoration: none; font-size: 13px; }
+.logs-heading { position: static; z-index: auto; display: flex; align-items: center; justify-content: space-between; padding: 14px 0; background: transparent; border: 0; box-shadow: none; }
+.logs-heading h1 { margin: 5px 0 0; font-size: 32px; letter-spacing: -.035em; }
+.logs-eyebrow { color: var(--accent); font-size: 10px; letter-spacing: .2em; font-weight: 700; }
+.logs-heading > span, .logs-toolbar > span { color: var(--log-muted); font-size: 12px; }
+.logs-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; margin-bottom: 12px; }
+.logs-toolbar > [data-storage] { margin-left: auto; }
+.logs-pair-controls { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; min-width: 0; }
+.logs-page [data-pair], .logs-page [data-pair] + .cw-icon-select { width: 310px; max-width: 100%; }
+.logs-page [data-level], .logs-page [data-level] + .cw-icon-select { width: 140px; flex-shrink: 0; }
+.logs-pair-controls .cw-icon-select-btn { width: 100%; }
+.logs-tabs { display: flex; gap: 4px; padding: 3px; background: var(--log-surface); border: 1px solid var(--log-line); border-radius: 9px; }
+.logs-page button,.logs-page select,.logs-page input:not([type="checkbox"]),.logs-options summary { font: inherit; font-size: 12px; color: inherit; background: var(--log-surface); border: 1px solid var(--log-line); border-radius: 7px; padding: 8px 12px; }
+.logs-page button { cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 6px; }
+.logs-page button:hover:not(:disabled) { border-color: var(--accent); }
+.logs-page button:disabled { opacity: .4; cursor: default; }
+.logs-page :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.logs-tabs button { border: 0; }
+.logs-tabs [aria-selected="true"] { background: color-mix(in srgb, var(--accent) 20%, transparent); color: var(--accent); }
+.logs-page .material-symbols-rounded { font-size: 18px; }
+.logs-search { display: flex; align-items: center; gap: 8px; flex: 1; min-width: 180px; background: var(--log-surface); border: 1px solid var(--log-line); border-radius: 7px; padding-left: 12px; }
+.logs-page .logs-search input { width: 100%; border: 0; background: transparent; }
+.logs-page [data-provider] { width: 125px; }
+.logs-runbar > strong { flex: 1; font-size: 13px; }
+.logs-page .logs-error { color: #ef8791; }
+.logs-page .logs-warn { color: #e8bb69; }
+.logs-options { position: relative; }
+.logs-options summary { cursor: pointer; }
+.logs-options > div { position: absolute; right: 0; top: 100%; z-index: 5; display: grid; gap: 6px; padding: 12px; width: 210px; background: var(--log-surface); border: 1px solid var(--log-line); border-radius: 9px; }
+.logs-options label { display: flex; align-items: center; gap: 8px; font-size: 12px; padding: 5px; }
+.logs-content { flex: 1; min-height: 0; overflow: auto; overscroll-behavior: contain; border: 1px solid var(--log-line); border-radius: 10px; background: var(--log-surface); scrollbar-gutter: stable; }
+.logs-line { display: grid; grid-template-columns: 78px 48px 90px minmax(0, 1fr) 28px; align-items: start; gap: 10px; padding: 7px 12px; border-bottom: 1px solid var(--log-line); font: 12px/1.55 ui-monospace, Consolas, monospace; border-left: 3px solid transparent; }
+.logs-line time,.logs-provider,.logs-level { color: var(--log-muted); overflow-wrap: anywhere; }
+.logs-message { white-space: pre-wrap; overflow-wrap: anywhere; }
+.logs-nowrap .logs-message { white-space: pre; }
+.logs-nowrap .logs-line { grid-template-columns: 78px 48px 90px minmax(max-content, 1fr) 28px; }
+.logs-line.logs-error { border-left-color: #ef8791; background: #ef879110; }
+.logs-line.logs-warn { border-left-color: #e8bb69; background: #e8bb690b; }
+.logs-error .logs-level { color: #ef8791; }
+.logs-warn .logs-level { color: #e8bb69; }
+.logs-line button { border: 0; padding: 1px; background: transparent; }
+.logs-line mark { background: #e8bb69; color: #161822; border-radius: 2px; }
+.logs-line.logs-current-match { outline: 1px solid var(--accent); outline-offset: -1px; }
+.logs-context { margin: 8px 16px; border: 1px solid var(--log-line); border-radius: 6px; }
+.logs-context-line { opacity: .85; }
+.logs-footer { display: flex; align-items: center; gap: 12px; padding: 10px 0; font-size: 12px; color: var(--log-muted); }
+.logs-footer > span:first-child { margin-right: auto; }
+.logs-saved-row { width: 100%; text-align: left; display: flex!important; align-items: flex-start!important; flex-direction: column; gap: 8px!important; padding: 16px!important; border-width: 0 0 1px!important; border-radius: 0!important; }
+.logs-saved-row span:first-child { display: flex; align-items: center; gap: 10px; }
+.logs-saved-row span:not(:first-child) { color: var(--log-muted); }
+.logs-empty { padding: 48px 24px; text-align: center; color: var(--log-muted); }
+.logs-notice { font-size: 12px; color: #e8bb69; margin: 0 0 10px; }
+@media(max-width:700px) { .logs-heading { padding: 8px 0; } .logs-heading h1 { font-size: 25px; } .logs-toolbar { gap: 6px; margin-bottom: 8px; } .logs-toolbar > [data-storage] { display: none; } .logs-line { grid-template-columns: 65px 45px minmax(0,1fr) 24px; gap: 6px; } .logs-message { grid-column: 1 / 4; grid-row: 2; } .logs-line > button { grid-column: 4; grid-row: 1 / 3; } .logs-nowrap .logs-line { grid-template-columns: 65px 45px minmax(max-content,1fr) 24px; } }

--- a/assets/helpers/core.js
+++ b/assets/helpers/core.js
@@ -83,7 +83,7 @@
   const statusCacheKey = () => `${STATUS_CACHE_KEY}.${String(window.CW?.OverviewProfile?.id || "").trim() || "all"}`;
   const DETAILS_MAX_LINES = 300;
   const authSetupPending = () => window.cwIsAuthSetupPending?.() === true;
-  const ROUTE_TABS = new Set(["main", "watchlist", "playback_progress", "snapshots", "playlists", "editor", "analyzer", "import_export", "interactive_sync", "settings"]);
+  const ROUTE_TABS = new Set(["main", "watchlist", "playback_progress", "snapshots", "playlists", "editor", "analyzer", "events", "logs", "import_export", "interactive_sync", "settings"]);
   const SETTINGS_PANES = new Set(["overview", "providers", "sync", "scrobbler", "scheduling", "app", "maintenance"]);
   let routeSyncing = false;
 
@@ -110,7 +110,7 @@
     if (normalized === "main") return perms.dashboard !== false;
     if (normalized === "playback_progress") return perms.playback !== false;
     if (normalized === "watchlist") return perms.watchlist !== false;
-    if (["snapshots", "playlists", "editor", "analyzer", "import_export", "interactive_sync"].includes(normalized)) return perms.write === true;
+    if (["snapshots", "playlists", "editor", "analyzer", "events", "logs", "import_export", "interactive_sync"].includes(normalized)) return perms.write === true;
     return false;
   }
 
@@ -150,6 +150,8 @@
 
   function routeHash(tab, pane) {
     if (tab === "interactive_sync") return "#interactive_sync" + (window.location.hash.startsWith("#interactive_sync?") ? window.location.hash.slice(window.location.hash.indexOf("?")) : "");
+    if (tab === "logs") return "#logs" + (window.location.hash.startsWith("#logs?") ? window.location.hash.slice(window.location.hash.indexOf("?")) : "");
+    if (tab === "events") return "#events" + (window.location.hash.startsWith("#events?") ? window.location.hash.slice(window.location.hash.indexOf("?")) : "");
     if (tab === "main") return "";
     if (tab === "settings") {
       const settingsPane = normalizeSettingsPane(pane || window.__cwSettingsPane || "overview");
@@ -1029,7 +1031,7 @@
   }
 
   function setTabHeaderState(tab) {
-    ["main", "watchlist", "playback_progress", "snapshots", "playlists", "editor", "analyzer", "import_export", "settings"].forEach((name) => {
+    ["main", "watchlist", "playback_progress", "snapshots", "playlists", "editor", "analyzer", "events", "logs", "import_export", "settings"].forEach((name) => {
       byId(`tab-${name}`)?.classList.toggle("active", name === tab);
     });
   }
@@ -1045,6 +1047,8 @@
     byId("page-playlists")?.classList.toggle("hidden", tab !== "playlists");
     byId("page-editor")?.classList.toggle("hidden", tab !== "editor");
     byId("page-analyzer")?.classList.toggle("hidden", tab !== "analyzer");
+    byId("page-events")?.classList.toggle("hidden", tab !== "events");
+    byId("page-logs")?.classList.toggle("hidden", tab !== "logs");
     byId("page-import_export")?.classList.toggle("hidden", tab !== "import_export");
     byId("page-interactive_sync")?.classList.toggle("hidden", tab !== "interactive_sync");
     byId("page-settings")?.classList.toggle("hidden", tab !== "settings");
@@ -1091,12 +1095,14 @@
       const watchlistAllowed = perms.watchlist !== false;
       const playbackAllowed = perms.playback !== false;
       const writeAllowed = perms.write === true;
-      if (!(tab === "main" && dashboardAllowed) && !(tab === "watchlist" && watchlistAllowed) && !(tab === "playback_progress" && playbackAllowed) && !(["snapshots", "playlists", "editor", "analyzer", "import_export"].includes(tab) && writeAllowed)) tab = allowedRouteTab(tab);
+      if (!(tab === "main" && dashboardAllowed) && !(tab === "watchlist" && watchlistAllowed) && !(tab === "playback_progress" && playbackAllowed) && !(["snapshots", "playlists", "editor", "analyzer", "events", "logs", "import_export"].includes(tab) && writeAllowed)) tab = allowedRouteTab(tab);
     }
     writeRouteHash(tab);
 
     if (state.currentTab === tab) {
       if (tab === "interactive_sync") window.InteractiveSync?.refresh?.();
+      if (tab === "events") await window.EventsPage?.mount?.(byId("page-events"));
+      if (tab === "logs") await window.LogsPage?.mount?.(byId("page-logs"));
       if (tab === "settings") {
         const pane = normalizeSettingsPane(window.__cwSettingsPane || readRouteHash().pane || "overview");
         window.__cwSettingsPane = pane;
@@ -1109,6 +1115,8 @@
     const previousTab = state.currentTab;
     const isCurrentNavigation = () => navSeq === state.navSeq;
 
+    if (previousTab === "events") window.EventsPage?.hide?.();
+    if (previousTab === "logs") window.LogsPage?.hide?.();
     setTabHeaderState(tab);
     setPageVisibility(tab);
     document.dispatchEvent(new CustomEvent("tab-changed", { detail: { id: tab, tab } }));
@@ -1205,6 +1213,39 @@
         const root = byId("page-import_export");
         if (root) root.innerHTML = '<div class="cw-page-load-error">Import / Export failed to load. Refresh the page and try again.</div>';
         console.error("Import / Export failed to load", error);
+      }
+      return;
+    }
+
+    if (tab === "logs") {
+      try {
+        await ensurePageModule("logs", "/assets/js/logs.js", "LogsPage");
+        if (!isCurrentNavigation()) return;
+        await window.LogsPage.mount(byId("page-logs"));
+      } catch (error) {
+        if (!isCurrentNavigation()) return;
+        window.LogsPage?.unmount?.();
+        const root = byId("page-logs");
+        if (root) root.innerHTML = '<div class="cw-page-load-error">Logs failed to load. Refresh the page and try again.</div>';
+      }
+      return;
+    }
+
+    if (tab === "events") {
+      try {
+        const root = byId("page-events");
+        if (root && !root.children.length) {
+          root.innerHTML = '<div class="cw-page-loading" role="status">Loading events…</div>';
+        }
+        await ensurePageModule("events", "/assets/js/events/page.js", "EventsPage");
+        if (!isCurrentNavigation()) return;
+        await window.EventsPage.mount(byId("page-events"));
+      } catch (error) {
+        if (!isCurrentNavigation()) return;
+        window.EventsPage?.unmount?.();
+        const root = byId("page-events");
+        if (root) root.innerHTML = '<div class="cw-page-load-error">Events failed to load. Refresh the page and try again.</div>';
+        console.error("Events failed to load", error);
       }
       return;
     }

--- a/assets/js/connections.pairs.overlay.js
+++ b/assets/js/connections.pairs.overlay.js
@@ -344,6 +344,10 @@
                 <svg viewBox="0 0 24 24" class="ico" aria-hidden="true"><path d="M8 5l11 7-11 7V5z"></path></svg>
               </button>
 
+              <button type="button" class="icon-btn" data-tip="Latest logs" aria-label="Latest logs" data-pair-logs="${esc(pr.id)}">
+                <svg viewBox="0 0 24 24" class="ico" aria-hidden="true"><rect x="3" y="4" width="18" height="16" rx="2"></rect><path d="m7 9 3 3-3 3M13 15h4"></path></svg>
+              </button>
+
               <label class="icon-btn power ${enabled ? "" : "off"}" data-tip="Enable / disable" role="switch" aria-checked="${enabled}">
                 <input class="sr-only" type="checkbox" name="pair-enabled" ${enabled ? "checked" : ""}
                   onchange="this.closest('.icon-btn.power')?.setAttribute('aria-checked', this.checked); window.cxToggleEnable && window.cxToggleEnable('${pr.id}', this.checked, this)">
@@ -440,6 +444,8 @@
   document.addEventListener("cx-state-change", renderOrEnhance);
   window.addEventListener("auth-changed", () => renderOrEnhance());
   document.addEventListener("click", event => {
+    const logs = event.target.closest?.('[data-pair-logs]');
+    if (logs) window.openLogs?.({pairId:logs.dataset.pairLogs, latest:true});
     const button = event.target.closest?.("[data-interactive-pair]");
     if (button && !button.disabled) location.hash = `interactive_sync?pair=${encodeURIComponent(button.dataset.interactivePair)}`;
   });

--- a/assets/js/logs.js
+++ b/assets/js/logs.js
@@ -1,0 +1,211 @@
+/* assets/js/logs.js */
+/* CrossWatch - Live and saved diagnostic logs */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+
+const esc = value => String(value ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+const icon = name => `<span class="material-symbols-rounded" aria-hidden="true">${name}</span>`;
+const date = ts => ts ? new Date(ts * 1000).toLocaleString() : 'Live';
+export function highlight(text, query) {
+  if (!query) return esc(text);
+  const lower = text.toLowerCase(), needle = query.toLowerCase();
+  let pos = 0, result = '', found;
+  while ((found = lower.indexOf(needle, pos)) !== -1) {
+    result += esc(text.slice(pos, found)) + '<mark>' + esc(text.slice(found, found + query.length)) + '</mark>';
+    pos = found + query.length;
+  }
+  return result + esc(text.slice(pos));
+}
+
+let dispose = null, root = null;
+const LogsPage = {
+  async mount(host) {
+    dispose?.(); root = host;
+    if (!host) return;
+    if (!document.getElementById('cw-logs-css')) {
+      const css = document.createElement('link'); css.id = 'cw-logs-css'; css.rel = 'stylesheet';
+      css.href = `/assets/css/logs.css?v=${encodeURIComponent(window.APP_VERSION || '1')}`; document.head.append(css);
+    }
+    const route = new URLSearchParams(location.hash.split('?')[1] || '');
+    let channel = ['sync','watcher','debug'].includes(route.get('channel')) ? route.get('channel') : 'sync';
+    let pairId = route.get('pairId') || '', latestRequested = route.get('latest') === '1', pairs = [], latestRunId = '';
+    if (channel === 'watcher') pairId = '';
+    let runId = route.get('runId') || '', mode = runId || latestRequested ? 'saved' : 'live', sid = '', sessions = [], current = null;
+    let alive = true, busy = false, sequence = 0, timer, searchTimer, offset = 0, total = 0, follow = mode === 'live', rows = [], matchIndex = -1;
+    let query = '', level = '', provider = '', listPage = 0, showingRuns = mode === 'saved', controller = null, pendingMatch = null;
+    const profile = window.CW?.OverviewProfile?.id || '';
+    host.innerHTML = `<div class="logs-page"><a href="#main" class="logs-back">${icon('arrow_back')}Main</a>
+      <header class="logs-heading"><div><div class="logs-eyebrow">DIAGNOSTICS</div><h1>Logs</h1></div><span data-connection role="status">Connecting…</span></header>
+      <div class="logs-toolbar"><div class="logs-tabs" role="tablist" aria-label="Log channel">${['sync','watcher','debug'].map(c=>`<button data-channel="${c}" role="tab">${c[0].toUpperCase()+c.slice(1)}</button>`).join('')}</div><div class="logs-tabs" role="tablist" aria-label="Log source"><button data-mode="live" role="tab">Live</button><button data-mode="saved" role="tab">Saved logs</button></div><div class="logs-pair-controls" data-pair-controls><select data-pair aria-label="Sync pair"><option value="">All pairs</option></select><button data-latest title="Open the latest run for this selection">${icon('history')}Latest run</button></div><span data-storage></span></div>
+      <div class="logs-toolbar" data-filters><label class="logs-search">${icon('search')}<input data-query type="search" placeholder="Search logs…" aria-label="Search logs"></label><select data-level aria-label="Log level"><option value="">All levels</option><option value="ERROR">Errors</option><option value="WARN">Warnings</option><option value="INFO">Info</option><option value="DEBUG">Debug</option></select><input data-provider placeholder="Provider" aria-label="Filter by provider" list="log-providers"><datalist id="log-providers"></datalist><button data-prev-match title="Previous match" aria-label="Previous match">${icon('keyboard_arrow_up')}</button><button data-next-match title="Next match" aria-label="Next match">${icon('keyboard_arrow_down')}</button><button data-follow>${icon('podcasts')}Follow live</button>
+      <details class="logs-options"><summary>More</summary><div><label><input data-wrap type="checkbox" checked>Wrap lines</label><button data-copy>Copy filtered log</button><button data-copy-full>Copy full log</button><button data-download>Download filtered log</button><button data-download-full>Download full log</button></div></details></div>
+      <div class="logs-toolbar logs-runbar"><button data-back-runs hidden>${icon('arrow_back')}Saved logs</button><strong data-title></strong><button data-errors class="logs-error"></button><button data-warnings class="logs-warn"></button><button data-pin hidden>${icon('push_pin')}Keep this log</button><button data-delete hidden>${icon('delete')}Delete</button><button data-clear hidden>Clear older logs</button></div>
+      <p class="logs-notice" data-notice role="status" hidden></p><div class="logs-content" tabindex="0" aria-label="Log output"><div data-output></div></div>
+      <footer class="logs-footer"><span data-count></span><button data-previous>Previous</button><span data-page></span><button data-next>Next</button></footer></div>`;
+    const $ = s => host.querySelector(s);
+    const content = $('.logs-content');
+    function resize() { const page=$('.logs-page'); if(alive && page)page.style.height = `${Math.max(260, window.innerHeight - host.getBoundingClientRect().top - 16)}px`; }
+    window.addEventListener('resize', resize); resize();
+    function url(path, values = {}) { const p = new URLSearchParams({...values, user_profile:profile}); return '/api/logs/archive' + path + '?' + p; }
+    const scope = () => ({pair_id:pairId, run_id:runId});
+    function writeRoute() {
+      const params = new URLSearchParams({channel});
+      if(pairId)params.set('pairId',pairId);
+      if(runId)params.set('runId',runId);
+      if(latestRequested)params.set('latest','1');
+      window.history.replaceState(null,'','#logs?'+params);
+    }
+    function clearFilters() {
+      query=level=provider='';
+      for(const selector of ['[data-query]','[data-level]','[data-provider]'])$(selector).value='';
+      $('[data-level]').dispatchEvent(new Event('change',{bubbles:true}));
+    }
+    async function api(path, values = {}, options = {}) {
+      const res = await fetch(url(path, values), {cache:'no-store', signal:controller?.signal, ...options});
+      if (!res.ok) { let message = 'Could not load logs.'; try { message = (await res.json()).detail || message; } catch {} throw new Error(message); }
+      return res.json();
+    }
+    function notice(text = '') { $('[data-notice]').textContent = text; $('[data-notice]').hidden = !text; }
+    function revealMatch(index) {
+      matchIndex = Math.max(0, Math.min(rows.length - 1, index));
+      host.querySelectorAll('.logs-current-match').forEach(el=>el.classList.remove('logs-current-match'));
+      const line = host.querySelector(`[data-line="${rows[matchIndex]?.id}"]`);
+      line?.classList.add('logs-current-match');
+      line?.scrollIntoView({block:'center'});
+    }
+    function paintControls() {
+      host.querySelectorAll('[data-channel]').forEach(b=>b.setAttribute('aria-selected',String(b.dataset.channel===channel)));
+      host.querySelectorAll('[data-mode]').forEach(b=>b.setAttribute('aria-selected',String(b.dataset.mode===mode)));
+      $('[data-follow]').textContent = follow ? 'Following live' : 'Resume live';
+      $('[data-follow]').hidden = mode !== 'live';
+      $('[data-filters]').hidden = showingRuns;
+      $('[data-back-runs]').hidden = showingRuns || mode === 'live';
+      $('[data-clear]').hidden = !showingRuns || !!pairId;
+      $('[data-pair-controls]').hidden = channel === 'watcher';
+      $('[data-latest]').disabled = !latestRunId;
+      $('[data-pin]').hidden = showingRuns || !current;
+      $('[data-delete]').hidden = showingRuns || !current || current.ended === null;
+      $('[data-pin]').textContent = current?.pinned ? 'Unpin log' : 'Keep this log';
+      $('[data-pin]').title = 'Keep the entire saved log, including any other pairs in it';
+      $('[data-errors]').hidden = showingRuns || !current;
+      $('[data-warnings]').hidden = showingRuns || !current;
+      $('[data-errors]').textContent = `${current?.errors || 0} errors`;
+      $('[data-warnings]').textContent = `${current?.warnings || 0} warnings`;
+      const pairLabel = pairs.find(p=>p.id===pairId)?.label;
+      $('[data-title]').textContent = showingRuns ? 'Saved logs' : current ? `${pairLabel || current.label} · ${date(current.started)}` : 'No log selected';
+      $('[data-count]').textContent = showingRuns ? `${sessions.length} saved logs` : `${total} matching lines`;
+      $('[data-page]').textContent = showingRuns ? `${listPage+1} / ${Math.max(1,Math.ceil(sessions.length/10))}` : `${Math.floor(offset/500)+1} / ${Math.max(1,Math.ceil(total/500))}`;
+      $('[data-previous]').disabled = showingRuns ? listPage === 0 : offset === 0;
+      $('[data-next]').disabled = showingRuns ? (listPage+1)*10 >= sessions.length : offset+500 >= total;
+      $('[data-prev-match]').disabled = $('[data-next-match]').disabled = !query || !total;
+    }
+    function renderRuns() {
+      listPage = Math.min(listPage, Math.max(0, Math.ceil(sessions.length / 10) - 1));
+      $('[data-output]').innerHTML = sessions.slice(listPage*10,listPage*10+10).map(s=>`<button class="logs-saved-row" data-session="${esc(s.id)}"><span>${icon(s.pinned ? 'push_pin' : 'description')}<strong>${esc(s.label)}</strong></span><span>${esc(date(s.started))} · ${s.ended ? Math.max(0,Math.round(s.ended-s.started))+'s' : 'Live'} · ${esc(s.status)}</span><span>${s.errors} errors · ${s.warnings} warnings</span></button>`).join('') || '<div class="logs-empty">No saved logs for this selection. New logs are saved automatically; older logs from before this update are unavailable.</div>';
+      paintControls();
+    }
+    function lineMarkup(row, context = false) {
+      return `<div class="logs-line logs-${row.level.toLowerCase()}${context?' logs-context-line':''}" ${context?'':`data-line="${row.id}"`}><time>${esc(new Date(row.ts*1000).toLocaleTimeString())}</time><span class="logs-level">${esc(row.level)}</span><span class="logs-provider">${esc(row.provider)}</span><span class="logs-message">${highlight(row.text,query)}</span>${context?'':`<button data-context="${row.id}" aria-label="Show context for line ${row.id}" title="Show surrounding lines">${icon('unfold_more')}</button>`}</div>`;
+    }
+    async function refresh() {
+      if (busy || !alive) return;
+      busy = true; const token = sequence;
+      controller = new AbortController();
+      try {
+        let listing = await api('', {channel, ...scope()});
+        if (!alive || token !== sequence) return;
+        pairs=listing.pairs || [];latestRunId=listing.latest_run_id || '';
+        const options='<option value="">All pairs</option>'+pairs.map(p=>`<option value="${esc(p.id)}">${esc(p.label)}</option>`).join('')+(pairId&&!pairs.some(p=>p.id===pairId)?`<option value="${esc(pairId)}" disabled>Pair unavailable</option>`:'');
+        if($('[data-pair]').innerHTML!==options){$('[data-pair]').innerHTML=options;$('[data-pair]').value=pairId;$('[data-pair]').dispatchEvent(new Event('change'));}
+        if(latestRequested){
+          latestRequested=false;
+          if(latestRunId){runId=latestRunId;listing=await api('',{channel,...scope()});if(!alive||token!==sequence)return;}
+          else notice('No saved run for this pair yet. Logs will appear after its next sync.');
+          writeRoute();
+        }
+        sessions = listing.items;
+        host.querySelectorAll('[data-channel]').forEach(b=>{b.hidden=!listing.channels.includes(b.dataset.channel)});
+        if (!listing.channels.includes(channel)) { channel='sync'; runId=''; sid=''; scheduleReload(); return; }
+        $('[data-storage]').textContent = `${listing.retention_days}-day retention · ${Math.round(listing.used_bytes/1048576)} / ${Math.round(listing.max_bytes/1048576)} MB`;
+        if (showingRuns) {
+          if (runId && sessions.length) { sid=sessions[0].id; showingRuns=false; }
+          else {renderRuns(); $('[data-connection]').textContent='Saved on this server'; return;}
+        }
+        if (mode === 'live') {
+          const newest = sessions.find(s=>s.ended===null) || sessions[0];
+          if (newest && newest.id!==sid) {sid=newest.id;offset=0;}
+        }
+        current=sessions.find(s=>s.id===sid) || null;
+        if (!current) { rows=[];total=0;$('[data-output]').innerHTML='<div class="logs-empty">No logs available yet. Logging is saved automatically as activity arrives.</div>';$('[data-connection]').textContent='Waiting for activity';paintControls();return; }
+        let data=await api(`/${sid}/lines`,{q:query,level,provider,offset,limit:500,...scope()});
+        if (!alive || token!==sequence) return;
+        const nextOffset=follow?Math.max(0,Math.floor((data.total-1)/500)*500):Math.min(offset,Math.max(0,Math.floor((data.total-1)/500)*500));
+        if (nextOffset!==offset) {offset=nextOffset;data=await api(`/${sid}/lines`,{q:query,level,provider,offset,limit:500,...scope()});}
+        if (!alive || token!==sequence) return;
+        current=data.session;total=data.total;
+        // Keep expanded context and text selection intact when the page did not change.
+        if (JSON.stringify(rows)!==JSON.stringify(data.items)) {
+          rows=data.items;
+          $('[data-output]').innerHTML=rows.map(r=>lineMarkup(r)).join('') || '<div class="logs-empty">No matching lines. Try a different search or level.</div>';
+          $('#log-providers').innerHTML=[...new Set(rows.map(r=>r.provider))].sort().map(p=>`<option value="${esc(p)}"></option>`).join('');
+          if(follow) content.scrollTop=content.scrollHeight;
+        }
+        if (pendingMatch !== null) {revealMatch(pendingMatch < 0 ? rows.length-1 : 0);pendingMatch=null;}
+        $('[data-connection]').textContent = mode==='live' ? current.ended ? 'Waiting for activity' : 'Live · updates every 2s' : 'Saved log';
+        if(current.truncated) notice('This log reached the storage limit. Some lines were not saved. Delete or unpin older logs to free space.');
+        paintControls();
+      } catch(error) {if(alive && token===sequence && error.name!=='AbortError'){notice(error.message);$('[data-connection]').textContent='Disconnected · retrying';}}
+      finally {busy=false;}
+    }
+    function scheduleReload() {
+      sequence++; controller?.abort(); rows=[];matchIndex=-1;
+      clearTimeout(searchTimer); searchTimer=setTimeout(()=>{if(busy){scheduleReload();return;}refresh();},150);
+    }
+    function reset() {sid='';current=null;offset=0;total=0;listPage=0;rows=[];pendingMatch=null;$('[data-output]').replaceChildren();notice();scheduleReload();paintControls();writeRoute();}
+    host.addEventListener('click', onClick);
+    async function onClick(event) {
+      const button=event.target.closest('button');if(!button)return;
+      try {
+        if(button.dataset.channel){channel=button.dataset.channel;if(channel==='watcher'){runId='';pairId='';latestRequested=false;}showingRuns=mode==='saved';reset();}
+        else if(button.dataset.mode){mode=button.dataset.mode;showingRuns=mode==='saved';follow=mode==='live';runId='';latestRequested=false;reset();}
+        else if(button.hasAttribute('data-latest')){latestRequested=true;runId='';mode='saved';showingRuns=true;follow=false;clearFilters();reset();}
+        else if(button.dataset.session){sid=button.dataset.session;if(channel==='sync')runId=sessions.find(s=>s.id===sid)?.run_id||'';showingRuns=false;offset=0;rows=[];notice();scheduleReload();writeRoute();}
+        else if(button.hasAttribute('data-back-runs')){showingRuns=true;runId='';reset();}
+        else if(button.hasAttribute('data-follow')){follow=!follow;paintControls();if(follow){content.scrollTop=content.scrollHeight;scheduleReload();}}
+        else if(button.hasAttribute('data-errors')||button.hasAttribute('data-warnings')){level=button.hasAttribute('data-errors')?'ERROR':'WARN';$('[data-level]').value=level;follow=false;offset=0;scheduleReload();}
+        else if(button.hasAttribute('data-previous')||button.hasAttribute('data-next')){const delta=button.hasAttribute('data-next')?1:-1;follow=false;if(showingRuns){listPage+=delta;renderRuns();}else{offset=Math.max(0,offset+delta*500);scheduleReload();}content.scrollTop=0;}
+        else if(button.hasAttribute('data-next-match')||button.hasAttribute('data-prev-match')){
+          const delta=button.hasAttribute('data-next-match')?1:-1;
+          follow=false;
+          if(delta>0 && matchIndex>=rows.length-1 && offset+500<total){offset+=500;scheduleReload();pendingMatch=1;}
+          else if(delta<0 && matchIndex===0 && offset>0){offset-=500;scheduleReload();pendingMatch=-1;}
+          else revealMatch(matchIndex<0 ? (delta>0?0:rows.length-1) : matchIndex+delta);
+          paintControls();
+        }
+        else if(button.dataset.context){const container=button.closest('[data-line]');if(container.nextElementSibling?.classList.contains('logs-context')){container.nextElementSibling.remove();return;}const token=sequence, target=sid;const data=await api(`/${sid}/context/${button.dataset.context}`,scope());if(!alive||token!==sequence||target!==sid||!container.isConnected)return;const el=document.createElement('div');el.className='logs-context';el.innerHTML=data.items.map(r=>lineMarkup(r,true)).join('');container.after(el);}
+        else if(button.hasAttribute('data-pin')){await api(`/${sid}`,{}, {method:'PATCH',headers:{'Content-Type':'application/json'},body:JSON.stringify({pinned:!current.pinned})});scheduleReload();}
+        else if(button.hasAttribute('data-delete')){if(!window.confirm('Delete this entire saved log, including any other pairs in it?'))return;await api(`/${sid}`,{}, {method:'DELETE'});showingRuns=true;runId='';reset();}
+        else if(button.hasAttribute('data-clear')){if(!window.confirm('Delete completed, unpinned logs in this channel for the current profile?'))return;await api('',{channel},{method:'DELETE'});reset();}
+        else if(['data-copy','data-copy-full','data-download','data-download-full'].some(a=>button.hasAttribute(a))){
+          if(!sid)return; const full=button.hasAttribute('data-copy-full')||button.hasAttribute('data-download-full');
+          const res=await fetch(url(`/${sid}/download`,{...scope(),...(full?{}:{q:query,level,provider})}),{cache:'no-store'});if(!res.ok)throw new Error('Could not export this log.');
+          const text=await res.text();if(!alive)return;
+          if(button.hasAttribute('data-copy')||button.hasAttribute('data-copy-full')){await navigator.clipboard.writeText(text);notice('Log copied.');}
+          else {const link=document.createElement('a');const object=URL.createObjectURL(new Blob([text],{type:'text/plain'}));link.href=object;link.download=`crosswatch-${channel}-${sid}.log`;link.click();setTimeout(()=>URL.revokeObjectURL(object),1000);}
+        }
+      } catch(error){if(alive)notice(error.message);}
+    }
+    for(const selector of ['[data-query]','[data-level]','[data-provider]']) $(selector).addEventListener('input',()=>{query=$('[data-query]').value;level=$('[data-level]').value;provider=$('[data-provider]').value.trim().toUpperCase();offset=0;follow=false;pendingMatch=null;notice();scheduleReload();});
+    $('[data-pair]').addEventListener('input',()=>{pairId=$('[data-pair]').value;runId='';latestRequested=mode==='saved';showingRuns=mode==='saved';follow=mode==='live';clearFilters();reset();});
+    $('[data-wrap]').onchange=()=>content.classList.toggle('logs-nowrap',!$('[data-wrap]').checked);
+    content.addEventListener('wheel',event=>{if(event.deltaY<0){follow=false;paintControls();}},{passive:true});
+    content.addEventListener('scroll',()=>{if(follow && content.scrollHeight-content.scrollTop-content.clientHeight>50){follow=false;paintControls();}});
+    timer=setInterval(refresh,2000);
+    dispose=()=>{alive=false;sequence++;controller?.abort();clearInterval(timer);clearTimeout(searchTimer);window.removeEventListener('resize',resize);host.removeEventListener('click',onClick);};
+    paintControls();await refresh();resize();
+  },
+  hide(){dispose?.();dispose=null;},
+  unmount(){this.hide();root?.replaceChildren();root=null;}
+};
+window.LogsPage=LogsPage;
+for(const name of ['cw:overview-profile-changed','cw:auth-state-changed'])window.addEventListener(name,()=>{const host=root;LogsPage.unmount();if(host&&document.documentElement.dataset.tab==='logs')LogsPage.mount(host);});
+export default LogsPage;

--- a/assets/js/modals.js
+++ b/assets/js/modals.js
@@ -20,7 +20,6 @@ const { ModalRegistry } = await import(_cwVer('./modals/core/registry.js'));
 // Register modals
 ModalRegistry.register('pair-config', () => import(_cwVer('./modals/pair-config/index.js')));
 ModalRegistry.register('about',        () => import(_cwVer('./modals/about.js')));
-ModalRegistry.register('events',       () => import(_cwVer('./modals/events/index.js')));
 ModalRegistry.register('maintenance',  () => import(_cwVer('./modals/maintenance/index.js')));
 ModalRegistry.register('manual-watched', () => import(_cwVer('./modals/manual-watched/index.js')));
 ModalRegistry.register('insight-settings', () => import(_cwVer('./modals/insight-settings/index.js')));
@@ -55,7 +54,31 @@ window.closeAbout = async () => {
 };
 
 window.openAnalyzer = () => window.showTab ? window.showTab('analyzer') : (location.hash = 'analyzer');
-window.openEvents = (props = {}) => ModalRegistry.open('events', props);
+window.openLogs = (props = {}) => {
+  const query = new URLSearchParams({channel: props.channel || 'sync'});
+  if (props.runId) query.set('runId', props.runId);
+  if (props.pairId) query.set('pairId', props.pairId);
+  if (props.latest) query.set('latest', '1');
+  const hash = '#logs?' + query;
+  ModalRegistry.close();
+  if (!document.getElementById('page-logs') || !window.showTab) { location.href = '/?main=1' + hash; return; }
+  if (location.hash !== hash) history.pushState(null, '', hash);
+  return window.showTab('logs');
+};
+window.openEvents = (props = {}) => {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries({ groupId: props.groupId || props.eventGroupId, runId: props.runId || props.run_id, domain: props.domain, visibility: props.visibility, mode: props.mode })) {
+    if (value) query.set(key, String(value));
+  }
+  const hash = '#events' + (query.size ? `?${query}` : '');
+  ModalRegistry.close();
+  if (!document.getElementById('page-events') || !window.showTab) {
+    location.href = '/?main=1' + hash;
+    return;
+  }
+  if (location.hash !== hash) history.pushState(null, '', hash);
+  return window.showTab('events');
+};
 window.openStatisticsModal = (props = {}) => ModalRegistry.open('statistics', props);
 window.openExporter = () => window.showTab ? window.showTab('import_export') : (location.hash = 'import_export');
 

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -456,6 +456,8 @@ def _non_admin_permission_allowed(user: dict, path: str, method: str = "GET") ->
         return bool(perms.get("dashboard"))
     if path == "/api/logs/stream":
         return write
+    if path == "/api/logs/archive" or path.startswith("/api/logs/archive/"):
+        return write
     if path == "/api/logs/watcher":
         return False
     if path == "/api/pairs":
@@ -873,6 +875,9 @@ def ansi_to_html(line: str) -> str:
 def _append_log_to_buffer(tag: str, raw_line: str) -> None:
     t = _norm_log_tag(tag)
     safe_line = _redact_secrets_in_text(raw_line)
+    if t in {"SYNC", DIAG_LOG_TAG} or t in WATCH_LOG_TAGS:
+        from services.log_archive import capture
+        capture(t, safe_line, watcher=t in WATCH_LOG_TAGS)
     html = ansi_to_html(safe_line.rstrip("\n"))
     buf = _get_log_buf(t)
     buf.append(html)

--- a/cw_platform/log_context.py
+++ b/cw_platform/log_context.py
@@ -1,0 +1,8 @@
+# cw_platform/log_context.py
+# CrossWatch - Task-local log attribution
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+
+from contextvars import ContextVar
+
+log_run_id: ContextVar[str] = ContextVar('log_run_id', default='')
+log_pair_id: ContextVar[str] = ContextVar('log_pair_id', default='')

--- a/cw_platform/orchestrator/_pairs.py
+++ b/cw_platform/orchestrator/_pairs.py
@@ -22,6 +22,7 @@ from ._pairs_playlists import run_playlist_mappings
 from ..run_control import SyncCancelled, cancel_requested
 from ..value_coercion import coerce_bool
 from ..pair_scope import pair_feature_scope
+from ..log_context import log_pair_id
 
 def _deep_merge_provider_overrides(dst: dict[str, Any], src: Mapping[str, Any]) -> None:
     for k, v in (src or {}).items():
@@ -330,6 +331,7 @@ def _pair_env(pair: Mapping[str, Any], *, i: int, src: str, dst: str, mode: str,
     }
 
     old = {k: os.environ.get(k) for k in new.keys()}
+    log_token = log_pair_id.set(str(pair.get('id') or ''))
     try:
         for k, v in new.items():
             if v is None:
@@ -338,6 +340,7 @@ def _pair_env(pair: Mapping[str, Any], *, i: int, src: str, dst: str, mode: str,
                 os.environ[k] = str(v)
         yield
     finally:
+        log_pair_id.reset(log_token)
         for k, v in old.items():
             if v is None:
                 os.environ.pop(k, None)
@@ -439,6 +442,7 @@ def run_pairs(ctx) -> dict[str, Any]:
         if not features:
             emit(
                 "run:pair:skip",
+                pair_id=str(pair.get('id') or ''),
                 src=src,
                 dst=dst,
                 mode=mode,
@@ -451,6 +455,7 @@ def run_pairs(ctx) -> dict[str, Any]:
 
         emit(
             "run:pair",
+            pair_id=str(pair.get('id') or ''),
             i=i,
             n=len(pairs),
             src=src,
@@ -464,13 +469,14 @@ def run_pairs(ctx) -> dict[str, Any]:
         sops = provs.get(src)
         dops = provs.get(dst)
         if not sops or not dops:
+            emit('pair:skip', pair_id=str(pair.get('id') or ''), src=src, dst=dst, reason='missing_provider_ops')
             emit_info(f"[!] Missing provider ops for {src}→{dst}")
             continue
 
         ss = health_status(health_map.get(f"{src}#{src_inst}") or health_map.get(src) or {})
         sd = health_status(health_map.get(f"{dst}#{dst_inst}") or health_map.get(dst) or {})
         if ss == "auth_failed" or sd == "auth_failed":
-            emit("pair:skip", src=src, dst=dst, reason="auth_failed", src_status=ss, dst_status=sd)
+            emit("pair:skip", pair_id=str(pair.get('id') or ''), src=src, dst=dst, reason="auth_failed", src_status=ss, dst_status=sd)
             continue
 
         injected = False

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -1,0 +1,17 @@
+# Logs
+
+Open **View details** on Main and choose the expand icon beside Copy to open the Logs page. The selected Sync, Watcher or Debug tab follows you to the page. Events also offers **View logs** for a sync run.
+
+Search across the available log, filter by level or provider, or select the error and warning counts to focus on problems. Expand a line to see the surrounding messages. Scrolling up pauses Follow live; **Resume live** returns to the latest output. The More menu offers line wrapping, copying and downloading the filtered or full log.
+
+Choose a **Sync pair** to see that pair's Sync or Debug messages, including within a run containing several pairs. **Latest run** opens its most recent recorded run and clears the text, level and provider filters. Pair cards also have a **Latest logs** icon. Pair selection is retained when switching between Sync and Debug, and applies to search, counts, surrounding context and exports. General run messages without a pair remain available under All pairs. Pinning or deleting still acts on the entire saved log.
+
+Pair attribution is recorded for new logs; existing development logs are not backfilled. Watcher activity uses its separate continuous log.
+
+**Saved logs** contains each sync run and daily Watcher and Debug logs. Logs are saved on the server and survive restarts. Capture begins with this update; earlier in-memory logs cannot be recovered. The archive contains the messages emitted by the existing logging configuration, so it cannot recover debug messages that were never emitted.
+
+Unpinned logs expire after seven days. A shared 100 MB log-data budget removes the oldest completed, unpinned logs sooner when necessary. **Keep this log** protects a log from automatic cleanup. If active and pinned logs fill the budget, capture stops accepting new lines until space is available; affected logs show a notice. SQLite metadata and journal files use some additional disk space.
+
+You can download or delete individual completed logs, or clear completed, unpinned logs in the current channel. Clearing the quick live view does not delete the saved archive. Watcher and Debug follow their existing administrator-only access; sync logs require access to every provider instance involved in the run, including the selected profile's restrictions.
+
+The archive is stored in `logs.db` beside the CrossWatch SQLite database. Keep that directory on persistent storage when running CrossWatch in a container.

--- a/services/log_archive.py
+++ b/services/log_archive.py
@@ -30,7 +30,7 @@ def describe_line(text: str, tag: str) -> tuple[str, str, str]:
     level = (matches[-1].upper() if matches else "WARN" if text.startswith("[!]") else "INFO")
     level = {"WARNING": "WARN", "CRITICAL": "ERROR", "SUCCESS": "INFO"}.get(level, level)
     provider = tag.upper()
-    tags = re.findall(r"\[([A-Z][A-Z0-9_-]*)(?::[^\]]+)?\]", text)
+    tags = re.findall(r"\[([A-Z][A-Z0-9_-]*)(?::[^\[\]]+)?\]", text)
     if tags:
         provider = tags[-1]
     try:

--- a/services/log_archive.py
+++ b/services/log_archive.py
@@ -1,0 +1,298 @@
+# services/log_archive.py
+# CrossWatch - Persistent diagnostic log archive
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+
+from __future__ import annotations
+
+import atexit
+import json
+import re
+import sqlite3
+import threading
+import time
+import uuid
+from pathlib import Path
+from datetime import datetime, timezone
+
+from _logging import _redact_log_text
+from cw_platform.local_db import crosswatch_db_path
+from cw_platform.log_context import log_pair_id, log_run_id
+
+RETENTION_DAYS = 7
+MAX_BYTES = 100 * 1024 * 1024
+ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+LEVEL = re.compile(r"(?:^|\]\s+|\d{2}:\d{2}:\d{2}\s+)(ERROR|CRITICAL|WARNING|WARN|DEBUG|INFO|SUCCESS)\b", re.I)
+
+
+def describe_line(text: str, tag: str) -> tuple[str, str, str]:
+    text = _redact_log_text(ANSI.sub("", str(text))).rstrip()[:32768]
+    matches = LEVEL.findall(text)
+    level = (matches[-1].upper() if matches else "WARN" if text.startswith("[!]") else "INFO")
+    level = {"WARNING": "WARN", "CRITICAL": "ERROR", "SUCCESS": "INFO"}.get(level, level)
+    provider = tag.upper()
+    tags = re.findall(r"\[([A-Z][A-Z0-9_-]*)(?::[^\]]+)?\]", text)
+    if tags:
+        provider = tags[-1]
+    try:
+        obj = json.loads(text[text.index("{"):])
+        if isinstance(obj, dict):
+            provider = str(obj.get("provider") or obj.get("dst") or obj.get("src") or provider).upper()
+            reported_level = str(obj.get('level') or '').upper()
+            if reported_level in {'ERROR', 'CRITICAL', 'WARN', 'WARNING', 'INFO', 'DEBUG'}:
+                level = {'CRITICAL':'ERROR', 'WARNING':'WARN'}.get(reported_level, reported_level)
+            if obj.get("event") == "debug":
+                level = "DEBUG"
+            if obj.get("event") in {"error", "run:error"} or str(obj.get("errors") or '0') != '0':
+                level = "ERROR"
+            elif str(obj.get("unresolved") or '0') != '0' or obj.get("event") in {"apply:unresolved", "warning"}:
+                level = "WARN"
+    except (ValueError, TypeError):
+        pass
+    if re.search(r"\b(?:Sync error|exit code: [1-9])", text, re.I):
+        level = "ERROR"
+    return text, level, provider
+
+
+class LogArchive:
+    def __init__(self, path: Path, *, max_bytes: int = MAX_BYTES, retention_days: int = RETENTION_DAYS):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self.lock = threading.RLock()
+        self.max_bytes = max_bytes
+        self.retention_days = retention_days
+        self.db = sqlite3.connect(path, check_same_thread=False, timeout=5)
+        self.db.row_factory = sqlite3.Row
+        self.db.executescript("""
+          PRAGMA journal_mode=WAL;
+          PRAGMA synchronous=NORMAL;
+          PRAGMA foreign_keys=ON;
+          CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY, run_id TEXT, channel TEXT NOT NULL, label TEXT NOT NULL,
+            started REAL NOT NULL, ended REAL, status TEXT NOT NULL, pairs TEXT NOT NULL DEFAULT '[]',
+            pinned INTEGER NOT NULL DEFAULT 0, bytes INTEGER NOT NULL DEFAULT 0,
+            lines INTEGER NOT NULL DEFAULT 0, errors INTEGER NOT NULL DEFAULT 0,
+            warnings INTEGER NOT NULL DEFAULT 0, truncated INTEGER NOT NULL DEFAULT 0);
+          CREATE TABLE IF NOT EXISTS lines (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            ts REAL NOT NULL, level TEXT NOT NULL, provider TEXT NOT NULL, text TEXT NOT NULL);
+          CREATE INDEX IF NOT EXISTS lines_session ON lines(session_id,id);
+          CREATE INDEX IF NOT EXISTS sessions_run ON sessions(run_id);
+        """)
+        columns = {row['name'] for row in self.db.execute('PRAGMA table_info(lines)')}
+        for name in ('pair_id', 'run_id'):
+            if name not in columns:
+                self.db.execute(f"ALTER TABLE lines ADD COLUMN {name} TEXT NOT NULL DEFAULT ''")
+        self.db.execute('CREATE INDEX IF NOT EXISTS lines_pair ON lines(session_id,pair_id,run_id,id)')
+        self.db.execute("UPDATE sessions SET ended=?,status='interrupted' WHERE ended IS NULL", (time.time(),))
+        self.db.commit()
+        self.active: dict[str, str] = {}
+        self.used = int(self.db.execute("SELECT COALESCE(SUM(bytes),0) FROM sessions").fetchone()[0])
+        self.last_commit = 0.0
+        self.last_cleanup = 0.0
+        self.pending = 0
+        self.cleanup()
+
+    def flush(self):
+        with self.lock:
+            self.db.commit()
+            self.pending = 0
+            self.last_commit = time.monotonic()
+
+    def cleanup(self, *, before: float | None = None):
+        with self.lock:
+            midnight = int(time.time() // 86400) * 86400
+            self.db.execute("UPDATE sessions SET ended=?,status='saved' WHERE run_id IS NULL AND ended IS NULL AND started<?", (midnight, midnight))
+            cutoff = before if before is not None else time.time() - self.retention_days * 86400
+            self.db.execute("DELETE FROM sessions WHERE pinned=0 AND ended IS NOT NULL AND ended<?", (cutoff,))
+            self.used = int(self.db.execute("SELECT COALESCE(SUM(bytes),0) FROM sessions").fetchone()[0])
+            self.last_cleanup = time.monotonic()
+            self.flush()
+
+    def _room(self, size: int) -> bool:
+        if self.used + size <= self.max_bytes:
+            return True
+        for row in self.db.execute("SELECT id,bytes FROM sessions WHERE pinned=0 AND ended IS NOT NULL ORDER BY started").fetchall():
+            self.db.execute("DELETE FROM sessions WHERE id=?", (row['id'],))
+            self.used -= row['bytes']
+            if self.used + size <= self.max_bytes:
+                return True
+        return False
+
+    def start(self, run_id: str, pairs: list[dict]) -> str:
+        with self.lock:
+            previous = self.active.get('sync')
+            if previous:
+                self.db.execute("UPDATE sessions SET ended=?,status='saved' WHERE id=?", (time.time(), previous))
+            sid = uuid.uuid4().hex
+            if not self._room(512):
+                self.flush()
+                self.active.pop('sync', None)
+                return ''
+            labels = [f"{p.get('source', '?')} → {p.get('target', '?')}" for p in pairs]
+            self.db.execute("INSERT INTO sessions(id,run_id,channel,label,started,status,pairs,bytes) VALUES(?,?,?,?,?,'running',?,512)",
+                            (sid, run_id, 'sync', ', '.join(dict.fromkeys(labels)) or 'Sync run', time.time(), json.dumps(pairs)))
+            self.used += 512
+            self.active['sync'] = sid
+            self.flush()
+            return sid
+
+    def finish(self, sid: str, status: str):
+        with self.lock:
+            self.db.execute("UPDATE sessions SET ended=?,status=? WHERE id=?", (time.time(), status, sid))
+            if self.active.get('sync') == sid:
+                del self.active['sync']
+            self.flush()
+
+    def append(self, channel: str, tag: str, text: str):
+        text, level, provider = describe_line(text, tag)
+        if not text or '::CLEAR::' in text:
+            return
+        with self.lock:
+            now = time.time()
+            if time.monotonic() - self.last_cleanup > 3600:
+                self.cleanup()
+            sid = self.active.get(channel)
+            if channel != 'sync' or not sid or sid.startswith('sync-'):
+                day = time.strftime('%Y-%m-%d', time.gmtime(now))
+                sid = f'{channel}-{day}'
+                # Continuous logs close at midnight and resume the same day after a restart.
+                if self.active.get(channel) != sid:
+                    previous = self.active.get(channel)
+                    if previous:
+                        self.db.execute("UPDATE sessions SET ended=?,status='saved' WHERE id=?", (now, previous))
+                    if not self.session(sid):
+                        if not self._room(512):
+                            self.flush()
+                            return
+                        self.db.execute("INSERT INTO sessions(id,channel,label,started,status,bytes) VALUES(?,?,?,?,?,512)",
+                                        (sid, channel, f'{channel.title()} · {day} UTC', now, 'live'))
+                        self.used += 512
+                    self.db.execute("UPDATE sessions SET ended=NULL,status='live' WHERE id=?", (sid,))
+                    self.active[channel] = sid
+            pair_id, run_id = log_pair_id.get(), log_run_id.get()
+            if channel == 'sync':
+                session = self.session(sid)
+                if session is None:
+                    return
+                run_id = session['run_id'] or ''
+                pairs = json.loads(session['pairs'])
+                if not pair_id and len(pairs) == 1:
+                    pair_id = str(pairs[0].get('id') or '')
+            elif channel == 'debug' and run_id and not pair_id:
+                session = self.session(self.active.get('sync', ''))
+                if session and session['run_id'] == run_id:
+                    pairs = json.loads(session['pairs'])
+                    if len(pairs) == 1:
+                        pair_id = str(pairs[0].get('id') or '')
+            # Pair-start messages are emitted before entering the feature's log scope.
+            try:
+                event = json.loads(text[text.index('{'):])
+                if event.get('event') in {'run:pair', 'run:pair:skip', 'pair:skip'}:
+                    pair_id = str(event.get('pair_id') or pair_id)
+            except (ValueError, TypeError, AttributeError):
+                pass
+            size = len(text.encode('utf-8')) + len(pair_id) + len(run_id) + 128
+            if not self._room(size):
+                self.db.execute("UPDATE sessions SET truncated=1 WHERE id=?", (sid,))
+            else:
+                self.db.execute("INSERT INTO lines(session_id,ts,level,provider,text,pair_id,run_id) VALUES(?,?,?,?,?,?,?)", (sid, now, level, provider, text, pair_id, run_id))
+                self.db.execute("UPDATE sessions SET bytes=bytes+?,lines=lines+1,errors=errors+?,warnings=warnings+? WHERE id=?",
+                                (size, int(level == 'ERROR'), int(level == 'WARN'), sid))
+                self.used += size
+            self.pending += 1
+            if self.pending >= 100 or time.monotonic() - self.last_commit > 1:
+                self.flush()
+
+    def sessions(self, channel: str, run_id: str = '', pair_id: str = '') -> list[dict]:
+        with self.lock:
+            self.cleanup()
+            rows = self.db.execute("""SELECT * FROM sessions s WHERE channel=?
+                AND (?='' OR s.run_id=? OR EXISTS(SELECT 1 FROM lines l WHERE l.session_id=s.id AND l.run_id=?))
+                AND (?='' OR EXISTS(SELECT 1 FROM lines l WHERE l.session_id=s.id AND l.pair_id=? AND (?='' OR l.run_id=?)))
+                ORDER BY started DESC LIMIT 5000""", (channel, run_id, run_id, run_id, pair_id, pair_id, run_id, run_id)).fetchall()
+            return [dict(row) for row in rows]
+
+    def session(self, sid: str) -> dict | None:
+        with self.lock:
+            row = self.db.execute('SELECT * FROM sessions WHERE id=?', (sid,)).fetchone()
+            return dict(row) if row else None
+
+    def page(self, sid: str, *, q: str = '', level: str = '', provider: str = '', after: int = 0, offset: int = 0, limit: int = 500, pair_id: str = '', run_id: str = '') -> dict:
+        with self.lock:
+            where = "session_id=? AND id>? AND (?='' OR instr(lower(text),lower(?))>0) AND (?='' OR level=?) AND (?='' OR provider=?) AND (?='' OR pair_id=?) AND (?='' OR run_id=?)"
+            args = (sid, after, q, q, level, level, provider, provider, pair_id, pair_id, run_id, run_id)
+            total = self.db.execute(f'SELECT COUNT(*) FROM lines WHERE {where}', args).fetchone()[0]
+            rows = self.db.execute(f'SELECT * FROM lines WHERE {where} ORDER BY id LIMIT ? OFFSET ?', (*args, limit, offset)).fetchall()
+            return dict(items=[dict(r) for r in rows], total=total)
+
+    def counts(self, sid: str, pair_id: str = '', run_id: str = '') -> dict:
+        with self.lock:
+            row = self.db.execute("""SELECT COUNT(*) AS lines, COALESCE(SUM(level='ERROR'),0) AS errors,
+                COALESCE(SUM(level='WARN'),0) AS warnings FROM lines WHERE session_id=?
+                AND (?='' OR pair_id=?) AND (?='' OR run_id=?)""", (sid, pair_id, pair_id, run_id, run_id)).fetchone()
+            return dict(row)
+
+    def context(self, sid: str, line_id: int, pair_id: str = '', run_id: str = '') -> list[dict]:
+        with self.lock:
+            scope = "session_id=? AND (?='' OR pair_id=?) AND (?='' OR run_id=?)"
+            args = (sid, pair_id, pair_id, run_id, run_id, line_id)
+            before = self.db.execute(f'SELECT * FROM lines WHERE {scope} AND id<=? ORDER BY id DESC LIMIT 6', args).fetchall()
+            after = self.db.execute(f'SELECT * FROM lines WHERE {scope} AND id>? ORDER BY id LIMIT 5', args).fetchall()
+            return [dict(r) for r in reversed(before)] + [dict(r) for r in after]
+
+    def export(self, sid: str, *, q: str = '', level: str = '', provider: str = '', pair_id: str = '', run_id: str = ''):
+        # Bound each read so exporting a long log does not copy the archive into memory.
+        with self.lock:
+            end = self.db.execute('SELECT COALESCE(MAX(id),0) FROM lines WHERE session_id=?', (sid,)).fetchone()[0]
+        after = 0
+        while after < end:
+            with self.lock:
+                rows = self.db.execute("""SELECT * FROM lines WHERE session_id=? AND id>? AND id<=?
+                    AND (?='' OR instr(lower(text),lower(?))>0) AND (?='' OR level=?)
+                    AND (?='' OR provider=?) AND (?='' OR pair_id=?) AND (?='' OR run_id=?) ORDER BY id LIMIT 1000""",
+                    (sid, after, end, q, q, level, level, provider, provider, pair_id, pair_id, run_id, run_id)).fetchall()
+            if not rows:
+                return
+            for row in rows:
+                timestamp = datetime.fromtimestamp(row['ts'], timezone.utc).isoformat(timespec='milliseconds')
+                yield f"{timestamp} [{row['provider']}] {row['level']} {row['text']}\n"
+            after = rows[-1]['id']
+
+    def pin(self, sid: str, value: bool):
+        with self.lock:
+            self.db.execute('UPDATE sessions SET pinned=? WHERE id=?', (int(value), sid))
+            self.flush()
+
+    def delete(self, sid: str):
+        with self.lock:
+            row = self.session(sid)
+            if row and row['ended'] is None:
+                raise ValueError('This log is still active.')
+            self.db.execute('DELETE FROM sessions WHERE id=?', (sid,))
+            self.used -= int((row or {}).get('bytes', 0))
+            self.flush()
+
+    def close(self):
+        with self.lock:
+            self.flush()
+            self.db.close()
+
+
+_archive: LogArchive | None = None
+_init_lock = threading.Lock()
+
+
+def archive() -> LogArchive:
+    global _archive
+    with _init_lock:
+        if _archive is None:
+            _archive = LogArchive(crosswatch_db_path().with_name('logs.db'))
+            atexit.register(_archive.close)
+        return _archive
+
+
+def capture(tag: str, text: str, *, watcher: bool = False):
+    try:
+        archive().append('sync' if tag == 'SYNC' else 'watcher' if watcher else 'debug', tag, text)
+    except Exception:
+        # Logging must never prevent a sync from completing.
+        pass

--- a/tests/logs-page.test.mjs
+++ b/tests/logs-page.test.mjs
@@ -1,0 +1,13 @@
+/* tests/logs-page.test.mjs */
+/* CrossWatch - Log search highlighting tests */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+globalThis.window={addEventListener(){}};
+const {highlight}=await import('../assets/js/logs.js');
+test('search highlights literal matches and escapes log HTML',()=>{
+  assert.equal(highlight('<script>Error & ERROR</script>','error'),'&lt;script&gt;<mark>Error</mark> &amp; <mark>ERROR</mark>&lt;/script&gt;');
+  assert.equal(highlight('x.* x.*','.*'),'x<mark>.*</mark> x<mark>.*</mark>');
+  assert.equal(highlight('plain <text>',''),'plain &lt;text&gt;');
+});

--- a/tests/test_log_archive.py
+++ b/tests/test_log_archive.py
@@ -17,6 +17,19 @@ from cw_platform.log_context import log_run_id, log_pair_id
 from cw_platform.orchestrator._pairs import _pair_env
 
 
+@pytest.mark.parametrize("text,tag,expected", [
+    ("[MDBLIST:history] INFO index_done", "SYNC", "MDBLIST"),
+    ("[SYNC] [PLEX-WATCH] INFO playing", "SYNC", "PLEX-WATCH"),
+    ("[SIMKL:history:episodes] DEBUG read", "SYNC", "SIMKL"),
+    ("[A:" * 10000, "SYNC", "SYNC"),
+    ("[A:" * 10000 + "[TRAKT:history] INFO read", "SYNC", "TRAKT"),
+    ("[A:" * 10000 + "]", "SYNC", "SYNC"),
+    ('[SYNC] {"provider":"MDBLIST","event":"debug"}', "SYNC", "MDBLIST"),
+])
+def test_provider_tags_handle_valid_and_unclosed_brackets(text, tag, expected):
+    assert describe_line(text, tag)[2] == expected
+
+
 @pytest.fixture
 def store(tmp_path):
     result = LogArchive(tmp_path / 'logs.db')

--- a/tests/test_log_archive.py
+++ b/tests/test_log_archive.py
@@ -1,0 +1,236 @@
+# tests/test_log_archive.py
+# CrossWatch - Log archive persistence, retention and access tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+
+from __future__ import annotations
+
+import time
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from services.log_archive import LogArchive, describe_line
+from cw_platform.log_context import log_run_id, log_pair_id
+from cw_platform.orchestrator._pairs import _pair_env
+
+
+@pytest.fixture
+def store(tmp_path):
+    result = LogArchive(tmp_path / 'logs.db')
+    yield result
+    result.close()
+
+
+def test_saved_run_survives_restart_and_interrupted_run_is_marked(tmp_path):
+    path = tmp_path / 'logs.db'
+    log = LogArchive(path)
+    sid = log.start('run-one', [{'source':'PLEX','target':'TRAKT'}])
+    log.append('sync', 'SYNC', '[TRAKT] ERROR token=secret could not write')
+    log.close()
+    log = LogArchive(path)
+    try:
+        assert log.session(sid)['status'] == 'interrupted'
+        assert log.session(sid)['errors'] == 1
+        assert 'secret' not in log.page(sid)['items'][0]['text']
+        assert log.page(sid)['items'][0]['provider'] == 'TRAKT'
+    finally:
+        log.close()
+
+
+def test_full_search_paging_and_context_ignore_filters(store):
+    sid = store.start('run', [])
+    for index in range(16):
+        store.append('sync', 'PLEX', f'{"ERROR" if index == 8 else "INFO"} item {index}')
+    result = store.page(sid, q='ITEM 8', level='ERROR', provider='PLEX')
+    assert result['total'] == 1
+    context = store.context(sid, result['items'][0]['id'])
+    assert len(context) == 11
+    assert context[0]['text'] == 'INFO item 3'
+    assert context[-1]['text'] == 'INFO item 13'
+    assert len(store.page(sid, offset=10, limit=5)['items']) == 5
+
+
+def test_retention_skips_pinned_and_active_logs(store):
+    old = store.start('old', [])
+    store.finish(old, 'completed')
+    keep = store.start('keep', [])
+    store.finish(keep, 'completed')
+    store.pin(keep, True)
+    active = store.start('active', [])
+    store.cleanup(before=time.time()+1)
+    assert store.session(old) is None
+    assert store.session(keep)['pinned'] == 1
+    assert store.session(active)['ended'] is None
+    with pytest.raises(ValueError):
+        store.delete(active)
+
+
+def test_storage_cap_keeps_pin_and_marks_truncated(tmp_path):
+    log = LogArchive(tmp_path / 'small.db', max_bytes=1800)
+    try:
+        keep = log.start('keep', [])
+        log.append('sync', 'SYNC', 'INFO ' + 'x'*400)
+        log.finish(keep, 'completed')
+        log.pin(keep, True)
+        sid = log.start('next', [])
+        for _ in range(10):
+            log.append('sync', 'SYNC', 'ERROR ' + 'x'*200)
+        assert log.used <= 1800
+        assert log.session(keep)['pinned'] == 1
+        assert log.session(sid)['truncated'] == 1
+    finally:
+        log.close()
+
+
+def test_old_unpinned_log_is_evicted_to_make_room(tmp_path):
+    log = LogArchive(tmp_path/'small.db', max_bytes=1600)
+    try:
+        old = log.start('old', [])
+        log.append('sync', 'SYNC', 'x'*400)
+        log.finish(old, 'completed')
+        new = log.start('new', [])
+        log.append('sync', 'SYNC', 'x'*400)
+        assert log.session(old) is None
+        assert log.page(new)['total'] == 1
+    finally:
+        log.close()
+
+
+def test_daily_channels_and_completed_run_remain_separate(store):
+    sid=store.start('sync', [])
+    store.append('sync','SYNC','INFO run')
+    store.append('watcher','PLEX-WATCH','INFO playing')
+    store.append('debug','DEBUG','DEBUG diagnostic')
+    store.finish(sid,'completed')
+    store.append('sync','SYNC','INFO outside run')
+    assert store.page(sid)['total'] == 1
+    assert len(store.sessions('watcher')) == 1
+    assert len(store.sessions('debug')) == 1
+    assert len(store.sessions('sync')) == 2
+
+
+def test_structured_error_levels():
+    assert describe_line('{"event":"apply:update:done","errors":2}', 'SYNC')[1] == 'ERROR'
+    assert describe_line('{"event":"debug","msg":"snapshot"}', 'SYNC')[1] == 'DEBUG'
+    assert describe_line('{"event":"run:done","unresolved":1}', 'SYNC')[1] == 'WARN'
+    assert describe_line('{"event":"run:done","errors":"0","unresolved":"0"}', 'SYNC')[1] == 'INFO'
+    assert describe_line('[MDBLIST] INFO [MDBLIST:history] DEBUG index_cache_hit', 'SYNC')[1] == 'DEBUG'
+    assert describe_line('INFO Done. Total errors: 0', 'SYNC')[1] == 'INFO'
+    assert describe_line('{"provider":"SIMKL","level":"WARN","msg":"rate_limited"}', 'DEBUG')[1:] == ('WARN', 'SIMKL')
+
+
+def test_api_scopes_every_read_export_pin_and_delete(monkeypatch, store):
+    from api import logsAPI
+    monkeypatch.setattr(logsAPI, 'archive', lambda:store)
+    monkeypatch.setattr(logsAPI, 'load_config', lambda:{})
+    monkeypatch.setattr(logsAPI, 'user_can_access_instance', lambda cfg,user,provider,instance:provider=='PLEX')
+    mine=store.start('mine', [{'id':'mine','source':'PLEX','target':'PLEX'}]);store.append('sync','SYNC','INFO own log');store.finish(mine,'completed')
+    theirs=store.start('theirs',[{'id':'theirs','source':'TRAKT','target':'TRAKT'}]);store.append('sync','SYNC','ERROR private log');store.finish(theirs,'failed')
+    mixed=store.start('mixed',[{'source':'PLEX','target':'PLEX'},{'source':'TRAKT','target':'TRAKT'}]);store.finish(mixed,'completed')
+    store.append('debug','DEBUG','INFO private diagnostics')
+    app=FastAPI()
+    @app.middleware('http')
+    async def user(request,call_next):
+        request.state.cw_user={'is_admin':False,'profile_id':'a'*32,'permissions':{'write':True}}
+        return await call_next(request)
+    app.include_router(logsAPI.router)
+    with TestClient(app) as client:
+        data=client.get('/api/logs/archive').json()
+        assert [row['id'] for row in data['items']] == [mine]
+        assert data['channels']==['sync']
+        assert [pair['id'] for pair in data['pairs']] == ['mine']
+        assert client.get('/api/logs/archive?pair_id=theirs').json()['latest_run_id'] == ''
+        assert client.get('/api/logs/archive?channel=debug').json()['items']==[]
+        for sid in (theirs,mixed):
+            assert client.get(f'/api/logs/archive/{sid}/lines').status_code==404
+            assert client.get(f'/api/logs/archive/{sid}/lines?pair_id=mine').status_code==404
+            assert client.get(f'/api/logs/archive/{sid}/context/1').status_code==404
+            assert client.get(f'/api/logs/archive/{sid}/download').status_code==404
+            assert client.patch(f'/api/logs/archive/{sid}',json={'pinned':True}).status_code==404
+            assert client.delete(f'/api/logs/archive/{sid}').status_code==404
+        assert client.get(f'/api/logs/archive/{mine}/download').text.endswith('[SYNC] INFO INFO own log\n')
+        assert client.patch(f'/api/logs/archive/{mine}',json={'pinned':True}).status_code==200
+        assert client.delete('/api/logs/archive').json()['deleted']==0
+        assert store.session(theirs) is not None
+        assert client.delete(f'/api/logs/archive/{mine}').status_code==200
+
+
+def test_export_batches_and_applies_filters(store):
+    sid = store.start('export', [])
+    for i in range(1010):
+        store.append('sync', 'PLEX', f'INFO item {i}')
+    assert len(list(store.export(sid))) == 1010
+    result = list(store.export(sid, q='item 1009', level='INFO', provider='PLEX'))
+    assert len(result) == 1
+    assert '+00:00 [PLEX] INFO INFO item 1009' in result[0]
+
+
+def record_pair_run(store, run_id, pairs):
+    sid = store.start(run_id, pairs)
+    token = log_run_id.set(run_id)
+    try:
+        store.append('sync', 'SYNC', 'INFO shared preparation')
+        for i, pair in enumerate(pairs):
+            store.append('sync', 'SYNC', json.dumps({'event':'run:pair', 'pair_id':pair['id']}))
+            with _pair_env(pair, i=i, src=pair['source'], dst=pair['target'], mode='one-way', feature='history'):
+                store.append('sync', 'SYNC', f"ERROR {pair['id']} failed")
+                store.append('debug', 'DEBUG', f"DEBUG {pair['id']} detail for {run_id}")
+                # A Watcher/HTTP worker running at the same time has no sync context.
+                with ThreadPoolExecutor(max_workers=1) as executor:
+                    executor.submit(store.append, 'debug', 'DEBUG', 'INFO unrelated background').result()
+            assert log_pair_id.get() == ''
+        store.finish(sid, 'failed')
+    finally:
+        log_run_id.reset(token)
+    return sid
+
+
+def test_pair_filters_distinguish_identical_routes_and_keep_context_and_exports_scoped(store):
+    pairs = [dict(id=pid, source='PLEX', target='TRAKT') for pid in ('a','b')]
+    sid = record_pair_run(store, 'run-one', pairs)
+    rows = store.page(sid, pair_id='a')['items']
+    assert len(rows) == 2
+    assert {r['pair_id'] for r in rows} == {'a'}
+    assert store.counts(sid, 'a')['errors'] == 1
+    assert {r['pair_id'] for r in store.context(sid, rows[-1]['id'], 'a')} == {'a'}
+    exported = ''.join(store.export(sid, pair_id='a'))
+    assert 'a failed' in exported and 'b failed' not in exported and 'shared preparation' not in exported
+    debug = store.sessions('debug')[0]['id']
+    assert store.page(debug, pair_id='a')['total'] == 1
+    assert store.page(debug, pair_id='b')['total'] == 1
+    assert store.page(debug)['total'] == 4
+    newer = record_pair_run(store, 'run-two', pairs[:1])
+    assert store.sessions('sync', pair_id='a')[0]['id'] == newer
+    assert store.sessions('sync', pair_id='b')[0]['id'] == sid
+    assert store.page(debug, pair_id='a', run_id='run-two')['total'] == 1
+    assert 'run-one' not in ''.join(store.export(debug, pair_id='a', run_id='run-two'))
+
+
+def test_pair_api_latest_run_counts_context_and_debug_run(monkeypatch, store):
+    from api import logsAPI
+    pairs = [dict(id=pid, source='PLEX', target='TRAKT') for pid in ('a','b')]
+    old = record_pair_run(store, 'run-one', pairs)
+    new = record_pair_run(store, 'run-two', pairs[:1])
+    monkeypatch.setattr(logsAPI, 'archive', lambda:store)
+    monkeypatch.setattr(logsAPI, 'load_config', lambda:{'pairs':pairs})
+    app = FastAPI(); app.include_router(logsAPI.router)
+    with TestClient(app) as client:
+        result = client.get('/api/logs/archive?pair_id=b').json()
+        assert result['latest_run_id'] == 'run-one'
+        assert [item['id'] for item in result['items']] == [old]
+        assert {p['id'] for p in result['pairs']} == {'a','b'}
+        assert result['items'][0]['errors'] == 1
+        assert client.get('/api/logs/archive?pair_id=a').json()['latest_run_id'] == 'run-two'
+        page = client.get(f'/api/logs/archive/{old}/lines?pair_id=b').json()
+        assert {row['pair_id'] for row in page['items']} == {'b'}
+        context = client.get(f"/api/logs/archive/{old}/context/{page['items'][0]['id']}?pair_id=b").json()
+        assert {row['pair_id'] for row in context['items']} == {'b'}
+        assert 'a failed' not in client.get(f'/api/logs/archive/{old}/download?pair_id=b').text
+        debug = client.get('/api/logs/archive?channel=debug&pair_id=a&run_id=run-two').json()['items'][0]
+        lines = client.get(f"/api/logs/archive/{debug['id']}/lines?pair_id=a&run_id=run-two").json()
+        assert len(lines['items']) == 1
+        assert lines['items'][0]['run_id'] == 'run-two'
+        assert client.get('/api/logs/archive?pair_id=missing').json()['items'] == []

--- a/ui_frontend.py
+++ b/ui_frontend.py
@@ -132,21 +132,21 @@ def register_ui_root(app: FastAPI) -> None:
 
 
 _HELPER_SCRIPTS = (
-    "help-links.js", "provider-meta.js", "feature-meta.js", "icon-select.js", "profile-select.js", "page-loader.js", "dom.js", "events.js", "auth-state.js", "account-menu.js", "api.js", "core.js", "details-log.js",
+    "help-links.js", "provider-meta.js", "feature-meta.js", "icon-select.js", "profile-select.js", "page-loader.js", "dom.js", "events.js", "auth-state.js", "account-menu.js", "notifications.js", "update-notifications.js", "api.js", "core.js", "details-log.js",
     "media-meta.js", "trailer.js", "playing-card.js", "watchlist-preview.js", "providers-ui.js", "settings-ui.js", "settings-save.js", "maintenance.js", "backups.js",
     "restart_apply.js",
 )
 _APP_SCRIPTS = (
-    "syncbar.js", "run-summary-stream.js", "overview-profile.js", "main.js", "connections.overlay.js", "connections.pairs.overlay.js", "scheduler.js",
+    "syncbar.js", "run-summary-stream.js", "overview-profile.js", "sync-reviews.js", "main.js", "connections.overlay.js", "connections.pairs.overlay.js", "scheduler.js",
     "schedulerbanner.js", "playingcard.js", "insights.js", "activity.js", "dashboard-widgets.js", "auth-dots.js", "main-status.js",
     "scrobbler.js", "user-profiles.js", "app-users.js",
 )
 _USER_HELPER_SCRIPTS = (
-    "help-links.js", "provider-meta.js", "icon-select.js", "profile-select.js", "page-loader.js", "dom.js", "events.js", "auth-state.js", "account-menu.js", "api.js", "core.js",
+    "help-links.js", "provider-meta.js", "icon-select.js", "profile-select.js", "page-loader.js", "dom.js", "events.js", "auth-state.js", "account-menu.js", "notifications.js", "update-notifications.js", "api.js", "core.js",
     "media-meta.js", "trailer.js", "playing-card.js", "watchlist-preview.js",
 )
 _USER_APP_SCRIPTS = (
-    "overview-profile.js", "main.js", "playingcard.js", "insights.js", "activity.js", "dashboard-widgets.js", "auth-dots.js", "main-status.js",
+    "overview-profile.js", "sync-reviews.js", "main.js", "playingcard.js", "insights.js", "activity.js", "dashboard-widgets.js", "auth-dots.js", "main-status.js",
 )
 _FULL_USER_HELPER_SCRIPTS = tuple(dict.fromkeys((*_USER_HELPER_SCRIPTS, "details-log.js")))
 _FULL_USER_APP_SCRIPTS = tuple(dict.fromkeys(("syncbar.js", "run-summary-stream.js", "schedulerbanner.js", *_USER_APP_SCRIPTS)))
@@ -323,6 +323,8 @@ def _managed_user_shell(html: str, user: dict | None = None) -> str:
             '  <section id="page-playlists" class="card hidden tab-page"></section>\n\n',
             '  <section id="page-editor" class="card hidden tab-page"></section>\n\n',
             '  <section id="page-analyzer" class="card hidden tab-page"></section>\n\n',
+            '  <section id="page-events" class="card hidden tab-page"></section>\n\n',
+            '  <section id="page-logs" class="card hidden tab-page"></section>\n\n',
             '  <section id="page-import_export" class="card hidden tab-page"></section>\n\n',
             '  <section id="page-interactive_sync" class="card hidden tab-page"></section>\n\n',
         ):
@@ -420,6 +422,8 @@ def _get_index_html_static() -> str:
     playlists: "Playlists",
     editor: "Editor",
     analyzer: "Analyzer",
+    events: "Events",
+    logs: "Logs",
     import_export: "Import / Export",
     interactive_sync: "Interactive Sync",
     settings: "Settings",
@@ -486,6 +490,7 @@ def _get_index_html_static() -> str:
 <link rel="stylesheet" href="/assets/css/pages.css?v=__CW_VERSION__">
 <link rel="stylesheet" href="/assets/ui-shell.css?v=__CW_VERSION__">
 <link rel="stylesheet" href="/assets/css/account-menu.css?v=__CW_VERSION__">
+<link id="cw-notifications-css" rel="stylesheet" href="/assets/css/notifications.css?v=__CW_VERSION__">
 <link rel="stylesheet" href="/assets/css/app-users.css?v=__CW_VERSION__">
 <link rel="stylesheet" href="/assets/css/topology.css?v=__CW_VERSION__">
 <script>
@@ -518,7 +523,7 @@ def _get_index_html_static() -> str:
 (() => {
   try {
     const route = String(window.location.hash || "").replace(/^#\/?/, "").split("?")[0].split("/")[0].trim().toLowerCase().replace(/-/g, "_");
-    const tabs = new Set(["watchlist", "playback_progress", "snapshots", "playlists", "editor", "analyzer", "import_export", "interactive_sync", "settings"]);
+    const tabs = new Set(["watchlist", "playback_progress", "snapshots", "playlists", "editor", "analyzer", "events", "logs", "import_export", "interactive_sync", "settings"]);
     let tab = tabs.has(route) ? route : "main";
     if (document.documentElement.classList.contains("cw-compact") && tab !== "main") tab = "main";
     document.documentElement.dataset.cwInitialTab = tab;
@@ -539,6 +544,8 @@ html[data-cw-initial-tab="snapshots"] #page-snapshots,
 html[data-cw-initial-tab="playlists"] #page-playlists,
 html[data-cw-initial-tab="editor"] #page-editor,
 html[data-cw-initial-tab="analyzer"] #page-analyzer,
+html[data-cw-initial-tab="events"] #page-events,
+html[data-cw-initial-tab="logs"] #page-logs,
 html[data-cw-initial-tab="import_export"] #page-import_export,
 html[data-cw-initial-tab="interactive_sync"] #page-interactive_sync,
 html[data-cw-initial-tab="settings"] #page-settings{display:block!important}
@@ -694,6 +701,7 @@ html[data-cw-initial-tab="settings"] #page-settings{display:block!important}
                 role="tab" aria-selected="false" aria-controls="det-panel-debug" data-tab="debug" hidden disabled aria-hidden="true" aria-disabled="true">Debug</button>
             </div>
             <div class="det-tools">
+              <button id="det-open-logs" class="ghost det-tool-icon" type="button" title="Open logs page" aria-label="Open logs page" onclick="openLogs({channel: window._detailsTab || 'sync'})"><span class="material-symbols-rounded" aria-hidden="true">open_in_full</span></button>
               <button id="det-copy" class="ghost det-tool-icon" type="button" title="Copy current output" aria-label="Copy current output"><span class="material-symbols-rounded" aria-hidden="true">content_copy</span></button>
               <button id="det-clear" class="ghost det-tool-icon" type="button" title="Clear current output" aria-label="Clear current output"><span class="material-symbols-rounded" aria-hidden="true">delete</span></button>
               <button id="det-follow" class="ghost det-follow" type="button" title="Toggle auto-follow" aria-pressed="true"><span class="material-symbols-rounded det-follow-icon" aria-hidden="true">podcasts</span><span>Follow</span><span class="material-symbols-rounded det-follow-caret" aria-hidden="true">expand_more</span></button>
@@ -879,6 +887,10 @@ html[data-cw-initial-tab="settings"] #page-settings{display:block!important}
   <section id="page-editor" class="card hidden tab-page"></section>
 
   <section id="page-analyzer" class="card hidden tab-page"></section>
+
+  <section id="page-events" class="card hidden tab-page"></section>
+
+  <section id="page-logs" class="card hidden tab-page"></section>
 
   <section id="page-import_export" class="card hidden tab-page"></section>
 
@@ -2017,6 +2029,7 @@ def get_profile_html(user: dict | None = None) -> str:
 <link rel="stylesheet" href="/assets/css/pages.css?v=__CW_VERSION__">
 <link rel="stylesheet" href="/assets/ui-shell.css?v=__CW_VERSION__">
 <link rel="stylesheet" href="/assets/css/account-menu.css?v=__CW_VERSION__">
+<link id="cw-notifications-css" rel="stylesheet" href="/assets/css/notifications.css?v=__CW_VERSION__">
 <link rel="stylesheet" href="/assets/css/profile-page.css?v=__CW_VERSION__">
 <link rel="preload" href="/assets/fonts/material-symbols-rounded-full-v355.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="stylesheet" href="/assets/fonts/material-symbols-rounded.css?v=__CW_VERSION__">
@@ -2390,6 +2403,10 @@ def get_profile_html(user: dict | None = None) -> str:
 <script src="/assets/helpers/provider-meta.js?v=__CW_VERSION__" defer></script>
 <script src="/assets/helpers/icon-select.js?v=__CW_VERSION__" defer></script>
 <script src="/assets/helpers/account-menu.js?v=__CW_VERSION__" defer></script>
+<script src="/assets/helpers/notifications.js?v=__CW_VERSION__" defer></script>
+<script src="/assets/helpers/update-notifications.js?v=__CW_VERSION__" defer></script>
+<script src="/assets/js/overview-profile.js?v=__CW_VERSION__" defer></script>
+<script src="/assets/js/sync-reviews.js?v=__CW_VERSION__" defer></script>
 <script src="/assets/helpers/api.js?v=__CW_VERSION__" defer></script>
 <script src="/assets/helpers/media-meta.js?v=__CW_VERSION__" defer></script>
 <script src="/assets/helpers/trailer.js?v=__CW_VERSION__" defer></script>


### PR DESCRIPTION
# Pull request

## Change

Added a dedicated Logs page, accessible from View details and each sync pair’s Latest logs button.
- Follow live Sync, Watcher and Debug logging.
- Search messages and filter by severity, provider, pair or run.
- Highlight errors and warnings and inspect surrounding log lines.
- Browse saved logs, keep important logs and download full or filtered output.
- Retain logs for seven days within a 100 MB storage budget.
- Restrict log access to the permitted profiles and provider instances.

## Why

Users need more space and better filtering to investigate sync problems.

## Testing

- Tested persistence, retention, downloads and pair/run filtering.
- Verified profile access restrictions and background-log separation.
- Full test suite used.

## Issue

NA