### PR TITLE
Add: scoped mappings and block rules

### DIFF
--- a/api/editorAPI.py
+++ b/api/editorAPI.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
-from typing import Any, Mapping, cast
+from typing import Any, Literal, Mapping, cast
 
 import io
 import json
@@ -32,6 +32,7 @@ from cw_platform.provider_instances import (
     sanitize_instance_label,
 )
 from services import playlists as playlist_svc
+from services.editor_mapping import MappingRequest as EditorMappingRequest, BlockRequest
 
 from services.editor import (
     Kind,
@@ -41,15 +42,27 @@ router = APIRouter(prefix="/api/editor", tags=["editor"])
 
 _STATE_BASE = Path(CONFIG_DIR)
 
+@router.post("/mapping")
+def api_editor_mapping(payload: EditorMappingRequest, request: Request):
+    from services.editor_mapping import handle_mapping
+    return handle_mapping(payload, request)
+
+
+@router.post("/mapping-block")
+def api_editor_mapping_block(payload: BlockRequest, request: Request):
+    from services.editor_mapping import update_block
+    return update_block(payload, request)
+
 
 @router.get("/mappings")
 def api_saved_mappings(request: Request, q: str = Query(default="", max_length=256),
                        provider: str = "", instance: str = "", feature: str = "",
+                       pair_id: str = "", entry_type: Literal["mapping", "block"] = "mapping",
                        offset: int = Query(default=0, ge=0), limit: int = Query(default=50, ge=1, le=100),
                        user_profile: str = Query(default="", max_length=64)):
-    from cw_platform.access_policy import profile_instances_map, profile_allows_instance
+    from cw_platform.access_policy import profile_instances_map, profile_allows_instance, user_can_access_pair
     from cw_platform.provider_instances import normalize_user_profile_id
-    from services.saved_mappings import saved_corrections
+    from services.saved_mappings import saved_corrections, saved_blocks
 
     cfg, user = load_config(), request_user(request)
     if user and not user.get("is_admin") and not (user.get("permissions") or {}).get("write"):
@@ -58,16 +71,37 @@ def api_saved_mappings(request: Request, q: str = Query(default="", max_length=2
     if user_profile.strip() and not profile:
         raise HTTPException(400, "Invalid profile")
     scope = profile_instances_map(cfg, profile) if profile else {}
-    rows = [row for row in saved_corrections(_load_policy())
+    pairs = {str(p.get("id")): p for p in cfg.get("pairs", []) if user_can_access_pair(cfg, user, p)}
+    entries = saved_blocks if entry_type == "block" else saved_corrections
+    rows = [row for row in entries(_load_policy())
             if user_can_access_instance(cfg, user, row["provider"], row["instance"])
+            and (not row["pair_id"] or row["pair_id"] in pairs)
             and (not profile or profile_allows_instance(scope, row["provider"], row["instance"]))]
+    for row in rows:
+        pair = pairs.get(row["pair_id"]) or {}
+        row["scope_label"] = str(pair.get("name") or pair.get("label") or
+                                 f"{pair.get('source')} → {pair.get('target')}") if row["pair_id"] else "All pairs"
     sources = sorted({(row["provider"], row["instance"]) for row in rows})
     query = q.strip().casefold()
     rows = [row for row in rows if (not provider or str(row.get("provider") or "").casefold() == provider.casefold())
+            and (not pair_id or row["pair_id"] == ("" if pair_id == "shared" else pair_id))
             and (not instance or row["instance"] == instance) and (not feature or row["feature"] == feature)
             and (not query or query in json.dumps(row, ensure_ascii=False).casefold())]
     rows.sort(key=lambda row: (-(row["saved_at"] or 0), row["provider"], row["instance"], row["feature"], row["key"]))
-    return dict(ok=True, items=rows[offset:offset + limit], total=len(rows), offset=offset, limit=limit,
+    page = rows[offset:offset + limit]
+    if entry_type == "block":
+        from services.saved_mappings import mapping_details
+        details: dict[tuple[Kind, str, str], dict[str, Any]] = {}
+        for row in page:
+            if row["feature"] not in ("watchlist", "history", "ratings", "progress", "collection"):
+                continue
+            identity = (cast(Kind, row["feature"]), row["provider"], row["instance"])
+            if identity not in details:
+                details[identity] = _load_state_items(*identity)
+            item = details[identity].get(row["key"])
+            if not row["corrected"] and item:
+                row["corrected"] = mapping_details(item)
+    return dict(ok=True, items=page, total=len(rows), offset=offset, limit=limit,
                 sources=[dict(provider=p, instance=i) for p, i in sources])
 
 
@@ -203,6 +237,8 @@ def _policy_providers(raw: dict[str, Any]) -> list[str]:
 def _union_providers(state_raw: dict[str, Any], policy_raw: dict[str, Any]) -> list[str]:
     a = _state_providers(state_raw)
     b = _policy_providers(policy_raw)
+    for scoped in (policy_raw.get("pairs") or {}).values():
+        b.extend(_policy_providers(scoped))
     seen: set[str] = set()
     out: list[str] = []
     for x in a + b:
@@ -268,8 +304,11 @@ def _load_policy_manual(
     provider: str,
     provider_instance: str | None = None,
     raw_policy: dict[str, Any] | None = None,
+    pair_id: str = "",
 ) -> tuple[dict[str, Any], list[str]]:
     raw = raw_policy if isinstance(raw_policy, dict) else _load_policy()
+    if pair_id:
+        raw = (raw.get("pairs") or {}).get(pair_id) or {}
     node = _policy_provider_node(raw, provider, provider_instance)
     if not isinstance(node, dict):
         return {}, []
@@ -323,72 +362,13 @@ def _save_policy_manual(
     _save_policy_manual_batch([(kind, provider, adds_items, blocks, provider_instance)], merge=merge)
 
 
-def _save_policy_manual_batch(edits, *, merge=True, mappings=None):
-    prepared = [(kind, provider, _canonicalize_manual_items(items, kind), blocks, instance)
+def _save_policy_manual_batch(edits, *, merge=True, mappings=None, pair_id=""):
+    from cw_platform.mapping_policy import update_mappings
+    prepared = [(kind, provider, _canonicalize_manual_items(items, kind), blocks, normalize_instance_id(instance))
                 for kind, provider, items, blocks, instance in edits]
-
-    def _mutate(raw: dict[str, Any]) -> None:
-        for kind, provider, adds_items, blocks, provider_instance in prepared:
-            providers = raw.get("providers")
-            if not isinstance(providers, dict):
-                providers = {}
-                raw["providers"] = providers
-
-            key = None
-            if provider in providers:
-                key = provider
-            else:
-                pl = str(provider).lower()
-                for k in providers.keys():
-                    if str(k).lower() == pl:
-                        key = str(k)
-                        break
-            if key is None:
-                key = provider
-                providers[key] = {}
-
-            node = providers.get(key)
-            if not isinstance(node, dict):
-                node = {}
-                providers[key] = node
-
-            inst = normalize_instance_id(provider_instance)
-            if inst != "default":
-                insts = node.get("instances")
-                if not isinstance(insts, dict):
-                    insts = {}
-                    node["instances"] = insts
-                in_node = insts.get(inst)
-                if not isinstance(in_node, dict):
-                    in_node = {}
-                    insts[inst] = in_node
-                node = in_node
-
-            f = node.get(kind)
-            if not isinstance(f, dict):
-                f = {}
-                node[kind] = f
-
-            f["blocks"] = _merge_blocks(f.get("blocks") or [], blocks or []) if merge else list(blocks or [])
-
-            adds = f.get("adds")
-            if not isinstance(adds, dict):
-                adds = {}
-                f["adds"] = adds
-            adds["items"] = {**(adds.get("items") or {}), **adds_items} if merge else dict(adds_items or {})
-            records = dict(f.get("mappings") or {})
-            for target, record in (mappings or {}).get((kind, provider, inst), {}).items():
-                previous = records.get(target) or records.get(record.get("original_key"))
-                if isinstance(previous, dict) and previous.get("original"):
-                    record = {**record, "original": previous["original"], "original_key": previous["original_key"]}
-                records[target] = record
-            if records:
-                f["mappings"] = {key: value for key, value in records.items() if key in adds["items"]}
-
-
-
     try:
-        sqlite_manual_policy.update_policy(_STATE_BASE, _mutate)
+        sqlite_manual_policy.update_policy(_STATE_BASE, lambda raw: update_mappings(
+            raw, prepared, mappings=mappings, pair_id=pair_id, merge=merge))
     except HTTPException:
         raise
     except Exception as e:
@@ -404,6 +384,7 @@ def _merge_policy(into: dict[str, Any], src: dict[str, Any], mode: str) -> dict[
         base = {"version": 1, "providers": {}}
         prov = src.get("providers") if isinstance(src, dict) else None
         base["providers"] = prov if isinstance(prov, dict) else {}
+        base["pairs"] = src.get("pairs") or {}
         return base
 
     out = into if isinstance(into, dict) else {"version": 1, "providers": {}}
@@ -414,6 +395,10 @@ def _merge_policy(into: dict[str, Any], src: dict[str, Any], mode: str) -> dict[
         prov_out = {}
         out["providers"] = prov_out
 
+    for pair_id, policy in (src.get("pairs") or {}).items():
+        if isinstance(policy, dict):
+            pairs = out.setdefault("pairs", {})
+            pairs[pair_id] = _merge_policy(pairs.get(pair_id) or {}, policy, "merge")
     prov_in = src.get("providers") if isinstance(src, dict) else None
     if not isinstance(prov_in, dict):
         return out
@@ -922,6 +907,7 @@ def api_editor_get_state(
     provider: str | None = None,
     provider_instance: str | None = None,
     endpoint: str | None = None,
+    pair_id: str = "",
     request: Request = cast(Request, None),
 ) -> dict[str, Any]:
     k = _normalize_kind(kind)
@@ -929,6 +915,7 @@ def api_editor_get_state(
     if src in ("playlist", "playlists", "playlist-endpoint"):
         return api_editor_playlist_endpoint((endpoint or snapshot or "").strip(), request=request)
 
+    from services.editor_mapping import require_mapping_pair, scope_options
     cfg = load_config() or {}
     if src in ("state", "current"):
         raw_state = _load_current_state_features({k})
@@ -952,14 +939,41 @@ def api_editor_get_state(
 
         inst = _instance_for_request(cfg, request, chosen, provider_instance)
         _require_instance_scope(cfg, request, chosen, inst)
+        pair = require_mapping_pair(cfg, request, pair_id, chosen, inst, k)
 
+        if pair:
+            from cw_platform.pair_scope import pair_feature_scope
+            from cw_platform.local_db import state as sqlite_state
+            raw_state = sqlite_state.load_pair_state(_STATE_BASE, pair_feature_scope(cfg, pair, k, cfg["pairs"].index(pair) + 1), {k})
         items = _load_state_items(k, chosen, inst, raw_state=raw_state)
-        st_adds, st_blocks = _load_state_manual(k, chosen, inst, raw_state=raw_state) if raw_state else ({}, [])
-        pol_adds, pol_blocks = _load_policy_manual(k, chosen, inst, raw_policy=raw_policy)
+        inherited: dict[str, Any] = {}
+        if pair_id:
+            from cw_platform.mapping_policy import effective_policy
+            effective = effective_policy(raw_policy, pair_id)
+            effective_adds, effective_blocks = _load_policy_manual(k, chosen, inst, raw_policy=effective)
+            own_adds, own_blocks = _load_policy_manual(k, chosen, inst, raw_policy=raw_policy, pair_id=pair_id)
+            inherited = {key: item for key, item in effective_adds.items() if key not in own_adds}
+            own_node = _policy_provider_node((raw_policy.get("pairs") or {}).get(pair_id) or {}, chosen, inst) or {}
+            originals = {record.get("original_key") for record in (own_node.get(k, {}).get("mappings") or {}).values()}
+            # Keep ordinary blocked rows editable. Mapping originals stay hidden;
+            # their blocks are maintained with the saved correction itself.
+            editable_blocks = set(own_blocks) - originals
+            items = {key: item for key, item in {**items, **inherited}.items()
+                     if key not in effective_blocks or key in editable_blocks}
+        st_adds, st_blocks = _load_state_manual(k, chosen, inst, raw_state=raw_state) if raw_state and not pair_id else ({}, [])
+        pol_adds, pol_blocks = _load_policy_manual(k, chosen, inst, raw_policy=raw_policy, pair_id=pair_id)
 
         manual_adds = dict(st_adds or {})
         manual_adds.update(dict(pol_adds or {}))
         manual_blocks = _merge_blocks(st_blocks or [], pol_blocks or [])
+        from services.saved_mappings import correction_block_keys
+        scoped_policy = (raw_policy.get("pairs") or {}).get(pair_id) or {} if pair_id else raw_policy
+        scoped_node = _policy_provider_node(scoped_policy, chosen, inst) or {}
+        automatic_blocks = correction_block_keys(scoped_node.get(k) or {})
+        visible_keys = {key.lower() for key in [*items, *manual_adds]}
+        manual_keys = {key.lower() for key in manual_adds}
+        preserved_blocks = [key for key in manual_blocks if key.lower() not in automatic_blocks
+                            and (key.lower() not in visible_keys or key.lower() in manual_keys)]
 
         ts = None
         try:
@@ -980,7 +994,12 @@ def api_editor_get_state(
             "items": items,
             "manual_adds": manual_adds,
             "manual_blocks": manual_blocks,
-            "instance_sharing": _shared_instance_note(cfg, chosen, inst),
+            "preserved_blocks": preserved_blocks,
+            "instance_sharing": _shared_instance_note(cfg, chosen, inst) if not pair_id else None,
+            "pair_id": pair_id,
+            "mapping_scopes": scope_options(cfg, request, chosen, inst, k),
+            "mapping_origins": {**({key: "shared" for key in inherited} if pair_id else {}),
+                                **{key: "pair" if pair_id else "shared" for key in manual_adds}},
         }
     if src in ("manual", "manual-overrides", "policy", "overrides"):
         raw_state = _load_current_state_features({k})
@@ -1004,8 +1023,9 @@ def api_editor_get_state(
 
         inst = _instance_for_request(cfg, request, chosen, provider_instance)
         _require_instance_scope(cfg, request, chosen, inst)
-        pol_adds, pol_blocks = _load_policy_manual(k, chosen, inst, raw_policy=raw_policy)
-        if not pol_adds and not pol_blocks and raw_state:
+        pair = require_mapping_pair(cfg, request, pair_id, chosen, inst, k)
+        pol_adds, pol_blocks = _load_policy_manual(k, chosen, inst, raw_policy=raw_policy, pair_id=pair_id)
+        if not pair_id and not pol_adds and not pol_blocks and raw_state:
             pol_adds, pol_blocks = _load_state_manual(k, chosen, inst, raw_state=raw_state)
 
         ts = None
@@ -1029,7 +1049,10 @@ def api_editor_get_state(
             "items": manual_adds,
             "manual_adds": manual_adds,
             "manual_blocks": manual_blocks,
-            "instance_sharing": _shared_instance_note(cfg, chosen, inst),
+            "instance_sharing": _shared_instance_note(cfg, chosen, inst) if not pair_id else None,
+            "pair_id": pair_id,
+            "mapping_scopes": scope_options(cfg, request, chosen, inst, k),
+            "mapping_origins": {key: "pair" if pair_id else "shared" for key in manual_adds},
         }
     raise HTTPException(status_code=400, detail=f"Unsupported source: {src}")
 
@@ -1121,6 +1144,9 @@ def api_editor_save_state(payload: dict[str, Any] = Body(...), request: Request 
         inst = _instance_for_request(cfg, request, provider, payload.get("provider_instance"))
         _require_instance_scope(cfg, request, provider, inst)
 
+        from services.editor_mapping import require_mapping_pair
+        pair_id = str(payload.get("pair_id") or "")
+        pair = require_mapping_pair(cfg, request, pair_id, provider, inst, kind)
         blocks = _normalize_blocks(payload.get("blocks"))
 
         from services.saved_mappings import mapping_details
@@ -1129,7 +1155,13 @@ def api_editor_save_state(payload: dict[str, Any] = Body(...), request: Request 
         original_keys = payload.get("mapping_originals")
         if isinstance(original_keys, dict) and original_keys:
             baseline = _load_state_items(kind, provider, inst)
-            previous, _ = _load_policy_manual(kind, provider, inst)
+            if pair:
+                from cw_platform.pair_scope import pair_feature_scope
+                from cw_platform.local_db import state as sqlite_state
+                raw_state = sqlite_state.load_pair_state(_STATE_BASE, pair_feature_scope(cfg, pair, kind, cfg["pairs"].index(pair) + 1), {kind})
+                baseline = {**baseline, **_load_state_items(kind, provider, inst, raw_state=raw_state)}
+            from cw_platform.mapping_policy import effective_policy
+            previous, _ = _load_policy_manual(kind, provider, inst, raw_policy=effective_policy(_load_policy(), pair_id))
             for input_key, corrected in (payload.get("items") or {}).items():
                 old_key = original_keys.get(input_key)
                 original = previous.get(old_key) or baseline.get(old_key) if isinstance(old_key, str) else None
@@ -1138,7 +1170,7 @@ def api_editor_save_state(payload: dict[str, Any] = Body(...), request: Request 
                     if target:
                         records[target] = dict(original_key=old_key, original=mapping_details(original),
                                                saved_at=int(time.time()), origin="editor")
-        _save_policy_manual_batch([(kind, provider, items, blocks, inst)], mappings={(kind, provider, inst): records})
+        _save_policy_manual_batch([(kind, provider, items, blocks, inst)], mappings={(kind, provider, inst): records}, pair_id=pair_id, merge=False)
         ts = None
         try:
             ts = _policy_mtime()

--- a/api/interactiveSyncAPI.py
+++ b/api/interactiveSyncAPI.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from copy import deepcopy
 import threading
 import time
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
@@ -54,10 +54,11 @@ class MappingChange(BaseModel):
 
 
 class MappingEdit(Revision, MappingChange):
-    pass
+    scope: Literal["pair", "shared"] = "pair"
 
 
 class MappingBatch(Revision):
+    scope: Literal["pair", "shared"] = "pair"
     selection_version: int = Field(ge=0)
     edits: list[MappingChange] = Field(min_length=1, max_length=200)
 
@@ -287,7 +288,7 @@ def prepare_mapping(row, corrected):
     return key, item, blocks
 
 
-def save_mappings(session, cfg, request, changes):
+def save_mappings(session, cfg, request, changes, scope="pair"):
     from .editorAPI import _require_instance_scope, _save_policy_manual_batch
     from services.saved_mappings import mapping_details
 
@@ -316,7 +317,7 @@ def save_mappings(session, cfg, request, changes):
         corrections.append(dict(identity=(row["feature"], key, row["source"], row["source_instance"], row["provider"], row["instance"]),
                                 selected=edit.selected))
     launch(session, svc.refresh_mappings, cfg, dict(session.plan.choices), corrections,
-           prepare=lambda: _save_policy_manual_batch(prepared, mappings=mappings))
+           prepare=lambda: _save_policy_manual_batch(prepared, mappings=mappings, pair_id=session.pair_id if scope == "pair" else ""))
     return session.public()
 
 
@@ -326,7 +327,7 @@ def mapping(sid: str, payload: MappingEdit, request: Request):
     with svc.LOCK:
         session = get_session(sid, request, cfg)
         check_revision(session, payload.revision)
-        return save_mappings(session, cfg, request, [payload])
+        return save_mappings(session, cfg, request, [payload], payload.scope)
 
 
 @router.post("/{sid}/mappings")
@@ -336,7 +337,7 @@ def mappings(sid: str, payload: MappingBatch, request: Request):
         session = get_session(sid, request, cfg)
         check_revision(session, payload.revision)
         check_selection(session, payload.selection_version)
-        return save_mappings(session, cfg, request, payload.edits)
+        return save_mappings(session, cfg, request, payload.edits, payload.scope)
 
 
 @router.get("/{sid}/mapping-catalogs")

--- a/cw_platform/local_db/manual_policy.py
+++ b/cw_platform/local_db/manual_policy.py
@@ -284,6 +284,11 @@ def load_policy(base_path: str | Path, policy_path: str | Path | None = None) ->
             if isinstance(mappings, dict) and mappings:
                 node[feature]["mappings"] = {key: value for key, value in mappings.items() if key in items}
 
+        pairs = {str(row[0]): json.loads(row[1]) for row in conn.execute(
+            "SELECT pair_id,policy_json FROM manual_policy_pairs ORDER BY pair_id"
+        )}
+        if pairs:
+            out["pairs"] = pairs
         return out
 
 
@@ -341,6 +346,12 @@ def save_policy(base_path: str | Path, policy: Mapping[str, Any], policy_path: s
         ]
         item_sql = f"INSERT INTO manual_policy_add_items({','.join(item_columns)}) VALUES({','.join('?' for _ in item_columns)})"
         with conn:
+            conn.execute("DELETE FROM manual_policy_pairs")
+            conn.executemany("INSERT INTO manual_policy_pairs(pair_id,policy_json,updated_at) VALUES(?,?,?)", [
+                (str(pair_id), json.dumps(scoped, ensure_ascii=False), ts)
+                for pair_id, scoped in (policy.get("pairs") or {}).items()
+                if pair_id and isinstance(scoped, Mapping)
+            ])
             conn.execute("DELETE FROM manual_policy_add_items")
             conn.execute("DELETE FROM manual_policy_blocks")
             conn.execute("DELETE FROM manual_policy_features")
@@ -425,7 +436,7 @@ def has_policy(base_path: str | Path, policy_path: str | Path | None = None) -> 
         if conn is None:
             return False
         row = conn.execute("SELECT COUNT(*) FROM manual_policy_features").fetchone()
-        return bool(row and int(row[0] or 0) > 0)
+        return bool(row and int(row[0] or 0) > 0) or bool(conn.execute("SELECT 1 FROM manual_policy_pairs LIMIT 1").fetchone())
 
 
 def policy_mtime(base_path: str | Path) -> int | None:
@@ -442,6 +453,7 @@ def clear_policy(base_path: str | Path) -> None:
         if conn is None:
             return
         with conn:
+            conn.execute("DELETE FROM manual_policy_pairs")
             conn.execute("DELETE FROM manual_policy_add_items")
             conn.execute("DELETE FROM manual_policy_blocks")
             conn.execute("DELETE FROM manual_policy_features")

--- a/cw_platform/local_db/schema.py
+++ b/cw_platform/local_db/schema.py
@@ -638,6 +638,9 @@ def apply_schema(conn: sqlite3.Connection) -> int:
         conn.execute(_CREATE_STATISTICS_FEATURE_TOTALS)
         conn.execute(_CREATE_STATISTICS_INGESTED_RUNS)
         conn.execute(_CREATE_MANUAL_POLICY_FEATURES)
+        conn.execute("""CREATE TABLE IF NOT EXISTS manual_policy_pairs (
+            pair_id TEXT PRIMARY KEY, policy_json TEXT NOT NULL, updated_at INTEGER NOT NULL
+        )""")
         conn.execute(_CREATE_MANUAL_POLICY_BLOCKS)
         conn.execute(_CREATE_MANUAL_POLICY_ADD_ITEMS)
         _ensure_column(conn, "manual_policy_add_items", "collected_at", "TEXT")

--- a/cw_platform/mapping_policy.py
+++ b/cw_platform/mapping_policy.py
@@ -1,0 +1,84 @@
+# cw_platform/mapping_policy.py
+# CrossWatch - Shared and pair-specific mapping policy
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from copy import deepcopy
+
+from .id_map import keys_for_item
+from .local_db.manual_policy import _feature_blocks, _normalize_blocks
+
+
+def feature_node(policy, provider, instance, feature):
+    providers = policy.setdefault("providers", {})
+    name = next((key for key in providers if key.upper() == provider.upper()), provider.upper())
+    node = providers.setdefault(name, {})
+    if instance != "default":
+        node = node.setdefault("instances", {}).setdefault(instance, {})
+    return node.setdefault(feature, {})
+
+
+def effective_policy(policy, pair_id=""):
+    result = {"version": policy.get("version", 1), "providers": deepcopy(policy.get("providers") or {})}
+    scoped = (policy.get("pairs") or {}).get(pair_id) or {}
+    for provider, instance, feature, override in _feature_blocks(scoped):
+        node = feature_node(result, provider, instance, feature)
+        items = node.setdefault("adds", {}).setdefault("items", {})
+        records = node.setdefault("mappings", {})
+        blocks = list(node.get("blocks") or [])
+        for target, record in (override.get("mappings") or {}).items():
+            original = record.get("original_key")
+            for key, shared in list(records.items()):
+                if original and (key == original or shared.get("original_key") == original):
+                    items.pop(key, None)
+                    records.pop(key, None)
+                    if key != target:
+                        blocks.append(key)
+        items.update(deepcopy((override.get("adds") or {}).get("items") or {}))
+        records.update(deepcopy(override.get("mappings") or {}))
+        corrected = {alias.lower() for key in (override.get("mappings") or {})
+                     for alias in [key, *keys_for_item(items.get(key) or {})]}
+        node["blocks"] = _normalize_blocks([
+            *(key for key in blocks if key.lower() not in corrected),
+            *(override.get("blocks") or []),
+        ])
+    return result
+
+
+def update_mappings(raw, edits, *, mappings=None, pair_id="", merge=True):
+    effective = effective_policy(raw, pair_id)
+    scoped = raw.setdefault("pairs", {}).setdefault(pair_id, {"version": 1, "providers": {}}) if pair_id else raw
+    for feature, provider, additions, blocks, instance in edits:
+        node = feature_node(scoped, provider, instance, feature)
+        items = dict((node.get("adds") or {}).get("items") or {}) if merge else {}
+        records = dict(node.get("mappings") or {})
+        previous = (feature_node(effective, provider, instance, feature).get("mappings") or {})
+        incoming_records = (mappings or {}).get((feature, provider, instance), {})
+        for target, incoming in incoming_records.items():
+            record = deepcopy(incoming)
+            replaced = record.get("original_key")
+            if replaced != target:
+                items.pop(replaced, None)
+                records.pop(replaced, None)
+            parent = previous.get(record.get("original_key")) or previous.get(target)
+            if isinstance(parent, dict) and parent.get("original"):
+                record.update(original=parent["original"], original_key=parent["original_key"])
+            for key, old in list(records.items()):
+                if key != target and record.get("original_key") and old.get("original_key") == record["original_key"]:
+                    items.pop(key, None)
+                    records.pop(key, None)
+            records[target] = record
+            if record.get("original_key") and record["original_key"] != target and record["original_key"] not in keys_for_item(additions.get(target) or {}):
+                blocks = [*blocks, record["original_key"]]
+        items.update(additions)
+        node["adds"] = {"items": items}
+        node["blocks"] = _normalize_blocks([*(node.get("blocks") or []), *blocks] if merge else blocks)
+        corrected = {alias.lower() for key in incoming_records for alias in [key, *keys_for_item(items.get(key) or {})]}
+        node["blocks"] = [key for key in node["blocks"] if key.lower() not in corrected]
+        node["mappings"] = {key: value for key, value in records.items() if key in items}
+        # A full Editor save can retain a correction without resending its hidden
+        # original row. Keep excluding that original while the mapping exists.
+        for target, record in node["mappings"].items():
+            original = record.get("original_key")
+            if original and original != target and original not in keys_for_item(items[target]):
+                node["blocks"] = _normalize_blocks([*node["blocks"], original])

--- a/cw_platform/orchestrator/_pairs.py
+++ b/cw_platform/orchestrator/_pairs.py
@@ -493,7 +493,7 @@ def run_pairs(ctx) -> dict[str, Any]:
             with _pair_env(pair, i=i, src=src, dst=dst, mode=mode, feature=feature, scope=scope):
                 prev_cfg = ctx.config
                 prev_store = ctx.state_store
-                ctx.state_store = prev_store.for_pair(scope)
+                ctx.state_store = prev_store.for_pair(scope, pair_id=str(pair.get("id") or ""))
                 ctx.config = {**_config_with_pair_feature_options(pair_cfg_view, fcfg, (src, dst), feature), "_cw_pair_scope": scope}
                 try:
                     if not injected:

--- a/cw_platform/orchestrator/_state_store.py
+++ b/cw_platform/orchestrator/_state_store.py
@@ -18,11 +18,12 @@ from ..local_db import watchlist_hide as sqlite_watchlist_hide
 class StateStore:
     base_path: Path
     pair_scope: str | None = None
+    mapping_pair_id: str = ""
 
-    def for_pair(self, scope: str) -> StateStore:
+    def for_pair(self, scope: str, *, pair_id: str = "") -> StateStore:
         if not scope:
             raise ValueError("Pair scope is required")
-        return StateStore(self.base_path, pair_scope=scope)
+        return StateStore(self.base_path, pair_scope=scope, mapping_pair_id=pair_id)
 
     @property
     def cw_state_dir(self) -> Path:
@@ -142,8 +143,12 @@ class StateStore:
 
     def load_state(self) -> dict[str, Any]:
         state = sqlite_state.load_pair_state(self.base_path, self.pair_scope) if self.pair_scope else sqlite_state.load_state(self.base_path)
-        policy = sqlite_manual_policy.load_policy(self.base_path)
+        policy = self._mapping_policy()
         return self._merge_policy(state, policy)
+
+    def _mapping_policy(self) -> dict[str, Any]:
+        from ..mapping_policy import effective_policy
+        return effective_policy(sqlite_manual_policy.load_policy(self.base_path), self.mapping_pair_id)
 
     def _filter_policy_features(self, policy: Mapping[str, Any], features: set[str]) -> dict[str, Any]:
         wanted = {str(feature or "").strip().lower() for feature in features if str(feature or "").strip()}
@@ -181,7 +186,7 @@ class StateStore:
     ) -> dict[str, Any]:
         wanted = {str(feature or "").strip().lower() for feature in features or [] if str(feature or "").strip()}
         state = sqlite_state.load_pair_state(self.base_path, self.pair_scope, wanted) if self.pair_scope else sqlite_state.load_state_features(self.base_path, features, recent_limit=recent_limit)
-        policy = self._filter_policy_features(sqlite_manual_policy.load_policy(self.base_path), wanted)
+        policy = self._filter_policy_features(self._mapping_policy(), wanted)
         return self._merge_policy(state, policy)
 
     def provider_feature_counts(self, feature: str = "watchlist") -> dict[str, int]:

--- a/services/analyzer.py
+++ b/services/analyzer.py
@@ -477,7 +477,7 @@ def _load_state_handles(pairs_raw: str | None, features: Iterable[str] | None = 
         pid = _pair_id(pair)
         for feature in wanted:
             scope = pair_feature_scope(cfg, pair, feature, index)
-            state = StateStore(CONFIG_DIR).for_pair(scope).load_state_features({feature})
+            state = StateStore(CONFIG_DIR).for_pair(scope, pair_id=pid).load_state_features({feature})
             handles.append({"pair": pid, "safe": scope, "state": state})
     if handles or cfg.get("pairs") or str(pairs_raw or "").startswith(_STRICT_PAIRS_PREFIX):
         return handles

--- a/services/analyzer_mapping.py
+++ b/services/analyzer_mapping.py
@@ -17,6 +17,7 @@ from cw_platform.access_policy import request_user, user_can_access_pair
 
 
 class MappingRequest(BaseModel):
+    scope: Literal["pair", "shared"] = "pair"
     pair_id: str = Field(min_length=1, max_length=256)
     provider: str = Field(min_length=1, max_length=128)
     feature: Literal["history", "watchlist", "ratings", "progress", "collection"]
@@ -105,5 +106,5 @@ def handle_mapping(payload: MappingRequest, request):
     scope = (row["feature"], row["source"], row["source_instance"])
     records = {scope: {key: dict(original_key=row["key"], original=mapping_details(row["item"]),
                                saved_at=int(time.time()), origin="analyzer")}}
-    _save_policy_manual_batch([(row["feature"], row["source"], {key: item}, blocks, row["source_instance"])], mappings=records)
+    _save_policy_manual_batch([(row["feature"], row["source"], {key: item}, blocks, row["source_instance"])], mappings=records, pair_id=payload.pair_id if payload.scope == "pair" else "")
     return dict(ok=True, key=key)

--- a/services/editor_mapping.py
+++ b/services/editor_mapping.py
@@ -1,0 +1,120 @@
+# services/editor_mapping.py
+# CrossWatch - Editor mapping workspace and scope validation
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastapi import HTTPException
+from pydantic import BaseModel, Field
+
+from cw_platform.access_policy import request_user, user_can_access_pair
+from cw_platform.provider_instances import normalize_instance_id
+
+
+def mapping_pairs(cfg, request, provider, instance, feature):
+    return [pair for pair in cfg.get("pairs", [])
+            if pair.get("id") and user_can_access_pair(cfg, request_user(request), pair)
+            and feature in (pair.get("features") or {})
+            and any(str(pair.get(side) or "").upper() == provider.upper()
+                    and normalize_instance_id(pair.get(f"{side}_instance")) == instance
+                    for side in ("source", "target"))]
+
+
+def require_mapping_pair(cfg, request, pair_id, provider, instance, feature):
+    if not pair_id:
+        return None
+    pair = next((p for p in mapping_pairs(cfg, request, provider, instance, feature)
+                 if str(p["id"]) == pair_id), None)
+    if pair is None:
+        raise HTTPException(404, "Sync pair not found for this provider instance and feature")
+    return pair
+
+
+def scope_options(cfg, request, provider, instance, feature):
+    return [dict(id=str(p["id"]), label=str(p.get("name") or p.get("label") or
+                 f"Pair {cfg['pairs'].index(p) + 1} · {p.get('source')} → {p.get('target')}"))
+            for p in mapping_pairs(cfg, request, provider, instance, feature)]
+
+
+class MappingRequest(BaseModel):
+    provider: str = Field(min_length=1, max_length=128)
+    instance: str = Field(default="default", max_length=128)
+    pair_id: str = Field(default="", max_length=256)
+    feature: Literal["history", "watchlist", "ratings", "progress", "collection"]
+    key: str = Field(min_length=1, max_length=1024)
+    original: dict[str, Any]
+    action: Literal["catalogs", "search", "episodes", "prepare"]
+    q: str = Field(default="", max_length=200)
+    catalog: Literal["destination", "tmdb"] = "tmdb"
+    item: dict[str, Any] = Field(default_factory=dict)
+
+
+class BlockRequest(BaseModel):
+    provider: str = Field(min_length=1, max_length=128)
+    instance: str = Field(default="default", max_length=128)
+    pair_id: str = Field(default="", max_length=256)
+    feature: Literal["history", "watchlist", "ratings", "progress", "collection"]
+    key: str = Field(min_length=1, max_length=1024)
+    blocked: bool
+
+
+def update_block(payload, request):
+    from api.editorAPI import load_config, _require_instance_scope, _STATE_BASE
+    from cw_platform.local_db import manual_policy
+    from cw_platform.mapping_policy import feature_node
+    from services.saved_mappings import correction_block_keys
+
+    cfg, user = load_config(), request_user(request)
+    if user and not user.get("is_admin") and not (user.get("permissions") or {}).get("write"):
+        raise HTTPException(403, "Write permission required")
+    provider, instance = payload.provider.strip().upper(), normalize_instance_id(payload.instance)
+    _require_instance_scope(cfg, request, provider, instance)
+    require_mapping_pair(cfg, request, payload.pair_id, provider, instance, payload.feature)
+    key = payload.key.strip()
+    if not key or any(ord(c) < 32 for c in key):
+        raise HTTPException(400, "Enter a valid item key")
+
+    def apply(policy):
+        scoped = policy.setdefault("pairs", {}).setdefault(payload.pair_id, {"version": 1, "providers": {}}) if payload.pair_id else policy
+        node = feature_node(scoped, provider, instance, payload.feature)
+        if not payload.blocked and key.lower() in correction_block_keys(node):
+            raise HTTPException(409, "This block belongs to a saved correction. Edit or remove that mapping instead.")
+        blocks = [value for value in node.get("blocks") or [] if value.lower() != key.lower()]
+        node["blocks"] = [*blocks, key] if payload.blocked else blocks
+
+    manual_policy.update_policy(_STATE_BASE, apply)
+    return dict(ok=True, key=key, blocked=payload.blocked)
+
+
+def handle_mapping(payload, request):
+    from api.editorAPI import load_config, _require_instance_scope
+    from api.interactiveSyncAPI import prepare_mapping
+    from services.interactive_sync_catalogs import search_catalogs
+    from services.interactive_sync_mapping import search_candidates
+    from services.interactive_sync_episodes import metadata_key, suggest_episodes
+
+    cfg = load_config()
+    user = request_user(request)
+    if user and not user.get("is_admin") and not (user.get("permissions") or {}).get("write"):
+        raise HTTPException(403, "Write permission required")
+    provider, instance = payload.provider.upper(), normalize_instance_id(payload.instance)
+    _require_instance_scope(cfg, request, provider, instance)
+    pair = require_mapping_pair(cfg, request, payload.pair_id, provider, instance, payload.feature)
+    destination, target_instance = provider, instance
+    if pair:
+        side = "target" if str(pair.get("source") or "").upper() == provider and normalize_instance_id(pair.get("source_instance")) == instance else "source"
+        destination, target_instance = str(pair[side]).upper(), normalize_instance_id(pair.get(f"{side}_instance"))
+    row = dict(id="editor-item", key=payload.key, item=payload.original, feature=payload.feature,
+               source=provider, source_instance=instance, provider=destination, instance=target_instance,
+               operation="add", metadata_only=not bool(pair))
+    if payload.action == "catalogs":
+        return {**search_catalogs(cfg, row), "episode_matching": bool(metadata_key(cfg, row)), "row": row}
+    if payload.action == "search":
+        if len(payload.q.strip()) < 2:
+            raise HTTPException(400, "Enter at least two characters")
+        return search_candidates(cfg, row, payload.q, catalog=payload.catalog)
+    if payload.action == "episodes":
+        return suggest_episodes(cfg, [(row, payload.item)])
+    key, item, blocks = prepare_mapping(row, payload.item)
+    return dict(ok=True, key=key, item=item, blocks=blocks)

--- a/services/interactive_sync_catalogs.py
+++ b/services/interactive_sync_catalogs.py
@@ -52,6 +52,8 @@ def configured(provider, block):
 
 
 def search_catalogs(cfg, row):
+    if row.get("metadata_only"):
+        return dict(ok=True, catalogs=[dict(id="tmdb", label="TMDb metadata")] if (cfg.get("tmdb") or {}).get("api_key") else [])
     provider = str(row["provider"]).upper()
     block = provider_block(cfg, provider, row.get("instance") or "default")
     options = []

--- a/services/interactive_sync_episodes.py
+++ b/services/interactive_sync_episodes.py
@@ -14,6 +14,8 @@ from services.interactive_sync_catalogs import configured, provider_block
 
 
 def metadata_key(cfg, row):
+    if row.get("metadata_only"):
+        return (cfg.get("tmdb") or {}).get("api_key")
     provider = str(row["provider"]).upper()
     block = provider_block(cfg, provider, row.get("instance") or "default")
     if not configured(provider, block):

--- a/services/saved_mappings.py
+++ b/services/saved_mappings.py
@@ -4,9 +4,26 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Any, Mapping
+from typing import Any, Iterator, Literal, Mapping, NotRequired, TypedDict
 
 from cw_platform.local_db.manual_policy import _feature_blocks
+
+
+class SavedRule(TypedDict):
+    pair_id: str
+    scope: Literal["pair", "shared"]
+    provider: str
+    instance: str
+    feature: str
+    key: str
+    corrected: dict[str, Any] | None
+    original: dict[str, Any] | None
+    original_key: str | None
+    saved_at: int | float | None
+    origin: str | None
+    excluded: bool
+    entry_type: NotRequired[Literal["mapping", "block"]]
+    scope_label: NotRequired[str]
 
 
 def mapping_details(item: Mapping[str, Any]) -> dict[str, Any]:
@@ -15,7 +32,32 @@ def mapping_details(item: Mapping[str, Any]) -> dict[str, Any]:
     ) if key in item}
 
 
-def saved_corrections(policy):
+def saved_corrections(policy: Mapping[str, Any]) -> Iterator[SavedRule]:
+    for pair_id, scoped in [("", policy), *(policy.get("pairs") or {}).items()]:
+        yield from _scoped_corrections(scoped, pair_id)
+
+
+def correction_block_keys(block):
+    items = (block.get("adds") or {}).get("items") or {}
+    return {str(record["original_key"]).lower() for target, record in (block.get("mappings") or {}).items()
+            if target in items and record.get("original_key") and record["original_key"] != target}
+
+
+def saved_blocks(policy: Mapping[str, Any]) -> Iterator[SavedRule]:
+    for pair_id, scoped in [("", policy), *(policy.get("pairs") or {}).items()]:
+        for provider, instance, feature, block in _feature_blocks(scoped):
+            automatic = correction_block_keys(block)
+            items = (block.get("adds") or {}).get("items") or {}
+            for key in block.get("blocks") or []:
+                if key.lower() in automatic:
+                    continue
+                yield SavedRule(pair_id=pair_id, scope="pair" if pair_id else "shared", provider=provider,
+                           instance=instance, feature=feature, key=key, entry_type="block",
+                           corrected=mapping_details(items[key]) if key in items else None,
+                           original=None, original_key=None, saved_at=None, origin=None, excluded=True)
+
+
+def _scoped_corrections(policy: Mapping[str, Any], pair_id: str) -> Iterator[SavedRule]:
     for provider, instance, feature, block in _feature_blocks(policy):
         records = block.get("mappings") or {}
         blocks = set(block.get("blocks") or [])
@@ -24,7 +66,7 @@ def saved_corrections(policy):
                 continue
             record = records.get(key) if isinstance(records, dict) else None
             record = record if isinstance(record, dict) else {}
-            yield dict(provider=provider, instance=instance, feature=feature, key=key,
+            yield SavedRule(pair_id=pair_id, scope="pair" if pair_id else "shared", provider=provider, instance=instance, feature=feature, key=key,
                        corrected=mapping_details(item), original=record.get("original"),
                        original_key=record.get("original_key"), saved_at=record.get("saved_at"),
                        origin=record.get("origin"), excluded=key in blocks)

--- a/tests/test_analyzer_mapping.py
+++ b/tests/test_analyzer_mapping.py
@@ -43,6 +43,7 @@ def test_saves_source_profile_preserving_watched_date_and_rating(mapping_case, m
     result = mapping.handle_mapping(payload.model_copy(update=dict(action="save", version=context["version"], item=corrected)), None)
     assert result["key"] == "tmdb:456#s01e03"
     edits, metadata = saved[0]
+    assert metadata["pair_id"] == "p1"
     feature, provider, items, blocks, instance = edits[0]
     assert (feature, provider, instance) == ("history", "SIMKL", "alice")
     assert items[result["key"]]["watched_at"] == original["watched_at"]
@@ -114,7 +115,7 @@ def test_api_save_persists_in_editor_saved_mappings(mapping_case, config_base, m
     from api import editorAPI
 
     monkeypatch.setattr(editorAPI, "_STATE_BASE", config_base)
-    monkeypatch.setattr(editorAPI, "load_config", lambda: {})
+    monkeypatch.setattr(editorAPI, "load_config", lambda: {"pairs": [mapping_case[1]]})
     app = FastAPI()
     app.include_router(an.router)
     app.include_router(editorAPI.router)

--- a/tests/test_interactive_sync.py
+++ b/tests/test_interactive_sync.py
@@ -641,7 +641,7 @@ def test_mapping_api_persists_and_recalculates(api_client, config_base, monkeypa
     assert len(session.plan.rows) == 1
     row = next(iter(session.plan.rows.values()))
     assert row["key"] == ("tmdb:2" if enrichment else "imdb:tt0000002")
-    adds, blocks = editorAPI._load_policy_manual("watchlist", "SRC")
+    adds, blocks = editorAPI._load_policy_manual("watchlist", "SRC", pair_id=session.pair_id)
     assert "_trakt_history_id" not in next(iter(adds.values()))
     assert blocks == ([] if enrichment else ["imdb:tt0000001"])
 

--- a/tests/test_interactive_sync_mapping.py
+++ b/tests/test_interactive_sync_mapping.py
@@ -50,7 +50,7 @@ def test_ten_corrections_one_policy_write_one_refresh(api_client, config_base, m
     assert session.store.counts["selected"] == (11 if selected else 1)
     assert not dst.add_calls and not src.add_calls
     policy = editorAPI.sqlite_manual_policy.load_policy(config_base)
-    records = policy["providers"]["SRC"]["watchlist"]["mappings"]
+    records = policy["pairs"][session.pair_id]["providers"]["SRC"]["watchlist"]["mappings"]
     assert len(records) == 10
     for n, row in enumerate(rows[:10]):
         record = records[next(iter(editorAPI._canonicalize_manual_items({"key": item(100+n)}, "watchlist")))]
@@ -101,7 +101,7 @@ def test_ids_and_episode_changed_together_preserve_watch_value(api_client, confi
     response = client.post(f"/api/interactive-sync/{session.id}/mappings", json=dict(
         revision=1, selection_version=0, edits=[dict(row_id=row["id"], item=corrected)]))
     assert response.status_code == 200
-    adds, blocks = editorAPI._load_policy_manual("history", "SRC")
+    adds, blocks = editorAPI._load_policy_manual("history", "SRC", pair_id=session.pair_id)
     saved = next(iter(adds.values()))
     assert saved["ids"] == saved["show_ids"] == {"tmdb": "1398"}
     assert (saved["season"], saved["episode"]) == (1, 9)
@@ -153,6 +153,22 @@ def test_batch_limit_rejects_oversized_request(api_client):
     edit = dict(row_id=next(iter(session.plan.rows)), item=item(1))
     response = client.post(f"/api/interactive-sync/{session.id}/mappings", json=dict(revision=1, selection_version=0, edits=[edit] * 201))
     assert response.status_code == 422
+
+
+def test_shared_scope_is_explicit_and_invalid_scope_cannot_save(api_client, config_base, monkeypatch):
+    from api import editorAPI
+    client, session, api = api_client
+    monkeypatch.setattr(editorAPI, "_STATE_BASE", config_base)
+    monkeypatch.setattr(api, "launch", lambda *args, prepare=None, **kwargs: prepare())
+    edit = dict(row_id=next(iter(session.plan.rows)), item=item(10))
+    payload = dict(revision=1, selection_version=0, edits=[edit])
+    assert client.post(f"/api/interactive-sync/{session.id}/mappings", json={**payload, "scope":"unknown"}).status_code == 422
+    assert not editorAPI._load_policy()["providers"]
+    response = client.post(f"/api/interactive-sync/{session.id}/mappings", json={**payload, "scope":"shared"})
+    assert response.status_code == 200, response.text
+    policy = editorAPI._load_policy()
+    assert policy["providers"]["SRC"]["watchlist"]["adds"]["items"]
+    assert not policy.get("pairs")
 
 
 @pytest.mark.parametrize("path", ["mappings", "mapping-search", "mapping-catalogs", "mapping-episodes"])

--- a/tests/test_mapping_blocks.py
+++ b/tests/test_mapping_blocks.py
@@ -1,0 +1,114 @@
+# CrossWatch - unified mapping and block rules
+from copy import deepcopy
+
+import pytest
+
+from cw_platform.id_map import canonical_key
+from cw_platform.local_db import manual_policy
+from cw_platform.mapping_policy import effective_policy
+from cw_platform.orchestrator import Orchestrator
+from cw_platform.orchestrator._interactive import InteractivePlan
+from test_interactive_sync import item, setup_ops
+from test_mapping_scopes import editor_client, save
+
+
+def rule(key="imdb:tt0000001", pair_id="p1", **extra):
+    return dict(provider="SRC", instance="default", feature="watchlist", pair_id=pair_id,
+                key=key, blocked=True, **extra)
+
+
+def test_block_manager_is_scoped_and_unblock_preserves_other_rules(editor_client, config_base):
+    client, api, cfg = editor_client
+    cfg["pairs"].append({**deepcopy(cfg["pairs"][0]), "id":"p2"})
+    for pair in ("", "p1", "p2"):
+        assert client.post("/api/editor/mapping-block", json=rule(pair_id=pair)).status_code == 200
+    before = manual_policy.fingerprint(config_base)
+    for pair in ("shared", "p1", "p2"):
+        viewed = client.get("/api/editor/mappings", params=dict(entry_type="block", pair_id=pair, provider="SRC", instance="default", feature="watchlist")).json()
+        assert viewed["total"] == 1
+        assert viewed["items"][0]["corrected"]["title"] == item(1)["title"]
+    assert client.post("/api/editor/mapping-block", json={**rule(), "blocked":False}).status_code == 200
+    assert manual_policy.fingerprint(config_base) != before
+    policy = api._load_policy()
+    assert not policy["pairs"]["p1"]["providers"]["SRC"]["watchlist"]["blocks"]
+    assert policy["pairs"]["p2"]["providers"]["SRC"]["watchlist"]["blocks"]
+    assert policy["providers"]["SRC"]["watchlist"]["blocks"]
+
+
+def test_correction_blocks_stay_with_mapping_but_corrected_item_can_be_blocked(editor_client):
+    client, api, cfg = editor_client
+    save(api, item(1), item(2), "p1")
+    assert client.get("/api/editor/mappings?entry_type=block&pair_id=p1").json()["total"] == 0
+    assert client.post("/api/editor/mapping-block", json={**rule(), "blocked":False}).status_code == 409
+    target = canonical_key(item(2))
+    assert client.post("/api/editor/mapping-block", json=rule(target)).status_code == 200
+    node = effective_policy(api._load_policy(), "p1")["providers"]["SRC"]["watchlist"]
+    assert target in node["blocks"]
+    viewed = client.get("/api/editor?source=state&provider=SRC&pair_id=p1").json()
+    assert target in viewed["preserved_blocks"]
+    assert client.post("/api/editor/mapping-block", json={**rule(target), "blocked":False}).status_code == 200
+    node = effective_policy(api._load_policy(), "p1")["providers"]["SRC"]["watchlist"]
+    assert target not in node["blocks"]
+    assert canonical_key(item(1)) in node["blocks"]
+    assert target in node["mappings"]
+
+
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_blocked_correction_is_excluded_in_real_sync(config_base, monkeypatch, editor_client, mode):
+    client, api, cfg = editor_client
+    setup_ops(config_base, monkeypatch, [item(1)])
+    cfg["pairs"][0]["mode"] = mode
+    cfg["pairs"].append({**deepcopy(cfg["pairs"][0]), "id":"p2"})
+    save(api, item(1), item(2), "p1")
+
+    def planned(pair):
+        plan = InteractivePlan()
+        result = Orchestrator(cfg, interactive=plan).run(dry_run=True, pair_scope_ids=[pair], write_state_json=False)
+        assert result["ok"]
+        return [row["item"]["ids"] for row in plan.rows.values()]
+
+    assert planned("p1") == [item(2)["ids"]]
+    assert client.post("/api/editor/mapping-block", json=rule(canonical_key(item(2)))).status_code == 200
+    assert planned("p1") == []
+    assert planned("p2") == [item(1)["ids"]]
+    assert client.post("/api/editor/mapping-block", json={**rule(canonical_key(item(2))), "blocked":False}).status_code == 200
+    assert planned("p1") == [item(2)["ids"]]
+
+
+def test_orphan_block_is_listed_and_preserved_when_editor_saves(editor_client):
+    client, api, cfg = editor_client
+    key = canonical_key(item(99))
+    assert client.post("/api/editor/mapping-block", json=rule(key)).status_code == 200
+    data = client.get("/api/editor/mappings?entry_type=block&pair_id=p1").json()
+    assert data["items"][0]["key"] == key
+    assert data["items"][0]["corrected"] is None
+    viewed = client.get("/api/editor?source=state&provider=SRC&pair_id=p1").json()
+    assert viewed["preserved_blocks"] == [key]
+    payload = dict(source="state", provider="SRC", pair_id="p1", kind="watchlist", items={}, blocks=viewed["preserved_blocks"])
+    assert client.post("/api/editor", json=payload).status_code == 200
+    assert client.get("/api/editor/mappings?entry_type=block&pair_id=p1").json()["total"] == 1
+
+
+def test_block_updates_reject_foreign_scopes_and_read_only_users(editor_client, monkeypatch):
+    from services import editor_mapping
+    client, api, cfg = editor_client
+    assert client.post("/api/editor/mapping-block", json=rule(pair_id="missing")).status_code == 404
+    monkeypatch.setattr(editor_mapping, "request_user", lambda request: {"permissions":{"write":False}})
+    assert client.post("/api/editor/mapping-block", json=rule()).status_code == 403
+    monkeypatch.setattr(editor_mapping, "request_user", lambda request: None)
+    monkeypatch.setattr(editor_mapping, "user_can_access_pair", lambda *args: False)
+    assert client.post("/api/editor/mapping-block", json=rule()).status_code == 404
+    assert not list(manual_policy.load_policy(api._STATE_BASE).get("pairs", {}))
+
+
+def test_blocks_list_respects_pair_and_profile_access(editor_client, monkeypatch):
+    from cw_platform import access_policy
+    client, api, cfg = editor_client
+    for pair in ("", "p1"):
+        assert client.post("/api/editor/mapping-block", json=rule(pair_id=pair)).status_code == 200
+    monkeypatch.setattr(access_policy, "user_can_access_pair", lambda *args: False)
+    data = client.get("/api/editor/mappings?entry_type=block").json()
+    assert data["total"] == 1 and data["items"][0]["scope"] == "shared"
+    monkeypatch.setattr(api, "user_can_access_instance", lambda *args: False)
+    data = client.get("/api/editor/mappings?entry_type=block").json()
+    assert data["total"] == 0 and data["sources"] == []

--- a/tests/test_mapping_scopes.py
+++ b/tests/test_mapping_scopes.py
@@ -1,0 +1,224 @@
+# tests/test_mapping_scopes.py
+# CrossWatch - Mapping scope isolation and Editor staging
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from copy import deepcopy
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cw_platform.id_map import canonical_key
+from cw_platform.local_db import manual_policy
+from cw_platform.mapping_policy import effective_policy
+from cw_platform.orchestrator import Orchestrator
+from cw_platform.orchestrator._interactive import InteractivePlan
+from test_interactive_sync import item, setup_ops
+from test_orchestrator_dry_run_no_side_effects import _cfg
+
+
+def save(api, old, new, pair_id="", feature="watchlist", instance="default"):
+    source, target = canonical_key(old), canonical_key(new)
+    api._save_policy_manual_batch([(feature, "SRC", {target: new}, [source], instance)], pair_id=pair_id,
+        mappings={(feature, "SRC", instance): {target: dict(original_key=source, original=old, origin="editor")}})
+
+
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_pair_override_replaces_shared_mapping_in_real_sync(config_base, monkeypatch, mode):
+    from api import editorAPI as api
+    setup_ops(config_base, monkeypatch, [item(1)])
+    monkeypatch.setattr(api, "_STATE_BASE", config_base)
+    cfg = _cfg(False)
+    cfg["pairs"][0]["mode"] = mode
+    cfg["pairs"].append({**deepcopy(cfg["pairs"][0]), "id": "p2"})
+    save(api, item(1), item(2))
+    save(api, item(2), item(3), "p1")
+
+    def planned(pair_id):
+        plan = InteractivePlan()
+        result = Orchestrator(cfg, interactive=plan).run(dry_run=True, pair_scope_ids=[pair_id], write_state_json=False)
+        assert result["ok"]
+        return [row["item"]["ids"] for row in plan.rows.values()]
+
+    assert planned("p1") == [item(3)["ids"]]
+    assert planned("p2") == [item(2)["ids"]]
+    save(api, item(3), item(4), "p1")
+    assert planned("p1") == [item(4)["ids"]]
+    assert planned("p2") == [item(2)["ids"]]
+    policy = api._load_policy()
+    record = next(iter(policy["pairs"]["p1"]["providers"]["SRC"]["watchlist"]["mappings"].values()))
+    assert record["original_key"] == canonical_key(item(1))
+    save(api, item(4), item(1), "p1")
+    assert planned("p1") == [item(1)["ids"]]
+    assert planned("p2") == [item(2)["ids"]]
+    policy["pairs"].pop("p1")
+    manual_policy.save_policy(config_base, policy)
+    assert planned("p1") == [item(2)["ids"]]
+
+
+@pytest.mark.parametrize("feature", ["watchlist", "history", "ratings", "progress", "collection"])
+def test_scope_roundtrip_backups_and_instance_isolation(config_base, monkeypatch, feature):
+    from api import editorAPI as api
+    monkeypatch.setattr(api, "_STATE_BASE", config_base)
+    save(api, item(1), item(2), feature=feature)
+    before = manual_policy.fingerprint(config_base)
+    save(api, item(1), item(3), "p1", feature, "second")
+    assert manual_policy.fingerprint(config_base) != before
+    policy = api._load_policy()
+    for mode in ("replace", "merge"):
+        restored = api._merge_policy({}, deepcopy(policy), mode)
+        manual_policy.save_policy(config_base, restored)
+        assert api._load_policy() == policy
+    scoped = effective_policy(policy, "p1")["providers"]["SRC"]
+    assert next(iter(scoped[feature]["adds"]["items"].values()))["ids"] == item(2)["ids"]
+    assert next(iter(scoped["instances"]["second"][feature]["adds"]["items"].values()))["ids"] == item(3)["ids"]
+    assert "instances" not in effective_policy(policy, "p2")["providers"]["SRC"]
+    manual_policy.clear_policy(config_base)
+    assert not manual_policy.has_policy(config_base)
+
+
+@pytest.fixture
+def editor_client(config_base, monkeypatch):
+    from api import editorAPI as api
+    cfg = _cfg(False)
+    monkeypatch.setattr(api, "_STATE_BASE", config_base)
+    monkeypatch.setattr(api, "load_config", lambda: cfg)
+    monkeypatch.setattr(api, "_load_state_items", lambda *args, **kwargs: {canonical_key(item(1)): item(1)})
+    app = FastAPI()
+    app.include_router(api.router)
+    with TestClient(app) as client:
+        yield client, api, cfg
+
+
+def test_editor_prepare_is_staged_and_save_has_explicit_scope(editor_client):
+    client, api, cfg = editor_client
+    original = item(1, watched_at="2026-09-08T10:00:00Z", rating=8)
+    payload = dict(provider="SRC", feature="watchlist", key=canonical_key(original), original=original,
+                   item=item(2, rating=1), action="prepare", pair_id="p1")
+    result = client.post("/api/editor/mapping", json=payload)
+    assert result.status_code == 200, result.text
+    prepared = result.json()
+    assert prepared["item"]["rating"] == 8
+    assert prepared["item"]["watched_at"] == original["watched_at"]
+    assert not api._load_policy().get("pairs")
+    result = client.post("/api/editor", json=dict(provider="SRC", source="state", kind="watchlist",
+        pair_id="p1", items={prepared["key"]: prepared["item"]}, blocks=prepared["blocks"],
+        mapping_originals={prepared["key"]: payload["key"]}))
+    assert result.status_code == 200, result.text
+    assert not api._load_policy()["providers"]
+    listed = client.get("/api/editor/mappings").json()["items"]
+    assert len(listed) == 1 and listed[0]["pair_id"] == "p1"
+    viewed = client.get("/api/editor?source=manual&provider=SRC&pair_id=p1").json()
+    assert prepared["key"] in viewed["manual_adds"]
+    assert viewed["mapping_scopes"][0]["id"] == "p1"
+    assert not client.get("/api/editor?source=manual&provider=SRC").json()["manual_adds"]
+
+
+def test_editor_rejects_foreign_pair_scopes(editor_client, monkeypatch):
+    client, api, cfg = editor_client
+    from services import editor_mapping
+    monkeypatch.setattr(editor_mapping, "user_can_access_pair", lambda *args: False)
+    assert client.get("/api/editor?provider=SRC&pair_id=p1").status_code == 404
+    assert client.post("/api/editor", json=dict(provider="SRC", pair_id="p1", items={})).status_code == 404
+    assert client.post("/api/editor/mapping", json=dict(provider="SRC", feature="watchlist", pair_id="p1",
+        action="prepare", key=canonical_key(item(1)), original=item(1), item=item(2))).status_code == 404
+    assert not api._load_policy().get("pairs")
+
+
+def test_editor_removal_restores_shared_mapping_and_preserves_other_scopes(editor_client):
+    client, api, cfg = editor_client
+    cfg["pairs"].append({**deepcopy(cfg["pairs"][0]), "id": "p2"})
+    save(api, item(1), item(2))
+    save(api, item(1), item(3), "p1")
+    save(api, item(1), item(4), "p2")
+    save(api, item(1), item(5), "p1", feature="history")
+    save(api, item(1), item(6), "p1", instance="second")
+    before = deepcopy(api._load_policy())
+    response = client.post("/api/editor", json=dict(source="state", provider="SRC",
+        kind="watchlist", pair_id="p1", items={}, blocks=[], mapping_originals={}))
+    assert response.status_code == 200, response.text
+    policy = api._load_policy()
+    assert policy["providers"] == before["providers"]
+    assert policy["pairs"]["p2"] == before["pairs"]["p2"]
+    scoped = policy["pairs"]["p1"]["providers"]["SRC"]
+    assert scoped["history"] == before["pairs"]["p1"]["providers"]["SRC"]["history"]
+    assert scoped["instances"] == before["pairs"]["p1"]["providers"]["SRC"]["instances"]
+    assert not scoped["watchlist"]["adds"]["items"]
+    assert not scoped["watchlist"]["blocks"]
+    assert not scoped["watchlist"]["mappings"]
+    assert next(iter(effective_policy(policy, "p1")["providers"]["SRC"]["watchlist"]["adds"]["items"].values()))["ids"] == item(2)["ids"]
+
+
+@pytest.mark.parametrize("pair_id", ["", "p1"])
+def test_editor_resave_keeps_original_block_and_removal_clears_mapping(editor_client, pair_id):
+    client, api, cfg = editor_client
+    save(api, item(1), item(2), pair_id)
+    key = canonical_key(item(2))
+    payload = dict(source="state", provider="SRC", kind="watchlist", pair_id=pair_id,
+                   items={key: item(2)}, blocks=[], mapping_originals={key: key})
+    assert client.post("/api/editor", json=payload).status_code == 200
+    effective = effective_policy(api._load_policy(), pair_id)["providers"]["SRC"]["watchlist"]
+    assert effective["blocks"] == [canonical_key(item(1))]
+    assert set(effective["adds"]["items"]) == {key}
+    viewed = client.get("/api/editor", params=dict(source="state", provider="SRC", pair_id=pair_id)).json()
+    assert viewed["mapping_origins"][key] == ("pair" if pair_id else "shared")
+    assert client.post("/api/editor", json={**payload, "items": {}, "mapping_originals": {}}).status_code == 200
+    effective = effective_policy(api._load_policy(), pair_id)["providers"]["SRC"]["watchlist"]
+    assert not effective["adds"]["items"]
+    assert not effective.get("mappings")
+    assert not effective["blocks"]
+
+
+def test_pair_editor_keeps_ordinary_block_rules_editable(editor_client):
+    client, api, cfg = editor_client
+    key = canonical_key(item(1))
+    payload = dict(source="state", provider="SRC", kind="watchlist", pair_id="p1", items={}, blocks=[key])
+    assert client.post("/api/editor", json=payload).status_code == 200
+    viewed = client.get("/api/editor", params=dict(source="state", provider="SRC", pair_id="p1")).json()
+    # The Editor must be able to render this as a blocked baseline row and
+    # include the rule in its next full save, or explicitly restore the row.
+    assert key in viewed["items"]
+    assert viewed["manual_blocks"] == [key]
+    assert key not in viewed["mapping_origins"]
+    assert client.post("/api/editor", json=payload).status_code == 200
+    assert effective_policy(api._load_policy(), "p1")["providers"]["SRC"]["watchlist"]["blocks"] == [key]
+    assert client.post("/api/editor", json={**payload, "blocks": []}).status_code == 200
+    assert not effective_policy(api._load_policy(), "p1")["providers"]["SRC"]["watchlist"]["blocks"]
+
+
+def test_saved_pair_mapping_visibility_requires_pair_access(editor_client, monkeypatch):
+    from cw_platform import access_policy
+    client, api, cfg = editor_client
+    save(api, item(1), item(2))
+    save(api, item(1), item(3), "p1")
+    monkeypatch.setattr(access_policy, "user_can_access_pair", lambda *args: False)
+    rows = client.get("/api/editor/mappings").json()["items"]
+    assert len(rows) == 1 and rows[0]["scope"] == "shared"
+
+
+def test_saved_mappings_filter_the_editor_scope_before_pagination(editor_client):
+    client, api, cfg = editor_client
+    cfg["pairs"].append({**deepcopy(cfg["pairs"][0]), "id":"p2"})
+    save(api, item(1), item(2))
+    save(api, item(1), item(3), "p1")
+    save(api, item(1), item(4), "p2")
+    save(api, item(1), item(5), "p1", instance="second")
+    save(api, item(1), item(6), "p1", feature="history")
+    api._save_policy_manual_batch([("watchlist", "OTHER", {canonical_key(item(7)): item(7)}, [], "default")], pair_id="p1")
+    filters = dict(provider="SRC", instance="default", feature="watchlist", limit=1)
+    for scope, expected in [("p1", 3), ("p2", 4), ("shared", 2)]:
+        result = client.get("/api/editor/mappings", params={**filters, "pair_id":scope}).json()
+        assert result["total"] == 1
+        assert result["items"][0]["corrected"]["ids"] == item(expected)["ids"]
+        assert not client.get("/api/editor/mappings", params={**filters, "pair_id":scope, "offset":1}).json()["items"]
+    assert client.get("/api/editor/mappings", params={**filters, "pair_id":"missing"}).json()["total"] == 0
+
+
+def test_editor_shared_search_uses_metadata_and_pair_search_uses_destination(editor_client):
+    client, api, cfg = editor_client
+    cfg["tmdb"] = {"api_key":"configured"}
+    payload = dict(provider="SRC", feature="watchlist", key=canonical_key(item(1)), original=item(1), action="catalogs")
+    shared = client.post("/api/editor/mapping", json=payload).json()
+    assert shared["catalogs"] == [{"id":"tmdb", "label":"TMDb metadata"}]
+    pair = client.post("/api/editor/mapping", json={**payload, "pair_id":"p1"}).json()
+    assert pair["row"]["provider"] == "DST"
+    assert pair["row"]["source"] == "SRC"


### PR DESCRIPTION
# Pull request

## Change

- Bring mappings and blocked items into one scoped view.
- Remove the Manual overrides source and unused Editor code.
- Add mapping icons in editor
- Load Editor helpers in parallel and show loading feedback with a retry button.

## Why

Keep mappings and blocks together

## Testing

- tests/test_interactive_sync.py

## Issue

NA