### PR TITLE
Add: media servers scrobble sinks

### DIFF
--- a/providers/scrobble/_episode_ids.py
+++ b/providers/scrobble/_episode_ids.py
@@ -1,0 +1,19 @@
+# providers/scrobble/_episode_ids.py
+# CrossWatch - Episode Provider Identity
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+PUBLIC_IDS = ("tmdb", "imdb", "tvdb")
+
+
+def episode_ids(ids: Mapping[str, Any], show_ids: Mapping[str, Any] | None = None) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for namespace in PUBLIC_IDS:
+        value = ids.get(f"{namespace}_episode") or ids.get(namespace)
+        known_show_ids = (ids.get(f"{namespace}_show"), (show_ids or {}).get(namespace))
+        if value and str(value) not in {str(show_id) for show_id in known_show_ids if show_id}:
+            out[namespace] = str(value)
+    return out

--- a/providers/scrobble/_jellyfin_emby.py
+++ b/providers/scrobble/_jellyfin_emby.py
@@ -1,0 +1,190 @@
+# providers/scrobble/_jellyfin_emby.py
+# CrossWatch - Jellyfin and Emby Scrobble Delivery
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+from urllib.parse import quote
+
+from providers.scrobble._media_server import DeliveryError, MediaServerSink, PUBLIC_IDS, ids_match
+from providers.sync.jellyfin import _routes as jf_routes
+from providers.sync.jellyfin._common import _ids_from_provider_ids
+
+_FIELDS = "ProviderIds,ParentId"
+
+
+def _ids(row: dict) -> dict[str, str]:
+    return {key: str(value) for key, value in _ids_from_provider_ids(row.get("ProviderIds")).items()
+            if key in PUBLIC_IDS and value}
+
+
+class JellyfinEmbySink(MediaServerSink):
+    def _new_adapter(self, cfg: dict[str, Any]) -> Any:
+        module = import_module(f"providers.sync._mod_{self.name.upper()}")
+        cfg = {**cfg, "auth": {k: v for k, v in (cfg.get("auth") or {}).items() if k != self.name}}
+        return getattr(module, f"{self.name.upper()}Module")(cfg)
+
+    def _path(self, adapter: Any, item_id: str = "", operation: str = "items") -> tuple[str, dict]:
+        uid = str(adapter.cfg.user_id)
+        iid = quote(str(item_id), safe="")
+        if self.name == "jellyfin":
+            path = {"items": jf_routes.items, "played": jf_routes.played, "data": jf_routes.user_data}[operation](iid or None)
+            return path, jf_routes.user_params(uid)
+        suffix = {"items": f"/Items{('/' + iid) if iid else ''}", "played": f"/PlayedItems/{iid}", "data": f"/Items/{iid}/UserData"}[operation]
+        return f"/Users/{quote(uid, safe='')}{suffix}", {}
+
+    def _body(self, response: Any, *, read: bool = True) -> Any:
+        status = int(getattr(response, "status_code", 0) or 0)
+        if status not in (200, 204):
+            raise DeliveryError(f"{self.name}_http_{status}")
+        return response.json() if read and status != 204 else None
+
+    def _fetch(self, adapter: Any, iid: str) -> dict:
+        path, params = self._path(adapter, iid)
+        row = self._body(adapter.client.get(path, params={**params, "Fields": _FIELDS, "EnableUserData": True}))
+        if not isinstance(row, dict) or str(row.get("Id") or "") != str(iid):
+            raise DeliveryError("invalid_destination_item")
+        return row
+
+    def _query(self, adapter: Any, params: dict, *, catalog: bool = False) -> list[dict]:
+        path, user = self._path(adapter)
+        out = []
+        seen: set[str] = set()
+        limit = 500 if catalog else 100
+        for start in range(0, 100_000 if catalog else 100, limit):
+            body = self._body(adapter.client.get(path, params={**user, "Recursive": True,
+                "Fields": _FIELDS,
+                "EnableUserData": not catalog, "EnableImages": False,
+                **params, "StartIndex": start, "Limit": limit, "EnableTotalRecordCount": True}))
+            if not isinstance(body, dict) or not isinstance(body.get("Items"), list):
+                raise DeliveryError("invalid_destination_catalog")
+            rows = body["Items"]
+            total = int(body.get("TotalRecordCount") or 0)
+            if not catalog and (total > limit or (not total and len(rows) >= limit)):
+                return []
+            page_ids = {str(row["Id"]) for row in rows if isinstance(row, dict) and row.get("Id")}
+            if rows and not page_ids - seen:
+                raise DeliveryError("destination_catalog_pagination_failed")
+            seen.update(page_ids)
+            out.extend(row for row in rows if isinstance(row, dict) and row.get("Id"))
+            if not rows or (total and start + len(rows) >= total) or (not total and len(rows) < limit):
+                return out
+        if catalog:
+            raise DeliveryError("destination_catalog_limit")
+        return out
+
+    def _in_scope(self, adapter: Any, row: dict, allowed: set[str]) -> bool:
+        if not allowed:
+            return True
+        libraries = {str(row[k]) for k in ("LibraryId", "CollectionFolderId") if row.get(k)}
+        libraries.update(str(x) for x in row.get("AncestorIds") or [])
+        if libraries:
+            return bool(libraries & allowed)
+        ancestors = self._body(adapter.client.get(f"/Items/{quote(str(row['Id']), safe='')}/Ancestors",
+                                                  params={"userId": str(adapter.cfg.user_id)}))
+        if not isinstance(ancestors, list):
+            raise DeliveryError("invalid_destination_ancestors")
+        return any(str(x.get("Id")) in allowed for x in ancestors if isinstance(x, dict))
+
+    def _matches(self, adapter: Any, row: dict, item: dict, allowed: set[str]) -> bool:
+        if str(row.get("Type") or "").lower() != item["type"] or not self._in_scope(adapter, row, allowed):
+            return False
+        own, wanted = _ids(row), item.get("ids") or {}
+        if any(wanted[k] != own[k] for k in set(wanted) & set(own)):
+            return False
+        if ids_match(wanted, own):
+            return True
+        show_ids = item.get("show_ids") or {}
+        if (item["type"] != "episode" or not show_ids or item.get("season") is None or item.get("episode") is None
+                or row.get("ParentIndexNumber") != item["season"] or row.get("IndexNumber") != item["episode"] or not row.get("SeriesId")):
+            return False
+        return ids_match(show_ids, _ids(self._fetch(adapter, str(row["SeriesId"]))))
+
+    def _resolve(self, adapter: Any, item: dict, allowed: set[str]) -> dict:
+        candidates: dict[str, dict] = {}
+        groups = [(item.get("ids") or {}, "Episode" if item["type"] == "episode" else "Movie")]
+        if item["type"] == "episode":
+            groups.append((item.get("show_ids") or {}, "Series"))
+        if self.name == "emby":
+            for ids, kind in groups:
+                for key, value in ids.items():
+                    for row in self._query(adapter, {"IncludeItemTypes": kind, "AnyProviderIdEquals": f"{key}.{value}"}):
+                        candidates[str(row["Id"])] = row
+        title = item.get("series_title") or item.get("title")
+        if not candidates and title:
+            for row in self._query(adapter, {"IncludeItemTypes": "Series" if item["type"] == "episode" else "Movie", "SearchTerm": title}):
+                candidates[str(row["Id"])] = row
+
+        def matches(rows: list[dict]) -> dict[str, dict]:
+            result = {}
+            for row in rows:
+                if row.get("Type") == "Series":
+                    if not ids_match(item.get("show_ids") or {}, _ids(row)) or item.get("season") is None or item.get("episode") is None:
+                        continue
+                    episodes = self._query(adapter, {"ParentId": str(row["Id"]), "IncludeItemTypes": "Episode",
+                                                    "ParentIndexNumber": item["season"], "IndexNumber": item["episode"]})
+                    for episode in episodes:
+                        if self._matches(adapter, episode, item, allowed):
+                            result[str(episode["Id"])] = episode
+                elif self._matches(adapter, row, item, allowed):
+                    result[str(row["Id"])] = row
+            return result
+
+        found = matches(list(candidates.values()))
+        if not found:
+            rows = self._catalog("library", lambda: self._query(adapter, {"IncludeItemTypes": "Movie,Episode,Series"}, catalog=True))
+            shows = {str(r["Id"]) for r in rows if r.get("Type") == "Series" and ids_match(item.get("show_ids") or {}, _ids(r))}
+            catalog_candidates = [r for r in rows if ids_match(item.get("ids") or {}, _ids(r))
+                                  or (item["type"] == "episode" and r.get("Type") == "Episode"
+                                      and str(r.get("SeriesId")) in shows
+                                      and r.get("ParentIndexNumber") == item.get("season") and r.get("IndexNumber") == item.get("episode"))]
+            found = matches(catalog_candidates)
+        if len(found) != 1:
+            raise DeliveryError("ambiguous_ids" if found else f"unmatched_in_{self.name}")
+        row = self._fetch(adapter, next(iter(found)))
+        if not self._matches(adapter, row, item, allowed):
+            raise DeliveryError(f"unmatched_in_{self.name}")
+        return row
+
+    def _deliver(self, adapter: Any, item: dict[str, Any], complete: bool, progress: float) -> dict[str, Any]:
+        helpers = import_module(f"providers.sync.{self.name}._common")
+        scope = getattr(helpers, "jf_selected_library_ids" if self.name == "jellyfin" else "emby_selected_library_ids")
+        allowed = scope(adapter.cfg, "history" if complete else "progress")
+        row = self._cached_target(item, sorted(allowed), fetch=lambda iid: self._fetch(adapter, iid),
+                                 matches=lambda r: self._matches(adapter, r, item, allowed),
+                                 resolve=lambda: self._resolve(adapter, item, allowed), key_of=lambda r: r["Id"])
+        sessions = self._body(adapter.client.get("/Sessions"))
+        if not isinstance(sessions, list):
+            raise DeliveryError("invalid_destination_sessions")
+        if any(str(s.get("UserId") or "") == str(adapter.cfg.user_id)
+               and str((s.get("NowPlayingItem") or {}).get("Id") or "") == str(row["Id"]) for s in sessions if isinstance(s, dict)):
+            return {"ok": False, "retryable": True, "error": "active_destination_session"}
+        data = row.get("UserData")
+        if not isinstance(data, dict):
+            raise DeliveryError("missing_destination_user_data")
+        watched = bool(data.get("Played") or data.get("IsPlayed") or int(data.get("PlayCount") or 0) > 0)
+        if complete and not watched:
+            path, params = self._path(adapter, row["Id"], "played")
+            self._body(adapter.client.post(path, params=params), read=False)
+            data = self._fetch(adapter, row["Id"]).get("UserData") or {}
+        elif not complete and watched:
+            return {"ok": True, "skipped": True, "reason": "destination_already_watched"}
+        if complete:
+            ticks = 0
+        else:
+            duration = int(row.get("RunTimeTicks") or 0)
+            if duration <= 0:
+                raise DeliveryError("missing_destination_duration")
+            ticks = round(duration * progress / 100.0)
+            if ticks <= 0:
+                return {"ok": True, "skipped": True, "reason": "no_progress"}
+        if int(data.get("PlaybackPositionTicks") or 0) != ticks:
+            if self.name == "jellyfin" and not adapter.client.progress_write_supported()[0]:
+                raise DeliveryError("jellyfin_progress_write_unsupported")
+            payload = {"PlaybackPositionTicks": ticks}
+            if self.name == "emby":
+                payload = {**{k: data[k] for k in ("Played", "PlayCount", "IsFavorite", "LastPlayedDate", "Rating") if k in data}, **payload}
+            path, params = self._path(adapter, row["Id"], "data")
+            self._body(adapter.client.post(path, params=params, json=payload), read=False)
+        return {"ok": True}

--- a/providers/scrobble/_media_server.py
+++ b/providers/scrobble/_media_server.py
@@ -1,0 +1,215 @@
+# providers/scrobble/_media_server.py
+# CrossWatch - Media Server Scrobble Delivery
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Callable
+from typing import Any
+
+from cw_platform.event_archive.scrobble_recorder import record_watch
+from cw_platform.provider_instances import normalize_instance_id
+from providers.scrobble._auto_remove_watchlist import remove_across_providers_by_ids
+from providers.scrobble._episode_ids import PUBLIC_IDS, episode_ids
+from providers.scrobble._watched_gate import resolve_stop_action
+from providers.scrobble.routes import same_scrobble_endpoint, scrobble_sink_config
+from providers.scrobble.scrobble import ScrobbleEvent
+from services.activity import record_scrobble_event
+
+CACHE_TTL = 900
+CACHE_MAX = 1024
+
+
+def event_item(event: ScrobbleEvent) -> dict[str, Any]:
+    ids = {key: str(event.ids[key]) for key in PUBLIC_IDS if event.ids.get(key)}
+    show_ids = {key: str(event.ids[f"{key}_show"]) for key in PUBLIC_IDS if event.ids.get(f"{key}_show")}
+    if event.media_type == "episode":
+        return {"type": "episode", "ids": episode_ids(event.ids, show_ids), "show_ids": show_ids,
+                "series_title": event.title, "season": event.season, "episode": event.number}
+    return {"type": "movie", "ids": ids, "title": event.title, "year": event.year}
+
+
+def ids_match(wanted: dict, actual: dict) -> bool:
+    common = set(wanted) & set(actual) & set(PUBLIC_IDS)
+    return bool(common) and all(str(wanted[key]) == str(actual[key]) for key in common)
+
+
+def auto_remove(event: ScrobbleEvent, cfg: dict[str, Any], provider: str, instance: str) -> None:
+    sc = cfg.get("scrobble") or {}
+    mode = str(((sc.get("watch") or {}).get("route_options") or {}).get("auto_remove_watchlist") or "inherit").lower()
+    if mode == "off" or (mode != "on" and not sc.get("delete_plex")):
+        return
+    types = sc.get("delete_plex_types") or []
+    types = [types] if isinstance(types, str) else types
+    if event.media_type not in {str(t).lower().rstrip("s") for t in types}:
+        return
+    ids = event_item(event).get("ids") or {}
+    if ids:
+        remove_across_providers_by_ids(ids, event.media_type, scope=f"{provider}:{instance}")
+
+
+class DeliveryError(RuntimeError):
+    pass
+
+
+class MediaServerSink:
+    name = ""
+
+    def __init__(self, cfg_provider: Callable[[], dict[str, Any]] | None = None, instance_id: str | None = None) -> None:
+        self._cfg_provider = cfg_provider
+        self._instance_id = normalize_instance_id(instance_id)
+        self._lock = threading.RLock()
+        self._adapter: Any = None
+        self._identity = ""
+        self._connected_at = 0.0
+        self._resolved: OrderedDict[str, tuple[float, str]] = OrderedDict()
+        self._sent: OrderedDict[str, tuple[float, str, float]] = OrderedDict()
+        self._catalogs: OrderedDict[str, tuple[float, Any]] = OrderedDict()
+        self._misses: OrderedDict[str, tuple[float, str]] = OrderedDict()
+
+    def _new_adapter(self, cfg: dict[str, Any]) -> Any:
+        raise NotImplementedError
+
+    def _deliver(self, adapter: Any, item: dict[str, Any], complete: bool, progress: float) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def _delivery_context(self, adapter: Any) -> Any:
+        return None
+
+    def _connect(self, cfg: dict[str, Any]) -> Any:
+        identity = hashlib.sha256(json.dumps(cfg.get(self.name) or {}, sort_keys=True, default=str).encode()).hexdigest()
+        if self._adapter is None or identity != self._identity or time.monotonic() - self._connected_at >= CACHE_TTL:
+            old_adapter = self._adapter
+            self._adapter = None
+            if old_adapter is not None:
+                try:
+                    session = getattr(getattr(old_adapter, "client", None), "session", None)
+                    if session is not None:
+                        session.close()
+                except Exception:
+                    pass
+            self._resolved.clear()
+            if identity != self._identity:
+                self._sent.clear()
+                self._misses.clear()
+                self._catalogs.clear()
+            self._adapter = self._new_adapter(cfg)
+            self._adapter.instance_id = self._instance_id
+            self._identity = identity
+            self._connected_at = time.monotonic()
+        return self._adapter
+
+    def _catalog(self, scope: Any, load: Callable) -> Any:
+        key = json.dumps(scope, sort_keys=True)
+        cached = self._catalogs.get(key)
+        if cached and time.monotonic() - cached[0] < 21600:
+            self._catalogs.move_to_end(key)
+            return cached[1]
+        rows = load()
+        self._catalogs[key] = (time.monotonic(), rows)
+        if len(self._catalogs) > 8:
+            self._catalogs.popitem(last=False)
+        return rows
+
+    def _cached_target(self, item: dict, scope: Any, *, fetch: Callable, matches: Callable, resolve: Callable, key_of: Callable) -> Any:
+        key = json.dumps([item, scope], sort_keys=True)
+        now = time.monotonic()
+        miss = self._misses.get(key)
+        if miss and now - miss[0] < 300:
+            self._misses.move_to_end(key)
+            raise DeliveryError(miss[1])
+        self._misses.pop(key, None)
+        cached = self._resolved.get(key)
+        if cached and now - cached[0] < CACHE_TTL:
+            try:
+                row = fetch(cached[1])
+                if matches(row):
+                    return row
+            except Exception:
+                pass
+            self._resolved.pop(key, None)
+        try:
+            row = resolve()
+        except DeliveryError as exc:
+            if str(exc).startswith("unmatched_in_") or str(exc) == "ambiguous_ids":
+                self._misses[key] = (now, str(exc))
+                if len(self._misses) > CACHE_MAX:
+                    self._misses.popitem(last=False)
+            raise
+        self._resolved[key] = (now, str(key_of(row)))
+        if len(self._resolved) > CACHE_MAX:
+            self._resolved.popitem(last=False)
+        return row
+
+    def send(self, event: ScrobbleEvent, cfg: dict[str, Any] | None = None) -> dict[str, Any]:
+        cfg = cfg if isinstance(cfg, dict) else (self._cfg_provider() if self._cfg_provider else {})
+        watch = ((cfg.get("scrobble") or {}).get("watch") or {})
+        source = str(watch.get("route_provider") or "").lower()
+        source_instance = normalize_instance_id(watch.get("route_provider_instance"))
+        if same_scrobble_endpoint(source, source_instance, self.name, self._instance_id):
+            return {"ok": False, "skipped": True, "error": "same_source_destination"}
+        try:
+            progress = float(event.progress)
+            if event.action not in {"start", "pause", "stop"} or event.media_type not in {"movie", "episode"} or not math.isfinite(progress):
+                raise ValueError
+        except (ValueError, TypeError):
+            return {"ok": False, "skipped": True, "error": "invalid_event"}
+        item = event_item(event)
+        if not item.get("ids") and not item.get("show_ids"):
+            return {"ok": False, "skipped": True, "error": "missing_external_ids"}
+        from providers.webhooks.config import sink_configured
+        if not sink_configured(cfg, self.name, self._instance_id):
+            return {"ok": False, "skipped": True, "error": "not_configured"}
+        view = scrobble_sink_config(cfg, self.name, self._instance_id)
+        policy = ((watch.get("route_options") or {}).get("scrobble") or {})
+        defaults = ((cfg.get("scrobble") or {}).get("trakt") or {})
+        threshold = float(policy.get("watched_at", defaults.get("watched_at", 90)))
+        step = float(policy.get("progress_step", defaults.get("progress_step", 25)))
+        progress = max(0.0, min(100.0, progress))
+        action = resolve_stop_action(progress, threshold) if event.action == "stop" else event.action
+        complete = action == "stop"
+        session = json.dumps([source, source_instance, event.server_uuid, event.account, event.session_key, item], sort_keys=True)
+        record = {"source_provider": source, "source_instance": source_instance,
+                  "destination_provider": self.name, "destination_instance": self._instance_id,
+                  "action": action, "progress": progress}
+        with self._lock:
+            try:
+                adapter = self._connect(view)
+                session = json.dumps([session, self._delivery_context(adapter)])
+                now = time.monotonic()
+                sent = self._sent.get(session)
+                if sent and now - sent[0] < CACHE_TTL:
+                    if sent[1] == "complete" or (event.action == "start" and sent[1] == "start" and abs(progress - sent[2]) < step):
+                        return {"ok": True, "skipped": True, "reason": "duplicate"}
+                result = self._deliver(adapter, item, complete, progress)
+                if not result.get("ok") or result.get("skipped"):
+                    return result
+                self._sent[session] = (now, "complete" if complete else event.action, progress)
+                self._sent.move_to_end(session)
+                if len(self._sent) > CACHE_MAX:
+                    self._sent.popitem(last=False)
+            except Exception as exc:
+                reason = str(exc) if isinstance(exc, DeliveryError) else f"{self.name}_scrobble_failed"
+                record_watch(event, **record, status="fail", reason=reason)
+                retryable = not (reason.startswith("unmatched_in_") or reason in {
+                    "ambiguous_ids", "missing_destination_duration", "jellyfin_progress_write_unsupported",
+                    "home_scope_not_applied",
+                } or reason.endswith(("_http_400", "_http_401", "_http_403")))
+                return {"ok": False, "error": reason, "retryable": retryable}
+            record_watch(event, **record)
+            if complete:
+                try:
+                    record_scrobble_event(event, source=source, source_instance=source_instance,
+                                          target=self.name, target_instance=self._instance_id, progress=progress)
+                except Exception:
+                    pass
+                try:
+                    auto_remove(event, cfg, self.name, self._instance_id)
+                except Exception:
+                    pass
+            return result

--- a/providers/scrobble/crosswatch/sink.py
+++ b/providers/scrobble/crosswatch/sink.py
@@ -8,7 +8,9 @@ import time
 from collections.abc import Callable, Mapping
 from typing import Any
 
+from cw_platform.id_map import canonical_key
 from cw_platform.provider_instances import build_provider_config_view, normalize_instance_id
+from providers.scrobble._episode_ids import episode_ids
 from providers.scrobble.scrobble import ScrobbleEvent, ScrobbleSink, mask_account
 from providers.sync._mod_CROSSWATCH import OPS as CROSSWATCH_OPS
 from services.activity import record_scrobble_event
@@ -213,6 +215,8 @@ def _item_from_event(ev: ScrobbleEvent, cfg: Mapping[str, Any], progress: float)
         series_title = str(detail.get("title") or ev.title or "").strip()
         if not show_ids and series_title:
             show_ids = {"slug": _slug(series_title)}
+        if canonical_key({"type": "show", "ids": show_ids}) == "unknown:":
+            return None
         item = {
             "type": "episode",
             "title": f"S{season:02d}E{episode:02d}",
@@ -220,7 +224,7 @@ def _item_from_event(ev: ScrobbleEvent, cfg: Mapping[str, Any], progress: float)
             "year": detail.get("year") or ev.year,
             "season": season,
             "episode": episode,
-            "ids": {},
+            "ids": episode_ids(ev.ids or {}, show_ids),
             "show_ids": show_ids,
             "progress_percent": round(progress, 3),
             "progress_at": now,

--- a/providers/scrobble/emby/sink.py
+++ b/providers/scrobble/emby/sink.py
@@ -1,0 +1,8 @@
+# providers/scrobble/emby/sink.py
+# CrossWatch - Emby Scrobble Sink
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from providers.scrobble._jellyfin_emby import JellyfinEmbySink
+
+
+class EmbySink(JellyfinEmbySink):
+    name = "emby"

--- a/providers/scrobble/jellyfin/sink.py
+++ b/providers/scrobble/jellyfin/sink.py
@@ -1,0 +1,8 @@
+# providers/scrobble/jellyfin/sink.py
+# CrossWatch - Jellyfin Scrobble Sink
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from providers.scrobble._jellyfin_emby import JellyfinEmbySink
+
+
+class JellyfinSink(JellyfinEmbySink):
+    name = "jellyfin"

--- a/providers/scrobble/kodi/sink.py
+++ b/providers/scrobble/kodi/sink.py
@@ -1,0 +1,154 @@
+# providers/scrobble/kodi/sink.py
+# CrossWatch - Kodi Scrobble Sink
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from typing import Any
+
+from providers.scrobble._media_server import DeliveryError, MediaServerSink, ids_match
+from providers.sync.kodi._common import normalize_uniqueids, path_allowed, watched_at_to_kodi
+
+_PROPS = {
+    "movie": ["title", "uniqueid", "file", "playcount", "resume", "runtime"],
+    "episode": ["title", "uniqueid", "file", "playcount", "resume", "runtime", "tvshowid", "season", "episode"],
+    "show": ["title", "uniqueid"],
+}
+_METHOD = {"movie": "Movie", "episode": "Episode", "show": "TVShow"}
+_ID = {"movie": "movieid", "episode": "episodeid", "show": "tvshowid"}
+
+
+def _ids(row: dict) -> dict:
+    return normalize_uniqueids(row.get("uniqueid") or {})
+
+
+def _key(row: dict) -> str:
+    return f"{row['_kind']}:{row[_ID[row['_kind']]]}"
+
+
+class KodiSink(MediaServerSink):
+    name = "kodi"
+
+    def _new_adapter(self, cfg: dict[str, Any]) -> Any:
+        from providers.sync._mod_KODI import KODIModule
+        return KODIModule(cfg)
+
+    def _fetch(self, adapter: Any, key: str) -> dict:
+        kind, iid = key.split(":", 1)
+        method = _METHOD[kind]
+        body = adapter.client.rpc(f"VideoLibrary.Get{method}Details", {_ID[kind]: int(iid), "properties": _PROPS[kind]})
+        row = (body or {}).get(f"{method.lower()}details")
+        if not isinstance(row, dict) or int(row.get(_ID[kind], -1)) != int(iid):
+            raise DeliveryError("invalid_destination_item")
+        return {**row, "_kind": kind}
+
+    def _query(self, adapter: Any, kind: str, params: dict, *, catalog: bool = False) -> list[dict]:
+        method = _METHOD[kind]
+        out = []
+        seen: set[str] = set()
+        limit = 500 if catalog else 100
+        properties = [p for p in _PROPS[kind] if p not in {"title", "runtime", "resume", "playcount"}] if catalog else _PROPS[kind]
+        for start in range(0, 100_000 if catalog else 100, limit):
+            body = adapter.client.rpc(f"VideoLibrary.Get{method}s", {"properties": properties, **params,
+                                       "limits": {"start": start, "end": start + limit}})
+            if not isinstance(body, dict):
+                raise DeliveryError("invalid_destination_catalog")
+            rows = body.get(f"{method.lower()}s") or []
+            total = int((body.get("limits") or {}).get("total") or 0)
+            if not catalog and (total > limit or (not total and len(rows) >= limit)):
+                return []
+            page_ids = {str(row[_ID[kind]]) for row in rows if isinstance(row, dict) and _ID[kind] in row}
+            if rows and not page_ids - seen:
+                raise DeliveryError("destination_catalog_pagination_failed")
+            seen.update(page_ids)
+            out.extend({**row, "_kind": kind} for row in rows if isinstance(row, dict) and _ID[kind] in row)
+            if not rows or (total and start + len(rows) >= total) or (not total and len(rows) < limit):
+                return out
+        if catalog:
+            raise DeliveryError("destination_catalog_limit")
+        return out
+
+    def _matches(self, adapter: Any, row: dict, item: dict, feature: str) -> bool:
+        if row.get("_kind") != item["type"] or not path_allowed(adapter.config, feature, row.get("file"), self._instance_id):
+            return False
+        own, wanted = _ids(row), item.get("ids") or {}
+        if any(wanted[k] != own[k] for k in set(wanted) & set(own)):
+            return False
+        if ids_match(wanted, own):
+            return True
+        if (item["type"] != "episode" or not item.get("show_ids") or item.get("season") is None or item.get("episode") is None
+                or row.get("season") != item["season"] or row.get("episode") != item["episode"] or row.get("tvshowid") is None):
+            return False
+        return ids_match(item["show_ids"], _ids(self._fetch(adapter, f"show:{row['tvshowid']}")))
+
+    def _resolve(self, adapter: Any, item: dict, feature: str, profile: str) -> dict:
+        candidates = []
+        title = item.get("series_title") or item.get("title")
+        if title:
+            if item["type"] == "movie":
+                candidates = self._query(adapter, "movie", {"filter": {"field": "title", "operator": "is", "value": title}})
+            elif item.get("season") is not None:
+                shows = self._query(adapter, "show", {"filter": {"field": "title", "operator": "is", "value": title}})
+                for show in shows:
+                    if ids_match(item.get("show_ids") or {}, _ids(show)):
+                        candidates.extend(self._query(adapter, "episode", {"tvshowid": show["tvshowid"], "season": item["season"]}))
+        found = {_key(r): r for r in candidates if self._matches(adapter, r, item, feature)}
+        if not found:
+            rows = self._catalog(profile, lambda: [r for kind in ("movie", "show", "episode") for r in self._query(adapter, kind, {}, catalog=True)])
+            shows = {r["tvshowid"] for r in rows if r["_kind"] == "show" and ids_match(item.get("show_ids") or {}, _ids(r))}
+            candidates = [r for r in rows if r["_kind"] == item["type"] and (ids_match(item.get("ids") or {}, _ids(r))
+                          or (item["type"] == "episode" and r.get("tvshowid") in shows
+                              and r.get("season") == item.get("season") and r.get("episode") == item.get("episode")))]
+            found = {_key(r): r for r in candidates if self._matches(adapter, r, item, feature)}
+        if len(found) != 1:
+            raise DeliveryError("ambiguous_ids" if found else "unmatched_in_kodi")
+        row = self._fetch(adapter, next(iter(found)))
+        if not self._matches(adapter, row, item, feature):
+            raise DeliveryError("unmatched_in_kodi")
+        return row
+
+    def _profile(self, adapter: Any) -> str:
+        body = adapter.client.rpc("Profiles.GetCurrentProfile")
+        profile = (body or {}).get("profile") or {}
+        if not isinstance(profile, dict) or not profile.get("label"):
+            raise DeliveryError("unknown_destination_profile")
+        return str(profile["label"])
+
+    def _delivery_context(self, adapter: Any) -> str:
+        adapter._cw_sink_profile = self._profile(adapter)
+        return adapter._cw_sink_profile
+
+    def _deliver(self, adapter: Any, item: dict[str, Any], complete: bool, progress: float) -> dict[str, Any]:
+        profile = adapter._cw_sink_profile
+        feature = "history" if complete else "progress"
+        row = self._cached_target(item, [feature, profile], fetch=lambda key: self._fetch(adapter, key),
+                                 matches=lambda r: self._matches(adapter, r, item, feature),
+                                 resolve=lambda: self._resolve(adapter, item, feature, profile), key_of=_key)
+        players = adapter.client.rpc("Player.GetActivePlayers")
+        if not isinstance(players, list):
+            raise DeliveryError("invalid_destination_sessions")
+        for player in players:
+            if player.get("type") != "video":
+                continue
+            playing = (adapter.client.rpc("Player.GetItem", {"playerid": player["playerid"]}) or {}).get("item") or {}
+            if playing.get("id") is not None and playing.get("type") == row["_kind"] and int(playing["id"]) == int(row[_ID[row["_kind"]]]):
+                return {"ok": False, "retryable": True, "error": "active_destination_session"}
+        watched = int(row.get("playcount") or 0) > 0
+        total = float((row.get("resume") or {}).get("total") or row.get("runtime") or 0)
+        if complete:
+            payload: dict[str, Any] = {"resume": {"position": 0.0, "total": max(0.0, total)}}
+            if not watched:
+                payload.update(playcount=1, lastplayed=watched_at_to_kodi(None))
+        else:
+            if watched:
+                return {"ok": True, "skipped": True, "reason": "destination_already_watched"}
+            if total <= 0:
+                raise DeliveryError("missing_destination_duration")
+            if progress <= 0:
+                return {"ok": True, "skipped": True, "reason": "no_progress"}
+            payload = {"resume": {"position": total * progress / 100.0, "total": total}}
+        if self._profile(adapter) != profile:
+            raise DeliveryError("destination_profile_changed")
+        method = adapter.client.set_movie if item["type"] == "movie" else adapter.client.set_episode
+        if method(int(row[_ID[row["_kind"]]]), payload) != "OK":
+            raise DeliveryError("kodi_write_not_acknowledged")
+        return {"ok": True}

--- a/providers/scrobble/plex/sink.py
+++ b/providers/scrobble/plex/sink.py
@@ -1,0 +1,147 @@
+# providers/scrobble/plex/sink.py
+# CrossWatch - Plex Scrobble Sink
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+from urllib.parse import urlencode
+
+from providers.scrobble._media_server import DeliveryError, MediaServerSink, PUBLIC_IDS as _PUBLIC_IDS, ids_match as _id_match
+from providers.scrobble.scrobble import ScrobbleEvent
+from providers.sync.plex._common import configure_plex_context, home_scope_enter, home_scope_exit, ids_from_obj, isolated_plex_context, plex_feature_library_ids
+from providers.sync.plex._progress import _currently_playing, _timeline_progress
+
+
+def _object_ids(obj: Any) -> dict[str, str]:
+    result = ids_from_obj(obj)
+    return {key: str(result[key]) for key in _PUBLIC_IDS if result.get(key)}
+
+
+def _matches(server: Any, obj: Any, item: Mapping[str, Any], allowed: set[str]) -> bool:
+    if str(getattr(obj, "type", "")) != item["type"]:
+        return False
+    if allowed and str(getattr(obj, "librarySectionID", "")) not in allowed:
+        return False
+    own = _object_ids(obj)
+    wanted = item.get("ids") or {}
+    if any(str(wanted[k]) != str(own[k]) for k in set(wanted) & set(own)):
+        return False
+    if item["type"] == "movie":
+        return _id_match(wanted, own)
+    if _id_match(wanted, own):
+        return True
+    show_ids = item.get("show_ids") or {}
+    if not show_ids or item.get("season") is None or item.get("episode") is None:
+        return False
+    if getattr(obj, "parentIndex", None) != item["season"] or getattr(obj, "index", None) != item["episode"]:
+        return False
+    parent = getattr(obj, "grandparentRatingKey", None)
+    return bool(parent and _id_match(show_ids, _object_ids(server.fetchItem(int(parent)))))
+
+
+def _resolve(adapter: Any, item: Mapping[str, Any], allowed: set[str]) -> Any:
+    server = adapter.client.server
+    candidates: dict[str, Any] = {}
+    groups = [(item.get("ids") or {}, 4 if item["type"] == "episode" else 1)]
+    if item["type"] == "episode":
+        groups.append((item.get("show_ids") or {}, 2))
+    for ids, plex_type in groups:
+        for key, value in ids.items():
+            query = urlencode({"guid": f"{key}://{value}", "type": plex_type,
+                               "X-Plex-Container-Start": 0, "X-Plex-Container-Size": 100})
+            root = server.query(f"/library/all?{query}")
+            if root is not None and int(root.attrib.get("totalSize") or root.attrib.get("size") or 0) > 100:
+                raise DeliveryError("ambiguous_ids")
+            for row in root.iter() if root is not None else []:
+                rk = row.attrib.get("ratingKey")
+                if rk:
+                    candidates[str(rk)] = server.fetchItem(int(rk))
+    if not candidates:
+        title = item.get("series_title") or item.get("title")
+        if title:
+            for obj in server.search(title, mediatype="show" if item["type"] == "episode" else "movie") or []:
+                candidates[str(obj.ratingKey)] = obj
+    matches: dict[str, Any] = {}
+    for obj in candidates.values():
+        if str(getattr(obj, "type", "")) == "show":
+            if (item.get("season") is None or item.get("episode") is None
+                    or not _id_match(item.get("show_ids") or {}, _object_ids(obj))):
+                continue
+            for episode in obj.episodes(parentIndex=item["season"], index=item["episode"]) or []:
+                episode = server.fetchItem(int(episode.ratingKey))
+                if _matches(server, episode, item, allowed):
+                    matches[str(episode.ratingKey)] = episode
+            continue
+        if _matches(server, obj, item, allowed):
+            matches[str(obj.ratingKey)] = obj
+    if len(matches) != 1:
+        raise DeliveryError("ambiguous_ids" if matches else "unmatched_in_plex")
+    return next(iter(matches.values()))
+
+
+class PlexSink(MediaServerSink):
+    name = "plex"
+
+    def send(self, event: ScrobbleEvent, cfg: dict[str, Any] | None = None) -> dict[str, Any]:
+        with isolated_plex_context():
+            return super().send(event, cfg)
+
+    def _connect(self, cfg: dict[str, Any]) -> Any:
+        adapter = super()._connect(cfg)
+        cli = adapter.client
+        server = cli.server
+        configure_plex_context(
+            baseurl=getattr(server, "_baseurl", None) or getattr(adapter.cfg, "baseurl", None),
+            token=getattr(server, "_token", None) or getattr(adapter.cfg, "pms_token", None) or getattr(adapter.cfg, "token", None),
+            account_token=getattr(cli, "cloud_token", None) or getattr(adapter.cfg, "token", None) or "",
+        )
+        return adapter
+
+    def _new_adapter(self, cfg: dict[str, Any]) -> Any:
+        from providers.sync._mod_PLEX import PLEXModule
+        with isolated_plex_context():
+            return PLEXModule(cfg)
+
+    def _deliver(self, adapter: Any, item: dict[str, Any], complete: bool, progress: float) -> dict[str, Any]:
+        switched = False
+        try:
+            server = adapter.client.server
+            if server is None:
+                raise DeliveryError("plex_server_unavailable")
+            needed, switched, account_id, username = home_scope_enter(adapter)
+            if needed and not switched:
+                raise DeliveryError("home_scope_not_applied")
+            if account_id is None and not username:
+                account_id = getattr(adapter.client, "user_account_id", None) or getattr(adapter.client, "token_account_id", None)
+                username = getattr(adapter.client, "user_username", None) or getattr(adapter.client, "token_username", None)
+            allowed = plex_feature_library_ids(adapter, "history" if complete else "progress")
+            obj = self._cached_target(
+                item, sorted(allowed), fetch=lambda rk: server.fetchItem(int(rk)),
+                matches=lambda row: _matches(server, row, item, allowed),
+                resolve=lambda: _resolve(adapter, item, allowed), key_of=lambda row: row.ratingKey,
+            )
+            rk = str(obj.ratingKey)
+            if _currently_playing(server, rk, account_id=account_id, username=username, fail_on_error=True):
+                return {"ok": False, "retryable": True, "error": "active_destination_session"}
+            watched = bool(getattr(obj, "viewCount", 0))
+            if complete:
+                if not watched:
+                    server.query("/:/scrobble", method=server._session.put,
+                                 params={"key": rk, "identifier": "com.plexapp.plugins.library"})
+                if int(getattr(obj, "viewOffset", 0) or 0) > 0:
+                    _timeline_progress(adapter, server, rk, 0, int(getattr(obj, "duration", 0) or 0))
+            else:
+                if watched:
+                    return {"ok": True, "skipped": True, "reason": "destination_already_watched"}
+                duration = int(getattr(obj, "duration", 0) or 0)
+                if duration <= 0:
+                    raise DeliveryError("missing_destination_duration")
+                position = round(duration * progress / 100.0)
+                if position <= 0:
+                    return {"ok": True, "skipped": True, "reason": "no_progress"}
+                if abs(position - int(getattr(obj, "viewOffset", 0) or 0)) >= 1000:
+                    _timeline_progress(adapter, server, rk, position, duration)
+            return {"ok": True}
+        finally:
+            home_scope_exit(adapter, switched)

--- a/providers/scrobble/routes.py
+++ b/providers/scrobble/routes.py
@@ -9,7 +9,7 @@ from cw_platform.provider_instances import get_provider_block, normalize_instanc
 
 DEFAULT_INSTANCE_ID = "default"
 ROUTE_PROVIDERS = {"plex", "emby", "jellyfin", "kodi", "scrob"}
-ROUTE_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "bingebase", "flicklist", "scrob"}
+ROUTE_SINKS = {"plex", "jellyfin", "emby", "kodi", "trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "bingebase", "flicklist", "scrob"}
 ROUTE_RATING_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "flicklist", "scrob"}
 ROUTE_OPTION_STATES = {"inherit", "on", "off"}
 ROUTE_RATINGS_MODES = {"off", "custom"}
@@ -24,6 +24,33 @@ ROUTE_WATCH_POLICY_RANGES = {
     "suppress_start_at": (0, 100),
 }
 ROUTE_WATCH_BOOLEAN_KEYS = {"unresolved_user_fallback", "anime_mapping"}
+
+
+def same_scrobble_endpoint(provider: Any, provider_instance: Any, sink: Any, sink_instance: Any) -> bool:
+    source = str(provider or "").strip().lower()
+    return bool(source) and source == str(sink or "").strip().lower() and normalize_instance_id(provider_instance) == normalize_instance_id(sink_instance)
+
+
+def route_is_self_target(route: dict[str, Any]) -> bool:
+    return same_scrobble_endpoint(route.get("provider"), route.get("provider_instance"), route.get("sink"), route.get("sink_instance"))
+
+
+def scrobble_sink_config(cfg: dict[str, Any], provider: str, instance: Any) -> dict[str, Any]:
+    inst = normalize_instance_id(instance)
+    captured = cfg.get("_cw_scrobble_sink") or {}
+    if captured.get("provider") == provider and captured.get("instance") == inst:
+        block = _deep_clone(captured.get("config") or {})
+    else:
+        original = cfg.get("_cw_scrobble_provider_configs") or {}
+        base = {**cfg, **original}
+        block = _deep_clone(get_provider_block(base, provider, inst))
+    block.pop("instances", None)
+    if inst == "default" and provider in {"jellyfin", "emby"}:
+        auth = (cfg.get("auth") or {}).get(provider) or {}
+        for field in ("server", "access_token", "user_id"):
+            if field not in block and auth.get(field) is not None:
+                block[field] = _deep_clone(auth[field])
+    return {**cfg, provider: block}
 
 
 def _deep_clone(v: Any) -> Any:
@@ -256,10 +283,16 @@ def build_route_cfg(cfg: dict[str, Any], route: dict[str, Any]) -> dict[str, Any
     out: dict[str, Any] = _deep_clone(cfg) if isinstance(cfg, dict) else {}
     w = _watch_cfg(out)
 
+    if r["sink"]:
+        out["_cw_scrobble_sink"] = {
+            "provider": r["sink"], "instance": r["sink_instance"],
+            "config": _deep_clone(scrobble_sink_config(cfg, r["sink"], r["sink_instance"])[r["sink"]]),
+        }
+
     if r["provider"]:
         out[r["provider"]] = _provider_view(out, r["provider"], r["provider_instance"])
-    if r["sink"]:
-        out[r["sink"]] = _provider_view(out, r["sink"], r["sink_instance"])
+    if r["sink"] and r["sink"] != r["provider"]:
+        out[r["sink"]] = _provider_view(cfg, r["sink"], r["sink_instance"])
     ratings = (r.get("options") or {}).get("ratings")
     rating_targets = ratings.get("targets") if isinstance(ratings, dict) else []
     for target in rating_targets if isinstance(rating_targets, list) else []:

--- a/providers/scrobble/scrob/sink.py
+++ b/providers/scrobble/scrob/sink.py
@@ -24,6 +24,7 @@ except Exception:
 
 from providers.scrobble._auto_remove_watchlist import remove_across_providers_by_ids as _rm_across
 from providers.scrobble._watched_gate import resolve_stop_action
+from providers.scrobble.routes import scrobble_sink_config
 
 try:
     from providers.scrobble.scrobble import ScrobbleEvent, ScrobbleSink, mask_account  # type: ignore
@@ -197,6 +198,8 @@ class ScrobSink(ScrobbleSink):
             try:
                 cfg = self._cfg_provider()
                 if isinstance(cfg, Mapping):
+                    if (cfg.get("_cw_scrobble_sink") or {}).get("provider") == "scrob":
+                        return scrobble_sink_config(dict(cfg), "scrob", self.instance_id)
                     return dict(cfg)
             except Exception:
                 pass

--- a/providers/scrobble/scrobble.py
+++ b/providers/scrobble/scrobble.py
@@ -7,6 +7,9 @@ import json
 import inspect
 import re
 import time
+import threading
+import hashlib
+from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Literal, Protocol
@@ -362,8 +365,14 @@ class Dispatcher:
         self._last_progress: dict[str, float] = {}
         self._sink_accepts_cfg: dict[int, bool] = {}
         self._route_log_ts: dict[str, float] = {}
+        self._retry_after: dict[str, tuple[float, int]] = {}
+        self._dispatch_lock = threading.RLock()
+        self._pending: OrderedDict[str, tuple[float, ScrobbleEvent]] = OrderedDict()
+        self._config_identity = ""
+        self._inflight: set[int] = set()
+        self._failed_ids: OrderedDict[str, dict[str, str]] = OrderedDict()
 
-    def _send_sink(self, sink: Any, ev: ScrobbleEvent, cfg: dict[str, Any]) -> None:
+    def _send_sink(self, sink: Any, ev: ScrobbleEvent, cfg: dict[str, Any]) -> Any:
         sid = id(sink)
         ok = self._sink_accepts_cfg.get(sid)
         if ok is None:
@@ -376,12 +385,11 @@ class Dispatcher:
                 ok = False
             self._sink_accepts_cfg[sid] = ok
         if not ok:
-            sink.send(ev)
-            return
+            return sink.send(ev)
         try:
-            sink.send(ev, cfg=cfg)
+            return sink.send(ev, cfg=cfg)
         except TypeError:
-            sink.send(ev, cfg)
+            return sink.send(ev, cfg)
 
     def _route_label(self, cfg: dict[str, Any]) -> str:
         try:
@@ -588,8 +596,7 @@ class Dispatcher:
             return False
         return True
 
-    def _should_send(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> bool:
-        sk = ev.session_key or "?"
+    def _should_send(self, ev: ScrobbleEvent, cfg: dict[str, Any], sk: str) -> bool:
         last_a = self._last_action.get(sk)
         last_p = self._last_progress.get(sk, -1)
         try:
@@ -601,7 +608,7 @@ class Dispatcher:
         if ev.action == "start" and last_p is not None and last_p >= sup and ev.progress >= sup:
             return False
 
-        changed = (ev.action != last_a) or (abs(ev.progress - (last_p or -1)) >= 1)
+        changed = (ev.action != last_a) or (abs(ev.progress - last_p) >= 1)
 
         if ev.action == "pause":
             now = time.time()
@@ -622,27 +629,195 @@ class Dispatcher:
         return self._passes_filters(ev, cfg)
 
     def dispatch(self, ev: ScrobbleEvent) -> bool:
+        return self._dispatch(ev)
+
+    def retry_pending(self, cancelled: threading.Event | None = None) -> None:
+        due: list[tuple[str, ScrobbleEvent]] = []
+        with self._dispatch_lock:
+            now = time.monotonic()
+            config_identity = self._config_identity
+            for sk, (created, ev) in list(self._pending.items()):
+                if cancelled is not None and cancelled.is_set():
+                    return
+                if now - created >= 3600:
+                    self._pending.pop(sk, None)
+                    self._retry_after.pop(sk, None)
+                    continue
+                if now >= self._retry_after.get(sk, (0.0, 0))[0]:
+                    due.append((sk, ev))
+        if not due or (cancelled is not None and cancelled.is_set()):
+            return
         cfg = self._cfg_provider() or {}
-        ev = self._route_event(ev, cfg)
-        if not self._passes_filters(ev, cfg):
-            return False
-        if not self._should_send(ev, cfg):
-            return False
+        started = time.monotonic()
+        for sk, ev in due[:4]:
+            if cancelled is not None and cancelled.is_set():
+                return
+            self._dispatch(ev, retry_key=sk, cfg=cfg, config_identity=config_identity)
+            if time.monotonic() - started >= 1.0:
+                break
+
+    def _queue_pending(self, sk: str, ev: ScrobbleEvent) -> None:
+        now = time.monotonic()
+        self._pending[sk] = (self._pending.get(sk, (now, ev))[0], ev)
+        self._pending.move_to_end(sk)
+        if len(self._pending) > 1024:
+            expired, _ = self._pending.popitem(last=False)
+            self._retry_after.pop(expired, None)
+
+    def _failed_sink(self, sk: str, ev: ScrobbleEvent) -> None:
+        retry = self._retry_after.get(sk)
+        attempts = min(5, (retry[1] if retry else 0) + 1)
+        now = time.monotonic()
+        self._retry_after[sk] = (now + min(300, 30 * 2 ** (attempts - 1)), attempts)
+        self._last_action.pop(sk, None)
+        self._last_progress.pop(sk, None)
+        self._queue_pending(sk, ev)
+
+    def _delivery_identity(self, cfg: dict[str, Any]) -> str:
+        from providers.scrobble.routes import scrobble_sink_config
+
+        scrobble = cfg.get("scrobble") or {}
+        watch = scrobble.get("watch") or {}
+        sink = str(watch.get("route_sink") or "").strip().lower()
+        block = scrobble_sink_config(cfg, sink, watch.get("route_sink_instance"))[sink] if sink else {}
+        relevant = {"watch": {k: v for k, v in watch.items() if k != "routes"},
+                    "sink": block, "policy": scrobble.get("trakt"), "anime_mapping": cfg.get("anime_mapping")}
+        return hashlib.sha256(json.dumps(relevant, sort_keys=True, default=str).encode()).hexdigest()
+
+    def _session_key(self, sink: Any, ev: ScrobbleEvent) -> str:
+        identity: Any = ev.session_key
+        raw = ev.raw if isinstance(ev.raw, dict) else {}
+        playing = raw.get("NowPlayingItem")
+        item_id = playing.get("Id") if isinstance(playing, dict) else None
+        if not identity:
+            identity = [ev.title, ev.year, ev.ids]
+        return json.dumps([id(sink), ev.server_uuid, ev.account, identity, item_id, ev.media_type, ev.season, ev.number], sort_keys=True)
+
+    def _dispatch(self, ev: ScrobbleEvent, *, retry_key: str | None = None, cfg: dict[str, Any] | None = None,
+                  config_identity: str | None = None) -> bool:
+        from providers.scrobble.routes import same_scrobble_endpoint
+        with self._dispatch_lock:
+            if config_identity is not None and config_identity != self._config_identity:
+                return False
+            cfg = cfg if cfg is not None else (self._cfg_provider() or {})
+            identity = self._delivery_identity(cfg)
+            watch = ((cfg.get("scrobble") or {}).get("watch") or {})
+            if identity != self._config_identity:
+                if self._pending:
+                    _log(f"route {self._route_label(cfg)}: cancelled {len(self._pending)} queued deliveries after destination or route configuration changed", "WARNING")
+                self._pending.clear()
+                self._retry_after.clear()
+                self._session_ok.clear()
+                self._last_action.clear()
+                self._last_progress.clear()
+                self._debounce.clear()
+                self._failed_ids.clear()
+                self._config_identity = identity
+            if retry_key is not None:
+                if retry_key not in self._pending:
+                    return False
+                ev = self._pending[retry_key][1]
+            if same_scrobble_endpoint(watch.get("route_provider"), watch.get("route_provider_instance"), watch.get("route_sink"), watch.get("route_sink_instance")):
+                return False
+            ev = self._route_event(ev, cfg)
+            if not self._passes_filters(ev, cfg):
+                return False
         sent = False
+        failed = False
+        queued = False
         for s in self._sinks:
+            sk = self._session_key(s, ev)
+            with self._dispatch_lock:
+                if identity != self._config_identity:
+                    return False
+                if retry_key is not None and (sk != retry_key or sk not in self._pending):
+                    continue
+                if id(s) in self._inflight:
+                    if retry_key is None:
+                        self._queue_pending(sk, ev)
+                        self._retry_after.setdefault(sk, (time.monotonic(), 0))
+                    queued = True
+                    continue
+                retry = self._retry_after.get(sk)
+                if retry and time.monotonic() < retry[0]:
+                    if sk in self._pending and retry_key is None:
+                        self._queue_pending(sk, ev)
+                    failed = True
+                    continue
+                if retry_key is None and sk in self._pending:
+                    self._queue_pending(sk, ev)
+                if sk in self._failed_ids and self._failed_ids[sk] != ev.ids:
+                    self._last_action.pop(sk, None)
+                    self._last_progress.pop(sk, None)
+                if not self._should_send(ev, cfg, sk):
+                    if retry_key is not None:
+                        self._pending.pop(sk, None)
+                        self._retry_after.pop(sk, None)
+                    continue
+                self._inflight.add(id(s))
+            delivered = False
             try:
-                ev_for_sink = maybe_enrich_event_for_sink(ev, sink_name_for_mapping(s), cfg)
-                self._send_sink(s, ev_for_sink, cfg)
-                sent = True
-            except Exception as e:
-                _log(f"Sink error: {e}", "ERROR")
-        if sent:
-            self._throttled_route_log(
-                f"sent|{ev.action}|{ev.account}|{ev.session_key}",
-                f"route {self._route_label(cfg)}: sent {ev.action} "
-                f"user={mask_account(ev.account)} sess={ev.session_key}",
-            )
-        return sent or not self._sinks
+                log_delivery = bool(getattr(s, "log_delivery", True))
+                try:
+                    ev_for_sink = maybe_enrich_event_for_sink(ev, sink_name_for_mapping(s), cfg)
+                    result = self._send_sink(s, ev_for_sink, cfg)
+                except Exception as e:
+                    result = {"ok": False, "error": str(e), "retryable": True}
+                delivered = True
+                with self._dispatch_lock:
+                    if identity != self._config_identity:
+                        continue
+                    pending = self._pending.get(sk)
+                    newer = pending is not None and pending[1] is not ev
+                    if isinstance(result, dict) and result.get("ok") is False:
+                        failed = True
+                        self._failed_ids[sk] = dict(ev.ids)
+                        self._failed_ids.move_to_end(sk)
+                        if len(self._failed_ids) > 1024:
+                            expired, _ = self._failed_ids.popitem(last=False)
+                            self._last_action.pop(expired, None)
+                            self._last_progress.pop(expired, None)
+                            self._debounce.pop(f"{expired}|pause", None)
+                        if result.get("retryable", not result.get("skipped")):
+                            self._failed_sink(sk, pending[1] if newer and pending else ev)
+                        elif newer:
+                            self._last_action.pop(sk, None)
+                            self._last_progress.pop(sk, None)
+                            self._retry_after[sk] = (time.monotonic(), 0)
+                        else:
+                            self._retry_after.pop(sk, None)
+                            self._pending.pop(sk, None)
+                        if log_delivery:
+                            _log(f"route {self._route_label(cfg)}: failed {ev.action} "
+                                 f"user={mask_account(ev.account)} sess={ev.session_key} "
+                                 f"reason={result.get('error') or 'unknown'}", "ERROR")
+                        continue
+                    self._failed_ids.pop(sk, None)
+                    if newer:
+                        self._retry_after[sk] = (time.monotonic(), 0)
+                    else:
+                        self._retry_after.pop(sk, None)
+                        self._pending.pop(sk, None)
+                    sent = True
+                    if log_delivery:
+                        skipped = isinstance(result, dict) and bool(result.get("skipped"))
+                        status = "skipped" if skipped else "accepted"
+                        reason = str(result.get("reason") or "unknown") if skipped else ""
+                        self._throttled_route_log(
+                            f"{id(s)}|{status}|{reason}|{ev.action}|{ev.account}|{ev.session_key}",
+                            f"route {self._route_label(cfg)}: {status} {ev.action} "
+                            f"user={mask_account(ev.account)} p={ev.progress} sess={ev.session_key}"
+                            + (f" reason={reason}" if reason else ""),
+                        )
+            finally:
+                with self._dispatch_lock:
+                    self._inflight.discard(id(s))
+                    if not delivered and identity == self._config_identity:
+                        self._last_action.pop(sk, None)
+                        self._last_progress.pop(sk, None)
+                        self._debounce.pop(f"{sk}|pause", None)
+
+        return not failed and (sent or queued or not self._sinks)
 
 
 __all__ = (

--- a/providers/scrobble/watch_manager.py
+++ b/providers/scrobble/watch_manager.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import inspect
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, cast
 
 try:
@@ -15,7 +15,7 @@ except Exception:
     BASE_LOG = None
 
 from cw_platform.config_base import load_config
-from providers.scrobble.routes import build_route_cfg, build_route_cfg_by_id, find_route, normalize_routes
+from providers.scrobble.routes import build_route_cfg, build_route_cfg_by_id, find_route, normalize_routes, route_is_self_target
 from providers.scrobble.scrobble import Dispatcher, ScrobbleEvent
 from providers.scrobble.sources import source_enabled
 
@@ -65,6 +65,9 @@ def _stop_groups(groups: dict[str, Any] | None) -> None:
     if not isinstance(groups, dict):
         return
     for g in list(groups.values()):
+        retry_stop = getattr(g, "retry_stop", None)
+        if retry_stop is not None:
+            retry_stop.set()
         try:
             _stop_blocking(getattr(g, "watcher", None))
         except Exception:
@@ -118,6 +121,8 @@ class MultiDispatcher:
 
 
 class _SchedulerEventSink:
+    log_delivery = False
+
     def __init__(self, route_id: str, route_provider: str, route_provider_instance: str) -> None:
         self._route_id = str(route_id or "").strip()
         self._provider = str(route_provider or "").strip().lower()
@@ -162,6 +167,18 @@ class WatchGroup:
     watcher: Any
     routes: list[RouteRunner]
     started_at: float
+    retry_stop: threading.Event = field(default_factory=threading.Event)
+
+
+def _retry_deliveries(group: WatchGroup) -> None:
+    while not group.retry_stop.wait(1.0):
+        for runner in group.routes:
+            if group.retry_stop.is_set():
+                return
+            try:
+                runner.dispatcher.retry_pending(group.retry_stop)
+            except Exception as exc:
+                _log(f"Route retry failed: {exc}", "ERROR")
 
 
 def _make_sink(name: str, cfg_provider: Callable[[], dict[str, Any]], instance_id: str) -> Any:
@@ -169,7 +186,23 @@ def _make_sink(name: str, cfg_provider: Callable[[], dict[str, Any]], instance_i
     if not sink:
         raise ValueError("Empty sink")
     cls: Any | None = None
-    if sink == "trakt":
+    if sink == "plex":
+        from providers.scrobble.plex.sink import PlexSink
+
+        cls = PlexSink
+    elif sink == "jellyfin":
+        from providers.scrobble.jellyfin.sink import JellyfinSink
+
+        cls = JellyfinSink
+    elif sink == "emby":
+        from providers.scrobble.emby.sink import EmbySink
+
+        cls = EmbySink
+    elif sink == "kodi":
+        from providers.scrobble.kodi.sink import KodiSink
+
+        cls = KodiSink
+    elif sink == "trakt":
         from providers.scrobble.trakt.sink import TraktSink
 
         cls = TraktSink
@@ -293,6 +326,9 @@ class WatchManager:
             routes = [r for r in normalize_routes(cfg) if isinstance(r, dict) and bool(r.get("enabled"))]
             grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
             for r in routes:
+                if route_is_self_target(r):
+                    _log(f"Skipping self-targeting route {r.get('id')}", "WARNING")
+                    continue
                 prov = str(r.get("provider") or "plex").strip().lower() or "plex"
                 inst = str(r.get("provider_instance") or "default").strip() or "default"
                 grouped.setdefault((prov, inst), []).append(r)
@@ -352,6 +388,7 @@ class WatchManager:
                     routes=runners,
                     started_at=time.time(),
                 )
+                threading.Thread(target=_retry_deliveries, args=(watch_groups[key],), daemon=True).start()
 
             self._app.state.watch_groups = watch_groups
             return self.status()
@@ -360,6 +397,8 @@ class WatchManager:
         with self._lock:
             groups = getattr(self._app.state, "watch_groups", None)
             groups_copy = dict(groups) if isinstance(groups, dict) else {}
+            for group in groups_copy.values():
+                group.retry_stop.set()
             self._app.state.watch_groups = {}
             if wait:
                 _stop_groups(groups_copy)

--- a/providers/sync/emby/_history.py
+++ b/providers/sync/emby/_history.py
@@ -1239,30 +1239,30 @@ def _normalize_for_write(base_item: Mapping[str, Any]) -> tuple[dict[str, Any], 
     base_ids: dict[str, Any] = dict(base_ids_raw) if isinstance(base_ids_raw, Mapping) else {}
     has_ids = bool(base_ids) and any(v not in (None, "", 0) for v in base_ids.values())
 
+    nm = emby_normalize(base)
+    m: dict[str, Any] = dict(nm)
+    for key in (
+        "type",
+        "title",
+        "year",
+        "watch_type",
+        "watched_at",
+        "library_id",
+        "season",
+        "episode",
+        "series_title",
+        "show_ids",
+        "series_year",
+    ):
+        if base.get(key) not in (None, ""):
+            m[key] = base[key]
     if has_ids:
-        nm = emby_normalize(base)
-        m: dict[str, Any] = dict(nm)
-        # Preserve common fields from the caller input.
-        for key in (
-            "type",
-            "title",
-            "year",
-            "watch_type",
-            "watched_at",
-            "library_id",
-            "season",
-            "episode",
-        ):
-            if base.get(key) not in (None, ""):
-                m[key] = base[key]
         ids = dict(nm.get("ids") or {})
         for k_id, v_id in base_ids.items():
             if v_id not in (None, "", 0):
                 ids[k_id] = v_id
         if ids:
             m["ids"] = ids
-    else:
-        m = dict(emby_normalize(base))
 
     _coerce_anime_type(m)
     return m, base

--- a/providers/sync/jellyfin/_history.py
+++ b/providers/sync/jellyfin/_history.py
@@ -886,11 +886,11 @@ def _prepare_want(
     if raw_iid:
         m["jellyfin_item_id"] = raw_iid
 
-    if has_ids:
-        for key in _COPY_OVER_KEYS:
-            if base_d.get(key) not in (None, ""):
-                m[key] = base_d[key]
+    for key in _COPY_OVER_KEYS:
+        if base_d.get(key) not in (None, ""):
+            m[key] = base_d[key]
 
+    if has_ids:
         ids = dict(nm.get("ids") or {})
         for k_id, v_id in base_ids.items():
             if str(k_id).strip().lower() != "jellyfin" and v_id not in (None, "", 0):

--- a/providers/sync/jellyfin/_progress.py
+++ b/providers/sync/jellyfin/_progress.py
@@ -163,7 +163,7 @@ def _series_ids_by_item_id(
                 items_route(),
                 params=user_params(uid, {
                     "Ids": ",".join(batch),
-                    "Fields": "ProviderIds,ProductionYear,Type,Name",
+                    "Fields": "ProviderIds",
                 }),
             )
             if getattr(response, "status_code", 0) != 200:
@@ -181,6 +181,27 @@ def _series_ids_by_item_id(
     return out
 
 
+def _progress_library_ids(http: Any, uid: str, raw: Mapping[str, Any], allowed: set[str], cache: dict[str, set[str]]) -> set[str]:
+    memberships = jf_item_library_ids(raw)
+    if memberships:
+        return memberships
+    parent_id = str(raw.get("ParentId") or "").strip()
+    if parent_id in allowed:
+        return {parent_id}
+    lookup_id = parent_id or str(raw.get("Id") or "").strip()
+    if not lookup_id:
+        raise RuntimeError("progress_library_scope_missing_item_id")
+    if lookup_id not in cache:
+        response = http.get(f"/Items/{lookup_id}/Ancestors", params=user_params(uid))
+        if getattr(response, "status_code", 0) != 200:
+            raise RuntimeError(f"progress_library_scope_http_{getattr(response, 'status_code', 0)}")
+        ancestors = response.json()
+        if not isinstance(ancestors, list):
+            raise RuntimeError("progress_library_scope_invalid_ancestors")
+        cache[lookup_id] = {str(row["Id"]) for row in ancestors if isinstance(row, Mapping) and row.get("Id")}
+    return cache[lookup_id]
+
+
 def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
     http = getattr(adapter, "client", None)
     uid = getattr(getattr(adapter, "cfg", None), "user_id", None)
@@ -190,7 +211,7 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
     base_params: dict[str, Any] = {
         "Recursive": True,
         "IncludeItemTypes": "Movie,Episode",
-        "Fields": "UserData,ProviderIds,RunTimeTicks,ProductionYear,Type,IndexNumber,ParentIndexNumber,SeriesId,ParentId,CollectionFolderId,AncestorIds,LibraryId,Name",
+        "Fields": "ProviderIds,ParentId",
         "EnableUserData": True,
         "Filters": "IsResumable",
     }
@@ -244,6 +265,7 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
                 break
 
     series_ids_by_item_id = _series_ids_by_item_id(http, str(uid), rows)
+    library_ids_cache: dict[str, set[str]] = {}
     out: dict[str, dict[str, Any]] = {}
     total_rows = 0
     dup_keys = 0
@@ -254,10 +276,13 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
             _warn("unsupported_progress_row_type", provider_item_id=str(raw.get("Id") or ""), media_type=raw_type)
             continue
         if allowed:
-            memberships = jf_item_library_ids(raw)
-            if memberships and not (memberships & allowed):
+            memberships = _progress_library_ids(http, str(uid), raw, allowed, library_ids_cache)
+            matched_libraries = memberships & allowed
+            if not matched_libraries:
                 _dbg("outside_library_scope", provider_item_id=str(raw.get("Id") or ""), source_library_id=source_library_id, allowed_library_ids=sorted(allowed), item_title=str(raw.get("Name") or ""), media_type=str(raw.get("Type") or ""), provider_ids=dict(raw.get("ProviderIds") or {}))
                 continue
+            if source_library_id not in matched_libraries:
+                source_library_id = sorted(matched_libraries)[0]
         try:
             item = jelly_normalize(raw)
         except Exception:

--- a/providers/sync/plex/_common.py
+++ b/providers/sync/plex/_common.py
@@ -9,6 +9,8 @@ import os
 import re
 import shutil
 import time
+from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import datetime, timezone
 import unicodedata
 import uuid
@@ -111,6 +113,21 @@ except ImportError:
     from _id_map import minimal as id_minimal, ids_from_guid  # type: ignore
 
 _PLEX_CTX: dict[str, str | None] = {"baseurl": None, "token": None, "account_token": None}
+_SCOPED_PLEX_CTX: ContextVar[dict[str, str | None] | None] = ContextVar("plex_context", default=None)
+
+
+def plex_context() -> dict[str, str | None]:
+    scoped = _SCOPED_PLEX_CTX.get()
+    return scoped if scoped is not None else _PLEX_CTX
+
+
+@contextmanager
+def isolated_plex_context():
+    token = _SCOPED_PLEX_CTX.set({"baseurl": None, "token": None, "account_token": None})
+    try:
+        yield
+    finally:
+        _SCOPED_PLEX_CTX.reset(token)
 
 
 def configure_plex_context(
@@ -119,10 +136,11 @@ def configure_plex_context(
     token: str | None,
     account_token: str | None = None,
 ) -> None:
-    _PLEX_CTX["baseurl"] = baseurl.rstrip("/") if isinstance(baseurl, str) else None
-    _PLEX_CTX["token"] = token or None
+    context = plex_context()
+    context["baseurl"] = baseurl.rstrip("/") if isinstance(baseurl, str) else None
+    context["token"] = token or None
     if account_token is not None:
-        _PLEX_CTX["account_token"] = account_token or None
+        context["account_token"] = account_token or None
 
 
 DISCOVER = "https://discover.provider.plex.tv"
@@ -754,7 +772,7 @@ _SHOW_PMS_GUID_CACHE: dict[str, dict[str, str]] = {}
 _EP_SHOW_IDS_CACHE: dict[str, dict[str, str]] = {}
 
 def _metadata_cache_key(rating_key: str, token: str | None = None, base: str | None = None) -> str:
-    identity = [scope_safe(), base or _PLEX_CTX.get("baseurl"), token or _PLEX_CTX.get("token"), _PLEX_CTX.get("account_token")]
+    identity = [scope_safe(), base or plex_context().get("baseurl"), token or plex_context().get("token"), plex_context().get("account_token")]
     digest = hashlib.sha256(json.dumps(identity, separators=(",", ":")).encode()).hexdigest()
     return f"{digest}:{rating_key}"
 
@@ -772,7 +790,7 @@ def _hydrate_show_ids_from_episode_rk(token: str | None, episode_rk: str | None)
 
     headers = plex_headers(token)
     headers["Accept"] = "application/json, application/xml;q=0.9,*/*;q=0.5"
-    base = str(_PLEX_CTX.get("baseurl") or "").strip().rstrip("/")
+    base = str(plex_context().get("baseurl") or "").strip().rstrip("/")
 
     def _parse(r: requests.Response) -> dict[str, str]:
         ctype = (r.headers.get("content-type") or "").lower()
@@ -826,8 +844,8 @@ def _hydrate_show_ids_from_pms(obj: Any) -> dict[str, str]:
     key = _metadata_cache_key(rk, getattr(srv, "token", None) or getattr(srv, "_token", None), _as_base_url(srv))
     if key in _SHOW_PMS_GUID_CACHE:
         return _SHOW_PMS_GUID_CACHE[key]
-    base = _as_base_url(srv) or _PLEX_CTX["baseurl"]
-    token = getattr(srv, "token", None) or getattr(srv, "_token", None) or _PLEX_CTX["token"]
+    base = _as_base_url(srv) or plex_context()["baseurl"]
+    token = getattr(srv, "token", None) or getattr(srv, "_token", None) or plex_context()["token"]
     if not base or not token:
         _SHOW_PMS_GUID_CACHE[key] = {}
         return {}
@@ -967,9 +985,9 @@ def hydrate_external_ids(token: str | None, rating_key: str | None) -> dict[str,
             return {}
 
     headers = plex_headers(token)
-    cloud_token = str(_PLEX_CTX.get("account_token") or "").strip() or token
+    cloud_token = str(plex_context().get("account_token") or "").strip() or token
     cloud_headers = plex_headers(cloud_token) if cloud_token != token else headers
-    base = str(_PLEX_CTX.get("baseurl") or "").strip().rstrip("/")
+    base = str(plex_context().get("baseurl") or "").strip().rstrip("/")
 
     meta_status: int | None = None
     last_err: str | None = None
@@ -1071,7 +1089,7 @@ def normalize(obj: Any) -> dict[str, Any]:
                 base.setdefault("show_ids", {}).update(extra)
         if not has_ext(base.get("show_ids")):
             srv = getattr(obj, "_server", None)
-            token = getattr(srv, "_token", None) or getattr(srv, "token", None) or _PLEX_CTX["token"]
+            token = getattr(srv, "_token", None) or getattr(srv, "token", None) or plex_context()["token"]
             gp_rk = getattr(obj, "grandparentRatingKey", None)
             if token and gp_rk:
                 extra2 = hydrate_external_ids(token, str(gp_rk))
@@ -1119,7 +1137,7 @@ def normalize_discover_row(
     hydrate_item_ids: bool = True,
 ) -> dict[str, Any]:
     if token is None:
-        token = _PLEX_CTX["token"]
+        token = plex_context()["token"]
     t = (row.get("type") or "movie").lower()
     ids = ids_from_discover_row(row)
     if hydrate_item_ids and not any(k in ids for k in ("tmdb", "imdb", "tvdb")) and token:
@@ -1895,7 +1913,7 @@ def minimal_from_history_row(
     m = _build_minimal_from_row(row, ids)
     if not _has_ext_ids(m.get("ids", {})):
         rk = m.get("ids", {}).get("plex")
-        tok = token or _PLEX_CTX["token"]
+        tok = token or plex_context()["token"]
         if rk and tok:
             _emit(
                 {
@@ -1918,7 +1936,7 @@ def minimal_from_history_row(
                 m["ids"].update({k: v for k, v in extra.items() if v})
                 
     if kind == "episode" and not _has_ext_ids(m.get("show_ids", {})):
-        tok = token or _PLEX_CTX["token"]
+        tok = token or plex_context()["token"]
         gp_rk = _row_get(row, "grandparentRatingKey")
         if tok and gp_rk:
             _emit(
@@ -1950,7 +1968,7 @@ def minimal_from_history_row(
                     m.setdefault("show_ids", {}).update({k: v for k, v in extra3.items() if v})
                     
     if not _has_ext_ids(m.get("ids", {})) and allow_discover:
-        tok = token or _PLEX_CTX["token"]
+        tok = token or plex_context()["token"]
         title = m.get("series_title") if kind == "episode" else m.get("title")
         year = m.get("year")
         _emit(

--- a/providers/sync/plex/_progress.py
+++ b/providers/sync/plex/_progress.py
@@ -141,6 +141,7 @@ def _currently_playing(
     *,
     account_id: int | None = None,
     username: str | None = None,
+    fail_on_error: bool = False,
 ) -> bool:
     try:
         for session in srv.sessions() or []:  # type: ignore[attr-defined]
@@ -161,6 +162,8 @@ def _currently_playing(
                     continue
             return True
     except Exception:
+        if fail_on_error:
+            raise
         pass
     return False
 

--- a/providers/webhooks/config.py
+++ b/providers/webhooks/config.py
@@ -8,10 +8,15 @@ from collections.abc import Mapping
 from typing import Any
 
 from cw_platform.provider_instances import get_provider_block, normalize_instance_id
+from providers.scrobble.routes import ROUTE_SINKS, same_scrobble_endpoint, scrobble_sink_config
 
-_SINKS = {"trakt", "simkl", "mdblist", "crosswatch", "floppy", "punchplay", "bingebase", "flicklist", "scrob"}
+_SINKS = ROUTE_SINKS
 
 _SINK_CREDENTIALS: dict[str, tuple[str, ...]] = {
+    "plex": ("account_token", "pms_token", "token"),
+    "jellyfin": ("access_token",),
+    "emby": ("access_token",),
+    "kodi": ("connection_verified",),
     "trakt": ("access_token",),
     "simkl": ("access_token",),
     "mdblist": ("api_key", "access_token"),
@@ -96,6 +101,18 @@ def profile_scoped_webhook(cfg: Mapping[str, Any] | None, provider: str, provide
 
 def sink_configured(cfg: Mapping[str, Any] | None, sink: str, instance_id: Any = None) -> bool:
     key = str(sink or "").strip().lower()
+    if key in {"jellyfin", "emby", "kodi"}:
+        block = scrobble_sink_config(_dict(cfg), key, instance_id)[key]
+        server = str(block.get("server") or "").strip()
+        if key == "kodi":
+            return bool(server and block.get("connection_verified") is True)
+        return bool(server and str(block.get("access_token") or "").strip() and str(block.get("user_id") or "").strip())
+    if key == "plex":
+        block = scrobble_sink_config(_dict(cfg), key, instance_id)[key]
+        pms = _dict(block.get("pms"))
+        server = block.get("server_url") or block.get("baseurl") or pms.get("url") or pms.get("baseurl") or pms.get("server_url") or block.get("server_name") or block.get("server")
+        token = block.get("pms_token") or block.get("account_token") or block.get("token") or pms.get("token") or pms.get("x_plex_token")
+        return bool(server and token)
     if key == "crosswatch":
         block = get_provider_block(_dict(cfg), key, normalize_instance_id(instance_id))
         value = block.get("enabled")
@@ -126,7 +143,8 @@ def configured_webhook_sinks(cfg: Mapping[str, Any] | None, provider: str, provi
     return [
         sink
         for sink in webhook_sinks(cfg, provider, provider_instance)
-        if sink_configured(cfg, sink, webhook_sink_instance(wh, sink))
+        if not same_scrobble_endpoint(provider, provider_instance, sink, webhook_sink_instance(wh, sink))
+        and sink_configured(cfg, sink, webhook_sink_instance(wh, sink))
     ]
 
 

--- a/providers/webhooks/dispatch.py
+++ b/providers/webhooks/dispatch.py
@@ -13,6 +13,7 @@ from cw_platform.user_profile_resources import webhook_assigned_profile_id, webh
 from providers.scrobble.anime_mapping import maybe_enrich_event_for_sink
 from providers.scrobble.media_filters import event_ignore_reason, log_media_filter_drop
 from providers.scrobble.scrobble import ScrobbleAction, ScrobbleEvent
+from providers.scrobble.routes import same_scrobble_endpoint
 from providers.webhooks.config import sink_configured, webhook_settings, webhook_sink_instance, webhook_sinks
 
 
@@ -72,7 +73,23 @@ def _make_sink(name: str, instance_id: str, cfg_provider: Callable[[], dict[str,
     if key in _SINKS:
         return _SINKS[key]
     cls: Any
-    if sink == "trakt":
+    if sink == "plex":
+        from providers.scrobble.plex.sink import PlexSink
+
+        cls = PlexSink
+    elif sink == "jellyfin":
+        from providers.scrobble.jellyfin.sink import JellyfinSink
+
+        cls = JellyfinSink
+    elif sink == "emby":
+        from providers.scrobble.emby.sink import EmbySink
+
+        cls = EmbySink
+    elif sink == "kodi":
+        from providers.scrobble.kodi.sink import KodiSink
+
+        cls = KodiSink
+    elif sink == "trakt":
         from providers.scrobble.trakt.sink import TraktSink
 
         cls = TraktSink
@@ -240,6 +257,9 @@ def dispatch_scrobble(
     dispatched: list[str] = []
     for sink in sinks:
         inst = webhook_sink_instance(wh, sink)
+        if same_scrobble_endpoint(provider_lc, provider_inst, sink, inst):
+            targets.append({"target": sink, "target_instance": inst, "ok": False, "skipped": True, "error": "same_source_destination"})
+            continue
         route_cfg = _route_cfg(cfg, provider_lc, provider_inst, sink, inst)
         ignore_reason = event_ignore_reason(ev, route_cfg)
         if ignore_reason:
@@ -259,13 +279,17 @@ def dispatch_scrobble(
         target = {"target": sink, "target_instance": inst, "ok": True}
         try:
             ev_for_sink = maybe_enrich_event_for_sink(ev, sink, route_cfg)
-            _make_sink(sink, inst, _provider).send(ev_for_sink, cfg=route_cfg)
+            result = _make_sink(sink, inst, _provider).send(ev_for_sink, cfg=route_cfg)
+            if isinstance(result, Mapping):
+                target.update({k: result[k] for k in ("ok", "skipped", "reason", "error", "retryable") if k in result})
         except Exception as e:
             target["ok"] = False
             target["error"] = str(e)
             _emit(logger, f"webhook sink {sink}:{inst} failed: {e}", "ERROR")
         targets.append(target)
     ok = not targets or any(bool(t.get("ok")) for t in targets)
+    if any(not bool(t.get("ok")) and not bool(t.get("skipped")) for t in targets):
+        ok = False
     payload = {
         "action": path,
         "status": 200 if ok else 502,


### PR DESCRIPTION
# Pull request

## Change

- Add media server sinks for watchers and webhooks, with ID matching, playback progress updates and delivery retries.

## Why

- Keep other servers updated as you watch, without running a full sync each time. 
- Block routes back to the same provider instance.

## Testing

- tests/test_media_server_scrobble_sinks.py 
- tests/test_plex_scrobble_sink.py 
- tests/test_scrobble_dispatch_retries.py

## Issue

Relates to #1062