### PR TITLE
Fix: Plex cache isolation and duplicate GUID lookups

### DIFF
--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -40,7 +40,7 @@ def _error(event: str, **fields: Any) -> None:
 def _log(msg: str) -> None:
     _dbg(msg)
 
-__VERSION__ = "2.5"
+__VERSION__ = "2.6"
 os.environ.setdefault("CW_PLEX_VERSION", __VERSION__)
 os.environ.setdefault("CW_PLEX_UA", f"CrossWatch/{__VERSION__} (Plex)")
 __all__ = ["get_manifest", "PLEXModule", "PLEXClient", "PLEXError", "PLEXAuthError", "PLEXNotFound", "OPS"]

--- a/providers/sync/plex/_common.py
+++ b/providers/sync/plex/_common.py
@@ -601,14 +601,20 @@ def meta_guids(meta_obj: Any) -> list[str]:
 
 
 def server_find_rating_key_by_guid(srv: Any, guids: Iterable[str]) -> str | None:
+    candidates = list(dict.fromkeys(str(g) for g in (guids or []) if g))
+    queried: set[str] = set()
     # PlexAPI XML query path
     try:
-        for g in [x for x in (guids or []) if x]:
+        for g in candidates:
             try:
                 qg = quote(str(g), safe="")
                 root = srv.query(  # type: ignore[attr-defined]
                     f"/library/all?guid={qg}&X-Plex-Container-Start=0&X-Plex-Container-Size=1"
                 )
+                # A valid empty response is a completed lookup. Raw HTTP is
+                # only needed if PlexAPI could not query or parse this GUID.
+                if root is not None and getattr(root, "tag", None) == "MediaContainer":
+                    queried.add(g)
                 el = None
                 try:
                     el = root.find(".//*[@ratingKey]") if root is not None else None
@@ -634,7 +640,9 @@ def server_find_rating_key_by_guid(srv: Any, guids: Iterable[str]) -> str | None
     hdrs = dict(getattr(ses, "headers", {}) or {})
     hdrs.update(plex_headers(tok, accept="application/xml, application/json;q=0.9,*/*;q=0.5"))
 
-    for g in [x for x in (guids or []) if x]:
+    for g in candidates:
+        if g in queried:
+            continue
         try:
             r = ses.get(
                 f"{base}/library/all",

--- a/providers/sync/plex/_history.py
+++ b/providers/sync/plex/_history.py
@@ -10,12 +10,17 @@ import time
 from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping
 from pathlib import Path
+from hashlib import sha256
+from threading import local
+
+from cw_platform.log_context import log_run_id
 
 from cw_platform.id_map import canonical_key, minimal as id_minimal, ids_from, ids_from_guid
 from providers.sync._mod_common import observation_time
 
 from ._common import (
     _as_base_url,
+    _pair_scope,
     _fb_cache_flush,
     _xml_to_container,
     active_pms_token,
@@ -106,55 +111,12 @@ def _save_watermark(key: str, epoch: int) -> None:
     except Exception:
         pass
 
-def _guid_index_path() -> Path:
-    return state_file("plex_history.guid_index.json")
-
-def _load_guid_index(srv: Any, allow: set[str]) -> bool:
-    try:
-        data = read_json(_guid_index_path()) or {}
-        mid = str(getattr(srv, "machineIdentifier", "") or "")
-        if not mid or data.get("machine_id") != mid:
-            return False
-        stored_allow = set(str(x) for x in (data.get("allow") or []))
-        if stored_allow != set(str(x) for x in (allow or set())):
-            return False
-        # TTL to avoid stale indices forever.
-        ttl_days = int(os.environ.get("CW_PLEX_GUID_INDEX_TTL_DAYS", "0") or "7")
-        created = int(data.get("created_epoch") or 0)
-        if created and ttl_days > 0 and (int(time.time()) - created) > ttl_days * 86400:
-            return False
-        movies = data.get("movies") or {}
-        shows = data.get("shows") or {}
-        if not isinstance(movies, dict) or not isinstance(shows, dict):
-            return False
-        _GUID_INDEX_MOVIE.update({str(k): str(v) for k, v in movies.items() if k and v})
-        _GUID_INDEX_SHOW.update({str(k): str(v) for k, v in shows.items() if k and v})
-        return bool(_GUID_INDEX_MOVIE or _GUID_INDEX_SHOW)
-    except Exception:
-        return False
-
-def _save_guid_index(srv: Any, allow: set[str]) -> None:
-    try:
-        mid = str(getattr(srv, "machineIdentifier", "") or "")
-        if not mid:
-            return
-        out = {
-            "machine_id": mid,
-            "allow": sorted(str(x) for x in (allow or set())),
-            "created_epoch": int(time.time()),
-            "movies": _GUID_INDEX_MOVIE,
-            "shows": _GUID_INDEX_SHOW,
-        }
-        write_json(_guid_index_path(), out, indent=0, sort_keys=False, separators=(",", ":"))
-    except Exception:
-        pass
 _dbg, _info, _warn, _error, _log = make_logger("history")
 
-
-# PMS GUID index cache (used for strict ID matching).
-_GUID_INDEX_MOVIE: dict[str, str] = {}
-_GUID_INDEX_SHOW: dict[str, str] = {}
-_GUID_INDEX_KEY: str | None = None
+# A sync thread owns its indexes. Persisted GUID snapshots are no longer read:
+# a new run must see library changes instead of loading an indefinitely old file.
+_INDEX_CACHE = local()
+_GUID_INDEX_TTL_SEC = 300
 _ALLOWED_HISTORY_TYPES = frozenset({"movie", "episode"})
 
 
@@ -162,17 +124,37 @@ def _allowed_history_type(row: Any) -> bool:
     return str(getattr(row, "type", "") or "").strip().lower() in _ALLOWED_HISTORY_TYPES
 
 
-def _guid_index_key(srv: Any, allow: set[str]) -> str:
-    mid = str(getattr(srv, "machineIdentifier", "") or "").strip()
-    libs = ",".join(sorted(str(x) for x in (allow or set())))
-    return f"{mid}|{libs}"
+def _index_cache_context(adapter: Any, allow: set[str], feature: str) -> tuple[tuple[Any, ...], bool]:
+    srv = getattr(getattr(adapter, "client", None), "server", None)
+    config = getattr(adapter, "config", {}) or {}
+    pair_scope = (config.get("_cw_pair_scope") if isinstance(config, Mapping) else None) or _pair_scope()
+    pair_scope = str(pair_scope or "").strip()
+    run_id = log_run_id.get()
+    base = _as_base_url(srv) or ""
+    token = str(active_pms_token(adapter) or "")
+    identity = sha256(token.encode()).digest()
+    share = bool(run_id and base and token and pair_scope and pair_scope.lower() not in {"unscoped", "default", "none"})
+    owner = None
+    if not share:
+        owner = getattr(adapter, "_plex_index_owner", None)
+        if owner is None:
+            owner = object()
+            setattr(adapter, "_plex_index_owner", owner)
+    key = (run_id, pair_scope, feature, base, str(getattr(srv, "machineIdentifier", "") or ""),
+           _user_scope_key(adapter), identity, tuple(sorted(str(x) for x in allow)), owner)
+    return key, share
 
 
 def _clear_guid_index() -> None:
-    global _GUID_INDEX_KEY
-    _GUID_INDEX_MOVIE.clear()
-    _GUID_INDEX_SHOW.clear()
-    _GUID_INDEX_KEY = None
+    _INDEX_CACHE.guid = None
+
+
+def _cached_guid_index(adapter: Any, allow: set[str], *, feature: str = "history") -> dict[str, Any] | None:
+    key, share = _index_cache_context(adapter, allow, feature)
+    entry = getattr(_INDEX_CACHE, "guid", None)
+    if entry is not None and entry["key"] == key and (share or time.monotonic() - entry["ts"] < _GUID_INDEX_TTL_SEC):
+        return entry
+    return None
 
 
 def _row_guids(row: Mapping[str, Any]) -> list[str]:
@@ -192,7 +174,7 @@ def _fetch_section_guid_rows(srv: Any, section_id: str, plex_type: int) -> tuple
     ses = getattr(srv, "_session", None)
     token = getattr(srv, "token", None) or getattr(srv, "_token", None) or ""
     if not (base and ses and token and section_id):
-        return [], 0
+        raise RuntimeError("plex_guid_index_server_unavailable")
 
     headers = dict(getattr(ses, "headers", {}) or {})
     headers.update(plex_headers(token))
@@ -213,11 +195,11 @@ def _fetch_section_guid_rows(srv: Any, section_id: str, plex_type: int) -> tuple
         }
         try:
             r = ses.get(f"{base}/library/sections/{section_id}/all", params=params, headers=headers, timeout=20)
-        except Exception:
-            break
+        except Exception as exc:
+            raise RuntimeError("plex_guid_index_request_failed") from exc
         made += 1
         if not getattr(r, "ok", False):
-            break
+            raise RuntimeError(f"plex_guid_index_http_{getattr(r, 'status_code', 0)}")
         try:
             ctype = (r.headers.get("content-type") or "").lower()
             data = (r.json() or {}) if "application/json" in ctype else _xml_to_container(r.text or "")
@@ -225,71 +207,60 @@ def _fetch_section_guid_rows(srv: Any, section_id: str, plex_type: int) -> tuple
             rows = [x for x in (mc.get("Metadata") or []) if isinstance(x, Mapping)]
             total = mc.get("totalSize")
             total_i = int(total) if total is not None else None
-        except Exception:
-            break
+        except Exception as exc:
+            raise RuntimeError("plex_guid_index_parse_failed") from exc
         if not rows:
+            if total_i is not None and start < total_i:
+                raise RuntimeError("plex_guid_index_incomplete_page")
             break
         signature = tuple(str(row.get("ratingKey") or row.get("key") or "") for row in rows)
         if signature in seen_pages:
-            break
+            raise RuntimeError("plex_guid_index_repeated_page")
         seen_pages.add(signature)
         out.extend(rows)
         start += len(rows)
         if total_i is not None and start >= total_i:
             break
-        if len(rows) < page_size:
+        if total_i is None and len(rows) < page_size:
             break
 
     return out, made
 
 
-def _build_guid_index(adapter: Any, allow: set[str], *, force: bool = False) -> None:
-    global _GUID_INDEX_KEY
-    srv = getattr(getattr(adapter, "client", None), "server", None)
-    key = _guid_index_key(srv, allow)
-    if (not force) and _GUID_INDEX_KEY == key and (_GUID_INDEX_MOVIE or _GUID_INDEX_SHOW):
-        return
+def _build_guid_index(adapter: Any, allow: set[str], *, force: bool = False, feature: str = "history") -> dict[str, Any]:
+    cached = None if force else _cached_guid_index(adapter, allow, feature=feature)
+    if cached is not None:
+        return cached
     _clear_guid_index()
-    if (not force) and srv and _load_guid_index(srv, allow):
-        _GUID_INDEX_KEY = key
-        _dbg("index_cache_hit", source="guid_index", movies=len(_GUID_INDEX_MOVIE), shows=len(_GUID_INDEX_SHOW))
-        return
-    try:
-        requests_made = 0
-        for sec in adapter.libraries(types=("movie", "show")) or []:
-            sid = str(getattr(sec, "key", "") or "").strip()
-            if allow and sid and sid not in allow:
+    srv = getattr(getattr(adapter, "client", None), "server", None)
+    key, _ = _index_cache_context(adapter, allow, feature)
+    entry: dict[str, Any] = {"key": key, "movies": {}, "shows": {}}
+    requests_made = 0
+    for sec in adapter.libraries(types=("movie", "show")) or []:
+        sid = str(getattr(sec, "key", "") or "").strip()
+        if allow and sid and sid not in allow:
+            continue
+        is_movie = getattr(sec, "type", "") == "movie"
+        dst = entry["movies" if is_movie else "shows"]
+        rows, n = _fetch_section_guid_rows(srv, sid, 1 if is_movie else 2)
+        requests_made += n
+        for row in rows:
+            rk = str(row.get("ratingKey") or "").strip()
+            if not rk:
                 continue
-            libtype = "movie" if getattr(sec, "type", "") == "movie" else "show"
-            dst = _GUID_INDEX_MOVIE if libtype == "movie" else _GUID_INDEX_SHOW
-            try:
-                rows, n = _fetch_section_guid_rows(srv, sid, 1 if libtype == "movie" else 2)
-                requests_made += n
-                for row in rows:
-                    rk = str(row.get("ratingKey") or "").strip()
-                    if not rk:
-                        continue
-                    for g in _row_guids(row):
-                        gg = str(g or "").strip().lower()
-                        if gg and gg not in dst:
-                            dst[gg] = rk
-            except Exception:
-                continue
-        if srv:
-            _save_guid_index(srv, allow)
-        _GUID_INDEX_KEY = key
-        _dbg(
-            "index_fetch_counts",
-            source="guid_index",
-            movies=len(_GUID_INDEX_MOVIE),
-            shows=len(_GUID_INDEX_SHOW),
-            requests=requests_made,
-        )
-    except Exception:
-        pass
+            for g in _row_guids(row):
+                gg = str(g or "").strip().lower()
+                if gg and gg not in dst:
+                    dst[gg] = rk
+    entry["ts"] = time.monotonic()
+    _INDEX_CACHE.guid = entry
+    _dbg("index_fetch_counts", source="guid_index", movies=len(entry["movies"]), shows=len(entry["shows"]), requests=requests_made)
+    return entry
+
 
 def _pms_find_in_guid_index(libtype: str, candidates: list[str]) -> str | None:
-    src = _GUID_INDEX_SHOW if libtype == "show" else _GUID_INDEX_MOVIE
+    entry = getattr(_INDEX_CACHE, "guid", None) or {}
+    src = entry.get("shows" if libtype == "show" else "movies", {})
     for g in candidates or []:
         gg = str(g or "").strip().lower()
         if gg and gg in src:
@@ -1144,12 +1115,12 @@ def _build_history_catalog(adapter: Any, allow: set[str], *, force: bool = False
     cat = HistoryCatalog()
     if force:
         _clear_guid_index()
-    _build_guid_index(adapter, allow, force=force)
-    for guid, rk in list(_GUID_INDEX_MOVIE.items()):
+    index = _build_guid_index(adapter, allow, force=force)
+    for guid, rk in list(index["movies"].items()):
         ids = ids_from_guid(str(guid))
         if ids:
             cat.add({"rk": rk, "type": "movie", "ids": ids, "watched": False})
-    for guid, rk in list(_GUID_INDEX_SHOW.items()):
+    for guid, rk in list(index["shows"].items()):
         ids = ids_from_guid(str(guid))
         if ids:
             cat.add({"rk": rk, "type": "show", "ids": ids, "watched": False})
@@ -1165,14 +1136,11 @@ def _build_history_catalog(adapter: Any, allow: set[str], *, force: bool = False
     _emit({
         "event": "plex.catalog", "action": "done", "feature": "history", "level": "debug",
         "force": bool(force), "live": bool(live), "allow": allow_list,
-        "guid_movies": len(_GUID_INDEX_MOVIE), "guid_shows": len(_GUID_INDEX_SHOW),
+        "guid_movies": len(index["movies"]), "guid_shows": len(index["shows"]),
         "watched_movies": watched_movies, "watched_episodes": watched_eps,
         "catalog_entries": len(cat.by_rk), "duration_ms": int((time.time() - t0) * 1000),
     })
     return cat
-
-
-_CATALOG_CACHE: dict[str, Any] = {"cat": None, "ts": 0.0, "key": None}
 
 
 def _user_scope_key(adapter: Any) -> str:
@@ -1188,22 +1156,20 @@ def _user_scope_key(adapter: Any) -> str:
     return _wm_key(acct, uname)
 
 
-def _catalog_cache_key(adapter: Any, allow: set[str]) -> str:
-    srv = getattr(getattr(adapter, "client", None), "server", None)
-    mid = str(getattr(srv, "machineIdentifier", "") or "")
-    return f"{mid}|{_user_scope_key(adapter)}|{','.join(sorted(str(x) for x in (allow or set())))}"
+def _catalog_cache_key(adapter: Any, allow: set[str]) -> tuple[Any, ...]:
+    return _index_cache_context(adapter, allow, "history")[0]
 
 
 def _store_history_catalog(adapter: Any, allow: set[str], cat: HistoryCatalog) -> None:
-    _CATALOG_CACHE.update({"cat": cat, "ts": time.time(), "key": _catalog_cache_key(adapter, allow)})
+    _INDEX_CACHE.catalog = {"cat": cat, "ts": time.monotonic(), "key": _catalog_cache_key(adapter, allow)}
 
 
 def _get_history_catalog(adapter: Any, allow: set[str], *, force: bool = False) -> HistoryCatalog:
     key = _catalog_cache_key(adapter, allow)
-    now = time.time()
-    if (not force) and _CATALOG_CACHE.get("cat") is not None and _CATALOG_CACHE.get("key") == key \
-            and (now - float(_CATALOG_CACHE.get("ts") or 0)) < _CATALOG_MEM_TTL_SEC:
-        return _CATALOG_CACHE["cat"]  # type: ignore[return-value]
+    cached = getattr(_INDEX_CACHE, "catalog", None)
+    if not force and cached is not None and cached["key"] == key and time.monotonic() - cached["ts"] < _CATALOG_MEM_TTL_SEC:
+        return cached["cat"]
+    _INDEX_CACHE.catalog = None
     cat = _build_history_catalog(adapter, allow, force=force)
     _store_history_catalog(adapter, allow, cat)
     return cat

--- a/providers/sync/plex/_playlists.py
+++ b/providers/sync/plex/_playlists.py
@@ -456,7 +456,7 @@ def _resolve_object(
                 candidates.append(obj)
         rk_idx = None
         try:
-            _hist_build_guid_index(adapter, allow)
+            _hist_build_guid_index(adapter, allow, feature="playlists")
             rk_idx = _hist_find_in_guid_index(_library_type_for(item), guids)
         except Exception:
             rk_idx = None

--- a/providers/sync/plex/_progress.py
+++ b/providers/sync/plex/_progress.py
@@ -595,7 +595,7 @@ def _resolve_rating_key(adapter: Any, it: Mapping[str, Any]) -> str | None:
     if guid_candidates:
         rk_idx = None
         try:
-            _hist_build_guid_index(adapter, allowed)
+            _hist_build_guid_index(adapter, allowed, feature="progress")
             rk_idx = _hist_find_in_guid_index("show" if is_episode else "movie", guid_candidates)
         except Exception:
             rk_idx = None

--- a/providers/sync/plex/_ratings.py
+++ b/providers/sync/plex/_ratings.py
@@ -192,7 +192,7 @@ def _resolve_rating_key(adapter: Any, it: Mapping[str, Any]) -> str | None:
             rk_any = None
         if not rk_any and guids:
             try:
-                _hist_build_guid_index(adapter, allow)
+                _hist_build_guid_index(adapter, allow, feature="ratings")
                 rk_any = _hist_find_in_guid_index("movie" if is_movie else "show", guids)
             except Exception:
                 pass

--- a/tests/test_plex_guid_index_fetch.py
+++ b/tests/test_plex_guid_index_fetch.py
@@ -76,26 +76,23 @@ def _setup(monkeypatch):
     adapter.client = type("C", (), {"server": srv})()
 
     monkeypatch.setattr(h, "_as_base_url", lambda _s: "http://pms")
-    monkeypatch.setattr(h, "_load_guid_index", lambda *a, **k: False)
-    monkeypatch.setattr(h, "_save_guid_index", lambda *a, **k: None)
     h._clear_guid_index()
-    h._GUID_INDEX_KEY = None
     return h, adapter, ses
 
 
 def test_guid_index_is_built_from_paged_rows(monkeypatch) -> None:
     h, adapter, ses = _setup(monkeypatch)
 
-    h._build_guid_index(adapter, set(), force=True)
+    index = h._build_guid_index(adapter, set(), force=True)
 
-    assert h._GUID_INDEX_MOVIE == {
+    assert index["movies"] == {
         "plex://movie/aaa": "11",
         "tmdb://603": "11",
         "imdb://tt0133093": "11",
         "plex://movie/bbb": "12",
         "tmdb://604": "12",
     }
-    assert h._GUID_INDEX_SHOW == {"plex://show/ccc": "21", "tvdb://81797": "21"}
+    assert h._cached_guid_index(adapter, set())["shows"] == {"plex://show/ccc": "21", "tvdb://81797": "21"}
 
 
 def test_requests_ask_for_guids_and_correct_types(monkeypatch) -> None:
@@ -123,7 +120,7 @@ def test_allow_filter_skips_other_sections(monkeypatch) -> None:
     h._build_guid_index(adapter, {"1"}, force=True)
 
     assert len(ses.calls) == 1
-    assert h._GUID_INDEX_SHOW == {}
+    assert h._cached_guid_index(adapter, {"1"})["shows"] == {}
 
 
 def test_row_guids_reads_attribute_and_children() -> None:

--- a/tests/test_plex_history_options.py
+++ b/tests/test_plex_history_options.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from cw_platform.log_context import log_run_id
+from providers.sync.plex import _common as common, _history as history
+
+
+@pytest.fixture
+def isolated_state(monkeypatch, tmp_path):
+    monkeypatch.setenv("CW_PAIR_KEY", "cw2_history_options")
+    monkeypatch.setattr(common, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(common, "_FBGUID_MEMO", {})
+    monkeypatch.setattr(common, "_FBGUID_MEMO_PATH", None)
+    monkeypatch.setattr(common, "_FBGUID_MEMO_DIRTY", False)
+    monkeypatch.setattr(common, "plex_context", lambda: {"baseurl": "http://plex", "token": "token", "account_token": "token"})
+    monkeypatch.setattr(common, "hydrate_external_ids", lambda *args: {})
+    monkeypatch.setattr(history, "_load_watermark", lambda *args: None)
+    monkeypatch.setattr(history, "_dbg", lambda *args, **kwargs: None)
+    monkeypatch.setattr(history, "_info", lambda *args, **kwargs: None)
+    monkeypatch.setattr(history, "_emit", lambda *args, **kwargs: None)
+    history._clear_guid_index()
+    token = log_run_id.set("options-run1")
+    yield
+    log_run_id.reset(token)
+    history._clear_guid_index()
+
+
+def test_fallback_guid_recovers_old_item_and_keeps_match_when_disabled(isolated_state, monkeypatch):
+    raw = SimpleNamespace(type="movie", ratingKey="42", title="Old movie", year=1990, viewedAt=1787093918)
+    server = SimpleNamespace(baseurl="http://plex", _token="token", machineIdentifier="server", history=lambda **kwargs: [raw])
+    config = {"_cw_pair_scope": "cw2_history_options", "plex": {
+        "fallback_GUID": False, "history_workers": 1, "history": {"include_marked_watched": False},
+    }}
+    ad = SimpleNamespace(client=SimpleNamespace(server=server), config=config, libraries=lambda **kwargs: [])
+    searches = []
+
+    def discover(*args, **kwargs):
+        searches.append(1)
+        return {"type": "movie", "title": "Old movie", "year": 1990, "Guid": [{"id": "tmdb://123"}]}
+
+    monkeypatch.setattr(common, "_discover_search_title", discover)
+    assert history.build_index(ad) == {}
+    assert not searches
+    config["plex"]["fallback_GUID"] = True
+    recovered = history.build_index(ad)
+    assert len(recovered) == 1
+    assert next(iter(recovered.values()))["ids"]["tmdb"] == "123"
+    assert next(iter(recovered.values()))["watched_at"] == history._iso(1787093918)
+    assert searches == [1]
+    assert common._fbguid_cache_path().exists()
+
+    # Simulate another run/process, with recovery switched off. The persistent
+    # fallback memo must survive retirement of the separate library GUID index.
+    log_run_id.set("options-run2")
+    config["plex"]["fallback_GUID"] = False
+    common._FBGUID_MEMO.clear()
+    monkeypatch.setattr(common, "_FBGUID_MEMO_PATH", None)
+    history._clear_guid_index()
+    assert history.build_index(ad) == recovered
+    assert searches == [1]
+
+
+@pytest.mark.parametrize("timestamp", [1787093918, None])
+def test_manual_watched_changes_survive_cached_guid_index(isolated_state, timestamp):
+    row = {"type": "movie", "ratingKey": "42", "title": "Manual movie", "year": 1990,
+           "Guid": [{"id": "tmdb://123"}], "viewCount": 0}
+    if timestamp is not None:
+        row["lastViewedAt"] = timestamp
+    index_reads = []
+
+    def get(url, *, params=None, **kwargs):
+        params = params or {}
+        if params.get("X-Plex-Container-Size") == 1000:
+            index_reads.append(1)
+        rows = [] if "unwatched" in params and not row["viewCount"] else [dict(row)]
+        return SimpleNamespace(ok=True, status_code=200, headers={"content-type": "application/json"},
+                               json=lambda: {"MediaContainer": {"Metadata": rows, "totalSize": len(rows)}})
+
+    server = SimpleNamespace(baseurl="http://plex", _token="token", machineIdentifier="server",
+                             history=lambda **kwargs: [], _session=SimpleNamespace(headers={}, get=get))
+    ad = SimpleNamespace(client=SimpleNamespace(server=server),
+                         config={"_cw_pair_scope": "cw2_history_options", "plex": {"history": {"include_marked_watched": True}}},
+                         libraries=lambda **kwargs: [SimpleNamespace(key="1", type="movie", title="Movies")])
+    assert history.build_index(ad) == {}
+    row["viewCount"] = 1
+    watched = history.build_index(ad)
+    assert len(watched) == 1
+    item = next(iter(watched.values()))
+    assert item["watched"] is True
+    if timestamp is not None:
+        assert item["watched_at"] == history._iso(timestamp)
+    else:
+        assert not item.get("watched_at")
+    assert history.build_index(ad) == watched
+    row["viewCount"] = 0
+    assert history.build_index(ad) == {}
+    assert len(index_reads) == 1

--- a/tests/test_plex_index_cache.py
+++ b/tests/test_plex_index_cache.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+from types import SimpleNamespace
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from cw_platform.log_context import log_run_id
+from providers.sync.plex import _common as common, _history as history
+
+
+def adapter(*, pair="cw2_pair_a", token="token", user="viewer", base="http://plex", movie="11"):
+    server = SimpleNamespace(machineIdentifier="server", _token=token, url=lambda path: base + path, movie=movie)
+    return SimpleNamespace(
+        client=SimpleNamespace(server=server),
+        config={"_cw_pair_scope": pair, "plex": {"username": user}},
+        libraries=lambda **kwargs: [SimpleNamespace(key="1", type="movie")],
+    )
+
+
+@pytest.fixture(autouse=True)
+def context(monkeypatch):
+    for name in ("CW_PAIR_KEY", "CW_PAIR_SCOPE", "CW_SYNC_PAIR", "CW_PAIR"):
+        monkeypatch.delenv(name, raising=False)
+    token = log_run_id.set("run1")
+    history._clear_guid_index()
+    monkeypatch.setattr(history._INDEX_CACHE, "catalog", None, raising=False)
+    monkeypatch.setattr(history, "_dbg", lambda *args, **kwargs: None)
+    yield
+    log_run_id.reset(token)
+    history._clear_guid_index()
+
+
+@pytest.fixture
+def fetches(monkeypatch):
+    calls = []
+
+    def fetch(server, section, kind):
+        calls.append((server.movie, section))
+        rows = [{"ratingKey": server.movie, "Guid": [{"id": "tmdb://1"}]}] if server.movie else []
+        return rows, 1
+
+    monkeypatch.setattr(history, "_fetch_section_guid_rows", fetch)
+    return calls
+
+
+@pytest.mark.parametrize("change", ["pair", "token", "user", "base", "machine", "libraries", "feature", "run"])
+def test_guid_index_isolated_across_batches_and_contexts(fetches, change):
+    first = adapter()
+    expected = history._build_guid_index(first, {"1"})
+    assert history._build_guid_index(adapter(), {"1"}) is expected
+    assert len(fetches) == 1
+    config = {change: "different"} if change in {"pair", "token", "user", "base"} else {}
+    second = adapter(**config)
+    if change == "machine":
+        second.client.server.machineIdentifier = "other-server"
+    if change == "run":
+        log_run_id.set("run2")
+    allowed = {"1", "2"} if change == "libraries" else {"1"}
+    feature = "progress" if change == "feature" else "history"
+    assert history._build_guid_index(second, allowed, feature=feature) is not expected
+    assert len(fetches) == 2
+
+
+@pytest.mark.parametrize("pair", [None, "", "unscoped", "default", "none"])
+def test_missing_pair_scope_prevents_cross_adapter_reuse(fetches, pair):
+    first, second = adapter(pair=pair), adapter(pair=pair)
+    history._build_guid_index(first, {"1"})
+    history._build_guid_index(first, {"1"})
+    history._build_guid_index(second, {"1"})
+    assert len(fetches) == 2
+
+
+def test_environment_run_id_does_not_enable_sharing(fetches, monkeypatch):
+    log_run_id.set("")
+    monkeypatch.setenv("CW_RUN_ID", "finished-run")
+    history._build_guid_index(adapter(), {"1"})
+    history._build_guid_index(adapter(), {"1"})
+    assert len(fetches) == 2
+
+
+def test_new_run_sees_library_changes_without_loading_old_disk_index(fetches, monkeypatch):
+    monkeypatch.setattr(history, "read_json", lambda *args: pytest.fail("persisted GUID cache must not be loaded"))
+    first = adapter()
+    history._build_guid_index(first, {"1"})
+    assert history._pms_find_in_guid_index("movie", ["tmdb://1"]) == "11"
+    first.client.server.movie = "22"
+    log_run_id.set("run2")
+    history._build_guid_index(first, {"1"})
+    assert history._pms_find_in_guid_index("movie", ["tmdb://1"]) == "22"
+    assert len(fetches) == 2
+
+
+@pytest.mark.parametrize("movie", ["11", ""])
+def test_long_run_reuses_index_including_empty_results(fetches, monkeypatch, movie):
+    now = [100.0]
+    monkeypatch.setattr(history.time, "monotonic", lambda: now[0])
+    first = history._build_guid_index(adapter(movie=movie), {"1"})
+    now[0] += 900
+    assert history._build_guid_index(adapter(movie=movie), {"1"}) is first
+    assert len(fetches) == 1
+
+
+def test_standalone_ttl_and_force_refresh(fetches, monkeypatch):
+    log_run_id.set("")
+    now = [100.0]
+    monkeypatch.setattr(history.time, "monotonic", lambda: now[0])
+    ad = adapter()
+    first = history._build_guid_index(ad, {"1"})
+    now[0] += 299
+    assert history._build_guid_index(ad, {"1"}) is first
+    now[0] += 2
+    second = history._build_guid_index(ad, {"1"})
+    assert second is not first
+    assert history._build_guid_index(ad, {"1"}, force=True) is not second
+    assert len(fetches) == 3
+
+
+def test_threads_do_not_overwrite_each_others_index(fetches):
+    barrier = Barrier(2)
+
+    def run(pair, movie):
+        log_run_id.set("parallel-run")
+        ad = adapter(pair=pair, movie=movie)
+        history._build_guid_index(ad, {"1"})
+        barrier.wait(timeout=5)
+        return history._pms_find_in_guid_index("movie", ["tmdb://1"])
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(run, "pair_a", "11")
+        second = pool.submit(run, "pair_b", "22")
+        assert (first.result(), second.result()) == ("11", "22")
+
+
+@pytest.mark.parametrize("change", ["pair", "token", "user", "base", "run"])
+def test_history_catalog_respects_scope(monkeypatch, change):
+    calls = []
+
+    def build(*args, **kwargs):
+        calls.append(1)
+        return history.HistoryCatalog()
+
+    monkeypatch.setattr(history, "_build_history_catalog", build)
+    first = history._get_history_catalog(adapter(), {"1"})
+    assert history._get_history_catalog(adapter(), {"1"}) is first
+    if change == "run":
+        log_run_id.set("run2")
+    second = adapter(**({change: "different"} if change != "run" else {}))
+    assert history._get_history_catalog(second, {"1"}) is not first
+    assert len(calls) == 2
+
+
+def test_history_catalog_keeps_live_state_ttl(monkeypatch):
+    now = [100.0]
+    monkeypatch.setattr(history.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(history, "_build_history_catalog", lambda *args, **kwargs: history.HistoryCatalog())
+    ad = adapter()
+    first = history._get_history_catalog(ad, {"1"})
+    now[0] += 91
+    second = history._get_history_catalog(ad, {"1"})
+    assert second is not first
+    assert history._get_history_catalog(ad, {"1"}, force=True) is not second
+
+
+def test_failed_page_never_leaves_partial_index(monkeypatch):
+    calls = []
+
+    def get(url, **kwargs):
+        start = kwargs["params"]["X-Plex-Container-Start"]
+        calls.append(start)
+        rows = [{"ratingKey": str(i), "Guid": [{"id": f"tmdb://{i}"}]} for i in range(1000)]
+        return SimpleNamespace(ok=start == 0, status_code=200 if start == 0 else 503,
+                               headers={"content-type": "application/json"},
+                               json=lambda: {"MediaContainer": {"Metadata": rows, "totalSize": 1200}})
+
+    ad = adapter()
+    ad.client.server._session = SimpleNamespace(headers={}, get=get)
+    with pytest.raises(RuntimeError, match="plex_guid_index_http_503"):
+        history._build_guid_index(ad, {"1"})
+    assert calls == [0, 1000]
+    assert history._cached_guid_index(ad, {"1"}) is None
+    assert history._pms_find_in_guid_index("movie", ["tmdb://1"]) is None
+
+
+def test_empty_guid_query_is_not_repeated_through_raw_http():
+    calls = []
+
+    def query(path):
+        calls.append(path)
+        return ET.fromstring('<MediaContainer size="0"/>')
+
+    server = SimpleNamespace(query=query, _token="token", url=lambda path: "http://plex" + path,
+                             _session=SimpleNamespace(headers={}, get=lambda *args, **kwargs: pytest.fail("duplicate query")))
+    assert common.server_find_rating_key_by_guid(server, iter(["tmdb://1", "tmdb://1"])) is None
+    assert len(calls) == 1
+
+
+def test_short_guid_page_with_remaining_total_keeps_paging():
+    starts = []
+    rows = [{"ratingKey": str(i), "Guid": [{"id": f"tmdb://{i}"}]} for i in range(3)]
+
+    def get(url, **kwargs):
+        start = kwargs["params"]["X-Plex-Container-Start"]
+        starts.append(start)
+        return SimpleNamespace(ok=True, headers={"content-type": "application/json"},
+                               json=lambda: {"MediaContainer": {"Metadata": rows[start:start + 2], "totalSize": 3}})
+
+    ad = adapter()
+    ad.client.server._session = SimpleNamespace(headers={}, get=get)
+    index = history._build_guid_index(ad, {"1"})
+    assert len(index["movies"]) == 3
+    assert starts == [0, 2]
+
+
+def test_failed_guid_query_still_uses_raw_http_fallback():
+    calls = []
+
+    def query(path):
+        raise RuntimeError("PlexAPI request failed")
+
+    def get(*args, **kwargs):
+        calls.append(kwargs["params"]["guid"])
+        return SimpleNamespace(ok=True, headers={"Content-Type": "application/json"},
+                               json=lambda: {"MediaContainer": {"Metadata": [{"ratingKey": "11"}]}})
+
+    server = SimpleNamespace(query=query, _token="token", url=lambda path: "http://plex" + path,
+                             _session=SimpleNamespace(headers={}, get=get))
+    assert common.server_find_rating_key_by_guid(server, ["tmdb://1"]) == "11"
+    assert calls == ["tmdb://1"]

--- a/tests/test_plex_playlists_resolve.py
+++ b/tests/test_plex_playlists_resolve.py
@@ -132,12 +132,9 @@ def plex(monkeypatch, tmp_path):
     from providers.sync.plex import _playlists as pl
 
     monkeypatch.setattr(h, "_as_base_url", lambda _s: "http://pms")
-    monkeypatch.setattr(h, "_load_guid_index", lambda *a, **k: False)
-    monkeypatch.setattr(h, "_save_guid_index", lambda *a, **k: None)
     monkeypatch.setattr(pl, "server_find_rating_key_by_guid", lambda *a, **k: None)
     monkeypatch.setattr(pl, "plex_feature_library_ids", lambda *a, **k: set())
     h._clear_guid_index()
-    h._GUID_INDEX_KEY = None
 
     playlist = _Playlist()
     return pl, _Adapter(_Server(playlist)), playlist

--- a/tests/test_plex_progress_guid_index_resolve.py
+++ b/tests/test_plex_progress_guid_index_resolve.py
@@ -99,10 +99,7 @@ def plex(monkeypatch):
     adapter = _Adapter(srv)
 
     monkeypatch.setattr(h, "_as_base_url", lambda _s: "http://pms")
-    monkeypatch.setattr(h, "_load_guid_index", lambda *a, **k: False)
-    monkeypatch.setattr(h, "_save_guid_index", lambda *a, **k: None)
     h._clear_guid_index()
-    h._GUID_INDEX_KEY = None
 
     monkeypatch.setattr(pr, "server_find_rating_key_by_guid", lambda *a, **k: None)
     monkeypatch.setattr(pr, "plex_feature_library_ids", lambda *a, **k: set())


### PR DESCRIPTION
# Pull request

## Change

- Keep Plex indexes scoped to the run, pair, server, user and feature. 
- Reuse them between batches and avoid duplicate GUID requests.

## Why

- Cached indexes could stay stale or be reused across pairs. Failed matches also caused unnecessary requests.

## Testing

- tests/test_plex_index_cache.py
- tests/test_plex_history_options.py

## Issue
Relates to #1071