### PR TITLE
Add: media server destinations to scrobbler

### DIFF
--- a/api/scrobbleAPI.py
+++ b/api/scrobbleAPI.py
@@ -281,7 +281,9 @@ def _resolve_media_webhook_request(request: Request, provider: str, legacy_key: 
             blocked = _webhook_profile_gate(cfg, provider_lc, inst)
             if blocked:
                 return None, inst, blocked
-            return apply_webhook_settings(build_provider_config_view(cfg, provider_lc, inst), provider_lc, inst), inst, None
+            view = build_provider_config_view(cfg, provider_lc, inst)
+            view["_cw_scrobble_provider_configs"] = {provider_lc: cfg.get(provider_lc) or {}}
+            return apply_webhook_settings(view, provider_lc, inst), inst, None
         return None, "default", {"ok": True, "ignored": True, "error": "invalid_profile"}
 
     ids = _ensure_webhook_ids(cfg)

--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -23,6 +23,7 @@ from providers.scrobble.routes import (
     normalize_route_options,
     normalize_routes,
     route_needs_account_filter,
+    same_scrobble_endpoint,
 )
 from providers.scrobble.sources import legacy_mode_for_sources, scrobble_sources
 from providers.webhooks.config import (
@@ -678,6 +679,8 @@ def _validate_route(cfg: Mapping[str, Any], route: dict[str, Any]) -> dict[str, 
         raise ValidationFailure([_err("provider", "unsupported_provider", "Unsupported source provider")])
     if sink not in ROUTE_SINKS:
         raise ValidationFailure([_err("sink", "unsupported_provider", "Unsupported destination provider")])
+    if same_scrobble_endpoint(provider, normalized.get("provider_instance"), sink, normalized.get("sink_instance")):
+        raise ValidationFailure([_err("sink_instance", "same_source_destination", "Source and destination must use different providers or profiles")])
     _require_source_profile(cfg, provider, str(normalized.get("provider_instance") or "default"))
     _require_sink_profile(cfg, sink, str(normalized.get("sink_instance") or "default"))
     normalized["filters"] = _normalize_filters(normalized.get("filters"), provider, "filters")
@@ -776,6 +779,10 @@ def api_profile_webhook_save(request: Request, payload: dict[str, Any] = Body(..
             if prev_sink in {"crosswatch", "simkl"} and prev_sink not in sinks_now:
                 node.pop(f"anime_mapping_{prev_sink}", None)
         node.update(settings)
+        effective = webhook_settings(after, provider, instance)
+        for sink in webhook_sinks(after, provider, instance):
+            if same_scrobble_endpoint(provider, instance, sink, webhook_sink_instance(effective, sink)):
+                raise ValidationFailure([_err(f"sink_instances.{sink}", "same_source_destination", "Source and destination must use different providers or profiles")])
         if any(k in settings for k in ("anime_mapping_crosswatch", "anime_mapping_simkl")):
             node.pop("anime_mapping", None)
         if "enabled" not in node:

--- a/assets/helpers/details-log.js
+++ b/assets/helpers/details-log.js
@@ -339,7 +339,9 @@ function _parseLogParts(raw, fallbackProvider = "") {
     const token = String(match[1] || "").trim();
     const tokenLevel = levelName(token);
     const tokenTime = token.match(/\b(\d{2}:\d{2}:\d{2})(?:[.,]\d+)?\b/);
-    if (tokenTime) time ||= tokenTime[1];
+    const isoTime = /^\d{4}-\d{2}-\d{2}T/.test(token) ? new Date(token) : null;
+    if (isoTime && !Number.isNaN(isoTime.getTime())) time ||= isoTime.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false });
+    else if (tokenTime) time ||= tokenTime[1];
     else if (tokenLevel) level ||= tokenLevel;
     else if (known.has(token.toUpperCase()) || /^[A-Z][A-Z0-9_-]{1,20}$/.test(token)) provider ||= token.toUpperCase();
     else break;

--- a/assets/js/modals/scrobbler-route/index.js
+++ b/assets/js/modals/scrobbler-route/index.js
@@ -2,7 +2,7 @@
 const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 const label = (v) => ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", kodi: "Kodi", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy", punchplay: "PunchPlay", bingebase: "BingeBase", flicklist: "FlickList", scrob: "Scrob" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
 const sources = ["plex", "jellyfin", "emby", "kodi", "scrob"];
-const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "bingebase", "flicklist", "scrob"];
+const sinks = ["plex", "jellyfin", "emby", "kodi", "crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "bingebase", "flicklist", "scrob"];
 const ratingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "flicklist", "scrob"];
 
 function flashCopied(btn) {
@@ -89,9 +89,9 @@ function allSourceProfiles(provider) {
   return (group?.profiles || []).filter((x) => x.eligible);
 }
 
-function allSinkProfiles(sink) {
+function allSinkProfiles(sink, source = draft?.provider || "", instance = draft?.provider_instance || "default") {
   const group = (props.overview?.destination_availability || []).find((x) => x.provider === sink);
-  return (group?.profiles || []).filter((x) => x.configured);
+  return (group?.profiles || []).filter((x) => x.configured && !(sink === source && normInst(x.instance) === normInst(instance)));
 }
 
 function sourceProviders(selected = "") {
@@ -100,11 +100,11 @@ function sourceProviders(selected = "") {
   return current && sources.includes(current) && !available.includes(current) ? [current, ...available] : available;
 }
 
-function sinkProviders(selected = "", source = "") {
+function sinkProviders(selected = "", source = "", instance = draft?.provider_instance || "default") {
   const self = String(source || "").toLowerCase();
-  const available = sinks.filter((p) => p !== self && allSinkProfiles(p).length);
+  const available = sinks.filter((p) => allSinkProfiles(p, self, instance).length);
   const current = String(selected || "").toLowerCase();
-  if (current === self) return available;
+  if (current === self && !allSinkProfiles(current, self, instance).length) return available;
   return current && sinks.includes(current) && !available.includes(current) ? [current, ...available] : available;
 }
 
@@ -128,14 +128,15 @@ function nextId() {
 
 function defaultRoute() {
   const srcProvider = sourceProviders()[0] || "";
-  const sink = sinkProviders("", srcProvider)[0] || "";
+  const srcInstance = allSourceProfiles(srcProvider)[0]?.instance || "";
+  const sink = sinkProviders("", srcProvider, srcInstance)[0] || "";
   return {
     id: nextId(),
     enabled: true,
     provider: srcProvider,
-    provider_instance: allSourceProfiles(srcProvider)[0]?.instance || "",
+    provider_instance: srcInstance,
     sink,
-    sink_instance: allSinkProfiles(sink)[0]?.instance || "",
+    sink_instance: allSinkProfiles(sink, srcProvider, srcInstance)[0]?.instance || "",
     filters: {},
     options: { auto_remove_watchlist: "inherit", ratings: { mode: "off", targets: [] }, scrobble: {}, watch: {} },
   };
@@ -668,6 +669,10 @@ function busy(flag) {
 async function save(regenerate = false) {
   if (saving) return;
   syncDraftFromDom();
+  if (draft.provider === draft.sink && normInst(draft.provider_instance) === normInst(draft.sink_instance)) {
+    render([{ message: "Source and destination must use different providers or profiles" }]);
+    return;
+  }
   if (duplicateRoute(ensureDraft())) {
     render();
     return;
@@ -863,7 +868,7 @@ export async function mount(shell, incoming = {}) {
       syncDraftFromDom();
       if (e.target.id === "scr-provider") {
         draft.provider_instance = allSourceProfiles(draft.provider)[0]?.instance || "";
-        if (draft.sink === draft.provider) draft.sink = sinkProviders("", draft.provider)[0] || "";
+        if (!allSinkProfiles(draft.sink).length) draft.sink = sinkProviders("", draft.provider)[0] || "";
         draft.sink_instance = allSinkProfiles(draft.sink)[0]?.instance || "";
         const keptTargets = (draft.options.ratings?.targets || []).filter((t) => t !== draft.provider);
         if (draft.options.ratings) draft.options.ratings.targets = keptTargets;
@@ -879,6 +884,10 @@ export async function mount(shell, incoming = {}) {
     if (["scr-provider-instance", "scr-sink-instance", "scr-ratings-mode"].includes(e.target.id)) {
       const keepTab = currentActiveTab();
       syncDraftFromDom();
+      if (e.target.id === "scr-provider-instance" && draft.provider === draft.sink) {
+        if (!allSinkProfiles(draft.sink).length) draft.sink = sinkProviders("", draft.provider)[0] || "";
+        if (!allSinkProfiles(draft.sink).some((p) => normInst(p.instance) === normInst(draft.sink_instance))) draft.sink_instance = allSinkProfiles(draft.sink)[0]?.instance || "";
+      }
       render();
       preserveVisiblePanel(keepTab);
       return;

--- a/assets/js/modals/scrobbler-webhook/index.js
+++ b/assets/js/modals/scrobbler-webhook/index.js
@@ -1,7 +1,7 @@
 /* CrossWatch - Scrobbler Webhook Modal */
 const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 const label = (v) => window.CW?.ProviderMeta?.label?.(v) || ({ plex: "Plex", jellyfin: "Jellyfin", emby: "Emby", trakt: "Trakt", simkl: "SIMKL", mdblist: "MDBList", crosswatch: "CrossWatch", floppy: "Floppy", punchplay: "PunchPlay", bingebase: "BingeBase", flicklist: "FlickList", scrob: "Scrob" }[String(v || "").toLowerCase()] || String(v || "").toUpperCase());
-const sinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "bingebase", "flicklist", "scrob"];
+const sinks = ["plex", "jellyfin", "emby", "kodi", "crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "bingebase", "flicklist", "scrob"];
 const ratingSinks = ["crosswatch", "trakt", "simkl", "mdblist", "floppy", "punchplay", "flicklist", "scrob"];
 const webhookSources = new Set(["plex", "jellyfin", "emby"]);
 const animeMappingSinks = new Set(["crosswatch", "simkl"]);
@@ -91,7 +91,8 @@ function allProfiles() {
 
 function sinkProfiles(sink) {
   const group = (props.overview?.destination_availability || []).find((x) => x.provider === sink);
-  return (group?.profiles || []).filter((x) => x.configured);
+  const source = selectedWebhook();
+  return (group?.profiles || []).filter((x) => x.configured && !(sink === source.provider && normInst(x.instance) === normInst(source.provider_instance)));
 }
 
 function selectedWebhook() {
@@ -352,8 +353,7 @@ function sourceProviderKey() {
 }
 
 function availableSinks() {
-  const self = sourceProviderKey();
-  return sinks.filter((s) => s !== self && sinkProfiles(s).length > 0);
+  return sinks.filter((s) => sinkProfiles(s).length > 0);
 }
 
 function availableRatingSinks() {
@@ -379,7 +379,7 @@ function selectedSinkKey() {
 
 function selectedSinkInstance(sink) {
   const cur = selectedWebhook();
-  if (String(cur.sink || "").toLowerCase() === sink && cur.sink_instance) return String(cur.sink_instance);
+  if (String(cur.sink || "").toLowerCase() === sink && sinkProfiles(sink).some((p) => normInst(p.instance) === normInst(cur.sink_instance))) return String(cur.sink_instance);
   return String(sinkProfiles(sink)[0]?.instance || "");
 }
 

--- a/assets/js/scrobbler.js
+++ b/assets/js/scrobbler.js
@@ -227,7 +227,7 @@
             <span class="sc2-logo sc2-add-logo"><span class="material-symbols-rounded">add</span></span>
             <div class="sc2-route-add-copy">
               <strong>Add watcher route</strong>
-              <span>Create a new source to tracker route.</span>
+              <span>Create a new source to destination route.</span>
             </div>
             <span class="material-symbols-rounded sc2-route-add-arrow">arrow_forward</span>
           </button>

--- a/crosswatch.py
+++ b/crosswatch.py
@@ -3,10 +3,11 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 from typing import Any, Dict, List, Optional
+from collections import deque
 from collections.abc import AsyncIterator
 
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from html.parser import HTMLParser
 from pathlib import Path
 from urllib.parse import parse_qsl, urlencode, quote
@@ -747,6 +748,9 @@ WATCH_LOG_DEFAULT_TAGS = [
     "SIMKL-SCROBBLE",
     "MDBLIST-SCROBBLE",
 ]
+WATCH_LOG_BUFFER: deque[tuple[int, str, str]] = deque(maxlen=MAX_LOG_LINES * len(WATCH_LOG_TAGS))
+WATCH_LOG_LOCK = threading.Lock()
+WATCH_LOG_NEXT_SEQ = 1
 
 ANSI_RE    = re.compile(r"\x1b\[([0-9;]*)m")
 ANSI_STRIP = re.compile(r"\x1b\[[0-9;]*m")
@@ -873,12 +877,18 @@ def ansi_to_html(line: str) -> str:
     return "".join(out)
 
 def _append_log_to_buffer(tag: str, raw_line: str) -> None:
+    global WATCH_LOG_NEXT_SEQ
     t = _norm_log_tag(tag)
     safe_line = _redact_secrets_in_text(raw_line)
     if t in {"SYNC", DIAG_LOG_TAG} or t in WATCH_LOG_TAGS:
         from services.log_archive import capture
         capture(t, safe_line, watcher=t in WATCH_LOG_TAGS)
     html = ansi_to_html(safe_line.rstrip("\n"))
+    if t in WATCH_LOG_TAGS:
+        with WATCH_LOG_LOCK:
+            stamp = datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+            WATCH_LOG_BUFFER.append((WATCH_LOG_NEXT_SEQ, t, f"[{stamp}] {html}"))
+            WATCH_LOG_NEXT_SEQ += 1
     buf = _get_log_buf(t)
     buf.append(html)
     LOG_NEXT_SEQ[t] = int(LOG_NEXT_SEQ.get(t, 1)) + 1
@@ -1215,6 +1225,24 @@ async def api_logs_stream_initial(
         },
     )
 
+def _watch_log_snapshot(tags: List[str], after: int, limit: int | None) -> tuple[int, list[tuple[int, str, str]]]:
+    with WATCH_LOG_LOCK:
+        latest = WATCH_LOG_NEXT_SEQ - 1
+        rows = list(WATCH_LOG_BUFFER)
+    selected: list[tuple[int, str, str]] = []
+    counts: dict[str, int] = {}
+    for row in reversed(rows):
+        seq, tag, _line = row
+        if seq <= after:
+            break
+        if tag not in tags or (limit and counts.get(tag, 0) >= limit):
+            continue
+        counts[tag] = counts.get(tag, 0) + 1
+        selected.append(row)
+    selected.reverse()
+    return latest, selected
+
+
 @app.get("/api/logs/watcher", tags=["logging"])
 async def api_logs_watcher(
     request: Request,
@@ -1233,45 +1261,22 @@ async def api_logs_watcher(
     tags_sel = _watch_log_selection(tags)
 
     async def agen():
-        last_seq: Dict[str, int] = {}
-
-        for t in tags_sel:
-            buf = _get_log_buf(t)
-            if not skip_backlog:
-                start = max(0, len(buf) - int(tail))
-                for line in buf[start:]:
-                    safe = _log_stream_text(line, plain)
-                    yield f"event: {t}\ndata: {safe}\n\n"
-            base = int(LOG_BASE_SEQ.get(t, int(LOG_NEXT_SEQ.get(t, 1))))
-            last_seq[t] = base + len(buf) - 1
+        last_seq, rows = _watch_log_snapshot(tags_sel, 0, int(tail))
+        if not skip_backlog:
+            for _seq, tag, line in rows:
+                safe = _log_stream_text(line, plain)
+                yield f"event: {tag}\ndata: {safe}\n\n"
 
         last = time.time()
         while True:
             if await request.is_disconnected():
                 break
 
-            for t in tags_sel:
-                buf = _get_log_buf(t)
-                base = int(LOG_BASE_SEQ.get(t, int(LOG_NEXT_SEQ.get(t, 1))))
-                seen = int(last_seq.get(t, base - 1))
-                if seen < base - 1:
-                    seen = base - 1
-                start_seq = max(seen + 1, base)
-                start_idx = int(start_seq - base)
-                if start_idx < 0:
-                    start_idx = 0
-                if max_backlog:
-                    backlog = len(buf) - start_idx
-                    if backlog > max_backlog:
-                        start_idx = max(0, len(buf) - int(max_backlog))
-                        seen = base + start_idx - 1
-                for i in range(start_idx, len(buf)):
-                    line = buf[i]
-                    safe = _log_stream_text(line, plain)
-                    yield f"event: {t}\ndata: {safe}\n\n"
-                    last = time.time()
-                    seen = base + i
-                last_seq[t] = seen
+            last_seq, rows = _watch_log_snapshot(tags_sel, last_seq, max_backlog)
+            for _seq, tag, line in rows:
+                safe = _log_stream_text(line, plain)
+                yield f"event: {tag}\ndata: {safe}\n\n"
+                last = time.time()
 
             if time.time() - last > 15:
                 yield "event: ping\ndata: 1\n\n"

--- a/tests/scrobbler-sink-instances.test.mjs
+++ b/tests/scrobbler-sink-instances.test.mjs
@@ -1,0 +1,69 @@
+/* tests/scrobbler-sink-instances.test.mjs */
+/* CrossWatch - Scrobbler Sink Instance Tests */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+import test from "node:test";
+import assert from "node:assert/strict";
+import {readFileSync} from "node:fs";
+import vm from "node:vm";
+
+function modal(name) {
+  const source = readFileSync(new URL(`../assets/js/modals/scrobbler-${name}/index.js`, import.meta.url), "utf8")
+    .replace(/export default \{ mount, unmount \};/, "")
+    .replace(/export (async )?function/g, "$1function");
+  const context = vm.createContext({window: {}, console});
+  vm.runInContext(source, context);
+  return (script) => JSON.parse(JSON.stringify(vm.runInContext(script, context)));
+}
+
+const overview = {
+  eligible_sources: [{provider: "plex", profiles: [{instance: "default", eligible: true}, {instance: "P01", eligible: true}]}],
+  destination_availability: [{provider: "plex", profiles: [{instance: "default", configured: true}, {instance: "P01", configured: true}]}],
+};
+
+for (const provider of ["plex", "jellyfin", "emby", "kodi", "scrob"]) {
+  test(`${provider} watcher filters its own instance while allowing another`, () => {
+    const run = modal("route");
+    const data = JSON.stringify(overview).replaceAll('"plex"', JSON.stringify(provider));
+    run(`props = {overview: ${data}}; draft = {provider: "${provider}", provider_instance: "default"}; null`);
+    assert.deepEqual(run(`sinkProviders("", "${provider}")`), [provider]);
+    assert.deepEqual(run(`allSinkProfiles("${provider}").map(p => p.instance)`), ["P01"]);
+    run('draft.provider_instance = "P01"; null');
+    assert.deepEqual(run(`allSinkProfiles("${provider}").map(p => p.instance)`), ["default"]);
+  });
+}
+
+test("watcher allows the same provider with a different instance in both directions", () => {
+  const run = modal("route");
+  run(`props = {overview: ${JSON.stringify(overview)}}; draft = {provider: "plex", provider_instance: "default"}; null`);
+  assert.deepEqual(run('sinkProviders("", "plex")'), ["plex"]);
+  assert.deepEqual(run('allSinkProfiles("plex").map(p => p.instance)'), ["P01"]);
+  run('draft.provider_instance = "P01"; null');
+  assert.deepEqual(run('allSinkProfiles("plex").map(p => p.instance)'), ["default"]);
+});
+
+test("watcher defaults select an allowed destination instance", () => {
+  const run = modal("route");
+  run(`props = {overview: ${JSON.stringify(overview)}}; null`);
+  const route = run('defaultRoute()');
+  assert.equal(route.provider_instance, "default");
+  assert.equal(route.sink_instance, "P01");
+});
+
+test("watcher hides a provider when its only instance is the source", () => {
+  const run = modal("route");
+  const onlyDefault = structuredClone(overview);
+  onlyDefault.destination_availability[0].profiles.pop();
+  run(`props = {overview: ${JSON.stringify(onlyDefault)}}; draft = {provider: "plex", provider_instance: "default"}; null`);
+  assert.deepEqual(run('sinkProviders("", "plex")'), []);
+});
+
+test("webhook filters instances rather than excluding the whole source provider", () => {
+  const run = modal("webhook");
+  run(`props = {overview: ${JSON.stringify(overview)}, webhook: {provider: "plex", provider_instance: "default"}}; null`);
+  assert.deepEqual(run('availableSinks()'), ["plex"]);
+  assert.deepEqual(run('sinkProfiles("plex").map(p => p.instance)'), ["P01"]);
+  assert.equal(run('selectedSinkInstance("plex")'), "P01");
+  run('props.webhook = {provider: "plex", provider_instance: "P01", sink: "plex", sink_instance: "P01"}; null');
+  assert.deepEqual(run('sinkProfiles("plex").map(p => p.instance)'), ["default"]);
+  assert.equal(run('selectedSinkInstance("plex")'), "default");
+});

--- a/tests/test_crosswatch_watcher_sink.py
+++ b/tests/test_crosswatch_watcher_sink.py
@@ -114,6 +114,8 @@ def test_crosswatch_watcher_sink_writes_progress_and_history(monkeypatch, tmp_pa
     history_item = ops.added[-1]["items"][0]
     assert progress_item["type"] == "episode"
     assert progress_item["show_ids"] == {"tmdb": "124800"}
+    assert progress_item["ids"] == {"tvdb": "9621656"}
+    assert history_item["ids"] == {"tvdb": "9621656"}
     assert progress_item["season"] == 1
     assert progress_item["episode"] == 7
     assert progress_item["progress_percent"] == 12.0

--- a/tests/test_media_server_scrobble_sinks.py
+++ b/tests/test_media_server_scrobble_sinks.py
@@ -1,0 +1,534 @@
+# tests/test_media_server_scrobble_sinks.py
+# CrossWatch - Media Server Scrobble Sink Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import copy
+from dataclasses import replace
+from importlib import import_module
+from types import SimpleNamespace
+
+import pytest
+
+from providers.scrobble import _media_server as common
+from providers.scrobble.routes import build_route_cfg
+from providers.scrobble.scrobble import ScrobbleEvent
+
+
+def config(provider):
+    block = {"server": "http://default", "access_token": "default-token", "user_id": "default-user", "connection_verified": True}
+    return {provider: {**block, "instances": {"P01": {**block, "server": "http://p01", "access_token": "p01-token", "user_id": "p01-user"}}},
+            "scrobble": {"watch": {"route_provider": "plex", "route_provider_instance": "default", "route_sink": provider}}}
+
+
+def event(**kwargs):
+    return replace(ScrobbleEvent("stop", "movie", {"tmdb": "42"}, "Movie", 2020, None, None, 95,
+                                "source-user", "source-server", "session", {}), **kwargs)
+
+
+def row(iid="10", kind="Movie", ids=None, **kwargs):
+    return {"Id": iid, "Type": kind, "ProviderIds": ids or {"Tmdb": "42"}, "Name": "Movie", "LibraryId": "L1",
+            "RunTimeTicks": 1_000_000_000, "UserData": {"Played": False, "PlayCount": 0, "PlaybackPositionTicks": 0,
+                                                     "IsFavorite": True, "Rating": 8, "LastPlayedDate": "2020-01-01T00:00:00Z"}, **kwargs}
+
+
+class Http:
+    def __init__(self, provider):
+        self.provider = provider
+        self.rows = {"10": row()}
+        self.calls = []
+        self.sessions = []
+        self.fail = False
+        self.fail_sessions = False
+        self.supported = True
+        self.session = SimpleNamespace(close=lambda: None)
+
+    def response(self, value, status=200):
+        return SimpleNamespace(status_code=status, json=lambda: copy.deepcopy(value))
+
+    def progress_write_supported(self):
+        return self.supported, "10.11.0"
+
+    def get(self, path, params=None):
+        params = params or {}
+        if params.get("Fields"):
+            assert set(params["Fields"].split(",")) <= {"ProviderIds", "ParentId"}, "Fields must use valid API enum names"
+        self.calls.append(("GET", path, dict(params)))
+        if path == "/Sessions":
+            return self.response(self.sessions, 503 if self.fail_sessions else 200)
+        if path.endswith("/Ancestors"):
+            return self.response([{"Id": "L1"}])
+        if path.endswith("/Items"):
+            rows = list(self.rows.values())
+            if params.get("IncludeItemTypes"):
+                rows = [r for r in rows if r["Type"] in params["IncludeItemTypes"].split(",")]
+            if params.get("SearchTerm"):
+                rows = [r for r in rows if params["SearchTerm"] == r["Name"]]
+            if params.get("AnyProviderIdEquals"):
+                key, val = params["AnyProviderIdEquals"].split(".", 1)
+                rows = [r for r in rows if {k.lower(): v for k, v in r["ProviderIds"].items()}.get(key) == val]
+            if params.get("ParentId"):
+                rows = [r for r in rows if r.get("SeriesId") == params["ParentId"]]
+            for key in ("IndexNumber", "ParentIndexNumber"):
+                if key in params:
+                    rows = [r for r in rows if r.get(key) == params[key]]
+            start, count = params.get("StartIndex", 0), params.get("Limit", 100)
+            return self.response({"Items": rows[start:start+count], "TotalRecordCount": len(rows)})
+        iid = path.rsplit("/", 1)[-1]
+        return self.response(self.rows.get(iid), 200 if iid in self.rows else 404)
+
+    def post(self, path, params=None, json=None):
+        self.calls.append(("POST", path, {"params": params or {}, "json": copy.deepcopy(json)}))
+        if self.fail:
+            return self.response({}, 503)
+        if path.endswith("/UserData"):
+            self.rows[path.split("/")[-2]]["UserData"].update(json)
+        else:
+            self.rows[path.rsplit("/", 1)[-1]]["UserData"].update(Played=True, PlayCount=1)
+        def empty():
+            raise ValueError("No JSON in response")
+        return SimpleNamespace(status_code=200, json=empty)
+
+
+@pytest.fixture(params=["jellyfin", "emby"])
+def media_server(request, monkeypatch):
+    provider = request.param
+    http = Http(provider)
+    configs = []
+    def adapter(cfg):
+        configs.append(copy.deepcopy(cfg))
+        block = cfg[provider]
+        return SimpleNamespace(config=cfg, cfg=SimpleNamespace(user_id=block["user_id"],
+            history_libraries=(block.get("history") or {}).get("libraries"),
+            progress_libraries=(block.get("progress") or {}).get("libraries")), client=http)
+    monkeypatch.setattr(import_module(f"providers.sync._mod_{provider.upper()}"), f"{provider.upper()}Module", adapter)
+    monkeypatch.setattr(common, "record_watch", lambda *a, **kw: None)
+    monkeypatch.setattr(common, "record_scrobble_event", lambda *a, **kw: None)
+    cls = getattr(import_module(f"providers.scrobble.{provider}.sink"), "JellyfinSink" if provider == "jellyfin" else "EmbySink")
+    return provider, cls, http, configs
+
+
+def test_media_server_completion_resume_and_duplicate(media_server):
+    provider, cls, http, _ = media_server
+    cfg = config(provider)
+    sink = cls()
+    http.rows["10"]["UserData"]["PlaybackPositionTicks"] = 300_000_000
+    assert sink.send(event(ids={"tmdb": "42", provider: "source-id"}), cfg)["ok"]
+    assert sink.send(event(ids={"tmdb": "42", provider: "source-id"}), cfg)["reason"] == "duplicate"
+    data = http.rows["10"]["UserData"]
+    assert data["Played"] and data["PlayCount"] == 1 and data["PlaybackPositionTicks"] == 0
+    assert data["IsFavorite"] and data["Rating"] == 8
+    writes = [c for c in http.calls if c[0] == "POST"]
+    assert len(writes) == 2
+    if provider == "jellyfin":
+        assert writes[0][1] == "/UserPlayedItems/10"
+        assert all(c[2]["params"]["userId"] == "default-user" for c in writes)
+    else:
+        assert writes[0][1] == "/Users/default-user/PlayedItems/10"
+        assert writes[1][2]["json"]["IsFavorite"] is True
+
+
+def test_media_server_partial_uses_destination_ticks_and_preserves_watched(media_server):
+    provider, cls, http, _ = media_server
+    sink = cls()
+    assert sink.send(event(action="pause", progress=30, duration_ms=200_000), config(provider))["ok"]
+    assert http.rows["10"]["UserData"]["PlaybackPositionTicks"] == 300_000_000
+    assert not http.rows["10"]["UserData"]["Played"]
+    http.rows["10"]["UserData"]["Played"] = True
+    http.calls.clear()
+    assert sink.send(event(action="pause", progress=40), config(provider))["reason"] == "destination_already_watched"
+    assert not any(c[0] == "POST" for c in http.calls)
+
+
+@pytest.mark.parametrize("source,target", [("default", "P01"), ("P01", "default"), ("default", "default"), ("P01", "P01")])
+def test_media_server_instance_isolation(media_server, source, target):
+    provider, cls, http, configs = media_server
+    cfg = config(provider)
+    view = build_route_cfg(cfg, {"provider": provider, "provider_instance": source, "sink": provider, "sink_instance": target})
+    result = cls(instance_id=target).send(event(), view)
+    if source == target:
+        assert result["error"] == "same_source_destination" and not configs
+    else:
+        assert result["ok"] and configs[0][provider]["access_token"] == f"{target.lower()}-token"
+        assert view[provider]["user_id"] == f"{source.lower()}-user"
+
+
+@pytest.mark.parametrize("case", ["missing_ids", "conflict", "ambiguous", "library", "active", "sessions_error", "missing_userdata"])
+def test_media_server_guards(media_server, case):
+    provider, cls, http, _ = media_server
+    cfg, ev = config(provider), event()
+    if case == "missing_ids":
+        ev = event(ids={provider: "10"})
+    elif case == "conflict":
+        ev = event(ids={"tmdb": "42", "imdb": "tt0000111"})
+        http.rows["10"]["ProviderIds"]["Imdb"] = "tt0000999"
+    elif case == "ambiguous":
+        http.rows["11"] = row("11")
+    elif case == "library":
+        cfg[provider]["history"] = {"libraries": ["other"]}
+    elif case == "active":
+        http.sessions = [{"UserId": "default-user", "NowPlayingItem": {"Id": "10"}}]
+    elif case == "sessions_error":
+        http.fail_sessions = True
+    else:
+        http.rows["10"].pop("UserData")
+    result = cls().send(ev, cfg)
+    assert not result["ok"] or result.get("skipped")
+    assert not any(c[0] == "POST" for c in http.calls)
+
+
+def test_media_server_other_users_playback_does_not_block(media_server):
+    provider, cls, http, _ = media_server
+    http.sessions = [{"UserId": "someone-else", "NowPlayingItem": {"Id": "10"}}]
+    assert cls().send(event(), config(provider))["ok"]
+
+
+def test_media_server_active_playback_is_retryable_and_not_acknowledged(media_server):
+    provider, cls, http, _ = media_server
+    sink = cls()
+    http.sessions = [{"UserId": "default-user", "NowPlayingItem": {"Id": "10"}}]
+    assert sink.send(event(), config(provider)) == {"ok": False, "retryable": True, "error": "active_destination_session"}
+    assert not sink._sent
+    http.sessions.clear()
+    assert sink.send(event(), config(provider))["ok"]
+
+
+def test_legacy_default_auth_credentials_are_captured_before_source_projection(media_server):
+    from providers.webhooks.config import sink_configured
+
+    provider, cls, http, configs = media_server
+    cfg = config(provider)
+    cfg["auth"] = {provider: {k: cfg[provider].pop(k) for k in ("server", "user_id", "access_token")}}
+    view = build_route_cfg(cfg, {"provider": provider, "provider_instance": "P01", "sink": provider, "sink_instance": "default"})
+    assert sink_configured(view, provider, "default")
+    assert cls().send(event(), view)["ok"]
+    assert configs[0][provider]["user_id"] == "default-user"
+    assert configs[0][provider]["access_token"] == "default-token"
+    assert not sink_configured(cfg, provider, "missing-instance")
+
+
+@pytest.mark.parametrize("action", ["pause", "stop"])
+def test_partial_events_do_not_archive_a_start_or_completion(media_server, monkeypatch, action):
+    from cw_platform.event_archive import scrobble_recorder
+
+    provider, cls, _, _ = media_server
+    records = []
+    monkeypatch.setattr(common, "record_watch", scrobble_recorder.record_watch)
+    monkeypatch.setattr(scrobble_recorder, "record", lambda *a, **kw: records.append(kw))
+    assert cls().send(event(action=action, progress=30), config(provider))["ok"]
+    assert not records
+
+
+def test_media_server_failed_delivery_retries(media_server):
+    provider, cls, http, _ = media_server
+    sink = cls()
+    http.fail = True
+    assert not sink.send(event(), config(provider))["ok"]
+    http.fail = False
+    assert sink.send(event(), config(provider))["ok"]
+
+
+def test_media_server_stale_mapping_and_catalog_revalidation(media_server):
+    provider, cls, http, _ = media_server
+    sink = cls()
+    assert sink.send(event(action="pause", progress=30), config(provider))["ok"]
+    http.rows["10"]["ProviderIds"] = {"Tmdb": "999"}
+    http.rows["20"] = row("20")
+    assert sink.send(event(), config(provider))["ok"]
+    assert not http.rows["10"]["UserData"]["Played"] and http.rows["20"]["UserData"]["Played"]
+
+
+def test_media_server_episode_show_ids_and_specials(media_server):
+    provider, cls, http, _ = media_server
+    http.rows = {"show": row("show", "Series"), "ep": row("ep", "Episode", {"Tmdb": "123"},
+                                                              SeriesId="show", ParentIndexNumber=0, IndexNumber=1)}
+    ev = event(media_type="episode", ids={"tmdb_show": "42", "tmdb": "42"}, season=0, number=1)
+    assert cls().send(ev, config(provider))["ok"]
+    assert http.rows["ep"]["UserData"]["Played"] and not http.rows["show"]["UserData"]["Played"]
+
+
+def test_media_server_id_only_lookup_catalog_is_reused(media_server):
+    provider, cls, http, _ = media_server
+    if provider == "emby":
+        pytest.skip("Emby supports targeted external ID queries")
+    sink = cls()
+    cfg = config(provider)
+    assert sink.send(event(title=None), cfg)["ok"]
+    http.rows["10"]["UserData"]["Played"] = False
+    assert sink.send(event(title=None, session_key="second"), cfg)["ok"]
+    assert not sink.send(event(title=None, ids={"tmdb": "999"}), cfg)["ok"]
+    assert not sink.send(event(title=None, ids={"tmdb": "888"}), cfg)["ok"]
+    catalogs = [c for c in http.calls if c[0] == "GET" and c[2].get("IncludeItemTypes") == "Movie,Episode,Series"]
+    assert len(catalogs) == 1
+
+
+def test_jellyfin_unsupported_resume_does_not_simulate_playback(media_server):
+    provider, cls, http, _ = media_server
+    if provider != "jellyfin":
+        pytest.skip("Jellyfin version gate")
+    http.supported = False
+    assert cls().send(event(action="pause", progress=30), config(provider))["error"] == "jellyfin_progress_write_unsupported"
+    assert not any(c[0] == "POST" for c in http.calls)
+
+
+@pytest.mark.parametrize("provider", ["plex", "jellyfin", "emby", "kodi"])
+def test_all_media_server_registries_and_self_route_validation(provider):
+    from api.scrobblerManagementAPI import _validate_route, ValidationFailure
+    from providers.scrobble.watch_manager import _make_sink
+    from providers.webhooks import dispatch
+    from providers.webhooks.config import sink_configured
+    cfg = config(provider)
+    if provider == "plex":
+        cfg[provider] = {"server_url": "http://plex", "pms_token": "token"}
+    assert sink_configured(cfg, provider, "default")
+    assert not sink_configured(cfg, provider, "unknown")
+    assert _make_sink(provider, lambda: cfg, "default").name == provider
+    dispatch._SINKS.clear()
+    assert dispatch._make_sink(provider, "default", lambda: cfg).name == provider
+    dispatch._SINKS.clear()
+    with pytest.raises(ValidationFailure) as exc:
+        _validate_route(cfg, {"provider": provider, "sink": provider})
+    assert "same_source_destination" in str(exc.value.errors)
+    if provider != "plex":
+        assert _validate_route(cfg, {"provider": provider, "sink": provider, "sink_instance": "P01"})["sink_instance"] == "P01"
+
+
+def test_webhook_partial_failure_is_not_acknowledged_as_complete(monkeypatch):
+    from providers.webhooks import dispatch
+    cfg = {"plex": {"server_url": "http://plex", "pms_token": "token"}, "scrobble": {"webhook": {"sinks": ["crosswatch", "plex"]}}}
+    monkeypatch.setattr(dispatch, "_make_sink", lambda name, *a: SimpleNamespace(send=lambda *a, **kw: {"ok": name == "crosswatch", "error": "offline"}))
+    result = dispatch.dispatch_scrobble("jellyfin", "/scrobble/stop", media_type="movie", ids={"tmdb": "42"}, progress=95, cfg=cfg)
+    assert result.status_code == 502
+    assert {t["target"]: t["ok"] for t in result.json()["targets"]} == {"crosswatch": True, "plex": False}
+
+
+def kodi_row(iid=10, kind="movie", **kwargs):
+    key = {"movie": "movieid", "episode": "episodeid", "show": "tvshowid"}[kind]
+    return {key: iid, "title": "Movie", "uniqueid": {"tmdb": "42"}, "runtime": 100,
+            "resume": {"position": 0, "total": 100}, "playcount": 0, "file": "/media/movie.mkv", **kwargs}
+
+
+class Kodi:
+    def __init__(self):
+        self.rows = {"movie:10": kodi_row()}
+        self.calls = []
+        self.playing = None
+        self.fail = False
+        self.profile = "Default"
+        self.switch = False
+        self.probes = 0
+
+    def rpc(self, method, params=None):
+        params = params or {}
+        self.calls.append((method, copy.deepcopy(params)))
+        if method == "Profiles.GetCurrentProfile":
+            self.probes += 1
+            return {"profile": {"label": "Changed" if self.switch and self.probes > 1 else self.profile}}
+        if method == "Player.GetActivePlayers":
+            return [{"type": "video", "playerid": 1}] if self.playing else []
+        if method == "Player.GetItem":
+            return {"item": self.playing}
+        kind = "show" if "TVShow" in method else "episode" if "Episode" in method else "movie"
+        name = {"movie": "movie", "episode": "episode", "show": "tvshow"}[kind]
+        iid_key = name + "id"
+        if method.endswith("Details"):
+            key = f"{kind}:{params[iid_key]}"
+            if method.startswith("VideoLibrary.Set"):
+                if self.fail:
+                    raise RuntimeError("failed token=secret-must-not-leak")
+                self.rows[key].update({k: v for k, v in params.items() if k != iid_key})
+                return "OK"
+            return {name + "details": copy.deepcopy(self.rows[key])}
+        rows = [r for k, r in self.rows.items() if k.startswith(kind + ":")]
+        if params.get("filter"):
+            rows = [r for r in rows if r["title"] == params["filter"]["value"]]
+        for field in ("tvshowid", "season"):
+            if field in params:
+                rows = [r for r in rows if r.get(field) == params[field]]
+        return {name + "s": copy.deepcopy(rows[params["limits"]["start"]:params["limits"]["end"]]), "limits": {"total": len(rows)}}
+
+    def set_movie(self, iid, payload):
+        return self.rpc("VideoLibrary.SetMovieDetails", {"movieid": iid, **payload})
+
+    def set_episode(self, iid, payload):
+        return self.rpc("VideoLibrary.SetEpisodeDetails", {"episodeid": iid, **payload})
+
+
+@pytest.fixture
+def kodi(monkeypatch):
+    from providers.scrobble.kodi.sink import KodiSink
+    from providers.sync import _mod_KODI
+    client, configs = Kodi(), []
+    def adapter(cfg):
+        configs.append(copy.deepcopy(cfg))
+        return SimpleNamespace(config=cfg, client=client)
+    monkeypatch.setattr(_mod_KODI, "KODIModule", adapter)
+    monkeypatch.setattr(common, "record_watch", lambda *a, **kw: None)
+    monkeypatch.setattr(common, "record_scrobble_event", lambda *a, **kw: None)
+    return KodiSink, client, configs
+
+
+def test_kodi_completion_resume_and_duplicate(kodi):
+    cls, client, _ = kodi
+    client.rows["movie:10"]["resume"]["position"] = 30
+    sink = cls()
+    assert sink.send(event(ids={"tmdb": "42", "kodi": "999"}), config("kodi"))["ok"]
+    assert sink.send(event(ids={"tmdb": "42", "kodi": "999"}), config("kodi"))["reason"] == "duplicate"
+    row = client.rows["movie:10"]
+    assert row["playcount"] == 1 and row["resume"]["position"] == 0 and row["lastplayed"]
+    assert len([c for c in client.calls if c[0].startswith("VideoLibrary.Set")]) == 1
+
+
+def test_kodi_partial_uses_seconds_and_preserves_watched(kodi):
+    cls, client, _ = kodi
+    sink = cls()
+    assert sink.send(event(action="pause", progress=30, duration_ms=200_000), config("kodi"))["ok"]
+    assert client.rows["movie:10"]["resume"] == {"position": 30, "total": 100}
+    client.rows["movie:10"]["playcount"] = 3
+    assert sink.send(event(action="pause", progress=40), config("kodi"))["reason"] == "destination_already_watched"
+    assert client.rows["movie:10"]["playcount"] == 3
+
+
+@pytest.mark.parametrize("source,target", [("default", "P01"), ("P01", "default"), ("default", "default"), ("P01", "P01")])
+def test_kodi_instance_isolation(kodi, source, target):
+    cls, client, configs = kodi
+    cfg = build_route_cfg(config("kodi"), {"provider": "kodi", "provider_instance": source, "sink": "kodi", "sink_instance": target})
+    result = cls(instance_id=target).send(event(), cfg)
+    if source == target:
+        assert result["error"] == "same_source_destination" and not configs
+    else:
+        assert result["ok"] and configs[0]["kodi"]["server"] == f"http://{target.lower()}"
+
+
+@pytest.mark.parametrize("case", ["missing_ids", "conflict", "ambiguous", "library", "active", "profile_change"])
+def test_kodi_guards(kodi, case):
+    cls, client, _ = kodi
+    cfg, ev = config("kodi"), event()
+    if case == "missing_ids":
+        ev = event(ids={"kodi": "10"})
+    elif case == "conflict":
+        ev = event(ids={"tmdb": "42", "imdb": "tt0000111"})
+        client.rows["movie:10"]["uniqueid"]["imdb"] = "tt0000999"
+    elif case == "ambiguous":
+        client.rows["movie:11"] = kodi_row(11)
+    elif case == "library":
+        cfg["kodi"]["history"] = {"libraries": ["/somewhere/else"]}
+    elif case == "active":
+        client.playing = {"type": "movie", "id": 10}
+    else:
+        client.switch = True
+    result = cls().send(ev, cfg)
+    assert not result["ok"] or result.get("skipped")
+    assert not any(c[0].startswith("VideoLibrary.Set") for c in client.calls)
+
+
+def test_kodi_failed_delivery_retries_without_exposing_credentials(kodi):
+    cls, client, _ = kodi
+    sink = cls()
+    client.fail = True
+    assert sink.send(event(), config("kodi")) == {"ok": False, "error": "kodi_scrobble_failed", "retryable": True}
+    client.fail = False
+    assert sink.send(event(), config("kodi"))["ok"]
+
+
+@pytest.mark.parametrize("playing", [{"type": "unknown"}, {"type": "movie", "id": 99}])
+def test_kodi_unrelated_playback_does_not_block_writes(kodi, playing):
+    cls, client, _ = kodi
+    client.playing = playing
+    assert cls().send(event(), config("kodi"))["ok"]
+    assert client.rows["movie:10"]["playcount"] == 1
+
+
+def test_kodi_active_target_is_retryable(kodi):
+    cls, client, _ = kodi
+    sink = cls()
+    client.playing = {"type": "movie", "id": 10}
+    assert sink.send(event(), config("kodi")) == {"ok": False, "retryable": True, "error": "active_destination_session"}
+    client.playing = None
+    assert sink.send(event(), config("kodi"))["ok"]
+
+
+def test_kodi_stale_ids_are_revalidated(kodi):
+    cls, client, _ = kodi
+    sink = cls()
+    assert sink.send(event(action="pause", progress=30), config("kodi"))["ok"]
+    client.rows["movie:10"]["uniqueid"] = {"tmdb": "999"}
+    client.rows["movie:20"] = kodi_row(20)
+    assert sink.send(event(), config("kodi"))["ok"]
+    assert client.rows["movie:10"]["playcount"] == 0 and client.rows["movie:20"]["playcount"] == 1
+
+
+def test_kodi_episode_show_ids_and_specials(kodi):
+    cls, client, _ = kodi
+    client.rows = {"show:30": kodi_row(30, "show"), "episode:20": kodi_row(20, "episode", uniqueid={"tmdb": "123"}, tvshowid=30, season=0, episode=1)}
+    ev = event(media_type="episode", ids={"tmdb_show": "42", "tmdb": "42"}, season=0, number=1)
+    assert cls().send(ev, config("kodi"))["ok"]
+    assert client.rows["episode:20"]["playcount"] == 1 and client.rows["show:30"]["playcount"] == 0
+
+
+def test_kodi_id_only_catalog_reused_and_isolated_by_current_profile(kodi):
+    cls, client, _ = kodi
+    sink = cls()
+    cfg = config("kodi")
+    assert sink.send(event(title=None), cfg)["ok"]
+    assert not sink.send(event(title=None, ids={"tmdb": "999"}), cfg)["ok"]
+    assert not sink.send(event(title=None, ids={"tmdb": "888"}), cfg)["ok"]
+    assert len([c for c in client.calls if c[0] == "VideoLibrary.GetMovies"]) == 1
+    client.profile = "Other"
+    assert not sink.send(event(title=None, ids={"tmdb": "777"}), cfg)["ok"]
+    assert len([c for c in client.calls if c[0] == "VideoLibrary.GetMovies"]) == 2
+
+
+def test_kodi_completion_acknowledgements_are_profile_specific(kodi):
+    cls, client, _ = kodi
+    sink = cls()
+    assert sink.send(event(), config("kodi"))["ok"]
+    client.profile = "Other"
+    client.rows["movie:10"]["playcount"] = 0
+    assert sink.send(event(), config("kodi")) == {"ok": True}
+    assert client.rows["movie:10"]["playcount"] == 1
+
+
+@pytest.mark.parametrize("provider", ["jellyfin", "emby", "kodi"])
+def test_real_adapter_construction_has_no_source_or_sync_instance_leak(provider, monkeypatch):
+    monkeypatch.setenv("CW_PAIR_DST_INSTANCE", "unrelated-sync-instance")
+    cfg = config(provider)
+    view = build_route_cfg(cfg, {"provider": provider, "provider_instance": "P01", "sink": provider, "sink_instance": "default"})
+    cls = getattr(import_module(f"providers.scrobble.{provider}.sink"), {"jellyfin": "JellyfinSink", "emby": "EmbySink", "kodi": "KodiSink"}[provider])
+    selected = common.scrobble_sink_config(view, provider, "default")
+    adapter = cls()._connect(selected)
+    assert adapter.cfg.server == "http://default"
+    if provider != "kodi":
+        assert adapter.cfg.user_id == "default-user" and adapter.cfg.access_token == "default-token"
+        adapter.client.session.close()
+
+
+@pytest.mark.parametrize("provider", ["jellyfin", "emby"])
+@pytest.mark.parametrize("source,target", [("default", "P01"), ("P01", "default"), ("default", "default"), ("P01", "P01")])
+def test_media_server_webhook_management_guards(provider, source, target, monkeypatch):
+    from api import scrobblerManagementAPI as api
+    cfg, saved = config(provider), []
+    monkeypatch.setattr(api, "load_config", lambda: cfg)
+    monkeypatch.setattr(api, "_save_and_runtime", lambda request, before, after: saved.append(after) or {"ok": True})
+    response = api.api_profile_webhook_save(None, {"provider": provider, "provider_instance": source,
+                                                 "sinks": [provider], "sink_instances": {provider: target}})
+    assert response.status_code == (400 if source == target else 200)
+    assert bool(saved) is (source != target)
+    if source == target:
+        assert b"same_source_destination" in response.body
+
+
+def test_catalog_survives_connection_renewal_but_refreshes_after_six_hours(kodi, monkeypatch):
+    cls, client, _ = kodi
+    current = [100.0]
+    monkeypatch.setattr(common.time, "monotonic", lambda: current[0])
+    sink = cls()
+    cfg = config("kodi")
+    ev = event(title=None)
+    assert sink.send(ev, cfg)["ok"]
+    current[0] += 1000
+    assert sink.send(ev, cfg)["ok"]
+    assert len([c for c in client.calls if c[0] == "VideoLibrary.GetMovies"]) == 1
+    current[0] += 21600
+    assert sink.send(ev, cfg)["ok"]
+    assert len([c for c in client.calls if c[0] == "VideoLibrary.GetMovies"]) == 2

--- a/tests/test_plex_scrobble_sink.py
+++ b/tests/test_plex_scrobble_sink.py
@@ -1,0 +1,617 @@
+# tests/test_plex_scrobble_sink.py
+# CrossWatch - Plex Scrobble Sink Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import replace
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlsplit
+from xml.etree.ElementTree import Element, SubElement
+
+import pytest
+
+from providers.scrobble.plex import sink as plex
+from providers.scrobble import _media_server as common
+from providers.scrobble.routes import build_route_cfg, same_scrobble_endpoint, scrobble_sink_config
+from providers.scrobble.scrobble import Dispatcher, ScrobbleEvent
+
+
+def config():
+    return {
+        "plex": {"server_url": "http://default", "pms_token": "default-token",
+                 "instances": {"P01": {"server_url": "http://p01", "pms_token": "p01-token"}}},
+        "scrobble": {"trakt": {"watched_at": 90, "progress_step": 25},
+                     "watch": {"route_provider": "jellyfin", "route_provider_instance": "default", "route_sink": "plex", "route_sink_instance": "default"},
+                     "webhook": {"sinks": ["plex"], "sink_instances": {"plex": "default"}}},
+    }
+
+
+def event(**kwargs):
+    base = ScrobbleEvent("stop", "movie", {"tmdb": "42"}, "Movie", 2020, None, None, 95,
+                         "alice", "source-server", "session-1", {})
+    return replace(base, **kwargs)
+
+
+def media(rk="10", kind="movie", ids=None, **kwargs):
+    return SimpleNamespace(ratingKey=rk, type=kind, title="Movie", year=2020,
+                           guid=None, guids=[SimpleNamespace(id=f"{k}://{v}") for k, v in (ids or {"tmdb": "42"}).items()],
+                           librarySectionID="1", duration=100_000, viewOffset=0, viewCount=0, **kwargs)
+
+
+class Server:
+    def __init__(self, *items):
+        self.items = {str(x.ratingKey): x for x in items}
+        self.calls = []
+        self.playing = []
+        self.fail_write = False
+        self.fail_sessions = False
+        self._session = SimpleNamespace(put=lambda: None, post=lambda: None, close=lambda: None)
+
+    def query(self, path, method=None, params=None):
+        verb = "PUT" if method is self._session.put else "POST" if method is self._session.post else method
+        self.calls.append((path, verb, params))
+        if method:
+            if self.fail_write:
+                raise RuntimeError("failed")
+            if path == "/:/scrobble":
+                self.items[str(params["key"])].viewCount = 1
+            if path == "/:/timeline":
+                self.items[str(params["ratingKey"])].viewOffset = params["time"]
+            return Element("MediaContainer")
+        query = parse_qs(urlsplit(path).query)
+        assert "guid" in query, "Sink must not scan the entire library"
+        root = Element("MediaContainer")
+        for item in self.items.values():
+            if query["guid"][0] in [x.id for x in item.guids]:
+                SubElement(root, "Video", {"ratingKey": str(item.ratingKey)})
+        return root
+
+    def fetchItem(self, key):
+        return self.items[str(key)]
+
+    def search(self, title, mediatype):
+        return [x for x in self.items.values() if x.type == mediatype]
+
+    def sessions(self):
+        if self.fail_sessions:
+            raise RuntimeError("session lookup failed")
+        return self.playing
+
+
+@pytest.fixture
+def harness(monkeypatch):
+    from providers.sync import _mod_PLEX
+
+    server = Server(media())
+    configs = []
+    records = []
+
+    def adapter(cfg):
+        configs.append(copy.deepcopy(cfg))
+        return SimpleNamespace(config=cfg, cfg=SimpleNamespace(client_id="sink-client"),
+                               client=SimpleNamespace(server=server, session=server._session))
+
+    monkeypatch.setattr(_mod_PLEX, "PLEXModule", adapter)
+    monkeypatch.setattr(common, "record_watch", lambda *a, **k: records.append(k))
+    monkeypatch.setattr(common, "record_scrobble_event", lambda *a, **k: None)
+    monkeypatch.setattr(common, "remove_across_providers_by_ids", lambda *a, **k: None)
+    return server, configs, records
+
+
+def test_completion_writes_put_once_and_never_uses_source_rating_key(harness):
+    server, configs, records = harness
+    dest = plex.PlexSink()
+    ev = event(ids={"tmdb": "42", "plex": "999"}, raw={"ratingKey": "999"})
+    assert dest.send(ev, config()) == {"ok": True}
+    assert dest.send(ev, config())["reason"] == "duplicate"
+    writes = [x for x in server.calls if x[1]]
+    assert writes == [("/:/scrobble", "PUT", {"key": "10", "identifier": "com.plexapp.plugins.library"})]
+    assert records[0]["destination_provider"] == "plex"
+
+
+def test_resume_uses_destination_duration_stopped_timeline_and_throttles(harness):
+    server, _, _ = harness
+    dest = plex.PlexSink()
+    assert dest.send(event(action="start", progress=30, duration_ms=200_000), config())["ok"]
+    assert dest.send(event(action="start", progress=31), config())["reason"] == "duplicate"
+    assert dest.send(event(action="pause", progress=32), config())["ok"]
+    writes = [x for x in server.calls if x[1]]
+    assert [x[2]["time"] for x in writes] == [30_000, 32_000]
+    assert all(x[0] == "/:/timeline" and x[1] == "POST" and x[2]["state"] == "stopped" for x in writes)
+
+
+def test_below_threshold_stop_does_not_mark_watched(harness):
+    server, _, _ = harness
+    assert plex.PlexSink().send(event(progress=40), config())["ok"]
+    assert not any(x[0] == "/:/scrobble" for x in server.calls)
+
+
+def test_completion_clears_resume_without_unwatching(harness):
+    server, _, _ = harness
+    server.items["10"].viewOffset = 20_000
+    assert plex.PlexSink().send(event(), config())["ok"]
+    assert server.items["10"].viewOffset == 0
+    assert server.items["10"].viewCount == 1
+
+
+@pytest.mark.parametrize("source,target,allowed", [("default", "default", False), ("P01", "P01", False), ("default", "P01", True), ("P01", "default", True)])
+def test_watcher_projection_and_self_route_protection(harness, source, target, allowed):
+    server, configs, _ = harness
+    cfg = config()
+    route = {"provider": "plex", "provider_instance": source, "sink": "plex", "sink_instance": target}
+    view = build_route_cfg(cfg, route)
+    expected = "default-token" if target == "default" else "p01-token"
+    assert scrobble_sink_config(view, "plex", target)["plex"]["pms_token"] == expected
+    assert view["plex"]["pms_token"] == ("default-token" if source == "default" else "p01-token")
+    assert plex.PlexSink(instance_id=target).send(event(), view)["ok"] is allowed
+    if allowed:
+        assert configs[0]["plex"]["pms_token"] == expected
+    else:
+        assert not configs and not server.calls
+
+
+def test_webhook_projection_keeps_default_destination_credentials(harness):
+    from cw_platform.provider_instances import build_provider_config_view
+    from providers.webhooks.dispatch import dispatch_scrobble, _SINKS
+
+    _SINKS.clear()
+    original = config()
+    cfg = build_provider_config_view(original, "plex", "P01")
+    cfg["_cw_scrobble_provider_configs"] = {"plex": original["plex"]}
+    result = dispatch_scrobble("plex", "/scrobble/stop", media_type="movie", ids={"tmdb": "42"}, progress=95, cfg=cfg, provider_instance="P01")
+    assert result.json()["targets"][0]["ok"]
+    assert harness[1][0]["plex"]["pms_token"] == "default-token"
+    _SINKS.clear()
+
+
+def test_direct_webhook_self_target_never_dispatches(harness):
+    from providers.webhooks.dispatch import dispatch_scrobble
+    result = dispatch_scrobble("plex", "/scrobble/stop", media_type="movie", ids={"tmdb": "42"}, progress=95, cfg=config())
+    assert result.status_code == 502
+    assert result.json()["targets"][0]["error"] == "same_source_destination"
+    assert not harness[1]
+
+
+@pytest.mark.parametrize("reason", ["active", "sessions_failed", "scope_failed", "missing_ids", "conflict", "ambiguous", "outside_library"])
+def test_rejects_unsafe_or_unresolved_writes(harness, monkeypatch, reason):
+    server, _, _ = harness
+    cfg, ev = config(), event()
+    if reason == "active":
+        server.playing = [SimpleNamespace(ratingKey="10")]
+    elif reason == "sessions_failed":
+        server.fail_sessions = True
+    elif reason == "scope_failed":
+        monkeypatch.setattr(plex, "home_scope_enter", lambda _: (True, False, 42, "alice"))
+    elif reason == "missing_ids":
+        ev = event(ids={"plex": "10"})
+    elif reason == "conflict":
+        ev = event(ids={"tmdb": "42", "imdb": "tt123"})
+        server.items["10"].guids.append(SimpleNamespace(id="imdb://tt999"))
+    elif reason == "ambiguous":
+        server.items["11"] = media("11")
+    elif reason == "outside_library":
+        cfg["plex"]["history"] = {"libraries": [2]}
+    result = plex.PlexSink().send(ev, cfg)
+    assert result.get("skipped") or not result["ok"]
+    assert not any(x[1] for x in server.calls)
+
+
+def test_failed_completion_is_retryable(harness):
+    server, _, _ = harness
+    dest = plex.PlexSink()
+    server.fail_write = True
+    assert not dest.send(event(), config())["ok"]
+    server.fail_write = False
+    assert dest.send(event(), config())["ok"]
+
+
+def test_stale_cached_rating_key_is_revalidated(harness):
+    server, _, _ = harness
+    dest = plex.PlexSink()
+    assert dest.send(event(action="pause", progress=30), config())["ok"]
+    server.items["10"].guids = [SimpleNamespace(id="tmdb://999")]
+    server.items["20"] = media("20")
+    assert dest.send(event(), config())["ok"]
+    assert server.items["10"].viewCount == 0
+    assert server.items["20"].viewCount == 1
+
+
+def test_episode_matches_show_ids_and_coordinates(harness):
+    server, _, _ = harness
+    episode = media("20", "episode", {"tmdb": "100"}, parentIndex=0, index=1, grandparentRatingKey="30")
+    show = media("30", "show", {"tmdb": "42"}, episodes=lambda **kw: [episode])
+    server.items = {"20": episode, "30": show}
+    ev = event(media_type="episode", ids={"tmdb_show": "42", "tmdb": "42"}, season=0, number=1)
+    assert plex.PlexSink().send(ev, config())["ok"]
+    assert episode.viewCount == 1 and show.viewCount == 0
+
+
+def test_duplicate_episode_coordinates_are_rejected(harness):
+    server, _, _ = harness
+    episodes = [media(key, "episode", {"tmdb": "100"}, parentIndex=1, index=2, grandparentRatingKey="30") for key in ("20", "21")]
+    show = media("30", "show", {"tmdb": "42"}, episodes=lambda **kw: episodes)
+    server.items = {str(x.ratingKey): x for x in [show, *episodes]}
+    result = plex.PlexSink().send(event(media_type="episode", ids={"tmdb_show": "42"}, season=1, number=2), config())
+    assert result == {"ok": False, "error": "ambiguous_ids", "retryable": False}
+    assert not any(x[1] for x in server.calls)
+
+
+def test_truncated_id_results_cannot_choose_an_arbitrary_item(harness, monkeypatch):
+    server, _, _ = harness
+    original = server.query
+    def query(path, **kwargs):
+        result = original(path, **kwargs)
+        result.set("totalSize", "101")
+        return result
+    monkeypatch.setattr(server, "query", query)
+    assert plex.PlexSink().send(event(), config()) == {"ok": False, "error": "ambiguous_ids", "retryable": False}
+    assert not any(x[1] for x in server.calls)
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_selected_account_scope_covers_writes_and_is_restored(harness, monkeypatch, fail):
+    server, _, _ = harness
+    active = []
+    def enter(adapter):
+        active.append("selected-user")
+        return True, True, 123, "selected-user"
+    def leave(adapter, switched):
+        assert switched and active.pop() == "selected-user"
+    original = server.query
+    def query(path, **kwargs):
+        assert active == ["selected-user"]
+        return original(path, **kwargs)
+    monkeypatch.setattr(plex, "home_scope_enter", enter)
+    monkeypatch.setattr(plex, "home_scope_exit", leave)
+    monkeypatch.setattr(server, "query", query)
+    server.fail_write = fail
+    assert plex.PlexSink().send(event(), config())["ok"] is not fail
+    assert active == []
+
+
+@pytest.mark.parametrize("mode,enabled,removed", [("inherit", False, False), ("inherit", True, True), ("off", True, False), ("on", False, True)])
+def test_completion_activity_and_watchlist_policy(harness, monkeypatch, mode, enabled, removed):
+    records, removals = [], []
+    monkeypatch.setattr(common, "record_scrobble_event", lambda *a, **kw: records.append(kw))
+    monkeypatch.setattr(common, "remove_across_providers_by_ids", lambda *a, **kw: removals.append((a, kw)))
+    cfg = config()
+    cfg["scrobble"].update(delete_plex=enabled, delete_plex_types=["movies"])
+    cfg["scrobble"]["watch"]["route_options"] = {"auto_remove_watchlist": mode}
+    dest = plex.PlexSink()
+    assert dest.send(event(action="pause", progress=40), cfg)["ok"]
+    assert not records and not removals
+    assert dest.send(event(), cfg)["ok"]
+    assert dest.send(event(), cfg)["reason"] == "duplicate"
+    assert len(records) == 1 and records[0]["target"] == "plex"
+    assert bool(removals) is removed
+    if removed:
+        assert removals == [(({"tmdb": "42"}, "movie"), {"scope": "plex:default"})]
+
+
+@pytest.mark.parametrize("source,target", [("default", "P01"), ("P01", "default")])
+def test_existing_scrob_sink_uses_captured_destination_config(source, target):
+    from providers.scrobble.scrob.sink import ScrobSink
+    cfg = {"scrob": {"server_url": "http://default", "api_key": "default-key", "instances": {
+        "P01": {"server_url": "http://p01", "api_key": "p01-key"}}}}
+    view = build_route_cfg(cfg, {"provider": "scrob", "provider_instance": source, "sink": "scrob", "sink_instance": target})
+    dest = ScrobSink(cfg_provider=lambda: view, instance_id=target)
+    assert view["scrob"]["server_url"] == f"http://{source.lower()}"
+    assert dest._block(dest.config)["server_url"] == f"http://{target.lower()}"
+
+
+def test_dispatcher_does_not_acknowledge_failed_sink_and_allows_retry(monkeypatch):
+    now = [100.0]
+    monkeypatch.setattr("providers.scrobble.scrobble.time.monotonic", lambda: now[0])
+    class Sink:
+        attempts = 0
+        def send(self, ev, cfg=None):
+            self.attempts += 1
+            return {"ok": self.attempts > 1}
+    dest = Sink()
+    dispatcher = Dispatcher([dest], cfg_provider=config)
+    assert not dispatcher.dispatch(event())
+    assert not dispatcher.dispatch(event())
+    assert dest.attempts == 1
+    now[0] += 30
+    assert dispatcher.dispatch(event())
+
+
+@pytest.mark.parametrize("result,status", [
+    ({"ok": False, "error": "unmatched_in_jellyfin", "retryable": False}, "failed"),
+    ({"ok": True, "skipped": True, "reason": "destination_already_watched"}, "skipped"),
+    ({"ok": True}, "accepted"),
+])
+def test_route_logs_destination_outcome_without_scheduler_success(monkeypatch, result, status):
+    from providers.scrobble.watch_manager import _SchedulerEventSink
+
+    messages = []
+    monkeypatch.setattr("providers.scrobble.scrobble._log", lambda message, *a: messages.append(message))
+    monkeypatch.setattr(_SchedulerEventSink, "send", lambda *a, **kw: None)
+    class Destination:
+        def send(self, event, cfg=None):
+            return result
+    cfg = config()
+    cfg["scrobble"]["watch"].update(route_id="R4", route_provider="plex", route_sink="jellyfin")
+    dispatcher = Dispatcher([Destination(), _SchedulerEventSink("R4", "plex", "default")], cfg_provider=lambda: cfg)
+    dispatcher.dispatch(event(action="start", progress=19))
+    matching = [message for message in messages if f"route R4 plex->jellyfin: {status} start" in message]
+    assert len(matching) == 1
+    assert not any(": sent " in message for message in messages)
+    if status != "accepted":
+        assert not any(": accepted " in message for message in messages)
+        assert (result.get("reason") or result.get("error")) in matching[0]
+
+
+@pytest.mark.parametrize("retryable", [False, True])
+def test_dispatcher_failure_never_replays_successful_scheduler_delivery(monkeypatch, retryable):
+    now = [100.0]
+    monkeypatch.setattr("providers.scrobble.scrobble.time.monotonic", lambda: now[0])
+    calls = []
+    class Destination:
+        def send(self, ev, cfg=None):
+            calls.append("destination")
+            return {"ok": False, "error": "unmatched_in_plex", "retryable": retryable}
+    class Scheduler:
+        def send(self, ev):
+            calls.append("scheduler")
+    dispatcher = Dispatcher([Destination(), Scheduler()], cfg_provider=config)
+    for _ in range(5):
+        dispatcher.dispatch(event())
+    assert calls == ["destination", "scheduler"]
+    now[0] += 30
+    dispatcher.retry_pending()
+    assert calls.count("scheduler") == 1
+    assert calls.count("destination") == (2 if retryable else 1)
+
+
+def test_active_destination_completion_retries_without_another_source_event(harness, monkeypatch):
+    server, _, _ = harness
+    now = [100.0]
+    monkeypatch.setattr("providers.scrobble.scrobble.time.monotonic", lambda: now[0])
+    server.playing = [SimpleNamespace(ratingKey="10")]
+    dispatcher = Dispatcher([plex.PlexSink()], cfg_provider=config)
+    assert not dispatcher.dispatch(event())
+    assert not any(c[1] for c in server.calls)
+    server.playing = []
+    now[0] += 30
+    dispatcher.retry_pending()
+    assert server.items["10"].viewCount == 1
+    assert not dispatcher._pending
+
+
+def test_retry_uses_latest_progress_and_cancels_on_configuration_change(monkeypatch):
+    now = [100.0]
+    monkeypatch.setattr("providers.scrobble.scrobble.time.monotonic", lambda: now[0])
+    calls = []
+    class Destination:
+        def send(self, ev, cfg=None):
+            calls.append(ev.progress)
+            return {"ok": False, "retryable": True}
+    cfg = config()
+    dispatcher = Dispatcher([Destination()], cfg_provider=lambda: cfg)
+    dispatcher.dispatch(event(action="start", progress=10))
+    dispatcher.dispatch(event(action="stop", progress=95))
+    now[0] += 30
+    dispatcher.retry_pending()
+    assert calls == [10, 95]
+    cfg["plex"]["pms_token"] = "replacement-token"
+    now[0] += 60
+    dispatcher.retry_pending()
+    assert calls == [10, 95] and not dispatcher._pending
+
+
+def test_pending_retries_expire_and_respect_watcher_shutdown(monkeypatch):
+    from threading import Event
+
+    now = [100.0]
+    monkeypatch.setattr("providers.scrobble.scrobble.time.monotonic", lambda: now[0])
+    calls = []
+    class Destination:
+        def send(self, ev, cfg=None):
+            calls.append(ev)
+            return {"ok": False, "retryable": True}
+    dispatcher = Dispatcher([Destination()], cfg_provider=config)
+    dispatcher.dispatch(event())
+    now[0] += 30
+    stopped = Event()
+    stopped.set()
+    dispatcher.retry_pending(stopped)
+    assert len(calls) == 1
+    now[0] += 3600
+    dispatcher.retry_pending()
+    assert len(calls) == 1 and not dispatcher._pending and not dispatcher._retry_after
+
+
+def test_successful_sink_dedup_survives_configuration_changes():
+    calls = []
+    class Destination:
+        def send(self, ev, cfg=None):
+            calls.append(ev)
+    cfg = config()
+    dispatcher = Dispatcher([Destination()], cfg_provider=lambda: cfg)
+    assert dispatcher.dispatch(event())
+    cfg["unrelated_setting"] = True
+    assert not dispatcher.dispatch(event())
+    assert len(calls) == 1
+
+
+def test_watcher_shutdown_stops_its_retry_worker():
+    from threading import Thread
+    from providers.scrobble.watch_manager import WatchGroup, WatchManager, _retry_deliveries
+
+    watcher = SimpleNamespace(stop=lambda: None, is_alive=lambda: False)
+    group = WatchGroup("plex", "default", watcher, [], 0)
+    app = SimpleNamespace(state=SimpleNamespace(watch_groups={"plex:default": group}))
+    thread = Thread(target=_retry_deliveries, args=(group,), daemon=True)
+    thread.start()
+    WatchManager(app).stop_all()
+    thread.join(timeout=2)
+    assert group.retry_stop.is_set() and not thread.is_alive()
+
+
+def test_plex_sink_context_does_not_escape_or_cross_threads(harness, monkeypatch):
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+    from providers.sync import _mod_PLEX
+    from providers.sync.plex import _common
+
+    monkeypatch.setattr(_common, "_PLEX_CTX", {"baseurl": "http://source", "token": "source", "account_token": "source-cloud"})
+    barrier = Barrier(2)
+    original = _mod_PLEX.PLEXModule
+    def adapter(cfg):
+        token = cfg["plex"]["pms_token"]
+        _common.configure_plex_context(baseurl=cfg["plex"]["server_url"], token=token, account_token=token)
+        barrier.wait(timeout=5)
+        assert _common.plex_context()["token"] == token
+        assert _common._PLEX_CTX["token"] == "source"
+        return original(cfg)
+    monkeypatch.setattr(_mod_PLEX, "PLEXModule", adapter)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(plex.PlexSink()._new_adapter, scrobble_sink_config(config(), "plex", inst)) for inst in ("default", "P01")]
+        for future in futures:
+            future.result(timeout=10)
+    assert _common.plex_context() == {"baseurl": "http://source", "token": "source", "account_token": "source-cloud"}
+
+
+def test_plex_context_is_restored_after_scoped_delivery_failure(harness, monkeypatch):
+    from providers.sync.plex import _common
+
+    monkeypatch.setattr(_common, "_PLEX_CTX", {"baseurl": "http://source", "token": "source", "account_token": "cloud"})
+    def enter(adapter):
+        _common.configure_plex_context(baseurl="http://destination", token="destination-user")
+        return True, True, 2, "destination-user"
+    def leave(adapter, switched):
+        assert switched
+        assert _common.plex_context()["token"] == "destination-user"
+        _common.configure_plex_context(baseurl="http://destination", token="destination-owner")
+    monkeypatch.setattr(plex, "home_scope_enter", enter)
+    monkeypatch.setattr(plex, "home_scope_exit", leave)
+    harness[0].fail_write = True
+    assert not plex.PlexSink().send(event(), config())["ok"]
+    assert _common.plex_context()["token"] == "source"
+
+
+def test_plex_active_session_guard_uses_authenticated_destination_user(harness, monkeypatch):
+    from providers.sync import _mod_PLEX
+
+    server, _, _ = harness
+    original = _mod_PLEX.PLEXModule
+    def adapter(cfg):
+        result = original(cfg)
+        result.client.user_account_id = 2
+        result.client.user_username = "backup"
+        return result
+    monkeypatch.setattr(_mod_PLEX, "PLEXModule", adapter)
+    server.playing = [SimpleNamespace(ratingKey="10", accountID=1, usernames=["source-user"])]
+    assert plex.PlexSink().send(event(), config())["ok"]
+
+
+def test_missing_target_is_cached_and_rechecked_after_expiry(harness, monkeypatch):
+    now = [100.0]
+    monkeypatch.setattr(common.time, "monotonic", lambda: now[0])
+    server, _, _ = harness
+    server.items.clear()
+    sink = plex.PlexSink()
+    assert sink.send(event(), config())["error"] == "unmatched_in_plex"
+    calls = len(server.calls)
+    server.items["10"] = media()
+    assert sink.send(event(), config())["error"] == "unmatched_in_plex"
+    assert len(server.calls) == calls
+    now[0] += 300
+    assert sink.send(event(), config())["ok"]
+
+
+def test_session_close_failure_does_not_prevent_reconnection(harness, monkeypatch):
+    now = [100.0]
+    monkeypatch.setattr(common.time, "monotonic", lambda: now[0])
+    server, configs, _ = harness
+    def failed_close():
+        raise RuntimeError("closed transport")
+    server._session.close = failed_close
+    sink = plex.PlexSink()
+    assert sink.send(event(action="pause", progress=10), config())["ok"]
+    now[0] += common.CACHE_TTL
+    assert sink.send(event(), config())["ok"]
+    assert len(configs) == 2
+
+
+def test_management_rejects_self_routes_before_credentials():
+    from api.scrobblerManagementAPI import ValidationFailure, _validate_route
+    for provider in ("plex", "jellyfin", "emby", "kodi", "scrob"):
+        assert same_scrobble_endpoint(provider.upper(), " Default ", provider, "default")
+    with pytest.raises(ValidationFailure) as exc:
+        _validate_route(config(), {"provider": "plex", "sink": "plex"})
+    assert "same_source_destination" in str(exc.value.errors)
+
+
+def test_management_webhook_rejects_implicit_self_instance(monkeypatch):
+    from api import scrobblerManagementAPI as api
+    cfg = config()
+    monkeypatch.setattr(api, "load_config", lambda: cfg)
+    monkeypatch.setattr(api, "_save_and_runtime", lambda *a: pytest.fail("must not save invalid route"))
+    response = api.api_profile_webhook_save(None, {"provider": "plex", "sinks": ["plex"]})
+    assert response.status_code == 400
+    assert b"same_source_destination" in response.body
+
+
+def test_missing_destination_instance_does_not_fall_back_to_default():
+    from providers.webhooks.config import sink_configured
+    assert not sink_configured(config(), "plex", "missing")
+
+
+@pytest.mark.parametrize("source,target", [("default", "P01"), ("P01", "default")])
+def test_management_accepts_cross_instance_routes(monkeypatch, source, target):
+    from api import scrobblerManagementAPI as api
+    cfg = config()
+    route = api._validate_route(cfg, {"provider": "plex", "provider_instance": source, "sink": "plex", "sink_instance": target})
+    assert route["sink_instance"] == target
+    cfg["scrobble"]["webhook"] = {}
+    monkeypatch.setattr(api, "load_config", lambda: cfg)
+    monkeypatch.setattr(api, "_ensure_media_profile_webhook_ids", lambda *a, **k: [])
+    monkeypatch.setattr(api, "_save_and_runtime", lambda req, before, after: {"ok": True, "config": after})
+    result = api.api_profile_webhook_save(None, {"provider": "plex", "provider_instance": source, "sinks": ["plex"], "sink_instances": {"plex": target}})
+    assert result.status_code == 200
+    node = json.loads(result.body)["config"]["scrobble"]["webhook"]["profiles"]["plex"][source]
+    assert node["sink_instances"] == {"plex": target}
+
+
+def test_watcher_self_route_is_blocked_even_with_a_custom_sink():
+    class Sink:
+        def send(self, event):
+            pytest.fail("self route must not dispatch")
+    cfg = build_route_cfg(config(), {"provider": "plex", "sink": "plex"})
+    assert not Dispatcher([Sink()], cfg_provider=lambda: cfg).dispatch(event())
+
+
+def test_destination_change_does_not_reuse_completion_acknowledgement(harness):
+    server, configs, _ = harness
+    dest = plex.PlexSink()
+    assert dest.send(event(), config())["ok"]
+    cfg = config()
+    cfg["plex"]["pms_token"] = "replacement-token"
+    server.items["10"].viewCount = 0
+    assert dest.send(event(), cfg) == {"ok": True}
+    assert len(configs) == 2
+
+
+def test_existing_watched_item_is_not_unwatched_by_partial_scrobble(harness):
+    server, _, _ = harness
+    server.items["10"].viewCount = 1
+    result = plex.PlexSink().send(event(action="pause", progress=30), config())
+    assert result["reason"] == "destination_already_watched"
+    assert not any(x[1] for x in server.calls)
+
+
+def test_scrobbler_instance_dropdowns():
+    import shutil
+    import subprocess
+    from pathlib import Path
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for modal behavior checks")
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run([node, "--test", "tests/scrobbler-sink-instances.test.mjs"], cwd=root,
+                            capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_plex_watcher_session_identity.py
+++ b/tests/test_plex_watcher_session_identity.py
@@ -354,7 +354,7 @@ def test_route_fallback_and_send_logs_name_the_route(monkeypatch: pytest.MonkeyP
 
     assert messages == [
         "route R2 plex->mdblist: unresolved user fallback used user=ow*** sess=30",
-        "route R2 plex->mdblist: sent start user=ow*** sess=30",
+        "route R2 plex->mdblist: accepted start user=ow*** p=5.0 sess=30",
     ]
 
 
@@ -867,4 +867,3 @@ def test_route_filtered_log_is_emitted_once_per_session(monkeypatch: pytest.Monk
 
     assert sink.events == []
     assert len([m for m in messages if m.startswith("event filtered by route dispatcher")]) == 1
-

--- a/tests/test_provider_usage_coverage.py
+++ b/tests/test_provider_usage_coverage.py
@@ -39,9 +39,12 @@ def test_every_webhook_sink_is_protected_from_deletion(sink: str):
 
 
 @pytest.mark.parametrize("sink", sorted(ROUTE_SINKS))
-def test_a_sink_that_is_not_selected_stays_deletable(sink: str):
+def test_a_sink_that_is_not_selected_has_no_sink_usage(sink: str):
     others = [s for s in sorted(ROUTE_SINKS) if s != sink]
-    assert find_provider_usage(webhook_cfg(others), sink) == []
+    usages = find_provider_usage(webhook_cfg(others), sink)
+    assert not any(u["role"] == "sink" for u in usages)
+    if sink not in WEBHOOK_SOURCE_PROVIDERS:
+        assert usages == []
 
 
 @pytest.mark.parametrize("provider", sorted(ROUTE_PROVIDERS))
@@ -151,28 +154,18 @@ def read_asset(rel: str) -> str:
     return (Path(__file__).resolve().parents[1] / rel).read_text(encoding="utf-8", errors="ignore")
 
 
-def test_route_modal_never_offers_a_provider_as_its_own_destination():
-    js = read_asset("assets/js/modals/scrobbler-route/index.js")
+@pytest.mark.parametrize("modal", ["watcher", "webhook"])
+def test_modals_enforce_instance_scoped_destinations(modal: str):
+    import shutil
+    import subprocess
+    from pathlib import Path
 
-    assert 'function sinkProviders(selected = "", source = "") {' in js
-    assert 'const available = sinks.filter((p) => p !== self && allSinkProfiles(p).length);' in js
-    assert 'if (current === self) return available;' in js
-
-    assert 'function ratingSinkProviders(selected = [], source = "") {' in js
-    assert 'ratingSinks.includes(x) && x !== self' in js
-
-    assert 'optionsForProviders("sink", r.sink, r.provider)' in js
-    assert 'const sink = sinkProviders("", srcProvider)[0] || "";' in js
-    assert 'ratingSinkProviders(ratingTargets, r.provider)' in js
-    assert 'if (draft.sink === draft.provider) draft.sink = sinkProviders("", draft.provider)[0] || "";' in js
-
-
-def test_webhook_modal_never_offers_a_provider_as_its_own_destination():
-    js = read_asset("assets/js/modals/scrobbler-webhook/index.js")
-
-    assert "function sourceProviderKey() {" in js
-    assert "return sinks.filter((s) => s !== self && sinkProfiles(s).length > 0);" in js
-    assert "return ratingSinks.filter((s) => s !== self && sinkProfiles(s).length > 0);" in js
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("Node.js unavailable")
+    result = subprocess.run([node, "--test", f"--test-name-pattern={modal}", "tests/scrobbler-sink-instances.test.mjs"],
+                            cwd=Path(__file__).resolve().parents[1], capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_both_modals_offer_every_route_sink():
@@ -183,7 +176,11 @@ def test_both_modals_offer_every_route_sink():
         assert offered == ROUTE_SINKS, f"{rel} offers {offered}, ROUTE_SINKS is {ROUTE_SINKS}"
 
 
-def test_scrob_is_the_only_provider_that_could_self_route():
-    from providers.scrobble.routes import ROUTE_PROVIDERS
+@pytest.mark.parametrize("provider", sorted(ROUTE_PROVIDERS & ROUTE_SINKS))
+def test_source_providers_require_distinct_destination_instances(provider: str):
+    from providers.scrobble.routes import same_scrobble_endpoint
 
-    assert ROUTE_PROVIDERS & ROUTE_SINKS == {"scrob"}
+    assert same_scrobble_endpoint(provider, "default", provider, "default")
+    assert same_scrobble_endpoint(provider, "P01", provider, "P01")
+    assert not same_scrobble_endpoint(provider, "default", provider, "P01")
+    assert not same_scrobble_endpoint(provider, "P01", provider, "default")

--- a/tests/test_scrobble_dispatch_retries.py
+++ b/tests/test_scrobble_dispatch_retries.py
@@ -1,0 +1,296 @@
+# tests/test_scrobble_dispatch_retries.py
+# CrossWatch - Scrobble Retry Isolation and Concurrency Regression Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from dataclasses import replace
+from threading import Event, Thread
+from typing import Any
+
+import pytest
+
+from providers.scrobble.scrobble import Dispatcher, ScrobbleEvent
+
+
+def event(**changes):
+    return replace(ScrobbleEvent("start", "episode", {"tmdb": "10"}, "Series", 2020, 1, 1, 10,
+                                "user", "server", "session", {}), **changes)
+
+
+@pytest.fixture
+def setup(monkeypatch):
+    now = [100.0]
+    monkeypatch.setattr("providers.scrobble.scrobble.time.monotonic", lambda: now[0])
+    cfg = {"jellyfin": {"server": "http://destination", "user_id": "user", "access_token": "token"},
+           "scrobble": {"watch": {"route_provider": "plex", "route_provider_instance": "default",
+                                   "route_sink": "jellyfin", "route_sink_instance": "default"}}}
+    return cfg, now
+
+
+@pytest.mark.parametrize("unrelated", [{"theme": "dark"}, {"trakt": {"access_token": "refreshed"}}])
+def test_unrelated_config_edits_keep_pending_delivery(setup, unrelated):
+    cfg, now = setup
+    calls = []
+    class Sink:
+        def send(self, event, cfg=None) -> Any:
+            calls.append(event.session_key)
+            return {"ok": len(calls) > 1}
+    dispatcher = Dispatcher([Sink()], cfg_provider=lambda: cfg)
+    dispatcher.dispatch(event())
+    cfg.update(unrelated)
+    now[0] += 30
+    dispatcher.retry_pending()
+    assert calls == ["session", "session"] and not dispatcher._pending
+
+
+def test_enriched_ids_do_not_reset_session_dedup(setup):
+    cfg, _ = setup
+    calls = []
+    class Sink:
+        def send(self, event, cfg=None) -> Any:
+            calls.append(event)
+    dispatcher = Dispatcher([Sink()], cfg_provider=lambda: cfg)
+    dispatcher.dispatch(event())
+    dispatcher.dispatch(event(ids={"tmdb": "10", "imdb": "tt1234567"}))
+    assert len(calls) == 1
+
+
+def test_new_ids_allow_retry_after_a_previous_resolution_miss(setup):
+    cfg, _ = setup
+    calls = []
+    class Sink:
+        def send(self, event, cfg=None) -> Any:
+            calls.append(event)
+            return {"ok": bool(event.ids.get("imdb")), "retryable": False}
+    dispatcher = Dispatcher([Sink()], cfg_provider=lambda: cfg)
+    dispatcher.dispatch(event())
+    assert dispatcher.dispatch(event(ids={"tmdb": "10", "imdb": "tt1234567"}))
+    assert len(calls) == 2
+
+
+@pytest.mark.parametrize("changes", [{"account": "other"}, {"server_uuid": "other"}, {"number": 2},
+                                      {"raw": {"NowPlayingItem": {"Id": "other-movie"}}}])
+def test_session_dedup_keeps_accounts_servers_and_items_separate(setup, changes):
+    cfg, _ = setup
+    calls = []
+    class Sink:
+        def send(self, event, cfg=None) -> Any:
+            calls.append(event)
+    dispatcher = Dispatcher([Sink()], cfg_provider=lambda: cfg)
+    dispatcher.dispatch(event())
+    dispatcher.dispatch(event(**changes))
+    assert len(calls) == 2
+
+
+def test_retry_pass_is_bounded_and_loads_config_once(setup):
+    cfg, now = setup
+    loads, calls = [], []
+    def config():
+        loads.append(True)
+        return cfg
+    class Sink:
+        def send(self, event, cfg=None) -> Any:
+            calls.append(event.session_key)
+            return {"ok": False, "retryable": True}
+    dispatcher = Dispatcher([Sink()], cfg_provider=config)
+    for index in range(9):
+        dispatcher.dispatch(event(session_key=str(index)))
+    now[0] += 30
+    calls.clear()
+    loads.clear()
+    dispatcher.retry_pending()
+    assert len(calls) == 4 and len(loads) == 1
+
+
+def test_failed_retry_keeps_newest_ids_and_progress(setup):
+    cfg, now = setup
+    calls = []
+    class Sink:
+        def send(self, event, cfg=None) -> Any:
+            calls.append(event)
+            return {"ok": len(calls) > 1}
+    dispatcher = Dispatcher([Sink()], cfg_provider=lambda: cfg)
+    dispatcher.dispatch(event())
+    dispatcher.dispatch(event(action="stop", progress=95, ids={"tmdb": "10", "imdb": "tt1234567"}))
+    assert len(dispatcher._pending) == 1
+    now[0] += 30
+    dispatcher.retry_pending()
+    assert len(calls) == 2 and calls[1].action == "stop" and "imdb" in calls[1].ids
+
+
+def test_live_completion_replaces_an_older_retry_after_backoff(setup):
+    cfg, now = setup
+    calls = []
+    class Sink:
+        def send(self, event, cfg=None) -> Any:
+            calls.append(event.action)
+            return {"ok": len(calls) > 1}
+    dispatcher = Dispatcher([Sink()], cfg_provider=lambda: cfg)
+    dispatcher.dispatch(event())
+    now[0] += 30
+    assert dispatcher.dispatch(event(action="stop", progress=95))
+    dispatcher.retry_pending()
+    assert calls == ["start", "stop"] and not dispatcher._pending
+
+
+def test_changing_another_destination_instance_keeps_pending_delivery(setup):
+    cfg, now = setup
+    cfg["jellyfin"]["instances"] = {"P01": {"server": "http://other"}}
+    calls = []
+    class Sink:
+        def send(self, event, cfg=None) -> Any:
+            calls.append(event)
+            return {"ok": len(calls) > 1}
+    dispatcher = Dispatcher([Sink()], cfg_provider=lambda: cfg)
+    dispatcher.dispatch(event())
+    cfg["jellyfin"]["instances"]["P01"]["server"] = "http://changed"
+    now[0] += 30
+    dispatcher.retry_pending()
+    assert len(calls) == 2 and not dispatcher._pending
+
+
+def test_live_stop_does_not_wait_for_retry_io_and_is_not_overwritten(setup):
+    cfg, now = setup
+    entered, release, finished = Event(), Event(), Event()
+    calls = []
+    class Sink:
+        def send(self, event, cfg=None) -> Any:
+            calls.append(event.action)
+            if len(calls) == 1:
+                return {"ok": False, "retryable": True}
+            if len(calls) == 2:
+                entered.set()
+                assert release.wait(3)
+            return {"ok": True}
+    dispatcher = Dispatcher([Sink()], cfg_provider=lambda: cfg)
+    dispatcher.dispatch(event())
+    now[0] += 30
+    retry = Thread(target=dispatcher.retry_pending)
+    retry.start()
+    assert entered.wait(1)
+    def live_stop():
+        try:
+            dispatcher.dispatch(event(action="stop", progress=95))
+        finally:
+            finished.set()
+    live = Thread(target=live_stop)
+    live.start()
+    try:
+        assert finished.wait(0.5)
+    finally:
+        release.set()
+        retry.join(2)
+        live.join(2)
+    dispatcher.retry_pending()
+    assert calls == ["start", "start", "stop"]
+    assert not dispatcher._pending
+
+
+def test_reconfigured_destination_is_not_acknowledged_by_old_inflight_delivery(setup):
+    cfg, _ = setup
+    entered, release = Event(), Event()
+    calls = []
+    class Sink:
+        def send(self, event, cfg=None) -> Any:
+            assert cfg is not None
+            calls.append(cfg["jellyfin"]["user_id"])
+            if len(calls) == 1:
+                entered.set()
+                assert release.wait(3)
+            return {"ok": True}
+    dispatcher = Dispatcher([Sink()], cfg_provider=lambda: cfg)
+    original = Thread(target=lambda: dispatcher.dispatch(event()))
+    original.start()
+    assert entered.wait(1)
+    try:
+        cfg["jellyfin"]["user_id"] = "replacement"
+        assert dispatcher.dispatch(event())
+    finally:
+        release.set()
+        original.join(2)
+    dispatcher.retry_pending()
+    assert calls == ["user", "replacement"] and not dispatcher._pending
+
+
+def test_old_retry_snapshot_cannot_cancel_a_new_route_queue(setup):
+    cfg, now = setup
+    class Sink:
+        def send(self, event, cfg=None) -> Any:
+            return {"ok": False, "retryable": True}
+    dispatcher = Dispatcher([Sink()], cfg_provider=lambda: cfg)
+    dispatcher.dispatch(event())
+    old_identity = dispatcher._config_identity
+    old_key = next(iter(dispatcher._pending))
+    cfg["jellyfin"]["user_id"] = "replacement"
+    dispatcher.dispatch(event(session_key="new-session"))
+    current = list(dispatcher._pending)
+    now[0] += 30
+    assert not dispatcher._dispatch(event(), retry_key=old_key, cfg=cfg, config_identity=old_identity)
+    assert list(dispatcher._pending) == current
+
+
+def test_slow_retry_yields_before_attempting_the_rest_of_the_batch(setup):
+    cfg, now = setup
+    calls = []
+    slow = [False]
+    class Sink:
+        def send(self, event, cfg=None) -> Any:
+            calls.append(event.session_key)
+            if slow[0]:
+                now[0] += 2
+            return {"ok": False, "retryable": True}
+    dispatcher = Dispatcher([Sink()], cfg_provider=lambda: cfg)
+    for index in range(5):
+        dispatcher.dispatch(event(session_key=str(index)))
+    now[0] += 30
+    slow[0] = True
+    calls.clear()
+    dispatcher.retry_pending()
+    assert calls == ["0"]
+
+
+def test_permanent_failure_identity_cache_is_bounded(setup, monkeypatch):
+    cfg, _ = setup
+    monkeypatch.setattr("providers.scrobble.scrobble._log", lambda *a, **kw: None)
+    calls = []
+    class Sink:
+        def send(self, event, cfg=None) -> Any:
+            calls.append(event.session_key)
+            return {"ok": False, "retryable": False}
+    sink = Sink()
+    dispatcher = Dispatcher([sink], cfg_provider=lambda: cfg)
+    for index in range(1025):
+        dispatcher.dispatch(event(session_key=str(index)))
+    assert not dispatcher._pending
+    assert len(dispatcher._failed_ids) == 1024
+    assert dispatcher._session_key(sink, event(session_key="0")) not in dispatcher._failed_ids
+    dispatcher.dispatch(event(session_key="0", ids={"tmdb": "10", "imdb": "tt1234567"}))
+    assert calls.count("0") == 2
+
+
+@pytest.mark.parametrize("retry", [False, True])
+def test_sink_interruption_always_releases_inflight_and_allows_redelivery(setup, retry):
+    cfg, now = setup
+    calls = []
+    class Interrupted(BaseException):
+        pass
+    class Sink:
+        def send(self, event, cfg=None) -> Any:
+            calls.append(event)
+            if retry and len(calls) == 1:
+                return {"ok": False, "retryable": True}
+            if len(calls) == (2 if retry else 1):
+                raise Interrupted()
+            return {"ok": True}
+    dispatcher = Dispatcher([Sink()], cfg_provider=lambda: cfg)
+    if retry:
+        dispatcher.dispatch(event())
+        now[0] += 30
+    with pytest.raises(Interrupted):
+        if retry:
+            dispatcher.retry_pending()
+        else:
+            dispatcher.dispatch(event())
+    assert not dispatcher._inflight
+    assert dispatcher.dispatch(event())
+    assert not dispatcher._pending

--- a/tests/test_scrobble_history_identity.py
+++ b/tests/test_scrobble_history_identity.py
@@ -1,0 +1,234 @@
+# tests/test_scrobble_history_identity.py
+# CrossWatch - Scrobble History Identity Regression Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+from importlib import import_module
+from types import SimpleNamespace
+
+import pytest
+
+from cw_platform.id_map import canonical_key, keys_for_item, minimal
+from providers.scrobble.crosswatch import sink as crosswatch
+from providers.scrobble.scrobble import ScrobbleEvent
+
+
+def episode_event(ids: dict[str, str], title: str | None = "Series") -> ScrobbleEvent:
+    return ScrobbleEvent("stop", "episode", ids, title, 2020, 0, 2, 95,
+                         "user", "server", "session", {})
+
+
+@pytest.mark.parametrize("ids,expected", [
+    ({"imdb": "tt1234567", "tmdb": "10", "tvdb": "20", "plex": "native", "jellyfin": "native", "emby": "native",
+      "trakt": "30", "simkl": "40", "slug": "episode"}, {"imdb": "tt1234567", "tmdb": "10", "tvdb": "20"}),
+    ({"imdb": "tt1111111", "imdb_episode": "tt2222222"}, {"imdb": "tt2222222"}),
+    ({"tmdb": "10", "tmdb_show": "10", "tvdb_episode": "20", "tvdb_show": "20"}, {}),
+])
+def test_crosswatch_preserves_only_episode_provider_ids(monkeypatch, ids, expected):
+    monkeypatch.setattr(crosswatch, "_tmdb_enrich", lambda *a, **kw: {})
+    item = crosswatch._item_from_event(episode_event(ids), {}, 95)
+    assert item is not None
+    assert item.get("ids", {}) == expected
+    assert item["season"] == 0 and item["episode"] == 2
+
+
+def test_episode_id_is_rejected_when_it_matches_enriched_show_identity(monkeypatch):
+    monkeypatch.setattr(crosswatch, "_tmdb_enrich", lambda *a, **kw: {"ids": {"tmdb": "10"}, "title": "Series"})
+    item = crosswatch._item_from_event(episode_event({"tmdb_episode": "10", "imdb_episode": "tt1234567"}), {}, 95)
+    assert item is not None
+    assert item.get("ids") == {"imdb": "tt1234567"}
+    assert item["show_ids"] == {"tmdb": "10"}
+
+
+@pytest.mark.parametrize("show_ids", [None, {}, {"unsupported": "10"}])
+def test_legacy_episode_keys_keep_show_ids_and_coordinates(show_ids):
+    item = {"type": "episode", "ids": {"tmdb": "1399"}, "season": 1, "episode": 4}
+    if show_ids is not None:
+        item["show_ids"] = show_ids
+    for candidate in (item, minimal(item)):
+        assert canonical_key(candidate) == "tmdb:1399#s01e04"
+        assert canonical_key(candidate) in keys_for_item(candidate)
+        other = {**candidate, "episode": 5}
+        assert canonical_key(other) == "tmdb:1399#s01e05"
+        assert canonical_key(candidate) != canonical_key(other)
+
+
+@pytest.mark.parametrize("show_ids", [{}, {"mdblist_show": "10"}])
+def test_crosswatch_skips_episode_without_show_identity(monkeypatch, show_ids):
+    monkeypatch.setattr(crosswatch, "_tmdb_enrich", lambda *a, **kw: {})
+    item = crosswatch._item_from_event(episode_event({"imdb_episode": "tt1234567", **show_ids}, title=None), {}, 95)
+    assert item is None
+
+
+@pytest.mark.parametrize("namespace", ["mal", "anilist", "anidb", "kitsu", "simkl"])
+@pytest.mark.parametrize("season", [0, 2])
+def test_anime_only_show_identity_survives_crosswatch_for_simkl(monkeypatch, namespace, season):
+    from dataclasses import replace
+    from providers.sync.crosswatch import _history as tracker_history
+    from providers.sync.simkl import _history as simkl_history
+
+    monkeypatch.setattr(crosswatch, "_tmdb_enrich", lambda *a, **kw: {})
+    raw = {"_cw_anime_map": {"namespace": namespace, "target_id": "813", "absolute": 52},
+           "_anime_absolute": 52, "_simkl_episode_number": 52, "simkl_bucket": "anime", "anime_type": "tv"}
+    event = replace(episode_event({f"{namespace}_show": "813", "tvdb_episode": "999001"}, title=None),
+                    season=season, raw=raw)
+    item = crosswatch._item_from_event(event, {}, 95)
+    assert item is not None
+    item["watched_at"] = "2026-09-01T12:00:00Z"
+    adapter = SimpleNamespace()
+    stored = tracker_history._history_minimal(adapter, tracker_history._accepted(item))
+    assert tracker_history._history_key(adapter, stored) == f"{namespace}:813#s{season:02d}e02"
+    assert stored["ids"] == {"tvdb": "999001"}
+    assert simkl_history._show_ids_of_episode(stored) == {namespace: "813"}
+    assert stored["season"] == season and stored["episode"] == 2
+    for field, value in raw.items():
+        assert stored[field] == value
+
+
+def test_legacy_episode_key_cannot_collide_with_movie_or_show():
+    ids = {"tmdb": "10"}
+    episode = {"type": "episode", "ids": ids, "season": 0, "episode": 2}
+    assert canonical_key(episode) == "tmdb:10#s00e02"
+    assert canonical_key(episode) != canonical_key({"type": "movie", "ids": ids})
+    assert canonical_key(episode) != canonical_key({"type": "show", "ids": ids})
+
+
+@pytest.mark.parametrize("show_ids,expected_key", [({}, "slug:series#s00e02"), ({"tmdb_show": "10"}, "tmdb:10#s00e02")])
+@pytest.mark.parametrize("provider", ["jellyfin", "emby"])
+def test_tracker_episode_ids_reach_destination_id_resolver(monkeypatch, provider, show_ids, expected_key):
+    from providers.sync.crosswatch import _history as tracker_history
+
+    monkeypatch.setattr(crosswatch, "_tmdb_enrich", lambda *a, **kw: {})
+    item = crosswatch._item_from_event(episode_event({"imdb_episode": "tt1234567", **show_ids}), {}, 95)
+    assert item is not None
+    item["watched_at"] = "2026-09-01T12:00:00Z"
+    item = tracker_history._accepted(item)
+    adapter = SimpleNamespace(client=SimpleNamespace(), cfg=SimpleNamespace(user_id="user", strict_id_matching=True))
+    assert tracker_history._history_key(adapter, item) == expected_key
+    assert "imdb:tt1234567#s00e02" not in keys_for_item(item)
+    history = import_module(f"providers.sync.{provider}._history")
+    common = import_module(f"providers.sync.{provider}._common")
+    target_id = "1234567890abcdef1234567890abcdef"
+    row = {"Id": target_id, "Type": "Episode", "ProviderIds": {"Imdb": "tt1234567"}, "ParentIndexNumber": 0, "IndexNumber": 2}
+    if provider == "jellyfin":
+        _, prepared, error = history._prepare_want(item)
+        assert error is None
+        monkeypatch.setattr(common, "_targeted_lookup_item_id", lambda *a, **kw: None)
+        monkeypatch.setattr(common, "build_provider_index", lambda *a, **kw: {"imdb.tt1234567": [row]})
+    else:
+        prepared, _ = history._normalize_for_write(item)
+        def query(http, uid, pairs, kind, scope):
+            assert pairs == ["imdb.tt1234567"]
+            assert kind == "Episode,Series"
+            return [row]
+        monkeypatch.setattr(common, "_direct_query_by_pairs", query)
+    assert prepared is not None
+    assert prepared["watched_at"] == item["watched_at"]
+    assert common.resolve_item_id(adapter, prepared) == target_id
+
+
+@pytest.mark.parametrize("provider", ["jellyfin", "emby"])
+@pytest.mark.parametrize("ids", [None, {}, {"imdb": "tt1234567"}])
+def test_history_write_preserves_metadata_without_episode_ids(provider, ids):
+    module = import_module(f"providers.sync.{provider}._history")
+    item = {"type": "episode", "title": "Special", "series_title": "Series", "season": 0, "episode": 2,
+            "watched_at": "2026-09-01T12:00:00Z", "show_ids": {"tmdb": "10"}, "series_year": 2020}
+    if ids is not None:
+        item["ids"] = ids
+    if provider == "jellyfin":
+        key, prepared, error = module._prepare_want(item)
+        assert error is None and key == "tmdb:10#s00e02"
+    else:
+        prepared, _ = module._normalize_for_write(item)
+    assert prepared is not None
+    for field, value in item.items():
+        assert prepared.get(field) == value
+    assert canonical_key(prepared) == "tmdb:10#s00e02"
+
+
+def test_jellyfin_progress_uses_supported_fields_and_keeps_user_timestamp():
+    from providers.sync.jellyfin import _progress
+
+    row = {"Id": "movie", "Type": "Movie", "Name": "Movie", "ProviderIds": {"Tmdb": "10"},
+           "RunTimeTicks": 1_000_000_000,
+           "UserData": {"PlaybackPositionTicks": 300_000_000, "PlayCount": 1, "LastPlayedDate": "2026-09-01T12:00:00Z"}}
+    calls = []
+    class Http:
+        def get(self, path, params=None):
+            assert params is not None
+            calls.append((path, params))
+            assert set(params.get("Fields", "").split(",")) <= {"ProviderIds", "ParentId"}
+            assert params["EnableUserData"] is True
+            return SimpleNamespace(status_code=200, json=lambda: {"Items": [row], "TotalRecordCount": 1})
+    adapter = SimpleNamespace(client=Http(), cfg=SimpleNamespace(user_id="user"))
+    result = _progress.build_index(adapter)
+    assert result["tmdb:10"]["progress_at"] == "2026-09-01T12:00:00Z"
+    assert result["tmdb:10"]["progress_ms"] == 30_000
+    assert len(calls) == 1
+
+
+def test_jellyfin_progress_revalidates_scope_without_membership_fields():
+    from providers.sync.jellyfin import _progress
+
+    rows = [{"Id": str(index), "Type": "Movie", "Name": "Movie", "ParentId": parent,
+             "ProviderIds": {"Tmdb": str(index)}, "UserData": {"PlaybackPositionTicks": 300_000_000}}
+            for index, parent in enumerate(("folder", "folder", "outside", "library-b"), 1)]
+    calls = []
+
+    class Http:
+        def get(self, path, params=None):
+            assert params is not None and params["userId"] == "user"
+            calls.append(path)
+            if path == "/Items":
+                assert params["ParentId"] in {"library-a", "library-b"}
+                body = {"Items": rows, "TotalRecordCount": len(rows)}
+            elif path == "/Items/folder/Ancestors":
+                body = [{"Id": "library-b"}, {"Id": "root"}]
+            elif path == "/Items/outside/Ancestors":
+                body = [{"Id": "library-c"}, {"Id": "root"}]
+            else:
+                pytest.fail(f"Unexpected request: {path}")
+            return SimpleNamespace(status_code=200, json=lambda: body)
+
+    adapter = SimpleNamespace(client=Http(), cfg=SimpleNamespace(user_id="user", progress_libraries=["library-a", "library-b"]))
+    for _ in range(2):
+        result = _progress.build_index(adapter)
+        assert set(result) == {"tmdb:1", "tmdb:2", "tmdb:4"}
+        assert all(item["library_id"] == "library-b" for item in result.values())
+    assert calls.count("/Items/folder/Ancestors") == 2
+    assert calls.count("/Items/outside/Ancestors") == 2
+
+
+@pytest.mark.parametrize("status,body", [(503, []), (200, {"Items": []})])
+def test_jellyfin_progress_does_not_return_an_index_when_scope_cannot_be_verified(status, body):
+    from providers.sync.jellyfin import _progress
+
+    class Http:
+        def get(self, path, params=None):
+            assert params is not None and params["userId"] == "user"
+            if path == "/Items":
+                row = {"Id": "movie", "Type": "Movie", "ProviderIds": {"Tmdb": "10"},
+                       "UserData": {"PlaybackPositionTicks": 300_000_000}}
+                return SimpleNamespace(status_code=200, json=lambda: {"Items": [row], "TotalRecordCount": 1})
+            assert path == "/Items/movie/Ancestors"
+            return SimpleNamespace(status_code=status, json=lambda: body)
+
+    adapter = SimpleNamespace(client=Http(), cfg=SimpleNamespace(user_id="user", progress_libraries=["library"]))
+    with pytest.raises(RuntimeError, match="progress_library_scope_"):
+        _progress.build_index(adapter)
+
+
+@pytest.mark.parametrize("field,value", [("LibraryId", "library"), ("CollectionFolderId", "library"), ("AncestorIds", ["library"])])
+def test_jellyfin_progress_retains_supplied_library_membership(field, value):
+    from providers.sync.jellyfin import _progress
+
+    class Http:
+        def get(self, path, params=None):
+            assert path == "/Items"
+            rows = [{"Id": str(index), "Type": "Movie", "ProviderIds": {"Tmdb": str(index)}, field: membership,
+                     "UserData": {"PlaybackPositionTicks": 300_000_000}}
+                    for index, membership in enumerate((value, ["outside"] if isinstance(value, list) else "outside"), 1)]
+            return SimpleNamespace(status_code=200, json=lambda: {"Items": rows, "TotalRecordCount": 2})
+
+    adapter = SimpleNamespace(client=Http(), cfg=SimpleNamespace(user_id="user", progress_libraries=["library"]))
+    assert set(_progress.build_index(adapter)) == {"tmdb:1"}

--- a/tests/test_watcher_log_stream.py
+++ b/tests/test_watcher_log_stream.py
@@ -1,0 +1,82 @@
+# tests/test_watcher_log_stream.py
+# CrossWatch - Watcher Log Ordering and Timestamp Regression Tests
+# Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def logs(monkeypatch):
+    import crosswatch
+
+    monkeypatch.setattr(crosswatch, "WATCH_LOG_BUFFER", deque(maxlen=5))
+    monkeypatch.setattr(crosswatch, "WATCH_LOG_NEXT_SEQ", 1)
+    monkeypatch.setattr(crosswatch, "LOG_BUFFERS", {})
+    monkeypatch.setattr(crosswatch, "LOG_BASE_SEQ", {})
+    monkeypatch.setattr(crosswatch, "LOG_NEXT_SEQ", {})
+    monkeypatch.setattr("services.log_archive.capture", lambda *a, **kw: None)
+    stamp = datetime(2026, 9, 9, 21, 49, 2, tzinfo=timezone.utc)
+    monkeypatch.setattr(crosswatch, "datetime", SimpleNamespace(now=lambda *a: stamp))
+    return crosswatch
+
+
+def test_watcher_backlog_keeps_capture_time_and_cross_provider_order(logs):
+    logs._append_log_to_buffer("PLEX-WATCH", "INFO first")
+    logs._append_log_to_buffer("SCROBBLE", "DEBUG second")
+    logs._append_log_to_buffer("PLEX-WATCH", "INFO third")
+    cursor, rows = logs._watch_log_snapshot(["SCROBBLE", "PLEX-WATCH"], 0, 200)
+    assert cursor == 3
+    assert [row[1] for row in rows] == ["PLEX-WATCH", "SCROBBLE", "PLEX-WATCH"]
+    assert all(row[2].startswith("[2026-09-09T21:49:02.000+00:00]") for row in rows)
+    assert logs._watch_log_snapshot(["SCROBBLE", "PLEX-WATCH"], 0, 200) == (cursor, rows)
+
+
+def test_watcher_tail_filters_and_buffer_eviction_keep_order(logs):
+    for index in range(8):
+        logs._append_log_to_buffer("PLEX-WATCH" if index % 2 else "SCROBBLE", f"INFO row {index}")
+    cursor, rows = logs._watch_log_snapshot(["PLEX-WATCH", "SCROBBLE"], 0, 1)
+    assert cursor == 8 and [row[0] for row in rows] == [7, 8]
+    assert len(logs.WATCH_LOG_BUFFER) == 5
+    assert [row[0] for row in logs._watch_log_snapshot(["SCROBBLE"], 0, None)[1]] == [5, 7]
+    assert logs._watch_log_snapshot(["PLEX-WATCH"], cursor, None) == (8, [])
+
+
+@pytest.mark.parametrize("skip_backlog", [False, True])
+def test_watcher_stream_keeps_events_arriving_during_replay(logs, skip_backlog):
+    async def disconnected():
+        return False
+
+    async def collect():
+        logs._append_log_to_buffer("PLEX-WATCH", "INFO old source")
+        logs._append_log_to_buffer("SCROBBLE", "DEBUG old sink")
+        request = SimpleNamespace(state=SimpleNamespace(), is_disconnected=disconnected)
+        response = await logs.api_logs_watcher(request, tail=200, tags="SCROBBLE,PLEX-WATCH",
+                                               max_backlog=80, skip_backlog=skip_backlog, plain=True)
+        iterator = response.body_iterator
+        if skip_backlog:
+            async def arrival():
+                logs._append_log_to_buffer("PLEX-WATCH", "INFO live source")
+                return False
+            request.is_disconnected = arrival
+        else:
+            first = await anext(iterator)
+            assert "old source" in first and "2026-09-09T21:49:02.000+00:00" in first
+            logs._append_log_to_buffer("PLEX-WATCH", "INFO live source")
+            assert "old sink" in await anext(iterator)
+        assert "live source" in await anext(iterator)
+        await iterator.aclose()
+
+    asyncio.run(collect())
+
+
+def test_watcher_feed_keeps_multiline_text_in_one_sse_record(logs):
+    logs._append_log_to_buffer("PLEX-WATCH", "INFO <test>\nevent: forged")
+    _, rows = logs._watch_log_snapshot(["PLEX-WATCH"], 0, None)
+    line = logs._log_stream_text(rows[0][2], True)
+    assert "\n" not in line and "<test>" in line

--- a/tests/watcher-log-time.test.mjs
+++ b/tests/watcher-log-time.test.mjs
@@ -1,0 +1,29 @@
+/* tests/watcher-log-time.test.mjs */
+/* CrossWatch - Watcher Log Display Timestamp Regression Tests */
+/* Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch) */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+import vm from 'node:vm';
+
+const source = readFileSync(new URL('../assets/helpers/details-log.js', import.meta.url), 'utf8');
+const parser = source.slice(source.indexOf('function _plainLogText('), source.indexOf('function _cwUnresEsc('));
+const context = vm.createContext({_watchLogKnownTags: () => ['PLEX-WATCH', 'SCROBBLE']});
+vm.runInContext(parser, context);
+
+test('watcher replay uses the captured UTC timestamp converted to local time', () => {
+  const stamp = '2026-09-09T21:49:02.000+00:00';
+  const raw = `[${stamp}] [PLEX-WATCH] INFO event start episode p=18`;
+  const expected = new Date(stamp).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit', hour12:false});
+  for (let i = 0; i < 2; i++) {
+    const parsed = context._parseLogParts(raw, 'PLEX-WATCH');
+    assert.equal(parsed.time, expected);
+    assert.equal(parsed.provider, 'PLEX-WATCH');
+    assert.equal(parsed.level, 'INFO');
+    assert.equal(parsed.message, 'event start episode p=18');
+  }
+});
+
+test('existing timestamped lines keep their time', () => {
+  assert.equal(context._parseLogParts('[23:49:33] [SCROBBLE] DEBUG accepted stop').time, '23:49:33');
+});


### PR DESCRIPTION
# Pull request

## Change

- Add media server destinations to watcher and webhook setup, with profile validation. 
- Preserve watcher log timestamps and event order. 
- Add regression tests for the new sinks and routing.

## Why

- Make the new sinks configurable and prevent routes back to the same provider instance. 
- Keep watcher logs accurate when reopening View details.

## Testing

- tests/test_watcher_log_stream.py

## Issue

Relates to #1062