### PR TITLE
Fix: skip partial playback on history import

### DIFF
--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -495,7 +495,9 @@ DEFAULT_CFG: dict[str, Any] = {
          "history": {
              "user_id": "",                             # Optional user filter
              "per_page": 100,                           # Tautulli history page size
-             "max_pages": 5000                          # Safety cap
+             "max_pages": 5000,                         # Safety cap
+             "watched_only": True,                      # Skip partial playback sessions (Tautulli logs every play)
+             "min_percent": 90                          # Completion fallback when watched_status is absent
          },
      },
 

--- a/providers/sync/plex/_history.py
+++ b/providers/sync/plex/_history.py
@@ -894,7 +894,7 @@ def _iter_marked_watched_from_library(
             for row in rows:
                 view_count = max(_int0(row.get("viewCount")), _int0(row.get("leafCountViewed")))
                 ts = _as_epoch(row.get("lastViewedAt") or row.get("viewedAt"))
-                watched = view_count > 0 or bool(ts)
+                watched = view_count > 0
                 if not watched:
                     continue
                 page_watched += 1

--- a/providers/sync/tautulli/_history.py
+++ b/providers/sync/tautulli/_history.py
@@ -33,6 +33,25 @@ def _rewatches_enabled(adapter: Any) -> bool:
     return bool(isinstance(cfg, Mapping) and cfg.get("_cw_history_rewatches"))
 
 
+def _to_float(v: Any) -> float | None:
+    if v is None or isinstance(v, bool):
+        return None
+    try:
+        return float(str(v).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _row_is_watched(row: Mapping[str, Any], min_percent: float) -> bool:
+    ws = _to_float(row.get("watched_status"))
+    if ws is not None:
+        return ws >= 1.0
+    pc = _to_float(row.get("percent_complete"))
+    if pc is not None:
+        return pc >= min_percent
+    return True
+
+
 def _to_int(v: Any) -> int | None:
     if v is None or isinstance(v, bool):
         return None
@@ -235,8 +254,19 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 5000) -> 
     cfg_max_pages = int(_cfg_get(adapter, "tautulli.history.max_pages", max_pages) or max_pages)
     if cfg_max_pages <= 0:
         cfg_max_pages = max_pages
+    watched_only = bool(_cfg_get(adapter, "tautulli.history.watched_only", True))
+    min_percent = _to_float(_cfg_get(adapter, "tautulli.history.min_percent", 90))
+    if min_percent is None:
+        min_percent = 90.0
 
-    _log("index_fetch_counts", per_page=cfg_per_page, max_pages=cfg_max_pages, has_user_id=bool(user_id))
+    _log(
+        "index_fetch_counts",
+        per_page=cfg_per_page,
+        max_pages=cfg_max_pages,
+        has_user_id=bool(user_id),
+        watched_only=watched_only,
+        min_percent=min_percent,
+    )
 
     out: dict[str, dict[str, Any]] = {}
     meta_cache: dict[str, Mapping[str, Any] | None] = {}
@@ -248,6 +278,7 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 5000) -> 
     rows_seen = 0
     rows_kept = 0
     skipped_type = 0
+    skipped_partial = 0
     skipped_no_time = 0
     skipped_no_ids = 0
     event_mode = _rewatches_enabled(adapter)
@@ -324,6 +355,10 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 5000) -> 
             mtype = (row.get("media_type") or row.get("mediaType") or "").lower()
             if mtype not in ("movie", "episode"):
                 skipped_type += 1
+                continue
+
+            if watched_only and not _row_is_watched(row, min_percent):
+                skipped_partial += 1
                 continue
 
             ts = _as_epoch(row.get("date") or row.get("started") or row.get("time"))
@@ -413,6 +448,7 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 5000) -> 
         rows_seen=rows_seen,
         rows_kept=rows_kept,
         skipped_type=skipped_type,
+        skipped_partial=skipped_partial,
         skipped_no_time=skipped_no_time,
         skipped_no_ids=skipped_no_ids,
         meta_cache=len(meta_cache),

--- a/tests/test_plex_marked_watched_fallback.py
+++ b/tests/test_plex_marked_watched_fallback.py
@@ -1,0 +1,176 @@
+# tests/test_plex_marked_watched_fallback.py
+# CrossWatch - Plex Marked-Watched Library Scan Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Callable
+
+import pytest
+
+from providers.sync.plex import _history as history
+
+
+LAST_VIEWED = 1787093918
+
+
+class _Resp:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self.ok = True
+        self.status_code = 200
+        self.headers = {"content-type": "application/json"}
+        self._payload = {"MediaContainer": {"Metadata": rows, "totalSize": len(rows)}}
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _Session:
+    def __init__(self, handler: Callable[[dict[str, Any]], _Resp]):
+        self.headers: dict[str, str] = {}
+        self._handler = handler
+        self.requests: list[dict[str, Any]] = []
+
+    def get(self, url: str, params: Any = None, headers: Any = None, timeout: Any = None) -> _Resp:
+        p = dict(params or {})
+        self.requests.append(p)
+        return self._handler(p)
+
+
+def _episode(rating_key: str, view_count: int, last_viewed: int | None = LAST_VIEWED) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "type": "episode",
+        "ratingKey": rating_key,
+        "title": f"Episode {rating_key}",
+        "grandparentTitle": "Example series",
+        "parentIndex": 1,
+        "index": int(rating_key),
+        "viewCount": view_count,
+    }
+    if last_viewed is not None:
+        row["lastViewedAt"] = last_viewed
+    return row
+
+
+def _movie(rating_key: str, view_count: int, last_viewed: int | None = LAST_VIEWED) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "type": "movie",
+        "ratingKey": rating_key,
+        "title": f"Movie {rating_key}",
+        "viewCount": view_count,
+    }
+    if last_viewed is not None:
+        row["lastViewedAt"] = last_viewed
+    return row
+
+
+@pytest.fixture
+def scan(monkeypatch):
+    monkeypatch.setattr(history, "_load_marked_state", lambda: {})
+    monkeypatch.setattr(history, "_save_marked_state", lambda *_: None)
+    monkeypatch.setattr(history, "plex_headers", lambda _t: {})
+    monkeypatch.setattr(
+        history,
+        "normalize_discover_row",
+        lambda row, token=None: {
+            "type": row.get("type"),
+            "title": row.get("title"),
+            "series_title": row.get("grandparentTitle"),
+            "season": row.get("parentIndex"),
+            "episode": row.get("index"),
+            "ids": {"plex": str(row.get("ratingKey"))},
+        },
+    )
+
+    def _run(handler: Callable[[dict[str, Any]], _Resp], section_type: str = "show") -> tuple[list, _Session]:
+        ses = _Session(handler)
+        server = SimpleNamespace(baseurl="http://plex.local:32400", _session=ses, token="tok")
+        section = SimpleNamespace(type=section_type, key="1", title="Example section")
+        adapter = SimpleNamespace(
+            client=SimpleNamespace(server=server),
+            libraries=lambda types=(): [section],
+        )
+        return history._iter_marked_watched_from_library(adapter, set()), ses
+
+    return _run
+
+
+def test_in_progress_episode_is_not_reported_as_marked_watched(scan):
+    def handler(params: dict[str, Any]) -> _Resp:
+        if "unwatched" in params:
+            return _Resp([])
+        return _Resp([_episode("2", view_count=0)])
+
+    results, ses = scan(handler)
+
+    assert results == []
+    assert any("unwatched" not in r for r in ses.requests), "the unfiltered fallback scan should still run"
+
+
+def test_fallback_still_returns_genuinely_watched_episodes(scan):
+    def handler(params: dict[str, Any]) -> _Resp:
+        if "unwatched" in params:
+            return _Resp([])
+        return _Resp([_episode("2", view_count=1)])
+
+    results, _ = scan(handler)
+
+    assert len(results) == 1
+    meta, ts = results[0]
+    assert meta["ids"]["plex"] == "2"
+    assert ts == LAST_VIEWED
+
+
+def test_fallback_keeps_watched_and_drops_in_progress(scan):
+    def handler(params: dict[str, Any]) -> _Resp:
+        if "unwatched" in params:
+            return _Resp([])
+        return _Resp([
+            _episode("1", view_count=1),
+            _episode("2", view_count=0),
+            _episode("3", view_count=2),
+            _episode("4", view_count=0),
+        ])
+
+    results, _ = scan(handler)
+
+    assert sorted(m["ids"]["plex"] for m, _ in results) == ["1", "3"]
+
+
+def test_filtered_scan_is_unaffected_and_skips_the_fallback(scan):
+    def handler(params: dict[str, Any]) -> _Resp:
+        if "unwatched" in params:
+            return _Resp([_movie("7", view_count=1)])
+        raise AssertionError("fallback must not run when the filtered scan returned rows")
+
+    results, ses = scan(handler, section_type="movie")
+
+    assert len(results) == 1
+    assert results[0][0]["ids"]["plex"] == "7"
+    assert all("unwatched" in r for r in ses.requests)
+
+
+def test_movie_section_never_falls_back(scan):
+    def handler(params: dict[str, Any]) -> _Resp:
+        if "unwatched" in params:
+            return _Resp([])
+        raise AssertionError("movie sections must not run the unfiltered fallback")
+
+    results, _ = scan(handler, section_type="movie")
+
+    assert results == []
+
+
+def test_watched_row_without_timestamp_is_still_returned(scan):
+    def handler(params: dict[str, Any]) -> _Resp:
+        if "unwatched" in params:
+            return _Resp([_episode("5", view_count=1, last_viewed=None)])
+        return _Resp([])
+
+    results, _ = scan(handler)
+
+    assert len(results) == 1
+    meta, ts = results[0]
+    assert ts == 0
+    assert meta["watched_at"] is None
+    assert meta["_cw_watched_at_missing"] is True

--- a/tests/test_tautulli_history_watched_only.py
+++ b/tests/test_tautulli_history_watched_only.py
@@ -1,0 +1,113 @@
+# tests/test_tautulli_history_watched_only.py
+# CrossWatch - Tautulli History Partial Playback Gate Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from providers.sync.tautulli import _history as history
+
+
+WATCHED_AT = 1787093918
+
+
+def _row(**over: Any) -> dict[str, Any]:
+    row = {
+        "media_type": "movie",
+        "title": "Example movie",
+        "year": 2026,
+        "rating_key": "42",
+        "guid": "com.plexapp.agents.imdb://tt1234567",
+        "date": WATCHED_AT,
+        "watched_status": 1,
+        "percent_complete": 100,
+    }
+    row.update(over)
+    return row
+
+
+def _adapter(rows: list[dict[str, Any]], cfg: dict[str, Any] | None = None) -> SimpleNamespace:
+    calls: list[dict[str, Any]] = []
+
+    def call(cmd: str, **params: Any) -> Any:
+        calls.append({"cmd": cmd, **params})
+        if cmd != "get_history":
+            return None
+        if params.get("start", 0):
+            return {"data": [], "recordsFiltered": len(rows)}
+        return {"data": list(rows), "recordsFiltered": len(rows)}
+
+    client = SimpleNamespace(call=call, calls=calls)
+    history_cfg = {"per_page": 100, "max_pages": 5}
+    history_cfg.update(cfg or {})
+    return SimpleNamespace(client=client, cfg={"tautulli": {"history": history_cfg}}, calls=calls)
+
+
+def test_partial_playback_is_not_imported_as_watched():
+    adapter = _adapter([_row(watched_status=0, percent_complete=2)])
+    assert history.build_index(adapter) == {}
+
+
+def test_half_watched_status_is_not_imported():
+    adapter = _adapter([_row(watched_status=0.5, percent_complete=55)])
+    assert history.build_index(adapter) == {}
+
+
+def test_completed_playback_is_imported():
+    adapter = _adapter([_row()])
+    out = history.build_index(adapter)
+    assert len(out) == 1
+    assert next(iter(out.values()))["watched_at"].startswith("2026-")
+
+
+def test_partial_row_skips_metadata_lookups():
+    adapter = _adapter([_row(watched_status=0, percent_complete=2, guid="")])
+    history.build_index(adapter)
+    assert not [c for c in adapter.calls if c["cmd"] == "get_metadata"]
+
+
+def test_watched_only_disabled_keeps_partial_rows():
+    adapter = _adapter([_row(watched_status=0, percent_complete=2)], {"watched_only": False})
+    assert len(history.build_index(adapter)) == 1
+
+
+@pytest.mark.parametrize(
+    ("percent", "min_percent", "kept"),
+    [(2, 90, False), (40, 90, False), (95, 90, True), (80, 75, True), (80, 90, False)],
+)
+def test_percent_complete_is_the_fallback_when_watched_status_is_absent(percent, min_percent, kept):
+    row = _row(percent_complete=percent)
+    row.pop("watched_status")
+    adapter = _adapter([row], {"min_percent": min_percent})
+    assert len(history.build_index(adapter)) == (1 if kept else 0)
+
+
+def test_rows_without_completion_fields_are_kept():
+    row = _row()
+    row.pop("watched_status")
+    row.pop("percent_complete")
+    adapter = _adapter([row])
+    assert len(history.build_index(adapter)) == 1
+
+
+def test_unparsable_completion_fields_fall_back_rather_than_dropping():
+    adapter = _adapter([_row(watched_status="", percent_complete="")])
+    assert len(history.build_index(adapter)) == 1
+
+
+def test_episode_partial_playback_is_not_imported():
+    adapter = _adapter([
+        _row(
+            media_type="episode",
+            watched_status=0,
+            percent_complete=3,
+            parent_media_index=1,
+            media_index=2,
+            grandparent_title="Example series",
+            grandparent_guid="com.plexapp.agents.thetvdb://99",
+        )
+    ])
+    assert history.build_index(adapter) == {}


### PR DESCRIPTION
# Pull request

## Change

Tautulli history now skips partial playback sessions.
It checks watched_status first, since Tautulli already applies your own watched percent settings.
Rows with neither field are kept so nothing silently disappears.

Two new settings under tautulli.history (config.json):
- watched_only, default true
- min_percent, default 90

## Why

Tautulli was added as a one-time import helper so the index took every history row it got back. 
Tautulli logs a session the moment you press play, so a 2% start became watched.

## Testing

- tests/test_tautulli_history_watched_only.py 
- tests/test_plex_marked_watched_fallback.py

## Issue

Relates to #1053
