### PR TITLE
Fix: Tautulli history timestamps and grouping

### DIFF
--- a/providers/sync/_mod_TAUTULLI.py
+++ b/providers/sync/_mod_TAUTULLI.py
@@ -17,7 +17,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "1.0"
+__VERSION__ = "1.1"
 os.environ.setdefault("CW_TAUTULLI_VERSION", __VERSION__)
 os.environ.setdefault("CW_TAUTULLI_UA", f"CrossWatch/{__VERSION__} (Tautulli)")
 __all__ = ["get_manifest", "OPS"]

--- a/providers/sync/tautulli/_history.py
+++ b/providers/sync/tautulli/_history.py
@@ -78,7 +78,7 @@ def _to_int_total(v: Any) -> int | None:
 
 
 def _as_epoch(v: Any) -> int | None:
-    if v is None:
+    if v is None or isinstance(v, bool):
         return None
     try:
         if isinstance(v, (int, float)):
@@ -97,7 +97,8 @@ def _as_epoch(v: Any) -> int | None:
         dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
         if not dt.tzinfo:
             dt = dt.replace(tzinfo=timezone.utc)
-        return int(dt.timestamp())
+        x = int(dt.timestamp())
+        return x if x > 0 else None
     except Exception:
         return None
 
@@ -109,6 +110,14 @@ def _iso_z(epoch: int | None) -> str | None:
         return datetime.fromtimestamp(int(epoch), tz=timezone.utc).isoformat().replace("+00:00", "Z")
     except Exception:
         return None
+
+
+def _watched_at(row: Mapping[str, Any]) -> str | None:
+    for field in ("stopped", "date", "started", "time"):
+        value = _iso_z(_as_epoch(row.get(field)))
+        if value:
+            return value
+    return None
 
 
 def _clean_guid(s: str) -> str:
@@ -314,7 +323,14 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 5000) -> 
             _log("index_reconcile", level="warn", reason="max_pages_reached", pages=pages, max_pages=cfg_max_pages)
             break
 
-        params: dict[str, Any] = {"start": start, "length": cfg_per_page, "order_column": "date", "order_dir": "desc"}
+        params: dict[str, Any] = {
+            "start": start,
+            "length": cfg_per_page,
+            "order_column": "date",
+            "order_dir": "desc",
+            "grouping": 1,
+            "include_activity": 0,
+        }
         if user_id:
             params["user_id"] = user_id
 
@@ -361,8 +377,7 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 5000) -> 
                 skipped_partial += 1
                 continue
 
-            ts = _as_epoch(row.get("date") or row.get("started") or row.get("time"))
-            watched_at = _iso_z(ts)
+            watched_at = _watched_at(row)
             if not watched_at:
                 skipped_no_time += 1
                 continue
@@ -429,9 +444,10 @@ def build_index(adapter: Any, *, per_page: int = 100, max_pages: int = 5000) -> 
                 continue
 
             ck = canonical_key(item)
-            if ck and ck not in out:
+            if ck and (ck not in out or watched_at > out[ck]["watched_at"]):
+                if ck not in out:
+                    rows_kept += 1
                 out[ck] = item
-                rows_kept += 1
 
         start += cfg_per_page
         total_i = _to_int_total(total)

--- a/tests/test_history_baseline_native.py
+++ b/tests/test_history_baseline_native.py
@@ -197,6 +197,63 @@ def _baseline(orch: Orchestrator, provider: str, feature: str) -> dict[str, Any]
     return dict((block.get("baseline") or {}).get("items") or {})
 
 
+@pytest.mark.parametrize("rewatches", [False, True])
+def test_tautulli_history_import_converges_on_second_run(
+    config_base: Any, monkeypatch: pytest.MonkeyPatch, rewatches: bool
+) -> None:
+    from providers.sync import _mod_TAUTULLI
+
+    class TautulliSource(HistoryOps):
+        def capabilities(self) -> Mapping[str, Any]:
+            return _mod_TAUTULLI.OPS.capabilities()
+
+        def build_index(self, cfg: Mapping[str, Any], *, feature: str) -> Mapping[str, dict[str, Any]]:
+            return _mod_TAUTULLI.OPS.build_index(
+                {**cfg, "tautulli": {"server_url": "http://tautulli.test", "api_key": "test"}},
+                feature=feature,
+            )
+
+    def call(_client: Any, cmd: str, **params: Any) -> Mapping[str, Any]:
+        assert cmd == "get_history"
+        assert params["grouping"] == 1
+        assert params["include_activity"] == 0
+        return {
+            "data": [
+                {
+                    "media_type": "movie",
+                    "guid": "com.plexapp.agents.themoviedb://550",
+                    "row_id": row_id,
+                    "reference_id": row_id - 1,
+                    "group_count": 2,
+                    "group_ids": f"{row_id - 1},{row_id}",
+                    "started": stopped - 3600,
+                    "date": stopped - 1800,
+                    "stopped": stopped,
+                    "watched_status": 1,
+                }
+                for row_id, stopped in [(20, 1704153600), (10, 1704067200)]
+            ],
+            "recordsFiltered": 2,
+        }
+
+    monkeypatch.setattr(_mod_TAUTULLI.TAUTULLIClient, "call", call)
+    src = TautulliSource("SRC", {})
+    dst = HistoryOps("DST", {}, history_rewatches=True)
+
+    orch = _run(monkeypatch, src, dst, "history", rewatches=rewatches)
+
+    assert len(dst.add_calls) == 1
+    assert sorted(item["watched_at"] for item in dst.add_calls[0]) == (
+        ["2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z"] if rewatches else ["2024-01-02T00:00:00Z"]
+    )
+    assert _baseline(orch, "SRC", "history").keys() == _baseline(orch, "DST", "history").keys()
+
+    orch.run()
+
+    assert len(dst.add_calls) == 1
+    assert dst.remove_calls == []
+
+
 def test_same_key_history_pair_converges_and_stays_native(
     config_base: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_tautulli_history_timestamps.py
+++ b/tests/test_tautulli_history_timestamps.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from providers.sync.tautulli import _history as history
+
+
+START = 1704067200
+RESUME = START + 1800
+STOP = START + 3600
+
+
+def _iso(epoch: int) -> str:
+    return datetime.fromtimestamp(epoch, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _row(**overrides: Any) -> dict[str, Any]:
+    return {
+        "row_id": 10,
+        "reference_id": 10,
+        "media_type": "movie",
+        "title": "Example movie",
+        "guid": "com.plexapp.agents.themoviedb://550",
+        "started": START,
+        "date": START,
+        "stopped": STOP,
+        "watched_status": 1,
+        **overrides,
+    }
+
+
+def _adapter(rows: list[dict[str, Any]], *, rewatches: bool = False) -> SimpleNamespace:
+    def call(cmd: str, **params: Any) -> dict[str, Any]:
+        assert cmd == "get_history"
+        start, length = params["start"], params["length"]
+        return {"data": rows[start:start + length], "recordsFiltered": len(rows)}
+
+    return SimpleNamespace(cfg={"_cw_history_rewatches": rewatches}, client=SimpleNamespace(call=call))
+
+
+@pytest.mark.parametrize("rewatches", [False, True])
+@pytest.mark.parametrize("grouped", [False, True])
+@pytest.mark.parametrize("media_type", ["movie", "episode"])
+def test_completion_time_wins_over_start_fields(rewatches, grouped, media_type):
+    row = _row(
+        media_type=media_type,
+        parent_media_index=1,
+        media_index=2,
+        date=RESUME if grouped else START,
+        group_count=2 if grouped else 1,
+        group_ids="10,11" if grouped else "10",
+        time=START - 60,
+    )
+    out = history.build_index(_adapter([row], rewatches=rewatches))
+
+    assert len(out) == 1
+    assert next(iter(out.values()))["watched_at"] == _iso(STOP)
+    if rewatches:
+        assert next(iter(out)).endswith(f"@{STOP}")
+
+
+@pytest.mark.parametrize("stopped", [STOP, str(STOP), STOP * 1000, str(STOP * 1000), _iso(STOP)])
+def test_supported_completion_timestamp_formats(stopped):
+    out = history.build_index(_adapter([_row(stopped=stopped)]))
+    assert next(iter(out.values()))["watched_at"] == _iso(STOP)
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [None, "", "garbage", 0, "0", -1, "-1", True, False, float("nan"), float("inf"),
+     10**30, "1969-12-31T23:59:59Z", "1970-01-01T00:00:00Z", {}, []],
+)
+@pytest.mark.parametrize("fallback", ["date", "started", "time"])
+def test_invalid_timestamp_fields_fall_back_in_order(invalid, fallback):
+    row = _row(stopped=invalid, date=invalid, started=invalid, time=invalid)
+    row[fallback] = START
+    fields = ("stopped", "date", "started", "time")
+    for field in fields[fields.index(fallback) + 1:]:
+        row[field] = STOP
+
+    out = history.build_index(_adapter([row]))
+    assert next(iter(out.values()))["watched_at"] == _iso(START)
+
+
+def test_missing_completion_field_uses_legacy_date():
+    row = _row()
+    del row["stopped"]
+    out = history.build_index(_adapter([row]))
+    assert next(iter(out.values()))["watched_at"] == _iso(START)
+
+
+def test_no_valid_timestamp_skips_only_the_invalid_row():
+    invalid = _row(stopped="invalid", date=None, started=0, time=False)
+    out = history.build_index(_adapter([invalid, _row()], rewatches=True))
+    assert list(out) == [f"tmdb:550@{STOP}"]
+
+
+@pytest.mark.parametrize("separation", [0, 1, 86400])
+def test_genuine_watches_remain_separate_even_with_close_or_equal_timestamps(separation):
+    rows = [_row(), _row(row_id=20, reference_id=20, stopped=STOP + separation)]
+    out = history.build_index(_adapter(rows, rewatches=True))
+
+    assert len(out) == 2
+    assert sorted(item["watched_at"] for item in out.values()) == [_iso(STOP), _iso(STOP + separation)]
+    assert all(item["_cw_rewatch_sync"] for item in out.values())
+
+
+@pytest.mark.parametrize("rewatches", [False, True])
+@pytest.mark.parametrize("watched_only", [False, True])
+@pytest.mark.parametrize("nested_payload", [False, True])
+def test_requests_grouped_completed_history_on_every_page(rewatches, watched_only, nested_payload):
+    segments = [
+        _row(row_id=11, date=RESUME, started=RESUME, watched_status=1),
+        _row(stopped=START + 900, watched_status=0.25),
+    ]
+    grouped = _row(row_id=11, date=RESUME, group_count=2, group_ids="10,11")
+    rewatch = _row(row_id=20, reference_id=20, date=STOP + 1, started=STOP + 1, stopped=STOP + 3600)
+    live = _row(row_id=None, reference_id=None, date=STOP + 7200, stopped=0, state="playing")
+    calls = []
+
+    def call(cmd: str, **params: Any) -> dict[str, Any]:
+        assert cmd == "get_history"
+        calls.append(params)
+        rows = [rewatch, grouped] if params.get("grouping", 0) else [rewatch, *segments]
+        if params.get("include_activity", 1):
+            rows = [live, *rows]
+        start, length = params["start"], params["length"]
+        payload = {"data": rows[start:start + length], "recordsFiltered": len(rows)}
+        return {"data": payload} if nested_payload else payload
+
+    cfg = {
+        "_cw_history_rewatches": rewatches,
+        "tautulli": {"history": {"user_id": "7", "per_page": 1, "watched_only": watched_only}},
+    }
+    out = history.build_index(SimpleNamespace(cfg=cfg, client=SimpleNamespace(call=call)))
+
+    expected = [f"tmdb:550@{STOP}", f"tmdb:550@{STOP + 3600}"] if rewatches else ["tmdb:550"]
+    assert sorted(out) == expected
+    assert sorted(item["watched_at"] for item in out.values()) == (
+        [_iso(STOP), _iso(STOP + 3600)] if rewatches else [_iso(STOP + 3600)]
+    )
+    assert [params["start"] for params in calls] == [0, 1]
+    assert all(params["grouping"] == 1 and params["include_activity"] == 0 for params in calls)
+    assert all(params["user_id"] == "7" for params in calls)
+
+
+def test_non_rewatch_import_keeps_latest_completion_across_pages():
+    rows = [_row(date=RESUME, started=RESUME), _row(row_id=20, reference_id=20, stopped=STOP + 60)]
+    out = history.build_index(_adapter(rows), per_page=1)
+
+    assert list(out) == ["tmdb:550"]
+    assert out["tmdb:550"]["watched_at"] == _iso(STOP + 60)
+    assert "_cw_rewatch_sync" not in out["tmdb:550"]


### PR DESCRIPTION
# Pull request

## Change

- Use stopped for watched_at, with safe fallbacks. Explicitly group resumed playback.

## Why

- History should use completion times and preserve genuine rewatches without counting resume segments as extra watches.

## Testing

- tests/test_tautulli_history_timestamps.py
- live tested with Tautulli instance

## Issue

Relates to #1063