### PR TITLE
Change: Jellyfin ID matching and lookup caching

### DIFF
--- a/assets/js/modals/pair-config/help.js
+++ b/assets/js/modals/pair-config/help.js
@@ -52,8 +52,8 @@ export const HELP_TEXT = {
   "plx-fallback-guid": "Plex: Fallback GUID\nAlso searches Plex's database beyond your visible libraries (including hidden/old items) to recover older matches.\nWarning: enable only for a single run, it increases duration and resource usage.",
   "plx-marked-watched": "Plex: Marked watched\nInclude items you manually marked as watched in Plex when syncing history.\nDisable if you only want actual play history.",
   "plx-strict-ids": "Plex: Strict ID matching\nWhen enabled, CrossWatch only matches by IDs (Plex IDs + external IDs). Title/year searches are disabled.",
-  "jf-strict-ids": "Jellyfin: Strict ID matching\nWhen enabled, CrossWatch only matches by IDs (Jellyfin IDs + external IDs). Title/year searches are disabled.",
-  "jf-targeted-lookup": "Jellyfin: Targeted library lookup\nWhen writing to Jellyfin, search Jellyfin by title first and verify the result before falling back to the full library scan. Disable to use the slower all-items scan behavior.",
+  "jf-strict-ids": "Jellyfin: Strict ID matching\nRequire Jellyfin or external IDs to confirm matches. Title searches and path matching are disabled. Episodes can match by series ID plus season and episode numbers.",
+  "jf-targeted-lookup": "Jellyfin: Targeted library lookup\nMatch through a cached movie and series ID catalogue, then fetch episodes only for matched series. The catalogue checks for metadata changes on each sync that needs matching and refreshes fully every 24 hours. Disable to allow a full episode index. Title and path fallback require Strict ID matching to be off.",
   "em-strict-ids": "Emby: Strict ID matching\nWhen enabled, CrossWatch only matches by IDs (Emby IDs + external IDs). Title/year searches are disabled.",
 };
 

--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -568,7 +568,7 @@ DEFAULT_CFG: dict[str, Any] = {
         "verify_ssl": False,                            # Verify TLS certificates
         "timeout": 15.0,                                # HTTP timeout (seconds)
         "max_retries": 3,                               # Retry budget for API calls
-        "targeted_lookup": True,                        # Use targeted title search before full library scans when resolving writes
+        "targeted_lookup": True,                        # Cache movie/series IDs; fetch matched series episodes. False indexes all episodes.
 
         "scrobble": {
             "libraries": []                             # whitelist of library GUIDs; empty = all

--- a/providers/sync/jellyfin/_common.py
+++ b/providers/sync/jellyfin/_common.py
@@ -842,7 +842,10 @@ def get_series_episodes(
         "Fields": "IndexNumber,ParentIndexNumber,SeasonId,SeriesId,ProviderIds,ProductionYear,Type",
         "EnableUserData": False,
     }
+    started = time.monotonic()
     r = http.get(f"/Shows/{series_id}/Episodes", params=q)
+    _dbg("series_episodes_response", series_id=series_id, status=getattr(r, "status_code", 0),
+         latency_ms=int((time.monotonic() - started) * 1000))
     if getattr(r, "status_code", 0) != 200:
         return None
     try:
@@ -1209,6 +1212,7 @@ def _native_row_matches_request(
     want_type: str | None,
     title: str,
     year: Any,
+    strict: bool = False,
 ) -> bool:
     if not row or not _row_matches_type(row, want_type):
         return False
@@ -1218,10 +1222,13 @@ def _native_row_matches_request(
         row_public = _ids_from_provider_ids(row.get("ProviderIds"))
         if any(row_public.get(key) == value for key, value in requested_public.items()):
             return True
-        if row_public:
+        if row_public or strict:
             return False
         return _row_matches_title_year(row, title, year)
 
+    if strict:
+        # The caller already verified the native item ID, type and library scope.
+        return True
     if title:
         return _row_matches_title_year(row, title, year)
     return True
@@ -1240,7 +1247,8 @@ def _validate_native_item_id(
     s = str(iid or "").strip()
     if not s or looks_like_bad_id(s):
         return None
-    needs_validation = bool(selected_libs or _public_ids(ids) or title)
+    strict = bool(getattr(getattr(adapter, "cfg", None), "strict_id_matching", False))
+    needs_validation = bool(strict or selected_libs or _public_ids(ids) or title)
     if not needs_validation:
         _dbg("resolve_hit", kind="direct", method="provider_id", item_id=s)
         return s
@@ -1258,7 +1266,9 @@ def _validate_native_item_id(
         setattr(adapter, "_jellyfin_last_resolve_hint", "outside_library_scope")
         _dbg("target_candidate_outside_library_scope", item_id=s, allowed_library_ids=sorted(selected_libs), resolution_method="provider_id")
         return None
-    if row and _native_row_matches_request(row, ids, want_type=want_type, title=title, year=year):
+    if row and (not strict or str(row.get("Id") or "") == s) and _native_row_matches_request(
+        row, ids, want_type=want_type, title=title, year=year, strict=strict,
+    ):
         return s
     _dbg("native_id_rejected", item_id=s, kind=want_type, title=title, year=year)
     return None
@@ -1348,20 +1358,63 @@ def _valid_item_id(value: Any) -> str | None:
     return s if s and not looks_like_bad_id(s) else None
 
 
+_TARGETED_CACHE = local()
+
+
+def _targeted_enabled(adapter: Any) -> bool:
+    value = getattr(getattr(adapter, "cfg", None), "targeted_lookup", True)
+    return str(value).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _targeted_cache(adapter: Any, feature: str) -> dict[Any, Any]:
+    cfg = adapter.cfg
+    config = getattr(adapter, "config", None)
+    scope = config.get("_cw_pair_scope") if isinstance(config, Mapping) else None
+    scope = str(scope or _pair_scope() or "")
+    run = log_run_id.get()
+    server = str(getattr(cfg, "server", "") or "")
+    user = str(getattr(cfg, "user_id", "") or "")
+    credential = str(getattr(cfg, "access_token", "") or "")
+    key = (run, server, user, sha256(credential.encode()).digest(), scope, feature,
+           tuple(sorted(jf_selected_library_ids(cfg, feature))))
+    shared = bool(run and server and user and credential and scope
+                  and scope.lower() not in {"unscoped", "default", "none"})
+    if shared:
+        entry = getattr(_TARGETED_CACHE, "entry", None)
+        if entry is None or entry[0] != key:
+            entry = (key, {})
+            _TARGETED_CACHE.entry = entry
+        return entry[1]
+    # Without a complete scope, reuse only on this adapter during an active run.
+    if not run:
+        return {}
+    entry = getattr(adapter, "_jellyfin_targeted_cache", None)
+    if entry is None or entry[0] != key:
+        entry = (key, {})
+        setattr(adapter, "_jellyfin_targeted_cache", entry)
+    return entry[1]
+
+
 def _targeted_search(
     adapter: Any,
     feature: str,
     selected_libs: set[str],
     include_types: str,
     term: str,
+    *,
+    verify_ancestors: bool = False,
 ) -> list[Mapping[str, Any]]:
     if not str(term or "").strip():
         return []
+    cache = _targeted_cache(adapter, feature)
+    key = ("search", include_types, term, verify_ancestors)
+    if key in cache:
+        _dbg("targeted_search_cache_hit", lookup_feature=feature, term=term, kind=include_types,
+             candidates=len(cache[key]), verify_ancestors=verify_ancestors)
+        return cache[key]
     try:
-        rows = jf_get_scoped_items(
-            adapter.client,
-            adapter.cfg.user_id,
-            {
+        rows: list[Mapping[str, Any]] = []
+        params = {
                 "recursive": True,
                 "includeItemTypes": include_types,
                 "SearchTerm": term,
@@ -1371,12 +1424,64 @@ def _targeted_search(
                 ),
                 "Limit": 50,
                 "EnableUserData": False,
-            },
-            adapter.cfg,
-            feature,
-        )
-        return jf_filter_library_candidates(rows, selected_libs, trust_query_scope=True)
-    except Exception:
+                "EnableImages": False,
+            }
+        queries = [params] if verify_ancestors else jf_scoped_params(params, adapter.cfg, feature)
+        for query in queries:
+            started = time.monotonic()
+            response = adapter.client.get("/Items", params={**query, "userId": adapter.cfg.user_id})
+            status = getattr(response, "status_code", 0)
+            if status != 200:
+                _dbg("targeted_search_response", lookup_feature=feature, term=term, kind=include_types,
+                     status=status, source_library_id=query.get("ParentId"), reason="http_error",
+                     latency_ms=int((time.monotonic() - started) * 1000))
+                return []  # Do not remember a failed or partially successful search.
+            page = (response.json() or {}).get("Items") or []
+            _dbg("targeted_search_response", lookup_feature=feature, term=term, kind=include_types,
+                 status=status, source_library_id=query.get("ParentId"), candidates=len(page),
+                 limit=params["Limit"], limit_reached=len(page) >= params["Limit"],
+                 latency_ms=int((time.monotonic() - started) * 1000))
+            rows.extend(row for row in page if isinstance(row, Mapping))
+        before_scope = len(rows)
+        if verify_ancestors:
+            verified = []
+            for row in rows:
+                iid = _valid_item_id(row.get("Id"))
+                if not iid:
+                    continue
+                ancestor_key = ("ancestors", iid)
+                ancestors = cache.get(ancestor_key)
+                if ancestors is None:
+                    response = adapter.client.get(f"/Items/{iid}/Ancestors", params=user_params(adapter.cfg.user_id))
+                    if getattr(response, "status_code", 0) != 200:
+                        _dbg("targeted_search_ancestors_failed", lookup_feature=feature, term=term,
+                             item_id=iid, status=getattr(response, "status_code", 0), reason="http_error")
+                        return []
+                    body = response.json()
+                    if not isinstance(body, list):
+                        _dbg("targeted_search_ancestors_failed", lookup_feature=feature, term=term,
+                             item_id=iid, reason="invalid_response")
+                        return []
+                    ancestors = {str(a["Id"]) for a in body if isinstance(a, Mapping) and a.get("Id")}
+                    cache[ancestor_key] = ancestors
+                if ancestors & selected_libs:
+                    verified.append(row)
+            rows = verified
+        else:
+            rows = jf_filter_library_candidates(rows, selected_libs, trust_query_scope=True)
+        if selected_libs:
+            _dbg("targeted_search_scope", lookup_feature=feature, term=term, kind=include_types,
+                 candidates=before_scope, accepted=len(rows), rejected=before_scope - len(rows),
+                 allowed_library_ids=sorted(selected_libs), verify_ancestors=verify_ancestors)
+        rows = list({str(row.get("Id")): row for row in rows if _valid_item_id(row.get("Id"))}.values())
+        if len(cache) >= 2048:
+            cache.clear()
+        cache[key] = rows
+        return rows
+    except Exception as exc:
+        # Exception messages and request URLs may contain credentials.
+        _dbg("targeted_search_failed", lookup_feature=feature, term=term, kind=include_types,
+             error_type=type(exc).__name__)
         return []
 
 
@@ -1410,7 +1515,7 @@ def _targeted_year_ok(row: Mapping[str, Any], year: Any, *, missing_ok: bool) ->
         return False
 
 
-def _pick_targeted_match(
+def _targeted_matches(
     rows: Iterable[Mapping[str, Any]],
     *,
     jf_type: str,
@@ -1418,27 +1523,49 @@ def _pick_targeted_match(
     year: Any,
     pairs: Iterable[str],
     strict: bool,
-) -> Mapping[str, Any] | None:
+    feature: str = "history",
+) -> list[Mapping[str, Any]]:
     pair_list = list(pairs or [])
-    cands = [
-        row for row in rows
-        if (row.get("Type") or "") == jf_type
-        and (row.get("Name") or "").strip().lower() == title.strip().lower()
-        and _valid_item_id(row.get("Id"))
-    ]
-    pair_cands = [
-        row for row in cands
-        if _row_matches_pair(row, pair_list) and _targeted_year_ok(row, year, missing_ok=True)
-    ]
-    if len(pair_cands) == 1:
-        return pair_cands[0]
-    if strict or pair_list:
-        return None
-    plain = [row for row in cands if _targeted_year_ok(row, year, missing_ok=False)]
-    return plain[0] if len(plain) == 1 else None
+    candidates = list(rows)
+    matched = []
+    rejected: dict[str, int] = {}
+    for row in candidates:
+        reason = ""
+        if row.get("Type") != jf_type:
+            reason = "type_mismatch"
+        elif not _valid_item_id(row.get("Id")):
+            reason = "invalid_item_id"
+        elif pair_list and not _row_matches_pair(row, pair_list):
+            reason = "id_mismatch"
+        elif not pair_list and strict:
+            reason = "missing_source_ids"
+        elif not pair_list and (row.get("Name") or "").strip().casefold() != title.strip().casefold():
+            reason = "title_mismatch"
+        elif not (strict and pair_list) and not _targeted_year_ok(row, year, missing_ok=bool(pair_list)):
+            reason = "year_mismatch"
+        if reason:
+            rejected[reason] = rejected.get(reason, 0) + 1
+        else:
+            matched.append(row)
+    if not pair_list and len(matched) > 1:
+        rejected["ambiguous_title"] = len(matched)
+        matched = []
+    _dbg("targeted_search_match", lookup_feature=feature, term=title, kind=jf_type,
+         candidates=len(candidates), matched=len(matched), rejected=rejected)
+    return matched
 
 
-def _targeted_lookup_item_id(
+def _targeted_search_terms(title: str, *, has_ids: bool) -> list[str]:
+    terms = [title]
+    if has_ids:
+        # Only query text changes. A shortened query must still match external IDs.
+        cleaned = re.sub(r"(?:\s*\((?:NL|(?:19|20)\d{2})\))+$", "", title, flags=re.I).strip()
+        if cleaned and cleaned != title:
+            terms.append(cleaned)
+    return terms
+
+
+def _targeted_lookup_item_ids(
     adapter: Any,
     it: Mapping[str, Any],
     *,
@@ -1447,10 +1574,9 @@ def _targeted_lookup_item_id(
     episode_pairs: list[str],
     series_pairs: list[str],
     selected_libs: set[str],
-) -> str | None:
-    enabled = getattr(getattr(adapter, "cfg", None), "targeted_lookup", True)
-    if str(enabled).strip().lower() in ("0", "false", "no", "off"):
-        return None
+) -> list[str]:
+    if not _targeted_enabled(adapter):
+        return []
 
     item_type = _lookup_type(it)
     title = (it.get("title") or "").strip()
@@ -1460,55 +1586,105 @@ def _targeted_lookup_item_id(
     series_title = (it.get("series_title") or "").strip()
     strict = bool(getattr(getattr(adapter, "cfg", None), "strict_id_matching", False))
 
-    if item_type in ("movie", "show", "series") and title:
-        jf_type = "Movie" if item_type == "movie" else "Series"
-        row = _pick_targeted_match(
-            _targeted_search(adapter, feature, selected_libs, jf_type, title),
-            jf_type=jf_type,
-            title=title,
-            year=year,
-            pairs=pairs,
-            strict=strict,
-        )
-        iid = _valid_item_id(row.get("Id")) if row else None
-        if iid:
-            kind = "movie" if jf_type == "Movie" else "series"
-            _dbg("resolve_hit", kind=kind, method="targeted_search", title=title, year=year, item_id=iid)
-            return iid
-        return None
+    def search_matches(jf_type: str, term: str, ids: list[str], want_year: Any) -> list[Mapping[str, Any]]:
+        if ids and jf_type in {"Movie", "Series"}:
+            from ._id_lookup import find
+            matches = find(adapter, feature, jf_type, ids)
+            if matches:
+                return matches
+        if strict or not term:
+            return []
+        for search_term in _targeted_search_terms(term, has_ids=bool(ids)):
+            if search_term != term:
+                _dbg("targeted_search_variant", lookup_feature=feature, kind=jf_type,
+                     original_term=term, term=search_term)
+            for retry in ([False, True] if selected_libs else [False]):
+                matches = _targeted_matches(
+                    _targeted_search(adapter, feature, selected_libs, jf_type, search_term, verify_ancestors=retry),
+                    jf_type=jf_type, title=term, year=want_year, pairs=ids, strict=strict, feature=feature,
+                )
+                if matches:
+                    return matches
+        return []
 
-    if item_type == "episode" and series_title and season is not None and episode is not None:
-        series_row = _pick_targeted_match(
-            _targeted_search(adapter, feature, selected_libs, "Series", series_title),
-            jf_type="Series",
-            title=series_title,
-            year=None,
-            pairs=series_pairs,
-            strict=strict,
-        )
-        sid = _valid_item_id(series_row.get("Id")) if series_row else None
-        if not sid:
-            return None
-        body = get_series_episodes(adapter.client, adapter.cfg.user_id, sid, start=0, limit=10000)
-        if body is None:
-            return None
-        rows = [
-            row for row in (body.get("Items") or [])
-            if isinstance(row, Mapping)
-            and (row.get("Type") or "") == "Episode"
-            and _episode_number_matches(row, season, episode)
-        ]
+    if item_type in ("movie", "show", "series") and (title or pairs):
+        jf_type = "Movie" if item_type == "movie" else "Series"
+        rows = search_matches(jf_type, title, pairs, year)
+        found = sorted({str(row["Id"]) for row in rows})
+        if found:
+            kind = "movie" if jf_type == "Movie" else "series"
+            _dbg("resolve_hit", kind=kind, method="targeted_lookup", title=title, year=year, item_id=found[0], copies=len(found))
+        return found
+
+    if item_type == "episode" and (series_title or series_pairs) and season is not None and episode is not None:
+        series_rows = search_matches("Series", series_title, series_pairs, None)
+        rows = []
+        cache = _targeted_cache(adapter, feature)
+        for series_row in series_rows:
+            sid = str(series_row["Id"])
+            cache_key = ("episodes", sid)
+            episode_rows = cache.get(cache_key)
+            if episode_rows is None:
+                episode_rows = []
+                page_start = 0
+                seen_pages = set()
+                complete = True
+                while True:
+                    body = get_series_episodes(adapter.client, adapter.cfg.user_id, sid, start=page_start, limit=500)
+                    page = body.get("Items") if isinstance(body, Mapping) else None
+                    if not isinstance(page, list) or any(not isinstance(row, Mapping) for row in page):
+                        episode_rows = []
+                        complete = False
+                        break
+                    signature = tuple(str(row.get("Id") or "") for row in page)
+                    if page and signature in seen_pages:
+                        episode_rows = []
+                        complete = False
+                        break
+                    seen_pages.add(signature)
+                    episode_rows.extend(page)
+                    if len(page) < 500:
+                        break
+                    page_start += len(page)
+                if len(cache) >= 2048:
+                    cache.clear()
+                if complete:
+                    cache[cache_key] = episode_rows
+            rows.extend(row for row in episode_rows
+                        if row.get("Type") == "Episode"
+                        and str(row.get("SeriesId") or sid) == sid
+                        and _valid_item_id(row.get("Id")))
         pair_rows = [row for row in rows if _row_matches_pair(row, episode_pairs)]
+        numbered_rows = [row for row in rows if _episode_number_matches(row, season, episode)]
+        _dbg("targeted_episode_candidates", lookup_feature=feature, series_title=series_title,
+             season=season, episode=episode, series_matches=len(series_rows),
+             numbered_candidates=len(numbered_rows), episode_id_matches=len(pair_rows))
         chosen: Mapping[str, Any] | None = None
-        if len(pair_rows) == 1:
-            chosen = pair_rows[0]
-        elif len(rows) == 1:
-            chosen = rows[0]
+        # Multiple copies with verified series identity and the same coordinates
+        # represent the same episode. Keep a deterministic destination item.
+        # An exact episode ID leads even when servers use different numbering.
+        numbered_pair_rows = [row for row in pair_rows if _episode_number_matches(row, season, episode)]
+        candidates = numbered_pair_rows or pair_rows or numbered_rows
+        if candidates:
+            chosen = min(candidates, key=lambda row: str(row["Id"]))
         iid = _valid_item_id(chosen.get("Id")) if chosen else None
         if iid:
-            _dbg("resolve_hit", kind="episode", method="targeted_series_search", series_title=series_title, season=season, episode=episode, item_id=iid)
-            return iid
-    return None
+            _dbg("resolve_hit", kind="episode", method="targeted_series_lookup", series_title=series_title, season=season, episode=episode, item_id=iid)
+            return [iid]
+    # A source can supply episode IDs and a title without usable series metadata.
+    # Search only that title and require an episode ID match in this route.
+    if not strict and item_type == "episode" and title and episode_pairs:
+        rows = search_matches("Episode", title, episode_pairs, None)
+        found = sorted({str(row["Id"]) for row in rows})
+        if found:
+            _dbg("resolve_hit", kind="episode", method="targeted_episode_search", item_id=found[0])
+            return found[:1]
+    return []
+
+
+def _targeted_lookup_item_id(adapter: Any, it: Mapping[str, Any], **kwargs: Any) -> str | None:
+    found = _targeted_lookup_item_ids(adapter, it, **kwargs)
+    return found[0] if found else None
 
 
 def _path_match_item_id(
@@ -1615,7 +1791,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
 
     strict = bool(getattr(getattr(adapter, "cfg", None), "strict_id_matching", False))
 
-    path_iid = _path_match_item_id(
+    path_iid = None if strict or _targeted_enabled(adapter) else _path_match_item_id(
         adapter,
         it,
         feature=feature,
@@ -1649,6 +1825,12 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
     )
     if targeted_iid:
         return targeted_iid
+    if _targeted_enabled(adapter):
+        _dbg("resolve_miss", kind=t, title=title, series_title=series_title,
+             season=season, episode=episode, method="targeted_only")
+        setattr(adapter, "_jellyfin_last_resolve_hint",
+                "outside_library_scope" if outside_scope_seen else "unmatched_in_jellyfin")
+        return None
 
     # Movies
     if t == "movie":
@@ -1662,6 +1844,7 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
             )
             if raw_cands and not cands and selected_libs:
                 outside_scope_seen = True
+            cands = [row for row in cands if _row_matches_type(row, "movie")]
             iid = _pick_from_candidates(cands, want_type="movie", want_year=year)
             if iid:
                 _dbg('resolve_hit', kind='movie', method='provider_index', pref=pref, item_id=iid)
@@ -1908,6 +2091,16 @@ def resolve_item_ids(adapter: Any, it: Mapping[str, Any], *, feature: str = "his
         for p in spairs:
             if p not in pairs:
                 pairs.append(p)
+
+    if _targeted_enabled(adapter):
+        found = _targeted_lookup_item_ids(
+            adapter, it, feature=feature, pairs=pairs,
+            episode_pairs=all_ext_pairs(ids, prio),
+            series_pairs=all_ext_pairs(show_ids, prio) if show_ids else [],
+            selected_libs=selected_libs,
+        )
+        # Retain a validated native item even if a title search cannot find it.
+        return list(dict.fromkeys(([str(one)] if one else []) + found))
 
     idx = build_provider_index(adapter) if feature == "history" else build_provider_index(adapter, feature=feature)
 

--- a/providers/sync/jellyfin/_history.py
+++ b/providers/sync/jellyfin/_history.py
@@ -951,6 +951,9 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
         reason_counts[reason] = reason_counts.get(reason, 0) + 1
         results.append(_result_row(str(u.get("key") or ""), _ST_RESOLVE_FAILED, action="resolve", reason=reason))
 
+    from ._id_lookup import prepare
+    prepare(adapter, "history", wants.values())
+
     for k, m in wants.items():
         iid = _try_resolve_iid(adapter, m)
         if iid:

--- a/providers/sync/jellyfin/_id_lookup.py
+++ b/providers/sync/jellyfin/_id_lookup.py
@@ -1,0 +1,242 @@
+"""Pair-scoped movie/series identity catalogue for targeted Jellyfin writes."""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from datetime import datetime, timezone
+from hashlib import sha256
+from math import isfinite
+from pathlib import Path
+from typing import Any, Mapping
+
+from . import _common as common
+
+_VERSION = 1
+_FULL_REFRESH_SECONDS = 86400
+_OVERLAP_SECONDS = 120
+_PAGE_SIZE = 500
+_FIELDS = "ProviderIds,Type,Name,ProductionYear,ParentId,CollectionFolderId,AncestorIds,LibraryId"
+
+
+def _cache_path(adapter: Any, feature: str) -> Path | None:
+    cfg = adapter.cfg
+    config = getattr(adapter, "config", None)
+    scope = config.get("_cw_pair_scope") if isinstance(config, Mapping) else None
+    scope = str(scope or common._pair_scope() or "")
+    server = str(getattr(cfg, "server", "") or "")
+    user = str(getattr(cfg, "user_id", "") or "")
+    token = str(getattr(cfg, "access_token", "") or "")
+    if not server or not user or not token or not scope or scope.lower() in {"none", "default", "unscoped"}:
+        return None
+    identity = [scope, server, user, token, feature, sorted(common.jf_selected_library_ids(cfg, feature))]
+    digest = sha256(json.dumps(identity, separators=(",", ":")).encode()).hexdigest()
+    return common.STATE_DIR / f"jellyfin_identity.{digest}.json"
+
+
+def _compact(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: row[key] for key in ("Id", *_FIELDS.split(",")) if key in row}
+
+
+def _fetch(adapter: Any, feature: str, *, after: float | None = None) -> dict[str, dict[str, Any]]:
+    selected = common.jf_selected_library_ids(adapter.cfg, feature)
+    out: dict[str, dict[str, Any]] = {}
+    for parent in sorted(selected) or [None]:
+        start = 0
+        seen: set[tuple[str, ...]] = set()
+        while True:
+            params = {
+                "userId": adapter.cfg.user_id, "Recursive": True,
+                "IncludeItemTypes": "Movie,Series", "Fields": _FIELDS,
+                "EnableImages": False, "EnableUserData": False,
+                "EnableTotalRecordCount": False, "StartIndex": start, "Limit": _PAGE_SIZE,
+            }
+            if parent:
+                params["ParentId"] = parent
+            if after is not None:
+                params["MinDateLastSaved"] = datetime.fromtimestamp(after, timezone.utc).isoformat()
+            response = adapter.client.get("/Items", params=params)
+            if response.status_code != 200:
+                raise RuntimeError(f"identity_index_http_{response.status_code}")
+            body = response.json()
+            if not isinstance(body, dict) or not isinstance(body.get("Items"), list):
+                raise ValueError("invalid_identity_index_response")
+            rows = body["Items"]
+            if any(not isinstance(row, dict) or not common._valid_item_id(row.get("Id")) for row in rows):
+                raise ValueError("invalid_identity_index_row")
+            signature = tuple(str(row["Id"]) for row in rows)
+            if rows and signature in seen:
+                raise ValueError("identity_index_repeated_page")
+            seen.add(signature)
+            scoped = common.jf_filter_library_candidates(rows, selected, trust_query_scope=True)
+            for row in scoped:
+                if row.get("Type") in {"Movie", "Series"}:
+                    out[str(row["Id"])] = _compact(row)
+            common._dbg("identity_index_page", lookup_feature=feature, count=len(rows), start=start,
+                        refresh="delta" if after is not None else "full")
+            if len(rows) < _PAGE_SIZE:
+                break
+            start += len(rows)
+    return out
+
+
+def _load(path: Path | None) -> dict[str, Any] | None:
+    if path is None:
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if data.get("version") != _VERSION or not isinstance(data.get("rows"), dict):
+            return None
+        if any(not isinstance(row, dict) or str(row.get("Id")) != iid for iid, row in data["rows"].items()):
+            return None
+        data["refreshed"] = float(data["refreshed"])
+        data["full_refresh"] = float(data["full_refresh"])
+        if not isfinite(data["refreshed"]) or not isfinite(data["full_refresh"]):
+            return None
+        return data
+    except (OSError, ValueError, TypeError, KeyError, AttributeError):
+        return None
+
+
+def _save(path: Path | None, data: dict[str, Any]) -> None:
+    if path is None:
+        return
+    temporary = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", dir=path.parent, prefix=path.name, suffix=".tmp", delete=False) as fh:
+            temporary = Path(fh.name)
+            json.dump(data, fh, separators=(",", ":"), ensure_ascii=False)
+        os.replace(temporary, path)
+    except OSError as exc:
+        common._dbg("identity_index_cache_write_failed", error_type=type(exc).__name__)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def _catalogue(adapter: Any, feature: str) -> dict[str, Any] | None:
+    cache = common._targeted_cache(adapter, feature)
+    key = ("identity_catalogue",)
+    if key in cache:
+        return cache[key]
+    # A failed refresh is not retried for every unresolved source item.
+    cache[key] = None
+    path = _cache_path(adapter, feature)
+    previous = _load(path)
+    now = time.time()
+    full = (previous is None or now < previous["refreshed"]
+            or now - previous["full_refresh"] >= _FULL_REFRESH_SECONDS
+            or previous.get("delta_supported") is False)
+    try:
+        if previous is not None and not full:
+            after = previous["refreshed"] - _OVERLAP_SECONDS
+            rows = dict(previous["rows"])
+            full_refresh = previous["full_refresh"]
+        else:
+            after = None
+            rows = {}
+            full_refresh = now
+        changed = _fetch(adapter, feature, after=after)
+        rows.update(changed)
+        delta_supported = previous.get("delta_supported", True) if previous else True
+        if previous is None:
+            # Unsupported query parameters can be silently ignored by Jellyfin.
+            # A future-date probe must return no rows before enabling deltas.
+            delta_supported = not _fetch(adapter, feature, after=now + _FULL_REFRESH_SECONDS)
+        data = {"version": _VERSION, "rows": rows, "refreshed": now,
+                "full_refresh": full_refresh, "delta_supported": delta_supported}
+        _save(path, data)
+        index: dict[str, list[dict[str, Any]]] = {}
+        for row in rows.values():
+            common._index_row_provider_ids(index, row)
+        result = {"index": index, "fresh": set(changed), "validated": {}}
+        cache[key] = result
+        common._dbg("identity_index_ready", lookup_feature=feature, refresh="full" if full else "delta",
+                    items=len(rows), changed=len(changed), delta_supported=delta_supported)
+        return result
+    except Exception as exc:
+        common._dbg("identity_index_failed", lookup_feature=feature, error_type=type(exc).__name__)
+        return None
+
+
+def find(adapter: Any, feature: str, kind: str, pairs: list[str]) -> list[Mapping[str, Any]]:
+    if not pairs:
+        return []
+    catalogue = _catalogue(adapter, feature)
+    if catalogue is None:
+        return []
+    candidates = {str(row["Id"]): row for pair in pairs for row in catalogue["index"].get(pair, [])
+                  if row.get("Type") == kind}
+    found = []
+    selected = common.jf_selected_library_ids(adapter.cfg, feature)
+    for iid, row in sorted(candidates.items()):
+        if iid not in catalogue["fresh"]:
+            # Validate persisted matches, including deleted items, changed IDs
+            # and items moved out of the pair's selected libraries.
+            if iid not in catalogue["validated"]:
+                try:
+                    response = adapter.client.get(f"/Items/{iid}", params={"userId": adapter.cfg.user_id, "Fields": _FIELDS})
+                    current = response.json() if response.status_code == 200 else {}
+                    if not isinstance(current, dict) or str(current.get("Id") or "") != iid:
+                        current = {}
+                    if current and selected:
+                        ancestors = adapter.client.get(f"/Items/{iid}/Ancestors", params={"userId": adapter.cfg.user_id})
+                        allowed = ancestors.json() if ancestors.status_code == 200 else []
+                        if not isinstance(allowed, list) or not any(isinstance(a, dict) and str(a.get("Id")) in selected for a in allowed):
+                            current = {}
+                    catalogue["validated"][iid] = current
+                except Exception:
+                    catalogue["validated"][iid] = {}
+            row = catalogue["validated"][iid]
+        if row.get("Type") == kind and common._row_matches_pair(row, pairs):
+            found.append(row)
+    common._dbg("identity_index_match", lookup_feature=feature, kind=kind, candidates=len(candidates), matched=len(found))
+    return found
+
+
+def prepare(adapter: Any, feature: str, items: Any) -> None:
+    """Validate cached targets together before a history write batch resolves them."""
+    if not common._targeted_enabled(adapter):
+        return
+    requested = []
+    priority = common._merged_guid_priority(adapter)
+    for source in items:
+        kind = common._lookup_type(source)
+        ids = source.get("show_ids") if kind == "episode" else source.get("ids")
+        pairs = common.all_ext_pairs(ids or {}, priority)
+        if pairs:
+            requested.append(("Movie" if kind == "movie" else "Series", pairs))
+    if not requested:
+        return
+    catalogue = _catalogue(adapter, feature)
+    if catalogue is None:
+        return
+    # Scoped matches also require current ancestry verification; find handles it.
+    if common.jf_selected_library_ids(adapter.cfg, feature):
+        return
+    pending = sorted({str(row["Id"]) for kind, pairs in requested for pair in pairs
+                      for row in catalogue["index"].get(pair, []) if row.get("Type") == kind
+                      and str(row["Id"]) not in catalogue["fresh"]
+                      and str(row["Id"]) not in catalogue["validated"]})
+    for offset in range(0, len(pending), 100):
+        batch = pending[offset:offset + 100]
+        # Missing/deleted items and failed reads must not become assumed matches.
+        catalogue["validated"].update({iid: {} for iid in batch})
+        try:
+            response = adapter.client.get("/Items", params={
+                "userId": adapter.cfg.user_id, "Ids": ",".join(batch), "Fields": _FIELDS,
+                "EnableImages": False, "EnableUserData": False, "Limit": len(batch),
+            })
+            if response.status_code != 200:
+                continue
+            body = response.json()
+            rows = body.get("Items") if isinstance(body, dict) else None
+            if not isinstance(rows, list):
+                continue
+            for row in rows:
+                if isinstance(row, dict) and str(row.get("Id")) in batch:
+                    catalogue["validated"][str(row["Id"])] = row
+        except Exception as exc:
+            common._dbg("identity_validation_failed", lookup_feature=feature, error_type=type(exc).__name__)

--- a/providers/sync/jellyfin/_progress.py
+++ b/providers/sync/jellyfin/_progress.py
@@ -139,7 +139,7 @@ def _target_state(http: Any, uid: str, item_id: str) -> dict[str, Any]:
         "watched": bool(user_data.get("Played") or user_data.get("IsPlayed")),
         "progress_ms": _ticks_to_ms(user_data.get("PlaybackPositionTicks")),
         "duration_ms": _ticks_to_ms(row.get("RunTimeTicks")),
-        "timestamp": user_data.get("LastPlayedDate") or user_data.get("LastPlayed") or row.get("DateLastSaved"),
+        "timestamp": user_data.get("LastPlayedDate") or user_data.get("LastPlayed"),
         "library_id": row.get("LibraryId") or row.get("CollectionFolderId"),
     }
 

--- a/providers/sync/plex/_history.py
+++ b/providers/sync/plex/_history.py
@@ -16,7 +16,6 @@ from threading import local
 from cw_platform.log_context import log_run_id
 
 from cw_platform.id_map import canonical_key, minimal as id_minimal, ids_from, ids_from_guid
-from providers.sync._mod_common import observation_time
 
 from ._common import (
     _as_base_url,
@@ -1363,7 +1362,6 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
         max_seen = 0
         workers = plex_worker_count(adapter, "history_workers", "CW_PLEX_HISTORY_WORKERS", 12)
         include_marked = bool(_history_cfg_get(adapter, "include_marked_watched", True))
-        interactive_read = bool(observation_time(adapter))
 
         # Optional cursor debugging: show the rows that are considered "new" for this run.
         if eff_since is not None and str(os.environ.get("CW_PLEX_HISTORY_DEBUG_CURSOR", "")).strip().lower() in ("1", "true", "yes"):
@@ -1419,8 +1417,15 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
                 return None
 
             rk = str(getattr(raw, "ratingKey", None) or "").strip()
-            catalog_entry = cat.by_rk.get(rk) if interactive_read and scope_ok else None
-            if catalog_entry and (has_external_ids(catalog_entry.get("ids") or {}) or has_external_ids(catalog_entry.get("show_ids") or {})):
+            # History retains titles from playback time. Use the same current
+            # metadata as incremental presence reads when this library item is
+            # available, so targeted destination searches stay stable across runs.
+            catalog_entry = cat.by_rk.get(rk) if scope_ok else None
+            if (
+                catalog_entry
+                and (catalog_entry.get("title") or catalog_entry.get("series_title"))
+                and (has_external_ids(catalog_entry.get("ids") or {}) or has_external_ids(catalog_entry.get("show_ids") or {}))
+            ):
                 meta = _catalog_entry_to_minimal(catalog_entry)
             else:
                 meta = minimal_from_history_row(raw, token=None, allow_discover=False)

--- a/providers/tests/test_jellyfin_resolver.py
+++ b/providers/tests/test_jellyfin_resolver.py
@@ -102,6 +102,7 @@ def jf_row(
 def test_episode_provider_id_resolves_from_index_without_jellyfin_filter_query():
     episode = jf_row("E1", "Episode", "Pilot", tmdb="7535444", series_id="S1", season=1, episode=1)
     adapter = FakeAdapter(FakeHttp([episode]))
+    adapter.cfg.targeted_lookup = False
 
     item = {"type": "episode", "title": "Pilot", "season": 1, "episode": 1, "ids": {"tmdb": "7535444"}}
 
@@ -132,6 +133,7 @@ def test_episode_can_resolve_by_path_when_provider_ids_are_missing():
     path = r"Z:\TV\Example Show\Season 01\S01E02.mkv"
     episode = jf_row("E3", "Episode", "Second", series_id="S1", season=1, episode=2, path=path)
     adapter = FakeAdapter(FakeHttp([episode]))
+    adapter.cfg.targeted_lookup = False
 
     item = {"type": "episode", "title": "Second", "season": 1, "episode": 2, "ids": {}, "path": path}
 
@@ -166,7 +168,7 @@ def test_resolve_rejects_stale_native_jellyfin_id_when_public_id_disagrees():
 
     assert common.resolve_item_id(adapter, item, feature="history") == "M1"
     assert any(call["path"] == "/Items/M0" for call in adapter.client.calls)
-    assert any(call["params"].get("SearchTerm") == "Encanto" for call in adapter.client.calls)
+    assert not any(call["params"].get("SearchTerm") for call in adapter.client.calls)
 
 
 def test_resolve_rejects_stale_jellyfin_item_id_when_public_id_disagrees():
@@ -178,7 +180,7 @@ def test_resolve_rejects_stale_jellyfin_item_id_when_public_id_disagrees():
 
     assert common.resolve_item_id(adapter, item, feature="history") == "M1"
     assert any(call["path"] == "/Items/M0" for call in adapter.client.calls)
-    assert any(call["params"].get("SearchTerm") == "Encanto" for call in adapter.client.calls)
+    assert not any(call["params"].get("SearchTerm") for call in adapter.client.calls)
 
 
 def test_progress_write_does_not_trust_stale_jellyfin_item_id():
@@ -214,8 +216,8 @@ def test_movie_targeted_lookup_resolves_without_full_provider_index():
     item = {"type": "movie", "title": "Encanto", "year": 2021, "ids": {"tmdb": "568124"}}
 
     assert common.resolve_item_id(adapter, item, feature="history") == "M1"
-    assert any(call["params"].get("SearchTerm") == "Encanto" for call in adapter.client.calls)
-    assert not any("StartIndex" in call["params"] for call in adapter.client.calls)
+    assert not any(call["params"].get("SearchTerm") for call in adapter.client.calls)
+    assert all(call["params"].get("IncludeItemTypes") == "Movie,Series" for call in adapter.client.calls if call["path"] == "/Items")
 
 
 def test_movie_targeted_lookup_disabled_falls_back_to_provider_index():
@@ -239,11 +241,11 @@ def test_strict_targeted_lookup_requires_provider_id_match():
     item = {"type": "movie", "title": "Encanto", "year": 2021, "ids": {"tmdb": "568124"}}
 
     assert common.resolve_item_id(adapter, item, feature="history") == "M1"
-    assert any(call["params"].get("SearchTerm") == "Encanto" for call in adapter.client.calls)
-    assert not any("StartIndex" in call["params"] for call in adapter.client.calls)
+    assert not any(call["params"].get("SearchTerm") for call in adapter.client.calls)
+    assert all(call["params"].get("IncludeItemTypes") == "Movie,Series" for call in adapter.client.calls if call["path"] == "/Items")
 
 
-def test_episode_targeted_lookup_uses_series_search_and_episode_numbers():
+def test_episode_targeted_lookup_uses_series_ids_and_episode_numbers():
     series = jf_row("S1", "Series", "Example Show", tmdb="999")
     episode = jf_row("E2", "Episode", "Second", series_id="S1", season=1, episode=2)
     adapter = FakeAdapter(FakeHttp([series], episodes={"S1": [episode]}))
@@ -259,9 +261,9 @@ def test_episode_targeted_lookup_uses_series_search_and_episode_numbers():
     }
 
     assert common.resolve_item_id(adapter, item, feature="history") == "E2"
-    assert any(call["path"] == "/Items" and call["params"].get("SearchTerm") == "Example Show" for call in adapter.client.calls)
+    assert not any(call["params"].get("SearchTerm") for call in adapter.client.calls)
     assert any(call["path"] == "/Shows/S1/Episodes" for call in adapter.client.calls)
-    assert not any("StartIndex" in call["params"] for call in adapter.client.calls if call["path"] == "/Items")
+    assert all(call["params"].get("IncludeItemTypes") == "Movie,Series" for call in adapter.client.calls if call["path"] == "/Items")
 
 
 def test_jellyfin_scoped_provider_index_trusts_rows_without_library_metadata():

--- a/tests/test_interactive_sync_plex_history.py
+++ b/tests/test_interactive_sync_plex_history.py
@@ -19,7 +19,7 @@ from providers.sync.plex import _history as history
 def test_history_selection_survives_full_to_incremental_read(config_base, monkeypatch, kind, interactive, include_marked):
     watched_at = 1787093918
     raw = SimpleNamespace(type=kind, ratingKey="42", title="History title", guid="tmdb://123",
-                          viewedAt=watched_at, grandparentTitle="Example series", grandparentGuid="tvdb://99", parentIndex=1, index=2)
+                          viewedAt=watched_at, grandparentTitle="Old series title", grandparentGuid="tvdb://99", parentIndex=1, index=2)
     server = SimpleNamespace(history=lambda **kwargs: [] if kwargs.get("mindate") else [raw])
     adapter = SimpleNamespace(client=SimpleNamespace(server=server), cfg=SimpleNamespace(), config={"_cw_interactive_planned_at": 1788650000} if interactive else {})
     catalog = history.HistoryCatalog()
@@ -46,13 +46,14 @@ def test_history_selection_survives_full_to_incremental_read(config_base, monkey
     first = history.build_index(adapter)
     second = history.build_index(adapter)
     assert len(first) == len(second) == 1
+    assert first == second
+    row = next(iter(first.values()))
+    assert row["year"] == 2026
+    if kind == "movie":
+        assert row["title"] == "Catalog title"
+    else:
+        assert row["series_title"] == "Example series"
     if not interactive:
-        expected = history.minimal_from_history_row(raw, token=None, allow_discover=False)
-        row = next(iter(first.values()))
-        assert row["ids"] == expected["ids"]
-        assert row["year"] == expected["year"]
-        if kind == "movie":
-            assert row["title"] == "History title"
         return
     initial = InteractivePlan()
     initial.filter("history", "SIMKL", "SIMKL-P01", "add", [minimal(row) for row in first.values()], source="PLEX")

--- a/tests/test_jellyfin_id_lookup.py
+++ b/tests/test_jellyfin_id_lookup.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from cw_platform.log_context import log_run_id
+from providers.sync.jellyfin import _common as common, _id_lookup as lookup
+
+
+def item(iid, *, kind="Movie", external="1", library="A", changed=900, **extra):
+    return {"Id": iid, "Type": kind, "Name": "English title", "ProductionYear": 2026,
+            "ProviderIds": {"Tmdb": external}, "LibraryId": library, "changed": changed, **extra}
+
+
+class Server:
+    def __init__(self, *rows):
+        self.rows = {row["Id"]: row for row in rows}
+        self.episodes = {}
+        self.calls = []
+        self.fail = False
+        self.repeat = False
+        self.ignore_delta = False
+
+    def get(self, path, *, params):
+        self.calls.append((path, dict(params)))
+        assert "SearchTerm" not in params, "Strict matching must never search titles"
+        assert "AnyProviderIdEquals" not in params
+        if self.fail:
+            return SimpleNamespace(status_code=503, json=lambda: {})
+        if path == "/Items":
+            if params.get("Ids"):
+                rows = [row for iid, row in self.rows.items() if iid in params["Ids"].split(",")]
+            else:
+                assert params["IncludeItemTypes"] == "Movie,Series", "No library-wide episode scan"
+                rows = [row for row in self.rows.values() if not params.get("ParentId") or row["LibraryId"] == params["ParentId"]]
+            if params.get("MinDateLastSaved") and not self.ignore_delta:
+                after = datetime.fromisoformat(params["MinDateLastSaved"]).timestamp()
+                rows = [row for row in rows if row["changed"] >= after]
+        elif path.startswith("/Shows/"):
+            rows = self.episodes.get(path.split("/")[2], [])
+        elif path.endswith("/Ancestors"):
+            row = self.rows.get(path.split("/")[2])
+            return SimpleNamespace(status_code=200, json=lambda: [{"Id": row["LibraryId"]}] if row else [])
+        else:
+            row = self.rows.get(path.split("/")[2])
+            return SimpleNamespace(status_code=200 if row else 404, json=lambda: dict(row or {}))
+        start = 0 if self.repeat else params.get("StartIndex", 0)
+        page = [dict(row) for row in rows[start:start + params["Limit"]]]
+        # Jellyfin may report the page size when total counting is disabled.
+        return SimpleNamespace(status_code=200, json=lambda: {"Items": page, "TotalRecordCount": len(page)})
+
+
+def adapter(http, pair="pair-A", **config):
+    return SimpleNamespace(client=http, config={"_cw_pair_scope": pair}, cfg=SimpleNamespace(**{
+        "server": "http://jellyfin", "user_id": "user-A", "access_token": "private-token",
+        "targeted_lookup": True, "strict_id_matching": True, **config,
+    }))
+
+
+@pytest.fixture(autouse=True)
+def isolated(monkeypatch, tmp_path):
+    token = log_run_id.set("id-run-1")
+    monkeypatch.setattr(common, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(common._TARGETED_CACHE, "entry", None, raising=False)
+    monkeypatch.setattr(common, "_pair_scope", lambda: None)
+    monkeypatch.setattr(common, "build_provider_index", lambda *a, **kw: pytest.fail("Full episode/path index"))
+    monkeypatch.setattr(lookup.time, "time", lambda: 1000.0)
+    yield
+    log_run_id.reset(token)
+
+
+@pytest.mark.parametrize("title", [None, "Een andere titel"])
+@pytest.mark.parametrize("feature", ["history", "progress"])
+@pytest.mark.parametrize("strict", [True, False])
+def test_movies_match_only_ids_despite_titles_years_and_duplicate_copies(title, feature, strict):
+    server = Server(item("a"), item("b"), item("wrong", external="2"), item("series", kind="Series"))
+    source = {"type": "movie", "year": 2000, "ids": {"tmdb": "1"}}
+    if title:
+        source["title"] = title
+    ad = adapter(server, strict_id_matching=strict)
+    assert common.resolve_item_ids(ad, source, feature=feature) == ["a", "b"]
+    assert common.resolve_item_ids(ad, source, feature=feature) == ["a", "b"]
+    assert len(server.calls) == 2  # Initial catalogue and delta-support probe, reused across batches.
+    assert source.get("title") == title
+
+
+@pytest.mark.parametrize("title", [None, "Achter de attractie"])
+def test_series_id_and_coordinates_work_without_matching_title(title):
+    server = Server(item("series", kind="Series", external="95738"))
+    server.episodes["series"] = [item(str(n), kind="Episode", external=str(n + 100),
+                                      SeriesId="series", ParentIndexNumber=1, IndexNumber=n) for n in range(1, 4)]
+    for n in range(1, 4):
+        source = {"type": "episode", "series_title": title, "season": 1, "episode": n,
+                  "show_ids": {"tmdb": "95738"}}
+        assert common.resolve_item_id(adapter(server), source) == str(n)
+    assert len(server.calls) == 3
+
+
+def test_episode_id_leads_when_servers_use_different_numbering():
+    server = Server(item("series", kind="Series", external="95738"))
+    server.episodes["series"] = [
+        item("wrong", kind="Episode", external="101", SeriesId="series", ParentIndexNumber=1, IndexNumber=1),
+        item("correct", kind="Episode", external="102", SeriesId="series", ParentIndexNumber=2, IndexNumber=4),
+    ]
+    source = {"type": "episode", "season": 1, "episode": 1,
+              "show_ids": {"tmdb": "95738"}, "ids": {"tmdb": "102"}}
+    assert common.resolve_item_id(adapter(server), source) == "correct"
+
+
+def test_failed_episode_fetch_is_retried_in_same_run(monkeypatch):
+    server = Server(item("series", kind="Series", external="95738"))
+    source = {"type": "episode", "season": 1, "episode": 1, "show_ids": {"tmdb": "95738"}}
+    ad = adapter(server)
+    lookup.find(ad, "history", "Series", ["tmdb.95738"])
+    server.fail = True
+    assert common.resolve_item_id(ad, source) is None
+    server.fail = False
+    server.episodes["series"] = [item("correct", kind="Episode", SeriesId="series", ParentIndexNumber=1, IndexNumber=1)]
+    assert common.resolve_item_id(ad, source) == "correct"
+
+
+def test_pagination_reads_all_metadata_and_all_matched_series_episodes(monkeypatch):
+    monkeypatch.setattr(lookup, "_PAGE_SIZE", 2)
+    server = Server(item("m1"), item("m2"), item("series", kind="Series", external="9"))
+    server.episodes["series"] = [item(str(n), kind="Episode", SeriesId="series",
+                                      ParentIndexNumber=1, IndexNumber=n) for n in range(1, 502)]
+    source = {"type": "episode", "season": 1, "episode": 501, "show_ids": {"tmdb": "9"}}
+    assert common.resolve_item_id(adapter(server), source) == "501"
+    assert [p["StartIndex"] for path, p in server.calls if path.startswith("/Shows/")] == [0, 500]
+
+
+def test_next_run_refreshes_added_items_and_changed_ids(monkeypatch):
+    server = Server(item("old", changed=100))
+    source = {"type": "movie", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_id(adapter(server), source) == "old"
+    server.rows["old"] = item("old", external="2", changed=1001)
+    server.rows["new"] = item("new", external="3", changed=1001)
+    monkeypatch.setattr(lookup.time, "time", lambda: 1010.0)
+    log_run_id.set("id-run-2")
+    server.calls.clear()
+    ad = adapter(server)
+    assert common.resolve_item_id(ad, source) is None
+    assert common.resolve_item_id(ad, {"type": "movie", "ids": {"tmdb": "2"}}) == "old"
+    assert common.resolve_item_id(ad, {"type": "movie", "ids": {"tmdb": "3"}}) == "new"
+    assert len(server.calls) == 1
+    assert "MinDateLastSaved" in server.calls[0][1]
+
+
+@pytest.mark.parametrize("mutation", ["unchanged", "deleted", "changed_id", "moved_library"])
+def test_persisted_hits_are_revalidated_once_per_run(mutation):
+    server = Server(item("movie", changed=100))
+    source = {"type": "movie", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_id(adapter(server, history_libraries=["A"]), source) == "movie"
+    if mutation == "deleted":
+        del server.rows["movie"]
+    elif mutation == "changed_id":
+        server.rows["movie"]["ProviderIds"] = {"Tmdb": "9"}
+    elif mutation == "moved_library":
+        server.rows["movie"]["LibraryId"] = "B"
+    log_run_id.set("id-run-2")
+    server.calls.clear()
+    ad = adapter(server, history_libraries=["A"])
+    expected = "movie" if mutation == "unchanged" else None
+    assert common.resolve_item_id(ad, source) == expected
+    assert common.resolve_item_id(ad, source) == expected
+    assert sum(path == "/Items/movie" for path, _ in server.calls) == 1
+
+
+@pytest.mark.parametrize("change", ["pair", "server", "user_id", "access_token", "libraries", "feature"])
+def test_persistent_cache_does_not_cross_pair_or_profile_scope(change, tmp_path):
+    server = Server(item("movie"))
+    source = {"type": "movie", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_id(adapter(server), source) == "movie"
+    config = {change: "other"} if change in {"server", "user_id", "access_token"} else {}
+    if change == "libraries":
+        config["history_libraries"] = ["B"]
+    server.calls.clear()
+    ad = adapter(server, pair="pair-B" if change == "pair" else "pair-A", **config)
+    assert common.resolve_item_id(ad, source, feature="progress" if change == "feature" else "history") == (None if change == "libraries" else "movie")
+    assert "MinDateLastSaved" not in server.calls[0][1]
+    assert len(list(tmp_path.glob("jellyfin_identity.*.json"))) == 2
+    assert all("private-token" not in p.read_text() for p in tmp_path.glob("*.json"))
+
+
+def test_failed_refresh_preserves_disk_cache_and_is_not_retried_per_item(tmp_path):
+    server = Server(item("movie", changed=100))
+    source = {"type": "movie", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_id(adapter(server), source) == "movie"
+    path = next(tmp_path.glob("*.json"))
+    previous = path.read_bytes()
+    log_run_id.set("id-run-2")
+    server.fail = True
+    server.calls.clear()
+    ad = adapter(server)
+    assert common.resolve_item_id(ad, source) is None
+    assert common.resolve_item_id(ad, source) is None
+    assert len(server.calls) == 1
+    assert path.read_bytes() == previous
+
+
+def test_repeated_page_does_not_publish_partial_cache(monkeypatch, tmp_path):
+    monkeypatch.setattr(lookup, "_PAGE_SIZE", 2)
+    server = Server(item("a"), item("b"), item("c"))
+    server.repeat = True
+    assert common.resolve_item_id(adapter(server), {"type": "movie", "ids": {"tmdb": "1"}}) is None
+    assert not list(tmp_path.glob("*.json"))
+
+
+def test_periodic_full_refresh_removes_deleted_entries(monkeypatch, tmp_path):
+    server = Server(item("a"), item("b"))
+    source = {"type": "movie", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_id(adapter(server), source)
+    del server.rows["b"]
+    log_run_id.set("id-run-2")
+    monkeypatch.setattr(lookup.time, "time", lambda: 1000.0 + lookup._FULL_REFRESH_SECONDS)
+    server.calls.clear()
+    assert common.resolve_item_id(adapter(server), source) == "a"
+    assert "MinDateLastSaved" not in server.calls[0][1]
+    assert list(json.loads(next(tmp_path.glob("*.json")).read_text())["rows"]) == ["a"]
+
+
+def test_unsupported_delta_filter_uses_metadata_only_full_refresh():
+    server = Server(item("movie"))
+    server.ignore_delta = True
+    source = {"type": "movie", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_id(adapter(server), source) == "movie"
+    log_run_id.set("id-run-2")
+    server.calls.clear()
+    assert common.resolve_item_id(adapter(server), source) == "movie"
+    assert len(server.calls) == 1
+    assert "MinDateLastSaved" not in server.calls[0][1]
+
+
+@pytest.mark.parametrize("pair", [None, "", "unscoped", "default"])
+def test_no_persistence_without_explicit_pair(pair, tmp_path):
+    source = {"type": "movie", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_id(adapter(Server(item("movie")), pair=pair), source) == "movie"
+    assert not list(tmp_path.glob("*.json"))
+
+
+def test_history_prepares_cached_targets_in_batches_and_checks_current_ids():
+    server = Server(*(item(str(n), external=str(n), changed=100) for n in range(105)))
+    sources = [{"type": "movie", "ids": {"tmdb": str(n)}} for n in range(105)]
+    ad = adapter(server)
+    lookup.prepare(ad, "history", sources)
+    log_run_id.set("id-run-2")
+    server.calls.clear()
+    del server.rows["2"]
+    server.rows["3"]["ProviderIds"] = {"Tmdb": "900"}
+    ad = adapter(server)
+    lookup.prepare(ad, "history", sources)
+    for n, source in enumerate(sources):
+        assert common.resolve_item_id(ad, source) == (None if n in (2, 3) else str(n))
+    assert len(server.calls) == 3  # One delta query and two batched native-ID reads.
+    assert [len(params["Ids"].split(",")) for _, params in server.calls if params.get("Ids")] == [100, 5]
+
+
+def test_new_episode_is_seen_next_run_without_rebuilding_series_catalogue():
+    server = Server(item("series", kind="Series", external="9", changed=100))
+    source = {"type": "episode", "season": 2, "episode": 1, "show_ids": {"tmdb": "9"}}
+    assert common.resolve_item_id(adapter(server), source) is None
+    server.episodes["series"] = [item("new", kind="Episode", SeriesId="series", ParentIndexNumber=2, IndexNumber=1)]
+    log_run_id.set("id-run-2")
+    server.calls.clear()
+    assert common.resolve_item_id(adapter(server), source) == "new"
+    assert "MinDateLastSaved" in server.calls[0][1]
+    assert len(server.calls) == 3  # Delta, cached series validation, current episodes.
+
+
+def test_strict_title_only_item_is_left_unresolved_without_search():
+    server = Server(item("movie"))
+    assert common.resolve_item_id(adapter(server), {"type": "movie", "title": "English title"}) is None
+    assert not server.calls

--- a/tests/test_jellyfin_sync_regressions.py
+++ b/tests/test_jellyfin_sync_regressions.py
@@ -87,7 +87,7 @@ def test_progress_movies_still_resolve_multiple_copies(monkeypatch):
     monkeypatch.setattr(common, "build_provider_index", lambda *args, **kwargs: {
         "tmdb.1": [{"Id": "copy1", "Type": "Movie"}, {"Id": "copy2", "Type": "Movie"}],
     })
-    adapter = SimpleNamespace(client=Library(0), cfg=SimpleNamespace(user_id="user"))
+    adapter = SimpleNamespace(client=Library(0), cfg=SimpleNamespace(user_id="user", targeted_lookup=False))
     assert common.resolve_item_ids(adapter, {"type": "movie", "ids": {"tmdb": "1"}}, feature="progress") == ["copy1", "copy2"]
 
 

--- a/tests/test_jellyfin_targeted_lookup.py
+++ b/tests/test_jellyfin_targeted_lookup.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from cw_platform.log_context import log_run_id
+from providers.sync.jellyfin import _common as common, _id_lookup
+
+
+class Response:
+    def __init__(self, body, status=200):
+        self.body, self.status_code = body, status
+
+    def json(self):
+        return self.body
+
+
+class Server:
+    def __init__(self):
+        self.searches = {}
+        self.episodes = {}
+        self.items = {}
+        self.ancestors = {}
+        self.scoped_omissions = set()
+        self.calls = []
+        self.fail_parent = None
+
+    def get(self, path, *, params):
+        self.calls.append((path, dict(params)))
+        assert "AnyProviderIdEquals" not in params
+        if path == "/Items":
+            assert params.get("SearchTerm"), "Unbounded library query in targeted mode"
+            if params.get("ParentId") == self.fail_parent and self.fail_parent is not None:
+                return Response({}, 503)
+            rows = self.searches.get((params["includeItemTypes"], params["SearchTerm"]), [])
+            if params.get("ParentId"):
+                rows = [row for row in rows if row.get("LibraryId") == params["ParentId"]
+                        and row["Id"] not in self.scoped_omissions]
+            return Response({"Items": rows[:params["Limit"]], "TotalRecordCount": len(rows)})
+        if path.startswith("/Shows/"):
+            rows = self.episodes.get(path.split("/")[2], [])
+            return Response({"Items": rows, "TotalRecordCount": len(rows)})
+        if path.startswith("/Items/") and path.endswith("/Ancestors"):
+            ancestors = self.ancestors.get(path.split("/")[2])
+            return Response(ancestors or [], 200 if ancestors is not None else 503)
+        if path.startswith("/Items/"):
+            row = self.items.get(path.split("/")[2])
+            return Response(row or {}, 200 if row else 404)
+        raise AssertionError(path)
+
+
+def row(iid, kind="Movie", name="Example", tmdb="1", **extra):
+    return {"Id": iid, "Type": kind, "Name": name,
+            "ProviderIds": {"Tmdb": tmdb} if tmdb else {}, **extra}
+
+
+def adapter(http, *, pair="pair-a", **cfg):
+    return SimpleNamespace(
+        client=http,
+        config={"_cw_pair_scope": pair},
+        cfg=SimpleNamespace(**{
+            "server": "http://jellyfin", "user_id": "user", "access_token": "credential",
+            "targeted_lookup": True, "strict_id_matching": False, **cfg,
+        }),
+    )
+
+
+@pytest.fixture(autouse=True)
+def isolated_run(monkeypatch):
+    # Exercise optional title fallback independently of the ID catalogue.
+    monkeypatch.setattr(_id_lookup, "find", lambda *a, **kw: [])
+    token = log_run_id.set("targeted-test")
+    monkeypatch.setattr(common._TARGETED_CACHE, "entry", None, raising=False)
+    monkeypatch.setattr(common, "build_provider_index", lambda *a, **kw: pytest.fail("Full index in targeted mode"))
+    yield
+    log_run_id.reset(token)
+
+
+@pytest.mark.parametrize("feature", ["history", "progress"])
+@pytest.mark.parametrize("item", [
+    {"type": "movie", "title": "Missing", "ids": {"tmdb": "1"}},
+    {"type": "movie", "ids": {}},
+    {"type": "episode", "title": "Pilot", "season": 1, "episode": 1,
+     "series_title": "Missing", "show_ids": {"tmdb": "1"}},
+    {"type": "movie", "path": "/media/Example.mkv", "ids": {}},
+])
+def test_misses_and_paths_never_start_full_scan(feature, item):
+    assert common.resolve_item_ids(adapter(Server()), item, feature=feature) == []
+
+
+@pytest.mark.parametrize("strict", [False])
+def test_id_match_accepts_different_title_and_collects_movie_copies(strict):
+    server = Server()
+    server.searches["Movie", "Example"] = [
+        row("copy2", name="Example: Extended"), row("wrong", tmdb="2"),
+        row("copy1", name="Example (Original Title)"), row("copy1"),
+    ]
+    item = {"type": "movie", "title": "Example", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_ids(adapter(server, strict_id_matching=strict), item) == ["copy1", "copy2"]
+    assert len(server.calls) == 1
+
+
+@pytest.mark.parametrize("strict,ids,expected", [
+    (True, {}, []), (True, {"tmdb": "2"}, []),
+    (False, {"tmdb": "2"}, []), (False, {}, ["movie"]),
+])
+def test_strict_id_setting_remains_separate(strict, ids, expected):
+    server = Server()
+    server.searches["Movie", "Example"] = [row("movie")]
+    item = {"type": "movie", "title": "Example", "ids": ids}
+    assert common.resolve_item_ids(adapter(server, strict_id_matching=strict), item) == expected
+
+
+@pytest.mark.parametrize("feature", ["history", "progress"])
+@pytest.mark.parametrize("targeted", [True, False])
+@pytest.mark.parametrize("strict", [True, False])
+@pytest.mark.parametrize("native_field", ["ids", "jellyfin_item_id"])
+def test_native_id_cannot_use_title_to_replace_missing_public_ids(
+    monkeypatch, feature, targeted, strict, native_field,
+):
+    server = Server()
+    server.items["native"] = row("native", tmdb=None, ProductionYear=2020)
+    monkeypatch.setattr(common, "build_provider_index", lambda *a, **kw: {})
+    item = {"type": "movie", "title": "Example", "year": 2020, "ids": {"tmdb": "1"}}
+    if native_field == "ids":
+        item["ids"]["jellyfin"] = "native"
+    else:
+        item[native_field] = "native"
+    ad = adapter(server, targeted_lookup=targeted, strict_id_matching=strict)
+    assert common.resolve_item_id(ad, item, feature=feature) == (None if strict else "native")
+
+
+@pytest.mark.parametrize("feature", ["history", "progress"])
+@pytest.mark.parametrize("public_ids", [{}, {"tmdb": "1"}])
+def test_strict_native_id_match_survives_changed_title_and_year(feature, public_ids):
+    server = Server()
+    server.items["native"] = row("native", name="Renamed", ProductionYear=2026)
+    item = {"type": "movie", "title": "Old title", "year": 2000,
+            "ids": {"jellyfin": "native", **public_ids}}
+    assert common.resolve_item_id(adapter(server, strict_id_matching=True), item, feature=feature) == "native"
+
+
+@pytest.mark.parametrize("returned_id", [None, "different"])
+def test_strict_native_only_id_must_be_confirmed_by_server(returned_id):
+    server = Server()
+    if returned_id:
+        server.items["native"] = row(returned_id)
+    item = {"type": "movie", "ids": {"jellyfin": "native"}}
+    assert common.resolve_item_id(adapter(server, strict_id_matching=True), item) is None
+
+
+@pytest.mark.parametrize("feature", ["history", "progress"])
+@pytest.mark.parametrize("ids", [{}, {"tmdb": "1"}])
+def test_strict_full_lookup_skips_path_only_match(monkeypatch, feature, ids):
+    server = Server()
+    monkeypatch.setattr(common, "_path_match_item_id", lambda *a, **kw: pytest.fail("Path match in strict mode"))
+    monkeypatch.setattr(common, "build_provider_index", lambda *a, **kw: {})
+    item = {"type": "movie", "path": "/media/Example.mkv", "ids": ids}
+    assert common.resolve_item_id(adapter(server, targeted_lookup=False, strict_id_matching=True), item, feature=feature) is None
+
+
+def test_strict_full_lookup_does_not_confuse_movie_and_series_ids(monkeypatch):
+    monkeypatch.setattr(common, "build_provider_index", lambda *a, **kw: {"tmdb.1": [row("series", "Series")]})
+    item = {"type": "movie", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_id(adapter(Server(), targeted_lookup=False, strict_id_matching=True), item) is None
+
+
+def test_ambiguous_title_only_movie_is_not_guessed():
+    server = Server()
+    server.searches["Movie", "Example"] = [row("a", tmdb="1"), row("b", tmdb="2")]
+    assert common.resolve_item_ids(adapter(server, strict_id_matching=False), {"type": "movie", "title": "Example"}) == []
+
+
+def test_duplicate_series_resolve_episodes_and_reuse_searches_between_batches():
+    server = Server()
+    server.searches["Series", "Example"] = [
+        row("s1", "Series", "Example (US)"), row("s2", "Series", "Example (US)"),
+    ]
+    for sid in ("s1", "s2"):
+        server.episodes[sid] = [
+            row(f"{sid}e{n}", "Episode", tmdb=str(100 + n), SeriesId=sid,
+                ParentIndexNumber=0, IndexNumber=n) for n in (1, 2)
+        ]
+    for n in (1, 2):
+        item = {"type": "episode", "series_title": "Example", "season": 0, "episode": n,
+                "show_ids": {"tmdb": "1"}, "ids": {"tmdb": str(100 + n)}}
+        assert common.resolve_item_ids(adapter(server), item) == [f"s1e{n}"]
+    assert len(server.calls) == 3  # One series search, one episode request per copy.
+
+
+def test_episode_title_search_requires_episode_ids_without_series_metadata():
+    server = Server()
+    server.searches["Episode", "Pilot"] = [row("wrong", "Episode", "Pilot", "2"),
+                                              row("right", "Episode", "Pilot: Part One", "1")]
+    item = {"type": "episode", "title": "Pilot", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_ids(adapter(server), item) == ["right"]
+
+
+@pytest.mark.parametrize("change", ["pair", "server", "user_id", "access_token", "libraries", "feature", "run"])
+def test_targeted_cache_isolated_and_new_runs_see_new_items(change):
+    server = Server()
+    server.searches["Movie", "Example"] = [row("a", LibraryId="A")]
+    item = {"type": "movie", "title": "Example", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_ids(adapter(server), item) == ["a"]
+    server.searches["Movie", "Example"] = [row("b", LibraryId="B")]
+    cfg = {change: "other"} if change in {"server", "user_id", "access_token"} else {}
+    if change == "libraries":
+        cfg["history_libraries"] = ["B"]
+    if change == "run":
+        log_run_id.set("next-run")
+    other = adapter(server, pair="other" if change == "pair" else "pair-a", **cfg)
+    assert common.resolve_item_ids(other, item, feature="progress" if change == "feature" else "history") == ["b"]
+    assert len(server.calls) == 2
+
+
+@pytest.mark.parametrize("pair", [None, "", "unscoped", "default"])
+def test_incomplete_scope_does_not_share_between_adapters(pair, monkeypatch):
+    monkeypatch.setattr(common, "_pair_scope", lambda: None)
+    server = Server()
+    item = {"type": "movie", "title": "Example", "ids": {"tmdb": "1"}}
+    server.searches["Movie", "Example"] = [row("a")]
+    assert common.resolve_item_ids(adapter(server, pair=pair), item) == ["a"]
+    server.searches["Movie", "Example"] = [row("b")]
+    assert common.resolve_item_ids(adapter(server, pair=pair), item) == ["b"]
+
+
+def test_scoped_search_failure_does_not_cache_partial_results():
+    server = Server()
+    server.searches["Movie", "Example"] = [row("a", LibraryId="A"), row("b", LibraryId="B")]
+    server.fail_parent = "B"
+    ad = adapter(server, history_libraries=["A", "B"])
+    item = {"type": "movie", "title": "Example", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_ids(ad, item) == []
+    server.fail_parent = None
+    assert common.resolve_item_ids(ad, item) == ["a", "b"]
+
+
+def test_stale_native_id_is_revalidated_before_targeted_matching():
+    server = Server()
+    server.items["stale"] = row("stale", tmdb="2")
+    server.searches["Movie", "Example"] = [row("correct")]
+    item = {"type": "movie", "title": "Example", "ids": {"tmdb": "1"}, "jellyfin_item_id": "stale"}
+    assert common.resolve_item_ids(adapter(server), item) == ["correct"]
+    assert server.calls[0][0] == "/Items/stale"
+
+
+@pytest.mark.parametrize("ancestor,expected", [("A", ["movie"]), ("B", []), (None, [])])
+def test_scoped_search_omission_retries_title_with_verified_ancestry(ancestor, expected):
+    server = Server()
+    server.searches["Movie", "Example"] = [row("movie", LibraryId="A")]
+    server.scoped_omissions.add("movie")
+    if ancestor is not None:
+        server.ancestors["movie"] = [{"Id": ancestor, "Type": "CollectionFolder"}]
+    ad = adapter(server, history_libraries=["A"])
+    item = {"type": "movie", "title": "Example", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_ids(ad, item) == expected
+    assert any(path.endswith("/Ancestors") for path, _ in server.calls)
+
+
+def test_failed_ancestor_check_is_retried_and_does_not_poison_cache():
+    server = Server()
+    server.searches["Movie", "Example"] = [row("movie", LibraryId="A")]
+    server.scoped_omissions.add("movie")
+    ad = adapter(server, history_libraries=["A"])
+    item = {"type": "movie", "title": "Example", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_ids(ad, item) == []
+    server.ancestors["movie"] = [{"Id": "A"}]
+    assert common.resolve_item_ids(ad, item) == ["movie"]
+
+
+@pytest.mark.parametrize("title", ["Example (NL)", "Example (2024)", "Example (2024) (nl)"])
+@pytest.mark.parametrize("feature", ["history", "progress"])
+def test_title_suffix_retry_requires_ids_and_preserves_source(title, feature):
+    server = Server()
+    server.searches["Movie", "Example"] = [row("wrong", tmdb="2"), row("right")]
+    item = {"type": "movie", "title": title, "ids": {"tmdb": "1"}}
+    assert common.resolve_item_ids(adapter(server), item, feature=feature) == ["right"]
+    assert item["title"] == title
+    assert [params["SearchTerm"] for _, params in server.calls] == [title, "Example"]
+
+
+def test_year_suffix_on_series_uses_ids_and_episode_coordinates():
+    server = Server()
+    server.searches["Series", "Example"] = [row("series", "Series")]
+    server.episodes["series"] = [row("episode", "Episode", tmdb="2", SeriesId="series",
+                                    ParentIndexNumber=1, IndexNumber=3)]
+    item = {"type": "episode", "series_title": "Example (2024)", "season": 1, "episode": 3,
+            "show_ids": {"tmdb": "1"}, "ids": {"tmdb": "2"}}
+    assert common.resolve_item_ids(adapter(server), item) == ["episode"]
+    assert item["series_title"] == "Example (2024)"
+
+
+@pytest.mark.parametrize("title,ids", [("Example (NL)", {}), ("Example (Extended Cut)", {"tmdb": "1"}),
+                                       ("Example (2024) Part Two", {"tmdb": "1"})])
+def test_no_title_cleanup_without_ids_or_for_unrecognized_suffix(title, ids):
+    server = Server()
+    server.searches["Movie", "Example"] = [row("movie")]
+    item = {"type": "movie", "title": title, "ids": ids}
+    assert common.resolve_item_ids(adapter(server, strict_id_matching=False), item) == []
+    assert [params["SearchTerm"] for _, params in server.calls] == [title]
+
+
+def test_suffix_retry_rejects_different_ids_even_when_title_matches():
+    server = Server()
+    server.searches["Movie", "Example"] = [row("wrong", tmdb="2")]
+    item = {"type": "movie", "title": "Example (NL)", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_ids(adapter(server, strict_id_matching=False), item) == []
+
+
+def test_original_title_match_does_not_make_variant_request():
+    server = Server()
+    server.searches["Movie", "Example (NL)"] = [row("movie")]
+    assert common.resolve_item_ids(adapter(server), {"type": "movie", "title": "Example (NL)", "ids": {"tmdb": "1"}}) == ["movie"]
+    assert len(server.calls) == 1
+
+
+def test_debug_diagnostics_include_status_candidates_and_rejection_counts(monkeypatch):
+    events = []
+    monkeypatch.setattr(common, "_dbg", lambda event, **fields: events.append((event, fields)))
+    server = Server()
+    server.searches["Movie", "Example"] = [row("wrong", tmdb="2")]
+    item = {"type": "movie", "title": "Example", "ids": {"tmdb": "1"}}
+    assert common.resolve_item_ids(adapter(server), item) == []
+    assert any(event == "targeted_search_response" and fields["status"] == 200
+               and fields["candidates"] == 1 and fields["term"] == "Example" for event, fields in events)
+    assert any(event == "targeted_search_match" and fields["rejected"] == {"id_mismatch": 1}
+               for event, fields in events)
+
+
+def test_debug_failure_does_not_log_exception_secrets(monkeypatch):
+    events = []
+    monkeypatch.setattr(common, "_dbg", lambda event, **fields: events.append((event, fields)))
+    server = Server()
+    def fail(*args, **kwargs):
+        raise RuntimeError("secret-token-and-password-in-request-url")
+    monkeypatch.setattr(server, "get", fail)
+    assert common.resolve_item_ids(adapter(server), {"type": "movie", "title": "Example", "ids": {"tmdb": "1"}}) == []
+    assert any(event == "targeted_search_failed" and fields["error_type"] == "RuntimeError"
+               for event, fields in events)
+    assert "secret-token-and-password" not in repr(events)

--- a/tests/test_plex_history_options.py
+++ b/tests/test_plex_history_options.py
@@ -98,3 +98,48 @@ def test_manual_watched_changes_survive_cached_guid_index(isolated_state, timest
     row["viewCount"] = 0
     assert history.build_index(ad) == {}
     assert len(index_reads) == 1
+
+
+@pytest.mark.parametrize("catalog_kind", ["current", "missing", "id_only", "no_external_ids", "wrong_user_scope"])
+@pytest.mark.parametrize("include_marked", [False, True])
+def test_history_metadata_selection_preserves_fallback_and_watched_dates(
+    isolated_state, monkeypatch, catalog_kind, include_marked,
+):
+    played_at = 1787093918
+    live_at = played_at + 3600
+    raw = SimpleNamespace(type="movie", ratingKey="42", title="Historical title", year=2020, viewedAt=played_at)
+    server = SimpleNamespace(history=lambda **kwargs: [raw])
+    adapter = SimpleNamespace(client=SimpleNamespace(server=server), config={"plex": {
+        "history_workers": 1, "history": {"include_marked_watched": include_marked},
+    }})
+    catalog = history.HistoryCatalog()
+    if catalog_kind != "missing":
+        catalog.add({
+            "rk": "42", "type": "movie", "title": None if catalog_kind == "id_only" else "Current title",
+            "ids": {"plex": "42"} if catalog_kind == "no_external_ids" else {"plex": "42", "tmdb": "123"},
+        })
+    fallback_calls = []
+
+    def fallback(*args, **kwargs):
+        fallback_calls.append(1)
+        return {"type": "movie", "title": "Historical title", "ids": {"plex": "42", "tmdb": "123"}}
+
+    monkeypatch.setattr(history, "home_scope_enter", lambda _: (catalog_kind == "wrong_user_scope", False, None, None))
+    monkeypatch.setattr(history, "home_scope_exit", lambda *_: None)
+    monkeypatch.setattr(history, "plex_feature_library_ids", lambda *_: set())
+    monkeypatch.setattr(history, "_history_force_full", lambda _: False)
+    monkeypatch.setattr(history, "_build_history_catalog", lambda *a, **k: catalog)
+    monkeypatch.setattr(history, "_store_history_catalog", lambda *_: None)
+    monkeypatch.setattr(history, "_save_watermark", lambda *_: None)
+    monkeypatch.setattr(history, "_keep_in_snapshot", lambda *_: True)
+    monkeypatch.setattr(history, "minimal_from_history_row", fallback)
+    monkeypatch.setattr(history, "_pms_fetch_metadata_row", lambda *_: {"viewCount": 1, "lastViewedAt": live_at})
+    monkeypatch.setattr(history, "_load_marked_state", lambda: {})
+    monkeypatch.setattr(history, "_iter_marked_watched_from_library", lambda *a, **k: [])
+
+    result = history.build_index(adapter)
+    assert len(result) == 1
+    item = next(iter(result.values()))
+    assert item["watched_at"] == history._iso(live_at if include_marked else played_at)
+    assert item["title"] == ("Current title" if catalog_kind == "current" else "Historical title")
+    assert len(fallback_calls) == (0 if catalog_kind == "current" else 1)

--- a/tests/test_scrobble_history_identity.py
+++ b/tests/test_scrobble_history_identity.py
@@ -111,6 +111,7 @@ def test_tracker_episode_ids_reach_destination_id_resolver(monkeypatch, provider
     target_id = "1234567890abcdef1234567890abcdef"
     row = {"Id": target_id, "Type": "Episode", "ProviderIds": {"Imdb": "tt1234567"}, "ParentIndexNumber": 0, "IndexNumber": 2}
     if provider == "jellyfin":
+        adapter.cfg.targeted_lookup = False
         _, prepared, error = history._prepare_want(item)
         assert error is None
         monkeypatch.setattr(common, "_targeted_lookup_item_id", lambda *a, **kw: None)


### PR DESCRIPTION
# Pull request

## Change
- Add a local ID index with incremental refresh.
- Match by external IDs, including episodes with different numbering.
- Retry failed episode lookups.
- Use playback timestamps for progress checks.

## Why
Avoid repeated library scans, localized title mismatches and incorrectly skipped progress updates.

## Testing
- tests/test_jellyfin_id_lookup.py 
- tests/test_media_server_progress_state.py

## Issue
Relates to #1067