### PR TITLE
Fix: Emby library cache reuse

### DIFF
--- a/providers/sync/_mod_EMBY.py
+++ b/providers/sync/_mod_EMBY.py
@@ -117,7 +117,7 @@ try:  # type: ignore[name-defined]
 except Exception:
     ctx = None  # type: ignore[assignment]
 
-__VERSION__ = "2.5"
+__VERSION__ = "2.6"
 os.environ.setdefault("CW_EMBY_VERSION", __VERSION__)
 os.environ.setdefault("CW_EMBY_UA", f"CrossWatch/{__VERSION__} (Emby)")
 __all__ = ["get_manifest", "EMBYModule", "OPS"]

--- a/providers/sync/emby/_common.py
+++ b/providers/sync/emby/_common.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 from typing import Any, Iterable, Mapping, Sequence
 from datetime import datetime
+from hashlib import sha256
 from pathlib import Path
+from threading import local
 import json
 import os
 import re
@@ -12,6 +14,7 @@ import shutil
 import time
 from cw_platform.anime_mapping.service import mapped_or_default_media_type
 from cw_platform.id_map import minimal as id_minimal, canonical_key
+from cw_platform.log_context import log_run_id
 from .._log import log as cw_log
 
 _STATE_DIR = Path("/config/.cw_state")
@@ -67,8 +70,8 @@ _BAD_NUM = re.compile(r"^\d{13,}$")
 
 CfgLike = Mapping[str, Any] | object
 
-# Adapter-scoped provider-index cache
-_PROVIDER_INDEX_CACHE: dict[tuple[Any, ...], tuple[float, dict[str, list[dict[str, Any]]]]] = {}
+# One shared index per sync thread; standalone calls cache on their adapter.
+_RUN_PROVIDER_INDEX = local()
 
 
 def _debug_level() -> str:
@@ -686,6 +689,8 @@ def build_provider_index(adapter: Any, *, feature: str | None = None) -> dict[st
         if parent_id:
             params["ParentId"] = parent_id
         r = http.get(f"/Users/{uid}/Items", params=params)
+        if getattr(r, "status_code", 0) != 200:
+            raise RuntimeError(f"emby_provider_index_http_{getattr(r, 'status_code', 0)}")
         body = r.json() or {}
         items = body.get("Items") or []
         signature = tuple(str(row.get("Id") or "") for row in items if isinstance(row, Mapping))
@@ -735,23 +740,50 @@ def build_provider_index(adapter: Any, *, feature: str | None = None) -> dict[st
     return out
 
 
+def _provider_index_context(adapter: Any, feature: str) -> tuple[tuple[Any, ...], bool]:
+    # CW_RUN_ID can remain in the environment after a run; use its context ID.
+    run_id = log_run_id.get()
+    cfg = adapter.cfg
+    server = str(getattr(cfg, "server", "") or "")
+    user = str(getattr(cfg, "user_id", "") or "")
+    credential = sha256(str(getattr(cfg, "access_token", "") or "").encode()).digest()
+    pair_scope = _pair_scope()
+    key = (run_id, server, user, credential, pair_scope, feature, tuple(sorted(emby_selected_library_ids(cfg, feature))))
+    share = bool(run_id and server and user and pair_scope and pair_scope.lower() not in {"unscoped", "default", "none"})
+    return key, share
+
+
 def provider_index(adapter: Any, *, ttl_sec: int = 300, force_refresh: bool = False, feature: str = "history") -> dict[str, list[dict[str, Any]]]:
-    key = (id(adapter), scope_safe(), feature, tuple(sorted(emby_selected_library_ids(adapter.cfg, feature))))
-    now = time.time()
     if not force_refresh:
-        hit = _PROVIDER_INDEX_CACHE.get(key)
-        if hit and (now - hit[0]) < max(1, int(ttl_sec)):
-            return hit[1]
+        cached = _cached_provider_index(adapter, feature, ttl_sec=ttl_sec)
+        if cached is not None:
+            return cached
+    key, share = _provider_index_context(adapter, feature)
+    adapter._provider_index_cache = None
+    _RUN_PROVIDER_INDEX.entry = None
     idx = build_provider_index(adapter) if feature == "history" else build_provider_index(adapter, feature=feature)
-    _PROVIDER_INDEX_CACHE[key] = (now, idx)
+    entry = (key, time.monotonic(), idx)
+    adapter._provider_index_cache = entry
+    if share:
+        _RUN_PROVIDER_INDEX.entry = entry
     return idx
 
 
 def _cached_provider_index(adapter: Any, feature: str, *, ttl_sec: int = 300) -> dict[str, list[dict[str, Any]]] | None:
-    key = (id(adapter), scope_safe(), feature, tuple(sorted(emby_selected_library_ids(adapter.cfg, feature))))
-    hit = _PROVIDER_INDEX_CACHE.get(key)
-    if hit and (time.time() - hit[0]) < max(1, int(ttl_sec)):
-        return hit[1]
+    key, share = _provider_index_context(adapter, feature)
+    if not share:
+        _RUN_PROVIDER_INDEX.entry = None
+    shared = getattr(_RUN_PROVIDER_INDEX, "entry", None) if share else None
+    if shared is not None and shared[0] == key:
+        if getattr(adapter, "_provider_index_cache", None) is not shared:
+            cw_log("EMBY", "common", "debug", "index_cache_hit", source="run", count=len(shared[2]))
+        adapter._provider_index_cache = shared
+        return shared[2]
+    hit = getattr(adapter, "_provider_index_cache", None)
+    # Active syncs reuse the index for the entire run. Standalone adapters keep
+    # the existing TTL, without retaining them in a process-wide ID cache.
+    if hit is not None and hit[0] == key and (share or time.monotonic() - hit[1] < max(1, int(ttl_sec))):
+        return hit[2]
     return None
 
 
@@ -2074,6 +2106,9 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "his
         return []
 
     one = resolve_item_id(adapter, it, feature=feature)
+    # A resolved episode/show needs no movie/series index expansion.
+    if one and _lookup_type(it) != "movie":
+        return [str(one)]
     selected_libs = emby_selected_library_ids(adapter.cfg, feature)
 
     ids = dict(it.get("ids") or {})
@@ -2098,7 +2133,7 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "his
             if p not in pairs:
                 pairs.append(p)
 
-    idx = build_provider_index(adapter) if feature == "history" else build_provider_index(adapter, feature=feature)
+    idx = provider_index(adapter, feature=feature)
 
     def _valid(iid: Any) -> str | None:
         s = str(iid or "").strip()

--- a/tests/test_emby_index_cache.py
+++ b/tests/test_emby_index_cache.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from cw_platform.log_context import log_run_id
+from cw_platform.orchestrator import _applier
+from providers.sync import _mod_EMBY as module
+from providers.sync.emby import _common as common
+
+
+class Library:
+    def __init__(self, count=2):
+        self.rows = [
+            {"Id": str(i), "Type": "Movie", "Name": f"Movie {i}", "ProviderIds": {"Tmdb": str(i)}}
+            for i in range(1, count + 1)
+        ]
+        self.calls = []
+        self.fail_start = None
+
+    def get(self, path, *, params):
+        self.calls.append(dict(params))
+        start = params.get("StartIndex", 0)
+        rows = self.rows[start:start + params.get("Limit", 500)]
+        return SimpleNamespace(
+            status_code=503 if start == self.fail_start else 200,
+            json=lambda: {"Items": rows, "TotalRecordCount": len(self.rows)},
+        )
+
+
+def adapter(count=2, **config):
+    return SimpleNamespace(client=Library(count), cfg=SimpleNamespace(**{
+        "server": "http://emby", "user_id": "user", "access_token": "token", **config,
+    }))
+
+
+@pytest.fixture(autouse=True)
+def isolated_context(monkeypatch):
+    for name in ("CW_PAIR_KEY", "CW_PAIR_SCOPE", "CW_SYNC_PAIR", "CW_PAIR"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(common._RUN_PROVIDER_INDEX, "entry", None, raising=False)
+    monkeypatch.setattr(common, "cw_log", lambda *args, **kwargs: None)
+    token = log_run_id.set("")
+    yield
+    log_run_id.reset(token)
+
+
+def test_real_apply_reuses_index_across_batches_and_refreshes_next_run(monkeypatch):
+    monkeypatch.setenv("CW_PAIR_KEY", "pair1")
+    adapters = []
+
+    class Adapter:
+        def __init__(self, cfg):
+            self.cfg = adapter().cfg
+            self.client = Library()
+            adapters.append(self)
+
+        def add(self, feature, items, *, dry_run):
+            common.provider_index(self, feature=feature)
+            return {"ok": True, "count": len(items), "confirmed_keys": [common.key_of(it) for it in items]}
+
+    monkeypatch.setattr(module, "EMBYModule", Adapter)
+    monkeypatch.setattr(_applier, "cancel_requested", lambda: False)
+    for run in ("first", "second"):
+        log_run_id.set(run)
+        result = _applier.apply_add(
+            dst_ops=module._EmbyOPS(), cfg={}, dst_name="EMBY", feature="history",
+            items=[{"type": "movie", "ids": {"tmdb": str(i)}} for i in range(1, 4)],
+            dry_run=False, emit=lambda *args, **kwargs: None, dbg=lambda *args, **kwargs: None,
+            chunk_size=1, chunk_pause_ms=0,
+        )
+        assert result["confirmed"] == 3
+    assert [len(ad.client.calls) for ad in adapters] == [1, 0, 0, 1, 0, 0]
+
+
+@pytest.mark.parametrize("change", ["server", "user_id", "access_token", "history_libraries", "feature", "pair", "run"])
+@pytest.mark.parametrize("reuse_adapter", [False, True])
+def test_cache_never_crosses_identity_or_scope(monkeypatch, change, reuse_adapter):
+    monkeypatch.setenv("CW_PAIR_KEY", "pair/a")
+    log_run_id.set("run1")
+    first = adapter(history_libraries=["A"], progress_libraries=["A"])
+    index = common.provider_index(first)
+    second = first if reuse_adapter else adapter(**vars(first.cfg))
+    assert common.provider_index(second) is index
+    before = len(second.client.calls)
+    feature = "history"
+    if change == "pair":
+        # These collide after filename sanitization, but must not share a cache.
+        monkeypatch.setenv("CW_PAIR_KEY", "pair?a")
+    elif change == "run":
+        log_run_id.set("run2")
+    elif change == "feature":
+        feature = "progress"
+    else:
+        setattr(second.cfg, change, ["B"] if change == "history_libraries" else "changed")
+    assert common.provider_index(second, feature=feature) is not index
+    assert len(second.client.calls) == before + 1
+
+
+@pytest.mark.parametrize("scope", [None, "", "unscoped", "default", "none"])
+def test_missing_scope_disables_cross_adapter_reuse(monkeypatch, scope):
+    log_run_id.set("run1")
+    if scope is not None:
+        monkeypatch.setenv("CW_PAIR_KEY", scope)
+    first, second = adapter(), adapter()
+    assert common.provider_index(first) == common.provider_index(second)
+    assert len(first.client.calls) == len(second.client.calls) == 1
+    assert common._RUN_PROVIDER_INDEX.entry is None
+
+
+def test_stale_environment_run_does_not_enable_sharing(monkeypatch):
+    monkeypatch.setenv("CW_RUN_ID", "finished-run")
+    monkeypatch.setenv("CW_PAIR_KEY", "pair1")
+    first, second = adapter(), adapter()
+    assert common.provider_index(first) == common.provider_index(second)
+    assert len(first.client.calls) == len(second.client.calls) == 1
+
+
+@pytest.mark.parametrize("count", [0, 2])
+def test_long_run_reuses_even_empty_index_and_force_refreshes(monkeypatch, count):
+    log_run_id.set("run1")
+    monkeypatch.setenv("CW_PAIR_KEY", "pair1")
+    now = [100.0]
+    monkeypatch.setattr(common.time, "monotonic", lambda: now[0])
+    first = adapter(count)
+    index = common.provider_index(first)
+    now[0] += 900
+    second = adapter(count)
+    assert common.provider_index(second) is index
+    assert not second.client.calls
+    refreshed = common.provider_index(second, force_refresh=True)
+    assert refreshed is not index
+    assert common.provider_index(first) is refreshed
+    assert len(second.client.calls) == 1
+
+
+def test_standalone_adapter_retains_ttl(monkeypatch):
+    now = [100.0]
+    monkeypatch.setattr(common.time, "monotonic", lambda: now[0])
+    ad = adapter()
+    index = common.provider_index(ad, ttl_sec=10)
+    now[0] += 9
+    assert common.provider_index(ad, ttl_sec=10) is index
+    now[0] += 2
+    assert common.provider_index(ad, ttl_sec=10) is not index
+    assert len(ad.client.calls) == 2
+
+
+def test_failed_page_is_not_cached(monkeypatch):
+    log_run_id.set("run1")
+    monkeypatch.setenv("CW_PAIR_KEY", "pair1")
+    failed = adapter(600)
+    failed.client.fail_start = 500
+    with pytest.raises(RuntimeError, match="emby_provider_index_http_503"):
+        common.provider_index(failed)
+    assert common._cached_provider_index(failed, "history") is None
+    recovered = adapter(600)
+    assert len(common.provider_index(recovered)) == 600
+    assert len(recovered.client.calls) == 2
+
+
+def test_resolved_episode_needs_only_provider_id_query():
+    ad = adapter(1)
+    ad.client.rows = [{"Id": "123", "Type": "Episode", "ProviderIds": {"Tvdb": "456"}, "ParentIndexNumber": 1, "IndexNumber": 2}]
+    item = {"type": "episode", "ids": {"tvdb": "456"}, "season": 1, "episode": 2}
+    assert common.resolve_item_ids(ad, item, feature="progress") == ["123"]
+    assert len(ad.client.calls) == 1
+    assert ad.client.calls[0]["AnyProviderIdEquals"] == "tvdb.456"
+
+
+def test_movie_copies_still_expand_and_reuse_index(monkeypatch):
+    ad = adapter(2)
+    for row in ad.client.rows:
+        row["ProviderIds"] = {"Tmdb": "1"}
+    monkeypatch.setattr(common, "resolve_item_id", lambda *args, **kwargs: "1")
+    for _ in range(2):
+        assert common.resolve_item_ids(ad, {"type": "movie", "ids": {"tmdb": "1"}}, feature="progress") == ["1", "2"]
+    assert len(ad.client.calls) == 1


### PR DESCRIPTION
# Pull request

## Change

- Reuse the Emby library index across batches within the same pair, feature, and run. 
- Avoid extra scans after resolving progress episodes.

## Why

- Each new batch rebuilt the index, and resolved progress episodes triggered unnecessary scans.

## Testing

- Live Emby test: later batches made zero index requests, new runs refreshed the cache, and episode resolution used one request.

## Issue
Relates to #1069