### PR TITLE
Fix: event archive database concurrency errors

### DIFF
--- a/cw_platform/event_archive/groups.py
+++ b/cw_platform/event_archive/groups.py
@@ -8,8 +8,10 @@ import json
 import logging
 import re
 import sqlite3
+import threading
 import time
-from typing import Any
+from functools import wraps
+from typing import Any, Callable, ParamSpec, TypeVar
 
 from .db import get_conn
 from . import query as _query
@@ -17,6 +19,21 @@ from .scrobble_recorder import session_token
 from ..reason_labels import friendly_reason
 
 _LOG = logging.getLogger("crosswatch.event_archive")
+
+_GROUP_LOCK = threading.RLock()
+_PArgs = ParamSpec("_PArgs")
+_Result = TypeVar("_Result")
+
+
+def _serialized(fn: Callable[_PArgs, _Result]) -> Callable[_PArgs, _Result]:
+    @wraps(fn)
+    def wrapped(*args: _PArgs.args, **kwargs: _PArgs.kwargs) -> _Result:
+        # Include version checks and reads so a rebuild cannot invalidate the
+        # groups another request is currently assembling.
+        with _GROUP_LOCK:
+            return fn(*args, **kwargs)
+    return wrapped
+
 
 _GROUP_COLUMNS = (
     "id", "group_hash", "domain", "created_at", "updated_at", "first_event_at", "last_event_at",
@@ -576,38 +593,33 @@ def _persist_titles(conn: sqlite3.Connection, ids: list[int]) -> None:
             pass
 
 
+@_serialized
 def correlate(*, conn: sqlite3.Connection | None = None, reset: bool = False) -> dict[str, Any]:
     c = conn or get_conn()
     if c is None:
         return {"ok": False, "available": False, "grouped": 0}
-    if reset:
-        try:
-            with c:
-                c.execute("UPDATE events SET group_id=NULL")
-                c.execute("DELETE FROM event_groups")
-        except Exception as exc:
-            _LOG.warning("event correlation reset failed: %s", exc)
-    try:
-        rows = c.execute(
-            "SELECT id, event_hash, domain, event_type, feature, operation, item_key, title, season, episode, created_at, "
-            "source_kind, session_key, source_provider, source_instance, destination_provider, destination_instance, "
-            "pair_key, run_id FROM events WHERE group_id IS NULL"
-        ).fetchall()
-    except Exception as exc:
-        _LOG.warning("event correlation query failed: %s", exc)
-        return {"ok": False, "error": "internal_error", "grouped": 0}
-    if not rows:
-        return {"ok": True, "grouped": 0, "groups_touched": 0}
-
-    now = int(time.time())
-    all_ids = [int(r["id"]) for r in rows]
-    buckets: dict[str, list[int]] = {}
-    for r in rows:
-        buckets.setdefault(group_hash(r), []).append(int(r["id"]))
-
-    touched: set[int] = set()
     try:
         with c:
+            # Reset and replacement must commit together. On failure, retain
+            # the previous groups so the next request can retry the rebuild.
+            if reset:
+                c.execute("UPDATE events SET group_id=NULL")
+                c.execute("DELETE FROM event_groups")
+            rows = c.execute(
+                "SELECT id, event_hash, domain, event_type, feature, operation, item_key, title, season, episode, created_at, "
+                "source_kind, session_key, source_provider, source_instance, destination_provider, destination_instance, "
+                "pair_key, run_id FROM events WHERE group_id IS NULL"
+            ).fetchall()
+            if not rows:
+                return {"ok": True, "grouped": 0, "groups_touched": 0}
+
+            now = int(time.time())
+            all_ids = [int(r["id"]) for r in rows]
+            buckets: dict[str, list[int]] = {}
+            for r in rows:
+                buckets.setdefault(group_hash(r), []).append(int(r["id"]))
+
+            touched: set[int] = set()
             _persist_titles(c, all_ids)
             for gh, ids in buckets.items():
                 c.execute(
@@ -621,18 +633,21 @@ def correlate(*, conn: sqlite3.Connection | None = None, reset: bool = False) ->
             for gid in touched:
                 _recompute(c, gid, now)
     except Exception as exc:
-        _LOG.warning("event correlation failed: %s", exc)
+        _LOG.warning("event correlation failed: %s", exc, exc_info=True)
         return {"ok": False, "error": "internal_error", "grouped": 0}
     return {"ok": True, "grouped": len(rows), "groups_touched": len(touched)}
 
 
+@_serialized
 def _ensure_correlated(conn: sqlite3.Connection) -> None:
     try:
         appid = int(conn.execute("PRAGMA application_id").fetchone()[0] or 0)
     except Exception:
         appid = CORRELATION_VERSION
     if appid < CORRELATION_VERSION:
-        correlate(conn=conn, reset=True)
+        result = correlate(conn=conn, reset=True)
+        if not result.get("ok"):
+            return
         try:
             conn.execute(f"PRAGMA application_id={CORRELATION_VERSION}")
         except Exception:
@@ -671,6 +686,7 @@ _CATEGORY_STATUS = {
 }
 
 
+@_serialized
 def list_groups(
     *,
     q: str | None = None,
@@ -804,7 +820,7 @@ def list_groups(
             [*params, lim, off],
         ).fetchall()
     except Exception as exc:
-        _LOG.warning("group list failed: %s", exc)
+        _LOG.warning("group list failed: %s", exc, exc_info=True)
         return {"items": [], "total": 0, "limit": lim, "offset": off}
     return {"items": _with_reason_labels([dict(r) for r in rows]), "total": total, "limit": lim, "offset": off}
 
@@ -1080,6 +1096,7 @@ def _run_problem_status_counts_bulk(
     return out
 
 
+@_serialized
 def list_tree(*, order: str | None = "newest", limit: int = 50, offset: int = 0,
               include_children: bool = True, domain: str | None = None,
               conn: sqlite3.Connection | None = None, **filters: Any) -> dict[str, Any]:

--- a/cw_platform/local_db/db.py
+++ b/cw_platform/local_db/db.py
@@ -12,8 +12,9 @@ from pathlib import Path
 _LOG = logging.getLogger("crosswatch.local_db")
 
 _LOCK = threading.RLock()
-_CONN: sqlite3.Connection | None = None
-_CONN_PATH: str | None = None
+# A connection owns its transaction state. Sharing it between workers allows
+# one worker's commit/rollback to affect another worker's writes.
+_CONNECTIONS: dict[threading.Thread, tuple[str, sqlite3.Connection]] = {}
 
 
 class LocalDatabaseError(Exception):
@@ -107,43 +108,46 @@ def connect(
 
 
 def get_conn(base_path: str | os.PathLike[str] | None = None) -> sqlite3.Connection | None:
-    global _CONN, _CONN_PATH
     with _LOCK:
+        worker = threading.current_thread()
+        # Reap short-lived workers without relying on recycled thread IDs.
+        for owner in list(_CONNECTIONS):
+            if owner is not worker and not owner.is_alive():
+                _, stale = _CONNECTIONS.pop(owner)
+                try:
+                    stale.close()
+                except Exception:
+                    pass
         want = str(crosswatch_db_path(base_path))
-        if _CONN is not None and _CONN_PATH == want:
-            if want == ":memory:" or Path(want).exists():
-                return _CONN
+        cached = _CONNECTIONS.get(worker)
+        if cached is not None:
+            path, conn = cached
+            if path == want and (want == ":memory:" or Path(want).exists()):
+                return conn
             try:
-                _CONN.close()
+                conn.close()
             except Exception:
                 pass
-            _CONN = None
-            _CONN_PATH = None
-            _LOG.warning("local database file missing; recreating %s", want)
-        if _CONN is not None:
-            try:
-                _CONN.close()
-            except Exception:
-                pass
-            _CONN = None
-        try:
-            _CONN = connect(want, base_path=base_path)
-            _CONN_PATH = want
-            return _CONN
-        except Exception as exc:
-            _LOG.warning("local database unavailable: %s", exc)
-            _CONN = None
-            _CONN_PATH = None
-            return None
+            del _CONNECTIONS[worker]
+            if path == want:
+                _LOG.warning("local database file missing; recreating %s", want)
+    # Schema setup can wait for another worker's transaction. Do not hold the
+    # registry lock while waiting: that worker may need get_conn() to finish.
+    try:
+        conn = connect(want, base_path=base_path)
+        with _LOCK:
+            _CONNECTIONS[worker] = (want, conn)
+        return conn
+    except Exception as exc:
+        _LOG.warning("local database unavailable: %s", exc)
+        return None
 
 
 def close_conn() -> None:
-    global _CONN, _CONN_PATH
     with _LOCK:
-        if _CONN is not None:
+        for _, conn in _CONNECTIONS.values():
             try:
-                _CONN.close()
+                conn.close()
             except Exception:
                 pass
-        _CONN = None
-        _CONN_PATH = None
+        _CONNECTIONS.clear()

--- a/tests/test_event_archive_concurrency.py
+++ b/tests/test_event_archive_concurrency.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from cw_platform.event_archive import db, groups
+from cw_platform.event_archive.recorder import record_events
+
+
+def _events(start, count):
+    return [
+        {
+            "event_hash": f"event-{i}",
+            "domain": "sync",
+            "created_at": 1770000000 + i,
+            "run_id": f"run-{i}",
+            "event_type": "sync_run_started",
+            "severity": "info",
+        }
+        for i in range(start, start + count)
+    ]
+
+
+@pytest.fixture()
+def archive(tmp_path, monkeypatch):
+    monkeypatch.setenv("CROSSWATCH_DB", str(tmp_path / "crosswatch.sqlite3"))
+    monkeypatch.setenv("CONFIG_BASE", str(tmp_path))
+    db.close_conn()
+    conn = db.get_conn()
+    assert conn is not None
+    assert record_events(_events(0, 8), conn=conn) == 8
+    yield conn
+    db.close_conn()
+
+
+def test_failed_rebuild_preserves_groups_and_retries_version(archive, monkeypatch, caplog):
+    original = groups.list_groups(visibility="all", conn=archive)
+    assert original["total"] == 8
+    old_version = groups.CORRELATION_VERSION - 1
+    archive.execute(f"PRAGMA application_id={old_version}")
+    original_ids = [tuple(row) for row in archive.execute("SELECT id, group_id FROM events ORDER BY id")]
+
+    with monkeypatch.context() as patch:
+        def fail(*args):
+            raise RuntimeError("injected rebuild failure")
+
+        patch.setattr(groups, "_recompute", fail)
+        with caplog.at_level(logging.WARNING, logger="crosswatch.event_archive"):
+            result = groups.list_groups(visibility="all", conn=archive)
+        assert result == original
+        assert archive.execute("PRAGMA application_id").fetchone()[0] == old_version
+        assert [tuple(row) for row in archive.execute("SELECT id, group_id FROM events ORDER BY id")] == original_ids
+        assert any(record.exc_info for record in caplog.records if "event correlation failed" in record.message)
+
+    result = groups.list_groups(visibility="all", conn=archive)
+    assert result["total"] == 8
+    assert archive.execute("PRAGMA application_id").fetchone()[0] == groups.CORRELATION_VERSION
+
+
+def test_concurrent_feed_rebuild_and_recording_preserve_all_events(archive, caplog):
+    barrier = threading.Barrier(4)
+
+    def reader(tree):
+        barrier.wait(timeout=10)
+        for _ in range(12):
+            result = (groups.list_tree if tree else groups.list_groups)(visibility="all", limit=100)
+            assert 8 <= result["total"] <= 20
+            assert len(result["items"]) == result["total"]
+            assert all(item["event_count"] == 1 for item in result["items"])
+
+    def rebuilder():
+        barrier.wait(timeout=10)
+        for _ in range(12):
+            assert groups.correlate(reset=True)["ok"]
+
+    def writer():
+        barrier.wait(timeout=10)
+        for i in range(8, 20):
+            assert record_events(_events(i, 1)) == 1
+
+    with caplog.at_level(logging.WARNING, logger="crosswatch.event_archive"):
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(reader, False), pool.submit(reader, True), pool.submit(rebuilder), pool.submit(writer)]
+            for future in futures:
+                future.result(timeout=30)
+    result = groups.list_groups(visibility="all", conn=archive)
+    assert result["total"] == 20
+    assert archive.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 20
+    assert archive.execute(
+        "SELECT COUNT(*) FROM events e LEFT JOIN event_groups g ON g.id=e.group_id WHERE g.id IS NULL"
+    ).fetchone()[0] == 0
+    assert archive.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    assert not [record for record in caplog.records if record.levelno >= logging.WARNING]

--- a/tests/test_local_db_concurrency.py
+++ b/tests/test_local_db_concurrency.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from cw_platform.local_db import db
+
+
+@pytest.fixture()
+def database(tmp_path, monkeypatch):
+    monkeypatch.setenv("CROSSWATCH_DB", str(tmp_path / "crosswatch.sqlite3"))
+    monkeypatch.setenv("CONFIG_BASE", str(tmp_path))
+    db.close_conn()
+    conn = db.get_conn()
+    assert conn is not None
+    with conn:
+        conn.execute("CREATE TABLE concurrency_test (value TEXT)")
+    yield conn
+    db.close_conn()
+
+
+def test_workers_cannot_read_or_commit_each_others_transaction(database):
+    written = threading.Event()
+    release = threading.Event()
+
+    def writer():
+        conn = db.get_conn()
+        assert conn is not None
+        try:
+            with conn:
+                conn.execute("INSERT INTO concurrency_test VALUES ('uncommitted')")
+                written.set()
+                assert release.wait(10)
+                raise ValueError("roll back this worker")
+        except ValueError:
+            pass
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(writer)
+        try:
+            assert written.wait(10)
+            assert database.execute("SELECT COUNT(*) FROM concurrency_test").fetchone()[0] == 0
+            # A reader's commit must not commit the writer's pending insert.
+            database.commit()
+        finally:
+            release.set()
+        future.result(timeout=10)
+    assert database.execute("SELECT COUNT(*) FROM concurrency_test").fetchone()[0] == 0
+
+
+def test_connection_cache_and_close_cover_all_workers(database):
+    barrier = threading.Barrier(3)
+
+    def worker():
+        conn = db.get_conn()
+        assert conn is db.get_conn()
+        barrier.wait(timeout=10)
+        return conn
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(worker) for _ in range(2)]
+        barrier.wait(timeout=10)
+        connections = [database, *(future.result(timeout=10) for future in futures)]
+        assert len({id(conn) for conn in connections}) == 3
+        db.close_conn()
+        for conn in connections:
+            with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+                conn.execute("SELECT 1")
+        replacement = db.get_conn()
+        assert replacement is not database
+        assert replacement.execute("SELECT COUNT(*) FROM concurrency_test").fetchone()[0] == 0
+
+
+def test_finished_worker_connection_is_closed_on_next_lookup(database):
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        conn = pool.submit(db.get_conn).result(timeout=10)
+    assert db.get_conn() is database
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        conn.execute("SELECT 1")
+
+
+def test_switching_database_replaces_only_current_workers_connection(database, tmp_path, monkeypatch):
+    monkeypatch.setenv("CROSSWATCH_DB", str(tmp_path / "replacement.sqlite3"))
+    replacement = db.get_conn()
+    assert replacement is not None and replacement is not database
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        database.execute("SELECT 1")
+    assert replacement.execute("PRAGMA integrity_check").fetchone()[0] == "ok"


### PR DESCRIPTION
# Pull request

## Change

- Give each worker its own database connection.
- Serialize event regrouping.
- Keep existing groups when a rebuild fails and retry later.
- Include tracebacks in error logs.

## Why

- Overlapping database operations could interfere with each other and leave the event feed empty.

## Testing

- tests/test_local_db_concurrency.py 
- tests/test_event_archive_concurrency.py`

## Issue

NA