### PR TITLE
Change: clarify analyzer watch time differences

### DIFF
--- a/assets/js/analyzer/index.js
+++ b/assets/js/analyzer/index.js
@@ -4,7 +4,7 @@
 
 const FEATURES = ["history", "watchlist", "ratings", "progress", "collection"];
 const VIEWS = {
-  missing: { title: "Missing items", icon: "compare_arrows", description: "Items present in one saved snapshot and missing from a destination. These are findings, not proposed sync changes." },
+  missing: { title: "Snapshot differences", icon: "compare_arrows", description: "Missing items and unmatched watch times in saved snapshots. Review each finding before deciding whether a sync change is needed." },
   pending: { title: "Pending retries", icon: "pending_actions", description: "Items a previous sync could not match or write. Review the reason before running the pair again." },
   system: { title: "System health", icon: "monitor_heart", description: "Provider, orchestrator and saved-state diagnostics across CrossWatch, plus findings for the selected pairs." },
   blocked: { title: "Blocked items", icon: "block", description: "Items held back by saved blocking rules or automatic protections." },
@@ -26,6 +26,28 @@ const label = row => {
 };
 const reasonText = hint => hint?.message || [hint?.provider, array(hint?.reasons).join(", ") || hint?.reason || hint?.kind].filter(Boolean).join(": ");
 const unique = rows => [...new Map(rows.map(row => [JSON.stringify(row), row])).values()];
+export function watchDifferenceLabel(row, providerName = String) {
+  const differences = array(row.watch_time_differences);
+  const timeTargets = new Set(differences.map(entry => entry.target));
+  const missing = array(row.targets).filter(target => !timeTargets.has(target));
+  return [differences.length && `Watch time differs at ${[...timeTargets].map(providerName).join(", ")}`,
+    missing.length && `Missing at ${missing.map(providerName).join(", ")}`].filter(Boolean).join("; ") || "Missing at destination";
+}
+export function retryLabel(row) {
+  return row.retry_blocked ? "Automatic retries blocked" : "Pending retry";
+}
+export function nextStepText(row) {
+  const blocked = row.retry_blocked ? "Automatic retries are blocked after repeated failures. Resolve the cause before clearing the retry block. " : "";
+  if (array(row.watch_time_differences).length) return blocked + "Compare the recorded watch times and playback history. Matching IDs do not establish whether these are the same playback or separate watches. A mapping edit does not correct the watch time.";
+  return blocked + "Review the provider's reported reason and the pair's sync rules. Correct the mapping only if the item was identified incorrectly.";
+}
+export function watchDifferenceDetails(differences, providerName = String) {
+  return array(differences).map(entry => {
+    const seconds = Math.abs(Number(entry.difference_seconds));
+    const duration = `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+    return `<div class="an-detail-reasons"><h4>Watch time differs</h4><p>${esc(providerName(entry.source))}: ${esc(entry.source_watched_at)}</p><p>${esc(providerName(entry.target))} (closest recorded watch): ${esc(entry.target_watched_at)}</p><p>Difference: ${esc(duration)}. Times are shown with their recorded time zone.</p><p>${esc(entry.message)}</p></div>`;
+  }).join("");
+}
 const affectedLabels = row => [
   ...array(row.affected_items).map(value => [value.label || value.key, value.reason, value.attempts != null && `Attempts: ${value.attempts}`].filter(Boolean).join(" · ")),
   ...array(row.extra_source_titles || row.extra_source).map(value => `Only at source: ${value}`),
@@ -187,6 +209,10 @@ const Analyzer = {
       const endpoint = (provider, instance) => providerName(`${provider}${instance ? `@${instance}` : ""}`);
       return `${endpoint(pair.source, pair.source_instance)} ${twoWay ? "↔" : "→"} ${endpoint(pair.target, pair.target_instance)}`;
     };
+    const rowPairName = row => {
+      const pair = pairs.find(pair => pair.id === row.pair_id);
+      return pair ? pairName(pair) : row.pair_id || "";
+    };
     const filterResults = createResultFilter(providerName);
     let groups = { missing: [], blocked: [], system: [], errors: 0, warnings: 0 };
     function indexResultGroups() {
@@ -273,8 +299,8 @@ const Analyzer = {
         if (!$("#an-search").value && !$("#an-feature").value && !$("#an-severity").value) {
           const loading = view === "system" ? systemState === "loading" : analysisState === "loading";
           const failed = view === "system" ? systemState === "error" : analysisState === "error";
-          title = loading ? "Analysis in progress" : failed ? "Results unavailable" : ({ missing: "No missing items found", pending: "No pending retries", blocked: "No blocked items", system: "No system findings", all: "No saved items" })[view];
-          message = loading ? "Results will appear here as the checks finish." : failed ? "Retry the failed check using the message above." : view === "system" && systemState === "restricted" ? "Global system diagnostics are available to administrators. Pair findings remain visible here." : view === "missing" ? "No presence differences were found in the saved snapshots for these pairs." : "There is nothing to review in this view for the current scope.";
+          title = loading ? "Analysis in progress" : failed ? "Results unavailable" : ({ missing: "No snapshot differences found", pending: "No pending retries", blocked: "No blocked items", system: "No system findings", all: "No saved items" })[view];
+          message = loading ? "Results will appear here as the checks finish." : failed ? "Retry the failed check using the message above." : view === "system" && systemState === "restricted" ? "Global system diagnostics are available to administrators. Pair findings remain visible here." : view === "missing" ? "No missing items or unmatched watch times were found in the saved snapshots for these pairs." : "There is nothing to review in this view for the current scope.";
           symbol = loading ? "progress_activity" : failed ? "error" : "check_circle";
           if (!loading && !failed && view === "missing" && snapshotGaps.length) {
             title = "Comparison incomplete";
@@ -297,15 +323,15 @@ const Analyzer = {
       const editable = view === "pending" && window.CW?.AuthState?.read?.().permissions?.write !== false;
       $("#an-list").innerHTML = `<div class="an-table-scroll"><table class="an-table"><thead><tr><th scope="col">Item</th><th scope="col">Provider</th><th scope="col">Feature</th><th scope="col">Finding</th>${editable ? '<th scope="col" class="an-mapping-column" aria-label="Edit mapping"></th>' : ''}</tr></thead><tbody>${currentRows.map((row, index) => {
         const mismatch = missingIndex.get(identity(row));
-        const finding = view === "pending" ? "Pending retry" : row.type === "missing_peer" || mismatch ? `Missing at ${array((mismatch || row).targets).map(providerName).join(", ") || "destination"}` : blockedIndex.has(identity(row)) ? "Blocked" : "No presence issue";
-        return `<tr data-row="${index}" class="${selected === row ? "is-selected" : ""}"><td><button type="button" class="an-item-button" data-row="${index}" aria-pressed="${selected === row}"><strong>${esc(label(row))}</strong><span>${esc([human(row.item_type || row.item?.type || (row.type === "missing_peer" ? "" : row.type)), row.year || row.item?.year].filter(Boolean).join(" · "))}</span></button></td><td>${esc(providerName(row.provider))}</td><td><span class="an-feature-badge">${esc(human(row.feature))}</span></td><td><span class="an-result-badge ${mismatch || row.type === "missing_peer" ? "an-warn-text" : ""}">${esc(finding)}</span></td>${editable ? `<td class="an-mapping-column">${row.key && FEATURES.includes(row.feature) ? `<button type="button" class="an-icon-button" data-edit-mapping="${index}" title="Edit mapping" aria-label="Edit mapping for ${esc(label(row))}">${icon("edit")}</button>` : ''}</td>` : ''}</tr>`;
+        const finding = view === "pending" ? retryLabel(row) : row.type === "missing_peer" || mismatch ? watchDifferenceLabel(mismatch || row, providerName) : blockedIndex.has(identity(row)) ? "Blocked" : "No presence issue";
+        return `<tr data-row="${index}" class="${selected === row ? "is-selected" : ""}"><td><button type="button" class="an-item-button" data-row="${index}" aria-pressed="${selected === row}"><strong>${esc(label(row))}</strong><span>${esc([human(row.item_type || row.item?.type || (row.type === "missing_peer" ? "" : row.type)), row.year || row.item?.year].filter(Boolean).join(" · "))}</span></button></td><td>${esc(providerName(row.provider))}${rowPairName(row) ? `<span class="an-pair-label">${esc(rowPairName(row))}</span>` : ""}</td><td><span class="an-feature-badge">${esc(human(row.feature))}</span></td><td><span class="an-result-badge ${mismatch || row.type === "missing_peer" ? "an-warn-text" : ""}">${esc(finding)}</span></td>${editable ? `<td class="an-mapping-column">${row.key && FEATURES.includes(row.feature) && !array(row.watch_time_differences).length ? `<button type="button" class="an-icon-button" data-edit-mapping="${index}" title="Edit mapping" aria-label="Edit mapping for ${esc(label(row))}">${icon("edit")}</button>` : ''}</td>` : ''}</tr>`;
       }).join("")}</tbody></table></div>`;
     }
     function renderFinding(row, index) {
       const sev = severity(row);
       const title = row.title || row.message || human(row.type) || "Diagnostic finding";
       const context = [providerName(row.provider || row.source), row.feature && human(row.feature), row.category && human(row.category)].filter(Boolean).join(" · ");
-      const detail = [row.message && row.message !== title ? row.message : "", row.item_title, row.key && `Key: ${row.key}`, row.module && `Module: ${row.module}`, row.path && `Path: ${row.path}`, row.error, row.reason, row.count != null && `Items affected: ${row.count}`, row.source && row.target && `${row.source} → ${row.target}`, row.show_delta && `Shows: ${row.show_delta.source} at source / ${row.show_delta.target} at destination`, row.show_gap && `Source-only shows: ${row.show_gap.source_only}; destination-only shows: ${row.show_gap.target_only}`, row.missing?.length && `Missing IDs: ${row.missing.join(", ")}`, row.id_name && `ID field: ${row.id_name} (${row.id_value ?? ""})`, row.watermark_key && `Watermark: ${row.watermark_key}`, row.value != null && `Value: ${row.value}`].filter(Boolean);
+      const detail = [rowPairName(row) && `Sync pair: ${rowPairName(row)}`, row.message && row.message !== title ? row.message : "", row.item_title, row.key && `Key: ${row.key}`, row.module && `Module: ${row.module}`, row.path && `Path: ${row.path}`, row.error, row.reason, row.count != null && `Items affected: ${row.count}`, row.source && row.target && `${row.source} → ${row.target}`, row.show_delta && `Shows: ${row.show_delta.source} at source / ${row.show_delta.target} at destination`, row.show_gap && `Source-only shows: ${row.show_gap.source_only}; destination-only shows: ${row.show_gap.target_only}`, row.missing?.length && `Missing IDs: ${row.missing.join(", ")}`, row.id_name && `ID field: ${row.id_name} (${row.id_value ?? ""})`, row.watermark_key && `Watermark: ${row.watermark_key}`, row.value != null && `Value: ${row.value}`].filter(Boolean);
       const items = affectedLabels(row);
       return `<article class="an-finding an-severity-${sev}"><div class="an-finding-icon">${icon(sev === "error" ? "error" : sev === "warn" ? "warning" : "info")}</div><div class="an-finding-content"><div class="an-finding-top"><span class="an-severity-badge">${sev === "error" ? "Error" : sev === "warn" ? "Warning" : "Information"}</span><span>${esc(context)}</span></div><h3>${esc(title)}</h3>${detail.map(value => `<p>${esc(value)}</p>`).join("")}${items.length ? `<details class="an-affected"><summary>Affected items (${items.length.toLocaleString()})</summary><ul>${items.slice(0, 25).map(value => `<li>${esc(value)}</li>`).join("")}</ul>${items.length > 25 ? `<button type="button" class="an-button" data-more="${index}" data-shown="25">Show more</button>` : ""}</details>` : ""}<span class="an-finding-code">${esc(row.type)}</span></div></article>`;
     }
@@ -390,18 +416,19 @@ const Analyzer = {
       const mismatch = missingIndex.get(identity(row));
       const render = (detail = {}, error = "") => {
         if (controller.signal.aborted || lifetime.signal.aborted || selected !== row) return;
-        const reasons = [...new Set([row.message, row.reason, ...array(detail.hints).map(reasonText), ...array(detail.target_show_info).map(reasonText)].filter(Boolean))];
+        const reasons = [...new Set([row.message, row.reason_message || row.reason, ...array(detail.hints).map(reasonText), ...array(detail.target_show_info).map(reasonText)].filter(Boolean))];
         const targets = array(detail.targets || mismatch?.targets || row.targets);
         const ids = Object.entries(row.ids || row.item?.ids || {});
         const provider = providerName(row.provider);
-        const presence = view === "pending" ? "Waiting for a successful retry" : blockedIndex.has(identity(row)) ? "Blocked by a saved rule" : mismatch ? `Missing at ${targets.map(providerName).join(", ") || "destination"}` : "Present in the saved snapshot";
+        const diagnosis = { ...row, ...mismatch, ...detail, retry_blocked: row.retry_blocked || mismatch?.retry_blocked || array(detail.hints).some(hint => hint.kind === "blackbox") };
+        const presence = view === "pending" ? retryLabel(row) : blockedIndex.has(identity(row)) ? "Blocked by a saved rule" : mismatch ? watchDifferenceLabel(diagnosis, providerName) : "Present in the saved snapshot";
         const limitNotes = targets.map(target => {
           const provider = status.providers?.[String(target).split("@")[0]];
           const key = row.feature === "collection" ? "collection" : "watchlist";
           const limit = ["watchlist", "collection"].includes(row.feature) ? provider?.limits?.[key] : null;
           return limit && limit.item_count > 0 && limit.used >= limit.item_count ? `${providerName(target)} ${human(key)} limit reached (${limit.used}/${limit.item_count}). Free up space or review the provider account limit.` : "";
         }).filter(Boolean);
-        $("#an-detail").innerHTML = `<div class="an-detail-heading"><span class="an-eyebrow">ITEM DETAILS</span><button type="button" class="an-icon-button" id="an-close-detail" aria-label="Close item details">${icon("close")}</button></div><h3>${esc(label(row))}</h3><p class="an-detail-meta">${esc([provider, human(row.feature), row.year || row.item?.year].filter(Boolean).join(" · "))}</p><div class="an-detail-status">${icon(mismatch || view === "pending" ? "info" : "check_circle")}<strong>${esc(presence)}</strong></div>${reasons.length || limitNotes.length ? `<div class="an-detail-reasons"><h4>What happened</h4>${[...limitNotes, ...reasons].map(reason => `<p>${esc(reason)}</p>`).join("")}</div>` : mismatch ? '<p class="an-muted">CrossWatch found this item in the source snapshot but could not confirm it at the destination.</p>' : ""}${error ? `<p class="an-detail-error" role="alert">${esc(error)}</p><button type="button" class="an-button" id="an-retry-detail">Retry details</button>` : ""}${mismatch || view === "pending" ? '<div class="an-next-step"><h4>Next step</h4><p>Check the pair’s sync rules and the provider. Use the pencil beside a pending item to correct its mapping, then run the pair again.</p></div>' : ""}${ids.length ? `<details class="an-identifiers"><summary>Item IDs (${ids.length})</summary><dl>${ids.map(([key, value]) => `<div><dt>${esc(key)}</dt><dd>${esc(value)}</dd></div>`).join("")}</dl></details>` : ""}${row.key ? `<p class="an-item-key">${esc(row.key)}</p>` : ""}`;
+        $("#an-detail").innerHTML = `<div class="an-detail-heading"><span class="an-eyebrow">ITEM DETAILS</span><button type="button" class="an-icon-button" id="an-close-detail" aria-label="Close item details">${icon("close")}</button></div><h3>${esc(label(row))}</h3><p class="an-detail-meta">${esc([provider, human(row.feature), row.year || row.item?.year].filter(Boolean).join(" · "))}</p>${rowPairName(row) ? `<p class="an-detail-meta">Sync pair: ${esc(rowPairName(row))}</p>` : ""}<div class="an-detail-status">${icon(mismatch || view === "pending" ? "info" : "check_circle")}<strong>${esc(presence)}</strong></div>${reasons.length || limitNotes.length ? `<div class="an-detail-reasons"><h4>What happened</h4>${[...limitNotes, ...reasons].map(reason => `<p>${esc(reason)}</p>`).join("")}</div>` : mismatch ? '<p class="an-muted">CrossWatch found this item in the source snapshot but could not confirm it at the destination.</p>' : ""}${watchDifferenceDetails(diagnosis.watch_time_differences, providerName)}${error ? `<p class="an-detail-error" role="alert">${esc(error)}</p><button type="button" class="an-button" id="an-retry-detail">Retry details</button>` : ""}${mismatch || view === "pending" ? `<div class="an-next-step"><h4>Next step</h4><p>${esc(nextStepText(diagnosis))}</p></div>` : ""}${ids.length ? `<details class="an-identifiers"><summary>Item IDs (${ids.length})</summary><dl>${ids.map(([key, value]) => `<div><dt>${esc(key)}</dt><dd>${esc(value)}</dd></div>`).join("")}</dl></details>` : ""}${row.key ? `<p class="an-item-key">${esc(row.key)}</p>` : ""}`;
       };
       render(detailCache.get(identity(row)));
       if (!mismatch || detailCache.has(identity(row))) return;

--- a/assets/js/analyzer/styles.css
+++ b/assets/js/analyzer/styles.css
@@ -147,3 +147,9 @@
 .an-page .an-mapping-column{width:56px;text-align:right;white-space:nowrap}
 .an-page .an-mapping-column .an-icon-button:hover{color:var(--accent,#8057ff);border-color:var(--accent,#8057ff)}
 .an-page .an-mapping-notice{padding:12px 16px;border:1px solid var(--border,#2a2e38);border-radius:12px;background:var(--panel,#101318);color:var(--muted,#959eab)}
+.an-page .an-pair-label {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.8rem;
+  opacity: 0.7;
+}

--- a/services/analyzer.py
+++ b/services/analyzer.py
@@ -2518,6 +2518,7 @@ class _AnalysisContext:
     history_pair_aliases: dict[tuple[str, str], dict[str, Any]] = field(default_factory=dict)
     history_keys: dict[str, dict[str, Any]] = field(default_factory=dict)
     history_rewatch_pairs: set[tuple[str, str]] = field(default_factory=set)
+    history_identity_items: dict[str, dict[str, list[tuple[str, Mapping[str, Any]]]]] = field(default_factory=dict)
     anime_coords: _AnimeHistoryCoords | None = None
 
     def anime_history_match(self, src_tok: str, dst_tok: str, item: Mapping[str, Any], *, require_minute: bool = False) -> bool:
@@ -2586,6 +2587,42 @@ def _target_peer_match(
     if feat_key == "history" and ctx.anime_history_match(prov_key, dst_key, item):
         return "anime_coords"
     return ""
+
+
+def _history_time_differences(
+    ctx: _AnalysisContext, prov: str, feat: str, item: Mapping[str, Any], targets: Iterable[str],
+) -> list[dict[str, Any]]:
+    """Explain unmatched events without accepting a different watch as synchronized."""
+    if feat != "history":
+        return []
+    source_epoch = _parse_epochish(item.get("watched_at"))
+    if source_epoch is None:
+        return []
+    tokens = _history_event_tokens(item)
+    differences = []
+    for dst in targets:
+        if (_norm_prov_token(prov), _norm_prov_token(dst)) not in ctx.history_rewatch_pairs:
+            continue
+        if dst not in ctx.history_identity_items:
+            index: dict[str, list[tuple[str, Mapping[str, Any]]]] = defaultdict(list)
+            for key, peer in (ctx.history_keys.get(dst) or {}).items():
+                if isinstance(peer, Mapping):
+                    for token in _history_event_tokens(peer):
+                        index[token].append((key, peer))
+            ctx.history_identity_items[dst] = dict(index)
+        candidates = {key: peer for token in tokens for key, peer in ctx.history_identity_items[dst].get(token, [])}
+        dated = [(abs(source_epoch - epoch), key, peer, epoch) for key, peer in candidates.items()
+                 if (epoch := _parse_epochish(peer.get("watched_at"))) is not None]
+        if not dated or any(delta == 0 for delta, *_ in dated):
+            continue
+        _, key, peer, epoch = min(dated, key=lambda row: (row[0], row[1]))
+        differences.append({
+            "target": dst, "source": prov, "source_watched_at": item.get("watched_at"),
+            "target_watched_at": peer.get("watched_at"), "difference_seconds": source_epoch - epoch,
+            "target_key": key, "candidate_count": len(dated),
+            "message": f"{dst} has this item, but no watch at the source timestamp. The closest recorded watch is shown; it may represent a different playback.",
+        })
+    return differences
 
 
 def _target_has_peer(
@@ -3195,7 +3232,7 @@ def _missing_peer_show_hints(
         elif has_episode:
             msg = (
                 f"{dst_name} history snapshot already has this episode, "
-                "but it did not match by IDs."
+                "but the saved history entry did not match."
             )
         else:
             if season is not None and episode is not None:
@@ -3314,6 +3351,8 @@ def _iter_unresolved_files(
                 stem = stem[: -len(marker)]
                 break
         for marker, knd in (
+            (".blackbox.", "blackbox"),
+            ("_blackbox.", "blackbox"),
             (".unresolved.", "unresolved"),
             ("_unresolved.", "unresolved"),
             (".shadow.", "shadow"),
@@ -3325,7 +3364,7 @@ def _iter_unresolved_files(
                 kind = knd
                 stem = stem.split(marker, 1)[0]
                 break
-        for knd in ("unresolved", "shadow"):
+        for knd in ("unresolved", "shadow", "blackbox"):
             if kind is not None:
                 break
             if stem.endswith(f".{knd}"):
@@ -3402,6 +3441,8 @@ def _unresolved_index(allowed_scopes: set[str] | None) -> dict[tuple[str, str], 
             if not aks:
                 continue
             meta: dict[str, Any] = {"file": name, "kind": "unresolved_pending" if pending else kind}
+            if kind == "blackbox":
+                meta["blocked_key"] = uk
             reasons = rec.get("reasons")
             if isinstance(reasons, list):
                 meta["reasons"] = [str(r) for r in reasons if str(r or "").strip()]
@@ -3417,7 +3458,10 @@ def _unresolved_index(allowed_scopes: set[str] | None) -> dict[tuple[str, str], 
 
 def _unresolved_records(allowed_scopes: set[str] | None) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
-    for prov_key, feat_key, kind, pending, name, rows in _iter_unresolved_files(allowed_scopes):
+    files = list(_iter_unresolved_files(allowed_scopes))
+    blocked_keys = {(prov, feat, key) for prov, feat, kind, _, _, rows in files
+                    if kind == "blackbox" for key, _, _ in rows}
+    for prov_key, feat_key, kind, pending, name, rows in files:
         if kind != "unresolved":
             continue
         for uk, item, rec in rows:
@@ -3437,7 +3481,9 @@ def _unresolved_records(allowed_scopes: set[str] | None) -> list[dict[str, Any]]
                     "ids": dict(item.get("ids") or {}) if isinstance(item, dict) else {},
                     "item": item if isinstance(item, dict) else {},
                     "reason": reason,
+                    "reason_message": _unresolved_reason_message(prov_key, feat_key, [reason]),
                     "pending": pending,
+                    "retry_blocked": (prov_key, feat_key, uk) in blocked_keys,
                     "file": name,
                 }
             )
@@ -3517,6 +3563,7 @@ def _attention_model(
             "season": row.get("season"),
             "episode": row.get("episode"),
             "ids": row.get("ids") or {},
+            "watch_time_differences": row.get("watch_time_differences") or [],
         }
         targets = row.get("targets") or []
         if not targets:
@@ -3543,7 +3590,9 @@ def _attention_model(
                 "key": rec.get("key"),
                 "ids": rec.get("ids") or {},
                 "reason": rec.get("reason"),
+                "reason_message": rec.get("reason_message"),
                 "item": rec.get("item") or {},
+                "retry_blocked": bool(rec.get("retry_blocked")),
             },
         )
 
@@ -3571,6 +3620,9 @@ def _attention_model(
                     "current_mismatch": cm,
                     "unresolved": un,
                     "blocked": bl,
+                    "retry_blocked": any(c["data"].get("retry_blocked") for c in cluster),
+                    "reason": next((c["data"]["reason"] for c in cluster if c["data"].get("reason")), data.get("reason")),
+                    "reason_message": next((c["data"]["reason_message"] for c in cluster if c["data"].get("reason_message")), data.get("reason_message")),
                     "keys": alias_union,
                 }
             )
@@ -3625,6 +3677,7 @@ def _attention_mismatch_rows(problems: Iterable[Mapping[str, Any]]) -> list[dict
                 "season": p.get("season"),
                 "episode": p.get("episode"),
                 "ids": p.get("ids") or {},
+                "watch_time_differences": p.get("watch_time_differences") or [],
             }
         )
     return rows
@@ -3692,6 +3745,8 @@ def _attention_from_analysis(
 
 def _unresolved_reason_message(dst: str, feature: str, reasons: list[str]) -> str:
     for reason in reasons:
+        if reason == "apply:add:no_confirmations_fallback":
+            return "The previous write did not confirm that the requested item or watch event was added."
         message = reason_message(reason, provider=dst, feature=feature)
         if message:
             return message
@@ -3730,6 +3785,7 @@ def _missing_peer_hints(
     alias_keys: list[str],
     missing_targets: list[str],
     blocked: bool,
+    item_key: str = "",
 ) -> list[dict[str, Any]]:
     hints: list[dict[str, Any]] = []
     seen: set[tuple[str, str, str, str]] = set()
@@ -3749,6 +3805,8 @@ def _missing_peer_hints(
                 if rows:
                     break
             for meta in rows:
+                if meta.get("kind") == "blackbox" and meta.get("blocked_key") != item_key:
+                    continue
                 h: dict[str, Any] = {"provider": dst, "feature": feat}
                 reasons = [str(r) for r in (meta.get("reasons") or []) if str(r or "").strip()] if isinstance(meta.get("reasons"), list) else []
                 reason = str(meta.get("reason") or "").strip()
@@ -3765,6 +3823,8 @@ def _missing_peer_hints(
                     h["source"] = meta["file"]
                 if "kind" in meta:
                     h["kind"] = meta["kind"]
+                    if meta["kind"] == "blackbox":
+                        h["message"] = "Automatic retries are blocked after repeated failures."
                 dedupe = (
                     str(h.get("provider") or ""),
                     str(h.get("source") or ""),
@@ -3846,11 +3906,14 @@ def _problems(
                     "targets": missing_targets,
                     **({"manual_ref": _MANUAL_POLICY_REF} if blocked else {}),
                 }
+                time_differences = _history_time_differences(analysis, prov, feat, v, missing_targets)
+                if time_differences:
+                    prob["watch_time_differences"] = time_differences
                 if tracker_to_media and not blocked:
                     prob["sync_context"] = "tracker_to_media_server"
                     prob["message"] = TRACKER_TO_MEDIA_SERVER_MESSAGE
                 if include_hints:
-                    hints = _missing_peer_hints(unresolved_index, feat, alias_keys, missing_targets, blocked)
+                    hints = _missing_peer_hints(unresolved_index, feat, alias_keys, missing_targets, blocked, k)
                     anime_hint = _anime_history_hint(analysis, feat, v)
                     if anime_hint:
                         hints.append(anime_hint)
@@ -3865,6 +3928,8 @@ def _problems(
                         prob["hints"] = hints
                     _th = time.perf_counter()
                     details = _missing_peer_show_hints(feat, v, missing_targets, analysis.history_show_index)
+                    time_targets = {entry["target"] for entry in time_differences}
+                    details = [entry for entry in details if entry["target"] not in time_targets]
                     hint_seconds += time.perf_counter() - _th
                     if blocked:
                         details = ([{"target": "ALL", "feature": feat, "message": f"Blocked by {_MANUAL_POLICY_REF}."}] + (details or []))
@@ -4423,6 +4488,7 @@ def _detail_for_item(pairs_raw: str | None, provider: str, feature: str, key: st
             "targets": sorted({target for _, part in parts for target in part["targets"]}),
             "hints": [{**hint, "pair_id": pid} for pid, part in parts for hint in part["hints"]],
             "target_show_info": [{**hint, "pair_id": pid} for pid, part in parts for hint in part["target_show_info"]],
+            "watch_time_differences": [{**hint, "pair_id": pid} for pid, part in parts for hint in part.get("watch_time_differences", [])],
         }
     state, context, allowed, _cfg_sel, _tim = _load_analysis_state(pairs_raw)
     prov_key = _norm_prov_token(provider)
@@ -4441,15 +4507,18 @@ def _detail_for_item(pairs_raw: str | None, provider: str, feature: str, key: st
     blocks = _manual_blocks_for(manual_blocks, prov_key, feat_key)
     blocked = bool(blocks and any(kk in blocks for kk in [key, *alias_keys]))
 
-    hints = _missing_peer_hints(_unresolved_index(allowed), feat_key, alias_keys, missing_targets, blocked)
+    hints = _missing_peer_hints(_unresolved_index(allowed), feat_key, alias_keys, missing_targets, blocked, key)
     if missing_targets:
         anime_hint = _anime_history_hint(context, feat_key, it)
         if anime_hint:
             hints.append(anime_hint)
     details = _missing_peer_show_hints(feat_key, it, missing_targets, context.history_show_index)
+    time_differences = _history_time_differences(context, prov_key, feat_key, it, missing_targets)
+    time_targets = {entry["target"] for entry in time_differences}
+    details = [entry for entry in details if entry["target"] not in time_targets]
     if blocked:
         details = ([{"target": "ALL", "feature": feat_key, "message": f"Blocked by {_MANUAL_POLICY_REF}."}] + details)
-    return {"targets": missing_targets, "hints": hints, "target_show_info": details}
+    return {"targets": missing_targets, "hints": hints, "target_show_info": details, "watch_time_differences": time_differences}
 
 @router.get("/analyzer/state", response_class=JSONResponse)
 def api_state(

--- a/tests/analyzer-results.test.mjs
+++ b/tests/analyzer-results.test.mjs
@@ -7,7 +7,7 @@ import assert from "node:assert/strict";
 
 globalThis.window = {};
 globalThis.document = { addEventListener() {} };
-const { createResultFilter } = await import("../assets/js/analyzer/index.js");
+const { createResultFilter, watchDifferenceLabel, retryLabel, nextStepText, watchDifferenceDetails } = await import("../assets/js/analyzer/index.js");
 const features = ["history", "watchlist", "ratings", "progress", "collection"];
 const rows = Object.freeze(Array.from({ length: 5000 }, (_, n) => Object.freeze({
   title: `Movie ${String(n).padStart(5, "0")}`, provider: "SIMKL", feature: features[n % 5],
@@ -63,4 +63,28 @@ test("repeated filtering reuses searchable labels for unchanged rows", () => {
 test("pending episode retries are searchable by title, IDs and episode", () => {
   const row = { provider: "SIMKL", feature: "history", item: { type: "episode", series_title: "The Series", season: 1, episode: 23, ids: { tvdb: "123" } } };
   assert.deepEqual(createResultFilter()([row], { query: "series S01E23 tvdb:123" }), [row]);
+});
+
+test("watch time differences remain distinct from absent destinations", () => {
+  const row = { targets: ["SIMKL", "TRAKT"], watch_time_differences: [{ target: "SIMKL" }] };
+  assert.equal(watchDifferenceLabel(row), "Watch time differs at SIMKL; Missing at TRAKT");
+  assert.match(nextStepText(row), /separate watches/);
+  assert.match(nextStepText(row), /mapping edit does not correct/);
+});
+
+test("blocked retries explain why another sync does not retry", () => {
+  assert.equal(retryLabel({ retry_blocked: true }), "Automatic retries blocked");
+  assert.equal(retryLabel({}), "Pending retry");
+  assert.match(nextStepText({ retry_blocked: true }), /Resolve the cause before clearing/);
+});
+
+test("watch comparison displays both times and safely escapes provider data", () => {
+  const html = watchDifferenceDetails([{ source: "<CROSSWATCH>", target: "SIMKL", difference_seconds: -352,
+    source_watched_at: "2026-09-05T11:12:58Z", target_watched_at: "2026-09-05T11:07:06Z", message: "<script>" }]);
+  assert.match(html, /5m 52s/);
+  assert.match(html, /11:12:58Z/);
+  assert.match(html, /11:07:06Z/);
+  assert.match(html, /closest recorded watch/);
+  assert(!html.includes("<script>"));
+  assert(html.includes("&lt;CROSSWATCH&gt;"));
 });

--- a/tests/test_analyzer_watch_times.py
+++ b/tests/test_analyzer_watch_times.py
@@ -1,0 +1,111 @@
+from copy import deepcopy
+
+import pytest
+
+import services.analyzer as A
+from cw_platform.orchestrator._state_store import StateStore
+from cw_platform.pair_scope import pair_feature_scope
+
+
+@pytest.fixture
+def watch_pair(config_base, monkeypatch):
+    monkeypatch.setattr(A, "CONFIG_DIR", config_base)
+    monkeypatch.setattr(A, "CWS_DIR", config_base / ".cw_state")
+    for cache in ("_STATE_CACHE", "_SCOPED_ROWS_CACHE", "_ANALYSIS_CACHE"):
+        monkeypatch.setattr(A, cache, {})
+    cfg = {"pairs": [{"id": "cw-simkl", "source": "CROSSWATCH", "target": "SIMKL", "enabled": True,
+                      "mode": "one-way", "features": {"history": {"enable": True, "rewatches": True}}}]}
+    monkeypatch.setattr(A, "_cfg", lambda: cfg)
+    source = dict(type="episode", series_title="Breaking Bad", season=2, episode=1,
+                  ids={"tvdb": "438912", "tmdb": "972873"}, show_ids={"tmdb": "1396", "tvdb": "81189"},
+                  watched_at="2026-09-04T18:12:30Z")
+    peer = {**source, "ids": {"tvdb": "438912"}, "watched_at": "2026-09-04T18:07:36Z"}
+    key = "tmdb:1396#s02e01@1788545550"
+    peer_key = "tmdb:1396#s02e01@1788545256"
+    state = {"providers": {name: {"history": {"baseline": {"items": items}}} for name, items in
+                           (("CROSSWATCH", {key: source}), ("SIMKL", {peer_key: peer}))}}
+    return cfg, state, key, peer_key
+
+
+def save_pair(cfg, state):
+    store = StateStore(A.CONFIG_DIR)
+    scope = pair_feature_scope(cfg, cfg["pairs"][0], "history")
+    store.for_pair(scope).save_feature_blocks({(name, "default", "history"): value["history"]
+                                              for name, value in state["providers"].items()})
+
+
+def test_watch_time_mismatch_stays_visible_in_analysis_attention_and_detail(watch_pair):
+    cfg, state, key, peer_key = watch_pair
+    before = deepcopy(state)
+    save_pair(cfg, state)
+    result = A._cached_analysis("cw-simkl", include_hints=True)
+    problem = next(p for p in result["problems"] if p["type"] == "missing_peer")
+    difference = problem["watch_time_differences"][0]
+    assert difference["difference_seconds"] == 294
+    assert difference["target_key"] == peer_key
+    assert difference["source_watched_at"] == "2026-09-04T18:12:30Z"
+    assert difference["target_watched_at"] == "2026-09-04T18:07:36Z"
+    assert not problem.get("target_show_info")
+    assert result["attention"]["counts"]["current_mismatch"] == 1
+    assert result["attention"]["rows"][0]["watch_time_differences"] == [difference]
+    detail = A._detail_for_item("cw-simkl", "CROSSWATCH", "history", key)
+    assert detail["watch_time_differences"] == [difference]
+    assert detail["targets"] == ["SIMKL"]
+    assert state == before
+
+
+@pytest.mark.parametrize("case", ["exact", "different_episode", "unread", "non_rewatch"])
+def test_time_diagnosis_requires_an_unmatched_event_with_matching_identity(watch_pair, case):
+    cfg, state, key, peer_key = watch_pair
+    dst = state["providers"]["SIMKL"]["history"]["baseline"]["items"]
+    if case == "exact":
+        dst[peer_key]["watched_at"] = "2026-09-04T18:12:30.900Z"
+    elif case == "different_episode":
+        dst[peer_key]["episode"] = 2
+    elif case == "unread":
+        del state["providers"]["SIMKL"]
+    else:
+        cfg["pairs"][0]["features"]["history"]["rewatches"] = False
+    save_pair(cfg, state)
+    result = A._cached_analysis("cw-simkl")
+    assert not any(p.get("watch_time_differences") for p in result["problems"])
+    assert result["attention"]["counts"]["current_mismatch"] == int(case == "different_episode")
+
+
+def test_closest_watch_is_context_not_confirmation(watch_pair):
+    cfg, state, key, peer_key = watch_pair
+    dst = state["providers"]["SIMKL"]["history"]["baseline"]["items"]
+    dst["older"] = {**dst[peer_key], "watched_at": "2026-09-03T18:12:30Z"}
+    save_pair(cfg, state)
+    detail = A._detail_for_item("cw-simkl", "CROSSWATCH", "history", key)
+    assert detail["watch_time_differences"][0]["candidate_count"] == 2
+    assert detail["watch_time_differences"][0]["target_key"] == peer_key
+    assert detail["targets"] == ["SIMKL"]
+
+
+def test_retry_block_matches_exact_event_and_stays_in_its_scope(watch_pair, monkeypatch):
+    cfg, state, key, peer_key = watch_pair
+    item = state["providers"]["CROSSWATCH"]["history"]["baseline"]["items"][key]
+    documents = {
+        "SIMKL_history.unresolved.first.json": {key: {"item": item, "reason": "apply:add:no_confirmations_fallback"}},
+        "SIMKL_history.blackbox.first.json": {key: {"since": 1}},
+        "SIMKL_history.unresolved.second.json": {key: {"item": item}},
+        "SIMKL_history.blackbox.second.json": {peer_key: {"since": 1}},
+    }
+    monkeypatch.setattr(A, "_read_cw_state", lambda scopes: {name: data for name, data in documents.items()
+                                                          if any(name.endswith(f".{scope}.json") for scope in scopes)})
+    first = A._unresolved_records({"first"})
+    second = A._unresolved_records({"second"})
+    assert first[0]["retry_blocked"] is True
+    assert second[0]["retry_blocked"] is False
+    model = A._attention_model([], first)
+    assert model["rows"][0]["retry_blocked"] is True
+    assert model["rows"][0]["reason"] == "apply:add:no_confirmations_fallback"
+    assert "did not confirm" in model["rows"][0]["reason_message"]
+    assert model["counts"]["pending_retry"] == 1
+    index = A._unresolved_index({"first"})
+    aliases = A._alias_keys({**item, "_key": key})
+    exact = A._missing_peer_hints(index, "history", aliases, ["SIMKL"], False, key)
+    other = A._missing_peer_hints(index, "history", aliases, ["SIMKL"], False, peer_key)
+    assert any(h.get("kind") == "blackbox" for h in exact)
+    assert not any(h.get("kind") == "blackbox" for h in other)


### PR DESCRIPTION
# Pull request

## Change

- Show both watch times and their difference, explain blocked retries, and add sync pair labels.

## Why

- Timestamp differences looked like missing items and suggested mapping changes even when the IDs matched. 
- Sync behavior stays unchanged.

## Testing
- tests/test_analyzer_watch_times.py
- tests/analyzer-results.test.mjs

## Issue
Relates to #1080