### PR TITLE
Change: Jellyfin history failures and lookup cache

### DIFF
--- a/providers/sync/jellyfin/_common.py
+++ b/providers/sync/jellyfin/_common.py
@@ -1385,12 +1385,11 @@ def _targeted_cache(adapter: Any, feature: str) -> dict[Any, Any]:
             entry = (key, {})
             _TARGETED_CACHE.entry = entry
         return entry[1]
-    # Without a complete scope, reuse only on this adapter during an active run.
-    if not run:
-        return {}
+    now = time.monotonic()
     entry = getattr(adapter, "_jellyfin_targeted_cache", None)
-    if entry is None or entry[0] != key:
-        entry = (key, {})
+    if (entry is None or entry[0] != key
+            or (not run and (len(entry) < 3 or now - entry[2] >= 300))):
+        entry = (key, {}, now)
         setattr(adapter, "_jellyfin_targeted_cache", entry)
     return entry[1]
 

--- a/providers/sync/jellyfin/_history.py
+++ b/providers/sync/jellyfin/_history.py
@@ -633,14 +633,22 @@ def build_index(
             params["ParentId"] = current_parent
 
         r = http.get(items_route(), params=user_params(uid, params))
-        body = r.json() or {}
-        rows = body.get("Items") or []
+        if getattr(r, "status_code", 0) != 200:
+            raise RuntimeError(f"jellyfin_history_http_{getattr(r, 'status_code', 0)}")
+        try:
+            body = r.json()
+        except Exception as exc:
+            raise ValueError("jellyfin_history_invalid_response") from exc
+        if not isinstance(body, Mapping) or not isinstance(body.get("Items"), list):
+            raise ValueError("jellyfin_history_invalid_response")
+        rows = body["Items"]
+        if any(not isinstance(row, Mapping) or not row.get("Id") for row in rows):
+            raise ValueError("jellyfin_history_invalid_row")
         raw_count = len(rows)
         signature = tuple(str(row.get("Id") or "") for row in rows if isinstance(row, Mapping))
         if rows and signature in seen_pages:
             _warn("pagination_repeated_page", source_library_id=current_parent, start_index=start)
-            rows = []
-            raw_count = 0
+            raise RuntimeError("jellyfin_history_repeated_page")
         seen_pages.add(signature)
         page += 1
         took_ms = int((time.monotonic() - t0) * 1000)

--- a/providers/sync/jellyfin/_id_lookup.py
+++ b/providers/sync/jellyfin/_id_lookup.py
@@ -222,8 +222,6 @@ def prepare(adapter: Any, feature: str, items: Any) -> None:
                       and str(row["Id"]) not in catalogue["validated"]})
     for offset in range(0, len(pending), 100):
         batch = pending[offset:offset + 100]
-        # Missing/deleted items and failed reads must not become assumed matches.
-        catalogue["validated"].update({iid: {} for iid in batch})
         try:
             response = adapter.client.get("/Items", params={
                 "userId": adapter.cfg.user_id, "Ids": ",".join(batch), "Fields": _FIELDS,
@@ -235,8 +233,11 @@ def prepare(adapter: Any, feature: str, items: Any) -> None:
             rows = body.get("Items") if isinstance(body, dict) else None
             if not isinstance(rows, list):
                 continue
+            if any(not isinstance(row, dict) or str(row.get("Id")) not in batch for row in rows):
+                continue
+            validated = {iid: {} for iid in batch}
             for row in rows:
-                if isinstance(row, dict) and str(row.get("Id")) in batch:
-                    catalogue["validated"][str(row["Id"])] = row
+                validated[str(row["Id"])] = row
+            catalogue["validated"].update(validated)
         except Exception as exc:
             common._dbg("identity_validation_failed", lookup_feature=feature, error_type=type(exc).__name__)

--- a/tests/test_jellyfin_history_failures.py
+++ b/tests/test_jellyfin_history_failures.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+
+import pytest
+
+from cw_platform.orchestrator import _snapshots
+from providers.sync.jellyfin import _history as history
+
+
+@pytest.fixture
+def history_adapter(monkeypatch):
+    monkeypatch.setattr(history, "jf_get_library_roots", lambda *a: {})
+    monkeypatch.setattr(history, "_shadow_load", lambda: {})
+    monkeypatch.setattr(history, "_bb_load", lambda: {})
+    monkeypatch.setattr(history, "_history_page_size", lambda *a: 2)
+    for name in ("_dbg", "_info", "_warn"):
+        monkeypatch.setattr(history, name, lambda *a, **k: None)
+    ad = SimpleNamespace(cfg=SimpleNamespace(user_id="user"), client=None)
+    return "jellyfin", history, ad
+
+
+def response(status, body):
+    return SimpleNamespace(status_code=status, json=lambda: body)
+
+
+def watched_rows():
+    return [{"Id": str(n), "Type": "Movie", "Name": f"Movie {n}", "ProviderIds": {"Tmdb": str(n)},
+             "UserData": {"Played": True, "LastPlayedDate": "2026-09-01T12:00:00Z"}} for n in (1, 2)]
+
+
+@pytest.mark.parametrize("status", [401, 500])
+@pytest.mark.parametrize("fail_start", [0, 2])
+def test_http_failure_cannot_publish_empty_or_partial_history(history_adapter, status, fail_start):
+    _, history, ad = history_adapter
+    calls = []
+
+    def get(path, *, params):
+        start = params.get("StartIndex", 0)
+        calls.append(start)
+        return response(status, {"error": "failed"}) if start == fail_start else response(200, {"Items": watched_rows()})
+
+    ad.client = SimpleNamespace(get=get)
+    with pytest.raises(RuntimeError, match=f"history_http_{status}"):
+        history.build_index(ad)
+    assert calls == ([0] if fail_start == 0 else [0, 2])
+
+
+@pytest.mark.parametrize("body", [{}, {"Items": None}, {"Items": [None]}, {"Items": [{"Name": "Missing ID"}]}])
+@pytest.mark.parametrize("fail_start", [0, 2])
+def test_malformed_history_is_not_an_empty_library(history_adapter, body, fail_start):
+    _, history, ad = history_adapter
+    ad.client = SimpleNamespace(get=lambda path, *, params: response(
+        200, body if params.get("StartIndex", 0) == fail_start else {"Items": watched_rows()}))
+    with pytest.raises(ValueError, match="history_invalid"):
+        history.build_index(ad)
+
+
+@pytest.mark.parametrize("fail_start", [0, 2])
+def test_invalid_json_cannot_publish_empty_or_partial_history(history_adapter, fail_start):
+    _, history, ad = history_adapter
+
+    def invalid_json():
+        raise ValueError("Invalid JSON")
+
+    def get(path, *, params):
+        if params.get("StartIndex", 0) == fail_start:
+            return SimpleNamespace(status_code=200, json=invalid_json)
+        return response(200, {"Items": watched_rows()})
+
+    ad.client = SimpleNamespace(get=get)
+    with pytest.raises(ValueError, match="history_invalid_response"):
+        history.build_index(ad)
+
+
+def test_repeated_history_page_is_a_failure(history_adapter):
+    _, history, ad = history_adapter
+    ad.client = SimpleNamespace(get=lambda *a, **k: response(200, {"Items": watched_rows()}))
+    with pytest.raises(RuntimeError, match="history_repeated_page"):
+        history.build_index(ad)
+
+
+def test_valid_empty_history_remains_supported(history_adapter):
+    _, history, ad = history_adapter
+    ad.client = SimpleNamespace(get=lambda *a, **k: response(200, {"Items": []}))
+    assert history.build_index(ad) == {}
+
+
+def test_failed_history_does_not_reach_snapshot_callback_or_cache(history_adapter, monkeypatch):
+    provider, history, ad = history_adapter
+    ad.client = SimpleNamespace(get=lambda *a, **k: response(500, {"error": "failed"}))
+    ops = SimpleNamespace(features=lambda: {"history": True}, build_index=lambda *a, **k: history.build_index(ad))
+    monkeypatch.setattr(_snapshots, "provider_configured", lambda *a: True)
+    monkeypatch.setattr(_snapshots, "allowed_providers_for_feature", lambda *a: set())
+    callbacks, cache = [], {}
+    with pytest.raises(RuntimeError, match="history_http_500"):
+        _snapshots.build_snapshots_for_feature(feature="history", config={}, providers={provider.upper(): ops},
+            snap_cache=cache, snap_ttl_sec=300, dbg=lambda *a, **k: None, emit_info=lambda *a: None,
+            on_snapshot=lambda *args: callbacks.append(args))
+    assert callbacks == []
+    assert cache == {}

--- a/tests/test_jellyfin_id_lookup.py
+++ b/tests/test_jellyfin_id_lookup.py
@@ -274,3 +274,47 @@ def test_strict_title_only_item_is_left_unresolved_without_search():
     server = Server(item("movie"))
     assert common.resolve_item_id(adapter(server), {"type": "movie", "title": "English title"}) is None
     assert not server.calls
+
+
+def test_standalone_cache_is_local_bounded_and_refreshes_next_run(monkeypatch):
+    log_run_id.set("")
+    now = [100.0]
+    monkeypatch.setattr(common.time, "monotonic", lambda: now[0])
+    server = Server(item("movie"))
+    ad = adapter(server, pair=None)
+    source = {"type": "movie", "ids": {"tmdb": "1"}}
+    for _ in range(3):
+        assert common.resolve_item_id(ad, source) == "movie"
+    assert len(server.calls) == 2
+    other = adapter(server, pair=None)
+    assert common.resolve_item_id(other, source) == "movie"
+    assert len(server.calls) == 4
+    server.rows.clear()
+    now[0] += 301
+    assert common.resolve_item_id(ad, source) is None
+    assert len(server.calls) == 6
+    server.rows["new"] = item("new")
+    log_run_id.set("new-run")
+    assert common.resolve_item_id(ad, source) == "new"
+
+
+@pytest.mark.parametrize("failure", ["http", "exception", "malformed"])
+def test_failed_batch_validation_retries_individually(failure):
+    server = Server(item("movie", changed=100))
+    ad = adapter(server)
+    source = {"type": "movie", "ids": {"tmdb": "1"}}
+    lookup.prepare(ad, "history", [source])
+    log_run_id.set("id-run-2")
+    original = server.get
+
+    def get(path, *, params):
+        if params.get("Ids"):
+            if failure == "exception":
+                raise RuntimeError("Batch unavailable")
+            return SimpleNamespace(status_code=500 if failure == "http" else 200, json=lambda: {})
+        return original(path, params=params)
+
+    server.get = get
+    lookup.prepare(ad, "history", [source])
+    assert common.resolve_item_id(ad, source) == "movie"
+    assert any(path == "/Items/movie" for path, _ in server.calls)


### PR DESCRIPTION
# Pull request

## Change
- Stop history snapshots when requests fail or return incomplete data.
- Reuse standalone lookup caches for five minutes.
- Retry failed batch validation with individual item checks.

## Why
Prevent incorrect removals, repeated lookups and skipped matches.

## Testing
- tests/test_jellyfin_history_failures.py
- tests/test_jellyfin_id_lookup.py

## Issue
Relates to #1067