### PR TITLE
Change: Plex lookup caching and progress ID validation

### DIFF
--- a/providers/sync/plex/_common.py
+++ b/providers/sync/plex/_common.py
@@ -17,11 +17,12 @@ import uuid
 import socket
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from threading import RLock
+from threading import RLock, local
 from typing import Any, Iterable, Mapping
 from urllib.parse import urlsplit, quote
 
 from .._log import log as cw_log
+from cw_platform.log_context import log_run_id
 
 import requests
 
@@ -600,12 +601,42 @@ def meta_guids(meta_obj: Any) -> list[str]:
     return vals
 
 
+_LOOKUP_SCOPE: ContextVar[tuple[Any, ...] | None] = ContextVar("plex_lookup_scope", default=None)
+_LOOKUP_CACHE = local()
+
+
+@contextmanager
+def guid_lookup_scope(key: tuple[Any, ...]):
+    token = _LOOKUP_SCOPE.set(key)
+    try:
+        yield
+    finally:
+        _LOOKUP_SCOPE.reset(token)
+
+
+def _guid_query_cache() -> dict[str, str | None]:
+    key = _LOOKUP_SCOPE.get()
+    if key is None:
+        return {}
+    entry = getattr(_LOOKUP_CACHE, "entry", None)
+    if entry is None or entry[0] != key or (not log_run_id.get() and time.monotonic() - entry[1] >= 300):
+        entry = (key, time.monotonic(), {})
+        _LOOKUP_CACHE.entry = entry
+    return entry[2]
+
+
 def server_find_rating_key_by_guid(srv: Any, guids: Iterable[str]) -> str | None:
     candidates = list(dict.fromkeys(str(g) for g in (guids or []) if g))
+    cache = _guid_query_cache()
     queried: set[str] = set()
     # PlexAPI XML query path
     try:
         for g in candidates:
+            if g in cache:
+                if cache[g]:
+                    return cache[g]
+                queried.add(g)
+                continue
             try:
                 qg = quote(str(g), safe="")
                 root = srv.query(  # type: ignore[attr-defined]
@@ -624,7 +655,10 @@ def server_find_rating_key_by_guid(srv: Any, guids: Iterable[str]) -> str | None
                     a = getattr(el, "attrib", {}) or {}
                     rk = a.get("ratingKey") or a.get("ratingkey")
                     if rk:
+                        cache[g] = str(rk)
                         return str(rk)
+                if g in queried and root is not None and not list(root) and root.get("size") == "0":
+                    cache[g] = None
             except Exception:
                 continue
     except Exception:
@@ -657,15 +691,19 @@ def server_find_rating_key_by_guid(srv: Any, guids: Iterable[str]) -> str | None
 
             # JSON path
             if "json" in ct:
-                try:
-                    j = r.json()
-                except Exception:
-                    j = {}
-                md = (j.get("MediaContainer", {}) or {}).get("Metadata") or []
+                j = r.json()
+                container = j.get("MediaContainer") if isinstance(j, Mapping) else None
+                if not isinstance(container, Mapping):
+                    continue
+                md = container.get("Metadata") or []
                 if md and isinstance(md, list):
                     rk = md[0].get("ratingKey") or md[0].get("ratingkey")
                     if rk:
+                        cache[g] = str(rk)
                         return str(rk)
+                if not md and (container.get("size") == 0 or container.get("Metadata") == []):
+                    cache[g] = None
+                continue
 
             # XML path
             try:
@@ -677,7 +715,10 @@ def server_find_rating_key_by_guid(srv: Any, guids: Iterable[str]) -> str | None
             if el is not None:
                 rk = (el.attrib or {}).get("ratingKey") or (el.attrib or {}).get("ratingkey")
                 if rk:
+                    cache[g] = str(rk)
                     return str(rk)
+            if root.tag == "MediaContainer" and not list(root) and root.get("size") == "0":
+                cache[g] = None
         except Exception:
             pass
     return None
@@ -1379,7 +1420,7 @@ def season_rating_key_from_show(show_obj: Any, season: Any) -> str | None:
     return None
 
 
-_SHOW_EPISODE_CACHE: dict[str, dict[str, Any]] = {}
+_SHOW_EPISODE_CACHE: dict[tuple[Any, ...], dict[str, Any]] = {}
 _SHOW_EPISODE_CACHE_TTL = 300.0
 _SHOW_EPISODE_CACHE_MAX = 256
 
@@ -1390,7 +1431,9 @@ def _show_episode_cache_entry(show_obj: Any) -> dict[str, Any]:
     if rk:
         srv = getattr(show_obj, "_server", None) or getattr(show_obj, "server", None)
         sid = getattr(srv, "machineIdentifier", None) or _as_base_url(srv) or ""
-        key = _metadata_cache_key(f"{sid}:{rk}", getattr(srv, "_token", None), _as_base_url(srv))
+        owner = _LOOKUP_SCOPE.get() or ("object", id(show_obj))
+        key = (owner, log_run_id.get(), _pair_scope(),
+               _metadata_cache_key(f"{sid}:{rk}", getattr(srv, "_token", None), _as_base_url(srv)))
     now = time.monotonic()
     if key:
         entry = _SHOW_EPISODE_CACHE.get(key)

--- a/providers/sync/plex/_progress.py
+++ b/providers/sync/plex/_progress.py
@@ -15,10 +15,12 @@ from providers.sync._progress_policy import decide_progress_write, select_progre
 from ._common import (
     active_pms_token,
     episode_rating_key_from_show,
+    guid_lookup_scope,
     has_external_ids,
     home_scope_enter,
     home_scope_exit,
     item_guid_candidates,
+    ids_from_obj,
     plex_cfg_get,
     plex_feature_cfg,
     plex_feature_library_ids,
@@ -33,6 +35,7 @@ from ._common import (
 from ._history import (
     _build_guid_index as _hist_build_guid_index,
     _pms_find_in_guid_index as _hist_find_in_guid_index,
+    _index_cache_context,
 )
 
 
@@ -468,6 +471,44 @@ def build_index(adapter: Any, **_kwargs: Any) -> Mapping[str, dict[str, Any]]:
 
 
 def _resolve_rating_key(adapter: Any, it: Mapping[str, Any]) -> str | None:
+    allowed = plex_feature_library_ids(adapter, "progress")
+    key, _ = _index_cache_context(adapter, allowed, "progress")
+    with guid_lookup_scope(key):
+        return _resolve_rating_key_in_scope(adapter, it)
+
+
+def _native_progress_identity_matches(obj: Any, item: Mapping[str, Any], ids: Mapping[str, Any]) -> bool:
+    kind = str(item.get("type") or "movie").lower()
+    kind = "episode" if kind == "anime" else kind
+    if str(getattr(obj, "type", "") or "").lower() != kind:
+        return False
+    namespaces = ("tmdb", "imdb", "tvdb", "mal", "anilist")
+
+    def matches(requested: Mapping[str, Any], current: Mapping[str, Any]) -> bool:
+        for key in namespaces:
+            want = str(requested.get(key) or "").strip().lower()
+            have = str(current.get(key) or "").strip().lower()
+            if want and have and (want == have or (want.isdigit() and have.isdigit() and int(want) == int(have))):
+                return True
+        return False
+
+    try:
+        if any(ids.get(key) for key in namespaces):
+            return matches(ids, ids_from_obj(obj))
+        if kind == "episode":
+            show_ids = item.get("show_ids") or {}
+            if any(show_ids.get(key) for key in namespaces):
+                if not matches(show_ids, ids_from_obj(obj.show())):
+                    return False
+            for field, attr in (("season", "parentIndex"), ("episode", "index")):
+                if item.get(field) is not None and int(getattr(obj, attr, -1)) != int(item[field]):
+                    return False
+        return True
+    except Exception:
+        return False
+
+
+def _resolve_rating_key_in_scope(adapter: Any, it: Mapping[str, Any]) -> str | None:
     setattr(adapter, "_plex_progress_last_resolve_hint", None)
     allowed = plex_feature_library_ids(adapter, "progress")
     outside_scope_seen = False
@@ -497,7 +538,9 @@ def _resolve_rating_key(adapter: Any, it: Mapping[str, Any]) -> str | None:
             direct_obj = srv0.fetchItem(int(base_rk)) if srv0 else None  # type: ignore[attr-defined]
         except Exception:
             direct_obj = None
-        if direct_obj is not None and _allowed_obj(direct_obj, "direct_plex_rating_key"):
+        if (direct_obj is not None and str(getattr(direct_obj, "ratingKey", "")) == base_rk
+                and _native_progress_identity_matches(direct_obj, it, ids)
+                and _allowed_obj(direct_obj, "direct_plex_rating_key")):
             return base_rk
 
     srv = getattr(getattr(adapter, "client", None), "server", None)

--- a/tests/test_plex_lookup_cache.py
+++ b/tests/test_plex_lookup_cache.py
@@ -1,0 +1,166 @@
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlsplit
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from cw_platform.log_context import log_run_id
+from providers.sync.plex import _common as common, _history as history, _progress as progress
+
+
+def obj(rk="11", kind="movie", external="1", **extra):
+    return SimpleNamespace(ratingKey=rk, type=kind, librarySectionID="1", title="Different title",
+                           guids=[SimpleNamespace(id=f"tmdb://{external}")], **extra)
+
+
+class Server:
+    _token = "test-token"
+    machineIdentifier = "server"
+    base = "http://plex"
+
+    def __init__(self):
+        self.rows = {"11": obj()}
+        self.matches = {"tmdb://1": "11"}
+        self.queries = []
+        self.fail = False
+        self.library = None
+
+    def url(self, path):
+        return self.base + path
+
+    def query(self, path):
+        self.queries.append(path)
+        if self.fail:
+            raise RuntimeError("Request failed")
+        guid = parse_qs(urlsplit(path).query)["guid"][0]
+        rk = self.matches.get(guid)
+        return ET.fromstring(f'<MediaContainer size="1"><Video ratingKey="{rk}"/></MediaContainer>' if rk else '<MediaContainer size="0"/>')
+
+    def fetchItem(self, rk):
+        return self.rows[str(rk)]
+
+
+def adapter(server=None, pair="pair/a", user="viewer"):
+    return SimpleNamespace(client=SimpleNamespace(server=server or Server()), libraries=lambda **kwargs: [],
+                           config={"_cw_pair_scope": pair, "plex": {"username": user, "strict_id_matching": True}})
+
+
+@pytest.fixture(autouse=True)
+def isolated(monkeypatch):
+    token = log_run_id.set("run1")
+    monkeypatch.setattr(common._LOOKUP_CACHE, "entry", None, raising=False)
+    common._SHOW_EPISODE_CACHE.clear()
+    history._clear_guid_index()
+    for name in ("CW_PAIR_KEY", "CW_PAIR_SCOPE", "CW_SYNC_PAIR", "CW_PAIR"):
+        monkeypatch.delenv(name, raising=False)
+    yield
+    log_run_id.reset(token)
+
+
+def test_query_hits_and_misses_are_reused_across_batches_and_refresh_next_run():
+    srv = Server()
+    sources = [{"type": "movie", "ids": {"tmdb": external}} for external in ("1", "2")]
+    first_count = None
+    for _ in range(3):
+        assert [progress._resolve_rating_key(adapter(srv), source) for source in sources] == ["11", None]
+        if first_count is None:
+            first_count = len(srv.queries)
+        assert len(srv.queries) == first_count
+    srv.rows["22"] = obj("22", external="2")
+    srv.matches["tmdb://2"] = "22"
+    log_run_id.set("run2")
+    assert progress._resolve_rating_key(adapter(srv), sources[1]) == "22"
+    assert len(srv.queries) == first_count + 1
+
+
+@pytest.mark.parametrize("change", ["pair", "user", "token", "base", "machine", "libraries", "run", "feature"])
+def test_lookup_cache_cannot_cross_scope(change):
+    srv = Server()
+    ad = adapter(srv)
+    key, _ = history._index_cache_context(ad, set(), "progress")
+    with common.guid_lookup_scope(key):
+        assert common.server_find_rating_key_by_guid(srv, ["tmdb://1"]) == "11"
+    if change == "pair":
+        ad.config["_cw_pair_scope"] = "pair?a"
+    elif change == "user":
+        ad.config["plex"]["username"] = "another-viewer"
+    elif change == "run":
+        log_run_id.set("run2")
+    elif change in {"token", "base", "machine"}:
+        setattr(srv, {"token": "_token", "machine": "machineIdentifier"}.get(change, change), "different")
+    key, _ = history._index_cache_context(ad, {"1"} if change == "libraries" else set(), "history" if change == "feature" else "progress")
+    with common.guid_lookup_scope(key):
+        assert common.server_find_rating_key_by_guid(srv, ["tmdb://1"]) == "11"
+    assert len(srv.queries) == 2
+
+
+def test_failed_query_can_retry_in_same_run():
+    srv = Server()
+    ad = adapter(srv)
+    srv.fail = True
+    key, _ = history._index_cache_context(ad, set(), "progress")
+    with common.guid_lookup_scope(key):
+        assert common.server_find_rating_key_by_guid(srv, ["tmdb://1"]) is None
+        srv.fail = False
+        assert common.server_find_rating_key_by_guid(srv, ["tmdb://1"]) == "11"
+    assert len(srv.queries) == 2
+
+
+@pytest.mark.parametrize("kind,external", [("movie", "999"), ("episode", "1")])
+def test_stale_native_id_is_rejected_before_external_lookup(kind, external):
+    srv = Server()
+    srv.rows["99"] = obj("99", kind=kind, external=external)
+    source = {"type": "movie", "ids": {"plex": "99", "tmdb": "1"}}
+    assert progress._resolve_rating_key(adapter(srv), source) == "11"
+    assert len(srv.queries) == 1
+
+
+def test_verified_native_id_needs_no_guid_query():
+    srv = Server()
+    assert progress._resolve_rating_key(adapter(srv), {"type": "movie", "title": "Localized title", "ids": {"plex": "11", "tmdb": "1"}}) == "11"
+    assert srv.queries == []
+
+
+def test_episode_cache_sees_new_episodes_on_next_run():
+    srv = Server()
+    rows = [SimpleNamespace(ratingKey="101", parentIndex=0, index=1)]
+    calls = []
+
+    def episodes():
+        calls.append(1)
+        return list(rows)
+
+    for episode, run, expected in [(1, "run1", "101"), (2, "run1", None), (2, "run2", "102")]:
+        log_run_id.set(run)
+        ad = adapter(srv)
+        key, _ = history._index_cache_context(ad, set(), "progress")
+        show = SimpleNamespace(ratingKey="10", _server=srv, episodes=episodes)
+        with common.guid_lookup_scope(key):
+            assert common.episode_rating_key_from_show(show, 0, episode) == expected
+        if episode == 1:
+            rows.append(SimpleNamespace(ratingKey="102", parentIndex=0, index=2))
+    assert len(calls) == 2
+
+
+def test_no_pair_scope_never_shares_queries_between_adapters():
+    srv = Server()
+    for _ in range(2):
+        assert progress._resolve_rating_key(adapter(srv, pair=None), {"type": "movie", "ids": {"tmdb": "1"}}) == "11"
+    assert len(srv.queries) == 2
+
+
+@pytest.mark.parametrize("wrong", ["series", "number"])
+def test_native_episode_with_only_series_ids_checks_parent_and_number(wrong):
+    source = {"type": "episode", "ids": {"plex": "99"}, "show_ids": {"tmdb": "10"}, "season": 0, "episode": 2}
+    parent = obj("20", "show", external="999" if wrong == "series" else "10")
+    stale = obj("99", "episode", parentIndex=0, index=1 if wrong == "number" else 2, show=lambda: parent)
+    assert not progress._native_progress_identity_matches(stale, source, source["ids"])
+    correct = obj("100", "episode", parentIndex=0, index=2, show=lambda: obj("20", "show", external="10"))
+    assert progress._native_progress_identity_matches(correct, source, source["ids"])
+
+
+def test_exact_episode_id_leads_over_numbering_and_numeric_id_padding():
+    source = {"type": "episode", "ids": {"plex": "99", "tvdb": "000123"}, "season": 1, "episode": 2}
+    target = obj("99", "episode", parentIndex=2, index=4)
+    target.guids = [SimpleNamespace(id="tvdb://123")]
+    assert progress._native_progress_identity_matches(target, source, source["ids"])


### PR DESCRIPTION
# Pull request

## Change
- Reuse GUID lookups across progress batches.
- Keep lookup and episode caches isolated per pair.
- Validate native Plex IDs before writing progress.

## Why
Reduce repeated requests and prevent progress writes to the wrong item.

## Testing
- tests/test_plex_lookup_cache.py

## Issue
Relates to #1071