### PR TITLE
Change: clarify skipped scrobble progress logs

### DIFF
--- a/providers/scrobble/_media_server.py
+++ b/providers/scrobble/_media_server.py
@@ -184,8 +184,11 @@ class MediaServerSink:
                 now = time.monotonic()
                 sent = self._sent.get(session)
                 if sent and now - sent[0] < CACHE_TTL:
-                    if sent[1] == "complete" or (event.action == "start" and sent[1] == "start" and abs(progress - sent[2]) < step):
+                    if sent[1] == "complete":
                         return {"ok": True, "skipped": True, "reason": "duplicate"}
+                    if event.action == "start" and sent[1] == "start" and abs(progress - sent[2]) < step:
+                        reason = "duplicate" if progress == sent[2] else "progress_step_not_reached"
+                        return {"ok": True, "skipped": True, "reason": reason}
                 result = self._deliver(adapter, item, complete, progress)
                 if not result.get("ok") or result.get("skipped"):
                     return result

--- a/tests/test_plex_scrobble_sink.py
+++ b/tests/test_plex_scrobble_sink.py
@@ -115,7 +115,8 @@ def test_resume_uses_destination_duration_stopped_timeline_and_throttles(harness
     server, _, _ = harness
     dest = plex.PlexSink()
     assert dest.send(event(action="start", progress=30, duration_ms=200_000), config())["ok"]
-    assert dest.send(event(action="start", progress=31), config())["reason"] == "duplicate"
+    assert dest.send(event(action="start", progress=30), config())["reason"] == "duplicate"
+    assert dest.send(event(action="start", progress=31), config())["reason"] == "progress_step_not_reached"
     assert dest.send(event(action="pause", progress=32), config())["ok"]
     writes = [x for x in server.calls if x[1]]
     assert [x[2]["time"] for x in writes] == [30_000, 32_000]


### PR DESCRIPTION
# Pull request

## Change

- Use `progress_step_not_reached` when progress changed but is below the update threshold. 
- Keep `duplicate` for repeated progress or completed sessions.

## Why

Normal progress throttling was logged as duplicate, which was confusing. Scrobble behavior stays the same.

## Testing

- tests/test_plex_scrobble_sink.py

## Issue

NA.