### PR TITLE
Change: preserve sync feature metadata

### DIFF
--- a/api/logsAPI.py
+++ b/api/logsAPI.py
@@ -18,7 +18,14 @@ from services.log_archive import archive, MAX_BYTES, RETENTION_DAYS
 router = APIRouter(prefix='/api/logs/archive', tags=['logging'])
 
 
+def debug_enabled(cfg: dict) -> bool:
+    runtime = cfg.get('runtime') or {}
+    return bool(runtime.get('debug') or runtime.get('debug_mods'))
+
+
 def allowed(request: Request, session: dict) -> bool:
+    if session['channel'] == 'debug' and not debug_enabled(load_config() or {}):
+        return False
     user = request_user(request)
     profile = requested_view_as_profile(request)
     if (not user or user.get('is_admin')) and not profile:
@@ -50,7 +57,8 @@ def sessions(request: Request, channel: Literal['sync', 'watcher', 'debug'] = 's
     sync_logs = [item for item in store.sessions('sync') if allowed(request, item)]
     choices = {}
     # Include configured pairs with no logs yet, and retained logs for removed pairs.
-    configured = (load_config() or {}).get('pairs') or []
+    cfg = load_config() or {}
+    configured = cfg.get('pairs') or []
     for pair in configured:
         if isinstance(pair, dict) and allowed(request, dict(channel='sync', pairs=json.dumps([pair]))):
             choices[str(pair.get('id') or '')] = pair
@@ -69,7 +77,10 @@ def sessions(request: Request, channel: Literal['sync', 'watcher', 'debug'] = 's
         items = [dict(item, **store.counts(item['id'], pair_id, run_id)) for item in items]
     user = request_user(request)
     admin = (not user or bool(user.get('is_admin'))) and not requested_view_as_profile(request)
-    return dict(items=items, pairs=pairs, latest_run_id=latest, channels=['sync', 'watcher', 'debug'] if admin else ['sync'], retention_days=RETENTION_DAYS,
+    channels = ['sync', 'watcher'] if admin else ['sync']
+    if admin and debug_enabled(cfg):
+        channels.append('debug')
+    return dict(items=items, pairs=pairs, latest_run_id=latest, channels=channels, retention_days=RETENTION_DAYS,
                 max_bytes=MAX_BYTES, used_bytes=archive().used if admin else sum(item['bytes'] for item in items))
 
 

--- a/api/syncAPI.py
+++ b/api/syncAPI.py
@@ -789,7 +789,7 @@ def _run_pairs_thread(run_id: str, overrides: dict | None = None, *, interactive
         requested = str(overrides.get("pair_id") or overrides.get("pair_scope") or "").strip()
         raw_log_scope = overrides.get("pair_scope_ids")
         scope = {str(value or '').strip() for value in raw_log_scope if str(value or '').strip()} if isinstance(raw_log_scope, list) else set()
-        log_pairs = [{key: p.get(key) for key in ("id", "source", "source_instance", "src_instance", "target", "target_instance", "dst_instance", "mode")}
+        log_pairs = [{key: p.get(key) for key in ("id", "source", "source_instance", "src_instance", "target", "target_instance", "dst_instance", "mode", "features")}
                      for p in log_cfg.get("pairs", []) if isinstance(p, dict) and coerce_bool(p.get("enabled", True), True)
                      and (not requested or str(p.get("id")) == requested)
                      and (not scope or str(p.get("id") or '').strip() in scope)]

--- a/cw_platform/orchestrator/_pairs.py
+++ b/cw_platform/orchestrator/_pairs.py
@@ -662,7 +662,7 @@ def run_pairs(ctx) -> dict[str, Any]:
         emit(
             "debug",
             msg="state.persisted",
-            providers=len((ctx.providers or {})),
+            loaded_adapters=len((ctx.providers or {})),
             wall=(len(wall) if isinstance(wall, dict) else 0),
         )
     except Exception:

--- a/cw_platform/orchestrator/facade.py
+++ b/cw_platform/orchestrator/facade.py
@@ -459,7 +459,7 @@ class Orchestrator:
             self.state_store.set_last_sync_epoch(last_sync_epoch)
         self.dbg(
             "state.persisted",
-            providers=len(touched),
+            saved_state_providers=len(touched),
             wall=0,
         )
         return {"providers": {name: {} for name in sorted(touched)}, "last_sync_epoch": last_sync_epoch}
@@ -520,7 +520,7 @@ class Orchestrator:
         self.state_store.set_last_sync_epoch(last_sync_epoch)
         self.dbg(
             "state.persisted",
-            providers=len(providers),
+            saved_state_providers=len(providers),
             wall=len(uniq),
         )
         return state

--- a/services/log_archive.py
+++ b/services/log_archive.py
@@ -21,7 +21,7 @@ from cw_platform.log_context import log_pair_id, log_run_id
 RETENTION_DAYS = 7
 MAX_BYTES = 100 * 1024 * 1024
 ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
-LEVEL = re.compile(r"(?:^|\]\s+|\d{2}:\d{2}:\d{2}\s+)(ERROR|CRITICAL|WARNING|WARN|DEBUG|INFO|SUCCESS)\b", re.I)
+LEVEL = re.compile(r"(?:^|\]\s+|\d{2}:\d{2}:\d{2}\s+|\[)(ERROR|CRITICAL|WARNING|WARN|DEBUG|INFO|SUCCESS)\b", re.I)
 
 
 def describe_line(text: str, tag: str) -> tuple[str, str, str]:
@@ -30,7 +30,8 @@ def describe_line(text: str, tag: str) -> tuple[str, str, str]:
     level = (matches[-1].upper() if matches else "WARN" if text.startswith("[!]") else "INFO")
     level = {"WARNING": "WARN", "CRITICAL": "ERROR", "SUCCESS": "INFO"}.get(level, level)
     provider = tag.upper()
-    tags = re.findall(r"\[([A-Z][A-Z0-9_-]*)(?::[^\[\]]+)?\]", text)
+    tags = [value for value in re.findall(r"\[([A-Z][A-Z0-9_-]*)(?::[^\[\]]+)?\]", text)
+            if value not in {'ERROR', 'CRITICAL', 'WARNING', 'WARN', 'DEBUG', 'INFO', 'SUCCESS'}]
     if tags:
         provider = tags[-1]
     try:

--- a/tests/test_log_archive.py
+++ b/tests/test_log_archive.py
@@ -135,10 +135,68 @@ def test_structured_error_levels():
     assert describe_line('{"provider":"SIMKL","level":"WARN","msg":"rate_limited"}', 'DEBUG')[1:] == ('WARN', 'SIMKL')
 
 
+@pytest.mark.parametrize('text,level,provider', [
+    ('[DEBUG] snapshot loaded', 'DEBUG', 'SYNC'),
+    ('[SYNC] INFO [DEBUG] snapshot loaded', 'DEBUG', 'SYNC'),
+    ('[TRAKT:history] [DEBUG] index cache hit', 'DEBUG', 'TRAKT'),
+    ('2026-09-07T20:48:20.486+00:00 [SYNC] [DEBUG] detail', 'DEBUG', 'SYNC'),
+    ('[WARN] rate limited', 'WARN', 'SYNC'),
+    ('[PLEX] [ERROR] failed', 'ERROR', 'PLEX'),
+    ('[PLEX] INFO debug logging enabled', 'INFO', 'PLEX'),
+])
+def test_bracketed_levels_are_not_mistaken_for_providers(text, level, provider):
+    assert describe_line(text, 'SYNC')[1:] == (level, provider)
+
+
+def test_orchestrator_debug_messages_are_searchable_by_level(store):
+    from cw_platform.orchestrator._logging import Emitter
+    sid = store.start('debug-run', [])
+    emitter = Emitter(lambda text: store.append('sync', 'SYNC', text))
+    emitter.dbg(True, 'snapshot loaded')
+    emitter.dbg(True, 'state.persisted', saved_state_providers=2)
+    emitter.dbg(False, 'not emitted')
+    emitter.info('Normal sync message')
+    result = store.page(sid, level='DEBUG')
+    assert result['total'] == 2
+    assert {row['provider'] for row in result['items']} == {'SYNC'}
+    assert 'snapshot loaded' in ''.join(store.export(sid, level='DEBUG'))
+    assert store.page(sid, level='INFO')['total'] == 1
+
+
+@pytest.mark.parametrize('runtime,enabled', [
+    ({}, False), ({'debug': False, 'debug_mods': False}, False),
+    ({'debug': True}, True), ({'debug_mods': True}, True),
+    ({'debug': True, 'debug_mods': True, 'debug_http': True}, True),
+    ({'debug_http': True}, False),
+])
+def test_debug_archive_access_follows_runtime_setting(monkeypatch, store, runtime, enabled):
+    from api import logsAPI
+    cfg = {'runtime': runtime}
+    monkeypatch.setattr(logsAPI, 'archive', lambda: store)
+    monkeypatch.setattr(logsAPI, 'load_config', lambda: cfg)
+    store.append('debug', 'META', '[DEBUG] detail')
+    sid = store.sessions('debug')[0]['id']
+    line_id = store.page(sid)['items'][0]['id']
+    app = FastAPI()
+    app.include_router(logsAPI.router)
+    with TestClient(app) as client:
+        listing = client.get('/api/logs/archive?channel=debug').json()
+        assert ('debug' in listing['channels']) == enabled
+        assert bool(listing['items']) == enabled
+        for path in ('lines', f'context/{line_id}', 'download'):
+            assert client.get(f'/api/logs/archive/{sid}/{path}').status_code == (200 if enabled else 404)
+        assert client.patch(f'/api/logs/archive/{sid}', json={'pinned': True}).status_code == (200 if enabled else 404)
+        cfg['runtime'] = {'debug': False, 'debug_mods': False}
+        assert 'debug' not in client.get('/api/logs/archive').json()['channels']
+        assert client.get(f'/api/logs/archive/{sid}/lines').status_code == 404
+        assert client.delete(f'/api/logs/archive/{sid}').status_code == 404
+        assert store.session(sid) is not None
+
+
 def test_api_scopes_every_read_export_pin_and_delete(monkeypatch, store):
     from api import logsAPI
     monkeypatch.setattr(logsAPI, 'archive', lambda:store)
-    monkeypatch.setattr(logsAPI, 'load_config', lambda:{})
+    monkeypatch.setattr(logsAPI, 'load_config', lambda:{'runtime':{'debug':True}})
     monkeypatch.setattr(logsAPI, 'user_can_access_instance', lambda cfg,user,provider,instance:provider=='PLEX')
     mine=store.start('mine', [{'id':'mine','source':'PLEX','target':'PLEX'}]);store.append('sync','SYNC','INFO own log');store.finish(mine,'completed')
     theirs=store.start('theirs',[{'id':'theirs','source':'TRAKT','target':'TRAKT'}]);store.append('sync','SYNC','ERROR private log');store.finish(theirs,'failed')
@@ -228,7 +286,7 @@ def test_pair_api_latest_run_counts_context_and_debug_run(monkeypatch, store):
     old = record_pair_run(store, 'run-one', pairs)
     new = record_pair_run(store, 'run-two', pairs[:1])
     monkeypatch.setattr(logsAPI, 'archive', lambda:store)
-    monkeypatch.setattr(logsAPI, 'load_config', lambda:{'pairs':pairs})
+    monkeypatch.setattr(logsAPI, 'load_config', lambda:{'pairs':pairs, 'runtime':{'debug':True}})
     app = FastAPI(); app.include_router(logsAPI.router)
     with TestClient(app) as client:
         result = client.get('/api/logs/archive?pair_id=b').json()

--- a/tests/test_sync_cancel.py
+++ b/tests/test_sync_cancel.py
@@ -339,6 +339,26 @@ def test_normal_run_is_not_marked_cancelled(monkeypatch, tmp_path) -> None:
     assert any("Done. Total added: 1" in line for line in log["SYNC"])
 
 
+def test_saved_run_keeps_feature_settings_from_start(monkeypatch, tmp_path) -> None:
+    from services import log_archive
+
+    sync, _events, _log = _run_thread_harness(monkeypatch, tmp_path, {"added": 1})
+    cfg = sync._env()[0]()
+    cfg["pairs"][0]["features"] = {"watchlist": {"enable": True}, "history": {"enable": False}}
+    store = log_archive.LogArchive(tmp_path / "features.db")
+    monkeypatch.setattr(log_archive, "archive", lambda: store)
+    try:
+        sync._run_pairs_thread("run-features", {"pair_id": "plex-trakt"})
+        cfg["pairs"][0]["features"]["watchlist"]["enable"] = False
+        saved = store.sessions("sync", run_id="run-features")
+        assert len(saved) == 1
+        assert json.loads(saved[0]["pairs"])[0]["features"] == {
+            "watchlist": {"enable": True}, "history": {"enable": False},
+        }
+    finally:
+        store.close()
+
+
 def test_final_unresolved_summary_uses_deduped_orchestrator_count(monkeypatch, tmp_path) -> None:
     item = {
         "type": "episode",


### PR DESCRIPTION
# Pull request

## Change

- Correct severity detection for bracketed DEBUG messages.
- Restrict debug log access to when debugging is enabled.
- Distinguish loaded adapters from saved-state providers in diagnostics.
- Preserve enabled features in archived sync-pair metadata.

## Why

Make diagnostic levels and provider counts accurate, and retain the feature settings used during each saved run.

## Testing

- test_log_archive.py
- test_sync_cancel.py.

## Issue

NA