### PR TITLE
Add: interactive Sync mapping and notifications

### DIFF
--- a/api/interactiveSyncAPI.py
+++ b/api/interactiveSyncAPI.py
@@ -11,7 +11,8 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
-from cw_platform.access_policy import request_user, user_can_access_pair
+from cw_platform.access_policy import request_user, user_can_access_pair, pair_profile_id, profile_allows_pair, profile_instances_map
+from cw_platform.provider_instances import normalize_user_profile_id
 from cw_platform.config_base import load_config
 from cw_platform.id_map import canonical_key, coalesce_ids, keys_for_item, ID_KEYS
 from cw_platform.value_coercion import coerce_bool
@@ -46,9 +47,19 @@ class Selection(Revision):
     q: str = Field(default="", max_length=256)
 
 
-class MappingEdit(Revision):
-    row_id: str
+class MappingChange(BaseModel):
+    row_id: str = Field(min_length=1, max_length=128)
     item: dict[str, Any]
+    selected: bool = True
+
+
+class MappingEdit(Revision, MappingChange):
+    pass
+
+
+class MappingBatch(Revision):
+    selection_version: int = Field(ge=0)
+    edits: list[MappingChange] = Field(min_length=1, max_length=200)
 
 
 def owner(request):
@@ -107,6 +118,38 @@ def launch(session, task, *args, applying=False, prepare=None):
         thread.start()
 
 
+@router.get("")
+def reviews(request: Request, user_profile: str = Query(default="", max_length=64)):
+    cfg = load_config()
+    user_id = owner(request)
+    profile = normalize_user_profile_id(user_profile)
+    if user_profile.strip() and not profile:
+        raise HTTPException(400, "Invalid profile")
+    instances = profile_instances_map(cfg, profile) if profile else {}
+    with svc.LOCK:
+        svc.prune()
+        available = []
+        for session in sorted(svc.SESSIONS.values(), key=lambda s: (s.status in ("reading", "applying"), s.touched), reverse=True):
+            if session.owner != user_id:
+                continue
+            try:
+                pair = pair_for(cfg, request, session.pair_id)
+            except HTTPException:
+                continue
+            if profile:
+                assigned = pair_profile_id(pair)
+                matches = assigned == profile if assigned else profile_allows_pair(instances, pair)
+                if not matches:
+                    continue
+            available.append(dict(
+                id=session.id, pair_id=session.pair_id, status=session.status,
+                pair={k: pair.get(k) for k in ("source", "target", "source_instance", "target_instance", "mode", "name")},
+                planned_at=session.planned_at,
+            ))
+        # Listing must not extend the lifetime of unattended reviews.
+        return dict(ok=True, sessions=available)
+
+
 @router.post("")
 def start(payload: Start, request: Request):
     cfg = load_config()
@@ -159,7 +202,8 @@ def report_issues(sid: str, request: Request, offset: int = Query(default=0, ge=
 @router.get("/{sid}/rows")
 def rows(sid: str, request: Request, revision: int = Query(ge=0), offset: int = Query(default=0, ge=0),
          limit: int = Query(default=75, ge=1, le=200), feature: str = Query(default="", max_length=32),
-         result: str = Query(default="", max_length=32), q: str = Query(default="", max_length=256)):
+         result: str = Query(default="", max_length=32), q: str = Query(default="", max_length=256),
+         selected_only: bool = False, editable_only: bool = False):
     with svc.LOCK:
         session = get_session(sid, request, load_config())
         if revision != session.revision:
@@ -167,7 +211,8 @@ def rows(sid: str, request: Request, revision: int = Query(ge=0), offset: int = 
         if session.store is None:
             raise HTTPException(409, "Wait for the plan to finish")
         return dict(ok=True, revision=session.revision, selection_version=session.selection_version,
-                    counts=dict(session.store.counts), **session.store.page(offset=offset, limit=limit, feature=feature, result=result, q=q))
+                    counts=dict(session.store.counts), **session.store.page(offset=offset, limit=limit, feature=feature, result=result, q=q,
+                                                                          selected_only=selected_only, editable_only=editable_only))
 
 
 @router.post("/{sid}/selection")
@@ -204,45 +249,135 @@ def apply(sid: str, payload: Apply, request: Request):
         return session.public()
 
 
+def mapping_row(session, row_id):
+    row = session.plan.rows.get(row_id)
+    if not row or row["operation"] not in ("add", "update") or row["feature"] == "playlists":
+        raise HTTPException(400, "This change cannot be remapped")
+    return row
+
+
+def prepare_mapping(row, corrected):
+    item = deepcopy(row["item"])
+    for key in (*ID_KEYS, "_trakt_history_id", "history_id", "_simkl_history_id", "_plex_history_id", "watched_id", "play_id", "provider_item_id", "provider_event_id"):
+        item.pop(key, None)
+    for key in ("type", "title", "year", "season", "episode", "series_title", "series_year", "show_ids"):
+        item.pop(key, None)
+        if key in corrected:
+            item[key] = corrected[key]
+    ids = corrected.get("ids")
+    if not isinstance(ids, dict) or any(k not in ID_KEYS for k in ids):
+        raise HTTPException(400, "Supply supported media identifiers")
+    item["ids"] = coalesce_ids(ids)
+    if "show_ids" in item:
+        if not isinstance(item["show_ids"], dict) or any(k not in ID_KEYS for k in item["show_ids"]):
+            raise HTTPException(400, "Supply supported show identifiers")
+        item["show_ids"] = coalesce_ids(item["show_ids"])
+    if item.get("type") not in ("movie", "show", "anime", "season", "episode"):
+        raise HTTPException(400, "Invalid media type")
+    if item["type"] in ("season", "episode"):
+        for field in (("season", "episode") if item["type"] == "episode" else ("season",)):
+            number = item.get(field)
+            if isinstance(number, bool) or not isinstance(number, int) or number < (1 if field == "episode" else 0):
+                raise HTTPException(400, f"Supply a valid {field} number")
+    key = canonical_key(item)
+    if key == "unknown:" or not (item["ids"] or item.get("show_ids")):
+        raise HTTPException(400, "A media identifier is required")
+    original = row["key"]
+    blocks = [original] if original and key != original and original not in keys_for_item(item) else []
+    return key, item, blocks
+
+
+def save_mappings(session, cfg, request, changes):
+    from .editorAPI import _require_instance_scope, _save_policy_manual_batch
+    from services.saved_mappings import mapping_details
+
+    prepared, corrections, seen, targets = [], [], set(), set()
+    mappings = {}
+    for edit in changes:
+        if edit.row_id in seen:
+            raise HTTPException(400, "An item can only be corrected once per batch")
+        seen.add(edit.row_id)
+        row = mapping_row(session, edit.row_id)
+        _require_instance_scope(cfg, request, row["source"], row["source_instance"])
+        try:
+            key, item, blocks = prepare_mapping(row, edit.item)
+        except HTTPException as error:
+            label = str(row["item"].get("series_title") or row["item"].get("title") or row["key"])
+            raise HTTPException(error.status_code, f"{label} ({row['key']}): {error.detail}") from error
+        target = (row["feature"], row["source"], row["source_instance"], key)
+        if target in targets:
+            raise HTTPException(400, "Two corrections point to the same item. Check the destination episode numbers.")
+        targets.add(target)
+        mappings.setdefault(target[:3], {})[key] = dict(
+            original_key=row["key"], original=mapping_details(row["item"]),
+            saved_at=int(time.time()), origin="interactive_sync",
+        )
+        prepared.append((row["feature"], row["source"], {key: item}, blocks, row["source_instance"]))
+        corrections.append(dict(identity=(row["feature"], key, row["source"], row["source_instance"], row["provider"], row["instance"]),
+                                selected=edit.selected))
+    launch(session, svc.refresh_mappings, cfg, dict(session.plan.choices), corrections,
+           prepare=lambda: _save_policy_manual_batch(prepared, mappings=mappings))
+    return session.public()
+
+
 @router.post("/{sid}/mapping")
 def mapping(sid: str, payload: MappingEdit, request: Request):
-    from .editorAPI import _require_instance_scope, _save_policy_manual
+    cfg = load_config()
+    with svc.LOCK:
+        session = get_session(sid, request, cfg)
+        check_revision(session, payload.revision)
+        return save_mappings(session, cfg, request, [payload])
+
+
+@router.post("/{sid}/mappings")
+def mappings(sid: str, payload: MappingBatch, request: Request):
+    cfg = load_config()
+    with svc.LOCK:
+        session = get_session(sid, request, cfg)
+        check_revision(session, payload.revision)
+        check_selection(session, payload.selection_version)
+        return save_mappings(session, cfg, request, payload.edits)
+
+
+@router.get("/{sid}/mapping-catalogs")
+def mapping_catalogs(sid: str, request: Request, revision: int = Query(ge=0),
+                     row_id: str = Query(min_length=1, max_length=128)):
+    from services.interactive_sync_catalogs import search_catalogs
+
+    cfg = load_config()
+    with svc.LOCK:
+        session = get_session(sid, request, cfg)
+        check_revision(session, revision)
+        row = deepcopy(mapping_row(session, row_id))
+    from services.interactive_sync_episodes import metadata_key
+    return {**search_catalogs(cfg, row), "episode_matching": bool(metadata_key(cfg, row))}
+
+
+@router.post("/{sid}/mapping-episodes")
+def mapping_episodes(sid: str, payload: MappingBatch, request: Request):
+    from services.interactive_sync_episodes import suggest_episodes
 
     cfg = load_config()
     with svc.LOCK:
         session = get_session(sid, request, cfg)
         check_revision(session, payload.revision)
-        row = session.plan.rows.get(payload.row_id)
-        if not row or row["operation"] not in ("add", "update") or row["feature"] == "playlists":
-            raise HTTPException(400, "This change cannot be remapped")
-        _require_instance_scope(cfg, request, row["source"], row["source_instance"])
-        item = deepcopy(row["item"])
-        for key in (*ID_KEYS, "_trakt_history_id", "history_id", "_simkl_history_id", "_plex_history_id", "watched_id", "play_id"):
-            item.pop(key, None)
-        for key in ("type", "title", "year", "season", "episode", "series_title", "series_year", "show_ids"):
-            item.pop(key, None)
-            if key in payload.item:
-                item[key] = payload.item[key]
-        ids = payload.item.get("ids")
-        if not isinstance(ids, dict) or any(k not in ID_KEYS for k in ids):
-            raise HTTPException(400, "Supply supported media identifiers")
-        item["ids"] = coalesce_ids(ids)
-        if "show_ids" in item:
-            if not isinstance(item["show_ids"], dict) or any(k not in ID_KEYS for k in item["show_ids"]):
-                raise HTTPException(400, "Supply supported show identifiers")
-            item["show_ids"] = coalesce_ids(item["show_ids"])
-        if item.get("type") not in ("movie", "show", "anime", "season", "episode"):
-            raise HTTPException(400, "Invalid media type")
-        key = canonical_key(item)
-        if key == "unknown:" or not (item["ids"] or item.get("show_ids")):
-            raise HTTPException(400, "A media identifier is required")
-        original = row["key"]
-        def save():
-            _save_policy_manual(row["feature"], row["source"], {key: item},
-                                [original] if original and key != original and original not in keys_for_item(item) else [],
-                                row["source_instance"], merge=True)
-        launch(session, svc.refresh, cfg, session.plan.choices, prepare=save)
-        return session.public()
+        check_selection(session, payload.selection_version)
+        edits = [(deepcopy(mapping_row(session, edit.row_id)), edit.item) for edit in payload.edits]
+    return suggest_episodes(cfg, edits)
+
+
+@router.get("/{sid}/mapping-search")
+def mapping_search(sid: str, request: Request, revision: int = Query(ge=0),
+                   row_id: str = Query(min_length=1, max_length=128), q: str = Query(min_length=2, max_length=200),
+                   catalog: str = Query(default="destination", pattern="^(destination|tmdb)$")):
+    from services.interactive_sync_mapping import search_candidates
+
+    cfg = load_config()
+    with svc.LOCK:
+        session = get_session(sid, request, cfg)
+        check_revision(session, revision)
+        row = deepcopy(mapping_row(session, row_id))
+    return search_candidates(cfg, row, q, catalog=catalog)
 
 
 @router.delete("/{sid}")

--- a/assets/css/interactive-sync.css
+++ b/assets/css/interactive-sync.css
@@ -12,8 +12,8 @@
 .is-header { position: static; top: auto; z-index: auto; display: flex; align-items: center; justify-content: space-between; gap: 24px; margin-bottom: 26px; padding: 0; border: 0; background: transparent; box-shadow: none; }
 .is-eyebrow { font-size: 10px; letter-spacing: .2em; color: var(--is-accent); font-weight: 750; }
 .is-header h1 { font-size: clamp(26px, 3vw, 36px); line-height: 1.2; letter-spacing: -.04em; margin: 7px 0 10px; }
-.is-header p, .is-mapping p { color: var(--is-muted); margin: 0; }
-.is-header-actions, .is-map-tools { display: flex; flex-wrap: wrap; gap: 10px; }
+.is-header p { color: var(--is-muted); margin: 0; }
+.is-header-actions { display: flex; flex-wrap: wrap; gap: 10px; }
 .is-btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; border: 1px solid var(--is-line); background: var(--is-surface); color: inherit; border-radius: 10px; padding: 10px 15px; cursor: pointer; text-decoration: none; transition: border-color .15s, background .15s; white-space: nowrap; }
 .is-btn:hover:not(:disabled) { border-color: var(--is-accent); background: color-mix(in srgb, var(--is-accent) 10%, var(--is-surface)); }
 .is-btn.is-primary { background: var(--is-accent); border-color: var(--is-accent); color: #fff; font-weight: 650; }
@@ -109,21 +109,84 @@
 .is-footer small { display: block; color: var(--is-muted); font-size: 11px; margin-top: 4px; }
 .is-notices { padding: 14px 18px; border: 1px solid var(--is-line); border-radius: 10px; margin-bottom: 20px; font-size: 12px; color: var(--is-muted); }
 .is-notices summary { cursor: pointer; color: #dfbc86; }
-.is-mapping { margin-top: 24px; padding: 26px; border: 1px solid var(--is-accent); border-radius: 14px; background: var(--is-surface); }
-.is-mapping-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 20px; margin-bottom: 16px; }
-.is-mapping h2 { font-size: 20px; margin: 0 0 5px; }
-.is-map-tools { margin: 20px 0; }
-.is-map-fields { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 14px; margin-bottom: 20px; }
-.is-map-fields label { display: flex; flex-direction: column; gap: 5px; font-size: 11px; color: var(--is-muted); }
-.is-map-search:empty { display: none; }
-.is-map-search { margin-top: 24px; padding-top: 20px; border-top: 1px solid var(--is-line); }
-.is-map-search .cw-search-bar, .is-map-search .cw-datetime-grid { display: flex; flex-wrap: wrap; gap: 12px; }
-.is-map-search label { display: flex; flex-direction: column; gap: 5px; }
-.is-map-search button { cursor: pointer; }
-.is-map-search .cw-meta-search-head { display: flex; gap: 10px; align-items: center; margin-bottom: 15px; }
-.is-map-search .cw-meta-search-close { margin-left: auto; }
-.is-map-search .cw-search-results { max-height: 400px; overflow: auto; }
-.is-map-search img { max-width: 65px; border-radius: 6px; }
+dialog.is-mapping-dialog { box-sizing: border-box; width: min(1400px, calc(100vw - 40px)); max-width: 1400px; max-height: calc(100dvh - 40px); margin: auto; padding: 0; border: 1px solid var(--is-line); border-radius: 14px; background: var(--is-surface); color: var(--fg, #edf0f8); overflow: hidden; }
+dialog.is-mapping-dialog[open] { display: grid; grid-template-rows: auto minmax(0, 1fr) auto; }
+html:has(dialog.is-mapping-dialog[open]) { overflow: hidden; }
+.is-mapping-dialog [hidden] { display: none!important; }
+.is-mapping-dialog::backdrop { background: #000b; }
+.is-mapping-dialog .is-mapping-head { display: flex; justify-content: space-between; gap: 20px; padding: 18px 24px; border-bottom: 1px solid var(--is-line); position: static; background: var(--is-surface); box-shadow: none; }
+.is-mapping-dialog .is-mapping-head p { margin: 0; }
+.is-mapping-dialog h2 { margin: 6px 0; font-size: 24px; }
+.is-mapping-dialog h3 { margin: 0 0 16px; font-size: 17px; }
+.is-mapping-dialog p, .is-mapping-dialog small { color: var(--is-muted); font-size: 13px; line-height: 1.5; }
+.is-mapping-body { min-height: 0; min-width: 0; overflow: auto; overscroll-behavior: contain; scrollbar-gutter: stable; padding: 0 24px 24px; }
+.is-map-intro, .is-map-search-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.is-map-intro { margin: 14px 0; color: var(--is-muted); font-size: 12px; }
+.is-map-help { max-width: 600px; }
+.is-map-help summary { list-style: none; text-align: right; cursor: pointer; }
+.is-map-help summary::-webkit-details-marker { display: none; }
+.is-map-help p { margin: 8px 0; }
+.is-map-search-heading { margin-bottom: 14px; }
+.is-mapping-dialog .is-map-search-heading h3 { margin: 0; font-size: 15px; }
+.is-map-close { align-self: flex-start; padding: 8px; }
+.is-map-chosen, .is-map-chosen > span { display: flex; align-items: center; gap: 12px; }
+.is-map-chosen { justify-content: space-between; padding: 12px 14px; border: 1px solid color-mix(in srgb, var(--is-accent) 40%, var(--is-line)); border-radius: 8px; background: color-mix(in srgb, var(--is-accent) 8%, transparent); }
+.is-map-chosen > span { min-width: 0; overflow-wrap: anywhere; }
+.is-map-chosen .material-symbols-rounded { color: var(--is-accent); }
+.is-map-candidates:not(:empty) { margin-top: 14px; }
+.is-map-bulk [data-search-status] { margin: 12px 0 0; }
+.is-map-bulk { border: 1px solid var(--is-line); border-radius: 10px; padding: 18px; }
+.is-map-search-bar, .is-map-numbering-fields, .is-map-row-tools { display: flex; align-items: end; flex-wrap: wrap; gap: 12px; }
+.is-map-search-bar label:first-child { flex: 1; min-width: 200px; }
+.is-mapping-dialog label { display: flex; flex-direction: column; gap: 5px; font-size: 12px; color: var(--is-muted); }
+.is-mapping-dialog input:not([type=checkbox]), .is-mapping-dialog select { box-sizing: border-box; width: 100%; min-height: 38px; border: 1px solid var(--is-line); border-radius: 6px; padding: 7px 10px; background: var(--is-surface); color: var(--fg); }
+.is-map-candidates { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(230px, 100%), 1fr)); gap: 8px; }
+.is-map-candidate { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 68px; padding: 12px 14px; white-space: normal; text-align: left; }
+.is-map-candidate strong { min-width: 0; font-size: 13px; font-weight: 600; line-height: 1.4; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; line-clamp: 2; overflow: hidden; overflow-wrap: anywhere; }
+.is-map-candidate-year { flex-shrink: 0; border-radius: 5px; padding: 3px 7px; background: color-mix(in srgb, var(--is-muted) 9%, transparent); color: var(--is-muted); font-size: 11px; font-variant-numeric: tabular-nums; }
+.is-map-candidate[aria-pressed=true] { border-color: var(--is-accent); background: color-mix(in srgb, var(--is-accent) 14%, var(--is-surface)); }
+.is-map-row-tools { align-items: center; margin: 20px 0 12px; font-size: 12px; color: var(--is-muted); }
+.is-map-row-tools strong { margin-right: auto; }
+.is-map-numbering { margin-bottom: 16px; padding: 12px 14px; border: 1px solid var(--is-line); border-radius: 8px; }
+.is-map-numbering summary, .is-map-advanced summary { cursor: pointer; color: var(--is-muted); font-size: 12px; }
+.is-map-numbering-fields { margin-top: 14px; }
+.is-map-numbering-fields label { width: 160px; }
+.is-map-review { display: grid; gap: 10px; }
+.is-map-row, .is-map-group { min-width: 0; border: 1px solid var(--is-line); border-radius: 10px; }
+.is-map-row-preview { display: grid; grid-template-columns: max-content minmax(0, 1fr) 20px minmax(0, 1fr) auto; gap: 18px; align-items: center; padding: 16px; }
+.is-map-row-preview > input[type="checkbox"] { margin: 0; }
+.is-map-row-preview > .material-symbols-rounded { color: var(--is-muted); }
+.is-map-row-preview strong { display: block; overflow-wrap: anywhere; font-size: 13px; font-weight: 600; }
+.is-map-row-preview small, .is-map-status { display: block; margin-top: 4px; }
+.is-map-row-editor { margin: 0 16px 16px 48px; padding-top: 16px; border-top: 1px solid var(--is-line); }
+.is-map-edit-fields { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 12px; }
+.is-map-edit-fields label { flex: 1; min-width: 90px; }
+.is-map-edit-fields label:first-child { flex: 3; min-width: min(240px, 100%); }
+.is-map-advanced { margin-top: 14px; }
+.is-map-group > summary { cursor: pointer; padding: 16px; font-size: 13px; }
+.is-map-group > summary > span { display: inline; overflow-wrap: anywhere; }
+.is-map-group > summary small { display: block; margin: 4px 0 0 18px; }
+.is-map-group [data-group-after] { display: block; margin: 8px 0 0 18px; color: var(--is-accent); font-size: 12px; }
+.is-map-group-tools { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; padding: 0 16px 12px; font-size: 12px; color: var(--is-muted); }
+.is-map-group > .is-map-row { border-radius: 0; border-width: 1px 0 0; }
+.is-map-group > .is-map-row:last-child { border-radius: 0 0 10px 10px; }
+.is-map-id-inputs { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 8px; margin-top: 8px; }
+.is-map-id-inputs label { min-width: 0; }
+.is-map-id-inputs label + label { margin-top: 0!important; }
+.is-map-save { position: relative; z-index: 2; display: flex; flex-wrap: wrap; gap: 16px; align-items: center; justify-content: space-between; padding: 18px 24px; background: var(--is-surface); border-top: 1px solid var(--is-line); }
+.is-map-save [data-error] { color: #ef8b93; margin: 8px 0 0; }
+.is-map-save [data-error]:empty { display: none; }
+@media (max-width: 700px) {
+  .is-map-row-preview { grid-template-columns: max-content minmax(0, 1fr) auto; gap: 16px; }
+  .is-map-row-preview > .material-symbols-rounded { grid-column: 1; grid-row: 2; }
+  .is-map-after { grid-column: 2; grid-row: 2; }
+  .is-map-row-preview > .is-map-actions { grid-column: 3; grid-row: 1 / span 2; flex-direction: column; }
+  .is-map-row-editor { margin-left: 16px; }
+  .is-map-chosen { align-items: flex-start; flex-direction: column; }
+  .is-map-search-heading { flex-wrap: wrap; }
+}
+@media (max-width: 700px) { dialog.is-mapping-dialog { width: calc(100vw - 16px); max-height: calc(100dvh - 16px); } .is-map-save .is-primary { width: 100%; white-space: normal; } .is-mapping-dialog .is-mapping-head, .is-mapping-body, .is-map-save { padding: 16px; } }
+
 .is-report { --is-good: var(--cw-theme-good, #69c99f); --is-warning: var(--cw-theme-warning, #e8bb69); --is-danger: var(--cw-theme-danger, #ee818d); margin-top: 24px; }
 .is-report-outcome { display: flex; align-items: center; gap: 18px; padding: 26px; border: 1px solid color-mix(in srgb, var(--is-good) 35%, var(--is-line)); border-radius: 16px; background: color-mix(in srgb, var(--is-good) 7%, var(--is-surface)); margin-bottom: 24px; }
 .is-report-outcome > .material-symbols-rounded { font-size: 38px; color: var(--is-good); }
@@ -174,5 +237,12 @@
 @keyframes is-spin { to { transform: rotate(360deg); } }
 .is-page .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip-path: inset(50%); white-space: nowrap; border: 0; }
 @media (prefers-reduced-motion: reduce) { .is-working > span { animation: none; } }
-@media (max-width: 800px) { .is-header { align-items: flex-start; flex-direction: column; gap: 16px; } .is-toolbar { flex-wrap: wrap; } .is-search { flex-basis: 100%; } .is-toolbar label:not(.is-search) { flex: 1; } .is-metrics > div { padding: 16px; } .is-footer { bottom: 8px; padding: 15px; } .is-footer small { max-width: 220px; } .is-map-fields { grid-template-columns: repeat(2, minmax(0, 1fr)); } .is-table { min-width: 740px; } }
+@media (max-width: 800px) { .is-header { align-items: flex-start; flex-direction: column; gap: 16px; } .is-toolbar { flex-wrap: wrap; } .is-search { flex-basis: 100%; } .is-toolbar label:not(.is-search) { flex: 1; } .is-metrics > div { padding: 16px; } .is-footer { bottom: 8px; padding: 15px; } .is-footer small { max-width: 220px; } .is-table { min-width: 740px; } }
 @media (max-width: 480px) { .is-footer { align-items: stretch; flex-direction: column; gap: 12px; } .is-footer small { max-width: none; } .is-route { padding: 14px; gap: 10px; } .is-route-mode { display: none; } .is-page { padding: 12px 0 24px; } }
+
+.is-map-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
+.is-page .is-map-action { display: inline-flex; align-items: center; gap: 6px; min-height: 32px; padding: 5px 9px; border-radius: 6px; font-size: 12px; font-weight: 400; white-space: nowrap; }
+.is-map-action .material-symbols-rounded, .is-map-status .material-symbols-rounded { font-size: 17px; flex-shrink: 0; }
+.is-map-status { display: inline-flex; align-items: center; gap: 6px; color: var(--is-muted); font-size: 12px; white-space: nowrap; }
+.is-map-status.is-edited { color: var(--is-accent); }
+.is-map-status.is-review { color: var(--cw-theme-warning, #e8bb69); }

--- a/assets/css/notifications.css
+++ b/assets/css/notifications.css
@@ -1,0 +1,49 @@
+/* assets/css/notifications.css */
+/* CrossWatch - flat notification bell and menu. */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+#cw-notifications-button, #cw-notifications-panel {
+  --notice-bg: var(--cw-theme-surface, #101217);
+  --notice-hover: var(--cw-theme-surface-raised, #191c23);
+  --notice-line: var(--cw-theme-border, #292d35);
+  --notice-text: var(--cw-theme-text, #e6e9ee);
+  --notice-muted: var(--cw-theme-muted, #929ba8);
+  --notice-accent: var(--cw-theme-accent, #7957ff);
+  color: var(--notice-text); font-family: inherit;
+}
+#cw-notifications-button { position: relative; display: inline-flex; align-items: center; justify-content: center; align-self: center; flex: 0 0 40px; width: 40px; height: 40px; padding: 0; margin: 0 6px; background: transparent; border: 1px solid transparent; border-radius: 8px; cursor: pointer; box-shadow: none; transition: background .12s, transform .12s; }
+#cw-notifications-button > .cw-notifications-bell { display: block; width: 22px; height: 22px; flex: none; }
+#cw-notifications-button:hover, #cw-notifications-button[aria-expanded="true"] { background: var(--notice-hover); border-color: var(--notice-line); }
+#cw-notifications-button:active { transform: translateY(1px); }
+#cw-notifications-button .cw-notifications-count { position: absolute; top: -3px; right: -4px; min-width: 18px; height: 18px; padding: 0 4px; border: 2px solid var(--notice-bg); border-radius: 12px; background: var(--notice-accent); color: #fff; font: 600 10px/14px system-ui, sans-serif; box-sizing: border-box; }
+#cw-notifications-panel { position: fixed; z-index: 10000; width: min(390px, calc(100vw - 16px)); display: flex; flex-direction: column; overflow: hidden; background: var(--notice-bg); border: 1px solid var(--notice-line); border-radius: 10px; box-shadow: 0 12px 32px #0004; }
+#cw-notifications-panel[hidden], #cw-notifications-panel [hidden], #cw-notifications-button [hidden] { display: none; }
+.cw-notifications-tools { display: flex; align-items: center; gap: 8px; }
+.cw-notifications-body li { display: flex; align-items: flex-start; }
+#cw-notifications-panel .cw-notification { flex: 1; min-width: 0; }
+#cw-notifications-panel [data-notification-clear] { flex: 0 0 32px; width: 32px; height: 32px; margin: 12px 10px 0 0; }
+.cw-notifications-head { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 14px 16px; border-bottom: 1px solid var(--notice-line); }
+#cw-notifications-title { font-size: 14px; font-weight: 600; letter-spacing: 0; margin: 0; }
+#cw-notifications-panel button { display: inline-flex; justify-content: center; align-items: center; padding: 6px; border: 1px solid transparent; border-radius: 6px; background: transparent; box-shadow: none; color: var(--notice-muted); font: inherit; font-size: 13px; cursor: pointer; }
+#cw-notifications-panel button:hover { background: var(--notice-hover); color: var(--notice-text); }
+#cw-notifications-panel button .material-symbols-rounded { font-size: 19px; }
+.cw-notifications-body { overflow: auto; overscroll-behavior: contain; }
+.cw-notifications-body ul { list-style: none; margin: 0; padding: 0; }
+.cw-notifications-body li + li { border-top: 1px solid var(--notice-line); }
+#cw-notifications-panel .cw-notification { display: flex; align-items: flex-start; gap: 12px; padding: 16px; text-decoration: none; color: var(--notice-text); background: transparent; }
+#cw-notifications-panel .cw-notification:hover { background: var(--notice-hover); }
+.cw-notification-icon { font-size: 22px; color: var(--notice-accent); margin-top: 2px; }
+.cw-notification-copy { display: grid; gap: 5px; min-width: 0; overflow-wrap: anywhere; font-size: 13px; }
+.cw-notification-copy strong { font-size: 14px; font-weight: 600; line-height: 1.4; }
+.cw-notification-copy > span, .cw-notification-copy small { color: var(--notice-muted); }
+.cw-notification-copy small { font-size: 11px; }
+.cw-notification-copy .cw-notification-action { display: flex; align-items: center; gap: 6px; margin-top: 5px; color: var(--notice-accent); }
+.cw-notification-action .material-symbols-rounded, .cw-notifications-footer .material-symbols-rounded { font-size: 17px; }
+.cw-notifications-empty { padding: 38px 20px; text-align: center; color: var(--notice-muted); }
+.cw-notifications-empty > .material-symbols-rounded { font-size: 38px; opacity: .6; }
+.cw-notifications-empty p { margin: 12px 0 6px; font-size: 15px; color: var(--notice-text); }
+.cw-notifications-empty small { font-size: 12px; }
+#cw-notifications-panel .cw-notifications-footer { display: flex; justify-content: center; align-items: center; gap: 8px; padding: 14px 16px; border-top: 1px solid var(--notice-line); color: var(--notice-accent); text-decoration: none; font-size: 13px; }
+.cw-notifications-footer:hover { background: var(--notice-hover); }
+.cw-notifications-message { padding: 16px; color: var(--notice-muted); font-size: 13px; }
+#cw-notifications-button:focus-visible, #cw-notifications-panel :is(a, button):focus-visible { outline: 2px solid var(--notice-accent); outline-offset: -3px; }
+@media (prefers-reduced-motion: reduce) { #cw-notifications-button { transition: none; transform: none; } }

--- a/assets/css/sync-reviews.css
+++ b/assets/css/sync-reviews.css
@@ -1,0 +1,27 @@
+/* assets/css/sync-reviews.css */
+/* CrossWatch - Interactive Sync return links */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+
+.cw-sync-reviews { scroll-margin-top: 100px; margin: 20px 0 0; padding-top: 20px; border-top: 1px solid #262b34; color: #e6e9ee; }
+.cw-sync-reviews[hidden] { display: none; }
+#sec-sync .cw-sync-reviews { scroll-margin-top: 100px; margin: 24px 0; }
+.cw-sync-reviews h3 { margin: 0 0 12px; font-size: 16px; font-weight: 600; }
+.cw-sync-reviews ul { display: grid; gap: 8px; padding: 0; margin: 0; list-style: none; }
+.cw-sync-reviews li { display: flex; align-items: center; gap: 14px; padding: 14px 16px; background: #0f1217; border: 1px solid #262b34; border-radius: 8px; }
+.cw-sync-reviews .cw-review-icon { color: #7957ff; font-size: 24px; }
+.cw-sync-reviews .cw-review-copy { display: grid; gap: 4px; flex: 1; min-width: 0; overflow-wrap: anywhere; }
+.cw-sync-reviews strong { font-size: 14px; font-weight: 600; }
+.cw-sync-reviews small, .cw-sync-reviews p, .cw-review-copy > span { color: #929ba8; font-size: 13px; }
+.cw-sync-reviews p { margin: 10px 0 0; }
+.cw-sync-reviews .cw-review-link, .cw-sync-reviews button { display: inline-flex; align-items: center; justify-content: center; gap: 8px; padding: 9px 12px; background: #15191f; border: 1px solid #303642; border-radius: 6px; color: #e6e9ee; font: inherit; font-size: 14px; font-weight: 400; text-decoration: none; white-space: nowrap; cursor: pointer; transition: background .12s, transform .12s; }
+.cw-sync-reviews .cw-review-link:hover, .cw-sync-reviews button:hover { background: #20252d; }
+.cw-sync-reviews .cw-review-link:active, .cw-sync-reviews button:active { transform: translateY(1px); }
+.cw-sync-reviews .cw-review-link:focus-visible, .cw-sync-reviews button:focus-visible { outline: 2px solid #7957ff; outline-offset: 3px; }
+.cw-review-link .material-symbols-rounded { font-size: 18px; }
+@media (max-width: 600px) {
+  .cw-sync-reviews li { flex-wrap: wrap; }
+  .cw-sync-reviews .cw-review-link { width: 100%; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cw-sync-reviews .cw-review-link, .cw-sync-reviews button { transition: none; transform: none; }
+}

--- a/assets/helpers/icon-select.js
+++ b/assets/helpers/icon-select.js
@@ -277,7 +277,7 @@
       const menu = d.createElement("div");
       menu.className = "cw-icon-select-menu hidden";
       menu.setAttribute("role", "listbox");
-      d.body.appendChild(menu);
+      (select.closest("dialog") || d.body).appendChild(menu);
       wrap.__cwMenu = menu;
       select.classList.add("cw-icon-select-native");
       select.insertAdjacentElement("afterend", wrap);
@@ -285,7 +285,7 @@
       const menu = d.createElement("div");
       menu.className = "cw-icon-select-menu hidden";
       menu.setAttribute("role", "listbox");
-      d.body.appendChild(menu);
+      (select.closest("dialog") || d.body).appendChild(menu);
       wrap.__cwMenu = menu;
     }
     wrap.__cwNativeSelect = select;

--- a/assets/helpers/notifications.js
+++ b/assets/helpers/notifications.js
@@ -1,0 +1,158 @@
+/* assets/helpers/notifications.js */
+/* CrossWatch - shared notification menu, with replaceable notification sources. */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+(() => {
+  const account = document.getElementById("cw-nav-profile-menu");
+  if (!account || window.CW?.Notifications) return;
+  const esc = value => String(value ?? "").replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+  const sources = new Map();
+  const dismissedScopes = new Map();
+  const storagePrefix = "cw.notifications.dismissed.v1:";
+  let visibleItems = [];
+  const scopeKey = (scope = "profile") => storagePrefix + JSON.stringify([
+    window.CW?.AuthState?.user?.id || window.CW?.AuthState?.user?.username || "local",
+    scope === "account" ? "account" : (window.CW?.OverviewProfile?.id || window.CW?.AuthState?.profileId || "all"),
+  ]);
+  function dismissed(scope) {
+    const key = scopeKey(scope);
+    if (!dismissedScopes.has(key)) {
+      let entries = [];
+      try {
+        const saved = JSON.parse(localStorage.getItem(key) || "[]");
+        if (Array.isArray(saved)) entries = saved.filter(value => typeof value === "string");
+      } catch {}
+      dismissedScopes.set(key, new Set(entries));
+    }
+    return dismissedScopes.get(key);
+  }
+  function clearItems(items) {
+    for (const scope of new Set(items.map(item => item.dismissalScope))) {
+      const entries = dismissed(scope);
+      for (const item of items.filter(item => item.dismissalScope === scope)) entries.add(item.notificationKey);
+      // Bound browser storage; the newest dismissals are retained across reloads.
+      while (entries.size > 2000) entries.delete(entries.values().next().value);
+      try { localStorage.setItem(scopeKey(scope), JSON.stringify([...entries])); } catch {}
+    }
+    render();
+    panel.querySelector("[data-notification-clear]")?.focus();
+    if (!visibleItems.length) panel.querySelector("[data-notifications-close]").focus();
+  }
+  let style = document.getElementById("cw-notifications-css");
+  if (!style) {
+    style = document.createElement("link");
+    style.id = "cw-notifications-css";
+    style.rel = "stylesheet";
+    style.href = `/assets/css/notifications.css?v=${encodeURIComponent(window.APP_VERSION || "1")}`;
+    document.head.append(style);
+  }
+  const bell = document.createElement("button");
+  bell.id = "cw-notifications-button";
+  bell.type = "button";
+  bell.setAttribute("aria-label", "Notifications");
+  bell.setAttribute("aria-haspopup", "dialog");
+  bell.setAttribute("aria-expanded", "false");
+  bell.setAttribute("aria-controls", "cw-notifications-panel");
+  bell.innerHTML = '<svg class="cw-notifications-bell" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M18 8a6 6 0 0 0-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9"/><path d="M9 17a3 3 0 0 0 6 0"/></svg><span class="cw-notifications-count" hidden aria-hidden="true"></span>';
+  // Older shells may still load this stylesheet lazily. Never show an unstyled button.
+  if (!style.sheet) {
+    bell.style.visibility = "hidden";
+    style.addEventListener("load", () => { bell.style.visibility = ""; }, { once: true });
+  }
+  account.before(bell);
+  const panel = document.createElement("section");
+  panel.id = "cw-notifications-panel";
+  panel.hidden = true;
+  panel.setAttribute("role", "dialog");
+  panel.setAttribute("aria-labelledby", "cw-notifications-title");
+  panel.innerHTML = '<div class="cw-notifications-head"><h2 id="cw-notifications-title">Notifications</h2><div class="cw-notifications-tools"><button type="button" data-notifications-clear-all hidden>Clear all</button><button type="button" data-notifications-close aria-label="Close notifications"><span class="material-symbols-rounded" aria-hidden="true">close</span></button></div></div><div class="cw-notifications-body"></div>';
+  document.body.append(panel);
+  const body = panel.querySelector(".cw-notifications-body");
+  const badge = bell.querySelector(".cw-notifications-count");
+
+  function position() {
+    if (panel.hidden) return;
+    const rect = bell.getBoundingClientRect();
+    const top = Math.min(rect.bottom + 10, window.innerHeight - 100);
+    panel.style.top = `${Math.max(8, top)}px`;
+    panel.style.right = `${Math.max(8, Math.min(window.innerWidth - rect.right, window.innerWidth - panel.offsetWidth - 8))}px`;
+    panel.style.maxHeight = `${Math.max(80, window.innerHeight - top - 12)}px`;
+  }
+
+  function setOpen(open, restoreFocus = false) {
+    panel.hidden = !open;
+    bell.setAttribute("aria-expanded", String(open));
+    if (open) {
+      position();
+      panel.querySelector("[data-notifications-close]").focus();
+      window.dispatchEvent(new CustomEvent("cw:notifications-refresh"));
+    } else if (restoreFocus) bell.focus();
+  }
+
+  function render() {
+    const values = [...sources.values()];
+    const items = visibleItems = [...sources].flatMap(([name, source]) => (source.items || []).map(item => ({
+      ...item, dismissalScope: source.scope === "account" ? "account" : "profile",
+      notificationKey: JSON.stringify([name, item.id || item.href, item.revision || ""]),
+    }))).filter(item => !dismissed(item.dismissalScope).has(item.notificationKey));
+    panel.querySelector("[data-notifications-clear-all]").hidden = !items.length;
+    badge.hidden = !items.length;
+    badge.textContent = items.length > 99 ? "99+" : String(items.length);
+    bell.setAttribute("aria-label", items.length ? `Notifications (${items.length})` : "Notifications");
+    const loading = values.some(source => source.loading);
+    const errors = values.map(source => source.error).filter(Boolean);
+    const html = `${items.length ? `<ul>${items.map(item => {
+      // Only local pages and official CrossWatch releases are valid targets.
+      const href = String(item.href || "");
+      let external = false;
+      try {
+        const url = new URL(href, location.href);
+        external = url.origin !== location.origin;
+        if (!href || (external && !(url.origin === "https://github.com" && url.pathname.startsWith("/cenodude/CrossWatch/releases/") && !url.username && !url.password))) return "";
+      } catch { return ""; }
+      const time = item.time ? new Date(item.time * 1000).toLocaleString() : "";
+      return `<li><a class="cw-notification" href="${esc(href)}"${external ? ' target="_blank" rel="noopener noreferrer"' : ""}><span class="material-symbols-rounded cw-notification-icon" aria-hidden="true">${esc(item.icon || "notifications")}</span><span class="cw-notification-copy"><strong>${esc(item.title)}</strong><span>${esc(item.detail)}</span>${time ? `<small>${esc(time)}</small>` : ""}<span class="cw-notification-action">${esc(item.action || "View")}<span class="material-symbols-rounded" aria-hidden="true">arrow_forward</span></span></span></a><button type="button" data-notification-clear="${esc(item.notificationKey)}" aria-label="${esc(`Clear notification: ${item.title}`)}" title="Clear notification"><span class="material-symbols-rounded" aria-hidden="true">close</span></button></li>`;
+    }).join("")}</ul>` : !loading && !errors.length ? '<div class="cw-notifications-empty"><span class="material-symbols-rounded" aria-hidden="true">notifications_none</span><p>You’re all caught up</p><small>New notifications will appear here.</small></div>' : ""}${loading ? '<p class="cw-notifications-message" role="status">Loading notifications…</p>' : ""}${errors.length ? `<div class="cw-notifications-message"><p>${errors.map(esc).join("<br>")}</p><button type="button" data-notifications-retry>Try again</button></div>` : ""}${document.getElementById("pairs_list") ? '<a class="cw-notifications-footer" href="#settings/sync">View sync reviews<span class="material-symbols-rounded" aria-hidden="true">arrow_forward</span></a>' : ""}`;
+    if (body.innerHTML !== html) body.innerHTML = html;
+    position();
+  }
+
+  bell.addEventListener("click", () => setOpen(panel.hidden));
+  panel.addEventListener("click", event => {
+    if (event.target.closest("[data-notifications-clear-all]")) clearItems(visibleItems);
+    const clear = event.target.closest("[data-notification-clear]");
+    if (clear) clearItems(visibleItems.filter(item => item.notificationKey === clear.dataset.notificationClear));
+    if (event.target.closest("[data-notifications-close]")) setOpen(false, true);
+    if (event.target.closest("[data-notifications-retry]")) window.dispatchEvent(new CustomEvent("cw:notifications-refresh"));
+    if (event.target.closest("a")) setOpen(false);
+  });
+  document.addEventListener("pointerdown", event => {
+    if (!panel.contains(event.target) && !bell.contains(event.target)) setOpen(false);
+  }, true);
+  document.addEventListener("keydown", event => {
+    if (event.key === "Escape" && !panel.hidden) { event.preventDefault(); setOpen(false, true); }
+  });
+  document.addEventListener("focusin", event => {
+    if (!panel.hidden && !panel.contains(event.target) && !bell.contains(event.target)) setOpen(false);
+  });
+  document.addEventListener("tab-changed", () => setOpen(false));
+  window.addEventListener("hashchange", () => setOpen(false));
+  window.addEventListener("resize", position);
+  window.addEventListener("scroll", position, true);
+  function reset() { sources.clear(); setOpen(false); render(); }
+  window.addEventListener("auth-changed", reset);
+  window.addEventListener("cw:auth-state-changed", reset);
+  window.addEventListener("cw:overview-profile-changed", () => {
+    for (const [name, source] of sources) if (source.scope !== "account") sources.delete(name);
+    setOpen(false); render();
+  });
+  window.addEventListener("storage", event => {
+    if (event.key === null || (event.key === scopeKey() || event.key === scopeKey("account"))) {
+      dismissedScopes.clear(); render();
+    }
+  });
+  (window.CW ||= {}).Notifications = {
+    setSource(name, value) { sources.set(name, value); render(); },
+    removeSource(name) { sources.delete(name); render(); },
+  };
+  render();
+})();

--- a/assets/helpers/update-notifications.js
+++ b/assets/helpers/update-notifications.js
@@ -1,0 +1,45 @@
+/* assets/helpers/update-notifications.js */
+/* CrossWatch - Release announcements in the shared notification menu */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+
+(() => {
+  let checkedAt = 0, controller;
+  function publish(status) {
+    if (!status || status.unavailable) return;
+    const latest = String(status.latest || status.latest_version || "").trim().replace(/^v/i, "");
+    const current = String(status.current || status.current_version || "").trim();
+    const available = status.available ?? status.update_available;
+    window.CW?.Notifications?.setSource("updates", {scope:"account", items: available && latest ? [{
+      id: latest, title: `CrossWatch v${latest} is available`,
+      detail: current ? `Installed version: v${current.replace(/^v/i, "")}` : "A new CrossWatch release is available.",
+      icon: "system_update_alt", action: "View release notes",
+      href: `https://github.com/cenodude/CrossWatch/releases/tag/v${encodeURIComponent(latest)}`,
+    }] : []});
+  }
+  async function refresh() {
+    if (document.hidden || controller || Date.now() - checkedAt < 300000) return;
+    const request = controller = new AbortController();
+    const timeout = setTimeout(() => request.abort(), 15000);
+    try {
+      await window.__cwAuthBootstrapPromise;
+      if (request.signal.aborted || window.cwIsAuthSetupPending?.()) return;
+      const response = await fetch("/api/version", {credentials:"same-origin", cache:"no-store", signal:request.signal});
+      checkedAt = Date.now();
+      if (response.ok) {
+        const status = await response.json();
+        if (!request.signal.aborted) publish(status);
+      }
+    } catch {} finally {
+      clearTimeout(timeout);
+      if (controller === request) controller = null;
+    }
+  }
+  document.addEventListener("cw-update-status", event => publish(event.detail));
+  document.addEventListener("visibilitychange", refresh);
+  window.addEventListener("cw:notifications-refresh", refresh);
+  const reset = () => { controller?.abort(); controller=null; checkedAt=0; refresh(); };
+  window.addEventListener("auth-changed", reset);
+  window.addEventListener("cw:auth-state-changed", reset);
+  setInterval(refresh, 300000);
+  refresh();
+})();

--- a/assets/js/interactive-sync-mapping.js
+++ b/assets/js/interactive-sync-mapping.js
@@ -1,0 +1,434 @@
+/* assets/js/interactive-sync-mapping.js */
+/* CrossWatch - Batch mapping workspace for Interactive Sync */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+const ID_FIELDS = ["tmdb", "imdb", "tvdb", "trakt", "simkl", "mdblist", "anilist", "mal", "anidb"];
+const icon = name => `<span class="material-symbols-rounded" aria-hidden="true">${name}</span>`;
+const esc = value => String(value ?? "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"})[c]);
+export const seriesTitle = item => String(item.series_title || item.show_title || item.title || "").replace(/\s*[·-]?\s*S\d+E\d+.*$/i, "").trim();
+export function sameSeason(left, right) {
+  return left.item.type === "episode" && right.item.type === "episode"
+    && ["source", "source_instance", "provider", "instance", "feature"].every(key => left[key] === right[key])
+    && seriesTitle(left.item).toLocaleLowerCase() === seriesTitle(right.item).toLocaleLowerCase()
+    && Number(left.item.season) === Number(right.item.season);
+}
+export function correctedItem(original, {ids, title, season, offset = 0}) {
+  const item = structuredClone(original);
+  if (ids) {
+    item.ids = {...ids};
+    if (["episode", "season"].includes(item.type)) item.show_ids = {...ids};
+  }
+  if (title) {
+    item.title = title;
+    if (["episode", "season"].includes(item.type)) {
+      item.series_title = title;
+      item.show_title = title;
+    }
+  }
+  if (["episode", "season"].includes(item.type) && season !== "" && season != null) item.season = Number(season);
+  if (item.type === "episode") item.episode = Number(item.episode) + Number(offset);
+  return item;
+}
+
+export function mappingGroups(rows) {
+  const groups = [];
+  rows.forEach((row, index) => {
+    const group = groups.find(indices => sameSeason(rows[indices[0]], row));
+    if (group) group.push(index); else groups.push([index]);
+  });
+  return groups;
+}
+
+export function correctedEpisode(original, match) {
+  const ids = original.show_ids || original.ids || {};
+  const sameShow = ids.tmdb && String(ids.tmdb) === String(match.ids?.tmdb);
+  return {...correctedItem(original, {...match, ids: sameShow ? {...ids, ...match.ids} : match.ids}), episode:match.episode};
+}
+
+export function openMappingWorkspace({rows, session = {}, json, post, onSaved, onClose, total, mappingApi, standalone = false}) {
+  const api = mappingApi || {
+    catalogs: row => json(`/api/interactive-sync/${session.id}/mapping-catalogs?${new URLSearchParams({revision:session.revision, row_id:row.id})}`),
+    search: (row, q, catalog, options) => json(`/api/interactive-sync/${session.id}/mapping-search?${new URLSearchParams({revision:session.revision, row_id:row.id, q, catalog})}`, options),
+    episodes: (edits, options) => json(`/api/interactive-sync/${session.id}/mapping-episodes`, {...options, method:"POST", headers:{"Content-Type":"application/json"}, body:JSON.stringify({revision:session.revision, selection_version:session.selection_version, edits})}),
+    save: edits => post(`/api/interactive-sync/${session.id}/mappings`, {revision:session.revision, selection_version:session.selection_version, edits}),
+  };
+  const dialog = document.createElement("dialog");
+  dialog.className = "is-page is-mapping-dialog";
+  dialog.setAttribute("aria-label", "Edit mappings");
+  const drafts = rows.map(row => ({row, item: structuredClone(row.item), checked: true, dirty: false}));
+  const cache = new Map();
+  const catalogs = new Map();
+  const episodeMatching = new Map();
+  const routeKey = row => JSON.stringify([row.provider, row.instance || "default"]);
+  let saving = false, searching = false, closed = false, searchController = null;
+  const groups = mappingGroups(rows);
+  const first = rows[0];
+  const endpoint = row => [row.provider, row.instance !== "default" ? row.instance : ""].filter(Boolean).join(" · ");
+  const input = (name, value, type = "text", extra = "") => `<input data-field="${name}" type="${type}" value="${esc(value)}" ${extra}>`;
+  const episodeLabel = item => item.type === "episode" ? `S${String(item.season).padStart(2,"0")}E${String(item.episode).padStart(2,"0")}` : item.type;
+  const itemLabel = item => [seriesTitle(item), item.type === "episode" ? episodeLabel(item) : item.year].filter(Boolean).join(" · ");
+  const renderDraft = index => {
+    const {row, item} = drafts[index], episodic = ["episode", "season"].includes(item.type), ids = item.show_ids || item.ids || {};
+    return `<article class="is-map-row" data-draft="${index}">
+      <div class="is-map-row-preview"><input type="checkbox" data-edit checked aria-label="Select ${esc(itemLabel(item))}">
+        <div class="is-map-before"><strong>${esc(itemLabel(item))}</strong><small>${esc(endpoint(row))} · ${esc(row.feature)}</small></div>
+        ${icon("arrow_forward")}<div class="is-map-after"><strong data-after>${esc(itemLabel(item))}</strong><span data-draft-status class="is-map-status">Unchanged</span></div>
+        <div class="is-map-actions"><button class="is-btn is-map-action" data-edit-row aria-expanded="false" aria-controls="mapping-edit-${index}" aria-label="Edit ${esc(itemLabel(item))}" title="Edit">${icon("edit")}</button><button class="is-btn is-map-action" data-reset hidden aria-label="Undo changes to ${esc(itemLabel(item))}" title="Undo">${icon("undo")}</button></div>
+      </div>
+      <div class="is-map-row-editor" id="mapping-edit-${index}" hidden><p data-review-reason hidden></p>
+        <div class="is-map-edit-fields"><label>Title${input("title", seriesTitle(item))}</label>${episodic ? `<label>Season${input("season", item.season, "number", 'min="0"')}</label>` : ""}${item.type === "episode" ? `<label>Episode${input("episode", item.episode, "number", 'min="1"')}</label>` : ""}</div>
+        <button class="is-btn is-map-action" data-find-row hidden>${icon("search")}Find another title</button>
+        <details class="is-map-advanced"><summary>Advanced · Manual IDs</summary><div class="is-map-id-inputs">${ID_FIELDS.map(key => `<label>${key.toUpperCase()}${input(key, ids[key] || "")}</label>`).join("")}</div></details>
+      </div></article>`;
+  };
+  dialog.innerHTML = `<header class="is-mapping-head"><div><div class="is-eyebrow">MAPPING</div><h2>Edit mappings</h2><p>Choose the correct title and review your changes.</p></div><button class="is-btn is-map-close" data-close aria-label="Close" title="Close">${icon("close")}</button></header>
+    <div class="is-mapping-body">
+    <div class="is-map-intro"><span>${rows.length} item${rows.length === 1 ? "" : "s"}${total > rows.length ? ` from ${total} results` : ""}</span><details class="is-map-help"><summary aria-label="About saved mappings" title="About saved mappings">${icon("info")}</summary><p>Saved mappings also apply to future syncs using the same source and profile. Watched dates and ratings are kept. ${standalone ? "Run the pair again to retry with your correction. Saving does not start a sync." : "Saving updates your sync review; it does not start a sync."}</p></details></div>
+    <section class="is-map-bulk" aria-label="Choose a title"><div class="is-map-search-heading"><h3>Choose a title</h3><div class="is-map-actions"><button class="is-btn" data-suggest hidden>${icon("auto_fix_high")}Auto match</button><button class="is-btn" data-stop-search hidden>Stop search</button></div></div>
+      <div data-chosen hidden class="is-map-chosen"><span>${icon("check_circle")}<strong data-match></strong></span><button class="is-btn is-small" data-change-match>Change match</button></div>
+      <div data-search-panel><div class="is-map-search-bar" hidden><label>Search title<input data-search-query value="${esc(seriesTitle(first.item))}" maxlength="200"></label><label>Search in<select data-catalog></select></label><button class="is-btn" data-search>Find matches</button></div><div class="is-map-candidates"></div></div>
+      <p data-search-status role="status">Choose a match or try Auto match.</p>
+    </section>
+    <div class="is-map-row-tools"><strong data-selection-count></strong><button class="is-btn is-small" data-check-all>Select all</button><button class="is-btn is-small" data-check-none>Clear selection</button></div>
+    <details class="is-map-numbering" hidden><summary>Adjust episode numbering</summary><div class="is-map-numbering-fields"><label>Season<input data-season type="number" min="0" placeholder="Keep current"></label><label>Shift episode numbers by<input data-offset type="number" value="0"></label><button class="is-btn" data-bulk>Apply numbering</button></div><p>Use 0 to keep episode numbers, or a shift such as −10 to change episode 11 to 1. Applies to selected episodes.</p></details>
+    <div class="is-map-review">${groups.map((indices, groupIndex) => indices.length === 1 ? renderDraft(indices[0]) : `<details class="is-map-group" data-group="${groupIndex}"><summary><span><strong>${esc(seriesTitle(rows[indices[0]].item))} · Season ${esc(rows[indices[0]].item.season)}</strong><small>${indices.length} episodes · ${esc(endpoint(rows[indices[0]]))}</small></span><span data-group-after>Review episodes</span></summary><div class="is-map-group-tools"><button class="is-btn is-small" data-select-group="${groupIndex}">Select this season</button><span data-group-count></span></div>${indices.map(renderDraft).join("")}</details>`).join("")}</div>
+    </div><footer class="is-map-save"><div><strong data-count>No changes yet</strong><p data-error role="alert"></p></div><button class="is-btn is-primary" data-save disabled>Save mappings</button></footer>`;
+  document.body.append(dialog);
+  dialog.showModal();
+  const $ = selector => dialog.querySelector(selector);
+  function updateCatalogs() {
+    const row = drafts.find(d => d.checked)?.row || first;
+    const options = catalogs.get(routeKey(row)) || [];
+    const select = $("[data-catalog]"), previous = select.value;
+    select.innerHTML = options.map(option => `<option value="${esc(option.id)}">${esc(option.label)}</option>`).join("");
+    if (options.some(option => option.id === previous)) select.value = previous;
+    $(".is-map-search-bar").hidden = !options.length;
+    $("[data-suggest]").hidden = !options.length;
+    $(".is-map-numbering").hidden = !drafts.some(d => d.checked && d.item.type === "episode");
+    $("[data-selection-count]").textContent = `${drafts.filter(d => d.checked).length} selected`;
+    dialog.querySelectorAll("[data-find-row]").forEach(button => {
+      const index = Number(button.closest("[data-draft]").dataset.draft);
+      button.hidden = !(catalogs.get(routeKey(drafts[index].row)) || []).length;
+    });
+    updateGroups();
+  }
+  async function loadCatalogs() {
+    const unique = new Map(rows.map(row => [routeKey(row), row]));
+    const results = await Promise.allSettled([...unique].map(async ([key, row]) => {
+      const data = await api.catalogs(row);
+      catalogs.set(key, data.catalogs || []);
+      episodeMatching.set(key, !!data.episode_matching);
+    }));
+    if (closed) return;
+    updateCatalogs();
+    if (results.some(result => result.status === "rejected")) status("Could not check available catalogs. Reopen mapping to retry. Manual editing is available.");
+    else if (![...catalogs.values()].some(options => options.length)) status("No configured search catalog is available. You can still edit IDs and episode numbers below.");
+  }
+  loadCatalogs();
+  function status(message) { $("[data-search-status]").textContent = message; }
+  function showSearch() {
+    $("[data-search-panel]").hidden = false;
+    $("[data-chosen]").hidden = true;
+  }
+  function selectionChanged() {
+    dialog.querySelectorAll("[data-edit]").forEach(el => { el.checked = drafts[Number(el.closest("[data-draft]").dataset.draft)].checked; });
+    showSearch();
+    updateCatalogs();
+  }
+  function updateGroups() {
+    groups.forEach((indices, groupIndex) => {
+      const group = $(`[data-group="${groupIndex}"]`);
+      if (!group) return;
+      const items = indices.map(index => drafts[index]);
+      const changed = items.filter(d => d.dirty).length;
+      const review = items.filter(d => d.review).length;
+      const targets = [...new Set(items.filter(d => d.dirty).map(d => `${seriesTitle(d.item)} · Season ${d.item.season}`))];
+      group.querySelector("[data-group-after]").textContent = [targets.length === 1 ? `→ ${targets[0]}` : targets.length ? `${targets.length} corrected titles / seasons` : "Review episodes", review ? `${review} need review` : changed ? `${changed} changed` : ""].filter(Boolean).join(" · ");
+      group.querySelector("[data-group-count]").textContent = `${items.filter(d => d.checked).length} of ${items.length} selected`;
+    });
+  }
+  function draftStatus(draft, reason = "") {
+    const cell = dialog.querySelector(`[data-draft="${drafts.indexOf(draft)}"] [data-draft-status]`);
+    cell.className = `is-map-status${draft.review ? " is-review" : draft.dirty ? " is-edited" : ""}`;
+    cell.textContent = draft.review ? "Needs review" : draft.dirty ? "Changed" : "Unchanged";
+    cell.title = reason || draft.review || "";
+    const explanation = $(`[data-draft="${drafts.indexOf(draft)}"] [data-review-reason]`);
+    explanation.textContent = draft.review || "";
+    explanation.hidden = !draft.review;
+    updateGroups();
+  }
+  function changed(draft) {
+    draft.dirty = JSON.stringify(draft.item) !== JSON.stringify(draft.row.item);
+    draftStatus(draft);
+    const count = drafts.filter(d => d.dirty).length;
+    $("[data-count]").textContent = count ? `${count} change${count === 1 ? "" : "s"} ready to save` : "No changes yet";
+    const row = $(`[data-draft="${drafts.indexOf(draft)}"]`);
+    row.querySelector("[data-after]").textContent = itemLabel(draft.item);
+    row.querySelector("[data-reset]").hidden = !draft.dirty;
+    $("[data-save]").disabled = !count || saving || searching;
+  }
+  function paint(draft) {
+    const el = dialog.querySelector(`[data-draft="${drafts.indexOf(draft)}"]`);
+    el.querySelectorAll("[data-field]").forEach(field => {
+      const key = field.dataset.field;
+      field.value = ID_FIELDS.includes(key) ? (draft.item.show_ids || draft.item.ids || {})[key] || "" : key === "title" ? seriesTitle(draft.item) : draft.item[key] ?? "";
+    });
+    changed(draft);
+  }
+  function lock(value) {
+    dialog.querySelectorAll("button,input,select").forEach(el => { el.disabled = value || el.hasAttribute("data-match-unavailable"); });
+    $("[data-stop-search]").hidden = !searching;
+    $("[data-stop-search]").disabled = !searching;
+    if (!value) $("[data-save]").disabled = !drafts.some(d => d.dirty) || saving || searching;
+  }
+  async function search(row, term) {
+    const catalog = $("[data-catalog]").value;
+    if (!(catalogs.get(routeKey(row)) || []).some(option => option.id === catalog)) return null;
+    const key = JSON.stringify([row.provider, row.instance, row.item.type === "movie" ? "movie" : "show", term, catalog]);
+    if (!cache.has(key)) {
+      const data = await api.search(row, term, catalog, {signal:searchController?.signal});
+      if (data.results.some(match => match.mapping_unavailable)) return data;
+      cache.set(key, data);
+    }
+    return cache.get(key);
+  }
+  async function find(row) {
+    const term = $("[data-search-query]").value.trim();
+    if (term.length < 2) { status("Enter at least two characters."); return; }
+    showSearch();
+    searchController = new AbortController(); searching = true; lock(true); status(`Searching ${endpoint(row)}...`);
+    try {
+      const data = await search(row, term);
+      if (closed) return;
+      if (!data) { status("Search is not available for this destination. Choose another configured catalog."); return; }
+      const matches = data.results.slice(0, 10);
+      status(`${data.catalog}: ${matches.length} match${matches.length === 1 ? "" : "es"}${data.results.length > matches.length ? " shown. Refine your search for more specific results." : ". Choose a title to update the checked items."}`);
+      $(".is-map-candidates").replaceChildren();
+      matches.forEach(match => {
+        const button = document.createElement("button");
+        button.type = "button"; button.className = "is-btn is-map-candidate";
+        if (match.mapping_unavailable) {
+          button.setAttribute("data-match-unavailable", "");
+          button.disabled = true;
+        }
+        button.title = [match.title, match.year, match.mapping_unavailable].filter(Boolean).join(" · ");
+        button.innerHTML = `<strong>${esc(match.title)}</strong>${match.year ? `<span class="is-map-candidate-year">${esc(match.year)}</span>` : ""}`;
+        button.onclick = async () => {
+          if (match.mapping_unavailable) { status(match.mapping_unavailable); return; }
+          const selected = drafts.filter(d => d.checked);
+          if (!selected.length) { status("Check the items you want to update first."); return; }
+          if (selected.some(d => routeKey(d.row) !== routeKey(row)
+            || (d.item.type === "movie" ? "movie" : "show") !== (row.item.type === "movie" ? "movie" : "show"))) {
+            status("Choose rows with the same destination and media type for this match.");
+            return;
+          }
+          selected.forEach(draft => {
+            draft.review = "";
+            draft.item = correctedItem(draft.item, {ids:match.ids, title:match.title});
+            paint(draft);
+          });
+          $("[data-match]").textContent = [match.title, match.year].filter(Boolean).join(" · ");
+          $("[data-chosen]").hidden = false;
+          $("[data-search-panel]").hidden = true;
+          $("[data-change-match]").focus();
+          $(".is-map-candidates").querySelectorAll("button").forEach(b => b.setAttribute("aria-pressed", String(b === button)));
+          searchController = new AbortController(); searching = true; lock(true);
+          status("Checking episode numbering…");
+          try {
+            const review = await matchEpisodes(selected);
+            if (!closed) status(`${selected.length} item${selected.length === 1 ? "" : "s"} updated. ${review ? `${review} need episode review.` : "Review your changes below."}`);
+          } catch (error) { if (!closed) status(error.name === "AbortError" ? "Stopped. Your changes are kept; check episode numbers before saving." : `Title updated. Could not check episode numbers: ${error.message}`); }
+          finally { searching = false; if (!closed) lock(false); }
+        };
+        $(".is-map-candidates").append(button);
+      });
+    } catch (error) { status(error.name === "AbortError" ? "Search stopped. Your drafts are kept." : error.message); }
+    finally { searching = false; lock(false); }
+  }
+  dialog.addEventListener("input", event => {
+    const field = event.target, tr = field.closest("[data-draft]");
+    if (!tr || !field.dataset.field) return;
+    const draft = drafts[Number(tr.dataset.draft)], key = field.dataset.field;
+    draft.review = "";
+    if (ID_FIELDS.includes(key)) {
+      const ids = {...(draft.item.show_ids || draft.item.ids || {})};
+      if (field.value.trim()) ids[key] = field.value.trim(); else delete ids[key];
+      draft.item = correctedItem(draft.item, {ids});
+    } else if (key === "title") draft.item = correctedItem(draft.item, {title:field.value});
+    else draft.item[key] = field.value === "" ? null : Number(field.value);
+    changed(draft);
+  });
+  dialog.addEventListener("change", event => {
+    if (event.target.hasAttribute("data-edit")) {
+      drafts[Number(event.target.closest("[data-draft]").dataset.draft)].checked = event.target.checked;
+      selectionChanged();
+    }
+  });
+  dialog.addEventListener("click", event => {
+    const button = event.target.closest("button");
+    if (!button) return;
+    if (button.hasAttribute("data-select-group")) {
+      const indices = groups[Number(button.dataset.selectGroup)];
+      drafts.forEach((d, index) => { d.checked = indices.includes(index); });
+      selectionChanged();
+      $("[data-search-query]").value = seriesTitle(drafts[indices[0]].item);
+      $(".is-map-bulk").scrollIntoView({block:"nearest"});
+      return;
+    }
+    const row = button.closest("[data-draft]");
+    if (!row) return;
+    const draft = drafts[Number(row.dataset.draft)];
+    if (button.hasAttribute("data-edit-row")) {
+      const editor = row.querySelector(".is-map-row-editor");
+      editor.hidden = !editor.hidden;
+      button.setAttribute("aria-expanded", String(!editor.hidden));
+      if (!editor.hidden) editor.querySelector("input").focus();
+    }
+    if (button.hasAttribute("data-reset")) {
+      draft.item = structuredClone(draft.row.item); draft.review = ""; paint(draft);
+      showSearch();
+      row.querySelector("[data-edit-row]").focus();
+    }
+    if (button.hasAttribute("data-find-row")) {
+      drafts.forEach(d => { d.checked = d === draft; });
+      selectionChanged();
+      $("[data-search-query]").value = seriesTitle(draft.item);
+      $(".is-map-bulk").scrollIntoView({block:"nearest"});
+      find(draft.row);
+    }
+  });
+  $("[data-change-match]").onclick = () => { showSearch(); $("[data-search-query]").focus(); };
+  $("[data-stop-search]").onclick = () => searchController?.abort();
+  $("[data-search]").onclick = () => {
+    const selected = drafts.find(d => d.checked);
+    if (!selected) { status("Select an item to find a match for."); return; }
+    find(selected.row);
+  };
+  $("[data-search-query]").onkeydown = event => { if (event.key === "Enter") { event.preventDefault(); $("[data-search]").click(); } };
+  async function matchEpisodes(items) {
+    const episodes = items.filter(d => d.item.type === "episode");
+    const selected = episodes.filter(d => episodeMatching.get(routeKey(d.row)));
+    for (const draft of episodes.filter(d => !selected.includes(d))) {
+      draft.review = "Automatic episode matching is unavailable. Check the season and episode.";
+      draftStatus(draft);
+    }
+    if (!selected.length) return episodes.length;
+    try {
+      const data = await api.episodes(selected.map(d => ({row_id:d.row.id, item:d.item})), {signal:searchController.signal});
+      if (closed) return 0;
+      for (const draft of selected) {
+        const result = data.results.find(result => result.row_id === draft.row.id);
+        if (result?.match) {
+          draft.item = correctedEpisode(draft.item, result.match);
+          draft.review = "";
+          paint(draft);
+          draftStatus(draft, result.reason);
+        } else {
+          draft.review = result?.reason || "No reliable episode match. Check the season and episode.";
+          draftStatus(draft);
+        }
+      }
+      return episodes.filter(d => d.review).length;
+    } catch (error) {
+      for (const draft of selected) {
+        draft.review = "Episode numbering could not be checked. Review it before saving.";
+        draftStatus(draft);
+      }
+      throw error;
+    }
+  }
+  $("[data-suggest]").onclick = async () => {
+    const selected = drafts.filter(d => d.checked);
+    if (!selected.length) { status("Select the items you want to match first."); return; }
+    searchController = new AbortController(); searching = true; lock(true);
+    const matched = [];
+    try {
+      for (const draft of selected) {
+        if (searchController.signal.aborted) break;
+        status(`Finding matches: ${selected.indexOf(draft) + 1} of ${selected.length}…`);
+        const data = await search(draft.row, seriesTitle(draft.item));
+        if (closed) return;
+        const year = ["episode", "season"].includes(draft.item.type) ? draft.item.series_year : draft.item.year;
+        const exact = (data?.results || []).filter(row => row.exact_title && (!year || !row.year || Number(year) === Number(row.year)));
+        if (exact.length === 1 && !exact[0].mapping_unavailable) {
+          draft.review = draft.item.type === "episode" ? "Episode numbering still needs to be checked." : "";
+          draft.item = correctedItem(draft.item, {ids:exact[0].ids, title:exact[0].title});
+          paint(draft); matched.push(draft);
+        } else {
+          draft.review = "Choose a title manually; no single reliable match was found.";
+          draftStatus(draft);
+        }
+      }
+      if (searchController.signal.aborted) {
+        status("Stopped. Your changes are kept; review them before saving.");
+        return;
+      }
+      status("Checking episode numbering…");
+      const episodeReview = await matchEpisodes(matched);
+      if (!closed) {
+        const review = selected.length - matched.length + episodeReview;
+        status(`${selected.length - review} matched${review ? ` · ${review} need review` : ""}. Review your changes below.`);
+        if (review) showSearch();
+        else {
+          $("[data-match]").textContent = `${matched.length} item${matched.length === 1 ? "" : "s"} matched`;
+          $("[data-search-panel]").hidden = true;
+          $("[data-chosen]").hidden = false;
+        }
+      }
+    } catch (error) { if (!closed) status(error.name === "AbortError" ? "Stopped. Your changes are kept; review them before saving." : `Your changes are kept. ${error.message}`); }
+    finally { searching = false; if (!closed) lock(false); }
+  };
+  $("[data-bulk]").onclick = () => {
+    const selected = drafts.filter(d => d.checked && d.item.type === "episode");
+    const season = $("[data-season]"), offset = $("[data-offset]");
+    if (!season.reportValidity() || !offset.reportValidity()) return;
+    const corrected = selected.map(d => correctedItem(d.item, {season:season.value, offset:offset.value}));
+    if (corrected.some(item => !Number.isInteger(item.episode) || item.episode < 1)) {
+      status("This shift would produce an invalid episode number. No items were changed."); return;
+    }
+    selected.forEach((draft,i) => { draft.item = corrected[i]; draft.review = ""; paint(draft); });
+    status(`Episode numbering updated for ${selected.length} items.`);
+    offset.value = "0";
+    $(".is-map-numbering").open = false;
+  };
+  for (const [selector, checked] of [["[data-check-all]",true],["[data-check-none]",false]]) $(selector).onclick = () => {
+    drafts.forEach(d => { d.checked = checked; });
+    selectionChanged();
+  };
+  function close() {
+    if (saving || searching) return;
+    if (drafts.some(d => d.dirty) && !window.confirm("Discard unsaved mapping corrections?")) return;
+    dismiss();
+  }
+  function dismiss() {
+    if (closed) return;
+    closed = true; dialog.close(); dialog.remove(); onClose();
+  }
+  const warnUnsaved = event => { if (drafts.some(d => d.dirty) && !closed) { event.preventDefault(); event.returnValue = ""; } };
+  window.addEventListener("beforeunload", warnUnsaved);
+  dialog.addEventListener("close", () => window.removeEventListener("beforeunload", warnUnsaved));
+  dialog.addEventListener("cancel", event => { event.preventDefault(); close(); });
+  $("[data-close]").onclick = close;
+  $("[data-save]").onclick = async () => {
+    for (const draft of drafts.filter(d => d.dirty)) {
+      const row = $(`[data-draft="${drafts.indexOf(draft)}"]`);
+      const invalid = Array.from(row.querySelectorAll("[data-field]")).find(el => !el.checkValidity());
+      if (!invalid) continue;
+      const group = row.closest(".is-map-group");
+      if (group) group.open = true;
+      row.querySelector(".is-map-row-editor").hidden = false;
+      row.querySelector("[data-edit-row]").setAttribute("aria-expanded", "true");
+      if (invalid.closest("details")) invalid.closest("details").open = true;
+      invalid.reportValidity();
+      return;
+    }
+    const edits = drafts.filter(d => d.dirty).map(d => ({row_id:d.row.id, item:d.item, selected:true}));
+    if (!edits.length) return;
+    saving = true; lock(true); $("[data-error]").textContent = "";
+    try {
+      const data = await api.save(edits);
+      closed = true; dialog.close(); dialog.remove(); onSaved(data);
+    } catch (error) { $("[data-error]").textContent = error.message; }
+    finally { saving = false; if (!closed) lock(false); }
+  };
+  return {close, destroy() { searchController?.abort(); dismiss(); }};
+}

--- a/assets/js/interactive-sync.js
+++ b/assets/js/interactive-sync.js
@@ -5,9 +5,9 @@
   const API = "/api/interactive-sync";
   const host = document.getElementById("page-interactive_sync");
   const esc = value => String(value ?? "").replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]);
-  const labels = { add: "Add", remove: "Remove", update: "Update", unresolved: "Needs mapping", blocked: "Blocked", conflict: "Conflict" };
+  const labels = { add: "Add", remove: "Remove", update: "Update", unresolved: "Needs attention", blocked: "Blocked", conflict: "Conflict" };
   let session = null, busy = false, timer = null, page = 0, route = "", generation = 0;
-  let feature = "", result = "", query = "", mappingDirty = false;
+  let feature = "", result = "", query = "", mappingDirty = false, mappingWorkspace = null;
   let pageData = { items: [], total: 0 }, pageLoading = false, pageRequest = 0, pageController = null, searchTimer = null;
   let progressTimer = null, progressReceived = Date.now(), pollFailures = 0;
   const PAGE_SIZE = 75;
@@ -62,7 +62,7 @@
       <div class="is-progress-caption"><strong>${determinate ? `${number(p.done)} of ${number(p.total)} ${esc(p.unit)}` : p.done ? `${number(p.done)} ${esc(p.unit)}` : ["reading", "verifying"].includes(p.stage) ? "Waiting for provider totals" : "Working on this stage"}</strong><span>${determinate ? `${p.percent}%` : "In progress"}</span></div>
       <div class="is-progress-track ${determinate ? "" : "indeterminate"}" role="progressbar" aria-label="${esc(p.label || "Current sync activity")}" aria-valuemin="0" aria-valuemax="100" ${determinate ? `aria-valuenow="${p.percent}"` : 'aria-valuetext="In progress; total not yet available"'}><span style="width:${determinate ? p.percent : 30}%"></span></div>
       <div class="is-progress-stats"><div><span>Elapsed</span><strong data-progress-elapsed>${duration(p.elapsed_seconds)}</strong></div><div><span>Current activity</span><strong data-progress-stage>${duration(p.stage_seconds)}</strong></div><div><span>Items read</span><strong>${number(p.items_read)}</strong></div><div><span>API requests</span><strong>${number(p.requests)}</strong></div></div>
-      <div class="is-progress-note"><span class="material-symbols-rounded" aria-hidden="true">info</span><p><span data-progress-quiet>Waiting for the next provider update.</span><br>You can leave this page and return. This operation continues on the server.</p></div>
+      <div class="is-progress-note"><span class="material-symbols-rounded" aria-hidden="true">info</span><p><span data-progress-quiet>Waiting for the next provider update.</span><br>This operation continues on the server. Return using the notification bell or Sync reviews below your pairs in Synchronization settings.</p></div>
       ${(p.recent || []).length ? `<details class="is-progress-details" ${detailsOpen ? "open" : ""}><summary>Recent activity</summary><ol>${p.recent.slice().reverse().map(row => `<li><time>${esc(new Date(row.at * 1000).toLocaleTimeString())}</time><span>${esc(row.text)}</span></li>`).join("")}</ol></details>` : ""}
     </section>`;
   }
@@ -186,6 +186,7 @@
       ${changes ? `<div class="is-report-distribution" role="img" aria-label="${number(totals.added)} added, ${number(totals.updated)} updated, ${number(totals.removed)} removed">${["added", "updated", "removed"].map(key => `<span class="${key}" style="width:${totals[key] / changes * 100}%"></span>`).join("")}</div><div class="is-report-legend">${columns.slice(0, 3).map(([key, label]) => `<span><i class="${key}"></i>${label}</span>`).join("")}</div>` : ""}
       <dl class="is-report-facts"><div><dt>Selected for this run</dt><dd>${number(report.requested)} of ${number(report.proposed)} proposals</dd></div><div><dt>Not selected</dt><dd>${number(report.not_selected)}</dd></div><div><dt>Started</dt><dd>${date(report.started_at)}</dd></div><div><dt>Finished</dt><dd>${date(report.finished_at)}</dd></div><div><dt>API requests</dt><dd>${number(report.requests)}</dd></div><div><dt>Conflict decisions</dt><dd>${number(report.conflicts_reviewed)}</dd></div></dl>
       <section class="is-report-section"><h2>Results by feature and destination</h2><p>Counts reported by the sync engine for this operation.</p><div class="is-table-wrap"><table class="is-table is-report-table"><thead><tr><th scope="col">Feature / destination</th>${columns.map(([, label]) => `<th scope="col">${label}</th>`).join("")}</tr></thead><tbody>${report.features.map(row => `<tr class="is-report-feature"><th scope="row">${esc(row.feature.charAt(0).toUpperCase() + row.feature.slice(1))}</th>${cells(row)}</tr>${row.destinations.map(dst => `<tr><th scope="row" class="is-report-destination">${esc(endpoint(dst.provider, dst.instance))}</th>${cells(dst)}</tr>`).join("")}`).join("") || `<tr><td colspan="8">No completed feature results were reported.</td></tr>`}</tbody></table></div></section>
+      ${report.manual_excluded ? `<section class="is-report-section" aria-label="Mapping and manual exclusions"><h2>Mapping and manual exclusions</h2><p>${number(report.manual_excluded)} items were excluded by saved mappings or Editor rules. Old identities stay excluded so their corrected replacements can sync. These exclusions are not failed sync attempts.</p><dl class="is-report-facts">${report.features.filter(row => row.manual_excluded).map(row => `<div><dt>${esc(row.feature.charAt(0).toUpperCase() + row.feature.slice(1))}</dt><dd>${number(row.manual_excluded)} excluded</dd></div>`).join("")}</dl></section>` : ""}
       <section class="is-report-section is-report-attention"><h2>Attention and follow-up</h2><div class="is-report-checks">${[["Unresolved items", totals.unresolved], ["Provider errors", totals.errors], ["Blocked by sync rules", totals.blocked], ["Selected proposals not reached", report.not_reached]].map(([label, n]) => `<div class="${n ? "needs-attention" : ""}"><span>${label}</span><strong>${number(n)}</strong></div>`).join("")}</div>${report.not_reached ? `<p>These selected proposals did not reach execution. Data may have changed, a protection may have stopped them, or the run may have ended early.</p>` : ""}${report.incomplete_note ? `<p class="is-report-warning">${esc(report.incomplete_note)}</p>` : ""}${report.outcome !== "success" ? `<p>${report.issue_count ? "Review the affected items below." : "The engine did not include item-level details. Check Events for the available diagnostics."} Start a new review to see what still needs syncing before retrying.</p>` : ""}</section>
       ${(report.notices || []).length ? `<details class="is-notices" open><summary>Execution notices (${number(report.notices.length)})</summary>${report.notices.map(n => `<p><strong>${esc([n.feature, n.provider].filter(Boolean).join(" · "))}</strong> ${esc(n.reason)}${n.occurrences > 1 ? ` (${number(n.occurrences)} occurrences)` : ""}</p>`).join("")}${report.notice_overflow ? `<p>Additional notices are available in Events.</p>` : ""}</details>` : ""}
       ${(report.review_notices || []).length ? `<details class="is-notices"><summary>Protections and notices from the preview (${number(report.review_notices.length)})</summary>${report.review_notices.map(n => `<p>${esc(n.feature)} ${esc(n.provider)} · ${esc(n.reason)}</p>`).join("")}</details>` : ""}
@@ -216,7 +217,7 @@
       ${done ? `<div class="is-metrics">${[["Added", summary.added], ["Updated", summary.updated], ["Removed", summary.removed], ["Unresolved", summary.unresolved], ["Errors", summary.errors], ["Changed since review", summary.not_applied]].map(([label, n]) => `<div><strong>${Number(n || 0)}</strong><span>${label}</span></div>`).join("")}</div>` : `<div class="is-metrics"><div><strong>${count}</strong><span>Proposed changes</span></div><div><strong>${selectedCount}</strong><span>Selected</span></div><div><strong>${session?.counts?.conflicts || 0}</strong><span>Conflicts to review</span></div><div><strong>${session?.counts?.attention || 0}</strong><span>Need attention</span></div></div>`}
       ${(session?.notices || []).length ? `<details class="is-notices"><summary>Sync protections and provider notices (${session.notices.length})</summary>${session.notices.map(n => `<p>${esc(n.feature)} ${esc(n.provider)} · ${esc(n.reason.replaceAll("_", " ").replaceAll(":", ": "))}</p>`).join("")}</details>` : ""}
       <div class="is-toolbar"><label class="is-search"><span class="material-symbols-rounded" aria-hidden="true">search</span><input data-filter="query" type="search" maxlength="256" placeholder="Search titles or IDs" aria-label="Search proposed changes" value="${esc(query)}"></label><label>Feature<select data-filter="feature"><option value="">All features</option>${(session?.features || []).map(f => `<option value="${esc(f)}" ${feature === f ? "selected" : ""}>${esc(f.charAt(0).toUpperCase() + f.slice(1))}</option>`).join("")}</select></label><label>Result<select data-filter="result"><option value="">All results</option>${Object.entries(labels).map(([k, v]) => `<option value="${k}" ${result === k ? "selected" : ""}>${v}</option>`).join("")}</select></label></div>
-      <div class="is-list-actions"><span>${pageLoading ? "Loading page..." : `${pageData.total} matching items`}</span><button class="is-link" data-action="select" ${locked ? "disabled" : ""}>Select filtered</button><button class="is-link" data-action="deselect" ${locked ? "disabled" : ""}>Deselect filtered</button></div>
+      <div class="is-list-actions"><span>${pageLoading ? "Loading page..." : `${pageData.total} matching items`}</span><button class="is-btn is-small" data-action="map-selected" ${locked || !selectedCount ? "disabled" : ""} title="Edit checked items across all pages">Edit selected</button><button class="is-link" data-action="select" ${locked ? "disabled" : ""}>Select filtered</button><button class="is-link" data-action="deselect" ${locked ? "disabled" : ""}>Deselect filtered</button></div>
       <div class="is-table-wrap" aria-busy="${pageLoading}"><table class="is-table"><thead><tr><th scope="col"><span class="sr-only">Selected</span></th><th scope="col">Item</th><th scope="col">Feature</th><th scope="col">Proposed change</th><th scope="col">Review</th></tr></thead><tbody>${rows.map(row => {
         if (row.result === "conflict") return `<tr class="is-conflict"><td><span class="material-symbols-rounded" aria-hidden="true">compare_arrows</span></td><td><strong>${esc(title(row.left))}</strong><small>${esc(row.key)}</small></td><td>${esc(row.feature)}</td><td><span class="is-badge conflict">Conflict</span><small>${esc(row.source)}: ${esc(value(row.left, row.feature))} · ${esc(row.target)}: ${esc(value(row.right, row.feature))}</small></td><td><label class="is-sr-label" for="choice-${row.id}">Use value from</label><select id="choice-${row.id}" data-choice="${row.id}" ${locked ? "disabled" : ""}>${[row.source, row.target].map(p => `<option value="${esc(p)}" ${p === row.winner ? "selected" : ""}>Use ${esc(p)}</option>`).join("")}</select></td></tr>`;
         return `<tr><td><input type="checkbox" data-select="${row.id}" aria-label="Select ${esc(title(row.item))}" ${row.selected ? "checked" : ""} ${locked || !row.selectable ? "disabled" : ""}></td><td><strong>${esc(title(row.item))}</strong><small>${esc(row.item.type || "")} ${esc(row.item.year || "")} · ${esc(row.key)}</small>${row.reason ? `<small class="is-reason">${esc(row.reason)}</small>` : ""}</td><td>${esc(row.feature)}</td><td><span class="is-badge ${esc(row.result)}">${labels[row.result] || esc(row.result)}</span><span class="is-destination">${esc(endpoint(row.provider, row.instance))}</span>${row.destination_label ? `<small>${esc(row.destination_label)}</small>` : ""}<small>${esc(value(row.before, row.feature))} → ${row.operation === "remove" ? "Removed" : esc(value(row.item, row.feature))}</small></td><td>${["add", "update"].includes(row.operation) && row.feature !== "playlists" ? `<button class="is-btn is-small" data-map="${row.id}" ${locked ? "disabled" : ""}>Mapping</button>` : "—"}</td></tr>`;
@@ -224,7 +225,6 @@
       <div class="is-pagination"><button class="is-btn is-small" data-action="first" ${pageLoading || page === 0 ? "disabled" : ""}>First</button><button class="is-btn is-small" data-action="prev" ${pageLoading || page === 0 ? "disabled" : ""}>Previous</button><label>Page <input data-page type="number" min="1" max="${pages}" value="${page + 1}" aria-label="Page number" ${pageLoading ? "disabled" : ""}> of ${pages}</label><button class="is-btn is-small" data-action="next" ${pageLoading || page + 1 >= pages ? "disabled" : ""}>Next</button><button class="is-btn is-small" data-action="last" ${pageLoading || page + 1 >= pages ? "disabled" : ""}>Last</button></div>
       <footer class="is-footer"><div><strong>${done ? "Operation finished" : `${selectedCount} changes selected`}</strong><small>${done ? "Provider results are also available in Events." : "Mappings are saved permanently. Only selected sync changes will be applied."}</small></div>${done ? `<a class="is-btn is-primary" href="#settings/sync">Back to Synchronization</a>` : `<button class="is-btn is-primary" data-action="apply" ${locked || !selectedCount ? "disabled" : ""}><span class="material-symbols-rounded" aria-hidden="true">check</span>Apply selected (${selectedCount})</button>`}</footer>
       </div>`}
-      <div class="is-mapping-host"></div>
     </div>`;
     if (focused) {
       const input = host.querySelector('[data-filter="query"]');
@@ -259,39 +259,21 @@
     }
   }
   async function mapping(row) {
-    const root = host.querySelector(".is-mapping-host");
-    root.innerHTML = `<section class="is-mapping" aria-label="Resolve mapping"><div class="is-mapping-head"><div><h2>Resolve mapping</h2><p>${esc(title(row.item))}</p></div><button class="is-btn" data-close-map>Close</button></div><p>Save a persistent correction using the same overrides as Editor. The plan will be recalculated.</p><div class="is-map-tools"><button class="is-btn" data-search-map>Search metadata</button>${document.documentElement.dataset.cwRole !== "user" ? `<button class="is-btn" data-anime-map>Anime ID mappings</button>` : ""}</div><form class="is-map-form"><div class="is-map-fields">${["imdb", "tmdb", "tvdb", "trakt", "simkl", "anilist", "mal", "anidb"].map(k => `<label>${esc(k.toUpperCase())}<input name="${k}" value="${esc(row.item.ids?.[k] || "")}" autocomplete="off"></label>`).join("")}</div><button type="submit" class="is-btn is-primary">Save mapping and recalculate</button></form><div class="is-map-search"></div></section>`;
-    root.scrollIntoView({ behavior: "smooth", block: "center" });
-    root.querySelector("input")?.focus();
-    root.querySelector("[data-close-map]").onclick = () => { root.innerHTML = ""; };
-    root.querySelector("form").onsubmit = event => {
-      event.preventDefault();
-      const ids = { ...row.item.ids };
-      for (const [k, v] of new FormData(event.target)) { if (String(v).trim()) ids[k] = String(v).trim(); else delete ids[k]; }
-      action("mapping", { row_id: row.id, item: { ...row.item, ids } });
-    };
-    root.querySelector("[data-anime-map]")?.addEventListener("click", async () => {
-      if (!window.openAnimeOverridesModal) await import(`/assets/js/modals.js?v=${encodeURIComponent(window.APP_VERSION || "1")}`);
-      window.openAnimeOverridesModal?.();
-    });
-    root.querySelector("[data-search-map]").onclick = async event => {
-      try {
-        for (const name of ["datetime", "search", "row-editor", "metadata-replacer"]) await import(`/assets/js/editor/${name}.js?v=${encodeURIComponent(window.APP_VERSION || "1")}`);
-        const editorRow = { key: row.key, type: row.item.type, title: title(row.item), year: row.item.year, raw: structuredClone(row.item) };
-        const searchRoot = root.querySelector(".is-map-search");
-        window.CW.Editor.MetadataReplacer.openItemReplacer(editorRow, event.target, {
-          isPolicySource: () => true,
-          fetchJSON: json,
-          formatEpisodeVisualTitle: r => title(r.raw),
-          updateTypeDisplay: window.CW.Editor.RowEditor.updateTypeDisplay,
-          openPopup: (_, build) => { searchRoot.innerHTML = ""; build(searchRoot, () => { searchRoot.innerHTML = ""; }); },
-          appendPopupTitle: (el, text) => { const h = document.createElement("h3"); h.textContent = text; el.append(h); },
-          appendPopupActions: (el, buttons) => buttons.forEach(b => { const btn = document.createElement("button"); btn.type = "button"; btn.className = "is-btn"; btn.textContent = b.label; btn.onclick = b.onClick; el.append(btn); }),
-          setStatusSticky: text => showError(new Error(text)),
-          commitReplacement: (_, corrected) => { action("mapping", { row_id: row.id, item: corrected }); return ""; },
-        });
-      } catch (error) { showError(error); }
-    };
+    if (mappingWorkspace || pending() || pageLoading) return;
+    const sid = session.id, revision = session.revision, selectionVersion = session.selection_version;
+    mappingWorkspace = {};
+    try {
+      const {openMappingWorkspace} = await import(`/assets/js/interactive-sync-mapping.js?v=${encodeURIComponent(window.APP_VERSION || "1")}`);
+      const data = row ? {items:[row], total:1} : await json(`${API}/${sid}/rows?${new URLSearchParams({revision, limit:200, selected_only:true, editable_only:true})}`);
+      if (sid !== session?.id || revision !== session.revision) throw new Error("The plan changed. Open mapping again.");
+      if (!row && (data.selection_version !== selectionVersion || session.selection_version !== selectionVersion)) throw new Error("Your selection changed. Open mapping again.");
+      const editable = data.items.filter(item => ["add", "update"].includes(item.operation) && item.feature !== "playlists");
+      if (!editable.length) throw new Error("Check items to edit first. Removed items and playlists cannot be mapped.");
+      mappingWorkspace = openMappingWorkspace({rows:editable, total:data.total, session:{...session}, json, post,
+        onClose: () => { mappingWorkspace = null; },
+        onSaved: data => { mappingWorkspace = null; if (session?.id === sid) accept(data, true); },
+      });
+    } catch (error) { mappingWorkspace = null; showError(error); }
   }
   host?.addEventListener("change", event => {
     const el = event.target;
@@ -320,6 +302,7 @@
     if (!button || button.disabled) return;
     if (button.dataset.map) return mapping(pageData.items.find(row => row.id === button.dataset.map));
     const name = button.dataset.action;
+    if (name === "map-selected") return mapping();
     if (name === "download-report" && session.report) {
       const report = session.report, sid = session.id, issues = [];
       button.disabled = true;

--- a/assets/js/schedulerbanner.js
+++ b/assets/js/schedulerbanner.js
@@ -28,10 +28,10 @@
         urls=[url,wh.base_url,wh.healthchecks_base_url,wh.start_url,wh.success_url,wh.failure_url].map(v=>String(v||"").trim()).filter(Boolean);
       return {active:label==="Notifiarr Passthrough"?!!url:urls.length>0,label};
     },
-    chipText={pairs:"Sync pairs",sched:"Scheduler",watch:"Watcher",hook:"Webhook",health:"CrossWatch health",update:"Updates"},
-    chipIcon={pairs:"sync_alt",sched:"calendar_month",watch:"visibility",hook:"webhook",health:"arrow_upward",update:"notifications"},
-    chipNav={pairs:{target:"pairs",label:"Open sync pair settings"},sched:{target:"scheduling",label:"Open scheduler settings"},watch:{target:"watcher",label:"Open watcher settings"},hook:{target:"webhook",label:"Open webhook settings"},health:{target:"maintenance",label:"Open Maintenance tools"},update:{target:"refresh-update",label:"Re-check for updates"}},
-    S={cfg:null,pairs:{total:0,active:0},sched:{enabled:false,running:false,next:0,advanced:false,captures:0,webhooks:false,webhookLabel:"",warning:false,warnings:[]},evt:{enabled:false,count:0},watch:{...blank(),alive:false},hook:blank(),system:{health:{known:false,ok:false,status:"checking"},update:{known:false,available:false,current:"",latest:"",url:""}},timers:{sched:null,scrob:null,health:null,wait:null,rotate:null},debounce:null,last:{watcher:"",webhook:""}};
+    chipText={pairs:"Sync pairs",sched:"Scheduler",watch:"Watcher",hook:"Webhook",health:"CrossWatch health"},
+    chipIcon={pairs:"sync_alt",sched:"calendar_month",watch:"visibility",hook:"webhook",health:"arrow_upward"},
+    chipNav={pairs:{target:"pairs",label:"Open sync pair settings"},sched:{target:"scheduling",label:"Open scheduler settings"},watch:{target:"watcher",label:"Open watcher settings"},hook:{target:"webhook",label:"Open webhook settings"},health:{target:"maintenance",label:"Open Maintenance tools"}},
+    S={cfg:null,pairs:{total:0,active:0},sched:{enabled:false,running:false,next:0,advanced:false,captures:0,webhooks:false,webhookLabel:"",warning:false,warnings:[]},evt:{enabled:false,count:0},watch:{...blank(),alive:false},hook:blank(),system:{health:{known:false,ok:false,status:"checking"}},timers:{sched:null,scrob:null,health:null,wait:null,rotate:null},debounce:null,last:{watcher:"",webhook:""}};
   const SHARED_WATCH_KEY="__CW_CURRENT_WATCHING_SHARED__",SHARED_WATCH_TTL_MS=3000,WATCHER_UNAVAILABLE_GRACE_MS=35000;
   let scrobPollSeq=0;
   const isManaged=()=>document.documentElement?.dataset?.cwRole==="user";
@@ -41,7 +41,7 @@
     st.id="sched-banner-css";
     st.textContent=`#ops-card .action-row{display:flex;align-items:center;justify-content:flex-start;gap:12px;flex-wrap:nowrap}#ops-card .action-buttons{display:flex;gap:10px;flex:0 0 auto;min-width:0;align-items:center;flex-wrap:nowrap;order:1}#ops-card .cw-status-dock{display:flex;flex:1 1 auto;width:auto;min-width:0;justify-content:flex-end;align-items:center;margin-left:auto;order:2}#ops-card .cw-status-dock:not(:has(.sched)){display:none}#sched-inline-log{position:static;z-index:2;pointer-events:none;display:flex;gap:10px;align-items:center;justify-content:flex-end;flex-wrap:wrap;max-width:100%;width:100%}#sched-inline-log .sched,#sched-inline-log .sched *,#sched-inline-log .sched *::before,#sched-inline-log .sched *::after{box-sizing:border-box}#sched-inline-log .sched{--chip-accent:#ef4444;position:relative;display:inline-flex;align-items:center;gap:10px;min-height:34px;max-width:min(420px,100%);padding:5px 12px;border-radius:999px;background:linear-gradient(180deg,rgba(17,21,29,.96),rgba(10,13,20,.98));backdrop-filter:blur(6px);border:1px solid rgba(255,255,255,.08);box-shadow:inset 0 1px 0 rgba(255,255,255,.03),0 8px 18px rgba(0,0,0,.24);overflow:hidden;pointer-events:auto;white-space:nowrap}#sched-inline-log .sched.ok,#sched-inline-log .sched.live{--chip-accent:#22c55e}#sched-inline-log .sched.idle{--chip-accent:#ef4444;background:linear-gradient(180deg,rgba(17,21,29,.94),rgba(10,13,20,.96));border-color:rgba(255,255,255,.07)}#sched-inline-log .sched.warn{--chip-accent:#ef4444;background:linear-gradient(180deg,rgba(30,16,18,.96),rgba(18,10,12,.98));border-color:rgba(211,106,106,.18)}#sched-inline-log .ic{position:relative;display:inline-flex!important;align-items:center!important;justify-content:center!important;align-self:center!important;flex:0 0 auto;z-index:1}#sched-inline-log .ic.dot{width:10px;height:10px;border-radius:50%;background:var(--chip-accent);box-shadow:0 0 0 1px rgba(0,0,0,.48),0 0 10px color-mix(in srgb,var(--chip-accent) 40%,transparent)}#sched-inline-log .sched.live .ic.dot::after{content:"";position:absolute;inset:-4px;border-radius:50%;border:1px solid color-mix(in srgb,var(--chip-accent) 42%,transparent);opacity:.7;animation:ringPulse 1.7s ease-out infinite}#sched-inline-log .copy{position:relative;z-index:1;display:inline-flex!important;align-items:center!important;align-self:center!important;gap:7px;min-width:0;max-width:100%;height:20px;line-height:20px;overflow:hidden}#sched-inline-log .label{display:inline-flex!important;align-items:center!important;align-self:center!important;vertical-align:middle!important;height:20px;line-height:20px;margin:0!important;padding:0!important;position:relative;top:0!important;bottom:auto!important;transform:none!important;font-size:10px;font-weight:800;letter-spacing:.14em;text-transform:uppercase;color:rgba(181,190,208,.76);flex:0 0 auto}#sched-inline-log .value,#sched-inline-log .meta,#sched-inline-log .badges{position:relative;top:-1.5px!important}#sched-inline-log .value,#sched-inline-log .meta{display:inline-flex!important;align-items:center!important;align-self:center!important;vertical-align:middle!important;height:20px;line-height:20px;margin:0!important;padding:0!important;bottom:auto!important;transform:none!important}#sched-inline-log .value{font-size:12px;font-weight:800;letter-spacing:.02em;color:#eef3ff;flex:0 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis}#sched-inline-log .meta{min-width:0;overflow:hidden;text-overflow:ellipsis;font-size:12px;font-weight:700;color:rgba(188,197,214,.68)}#sched-inline-log .badges{display:inline-flex!important;align-items:center!important;align-self:center!important;gap:6px;flex:0 0 auto;height:20px}#sched-inline-log .badge{display:inline-flex;align-items:center;justify-content:center;min-width:24px;height:18px;padding:0 6px;border-radius:999px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.05);color:rgba(232,238,250,.82);font-size:10px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;line-height:18px}#sched-inline-log .sched[data-tip]{cursor:help;transition:transform .16s ease,box-shadow .16s ease,border-color .16s ease,background .16s ease}#sched-inline-log .sched[data-tip]:hover{transform:translateY(-1px);border-color:rgba(255,255,255,.12);background:linear-gradient(180deg,rgba(20,24,32,.98),rgba(12,15,22,.99));box-shadow:inset 0 1px 0 rgba(255,255,255,.04),0 10px 22px rgba(0,0,0,.28)}#sched-inline-log .sched.warn[data-tip]:hover{background:linear-gradient(180deg,rgba(34,18,21,.98),rgba(22,11,14,.99))}#sched-inline-log .sched[data-tip]::after{content:attr(data-tip);position:absolute;left:50%;bottom:calc(100% + 8px);transform:translateX(-50%) translateY(4px);opacity:0;pointer-events:none;min-width:180px;max-width:min(320px,72vw);padding:8px 10px;border-radius:12px;background:rgba(10,13,20,.98);border:1px solid rgba(255,255,255,.08);box-shadow:0 10px 30px rgba(0,0,0,.34);color:#edf4ff;font-size:11px;font-weight:700;line-height:1.35;white-space:pre-line;text-align:left;transition:opacity .16s ease,transform .16s ease}#sched-inline-log .sched[data-tip]:hover::after{opacity:1;transform:translateX(-50%) translateY(0)}@keyframes ringPulse{0%{transform:scale(.72);opacity:.8}80%{transform:scale(1.28);opacity:0}100%{transform:scale(1.28);opacity:0}}@media (max-width:640px){#ops-card .action-row{flex-wrap:wrap}#ops-card .action-buttons{width:100%;flex-wrap:wrap}#ops-card .cw-status-dock{width:100%;margin-left:0}#sched-inline-log{gap:8px}#sched-inline-log .sched{min-height:32px;padding:4px 10px;max-width:100%}#sched-inline-log .copy{gap:6px;height:18px;line-height:18px}#sched-inline-log .label,#sched-inline-log .value,#sched-inline-log .meta{height:18px;line-height:18px}#sched-inline-log .label{font-size:9px}#sched-inline-log .value,#sched-inline-log .meta{font-size:11px}#sched-inline-log .value,#sched-inline-log .meta,#sched-inline-log .badges{top:-1px!important}#sched-inline-log .badges{height:18px}#sched-inline-log .badge{height:17px;min-width:22px;padding:0 5px;font-size:9px;line-height:17px}}`;
     st.textContent+=`
-#ops-card{--hub-service-good:#57b58a;--hub-service-bad:#e06470;--hub-service-disabled:#788291;--hub-service-update:#8b5cf6;--hub-action-bg:rgba(255,255,255,.035);--hub-action-hover:rgba(255,255,255,.065);--hub-card-bg:linear-gradient(180deg,rgba(20,24,34,.96),rgba(12,15,23,.98));--hub-card-border:rgba(255,255,255,.09);--hub-text:#eef3ff;--hub-muted:rgba(188,198,217,.68);}
+#ops-card{--hub-service-good:#57b58a;--hub-service-bad:#e06470;--hub-service-disabled:#788291;--hub-action-bg:rgba(255,255,255,.035);--hub-action-hover:rgba(255,255,255,.065);--hub-card-bg:linear-gradient(180deg,rgba(20,24,34,.96),rgba(12,15,23,.98));--hub-card-border:rgba(255,255,255,.09);--hub-text:#eef3ff;--hub-muted:rgba(188,198,217,.68);}
 #ops-card .action-row{display:flex!important;align-items:center!important;justify-content:flex-start!important;flex-wrap:nowrap!important;gap:14px!important;margin-top:14px!important;padding:14px!important;}
 #ops-card .action-buttons{display:flex!important;flex:0 0 auto!important;min-width:0!important;width:auto!important;align-items:center!important;justify-content:flex-start!important;gap:10px!important;order:1!important;flex-wrap:nowrap!important;}
 #ops-card .action-buttons .cw-hub-action{display:inline-flex!important;align-items:center!important;justify-content:center!important;gap:9px!important;flex:0 0 auto!important;min-width:132px!important;min-height:46px!important;height:46px!important;padding:0 16px!important;border-radius:14px!important;background:var(--hub-action-bg)!important;border:1px solid var(--hub-card-border)!important;color:var(--hub-text)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.035)!important;white-space:nowrap!important;line-height:1!important;}
@@ -118,18 +118,10 @@
 #ops-card #sched-inline-log :is(#chip-watch,#chip-hook)[data-tip]:hover>.cw-hub-tip,#ops-card #sched-inline-log :is(#chip-watch,#chip-hook)[data-tip]:focus-visible>.cw-hub-tip{transform:translateX(0) translateY(0);}
 #ops-card #sched-inline-log .hub-group-system .sched:last-child .cw-hub-tip{left:auto;right:0;transform:translateX(0) translateY(4px);}
 #ops-card #sched-inline-log .hub-group-system .sched:last-child[data-tip]:hover>.cw-hub-tip,#ops-card #sched-inline-log .hub-group-system .sched:last-child[data-tip]:focus-visible>.cw-hub-tip{transform:translateX(0) translateY(0);}
-html[data-cw-theme="flat-dark"] #ops-card{--hub-service-good:#57b58a;--hub-service-bad:#d86672;--hub-service-disabled:#7c8491;--hub-service-update:#a78bfa;--hub-action-bg:#20242d;--hub-action-hover:#272c36;--hub-card-bg:#20242d;--hub-card-border:rgba(255,255,255,.13);--hub-text:#eef1f6;--hub-muted:#a9b0bd;}
-html[data-cw-theme="flat-light"] #ops-card{--hub-service-good:#276348;--hub-service-bad:#a93f4d;--hub-service-disabled:#98a2b3;--hub-service-update:#6d3fd1;--hub-action-bg:#fff;--hub-action-hover:#eef2f7;--hub-card-bg:#fff;--hub-card-border:rgba(16,24,40,.16);--hub-text:#172033;--hub-muted:#667085;}
-html.cw-theme-original #ops-card{--hub-service-good:#57b58a;--hub-service-bad:#e06470;--hub-service-disabled:#77808f;--hub-service-update:#8b5cf6;--hub-action-bg:rgba(255,255,255,.035);--hub-action-hover:rgba(255,255,255,.065);--hub-card-bg:linear-gradient(180deg,rgba(20,24,34,.96),rgba(12,15,23,.98));--hub-card-border:rgba(255,255,255,.09);--hub-text:#eef3ff;--hub-muted:rgba(188,198,217,.68);}
-#ops-card #sched-inline-log #chip-update.update-available{--service-state:var(--hub-service-update,#8b5cf6)!important;}
-#ops-card #sched-inline-log #chip-update.update-available .service-icon{opacity:1!important;color:var(--service-state)!important;font-variation-settings:"FILL" 1,"wght" 500,"GRAD" 0,"opsz" 24!important;transform-origin:50% 5px;animation:cwHubBellRing 3.6s ease-in-out infinite;}
-#ops-card #sched-inline-log #chip-update.update-available::before{opacity:1!important;box-shadow:0 0 10px color-mix(in srgb,var(--service-state) 55%,transparent)!important;animation:cwHubBellBar 3.6s ease-in-out infinite;}
-#ops-card #sched-inline-log #chip-update.update-available::after{content:""!important;display:block!important;position:absolute!important;z-index:3!important;top:5px!important;right:9px!important;left:auto!important;bottom:auto!important;width:7px!important;height:7px!important;min-width:0!important;max-width:none!important;margin:0!important;padding:0!important;border:2px solid var(--hub-action-bg)!important;border-radius:50%!important;background:var(--service-state)!important;opacity:1!important;transform:none!important;pointer-events:none!important;animation:cwHubBellDot 2.4s ease-out infinite;}
-@keyframes cwHubBellRing{0%,60%,100%{transform:rotate(0)}64%{transform:rotate(14deg)}68%{transform:rotate(-12deg)}72%{transform:rotate(9deg)}76%{transform:rotate(-7deg)}80%{transform:rotate(4deg)}84%{transform:rotate(-2deg)}88%{transform:rotate(0)}}
-@keyframes cwHubBellBar{0%,60%,100%{opacity:1}70%{opacity:.45}80%{opacity:1}}
-@keyframes cwHubBellDot{0%{box-shadow:0 0 0 0 color-mix(in srgb,var(--service-state) 60%,transparent)}70%{box-shadow:0 0 0 7px color-mix(in srgb,var(--service-state) 0%,transparent)}100%{box-shadow:0 0 0 0 color-mix(in srgb,var(--service-state) 0%,transparent)}}
+html[data-cw-theme="flat-dark"] #ops-card{--hub-service-good:#57b58a;--hub-service-bad:#d86672;--hub-service-disabled:#7c8491;--hub-action-bg:#20242d;--hub-action-hover:#272c36;--hub-card-bg:#20242d;--hub-card-border:rgba(255,255,255,.13);--hub-text:#eef1f6;--hub-muted:#a9b0bd;}
+html[data-cw-theme="flat-light"] #ops-card{--hub-service-good:#276348;--hub-service-bad:#a93f4d;--hub-service-disabled:#98a2b3;--hub-action-bg:#fff;--hub-action-hover:#eef2f7;--hub-card-bg:#fff;--hub-card-border:rgba(16,24,40,.16);--hub-text:#172033;--hub-muted:#667085;}
+html.cw-theme-original #ops-card{--hub-service-good:#57b58a;--hub-service-bad:#e06470;--hub-service-disabled:#77808f;--hub-action-bg:rgba(255,255,255,.035);--hub-action-hover:rgba(255,255,255,.065);--hub-card-bg:linear-gradient(180deg,rgba(20,24,34,.96),rgba(12,15,23,.98));--hub-card-border:rgba(255,255,255,.09);--hub-text:#eef3ff;--hub-muted:rgba(188,198,217,.68);}
 @keyframes cwHubSyncSpin{to{transform:rotate(360deg)}}
-@media(prefers-reduced-motion:reduce){#ops-card #sched-inline-log #chip-update.update-available .service-icon,#ops-card #sched-inline-log #chip-update.update-available::before,#ops-card #sched-inline-log #chip-update.update-available::after{animation:none!important;}}
 @media(max-width:760px){#ops-card .action-buttons{width:100%!important;flex-wrap:wrap!important;}#ops-card .action-buttons>.cw-split-run,#ops-card .action-buttons>.cw-hub-action{flex:1 1 150px!important;}#sched-inline-log{flex-wrap:wrap!important;}#ops-card #sched-inline-log .hub-group-system{margin-left:0;}}
 @media(max-width:480px){#ops-card .action-buttons>.cw-split-run,#ops-card .action-buttons>.cw-hub-action{flex:1 1 100%!important;}#ops-card #sched-inline-log .sched[data-tip]::after{left:0!important;transform:translateX(0) translateY(4px)!important;}#ops-card #sched-inline-log .sched[data-tip]:hover::after,#ops-card #sched-inline-log .sched[data-tip]:focus-visible::after{transform:translateX(0) translateY(0)!important;}}
 `;
@@ -150,7 +142,6 @@ html.cw-theme-original #ops-card{--hub-service-good:#57b58a;--hub-service-bad:#e
 
   function activateStatusTarget(target){
     if (target==="maintenance") return window.openMaintenanceModal?.();
-    if (target==="refresh-update") return CW().checkForUpdate?.();
     window.showTab?.("settings");
     setTimeout(()=>{
       if (target==="scheduling") return window.cwSettingsSelect?.("scheduling");
@@ -182,7 +173,7 @@ html.cw-theme-original #ops-card{--hub-service-good:#57b58a;--hub-service-bad:#e
           <div class="hub-group-items">${(isManaged()?["watch","hook"]:["sched","watch","hook"]).map(statusTile).join("")}</div>
         </div>
         <div class="hub-status-group hub-group-system">
-          <div class="hub-group-items">${["pairs","health","update"].map(statusTile).join("")}</div>
+          <div class="hub-group-items">${["pairs","health"].map(statusTile).join("")}</div>
         </div>`;
       host.appendChild(wrap);
     }
@@ -349,7 +340,7 @@ html.cw-theme-original #ops-card{--hub-service-good:#57b58a;--hub-service-bad:#e
     const host=ensureBanner();
     if (!host) return;
     const E=k=>{const chip=$(`#chip-${k}`,host);return {chip,icon:chip?$(".service-icon",chip):null,value:$(`#${k}-value`,host),meta:$(`#${k}-meta`,host),badges:$(`#${k}-badges`,host),tip:chip?$(".cw-hub-tip",chip):null,progress:["watch","hook"].includes(k)&&chip?$(".watch-progress",chip):null,progressValue:["watch","hook"].includes(k)?$(`#${k}-progress-value`,host):null};},
-      pairs=E("pairs"), sched=E("sched"), watch=E("watch"), hook=E("hook"), health=E("health"), update=E("update"),
+      pairs=E("pairs"), sched=E("sched"), watch=E("watch"), hook=E("hook"), health=E("health"),
       managed=isManaged(),
       watchItem=currentItem(S.watch),
       hookItem=currentItem(S.hook),
@@ -421,61 +412,11 @@ html.cw-theme-original #ops-card{--hub-service-good:#57b58a;--hub-service-bad:#e
       tip:["CrossWatch health","Status: down",healthState.status&&healthState.status!=="down"?`Response: ${healthState.status}`:""].filter(Boolean).join("\n")
     });
 
-    const updateState=S.system.update||{};
-    paint(update,managed?{
-      value:"admin", ok:false, disabled:true,
-      tip:"Updates\nManaged by administrator"
-    }:!updateState.known?{
-      value:"checking", ok:false, disabled:true,
-      tip:"Updates\nStatus: checking"
-    }:updateState.available?{
-      value:"available", ok:false, disabled:true,
-      tip:["Update available",updateState.latest?`Latest: ${updateState.latest}`:"",updateState.current?`Installed: ${updateState.current}`:""].filter(Boolean).join("\n")
-    }:updateState.ahead?{
-      value:"ahead", ok:true,
-      tip:["Updates","Status: newer than latest release",updateState.current?`Installed: ${updateState.current}`:"",updateState.latest?`Latest release: ${updateState.latest}`:""].filter(Boolean).join("\n")
-    }:updateState.unavailable?{
-      value:"unknown", ok:false, disabled:true,
-      tip:["Updates","Status: GitHub release check unavailable",updateState.current?`Installed: ${updateState.current}`:""].filter(Boolean).join("\n")
-    }:{
-      value:"current", ok:true,
-      tip:["Updates","Status: up to date",updateState.current?`Installed: ${updateState.current}`:""].filter(Boolean).join("\n")
-    });
-    update.chip?.classList.toggle("update-available",!!updateState.available);
-
     host.style.display="flex";
   }
 
   async function readConfig(force=false){
     try { return await API()?.Config.load(force)||{}; } catch { return Cache()?.getCfg()||{}; }
-  }
-
-  function applyUpdateStatus(detail=window.__CW_UPDATE_STATUS__){
-    if (!detail||typeof detail!=="object") return;
-    const publicVersion=value=>{
-      const raw=String(value||"").trim(),match=raw.match(/(?:^|[^0-9])(\d+\.\d+\.\d+)(?:[^0-9]|$)/);
-      return match?`v${match[1]}`:raw;
-    };
-    const versionParts=value=>String(value||"").match(/\d+/g)?.map(Number)||[];
-    const compareVersions=(left,right)=>{
-      const a=versionParts(left),b=versionParts(right),length=Math.max(a.length,b.length);
-      for(let index=0;index<length;index+=1){
-        const diff=(a[index]||0)-(b[index]||0);
-        if(diff) return diff>0?1:-1;
-      }
-      return 0;
-    };
-    const current=publicVersion(detail.current||detail.current_version||"");
-    const latest=publicVersion(detail.latest||detail.latest_version||"");
-    S.system.update={
-      known:detail.known!==false,
-      available:!!(detail.available??detail.update_available),
-      ahead:!!(current&&latest&&compareVersions(current,latest)>0),
-      current,
-      latest,
-      unavailable:detail.unavailable===true||!latest,
-      url:String(detail.url||detail.html_url||"")
-    };
   }
 
   async function pollPairs(force=false){
@@ -603,7 +544,6 @@ html.cw-theme-original #ops-card{--hub-service-good:#57b58a;--hub-service-bad:#e
   async function refresh(forceCfg=false){
     stop();
     [S.cfg]=await Promise.all([readConfig(forceCfg),pollPairs(forceCfg),pollHealth()]);
-    applyUpdateStatus();
     if ((isManaged()||!schedulingOn(S.cfg?.scheduling)) && !S.cfg?.scrobble?.enabled) {
       S.sched={enabled:false,running:false,next:0,advanced:false,captures:0,webhooks:false,webhookLabel:"",warning:false,warnings:[]};
       S.evt={enabled:false,count:0};
@@ -634,7 +574,6 @@ html.cw-theme-original #ops-card{--hub-service-good:#57b58a;--hub-service-bad:#e
     document.addEventListener("config-saved",()=>queueRefresh(true));
     window.addEventListener("cx:pairs:changed",refreshPairs);
     document.addEventListener("cx-state-change",refreshPairs);
-    document.addEventListener("cw-update-status",event=>{applyUpdateStatus(event?.detail);render();});
     window.addEventListener("auth-changed",()=>queueRefresh(true));
     document.addEventListener("scheduling-status-refresh",()=>!isManaged()&&pollSched(true));
     document.addEventListener("watcher-status-refresh",()=>pollScrob(true));

--- a/assets/js/sync-reviews.js
+++ b/assets/js/sync-reviews.js
@@ -1,0 +1,101 @@
+/* assets/js/sync-reviews.js */
+/* CrossWatch - Reopen Interactive Sync reviews from notifications and Synchronization */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+
+(() => {
+  const style = document.createElement("link");
+  style.rel = "stylesheet";
+  style.href = `/assets/css/sync-reviews.css?v=${encodeURIComponent(window.APP_VERSION || "1")}`;
+  document.head.appendChild(style);
+  const esc = value => String(value ?? "").replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+  let timer, controller, jumpToReviews = false;
+  const active = () => !document.hidden;
+
+  function roots() {
+    const pairs = document.getElementById("pairs_list");
+    if (!pairs) return [];
+    let root = document.getElementById("cw-sync-reviews");
+    if (!root) {
+      root = document.createElement("section");
+      root.id = "cw-sync-reviews";
+      root.className = "cw-sync-reviews";
+      root.setAttribute("aria-label", "Sync reviews");
+      root.hidden = true;
+    }
+    if (pairs.nextElementSibling !== root) pairs.after(root);
+    return [root];
+  }
+
+  function render(sessions, error = false, loading = false) {
+    const states = {
+      reading: ["Preparing review", "View progress", "sync"],
+      applying: ["Applying changes", "View progress", "sync"],
+      review: ["Ready to review", "Resume review", "fact_check"],
+      complete: ["Finished", "View report", "description"],
+      error: ["Needs attention", "Open review", "error_outline"],
+    };
+    const notifications = [];
+    const body = sessions.map(session => {
+      const pair = session.pair || {};
+      const endpoint = side => `${pair[side] || "Provider"}${pair[`${side}_instance`] && pair[`${side}_instance`] !== "default" ? ` · ${pair[`${side}_instance`]}` : ""}`;
+      const label = `${endpoint("source")} ${pair.mode === "two-way" ? "↔" : "→"} ${endpoint("target")}`;
+      const [status, action, icon] = states[session.status] || states.error;
+      const time = session.planned_at ? new Date(session.planned_at * 1000).toLocaleString() : "";
+      notifications.push({
+        id: session.id, revision: `${session.status}:${session.planned_at || ""}`, title: pair.name || label, detail: status, icon,
+        href: `/#interactive_sync?session=${encodeURIComponent(session.id)}`,
+        action, time: session.planned_at,
+      });
+      return `<li><span class="material-symbols-rounded cw-review-icon" aria-hidden="true">${icon}</span><div class="cw-review-copy"><strong>${esc(pair.name || label)}</strong>${pair.name ? `<span>${esc(label)}</span>` : ""}<small>${esc(status)}${time ? ` · ${esc(time)}` : ""}</small></div><a class="cw-review-link" href="#interactive_sync?session=${encodeURIComponent(session.id)}" aria-label="${esc(`${action}: ${pair.name || label}`)}">${action}<span class="material-symbols-rounded" aria-hidden="true">arrow_forward</span></a></li>`;
+    }).join("");
+    const html = `<h3>Sync reviews</h3>${error ? '<p>Could not load your reviews. <button type="button" data-reviews-retry>Try again</button></p>' : `<ul>${body}</ul><p>Open reviews stay available for one hour of inactivity, until closed, or until CrossWatch restarts.</p>`}`;
+    window.CW?.Notifications?.setSource("sync-reviews", { items: notifications, loading, error: error ? "Could not load sync reviews." : "" });
+    for (const root of roots()) {
+      root.hidden = !error && !sessions.length;
+      if (root.innerHTML !== html) root.innerHTML = html;
+      if (jumpToReviews && document.documentElement.dataset.tab === "settings" && window.__cwSettingsPane === "sync") {
+        jumpToReviews = false;
+        (root.hidden ? document.getElementById("pairs_list") : root).scrollIntoView({ block: "start" });
+      }
+    }
+  }
+
+  async function refresh() {
+    clearTimeout(timer);
+    controller?.abort();
+    if (!active()) return;
+    const request = controller = new AbortController();
+    let allowed = true;
+    try {
+      await window.__cwAuthBootstrapPromise;
+      await window.CW?.OverviewProfile?.ready;
+      if (request.signal.aborted) return;
+      if (window.cwIsAuthSetupPending?.() || (document.documentElement.dataset.cwRole === "user" && document.documentElement.dataset.cwPermWrite !== "on")) { allowed = false; render([]); return; }
+      const profile = String(window.CW?.OverviewProfile?.id || "").trim();
+      const url = `/api/interactive-sync${profile ? `?user_profile=${encodeURIComponent(profile)}` : ""}`;
+      const response = await fetch(url, { credentials: "same-origin", cache: "no-store", signal: request.signal });
+      if (response.status === 401 || response.status === 403) { allowed = false; render([]); return; }
+      if (!response.ok) throw new Error("Reviews unavailable");
+      const data = await response.json();
+      if (!request.signal.aborted) render(data.sessions || []);
+    } catch (error) {
+      if (!request.signal.aborted) render([], true);
+    } finally {
+      if (!request.signal.aborted && active() && allowed) timer = setTimeout(refresh, 10000);
+    }
+  }
+  window.addEventListener("cw:overview-profile-changed", () => { render([], false, true); refresh(); });
+  document.addEventListener("tab-changed", refresh);
+  document.addEventListener("cw-settings-pane-changed", refresh);
+  document.addEventListener("visibilitychange", refresh);
+  window.addEventListener("auth-changed", () => { render([]); refresh(); });
+  window.addEventListener("cw:auth-state-changed", () => { render([]); refresh(); });
+  document.addEventListener("click", event => {
+    if (event.target.closest?.("[data-reviews-retry]")) refresh();
+    if (event.target.closest?.(".cw-notifications-footer")) { jumpToReviews = true; refresh(); }
+  });
+  window.SyncReviews = { refresh };
+  window.addEventListener("cw:notifications-refresh", refresh);
+  window.CW?.Notifications?.setSource("sync-reviews", { items: [], loading: true });
+  refresh();
+})();

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -1700,7 +1700,7 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
         updates = review.filter(feature, dst, dst_inst, "update", updates, **review_args)
         removes = review.filter(feature, dst, dst_inst, "remove", removes, **review_args)
         if review.preview:
-            return {"blocked": blocked_total, "cancelled": cancelled}
+            return {"blocked": blocked_total, "manual_excluded": int(manual_blocked), "cancelled": cancelled}
 
     attempted_keys: list[str] = []
     key2item: dict[str, Any] = {}
@@ -2273,6 +2273,7 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
         "skipped_exact": int((res_update or {}).get("skipped_exact", 0)) + int((res_add or {}).get("skipped_exact", 0)),
         "skipped_inferred": int((res_update or {}).get("skipped_inferred", 0)) + int((res_add or {}).get("skipped_inferred", 0)),
         "blocked": int(blocked_total),
+        "manual_excluded": int(manual_blocked),
         "res_add": res_add,
         "res_update": res_update,
         "res_remove": res_remove,

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -2641,6 +2641,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
         "unresolved": unresolved_total,
         "skipped": skipped_total,
         "blocked": int(blocked_total),
+        "manual_excluded": int(manual_blocked),
         "errors": errors_total,
         "cancelled": bool(cancelled or cancel_requested()),
     }

--- a/docs/interactive-sync-mapping-search.md
+++ b/docs/interactive-sync-mapping-search.md
@@ -1,0 +1,40 @@
+# Interactive Sync mapping search
+
+Search and automatic suggestions only appear for a configured destination instance. The server checks availability again on every search. Missing connections cannot borrow credentials from another instance. Manual mapping remains available.
+
+| Destination | Search source |
+| --- | --- |
+| Plex | Plex Discover catalog with the configured account token |
+| Jellyfin, Emby | Configured server library, scoped to the configured user |
+| Kodi | Configured library through read-only JSON-RPC queries |
+| Scrob | Scrob media search |
+| Trakt | Trakt catalog |
+| MDBList | MDBList catalog |
+| SIMKL | SIMKL movie, TV and anime catalogs |
+| Punchplay | Punchplay public catalog |
+| TMDb Sync | TMDb catalog using that sync instance's API key |
+| Floppy | Floppy's TMDb catalog search |
+| FlickList, PublicMetaDB, Nuvio, Stremio | TMDb metadata fallback when a metadata API key is configured |
+
+Plex instances with only a server token can use the metadata fallback. The fallback is labelled **TMDb metadata** and does not check destination availability. It uses the metadata settings key, separate from TMDb Sync credentials.
+
+Direct search is not currently integrated for FlickList, PublicMetaDB, Nuvio or Stremio. PublicMetaDB's external API documents ID lookup, but no title-search endpoint. No public FlickList search contract was verified. Nuvio and Stremio use addon catalogs; this implementation does not search installed addons. BingeBase is excluded because it has no CrossWatch sync provider.
+
+Suggestions require one exact title match, with a compatible year when known. They remain editable drafts. The user reviews show IDs and season/episode numbering, then saves the batch with one recalculation. **Suggest season and episode** resolves original TVDB/IMDb episode IDs through TMDb, or compares unique episode titles and compatible air dates against the chosen TMDb show. It updates show IDs and coordinates together as drafts. It requires a configured destination plus a TMDb metadata key (or the selected TMDb Sync instance key). It uses TMDb numbering; it does not infer destination-specific episode orders. Conflicting IDs, generic episode titles and ambiguous matches stay unchanged with a reason shown on each row. Lookups share a request cache within each batch and have request/time limits. Ambiguous matches are left for manual review. Search does not mark anything watched or apply sync changes.
+
+MDBList search results are enriched with missing TMDb and IMDb IDs through its media-info batch endpoint, using the same configured destination instance. Results are joined by provider ID rather than response order. A result without a verified TMDb ID remains visible with an explanation, but cannot be selected or used by Auto match. Incomplete lookups are not cached, so Find matches can retry. Selecting a complete result updates the checked drafts' titles and IDs immediately; season and episode numbers remain unchanged until edited or suggested separately.
+
+## API references
+
+- [Punchplay search contract](https://docs.punchplay.tv/api-reference/public-catalog/search-movies-shows-or-anime)
+- [Floppy search contract tests](https://github.com/dannyvfilms/Floppy/blob/latest/src/api/tests/test_search.py)
+- [Scrob media routes](https://github.com/ellite/scrob/blob/main/backend/routers/media.py)
+- [Emby library API](https://dev.emby.media/doc/restapi/Browsing-the-Library.html)
+- [Kodi JSON-RPC examples](https://kodi.wiki/view/JSON-RPC_API/Examples)
+- [TMDb TV search](https://developer.themoviedb.org/reference/search-tv)
+- [MDBList API](https://docs.mdblist.com/docs/api)
+- [SIMKL API](https://github.com/SIMKL/API/blob/master/apiary.apib)
+- [Trakt API](https://trakt.docs.apiary.io/)
+- [PublicMetaDB external API](https://publicmetadb.com/api-docs)
+- [Stremio catalog protocol](https://stremio.github.io/stremio-addon-sdk/protocol.html)
+- [Nuvio backend and default catalog configuration](https://github.com/NuvioMedia/self-host/blob/main/.env.example)

--- a/services/interactive_sync.py
+++ b/services/interactive_sync.py
@@ -106,23 +106,25 @@ def build(session: Session, cfg: dict[str, Any], choices: dict[str, str], *, sto
     return plan, summary
 
 
-def refresh(session: Session, cfg: dict[str, Any], choices: dict[str, str], *, restart_progress=True):
+def refresh(session: Session, cfg: dict[str, Any], choices: dict[str, str], *, restart_progress=True, corrections=()):
     if restart_progress:
         session.progress.begin("preview")
     version = mapping_version(cfg)
     store = ReviewStore()
     try:
         plan, summary = build(session, cfg, choices, store=store)
-        _finish_review(session, cfg, version, plan, summary, store)
+        _finish_review(session, cfg, version, plan, summary, store, corrections=corrections)
     except Exception:
         if session.store is not store:
             store.close()
         raise
 
 
-def _finish_review(session, cfg, version, plan, summary, store):
+def _finish_review(session, cfg, version, plan, summary, store, *, corrections=()):
     session.progress.set_stage("finalizing", "Preparing pages and preserving selections")
     store.finish(session.store)
+    if summary.get("ok"):
+        store.select_corrected(corrections)
     with LOCK:
         session.close()
         session.store = store
@@ -136,10 +138,16 @@ def _finish_review(session, cfg, version, plan, summary, store):
         session.report = None
         session.status = "review" if summary.get("ok") else "error"
         session.message = "Review the proposed changes. Nothing has been applied." if summary.get("ok") else "The plan could not be completed. Check provider status and refresh."
+        if corrections and summary.get("ok"):
+            session.message = "Mappings saved and the plan recalculated. Review the corrected changes before applying."
         if summary.get("cancelled"):
             session.message = "Reading cancelled. Refresh to build a new plan."
         session.touched = time.monotonic()
         session.progress.finish("cancelled" if summary.get("cancelled") else session.status, session.message)
+
+
+def refresh_mappings(session, cfg, choices, corrections):
+    refresh(session, cfg, choices, corrections=corrections)
 
 
 def _apply_needs_review(session, selected, reason):

--- a/services/interactive_sync_catalogs.py
+++ b/services/interactive_sync_catalogs.py
@@ -1,0 +1,144 @@
+# services/interactive_sync_catalogs.py
+# CrossWatch - Configured mapping catalogs and destination searches
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from importlib import import_module
+from urllib.parse import quote
+
+from fastapi import HTTPException
+
+from cw_platform.provider_instances import get_provider_block
+
+
+PROVIDERS = frozenset(("PLEX", "JELLYFIN", "EMBY", "KODI", "SCROB", "TRAKT", "MDBLIST", "SIMKL",
+                       "PUNCHPLAY", "FLICKLIST", "TMDB", "PUBLICMETADB", "NUVIO", "STREMIO", "FLOPPY"))
+NATIVE = PROVIDERS - {"FLICKLIST", "PUBLICMETADB", "NUVIO", "STREMIO"}
+LIBRARY = {"JELLYFIN", "EMBY", "KODI"}
+
+
+def provider_block(cfg, provider, instance):
+    key = "tmdb_sync" if provider == "TMDB" else provider.lower()
+    block = get_provider_block(cfg, key, instance)
+    block.pop("instances", None)
+    if instance == "default" and provider in {"PLEX", "JELLYFIN", "EMBY", "TRAKT", "SIMKL"}:
+        legacy = (cfg.get("auth") or {}).get(key) or {}
+        block = {**legacy, **block}
+    return block
+
+
+def configured(provider, block):
+    if provider not in PROVIDERS or not block:
+        return False
+    if provider in {"SCROB", "PUNCHPLAY", "FLICKLIST", "NUVIO", "STREMIO", "FLOPPY"}:
+        return import_module(f"providers.auth._auth_{provider}").is_configured(block)
+    if provider == "MDBLIST":
+        from providers.sync.mdblist._auth import is_configured
+        return is_configured(block)
+    if provider in {"TRAKT", "SIMKL"}:
+        token = block.get("access_token") or block.get("token") or (block.get("oauth") or {}).get("access_token")
+        key = block.get("client_id") if provider == "TRAKT" else block.get("client_id") or block.get("api_key")
+        return bool(str(token or "").strip() and str(key or "").strip())
+    if provider in {"JELLYFIN", "EMBY"}:
+        return all(block.get(key) for key in ("server", "access_token", "user_id"))
+    if provider == "KODI":
+        return bool(block.get("server") and block.get("connection_verified") is True)
+    if provider == "PLEX":
+        return bool(block.get("account_token") or block.get("token") or block.get("pms_token")
+                    or (block.get("pms") or {}).get("token") or (block.get("pms") or {}).get("x_plex_token"))
+    if provider == "TMDB":
+        return bool(block.get("api_key") and block.get("session_id"))
+    return bool(block.get("api_key"))
+
+
+def search_catalogs(cfg, row):
+    provider = str(row["provider"]).upper()
+    block = provider_block(cfg, provider, row.get("instance") or "default")
+    options = []
+    if configured(provider, block):
+        native = provider in NATIVE
+        if provider == "PLEX":
+            native = bool(block.get("account_token") or block.get("token"))
+        if native:
+            suffix = "library" if provider in LIBRARY else "catalog"
+            options.append(dict(id="destination", label=f"{provider} {suffix}"))
+        if (cfg.get("tmdb") or {}).get("api_key"):
+            options.append(dict(id="tmdb", label="TMDb metadata"))
+    return dict(ok=True, catalogs=options)
+
+
+def destination_rows(client, cfg, row, block, query, entity):
+    provider = str(row["provider"]).upper()
+    instance = row.get("instance") or "default"
+    if provider in {"JELLYFIN", "EMBY"}:
+        response = client.get(f"{str(block['server']).rstrip('/')}/Users/{quote(str(block['user_id']), safe='')}/Items",
+                              headers={"X-Emby-Token": block["access_token"], "Accept": "application/json"},
+                              params={"SearchTerm": query, "IncludeItemTypes": "Movie" if entity == "movie" else "Series",
+                                      "Recursive": "true", "Fields": "ProviderIds", "Limit": 20, "EnableImages": "false"},
+                              timeout=10, verify=bool(block.get("verify_ssl", True)))
+        body = checked_json(response, provider)
+        return [dict(title=r.get("Name"), year=r.get("ProductionYear"),
+                     ids={k.lower(): v for k, v in (r.get("ProviderIds") or {}).items()})
+                for r in body.get("Items", []) if isinstance(r, dict)]
+    if provider == "KODI":
+        from providers.sync.kodi._common import KodiClient, make_config, normalize_uniqueids
+        kodi = KodiClient(make_config({"kodi": {**block, "timeout": 10}}))
+        kind = "Movies" if entity == "movie" else "TVShows"
+        body = kodi.rpc(f"VideoLibrary.Get{kind}", {"properties": ["title", "year", "uniqueid"],
+                        "filter": {"field": "title", "operator": "contains", "value": query},
+                        "limits": {"start": 0, "end": 20}})
+        return [dict(title=r.get("title") or r.get("label"), year=r.get("year"), ids=normalize_uniqueids(r.get("uniqueid")))
+                for r in body.get(kind.lower(), []) if isinstance(r, dict)]
+    if provider == "SCROB":
+        from providers.auth._auth_SCROB import request_with_auth
+        from providers.sync.scrob._common import url_for
+        response = request_with_auth(client, "GET", url_for(block, "media/search"), cfg=cfg, instance_id=instance,
+                                     params={"q": query, "type": "movie" if entity == "movie" else "series"}, timeout=10)
+    elif provider == "FLOPPY":
+        from providers.auth._auth_FLOPPY import FloppyClient
+        body = FloppyClient(block["server_url"], block["api_token"], verify_ssl=bool(block.get("verify_ssl", False)),
+                            timeout=10, session=client).request_json(f"search/{'movie' if entity == 'movie' else 'tv'}/",
+                            params={"search": query, "source": "tmdb", "limit": 20})
+        return [dict(r, ids={str(r.get("source")): r.get("media_id")}) for r in body.get("results", []) if isinstance(r, dict)]
+    elif provider == "PUNCHPLAY":
+        response = client.get("https://punchplay.tv/api/public/v1/catalog/search",
+                              params={"q": query[:100], "type": entity}, timeout=10)
+        body = checked_json(response, provider)
+        return [dict(r, ids={"tmdb": r.get("tmdbId")}) for r in body.get("items", [])
+                if isinstance(r, dict) and r.get("type") == entity]
+    elif provider == "PLEX":
+        response = client.get("https://discover.provider.plex.tv/library/search",
+                              headers={"X-Plex-Token": block.get("account_token") or block.get("token"),
+                                       "Accept": "application/json", "X-Plex-Product": "CrossWatch",
+                                       "X-Plex-Client-Identifier": block.get("client_id") or "crosswatch-mapping"},
+                              params={"query": query, "limit": 20, "searchProviders": "discover",
+                                      "searchTypes": "movies" if entity == "movie" else "shows", "includeMetadata": 1}, timeout=10)
+        body = checked_json(response, provider)
+        found = []
+        def collect(value):
+            if isinstance(value, list):
+                for child in value:
+                    collect(child)
+            elif isinstance(value, dict):
+                if value.get("type") == entity and value.get("title"):
+                    ids = {}
+                    for guid in value.get("Guid") or []:
+                        if isinstance(guid, dict) and "://" in str(guid.get("id")):
+                            key, identifier = guid["id"].split("://", 1)
+                            ids[key] = identifier
+                    found.append(dict(title=value["title"], year=value.get("year"), ids=ids))
+                for key in ("MediaContainer", "SearchResults", "SearchResult", "Metadata", "Hub"):
+                    if key in value:
+                        collect(value[key])
+        collect(body)
+        return found
+    else:
+        raise HTTPException(409, "This destination does not expose a supported search catalog.")
+    body = checked_json(response, provider)
+    return body.get("results", [])
+
+
+def checked_json(response, provider):
+    if response.status_code >= 400:
+        raise HTTPException(502, f"{provider} search returned HTTP {response.status_code}. Try again or use manual IDs.")
+    return response.json()

--- a/services/interactive_sync_episodes.py
+++ b/services/interactive_sync_episodes.py
@@ -1,0 +1,139 @@
+# services/interactive_sync_episodes.py
+# CrossWatch - Episode identity suggestions for Interactive Sync
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import re
+import time
+from urllib.parse import quote
+
+import requests
+from fastapi import HTTPException
+
+from services.interactive_sync_catalogs import configured, provider_block
+
+
+def metadata_key(cfg, row):
+    provider = str(row["provider"]).upper()
+    block = provider_block(cfg, provider, row.get("instance") or "default")
+    if not configured(provider, block):
+        return None
+    return block.get("api_key") if provider == "TMDB" else (cfg.get("tmdb") or {}).get("api_key")
+
+
+def _number(value, minimum=0):
+    if isinstance(value, bool) or not re.fullmatch(r"\d+", str(value)):
+        return None
+    number = int(value)
+    return number if number >= minimum else None
+
+
+def _title(value):
+    return re.sub(r"\W+", "", str(value or "")).casefold()
+
+
+def match_episode(source, episodes):
+    name = _title(source.get("name"))
+    if not name or re.fullmatch(r"(?:episode\d+|s\d+e\d+)", name):
+        return None
+    matches = [ep for ep in episodes if _title(ep.get("name")) == name
+               and (not source.get("air_date") or not ep.get("air_date") or source["air_date"] == ep["air_date"])]
+    return matches[0] if len(matches) == 1 else None
+
+
+def suggest_episodes(cfg, edits):
+    cache = {}
+    requests_left = 60
+    deadline = time.monotonic() + 45
+    results = []
+    with requests.Session() as client:
+        def get(key, path, **params):
+            nonlocal requests_left
+            identity = (key, path, tuple(sorted(params.items())))
+            if identity not in cache:
+                if requests_left <= 0 or time.monotonic() >= deadline:
+                    raise HTTPException(409, "Episode lookup limit reached. Try a smaller batch.")
+                requests_left -= 1
+                response = client.get(f"https://api.themoviedb.org/3/{path}",
+                                      params={"api_key": key, **params}, timeout=8)
+                if response.status_code == 404:
+                    body = {}
+                elif response.status_code >= 400:
+                    raise HTTPException(502, f"TMDb episode lookup returned HTTP {response.status_code}.")
+                else:
+                    body = response.json()
+                if not isinstance(body, dict):
+                    raise HTTPException(502, "TMDb returned an unreadable episode response.")
+                cache[identity] = body
+            return cache[identity]
+
+        for row, draft in edits:
+            result: dict[str, object] = dict(row_id=row["id"], match=None, reason="No reliable episode match found. Choose the show and adjust numbering manually.")
+            results.append(result)
+            key = metadata_key(cfg, row)
+            if not key:
+                result["reason"] = "Configure the destination and a TMDb metadata key to match episodes."
+                continue
+            original = row["item"]
+            if original.get("type") != "episode":
+                result["reason"] = "Season and episode suggestions apply to episodes only."
+                continue
+            try:
+                identities = {}
+                for namespace in ("tvdb", "imdb"):
+                    identifier = (original.get("ids") or {}).get(namespace)
+                    if not identifier:
+                        continue
+                    if str(identifier) == str((original.get("show_ids") or {}).get(namespace)):
+                        continue
+                    body = get(key, f"find/{quote(str(identifier), safe='')}", external_source=f"{namespace}_id")
+                    for ep in body.get("tv_episode_results") or []:
+                        if not isinstance(ep, dict):
+                            continue
+                        identity = (_number(ep.get("show_id"), 1), _number(ep.get("season_number")), _number(ep.get("episode_number"), 1))
+                        if all(value is not None for value in identity):
+                            identities[identity] = ep
+                if len(identities) > 1:
+                    result["reason"] = "Episode IDs disagree. Review the match manually."
+                    continue
+                reason = "Matched the original episode ID in TMDb."
+                if identities:
+                    show_id, season, episode = next(iter(identities))
+                else:
+                    show_id = _number((draft.get("show_ids") or draft.get("ids") or {}).get("tmdb"), 1)
+                    source = {"name": original.get("episode_title"), "air_date": original.get("air_date")}
+                    source_show = _number((original.get("show_ids") or {}).get("tmdb"), 1)
+                    source_season = _number(original.get("season"))
+                    source_episode = _number(original.get("episode"), 1)
+                    if not source.get("name") and source_show and source_season is not None and source_episode:
+                        source = get(key, f"tv/{source_show}/season/{source_season}/episode/{source_episode}")
+                    if not show_id or not source.get("name"):
+                        continue
+                    show = get(key, f"tv/{show_id}")
+                    seasons = [s for s in show.get("seasons") or [] if isinstance(s, dict) and _number(s.get("season_number")) is not None]
+                    if len(seasons) > 30:
+                        result["reason"] = "This show has too many seasons for automatic comparison. Use an exact episode ID or adjust manually."
+                        continue
+                    episodes = []
+                    for season_info in seasons:
+                        body = get(key, f"tv/{show_id}/season/{season_info['season_number']}")
+                        if "episodes" not in body:
+                            raise HTTPException(502, "Could not read every season. No episode number was guessed.")
+                        episodes.extend(ep for ep in body["episodes"] if isinstance(ep, dict))
+                    match = match_episode(source, episodes)
+                    if not match:
+                        continue
+                    season, episode = _number(match.get("season_number")), _number(match.get("episode_number"), 1)
+                    if season is None or episode is None:
+                        continue
+                    reason = "Matched a unique episode title and compatible air date in TMDb."
+                show = get(key, f"tv/{show_id}")
+                if not show.get("name"):
+                    result["reason"] = "Episode found, but show metadata is unavailable. Try again."
+                    continue
+                result.update(match=dict(ids={"tmdb": str(show_id)}, title=show["name"], season=season, episode=episode), reason=reason)
+            except HTTPException as error:
+                result["reason"] = str(error.detail)
+            except Exception:
+                result["reason"] = "Episode lookup is unavailable. Try again; your draft is unchanged."
+    return dict(ok=True, results=results, note="Suggestions use TMDb episode numbering. Review the drafts before saving.")

--- a/services/interactive_sync_mapping.py
+++ b/services/interactive_sync_mapping.py
@@ -1,0 +1,161 @@
+# services/interactive_sync_mapping.py
+# CrossWatch - Destination catalog suggestions for interactive mapping
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import re
+
+import requests
+from fastapi import HTTPException
+
+from cw_platform.id_map import coalesce_ids, ID_KEYS
+from services.interactive_sync_catalogs import destination_rows, provider_block, search_catalogs
+
+
+def _candidate_ids(item, source):
+    raw = item.get("ids")
+    ids = dict(raw) if isinstance(raw, dict) else {}
+    if ids.get("simkl_id"):
+        ids["simkl"] = ids["simkl_id"]
+    for key in ID_KEYS:
+        value = item.get(key) or item.get(key + "id") or item.get(key + "_id")
+        if value:
+            ids[key] = value
+    if source == "TMDB":
+        ids["tmdb"] = item.get("id")
+    elif source == "MDBLIST" and str(item.get("id") or "").startswith("tt"):
+        ids["imdb"] = item["id"]
+    return coalesce_ids({key: value for key, value in ids.items() if key in ID_KEYS})
+
+
+def _mdblist_metadata(client, cfg, instance, entity, body):
+    from providers.sync.mdblist._auth import request_with_auth
+
+    rows = body if isinstance(body, list) else (body.get("search") or body.get("results") or []) if isinstance(body, dict) else []
+    if not isinstance(rows, list):
+        return body
+    rows = [dict(item) for item in rows[:20] if isinstance(item, dict)]
+    groups = {}
+    for item in rows:
+        ids = _candidate_ids(item, "MDBLIST")
+        if ids.get("tmdb") and ids.get("imdb"):
+            continue
+        namespace = next((key for key in ("mdblist", "imdb", "tmdb") if ids.get(key)), None)
+        if namespace:
+            groups.setdefault(namespace, {}).setdefault(ids[namespace], []).append(item)
+    for namespace, targets in groups.items():
+        try:
+            response = request_with_auth(client, "POST", f"https://api.mdblist.com/{namespace}/{entity}/",
+                                         cfg=cfg, instance_id=instance, timeout=10, max_retries=0,
+                                         json={"ids": list(targets)})
+            if response.status_code >= 400:
+                continue
+            details = response.json()
+            if not isinstance(details, list):
+                continue
+            by_id = {}
+            for detail in details:
+                if not isinstance(detail, dict):
+                    continue
+                ids = _candidate_ids(detail, "MDBLIST")
+                if ids.get(namespace) in targets:
+                    by_id.setdefault(ids[namespace], []).append(ids)
+            for identity, items in targets.items():
+                matches = by_id.get(identity, [])
+                if len(matches) != 1:
+                    continue
+                resolved = matches[0]
+                for item in items:
+                    original = _candidate_ids(item, "MDBLIST")
+                    if any(original[key] != resolved[key] for key in original.keys() & resolved.keys()):
+                        continue
+                    item["ids"] = {**original, **resolved}
+        except Exception:
+            continue
+    return rows
+
+
+def search_candidates(cfg, row, query, *, catalog="destination"):
+    provider = str(row["provider"]).upper()
+    instance = row.get("instance") or "default"
+    entity = "movie" if row["item"].get("type") == "movie" else "show"
+    catalogs = search_catalogs(cfg, row)["catalogs"]
+    if not isinstance(catalogs, list) or catalog not in {option["id"] for option in catalogs}:
+        raise HTTPException(409, "Search is not available for this configured destination and catalog.")
+    source = provider if catalog == "destination" else "TMDB"
+    block = provider_block(cfg, provider, instance)
+    extra = []
+    try:
+        with requests.Session() as client:
+            if source == "MDBLIST":
+                from providers.sync.mdblist._auth import request_with_auth
+
+                response = request_with_auth(client, "GET", f"https://api.mdblist.com/search/{entity}",
+                                             cfg=cfg, instance_id=instance, timeout=10, max_retries=0,
+                                             params={"query": query, "limit": 20})
+            elif source == "SIMKL":
+                key = block.get("api_key") or block.get("client_id")
+                if not key:
+                    raise HTTPException(409, "Configure SIMKL search credentials for this destination instance.")
+                response = client.get(f"https://api.simkl.com/search/{'movie' if entity == 'movie' else 'tv'}",
+                                      params={"q": query, "client_id": key, "limit": 20}, timeout=10)
+                if entity == "show":
+                    anime = client.get("https://api.simkl.com/search/anime", params={"q": query, "client_id": key, "limit": 20}, timeout=10)
+                    if anime.status_code >= 400:
+                        raise HTTPException(502, f"SIMKL anime search returned HTTP {anime.status_code}. Try again.")
+                    extra = anime.json()
+            elif source == "TRAKT":
+                key = block.get("client_id")
+                if not key:
+                    raise HTTPException(409, "Configure Trakt search credentials for this destination instance.")
+                response = client.get(f"https://api.trakt.tv/search/{entity}", params={"query": query, "limit": 20},
+                                      headers={"trakt-api-key": key, "trakt-api-version": "2"}, timeout=10)
+            elif source == "TMDB":
+                key = block.get("api_key") if catalog == "destination" else (cfg.get("tmdb") or {}).get("api_key")
+                if not key:
+                    raise HTTPException(409, "Add a TMDb API key in metadata settings to search this catalog.")
+                response = client.get(f"https://api.themoviedb.org/3/search/{'movie' if entity == 'movie' else 'tv'}",
+                                      params={"api_key": key, "query": query, "include_adult": False}, timeout=10)
+            else:
+                body = destination_rows(client, cfg, row, block, query, entity)
+                response = None
+            if response is not None and response.status_code >= 400:
+                raise HTTPException(502, f"{source} search returned HTTP {response.status_code}. Try again or use manual IDs.")
+            if response is not None:
+                body = response.json()
+            if source == "MDBLIST":
+                body = _mdblist_metadata(client, cfg, instance, entity, body)
+    except HTTPException:
+        raise
+    except Exception as error:
+        raise HTTPException(502, f"{source} search is unavailable. Try again or use manual IDs.") from error
+    rows = body if isinstance(body, list) else (body.get("search") or body.get("results") or []) if isinstance(body, dict) else []
+    if not isinstance(rows, list):
+        raise HTTPException(502, f"{source} returned an unreadable search response.")
+    rows = rows[:20] + (extra[:20] if isinstance(extra, list) else [])
+    results = []
+    seen = set()
+    for raw in rows:
+        if not isinstance(raw, dict):
+            continue
+        item = raw.get(entity)
+        if not isinstance(item, dict):
+            item = raw
+        if source == "SIMKL" and entity == "show" and item.get("endpoint_type") == "anime" and item.get("type") == "movie":
+            continue
+        ids = _candidate_ids(item, source)
+        title = str(item.get("title_en") or item.get("title") or item.get("name") or "")[:300]
+        identity = tuple(sorted(ids.items()))
+        if not ids or not title or identity in seen:
+            continue
+        seen.add(identity)
+        year = str(item.get("year") or item.get("release_date") or item.get("first_air_date") or "")[:4]
+        exact = re.sub(r"\W+", "", title).casefold() == re.sub(r"\W+", "", query).casefold()
+        results.append(dict(title=title, year=int(year) if year.isdigit() else None, ids=ids,
+                            type=entity, exact_title=exact))
+        if source == "MDBLIST" and not ids.get("tmdb"):
+            results[-1]["mapping_unavailable"] = "TMDb ID could not be retrieved. Try searching again or enter a verified TMDb ID manually."
+    results.sort(key=lambda item: not item["exact_title"])
+    return dict(ok=True, catalog=source, destination=provider, results=results[:20],
+                note="Review the match and episode numbering before saving."
+                if catalog == "destination" else "TMDb metadata suggestions; destination availability has not been checked.")

--- a/services/interactive_sync_report.py
+++ b/services/interactive_sync_report.py
@@ -123,6 +123,8 @@ class SyncReport:
 
     def record(self, feature, src, dst, src_instance, dst_instance, mode, result):
         totals = {key: count(result.get(key)) for key in COUNTERS}
+        manual_excluded = min(totals["blocked"], count(result.get("manual_excluded")))
+        totals["blocked"] -= manual_excluded
         destinations = []
         if mode == "two-way" and feature != "playlists":
             for side, provider, instance in (("A", src, src_instance), ("B", dst, dst_instance)):
@@ -141,19 +143,25 @@ class SyncReport:
                 totals[key] += count(result.get(f"{key}_to_A")) + count(result.get(f"{key}_to_B"))
         elif feature != "playlists":
             destinations.append(dict(provider=dst, instance=dst_instance, **totals))
-        self.features.append(dict(feature=feature, **totals, destinations=destinations))
+        self.features.append(dict(feature=feature, **totals, manual_excluded=manual_excluded, destinations=destinations))
 
     def finish(self, session, execution, result):
         totals = {key: count(result.get(key)) if result is not None else sum(row[key] for row in self.features) for key in COUNTERS}
+        manual_excluded = sum(row["manual_excluded"] for row in self.features)
+        engine_blocked = totals["blocked"] if result is not None else totals["blocked"] + manual_excluded
+        if result is not None:
+            manual_excluded = min(totals["blocked"], manual_excluded)
+            totals["blocked"] -= manual_excluded
         requested = len(execution.selected)
         not_reached = len(execution.selected - execution.seen)
         cancelled = self.cancelled or bool((result or {}).get("cancelled"))
         outcome = "cancelled" if cancelled else "incomplete" if result is None or not result.get("ok", True) else "attention" if not_reached or any(totals[k] for k in ("errors", "unresolved", "blocked")) or self.notices else "success"
         counts = session.store.counts if session.store else {}
-        return dict(version=2, run_id="interactive-" + session.id, pair=dict(session.pair),
+        return dict(version=3, run_id="interactive-" + session.id, pair=dict(session.pair),
                     started_at=timestamp(self.started), finished_at=timestamp(time.time()),
                     duration_seconds=session.progress.public().get("elapsed_seconds", 0),
                     outcome=outcome, totals=totals, requested=requested,
+                    manual_excluded=manual_excluded, engine_blocked=engine_blocked,
                     proposed=count(counts.get("changes")),
                     not_selected=max(0, count(counts.get("changes")) - requested),
                     reached_execution=requested - not_reached, not_reached=not_reached,
@@ -163,5 +171,5 @@ class SyncReport:
                     issue_details_omitted=sum(self.detail_omitted.values()),
                     review_notices=session.plan.notices[:100],
                     requests=session.progress.public().get("requests", 0),
-                    accounting_note="Totals use the existing sync engine's provider results. Skips can include items already present. Errors and protection counts can overlap or describe a whole batch; they are not an item-by-item receipt. Playlist totals count playlist contents and ordering operations.",
+                    accounting_note="Totals use the existing sync engine's provider results. Mapping and manual exclusions are shown separately from blocked items; the raw engine blocked count includes both. Skips can include items already present. Errors and protection counts can overlap or describe a whole batch; they are not an item-by-item receipt. Playlist totals count playlist contents and ordering operations.",
                     incomplete_note="Some writes may have completed before the interruption without final counts. Check Events before starting another sync." if outcome in ("cancelled", "incomplete") else "")

--- a/services/interactive_sync_store.py
+++ b/services/interactive_sync_store.py
@@ -95,7 +95,7 @@ class ReviewStore:
         payload = json.dumps(value, ensure_ascii=False, separators=(",", ":"), default=str)
         with self.lock:
             self.db.execute("INSERT INTO review(id,kind,feature,result,selectable,selected,search,payload) VALUES(?,?,?,?,?,?,?,?) ON CONFLICT(id) DO UPDATE SET payload=excluded.payload,search=excluded.search",
-                            (key, kind, value["feature"], result, selectable, selectable, search.casefold(), payload))
+                            (key, kind, value["feature"], result, selectable, selectable and result != "unresolved", search.casefold(), payload))
 
     def finish(self, previous=None):
         with self.lock:
@@ -136,10 +136,14 @@ class ReviewStore:
             args.append(q.casefold())
         return " AND ".join(clauses), args
 
-    def page(self, *, offset=0, limit=75, feature="", result="", q=""):
+    def page(self, *, offset=0, limit=75, feature="", result="", q="", selected_only=False, editable_only=False):
         where, args = self.where(feature, result, q)
+        if selected_only:
+            where += " AND selected=1"
+        if editable_only:
+            where += " AND kind='change' AND feature!='playlists' AND json_extract(payload,'$.operation') IN ('add','update')"
         with self.lock:
-            if not args:
+            if not args and not selected_only and not editable_only:
                 total = self.counts["changes"] + self.counts["conflicts"]
                 selectable, selected = self.selectable_count, self.counts["selected"]
             else:
@@ -179,6 +183,19 @@ class ReviewStore:
     def selected_ids(self):
         with self.lock:
             return {r[0] for r in self.db.execute("SELECT id FROM review WHERE selected=1")}
+
+    def select_corrected(self, corrections):
+        with self.lock:
+            for correction in corrections:
+                rows = self.db.execute(
+                    "SELECT id FROM review WHERE kind='change' AND selectable=1 AND result IN ('add','update') "
+                    "AND feature=? AND json_extract(payload,'$.key')=? "
+                    "AND json_extract(payload,'$.source')=? AND json_extract(payload,'$.source_instance')=? "
+                    "AND json_extract(payload,'$.provider')=? AND json_extract(payload,'$.instance')=?",
+                    correction["identity"],
+                ).fetchall()
+                if len(rows) == 1:
+                    self.select(correction["selected"], ids=[rows[0][0]])
 
     def recheck_details(self, previous, missing, *, limit=5):
         from itertools import islice

--- a/tests/interactive-sync-mapping.test.mjs
+++ b/tests/interactive-sync-mapping.test.mjs
@@ -1,0 +1,63 @@
+/* tests/interactive-sync-mapping.test.mjs */
+/* CrossWatch - Batch episode correction tests */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+import test from "node:test";
+import assert from "node:assert/strict";
+import {correctedItem, correctedEpisode, mappingGroups, sameSeason, seriesTitle} from "../assets/js/interactive-sync-mapping.js";
+
+test("a season can move to a separate show while preserving episode order and watched dates", () => {
+  const originals = Array.from({length:10}, (_,i) => ({type:"episode", series_title:"Monster", title:`S02E${i+1}`,
+    ids:{tvdb:String(1000+i)}, show_ids:{tmdb:"113988"}, season:2, episode:i+1, watched_at:"2024-09-19T08:00:00Z"}));
+  const before = structuredClone(originals);
+  const corrections = originals.map(item => correctedItem(item, {ids:{tmdb:"1398"}, title:"Another season title", season:1}));
+  assert.deepEqual(originals, before);
+  assert.deepEqual(corrections.map(item => item.episode), [1,2,3,4,5,6,7,8,9,10]);
+  for (const item of corrections) {
+    assert.deepEqual(item.ids, {tmdb:"1398"});
+    assert.deepEqual(item.show_ids, {tmdb:"1398"});
+    assert.equal(item.season, 1);
+    assert.equal(item.series_title, "Another season title");
+    assert.equal(item.watched_at, "2024-09-19T08:00:00Z");
+  }
+});
+
+test("episode offsets preserve gaps instead of renumbering by table order", () => {
+  const episodes = [21,23,27].map(episode => correctedItem({type:"episode",season:2,episode}, {season:1,offset:-20}));
+  assert.deepEqual(episodes.map(item=>item.episode), [1,3,7]);
+});
+
+test("season grouping respects source, destination, feature and season", () => {
+  const row = {source:"PLEX",source_instance:"one",provider:"SIMKL",instance:"two",feature:"history",
+    item:{type:"episode",series_title:"Monster",season:2,episode:1}};
+  assert.equal(sameSeason(row, {...row,item:{...row.item,episode:9}}), true);
+  for (const field of ["source","source_instance","provider","instance","feature"]) {
+    assert.equal(sameSeason(row,{...row,[field]:"other"}),false);
+  }
+  assert.equal(sameSeason(row,{...row,item:{...row.item,season:3}}),false);
+  assert.equal(sameSeason(row,{...row,item:{...row.item,series_title:"Another show"}}),false);
+});
+
+test("show searches use the series title without episode suffixes", () => {
+  assert.equal(seriesTitle({title:"Monster · S02E09"}), "Monster");
+  assert.equal(seriesTitle({title:"Episode name",series_title:"Monster"}), "Monster");
+});
+
+test("nonadjacent episodes group together without mixing destinations or movies", () => {
+  const episode = {source:"SIMKL", source_instance:"default", provider:"MDBLIST", instance:"one", feature:"history",
+    item:{type:"episode", title:"Monster", season:3, episode:1}};
+  const movie = {...episode,item:{type:"movie",title:"Monster"}};
+  assert.deepEqual(mappingGroups([episode,movie,{...episode,item:{...episode.item,episode:2}},
+    {...episode,instance:"two"},movie]), [[0,2],[1],[3],[4]]);
+});
+
+test("episode suggestions keep enriched IDs for the same show and discard IDs for a replaced show", () => {
+  const original = {type:"episode",title:"Monster",season:3,episode:5,watched_at:"2025-10-03T08:00:00Z",
+    ids:{tmdb:"286801",imdb:"tt1234567",mdblist:"abc"}};
+  const match = {title:"Monster: The Ed Gein Story",ids:{tmdb:"286801"},season:1,episode:5};
+  const same = correctedEpisode(original,match);
+  assert.deepEqual(same.show_ids,original.ids);
+  assert.equal(same.season,1);
+  assert.equal(same.episode,5);
+  assert.equal(same.watched_at,original.watched_at);
+  assert.deepEqual(correctedEpisode(original,{...match,ids:{tmdb:"999"}}).show_ids,{tmdb:"999"});
+});

--- a/tests/notifications.test.mjs
+++ b/tests/notifications.test.mjs
@@ -1,0 +1,105 @@
+/* tests/notifications.test.mjs */
+/* CrossWatch - Notification dismissal, persistence and profile isolation tests */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import vm from "node:vm";
+import {readFileSync} from "node:fs";
+
+const script = readFileSync(new URL("../assets/helpers/notifications.js", import.meta.url), "utf8");
+function setup(storage = new Map()) {
+  class Element {
+    hidden = false; innerHTML = ""; style = {}; dataset = {}; children = new Map(); listeners = {};
+    setAttribute() {} append() {} before() {} focus() {} contains() { return true; }
+    getBoundingClientRect() { return {bottom:40,right:900}; }
+    querySelector(selector) {
+      if (!this.children.has(selector)) this.children.set(selector, new Element());
+      return this.children.get(selector);
+    }
+    addEventListener(name, fn) { this.listeners[name] = fn; }
+  }
+  const elements = [];
+  const document = {head:new Element(),body:new Element(),getElementById:id=>id==="cw-notifications-css" ? null : new Element(),
+    createElement:()=>{const el=new Element();elements.push(el);return el;},addEventListener:(name,fn)=>events[name]=fn};
+  const events = {};
+  const window = {CW:{AuthState:{user:{id:"alice"}},OverviewProfile:{id:"home"}},
+    innerHeight:900,innerWidth:1200,addEventListener:(name,fn)=>events[name]=fn};
+  const context = {window,document,location:{href:"http://localhost/",origin:"http://localhost"},URL,
+    localStorage:{getItem:key=>storage.get(key),setItem:(key,value)=>storage.set(key,value)}};
+  vm.runInNewContext(script, context);
+  const panel = elements[2], body = panel.querySelector(".cw-notifications-body");
+  const item = (id,revision="review") => ({id,revision,title:`Review ${id}`,href:`/#review=${id}`});
+  function publish(items, name="sync-reviews", scope="profile") { window.CW.Notifications.setSource(name,{items,scope}); }
+  function clear(id,revision="review") {
+    const button = {dataset:{notificationClear:JSON.stringify(["sync-reviews",id,revision])}};
+    panel.listeners.click({target:{closest:selector=>selector==="[data-notification-clear]" ? button : null}});
+  }
+  function clearAll() {
+    panel.listeners.click({target:{closest:selector=>selector==="[data-notifications-clear-all]" ? {} : null}});
+  }
+  return {window,events,publish,clear,clearAll,item,html:()=>body.innerHTML,storage,context};
+}
+
+test("clear one survives polling and reload without clearing another review", () => {
+  const app=setup(), items=[app.item("one"),app.item("two")];
+  app.publish(items); app.clear("one"); app.publish(items);
+  assert.doesNotMatch(app.html(), /Review one/);
+  assert.match(app.html(), /Review two/);
+  const reloaded=setup(app.storage); reloaded.publish(items);
+  assert.doesNotMatch(reloaded.html(), /Review one/);
+  assert.match(reloaded.html(), /Review two/);
+});
+
+test("clear all affects current notifications but allows new notifications and status changes", () => {
+  const app=setup(); app.publish([app.item("one"),app.item("two")]); app.clearAll();
+  assert.match(app.html(), /all caught up/);
+  app.publish([app.item("one"),app.item("two","complete"),app.item("three")]);
+  assert.doesNotMatch(app.html(), /Review one/);
+  assert.match(app.html(), /Review two/);
+  assert.match(app.html(), /Review three/);
+});
+
+test("dismissals are isolated by account, profile and notification source", () => {
+  const app=setup(), items=[app.item("one")]; app.publish(items); app.clearAll();
+  app.window.CW.OverviewProfile.id="work"; app.events["cw:overview-profile-changed"](); app.publish(items);
+  assert.match(app.html(), /Review one/);
+  app.window.CW.OverviewProfile.id="home"; app.events["cw:overview-profile-changed"](); app.publish(items);
+  assert.doesNotMatch(app.html(), /Review one/);
+  app.publish(items,"another-source"); assert.match(app.html(), /Review one/);
+  app.window.CW.AuthState.user.id="bob"; app.events["auth-changed"](); app.publish(items);
+  assert.match(app.html(), /Review one/);
+});
+
+test("storage events reflect clearing in another tab", () => {
+  const app=setup(), other=setup(app.storage), items=[app.item("one")];
+  app.publish(items); other.publish(items); other.clearAll();
+  app.events.storage({key:[...app.storage.keys()][0]});
+  assert.doesNotMatch(app.html(), /Review one/);
+});
+
+test("release dismissals follow the account across profiles and allow newer releases", () => {
+  const app=setup(), release=app.item("0.12.0");
+  app.publish([release],"updates","account"); app.clearAll();
+  app.window.CW.OverviewProfile.id="work"; app.events["cw:overview-profile-changed"]();
+  app.publish([release],"updates","account"); assert.doesNotMatch(app.html(),/Review 0.12.0/);
+  app.publish([app.item("0.12.1")],"updates","account"); assert.match(app.html(),/Review 0.12.1/);
+  app.window.CW.AuthState.user.id="bob"; app.events["auth-changed"]();
+  app.publish([release],"updates","account"); assert.match(app.html(),/Review 0.12.0/);
+});
+
+test("release announcements use the read-only version endpoint and official release links", async () => {
+  const app=setup();
+  Object.assign(app.context,{AbortController,setTimeout,clearTimeout,setInterval(){},fetch:async url=>{
+    assert.equal(url,"/api/version");
+    return {ok:true,json:async()=>({current:"0.11.7",latest:"0.12.0",update_available:true})};
+  }});
+  vm.runInNewContext(readFileSync(new URL("../assets/helpers/update-notifications.js",import.meta.url),"utf8"),app.context);
+  await new Promise(resolve=>setImmediate(resolve));
+  assert.match(app.html(), /CrossWatch v0.12.0 is available/);
+  assert.match(app.html(), /https:\/\/github.com\/cenodude\/CrossWatch\/releases\/tag\/v0.12.0/);
+  assert.match(app.html(), /target="_blank" rel="noopener noreferrer"/);
+  app.events["cw:overview-profile-changed"](); assert.match(app.html(),/CrossWatch v0.12.0/);
+  app.events["cw-update-status"]({detail:{current:"0.12.0",latest:"0.12.0",available:false}});
+  assert.doesNotMatch(app.html(),/CrossWatch v0.12.0 is available/);
+});

--- a/tests/test_interactive_sync.py
+++ b/tests/test_interactive_sync.py
@@ -386,6 +386,91 @@ def test_api_rejects_cross_user_session(api_client):
     assert client.get(f"/api/interactive-sync/{session.id}", headers={"x-test-user": "bob"}).status_code == 404
 
 
+def test_review_list_is_private_and_does_not_extend_expiry(api_client, monkeypatch):
+    client, session, api = api_client
+    touched = session.touched
+    monkeypatch.setattr(api, "launch", lambda *a, **k: pytest.fail("Reopening must not start another scan"))
+    response = client.get("/api/interactive-sync")
+    assert response.status_code == 200
+    entries = response.json()["sessions"]
+    assert [entry["id"] for entry in entries] == [session.id]
+    assert entries[0]["pair"]["source"] == "SRC"
+    assert "report" not in entries[0] and "owner" not in entries[0]
+    assert session.touched == touched
+    assert client.get("/api/interactive-sync", headers={"x-test-user": "bob"}).json()["sessions"] == []
+    reopened = client.get(f"/api/interactive-sync/{entries[0]['id']}").json()
+    assert reopened["revision"] == session.revision
+    assert reopened["status"] == "review"
+
+
+def test_review_list_hides_inaccessible_and_disabled_pairs(api_client, monkeypatch):
+    client, session, api = api_client
+    monkeypatch.setattr(api, "user_can_access_pair", lambda *a: False)
+    assert client.get("/api/interactive-sync").json()["sessions"] == []
+    monkeypatch.setattr(api, "user_can_access_pair", lambda *a: True)
+    api.load_config()["pairs"][0]["enabled"] = False
+    assert client.get("/api/interactive-sync").json()["sessions"] == []
+
+
+@pytest.mark.parametrize("status", ["reading", "applying", "review", "complete", "error"])
+def test_review_list_expiry_and_running_operations(api_client, status):
+    from services import interactive_sync as svc
+
+    client, session, api = api_client
+    session.status = status
+    session.touched = -svc.SESSION_TTL
+    entries = client.get("/api/interactive-sync").json()["sessions"]
+    assert bool(entries) == (status in ("reading", "applying"))
+
+
+def test_review_list_requires_write_permission(api_client, monkeypatch):
+    client, session, api = api_client
+    monkeypatch.setattr(api, "request_user", lambda request: dict(id="alice", permissions=dict(write=False)))
+    assert client.get("/api/interactive-sync").status_code == 403
+
+
+def test_review_list_keeps_reports_until_explicitly_closed(api_client):
+    client, session, api = api_client
+    session.status = "complete"
+    assert client.get("/api/interactive-sync").json()["sessions"][0]["status"] == "complete"
+    assert client.delete(f"/api/interactive-sync/{session.id}").status_code == 200
+    assert client.get("/api/interactive-sync").json()["sessions"] == []
+
+
+def test_review_list_follows_profile_and_legacy_pair_instances(api_client, monkeypatch):
+    from services import interactive_sync as svc
+
+    client, session, api = api_client
+    cfg = api.load_config()
+    base = dict(cfg["pairs"][0])
+    cfg["pairs"][0]["profile_id"] = "alice-profile"
+    # Both profiles share endpoints: explicit assignments must still take precedence.
+    cfg["pairs"].extend([
+        {**base, "id": "p2", "profile_id": "bob-profile"},
+        {**base, "id": "legacy"},
+        {**base, "id": "other-instance", "target_instance": "other"},
+    ])
+    for pair_id in ("p2", "legacy", "other-instance"):
+        extra = svc.Session(pair_id=pair_id, owner="alice", status="review")
+        svc.SESSIONS[extra.id] = extra
+    monkeypatch.setattr(api, "profile_instances_map", lambda cfg, pid:
+                        {"SRC": ["default"], "DST": ["default"]} if pid in ("alice-profile", "bob-profile") else {})
+
+    def pair_ids(profile=""):
+        response = client.get("/api/interactive-sync", params={"user_profile": profile})
+        assert response.status_code == 200
+        return {entry["pair_id"] for entry in response.json()["sessions"]}
+
+    assert pair_ids() == {"p1", "p2", "legacy", "other-instance"}
+    assert pair_ids("alice-profile") == {"p1", "legacy"}
+    assert pair_ids("bob-profile") == {"p2", "legacy"}
+    assert pair_ids("unknown-profile") == set()
+    assert client.get("/api/interactive-sync?user_profile=bad/profile").status_code == 400
+    assert client.get("/api/interactive-sync?user_profile=alice-profile", headers={"x-test-user": "bob"}).json()["sessions"] == []
+    monkeypatch.setattr(api, "user_can_access_pair", lambda *a: False)
+    assert pair_ids("alice-profile") == set()
+
+
 @pytest.mark.parametrize("payload, status", [({"revision": 0, "selection_version": 0}, 409), ({"revision": 1, "selection_version": 9}, 409), ({"revision": 1, "selection_version": 0, "selected": ["forged"]}, 422)])
 def test_api_rejects_stale_or_invalid_selection(api_client, payload, status):
     client, session, api = api_client

--- a/tests/test_interactive_sync_catalogs.py
+++ b/tests/test_interactive_sync_catalogs.py
@@ -1,0 +1,159 @@
+# tests/test_interactive_sync_catalogs.py
+# CrossWatch - Mapping catalog availability and provider contract tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from copy import deepcopy
+
+import pytest
+import requests
+from fastapi import HTTPException
+
+from services.interactive_sync_catalogs import search_catalogs
+from services.interactive_sync_mapping import search_candidates
+
+
+CONNECTIONS = {
+    "PLEX": {"account_token": "plex-token"},
+    "JELLYFIN": {"server": "https://jellyfin.test", "user_id": "user-two", "access_token": "jf-token"},
+    "EMBY": {"server": "https://emby.test", "user_id": "user-two", "access_token": "emby-token"},
+    "KODI": {"server": "https://kodi.test", "connection_verified": True},
+    "SCROB": {"server_url": "https://scrob.test", "api_key": "scrob-key", "username": "me", "password": "pass"},
+    "TRAKT": {"client_id": "trakt-key", "access_token": "trakt-token"},
+    "MDBLIST": {"api_key": "mdblist-key"},
+    "SIMKL": {"client_id": "simkl-key", "access_token": "simkl-token"},
+    "PUNCHPLAY": {"access_token": "punchplay-token"},
+    "FLICKLIST": {"api_key": "flicklist-key"},
+    "TMDB": {"api_key": "sync-key", "session_id": "sync-session"},
+    "PUBLICMETADB": {"api_key": "publicmeta-key"},
+    "NUVIO": {"access_token": "nuvio-token", "profile_id": 2, "base_url": "https://nuvio.test"},
+    "STREMIO": {"auth_key": "stremio-key"},
+    "FLOPPY": {"server_url": "https://floppy.test", "api_token": "floppy-token"},
+}
+
+
+def context(provider, metadata=True):
+    key = "tmdb_sync" if provider == "TMDB" else provider.lower()
+    cfg = {key: {"instances": {"second": deepcopy(CONNECTIONS[provider])}}}
+    if metadata:
+        cfg["tmdb"] = {"api_key": "metadata-key"}
+    return cfg, dict(provider=provider, instance="second", item=dict(type="episode"))
+
+
+@pytest.mark.parametrize("provider", CONNECTIONS)
+def test_catalogs_require_configured_exact_instance(provider, monkeypatch):
+    def unexpected(*args, **kwargs):
+        pytest.fail("Availability checks must not access provider APIs")
+    monkeypatch.setattr(requests.Session, "request", unexpected)
+    cfg, row = context(provider)
+    options = search_catalogs(cfg, row)["catalogs"]
+    assert options and "metadata-key" not in str(options)
+    assert not search_catalogs(cfg, dict(row, instance="missing"))["catalogs"]
+    assert not search_catalogs(cfg, dict(row, instance="default"))["catalogs"]
+    with pytest.raises(HTTPException) as error:
+        search_candidates(cfg, dict(row, instance="missing"), "Monster", catalog="tmdb")
+    assert error.value.status_code == 409
+
+
+@pytest.mark.parametrize("provider", ["FLICKLIST", "PUBLICMETADB", "NUVIO", "STREMIO"])
+def test_unverified_destination_search_is_not_advertised_as_native(provider):
+    cfg, row = context(provider)
+    assert search_catalogs(cfg, row)["catalogs"] == [{"id": "tmdb", "label": "TMDb metadata"}]
+    del cfg["tmdb"]
+    assert not search_catalogs(cfg, row)["catalogs"]
+
+
+def test_bingebase_is_excluded():
+    assert not search_catalogs({"bingebase": {"api_key": "key"}, "tmdb": {"api_key": "key"}},
+                               dict(provider="BINGEBASE"))["catalogs"]
+
+
+@pytest.mark.parametrize("provider", ["JELLYFIN", "EMBY"])
+def test_server_search_uses_selected_user_and_external_ids(provider, monkeypatch):
+    cfg, row = context(provider)
+    class Response:
+        status_code = 200
+        def json(self):
+            return {"Items": [{"Name": "Monster", "ProductionYear": 2022,
+                               "Id": "internal-id", "ProviderIds": {"Tmdb": "113988", "Imdb": "tt13207736"}}]}
+    def get(self, url, **kwargs):
+        assert url == CONNECTIONS[provider]["server"] + "/Users/user-two/Items"
+        assert kwargs["headers"]["X-Emby-Token"] == CONNECTIONS[provider]["access_token"]
+        assert kwargs["params"]["IncludeItemTypes"] == "Series"
+        assert kwargs["params"]["Limit"] == 20
+        return Response()
+    monkeypatch.setattr(requests.Session, "get", get)
+    result = search_candidates(cfg, row, "Monster")
+    assert result["results"][0]["ids"] == {"tmdb": "113988", "imdb": "tt13207736"}
+
+
+def test_kodi_search_is_bounded_read_only_rpc(monkeypatch):
+    from providers.sync.kodi._common import KodiClient
+    cfg, row = context("KODI")
+    def rpc(self, method, params):
+        assert self.cfg.server == "https://kodi.test"
+        assert method == "VideoLibrary.GetTVShows"
+        assert params["limits"] == {"start": 0, "end": 20}
+        assert params["filter"]["value"] == "Monster"
+        return {"tvshows": [{"title": "Monster", "year": 2022, "uniqueid": {"tmdb": "113988"}}]}
+    monkeypatch.setattr(KodiClient, "rpc", rpc)
+    assert search_candidates(cfg, row, "Monster")["results"][0]["ids"] == {"tmdb": "113988"}
+
+
+def test_floppy_search_uses_catalog_source_ids(monkeypatch):
+    from providers.auth._auth_FLOPPY import FloppyClient
+    cfg, row = context("FLOPPY")
+    def request(self, path, **kwargs):
+        assert self.api_token == "floppy-token"
+        assert path == "search/tv/" and kwargs["params"]["source"] == "tmdb"
+        return {"results": [{"title": "Monster", "media_id": 113988, "source": "tmdb"}]}
+    monkeypatch.setattr(FloppyClient, "request_json", request)
+    assert search_candidates(cfg, row, "Monster")["results"][0]["ids"] == {"tmdb": "113988"}
+
+
+def test_scrob_search_uses_instance_auth_helper(monkeypatch):
+    from providers.auth import _auth_SCROB
+    cfg, row = context("SCROB")
+    class Response:
+        status_code = 200
+        def json(self):
+            return {"results": [{"title": "Monster", "tmdb_id": 113988, "type": "series"}]}
+    def request(client, method, url, **kwargs):
+        assert method == "GET" and url == "https://scrob.test/media/search"
+        assert kwargs["instance_id"] == "second"
+        assert kwargs["params"] == {"q": "Monster", "type": "series"}
+        return Response()
+    monkeypatch.setattr(_auth_SCROB, "request_with_auth", request)
+    assert search_candidates(cfg, row, "Monster")["results"][0]["ids"] == {"tmdb": "113988"}
+
+
+def test_punchplay_catalog_does_not_mix_movies_and_shows(monkeypatch):
+    cfg, row = context("PUNCHPLAY")
+    class Response:
+        status_code = 200
+        def json(self):
+            return {"items": [{"name": "Monster", "tmdbId": 113988, "type": "show"},
+                              {"name": "Monster", "tmdbId": 1, "type": "movie"}]}
+    def get(self, url, **kwargs):
+        assert url == "https://punchplay.tv/api/public/v1/catalog/search"
+        assert kwargs["params"] == {"q": "Monster", "type": "show"}
+        assert "headers" not in kwargs
+        return Response()
+    monkeypatch.setattr(requests.Session, "get", get)
+    result = search_candidates(cfg, row, "Monster")
+    assert len(result["results"]) == 1 and result["results"][0]["ids"] == {"tmdb": "113988"}
+
+
+def test_tmdb_sync_uses_sync_instance_key_not_metadata_key(monkeypatch):
+    cfg, row = context("TMDB")
+    keys = []
+    class Response:
+        status_code = 200
+        def json(self):
+            return {"results": [{"name": "Monster", "id": 113988}]}
+    def get(self, url, **kwargs):
+        keys.append(kwargs["params"]["api_key"])
+        return Response()
+    monkeypatch.setattr(requests.Session, "get", get)
+    search_candidates(cfg, row, "Monster")
+    result = search_candidates(cfg, row, "Monster", catalog="tmdb")
+    assert keys == ["sync-key", "metadata-key"]
+    assert "not been checked" in result["note"]

--- a/tests/test_interactive_sync_episodes.py
+++ b/tests/test_interactive_sync_episodes.py
@@ -1,0 +1,94 @@
+# tests/test_interactive_sync_episodes.py
+# CrossWatch - Episode suggestion regression tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from copy import deepcopy
+
+import pytest
+import requests
+
+from services.interactive_sync_episodes import match_episode, suggest_episodes
+
+
+CFG = {"mdblist": {"api_key": "destination"}, "tmdb": {"api_key": "metadata"}}
+
+
+def row(n=1):
+    return dict(id=str(n), provider="MDBLIST", instance="default", item=dict(type="episode", season=3, episode=n,
+                ids={"tvdb": str(1000+n)}, show_ids={"tmdb": "10"}, watched_at="2025-10-03T08:00:00Z"))
+
+
+def mock_api(monkeypatch, payloads):
+    calls = []
+    class Response:
+        status_code = 200
+        def __init__(self, body): self.body = body
+        def json(self): return self.body
+    def get(self, url, **kwargs):
+        path = url.split("/3/", 1)[1]
+        calls.append(path)
+        assert kwargs["params"]["api_key"] == "metadata"
+        return Response(payloads[path])
+    monkeypatch.setattr(requests.Session, "get", get)
+    return calls
+
+
+def test_ten_exact_episode_ids_correct_split_show_and_coordinates_without_writes(monkeypatch):
+    rows = [row(n) for n in range(1,11)]
+    before = deepcopy(rows)
+    payloads = {f"find/{1000+n}": {"tv_episode_results": [dict(show_id=20, season_number=1, episode_number=n+2)]} for n in range(1,11)}
+    payloads["tv/20"] = {"name": "Monster: Another Story"}
+    calls = mock_api(monkeypatch, payloads)
+    result = suggest_episodes(CFG, [(r, r["item"]) for r in rows])
+    assert rows == before
+    assert calls.count("tv/20") == 1
+    assert [r["match"]["episode"] for r in result["results"]] == list(range(3,13))
+    assert all(r["match"]["season"] == 1 and r["match"]["ids"] == {"tmdb": "20"} for r in result["results"])
+
+
+def test_conflicting_episode_identifiers_do_not_guess(monkeypatch):
+    r = row()
+    r["item"]["ids"]["imdb"] = "tt123"
+    mock_api(monkeypatch, {"find/1001": {"tv_episode_results": [dict(show_id=20,season_number=1,episode_number=1)]},
+                           "find/tt123": {"tv_episode_results": [dict(show_id=30,season_number=1,episode_number=1)]}})
+    result = suggest_episodes(CFG, [(r, r["item"])])["results"][0]
+    assert result["match"] is None and "disagree" in result["reason"]
+
+
+def test_title_and_air_date_match_across_seasons(monkeypatch):
+    r = row()
+    r["item"]["ids"] = {}
+    draft = {**r["item"], "show_ids": {"tmdb": "20"}}
+    mock_api(monkeypatch, {
+        "tv/10/season/3/episode/1": {"name": "A New Beginning", "air_date": "2025-10-03"},
+        "tv/20": {"name": "Monster", "seasons": [{"season_number": 1}, {"season_number": 2}]},
+        "tv/20/season/1": {"episodes": [{"name": "A New Beginning", "air_date": "2025-10-03", "season_number": 1,"episode_number": 7}]},
+        "tv/20/season/2": {"episodes": [{"name": "Unrelated", "season_number": 2, "episode_number": 1}]},
+    })
+    match = suggest_episodes(CFG, [(r, draft)])["results"][0]["match"]
+    assert match["season"] == 1 and match["episode"] == 7
+
+
+@pytest.mark.parametrize("name", ["Episode 3", "S03E03", ""])
+def test_generic_episode_names_are_not_evidence(name):
+    assert match_episode({"name": name}, [{"name": name, "season_number": 1, "episode_number": 3}]) is None
+
+
+def test_duplicate_titles_are_ambiguous_and_watched_dates_are_not_air_dates():
+    candidates = [{"name": "Pilot", "air_date": "2024-01-01"}, {"name": "Pilot", "air_date": "2025-01-01"}]
+    assert match_episode({"name": "Pilot", "watched_at": "2025-01-01"}, candidates) is None
+    assert match_episode({"name": "Pilot", "air_date": "2025-01-01"}, candidates) == candidates[1]
+
+
+def test_missing_configuration_does_not_search(monkeypatch):
+    def fail(*args, **kwargs): pytest.fail("No request expected")
+    monkeypatch.setattr(requests.Session, "get", fail)
+    r = row()
+    assert suggest_episodes({"tmdb": {"api_key": "metadata"}}, [(r,r["item"])])["results"][0]["match"] is None
+
+
+def test_failed_lookup_keeps_draft_and_hides_credentials(monkeypatch):
+    def fail(*args, **kwargs): raise requests.Timeout("api_key=SECRET")
+    monkeypatch.setattr(requests.Session, "get", fail)
+    r = row()
+    result = suggest_episodes(CFG, [(r,r["item"])])["results"][0]
+    assert result["match"] is None and "SECRET" not in str(result)

--- a/tests/test_interactive_sync_mapping.py
+++ b/tests/test_interactive_sync_mapping.py
@@ -1,0 +1,273 @@
+# tests/test_interactive_sync_mapping.py
+# CrossWatch - Batch mapping and destination search regression tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from copy import deepcopy
+
+import pytest
+
+from cw_platform.orchestrator._interactive import InteractivePlan
+from services.interactive_sync_store import ReviewStore
+from test_interactive_sync import api_client, setup_ops, item, _cfg
+
+
+def synchronous_launch(current, task, *args, prepare=None, **kwargs):
+    if prepare:
+        prepare()
+    task(current, *args)
+
+
+@pytest.mark.parametrize("selected", [True, False])
+def test_ten_corrections_one_policy_write_one_refresh(api_client, config_base, monkeypatch, selected):
+    from api import editorAPI
+    from services import interactive_sync as svc
+
+    client, session, api = api_client
+    src, dst = setup_ops(config_base, monkeypatch, [item(n) for n in range(1, 12)])
+    monkeypatch.setattr(editorAPI, "_STATE_BASE", config_base)
+    svc.refresh(session, _cfg(False), {})
+    session.store.select(True)
+    reads, writes = [], []
+    build, update = svc.build, editorAPI.sqlite_manual_policy.update_policy
+
+    def track_build(*args, **kwargs):
+        reads.append(True)
+        return build(*args, **kwargs)
+
+    def track_write(*args, **kwargs):
+        writes.append(True)
+        return update(*args, **kwargs)
+
+    monkeypatch.setattr(svc, "build", track_build)
+    monkeypatch.setattr(editorAPI.sqlite_manual_policy, "update_policy", track_write)
+    monkeypatch.setattr(api, "launch", synchronous_launch)
+    rows = list(session.plan.rows.values())
+    edits = [dict(row_id=row["id"], item=item(100 + n), selected=selected) for n, row in enumerate(rows[:10])]
+    response = client.post(f"/api/interactive-sync/{session.id}/mappings", json=dict(
+        revision=session.revision, selection_version=session.selection_version, edits=edits))
+    assert response.status_code == 200, response.text
+    assert len(reads) == len(writes) == 1
+    assert len(session.plan.rows) == 11
+    assert session.store.counts["selected"] == (11 if selected else 1)
+    assert not dst.add_calls and not src.add_calls
+    policy = editorAPI.sqlite_manual_policy.load_policy(config_base)
+    records = policy["providers"]["SRC"]["watchlist"]["mappings"]
+    assert len(records) == 10
+    for n, row in enumerate(rows[:10]):
+        record = records[next(iter(editorAPI._canonicalize_manual_items({"key": item(100+n)}, "watchlist")))]
+        assert record["original_key"] == row["key"]
+        assert record["original"]["ids"] == row["item"]["ids"]
+        assert record["origin"] == "interactive_sync"
+
+
+@pytest.mark.parametrize("bad", ["invalid_id", "missing_row", "duplicate_row", "duplicate_target", "bad_episode"])
+def test_invalid_batch_saves_nothing(api_client, config_base, monkeypatch, bad):
+    from api import editorAPI
+
+    client, session, api = api_client
+    monkeypatch.setattr(editorAPI, "_STATE_BASE", config_base)
+    session.plan.filter("watchlist", "DST", "default", "add", [item(2)], source="SRC")
+    session.store.finish()
+    rows = list(session.plan.rows)
+    edits = [dict(row_id=rows[0], item=item(10)), dict(row_id=rows[1], item=item(20))]
+    if bad == "invalid_id": edits[1]["item"]["ids"] = {"tmdb": "bad"}
+    if bad == "missing_row": edits[1]["row_id"] = "forged"
+    if bad == "duplicate_row": edits[1]["row_id"] = rows[0]
+    if bad == "duplicate_target": edits[1]["item"] = item(10)
+    if bad == "bad_episode": edits[1]["item"].update(type="episode", season=1, episode=0)
+    monkeypatch.setattr(api, "launch", lambda *a, **k: pytest.fail("Invalid batch reached save"))
+    response = client.post(f"/api/interactive-sync/{session.id}/mappings", json=dict(revision=1, selection_version=0, edits=edits))
+    assert response.status_code == 400
+    assert editorAPI._load_policy_manual("watchlist", "SRC") == ({}, [])
+
+
+def test_ids_and_episode_changed_together_preserve_watch_value(api_client, config_base, monkeypatch):
+    from api import editorAPI
+
+    client, session, api = api_client
+    monkeypatch.setattr(editorAPI, "_STATE_BASE", config_base)
+    original = dict(type="episode", title="Monster", season=2, episode=9, ids={"tvdb": "10649177"},
+                    watched_at="2024-09-19T08:00:00Z", _trakt_history_id="private-event")
+    session.plan.filter("history", "DST", "second", "add", [original], source="SRC")
+    row = next(row for row in session.plan.rows.values() if row["feature"] == "history")
+    corrected = dict(original, ids={"tmdb": "1398"}, show_ids={"tmdb": "1398"}, season=1)
+    corrected["watched_at"] = "2099-01-01T00:00:00Z"
+    launches = []
+
+    def launch(current, task, *args, prepare=None, **kwargs):
+        prepare()
+        launches.append(args[-1])
+
+    monkeypatch.setattr(api, "launch", launch)
+    response = client.post(f"/api/interactive-sync/{session.id}/mappings", json=dict(
+        revision=1, selection_version=0, edits=[dict(row_id=row["id"], item=corrected)]))
+    assert response.status_code == 200
+    adds, blocks = editorAPI._load_policy_manual("history", "SRC")
+    saved = next(iter(adds.values()))
+    assert saved["ids"] == saved["show_ids"] == {"tmdb": "1398"}
+    assert (saved["season"], saved["episode"]) == (1, 9)
+    assert saved["watched_at"] == original["watched_at"]
+    assert "_trakt_history_id" not in saved
+    assert row["key"] in blocks
+    assert launches[0][0]["identity"][-1] == "second"
+
+
+def test_unresolved_starts_unchecked_but_can_be_retried():
+    store = ReviewStore()
+    try:
+        plan = InteractivePlan(rows=store.rows)
+        plan.filter("watchlist", "DST", "default", "add", [dict(type="movie", title="Needs lookup"), item(1)])
+        store.finish()
+        unresolved = next(row for row in store.page()["items"] if row["result"] == "unresolved")
+        assert unresolved["selectable"] and not unresolved["selected"]
+        assert store.counts["selected"] == 1
+        store.select(True, ids=[unresolved["id"]])
+        assert store.counts["selected"] == 2
+    finally:
+        store.close()
+
+
+def test_corrected_selection_stays_with_its_route_and_skips_unresolved():
+    store = ReviewStore()
+    try:
+        plan = InteractivePlan(rows=store.rows)
+        for instance in ("one", "two"):
+            plan.filter("history", "DST", instance, "update", [item(1)], source="SRC", source_instance="source-one")
+        unresolved = dict(type="movie", title="Still unresolved")
+        plan.filter("history", "DST", "one", "add", [unresolved], source="SRC", source_instance="source-one")
+        store.finish()
+        store.select(False)
+        pending = next(row for row in store.rows.values() if row["result"] == "unresolved")
+        store.select_corrected([
+            dict(identity=("history", "imdb:tt0000001", "SRC", "source-one", "DST", "one"), selected=True),
+            dict(identity=("history", pending["key"], "SRC", "source-one", "DST", "one"), selected=True),
+        ])
+        selected = [row for row in store.page()["items"] if row["selected"]]
+        assert len(selected) == 1 and selected[0]["instance"] == "one"
+        assert selected[0]["result"] == "update"
+    finally:
+        store.close()
+
+
+def test_batch_limit_rejects_oversized_request(api_client):
+    client, session, api = api_client
+    edit = dict(row_id=next(iter(session.plan.rows)), item=item(1))
+    response = client.post(f"/api/interactive-sync/{session.id}/mappings", json=dict(revision=1, selection_version=0, edits=[edit] * 201))
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("path", ["mappings", "mapping-search", "mapping-catalogs", "mapping-episodes"])
+def test_mapping_requires_current_revision_and_owner(api_client, path):
+    client, session, api = api_client
+    row = next(iter(session.plan.rows))
+    def request(revision, user="alice", version=0):
+        if path in {"mapping-search", "mapping-catalogs"}:
+            return client.get(f"/api/interactive-sync/{session.id}/{path}", params=dict(revision=revision, row_id=row, q="Movie"), headers={"x-test-user": user})
+        return client.post(f"/api/interactive-sync/{session.id}/{path}", json=dict(revision=revision, selection_version=version,
+            edits=[dict(row_id=row, item=item(2))]), headers={"x-test-user":user})
+    assert request(0).status_code == 409
+    assert request(1, "bob").status_code == 404
+    if path == "mappings": assert request(1, version=9).status_code == 409
+
+
+@pytest.mark.parametrize("provider,body,expected", [
+    ("MDBLIST", {"search":[{"title":"Monster", "year":2022, "id":"tt13207736", "tmdbid":113988}]}, {"imdb":"tt13207736", "tmdb":"113988"}),
+    ("SIMKL", [{"title":"Monster", "year":2022, "ids":{"simkl_id":123, "tmdb":113988}}], {"simkl":"123", "tmdb":"113988"}),
+    ("TRAKT", [{"show":{"title":"Monster", "year":2022, "ids":{"trakt":123, "tmdb":113988}}}], {"trakt":"123", "tmdb":"113988"}),
+    ("PLEX", {"MediaContainer":{"Metadata":[{"title":"Monster", "type":"show", "year":2022, "Guid":[{"id":"tmdb://113988"}]}]}}, {"tmdb":"113988"}),
+])
+def test_destination_search_normalizes_and_uses_instance(monkeypatch, provider, body, expected):
+    from services.interactive_sync_mapping import search_candidates
+    from providers.sync.mdblist import _auth
+    import requests
+
+    calls = []
+    class Response:
+        status_code = 200
+        def json(self): return body
+    def get(self, url, **kwargs):
+        calls.append((url, kwargs))
+        return Response()
+    monkeypatch.setattr(requests.Session, "get", get)
+    def authenticated(client, method, url, **kwargs):
+        assert kwargs["instance_id"] == "second"
+        return get(client, url, **kwargs)
+    monkeypatch.setattr(_auth, "request_with_auth", authenticated)
+    cfg = {provider.lower(): {"client_id":"default-key", "instances":{"second":{"client_id":"second-key", "api_key":"second-key", "access_token":"second-token", "account_token":"plex-second-token"}}},
+           "tmdb":{"api_key":"metadata-key"}}
+    result = search_candidates(cfg, dict(provider=provider, instance="second", item=dict(type="episode")), "Monster")
+    assert result["results"][0]["ids"] == expected
+    assert result["results"][0]["exact_title"]
+    assert "key" not in str(result)
+    if provider == "SIMKL": assert calls[0][1]["params"]["client_id"] == "second-key"
+    if provider == "TRAKT": assert calls[0][1]["headers"]["trakt-api-key"] == "second-key"
+    if provider == "PLEX": assert calls[0][1]["headers"]["X-Plex-Token"] == "plex-second-token"
+
+
+def test_search_failure_does_not_expose_credentials(monkeypatch):
+    import requests
+    from fastapi import HTTPException
+    from services.interactive_sync_mapping import search_candidates
+
+    def fail(*args, **kwargs): raise requests.Timeout("https://example/?api_key=SECRET")
+    monkeypatch.setattr(requests.Session, "get", fail)
+    with pytest.raises(HTTPException) as error:
+        search_candidates({"plex":{"account_token":"SECRET"}}, dict(provider="PLEX", item=dict(type="movie")), "Title")
+    assert error.value.status_code == 502
+    assert "SECRET" not in error.value.detail
+
+
+@pytest.mark.parametrize("entity", ["movie", "show"])
+def test_mdblist_search_fetches_external_ids_in_one_batch(monkeypatch, entity):
+    from services.interactive_sync_mapping import search_candidates
+    from providers.sync.mdblist import _auth
+
+    calls = []
+    class Response:
+        status_code = 200
+        def __init__(self, body): self.body = body
+        def json(self): return self.body
+    def request(client, method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        assert kwargs["instance_id"] == "second"
+        if method == "GET":
+            return Response({"search": [{"title": "Monster", "ids": {"mdblist": "o6b1"}},
+                                        {"title": "Another title", "ids": {"mdblist": "n3n8"}}]})
+        assert kwargs["json"] == {"ids": ["o6b1", "n3n8"]}
+        return Response([{"mdblist_id": "n3n8", "tmdbid": 22, "imdbid": "tt22222"},
+                         {"mdblist_id": "o6b1", "tmdbid": 11, "imdbid": "tt11111"}])
+    monkeypatch.setattr(_auth, "request_with_auth", request)
+    cfg = {"mdblist": {"instances": {"second": {"api_key": "test-key"}}}}
+    result = search_candidates(cfg, {"provider": "MDBLIST", "instance": "second", "item": {"type": entity}}, "Monster")
+    assert result["results"][0]["ids"] == {"mdblist": "o6b1", "tmdb": "11", "imdb": "tt11111"}
+    assert result["results"][1]["ids"]["tmdb"] == "22"
+    assert len(calls) == 2
+    assert calls[1][1] == f"https://api.mdblist.com/mdblist/{entity}/"
+    assert all(not item.get("mapping_unavailable") for item in result["results"])
+
+
+@pytest.mark.parametrize("failure", ["timeout", "http", "missing", "wrong_id", "ambiguous", "malformed"])
+def test_mdblist_incomplete_matches_cannot_replace_mapping(monkeypatch, failure):
+    import requests
+    from services.interactive_sync_mapping import search_candidates
+    from providers.sync.mdblist import _auth
+
+    class Response:
+        status_code = 200
+        def __init__(self, body): self.body = body
+        def json(self): return self.body
+    def request(client, method, url, **kwargs):
+        if method == "GET":
+            return Response({"search": [{"title": "Monster", "ids": {"mdblist": "o6b1"}}]})
+        if failure == "timeout": raise requests.Timeout("SECRET")
+        if failure == "http":
+            response = Response({}); response.status_code = 429; return response
+        if failure == "wrong_id": return Response([{"mdblist_id": "other", "tmdbid": 11}])
+        if failure == "ambiguous": return Response([{"mdblist_id": "o6b1", "tmdbid": n} for n in (11, 22)])
+        if failure == "malformed": return Response({"error": "SECRET"})
+        return Response([{"mdblist_id": "o6b1"}])
+    monkeypatch.setattr(_auth, "request_with_auth", request)
+    result = search_candidates({"mdblist": {"api_key": "test-key"}},
+                               {"provider": "MDBLIST", "item": {"type": "show"}}, "Monster")
+    assert result["results"][0]["ids"] == {"mdblist": "o6b1"}
+    assert "TMDb ID" in result["results"][0]["mapping_unavailable"]
+    assert "SECRET" not in str(result)

--- a/tests/test_interactive_sync_paging.py
+++ b/tests/test_interactive_sync_paging.py
@@ -54,6 +54,32 @@ def test_fifty_thousand_rows_have_bounded_responses_and_server_selection(api_cli
                          status_bytes=len(status.content), last_page_bytes=len(last_response.content), sqlite_bytes=session.store.path.stat().st_size)))
 
 
+def test_mapping_rows_filter_selection_before_paging(api_client):
+    client, session, api = api_client
+    session.close()
+    session.store = ReviewStore()
+    session.plan = InteractivePlan(rows=session.store.rows, conflicts=session.store.conflicts, copy_rows=False)
+    session.plan.filter("history", "DST", "default", "remove", (item(i) for i in range(300)), source="SRC")
+    session.plan.filter("history", "DST", "default", "add", (item(i) for i in range(300, 5300)), source="SRC")
+    session.store.finish()
+    all_rows = list(session.store.rows.values())
+    chosen = [r["id"] for r in all_rows[:300] + all_rows[-3:]]
+    session.store.select(False)
+    session.store.select(True, ids=chosen)
+    params = dict(revision=1, selected_only=True, editable_only=True, limit=2)
+    first = client.get(f"/api/interactive-sync/{session.id}/rows", params=params).json()
+    last = client.get(f"/api/interactive-sync/{session.id}/rows", params={**params, "offset": 2}).json()
+    assert first["total"] == last["total"] == 3
+    assert len(first["items"]) == 2 and len(last["items"]) == 1
+    returned = first["items"] + last["items"]
+    assert {r["id"] for r in returned} == set(chosen[-3:])
+    assert all(r["selected"] and r["operation"] == "add" for r in returned)
+    assert session.store.counts["selected"] == 303
+    session.store.select(False)
+    empty = client.get(f"/api/interactive-sync/{session.id}/rows", params=params).json()
+    assert empty["total"] == 0 and empty["items"] == []
+
+
 def test_conflicts_share_bounded_paging(api_client):
     client, session, api = api_client
     for i in range(1200):

--- a/tests/test_interactive_sync_report.py
+++ b/tests/test_interactive_sync_report.py
@@ -218,3 +218,52 @@ def test_report_issue_api_is_paged_and_session_scoped(api_client):
     assert client.get(url, params=dict(limit=201)).status_code == 422
     assert client.get(url, headers={"x-test-user":"bob"}).status_code == 404
     assert client.get(url.replace(session.id,"missing")).status_code == 404
+
+
+@pytest.mark.parametrize("feature", FEATURES)
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_mapping_exclusions_are_informational_and_still_suppress_originals(config_base, monkeypatch, feature, mode):
+    from api import editorAPI
+    from cw_platform.id_map import canonical_key
+
+    original, corrected = feature_item(feature, 1), feature_item(feature, 2)
+    cfg, src, dst = feature_setup(config_base, monkeypatch, feature, [original], [], mode)
+    monkeypatch.setattr(editorAPI, "_STATE_BASE", config_base)
+    editorAPI._save_policy_manual(feature, "SRC", {canonical_key(corrected): corrected}, [canonical_key(original)])
+    preview = InteractivePlan()
+    run(cfg, preview)
+    assert {row["key"] for row in preview.rows.values()} == {canonical_key(corrected)}
+    collector = SyncReport()
+    execution = InteractivePlan(preview=False, selected=set(preview.rows), on_result=collector.record)
+    result = run(cfg, execution)
+    report = collector.finish(Session(pair_id="p1", owner="local"), execution, result)
+    assert report["outcome"] == "success"
+    assert report["manual_excluded"] == report["engine_blocked"] == result["blocked"] == 1
+    assert report["totals"]["blocked"] == report["features"][0]["blocked"] == 0
+    assert report["totals"]["added"] == 1
+    assert report["features"][0]["manual_excluded"] == 1
+    if mode == "one-way":
+        assert report["features"][0]["destinations"][0]["blocked"] == 0
+    assert [canonical_key(it) for batch in dst.add_calls for it in batch] == [canonical_key(corrected)]
+    assert not src.add_calls
+
+
+@pytest.mark.parametrize("result", [{"ok": True, "blocked": 13}, None])
+def test_manual_exclusions_do_not_hide_other_protection_blocks(result):
+    collector = SyncReport()
+    collector.record("history", "SIMKL", "MDBLIST", "default", "other", "one-way",
+                     {"updated": 7, "blocked": 13, "manual_excluded": 11})
+    report = collector.finish(Session(pair_id="p1", owner="local"), InteractivePlan(preview=False), result)
+    assert report["manual_excluded"] == 11
+    assert report["engine_blocked"] == 13
+    assert report["totals"]["blocked"] == report["features"][0]["blocked"] == 2
+    assert report["outcome"] == ("attention" if result else "incomplete")
+
+
+def test_report_without_exclusion_breakdown_keeps_all_blocks():
+    collector = SyncReport()
+    collector.record("history", "SIMKL", "MDBLIST", "default", "other", "one-way", {"blocked": 11})
+    report = collector.finish(Session(pair_id="p1", owner="local"), InteractivePlan(preview=False), {"ok": True, "blocked": 11})
+    assert report["totals"]["blocked"] == report["engine_blocked"] == 11
+    assert report["manual_excluded"] == 0
+    assert report["outcome"] == "attention"


### PR DESCRIPTION
# Pull request

## Change

Expanded Interactive Sync with bulk mapping and easier access to ongoing reviews.
- Correct titles, IDs, seasons and episodes through a shared mapping dialog.
- Search configured provider catalogs and use Auto match for suggestions.
- Save mappings and automatically select corrected changes in the refreshed review.
- Report saved exclusions separately from protection blocks.
- Resume reviews and view reports below the configured sync pairs.
- Add profile-aware review notifications and release updates to the new notification bell.
- Clear individual notifications or all visible notifications.

## Why

- Easier way to correct mismatches.

## Testing

- test_interactive_sync.py
- test_interactive_sync_paging.py
- test_interactive_sync_report.py
- test_interactive_sync_catalogs.py
- test_interactive_sync_episodes.py
- test_interactive_sync_mapping.py
- interactive-sync-mapping.test.mjs
- notifications.test.mjs

## Issue

Relates to #1018.