### PR TITLE
Change: save baselines for empty i-syncs

### DIFF
--- a/assets/js/interactive-sync.js
+++ b/assets/js/interactive-sync.js
@@ -170,7 +170,7 @@
   function reportHTML() {
     const report = session.report, totals = report.totals;
     const outcomes = {
-      success: ["check_circle", "Sync completed", "The sync engine finished processing your selected changes."],
+      success: ["check_circle", "Sync completed", report.requested === 0 ? "No changes applied. Your sync data has been refreshed." : "The sync engine finished processing your selected changes."],
       attention: ["warning", "Finished with items to review", "Some changes need attention. Review the results and notices below."],
       cancelled: ["pause_circle", "Sync cancelled", "Changes already applied were kept."],
       incomplete: ["error", "Sync did not finish", "The report contains the results available before the operation stopped."]

--- a/services/interactive_sync.py
+++ b/services/interactive_sync.py
@@ -14,6 +14,7 @@ import uuid
 
 from cw_platform.orchestrator import Orchestrator
 from cw_platform.orchestrator._interactive import InteractivePlan, fingerprint
+from cw_platform.value_coercion import coerce_bool
 from .interactive_sync_store import ReviewStore
 from .interactive_sync_progress import SyncProgress
 from .interactive_sync_report import SyncReport
@@ -106,7 +107,12 @@ def build(session: Session, cfg: dict[str, Any], choices: dict[str, str], *, sto
     return plan, summary
 
 
-def refresh(session: Session, cfg: dict[str, Any], choices: dict[str, str], *, restart_progress=True, corrections=()):
+def _empty_review(plan, summary):
+    return (bool(summary.get("ok")) and not plan.rows and not plan.conflicts and not plan.notices
+            and not any(summary.get(key) for key in ("cancelled", "errors", "unresolved", "blocked")))
+
+
+def refresh(session: Session, cfg: dict[str, Any], choices: dict[str, str], *, restart_progress=True, corrections=(), complete_empty=True):
     if restart_progress:
         session.progress.begin("preview")
     version = mapping_version(cfg)
@@ -118,6 +124,13 @@ def refresh(session: Session, cfg: dict[str, Any], choices: dict[str, str], *, r
         if session.store is not store:
             store.close()
         raise
+    if complete_empty and _empty_review(plan, summary) and not coerce_bool((cfg.get("sync") or {}).get("dry_run", False)):
+        # An empty review has no Apply action. Finish through the normal run path
+        # so provider baselines and the state-backed inventory are still saved.
+        with LOCK:
+            session.status = "applying"
+            session.message = "No changes proposed. Checking providers and saving the sync baseline."
+        apply(session, cfg, set())
 
 
 def _finish_review(session, cfg, version, plan, summary, store, *, corrections=()):
@@ -169,19 +182,22 @@ def apply(session: Session, cfg: dict[str, Any], selected: set[str]):
     session.report = None
     report = SyncReport(session.store, session.pair)
     if fingerprint(cfg) != session.config_hash or mapping_version(cfg) != session.mapping_version:
-        refresh(session, cfg, session.plan.choices, restart_progress=False)
+        refresh(session, cfg, session.plan.choices, restart_progress=False, complete_empty=False)
         _apply_needs_review(session, selected, "Settings or mappings changed.")
         return
     version = mapping_version(cfg)
     store = ReviewStore()
     try:
         plan, summary = build(session, cfg, session.plan.choices, selected=selected, store=store)
-        if not summary.get("ok") or not selected <= plan.seen:
+        empty_changed = not selected and not _empty_review(plan, summary)
+        if not summary.get("ok") or not selected <= plan.seen or empty_changed:
             if session.store is not None:
                 for detail in store.recheck_details(session.store, selected - plan.seen):
                     LOG.info("interactive_sync_proposal_changed session=%s detail=%s", session.id, json.dumps(detail, sort_keys=True))
             _finish_review(session, cfg, version, plan, summary, store)
             reason = "The provider recheck could not be completed." if not summary.get("ok") else "Some selected proposals changed or are no longer available."
+            if empty_changed and summary.get("ok"):
+                reason = "Provider data changed or needs attention."
             _apply_needs_review(session, selected, reason)
             return
     finally:
@@ -207,6 +223,8 @@ def apply(session: Session, cfg: dict[str, Any], selected: set[str]):
         session.summary["not_applied"] = len(selected - execution.seen)
         session.status = "complete" if result is not None else "error"
         session.message = "Selected changes processed. Review the results below." if result is not None else "Sync failed. Check Events before running again."
+        if not selected and session.report.get("outcome") == "success":
+            session.message = "No changes needed. Sync baseline saved."
         if session.summary.get("cancelled"):
             session.message = "Sync cancelled. Changes already applied were kept."
         session.touched = time.monotonic()

--- a/tests/test_interactive_sync_baseline.py
+++ b/tests/test_interactive_sync_baseline.py
@@ -1,0 +1,116 @@
+from copy import deepcopy
+from unittest.mock import Mock
+
+import pytest
+
+from api import syncAPI
+from cw_platform.orchestrator._state_store import StateStore
+from cw_platform.pair_scope import pair_feature_scope
+from services import interactive_sync as svc
+from test_interactive_sync_features import FEATURES, feature_item, feature_setup
+
+
+@pytest.mark.parametrize("feature", FEATURES)
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+@pytest.mark.parametrize("empty", [False, True])
+def test_empty_review_saves_pair_baselines_and_inventory(config_base, monkeypatch, feature, mode, empty):
+    items = [] if empty else [feature_item(feature, 1)]
+    cfg, src, dst = feature_setup(config_base, monkeypatch, feature, items, items, mode)
+    for ops in (src, dst):
+        monkeypatch.setattr(ops, "remove", Mock(wraps=ops.remove))
+    monkeypatch.setattr(syncAPI, "_env", lambda: (lambda: deepcopy(cfg), lambda *_: None))
+    store = StateStore(config_base)
+    other = store.for_pair("other-pair")
+    other.save_feature_blocks({("SRC", "default", feature): {"baseline": {"items": {"other": feature_item(feature, 2)}}}})
+    before_other = deepcopy(other.load_state())
+    pair_store = store.for_pair(pair_feature_scope(cfg, cfg["pairs"][0], feature))
+    assert not pair_store.load_state()["providers"]
+    session = svc.Session(pair_id="p1", owner="local")
+    try:
+        svc.refresh(session, cfg, {})
+        assert session.status == "complete", session.message
+        assert session.report["outcome"] == "success"
+        assert session.report["requested"] == 0
+        for state in (pair_store.load_state(), store.load_state()):
+            for provider in ("SRC", "DST"):
+                baseline = state["providers"][provider][feature]["baseline"]["items"]
+                assert set(baseline) == (set() if empty else {"imdb:tt0000001"})
+                if not empty:
+                    assert baseline["imdb:tt0000001"]["title"] == items[0]["title"]
+        assert other.load_state() == before_other
+        assert not src.add_calls and not dst.add_calls
+        src.remove.assert_not_called()
+        dst.remove.assert_not_called()
+    finally:
+        session.close()
+
+
+@pytest.mark.parametrize("dry_run", [True, "true"])
+def test_empty_dry_run_does_not_save_baselines(config_base, monkeypatch, dry_run):
+    cfg, _, _ = feature_setup(config_base, monkeypatch, "watchlist", [], [])
+    cfg["sync"]["dry_run"] = dry_run
+    monkeypatch.setattr(syncAPI, "_run_pairs_thread", lambda *a, **k: pytest.fail("dry run reached execution"))
+    session = svc.Session(pair_id="p1", owner="local")
+    try:
+        svc.refresh(session, cfg, {})
+        assert session.status == "review"
+        assert session.report is None
+        assert not StateStore(config_base).load_state()["providers"]
+    finally:
+        session.close()
+
+
+@pytest.mark.parametrize("problem", ["cancelled", "errors", "unresolved", "blocked", "notice", "failed"])
+def test_incomplete_empty_review_does_not_run(config_base, monkeypatch, problem):
+    cfg, _, _ = feature_setup(config_base, monkeypatch, "watchlist", [], [])
+    original_build = svc.build
+
+    def build(*args, **kwargs):
+        plan, summary = original_build(*args, **kwargs)
+        if problem == "notice":
+            plan.notices.append(dict(event="feature:unsupported"))
+        elif problem == "failed":
+            summary["ok"] = False
+        else:
+            summary[problem] = 1
+        return plan, summary
+
+    monkeypatch.setattr(svc, "build", build)
+    monkeypatch.setattr(syncAPI, "_run_pairs_thread", lambda *a, **k: pytest.fail("incomplete review reached execution"))
+    session = svc.Session(pair_id="p1", owner="local")
+    try:
+        svc.refresh(session, cfg, {})
+        assert session.status != "complete"
+        assert session.report is None
+        assert not StateStore(config_base).load_state()["providers"]
+    finally:
+        session.close()
+
+
+def test_new_changes_during_empty_review_recheck_return_to_review(config_base, monkeypatch):
+    common = feature_item("watchlist", 1)
+    cfg, src, dst = feature_setup(config_base, monkeypatch, "watchlist", [common], [common])
+    original_build = svc.build
+    builds = []
+
+    def build(*args, **kwargs):
+        plan, summary = original_build(*args, **kwargs)
+        builds.append(True)
+        if len(builds) == 1:
+            src.index["imdb:tt0000002"] = feature_item("watchlist", 2)
+        return plan, summary
+
+    monkeypatch.setattr(svc, "build", build)
+    monkeypatch.setattr(syncAPI, "_run_pairs_thread", lambda *a, **k: pytest.fail("changed review reached execution"))
+    session = svc.Session(pair_id="p1", owner="local")
+    try:
+        svc.refresh(session, cfg, {})
+        assert len(builds) == 2
+        assert session.status == "review"
+        assert session.store.counts["changes"] == 1
+        assert session.apply_review["applied"] == 0
+        assert session.report is None
+        assert not src.add_calls and not dst.add_calls
+        assert not StateStore(config_base).load_state()["providers"]
+    finally:
+        session.close()


### PR DESCRIPTION
# Pull request

## Change

- Complete empty interactive reviews through the normal sync path so provider baselines and the local inventory are saved. 
- Show a completion message confirming that no changes were applied.
- Keep dry runs and reviews with errors or notices from executing. If the provider recheck finds new changes, return to review.

## Why

An empty review has no Apply action, which previously left baselines and the local inventory unsaved even when both providers matched.

## Testing

- test_interactive_sync_baseline.py 

## Issue

Relates to #1018 