### PR TITLE
Fix: connection modal ignoring  profile limit

### DIFF
--- a/assets/helpers/providers-ui.js
+++ b/assets/helpers/providers-ui.js
@@ -1117,11 +1117,16 @@
 
   function refreshConnectionProfileCreateState(select, newBtn) {
     if (!select || !newBtn) return;
+    const raw = getCachedConfig()?.runtime?.max_profiles_per_provider;
+    const valid = typeof raw === "number" || typeof raw === "boolean"
+      || (typeof raw === "string" && /^[+-]?\d+$/.test(raw.trim()));
+    const parsed = valid ? Number(raw) : NaN;
+    const limit = Math.max(1, Math.min(100, Number.isFinite(parsed) ? Math.trunc(parsed) : 10));
     const count = Array.from(select.options || []).filter((option) => option.value).length;
-    const capped = count >= 10;
+    const capped = count >= limit;
     newBtn.disabled = capped;
     newBtn.setAttribute("aria-disabled", capped ? "true" : "false");
-    if (capped) newBtn.title = "Maximum 10 profiles reached.";
+    if (capped) newBtn.title = `Maximum ${limit} profiles reached.`;
     else newBtn.removeAttribute("title");
   }
 


### PR DESCRIPTION
# Pull request

## Change

- Use runtime.max_profiles_per_provider for the New profile button and its limit tooltip.

## Why

The modal still stopped at 10 profiles even when a higher limit was configured.

## Testing

- connection-profile-limit.test.mjs
- test_provider_profile_limit.py
- test_provider_profile_limit_e2e.py

## Issue

NA