### PR TITLE
Change: preserve Plex playback dates and improve caching

### DIFF
--- a/api/maintenanceAPI.py
+++ b/api/maintenanceAPI.py
@@ -52,6 +52,7 @@ SYNC_STATE_PATTERNS = (
     "*.unresolved*.json",
     "*history.cache*.json",
     "*_history.index*.json",
+    "plex_history.playback.*.json",
     "*watermark*.json",
     "tombstones.json",
     "*.tombstones.json",

--- a/providers/sync/_mod_PLEX.py
+++ b/providers/sync/_mod_PLEX.py
@@ -75,10 +75,7 @@ from ._mod_common import (
     make_snapshot_progress,
 )
 
-try:  # type: ignore[name-defined]
-    ctx  # type: ignore
-except Exception:
-    ctx = None  # type: ignore
+ctx = globals().get("ctx")
 
 try:
     from .plex import _watchlist as feat_watchlist
@@ -940,7 +937,6 @@ class PLEXClient:
         try:
             user_token = _plex_tv_switch_user(token, client_id, user_id=user_id, pin=use_pin, timeout=float(self.cfg.timeout))
         except Exception as e:
-            hint = " (PIN?)" if use_pin else ""
             _warn("home_switch_failed", target=(picked.get("title") or target_username or user_id), hint=("PIN?" if use_pin else None), error=str(e))
             return False
 
@@ -1494,7 +1490,7 @@ class PLEXModule:
                             res[f] = hm[f]
             return res
         except Exception as e:
-            return {"ok": False, "error": str(e)}
+            return {"ok": False, "error": str(e), "count": 0, "errors": len(lst), "confirmed_keys": []}
 
     def remove(
         self,
@@ -1527,7 +1523,7 @@ class PLEXModule:
                 "results": list(getattr(self, "_progress_write_results", [])) if feature == "progress" else [],
             }
         except Exception as e:
-            return {"ok": False, "error": str(e)}
+            return {"ok": False, "error": str(e), "count": 0, "errors": len(lst), "confirmed_keys": []}
 
 
 class _PlexOPS:

--- a/providers/sync/plex/_common.py
+++ b/providers/sync/plex/_common.py
@@ -23,6 +23,7 @@ from urllib.parse import urlsplit, quote
 
 from .._log import log as cw_log
 from cw_platform.log_context import log_run_id
+from cw_platform.id_map import ids_from
 
 import requests
 
@@ -424,10 +425,10 @@ def active_pms_token(source: Any) -> str | None:
         seen.add(marker)
         candidates.append(obj)
 
+    add(getattr(getattr(source, "client", None), "server", None))
+    add(getattr(source, "server", None))
     add(source)
     add(getattr(source, "client", None))
-    add(getattr(source, "server", None))
-    add(getattr(getattr(source, "client", None), "server", None))
     add(getattr(source, "cfg", None))
     add(getattr(getattr(source, "client", None), "cfg", None))
 
@@ -473,6 +474,11 @@ def active_cloud_token(source: Any) -> str | None:
                 return str(tok).strip()
         except Exception:
             pass
+    for obj in (source, getattr(source, "client", None)):
+        cfg = getattr(obj, "cfg", None)
+        token = getattr(cfg, "token", None)
+        if token and str(token).strip():
+            return str(token).strip()
     return active_pms_token(source)
 
 
@@ -1358,7 +1364,41 @@ def section_allowed(obj: Any, allow: set[str]) -> bool:
     if not allow:
         return True
     sid = str(getattr(obj, "librarySectionID", "") or getattr(obj, "sectionID", "") or "").strip()
-    return not sid or sid in allow
+    return sid in allow
+
+
+def native_item_matches(obj: Any, item: Mapping[str, Any]) -> bool:
+    kind = str(item.get("type") or "movie").lower()
+    kind = "episode" if kind == "anime" else kind
+    if object_type(obj) != kind:
+        return False
+    namespaces = ("tmdb", "imdb", "tvdb", "mal", "anilist")
+
+    def matches(wanted: Mapping[str, Any], actual: Mapping[str, Any]) -> bool:
+        for key in namespaces:
+            want, have = str(wanted.get(key) or "").strip().lower(), str(actual.get(key) or "").strip().lower()
+            if want and have and (want == have or (want.isdigit() and have.isdigit() and int(want) == int(have))):
+                return True
+        return False
+
+    try:
+        if kind in ("episode", "season"):
+            season = item.get("season") if item.get("season") is not None else item.get("season_number")
+            episode = item.get("episode") if item.get("episode") is not None else item.get("episode_number")
+            if season is not None and int(getattr(obj, "parentIndex" if kind == "episode" else "index", -1)) != int(season):
+                return False
+            if kind == "episode" and episode is not None and int(getattr(obj, "index", -1)) != int(episode):
+                return False
+        ids = ids_from(item)
+        if any(ids.get(key) for key in namespaces) and not matches(ids, ids_from_obj(obj)):
+            return False
+        if kind in ("episode", "season"):
+            show_ids = extract_show_ids(item)
+            if any(show_ids.get(key) for key in namespaces) and not matches(show_ids, ids_from_obj(obj.show())):
+                return False
+        return True
+    except Exception:
+        return False
 
 
 def item_guid_candidates(ids: Mapping[str, Any], show_ids: Mapping[str, Any], item: Mapping[str, Any]) -> list[str]:

--- a/providers/sync/plex/_history.py
+++ b/providers/sync/plex/_history.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+import json
 import os
 import re
 import time
@@ -12,6 +13,7 @@ from typing import Any, Iterable, Mapping
 from pathlib import Path
 from hashlib import sha256
 from threading import local
+from xml.etree import ElementTree as ET
 
 from cw_platform.log_context import log_run_id
 
@@ -43,6 +45,7 @@ from ._common import (
     plex_worker_count,
     resolve_obj_by_guids,
     section_allowed,
+    native_item_matches,
     state_file,
     write_json,
     emit,
@@ -62,53 +65,12 @@ def _event_key(item: Mapping[str, Any]) -> str:
 def _shadow_path() -> Path:
     return state_file("plex_history.shadow.json")
 
-def _marked_state_path() -> Path:
-    return state_file("plex_history.marked_watched.json")
-
-def _load_marked_state() -> dict[str, Any]:
-    return read_json(_marked_state_path())
-
-def _save_marked_state(data: Mapping[str, Any]) -> None:
-    try:
-        write_json(_marked_state_path(), data, indent=0, sort_keys=False, separators=(",", ":"))
-    except Exception:
-        pass
-
-
-
-def _watermark_path() -> Path:
-    return state_file("plex_history.watermark.json")
-
 def _wm_key(acct_id: int, uname: str) -> str:
     if acct_id:
         return f"acct:{acct_id}"
     if uname:
         return f"user:{uname.lower()}"
     return "default"
-
-def _load_watermark(key: str) -> int | None:
-    try:
-        data = read_json(_watermark_path()) or {}
-        by_user = data.get("by_user") or {}
-        v = by_user.get(key)
-        return int(v) if v else None
-    except Exception:
-        return None
-
-def _save_watermark(key: str, epoch: int) -> None:
-    try:
-        path = _watermark_path()
-        data = read_json(path) or {}
-        by_user = dict(data.get("by_user") or {})
-        cur = int(by_user.get(key) or 0)
-        epoch_i = int(epoch or 0)
-        if epoch_i <= 0 or epoch_i <= cur:
-            return
-        by_user[key] = epoch_i
-        out = {"by_user": by_user, "updated_at": _iso(epoch_i)}
-        write_json(path, out, indent=0, sort_keys=False, separators=(",", ":"))
-    except Exception:
-        pass
 
 _dbg, _info, _warn, _error, _log = make_logger("history")
 
@@ -282,19 +244,11 @@ _TOKEN_KEYS = ("tmdb", "imdb", "tvdb", "plex")
 
 # Internal tuning defaults.
 _DATE_TOLERANCE_SEC = 60
-_FALLBACK_EMPTY_PAGES_DEFAULT = 3
 _CATALOG_MEM_TTL_SEC = 90
 
 
 def _env_truthy(name: str) -> bool:
     return str(os.environ.get(name, "") or "").strip().lower() in ("1", "true", "yes", "on")
-
-
-def _fallback_empty_pages() -> int:
-    try:
-        return max(1, int(os.environ.get("CW_PLEX_WATCHED_FALLBACK_EMPTY_PAGES", "") or _FALLBACK_EMPTY_PAGES_DEFAULT))
-    except Exception:
-        return _FALLBACK_EMPTY_PAGES_DEFAULT
 
 
 def _id_tokens(ids: Mapping[str, Any] | None) -> set[str]:
@@ -314,7 +268,8 @@ def _item_show_tokens(item: Mapping[str, Any]) -> set[str]:
     kind = (item.get("type") or "").strip().lower()
     if not toks and kind in ("show", "season", "episode", "anime"):
         toks = _id_tokens(ids_from(item))
-    return toks
+    external = {tok for tok in toks if not tok.startswith("plex:")}
+    return external or toks
 
 
 def _item_se(item: Mapping[str, Any]) -> tuple[int | None, int | None]:
@@ -332,9 +287,10 @@ def _item_se(item: Mapping[str, Any]) -> tuple[int | None, int | None]:
 
 
 class HistoryCatalog:
-    __slots__ = ("by_rk", "movie_tokens", "show_tokens", "episode_index", "movie_title_year")
+    __slots__ = ("by_rk", "movie_tokens", "show_tokens", "episode_index", "movie_title_year", "live_complete")
 
     def __init__(self) -> None:
+        self.live_complete = False
         self.by_rk: dict[str, dict[str, Any]] = {}
         self.movie_tokens: dict[str, str] = {}
         self.show_tokens: dict[str, str] = {}
@@ -360,6 +316,7 @@ class HistoryCatalog:
             "season": entry.get("season"),
             "episode": entry.get("episode"),
             "watched": bool(entry.get("watched")),
+            "write_accepted": bool(entry.get("write_accepted")),
             "view_count": entry.get("view_count"),
             "last_viewed_at": entry.get("last_viewed_at"),
             "added_at": entry.get("added_at"),
@@ -431,6 +388,8 @@ class HistoryCatalog:
             return None, CLASS_NOT_IN_PLEX_CATALOG
 
         tokens = _id_tokens(ids_from(item))
+        external = {tok for tok in tokens if not tok.startswith("plex:")}
+        tokens = external or tokens
         hit_rks = {self.movie_tokens[tok] for tok in tokens if tok in self.movie_tokens}
         if len(hit_rks) == 1:
             rk = next(iter(hit_rks))
@@ -700,25 +659,6 @@ def _shadow_remove(item: Mapping[str, Any]) -> None:
     except Exception:
         pass
 
-def _marked_set_unwatched(rating_key: Any, item: Mapping[str, Any]) -> None:
-    try:
-        rk = str(rating_key or ids_from(item).get("plex") or "").strip()
-        if not rk:
-            return
-        st = _load_marked_state() or {}
-        marked0 = st.get("items") or {}
-        marked: dict[str, Any] = dict(marked0) if isinstance(marked0, Mapping) else {}
-        prev = marked.get(rk)
-        entry: dict[str, Any] = dict(prev) if isinstance(prev, Mapping) else dict(id_minimal(item))
-        entry["watched"] = False
-        marked[rk] = entry
-        st = dict(st) if isinstance(st, Mapping) else {}
-        st["items"] = marked
-        st["last_updated_at"] = int(time.time())
-        _save_marked_state(st)
-    except Exception:
-        pass
-
 def _has_external_ids(minimal: Mapping[str, Any]) -> bool:
     ids = minimal.get("ids") or {}
     show_ids = minimal.get("show_ids") or {}
@@ -766,13 +706,51 @@ def _marked_section_id(sec: Any) -> str | None:
             return m.group(1)
     return None
 
+def _episode_play_count_supported(adapter: Any, section_id: str, allow: set[str]) -> bool:
+    key, shared = _index_cache_context(adapter, allow, "history")
+    cached = getattr(_INDEX_CACHE, "watched_filters", None)
+    if cached is None or cached["key"] != key or (not shared and time.monotonic() - cached["ts"] >= _CATALOG_MEM_TTL_SEC):
+        cached = {"key": key, "ts": time.monotonic(), "sections": {}}
+        _INDEX_CACHE.watched_filters = cached
+    if section_id in cached["sections"]:
+        return cached["sections"][section_id]
+    srv = getattr(getattr(adapter, "client", None), "server", None)
+    token = active_pms_token(adapter)
+    if srv is None or not token:
+        cached["sections"][section_id] = False
+        return False
+    supported = False
+    try:
+        headers = plex_headers(token)
+        headers["Accept"] = "application/json"
+        response = srv._session.get(
+            f"{_as_base_url(srv)}/library/sections/{section_id}/all",
+            params={"includeMeta": 1, "includeAdvanced": 1, "X-Plex-Container-Start": 0, "X-Plex-Container-Size": 0},
+            headers=headers, timeout=15,
+        )
+        if response.ok:
+            if "json" in str(response.headers.get("content-type", "")).lower():
+                meta = response.json()["MediaContainer"].get("Meta", {})
+                field = any(f.get("key") == "episode.viewCount" and f.get("type") == "integer"
+                            for kind in meta.get("Type", []) for f in kind.get("Field", []))
+                operator = any(op.get("key") == ">>=" for kind in meta.get("FieldType", [])
+                               if kind.get("type") == "integer" for op in kind.get("Operator", []))
+            else:
+                meta = ET.fromstring(response.text).find("Meta")
+                field = meta is not None and meta.find("./Type/Field[@key='episode.viewCount'][@type='integer']") is not None
+                operator = meta is not None and meta.find("./FieldType[@type='integer']/Operator[@key='>>=']") is not None
+            supported = bool(field and operator)
+    except Exception:
+        pass
+    cached["sections"][section_id] = supported
+    return supported
+
+
 def _iter_marked_watched_from_library(
     adapter: Any,
     allow: set[str],
-    since: int | None = None,
-    *,
-    full: bool = False,
 ) -> list[tuple[dict[str, Any], int]]:
+    setattr(adapter, "_plex_live_scan_complete", False)
     srv = getattr(getattr(adapter, "client", None), "server", None)
     if not srv:
         return []
@@ -782,13 +760,6 @@ def _iter_marked_watched_from_library(
     if not (base and ses and token):
         return []
 
-    state = _load_marked_state()
-    try:
-        last_ts = int((state.get("last_ts") if isinstance(state, dict) else 0) or 0)
-    except Exception:
-        last_ts = 0
-    cutoff = 0 if full else (max(int(since or 0), last_ts) if (since is not None or last_ts) else 0)
-
     headers = dict(getattr(ses, "headers", {}) or {})
     headers.update(plex_headers(token))
     headers["Accept"] = "application/json"
@@ -797,13 +768,19 @@ def _iter_marked_watched_from_library(
         try:
             ctype = (r.headers.get("content-type") or "").lower()
             data = (r.json() or {}) if "application/json" in ctype else _xml_to_container(r.text or "")
-            mc = data.get("MediaContainer") or {}
-            rows = mc.get("Metadata") or []
+            mc = data.get("MediaContainer")
+            if not isinstance(mc, Mapping):
+                raise ValueError("invalid_media_container")
+            rows = mc.get("Metadata")
+            if rows is None and (mc.get("size") == 0 or mc.get("totalSize") == 0):
+                rows = []
+            if not isinstance(rows, list) or any(not isinstance(row, Mapping) or not row.get("ratingKey") for row in rows):
+                raise ValueError("invalid_metadata")
             total = mc.get("totalSize")
             total_i = int(total) if total is not None else None
             return [x for x in rows if isinstance(x, Mapping)], total_i
-        except Exception:
-            return [], None
+        except Exception as exc:
+            raise RuntimeError("plex_watched_scan_invalid_response") from exc
 
     def _int0(v: Any) -> int:
         try:
@@ -813,7 +790,6 @@ def _iter_marked_watched_from_library(
 
     page_size = 200
     results: list[tuple[dict[str, Any], int]] = []
-    newest = last_ts
     summary = {
         "sections_scanned": 0, "movie_sections": 0, "show_sections": 0,
         "watched_rows_seen": 0, "watched_rows_returned": 0,
@@ -822,17 +798,23 @@ def _iter_marked_watched_from_library(
 
     try:
         sections = list(adapter.libraries(types=("movie", "show")) or [])
-    except Exception:
-        sections = []
+    except Exception as exc:
+        raise RuntimeError("plex_watched_libraries_failed") from exc
 
-    def _scan_section(section_id: str, plex_type: int, section_type: str, section_title: str, *, use_unwatched_filter: bool) -> int:
-        nonlocal newest
+    available = {_marked_section_id(sec) for sec in sections if str(getattr(sec, "type", "")).lower() in ("movie", "show")}
+    missing = allow - available
+    if missing:
+        _warn("history_libraries_unavailable", library_ids=sorted(missing))
+        if not allow.intersection(available):
+            raise RuntimeError(f"plex_history_no_accessible_selected_libraries: {','.join(sorted(missing))}")
+
+    def _scan_section(section_id: str, plex_type: int, section_type: str, section_title: str, *, use_unwatched_filter: bool, play_count_filter: bool = False) -> int:
         start = 0
         seen_pages: set[tuple[str, ...]] = set()
+        page_retries = 0
         sec = {"seen": 0, "vc": 0, "lva": 0, "no_ts": 0, "norm_fail": 0, "no_rk": 0, "ret": 0}
         last_status: Any = None
         last_total: Any = None
-        empty_streak = 0
         while True:
             params: dict[str, Any] = {
                 "type": plex_type,
@@ -842,50 +824,48 @@ def _iter_marked_watched_from_library(
                 "X-Plex-Container-Size": page_size,
             }
             if use_unwatched_filter:
-                params["unwatched"] = 0
+                params["episode.viewCount>>" if play_count_filter else "unwatched"] = 0
             try:
                 r = ses.get(f"{base}/library/sections/{section_id}/all", params=params, headers=headers, timeout=15)
-            except Exception:
-                break
+            except Exception as exc:
+                raise RuntimeError("plex_watched_scan_request_failed") from exc
             last_status = getattr(r, "status_code", None)
             if not getattr(r, "ok", False):
-                break
+                if play_count_filter and start == 0 and last_status in (400, 422):
+                    return _scan_section(section_id, plex_type, section_type, section_title, use_unwatched_filter=False)
+                raise RuntimeError(f"plex_watched_scan_http_{last_status}")
             rows, total = _rows_from(r)
             last_total = total
             if not rows:
+                if total is not None and start < total:
+                    raise RuntimeError("plex_watched_scan_incomplete_page")
                 break
             signature = tuple(str(row.get("ratingKey") or row.get("key") or "") for row in rows)
             if signature in seen_pages:
-                break
+                if page_retries == 0:
+                    page_retries += 1
+                    continue
+                raise RuntimeError("plex_watched_scan_repeated_page")
+            page_retries = 0
             seen_pages.add(signature)
 
-            stop = False
-            page_watched = 0
             for row in rows:
                 view_count = max(_int0(row.get("viewCount")), _int0(row.get("leafCountViewed")))
                 ts = _as_epoch(row.get("lastViewedAt") or row.get("viewedAt"))
                 watched = view_count > 0
                 if not watched:
                     continue
-                page_watched += 1
                 sec["seen"] += 1
                 if view_count > 0:
                     sec["vc"] += 1
                 if ts:
                     sec["lva"] += 1
                 ts_i = int(ts) if ts else 0
-                if (not full) and cutoff and ts_i and ts_i < cutoff:
-                    stop = True
-                    break
-                if ts_i and ts_i > newest:
-                    newest = ts_i
                 meta = normalize_discover_row(row, token=token) or {}
                 if not meta:
-                    sec["norm_fail"] += 1
-                    continue
+                    raise RuntimeError("plex_watched_scan_normalize_failed")
                 if not (meta.get("ids") or {}).get("plex"):
-                    sec["no_rk"] += 1
-                    continue
+                    raise RuntimeError("plex_watched_scan_missing_identity")
                 meta['_cw_marked'] = True
                 meta['_cw_view_count'] = view_count
                 if ts_i:
@@ -897,17 +877,11 @@ def _iter_marked_watched_from_library(
                 results.append((meta, ts_i))
                 sec["ret"] += 1
 
-            if stop:
-                break
             start += len(rows)
             if total is not None and start >= total:
                 break
-            if len(rows) < page_size:
+            if len(rows) < page_size and total is None:
                 break
-            if not use_unwatched_filter:
-                empty_streak = empty_streak + 1 if page_watched == 0 else 0
-                if empty_streak >= _fallback_empty_pages():
-                    break
 
         _dbg(
             "live_watched.section",
@@ -947,21 +921,16 @@ def _iter_marked_watched_from_library(
         else:
             summary["show_sections"] += 1
 
-        ret = _scan_section(section_id, plex_type, section_type, section_title, use_unwatched_filter=True)
-        if ret == 0 and plex_type == 4:
+        play_count_filter = plex_type == 4 and _episode_play_count_supported(adapter, section_id, allow)
+        ret = _scan_section(section_id, plex_type, section_type, section_title, use_unwatched_filter=True, play_count_filter=play_count_filter)
+        if ret == 0 and plex_type == 4 and not play_count_filter:
             _scan_section(section_id, plex_type, section_type, section_title, use_unwatched_filter=False)
 
-    if newest and newest != last_ts:
-        try:
-            st = dict(state) if isinstance(state, dict) else {}
-            st["last_ts"] = newest
-            _save_marked_state(st)
-        except Exception:
-            pass
+    setattr(adapter, "_plex_live_scan_complete", True)
 
     _emit({
         "event": "plex.presence", "action": "live_watched_summary", "feature": "history",
-        "level": "debug", "full": bool(full), **summary,
+        "level": "debug", "full": True, **summary,
     })
     return results
 
@@ -990,9 +959,9 @@ def _live_watched_entry(meta: Mapping[str, Any], ts: int) -> dict[str, Any] | No
     }
 
 
-def _iter_live_watched(adapter: Any, allow: set[str], *, full: bool = True) -> list[dict[str, Any]]:
+def _iter_live_watched(adapter: Any, allow: set[str]) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
-    for meta, ts in _iter_marked_watched_from_library(adapter, allow, full=full):
+    for meta, ts in _iter_marked_watched_from_library(adapter, allow):
         entry = _live_watched_entry(meta, ts)
         if entry:
             out.append(entry)
@@ -1088,6 +1057,7 @@ def _populate_catalog_episode_leaves(adapter: Any, allow: set[str], cat: History
                     "season": meta.get("season"),
                     "episode": meta.get("episode"),
                     "watched": bool(existing.get("watched")),
+                    "write_accepted": bool(existing.get("write_accepted")),
                     "view_count": existing.get("view_count"),
                     "last_viewed_at": existing.get("last_viewed_at"),
                 }
@@ -1126,12 +1096,14 @@ def _build_history_catalog(adapter: Any, allow: set[str], *, force: bool = False
     watched_movies = 0
     watched_eps = 0
     if live:
-        for entry in _iter_live_watched(adapter, allow, full=True):
+        setattr(adapter, "_plex_live_scan_complete", False)
+        for entry in _iter_live_watched(adapter, allow):
             cat.add(entry)
             if (entry.get("type") or "") == "episode":
                 watched_eps += 1
             else:
                 watched_movies += 1
+        cat.live_complete = bool(getattr(adapter, "_plex_live_scan_complete", False))
     _emit({
         "event": "plex.catalog", "action": "done", "feature": "history", "level": "debug",
         "force": bool(force), "live": bool(live), "allow": allow_list,
@@ -1155,6 +1127,50 @@ def _user_scope_key(adapter: Any) -> str:
     return _wm_key(acct, uname)
 
 
+def _playback_cache_path(adapter: Any, allow: set[str]) -> Path | None:
+    key, _ = _index_cache_context(adapter, allow, "history")
+    if not key[1] or str(key[1]).lower() in {"unscoped", "default", "none"} or not key[3] or not active_pms_token(adapter):
+        return None
+    options = {name: plex_cfg_get(adapter, name, None) for name in (
+        "history_ignore_local_guid", "history_ignore_guid_prefixes", "history_require_external_ids",
+    )}
+    options["fallback_guid"] = bool(plex_cfg_get(adapter, "fallback_GUID", False) or plex_cfg_get(adapter, "fallback_guid", False))
+    owner = sha256(json.dumps(key[1:7], default=str).encode()).hexdigest()[:32]
+    identity = json.dumps([key[1:-1], options], default=str, sort_keys=True)
+    digest = sha256(identity.encode()).hexdigest()[:32]
+    return state_file(f"plex_history.playback.{owner}.{digest}.json")
+
+
+def _load_playback_cache(path: Path | None) -> dict[str, Any] | None:
+    if path is None:
+        return None
+    data = read_json(path)
+    if not isinstance(data, Mapping) or data.get("version") != 1 or not isinstance(data.get("items"), dict):
+        return None
+    cursor = data.get("cursor")
+    if not isinstance(cursor, int) or cursor < 0:
+        return None
+    if not isinstance(data.get("full_refreshed", 0), int) or data.get("full_refreshed", 0) < 0:
+        return None
+    for key, row in data["items"].items():
+        if not isinstance(row, dict) or not _as_epoch(row.get("watched_at")) or _event_key(row) != key:
+            return None
+    return dict(data)
+
+
+_PLAYBACK_OVERLAP_SECONDS = 120
+
+
+def _prune_playback_caches(path: Path, now: float) -> None:
+    prefix = ".".join(path.name.split(".")[:3]) + "."
+    try:
+        for candidate in path.parent.glob(prefix + "*.json"):
+            if candidate != path and now - candidate.stat().st_mtime > 30 * 86400:
+                candidate.unlink()
+    except OSError as exc:
+        _dbg("playback_cache_cleanup_failed", error_type=type(exc).__name__)
+
+
 def _catalog_cache_key(adapter: Any, allow: set[str]) -> tuple[Any, ...]:
     return _index_cache_context(adapter, allow, "history")[0]
 
@@ -1164,9 +1180,9 @@ def _store_history_catalog(adapter: Any, allow: set[str], cat: HistoryCatalog) -
 
 
 def _get_history_catalog(adapter: Any, allow: set[str], *, force: bool = False) -> HistoryCatalog:
-    key = _catalog_cache_key(adapter, allow)
+    key, shared = _index_cache_context(adapter, allow, "history")
     cached = getattr(_INDEX_CACHE, "catalog", None)
-    if not force and cached is not None and cached["key"] == key and time.monotonic() - cached["ts"] < _CATALOG_MEM_TTL_SEC:
+    if not force and cached is not None and cached["key"] == key and (shared or time.monotonic() - cached["ts"] < _CATALOG_MEM_TTL_SEC):
         return cached["cat"]
     _INDEX_CACHE.catalog = None
     cat = _build_history_catalog(adapter, allow, force=force)
@@ -1202,23 +1218,31 @@ def _set_write_meta(adapter: Any, meta: Mapping[str, Any]) -> None:
     except Exception:
         pass
 
-def _pms_fetch_metadata_row(adapter: Any, rating_key: str) -> Mapping[str, Any] | None:
+def _pms_fetch_metadata_row(adapter: Any, rating_key: str, *, strict: bool = False) -> Mapping[str, Any] | None:
     srv = getattr(getattr(adapter, "client", None), "server", None)
     if not srv:
+        if strict:
+            raise RuntimeError("plex_history_metadata_unavailable")
         return None
     base = _as_base_url(srv)
     ses = getattr(srv, "_session", None)
     token = getattr(srv, "token", None) or getattr(srv, "_token", None) or ""
     if not (base and ses and token and rating_key):
+        if strict:
+            raise RuntimeError("plex_history_metadata_unavailable")
         return None
     headers = dict(getattr(ses, "headers", {}) or {})
     headers.update(plex_headers(token))
     headers["Accept"] = "application/json"
     try:
         r = ses.get(f"{base}/library/metadata/{rating_key}", headers=headers, timeout=15)
-    except Exception:
+    except Exception as exc:
+        if strict:
+            raise RuntimeError("plex_history_metadata_request_failed") from exc
         return None
     if not getattr(r, "ok", False):
+        if strict and getattr(r, "status_code", 0) != 404:
+            raise RuntimeError(f"plex_history_metadata_http_{getattr(r, 'status_code', 0)}")
         return None
     try:
         ctype = (r.headers.get("content-type") or "").lower()
@@ -1226,9 +1250,15 @@ def _pms_fetch_metadata_row(adapter: Any, rating_key: str) -> Mapping[str, Any] 
         mc = data.get("MediaContainer") or {}
         rows = mc.get("Metadata") or []
         if isinstance(rows, list) and rows and isinstance(rows[0], Mapping):
+            if strict and str(rows[0].get("ratingKey") or "") != str(rating_key):
+                raise ValueError("unexpected_rating_key")
             return rows[0]
-    except Exception:
+    except Exception as exc:
+        if strict:
+            raise RuntimeError("plex_history_metadata_invalid_response") from exc
         return None
+    if strict:
+        raise RuntimeError("plex_history_metadata_invalid_response")
     return None
 
 
@@ -1242,8 +1272,14 @@ def _pms_row_is_watched(row: Mapping[str, Any]) -> bool:
         return False
 
 
-def _pms_row_watched_ts(row: Mapping[str, Any]) -> int | None:
-    return _as_epoch(row.get("lastViewedAt") or row.get("viewedAt"))
+def _history_access_denied(error: Exception) -> bool:
+    from plexapi.exceptions import BadRequest, Unauthorized
+
+    status = getattr(getattr(error, "response", None), "status_code", None)
+    return (isinstance(error, (PermissionError, Unauthorized)) or status in (401, 403)
+            or (isinstance(error, BadRequest) and str(error).startswith("(403)")))
+
+
 def build_index(adapter: Any, since: int | None = None, limit: int | None = None, *, force: bool = False) -> dict[str, dict[str, Any]]:
     need_home_scope, did_home_switch, sel_aid, sel_uname = home_scope_enter(adapter)
     try:
@@ -1272,12 +1308,8 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
         uname = cfg_uname or cli_uname
 
         wm_key = _wm_key(acct_id, uname)
-        wm = _load_watermark(wm_key) if (since is None or int(since or 0) <= 0) else None
-                # Treat cursors as *exclusive* to avoid re-reading the boundary event forever.
         if since is not None and int(since or 0) > 0:
-            eff_since = int(since) + 1
-        elif wm:
-            eff_since = int(wm) + 1
+            eff_since = int(since)
         else:
             eff_since = None
 
@@ -1286,14 +1318,25 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
 
         force = bool(force) or _history_force_full(adapter)
         if force:
-            wm = None
             eff_since = None
 
         scope_ok = not (need_home_scope and not did_home_switch)
         if not scope_ok:
             _warn("home_scope_not_applied", op="build_index", selected=(sel_aid or sel_uname))
 
+        maxresults = _int_or_zero(_history_cfg_get(adapter, "maxresults", 0))
+        cache_path = _playback_cache_path(adapter, allow) if scope_ok and not limit and not maxresults and not since else None
+        playback_cache = _load_playback_cache(cache_path)
+        now = int(time.time())
+        refreshed = (playback_cache or {}).get("full_refreshed", 0)
+        refresh_full = force or not playback_cache
+        if not since:
+            eff_since = max(0, int(playback_cache["cursor"]) - _PLAYBACK_OVERLAP_SECONDS) if playback_cache and not refresh_full else None
+
         cat = _build_history_catalog(adapter, allow, force=force, live=scope_ok)
+        include_marked = bool(_history_cfg_get(adapter, "include_marked_watched", True))
+        if include_marked and scope_ok and not cat.live_complete:
+            raise RuntimeError("plex_history_incomplete_watched_catalog")
         if scope_ok:
             _store_history_catalog(adapter, allow, cat)
 
@@ -1302,7 +1345,6 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
             _dbg(
                 "cursor",
                 since_arg=int(since or 0) if since is not None else None,
-                wm=int(wm or 0) if wm else None,
                 eff_since=int(eff_since or 0) if eff_since else None,
                 wm_key=wm_key,
             )
@@ -1316,21 +1358,29 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
         if eff_since is not None and eff_since > 0:
             base_kwargs["mindate"] = datetime.fromtimestamp(eff_since, tz=timezone.utc)
 
-        maxresults = _int_or_zero(_history_cfg_get(adapter, "maxresults", 0))
         if maxresults:
             base_kwargs["maxresults"] = int(maxresults)
 
+        full_scopes: set[str | None] = set()
+
         def _call_history(**kwargs: Any) -> list[Any]:
             try:
-                return list(srv.history(**kwargs) or [])
+                result = list(srv.history(**kwargs) or [])
             except Exception as e:
                 if "mindate" in kwargs:
                     _dbg("mindate_fallback_drop", error=str(e))
                     kwargs.pop("mindate", None)
-                    return list(srv.history(**kwargs) or [])
-                raise
+                    result = list(srv.history(**kwargs) or [])
+                else:
+                    raise
+            if "mindate" not in kwargs:
+                sid = kwargs.get("librarySectionID")
+                full_scopes.add(str(sid) if sid is not None else None)
+            return result
 
         rows: list[Any] = []
+        history_complete = True
+        history_errors: list[Exception] = []
         try:
             if allow:
                 for sid in sorted(allow):
@@ -1338,14 +1388,18 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
                         kw = dict(base_kwargs)
                         kw["librarySectionID"] = int(sid)
                         part = _call_history(**kw)
-                    except Exception:
+                    except Exception as exc:
+                        history_complete = False
+                        history_errors.append(exc)
                         part = []
                     if not part and "accountID" in kw and not explicit_user:
                         try:
                             kw2 = dict(kw)
                             kw2.pop("accountID", None)
                             part = _call_history(**kw2)
-                        except Exception:
+                        except Exception as exc:
+                            history_complete = False
+                            history_errors.append(exc)
                             part = []
                     rows.extend(part)
             else:
@@ -1356,12 +1410,15 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
                     rows = _call_history(**base_kwargs2)
         except Exception as e:
             _warn("http_failed", op="build_index", error=str(e))
+            history_complete = False
+            history_errors.append(e)
             rows = []
 
+        if history_errors and not playback_cache and any(not _history_access_denied(exc) for exc in history_errors):
+            raise RuntimeError("plex_history_playback_unavailable_without_cache") from history_errors[0]
+
         total = len(rows)
-        max_seen = 0
         workers = plex_worker_count(adapter, "history_workers", "CW_PLEX_HISTORY_WORKERS", 12)
-        include_marked = bool(_history_cfg_get(adapter, "include_marked_watched", True))
 
         # Optional cursor debugging: show the rows that are considered "new" for this run.
         if eff_since is not None and str(os.environ.get("CW_PLEX_HISTORY_DEBUG_CURSOR", "")).strip().lower() in ("1", "true", "yes"):
@@ -1398,7 +1455,7 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
                 return None
             ts_i = int(ts)
 
-            if eff_since is not None and ts_i < int(eff_since):
+            if since and not force and eff_since is not None and ts_i <= int(eff_since):
                 return None
 
             if allow:
@@ -1436,17 +1493,6 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
             if not _keep_in_snapshot(adapter, meta):
                 return None
 
-            if include_marked:
-                rk = str((meta.get("ids") or {}).get("plex") or getattr(raw, "ratingKey", None) or "").strip()
-                if rk:
-                    live_row = _pms_fetch_metadata_row(adapter, rk)
-                    if live_row is not None:
-                        if not _pms_row_is_watched(live_row):
-                            return None
-                        live_ts = _pms_row_watched_ts(live_row)
-                        if live_ts:
-                            ts_i = int(live_ts)
-
             row = dict(meta)
             _force_episode_title(row)
             row["watched"] = True
@@ -1483,19 +1529,61 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
                     break
             _fb_cache_flush()
 
+        reconciled = history_complete and not limit and not maxresults and full_scopes == (set(allow) or {None})
+        recorded = dict(playback_cache["items"]) if playback_cache and not reconciled else {}
+        recorded.update(out)
+        playback_cursor = max((_as_epoch(row.get("watched_at")) or 0 for row in recorded.values()), default=0)
+        out = {}
+        live_rows: dict[str, Mapping[str, Any] | None] = {}
+        if include_marked and scope_ok:
+            rating_keys = sorted({str((row.get("ids") or {}).get("plex")) for row in recorded.values()
+                                  if (row.get("ids") or {}).get("plex")
+                                  and str(row["ids"]["plex"]) not in cat.by_rk})
+            with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="plex-history-state") as executor:
+                fetched = executor.map(lambda rk: _pms_fetch_metadata_row(adapter, rk, strict=True), rating_keys)
+                live_rows.update(zip(rating_keys, fetched))
+        for saved in recorded.values():
+            rk = str((saved.get("ids") or {}).get("plex") or "")
+            entry = cat.by_rk.get(rk) if scope_ok else None
+            if include_marked and scope_ok and rk:
+                if entry is not None and not entry.get("watched"):
+                    continue
+                live_row = live_rows.get(rk)
+                if live_row is not None and not _pms_row_is_watched(live_row):
+                    continue
+            if (entry and (entry.get("title") or entry.get("series_title"))
+                    and (has_external_ids(entry.get("ids") or {}) or has_external_ids(entry.get("show_ids") or {}))):
+                row = _catalog_entry_to_minimal(entry)
+                row.update(watched=True, watched_at=saved["watched_at"])
+                _force_episode_title(row)
+            else:
+                row = dict(saved)
+            if _keep_in_snapshot(adapter, row):
+                out[_event_key(row)] = row
+                if limit and len(out) >= int(limit):
+                    break
+
         base_present: set[str] = set()
+        playback_rating_keys = {str((row.get("ids") or {}).get("plex")) for row in out.values()
+                                if (row.get("ids") or {}).get("plex")}
         for r in out.values():
             try:
                 base_present.add(canonical_key(r))
             except Exception:
                 pass
 
-        presence = cat.presence()
+        presence = cat.presence() if include_marked and scope_ok else {}
         presence_added = 0
         presence_dropped_keep = 0
         for key, row in presence.items():
             if limit and len(out) >= int(limit):
                 break
+            rk = str((row.get("ids") or {}).get("plex") or "")
+            if rk and rk in playback_rating_keys:
+                continue
+            live_row = live_rows.get(rk)
+            if live_row is not None and not _pms_row_is_watched(live_row):
+                continue
             if key in out:
                 continue
             try:
@@ -1520,111 +1608,16 @@ def build_index(adapter: Any, since: int | None = None, limit: int | None = None
         })
         _maybe_trace_snapshot(cat, allow, out)
 
-        if out:
-            max_seen = max((_as_epoch(r.get("watched_at")) or 0) for r in out.values())
-
-        if include_marked and scope_ok and not force and (not limit or len(out) < int(limit)):
-            st = _load_marked_state() or {}
-            marked0 = st.get("items") or {}
-            marked: dict[str, Any] = dict(marked0) if isinstance(marked0, Mapping) else {}
-            changed = False
-
-            # Discover newly watched items
-            found = 0
-            for entry, ts_i in _iter_marked_watched_from_library(adapter, allow, since=eff_since):
-                rk = str(ids_from(entry).get("plex") or "")
-                if not rk:
-                    continue
-                prev = marked.get(rk)
-                prev_ts = _as_epoch((prev or {}).get("watched_at")) if isinstance(prev, Mapping) else None
-                if not prev or (ts_i and (not prev_ts or int(ts_i) != int(prev_ts))):
-                    e = dict(entry)
-                    e["_cw_marked"] = True
-                    e["watched"] = True
-                    if ts_i:
-                        e["watched_at"] = e.get("watched_at") or _iso(int(ts_i))
-                    else:
-                        e["watched_at"] = None
-                        e["watched_at_missing"] = True
-                    marked[rk] = e
-                    changed = True
-                found += 1
-
-            # Validate watched/unwatched toggles directly from PMS metadata.
-            def _fetch_marked_meta(rk_item: tuple[str, Any]) -> tuple[str, Any, Mapping[str, Any] | None]:
-                rk_, item_ = rk_item
-                if not isinstance(item_, Mapping):
-                    return rk_, item_, None
-                return rk_, item_, _pms_fetch_metadata_row(adapter, str(rk_))
-
-            marked_pairs = list(marked.items())
-            meta_workers = plex_worker_count(adapter, "marked_meta_workers", "CW_PLEX_MARKED_META_WORKERS", 8)
-            with ThreadPoolExecutor(max_workers=meta_workers, thread_name_prefix="plex-marked-meta") as meta_exec:
-                fetched_rows = list(meta_exec.map(_fetch_marked_meta, marked_pairs))
-
-            for rk, item, row in fetched_rows:
-                if not isinstance(item, Mapping):
-                    continue
-                if not row:
-                    continue
-                is_watched = _pms_row_is_watched(row)
-                prev_watched = bool(item.get("watched"))
-                ts = _pms_row_watched_ts(row)
-                prev_ts = _as_epoch(item.get("watched_at"))
-                if is_watched != prev_watched:
-                    e = dict(item)
-                    e["watched"] = bool(is_watched)
-                    if is_watched:
-                        if ts and (not prev_ts or int(ts) > int(prev_ts)):
-                            use_ts = int(ts)
-                        else:
-                            use_ts = int(time.time())
-                        e["watched_at"] = _iso(use_ts)
-                    marked[rk] = e
-                    changed = True
-                elif is_watched:
-                    # Keep watched_at stable; only upgrade if PMS has a newer timestamp.
-                    if ts and (not prev_ts or int(ts) > int(prev_ts)):
-                        e = dict(item)
-                        e["watched"] = True
-                        e["watched_at"] = _iso(int(ts))
-                        marked[rk] = e
-                        changed = True
-                else:
-                    # Unwatched: keep entry for future re-watch detection.
-                    if prev_watched:
-                        e = dict(item)
-                        e["watched"] = False
-                        marked[rk] = e
-                        changed = True
-
-            if found or changed:
-                st = dict(st) if isinstance(st, Mapping) else {}
-                st["items"] = marked
-                st["last_updated_at"] = int(time.time())
-                _save_marked_state(st)
-
-            for rk, item in (marked or {}).items():
-                if not isinstance(item, Mapping) or not item.get("watched"):
-                    continue
-                row = dict(item)
-                _force_episode_title(row)
-                ts3 = _as_epoch(row.get("watched_at"))
-                if not ts3:
-                    continue
-                row["watched"] = True
-                row["watched_at"] = _iso(int(ts3))
-                key = f"{canonical_key(row)}@{int(ts3)}"
-                if key not in out and _keep_in_snapshot(adapter, row):
-                    out[key] = row
-                    if limit and len(out) >= int(limit):
-                        break
+        if cache_path is not None and history_complete:
+            cache_data = {"version": 1, "cursor": playback_cursor, "items": recorded,
+                          "full_refreshed": now if reconciled else refreshed}
+            if cache_data != playback_cache:
+                write_json(cache_path, cache_data, indent=0, sort_keys=False, separators=(",", ":"))
+            if reconciled:
+                _prune_playback_caches(cache_path, now)
 
         if prog:
             prog.done(total=len(out), ok=True)
-
-        if max_seen:
-            _save_watermark(wm_key, int(max_seen))
 
         _info(
             "index_done",
@@ -1736,7 +1729,6 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
             return 0, unresolved
 
         allow = plex_feature_library_ids(adapter, "history")
-        strict = bool(plex_cfg_get(adapter, "strict_id_matching", False))
         write_strict = True
         force = _history_force_full(adapter)
         cat = _get_history_catalog(adapter, allow, force=force)
@@ -1775,13 +1767,18 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
 
             if klass == CLASS_IN_CATALOG_WATCHED and rk:
                 entry = cat.by_rk.get(rk) or {}
+                if entry.get("write_accepted"):
+                    meta["accepted_keys"].append(key)
+                    meta["accepted_not_seen_live_keys"].append(key)
+                    ok += 1
+                    continue
                 ds, _delta = _date_status(int(ts), entry.get("last_viewed_at"), tol)
                 meta["accepted_keys"].append(key)
                 meta["presence_confirmed_keys"].append(key)
                 meta["live_confirmed_keys"].append(key)
                 if ds == DATE_MISMATCH:
                     meta["date_mismatch_keys"].append(key)
-                else:
+                elif ds == DATE_EXACT:
                     meta["date_confirmed_keys"].append(key)
                 ok += 1
                 continue
@@ -1836,6 +1833,11 @@ def add(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[dic
                     meta["accepted_keys"].append(key)
                     meta["accepted_not_seen_live_keys"].append(key)
                     shadow_batch.append(item)
+                    entry = cat.by_rk.get(_rk)
+                    if entry is not None:
+                        entry["watched"] = True
+                        entry["write_accepted"] = True
+                        entry["last_viewed_at"] = None
                 else:
                     unresolved.append({"item": id_minimal(item), "key": key, "hint": "scrobble_failed", "reason": DATE_WRITE_FAILED})
                     meta["unresolved_keys"].append(key)
@@ -1886,7 +1888,14 @@ def remove(adapter: Any, items: Iterable[Mapping[str, Any]]) -> tuple[int, list[
             if _unscrobble(srv, rating_key):
                 ok += 1
                 _shadow_remove(item)
-                _marked_set_unwatched(rating_key, item)
+                cached = getattr(_INDEX_CACHE, "catalog", None)
+                allow = plex_feature_library_ids(adapter, "history")
+                if cached is not None and cached["key"] == _catalog_cache_key(adapter, allow):
+                    entry = cached["cat"].by_rk.get(str(rating_key))
+                    if entry is not None:
+                        entry["watched"] = False
+                        entry.pop("write_accepted", None)
+                        entry["last_viewed_at"] = None
             else:
                 unresolved.append({"item": id_minimal(item), "key": key, "hint": "unscrobble_failed", "reason": "unscrobble_failed"})
         _info("write_done", op="remove", ok=len(unresolved) == 0, applied=ok, unresolved=len(unresolved))
@@ -1910,7 +1919,7 @@ def _resolve_rating_key(adapter: Any, item: Mapping[str, Any], *, strict: bool |
     if rk:
         try:
             obj_rk = srv.fetchItem(int(rk))
-            if obj_rk and section_allowed(obj_rk, allow):
+            if obj_rk and section_allowed(obj_rk, allow) and native_item_matches(obj_rk, item):
                 return str(rk)
         except Exception:
             pass
@@ -1922,8 +1931,8 @@ def _resolve_rating_key(adapter: Any, item: Mapping[str, Any], *, strict: bool |
 
     strict = bool(plex_cfg_get(adapter, "strict_id_matching", False)) if strict is None else bool(strict)
 
-    season = item.get("season") or item.get("season_number")
-    episode = item.get("episode") or item.get("episode_number")
+    season = item.get("season") if item.get("season") is not None else item.get("season_number")
+    episode = item.get("episode") if item.get("episode") is not None else item.get("episode_number")
 
     guids = item_guid_candidates(ids, show_ids, item)
 
@@ -1933,18 +1942,19 @@ def _resolve_rating_key(adapter: Any, item: Mapping[str, Any], *, strict: bool |
 
         if is_episode:
             rk_show = show_ids.get("plex")
-            if rk_show:
+            if rk_show and _has_matchable_ids(show_ids):
                 try:
                     obj0 = srv.fetchItem(int(rk_show))
                 except Exception:
                     obj0 = None
-                if obj0 and section_allowed(obj0, allow):
+                if (obj0 and section_allowed(obj0, allow)
+                        and native_item_matches(obj0, {"type": "show", "ids": show_ids})):
                     rk0 = episode_rating_key_from_show(obj0, season, episode)
                     if rk0:
                         return rk0
 
             obj = resolve_obj_by_guids(srv, guids, allow, {"episode"})
-            if obj:
+            if obj and native_item_matches(obj, item):
                 return str(getattr(obj, "ratingKey", None) or "")
             obj2 = resolve_obj_by_guids(srv, guids, allow, {"show", "season"})
             if obj2:
@@ -2125,9 +2135,12 @@ def _scrobble_with_date(srv: Any, rating_key: Any, epoch: int) -> bool:
 
 def _unscrobble(srv: Any, rating_key: Any) -> bool:
     try:
+        token = active_pms_token(srv)
+        if not token:
+            return False
         url = srv.url("/:/unscrobble")
         params = {"key": int(rating_key), "identifier": "com.plexapp.plugins.library"}
-        resp = srv._session.get(url, params=params, timeout=10)
+        resp = srv._session.get(url, params=params, headers=plex_headers(token), timeout=10)
         return resp.ok
     except Exception:
         return False

--- a/providers/sync/plex/_playlists.py
+++ b/providers/sync/plex/_playlists.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable as IterableABC, Mapping as MappingABC
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Mapping, Sequence
 
 from cw_platform.id_map import canonical_key, minimal as id_minimal
 from cw_platform.playlists import (

--- a/providers/sync/plex/_progress.py
+++ b/providers/sync/plex/_progress.py
@@ -215,10 +215,6 @@ def _truthy_attr(obj: Any, name: str) -> bool:
         return False
 
 
-def _fetch_resume_rating_keys(srv: Any, *, limit: int = 100) -> set[str]:
-    return set(_fetch_resume_items(srv, page_size=limit))
-
-
 def _library_id(value: Any) -> str | None:
     source = getattr(value, "attrib", None) if not isinstance(value, Mapping) else value
     source = source if isinstance(source, Mapping) else {}
@@ -231,7 +227,8 @@ def _library_id(value: Any) -> str | None:
 
 def _page_total(root: Any) -> int | None:
     attributes = getattr(root, "attrib", {}) or {}
-    return _to_int(attributes.get("totalSize") or attributes.get("totalRecordCount"))
+    value = attributes.get("totalSize")
+    return _to_int(value if value is not None else attributes.get("totalRecordCount"))
 
 
 def _library_sort_key(section: tuple[str, int]) -> tuple[int, str]:
@@ -241,6 +238,8 @@ def _library_sort_key(section: tuple[str, int]) -> tuple[int, str]:
 
 def _progress_sections(srv: Any, allowed: set[str]) -> list[tuple[str, int]]:
     root = srv.query("/library/sections")  # type: ignore[attr-defined]
+    if root is None or getattr(root, "tag", None) != "MediaContainer":
+        raise RuntimeError("plex_progress_invalid_libraries_response")
     rows = list(root) if root is not None else []
     sections: list[tuple[str, int]] = []
     found: set[str] = set()
@@ -256,7 +255,9 @@ def _progress_sections(srv: Any, allowed: set[str]) -> list[tuple[str, int]]:
         sections.append((library_id, 1 if library_type == "movie" else 4))
     missing = sorted(allowed - found)
     if missing:
-        raise RuntimeError(f"plex_progress_libraries_not_found:{','.join(missing)}")
+        _warn("progress_libraries_unavailable", library_ids=missing)
+        if not sections:
+            raise RuntimeError(f"plex_progress_libraries_not_found:{','.join(missing)}")
     return sorted(sections, key=_library_sort_key)
 
 
@@ -315,20 +316,24 @@ def _fetch_resume_items(
                     "includeGuids": 1,
                 },
             )
+            if root is None or getattr(root, "tag", None) != "MediaContainer":
+                raise RuntimeError("plex_progress_invalid_page")
             rows = list(root) if root is not None else []
+            total = _page_total(root)
+            if not rows and total is not None and start < total:
+                raise RuntimeError("plex_progress_incomplete_page")
             signature = tuple(
                 str((getattr(el, "attrib", {}) or {}).get("ratingKey") or (getattr(el, "attrib", {}) or {}).get("key") or "")
                 for el in rows
             )
             if rows and signature in seen_pages:
-                _warn("pagination_repeated_page", source=path, library_id=library_id, start_index=start)
-                break
+                raise RuntimeError("plex_progress_repeated_page")
             seen_pages.add(signature)
             for el in rows:
                 a = getattr(el, "attrib", {}) or {}
                 rk = a.get("ratingKey") or a.get("key")
                 if not rk:
-                    continue
+                    raise RuntimeError("plex_progress_missing_rating_key")
                 progress_ms = _to_int(a.get("viewOffset"))
                 if progress_ms is None or progress_ms <= 0:
                     continue
@@ -340,7 +345,7 @@ def _fetch_resume_items(
                 items[key_id] = (row, ids)
             start += len(rows)
             total = _page_total(root)
-            if not rows or len(rows) < page_size or (total is not None and start >= total):
+            if not rows or (len(rows) < page_size and total is None) or (total is not None and start >= total):
                 break
 
     for library_id, plex_type in sections:

--- a/providers/sync/plex/_ratings.py
+++ b/providers/sync/plex/_ratings.py
@@ -32,6 +32,7 @@ from ._common import (
     plex_worker_count,
     season_rating_key_from_show,
     section_allowed,
+    native_item_matches,
     unresolved_home_scope_not_applied,
     emit,
     make_logger,
@@ -159,10 +160,11 @@ def _resolve_rating_key(adapter: Any, it: Mapping[str, Any]) -> str | None:
         return False
 
     rk = ids.get("plex")
+    allow = plex_feature_library_ids(adapter, "ratings")
     if rk:
         try:
             obj0 = srv.fetchItem(int(rk))
-            if obj0 and _accept_obj(obj0):
+            if obj0 and section_allowed(obj0, allow) and native_item_matches(obj0, {**it, "type": kind}):
                 return str(rk)
         except Exception:
             pass
@@ -175,8 +177,8 @@ def _resolve_rating_key(adapter: Any, it: Mapping[str, Any]) -> str | None:
         return None
 
     year = it.get("year")
-    season = it.get("season") or it.get("season_number")
-    episode = it.get("episode") or it.get("episode_number")
+    season = it.get("season") if it.get("season") is not None else it.get("season_number")
+    episode = it.get("episode") if it.get("episode") is not None else it.get("episode_number")
 
     allow = plex_feature_library_ids(adapter, "ratings")
     sec_types = ("show",) if (is_episode or is_season or is_show) else ("movie",)
@@ -200,7 +202,9 @@ def _resolve_rating_key(adapter: Any, it: Mapping[str, Any]) -> str | None:
             try:
                 obj = srv.fetchItem(int(rk_any))
                 if obj and _accept_obj(obj):
-                    if section_allowed(obj, allow):
+                    identity_ok = (_otype(obj) not in {"episode", "season"}
+                                   or native_item_matches(obj, {**it, "type": kind}))
+                    if section_allowed(obj, allow) and identity_ok:
                         hits.append(obj)
             except Exception:
                 pass
@@ -330,7 +334,7 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
                 reason="shared_user_ratings_unsupported",
                 selected=(sel_aid or sel_uname),
             )
-            return {}
+            raise RuntimeError("shared_user_ratings_unsupported")
 
         srv = getattr(getattr(adapter, "client", None), "server", None)
         if not srv:
@@ -359,9 +363,6 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
             tok, tok_source = _preferred_pms_token(adapter)
         configure_plex_context(baseurl=base, token=tok)
 
-        cli = getattr(adapter, "client", None)
-    
-    
         if not (base and tok and ses):
             raise RuntimeError(f"PLEX ratings fast query unavailable (base={bool(base)} tok={bool(tok)} ses={bool(ses)})")
     
@@ -451,7 +452,7 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
         except Exception:
             section_specs = []
 
-        def _iter_rating_rows(path: str, tnum: int) -> Iterable[Mapping[str, Any]]:
+        def _iter_rating_rows(path: str, tnum: int, library_id: str | None = None) -> Iterable[Mapping[str, Any]]:
             nonlocal total
             start = 0
             expected_total: int | None = None
@@ -477,7 +478,9 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
                     head = (r.text or "")[:140].replace("\n", " ")
                     raise RuntimeError(f"PLEX ratings fast query parse failed (ct={(r.headers or {}).get('Content-Type')}; head={head!r})")
 
-                mc = cont.get("MediaContainer") or {}
+                mc = cont.get("MediaContainer")
+                if not isinstance(mc, Mapping):
+                    raise RuntimeError("plex_ratings_invalid_response")
                 try:
                     raw_total = mc.get("totalSize")
                     if raw_total is not None:
@@ -491,18 +494,26 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
                         pass
                     _tick(force=True)
 
-                rows = mc.get("Metadata") or []
+                rows = mc.get("Metadata")
+                if rows is None and (mc.get("size") == 0 or mc.get("totalSize") == 0):
+                    rows = []
+                if not isinstance(rows, list) or any(not isinstance(row, Mapping) or not row.get("ratingKey") for row in rows):
+                    raise RuntimeError("plex_ratings_invalid_metadata")
                 if not rows:
+                    if expected_total is not None and start < expected_total:
+                        raise RuntimeError("plex_ratings_incomplete_page")
                     break
                 signature = tuple(str(row.get("ratingKey") or row.get("key") or "") for row in rows if isinstance(row, Mapping))
                 if signature in seen_pages:
-                    break
+                    raise RuntimeError("plex_ratings_repeated_page")
                 seen_pages.add(signature)
                 for row in rows:
                     if isinstance(row, Mapping):
+                        if library_id:
+                            row = {**row, "librarySectionID": library_id}
                         yield cast(Mapping[str, Any], row)
                 start += len(rows)
-                if len(rows) < page_size or (expected_total is not None and start >= expected_total):
+                if (len(rows) < page_size and expected_total is None) or (expected_total is not None and start >= expected_total):
                     break
 
         def _consume_rows(rows: list[Mapping[str, Any]], tnum: int) -> bool:
@@ -616,11 +627,22 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
             return False
 
         try:
-            for tnum in (1, 2, 3, 4):
-                rows = list(_iter_rating_rows(f"{base}/library/all", tnum))
-                if _consume_rows(rows, tnum):
-                    return out
+            if allow:
+                if not section_specs:
+                    raise RuntimeError("plex_ratings_no_accessible_selected_libraries")
+                for sid, tnums in section_specs:
+                    for tnum in tnums:
+                        rows = list(_iter_rating_rows(f"{base}/library/sections/{sid}/all", tnum, sid))
+                        if _consume_rows(rows, tnum):
+                            return out
+            else:
+                for tnum in (1, 2, 3, 4):
+                    rows = list(_iter_rating_rows(f"{base}/library/all", tnum))
+                    if _consume_rows(rows, tnum):
+                        return out
         except RuntimeError as e:
+            if allow:
+                raise
             if "status=401" not in str(e) and "status=403" not in str(e):
                 raise
             _warn("fast_query_fallback", mode="section_scan", reason=str(e))
@@ -635,7 +657,7 @@ def build_index(adapter: Any, limit: int | None = None) -> dict[str, dict[str, A
                     pass
             for sid, tnums in section_specs:
                 for tnum in tnums:
-                    rows = list(_iter_rating_rows(f"{base}/library/sections/{sid}/all", tnum))
+                    rows = list(_iter_rating_rows(f"{base}/library/sections/{sid}/all", tnum, sid))
                     if _consume_rows(rows, tnum):
                         return out
     

--- a/providers/sync/plex/_utils.py
+++ b/providers/sync/plex/_utils.py
@@ -1102,5 +1102,5 @@ def ensure_whitelist_defaults(
             changed = True
     if changed and persist:
         save_config(cfg)
-        _info("whitelist_defaults_ensured")
+        _dbg("whitelist_defaults_ensured")
     return changed

--- a/providers/sync/plex/_watchlist.py
+++ b/providers/sync/plex/_watchlist.py
@@ -509,9 +509,16 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
             )
     
             mc = (cont or {}).get("MediaContainer") if isinstance(cont, Mapping) else None
+            if not isinstance(mc, Mapping):
+                raise RuntimeError("plex_watchlist_invalid_response")
+            raw_rows = mc.get("Metadata")
+            if raw_rows is None and (mc.get("size") == 0 or mc.get("totalSize") == 0):
+                raw_rows = []
+            if not isinstance(raw_rows, list) or any(not isinstance(row, Mapping) for row in raw_rows):
+                raise RuntimeError("plex_watchlist_invalid_metadata")
             if total is None:
                 try:
-                    t = (mc or {}).get("totalSize") or (mc or {}).get("size")
+                    t = mc.get("totalSize")
                     total = int(t) if t is not None and str(t).isdigit() else None
                 except Exception:
                     total = None
@@ -526,10 +533,12 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
                     pass
     
             if not rows:
+                if total is not None and start < total:
+                    raise RuntimeError("plex_watchlist_incomplete_page")
                 break
             signature = tuple(str(row.get("ratingKey") or row.get("key") or row.get("guid") or "") for row in rows)
             if signature in seen_pages:
-                break
+                raise RuntimeError("plex_watchlist_repeated_page")
             seen_pages.add(signature)
     
             stop = False
@@ -554,7 +563,7 @@ def build_index(adapter: Any) -> dict[str, dict[str, Any]]:
             if stop:
                 break
             start += len(rows)
-            if len(rows) < page_size or (total is not None and start >= total):
+            if (len(rows) < page_size and total is None) or (total is not None and start >= total):
                 break
     
         _info("index_done", count=len(out), raw=raw, collections=coll, types=typ)

--- a/tests/test_interactive_sync_plex_history.py
+++ b/tests/test_interactive_sync_plex_history.py
@@ -23,10 +23,10 @@ def test_history_selection_survives_full_to_incremental_read(config_base, monkey
     server = SimpleNamespace(history=lambda **kwargs: [] if kwargs.get("mindate") else [raw])
     adapter = SimpleNamespace(client=SimpleNamespace(server=server), cfg=SimpleNamespace(), config={"_cw_interactive_planned_at": 1788650000} if interactive else {})
     catalog = history.HistoryCatalog()
+    catalog.live_complete = True
     catalog.add(dict(rk="42", type=kind, title="Catalog title", year=2026, ids={"tmdb": "123", "plex": "42"},
                      series_title="Example series", season=1, episode=2, show_ids={"tvdb": "99"},
                      watched=True, view_count=1, last_viewed_at=watched_at))
-    watermark = {}
     monkeypatch.setattr(history, "home_scope_enter", lambda _: (False, False, None, None))
     monkeypatch.setattr(history, "home_scope_exit", lambda *_: None)
     monkeypatch.setattr(history, "plex_cfg_get", lambda _, key, default=None: default)
@@ -35,11 +35,8 @@ def test_history_selection_survives_full_to_incremental_read(config_base, monkey
     monkeypatch.setattr(history, "_history_force_full", lambda _: False)
     monkeypatch.setattr(history, "_build_history_catalog", lambda *a, **k: catalog)
     monkeypatch.setattr(history, "_store_history_catalog", lambda *_: None)
-    monkeypatch.setattr(history, "_load_watermark", lambda key: watermark.get(key))
-    monkeypatch.setattr(history, "_save_watermark", lambda key, value: watermark.update({key: value}))
     monkeypatch.setattr(history, "_keep_in_snapshot", lambda *_: True)
     monkeypatch.setattr(history, "_pms_fetch_metadata_row", lambda *_: dict(viewCount=1, lastViewedAt=watched_at))
-    monkeypatch.setattr(history, "_load_marked_state", lambda: {})
     monkeypatch.setattr(history, "_iter_marked_watched_from_library", lambda *a, **k: [])
     monkeypatch.setattr(history, "_fb_cache_flush", lambda: None)
     monkeypatch.setattr(history, "plex_worker_count", lambda *a: 1)
@@ -64,6 +61,7 @@ def test_history_selection_survives_full_to_incremental_read(config_base, monkey
     third = history.build_index(adapter)
     assert len(recheck.filter("history", "SIMKL", "SIMKL-P01", "add", [minimal(row) for row in third.values()], source="PLEX")) == 1
     catalog.by_rk["42"]["last_viewed_at"] = watched_at + 3600
+    raw.viewedAt = watched_at + 3600
     changed = history.build_index(adapter)
     assert not recheck.filter("history", "SIMKL", "SIMKL-P01", "add", [minimal(row) for row in changed.values()], source="PLEX")
 

--- a/tests/test_maintenance_api.py
+++ b/tests/test_maintenance_api.py
@@ -440,6 +440,7 @@ def test_clear_provider_cache_preserves_pair_scoped_history_mapping_state(tmp_pa
         "trakt_history.unresolved.pending.one-way_SIMKL_default-TRAKT_default_p1.json",
         "trakt.history.cache.one-way_SIMKL_default-TRAKT_default_p1.json",
         "simkl.history.cache.one-way_SIMKL_default-TRAKT_default_p1.json",
+        "plex_history.playback.owner.digest.cw2_test_pair.json",
         "watermarks.json",
         "tombstones.json",
     }
@@ -491,6 +492,7 @@ def _seed_rebuild_state(state_dir):
         "simkl_history.unresolved.one-way_SIMKL_default-TRAKT_default_p1.json",
         "trakt_history.unresolved.pending.one-way_SIMKL_default-TRAKT_default_p1.json",
         "trakt.history.cache.one-way_SIMKL_default-TRAKT_default_p1.json",
+        "plex_history.playback.owner.digest.cw2_test_pair.json",
         "watermarks.json",
         "tombstones.json",
     }

--- a/tests/test_percent_progress_sync.py
+++ b/tests/test_percent_progress_sync.py
@@ -133,8 +133,10 @@ def test_plex_progress_keeps_resume_item_with_view_count(monkeypatch) -> None:
     class Server:
         def query(self, path: str, params: dict[str, Any] | None = None):
             if path == "/library/sections":
-                return Element({}, [Element({"key": "3", "type": "show"})])
-            return Element(
+                result = Element({}, [Element({"key": "3", "type": "show"})])
+                result.tag = "MediaContainer"
+                return result
+            result = Element(
                 {"totalSize": "1"},
                 [
                     Element(
@@ -153,6 +155,8 @@ def test_plex_progress_keeps_resume_item_with_view_count(monkeypatch) -> None:
                     )
                 ],
             )
+            result.tag = "MediaContainer"
+            return result
 
     rows = _progress._fetch_resume_items(Server(), page_size=150, allowed_library_ids={"3"})
 

--- a/tests/test_plex_history_options.py
+++ b/tests/test_plex_history_options.py
@@ -17,7 +17,6 @@ def isolated_state(monkeypatch, tmp_path):
     monkeypatch.setattr(common, "_FBGUID_MEMO_DIRTY", False)
     monkeypatch.setattr(common, "plex_context", lambda: {"baseurl": "http://plex", "token": "token", "account_token": "token"})
     monkeypatch.setattr(common, "hydrate_external_ids", lambda *args: {})
-    monkeypatch.setattr(history, "_load_watermark", lambda *args: None)
     monkeypatch.setattr(history, "_dbg", lambda *args, **kwargs: None)
     monkeypatch.setattr(history, "_info", lambda *args, **kwargs: None)
     monkeypatch.setattr(history, "_emit", lambda *args, **kwargs: None)
@@ -113,9 +112,11 @@ def test_history_metadata_selection_preserves_fallback_and_watched_dates(
         "history_workers": 1, "history": {"include_marked_watched": include_marked},
     }})
     catalog = history.HistoryCatalog()
+    catalog.live_complete = True
     if catalog_kind != "missing":
         catalog.add({
             "rk": "42", "type": "movie", "title": None if catalog_kind == "id_only" else "Current title",
+            "watched": True,
             "ids": {"plex": "42"} if catalog_kind == "no_external_ids" else {"plex": "42", "tmdb": "123"},
         })
     fallback_calls = []
@@ -130,16 +131,14 @@ def test_history_metadata_selection_preserves_fallback_and_watched_dates(
     monkeypatch.setattr(history, "_history_force_full", lambda _: False)
     monkeypatch.setattr(history, "_build_history_catalog", lambda *a, **k: catalog)
     monkeypatch.setattr(history, "_store_history_catalog", lambda *_: None)
-    monkeypatch.setattr(history, "_save_watermark", lambda *_: None)
     monkeypatch.setattr(history, "_keep_in_snapshot", lambda *_: True)
     monkeypatch.setattr(history, "minimal_from_history_row", fallback)
-    monkeypatch.setattr(history, "_pms_fetch_metadata_row", lambda *_: {"viewCount": 1, "lastViewedAt": live_at})
-    monkeypatch.setattr(history, "_load_marked_state", lambda: {})
+    monkeypatch.setattr(history, "_pms_fetch_metadata_row", lambda *_, **kw: {"viewCount": 1, "lastViewedAt": live_at})
     monkeypatch.setattr(history, "_iter_marked_watched_from_library", lambda *a, **k: [])
 
     result = history.build_index(adapter)
     assert len(result) == 1
     item = next(iter(result.values()))
-    assert item["watched_at"] == history._iso(live_at if include_marked else played_at)
+    assert item["watched_at"] == history._iso(played_at)
     assert item["title"] == ("Current title" if catalog_kind == "current" else "Historical title")
     assert len(fallback_calls) == (0 if catalog_kind == "current" else 1)

--- a/tests/test_plex_history_scan_recovery.py
+++ b/tests/test_plex_history_scan_recovery.py
@@ -1,0 +1,194 @@
+from types import SimpleNamespace
+
+import pytest
+
+from providers.sync.plex import _history as history
+from providers.sync._mod_PLEX import PLEXModule
+from test_plex_playback_dates import PLAYED, playback
+
+
+SCAN = history._iter_marked_watched_from_library
+BUILD = history._build_history_catalog
+
+
+def response(rows=None, total=0, meta=None, status=200):
+    return SimpleNamespace(ok=status == 200, status_code=status, headers={"content-type": "application/json"},
+                           json=lambda: {"MediaContainer": {"Metadata": rows or [], "totalSize": total, "Meta": meta or {}}})
+
+
+@pytest.fixture
+def library(playback, monkeypatch):
+    ad = playback.adapter()
+    ad.libraries = lambda **kw: [SimpleNamespace(key="1", type="show", title="Shows")]
+    monkeypatch.setattr(history, "_iter_marked_watched_from_library", SCAN)
+    monkeypatch.setattr(history, "_build_guid_index", lambda *a, **kw: {"movies": {}, "shows": {}})
+    monkeypatch.setattr(history, "normalize_discover_row", lambda row, **kw: {
+        "type": row["type"], "ids": {"plex": row["ratingKey"]}, "title": "Item",
+    })
+    monkeypatch.setattr(history._INDEX_CACHE, "watched_filters", None, raising=False)
+    return ad
+
+
+CAPABILITY = {"Type": [{"Field": [{"key": "episode.viewCount", "type": "integer"}]}],
+              "FieldType": [{"type": "integer", "Operator": [{"key": ">>="}]}]}
+
+
+@pytest.mark.parametrize("format", ["json", "xml"])
+def test_confirmed_empty_episode_filter_never_scans_all_episodes(library, format):
+    calls = []
+
+    def get(*a, **kw):
+        params = kw["params"]
+        calls.append(params)
+        if params.get("includeMeta"):
+            if format == "json":
+                return response(meta=CAPABILITY)
+            return SimpleNamespace(ok=True, headers={"content-type": "application/xml"}, text=
+                '<MediaContainer><Meta><Type><Field key="episode.viewCount" type="integer" /></Type>'
+                '<FieldType type="integer"><Operator key="&gt;&gt;=" /></FieldType></Meta></MediaContainer>')
+        assert params.get("episode.viewCount>>") == 0
+        return response()
+
+    library.client.server._session = SimpleNamespace(headers={}, get=get)
+    assert BUILD(library, {"1"}).live_complete
+    assert BUILD(library, {"1"}).live_complete
+    assert len(calls) == 3
+
+
+def test_unsupported_filter_retains_full_fallback_for_false_empty_response(library):
+    calls = []
+
+    def get(*a, **kw):
+        params = kw["params"]
+        calls.append(params)
+        if params.get("includeMeta") or "unwatched" in params:
+            return response()
+        return response([{"ratingKey": "42", "type": "episode", "viewCount": 1, "lastViewedAt": PLAYED}], 1)
+
+    library.client.server._session = SimpleNamespace(headers={}, get=get)
+    cat = BUILD(library, {"1"})
+    assert cat.live_complete
+    assert cat.by_rk["42"]["watched"]
+    assert len(calls) == 3
+
+
+def test_advertised_filter_rejected_by_server_falls_back(library):
+    def get(*a, **kw):
+        params = kw["params"]
+        if params.get("includeMeta"):
+            return response(meta=CAPABILITY)
+        if "episode.viewCount>>" in params:
+            return response(status=400)
+        return response([{"ratingKey": "42", "type": "episode", "viewCount": 1}], 1)
+
+    library.client.server._session = SimpleNamespace(headers={}, get=get)
+    cat = BUILD(library, {"1"})
+    assert cat.live_complete and cat.by_rk["42"]["watched"]
+
+
+def test_missing_library_does_not_block_other_selected_libraries(library, monkeypatch):
+    warnings = []
+    monkeypatch.setattr(history, "_warn", lambda event, **kw: warnings.append((event, kw)))
+    requests = []
+
+    def get(url, **kw):
+        requests.append(url)
+        return response(meta=CAPABILITY)
+
+    library.client.server._session = SimpleNamespace(headers={}, get=get)
+    allow = {"1", "99"}
+    assert BUILD(library, allow).live_complete
+    assert allow == {"1", "99"}
+    assert all("/sections/1/" in path for path in requests)
+    assert warnings == [("history_libraries_unavailable", {"library_ids": ["99"]})]
+
+
+def test_no_selected_library_available_does_not_expand_scope(library):
+    library.client.server._session = SimpleNamespace(headers={}, get=lambda *a, **kw: pytest.fail("Outside whitelist"))
+    with pytest.raises(RuntimeError, match="no_accessible_selected_libraries: 99"):
+        BUILD(library, {"99"})
+
+
+def test_repeated_page_recovers_with_one_retry(library):
+    library.libraries = lambda **kw: [SimpleNamespace(key="1", type="movie")]
+    calls = []
+
+    def get(*a, **kw):
+        start = kw["params"]["X-Plex-Container-Start"]
+        calls.append(start)
+        rk = "42" if len(calls) <= 2 else "43"
+        return response([{"ratingKey": rk, "type": "movie", "viewCount": 1}], 2)
+
+    library.client.server._session = SimpleNamespace(headers={}, get=get)
+    cat = BUILD(library, {"1"})
+    assert cat.live_complete and set(cat.by_rk) == {"42", "43"}
+    assert calls == [0, 1, 1]
+
+
+def test_successful_write_is_reused_without_claiming_live_or_date_confirmation(playback, monkeypatch):
+    ad = playback.adapter()
+    playback.catalog.by_rk["42"]["watched"] = False
+    writes = []
+    monkeypatch.setattr(history, "_scrobble_with_date", lambda srv, rk, ts: writes.append(rk) or True)
+    monkeypatch.setattr(history, "_ensure_session_pool", lambda *a: None)
+    monkeypatch.setattr(history, "_shadow_add_batch", lambda *a: None)
+    monkeypatch.setattr(history, "_get_history_catalog", lambda *a, **kw: playback.catalog)
+    item = {"type": "movie", "ids": {"tmdb": "123", "plex": "42"}, "watched_at": history._iso(PLAYED)}
+    assert history.add(ad, [item]) == (1, [])
+    assert history.add(ad, [item]) == (1, [])
+    assert writes == ["42"]
+    assert ad._plex_history_write_meta["accepted_not_seen_live_keys"]
+    assert ad._plex_history_write_meta["live_confirmed_keys"] == []
+    assert ad._plex_history_write_meta["date_confirmed_keys"] == []
+
+
+def test_missing_live_timestamp_is_not_date_confirmation(playback, monkeypatch):
+    playback.catalog.by_rk["42"]["last_viewed_at"] = None
+    monkeypatch.setattr(history, "_get_history_catalog", lambda *a, **kw: playback.catalog)
+    monkeypatch.setattr(history, "_shadow_add_batch", lambda *a: None)
+    ad = playback.adapter()
+    item = {"type": "movie", "ids": {"tmdb": "123"}, "watched_at": history._iso(PLAYED)}
+    assert history.add(ad, [item]) == (1, [])
+    assert ad._plex_history_write_meta["live_confirmed_keys"]
+    assert not ad._plex_history_write_meta["date_confirmed_keys"]
+
+
+def test_failed_apply_is_reported_as_errors(playback, monkeypatch):
+    ad = playback.adapter()
+    ad._is_enabled = lambda feature: True
+
+    def fail(*a, **kw):
+        raise RuntimeError("plex_watched_scan_http_500")
+
+    monkeypatch.setattr(history, "_get_history_catalog", fail)
+    result = PLEXModule.add(ad, "history", [{"type": "movie", "ids": {"tmdb": "123"}}])
+    assert result["ok"] is False
+    assert result["errors"] == 1
+    assert result["count"] == 0
+    assert result["confirmed_keys"] == []
+
+
+def test_failed_remove_is_reported_as_errors(playback, monkeypatch):
+    ad = playback.adapter()
+    ad._is_enabled = lambda feature: True
+
+    def fail(*a, **kw):
+        raise RuntimeError("Server unavailable")
+
+    monkeypatch.setattr(history, "remove", fail)
+    result = PLEXModule.remove(ad, "history", [{"type": "movie", "ids": {"tmdb": "123"}}])
+    assert result["ok"] is False
+    assert result["errors"] == 1
+    assert result["count"] == 0
+    assert result["confirmed_keys"] == []
+
+
+def test_episode_catalog_hydration_preserves_pending_write(library):
+    cat = history.HistoryCatalog()
+    cat.add({"rk": "42", "type": "episode", "ids": {"plex": "42"}, "watched": True,
+             "write_accepted": True, "last_viewed_at": None})
+    library.client.server._session = SimpleNamespace(headers={}, get=lambda *a, **kw:
+        response([{"ratingKey": "42", "type": "episode", "viewCount": 0}], 1))
+    assert history._populate_catalog_episode_leaves(library, {"1"}, cat) == 1
+    assert cat.by_rk["42"]["write_accepted"] is True
+    assert cat.by_rk["42"]["last_viewed_at"] is None

--- a/tests/test_plex_index_cache.py
+++ b/tests/test_plex_index_cache.py
@@ -153,6 +153,7 @@ def test_history_catalog_respects_scope(monkeypatch, change):
 
 
 def test_history_catalog_keeps_live_state_ttl(monkeypatch):
+    log_run_id.set("")
     now = [100.0]
     monkeypatch.setattr(history.time, "monotonic", lambda: now[0])
     monkeypatch.setattr(history, "_build_history_catalog", lambda *args, **kwargs: history.HistoryCatalog())
@@ -162,6 +163,17 @@ def test_history_catalog_keeps_live_state_ttl(monkeypatch):
     second = history._get_history_catalog(ad, {"1"})
     assert second is not first
     assert history._get_history_catalog(ad, {"1"}, force=True) is not second
+
+
+def test_history_catalog_survives_long_run_but_refreshes_next_run(monkeypatch):
+    now = [100.0]
+    monkeypatch.setattr(history.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(history, "_build_history_catalog", lambda *args, **kwargs: history.HistoryCatalog())
+    first = history._get_history_catalog(adapter(), {"1"})
+    now[0] += 3600
+    assert history._get_history_catalog(adapter(), {"1"}) is first
+    log_run_id.set("run2")
+    assert history._get_history_catalog(adapter(), {"1"}) is not first
 
 
 def test_failed_page_never_leaves_partial_index(monkeypatch):

--- a/tests/test_plex_marked_watched_fallback.py
+++ b/tests/test_plex_marked_watched_fallback.py
@@ -34,6 +34,8 @@ class _Session:
     def get(self, url: str, params: Any = None, headers: Any = None, timeout: Any = None) -> _Resp:
         p = dict(params or {})
         self.requests.append(p)
+        if p.get("includeMeta"):
+            return _Resp([])
         return self._handler(p)
 
 
@@ -66,8 +68,6 @@ def _movie(rating_key: str, view_count: int, last_viewed: int | None = LAST_VIEW
 
 @pytest.fixture
 def scan(monkeypatch):
-    monkeypatch.setattr(history, "_load_marked_state", lambda: {})
-    monkeypatch.setattr(history, "_save_marked_state", lambda *_: None)
     monkeypatch.setattr(history, "plex_headers", lambda _t: {})
     monkeypatch.setattr(
         history,

--- a/tests/test_plex_native_identity.py
+++ b/tests/test_plex_native_identity.py
@@ -1,0 +1,205 @@
+from copy import deepcopy
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlsplit
+from xml.etree import ElementTree as ET
+
+import pytest
+from plexapi.server import PlexServer
+
+from providers.sync.plex import _common as common, _history as history, _ratings as ratings
+
+
+def media(kind, key, *, show="73739", season=1, episode=2, parent="900", modern=False):
+    row = {"type": kind, "ratingKey": key, "key": f"/library/metadata/{key}",
+           "librarySectionID": "1", "title": "Test item"}
+    suffix = f"/{season}/{episode}" if kind == "episode" else f"/{season}" if kind == "season" else ""
+    row["guid"] = f"com.plexapp.agents.thetvdb://{show}{suffix}?lang=en"
+    if modern:
+        row["guid"] = f"plex://{kind}/{key}"
+        row["Guid"] = [{"id": f"tvdb://{show if kind == 'show' else '98765'}"}]
+    if kind in ("episode", "season"):
+        row.update(index=episode if kind == "episode" else season,
+                   parentKey=f"/library/metadata/{parent}", parentRatingKey=parent,
+                   parentGuid=f"tvdb://{show}")
+    if kind == "episode":
+        row.update(parentIndex=season, grandparentKey=f"/library/metadata/{parent}",
+                   grandparentRatingKey=parent, grandparentGuid=f"tvdb://{show}", grandparentTitle="Test show")
+    return row
+
+
+class PlexTransport:
+    def __init__(self):
+        self.headers = {"X-Plex-Token": "test-token"}
+        self.rows = {}
+        self.writes = []
+        self.reads = []
+
+    def get(self, url, params=None, **kwargs):
+        parsed = urlsplit(url)
+        path = parsed.path
+        query = {key: values[0] for key, values in parse_qs(parsed.query).items()}
+        query.update(params or {})
+        self.reads.append(path)
+        if path in ("/:/scrobble", "/:/rate"):
+            self.writes.append((path, str(query.get("key") or query.get("ratingKey"))))
+            rows = []
+        elif path == "/":
+            rows = []
+        elif path == "/library/all":
+            guid = query.get("guid")
+            rows = [row for row in self.rows.values() if row["guid"] == guid
+                    or any(value["id"] == guid for value in row.get("Guid", []))][:1]
+        elif path == "/library/sections/1/all":
+            kind = {1: "movie", 2: "show", 4: "episode"}[int(query["type"])]
+            rows = [row for row in self.rows.values() if row["type"] == kind]
+        elif path.endswith("/allLeaves"):
+            parent = path.split("/")[-2]
+            rows = [row for row in self.rows.values() if row.get("grandparentRatingKey") == parent]
+        elif path.startswith("/library/metadata/"):
+            key = path.split("/")[-1]
+            rows = [self.rows[key]] if key in self.rows else []
+        else:
+            raise AssertionError(f"Unexpected Plex request: {path}")
+        root = ET.Element("MediaContainer", size=str(len(rows)), totalSize=str(len(rows)), machineIdentifier="test-server")
+        for row in rows:
+            node = ET.SubElement(root, "Video" if row["type"] in ("movie", "episode") else "Directory",
+                                 {key: str(value) for key, value in row.items() if key != "Guid"})
+            for guid in row.get("Guid", []):
+                ET.SubElement(node, "Guid", guid)
+        return SimpleNamespace(ok=True, status_code=200, text=ET.tostring(root, encoding="unicode"),
+                               headers={"content-type": "application/xml"})
+
+
+@pytest.fixture
+def plex(monkeypatch, tmp_path):
+    transport = PlexTransport()
+    server = PlexServer("http://plex.test", "test-token", session=transport)
+    adapter = SimpleNamespace(client=SimpleNamespace(server=server), cfg=SimpleNamespace(), config={"plex": {
+        "strict_id_matching": True, "history_workers": 1,
+        "history": {"libraries": [1]}, "ratings": {"libraries": [1]},
+    }}, libraries=lambda **kwargs: [SimpleNamespace(key="1", type="show")])
+    monkeypatch.setattr(common, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(history._INDEX_CACHE, "guid", None, raising=False)
+    monkeypatch.setattr(common, "_SHOW_EPISODE_CACHE", {})
+    for module in (history, ratings):
+        monkeypatch.setattr(module, "home_scope_enter", lambda *args: (False, False, None, None))
+        monkeypatch.setattr(module, "home_scope_exit", lambda *args: None)
+    return SimpleNamespace(adapter=adapter, server=server, transport=transport)
+
+
+def source_item(kind="episode", *, season=1, modern=False):
+    row = common.normalize_discover_row(media(kind, "1234", season=season, modern=modern), token=None)
+    assert row is not None
+    if kind == "season":
+        row["show_ids"] = {"tvdb": "73739", "plex": "900"}
+    row.update(watched_at="2026-01-01T12:00:00Z", rating=8)
+    return row
+
+
+def ambiguous_catalogue(monkeypatch, item):
+    cat = history.HistoryCatalog()
+    for key in ("1001", "1002"):
+        cat.add({"rk": key, "type": "episode", "ids": {"plex": key}, "show_ids": item["show_ids"],
+                 "season": item["season"], "episode": item["episode"], "watched": False})
+    assert cat.resolve(item, strict=True) == (None, history.CLASS_RESOLVE_AMBIGUOUS)
+    monkeypatch.setattr(history, "_get_history_catalog", lambda *args, **kwargs: cat)
+
+
+@pytest.mark.parametrize(("kind", "case"), [
+    (kind, case) for kind in ("episode", "season")
+    for case in ("correct", "wrong_season", "wrong_episode", "wrong_parent")
+    if kind == "episode" or case != "wrong_episode"
+])
+@pytest.mark.parametrize("modern", [False, True])
+def test_native_match_checks_coordinates_and_parent(plex, kind, modern, case):
+    item = source_item(kind, modern=modern)
+    plex.transport.rows["1234"] = media(kind, "1234", modern=modern,
+        season=7 if case == "wrong_season" else 1, episode=11 if case == "wrong_episode" else 2)
+    plex.transport.rows["900"] = media("show", "900", show="99999" if case == "wrong_parent" else "73739", modern=modern)
+    obj = plex.server.fetchItem(1234)
+    assert common.native_item_matches(obj, item) is (case == "correct")
+
+
+@pytest.mark.parametrize(("feature", "kind"), [("history", "episode"), ("ratings", "episode"), ("ratings", "season")])
+@pytest.mark.parametrize("modern", [False, True])
+@pytest.mark.parametrize("case", ["correct", "wrong_episode", "wrong_parent"])
+def test_writes_never_use_wrong_native_episode(plex, monkeypatch, feature, kind, modern, case):
+    item = source_item(kind, modern=modern)
+    plex.transport.rows["1234"] = media(kind, "1234", episode=11 if case == "wrong_episode" else 2,
+        season=7 if case == "wrong_episode" and kind == "season" else 1, modern=modern,
+        show="99999" if case == "wrong_parent" else "73739")
+    plex.transport.rows["900"] = media("show", "900", show="99999" if case == "wrong_parent" else "73739")
+    if feature == "history":
+        ambiguous_catalogue(monkeypatch, item)
+    module = history if feature == "history" else ratings
+    count, unresolved = module.add(plex.adapter, [item])
+    assert count == int(case == "correct")
+    assert bool(unresolved) is (case != "correct")
+    endpoint = "/:/scrobble" if feature == "history" else "/:/rate"
+    assert plex.transport.writes == ([(endpoint, "1234")] if case == "correct" else [])
+
+
+@pytest.mark.parametrize("correct_available", [False, True])
+def test_history_reused_parent_key_cannot_override_external_show_id(plex, monkeypatch, correct_available):
+    item = source_item()
+    plex.transport.rows["1234"] = media("episode", "1234", show="99999", season=7, episode=11)
+    plex.transport.rows["900"] = media("show", "900", show="99999")
+    plex.transport.rows["5555"] = media("episode", "5555", show="99999")
+    if correct_available:
+        plex.transport.rows["901"] = media("show", "901")
+        plex.transport.rows["5678"] = media("episode", "5678", parent="901")
+    ambiguous_catalogue(monkeypatch, item)
+    count, unresolved = history.add(plex.adapter, [item])
+    assert count == int(correct_available)
+    assert bool(unresolved) is not correct_available
+    assert plex.transport.writes == ([("/:/scrobble", "5678")] if correct_available else [])
+    assert "/library/metadata/900/allLeaves" not in plex.transport.reads
+
+
+@pytest.mark.parametrize("feature", ["history", "ratings"])
+def test_specials_keep_zero_season_during_external_id_fallback(plex, monkeypatch, feature):
+    item = source_item(season=0)
+    plex.transport.rows["900"] = media("show", "900")
+    plex.transport.rows["1111"] = media("episode", "1111", season=1)
+    plex.transport.rows["2222"] = media("episode", "2222", season=0)
+    if feature == "history":
+        ambiguous_catalogue(monkeypatch, item)
+    module = history if feature == "history" else ratings
+    count, unresolved = module.add(plex.adapter, [item])
+    assert (count, unresolved) == (1, [])
+    endpoint = "/:/scrobble" if feature == "history" else "/:/rate"
+    assert plex.transport.writes == [(endpoint, "2222")]
+
+
+def test_native_only_episode_still_requires_coordinates(plex):
+    plex.transport.rows["1234"] = media("episode", "1234")
+    obj = plex.server.fetchItem(1234)
+    item = {"type": "episode", "ids": {"plex": "1234"}, "season": 1, "episode": 2}
+    assert common.native_item_matches(obj, item)
+    wrong = deepcopy(item)
+    wrong["episode"] = 11
+    assert not common.native_item_matches(obj, wrong)
+
+
+@pytest.mark.parametrize("identity", ["episode_external_id", "show_guid"])
+@pytest.mark.parametrize("correct_available", [False, True])
+def test_history_parent_shortcut_requires_external_show_evidence(plex, monkeypatch, identity, correct_available):
+    item = source_item(modern=True)
+    item["show_ids"] = {"plex": "900"}
+    plex.transport.rows["900"] = media("show", "900", show="99999")
+    plex.transport.rows["5555"] = media("episode", "5555", show="99999")
+    if identity == "show_guid":
+        item["ids"] = {"plex": "1234"}
+        item["guid"] = "plex://episode/original-episode"
+        item["show_guid"] = "plex://show/original-show"
+    if correct_available:
+        plex.transport.rows["901"] = media("show", "901")
+        plex.transport.rows["5678"] = media("episode", "5678", parent="901", modern=True)
+        if identity == "show_guid":
+            plex.transport.rows["901"]["guid"] = item["show_guid"]
+    ambiguous_catalogue(monkeypatch, item)
+    count, unresolved = history.add(plex.adapter, [item])
+    assert count == int(correct_available)
+    assert bool(unresolved) is not correct_available
+    assert plex.transport.writes == ([("/:/scrobble", "5678")] if correct_available else [])
+    assert "/library/metadata/900/allLeaves" not in plex.transport.reads

--- a/tests/test_plex_playback_cache_recovery.py
+++ b/tests/test_plex_playback_cache_recovery.py
@@ -1,0 +1,263 @@
+import json
+import os
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from providers.sync.plex import _history as history
+from test_plex_playback_dates import MARKED, PLAYED, playback
+
+
+BUILD_CATALOG = history._build_history_catalog
+SCAN_WATCHED = history._iter_marked_watched_from_library
+READ_METADATA = history._pms_fetch_metadata_row
+
+
+def response(status=200, metadata=None, total=None):
+    body = {"Metadata": metadata or []}
+    if total is not None:
+        body["totalSize"] = total
+    return SimpleNamespace(ok=status == 200, status_code=status, headers={"content-type": "application/json"},
+                           json=lambda: {"MediaContainer": body})
+
+
+def test_cached_library_items_do_not_require_individual_metadata_requests(playback, monkeypatch):
+    for i in range(40):
+        rk = str(100 + i)
+        playback.catalog.add({"rk": rk, "type": "movie", "title": rk, "ids": {"tmdb": rk, "plex": rk},
+                              "watched": True, "last_viewed_at": MARKED})
+        playback.state["history"].append(SimpleNamespace(type="movie", ratingKey=rk, title=rk,
+                                                       viewedAt=PLAYED + i, accountID=17))
+    monkeypatch.setattr(history, "_pms_fetch_metadata_row", lambda *a, **kw: pytest.fail("Unnecessary item request"))
+    monkeypatch.setattr(history, "_iter_marked_watched_from_library", lambda *a, **kw: pytest.fail("Second library scan"))
+    first = history.build_index(playback.adapter())
+    assert len(first) == 41
+    assert history.build_index(playback.adapter()) == first
+
+
+@pytest.mark.parametrize("status", [401, 500])
+def test_unknown_item_state_aborts_without_resurrecting_cached_play(playback, monkeypatch, status):
+    ad = playback.adapter()
+    history.build_index(ad)
+    playback.catalog.by_rk["42"]["watched"] = False
+    assert history.build_index(ad) == {}
+    path = history._playback_cache_path(ad, {"1"})
+    before = path.read_bytes()
+    playback.catalog.by_rk.clear()
+    ad.client.server._session = SimpleNamespace(headers={}, get=lambda *a, **kw: response(status))
+    monkeypatch.setattr(history, "_pms_fetch_metadata_row", READ_METADATA)
+    with pytest.raises(RuntimeError, match=f"metadata_http_{status}"):
+        history.build_index(ad)
+    assert path.read_bytes() == before
+
+
+def test_removed_library_item_keeps_real_history_until_history_itself_is_deleted(playback, monkeypatch):
+    ad = playback.adapter()
+    expected = history.build_index(ad)
+    playback.catalog.by_rk.clear()
+    ad.client.server._session = SimpleNamespace(headers={}, get=lambda *a, **kw: response(404))
+    monkeypatch.setattr(history, "_pms_fetch_metadata_row", READ_METADATA)
+    result = history.build_index(ad)
+    assert set(result) == set(expected)
+    assert next(iter(result.values()))["watched_at"] == history._iso(PLAYED)
+    playback.state["history"] = []
+    assert history.build_index(ad, force=True) == {}
+
+
+@pytest.mark.parametrize("failure", ["timeout", "empty", "wrong_item"])
+def test_invalid_metadata_check_cannot_publish_a_snapshot(playback, monkeypatch, failure):
+    ad = playback.adapter()
+    history.build_index(ad)
+    playback.catalog.by_rk.clear()
+
+    def get(*a, **kw):
+        if failure == "timeout":
+            raise TimeoutError("Unavailable")
+        return response(metadata=[{"ratingKey": "different", "viewCount": 1}] if failure == "wrong_item" else [])
+
+    ad.client.server._session = SimpleNamespace(headers={}, get=get)
+    monkeypatch.setattr(history, "_pms_fetch_metadata_row", READ_METADATA)
+    with pytest.raises(RuntimeError, match="plex_history_metadata"):
+        history.build_index(ad)
+
+
+@pytest.mark.parametrize("offset", [0, -60])
+def test_cursor_overlap_recovers_recent_late_plays(playback, offset):
+    history.build_index(playback.adapter())
+    late = deepcopy(playback.state["history"][0])
+    late.ratingKey = "43"
+    late.viewedAt = PLAYED + offset
+    playback.state["history"].append(late)
+    playback.catalog.add({"rk": "43", "type": "movie", "title": "Late play", "ids": {"plex": "43", "tmdb": "124"},
+                          "watched": True, "last_viewed_at": MARKED})
+    assert len(history.build_index(playback.adapter())) == 2
+
+
+@pytest.mark.parametrize("elapsed", [12 * 3600, 24 * 3600, 30 * 86400])
+def test_scheduled_runs_stay_incremental_and_pick_up_new_plays(playback, monkeypatch, elapsed):
+    now = [2000000000]
+    monkeypatch.setattr(history.time, "time", lambda: now[0])
+    first = history.build_index(playback.adapter())
+    assert "mindate" not in playback.calls[-1]
+    now[0] += elapsed
+    latest = deepcopy(playback.state["history"][0])
+    latest.viewedAt = now[0] - 60
+    playback.state["history"].append(latest)
+    result = history.build_index(playback.adapter())
+    assert playback.calls[-1]["mindate"].timestamp() == PLAYED - 120
+    assert set(first).issubset(result)
+    assert {row["watched_at"] for row in result.values()} == {history._iso(PLAYED), history._iso(latest.viewedAt)}
+
+
+def test_force_refresh_recovers_backfills_and_reconciles_deleted_events(playback, monkeypatch):
+    now = [2000000000]
+    monkeypatch.setattr(history.time, "time", lambda: now[0])
+    ad = playback.adapter()
+    old = deepcopy(playback.state["history"][0])
+    old.viewedAt = PLAYED - 86400
+    playback.state["history"].append(old)
+    assert len(history.build_index(ad)) == 2
+    playback.state["history"].remove(old)
+    backfill = deepcopy(old)
+    backfill.viewedAt -= 86400
+    playback.state["history"].append(backfill)
+    assert old.viewedAt != backfill.viewedAt
+    assert {row["watched_at"] for row in history.build_index(ad).values()} == {history._iso(PLAYED), history._iso(old.viewedAt)}
+    now[0] += 12 * 3600
+    assert {row["watched_at"] for row in history.build_index(ad).values()} == {history._iso(PLAYED), history._iso(old.viewedAt)}
+    assert "mindate" in playback.calls[-1]
+    refreshed = history.build_index(ad, force=True)
+    assert {row["watched_at"] for row in refreshed.values()} == {history._iso(PLAYED), history._iso(backfill.viewedAt)}
+    assert "mindate" not in playback.calls[-1]
+
+
+def test_clear_state_makes_next_playback_read_full(playback, monkeypatch):
+    from api import maintenanceAPI
+
+    ad = playback.adapter()
+    history.build_index(ad)
+    path = history._playback_cache_path(ad, {"1"})
+    config_dir = playback.directory / "config"
+    config_dir.mkdir()
+    monkeypatch.setattr(maintenanceAPI, "_cw", lambda: (
+        config_dir / "cache", config_dir, playback.directory, None, None, None,
+    ))
+    late = deepcopy(playback.state["history"][0])
+    late.viewedAt -= 86400
+    playback.state["history"] = [late]
+    result = maintenanceAPI.clear_state_minimal()
+    assert result["ok"] is True
+    assert path.name in result["removed_sync_state"]
+    assert not path.exists()
+    refreshed = history.build_index(playback.adapter())
+    assert "mindate" not in playback.calls[-1]
+    assert {row["watched_at"] for row in refreshed.values()} == {history._iso(late.viewedAt)}
+
+
+def test_date_filter_fallback_reconciles_full_results(playback):
+    ad = playback.adapter()
+    history.build_index(ad)
+    late = deepcopy(playback.state["history"][0])
+    late.viewedAt -= 86400
+    playback.state["history"] = [late]
+
+    def get(**kwargs):
+        if "mindate" in kwargs:
+            raise ValueError("Unsupported date filter")
+        return [late]
+
+    ad.client.server.history = get
+    result = history.build_index(ad)
+    assert len(result) == 1
+    assert next(iter(result.values()))["watched_at"] == history._iso(late.viewedAt)
+
+
+def test_unchanged_playback_cache_is_not_written_again(playback, monkeypatch):
+    now = 2000000000
+    monkeypatch.setattr(history.time, "time", lambda: now)
+    ad = playback.adapter()
+    history.build_index(ad)
+    monkeypatch.setattr(history, "write_json", lambda *a, **kw: pytest.fail("Unchanged cache rewritten"))
+    history.build_index(ad)
+
+
+def test_both_fallback_guid_spellings_share_effective_cache_options(playback):
+    ad = playback.adapter()
+    disabled = history._playback_cache_path(ad, {"1"})
+    ad.config["plex"]["fallback_guid"] = True
+    lowercase = history._playback_cache_path(ad, {"1"})
+    assert lowercase != disabled
+    ad.config["plex"].pop("fallback_guid")
+    ad.config["plex"]["fallback_GUID"] = True
+    assert history._playback_cache_path(ad, {"1"}) == lowercase
+
+
+def test_failed_force_refresh_preserves_playback_cache_and_snapshot(playback):
+    ad = playback.adapter()
+    ad.config["plex"]["history"]["include_marked_watched"] = False
+    expected = history.build_index(ad)
+    path = history._playback_cache_path(ad, {"1"})
+    original = path.read_bytes()
+    playback.state["denied"] = True
+    assert history.build_index(ad, force=True) == expected
+    assert path.read_bytes() == original
+
+
+def test_cold_playback_failure_cannot_replace_dates_with_manual_state(playback):
+    ad = playback.adapter()
+
+    def fail(**kwargs):
+        raise TimeoutError("Playback history unavailable")
+
+    ad.client.server.history = fail
+    with pytest.raises(RuntimeError, match="playback_unavailable_without_cache"):
+        history.build_index(ad)
+    assert not list(playback.directory.glob("*playback*"))
+
+
+def test_incomplete_catalog_does_not_publish_or_update_cache(playback):
+    ad = playback.adapter()
+    history.build_index(ad)
+    path = history._playback_cache_path(ad, {"1"})
+    original = path.read_bytes()
+    playback.catalog.live_complete = False
+    with pytest.raises(RuntimeError, match="incomplete_watched_catalog"):
+        history.build_index(ad)
+    assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize("failure", ["http", "malformed", "repeated", "incomplete"])
+def test_actual_library_scan_rejects_incomplete_data(playback, monkeypatch, failure):
+    ad = playback.adapter()
+    ad.libraries = lambda **kw: [SimpleNamespace(key="1", type="movie", title="Movies")]
+    row = {"ratingKey": "42", "type": "movie", "title": "Movie", "viewCount": 1, "lastViewedAt": MARKED}
+
+    def get(*a, **kw):
+        if failure == "http":
+            return response(500)
+        if failure == "malformed":
+            return SimpleNamespace(ok=True, status_code=200, headers={"content-type": "application/json"}, json=lambda: {})
+        start = kw["params"]["X-Plex-Container-Start"]
+        return response(metadata=[] if failure == "incomplete" and start else [row], total=3)
+
+    ad.client.server._session = SimpleNamespace(headers={}, get=get)
+    monkeypatch.setattr(history, "_iter_marked_watched_from_library", SCAN_WATCHED)
+    monkeypatch.setattr(history, "_build_guid_index", lambda *a, **kw: {"movies": {"tmdb://123": "42"}, "shows": {}})
+    monkeypatch.setattr(history, "normalize_discover_row", lambda *a, **kw: {"type": "movie", "ids": {"plex": "42", "tmdb": "123"}})
+    with pytest.raises(RuntimeError, match="plex_watched_scan"):
+        BUILD_CATALOG(ad, {"1"}, live=True)
+
+
+def test_cleanup_only_removes_old_variants_of_the_same_pair_and_user(playback):
+    now = 2000000000
+    current = history._playback_cache_path(playback.adapter(), {"1"})
+    old = history._playback_cache_path(playback.adapter(), {"2"})
+    other_pair = history._playback_cache_path(playback.adapter(pair="different"), {"2"})
+    other_user = history._playback_cache_path(playback.adapter(account=18), {"2"})
+    for path in (current, old, other_pair, other_user):
+        path.write_text(json.dumps({}))
+        os.utime(path, (now - 31 * 86400, now - 31 * 86400))
+    history._prune_playback_caches(current, now)
+    assert not old.exists()
+    assert all(path.exists() for path in (current, other_pair, other_user))

--- a/tests/test_plex_playback_dates.py
+++ b/tests/test_plex_playback_dates.py
@@ -1,0 +1,206 @@
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from cw_platform.log_context import log_run_id
+from providers.sync.plex import _common as common, _history as history
+
+
+PLAYED = 1726353929
+MARKED = 1771430695
+
+
+@pytest.fixture
+def playback(monkeypatch, tmp_path):
+    monkeypatch.setenv("CW_PAIR_KEY", "cw2_playback_dates")
+    monkeypatch.setattr(common, "STATE_DIR", tmp_path)
+    token = log_run_id.set("playback-first")
+    calls = []
+    raw = SimpleNamespace(type="movie", ratingKey="42", title="Recorded title", viewedAt=PLAYED, accountID=17)
+    state = {"history": [raw], "denied": False, "scope_ok": True}
+    catalog = history.HistoryCatalog()
+    catalog.live_complete = True
+    catalog.add({"rk": "42", "type": "movie", "title": "Current title", "ids": {"tmdb": "123", "plex": "42"},
+                 "watched": True, "view_count": 1, "last_viewed_at": MARKED, "library_id": "1"})
+
+    def read_history(**kwargs):
+        calls.append(kwargs)
+        if state["denied"]:
+            raise PermissionError("History unavailable to this user")
+        since = kwargs.get("mindate")
+        return [r for r in state["history"] if since is None or r.viewedAt > since.timestamp()]
+
+    def adapter(pair="cw2_playback_dates", account=17, server="http://plex.test", token="test-token"):
+        srv = SimpleNamespace(baseurl=server, _token=token, machineIdentifier="server", history=read_history)
+        return SimpleNamespace(client=SimpleNamespace(server=srv, user_account_id=account), config={
+            "_cw_pair_scope": pair, "plex": {"account_id": account, "history_workers": 1,
+                "history": {"include_marked_watched": True}},
+        })
+
+    monkeypatch.setattr(history, "home_scope_enter", lambda _: (not state["scope_ok"], False, 17, None))
+    monkeypatch.setattr(history, "home_scope_exit", lambda *a: None)
+    monkeypatch.setattr(history, "plex_feature_library_ids", lambda *a: {"1"})
+    monkeypatch.setattr(history, "_history_force_full", lambda _: False)
+    monkeypatch.setattr(history, "_build_history_catalog", lambda *a, **kw: catalog if kw.get("live", True) else history.HistoryCatalog())
+    monkeypatch.setattr(history, "_store_history_catalog", lambda *a: None)
+    monkeypatch.setattr(history, "_keep_in_snapshot", lambda *a: True)
+    monkeypatch.setattr(history, "minimal_from_history_row", lambda r, **kw: {
+        "type": r.type, "title": r.title, "ids": {"plex": r.ratingKey, "tmdb": "123"},
+    })
+    monkeypatch.setattr(history, "_pms_fetch_metadata_row", lambda *a, **kw: {
+        "viewCount": int(catalog.by_rk["42"]["watched"]), "lastViewedAt": catalog.by_rk["42"]["last_viewed_at"],
+    })
+    monkeypatch.setattr(history, "_iter_marked_watched_from_library", lambda *a, **kw: [
+        (history._catalog_entry_to_minimal(row), row["last_viewed_at"])
+        for row in catalog.by_rk.values() if row["watched"]
+    ])
+    for name in ("_emit", "_info", "_warn", "_dbg", "_fb_cache_flush"):
+        monkeypatch.setattr(history, name, lambda *a, **kw: None)
+    yield SimpleNamespace(adapter=adapter, state=state, catalog=catalog, calls=calls, directory=tmp_path)
+    log_run_id.reset(token)
+
+
+def test_playback_dates_survive_restart_and_ignore_legacy_watermark(playback):
+    common.state_file("plex_history.watermark.json").write_text('{"by_user":{"acct:17":1771430695}}')
+    first = history.build_index(playback.adapter())
+    assert len(first) == 1
+    assert next(iter(first.values()))["watched_at"] == history._iso(PLAYED)
+    assert "mindate" not in playback.calls[0]
+    log_run_id.set("playback-second")
+    second = history.build_index(playback.adapter())
+    assert second == first
+    assert playback.calls[-1]["mindate"].timestamp() == PLAYED - 120
+    assert all("test-token" not in path.read_text() for path in playback.directory.glob("*"))
+
+
+@pytest.mark.parametrize("offset", [1, 86400])
+def test_real_rewatch_keeps_both_recorded_dates(playback, offset):
+    history.build_index(playback.adapter())
+    latest = deepcopy(playback.state["history"][0])
+    latest.viewedAt = PLAYED + offset
+    playback.state["history"].append(latest)
+    result = history.build_index(playback.adapter())
+    assert {row["watched_at"] for row in result.values()} == {history._iso(PLAYED), history._iso(latest.viewedAt)}
+    assert history.build_index(playback.adapter()) == result
+
+
+def test_manual_unwatch_and_rewatch_keep_recorded_playback_date(playback):
+    expected = history.build_index(playback.adapter())
+    playback.catalog.by_rk["42"]["watched"] = False
+    assert history.build_index(playback.adapter()) == {}
+    playback.catalog.by_rk["42"]["watched"] = True
+    playback.catalog.by_rk["42"]["last_viewed_at"] += 3600
+    assert history.build_index(playback.adapter()) == expected
+
+
+def test_complete_library_scan_detects_unwatch_without_individual_checks(playback, monkeypatch):
+    history.build_index(playback.adapter())
+    playback.catalog.by_rk["42"]["watched"] = False
+    monkeypatch.setattr(history, "_pms_fetch_metadata_row", lambda *a, **kw: pytest.fail("Catalogue already confirms unwatch"))
+    assert history.build_index(playback.adapter()) == {}
+
+
+def test_disabled_marked_watched_excludes_manual_only_items(playback):
+    playback.state["history"] = []
+    ad = playback.adapter()
+    ad.config["plex"]["history"]["include_marked_watched"] = False
+    assert history.build_index(ad) == {}
+
+
+def test_disabled_marked_watched_keeps_actual_plays_without_manual_state_checks(playback, monkeypatch):
+    ad = playback.adapter()
+    ad.config["plex"]["history"]["include_marked_watched"] = False
+    monkeypatch.setattr(history, "_pms_fetch_metadata_row", lambda *a: pytest.fail("Manual state checks are disabled"))
+    first = history.build_index(ad)
+    playback.catalog.by_rk["42"]["watched"] = False
+    assert history.build_index(ad) == first
+    assert next(iter(first.values()))["watched_at"] == history._iso(PLAYED)
+
+
+def test_marked_watched_toggle_applies_to_existing_playback_cache(playback):
+    ad = playback.adapter()
+    expected = history.build_index(ad)
+    playback.catalog.by_rk["42"]["watched"] = False
+    assert history.build_index(ad) == {}
+    ad.config["plex"]["history"]["include_marked_watched"] = False
+    assert history.build_index(ad) == expected
+    ad.config["plex"]["history"]["include_marked_watched"] = True
+    assert history.build_index(ad) == {}
+
+
+def test_manual_only_item_keeps_last_viewed_date_and_sees_updates(playback):
+    playback.state["history"] = []
+    result = history.build_index(playback.adapter())
+    assert next(iter(result.values()))["watched_at"] == history._iso(MARKED)
+    playback.catalog.by_rk["42"]["last_viewed_at"] += 3600
+    result = history.build_index(playback.adapter())
+    assert next(iter(result.values()))["watched_at"] == history._iso(MARKED + 3600)
+
+
+@pytest.mark.parametrize("change", ["pair", "account", "server", "token", "libraries"])
+def test_playback_cache_cannot_cross_scope(playback, monkeypatch, change):
+    history.build_index(playback.adapter())
+    kwargs = {change: 18 if change == "account" else "different"} if change != "libraries" else {}
+    if change == "libraries":
+        monkeypatch.setattr(history, "plex_feature_library_ids", lambda *a: {"2"})
+    playback.state["history"] = []
+    result = history.build_index(playback.adapter(**kwargs))
+    assert "mindate" not in playback.calls[-1]
+    assert next(iter(result.values()))["watched_at"] == history._iso(MARKED)
+
+
+def test_shared_user_does_not_use_owner_history(playback):
+    playback.state["history"][0].accountID = 1
+    result = history.build_index(playback.adapter(account=17))
+    assert next(iter(result.values()))["watched_at"] == history._iso(MARKED)
+    assert all(call.get("accountID") in (None, 17) for call in playback.calls)
+
+
+def test_shared_user_without_history_access_uses_own_watched_state(playback):
+    playback.state["denied"] = True
+    result = history.build_index(playback.adapter(account=17))
+    assert next(iter(result.values()))["watched_at"] == history._iso(MARKED)
+    assert not list(playback.directory.glob("*playback*"))
+    assert all(call.get("accountID") in (None, 17) for call in playback.calls)
+
+
+def test_failed_user_switch_does_not_read_owner_watched_state(playback, monkeypatch):
+    playback.state["scope_ok"] = False
+    monkeypatch.setattr(history, "_pms_fetch_metadata_row", lambda *a: pytest.fail("Owner metadata must not be read"))
+    result = history.build_index(playback.adapter(account=17))
+    assert next(iter(result.values()))["watched_at"] == history._iso(PLAYED)
+    assert not list(playback.directory.glob("*playback*"))
+
+
+def test_corrupt_cache_reloads_history_instead_of_using_old_watermark(playback):
+    expected = history.build_index(playback.adapter())
+    path = history._playback_cache_path(playback.adapter(), {"1"})
+    path.write_text("{}")
+    assert history.build_index(playback.adapter()) == expected
+    assert "mindate" not in playback.calls[-1]
+
+
+def test_failed_history_read_does_not_replace_cached_plays(playback):
+    expected = history.build_index(playback.adapter())
+    path = history._playback_cache_path(playback.adapter(), {"1"})
+    original = path.read_bytes()
+    playback.state["denied"] = True
+    assert history.build_index(playback.adapter()) == expected
+    assert path.read_bytes() == original
+
+
+def test_force_refresh_rebuilds_cached_playback_history(playback):
+    history.build_index(playback.adapter())
+    playback.state["history"] = []
+    result = history.build_index(playback.adapter(), force=True)
+    assert next(iter(result.values()))["watched_at"] == history._iso(MARKED)
+    assert "mindate" not in playback.calls[-1]
+
+
+def test_unscoped_adapter_reads_full_history_without_sharing_cache(playback, monkeypatch):
+    monkeypatch.setattr(history, "_pair_scope", lambda: None)
+    first = history.build_index(playback.adapter(pair=""))
+    assert history.build_index(playback.adapter(pair="")) == first
+    assert all("mindate" not in call for call in playback.calls)
+    assert not list(playback.directory.glob("*playback*"))

--- a/tests/test_plex_snapshot_failures.py
+++ b/tests/test_plex_snapshot_failures.py
@@ -1,0 +1,107 @@
+from types import SimpleNamespace
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from providers.sync.plex import _common as common, _history as history, _progress as progress, _ratings as ratings, _watchlist as watchlist
+
+
+def page(key="1", total=2):
+    return {"MediaContainer": {"Metadata": [{"ratingKey": key, "type": "movie", "userRating": 7}], "totalSize": total}}
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    for module in (ratings, watchlist):
+        monkeypatch.setattr(module, "home_scope_enter", lambda *a: (False, False, None, None))
+        monkeypatch.setattr(module, "home_scope_exit", lambda *a: None)
+        monkeypatch.setattr(module, "normalize_discover_row", lambda row, **kw: {
+            "type": "movie", "ids": {"tmdb": row["ratingKey"], "plex": row["ratingKey"]},
+        })
+        for name in ("_info", "_warn", "_dbg"):
+            monkeypatch.setattr(module, name, lambda *a, **kw: None)
+    monkeypatch.setattr(watchlist, "active_cloud_token", lambda *a: "test-token")
+    srv = SimpleNamespace(baseurl="http://plex.test", _token="test-token")
+    return SimpleNamespace(client=SimpleNamespace(server=srv, session=object()), cfg=SimpleNamespace(),
+                           config={"plex": {"rating_workers": 1, "ratings": {"libraries": [1]}}},
+                           libraries=lambda **kw: [SimpleNamespace(key="1", type="movie")])
+
+
+@pytest.mark.parametrize("feature", ["ratings", "watchlist"])
+@pytest.mark.parametrize("failure", ["missing", "malformed", "truncated", "repeated"])
+def test_incomplete_snapshots_raise_instead_of_becoming_empty_or_partial(adapter, monkeypatch, feature, failure):
+    second = {"missing": {}, "malformed": {"MediaContainer": {"Metadata": "invalid"}},
+              "truncated": {"MediaContainer": {"Metadata": [], "totalSize": 2}}, "repeated": page()}[failure]
+    pages = iter([page(), second])
+    if feature == "watchlist":
+        monkeypatch.setattr(watchlist, "_get_container", lambda *a, **kw: next(pages))
+        module = watchlist
+    else:
+        adapter.client.server._session = SimpleNamespace(get=lambda *a, **kw: SimpleNamespace(
+            ok=True, text="{}", headers={"Content-Type": "application/json"}, json=lambda: next(pages)))
+        module = ratings
+    with pytest.raises(RuntimeError):
+        module.build_index(adapter)
+
+
+@pytest.mark.parametrize("feature", ["ratings", "watchlist"])
+def test_short_pages_follow_reported_total(adapter, monkeypatch, feature):
+    pages = iter([page("1"), page("2")])
+    paths = []
+    if feature == "watchlist":
+        monkeypatch.setattr(watchlist, "_get_container", lambda *a, **kw: next(pages))
+        module = watchlist
+    else:
+        def get(path, **kw):
+            paths.append(path)
+            return SimpleNamespace(ok=True, headers={"Content-Type": "application/json"}, json=lambda: next(pages))
+        adapter.client.server._session = SimpleNamespace(get=get)
+        module = ratings
+    result = module.build_index(adapter)
+    assert len(result) == 2
+    assert all("/library/sections/1/all" in path for path in paths)
+
+
+@pytest.mark.parametrize("failure", ["missing", "truncated", "repeated"])
+def test_progress_does_not_publish_incomplete_pages(failure):
+    first = ET.fromstring('<MediaContainer totalSize="2"><Video ratingKey="1" viewOffset="1000" /></MediaContainer>')
+    second = {"missing": None, "truncated": ET.fromstring('<MediaContainer totalSize="2" />'), "repeated": first}[failure]
+    pages = iter([first, second])
+    srv = SimpleNamespace(query=lambda path, **kw: ET.fromstring('<MediaContainer><Directory key="1" type="movie" /></MediaContainer>')
+                          if path == "/library/sections" else next(pages))
+    with pytest.raises(RuntimeError):
+        progress._fetch_resume_items(srv, allowed_library_ids={"1"})
+
+
+def test_unknown_library_identity_is_not_accepted_by_whitelist():
+    assert not common.section_allowed(SimpleNamespace(), {"1"})
+    assert common.section_allowed(SimpleNamespace(librarySectionID="1"), {"1"})
+
+
+def test_external_id_takes_precedence_over_reused_native_rating_key():
+    cat = history.HistoryCatalog()
+    cat.add({"rk": "42", "type": "movie", "ids": {"plex": "42", "tmdb": "100"}})
+    cat.add({"rk": "43", "type": "movie", "ids": {"plex": "43", "tmdb": "200"}})
+    assert cat.resolve({"type": "movie", "ids": {"plex": "42", "tmdb": "200"}}, strict=True)[0] == "43"
+    assert cat.resolve({"type": "movie", "ids": {"plex": "42", "tmdb": "300"}}, strict=True)[0] is None
+
+
+def test_native_item_with_conflicting_external_id_is_rejected():
+    obj = SimpleNamespace(type="movie", guids=[SimpleNamespace(id="tmdb://100")])
+    assert not common.native_item_matches(obj, {"type": "movie", "ids": {"tmdb": "200", "plex": "42"}})
+    assert common.native_item_matches(obj, {"type": "movie", "ids": {"tmdb": "100", "plex": "42"}})
+
+
+def test_unsupported_shared_ratings_cannot_publish_empty_snapshot(adapter):
+    adapter.client._user_scope_kind = "shared"
+    with pytest.raises(RuntimeError, match="shared_user_ratings_unsupported"):
+        ratings.build_index(adapter)
+
+
+def test_server_token_precedes_adapter_cloud_credential():
+    server = SimpleNamespace(_token="server-token", _session=SimpleNamespace(headers={"X-Plex-Token": "active-user-token"}))
+    ad = SimpleNamespace(cfg=SimpleNamespace(token="account-token"), client=SimpleNamespace(server=server))
+    assert common.active_pms_token(ad) == "active-user-token"
+    assert common.active_cloud_token(ad) == "account-token"
+    ad.client._cloud_token_suppressed = True
+    assert common.active_cloud_token(ad) is None


### PR DESCRIPTION
# Pull request

## Change

- Preserve playback history dates and cache reads per pair.
- Improve non-owner access and validate native IDs before writes.
- Reject incomplete snapshots and handle stale library selections.
- Clear playback caches when rebuilding sync state.
- Remove unused code and reduce whitelist log noise.

## Why

- Avoid repeated history reads, incorrect watched dates and matches against reused Plex IDs. 
- Keep Marked Watched and Fallback GUID gated.

## Testing

- tests/test_plex_playback_dates.py 
- tests/test_plex_native_identity.py 
- tests/test_plex_history_scan_recovery.py 
- tests/test_plex_playback_cache_recovery.py

## Issue

Relates to #1071