### PR TITLE
Add: configurable profiles per provider

### DIFF
--- a/api/providerInstancesAPI.py
+++ b/api/providerInstancesAPI.py
@@ -51,7 +51,22 @@ _CFG_KEY_ALIAS = {
     "cw": "crosswatch",
     "crosswatch": "crosswatch",
 }
-_MAX_GENERATED_PROFILES = 9
+_DEFAULT_MAX_PROFILES = 10
+
+
+def _max_profiles_per_provider(cfg: Mapping[str, Any] | None = None) -> int:
+    try:
+        src = cfg if isinstance(cfg, Mapping) else (load_config() or {})
+        rt = src.get("runtime")
+        raw = rt.get("max_profiles_per_provider") if isinstance(rt, Mapping) else None
+        total = _DEFAULT_MAX_PROFILES if raw is None else int(raw)
+    except Exception:
+        total = _DEFAULT_MAX_PROFILES
+    return max(1, min(100, total))
+
+
+def _max_generated_profiles(cfg: Mapping[str, Any] | None = None) -> int:
+    return _max_profiles_per_provider(cfg) - 1
 
 
 def _cfg_key(provider: str) -> str:
@@ -88,7 +103,7 @@ def _prov_prefix(provider: str) -> str:
     return str(provider or "").strip().upper()
 
 
-def _canonical_profile_id(provider: str, instance_id: Any) -> str | None:
+def _canonical_profile_id(provider: str, instance_id: Any, cfg: Mapping[str, Any] | None = None) -> str | None:
     inst = normalize_instance_id(instance_id)
     if inst == "default":
         return None
@@ -100,15 +115,15 @@ def _canonical_profile_id(provider: str, instance_id: Any) -> str | None:
         num = int(m.group(1))
     except Exception:
         return ""
-    if num < 1 or num > _MAX_GENERATED_PROFILES:
+    if num < 1 or num > _max_generated_profiles(cfg):
         return ""
     return f"{prov}-P{num:02d}"
 
 
-def _next_profile_id(provider: str, insts: dict[str, Any]) -> str:
+def _next_profile_id(provider: str, insts: dict[str, Any], cfg: Mapping[str, Any] | None = None) -> str:
     prov = _prov_prefix(provider)
     existing = {str(k).strip().upper() for k in (insts or {}).keys()}
-    for n in range(1, _MAX_GENERATED_PROFILES + 1):
+    for n in range(1, _max_generated_profiles(cfg) + 1):
         cand = f"{prov}-P{n:02d}"
         if cand not in existing:
             return cand
@@ -356,9 +371,9 @@ def api_provider_instances_create_next(provider: str, payload: dict[str, Any] = 
         insts = {}
         blk["instances"] = insts
 
-    inst = _next_profile_id(provider, insts)
+    inst = _next_profile_id(provider, insts, cfg)
     if not inst:
-        return {"ok": False, "error": "profile_limit_reached"}
+        return {"ok": False, "error": "profile_limit_reached", "limit": _max_profiles_per_provider(cfg)}
 
     if inst in insts and isinstance(insts.get(inst), dict):
         uid = provider_instance_uid_for(cfg, provider, inst, create=True)
@@ -373,14 +388,14 @@ def api_provider_instances_create_next(provider: str, payload: dict[str, Any] = 
 
 @router.post("/provider-instances/{provider}/{instance_id}")
 def api_provider_instances_create(provider: str, instance_id: str, payload: dict[str, Any] = Body(default_factory=dict), request: Request = cast(Request, None)) -> Any:
-    canon = _canonical_profile_id(provider, instance_id)
+    cfg = dict(load_config() or {})
+    canon = _canonical_profile_id(provider, instance_id, cfg)
     if canon is None:
         return {"ok": False, "error": "reserved_instance_id"}
     if not canon:
         return {"ok": False, "error": "invalid_instance_id"}
     inst = canon
 
-    cfg = dict(load_config() or {})
     blocked = _admin_required_response(request, cfg)
     if blocked is not None:
         return blocked

--- a/assets/auth/auth.shared.js
+++ b/assets/auth/auth.shared.js
@@ -631,13 +631,17 @@
           });
           const j = await r.json().catch(() => ({}));
           const id = txt(j && j.id);
-          if (!r.ok || (j && j.ok === false) || !id) throw new Error(String((j && j.error) || "create_failed"));
+          if (!r.ok || (j && j.ok === false) || !id) {
+            const err = new Error(String((j && j.error) || "create_failed"));
+            if (j && j.limit) err.limit = j.limit;
+            throw err;
+          }
           setInstance(id);
           await refreshOptions(true);
           try { panel.dispatchEvent(new CustomEvent("cw-auth-profile-created", { bubbles: true, detail: { provider: apiProvider, instance: id } })); } catch (_) {}
           try { Promise.resolve(onChange?.()).catch(() => {}); } catch (_) {}
         } catch (e) {
-          const message = e && e.message === "profile_limit_reached" ? "Maximum 10 profiles reached." : (e && e.message ? e.message : e);
+          const message = e && e.message === "profile_limit_reached" ? `Maximum ${e.limit || 10} profiles reached.` : (e && e.message ? e.message : e);
           notify("Could not create profile: " + message);
         }
       });

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -727,6 +727,7 @@ DEFAULT_CFG: dict[str, Any] = {
         "debug_mods": False,                            # Extra verbode MODS logging for Synchronization Providers
         "state_dir": "",                                # Optional override for state dir (defaults to CONFIG/state)  - this will break container setups!
         "telemetry": {"enabled": True},                 # Usage stats
+        "max_profiles_per_provider": 10,                # Total profiles per provider incl. default (1-100)
 
         # progress
         "snapshot_ttl_sec": 300,                        # Reuse snapshots within 5 min

--- a/tests/test_provider_profile_limit.py
+++ b/tests/test_provider_profile_limit.py
@@ -1,0 +1,71 @@
+# tests/test_provider_profile_limit.py
+# CrossWatch - Configurable Profiles Per Provider Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import api.providerInstancesAPI as provider_api
+
+
+def _cfg(limit: Any = None) -> dict[str, Any]:
+    runtime: dict[str, Any] = {}
+    if limit is not None:
+        runtime["max_profiles_per_provider"] = limit
+    return {"runtime": runtime}
+
+
+def _insts(count: int, prov: str = "PLEX") -> dict[str, Any]:
+    out: dict[str, Any] = {"default": {}}
+    for n in range(1, count + 1):
+        out[f"{prov}-P{n:02d}"] = {}
+    return out
+
+
+def test_default_limit_is_ten_total():
+    assert provider_api._max_profiles_per_provider(_cfg()) == 10
+    assert provider_api._max_generated_profiles(_cfg()) == 9
+
+
+def test_config_key_raises_the_limit():
+    assert provider_api._max_profiles_per_provider(_cfg(25)) == 25
+    assert provider_api._max_generated_profiles(_cfg(25)) == 24
+
+
+@pytest.mark.parametrize(("raw", "expected"), [(0, 1), (-5, 1), (500, 100), ("no", 10), (None, 10)])
+def test_limit_is_clamped_and_falls_back(raw, expected):
+    assert provider_api._max_profiles_per_provider(_cfg(raw)) == expected
+
+
+def test_next_profile_id_stops_at_the_default_limit():
+    assert provider_api._next_profile_id("PLEX", _insts(8), _cfg()) == "PLEX-P09"
+    assert provider_api._next_profile_id("PLEX", _insts(9), _cfg()) == ""
+
+
+def test_next_profile_id_continues_past_ten_when_raised():
+    assert provider_api._next_profile_id("PLEX", _insts(9), _cfg(12)) == "PLEX-P10"
+    assert provider_api._next_profile_id("PLEX", _insts(11), _cfg(12)) == ""
+
+
+def test_ids_past_ten_are_rejected_by_default_but_valid_when_raised():
+    assert provider_api._canonical_profile_id("PLEX", "PLEX-P10", _cfg()) == ""
+    assert provider_api._canonical_profile_id("PLEX", "PLEX-P10", _cfg(12)) == "PLEX-P10"
+
+
+def test_two_digit_ids_keep_their_format():
+    assert provider_api._canonical_profile_id("PLEX", "PLEX-P11", _cfg(20)) == "PLEX-P11"
+    assert provider_api._next_profile_id("PLEX", _insts(10), _cfg(20)) == "PLEX-P11"
+
+
+def test_default_instance_and_junk_are_still_handled():
+    assert provider_api._canonical_profile_id("PLEX", "default", _cfg(20)) is None
+    assert provider_api._canonical_profile_id("PLEX", "PLEX-P00", _cfg(20)) == ""
+    assert provider_api._canonical_profile_id("PLEX", "nonsense", _cfg(20)) == ""
+
+
+def test_limit_resolves_from_config_when_not_passed(monkeypatch):
+    monkeypatch.setattr(provider_api, "load_config", lambda: _cfg(15))
+    assert provider_api._max_profiles_per_provider() == 15
+    assert provider_api._next_profile_id("PLEX", _insts(9)) == "PLEX-P10"

--- a/tests/test_provider_profile_limit_e2e.py
+++ b/tests/test_provider_profile_limit_e2e.py
@@ -1,0 +1,125 @@
+# tests/test_provider_profile_limit_e2e.py
+# CrossWatch - Configurable Profiles Per Provider End To End Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import api.providerInstancesAPI as provider_api
+from cw_platform.config_base import load_config
+
+
+def _write_cfg(base: Path, runtime: dict[str, Any] | None) -> None:
+    cfg: dict[str, Any] = {"plex": {"instances": {}}}
+    if runtime is not None:
+        cfg["runtime"] = runtime
+    (base / "config.json").write_text(json.dumps(cfg), "utf-8")
+
+
+def _req():
+    from tests.test_app_auth_api import _request
+
+    return _request("/api/provider-instances/PLEX/next", method="POST")
+
+
+def _create_until_blocked(max_attempts: int = 40) -> tuple[list[str], dict[str, Any]]:
+    created: list[str] = []
+    last: dict[str, Any] = {}
+    for _ in range(max_attempts):
+        res = provider_api.api_provider_instances_create_next("PLEX", {}, _req())
+        last = res if isinstance(res, dict) else {}
+        if not last.get("ok"):
+            break
+        created.append(str(last.get("id")))
+    return created, last
+
+
+def test_default_config_stops_at_ten_profiles(config_base: Path):
+    _write_cfg(config_base, None)
+
+    created, last = _create_until_blocked()
+
+    assert len(created) == 9
+    assert created[0] == "PLEX-P01"
+    assert created[-1] == "PLEX-P09"
+    assert last.get("error") == "profile_limit_reached"
+    assert last.get("limit") == 10
+
+    insts = (load_config().get("plex") or {}).get("instances") or {}
+    assert len(insts) == 9
+
+
+def test_raising_the_key_allows_more_profiles(config_base: Path):
+    _write_cfg(config_base, {"max_profiles_per_provider": 15})
+
+    created, last = _create_until_blocked()
+
+    assert len(created) == 14
+    assert created[-1] == "PLEX-P14"
+    assert last.get("error") == "profile_limit_reached"
+    assert last.get("limit") == 15
+
+    insts = (load_config().get("plex") or {}).get("instances") or {}
+    assert "PLEX-P10" in insts and "PLEX-P14" in insts
+
+
+def test_missing_runtime_block_behaves_like_the_default(config_base: Path):
+    _write_cfg(config_base, None)
+    assert load_config()["runtime"]["max_profiles_per_provider"] == 10
+
+    created, last = _create_until_blocked()
+
+    assert len(created) == 9
+    assert last.get("limit") == 10
+
+
+def test_explicit_null_falls_back_to_the_default(config_base: Path):
+    _write_cfg(config_base, {"max_profiles_per_provider": None})
+
+    created, last = _create_until_blocked()
+
+    assert len(created) == 9
+    assert last.get("limit") == 10
+
+
+def test_profiles_past_ten_survive_a_config_reload(config_base: Path):
+    _write_cfg(config_base, {"max_profiles_per_provider": 12})
+    created, _ = _create_until_blocked()
+    assert "PLEX-P11" in created
+
+    reloaded = (load_config().get("plex") or {}).get("instances") or {}
+    assert "PLEX-P11" in reloaded
+
+    canon = provider_api._canonical_profile_id("PLEX", "PLEX-P11", load_config())
+    assert canon == "PLEX-P11"
+
+
+def test_lowering_the_limit_keeps_existing_profiles_readable(config_base: Path):
+    _write_cfg(config_base, {"max_profiles_per_provider": 12})
+    created, _ = _create_until_blocked()
+    assert "PLEX-P11" in created
+
+    cfg = json.loads((config_base / "config.json").read_text("utf-8"))
+    cfg["runtime"]["max_profiles_per_provider"] = 10
+    (config_base / "config.json").write_text(json.dumps(cfg), "utf-8")
+
+    insts = (load_config().get("plex") or {}).get("instances") or {}
+    assert "PLEX-P11" in insts
+
+    _, last = _create_until_blocked(max_attempts=3)
+    assert last.get("error") == "profile_limit_reached"
+    assert last.get("limit") == 10
+
+
+@pytest.mark.parametrize("limit", [1, 2, 3])
+def test_small_limits_are_honoured(config_base: Path, limit: int):
+    _write_cfg(config_base, {"max_profiles_per_provider": limit})
+
+    created, last = _create_until_blocked()
+
+    assert len(created) == limit - 1
+    assert last.get("limit") == limit


### PR DESCRIPTION
# Pull request

## Change

New` runtime.max_profiles_per_provider `key, default 10 so nothing changes.
Total per provider incl default, clamped 1-100.

## Why

The cap was hardcoded at 9 generated profiles + 1 default = 10. No way to raise it.

## Testing

- tests/test_provider_profile_limit.py 
- tests/test_provider_profile_limit_e2e.py

## Issue

Relates to #1056