### PR TITLE
Change: log readability

### DIFF
--- a/assets/css/logs.css
+++ b/assets/css/logs.css
@@ -4,7 +4,8 @@
 
 html[data-tab="logs"] { overflow: hidden; }
 #page-logs { padding: 0; background: transparent; border: 0; box-shadow: none; }
-.logs-page { display: flex; flex-direction: column; min-height: 0; padding: 12px 8px 0; color: var(--fg, #edf0f8); --log-line: var(--border, #ffffff16); --log-surface: var(--panel, #101217); --log-muted: var(--muted, #9296aa); }
+#page-logs,.logs-page { min-width: 0; width: 100%; max-width: 100%; box-sizing: border-box; }
+.logs-page { display: flex; flex-direction: column; min-height: 0; padding: 12px 8px 0; color: var(--cw-theme-text, var(--fg, #edf0f8)); --log-line: var(--cw-theme-border, var(--border, #ffffff16)); --log-surface: var(--cw-theme-surface, var(--panel, #101217)); --log-muted: var(--cw-theme-muted, var(--muted, #9296aa)); }
 .logs-page [hidden] { display: none!important; }
 .logs-back { display: inline-flex; align-items: center; align-self: flex-start; gap: 8px; color: var(--log-muted); text-decoration: none; font-size: 13px; }
 .logs-heading { position: static; z-index: auto; display: flex; align-items: center; justify-content: space-between; padding: 14px 0; background: transparent; border: 0; box-shadow: none; }
@@ -12,11 +13,28 @@ html[data-tab="logs"] { overflow: hidden; }
 .logs-eyebrow { color: var(--accent); font-size: 10px; letter-spacing: .2em; font-weight: 700; }
 .logs-heading > span, .logs-toolbar > span { color: var(--log-muted); font-size: 12px; }
 .logs-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; margin-bottom: 12px; }
-.logs-toolbar > [data-storage] { margin-left: auto; }
+.logs-connection { display: inline-flex; align-items: center; gap: 8px; margin-left: auto; padding: 8px 0; }
+.logs-connection[data-state="live"] .material-symbols-rounded { color: #50b88f; }
+.logs-connection[data-state="error"] { color: #ef8791; }
+.logs-controls { padding: 12px; background: var(--log-surface); border: 1px solid var(--log-line); border-radius: 12px; }
+.logs-storage { margin-left: auto; width: 240px; max-width: 100%; color: var(--log-muted); font-size: 11px; }
+.logs-storage-copy { display: flex; align-items: center; justify-content: space-between; gap: 14px; margin-bottom: 7px; }
+.logs-storage-copy > span:first-child { display: inline-flex; align-items: center; gap: 6px; color: var(--cw-theme-text, var(--fg)); font-variant-numeric: tabular-nums; }
+.logs-storage progress { display: block; width: 100%; height: 5px; overflow: hidden; appearance: none; border: 0; border-radius: 10px; background: color-mix(in srgb, var(--log-muted) 15%, transparent); color: var(--accent); accent-color: var(--accent); --storage-fill: var(--accent); }
+.logs-storage progress::-webkit-progress-bar { background: color-mix(in srgb, var(--log-muted) 15%, transparent); border-radius: 10px; }
+.logs-storage progress::-webkit-progress-value { background: var(--storage-fill); border-radius: 10px; }
+.logs-storage progress::-moz-progress-bar { background: var(--storage-fill); border-radius: 10px; }
+.logs-storage[data-usage="warning"] progress { --storage-fill: #e8bb69; }
+.logs-storage[data-usage="high"] progress { --storage-fill: #ef8791; }
 .logs-pair-controls { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; min-width: 0; }
 .logs-page [data-pair], .logs-page [data-pair] + .cw-icon-select { width: 310px; max-width: 100%; }
 .logs-page [data-level], .logs-page [data-level] + .cw-icon-select { width: 140px; flex-shrink: 0; }
 .logs-pair-controls .cw-icon-select-btn { width: 100%; }
+html[data-cw-theme="flat-dark"] #page-logs :is(select,.cw-icon-select-btn) { background: var(--cw-theme-surface, #101217)!important; background-image: none!important; border-color: var(--cw-theme-border, #292d36)!important; color: var(--cw-theme-text, #f1f3f5)!important; box-shadow: none!important; }
+html[data-cw-theme="flat-dark"] #page-logs :is(select,.cw-icon-select-btn):is(:hover,:focus-visible,[aria-expanded="true"]) { border-color: var(--accent)!important; }
+html[data-cw-theme="flat-dark"][data-tab="logs"] .cw-icon-select-menu { background: var(--cw-theme-surface, #101217)!important; background-image: none!important; border-color: var(--cw-theme-border, #292d36)!important; }
+html[data-cw-theme="flat-dark"][data-tab="logs"] .cw-icon-select-menu .cw-icon-select-item { background: transparent!important; border-color: transparent!important; box-shadow: none!important; }
+html[data-cw-theme="flat-dark"][data-tab="logs"] .cw-icon-select-menu .cw-icon-select-item:is(:hover,:focus-visible,[aria-selected="true"]) { background: color-mix(in srgb, var(--accent) 16%, transparent)!important; border-color: color-mix(in srgb, var(--accent) 30%, transparent)!important; }
 .logs-tabs { display: flex; gap: 4px; padding: 3px; background: var(--log-surface); border: 1px solid var(--log-line); border-radius: 9px; }
 .logs-page button,.logs-page select,.logs-page input:not([type="checkbox"]),.logs-options summary { font: inherit; font-size: 12px; color: inherit; background: var(--log-surface); border: 1px solid var(--log-line); border-radius: 7px; padding: 8px 12px; }
 .logs-page button { cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 6px; }
@@ -25,23 +43,45 @@ html[data-tab="logs"] { overflow: hidden; }
 .logs-page :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .logs-tabs button { border: 0; }
 .logs-tabs [aria-selected="true"] { background: color-mix(in srgb, var(--accent) 20%, transparent); color: var(--accent); }
+.logs-channels { border-bottom: 1px solid var(--log-line); }
+.logs-channels .logs-tabs { border: 0; padding: 0; background: transparent; gap: 12px; }
+.logs-channels .logs-tabs button { padding: 10px 12px; border-radius: 0; border-bottom: 2px solid transparent; background: transparent; color: var(--log-muted); }
+.logs-channels .logs-tabs [aria-selected="true"] { border-bottom-color: var(--accent); color: var(--accent); }
 .logs-page .material-symbols-rounded { font-size: 18px; }
 .logs-search { display: flex; align-items: center; gap: 8px; flex: 1; min-width: 180px; background: var(--log-surface); border: 1px solid var(--log-line); border-radius: 7px; padding-left: 12px; }
 .logs-page .logs-search input { width: 100%; border: 0; background: transparent; }
 .logs-page [data-provider] { width: 125px; }
-.logs-runbar > strong { flex: 1; font-size: 13px; }
+.logs-run-title { flex: 1; display: flex; align-items: center; gap: 8px; min-width: 0; font-size: 13px; }
+.logs-run-title > .material-symbols-rounded { color: var(--log-muted); }
+.logs-run-title strong { overflow-wrap: anywhere; }
+.logs-run-count { padding: 3px 8px; background: var(--log-surface); border: 1px solid var(--log-line); border-radius: 6px; color: var(--log-muted); font-size: 11px; font-variant-numeric: tabular-nums; }
 .logs-page .logs-error { color: #ef8791; }
 .logs-page .logs-warn { color: #e8bb69; }
 .logs-options { position: relative; }
-.logs-options summary { cursor: pointer; }
-.logs-options > div { position: absolute; right: 0; top: 100%; z-index: 5; display: grid; gap: 6px; padding: 12px; width: 210px; background: var(--log-surface); border: 1px solid var(--log-line); border-radius: 9px; }
-.logs-options label { display: flex; align-items: center; gap: 8px; font-size: 12px; padding: 5px; }
-.logs-content { flex: 1; min-height: 0; overflow: auto; overscroll-behavior: contain; border: 1px solid var(--log-line); border-radius: 10px; background: var(--log-surface); scrollbar-gutter: stable; }
+.logs-options summary { cursor: pointer; display: flex; align-items: center; gap: 6px; list-style: none; }
+.logs-options summary::-webkit-details-marker { display: none; }
+.logs-options[open] summary { border-color: var(--accent); }
+.logs-options > div { position: absolute; right: 0; top: calc(100% + 6px); z-index: 5; display: grid; gap: 4px; padding: 6px; width: 240px; max-width: calc(100vw - 24px); box-sizing: border-box; background: var(--log-surface); border: 1px solid var(--log-line); border-radius: 9px; box-shadow: 0 12px 28px #0004; }
+.logs-options > div > button,.logs-options > div > label { display: grid; grid-template-columns: 20px minmax(0,1fr); align-items: center; gap: 12px; width: 100%; min-height: 38px; margin: 0; padding: 8px 10px; box-sizing: border-box; text-align: left; font-size: 12px; font-weight: 500; border: 1px solid transparent; border-radius: 6px; background: transparent; cursor: pointer; }
+.logs-options > div > label { margin-bottom: 4px; padding-bottom: 12px; border-bottom-color: var(--log-line); border-radius: 0; }
+.logs-options > div > button:hover { background: color-mix(in srgb, var(--accent) 8%, transparent); }
+.logs-options input[type="checkbox"] { width: 18px; height: 18px; min-width: 18px; min-height: 18px; margin: 0; justify-self: center; accent-color: var(--accent); }
+.logs-options button > .material-symbols-rounded { width: 20px; text-align: center; }
+.logs-options .logs-copied > .material-symbols-rounded { color: #50b88f; animation: logs-copy-check .3s ease-out; }
+@keyframes logs-copy-check { from { opacity: 0; transform: scale(.5) rotate(-20deg); } to { opacity: 1; transform: scale(1) rotate(0); } }
+@media(prefers-reduced-motion:reduce) { .logs-options .logs-copied > .material-symbols-rounded { animation: none; } }
+.logs-readable-switch { position: relative; display: inline-flex; align-items: center; gap: 8px; padding: 8px 2px; white-space: nowrap; font-size: 12px; cursor: pointer; }
+.logs-readable-switch input { position: absolute; opacity: 0; width: 1px; height: 1px; }
+.logs-switch-track { display: inline-flex; align-items: center; width: 28px; height: 16px; padding: 2px; border-radius: 12px; background: color-mix(in srgb, var(--log-muted) 25%, transparent); }
+.logs-switch-track::after { content: ''; width: 12px; height: 12px; border-radius: 50%; background: var(--log-muted); }
+.logs-readable-switch input:checked + .logs-switch-track { background: color-mix(in srgb, var(--accent) 35%, transparent); }
+.logs-readable-switch input:checked + .logs-switch-track::after { transform: translateX(12px); background: var(--accent); }
+.logs-readable-switch input:focus-visible + .logs-switch-track { outline: 2px solid var(--accent); outline-offset: 3px; }
+.logs-content { flex: 1; min-width: 0; max-width: 100%; min-height: 0; contain: inline-size; overflow: auto; overscroll-behavior: contain; border: 1px solid var(--log-line); border-radius: 10px; background: var(--log-surface); scrollbar-gutter: stable; }
 .logs-line { display: grid; grid-template-columns: 78px 48px 90px minmax(0, 1fr) 28px; align-items: start; gap: 10px; padding: 7px 12px; border-bottom: 1px solid var(--log-line); font: 12px/1.55 ui-monospace, Consolas, monospace; border-left: 3px solid transparent; }
 .logs-line time,.logs-provider,.logs-level { color: var(--log-muted); overflow-wrap: anywhere; }
-.logs-message { white-space: pre-wrap; overflow-wrap: anywhere; }
-.logs-nowrap .logs-message { white-space: pre; }
-.logs-nowrap .logs-line { grid-template-columns: 78px 48px 90px minmax(max-content, 1fr) 28px; }
+.logs-message { min-width: 0; max-width: 100%; white-space: pre-wrap; overflow-wrap: anywhere; }
+.logs-nowrap .logs-message { white-space: pre; overflow-x: auto; }
 .logs-line.logs-error { border-left-color: #ef8791; background: #ef879110; }
 .logs-line.logs-warn { border-left-color: #e8bb69; background: #e8bb690b; }
 .logs-error .logs-level { color: #ef8791; }
@@ -51,11 +91,70 @@ html[data-tab="logs"] { overflow: hidden; }
 .logs-line.logs-current-match { outline: 1px solid var(--accent); outline-offset: -1px; }
 .logs-context { margin: 8px 16px; border: 1px solid var(--log-line); border-radius: 6px; }
 .logs-context-line { opacity: .85; }
+.logs-pretty .logs-line { padding-top: 10px; padding-bottom: 10px; }
+.logs-pretty .logs-message { display: flex; flex-direction: column; align-items: flex-start; gap: 7px; font: 12px/1.5 system-ui, sans-serif; white-space: normal; min-width: 0; }
+.logs-readable-summary { font-weight: 600; white-space: pre-wrap; }
+.logs-pill-list { display: flex; flex-wrap: wrap; gap: 5px; max-width: 100%; }
+.logs-pill { display: inline-flex; align-items: center; flex-wrap: wrap; gap: 5px; max-width: 100%; border: 1px solid var(--log-line); background: color-mix(in srgb, var(--log-muted) 5%, transparent); border-radius: 6px; padding: 2px 7px; font-size: 11px; }
+.logs-pill small { font-size: inherit; color: var(--log-muted); }
+.logs-pill img { object-fit: contain; flex-shrink: 0; }
+.logs-pill-feature { color: var(--accent); background: color-mix(in srgb, var(--accent) 8%, transparent); }
+.logs-pill-success { color: #50b88f; border-color: #50b88f40; }
+.logs-pill-error { color: #ef8791; border-color: #ef879140; }
+.logs-pill-warning { color: #e8bb69; border-color: #e8bb6940; }
+.logs-completion { display: flex; flex-direction: column; gap: 10px; width: 100%; box-sizing: border-box; padding: 12px 14px; border: 1px solid var(--log-line); border-left: 3px solid var(--completion-color); border-radius: 8px; background: color-mix(in srgb, var(--completion-color) 4%, transparent); --completion-color: #50b88f; }
+.logs-completion-warning { --completion-color: #e8bb69; }
+.logs-completion-error { --completion-color: #ef8791; }
+.logs-completion-start { --completion-color: var(--accent); }
+.logs-completion .logs-readable-summary { display: flex; align-items: center; gap: 8px; font-size: 14px; }
+.logs-completion .logs-readable-summary > .material-symbols-rounded { color: var(--completion-color); }
+.logs-completion .logs-pill { padding: 5px 9px; gap: 8px; }
+.logs-completion .logs-pill > span { font-size: 14px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.logs-pretty .logs-level { font-size: 10px; text-align: center; padding: 2px 4px; border-radius: 5px; background: color-mix(in srgb, var(--log-muted) 8%, transparent); }
+.logs-debug .logs-level { color: #b69cff; }
+.logs-pretty .logs-debug .logs-level { background: color-mix(in srgb, var(--accent) 14%, transparent); }
+.logs-original { max-width: 100%; min-width: 0; color: var(--log-muted); }
+.logs-original summary { cursor: pointer; font-size: 10px; }
+.logs-original pre { margin: 6px 0 0; padding: 8px 10px; border: 1px solid var(--log-line); border-radius: 6px; white-space: pre-wrap; overflow-wrap: anywhere; font: 11px/1.55 ui-monospace, Consolas, monospace; }
+.logs-nowrap.logs-pretty .logs-line { grid-template-columns: 78px 48px 90px minmax(0, 1fr) 28px; }
+.logs-nowrap.logs-pretty .logs-original pre { white-space: pre; overflow: auto; }
 .logs-footer { display: flex; align-items: center; gap: 12px; padding: 10px 0; font-size: 12px; color: var(--log-muted); }
 .logs-footer > span:first-child { margin-right: auto; }
-.logs-saved-row { width: 100%; text-align: left; display: flex!important; align-items: flex-start!important; flex-direction: column; gap: 8px!important; padding: 16px!important; border-width: 0 0 1px!important; border-radius: 0!important; }
-.logs-saved-row span:first-child { display: flex; align-items: center; gap: 10px; }
-.logs-saved-row span:not(:first-child) { color: var(--log-muted); }
-.logs-empty { padding: 48px 24px; text-align: center; color: var(--log-muted); }
+.logs-saved-table { width: 100%; min-width: 900px; border-collapse: separate; border-spacing: 0; text-align: left; font-size: 12px; }
+.logs-saved-table th { position: sticky; top: 0; z-index: 1; padding: 12px 16px; background: var(--log-surface); border-bottom: 1px solid var(--log-line); color: var(--log-muted); font-size: 11px; font-weight: 500; white-space: nowrap; }
+.logs-saved-table th .material-symbols-rounded { font-size: 14px; vertical-align: middle; }
+.logs-saved-table td { padding: 14px 16px; border-bottom: 1px solid var(--log-line); color: var(--log-muted); vertical-align: middle; font-variant-numeric: tabular-nums; }
+.logs-saved-table td:first-child { width: 30%; }
+.logs-saved-table tbody tr { cursor: pointer; }
+.logs-saved-table tbody tr:hover,.logs-saved-table tbody tr:focus-within { background: color-mix(in srgb, var(--accent) 5%, transparent); }
+.logs-saved-table tbody tr:last-child td { border-bottom: 0; }
+.logs-page .logs-saved-open { padding: 0; gap: 12px; border: 0; background: transparent; text-align: left; justify-content: flex-start; color: var(--cw-theme-text, var(--fg)); }
+.logs-saved-open strong { font-weight: 600; overflow-wrap: anywhere; }
+.logs-saved-open > .material-symbols-rounded { color: var(--log-muted); flex-shrink: 0; font-size: 22px; }
+.logs-saved-table time { white-space: nowrap; line-height: 1.6; }
+.logs-saved-table time small { display: block; font-size: inherit; }
+.logs-status { display: inline-flex; align-items: center; gap: 6px; padding: 5px 8px; border: 1px solid color-mix(in srgb, currentColor 22%, transparent); border-radius: 7px; white-space: nowrap; }
+.logs-status-success { color: #50b88f; background: #50b88f0d; }
+.logs-status-error { color: #ef8791; background: #ef87910d; }
+.logs-status-warning { color: #e8bb69; background: #e8bb690d; }
+.logs-status-active { color: var(--accent); background: color-mix(in srgb, var(--accent) 8%, transparent); }
+.logs-features { display: inline-flex; align-items: center; gap: 6px; padding: 7px 9px; border: 1px solid var(--log-line); border-radius: 20px; }
+.logs-feature-dot { flex: 0 0 11px; width: 11px; height: 11px; border: 2px solid color-mix(in srgb, var(--log-muted) 40%, transparent); border-radius: 50%; }
+.logs-feature-dot.on { background: var(--feature-color); border-color: transparent; }
+.logs-feature-dot.wl { --feature-color: #00ffa3; }.logs-feature-dot.rt { --feature-color: #ffc400; }.logs-feature-dot.hi { --feature-color: #2de2ff; }.logs-feature-dot.pr { --feature-color: #a78bfa; }.logs-feature-dot.pl { --feature-color: #ff00e5; }.logs-feature-dot.co { --feature-color: #ff7a1a; }
+.logs-saved-arrow { width: 28px; }
+.logs-saved-table tr:hover .logs-saved-arrow { color: var(--accent); }
+.logs-sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%); white-space: nowrap; }
+.logs-content > [data-output] { min-height: 100%; display: flex; flex-direction: column; }
+.logs-empty { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; padding: 32px 24px; min-height: 240px; box-sizing: border-box; text-align: center; color: var(--log-muted); }
+.logs-empty-icon { display: grid; place-items: center; width: 58px; height: 58px; margin-bottom: 4px; background: color-mix(in srgb, var(--accent) 14%, transparent); border: 1px solid color-mix(in srgb, var(--accent) 22%, transparent); border-radius: 16px; color: var(--accent); }
+.logs-empty-icon .material-symbols-rounded { font-size: 30px; }
+.logs-empty h2 { margin: 0; color: var(--cw-theme-text, var(--fg)); font-size: 18px; letter-spacing: -.02em; }
+.logs-empty p { max-width: 440px; margin: 0; font-size: 13px; line-height: 1.6; }
+.logs-page .logs-empty-action { margin-top: 6px; border-color: color-mix(in srgb, var(--accent) 40%, var(--log-line)); background: color-mix(in srgb, var(--accent) 12%, transparent); }
+.logs-empty small { display: flex; align-items: center; gap: 6px; margin-top: 8px; font-size: 11px; }
 .logs-notice { font-size: 12px; color: #e8bb69; margin: 0 0 10px; }
-@media(max-width:700px) { .logs-heading { padding: 8px 0; } .logs-heading h1 { font-size: 25px; } .logs-toolbar { gap: 6px; margin-bottom: 8px; } .logs-toolbar > [data-storage] { display: none; } .logs-line { grid-template-columns: 65px 45px minmax(0,1fr) 24px; gap: 6px; } .logs-message { grid-column: 1 / 4; grid-row: 2; } .logs-line > button { grid-column: 4; grid-row: 1 / 3; } .logs-nowrap .logs-line { grid-template-columns: 65px 45px minmax(max-content,1fr) 24px; } }
+@media(max-width:700px) { .logs-heading { padding: 8px 0; } .logs-heading h1 { font-size: 25px; } .logs-toolbar { gap: 6px; margin-bottom: 8px; } .logs-storage { width: 100%; margin: 4px 0 0; } .logs-pair-controls { flex: 1 1 100%; } .logs-page [data-pair], .logs-page [data-pair] + .cw-icon-select { flex: 1; width: 0; min-width: 140px; } .logs-controls { padding: 8px; } .logs-line { grid-template-columns: 65px 45px minmax(0,1fr) 24px; gap: 6px; } .logs-message { grid-column: 1 / 4; grid-row: 2; } .logs-line > button { grid-column: 4; grid-row: 1 / 3; } }
+@media(max-height:650px) { html[data-tab="logs"] { overflow: auto; } .logs-page { height: auto!important; min-height: calc(100dvh - 100px); } .logs-content { flex: none; height: 320px; } }
+@media(max-width:700px) { .logs-nowrap.logs-pretty .logs-line { grid-template-columns: 65px 45px minmax(0,1fr) 24px; } }
+@media(max-width:700px) { .logs-options { margin-left: auto; } .logs-run-title { flex: 1 1 100%; order: -1; } }

--- a/assets/js/events/index.js
+++ b/assets/js/events/index.js
@@ -2,6 +2,8 @@
 /* CrossWatch - Events page */
 /* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
 
+import {pageBackLink, statisticsReturn, returnFromEvents} from '../page-return.js';
+
 const esc = (s) => String(s ?? "").replace(/[&<>"']/g, (c) => (
   { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]
 ));
@@ -463,6 +465,8 @@ export default {
     const initialDomain = String(props?.domain || "").trim().toLowerCase();
     const initialVisibility = String(props?.visibility || "").trim().toLowerCase();
     const initialMode = String(props?.mode || "").trim().toLowerCase();
+    const back = pageBackLink(props?.returnTo, location.href, 'events');
+    if (statisticsReturn(props?.returnContext)) back.label = 'Sync activity';
     let runFilter = String(props?.runId || props?.run_id || "").trim();
     let visibility = ["open", "acknowledged", "all"].includes(initialVisibility) ? initialVisibility : ls("cw.events.visibility", "open");
     if (runFilter) visibility = ["open", "acknowledged", "all"].includes(initialVisibility) ? initialVisibility : "all";
@@ -478,7 +482,7 @@ export default {
 
     root.innerHTML = `
       <div class="ev-app">
-        <a class="ev-back" href="#main" id="ev-back"><span class="material-symbols-rounded" aria-hidden="true">arrow_back</span>Main</a>
+        <a class="ev-back" href="${esc(back.href)}" id="ev-back"><span class="material-symbols-rounded" aria-hidden="true">arrow_back</span>${esc(back.label)}</a>
         <header class="ev-header">
           <div>
             <div class="ev-eyebrow">ACTIVITY HISTORY</div>
@@ -581,10 +585,10 @@ export default {
       if (listReturnPosition !== null) window.scrollTo({ top: listReturnPosition, behavior: "instant" });
       listEl.querySelector(".ev-row.sel")?.focus({ preventScroll: true });
     });
-    Q("#ev-back", root).addEventListener("click", event => {
+    Q("#ev-back", root).addEventListener("click", async event => {
       if (event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) return;
       event.preventDefault();
-      window.showTab?.("main");
+      await returnFromEvents(props);
     });
 
     // resizable list/detail split

--- a/assets/js/events/page.js
+++ b/assets/js/events/page.js
@@ -8,7 +8,7 @@ const { default: EventsView } = await import(viewURL.href);
 
 export function readEventsRoute(hash = window.location.hash) {
   const query = new URLSearchParams(String(hash).split('?')[1] || '');
-  const props = Object.fromEntries(['groupId', 'runId', 'domain', 'visibility', 'mode'].map(key => [key, query.get(key) || '']));
+  const props = Object.fromEntries(['groupId', 'runId', 'domain', 'visibility', 'mode', 'returnTo', 'returnContext'].map(key => [key, query.get(key) || '']));
   if (!/^\d+$/.test(props.groupId)) props.groupId = '';
   return props;
 }

--- a/assets/js/logs-format.js
+++ b/assets/js/logs-format.js
@@ -1,0 +1,114 @@
+/* assets/js/logs-format.js */
+/* CrossWatch - Readable diagnostic log formatting */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+
+const esc = value => String(value ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+const humanize = value => String(value).replace(/[_.:]+/g, ' ').trim().replace(/\b\w/, c => c.toUpperCase());
+const titles = new Map(Object.entries({
+  health:'Provider health checked', 'api:hit':'API request', 'api:totals':'API usage summary',
+  'run:start':'Sync started', 'run:pair':'Syncing pair', 'run:done':'Sync finished',
+  'run:error':'Sync failed', 'feature:start':'Feature sync started', 'feature:done':'Feature sync finished',
+  'two:start':'Two-way sync started', 'two:plan':'Sync changes planned', 'two:done':'Two-way sync finished',
+  'snapshot:start':'Reading provider items', 'snapshot:progress':'Reading progress', 'snapshot:done':'Provider items loaded',
+  'drop_guard:skipped':'Removal protection skipped', 'stats:overview':'Sync overview', 'http:overview':'HTTP activity summary',
+  'state.persisted':'Sync state saved', 'run.kwargs.ignored':'Unused sync options ignored',
+  'observed.deletions':'Deletions checked', 'tombstones.marked':'Removal records updated', 'hidefile.cleared':'Hidden-item records cleared',
+}));
+
+export function describeLog(row) {
+  const raw = String(row.text ?? '');
+  let text = raw.trim().replace(/^\d{4}-\d{2}-\d{2}T\S+\s+/, '').replace(/^\[\d{4}-\d{2}-\d{2}[^\]]*\]\s*/, '');
+  for (let i = 0; i < 6; i++) {
+    const next = text.replace(/^\[(?:[A-Z][A-Z0-9_-]*(?::[^\[\]]*)?|i|!)\]\s*/, '').replace(/^(?:INFO|DEBUG|WARN(?:ING)?|ERROR|CRITICAL|SUCCESS)\s+/, '');
+    if (next === text) break;
+    text = next;
+  }
+  const start = text.match(/^SYNC start:\s+orchestrator pairs run_id=(\S+)$/);
+  if (start) return {summary:'Sync started', pills:[{label:'Run',value:start[1],tone:''}], raw, structured:true, start:true};
+  const pair = text.match(/^Running single pair:\s+(.+?)\s+→\s+(.+?)\s+\(([^()\s]+)\)$/);
+  if (pair) return {
+    summary:'Sync pair',
+    pills:[{label:'From',value:pair[1],tone:'provider'},{label:'To',value:pair[2],tone:'provider'},{label:'Pair',value:pair[3],tone:''}],
+    raw, structured:true,
+  };
+  const completion = text.match(/^(Done|Cancelled)\.\s+(.+)$/i);
+  if (completion) {
+    const counts = completion[2].split(/,\s*/).map(part => part.match(/^Total (added|removed|updated|skipped|unresolved|errors|blocked):\s*(\d+)\s*$/i));
+    if (counts.length === 7 && counts.every(Boolean) && new Set(counts.map(count => count[1].toLowerCase())).size === 7) {
+      const cancelled = completion[1].toLowerCase() === 'cancelled';
+      const issues = counts.some(count => ['unresolved','errors','blocked'].includes(count[1].toLowerCase()) && Number(count[2]) > 0);
+      const failed = counts.some(count => count[1].toLowerCase() === 'errors' && Number(count[2]) > 0);
+      return {
+        summary:cancelled ? 'Sync cancelled' : issues ? 'Sync finished with issues' : 'Sync completed',
+        pills:counts.map(count => {
+          const name = count[1].toLowerCase(), positive = Number(count[2]) > 0;
+          const tone = !positive ? '' : name === 'errors' ? 'error' : ['unresolved','blocked','skipped'].includes(name) ? 'warning' : name === 'added' ? 'success' : 'feature';
+          return {label:humanize(name), value:count[2], tone};
+        }),
+        raw, structured:true, completion:failed ? 'error' : cancelled || issues ? 'warning' : 'success',
+      };
+    }
+  }
+  let data;
+  if (text.startsWith('{')) {
+    try { const value = JSON.parse(text); if (value && typeof value === 'object' && !Array.isArray(value)) data = value; } catch {}
+  }
+  if (!data) return {summary:text || raw, pills:[], raw, structured:false};
+  const event = typeof data.event === 'string' ? data.event : '';
+  const message = typeof data.msg === 'string' ? data.msg : typeof data.message === 'string' ? data.message : '';
+  const key = event === 'debug' && message ? message : event;
+  let summary = titles.get(key) || (message ? humanize(message) : key ? humanize(key) : 'Log details');
+  if (event === 'run:done') {
+    if (data.cancelled === true) summary = 'Sync cancelled';
+    else if (['errors','unresolved','blocked'].some(k => Number(data[k]) > 0)) summary = 'Sync finished with issues';
+  }
+  const pills = [];
+  const add = (label, value, tone = '') => {
+    if (value === null || value === undefined || value === '') return;
+    if (Array.isArray(value)) { if (!value.length || value.some(v => v && typeof v === 'object')) return; value = value.join(', '); }
+    if (typeof value === 'object') return;
+    pills.push({label, value:typeof value === 'boolean' ? value ? 'On' : 'Off' : String(value), tone});
+  };
+  const src = typeof data.src === 'string' ? data.src : typeof data.a === 'string' ? data.a : '';
+  const dst = typeof data.dst === 'string' ? data.dst : typeof data.b === 'string' ? data.b : '';
+  if (src) add('From', src, 'provider');
+  if (dst) add('To', dst, 'provider');
+  if (data.provider && data.provider !== row.provider && data.provider !== src && data.provider !== dst) add('Provider', data.provider, 'provider');
+  if (data.instance && data.instance !== 'default') add('Instance', data.instance);
+  for (const side of ['src','dst']) if (data[`${side}_instance`] && data[`${side}_instance`] !== 'default') add(side === 'src' ? 'Source instance' : 'Target instance', data[`${side}_instance`]);
+  add('Feature', data.feature, 'feature');
+  if (Array.isArray(data.features)) add('Features', data.features, 'feature');
+  if (data.status != null) {
+    const status = String(data.status), code = Number(status);
+    add('Status', status, ['ok','success','completed'].includes(status) || (code >= 200 && code < 300) ? 'success' : ['error','failed'].includes(status) || code >= 400 ? 'error' : '');
+  }
+  add('Endpoint', data.endpoint);
+  if (typeof data.latency_ms === 'number') add('Latency', `${data.latency_ms} ms`);
+  if (data.done != null && data.total != null) add('Items', `${data.done} / ${data.total}`);
+  else add('Items', data.count ?? data.total);
+  for (const name of ['added','updated','removed','skipped','unresolved','blocked','errors','warnings','pairs']) {
+    add(humanize(name), data[name], Number(data[name]) > 0 ? name === 'errors' ? 'error' : ['warnings','unresolved','blocked'].includes(name) ? 'warning' : '' : '');
+  }
+  for (const [field, label] of Object.entries({add_to_A:'Add to source',add_to_B:'Add to target',adds_to_A:'Added to source',adds_to_B:'Added to target',upd_to_A:'Update source',upd_to_B:'Update target',rem_from_A:'Remove from source',rem_from_B:'Remove from target'})) add(label, data[field]);
+  if (data.totals && typeof data.totals === 'object') add('Requests', data.totals.total);
+  if (data.overview && typeof data.overview === 'object') for (const [field,value] of Object.entries(data.overview)) add(humanize(field),value);
+  add('Loaded adapters', data.loaded_adapters);
+  add('Saved-state providers', data.saved_state_providers);
+  for (const field of ['reason','error','detail','dry_run','mode','removals','providers','keys','scope']) add(humanize(field),data[field]);
+  return {summary, pills:pills.slice(0,16), raw, structured:true};
+}
+
+export function readableLogHTML(row, highlight, query = '', providerMeta = null) {
+  const item = describeLog(row);
+  const pills = item.pills.map(p => {
+    const brand = p.tone === 'provider' ? providerMeta?.brandInfo?.(p.value) : null;
+    const logo = brand?.icon ? `<img src="${esc(brand.icon)}" alt="" width="14" height="14" aria-hidden="true">` : '';
+    return `<span class="logs-pill${p.tone ? ` logs-pill-${p.tone}` : ''}"><small>${highlight(p.label,query)}</small>${logo}<span>${highlight(brand?.label || p.value,query)}</span></span>`;
+  }).join('');
+  const shown = [item.summary, ...item.pills.flatMap(p => [p.label,p.value])].join(' ').toLowerCase();
+  const rawMatch = query && item.raw.toLowerCase().includes(query.toLowerCase()) && !shown.includes(query.toLowerCase());
+  const cardTone = item.start ? 'start' : item.completion;
+  const summaryIcon = cardTone ? `<span class="material-symbols-rounded" aria-hidden="true">${item.start ? 'sync' : item.completion === 'success' ? 'check_circle' : item.completion === 'error' ? 'error_outline' : 'warning'}</span>` : '';
+  const body = `<span class="logs-readable-summary">${summaryIcon}${highlight(item.summary,query)}</span>${pills ? `<span class="logs-pill-list">${pills}</span>` : ''}`;
+  return `${cardTone ? `<div class="logs-completion logs-completion-${cardTone}">${body}</div>` : body}<details class="logs-original"${rawMatch ? ' open' : ''}><summary>Original log</summary><pre>${highlight(item.raw,query)}</pre></details>`;
+}

--- a/assets/js/logs.js
+++ b/assets/js/logs.js
@@ -2,9 +2,42 @@
 /* CrossWatch - Live and saved diagnostic logs */
 /* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
 
+import {readableLogHTML} from './logs-format.js';
+import {pageBackLink} from './page-return.js';
+
 const esc = value => String(value ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 const icon = name => `<span class="material-symbols-rounded" aria-hidden="true">${name}</span>`;
 const date = ts => ts ? new Date(ts * 1000).toLocaleString() : 'Live';
+const logFeatures = [['watchlist','Watchlist','wl'],['ratings','Ratings','rt'],['history','History','hi'],['progress','Progress','pr'],['playlists','Playlists','pl'],['collection','Collections','co']];
+export function savedLogFeatures(session, pairId = '') {
+  let pairs;
+  try { pairs = typeof session.pairs === 'string' ? JSON.parse(session.pairs) : session.pairs; } catch { return null; }
+  if (!Array.isArray(pairs)) return null;
+  const selected = pairs.filter(p => p && (!pairId || String(p.id) === pairId));
+  if (!selected.length || selected.some(p => !p.features || typeof p.features !== 'object' || Array.isArray(p.features))) return null;
+  const enabled = value => {
+    if (value && typeof value === 'object') value = value.enable ?? value.enabled;
+    return value === true || value === 1 || ['true','1','on','yes'].includes(String(value).toLowerCase());
+  };
+  return logFeatures.map(([key]) => selected.some(p => enabled(p.features[key])));
+}
+export function savedLogsTable(sessions, pairId = '', channel = 'sync') {
+  const rows = sessions.map(s => {
+    const started = new Date(s.started * 1000);
+    const features = savedLogFeatures(s, pairId);
+    const enabledNames = features ? logFeatures.filter((_, i) => features[i]).map(([,name]) => name) : [];
+    const featureLabel = enabledNames.length ? `Enabled features: ${enabledNames.join(', ')}. Combined across pairs in this run.` : 'No enabled features';
+    const dots = features ? `<span class="logs-features" role="img" aria-label="${esc(featureLabel)}" title="${esc(featureLabel)}">${logFeatures.map(([,name,cls],i) => `<span class="logs-feature-dot ${cls}${features[i] ? ' on' : ''}" title="${name}: ${features[i] ? 'enabled' : 'disabled'}" aria-hidden="true"></span>`).join('')}</span>` : '<span class="logs-unavailable" title="Feature settings were not recorded for this log" aria-label="Feature settings unavailable">—</span>';
+    const status = String(s.status || 'unknown').toLowerCase();
+    const statuses = {completed:['Completed','check_circle','success'],complete:['Completed','check_circle','success'],issues:['Completed with issues','warning','warning'],failed:['Failed','error','error'],error:['Error','error','error'],cancelled:['Cancelled','cancel','warning'],interrupted:['Interrupted','warning','warning'],running:['Running','sync','active'],live:['Live','sensors','active'],saved:['Saved','inventory_2','neutral']};
+    const [label, symbol, tone] = Object.hasOwn(statuses,status) ? statuses[status] : [s.status || 'Unknown','info','neutral'];
+    const errors = Math.max(0, Number(s.errors) || 0), warnings = Math.max(0, Number(s.warnings) || 0);
+    const duration = s.ended == null ? 'Live' : `${Math.max(0,Math.round(s.ended-s.started))}s`;
+    return `<tr data-session="${esc(s.id)}"><td><button class="logs-saved-open" data-session="${esc(s.id)}" aria-label="${esc(`Open log: ${s.label}`)}">${icon(s.pinned ? 'push_pin' : 'description')}<strong>${esc(s.label)}</strong></button></td><td>${dots}</td><td><time datetime="${started.toISOString()}">${esc(started.toLocaleDateString())}<small>${esc(started.toLocaleTimeString())}</small></time></td><td>${duration}</td><td><span class="logs-status logs-status-${tone}">${icon(symbol)}${esc(label)}</span></td><td class="${errors ? 'logs-error' : ''}">${errors}</td><td class="${warnings ? 'logs-warn' : ''}">${warnings}</td><td class="logs-saved-arrow">${icon('chevron_right')}</td></tr>`;
+  }).join('');
+  return `<table class="logs-saved-table" aria-label="Saved logs"><thead><tr><th scope="col">${channel === 'sync' ? 'Sync pair' : 'Log'}</th><th scope="col">Features</th><th scope="col" aria-sort="descending">Started ${icon('arrow_downward')}</th><th scope="col">Duration</th><th scope="col">Status</th><th scope="col">Errors</th><th scope="col">Warnings</th><th scope="col"><span class="logs-sr-only">Open log</span></th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+export const logsBackLink = pageBackLink;
 export function highlight(text, query) {
   if (!query) return esc(text);
   const lower = text.toLowerCase(), needle = query.toLowerCase();
@@ -26,23 +59,31 @@ const LogsPage = {
       css.href = `/assets/css/logs.css?v=${encodeURIComponent(window.APP_VERSION || '1')}`; document.head.append(css);
     }
     const route = new URLSearchParams(location.hash.split('?')[1] || '');
+    const back = logsBackLink(route.get('returnTo'), location.href);
     let channel = ['sync','watcher','debug'].includes(route.get('channel')) ? route.get('channel') : 'sync';
     let pairId = route.get('pairId') || '', latestRequested = route.get('latest') === '1', pairs = [], latestRunId = '';
     if (channel === 'watcher') pairId = '';
     let runId = route.get('runId') || '', mode = runId || latestRequested ? 'saved' : 'live', sid = '', sessions = [], current = null;
     let alive = true, busy = false, sequence = 0, timer, searchTimer, offset = 0, total = 0, follow = mode === 'live', rows = [], matchIndex = -1;
     let query = '', level = '', provider = '', listPage = 0, showingRuns = mode === 'saved', controller = null, pendingMatch = null;
+    let readable = true;
+    try { readable = window.localStorage.getItem('cw.logs.readable') !== 'off'; } catch {}
+    const visibleRows = new Map();
+    const copyFeedback = new Map();
     const profile = window.CW?.OverviewProfile?.id || '';
-    host.innerHTML = `<div class="logs-page"><a href="#main" class="logs-back">${icon('arrow_back')}Main</a>
-      <header class="logs-heading"><div><div class="logs-eyebrow">DIAGNOSTICS</div><h1>Logs</h1></div><span data-connection role="status">Connecting…</span></header>
-      <div class="logs-toolbar"><div class="logs-tabs" role="tablist" aria-label="Log channel">${['sync','watcher','debug'].map(c=>`<button data-channel="${c}" role="tab">${c[0].toUpperCase()+c.slice(1)}</button>`).join('')}</div><div class="logs-tabs" role="tablist" aria-label="Log source"><button data-mode="live" role="tab">Live</button><button data-mode="saved" role="tab">Saved logs</button></div><div class="logs-pair-controls" data-pair-controls><select data-pair aria-label="Sync pair"><option value="">All pairs</option></select><button data-latest title="Open the latest run for this selection">${icon('history')}Latest run</button></div><span data-storage></span></div>
-      <div class="logs-toolbar" data-filters><label class="logs-search">${icon('search')}<input data-query type="search" placeholder="Search logs…" aria-label="Search logs"></label><select data-level aria-label="Log level"><option value="">All levels</option><option value="ERROR">Errors</option><option value="WARN">Warnings</option><option value="INFO">Info</option><option value="DEBUG">Debug</option></select><input data-provider placeholder="Provider" aria-label="Filter by provider" list="log-providers"><datalist id="log-providers"></datalist><button data-prev-match title="Previous match" aria-label="Previous match">${icon('keyboard_arrow_up')}</button><button data-next-match title="Next match" aria-label="Next match">${icon('keyboard_arrow_down')}</button><button data-follow>${icon('podcasts')}Follow live</button>
-      <details class="logs-options"><summary>More</summary><div><label><input data-wrap type="checkbox" checked>Wrap lines</label><button data-copy>Copy filtered log</button><button data-copy-full>Copy full log</button><button data-download>Download filtered log</button><button data-download-full>Download full log</button></div></details></div>
-      <div class="logs-toolbar logs-runbar"><button data-back-runs hidden>${icon('arrow_back')}Saved logs</button><strong data-title></strong><button data-errors class="logs-error"></button><button data-warnings class="logs-warn"></button><button data-pin hidden>${icon('push_pin')}Keep this log</button><button data-delete hidden>${icon('delete')}Delete</button><button data-clear hidden>Clear older logs</button></div>
-      <p class="logs-notice" data-notice role="status" hidden></p><div class="logs-content" tabindex="0" aria-label="Log output"><div data-output></div></div>
-      <footer class="logs-footer"><span data-count></span><button data-previous>Previous</button><span data-page></span><button data-next>Next</button></footer></div>`;
+    host.innerHTML = `<div class="logs-page"><a href="${esc(back.href)}" class="logs-back">${icon('arrow_back')}${esc(back.label)}</a>
+      <header class="logs-heading"><div><div class="logs-eyebrow">DIAGNOSTICS</div><h1>Logs</h1></div></header>
+      <div class="logs-toolbar logs-channels"><div class="logs-tabs" role="tablist" aria-label="Log channel">${['sync','watcher','debug'].map(c=>`<button data-channel="${c}" role="tab"${c === 'debug' ? ' hidden' : ''}>${icon({sync:"sync",watcher:"sensors",debug:"bug_report"}[c])}${c[0].toUpperCase()+c.slice(1)}</button>`).join('')}</div><span class="logs-connection" data-connection role="status">${icon('sensors')}<span data-connection-text>Connecting…</span></span></div>
+      <div class="logs-toolbar logs-controls"><div class="logs-tabs" role="tablist" aria-label="Log source"><button data-mode="live" role="tab">${icon("podcasts")}Live</button><button data-mode="saved" role="tab">${icon("inventory_2")}Saved logs</button></div><div class="logs-pair-controls" data-pair-controls><select data-pair aria-label="Sync pair"><option value="">All pairs</option></select><button data-latest title="Open the latest run for this selection">${icon('history')}Latest run</button></div><div class="logs-storage" data-storage hidden><div class="logs-storage-copy"><span>${icon("hard_drive")}<span data-storage-size></span></span><span data-retention></span></div><progress data-storage-meter max="100" value="0" aria-label="Log storage used"></progress></div></div>
+      <div class="logs-toolbar" data-filters><label class="logs-search">${icon('search')}<input data-query type="search" placeholder="Search logs…" aria-label="Search logs"></label><select data-level aria-label="Log level"><option value="">All levels</option><option value="ERROR">Errors</option><option value="WARN">Warnings</option><option value="INFO">Info</option><option value="DEBUG">Debug</option></select><input data-provider placeholder="Provider" aria-label="Filter by provider" list="log-providers"><datalist id="log-providers"></datalist><button data-prev-match title="Previous match" aria-label="Previous match">${icon('keyboard_arrow_up')}</button><button data-next-match title="Next match" aria-label="Next match">${icon('keyboard_arrow_down')}</button><button data-follow>${icon("podcasts")}<span>Follow live</span></button>
+      <label class="logs-readable-switch" title="Format log messages for easier reading"><input data-readable type="checkbox" role="switch" ${readable ? 'checked' : ''}><span class="logs-switch-track" aria-hidden="true"></span>Readable view</label>
+      <details class="logs-options"><summary>${icon("tune")}More</summary><div><label><input data-wrap type="checkbox" checked>Wrap lines</label><button data-copy>${icon("content_copy")}Copy filtered log</button><button data-copy-full>${icon("copy_all")}Copy full log</button><button data-download>${icon("download")}Download filtered log</button><button data-download-full>${icon("file_download")}Download full log</button></div></details></div>
+      <div class="logs-toolbar logs-runbar"><button data-back-runs hidden>${icon('arrow_back')}Saved logs</button><div class="logs-run-title">${icon("terminal")}<strong data-title></strong><span class="logs-run-count" data-run-count hidden></span></div><button data-errors class="logs-error">${icon("error_outline")}<span></span></button><button data-warnings class="logs-warn">${icon("warning")}<span></span></button><button data-pin hidden>${icon("push_pin")}<span>Keep this log</span></button><button data-delete hidden>${icon('delete')}Delete</button><button data-clear hidden>${icon("delete_sweep")}Clear older logs</button></div>
+      <span class="logs-sr-only" data-copy-status role="status"></span><p class="logs-notice" data-notice role="status" hidden></p><div class="logs-content" tabindex="0" aria-label="Log output"><div data-output></div></div>
+      <footer class="logs-footer"><span data-count></span><button data-previous>${icon("chevron_left")}Previous</button><span data-page></span><button data-next>Next${icon("chevron_right")}</button></footer></div>`;
     const $ = s => host.querySelector(s);
     const content = $('.logs-content');
+    content.classList.toggle('logs-pretty', readable);
     function resize() { const page=$('.logs-page'); if(alive && page)page.style.height = `${Math.max(260, window.innerHeight - host.getBoundingClientRect().top - 16)}px`; }
     window.addEventListener('resize', resize); resize();
     function url(path, values = {}) { const p = new URLSearchParams({...values, user_profile:profile}); return '/api/logs/archive' + path + '?' + p; }
@@ -52,6 +93,7 @@ const LogsPage = {
       if(pairId)params.set('pairId',pairId);
       if(runId)params.set('runId',runId);
       if(latestRequested)params.set('latest','1');
+      if(route.has('returnTo'))params.set('returnTo',route.get('returnTo'));
       window.history.replaceState(null,'','#logs?'+params);
     }
     function clearFilters() {
@@ -64,7 +106,37 @@ const LogsPage = {
       if (!res.ok) { let message = 'Could not load logs.'; try { message = (await res.json()).detail || message; } catch {} throw new Error(message); }
       return res.json();
     }
+    function connection(text, symbol = 'sensors', state = 'idle') {
+      $('[data-connection-text]').textContent = text;
+      $('[data-connection] .material-symbols-rounded').textContent = symbol;
+      $('[data-connection]').dataset.state = state;
+    }
+    function emptyState(symbol, title, detail, liveAction = false) {
+      return `<div class="logs-empty"><span class="logs-empty-icon">${icon(symbol)}</span><h2>${esc(title)}</h2><p>${esc(detail)}</p>${liveAction ? `<button data-mode="live" class="logs-empty-action">View live logs${icon('arrow_forward')}</button><small>${icon('info')}Logs are saved automatically on this server.</small>` : ''}</div>`;
+    }
+    function output(html) {
+      if ($('[data-output]').innerHTML !== html) $('[data-output]').innerHTML = html;
+    }
     function notice(text = '') { $('[data-notice]').textContent = text; $('[data-notice]').hidden = !text; }
+    function copied(button) {
+      if (!alive) return;
+      const symbol = button.querySelector('.material-symbols-rounded');
+      const previous = copyFeedback.get(button);
+      clearTimeout(previous?.timer);
+      const original = previous?.original ?? symbol.textContent;
+      symbol.textContent = 'check';
+      button.classList.remove('logs-copied');
+      void button.offsetWidth;
+      button.classList.add('logs-copied');
+      $('[data-copy-status]').textContent = 'Log copied to clipboard.';
+      const timer = setTimeout(() => {
+        symbol.textContent = original;
+        button.classList.remove('logs-copied');
+        copyFeedback.delete(button);
+        if (!copyFeedback.size) $('[data-copy-status]').textContent = '';
+      }, 1800);
+      copyFeedback.set(button, {original, timer});
+    }
     function revealMatch(index) {
       matchIndex = Math.max(0, Math.min(rows.length - 1, index));
       host.querySelectorAll('.logs-current-match').forEach(el=>el.classList.remove('logs-current-match'));
@@ -74,8 +146,8 @@ const LogsPage = {
     }
     function paintControls() {
       host.querySelectorAll('[data-channel]').forEach(b=>b.setAttribute('aria-selected',String(b.dataset.channel===channel)));
-      host.querySelectorAll('[data-mode]').forEach(b=>b.setAttribute('aria-selected',String(b.dataset.mode===mode)));
-      $('[data-follow]').textContent = follow ? 'Following live' : 'Resume live';
+      host.querySelectorAll('[data-mode][role="tab"]').forEach(b=>b.setAttribute('aria-selected',String(b.dataset.mode===mode)));
+      $('[data-follow] span:not(.material-symbols-rounded)').textContent = follow ? 'Following live' : 'Resume live';
       $('[data-follow]').hidden = mode !== 'live';
       $('[data-filters]').hidden = showingRuns;
       $('[data-back-runs]').hidden = showingRuns || mode === 'live';
@@ -84,14 +156,17 @@ const LogsPage = {
       $('[data-latest]').disabled = !latestRunId;
       $('[data-pin]').hidden = showingRuns || !current;
       $('[data-delete]').hidden = showingRuns || !current || current.ended === null;
-      $('[data-pin]').textContent = current?.pinned ? 'Unpin log' : 'Keep this log';
+      $('[data-pin] span:not(.material-symbols-rounded)').textContent = current?.pinned ? 'Unpin log' : 'Keep this log';
       $('[data-pin]').title = 'Keep the entire saved log, including any other pairs in it';
       $('[data-errors]').hidden = showingRuns || !current;
       $('[data-warnings]').hidden = showingRuns || !current;
-      $('[data-errors]').textContent = `${current?.errors || 0} errors`;
-      $('[data-warnings]').textContent = `${current?.warnings || 0} warnings`;
+      $('[data-errors] span:not(.material-symbols-rounded)').textContent = `${current?.errors || 0} errors`;
+      $('[data-warnings] span:not(.material-symbols-rounded)').textContent = `${current?.warnings || 0} warnings`;
       const pairLabel = pairs.find(p=>p.id===pairId)?.label;
       $('[data-title]').textContent = showingRuns ? 'Saved logs' : current ? `${pairLabel || current.label} · ${date(current.started)}` : 'No log selected';
+      $('[data-run-count]').hidden = !showingRuns;
+      $('[data-run-count]').textContent = String(sessions.length);
+      $('.logs-run-title .material-symbols-rounded').textContent = showingRuns ? 'inventory_2' : 'terminal';
       $('[data-count]').textContent = showingRuns ? `${sessions.length} saved logs` : `${total} matching lines`;
       $('[data-page]').textContent = showingRuns ? `${listPage+1} / ${Math.max(1,Math.ceil(sessions.length/10))}` : `${Math.floor(offset/500)+1} / ${Math.max(1,Math.ceil(total/500))}`;
       $('[data-previous]').disabled = showingRuns ? listPage === 0 : offset === 0;
@@ -100,11 +175,13 @@ const LogsPage = {
     }
     function renderRuns() {
       listPage = Math.min(listPage, Math.max(0, Math.ceil(sessions.length / 10) - 1));
-      $('[data-output]').innerHTML = sessions.slice(listPage*10,listPage*10+10).map(s=>`<button class="logs-saved-row" data-session="${esc(s.id)}"><span>${icon(s.pinned ? 'push_pin' : 'description')}<strong>${esc(s.label)}</strong></span><span>${esc(date(s.started))} · ${s.ended ? Math.max(0,Math.round(s.ended-s.started))+'s' : 'Live'} · ${esc(s.status)}</span><span>${s.errors} errors · ${s.warnings} warnings</span></button>`).join('') || '<div class="logs-empty">No saved logs for this selection. New logs are saved automatically; older logs from before this update are unavailable.</div>';
+      output(sessions.length ? savedLogsTable(sessions.slice(listPage*10,listPage*10+10), pairId, channel) : emptyState('manage_history', 'No saved logs yet', runId ? 'No saved log is available for this run.' : pairId ? 'Logs will appear after the next sync for this pair.' : 'Logs will appear here as new activity is recorded.', true));
       paintControls();
     }
     function lineMarkup(row, context = false) {
-      return `<div class="logs-line logs-${row.level.toLowerCase()}${context?' logs-context-line':''}" ${context?'':`data-line="${row.id}"`}><time>${esc(new Date(row.ts*1000).toLocaleTimeString())}</time><span class="logs-level">${esc(row.level)}</span><span class="logs-provider">${esc(row.provider)}</span><span class="logs-message">${highlight(row.text,query)}</span>${context?'':`<button data-context="${row.id}" aria-label="Show context for line ${row.id}" title="Show surrounding lines">${icon('unfold_more')}</button>`}</div>`;
+      visibleRows.set(String(row.id), row);
+      const message = readable ? readableLogHTML(row, highlight, query, window.CW?.ProviderMeta) : highlight(row.text,query);
+      return `<div class="logs-line logs-${row.level.toLowerCase()}${context?' logs-context-line':''}" data-log-id="${esc(row.id)}" ${context?'':`data-line="${row.id}"`}><time>${esc(new Date(row.ts*1000).toLocaleTimeString())}</time><span class="logs-level">${esc(row.level)}</span><span class="logs-provider">${esc(row.provider)}</span><div class="logs-message">${message}</div>${context?'':`<button data-context="${row.id}" aria-label="Show context for line ${row.id}" title="Show surrounding lines">${icon('unfold_more')}</button>`}</div>`;
     }
     async function refresh() {
       if (busy || !alive) return;
@@ -119,23 +196,31 @@ const LogsPage = {
         if(latestRequested){
           latestRequested=false;
           if(latestRunId){runId=latestRunId;listing=await api('',{channel,...scope()});if(!alive||token!==sequence)return;}
-          else notice('No saved run for this pair yet. Logs will appear after its next sync.');
           writeRoute();
         }
         sessions = listing.items;
         host.querySelectorAll('[data-channel]').forEach(b=>{b.hidden=!listing.channels.includes(b.dataset.channel)});
-        if (!listing.channels.includes(channel)) { channel='sync'; runId=''; sid=''; scheduleReload(); return; }
-        $('[data-storage]').textContent = `${listing.retention_days}-day retention · ${Math.round(listing.used_bytes/1048576)} / ${Math.round(listing.max_bytes/1048576)} MB`;
+        if (!listing.channels.includes(channel)) { channel='sync'; runId=''; latestRequested=false; showingRuns=mode==='saved'; clearFilters(); reset(); return; }
+        const used = Math.max(0, Number(listing.used_bytes) || 0), capacity = Math.max(0, Number(listing.max_bytes) || 0);
+        const percent = capacity ? Math.min(100, used / capacity * 100) : 0;
+        const size = bytes => (bytes / 1048576).toLocaleString(undefined, {maximumFractionDigits:1});
+        const storageText = `${size(used)} / ${size(capacity)} MB`;
+        $('[data-storage]').hidden = false;
+        $('[data-storage]').dataset.usage = percent >= 95 ? 'high' : percent >= 80 ? 'warning' : 'normal';
+        $('[data-storage-size]').textContent = storageText;
+        $('[data-retention]').textContent = `${listing.retention_days}-day retention`;
+        $('[data-storage-meter]').value = percent;
+        $('[data-storage-meter]').setAttribute('aria-valuetext', `${storageText} used`);
         if (showingRuns) {
           if (runId && sessions.length) { sid=sessions[0].id; showingRuns=false; }
-          else {renderRuns(); $('[data-connection]').textContent='Saved on this server'; return;}
+          else {renderRuns(); connection('Saved on this server', 'dns'); return;}
         }
         if (mode === 'live') {
           const newest = sessions.find(s=>s.ended===null) || sessions[0];
           if (newest && newest.id!==sid) {sid=newest.id;offset=0;}
         }
         current=sessions.find(s=>s.id===sid) || null;
-        if (!current) { rows=[];total=0;$('[data-output]').innerHTML='<div class="logs-empty">No logs available yet. Logging is saved automatically as activity arrives.</div>';$('[data-connection]').textContent='Waiting for activity';paintControls();return; }
+        if (!current) { rows=[];total=0;output(emptyState('sensors', 'Waiting for activity', 'New log lines will appear here automatically.'));connection('Waiting for activity');paintControls();return; }
         let data=await api(`/${sid}/lines`,{q:query,level,provider,offset,limit:500,...scope()});
         if (!alive || token!==sequence) return;
         const nextOffset=follow?Math.max(0,Math.floor((data.total-1)/500)*500):Math.min(offset,Math.max(0,Math.floor((data.total-1)/500)*500));
@@ -143,17 +228,18 @@ const LogsPage = {
         if (!alive || token!==sequence) return;
         current=data.session;total=data.total;
         // Keep expanded context and text selection intact when the page did not change.
-        if (JSON.stringify(rows)!==JSON.stringify(data.items)) {
+        if (!data.items.length || JSON.stringify(rows)!==JSON.stringify(data.items)) {
           rows=data.items;
-          $('[data-output]').innerHTML=rows.map(r=>lineMarkup(r)).join('') || '<div class="logs-empty">No matching lines. Try a different search or level.</div>';
+          visibleRows.clear();
+          output(rows.map(r=>lineMarkup(r)).join('') || emptyState('search_off', 'No matching lines', 'Try another search or adjust the level and provider filters.'));
           $('#log-providers').innerHTML=[...new Set(rows.map(r=>r.provider))].sort().map(p=>`<option value="${esc(p)}"></option>`).join('');
           if(follow) content.scrollTop=content.scrollHeight;
         }
         if (pendingMatch !== null) {revealMatch(pendingMatch < 0 ? rows.length-1 : 0);pendingMatch=null;}
-        $('[data-connection]').textContent = mode==='live' ? current.ended ? 'Waiting for activity' : 'Live · updates every 2s' : 'Saved log';
+        connection(mode==='live' ? current.ended ? 'Waiting for activity' : 'Live · updates every 2s' : 'Saved log', mode==='live' ? 'sensors' : 'dns', mode==='live' && !current.ended ? 'live' : 'idle');
         if(current.truncated) notice('This log reached the storage limit. Some lines were not saved. Delete or unpin older logs to free space.');
         paintControls();
-      } catch(error) {if(alive && token===sequence && error.name!=='AbortError'){notice(error.message);$('[data-connection]').textContent='Disconnected · retrying';}}
+      } catch(error) {if(alive && token===sequence && error.name!=='AbortError'){notice(error.message);connection('Disconnected · retrying', 'cloud_off', 'error');}}
       finally {busy=false;}
     }
     function scheduleReload() {
@@ -163,7 +249,7 @@ const LogsPage = {
     function reset() {sid='';current=null;offset=0;total=0;listPage=0;rows=[];pendingMatch=null;$('[data-output]').replaceChildren();notice();scheduleReload();paintControls();writeRoute();}
     host.addEventListener('click', onClick);
     async function onClick(event) {
-      const button=event.target.closest('button');if(!button)return;
+      const button=event.target.closest('button, tr[data-session]');if(!button)return;
       try {
         if(button.dataset.channel){channel=button.dataset.channel;if(channel==='watcher'){runId='';pairId='';latestRequested=false;}showingRuns=mode==='saved';reset();}
         else if(button.dataset.mode){mode=button.dataset.mode;showingRuns=mode==='saved';follow=mode==='live';runId='';latestRequested=false;reset();}
@@ -189,18 +275,33 @@ const LogsPage = {
           if(!sid)return; const full=button.hasAttribute('data-copy-full')||button.hasAttribute('data-download-full');
           const res=await fetch(url(`/${sid}/download`,{...scope(),...(full?{}:{q:query,level,provider})}),{cache:'no-store'});if(!res.ok)throw new Error('Could not export this log.');
           const text=await res.text();if(!alive)return;
-          if(button.hasAttribute('data-copy')||button.hasAttribute('data-copy-full')){await navigator.clipboard.writeText(text);notice('Log copied.');}
+          if(button.hasAttribute('data-copy')||button.hasAttribute('data-copy-full')){await navigator.clipboard.writeText(text);copied(button);}
           else {const link=document.createElement('a');const object=URL.createObjectURL(new Blob([text],{type:'text/plain'}));link.href=object;link.download=`crosswatch-${channel}-${sid}.log`;link.click();setTimeout(()=>URL.revokeObjectURL(object),1000);}
         }
       } catch(error){if(alive)notice(error.message);}
     }
     for(const selector of ['[data-query]','[data-level]','[data-provider]']) $(selector).addEventListener('input',()=>{query=$('[data-query]').value;level=$('[data-level]').value;provider=$('[data-provider]').value.trim().toUpperCase();offset=0;follow=false;pendingMatch=null;notice();scheduleReload();});
     $('[data-pair]').addEventListener('input',()=>{pairId=$('[data-pair]').value;runId='';latestRequested=mode==='saved';showingRuns=mode==='saved';follow=mode==='live';clearFilters();reset();});
-    $('[data-wrap]').onchange=()=>content.classList.toggle('logs-nowrap',!$('[data-wrap]').checked);
+    $('[data-wrap]').onchange=()=>{
+      content.classList.toggle('logs-nowrap',!$('[data-wrap]').checked);
+      content.scrollLeft=0;
+      if(follow)content.scrollTop=content.scrollHeight;
+    };
+    $('[data-readable]').onchange=()=>{
+      readable=$('[data-readable]').checked;
+      try { window.localStorage.setItem('cw.logs.readable',readable ? 'on' : 'off'); } catch {}
+      const top=content.scrollTop;
+      content.classList.toggle('logs-pretty',readable);
+      host.querySelectorAll('[data-log-id]').forEach(line=>{
+        const row=visibleRows.get(line.dataset.logId);
+        if(row)line.querySelector('.logs-message').innerHTML=readable ? readableLogHTML(row,highlight,query,window.CW?.ProviderMeta) : highlight(row.text,query);
+      });
+      content.scrollTop=follow ? content.scrollHeight : top;
+    };
     content.addEventListener('wheel',event=>{if(event.deltaY<0){follow=false;paintControls();}},{passive:true});
     content.addEventListener('scroll',()=>{if(follow && content.scrollHeight-content.scrollTop-content.clientHeight>50){follow=false;paintControls();}});
     timer=setInterval(refresh,2000);
-    dispose=()=>{alive=false;sequence++;controller?.abort();clearInterval(timer);clearTimeout(searchTimer);window.removeEventListener('resize',resize);host.removeEventListener('click',onClick);};
+    dispose=()=>{alive=false;sequence++;controller?.abort();clearInterval(timer);clearTimeout(searchTimer);for(const feedback of copyFeedback.values())clearTimeout(feedback.timer);copyFeedback.clear();window.removeEventListener('resize',resize);host.removeEventListener('click',onClick);};
     paintControls();await refresh();resize();
   },
   hide(){dispose?.();dispose=null;},

--- a/assets/js/modals.js
+++ b/assets/js/modals.js
@@ -2,6 +2,8 @@
 /* CrossWatch - JavaScript Modal Management Module */
 /* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
 
+import {statisticsReturn, resumeEventsReturn} from './page-return.js';
+
 const _cwGetV = () => {
   try {
     return (window.__CW_VERSION__ || new URL(import.meta.url).searchParams.get('v') || Date.now());
@@ -59,6 +61,10 @@ window.openLogs = (props = {}) => {
   if (props.runId) query.set('runId', props.runId);
   if (props.pairId) query.set('pairId', props.pairId);
   if (props.latest) query.set('latest', '1');
+  const returnTo = location.hash.startsWith('#logs')
+    ? new URLSearchParams(location.hash.split('?')[1] || '').get('returnTo')
+    : location.pathname + location.search + location.hash;
+  if (returnTo) query.set('returnTo', returnTo);
   const hash = '#logs?' + query;
   ModalRegistry.close();
   if (!document.getElementById('page-logs') || !window.showTab) { location.href = '/?main=1' + hash; return; }
@@ -70,6 +76,11 @@ window.openEvents = (props = {}) => {
   for (const [key, value] of Object.entries({ groupId: props.groupId || props.eventGroupId, runId: props.runId || props.run_id, domain: props.domain, visibility: props.visibility, mode: props.mode })) {
     if (value) query.set(key, String(value));
   }
+  const previous = location.hash.split('?')[0] === '#events' ? new URLSearchParams(location.hash.split('?')[1] || '') : null;
+  const returnTo = previous ? previous.get('returnTo') : location.pathname + location.search + location.hash;
+  const returnContext = statisticsReturn(props.returnContext || previous?.get('returnContext'));
+  if (returnTo) query.set('returnTo', returnTo);
+  if (returnContext) query.set('returnContext', JSON.stringify(returnContext));
   const hash = '#events' + (query.size ? `?${query}` : '');
   ModalRegistry.close();
   if (!document.getElementById('page-events') || !window.showTab) {
@@ -80,6 +91,8 @@ window.openEvents = (props = {}) => {
   return window.showTab('events');
 };
 window.openStatisticsModal = (props = {}) => ModalRegistry.open('statistics', props);
+if (document.readyState === 'complete') resumeEventsReturn();
+else window.addEventListener('load', resumeEventsReturn, {once:true});
 window.openExporter = () => window.showTab ? window.showTab('import_export') : (location.hash = 'import_export');
 
 window.openMaintenanceModal = (props = {}) => ModalRegistry.open('maintenance', props);

--- a/assets/js/modals/statistics/index.js
+++ b/assets/js/modals/statistics/index.js
@@ -2,6 +2,8 @@
 /* CrossWatch - Sync activity modal */
 /* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
 
+import {statisticsReturn} from '../../page-return.js';
+
 const esc = (s) => String(s ?? "").replace(/[&<>"']/g, (c) => (
   { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]
 ));
@@ -149,8 +151,9 @@ export default {
     }
 
     let alive = true;
-    let range = RANGES.some((r) => r.value === ls("cw.stats.range", "")) ? ls("cw.stats.range", "12m") : "12m";
-    let metric = METRICS.some((m) => m.value === ls("cw.stats.metric", "")) ? ls("cw.stats.metric", "changes") : "changes";
+    let restored = statisticsReturn(props);
+    let range = restored?.range || (RANGES.some((r) => r.value === ls("cw.stats.range", "")) ? ls("cw.stats.range", "12m") : "12m");
+    let metric = restored?.metric || (METRICS.some((m) => m.value === ls("cw.stats.metric", "")) ? ls("cw.stats.metric", "changes") : "changes");
     let payload = null;
     let byIndex = new Map();
     let selected = Number(props?.day) || null;
@@ -383,8 +386,7 @@ export default {
         const id = btn.closest(".sc-run")?.dataset?.run;
         const openEvents = window.openEvents;
         if (!id || typeof openEvents !== "function") return;
-        window.cxCloseModal?.();
-        openEvents({ runId: id, domain: "sync", visibility: "all", mode: "grouped" });
+        openEvents({ runId: id, domain: "sync", visibility: "all", mode: "grouped", returnContext:{modal:'statistics',day:selected,range,metric,filter:dayState.filter,expanded:[...dayState.expanded]} });
       }));
     };
 
@@ -421,6 +423,11 @@ export default {
     const selectDay = async (index) => {
       selected = index;
       dayState = { index, runs: [], loading: true, error: "", filter: "", expanded: new Set() };
+      if (restored?.day === index) {
+        dayState.filter = restored.filter;
+        dayState.expanded = new Set(restored.expanded);
+      }
+      restored = null;
       renderCalendar();
       renderDay();
       const since = index * DAY - TZ;

--- a/assets/js/page-return.js
+++ b/assets/js/page-return.js
@@ -1,0 +1,71 @@
+/* assets/js/page-return.js */
+/* CrossWatch - Page return navigation */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+
+export function pageBackLink(returnTo, currentHref, source = 'logs') {
+  const fallback = {href:'#main', label:'Main'};
+  if (!returnTo) return fallback;
+  try {
+    const current = new URL(currentHref), target = new URL(returnTo, current);
+    if (target.origin !== current.origin || target.username || target.password) return fallback;
+    const path = target.hash.slice(1).split('?')[0];
+    if (path === source) return fallback;
+    const labels = new Map([
+      ['', 'Main'], ['main', 'Main'], ['watchlist', 'Watchlist'], ['playback_progress', 'Playback'],
+      ['snapshots', 'Captures'], ['playlists', 'Playlists'], ['editor', 'Editor'], ['analyzer', 'Sync Analyzer'],
+      ['events', 'Events'], ['logs', 'Logs'], ['import_export', 'Import and Export'], ['interactive_sync', 'Interactive Sync'],
+      ['settings', 'Settings'], ['settings/overview', 'Settings'], ['settings/providers', 'Connections'],
+      ['settings/sync', 'Sync pairs'], ['settings/pairs', 'Sync pairs'], ['settings/scrobbler', 'Scrobbler'],
+      ['settings/scheduling', 'Scheduling'], ['settings/app', 'UI and Security'], ['settings/maintenance', 'Maintenance'],
+    ]);
+    const label = target.pathname === '/profile' ? 'Profile' : target.pathname === '/' ? labels.get(path) : null;
+    if (!label) return fallback;
+    const href = target.pathname === current.pathname && target.search === current.search
+      ? target.hash || '#main' : target.pathname + target.search + target.hash;
+    return {href, label};
+  } catch { return fallback; }
+}
+
+export function statisticsReturn(value) {
+  try {
+    const data = typeof value === 'string' ? JSON.parse(value) : value;
+    if (data?.modal !== 'statistics') return null;
+    return {
+      modal:'statistics',
+      day:Number.isInteger(data.day) && data.day >= 0 && data.day < 1000000 ? data.day : null,
+      range:['3m','6m','12m'].includes(data.range) ? data.range : '12m',
+      metric:['changes','runs','failed'].includes(data.metric) ? data.metric : 'changes',
+      filter:typeof data.filter === 'string' ? data.filter.slice(0,200) : '',
+      expanded:Array.isArray(data.expanded) ? data.expanded.filter(v=>typeof v==='string').slice(0,300) : [],
+    };
+  } catch { return null; }
+}
+
+export async function returnFromEvents(props) {
+  const back = pageBackLink(props.returnTo, location.href, 'events');
+  const modal = statisticsReturn(props.returnContext);
+  const target = new URL(back.href, location.href);
+  if (target.pathname !== location.pathname || target.search !== location.search || !window.showTab) {
+    if (modal) {
+      try { sessionStorage.setItem('cw.events.pendingReturn',JSON.stringify({href:target.href,modal})); } catch {}
+    }
+    location.href = target.href;
+    return;
+  }
+  history.pushState(null,'',target.href);
+  const route = target.hash.slice(1).split('?')[0];
+  const [tab, pane] = route.split('/');
+  if (tab === 'settings') window.__cwSettingsPane = pane || 'overview';
+  await window.showTab(tab || 'main');
+  if (modal) await window.openStatisticsModal?.(modal);
+}
+
+export function resumeEventsReturn() {
+  try {
+    const saved = JSON.parse(sessionStorage.getItem('cw.events.pendingReturn') || 'null');
+    sessionStorage.removeItem('cw.events.pendingReturn');
+    if (saved?.href !== location.href) return;
+    const modal = statisticsReturn(saved.modal);
+    if (modal) window.openStatisticsModal?.(modal);
+  } catch {}
+}

--- a/tests/events-page.test.mjs
+++ b/tests/events-page.test.mjs
@@ -5,6 +5,62 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+import {pageBackLink,statisticsReturn,returnFromEvents,resumeEventsReturn} from '../assets/js/page-return.js';
+
+test('Events captures its caller and keeps Sync activity context when opened again',async()=>{
+  const source=await readFile(new URL('../assets/js/modals.js',import.meta.url),'utf8');
+  const script=source.slice(source.indexOf('window.openEvents ='),source.indexOf('window.openStatisticsModal ='));
+  const location=new URL('http://localhost/?main=1#settings/sync');
+  const context={location,URLSearchParams,statisticsReturn,ModalRegistry:{close(){}},document:{getElementById:()=>({})},window:{showTab(){}},history:{pushState(_state,_title,hash){location.hash=hash;}}};
+  vm.runInNewContext(script,context);
+  const restore={modal:'statistics',day:20704,range:'6m',metric:'runs',filter:'Plex',expanded:['run-one']};
+  context.window.openEvents({runId:'run-one',returnContext:restore});
+  let query=new URLSearchParams(location.hash.split('?')[1]);
+  assert.equal(query.get('returnTo'),'/?main=1#settings/sync');
+  assert.deepEqual(JSON.parse(query.get('returnContext')),restore);
+  context.window.openEvents({groupId:'42'});
+  query=new URLSearchParams(location.hash.split('?')[1]);
+  assert.equal(query.get('returnTo'),'/?main=1#settings/sync');
+  assert.deepEqual(JSON.parse(query.get('returnContext')),restore);
+});
+
+test('Events safely labels callers and only accepts the supported return modal',()=>{
+  const current='http://localhost/#events';
+  assert.deepEqual(pageBackLink('/#settings/sync',current,'events'),{href:'#settings/sync',label:'Sync pairs'});
+  assert.deepEqual(pageBackLink('/profile',current,'events'),{href:'/profile',label:'Profile'});
+  for(const url of ['https://example.com/','javascript:alert(1)','/#events?runId=one'])assert.equal(pageBackLink(url,current,'events').href,'#main');
+  assert.equal(statisticsReturn('{invalid'),null);
+  assert.equal(statisticsReturn({modal:'maintenance'}),null);
+  assert.deepEqual(statisticsReturn({modal:'statistics',day:-1,range:'bad',metric:'bad'}),{modal:'statistics',day:null,range:'12m',metric:'changes',filter:'',expanded:[]});
+});
+
+test('Events returns to the settings pane before reopening Sync activity',async()=>{
+  const calls=[];
+  globalThis.location=new URL('http://localhost/#events');
+  globalThis.history={pushState(_state,_title,href){location.href=href;}};
+  globalThis.window={async showTab(tab){calls.push([tab,window.__cwSettingsPane]);},async openStatisticsModal(props){calls.push(props);}};
+  const restore={modal:'statistics',day:20704,range:'3m',metric:'failed',filter:'SIMKL',expanded:['one']};
+  try {
+    await returnFromEvents({returnTo:'/#settings/sync',returnContext:JSON.stringify(restore)});
+    assert.deepEqual(calls,[['settings','sync'],restore]);
+    assert.equal(location.hash,'#settings/sync');
+  } finally {delete globalThis.window;delete globalThis.location;delete globalThis.history;}
+});
+
+test('a return across pages restores Sync activity once on the destination',async()=>{
+  const saved=new Map(),opened=[];
+  globalThis.location=new URL('http://localhost/?main=1#events');
+  globalThis.sessionStorage={getItem:key=>saved.get(key),setItem:(key,value)=>saved.set(key,value),removeItem:key=>saved.delete(key)};
+  globalThis.window={openStatisticsModal:props=>opened.push(props)};
+  try {
+    await returnFromEvents({returnTo:'/profile',returnContext:{modal:'statistics',day:20704}});
+    assert.equal(location.href,'http://localhost/profile');
+    resumeEventsReturn();resumeEventsReturn();
+    assert.equal(opened.length,1);
+    assert.equal(opened[0].day,20704);
+  } finally {delete globalThis.window;delete globalThis.location;delete globalThis.sessionStorage;}
+});
 
 test('Events retains the view on return and isolates a new route or profile', async () => {
   const calls = [];

--- a/tests/logs-format.test.mjs
+++ b/tests/logs-format.test.mjs
@@ -100,7 +100,19 @@ test('search reveals raw-only matches and all log values are escaped',()=>{
   assert.match(html,/<mark>internal_key<\/mark>/);
   assert.doesNotMatch(html,/<img src=x/);
   assert.match(html,/&lt;img/);
-  const plain=readableLogHTML({text:'<script>alert(1)</script>'},highlight);
-  assert.doesNotMatch(plain,/<script>/);
   assert.equal(describeLog(row({event:'__proto__'})).summary,'Proto');
+});
+
+test('readable summaries and original logs escape HTML in every tag case',()=>{
+  for(const [text,escaped] of [
+    ['<script>alert(1)</script>','&lt;script&gt;alert(1)&lt;/script&gt;'],
+    ['<SCRIPT>alert(1)</SCRIPT>','&lt;SCRIPT&gt;alert(1)&lt;/SCRIPT&gt;'],
+    ['<ScRiPt src="x">alert(1)</ScRiPt >','&lt;ScRiPt src=&quot;x&quot;&gt;alert(1)&lt;/ScRiPt &gt;'],
+    ["<IMG src=x onerror='alert(1)'> & text",'&lt;IMG src=x onerror=&#39;alert(1)&#39;&gt; &amp; text'],
+  ]) {
+    assert.equal(readableLogHTML({text},highlight),
+      `<span class="logs-readable-summary">${escaped}</span><details class="logs-original"><summary>Original log</summary><pre>${escaped}</pre></details>`);
+  }
+  assert.equal(highlight('<ScRiPt>alert(1)</ScRiPt>','script'),
+    '&lt;<mark>ScRiPt</mark>&gt;alert(1)&lt;/<mark>ScRiPt</mark>&gt;');
 });

--- a/tests/logs-format.test.mjs
+++ b/tests/logs-format.test.mjs
@@ -1,0 +1,106 @@
+/* tests/logs-format.test.mjs */
+/* CrossWatch - Readable log formatting and original data preservation tests */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {describeLog,readableLogHTML} from '../assets/js/logs-format.js';
+globalThis.window={addEventListener(){}};
+const {highlight}=await import('../assets/js/logs.js');
+const row = data => ({text:JSON.stringify(data),provider:'SYNC',level:'INFO'});
+
+test('sync start uses a matching card and pair details use branded pills',()=>{
+  const text='[SYNC] INFO SYNC start: orchestrator pairs run_id=1788821602';
+  const result=describeLog({text});
+  assert.equal(result.summary,'Sync started');
+  assert.equal(result.start,true);
+  assert.deepEqual(result.pills,[{label:'Run',value:'1788821602',tone:''}]);
+  const html=readableLogHTML({text},highlight,'orchestrator');
+  assert.match(html,/logs-completion-start/);
+  assert.match(html,/<details class="logs-original" open>/);
+  const pair={text:'[i] Running single pair: PLEX → SIMKL (pair_981e2ec7613e)'};
+  assert.deepEqual(describeLog(pair).pills,[{label:'From',value:'PLEX',tone:'provider'},{label:'To',value:'SIMKL',tone:'provider'},{label:'Pair',value:'pair_981e2ec7613e',tone:''}]);
+  assert.match(readableLogHTML(pair,highlight,'',{brandInfo:value=>({label:value,icon:`/assets/img/${value}.svg`})}),/PLEX\.svg/);
+  assert.equal(describeLog(pair).raw,pair.text);
+  assert.equal(describeLog({text:'SYNC start: something else'}).structured,false);
+});
+
+test('state diagnostics distinguish loaded adapters from saved-state providers',()=>{
+  for(const [field,label,count] of [['loaded_adapters','Loaded adapters',18],['saved_state_providers','Saved-state providers',4],['saved_state_providers','Saved-state providers',0]]) {
+    const entry=row({event:'debug',msg:'state.persisted',[field]:count});
+    const result=describeLog(entry);
+    assert.equal(result.summary,'Sync state saved');
+    assert.deepEqual(result.pills,[{label,value:String(count),tone:''}]);
+    assert.equal(result.raw,entry.text);
+    assert.match(readableLogHTML(entry,highlight,field),/<details class="logs-original" open>/);
+  }
+  assert.deepEqual(describeLog(row({event:'debug',msg:'state.persisted',providers:4})).pills,[{label:'Providers',value:'4',tone:''}]);
+});
+
+test('final text totals become a prominent summary with all seven counts',()=>{
+  const text='2026-09-07T20:48:22.000+00:00 [SYNC] INFO [i] Done. Total added: 0, Total removed: 0, Total updated: 0, Total skipped: 0, Total unresolved: 0, Total errors: 0, Total blocked: 0';
+  const result=describeLog({text});
+  assert.equal(result.summary,'Sync completed');
+  assert.equal(result.completion,'success');
+  assert.deepEqual(result.pills.map(p=>p.label),['Added','Removed','Updated','Skipped','Unresolved','Errors','Blocked']);
+  assert.ok(result.pills.every(p=>p.value==='0' && p.tone===''));
+  assert.equal(result.raw,text);
+  const errors=describeLog({text:text.replace('Total errors: 0','Total errors: 12')});
+  assert.equal(errors.summary,'Sync finished with issues');
+  assert.equal(errors.completion,'error');
+  assert.ok(errors.pills.some(p=>p.label==='Errors' && p.value==='12' && p.tone==='error'));
+  assert.equal(describeLog({text:text.replace('Total unresolved: 0','Total unresolved: 3')}).completion,'warning');
+  assert.equal(describeLog({text:text.replace('Done.','Cancelled.')}).summary,'Sync cancelled');
+  const html=readableLogHTML({text},highlight,'Total added');
+  assert.match(html,/logs-completion-success/);
+  assert.match(html,/<details class="logs-original" open>/);
+  for(const invalid of [text+' extra details',text.replace('Total errors: 0','Total errors: unknown')])assert.equal(describeLog({text:invalid}).structured,false);
+});
+
+test('structured sync events become messages and useful pills',()=>{
+  const result=describeLog(row({event:'run:done',added:2,updated:1,removed:0,errors:0,pairs:1}));
+  assert.equal(result.summary,'Sync finished');
+  assert.ok(result.pills.some(p=>p.label==='Added' && p.value==='2'));
+  assert.ok(result.pills.some(p=>p.label==='Errors' && p.value==='0'));
+  assert.equal(describeLog(row({event:'run:done',errors:1})).summary,'Sync finished with issues');
+  assert.equal(describeLog(row({event:'run:done',cancelled:true})).summary,'Sync cancelled');
+  assert.equal(describeLog(row({event:'debug',msg:'state.persisted'})).summary,'Sync state saved');
+  const progress=describeLog(row({event:'snapshot:progress',done:6,total:6,feature:'watchlist'}));
+  assert.equal(progress.summary,'Reading progress');
+  assert.ok(progress.pills.some(p=>p.value==='6 / 6'));
+});
+
+test('provider health retains nested details in the original log',()=>{
+  const health=row({event:'health',provider:'PLEX',status:'ok',latency_ms:137,api:{pms:{status:200}},features:{watchlist:true}});
+  const result=describeLog(health);
+  assert.equal(result.summary,'Provider health checked');
+  assert.ok(result.pills.some(p=>p.value==='137 ms'));
+  assert.equal(result.raw,health.text);
+  const html=readableLogHTML(health,highlight,'', {brandInfo:()=>({label:'Plex',icon:'/assets/img/PLEX.svg'})});
+  assert.match(html,/PLEX\.svg/);
+  assert.match(html,/Original log/);
+  assert.match(html,/&quot;pms&quot;/);
+});
+
+test('known timestamp and level prefixes are removed without losing the original',()=>{
+  const text='2026-09-07T20:48:20.486+00:00 [SYNC] INFO [i] Sync started';
+  assert.deepEqual(describeLog({text}),{summary:'Sync started',raw:text,pills:[],structured:false});
+  const structured='[2026-09-07 20:48:21] [SYNC] DEBUG {"event":"debug","msg":"state.persisted"}';
+  assert.equal(describeLog({text:structured}).summary,'Sync state saved');
+  for(const text of ['unexpected {broken json','[custom message] with details','{"event":broken','[]']) {
+    assert.equal(describeLog({text}).summary,text);
+    assert.equal(describeLog({text}).raw,text);
+  }
+});
+
+test('search reveals raw-only matches and all log values are escaped',()=>{
+  const entry=row({event:'run:done',nested:{internal_key:'<img src=x onerror=alert(1)>'},errors:0});
+  const html=readableLogHTML(entry,highlight,'internal_key');
+  assert.match(html,/<details class="logs-original" open>/);
+  assert.match(html,/<mark>internal_key<\/mark>/);
+  assert.doesNotMatch(html,/<img src=x/);
+  assert.match(html,/&lt;img/);
+  const plain=readableLogHTML({text:'<script>alert(1)</script>'},highlight);
+  assert.doesNotMatch(plain,/<script>/);
+  assert.equal(describeLog(row({event:'__proto__'})).summary,'Proto');
+});

--- a/tests/logs-page.test.mjs
+++ b/tests/logs-page.test.mjs
@@ -4,10 +4,75 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import vm from 'node:vm';
+import {readFileSync} from 'node:fs';
 globalThis.window={addEventListener(){}};
-const {highlight}=await import('../assets/js/logs.js');
+const {highlight,logsBackLink,savedLogFeatures,savedLogsTable}=await import('../assets/js/logs.js');
+
+test('saved features use the archived settings and respect the selected pair',()=>{
+  const pairs=[{id:'a',features:{watchlist:true,ratings:{enable:false},history:{enable:true}}},{id:'b',features:{ratings:{enabled:'on'},progress:true,playlists:'false',collection:1}}];
+  const session={pairs:JSON.stringify(pairs)};
+  assert.deepEqual(savedLogFeatures(session),[true,true,true,true,false,true]);
+  assert.deepEqual(savedLogFeatures(session,'a'),[true,false,true,false,false,false]);
+  assert.equal(savedLogFeatures(session,'missing'),null);
+  assert.equal(savedLogFeatures({pairs:'invalid'}),null);
+  assert.equal(savedLogFeatures({pairs:[{id:'old'}]}),null);
+  pairs[0].features.watchlist=false;
+  assert.equal(savedLogFeatures(session,'a')[0],true);
+});
+
+test('saved logs render columns, feature states, status badges and safe log labels',()=>{
+  const base={id:'one',label:'PLEX <script> to TRAKT',started:100,ended:102,status:'completed',errors:0,warnings:0,pairs:JSON.stringify([{id:'a',features:{ratings:true,history:true,progress:true}}])};
+  const html=savedLogsTable([base]);
+  for(const name of ['Sync pair','Features','Started','Duration','Status','Errors','Warnings'])assert.ok(html.includes(name));
+  assert.equal((html.match(/class="logs-feature-dot /g)||[]).length,6);
+  assert.equal((html.match(/class="logs-feature-dot \w+ on"/g)||[]).length,3);
+  assert.match(html,/logs-status-success/);assert.match(html,/>2s</);
+  assert.match(html,/PLEX &lt;script&gt;/);assert.doesNotMatch(html,/<script>/);
+  assert.match(savedLogsTable([{...base,status:'issues'}]),/logs-status-warning/);
+  assert.match(savedLogsTable([{...base,status:'__proto__'}]),/logs-status-neutral/);
+  assert.match(savedLogsTable([{...base,pairs:'[]'}]),/Feature settings unavailable/);
+});
 test('search highlights literal matches and escapes log HTML',()=>{
   assert.equal(highlight('<script>Error & ERROR</script>','error'),'&lt;script&gt;<mark>Error</mark> &amp; <mark>ERROR</mark>&lt;/script&gt;');
   assert.equal(highlight('x.* x.*','.*'),'x<mark>.*</mark> x<mark>.*</mark>');
   assert.equal(highlight('plain <text>',''),'plain &lt;text&gt;');
+});
+
+test('Logs returns to its caller with the correct label and route parameters',()=>{
+  const current='http://localhost/?main=1#logs?channel=sync';
+  assert.deepEqual(logsBackLink('/?main=1#settings/sync',current),{href:'#settings/sync',label:'Sync pairs'});
+  assert.deepEqual(logsBackLink('/?main=1#events?runId=abc&visibility=all',current),{href:'#events?runId=abc&visibility=all',label:'Events'});
+  assert.deepEqual(logsBackLink('/profile#preferences',current),{href:'/profile#preferences',label:'Profile'});
+  assert.deepEqual(logsBackLink('/?main=1',current),{href:'#main',label:'Main'});
+});
+
+test('direct links and invalid return destinations fall back to Main',()=>{
+  for(const target of [null,'https://example.com/#events','//example.com/#events','javascript:alert(1)','/api/logs/archive','/#logs?channel=debug','/#unknown']){
+    assert.deepEqual(logsBackLink(target,'http://localhost/#logs'),{href:'#main',label:'Main'});
+  }
+});
+
+test('opening Logs captures the caller before navigation and preserves it when reopened',()=>{
+  const source=readFileSync(new URL('../assets/js/modals.js',import.meta.url),'utf8');
+  const start=source.indexOf('window.openLogs =');
+  const script=source.slice(start,source.indexOf('window.openEvents =',start));
+  const url=new URL('http://localhost/?main=1#settings/sync');
+  const location={get pathname(){return url.pathname;},get search(){return url.search;},
+    get hash(){return url.hash;},set hash(value){url.hash=value;},
+    get href(){return url.href;},set href(value){url.href=new URL(value,url).href;}};
+  const context={location,URLSearchParams,ModalRegistry:{close(){}},document:{getElementById(){return {}; }},
+    window:{showTab(tab){assert.equal(tab,'logs');}},history:{pushState(_state,_title,hash){location.hash=hash;}}};
+  vm.runInNewContext(script,context);
+  context.window.openLogs({pairId:'pair 5',latest:true});
+  let route=new URLSearchParams(location.hash.split('?')[1]);
+  assert.equal(route.get('returnTo'),'/?main=1#settings/sync');
+  assert.equal(route.get('pairId'),'pair 5');
+  context.window.openLogs({channel:'debug'});
+  route=new URLSearchParams(location.hash.split('?')[1]);
+  assert.equal(route.get('returnTo'),'/?main=1#settings/sync');
+  location.href='http://localhost/profile';
+  context.document.getElementById=()=>null;
+  context.window.openLogs();
+  assert.equal(new URLSearchParams(location.hash.split('?')[1]).get('returnTo'),'/profile');
 });

--- a/tests/logs-page.test.mjs
+++ b/tests/logs-page.test.mjs
@@ -28,10 +28,25 @@ test('saved logs render columns, feature states, status badges and safe log labe
   assert.equal((html.match(/class="logs-feature-dot /g)||[]).length,6);
   assert.equal((html.match(/class="logs-feature-dot \w+ on"/g)||[]).length,3);
   assert.match(html,/logs-status-success/);assert.match(html,/>2s</);
-  assert.match(html,/PLEX &lt;script&gt;/);assert.doesNotMatch(html,/<script>/);
+  assert.ok(html.includes('<strong>PLEX &lt;script&gt; to TRAKT</strong>'));
   assert.match(savedLogsTable([{...base,status:'issues'}]),/logs-status-warning/);
   assert.match(savedLogsTable([{...base,status:'__proto__'}]),/logs-status-neutral/);
   assert.match(savedLogsTable([{...base,pairs:'[]'}]),/Feature settings unavailable/);
+});
+
+test('saved log labels escape tags and quotes in both text and attributes',()=>{
+  const base={id:'one',started:100,ended:102,status:'completed',errors:0,warnings:0};
+  for(const [label,escaped] of [
+    ['<script>alert(1)</script>','&lt;script&gt;alert(1)&lt;/script&gt;'],
+    ['<SCRIPT>alert(1)</SCRIPT>','&lt;SCRIPT&gt;alert(1)&lt;/SCRIPT&gt;'],
+    ['<ScRiPt src="x">alert(1)</ScRiPt >','&lt;ScRiPt src=&quot;x&quot;&gt;alert(1)&lt;/ScRiPt &gt;'],
+    ['" onmouseover="alert(1)" & \'quoted\'','&quot; onmouseover=&quot;alert(1)&quot; &amp; &#39;quoted&#39;'],
+  ]) {
+    const html=savedLogsTable([{...base,label}]);
+    assert.ok(html.includes(`<strong>${escaped}</strong>`));
+    assert.ok(html.includes(`aria-label="Open log: ${escaped}"`));
+    assert.equal(html,savedLogsTable([{...base,label:'SAFE_LABEL'}]).replaceAll('SAFE_LABEL',escaped));
+  }
 });
 test('search highlights literal matches and escapes log HTML',()=>{
   assert.equal(highlight('<script>Error & ERROR</script>','error'),'&lt;script&gt;<mark>Error</mark> &amp; <mark>ERROR</mark>&lt;/script&gt;');


### PR DESCRIPTION
# Pull request

## Change

- Add readable logs with summary cards, branded pills and expandable original messages.
- Display saved logs in columns with feature indicators and storage usage.
- Improve line wrapping, dropdown alignment and copy feedback.
- Return Logs and Events to their caller, preserving Sync activity selections.

## Why

Make logs easier to understand and let users return to where they opened diagnostics.

## Testing

- events-page.test.mjs
- logs-page.test.mjs
- logs-format.test.mjs.

## Issue

NA