### PR TITLE
Fix: disabled watcher routes continuing to scrobble

### DIFF
--- a/providers/scrobble/plex/watch.py
+++ b/providers/scrobble/plex/watch.py
@@ -1345,6 +1345,8 @@ class WatchService:
             pass
 
     def _handle_alert(self, alert: dict[str, Any]) -> None:
+        if self._stop.is_set():
+            return
         try:
             t = (alert.get("type") or "").lower()
         except Exception:
@@ -1556,6 +1558,8 @@ class WatchService:
                 "DEBUG",
             )
             self._log(f"ids resolved: {_media_name(ev)} -> {_ids_desc(ev.ids)} sess={ev.session_key}", "DEBUG")
+            if self._stop.is_set():
+                return
             accepted = bool(self._dispatch.dispatch(ev))
             if not accepted:
                 self._throttled_route_filtered_log(ev, dispatched=True)
@@ -1576,6 +1580,9 @@ class WatchService:
             
     def start(self) -> None:
         self._stop.clear()
+        self._run()
+
+    def _run(self) -> None:
         cfg = self._cfg_provider() or {}
         if not source_enabled(cfg, "watcher"):
             self._log("Watcher disabled by config; not starting", "INFO")
@@ -1590,10 +1597,14 @@ class WatchService:
                     return
                 self._plex = PlexServer(base, token)
                 self._refresh_account_context()
+                if self._stop.is_set():
+                    break
                 self._listener = self._plex.startAlertListener(
                     callback=self._handle_alert,
                     callbackError=lambda e: self._mark_offline(e if isinstance(e, Exception) else RuntimeError(str(e))),
                 )
+                if self._stop.is_set():
+                    break
                 self._attempt = 0
                 self._mark_online()
                 self._log(f"Watcher connected; inst={self._instance_display()}", lvl)
@@ -1601,6 +1612,14 @@ class WatchService:
                     time.sleep(0.5)
             except Exception as e:
                 self._mark_offline(e)
+            finally:
+                listener = self._listener
+                self._listener = None
+                if listener is not None:
+                    try:
+                        listener.stop()
+                    except Exception:
+                        pass
             if self._stop.is_set():
                 break
             self._attempt += 1
@@ -1623,7 +1642,8 @@ class WatchService:
     def start_async(self) -> None:
         if self._bg and self._bg.is_alive():
             return
-        self._bg = threading.Thread(target=self.start, name="PlexWatch", daemon=True)
+        self._stop.clear()
+        self._bg = threading.Thread(target=self._run, name="PlexWatch", daemon=True)
         self._bg.start()
 
     def is_alive(self) -> bool:

--- a/providers/scrobble/routes.py
+++ b/providers/scrobble/routes.py
@@ -302,6 +302,7 @@ def build_route_cfg(cfg: dict[str, Any], route: dict[str, Any]) -> dict[str, Any
 
     w["filters"] = _deep_clone(r.get("filters") or {})
     w["route_id"] = r["id"]
+    w["route_enabled"] = r["enabled"]
     w["route_profile_id"] = route_assigned_profile_id(out, r)
     w["route_effective_profile_id"] = route_profile_id(out, r)
     w["route_provider"] = r["provider"]

--- a/providers/scrobble/scrobble.py
+++ b/providers/scrobble/scrobble.py
@@ -476,6 +476,8 @@ class Dispatcher:
             return False
 
     def _passes_filters(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> bool:
+        if not ((cfg.get("scrobble") or {}).get("watch") or {}).get("route_enabled", True):
+            return False
         cache_key: str | None = None
         if ev.session_key:
             cache_key = f"{ev.session_key}|{_norm_user(ev.account or '')}|{str(ev.server_uuid or '').strip().lower()}"
@@ -506,6 +508,8 @@ class Dispatcher:
             return True
 
     def _identity_allowed(self, ev: ScrobbleEvent, cfg: dict[str, Any]) -> bool:
+        if not ((cfg.get("scrobble") or {}).get("watch") or {}).get("route_enabled", True):
+            return False
         filt = (((cfg.get("scrobble") or {}).get("watch") or {}).get("filters") or {})
         if not isinstance(filt, dict):
             filt = {}

--- a/providers/scrobble/watch_manager.py
+++ b/providers/scrobble/watch_manager.py
@@ -260,7 +260,11 @@ def _route_cfg_provider(route_id: str) -> Callable[[], dict[str, Any]]:
     def _provider() -> dict[str, Any]:
         cfg = load_config() or {}
         built = build_route_cfg_by_id(cfg, rid)
-        return built if isinstance(built, dict) else {}
+        if not isinstance(built, dict):
+            return {"scrobble": {"watch": {"route_id": rid, "route_enabled": False}}}
+        if not source_enabled(cfg, "watcher"):
+            built["scrobble"]["watch"]["route_enabled"] = False
+        return built
 
     return _provider
 

--- a/tests/test_plex_watcher_session_identity.py
+++ b/tests/test_plex_watcher_session_identity.py
@@ -496,6 +496,61 @@ def _identity_logs(monkeypatch: pytest.MonkeyPatch, service: Any) -> list[str]:
     return lines
 
 
+def test_stopped_watcher_ignores_late_alert(monkeypatch: pytest.MonkeyPatch) -> None:
+    service, sink = _service(monkeypatch, _cfg(["owner"]), FakePlex([_session_xml("late", user_name="owner", user_id="1")]))
+    service.stop()
+    service._handle_alert(_alert("late"))
+    assert sink.events == []
+
+
+def test_listener_created_during_stop_is_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.plex import watch
+
+    service, _ = _service(monkeypatch, _cfg(["owner"]), FakePlex([]))
+    closed = []
+
+    class Listener:
+        def stop(self):
+            closed.append(True)
+
+    class Server:
+        def startAlertListener(self, **kwargs):
+            service.stop()
+            return Listener()
+
+    monkeypatch.setattr(watch, "PlexServer", lambda *args: Server())
+    monkeypatch.setattr(service, "_refresh_account_context", lambda: None)
+    service.start()
+    assert closed == [True]
+    assert service._listener is None
+
+
+def test_async_stop_before_thread_starts_is_preserved(monkeypatch: pytest.MonkeyPatch) -> None:
+    from providers.scrobble.plex import watch
+
+    service, _ = _service(monkeypatch, _cfg(["owner"]), FakePlex([]))
+    targets = []
+    connections = []
+
+    class DeferredThread:
+        def __init__(self, *, target, **kwargs):
+            targets.append(target)
+
+        def start(self):
+            pass
+
+        def is_alive(self):
+            return False
+
+    monkeypatch.setattr(watch.threading, "Thread", DeferredThread)
+    monkeypatch.setattr(watch, "PlexServer", lambda *args: connections.append(args))
+    service.start_async()
+    service.stop()
+    targets[0]()
+    assert service.is_stopping()
+    assert connections == []
+
+
 def test_identity_log_reports_resolution_details(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = _cfg(["Carmen"])
     plex = FakePlex([_session_xml("31", user_name="Carmen", user_id="176467484")])

--- a/tests/test_watch_route_disable.py
+++ b/tests/test_watch_route_disable.py
@@ -1,0 +1,49 @@
+from dataclasses import replace
+from typing import Any
+
+import pytest
+
+from providers.scrobble.scrobble import Dispatcher, ScrobbleEvent
+from providers.scrobble import watch_manager
+
+
+@pytest.mark.parametrize("change", ["disable", "delete", "source", "global"])
+@pytest.mark.parametrize("delivered", [False, True])
+def test_existing_dispatcher_stops_sending_after_route_disabled(monkeypatch, change, delivered):
+    route = {"id": "R1", "enabled": True, "provider": "plex", "sink": "mdblist"}
+    cfg = {"scrobble": {"enabled": True, "sources": {"watcher": True}, "watch": {"routes": [route]}}}
+    monkeypatch.setattr(watch_manager, "load_config", lambda: cfg)
+    calls = []
+
+    class Sink:
+        def send(self, event, cfg=None) -> Any:
+            calls.append(event)
+            return {"ok": delivered}
+
+    dispatcher = Dispatcher([Sink()], cfg_provider=watch_manager._route_cfg_provider("R1"))
+    event = ScrobbleEvent("start", "movie", {"tmdb": "10"}, "Movie", 2020, None, None,
+                          10, "TestUser", "server", "session", {})
+    dispatcher.dispatch(event)
+    assert len(calls) == 1
+    assert bool(dispatcher._pending) is not delivered
+    if change == "disable":
+        route["enabled"] = False
+    elif change == "delete":
+        cfg["scrobble"]["watch"]["routes"] = []
+    elif change == "source":
+        cfg["scrobble"]["sources"]["watcher"] = False
+    else:
+        cfg["scrobble"]["enabled"] = False
+    dispatcher._retry_after = {key: (0, 1) for key in dispatcher._pending}
+    dispatcher.retry_pending()
+    assert not dispatcher.accepts_user(event)
+    assert not dispatcher.accepts(event)
+    assert not dispatcher.dispatch(replace(event, progress=20))
+    assert len(calls) == 1 and not dispatcher._pending
+    route["enabled"] = True
+    cfg["scrobble"]["enabled"] = True
+    cfg["scrobble"]["sources"]["watcher"] = True
+    cfg["scrobble"]["watch"]["routes"] = [route]
+    assert dispatcher.accepts_user(event)
+    dispatcher.dispatch(replace(event, progress=30))
+    assert len(calls) == 2


### PR DESCRIPTION
# Pull request

## Change

- Stop disabled or deleted routes from sending scrobbles and retrying deliveries. 
- Fix Plex watcher shutdown races and ignore late alerts after stopping.

## Why

- Old dispatchers could keep sending even when their routes were disabled.

## Testing
- tests/test_watch_route_disable.py 
- tests/test_plex_watcher_session_identity.py

## Issue
Relates to #1094