### PR TITLE
Fix: episode scrobble matching

### DIFF
--- a/providers/scrobble/_jellyfin_emby.py
+++ b/providers/scrobble/_jellyfin_emby.py
@@ -91,15 +91,14 @@ class JellyfinEmbySink(MediaServerSink):
         if str(row.get("Type") or "").lower() != item["type"] or not self._in_scope(adapter, row, allowed):
             return False
         own, wanted = _ids(row), item.get("ids") or {}
-        if any(wanted[k] != own[k] for k in set(wanted) & set(own)):
-            return False
         if ids_match(wanted, own):
             return True
         show_ids = item.get("show_ids") or {}
         if (item["type"] != "episode" or not show_ids or item.get("season") is None or item.get("episode") is None
                 or row.get("ParentIndexNumber") != item["season"] or row.get("IndexNumber") != item["episode"] or not row.get("SeriesId")):
             return False
-        return ids_match(show_ids, _ids(self._fetch(adapter, str(row["SeriesId"]))))
+        show = self._fetch(adapter, str(row["SeriesId"]))
+        return show.get("Type") == "Series" and ids_match(show_ids, _ids(show))
 
     def _resolve(self, adapter: Any, item: dict, allowed: set[str]) -> dict:
         candidates: dict[str, dict] = {}

--- a/providers/scrobble/kodi/sink.py
+++ b/providers/scrobble/kodi/sink.py
@@ -71,8 +71,6 @@ class KodiSink(MediaServerSink):
         if row.get("_kind") != item["type"] or not path_allowed(adapter.config, feature, row.get("file"), self._instance_id):
             return False
         own, wanted = _ids(row), item.get("ids") or {}
-        if any(wanted[k] != own[k] for k in set(wanted) & set(own)):
-            return False
         if ids_match(wanted, own):
             return True
         if (item["type"] != "episode" or not item.get("show_ids") or item.get("season") is None or item.get("episode") is None

--- a/providers/scrobble/plex/sink.py
+++ b/providers/scrobble/plex/sink.py
@@ -25,8 +25,6 @@ def _matches(server: Any, obj: Any, item: Mapping[str, Any], allowed: set[str]) 
         return False
     own = _object_ids(obj)
     wanted = item.get("ids") or {}
-    if any(str(wanted[k]) != str(own[k]) for k in set(wanted) & set(own)):
-        return False
     if item["type"] == "movie":
         return _id_match(wanted, own)
     if _id_match(wanted, own):
@@ -37,7 +35,10 @@ def _matches(server: Any, obj: Any, item: Mapping[str, Any], allowed: set[str]) 
     if getattr(obj, "parentIndex", None) != item["season"] or getattr(obj, "index", None) != item["episode"]:
         return False
     parent = getattr(obj, "grandparentRatingKey", None)
-    return bool(parent and _id_match(show_ids, _object_ids(server.fetchItem(int(parent)))))
+    if not parent:
+        return False
+    show = server.fetchItem(int(parent))
+    return getattr(show, "type", "") == "show" and _id_match(show_ids, _object_ids(show))
 
 
 def _resolve(adapter: Any, item: Mapping[str, Any], allowed: set[str]) -> Any:

--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -277,13 +277,11 @@ def _as_set_str(v: Any) -> set[str]:
 
 def _ids_desc(ids: dict[str, Any] | None) -> str:
     d = ids or {}
-    for k in ("trakt", "tmdb", "imdb", "tvdb"):
-        if d.get(k):
-            return f"{k}:{d[k]}"
-    for k in ("trakt_show", "imdb_show", "tmdb_show", "tvdb_show"):
-        if d.get(k):
-            return f"{k.replace('_show', '')}:{d[k]}"
-    return "none"
+    return ", ".join(
+        f"{k}:{d[k]}"
+        for k in ("plex", "trakt", "tmdb", "imdb", "tvdb", "trakt_show", "imdb_show", "tmdb_show", "tvdb_show")
+        if d.get(k)
+    ) or "none"
 
 
 def _iter_guid_strings(value: Any) -> Iterable[str]:
@@ -651,7 +649,7 @@ class WatchService:
         self._max_seen[sk] = max(pct_i, self._max_seen.get(sk, 0))
         accepted = bool(self._dispatch.dispatch(ev2))
         if not accepted:
-            self._throttled_route_filtered_log(ev2, "seek update")
+            self._throttled_route_filtered_log(ev2, "seek update", dispatched=True)
             self._clear_currently_watching(ev2)
             return
         try:
@@ -1316,14 +1314,15 @@ class WatchService:
             self._dbg(f"event filtered: user={_mask_account(ev.account)} server={ev.server_uuid} sess={ev.session_key}")
             self._filtered_ts[key] = now
 
-    def _throttled_route_filtered_log(self, ev: ScrobbleEvent, kind: str = "event") -> None:
-        if not str(ev.account or "").strip():
+    def _throttled_route_filtered_log(self, ev: ScrobbleEvent, kind: str = "event", *, dispatched: bool = False) -> None:
+        if not dispatched and not str(ev.account or "").strip():
             return
-        key = f"{kind}|{ev.account}|{ev.server_uuid}|{ev.session_key or self._find_rating_key(ev.raw or {}) or '?'}"
+        outcome = "not delivered" if dispatched else "filtered"
+        key = f"{outcome}|{kind}|{ev.account}|{ev.server_uuid}|{ev.session_key or self._find_rating_key(ev.raw or {}) or '?'}"
         if key in self._route_filtered_ts:
             return
         self._route_filtered_ts[key] = time.time()
-        self._dbg(f"{kind} filtered by route dispatcher: user={_mask_account(ev.account)} server={ev.server_uuid} sess={ev.session_key}")
+        self._dbg(f"{kind} {outcome} by route dispatcher: user={_mask_account(ev.account)} server={ev.server_uuid} sess={ev.session_key}")
 
     def _clear_currently_watching(self, ev: ScrobbleEvent) -> None:
         try:
@@ -1416,11 +1415,11 @@ class WatchService:
                 if prev_acc:
                     ev = ScrobbleEvent(**{**ev.__dict__, "account": prev_acc})
 
-            if not str(ev.account or "").strip() and self._needs_user_resolution():
+            if not str(ev.account or "").strip():
                 shared = self._shared_instance_identity()
                 if shared:
                     ev = self._event_with_session_identity(ev, shared)
-                else:
+                elif self._needs_user_resolution():
                     ident = self._resolve_session_identity(ev.session_key)
                     ev = self._event_with_session_identity(ev, ident)
                     if not str(ev.account or "").strip() and getattr(self, "_no_sessions_access", False):
@@ -1552,17 +1551,17 @@ class WatchService:
                             self._dbg(f"suppress duplicate stop sess={sk} p={ev.progress}")
                         return
 
+            self._log(
+                f"incoming '{ev.action}' user='{_mask_account(ev.account)}' server='{ev.server_uuid}' media='{_media_name(ev)}' sess={ev.session_key}",
+                "DEBUG",
+            )
+            self._log(f"ids resolved: {_media_name(ev)} -> {_ids_desc(ev.ids)} sess={ev.session_key}", "DEBUG")
             accepted = bool(self._dispatch.dispatch(ev))
             if not accepted:
-                self._throttled_route_filtered_log(ev)
+                self._throttled_route_filtered_log(ev, dispatched=True)
                 self._clear_currently_watching(ev)
                 return
 
-            self._log(
-                f"incoming 'playing' user='{_mask_account(ev.account)}' server='{ev.server_uuid}' media='{_media_name(ev)}'",
-                "DEBUG",
-            )
-            self._log(f"ids resolved: {_media_name(ev)} -> {_ids_desc(ev.ids)}", "DEBUG")
             try:
                 _cw_update("plex", ev, duration_ms=d, provider_instance=str(self._instance_id or "default"))
             except Exception:

--- a/tests/test_media_server_scrobble_sinks.py
+++ b/tests/test_media_server_scrobble_sinks.py
@@ -247,6 +247,59 @@ def test_media_server_episode_show_ids_and_specials(media_server):
     assert http.rows["ep"]["UserData"]["Played"] and not http.rows["show"]["UserData"]["Played"]
 
 
+@pytest.mark.parametrize("season", [0, 1])
+@pytest.mark.parametrize("action,progress", [("start", 20), ("stop", 95)])
+def test_episode_conflict_matches_verified_show_and_coordinates(media_server, season, action, progress):
+    provider, cls, http, _ = media_server
+    http.rows = {"show": row("show", "Series", {"Tmdb": "42", "Tvdb": "43"}),
+                 "ep": row("ep", "Episode", {"Imdb": "tt0000999", "Tvdb": "456"},
+                           SeriesId="show", ParentIndexNumber=season, IndexNumber=2)}
+    ev = event(action=action, progress=progress, media_type="episode", season=season, number=2,
+               ids={"imdb": "tt0000111", "tvdb": "456", "tmdb_show": "42", "tvdb_show": "43"})
+    assert cls().send(ev, config(provider))["ok"]
+    assert bool(http.rows["ep"]["UserData"]["Played"]) == (action == "stop")
+    assert not http.rows["show"]["UserData"]["Played"]
+    assert any(c[0] == "POST" for c in http.calls)
+
+
+@pytest.mark.parametrize("case", ["different_show", "conflicting_show_id", "wrong_season", "wrong_episode",
+                                  "no_show_ids", "missing_coordinates", "not_a_show", "library", "ambiguous"])
+def test_episode_conflict_fallback_still_rejects_invalid_matches(media_server, case):
+    provider, cls, http, _ = media_server
+    cfg = config(provider)
+    ids = {"imdb": "tt0000111", "tvdb": "456", "tmdb_show": "42", "tvdb_show": "43"}
+    http.rows = {"show": row("show", "Series", {"Tmdb": "42", "Tvdb": "43"}),
+                 "ep": row("ep", "Episode", {"Imdb": "tt0000999", "Tvdb": "456"},
+                           SeriesId="show", ParentIndexNumber=1, IndexNumber=2)}
+    if case == "different_show":
+        http.rows["show"]["ProviderIds"] = {"Tmdb": "999"}
+    elif case == "conflicting_show_id":
+        http.rows["show"]["ProviderIds"]["Tvdb"] = "999"
+    elif case == "wrong_season":
+        http.rows["ep"]["ParentIndexNumber"] = 2
+    elif case == "wrong_episode":
+        http.rows["ep"]["IndexNumber"] = 3
+    elif case == "no_show_ids":
+        ids = {"imdb": "tt0000111", "tvdb": "456"}
+    elif case == "not_a_show":
+        http.rows["show"]["Type"] = "Movie"
+    elif case == "library":
+        cfg[provider]["history"] = {"libraries": ["other"]}
+    elif case == "ambiguous":
+        http.rows["ep2"] = {**copy.deepcopy(http.rows["ep"]), "Id": "ep2"}
+    ev = event(media_type="episode", ids=ids, season=None if case == "missing_coordinates" else 1, number=2)
+    assert not cls().send(ev, cfg)["ok"]
+    assert not any(c[0] == "POST" for c in http.calls)
+
+
+def test_direct_episode_id_match_allows_different_numbering(media_server):
+    provider, cls, http, _ = media_server
+    http.rows = {"ep": row("ep", "Episode", {"Tmdb": "123"}, ParentIndexNumber=2, IndexNumber=3)}
+    ev = event(media_type="episode", ids={"tmdb": "123"}, season=1, number=2)
+    assert cls().send(ev, config(provider))["ok"]
+    assert http.rows["ep"]["UserData"]["Played"]
+
+
 def test_media_server_id_only_lookup_catalog_is_reused(media_server):
     provider, cls, http, _ = media_server
     if provider == "emby":
@@ -464,6 +517,50 @@ def test_kodi_episode_show_ids_and_specials(kodi):
     ev = event(media_type="episode", ids={"tmdb_show": "42", "tmdb": "42"}, season=0, number=1)
     assert cls().send(ev, config("kodi"))["ok"]
     assert client.rows["episode:20"]["playcount"] == 1 and client.rows["show:30"]["playcount"] == 0
+
+
+@pytest.mark.parametrize("season", [0, 1])
+@pytest.mark.parametrize("action,progress", [("start", 20), ("stop", 95)])
+def test_kodi_episode_conflict_accepts_verified_show_and_coordinates(kodi, season, action, progress):
+    cls, client, _ = kodi
+    client.rows = {"show:30": kodi_row(30, "show"),
+                   "episode:20": kodi_row(20, "episode", uniqueid={"imdb": "tt0000999", "tvdb": "456"}, tvshowid=30, season=season, episode=2)}
+    ev = event(action=action, progress=progress, media_type="episode", ids={"imdb": "tt0000111", "tvdb": "456", "tmdb_show": "42"}, season=season, number=2)
+    assert cls().send(ev, config("kodi"))["ok"]
+    assert client.rows["episode:20"]["playcount"] == (1 if action == "stop" else 0)
+    assert client.rows["show:30"]["playcount"] == 0
+    assert any(c[0].startswith("VideoLibrary.Set") for c in client.calls)
+
+
+@pytest.mark.parametrize("case", ["show", "season", "episode", "missing_show", "missing_coordinates", "library", "ambiguous"])
+def test_kodi_episode_conflict_fallback_rejects_invalid_matches(kodi, case):
+    cls, client, _ = kodi
+    cfg = config("kodi")
+    ids = {"imdb": "tt0000111", "tvdb": "456", "tmdb_show": "42", "tvdb_show": "43"}
+    client.rows = {"show:30": kodi_row(30, "show", uniqueid={"tmdb": "42", "tvdb": "43"}),
+                   "episode:20": kodi_row(20, "episode", uniqueid={"imdb": "tt0000999", "tvdb": "456"}, tvshowid=30, season=1, episode=2)}
+    if case == "show":
+        client.rows["show:30"]["uniqueid"]["tvdb"] = "999"
+    elif case == "season":
+        client.rows["episode:20"]["season"] = 2
+    elif case == "episode":
+        client.rows["episode:20"]["episode"] = 3
+    elif case == "missing_show":
+        ids = {"imdb": "tt0000111", "tvdb": "456"}
+    elif case == "library":
+        cfg["kodi"]["history"] = {"libraries": ["/somewhere/else"]}
+    elif case == "ambiguous":
+        client.rows["episode:21"] = {**copy.deepcopy(client.rows["episode:20"]), "episodeid": 21}
+    ev = event(media_type="episode", ids=ids, season=None if case == "missing_coordinates" else 1, number=2)
+    assert not cls().send(ev, cfg)["ok"]
+    assert not any(c[0].startswith("VideoLibrary.Set") for c in client.calls)
+
+
+def test_kodi_direct_episode_id_keeps_different_numbering_support(kodi):
+    cls, client, _ = kodi
+    client.rows = {"episode:20": kodi_row(20, "episode", uniqueid={"tmdb": "100"}, season=2, episode=3)}
+    assert cls().send(event(media_type="episode", ids={"tmdb": "100"}, season=1, number=2), config("kodi"))["ok"]
+    assert client.rows["episode:20"]["playcount"] == 1
 
 
 def test_kodi_id_only_catalog_reused_and_isolated_by_current_profile(kodi):

--- a/tests/test_plex_scrobble_sink.py
+++ b/tests/test_plex_scrobble_sink.py
@@ -228,6 +228,58 @@ def test_episode_matches_show_ids_and_coordinates(harness):
     assert episode.viewCount == 1 and show.viewCount == 0
 
 
+@pytest.mark.parametrize("season", [0, 1])
+@pytest.mark.parametrize("action,progress", [("start", 20), ("stop", 95)])
+def test_episode_conflicting_id_accepts_verified_show_and_coordinates(harness, season, action, progress):
+    server, _, _ = harness
+    episode = media("20", "episode", {"imdb": "tt0000999", "tvdb": "456"}, parentIndex=season, index=2, grandparentRatingKey="30")
+    show = media("30", "show", {"tmdb": "42"}, episodes=lambda **kw: [episode])
+    server.items = {"20": episode, "30": show}
+    ev = event(action=action, progress=progress, media_type="episode", ids={"imdb": "tt0000111", "tvdb": "456", "tmdb_show": "42"}, season=season, number=2)
+    assert plex.PlexSink().send(ev, config())["ok"]
+    assert episode.viewCount == (1 if action == "stop" else 0)
+    assert show.viewCount == 0
+    assert any(call[1] for call in server.calls)
+
+
+@pytest.mark.parametrize("case", ["show", "season", "episode", "missing_show", "missing_coordinates", "parent_type", "library", "ambiguous"])
+def test_episode_conflicting_id_fallback_rejects_invalid_matches(harness, case):
+    server, _, _ = harness
+    episode = media("20", "episode", {"imdb": "tt0000999", "tvdb": "456"}, parentIndex=1, index=2, grandparentRatingKey="30")
+    show = media("30", "show", {"tmdb": "42", "tvdb": "43"}, episodes=lambda **kw: [episode])
+    server.items = {"20": episode, "30": show}
+    cfg = config()
+    ids = {"imdb": "tt0000111", "tvdb": "456", "tmdb_show": "42", "tvdb_show": "43"}
+    if case == "show":
+        show.guids = [SimpleNamespace(id="tmdb://42"), SimpleNamespace(id="tvdb://999")]
+    elif case == "season":
+        episode.parentIndex = 2
+    elif case == "episode":
+        episode.index = 3
+    elif case == "missing_show":
+        ids = {"imdb": "tt0000111", "tvdb": "456"}
+    elif case == "parent_type":
+        show.type = "movie"
+    elif case == "library":
+        cfg["plex"]["history"] = {"libraries": [2]}
+    elif case == "ambiguous":
+        duplicate = copy.deepcopy(episode)
+        duplicate.ratingKey = "21"
+        server.items["21"] = duplicate
+        show.episodes = lambda **kw: [episode, duplicate]
+    ev = event(media_type="episode", ids=ids, season=None if case == "missing_coordinates" else 1, number=2)
+    assert not plex.PlexSink().send(ev, cfg)["ok"]
+    assert not any(call[1] for call in server.calls)
+
+
+def test_direct_episode_id_keeps_different_numbering_support(harness):
+    server, _, _ = harness
+    episode = media("20", "episode", {"tmdb": "100"}, parentIndex=2, index=3)
+    server.items = {"20": episode}
+    assert plex.PlexSink().send(event(media_type="episode", ids={"tmdb": "100"}, season=1, number=2), config())["ok"]
+    assert episode.viewCount == 1
+
+
 def test_duplicate_episode_coordinates_are_rejected(harness):
     server, _, _ = harness
     episodes = [media(key, "episode", {"tmdb": "100"}, parentIndex=1, index=2, grandparentRatingKey="30") for key in ("20", "21")]

--- a/tests/test_plex_watcher_session_identity.py
+++ b/tests/test_plex_watcher_session_identity.py
@@ -767,6 +767,41 @@ def test_shared_instance_uses_plex_tv_identity_instead_of_the_fallback(monkeypat
     assert plex.queries == []
 
 
+@pytest.mark.parametrize("whitelist", [None, []])
+@pytest.mark.parametrize("state", ["playing", "paused", "stopped"])
+def test_shared_identity_without_user_filter_requires_no_requests(monkeypatch: pytest.MonkeyPatch, whitelist: list[str] | None, state: str) -> None:
+    from providers.scrobble.plex import watch
+
+    def unexpected(*args: Any, **kwargs: Any) -> Any:
+        pytest.fail("Known shared identity must not perform a network lookup")
+
+    monkeypatch.setattr(watch, "fetch_cloud_home_users", unexpected)
+    monkeypatch.setattr(watch, "fetch_cloud_account_users", unexpected)
+    cfg = _cfg(whitelist)
+    plex = FakePlex([])
+    service, sink = _service_with_account_ctx(monkeypatch, cfg, plex, {"owned": False, "name": "shared-user", "user_id": "12345"})
+    monkeypatch.setattr(service, "_resolve_session_identity", unexpected)
+    assert not service._needs_user_resolution()
+
+    service._handle_alert(_alert("s-known", state=state))
+
+    assert len(sink.events) == 1
+    assert sink.events[0].account == "shared-user"
+    assert sink.events[0].raw["_cw_session_identity"]["user_id"] == "12345"
+    assert plex.queries == []
+
+
+@pytest.mark.parametrize("ctx", [None, {"owned": True, "name": "owner"}])
+def test_no_user_filter_does_not_guess_an_owner_identity(monkeypatch: pytest.MonkeyPatch, ctx: dict[str, Any] | None) -> None:
+    service, sink = _service_with_account_ctx(monkeypatch, _cfg([]), FakePlex([]), ctx)
+
+    service._handle_alert(_alert("s-unknown"))
+
+    assert len(sink.events) == 1
+    assert not sink.events[0].account
+    assert service._plex.queries == []
+
+
 def test_owned_instance_never_probes_plex_tv(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = _cfg(["Carmen"])
     plex = FakePlex([_session_xml("41", user_name="Carmen", user_id="176467484")])
@@ -999,3 +1034,39 @@ def test_route_filtered_log_is_emitted_once_per_session(monkeypatch: pytest.Monk
 
     assert sink.events == []
     assert len([m for m in messages if m.startswith("event filtered by route dispatcher")]) == 1
+
+
+@pytest.mark.parametrize("whitelist", [["owner"], []])
+@pytest.mark.parametrize("media_type", ["movie", "episode"])
+def test_failed_delivery_logs_identity_before_dispatch(monkeypatch: pytest.MonkeyPatch, whitelist: list[str], media_type: str) -> None:
+    cfg = _cfg(whitelist)
+    service, sink = _service(monkeypatch, cfg, FakePlex([_session_xml("s-failed", user_name="owner", user_id="u1")]))
+    messages: list[str] = []
+    monkeypatch.setattr(service, "_log", lambda msg, *args: messages.append(str(msg)))
+    monkeypatch.setattr(service, "_dbg", lambda msg: messages.append(str(msg)))
+
+    def fail_delivery(event: Any, **kwargs: Any) -> dict[str, Any]:
+        messages.append("delivery attempted")
+        return {"ok": False, "retryable": False, "error": "unmatched_in_jellyfin"}
+
+    monkeypatch.setattr(sink, "send", fail_delivery)
+    service._handle_alert(_alert("s-failed", media_type=media_type))
+
+    attempt = messages.index("delivery attempted")
+    incoming = next(i for i, msg in enumerate(messages) if msg.startswith("incoming 'start'"))
+    ids = next(i for i, msg in enumerate(messages) if msg.startswith("ids resolved:"))
+    assert incoming < ids < attempt
+    assert "sess=s-failed" in messages[incoming]
+    assert "imdb:tt0000001" in messages[ids]
+    assert "sess=s-failed" in messages[ids]
+    assert any(msg.startswith("event not delivered by route dispatcher") for msg in messages)
+    assert not any("filtered by route dispatcher" in msg for msg in messages)
+    if not whitelist:
+        assert any("user=unknown" in msg for msg in messages if "not delivered" in msg)
+
+
+def test_id_diagnostics_preserve_episode_and_show_namespaces() -> None:
+    from providers.scrobble.plex.watch import _ids_desc
+
+    assert _ids_desc({"plex": "42", "tmdb": "123", "imdb": "tt0000001", "tmdb_show": "456"}) == "plex:42, tmdb:123, imdb:tt0000001, tmdb_show:456"
+    assert _ids_desc({}) == "none"


### PR DESCRIPTION
# Pull request

## Change
- Allow matching show IDs and season/episode numbers to resolve episode ID conflicts in Plex, Jellyfin, Emby and Kodi.
- Keep known Plex shared-account usernames when filters are empty.
- Log titles and IDs before delivery and stop labelling delivery failures as filtered events.

## Why
Valid episodes could fail to scrobble, while missing details and unknown usernames made troubleshooting harder.

## Testing
- tests/test_media_server_scrobble_sinks.py
- tests/test_plex_scrobble_sink.py
- tests/test_plex_watcher_session_identity.py

## Issue
Relates to #1071
