### PR TITLE
Change: Emby history failures and ID matching

### DIFF
--- a/providers/sync/emby/_common.py
+++ b/providers/sync/emby/_common.py
@@ -1640,7 +1640,8 @@ def _direct_query_by_pairs(
                 seen_pages.add(signature)
                 for row in page:
                     iid = str(row.get("Id") or "")
-                    row_pairs = {f"{k}.{v}" for k, v in _ids_from_provider_ids(row.get("ProviderIds")).items()}
+                    row_pairs = {format_provider_pair(k, v)
+                                 for k, v in _ids_from_provider_ids(row.get("ProviderIds")).items()}
                     if not requested.intersection(row_pairs) or row.get("Type") not in types:
                         raise RuntimeError("unexpected_provider_id_result")
                     if iid and not looks_like_bad_id(iid):
@@ -1880,11 +1881,12 @@ def resolve_item_id(adapter: Any, it: Mapping[str, Any], *, feature: str = "hist
         if season is not None and episode is not None:
             for pref in series_pairs:
                 rows = _query_by_pairs(adapter, [pref], "Series", scope, feature)
-                for series in _prefer_library(rows):
+                for series in sorted(_prefer_library(rows), key=lambda row: str(row.get("Id") or "")):
                     sid = str(series.get("Id") or "")
                     if series.get("Type") != "Series" or not sid:
                         continue
-                    for ep in _series_episodes_cached(adapter, http, uid, sid, feature=feature):
+                    episodes = _series_episodes_cached(adapter, http, uid, sid, feature=feature)
+                    for ep in sorted(episodes, key=lambda row: str(row.get("Id") or "")):
                         iid = str(ep.get("Id") or "")
                         if (iid and not looks_like_bad_id(iid) and ep.get("Type") == "Episode"
                                 and str(ep.get("SeriesId") or sid) == sid

--- a/providers/sync/emby/_history.py
+++ b/providers/sync/emby/_history.py
@@ -876,20 +876,22 @@ def build_index(adapter: Any, since: Any | None = None, limit: int | None = None
 
             r = http.get(f"/Users/{uid}/Items", params=params)
             if getattr(r, "status_code", 0) != 200:
-                _warn("http_failed", op="index", status=getattr(r, 'status_code', None), body=_resp_snip(r))
-                break
+                raise RuntimeError(f"emby_history_http_{getattr(r, 'status_code', 0)}")
 
             try:
-                body = r.json() or {}
-                rows = body.get("Items") or []
-            except Exception as e:
-                _warn("parse_failed", op="index", error=str(e))
-                rows = []
+                body = r.json()
+            except Exception as exc:
+                raise ValueError("emby_history_invalid_response") from exc
+            if not isinstance(body, Mapping) or not isinstance(body.get("Items"), list):
+                raise ValueError("emby_history_invalid_response")
+            rows = body["Items"]
+            if any(not isinstance(row, Mapping) or not row.get("Id") for row in rows):
+                raise ValueError("emby_history_invalid_row")
 
             signature = tuple(str(row.get("Id") or "") for row in rows if isinstance(row, Mapping))
             if rows and signature in seen_pages:
                 _warn("pagination_repeated_page", scan=include_types, source_library_id=parent_id, start_index=start)
-                break
+                raise RuntimeError("emby_history_repeated_page")
             seen_pages.add(signature)
 
             page += 1

--- a/tests/test_emby_history_failures.py
+++ b/tests/test_emby_history_failures.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+
+import pytest
+
+from cw_platform.orchestrator import _snapshots
+from providers.sync.emby import _history as history
+
+
+@pytest.fixture
+def history_adapter(monkeypatch):
+    monkeypatch.setattr(history, "_emby_library_roots", lambda *a: {})
+    monkeypatch.setattr(history, "_shadow_load", lambda: {})
+    monkeypatch.setattr(history, "_bb_load", lambda: {})
+    monkeypatch.setattr(history, "_history_page_size", lambda *a: 2)
+    for name in ("_dbg", "_info", "_warn"):
+        monkeypatch.setattr(history, name, lambda *a, **k: None)
+    ad = SimpleNamespace(cfg=SimpleNamespace(user_id="user"), client=None)
+    return "emby", history, ad
+
+
+def response(status, body):
+    return SimpleNamespace(status_code=status, json=lambda: body)
+
+
+def watched_rows():
+    return [{"Id": str(n), "Type": "Movie", "Name": f"Movie {n}", "ProviderIds": {"Tmdb": str(n)},
+             "UserData": {"Played": True, "LastPlayedDate": "2026-09-01T12:00:00Z"}} for n in (1, 2)]
+
+
+@pytest.mark.parametrize("status", [401, 500])
+@pytest.mark.parametrize("fail_start", [0, 2])
+def test_http_failure_cannot_publish_empty_or_partial_history(history_adapter, status, fail_start):
+    _, history, ad = history_adapter
+    calls = []
+
+    def get(path, *, params):
+        start = params.get("StartIndex", 0)
+        calls.append(start)
+        return response(status, {"error": "failed"}) if start == fail_start else response(200, {"Items": watched_rows()})
+
+    ad.client = SimpleNamespace(get=get)
+    with pytest.raises(RuntimeError, match=f"history_http_{status}"):
+        history.build_index(ad)
+    assert calls == ([0] if fail_start == 0 else [0, 2])
+
+
+@pytest.mark.parametrize("body", [{}, {"Items": None}, {"Items": [None]}, {"Items": [{"Name": "Missing ID"}]}])
+@pytest.mark.parametrize("fail_start", [0, 2])
+def test_malformed_history_is_not_an_empty_library(history_adapter, body, fail_start):
+    _, history, ad = history_adapter
+    ad.client = SimpleNamespace(get=lambda path, *, params: response(
+        200, body if params.get("StartIndex", 0) == fail_start else {"Items": watched_rows()}))
+    with pytest.raises(ValueError, match="history_invalid"):
+        history.build_index(ad)
+
+
+@pytest.mark.parametrize("fail_start", [0, 2])
+def test_invalid_json_cannot_publish_empty_or_partial_history(history_adapter, fail_start):
+    _, history, ad = history_adapter
+
+    def invalid_json():
+        raise ValueError("Invalid JSON")
+
+    def get(path, *, params):
+        if params.get("StartIndex", 0) == fail_start:
+            return SimpleNamespace(status_code=200, json=invalid_json)
+        return response(200, {"Items": watched_rows()})
+
+    ad.client = SimpleNamespace(get=get)
+    with pytest.raises(ValueError, match="history_invalid_response"):
+        history.build_index(ad)
+
+
+def test_repeated_history_page_is_a_failure(history_adapter):
+    _, history, ad = history_adapter
+    ad.client = SimpleNamespace(get=lambda *a, **k: response(200, {"Items": watched_rows()}))
+    with pytest.raises(RuntimeError, match="history_repeated_page"):
+        history.build_index(ad)
+
+
+def test_valid_empty_history_remains_supported(history_adapter):
+    _, history, ad = history_adapter
+    ad.client = SimpleNamespace(get=lambda *a, **k: response(200, {"Items": []}))
+    assert history.build_index(ad) == {}
+
+
+def test_failed_history_does_not_reach_snapshot_callback_or_cache(history_adapter, monkeypatch):
+    provider, history, ad = history_adapter
+    ad.client = SimpleNamespace(get=lambda *a, **k: response(500, {"error": "failed"}))
+    ops = SimpleNamespace(features=lambda: {"history": True}, build_index=lambda *a, **k: history.build_index(ad))
+    monkeypatch.setattr(_snapshots, "provider_configured", lambda *a: True)
+    monkeypatch.setattr(_snapshots, "allowed_providers_for_feature", lambda *a: set())
+    callbacks, cache = [], {}
+    with pytest.raises(RuntimeError, match="history_http_500"):
+        _snapshots.build_snapshots_for_feature(feature="history", config={}, providers={provider.upper(): ops},
+            snap_cache=cache, snap_ttl_sec=300, dbg=lambda *a, **k: None, emit_info=lambda *a: None,
+            on_snapshot=lambda *args: callbacks.append(args))
+    assert callbacks == []
+    assert cache == {}

--- a/tests/test_emby_targeted_lookup.py
+++ b/tests/test_emby_targeted_lookup.py
@@ -234,3 +234,21 @@ def test_series_episode_response_cannot_match_wrong_type_or_parent(extra):
 
     ad = adapter(WrongSeries([series]))
     assert common.resolve_item_ids(ad, {"type": "episode", "show_ids": {"tmdb": "20"}, "season": 1, "episode": 1}) == []
+
+
+def test_zero_padded_provider_ids_are_valid_query_matches():
+    row = movie(ProviderIds={"Tvdb": "0081871"})
+    http = SimpleNamespace(get=lambda *a, **k: SimpleNamespace(status_code=200, json=lambda: {"Items": [row]}))
+    assert common._direct_query_by_pairs(http, "user", ["tvdb.81871"], "Movie", {}) == [row]
+
+
+def test_duplicate_series_and_episode_order_does_not_change_match():
+    series = [{"Id": sid, "Type": "Series", "ProviderIds": {"Tmdb": "20"}} for sid in ("10", "20")]
+    episodes = [{"Id": sid + suffix, "Type": "Episode", "SeriesId": sid, "ParentIndexNumber": 0, "IndexNumber": 1}
+                for sid in ("10", "20") for suffix in ("1", "2")]
+    server = Server(series + episodes)
+    source = {"type": "episode", "show_ids": {"tmdb": "20"}, "season": 0, "episode": 1}
+    assert common.resolve_item_id(adapter(server), source) == "101"
+    server.rows.reverse()
+    log_run_id.set("second")
+    assert common.resolve_item_id(adapter(server), source) == "101"


### PR DESCRIPTION
# Pull request

## Change
- Stop history snapshots when requests fail or return invalid or repeated pages.
- Match external IDs with leading zeros correctly.
- Keep duplicate episode selection consistent between runs.

## Why
Prevent incorrect removals, missed ID matches and changing episode targets.

## Testing
- tests/test_emby_history_failures.py
- tests/test_emby_targeted_lookup.py

## Issue
Relates to #1069