### PR TITLE
Fix: Plex watcher username filtering for display names

### DIFF
--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -33,6 +33,7 @@ from providers.scrobble.currently_watching import update_from_event as _cw_updat
 from providers.scrobble.media_filters import event_ignore_reason, log_media_filter_drop
 from providers.scrobble.sources import source_enabled
 from providers.sync.plex._common import stable_client_id
+from providers.sync.plex._utils import fetch_cloud_home_users, fetch_cloud_account_users
 from cw_platform.provider_instances import get_instance_block, sanitize_instance_label
 
 
@@ -401,6 +402,9 @@ class WatchService:
         self._tl_last: dict[str, tuple[int, int, int, float]] = {}
         self._last_seek_emit: dict[str, float] = {}
         self._sess_identity_cache: dict[str, dict[str, Any]] = {}
+        self._user_alias_scope: tuple[str, str] | None = None
+        self._user_alias_cache: dict[str, list[str]] = {}
+        self._user_alias_expires = 0.0
         self._offline = False
         self._offline_failures = 0
         self._offline_retry = OFFLINE_INITIAL_RETRY_SECONDS
@@ -944,6 +948,7 @@ class WatchService:
         return {
             "name": name,
             "user_name": name,
+            "user_username": name,
             "user_id": str(ctx.get("user_id") or ""),
             "account_name": "",
             "account_id": "",
@@ -1017,6 +1022,7 @@ class WatchService:
                 if not vk:
                     continue
                 user_name = ""
+                user_username = ""
                 user_id = ""
                 acc_name = ""
                 acc_id = ""
@@ -1025,6 +1031,7 @@ class WatchService:
                 u = v.find("User")
                 if u is not None:
                     user_id = str(u.get("id") or "").strip()
+                    user_username = str(u.get("username") or "").strip()
                     for attr in ("title", "name", "username"):
                         val = u.get(attr)
                         if val:
@@ -1044,6 +1051,7 @@ class WatchService:
                 row: dict[str, Any] = {
                     "name": user_name or acc_name,
                     "user_name": user_name,
+                    "user_username": user_username,
                     "user_id": user_id,
                     "account_name": acc_name,
                     "account_id": acc_id,
@@ -1109,10 +1117,41 @@ class WatchService:
             )
             return None
 
+    def _user_aliases(self, user_id: str) -> list[str]:
+        if not user_id.isdigit() or int(user_id) <= 0:
+            return []
+        plex_cfg = self._active_cfg().get("plex") or {}
+        token = str(plex_cfg.get("account_token") or plex_cfg.get("token") or "").strip()
+        scope = (str(plex_cfg.get("server_url") or ""), token)
+        if self._user_alias_scope != scope:
+            self._user_alias_scope = scope
+            self._user_alias_cache = {}
+            self._user_alias_expires = 0.0
+        if not token:
+            return []
+        now = time.monotonic()
+        if now >= self._user_alias_expires:
+            aliases: dict[str, list[str]] = {}
+            for fetch in (fetch_cloud_home_users, fetch_cloud_account_users):
+                try:
+                    rows = fetch(token, timeout=3.0)
+                except Exception:
+                    continue
+                for row in rows:
+                    uid = str(row.get("id") or "").strip()
+                    username = str(row.get("username") or "").strip()
+                    if uid.isdigit() and username:
+                        names = aliases.setdefault(str(int(uid)), [])
+                        if username not in names:
+                            names.append(username)
+            self._user_alias_cache = aliases
+            self._user_alias_expires = now + (300.0 if aliases else 60.0)
+        return list(self._user_alias_cache.get(str(int(user_id)), []))
+
     def _event_with_session_identity(self, ev: ScrobbleEvent, ident: dict[str, Any] | None) -> ScrobbleEvent:
         if not isinstance(ident, dict):
             return ev
-        clean_ident = {
+        clean_ident: dict[str, Any] = {
             "name": str(ident.get("name") or "").strip(),
             "user_name": str(ident.get("user_name") or "").strip(),
             "user_id": str(ident.get("user_id") or "").strip(),
@@ -1122,6 +1161,8 @@ class WatchService:
         }
         if not any(clean_ident.values()):
             return ev
+        username = str(ident.get("user_username") or "").strip()
+        clean_ident["user_aliases"] = [username] if username else self._user_aliases(clean_ident["user_id"])
         raw = dict(ev.raw or {})
         raw["_cw_session_identity"] = clean_ident
         account = clean_ident["name"] or ev.account

--- a/providers/scrobble/scrobble.py
+++ b/providers/scrobble/scrobble.py
@@ -586,7 +586,15 @@ class Dispatcher:
             )
             return False
 
-        if not media_account_allowed(wl, account, account_id=acc_id, account_uuid=acc_uuid, user_id=user_id, default_allow=not scoped):
+        accounts = [account]
+        aliases = ident.get("user_aliases")
+        provider = str(((cfg.get("scrobble") or {}).get("watch") or {}).get("route_provider") or "plex").lower()
+        if provider == "plex" and isinstance(aliases, list):
+            accounts.extend(alias for alias in aliases if isinstance(alias, str) and alias.strip())
+        if not any(
+            media_account_allowed(wl, name, account_id=acc_id, account_uuid=acc_uuid, user_id=user_id, default_allow=not scoped)
+            for name in accounts
+        ):
             if resolved:
                 self._throttled_route_log(
                     f"username|{account}|{ev.session_key}",

--- a/tests/test_plex_watcher_session_identity.py
+++ b/tests/test_plex_watcher_session_identity.py
@@ -6,6 +6,138 @@ from typing import Any
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def no_cloud_user_requests(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.plex import watch
+
+    monkeypatch.setattr(watch, "fetch_cloud_home_users", lambda *args, **kwargs: [])
+    monkeypatch.setattr(watch, "fetch_cloud_account_users", lambda *args, **kwargs: [])
+
+
+@pytest.mark.parametrize("whitelist", ["AccountName", "accountname", "Display Name", "id:12345"])
+@pytest.mark.parametrize("directory", ["fetch_cloud_home_users", "fetch_cloud_account_users"])
+def test_session_display_name_matches_username_by_user_id(monkeypatch: pytest.MonkeyPatch, whitelist: str, directory: str) -> None:
+    from providers.scrobble.plex import watch
+
+    monkeypatch.setattr(watch, directory, lambda *args, **kwargs: [{"id": 12345, "username": "AccountName", "title": "Display Name"}])
+    cfg = _cfg([whitelist])
+    service, sink = _service(monkeypatch, cfg, FakePlex([_session_xml("s-alias", user_name="Display Name", user_id="12345")]))
+
+    service._handle_alert(_alert("s-alias"))
+
+    assert len(sink.events) == 1
+    assert sink.events[0].account == "Display Name"
+
+
+@pytest.mark.parametrize("user_id", ["99999", ""])
+def test_same_display_name_does_not_link_different_users(monkeypatch: pytest.MonkeyPatch, user_id: str) -> None:
+    from providers.scrobble.plex import watch
+
+    monkeypatch.setattr(watch, "fetch_cloud_home_users", lambda *args, **kwargs: [{"id": 12345, "username": "AccountName", "title": "Display Name"}])
+    service, sink = _service(monkeypatch, _cfg(["AccountName"]), FakePlex([_session_xml("s-other", user_name="Display Name", user_id=user_id)]))
+
+    service._handle_alert(_alert("s-other"))
+
+    assert sink.events == []
+
+
+def test_session_username_is_used_without_cloud_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.plex import watch
+
+    calls: list[str] = []
+    monkeypatch.setattr(watch, "fetch_cloud_home_users", lambda *args, **kwargs: calls.append("home") or [])
+    xml = '<MediaContainer><Video sessionKey="s-direct"><User id="12345" title="Display Name" username="AccountName" /></Video></MediaContainer>'
+    service, sink = _service(monkeypatch, _cfg(["AccountName"]), FakePlex([xml]))
+
+    service._handle_alert(_alert("s-direct"))
+
+    assert len(sink.events) == 1
+    assert calls == []
+
+
+@pytest.mark.parametrize("restriction", ["user", "server", "empty_profile"])
+def test_username_alias_preserves_route_restrictions(monkeypatch: pytest.MonkeyPatch, restriction: str) -> None:
+    from providers.scrobble.plex import watch
+
+    monkeypatch.setattr(watch, "fetch_cloud_home_users", lambda *args, **kwargs: [{"id": 12345, "username": "AccountName"}])
+    cfg = _cfg(["AccountName"])
+    filters = cfg["scrobble"]["watch"]["filters"]
+    if restriction == "user":
+        filters["user_id"] = "99999"
+    elif restriction == "server":
+        filters["server_uuid_whitelist"] = ["other-server"]
+    else:
+        filters["username_whitelist"] = []
+        cfg["scrobble"]["watch"]["route_profile_id"] = "profile-test"
+    service, sink = _service(monkeypatch, cfg, FakePlex([_session_xml("s-filter", user_name="Display Name", user_id="12345")]))
+
+    service._handle_alert(_alert("s-filter"))
+
+    assert sink.events == []
+
+
+def test_user_alias_cache_refreshes_and_isolates_profiles(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.plex import watch
+
+    clock = [100.0]
+    calls: list[str] = []
+    rows = [{"id": 12345, "username": "AccountName"}]
+
+    def fetch(token: str, **kwargs: Any) -> list[dict[str, Any]]:
+        calls.append(token)
+        return list(rows)
+
+    monkeypatch.setattr(watch.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(watch, "fetch_cloud_home_users", fetch)
+    cfg = _cfg(["AccountName"])
+    service, _ = _service(monkeypatch, cfg, FakePlex([]))
+    assert service._user_aliases("12345") == ["AccountName"]
+    assert service._user_aliases("12345") == ["AccountName"]
+    assert len(calls) == 1
+    rows[0] = {"id": 12345, "username": "RenamedAccount"}
+    clock[0] += 301
+    assert service._user_aliases("12345") == ["RenamedAccount"]
+    assert len(calls) == 2
+    rows.clear()
+    cfg["plex"]["account_token"] = "other-test-token"
+    assert service._user_aliases("12345") == []
+    assert len(calls) == 3
+    rows.append({"id": 12345, "username": "NewProfileAccount"})
+    other, _ = _service(monkeypatch, cfg, FakePlex([]))
+    assert other._user_aliases("12345") == ["NewProfileAccount"]
+    assert service._user_aliases("12345") == []
+    clock[0] += 61
+    assert service._user_aliases("12345") == ["NewProfileAccount"]
+
+
+def test_cloud_failure_does_not_guess_username(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.plex import watch
+
+    def failed(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        raise RuntimeError("unavailable")
+
+    monkeypatch.setattr(watch, "fetch_cloud_home_users", failed)
+    monkeypatch.setattr(watch, "fetch_cloud_account_users", failed)
+    service, sink = _service(monkeypatch, _cfg(["AccountName"]), FakePlex([_session_xml("s-failed", user_name="Display Name", user_id="12345")]))
+
+    service._handle_alert(_alert("s-failed"))
+
+    assert sink.events == []
+
+
+def test_plex_aliases_do_not_apply_to_other_source_providers(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.scrobble import Dispatcher, from_plex_pssn
+
+    cfg = _cfg(["AccountName"])
+    cfg["scrobble"]["watch"]["route_provider"] = "jellyfin"
+    service, _ = _service(monkeypatch, cfg, FakePlex([]))
+    event = from_plex_pssn(_alert("s-source"))
+    assert event is not None
+    event = service._event_with_session_identity(event, {"name": "Display Name", "user_username": "AccountName", "user_id": "12345"})
+
+    assert Dispatcher([], cfg_provider=lambda: cfg)._identity_allowed(event, cfg) is False
+
+
 class CaptureSink:
     def __init__(self) -> None:
         self.events: list[Any] = []


### PR DESCRIPTION
# Pull request

## Change

- Match Plex display names to account usernames by user ID, with cached lookups per watcher profile.

## Why

- Plex can report a display name during playback while the user picker saves the username, causing valid events to be filtered out.

## Testing
- tests/test_plex_watcher_session_identity.py

## Issue
Relates to #1071